### PR TITLE
Fix #2074

### DIFF
--- a/src/scenegraph/Billboard.cpp
+++ b/src/scenegraph/Billboard.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Billboard.h"
+#include "NodeVisitor.h"
 #include "graphics/Renderer.h"
 
 namespace SceneGraph {
@@ -32,6 +33,11 @@ Billboard::Billboard(const Billboard &billboard)
 Node* Billboard::Clone()
 {
 	return new Billboard(*this);
+}
+
+void Billboard::Accept(NodeVisitor &nv)
+{
+	nv.ApplyBillboard(*this);
 }
 
 void Billboard::Render(const matrix4x4f &trans, RenderData *rd)

--- a/src/scenegraph/Billboard.h
+++ b/src/scenegraph/Billboard.h
@@ -17,6 +17,7 @@ public:
 	Billboard(Graphics::Renderer *r, const std::vector<vector3f>&, RefCountedPtr<Graphics::Material>, float size);
 	Billboard(const Billboard&);
 	virtual Node *Clone();
+	virtual void Accept(NodeVisitor &v);
 	virtual const char *GetTypeName() { return "Billboard"; }
 	virtual void Render(const matrix4x4f &trans, RenderData *rd);
 

--- a/src/scenegraph/LOD.cpp
+++ b/src/scenegraph/LOD.cpp
@@ -2,8 +2,9 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "LOD.h"
-#include "graphics/Graphics.h"
+#include "NodeVisitor.h"
 #include "StringF.h"
+#include "graphics/Graphics.h"
 
 namespace SceneGraph {
 
@@ -20,6 +21,11 @@ LOD::LOD(const LOD &lod)
 Node* LOD::Clone()
 {
 	return new LOD(*this);
+}
+
+void LOD::Accept(NodeVisitor &nv)
+{
+	nv.ApplyLOD(*this);
 }
 
 void LOD::AddLevel(float pixelSize, Node *nod)

--- a/src/scenegraph/LOD.h
+++ b/src/scenegraph/LOD.h
@@ -16,6 +16,7 @@ public:
 	LOD(const LOD&);
 	virtual Node *Clone();
 	virtual const char *GetTypeName() { return "LOD"; }
+	virtual void Accept(NodeVisitor &v);
 	void AddLevel(float pixelRadius, Node *child);
 	virtual void Render(const matrix4x4f &trans, RenderData *rd);
 protected:

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Thruster.h"
+#include "NodeVisitor.h"
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
 #include "graphics/Material.h"
@@ -43,6 +44,11 @@ Thruster::Thruster(const Thruster &thruster)
 Node* Thruster::Clone()
 {
 	return this; //thrusters are shared
+}
+
+void Thruster::Accept(NodeVisitor &nv)
+{
+	nv.ApplyThruster(*this);
 }
 
 void Thruster::Render(const matrix4x4f &trans, RenderData *rd)

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -22,6 +22,7 @@ public:
 	Thruster(Graphics::Renderer *, bool linear, const vector3f &pos, const vector3f &dir);
 	Thruster(const Thruster&);
 	Node *Clone();
+	virtual void Accept(NodeVisitor &v);
 	virtual const char *GetTypeName() { return "Thruster"; }
 	virtual void Render(const matrix4x4f &trans, RenderData *rd);
 


### PR DESCRIPTION
Coder decides to use double dispatch, forgets to fully implement it, chaos ensues.

CopyVisitor never called ApplyLOD, so the LODs were replaced by Groups.

Fixes #2074
