### PR TITLE
Trade ships update

### DIFF
--- a/data/modules/TradeShips.lua
+++ b/data/modules/TradeShips.lua
@@ -571,7 +571,12 @@ local onShipDocked = function (ship, starport)
 
 	-- delay undocking by 30-45 seconds for every unit of cargo transfered
 	-- or 2-3 minutes for every unit of hull repaired
-	trader['delay'] = Game.time + (delay * Engine.rand:Number(30, 45))
+	if delay > 0 then
+		trader['delay'] = Game.time + (delay * Engine.rand:Number(30, 45))
+	else
+		trader['delay'] = Game.time + Engine.rand:Number(600, 3600)
+	end
+
 	if trader.status == 'docked' then
 		Timer:CallAt(trader.delay, function () doUndock(ship) end)
 	end


### PR DESCRIPTION
Switch to using the ship object ref instead of the ship's label as the key, which simplifies onShipDestroyed and OnGameStart. Also avoids technical possibility of two ships having the same label. This requires a save version bump. I can't think of a way to update old tables that doesn't greatly complicate everything.

Adds amounts to and uses the list of cargo to greatly reduce the number of loops in getSystem.

Adds comments that document how the tables that are global to the module are used.

Moves compiling the list of nearby systems, required to spawn ships in hyperspace, from once per ship to once per system.

Fixes:
#861

dead ship being given order to orbit
active ships being forgotten in systems without starports
ships without any cargo to transfer undocking immediately

Everything except the last two commits was tested, but against an out of date version of master. I'll try to get some testing in over the next couple of days, but would appreciate if others could help.
