### PR TITLE
Zero input states when a new game starts

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -85,6 +85,7 @@
 #include "ModManager.h"
 #include "graphics/Light.h"
 #include "gui/Gui.h"
+#include <algorithm>
 #include <fstream>
 
 float Pi::gameTickAlpha;
@@ -722,6 +723,17 @@ void Pi::InitGame()
 {
 	// this is a bit brittle. skank may be forgotten and survive between
 	// games
+
+	//reset input states
+	keyModState = 0;
+	std::fill(keyState, keyState + COUNTOF(keyState), 0);
+	std::fill(mouseButton, mouseButton + COUNTOF(mouseButton), 0);
+	std::fill(mouseMotion, mouseMotion + COUNTOF(mouseMotion), 0);
+	for (std::vector<JoystickState>::iterator stick = joysticks.begin(); stick != joysticks.end(); ++stick) {
+		std::fill(stick->buttons.begin(), stick->buttons.end(), false);
+		std::fill(stick->hats.begin(), stick->hats.end(), 0);
+		std::fill(stick->axes.begin(), stick->axes.end(), 0.f);
+	}
 
 	Polit::Init();
 


### PR DESCRIPTION
Zero all input states when starting a new game.

Avoids the unreported problem of laser firing on the next takeoff, if you previously aborted Tombstone with the fire key.
