### PR TITLE
Make FileSystem.ReadDirectory return names only

### DIFF
--- a/src/LuaFileSystem.cpp
+++ b/src/LuaFileSystem.cpp
@@ -111,7 +111,7 @@ static int l_filesystem_join_path(lua_State *l)
 	try {
 		std::string path;
 		for (int i = 1; i <= lua_gettop(l); i++)
-			path = FileSystem::JoinPath(path, lua_tostring(l, i));
+			path = FileSystem::JoinPath(path, luaL_checkstring(l, i));
 		path = FileSystem::NormalisePath(path);
 		lua_pushlstring(l, path.c_str(), path.size());
 		return 1;


### PR DESCRIPTION
Its easier to join the path back onto the name than it is to split it off, particularly when the full path probably isn't something you want to display.

However that now raises the question: do I need to expose `JoinPath` to Lua to do this safely?
