### PR TITLE
Reset the sample position when setting up a new sample

### DIFF
--- a/src/Sound.cpp
+++ b/src/Sound.cpp
@@ -161,6 +161,7 @@ eventid PlaySfx (const char *fx, const float volume_left, const float volume_rig
 	}
 	wavstream[idx].sample = GetSample(fx);
 	wavstream[idx].oggv = 0;
+	wavstream[idx].buf_pos = 0;
 	wavstream[idx].volume[0] = volume_left * GetSfxVolume();
 	wavstream[idx].volume[1] = volume_right * GetSfxVolume();
 	wavstream[idx].op = op;
@@ -184,6 +185,7 @@ eventid PlayMusic(const char *fx, const float volume_left, const float volume_ri
 		DestroyEvent(&wavstream[idx]);
 	wavstream[idx].sample = GetSample(fx);
 	wavstream[idx].oggv = 0;
+	wavstream[idx].buf_pos = 0;
 	wavstream[idx].volume[0] = volume_left;
 	wavstream[idx].volume[1] = volume_right;
 	wavstream[idx].op = op;


### PR DESCRIPTION
See #251. The array of currently-playing samples gets reused as new sounds are wanted. The current sample buffer position wasn't being reset when a new sample was setup. If the previous sample was larger than the new one and was playing past the length of the new one, it would try and start playing from somewhere past the end of the new buffer, causing a crash.
