### PR TITLE
Let Rand.New(seed) raise an error if seed is given, but non-numeric.

### DIFF
--- a/src/LuaRand.cpp
+++ b/src/LuaRand.cpp
@@ -15,12 +15,13 @@
  *
  * Creates a new random number generator.
  *
- * > rand = Rand:New(seed)
+ * > rand = Rand.New(seed)
  *
  * Parameters:
  *
  *   seed - optional, the value to seed the generator with. If omitted it will
- *          be set to the current system (not game) time
+ *          be set to the current system (not game) time. seed must be numeric
+ *          if given.
  *
  * Return:
  *
@@ -37,8 +38,12 @@
 static int l_rand_new(lua_State *l)
 {
 	int seed = int(time(0));
-	if (lua_isnumber(l, 1))
-		seed = lua_tointeger(l, 1);
+	if (!lua_isnoneornil(l, 1)) {
+		if (lua_isnumber(l, 1))
+			seed = lua_tointeger(l, 1);
+		else
+			luaL_error(l, "seed must be numeric if given");
+	}
 	LuaObject<Random>::PushToLua(new Random(seed));
 	return 1;
 }


### PR DESCRIPTION
As was learned by @TheNewBob the hard way the documentation of `Rand.New` falsely claimed that `Rand:New(seed)` instead of `Rand.New(seed)` (i.e. with colon instead of period) was the right syntax to create a new random generator.

This passed the Rand table as the seed which was ignored by Rand.New because of not being numeric, creating a random generator based on the current time, instead of the seed thus creating different numbers (see http://pioneerspacesim.net/forum/viewtopic.php?f=3&t=16&start=50#p683 for the whole story).

I think, such silent failure is a bad thing. This PR fixes the documentation and causes Rand.New to raise a LUA error if `seed` is given but not numeric. Not giving any seed still creates a time-based random generator.
