### PR TITLE
Fix star orbit frame size being 0 if there are no children. 

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -502,10 +502,12 @@ static Frame *MakeFrameFor(SystemBody *sbody, Body *b, Frame *f)
 	}
 	else if (supertype == SystemBody::SUPERTYPE_STAR) {
 		// stars want a single small non-rotating frame
+		// bigger than it's furtherest orbiting body.
+		// if there are no orbiting bodies use a frame of several radii.
 		orbFrame = new Frame(f, sbody->name.c_str());
 		orbFrame->m_sbody = sbody;
 		orbFrame->m_astroBody = b;
-		orbFrame->SetRadius(sbody->GetMaxChildOrbitalDistance()*1.1);
+		orbFrame->SetRadius(std::max(10.0*sbody->GetRadius(), sbody->GetMaxChildOrbitalDistance()*1.1));
 		b->SetFrame(orbFrame);
 		return orbFrame;
 	}


### PR DESCRIPTION
 The star orbit frame size depended only on the furtherest child. For stars without orbiting bodies (single star systems or stars (like brown dwarves) orbiting others the orbit frame radius was zero.

This also avoids the issues in #1626 for the case of Achernar. Stars which are heavy and have small radius like white dwarfs will still have autopilot problems. 

To test:
Achernar and autopilot selection working are are good enough way. SystemPath.New(4,-9,-16,0,16) can be used to modify a startpoint in lua to get there.
