### PR TITLE
Remove techlevels

### DIFF
--- a/src/EquipType.cpp
+++ b/src/EquipType.cpp
@@ -5,319 +5,319 @@
 const EquipType Equip::types[Equip::TYPE_MAX] = {
 	{ Lang::NONE, 0,
 	  Equip::SLOT_CARGO, -1, {},
-	  0, 0, 0, 0, 0, 0
+	  0, 0, 0, 0, true, 0
 	},{
 	  Lang::HYDROGEN, Lang::HYDROGEN_DESCRIPTION,
 	  Equip::SLOT_CARGO, -1, {},
-	  100, 1, 0, ECON_MINING, 0, 0
+	  100, 1, 0, ECON_MINING, true, 0
 	},{
 	  Lang::LIQUID_OXYGEN, Lang::LIQUID_OXYGEN_DESCRIPTION,
 	  Equip::SLOT_CARGO, -1, { Equip::WATER, Equip::INDUSTRIAL_MACHINERY },
-	  150, 1, 0, ECON_MINING, 0, 0
+	  150, 1, 0, ECON_MINING, true, 0
 	},{
 	  Lang::METAL_ORE, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::MINING_MACHINERY },
-	  300, 1, 0, ECON_MINING, 0, 0
+	  300, 1, 0, ECON_MINING, true, 0
 	},{
 	  Lang::CARBON_ORE, Lang::CARBON_ORE_DESCRIPTION,
 	  Equip::SLOT_CARGO, -1, { Equip::MINING_MACHINERY },
-	  500, 1, 0, ECON_MINING, 0, 0
+	  500, 1, 0, ECON_MINING, true, 0
 	},{
 	  Lang::METAL_ALLOYS, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::METAL_ORE, Equip::INDUSTRIAL_MACHINERY },
-	  800, 1, 0, ECON_INDUSTRY, 1, 0
+	  800, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::PLASTICS, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::CARBON_ORE, Equip::INDUSTRIAL_MACHINERY },
-	  1200, 1, 0, ECON_INDUSTRY, 2, 0
+	  1200, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::FRUIT_AND_VEG, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::FARM_MACHINERY, Equip::FERTILIZER },
-	  1200, 1, 0, ECON_AGRICULTURE, 1, 0
+	  1200, 1, 0, ECON_AGRICULTURE, true, 0
 	},{
 	  Lang::ANIMAL_MEAT, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::FARM_MACHINERY, Equip::FERTILIZER },
-	  1800, 1, 0, ECON_AGRICULTURE, 1, 0
+	  1800, 1, 0, ECON_AGRICULTURE, true, 0
 	},{
 	  Lang::LIVE_ANIMALS, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::FARM_MACHINERY, Equip::FERTILIZER },
-	  3200, 1, 0, ECON_AGRICULTURE, 1, 0
+	  3200, 1, 0, ECON_AGRICULTURE, true, 0
 	},{
 	  Lang::LIQUOR, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::FARM_MACHINERY, Equip::FERTILIZER },
-	  800, 1, 0, ECON_AGRICULTURE, 1, 0
+	  800, 1, 0, ECON_AGRICULTURE, true, 0
 	},{
 	  Lang::GRAIN, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::FARM_MACHINERY, Equip::FERTILIZER },
-	  1000, 1, 0, ECON_AGRICULTURE, 1, 0
+	  1000, 1, 0, ECON_AGRICULTURE, true, 0
 	},{
 	  Lang::TEXTILES, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::PLASTICS },
-	  850, 1, 0, ECON_INDUSTRY, 2, 0
+	  850, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::FERTILIZER, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::CARBON_ORE },
-	  400, 1, 0, ECON_INDUSTRY, 2, 0
+	  400, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::WATER, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::MINING_MACHINERY },
-	  120, 1, 0, ECON_MINING, 0, 0
+	  120, 1, 0, ECON_MINING, true, 0
 	},{
 	  Lang::MEDICINES,0,
 	  Equip::SLOT_CARGO, -1, { Equip::COMPUTERS, Equip::CARBON_ORE },
-	  2200, 1, 0, ECON_INDUSTRY, 3, 0
+	  2200, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::CONSUMER_GOODS,0,
 	  Equip::SLOT_CARGO, -1, { Equip::PLASTICS, Equip::TEXTILES },
-	  14000, 1, 0, ECON_INDUSTRY, 4, 0
+	  14000, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::COMPUTERS,0,
 	  Equip::SLOT_CARGO, -1, { Equip::PRECIOUS_METALS, Equip::INDUSTRIAL_MACHINERY },
-	  8000, 1, 0, ECON_INDUSTRY, 5, 0
+	  8000, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::ROBOTS,0,
 	  Equip::SLOT_CARGO, -1, { Equip::PLASTICS, Equip::COMPUTERS },
-	  6300, 1, 0, ECON_INDUSTRY, 5, 0
+	  6300, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::PRECIOUS_METALS, 0,
 	  Equip::SLOT_CARGO, -1, { Equip::MINING_MACHINERY },
-	  18000, 1, 0, ECON_MINING, 1, 0
+	  18000, 1, 0, ECON_MINING, true, 0
 	},{
 	  Lang::INDUSTRIAL_MACHINERY,0,
 	  Equip::SLOT_CARGO, -1, { Equip::METAL_ALLOYS, Equip::ROBOTS },
-	  1300, 1, 0, ECON_INDUSTRY, 3, 0
+	  1300, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::FARM_MACHINERY,0,
 	  Equip::SLOT_CARGO, -1, { Equip::METAL_ALLOYS, Equip::ROBOTS },
-	  1100, 1, 0, ECON_INDUSTRY, 3, 0
+	  1100, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::MINING_MACHINERY,0,
 	  Equip::SLOT_CARGO, -1, { Equip::METAL_ALLOYS, Equip::ROBOTS },
-	  1200, 1, 0, ECON_INDUSTRY, 3, 0
+	  1200, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::AIR_PROCESSORS,0,
 	  Equip::SLOT_CARGO, -1, { Equip::PLASTICS, Equip::INDUSTRIAL_MACHINERY },
-	  2000, 1, 0, ECON_INDUSTRY, 3, 0
+	  2000, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::SLAVES,0,
 	  Equip::SLOT_CARGO, -1, { },
-	  23200, 1, 0, ECON_AGRICULTURE, 0, 0
+	  23200, 1, 0, ECON_AGRICULTURE, true, 0
 	},{
 	  Lang::HAND_WEAPONS,0,
 	  Equip::SLOT_CARGO, -1, { Equip::COMPUTERS },
-	  12400, 1, 0, ECON_INDUSTRY, 4, 0
+	  12400, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::BATTLE_WEAPONS,0,
 	  Equip::SLOT_CARGO, -1, { Equip::INDUSTRIAL_MACHINERY, Equip::METAL_ALLOYS },
-	  22000, 1, 0, ECON_INDUSTRY, 4, 0
+	  22000, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::NERVE_GAS,0,
 	  Equip::SLOT_CARGO, -1, {},
-	  26500, 1, 0, ECON_INDUSTRY, 3, 0
+	  26500, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::NARCOTICS,0,
 	  Equip::SLOT_CARGO, -1, {},
-	  15700, 1, 0, ECON_INDUSTRY, 3, 0
+	  15700, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::MILITARY_FUEL,0,
 	  Equip::SLOT_CARGO, -1, { Equip::HYDROGEN },
-	  6000, 1, 0, ECON_INDUSTRY, 3, 0
+	  6000, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::RUBBISH,0,
 	  Equip::SLOT_CARGO, -1, { },
-	  -10, 1, 0, ECON_INDUSTRY, 0, 0
+	  -10, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::RADIOACTIVES,0,
 	  Equip::SLOT_CARGO, -1, { },
-	  -35, 1, 0, ECON_INDUSTRY, 0, 0
+	  -35, 1, 0, ECON_INDUSTRY, true, 0
 	},{
 	  Lang::MISSILE_UNGUIDED,0,
 	  Equip::SLOT_MISSILE, -1, {},
-	  3000, 1, 0, 0, 0, 0
+	  3000, 1, 0, 0, true, 0
 	},{
 	  Lang::MISSILE_GUIDED,0,
 	  Equip::SLOT_MISSILE, -1, {},
-	  5000, 1, 0, 0, 0, 0
+	  5000, 1, 0, 0, true, 0
 	},{
 	  Lang::MISSILE_SMART,0,
 	  Equip::SLOT_MISSILE, -1, {},
-	  9500, 1, 0, 0, 3, 0
+	  9500, 1, 0, 0, true, 0
 	},{
 	  Lang::MISSILE_NAVAL,0,
 	  Equip::SLOT_MISSILE, -1, {},
-	  16000, 1, 0, 0, 4, 0
+	  16000, 1, 0, 0, true, 0
 	},{
 	  Lang::ATMOSPHERIC_SHIELDING,
 	  Lang::ATMOSPHERIC_SHIELDING_DESCRIPTION,
 	  Equip::SLOT_ATMOSHIELD, -1, {},
-	  20000, 1, 1, 0, 1, 0
+	  20000, 1, 1, 0, true, 0
 	},{
 	  Lang::ECM_BASIC,
 	  Lang::ECM_BASIC_DESCRIPTION,
 	  Equip::SLOT_ECM, -1, {},
-	  600000, 2, 2, 0, 2, 5.0,
+	  600000, 2, 2, 0, true, 5.0,
 	},{
 	  Lang::SCANNER,
 	  Lang::SCANNER_DESCRIPTION,
 	  Equip::SLOT_SCANNER, -1, {},
-	  68000, 1, 0, 0, 2, 0
+	  68000, 1, 0, 0, true, 0
 	},{
 	  Lang::ECM_ADVANCED,
 	  Lang::ECM_ADVANCED_DESCRIPTION,
 	  Equip::SLOT_ECM, -1, {},
-	  1520000, 2, 3, 0, 5, 5.0
+	  1520000, 2, 3, 0, true, 5.0
 	},{
 	  Lang::UNOCCUPIED_CABIN,
 	  Lang::UNOCCUPIED_CABIN_DESCRIPTION,
 	  Equip::SLOT_CABIN, -1, {},
-	  135000, 5, 1, 0, 1, 5.0
+	  135000, 5, 1, 0, true, 5.0
 	},{
 	  Lang::PASSENGER_CABIN,0,
 	  Equip::SLOT_CABIN, -1, {},
-	  -135000, 5, 1, 0, 99, 5.0 // XXX: techLevel is 99 so that item can not be bought/sold
+	  -135000, 5, 1, 0, false, 5.0
 	},{
 	  Lang::SHIELD_GENERATOR,
 	  Lang::SHIELD_GENERATOR_DESCRIPTION,
 	  Equip::SLOT_SHIELD, -1, {},
-	  250000, 4, 1, 0, 4, 5.0
+	  250000, 4, 1, 0, true, 5.0
 	},{
 	  Lang::LASER_COOLING_BOOSTER,
 	  Lang::LASER_COOLING_BOOSTER_DESCRIPTION,
 	  Equip::SLOT_LASERCOOLER, -1, {},
-	  38000, 1, 2, 0, 2, 0
+	  38000, 1, 2, 0, true, 0
 	},{
 	  Lang::CARGO_LIFE_SUPPORT,
 	  Lang::CARGO_LIFE_SUPPORT_DESCRIPTION,
 	  Equip::SLOT_CARGOLIFESUPPORT, -1, {},
-	  70000, 1, 1, 0, 2, 0
+	  70000, 1, 1, 0, true, 0
 	},{
 	  Lang::AUTOPILOT,
 	  Lang::AUTOPILOT_DESCRIPTION,
 	  Equip::SLOT_AUTOPILOT, -1, {},
-	  140000, 1, 1, 0, 2, 0
+	  140000, 1, 1, 0, true, 0
 	},{
 	  Lang::RADAR_MAPPER,
 	  Lang::RADAR_MAPPER_DESCRIPTION,
 	  Equip::SLOT_RADARMAPPER, -1, {},
-	  90000, 1, 1, 0, 3, 0
+	  90000, 1, 1, 0, true, 0
 	},{
 	  Lang::FUEL_SCOOP,
 	  Lang::FUEL_SCOOP_DESCRIPTION,
 	  Equip::SLOT_FUELSCOOP, -1, {},
-	  350000, 6, 1, 0, 1, 0
+	  350000, 6, 1, 0, true, 0
 	},{
 	  Lang::CARGO_SCOOP,
 	  Lang::CARGO_SCOOP_DESCRIPTION,
 	  Equip::SLOT_CARGOSCOOP, -1, {},
-	  390000, 7, 1, 0, 1, 0
+	  390000, 7, 1, 0, true, 0
 	},{
 	  Lang::HYPERCLOUD_ANALYZER,
 	  Lang::HYPERCLOUD_ANALYZER_DESCRIPTION,
 	  Equip::SLOT_HYPERCLOUD, -1, {},
-	  150000, 1, 1, 0, 3, 0
+	  150000, 1, 1, 0, true, 0
 	},{
 	  Lang::HULL_AUTOREPAIR,
 	  Lang::HULL_AUTOREPAIR_DESCRIPTION,
 	  Equip::SLOT_HULLAUTOREPAIR, -1, {},
-	  1600000, 40, 1, 0, 4, 0
+	  1600000, 40, 1, 0, true, 0
 	},{
 	  Lang::SHIELD_ENERGY_BOOSTER,
 	  Lang::SHIELD_ENERGY_BOOSTER_DESCRIPTION,
 	  Equip::SLOT_ENERGYBOOSTER, -1, {},
-	  1000000, 8, 2, 0, 3, 0
+	  1000000, 8, 2, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS1,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  70000, 4, 1, 0, 0, 0
+	  70000, 4, 1, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS2,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  130000, 10, 2, 0, 0, 0
+	  130000, 10, 2, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS3,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  250000, 20, 3, 0, 0, 0
+	  250000, 20, 3, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS4,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  500000, 40, 4, 0, 0, 0
+	  500000, 40, 4, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS5,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  1000000, 120, 5, 0, 0, 0
+	  1000000, 120, 5, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS6,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  2000000, 225, 6, 0, 0, 0
+	  2000000, 225, 6, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS7,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  3000000, 400, 7, 0, 0, 0
+	  3000000, 400, 7, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS8,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  6000000, 580, 8, 0, 0, 0
+	  6000000, 580, 8, 0, true, 0
 	},{
 	  Lang::DRIVE_CLASS9,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::HYDROGEN},
-	  12000000, 740, 9, 0, 0, 0
+	  12000000, 740, 9, 0, true, 0
 	},{
 	  Lang::DRIVE_MIL1,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::MILITARY_FUEL},
-	  2300000, 3, 1, 0, 0, 0
+	  2300000, 3, 1, 0, true, 0
 	},{
 	  Lang::DRIVE_MIL2,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::MILITARY_FUEL},
-	  4700000, 8, 2, 0, 0, 0
+	  4700000, 8, 2, 0, true, 0
 	},{
 	  Lang::DRIVE_MIL3,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::MILITARY_FUEL},
-	  8500000, 16, 3, 0, 0, 0
+	  8500000, 16, 3, 0, true, 0
 	},{
 	  Lang::DRIVE_MIL4,0,
 	  Equip::SLOT_ENGINE, -1, {Equip::MILITARY_FUEL},
-	  21400000, 30, 4, 0, 0, 0
+	  21400000, 30, 4, 0, true, 0
 	},{
 	  Lang::PULSECANNON_1MW,0,
 	  Equip::SLOT_LASER, 1, {},
-	  60000, 1, 1, 0, 0, 0
+	  60000, 1, 1, 0, true, 0
 	},{
 	  Lang::PULSECANNON_DUAL_1MW,0,
 	  Equip::SLOT_LASER, 2, {},
-	  110000, 4, 2, 0, 0, 0
+	  110000, 4, 2, 0, true, 0
 	},{
 	  Lang::PULSECANNON_2MW,0,
 	  Equip::SLOT_LASER, 3, {},
-	  100000, 3, 2, 0, 0, 0
+	  100000, 3, 2, 0, true, 0
 	},{
 	  Lang::PULSECANNON_RAPID_2MW,0,
 	  Equip::SLOT_LASER, 4, {},
-	  180000, 7, 2, 0, 0, 0
+	  180000, 7, 2, 0, true, 0
 	},{
 	  Lang::PULSECANNON_4MW,0,
 	  Equip::SLOT_LASER, 5, {},
-	  220000, 10, 4, 0, 0, 0
+	  220000, 10, 4, 0, true, 0
 	},{
 	  Lang::PULSECANNON_10MW,0,
 	  Equip::SLOT_LASER, 6, {},
-	  490000, 30, 10, 0, 0, 0
+	  490000, 30, 10, 0, true, 0
 	},{
 	  Lang::PULSECANNON_20MW,0,
 	  Equip::SLOT_LASER, 7, {},
-	  1200000, 65, 20, 0, 0, 0
+	  1200000, 65, 20, 0, true, 0
 	},{
 	  Lang::MININGCANNON_17MW,
 	  Lang::MININGCANNON_17MW_DESCRIPTION,
 	  Equip::SLOT_LASER, 8, {},
-	  1060000, 10, 17, 0, 1, 0
+	  1060000, 10, 17, 0, true, 0
 	},{
 	  Lang::SMALL_PLASMA_ACCEL,0,
 	  Equip::SLOT_LASER, 9, {},
-	  12000000, 22, 50, 0, 0, 0
+	  12000000, 22, 50, 0, true, 0
 	},{
 	  Lang::LARGE_PLASMA_ACCEL,0,
 	  Equip::SLOT_LASER, 10, {},
-	  39000000, 50, 100, 0, 0, 0
+	  39000000, 50, 100, 0, true, 0
 	}
 };
 

--- a/src/EquipType.h
+++ b/src/EquipType.h
@@ -135,7 +135,7 @@ struct EquipType {
 	int mass;
 	int pval; // hello angband. used for general 'power' attribute...
 	int econType;
-	int techLevel; /* 0-5 */
+	bool purchasable;
 	float rechargeTime;			// to be eliminated maybe
 };
 

--- a/src/Polit.cpp
+++ b/src/Polit.cpp
@@ -51,30 +51,29 @@ const char *s_econDesc[ECON_MAX] = {
 
 struct politDesc_t {
 	const char *description;
-	int minTechLevel;
 	int rarity;
 	Bloc bloc;
 	PolitEcon econ;
 	fixed baseLawlessness;
 };
 const politDesc_t s_govDesc[GOV_MAX] = {
-	{ "<invalid turd>", 0, 0, BLOC_NONE, ECON_NONE, fixed(1,1) },
-	{ Lang::NO_CENTRAL_GOVERNANCE, 0, 0, BLOC_NONE, ECON_NONE, fixed(1,1) },
-	{ Lang::EARTH_FEDERATION_COLONIAL_RULE, 0, 2, BLOC_EARTHFED, ECON_CAPITALIST, fixed(3,10) },
-	{ Lang::EARTH_FEDERATION_DEMOCRACY, 4, 3, BLOC_EARTHFED, ECON_CAPITALIST, fixed(15,100) },
-	{ Lang::IMPERIAL_RULE, 4, 3, BLOC_EMPIRE, ECON_PLANNED, fixed(15,100) },
-	{ Lang::LIBERAL_DEMOCRACY, 3, 2, BLOC_CIS, ECON_CAPITALIST, fixed(25,100) },
-	{ Lang::SOCIAL_DEMOCRACY, 3, 2, BLOC_CIS, ECON_MIXED, fixed(20,100) },
-	{ Lang::LIBERAL_DEMOCRACY, 3, 2, BLOC_NONE, ECON_CAPITALIST, fixed(25,100) },
-	{ Lang::CORPORATE_SYSTEM, 1, 2, BLOC_NONE, ECON_CAPITALIST, fixed(40,100) },
-	{ Lang::SOCIAL_DEMOCRACY, 3, 2, BLOC_NONE, ECON_MIXED, fixed(25,100) },
-	{ Lang::MILITARY_DICTATORSHIP, 1, 5, BLOC_EARTHFED, ECON_CAPITALIST, fixed(40,100) },
-	{ Lang::MILITARY_DICTATORSHIP, 1, 6, BLOC_NONE, ECON_CAPITALIST, fixed(25,100) },
-	{ Lang::MILITARY_DICTATORSHIP, 1, 6, BLOC_NONE, ECON_MIXED, fixed(25,100) },
-	{ Lang::MILITARY_DICTATORSHIP, 1, 5, BLOC_EMPIRE, ECON_MIXED, fixed(40,100) },
-	{ Lang::COMMUNIST, 1, 10, BLOC_NONE, ECON_PLANNED, fixed(25,100) },
-	{ Lang::PLUTOCRATIC_DICTATORSHIP, 1, 4, BLOC_NONE, ECON_VERY_CAPITALIST, fixed(45,100) },
-	{ Lang::VIOLENT_ANARCHY, 0, 2, BLOC_NONE, ECON_NONE, fixed(90,100) },
+	{ "<invalid turd>", 0, BLOC_NONE, ECON_NONE, fixed(1,1) },
+	{ Lang::NO_CENTRAL_GOVERNANCE, 0, BLOC_NONE, ECON_NONE, fixed(1,1) },
+	{ Lang::EARTH_FEDERATION_COLONIAL_RULE, 2, BLOC_EARTHFED, ECON_CAPITALIST, fixed(3,10) },
+	{ Lang::EARTH_FEDERATION_DEMOCRACY, 3, BLOC_EARTHFED, ECON_CAPITALIST, fixed(15,100) },
+	{ Lang::IMPERIAL_RULE, 3, BLOC_EMPIRE, ECON_PLANNED, fixed(15,100) },
+	{ Lang::LIBERAL_DEMOCRACY, 2, BLOC_CIS, ECON_CAPITALIST, fixed(25,100) },
+	{ Lang::SOCIAL_DEMOCRACY, 2, BLOC_CIS, ECON_MIXED, fixed(20,100) },
+	{ Lang::LIBERAL_DEMOCRACY, 2, BLOC_NONE, ECON_CAPITALIST, fixed(25,100) },
+	{ Lang::CORPORATE_SYSTEM, 2, BLOC_NONE, ECON_CAPITALIST, fixed(40,100) },
+	{ Lang::SOCIAL_DEMOCRACY, 2, BLOC_NONE, ECON_MIXED, fixed(25,100) },
+	{ Lang::MILITARY_DICTATORSHIP, 5, BLOC_EARTHFED, ECON_CAPITALIST, fixed(40,100) },
+	{ Lang::MILITARY_DICTATORSHIP, 6, BLOC_NONE, ECON_CAPITALIST, fixed(25,100) },
+	{ Lang::MILITARY_DICTATORSHIP, 6, BLOC_NONE, ECON_MIXED, fixed(25,100) },
+	{ Lang::MILITARY_DICTATORSHIP, 5, BLOC_EMPIRE, ECON_MIXED, fixed(40,100) },
+	{ Lang::COMMUNIST, 10, BLOC_NONE, ECON_PLANNED, fixed(25,100) },
+	{ Lang::PLUTOCRATIC_DICTATORSHIP, 4, BLOC_NONE, ECON_VERY_CAPITALIST, fixed(45,100) },
+	{ Lang::VIOLENT_ANARCHY, 2, BLOC_NONE, ECON_NONE, fixed(90,100) },
 };
 
 void Init()
@@ -212,10 +211,7 @@ void GetSysPolitStarSystem(const StarSystem *s, const fixed human_infestedness, 
 		if (path == SystemPath(0,0,0,0)) {
 			a = Polit::GOV_EARTHDEMOC;
 		} else if (human_infestedness > 0) {
-			for (int tries=10; tries--; ) {
-				a = static_cast<GovType>(rand.Int32(GOV_RAND_MIN, GOV_RAND_MAX));
-				if (s_govDesc[a].minTechLevel <= s->m_techlevel) break;
-			}
+			a = static_cast<GovType>(rand.Int32(GOV_RAND_MIN, GOV_RAND_MAX));
 		} else {
 			a = GOV_NONE;
 		}

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -834,10 +834,7 @@ void SpaceStation::CreateBB()
 		if (Equip::types[i].slot == Equip::SLOT_CARGO) {
 			m_equipmentStock[i] = Pi::rng.Int32(0,100) * Pi::rng.Int32(1,100);
 		} else {
-			if (Equip::types[i].techLevel <= Pi::game->GetSpace()->GetStarSystem()->m_techlevel)
-				m_equipmentStock[i] = Pi::rng.Int32(0,100);
-			else
-				m_equipmentStock[i] = 0;
+			m_equipmentStock[i] = Pi::rng.Int32(0,100);
 		}
 	}
 

--- a/src/StarSystem.cpp
+++ b/src/StarSystem.cpp
@@ -1741,8 +1741,6 @@ void StarSystem::Populate(bool addSpaceStations)
 
 	/* Various system-wide characteristics */
 	m_humanProx = fixed(3,1) / isqrt(9 + 10*(m_path.sectorX*m_path.sectorX + m_path.sectorY*m_path.sectorY + m_path.sectorZ*m_path.sectorZ));
-	m_techlevel = (m_humanProx*5).ToInt32() + rand.Int32(-2,2);
-	m_techlevel = Clamp(m_techlevel, 1, 5);
 	m_econType = ECON_INDUSTRY;
 	m_industrial = rand.Fixed();
 	m_agricultural = 0;
@@ -1750,7 +1748,6 @@ void StarSystem::Populate(bool addSpaceStations)
 	/* system attributes */
 	m_totalPop = fixed(0);
 	rootBody->PopulateStage1(this, m_totalPop);
-	if (m_totalPop == 0) m_techlevel = 0;
 	
 //	printf("Trading rates:\n");
 	// So now we have balances of trade of various commodities.
@@ -1771,7 +1768,7 @@ void StarSystem::Populate(bool addSpaceStations)
 //		const EquipType &type = Equip::types[t];
 //		printf("%s: %d%%\n", type.name, m_tradeLevel[t]);
 //	}
-//	printf("System total population %.3f billion, tech level %d\n", m_totalPop.ToFloat(), m_techlevel);
+//	printf("System total population %.3f billion\n", m_totalPop.ToFloat());
 	Polit::GetSysPolitStarSystem(this, m_totalPop, m_polit);
 
 	if (addSpaceStations) {
@@ -1850,7 +1847,6 @@ void SBody::PopulateStage1(StarSystem *system, fixed &outTotalPop)
 	for (int i=Equip::FIRST_COMMODITY; i<Equip::LAST_COMMODITY; i++) {
 		Equip::Type t = Equip::Type(i);
 		const EquipType &itype = Equip::types[t];
-		if (itype.techLevel > system->m_techlevel) continue;
 
 		fixed affinity = fixed(1,1);
 		if (itype.econType & ECON_AGRICULTURE) {

--- a/src/StarSystem.h
+++ b/src/StarSystem.h
@@ -219,7 +219,6 @@ public:
 	// percent price alteration
 	int m_tradeLevel[Equip::TYPE_MAX];
 	int m_econType;
-	int m_techlevel; /* 0-5 like in EquipType.h */
 	int m_seed;
 
 	bool m_unexplored;

--- a/src/StationShipEquipmentForm.cpp
+++ b/src/StationShipEquipmentForm.cpp
@@ -49,10 +49,11 @@ StationShipEquipmentForm::StationShipEquipmentForm(FormController *controller) :
 
 	for (int i=Equip::FIRST_SHIPEQUIP, num=0; i<=Equip::LAST_SHIPEQUIP; i++) {
 		Equip::Type type = static_cast<Equip::Type>(i);
-		if (!m_station->GetStock(type) &&
-			!(Pi::player->m_equipment.Count(Equip::types[i].slot, type) &&
-			Equip::types[i].techLevel <= Pi::game->GetSpace()->GetStarSystem()->m_techlevel))
+
+		// must be purchasable and at least one available somewhere
+		if ((!Equip::types[i].purchasable) && (m_station->GetStock(type) || Pi::player->m_equipment.Count(Equip::types[i].slot, type) > 0))
 			continue;
+
 		Gui::Label *l = new Gui::Label(Equip::types[i].name);
 		if (Equip::types[i].description) {
 			l->SetToolTip(Equip::types[i].description);


### PR DESCRIPTION
Mainly to make autopilots and other useful things available to Lave and surrounds and thus reduce tech support load for Alpha 21. We could hack in some "distance to Lave" or custom system data or whatever, but we're all pretty much in agreement that techlevels aren't in our final plans. Removing them entirely seemed to make more sense.
