### PR TITLE
Create only one shader using Eclipse code or not.

### DIFF
--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -438,10 +438,8 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 	// no frustum test of entire geosphere, since Space::Render does this
 	// for each body using its GetBoundingRadius() value
 
-	const EclipseState es = (Pi::config->Int("DisableEclipse") == 0) ? ECLIPSE_ENABLED : ECLIPSE_DISABLED;
-
 	//First draw - create materials (they do not change afterwards)
-	if (!m_surfaceMaterial[es].Valid())
+	if (!m_surfaceMaterial.Valid())
 		SetUpMaterials();
 
 	if (Graphics::AreShadersEnabled()) {
@@ -454,24 +452,24 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 
 		m_materialParameters.shadows = shadows;
 
-		m_surfaceMaterial[es]->specialParameter0 = &m_materialParameters;
+		m_surfaceMaterial->specialParameter0 = &m_materialParameters;
 
 		if (m_materialParameters.atmosphere.atmosDensity > 0.0) {
-			m_atmosphereMaterial[es]->specialParameter0 = &m_materialParameters;
+			m_atmosphereMaterial->specialParameter0 = &m_materialParameters;
 
 			renderer->SetBlendMode(Graphics::BLEND_ALPHA_ONE);
 			renderer->SetDepthWrite(false);
 			// make atmosphere sphere slightly bigger than required so
 			// that the edges of the pixel shader atmosphere jizz doesn't
 			// show ugly polygonal angles
-			DrawAtmosphereSurface(renderer, trans, campos, m_materialParameters.atmosphere.atmosRadius*1.01, m_atmosphereMaterial[es].Get());
+			DrawAtmosphereSurface(renderer, trans, campos, m_materialParameters.atmosphere.atmosRadius*1.01, m_atmosphereMaterial.Get());
 			renderer->SetDepthWrite(true);
 			renderer->SetBlendMode(Graphics::BLEND_SOLID);
 		}
 	}
 
 	Color ambient;
-	Color &emission = m_surfaceMaterial[es]->emissive;
+	Color &emission = m_surfaceMaterial->emissive;
 
 	// save old global ambient
 	const Color oldAmbient = renderer->GetAmbientColor();
@@ -504,7 +502,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 #endif
 	// this is pretty much the only place where a non-renderer is allowed to call Apply()
 	// to be removed when someone rewrites terrain
-	m_surfaceMaterial[es]->Apply();
+	m_surfaceMaterial->Apply();
 
 	renderer->SetTransform(modelView);
 
@@ -523,7 +521,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 	glBindBufferARB(GL_ARRAY_BUFFER_ARB, 0);
 	glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER, 0);
 
-	m_surfaceMaterial[es]->Unapply();
+	m_surfaceMaterial->Unapply();
 
 	renderer->SetAmbientColor(oldAmbient);
 #ifdef USE_WIREFRAME
@@ -564,17 +562,21 @@ void GeoSphere::SetUpMaterials()
 			surfDesc.quality &= ~Graphics::GL2::HAS_ATMOSPHERE;
 		}
 	}
-	m_surfaceMaterial[ECLIPSE_DISABLED].Reset(Pi::renderer->CreateMaterial(surfDesc));
-	surfDesc.quality |= Graphics::GL2::HAS_ECLIPSES;
-	m_surfaceMaterial[ECLIPSE_ENABLED].Reset(Pi::renderer->CreateMaterial(surfDesc));
+
+	const bool bEnableEclipse = (Pi::config->Int("DisableEclipse") == 0);
+	if (bEnableEclipse) {
+		surfDesc.quality |= Graphics::GL2::HAS_ECLIPSES;
+	}
+	m_surfaceMaterial.Reset(Pi::renderer->CreateMaterial(surfDesc));
 
 	//Shader-less atmosphere is drawn in Planet
 	if (Graphics::AreShadersEnabled()) {
 		Graphics::MaterialDescriptor skyDesc;
 		skyDesc.effect = Graphics::EFFECT_GEOSPHERE_SKY;
 		skyDesc.lighting = true;
-		m_atmosphereMaterial[ECLIPSE_DISABLED].Reset(Pi::renderer->CreateMaterial(skyDesc));
-		skyDesc.quality |= Graphics::GL2::HAS_ECLIPSES;
-		m_atmosphereMaterial[ECLIPSE_ENABLED].Reset(Pi::renderer->CreateMaterial(skyDesc));
+		if (bEnableEclipse) {
+			skyDesc.quality |= Graphics::GL2::HAS_ECLIPSES;
+		}
+		m_atmosphereMaterial.Reset(Pi::renderer->CreateMaterial(skyDesc));
 	}
 }

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -100,13 +100,8 @@ private:
 	static RefCountedPtr<GeoPatchContext> s_patchContext;
 
 	void SetUpMaterials();
-	enum EclipseState {
-		ECLIPSE_ENABLED,
-		ECLIPSE_DISABLED,
-		ECLIPSE_MAX
-	};
-	ScopedPtr<Graphics::Material> m_surfaceMaterial[ECLIPSE_MAX];
-	ScopedPtr<Graphics::Material> m_atmosphereMaterial[ECLIPSE_MAX];
+	ScopedPtr<Graphics::Material> m_surfaceMaterial;
+	ScopedPtr<Graphics::Material> m_atmosphereMaterial;
 	//special parameters for shaders
 	MaterialParameters m_materialParameters;
 


### PR DESCRIPTION
Robn was right, it makes more sense to just choose to use the eclipse code or not when creating a single shader.

If in the future we want to pick and choose for planets that can have eclipses or not then we can add it at that time.

Hopefully this should work in more cases and resolve #2190
