### PR TITLE
Character integration

### DIFF
--- a/data/modules/DeliverPackage/DeliverPackage.lua
+++ b/data/modules/DeliverPackage/DeliverPackage.lua
@@ -93,9 +93,14 @@ end
 
 local onDelete = function (ref)
 	-- Keep the ad's character for the future
-	ads[ref].Client:Save()
-	ads[ref].Client.lastSavedSystemPath = ads[ref].station.path
-	ads[ref].Client.title = "Persistent"
+	if ads[ref].Client.useCount > 0 or ads[ref].Client:TestRoll('notoriety',10) then
+		-- All characters that already existed, or approximately one in
+		-- five of newly created characters (with notoriety benefits, just
+		-- in case). Default notoriety is 15, +10 modifier makes 25. Chance
+		-- of successful testroll is about 19%-20%.
+		ads[ref].Client:Save()
+		ads[ref].Client.lastSavedSystemPath = ads[ref].station.path
+	end
 	ads[ref] = nil
 end
 


### PR DESCRIPTION
Deliver Packages now uses persistent characters, which will gradually be reused (preferring the less-used ones) and saving one in every five newly-created characters.  This causes a gradually increasing number of familiar faces on a bulletin board for a given station. People who are often on the look-out for somebody to take something somewhere.

Possibilities for the future:
- The player's reputation with a specific character is affected by their ability to get the jobs done, and could affect payment rates in the future.
- The person receiving the package shouldn't necessarily be the person who sent it (at the moment it always is). Temporary characters could be created to pick it up, or the mission could be rewritten so that the player must locate the recipient (amongst decoys) on the destination BBS and give it to the right person.
- A character might have a couple of packages to take to a couple of different places. They could appear in more than one bulletin board ad.

Possibilities for interaction:
- Any of these characters could be picked up as assassination targets in the future. Some of them might be the ones doing the asking.
- We could implement the old "Have you seen so-and-so on your travels?" mission from Frontier.
