### PR TITLE
Add onShipTakeOff lua event for planetary takeoffs

### DIFF
--- a/src/LuaEventQueue.cpp
+++ b/src/LuaEventQueue.cpp
@@ -399,6 +399,29 @@ void LuaEventQueueBase::Emit()
  *   experimental
  *
  *
+ * Event: onShipTakeOff
+ *
+ * Triggered when a ship takes off from a surface
+ * (not from a spaceport).
+ *
+ * > local onBlastOff = function (ship, body) ... end
+ * > EventQueue.onShipTakeOff:Connect(onBlastOff)
+ *
+ * Parameters:
+ *
+ *   ship - the <Ship> that took off
+ *
+ *   body - the <Body> the ship took off from
+ *
+ * Availability:
+ *
+ *   alpha 13
+ *
+ * Status:
+ *
+ *   experimental
+ *
+ *
  * Event: onShipAlertChanged
  *
  * Triggered when a ship's alert status changes.

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -89,6 +89,7 @@ LuaEventQueue<Ship,Body> Pi::luaOnShipCollided("onShipCollided");
 LuaEventQueue<Ship,SpaceStation> Pi::luaOnShipDocked("onShipDocked");
 LuaEventQueue<Ship,SpaceStation> Pi::luaOnShipUndocked("onShipUndocked");
 LuaEventQueue<Ship, Body> Pi::luaOnShipLanded("onShipLanded");
+LuaEventQueue<Ship, Body> Pi::luaOnShipTakeOff("onShipTakeOff");
 LuaEventQueue<Ship,const char *> Pi::luaOnShipAlertChanged("onShipAlertChanged");
 LuaEventQueue<Ship,CargoBody> Pi::luaOnJettison("onJettison");
 LuaEventQueue<Ship> Pi::luaOnAICompleted("onAICompleted");
@@ -214,6 +215,7 @@ static void LuaInit()
 	Pi::luaOnShipCollided.RegisterEventQueue();
 	Pi::luaOnShipDocked.RegisterEventQueue();
 	Pi::luaOnShipLanded.RegisterEventQueue();
+	Pi::luaOnShipTakeOff.RegisterEventQueue();
 	Pi::luaOnShipUndocked.RegisterEventQueue();
 	Pi::luaOnShipAlertChanged.RegisterEventQueue();
 	Pi::luaOnJettison.RegisterEventQueue();
@@ -248,6 +250,7 @@ static void LuaInitGame() {
 	Pi::luaOnShipDocked.ClearEvents();
 	Pi::luaOnShipUndocked.ClearEvents();
 	Pi::luaOnShipLanded.ClearEvents();
+	Pi::luaOnShipTakeOff.ClearEvents();
 	Pi::luaOnShipAlertChanged.ClearEvents();
 	Pi::luaOnJettison.ClearEvents();
 	Pi::luaOnAICompleted.ClearEvents();

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -120,6 +120,7 @@ public:
 	static LuaEventQueue<Ship,SpaceStation> luaOnShipDocked;
 	static LuaEventQueue<Ship,SpaceStation> luaOnShipUndocked;
 	static LuaEventQueue<Ship,Body> luaOnShipLanded;
+	static LuaEventQueue<Ship,Body> luaOnShipTakeOff;
 	static LuaEventQueue<Ship,const char *> luaOnShipAlertChanged;
 	static LuaEventQueue<Ship,CargoBody> luaOnJettison;
 	static LuaEventQueue<Ship> luaOnAICompleted;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -509,6 +509,8 @@ void Ship::Blastoff()
 	// XXX hm. we need to be able to get sbre aabb
 	SetPosition(up*planetRadius - aabb.min.y*up);
 	SetThrusterState(1, 1.0);		// thrust upwards
+
+	Pi::luaOnShipTakeOff.Queue(this, GetFrame()->m_astroBody);
 }
 
 void Ship::TestLanded()

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -575,6 +575,7 @@ void TimeStep(float step)
 	Pi::luaOnShipAlertChanged.Emit();
 	Pi::luaOnShipUndocked.Emit();
 	Pi::luaOnShipLanded.Emit();
+	Pi::luaOnShipTakeOff.Emit();
 	Pi::luaOnJettison.Emit();
 	Pi::luaOnAICompleted.Emit();
 	Pi::luaOnCreateBB.Emit();


### PR DESCRIPTION
Dunno why I didn't think of this with the onShipLanded event.

Tested with:

``` lua
EventQueue.onShipTakeOff:Connect(function (ship, body)
    UI.Message(ship.label .. "took off from" .. body.type .. body.label)
end)
```
