### PR TITLE
Fix a couple of LMR problems that are in people's way

### DIFF
--- a/src/LmrModel.cpp
+++ b/src/LmrModel.cpp
@@ -4161,8 +4161,8 @@ namespace ObjLoader {
 	 * Load a Wavefront OBJ model file.
 	 * 
 	 * If an associated .mtl material definition file is found, Pioneer will
-	 * use the diffuse texture (map_Kd) settings from that file. Other material
-	 * settings in the .mtl file are currently ignored.
+	 * use the diffuse and emission textures (map_Kd and map_Ke) from that file.
+	 * Other material settings in the .mtl file are currently ignored.
 	 *
 	 * > load_obj(modelname, transform)
 	 *


### PR DESCRIPTION
Bugs addressed:
- When loading .obj files with associated textures, there was a bug that caused each individual face (triangle or quad) from the .obj to generate a separate OP_DRAW_ELEMENTS operation in the model oplist.
- Documentation of the way load_obj handles .mtl files was incorrect.
- .mtl files containing texture channels other than diffuse caused an assert (actually PiVerify) error on load.

New features:
- The `map_Ke` (emission map) specifier in .mtl files is now interpreted to set the glow map.
