### PR TITLE
Fuel mass fix

### DIFF
--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -29,7 +29,7 @@ public:
 	bool IsEnabled() const { return m_enabled; }
 	virtual void Disable();
 	virtual void Enable();
-	virtual double GetMass() const { return m_mass; }
+	virtual double GetMass() const { return m_mass; }	// XXX don't override this
 	virtual void TimeStepUpdate(const float timeStep);
 	void CalcExternalForce();
 	void ApplyAccel(const float timeStep);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -222,7 +222,7 @@ void Ship::SetPercentHull(float p)
 void Ship::UpdateMass()
 {
 	CalcStats();
-	SetMass(m_stats.total_mass*1000);
+	SetMass((m_stats.total_mass + GetFuel()*GetShipType().fuelTankMass)*1000);
 }
 
 bool Ship::OnDamage(Object *attacker, float kgDamage)
@@ -699,6 +699,9 @@ void Ship::TimeStepUpdate(const float timeStep)
 	AddRelTorque(GetShipType().angThrust * m_angThrusters);
 
 	DynamicBody::TimeStepUpdate(timeStep);
+
+	// fuel use decreases mass, so do this as the last thing in the frame
+	UpdateFuel(timeStep);
 }
 
 void Ship::FireWeapon(int num)
@@ -853,6 +856,8 @@ void Ship::UpdateFuel(const float timeStep)
 	SetFuel(GetFuel() - timeStep * (totalThrust * fuelUseRate));
 	FuelState currentState = GetFuelState();
 
+	UpdateMass();
+
 	if (currentState != lastState)
 		Pi::luaOnShipFuelChanged->Queue(this, LuaConstants::GetConstantString(Pi::luaManager->GetLuaState(), "ShipFuelStatus", currentState));
 }
@@ -864,8 +869,6 @@ void Ship::StaticUpdate(const float timeStep)
 	if (GetHullTemperature() > 1.0) {
 		Pi::game->GetSpace()->KillBody(this);
 	}
-
-	UpdateFuel(timeStep);
 
 	UpdateAlertState();
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -80,9 +80,6 @@ public:
 	bool Undock();
 	virtual void TimeStepUpdate(const float timeStep);
 	virtual void StaticUpdate(const float timeStep);
-	virtual double GetMass() const {
-		return DynamicBody::GetMass() + GetFuel() * (GetShipType().fuelTankMass * 1000);
-	}
 
 	virtual void NotifyRemoved(const Body* const removedBody);
 	virtual bool OnCollision(Object *o, Uint32 flags, double relVel);


### PR DESCRIPTION
As discussed today:
- Set mass directly after fuel change so physics and AI have a consistent idea of the ship's mass
- Do fuel/mass updates at the end of the timestep so its not changing half way through

Fixes #1043.
