### PR TITLE
Add onShipLanded lua event for planetary landings

### DIFF
--- a/src/LuaEventQueue.cpp
+++ b/src/LuaEventQueue.cpp
@@ -376,6 +376,29 @@ void LuaEventQueueBase::Emit()
  *   stable
  *
  *
+ * Event: onShipLanded
+ *
+ * Triggered when a ship performs a surface landing
+ * (not on a spaceport).
+ *
+ * > local onShipLanded = function (ship, body) ... end
+ * > EventQueue.onShipLanded:Connect(onShipLanded)
+ *
+ * Parameters:
+ *
+ *   ship - the <Ship> that landed
+ *
+ *   body - the <Body> the ship landed on
+ *
+ * Availability:
+ *
+ *   alpha 13
+ *
+ * Status:
+ *
+ *   experimental
+ *
+ *
  * Event: onShipAlertChanged
  *
  * Triggered when a ship's alert status changes.

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -88,6 +88,7 @@ LuaEventQueue<Ship,Body> Pi::luaOnShipHit("onShipHit");
 LuaEventQueue<Ship,Body> Pi::luaOnShipCollided("onShipCollided");
 LuaEventQueue<Ship,SpaceStation> Pi::luaOnShipDocked("onShipDocked");
 LuaEventQueue<Ship,SpaceStation> Pi::luaOnShipUndocked("onShipUndocked");
+LuaEventQueue<Ship, Body> Pi::luaOnShipLanded("onShipLanded");
 LuaEventQueue<Ship,const char *> Pi::luaOnShipAlertChanged("onShipAlertChanged");
 LuaEventQueue<Ship,CargoBody> Pi::luaOnJettison("onJettison");
 LuaEventQueue<Ship> Pi::luaOnAICompleted("onAICompleted");
@@ -212,6 +213,7 @@ static void LuaInit()
 	Pi::luaOnShipHit.RegisterEventQueue();
 	Pi::luaOnShipCollided.RegisterEventQueue();
 	Pi::luaOnShipDocked.RegisterEventQueue();
+	Pi::luaOnShipLanded.RegisterEventQueue();
 	Pi::luaOnShipUndocked.RegisterEventQueue();
 	Pi::luaOnShipAlertChanged.RegisterEventQueue();
 	Pi::luaOnJettison.RegisterEventQueue();
@@ -245,6 +247,7 @@ static void LuaInitGame() {
 	Pi::luaOnShipCollided.ClearEvents();
 	Pi::luaOnShipDocked.ClearEvents();
 	Pi::luaOnShipUndocked.ClearEvents();
+	Pi::luaOnShipLanded.ClearEvents();
 	Pi::luaOnShipAlertChanged.ClearEvents();
 	Pi::luaOnJettison.ClearEvents();
 	Pi::luaOnAICompleted.ClearEvents();

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -119,6 +119,7 @@ public:
 	static LuaEventQueue<Ship,Body> luaOnShipCollided;
 	static LuaEventQueue<Ship,SpaceStation> luaOnShipDocked;
 	static LuaEventQueue<Ship,SpaceStation> luaOnShipUndocked;
+	static LuaEventQueue<Ship,Body> luaOnShipLanded;
 	static LuaEventQueue<Ship,const char *> luaOnShipAlertChanged;
 	static LuaEventQueue<Ship,CargoBody> luaOnJettison;
 	static LuaEventQueue<Ship> luaOnAICompleted;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -556,6 +556,7 @@ void Ship::TestLanded()
 				ClearThrusterState();
 				m_flightState = LANDED;
 				Sound::PlaySfx("Rough_Landing", 1.0f, 1.0f, 0);
+				Pi::luaOnShipLanded.Queue(this, GetFrame()->GetBodyFor());
 			}
 		}
 	}

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -574,6 +574,7 @@ void TimeStep(float step)
 	Pi::luaOnShipDocked.Emit();
 	Pi::luaOnShipAlertChanged.Emit();
 	Pi::luaOnShipUndocked.Emit();
+	Pi::luaOnShipLanded.Emit();
 	Pi::luaOnJettison.Emit();
 	Pi::luaOnAICompleted.Emit();
 	Pi::luaOnCreateBB.Emit();


### PR DESCRIPTION
Tested with this:

function lol(ship, body)
    print(body.label)
    print(body.type)
end

EventQueue.onShipLanded:Connect(lol)

Should print "Earth" and "PLANET_TERRESTRIAL" when landed on Earth.
