### PR TITLE
Make failure to open the custom language file a soft-fail (issue #354)

### DIFF
--- a/src/Lang.cpp
+++ b/src/Lang.cpp
@@ -182,7 +182,9 @@ bool LoadStrings(const std::string &lang)
 	f = fopen(filename.c_str(), "r");
 	if (!f) {
 		fprintf(stderr, "couldn't open string file '%s': %s\n", filename.c_str(), strerror(errno));
-		return false;
+		// we failed to open/find the language file, but we've already successfully
+		// read the default language above, so we still claim success here.
+		return true;
 	}
 
 	lineno = 0;


### PR DESCRIPTION
Make Lang.cpp/LoadStrings() claim success if it can read the default language
file but fails to open the configured language file.
