### PR TITLE
fix for bug #2650, shipyard never stops growing

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -194,7 +194,7 @@ local function updateShipsOnSale (station)
 	local toAdd, toRemove = 0, 0
 	if #shipsOnSale == 0 then
 		toAdd = Engine.rand:Integer(20)
-	elseif Engine.rand:Integer(2) > 0 then
+	elseif Engine.rand:Integer(1) > 0 then
 		toAdd = 1
 	elseif #shipsOnSale > 0 then
 		toRemove = 1


### PR DESCRIPTION
A fix for the shipyard that keeps growing. This fixes #2650

I've attached a plot (I do that a lot these days) of number of ships in Barnards Star Tranquility and Serenity shipyards, before and after bugfix, simply as a function of number of updates to the shipyard. I ran for different times. 21 of January for one, and longer for the other I think.

![bugfix](https://f.cloud.github.com/assets/619390/1918837/a623e5f8-7dc7-11e3-8dc4-044d171d18ef.png)
