### PR TITLE
Terrain color EarthLike/TFPoor optimisation

### DIFF
--- a/src/terrain/TerrainColorEarthLike.cpp
+++ b/src/terrain/TerrainColorEarthLike.cpp
@@ -20,16 +20,7 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 {
 	double n = m_invMaxHeight*height;
 	double flatness = pow(p.Dot(norm), 8.0);
-	//textures:
-	double tex_rock(0), tex_sand(0), tex_grass(0), tex_forest(0);
 
-	if (textures) {
-		tex_rock   =   rock;
-		tex_sand   =   sand;
-		tex_grass  =  grass;
-		tex_forest = forest;
-	}
-	//textures end
 	double continents = 0;
 	double equatorial_desert = (2.0-m_icyness)*(-1.0+2.0*octavenoise(12, 0.5, 2.0, (n*2.0)*p)) *
 			1.0*(2.0-m_icyness)*(1.0-p.y*p.y);
@@ -41,7 +32,7 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 			// ice on mountains
 			if (flatness > 0.6/Clamp(n*m_icyness+(m_icyness*0.5)+(fabs(p.y*p.y*p.y*0.38)), 0.1, 1.0)) {
 				if (textures) {
-					col = interpolate_color(tex_rock, color_cliffs, m_rockColor[5]);
+					col = interpolate_color(rock, color_cliffs, m_rockColor[5]);
 					col = interpolate_color(flatness, col, vector3d(1,1,1));
 				} else col = interpolate_color(flatness, color_cliffs, vector3d(1,1,1));
 				return col;
@@ -50,7 +41,7 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 			if ((m_icyness*0.5)+(fabs(p.y*p.y*p.y*0.38)) > 0.6) {
 				//if (flatness > 0.5/Clamp(fabs(p.y*m_icyness), 0.1, 1.0)) {
 				if (textures) {
-					col = interpolate_color(tex_rock, color_cliffs, m_rockColor[5]);
+					col = interpolate_color(rock, color_cliffs, m_rockColor[5]);
 					col = interpolate_color(flatness, col, vector3d(1,1,1));
 				} else col = interpolate_color(flatness, color_cliffs, vector3d(1,1,1));
 				return col;
@@ -61,7 +52,7 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 		//printf("flatness : %d", flatness);
 		if (flatness > 0.6/Clamp(n*m_icyness+(m_icyness*0.5)+(fabs(p.y*p.y*p.y*0.38)), 0.1, 1.0)) {
 			if (textures) {
-				col = interpolate_color(tex_rock, color_cliffs, m_rockColor[5]);
+				col = interpolate_color(rock, color_cliffs, m_rockColor[5]);
 				col = interpolate_color(flatness, col, vector3d(1,1,1));
 			} else col = interpolate_color(flatness, color_cliffs, vector3d(1,1,1));
 			return col;
@@ -70,7 +61,7 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 		if ((m_icyness*0.5)+(fabs(p.y*p.y*p.y*0.38)) > 0.6) {
 			//if (flatness > 0.5/Clamp(fabs(p.y*m_icyness), 0.1, 1.0)) {
 			if (textures) {
-				col = interpolate_color(tex_rock, color_cliffs, m_rockColor[5]);
+				col = interpolate_color(rock, color_cliffs, m_rockColor[5]);
 				col = interpolate_color(flatness, col, vector3d(1,1,1));
 			} else col = interpolate_color(flatness, color_cliffs, vector3d(1,1,1));
 			return col;
@@ -110,8 +101,8 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 		col = interpolate_color(equatorial_desert, m_rockColor[2], m_rockColor[4]);
 		col = interpolate_color(n, col, m_darkrockColor[6]);
 		if (textures) {
-			tex1 = interpolate_color(tex_rock, col, color_cliffs);
-			tex2 = interpolate_color(tex_sand, col, m_darkdirtColor[3]);
+			tex1 = interpolate_color(rock, col, color_cliffs);
+			tex2 = interpolate_color(sand, col, m_darkdirtColor[3]);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -122,8 +113,8 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 		col = interpolate_color(equatorial_desert, m_darkrockColor[3], m_darksandColor[1]);
 		col = interpolate_color(n, col, m_rockColor[2]);
 		if (textures) {
-			tex1 = interpolate_color(tex_rock, col, color_cliffs);
-			tex2 = interpolate_color(tex_sand, col, m_darkdirtColor[3]);
+			tex1 = interpolate_color(rock, col, color_cliffs);
+			tex2 = interpolate_color(sand, col, m_darkdirtColor[3]);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -134,8 +125,8 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 		col = interpolate_color(equatorial_desert, m_darkplantColor[2], m_sandColor[2]);
 		col = interpolate_color(n, col, m_darkrockColor[3]);
 		if (textures) {
-			tex1 = interpolate_color(tex_rock, col, color_cliffs);
-			tex2 = interpolate_color(tex_forest, col, color_cliffs);
+			tex1 = interpolate_color(rock, col, color_cliffs);
+			tex2 = interpolate_color(forest, col, color_cliffs);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -146,8 +137,8 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 		col = interpolate_color(equatorial_desert, m_plantColor[1], m_plantColor[0]);
 		col = interpolate_color(n, col, m_darkplantColor[2]);
 		if (textures) {
-			tex1 = interpolate_color(tex_rock, col, color_cliffs);
-			tex2 = interpolate_color(tex_grass, color_cliffs, col);
+			tex1 = interpolate_color(rock, col, color_cliffs);
+			tex2 = interpolate_color(grass, color_cliffs, col);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -158,8 +149,8 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 		col = interpolate_color(equatorial_desert, m_darkplantColor[0], m_sandColor[1]);
 		col = interpolate_color(n, col, m_plantColor[0]);
 		if (textures) {
-			tex1 = interpolate_color(tex_rock, col, color_cliffs);
-			tex2 = interpolate_color(tex_grass, color_cliffs, col);
+			tex1 = interpolate_color(rock, col, color_cliffs);
+			tex2 = interpolate_color(grass, color_cliffs, col);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -170,8 +161,8 @@ vector3d TerrainColorFractal<TerrainColorEarthLike>::GetColor(const vector3d &p,
 		col = interpolate_color(equatorial_desert, m_sandColor[0], m_sandColor[1]);
 		col = interpolate_color(n, col, m_darkplantColor[0]);
 		if (textures) {
-			tex1 = interpolate_color(tex_rock, col, color_cliffs);
-			tex2 = interpolate_color(tex_sand, col, color_cliffs);
+			tex1 = interpolate_color(rock, col, color_cliffs);
+			tex2 = interpolate_color(sand, col, color_cliffs);
 			return col = interpolate_color(flatness, tex1, tex2);
 		} else { 
 			return col = interpolate_color(flatness, color_cliffs, col);

--- a/src/terrain/TerrainColorTFPoor.cpp
+++ b/src/terrain/TerrainColorTFPoor.cpp
@@ -16,18 +16,7 @@ vector3d TerrainColorFractal<TerrainColorTFPoor>::GetColor(const vector3d &p, do
 {
 	double n = m_invMaxHeight*height;
 	double flatness = pow(p.Dot(norm), 8.0);
-	//textures:
-	double tex_rock(0), tex_rock2(0), tex_mud(0), tex_sand(0), tex_sand2(0), tex_grass(0), tex_grass2(0);
-	if (textures) {
-		tex_rock   = rock;
-		tex_rock2  = rock2;
-		tex_mud    = mud;
-		tex_sand   = sand;
-		tex_sand2  = sand2;
-		tex_grass  = grass;
-		tex_grass2 = grass2;
-	}
-	//textures end
+
 	double continents = 0;
 	double equatorial_desert = (2.0-m_icyness)*(-1.0+2.0*octavenoise(12, 0.5, 2.0, (n*2.0)*p)) *
 			1.0*(2.0-m_icyness)*(1.0-p.y*p.y);
@@ -36,7 +25,7 @@ vector3d TerrainColorFractal<TerrainColorTFPoor>::GetColor(const vector3d &p, do
 	// ice on mountains and poles
 	if (fabs(m_icyness*p.y) + m_icyness*n > 1) {
 		if (textures) {
-			col = interpolate_color(tex_rock2, color_cliffs, vector3d(.9,.9,.9));
+			col = interpolate_color(rock2, color_cliffs, vector3d(.9,.9,.9));
 			col = interpolate_color(flatness, col, vector3d(1,1,1));
 		} else col = interpolate_color(flatness, color_cliffs, vector3d(1,1,1));
 		return col;
@@ -77,8 +66,8 @@ vector3d TerrainColorFractal<TerrainColorTFPoor>::GetColor(const vector3d &p, do
 		col = interpolate_color(equatorial_desert, m_rockColor[2], m_rockColor[6]);
 		col = interpolate_color(n, col, m_darkrockColor[6]);
 		if (textures) {
-			tex1 = interpolate_color(tex_rock, col, color_cliffs);
-			tex2 = interpolate_color(tex_rock2, col, color_cliffs);
+			tex1 = interpolate_color(rock, col, color_cliffs);
+			tex2 = interpolate_color(rock2, col, color_cliffs);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -89,8 +78,8 @@ vector3d TerrainColorFractal<TerrainColorTFPoor>::GetColor(const vector3d &p, do
 		col = interpolate_color(equatorial_desert, m_darkrockColor[4], m_darksandColor[6]);
 		col = interpolate_color(n, col, m_rockColor[2]);
 		if (textures) {
-			tex1 = interpolate_color(tex_rock, col, color_cliffs);
-			tex2 = interpolate_color(tex_mud, col, color_cliffs);
+			tex1 = interpolate_color(rock, col, color_cliffs);
+			tex2 = interpolate_color(mud, col, color_cliffs);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -102,8 +91,8 @@ vector3d TerrainColorFractal<TerrainColorTFPoor>::GetColor(const vector3d &p, do
 		col = interpolate_color(equatorial_desert, m_darksandColor[2], m_sandColor[2]);
 		col = interpolate_color(n, col, m_darkrockColor[3]);
 		if (textures) {
-			tex1 = interpolate_color(tex_mud, col, color_cliffs);
-			tex2 = interpolate_color(tex_grass, col, color_cliffs);
+			tex1 = interpolate_color(mud, col, color_cliffs);
+			tex2 = interpolate_color(grass, col, color_cliffs);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -114,8 +103,8 @@ vector3d TerrainColorFractal<TerrainColorTFPoor>::GetColor(const vector3d &p, do
 		col = interpolate_color(equatorial_desert, m_sandColor[1], m_sandColor[0]);
 		col = interpolate_color(n, col, m_darksandColor[2]);
 		if (textures) {
-			tex1 = interpolate_color(tex_grass, col, color_cliffs);
-			tex2 = interpolate_color(tex_grass2, col, color_cliffs);
+			tex1 = interpolate_color(grass, col, color_cliffs);
+			tex2 = interpolate_color(grass2, col, color_cliffs);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -126,8 +115,8 @@ vector3d TerrainColorFractal<TerrainColorTFPoor>::GetColor(const vector3d &p, do
 		col = interpolate_color(equatorial_desert, m_darkplantColor[0], m_sandColor[1]);
 		col = interpolate_color(n, col, m_plantColor[0]);
 		if (textures) {
-			tex1 = interpolate_color(tex_sand2, col, color_cliffs);
-			tex2 = interpolate_color(tex_grass, col, color_cliffs);
+			tex1 = interpolate_color(sand2, col, color_cliffs);
+			tex2 = interpolate_color(grass, col, color_cliffs);
 			col = interpolate_color(flatness, tex1, tex2);
 		} else col = interpolate_color(flatness, color_cliffs, col);
 		return col;
@@ -138,7 +127,7 @@ vector3d TerrainColorFractal<TerrainColorTFPoor>::GetColor(const vector3d &p, do
 		col = interpolate_color(equatorial_desert, m_sandColor[0], m_sandColor[1]);
 		col = interpolate_color(n, col, m_darkplantColor[0]);
 		if (textures) {
-			tex1 = interpolate_color(tex_sand, col, color_cliffs);
+			tex1 = interpolate_color(sand, col, color_cliffs);
 			//tex2 = interpolate_color(sand2, col, color_cliffs);
 			col = interpolate_color(flatness, tex1, col);
 		} else col = interpolate_color(flatness, color_cliffs, col);

--- a/src/terrain/TerrainNoise.h
+++ b/src/terrain/TerrainNoise.h
@@ -155,17 +155,18 @@ namespace TerrainNoise {
 
 // common colours for earthlike worlds
 // XXX better way to do this?
-#define rock   octavenoise(GetFracDef(0), 0.65, p);
-#define rock2  octavenoise(GetFracDef(1), 0.6, p)*ridged_octavenoise(GetFracDef(0), 0.55, p);
-#define rock3  0.5*ridged_octavenoise(GetFracDef(0), 0.5, p)*voronoiscam_octavenoise(GetFracDef(0), 0.5, p)*ridged_octavenoise(GetFracDef(1), 0.5, p);
-#define rock4  ridged_octavenoise(GetFracDef(1), 0.5, p)*octavenoise(GetFracDef(1), 0.5, p)*octavenoise(GetFracDef(5), 0.5, p);
-#define mud    0.1*voronoiscam_octavenoise(GetFracDef(1), 0.5, p)*octavenoise(GetFracDef(1), 0.5, p) * GetFracDef(5).amplitude;
-#define sand   ridged_octavenoise(GetFracDef(0), 0.4, p)*dunes_octavenoise(GetFracDef(2), 0.4, p) + 0.1*dunes_octavenoise(GetFracDef(1), 0.5, p);
-#define sand2  dunes_octavenoise(GetFracDef(0), 0.6, p)*octavenoise(GetFracDef(4), 0.6, p);
-#define sand3  dunes_octavenoise(GetFracDef(2), 0.6, p)*dunes_octavenoise(GetFracDef(6), 0.6, p);
-#define grass  billow_octavenoise(GetFracDef(1), 0.8, p);
-#define grass2 billow_octavenoise(GetFracDef(3), 0.6, p)*voronoiscam_octavenoise(GetFracDef(4), 0.6, p)*river_octavenoise(GetFracDef(5), 0.6, p);
-#define forest octavenoise(GetFracDef(1), 0.65, p)*voronoiscam_octavenoise(GetFracDef(2), 0.65, p);
-#define water  dunes_octavenoise(GetFracDef(6), 0.6, p);
+#define rock   octavenoise(GetFracDef(0), 0.65, p)
+#define rock2  octavenoise(GetFracDef(1), 0.6, p)*ridged_octavenoise(GetFracDef(0), 0.55, p)
+#define rock3  0.5*ridged_octavenoise(GetFracDef(0), 0.5, p)*voronoiscam_octavenoise(GetFracDef(0), 0.5, p)*ridged_octavenoise(GetFracDef(1), 0.5, p)
+#define rock4  ridged_octavenoise(GetFracDef(1), 0.5, p)*octavenoise(GetFracDef(1), 0.5, p)*octavenoise(GetFracDef(5), 0.5, p)
+#define mud    0.1*voronoiscam_octavenoise(GetFracDef(1), 0.5, p)*octavenoise(GetFracDef(1), 0.5, p) * GetFracDef(5).amplitude
+#define sand   ridged_octavenoise(GetFracDef(0), 0.4, p)*dunes_octavenoise(GetFracDef(2), 0.4, p) + 0.1*dunes_octavenoise(GetFracDef(1), 0.5, p)
+#define sand2  dunes_octavenoise(GetFracDef(0), 0.6, p)*octavenoise(GetFracDef(4), 0.6, p)
+#define sand3  dunes_octavenoise(GetFracDef(2), 0.6, p)*dunes_octavenoise(GetFracDef(6), 0.6, p)
+#define grass  billow_octavenoise(GetFracDef(1), 0.8, p)
+#define grass2 billow_octavenoise(GetFracDef(3), 0.6, p)*voronoiscam_octavenoise(GetFracDef(4), 0.6, p)*river_octavenoise(GetFracDef(5), 0.6, p)
+#define forest octavenoise(GetFracDef(1), 0.65, p)*voronoiscam_octavenoise(GetFracDef(2), 0.65, p)
+#define water  dunes_octavenoise(GetFracDef(6), 0.6, p)
+
 
 #endif


### PR DESCRIPTION
Minor optimisation which reduces the _decrease_ in performance when fractal textures are enabled. It affects terrain with EarthLike and TFPoor colours. 

As I discussed with @s20dan a while back (calculating fractal textures only as needed by each point) ..

**Results:**
Fractal detail very high (important), detail distance very high (shouldn't matter but makes generation take a long time so observing is easier), observed on the landing pad on Earth, release mode on msvc.

Vtx/sec counts:

```
Without optimisation: Without textures: ~88k With textures: ~69k
With optimisation: Without textures: ~88k With textures: ~83k
```
