### PR TITLE
Update player character name immediately during player name text entry

### DIFF
--- a/data/ui/InfoView.lua
+++ b/data/ui/InfoView.lua
@@ -160,7 +160,7 @@ local personalInfo = function ()
 	local faceWidgetContainer = ui:Margin(0, "ALL", faceWidget)
 
 	local nameEntry = ui:TextEntry(player.name):SetFont("HEADING_LARGE")
-	nameEntry.onEnter:Connect(function (newName)
+	nameEntry.onChange:Connect(function (newName)
 		player.name = newName
         faceWidget:UpdateInfo(player)
 	end )


### PR DESCRIPTION
Makes the system seem more reactive, and avoids the problem of players (like me) not knowing that they have to press Enter to commit their name change.
