### PR TITLE
Enforce savefile versions

### DIFF
--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -411,13 +411,8 @@ void LoadGame(const char *filename)
 	rd.SetStreamVersion(rd.Int32());
 	fprintf(stderr, "Savefile version %d. ", rd.StreamVersion());
 
-	if (rd.StreamVersion() > SAVEFILE_VERSION) {
-		fprintf(stderr, "Can't load savefile. It is for a newer version of Pioneer.\n");
-		throw SavedGameCorruptException();
-	}
-
-	if (rd.StreamVersion() < 21) {
-		fprintf(stderr, "Can't load old savefile < alpha9.\n");
+	if (rd.StreamVersion() != SAVEFILE_VERSION) {
+		fprintf(stderr, "Can't load savefile, expected version %d\n", SAVEFILE_VERSION);
 		throw SavedGameCorruptException();
 	}
 


### PR DESCRIPTION
Currently Pioneer tries to load older (but not ancient) save files and ends up crashing because they really make no sense. This forces it to only accept savefiles with the current version.
