### PR TITLE
Fix #2346

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -442,8 +442,8 @@ void ModelViewer::DrawDockingLocators()
 // Draw collision mesh as a wireframe overlay
 void ModelViewer::DrawCollisionMesh()
 {
-	CollMesh *mesh = m_model->GetCollisionMesh();
-	if(!mesh) return;
+	RefCountedPtr<CollMesh> mesh = m_model->GetCollisionMesh();
+	if(!mesh.Valid()) return;
 
 	std::vector<vector3f> &vertices = mesh->m_vertices;
 	std::vector<int> &indices = mesh->m_indices;

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -123,6 +123,10 @@ void Model::Render(const matrix4x4f &trans, RenderData *rd)
 
 RefCountedPtr<CollMesh> Model::CreateCollisionMesh()
 {
+	if(m_collMesh.Valid()) {
+		return m_collMesh;
+	}
+
 	CollisionVisitor cv;
 	m_root->Accept(cv);
 	m_collMesh = cv.CreateCollisionMesh();

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -95,7 +95,7 @@ public:
 	float GetDrawClipRadius() const { return m_boundingRadius; }
 	void Render(const matrix4x4f &trans, RenderData *params = 0); //ModelNode can override RD
 	RefCountedPtr<CollMesh> CreateCollisionMesh();
-	CollMesh *GetCollisionMesh() const { return m_collMesh.Get(); }
+	RefCountedPtr<CollMesh> GetCollisionMesh() const { return m_collMesh; }
 	RefCountedPtr<Group> GetRoot() { return m_root; }
 	//materials used in the nodes should be accessible from here for convenience
 	RefCountedPtr<Graphics::Material> GetMaterialByName(const std::string &name) const;


### PR DESCRIPTION
# Description:

Initial attempt to improve the situation discovered by @Luomu in #2346 (doh, called it 2364!)
# Commits:

GetCollisionMesh now returns a ref counted pointer.
CreateCollisionMesh will return the existing m_collMesh if there is one otherwise it will create a new one as usual.
