### PR TITLE
Give planet a name if it has any population at all

### DIFF
--- a/src/StarSystem.cpp
+++ b/src/StarSystem.cpp
@@ -1874,7 +1874,7 @@ void SBody::PopulateStage1(StarSystem *system, fixed &outTotalPop)
 		}
 	}
 
-	if (!system->m_hasCustomBodies && m_population > fixed(1,10))
+	if (!system->m_hasCustomBodies && m_population > 0)
 		name = Pi::luaNameGen->BodyName(this, namerand);
 	
 	// Add a bunch of things people consume


### PR DESCRIPTION
Lafa a in Lafa [-24,-1,0,0] has a starport but does not get a name. This is a rare occurence, but possible because names are handed out to any planet with more than 10 million people. The population is used as a kind of probability when deciding if a starport should be created. Most of the time for a tiny population, one won't be generated but in rare cases such as this the numbers fall out and it gets one.

This trivial patch always names a planet if it has any population at all. Generally it will get a starport and so this won't change. It does make sure that Lafa a gets a name (Sosa Colony). It may occasionally name a planet that does not have a starport, but this doesn't seem like a terrible thing (and Frontier did it from time to time iirc).
