### PR TITLE
colonoscopy

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -929,7 +929,7 @@
    },
    "WEIGHT_EMPTY" : {
       "description" : "",
-      "message" : "Weight empty:"
+      "message" : "Weight empty"
    },
    "WEIGHT_FULLY_LOADED" : {
       "description" : "",


### PR DESCRIPTION
I think the extra colon in "Weight empty:" looks odd (reusing image from other PR, pardon me being lazy):

![shipmarket](https://f.cloud.github.com/assets/619390/1997425/9f7f6f60-8524-11e3-9588-ced5c3e690b4.png)

None of the other descriptions in the list end with a colon. If there should be a colon, it might be sensible to oncatenate one with the translated string afterwards.
