### PR TITLE
Renderer state capture

### DIFF
--- a/src/ShipSpinnerWidget.cpp
+++ b/src/ShipSpinnerWidget.cpp
@@ -57,16 +57,10 @@ void ShipSpinnerWidget::Draw()
 		glVertex2f(m_width, 0.0f);
 	glEnd();
 
-	glMatrixMode(GL_PROJECTION);
-	glPushMatrix();
-	glMatrixMode(GL_MODELVIEW);
-	glPushMatrix();
+	ScopedPtr<Graphics::Renderer::State> state(Pi::renderer->CaptureState());
 
 	Pi::renderer->SetPerspectiveProjection(45.f, 1.f, 1.f, 10000.f);
 	Pi::renderer->SetTransform(matrix4x4f::Identity());
-
-	glPushAttrib(GL_ALL_ATTRIB_BITS);
-	glDepthRange (0.0, 1.0); //XXX this is the default so perhaps not necessary
 
 	Pi::renderer->SetDepthTest(true);
 	Pi::renderer->ClearDepthBuffer();
@@ -83,11 +77,4 @@ void ShipSpinnerWidget::Draw()
 	rot[14] = -1.5f * m_model->GetDrawClipRadius();
 
 	m_model->Render(rot, &m_params);
-
-	glPopAttrib();
-
-	glMatrixMode(GL_PROJECTION);
-	glPopMatrix();
-	glMatrixMode(GL_MODELVIEW);
-	glPopMatrix();
 }

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -122,9 +122,31 @@ public:
 	//complex unchanging geometry that is worthwhile to store in VBOs etc.
 	virtual bool DrawStaticMesh(StaticMesh *thing) { return false; }
 
+	// class representing the current state of the renderer. call CaptureState
+	// to obtain one. when it goes out of scope the destructor is called and
+	// will restore the renderer to its previous state
+	class State {
+	public:
+		virtual ~State() { m_renderer->PopState(); }
+	private:
+		State(const State&);
+		State &operator=(const State&);
+
+		friend class Renderer;
+		State(Renderer *r) : m_renderer(r) { m_renderer->PushState(); }
+
+		Renderer *m_renderer;
+	};
+
+	State *CaptureState() { return new State(this); }
+	
+
 protected:
 	int m_width;
 	int m_height;
+
+	virtual void PushState() = 0;
+	virtual void PopState() = 0;
 };
 
 // subclass this to store renderer specific information

--- a/src/graphics/RendererGL2.cpp
+++ b/src/graphics/RendererGL2.cpp
@@ -51,7 +51,7 @@ bool RendererGL2::SetPerspectiveProjection(float fov, float aspect, float near, 
 	glFrustum(xmin, xmax, ymin, ymax, near, far);
 
 	// update values for log-z hack
-	State::SetZnearZfar(near, far);
+	Graphics::State::SetZnearZfar(near, far);
 	return true;
 }
 

--- a/src/graphics/RendererLegacy.cpp
+++ b/src/graphics/RendererLegacy.cpp
@@ -227,7 +227,7 @@ bool RendererLegacy::SetLights(int numlights, const Light *lights)
 	}
 	//XXX should probably disable unused lights (for legacy renderer only)
 
-	State::SetNumLights(numlights);
+	Graphics::State::SetNumLights(numlights);
 
 	return true;
 }
@@ -603,6 +603,24 @@ bool RendererLegacy::BufferStaticMesh(StaticMesh *mesh)
 	mesh->cached = true;
 
 	return true;
+}
+
+void RendererLegacy::PushState()
+{
+	glMatrixMode(GL_PROJECTION);
+	glPushMatrix();
+	glMatrixMode(GL_MODELVIEW);
+	glPushMatrix();
+	glPushAttrib(GL_ALL_ATTRIB_BITS);
+}
+
+void RendererLegacy::PopState()
+{
+	glPopAttrib();
+	glMatrixMode(GL_PROJECTION);
+	glPopMatrix();
+	glMatrixMode(GL_MODELVIEW);
+	glPopMatrix();
 }
 
 }

--- a/src/graphics/RendererLegacy.h
+++ b/src/graphics/RendererLegacy.h
@@ -49,6 +49,9 @@ public:
 	virtual bool DrawStaticMesh(StaticMesh *thing);
 
 protected:
+	virtual void PushState();
+	virtual void PopState();
+
 	virtual void ApplyMaterial(const Material *mat);
 	virtual void UnApplyMaterial(const Material *mat);
 	//figure out states from a vertex array and enable them


### PR DESCRIPTION
Based on an idea in IRC today. Not for merge (yet). For use in cases where the current renderer state must be saved and restored (eg #1001).

Very simple. Each renderer provides a `PushState()` and `PopState()` that will somehow save and restore renderer state. For OpenGL its the normal matrix/attribute push/pop; for something else the renderer might have to carry its own stack. Whatever.

Client that needs to preserve state calls `renderer->CaptureState()`. It gets back an object representing the current state of the stack. When that object is destroyed, the state is restored. Constructing the object this way allows the following pattern:

```
{
    ScopedPtr<Graphics::Renderer::State> state(renderer->CaptureState());

    renderer->SetViewport(...)
    renderer->SetTransform(...)
    renderer->DrawFoo(...)
}
```

When `state` goes out of scope, `ScopedPtr` deletes it and the state is restored.

The possible problem/quirk I see with this is that `State` does not really represent a renderer "state", but is really just a handle on a push/pop pair. Its not possible to "restore" the state, only pull it back from the stack. If two of these objects are retrieved and deleted out of order, state will not be restored to that of the last one. If there was a practical way to retrieve the entire GL state then this could be coded around (with something slightly different to `PushState()` and `PopState()` - probably `GetState()` and `SetState()`).

Really, this is probably just a problem of naming. I don't think that capturing the state and _not_ restoring it shortly after is something you'd want to do. I can't find a good name for the class that conveys the semantics in one or two words.

I'm not entirely sure what to do about clients leaking and/or storing a pointer to these returned state objects. But, to quote @johnbartholomew, "as long as the easiest way to use the thing is the right way then you've got a good start". Given we're the ones using this, and saving state for all renderers becomes as simple as copying that single `ScopedPtr...` line above, you've really got to go out of your way to screw things up.

Feedback please. Should I continue with this?
