### PR TITLE
Modify Serializer::Reader to work from an externally provided ByteRange

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -707,11 +707,11 @@ void Game::DestroyViews()
 Game *Game::LoadGame(const std::string &filename)
 {
 	printf("Game::LoadGame('%s')\n", filename.c_str());
-	FILE *f = FileSystem::userFiles.OpenReadStream(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
-	if (!f) throw CouldNotOpenFileException();
-	Serializer::Reader rd(f);
-	fclose(f);
+	auto file = FileSystem::userFiles.ReadFile(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
+	if (!file) throw CouldNotOpenFileException();
+	Serializer::Reader rd(file->AsByteRange());
 	return new Game(rd);
+	// file data is freed here
 }
 
 void Game::SaveGame(const std::string &filename, Game *game)

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -373,7 +373,8 @@ const char *LuaSerializer::unpickle(lua_State *l, const char *pos)
 				pos = end+1; // skip newline
 
 				std::string buf(pos, serlen);
-				Serializer::Reader rd(buf);
+				const char *bufp = buf.c_str();
+				Serializer::Reader rd(ByteRange(bufp, bufp + buf.size()));
 				SceneGraph::ModelSkin skin;
 				skin.Load(rd);
 

--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -108,29 +108,31 @@ void Writer::WrQuaternionf(const Quaternionf &q)
 }
 
 
-Reader::Reader(): m_data(""), m_pos(0) {
-}
-Reader::Reader(const std::string &data):
+Reader::Reader(const ByteRange &data):
 	m_data(data),
-	m_pos(0) {
+	m_at(data.begin)
+{}
 
+bool Reader::AtEnd() { return (m_at == m_data.end); }
+void Reader::Seek(int pos)
+{
+	assert(pos >= 0 && size_t(pos) <= m_data.Size());
+	m_at = m_data.begin + pos;
 }
-Reader::Reader(FILE *fptr): m_pos(0) {
-	m_data = "";
-	while (!feof(fptr)) m_data.push_back(fgetc(fptr));
-	printf(SIZET_FMT " characters in savefile\n", m_data.size());
-}
-bool Reader::AtEnd() { return m_pos >= m_data.size(); }
-void Reader::Seek(int pos) { m_pos = pos; }
-Uint8 Reader::Byte() {
+
+Uint8 Reader::Byte()
+{
 #ifdef DEBUG
-	assert(m_pos < m_data.size());
+	assert(!AtEnd());
 #endif /* DEBUG */
-	return Uint8(m_data[m_pos++]);
+	return Uint8(*m_at++);
 }
-bool Reader::Bool() {
+
+bool Reader::Bool()
+{
 	return Byte() != 0;
 }
+
 Uint16 Reader::Int16()
 {
 	int t1, t2;
@@ -189,19 +191,29 @@ double Reader::Double ()
 	return p.f;
 }
 
-std::string Reader::String()
+ByteRange Reader::Blob()
 {
 	int size = Int32();
-	if (size == 0) return "";
+	if (size == 0) return ByteRange();
 
-	std::string buf;
-	buf.reserve(size-1);
-
-	for (int i=0; i<size-1; i++) {
-		buf.push_back(char(Byte()));
+	if (size > (m_data.end - m_at)) {
+		// XXX error condition -- exception? some kind of error state on the Reader?
+		assert(0 && "Serializer:Reader stream is truncated");
+		size = (m_data.end - m_at);
 	}
-	Byte();// discard null terminator
-	return buf;
+
+	assert(size > 0);
+	assert(size <= (m_data.end - m_at));
+	ByteRange range = ByteRange(m_at, m_at + (size - 1)); // -1 to exclude the null terminator
+	m_at += size;
+	assert(m_at <= m_data.end);
+	return range;
+}
+
+std::string Reader::String()
+{
+	ByteRange range = Blob();
+	return std::string(range.begin, range.Size());
 }
 
 vector3d Reader::Vector3d()

--- a/src/Serializer.h
+++ b/src/Serializer.h
@@ -6,6 +6,7 @@
 
 #include "utils.h"
 #include "Quaternion.h"
+#include "ByteRange.h"
 #include <vector>
 
 class Frame;
@@ -50,9 +51,9 @@ namespace Serializer {
 
 	class Reader {
 	public:
-		Reader();
-		Reader(const std::string &data);
-		Reader(FILE *fptr);
+		Reader(): m_at(nullptr), m_streamVersion(-1) {}
+		explicit Reader(const ByteRange &data);
+
 		bool AtEnd();
 		void Seek(int pos);
 		Uint8 Byte();
@@ -63,13 +64,14 @@ namespace Serializer {
 		float Float ();
 		double Double ();
 		std::string String();
+		ByteRange Blob();
 		vector3d Vector3d();
 		Quaternionf RdQuaternionf();
 		Reader RdSection(const std::string &section_label_expected) {
 			if (section_label_expected != String()) {
 				throw SavedGameCorruptException();
 			}
-			Reader section = Reader(String());
+			Reader section = Reader(Blob());
 			section.SetStreamVersion(StreamVersion());
 			return section;
 		}
@@ -80,9 +82,10 @@ namespace Serializer {
 		void Auto(double *x) { *x = Double(); }
 		int StreamVersion() const { return m_streamVersion; }
 		void SetStreamVersion(int x) { m_streamVersion = x; }
+
 	private:
-		std::string m_data;
-		size_t m_pos;
+		ByteRange m_data;
+		const char *m_at;
 		int m_streamVersion;
 	};
 


### PR DESCRIPTION
For #2643.

This eliminates the pointless allocation and copying that happened when Reader had its own copy of the data in a std::string, and makes it easy to create a Reader to unserialise data from a FileData object (ie, easy to use with FileSystem).

(**warning**: completely untested apart from checking that it compiles)
