### PR TITLE
Clamp terrain m_maxHeightInMeters to prevent insane spike-balls

### DIFF
--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -436,9 +436,10 @@ Terrain::Terrain(const SystemBody *body) : m_body(body), m_seed(body->seed), m_r
 	if ((m_body->heightMapFilename) && m_body->heightMapFractal > 1){ // if scaled heightmap
 		m_maxHeightInMeters = 1.1*pow(2.0, 16.0)*m_heightScaling; // no min height required as it's added to radius in lua
 	}else {
-		m_maxHeightInMeters = std::max(100.0, (9000.0*rad*rad*(m_volcanic+0.5)) / (m_body->GetMass() * 6.64e-12));
-		if (!isfinite(m_maxHeightInMeters)) m_maxHeightInMeters = rad * 0.5;
-		//             ^^^^ max mountain height for earth-like planet (same mass, radius)
+		// NB: 0.00000000000664 == 6.64e-12
+		m_maxHeightInMeters = (9000.0*rad*rad*(m_volcanic+0.5)) / (m_body->GetMass() * 6.64e-12);
+		m_maxHeightInMeters = Clamp(m_maxHeightInMeters, 100.0, rad * 0.25);
+		// ^^^^ max mountain height for earth-like planet (same mass, radius)
 		// and then in sphere normalized jizz
 	}
 	m_maxHeight = std::min(1.0, m_maxHeightInMeters / rad);


### PR DESCRIPTION
We've had problems with overly spiky terrains for ages. Issue #1680.

The problem seems to be partly caused by some bodies being given an excessively large `m_maxHeightInMeters`. This clamps it to avoid crazy spike-balls.

(We'll have to revisit this in the future, to allow more extreme bodies without placing surface starports on them).

Before:
![screenshot-20130527-140055](https://f.cloud.github.com/assets/115749/568129/8176b994-c6cd-11e2-8d78-6d21aff3d397.png)

After:
![screenshot-20130527-135858](https://f.cloud.github.com/assets/115749/568118/56f36ee2-c6cd-11e2-89eb-412b7ea91471.png)
