### PR TITLE
Luatable API cleanup and documentation

### DIFF
--- a/src/LuaTable.h
+++ b/src/LuaTable.h
@@ -78,6 +78,15 @@
  * The two methods are LuaTable::Begin<Value>() and LuaTable::End<Value>()
  *
  * As usual, since C++ is static typed, the iterators will fail in a mixed-typed table
+ *
+ * ScopedTable:
+ *
+ * The ScopedTable class is a LuaTable derivative that comes with two constructors:
+ *   * New table constructor: ScopedTable(l);
+ *   * LuaRef contructor: ScopedTable(my_lua_ref_object);
+ * Both constructors will push a new table onto the stack, and when the C++
+ * ScopedTable objects are destroyed, this new table is removed and everything
+ * above it on the stack gets shifted down.
  */
 class LuaTable {
 public:


### PR DESCRIPTION
I started documenting this class, and realized that the API could use a bit of rework to make better use of iterators.

I deleted something unused (GetMap), and rewrote the Load\* methods (all use cases are not yet merged in master) to use generic iterators instead of references to map and vector, which makes the include lighter and the methods more generic.
