### PR TITLE
Output console command before its execution

### DIFF
--- a/src/LuaConsole.cpp
+++ b/src/LuaConsole.cpp
@@ -298,6 +298,17 @@ void LuaConsole::ExecOrContinue() {
 		return;
 	}
 
+	std::istringstream stmt_stream(stmt);
+	std::string string_buffer;
+
+	std::getline(stmt_stream, string_buffer);
+	AddOutput("> " + string_buffer);
+
+	while(!stmt_stream.eof()) {
+		std::getline(stmt_stream, string_buffer);
+		AddOutput("  " + string_buffer);
+	}
+
 	// perform a protected call
 	int top = lua_gettop(L) - 1; // -1 for the chunk itself
 	result = lua_pcall(L, 0, LUA_MULTRET, 0);
@@ -313,17 +324,6 @@ void LuaConsole::ExecOrContinue() {
 	} else if (result == LUA_ERRMEM) {
 		AddOutput("memory allocation failure");
 	} else {
-		std::istringstream stmt_stream(stmt);
-		std::string string_buffer;
-
-		std::getline(stmt_stream, string_buffer);
-		AddOutput("> " + string_buffer);
-
-		while(!stmt_stream.eof()) {
-			std::getline(stmt_stream, string_buffer);
-			AddOutput("  " + string_buffer);
-		}
-
 		int nresults = lua_gettop(L) - top;
 		if (nresults) {
 			std::ostringstream ss;


### PR DESCRIPTION
In the previous code, anything printed within the Lua code would be
printed before the command. Also, the command would not be printed in
case of runtime error, while it is still a valid command, which is
semantically wrong.

Example:

> function bogus () print('test') end
> test
> bogus() -- the print is executed before outputting the command

This patch moves the command printing right before the command
execution, but still after the parsing.
