### PR TITLE
Hack-fix to avoid 0 temperatures from causing nans in shader uniforms

### DIFF
--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -1288,7 +1288,12 @@ SystemBody::AtmosphereParameters SystemBody::CalcAtmosphereParams() const
 	const double massPlanet_in_kg = (mass.ToDouble()*EARTH_MASS);
 	const double g = G*massPlanet_in_kg/(radiusPlanet_in_m*radiusPlanet_in_m);
 
-	const double T = static_cast<double>(averageTemp);
+	double T = static_cast<double>(averageTemp);
+
+	// XXX hack to avoid issues with sysgen giving 0 temps
+	// temporary as part of sysgen needs to be rewritten before the proper fix can be used
+	if (T < 1) 
+		T = 40;
 
 	// XXX just use earth's composition for now
 	const double M = 0.02897f; // in kg/mol


### PR DESCRIPTION
Avoid 0 temperatures from causing nans in shader uniforms. Temporary, as part of sysgen needs to be rewritten before the proper fix can be used. Pioneer probably relies heavily on the bug for cooler planets, which allows life/different terrains - without this planets at common distances are probably very hot as found in the temperature refactor.

Using the proper solution involves redoing the planet generation which is a lengthy process (this is wip as part of the softfloat related rewrite).

Edwa C g , SystemPath.New(-4,0,89,0,9) can be used to get to the system.

Note: Pressure is still low as the temperature is set close to absolute zero.

Edit2: stepping through the sysgen reveals it is a fixed point related issue which will be dealt with in the softfloat related rewrite. 

![](http://i.imgur.com/YQDD0.png)
