### PR TITLE
Fix the virtual screen size of control panel icons

### DIFF
--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -25,10 +25,12 @@ GalacticView::GalacticView() :
 
 	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
 	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
+	m_zoomInButton->SetRenderDimensions(30, 22);
 	Add(m_zoomInButton, 700, 5);
 
 	m_zoomOutButton = new Gui::ImageButton("icons/zoom_out.png");
 	m_zoomOutButton->SetToolTip(Lang::ZOOM_OUT);
+	m_zoomOutButton->SetRenderDimensions(30, 22);
 	Add(m_zoomOutButton, 732, 5);
 
 	m_scaleReadout = new Gui::Label("");

--- a/src/GameMenuView.h
+++ b/src/GameMenuView.h
@@ -20,6 +20,7 @@ class VolumeControl : public Gui::HBox
 			m_muteButton->AddState(0, "icons/volume_unmuted.png", "Mute");
 			m_muteButton->AddState(1, "icons/volume_muted.png", "Unmute");
 			m_muteButton->SetActiveState(muted ? 1 : 0);
+			m_muteButton->SetRenderDimensions(32, 32);
 			PackEnd(m_muteButton);
 			m_adjustment = new Gui::Adjustment();
 			m_adjustment->SetValue(volume);

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -97,10 +97,12 @@ void SectorView::InitObject()
 
 	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
 	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
+	m_zoomInButton->SetRenderDimensions(30, 22);
 	Add(m_zoomInButton, 700, 5);
 
 	m_zoomOutButton = new Gui::ImageButton("icons/zoom_out.png");
 	m_zoomOutButton->SetToolTip(Lang::ZOOM_OUT);
+	m_zoomOutButton->SetRenderDimensions(30, 22);
 	Add(m_zoomOutButton, 732, 5);
 
 	Add(new Gui::Label(Lang::SEARCH), 650, 500);

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -54,6 +54,7 @@ void ShipCpanel::InitObject()
 	SetTransparency(true);
 
 	Gui::Image *img = new Gui::Image("icons/cpanel.png");
+	img->SetRenderDimensions(800, 80);
 	Add(img, 0, 0);
 
 	m_currentMapView = MAP_SECTOR;
@@ -80,6 +81,7 @@ void ShipCpanel::InitObject()
 	Gui::ImageRadioButton *b = new Gui::ImageRadioButton(0, "icons/timeaccel0.png", "icons/timeaccel0_on.png");
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnClickTimeaccel), Game::TIMEACCEL_PAUSED));
 	b->SetShortcut(SDLK_ESCAPE, KMOD_LSHIFT);
+	b->SetRenderDimensions(22, 18);
 	Add(b, 0, 36);
 	m_timeAccelButtons[0] = b;
 
@@ -87,30 +89,35 @@ void ShipCpanel::InitObject()
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnClickTimeaccel), Game::TIMEACCEL_1X));
 	b->SetShortcut(SDLK_F1, KMOD_LSHIFT);
 	b->SetSelected(true);
+	b->SetRenderDimensions(22, 18);
 	Add(b, 22, 36);
 	m_timeAccelButtons[1] = b;
 
 	b = new Gui::ImageRadioButton(0, "icons/timeaccel2.png", "icons/timeaccel2_on.png");
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnClickTimeaccel), Game::TIMEACCEL_10X));
 	b->SetShortcut(SDLK_F2, KMOD_LSHIFT);
+	b->SetRenderDimensions(22, 18);
 	Add(b, 44, 36);
 	m_timeAccelButtons[2] = b;
 
 	b = new Gui::ImageRadioButton(0, "icons/timeaccel3.png", "icons/timeaccel3_on.png");
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnClickTimeaccel), Game::TIMEACCEL_100X));
 	b->SetShortcut(SDLK_F3, KMOD_LSHIFT);
+	b->SetRenderDimensions(22, 18);
 	Add(b, 66, 36);
 	m_timeAccelButtons[3] = b;
 
 	b = new Gui::ImageRadioButton(0, "icons/timeaccel4.png", "icons/timeaccel4_on.png");
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnClickTimeaccel), Game::TIMEACCEL_1000X));
 	b->SetShortcut(SDLK_F4, KMOD_LSHIFT);
+	b->SetRenderDimensions(22, 18);
 	Add(b, 88, 36);
 	m_timeAccelButtons[4] = b;
 
 	b = new Gui::ImageRadioButton(0, "icons/timeaccel5.png", "icons/timeaccel5_on.png");
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnClickTimeaccel), Game::TIMEACCEL_10000X));
 	b->SetShortcut(SDLK_F5, KMOD_LSHIFT);
+	b->SetRenderDimensions(22, 18);
 	Add(b, 110, 36);
 	m_timeAccelButtons[5] = b;
 
@@ -124,6 +131,7 @@ void ShipCpanel::InitObject()
 	m_camButton->AddState(WorldView::CAM_SIDEREAL, "icons/cam_sidereal.png", "icons/cam_sidereal_on.png", Lang::SIDEREAL_VIEW);
 	m_camButton->SetShortcut(SDLK_F1, KMOD_NONE);
 	m_camButton->onClick.connect(sigc::mem_fun(this, &ShipCpanel::OnChangeCamView));
+	m_camButton->SetRenderDimensions(30, 22);
 	Add(m_camButton, 2, 56);
 
 	Gui::MultiStateImageButton *map_button = new Gui::MultiStateImageButton();
@@ -132,6 +140,7 @@ void ShipCpanel::InitObject()
 	map_button->SetShortcut(SDLK_F2, KMOD_NONE);
 	map_button->AddState(0, "icons/cpan_f2_map.png", "icons/cpan_f2_map_on.png", Lang::NAVIGATION_STAR_MAPS);
 	map_button->onClick.connect(sigc::mem_fun(this, &ShipCpanel::OnChangeToMapView));
+	map_button->SetRenderDimensions(30, 22);
 	Add(map_button, 34, 56);
 
 	Gui::MultiStateImageButton *info_button = new Gui::MultiStateImageButton();
@@ -140,6 +149,7 @@ void ShipCpanel::InitObject()
 	info_button->SetShortcut(SDLK_F3, KMOD_NONE);
 	info_button->AddState(0, "icons/cpan_f3_shipinfo.png", "icons/cpan_f3_shipinfo_on.png", Lang::SHIP_INFORMATION);
 	info_button->onClick.connect(sigc::mem_fun(this, &ShipCpanel::OnChangeInfoView));
+	info_button->SetRenderDimensions(30, 22);
 	Add(info_button, 66, 56);
 
 	Gui::MultiStateImageButton *comms_button = new Gui::MultiStateImageButton();
@@ -148,6 +158,7 @@ void ShipCpanel::InitObject()
 	comms_button->SetShortcut(SDLK_F4, KMOD_NONE);
 	comms_button->AddState(0, "icons/comms_f4.png", "icons/comms_f4_on.png", Lang::COMMS);
 	comms_button->onClick.connect(sigc::mem_fun(this, &ShipCpanel::OnClickComms));
+	comms_button->SetRenderDimensions(30, 22);
 	Add(comms_button, 98, 56);
 
 	m_clock = (new Gui::Label(""))->Color(1.0f,0.7f,0.0f);
@@ -159,37 +170,44 @@ void ShipCpanel::InitObject()
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnChangeMapView), MAP_SECTOR));
 	b->SetShortcut(SDLK_F5, KMOD_NONE);
 	b->SetToolTip(Lang::GALAXY_SECTOR_VIEW);
+	b->SetRenderDimensions(30, 22);
 	Add(b, 674, 56);
 	m_mapViewButtons[0] = b;
 	b = new Gui::ImageRadioButton(m_rightButtonGroup, "icons/map_system_view.png", "icons/map_system_view_on.png");
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnChangeMapView), MAP_SYSTEM));
 	b->SetShortcut(SDLK_F6, KMOD_NONE);
 	b->SetToolTip(Lang::SYSTEM_ORBIT_VIEW);
+	b->SetRenderDimensions(30, 22);
 	Add(b, 706, 56);
 	m_mapViewButtons[1] = b;
 	b = new Gui::ImageRadioButton(m_rightButtonGroup, "icons/map_sysinfo_view.png", "icons/map_sysinfo_view_on.png");
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnChangeMapView), MAP_INFO));
 	b->SetShortcut(SDLK_F7, KMOD_NONE);
 	b->SetToolTip(Lang::STAR_SYSTEM_INFORMATION);
+	b->SetRenderDimensions(30, 22);
 	Add(b, 738, 56);
 	m_mapViewButtons[2] = b;
 	b = new Gui::ImageRadioButton(m_rightButtonGroup, "icons/map_galactic_view.png", "icons/map_galactic_view_on.png");
 	b->onSelect.connect(sigc::bind(sigc::mem_fun(this, &ShipCpanel::OnChangeMapView), MAP_GALACTIC));
 	b->SetShortcut(SDLK_F8, KMOD_NONE);
 	b->SetToolTip(Lang::GALACTIC_VIEW);
+	b->SetRenderDimensions(30, 22);
 	Add(b, 770, 56);
 	m_mapViewButtons[3] = b;
 
 	img = new Gui::Image("icons/alert_green.png");
 	img->SetToolTip(Lang::NO_ALERT);
+	img->SetRenderDimensions(20, 13);
 	Add(img, 780, 37);
 	m_alertLights[0] = img;
 	img = new Gui::Image("icons/alert_yellow.png");
 	img->SetToolTip(Lang::SHIP_NEARBY);
+	img->SetRenderDimensions(20, 13);
 	Add(img, 780, 37);
 	m_alertLights[1] = img;
 	img = new Gui::Image("icons/alert_red.png");
 	img->SetToolTip(Lang::LASER_FIRE_DETECTED);
+	img->SetRenderDimensions(20, 13);
 	Add(img, 780, 37);
 	m_alertLights[2] = img;
 

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -551,7 +551,7 @@ void UseEquipWidget::UpdateEquip()
 			const Equip::Type t = Pi::player->m_equipment.Get(Equip::SLOT_MISSILE, i);
 			if (t == Equip::NONE) continue;
 
-			Gui::Button *b;
+			Gui::ImageButton *b;
 			switch (t) {
 				case Equip::MISSILE_UNGUIDED:
 					b = new Gui::ImageButton("icons/missile_unguided.png");
@@ -570,18 +570,20 @@ void UseEquipWidget::UpdateEquip()
 			Add(b, spacing * i, 40);
 			b->onClick.connect(sigc::bind(sigc::mem_fun(this, &UseEquipWidget::FireMissile), i));
 			b->SetToolTip(Equip::types[t].name);
+			b->SetRenderDimensions(16, 16);
 		}
 	}
 
 	{
 		const Equip::Type t = Pi::player->m_equipment.Get(Equip::SLOT_ECM);
 		if (t != Equip::NONE) {
-			Gui::Button *b = 0;
+			Gui::ImageButton *b = 0;
 			if (t == Equip::ECM_BASIC) b = new Gui::ImageButton("icons/ecm_basic.png");
 			else if (t == Equip::ECM_ADVANCED) b = new Gui::ImageButton("icons/ecm_advanced.png");
 			assert(b);
 
 			b->onClick.connect(sigc::mem_fun(Pi::player, &Ship::UseECM));
+			b->SetRenderDimensions(32, 32);
 
 			Add(b, 32, 0);
 		}
@@ -600,14 +602,17 @@ MultiFuncSelectorWidget::MultiFuncSelectorWidget(): Gui::Fixed(144, 17)
 	m_buttons[0]->onSelect.connect(sigc::bind(sigc::mem_fun(this, &MultiFuncSelectorWidget::OnClickButton), MFUNC_SCANNER));
 	m_buttons[0]->SetShortcut(SDLK_F9, KMOD_NONE);
 	m_buttons[0]->SetSelected(true);
+	m_buttons[0]->SetRenderDimensions(34, 17);
 
 	m_buttons[1] = new Gui::ImageRadioButton(m_rg, "icons/multifunc_equip.png", "icons/multifunc_equip_on.png");
 	m_buttons[1]->onSelect.connect(sigc::bind(sigc::mem_fun(this, &MultiFuncSelectorWidget::OnClickButton), MFUNC_EQUIPMENT));
 	m_buttons[1]->SetShortcut(SDLK_F10, KMOD_NONE);
+	m_buttons[1]->SetRenderDimensions(34, 17);
 
 	m_buttons[2] = new Gui::ImageRadioButton(m_rg, "icons/multifunc_msglog.png", "icons/multifunc_msglog_on.png");
 	m_buttons[2]->onSelect.connect(sigc::bind(sigc::mem_fun(this, &MultiFuncSelectorWidget::OnClickButton), MFUNC_MSGLOG));
 	m_buttons[2]->SetShortcut(SDLK_F11, KMOD_NONE);
+	m_buttons[2]->SetRenderDimensions(34, 17);
 
 	UpdateButtons();
 

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -35,40 +35,48 @@ SystemView::SystemView()
 
 	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
 	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
+	m_zoomInButton->SetRenderDimensions(30, 22);
 	Add(m_zoomInButton, 700, 5);
 
 	m_zoomOutButton = new Gui::ImageButton("icons/zoom_out.png");
 	m_zoomOutButton->SetToolTip(Lang::ZOOM_OUT);
+	m_zoomOutButton->SetRenderDimensions(30, 22);
 	Add(m_zoomOutButton, 732, 5);
 
 	Gui::ImageButton *b = new Gui::ImageButton("icons/sysview_accel_r3.png", "icons/sysview_accel_r3_on.png");
 	b->onPress.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), -10000000.f));
 	b->onRelease.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 0.0f));
+	b->SetRenderDimensions(19, 17);
 	m_rightRegion2->Add(b, 0, 0);
 
 	b = new Gui::ImageButton("icons/sysview_accel_r2.png", "icons/sysview_accel_r2_on.png");
 	b->onPress.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), -1000000.f));
 	b->onRelease.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 0.0f));
+	b->SetRenderDimensions(19, 17);
 	m_rightRegion2->Add(b, 26, 0);
 
 	b = new Gui::ImageButton("icons/sysview_accel_r1.png", "icons/sysview_accel_r1_on.png");
 	b->onPress.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), -100000.f));
 	b->onRelease.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 0.0f));
+	b->SetRenderDimensions(19, 17);
 	m_rightRegion2->Add(b, 45, 0);
 
 	b = new Gui::ImageButton("icons/sysview_accel_f1.png", "icons/sysview_accel_f1_on.png");
 	b->onPress.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 100000.f));
 	b->onRelease.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 0.0f));
+	b->SetRenderDimensions(19, 17);
 	m_rightRegion2->Add(b, 64, 0);
 
 	b = new Gui::ImageButton("icons/sysview_accel_f2.png", "icons/sysview_accel_f2_on.png");
 	b->onPress.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 1000000.f));
 	b->onRelease.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 0.0f));
+	b->SetRenderDimensions(19, 17);
 	m_rightRegion2->Add(b, 83, 0);
 
 	b = new Gui::ImageButton("icons/sysview_accel_f3.png", "icons/sysview_accel_f3_on.png");
 	b->onPress.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 10000000.f));
 	b->onRelease.connect(sigc::bind(sigc::mem_fun(this, &SystemView::OnClickAccel), 0.0f));
+	b->SetRenderDimensions(19, 17);
 	m_rightRegion2->Add(b, 102, 0);
 
 	m_onMouseButtonDown =

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -104,24 +104,28 @@ void WorldView::InitObject()
 	m_wheelsButton->AddState(0, "icons/wheels_up.png", Lang::WHEELS_ARE_UP);
 	m_wheelsButton->AddState(1, "icons/wheels_down.png", Lang::WHEELS_ARE_DOWN);
 	m_wheelsButton->onClick.connect(sigc::mem_fun(this, &WorldView::OnChangeWheelsState));
+	m_wheelsButton->SetRenderDimensions(30.0f, 22.0f);
 	m_rightButtonBar->Add(m_wheelsButton, 34, 2);
 
 	Gui::ImageButton *set_low_thrust_power_button = new Gui::ImageButton("icons/set_low_thrust_power.png");
 	set_low_thrust_power_button->SetShortcut(SDLK_F8, KMOD_NONE);
 	set_low_thrust_power_button->SetToolTip(Lang::SELECT_LOW_THRUST_POWER_LEVEL);
 	set_low_thrust_power_button->onClick.connect(sigc::mem_fun(this, &WorldView::OnClickLowThrustPower));
+	set_low_thrust_power_button->SetRenderDimensions(30.0f, 22.0f);
 	m_rightButtonBar->Add(set_low_thrust_power_button, 98, 2);
 
 	m_hyperspaceButton = new Gui::ImageButton("icons/hyperspace_f8.png");
 	m_hyperspaceButton->SetShortcut(SDLK_F7, KMOD_NONE);
 	m_hyperspaceButton->SetToolTip(Lang::HYPERSPACE_JUMP);
 	m_hyperspaceButton->onClick.connect(sigc::mem_fun(this, &WorldView::OnClickHyperspace));
+	m_hyperspaceButton->SetRenderDimensions(30.0f, 22.0f);
 	m_rightButtonBar->Add(m_hyperspaceButton, 66, 2);
 
 	m_launchButton = new Gui::ImageButton("icons/blastoff.png");
 	m_launchButton->SetShortcut(SDLK_F5, KMOD_NONE);
 	m_launchButton->SetToolTip(Lang::TAKEOFF);
 	m_launchButton->onClick.connect(sigc::mem_fun(this, &WorldView::OnClickBlastoff));
+	m_launchButton->SetRenderDimensions(30.0f, 22.0f);
 	m_rightButtonBar->Add(m_launchButton, 2, 2);
 
 	m_flightControlButton = new Gui::MultiStateImageButton();
@@ -133,6 +137,7 @@ void WorldView::InitObject()
 	m_flightControlButton->AddState(CONTROL_FIXHEADING_BACKWARD, "icons/manual_control.png", Lang::COMPUTER_HEADING_CONTROL);
 	m_flightControlButton->AddState(CONTROL_AUTOPILOT, "icons/autopilot.png", Lang::AUTOPILOT_ON);
 	m_flightControlButton->onClick.connect(sigc::mem_fun(this, &WorldView::OnChangeFlightState));
+	m_flightControlButton->SetRenderDimensions(30.0f, 22.0f);
 	m_rightButtonBar->Add(m_flightControlButton, 2, 2);
 
 	m_flightStatus = (new Gui::Label(""))->Color(1.0f, 0.7f, 0.0f);

--- a/src/gui/GuiImageButton.cpp
+++ b/src/gui/GuiImageButton.cpp
@@ -53,4 +53,10 @@ void ImageButton::Draw()
 	img->Draw();
 }
 
+void ImageButton::SetRenderDimensions(const float wide, const float high)
+{
+	if(m_imgNormal) {m_imgNormal->SetRenderDimensions(wide, high);}
+	if(m_imgPressed) {m_imgPressed->SetRenderDimensions(wide, high);}
+}
+
 }

--- a/src/gui/GuiImageButton.h
+++ b/src/gui/GuiImageButton.h
@@ -14,6 +14,7 @@ namespace Gui {
 		virtual void Draw();
 		virtual ~ImageButton();
 		virtual void GetSizeRequested(float size[2]);
+		void SetRenderDimensions(const float wide, const float high);
 	private:
 		void LoadImages(const char *img_normal, const char *img_pressed);
 		Image *m_imgNormal;

--- a/src/gui/GuiImageRadioButton.cpp
+++ b/src/gui/GuiImageRadioButton.cpp
@@ -33,4 +33,10 @@ void ImageRadioButton::Draw()
 	}
 }
 
+void ImageRadioButton::SetRenderDimensions(const float wide, const float high)
+{
+	if(m_imgPressed) {m_imgPressed->SetRenderDimensions(wide, high);}
+	if(m_imgNormal)  {m_imgNormal->SetRenderDimensions(wide, high);}
+}
+
 }

--- a/src/gui/GuiImageRadioButton.h
+++ b/src/gui/GuiImageRadioButton.h
@@ -13,6 +13,7 @@ namespace Gui {
 		virtual ~ImageRadioButton();
 		virtual void Draw();
 		virtual void GetSizeRequested(float size[2]);
+		void SetRenderDimensions(const float wide, const float high);
 	private:
 		Image *m_imgNormal;
 		Image *m_imgPressed;

--- a/src/gui/GuiMultiStateImageButton.cpp
+++ b/src/gui/GuiMultiStateImageButton.cpp
@@ -101,4 +101,12 @@ std::string MultiStateImageButton::GetOverrideTooltip()
 	return m_states[m_curState].tooltip;
 }
 
+void MultiStateImageButton::SetRenderDimensions(const float wide, const float high)
+{
+	for (std::vector<State>::iterator i = m_states.begin(); i != m_states.end(); ++i) {
+		if((*i).activeImage) {(*i).activeImage->SetRenderDimensions(wide, high);}
+		if((*i).inactiveImage) {(*i).inactiveImage->SetRenderDimensions(wide, high);}
+	}
+}
+
 }

--- a/src/gui/GuiMultiStateImageButton.h
+++ b/src/gui/GuiMultiStateImageButton.h
@@ -23,6 +23,7 @@ namespace Gui {
 		sigc::signal<void, MultiStateImageButton*> onClick;
 		virtual void SetSelected(bool state);
 		void SetActiveState(int state);
+		void SetRenderDimensions(const float wide, const float high);
 	protected:
 		virtual std::string GetOverrideTooltip();
 	private:


### PR DESCRIPTION
Adie123 asked me to fix the icon scaling for the control panel icons, I've done a little bit more than that, the control panel itself is now a fixed size (800, 80) too so it can be updated to a higher resolution image.

I've tested the changes (of course) and can't find any technical issue with them. Stylistically I considered adding the SetRenderDimensions method as a virtual too a class higher up the inheritance graph but I couldn't find a place I was actually happy with putting it!

Commit message:
Added SetRenderDimensions methods to GuiImageButton, GuiImageRadioButton, GuiMultiStateImageButton classes.
Used the above SetRenderDimensions methods to fix the size of icon and cpanel rendering wherever I could find it in the code.
Tested by doubling the size of icons and things using Paint.NET and seeing if it worked! All checked out ok so far.
