### PR TITLE
Kanara_civ hyperdrive

### DIFF
--- a/data/ships/kanara_civ.lua
+++ b/data/ships/kanara_civ.lua
@@ -16,7 +16,7 @@ define_ship {
 	max_laser = 1,
 	max_missile = 8,
 	max_cargoscoop = 0,
-	max_engine = 0,
+	max_engine = 1,
 	min_crew = 1,
 	max_crew = 2,
 	capacity = 19,


### PR DESCRIPTION
@robn I misunderstood what you asked. I think the player should be able to install a hyperdrive in the civilian Kanara. I thought you were asking about the default setting for it. Which should stay 0 in my opinion.
I've updated the max_engine to 1.
