### PR TITLE
Add onPress and onRelease signals to key bindings - closes #398

### DIFF
--- a/src/KeyBindings.cpp
+++ b/src/KeyBindings.cpp
@@ -6,23 +6,23 @@
 
 namespace KeyBindings {
 
-KeyBinding pitchUp;
-KeyBinding pitchDown;
-KeyBinding yawLeft;
-KeyBinding yawRight;
-KeyBinding rollLeft;
-KeyBinding rollRight;
-KeyBinding thrustForward;
-KeyBinding thrustBackwards;
-KeyBinding thrustUp;
-KeyBinding thrustDown;
-KeyBinding thrustLeft;
-KeyBinding thrustRight;
-KeyBinding increaseSpeed;
-KeyBinding decreaseSpeed;
-KeyBinding fireLaser;
-KeyBinding fastRotate;
-KeyBinding targetObject;
+KeyAction pitchUp;
+KeyAction pitchDown;
+KeyAction yawLeft;
+KeyAction yawRight;
+KeyAction rollLeft;
+KeyAction rollRight;
+KeyAction thrustForward;
+KeyAction thrustBackwards;
+KeyAction thrustUp;
+KeyAction thrustDown;
+KeyAction thrustLeft;
+KeyAction thrustRight;
+KeyAction increaseSpeed;
+KeyAction decreaseSpeed;
+KeyAction fireLaser;
+KeyAction fastRotate;
+KeyAction targetObject;
 
 AxisBinding pitchAxis;
 AxisBinding rollAxis;
@@ -38,23 +38,76 @@ KeyBinding KeyBinding::keyboardBinding(SDLKey key, SDLMod mod) {
 	return kb;
 }
 
-bool KeyBinding::IsActive()
+bool KeyAction::IsActive() const
 {
-	if (type == KEYBOARD_KEY) {
+	if (binding.type == KEYBOARD_KEY) {
 		// 0xfff filters out numlock, capslock and other shit
-		if (u.keyboard.mod != 0)
-			return Pi::KeyState(u.keyboard.key) && ((Pi::KeyModState()&0xfff) == u.keyboard.mod);
+		if (binding.u.keyboard.mod != 0)
+			return Pi::KeyState(binding.u.keyboard.key) && ((Pi::KeyModState()&0xfff) == binding.u.keyboard.mod);
 
-		return Pi::KeyState(u.keyboard.key) != 0;
+		return Pi::KeyState(binding.u.keyboard.key) != 0;
 
-	} else if (type == JOYSTICK_BUTTON) {
-		return Pi::JoystickButtonState(u.joystickButton.joystick, u.joystickButton.button) != 0;
-	} else if (type == JOYSTICK_HAT) {
-		return Pi::JoystickHatState(u.joystickHat.joystick, u.joystickHat.hat) == u.joystickHat.direction;
+	} else if (binding.type == JOYSTICK_BUTTON) {
+		return Pi::JoystickButtonState(binding.u.joystickButton.joystick, binding.u.joystickButton.button) != 0;
+	} else if (binding.type == JOYSTICK_HAT) {
+		return Pi::JoystickHatState(binding.u.joystickHat.joystick, binding.u.joystickHat.hat) == binding.u.joystickHat.direction;
 	} else
 		abort();
 
 	return false;
+}
+
+void KeyAction::CheckSDLEventAndDispatch(const SDL_Event *event) {
+	switch (event->type) {
+		case SDL_KEYDOWN:
+		case SDL_KEYUP:
+		{
+			if (binding.type != KEYBOARD_KEY)
+				return;
+			SDL_keysym sym = event->key.keysym;
+			// 0xfff filters out numlock, capslock and other shit
+			if (binding.u.keyboard.mod && ((sym.mod & 0xfff) != binding.u.keyboard.mod))
+				return;
+			if (sym.sym == binding.u.keyboard.key) {
+				if (event->key.state == SDL_PRESSED)
+					onPress.emit();
+				else if (event->key.state == SDL_RELEASED)
+					onRelease.emit();
+			}
+			break;
+		}
+		case SDL_JOYBUTTONDOWN:
+		case SDL_JOYBUTTONUP:
+		{
+			if (binding.type != JOYSTICK_BUTTON)
+				return;
+			if (binding.u.joystickButton.joystick != event->jbutton.which)
+				return;
+			if (binding.u.joystickButton.button != event->jbutton.button) {
+				if (event->jbutton.state == SDL_PRESSED)
+					onPress.emit();
+				else if (event->jbutton.state == SDL_RELEASED)
+					onRelease.emit();
+			}
+			break;
+		}
+		case SDL_JOYHATMOTION:
+		{
+			if (binding.type != JOYSTICK_HAT)
+				return;
+			if (binding.u.joystickHat.joystick != event->jhat.which)
+				return;
+			if (binding.u.joystickHat.hat != event->jhat.hat)
+				return;
+			if (event->jhat.value == binding.u.joystickHat.direction) {
+				onPress.emit();
+				// XXX to emit onRelease, we need to have access to the state of the joystick hat prior to this event,
+				// so that we can detect the case of switching from a direction that matches the binding to some other direction
+			}
+			break;
+		}
+		default: break;
+	}
 }
 
 std::string KeyBinding::Description() const {
@@ -121,36 +174,36 @@ std::string AxisBinding::Description() const {
 }
 
 const BindingPrototype bindingProtos[] = {
-	{ Lang::WEAPONS, 0 },
-	{ Lang::TARGET_OBJECT_IN_SIGHTS, "BindTargetObject" },
-	{ Lang::FIRE_LASER, "BindFireLaser" },
-	{ Lang::SHIP_ORIENTATION, 0 },
-	{ Lang::FAST_ROTATION_CONTROL, "BindFastRotate" },
-	{ Lang::PITCH_UP, "BindPitchUp" },
-	{ Lang::PITCH_DOWN, "BindPitchDown" },
-	{ Lang::YAW_LEFT, "BindYawLeft" },
-	{ Lang::YAW_RIGHT, "BindYawRight" },
-	{ Lang::ROLL_LEFT, "BindRollLeft" },
-	{ Lang::ROLL_RIGHT, "BindRollRight" },
-	{ Lang::MANUAL_CONTROL_MODE, 0 },
-	{ Lang::THRUSTER_MAIN, "BindThrustForward" },
-	{ Lang::THRUSTER_RETRO, "BindThrustBackwards" },
-	{ Lang::THRUSTER_VENTRAL, "BindThrustUp" },
-	{ Lang::THRUSTER_DORSAL, "BindThrustDown" },
-	{ Lang::THRUSTER_PORT, "BindThrustLeft" },
-	{ Lang::THRUSTER_STARBOARD, "BindThrustRight" },
-	{ Lang::SPEED_CONTROL_MODE, 0 },
-	{ Lang::INCREASE_SET_SPEED, "BindIncreaseSpeed" },
-	{ Lang::DECREASE_SET_SPEED, "BindDecreaseSpeed" },
-	{ 0, 0 },
+	{ Lang::WEAPONS, 0, 0, 0 },
+	{ Lang::TARGET_OBJECT_IN_SIGHTS, "BindTargetObject", &targetObject, 0 },
+	{ Lang::FIRE_LASER, "BindFireLaser", &fireLaser, 0 },
+	{ Lang::SHIP_ORIENTATION, 0, 0, 0 },
+	{ Lang::FAST_ROTATION_CONTROL, "BindFastRotate", &fastRotate, 0 },
+	{ Lang::PITCH_UP, "BindPitchUp", &pitchUp, 0 },
+	{ Lang::PITCH_DOWN, "BindPitchDown", &pitchDown, 0 },
+	{ Lang::YAW_LEFT, "BindYawLeft", &yawLeft, 0 },
+	{ Lang::YAW_RIGHT, "BindYawRight", &yawRight, 0 },
+	{ Lang::ROLL_LEFT, "BindRollLeft", &rollLeft, 0 },
+	{ Lang::ROLL_RIGHT, "BindRollRight", &rollRight, 0 },
+	{ Lang::MANUAL_CONTROL_MODE, 0, 0, 0 },
+	{ Lang::THRUSTER_MAIN, "BindThrustForward", &thrustForward, 0 },
+	{ Lang::THRUSTER_RETRO, "BindThrustBackwards", &thrustBackwards, 0 },
+	{ Lang::THRUSTER_VENTRAL, "BindThrustUp", &thrustUp, 0 },
+	{ Lang::THRUSTER_DORSAL, "BindThrustDown", &thrustDown, 0 },
+	{ Lang::THRUSTER_PORT, "BindThrustLeft", &thrustLeft, 0 },
+	{ Lang::THRUSTER_STARBOARD, "BindThrustRight", &thrustRight, 0 },
+	{ Lang::SPEED_CONTROL_MODE, 0, 0, 0 },
+	{ Lang::INCREASE_SET_SPEED, "BindIncreaseSpeed", &increaseSpeed, 0 },
+	{ Lang::DECREASE_SET_SPEED, "BindDecreaseSpeed", &decreaseSpeed, 0 },
+	{ 0, 0, 0, 0 },
 };
 
 const BindingPrototype axisBindingProtos[] = {
-	{ Lang::JOYSTICK_INPUT, 0 },
-	{ Lang::PITCH, "BindAxisPitch" },
-	{ Lang::ROLL, "BindAxisRoll" },
-	{ Lang::YAW, "BindAxisYaw" },
-	{ 0, 0 },
+	{ Lang::JOYSTICK_INPUT, 0, 0, 0 },
+	{ Lang::PITCH, "BindAxisPitch", 0, &pitchAxis },
+	{ Lang::ROLL, "BindAxisRoll", 0, &rollAxis },
+	{ Lang::YAW, "BindAxisYaw", 0, &yawAxis },
+	{ 0, 0, 0, 0 },
 };
 
 /**
@@ -291,11 +344,30 @@ std::string AxisBindingToString(const AxisBinding &ab) {
 	return oss.str();
 }
 
-#define SET_KEY_BINDING(var,bindname) \
-	KeyBindingFromString(Pi::config.String(bindname).c_str(), &(var));
+#define SET_KEY_BINDING(var, bindname) \
+	KeyBindingFromString(Pi::config.String(bindname).c_str(), &(var.binding));
 
 #define SET_AXIS_BINDING(var, bindname) \
 	AxisBindingFromString(Pi::config.String(bindname).c_str(), &(var));
+
+void DispatchSDLEvent(const SDL_Event *event) {
+	switch (event->type) {
+		case SDL_KEYDOWN:
+		case SDL_KEYUP:
+		case SDL_JOYBUTTONDOWN:
+		case SDL_JOYBUTTONUP:
+		case SDL_JOYHATMOTION:
+			break;
+		default: return;
+	}
+
+	// simplest possible approach here: just check each binding and dispatch if it matches
+	for (int i = 0; bindingProtos[i].label; ++i) {
+		KeyAction *kb = bindingProtos[i].kb;
+		if (kb)
+			kb->CheckSDLEventAndDispatch(event);
+	}
+}
 
 void OnKeyBindingsChanged()
 {

--- a/src/KeyBindings.h
+++ b/src/KeyBindings.h
@@ -31,10 +31,19 @@ namespace KeyBindings {
 			} joystickHat;
 		} u;
 
-		bool IsActive();
 		std::string Description() const;
 
 		static KeyBinding keyboardBinding(SDLKey key, SDLMod mod);
+	};
+
+	struct KeyAction {
+		KeyBinding binding;
+
+		sigc::signal<void> onPress;
+		sigc::signal<void> onRelease;
+
+		bool IsActive() const;
+		void CheckSDLEventAndDispatch(const SDL_Event *event);
 	};
 
 	enum AxisDirection {
@@ -55,6 +64,8 @@ namespace KeyBindings {
 
 	struct BindingPrototype {
 		const char *label, *function;
+		KeyAction *kb;
+		AxisBinding *ab;
 	};
 
 	extern const BindingPrototype bindingProtos[];
@@ -70,23 +81,25 @@ namespace KeyBindings {
 	AxisBinding AxisBindingFromString(const std::string &str);
 	std::string AxisBindingToString(const AxisBinding &ab);
 
-	extern KeyBinding pitchUp;
-	extern KeyBinding pitchDown;
-	extern KeyBinding yawLeft;
-	extern KeyBinding yawRight;
-	extern KeyBinding rollLeft;
-	extern KeyBinding rollRight;
-	extern KeyBinding thrustForward;
-	extern KeyBinding thrustBackwards;
-	extern KeyBinding thrustUp;
-	extern KeyBinding thrustDown;
-	extern KeyBinding thrustLeft;
-	extern KeyBinding thrustRight;
-	extern KeyBinding increaseSpeed;
-	extern KeyBinding decreaseSpeed;
-	extern KeyBinding fireLaser;
-	extern KeyBinding fastRotate;
-	extern KeyBinding targetObject;
+	void DispatchSDLEvent(const SDL_Event *event);
+
+	extern KeyAction pitchUp;
+	extern KeyAction pitchDown;
+	extern KeyAction yawLeft;
+	extern KeyAction yawRight;
+	extern KeyAction rollLeft;
+	extern KeyAction rollRight;
+	extern KeyAction thrustForward;
+	extern KeyAction thrustBackwards;
+	extern KeyAction thrustUp;
+	extern KeyAction thrustDown;
+	extern KeyAction thrustLeft;
+	extern KeyAction thrustRight;
+	extern KeyAction increaseSpeed;
+	extern KeyAction decreaseSpeed;
+	extern KeyAction fireLaser;
+	extern KeyAction fastRotate;
+	extern KeyAction targetObject;
 
 	extern AxisBinding pitchAxis;
 	extern AxisBinding rollAxis;

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -555,6 +555,8 @@ void Pi::HandleEvents()
 	Pi::mouseMotion[0] = Pi::mouseMotion[1] = 0;
 	while (SDL_PollEvent(&event)) {
 		Gui::HandleSDLEvent(&event);
+		KeyBindings::DispatchSDLEvent(&event);
+
 		switch (event.type) {
 			case SDL_KEYDOWN:
 				if (event.key.keysym.sym == SDLK_ESCAPE) {


### PR DESCRIPTION
`KeyBinding` is intended to be plain-old-data (or very close to it); it has no active components. The new `KeyAction` wraps a `KeyBinding` and adds signal dispatch functionality (as well as taking over the `IsActive` method that was previously in `KeyBinding`). This avoids the irritating problem of having to change all the code to avoid all copies of `KeyBinding` objects, which was the reason @Luomu's original patch didn't work.

Limitations/later improvements:
1. Dispatch is currently done by looping over the KeyAction objects on every KeyDown/Up/JoystickButtonDown/Up/JoystickHatMotion event, and checking each one for a match.
2. Joystick Hat motion only emits onPress signals at the moment. To fix this we'd need to track the state (ie, direction) of each joystick hat and update it as events come in, so that we can check against the previous hat state to determine if the hat state has gone from matching to non-matching (which is a "release" of that button, effectively). Note that Pi already does track this state, but we need to be careful with this because at the moment event handling is spread around a lot.

Notes for the first point:
With small numbers of bindings, looping over them is no big deal (in fact even with large numbers of bindings we probably wouldn't notice it). However, if we do end up with large numbers of bindings (and I'd be inclined to say that we _should_, since I think all GUI hot-keys should actually go through the keybinding system, even if that configurability isn't exposed in the config menu), then this should be replaced with either a direct sparse array dispatch (i.e., you have a big fixed array that maps directly from key/joystick+button/joystick+hat+direction index to a `KeyAction*` so you can look up the appropriate action in constant time), or have a hash table doing the same thing. The big fixed array is easier... although if you store 64-bit `KeyAction` pointers in it then it could easily end up being multiple KB; it could be shrunk somewhat by keeping the KeyAction objects contiguous themselves so you can just store a 16-bit index rather than a full 64-bit pointer.
