### PR TITLE
Modelviewer FPS-style (mouselook) view controls

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -25,7 +25,7 @@ ModelViewer::Options::Options()
 , showLandingPad(false)
 , showUI(true)
 , wireframe(false)
-, fpsViewControls(false)
+, mouselookEnabled(false)
 , gridInterval(10.f)
 , lightPreset(0)
 {
@@ -290,14 +290,14 @@ void ModelViewer::ChangeCameraPreset(SDL_Keycode key, SDL_Keymod mod)
 
 void ModelViewer::ToggleViewControlMode()
 {
-	m_options.fpsViewControls = !m_options.fpsViewControls;
-	m_renderer->GetWindow()->SetGrab(m_options.fpsViewControls);
+	m_options.mouselookEnabled = !m_options.mouselookEnabled;
+	m_renderer->GetWindow()->SetGrab(m_options.mouselookEnabled);
 
-	if (m_options.fpsViewControls) {
+	if (m_options.mouselookEnabled) {
 		m_viewRot = matrix3x3f::RotateY(DEG2RAD(m_rotY)) * matrix3x3f::RotateX(DEG2RAD(Clamp(m_rotX, -90.0f, 90.0f)));
 		m_viewPos = zoom_distance(m_baseDistance, m_zoom) * m_viewRot.VectorZ();
 	} else {
-		// XXX re-initialise the turntable style view position from the FPS-style view position
+		// XXX re-initialise the turntable style view position from the current mouselook view
 		ResetCamera();
 	}
 }
@@ -313,7 +313,7 @@ void ModelViewer::ClearModel()
 	m_gunModel.reset();
 	m_scaleModel.reset();
 
-	m_options.fpsViewControls = false;
+	m_options.mouselookEnabled = false;
 	m_renderer->GetWindow()->SetGrab(false);
 	m_viewPos = vector3f(0.0f, 0.0f, 10.0f);
 	ResetCamera();
@@ -502,7 +502,7 @@ void ModelViewer::DrawModel()
 	UpdateLights();
 
 	matrix4x4f mv;
-	if (m_options.fpsViewControls) {
+	if (m_options.mouselookEnabled) {
 		mv = m_viewRot.Transpose() * matrix4x4f::Translation(-m_viewPos);
 	} else {
 		m_rotX = Clamp(m_rotX, -90.0f, 90.0f);
@@ -1136,7 +1136,7 @@ void ModelViewer::UpdateCamera()
 		rotateRate *= 2.0f;
 	}
 
-	if (m_options.fpsViewControls) {
+	if (m_options.mouselookEnabled) {
 		const float degrees_per_pixel = 0.2f;
 		if (!m_mouseButton[SDL_BUTTON_RIGHT]) {
 			// yaw and pitch

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -73,7 +73,7 @@ private:
 		bool showLandingPad;
 		bool showUI;
 		bool wireframe;
-		bool fpsViewControls;
+		bool mouselookEnabled;
 		float gridInterval;
 		int lightPreset;
 


### PR DESCRIPTION
Press F to toggle the FPS-style view controls. The WASD keys do the normal thing. The Q and E keys let you move up and down directly. When you switch to the FPS-style control mode, the current view is retained. However, when you switch back to the turntable-style control mode, the view is reset. This is because the turntable-style mode is more restrictive in the views it will give you (it always has the camera pointing directly towards the model's 0,0,0 point).

It's not currently as useful as it's supposed to be, because (as in a normal FPS-style view) rotation works on an azimuth/elevation model. That is, you can rotate fully around the Y (up) axis, and you can rotate between -90 and +90 degrees in the X (right) axis to look up or down, but you can't rotate in the Z axis.

This seems fine for ships, but is bad for station models, because station designs often don't have a single "up" axis ("up" might be, e.g., towards the centre of the station ring, rather than a particular cartesian axis).

(/cc @nozmajner)
