### PR TITLE
Fix duplication of cargo during cargo scooping

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -413,6 +413,7 @@ bool Ship::OnCollision(Object *b, Uint32 flags, double relVel)
 	// hitting cargo scoop surface shouldn't do damage
 	if ((m_equipment.Get(Equip::SLOT_CARGOSCOOP) != Equip::NONE) &&
 			b->IsType(Object::CARGOBODY) &&
+			!dynamic_cast<Body*>(b)->IsDead() &&
 			m_stats.free_capacity) {
 		Equip::Type item = dynamic_cast<CargoBody*>(b)->GetCargoType();
 		Pi::game->GetSpace()->KillBody(dynamic_cast<Body*>(b));


### PR DESCRIPTION
For #2644.

When the cargo scoop triggers (in `Ship::OnCollision`), the cargo is 'killed'. However, killing an object doesn't actually remove it from the collision data structure, so it's possible for the cargo to generate another collision against the ship, which results in the scoop triggering again and the cargo being duplicated in the ship's hold.

This just adds an IsDead() check to prevent that. It would probably be better to do more work when a body is killed, so that it gets removed from collision structures and so on, but that would need much more extensive checking to ensure it doesn't break other things.
