### PR TITLE
Fix wee bug with new drives acting like old ones after warranty expiry

### DIFF
--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -124,6 +124,7 @@ local onShipEquipmentChanged = function (ship, equipment)
 		service_history.company = nil
 		service_history.lastdate = Game.time
 		service_history.service_period = oneyear
+		service_history.jumpcount = oneyear
 	end
 end
 


### PR DESCRIPTION
A one-line fix. If a drive was really hammered, and broke, and the player bought a new one, that new one would fail as soon as its warranty expired because the jump count wasn't set back to zero.
