### PR TITLE
Restore ship repair cost to approximately match prior behaviour

### DIFF
--- a/src/StationShipRepairForm.cpp
+++ b/src/StationShipRepairForm.cpp
@@ -60,7 +60,8 @@ void StationShipRepairForm::ShowAll()
 
 int StationShipRepairForm::GetRepairCost(float percent) const
 {
-	return int(Pi::player->GetShipType()->baseprice * percent);
+	// repairing 1% hull damage costs 0.1% of ship price
+	return int(Pi::player->GetShipType()->baseprice * (percent * 0.001));
 }
 
 void StationShipRepairForm::RepairHull(float percent)


### PR DESCRIPTION
Fixes #2113.

This makes repair cost for 1% hull damage equal to 0.1% of the ship base price. That approximately matches behaviour prior to @4878ffe2dc7ef3fe3b7d70e3f0effe76e0e92841.

When the shipyard form is rewritten using new-ui then this value will be controlled directly by Lua.
