### PR TITLE
Issue 404 (Lua API change ship type)

### DIFF
--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -152,8 +152,7 @@ static int l_set_ship_type(lua_State *l)
 
     if (s->GetFlightState() == Ship::DOCKED)
     {
-    	ShipFlavour f;
-        f.type = type;
+    	ShipFlavour f(type);
 
         s->ResetFlavour(&f);
         s->m_equipment.Set(Equip::SLOT_ENGINE, 0, ShipType::types[f.type].hyperdrive);


### PR DESCRIPTION
Please review.  Not sure whether this should throw an error if the ship wasn't docked, or just quietly exit.  I chose to throw an error, based on the fact that a script developer might want to know why it didn't work (and hopefully in the future, errors won't stop the game dead).

```
/* Method: SetShipType
 *
 * Replaces the ship with a new ship of the specified type.
 * (internal: Resets the ship flavour)
 *
 * > ship:SetShipType(newtype)
 *
 * Parameters:
 *
 *   newtype - mandatory. A ShipType.
 *
 * Example:
 *
 * > ship:SetShipType('Sirius Interdictor')
 *
 * Availability:
 * 
 *   alpha 15
 *
 * Status:
 *
 *   experimental
 */
```
