### PR TITLE
Fix Lua console so that it lets you continue incomplete commands

### DIFF
--- a/src/LuaConsole.cpp
+++ b/src/LuaConsole.cpp
@@ -226,7 +226,7 @@ void LuaConsole::ExecOrContinue() {
 	// check for an incomplete statement
 	// (follows logic from the official Lua interpreter lua.c:incomplete())
 	if (result == LUA_ERRSYNTAX) {
-		const char eofstring[] = LUA_QL("<eof>");
+		const char eofstring[] = "<eof>";
 		size_t msglen;
 		const char *msg = lua_tolstring(L, -1, &msglen);
 		if (msglen >= (sizeof(eofstring) - 1)) {


### PR DESCRIPTION
It was always supposed to do this, but at some point (probably the switch to Lua 5.2) it stopped working. If you hit return when the current command is syntactically incomplete, it will insert a newline and let you continue the command, instead of showing a syntax error.

Unfortunately, the Lua API doesn't actually have a good way of determining that a command is incomplete. The way that the official Lua REPL (lua.c from the Lua distribution) does it is to look at the syntax error message and see if it ends with &lt;eof&gt;. Personally I think that's sort of disgusting, but it's the only practical way.

The bug was caused because the syntax error message changed slightly. It used to end with `'<eof>'`, now it just ends with `<eof>`.
