### PR TITLE
Avoid virtual setters during Load/initialisation

### DIFF
--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -29,7 +29,7 @@ Body::Body() : PropertiedObject(Lua::manager)
 	, m_clipRadius(0.0)
 	, m_physRadius(0.0)
 {
-	SetLabel("");
+	Properties().Set("label", m_label);
 }
 
 Body::~Body()
@@ -51,7 +51,8 @@ void Body::Save(Serializer::Writer &wr, Space *space)
 void Body::Load(Serializer::Reader &rd, Space *space)
 {
 	m_frame = space->GetFrameByIndex(rd.Int32());
-	SetLabel(rd.String());
+	m_label = rd.String();
+	Properties().Set("label", m_label);
 	m_dead = rd.Bool();
 
 	m_pos = rd.Vector3d();

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -113,8 +113,10 @@ void Ship::Load(Serializer::Reader &rd, Space *space)
 	m_wheelState = rd.Float();
 	m_launchLockTimeout = rd.Float();
 	m_testLanded = rd.Bool();
-	SetFlightState(static_cast<FlightState>(rd.Int32()));
-	SetAlertState(static_cast<AlertState>(rd.Int32()));
+	m_flightState = static_cast<FlightState>(rd.Int32());
+	m_alertState = static_cast<AlertState>(rd.Int32());
+	Properties().Set("flightState", EnumStrings::GetString("ShipFlightState", m_flightState));
+	Properties().Set("alertStatus", EnumStrings::GetString("ShipAlertStatus", m_alertState));
 	m_lastFiringAlert = rd.Double();
 
 	m_hyperspace.dest = SystemPath::Unserialize(rd);
@@ -183,8 +185,10 @@ Ship::Ship(ShipType::Id shipId): DynamicBody(),
 	m_thrusterFuel(1.0),
 	m_reserveFuel(0.0)
 {
-	SetFlightState(FLYING);
-	SetAlertState(ALERT_NONE);
+	m_flightState = FLYING;
+	m_alertState = ALERT_NONE;
+	Properties().Set("flightState", EnumStrings::GetString("ShipFlightState", m_flightState));
+	Properties().Set("alertStatus", EnumStrings::GetString("ShipAlertStatus", m_alertState));
 
 	m_lastFiringAlert = 0.0;
 	m_testLanded = false;


### PR DESCRIPTION
Fixes #2221.

Load/Init should only be setting up state, whereas virtual setters are often overriden in derived classes to trigger things on particular state changes (e.g., put a message in the ship console when the ship alert state changes). Load/Init is not a state change, because there's no (valid) previous state.
#2221 was caused by Body::Load and Ship::Load calling virtual setters which failed because object initialisation (e.g., setting the ship's model, or setting up the ship console message log) hadn't finished.
