### PR TITLE
Tiny body radius fix

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -5,6 +5,7 @@ Alpha 12
 
   * Fixes
     * Lua model args passed as doubles to avoid loss of precision (eg time)
+    * Avoid loss of precision when calculating radius of very tiny bodies (#189)
 
   * Internal changes
     * All model timing now based of game time

--- a/src/StarSystem.cpp
+++ b/src/StarSystem.cpp
@@ -1519,8 +1519,15 @@ void SBody::PickPlanetType(StarSystem *system, MTRand &rand)
 	int bbody_temp = CalcSurfaceTemp(star, averageDistToStar, albedo, greenhouse);
 	
 	averageTemp = bbody_temp;
-	radius = fixed::CubeRootOf(mass);
-	
+
+	// radius is just the cube root of the mass. we get some more fractional
+	// bits for small bodies otherwise we can easily end up with 0 radius
+	// which breaks stuff elsewhere
+	if (mass <= fixed(1,1))
+		radius = fixed(fixedf<48>::CubeRootOf(fixedf<48>(mass)));
+	else
+		radius = fixed::CubeRootOf(mass);
+
 	m_metallicity = system->m_metallicity * rand.Fixed();
 	// harder to be volcanic when you are tiny (you cool down)
 	m_volcanicity = std::min(fixed(1,1), mass) * rand.Fixed();


### PR DESCRIPTION
A very small mass leads to an even small radius. A normal fixed32 has enough precision to store the result, but not handle the calculation, so we end up with a zero radius. This does the calc with a fixed48 to make sure we have enough room. Fixes #189.
