### PR TITLE
Fix Gui::VScrollPortal sizing

### DIFF
--- a/src/gui/GuiVScrollPortal.cpp
+++ b/src/gui/GuiVScrollPortal.cpp
@@ -12,7 +12,10 @@ VScrollPortal::VScrollPortal(float w, float h): Container()
 
 void VScrollPortal::GetSizeRequested(float size[2])
 {
-	GetSize(size);
+	if (m_child)
+		m_child->GetSizeRequested(size);
+	else
+		size[0] = size[1] = 0;
 }
 
 void VScrollPortal::OnChildResizeRequest(Widget *child)


### PR DESCRIPTION
make the portal try to take the size of its child, though it likely won't get it. this allows a vscrollportal to be created off-screen and still get displayed during showall
