### PR TITLE
Enable rolling while using mouse control.

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -299,8 +299,8 @@ void Player::PollControls(const float timeStep)
 		for (int axis=0; axis<3; axis++)
 			wantAngVel[axis] = Clamp(wantAngVel[axis], -invTimeAccelRate, invTimeAccelRate);
 		
+		AIModelCoordsMatchAngVel(wantAngVel, angThrustSoftness);
 		if (m_mouseActive) AIFaceDirection(m_mouseDir);
-		else AIModelCoordsMatchAngVel(wantAngVel, angThrustSoftness);
 	}
 }
 

--- a/src/Ship-AI.cpp
+++ b/src/Ship-AI.cpp
@@ -359,6 +359,7 @@ double Ship::AIFaceDirection(const vector3d &dir, double av)
 //	vector3d cav = GetAngVelocity() * rot;				// current obj-rel angvel
 	vector3d diff = (dav - cav) / frameAccel;					// find diff between current & desired angvel
 
+	diff.z = m_angThrusters.z;  // Leave roll unchanged
 	SetAngThrusterState(diff);
 	return ang;
 }


### PR DESCRIPTION
Fixes #278.

This addresses the same problem as #850, but properly stops accelerating at a certain angular velocity as in normal non-mouse angular control. 
