### PR TITLE
Support C++11 enum features in scan_enums.py

### DIFF
--- a/scripts/scan_enums.py
+++ b/scripts/scan_enums.py
@@ -311,6 +311,17 @@ def parse_enum(toktype, toktext, tokens, preceding_comment=None):
     else:
         identifier = ''
 
+    if toktype == 'punctuation' and toktext == ':':
+        # C++11 enum with fixed underlying type
+        # FIXME: look up correct grammar for enum underlying type
+        # currently this should match any valid underlying type, but also matches various invalid things
+        # that's ok, because exact syntactic semantic checking is the compiler's job, not the job of scan_enums
+        toktype, toktext = collect_comments(tokens, tag)
+        while toktype == 'keyword' and toktext in ['signed','unsigned','long','short','int','char']:
+            toktype, toktext = collect_comments(tokens, tag)
+        if toktype == 'identifier':
+            toktype, toktext = collect_comments(tokens, tag)
+
     if toktype == 'punctuation' and toktext == '{':
         # comments become part of the enum tag right up until
         # the identifier for the first elements


### PR DESCRIPTION
I haven't checked the formal C++11 spec for this, but I think it should be ok for now. Adds support for enum syntax added in C++11:

```
enum class Foo {};
enum class Foo : int {};
enum Foo : unsigned short int {};
```
