### PR TITLE
Model loader: improve instancing

### DIFF
--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -26,6 +26,10 @@ namespace Graphics {
  * Terrain: not necessarily tricky to convert, but let's see if it's going to be
  * rewritten first... Terrain would likely get a special DrawTerrain(GeoPatch *) function.
  * Reboot postprocessing, again (I'd like this to be a non-optional part of GL2 renderer)
+ *
+ * XXX 2013-Apr-21: Surface is a bit pointless, and StaticMesh could be more
+ * flexible with vertex attributes. Recommendation: replace with CreateVertexBuffer, CreateIndexBuffer
+ * type approach and encourage these for most drawing. This will solve the terrain issue as well.
  */
 
 class Light;
@@ -57,7 +61,7 @@ enum BlendMode {
 	BLEND_SOLID,
 	BLEND_ADDITIVE,
 	BLEND_ALPHA,
-	BLEND_ALPHA_ONE, //XXX what the hell to call this
+	BLEND_ALPHA_ONE, //"additive alpha"
 	BLEND_ALPHA_PREMULT
 };
 

--- a/src/graphics/RendererGLBuffers.h
+++ b/src/graphics/RendererGLBuffers.h
@@ -10,7 +10,6 @@ namespace Graphics {
 
 /* OpenGL renderer data structures and bufferobject stuff.
  * This can be used by both the Legacy and GL2 renderers
- * XXX 2013-Feb-2 this should be rewritten. Recommend renderer->CreateBuffer(...) approach
  */
 
 struct GLVertex {

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -376,16 +376,16 @@ RefCountedPtr<Node> Loader::LoadMesh(const std::string &filename, const AnimList
 
 	//turn all scene aiMeshes into Surfaces
 	//Index matches assimp index.
-	std::vector<RefCountedPtr<Graphics::Surface> > surfaces;
-	ConvertAiMeshesToSurfaces(surfaces, scene, m_model);
+	std::vector<RefCountedPtr<StaticGeometry> > geoms;
+	ConvertAiMeshes(geoms, scene);
 
 	// Recursive structure conversion. Matrix needs to be accumulated for
 	// special features that are absolute-positioned (thrusters)
 	RefCountedPtr<Node> meshRoot(new Group(m_renderer));
 
-	ConvertNodes(scene->mRootNode, static_cast<Group*>(meshRoot.Get()), surfaces, matrix4x4f::Identity());
+	ConvertNodes(scene->mRootNode, static_cast<Group*>(meshRoot.Get()), geoms, matrix4x4f::Identity());
 	ConvertAnimations(scene, animDefs, static_cast<Group*>(meshRoot.Get()));
-	
+
 	return meshRoot;
 }
 
@@ -463,17 +463,20 @@ void Loader::CheckAnimationConflicts(const Animation* anim, const std::vector<An
 	}
 }
 
-void Loader::ConvertAiMeshesToSurfaces(std::vector<RefCountedPtr<Graphics::Surface> > &surfaces, const aiScene *scene, Model *model)
+void Loader::ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry> > &geoms, const aiScene *scene)
 {
 	//XXX sigh, workaround for obj loader
 	int matIdxOffs = 0;
 	if (scene->mNumMaterials > scene->mNumMeshes)
 		matIdxOffs = 1;
 
-	//turn meshes into surfaces
+	//turn meshes into static geometry nodes
 	for (unsigned int i=0; i<scene->mNumMeshes; i++) {
 		const aiMesh *mesh = scene->mMeshes[i];
 		assert(mesh->HasNormals());
+
+		RefCountedPtr<StaticGeometry> geom(new StaticGeometry(m_renderer));
+		geom->SetName(stringf("sgMesh%0{u}", i));
 
 		const bool hasUVs = mesh->HasTextureCoords(0);
 		if (!hasUVs) AddLog(stringf("%0: missing UV coordinates", m_curMeshDef));
@@ -485,29 +488,34 @@ void Loader::ConvertAiMeshesToSurfaces(std::vector<RefCountedPtr<Graphics::Surfa
 		const aiMaterial *amat = scene->mMaterials[mesh->mMaterialIndex];
 		aiString aiMatName;
 		if(AI_SUCCESS == amat->Get(AI_MATKEY_NAME,aiMatName))
-			mat = model->GetMaterialByName(std::string(aiMatName.C_Str()));
+			mat = m_model->GetMaterialByName(std::string(aiMatName.C_Str()));
 
 		if (!mat.Valid()) {
 			const unsigned int matIdx = mesh->mMaterialIndex - matIdxOffs;
 			AddLog(stringf("%0: no material %1, using material %2{u} instead", m_curMeshDef, aiMatName.C_Str(), matIdx+1));
-			mat = model->GetMaterialByIndex(matIdx);
+			mat = m_model->GetMaterialByIndex(matIdx);
 		}
-
 		assert(mat.Valid());
 
-		Graphics::VertexArray *vts =
-			new Graphics::VertexArray(
-				Graphics::ATTRIB_POSITION |
-				Graphics::ATTRIB_NORMAL |
-				Graphics::ATTRIB_UV0,
-				mesh->mNumVertices);
+		//turn on alpha blending and mark entire node as transparent
+		//(all importers split by material so far)
+		if (mat->diffuse.a < 0.99f) {
+			geom->SetNodeMask(NODE_TRANSPARENT);
+			geom->m_blendMode = Graphics::BLEND_ALPHA;
+		}
 
+		const Graphics::AttributeSet vtxAttribs =
+			Graphics::ATTRIB_POSITION |
+			Graphics::ATTRIB_NORMAL |
+			Graphics::ATTRIB_UV0;
+		Graphics::VertexArray *vts = new Graphics::VertexArray(vtxAttribs, mesh->mNumVertices);
+
+		// huge meshes are split by the importer so this should not exceed 65K indices
 		RefCountedPtr<Graphics::Surface> surface(new Graphics::Surface(Graphics::TRIANGLES, vts, mat));
 		std::vector<unsigned short> &indices = surface->GetIndices();
 		indices.reserve(mesh->mNumFaces * 3);
 
 		//copy indices first
-		//note: index offsets are not adjusted, StaticMesh should do that for us
 		for (unsigned int f = 0; f < mesh->mNumFaces; f++) {
 			const aiFace *face = &mesh->mFaces[f];
 			for (unsigned int j = 0; j < face->mNumIndices; j++) {
@@ -524,9 +532,17 @@ void Loader::ConvertAiMeshesToSurfaces(std::vector<RefCountedPtr<Graphics::Surfa
 			vts->Add(vector3f(vtx.x, vtx.y, vtx.z),
 				vector3f(norm.x, norm.y, norm.z),
 				vector2f(uv0.x, uv0.y));
+
+			//update bounding box
+			//untransformed points, collision visitor will transform
+			geom->m_boundingBox.Update(vtx.x, vtx.y, vtx.z);
 		}
 
-		surfaces.push_back(surface);
+		RefCountedPtr<Graphics::StaticMesh> smesh(new Graphics::StaticMesh(Graphics::TRIANGLES));
+		smesh->AddSurface(surface);
+		geom->AddMesh(smesh);
+
+		geoms.push_back(geom);
 	}
 }
 
@@ -722,7 +738,7 @@ void Loader::CreateThruster(Group* parent, const matrix4x4f &m, const std::strin
 	parent->AddChild(trans);
 }
 
-void Loader::ConvertNodes(aiNode *node, Group *_parent, std::vector<RefCountedPtr<Graphics::Surface> >& surfaces, const matrix4x4f &accum)
+void Loader::ConvertNodes(aiNode *node, Group *_parent, std::vector<RefCountedPtr<StaticGeometry> >& geoms, const matrix4x4f &accum)
 {
 	Group *parent = _parent;
 	const std::string nodename(node->mName.C_Str());
@@ -765,7 +781,7 @@ void Loader::ConvertNodes(aiNode *node, Group *_parent, std::vector<RefCountedPt
 	//nodes named collision_* are not added as renderable geometry
 	if (node->mNumMeshes == 1 && starts_with(nodename, "collision_")) {
 		const unsigned int collflag = GetGeomFlagForNodeName(nodename);
-		RefCountedPtr<Graphics::Surface> surf = surfaces.at(node->mMeshes[0]);
+		RefCountedPtr<Graphics::Surface> surf = geoms.at(node->mMeshes[0])->GetMesh(0)->GetSurface(0);
 		RefCountedPtr<CollisionGeometry> cgeom(new CollisionGeometry(m_renderer, surf.Get(), collflag));
 		cgeom->SetName(nodename + "_cgeom");
 		parent->AddChild(cgeom.Get());
@@ -774,12 +790,6 @@ void Loader::ConvertNodes(aiNode *node, Group *_parent, std::vector<RefCountedPt
 
 	//nodes with visible geometry (StaticGeometry and decals)
 	if (node->mNumMeshes > 0) {
-		//is this node animated? add a transform
-		//does this node have children? Add a group
-		RefCountedPtr<StaticGeometry> geom(new StaticGeometry(m_renderer));
-		geom->SetName(nodename + "_mesh");
-		RefCountedPtr<Graphics::StaticMesh> smesh(new Graphics::StaticMesh(Graphics::TRIANGLES));
-
 		//expecting decal_0X
 		unsigned int numDecal = 0;
 		if (starts_with(nodename, "decal_")) {
@@ -789,44 +799,23 @@ void Loader::ConvertNodes(aiNode *node, Group *_parent, std::vector<RefCountedPt
 		}
 
 		for(unsigned int i=0; i<node->mNumMeshes; i++) {
-			RefCountedPtr<Graphics::Surface> surf = surfaces.at(node->mMeshes[i]);
+			RefCountedPtr<StaticGeometry> geom = geoms.at(node->mMeshes[i]);
 
-			//turn on alpha blending and mark entire node as transparent
-			//(all importers split by material so far)
-			if (surf->GetMaterial()->diffuse.a < 0.99f) {
-				geom->SetNodeMask(NODE_TRANSPARENT);
-				geom->m_blendMode = Graphics::BLEND_ALPHA;
-			}
+			//handle special decal material
 			//set special material for decals
 			if (numDecal > 0) {
 				geom->SetNodeMask(NODE_TRANSPARENT);
 				geom->m_blendMode = Graphics::BLEND_ALPHA;
-				surf->SetMaterial(GetDecalMaterial(numDecal));
-			}
-			//update bounding box
-			//untransformed points, collision visitor will transform
-			Graphics::VertexArray *vts = surf->GetVertices();
-			for (unsigned int j=0; j<vts->position.size(); j++) {
-				const vector3f &vtx = vts->position[j];
-				geom->m_boundingBox.Update(vtx.x, vtx.y, vtx.z);
+				geom->GetMesh(0)->GetSurface(0)->SetMaterial(GetDecalMaterial(numDecal));
 			}
 
-			//Out of space? Add a new mesh.
-			if(smesh->GetAvailableVertexSpace() < surf->GetNumVerts()) {
-				geom->AddMesh(smesh);
-				smesh = RefCountedPtr<Graphics::StaticMesh>(new Graphics::StaticMesh(Graphics::TRIANGLES));
-			}
-
-			smesh->AddSurface(surf);
+			parent->AddChild(geom.Get());
 		}
-		geom->AddMesh(smesh);
-
-		parent->AddChild(geom.Get());
 	}
 
 	for(unsigned int i=0; i<node->mNumChildren; i++) {
 		aiNode *child = node->mChildren[i];
-		ConvertNodes(child, parent, surfaces, accum * m);
+		ConvertNodes(child, parent, geoms, accum * m);
 	}
 }
 

--- a/src/scenegraph/Loader.h
+++ b/src/scenegraph/Loader.h
@@ -54,9 +54,9 @@ private:
 	RefCountedPtr<Node> LoadMesh(const std::string &filename, const AnimList &animDefs); //load one mesh file so it can be added to the model scenegraph. Materials should be created before this!
 	void AddLog(const std::string&);
 	void CheckAnimationConflicts(const Animation*, const std::vector<Animation*>&); //detect animation overlap
-	void ConvertAiMeshesToSurfaces(std::vector<RefCountedPtr<Graphics::Surface> >&, const aiScene*, Model*); //model is only for material lookup
+	void ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry> >&, const aiScene*); //model is only for material lookup
 	void ConvertAnimations(const aiScene *, const AnimList &, Node *meshRoot);
-	void ConvertNodes(aiNode *node, Group *parent, std::vector<RefCountedPtr<Graphics::Surface> >& meshes, const matrix4x4f&);
+	void ConvertNodes(aiNode *node, Group *parent, std::vector<RefCountedPtr<StaticGeometry> >& meshes, const matrix4x4f&);
 	void CreateLabel(Group *parent, const matrix4x4f&);
 	void CreateThruster(Group *parent, const matrix4x4f& nodeTrans, const std::string &name, const matrix4x4f &accum);
 	void FindPatterns(PatternContainer &output); //find pattern texture files from the model directory

--- a/src/scenegraph/StaticGeometry.h
+++ b/src/scenegraph/StaticGeometry.h
@@ -25,7 +25,11 @@ public:
 	virtual const char *GetTypeName() { return "StaticGeometry"; }
 	virtual void Accept(NodeVisitor &nv);
 	virtual void Render(const matrix4x4f &trans, RenderData *rd);
+
 	void AddMesh(RefCountedPtr<Graphics::StaticMesh>);
+	unsigned int GetNumMeshes() const { return m_meshes.size(); }
+	RefCountedPtr<Graphics::StaticMesh> GetMesh(unsigned int i) { return m_meshes.at(i); }
+
 	Aabb m_boundingBox;
 	Graphics::BlendMode m_blendMode;
 


### PR DESCRIPTION
Previously: create one Graphics::Surface per assimp aiMesh, which are then added into Graphics::StaticMeshes during Loader::ConvertNodes phase. The idea being, that if an assimp node uses multiple aiMeshes they are merged under one StaticMesh (and multiple SMs if the total exceeds 65k indices).
But, in reality multiple aiMeshes in one assimp node pretty much did not happen, and duplicate meshes would still get their own vertex buffers.

Now: just create one StaticMesh+StaticGeometry node per aiMesh. Simpler, saves memory.

No changes required to existing models, of course.
