### PR TITLE
Avoid an assert due to a glyph having 0 rows.

### DIFF
--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -328,6 +328,8 @@ TextureFont::Glyph TextureFont::BakeGlyph(Uint32 chr)
 	}
 
 	const FT_BitmapGlyph bmGlyph = FT_BitmapGlyph(ftGlyph);
+	if( 0 == bmGlyph->bitmap.rows )
+		return Glyph();
 
 	if (m_descriptor.outline) {
 		FT_Glyph strokeGlyph;


### PR DESCRIPTION
@robn, I get an assert when I run in Debug or PreRelease on Windows due to a Glyph having 0 rows, or with or anything else. Not sure how or why that happens but this guards against it.

Just wondered if this is ok.
