### PR TITLE
remove revived cargoscoop surface check again

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -340,7 +340,7 @@ bool Ship::OnCollision(Object *b, Uint32 flags, double relVel)
 	}
 
 	// hitting cargo scoop surface shouldn't do damage
-	if ((m_equipment.Get(Equip::SLOT_CARGOSCOOP) != Equip::NONE) && b->IsType(Object::CARGOBODY) && (flags & 0x100) && m_stats.free_capacity) {
+	if ((m_equipment.Get(Equip::SLOT_CARGOSCOOP) != Equip::NONE) && b->IsType(Object::CARGOBODY) && m_stats.free_capacity) {
 		Equip::Type item = dynamic_cast<CargoBody*>(b)->GetCargoType();
 		Pi::game->GetSpace()->KillBody(dynamic_cast<Body*>(b));
 		m_equipment.Add(item);


### PR DESCRIPTION
For some reason the check for the special cargoscoop surface was revived in merge 8dc4024bd3f296513a671c47626dadfb3f00cc17. So cargo scooping was not working. The revive was probably accidental, so this removes the check again.
