### PR TITLE
Fix New Hope always being automaticly relocated

### DIFF
--- a/data/systems/01_epsilon_eridani.lua
+++ b/data/systems/01_epsilon_eridani.lua
@@ -74,8 +74,8 @@ local newhope = CustomSystemBody:new('New Hope', 'PLANET_TERRESTRIAL')
 
 	local newhope_starports = {
 	CustomSystemBody:new('New Hope', 'STARPORT_SURFACE')
-		:latitude(math.deg2rad(31))
-		:longitude(math.deg2rad(-121)),
+		:latitude(math.deg2rad(-32.578))
+		:longitude(math.deg2rad(90.12)),
 	CustomSystemBody:new("Gandhi's Revenge", 'STARPORT_SURFACE')
 		:latitude(math.deg2rad(19))
 		:longitude(math.deg2rad(99)),


### PR DESCRIPTION
This is New Hope's real position after being automaticly relocated.
Also moved it abit towards the cliff edge.
It's original position is in middle of the Ocean somewhere.

![Alt Text](https://dl.dropbox.com/u/11319604/gbnh.png)
