### PR TITLE
Clamp planetary mass value into range representable by `fixed`

### DIFF
--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -1637,6 +1637,11 @@ void StarSystem::MakePlanetsAround(SystemBody *primary, MTRand &rand)
 			mass = mass_from_disk_area(a, b, discMax);
 			mass *= rand.Fixed() * discDensity;
 		}
+		if (mass < 0) {// hack around overflow
+			fprintf(stderr, "WARNING: planetary mass has overflowed! (child of %s)\n", primary->name.c_str());
+			mass = fixed(Sint64(0x7fFFffFFffFFffFFull));
+		}
+		assert(mass >= 0);
 
 		SystemBody *planet = NewBody();
 		planet->eccentricity = ecc;


### PR DESCRIPTION
Fixes #854, based on testing with [Brianetta's test system](https://gist.github.com/1499081).

The hang was an infinite loop in `TerrainBody::render`, which was a symptom of nan values creeping into the system. That nan was being generated as a result of a systembody having a negative mass, which was produced by the fixed-point planetary mass computation in `MakePlanetsAround` overflowing.

It would be a good idea to add some more comprehensive asserts to other fixed-point calculations to check for range problems (possibly put asserts in the `fixed` implementation itself). If this is merged before I get round to that, it would be good to add a TODO issue for it.
