### PR TITLE
Quick fix for #255

### DIFF
--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -166,10 +166,12 @@ void GalacticView::Update()
 
 void GalacticView::MouseButtonDown(int button, int x, int y)
 {
-	const float ft = Pi::GetFrameTime();
-	if (Pi::MouseButtonState(SDL_BUTTON_WHEELDOWN)) 
-			m_zoom *= pow(0.25f, ft);
-	if (Pi::MouseButtonState(SDL_BUTTON_WHEELUP)) 
-			m_zoom *= pow(4.0f, ft);
+	if (this == Pi::GetView()) {
+		const float ft = Pi::GetFrameTime();
+		if (Pi::MouseButtonState(SDL_BUTTON_WHEELDOWN)) 
+				m_zoom *= pow(0.25f, ft);
+		if (Pi::MouseButtonState(SDL_BUTTON_WHEELUP)) 
+				m_zoom *= pow(4.0f, ft);
+	}
 }
 

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -870,11 +870,13 @@ void SectorView::ShowAll()
 
 void SectorView::MouseButtonDown(int button, int x, int y)
 {
-	const float ft = Pi::GetFrameTime();
-	if (Pi::MouseButtonState(SDL_BUTTON_WHEELDOWN)) 
-			m_zoomMovingTo += 10.0*ft;
-	if (Pi::MouseButtonState(SDL_BUTTON_WHEELUP)) 
-			m_zoomMovingTo -= 10.0*ft;
+	if (this == Pi::GetView()) {
+		const float ft = Pi::GetFrameTime();
+		if (Pi::MouseButtonState(SDL_BUTTON_WHEELDOWN)) 
+				m_zoomMovingTo += 10.0*ft;
+		if (Pi::MouseButtonState(SDL_BUTTON_WHEELUP)) 
+				m_zoomMovingTo -= 10.0*ft;
+	}
 }
 
 Sector* SectorView::GetCached(int sectorX, int sectorY, int sectorZ)

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -335,9 +335,11 @@ void SystemView::Update()
 
 void SystemView::MouseButtonDown(int button, int x, int y)
 {
-	const float ft = Pi::GetFrameTime();
-	if (Pi::MouseButtonState(SDL_BUTTON_WHEELDOWN)) 
-			m_zoom *= pow(0.25f, ft);
-	if (Pi::MouseButtonState(SDL_BUTTON_WHEELUP)) 
-			m_zoom *= pow(4.0f, ft);
+	if (this == Pi::GetView()) {
+		const float ft = Pi::GetFrameTime();
+		if (Pi::MouseButtonState(SDL_BUTTON_WHEELDOWN)) 
+				m_zoom *= pow(0.25f, ft);
+		if (Pi::MouseButtonState(SDL_BUTTON_WHEELUP)) 
+				m_zoom *= pow(4.0f, ft);
+	}
 }

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1602,7 +1602,7 @@ void WorldView::DrawEdgeMarker(const Indicator &marker)
 
 void WorldView::MouseButtonDown(int button, int x, int y)
 {
-	if (GetCamType() == CAM_EXTERNAL)
+	if (this == Pi::GetView() && GetCamType() == CAM_EXTERNAL)
 	{
 		const float ft = Pi::GetFrameTime();
 		if (Pi::MouseButtonState(SDL_BUTTON_WHEELDOWN))


### PR DESCRIPTION
Each View's onMouseButtonDown() checks whether it is the current view before doing scrolling effects.

In #255 @richardpl says this approach would make the code even uglier. I agree, but I intend this patch only as a stop-gap measure until the UI rewrite happens. I also believe that if the code will eventually be thrown out, it could afford to get a little uglier.
