### PR TITLE
Only load thruster & navlight nodes from the highest LOD

### DIFF
--- a/src/scenegraph/Billboard.cpp
+++ b/src/scenegraph/Billboard.cpp
@@ -44,7 +44,7 @@ void Billboard::Render(const matrix4x4f &trans, RenderData *rd)
 	const matrix3x3f rot = trans.GetOrient().Transpose();
 
 	//some hand-tweaked scaling, to make the lights seem larger from distance
-	const float size = m_size * Graphics::GetFovFactor() * Clamp(trans.GetTranslate().Length() / 100.f, 0.25f, 15.f);
+	const float size = m_size * Graphics::GetFovFactor() * Clamp(trans.GetTranslate().Length() / 500.f, 0.25f, 15.f);
 
 	const vector3f rotv1 = rot * vector3f(size/2.f, -size/2.f, 0.0f);
 	const vector3f rotv2 = rot * vector3f(size/2.f, size/2.f, 0.0f);

--- a/src/scenegraph/Loader.h
+++ b/src/scenegraph/Loader.h
@@ -42,10 +42,14 @@ private:
 	Graphics::Renderer *m_renderer;
 	Model *m_model;
 	bool m_doLog;
+	bool m_mostDetailedLod;
 	RefCountedPtr<Text::DistanceFieldFont> m_labelFont;
 	std::string m_curPath;
 	std::vector<std::string> m_logMessages;
 	std::string m_curMeshDef; //for logging
+
+	RefCountedPtr<Group> m_thrustersRoot;
+	RefCountedPtr<Group> m_billboardsRoot;
 
 	bool CheckKeysInRange(const aiNodeAnim *, double start, double end);
 	matrix4x4f ConvertMatrix(const aiMatrix4x4&) const;
@@ -58,7 +62,8 @@ private:
 	void ConvertAnimations(const aiScene *, const AnimList &, Node *meshRoot);
 	void ConvertNodes(aiNode *node, Group *parent, std::vector<RefCountedPtr<StaticGeometry> >& meshes, const matrix4x4f&);
 	void CreateLabel(Group *parent, const matrix4x4f&);
-	void CreateThruster(Group *parent, const matrix4x4f& nodeTrans, const std::string &name, const matrix4x4f &accum);
+	void CreateThruster(const std::string &name, const matrix4x4f& nodeTrans, const matrix4x4f &accum);
+	void CreateNavlight(const std::string &name, const matrix4x4f& nodeTrans, const matrix4x4f &accum);
 	void FindPatterns(PatternContainer &output); //find pattern texture files from the model directory
 	void LoadCollision(const std::string &filename);
 


### PR DESCRIPTION
Re: #2110, only three months later.

Thruster and navlight nodes are only loaded form the highest detail level, and attached outside the LOD structure. It is no longer needed to duplicate these nodes for all detail levels. The amount of geometry is too small to benefit from lodding, and these nodes are visible from long ranges.
Updating the workflow now will make future changes easier (I've wanted to do some thruster refactoring, but that may take x more months).

Ideally, the old models would be cleaned and re-exported, but I made it so the extra nodes are just silently ignored in game. In modelviewer you get extra warnings.
