### PR TITLE
short money format

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,7 +12,7 @@
 std::string format_money(Sint64 money)
 {
 	char buf[32];
-	snprintf(buf, sizeof(buf), "$%.2f", 0.01*double(money));
+	snprintf(buf, sizeof(buf), "$%.0f", double(money));
 	return std::string(buf);
 }
 


### PR DESCRIPTION
Use the short form of money, there where it looks better.

closes #133
