### PR TITLE
Initialise HyperspaceCloud graphics in unserialize constructor

### DIFF
--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -28,17 +28,22 @@ HyperspaceCloud::HyperspaceCloud(Ship *s, double dueDate, bool isArrival)
 	m_birthdate = Pi::game->GetTime();
 	m_due = dueDate;
 	SetIsArrival(isArrival);
-
-	m_graphic.vertices.Reset(new Graphics::VertexArray(ATTRIB_POSITION | ATTRIB_DIFFUSE));
-	Graphics::MaterialDescriptor desc;
-	desc.vertexColors = true;
-	m_graphic.material.Reset(Pi::renderer->CreateMaterial(desc));
+	InitGraphics();
 }
 
 HyperspaceCloud::HyperspaceCloud()
 {
 	m_ship = 0;
 	m_pos = vector3d(0,0,0);
+	InitGraphics();
+}
+
+void HyperspaceCloud::InitGraphics()
+{
+	m_graphic.vertices.Reset(new Graphics::VertexArray(ATTRIB_POSITION | ATTRIB_DIFFUSE));
+	Graphics::MaterialDescriptor desc;
+	desc.vertexColors = true;
+	m_graphic.material.Reset(Pi::renderer->CreateMaterial(desc));
 }
 
 HyperspaceCloud::~HyperspaceCloud()

--- a/src/HyperspaceCloud.h
+++ b/src/HyperspaceCloud.h
@@ -42,6 +42,8 @@ protected:
 	virtual void Load(Serializer::Reader &rd, Space *space);
 
 private:
+	void InitGraphics();
+
 	Ship *m_ship;
 	vector3d m_pos;
 	vector3d m_vel;


### PR DESCRIPTION
Fixes #1551.

We've had a save bump since alpha26, so to test this with the save file provided in that issue you have to cherry-pick it onto a26.
