### PR TITLE
Save version bump (for #1444)

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -19,7 +19,7 @@
 #include "ObjectViewerView.h"
 #include "graphics/Renderer.h"
 
-static const int  s_saveVersion   = 51;
+static const int  s_saveVersion   = 52;
 static const char s_saveStart[]   = "PIONEER";
 static const char s_saveEnd[]     = "END";
 


### PR DESCRIPTION
#1444 broke saves, because saves contain references to particular ship types (specifically, `ShipFlavour::Save`). I didn't think of it at the time, but this needs a save version bump.
