### PR TITLE
Flight recorder

### DIFF
--- a/data/libs/FlightLog.lua
+++ b/data/libs/FlightLog.lua
@@ -38,14 +38,14 @@ FlightLog = {
 --   iterator - A function which will generate the paths from the log, returning
 --              one each time it is called until it runs out, after which it
 --              returns nil. It also returns, as secondary and tertiary values,
---              the game times at shich the system was entered left.
+--              the game times at shich the system was entered and left.
 --
 -- Example:
 --
 -- Print the names and departure times of the last five systems visited by
 -- the player
 --
--- > for systemp,deptime in FlightLog.GetSystemPaths(5) do
+-- > for systemp,arrtime,deptime in FlightLog.GetSystemPaths(5) do
 -- >   print(systemp:GetStarSystem().name, Format.Date(deptime))
 -- > end
 
@@ -61,7 +61,7 @@ FlightLog = {
 				    	   FlightLogSystem[counter][3]
 				end
 			end
-			return nil, nil
+			return nil, nil, nil
 		end
 	end,
 


### PR DESCRIPTION
Records a list of the last 1,000 systems and (separately) the last 1,000 stations the player has visited. Data are private, and can only be reached using the provided methods. There are currently four methods:
1. A method to get the most recent station's SystemPath
2. A method to get the most recent system's SystemPath
3. A method which returns an iterator, allowing a script to loop across previous systems by SystemPath and date
4. A method which returns an iterator, allowing a script to loop across previous stations by SystemPath and date

CodeDoc is included.
