### PR TITLE
Added miniz dependency for vc2010 solution and fixed crash bug.

### DIFF
--- a/src/LuaModelViewer.cpp
+++ b/src/LuaModelViewer.cpp
@@ -186,6 +186,7 @@ public:
 			
 			Add(new Gui::Label("Animations (0 gear, 1-4 are time - ignore them comrade)"),
 					200, Gui::Screen::GetHeight()-140.0f);
+			memset(m_anim,0,sizeof(Gui::Adjustment*)*LMR_ARG_MAX);
 			for (int i=0; i<LMR_ARG_MAX; i++) {
 				float x = float(200+i*25);
 				float w = 32.0f;
@@ -222,7 +223,11 @@ public:
 	}
 
 	void OnResetAdjustments() {
-		for (int i=0; i<LMR_ARG_MAX; i++) m_anim[i]->SetValue(0);
+		for (int i=0; i<LMR_ARG_MAX; i++) {
+			if(m_anim[i]) {
+				m_anim[i]->SetValue(0);
+			}
+		}
 		for (int i=0; i<3; i++) {
 			m_linthrust[i]->SetValue(0.5);
 			m_angthrust[i]->SetValue(0.5);

--- a/win32/vc2010/pioneer.sln
+++ b/win32/vc2010/pioneer.sln
@@ -3,6 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual C++ Express 2010
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pioneer", "pioneer.vcxproj", "{65A1BBFB-7A42-497C-BF65-A0A06664A204}"
 	ProjectSection(ProjectDependencies) = postProject
+		{869EEE1B-C824-4EEF-8AB0-2C95507406DE} = {869EEE1B-C824-4EEF-8AB0-2C95507406DE}
 		{5085B12D-F9AC-4878-9672-1FD4EB0EFB67} = {5085B12D-F9AC-4878-9672-1FD4EB0EFB67}
 	EndProjectSection
 EndProject
@@ -10,6 +11,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lua", "lua.vcxproj", "{5085
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "modelviewer", "modelviewer.vcxproj", "{BD7B420B-07C1-43F2-A987-F9A4915005E5}"
 	ProjectSection(ProjectDependencies) = postProject
+		{869EEE1B-C824-4EEF-8AB0-2C95507406DE} = {869EEE1B-C824-4EEF-8AB0-2C95507406DE}
 		{5085B12D-F9AC-4878-9672-1FD4EB0EFB67} = {5085B12D-F9AC-4878-9672-1FD4EB0EFB67}
 	EndProjectSection
 EndProject


### PR DESCRIPTION
--Added miniz dependency for Pioneer and ModelViewer projects.
This was to get them both to compile.

--Fixed crash bug in ModelViewer.
Found that when you clicked on the reset sliders button it iterated right along a list that wasn't guaranteed to hold valid pointers causing an invalid access crash.
