### PR TITLE
Fixes bug #2301

### DIFF
--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -62,6 +62,16 @@ static void print_info(const SystemBody *sbody, const Terrain *terrain)
 		sbody->name.c_str(), terrain->GetHeightFractalName(), terrain->GetColorFractalName(), sbody->seed);
 }
 
+// static 
+void GeoSphere::UpdateAllGeoSpheres()
+{
+	for(std::vector<GeoSphere*>::iterator i = s_allGeospheres.begin(); i != s_allGeospheres.end(); ++i) 
+	{
+		(*i)->Update();
+	}
+}
+
+// static 
 void GeoSphere::OnChangeDetailLevel()
 {
 //#warning "cancel jobs"

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -53,6 +53,7 @@ public:
 	friend class GeoPatch;
 	static void Init();
 	static void Uninit();
+	static void UpdateAllGeoSpheres();
 	static void OnChangeDetailLevel();
 	static bool OnAddQuadSplitResult(const SystemPath &path, SQuadSplitResult *res);
 	static bool OnAddSingleSplitResult(const SystemPath &path, SSingleSplitResult *res);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -984,6 +984,7 @@ void Pi::MainLoop()
 					break;
 				}
 				game->TimeStep(step);
+				GeoSphere::UpdateAllGeoSpheres();
 
 				accumulator -= step;
 			}
@@ -997,6 +998,7 @@ void Pi::MainLoop()
 #endif
 		} else {
 			// paused
+			GeoSphere::UpdateAllGeoSpheres();
 		}
 		frame_stat++;
 

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -56,13 +56,6 @@ void TerrainBody::Load(Serializer::Reader &rd, Space *space)
 	InitTerrainBody(sbody);
 }
 
-void TerrainBody::TimeStepUpdate(const float timeStep)
-{
-	if( m_geosphere ) {
-		m_geosphere->Update();
-	}
-}
-
 void TerrainBody::Render(Graphics::Renderer *renderer, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform)
 {
 	matrix4x4d ftran = viewTransform;

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -16,7 +16,6 @@ class TerrainBody : public Body {
 public:
 	OBJDEF(TerrainBody, Body, TERRAINBODY);
 
-	virtual void TimeStepUpdate(const float timeStep);
 	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
 	virtual void SubRender(Graphics::Renderer *r, const Camera *camera, const vector3d &camPos) {}
 	virtual void SetFrame(Frame *f);


### PR DESCRIPTION
Fixes bug #2301
Remove TimeStepUpdate from TerrainBody.
Add a static UpdateAllGeoSpheres() method to the GeoSphere class.
Call aforementioned from Pi::MainLoop().
