### PR TITLE
Allow jettisoning cargo while landed/docked

### DIFF
--- a/src/LuaEventQueue.cpp
+++ b/src/LuaEventQueue.cpp
@@ -509,6 +509,28 @@ void LuaEventQueueBase::Emit()
  *   experimental
  *
  *
+ * Event: onCargoUnload
+ *
+ * Triggered when the player unloads a cargo item while docked or landed.
+ *
+ * > local onUnload = function (body, cargoType) ... end
+ * > EventQueue.onCargoUnload:Connect(onUnload)
+ *
+ * Parameters:
+ *
+ *   body - the <Body> the <Player> was docked with (a <SpaceStation>) or landed on (a <Planet>)
+ *
+ *   cargoType - <EquipType> of the unloaded cargo
+ *
+ * Availability:
+ *
+ *   alpha 18
+ *
+ * Status:
+ *
+ *   experimental
+ *
+ *
  * Event: onAICompleted
  *
  * Triggered when a ship AI completes

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -97,6 +97,7 @@ LuaEventQueue<Ship,Body> *Pi::luaOnShipLanded;
 LuaEventQueue<Ship,Body> *Pi::luaOnShipTakeOff;
 LuaEventQueue<Ship,const char *> *Pi::luaOnShipAlertChanged;
 LuaEventQueue<Ship,CargoBody> *Pi::luaOnJettison;
+LuaEventQueue<Body,const char *> *Pi::luaOnCargoUnload;
 LuaEventQueue<Ship,const char *> *Pi::luaOnAICompleted;
 LuaEventQueue<SpaceStation> *Pi::luaOnCreateBB;
 LuaEventQueue<SpaceStation> *Pi::luaOnUpdateBB;
@@ -228,6 +229,7 @@ static void LuaInit()
 	Pi::luaOnShipTakeOff = new LuaEventQueue<Ship,Body>("onShipTakeOff");
 	Pi::luaOnShipAlertChanged = new LuaEventQueue<Ship,const char *>("onShipAlertChanged");
 	Pi::luaOnJettison = new LuaEventQueue<Ship,CargoBody>("onJettison");
+	Pi::luaOnCargoUnload = new LuaEventQueue<Body,const char*>("onCargoUnload");
 	Pi::luaOnAICompleted = new LuaEventQueue<Ship,const char *>("onAICompleted");
 	Pi::luaOnCreateBB = new LuaEventQueue<SpaceStation>("onCreateBB");
 	Pi::luaOnUpdateBB = new LuaEventQueue<SpaceStation>("onUpdateBB");
@@ -249,6 +251,7 @@ static void LuaInit()
 	Pi::luaOnShipUndocked->RegisterEventQueue();
 	Pi::luaOnShipAlertChanged->RegisterEventQueue();
 	Pi::luaOnJettison->RegisterEventQueue();
+	Pi::luaOnCargoUnload->RegisterEventQueue();
 	Pi::luaOnAICompleted->RegisterEventQueue();
 	Pi::luaOnCreateBB->RegisterEventQueue();
 	Pi::luaOnUpdateBB->RegisterEventQueue();
@@ -290,6 +293,7 @@ static void LuaUninit() {
 	delete Pi::luaOnShipTakeOff;
 	delete Pi::luaOnShipAlertChanged;
 	delete Pi::luaOnJettison;
+	delete Pi::luaOnCargoUnload;
 	delete Pi::luaOnAICompleted;
 	delete Pi::luaOnCreateBB;
 	delete Pi::luaOnUpdateBB;
@@ -316,6 +320,7 @@ static void LuaInitGame() {
 	Pi::luaOnShipTakeOff->ClearEvents();
 	Pi::luaOnShipAlertChanged->ClearEvents();
 	Pi::luaOnJettison->ClearEvents();
+	Pi::luaOnCargoUnload->ClearEvents();
 	Pi::luaOnAICompleted->ClearEvents();
 	Pi::luaOnCreateBB->ClearEvents();
 	Pi::luaOnUpdateBB->ClearEvents();

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -118,6 +118,7 @@ public:
 	static LuaEventQueue<Ship,Body> *luaOnShipTakeOff;
 	static LuaEventQueue<Ship,const char *> *luaOnShipAlertChanged;
 	static LuaEventQueue<Ship,CargoBody> *luaOnJettison;
+	static LuaEventQueue<Body,const char *> *luaOnCargoUnload;
 	static LuaEventQueue<Ship,const char *> *luaOnAICompleted;
 	static LuaEventQueue<SpaceStation> *luaOnCreateBB;
 	static LuaEventQueue<SpaceStation> *luaOnUpdateBB;

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -618,6 +618,7 @@ void Space::TimeStep(float step)
 		Pi::luaOnShipLanded->Emit();
 		Pi::luaOnShipTakeOff->Emit();
 		Pi::luaOnJettison->Emit();
+		Pi::luaOnCargoUnload->Emit();
 		Pi::luaOnAICompleted->Emit();
 		Pi::luaOnCreateBB->Emit();
 		Pi::luaOnUpdateBB->Emit();


### PR DESCRIPTION
This is rather quickly put together. It adds a new lua event for when cargo is dumped while landed or docked. This allows some mission script possibilities, more if combined with a custom cargo type. For example it would be possible to script a mining prototype with this: dump 1 ton of mining machinery, get a random amount of minerals back.

When unloading on a station, it would be possible to put the cargo to a temporary storage (serialized, but destroyed when leaving the system), but it would require a GUI to view and recover the cargo, so now the stuff is lost (confiscated!).
When unloading on a planet, the cargo is lost, since there are no facilities to move the containers.

``` lua
--testmodule.lua
local Dumpo = function (body, cargotype)
    if body.type == 'ROCKY_PLANET' then
        print("Dumped on a planet")
    elseif body.type == 'STARPORT' then
        print("Dumped on a starport")
    end
    local msg = body.label .. ": Don't dump your " .. cargotype .. " here!"
    print(msg)
    UI.Message(cargotype, body.label)
end

EventQueue.onCargoUnload:Connect(Dumpo)
```
