### PR TITLE
Make AddWidget "steal" a widget if it already belongs to another container

### DIFF
--- a/src/ui/Box.cpp
+++ b/src/ui/Box.cpp
@@ -156,13 +156,13 @@ Box *Box::PackEnd(const WidgetSet &set, Uint32 flags)
 	return this;
 }
 
-void Box::Remove(Widget *widget)
+void Box::RemoveWidget(Widget *widget)
 {
 	for (std::list<Child>::iterator i = m_children.begin(); i != m_children.end(); ++i)
 		if ((*i).widget == widget) {
 			if ((*i).flags & BOX_EXPAND) m_countExpanded--;
 			m_children.erase(i);
-			RemoveWidget(widget);
+			Container::RemoveWidget(widget);
 			return;
 		}
 }

--- a/src/ui/Box.h
+++ b/src/ui/Box.h
@@ -32,8 +32,11 @@ public:
 	Box *PackEnd(Widget *child, Uint32 flags = 0);
 	Box *PackEnd(const WidgetSet &set, Uint32 flags = 0);
 
-	void Remove(Widget *child);
+	void Remove(Widget *child) { RemoveWidget(child); }
 	void Clear();
+
+protected:
+	virtual void RemoveWidget(Widget *widget);
 
 private:
 	BoxOrientation m_orient;

--- a/src/ui/Container.cpp
+++ b/src/ui/Container.cpp
@@ -36,7 +36,8 @@ void Container::LayoutChildren()
 
 void Container::AddWidget(Widget *widget)
 {
-	assert(!widget->GetContainer());
+	if (widget->GetContainer())
+		widget->GetContainer()->RemoveWidget(widget);
 
 	std::vector< RefCountedPtr<Widget> >::iterator i;
 	for (i = m_widgets.begin(); i != m_widgets.end(); ++i)

--- a/src/ui/Container.h
+++ b/src/ui/Container.h
@@ -46,7 +46,7 @@ protected:
 	void LayoutChildren();
 
 	void AddWidget(Widget *);
-	void RemoveWidget(Widget *);
+	virtual void RemoveWidget(Widget *);
 	void RemoveAllWidgets();
 
 	void SetWidgetDimensions(Widget *widget, const Point &position, const Point &size);

--- a/src/ui/FloatContainer.h
+++ b/src/ui/FloatContainer.h
@@ -13,7 +13,7 @@ public:
 	virtual void Layout();
 
 	void AddWidget(Widget *w, const Point &pos, const Point &size);
-	void RemoveWidget(Widget *w);
+	virtual void RemoveWidget(Widget *w);
 
 private:
 	virtual Point PreferredSize() { return Point(); }

--- a/src/ui/Grid.cpp
+++ b/src/ui/Grid.cpp
@@ -117,7 +117,7 @@ void Grid::ClearRow(int rowNum)
 	for (int i = 0; i < m_numCols; i++) {
 		const int n = rowNum*m_numCols+i;
 		if (m_widgets[n]) {
-			RemoveWidget(m_widgets[n]);
+			Container::RemoveWidget(m_widgets[n]);
 			m_widgets[n] = 0;
 		}
 	}
@@ -130,7 +130,7 @@ void Grid::ClearColumn(int colNum)
 	for (int i = 0; i < m_numRows; i++) {
 		const int n = i*m_numCols+colNum;
 		if (m_widgets[n]) {
-			RemoveWidget(m_widgets[n]);
+			Container::RemoveWidget(m_widgets[n]);
 			m_widgets[n] = 0;
 		}
 	}
@@ -141,7 +141,16 @@ void Grid::Clear()
 	for (int i = 0; i < m_numRows*m_numCols; i++)
 		m_widgets[i] = 0;
 
-	RemoveAllWidgets();
+	Container::RemoveAllWidgets();
+}
+
+void Grid::RemoveWidget(Widget *widget)
+{
+	for (size_t i = 0; i < m_numRows*m_numCols; i++)
+		if (m_widgets[i] == widget) {
+			Container::RemoveWidget(widget);
+			m_widgets[i] = 0;
+		}
 }
 
 }

--- a/src/ui/Grid.h
+++ b/src/ui/Grid.h
@@ -29,6 +29,9 @@ public:
 	size_t GetNumRows() const { return m_numRows; }
 	size_t GetNumCols() const { return m_numCols; }
 
+protected:
+	virtual void RemoveWidget(Widget *);
+
 private:
 	CellSpec m_rowSpec, m_colSpec;
 	int m_numRows, m_numCols;

--- a/src/ui/Scroller.cpp
+++ b/src/ui/Scroller.cpp
@@ -89,9 +89,16 @@ Scroller *Scroller::SetInnerWidget(Widget *widget)
 void Scroller::RemoveInnerWidget()
 {
 	if (m_innerWidget) {
-		RemoveWidget(m_innerWidget);
+		Container::RemoveWidget(m_innerWidget);
 		m_innerWidget = 0;
 	}
+}
+
+void Scroller::RemoveWidget(Widget *widget)
+{
+	if (m_innerWidget != widget)
+		return;
+	RemoveInnerWidget();
 }
 
 }

--- a/src/ui/Scroller.h
+++ b/src/ui/Scroller.h
@@ -24,6 +24,8 @@ protected:
 	friend class Context;
 	Scroller(Context *context);
 
+	virtual void RemoveWidget(Widget *widget);
+
 private:
 	Widget *m_innerWidget;
 	VSlider *m_slider;

--- a/src/ui/Single.cpp
+++ b/src/ui/Single.cpp
@@ -33,9 +33,16 @@ Single *Single::SetInnerWidget(Widget *widget)
 void Single::RemoveInnerWidget()
 {
 	if (m_innerWidget) {
-		RemoveWidget(m_innerWidget);
+		Container::RemoveWidget(m_innerWidget);
 		m_innerWidget = 0;
 	}
+}
+
+void Single::RemoveWidget(Widget *widget)
+{
+	if (m_innerWidget != widget)
+		return;
+	RemoveInnerWidget();
 }
 
 }

--- a/src/ui/Single.h
+++ b/src/ui/Single.h
@@ -20,6 +20,8 @@ public:
 protected:
 	Single(Context *context) : Container(context), m_innerWidget(0) {}
 
+    virtual void RemoveWidget(Widget *widget);
+
 private:
 	Widget *m_innerWidget;
 };


### PR DESCRIPTION
The assert that was at the top of AddWidget is surprisingly easy to trip when you're doing things with a lot of widgets and event handlers. This makes it do somehing sane. To do it we need an always-reliable method of removing a widget from any container. As a result, RemoveWidget() is now virtual and any container that tracks its children independently of Container needs to implement it.

@Brianetta's test case (for `new-ui-infoview` @9bf87e07): http://pastebin.com/qCGmmJbU
