### PR TITLE
Compile fail on clang 3.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,9 +111,15 @@ AC_DEFUN([PIONEER_WARN_C_CXX_FLAG],
 	[_PIONEER_COMPILER_FLAG([C], [WARN], [C], [$1], [$CC/$CXX], [WARN_CXXFLAGS="$WARN_CXXFLAGS $1"])])
 
 dnl Early check for C++11
-dnl XXX -std=c++11 defines __STRICT_ANSI__, which causes MinGW some problems
-dnl     -std=gnu++11 does not, and appears to work fine with clang as well
-_PIONEER_COMPILER_FLAG([C++], [STD], [CXX], [-std=gnu++11], [$CXX], [], [AC_MSG_ERROR([No compiler support for C++11. Unable to build])])
+dnl     -std=c++11 defines __STRICT_ANSI__, which causes MinGW some problems so use gnu++11 on it instead
+case "$host" in
+  i686-pc-mingw32|x86_64-pc-mingw64)
+	_PIONEER_COMPILER_FLAG([C++], [STD], [CXX], [-std=gnu++11], [$CXX], [], [AC_MSG_ERROR([No compiler support for C++11. Unable to build])])
+	;;
+  *)
+	_PIONEER_COMPILER_FLAG([C++], [STD], [CXX], [-std=c++11], [$CXX], [], [AC_MSG_ERROR([No compiler support for C++11. Unable to build])])
+esac
+
 
 dnl Always add -Wall, where supported
 PIONEER_WARN_C_CXX_FLAG([-Wall])


### PR DESCRIPTION
Compiling pioneer with clang 3.3, on arch linux, x86_64:

<pre>
make[2]: Entering directory `.../pioneer/src/collider'
clang++ -DPACKAGE_NAME=\"pioneer\" -DPACKAGE_TARNAME=\"pioneer\" -DPACKAGE_VERSION=\"0.00\" -DPACKAGE_STRING=\"pioneer\ 0.00\" -DPACKAGE_BUGREPORT=\"pioneer-dev@pioneerspacesim.net\" -DPACKAGE_URL=\"\" -DPACKAGE=\"pioneer\" -DVERSION=\"0.00\" -I. -I./.. -isystem ../../contrib -DPIONEER_VERSION=\"git\" -DPIONEER_EXTRAVERSION=\"acecd8a\" -DGLEW_STATIC   -I/usr/include/freetype2  -I/usr/include/libdrm  -DLUA_USE_POSIX -D_REENTRANT -I/usr/include/SDL2  -I/usr/include/sigc++-2.0 -I/usr/lib/sigc++-2.0/include    -I/usr/include -std=gnu++11 -Wall -Wformat -Wstrict-aliasing=2 -Wmissing-format-attribute -Wmissing-noreturn -Wdisabled-optimization -Wfloat-equal -Wshadow -Wcast-qual -Wcast-align -Wformat-security -Wold-style-cast -Wsign-promo -g -O2 -O3 -MT BVHTree.o -MD -MP -MF .deps/BVHTree.Tpo -c -o BVHTree.o BVHTree.cpp
clang++ -DPACKAGE_NAME=\"pioneer\" -DPACKAGE_TARNAME=\"pioneer\" -DPACKAGE_VERSION=\"0.00\" -DPACKAGE_STRING=\"pioneer\ 0.00\" -DPACKAGE_BUGREPORT=\"pioneer-dev@pioneerspacesim.net\" -DPACKAGE_URL=\"\" -DPACKAGE=\"pioneer\" -DVERSION=\"0.00\" -I. -I./.. -isystem ../../contrib -DPIONEER_VERSION=\"git\" -DPIONEER_EXTRAVERSION=\"acecd8a\" -DGLEW_STATIC   -I/usr/include/freetype2  -I/usr/include/libdrm  -DLUA_USE_POSIX -D_REENTRANT -I/usr/include/SDL2  -I/usr/include/sigc++-2.0 -I/usr/lib/sigc++-2.0/include    -I/usr/include -std=gnu++11 -Wall -Wformat -Wstrict-aliasing=2 -Wmissing-format-attribute -Wmissing-noreturn -Wdisabled-optimization -Wfloat-equal -Wshadow -Wcast-qual -Wcast-align -Wformat-security -Wold-style-cast -Wsign-promo -g -O2 -O3 -MT CollisionSpace.o -MD -MP -MF .deps/CollisionSpace.Tpo -c -o CollisionSpace.o CollisionSpace.cpp
In file included from BVHTree.cpp:4:
In file included from ./BVHTree.h:8:
In file included from /usr/lib64/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../include/c++/4.8.1/vector:60:
In file included from /usr/lib64/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../include/c++/4.8.1/bits/stl_algobase.h:64:
In file included from /usr/lib64/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../include/c++/4.8.1/bits/stl_pair.h:59:
In file included from /usr/lib64/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../include/c++/4.8.1/bits/move.h:57:
/usr/lib64/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../include/c++/4.8.1/type_traits:269:39: error: use of undeclared identifier '__float128'
    struct __is_floating_point_helper<__float128>
                                      ^
</pre>


The error is caused by clang using gcc headers from /usr/lib/gcc which is caused by the flag --std=gnu++11 defined in configure.ac. Changing the flag to --std=c++11 fixes the issue.
