### PR TITLE
Test object_missile in the missile callback (closes: #2066)

### DIFF
--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -73,6 +73,9 @@ function Ship:FireMissileAt(missile, target)
 		end
 		-- Let's keep a safe distance before activating this device, shall we ?
 		Timer:CallEvery(2, function ()
+			if not missile_object:exists() then -- Usually means it has already exploded
+				return true
+			end
 			if missile_object:DistanceTo(self) < 300 then
 				return false
 			else


### PR DESCRIPTION
If a missile explodes before being activated (because shot at, ECMed or
by direct contact with any Body, including its target) the Timer set to
activate it wasn't aware of it, hence the Lua equivalent of a segfault.
