### PR TITLE
Simplify lock management in GeoSphere UpdateLODThread

### DIFF
--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -994,27 +994,23 @@ static bool s_exitFlag = false;
 /* Thread that updates geosphere level of detail thingies */
 int GeoSphere::UpdateLODThread(void *data)
 {
-	bool done = false;
+	SDL_mutexP(s_geosphereUpdateQueueLock);
 
-	while (!done) {
-
-		// pull the next GeoSphere off the queue
-		SDL_mutexP(s_geosphereUpdateQueueLock);
+	while (true) {
 
 		// check for exit. doing it here to avoid needing another lock
-		if (s_exitFlag) {
-			done = true;
-			SDL_mutexV(s_geosphereUpdateQueueLock);
+		if (s_exitFlag)
 			break;
-		}
+
+		assert(s_currentlyUpdatingGeoSphere == 0);
 
 		if (! s_geosphereUpdateQueue.empty()) {
+			// pull the next GeoSphere off the queue
 			s_currentlyUpdatingGeoSphere = s_geosphereUpdateQueue.front();
 			s_geosphereUpdateQueue.pop_front();
-		} else
-			s_currentlyUpdatingGeoSphere = 0;
 
-		if (s_currentlyUpdatingGeoSphere) {
+			assert(s_currentlyUpdatingGeoSphere);
+
 			GeoSphere *gs = s_currentlyUpdatingGeoSphere;
 			// overlap locks to ensure gs doesn't die before we've locked it
 			SDL_mutexP(gs->m_updateLock);
@@ -1028,16 +1024,16 @@ int GeoSphere::UpdateLODThread(void *data)
 			SDL_mutexP(s_geosphereUpdateQueueLock);
 			assert(s_currentlyUpdatingGeoSphere == gs);
 			s_currentlyUpdatingGeoSphere = 0;
-			SDL_mutexV(s_geosphereUpdateQueueLock);
 
 			SDL_mutexV(gs->m_updateLock);
 		} else {
-			// if there's nothing in the update queue, just sleep for a bit before checking it again
-			SDL_CondWait(s_geosphereUpdateQueueCondition, s_geosphereUpdateQueueLock);		// Unlocks s_geosphereUpdateQueueLock
-			SDL_mutexV(s_geosphereUpdateQueueLock);				// Even if SDL doc doesn't say it, SDL_CondWait re-locks the mutex on exit
+			// queue is empty; wait to be signalled
+			// note: SDL_CondWait unlocks the mutex while it's blocked
+			SDL_CondWait(s_geosphereUpdateQueueCondition, s_geosphereUpdateQueueLock);
 		}
 	}
 
+	SDL_mutexV(s_geosphereUpdateQueueLock);
 	return 0;
 }
 


### PR DESCRIPTION
This removes an unnecessary gap where `s_geosphereUpdateQueueLock` is unlocked briefly between cycles in UpdateLODThread. Gaps like that make it harder to reason about the threading behaviour, because they introduce more possible execution orders over the two threads.
