### PR TITLE
Bug fix for repeatedly loading terrain.

### DIFF
--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -171,7 +171,7 @@ void GeoPatch::LODUpdate(const vector3d &campos) {
 
 			SQuadSplitRequest *ssrd = new SQuadSplitRequest(v0, v1, v2, v3, centroid.Normalized(), m_depth,
 						geosphere->m_sbody->path, mPatchID, ctx->edgeLen,
-						ctx->frac, Terrain::InstanceTerrain(geosphere->m_sbody));
+						ctx->frac, geosphere->m_terrain.Get());
 			Pi::Jobs()->Queue(new QuadPatchJob(ssrd));
 		} else {
 			for (int i=0; i<NUM_KIDS; i++) {
@@ -196,7 +196,7 @@ void GeoPatch::RequestSinglePatch()
         assert(!mHasJobRequest);
 		mHasJobRequest = true;
 		SSingleSplitRequest *ssrd = new SSingleSplitRequest(v0, v1, v2, v3, centroid.Normalized(), m_depth,
-					geosphere->m_sbody->path, mPatchID, ctx->edgeLen, ctx->frac, Terrain::InstanceTerrain(geosphere->m_sbody));
+					geosphere->m_sbody->path, mPatchID, ctx->edgeLen, ctx->frac, geosphere->m_terrain.Get());
 		Pi::Jobs()->Queue(new SinglePatchJob(ssrd));
 	}
 }

--- a/src/GeoPatchJobs.h
+++ b/src/GeoPatchJobs.h
@@ -36,7 +36,7 @@ public:
 	const GeoPatchID patchID;
 	const int edgeLen;
 	const double fracStep;
-	ScopedPtr<Terrain> pTerrain;
+	RefCountedPtr<Terrain> pTerrain;
 
 protected:
 	// deliberately prevent copy constructor access

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -79,7 +79,7 @@ private:
 	const SystemBody *m_sbody;
 
 	// all variables for GetHeight(), GetColor()
-	ScopedPtr<Terrain> m_terrain;
+	RefCountedPtr<Terrain> m_terrain;
 
 	static const uint32_t MAX_SPLIT_OPERATIONS = 128;
 	std::deque<SQuadSplitResult*> mQuadSplitResults;

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -23,7 +23,7 @@ struct fracdef_t {
 template <typename,typename> class TerrainGenerator;
 
 
-class Terrain {
+class Terrain : public RefCounted {
 public:
 	// location and intensity of effects are controlled by the colour fractals;
 	// it's possible for a Terrain to have a flag set but not actually to exhibit any of that effect


### PR DESCRIPTION
# Description:

Bug fix for repeatedly loading terrain which should fix issue #2405

I found that it was reloading the terrain heightmap for each and every patch requested due to my changes to unify the heightmaps :( Stupid mistake on my part testing with an SSD again so I hardly noticed anything.

Changed the Patch generation jobs to use the terrain pointer directly and to store it as a RefCountedPtr, made the terrain base class inherit from RefCounted and fixed up other minor things. This is probably the way I should originally have done it but I dislike passing pointer around across threads etc.

I've tested it, hyperspacing to and from the Sol system, checked that terrain is destroyed and reloaded and quit during generation etc. So far I haven't seen any issues but will try testing on my low-end Linux test box now.
# Commits:

Avoid using the terrain instance.
Make Terrain a RefCountedPtr object.
Hand off the terrain to a RefCountedPtr for each patch generation job.

Andy
