### PR TITLE
fix to be about 10km, not 10m

### DIFF
--- a/src/StarSystem.cpp
+++ b/src/StarSystem.cpp
@@ -1600,7 +1600,7 @@ void SBody::PickPlanetType(StarSystem *system, MTRand &rand)
 	else
 		radius = fixed::CubeRootOf(mass);
 	// enforce minimum size of 10km
-	radius = std::max(radius, fixed(1,630000));
+	radius = std::max(radius, fixed(1,630));
 
 	m_metallicity = system->m_metallicity * rand.Fixed();
 	// harder to be volcanic when you are tiny (you cool down)


### PR DESCRIPTION
Matches the comment which seems to have been the intent.

The radius of moon i2 in #929 is 10m so that is clearly too small.
