### PR TITLE
Fix clumsy police spawns, prevents the intensive collisons when they spawn.

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -451,7 +451,7 @@ void SpaceStation::StaticUpdate(const float timeStep)
 		m_lastUpdatedShipyard = Pi::game->GetTime() + 3600.0 + 3600.0*Pi::rng.Double();
 	}
 
-	DoLawAndOrder();
+	DoLawAndOrder(timeStep);
 	DockingUpdate(timeStep);
 }
 
@@ -788,7 +788,7 @@ vector3d SpaceStation::GetTargetIndicatorPosition(const Frame *relTo) const
 	return GetInterpPositionRelTo(relTo);
 }
 
-void SpaceStation::DoLawAndOrder()
+void SpaceStation::DoLawAndOrder(const double timeStep)
 {
 	Sint64 fine, crimeBitset;
 	Polit::GetCrime(&crimeBitset, &fine);
@@ -797,7 +797,8 @@ void SpaceStation::DoLawAndOrder()
 			&& (fine > 1000)
 			&& (GetPositionRelTo(Pi::player).Length() < 100000.0)) {
 		int port = GetFreeDockingPort();
-		if (port != -1) {
+		//Spawn police with small delay between ships
+		if (port != -1 && 2.0*Pi::rng.Double() < timeStep) {
 			m_numPoliceDocked--;
 			// Make police ship intent on killing the player
 			Ship *ship = new Ship(ShipType::LADYBIRD);

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -114,7 +114,7 @@ protected:
 private:
 	void DockingUpdate(const double timeStep);
 	void PositionDockedShip(Ship *ship, int port) const;
-	void DoLawAndOrder();
+	void DoLawAndOrder(const double timeStep);
 	void CalcLighting(Planet *planet, double &ambient, double &intensity, const std::vector<Camera::LightSource> &lightSources);
 
 	/* Stage 0 means docking port empty


### PR DESCRIPTION
It just adds a small delay between each police ship spawned to prevent the intensive collisions happening when police spawns wich really kills fps.
