### PR TITLE
Fix luaL_error format code use in LuaObject

### DIFF
--- a/src/LuaObject.cpp
+++ b/src/LuaObject.cpp
@@ -159,6 +159,8 @@ int LuaObjectBase::l_isa(lua_State *l)
 
 	LuaObjectBase *lo = Lookup(*idp);
 	if (!lo) {
+		// luaL_error format codes are very limited (can't handle width or fill specifiers),
+		// so we use snprintf here to do the real formatting
 		char objectCode[16];
 		snprintf(objectCode, sizeof(objectCode), "0x%08x", *idp);
 		luaL_error(l, "Lua object with id %s not found in registry", objectCode);
@@ -546,6 +548,8 @@ DeleteEmitter *LuaObjectBase::GetFromLua(int index, const char *type)
 
 	LuaObjectBase *lo = LuaObjectBase::Lookup(*idp);
 	if (!lo) {
+		// luaL_error format codes are very limited (can't handle width or fill specifiers),
+		// so we use snprintf here to do the real formatting
 		char objectCode[16];
 		snprintf(objectCode, sizeof(objectCode), "0x%08x", *idp);
 		luaL_error(l, "Lua object with id %s not found in registry", objectCode);


### PR DESCRIPTION
luaL_error only supports very simple format codes, and LuaObject contained some error handling code that tried to use an unsupported format code. This resulted in a rather unhelpful error message in some circumstances.

Found and diagnosed in #1348.
