### PR TITLE
Explicitly layout the (blank) new-ui when switching back to old-ui screens

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -832,6 +832,7 @@ void Pi::Start()
 	}
 
 	ui->RemoveInnerWidget();
+	ui->Layout(); // UI does important things on layout, like updating keyboard shortcuts
 
 	InitGame();
 	StartGame();

--- a/src/UIView.cpp
+++ b/src/UIView.cpp
@@ -28,4 +28,5 @@ void UIView::OnSwitchTo()
 void UIView::OnSwitchFrom()
 {
 	Pi::ui->RemoveInnerWidget();
+	Pi::ui->Layout(); // UI does important things on layout, like updating keyboard shortcuts
 }


### PR DESCRIPTION
Fixes #1840.

Run Layout after clearing the UI, to clear keyboard shortcuts. This is a bit of a hack; when new-ui is used everywhere it will no longer be needed, because layout will be done whenever necessary in the frame's UI Update stage.
