### PR TITLE
Don't auto-correct speed while any thruster key is down

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -109,6 +109,7 @@ void Player::StaticUpdate(const float timeStep)
 		switch (m_flightControlState) {
 		case CONTROL_FIXSPEED:
 			if (Pi::GetView() == Pi::worldView) PollControls(timeStep);
+			if (IsAnyThrusterKeyDown()) break;
 			GetRotMatrix(m);
 			v = m * vector3d(0, 0, -m_setSpeed);
 			AIMatchVel(v);
@@ -320,4 +321,16 @@ void Player::SetAlertState(Ship::AlertState as)
 	Pi::cpan->SetAlertState(as);
 
 	Ship::SetAlertState(as);
+}
+
+bool Player::IsAnyThrusterKeyDown()
+{
+	return (
+		KeyBindings::thrustForward.IsActive()	||
+		KeyBindings::thrustBackwards.IsActive()	||
+		KeyBindings::thrustUp.IsActive()		||
+		KeyBindings::thrustDown.IsActive()		||
+		KeyBindings::thrustLeft.IsActive()		||
+		KeyBindings::thrustRight.IsActive()
+	);
 }

--- a/src/Player.h
+++ b/src/Player.h
@@ -37,8 +37,8 @@ public:
 	int GetKillCount() const { return m_knownKillCount; }
 	virtual bool SetWheelState(bool down); // returns success of state change, NOT state itself
 	virtual bool FireMissile(int idx, Ship *target);
-
 	virtual void SetAlertState(Ship::AlertState as);
+	bool IsAnyThrusterKeyDown();
 
 	// test code
 	virtual void TimeStepUpdate(const float timeStep);


### PR DESCRIPTION
(This old request was forgotten in reorganizing, submitting again)

Allow player to use thruster override keys in set speed mode without the autopilot fighting back until the keys are released. Good for precise maneuvers such as landing.
