### PR TITLE
Fix definition for big_crappy station

### DIFF
--- a/data/lmrmodels/spacestations.lua
+++ b/data/lmrmodels/spacestations.lua
@@ -626,7 +626,7 @@ define_model('big_crappy_spacestation', {
 		billboard('smoke.png', 350.0, v(0,1,0), {v(1620,0,0)})
 		billboard('smoke.png', 350.0, v(1,1,1), {v(0,-515,0)})
 		-- docking trigger surface (only need to indicate surface for
-		-- port zero since this is a 'dock_one_at_a_time_please' station
+		-- port zero since this is a 'dock_one_at_a_time' station
 		geomflag(0x10)
 		invisible_tri(v(-100,600,-100),v(100,600,100),v(100,600,-100))
 		invisible_tri(v(-100,600,-100), v(-100,600,100),v(100,600,100))

--- a/data/stations/big_crappy.lua
+++ b/data/stations/big_crappy.lua
@@ -6,8 +6,8 @@ define_orbital_station {
 	parking_gap_size = 500.0,
 	ship_launch_stage = 3,
 	-- for stations where each docking port shares the
-	-- same front door, set dock_one_at_a_time_please = true,
-	dock_one_at_a_time_please = true,
+	-- same front door, set dock_one_at_a_time = true,
+	dock_one_at_a_time = true,
 	dock_anim_stage_duration = { DOCKING_TIMEOUT_SECONDS, 10.0, 5.0, 5.0 },
 	undock_anim_stage_duration = { 5.0, 5.0, 10.0 },
 	ship_dock_anim = function(port, stage, t, from, ship_aabb)


### PR DESCRIPTION
Fixes #1931.

When testing, note that the bug only occurs if there is already a ship docked in the station, because otherwise you will be assigned port zero, which passes the port check in `SpaceStation::OnCollision` (the shared entry port collision geometry is for port zero).
