### PR TITLE
Disable DGA mouse on Linux by default

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -107,6 +107,8 @@ char Pi::keyState[SDLK_LAST];
 char Pi::mouseButton[6];
 int Pi::mouseMotion[2];
 bool Pi::doingMouseGrab = false;
+bool Pi::warpAfterMouseGrab = false;
+int Pi::mouseGrabWarpPos[2];
 Player *Pi::player;
 View *Pi::currentView;
 WorldView *Pi::worldView;
@@ -292,6 +294,24 @@ void Pi::Init()
 	Pi::detail.textures = config->Int("Textures");
 	Pi::detail.fracmult = config->Int("FractalMultiple");
 	Pi::detail.cities = config->Int("DetailCities");
+
+#ifdef __linux__
+	// there appears to be a bug in the Linux evdev input driver that stops
+	// DGA mouse grab restoring state correctly. SDL can use an alternative
+	// method, but its only configurable via environment variable. Here we set
+	// that environment variable (unless the user explicitly doesn't want it
+	// via config).
+	//
+	// we also enable warp-after-grab here, as the SDL alternative method
+	// doesn't restore the mouse pointer to its pre-grab position
+	//
+	// XXX SDL2 uses a different mechanism entirely and this environment
+	// variable doesn't exist there, so we can get rid of it when we go to SDL2
+	if (!config->Int("SDLUseDGAMouse")) {
+		Pi::warpAfterMouseGrab = true;
+		setenv("SDL_VIDEO_X11_DGAMOUSE", "0", 1);
+	}
+#endif
 
 	// Initialize SDL
 	Uint32 sdlInitFlags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
@@ -1199,13 +1219,15 @@ void Pi::SetMouseGrab(bool on)
 	if (!doingMouseGrab && on) {
 		SDL_ShowCursor(0);
 		SDL_WM_GrabInput(SDL_GRAB_ON);
-//		SDL_SetRelativeMouseMode(true);
+		if (Pi::warpAfterMouseGrab)
+			SDL_GetMouseState(&mouseGrabWarpPos[0], &mouseGrabWarpPos[1]);
 		doingMouseGrab = true;
 	}
 	else if(doingMouseGrab && !on) {
-		SDL_ShowCursor(1);
 		SDL_WM_GrabInput(SDL_GRAB_OFF);
-//		SDL_SetRelativeMouseMode(false);
+		if (Pi::warpAfterMouseGrab)
+			SDL_WarpMouse(mouseGrabWarpPos[0], mouseGrabWarpPos[1]);
+		SDL_ShowCursor(1);
 		doingMouseGrab = false;
 	}
 }

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -181,6 +181,8 @@ private:
 	static char mouseButton[6];
 	static int mouseMotion[2];
 	static bool doingMouseGrab;
+	static bool warpAfterMouseGrab;
+	static int mouseGrabWarpPos[2];
 	static const float timeAccelRates[];
 
 	static bool joystickEnabled;


### PR DESCRIPTION
Its been discovered that SDL_VIDEO_X11_DGAMOUSE=0 fixes the broken mouse grab on Linux that we've known about forever. See #5.

There's anecdotal evidence to suggest this is a bug in the evdev kernel driver - it doesn't implement parts of DGA correctly.

http://en.gentoo-wiki.com/wiki/X.Org/Mouse#Uncontrollable_mouse_in_SDL_apps
http://www.quakelive.com/forum/showthread.php?5507-Raw-mouse-input-under-Linux
https://bugs.freedesktop.org/show_bug.cgi?id=20770
https://bugs.launchpad.net/ubuntu/+source/xserver-xorg-input-evdev/+bug/205480

Since DGA is ancient and deprecated, I'm not entirely surprised that it hasn't been fixed. SDL2 uses a different mechanism for mouse grabs (`XGrabPointer`) which shouldn't have any of these problems.

With this environment variable, SDL uses an alternate implementation to mouse grabbing, which isn't really much more than just turning off the mouse pointer and sending mouse warp events to X to keep the mouse inside the window.

So this patch sets that environment variable early on Linux only, and also adds a little tracking to restore the mouse pointer to its pre-grab location (which SDL's alternate grab implementation doesn't do). It also adds a config item, `SDLUseDGAMouse` to use the default behaviour on the off chance a user prefers it.
