### PR TITLE
Supply a preferred size for MultiLineText

### DIFF
--- a/src/ui/MultiLineText.cpp
+++ b/src/ui/MultiLineText.cpp
@@ -10,15 +10,20 @@ namespace UI {
 MultiLineText::MultiLineText(Context *context, const std::string &text) : Widget(context), m_text(text)
 {
 	m_layout.Reset(new TextLayout(GetContext()->GetFont(GetFont()), m_text));
-
-	SetSizeControlFlags(EXPAND_WIDTH);
 }
 
 Point MultiLineText::PreferredSize()
 {
 	if (m_preferredSize != Point())
 		return m_preferredSize;
-	return Point();
+
+	// 50-75 chars per line is ideal for general readability
+	// http://baymard.com/blog/line-length-readability
+	//
+	// we'll compute a size for about 75 chars wide. container may choose to
+	// override us, but if it gives us what we ask for this will make sure we
+	// get something readable
+	return m_layout->ComputeSize(Point(GetContext()->GetFont(GetFont())->GetGlyph(' ').advx * 75, 0));
 }
 
 void MultiLineText::Layout()

--- a/src/uitest.cpp
+++ b/src/uitest.cpp
@@ -31,7 +31,6 @@ static bool toggle_disabled_handler(UI::Widget *w)
 	printf("toggle disabled: %p %s now %s\n", w, typeid(*w).name(), w->IsDisabled() ? "DISABLED" : "ENABLED");
 	return true;
 }
-#endif
 
 static bool click_handler(UI::Widget *w)
 {
@@ -39,13 +38,11 @@ static bool click_handler(UI::Widget *w)
 	return true;
 }
 
-#if 0
 static bool move_handler(const UI::MouseMotionEvent &event, UI::Widget *w)
 {
 	printf("move: %p %s %d,%d\n", w, typeid(*w).name(), event.pos.x, event.pos.y);
 	return true;
 }
-#endif
 
 static bool over_handler(UI::Widget *w)
 {
@@ -59,7 +56,6 @@ static bool out_handler(UI::Widget *w)
 	return true;
 }
 
-#if 0
 static void colour_change(float v, UI::ColorBackground *back, UI::Slider *r, UI::Slider *g, UI::Slider *b)
 {
 	back->SetColor(Color(r->GetValue(), g->GetValue(), b->GetValue()));
@@ -550,6 +546,7 @@ int main(int argc, char **argv)
 	c->GetTopLayer()->SetInnerWidget(c->Grid(2,1)->SetCell(0,0,table));
 #endif
 
+#if 0
 	UI::DropDown *d1, *d2;
 	c->GetTopLayer()->SetInnerWidget(
 		c->VBox()->PackEnd(UI::WidgetSet(
@@ -570,6 +567,23 @@ int main(int argc, char **argv)
 	d1->onMouseOut.connect(sigc::bind(sigc::ptr_fun(&out_handler), d1));
 	d2->onMouseOver.connect(sigc::bind(sigc::ptr_fun(&over_handler), d2));
 	d2->onMouseOut.connect(sigc::bind(sigc::ptr_fun(&out_handler), d2));
+#endif
+
+#if 0
+	c->GetTopLayer()->SetInnerWidget(
+		c->Align(UI::Align::MIDDLE)->SetInnerWidget(
+			c->Background()->SetInnerWidget(
+				c->MultiLineText("Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+			)
+		)
+	);
+#endif
+
+	UI::Table *t = c->Table();
+	t->AddRow(c->MultiLineText("Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."));
+	t->AddRow(c->MultiLineText("Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."));
+	t->AddRow(c->MultiLineText("Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."));
+	c->GetTopLayer()->SetInnerWidget(t);
 
 	//int count = 0;
 


### PR DESCRIPTION
Because there's so many ways to "correctly" lay out a block of text, `MultiLineText` always just washed its hands of the whole thing and returned a "I don't care" preferred size, leaving it to the container to choose. For containers where it determines size and layout based on the wants of its children, this always resulted in a `MultiLineText` receiving what it asked for - nothing. That made it impossible do things like a nice dialog box where the background would shrinkwrap its content.

It turns out that in the absence of any other information, there's one thing we do know about a body of text - it needs to be readable! According to [this blog post](http://baymard.com/blog/line-length-readability) the optimal line length is somewhere between 50 and 75 characters. After that the eyes the brain start to lose focus.

So now we do an intiial layout of about 75 characters and report the result as the preferred size. The container can still choose to ignore that, as it can for all widgets. But for the ones that use the preferred size to calculate layout, they'll now produce something sane.

![snap](https://f.cloud.github.com/assets/130670/1321321/e80ea932-33b0-11e3-8c6b-63d7f557b40d.png)
