### PR TITLE
Autopilot FlyTo flip mode fix

### DIFF
--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -693,8 +693,9 @@ static int GetFlipMode(Ship *ship, Frame *targframe, vector3d &posoff)
 
 void AICmdFlyTo::NavigateAroundBody(Body *body, vector3d &targpos)
 {
-printf("Flying to tangent of body: %s\n", body->GetLabel().c_str());
-
+//if(m_ship->IsType(Object::PLAYER)) {
+//	printf("Flying to tangent of body: %s\n", body->GetLabel().c_str());
+//}
 	// build tangent vector in body's rotating frame unless space station (or distant)
 	Frame *targframe = body->GetFrame();
 	double tanmul = 1.02;
@@ -922,6 +923,7 @@ bool AICmdFlyTo::TimeStepUpdate()
 
 	if (m_frame != m_ship->GetFrame()) {				// frame switch check
 		if (m_state >= 3 && m_state <= 5) return true;			// bailout case for accidental planet-dives
+		if (!m_frame) m_state = GetFlipMode(m_ship, m_targframe, m_posoff);
 		CheckCollisions();
 		if (!m_child) CheckSuicide();
 		if (m_child) { ProcessChild(); return false; }			// child can handle at least one timestep
@@ -935,6 +937,11 @@ bool AICmdFlyTo::TimeStepUpdate()
 	vector3d reldir = relpos.NormalizedSafe();
 	double targdist = relpos.Length();
 	double sideacc = m_ship->GetMaxThrust(vector3d(0.0)).x / m_ship->GetMass();
+
+//if(m_ship->IsType(Object::PLAYER)) {
+//	printf("Autopilot dist = %f, speed = %f, term = %f, state = 0x%x\n", targdist, relvel.Length(),
+//		reldir.Dot(m_reldir), m_state);
+//}
 
 	// planet evasion case
 	if (m_state == 4 || m_state == 5) {
@@ -974,9 +981,6 @@ bool AICmdFlyTo::TimeStepUpdate()
 
 	// limit forward acceleration when facing wrong way
 	if (decel > 0 && fabs(ang) > 0.02) ClampMainThruster(m_ship);
-
-//printf("Autopilot dist = %f, speed = %f, term = %f, state = 0x%x\n", targdist, relvel.Length(),
-//	reldir.Dot(m_reldir), m_state);
 
 	if (m_state == 9) return true;
 	return false;

--- a/win32/vc2008/pioneer-msvc-9.0.vcproj
+++ b/win32/vc2008/pioneer-msvc-9.0.vcproj
@@ -789,6 +789,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\StringF.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\SystemInfoView.cpp"
 				>
 			</File>
@@ -1479,11 +1483,11 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\src\Render.h"
+				RelativePath="..\..\src\render\Render.h"
 				>
 			</File>
 			<File
-				RelativePath="..\..\src\render\Render.h"
+				RelativePath="..\..\src\Render.h"
 				>
 			</File>
 			<File
@@ -1612,6 +1616,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\StationShipyardForm.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\StringF.h"
 				>
 			</File>
 			<File


### PR DESCRIPTION
@Brianetta, this should fix your crashing save game.

```
12:59 < JohnJ> ok, ShipAICmd.cpp line 925?, just before CheckCollisions(), add:
13:00 < JohnJ> if (!m_frame) m_state = GetFlipMode(m_ship, m_targframe, m_posoff);
13:05 < JohnJ> Added to branch jaj22/autopilot too.
13:08 < JohnJ> The crash itself is rare because there's only a small zone where the sidevel is too large to correct but CheckSuicide doesn't notice.
13:08 < robn> no probs, will take it from there. is there a human-readable description of the change?
13:09 < robn> otherwise its "fixed something in the autopilot" ;)
13:09 < JohnJ> In -m :-)
13:09 < JohnJ> Full explanation of why it causes occasional crashes would be extremely long :-)
13:09 < JohnJ> But it was never supposed to flip on short runs anyway.
13:11 < JohnJ> gah, did I just absent-mindedly kill my msys terminal...
13:12 < robn> so now it doesn't flip on short runs? or does it just set the state to something sane?
13:12 < JohnJ> It rechecks whether it should flip.
13:13 < JohnJ> (after whatever planet-evasion crap it did in between)
13:14 < robn> right. and by flipping its presumably not going to power into the planet
13:14 < JohnJ> Well, the problem with flipping is that you travel a lot faster.
13:15 < JohnJ> And at certain angles that doesn't give it time to correct the velocity left (deliberately) at the end of a tangent step.
13:15 < JohnJ> The end velocity calc assumes that it doesn't flip.
13:16 < JohnJ> In most cases CheckSuicide would pick that up anyway and keep you alive.
13:16 < JohnJ> But CheckSuicide doesn't account for gravity assist.
13:17 < JohnJ> Eagle is a full 1g faster than normal when plunging straight down to a starport :-)
13:24 < robn> ok that's making some sense
```
