### PR TITLE
fixes vc2010 warning in Projectile.cpp

### DIFF
--- a/src/LuaModelViewer.cpp
+++ b/src/LuaModelViewer.cpp
@@ -483,7 +483,7 @@ static void raytraceCollMesh(vector3d camPos, vector3d camera_up, vector3d camer
 			toPoint = (topLeft + (xMov * xpos) + (yMov * ypos)).Normalized();
 			
 			CollisionContact c;
-			space->TraceRay(camPos, toPoint, 1000000.0f, &c);
+			space->TraceRay(camPos, toPoint, 1000000.0, &c);
 
 			if (c.triIdx != -1) {
 				wank[x][y] = 100.0/(10*c.dist);

--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -256,7 +256,7 @@ void CollisionSpace::CollideRaySphere(const vector3d &start, const vector3d &dir
 	}
 }
 
-void CollisionSpace::TraceRay(const vector3d &start, const vector3d &dir, float len, CollisionContact *c, Geom *ignore)
+void CollisionSpace::TraceRay(const vector3d &start, const vector3d &dir, double len, CollisionContact *c, Geom *ignore)
 {
 	vector3d invDir(1.0/dir.x, 1.0/dir.y, 1.0/dir.z);
 	c->dist = len;

--- a/src/collider/CollisionSpace.h
+++ b/src/collider/CollisionSpace.h
@@ -27,7 +27,7 @@ public:
 	void RemoveGeom(Geom*);
 	void AddStaticGeom(Geom*);
 	void RemoveStaticGeom(Geom*);
-	void TraceRay(const vector3d &start, const vector3d &dir, float len, CollisionContact *c, Geom *ignore = 0);
+	void TraceRay(const vector3d &start, const vector3d &dir, double len, CollisionContact *c, Geom *ignore = 0);
 	void Collide(void (*callback)(CollisionContact*));
 	void SetSphere(const vector3d &pos, double radius, void *user_data) {
 		sphere.pos = pos; sphere.radius = radius; sphere.userData = user_data;


### PR DESCRIPTION
It makes more sense to me that if it expects double vectors it should expect a double length.

I'm not sure if the `c->depth = len - isect.dist;` should be done as float or double, but depth is a double.
