### PR TITLE
Fuel club

### DIFF
--- a/data/modules/FuelClub/FuelClub.lua
+++ b/data/modules/FuelClub/FuelClub.lua
@@ -158,8 +158,11 @@ onChat = function (form, ref, option)
 				milrads = 0,
 			}
 			Game.player:AddMoney(0 - ad.flavour.annual_fee)
-			onChat(form,ref,0)
-			return
+			setMessage(t("You are now a member. Your membership will expire on {expiry_date}."):interp({
+				expiry_date = Format.Date(memberships[ad.flavour.clubname].joined + memberships[ad.flavour.clubname].expiry)
+			}))
+			form:AddOption(t('Begin trade'),0)
+			form:AddOption(t('HANG_UP'),-1)
 		else
 			-- Membership application unsuccessful
 			setMessage(t('Your membership application has been declined.'))

--- a/data/modules/FuelClub/Languages.lua
+++ b/data/modules/FuelClub/Languages.lua
@@ -23,4 +23,5 @@ Translate:Add({English = {
 	["Your membership application has been declined."] = "Your membership application has been declined.",
 	["You are now a member. Your membership will expire on {expiry_date}."] = "You are now a member. Your membership will expire on {expiry_date}.",
 	["You must buy our {military_fuel} before we will take your {radioactives}"] = "You must buy our {military_fuel} before we will take your {radioactives}",
+	["Begin trade"] = "Begin trade",
 }})


### PR DESCRIPTION
This adds an "Interstellar Pilots' Fuel Cooperative" to the bulletin boards of approximately every third space station.

Initially, the advert will invite the player to become a member.  Membership costs $400 for one year.

Once a member the advert switches mode, and becomes a trader. The player can buy hydrogen at half price, and buy military fuel at 20% less than the going rate. In addition to this, selling radioactives is free - but only as many radioactives as the player has bought millitary fuel from this vendor.

It's not particularly easy for the starting player to get into this club, and probably not worth the cash, but membership starts to pay for itself with the high fuel requirements of larger ships, and it's certainly worth it for those ships fitted with military drives.

To do: Add checking code that penalises the player's chances of being allowed back into the club next year if all the player does is buy all the milfuel for sale on the open market. It's an abuse of club privileges!
