### PR TITLE
Set max mipmap level to zero when not using mipmaps

### DIFF
--- a/src/graphics/TextureGL.cpp
+++ b/src/graphics/TextureGL.cpp
@@ -85,6 +85,8 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 		case GL_TEXTURE_2D:
 			if (descriptor.generateMipmaps)
 				glTexParameteri(m_target, GL_GENERATE_MIPMAP, GL_TRUE);
+			else
+				glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, 0);
 
 			glTexImage2D(
 				m_target, 0, compressTexture ? GLCompressedTextureFormat(descriptor.format) : GLTextureFormat(descriptor.format),


### PR DESCRIPTION
When using the opengl debug extension I get flooded by these messages:

`Type: Other, Source: API, ID: 131204, Severity: Low, Message: Texture state usage warning: Waste of memory: Texture 0 has mipmaps, while it's min filter is inconsistent with mipmaps.`

Setting the max mipmap level to zero (default is 1000) stops the warning, all other parameters seem to be correct.
I don't think there's actually any memory wasted, but I don't think nvidia is considering this a driver issue since it's been this way for as long as I remember.
