### PR TITLE
Make ring shadows visible

### DIFF
--- a/data/shaders/planetrings.frag.glsl
+++ b/data/shaders/planetrings.frag.glsl
@@ -2,7 +2,7 @@
 void main(void)
 {
 	// Bits of ring in shadow!
-	vec4 col = vec4(0.0);
+	vec4 col = gl_Color * 0.3;
 
 	for (int i=0; i<NUM_LIGHTS; ++i) {
 		float l = findSphereEyeRayEntryDistance(-vec3(gl_TexCoord[0]), vec3(gl_ModelViewMatrixInverse * gl_LightSource[i].position), 1.0);


### PR DESCRIPTION
Currently they look like a giant chunk has been chopped out of it. Now they appear, just darker.

![](http://i.imgur.com/wG3TF.png)

No idea if its a) realistic or b) implemented sanely (shaders are still deeply magical to me). It looks nice in my eyes at least :)
