### PR TITLE
Fix fuel gauge using incorrect formatting in some circumstances

### DIFF
--- a/data/ui/InfoView/EconTrade.lua
+++ b/data/ui/InfoView/EconTrade.lua
@@ -100,7 +100,9 @@ local econTrade = function ()
 
 	local refuelButtonRefresh = function ()
 		if Game.player.fuel == 100 or Game.player:GetEquipCount('CARGO', 'WATER') == 0 then refuelButton.widget:Disable() end
-		fuelGauge:SetValue(Game.player.fuel/100)
+		local fuel_percent = Game.player.fuel/100
+		fuelGauge.gauge:SetValue(fuel_percent)
+		fuelGauge.label:SetValue(fuel_percent)
 	end
 	refuelButtonRefresh()
 


### PR DESCRIPTION
For #2659.

InfoGauge:SetValue calls label:SetText directly, which is wrong when the label is a NumberLabel; for NumberLabel it should call SetValue and let the label itself apply formatting.
