### PR TITLE
Limit model material shininess to 128

### DIFF
--- a/src/graphics/Material.cpp
+++ b/src/graphics/Material.cpp
@@ -14,7 +14,7 @@ Material::Material() :
 	diffuse(Color::WHITE),
 	specular(Color::BLACK),
 	emissive(Color::BLACK),
-	shininess(100.0), //somewhat sharp
+	shininess(100), //somewhat sharp
 	twoSided(false),
 	specialParameter0(0)
 {

--- a/src/graphics/Material.h
+++ b/src/graphics/Material.h
@@ -71,7 +71,7 @@ public:
 	Color diffuse;
 	Color specular;
 	Color emissive;
-	int shininess; //specular power
+	int shininess; //specular power 0-128
 
 	virtual void Apply() { }
 	virtual void Unapply() { }

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -219,6 +219,7 @@ Model *Loader::CreateModel(ModelDefinition &def)
 		mat->specular = (*it).specular;
 		mat->emissive = (*it).emissive;
 		mat->shininess = (*it).shininess;
+
 		//semitransparent material
 		//the node must be marked transparent when using this material
 		//and should not be mixed with opaque materials

--- a/src/scenegraph/LoaderDefinitions.h
+++ b/src/scenegraph/LoaderDefinitions.h
@@ -19,7 +19,7 @@ struct MaterialDefinition {
 		specular(Color(1.f)),
 		ambient(Color(0.f)),
 		emissive(Color(0.f)),
-		shininess(200),
+		shininess(100),
 		opacity(100),
 		use_pattern(false)
 	{ }
@@ -31,8 +31,8 @@ struct MaterialDefinition {
 	Color specular;
 	Color ambient;
 	Color emissive;
-	int shininess; //specular power, 0+
-	int opacity;
+	unsigned int shininess; //specular power, 0-128
+	unsigned int opacity; //0-100
 	bool use_pattern;
 };
 
@@ -75,4 +75,5 @@ struct ModelDefinition {
 };
 
 }
+
 #endif

--- a/src/scenegraph/Parser.cpp
+++ b/src/scenegraph/Parser.cpp
@@ -187,7 +187,7 @@ bool Parser::parseLine(const std::string &line)
 				else if (match(token, "shininess")) {
 					int shininess;
 					ss >> shininess;
-					m_curMat->shininess = std::max(shininess, 0);
+					m_curMat->shininess = Clamp(shininess, 0, 128);
 					return true;
 				} else if (match(token, "opacity")) {
 					int opacity;


### PR DESCRIPTION
The shader based implementation happily accepts higher values, but LegacyMaterial will cause GL_INVALID_VALUE with values outside 0-128 range. The default value was 200, but this problem was hidden until #1908.

Please cp this to a30 freeze since this is sure to cause problems...
