### PR TITLE
Return to menu if load is cancelled

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1120,6 +1120,11 @@ void Pi::HandleMenuKey(int n)
 			GameLoader loader;
 			loader.DialogMainLoop();
 			game = loader.GetGame();
+			if (! game) {
+				// loading screen was cancelled;
+				// return without setting menuDone so the menu is re-displayed
+				return;
+			}
 			break;
 		}
 


### PR DESCRIPTION
Fixes #920. Implemented as suggested by @Ziusudra.

I don't like the main menu loop: having to pass the core menu state through a side-channel -- the `menuDone` variable -- isn't very nice. But this should fix the problem anyway.
