### PR TITLE
Add the Lua context files back to the VC2010 project.

### DIFF
--- a/win32/vc2010/pioneer.vcxproj
+++ b/win32/vc2010/pioneer.vcxproj
@@ -134,6 +134,7 @@
     <ClCompile Include="..\..\src\KeyBindings.cpp" />
     <ClCompile Include="..\..\src\Lang.cpp" />
     <ClCompile Include="..\..\src\LmrModel.cpp" />
+    <ClCompile Include="..\..\src\Lua.cpp" />
     <ClCompile Include="..\..\src\LuaBody.cpp" />
     <ClCompile Include="..\..\src\LuaCargoBody.cpp" />
     <ClCompile Include="..\..\src\LuaChatForm.cpp" />
@@ -281,6 +282,7 @@
     <ClInclude Include="..\..\src\KeyBindings.h" />
     <ClInclude Include="..\..\src\libs.h" />
     <ClInclude Include="..\..\src\LmrModel.h" />
+    <ClInclude Include="..\..\src\Lua.h" />
     <ClInclude Include="..\..\src\LuaBody.h" />
     <ClInclude Include="..\..\src\LuaCargoBody.h" />
     <ClInclude Include="..\..\src\LuaChatForm.h" />

--- a/win32/vc2010/pioneer.vcxproj.filters
+++ b/win32/vc2010/pioneer.vcxproj.filters
@@ -387,6 +387,9 @@
     <ClCompile Include="..\..\src\LuaFileSystem.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Lua.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Aabb.h">
@@ -807,6 +810,9 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\LuaFileSystem.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Lua.h">
       <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Seems like the Lua.cpp/h files weren't added to the Visual Studio 2010 project when the Lua context was moved from Pi to Lua.
This commit just fixes that.
