### PR TITLE
Fix bug in fuel scoop logic

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -964,7 +964,7 @@ void Ship::StaticUpdate(const float timeStep)
 	UpdateAlertState();
 
 	/* FUEL SCOOPING!!!!!!!!! */
-	if (m_equipment.Get(Equip::SLOT_FUELSCOOP) != Equip::NONE) {
+	if ((m_flightState == FLYING) && (m_equipment.Get(Equip::SLOT_FUELSCOOP) != Equip::NONE)) {
 		Body *astro = GetFrame()->m_astroBody;
 		if (astro && astro->IsType(Object::PLANET)) {
 			Planet *p = static_cast<Planet*>(astro);
@@ -972,7 +972,7 @@ void Ship::StaticUpdate(const float timeStep)
 				double dist = GetPosition().Length();
 				double pressure, density;
 				p->GetAtmosphericState(dist, &pressure, &density);
-			
+
 				double speed = GetVelocity().Length();
 				vector3d vdir = GetVelocity().Normalized();
 				matrix4x4d rot;


### PR DESCRIPTION
For #1200.

`p->Body::GetSBody()` is not the same as `p->GetSBody()`. The first bypasses dynamic dispatch; that is, it ignores the 'virtual'ness of `GetSBody` and calls `Body::GetSBody` directly.

This patch also adds a short-cut test so the fuel scoop logic is only run during flight.
