### PR TITLE
Update sector view info when view is switched to

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -611,14 +611,16 @@ void SectorView::OnSwitchTo() {
 	if (m_firstTime) {
 		m_current = Pi::currentSystem->GetPath();
 
-		UpdateSystemLabels(m_currentSystemLabels, m_current);
-
 		WarpToSystem(m_current);
 		OnClickSystem(m_current);
 
 		m_firstTime = false;
 	}
 	
+	UpdateSystemLabels(m_currentSystemLabels, m_current);
+	UpdateSystemLabels(m_selectedSystemLabels, m_selected);
+	UpdateSystemLabels(m_targetSystemLabels, m_hyperspaceTarget);
+
 	if (!m_onKeyPressConnection.connected())
 		m_onKeyPressConnection =
 			Pi::onKeyPress.connect(sigc::mem_fun(this, &SectorView::OnKeyPress));


### PR DESCRIPTION
Without this we see two problems (at least):
- Switching to sector view from Sol start point leaves selected & hyperspace info unset.
- Switching to sector view after increasing hyperspace range (eg buying fuel) does not update the range info.
