### PR TITLE
Really fix os win32

### DIFF
--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -11,6 +11,10 @@
 #include <wchar.h>
 #include <windows.h>
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4996)
+#endif
+
 namespace OS {
 
 	namespace {


### PR DESCRIPTION
Use the ASCII version of GetVersionEx(A) also disable the deprecation warning that GetVersionExA gives when compiling under VS2013
