### PR TITLE
Draw starfield with interpolated transform

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -141,7 +141,7 @@ void Camera::Draw()
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	matrix4x4d trans2bg;
-	Frame::GetFrameTransform(Pi::game->GetSpace()->GetRootFrame(), m_camFrame, trans2bg);
+	Frame::GetFrameRenderTransform(Pi::game->GetSpace()->GetRootFrame(), m_camFrame, trans2bg);
 	trans2bg.ClearToRotOnly();
 	Pi::game->GetSpace()->GetBackground().Draw(trans2bg);
 


### PR DESCRIPTION
Previously Camera drew the background elements using the FrameTransform to the root frame. This caused the background to jitter when the player was in a rotating frame, e.g. around orbital stations or planets at high time acceleration. Camera now uses FrameRenderTransform, eliminating the jitter.
