### PR TITLE
fix "how many answer" always treated as plural

### DIFF
--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -195,7 +195,7 @@ local onChat = function (form, ref, option)
 
 		return
 	elseif option == 4 then
-		if flavours[ad.flavour].single == 1 then
+		if flavours[ad.flavour].single then
 			form:SetMessage(l.I_MUST_BE_THERE_BEFORE..Format.Date(ad.due))
 		else
 			form:SetMessage(l.WE_WANT_TO_BE_THERE_BEFORE..Format.Date(ad.due))


### PR DESCRIPTION
This fixes single persons replying "We want to be there by {stardate}"

Same type of bug as in #2622-#2624. 

I've noticed it in gameplay, but didn't realize it was unrelated to #2623 (which also confuses "single" person with "group"), until I saw it today in the code.

I've also checked through both DeliverPackage, and Taxi missions to see if there were any more of thises bugs, but I think that should be it. Other scripts seem to not have been written in that way
