### PR TITLE
Fix HDR flickering on ATI

### DIFF
--- a/data/shaders/postprocessLuminance.frag.glsl
+++ b/data/shaders/postprocessLuminance.frag.glsl
@@ -1,9 +1,10 @@
 uniform sampler2DRect fboTex;
+varying vec2 texcoord;
 // downscale stage of making the bloom texture
 
 void main(void)
 {
 	const float delta = 0.001;
-	vec3 col = vec3(texture2DRect(fboTex, gl_TexCoord[0].st));
+	vec3 col = vec3(texture2DRect(fboTex, texcoord.st));
 	gl_FragColor = vec4(log(delta + dot(col, vec3(0.299,0.587,0.114))));
 }

--- a/data/shaders/postprocessLuminance.vert.glsl
+++ b/data/shaders/postprocessLuminance.vert.glsl
@@ -1,6 +1,8 @@
+varying vec2 texcoord;
+
 void main(void)
 {
 	gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
-	gl_TexCoord[0] = gl_MultiTexCoord0;
+	texcoord = gl_MultiTexCoord0.st;
 }
 


### PR DESCRIPTION
Fixes #266.

Background: the scene texture is downscaled several times (by mipmapping) so we can determine the average scene luminance. However, the luminance shader ended up sampling just a small corner of the scene texture, resulting in flickering.
This is avoided by passing passing the texture coordinates in a varying instead of using a builtin to the fragment shader. The coordinates were clamped to some smaller range while they need to be pixel coordinates as the scene texture is a rectangle texture.
