### PR TITLE
Remove UI::Image dependency on Gui::TexturedQuad

### DIFF
--- a/src/ui/Image.h
+++ b/src/ui/Image.h
@@ -6,7 +6,8 @@
 
 #include "Widget.h"
 #include "SmartPtr.h"
-#include "gui/GuiTexturedQuad.h"
+#include "graphics/Material.h"
+#include "graphics/Texture.h"
 
 namespace UI {
 
@@ -26,7 +27,8 @@ protected:
 	Image(Context *context, const std::string &filename, StretchMode stretchMode);
 
 private:
-	ScopedPtr<Gui::TexturedQuad> m_quad;
+	RefCountedPtr<Graphics::Texture> m_texture;
+	RefCountedPtr<Graphics::Material> m_material;
 	StretchMode m_stretchMode;
 	Point m_initialSize;
 };


### PR DESCRIPTION
Pretty simple. Just splices the relevant bits of code from `Gui::TexturedQuad` into `UI::Image` to remove the dependency. I'm assuming we're happy for the UI code to draw directly with the renderer (rather than using Drawables for everything), because other widgets (e.g., `UI::ColorBackground`) already do that.
