### PR TITLE
Enable speedlines when the 2D GUI is disabled

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -395,8 +395,6 @@ void WorldView::Draw3D()
 	assert(!Pi::player->IsDead());
 	m_camera->Draw(m_renderer, GetCamType() == CAM_INTERNAL ? Pi::player : 0);
 
-	if (!Pi::DrawGUI) return;
-
 	// Draw 3D HUD
 	// Speed lines
 	if (Pi::AreSpeedLinesDisplayed())


### PR DESCRIPTION
Enable speedlines, and other 3D HUD features in future, when the 2D GUI is disabled.
