### PR TITLE
fixes a couple of edge crashes in TradeShips.lua

### DIFF
--- a/data/modules/TradeShips.lua
+++ b/data/modules/TradeShips.lua
@@ -131,7 +131,7 @@ local getSystem = function (ship)
 		local prices = next_system:GetCommodityBasePriceAlterations()
 		local next_prices = 0
 		for _, cargo in ipairs(cargo_list) do
-			if cargo ~= 'HYDROGEN' and cargo ~= 'SHIELD_GENERATOR' then
+			if cargo ~= 'HYDROGEN' and cargo ~= 'SHIELD_GENERATOR' and cargo ~= 'NONE' then
 				next_prices = next_prices + prices[cargo]
 			end
 		end


### PR DESCRIPTION
If the player was following a ship through hyperspace but arrived after the ship then the system data was not updated. This could result in getNearestStarport trying to use starport objects from the previous system that were no longer in the registry.

If a trade ship got carried over from the previous system then it used up some fuel and had empty cargo space which GetEquip('cargo') puts in the table as 'NONE'.
