### PR TITLE
Text for Barnard's Star needed cleaning up a little, so I cleaned it up a little.

### DIFF
--- a/data/systems/n01p00/04_barnard's_star.lua
+++ b/data/systems/n01p00/04_barnard's_star.lua
@@ -1,9 +1,9 @@
 local s = CustomSystem:new('Barnard\'s star',{ Body.Type.STAR_M })
    :govtype(Polit.GovType.EARTHCOLONIAL)
    :short_desc('Earth Federation Colonial Rule')
-   :long_desc([[Barnard's Star is a very low-mass red dwarf star.  Somewhere between 7 and 12 billion years old, it is probably one of the most ancient stars in the galaxy.  Despite that, it is still fairly active.  Pilots entering the system are warned that there might be consideral stellar activity, including flares and massive coronal ejections.
+   :long_desc([[Barnard's Star is a very low-mass red dwarf star.  Somewhere between 7 and 12 billion years old, it is probably one of the most ancient stars in the galaxy.  Despite that, it is still fairly active.  Pilots entering the system are warned that there might be considerable stellar activity, including flares and coronal mass ejections.
 
-One of the first stars to be visited after the introduction of interstellar travel, Barnard's Star was found to be solitary, with no planets.  Despite this, habitats were built here to serve as Federal prison colonies.
+One of the first stars to be visited after the introduction of interstellar travel, Barnard's Star was found to be solitary, with no planets.  Despite this, habitats were eventually built here to serve as Federal prison colonies.
    
 A permit is normally required in order to enter this system whilst carrying weapons.]])
 


### PR DESCRIPTION
- Corrected spelling of "considerable"
- Corrected "massive coronal ejections" to the as-correct but far more common "coronal mass ejections"
- Added the word "eventually" to the bit about building habitats, to make it clear that, whilst old, the system was not colonized before Epsilon Eridani.  Now is the time to get the continuity right!
