### PR TITLE
Support alpha channels in model patterns

### DIFF
--- a/data/shaders/gl2/multi.frag
+++ b/data/shaders/gl2/multi.frag
@@ -48,9 +48,10 @@ void main(void)
 #endif
 //patterns - simple lookup
 #ifdef MAP_COLOR
-	float pat = texture2D(texture3, texCoord0).r;
-	vec4 mapColor = texture2D(texture4, vec2(pat, 0.0));
-	color *= mapColor;
+	vec4 pat = texture2D(texture3, texCoord0);
+	vec4 mapColor = texture2D(texture4, vec2(pat.r, 0.0));
+	vec4 tint = mix(vec4(1.0),mapColor,pat.a);
+	color *= tint;
 #endif
 
 #ifdef ALPHA_TEST


### PR DESCRIPTION
Uses the alpha channel in the pattern texture to interpolate the pattern tint from white to the normal pattern colour.

![](http://i.imgur.com/gRiifYX.png)

Test pattern used above:

![](http://i.imgur.com/E1Pe5G0.png)

I don't really know what I'm doing when it comes to shaders, so hopefully I'm not doing anything stupid there.
