### PR TITLE
Limit docking to the applicable docking bay sizes.

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -347,13 +347,24 @@ bool SpaceStation::GetDockingClearance(Ship *s, std::string &outMsg)
 		}
 	}
 	for (uint32_t i=0; i<m_shipDocking.size(); i++) {
+		// initial unoccupied check
 		if (m_shipDocking[i].ship != 0) continue;
-		shipDocking_t &sd = m_shipDocking[i];
-		sd.ship = s;
-		sd.stage = 1;
-		sd.stagePos = 0;
-		outMsg = stringf(Lang::CLEARANCE_GRANTED_BAY_N, formatarg("bay", i+1));
-		return true;
+
+		// size-of-ship vs size-of-bay check
+		const SpaceStationType::SBayGroup *const pBayGroup = m_type->FindGroupByBay(i);
+		if( !pBayGroup ) continue;
+
+		const Aabb &bbox = s->GetAabb();
+		const double bboxRad = bbox.GetRadius();
+
+		if( pBayGroup->minShipSize < bboxRad && bboxRad < pBayGroup->maxShipSize ) {
+			shipDocking_t &sd = m_shipDocking[i];
+			sd.ship = s;
+			sd.stage = 1;
+			sd.stagePos = 0;
+			outMsg = stringf(Lang::CLEARANCE_GRANTED_BAY_N, formatarg("bay", i+1));
+			return true;
+		}
 	}
 	outMsg = Lang::CLEARANCE_DENIED_NO_BAYS;
 	return false;

--- a/src/SpaceStationType.cpp
+++ b/src/SpaceStationType.cpp
@@ -113,8 +113,7 @@ void SpaceStationType::OnSetupComplete()
 const SpaceStationType::SBayGroup* SpaceStationType::FindGroupByBay(const int zeroBaseBayID) const
 {
 	for (TBayGroups::const_iterator bayIter = bayGroups.begin(), grpEnd=bayGroups.end(); bayIter!=grpEnd ; ++bayIter ) {
-		std::vector<int>::const_iterator idIter = (*bayIter).bayIDs.begin();
-		for ( ; idIter!=(*bayIter).bayIDs.end() ; ++idIter ) {
+		for (std::vector<int>::const_iterator idIter = (*bayIter).bayIDs.begin(), idIEnd = (*bayIter).bayIDs.end(); idIter!=idIEnd ; ++idIter ) {
 			if ((*idIter)==zeroBaseBayID) {
 				return &(*bayIter);
 			}
@@ -127,8 +126,7 @@ const SpaceStationType::SBayGroup* SpaceStationType::FindGroupByBay(const int ze
 SpaceStationType::SBayGroup* SpaceStationType::GetGroupByBay(const int zeroBaseBayID)
 {
 	for (TBayGroups::iterator bayIter = bayGroups.begin(), grpEnd=bayGroups.end(); bayIter!=grpEnd ; ++bayIter ) {
-		std::vector<int>::iterator idIter = (*bayIter).bayIDs.begin();
-		for ( ; idIter!=(*bayIter).bayIDs.end() ; ++idIter ) {
+		for (std::vector<int>::const_iterator idIter = (*bayIter).bayIDs.begin(), idIEnd = (*bayIter).bayIDs.end(); idIter!=idIEnd ; ++idIter ) {
 			if ((*idIter)==zeroBaseBayID) {
 				return &(*bayIter);
 			}


### PR DESCRIPTION
# Description:

Limit docking of ship to the applicable docking bay sizes.

Currently any size of ship can dock with any size of docking bay, through any size of entrance opening. In theory this means someone could load in an LRC configured to be playable and attempt to dock with a regular internal bay of a space station.

Hilarious as that is, it's not very useful or realistic.

When I added the waypoint docking system and knowledge of the docking bays I also added sizes for the ships that could dock. Typically I used a range of 0 to 500 metres to allow any current ship to dock anywhere.

Now that I'm enforcing these limits nothing should break in the game but new stations can take advantage of the bay sizes to manage docking and grouping of ships into certain docking bay groupings.

Andy

Also:
Correct some lines endings.
Tidy up the iterator end checking in SpaceStationType.cpp
