### PR TITLE
Fix SSC reported crash in Canti system

### DIFF
--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -765,7 +765,11 @@ printf("Autopilot dist = %.1f, speed = %.1f, zthrust = %.2f, state = %i\n",
 	double maxdecel = m_state ? m_ship->GetAccelFwd() : m_ship->GetAccelRev();
 	double gravdir = -reldir.Dot(m_ship->GetPosition().Normalized());
 	maxdecel -= gravdir * GetGravityAtPos(m_ship->GetFrame(), m_ship->GetPosition());
-	if (maxdecel < 0) maxdecel = 0.0;
+	bool bZeroDecel = false;
+	if (maxdecel < 0) {
+		maxdecel = 0.0;
+		bZeroDecel = true;
+	}
 
 	// target ship acceleration adjustment
 	if (m_target && m_target->IsType(Object::SHIP)) {
@@ -780,12 +784,11 @@ printf("Autopilot dist = %.1f, speed = %.1f, zthrust = %.2f, state = %i\n",
 		maxdecel = std::max(maxdecel, 0.1*m_ship->GetAccelFwd());
 	}
 
-	double curspeed = -relvel.Dot(reldir);
-	double tt = sqrt(2.0*targdist / maxdecel);
-	if (tt < timestep) tt = timestep;
-	vector3d perpvel = relvel + reldir * curspeed;
+	const double curspeed = -relvel.Dot(reldir);
+	const double tt = (bZeroDecel) ? timestep : std::max( sqrt(2.0*targdist / maxdecel), timestep );
+	const vector3d perpvel = relvel + reldir * curspeed;
 	double perpspeed = perpvel.Length();
-	vector3d perpdir = (perpspeed > 1e-30) ? perpvel / perpspeed : vector3d(0,0,1);
+	const vector3d perpdir = (perpspeed > 1e-30) ? perpvel / perpspeed : vector3d(0,0,1);
 
 	double sidefactor = perpspeed / (tt*0.5);
 	if (curspeed > (tt+timestep)*maxdecel || maxdecel < sidefactor) {


### PR DESCRIPTION
The crash was caused by a divide by zero I believe and this patch should prevent that from happening.

Bug [reported on SSC](http://spacesimcentral.com/ssc/topic/4030-appcrash-canti-d/)
