### PR TITLE
DDS file loading support.

### DIFF
--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -7,6 +7,8 @@
 #include <SDL_image.h>
 #include <SDL_rwops.h>
 
+#include <algorithm>
+
 namespace Graphics {
 
 TextureBuilder::TextureBuilder(const SDLSurfacePtr &surface, TextureSampleMode sampleMode, bool generateMipmaps, bool potExtend, bool forceRGBA, bool compressTextures) :
@@ -82,7 +84,9 @@ void TextureBuilder::PrepareSurface()
 	if (m_prepared) return;
 
 	if (!m_surface && !m_filename.empty()) {
-		if (ends_with(m_filename, ".dds")) {
+		std::string filename = m_filename;
+		std::transform(filename.begin(), filename.end(), filename.begin(), ::tolower);
+		if (ends_with(filename, ".dds")) {
 			LoadDDS();
 		} else {
 			LoadSurface();


### PR DESCRIPTION
# Description:

Add support for DXT1 and DXT5 formats compressed image formats using the DDS file type.

These are VERY widely supported formats and are what we internally compress to when the `Use Compressed Textures` flag is enabled. We already support their use internally but this avoids the lengthy conversion process on loading.
# Motivation:

@lionhearted pointed out to me recently [some issues](https://github.com/ParagonDevelopmentTeam/pioneer/issues/33) they were having with either running out of memory, or if they enabled compressed textures how long the load times got!

It turns out there's a lack of information and understanding about the difference between the size of a PNG on disk and how much ram it uses when loaded into memory. There are numerous tiny PNG files we load that once in memory take up over 16MiB of ram EACH. 

Not only does this hide from the artist the cost of having these giant, but mostly empty, textures in memory but it takes significant time to convert them on every load into the most appropriate DXTn format. Also the time taken to do that conversion, and it's subsequent quality, varies widely across platforms and drivers meaning that different machines might see different textures depending on whether they're being compressed or not.

These are issues within _Pioneer_ too, it's not a forked projects problem, it's OURS.
# What this commit adds/does:

This commit adds my PicoDDS library to the contrib folder. 
The license for this will need checking as it was partially extracted from the [Game Texture Loader](http://tgtl.sourceforge.net/) library and modified. It should be fully compliant with their usage but if not I know of an alternative GPLv3 that can be ported with some extra work.

It hooks the PicoDDS up with the TextureBuilder using a file extension check to decide if it should use the existing SDLWrapper loader or the PicoDDS loader. Some extra information had to be added to the TextureDescriptor to include the number of mipmaps and overall my implementation feels a bit hacky.

@Luomu I'd really appreciate a critical glance over the changes I made to the TextureBuilder if you've got time before this goes in.
# Summary:

Adds a compressed file format loader adding support for pre-converted DXT1 or DXT5 format images. This means the artist can control exactly how the texture will look after conversion independently of drivers or platform implementations. It also means that we save loading time by not needing to `load PNG -> decompress -> convert to DXTn -> generate mipmaps` for every texture.

This should also help artists get a handle on the fact that the file size of a PNG does not equal the amount of GPU ram it uses. Because DXTn doesn't change size once in memory it's is already compressed and is used directly by the GPU.

Andy
