### PR TITLE
Remove Infoview.h from win32 pre-compiled headers+vs2012 build update

### DIFF
--- a/src/win32/pch.h
+++ b/src/win32/pch.h
@@ -46,7 +46,6 @@
 #include "gui/GuiVScrollBar.h"
 #include "gui/GuiVScrollPortal.h"
 #include "gui/GuiWidget.h"
-#include "InfoView.h"
 #include "libs.h"
 #include "MarketAgent.h"
 #include "matrix4x4.h"

--- a/win32/vc2012/pioneer.vcxproj
+++ b/win32/vc2012/pioneer.vcxproj
@@ -135,7 +135,6 @@
     <ClCompile Include="..\..\src\GameMenuView.cpp" />
     <ClCompile Include="..\..\src\GeoSphere.cpp" />
     <ClCompile Include="..\..\src\HyperspaceCloud.cpp" />
-    <ClCompile Include="..\..\src\InfoView.cpp" />
     <ClCompile Include="..\..\src\IniConfig.cpp" />
     <ClCompile Include="..\..\src\Intro.cpp" />
     <ClCompile Include="..\..\src\KeyBindings.cpp" />
@@ -292,7 +291,6 @@
     <ClInclude Include="..\..\src\GameMenuView.h" />
     <ClInclude Include="..\..\src\GeoSphere.h" />
     <ClInclude Include="..\..\src\HyperspaceCloud.h" />
-    <ClInclude Include="..\..\src\InfoView.h" />
     <ClInclude Include="..\..\src\IniConfig.h" />
     <ClInclude Include="..\..\src\Intro.h" />
     <ClInclude Include="..\..\src\KeyBindings.h" />

--- a/win32/vc2012/pioneer.vcxproj.filters
+++ b/win32/vc2012/pioneer.vcxproj.filters
@@ -57,9 +57,6 @@
     <ClCompile Include="..\..\src\HyperspaceCloud.cpp">
       <Filter>src</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\InfoView.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\IniConfig.cpp">
       <Filter>src</Filter>
     </ClCompile>
@@ -484,9 +481,6 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\HyperspaceCloud.h">
-      <Filter>src</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\InfoView.h">
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\IniConfig.h">


### PR DESCRIPTION
Removed Infoview.h and .cpp files from vs2012 project files, and the win32 precompiled headers as they don't exist anymore.
