### PR TITLE
Use _controlfp on MinGW

### DIFF
--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -92,14 +92,24 @@ void RedirectStdio()
 
 void EnableFPE()
 {
+#ifdef __MINGW32__
+	// MinGW only has _controlfp
+	_controlfp(_EM_INEXACT | _EM_UNDERFLOW, _MCW_EM);
+#else
 	unsigned int control_word;
 	_controlfp_s(&control_word, _EM_INEXACT | _EM_UNDERFLOW, _MCW_EM);
+#endif
 }
 
 void DisableFPE()
 {
+#ifdef __MINGW32__
+	// MinGW only has _controlfp
+	_controlfp(_MCW_EM, _MCW_EM);
+#else
 	unsigned int control_word;
 	_controlfp_s(&control_word, _MCW_EM, _MCW_EM);
+#endif
 }
 
 Uint64 HFTimerFreq()


### PR DESCRIPTION
MinGW doesn't _controlfp_s, which is breaking the build right now.
