### PR TITLE
show min/max crew in shipmarket

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -535,6 +535,10 @@
       "description" : "",
       "message" : "max"
    },
+   "MAXIMUM_CREW" : {
+      "description" : "",
+      "message" : "Maximum crew"
+   },
    "MEDIUM" : {
       "description" : "",
       "message" : "Medium"

--- a/data/ui/StationView/ShipMarket.lua
+++ b/data/ui/StationView/ShipMarket.lua
@@ -153,14 +153,16 @@ shipTable.onRowClicked:Connect(function (row)
 							:AddRow({l.REVERSE_ACCEL_EMPTY, Format.AccelG(reverseAccelEmpty)})
 							:AddRow({l.REVERSE_ACCEL_FULL,  Format.AccelG(reverseAccelFull)})
 							:AddRow({l.DELTA_V_EMPTY, string.format("%d km/s", deltav / 1000)})
-							:AddRow({l.DELTA_V_FULL, string.format("%d km/s", deltav_f / 1000)}),
+							:AddRow({l.DELTA_V_FULL, string.format("%d km/s", deltav_f / 1000)})
+							:AddRow({l.DELTA_V_MAX, string.format("%d km/s", deltav_m / 1000)}),
 						ui:Table()
 							:SetColumnSpacing(5)
 							:AddRow({l.WEIGHT_EMPTY,        Format.MassTonnes(def.hullMass)})
 							:AddRow({l.CAPACITY,            Format.MassTonnes(def.capacity)})
+							:AddRow({l.MINIMUM_CREW,        def.minCrew})
+							:AddRow({l.MAXIMUM_CREW,        def.maxCrew})
 							:AddRow({l.WEIGHT_FULLY_LOADED, Format.MassTonnes(def.hullMass+def.capacity+def.fuelTankMass)})
 							:AddRow({l.FUEL_WEIGHT,         Format.MassTonnes(def.fuelTankMass)})
-							:AddRow({l.DELTA_V_MAX, string.format("%d km/s", deltav_m / 1000)})
 					})
 			),
 		})


### PR DESCRIPTION
fix for https://github.com/pioneerspacesim/pioneer/issues/2382

I think it's sensible to see the crew min/max.

Also moved the deltaV max to be with the others to balance. Maybe that is frowned upon?

![shipmarket](https://f.cloud.github.com/assets/619390/1997425/9f7f6f60-8524-11e3-9588-ced5c3e690b4.png)
