### PR TITLE
Faction Police and Military names shouldn't be CamelCased

### DIFF
--- a/data/factions/99_AutoGenerate.lua
+++ b/data/factions/99_AutoGenerate.lua
@@ -85,11 +85,11 @@ for i1,prefix in ipairs(prefixes) do
 		local seed = salt .. faction_name
 
 		table.insert(faction_names, faction_name)
-		if util.hash_random(seed..'police')   < 0.5 then table.insert(police_names,   prefix..police_suffixes  [util.hash_random(seed..'policep', 1, #police_suffixes)])
-		                                            else table.insert(police_names,   suffix..police_suffixes  [util.hash_random(seed..'polices', 1, #police_suffixes)])
+		if util.hash_random(seed..'police')   < 0.5 then table.insert(police_names,   prefix..' '..police_suffixes  [util.hash_random(seed..'policep', 1, #police_suffixes)])
+		                                            else table.insert(police_names,   suffix..' '..police_suffixes  [util.hash_random(seed..'polices', 1, #police_suffixes)])
 		end
-		if util.hash_random(seed..'military') < 0.5 then table.insert(military_names, prefix..military_suffixes[util.hash_random(seed..'militp',  1, #military_suffixes)])
-		                                            else table.insert(military_names, suffix..military_suffixes[util.hash_random(seed..'milits',  1, #military_suffixes)])
+		if util.hash_random(seed..'military') < 0.5 then table.insert(military_names, prefix..' '..military_suffixes[util.hash_random(seed..'militp',  1, #military_suffixes)])
+		                                            else table.insert(military_names, suffix..' '..military_suffixes[util.hash_random(seed..'milits',  1, #military_suffixes)])
 		end
 	end
 end


### PR DESCRIPTION
I was missing a space between the first and second words of the police and military names when making auto-generated Factions so they came out CamelCased. Oops.
