### PR TITLE
Fix issue #8 Deadzone support for joysticks

### DIFF
--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -26,6 +26,7 @@ GameConfig::GameConfig(const std::string &filename) : IniConfig(filename)
 	(*this)["SectorViewZRotation"] = "0";
 	(*this)["SectorViewZoom"] = "2.0";
 	(*this)["MaxPhysicsCyclesPerRender"] = "4";
+	(*this)["JoystickDeadzone"] = "0.1";
 
 #ifdef _WIN32
 	(*this)["RedirectStdio"] = "1";

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -20,6 +20,7 @@ Player::Player(ShipType::Type shipType): Ship(shipType)
 	m_setSpeedTarget = 0;
 	m_navTarget = 0;
 	m_combatTarget = 0;
+	m_JoystickDeadzone = Pi::config.Float("JoystickDeadzone");
 	UpdateMass();
 
 	m_accumTorque = vector3d(0,0,0);
@@ -295,7 +296,7 @@ void Player::PollControls(const float timeStep)
 		changeVec.z = KeyBindings::rollAxis.GetValue();
 
 		// Deadzone
-		float deadzoneSq = 0.1 * 0.1;
+		float deadzoneSq = m_JoystickDeadzone * m_JoystickDeadzone;
 		if(changeVec.LengthSqr() < deadzoneSq)
 			changeVec = vector3d(0.0);
 

--- a/src/Player.h
+++ b/src/Player.h
@@ -93,6 +93,7 @@ private:
 	Body* m_combatTarget;
 
 	int m_combatTargetIndex, m_navTargetIndex, m_setSpeedTargetIndex; // deserialisation
+	float m_JoystickDeadzone;
 };
 
 #endif /* _PLAYER_H */


### PR DESCRIPTION
Added a small deadzone to joystick input. Editable in the config.ini, but no UI for it. 10% set as the default.
