### PR TITLE
Fix to #914

### DIFF
--- a/src/Ship-AI.cpp
+++ b/src/Ship-AI.cpp
@@ -9,6 +9,7 @@
 #include "SpaceStation.h"
 #include "Space.h"
 #include "LuaConstants.h"
+#include "KeyBindings.h"
 
 
 
@@ -359,7 +360,9 @@ double Ship::AIFaceDirection(const vector3d &dir, double av)
 //	vector3d cav = GetAngVelocity() * rot;				// current obj-rel angvel
 	vector3d diff = (dav - cav) / frameAccel;					// find diff between current & desired angvel
 
-	diff.z = m_angThrusters.z;  // Leave roll unchanged
+	// If the player is pressing a roll key, don't override roll.
+	if (this == (Ship *)Pi::player && (KeyBindings::rollLeft.IsActive() || KeyBindings::rollRight.IsActive()))
+		diff.z = m_angThrusters.z;
 	SetAngThrusterState(diff);
 	return ang;
 }


### PR DESCRIPTION
AIFaceDirection now leaves m_angThrusters.z unmodified if and only if the Ship belongs to the player and the player is holding down one of the roll keys.

This is for the sake of AICmdFlyTo and any other AI function that currently relies on AIFaceDirection to nullify roll (a reasonable assumption).
