### PR TITLE
Correctly serialize multiple references to the same Lua table

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -18,7 +18,7 @@
 #include "ObjectViewerView.h"
 #include "graphics/Renderer.h"
 
-static const int  s_saveVersion   = 46;
+static const int  s_saveVersion   = 47;
 static const char s_saveStart[]   = "PIONEER";
 static const char s_saveEnd[]     = "END";
 


### PR DESCRIPTION
Passes the test in #1022. Nested tables are also supported, that is:

``` lua
local t = {}
t.t = t
```

and

``` lua
local t = {}
t[t] = t
```

will be restored correctly.

This will also work cross-module, since the serializer collects all module data into a single ordinary table before writing it out.

This has had very limited testing. @Brianetta, please confirm that it does what you want for your character branch. Everyone else, please confirm that when you save things, they come back in one piece :)
