### PR TITLE
Fix player->IsDead() assertion in WorldView

### DIFF
--- a/src/DeathView.cpp
+++ b/src/DeathView.cpp
@@ -24,11 +24,15 @@ DeathView::DeathView(): View()
 
 DeathView::~DeathView() {}
 
-void DeathView::OnSwitchTo()
+void DeathView::Init()
 {
 	m_cameraDist = Pi::player->GetBoundingRadius() * 5.0;
 	m_cam->SetPosition(vector3d(0, 0, m_cameraDist));
 	m_cam->SetOrientation(matrix4x4d::Identity());
+}
+
+void DeathView::OnSwitchTo()
+{
 	Pi::cpan->HideAll();
 }
 

--- a/src/DeathView.h
+++ b/src/DeathView.h
@@ -13,7 +13,7 @@ public:
 	DeathView();
 	virtual ~DeathView();
 
-	void Init(float camera_distance);
+	void Init();
 
 	virtual void Update();
 	virtual void Draw3D();

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -930,6 +930,7 @@ void Pi::MainLoop()
 				}
 			} else {
 				Pi::game->SetTimeAccel(Game::TIMEACCEL_1X);
+				Pi::deathView->Init();
 				Pi::SetView(Pi::deathView);
 				Pi::player->Disable();
 				time_player_died = Pi::game->GetTime();


### PR DESCRIPTION
Should fix #1698 and #1742 (which are duplicates, as far as I can tell).

Note: #1698 also reports a different assertion, which I don't _think_ this addresses, but that one is harder to reproduce so I'm inclined to ignore it until someone hits it again. It can be re-reported then as a separate issue.
