### PR TITLE
Re-initialise tables with new game. Closes #2038

### DIFF
--- a/data/modules/CrewContracts/CrewContracts.lua
+++ b/data/modules/CrewContracts/CrewContracts.lua
@@ -384,6 +384,9 @@ end)
 -- Load temporary crew from saved data
 local loaded_data
 Event.Register("onGameStart", function()
+    -- XXX Need to re-initialise these until Lua is re-initialised with a new game
+    nonPersistentCharactersForCrew = {}
+    stationsWithAdverts = {}
 	if loaded_data then
 		nonPersistentCharactersForCrew = loaded_data.nonPersistentCharactersForCrew
 		for k,station in ipairs(loaded_data.stationsWithAdverts) do


### PR DESCRIPTION
So, just when I thought I understood what went wrong... the bug comes back, this time with reproduction instructions. While #2025 was a legitimate bug fix, it's not for one that had actually manifested.

The problem here (#2038) is that the Lua environment isn't instanced per-game yet, so all module-local tables and variables really need to be re-initialised in onGameStart. Assuming that we hope to fix this situation in time, I've added an `XXX` comment.
