### PR TITLE
pass name of the station rather than path

### DIFF
--- a/data/modules/DeliverPackage.lua
+++ b/data/modules/DeliverPackage.lua
@@ -346,7 +346,7 @@ local onEnterSystem = function (player)
 
 			if ship then
 				local pirate_greeting = string.interp(pirate_taunts[Engine.rand:Integer(1,#pirate_taunts)], {
-					client = mission.client, location = mission.location,})
+					client = mission.client, location = mission.location:GetSystemBody().name,})
 				UI.ImportantMessage(pirate_greeting, ship.label)
 			end
 		end


### PR DESCRIPTION
fixes crash when attacked on entering mission system
