### PR TITLE
strtof is C++11, not supported on Visual Studio yet.

### DIFF
--- a/src/IniConfig.cpp
+++ b/src/IniConfig.cpp
@@ -52,7 +52,7 @@ float IniConfig::Float(const std::string &section, const std::string &key, float
 	const StringRange val = StringRange(it->second.c_str(), it->second.size()).StripSpace();
 	if (val.Empty()) return defval;
 	char *end = 0;
-	float x = strtof(val.begin, &end);
+	float x = strtod(val.begin, &end);
 	if (end != val.end) return defval;
 	return x;
 }


### PR DESCRIPTION
strtof is C++11, not supported on Visual Studio yet.
Switched to strtod.
