### PR TITLE
more info on ship stats in ship market

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -615,6 +615,10 @@
       "description" : "",
       "message" : "Minimum crew"
    },
+   "MISSILE_MOUNTS" : {
+      "description" : "",
+      "message" : "Missile mounts"
+   },
    "MISSIONS" : {
       "description" : "",
       "message" : "Missions"
@@ -682,6 +686,10 @@
    "NOT_ENOUGH_ALLOY_TO_ATTEMPT_A_REPAIR" : {
       "description" : "",
       "message" : "Not enough {alloy} to attempt a repair"
+   },
+   "NO" : {
+      "description" : "Negative answer to a question",
+      "message" : "No"
    },
    "NO_MISSIONS" : {
       "description" : "",
@@ -1014,6 +1022,10 @@
    "WE_HAVE_NO_BUSINESS_WITH_YOU" : {
       "description" : "",
       "message" : "We have no business with you at the moment."
+   },
+   "YES" : {
+      "description" : "Positive answer to a question",
+      "message" : "Yes"
    },
    "YOURE_GOING_TO_REGRET_SACKING_ME" : {
       "description" : "",

--- a/data/ui/StationView/ShipMarket.lua
+++ b/data/ui/StationView/ShipMarket.lua
@@ -115,6 +115,15 @@ local function buyShip (sos)
 
 end
 
+local yes_no = function (binary)
+	if binary == 1 then
+		return l.YES
+	elseif binary == 0 then
+		return l.NO
+	else error("argument to yes_no not 0 or 1")
+	end
+end
+
 local currentShipOnSale
 
 shipTable.onRowClicked:Connect(function (row)
@@ -172,6 +181,10 @@ shipTable.onRowClicked:Connect(function (row)
 							:AddRow({l.MAXIMUM_CREW,        def.maxCrew})
 							:AddRow({l.WEIGHT_FULLY_LOADED, Format.MassTonnes(def.hullMass+def.capacity+def.fuelTankMass)})
 							:AddRow({l.FUEL_WEIGHT,         Format.MassTonnes(def.fuelTankMass)})
+							:AddRow({l.MISSILE_MOUNTS,      def.equipSlotCapacity["MISSILE"]})
+							:AddRow({lcore.ATMOSPHERIC_SHIELDING, yes_no(def.equipSlotCapacity["ATMOSHIELD"])})
+							:AddRow({lcore.FUEL_SCOOP,            yes_no(def.equipSlotCapacity["FUELSCOOP"])})
+							:AddRow({lcore.CARGO_SCOOP,           yes_no(def.equipSlotCapacity["CARGOSCOOP"])})
 					})
 			),
 		})


### PR DESCRIPTION
Fixes #1733

I know this will be redone at some point, but until then we need this information when buying ships.

I'm putting it up for review here, because I suspect the way I'm using the language resources are less than pretty, but this way one does not have to translate "atmospheric shields" "fuel scoop" etc. twice (and risking different translation for the same item). However, for "missile mounts" a new string was needed. 

![ba5](https://cloud.githubusercontent.com/assets/619390/2614422/eb538838-bbe6-11e3-9787-f759698dd1f6.png)
