### PR TITLE
Replace WATER with HYDROGEN as the thruster fuel of choice.

### DIFF
--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -142,7 +142,7 @@ Ship.Refuel = function (self,amount)
     end
     local fuelTankMass = ShipDef[self.shipId].fuelTankMass
     local needed = math.clamp(math.ceil(fuelTankMass - self.fuelMassLeft),0, amount)
-    local removed = self:RemoveEquip('WATER', needed)
+    local removed = self:RemoveEquip('HYDROGEN', needed)
     self:SetFuelPercent(math.clamp(self.fuel + removed * 100 / fuelTankMass, 0, 100))
     return removed
 end

--- a/data/ui/InfoView/EconTrade.lua
+++ b/data/ui/InfoView/EconTrade.lua
@@ -102,7 +102,7 @@ local econTrade = function ()
 	local refuelButton = SmallLabeledButton.New(l.REFUEL)
 
 	local refuelButtonRefresh = function ()
-		if Game.player.fuel == 100 or Game.player:GetEquipCount('CARGO', 'WATER') == 0 then refuelButton.widget:Disable() end
+		if Game.player.fuel == 100 or Game.player:GetEquipCount('CARGO', 'HYDROGEN') == 0 then refuelButton.widget:Disable() end
 		local fuel_percent = Game.player.fuel/100
 		fuelGauge.gauge:SetValue(fuel_percent)
 		fuelGauge.label:SetValue(fuel_percent)


### PR DESCRIPTION
Reduce confusion amongst players, HYDROGEN can be scooped - WATER can't, allows player to carry less of a mix of things.

We have discussed it before on the [forum](http://pioneerspacesim.net/forum/viewtopic.php?f=3&t=159#p1892) and it's recently come up [again ](http://spacesimcentral.com/ssc/topic/4310-the-front-view/) so I've quickly made and tested this change.

Finally gas giant scooping will make a bit more sense once more.
