### PR TITLE
Include frame time in milliseconds in the stats overlay

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1283,9 +1283,9 @@ void Pi::MainLoop()
 
 			snprintf(
 				fps_readout, sizeof(fps_readout),
-				"%d fps, %d phys updates, %d triangles, %.3f M tris/sec, %d terrain vtx/sec, %d glyphs/sec\n"
+				"%d fps (%.1f ms/f), %d phys updates, %d triangles, %.3f M tris/sec, %d terrain vtx/sec, %d glyphs/sec\n"
 				"Lua mem usage: %d MB + %d KB + %d bytes",
-				frame_stat, phys_stat, Pi::statSceneTris, Pi::statSceneTris*frame_stat*1e-6,
+				frame_stat, (1000.0/frame_stat), phys_stat, Pi::statSceneTris, Pi::statSceneTris*frame_stat*1e-6,
 				GeoSphere::GetVtxGenCount(), Text::TextureFont::GetGlyphCount(),
 				lua_memMB, lua_memKB, lua_memB
 			);


### PR DESCRIPTION
This does the crappy thing of taking the FPS value and turning it into processing time in ms (1000/fps). Eventually it would be nice to have actual profiling information displayed, so we could see how much time is being spent on different things.
