### PR TITLE
Setting depth testing and writing correctly.

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -104,6 +104,9 @@ void Camera::Draw(Renderer *renderer, const Body *excludeBody)
 
 	m_renderer = renderer;
 
+	m_renderer->SetDepthWrite(true);
+	m_renderer->SetDepthTest(true);
+
 	glPushAttrib(GL_ALL_ATTRIB_BITS & (~GL_POINT_BIT));
 
 	m_renderer->SetPerspectiveProjection(m_fovAng, m_width/m_height, m_zNear, m_zFar);

--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -96,6 +96,9 @@ void Intro::Draw(float _time)
 	m_renderer->SetPerspectiveProjection(75, m_aspectRatio, 1.f, 10000.f);
 	m_renderer->SetTransform(matrix4x4f::Identity());
 
+	m_renderer->SetDepthTest(true);
+	m_renderer->SetDepthWrite(true);
+
 	glPushAttrib(GL_ALL_ATTRIB_BITS & (~GL_POINT_BIT));
 
 	const Color oldSceneAmbientColor = m_renderer->GetAmbientColor();

--- a/src/ShipSpinnerWidget.cpp
+++ b/src/ShipSpinnerWidget.cpp
@@ -57,6 +57,7 @@ void ShipSpinnerWidget::Draw()
 	Pi::renderer->SetPerspectiveProjection(45.f, 1.f, 1.f, 10000.f);
 	Pi::renderer->SetTransform(matrix4x4f::Identity());
 
+	Pi::renderer->SetDepthWrite(true);
 	Pi::renderer->SetDepthTest(true);
 	Pi::renderer->ClearDepthBuffer();
 

--- a/src/gameui/ModelSpinner.cpp
+++ b/src/gameui/ModelSpinner.cpp
@@ -52,6 +52,7 @@ void ModelSpinner::Draw()
 	r->SetPerspectiveProjection(fov, 1.f, 1.f, 10000.f);
 	r->SetTransform(matrix4x4f::Identity());
 
+	r->SetDepthWrite(true);
 	r->SetDepthTest(true);
 	r->ClearDepthBuffer();
 


### PR DESCRIPTION
# Description:

Setting depth testing and writing correctly.
We've been getting away with avoiding this for a while because things either restore the correct state or we're just lucky but recent work exposes where it gets left in the wrong state.
#2528, #2525 and #2527 will all need or include these changes.
