### PR TITLE
Fix that JobHandles were not removed from JobSet.

### DIFF
--- a/src/JobQueue.cpp
+++ b/src/JobQueue.cpp
@@ -112,7 +112,10 @@ void JobRunner::SetQueueDestroyed()
 }
 
 
-JobHandle::JobHandle(Job* job, JobQueue* queue, JobClient* client) : m_job(job), m_queue(queue), m_client(client)
+//static
+unsigned long long JobHandle::s_nextId(0);
+
+JobHandle::JobHandle(Job* job, JobQueue* queue, JobClient* client) : m_id(++s_nextId), m_job(job), m_queue(queue), m_client(client)
 {
 	assert(!m_job->GetHandle());
 	m_job->SetHandle(this);
@@ -132,12 +135,13 @@ void JobHandle::Unlink()
 		client->RemoveJob(this); // This might delete this JobHandle, so the object must be cleared before
 }
 
-JobHandle::JobHandle(JobHandle&& other) : m_job(other.m_job), m_queue(other.m_queue), m_client(other.m_client)
+JobHandle::JobHandle(JobHandle&& other) : m_id(other.m_id), m_job(other.m_job), m_queue(other.m_queue), m_client(other.m_client)
 {
 	if (m_job) {
 		assert(m_job->GetHandle() == &other);
 		m_job->SetHandle(this);
 	}
+	other.m_id = 0;
 	other.m_job = nullptr;
 	other.m_queue = nullptr;
 	other.m_client = nullptr;
@@ -147,6 +151,7 @@ JobHandle& JobHandle::operator=(JobHandle&& other)
 {
 	if (m_job && m_queue)
 		m_queue->Cancel(m_job);
+	m_id = other.m_id;
 	m_job = other.m_job;
 	m_queue = other.m_queue;
 	m_client = other.m_client;
@@ -154,6 +159,7 @@ JobHandle& JobHandle::operator=(JobHandle&& other)
 		assert(m_job->GetHandle() == &other);
 		m_job->SetHandle(this);
 	}
+	other.m_id = 0;
 	other.m_job = nullptr;
 	other.m_queue = nullptr;
 	other.m_client = nullptr;


### PR DESCRIPTION
During some ongoing tries to unify `Sector` and `StarSystem` caches (don't ask ;)), I noticed a bug in the Jobs implementation:

The `JobHandles` were not properly removed from their `JobSet`, because the pointer to the `Job` was used as a key, but when trying to remove a `JobHandle` it was already tried with `nullptr` as a key (the `JobHandle` had to be cleared before removing it from the `JobSet`, so `JobHandle::m_job` was always `nullptr` at that time). So, a `JobSet` would accumulate "empty" `JobHandles`. Not really critical, but not nice, either.

I solved that by giving `JobHandles` a unique ID and making `JobSet` a real set based on this ID.

I wondered, if `JobHandle::s_nextId` should be atomic, but I think it can only be used from the main thread, so made it a normal variable.

@fluffyfreak: You're a bit familiar with that code. Could you give it a short look, please (and while you're at it try to compile with MSVC, though there shouldn't be anything problematic in there ;)).
