### PR TITLE
Display correct (clamped) cost of repairing 1.0% damage

### DIFF
--- a/src/StationShipRepairForm.cpp
+++ b/src/StationShipRepairForm.cpp
@@ -86,8 +86,9 @@ void StationShipRepairForm::UpdateLabels()
 
 	else {
 		m_repairAllDesc->SetText(stringf(Lang::REPAIR_ENTIRE_HULL, formatarg("repairpercent", 100.0f - hullPercent)));
-		m_repairOneCost->SetText(format_money(GetRepairCost(1.0f)));
-		m_repairAllCost->SetText(format_money(GetRepairCost(100.f - hullPercent)));
+		const float hullDamage = 100.0f - hullPercent;
+		m_repairOneCost->SetText(format_money(GetRepairCost(std::min(hullDamage, 1.0f))));
+		m_repairAllCost->SetText(format_money(GetRepairCost(hullDamage)));
 
 		m_working->Hide();
 		m_tableBox->Show();


### PR DESCRIPTION
Closes #467.

Actual repair costs are clamped so that if you have damage < 100% you don't pay the full cost for a 100% repair, and if you have damage < 1%, you don't pay the full cost for 1% repair. That has been the case since #324.

This patch just makes the GUI for the repair screen display the correct clamped cost for 1% damage.
