### PR TITLE
Compare pointers not contents.

### DIFF
--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -406,7 +406,7 @@ Terrain::Terrain(const SystemBody *body) : m_body(body), m_seed(body->seed), m_r
 					(*pHeightMap) = val;
 					++pHeightMap;
 				}
-				assert(is_equal_general(*pHeightMap, m_heightMap[heightmapPixelArea]));
+				assert(pHeightMap == &m_heightMap[heightmapPixelArea]);
 				//Output("minHMap = (%hd), maxHMap = (%hd)\n", minHMap, maxHMap);
 				break;
 			}
@@ -437,7 +437,7 @@ Terrain::Terrain(const SystemBody *body) : m_body(body), m_seed(body->seed), m_r
 					(*pHeightMap) = val;
 					++pHeightMap;
 				}
-				assert(is_equal_general(*pHeightMap, m_heightMap[heightmapPixelArea]));
+				assert(pHeightMap == &m_heightMap[heightmapPixelArea]);
 				//Output("minHMapScld = (%hu), maxHMapScld = (%hu)\n", minHMapScld, maxHMapScld);
 				break;
 			}


### PR DESCRIPTION
Before we were dereferencing off the end of the array and comparing the contents.
The check itself though was really just to see if we're calculated the extent of the array correctly so instead we should just compare the addresses of the pointers.

@lwho or @jpab I don't have a working Linux machine right now so can't check other platforms.
