### PR TITLE
Issue 353

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -170,7 +170,7 @@ PKG_CHECK_MODULES([SDL], [sdl SDL_image])
 dnl Check for Freetype
 PKG_CHECK_MODULES([FREETYPE], [freetype2])
 
-dnl Not using vorbis yet
+dnl Check for libvorbis
 PKG_CHECK_MODULES([VORBIS], [vorbisfile])
 
 dnl Optionally use external liblua


### PR DESCRIPTION
For #353:
- Use pkg-config (`PKG_CHECK_MODULES`) to find SDL, SDL_image and freetype2.
- Remove `PIONEER_CHECK_CONFIG`, since it's no longer referenced.
