### PR TITLE
Fix damage particle rendering

### DIFF
--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -108,8 +108,7 @@ void Sfx::Render(Renderer *renderer, const matrix4x4d &ftransform)
 		case TYPE_NONE: break;
 		case TYPE_EXPLOSION: {
 			//Explosion effect: A quick flash of three concentric coloured spheres. A bit retro.
-			matrix4x4f trans = trans.Identity();
-			trans.Translate(fpos.x, fpos.y, fpos.z);
+			const matrix4x4f trans = matrix4x4f::Translation(fpos.x, fpos.y, fpos.z);
 			RefCountedPtr<Material> exmat = Sfx::explosionEffect->GetMaterial();
 			exmat->diffuse = Color(1.f, 1.f, 0.5f, 1.f);
 			renderer->SetTransform(trans * matrix4x4f::ScaleMatrix(500*m_age));
@@ -122,15 +121,13 @@ void Sfx::Render(Renderer *renderer, const matrix4x4d &ftransform)
 			renderer->SetTransform(trans * matrix4x4f::ScaleMatrix(1000*m_age));
 			Sfx::explosionEffect->Draw(renderer);
 			break;
-		}
-		case TYPE_DAMAGE:
-
+		} case TYPE_DAMAGE: {
+			renderer->SetTransform(matrix4x4d::Translation(fpos));
 			damageParticle->diffuse = Color(1.f, 1.f, 0.f, 1.0f-(m_age/2.0f));
 			renderer->SetBlendMode(BLEND_ALPHA_ONE);
 			renderer->DrawPointSprites(1, &pos, damageParticle, 20.f);
 			break;
-
-		case TYPE_SMOKE:
+		} case TYPE_SMOKE: {
 			float var = Pi::rng.Double()*0.05f; //slightly variation to trail color
 			if (m_age < 0.5)
 				//start trail
@@ -139,15 +136,13 @@ void Sfx::Render(Renderer *renderer, const matrix4x4d &ftransform)
 				//end trail
 				smokeParticle->diffuse = Color(0.75-var, 0.75f-var, 0.75f-var, 0.5*0.5-(m_age/16.0));
 
-			matrix4x4f trans = trans.Identity();
-			trans.Translate(fpos.x, fpos.y, fpos.z);
-			renderer->SetTransform(trans);
+			renderer->SetTransform(matrix4x4d::Translation(fpos));
 
 			damageParticle->diffuse*=0.05;
 			renderer->SetBlendMode(Graphics::BLEND_ALPHA);
 			renderer->DrawPointSprites(1, &pos, smokeParticle, (m_speed*m_age));
 			break;
-
+		}
 	}
 }
 


### PR DESCRIPTION
I don't know when exactly it broke, but for a long time damage particles have been rendered incorrectly and they didn't face the camera. After #2350 it became obvious that the effect just doesn't set the transformation at all. Here's a fix!
