### PR TITLE
Take field of view into account when calculating LOD

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -433,7 +433,6 @@ void ModelViewer::DrawDockingLocators()
 		}
 	}
 
-	
 	for(std::vector<Line3D>::iterator lineIter = sLines.begin(), lineEnd = sLines.end(); lineIter!=lineEnd; ++lineIter)
 	{
 		(*lineIter).Draw(m_renderer);

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -16,6 +16,7 @@ bool shadersEnabled = false;
 Material *vtxColorMaterial;
 Settings settings;
 static float g_fov = 85.f;
+static float g_fovFactor = 1.f;
 
 int GetScreenWidth()
 {
@@ -27,14 +28,20 @@ int GetScreenHeight()
 	return settings.height;
 }
 
-float GetFOV()
+float GetFov()
 {
 	return g_fov;
 }
 
-void SetFOV(float fov)
+void SetFov(float fov)
 {
 	g_fov = fov;
+	g_fovFactor = 2 * tan(DEG2RAD(g_fov) / 2.f);
+}
+
+float GetFovFactor()
+{
+	return g_fovFactor;
 }
 
 Renderer* Init(Settings vs)
@@ -157,11 +164,6 @@ Renderer* Init(Settings vs)
 void Uninit()
 {
 	delete vtxColorMaterial;
-}
-
-void SwapBuffers()
-{
-	SDL_GL_SwapBuffers();
 }
 
 bool AreShadersEnabled()

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -43,17 +43,15 @@ namespace Graphics {
 	int GetScreenWidth();
 	int GetScreenHeight();
 
-	float GetFOV();
-	void SetFOV(float);
+	float GetFov();
+	void SetFov(float);
+	float GetFovFactor(); //cached 2*tan(fov/2) for LOD
 
 	// does SDL video init, constructs appropriate Renderer
 	Renderer* Init(Settings);
 	void Uninit();
 	bool AreShadersEnabled();
 	std::vector<VideoMode> GetAvailableVideoModes();
-
-	//XXX keeping this because gui uses it...
-	void SwapBuffers();
 }
 
 #endif /* _RENDER_H */

--- a/src/graphics/RendererLegacy.cpp
+++ b/src/graphics/RendererLegacy.cpp
@@ -137,7 +137,7 @@ bool RendererLegacy::SwapBuffers()
 	}
 #endif
 
-	Graphics::SwapBuffers();
+	SDL_GL_SwapBuffers();
 	return true;
 }
 
@@ -191,7 +191,7 @@ bool RendererLegacy::SetTransform(const matrix4x4f &m)
 
 bool RendererLegacy::SetPerspectiveProjection(float fov, float aspect, float near, float far)
 {
-	Graphics::SetFOV(fov);
+	Graphics::SetFov(fov);
 
 	double ymax = near * tan(fov * M_PI / 360.0);
 	double ymin = -ymax;

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -19,7 +19,6 @@ namespace RawEvents {
 	sigc::signal<void, SDL_JoyHatEvent *> onJoyHatMotion;
 }
 
-
 void HandleSDLEvent(SDL_Event *event)
 {
 	switch (event->type) {
@@ -124,7 +123,7 @@ void MainLoopIteration()
 	SDL_ShowCursor(1);
 	SDL_WM_GrabInput(SDL_GRAB_OFF);
 	Gui::Draw();
-	Graphics::SwapBuffers();
+	SDL_GL_SwapBuffers();
 }
 
 namespace Theme {

--- a/src/scenegraph/Billboard.cpp
+++ b/src/scenegraph/Billboard.cpp
@@ -44,8 +44,7 @@ void Billboard::Render(const matrix4x4f &trans, RenderData *rd)
 	const matrix3x3f rot = trans.GetOrient().Transpose();
 
 	//some hand-tweaked scaling, to make the lights seem larger from distance
-	const float fovfactor = 2 * tan(DEG2RAD(Graphics::GetFOV()) / 2.f);
-	const float size = m_size * fovfactor * Clamp(trans.GetTranslate().Length() / 100.f, 0.25f, 15.f);
+	const float size = m_size * Graphics::GetFovFactor() * Clamp(trans.GetTranslate().Length() / 100.f, 0.25f, 15.f);
 
 	const vector3f rotv1 = rot * vector3f(size/2.f, -size/2.f, 0.0f);
 	const vector3f rotv2 = rot * vector3f(size/2.f, size/2.f, 0.0f);

--- a/src/scenegraph/LOD.cpp
+++ b/src/scenegraph/LOD.cpp
@@ -40,10 +40,11 @@ void LOD::AddLevel(float pixelSize, Node *nod)
 
 void LOD::Render(const matrix4x4f &trans, RenderData *rd)
 {
-	//figure out approximate pixel size on screen and pick a child to render
+	//figure out approximate pixel size of object's bounding radius
+	//on screen and pick a child to render
 	const vector3f cameraPos(-trans[12], -trans[13], -trans[14]);
-	const float pixrad = 0.5f * Graphics::GetScreenWidth() * rd->boundingRadius / cameraPos.Length();
-	assert(m_children.size() == m_pixelSizes.size());
+	//fov is vertical, so using screen height
+	const float pixrad = Graphics::GetScreenHeight() * rd->boundingRadius / (cameraPos.Length() * Graphics::GetFovFactor());
 	if (m_pixelSizes.empty()) return;
 	unsigned int lod = m_children.size() - 1;
 	for (unsigned int i=m_pixelSizes.size(); i > 0; i--) {


### PR DESCRIPTION
Does #2077.

Here is an example at three different resolutions & FOVs, taken just when a LOD defined at 100px is selected. You'll see that the monkey head is the same size in each, and if you measure the red or blue axis it's more or less 100 pixels (inaccuracy mostly from zoom keys...)

http://luomu.github.io/pioneer/issues/2077-fov/800_fov45.jpg
http://luomu.github.io/pioneer/issues/2077-fov/1024_fov85.jpg
http://luomu.github.io/pioneer/issues/2077-fov/1280_fov90.jpg
