### PR TITLE
Select navtarget from system info view

### DIFF
--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -30,7 +30,10 @@ void SystemInfoView::OnBodySelected(SBody *b)
 		if(body != 0)
 			Pi::player->SetNavTarget(body);
 	}
+}
 
+void SystemInfoView::OnBodyViewed(SBody *b)
+{
 	std::string desc, data;
 
 	m_infoBox->DeleteAllChildren();
@@ -178,6 +181,8 @@ void SystemInfoView::PutBodies(SBody *body, Gui::Fixed *container, int dir, floa
 		ib->GetSize(size);
 		if (prevSize < 0) prevSize = size[!dir];
 		ib->onClick.connect(sigc::bind(sigc::mem_fun(this, &SystemInfoView::OnBodySelected), body));
+		ib->onMouseEnter.connect(sigc::bind(sigc::mem_fun(this, &SystemInfoView::OnBodyViewed), body));
+		ib->onMouseLeave.connect(sigc::mem_fun(this, &SystemInfoView::OnSwitchTo));
 		myPos[0] += (dir ? prevSize*0.5 - size[0]*0.5 : 0);
 		myPos[1] += (!dir ? prevSize*0.5 - size[1]*0.5 : 0);
 		container->Add(ib, myPos[0], myPos[1]);

--- a/src/SystemInfoView.h
+++ b/src/SystemInfoView.h
@@ -19,6 +19,7 @@ public:
 private:
 	void SystemChanged(StarSystem *s);
 	void UpdateEconomyTab();
+	void OnBodyViewed(SBody *b);
 	void OnBodySelected(SBody *b);
 	void OnClickBackground(Gui::MouseButtonEvent *e);
 	void PutBodies(SBody *body, Gui::Fixed *container, int dir, float pos[2], int &majorBodies, int &starports, float &prevSize);


### PR DESCRIPTION
- In System info view, show a body's info on mouseover
- On click, select it as a nav target (if viewing a system player is not currently in, set as hyperspace target)

It is very convenient but as tomm once said system viewing could use a consistent redesign. For this I'd at least add a green box or something to show the currently selected body... whenever there's time.
