### PR TITLE
Produce a whole bunch of debug info when terrains fail

### DIFF
--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -28,7 +28,11 @@ public:
 		// XXX don't remove this. Fix your fractals instead
 		// Fractals absolutely MUST return heights >= 0.0 (one planet radius)
 		// otherwise atmosphere and other things break.
-		assert(h >= 0.0);
+		if (h < 0.0) {
+			fprintf(stderr, "GetHeight({ %f, %f, %f }) returned %f\n", p.x, p.y, p.z, h);
+			m_terrain->DebugDump();
+			assert(h >= 0.0);
+		}
 #endif /* DEBUG */
 		return h;
 	}

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -573,3 +573,18 @@ void Terrain::SetFracDef(unsigned int index, double featureHeightMeters, double 
 	m_fracdef[index].lacunarity = 2.0;
 	//printf("%d octaves\n", m_fracdef[index].octaves); //print
 }
+
+void Terrain::DebugDump() const
+{
+	fprintf(stderr, "Terrain state dump:\n");
+	fprintf(stderr, "  Height fractal: %s\n", GetHeightFractalName());
+	fprintf(stderr, "  Color fractal: %s\n", GetColorFractalName());
+	fprintf(stderr, "  Detail: fracnum %d  fracmult %f  textures %s\n", m_fracnum, m_fracmult, textures ? "true" : "false");
+	fprintf(stderr, "  Config: DetailPlanets %d   FractalMultiple %d  Textures  %d\n", Pi::config->Int("DetailPlanets"), Pi::config->Int("FractalMultiple"), Pi::config->Int("Textures"));
+	fprintf(stderr, "  Seed: %d\n", m_seed);
+	fprintf(stderr, "  Body: %s [%d,%d,%d,%u,%u]\n", m_body->name.c_str(), m_body->path.sectorX, m_body->path.sectorY, m_body->path.sectorZ, m_body->path.systemIndex, m_body->path.bodyIndex);
+	fprintf(stderr, "  Fracdefs:\n");
+	for (int i = 0; i < 10; i++) {
+		fprintf(stderr, "    %d: amp %f  freq %f  lac %f  oct %d\n", i, m_fracdef[i].amplitude, m_fracdef[i].frequency, m_fracdef[i].lacunarity, m_fracdef[i].octaves);
+	}
+}

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -50,6 +50,8 @@ public:
 
 	Uint32 GetSurfaceEffects() const { return m_surfaceEffects; }
 
+	void DebugDump() const;
+
 private:
 	template <typename HeightFractal, typename ColorFractal>
 	static Terrain *InstanceGenerator(const SystemBody *body) { return new TerrainGenerator<HeightFractal,ColorFractal>(body); }


### PR DESCRIPTION
Whenever people hit that h>=0 assert, we have no idea what really happening. This throws a bunch of info about the current terrain into stderr.txt to help debug it.

Sample output:

```
GetHeight({ 0.567496, -0.715613, -0.407243 }) returned 0.000349
Terrain state dump:
  Height fractal: MountainsNormal
  Color fractal: EarthLike
  Detail: fracnum 0  fracmult 1.000000  textures true
  Config: DetailPlanets 2   FractalMultiple 2  Textures  1
  Seed: 43
  Body: New Hope [1,-1,-1,0,3]
  Fracdefs:
    0: amp 1.000000  freq 4.664804  lac 2.000000  oct 8
    1: amp 0.000000  freq 85041.799995  lac 2.000000  oct 4
    2: amp 0.000000  freq 7886.079270  lac 2.000000  oct 1
    3: amp 0.000020  freq 1305.781353  lac 2.000000  oct 7
    4: amp 0.080000  freq 850.418000  lac 2.000000  oct 7
    5: amp 0.200000  freq 85.041800  lac 2.000000  oct 10
    6: amp 0.500000  freq 8.504180  lac 2.000000  oct 10
    7: amp 0.500000  freq 2.184295  lac 2.000000  oct 12
    8: amp 1.000000  freq 1.897802  lac 2.000000  oct 13
    9: amp 0.000000  freq 0.000000  lac 0.000000  oct 0
```
