### PR TITLE
Use SanitiseFileName on system names before they are exported

### DIFF
--- a/src/LuaStarSystem.cpp
+++ b/src/LuaStarSystem.cpp
@@ -349,7 +349,7 @@ static int l_starsystem_export_to_lua(lua_State *l)
 
 	// construct the filename with folder and extension
 	try {
-		const std::string filename(EXPORTED_SYSTEMS_DIR_NAME + "/" + s->GetName() + ".lua");
+		const std::string filename(EXPORTED_SYSTEMS_DIR_NAME + "/" + FileSystem::SanitiseFileName(s->GetName()) + ".lua");
 		const std::string finalPath = FileSystem::NormalisePath(
 				FileSystem::JoinPathBelow(FileSystem::GetUserDir(), filename));
 		s->ExportToLua(finalPath.c_str());


### PR DESCRIPTION
Apparently although I added the `FileSystem::SanitiseFileName` function in #2229, I forgot to actually _call_ it.
