### PR TITLE
handle the player object passed to Player.AddCrime

### DIFF
--- a/src/LuaPlayer.cpp
+++ b/src/LuaPlayer.cpp
@@ -388,8 +388,9 @@ static int l_player_add_money(lua_State *l)
  */
 static int l_player_add_crime(lua_State *l)
 {
-	Sint64 crimeBitset = LuaConstants::GetConstant(l, "PolitCrime", luaL_checkstring(l, 1));
-	double fine = Sint64(luaL_checknumber(l, 2) * 100.0);
+	Player *p = LuaPlayer::GetFromLua(1);
+	Sint64 crimeBitset = LuaConstants::GetConstant(l, "PolitCrime", luaL_checkstring(l, 2));
+	double fine = Sint64(luaL_checknumber(l, 3) * 100.0);
 	Polit::AddCrime(crimeBitset, fine);
 	return 0;
 }


### PR DESCRIPTION
Trivial argument order bug. Test with:

`EventQueue.onGameStart:Connect(function () Game.player:AddCrime('MURDER', 20) end)`
