### PR TITLE
For Ubuntu 12.10 the COMPILING.txt didn't have all of the necessary packages.

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -33,6 +33,7 @@ Linux - Autotools
     automake
     pkg-config
     libsigc++-dev
+    libsigc++-2.0-dev
     libsdl1.2-dev
     libsdl-image1.2-dev
     libfreetype6-dev


### PR DESCRIPTION
For Ubuntu 12.10 the COMPILING.txt didn't have all of the necessary packages.

Specifically sigc++-2.0.

This is a pitiful documentation update.
