### PR TITLE
Fade milyway along with stars to get better moon effect in atm

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -175,8 +175,10 @@ MilkyWay::MilkyWay(Graphics::Renderer *r)
 		dark);
 
 	Graphics::MaterialDescriptor desc;
+	desc.effect = Graphics::EFFECT_STARFIELD;
 	desc.vertexColors = true;
 	m_material.Reset(r->CreateMaterial(desc));
+	m_material->emissive = Color::WHITE;
 	//This doesn't fade. Could add a generic opacity/intensity value.
 	m_model->AddSurface(RefCountedPtr<Surface>(new Surface(TRIANGLE_STRIP, bottom, m_material)));
 	m_model->AddSurface(RefCountedPtr<Surface>(new Surface(TRIANGLE_STRIP, top, m_material)));


### PR DESCRIPTION
Motivation is to avoid dark unlit moon areas when in atmosphere.
Dark unlit side of moons should blend with atmosphere and be darker.

Applies to both current shaders and the new ones pulled in #1888

Current atmosphere:
![Alt Text](https://dl.dropbox.com/u/11319604/hades_fade_vs_nofade_old.jpg)

In new #1888 shaders : 
![Alt Text](https://dl.dropbox.com/u/11319604/hades_fade_vs_nofade.jpg)
