### PR TITLE
Fix state at game start (BreakdownServicing)

### DIFF
--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -163,16 +163,23 @@ local loaded_data
 local onGameStart = function ()
 	ads = {}
 
-	if not loaded_data then return end
+	if not loaded_data then
+		service_history = {
+			lastdate = 0, -- Default will be overwritten on game start
+			company = nil, -- Name of company that did the last service
+			service_period = oneyear, -- default
+			jumpcount = 0, -- Number of jumps made after the service_period
+		}
+	else
+		for k,ad in pairs(loaded_data.ads) do
+			local ref = ad.station:AddAdvert(ad.title, onChat, onDelete)
+			ads[ref] = ad
+		end
 
-	for k,ad in pairs(loaded_data.ads) do
-		local ref = ad.station:AddAdvert(ad.title, onChat, onDelete)
-		ads[ref] = ad
+		service_history = loaded_data.service_history
+
+		loaded_data = nil
 	end
-
-	service_history = loaded_data.service_history
-
-	loaded_data = nil
 end
 
 local onEnterSystem = function (ship)


### PR DESCRIPTION
If the game is started without quitting Pioneer after a previous game, the service history is not destroyed.  A player could get a free service this way.  Even better, they could stardream for a few hundred years, then get the drive serviced, and after starting a new game not have to have it serviced for a few hundred years.

This pull request fixes that. It can be reverted (for the ever so slight performance gain) after #773 is resolved.
