### PR TITLE
Fix issue #2263

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -289,16 +289,6 @@ int SpaceStation::GetMyDockingPort(const Ship *s) const
 	return -1;
 }
 
-bool SpaceStation::IsLaunching(const Ship *s) const
-{
-	for (uint32_t i=0; i<m_shipDocking.size(); i++) {
-		if (s == m_shipDocking[i].ship) {
-			return (m_shipDocking[i].stage<0);
-		}
-	}
-	return false;
-}
-
 int SpaceStation::GetFreeDockingPort() const
 {
 	for (unsigned int i=0; i<m_type->numDockingPorts; i++) {

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -84,7 +84,6 @@ public:
 	int GetDockingPortCount() const { return m_type->numDockingPorts; }
 	int GetFreeDockingPort() const; // returns -1 if none free
 	int GetMyDockingPort(const Ship *s) const;
-	bool IsLaunching(const Ship *s) const;
 
 	const SpaceStationType *GetStationType() const { return m_type; }
 	bool IsGroundStation() const;

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1005,7 +1005,7 @@ static void autopilot_flyto(Body *b)
 }
 static void autopilot_dock(Body *b)
 {
-	if(static_cast<SpaceStation*>(b)->IsLaunching(Pi::player))
+	if(Pi::player->GetFlightState() != Ship::FLYING)
 		return;
 
 	Pi::player->GetPlayerController()->SetFlightControlState(CONTROL_AUTOPILOT);


### PR DESCRIPTION
This attempts to fix issue #2263

Add method IsLeaving to SpaceStation so we can check if we're in the process of undocking.

Only add applicable communication options if we're not in the process of undocking.

Thanks to @radius75 as the solution is very similar to the one he suggested with just an additional check for undocking.
