### PR TITLE
Fix filter callback protection

### DIFF
--- a/src/LuaEquipType.cpp
+++ b/src/LuaEquipType.cpp
@@ -189,9 +189,16 @@ static int l_equiptype_get_equip_types(lua_State *l)
 				lua_pushvalue(l, 2);
 				lua_pushstring(l, name);
 				LuaEquipType::PushToLua(et);
-				// unprotected call because we want errors to propagate up to the next level
-				// (i.e., an error in the filter function should come out as an error from this function)
-				lua_call(l, 2, 1);
+				if (int ret = lua_pcall(l, 2, 1, 0)) {
+					const char *errmsg;
+					if (ret == LUA_ERRRUN)
+						errmsg = lua_tostring(l, -1);
+					else if (ret == LUA_ERRMEM)
+						errmsg = "memory allocation failure";
+					else if (ret == LUA_ERRERR)
+						errmsg = "error in error handler function";
+					luaL_error(l, "Error in filter function: %s", errmsg);
+				}
 				if (!lua_toboolean(l, -1)) {
 					lua_pop(l, 1);
 					continue;

--- a/src/LuaShipType.cpp
+++ b/src/LuaShipType.cpp
@@ -304,9 +304,16 @@ static int l_shiptype_get_ship_types(lua_State *l)
 			if (filter) {
 				lua_pushvalue(l, 2);
 				LuaShipType::PushToLua(st);
-				// unprotected call because we want errors to propagate up to the next level
-				// (i.e., an error in the filter function should come out as an error from this function)
-				lua_call(l, 1, 1);
+				if (int ret = lua_pcall(l, 1, 1, 0)) {
+					const char *errmsg;
+					if (ret == LUA_ERRRUN)
+						errmsg = lua_tostring(l, -1);
+					else if (ret == LUA_ERRMEM)
+						errmsg = "memory allocation failure";
+					else if (ret == LUA_ERRERR)
+						errmsg = "error in error handler function";
+					luaL_error(l, "Error in filter function: %s", errmsg);
+				}
 				if (!lua_toboolean(l, -1)) {
 					lua_pop(l, 1);
 					continue;

--- a/src/LuaSpace.cpp
+++ b/src/LuaSpace.cpp
@@ -464,9 +464,16 @@ static int l_space_get_bodies(lua_State *l)
 		if (filter) {
 			lua_pushvalue(l, 1);
 			LuaBody::PushToLua(b);
-			// unprotected call because we want errors to propagate up to the next level
-			// (i.e., an error in the filter function should come out as an error from this function)
-			lua_call(l, 1, 1);
+			if (int ret = lua_pcall(l, 1, 1, 0)) {
+				const char *errmsg;
+				if (ret == LUA_ERRRUN)
+					errmsg = lua_tostring(l, -1);
+				else if (ret == LUA_ERRMEM)
+					errmsg = "memory allocation failure";
+				else if (ret == LUA_ERRERR)
+					errmsg = "error in error handler function";
+				luaL_error(l, "Error in filter function: %s", errmsg);
+			}
 			if (!lua_toboolean(l, -1)) {
 				lua_pop(l, 1);
 				continue;


### PR DESCRIPTION
Fixes a bug noted on IRC by Brianetta:

```
<Brianetta> Error: [string "console"]:1: unable to resolve method or attribute 'name'
<Brianetta> stack traceback:
<Brianetta>  [C]: ?
<Brianetta>  [string "console"]:1: in function <[string "console"]:1>
<Brianetta>  [C]: in function 'GetBodies'
<Brianetta>  [string "console"]:1: in main chunk
<Brianetta> Lua error that isn't caught at console
<Brianetta> The error was within the filter function goven as an arg to GetBodies
```

Also fixes the documentation of Lua `EquipType.GetEquipTypes`.
