### PR TITLE
Re-enable trade-in of ships.

### DIFF
--- a/src/StationShipMarketForm.cpp
+++ b/src/StationShipMarketForm.cpp
@@ -71,13 +71,15 @@ void StationShipMarketForm::UpdateShipList()
 
 	const std::vector<ShipOnSale> &ships = m_station->GetShipsOnSale();
 
+	const int playerShipPrice = Pi::player->GetShipType()->baseprice >> 1;
+
 	int num = 0;
 	for (std::vector<ShipOnSale>::const_iterator i = ships.begin(); i!=ships.end(); ++i) {
 		Gui::Fixed *f = new Gui::Fixed(450, line_height);
 
 		Gui::Label *l = new Gui::Label(ShipType::types[(*i).id].name);
 		f->Add(l,0,0);
-		f->Add(new Gui::Label(format_money(ShipType::types[(*i).id].baseprice)), 200, 0);
+		f->Add(new Gui::Label(format_money(ShipType::types[(*i).id].baseprice - playerShipPrice)), 200, 0);
 		f->Add(new Gui::Label(stringf(Lang::NUMBER_TONNES, formatarg("mass", ShipType::types[(*i).id].capacity))), 350, 0);
 
 		Gui::SolidButton *sb = new Gui::SolidButton();

--- a/src/StationShipViewForm.cpp
+++ b/src/StationShipViewForm.cpp
@@ -54,10 +54,11 @@ StationShipViewForm::StationShipViewForm(FormController *controller, int marketI
 	float forward_accel_laden = type.linThrust[ShipType::THRUSTER_FORWARD] / (-9.81f*1000.0f*(type.hullMass+type.capacity+type.fuelTankMass));
 	float reverse_accel_empty = -type.linThrust[ShipType::THRUSTER_REVERSE] / (-9.81f*1000.0f*(type.hullMass+type.fuelTankMass));
 	float reverse_accel_laden = -type.linThrust[ShipType::THRUSTER_REVERSE] / (-9.81f*1000.0f*(type.hullMass+type.capacity+type.fuelTankMass));
-
+	
+	const int playerShipPrice = Pi::player->GetShipType()->baseprice >> 1;
 	Gui::VBox *dataBox = new Gui::VBox();
 	dataBox->PackEnd(new Gui::Label(type.name));
-	dataBox->PackEnd(new Gui::Label(format_money(type.baseprice)));
+	dataBox->PackEnd(new Gui::Label(format_money(type.baseprice - playerShipPrice)));
 	dataBox->PackEnd(new Gui::Label(m_sos.regId));
 	dataBox->PackEnd(new Gui::Label(" "));
 	dataBox->PackEnd(new Gui::Label(stringf(Lang::NUMBER_TONNES, formatarg("mass", type.hullMass))));
@@ -120,7 +121,8 @@ StationShipViewForm::StationShipViewForm(FormController *controller, int marketI
 
 void StationShipViewForm::BuyShip()
 {
-	Sint64 cost = ShipType::types[m_sos.id].baseprice;
+	const int playerShipPrice = Pi::player->GetShipType()->baseprice >> 1;
+	Sint64 cost = ShipType::types[m_sos.id].baseprice - playerShipPrice;
 	if (Pi::player->GetMoney() < cost) {
 		Pi::cpan->MsgLog()->Message("", Lang::YOU_NOT_ENOUGH_MONEY);
 		return;


### PR DESCRIPTION
# Description:

Y'know what they say: It halves in value as soon as you drive off it the forecourt!
Well the same applies to ships :)
You can trade in your old ship, at 50% of the value, for a shiny shiny new one once more.
If you buy a cheaper ship you'll get money back, if you get a new one... well you'll have to fork out for it.
# Only Commit:

Subtract 50% of the price of the players ship from the cost of the new one.
Refund the difference.

Fixes issues: #2343 & #2087 
