### PR TITLE
Small change to enable rolling while controlling ship with mouse.

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -297,7 +297,11 @@ void Player::PollControls(const float timeStep)
 		for (int axis=0; axis<3; axis++)
 			wantAngVel[axis] = Clamp(wantAngVel[axis], -invTimeAccel, invTimeAccel);
 		
-		if (m_mouseActive) AIFaceDirection(m_mouseDir);
+		if (m_mouseActive) {
+			AIFaceDirection(m_mouseDir);
+			if (wantAngVel.z != 0.0)
+				SetAngThrusterState(2, wantAngVel.z);
+		} 
 		else AIModelCoordsMatchAngVel(wantAngVel, angThrustSoftness);
 	}
 }


### PR DESCRIPTION
Rotating the ship with a mouse is a nice feature but currently it has a minor annoyance - you lose the control of Z axis and can't roll the ship while flying with the right mouse button down. This little commit fixes that.

The ability to roll the ship doesn't usually matter in space but it may be necessary when flying low in atmosphere using the mouse or docking. It's a minor thing but I'm starting small with my contributions :)
