### PR TITLE
Catalan translation extra lines, and missing string.

### DIFF
--- a/data/lang/Catala.txt
+++ b/data/lang/Catala.txt
@@ -82,7 +82,7 @@ CAPACITY
 FORWARD_ACCEL_EMPTY
     Acceleració davantera (buit)
 NUMBER_G
-    %acceleració{f.1} G
+    %acceleration{f.1} G
 FORWARD_ACCEL_LADEN
     Acceleració davantera (amb càrrega)
 REVERSE_ACCEL_EMPTY


### PR DESCRIPTION
Missed a string and deleted two extra lines that would show up as warnings when starting Pioneer from command line.
