### PR TITLE
gray out jettison button if not flying

### DIFF
--- a/data/ui/InfoView/EconTrade.lua
+++ b/data/ui/InfoView/EconTrade.lua
@@ -52,6 +52,9 @@ local econTrade = function ()
 							updateCargoListWidget()
 							cargoListWidget:SetInnerWidget(updateCargoListWidget())
 						end)
+						if Game.player.flightState ~= "FLYING" then
+							jettisonButton.widget:Disable()
+						end
 						table.insert(cargoJettisonColumn, jettisonButton.widget)
 					end
 				end


### PR DESCRIPTION
Instead of removing Jettison button as in #2687, just disable it. Looks better I think.

Hope I put the code in the right place, seems to work. Tested it when docked, and when flying.
