### PR TITLE
Fix 'make codedoc' for out-of-tree builds.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@ include $(top_srcdir)/Makefile.common
 
 .PHONY: codedoc
 codedoc:
-	@naturaldocs -i src/ -i data/libs/ -xi src/data/ -o HTML codedoc/ -p nd/ -do -ro -s Default Local
+	@mkdir -p codedoc
+	@naturaldocs -i ${top_srcdir}/src/ -i ${top_srcdir}/data/libs/ -xi ${top_srcdir}/src/data/ -o HTML codedoc/ -p ${top_srcdir}/nd/ -do -ro -s Default Local
 
 .PHONY: enums
 enums:


### PR DESCRIPTION
I was recently starting to use out-of-tree builds to not pollute the source tree with build files and to be able to switch between release and debug builds easily. For example I use from top-level directory: 

```
mkdir debug ; cd debug ; ../configure  --with-no-optimise --enable-debug
```

And to build from top-level:

```
make -C debug
```

Almost everything worked out-of-the-box, but I noticed that `make -C debug codedoc` did not.
This PR fixes it by passing the correct directories to naturaldocs.
