### PR TITLE
Fix #2282 crash

### DIFF
--- a/src/GeoPatchJobs.cpp
+++ b/src/GeoPatchJobs.cpp
@@ -101,8 +101,11 @@ void SinglePatchJob::OnFinish()  // runs in primary thread of the context
 
 void SinglePatchJob::OnCancel()   // runs in primary thread of the context
 {
-	mpResults->OnCancel();
-	delete mpResults;	mpResults = NULL;
+	if(mpResults) {
+		mpResults->OnCancel();
+		delete mpResults;
+		mpResults = NULL;
+	}
 	BasePatchJob::OnCancel();
 }
 
@@ -147,8 +150,11 @@ void QuadPatchJob::OnFinish()  // runs in primary thread of the context
 
 void QuadPatchJob::OnCancel()   // runs in primary thread of the context
 {
-	mpResults->OnCancel();
-	delete mpResults;	mpResults = NULL;
+	if(mpResults) {
+		mpResults->OnCancel();
+		delete mpResults;
+		mpResults = NULL;
+	}
 	BasePatchJob::OnCancel();
 }
 


### PR DESCRIPTION
This PR is supposed to fix issue #2282 found by @pgimeno

Guards against the case where mpResults is NULL somehow. 
Possibly due to a poorly timed cancellation of the job request.

I was unable to reproduce this on my own machines however the bug is fairly obvious so I've added some guards against it happening again.

Testing appreciated but the fix should go in anyway, it was clearly an oversight by me when I wrote it.
