### PR TITLE
Fix LMR lathe primitive to be consistent with cylinder, ring and tube

### DIFF
--- a/src/LmrModel.cpp
+++ b/src/LmrModel.cpp
@@ -23,7 +23,7 @@
 #include <set>
 #include <algorithm>
 
-static const Uint32 s_cacheVersion = 1;
+static const Uint32 s_cacheVersion = 2;
 
 /*
  * Interface: LMR
@@ -1571,16 +1571,17 @@ namespace ModelFuncs {
 		const vector3f axis1 = updir->Normalized();
 		const vector3f axis2 = updir->Cross(dir).Normalized();
 		const float inc = 2.0f*M_PI / float(steps);
+		const float radmod = 1.0f / cosf(0.5f*inc);
 
 		for (int i=0; i<num-3; i+=2) {
-			const float rad1 = jizz[i+1];
-			const float rad2 = jizz[i+3];
+			const float rad1 = jizz[i+1] * radmod;
+			const float rad2 = jizz[i+3] * radmod;
 			const vector3f _start = *start + (*end-*start)*jizz[i];
 			const vector3f _end = *start + (*end-*start)*jizz[i+2];
 			bool shitty_normal = is_equal_absolute(jizz[i], jizz[i+2], 1e-4f);
 
 			const int basevtx = vtxStart + steps*i;
-			float ang = 0;
+			float ang = 0.5*inc;
 			for (int j=0; j<steps; j++, ang += inc) {
 				const vector3f p1 = rad1 * (sin(ang)*axis1 + cos(ang)*axis2);
 				const vector3f p2 = rad2 * (sin(ang)*axis1 + cos(ang)*axis2);


### PR DESCRIPTION
There were two inconsistencies:
- `lathe` interprets its radius values as the distance to the vertices; cylinder and co. interpret radius as the distance to the middle of the edge.
- `lathe` interprets its "up" direction as the direction to the first vertex in a vertex ring. The others interpret it as the normal of the first edge in the ring.

Since `lathe` is used much less than the others, that's the function I've changed.

A test model to show the difference (try it before and after the patch):

```
define_model('test_lathe', {
    info = {
            bounding_radius = 60.0,
            lod_pixels = { 50 },
            materials = {'plain'}
        },
    static = function(lod)
        set_material('plain',
            0.7, 0.7, 0.7, 0.7, -- diffuse RGB; alpha
            1, 1, 1, 0.1, -- specular RGB; specular strength
            0, 0, 0) -- emissive RGB

        use_material('plain')

        tapered_cylinder(5, v(0,-20,0), v(0,-15,0), v(0,0,1), 1, 5)
        ring(5, v(0,-15,0), v(0,-10,0), v(0,0,1), 5)
        lathe(5, v(0,-10,0), v(0,10,0), v(0,0,1),
            {0,5, 0.4,10, 0.6,10, 1,5})
        cylinder(5, v(0,10,0), v(0,20,0), v(0,0,1), 5)

        quad(v(-5, 20,-5), v(-5, 20, 5), v( 5, 20, 5), v( 5, 20,-5))
        quad(v(-5, 20,-5), v( 5, 20,-5), v( 5, 20, 5), v(-5, 20, 5))
    end
})
```
