### PR TITLE
Set ship label on SGModel ships

### DIFF
--- a/src/LmrModel.cpp
+++ b/src/LmrModel.cpp
@@ -1502,8 +1502,6 @@ void LmrModel::Render(Graphics::Renderer *r, const matrix4x4f &trans, LmrObjPara
 
 void LmrModel::Render(const RenderState *rstate, const vector3f &cameraPos, const matrix4x4f &trans, LmrObjParams *params)
 {
-	if (!params->label) params->label = m_label.c_str();
-
 	// XXX some parts of models (eg billboards) are drawn through the
 	// renderer, while other stuff is drawn directly. we must make sure that
 	// we keep the renderer and the GL transform in sync otherwise weird stuff

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -151,6 +151,7 @@ void ModelBody::RenderLmrModel(Graphics::Renderer *r, const vector3d &viewCoords
 	trans[14] = viewCoords.z;
 	trans[15] = 1.0f;
 
+	m_params.label = GetLabel().c_str();
 	m_model->Render(r, trans, &m_params);
 	glPopMatrix();
 }


### PR DESCRIPTION
So you can set the ship registration label. I've tried to do this in the least intrusive way, so its still driven from `ShipFlavour`. Fixing that is a job for another time.

![](http://i.imgur.com/C8qgxZV.png)

![](http://i.imgur.com/2LYwMxJ.jpg)

(The black box is an uninitialised decal, fixed in #1976. The hyphen being down on the baseline in the second image is a problem with `DistanceFieldFont` ignoring glyph offsets. I'm working on that now and will have a PR for it soon).
