### PR TITLE
Fix console completion crashes

### DIFF
--- a/src/LuaObject.cpp
+++ b/src/LuaObject.cpp
@@ -358,6 +358,13 @@ static void get_names_from_table(lua_State *l, std::vector<std::string> &names, 
 	lua_pushnil(l);
 	while (lua_next(l, -2)) {
 
+		// only include string keys. the . syntax doesn't work for anything
+		// else
+		if (lua_type(l, -2) != LUA_TSTRING) {
+			lua_pop(l, 1);
+			continue;
+		}
+
 		// only include callable things if requested
 		if (methodsOnly && lua_type(l, -1) != LUA_TFUNCTION) {
 			lua_pop(l, 1);


### PR DESCRIPTION
There's a few ways to make the game crash via console completion:
- Try to complete on a non-table/non-userdata type.
- Try to complete on a read-only table proxy object (eg those used for anything under `Constants`).
- Try to complete on a table with non-string keys.

This fixes all of those.
