### PR TITLE
Don't unpause game when a message is displayed.

### DIFF
--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -62,8 +62,11 @@ void MsgLogWidget::ShowNext()
 	} else {
 		// current message expired and more in queue
 		Pi::BoinkNoise();
-		Pi::game->RequestTimeAccel(Game::TIMEACCEL_1X);
-		Pi::game->SetTimeAccel(Game::TIMEACCEL_1X);
+		// cancel time acceleration (but don't unpause)
+		if (Pi::game->GetTimeAccel() != Game::TIMEACCEL_PAUSED) {
+			Pi::game->RequestTimeAccel(Game::TIMEACCEL_1X);
+			Pi::game->SetTimeAccel(Game::TIMEACCEL_1X);
+		}
 		message_t msg("","",NONE);
 		// use MUST_SEE messages first
 		for (std::list<message_t>::iterator i = m_msgQueue.begin();


### PR DESCRIPTION
Discussion of desired behaviour from IRC:

```
<jpab1> what is the desired behaviour for queued messages and message timeouts in the presence of time acceleration?
<kko__> Message timeouts should ignore time acceleration
<_robn> jpab1: timeout should be realtime. I don't know if there's a case where they should force the timeaccel down as they do now
<jpab1> "realtime" meaning?
...
<_robn> OS clock
<_robn> Five seconds for the human player
<jpab1> ok
<jpab1> and if the player pauses while a message is on screen?
<Brianetta> Frontier's UI timeouts were not affected by stardreamer or pause
<Brianetta> luckily
<Brianetta> since they hid the scanner
<_robn> For simplicity I would keep it the same. 5s timeout
<jpab1> ok, so the only change to make is that if the game is paused when a message is displayed, it will remain paused
<Brianetta> unless unpaused in the meantime
<_robn> Yeah I think that's it
```
