### PR TITLE
Fix unpickle's interpretation of unsigned 32-bit values

### DIFF
--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -304,11 +304,11 @@ const char *LuaSerializer::unpickle(lua_State *l, const char *pos)
 				if (pos == end) throw SavedGameCorruptException();
 				pos = end+1; // skip newline
 
-				Sint32 systemNum = strtol(pos, const_cast<char**>(&end), 0);
+				Uint32 systemNum = strtoul(pos, const_cast<char**>(&end), 0);
 				if (pos == end) throw SavedGameCorruptException();
 				pos = end+1; // skip newline
 
-				Sint32 sbodyId = strtol(pos, const_cast<char**>(&end), 0);
+				Uint32 sbodyId = strtoul(pos, const_cast<char**>(&end), 0);
 				if (pos == end) throw SavedGameCorruptException();
 				pos = end+1; // skip newline
 
@@ -321,7 +321,7 @@ const char *LuaSerializer::unpickle(lua_State *l, const char *pos)
 			if (len == 4 && strncmp(pos, "Body", 4) == 0) {
 				pos = end;
 
-				int n = strtol(pos, const_cast<char**>(&end), 0);
+				Uint32 n = strtoul(pos, const_cast<char**>(&end), 0);
 				if (pos == end) throw SavedGameCorruptException();
 				pos = end+1; // skip newline
 


### PR DESCRIPTION
Fixes #1412. Problem and fix discussed in #1424.

This changes `LuaSerializer::unpickle` to use `strtoul` to read values written by `printf(...%u...)`. An alternate fix (implemented in #1424) is to change `pickle` to write out values with `%d` instead.

In either case, saves that loaded correctly in the past should load correctly now. Changing unpickle means that saves written in the past that caused a crash on load may now load correctly.
