### PR TITLE
Sectorview cleanup

### DIFF
--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -92,10 +92,9 @@ void GalacticView::PutLabels(vector3d offset)
 
 void GalacticView::Draw3D()
 {
-	int secx, secy;
-	Pi::sectorView->GetSector(&secx, &secy);
-	float offset_x = (secx*Sector::SIZE + Galaxy::SOL_OFFSET_X)/Galaxy::GALAXY_RADIUS;
-	float offset_y = (-secy*Sector::SIZE + Galaxy::SOL_OFFSET_Y)/Galaxy::GALAXY_RADIUS;
+	SystemPath path = Pi::sectorView->GetSelectedSystem();
+	float offset_x = (path.sectorX*Sector::SIZE + Galaxy::SOL_OFFSET_X)/Galaxy::GALAXY_RADIUS;
+	float offset_y = (-path.sectorY*Sector::SIZE + Galaxy::SOL_OFFSET_Y)/Galaxy::GALAXY_RADIUS;
 
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1261,12 +1261,7 @@ void Pi::MainLoop()
 
 StarSystem *Pi::GetSelectedSystem()
 {
-	SystemPath selectedPath;
-	if (!Pi::sectorView->GetSelectedSystem(&selectedPath)) {
-		if (selectedSystem) selectedSystem->Release();
-		selectedSystem = 0;
-		return 0;
-	}
+	SystemPath selectedPath = Pi::sectorView->GetSelectedSystem();
 
 	if (selectedSystem) {
 		if (selectedSystem->GetPath().IsSameSystem(selectedPath))

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -9,14 +9,12 @@
 #include "StarSystem.h"
 #include "GalacticView.h"
 		
-SectorView::SectorView()
+SectorView::SectorView() :
+	m_firstTime(true)
 {
 	SetTransparency(true);
-	m_lastShown = SystemPath(9999,9999,9999);
 	m_px = m_py = m_pxMovingTo = m_pyMovingTo = 0.5;
 	m_rot_x = m_rot_z = 0;
-	m_secx = m_secy = 0;
-	m_selected = -1;
 	m_zoom = 1.2;
 
 	m_clickableLabels = new Gui::LabelSet();
@@ -69,9 +67,7 @@ SectorView::~SectorView()
 void SectorView::Save(Serializer::Writer &wr)
 {
 	wr.Float(m_zoom);
-	wr.Int32(m_secx);
-	wr.Int32(m_secy);
-	wr.Int32(m_selected);
+	m_selected.Serialize(wr);
 	wr.Float(m_px);
 	wr.Float(m_py);
 	wr.Float(m_rot_x);
@@ -81,19 +77,11 @@ void SectorView::Save(Serializer::Writer &wr)
 void SectorView::Load(Serializer::Reader &rd)
 {
 	m_zoom = rd.Float();
-	m_secx = rd.Int32();
-	m_secy = rd.Int32();
-	m_selected = rd.Int32();
+	m_selected = SystemPath::Unserialize(rd);
 	m_px = m_pxMovingTo = rd.Float();
 	m_py = m_pyMovingTo = rd.Float();
 	m_rot_x = rd.Float();
 	m_rot_z = rd.Float();
-}
-
-bool SectorView::GetSelectedSystem(SystemPath *path)
-{
-	*path = SystemPath(m_secx, m_secy, m_selected);
-	return m_selected != -1;
 }
 
 #define DRAW_RAD	2
@@ -116,7 +104,7 @@ void SectorView::Draw3D()
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	
 	char buf[80];
-	snprintf(buf, sizeof(buf), "Sector: %d,%d", m_secx, m_secy);
+	snprintf(buf, sizeof(buf), "Sector: %d,%d", m_selected.sectorX, m_selected.sectorY);
 	m_infoLabel->SetText(buf);
 
 	// units are lightyears, my friend
@@ -135,7 +123,7 @@ void SectorView::Draw3D()
 		for (int sy = -DRAW_RAD; sy <= DRAW_RAD; sy++) {
 			glPushMatrix();
 			glTranslatef(sx*Sector::SIZE, sy*Sector::SIZE, 0);
-			DrawSector(m_secx+sx, m_secy+sy);
+			DrawSector(m_selected.sectorX+sx, m_selected.sectorY+sy);
 			glPopMatrix();
 		}
 	}
@@ -143,26 +131,33 @@ void SectorView::Draw3D()
 	glDisable(GL_FOG);
 	glEnable(GL_LIGHTING);
 }
-	
-void SectorView::GotoSystem(int sector_x, int sector_y, int system_idx)
+
+void SectorView::GotoSystem(const SystemPath &path)
 {
-	Sector* ps = GetCached(sector_x, sector_y);
-	const vector3f &p = ps->m_systems[system_idx].p;
-	m_pxMovingTo = sector_x + p.x/Sector::SIZE;
-	m_pyMovingTo = sector_y + p.y/Sector::SIZE;
+	Sector* ps = GetCached(path.sectorX, path.sectorY);
+	const vector3f &p = ps->m_systems[path.systemIndex].p;
+	m_pxMovingTo = path.sectorX + p.x/Sector::SIZE;
+	m_pyMovingTo = path.sectorY + p.y/Sector::SIZE;
 }
 
-void SectorView::OnClickSystem(int sx, int sy, int sys_idx)
+void SectorView::WarpToSystem(const SystemPath &path)
 {
-	GotoSystem(sx, sy, sys_idx);
+	GotoSystem(path);
+	m_px = m_pxMovingTo;
+	m_py = m_pyMovingTo;
 }
 
-void SectorView::PutClickableLabel(std::string &text, int sx, int sy, int sys_idx)
+void SectorView::OnClickSystem(const SystemPath &path)
+{
+	GotoSystem(path);
+}
+
+void SectorView::PutClickableLabel(std::string &text, const SystemPath &path)
 {
 	Gui::Screen::EnterOrtho();
 	vector3d pos;
 	if (Gui::Screen::Project(vector3d(0.0), pos)) {
-		m_clickableLabels->Add(text, sigc::bind(sigc::mem_fun(this, &SectorView::OnClickSystem), sx, sy, sys_idx), pos.x, pos.y);
+		m_clickableLabels->Add(text, sigc::bind(sigc::mem_fun(this, &SectorView::OnClickSystem), path), pos.x, pos.y);
 	}
 	Gui::Screen::LeaveOrtho();
 }
@@ -253,7 +248,7 @@ void SectorView::DrawSector(int sx, int sy)
 			glPopMatrix();
 		}
 		// selected indicator
-		if ((sx == m_secx) && (sy == m_secy) && (num == m_selected)) {
+		if ((sx == m_selected.sectorX) && (sy == m_selected.sectorY) && (num == m_selected.systemIndex)) {
 			glDepthRange(0.1,1.0);
 			glColor3f(0,0.8,0);
 			glScalef(2,2,2);
@@ -262,7 +257,7 @@ void SectorView::DrawSector(int sx, int sy)
 		glDepthRange(0,1);
 		glPopMatrix();
 		glColor3f(.7,.7,.7);
-		PutClickableLabel((*i).name, sx, sy, num);
+		PutClickableLabel((*i).name, SystemPath(sx, sy, num));
 		glDisable(GL_LIGHTING);
 
 		glPopMatrix();
@@ -271,7 +266,10 @@ void SectorView::DrawSector(int sx, int sy)
 }
 
 void SectorView::OnSwitchTo() {
-	m_lastShown = SystemPath(9999,9999,9999);
+	if (m_firstTime) {
+		WarpToSystem(Pi::currentSystem->GetPath());
+		m_firstTime = false;
+	}
 	Update();
 }
 
@@ -282,7 +280,7 @@ void SectorView::Update()
 	SystemPath playerLoc = Pi::currentSystem->GetPath();
 
 	if (Pi::KeyState(SDLK_c)) {
-		GotoSystem(playerLoc.sectorX, playerLoc.sectorY, playerLoc.systemIndex);
+		GotoSystem(playerLoc);
 		if (Pi::KeyState(SDLK_LSHIFT) || Pi::KeyState(SDLK_RSHIFT)) {
 			m_rot_x = m_rot_z = 0;
 			m_zoom = 1.2;
@@ -317,15 +315,16 @@ void SectorView::Update()
 		m_rot_x += motion[1];
 		m_rot_z += motion[0];
 	}
-	
-	m_secx = int(floor(m_px));
-	m_secy = int(floor(m_py));
 
-	Sector* ps = GetCached(m_secx, m_secy);
+	SystemPath last_selected = m_selected;
+	
+	m_selected.sectorX = int(floor(m_px));
+	m_selected.sectorY = int(floor(m_py));
+
+	Sector* ps = GetCached(m_selected.sectorX, m_selected.sectorY);
 	float px = FFRAC(m_px)*Sector::SIZE;
 	float py = FFRAC(m_py)*Sector::SIZE;
 
-	m_selected = -1;
 	float min_dist = FLT_MAX;
 	for (unsigned int i=0; i<ps->m_systems.size(); i++) {
 		Sector::System *ss = &ps->m_systems[i];
@@ -334,27 +333,24 @@ void SectorView::Update()
 		float dist = sqrtf(dx*dx + dy*dy);
 		if (dist < min_dist) {
 			min_dist = dist;
-			m_selected = i;
+			m_selected.systemIndex = i;
 		}
 	}
 	
-	StarSystem *sys = Pi::GetSelectedSystem();
-	if (!sys) return;
-
-	if (sys->GetPath() != m_lastShown) {
-		Sector sec(m_secx, m_secy);
+	if (last_selected != m_selected) {
+		Sector sec(m_selected.sectorX, m_selected.sectorY);
 		Sector psec(playerLoc.sectorX, playerLoc.sectorY);
-		const float dist = Sector::DistanceBetween(&sec, m_selected, &psec, playerLoc.systemIndex);
+		const float dist = Sector::DistanceBetween(&sec, m_selected.systemIndex, &psec, playerLoc.systemIndex);
+
 		char buf[256];
-		SystemPath path(m_secx, m_secy, m_selected);
 		int fuelRequired;
 		double dur;
 		enum Ship::HyperjumpStatus jumpStatus;
-		Pi::player->CanHyperspaceTo(&path, fuelRequired, dur, &jumpStatus);
+		Pi::player->CanHyperspaceTo(&m_selected, fuelRequired, dur, &jumpStatus);
 		switch (jumpStatus) {
 			case Ship::HYPERJUMP_OK:
 				snprintf(buf, sizeof(buf), "Dist. %.2f light years (fuel required: %dt | time loss: %.1fhrs)", dist, fuelRequired, dur*0.0002778);
-				Pi::player->SetHyperspaceTarget(&path);
+				Pi::player->SetHyperspaceTarget(&m_selected);
 				m_distance->Color(0.0f, 1.0f, 0.2f);
 				break;
 			case Ship::HYPERJUMP_CURRENT_SYSTEM:
@@ -379,6 +375,8 @@ void SectorView::Update()
 				break;
 		}
 
+		StarSystem *sys = StarSystem::GetCached(m_selected);
+
 		std::string desc;
 		if (sys->GetNumStars() == 4) {
 			desc = "Quadruple system. ";
@@ -390,12 +388,12 @@ void SectorView::Update()
 			desc = sys->rootBody->GetAstroDescription();
 		}
 
-		m_systemName->SetText(sec.m_systems[m_selected].name);
+		m_systemName->SetText(sys->GetName());
 		m_distance->SetText(buf);
 		m_starType->SetText(desc);
 		m_shortDesc->SetText(sys->GetShortDescription());
 
-		m_lastShown = sys->GetPath();
+		sys->Release();
 
 		// Think we'll only need to do this when our location has changed.
 		ShrinkCache();
@@ -433,10 +431,10 @@ Sector* SectorView::GetCached(int sectorX, int sectorY)
 void SectorView::ShrinkCache()
 {
 	// we're going to use these to determine if our sectors are within the range that we'll ever render
-	const int xmin = m_secx-DRAW_RAD;	// xmin
-	const int xmax = m_secx+DRAW_RAD;	// xmax
-	const int ymin = m_secy-DRAW_RAD;	// ymin
-	const int ymax = m_secy+DRAW_RAD;	// ymax
+	const int xmin = m_selected.sectorX-DRAW_RAD;
+	const int xmax = m_selected.sectorX+DRAW_RAD;
+	const int ymin = m_selected.sectorY-DRAW_RAD;
+	const int ymax = m_selected.sectorY+DRAW_RAD;
 
 	std::map<SystemPath,Sector*>::iterator iter = m_sectorCache.begin();
 	while (iter != m_sectorCache.end())	{

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -16,23 +16,25 @@ public:
 	virtual ~SectorView();
 	virtual void Update();
 	virtual void Draw3D();
-	bool GetSelectedSystem(SystemPath *path);
-	void GotoSystem(int sector_x, int sector_y, int system_idx);
-	void GetSector(int *outSecX, int *outSecY) const { *outSecX = m_secx; *outSecY = m_secy; }
+	SystemPath GetSelectedSystem() const { return m_selected; }
+	void GotoSystem(const SystemPath &path);
+	void WarpToSystem(const SystemPath &path);
 	virtual void Save(Serializer::Writer &wr);
 	virtual void Load(Serializer::Reader &rd);
 	virtual void OnSwitchTo();
 private:
 	void DrawSector(int x, int y);
-	void PutClickableLabel(std::string &text, int sx, int sy, int sys_idx);
-	void OnClickSystem(int sx, int sy, int sys_idx);
+	void PutClickableLabel(std::string &text, const SystemPath &path);
+	void OnClickSystem(const SystemPath &path);
 	void MouseButtonDown(int button, int x, int y);
 	Sector* GetCached(int sectorX, int sectorY);
 	void ShrinkCache();
 
 	float m_zoom;
-	int m_secx, m_secy;
-	int m_selected;
+
+	bool m_firstTime;
+	SystemPath m_selected;
+
 	float m_px, m_py;
 	float m_rot_x, m_rot_z;
 	float m_pxMovingTo, m_pyMovingTo;
@@ -42,7 +44,6 @@ private:
 	Gui::ImageButton *m_galaxyButton;
 	GLuint m_gluDiskDlist;
 	
-	SystemPath m_lastShown;
 	Gui::Label *m_systemName;
 	Gui::Label *m_distance;
 	Gui::Label *m_starType;

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -198,8 +198,7 @@ void SystemView::Draw3D()
 	glClearColor(0,0,0,0);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	
-	SystemPath path;
-	Pi::sectorView->GetSelectedSystem(&path);
+	SystemPath path = Pi::sectorView->GetSelectedSystem();
 	if (m_system) {
 		if (!m_system->GetPath().IsSameSystem(path)) {
 			m_system->Release();


### PR DESCRIPTION
Cleans up `SectorView.cpp` to use `SystemPath` instead of separate x, y and index. Also sets the selected system on first open to the current system, so that Eridani start point doesn't always show Sol selected.
