### PR TITLE
Unicode fix for VS2013

### DIFF
--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -154,7 +154,13 @@ const std::string GetOSInfoString()
 	if (name.empty())
 		return hwInfo + s_NoOSIdentified;
 
+#ifdef UNICODE
+	// Visual Studio WCHAR->std::string funtasticness
+	std::wstring ws( osv.szCSDVersion );
+	std::string patchName( ws.begin(), ws.end() );
+#else
 	std::string patchName(osv.szCSDVersion);
+#endif
 
 	if (patchName.empty())
 		return hwInfo + name;


### PR DESCRIPTION
VS2013 compiles with Unicode set so needs to handle Windows functions returning WCHAR's instead of char.

@robn is this ok for MINGW?
