### PR TITLE
Fixed up a memory overwriting issue to do with the mouse input

### DIFF
--- a/src/LuaModelViewer.cpp
+++ b/src/LuaModelViewer.cpp
@@ -26,7 +26,7 @@ static SDL_Surface *g_screen;
 static int g_width, g_height;
 static int g_mouseMotion[2];
 static char g_keyState[SDLK_LAST];
-#define MAX_MOUSE_BTN_IDX 6
+static const int MAX_MOUSE_BTN_IDX = SDL_BUTTON_WHEELDOWN + 1;
 static int g_mouseButton[MAX_MOUSE_BTN_IDX];	// inc to 6 as mouseScroll is index 5
 static float g_zbias;
 static bool g_doBenchmark = false;


### PR DESCRIPTION
Fixed up a memory overwriting issue to do with the mouse input in modelviewer.

It's only a minor issue but when viewing models in windows I got a problem with the zbias being overwritten by the mouse input. Simply added an upper bound on the input range for mouse buttons.
