### PR TITLE
Re-attribute ShipCockpit authorship.

### DIFF
--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -1,6 +1,9 @@
 // Copyright © 2013-14 Meteoric Games Ltd
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+// Copyright © 2008-2014 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
 #include "ShipCockpit.h"
 #include "ShipType.h"
 #include "Pi.h"

--- a/src/ShipCockpit.h
+++ b/src/ShipCockpit.h
@@ -1,6 +1,9 @@
 // Copyright © 2013-14 Meteoric Games Ltd
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+// Copyright © 2008-2014 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
 #ifndef _SHIP_COCKPIT_H_
 #define _SHIP_COCKPIT_H_
 


### PR DESCRIPTION
Re-attribute authorship, original author just copy-pasted our copyright instead of using their own.

Still GPL3 so no significant change just the one correction.
