### PR TITLE
Fix alpha blended text

### DIFF
--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -213,6 +213,8 @@ void TextureFont::RenderString(const char *str, float x, float y, const Color &c
 	m_renderer->SetBlendMode(Graphics::BLEND_ALPHA_PREMULT);
 	m_vertices.Clear();
 
+	const Color premult_color = Color(color.r * color.a, color.g * color.a, color.b * color.a, color.a);
+
 	float px = x;
 	float py = y;
 
@@ -231,7 +233,7 @@ void TextureFont::RenderString(const char *str, float x, float y, const Color &c
 			i += n;
 
 			const glfglyph_t &glyph = GetGlyph(chr);
-			AddGlyphGeometry(&m_vertices, glyph, roundf(px), py, color);
+			AddGlyphGeometry(&m_vertices, glyph, roundf(px), py, premult_color);
 
 			if (str[i]) {
 				Uint32 chr2;
@@ -259,6 +261,7 @@ Color TextureFont::RenderMarkup(const char *str, float x, float y, const Color &
 	float py = y;
 
 	Color c = color;
+	Color premult_c = Color(c.r*c.a, c.g*c.a, c.b*c.a, c.a);
 
 	int i = 0;
 	while (str[i]) {
@@ -268,6 +271,10 @@ Color TextureFont::RenderMarkup(const char *str, float x, float y, const Color &
 				c.r = float((hexcol&0xf00)>>4)/255.0f;
 				c.g = float((hexcol&0xf0))/255.0f;
 				c.b = float((hexcol&0xf)<<4)/255.0f;
+				// retain alpha value from RenderMarkup color parameter
+				premult_c.r = c.r * c.a;
+				premult_c.g = c.g * c.a;
+				premult_c.b = c.b * c.a;
 				i+=4;
 				continue;
 			}
@@ -286,7 +293,7 @@ Color TextureFont::RenderMarkup(const char *str, float x, float y, const Color &
 			i += n;
 
 			const glfglyph_t &glyph = GetGlyph(chr);
-			AddGlyphGeometry(&m_vertices, glyph, roundf(px), py, c);
+			AddGlyphGeometry(&m_vertices, glyph, roundf(px), py, premult_c);
 
 			// XXX kerning doesn't skip markup
 			if (str[i]) {


### PR DESCRIPTION
Since #1899, TextureFont has rendered with BLEND_ALPHA_PREMULT, because the texture itself stores (and has always stored) colours with pre-multiplied alpha. This is clear from the fact that the luminance value (in the RGB channels) is set to the same as the alpha value. That's true for the old RGBA storage, and the 2-channel luminance/alpha storage, and the 1-channel intensity storage (when a GL_INTENSITY texture is sampled, the stored value is replicated across the four canonical RGBA channels).

However, although the texture is in pre-multiplied alpha format, the vertex colours (used to control the overall text colour) are in non-pre-multiplied format. This patch fixes `TextureFont::RenderString` and `TextureFont::RenderMarkup` to convert the text colour to pre-multiplied format, so that text colours with alpha values less than 1 are rendered as expected.

Fixes #1904.
