### PR TITLE
Draw city before starport

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -965,21 +965,22 @@ void SpaceStation::Render(Graphics::Renderer *r, const Camera *camera, const vec
 			fadeInLength = 3000.0;
 		}
 
-		FadeInModelIfDark(r, GetLmrCollMesh()->GetBoundingRadius(),
-							viewCoords.Length(), fadeInEnd, fadeInLength, overallLighting, minIllumination);
-
-		RenderLmrModel(viewCoords, viewTransform);
-
-		// reset ambient colour as Fade-in model may change it
-		r->SetAmbientColor(Color::BLACK);
-
 		/* don't render city if too far away */
 		if (viewCoords.Length() < 1000000.0){
+			r->SetAmbientColor(Color::BLACK);
 			if (!m_adjacentCity) {
 				m_adjacentCity = new CityOnPlanet(planet, this, m_sbody->seed);
 			}
 			m_adjacentCity->Render(r, camera, this, viewCoords, viewTransform, overallLighting, minIllumination);
 		} 
+
+		// reset ambient colour as Fade-in model may change it
+		r->SetAmbientColor(Color::BLACK);
+
+		FadeInModelIfDark(r, GetLmrCollMesh()->GetBoundingRadius(),
+							viewCoords.Length(), fadeInEnd, fadeInLength, overallLighting, minIllumination);
+
+		RenderLmrModel(viewCoords, viewTransform);
 
 		// restore old lights
 		r->SetLights(origLights.size(), &origLights[0]);


### PR DESCRIPTION
The updated station pads have the lights right in front of the front view, and
it was very noticable from the start point that the billboards were being
drawn behind the surrounding city buildings. By drawing them first, GL can do
the right thing with the billboard transparency.

Before:

![](http://i.imgur.com/fnG9t.png)

After:

![](http://i.imgur.com/bZNw1.png)

Also it means you can see the city through the starport tower windows, which looks amazing :D

![](http://i.imgur.com/fil7x.png)
