### PR TITLE
vs2013 et al don't support constexpr

### DIFF
--- a/src/galaxy/SystemPath.h
+++ b/src/galaxy/SystemPath.h
@@ -120,11 +120,7 @@ public:
 	// (for example, to be used for hashing)
 	// see, LuaObject<SystemPath>::PushToLua in LuaSystemPath.cpp
 	static_assert(sizeof(Sint32) == sizeof(Uint32), "something crazy is going on!");
-#ifdef _MSC_VER
 	static const size_t SizeAsBlob = 5*sizeof(Uint32);
-#else
-	static constexpr const size_t SizeAsBlob = 5*sizeof(Uint32);
-#endif
 	void SerializeToBlob(char *blob) const {
 		// could just memcpy(blob, this, sizeof(SystemPath))
 		// but that might include packing and/or vtable pointer


### PR DESCRIPTION
Well, they support some C++11, just not as much as you might hope.
