### PR TITLE
Character rand seed

### DIFF
--- a/data/libs/Characters.lua
+++ b/data/libs/Characters.lua
@@ -421,7 +421,7 @@ Character = {
 		setmetatable(newCharacter,Character.meta)
 		-- initialize face characteristics if they weren't fully specified
 		if newCharacter.female == nil then newCharacter.female = (rand:Integer(1) ==1) end
-		newCharacter.name = newCharacter.name or NameGen.FullName(newCharacter.female)
+		newCharacter.name = newCharacter.name or NameGen.FullName(newCharacter.female,rand)
 		newCharacter.seed = newCharacter.seed or rand:Integer()
 		newCharacter.armour = newCharacter.armour or false
 		newCharacter.player = false -- Explicitly set this, if you need it.


### PR DESCRIPTION
This allows a developer to write a script that uses a Character which is not persistent (in that it's not stored in the PersistentCharacters table) but which is always the same, by providing the constructor with a custom random generator.

The need for this was discovered when I altered the Goods Traders script to use the Character class. The names and faces there are not characters with any great deal of interaction. The advantages of the Character class (consistent name/gender, ease of creation) were still desirable, but having a different face and name each time was not.
