### PR TITLE
Dump OpenGL implementation limits

### DIFF
--- a/src/graphics/RendererLegacy.cpp
+++ b/src/graphics/RendererLegacy.cpp
@@ -673,6 +673,29 @@ void RendererLegacy::PopState()
 	glPopMatrix();
 }
 
+static void dump_opengl_value(std::ostream &out, const char *name, GLenum id, int num_elems)
+{
+	assert(num_elems > 0 && num_elems <= 4);
+	assert(name);
+
+	GLdouble e[4];
+	glGetDoublev(id, e);
+
+	GLenum err = glGetError();
+	if (err == GL_NO_ERROR) {
+		out << name << " = " << e[0];
+		for (int i = 1; i < num_elems; ++i)
+			out << ", " << e[i];
+		out << "\n";
+	} else {
+		while (err != GL_NO_ERROR) {
+			if (err == GL_INVALID_ENUM) { out << name << " -- not supported\n"; }
+			else { out << name << " -- unexpected error (" << err << ") retrieving value\n"; }
+			err = glGetError();
+		}
+	}
+}
+
 bool RendererLegacy::PrintDebugInfo(std::ostream &out)
 {
 	out << "OpenGL version " << glGetString(GL_VERSION);
@@ -695,6 +718,49 @@ bool RendererLegacy::PrintDebugInfo(std::ostream &out)
 			std::istream_iterator<std::string>(),
 			std::ostream_iterator<std::string>(out, "\n  "));
 	}
+
+	out << "\nImplementation Limits:\n";
+
+	// first, clear all OpenGL error flags
+	while (glGetError() != GL_NO_ERROR) {}
+
+#define DUMP_GL_VALUE(name) dump_opengl_value(out, #name, name, 1)
+#define DUMP_GL_VALUE2(name) dump_opengl_value(out, #name, name, 2)
+
+	DUMP_GL_VALUE(GL_MAX_3D_TEXTURE_SIZE);
+	DUMP_GL_VALUE(GL_MAX_CLIENT_ATTRIB_STACK_DEPTH);
+	DUMP_GL_VALUE(GL_MAX_ATTRIB_STACK_DEPTH);
+	DUMP_GL_VALUE(GL_MAX_CLIP_PLANES);
+	DUMP_GL_VALUE(GL_MAX_COLOR_MATRIX_STACK_DEPTH);
+	DUMP_GL_VALUE(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS);
+	DUMP_GL_VALUE(GL_MAX_CUBE_MAP_TEXTURE_SIZE);
+	DUMP_GL_VALUE(GL_MAX_DRAW_BUFFERS);
+	DUMP_GL_VALUE(GL_MAX_ELEMENTS_INDICES);
+	DUMP_GL_VALUE(GL_MAX_ELEMENTS_VERTICES);
+	DUMP_GL_VALUE(GL_MAX_EVAL_ORDER);
+	DUMP_GL_VALUE(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS);
+	DUMP_GL_VALUE(GL_MAX_LIGHTS);
+	DUMP_GL_VALUE(GL_MAX_LIST_NESTING);
+	DUMP_GL_VALUE(GL_MAX_MODELVIEW_STACK_DEPTH);
+	DUMP_GL_VALUE(GL_MAX_NAME_STACK_DEPTH);
+	DUMP_GL_VALUE(GL_MAX_PIXEL_MAP_TABLE);
+	DUMP_GL_VALUE(GL_MAX_PROJECTION_STACK_DEPTH);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_COORDS);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_IMAGE_UNITS);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_LOD_BIAS);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_SIZE);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_STACK_DEPTH);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_UNITS);
+	DUMP_GL_VALUE(GL_MAX_VARYING_FLOATS);
+	DUMP_GL_VALUE(GL_MAX_VERTEX_ATTRIBS);
+	DUMP_GL_VALUE(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS);
+	DUMP_GL_VALUE(GL_MAX_VERTEX_UNIFORM_COMPONENTS);
+	DUMP_GL_VALUE2(GL_MAX_VIEWPORT_DIMS);
+	DUMP_GL_VALUE(GL_NUM_COMPRESSED_TEXTURE_FORMATS);
+	DUMP_GL_VALUE2(GL_POINT_SIZE_RANGE);
+
+#undef DUMP_GL_VALUE
+#undef DUMP_GL_VALUE2
 
 	return true;
 }


### PR DESCRIPTION
This extends the OpenGL info that is dumped on program start-up to include various numeric limits (e.g., max texture size, max varying floats for fragment shaders, max fragment shader uniforms, max vertex attributes).

I'm not sure that it dumps every limit we can get access to. Limits that are unknown (e.g., shader limits on a system without shaders) should just be listed as such without any ill-effect, but this needs testing.
