### PR TITLE
Small cleanup of SectorView system index usage for clarity

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -463,12 +463,9 @@ void SectorView::PutSystemLabels(Sector *sec, const vector3f &origin, int drawRa
 		// skip the system if it doesn't fall within the sphere we're viewing.
 		if ((m_pos*Sector::SIZE - (*sys).FullPosition()).Length() > drawRadius) continue;
 
-		// get a system path to pass to the event handler when the label is licked
-		SystemPath sysPath = SystemPath((*sys).sx, (*sys).sy, (*sys).sz, sysIdx);
-
 		// skip the system if it belongs to a Faction we've toggled off, and isn't any of our selections
 		if (m_hiddenFactions.find((*sys).faction) != m_hiddenFactions.end() 
-			&& !sysPath.IsSameSystem(m_selected) && !sysPath.IsSameSystem(m_hyperspaceTarget) && !sysPath.IsSameSystem(m_current)) continue;
+			&& !sys->IsSameSystem(m_selected) && !sys->IsSameSystem(m_hyperspaceTarget) && !sys->IsSameSystem(m_current)) continue;
 
 		// place the label
 		vector3d systemPos = vector3d((*sys).FullPosition() - origin);
@@ -477,6 +474,9 @@ void SectorView::PutSystemLabels(Sector *sec, const vector3f &origin, int drawRa
 			// work out the colour
 			float dist = Sector::DistanceBetween(sec, sysIdx, GetCached(m_current.sectorX, m_current.sectorY, m_current.sectorZ), m_current.systemIndex);
 			Color labelColor = (*sys).faction->AdjustedColour((*sys).population, dist <= m_playerHyperspaceRange);
+
+			// get a system path to pass to the event handler when the label is licked
+			SystemPath sysPath = SystemPath((*sys).sx, (*sys).sy, (*sys).sz, sysIdx);
 
 			// setup the label
 			m_clickableLabels->Add((*sys).name, sigc::bind(sigc::mem_fun(this, &SectorView::OnClickSystem), sysPath), screenPos.x, screenPos.y, labelColor);
@@ -719,13 +719,11 @@ void SectorView::DrawNearSector(int sx, int sy, int sz, const vector3f &playerAb
 		// ...and skip the system if it doesn't fall within the sphere we're viewing.
 		if (toCentreOfView.Length() > OUTER_RADIUS) continue;
 
-		SystemPath current = SystemPath(sx, sy, sz, sysIdx);
-
 		// if the system belongs to a faction we've chosen to temporarily hide, but isn't the current system 
 		// or target then skip it
 		m_visibleFactions.insert(i->faction);
 		if (m_hiddenFactions.find(i->faction) != m_hiddenFactions.end() 
-			&& !current.IsSameSystem(m_selected) && !current.IsSameSystem(m_hyperspaceTarget) && !current.IsSameSystem(m_current)) continue;
+			&& !i->IsSameSystem(m_selected) && !i->IsSameSystem(m_hyperspaceTarget) && !i->IsSameSystem(m_current)) continue;
 
 		// don't worry about looking for inhabited systems if they're
 		// unexplored (same calculation as in StarSystem.cpp) or we've
@@ -740,6 +738,7 @@ void SectorView::DrawNearSector(int sx, int sy, int sz, const vector3f &playerAb
 
 			// Ideally, since this takes so f'ing long, it wants to be done as a threaded job but haven't written that yet.
 			if( (diff.x < 0.001f && diff.y < 0.001f && diff.z < 0.001f) ) {
+				SystemPath current = SystemPath(sx, sy, sz, sysIdx);
 				RefCountedPtr<StarSystem> pSS = StarSystem::GetCached(current);
 				(*i).population = pSS->GetTotalPop();
 			}
@@ -775,7 +774,7 @@ void SectorView::DrawNearSector(int sx, int sy, int sz, const vector3f &playerAb
 			glVertex3f(0.1f, -0.1f, z);
 		glEnd();
 
-		if (current == m_selected) {
+		if (i->IsSameSystem(m_selected)) {
 			m_jumpLine.SetStart(vector3f(0.f, 0.f, 0.f));
 			m_jumpLine.SetEnd(playerAbsPos - sysAbsPos);
 			m_jumpLine.Draw(m_renderer);
@@ -792,21 +791,21 @@ void SectorView::DrawNearSector(int sx, int sy, int sz, const vector3f &playerAb
 		m_disk->Draw(m_renderer);
 
 		// player location indicator
-		if (m_inSystem && current == m_current) {
+		if (m_inSystem && i->IsSameSystem(m_current)) {
 			glDepthRange(0.2,1.0);
 			m_disk->SetColor(Color(0.f, 0.f, 0.8f));
 			m_renderer->SetTransform(systrans * matrix4x4f::ScaleMatrix(3.f));
 			m_disk->Draw(m_renderer);
 		}
 		// selected indicator
-		if (current == m_selected) {
+		if (i->IsSameSystem(m_current)) {
 			glDepthRange(0.1,1.0);
 			m_disk->SetColor(Color(0.f, 0.8f, 0.f));
 			m_renderer->SetTransform(systrans * matrix4x4f::ScaleMatrix(2.f));
 			m_disk->Draw(m_renderer);
 		}
 		// hyperspace target indicator (if different from selection)
-		if (current == m_hyperspaceTarget && m_hyperspaceTarget != m_selected && (!m_inSystem || m_hyperspaceTarget != m_current)) {
+		if (i->IsSameSystem(m_hyperspaceTarget) && m_hyperspaceTarget != m_selected && (!m_inSystem || m_hyperspaceTarget != m_current)) {
 			glDepthRange(0.1,1.0);
 			m_disk->SetColor(Color(0.3f));
 			m_renderer->SetTransform(systrans * matrix4x4f::ScaleMatrix(2.f));
@@ -855,16 +854,14 @@ void SectorView::DrawFarSectors(matrix4x4f modelview)
 void SectorView::BuildFarSector(Sector* sec, const vector3f &origin, std::vector<vector3f> &points, std::vector<Color> &colors)
 {
 	Color starColor;
-	Uint32 sysIdx = 0;
-	for (std::vector<Sector::System>::iterator i = sec->m_systems.begin(); i != sec->m_systems.end(); ++i, ++sysIdx) {
+	for (std::vector<Sector::System>::iterator i = sec->m_systems.begin(); i != sec->m_systems.end(); ++i) {
 		// skip the system if it doesn't fall within the sphere we're viewing.
 		if ((m_pos*Sector::SIZE - (*i).FullPosition()).Length() > (m_zoomClamped/FAR_THRESHOLD )*OUTER_RADIUS) continue;
 
 		// if the system belongs to a faction we've chosen to hide also skip it, if it's not selectd in some way
 		m_visibleFactions.insert(i->faction);
-		SystemPath sysPath = SystemPath((*i).sx, (*i).sy, (*i).sz, sysIdx);
 		if (m_hiddenFactions.find(i->faction) != m_hiddenFactions.end()
-			&& !sysPath.IsSameSystem(m_selected) && !sysPath.IsSameSystem(m_hyperspaceTarget) && !sysPath.IsSameSystem(m_current)) continue;
+			&& !i->IsSameSystem(m_selected) && !i->IsSameSystem(m_hyperspaceTarget) && !i->IsSameSystem(m_current)) continue;
 
 		// otherwise add the system's position (origin must be m_pos's *sector* or we get judder)
 		// and faction color to the list to draw

--- a/src/galaxy/Sector.cpp
+++ b/src/galaxy/Sector.cpp
@@ -22,9 +22,10 @@ void Sector::GetCustomSystems()
 	const std::vector<CustomSystem*> &systems = CustomSystem::GetCustomSystemsForSector(sx, sy, sz);
 	if (systems.size() == 0) return;
 
-	for (std::vector<CustomSystem*>::const_iterator it = systems.begin(); it != systems.end(); it++) {
+	Uint32 sysIdx = 0;
+	for (std::vector<CustomSystem*>::const_iterator it = systems.begin(); it != systems.end(); it++, sysIdx++) {
 		const CustomSystem *cs = *it;
-		System s(sx, sy, sz);
+		System s(sx, sy, sz, sysIdx);
 		s.p = SIZE*cs->pos;
 		s.name = cs->name;
 		for (s.numStars=0; s.numStars<cs->numStars; s.numStars++) {
@@ -57,7 +58,7 @@ Sector::Sector(int x, int y, int z)
 		int numSystems = (rng.Int32(4,20) * Galaxy::GetSectorDensity(x, y, z)) >> 8;
 
 		for (int i=0; i<numSystems; i++) {
-			System s(sx, sy, sz);
+			System s(sx, sy, sz, customCount + i);
 
 			switch (rng.Int32(15)) {
 				case 0:

--- a/src/galaxy/Sector.h
+++ b/src/galaxy/Sector.h
@@ -30,7 +30,7 @@ public:
 
 	class System {
 	public:
-		System(int x, int y, int z): customSys(0), population(-1), sx(x), sy(y), sz(z) {};
+		System(int x, int y, int z, Uint32 si): customSys(0), population(-1), sx(x), sy(y), sz(z), idx(si) {};
 		~System() {};
 
 		// Check that we've had our habitation status set
@@ -46,8 +46,12 @@ public:
 		fixed population;
 
 		vector3f FullPosition() { return Sector::SIZE*vector3f(float(sx), float(sy), float(sz)) + p; };
+		bool IsSameSystem(const SystemPath &b) const { 
+			return sx == b.sectorX && sy == b.sectorY && sz == b.sectorZ && idx == b.systemIndex;
+		}
 
 		int sx, sy, sz;
+		Uint32 idx;
 	};
 	std::vector<System> m_systems;
 


### PR DESCRIPTION
Some cleanups I didn't manage to get into the changes for #1864 before it was merged.
- Instead of using a variable called 'num' when iterating through systems in the various views 'sysIdx' is now used
- Added a method Sector:System:IsSameSystem, so that we don't have make a system path for a system before we can check whether it's the same as the current/target/selected system.
