### PR TITLE
Don't wipe criminal records after a game load

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -47,6 +47,8 @@ Game::Game(const SystemPath &path) :
 	m_player->SetFrame(station->GetFrame());
 	m_player->SetDockedWith(station, 0);
 
+	Polit::Init();
+
 	CreateViews();
 }
 
@@ -71,6 +73,8 @@ Game::Game(const SystemPath &path, const vector3d &pos) :
 
 	m_player->SetPosition(pos);
 	m_player->SetVelocity(vector3d(0,0,0));
+
+	Polit::Init();
 
 	CreateViews();
 }

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -56,7 +56,6 @@
 #include "OS.h"
 #include "Planet.h"
 #include "Player.h"
-#include "Polit.h"
 #include "Projectile.h"
 #include "SDLWrappers.h"
 #include "SectorView.h"
@@ -747,8 +746,6 @@ void Pi::InitGame()
 		std::fill(stick->hats.begin(), stick->hats.end(), 0);
 		std::fill(stick->axes.begin(), stick->axes.end(), 0.f);
 	}
-
-	Polit::Init();
 
 	if (!config->Int("DisableSound")) AmbientSounds::Init();
 


### PR DESCRIPTION
Fixes #1874.

This moves the call to `Polit::Init` from `Pi::InitGame` (which is run for both new and loaded games) to the `Game` new-game constructor. For loaded games, `Polit::Unserialize` is called from the Game's unserialize-constructor. `Polit::Unserialize` calls `Polit::Init` before loading criminal records.
