### PR TITLE
Bugfix of issue #1581.

### DIFF
--- a/src/LuaSpace.cpp
+++ b/src/LuaSpace.cpp
@@ -219,12 +219,13 @@ static int l_space_spawn_ship_near(lua_State *l)
 
 	// XXX protect against spawning inside the body
 	Frame * newframe = nearbody->GetFrame();
+	vector3d newPosition = (MathUtil::RandomPointOnSphere(min_dist, max_dist)* 1000.0) + nearbody->GetPosition();
 	// If the frame is rotating and the parent is non-rotating, use non-rotating.
-	if(newframe->IsRotatingFrame() && newframe->m_parent != 0)
+	if(newframe->IsRotatingFrame() && newframe->m_parent != 0 && !newframe->IsLocalPosInFrame(newPosition))
 		newframe = newframe->m_parent;
 
 	thing->SetFrame(newframe);;
-	thing->SetPosition((MathUtil::RandomPointOnSphere(min_dist, max_dist)* 1000.0) + nearbody->GetPosition());
+	thing->SetPosition(newPosition);
 	thing->SetVelocity(vector3d(0,0,0));
 	Pi::game->GetSpace()->AddBody(thing);
 


### PR DESCRIPTION
Bugfix of issue #1581. Some ships were initially placed into rotating frames 1000 km away from center, which catapulted them by tremendous velocities. This condition sets the ship reference frame to the parent of the rotating frame if the non-rotating parent frame is of the same name. (Belongs to the same body).

Should I somehow fix also cases when the frame is rotating and its parent has not the same name? (So far I haven't encounter such case, so it is probably not a problem.)
