### PR TITLE
#1734  UI: speeding up the buy and sell process in the marketplace

### DIFF
--- a/src/CommodityTradeWidget.cpp
+++ b/src/CommodityTradeWidget.cpp
@@ -106,11 +106,13 @@ void CommodityTradeWidget::ShowAll()
 		if (Equip::types[i].description)
 			l->SetToolTip(Equip::types[i].description);
 		innerbox->Add(l,42,num*YSEP+iconOffset);
-		Gui::Button *b = new Gui::RepeaterButton(RBUTTON_DELAY, RBUTTON_REPEAT);
-		b->onClick.connect(sigc::bind(sigc::mem_fun(this, &CommodityTradeWidget::OnClickBuy), i));
+		Gui::RepeaterButton *b = new Gui::RepeaterButton(RBUTTON_DELAY, RBUTTON_REPEAT);
+		sigc::slot<void> func = sigc::bind(sigc::mem_fun(this, &CommodityTradeWidget::OnClickBuy), i);
+		b->onClick.connect(sigc::bind(sigc::mem_fun(this, &CommodityTradeWidget::ManageRButton), b, func));
 		innerbox->Add(b, 380, num*YSEP+iconOffset);
 		b = new Gui::RepeaterButton(RBUTTON_DELAY, RBUTTON_REPEAT);
-		b->onClick.connect(sigc::bind(sigc::mem_fun(this, &CommodityTradeWidget::OnClickSell), i));
+		func = sigc::bind(sigc::mem_fun(this, &CommodityTradeWidget::OnClickSell), i);
+		b->onClick.connect(sigc::bind(sigc::mem_fun(this, &CommodityTradeWidget::ManageRButton), b, func));
 		innerbox->Add(b, 415, num*YSEP+iconOffset);
 		char buf[128];
 		innerbox->Add(new Gui::Label(
@@ -163,3 +165,15 @@ void CommodityTradeWidget::UpdateStock(int commodity_type)
 	m_stockLabels[commodity_type]->SetText(buf);
 }
 
+// XXX think about moving it to RepeaterButton class
+void CommodityTradeWidget::ManageRButton(Gui::RepeaterButton *b, sigc::slot<void> func)
+{
+	// hint: if you loop func n times, you'll buy/sell n commodies 'at once'
+	func();
+
+	// XXX don't boost first iterations
+	int boost_percent = 10;
+	int msRepeat = b->GetRepeat();
+	msRepeat -= msRepeat * boost_percent / 100 ;
+	b->SetRepeat(msRepeat);
+}

--- a/src/CommodityTradeWidget.h
+++ b/src/CommodityTradeWidget.h
@@ -24,6 +24,8 @@ private:
 		onClickSell.emit(commodity_type);
 	}
 
+	void ManageRButton(Gui::RepeaterButton *b, sigc::slot<void> func);
+
 	std::map<int, Gui::Label*> m_stockLabels;
 	std::map<int, Gui::Label*> m_cargoLabels;
 	MarketAgent *m_seller;

--- a/src/gui/GuiRepeaterButton.cpp
+++ b/src/gui/GuiRepeaterButton.cpp
@@ -15,6 +15,16 @@ RepeaterButton::RepeaterButton(int msDelay, int msRepeat)
 	onRelease.connect(sigc::mem_fun(this, &RepeaterButton::OnRelease));
 }
 
+int RepeaterButton::GetRepeat()
+{
+	return m_repeat;
+}
+
+void RepeaterButton::SetRepeat(int msRepeat)
+{
+	m_repeat = msRepeat;
+}
+
 RepeaterButton::~RepeaterButton()
 {
 	m_repeatCon.disconnect();

--- a/src/gui/GuiRepeaterButton.h
+++ b/src/gui/GuiRepeaterButton.h
@@ -13,6 +13,8 @@ namespace Gui {
 	class RepeaterButton: public SolidButton {
 	public:
 		RepeaterButton(int msDelay, int msRepeat);
+		int GetRepeat();
+		void SetRepeat(int msRepeat);
 		virtual ~RepeaterButton();
 	private:
 		void OnPress();


### PR DESCRIPTION
While buy/sell button is pressed, delay between sells decreasing by 10% with each sell.
Now it takes only 3 seconds to fill Deneb (was 12 secs).
