### PR TITLE
Allow Lua to connect an arbitrary method to a property signal

### DIFF
--- a/src/LuaPropertiedObject.cpp
+++ b/src/LuaPropertiedObject.cpp
@@ -83,8 +83,8 @@ public:
  *
  * Example:
  *
- * > ship:Connect("fuel", function ()
- * >     print(string.format("player fuel %f%%", Game.player.fuel)
+ * > ship:Connect("fuel", function (key, value)
+ * >     print(string.format("player fuel %f%%", value)
  * > end)
  *
  * Availability:
@@ -98,7 +98,12 @@ public:
 
 	static void _signal_trampoline(PropertyMap &map, const std::string &k, LuaRef ref, lua_State *l) {
 		ref.PushCopyToStack();
-		pi_lua_protected_call(l, 0, 0);
+		lua_pushlstring(l, k.c_str(), k.size());
+		map.PushLuaTable();
+		lua_pushvalue(l, -2);
+		lua_rawget(l, -2);
+		lua_remove(l, -2);
+		pi_lua_protected_call(l, 2, 0);
 	}
 
 	static int l_connect(lua_State *l) {


### PR DESCRIPTION
Allows something like:

``` Lua
player:Connect("fuel", function ()
    print("fuel now "..player.fuel)
end)
```

That is, when the property changes, the function gets called.

As noted in the docs, you do not want to use this for frequently-changing properties (like `fuel`!). For properties that change less often like `cargoUsed` from #2552, its great.

There's one fairly glaring problem with this. It means Lua can be called at any weird time that a property might change in the core code. I figure there's plenty of potential for performance problems and maybe even crashes if you were to do something weird at the wrong time.

I did intend to sort this out by creating a more general core->Lua deferred calling system, where all calls into Lua are queued and executed at a safe place in the frame. This is really hard to do right now because we have some stuff (UI signals, namegen) that call into Lua but need a response on the spot. Getting that right is a huge piece of work that needs serious thought. I don't want to hold this until then because I need it for the station UI. I'm hoping that we can ignore it for now and fix it later.
