### PR TITLE
Traverse the mission list using pairs rather than ipairs

### DIFF
--- a/data/ui/InfoView.lua
+++ b/data/ui/InfoView.lua
@@ -377,7 +377,7 @@ local missions = function ()
 
 	local missionbox = ui:VBox(10)
 
-	for ref,mission in ipairs(PersistentCharacters.player.missions) do
+	for ref,mission in pairs(PersistentCharacters.player.missions) do
 		-- Format the location
 		local missionLocationName
 		if mission.location.bodyIndex then


### PR DESCRIPTION
```
[20:50] <robn> Brianetta: InfoView.lua line 380. ipairs stops when it gets to a hole in the list. Which you get when a mission is removed
[20:51] <jpab> ugh, Lua :-(
[20:53] <Lo-lan-do> JohnJ: For some satellites the autopilot refuses to enter high orbit, only medium/low orbits are available. Am I right in guessing that the high orbit would be unstable because the satellite is too close to its planet?
[20:53] <robn> Yeah. What will we do
[20:55] <jpab> Why does removing a mission leave a hole? If the missions table is really being used as an array then we should be removing with table.remove or some equivalent, which will shift the remaining items up
[20:55] <laarmen> robn, Brianetta: the solution would be to do a pairs() and filter on the key type. Lua :-(
[20:55] <robn> Well just pairs alone is fine here. All the available keys are legit
```

...is the correct answer. This pull request removes a letter **i**.
