### PR TITLE
Read distance field font glyph offsets from font config

### DIFF
--- a/src/text/DistanceFieldFont.cpp
+++ b/src/text/DistanceFieldFont.cpp
@@ -162,7 +162,7 @@ void DistanceFieldFont::ParseChar(const StringRange &r)
 	g.uv = vector2f(float(x)/m_sheetSize.x, float(y)/m_sheetSize.y);
 	g.uvSize = vector2f(float(uSize)/m_sheetSize.x, float(vSize)/m_sheetSize.y);
 	g.size = vector2f(float(uSize), float(vSize)) * scale;
-	g.offset = vector2f(float(xoffset), float(yoffset)) * scale;
+	g.offset = vector2f(float(xoffset), float(m_lineHeight-vSize-yoffset)) * scale;
 	g.xAdvance = advance * scale;
 	m_glyphs[id] = g;
 }
@@ -179,6 +179,8 @@ void DistanceFieldFont::ParseCommon(const StringRange &line)
 			m_sheetSize.x = get_value<float>(pair.second);
 		else if (pair.first == "scaleH")
 			m_sheetSize.y = get_value<float>(pair.second);
+		else if (pair.first == "lineHeight")
+			m_lineHeight = get_value<float>(pair.second);
 	}
 }
 

--- a/src/text/DistanceFieldFont.h
+++ b/src/text/DistanceFieldFont.h
@@ -50,6 +50,7 @@ private:
 	Graphics::Texture *m_texture;
 	std::map<Uint32, Glyph> m_glyphs;
 	vector2f m_sheetSize;
+	float m_lineHeight;
 	float m_fontSize; //32 etc. Glyph size/advance will be scaled to 1/fontSize.
 
 	void AddGlyph(Graphics::VertexArray &va, const vector2f &pos, const Glyph&, vector2f &bounds);


### PR DESCRIPTION
The offsets were already being added when drawing, just not loaded from the config.

With #1979:

![](http://i.imgur.com/PYDiqYu.jpg)
