### PR TITLE
Specify the size of the mission list container properly

### DIFF
--- a/src/InfoView.cpp
+++ b/src/InfoView.cpp
@@ -64,7 +64,7 @@ public:
 		scroll->SetAdjustment(&portal->vscrollAdjust);
 
 		const std::list<const Mission*> &missions = Pi::player->missions.GetAll();
-		Gui::Fixed *innerbox = new Gui::Fixed(760, missions.size());
+		Gui::Fixed *innerbox = new Gui::Fixed(760, YSEP*3*missions.size());
 
 		float ypos = 0;
 		for (std::list<const Mission*>::const_iterator i = missions.begin(); i != missions.end(); ++i) {


### PR DESCRIPTION
Fixes #1291.

The inner container viewed through the VScollPortal was the wrong size so the scroll portal thought it fit inside the viewable area even when its content actually extended beyond that.
