### PR TITLE
Add a macro to let noreturn functions return a value on non-GNU compilers.

### DIFF
--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -965,7 +965,8 @@ int GeoSphere::UpdateLODThread(void *data)
 
 		SDL_Delay(10);
 	}
-	RETURN_NONGNU_ONLY(0);
+
+	RETURN_ZERO_NONGNU_ONLY;
 }
 
 void GeoSphere::_UpdateLODs()

--- a/src/LuaUtils.cpp
+++ b/src/LuaUtils.cpp
@@ -49,7 +49,9 @@ int pi_lua_panic(lua_State *L)
 	Error("%s", errorMsg.c_str());
 	// Error() is noreturn
 
-	RETURN_NONGNU_ONLY(0);
+	// XXX when Lua management is good enough, we can probably remove panic
+	//     entirely in favour of pcall and a nicer error handling system
+	RETURN_ZERO_NONGNU_ONLY;
 }
 
 void pi_lua_protected_call(lua_State* L, int nargs, int nresults) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -28,9 +28,9 @@
 // but other compilers which don't see the noreturn attribute of course require that
 // a function with a non-void return type should return something.
 #ifndef __GNUC__
-#define RETURN_NONGNU_ONLY(x) return(x)
+#define RETURN_ZERO_NONGNU_ONLY return 0;
 #else
-#define RETURN_NONGNU_ONLY(x) (void)(x)
+#define RETURN_ZERO_NONGNU_ONLY
 #endif
 
 void Error(const char *format, ...) __attribute((format(printf,1,2))) __attribute((noreturn));


### PR DESCRIPTION
Fixes the MSVC build that I broke (noted by Luomu in issue #375) also fixes #383.

I don't particularly like this solution, but it should fix the problem without re-introducing warnings on GCC (suggestions for a better alternative fix would be welcome).

This needs review from someone who builds with MSVC.
