### PR TITLE
Intro tweaks and cleanup

### DIFF
--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -48,7 +48,6 @@ Intro::Intro(Graphics::Renderer *r, int width, int height)
 	PiRngWrapper rng;
 	std::random_shuffle(m_models.begin(), m_models.end(), rng);
 
-	m_state = STATE_SELECT;
 	m_modelIndex = 0;
 
 	const int w = Graphics::GetScreenWidth();
@@ -59,6 +58,8 @@ Intro::Intro(Graphics::Renderer *r, int width, int height)
 	m_spinnerLeft = int(float(w)*-.5f - float(w)/6.f);
 	m_spinnerWidth = w*2;
 	m_spinnerRatio = w*2.f/h;
+
+	m_needReset = true;
 }
 
 Intro::~Intro()
@@ -67,45 +68,48 @@ Intro::~Intro()
 		delete (*i);
 }
 
+void Intro::Reset(float _time)
+{
+	m_model = m_models[m_modelIndex++];
+	if (m_modelIndex == m_models.size()) m_modelIndex = 0;
+	m_skin.SetRandomColors(Pi::rng);
+	m_skin.Apply(m_model);
+	m_model->SetPattern(Pi::rng.Int32(0, m_model->GetNumPatterns()));
+	m_zoomBegin = -10000.0f;
+	m_zoomEnd = -m_model->GetDrawClipRadius()*1.7f;
+	m_dist = m_zoomBegin;
+	m_startTime = _time;
+	m_needReset = false;
+}
+
+// stage end times
+static const float ZOOM_IN_END  = 2.0f;
+static const float WAIT_END     = 12.0f;
+static const float ZOOM_OUT_END = 14.0f;
+
 void Intro::Draw(float _time)
 {
-	switch (m_state) {
-		case STATE_SELECT:
-			m_model = m_models[m_modelIndex++];
-			if (m_modelIndex == m_models.size()) m_modelIndex = 0;
-			m_skin.SetRandomColors(Pi::rng);
-			m_skin.Apply(m_model);
-			m_model->SetPattern(Pi::rng.Int32(0, m_model->GetNumPatterns()));
-			m_zoomBegin = -10000.0f;
-			m_zoomEnd = -m_model->GetDrawClipRadius()*1.7f;
-			m_dist = m_zoomBegin;
-			m_state = STATE_ZOOM_IN;
-			m_startTime = _time;
-			break;
+	if (m_needReset)
+		Reset(_time);
 
-		case STATE_ZOOM_IN:
-			m_dist = Clamp(Easing::Quad::EaseOut(_time-m_startTime, m_zoomBegin, m_zoomEnd-m_zoomBegin, 2.0f), m_zoomBegin, m_zoomEnd);
-			if (_time-m_startTime > 2.0f) {
-				m_state = STATE_WAIT;
-				m_startTime = _time;
-			}
-			break;
+	float duration = _time-m_startTime;
 
-		case STATE_WAIT:
-			if (_time - m_startTime > 10.0f) {
-				m_state = STATE_ZOOM_OUT;
-				m_startTime = _time;
-			}
-			break;
+	// zoom in
+	if (duration < ZOOM_IN_END)
+		m_dist = Clamp(Easing::Quad::EaseOut(duration, m_zoomBegin, m_zoomEnd-m_zoomBegin, 2.0f), m_zoomBegin, m_zoomEnd);
 
-		case STATE_ZOOM_OUT:
-			m_dist = Clamp(Easing::Quad::EaseIn(_time-m_startTime, m_zoomEnd, m_zoomBegin-m_zoomEnd, 2.0f), m_zoomBegin, m_zoomEnd);
-			if (_time-m_startTime > 2.0f) {
-				m_state = STATE_SELECT;
-				m_startTime = _time;
-			}
-			break;
+	// wait
+	else if (duration < WAIT_END) {
+		m_dist = m_zoomEnd;
 	}
+
+	// zoom out
+	else if (duration < ZOOM_OUT_END)
+		m_dist = Clamp(Easing::Quad::EaseIn(duration-WAIT_END, m_zoomEnd, m_zoomBegin-m_zoomEnd, 2.0f), m_zoomBegin, m_zoomEnd);
+
+	// done
+	else
+		m_needReset = true;
 
 	Graphics::Renderer::StateTicket ticket(m_renderer);
 

--- a/src/Intro.h
+++ b/src/Intro.h
@@ -16,16 +16,12 @@ public:
 	virtual void Draw(float time);
 
 private:
+	void Reset(float time);
+	bool m_needReset;
+
 	std::vector<SceneGraph::Model*> m_models;
 	SceneGraph::ModelSkin m_skin;
 
-	enum State {
-		STATE_SELECT,
-		STATE_ZOOM_IN,
-		STATE_WAIT,
-		STATE_ZOOM_OUT
-	};
-	State m_state;
 	float m_startTime;
 
 	unsigned int m_modelIndex;


### PR DESCRIPTION
Intro doesn't get much love. Today it does :)
- Don't make direct GL calls
- Use a larger viewport to avoid clipping
- Don't spin vertically, its kind of nauseating
- Randomise skin and pattern for each ship display. No two ships the same, guaranteed!†

† Not a guarantee
