### PR TITLE
Fix New Ground station docking timeout

### DIFF
--- a/data/stations/new_ground.lua
+++ b/data/stations/new_ground.lua
@@ -14,6 +14,6 @@ define_surface_station {
     parking_distance = 5000.0,
     parking_gap_size = 2000.0,
     ship_launch_stage = 0,
-    dock_anim_stage_duration = { DOCKING_TIMEOUT_SECONDS, 4.0},
+    dock_anim_stage_duration = { 300, 4.0},
     undock_anim_stage_duration = { 0 },
 }


### PR DESCRIPTION
Changed the other two but forgot this one, DOCKING_STATION_TIMEOUT no longer exists since the `00_libs.lua` file went away.
