### PR TITLE
Adding deltaV data to Ship Market

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -175,6 +175,18 @@
       "description" : "",
       "message" : "Delta-v"
    },
+   "DELTA_V_EMPTY" : {
+      "description" : "Delta-v capacity of a ship with no cargo or upgrades",
+      "message" : "Delta-v (empty)"
+   },
+   "DELTA_V_FULL" : {
+      "description" : "Delta-v capacity of a ship with maximum cargo",
+      "message" : "Delta-v (full)"
+   },
+   "DELTA_V_MAX" : {
+      "description" : "Delta-v capacity of a ship with cargo bay fully loaded with propellant",
+      "message" : "Delta-v (max)"
+   },
    "DESCENT_TO_GROUND_SPEED" : {
       "description" : "",
       "message" : "Descent-to-ground speed:"

--- a/data/ui/StationView/ShipMarket.lua
+++ b/data/ui/StationView/ShipMarket.lua
@@ -110,6 +110,9 @@ shipTable.onRowClicked:Connect(function (row)
 	local forwardAccelFull  =  def.linearThrust.FORWARD / (-9.81*1000*(def.hullMass+def.capacity+def.fuelTankMass))
 	local reverseAccelEmpty = -def.linearThrust.REVERSE / (-9.81*1000*(def.hullMass+def.fuelTankMass))
 	local reverseAccelFull  = -def.linearThrust.REVERSE / (-9.81*1000*(def.hullMass+def.capacity+def.fuelTankMass))
+	local deltav = def.effectiveExhaustVelocity * math.log((def.hullMass + def.fuelTankMass) / def.hullMass)
+	local deltav_f = def.effectiveExhaustVelocity * math.log((def.hullMass + def.fuelTankMass + def.capacity) / (def.hullMass + def.capacity))
+	local deltav_m = def.effectiveExhaustVelocity * math.log((def.hullMass + def.fuelTankMass + def.capacity) / def.hullMass)
 
 	local buyButton = ui:Button(l.BUY_SHIP):SetFont("HEADING_LARGE")
 	buyButton.onClick:Connect(function () buyShip(currentShipOnSale) end)
@@ -140,13 +143,16 @@ shipTable.onRowClicked:Connect(function (row)
 							:AddRow({l.FORWARD_ACCEL_EMPTY, Format.AccelG(forwardAccelEmpty)})
 							:AddRow({l.FORWARD_ACCEL_FULL,  Format.AccelG(forwardAccelFull)})
 							:AddRow({l.REVERSE_ACCEL_EMPTY, Format.AccelG(reverseAccelEmpty)})
-							:AddRow({l.REVERSE_ACCEL_FULL,  Format.AccelG(reverseAccelFull)}),
+							:AddRow({l.REVERSE_ACCEL_FULL,  Format.AccelG(reverseAccelFull)})
+							:AddRow({l.DELTA_V_EMPTY, string.format("%d km/s", deltav / 1000)})
+							:AddRow({l.DELTA_V_FULL, string.format("%d km/s", deltav_f / 1000)}),							
 						ui:Table()
 							:SetColumnSpacing(5)
 							:AddRow({l.WEIGHT_EMPTY,        Format.MassTonnes(def.hullMass)})
 							:AddRow({l.CAPACITY,            Format.MassTonnes(def.capacity)})
-							:AddRow({l.FUEL_WEIGHT,         Format.MassTonnes(def.fuelTankMass)})
 							:AddRow({l.WEIGHT_FULLY_LOADED, Format.MassTonnes(def.hullMass+def.capacity+def.fuelTankMass)})
+							:AddRow({l.FUEL_WEIGHT,         Format.MassTonnes(def.fuelTankMass)})
+							:AddRow({l.DELTA_V_MAX, string.format("%d km/s", deltav_m / 1000)})
 					})
 			),
 			ui:Align("MIDDLE", buyButton),


### PR DESCRIPTION
Delta-V data entries for the ship market. Empty (with fuel only, no cargo or upgrades), Full (max cargo), Max (cargo is propellant).
Also added the lines (with tooltip description too) to the English lang file.

I've put The Max Delta-V to the secont column, so the layout is a bit better. I'm not sure if another column would look good on small screens or 4:3.

![screenshot-20140104-204317](https://f.cloud.github.com/assets/4182678/1845223/aab30cfe-7578-11e3-8064-d30c59d0a514.png)
