### PR TITLE
Remove jettison button while being docked/docking or in hyperspace

### DIFF
--- a/data/ui/InfoView/EconTrade.lua
+++ b/data/ui/InfoView/EconTrade.lua
@@ -47,8 +47,7 @@ local econTrade = function ()
 						table.insert(cargoQuantityColumn, ui:Label(count.."t"))
 
 						-- Don't jettison if DOCKED/DOCKING or in HYPERSPACE
-						if Game.player.flightState == "FLYING" or
-						Game.player.flightState == "LANDED"  then
+						if Game.player.flightState == "FLYING" then
 							local jettisonButton = SmallLabeledButton.New(l.JETTISON)
 							jettisonButton.button.onClick:Connect(function ()
 								Game.player:Jettison(type)


### PR DESCRIPTION
This fixes the cheat of taking on radioactives and then dumping them right in the station (without even taking off) by removing the jettison button if docked, or docking.

I've tested it while being docked, and while being in hyperspace. Not tested it landing on a planet outside a space port, which I assume is what "LANDED" is for if I read the [API](http://eatenbyagrue.org/f/pioneer/codedoc/files/LuaConstants-cpp.html#Constants.ShipFlightState) correct.

For the future: dumping cargo, or at least radioactives, in the vicinity of a space station should be a felony
#872
