### PR TITLE
Fix the outer radius of Saturn's rings

### DIFF
--- a/data/systems/00_sol.lua
+++ b/data/systems/00_sol.lua
@@ -266,7 +266,7 @@ local saturn = CustomSystemBody:new('Saturn', 'PLANET_GAS_GIANT')
 	:inclination(math.deg2rad(2.485))
 	:rotation_period(f(4,10))
 	:axial_tilt(fixed.deg2rad(f(2673,100)))
-	:rings(f(1298,1000), f(18,10), {0.435, 0.412, 0.335, 0.9})
+	:rings(f(1298,1000), f(2383,1000), {0.435, 0.412, 0.335, 0.9})
 
 local saturn_moons = {
 	CustomSystemBody:new('Dione', 'PLANET_TERRESTRIAL')


### PR DESCRIPTION
This increases the outer radius of Saturn's rings to be closer to reality (specifically, closer to the outer radius of Saturn's 'A' ring). Unfortunately the ring fractal produces several large-ish gaps in Saturn's rings, but I'd prefer that to be fixed properly (probably by loading a ring slice texture) rather than hacking in an adjustment to the fractal.
