### PR TITLE
Systeminfo tweaks

### DIFF
--- a/data/lang/English.txt
+++ b/data/lang/English.txt
@@ -971,7 +971,7 @@ MASS
 N_WHATEVER_MASSES
     %mass{f.3} %units masses
 N_WHATEVER_RADII
-    %radius{f.3} %units radii
+    %radius{f.3} %units radii (%radkm{f.0} km)
 SOLAR
     Solar
 EARTH

--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -74,7 +74,8 @@ void SystemInfoView::OnBodyViewed(SystemBody *b)
 		formatarg("units", std::string(b->GetSuperType() == SystemBody::SUPERTYPE_STAR ? Lang::SOLAR : Lang::EARTH))));
 
 	_add_label_and_value(Lang::RADIUS, stringf(Lang::N_WHATEVER_RADII, formatarg("radius", b->radius.ToDouble()),
-		formatarg("units", std::string(b->GetSuperType() == SystemBody::SUPERTYPE_STAR ? Lang::SOLAR : Lang::EARTH))));
+		formatarg("units", std::string(b->GetSuperType() == SystemBody::SUPERTYPE_STAR ? Lang::SOLAR : Lang::EARTH)),
+		formatarg("radkm", b->GetRadius() / 1000.0)));
 
 	if (b->GetSuperType() == SystemBody::SUPERTYPE_STAR) {
 		_add_label_and_value(Lang::EQUATORIAL_RADIUS_TO_POLAR_RADIUS_RATIO, stringf("%0{f.3}", b->aspectRatio.ToDouble()));


### PR DESCRIPTION
This PR adds two little tweaks for the SystemInfoView:
1. Ever needed to go to a C or D component of a ternary/quadruple system and on arrival noticed that it would be a travel of hundreds of AUs and you wouldn't meet a mission deadline? The required information to plan ahead for such cases currently isn't available. The first commit adds the required information of the orbit of the (A,B)-component and C or (C,D)-component around their common gravpoint.
2. Altitude information is only available when close to a body (e.g. in its atmosphere). To start breaking you often need to know it in advance. The second commit adds the body radius in kilometers additionally to Earth/Sol radii.
