### PR TITLE
Remove redundant Update*() calls

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -531,7 +531,6 @@ void Ship::UpdateEquipStats()
 	m_stats.shield_mass = TONS_HULL_PER_SHIELD * float(m_equipment.Count(Equip::SLOT_SHIELD, Equip::SHIELD_GENERATOR));
 	p.Set("shieldMass", m_stats.shield_mass);
 
-	UpdateMass();
 	UpdateFuelStats();
 
 	Equip::Type fuelType = GetHyperdriveFuelType();
@@ -561,7 +560,6 @@ void Ship::UpdateFuelStats()
 void Ship::UpdateStats()
 {
 	UpdateEquipStats();
-	UpdateFuelStats();
 }
 
 static float distance_to_system(const SystemPath &src, const SystemPath &dest)


### PR DESCRIPTION
UpdateMass() is called in UpdateFuelStats(), which is called in
UpdateEquipStats()
