### PR TITLE
Sector View: Prevent hypertarget following selection to current system

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -406,7 +406,7 @@ void SectorView::SetSelectedSystem(const SystemPath &path)
 {
     m_selected = path;
 
-	if (m_matchTargetToSelection) {
+	if (m_matchTargetToSelection && m_selected != m_current) {
 		m_hyperspaceTarget = m_selected;
 		onHyperspaceTargetChanged.emit();
 		UpdateSystemLabels(m_targetSystemLabels, m_hyperspaceTarget);


### PR DESCRIPTION
Stop me before I pull request again!....

...but this was really bugging me when playing the Alpha28 freeze build, and I suddenly realised that it's bugged me in every build I've played Pioneer.

It's a one liner that tweaks 'target follows selection' mode in the Sector View so that it doesn't follow your selection back to your current system when you click on it or select it using the buttons/shortcuts, which makes comparing info between current and destination systems a lot less annoying when in that mode.

Yeah, I should probably just get over it and use the manual target selection mode. :)
