### PR TITLE
Gettings defensive over AIGetLeadDir

### DIFF
--- a/src/Ship-AI.cpp
+++ b/src/Ship-AI.cpp
@@ -316,7 +316,7 @@ vector3d Ship::AIGetLeadDir(const Body *target, const vector3d& targaccel, int g
 {
 	assert(target);
 	if (m_equipment.Get(Equip::SLOT_LASER) != Equip::NONE)
-		return target->GetPosition();
+		return target->GetPositionRelTo(this);
 
 	const vector3d targpos = target->GetPositionRelTo(this);
 	const vector3d targvel = target->GetVelocityRelTo(this);


### PR DESCRIPTION
Gettings defensive over AIGetLeadDir - some issues were reported in #2437

This PR depends on #2546 to get it compiling in Visual Studio again.
