### PR TITLE
Deep gas-giant atmospheres

### DIFF
--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -46,20 +46,27 @@ void Planet::Load(Serializer::Reader &rd, Space *space)
 
 void Planet::InitParams(const SystemBody *sbody)
 {
-	const double SPECIFIC_HEAT_AIR_CP=1000.5;// constant pressure specific heat, for the combination of gasses that make up air
-	// XXX using earth's molar mass of air...
-	const double GAS_MOLAR_MASS = 0.02897;
+	double specificHeatCp;
+	double gasMolarMass;
+	if (sbody->GetSuperType() == SystemBody::SUPERTYPE_GAS_GIANT) {
+		specificHeatCp=12950.0; // constant pressure specific heat, for a combination of hydrogen and helium
+		gasMolarMass = 0.0023139903;
+	} else {
+		specificHeatCp=1000.5;// constant pressure specific heat, for the combination of gasses that make up air
+		// XXX using earth's molar mass of air...
+		gasMolarMass = 0.02897;
+	}
 	const double GAS_CONSTANT = 8.3144621;
 	const double PA_2_ATMOS = 1.0 / 101325.0;
 
 	// surface gravity = -G*M/planet radius^2
 	m_surfaceGravity_g = -G*sbody->GetMass()/(sbody->GetRadius()*sbody->GetRadius());
-	const double lapseRate_L = -m_surfaceGravity_g/SPECIFIC_HEAT_AIR_CP; // negative deg/m
+	const double lapseRate_L = -m_surfaceGravity_g/specificHeatCp; // negative deg/m
 	const double surfaceTemperature_T0 = sbody->averageTemp; //K
 
 	double surfaceDensity, h; Color c;
 	sbody->GetAtmosphereFlavor(&c, &surfaceDensity);// kg / m^3
-	surfaceDensity/=GAS_MOLAR_MASS;			// convert to moles/m^3
+	surfaceDensity/=gasMolarMass;			// convert to moles/m^3
 
 	//P = density*R*T=(n/V)*R*T
 	const double surfaceP_p0 = PA_2_ATMOS*((surfaceDensity)*GAS_CONSTANT*surfaceTemperature_T0); // in atmospheres
@@ -68,7 +75,7 @@ void Planet::InitParams(const SystemBody *sbody)
 		//*outPressure = p0*(1-l*h/T0)^(g*M/(R*L);
 		// want height for pressure 0.001 atm:
 		// h = (1 - exp(RL/gM * log(P/p0))) * T0 / l
-		double RLdivgM = (GAS_CONSTANT*lapseRate_L)/(-m_surfaceGravity_g*GAS_MOLAR_MASS);
+		double RLdivgM = (GAS_CONSTANT*lapseRate_L)/(-m_surfaceGravity_g*gasMolarMass);
 		h = (1.0 - exp(RLdivgM * log(0.001/surfaceP_p0))) * surfaceTemperature_T0 / lapseRate_L;
 //		double h2 = (1.0 - pow(0.001/surfaceP_p0, RLdivgM)) * surfaceTemperature_T0 / lapseRate_L;
 //		double P = surfaceP_p0*pow((1.0-lapseRate_L*h/surfaceTemperature_T0),1/RLdivgM);
@@ -96,10 +103,10 @@ void Planet::GetAtmosphericState(double dist, double *outPressure, double *outDe
 	static bool atmosphereTableShown = false;
 	if (!atmosphereTableShown) {
 		atmosphereTableShown = true;
-		for (double h = -1000; h <= 50000; h = h+1000.0) {
+		for (double h = -1000; h <= 100000; h = h+1000.0) {
 			double p = 0.0, d = 0.0;
 			GetAtmosphericState(h+this->GetSystemBody()->GetRadius(),&p,&d);
-			printf("height(m): %f, pressure(kpa): %f, density: %f\n", h, p*101325.0/1000.0, d);
+			printf("height(m): %f, pressure(hpa): %f, density: %f\n", h, p*101325.0/100.0, d);
 		}
 	}
 #endif
@@ -109,39 +116,46 @@ void Planet::GetAtmosphericState(double dist, double *outPressure, double *outDe
 	if (dist >= m_atmosphereRadius) {*outDensity = 0.0; *outPressure = 0.0; return;}
 
 	double surfaceDensity;
-	const double SPECIFIC_HEAT_AIR_CP=1000.5;// constant pressure specific heat, for the combination of gasses that make up air
-	// XXX using earth's molar mass of air...
-	const double GAS_MOLAR_MASS = 0.02897;
+	double specificHeatCp;
+	double gasMolarMass;
+	const SystemBody *sbody = this->GetSystemBody();
+	if (sbody->GetSuperType() == SystemBody::SUPERTYPE_GAS_GIANT) {
+		specificHeatCp=12950.0; // constant pressure specific heat, for a combination of hydrogen and helium
+		gasMolarMass = 0.0023139903;
+	} else {
+		specificHeatCp=1000.5;// constant pressure specific heat, for the combination of gasses that make up air
+		// XXX using earth's molar mass of air...
+		gasMolarMass = 0.02897;
+	}
 	const double GAS_CONSTANT = 8.3144621;
 	const double PA_2_ATMOS = 1.0 / 101325.0;
 
 	// lapse rate http://en.wikipedia.org/wiki/Adiabatic_lapse_rate#Dry_adiabatic_lapse_rate
 	// the wet adiabatic rate can be used when cloud layers are incorporated
 	// fairly accurate in the troposphere
-	const double lapseRate_L = -m_surfaceGravity_g/SPECIFIC_HEAT_AIR_CP; // negative deg/m
+	const double lapseRate_L = -m_surfaceGravity_g/specificHeatCp; // negative deg/m
 
-	const SystemBody *sbody = this->GetSystemBody();
 	const double height_h = (dist-sbody->GetRadius()); // height in m
 	const double surfaceTemperature_T0 = sbody->averageTemp; //K
 
 	Color c;
 	sbody->GetAtmosphereFlavor(&c, &surfaceDensity);// kg / m^3
 	// convert to moles/m^3
-	surfaceDensity/=GAS_MOLAR_MASS;
+	surfaceDensity/=gasMolarMass;
 
 	//P = density*R*T=(n/V)*R*T
 	const double surfaceP_p0 = PA_2_ATMOS*((surfaceDensity)*GAS_CONSTANT*surfaceTemperature_T0); // in atmospheres
 
 	// height below zero should not occur
-	if (height_h < 0.0) { *outPressure = surfaceP_p0; *outDensity = surfaceDensity*GAS_MOLAR_MASS; return; }
+	if (height_h < 0.0) { *outPressure = surfaceP_p0; *outDensity = surfaceDensity*gasMolarMass; return; }
 
 	//*outPressure = p0*(1-l*h/T0)^(g*M/(R*L);
-	*outPressure = surfaceP_p0*pow((1-lapseRate_L*height_h/surfaceTemperature_T0),(-m_surfaceGravity_g*GAS_MOLAR_MASS/(GAS_CONSTANT*lapseRate_L)));// in ATM since p0 was in ATM
+	*outPressure = surfaceP_p0*pow((1-lapseRate_L*height_h/surfaceTemperature_T0),(-m_surfaceGravity_g*gasMolarMass/(GAS_CONSTANT*lapseRate_L)));// in ATM since p0 was in ATM
 	//                                                                               ^^g used is abs(g)
 	// temperature at height
 	double temp = surfaceTemperature_T0+lapseRate_L*height_h;
 
-	*outDensity = (*outPressure/(PA_2_ATMOS*GAS_CONSTANT*temp))*GAS_MOLAR_MASS;
+	*outDensity = (*outPressure/(PA_2_ATMOS*GAS_CONSTANT*temp))*gasMolarMass;
 }
 
 void Planet::GenerateRings(Graphics::Renderer *renderer)

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -1351,18 +1351,10 @@ SystemBody::AtmosphereParameters SystemBody::CalcAtmosphereParams() const
 	if (T < 1)
 		T = 165;
 
-	// XXX just use earth's composition for now
-	const double M = 0.02897f; // in kg/mol
+	// We have two kinds of atmosphere: Earth-like and gas giant (hydrogen/helium)
+	const double M = type == TYPE_PLANET_GAS_GIANT ? 0.0023139903 : 0.02897f; // in kg/mol
 
 	float atmosScaleHeight = static_cast<float>(GAS_CONSTANT_R*T/(M*g));
-
-	// XXX temporary hack to fix small scale heights for gas giant atmospheres which are
-	// a result of using Earth atmosphere properties, as well as due to using
-	// a made up density value at the gas giant terrain 'surface'.
-	// This uses a minimum scale height as a fraction of gas giant radius based on
-	// Earth's scale height relative to its radius.
-	if (type == TYPE_PLANET_GAS_GIANT)
-		atmosScaleHeight = std::max(atmosScaleHeight, static_cast<float>((0.02*8000.0/EARTH_RADIUS)*GetRadius()));
 
 	// min of 2.0 corresponds to a scale height of 1/20 of the planet's radius,
 	params.atmosInvScaleHeight = std::max(20.0f, static_cast<float>(GetRadius() / atmosScaleHeight));


### PR DESCRIPTION
As you might have noticed when scooping a gas giant, its atmosphere is ridiculously shallow and has an insanely high pressure gradient.

The reason is that all atmospheres in the game use a the gas parameters of air (i.e. nitrogen/oxygen). However, gas giants have a hydrogen/helium atmosphere which is very different from air. The specific heat of such a mixture is 13 times as high as that of air and the molar mass is approx. 1/13th. Just using these parameters instead of the parameters of air give satisfactory results. So, this PR uses two sets of parameters, the "hydrogen/helium" parameters for gas giants and the "air" parameters for other planets/moons/asteroids.

The results for some gas planets in the solar system are:
- Jupiter: 1 atm at 58km altitude, fuel scooping pressure approx. 8.6 atm at 38km
- Saturn: 1 atm at 104km altitude, fuel scooping pressure approx. 7.0 atm at 57km
- Neptune: 1 atm at 50km altitude, fuel scooping pressure approx. 3.75 atm at 37km

You might notice the higher pressure for fuel scooping. The game currently uses a fixed gas density of 1 kg/m³ which results in a much higher pressure for hydrogen/helium than for air. But the height is still much above the "surface", so I think it is okay (but can be changed easily, since only gas giants are scoopable).
