### PR TITLE
Fix for the docking problems.

### DIFF
--- a/data/models/stations/hoop_spacestation/dockingpads.dae
+++ b/data/models/stations/hoop_spacestation/dockingpads.dae
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.0">
+  <asset>
+    <contributor>
+      <author></author>
+      <authoring_tool>FBX COLLADA exporter</authoring_tool>
+      <comments></comments>
+    </contributor>
+    <created>2013-03-12T20:03:06Z</created>
+    <modified>2013-03-12T20:03:06Z</modified>
+    <revision></revision>
+    <title></title>
+    <subject></subject>
+    <keywords></keywords>
+    <unit meter="0.025400"/>
+    <up_axis>Y_UP</up_axis>
+  </asset>
+  <library_materials>
+    <material id="wire_204204204" name="wire_204204204">
+      <instance_effect url="#wire_204204204-fx"/>
+    </material>
+  </library_materials>
+  <library_effects>
+    <effect id="wire_204204204-fx" name="wire_204204204">
+      <profile_COMMON>
+        <technique sid="standard">
+          <phong>
+            <emission>
+              <color sid="emission">0.000000  0.000000 0.000000 1.000000</color>
+            </emission>
+            <ambient>
+              <color sid="ambient">0.588000  0.588000 0.588000 1.000000</color>
+            </ambient>
+            <diffuse>
+              <color sid="diffuse">0.588000  0.588000 0.588000 1.000000</color>
+            </diffuse>
+            <specular>
+              <color sid="specular">0.000000  0.000000 0.000000 1.000000</color>
+            </specular>
+            <shininess>
+              <float sid="shininess">2.000000</float>
+            </shininess>
+            <reflective>
+              <color sid="reflective">0.000000  0.000000 0.000000 1.000000</color>
+            </reflective>
+            <reflectivity>
+              <float sid="reflectivity">1.000000</float>
+            </reflectivity>
+            <transparent>
+              <color sid="transparent">1.000000  1.000000 1.000000 1.000000</color>
+            </transparent>
+            <transparency>
+              <float sid="transparency">0.000000</float>
+            </transparency>
+          </phong>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_geometries>
+    <geometry id="collision_pad3-lib" name="collision_pad3Mesh">
+      <mesh>
+        <source id="collision_pad3-lib-Position">
+          <float_array id="collision_pad3-lib-Position-array" count="18">
+-108.241997 -108.241997 507.292511
+108.241997 -108.241997 507.292511
+108.241997 108.241997 507.292511
+-108.241997 108.241997 507.292511
+108.241997 108.241997 507.292511
+-108.241997 -108.241997 507.292511
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad3-lib-Position-array" count="6" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="collision_pad3-lib-Normal0">
+          <float_array id="collision_pad3-lib-Normal0-array" count="18">
+0.000000 0.000000 1.000000
+0.000000 0.000000 1.000000
+0.000000 0.000000 1.000000
+0.000000 0.000000 1.000000
+0.000000 0.000000 1.000000
+0.000000 0.000000 1.000000
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad3-lib-Normal0-array" count="6" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="collision_pad3-lib-UV0">
+          <float_array id="collision_pad3-lib-UV0-array" count="12">
+0.000100 0.000100
+0.999900 0.000100
+0.999900 0.999900
+0.000100 0.999900
+0.999900 0.999900
+0.000100 0.000100
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad3-lib-UV0-array" count="6" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="collision_pad3-lib-Vertex">
+          <input semantic="POSITION" source="#collision_pad3-lib-Position"/>
+        </vertices>
+        <polygons material="wire_204204204" count="2">
+          <input semantic="VERTEX" offset="0" source="#collision_pad3-lib-Vertex"/>
+          <input semantic="NORMAL" offset="1" source="#collision_pad3-lib-Normal0"/>
+          <input semantic="TEXCOORD" offset="2" set="0" source="#collision_pad3-lib-UV0"/>
+          <p>0 0 0 1 1 1 2 2 2</p>
+          <p>4 4 4 3 3 3 5 5 5</p>
+        </polygons>
+      </mesh>
+    </geometry>
+    <geometry id="collision_pad2-lib" name="collision_pad2Mesh">
+      <mesh>
+        <source id="collision_pad2-lib-Position">
+          <float_array id="collision_pad2-lib-Position-array" count="36">
+-0.000001 2.749349 2.749347
+-0.000001 2.749349 -13.205101
+0.000001 -2.749346 -13.205101
+0.000001 -2.749345 2.749348
+-2.749350 -0.000002 2.749347
+-2.749347 0.000001 -13.205101
+2.749348 0.000004 -13.205101
+2.749344 0.000001 2.749348
+0.000001 -2.749346 -13.205101
+-0.000001 2.749349 2.749347
+2.749348 0.000004 -13.205101
+-2.749350 -0.000002 2.749347
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad2-lib-Position-array" count="12" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="collision_pad2-lib-Normal0">
+          <float_array id="collision_pad2-lib-Normal0-array" count="36">
+-1.000000 -0.000000 -0.000000
+-1.000000 -0.000000 -0.000000
+-1.000000 -0.000000 -0.000000
+-1.000000 -0.000000 -0.000000
+0.000000 -1.000000 -0.000000
+0.000000 -1.000000 -0.000000
+0.000000 -1.000000 -0.000000
+0.000000 -1.000000 -0.000000
+-1.000000 -0.000000 -0.000000
+-1.000000 -0.000000 -0.000000
+0.000000 -1.000000 -0.000000
+0.000000 -1.000000 -0.000000
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad2-lib-Normal0-array" count="12" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="collision_pad2-lib-UV0">
+          <float_array id="collision_pad2-lib-UV0-array" count="24">
+0.000100 0.000100
+0.999900 0.000100
+0.999900 0.999900
+0.000100 0.999900
+0.000100 0.000100
+0.999900 0.000100
+0.999900 0.999900
+0.000100 0.999900
+0.999900 0.999900
+0.000100 0.000100
+0.999900 0.999900
+0.000100 0.000100
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad2-lib-UV0-array" count="12" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="collision_pad2-lib-Vertex">
+          <input semantic="POSITION" source="#collision_pad2-lib-Position"/>
+        </vertices>
+        <polygons material="wire_204204204" count="4">
+          <input semantic="VERTEX" offset="0" source="#collision_pad2-lib-Vertex"/>
+          <input semantic="NORMAL" offset="1" source="#collision_pad2-lib-Normal0"/>
+          <input semantic="TEXCOORD" offset="2" set="0" source="#collision_pad2-lib-UV0"/>
+          <p>0 0 0 1 1 1 2 2 2</p>
+          <p>8 8 8 3 3 3 9 9 9</p>
+          <p>4 4 4 5 5 5 6 6 6</p>
+          <p>10 10 10 7 7 7 11 11 11</p>
+        </polygons>
+      </mesh>
+    </geometry>
+    <geometry id="collision_pad4-lib" name="collision_pad4Mesh">
+      <mesh>
+        <source id="collision_pad4-lib-Position">
+          <float_array id="collision_pad4-lib-Position-array" count="18">
+-2.749347 2.749349 -12.348602
+2.749347 2.749349 -12.348602
+2.749347 -2.749345 -12.348602
+-2.749347 -2.749345 -12.348602
+2.749347 -2.749345 -12.348602
+-2.749347 2.749349 -12.348602
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad4-lib-Position-array" count="6" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="collision_pad4-lib-Normal0">
+          <float_array id="collision_pad4-lib-Normal0-array" count="18">
+0.000000 0.000000 -1.000000
+0.000000 0.000000 -1.000000
+0.000000 0.000000 -1.000000
+0.000000 0.000000 -1.000000
+0.000000 0.000000 -1.000000
+0.000000 0.000000 -1.000000
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad4-lib-Normal0-array" count="6" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="collision_pad4-lib-UV0">
+          <float_array id="collision_pad4-lib-UV0-array" count="12">
+0.000100 0.000100
+0.999900 0.000100
+0.999900 0.999900
+0.000100 0.999900
+0.999900 0.999900
+0.000100 0.000100
+</float_array>
+          <technique_common>
+            <accessor source="#collision_pad4-lib-UV0-array" count="6" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="collision_pad4-lib-Vertex">
+          <input semantic="POSITION" source="#collision_pad4-lib-Position"/>
+        </vertices>
+        <polygons material="wire_204204204" count="2">
+          <input semantic="VERTEX" offset="0" source="#collision_pad4-lib-Vertex"/>
+          <input semantic="NORMAL" offset="1" source="#collision_pad4-lib-Normal0"/>
+          <input semantic="TEXCOORD" offset="2" set="0" source="#collision_pad4-lib-UV0"/>
+          <p>0 0 0 1 1 1 2 2 2</p>
+          <p>4 4 4 3 3 3 5 5 5</p>
+        </polygons>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="RootNode" name="RootNode">
+      <node id="collision_pad3" name="collision_pad3">
+        <matrix sid="matrix">1.000000 0.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 -1.000000 0.000000 0.000000 0.000000 0.000000 0.000000 1.000000</matrix>
+        <instance_geometry url="#collision_pad3-lib">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="wire_204204204" target="#wire_204204204"/>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_pad2" name="collision_pad2">
+        <matrix sid="matrix">39.370079 0.000000 0.000000 0.000000 0.000000 0.000010 -39.370079 0.000000 0.000000 39.370079 0.000010 0.000000 0.000000 0.000000 0.000000 1.000000</matrix>
+        <instance_geometry url="#collision_pad2-lib">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="wire_204204204" target="#wire_204204204"/>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_pad4" name="collision_pad4">
+        <matrix sid="matrix">39.370079 0.000000 0.000000 0.000000 0.000000 0.000010 -39.370079 0.000000 0.000000 39.370079 0.000010 0.000000 0.000000 0.000000 0.000000 1.000000</matrix>
+        <instance_geometry url="#collision_pad4-lib">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="wire_204204204" target="#wire_204204204"/>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#RootNode"/>
+  </scene>
+</COLLADA>
+

--- a/data/models/stations/hoop_spacestation/hoop_spacestation.model
+++ b/data/models/stations/hoop_spacestation/hoop_spacestation.model
@@ -24,6 +24,7 @@ mesh connections.dae
 mesh mainhoop.dae
 mesh doors.dae
 mesh dockingbay.dae
+mesh dockingpads.dae
 
 collision collision.obj
 


### PR DESCRIPTION
Create additional docking collision_padX planes.

Instead of putting the vertically across the entrance which the high time acceleration can miss I line them along the docking bay route where the ships stop.

Fixes #2125 
