### PR TITLE
Fix scrolling down in Far SectorView running up against a wall of no systems.

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -820,7 +820,7 @@ void SectorView::DrawFarSectors(matrix4x4f modelview)
 		m_visibleFactions.clear();
 
 		for (int sx = secOrigin.x-buildRadius; sx <= secOrigin.x+buildRadius; sx++) {
-			for (int sy = secOrigin.z-buildRadius; sy <= secOrigin.y+buildRadius; sy++) {
+			for (int sy = secOrigin.y-buildRadius; sy <= secOrigin.y+buildRadius; sy++) {
 				for (int sz = secOrigin.z-buildRadius; sz <= secOrigin.z+buildRadius; sz++) {
 						if ((vector3f(sx,sy,sz) - secOrigin).Length() <= buildRadius){
 							BuildFarSector(GetCached(sx, sy, sz), Sector::SIZE * secOrigin, m_farstars, m_farstarsColor);


### PR DESCRIPTION
This changes a misplaced z to the y it should have been, which was the problem.
