### PR TITLE
Add 'Set Hyperspace Target' button on mission screens.

### DIFF
--- a/data/libs/ui/SmallLabeledButton.lua
+++ b/data/libs/ui/SmallLabeledButton.lua
@@ -2,11 +2,12 @@ local ui = Engine.ui
 
 UI.SmallLabeledButton = {
 
-New = function (text)
+New = function (text,font)
 	local self = {
 		button = ui:SmallButton(),
 		label  = ui:Label(text),
 	}
+	if font and type(font) == "string" then self.label = ui:Label(text):SetFont(font) end
 	self.widget = ui:HBox(10):PackEnd({ self.button, self.label })
 
 	setmetatable(self, {

--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -407,6 +407,12 @@ end
 local onClick = function (mission)
 	local ass_flavours = Translate:GetFlavours('Assassination')
 	local dist = Game.system:DistanceTo(mission.location)
+	local setHyperspaceButton = UI.SmallLabeledButton.New(t('Set as Hyperspace Target'), 'SMALL')
+	setHyperspaceButton.button.onClick:Connect(function () 
+		if Game.player:GetHyperspaceTarget() ~= mission.location:GetStarSystem().path then
+			Game.player:SetHyperspaceTarget(mission.location:GetStarSystem().path) 
+		end
+		end)
 	return ui:Grid(2,1)
 		:SetColumn(0,{ui:VBox(10):PackEnd({ui:MultiLineText((ass_flavours[mission.flavour].introtext):interp({
 														name   = mission.client.name,
@@ -424,6 +430,8 @@ local onClick = function (mission)
 													ui:Label(mission.target),
 													ui:Label(mission.location:GetSystemBody().name),
 													ui:Label(mission.location:GetStarSystem().name.." ("..mission.location.sectorX..","..mission.location.sectorY..","..mission.location.sectorZ..")"),
+													setHyperspaceButton.widget,
+													ui:Margin(6),
 													ui:Label(mission.shipname),
 													ui:Label(mission.shipregid),
 													ui:Label(Format.Date(mission.due)),

--- a/data/modules/Assassination/Languages.lua
+++ b/data/modules/Assassination/Languages.lua
@@ -75,6 +75,8 @@ Translate:Add({ English = {
   Target name:
   Spaceport:
   System:
+  
+  
   Ship:
   Ship ID:
   Target will be leaving spaceport at:
@@ -178,6 +180,8 @@ Translate:Add({ Polski = {
   Cel:
   Port kosmiczny:
   System:
+  
+  
   Statek:
   Identyfikator:
   Cel będzie opuszczał port kosmiczny o:
@@ -461,6 +465,8 @@ Translate:Add({ Russian = {
  Цель:
   Станция нахождения:
   Система нахождения:
+  
+  
   Тип корабля:
   Номер корабля:
   Цель покинет станцию:
@@ -563,6 +569,8 @@ Translate:Add({ Deutsch = {
   Zielname:
   Raumhafen:
   System:
+  
+  
   Schiff:
   Schiff-ID:
   Ziel wird Raumhafen verlassen um:

--- a/data/modules/DeliverPackage/DeliverPackage.lua
+++ b/data/modules/DeliverPackage/DeliverPackage.lua
@@ -293,6 +293,13 @@ end
 local onClick = function (mission)
 	local delivery_flavours = Translate:GetFlavours('DeliverPackage')
 	local dist = Game.system:DistanceTo(mission.location)
+	local setHyperspaceButton = UI.SmallLabeledButton.New(t('Set as Hyperspace Target'), 'SMALL')
+	setHyperspaceButton.button.onClick:Connect(function () 
+		if Game.player:GetHyperspaceTarget() ~= mission.location:GetStarSystem().path then
+			Game.player:SetHyperspaceTarget(mission.location:GetStarSystem().path) 
+		end
+		end)
+	if delivery_flavours[mission.flavour].localdelivery == 1 then setHyperspaceButton.widget:Disable() end
 	return ui:Grid(2,1)
 		:SetColumn(0,{ui:VBox(10):PackEnd({ui:MultiLineText((delivery_flavours[mission.flavour].introtext):interp({
 														name   = mission.client.name,
@@ -312,11 +319,14 @@ local onClick = function (mission)
 												ui:VBox():PackEnd({
 													ui:Label(mission.location:GetSystemBody().name),
 													ui:Label(mission.location:GetStarSystem().name.." ("..mission.location.sectorX..","..mission.location.sectorY..","..mission.location.sectorZ..")"),
+													setHyperspaceButton.widget,
+													ui:Margin(6),
 													ui:Label(Format.Date(mission.due)),
-													ui:Margin(10),
 													ui:Label(math.ceil(dist).." "..t("ly"))
 												})
 											})
+
+			
 		})})
 		:SetColumn(1, {
 			ui:VBox(10):PackEnd(UI.InfoFace.New(mission.client))

--- a/data/modules/DeliverPackage/Languages.lua
+++ b/data/modules/DeliverPackage/Languages.lua
@@ -142,8 +142,9 @@ Translate:Add({ English = {
   delivermissiondetail = [[
   Spaceport:
   System:
+  
+  
   Deadline:
-
   Distance:]],
 
  PIRATE_TAUNTS = {

--- a/data/modules/DeliverPackage/Languages.lua
+++ b/data/modules/DeliverPackage/Languages.lua
@@ -293,6 +293,8 @@ Translate:Add({ Polski = {
   delivermissiondetail = [[
   Port kosmiczny:
   System:
+  
+  
   Termin:
 
   Dystans:]],
@@ -724,6 +726,8 @@ Translate:Add({ Russian = {
   delivermissiondetail = [[
   Станция получателя:
   Система получателя:
+  
+  
   Срок доставки:
   
   Расстояние:]],
@@ -874,6 +878,8 @@ Translate:Add({ Deutsch = {
   delivermissiondetail = [[
   Raumhafen:
   System:
+  
+  
   Deadline:
 
   Distanz:]],

--- a/data/modules/Taxi/Languages.lua
+++ b/data/modules/Taxi/Languages.lua
@@ -215,6 +215,8 @@ Translate:Add({ English = {
   taximissiondetail = [[
   From:
   To:
+  
+  
   Group details:
   Danger:
   Deadline:

--- a/data/modules/Taxi/Languages.lua
+++ b/data/modules/Taxi/Languages.lua
@@ -447,6 +447,8 @@ Translate:Add({ Polski = {
   taximissiondetail = [[
   Z:
   Do:
+  
+  
   Pasażerów:
   Zagrożenie:
   Termin:
@@ -1185,6 +1187,8 @@ Translate:Add({ Russian = {
   taximissiondetail = [[
   Начало маршрута:
   Конец маршрута:
+  
+  
   О группе:
   Опасность:
   Крайний срок:
@@ -1415,6 +1419,8 @@ Translate:Add({ Deutsch = {
   taximissiondetail = [[
   Von:
   Nach:
+  
+  
   Gruppendetails:
   Gefahr:
   Deadline:

--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -330,6 +330,12 @@ end
 local onClick = function (mission)
 	local taxi_flavours = Translate:GetFlavours('Taxi')
 	local dist = Game.system:DistanceTo(mission.location)
+	local setHyperspaceButton = UI.SmallLabeledButton.New(t('Set as Hyperspace Target'), 'SMALL')
+	setHyperspaceButton.button.onClick:Connect(function () 
+		if Game.player:GetHyperspaceTarget() ~= mission.location:GetStarSystem().path then
+			Game.player:SetHyperspaceTarget(mission.location:GetStarSystem().path) 
+		end
+	end)
 	return ui:Grid(2,1)
 		:SetColumn(0,{ui:VBox(10):PackEnd({ui:MultiLineText((taxi_flavours[mission.flavour].introtext):interp({
 														name   = mission.client.name,
@@ -348,6 +354,8 @@ local onClick = function (mission)
 												ui:VBox():PackEnd({
 													ui:Label(mission.start:GetStarSystem().name.." ("..mission.location.sectorX..","..mission.location.sectorY..","..mission.location.sectorZ..")"),
 													ui:Label(mission.location:GetStarSystem().name.." ("..mission.location.sectorX..","..mission.location.sectorY..","..mission.location.sectorZ..")"),
+													setHyperspaceButton.widget,
+													ui:Margin(6),
 													ui:Label(string.interp(taxi_flavours[mission.flavour].howmany, {group = mission.group})),
 													ui:Label(taxi_flavours[mission.flavour].danger),
 													ui:Label(Format.Date(mission.due)),


### PR DESCRIPTION
As the title says, I added a button on the mission screens that will set the players hyperspace target to the mission location StarSystem. I attempted to add it in InfoView.lua, but couldn't make room on the screen for it. Although, I am running at 1024x768 resolution so I'm sure it's not as bad on higher resolutions.

I'm not very happy with how it looks, however. It seems kind of out of place. 
![image](https://f.cloud.github.com/assets/2941180/144452/bf69bb74-741c-11e2-85b9-0ba72534da61.png)


Ideas on how to improve this are very welcome. 

Included in this PR is a commit adding a font argument to the SmallLabeledButton, I found it useful for making the text smaller; as far as I know, you can't call :SetFont() on it. But I'm not sure if it needs to be in here.