### PR TITLE
Remove EquipType::types (mechanical rename to Equip::types)

### DIFF
--- a/src/CargoBody.cpp
+++ b/src/CargoBody.cpp
@@ -24,7 +24,7 @@ void CargoBody::Load(Serializer::Reader &rd)
 void CargoBody::Init()
 {
 	m_hitpoints = 1.0f;
-	SetLabel(EquipType::types[m_type].name);
+	SetLabel(Equip::types[m_type].name);
 	SetModel("cargo");
 	SetMassDistributionFromModel();
 }
@@ -49,7 +49,7 @@ bool CargoBody::OnDamage(Object *attacker, float kgDamage)
 void CargoBody::Render(const vector3d &viewCoords, const matrix4x4d &viewTransform)
 {
 	if (!IsEnabled()) return;
-	GetLmrObjParams().argStrings[0] = EquipType::types[m_type].name;
+	GetLmrObjParams().argStrings[0] = Equip::types[m_type].name;
 	RenderLmrModel(viewCoords, viewTransform);
 }
 

--- a/src/CommodityTradeWidget.cpp
+++ b/src/CommodityTradeWidget.cpp
@@ -75,7 +75,7 @@ void CommodityTradeWidget::ShowAll()
 	int NUM_ITEMS = 0;
 	const float YSEP = floor(Gui::Screen::GetFontHeight() * 2.5f);
 	for (int i=Equip::FIRST_COMMODITY; i<=Equip::LAST_COMMODITY; i++) {
-		assert(EquipType::types[i].slot == Equip::SLOT_CARGO);
+		assert(Equip::types[i].slot == Equip::SLOT_CARGO);
 
 		if (m_seller->DoesSell(Equip::Type(i))) {
 				NUM_ITEMS++;
@@ -86,7 +86,7 @@ void CommodityTradeWidget::ShowAll()
 	
 	const float iconOffset = 8.0f;
 	for (int i=Equip::FIRST_COMMODITY, num=0; i<=Equip::LAST_COMMODITY; i++) {
-		assert(EquipType::types[i].slot == Equip::SLOT_CARGO);
+		assert(Equip::types[i].slot == Equip::SLOT_CARGO);
 
 		if (!m_seller->DoesSell(Equip::Type(i))) continue;
 		int stock = m_seller->GetStock(static_cast<Equip::Type>(i));
@@ -97,9 +97,9 @@ void CommodityTradeWidget::ShowAll()
 			innerbox->Add(icon, 0, num*YSEP);
 		}
 
-		Gui::Label *l = new Gui::Label(EquipType::types[i].name);
-		if (EquipType::types[i].description)
-			l->SetToolTip(EquipType::types[i].description);
+		Gui::Label *l = new Gui::Label(Equip::types[i].name);
+		if (Equip::types[i].description)
+			l->SetToolTip(Equip::types[i].description);
 		innerbox->Add(l,42,num*YSEP+iconOffset);
 		Gui::Button *b = new Gui::RepeaterButton(RBUTTON_DELAY, RBUTTON_REPEAT);
 		b->onClick.connect(sigc::bind(sigc::mem_fun(this, &CommodityTradeWidget::OnClickBuy), i));
@@ -112,12 +112,12 @@ void CommodityTradeWidget::ShowAll()
 					format_money(m_seller->GetPrice(static_cast<Equip::Type>(i)))
 					), 200, num*YSEP+iconOffset);
 		
-		snprintf(buf, sizeof(buf), "%dt", stock*EquipType::types[i].mass);
+		snprintf(buf, sizeof(buf), "%dt", stock*Equip::types[i].mass);
 		Gui::Label *stocklabel = new Gui::Label(buf);
 		m_stockLabels[i] = stocklabel;
 		innerbox->Add(stocklabel, 275, num*YSEP+iconOffset);
 		
-		snprintf(buf, sizeof(buf), "%dt", Pi::player->m_equipment.Count(Equip::SLOT_CARGO, static_cast<Equip::Type>(i))*EquipType::types[i].mass);
+		snprintf(buf, sizeof(buf), "%dt", Pi::player->m_equipment.Count(Equip::SLOT_CARGO, static_cast<Equip::Type>(i))*Equip::types[i].mass);
 		Gui::Label *cargolabel = new Gui::Label(buf);
 		m_cargoLabels[i] = cargolabel;
 		innerbox->Add(cargolabel, 325, num*YSEP+iconOffset);
@@ -151,10 +151,10 @@ void CommodityTradeWidget::ShowAll()
 void CommodityTradeWidget::UpdateStock(int commodity_type)
 {
 	char buf[128];
-	snprintf(buf, sizeof(buf), "%dt", Pi::player->m_equipment.Count(Equip::SLOT_CARGO, static_cast<Equip::Type>(commodity_type))*EquipType::types[commodity_type].mass);
+	snprintf(buf, sizeof(buf), "%dt", Pi::player->m_equipment.Count(Equip::SLOT_CARGO, static_cast<Equip::Type>(commodity_type))*Equip::types[commodity_type].mass);
 	m_cargoLabels[commodity_type]->SetText(buf);
 	
-	snprintf(buf, sizeof(buf), "%dt", m_seller->GetStock(static_cast<Equip::Type>(commodity_type))*EquipType::types[commodity_type].mass);
+	snprintf(buf, sizeof(buf), "%dt", m_seller->GetStock(static_cast<Equip::Type>(commodity_type))*Equip::types[commodity_type].mass);
 	m_stockLabels[commodity_type]->SetText(buf);
 }
 

--- a/src/EquipType.cpp
+++ b/src/EquipType.cpp
@@ -2,8 +2,6 @@
 #include "StarSystem.h"
 #include "Lang.h"
 
-const EquipType *EquipType::types = Equip::types;
-
 const EquipType Equip::types[Equip::TYPE_MAX] = {
 	{ Lang::NONE, 0,
 	  Equip::SLOT_CARGO, -1, {},

--- a/src/EquipType.h
+++ b/src/EquipType.h
@@ -55,8 +55,6 @@ struct EquipType {
 	int econType;
 	int techLevel; /* 0-5 */
 	float rechargeTime;			// to be eliminated maybe
-
-	static const EquipType *types;		// deprecated
 };
 
 struct LaserType {

--- a/src/InfoView.cpp
+++ b/src/InfoView.cpp
@@ -122,15 +122,15 @@ public:
 		Add(new Gui::Label(Lang::JETTISON), 40, 40+YSEP*2);
 		float ypos = 40 + 3*YSEP;
 		for (int i=1; i<Equip::TYPE_MAX; i++) {
-			if (EquipType::types[i].slot != Equip::SLOT_CARGO) continue;
+			if (Equip::types[i].slot != Equip::SLOT_CARGO) continue;
 			const int gotNum = Pi::player->m_equipment.Count(Equip::SLOT_CARGO, static_cast<Equip::Type>(i));
 			if (!gotNum) continue;
 			Gui::Button *b = new Gui::SolidButton();
 			b->onClick.connect(sigc::bind(sigc::mem_fun(this, &CargoPage::JettisonCargo), static_cast<Equip::Type>(i)));
 			Add(b, 40, ypos);
-			Add(new Gui::Label(EquipType::types[i].name), 70, ypos);
+			Add(new Gui::Label(Equip::types[i].name), 70, ypos);
 			char buf[128];
-			snprintf(buf, sizeof(buf), "%dt", gotNum*EquipType::types[i].mass);
+			snprintf(buf, sizeof(buf), "%dt", gotNum*Equip::types[i].mass);
 			Add(new Gui::Label(buf), 300, ypos);
 			ypos += YSEP;
 		}
@@ -139,7 +139,7 @@ public:
 private:
 	void JettisonCargo(Equip::Type t) {
 		if (Pi::player->Jettison(t)) {
-			Pi::cpan->MsgLog()->Message("", stringf(Lang::JETTISONED_1T_OF_X, formatarg("commodity", EquipType::types[t].name)));
+			Pi::cpan->MsgLog()->Message("", stringf(Lang::JETTISONED_1T_OF_X, formatarg("commodity", Equip::types[t].name)));
 			m_infoView->UpdateInfo();
 		}
 	}
@@ -217,7 +217,7 @@ public:
 		col2 = "\n\n";
 
 		Equip::Type e = Pi::player->m_equipment.Get(Equip::SLOT_ENGINE);
-		col2 += std::string(EquipType::types[e].name);
+		col2 += std::string(Equip::types[e].name);
 
 		const shipstats_t *stats;
 		stats = Pi::player->CalcStats();
@@ -231,14 +231,14 @@ public:
 		int numLasers = Pi::player->m_equipment.GetSlotSize(Equip::SLOT_LASER);
 		if (numLasers >= 1) {
 			e = Pi::player->m_equipment.Get(Equip::SLOT_LASER, 0);
-			col2 += std::string("\n\n")+EquipType::types[e].name;
+			col2 += std::string("\n\n")+Equip::types[e].name;
 		} else {
 			col2 += "\n\n";
             col2 += std::string(Lang::NO_MOUNTING);
 		}
 		if (numLasers >= 2) {
 			e = Pi::player->m_equipment.Get(Equip::SLOT_LASER, 1);
-			col2 += std::string("\n")+EquipType::types[e].name;
+			col2 += std::string("\n")+Equip::types[e].name;
 		} else {
 			col2 += "\n";
             col2 += std::string(Lang::NO_MOUNTING);
@@ -251,13 +251,13 @@ public:
 
 		for (int i=Equip::FIRST_SHIPEQUIP; i<=Equip::LAST_SHIPEQUIP; i++) {
 			Equip::Type t = Equip::Type(i) ;
-			Equip::Slot s = EquipType::types[t].slot;
+			Equip::Slot s = Equip::types[t].slot;
 			if ((s == Equip::SLOT_MISSILE) || (s == Equip::SLOT_ENGINE) || (s == Equip::SLOT_LASER)) continue;
 			int num = Pi::player->m_equipment.Count(s, t);
 			if (num == 1) {
-				col1 += stringf("%0\n", EquipType::types[t].name);
+				col1 += stringf("%0\n", Equip::types[t].name);
 			} else if (num > 1) {
-				col1 += stringf("%0{d} %1s\n", num, EquipType::types[t].name);
+				col1 += stringf("%0{d} %1s\n", num, Equip::types[t].name);
 			}
 		}
 

--- a/src/LuaChatForm.cpp
+++ b/src/LuaChatForm.cpp
@@ -197,7 +197,7 @@ void LuaChatForm::OnClickBuy(int t) {
 
 	if (allow_buy) {
 		if (SellTo(Pi::player, static_cast<Equip::Type>(t), true)) {
-			Pi::Message(stringf(Lang::BOUGHT_1T_OF, formatarg("commodity", EquipType::types[t].name)));
+			Pi::Message(stringf(Lang::BOUGHT_1T_OF, formatarg("commodity", Equip::types[t].name)));
 		}
 		m_commodityTradeWidget->UpdateStock(t);
 	}
@@ -221,7 +221,7 @@ void LuaChatForm::OnClickSell(int t) {
 
 	if (allow_sell) {
 		if (BuyFrom(Pi::player, static_cast<Equip::Type>(t), true)) {
-			Pi::Message(stringf(Lang::SOLD_1T_OF, formatarg("commodity", EquipType::types[t].name)));
+			Pi::Message(stringf(Lang::SOLD_1T_OF, formatarg("commodity", Equip::types[t].name)));
 		}
 		m_commodityTradeWidget->UpdateStock(t);
 	}

--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -554,8 +554,8 @@ static int l_ship_add_equip(lua_State *l)
 		num = lua_tointeger(l, 3);
 
 	const shipstats_t *stats = s->CalcStats();
-	if (EquipType::types[e].mass != 0)
-		num = std::min(stats->free_capacity / (EquipType::types[e].mass), num);
+	if (Equip::types[e].mass != 0)
+		num = std::min(stats->free_capacity / (Equip::types[e].mass), num);
 
 	lua_pushinteger(l, s->m_equipment.Add(e, num));
 	s->UpdateMass();

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -394,9 +394,9 @@ void Player::Sold(Equip::Type t)
 
 bool Player::CanBuy(Equip::Type t, bool verbose) const
 {
-	Equip::Slot slot = EquipType::types[int(t)].slot;
+	Equip::Slot slot = Equip::types[int(t)].slot;
 	bool freespace = (m_equipment.FreeSpace(slot)!=0);
-	bool freecapacity = (m_stats.free_capacity >= EquipType::types[int(t)].mass);
+	bool freecapacity = (m_stats.free_capacity >= Equip::types[int(t)].mass);
 	if (verbose) {
 		if (!freespace) {
 			Pi::Message(Lang::NO_FREE_SPACE_FOR_ITEM);
@@ -410,11 +410,11 @@ bool Player::CanBuy(Equip::Type t, bool verbose) const
 
 bool Player::CanSell(Equip::Type t, bool verbose) const
 {
-	Equip::Slot slot = EquipType::types[int(t)].slot;
+	Equip::Slot slot = Equip::types[int(t)].slot;
 	bool cansell = (m_equipment.Count(slot, t) > 0);
 	if (verbose) {
 		if (!cansell) {
-			Pi::Message(stringf(Lang::YOU_DO_NOT_HAVE_ANY_X, formatarg("item", EquipType::types[int(t)].name)));
+			Pi::Message(stringf(Lang::YOU_DO_NOT_HAVE_ANY_X, formatarg("item", Equip::types[int(t)].name)));
 		}
 	}
 	return cansell;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -291,7 +291,7 @@ void Ship::ClearThrusterState()
 Equip::Type Ship::GetHyperdriveFuelType() const
 {
 	Equip::Type t = m_equipment.Get(Equip::SLOT_ENGINE);
-	return EquipType::types[t].inputs[0];
+	return Equip::types[t].inputs[0];
 }
 
 const shipstats_t *Ship::CalcStats()
@@ -305,8 +305,8 @@ const shipstats_t *Ship::CalcStats()
 	for (int i=0; i<Equip::SLOT_MAX; i++) {
 		for (int j=0; j<stype.equipSlotCapacity[i]; j++) {
 			Equip::Type t = m_equipment.Get(Equip::Slot(i), j);
-			if (t) m_stats.used_capacity += EquipType::types[t].mass;
-			if (Equip::Slot(i) == Equip::SLOT_CARGO) m_stats.used_cargo += EquipType::types[t].mass;
+			if (t) m_stats.used_capacity += Equip::types[t].mass;
+			if (Equip::Slot(i) == Equip::SLOT_CARGO) m_stats.used_cargo += Equip::types[t].mass;
 		}
 	}
 	m_stats.free_capacity = m_stats.max_capacity - m_stats.used_capacity;
@@ -316,7 +316,7 @@ const shipstats_t *Ship::CalcStats()
 
 	if (stype.equipSlotCapacity[Equip::SLOT_ENGINE]) {
 		Equip::Type t = m_equipment.Get(Equip::SLOT_ENGINE);
-		int hyperclass = EquipType::types[t].pval;
+		int hyperclass = Equip::types[t].pval;
 		if (!hyperclass) { // no drive
 			m_stats.hyperspace_range = m_stats.hyperspace_range_max = 0;
 		} else {
@@ -358,7 +358,7 @@ bool Ship::CanHyperspaceTo(const SystemPath *dest, int &outFuelRequired, double 
 {
 	Equip::Type t = m_equipment.Get(Equip::SLOT_ENGINE);
 	Equip::Type fuelType = GetHyperdriveFuelType();
-	int hyperclass = EquipType::types[t].pval;
+	int hyperclass = Equip::types[t].pval;
 	int fuel = m_equipment.Count(Equip::SLOT_CARGO, fuelType);
 	outFuelRequired = 0;
 	if (hyperclass == 0) {
@@ -417,7 +417,7 @@ Ship::HyperjumpStatus Ship::StartHyperspaceCountdown(const SystemPath &dest)
 		return status;
 	
 	Equip::Type t = m_equipment.Get(Equip::SLOT_ENGINE);
-	m_hyperspace.countdown = 1.0f + EquipType::types[t].pval;
+	m_hyperspace.countdown = 1.0f + Equip::types[t].pval;
 	m_hyperspace.now = false;
 
 	return Ship::HYPERJUMP_OK;
@@ -449,7 +449,7 @@ float Ship::GetECMRechargeTime()
 {
 	const Equip::Type t = m_equipment.Get(Equip::SLOT_ECM);
 	if (t != Equip::NONE) {
-		return EquipType::types[t].rechargeTime;
+		return Equip::types[t].rechargeTime;
 	} else {
 		return 0;
 	}
@@ -462,7 +462,7 @@ void Ship::UseECM()
 	if (t != Equip::NONE) {
 		Sound::BodyMakeNoise(this, "ECM", 1.0f);
 		m_ecmRecharge = GetECMRechargeTime();
-		Space::DoECM(GetFrame(), GetPosition(), EquipType::types[t].pval);
+		Space::DoECM(GetFrame(), GetPosition(), Equip::types[t].pval);
 	}
 }
 
@@ -801,7 +801,7 @@ void Ship::StaticUpdate(const float timeStep)
 		m_gunRecharge[i] -= timeStep;
 		float rateCooling = 0.01f;
 		if (m_equipment.Get(Equip::SLOT_LASERCOOLER) != Equip::NONE)  {
-			rateCooling *= float(EquipType::types[ m_equipment.Get(Equip::SLOT_LASERCOOLER) ].pval);
+			rateCooling *= float(Equip::types[ m_equipment.Get(Equip::SLOT_LASERCOOLER) ].pval);
 		}
 		m_gunTemperature[i] -= rateCooling*timeStep;
 		if (m_gunTemperature[i] < 0.0f) m_gunTemperature[i] = 0;
@@ -822,7 +822,7 @@ void Ship::StaticUpdate(const float timeStep)
 		// 250 second recharge
 		float recharge_rate = 0.004f;
 		if (m_equipment.Get(Equip::SLOT_ENERGYBOOSTER) != Equip::NONE) {
-			recharge_rate *= float(EquipType::types[ m_equipment.Get(Equip::SLOT_ENERGYBOOSTER) ].pval);
+			recharge_rate *= float(Equip::types[ m_equipment.Get(Equip::SLOT_ENERGYBOOSTER) ].pval);
 		}
 		m_stats.shield_mass_left += m_stats.shield_mass * recharge_rate * timeStep;
 	}
@@ -1041,7 +1041,7 @@ bool Ship::Jettison(Equip::Type t)
 {
 	if (m_flightState != FLYING) return false;
 	if (t == Equip::NONE) return false;
-	Equip::Slot slot = EquipType::types[int(t)].slot;
+	Equip::Slot slot = Equip::types[int(t)].slot;
 	if (m_equipment.Count(slot, t) > 0) {
 		m_equipment.Remove(t, 1);
 		UpdateMass();

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -120,7 +120,7 @@ bool AICmdJourney::TimeStepUpdate()
 					MarketAgent *trader = m_ship->GetDockedWith();
 					// need to lose some equipment and see if we get light enough
 					Equip::Type t = (Equip::Type)Pi::rng.Int32(Equip::TYPE_MAX);
-					if ((EquipType::types[t].slot == Equip::SLOT_ENGINE) && trader->CanSell(t)) {
+					if ((Equip::types[t].slot == Equip::SLOT_ENGINE) && trader->CanSell(t)) {
 						// try a different hyperdrive
 						m_ship->SellTo(trader, driveType);
 						if (!m_ship->BuyFrom(trader, t)) {

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -260,7 +260,7 @@ void UseEquipWidget::UpdateEquip()
 			}
 			Add(b, spacing*i, 40);
 			b->onClick.connect(sigc::bind(sigc::mem_fun(this, &UseEquipWidget::FireMissile), i));
-			b->SetToolTip(EquipType::types[t].name);
+			b->SetToolTip(Equip::types[t].name);
 		}
 	}
 

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -300,10 +300,10 @@ SpaceStation::SpaceStation(const SBody *sbody): ModelBody()
 	m_lastUpdatedShipyard = 0;
 	m_numPoliceDocked = Pi::rng.Int32(3,10);
 	for (int i=1; i<Equip::TYPE_MAX; i++) {
-		if (EquipType::types[i].slot == Equip::SLOT_CARGO) {
+		if (Equip::types[i].slot == Equip::SLOT_CARGO) {
 			m_equipmentStock[i] = Pi::rng.Int32(0,100) * Pi::rng.Int32(1,100);
 		} else {
-			if (EquipType::types[i].techLevel <= Pi::currentSystem->m_techlevel)
+			if (Equip::types[i].techLevel <= Pi::currentSystem->m_techlevel)
 				m_equipmentStock[i] = Pi::rng.Int32(0,100);
 		}
 	}
@@ -672,7 +672,7 @@ bool SpaceStation::DoesSell(Equip::Type t) const {
 
 Sint64 SpaceStation::GetPrice(Equip::Type t) const {
 	Sint64 mul = 100 + Pi::currentSystem->GetCommodityBasePriceModPercent(t);
-	return (mul * Sint64(EquipType::types[t].basePrice)) / 100;
+	return (mul * Sint64(Equip::types[t].basePrice)) / 100;
 }
 
 bool SpaceStation::OnCollision(Object *b, Uint32 flags, double relVel)

--- a/src/StarSystem.cpp
+++ b/src/StarSystem.cpp
@@ -1671,7 +1671,7 @@ void StarSystem::Populate(bool addSpaceStations)
 // Unused?
 //	for (int i=(int)Equip::FIRST_COMMODITY; i<=(int)Equip::LAST_COMMODITY; i++) {
 //		Equip::Type t = (Equip::Type)i;
-//		const EquipType &type = EquipType::types[t];
+//		const EquipType &type = Equip::types[t];
 //		printf("%s: %d%%\n", type.name, m_tradeLevel[t]);
 //	}
 //	printf("System total population %.3f billion, tech level %d\n", m_totalPop.ToFloat(), m_techlevel);
@@ -1750,7 +1750,7 @@ void SBody::PopulateStage1(StarSystem *system, fixed &outTotalPop)
 	/* Commodities we produce (mining and agriculture) */
 	for (int i=Equip::FIRST_COMMODITY; i<Equip::LAST_COMMODITY; i++) {
 		Equip::Type t = Equip::Type(i);
-		const EquipType &itype = EquipType::types[t];
+		const EquipType &itype = Equip::types[t];
 		if (itype.techLevel > system->m_techlevel) continue;
 
 		fixed affinity = fixed(1,1);

--- a/src/StationCommodityMarketForm.cpp
+++ b/src/StationCommodityMarketForm.cpp
@@ -22,7 +22,7 @@ StationCommodityMarketForm::StationCommodityMarketForm(FormController *controlle
 void StationCommodityMarketForm::OnClickBuy(int commodity)
 {
 	if (m_station->SellTo(Pi::player, Equip::Type(commodity), true)) {
-		Pi::cpan->MsgLog()->Message("", stringf(Lang::BOUGHT_1T_OF, formatarg("commodity", EquipType::types[commodity].name)));
+		Pi::cpan->MsgLog()->Message("", stringf(Lang::BOUGHT_1T_OF, formatarg("commodity", Equip::types[commodity].name)));
 	}
 	m_trader->UpdateStock(commodity);
 }
@@ -30,7 +30,7 @@ void StationCommodityMarketForm::OnClickBuy(int commodity)
 void StationCommodityMarketForm::OnClickSell(int commodity)
 {
 	if (m_station->BuyFrom(Pi::player, Equip::Type(commodity), true)) {
-		Pi::cpan->MsgLog()->Message("", stringf(Lang::SOLD_1T_OF, formatarg("commodity", EquipType::types[commodity].name)));
+		Pi::cpan->MsgLog()->Message("", stringf(Lang::SOLD_1T_OF, formatarg("commodity", Equip::types[commodity].name)));
 	}
 	m_trader->UpdateStock(commodity);
 }

--- a/src/StationShipEquipmentForm.cpp
+++ b/src/StationShipEquipmentForm.cpp
@@ -50,9 +50,9 @@ StationShipEquipmentForm::StationShipEquipmentForm(FormController *controller) :
 		Equip::Type type = static_cast<Equip::Type>(i);
 		int stock = m_station->GetStock(type);
 		if (!stock) continue;
-		Gui::Label *l = new Gui::Label(EquipType::types[i].name);
-		if (EquipType::types[i].description) {
-			l->SetToolTip(EquipType::types[i].description);
+		Gui::Label *l = new Gui::Label(Equip::types[i].name);
+		if (Equip::types[i].description) {
+			l->SetToolTip(Equip::types[i].description);
 		}
 		innerbox->Add(l,0,num*YSEP);
 		
@@ -61,7 +61,7 @@ StationShipEquipmentForm::StationShipEquipmentForm(FormController *controller) :
 		innerbox->Add(new Gui::Label(format_money(REMOVAL_VALUE_PERCENT * m_station->GetPrice(type) / 100)),
 				275, num*YSEP);
 		
-		innerbox->Add(new Gui::Label(stringf(Lang::NUMBER_TONNES, formatarg("mass", EquipType::types[i].mass))), 360, num*YSEP);
+		innerbox->Add(new Gui::Label(stringf(Lang::NUMBER_TONNES, formatarg("mass", Equip::types[i].mass))), 360, num*YSEP);
 
 		ButtonPair pair;
 		pair.type = type;
@@ -110,7 +110,7 @@ void StationShipEquipmentForm::ShowAll()
 void StationShipEquipmentForm::RecalcButtonVisibility()
 {
 	for (std::list<ButtonPair>::iterator i = m_buttons.begin(); i != m_buttons.end(); i++) {
-		Equip::Slot slot = EquipType::types[(*i).type].slot;
+		Equip::Slot slot = Equip::types[(*i).type].slot;
 
 		if (Pi::player->m_equipment.FreeSpace(slot))
 			(*i).add->Show();
@@ -126,7 +126,7 @@ void StationShipEquipmentForm::RecalcButtonVisibility()
 
 void StationShipEquipmentForm::FitItem(Equip::Type t)
 {
-	Equip::Slot slot = EquipType::types[t].slot;
+	Equip::Slot slot = Equip::types[t].slot;
 
 	const shipstats_t *stats = Pi::player->CalcStats();
 	int freespace = Pi::player->m_equipment.FreeSpace(slot);
@@ -136,7 +136,7 @@ void StationShipEquipmentForm::FitItem(Equip::Type t)
 		return;
 	}
 
-	if (!freespace || stats->free_capacity < EquipType::types[t].mass) {
+	if (!freespace || stats->free_capacity < Equip::types[t].mass) {
 		Pi::cpan->MsgLog()->Message("", Lang::NO_SPACE_ON_SHIP);
 		return;
 	}
@@ -151,7 +151,7 @@ void StationShipEquipmentForm::FitItem(Equip::Type t)
 }
 	
 void StationShipEquipmentForm::RemoveItem(Equip::Type t) {
-	Equip::Slot slot = EquipType::types[t].slot;
+	Equip::Slot slot = Equip::types[t].slot;
 
 	int num = Pi::player->m_equipment.Count(slot, t);
 	if (!num)
@@ -170,11 +170,11 @@ void StationShipEquipmentForm::FitItemForce(Equip::Type t, int pos) {
 	if (pos < 0)
 		Pi::player->m_equipment.Add(t);
 	else
-		Pi::player->m_equipment.Set(EquipType::types[t].slot, pos, t);
+		Pi::player->m_equipment.Set(Equip::types[t].slot, pos, t);
 
 	Pi::player->UpdateMass();
 	Pi::player->SetMoney(Pi::player->GetMoney() - m_station->GetPrice(t));
-	Pi::cpan->MsgLog()->Message("", Lang::FITTING+std::string(EquipType::types[t].name));
+	Pi::cpan->MsgLog()->Message("", Lang::FITTING+std::string(Equip::types[t].name));
 
 	RecalcButtonVisibility();
 }
@@ -183,12 +183,12 @@ void StationShipEquipmentForm::RemoveItemForce(Equip::Type t, int pos) {
 	if (pos < 0)
 		Pi::player->m_equipment.Remove(t, 1);
 	else
-		Pi::player->m_equipment.Set(EquipType::types[t].slot, pos, Equip::NONE);
+		Pi::player->m_equipment.Set(Equip::types[t].slot, pos, Equip::NONE);
 
 	Pi::player->UpdateMass();
 	Pi::player->SetMoney(Pi::player->GetMoney() + m_station->GetPrice(t) * REMOVAL_VALUE_PERCENT / 100);
 	m_station->AddEquipmentStock(t, 1);
-	Pi::cpan->MsgLog()->Message("", Lang::REMOVING+std::string(EquipType::types[t].name));
+	Pi::cpan->MsgLog()->Message("", Lang::REMOVING+std::string(Equip::types[t].name));
 
 	RecalcButtonVisibility();
 }
@@ -209,7 +209,7 @@ PickLaserMountForm::PickLaserMountForm(FormController *controller, StationShipEq
 	else
 		layoutBox->PackEnd(new Gui::Label(Lang::REMOVE_FROM_WHICH_MOUNT));
 
-	Equip::Slot slot = EquipType::types[m_equipType].slot;
+	Equip::Slot slot = Equip::types[m_equipType].slot;
 
 	for (int i=0; i<ShipType::GUNMOUNT_MAX; i++) {
 		if (m_doFit && (Pi::player->m_equipment.Get(slot, i) != Equip::NONE)) continue;

--- a/src/StationShipViewForm.cpp
+++ b/src/StationShipViewForm.cpp
@@ -68,7 +68,7 @@ StationShipViewForm::StationShipViewForm(FormController *controller, int marketI
 	dataBox->PackEnd(new Gui::Label(stringf(Lang::NUMBER_G, formatarg("acceleration", reverse_accel_empty))));
 	dataBox->PackEnd(new Gui::Label(stringf(Lang::NUMBER_G, formatarg("acceleration", reverse_accel_laden))));
 	dataBox->PackEnd(new Gui::Label(" "));
-	dataBox->PackEnd(new Gui::Label(EquipType::types[type.hyperdrive].name));
+	dataBox->PackEnd(new Gui::Label(Equip::types[type.hyperdrive].name));
 	statsBox->PackEnd(dataBox);
 
 
@@ -77,10 +77,10 @@ StationShipViewForm::StationShipViewForm(FormController *controller, int marketI
 
 	int row_size = 5, pos = 0;
 	for (int drivetype = Equip::DRIVE_CLASS1; drivetype <= Equip::DRIVE_CLASS9; drivetype++) {
-		if (type.capacity < EquipType::types[drivetype].mass)
+		if (type.capacity < Equip::types[drivetype].mass)
 			break;
 
-		int hyperclass = EquipType::types[drivetype].pval;
+		int hyperclass = Equip::types[drivetype].pval;
 		// for the sake of hyperspace range, we count ships mass as 60% of original.
 		float range = Pi::CalcHyperspaceRange(hyperclass, type.hullMass + type.capacity);
 
@@ -88,7 +88,7 @@ StationShipViewForm::StationShipViewForm(FormController *controller, int marketI
 		row->PackEnd(cell);
 
 		cell->PackEnd(new Gui::Label(stringf(Lang::CLASS_NUMBER, formatarg("class", hyperclass))));
-		if (type.capacity < EquipType::types[drivetype].mass)
+		if (type.capacity < Equip::types[drivetype].mass)
 			cell->PackEnd(new Gui::Label("---"));
 		else
 			cell->PackEnd(new Gui::Label(stringf(Lang::NUMBER_LY, formatarg("distance", range))));

--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -127,7 +127,7 @@ void SystemInfoView::UpdateEconomyTab()
 	data = std::string("#ff0")+std::string(Lang::MAJOR_IMPORTS)+std::string("\n");
 	for (int i=1; i<Equip::TYPE_MAX; i++) {
 		if (s->GetCommodityBasePriceModPercent(i) > 10)
-			crud.push_back(std::string("#fff")+EquipType::types[i].name);
+			crud.push_back(std::string("#fff")+Equip::types[i].name);
 	}
 	if (crud.size()) data += string_join(crud, "\n")+"\n";
 	else data += std::string("#777")+std::string(Lang::NONE)+std::string("\n");
@@ -137,7 +137,7 @@ void SystemInfoView::UpdateEconomyTab()
 	data = std::string("#ff0")+std::string(Lang::MINOR_IMPORTS)+std::string("\n");
 	for (int i=1; i<Equip::TYPE_MAX; i++) {
 		if ((s->GetCommodityBasePriceModPercent(i) > 2) && (s->GetCommodityBasePriceModPercent(i) <= 10))
-			crud.push_back(std::string("#777")+EquipType::types[i].name);
+			crud.push_back(std::string("#777")+Equip::types[i].name);
 	}
 	if (crud.size()) data += string_join(crud, "\n")+"\n";
 	else data += std::string("#777")+std::string(Lang::NONE)+std::string("\n");
@@ -147,7 +147,7 @@ void SystemInfoView::UpdateEconomyTab()
 	data = std::string("#ff0")+std::string(Lang::MAJOR_EXPORTS)+std::string("\n");
 	for (int i=1; i<Equip::TYPE_MAX; i++) {
 		if (s->GetCommodityBasePriceModPercent(i) < -10)
-			crud.push_back(std::string("#fff")+EquipType::types[i].name);
+			crud.push_back(std::string("#fff")+Equip::types[i].name);
 	}
 	if (crud.size()) data += string_join(crud, "\n")+"\n";
 	else data += std::string("#777")+std::string(Lang::NONE)+std::string("\n");
@@ -157,7 +157,7 @@ void SystemInfoView::UpdateEconomyTab()
 	data = std::string("#ff0")+std::string(Lang::MINOR_EXPORTS)+std::string("\n");
 	for (int i=1; i<Equip::TYPE_MAX; i++) {
 		if ((s->GetCommodityBasePriceModPercent(i) < -2) && (s->GetCommodityBasePriceModPercent(i) >= -10))
-			crud.push_back(std::string("#777")+EquipType::types[i].name);
+			crud.push_back(std::string("#777")+Equip::types[i].name);
 	}
 	if (crud.size()) data += string_join(crud, "\n")+"\n";
 	else data += std::string("#777")+std::string(Lang::NONE)+std::string("\n");
@@ -167,7 +167,7 @@ void SystemInfoView::UpdateEconomyTab()
 	data = std::string("#ff0")+std::string(Lang::ILLEGAL_GOODS)+std::string("\n");
 	for (int i=1; i<Equip::TYPE_MAX; i++) {
 		if (!Polit::IsCommodityLegal(s, Equip::Type(i)))
-			crud.push_back(std::string("#777")+EquipType::types[i].name);
+			crud.push_back(std::string("#777")+Equip::types[i].name);
 	}
 	if (crud.size()) data += string_join(crud, "\n")+"\n";
 	else data += std::string("#777")+std::string(Lang::NONE)+std::string("\n");

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -711,7 +711,7 @@ void WorldView::RefreshButtonStateAndVisibility()
 			if (s->m_equipment.Get(Equip::SLOT_ENGINE) == Equip::NONE) {
 				text += Lang::NO_HYPERDRIVE;
 			} else {
-				text += EquipType::types[s->m_equipment.Get(Equip::SLOT_ENGINE)].name;
+				text += Equip::types[s->m_equipment.Get(Equip::SLOT_ENGINE)].name;
 			}
 
 			text += "\n";


### PR DESCRIPTION
EquipType::types was marked deprecated. Equip::types is the canonical
name of that var.

Only one change, but it touches a lot of files so I'm submitting now to minimise merge pain later.
