### PR TITLE
Use stdlib.h instead of alloca.h

### DIFF
--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -1,16 +1,7 @@
-
-#include <float.h>
-#include <stdio.h>
-#include <assert.h>
-#include <map>
-#ifdef _WIN32
-#include <malloc.h>
-#else
-#include <alloca.h>
-#endif
-#include "../Aabb.h"
+#include "../libs.h"
 #include "GeomTree.h"
 #include "BVHTree.h"
+#include <map>
 
 int GeomTree::stats_rayTriIntersections;
 

--- a/src/libs.h
+++ b/src/libs.h
@@ -13,6 +13,7 @@
 #include <limits>
 #include <time.h>
 #include <stdarg.h>
+#include <stdlib.h>
 
 
 /* on unix this would probably become $PREFIX/pioneer */
@@ -31,9 +32,6 @@
 inline int isfinite(double x) { return _finite(x); }
 #endif
 #endif /* __MINGW32__ */
-
-#else
-#include <alloca.h>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
On all platforms except MSVC including stdlib.h. This should get Pioneer building on FreeBSD (see #273).

Compiles on Linux and MinGW. Requires compile on MSVC and OS X before it can be merged.
