### PR TITLE
OSX user datafiles (Screenshots, settings, saves, etc)..

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -69,7 +69,12 @@ std::string GetPiUserDir(const std::string &subdir)
 #else
 
 	std::string path = getenv("HOME");
+
+#ifdef __APPLE__
+	path += "/Library/Application Support/Pioneer";
+#else
 	path += "/.pioneer";
+#endif
 
 	struct stat st;
 	if (stat(path.c_str(), &st) < 0 && mkdir(path.c_str(), S_IRWXU|S_IRWXG|S_IRWXO) < 0) {


### PR DESCRIPTION
For OSX, store pioneer user datafiles (Screenshots, settings, saves, etc) in the Library/Application Support/Pioneer folder (as per apple application standards).
