### PR TITLE
Lua console print improvements

### DIFF
--- a/src/LuaConsole.cpp
+++ b/src/LuaConsole.cpp
@@ -313,6 +313,17 @@ void LuaConsole::ExecOrContinue() {
 	} else if (result == LUA_ERRMEM) {
 		AddOutput("memory allocation failure");
 	} else {
+		std::istringstream stmt_stream(stmt);
+		std::string string_buffer;
+
+		std::getline(stmt_stream, string_buffer);
+		AddOutput("> " + string_buffer);
+
+		while(!stmt_stream.eof()) {
+			std::getline(stmt_stream, string_buffer);
+			AddOutput("  " + string_buffer);
+		}
+
 		int nresults = lua_gettop(L) - top;
 		if (nresults) {
 			std::ostringstream ss;


### PR DESCRIPTION
With those two commits, the Pioneer Lua Console will lose its current status of "barely usable hack" to gain the prestigious ranks of the "nobody uses it but at least it looks nice" :-).

The first commit automatically output the result of the statement if it is an expression. No more "F*ck, I forgot the print !".

The second one gives some context to all those new shiny printouts by outputing every successful statement prefixed by > for the first line of the statement and simply indented for the remaining lines.

Tests, criticisms and praises are most welcome.
