### PR TITLE
consistent ordering of Sol system moons in SystemInfoView

### DIFF
--- a/data/systems/00_sol.lua
+++ b/data/systems/00_sol.lua
@@ -263,6 +263,23 @@ local saturn = CustomSBody:new('Saturn', 'PLANET_GAS_GIANT')
 	:axial_tilt(math.fixed.deg2rad(f(2673,100)))
 
 local saturn_moons = {
+	CustomSBody:new('Dione', 'PLANET_TERRESTRIAL')
+		:radius(f(881,10000))
+		:mass(f(328,1000000))
+		:temp(87)
+		:semi_major_axis(f(252,100000))
+		:eccentricity(f(22,10000))
+		:inclination(math.deg2rad(0.019))
+		:rotation_period(f(2737,1000)),
+	CustomSBody:new('Rhea', 'PLANET_TERRESTRIAL')
+		:radius(f(12,100))
+		:mass(f(39,10000))
+		:temp(81)
+		:semi_major_axis(f(441,100000))
+		:eccentricity(f(126,100000))
+		:inclination(math.deg2rad(0.345))
+		:rotation_period(f(452,100))
+		:atmos_density(f(1,10)),
 	CustomSBody:new('Titan', 'PLANET_TERRESTRIAL')
 		:seed(7)
 		:radius(f(400,1000))
@@ -286,15 +303,6 @@ local saturn_moons = {
 			:eccentricity(f(50,1000))
 			:rotation_period(f(11,9)),
 	},
-	CustomSBody:new('Rhea', 'PLANET_TERRESTRIAL')
-		:radius(f(12,100))
-		:mass(f(39,10000))
-		:temp(81)
-		:semi_major_axis(f(441,100000))
-		:eccentricity(f(126,100000))
-		:inclination(math.deg2rad(0.345))
-		:rotation_period(f(452,100))
-		:atmos_density(f(1,10)),
 	CustomSBody:new('Iapetus', 'PLANET_TERRESTRIAL')
 		:radius(f(1155,10000))
 		:mass(f(3,10000))
@@ -303,14 +311,6 @@ local saturn_moons = {
 		:eccentricity(f(29,1000))
 		:inclination(math.deg2rad(15.47))
 		:rotation_period(f(7932,100)),
-	CustomSBody:new('Dione', 'PLANET_TERRESTRIAL')
-		:radius(f(881,10000))
-		:mass(f(328,1000000))
-		:temp(87)
-		:semi_major_axis(f(252,100000))
-		:eccentricity(f(22,10000))
-		:inclination(math.deg2rad(0.019))
-		:rotation_period(f(2737,1000)),
 }
 
 local uranus = CustomSBody:new('Uranus', 'PLANET_GAS_GIANT')
@@ -325,6 +325,22 @@ local uranus = CustomSBody:new('Uranus', 'PLANET_GAS_GIANT')
 	:axial_tilt(math.fixed.deg2rad(f(9777,100)))
 
 local uranus_moons = {
+	CustomSBody:new('Ariel', 'PLANET_TERRESTRIAL')
+		:radius(f(908,10000))
+		:mass(f(226,1000000))
+		:temp(60)
+		:semi_major_axis(f(1277,1000000))
+		:eccentricity(f(12,10000))
+		:inclination(math.deg2rad(0.26))
+		:rotation_period(f(252,100)),
+	CustomSBody:new('Umbriel', 'PLANET_TERRESTRIAL')
+		:radius(f(92,1000))
+		:mass(f(2,10000))
+		:temp(75)
+		:semi_major_axis(f(178,100000))
+		:eccentricity(f(39,10000))
+		:inclination(math.deg2rad(0.128))
+		:rotation_period(f(4144,1000)),
 	CustomSBody:new('Titania', 'PLANET_TERRESTRIAL')
 		:radius(f(1235,10000))
 		:mass(f(5908,10000000))
@@ -342,22 +358,6 @@ local uranus_moons = {
 		:eccentricity(f(14,10000))
 		:inclination(math.deg2rad(0.058))
 		:rotation_period(f(135,10)),
-	CustomSBody:new('Umbriel', 'PLANET_TERRESTRIAL')
-		:radius(f(92,1000))
-		:mass(f(2,10000))
-		:temp(75)
-		:semi_major_axis(f(178,100000))
-		:eccentricity(f(39,10000))
-		:inclination(math.deg2rad(0.128))
-		:rotation_period(f(4144,1000)),
-	CustomSBody:new('Ariel', 'PLANET_TERRESTRIAL')
-		:radius(f(908,10000))
-		:mass(f(226,1000000))
-		:temp(60)
-		:semi_major_axis(f(1277,1000000))
-		:eccentricity(f(12,10000))
-		:inclination(math.deg2rad(0.26))
-		:rotation_period(f(252,100)),
 }
 
 local neptune = CustomSBody:new('Neptune', 'PLANET_GAS_GIANT')
@@ -372,6 +372,14 @@ local neptune = CustomSBody:new('Neptune', 'PLANET_GAS_GIANT')
 	:axial_tilt(math.fixed.deg2rad(f(2832,100)))
 
 local neptune_moons = {
+	CustomSBody:new('Proteus', 'PLANET_ASTEROID')
+		:radius(f(310,10000))
+		:mass(f(710,1000))
+		:temp(51)
+		:semi_major_axis(f(786,1000000))
+		:eccentricity(f(53,100000))
+		:inclination(math.deg2rad(0.524))
+		:rotation_period(f(1122,1000)),
 	CustomSBody:new('Triton', 'PLANET_TERRESTRIAL')
 		:radius(f(2122,10000))
 		:mass(f(359,100000))
@@ -396,14 +404,6 @@ local neptune_moons = {
 		:eccentricity(f(75,100))
 		:inclination(math.deg2rad(32.55))
 		:rotation_period(f(115,240)),
-	CustomSBody:new('Proteus', 'PLANET_ASTEROID')
-		:radius(f(310,10000))
-		:mass(f(710,1000))
-		:temp(51)
-		:semi_major_axis(f(786,1000000))
-		:eccentricity(f(53,100000))
-		:inclination(math.deg2rad(0.524))
-		:rotation_period(f(1122,1000)),
 }
 
 local pluto = CustomSBody:new('Pluto', 'PLANET_TERRESTRIAL')


### PR DESCRIPTION
SystemInfoView displays bodies in the order they were created. For all systems except Sol, bodies are created in increasing orbital distance.

This just changes the order in which the moons of Saturn, Uranus, and Neptune are created to match that. (All other bodies in Sol were already in the correct order, as were the bodies in all the other custom systems.)
