### PR TITLE
Fix delivery script crash on systems with no or tiny population.

### DIFF
--- a/data/modules/DeliverPackage.lua
+++ b/data/modules/DeliverPackage.lua
@@ -273,7 +273,7 @@ local makeAdvert = function (station)
 end
 
 local onCreateBB = function (station)
-	local num = Engine.rand:Integer(1, math.ceil(Game.system.population))
+	local num = Engine.rand:Integer(0, math.ceil(Game.system.population))
 	for i = 1,num do
 		makeAdvert(station)
 	end


### PR DESCRIPTION
If a system had a population below 0.4 the script would crash due to the rand engine using 1 as a low value and 0 as the high.
