### PR TITLE
MSVC doesn't support std::isfinite still

### DIFF
--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -5,6 +5,7 @@
 #include "perlin.h"
 #include "Pi.h"
 #include "FileSystem.h"
+#include "FloatComparison.h"
 
 // static instancer. selects the best height and color classes for the body
 Terrain *Terrain::InstanceTerrain(const SystemBody *body)
@@ -476,7 +477,11 @@ Terrain::Terrain(const SystemBody *body) : m_body(body), m_seed(body->seed), m_r
 		m_maxHeightInMeters = 1.1*pow(2.0, 16.0)*m_heightScaling; // no min height required as it's added to radius in lua
 	}else {
 		m_maxHeightInMeters = std::max(100.0, (9000.0*rad*rad*(m_volcanic+0.5)) / (m_body->GetMass() * 6.64e-12));
+#ifdef _MSC_VER
 		if (!isfinite(m_maxHeightInMeters)) m_maxHeightInMeters = rad * 0.5;
+#else
+		if (!is_finite(m_maxHeightInMeters)) m_maxHeightInMeters = rad * 0.5;
+#endif
 		//             ^^^^ max mountain height for earth-like planet (same mass, radius)
 		// and then in sphere normalized jizz
 	}


### PR DESCRIPTION
Sorry, but even in VS2013 you can't use the std::isfinite due to MS sucking at supporting the C++11 maths stuff.

I'm as sad-face as anyone can be :(

@robn
