### PR TITLE
Remove the Engine.userdir attribute

### DIFF
--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -39,26 +39,6 @@ static int l_engine_attr_rand(lua_State *l)
 }
 
 /*
- * Attribute: userdir
- *
- * The Pioneer configuration directory (should be writable).
- *
- * Availability:
- *
- *   alpha 14
- *
- * Status:
- *
- *   deprecated
- */
-static int l_engine_attr_userdir(lua_State *l)
-{
-	const std::string &userdir = FileSystem::GetUserDir();
-	lua_pushlstring(l, userdir.c_str(), userdir.size());
-	return 1;
-}
-
-/*
  * Attribute: ticks
  *
  * Number of milliseconds since Pioneer was started. This should be used for
@@ -83,7 +63,6 @@ void LuaEngine::Register()
 {
 	static const luaL_Reg l_attrs[] = {
 		{ "rand",    l_engine_attr_rand    },
-		{ "userdir", l_engine_attr_userdir },
 		{ "ticks",   l_engine_attr_ticks   },
 		{ 0, 0 }
 	};


### PR DESCRIPTION
I don't think we really want to expose this. It was only exposed before because the pidebug.lua core dump script used it, and that went away several alphas ago.

Edit: It's been marked "deprecated" since alpha 26 (@823bc385ced35083734454b8560327d55e252ba0)
