### PR TITLE
Lua translate function returns the token, rather than an error, if the...

### DIFF
--- a/data/libs/Translate.lua
+++ b/data/libs/Translate.lua
@@ -41,9 +41,10 @@ Translate = {
 	GetTranslator = function (self)
 		return function (token)
 			return
+				-- Check the native language, then English, before resorting to handing back the token.
 				(self.dictionary[self.language] and self.dictionary[self.language][token]) or
 				(self.dictionary.English and self.dictionary.English[token]) or
-				error("Translation token not found: "..token)
+				token
 		end
 	end,
 


### PR DESCRIPTION
...token is undefined.

Closes #1862

```
t = Translate:GetTranslator()
print(t('NONE'))
None
print(t('None'))
None
print(t('ENGINE'))
ENGINE
print(t('HYPERDRIVE'))
Hyperdrive
```
