### PR TITLE
Fix a bug where opening up an empty or invalid save game causes the game 

### DIFF
--- a/src/AmbientSounds.cpp
+++ b/src/AmbientSounds.cpp
@@ -148,6 +148,7 @@ void AmbientSounds::Update()
 		// when all the sounds are in we can use the body we are in frame of reference to
 		if (!starNoise.IsPlaying()) {
 			Frame *f = Pi::player->GetFrame();
+            if (!f) return; // When player has no frame (game abort) then get outta here!!
 			const SBody *sbody = f->GetSBodyFor();
 			const char *sample = 0;
 			for (; sbody && !sample; sbody = f->GetSBodyFor()) {

--- a/src/GameMenuView.cpp
+++ b/src/GameMenuView.cpp
@@ -315,11 +315,13 @@ private:
 			Gui::Screen::ShowBadError("This saved game cannot be loaded because it contains errors.");
 			Pi::UninitGame();
 			Pi::InitGame();
+            Pi::SetView(Pi::gameMenuView); // Pi::currentView is unset, set it back to the gameMenuView
 			return;
 		} catch (CouldNotOpenFileException) {
 			Gui::Screen::ShowBadError("This saved game file could not be opened due to permissions or something...");
 			Pi::UninitGame();
 			Pi::InitGame();
+            Pi::SetView(Pi::gameMenuView); // Pi::currentView is unset, set it back to the gameMenuView
 			return;
 		}
 		Pi::StartGame();

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -600,7 +600,7 @@ static Color get_color_for_warning_meter_bar(float v) {
 
 void WorldView::RefreshButtonStateAndVisibility()
 {
-	if ((!Pi::player) || Pi::player->IsDead()) {
+	if ((!Pi::player) || Pi::player->IsDead() || !Pi::IsGameStarted()) {
 		HideAll();
 		return;
 	}


### PR DESCRIPTION
Fix a bug where opening up an empty or invalid save game causes the game to Segfault. It should now gracefully return you to the main menu. Closes #9
