### PR TITLE
Render projectiles farther out so player can see them.

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -181,13 +181,13 @@ void Camera::Draw()
 
 		// draw spikes for far objects
 		double screenrad = 500 * rad / attrs->camDist;      // approximate pixel size
-		if (!attrs->body->IsType(Object::STAR) && screenrad < 2) {
-			if (!attrs->body->IsType(Object::PLANET)) continue;
+		if (attrs->body->IsType(Object::PLANET) && screenrad < 2) {
 			// absolute bullshit
 			double spikerad = (7 + 1.5*log10(screenrad)) * rad / screenrad;
 			DrawSpike(spikerad, attrs->viewCoords, attrs->viewTransform);
 		}
-		else
+		else if (screenrad >= 2 || attrs->body->IsType(Object::STAR) ||
+					(attrs->body->IsType(Object::PROJECTILE) && screenrad > 0.25))
 			attrs->body->Render(attrs->viewCoords, attrs->viewTransform);
 	}
 


### PR DESCRIPTION
Projectiles currently have a range of 8km but were only being rendered out to 2.5km from the camera. This made it rather difficult to see where they were going.

This change renders them out to 20km from the camera.
