### PR TITLE
Embed Scroller of SmartTable in ui:Expand to make it work again.

### DIFF
--- a/data/libs/ui/SmartTable.lua
+++ b/data/libs/ui/SmartTable.lua
@@ -29,7 +29,7 @@ New = function (rowspec)
 	self.widget =
 		ui:VBox(10):PackEnd({
 			self.headers,
-			ui:Scroller():SetInnerWidget(self.body)
+			ui:Expand():SetInnerWidget(ui:Scroller(self.body))
 		})
 
 	setmetatable(self, {

--- a/data/ui/InfoView.lua
+++ b/data/ui/InfoView.lua
@@ -451,7 +451,7 @@ local missions = function (tabGroup)
 		MissionList:AddRow(row)
 	end
 
-	MissionScreen:SetInnerWidget(ui:Scroller(MissionList))
+	MissionScreen:SetInnerWidget(MissionList)
 
 	return MissionScreen
 end


### PR DESCRIPTION
ui:Scroller does not seem to work when embedded in a VBox, Grid, etc. This seems to be the reason, why the Scroller in SmartTable does not show up. However, some experimentation showed that it works when embedded in ui:Expand.

This is not really a fix for the non-working Scroller in VBoxes etc. but works around the issue in SmartTable by introducing an ui:Expand in-between. So, the header is now fixed again, while the rest of the table scrolls.

Anyone has an idea, how to fix the deeper issue? My guess is, that VBox et. al. resize their children and grandchildren so that they fit. In that case, the scroller would not show up.
