### PR TITLE
Pass model args as doubles to avoid precision loss

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,9 @@ Alpha 12
   * New features
     * New star and planet images in system info view (#167)
 
+  * Fixes
+    * Lua model args passed as doubles to avoid loss of precision (eg time)
+
 Alpha 11
 
   * New features

--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -271,10 +271,10 @@ void CityOnPlanet::Render(const SpaceStation *station, const vector3d &viewCoord
 	
 	memset(&cityobj_params, 0, sizeof(LmrObjParams));
 	// this fucking rubbish needs to be moved into a function
-	cityobj_params.argFloats[1] = float(Pi::GetGameTime());
-	cityobj_params.argFloats[2] = float(Pi::GetGameTime() / 60.0);
-	cityobj_params.argFloats[3] = float(Pi::GetGameTime() / 3600.0);
-	cityobj_params.argFloats[4] = float(Pi::GetGameTime() / (24*3600.0));
+	cityobj_params.argDoubles[1] = float(Pi::GetGameTime());
+	cityobj_params.argDoubles[2] = float(Pi::GetGameTime() / 60.0);
+	cityobj_params.argDoubles[3] = float(Pi::GetGameTime() / 3600.0);
+	cityobj_params.argDoubles[4] = float(Pi::GetGameTime() / (24*3600.0));
 
 
 	for (std::vector<BuildingDef>::const_iterator i = m_buildings.begin();

--- a/src/LmrModel.cpp
+++ b/src/LmrModel.cpp
@@ -2212,7 +2212,7 @@ namespace ModelFuncs {
 	{
 		assert(s_curParams != 0);
 		int i = luaL_checkint(L, 1);
-		lua_pushnumber(L, s_curParams->argFloats[i]);
+		lua_pushnumber(L, s_curParams->argDoubles[i]);
 		return 1;
 	}
 	

--- a/src/LmrModel.h
+++ b/src/LmrModel.h
@@ -31,7 +31,7 @@ struct LmrLight {
 
 struct LmrObjParams
 {
-	float argFloats[LMR_ARG_MAX];
+	double argDoubles[LMR_ARG_MAX];
 	const char *argStrings[LMR_ARG_MAX];
 
 	float linthrust[3];		// 1.0 to -1.0

--- a/src/LuaModelViewer.cpp
+++ b/src/LuaModelViewer.cpp
@@ -260,13 +260,13 @@ void Viewer::SetSbreParams()
 	float gameTime = SDL_GetTicks() * 0.001f;
 
 	for (int i=0; i<LMR_ARG_MAX; i++) {
-		params.argFloats[i] = GetAnimValue(i);
+		params.argDoubles[i] = GetAnimValue(i);
 	}
 
-	params.argFloats[1] = gameTime;
-	params.argFloats[2] = gameTime / 60;
-	params.argFloats[3] = gameTime / 3600.0f;
-	params.argFloats[4] = gameTime / (24*3600.0f);
+	params.argDoubles[1] = gameTime;
+	params.argDoubles[2] = gameTime / 60;
+	params.argDoubles[3] = gameTime / 3600.0f;
+	params.argDoubles[4] = gameTime / (24*3600.0f);
 	
 	params.linthrust[0] = 2.0f * (m_linthrust[0]->GetValue() - 0.5f);
 	params.linthrust[1] = 2.0f * (m_linthrust[1]->GetValue() - 0.5f);

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -106,10 +106,10 @@ double ModelBody::GetBoundingRadius() const
 
 void ModelBody::SetLmrTimeParams()
 {
-	m_params.argFloats[1] = float(Pi::GetGameTime());
-	m_params.argFloats[2] = float(Pi::GetGameTime() / 60.0);
-	m_params.argFloats[3] = float(Pi::GetGameTime() / 3600.0);
-	m_params.argFloats[4] = float(Pi::GetGameTime() / (24*3600.0));
+	m_params.argDoubles[1] = float(Pi::GetGameTime());
+	m_params.argDoubles[2] = float(Pi::GetGameTime() / 60.0);
+	m_params.argDoubles[3] = float(Pi::GetGameTime() / 3600.0);
+	m_params.argDoubles[4] = float(Pi::GetGameTime() / (24*3600.0));
 }
 
 void ModelBody::SetRotMatrix(const matrix4x4d &r)

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -985,16 +985,16 @@ void Ship::Render(const vector3d &viewCoords, const matrix4x4d &viewTransform)
 		params.linthrust[0] = float(m_thrusters.x);
 		params.linthrust[1] = float(m_thrusters.y);
 		params.linthrust[2] = float(m_thrusters.z);
-		params.argFloats[0] = m_wheelState;
-		params.argFloats[5] = float(m_equipment.Get(Equip::SLOT_FUELSCOOP));
-		params.argFloats[6] = float(m_equipment.Get(Equip::SLOT_ENGINE));
-		params.argFloats[7] = float(m_equipment.Get(Equip::SLOT_ECM));
-		params.argFloats[8] = float(m_equipment.Get(Equip::SLOT_SCANNER));
-		params.argFloats[9] = float(m_equipment.Get(Equip::SLOT_ATMOSHIELD));
-		params.argFloats[10] = float(m_equipment.Get(Equip::SLOT_LASER, 0));
-		params.argFloats[11] = float(m_equipment.Get(Equip::SLOT_LASER, 1));
+		params.argDoubles[0] = m_wheelState;
+		params.argDoubles[5] = float(m_equipment.Get(Equip::SLOT_FUELSCOOP));
+		params.argDoubles[6] = float(m_equipment.Get(Equip::SLOT_ENGINE));
+		params.argDoubles[7] = float(m_equipment.Get(Equip::SLOT_ECM));
+		params.argDoubles[8] = float(m_equipment.Get(Equip::SLOT_SCANNER));
+		params.argDoubles[9] = float(m_equipment.Get(Equip::SLOT_ATMOSHIELD));
+		params.argDoubles[10] = float(m_equipment.Get(Equip::SLOT_LASER, 0));
+		params.argDoubles[11] = float(m_equipment.Get(Equip::SLOT_LASER, 1));
 		for (int i=0; i<8; i++) {
-			params.argFloats[12+i] = float(m_equipment.Get(Equip::SLOT_MISSILE, i));
+			params.argDoubles[12+i] = float(m_equipment.Get(Equip::SLOT_MISSILE, i));
 		}
 		//strncpy(params.pText[0], GetLabel().c_str(), sizeof(params.pText));
 		RenderLmrModel(viewCoords, viewTransform);

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -292,8 +292,8 @@ void SpaceStation::InitStation()
 	} else {
 		m_type = &surfaceStationTypes[ rand.Int32(surfaceStationTypes.size()) ];
 	}
-	GetLmrObjParams().argFloats[ARG_STATION_BAY1_STAGE] = 1.0;
-	GetLmrObjParams().argFloats[ARG_STATION_BAY1_POS] = 1.0;
+	GetLmrObjParams().argDoubles[ARG_STATION_BAY1_STAGE] = 1.0;
+	GetLmrObjParams().argDoubles[ARG_STATION_BAY1_POS] = 1.0;
 	SetModel(m_type->modelName, true);
 	m_bbCreated = false;
 }
@@ -753,8 +753,8 @@ void SpaceStation::Render(const vector3d &viewCoords, const matrix4x4d &viewTran
 	SetLmrTimeParams();
 
 	for (int i=0; i<MAX_DOCKING_PORTS; i++) {
-		params.argFloats[ARG_STATION_BAY1_STAGE + i] = float(m_shipDocking[i].stage);
-		params.argFloats[ARG_STATION_BAY1_POS + i] = float(m_shipDocking[i].stagePos);
+		params.argDoubles[ARG_STATION_BAY1_STAGE + i] = float(m_shipDocking[i].stage);
+		params.argDoubles[ARG_STATION_BAY1_POS + i] = float(m_shipDocking[i].stagePos);
 	}
 
 	RenderLmrModel(viewCoords, viewTransform);


### PR DESCRIPTION
Testable by having a model output get_arg(0) and note that after a few weeks of game time it will have mostly lost its fractional component. The game time is a double, Lua's internal number representation is also double, but model args were held as plain old floats and thus dropping lots of precision.
