### PR TITLE
Ignore key bindings when the console is active

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -618,7 +618,10 @@ void Pi::HandleEvents()
 			continue;
 
 		Gui::HandleSDLEvent(&event);
-		KeyBindings::DispatchSDLEvent(&event);
+		if (!Pi::IsConsoleActive())
+			KeyBindings::DispatchSDLEvent(&event);
+		else
+			KeyBindings::toggleLuaConsole.CheckSDLEventAndDispatch(&event);
 
 		switch (event.type) {
 			case SDL_KEYDOWN:


### PR DESCRIPTION
Fixes #1364, and the same problem for the scanner range mode key and the rotation damping key.

Like all the places where we ignore some input while the console is active, this is an ugly hack.
