### PR TITLE
Fix bug reported on Forum by AkiNebulae: Red screen during save

### DIFF
--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -369,6 +369,12 @@ local onGameStart = function ()
 end
 
 local serialize = function ()
+	-- Remove non-existent ships first, or the serializer will choke
+	for crewedShip,crew in pairs(CrewRoster) do
+		if not crewedShip:exists() then
+			CrewRoster[crewedShip] = nil
+		end
+	end
     return CrewRoster
 end
 


### PR DESCRIPTION
This error is caused by trying to save a table of ships, when a ship has stopped existing. The fix is to have the serializer function check each ship for reality, and removing those that aren't real any more before returning the table to the serializer.
![](http://img405.imageshack.us/img405/872/clipboard02qq.png)
