### PR TITLE
Switch to a different COUNTOF macro to avoid strict-aliasing warnings

### DIFF
--- a/src/libs.h
+++ b/src/libs.h
@@ -86,20 +86,10 @@ inline float  DEG2RAD(float  x) { return x*(float(M_PI)/180.f); }
 
 // --- typesafe compile time array length
 // by Ivan J. Johnson
-// http://www.drdobbs.com/cpp/counting-array-elements-at-compile-time/197800525
-class Bad_arg_to_COUNTOF
-{
-public:
-   class Is_pointer;  // intentionally incomplete type
-   class Is_array {};
-   template<typename T>
-   static Is_pointer check_type(const T*, const T* const*);
-   static Is_array check_type(const void*, const void*);
-};
-
-#define COUNTOF(x) \
-  ( 0 * sizeof( reinterpret_cast<const ::Bad_arg_to_COUNTOF*>(x) ) \
-  + 0 * sizeof( ::Bad_arg_to_COUNTOF::check_type((x), &(x))      ) \
-  + sizeof(x) / sizeof((x)[0]) )
+// from StackOverflow: http://stackoverflow.com/a/1500517/52251
+// Q: "Compile time sizeof_array without using a macro"
+template <typename T, size_t N>
+char ( &COUNTOF_Helper( T (&array)[N] ))[N];
+#define COUNTOF( array ) (sizeof( COUNTOF_Helper( array ) ))
 
 #endif /* _LIBS_H */


### PR DESCRIPTION
Fixes #1450.

Previous COUNTOF macro produces strict aliasing warnings because it does some pointer casting. Those warnings are erroneous, because that pointer casting happens inside sizeof() where nothing will be dereferenced.

This version has the advantage of looking a bit simpler and not producing warnings. It won't work for types defined inside functions, but we probably won't need that.
