### PR TITLE
Support to render minimum star halo

### DIFF
--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -51,8 +51,8 @@ void Star::Render(Graphics::Renderer *renderer, const Camera *camera, const vect
 		rad *= 0.99;
 		fpos = 0.99*fpos;
 		len *= 0.99;
-		if (rad <= 30.0) rad=30.0;
 	}
+	if (rad <= 30.0) rad=30.0; //minimum halo size
 
 	matrix4x4d trans = matrix4x4d::Identity();
 	trans.Translate(float(fpos.x), float(fpos.y), float(fpos.z));


### PR DESCRIPTION
This is just to have a minimum star halo.
I think it's nice to actually have the stars in the system you're in abit brighter than the background star so you can spot them easily when orienting..
