### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/generic-exec
+++ b/generic-exec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Executable wrapper script
 # Ensures the program is up-to-date, then hands over
 

--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -5,6 +5,8 @@
 #include <map>
 #ifdef _WIN32
 #include <malloc.h>
+#elif __FreeBSD__
+#include <stdlib.h>
 #else
 #include <alloca.h>
 #endif

--- a/src/libs.h
+++ b/src/libs.h
@@ -32,6 +32,8 @@ inline int isfinite(double x) { return _finite(x); }
 #endif
 #endif /* __MINGW32__ */
 
+#elif __FreeBSD__
+#include <stdlib.h>
 #else
 #include <alloca.h>
 #endif


### PR DESCRIPTION
*BSD do not have alloca.h

On *BSD default shell is sh, on linux sh is same as bash.
