### PR TITLE
InstanceTerrain GeneratorInstancer changes.

### DIFF
--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -182,7 +182,7 @@ void GeoPatch::LODUpdate(const vector3d &campos) {
 
 			SQuadSplitRequest *ssrd = new SQuadSplitRequest(v0, v1, v2, v3, centroid.Normalized(), m_depth,
 						geosphere->m_sbody->path, mPatchID, ctx->edgeLen,
-						ctx->frac, Terrain::InstanceTerrain(geosphere->m_sbody));
+						ctx->frac, Terrain::InstanceTerrain(*geosphere->m_terrain.Get()));
 			Pi::Jobs()->Queue(new QuadPatchJob(ssrd));
 		} else {
 			for (int i=0; i<NUM_KIDS; i++) {
@@ -207,7 +207,7 @@ void GeoPatch::RequestSinglePatch()
         assert(!mHasJobRequest);
 		mHasJobRequest = true;
 		SSingleSplitRequest *ssrd = new SSingleSplitRequest(v0, v1, v2, v3, centroid.Normalized(), m_depth,
-					geosphere->m_sbody->path, mPatchID, ctx->edgeLen, ctx->frac, Terrain::InstanceTerrain(geosphere->m_sbody));
+					geosphere->m_sbody->path, mPatchID, ctx->edgeLen, ctx->frac, Terrain::InstanceTerrain(*geosphere->m_terrain.Get()));
 		Pi::Jobs()->Queue(new SinglePatchJob(ssrd));
 	}
 }

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -6,47 +6,250 @@
 #include "Pi.h"
 #include "FileSystem.h"
 
+//static 
+const Terrain::GeneratorInstancer Terrain::sc_GeneratedTerrain[] = {
+	Terrain::InstanceGenerator<TerrainHeightMapped,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightMapped2,TerrainColorRock2>,
+	Terrain::InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarBrownDwarf>,
+	Terrain::InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarWhiteDwarf>,
+	Terrain::InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarM>,
+	Terrain::InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarK>,
+	Terrain::InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarG>,
+	Terrain::InstanceGenerator<TerrainHeightEllipsoid,TerrainColorSolid>,
+	Terrain::InstanceGenerator<TerrainHeightFlat,TerrainColorGGJupiter>,
+	Terrain::InstanceGenerator<TerrainHeightFlat,TerrainColorGGSaturn>,
+	Terrain::InstanceGenerator<TerrainHeightFlat,TerrainColorGGSaturn2>,
+	Terrain::InstanceGenerator<TerrainHeightFlat,TerrainColorGGNeptune>,
+	Terrain::InstanceGenerator<TerrainHeightFlat,TerrainColorGGNeptune2>,
+	Terrain::InstanceGenerator<TerrainHeightFlat,TerrainColorGGUranus>,
+	Terrain::InstanceGenerator<TerrainHeightAsteroid,TerrainColorAsteroid>,
+	Terrain::InstanceGenerator<TerrainHeightAsteroid2,TerrainColorAsteroid>,
+	Terrain::InstanceGenerator<TerrainHeightAsteroid3,TerrainColorAsteroid>,
+	Terrain::InstanceGenerator<TerrainHeightAsteroid4,TerrainColorAsteroid>,
+	Terrain::InstanceGenerator<TerrainHeightAsteroid,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightAsteroid2,TerrainColorBandedRock>,
+	Terrain::InstanceGenerator<TerrainHeightAsteroid3,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightAsteroid4,TerrainColorBandedRock>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRidged,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRivers,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightHillsDunes,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorEarthLike>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRidged,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRivers,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightHillsDunes,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRidged,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRivers,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightHillsDunes,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightHillsNormal,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRidged,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRivers,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightHillsDunes,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightHillsNormal,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRidged,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightHillsRivers,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightHillsDunes,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightHillsNormal,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightWaterSolid,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedLava,TerrainColorDesert>,
+	Terrain::InstanceGenerator<TerrainHeightHillsCraters,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsCraters,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightWaterSolid,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightWaterSolidCanyons,TerrainColorIce>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedLava,TerrainColorTFGood>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedLava,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedLava,TerrainColorVolcanic>,
+	Terrain::InstanceGenerator<TerrainHeightWaterSolid,TerrainColorTFPoor>,
+	Terrain::InstanceGenerator<TerrainHeightHillsNormal,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightHillsCraters2,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightMountainsCraters2,TerrainColorRock>,
+	Terrain::InstanceGenerator<TerrainHeightFlat,TerrainColorSolid>
+};
+
+enum EGeneratedTerrains {
+	eTerrainHeightMappedTerrainColorEarthLike=0,
+	eTerrainHeightMapped2TerrainColorRock2,
+	eTerrainHeightEllipsoidTerrainColorStarBrownDwarf,
+	eTerrainHeightEllipsoidTerrainColorStarWhiteDwarf,
+	eTerrainHeightEllipsoidTerrainColorStarM,
+	eTerrainHeightEllipsoidTerrainColorStarK,
+	eTerrainHeightEllipsoidTerrainColorStarG,
+	eTerrainHeightEllipsoidTerrainColorSolid,
+	eTerrainHeightFlatTerrainColorGGJupiter,
+	eTerrainHeightFlatTerrainColorGGSaturn,
+	eTerrainHeightFlatTerrainColorGGSaturn2,
+	eTerrainHeightFlatTerrainColorGGNeptune,
+	eTerrainHeightFlatTerrainColorGGNeptune2,
+	eTerrainHeightFlatTerrainColorGGUranus,
+	eTerrainHeightAsteroidTerrainColorAsteroid,
+	eTerrainHeightAsteroid2TerrainColorAsteroid,
+	eTerrainHeightAsteroid3TerrainColorAsteroid,
+	eTerrainHeightAsteroid4TerrainColorAsteroid,
+	eTerrainHeightAsteroidTerrainColorRock,
+	eTerrainHeightAsteroid2TerrainColorBandedRock,
+	eTerrainHeightAsteroid3TerrainColorRock,
+	eTerrainHeightAsteroid4TerrainColorBandedRock,
+	eTerrainHeightHillsRidgedTerrainColorEarthLike,
+	eTerrainHeightHillsRiversTerrainColorEarthLike,
+	eTerrainHeightHillsDunesTerrainColorEarthLike,
+	eTerrainHeightMountainsRidgedTerrainColorEarthLike,
+	eTerrainHeightMountainsNormalTerrainColorEarthLike,
+	eTerrainHeightMountainsRiversTerrainColorEarthLike,
+	eTerrainHeightMountainsVolcanoTerrainColorEarthLike,
+	eTerrainHeightMountainsRiversVolcanoTerrainColorEarthLike,
+	eTerrainHeightHillsRidgedTerrainColorDesert,
+	eTerrainHeightHillsRiversTerrainColorDesert,
+	eTerrainHeightHillsDunesTerrainColorDesert,
+	eTerrainHeightMountainsRidgedTerrainColorDesert,
+	eTerrainHeightMountainsNormalTerrainColorDesert,
+	eTerrainHeightMountainsRiversTerrainColorDesert,
+	eTerrainHeightMountainsVolcanoTerrainColorDesert,
+	eTerrainHeightMountainsRiversVolcanoTerrainColorDesert,
+	eTerrainHeightBarrenRockTerrainColorDesert,
+	eTerrainHeightBarrenRock2TerrainColorDesert,
+	eTerrainHeightHillsRidgedTerrainColorTFGood,
+	eTerrainHeightHillsRiversTerrainColorTFGood,
+	eTerrainHeightHillsDunesTerrainColorTFGood,
+	eTerrainHeightHillsNormalTerrainColorTFGood,
+	eTerrainHeightMountainsNormalTerrainColorTFGood,
+	eTerrainHeightMountainsRidgedTerrainColorTFGood,
+	eTerrainHeightMountainsVolcanoTerrainColorTFGood,
+	eTerrainHeightMountainsRiversVolcanoTerrainColorTFGood,
+	eTerrainHeightMountainsRiversTerrainColorTFGood,
+	eTerrainHeightRuggedDesertTerrainColorTFGood,
+	eTerrainHeightBarrenRockTerrainColorTFGood,
+	eTerrainHeightBarrenRock2TerrainColorTFGood,
+	eTerrainHeightHillsRidgedTerrainColorIce,
+	eTerrainHeightHillsRiversTerrainColorIce,
+	eTerrainHeightHillsDunesTerrainColorIce,
+	eTerrainHeightHillsNormalTerrainColorIce,
+	eTerrainHeightMountainsNormalTerrainColorIce,
+	eTerrainHeightMountainsRidgedTerrainColorIce,
+	eTerrainHeightMountainsVolcanoTerrainColorIce,
+	eTerrainHeightMountainsRiversVolcanoTerrainColorIce,
+	eTerrainHeightMountainsRiversTerrainColorIce,
+	eTerrainHeightRuggedDesertTerrainColorIce,
+	eTerrainHeightBarrenRockTerrainColorIce,
+	eTerrainHeightBarrenRock2TerrainColorIce,
+	eTerrainHeightBarrenRock3TerrainColorIce,
+	eTerrainHeightHillsRidgedTerrainColorTFPoor,
+	eTerrainHeightHillsRiversTerrainColorTFPoor,
+	eTerrainHeightHillsDunesTerrainColorTFPoor,
+	eTerrainHeightHillsNormalTerrainColorTFPoor,
+	eTerrainHeightMountainsNormalTerrainColorTFPoor,
+	eTerrainHeightMountainsRidgedTerrainColorTFPoor,
+	eTerrainHeightMountainsVolcanoTerrainColorTFPoor,
+	eTerrainHeightMountainsRiversVolcanoTerrainColorTFPoor,
+	eTerrainHeightMountainsRiversTerrainColorTFPoor,
+	eTerrainHeightRuggedDesertTerrainColorTFPoor,
+	eTerrainHeightBarrenRockTerrainColorTFPoor,
+	eTerrainHeightBarrenRock2TerrainColorTFPoor,
+	eTerrainHeightBarrenRock3TerrainColorTFPoor,
+	eTerrainHeightWaterSolidTerrainColorDesert,
+	eTerrainHeightRuggedDesertTerrainColorDesert,
+	eTerrainHeightRuggedLavaTerrainColorDesert,
+	eTerrainHeightHillsCratersTerrainColorIce,
+	eTerrainHeightMountainsCratersTerrainColorIce,
+	eTerrainHeightWaterSolidTerrainColorIce,
+	eTerrainHeightWaterSolidCanyonsTerrainColorIce,
+	eTerrainHeightRuggedLavaTerrainColorTFGood,
+	eTerrainHeightRuggedLavaTerrainColorTFPoor,
+	eTerrainHeightRuggedLavaTerrainColorVolcanic,
+	eTerrainHeightWaterSolidTerrainColorTFPoor,
+	eTerrainHeightHillsNormalTerrainColorRock,
+	eTerrainHeightMountainsNormalTerrainColorRock,
+	eTerrainHeightRuggedDesertTerrainColorRock,
+	eTerrainHeightBarrenRockTerrainColorRock,
+	eTerrainHeightBarrenRock2TerrainColorRock,
+	eTerrainHeightBarrenRock3TerrainColorRock,
+	eTerrainHeightHillsCraters2TerrainColorRock,
+	eTerrainHeightMountainsCraters2TerrainColorRock,
+	eTerrainHeightFlatTerrainColorSolid
+};
+
 // static instancer. selects the best height and color classes for the body
 Terrain *Terrain::InstanceTerrain(const SystemBody *body)
 {
+	uint32_t gs = 0;
+
 	// special case for heightmaps
 	// XXX this is terrible but will do for now until we get a unified
 	// heightmap setup. if you add another height fractal, remember to change
 	// the check in CustomSystem::l_height_map
 	if (body->heightMapFilename) {
-		const GeneratorInstancer choices[] = {
-			InstanceGenerator<TerrainHeightMapped,TerrainColorEarthLike>,
-			InstanceGenerator<TerrainHeightMapped2,TerrainColorRock2>
+		static const uint32_t choices[] = {
+			eTerrainHeightMappedTerrainColorEarthLike,
+			eTerrainHeightMapped2TerrainColorRock2
 		};
 		assert(body->heightMapFractal < COUNTOF(choices));
-		return choices[body->heightMapFractal](body);
+		gs = choices[body->heightMapFractal];
+		return sc_GeneratedTerrain[gs](body,gs);
 	}
 
 	Random rand(body->seed);
-
-	GeneratorInstancer gi = 0;
-
 	switch (body->type) {
 
 		case SystemBody::TYPE_BROWN_DWARF:
-			gi = InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarBrownDwarf>;
+			gs = eTerrainHeightEllipsoidTerrainColorStarBrownDwarf;
 			break;
 
 		case SystemBody::TYPE_WHITE_DWARF:
-			gi = InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarWhiteDwarf>;
+			gs = eTerrainHeightEllipsoidTerrainColorStarWhiteDwarf;
 			break;
 
 		case SystemBody::TYPE_STAR_M:
 		case SystemBody::TYPE_STAR_M_GIANT:
 		case SystemBody::TYPE_STAR_M_SUPER_GIANT:
 		case SystemBody::TYPE_STAR_M_HYPER_GIANT: {
-			const GeneratorInstancer choices[] = {
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarM>,
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarM>,
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarK>,
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarG>
+			static const uint32_t choices[] = {
+				eTerrainHeightEllipsoidTerrainColorStarM,
+				eTerrainHeightEllipsoidTerrainColorStarM,
+				eTerrainHeightEllipsoidTerrainColorStarK,
+				eTerrainHeightEllipsoidTerrainColorStarG
 			};
-			gi = choices[rand.Int32(COUNTOF(choices))];
+			gs = choices[rand.Int32(COUNTOF(choices))];
 			break;
 		}
 
@@ -54,13 +257,13 @@ Terrain *Terrain::InstanceTerrain(const SystemBody *body)
 		case SystemBody::TYPE_STAR_K_GIANT:
 		case SystemBody::TYPE_STAR_K_SUPER_GIANT:
 		case SystemBody::TYPE_STAR_K_HYPER_GIANT: {
-			const GeneratorInstancer choices[] = {
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarM>,
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarK>,
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarK>,
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarG>
+			static const uint32_t choices[] = {
+				eTerrainHeightEllipsoidTerrainColorStarM,
+				eTerrainHeightEllipsoidTerrainColorStarK,
+				eTerrainHeightEllipsoidTerrainColorStarK,
+				eTerrainHeightEllipsoidTerrainColorStarG
 			};
-			gi = choices[rand.Int32(COUNTOF(choices))];
+			gs = choices[rand.Int32(COUNTOF(choices))];
 			break;
 		}
 
@@ -68,11 +271,11 @@ Terrain *Terrain::InstanceTerrain(const SystemBody *body)
 		case SystemBody::TYPE_STAR_G_GIANT:
 		case SystemBody::TYPE_STAR_G_SUPER_GIANT:
 		case SystemBody::TYPE_STAR_G_HYPER_GIANT: {
-			const GeneratorInstancer choices[] = {
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarWhiteDwarf>,
-				InstanceGenerator<TerrainHeightEllipsoid,TerrainColorStarG>
+			static const uint32_t choices[] = {
+				eTerrainHeightEllipsoidTerrainColorStarWhiteDwarf,
+				eTerrainHeightEllipsoidTerrainColorStarG
 			};
-			gi = choices[rand.Int32(COUNTOF(choices))];
+			gs = choices[rand.Int32(COUNTOF(choices))];
 			break;
 		}
 
@@ -93,42 +296,42 @@ Terrain *Terrain::InstanceTerrain(const SystemBody *body)
 		case SystemBody::TYPE_STAR_O_HYPER_GIANT:
 		case SystemBody::TYPE_STAR_O_SUPER_GIANT:
 		case SystemBody::TYPE_STAR_O_WF:
-			gi = InstanceGenerator<TerrainHeightEllipsoid,TerrainColorSolid>;
+			gs = eTerrainHeightEllipsoidTerrainColorSolid;
 		break;
 
 		case SystemBody::TYPE_PLANET_GAS_GIANT: {
-			const GeneratorInstancer choices[] = {
-				InstanceGenerator<TerrainHeightFlat,TerrainColorGGJupiter>,
-				InstanceGenerator<TerrainHeightFlat,TerrainColorGGSaturn>,
-				InstanceGenerator<TerrainHeightFlat,TerrainColorGGSaturn2>,
-				InstanceGenerator<TerrainHeightFlat,TerrainColorGGNeptune>,
-				InstanceGenerator<TerrainHeightFlat,TerrainColorGGNeptune2>,
-				InstanceGenerator<TerrainHeightFlat,TerrainColorGGUranus>,
-				InstanceGenerator<TerrainHeightFlat,TerrainColorGGSaturn>
+			static const uint32_t choices[] = {
+				eTerrainHeightFlatTerrainColorGGJupiter,
+				eTerrainHeightFlatTerrainColorGGSaturn,
+				eTerrainHeightFlatTerrainColorGGSaturn2,
+				eTerrainHeightFlatTerrainColorGGNeptune,
+				eTerrainHeightFlatTerrainColorGGNeptune2,
+				eTerrainHeightFlatTerrainColorGGUranus,
+				eTerrainHeightFlatTerrainColorGGSaturn
 			};
-			gi = choices[rand.Int32(COUNTOF(choices))];
+			gs = choices[rand.Int32(COUNTOF(choices))];
 			break;
 		}
 
 		case SystemBody::TYPE_PLANET_ASTEROID: {
-			const GeneratorInstancer choices[] = {
-				InstanceGenerator<TerrainHeightAsteroid,TerrainColorAsteroid>,
-				InstanceGenerator<TerrainHeightAsteroid2,TerrainColorAsteroid>,
-				InstanceGenerator<TerrainHeightAsteroid3,TerrainColorAsteroid>,
-				InstanceGenerator<TerrainHeightAsteroid4,TerrainColorAsteroid>,
-				InstanceGenerator<TerrainHeightAsteroid,TerrainColorRock>,
-				InstanceGenerator<TerrainHeightAsteroid2,TerrainColorBandedRock>,
-				InstanceGenerator<TerrainHeightAsteroid3,TerrainColorRock>,
-				InstanceGenerator<TerrainHeightAsteroid4,TerrainColorBandedRock>
+			static const uint32_t choices[] = {
+				eTerrainHeightAsteroidTerrainColorAsteroid,
+				eTerrainHeightAsteroid2TerrainColorAsteroid,
+				eTerrainHeightAsteroid3TerrainColorAsteroid,
+				eTerrainHeightAsteroid4TerrainColorAsteroid,
+				eTerrainHeightAsteroidTerrainColorRock,
+				eTerrainHeightAsteroid2TerrainColorBandedRock,
+				eTerrainHeightAsteroid3TerrainColorRock,
+				eTerrainHeightAsteroid4TerrainColorBandedRock
 			};
-			gi = choices[rand.Int32(COUNTOF(choices))];
+			gs = choices[rand.Int32(COUNTOF(choices))];
 			break;
 		}
 
 		case SystemBody::TYPE_PLANET_TERRESTRIAL: {
 
 			//Over-ride:
-			//gi = InstanceGenerator<TerrainHeightAsteroid3,TerrainColorRock>;
+			//gs = eTerrainHeightAsteroid3TerrainColorRock;
 			//break;
 			// Earth-like world
 
@@ -136,34 +339,34 @@ Terrain *Terrain::InstanceTerrain(const SystemBody *body)
 				// There would be no life on the surface without atmosphere
 
 				if (body->averageTemp > 240) {
-					const GeneratorInstancer choices[] = {
-						InstanceGenerator<TerrainHeightHillsRidged,TerrainColorEarthLike>,
-						InstanceGenerator<TerrainHeightHillsRivers,TerrainColorEarthLike>,
-						InstanceGenerator<TerrainHeightHillsDunes,TerrainColorEarthLike>,
-						InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorEarthLike>,
-						InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorEarthLike>,
-						InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorEarthLike>,
-						InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorEarthLike>,
-						InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorEarthLike>
+					static const uint32_t choices[] = {
+						eTerrainHeightHillsRidgedTerrainColorEarthLike,
+						eTerrainHeightHillsRiversTerrainColorEarthLike,
+						eTerrainHeightHillsDunesTerrainColorEarthLike,
+						eTerrainHeightMountainsRidgedTerrainColorEarthLike,
+						eTerrainHeightMountainsNormalTerrainColorEarthLike,
+						eTerrainHeightMountainsRiversTerrainColorEarthLike,
+						eTerrainHeightMountainsVolcanoTerrainColorEarthLike,
+						eTerrainHeightMountainsRiversVolcanoTerrainColorEarthLike
 					};
-					gi = choices[rand.Int32(COUNTOF(choices))];
+					gs = choices[rand.Int32(COUNTOF(choices))];
 					break;
 				}
 
-				const GeneratorInstancer choices[] = {
-					InstanceGenerator<TerrainHeightHillsRidged,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightHillsRivers,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightHillsDunes,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightBarrenRock,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorDesert>//,
-					//InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorTFGood>
+				static const uint32_t choices[] = {
+					eTerrainHeightHillsRidgedTerrainColorDesert,
+					eTerrainHeightHillsRiversTerrainColorDesert,
+					eTerrainHeightHillsDunesTerrainColorDesert,
+					eTerrainHeightMountainsRidgedTerrainColorDesert,
+					eTerrainHeightMountainsNormalTerrainColorDesert,
+					eTerrainHeightMountainsRiversTerrainColorDesert,
+					eTerrainHeightMountainsVolcanoTerrainColorDesert,
+					eTerrainHeightMountainsRiversVolcanoTerrainColorDesert,
+					eTerrainHeightBarrenRockTerrainColorDesert,
+					eTerrainHeightBarrenRock2TerrainColorDesert//,
+					//eTerrainHeightBarrenRock3TerrainColorTFGood
 				};
-				gi = choices[rand.Int32(COUNTOF(choices))];
+				gs = choices[rand.Int32(COUNTOF(choices))];
 				break;
 			}
 
@@ -171,41 +374,41 @@ Terrain *Terrain::InstanceTerrain(const SystemBody *body)
 			if ((body->m_volatileGas > fixed(2,10)) && (body->m_life > fixed(4,10)) ) {
 
 				if (body->averageTemp > 240) {
-					const GeneratorInstancer choices[] = {
-						InstanceGenerator<TerrainHeightHillsRidged,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightHillsRivers,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightHillsDunes,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightHillsNormal,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightBarrenRock,TerrainColorTFGood>,
-						InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorTFGood>
-						//InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorTFGood>
+					static const uint32_t choices[] = {
+						eTerrainHeightHillsRidgedTerrainColorTFGood,
+						eTerrainHeightHillsRiversTerrainColorTFGood,
+						eTerrainHeightHillsDunesTerrainColorTFGood,
+						eTerrainHeightHillsNormalTerrainColorTFGood,
+						eTerrainHeightMountainsNormalTerrainColorTFGood,
+						eTerrainHeightMountainsRidgedTerrainColorTFGood,
+						eTerrainHeightMountainsVolcanoTerrainColorTFGood,
+						eTerrainHeightMountainsRiversVolcanoTerrainColorTFGood,
+						eTerrainHeightMountainsRiversTerrainColorTFGood,
+						eTerrainHeightRuggedDesertTerrainColorTFGood,
+						eTerrainHeightBarrenRockTerrainColorTFGood,
+						eTerrainHeightBarrenRock2TerrainColorTFGood
+						//eTerrainHeightBarrenRock3TerrainColorTFGood
 					};
-					gi = choices[rand.Int32(COUNTOF(choices))];
+					gs = choices[rand.Int32(COUNTOF(choices))];
 					break;
 				}
 
-				const GeneratorInstancer choices[] = {
-					InstanceGenerator<TerrainHeightHillsRidged,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightHillsRivers,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightHillsDunes,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightHillsNormal,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorIce>
+				static const uint32_t choices[] = {
+					eTerrainHeightHillsRidgedTerrainColorIce,
+					eTerrainHeightHillsRiversTerrainColorIce,
+					eTerrainHeightHillsDunesTerrainColorIce,
+					eTerrainHeightHillsNormalTerrainColorIce,
+					eTerrainHeightMountainsNormalTerrainColorIce,
+					eTerrainHeightMountainsRidgedTerrainColorIce,
+					eTerrainHeightMountainsVolcanoTerrainColorIce,
+					eTerrainHeightMountainsRiversVolcanoTerrainColorIce,
+					eTerrainHeightMountainsRiversTerrainColorIce,
+					eTerrainHeightRuggedDesertTerrainColorIce,
+					eTerrainHeightBarrenRockTerrainColorIce,
+					eTerrainHeightBarrenRock2TerrainColorIce,
+					eTerrainHeightBarrenRock3TerrainColorIce
 				};
-				gi = choices[rand.Int32(COUNTOF(choices))];
+				gs = choices[rand.Int32(COUNTOF(choices))];
 				break;
 			}
 
@@ -213,74 +416,74 @@ Terrain *Terrain::InstanceTerrain(const SystemBody *body)
 			else if ((body->m_volatileGas > fixed(1,10)) && (body->m_life > fixed(1,10)) ) {
 
 				if (body->averageTemp > 240) {
-					const GeneratorInstancer choices[] = {
-						InstanceGenerator<TerrainHeightHillsRidged,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightHillsRivers,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightHillsDunes,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightHillsNormal,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightBarrenRock,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorTFPoor>,
-						InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorTFPoor>
+					static const uint32_t choices[] = {
+						eTerrainHeightHillsRidgedTerrainColorTFPoor,
+						eTerrainHeightHillsRiversTerrainColorTFPoor,
+						eTerrainHeightHillsDunesTerrainColorTFPoor,
+						eTerrainHeightHillsNormalTerrainColorTFPoor,
+						eTerrainHeightMountainsNormalTerrainColorTFPoor,
+						eTerrainHeightMountainsRidgedTerrainColorTFPoor,
+						eTerrainHeightMountainsVolcanoTerrainColorTFPoor,
+						eTerrainHeightMountainsRiversVolcanoTerrainColorTFPoor,
+						eTerrainHeightMountainsRiversTerrainColorTFPoor,
+						eTerrainHeightRuggedDesertTerrainColorTFPoor,
+						eTerrainHeightBarrenRockTerrainColorTFPoor,
+						eTerrainHeightBarrenRock2TerrainColorTFPoor,
+						eTerrainHeightBarrenRock3TerrainColorTFPoor
 					};
-					gi = choices[rand.Int32(COUNTOF(choices))];
+					gs = choices[rand.Int32(COUNTOF(choices))];
 					break;
 				}
 
-				const GeneratorInstancer choices[] = {
-					InstanceGenerator<TerrainHeightHillsRidged,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightHillsRivers,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightHillsDunes,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightHillsNormal,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorIce>
+				static const uint32_t choices[] = {
+					eTerrainHeightHillsRidgedTerrainColorIce,
+					eTerrainHeightHillsRiversTerrainColorIce,
+					eTerrainHeightHillsDunesTerrainColorIce,
+					eTerrainHeightHillsNormalTerrainColorIce,
+					eTerrainHeightMountainsNormalTerrainColorIce,
+					eTerrainHeightMountainsRidgedTerrainColorIce,
+					eTerrainHeightMountainsVolcanoTerrainColorIce,
+					eTerrainHeightMountainsRiversVolcanoTerrainColorIce,
+					eTerrainHeightMountainsRiversTerrainColorIce,
+					eTerrainHeightRuggedDesertTerrainColorIce,
+					eTerrainHeightBarrenRockTerrainColorIce,
+					eTerrainHeightBarrenRock2TerrainColorIce,
+					eTerrainHeightBarrenRock3TerrainColorIce
 				};
-				gi = choices[rand.Int32(COUNTOF(choices))];
+				gs = choices[rand.Int32(COUNTOF(choices))];
 				break;
 			}
 
 			// Desert-like world, Mars -like.
 			if ((body->m_volatileLiquid < fixed(1,10)) && (body->m_volatileGas > fixed(1,5))) {
-				const GeneratorInstancer choices[] = {
-					InstanceGenerator<TerrainHeightHillsDunes,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightWaterSolid,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightRuggedLava,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightBarrenRock,TerrainColorDesert>,
-					InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorDesert>
+				static const uint32_t choices[] = {
+					eTerrainHeightHillsDunesTerrainColorDesert,
+					eTerrainHeightWaterSolidTerrainColorDesert,
+					eTerrainHeightRuggedDesertTerrainColorDesert,
+					eTerrainHeightRuggedLavaTerrainColorDesert,
+					eTerrainHeightMountainsVolcanoTerrainColorDesert,
+					eTerrainHeightMountainsRiversVolcanoTerrainColorDesert,
+					eTerrainHeightBarrenRockTerrainColorDesert,
+					eTerrainHeightBarrenRock2TerrainColorDesert
 				};
-				gi = choices[rand.Int32(COUNTOF(choices))];
+				gs = choices[rand.Int32(COUNTOF(choices))];
 				break;
 			}
 
 			// Frozen world
 			if ((body->m_volatileIces > fixed(8,10)) &&  (body->averageTemp < 250)) {
-				const GeneratorInstancer choices[] = {
-					InstanceGenerator<TerrainHeightHillsDunes,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightHillsCraters,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightMountainsCraters,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightWaterSolid,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightWaterSolidCanyons,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorIce>
+				static const uint32_t choices[] = {
+					eTerrainHeightHillsDunesTerrainColorIce,
+					eTerrainHeightHillsCratersTerrainColorIce,
+					eTerrainHeightMountainsCratersTerrainColorIce,
+					eTerrainHeightWaterSolidTerrainColorIce,
+					eTerrainHeightWaterSolidCanyonsTerrainColorIce,
+					eTerrainHeightRuggedDesertTerrainColorIce,
+					eTerrainHeightBarrenRockTerrainColorIce,
+					eTerrainHeightBarrenRock2TerrainColorIce,
+					eTerrainHeightBarrenRock3TerrainColorIce
 				};
-				gi = choices[rand.Int32(COUNTOF(choices))];
+				gs = choices[rand.Int32(COUNTOF(choices))];
 				break;
 			}
 
@@ -288,65 +491,71 @@ Terrain *Terrain::InstanceTerrain(const SystemBody *body)
 			if (body->m_volcanicity > fixed(7,10)) {
 
 				if (body->m_life > fixed(5,10))	// life on a volcanic world ;)
-					gi = InstanceGenerator<TerrainHeightRuggedLava,TerrainColorTFGood>;
+					gs = eTerrainHeightRuggedLavaTerrainColorTFGood;
 				else if (body->m_life > fixed(2,10))
-					gi = InstanceGenerator<TerrainHeightRuggedLava,TerrainColorTFPoor>;
+					gs = eTerrainHeightRuggedLavaTerrainColorTFPoor;
 				else
-					gi = InstanceGenerator<TerrainHeightRuggedLava,TerrainColorVolcanic>;
+					gs = eTerrainHeightRuggedLavaTerrainColorVolcanic;
 				break;
 			}
 
 			//Below might not be needed.
 			//Alien life world:
 			if (body->m_life > fixed(1,10))  {
-				const GeneratorInstancer choices[] = {
-					InstanceGenerator<TerrainHeightHillsDunes,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightHillsRidged,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightHillsRivers,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightMountainsRidged,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightMountainsVolcano,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightMountainsRiversVolcano,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightMountainsRivers,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightWaterSolid,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightRuggedLava,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorTFPoor>,
-					InstanceGenerator<TerrainHeightBarrenRock,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorIce>,
-					InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorIce>
+				static const uint32_t choices[] = {
+					eTerrainHeightHillsDunesTerrainColorTFPoor,
+					eTerrainHeightHillsRidgedTerrainColorTFPoor,
+					eTerrainHeightHillsRiversTerrainColorTFPoor,
+					eTerrainHeightMountainsNormalTerrainColorTFPoor,
+					eTerrainHeightMountainsRidgedTerrainColorTFPoor,
+					eTerrainHeightMountainsVolcanoTerrainColorTFPoor,
+					eTerrainHeightMountainsRiversVolcanoTerrainColorTFPoor,
+					eTerrainHeightMountainsRiversTerrainColorTFPoor,
+					eTerrainHeightWaterSolidTerrainColorTFPoor,
+					eTerrainHeightRuggedLavaTerrainColorTFPoor,
+					eTerrainHeightRuggedDesertTerrainColorTFPoor,
+					eTerrainHeightBarrenRockTerrainColorIce,
+					eTerrainHeightBarrenRock2TerrainColorIce,
+					eTerrainHeightBarrenRock3TerrainColorIce
 				};
-				gi = choices[rand.Int32(COUNTOF(choices))];
+				gs = choices[rand.Int32(COUNTOF(choices))];
 				break;
 			};
 
 			if (body->m_volatileGas > fixed(1,10)) {
-				const GeneratorInstancer choices[] = {
-					InstanceGenerator<TerrainHeightHillsNormal,TerrainColorRock>,
-					InstanceGenerator<TerrainHeightMountainsNormal,TerrainColorRock>,
-					InstanceGenerator<TerrainHeightRuggedDesert,TerrainColorRock>,
-					InstanceGenerator<TerrainHeightBarrenRock,TerrainColorRock>,
-					InstanceGenerator<TerrainHeightBarrenRock2,TerrainColorRock>,
-					InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorRock>
+				static const uint32_t choices[] = {
+					eTerrainHeightHillsNormalTerrainColorRock,
+					eTerrainHeightMountainsNormalTerrainColorRock,
+					eTerrainHeightRuggedDesertTerrainColorRock,
+					eTerrainHeightBarrenRockTerrainColorRock,
+					eTerrainHeightBarrenRock2TerrainColorRock,
+					eTerrainHeightBarrenRock3TerrainColorRock
 				};
-				gi = choices[rand.Int32(COUNTOF(choices))];
+				gs = choices[rand.Int32(COUNTOF(choices))];
 				break;
 			}
 
-			const GeneratorInstancer choices[] = {
-				InstanceGenerator<TerrainHeightHillsCraters2,TerrainColorRock>,
-				InstanceGenerator<TerrainHeightMountainsCraters2,TerrainColorRock>,
-				InstanceGenerator<TerrainHeightBarrenRock3,TerrainColorRock>
+			static const uint32_t choices[] = {
+				eTerrainHeightHillsCraters2TerrainColorRock,
+				eTerrainHeightMountainsCraters2TerrainColorRock,
+				eTerrainHeightBarrenRock3TerrainColorRock
 			};
-			gi = choices[rand.Int32(COUNTOF(choices))];
+			gs = choices[rand.Int32(COUNTOF(choices))];
 			break;
 		}
 
 		default:
-			gi = InstanceGenerator<TerrainHeightFlat,TerrainColorSolid>;
+			gs = eTerrainHeightFlatTerrainColorSolid;
 			break;
 	}
 
-	return gi(body);
+	return sc_GeneratedTerrain[gs](body,gs);
+}
+
+//static 
+Terrain *Terrain::InstanceTerrain(const Terrain& terrainIn)
+{
+	return sc_GeneratedTerrain[terrainIn.m_terrainEnumType](terrainIn.m_body, terrainIn.m_terrainEnumType);
 }
 
 static size_t bufread_or_die(void *ptr, size_t size, size_t nmemb, ByteRange &buf)
@@ -359,7 +568,7 @@ static size_t bufread_or_die(void *ptr, size_t size, size_t nmemb, ByteRange &bu
 	return read_count;
 }
 
-Terrain::Terrain(const SystemBody *body) : m_body(body), m_seed(body->seed), m_rand(body->seed), m_heightMap(0), m_heightMapScaled(0), m_heightScaling(0), m_minh(0) {
+Terrain::Terrain(const SystemBody *body, const uint32_t tET) : m_terrainEnumType(tET), m_body(body), m_seed(body->seed), m_rand(body->seed), m_heightMap(0), m_heightMapScaled(0), m_heightScaling(0), m_minh(0) {
 
 	// load the heightmap
 	if (m_body->heightMapFilename) {

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -34,6 +34,7 @@ public:
 	};
 
 	static Terrain *InstanceTerrain(const SystemBody *body);
+	static Terrain *InstanceTerrain(const Terrain& terrainIn);
 
 	virtual ~Terrain();
 
@@ -54,13 +55,16 @@ public:
 
 private:
 	template <typename HeightFractal, typename ColorFractal>
-	static Terrain *InstanceGenerator(const SystemBody *body) { return new TerrainGenerator<HeightFractal,ColorFractal>(body); }
+	static Terrain *InstanceGenerator(const SystemBody *body, const uint32_t tET) { return new TerrainGenerator<HeightFractal,ColorFractal>(body,tET); }
 
-	typedef Terrain* (*GeneratorInstancer)(const SystemBody *);
+	typedef Terrain* (*GeneratorInstancer)(const SystemBody *, const uint32_t);
 
+	static const GeneratorInstancer sc_GeneratedTerrain[];
 
 protected:
-	Terrain(const SystemBody *body);
+	Terrain(const SystemBody *body, const uint32_t tET);
+
+	uint32_t m_terrainEnumType;
 
 	bool textures;
 	int m_fracnum;
@@ -124,7 +128,7 @@ public:
 	virtual double GetHeight(const vector3d &p) const;
 	virtual const char *GetHeightFractalName() const;
 protected:
-	TerrainHeightFractal(const SystemBody *body);
+	TerrainHeightFractal(const SystemBody *body, const uint32_t tET);
 private:
 	TerrainHeightFractal() {}
 };
@@ -135,7 +139,7 @@ public:
 	virtual vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const;
 	virtual const char *GetColorFractalName() const;
 protected:
-	TerrainColorFractal(const SystemBody *body);
+	TerrainColorFractal(const SystemBody *body, const uint32_t tET);
 private:
 	TerrainColorFractal() {}
 };
@@ -144,7 +148,7 @@ private:
 template <typename HeightFractal, typename ColorFractal>
 class TerrainGenerator : public TerrainHeightFractal<HeightFractal>, public TerrainColorFractal<ColorFractal> {
 public:
-	TerrainGenerator(const SystemBody *body) : Terrain(body), TerrainHeightFractal<HeightFractal>(body), TerrainColorFractal<ColorFractal>(body) {}
+	TerrainGenerator(const SystemBody *body, const uint32_t tET) : Terrain(body,tET), TerrainHeightFractal<HeightFractal>(body,tET), TerrainColorFractal<ColorFractal>(body,tET) {}
 
 private:
 	TerrainGenerator() {}

--- a/src/terrain/TerrainColorAsteroid.cpp
+++ b/src/terrain/TerrainColorAsteroid.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorAsteroid>::GetColorFractalName() const { return "Asteroid"; }
 
 template <>
-TerrainColorFractal<TerrainColorAsteroid>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorAsteroid>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainColorBandedRock.cpp
+++ b/src/terrain/TerrainColorBandedRock.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorBandedRock>::GetColorFractalName() const { return "BandedRock"; }
 
 template <>
-TerrainColorFractal<TerrainColorBandedRock>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorBandedRock>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainColorDeadWithWater.cpp
+++ b/src/terrain/TerrainColorDeadWithWater.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorDeadWithWater>::GetColorFractalName() const { return "DeadWithWater"; }
 
 template <>
-TerrainColorFractal<TerrainColorDeadWithWater>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorDeadWithWater>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	m_surfaceEffects |= Terrain::EFFECT_WATER;
 }

--- a/src/terrain/TerrainColorDesert.cpp
+++ b/src/terrain/TerrainColorDesert.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorDesert>::GetColorFractalName() const { return "Desert"; }
 
 template <>
-TerrainColorFractal<TerrainColorDesert>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorDesert>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainColorEarthLike.cpp
+++ b/src/terrain/TerrainColorEarthLike.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorEarthLike>::GetColorFractalName() const { return "EarthLike"; }
 
 template <>
-TerrainColorFractal<TerrainColorEarthLike>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorEarthLike>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	// crappy water
 	//double height = m_maxHeightInMeters*0.5;

--- a/src/terrain/TerrainColorGGJupiter.cpp
+++ b/src/terrain/TerrainColorGGJupiter.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorGGJupiter>::GetColorFractalName() const { return "GGJupiter"; }
 
 template <>
-TerrainColorFractal<TerrainColorGGJupiter>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorGGJupiter>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	// spots
 	const double height = m_maxHeightInMeters*0.1;

--- a/src/terrain/TerrainColorGGNeptune.cpp
+++ b/src/terrain/TerrainColorGGNeptune.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorGGNeptune>::GetColorFractalName() const { return "GGNeptune"; }
 
 template <>
-TerrainColorFractal<TerrainColorGGNeptune>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorGGNeptune>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	const double height = m_maxHeightInMeters*0.1;
 	//spot boundary

--- a/src/terrain/TerrainColorGGNeptune2.cpp
+++ b/src/terrain/TerrainColorGGNeptune2.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorGGNeptune2>::GetColorFractalName() const { return "GGNeptune2"; }
 
 template <>
-TerrainColorFractal<TerrainColorGGNeptune2>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorGGNeptune2>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	// spots
 	const double height = m_maxHeightInMeters*0.1;

--- a/src/terrain/TerrainColorGGSaturn.cpp
+++ b/src/terrain/TerrainColorGGSaturn.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorGGSaturn>::GetColorFractalName() const { return "GGSaturn"; }
 
 template <>
-TerrainColorFractal<TerrainColorGGSaturn>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorGGSaturn>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	const double height = m_maxHeightInMeters*0.1;
 	//spot + clouds

--- a/src/terrain/TerrainColorGGSaturn2.cpp
+++ b/src/terrain/TerrainColorGGSaturn2.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorGGSaturn2>::GetColorFractalName() const { return "GGSaturn2"; }
 
 template <>
-TerrainColorFractal<TerrainColorGGSaturn2>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorGGSaturn2>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	const double height = m_maxHeightInMeters*0.1;
 	//spot + clouds

--- a/src/terrain/TerrainColorGGUranus.cpp
+++ b/src/terrain/TerrainColorGGUranus.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorGGUranus>::GetColorFractalName() const { return "GGUranus"; }
 
 template <>
-TerrainColorFractal<TerrainColorGGUranus>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorGGUranus>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	const double height = m_maxHeightInMeters*0.1;
 	SetFracDef(0, height, 3e7, 1000.0*m_fracmult);

--- a/src/terrain/TerrainColorIce.cpp
+++ b/src/terrain/TerrainColorIce.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorIce>::GetColorFractalName() const { return "Ice"; }
 
 template <>
-TerrainColorFractal<TerrainColorIce>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorIce>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainColorMethane.cpp
+++ b/src/terrain/TerrainColorMethane.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorMethane>::GetColorFractalName() const { return "Methane"; }
 
 template <>
-TerrainColorFractal<TerrainColorMethane>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorMethane>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainColorRock.cpp
+++ b/src/terrain/TerrainColorRock.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorRock>::GetColorFractalName() const { return "Rock"; }
 
 template <>
-TerrainColorFractal<TerrainColorRock>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorRock>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainColorRock2.cpp
+++ b/src/terrain/TerrainColorRock2.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorRock2>::GetColorFractalName() const { return "Rock2"; }
 
 template <>
-TerrainColorFractal<TerrainColorRock2>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorRock2>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainColorSolid.cpp
+++ b/src/terrain/TerrainColorSolid.cpp
@@ -7,7 +7,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorSolid>::GetColorFractalName() const { return "Solid"; }
 
 template <>
-TerrainColorFractal<TerrainColorSolid>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorSolid>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainColorStarBrownDwarf.cpp
+++ b/src/terrain/TerrainColorStarBrownDwarf.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorStarBrownDwarf>::GetColorFractalName() const { return "StarBrownDwarf"; }
 
 template <>
-TerrainColorFractal<TerrainColorStarBrownDwarf>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorStarBrownDwarf>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	double height = m_maxHeightInMeters*0.1;
 	SetFracDef(0, height, 5e8, 100.0*m_fracmult);

--- a/src/terrain/TerrainColorStarG.cpp
+++ b/src/terrain/TerrainColorStarG.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorStarG>::GetColorFractalName() const { return "StarG"; }
 
 template <>
-TerrainColorFractal<TerrainColorStarG>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorStarG>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	double height = m_maxHeightInMeters*0.1;
 	SetFracDef(0, height, 8e8, 1000.0*m_fracmult);

--- a/src/terrain/TerrainColorStarK.cpp
+++ b/src/terrain/TerrainColorStarK.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorStarK>::GetColorFractalName() const { return "StarK"; }
 
 template <>
-TerrainColorFractal<TerrainColorStarK>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorStarK>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	double height = m_maxHeightInMeters*0.1;
 	SetFracDef(0, height, 2e9, 100.0*m_fracmult);

--- a/src/terrain/TerrainColorStarM.cpp
+++ b/src/terrain/TerrainColorStarM.cpp
@@ -11,7 +11,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorStarM>::GetColorFractalName() const { return "StarM"; }
 
 template <>
-TerrainColorFractal<TerrainColorStarM>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorStarM>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	double height = m_maxHeightInMeters*0.1;
 	SetFracDef(0, height, 22e7, 1000.0*m_fracmult);

--- a/src/terrain/TerrainColorStarWhiteDwarf.cpp
+++ b/src/terrain/TerrainColorStarWhiteDwarf.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorStarWhiteDwarf>::GetColorFractalName() const { return "StarWhiteDwarf"; }
 
 template <>
-TerrainColorFractal<TerrainColorStarWhiteDwarf>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorStarWhiteDwarf>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	double height = m_maxHeightInMeters*0.1;
 	SetFracDef(0, height, 3e9, 100.0*m_fracmult); //why on Earth we need a feature size of 3,000,000 KM (2.2x the sun) I don't know, but we do... :)

--- a/src/terrain/TerrainColorTFGood.cpp
+++ b/src/terrain/TerrainColorTFGood.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorTFGood>::GetColorFractalName() const { return "TFGood"; }
 
 template <>
-TerrainColorFractal<TerrainColorTFGood>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorTFGood>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 		m_surfaceEffects |= Terrain::EFFECT_WATER;
 }

--- a/src/terrain/TerrainColorTFPoor.cpp
+++ b/src/terrain/TerrainColorTFPoor.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorTFPoor>::GetColorFractalName() const { return "TFPoor"; }
 
 template <>
-TerrainColorFractal<TerrainColorTFPoor>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorTFPoor>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 		m_surfaceEffects |= Terrain::EFFECT_WATER;
 }

--- a/src/terrain/TerrainColorVolcanic.cpp
+++ b/src/terrain/TerrainColorVolcanic.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainColorFractal<TerrainColorVolcanic>::GetColorFractalName() const { return "Volcanic"; }
 
 template <>
-TerrainColorFractal<TerrainColorVolcanic>::TerrainColorFractal(const SystemBody *body) : Terrain(body)
+TerrainColorFractal<TerrainColorVolcanic>::TerrainColorFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	// 50 percent chance of there being exposed lava
 	if (m_rand.Int32(100) > 50)

--- a/src/terrain/TerrainHeightAsteroid.cpp
+++ b/src/terrain/TerrainHeightAsteroid.cpp
@@ -14,7 +14,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightAsteroid>::GetHeightFractalName() const { return "Asteroid"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightAsteroid>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightAsteroid>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainHeightAsteroid2.cpp
+++ b/src/terrain/TerrainHeightAsteroid2.cpp
@@ -14,7 +14,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightAsteroid2>::GetHeightFractalName() const { return "Asteroid"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightAsteroid2>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightAsteroid2>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainHeightAsteroid3.cpp
+++ b/src/terrain/TerrainHeightAsteroid3.cpp
@@ -14,7 +14,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightAsteroid3>::GetHeightFractalName() const { return "Asteroid"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightAsteroid3>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightAsteroid3>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainHeightAsteroid4.cpp
+++ b/src/terrain/TerrainHeightAsteroid4.cpp
@@ -14,7 +14,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightAsteroid4>::GetHeightFractalName() const { return "Asteroid"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightAsteroid4>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightAsteroid4>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainHeightBarrenRock.cpp
+++ b/src/terrain/TerrainHeightBarrenRock.cpp
@@ -14,7 +14,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeightFractalName() const { return "Barren Rock"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightBarrenRock>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightBarrenRock>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	//SetFracDef(0, m_maxHeightInMeters, m_planetRadius);
 	// craters

--- a/src/terrain/TerrainHeightBarrenRock2.cpp
+++ b/src/terrain/TerrainHeightBarrenRock2.cpp
@@ -15,7 +15,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightBarrenRock2>::GetHeightFractalName() const { return "Barren Rock 2"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightBarrenRock2>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightBarrenRock2>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainHeightBarrenRock3.cpp
+++ b/src/terrain/TerrainHeightBarrenRock3.cpp
@@ -14,7 +14,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightBarrenRock3>::GetHeightFractalName() const { return "Barren Rock 3"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightBarrenRock3>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightBarrenRock3>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainHeightEllipsoid.cpp
+++ b/src/terrain/TerrainHeightEllipsoid.cpp
@@ -4,7 +4,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightEllipsoid>::GetHeightFractalName() const { return "Ellipsoid"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightEllipsoid>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightEllipsoid>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	const double rad = m_body->GetRadius();
 	m_maxHeight = m_body->aspectRatio.ToDouble() - 1.0;

--- a/src/terrain/TerrainHeightFlat.cpp
+++ b/src/terrain/TerrainHeightFlat.cpp
@@ -7,7 +7,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightFlat>::GetHeightFractalName() const { return "Flat"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightFlat>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightFlat>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainHeightHillsCraters.cpp
+++ b/src/terrain/TerrainHeightHillsCraters.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightHillsCraters>::GetHeightFractalName() const { return "HillsCraters"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightHillsCraters>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightHillsCraters>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6,1e7));
 	double height = m_maxHeightInMeters*0.3;

--- a/src/terrain/TerrainHeightHillsCraters2.cpp
+++ b/src/terrain/TerrainHeightHillsCraters2.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightHillsCraters2>::GetHeightFractalName() const { return "HillsCraters2"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightHillsCraters2>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightHillsCraters2>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6,1e7));
 	double height = m_maxHeightInMeters*0.6;

--- a/src/terrain/TerrainHeightHillsDunes.cpp
+++ b/src/terrain/TerrainHeightHillsDunes.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightHillsDunes>::GetHeightFractalName() const { return "HillsDunes"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightHillsDunes>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightHillsDunes>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	//textures
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(50, 100), 10*m_fracmult);

--- a/src/terrain/TerrainHeightHillsNormal.cpp
+++ b/src/terrain/TerrainHeightHillsNormal.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightHillsNormal>::GetHeightFractalName() const { return "HillsNormal"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightHillsNormal>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightHillsNormal>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	//textures
 	if (textures) {

--- a/src/terrain/TerrainHeightHillsRidged.cpp
+++ b/src/terrain/TerrainHeightHillsRidged.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightHillsRidged>::GetHeightFractalName() const { return "HillsRidged"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightHillsRidged>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightHillsRidged>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	//textures:
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(5, 15), 10*m_fracmult);

--- a/src/terrain/TerrainHeightHillsRivers.cpp
+++ b/src/terrain/TerrainHeightHillsRivers.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightHillsRivers>::GetHeightFractalName() const { return "HillsRivers"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightHillsRivers>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightHillsRivers>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	//textures
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(5, 15), 10*m_fracmult);

--- a/src/terrain/TerrainHeightMapped.cpp
+++ b/src/terrain/TerrainHeightMapped.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMapped>::GetHeightFractalName() const { return "Mapped"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMapped>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMapped>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	//textures
 	if (textures) {

--- a/src/terrain/TerrainHeightMapped2.cpp
+++ b/src/terrain/TerrainHeightMapped2.cpp
@@ -9,7 +9,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMapped2>::GetHeightFractalName() const { return "Mapped2"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMapped2>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMapped2>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 }
 

--- a/src/terrain/TerrainHeightMountainsCraters.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMountainsCraters>::GetHeightFractalName() const { return "MountainsCraters"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMountainsCraters>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMountainsCraters>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6,1e7));
 	double height = m_maxHeightInMeters*0.3;

--- a/src/terrain/TerrainHeightMountainsCraters2.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters2.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMountainsCraters2>::GetHeightFractalName() const { return "MountainsCraters2"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMountainsCraters2>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMountainsCraters2>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6,1e7));
 	double height = m_maxHeightInMeters*0.5;

--- a/src/terrain/TerrainHeightMountainsNormal.cpp
+++ b/src/terrain/TerrainHeightMountainsNormal.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMountainsNormal>::GetHeightFractalName() const { return "MountainsNormal"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMountainsNormal>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMountainsNormal>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6, 1e7), 10000*m_fracmult);
 	SetFracDef(1, m_maxHeightInMeters*0.00000000001, 100.0, 10*m_fracmult);

--- a/src/terrain/TerrainHeightMountainsRidged.cpp
+++ b/src/terrain/TerrainHeightMountainsRidged.cpp
@@ -10,7 +10,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMountainsRidged>::GetHeightFractalName() const { return "MountainsRidged"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMountainsRidged>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMountainsRidged>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6,1e7));
 	double height = m_maxHeightInMeters*0.9;

--- a/src/terrain/TerrainHeightMountainsRivers.cpp
+++ b/src/terrain/TerrainHeightMountainsRivers.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMountainsRivers>::GetHeightFractalName() const { return "MountainsRivers"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMountainsRivers>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMountainsRivers>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6, 2e6), 10*m_fracmult);
 	SetFracDef(1, m_maxHeightInMeters, 15e6, 100.0*m_fracmult);

--- a/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::GetHeightFractalName() const { return "MountainsRiversVolcano"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6,1e7));
 	double height = m_maxHeightInMeters*0.6;

--- a/src/terrain/TerrainHeightMountainsVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsVolcano.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightMountainsVolcano>::GetHeightFractalName() const { return "MountainsVolcano"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightMountainsVolcano>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightMountainsVolcano>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6,1e7));
 	double height = m_maxHeightInMeters*0.8;

--- a/src/terrain/TerrainHeightRuggedDesert.cpp
+++ b/src/terrain/TerrainHeightRuggedDesert.cpp
@@ -55,7 +55,7 @@ double TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeight(const vector3d
 }
 
 template <>
-TerrainHeightFractal<TerrainHeightRuggedDesert>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightRuggedDesert>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, 0.1*m_maxHeightInMeters, 2e6, 180e3*m_fracmult);
 	double height = m_maxHeightInMeters*0.9;

--- a/src/terrain/TerrainHeightRuggedLava.cpp
+++ b/src/terrain/TerrainHeightRuggedLava.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightRuggedLava>::GetHeightFractalName() const { return "RuggedLava"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightRuggedLava>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightRuggedLava>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6,1e7));
 	double height = m_maxHeightInMeters*1.0;

--- a/src/terrain/TerrainHeightWaterSolid.cpp
+++ b/src/terrain/TerrainHeightWaterSolid.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightWaterSolid>::GetHeightFractalName() const { return "WaterSolid"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightWaterSolid>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightWaterSolid>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(5e6,1e8));
 	double height = m_maxHeightInMeters*0.3;

--- a/src/terrain/TerrainHeightWaterSolidCanyons.cpp
+++ b/src/terrain/TerrainHeightWaterSolidCanyons.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::GetHeightFractalName() const { return "WaterSolidCanyons"; }
 
 template <>
-TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::TerrainHeightFractal(const SystemBody *body) : Terrain(body)
+TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::TerrainHeightFractal(const SystemBody *body, const uint32_t tET) : Terrain(body, tET)
 {
 	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(5e6,1e8));
 	double height = m_maxHeightInMeters*0.3;


### PR DESCRIPTION
Difficult one to describe this one, quite abstract.

Everytiem I request a job I have to go through the ridiculous process of calling `Terrain::InstanceTerrain` and pass it a body to get a bunch of data from and do lots of branching etc.

In this commit I'm constructing a single static const table of unique `InstanceGenerator` objects, instead of doing it everytime `Terrain::InstanceTerrain` is called. An enum into that table. Then changing the way that `InstanceGenerator` objects are called.

I also add a second way of getting the `InstanceGenerator` when I already know which one I want. 

It still has to do some stupid stuff like passing in the body each time rather than just copying the values across but the template madness is a bit much for me to work out today.

Andy
