### PR TITLE
Joystick handling correction during time compression

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -549,6 +549,16 @@ const float Game::s_timeAccelRates[] = {
 	100000.0f   // hyperspace
 };
 
+const float Game::s_timeInvAccelRates[] = {
+	0.0f,       // paused
+	1.0f,       // 1x
+	0.1f,      // 10x
+	0.01f,     // 100x
+	0.001f,    // 1000x
+	0.0001f,   // 10000x
+	0.00001f   // hyperspace
+};
+
 void Game::SetTimeAccel(TimeAccel t)
 {
 	// don't want player to spin like mad when hitting time accel

--- a/src/Game.h
+++ b/src/Game.h
@@ -78,6 +78,8 @@ public:
 	bool IsPaused() const { return m_timeAccel == TIMEACCEL_PAUSED; }
 
 	float GetTimeAccelRate() const { return s_timeAccelRates[m_timeAccel]; }
+	float GetInvTimeAccelRate() const { return s_timeInvAccelRates[m_timeAccel]; }
+
 	float GetTimeStep() const { return s_timeAccelRates[m_timeAccel]*(1.0f/PHYSICS_HZ); }
 
 private:
@@ -112,6 +114,7 @@ private:
 	bool m_forceTimeAccel;
 
 	static const float s_timeAccelRates[];
+	static const float s_timeInvAccelRates[];
 };
 
 #endif

--- a/src/ShipController.cpp
+++ b/src/ShipController.cpp
@@ -253,20 +253,25 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 		changeVec.y = KeyBindings::yawAxis.GetValue();
 		changeVec.z = KeyBindings::rollAxis.GetValue();
 
-		// Deadzone
-		if(changeVec.LengthSqr() < m_joystickDeadzone)
-			changeVec = vector3d(0.0);
-
-		changeVec *= 2.0;
+		// Deadzone more accurate
+		for (int axis=0; axis<3; axis++) {
+				if (fabs(changeVec[axis]) < m_joystickDeadzone)
+					changeVec[axis]=0.0;
+				else
+					changeVec[axis] = changeVec[axis] * 2.0;
+		}
+		
 		wantAngVel += changeVec;
 
-		double invTimeAccelRate = 1.0 / Pi::game->GetTimeAccelRate();
-		if(wantAngVel.Length() >= 0.001 || force_rotation_damping || m_rotationDamping) {
-			for (int axis=0; axis<3; axis++)
-				wantAngVel[axis] = Clamp(wantAngVel[axis], -invTimeAccelRate, invTimeAccelRate);
+		if (wantAngVel.Length() >= 0.001 || force_rotation_damping || m_rotationDamping) {
+			if (Pi::game->GetTimeAccel()!=Game::TIMEACCEL_1X) {
+				for (int axis=0; axis<3; axis++)
+					wantAngVel[axis] = wantAngVel[axis] * Pi::game->GetInvTimeAccelRate();
+			}
 
 			m_ship->AIModelCoordsMatchAngVel(wantAngVel, angThrustSoftness);
 		}
+
 		if (m_mouseActive) m_ship->AIFaceDirection(m_mouseDir);
 
 	}


### PR DESCRIPTION
I have corrected a problem on the joystick handling when the time accelerate rate was superior to x1. The higher the time compression parameter was, the worse the movement applied on the ship was.
The correction consists in applying the inverse of the time accelerate rate to the controls of the ship.
There was also a problem on the deadzone of the joystick. I have corrected it applying the deadzone to each axes individually.
