### PR TITLE
Trade ships fuel and landing updates

### DIFF
--- a/data/modules/TradeShips.lua
+++ b/data/modules/TradeShips.lua
@@ -62,7 +62,6 @@ local addFuel = function (ship)
 	count = count - ship:GetEquipCount('CARGO', 'HYDROGEN')
 
 	local added = ship:AddEquip('HYDROGEN', count)
-	ship:SetFuelPercent()
 
 	return added
 end


### PR DESCRIPTION
Ships now top off their thruster fuel tanks.

Now handles ships that manage to land instead of dock. AIOrbit is used as there is no ship:TakeOff.
