### PR TITLE
Fix #2576

### DIFF
--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -372,6 +372,11 @@ void SystemView::Draw3D()
 	glDisable(GL_FOG);
 }
 
+void SystemView::OnSwitchTo() 
+{
+	m_renderer->SetViewport(0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+}
+
 void SystemView::Update()
 {
 	const float ft = Pi::GetFrameTime();

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -20,7 +20,7 @@ public:
 	virtual void Update();
 	virtual void Draw3D();
 protected:
-	virtual void OnSwitchTo() {}
+	virtual void OnSwitchTo();
 private:
 	static const double PICK_OBJECT_RECT_SIZE;
 	void PutOrbit(const Orbit *orb, const vector3d &offset, const Color &color, double planetRadius = 0.0);


### PR DESCRIPTION
Make use of OnSwitchTo method to reset the viewport to fullscreen - fixes #2576
