### PR TITLE
Use shorter code path to explode missile on collision

### DIFF
--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -63,6 +63,14 @@ void Missile::TimeStepUpdate(const float timeStep)
 	m_distToTarget = dist;
 }
 
+bool Missile::OnCollision(Object *o, Uint32 flags, double relVel)
+{
+	if (!IsDead()) {
+		Explode();
+	}
+	return true;
+}
+
 bool Missile::OnDamage(Object *attacker, float kgDamage)
 {
 	if (!IsDead()) {

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -12,7 +12,8 @@ public:
 	Missile() {}
 	virtual ~Missile() {}
 	void TimeStepUpdate(const float timeStep);
-	bool OnDamage(Object *attacker, float kgDamage);
+	virtual bool OnCollision(Object *o, Uint32 flags, double relVel);
+	virtual bool OnDamage(Object *attacker, float kgDamage);
 	virtual void NotifyDeleted(const Body* const deletedBody);
 	virtual void PostLoadFixup();
 	void ECMAttack(int power_val);


### PR DESCRIPTION
This avoids going through the unneeded parent classes' OnCollision functions.
