### PR TITLE
Tidal-locking

### DIFF
--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -1786,7 +1786,7 @@ void SystemBody::PickPlanetType(MTRand &rand)
 	//		invTidalLockTime.ToFloat(), semiMajorAxis.ToFloat(), radius.ToFloat(), parent->mass.ToFloat(), mass.ToFloat());
 
 	if(invTidalLockTime > 10) { // 10x faster than Moon, no chance not to be tidal-locked
-		rotationPeriod = orbit.period/3600/24;
+		rotationPeriod = fixed(int(round(orbit.period)),3600*24);
 		axialTilt = fixed(0);
 	} else if(invTidalLockTime > fixed(1,100)) { // rotation speed changed in favour of tidal lock
 		// XXX: there should be some chance the satellite was captured only recenly and ignore this


### PR DESCRIPTION
This routine adds <a href=http://en.wikipedia.org/wiki/Tidal_locking>tidal locking</a> into system generation. The idea is that planets close to their stars and moons close to their planets, tend to go to tidal-lock state when orbital period = rotational period and axisTilt = 0. I used formula from Wikipedia. The planet is compared to Moon's tidal lock time and the orbit parameters are changed accordingly. 

Please check this especially for the floating-point operations problems. I'm especially worried about variable orbit.period, which is double and not fixed.
