### PR TITLE
Scan enums

### DIFF
--- a/scripts/scan_enums.py
+++ b/scripts/scan_enums.py
@@ -154,7 +154,8 @@ def lex(lines):
         ln, toktype, toktext = match_pp_token(ln, lines)
         # preprocessor include directives are a little special
         # (the source path is a different token type that only matches in this context)
-        if toktype == 'punctuation' and toktext == '#':
+        # this if predicate also copes with null directives (C99 6.10.7)
+        if toktype == 'punctuation' and toktext == '#' and ln != '':
             yield toktype, toktext
             ln, toktype, toktext = match_pp_token(ln, lines)
             while toktype == 'comment':


### PR DESCRIPTION
Fix `scan_enums.py` so that it doesn't break when it hits a preprocessor null directive.

Problem was encountered in libs.h and a workaround commited earlier @6a83258a932dc49e7255b336338b963bef3c44c8.
