### PR TITLE
Adding Barnard as new start

### DIFF
--- a/data/ui/MainMenu.lua
+++ b/data/ui/MainMenu.lua
@@ -30,6 +30,7 @@ end
 local buttonDefs = {
 	{ t("Start at Earth"),    function () Game.StartGame(SystemPath.New(0,0,0,0,9))   setupPlayerWave() end },
 	{ t("Start at New Hope"), function () Game.StartGame(SystemPath.New(1,-1,-1,0,4)) setupPlayerWave() end },
+	{ t("Start at Barnard's Star"), function () Game.StartGame(SystemPath.New(-1,0,0,0,1)) setupPlayerWave() end },
 	{ t("Load game"),         doLoadDialog },
 	{ t("Options"),           function () Engine.SettingsView() end },
 	{ t("Quit"),              function () Engine.Quit() end },


### PR DESCRIPTION
It is a shame that we have no space start.
Beginners may have their difficulties with finding out how to control their spaceship when this stupid gravity is disturbing them.
Space physics is different from earth physics, so a space start would be perfect to teach the mechanisms of physics in space.
Precise discussion in #2240.
