### PR TITLE
New UI: Expose relative mouse movement in MouseMotionEvent

### DIFF
--- a/src/ui/Event.cpp
+++ b/src/ui/Event.cpp
@@ -45,6 +45,7 @@ void MouseMotionEvent::ToLuaTable(lua_State *l) const
 	pi_lua_settable(l, "type", LuaConstants::GetConstantString(l, "UIEventType", type));
 
 	_settable(l, "pos", pos);
+	_settable(l, "rel", rel);
 }
 
 void MouseWheelEvent::ToLuaTable(lua_State *l) const

--- a/src/ui/Event.h
+++ b/src/ui/Event.h
@@ -101,7 +101,8 @@ public:
 
 class MouseMotionEvent : public MouseEvent {
 public:
-	MouseMotionEvent(const Point &_pos) : MouseEvent(Event::MOUSE_MOTION, _pos) {}
+	MouseMotionEvent(const Point &_pos, const Point &_rel) : MouseEvent(Event::MOUSE_MOTION, _pos), rel(_rel) {}
+	const Point rel;
 
 	void ToLuaTable(lua_State *l) const;
 };

--- a/src/ui/EventDispatcher.cpp
+++ b/src/ui/EventDispatcher.cpp
@@ -38,7 +38,7 @@ bool EventDispatcher::DispatchSDLEvent(const SDL_Event &event)
 			return Dispatch(MouseButtonEvent(MouseButtonEvent::BUTTON_UP, MouseButtonFromSDLButton(event.button.button), Point(event.button.x,event.button.y)));
 
 		case SDL_MOUSEMOTION:
-			return Dispatch(MouseMotionEvent(Point(event.motion.x,event.motion.y)));
+			return Dispatch(MouseMotionEvent(Point(event.motion.x,event.motion.y), Point(event.motion.xrel, event.motion.yrel)));
 	}
 
 	return false;
@@ -151,14 +151,14 @@ bool EventDispatcher::Dispatch(const Event &event)
 
 			// if there's a mouse-active widget, just send motion events directly into it
 			if (m_mouseActiveReceiver) {
-				MouseMotionEvent translatedEvent = MouseMotionEvent(m_lastMousePosition-m_mouseActiveReceiver->GetAbsolutePosition());
+				MouseMotionEvent translatedEvent = MouseMotionEvent(m_lastMousePosition-m_mouseActiveReceiver->GetAbsolutePosition(), mouseMotionEvent.rel);
 				return m_mouseActiveReceiver->TriggerMouseMove(translatedEvent);
 			}
 
 			// widget directly under the mouse
 			RefCountedPtr<Widget> target(m_baseContainer->GetWidgetAtAbsolute(m_lastMousePosition));
 
-			MouseMotionEvent translatedEvent = MouseMotionEvent(m_lastMousePosition-target->GetAbsolutePosition());
+			MouseMotionEvent translatedEvent = MouseMotionEvent(m_lastMousePosition-target->GetAbsolutePosition(), mouseMotionEvent.rel);
 			bool ret = target->TriggerMouseMove(translatedEvent);
 
 			DispatchMouseOverOut(target.Get(), m_lastMousePosition);

--- a/src/ui/Widget.cpp
+++ b/src/ui/Widget.cpp
@@ -133,7 +133,7 @@ bool Widget::TriggerMouseMove(const MouseMotionEvent &event, bool emit)
 	HandleMouseMove(event);
 	if (emit) emit = !onMouseMove.emit(event);
 	if (GetContainer() && !IsFloating()) {
-		MouseMotionEvent translatedEvent = MouseMotionEvent(event.pos+GetPosition());
+		MouseMotionEvent translatedEvent = MouseMotionEvent(event.pos+GetPosition(), event.rel);
 		GetContainer()->TriggerMouseMove(translatedEvent, emit);
 	}
 	return !emit;


### PR DESCRIPTION
Very simple. SDL reports travel as well as mouse position, so lets include it in our own events too. Used on `new-ui-infoview` for the ship spinner.
