### PR TITLE
no StaticUpdate needed for dead ships

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -864,6 +864,8 @@ void Ship::UpdateFuel(const float timeStep)
 
 void Ship::StaticUpdate(const float timeStep)
 {
+	if (IsDead()) return;
+
 	AITimeStep(timeStep);		// moved to correct place, maybe
 
 	if (GetHullTemperature() > 1.0) {


### PR DESCRIPTION
If they player was firing weapons when their ship was destroyed, the weapon would continue to fire.

Neither that nor anything else in StaticUpdate needs to or even should happen if the ship is dead.
