### PR TITLE
Fix scan_enums.py to work with Python 3

### DIFF
--- a/scripts/scan_enums.py
+++ b/scripts/scan_enums.py
@@ -142,7 +142,7 @@ def lex(lines):
         # grab the next line if this one is blank
         if ln == '':
             try:
-                ln = lines.next().lstrip()
+                ln = next(lines).lstrip()
             except StopIteration:
                 break
 


### PR DESCRIPTION
Code was mostly version-agnostic anyway (it's very simple). This just replaces a use of the `next()` method with a use of the `next()` free function, which was added in Python 2.6 and works in Python 3.

This fix works for me (script runs with 2.6.5 and 3.1.2).
