### PR TITLE
Handle missing model material definitions

### DIFF
--- a/src/scenegraph/LoaderDefinitions.h
+++ b/src/scenegraph/LoaderDefinitions.h
@@ -10,8 +10,8 @@
 namespace SceneGraph {
 
 struct MaterialDefinition {
-	MaterialDefinition() :
-		name(""),
+	MaterialDefinition(const std::string &n) :
+		name(n),
 		tex_diff(""),
 		tex_spec(""),
 		tex_glow(""),

--- a/src/scenegraph/Parser.cpp
+++ b/src/scenegraph/Parser.cpp
@@ -46,6 +46,14 @@ void Parser::Parse(ModelDefinition *m)
 			throw ParseError(ss.str());
 		}
 	}
+
+	if (m->lodDefs.empty() || m->lodDefs.back().meshNames.empty())
+		throw ParseError("No meshes defined");
+
+	//model without materials is not very useful but not fatal - add white default mat
+	if (m->matDefs.empty())
+		m->matDefs.push_back(MaterialDefinition("Default"));
+
 	//sort lods by feature size
 	std::sort(m->lodDefs.begin(), m->lodDefs.end(), LodSortPredicate);
 }
@@ -116,9 +124,8 @@ bool Parser::parseLine(const std::string &line)
 			m_isMaterial = true;
 			string matname;
 			checkMaterialName(ss, matname);
-			m_model->matDefs.push_back(MaterialDefinition());
+			m_model->matDefs.push_back(MaterialDefinition(matname));
 			m_curMat = &m_model->matDefs.back();
-			m_curMat->name = matname;
 			return true;
 		} else if(match(token, "lod")) {
 			endMaterial();


### PR DESCRIPTION
The absolute minimum .model definition is now

```
mesh something.dae
```

Fixes #1817
