### PR TITLE
Restore states after ship spinner widget render

### DIFF
--- a/src/ShipSpinnerWidget.cpp
+++ b/src/ShipSpinnerWidget.cpp
@@ -57,14 +57,19 @@ void ShipSpinnerWidget::Draw()
 		glVertex2f(m_width, 0.0f);
 	glEnd();
 
+	glMatrixMode(GL_PROJECTION);
+	glPushMatrix();
+	glMatrixMode(GL_MODELVIEW);
+	glPushMatrix();
+
 	Pi::renderer->SetPerspectiveProjection(45.f, 1.f, 1.f, 10000.f);
-	glDepthRange (0.0, 1.0); //XXX this is the default so perhaps not necessary
 	Pi::renderer->SetTransform(matrix4x4f::Identity());
+
+	glPushAttrib(GL_ALL_ATTRIB_BITS);
+	glDepthRange (0.0, 1.0); //XXX this is the default so perhaps not necessary
 
 	Pi::renderer->SetDepthTest(true);
 	Pi::renderer->ClearDepthBuffer();
-
-	glPushAttrib(GL_ALL_ATTRIB_BITS);
 
 	Pi::renderer->SetLights(1, &m_light);
 	Pi::renderer->SetViewport(
@@ -81,5 +86,8 @@ void ShipSpinnerWidget::Draw()
 
 	glPopAttrib();
 
-	Pi::renderer->SetDepthTest(false);
+	glMatrixMode(GL_PROJECTION);
+	glPopMatrix();
+	glMatrixMode(GL_MODELVIEW);
+	glPopMatrix();
 }


### PR DESCRIPTION
...so text won't break
