### PR TITLE
Redundant glUseProgram optimization

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -1286,6 +1286,7 @@ void SectorView::Update()
 		rsd.blendMode = Graphics::BLEND_ALPHA;
 		rsd.depthTest = false;
 		rsd.depthWrite = false;
+		rsd.cullMode = Graphics::CULL_NONE;
 		m_jumpSphereState = m_renderer->CreateRenderState(rsd);
 
 		Graphics::MaterialDescriptor matdesc;

--- a/src/graphics/gl2/FresnelColourMaterial.cpp
+++ b/src/graphics/gl2/FresnelColourMaterial.cpp
@@ -36,15 +36,6 @@ void FresnelColourMaterial::Apply()
 	p->invLogZfarPlus1.Set(m_renderer->m_invLogZfarPlus1);
 
 	p->diffuse.Set(this->diffuse);
-
-	glPushAttrib(GL_ENABLE_BIT);
-	glDisable(GL_CULL_FACE);
-}
-
-void FresnelColourMaterial::Unapply()
-{
-	glPopAttrib();
-	m_program->Unuse();
 }
 
 }

--- a/src/graphics/gl2/FresnelColourMaterial.h
+++ b/src/graphics/gl2/FresnelColourMaterial.h
@@ -23,7 +23,6 @@ namespace Graphics {
 		public:
 			virtual Program *CreateProgram(const MaterialDescriptor &);
 			virtual void Apply();
-			virtual void Unapply();
 		};
 	}
 }

--- a/src/graphics/gl2/GL2Material.cpp
+++ b/src/graphics/gl2/GL2Material.cpp
@@ -15,7 +15,6 @@ void Material::Apply()
 
 void Material::Unapply()
 {
-	m_program->Unuse();
 }
 
 }

--- a/src/graphics/gl2/MultiMaterial.cpp
+++ b/src/graphics/gl2/MultiMaterial.cpp
@@ -144,7 +144,6 @@ void MultiMaterial::Unapply()
 	if (texture0) {
 		static_cast<TextureGL*>(texture0)->Unbind();
 	}
-	m_program->Unuse();
 }
 
 }

--- a/src/graphics/gl2/Program.cpp
+++ b/src/graphics/gl2/Program.cpp
@@ -13,6 +13,7 @@ namespace Graphics {
 namespace GL2 {
 
 static const char *s_glslVersion = "#version 110\n";
+GLuint Program::s_curProgram = 0;
 
 // Check and warn about compile & link errors
 static bool check_glsl_errors(const char *filename, GLuint obj)
@@ -160,12 +161,15 @@ void Program::Reload()
 
 void Program::Use()
 {
-	glUseProgram(m_program);
+	if (s_curProgram != m_program)
+		glUseProgram(m_program);
+	s_curProgram = m_program;
 }
 
 void Program::Unuse()
 {
 	glUseProgram(0);
+	s_curProgram = 0;
 }
 
 //load, compile and link

--- a/src/graphics/gl2/Program.h
+++ b/src/graphics/gl2/Program.h
@@ -45,6 +45,8 @@ namespace Graphics {
 			Uniform sceneAmbient;
 
 		protected:
+			static GLuint s_curProgram;
+
 			void LoadShaders(const std::string&, const std::string &defines);
 			virtual void InitUniforms();
 			std::string m_name;

--- a/src/graphics/gl2/RingMaterial.cpp
+++ b/src/graphics/gl2/RingMaterial.cpp
@@ -21,9 +21,6 @@ Program *RingMaterial::CreateProgram(const MaterialDescriptor &desc)
 
 void RingMaterial::Apply()
 {
-	//setting cull mode here just to demonstrate materials are allowed control over this sort of thing
-	glPushAttrib(GL_ENABLE_BIT);
-	glDisable(GL_CULL_FACE);
 	m_program->Use();
 	m_program->invLogZfarPlus1.Set(m_renderer->m_invLogZfarPlus1);
 	assert(this->texture0);
@@ -34,8 +31,6 @@ void RingMaterial::Apply()
 void RingMaterial::Unapply()
 {
 	static_cast<TextureGL*>(texture0)->Unbind();
-	m_program->Unuse();
-	glPopAttrib();
 }
 
 }

--- a/src/graphics/gl2/ShieldMaterial.cpp
+++ b/src/graphics/gl2/ShieldMaterial.cpp
@@ -77,10 +77,5 @@ void ShieldMaterial::Apply()
 	}
 }
 
-void ShieldMaterial::Unapply()
-{
-	m_program->Unuse();
-}
-
 }
 }

--- a/src/graphics/gl2/ShieldMaterial.h
+++ b/src/graphics/gl2/ShieldMaterial.h
@@ -32,7 +32,6 @@ namespace Graphics {
 		public:
 			virtual Program *CreateProgram(const MaterialDescriptor &);
 			virtual void Apply();
-			virtual void Unapply();
 		};
 	}
 }

--- a/src/graphics/gl2/SkyboxMaterial.h
+++ b/src/graphics/gl2/SkyboxMaterial.h
@@ -31,10 +31,6 @@ namespace Graphics {
 				m_program->shininess.Set(fSkyboxFactor * em);
 			}
 
-			virtual void Unapply() {
-				m_program->Unuse();
-			}
-
 			// Skybox multiplier
 			float fSkyboxFactor;
 		};

--- a/src/graphics/gl2/StarfieldMaterial.h
+++ b/src/graphics/gl2/StarfieldMaterial.h
@@ -28,7 +28,6 @@ namespace Graphics {
 
 			virtual void Unapply() {
 				glDisable(GL_VERTEX_PROGRAM_POINT_SIZE_ARB);
-				m_program->Unuse();
 			}
 		};
 	}


### PR DESCRIPTION
After #2697, everything uses shaders for rendering and it's not necessary for materials to call Program::Unuse to clean up. This also makes it possible to avoid binding the same program repeatedly.

And it does actually make a small difference, I go from 5.1 - 5.3ms/frame to 3.4 - 3.6ms/frame in a completely unscientific test.
