### PR TITLE
Fixed bug on first run when no config dir exists it seg faults.

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -95,8 +95,9 @@ std::string GetPiUserDir(const std::string &subdir)
 		if (mkdir(path.c_str(), 0770) == -1) {
 			Gui::Screen::ShowBadError(stringf(128, "Error: Could not create or open '%s'.", path.c_str()).c_str());
 		}
+	} else {
+		closedir(dir);
 	}
-	closedir(dir);
 	if (subdir != "") {
 		path = join_path(homedir, ".pioneer", subdir.c_str(), 0);
 		dir = opendir(path.c_str());


### PR DESCRIPTION
Found a bug where if the ~/.pioneer directory doesn't exist the game segfaults. Found when testing on a clean machine. :)
