### PR TITLE
Separate config parser from game-specific config

### DIFF
--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -1,0 +1,24 @@
+#include "GameConfig.h"
+#include "KeyBindings.h"
+
+GameConfig::GameConfig(const std::string &filename) : IniConfig(filename)
+{
+	// set defaults
+	(*this)["EnableHDR"] = "0";
+	(*this)["DisableShaders"] = "0";
+	(*this)["DisableSound"] = "0";
+	(*this)["StartFullscreen"] = "0";
+	(*this)["ScrWidth"] = "800";
+	(*this)["ScrHeight"] = "600";
+	(*this)["DetailCities"] = "1";
+	(*this)["DetailPlanets"] = "1";
+	(*this)["SfxVolume"] = "0.8";
+	(*this)["EnableJoystick"] = "1";
+	(*this)["InvertMouseY"] = "0";
+
+	KeyBindings::SetDefaults();
+
+	Load();
+
+	KeyBindings::OnKeyBindingsChanged();
+}

--- a/src/GameConfig.h
+++ b/src/GameConfig.h
@@ -1,0 +1,11 @@
+#ifndef _GAMECONFIG_H
+#define _GAMECONFIG_H
+
+#include "IniConfig.h"
+
+class GameConfig : public IniConfig {
+public:
+	GameConfig(const std::string &filename);
+};
+
+#endif

--- a/src/IniConfig.cpp
+++ b/src/IniConfig.cpp
@@ -1,62 +1,44 @@
 #include "libs.h"
 #include "IniConfig.h"
-#include "KeyBindings.h"
 
-void IniConfig::Load(const std::string &filename_)
+void IniConfig::Load()
 {
-	this->clear();
-	this->filename = filename_;
-	FILE *f = fopen(filename_.c_str(), "r");
-		
-	// set defaults
-	(*this)["EnableHDR"] = "0";
-	(*this)["DisableShaders"] = "0";
-	(*this)["DisableSound"] = "0";
-	(*this)["StartFullscreen"] = "0";
-	(*this)["ScrWidth"] = "800";
-	(*this)["ScrHeight"] = "600";
-	(*this)["DetailCities"] = "1";
-	(*this)["DetailPlanets"] = "1";
-	(*this)["SfxVolume"] = "0.8";
-	(*this)["EnableJoystick"] = "1";
-	(*this)["InvertMouseY"] = "0";
-
-	KeyBindings::SetDefaults();
+	FILE *f = fopen(m_filename.c_str(), "r");
+	if (!f) return;
 	
-	if (f) {
-		char buf[1024];
-		while (fgets(buf, sizeof(buf), f)) {
-			if (buf[0] == '#') continue;
-			char *sep = strchr(buf, '=');
-			char *kend = sep;
-			if (!sep) continue;
-			*sep = 0;
-			// strip whitespace
-			while (isspace(*(--kend))) *kend = 0;
-			while (isspace(*(++sep))) *sep = 0;
-			// snip \r, \n
-			char *vend = sep;
-			while (*(++vend)) if ((*vend == '\r') || (*vend == '\n')) { *vend = 0; break; }
-			std::string key = std::string(buf);
-			std::string val = std::string(sep);
-			(*this)[key] = val;
-		}
-		fclose(f);
+	char buf[1024];
+	while (fgets(buf, sizeof(buf), f)) {
+		if (buf[0] == '#') continue;
+		char *sep = strchr(buf, '=');
+		char *kend = sep;
+		if (!sep) continue;
+		*sep = 0;
+		// strip whitespace
+		while (isspace(*(--kend))) *kend = 0;
+		while (isspace(*(++sep))) *sep = 0;
+		// snip \r, \n
+		char *vend = sep;
+		while (*(++vend)) if ((*vend == '\r') || (*vend == '\n')) { *vend = 0; break; }
+		std::string key = std::string(buf);
+		std::string val = std::string(sep);
+		(*this)[key] = val;
 	}
 
-	KeyBindings::OnKeyBindingsChanged();
+	fclose(f);
 }
 
 bool IniConfig::Save()
 {
-	FILE *f = fopen(filename.c_str(), "w");
-	if (!f) {
+	FILE *f = fopen(m_filename.c_str(), "w");
+	if (!f)
+		// XXX do something useful here
 		return false;
-	} else {
-		for (std::map<std::string, std::string>::const_iterator i = begin(); i!=end(); ++i) {
-			if ((*i).second != "") fprintf(f, "%s=%s\n", (*i).first.c_str(), (*i).second.c_str());
-		}
-		fclose(f);
-		return true;
+
+	for (std::map<std::string, std::string>::const_iterator i = begin(); i!=end(); ++i) {
+		if ((*i).second != "") fprintf(f, "%s=%s\n", (*i).first.c_str(), (*i).second.c_str());
 	}
+
+	fclose(f);
+
+	return true;
 }

--- a/src/IniConfig.h
+++ b/src/IniConfig.h
@@ -1,12 +1,15 @@
-#ifndef INICONFIG_H
-#define INICONFIG_H
+#ifndef _INICONFIG_H
+#define _INICONFIG_H
 
+#include "libs.h"
 #include <map>
 #include <string>
 
-class IniConfig: private std::map<std::string, std::string> {
-	public:
-	void Load(const std::string &filename);
+class IniConfig: protected std::map<std::string, std::string> {
+public:
+	void Load();
+	bool Save();
+
 	void SetInt(const char *key, int val) {
 		(*this)[key] = stringf(64, "%d", val);
 	}
@@ -27,9 +30,12 @@ class IniConfig: private std::map<std::string, std::string> {
 	std::string String(const char *key) {
 		return (*this)[key];
 	}
-	bool Save();
-	private:
-	std::string filename;
+
+protected:
+	IniConfig(const std::string &filename) : m_filename(filename) {}
+
+private:
+	std::string m_filename;
 };
 
-#endif /* INICONFIG_H */
+#endif /* _INICONFIG_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -59,6 +59,7 @@ noinst_HEADERS = \
 	HyperspaceCloud.h \
 	InfoView.h \
 	IniConfig.h \
+	GameConfig.h \
 	KeyBindings.h \
 	LmrModel.h \
 	LuaBody.h \
@@ -188,6 +189,7 @@ pioneer_SOURCES	= \
 	HyperspaceCloud.cpp \
 	InfoView.cpp \
 	IniConfig.cpp \
+	GameConfig.cpp \
 	KeyBindings.cpp \
 	LmrModel.cpp \
 	LuaBody.cpp \

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -117,7 +117,7 @@ bool Pi::showDebugInfo;
 #endif
 int Pi::statSceneTris;
 bool Pi::isGameStarted = false;
-IniConfig Pi::config;
+GameConfig Pi::config(GetPiUserDir() + "config.ini");
 struct DetailLevel Pi::detail = { 0, 0 };
 bool Pi::joystickEnabled;
 bool Pi::mouseYInvert;
@@ -244,8 +244,6 @@ static void LuaInitGame() {
 
 void Pi::Init()
 {
-	config.Load(GetPiUserDir() + "config.ini");
-
 	Pi::detail.planets = config.Int("DetailPlanets");
 	Pi::detail.cities = config.Int("DetailCities");
 

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -7,7 +7,7 @@
 #include "mtrand.h"
 #include "gameconsts.h"
 #include "Serializer.h"
-#include "IniConfig.h"
+#include "GameConfig.h"
 #include "LuaEventQueue.h"
 #include "LuaSerializer.h"
 #include "LuaTimer.h"
@@ -157,7 +157,7 @@ public:
 	static const char * const combatRating[];
 
 	static struct DetailLevel detail;
-	static IniConfig config;
+	static GameConfig config;
 private:
 	static void InitOpenGL();
 	static void HandleEvents();


### PR DESCRIPTION
I need extra config files for per-font config. This separates the parser from the game defaults. In my font branch I'll subclass IniConfig into a FontConfig and do what I need there.
