### PR TITLE
Skip rendering stars in Far Sectorview, if no stars

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -841,7 +841,9 @@ void SectorView::DrawFarSectors(matrix4x4f modelview)
 	}
 
 	// always draw the stars, slightly altering their size for different different resolutions, so they still look okay
-	m_renderer->DrawPoints(m_farstars.size(), &m_farstars[0], &m_farstarsColor[0], 1.f + (Pi::GetScrHeight() / 720.f));
+	if (m_farstars.size() > 0) {
+		m_renderer->DrawPoints(m_farstars.size(), &m_farstars[0], &m_farstarsColor[0], 1.f + (Pi::GetScrHeight() / 720.f));
+	}
 
 	// also add labels for any faction homeworlds among the systems we've drawn
 	PutFactionLabels(Sector::SIZE * secOrigin);


### PR DESCRIPTION
Implements @robn's suggested fix for #1784

I can't reproduce the original problem myself either, so someone who does is going to have to test.
