### PR TITLE
fix mission status if target is destroyed with missile

### DIFF
--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -173,6 +173,9 @@ local onShipDestroyed = function (ship, body)
 		if mission.status == 'ACTIVE' and
 		   mission.ship == ship and
 		   mission.due < Game.time then
+			if body:isa("Missile") then
+				return
+			end
 			if not body:isa("Ship") or
 			   not body:IsPlayer() then
 				mission.status = 'FAILED'


### PR DESCRIPTION
This fix bug if target from Assassination missision was destroyed with Player's missile. Such mission would incorrectly be marked as Failed.
