### PR TITLE
Warning Fix: Correct UpdateLODThread declaration

### DIFF
--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -953,7 +953,7 @@ static std::list<GeoSphere*> s_allGeospheres;
 SDL_mutex *s_allGeospheresLock;
 
 /* Thread that updates geosphere level of detail thingies */
-int GeoSphere::UpdateLODThread(void *data)
+void GeoSphere::UpdateLODThread(void *data)
 {
 	for(;;) {
 		SDL_mutexP(s_allGeospheresLock);
@@ -965,7 +965,6 @@ int GeoSphere::UpdateLODThread(void *data)
 
 		SDL_Delay(10);
 	}
-	return 0;
 }
 
 void GeoSphere::_UpdateLODs()

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -55,7 +55,7 @@ private:
 	///////////////////////////
 	// threading rubbbbbish
 	// update thread can't do it since only 1 thread can molest opengl
-	static int UpdateLODThread(void *data) __attribute((noreturn));
+	static void UpdateLODThread(void *data) __attribute((noreturn));
 	std::list<GLuint> m_vbosToDestroy;
 	SDL_mutex *m_vbosToDestroyLock;
 	void AddVBOToDestroy(GLuint vbo);


### PR DESCRIPTION
UpdateLODThread never returns and has the GCC attribute noreturn, so declare as void and remove return (issue #383)
