### PR TITLE
rework form onclose to be a virtual method instead of a signal

### DIFF
--- a/src/Form.h
+++ b/src/Form.h
@@ -14,6 +14,8 @@ public:
 	virtual const std::string &GetTitle() const { return m_title; }
 	void SetTitle(const std::string &title) { m_title = title; }
 
+	virtual void OnClose() { }
+
 protected:
 	Form(FormController *controller, float w, float h) : Gui::Fixed(w, h), m_formController(controller) {}
 	virtual ~Form() {}

--- a/src/FormController.cpp
+++ b/src/FormController.cpp
@@ -8,16 +8,22 @@ void FormController::ActivateForm(Form *form)
 
 void FormController::JumpToForm(Form *form)
 {
-	if (m_formStack->Size() > 0)
-		onClose.emit(static_cast<Form*>(m_formStack->Top()));
+	if (m_formStack->Size() > 0) {
+		Form *old_form = static_cast<Form*>(m_formStack->Top());
+		old_form->OnClose();
+		onClose.emit(old_form);
+	}
 	m_formStack->JumpTo(form);
 	Refresh();
 }
 
 void FormController::CloseForm()
 {
-	if (m_formStack->Size() > 0)
-		onClose.emit(static_cast<Form*>(m_formStack->Top()));
+	if (m_formStack->Size() > 0) {
+		Form *form = static_cast<Form*>(m_formStack->Top());
+		form->OnClose();
+		onClose.emit(form);
+	}
 	m_formStack->Pop();
 	Refresh();
 }

--- a/src/LuaChatForm.cpp
+++ b/src/LuaChatForm.cpp
@@ -12,17 +12,6 @@
 #include "FaceVideoLink.h"
 #include "StationPoliceForm.h"
 
-LuaChatForm::LuaChatForm(FormController *controller, SpaceStation *station, const BBAdvert &ad) :
-	StationAdvertForm(controller, station, ad), m_commodityTradeWidget(0)
-{
-	m_formClosedConnection = m_formController->onClose.connect(sigc::mem_fun(this, &LuaChatForm::OnClose));
-}
-
-LuaChatForm::~LuaChatForm()
-{
-	m_formClosedConnection.disconnect();
-}
-
 void LuaChatForm::OnOptionClicked(int option)
 {
     SetMoney(1000000000);
@@ -51,7 +40,7 @@ void LuaChatForm::OnOptionClicked(int option)
 	LUA_DEBUG_END(l, 0);
 }
 
-void LuaChatForm::OnClose(Form *form) {
+void LuaChatForm::OnClose() {
 	lua_State *l = Pi::luaManager.GetLuaState();
 	int ref = GetAdvert()->ref;
 

--- a/src/LuaChatForm.h
+++ b/src/LuaChatForm.h
@@ -13,10 +13,11 @@ class LuaChatForm: public StationAdvertForm, public MarketAgent, public DeleteEm
 	friend class LuaObject<LuaChatForm>;
 
 public:
-    LuaChatForm(FormController *controller, SpaceStation *station, const BBAdvert &ad);
-	~LuaChatForm();
+	LuaChatForm(FormController *controller, SpaceStation *station, const BBAdvert &ad) :
+		StationAdvertForm(controller, station, ad), m_commodityTradeWidget(0) {}
 
 	virtual void OnOptionClicked(int option);
+	virtual void OnClose();
 
 	/* MarketAgent stuff */
 	virtual Sint64 GetPrice(Equip::Type t) const;
@@ -41,9 +42,6 @@ private:
 	static int l_luachatform_close(lua_State *l);
 	static int l_luachatform_add_goods_trader(lua_State *l);
 	static int l_luachatform_goto_police(lua_State *l);
-
-	void OnClose(Form *form);
-	sigc::connection m_formClosedConnection;
 };
 
 #endif /* _LUACHATFORM_H */

--- a/src/StationAdvertForm.cpp
+++ b/src/StationAdvertForm.cpp
@@ -1,17 +1,6 @@
 #include "StationAdvertForm.h"
 
-StationAdvertForm::StationAdvertForm(FormController *controller, SpaceStation *station, const BBAdvert &ad) :
-	ChatForm(controller), m_adTaken(false), m_station(station), m_advert(ad)
-{
-	m_formClosedConnection = m_formController->onClose.connect(sigc::mem_fun(this, &StationAdvertForm::OnClose));
-}
-
-StationAdvertForm::~StationAdvertForm()
-{
-	m_formClosedConnection.disconnect();
-}
-
-void StationAdvertForm::OnClose(Form *form)
+void StationAdvertForm::OnClose()
 {
 	if (m_adTaken)
 		m_station->RemoveBBAdvert(m_advert.ref);

--- a/src/StationAdvertForm.h
+++ b/src/StationAdvertForm.h
@@ -7,8 +7,8 @@
 
 class StationAdvertForm : public ChatForm {
 public:
-	StationAdvertForm(FormController *controller, SpaceStation *station, const BBAdvert &ad);
-	~StationAdvertForm();
+	StationAdvertForm(FormController *controller, SpaceStation *station, const BBAdvert &ad) :
+		ChatForm(controller), m_adTaken(false), m_station(station), m_advert(ad) { }
 	
 	virtual void OnOptionClicked(int option) = 0;
 
@@ -18,9 +18,9 @@ public:
 	SpaceStation *GetStation() const { return m_station; }
 	const BBAdvert *GetAdvert() const { return &m_advert; }
 
-private:
-	void OnClose(Form *form);
+	virtual void OnClose();
 
+private:
 	bool m_adTaken;
 	sigc::connection m_formClosedConnection;
 


### PR DESCRIPTION
rework form onclose to be a virtual method instead of a signal. stops still-active forms tearing themselves down in response to a different form closing. closes #371
