### PR TITLE
Color: fix -Wshadow Clang warning

### DIFF
--- a/src/Color.h
+++ b/src/Color.h
@@ -10,7 +10,7 @@ struct Color4f {
 	operator float *() { return &r; }
 	operator const float *() const { return &r; }
 	Color4f &operator*=(const float v) { r*=v; g*=v; b*=v; a*=v; return *this; }
-	friend Color4f operator*(const Color4f &a, const float v) { return Color4f(a.r*v, a.g*v, a.b*v, a.a*v); }
+	friend Color4f operator*(const Color4f &c, const float v) { return Color4f(c.r*v, c.g*v, c.b*v, c.a*v); }
 
 	float GetLuminance() const;
 


### PR DESCRIPTION
Clang keeps screaming at me because of some method arguments shadowing attributes.
