### PR TITLE
Add goto sector coordinates to sectorview

### DIFF
--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -26,6 +26,7 @@ public:
 	void SetHyperspaceTarget(const SystemPath &path);
 	void FloatHyperspaceTarget();
 	void ResetHyperspaceTarget();
+	void GotoSector(const SystemPath &path);
 	void GotoSystem(const SystemPath &path);
 	void GotoCurrentSystem() { GotoSystem(m_current); }
 	void GotoSelectedSystem() { GotoSystem(m_selected); }
@@ -107,6 +108,7 @@ private:
 	sigc::connection m_onKeyPressConnection;
 
 	std::map<SystemPath,Sector*> m_sectorCache;
+	std::string m_previousSearch;
 
 	float m_playerHyperspaceRange;
 	Graphics::Drawables::Line3D m_jumpLine;


### PR DESCRIPTION
For #1253

Users can now enter sector X,Y,Z coordinates into the search box. Coordinates are three numbers separated by spaces or commas, with out without parentheses.

System index (fourth number) is not supported, it does not work reliably. BBS gives coordinates in X,X,X format anyway.

As a semi-hidden feature up arrow enters the last entered search into the box, I thought it was useful.
