### PR TITLE
Drive servicing - new feature implemented in Lua.

### DIFF
--- a/data/modules/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing.lua
@@ -108,7 +108,7 @@ local onChat = function (form, ref, option)
 
     -- Tariff!  ad.baseprice is from 2 to 10
     local price = ad.baseprice
-    price = price * ({
+    price = price * (({
         NONE = 0,
         DRIVE_CLASS1 = 1.0,
         DRIVE_CLASS2 = 1.2,
@@ -123,7 +123,7 @@ local onChat = function (form, ref, option)
         DRIVE_MIL2 = 1.6,
         DRIVE_MIL3 = 2.8,
         DRIVE_MIL4 = 4.0,
-    })[hyperdrive] or 10
+    })[hyperdrive] or 10)
 
     -- Now make it bigger (-:
     price = price * 10


### PR DESCRIPTION
A drive has a 12 month service period.  During that period, it will not fail.  This period begins:
- When the player starts a game
- When the player buys a new ship
- When the player replaces their hyperdrive
- When the player pays for a service at a dealer on the BBS

After the period is up, the engine will survive a maximum of 255 further jumps.  The probability of failure increases in inverse proportion to the maximum number of jumps remaining.  So after a year, the first jump gives a 1/255 chance of a drive failure.  The next, 1/254, then 1/253... right until 1/3 for the 253rd jump, 1/2 for the 254th and a guaranteed failure for the lucky bugger who made it to 255.

When the drive fails, the player is given a UI message informing them that the drive was destroyed by a malfunction.  The drive is removed from the ship and replaced with its own weight in rubbish.

If included, this is not an opt-in feature.  Drives will _require_ regular servicing.  This will affect long range exploration, and a future enhancement might be to have some plot-based mechanism for increasing the lifespan of the drive.

Additional:  All player-visible strings are defined near the top of the script, to make any future translation efforts simpler.
