### PR TITLE
Allow to always show rings for custom systems

### DIFF
--- a/src/CustomSystem.cpp
+++ b/src/CustomSystem.cpp
@@ -175,6 +175,7 @@ CustomSBody::CustomSBody(std::string s, std::string stype)
 	}
 
 	seed = averageTemp = 0;
+	rings = false;
 	latitude = longitude = 0.0;
 	want_rand_offset = true;
 	want_rand_seed = true;
@@ -188,5 +189,5 @@ EXPORT_OOLUA_FUNCTIONS_0_CONST(CustomSBody)
 CLASS_LIST_MEMBERS_START_OOLUA_NON_CONST(CustomSBody)
 LUA_MEMBER_FUNC_9(OOLUA::Proxy_class<CustomSBody>, seed, radius, mass, temp, semi_major_axis, eccentricity, orbital_offset, latitude, inclination)
 LUA_MEMBER_FUNC_9(OOLUA::Proxy_class<CustomSBody>, longitude, rotation_period, axial_tilt, height_map, metallicity, volcanicity, atmos_density, atmos_oxidizing, ocean_cover)
-LUA_MEMBER_FUNC_2(OOLUA::Proxy_class<CustomSBody>, ice_cover, life)
+LUA_MEMBER_FUNC_3(OOLUA::Proxy_class<CustomSBody>, ice_cover, life, rings)
 CLASS_LIST_MEMBERS_END

--- a/src/CustomSystem.h
+++ b/src/CustomSystem.h
@@ -23,6 +23,7 @@ public:
 	fixed                  eccentricity;
 	fixed                  orbitalOffset;
 	bool                   want_rand_offset;
+	bool                   rings; // rings are always shown
 	// for orbiting things, latitude = inclination
 	float                  latitude, longitude; // radians
 	fixed                  rotationPeriod; // in days
@@ -54,6 +55,7 @@ public:
 	inline CustomSBody* l_latitude(float l) { latitude = l; return this; }
 	inline CustomSBody* l_longitude(float l) { longitude = l; return this; }
 	inline CustomSBody* l_rotation_period(pi_fixed &p) { rotationPeriod = p; return this; }
+	inline CustomSBody* l_rings(bool r) { rings = r; return this; }
 	inline CustomSBody* l_axial_tilt(pi_fixed &t) { axialTilt = t; return this; }
 
 	inline CustomSBody* l_height_map(std::string f) {
@@ -91,6 +93,7 @@ OOLUA_CLASS_NO_BASES(CustomSBody)
 	OOLUA_MEM_FUNC_1_RENAME(latitude, CustomSBody*, l_latitude, float)
 	OOLUA_MEM_FUNC_1_RENAME(inclination, CustomSBody*, l_latitude, float)  // duplicate, latitude has different meaning for orbiting things
 	OOLUA_MEM_FUNC_1_RENAME(longitude, CustomSBody*, l_longitude, float)
+	OOLUA_MEM_FUNC_1_RENAME(rings, CustomSBody*, l_rings, bool)
 	OOLUA_MEM_FUNC_1_RENAME(rotation_period, CustomSBody*, l_rotation_period, pi_fixed&)
 	OOLUA_MEM_FUNC_1_RENAME(axial_tilt, CustomSBody*, l_axial_tilt, pi_fixed&)
 	OOLUA_MEM_FUNC_1_RENAME(height_map, CustomSBody*, l_height_map, std::string)

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -258,7 +258,7 @@ void Planet::DrawGasGiantRings()
 	const double maxRingWidth = 0.1 / double(2*(Pi::detail.planets + 1));
 
 	Render::State::UseProgram(Render::planetRingsShader[Pi::worldView->GetNumLights()-1]);
-	if (rng.Double(1.0) < ggdef.ringProbability) {
+	if ((rng.Double(1.0) < ggdef.ringProbability) || sbody->rings) {
 		float rpos = float(rng.Double(1.15,1.5));
 		float end = rpos + float(rng.Double(0.1, 1.0));
 		end = std::min(end, 2.5f);

--- a/src/StarSystem.cpp
+++ b/src/StarSystem.cpp
@@ -943,6 +943,7 @@ void StarSystem::CustomGetKidsOf(SBody *parent, const std::list<CustomSBody> *ch
 		kid->eccentricity = csbody->eccentricity;
 		kid->orbitalOffset = csbody->orbitalOffset;
 		kid->axialTilt = csbody->axialTilt;
+		kid->rings = csbody->rings;
 		kid->semiMajorAxis = csbody->semiMajorAxis;
 		kid->orbit.eccentricity = csbody->eccentricity.ToDouble();
 		kid->orbit.semiMajorAxis = csbody->semiMajorAxis.ToDouble() * AU;

--- a/src/StarSystem.h
+++ b/src/StarSystem.h
@@ -149,6 +149,7 @@ public:
 	fixed orbitalOffset;
 	fixed axialTilt; // in radians
 	int averageTemp;
+	bool rings;
 	BodyType type;
 
 	/* composition */


### PR DESCRIPTION
add :rings(true) to gas giant to always show rings and to ignore probability set from planet seed.

Once rings(true) is added to sol giants #87  can get closed.

The bool can be changed to float so that it can replace ringProbability if defined (default value could be negative) so in that way rings can be disabled even if seed allows them...
