### PR TITLE
Determine if system is explored in Sector layer instead of StarSystem.

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -24,7 +24,7 @@
 #include "FileSystem.h"
 #include "graphics/Renderer.h"
 
-static const int  s_saveVersion   = 71;
+static const int  s_saveVersion   = 72;
 static const char s_saveStart[]   = "PIONEER";
 static const char s_saveEnd[]     = "END";
 

--- a/src/galaxy/Sector.h
+++ b/src/galaxy/Sector.h
@@ -40,7 +40,7 @@ public:
 
 	class System {
 	public:
-		System(int x, int y, int z, Uint32 si): customSys(0), population(-1), sx(x), sy(y), sz(z), idx(si) {};
+		System(int x, int y, int z, Uint32 si): customSys(0), population(-1), explored(false), sx(x), sy(y), sz(z), idx(si) {};
 		~System() {};
 
 		// Check that we've had our habitation status set
@@ -54,6 +54,7 @@ public:
 		const CustomSystem *customSys;
 		Faction *faction;
 		fixed population;
+		bool explored;
 
 		vector3f FullPosition() { return Sector::SIZE*vector3f(float(sx), float(sy), float(sz)) + p; };
 		bool IsSameSystem(const SystemPath &b) const {
@@ -70,7 +71,7 @@ private:
 	bool m_factionsAssigned;
 
 	Sector(const SystemPath& path); // Only SectorCache(Job) are allowed to create sectors
-	void GetCustomSystems();
+	void GetCustomSystems(Random& rng);
 	const std::string GenName(System &sys, int si, Random &rand);
 	// sets appropriate factions for all systems in the sector
 	void AssignFactions();

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -1419,13 +1419,7 @@ StarSystem::StarSystem(const SystemPath &path) : m_path(path)
 	Uint32 _init[6] = { m_path.systemIndex, Uint32(m_path.sectorX), Uint32(m_path.sectorY), Uint32(m_path.sectorZ), UNIVERSE_SEED, Uint32(m_seed) };
 	Random rand(_init, 6);
 
-	/*
-	 * 0 - ~500ly from sol: explored
-	 * ~500ly - ~700ly (65-90 sectors): gradual
-	 * ~700ly+: unexplored
-	 */
-	int dist = isqrt(1 + m_path.sectorX*m_path.sectorX + m_path.sectorY*m_path.sectorY + m_path.sectorZ*m_path.sectorZ);
-	m_unexplored = !(((dist <= 90) && ( dist <= 65 || rand.Int32(dist) <= 40)) || Faction::IsHomeSystem(path));
+	m_unexplored = !s->m_systems[m_path.systemIndex].explored;
 
 	m_isCustom = m_hasCustomBodies = false;
 	if (s->m_systems[m_path.systemIndex].customSys) {
@@ -1434,7 +1428,6 @@ StarSystem::StarSystem(const SystemPath &path) : m_path(path)
 		m_numStars = custom->numStars;
 		if (custom->shortDesc.length() > 0) m_shortDesc = custom->shortDesc;
 		if (custom->longDesc.length() > 0) m_longDesc = custom->longDesc;
-		if (!custom->want_rand_explored) m_unexplored = !custom->explored;
 		if (!custom->IsRandom()) {
 			m_hasCustomBodies = true;
 			GenerateFromCustom(s->m_systems[m_path.systemIndex].customSys, rand);


### PR DESCRIPTION
This pulls up determination whether a system is explored from `StarSystem` to `Sector` as that is a high level property of a system. Systems within 65 sectors of Sol are not changed, as they are always set non-randomly to explored. Systems beyond that will change due to the random determination moved from the random generator of `StarSystem` to the one in `Sector`.

Thus, **bumps savegame** and is to be merged together with #2738
