### PR TITLE
Adding one laser to dsminer

### DIFF
--- a/data/ships/dsminer.lua
+++ b/data/ships/dsminer.lua
@@ -14,7 +14,7 @@ define_ship {
 	camera_offset = v(0,4,-35),
 	max_atmoshield = 0,
 	max_cargo = 500,
-	max_laser = 0,
+	max_laser = 1,
 	max_missile = 2,
 	max_cargoscoop = 1,
 	max_fuelscoop = 1,


### PR DESCRIPTION
The Deep Space Miner has got the word "Miner" in its name. In addition to this it has got a lot of cargo space and a cargoscoop. It is the ideal mining vehicle - but without a mining laser it doesn't make sense. So I added one line to add one laser slot. Only one slot because it is enough for mining but not enough for having a really strong fighter. And the miner shouldn't be used as a fighter. 
