### PR TITLE
Display correct distance to approved landing pad

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1117,7 +1117,8 @@ void WorldView::UpdateProjectedObjects()
 			HideIndicator(m_velIndicator);
 
 		// navtarget distance/target square indicator (displayed with navtarget label)
-		double dist = Pi::player->GetPositionRelTo(navtarget).Length();
+		double dist = (navtarget->GetTargetIndicatorPosition(cam_frame) 
+			- Pi::player->GetPositionRelTo(cam_frame)).Length();
 		m_navTargetIndicator.label->SetText(format_distance(dist).c_str());
 		UpdateIndicator(m_navTargetIndicator, navtarget->GetTargetIndicatorPosition(cam_frame));
 


### PR DESCRIPTION
If you are approved for landing, the distance indicator to the pad will show the distance to the landing pad such that the distance is 0m when you are landed, not (presumably) the distance to the location of the whole station object.
