### PR TITLE
Scale hyperspace entry point based on radius of primary star

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -263,18 +263,20 @@ vector3d Space::GetHyperspaceExitPoint(const SystemPath &source) const
 	const vector3d destPos = vector3d(dest_sys.p) + vector3d(dest.sectorX, dest.sectorY, dest.sectorZ);
 
 	// find the first non-gravpoint. should be the primary star
-	SystemPath primaryPath = dest;
-	primaryPath.bodyIndex = 0;
-	SBody *primary;
-	do { primary = m_starSystem->GetBodyByPath(primaryPath); primaryPath.bodyIndex++; } while (primary->type == SBody::TYPE_GRAVPOINT);
+	Body *primary = 0;
+	for (BodyIterator i = BodiesBegin(); i != BodiesEnd(); ++i)
+		if ((*i)->GetSBody()->type != SBody::TYPE_GRAVPOINT) {
+			primary = *i;
+			break;
+		}
 	assert(primary);
 
 	// point along the line between source and dest, a reasonable distance
 	// away based on the radius (don't want to end up inside black holes, and
 	// then mix it up so that ships don't end up on top of each other
-	vector3d pos = (sourcePos - destPos).Normalized() * (primary->GetRadius()/AU+1.0)*11.0*AU*Pi::rng.Double(0.95,1.2) + MathUtil::RandomPointOnSphere(5.0,20.0)*1000.0;
-	assert(pos.Length() > primary->GetRadius());
-	return pos;
+	vector3d pos = (sourcePos - destPos).Normalized() * (primary->GetSBody()->GetRadius()/AU+1.0)*11.0*AU*Pi::rng.Double(0.95,1.2) + MathUtil::RandomPointOnSphere(5.0,20.0)*1000.0;
+	assert(pos.Length() > primary->GetSBody()->GetRadius());
+	return pos + primary->GetPositionRelTo(GetRootFrame());
 }
 
 Body *Space::FindNearestTo(const Body *b, Object::Type t) const


### PR DESCRIPTION
Makes jumps into SM_BH systems possible while keeping jumps into normal systems roughly the same as before. Slightly larger distances, now 11AU+fudge, but for our good friend Black Hole, you'll emerge some 600AU out. That's enough to make it to port without getting dragged in, though the autopilot has some fun getting there and you'll need a few tanks of fuel. Give it a try!

![](http://i.imgur.com/58FdP.png)

Btw, to test the black hole jump I changed the debug start path to `SystemPath(-3125,-1,1,0,4)`.
