### PR TITLE
Fix musicplayer after filesystem changes

### DIFF
--- a/data/modules/MusicPlayer.lua
+++ b/data/modules/MusicPlayer.lua
@@ -2,7 +2,7 @@ local music = {}
 
 local getCategoryForSong = function (name)
 	if not name then return "" end
-	local _, _, category = string.find(name, "^core/([%l-]+)/")
+	local _, _, category = string.find(name, "^music/core/([%l-]+)/")
 	return category
 end
 


### PR DESCRIPTION
File paths are now reported as music/core/category/songname instead of core/category/songname. I'm fine with this, so let's just fix the player script.
