### PR TITLE
VS2012 doesn't support `= delete`.

### DIFF
--- a/src/galaxy/Sector.h
+++ b/src/galaxy/Sector.h
@@ -23,9 +23,6 @@ public:
 	static const float SIZE;
 	~Sector();
 
-	Sector(const Sector&) = delete;
-	Sector& operator=(const Sector&) = delete;
-
 	static float DistanceBetween(RefCountedPtr<const Sector> a, int sysIdxA, RefCountedPtr<const Sector> b, int sysIdxB);
 	static void Init();
 
@@ -67,6 +64,9 @@ public:
 	std::vector<System> m_systems;
 
 private:
+	Sector(const Sector&) {};
+	Sector& operator=(const Sector&) {};
+
 	int sx, sy, sz;
 	bool m_factionsAssigned;
 


### PR DESCRIPTION
It's true, it doesn't.
