### PR TITLE
Update German translation

### DIFF
--- a/data/lang/core/de.json
+++ b/data/lang/core/de.json
@@ -53,7 +53,7 @@
    },
    "ATMOSPHERIC_SHIELDING" : {
       "description" : "",
-      "message" : "Atmosphären Hitzeschild"
+      "message" : "Atmosphären-Hitzeschild"
    },
    "ATMOSPHERIC_SHIELDING_DESCRIPTION" : {
       "description" : "",
@@ -69,7 +69,7 @@
    },
    "AUTOPILOT_DESCRIPTION" : {
       "description" : "",
-      "message" : "Ein on-board Flugcomputer."
+      "message" : "Ein on-board-Flugcomputer."
    },
    "AUTOPILOT_DOCK_WITH_STATION" : {
       "description" : "",
@@ -113,7 +113,7 @@
    },
    "BODIES" : {
       "description" : "",
-      "message" : "Körper"
+      "message" : "Körpern"
    },
    "BODY" : {
       "description" : "",
@@ -161,11 +161,11 @@
    },
    "CARBON_ORE" : {
       "description" : "",
-      "message" : "Kohlenstoff Erz"
+      "message" : "Kohlenstofferz"
    },
    "CARBON_ORE_DESCRIPTION" : {
       "description" : "",
-      "message" : "Kohlenstoff Erze (Kohle und Öl) sind für die Synthese von vielen nützlichen Chemikalien, darunter Kunststoffe, synthetische Lebensmittel, Pharmazeutika und Textilien erforderlich."
+      "message" : "Kohlenstofferze (Kohle und Öl) sind für die Synthese von vielen nützlichen Chemikalien, darunter Kunststoffe, synthetische Lebensmittel, Pharmazeutika und Textilien erforderlich."
    },
    "CARGO" : {
       "description" : "",
@@ -177,7 +177,7 @@
    },
    "CARGO_LIFE_SUPPORT" : {
       "description" : "",
-      "message" : "Frachtraum Lebensterhaltung"
+      "message" : "Frachtraum-Lebenserhaltung"
    },
    "CARGO_LIFE_SUPPORT_DESCRIPTION" : {
       "description" : "",
@@ -265,7 +265,7 @@
    },
    "COUNT_STARPORTS" : {
       "description" : "",
-      "message" : "raumhäfen"
+      "message" : "Raumhäfen"
    },
    "CO_ATMOSPHERE" : {
       "description" : "",
@@ -293,7 +293,7 @@
    },
    "DECREASE_SET_SPEED" : {
       "description" : "",
-      "message" : "Gesetzten Geschwindigkeit verringern"
+      "message" : "Gesetzte Geschwindigkeit verringern"
    },
    "DEMOGRAPHICS" : {
       "description" : "",
@@ -333,11 +333,11 @@
    },
    "DRAW_OUT_RANGE_LABELS" : {
       "description" : "",
-      "message" : "Out-of-range System"
+      "message" : "Systeme außerhalb der Reichweite beschriften"
    },
    "DRAW_UNINHABITED_LABELS" : {
       "description" : "",
-      "message" : "Unbewohntes System"
+      "message" : "Unbewohnte Systeme beschriften"
    },
    "DRAW_VERTICAL_LINES" : {
       "description" : "",
@@ -345,55 +345,55 @@
    },
    "DRIVE_CLASS1" : {
       "description" : "",
-      "message" : "Klasse 1 Sprungtriebwerk"
+      "message" : "Klasse-1-Sprungtriebwerk"
    },
    "DRIVE_CLASS2" : {
       "description" : "",
-      "message" : "Klasse 2 Sprungtriebwerk"
+      "message" : "Klasse-2-Sprungtriebwerk"
    },
    "DRIVE_CLASS3" : {
       "description" : "",
-      "message" : "Klasse 3 Sprungtriebwerk"
+      "message" : "Klasse-3-Sprungtriebwerk"
    },
    "DRIVE_CLASS4" : {
       "description" : "",
-      "message" : "Klasse 4 Sprungtriebwerk"
+      "message" : "Klasse-4-Sprungtriebwerk"
    },
    "DRIVE_CLASS5" : {
       "description" : "",
-      "message" : "Klasse 5 Sprungtriebwerk"
+      "message" : "Klasse-5-Sprungtriebwerk"
    },
    "DRIVE_CLASS6" : {
       "description" : "",
-      "message" : "Klasse 6 Sprungtriebwerk"
+      "message" : "Klasse-6-Sprungtriebwerk"
    },
    "DRIVE_CLASS7" : {
       "description" : "",
-      "message" : "Klasse 7 Sprungtriebwerk"
+      "message" : "Klasse-7-Sprungtriebwerk"
    },
    "DRIVE_CLASS8" : {
       "description" : "",
-      "message" : "Klasse 8 Sprungtriebwerk"
+      "message" : "Klasse-8-Sprungtriebwerk"
    },
    "DRIVE_CLASS9" : {
       "description" : "",
-      "message" : "Klasse 9 Sprungtriebwerk"
+      "message" : "Klasse-9-Sprungtriebwerk"
    },
    "DRIVE_MIL1" : {
       "description" : "",
-      "message" : "Klasse 1 Militär-Hyperraumantrieb"
+      "message" : "Klasse-1-Militär-Hyperraumantrieb"
    },
    "DRIVE_MIL2" : {
       "description" : "",
-      "message" : "Klasse 2 Militär-Hyperraumantrieb"
+      "message" : "Klasse-2-Militär-Hyperraumantrieb"
    },
    "DRIVE_MIL3" : {
       "description" : "",
-      "message" : "Klasse 3 Militär-Hyperraumantrieb"
+      "message" : "Klasse-3-Militär-Hyperraumantrieb"
    },
    "DRIVE_MIL4" : {
       "description" : "",
-      "message" : "Klasse 4 Militär-Hyperraumantrieb"
+      "message" : "Klasse-4-Militär-Hyperraumantrieb"
    },
    "EARTH" : {
       "description" : "",
@@ -405,7 +405,7 @@
    },
    "EARTH_FEDERATION_DEMOCRACY" : {
       "description" : "",
-      "message" : "Erd-Föderation Demokratie"
+      "message" : "Erd-Föderations-Demokratie"
    },
    "ECCENTRICITY" : {
       "description" : "",
@@ -413,7 +413,7 @@
    },
    "ECM_ADVANCED" : {
       "description" : "",
-      "message" : "Erweitertes EGM System"
+      "message" : "Erweitertes EGM-System"
    },
    "ECM_ADVANCED_DESCRIPTION" : {
       "description" : "",
@@ -421,7 +421,7 @@
    },
    "ECM_BASIC" : {
       "description" : "",
-      "message" : "EGM System"
+      "message" : "EGM-System"
    },
    "ECM_BASIC_DESCRIPTION" : {
       "description" : "",
@@ -453,7 +453,7 @@
    },
    "EXTERNAL_VIEW" : {
       "description" : "",
-      "message" : "Aussenansicht"
+      "message" : "Außenansicht"
    },
    "FARM_MACHINERY" : {
       "description" : "",
@@ -509,11 +509,11 @@
    },
    "GALACTIC_VIEW" : {
       "description" : "",
-      "message" : "Galaxie Ansicht"
+      "message" : "Galaxienansicht"
    },
    "GALAXY_SECTOR_VIEW" : {
       "description" : "",
-      "message" : "Sektoren Ansicht"
+      "message" : "Sektorenansicht"
    },
    "GAME_LOAD_CANNOT_OPEN" : {
       "description" : "",
@@ -537,11 +537,11 @@
    },
    "GENERAL_VIEW_CONTROLS" : {
       "description" : "",
-      "message" : "Allgemeine Viewsteuerung"
+      "message" : "Allgemeine Ansichtssteuerung"
    },
    "GOVERNMENT_TYPE" : {
       "description" : "",
-      "message" : "Regierungstyp:"
+      "message" : "Regierungsform:"
    },
    "GRAIN" : {
       "description" : "",
@@ -553,7 +553,7 @@
    },
    "HARD_CAPITALIST" : {
       "description" : "",
-      "message" : "Völlig Kapitalistisch - kein staatliches Sozialsystem"
+      "message" : "Rein kapitalistisch – kein staatliches Sozialsystem"
    },
    "HAT" : {
       "description" : "",
@@ -585,7 +585,7 @@
    },
    "HULL_AUTOREPAIR" : {
       "description" : "",
-      "message" : "Rumpf Auto-Reparatur"
+      "message" : "Rumpf-Auto-Reparatur"
    },
    "HULL_AUTOREPAIR_DESCRIPTION" : {
       "description" : "",
@@ -609,11 +609,11 @@
    },
    "HYPERCLOUD_ANALYZER" : {
       "description" : "",
-      "message" : "Hyperraumwolken Analysator"
+      "message" : "Hyperraumwolkenanalysator"
    },
    "HYPERCLOUD_ANALYZER_DESCRIPTION" : {
       "description" : "",
-      "message" : "Analysiert Hyperraumwolken um den Zeitpunkt der Ankunft oder des Abfluges zu bestimmen."
+      "message" : "Analysiert Hyperraumwolken, um den Zeitpunkt der Ankunft oder des Abfluges zu bestimmen."
    },
    "HYPERSPACE" : {
       "description" : "",
@@ -621,15 +621,15 @@
    },
    "HYPERSPACE_ARRIVAL_CLOUD" : {
       "description" : "",
-      "message" : "Hyperraum Ankuft Wolke"
+      "message" : "Hyperraumankuftswolke"
    },
    "HYPERSPACE_ARRIVAL_CLOUD_REMNANT" : {
       "description" : "",
-      "message" : "Hyperraum Anflugwolkenrest"
+      "message" : "Hyperraumanflugswolkenrest"
    },
    "HYPERSPACE_DEPARTURE_CLOUD" : {
       "description" : "",
-      "message" : "Hyperraum Abflug Wolke"
+      "message" : "Hyperraumabflugswolke"
    },
    "HYPERSPACE_JUMP" : {
       "description" : "",
@@ -641,11 +641,11 @@
    },
    "HYPERSPACE_TARGET" : {
       "description" : "",
-      "message" : "Hyperraumsprung Ziel"
+      "message" : "Hyperraumsprungsziel"
    },
    "HYPERSPACING_IN_N_SECONDS" : {
       "description" : "",
-      "message" : "Hyperraumsprung in %countdown{f.0} Sekunden"
+      "message" : "Hyperraumsprung in %countdown{f.0} Sekunde(n)"
    },
    "H_ATMOSPHERE" : {
       "description" : "",
@@ -669,11 +669,11 @@
    },
    "INCREASE_SET_SPEED" : {
       "description" : "",
-      "message" : "Gesetzten Geschwindigkeit steigern"
+      "message" : "Gesetzte Geschwindigkeit steigern"
    },
    "INDUSTRIAL_COLONY" : {
       "description" : "",
-      "message" : "Industrielle Kolonie."
+      "message" : "Industriekolonie."
    },
    "INDUSTRIAL_HUB_SYSTEM" : {
       "description" : "",
@@ -737,7 +737,7 @@
    },
    "LASER_COOLING_BOOSTER" : {
       "description" : "",
-      "message" : "Laserkühlung Booster"
+      "message" : "Laserkühlungsbooster"
    },
    "LASER_COOLING_BOOSTER_DESCRIPTION" : {
       "description" : "",
@@ -765,7 +765,7 @@
    },
    "LIVE_ANIMALS" : {
       "description" : "",
-      "message" : "Lebende Tiere"
+      "message" : "Lebendige Tiere"
    },
    "LOCKED" : {
       "description" : "",
@@ -793,27 +793,27 @@
    },
    "MAP_TOGGLE_INFO_PANEL" : {
       "description" : "",
-      "message" : "Umschalten Infoansicht"
+      "message" : "Infoansicht umschalten"
    },
    "MAP_TOGGLE_SELECTION_FOLLOW_VIEW" : {
       "description" : "",
-      "message" : "Umschalten Verfolgungsansicht"
+      "message" : "Verfolgungsansicht umschalten"
    },
    "MAP_VIEW_ROTATE_DOWN" : {
       "description" : "",
-      "message" : "Rotierende Ansicht nach unten"
+      "message" : "Ansicht nach unten rotieren"
    },
    "MAP_VIEW_ROTATE_LEFT" : {
       "description" : "",
-      "message" : "Rotierende Ansicht nach Links"
+      "message" : "Ansicht nach links rotieren"
    },
    "MAP_VIEW_ROTATE_RIGHT" : {
       "description" : "",
-      "message" : "Rotierende Ansicht nach Rechts"
+      "message" : "Ansicht nach rechts rotieren"
    },
    "MAP_VIEW_ROTATE_UP" : {
       "description" : "",
-      "message" : "Rotierende Ansicht nach Oben"
+      "message" : "Ansicht nach oben rotieren"
    },
    "MAP_VIEW_SHIFT_BACKWARD" : {
       "description" : "",
@@ -841,15 +841,15 @@
    },
    "MAP_WARP_TO_CURRENT_SYSTEM" : {
       "description" : "",
-      "message" : "Springe ins aktuelle System"
+      "message" : "Ins aktuelle System springen"
    },
    "MAP_WARP_TO_HYPERSPACE_TARGET" : {
       "description" : "",
-      "message" : "Springe zum Hyperraumziel"
+      "message" : "Zum Hyperraumziel springen"
    },
    "MAP_WARP_TO_SELECTED_SYSTEM" : {
       "description" : "",
-      "message" : "Springe zum ausgewählten System"
+      "message" : "Zum ausgewählten System springen"
    },
    "MASS" : {
       "description" : "",
@@ -885,7 +885,7 @@
    },
    "METAL_ORE" : {
       "description" : "",
-      "message" : "Metall Erz"
+      "message" : "Metallerz"
    },
    "MILITARY_DICTATORSHIP" : {
       "description" : "",
@@ -897,7 +897,7 @@
    },
    "MININGCANNON_17MW" : {
       "description" : "",
-      "message" : "17MW Bergbaulaser"
+      "message" : "17MW-Bergbaulaser"
    },
    "MININGCANNON_17MW_DESCRIPTION" : {
       "description" : "",
@@ -905,7 +905,7 @@
    },
    "MINING_COLONY" : {
       "description" : "",
-      "message" : "Bergbaue Kolonie."
+      "message" : "Bergbaukolonie."
    },
    "MINING_MACHINERY" : {
       "description" : "",
@@ -929,19 +929,19 @@
    },
    "MISSILE_GUIDED" : {
       "description" : "",
-      "message" : "Gelenkte Rakete"
+      "message" : "Lenkrakete"
    },
    "MISSILE_NAVAL" : {
       "description" : "",
-      "message" : "Marine Rakete"
+      "message" : "Marinerakete"
    },
    "MISSILE_SMART" : {
       "description" : "",
-      "message" : "Smart Rakete"
+      "message" : "Intelligente Rakete"
    },
    "MISSILE_UNGUIDED" : {
       "description" : "",
-      "message" : "R40 Ungelenkte Rakete"
+      "message" : "Ungelenkte R40-Rakete"
    },
    "MIXED_ECONOMY" : {
       "description" : "",
@@ -1049,7 +1049,7 @@
    },
    "NO_CENTRAL_GOVERNANCE" : {
       "description" : "",
-      "message" : "Ohne zentrale Regierung"
+      "message" : "Ohne Zentralregierung"
    },
    "NO_ESTABLISHED_ORDER" : {
       "description" : "",
@@ -1073,7 +1073,7 @@
    },
    "NUMBER_DECIMAL_POINT" : {
       "description" : "Decimal delimiter used in numbers.",
-      "message" : "."
+      "message" : ","
    },
    "NUMBER_G" : {
       "description" : "",
@@ -1089,11 +1089,11 @@
    },
    "NUMBER_GROUP_SEP" : {
       "description" : "For large number, separator used when grouping digits. E.g. 1,000 or 1 000 or 1'000.",
-      "message" : ","
+      "message" : " "
    },
    "NUMBER_HOURS" : {
       "description" : "",
-      "message" : "%hours{f.1} Std."
+      "message" : "%hours{f.1} h"
    },
    "NUMBER_LY" : {
       "description" : "",
@@ -1101,7 +1101,7 @@
    },
    "NUMBER_TONNES" : {
       "description" : "",
-      "message" : "%{mass}t"
+      "message" : "%{mass} t"
    },
    "N_ATMOSPHERE" : {
       "description" : "",
@@ -1117,7 +1117,7 @@
    },
    "N_DEGREES" : {
       "description" : "",
-      "message" : "%angle{f.1} Grad"
+      "message" : "%angle{f.1}°"
    },
    "N_DISTANCE_TO_TARGET" : {
       "description" : "",
@@ -1129,7 +1129,7 @@
    },
    "N_WHATEVER_MASSES" : {
       "description" : "",
-      "message" : "%mass{f.3} %{units}Massen"
+      "message" : "%mass{f.3} %{units}massen"
    },
    "N_WHATEVER_RADII" : {
       "description" : "",
@@ -1205,11 +1205,11 @@
    },
    "PITCH_DOWN" : {
       "description" : "",
-      "message" : "Nicken nach unten"
+      "message" : "Nach unten nicken"
    },
    "PITCH_UP" : {
       "description" : "",
-      "message" : "Nicken nach oben"
+      "message" : "Nach oben nicken"
    },
    "PLANETARY_INFO" : {
       "description" : "",
@@ -1257,31 +1257,31 @@
    },
    "PULSECANNON_10MW" : {
       "description" : "",
-      "message" : "10MW Pulslaser"
+      "message" : "10MW-Pulslaser"
    },
    "PULSECANNON_1MW" : {
       "description" : "",
-      "message" : "1MW Pulslaser"
+      "message" : "1MW-Pulslaser"
    },
    "PULSECANNON_20MW" : {
       "description" : "",
-      "message" : "20MW Pulslaser"
+      "message" : "20MW-Pulslaser"
    },
    "PULSECANNON_2MW" : {
       "description" : "",
-      "message" : "2MW Pulslaser"
+      "message" : "2MW-Pulslaser"
    },
    "PULSECANNON_4MW" : {
       "description" : "",
-      "message" : "4MW Pulslaser"
+      "message" : "4MW-Pulslaser"
    },
    "PULSECANNON_DUAL_1MW" : {
       "description" : "",
-      "message" : "1MW Doppel-Pulslaser"
+      "message" : "1MW-Doppel-Pulslaser"
    },
    "PULSECANNON_RAPID_2MW" : {
       "description" : "",
-      "message" : "2MW Doppel-Pulslaser"
+      "message" : "2MW-Doppel-Pulslaser"
    },
    "QUADRUPLE_SYSTEM" : {
       "description" : "",
@@ -1289,7 +1289,7 @@
    },
    "RADAR_MAPPER" : {
       "description" : "",
-      "message" : "Radar Scanner"
+      "message" : "Radar-Scanner"
    },
    "RADAR_MAPPER_DESCRIPTION" : {
       "description" : "",
@@ -1337,11 +1337,11 @@
    },
    "ROLL_LEFT" : {
       "description" : "",
-      "message" : "Rollen nach links"
+      "message" : "Nach links rollen"
    },
    "ROLL_RIGHT" : {
       "description" : "",
-      "message" : "Rollen nach rechts"
+      "message" : "Nach rechts rollen"
    },
    "ROTATE_DOWN" : {
       "description" : "",
@@ -1393,7 +1393,7 @@
    },
    "SCREENSHOT_FILENAME_TEMPLATE" : {
       "description" : "",
-      "message" : "Pioneer Screenshot%index{d08}.png"
+      "message" : "Pioneer-Screenshot%index{d08}.png"
    },
    "SCUTUM_CENTAURUS_ARM" : {
       "description" : "",
@@ -1441,11 +1441,11 @@
    },
    "SET_HYPERSPACE_TARGET_TO_FOLLOW_THIS_DEPARTURE" : {
       "description" : "",
-      "message" : "Hyperraumwolken Analysator: Setzen Sie das Hyperraumsprungziel, um diesem Abflug zu folgen."
+      "message" : "Hyperraumwolkenanalysator: Setzen Sie das Hyperraumsprungziel, um diesem Abflug zu folgen."
    },
    "SET_LOW_THRUST_POWER_LEVEL_TO_X_PERCENT" : {
       "description" : "",
-      "message" : "Setze Niedrigschub-Energielevel auf %power%%"
+      "message" : "Niedrigschub-Energielevel auf %power%% setzen"
    },
    "SET_SPEED_KM_S" : {
       "description" : "",
@@ -1457,7 +1457,7 @@
    },
    "SHIELD_ENERGY_BOOSTER" : {
       "description" : "",
-      "message" : "Schildenergie Booster"
+      "message" : "Schildenergie-Booster"
    },
    "SHIELD_ENERGY_BOOSTER_DESCRIPTION" : {
       "description" : "",
@@ -1481,7 +1481,7 @@
    },
    "SHIFT" : {
       "description" : "Shift key on keyboard",
-      "message" : "Shift"
+      "message" : "Umschalt"
    },
    "SHIP" : {
       "description" : "",
@@ -1497,11 +1497,11 @@
    },
    "SHIP_INFORMATION" : {
       "description" : "",
-      "message" : "Raumschiff Information"
+      "message" : "Raumschiffsinformation"
    },
    "SHIP_MASS_N_TONNES" : {
       "description" : "",
-      "message" : "Schiff Masse: %{mass}t"
+      "message" : "Schiffsmasse: %{mass}t"
    },
    "SHIP_NEARBY" : {
       "description" : "",
@@ -1521,7 +1521,7 @@
    },
    "SIMULATING_UNIVERSE_EVOLUTION_N_BYEARS" : {
       "description" : "",
-      "message" : "Simulierte Evolution des Universums: %age{f.1} Milliarde(n) Jahre ;-)"
+      "message" : "Simulierte Evolution des Universums: %age{f.1} Mrd. Jahre ;-)"
    },
    "SLAVES" : {
       "description" : "",
@@ -1545,7 +1545,7 @@
    },
    "SMALL_SCALE_PROSPECTING_NO_SETTLEMENTS" : {
       "description" : "",
-      "message" : "Einzelne Schürfaktivitäten. Keine registrierten Siedlungen."
+      "message" : "Vereinzelte Schürfaktivitäten. Keine registrierten Siedlungen."
    },
    "SOCIAL_DEMOCRACY" : {
       "description" : "",
@@ -1581,7 +1581,7 @@
    },
    "STAR_A" : {
       "description" : "",
-      "message" : "Heißer, weißer Klasse 'A' Stern"
+      "message" : "Heißer, weißer Klasse-A-Stern"
    },
    "STAR_AF_GIANT" : {
       "description" : "",
@@ -1597,7 +1597,7 @@
    },
    "STAR_B" : {
       "description" : "",
-      "message" : "Heller, blauer Klasse 'B' Stern"
+      "message" : "Heller, blauer Klasse-B-Stern"
    },
    "STAR_B_GIANT" : {
       "description" : "",
@@ -1613,23 +1613,23 @@
    },
    "STAR_B_WF" : {
       "description" : "",
-      "message" : "Wolf-Rayet-Stern - Kollapsrisiko"
+      "message" : "Wolf-Rayet-Stern – Kollapsrisiko"
    },
    "STAR_F" : {
       "description" : "",
-      "message" : "Weißer Klasse 'F' Stern"
+      "message" : "Weißer Klasse-F-Stern"
    },
    "STAR_G" : {
       "description" : "",
-      "message" : "Gelber Klasse 'G' Stern"
+      "message" : "Gelber Klasse-G-Stern"
    },
    "STAR_G_GIANT" : {
       "description" : "",
-      "message" : "Gelber Riesenstern - Instabil"
+      "message" : "Gelber Riesenstern – Instabil"
    },
    "STAR_G_HYPER_GIANT" : {
       "description" : "",
-      "message" : "Gelber Hyperriese - Instabil"
+      "message" : "Gelber Hyperriese – Instabil"
    },
    "STAR_G_SUPER_GIANT" : {
       "description" : "",
@@ -1641,15 +1641,15 @@
    },
    "STAR_K" : {
       "description" : "",
-      "message" : "Orangfarbener Klasse 'K' Stern"
+      "message" : "Orange Klasse-K-Stern"
    },
    "STAR_K_GIANT" : {
       "description" : "",
-      "message" : "Orangfarbener Riesenstern - Instabil"
+      "message" : "Orange Riesenstern – Instabil"
    },
    "STAR_K_HYPER_GIANT" : {
       "description" : "",
-      "message" : "Orangfarbener Hyperriese - Instabil"
+      "message" : "Orange Hyperriese – Instabil"
    },
    "STAR_K_SUPER_GIANT" : {
       "description" : "",
@@ -1657,7 +1657,7 @@
    },
    "STAR_M" : {
       "description" : "",
-      "message" : "Roter Klasse 'M' Stern"
+      "message" : "Roter Klasse-M-Stern"
    },
    "STAR_M_GIANT" : {
       "description" : "",
@@ -1673,11 +1673,11 @@
    },
    "STAR_M_WF" : {
       "description" : "",
-      "message" : "Wolf-Rayet-Stern - Instabil"
+      "message" : "Wolf-Rayet-Stern – Instabil"
    },
    "STAR_O" : {
       "description" : "",
-      "message" : "Heißer, großer Klasse 'O' Stern"
+      "message" : "Heißer großer Klasse-O-Stern"
    },
    "STAR_O_GIANT" : {
       "description" : "",
@@ -1693,15 +1693,15 @@
    },
    "STAR_O_WF" : {
       "description" : "",
-      "message" : "Wolf-Rayet-Stern - Kollaps steht unmittelbar bevor"
+      "message" : "Wolf-Rayet-Stern – Kollaps steht unmittelbar bevor"
    },
    "STAR_SM_BH" : {
       "description" : "",
-      "message" : "Supermassereiches Schwarzes Loch"
+      "message" : "Supermassereiches schwarzes Loch"
    },
    "STAR_SYSTEM_INFORMATION" : {
       "description" : "",
-      "message" : "System Informationen"
+      "message" : "Systeminformationen"
    },
    "STAR_S_BH" : {
       "description" : "",
@@ -1713,7 +1713,7 @@
    },
    "SURFACE_GRAVITY" : {
       "description" : "",
-      "message" : "Oberfläche die Schwerkraft"
+      "message" : "Oberfläche der Schwerkraft"
    },
    "SURFACE_TEMPERATURE" : {
       "description" : "",
@@ -1729,7 +1729,7 @@
    },
    "SYSTEM_ORBIT_VIEW" : {
       "description" : "",
-      "message" : "Orbital Ansicht"
+      "message" : "Orbitalansicht"
    },
    "SYSTEM_TYPE" : {
       "description" : "",
@@ -1765,7 +1765,7 @@
    },
    "THRIVING_OUTDOOR_WORLD" : {
       "description" : "",
-      "message" : "Floriende Kolonie unter freien Himmel."
+      "message" : "Florierende Kolonie unter freien Himmel."
    },
    "THRUSTER_DORSAL" : {
       "description" : "",
@@ -1773,7 +1773,7 @@
    },
    "THRUSTER_MAIN" : {
       "description" : "",
-      "message" : "Schub Haupttriebwerk"
+      "message" : "Schub-Haupttriebwerk"
    },
    "THRUSTER_PORT" : {
       "description" : "",
@@ -1781,7 +1781,7 @@
    },
    "THRUSTER_RETRO" : {
       "description" : "",
-      "message" : "Schub Bremsraketen"
+      "message" : "Schub-Bremsraketen"
    },
    "THRUSTER_STARBOARD" : {
       "description" : "",
@@ -1793,7 +1793,7 @@
    },
    "TIME_POINT" : {
       "description" : "",
-      "message" : "Zeitpunkt:"
+      "message" : "Zeitpunkt: "
    },
    "TINY" : {
       "description" : "",
@@ -1805,7 +1805,7 @@
    },
    "TOGGLE_LUA_CONSOLE" : {
       "description" : "",
-      "message" : "Lua-console schalten"
+      "message" : "Lua-Konsole umschalten"
    },
    "TOGGLE_ROTATION_DAMPING" : {
       "description" : "",
@@ -1849,7 +1849,7 @@
    },
    "UNOCCUPIED_CABIN" : {
       "description" : "",
-      "message" : "Extra Passagier-Kabinen"
+      "message" : "Zusätzliche Passagier-Kabinen"
    },
    "UNOCCUPIED_CABIN_DESCRIPTION" : {
       "description" : "",
@@ -1861,7 +1861,7 @@
    },
    "VAST_STRIP_MINE" : {
       "description" : "",
-      "message" : "Riesige Tagebau Kolonie."
+      "message" : "Riesige Tagebaukolonie."
    },
    "VERY_DENSE" : {
       "description" : "",
@@ -1885,7 +1885,7 @@
    },
    "VIOLENT_ANARCHY" : {
       "description" : "",
-      "message" : "Anarchie - Verschiedene bewaffnete Gruppierungen kämpfen um die hoheitliche Kontrolle."
+      "message" : "Anarchie – Verschiedene bewaffnete Gruppierungen kämpfen um die hoheitliche Kontrolle."
    },
    "WATER" : {
       "description" : "",
@@ -1937,11 +1937,11 @@
    },
    "YAW_LEFT" : {
       "description" : "",
-      "message" : "Gieren nach links"
+      "message" : "Nach links gieren"
    },
    "YAW_RIGHT" : {
       "description" : "",
-      "message" : "Gieren nach rechts"
+      "message" : "Nach rechts gieren"
    },
    "YOUNG_FARMING_COLONY" : {
       "description" : "",

--- a/data/lang/module-assassination/de.json
+++ b/data/lang/module-assassination/de.json
@@ -5,27 +5,27 @@
    },
    "COULD_YOU_REPEAT_THE_ORIGINAL_REQUEST" : {
       "description" : "",
-      "message" : "Könntest du die Frage noch einmal wiederholen?"
+      "message" : "Könnten Sie die Frage noch einmal wiederholen?"
    },
    "DENY_0" : {
       "description" : "",
-      "message" : "Sorry, aber ich vertraue dir nicht."
+      "message" : "Sorry, aber ich vertraue Ihnen nicht."
    },
    "DENY_1" : {
       "description" : "",
-      "message" : "Komm wieder, wenn du besser qualifiziert bis."
+      "message" : "Kommen Sie wieder, wenn Sie besser qualifiziert sind."
    },
    "DENY_2" : {
       "description" : "",
-      "message" : "Ich glaube nicht, dass du der bist nach dem ich gesucht habe."
+      "message" : "Ich glaube nicht, dass Sie der, nach dem ich gesucht habe, sind."
    },
    "DENY_3" : {
       "description" : "",
-      "message" : "Du siehst nicht aus, als ob du in der Lage bist zu tun was getun werden muss."
+      "message" : "Sie sehen nicht aus, als ob Sie in der Lage sind, zu tun, was getan werden muss."
    },
    "DENY_4" : {
       "description" : "",
-      "message" : "Du bist eindeutig der falsche für den Job."
+      "message" : "Sie sind eindeutig der Falsche für den Job."
    },
    "DENY_5" : {
       "description" : "",
@@ -33,11 +33,11 @@
    },
    "DENY_6" : {
       "description" : "",
-      "message" : "Noch nie von dir gehört. Für den Vertrag brauche ich jemanden mit Erfahrung."
+      "message" : "Noch nie von Ihnen gehört. Für den Vertrag brauche ich jemanden mit Erfahrung."
    },
    "DENY_7" : {
       "description" : "",
-      "message" : "Der Vertrag ist mir als zu wichtig, als dass ich riskieren würde, dass er von einem Anfänger vermasselt wird."
+      "message" : "Der Vertrag ist mir allzu wichtig, als dass ich riskieren würde, dass er von einem Anfänger vermasselt wird."
    },
    "DISTANCE" : {
       "description" : "",
@@ -49,51 +49,51 @@
    },
    "FLAVOUR_0_ADTEXT" : {
       "description" : "",
-      "message" : "GESUCHT: Entfernung von {target} aus dem {system} System."
+      "message" : "GESUCHT: Entfernung von {target} aus dem »{system}«-System."
    },
    "FLAVOUR_0_FAILUREMSG" : {
       "description" : "",
-      "message" : "Ich bin sehr enttäuscht, dass {target} noch lebt. Den Lohn kannst du dir abschreiben."
+      "message" : "Ich bin sehr enttäuscht, dass {target} noch lebt. Den Lohn können Sie sich abschreiben."
    },
    "FLAVOUR_0_FAILUREMSG2" : {
       "description" : "",
-      "message" : "{target} wurde nicht von dir erledigt. Kein Lohn, vielleicht klappt es ja nächstes mal."
+      "message" : "{target} wurde nicht von Ihnen erledigt. Kein Lohn, vielleicht klappt es ja nächstes Mal."
    },
    "FLAVOUR_0_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, ich bin {name}. Ich werde dich mit {cash} belohnen, wenn du {target} aus dem Weg schaffst."
+      "message" : "Hallo, ich bin {name}. Ich werde Sie mit {cash} belohnen, wenn Sie {target} aus dem Weg schaffen."
    },
    "FLAVOUR_0_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Ich habe die Neuigkeiten über {target}s langen \"Urlaub\" empfangen. Gut gemacht, du wirst deinen Lohn erhalten."
+      "message" : "Ich habe die Neuigkeiten über {target}s langen »Urlaub« empfangen. Gut gemacht, Sie werden Ihren Lohn erhalten."
    },
    "FLAVOUR_1_ADTEXT" : {
       "description" : "",
-      "message" : "GESUCHT: Jemand der {target} aus dem {system} System tötet."
+      "message" : "GESUCHT: Jemand, der {target} aus dem »{system}«-System tötet."
    },
    "FLAVOUR_1_FAILUREMSG" : {
       "description" : "",
-      "message" : "Ich höre, dass {target} in bester Verfassung ist. This pains me."
+      "message" : "Ich höre, dass {target} in bester Verfassung ist. Das kotzt mich an."
    },
    "FLAVOUR_1_FAILUREMSG2" : {
       "description" : "",
-      "message" : "{target}s Ableben entstand nicht durch deine Hand, also frage nicht nach einer Bezahlung."
+      "message" : "{target}s Ableben entstand nicht durch Ihre Hand, also fragen Sie nicht nach einer Bezahlung."
    },
    "FLAVOUR_1_INTROTEXT" : {
       "description" : "",
-      "message" : "Ich will, dass {target} von der Bildfläche verschwindet. Wenn du es schaffst, erhälst du {cash}."
+      "message" : "Ich will, dass {target} von der Bildfläche verschwindet. Wenn Sie es schaffen, erhalten Sie {cash}."
    },
    "FLAVOUR_1_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Mit Trauer hörte ich von {target}s Ableben. Du erhälst deine volle Bezahlung."
+      "message" : "Mit Trauer hörte ich von {target}s Ableben. Sie erhalten Ihre volle Bezahlung."
    },
    "FLAVOUR_2_ADTEXT" : {
       "description" : "",
-      "message" : "ENTFERNUNG: {target} ist im {system} system nicht mehr erwünscht."
+      "message" : "ENTFERNUNG: {target} ist im »{system}«-System nicht mehr erwünscht."
    },
    "FLAVOUR_2_FAILUREMSG" : {
       "description" : "",
-      "message" : "Es ist sehr bedauerlich, dass {target} noch gesund und munter ist. Du hast deinen Auftrag nicht erfüllt, du wirst keinen Lohn erhalten."
+      "message" : "Es ist sehr bedauerlich, dass {target} noch gesund und munter ist. Sie haben Ihren Auftrag nicht erfüllt, Sie werden kein Bezahlung erhalten."
    },
    "FLAVOUR_2_FAILUREMSG2" : {
       "description" : "",
@@ -101,11 +101,11 @@
    },
    "FLAVOUR_2_INTROTEXT" : {
       "description" : "",
-      "message" : "Ich bin {name}, und ich werde dir {cash} zahlen, wenn du {target} eliminierst."
+      "message" : "Ich bin {name}, und ich werde Ihnen {cash} zahlen, wenn Sie {target} eliminieren."
    },
    "FLAVOUR_2_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Du wurdest für den erfolgreichen Abschluss dieses wichtigen Auftrages belohnt."
+      "message" : "Sie wurden für den erfolgreichen Abschluss dieses wichtigen Auftrages belohnt."
    },
    "FLAVOUR_3_ADTEXT" : {
       "description" : "",
@@ -113,19 +113,19 @@
    },
    "FLAVOUR_3_FAILUREMSG" : {
       "description" : "",
-      "message" : "Du wirst es noch bedauern, {target} nicht eleminiert zu haben!"
+      "message" : "Sie werden es noch bedauern, {target} nicht eleminiert zu haben!"
    },
    "FLAVOUR_3_FAILUREMSG2" : {
       "description" : "",
-      "message" : "Du willst Geld für den Job, den jemand anderes gemacht hat? Zieh Leine."
+      "message" : "Sie wollen Geld für den Job, den jemand anderes gemacht hat? Verschwinden Sie!"
    },
    "FLAVOUR_3_INTROTEXT" : {
       "description" : "",
-      "message" : "{target} muss zu Sternenstaub werden. Ich wede dich mit {cash} belohnen, wenn du es tust."
+      "message" : "{target} muss zu Sternenstaub werden. Ich werde Sie mit {cash} belohnen, wenn Sie es tun."
    },
    "FLAVOUR_3_SUCCESSMSG" : {
       "description" : "",
-      "message" : "{target} ist tot. Hier ist deine Belohnung"
+      "message" : "{target} ist tot. Hier ist Ihre Belohnung"
    },
    "FLAVOUR_4_ADTEXT" : {
       "description" : "",
@@ -133,7 +133,7 @@
    },
    "FLAVOUR_4_FAILUREMSG" : {
       "description" : "",
-      "message" : "{target} atmet noch und ich werde dir kein Geld geben."
+      "message" : "{target} atmet noch und ich werde Ihnen kein Geld geben."
    },
    "FLAVOUR_4_FAILUREMSG2" : {
       "description" : "",
@@ -145,7 +145,7 @@
    },
    "FLAVOUR_4_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Neuigkeiten von {target}s Rückzug. Hier ist dein Geld."
+      "message" : "Neuigkeiten von {target}s Rückzug. Hier ist Ihr Geld."
    },
    "FLAVOUR_5_ADTEXT" : {
       "description" : "",
@@ -161,11 +161,11 @@
    },
    "FLAVOUR_5_INTROTEXT" : {
       "description" : "",
-      "message" : "Wir wollen einende von {target}s Karriere im {system} System. Wir sind bereit, {cash} zu zahlen."
+      "message" : "Wir wollen einende von {target}s Karriere im System »{system}«. Wir sind bereit, {cash} zu zahlen."
    },
    "FLAVOUR_5_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Die Nachricht von {target}s Karriereende hat uns erreicht. Hier sind deine {cash}."
+      "message" : "Die Nachricht von {target}s Karriereende hat uns erreicht. Hier sind Ihre {cash}."
    },
    "HANG_UP" : {
       "description" : "",
@@ -177,11 +177,11 @@
    },
    "HOW_WILL_I_BE_PAID" : {
       "description" : "",
-      "message" : "Wie werde ich Bezahlt?"
+      "message" : "Wie werde ich bezahlt?"
    },
    "IT_MUST_BE_DONE_AFTER" : {
       "description" : "",
-      "message" : "Es muss passieren, nachdem {target}  {spaceport} verlässt. Lass dir diese Chance nicht entgehen."
+      "message" : "Es muss passieren, nachdem {target} {spaceport} verlässt. Lassen Sie sich diese Chance nicht entgehen!"
    },
    "LY" : {
       "description" : "",
@@ -189,11 +189,11 @@
    },
    "OK_AGREED" : {
       "description" : "",
-      "message" : "Okay, ich mache das.."
+      "message" : "Okay, ich mache das."
    },
    "RETURN_HERE_ON_THE_COMPLETION_OF_THE_CONTRACT_AND_YOU_WILL_BE_PAID" : {
       "description" : "",
-      "message" : "Komme hierhin zurück, um den Vertrag abzuschließen und deine Belohnung zu bekommen."
+      "message" : "Kommen Sie hierhin zurück, um den Vertrag abzuschließen und Ihre Belohnung zu bekommen."
    },
    "SHIP" : {
       "description" : "",
@@ -201,7 +201,7 @@
    },
    "SHIP_ID" : {
       "description" : "",
-      "message" : "Schiff-ID:"
+      "message" : "Schiffs-ID:"
    },
    "SPACEPORT" : {
       "description" : "",
@@ -325,6 +325,6 @@
    },
    "X_WILL_BE_LEAVING" : {
       "description" : "",
-      "message" : "{target} wird {spaceport} im {system} system ({sectorX}, {sectorY}, {sectorZ}) am Datum {date} verlassen. Das Schiff heißt {shipname} und hat die Registrations-ID {shipregid}."
+      "message" : "{target} wird {spaceport} im »{system}«-System ({sectorX}, {sectorY}, {sectorZ}) am Datum {date} verlassen. Das Schiff heißt »{shipname}« und hat die Registrations-ID {shipregid}."
    }
 }

--- a/data/lang/module-breakdownservicing/de.json
+++ b/data/lang/module-breakdownservicing/de.json
@@ -1,7 +1,7 @@
 {
    "FLAVOUR_0_INTRO" : {
       "description" : "",
-      "message" : "Vermeiden Sie die Unannehmlichkeiten eines kaputten Hyperraum-Antriebs.  Lassen Sie Ihres heute noch überholen, von der offiziell zugelassenen {name} Triebwerksservice-Firma.\n\nEngine: {drive}\nService: {price}\nGuarantee: 18 months\n{lasttime}"
+      "message" : "Vermeiden Sie die Unannehmlichkeiten eines kaputten Hyperraum-Antriebs. Lassen Sie Ihres heute noch überholen, vom offiziell zugelassenen Triebwerkswartungsunternehmen {name}.\n\nTriebwerk: {drive}\nKostenpunkt: {price}\nGarantie: 18 Monate\n{lasttime}"
    },
    "FLAVOUR_0_RESPONSE" : {
       "description" : "",
@@ -9,55 +9,55 @@
    },
    "FLAVOUR_0_TITLE" : {
       "description" : "",
-      "message" : "{name} Triebwerk Service GmbH "
+      "message" : "{name} Triebwerk-Service-GmbH "
    },
    "FLAVOUR_0_YESPLEASE" : {
       "description" : "",
-      "message" : "Überhole Hyperraum-Antrieb"
+      "message" : "Hyperraum-Antrieb überholen lassen"
    },
    "FLAVOUR_1_INTRO" : {
       "description" : "",
-      "message" : "Ich bin {proprietor}.  Ich kann Ihr {drive} überholen und garantiere mindestens ein Jahr problemloses Laufen.  Die Kosen für diesen Service liegen bei {price}.\n{lasttime}"
+      "message" : "Ich bin {proprietor}. Ich kann Ihr {drive} überholen und garantiere mindestens ein Jahr problemloses Laufen. Die Kosen für diese Dienstleistung liegen bei {price}.\n{lasttime}"
    },
    "FLAVOUR_1_RESPONSE" : {
       "description" : "",
-      "message" : "Ihr Hyperraum-Antrieb wurde in Stand gesetzt."
+      "message" : "Ihr Hyperraum-Antrieb wurde instand gesetzt."
    },
    "FLAVOUR_1_TITLE" : {
       "description" : "",
-      "message" : "{proprietor}: Hyperdrive Instandhaltungs-Spezialist"
+      "message" : "{proprietor}: Hyperraumantrieb-Instandhaltungs-Spezialist"
    },
    "FLAVOUR_1_YESPLEASE" : {
       "description" : "",
-      "message" : "Überhole Antrieb"
+      "message" : "Antrieb überholen"
    },
    "FLAVOUR_2_INTRO" : {
       "description" : "",
-      "message" : "Hallo.  Wir bei {proprietor} & Co stehen mit unserem guten Namen für unsere Arbeit.\n\n{lasttime}\nWir können den {drive} ihres Schiffes so abstimmen, dass 12 Monate Problemloses Laufen möglich ist. Das alles gibt es für nur {price}.  Ich werde die Arbeit persönlich überwachen, Sie können also auf eine gut ausgeführte Arbeit zählen."
+      "message" : "Hallo. Wir bei {proprietor} & Co. stehen mit unserem guten Namen für unsere Arbeit.\n\n{lasttime}\nWir können den {drive} ihres Schiffes so abstimmen, dass 12 Monate problemloses Laufen möglich ist. Das alles gibt es für nur {price}. Ich werde die Arbeit persönlich überwachen, Sie können also auf eine gut ausgeführte Arbeit zählen."
    },
    "FLAVOUR_2_RESPONSE" : {
       "description" : "",
-      "message" : "Die Arbeiten sind vollendet.  Danke, dass Sie sich für uns entschieden haben."
+      "message" : "Die Arbeiten sind vollendet. Danke, dass Sie sich für uns entschieden haben."
    },
    "FLAVOUR_2_TITLE" : {
       "description" : "",
-      "message" : "{proprietor} & Co HyperMechanik"
+      "message" : "{proprietor} & Co. HyperMechanik"
    },
    "FLAVOUR_2_YESPLEASE" : {
       "description" : "",
-      "message" : "Bitte stimmen sie meinen Antrieb für den genannten Preis ab."
+      "message" : "Bitte stimmen Sie meinen Antrieb für den genannten Preis ab."
    },
    "FLAVOUR_3_INTRO" : {
       "description" : "",
-      "message" : "Wilkommen SuperFix Instandhaltung.\n\n{lasttime}\nZeit für Ihren halbjährlichen Check? Lassen Sie uns von uns Ihren Hyperraum-Antrieb SuperFix-en!\nWir können Ihr {drive} für nur {price}.  Nur wir haben den besten Preis!"
+      "message" : "Wilkommen bei SuperFix-Instandhaltung.\n\n{lasttime}\nZeit für Ihren halbjährlichen Check? Lassen Sie uns von uns Ihren Hyperraum-Antrieb SuperFix-en!\nWir können Ihr {drive} für nur {price} warten. Nur wir haben den besten Preis!"
    },
    "FLAVOUR_3_RESPONSE" : {
       "description" : "",
-      "message" : "Ihr SuperFix Service ist fertiggestellt mit SuperFix Garantie!"
+      "message" : "Ihr SuperFix-Service ist fertiggestellt mit der SuperFix-Garantie!"
    },
    "FLAVOUR_3_TITLE" : {
       "description" : "",
-      "message" : "SuperFix Instandhaltung ({name} Ableger)"
+      "message" : "SuperFix Instandhaltung (Ableger: {name})"
    },
    "FLAVOUR_3_YESPLEASE" : {
       "description" : "",
@@ -65,23 +65,23 @@
    },
    "FLAVOUR_4_INTRO" : {
       "description" : "",
-      "message" : "Wilkommen bei Zeit und Raum.\n\nWir sind Spezialisten für Interstellare Antriebe. Alle Instandhaltungsarbeiten haben eine Garantie von 2 Jahren.\n{lasttime}\nServicing your {drive} will cost {price}.  Would you like to proceed?"
+      "message" : "Wilkommen bei Zeit und Raum.\n\nWir sind Spezialisten für Interstellare Antriebe. Alle Instandhaltungsarbeiten haben eine Garantie von 2 Jahren.\n{lasttime}\nDie Wartung von {drive} wird Sie {price} kosten. Möchten Sie diese Dienstleistung in Anspruch nehmen?"
    },
    "FLAVOUR_4_RESPONSE" : {
       "description" : "",
-      "message" : "We have completed the work on your hyperdrive."
+      "message" : "Wir haben die Arbeiten an ihrem Hyperraumantrieb abgeschlossen."
    },
    "FLAVOUR_4_TITLE" : {
       "description" : "",
-      "message" : "Zeit und Raum Triebwerke, Inc."
+      "message" : "Raum-und-Zeit-Triebwerke"
    },
    "FLAVOUR_4_YESPLEASE" : {
       "description" : "",
-      "message" : "Yes, please proceed"
+      "message" : "Ja."
    },
    "FLAVOUR_5_INTRO" : {
       "description" : "",
-      "message" : "Vermeiden Sie die Unannehmlichkeiten eines kaputten Hyperraum-Antriebs.  Lassen Sie Ihres heute noch überholen, von der offiziell zugelassenen {name} Triebwerksservice-Firma.\n\nEngine: {drive}\nService: {price}\nGuarantee: 18 months\n{lasttime}"
+      "message" : "Vermeiden Sie die Unannehmlichkeiten eines kaputten Hyperraum-Antriebs. Lassen Sie Ihren heute noch überholen, von der offiziell zugelassenen {name} Triebwerksservice-Firma.\n\nAntrieb: {drive}\nKostenpunkt: {price}\nGarantie: 18 Monate\n{lasttime}"
    },
    "FLAVOUR_5_RESPONSE" : {
       "description" : "",
@@ -89,11 +89,11 @@
    },
    "FLAVOUR_5_TITLE" : {
       "description" : "",
-      "message" : "{name} Triebwerk Service GmbH "
+      "message" : "{name} Triebwerk-Service-GmbH "
    },
    "FLAVOUR_5_YESPLEASE" : {
       "description" : "",
-      "message" : "Überhole Hyperraum-Antrieb"
+      "message" : "Hyperraum-Antrieb überholen lassen"
    },
    "HANG_UP" : {
       "description" : "",
@@ -105,7 +105,7 @@
    },
    "I_FIXED_THE_HYPERDRIVE_BEFORE_IT_BROKE_DOWN" : {
       "description" : "",
-      "message" : "Ich habe das Hyperdrive repariert bevor es kaputt ging."
+      "message" : "Ich habe den Hyperraumantrieb repariert, bevor er kaputt ging."
    },
    "THE_SHIPS_HYPERDRIVE_HAS_BEEN_DESTROYED_BY_A_MALFUNCTION" : {
       "description" : "",
@@ -117,14 +117,14 @@
    },
    "YOUR_DRIVE_WAS_LAST_SERVICED_ON" : {
       "description" : "",
-      "message" : "Der Antrieb wurde zuletzt am {date} von {company} überholt"
+      "message" : "Der Antrieb wurde zuletzt am {date} von {company} gewartet"
    },
    "YOU_DO_NOT_HAVE_A_DRIVE_TO_SERVICE" : {
       "description" : "",
-      "message" : "Es ist kein Antrieb vorhanden, der überholt werden könnte!"
+      "message" : "Es ist kein Antrieb vorhanden, der gewartet werden könnte!"
    },
    "YOU_FIXED_THE_HYPERDRIVE_BEFORE_IT_BROKE_DOWN" : {
       "description" : "",
-      "message" : "Du hast das Hyperdrive repariert bevor es kaputt ging"
+      "message" : "Sie haben den Hyperraumantrieb repariert, bevor er kaputt ging"
    }
 }

--- a/data/lang/module-crewcontracts/de.json
+++ b/data/lang/module-crewcontracts/de.json
@@ -5,7 +5,7 @@
    },
    "CREWDETAILSHEETBB" : {
       "description" : "",
-      "message" : "Crew for hire\n\nName: {name}\nErfahrung: {experience}\nLohnforderung: {wage} pro Woche\n\n{response}\n"
+      "message" : "Crewmitglieder auf Arbeitssuche\n\nName: {name}\nErfahrung: {experience}\nLohnforderung: {wage} pro Woche\n\n{response}\n"
    },
    "CREWMEMBER_WAGE_PER_WEEK" : {
       "description" : "",
@@ -13,11 +13,11 @@
    },
    "CREWTESTRESULTSBB" : {
       "description" : "",
-      "message" : "Examination results:\n\nGenerelle Crew-Kompetenzen: {general}%\nTechnik und Reperatur: {engineering}%\nSteuern und Raumflug: {piloting}%\nNavigation und Auswertung: {navigation}%\nSensoren und Abwehr: {sensors}%\nInsgesamtes Testergebnis: {overall}%"
+      "message" : "Testergebnisse:\n\nGenerelle Crew-Kompetenzen: {general}%\nTechnik und Reperatur: {engineering}%\nSteuern und Raumflug: {piloting}%\nNavigation und Auswertung: {navigation}%\nSensoren und Abwehr: {sensors}%\nInsgesamtes Testergebnis: {overall}%"
    },
    "CREW_FOR_HIRE" : {
       "description" : "",
-      "message" : "Suche Anstellung"
+      "message" : "Anstellung gesucht"
    },
    "GO_BACK" : {
       "description" : "",
@@ -61,7 +61,7 @@
    },
    "POTENTIAL_CREW_MEMBERS" : {
       "description" : "",
-      "message" : "Potenzielle Crewmitglieder sind als Arbeitssuchend registriert bei {station}:"
+      "message" : "Die folgenden potentiellen Crewmitglieder sind bei {station} als arbeitssuchend registriert:"
    },
    "SENSORS_AND_DEFENCE" : {
       "description" : "",
@@ -81,7 +81,7 @@
    },
    "SUGGEST_NEW_WEEKLY_WAGE_OF_N" : {
       "description" : "",
-      "message" : "Neuen wöchentlichen Lohn von {newAmount} vorschlagen"
+      "message" : "Neuen Wochenlohn von {newAmount} vorschlagen"
    },
    "THANKS_ILL_GET_SETTLED_ON_BOARD_IMMEDIATELY" : {
       "description" : "",
@@ -105,6 +105,6 @@
    },
    "VETERAN_TIME_SERVED_CREW_MEMBER" : {
       "description" : "",
-      "message" : "Veteran, langzeitiges Crewmitflied"
+      "message" : "Veteran, langzeitiges Crewmitglied"
    }
 }

--- a/data/lang/module-deliverpackage/de.json
+++ b/data/lang/module-deliverpackage/de.json
@@ -1,7 +1,7 @@
 {
    "COULD_YOU_REPEAT_THE_ORIGINAL_REQUEST" : {
       "description" : "",
-      "message" : "Was war nochmal die anfängliche Frage??"
+      "message" : "Was war nochmal die anfängliche Frage?"
    },
    "DANGER" : {
       "description" : "",
@@ -17,35 +17,35 @@
    },
    "DENY_0" : {
       "description" : "",
-      "message" : "Sorry, aber ich glaube nicht, dass ich dir diesen Lieferauftrag anvertrauen kann."
+      "message" : "Sorry, aber ich glaube nicht, dass ich Ihnen diesen Lieferauftrag anvertrauen kann."
    },
    "DENY_1" : {
       "description" : "",
-      "message" : "Komm wieder, wenn du über ein paar Qualifikation verfügst."
+      "message" : "Kommen Sie wieder, wenn Sie über ein paar Qualifikation verfügen."
    },
    "DENY_2" : {
       "description" : "",
-      "message" : "Ich glaube nicht, dass du der Pilot bist nach dem ich gesucht habe."
+      "message" : "Ich glaube nicht, dass Sie der Pilot, nach dem ich gesucht habe, sind."
    },
    "DENY_3" : {
       "description" : "",
-      "message" : "Du siehst nicht aus wie jemand, dem ich diese Lieferung anvertrauen kann."
+      "message" : "Sie sehen nicht aus wie jemand, dem ich diese Lieferung anvertrauen kann."
    },
    "DENY_4" : {
       "description" : "",
-      "message" : "Du bist nicht die Sorte Pilot nach der ich gesucht habe."
+      "message" : "Sie sind nicht die Sorte Pilot, nach der ich gesucht habe."
    },
    "DENY_5" : {
       "description" : "",
-      "message" : "Dir fehlt es eindeutig an Erfahrung für eine so wichtige Lieferung."
+      "message" : "Ihnen fehlt es eindeutig an Erfahrung für eine so wichtige Lieferung."
    },
    "DENY_6" : {
       "description" : "",
-      "message" : "Noch nie von dir gehört. Für die Lieferung brauche ich jemanden mit Erfahrung."
+      "message" : "Noch nie von Ihnen gehört. Für die Lieferung brauche ich jemanden mit Erfahrung."
    },
    "DENY_7" : {
       "description" : "",
-      "message" : "Die Lieferung ist mir als zu wichtig, als dass ich riskieren würde, dass es von einem Anfänger vermasselt wird."
+      "message" : "Die Lieferung ist mir zu wichtig, als dass ich riskieren würde, dass sie von einem Anfänger vermasselt wird."
    },
    "DISTANCE" : {
       "description" : "",
@@ -53,23 +53,23 @@
    },
    "EXCELLENT_I_WILL_LET_THE_RECIPIENT_KNOW_YOU_ARE_ON_YOUR_WAY" : {
       "description" : "",
-      "message" : "Exzellent. Ich werde den Empfänger wissen lassen, dass du auf dem Weg bist."
+      "message" : "Ausgezeichnet! Ich werde den Empfänger wissen lassen, dass Sie auf dem Weg sind."
    },
    "FLAVOUR_0_ADTEXT" : {
       "description" : "",
-      "message" : "AUF DEM WEG zum {system} System? Geld für die Ablieferung eines kleinen Paketes."
+      "message" : "AUF DEM WEG zum »{system}«-System? Geld für die Ablieferung eines kleinen Paketes."
    },
    "FLAVOUR_0_FAILUREMSG" : {
       "description" : "",
-      "message" : "Unakzeptabel! Du hast ewig für die Lieferung gebraucht. Ich werde dich nicht bezahlen."
+      "message" : "Unakzeptabel! Sie haben ewig für die Lieferung gebraucht. Ich werde Sie nicht bezahlen."
    },
    "FLAVOUR_0_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, ich bin {name}. Ich zahle dir {cash}, wenn du dieses kleine Paket für mich bei {starport} im {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly enfernt, ablieferst."
+      "message" : "Hallo, ich bin {name}. Ich zahle Ihnen {cash}, wenn sie dieses kleine Paket für mich bei {starport} im System {system} ({sectorx}, {sectory}, {sectorz}), {dist} Lj enfernt, abliefern."
    },
    "FLAVOUR_0_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für die Lieferung. Du wurdest voll bezahlt."
+      "message" : "Danke für die Lieferung. Sie wurden voll bezahlt."
    },
    "FLAVOUR_0_WHYSOMUCHTEXT" : {
       "description" : "",
@@ -77,19 +77,19 @@
    },
    "FLAVOUR_1_ADTEXT" : {
       "description" : "",
-      "message" : "GESUCHT. Lieferung eines Paketes zum {system} System."
+      "message" : "GESUCHT. Lieferung eines Paketes zum »{system}«-System."
    },
    "FLAVOUR_1_FAILUREMSG" : {
       "description" : "",
-      "message" : "Ich bin frustriert von der späten Lieferung und ich werde dich nicht bezahlen."
+      "message" : "Ich bin frustriert von der späten Lieferung und ich werde Sie nicht bezahlen."
    },
    "FLAVOUR_1_INTROTEXT" : {
       "description" : "",
-      "message" : "Hallo. Ich bin {name}. Ich werde demjenigen {cash} zahlen, der ein Paket für mich nach {starport} im {system} ({sectorx}, {sectory}, {sectorz}) System, in einer Entfernung von {dist} ly bringt."
+      "message" : "Hallo. Ich bin {name}. Ich werde demjenigen {cash} zahlen, der ein Paket für mich nach {starport} im »{system}«-System ({sectorx}, {sectory}, {sectorz}), in einer Entfernung von {dist} Lj, bringt."
    },
    "FLAVOUR_1_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Das Paket wurde empfangen, du wurdest dafür entlohnt."
+      "message" : "Das Paket wurde empfangen, Sie wurden dafür entlohnt."
    },
    "FLAVOUR_1_WHYSOMUCHTEXT" : {
       "description" : "",
@@ -97,39 +97,39 @@
    },
    "FLAVOUR_2_ADTEXT" : {
       "description" : "",
-      "message" : "DRINGEND. Schnelles Schiff gesucht, das ein Paket zum {system} System bringen kann."
+      "message" : "DRINGEND. Schnelles Schiff, das ein Paket zum »{system}«-System bringen kann, gesucht."
    },
    "FLAVOUR_2_FAILUREMSG" : {
       "description" : "",
-      "message" : "Ich denke, ich war ziemlich deutlich, was die deadline angeht und bin über die späte Lieferung sehr enttäuscht. Du wirst nicht bezahlt werden."
+      "message" : "Ich denke, ich war ziemlich deutlich, was den Termin betrifft und bin über die späte Lieferung sehr enttäuscht. Sie werden nicht bezahlt werden."
    },
    "FLAVOUR_2_INTROTEXT" : {
       "description" : "",
-      "message" : "Hallo. Ich bin {name}. Ich werde demjenigen {cash} zahlen, der ein Paket für mich nach {starport} im {system} ({sectorx}, {sectory}, {sectorz}) System, in einer Entfernung von {dist} ly bringt."
+      "message" : "Hallo. Ich bin {name}. Ich werde demjenigen {cash} zahlen, der ein Paket für mich nach {starport} im »{system}«-System ({sectorx}, {sectory}, {sectorz}), in einer Entfernung von {dist} Lj, bringt."
    },
    "FLAVOUR_2_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Du hast deinen vollen Lohn erhalten. Wir danken dir."
+      "message" : "Sie haben Ihren vollen Lohn erhalten. Wir danken Ihnen."
    },
    "FLAVOUR_2_WHYSOMUCHTEXT" : {
       "description" : "",
-      "message" : "Es ist ein Forschungsansatz, der schnell geliefert werden muss. Es muss bis zur deadline geliefert sein, oder wir bekommen keine Zuschüsse."
+      "message" : "Es ist ein Forschungsansatz, der schnell geliefert werden muss. Es muss bis zum vereinbarten Termin geliefert sein, sonst bekommen wir keine Zuschüsse."
    },
    "FLAVOUR_3_ADTEXT" : {
       "description" : "",
-      "message" : "LIEFERUNG. Dokumente zum {system} System. {cash} für einen erfahrenen Piloten."
+      "message" : "LIEFERUNG. Dokumente zum »{system}«-System. {cash} für einen erfahrenen Piloten."
    },
    "FLAVOUR_3_FAILUREMSG" : {
       "description" : "",
-      "message" : "Nutzlos! Ich werde mich nie mehr auf dich stützen! Natürlich werde ich dich nicht bezahlen."
+      "message" : "Nutzlos! Ich werde mich nie mehr auf Sie stützen! Natürlich werde ich Sie nicht bezahlen."
    },
    "FLAVOUR_3_INTROTEXT" : {
       "description" : "",
-      "message" : "Hallo. Ich bin {name}. Ich werde {cash} für ein Schiff zahlen, das ein Paket nach {starport} im {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly entfernt, bringen kann."
+      "message" : "Hallo. Ich bin {name}. Ich werde {cash} für ein Schiff zahlen, das ein Paket nach {starport} im »{system}«-System ({sectorx}, {sectory}, {sectorz}), {dist} Lj entfernt, bringen kann."
    },
    "FLAVOUR_3_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Ich weiß deine püntkliche und diskrete Lieferung zu Schätzen. Du erhälst deinen vollen Lohn."
+      "message" : "Ich weiß Ihre püntkliche und diskrete Lieferung zu schätzen. Sie erhalten Ihren vollen Lohn."
    },
    "FLAVOUR_3_WHYSOMUCHTEXT" : {
       "description" : "",
@@ -137,19 +137,19 @@
    },
    "FLAVOUR_4_ADTEXT" : {
       "description" : "",
-      "message" : "POSTDIENST. Wir brauchen ein Schiff für eine Lieferung zum {system} System."
+      "message" : "POSTDIENST. Wir brauchen ein Schiff für eine Lieferung zum »{system}«-System."
    },
    "FLAVOUR_4_FAILUREMSG" : {
       "description" : "",
-      "message" : "Die Registrierungs-ID deines Schiffes wurde notiert, wir werden all deine späteren Bewerbungen ablehnen."
+      "message" : "Die Registrierungs-ID Ihres Schiffes wurde notiert, wir werden all Ihre späteren Bewerbungen ablehnen."
    },
    "FLAVOUR_4_INTROTEXT" : {
       "description" : "",
-      "message" : "Hallo. Dies ist eine automatische Nachricht vom Bedford und {name} Kurierdienst. Wir zahlen {cash} für eine Lieferung nach {starport} im {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly entfernt."
+      "message" : "Hallo. Dies ist eine automatische Nachricht vom Kurierdienst Bedford und {name}. Wir zahlen {cash} für eine Lieferung nach {starport} im System {system} ({sectorx}, {sectory}, {sectorz}), Entfernung {dist} Lj."
    },
    "FLAVOUR_4_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Ich weiß deine püntkliche und diskrete Lieferung zu Schätzen. Du erhälst deinen vollen Lohn."
+      "message" : "Ich weiß Ihre püntkliche und diskrete Lieferung zu schätzen. Sie erhalten Ihren vollen Lohn."
    },
    "FLAVOUR_4_WHYSOMUCHTEXT" : {
       "description" : "",
@@ -161,15 +161,15 @@
    },
    "FLAVOUR_5_FAILUREMSG" : {
       "description" : "",
-      "message" : "Was ist das? Oh, Du hast so lange gebraucht, dass ich vergessen habe, das überhaupt gesendet zu haben!"
+      "message" : "Was ist das? Oh, Sie haben so lange gebraucht, dass ich vergessen habe, das überhaupt gesendet zu haben!"
    },
    "FLAVOUR_5_INTROTEXT" : {
       "description" : "",
-      "message" : "Ich bin erfreut dich zu treffen. Ich bin {name} und ich biete {cash} für jemanden mit einem Schiff, der mir helfen kann, meine Sachen nach {starport} zu bringen. Keine Eile, das ist nur, was vom Umzug noch übrig ist."
+      "message" : "Ich bin erfreut, Sie zu treffen. Ich bin {name} und ich biete {cash} für jemanden mit einem Schiff, der mir helfen kann, meine Sachen nach {starport} zu bringen. Keine Eile, das ist nur, was vom Umzug noch übrig ist."
    },
    "FLAVOUR_5_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Oh, wunderbar. Ich werde sofort Ausladen. Danke nochmal."
+      "message" : "Oh, wunderbar. Ich werde sofort ausladen. Danke nochmal."
    },
    "FLAVOUR_5_WHYSOMUCHTEXT" : {
       "description" : "",
@@ -181,7 +181,7 @@
    },
    "FLAVOUR_6_FAILUREMSG" : {
       "description" : "",
-      "message" : "Ich hätte es selbst schneller liefern können. Ich werde dich nicht bezahlen."
+      "message" : "Ich hätte es selbst schneller liefern können. Ich werde Sie nicht bezahlen."
    },
    "FLAVOUR_6_INTROTEXT" : {
       "description" : "",
@@ -189,7 +189,7 @@
    },
    "FLAVOUR_6_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für das Paket. Hier ist deine Bezahlung."
+      "message" : "Danke für das Paket. Hier ist Ihre Bezahlung."
    },
    "FLAVOUR_6_WHYSOMUCHTEXT" : {
       "description" : "",
@@ -209,7 +209,7 @@
    },
    "FLAVOUR_7_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Exzellent, wir haben dir den Lohn auf dein Konto überwiesen."
+      "message" : "Exzellent, wir haben Ihnen den Lohn auf Ihr Konto überwiesen."
    },
    "FLAVOUR_7_WHYSOMUCHTEXT" : {
       "description" : "",
@@ -221,15 +221,15 @@
    },
    "FLAVOUR_8_FAILUREMSG" : {
       "description" : "",
-      "message" : "Das Geld wurde für eine SCHNELLE Lieferung versprochen! Ich weigere mich für das hier zu Bezahlen."
+      "message" : "Das Geld wurde für eine SCHNELLE Lieferung versprochen! Ich weigere mich für das hier zu bezahlen."
    },
    "FLAVOUR_8_INTROTEXT" : {
       "description" : "",
-      "message" : "Mein Name ist {name} und dieser Gegenstand muss schnell zu einem Freund nach {starport} geliefert werden, ich werde dir  {cash}, wenn du es in einer angemessenen Zeit dort ablieferst."
+      "message" : "Mein Name ist {name} und dieser Gegenstand muss schnell zu einem Freund nach {starport} geliefert werden, ich werde Ihnen {cash} zahlen, wenn Sie es in einer angemessenen Zeit dort abliefern."
    },
    "FLAVOUR_8_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Ich schätze deine schnelle Lieferung. Ich habe dir den abgemachten Betrag überwiesen."
+      "message" : "Ich schätze Ihre schnelle Lieferung. Ich habe Ihnen den abgemachten Betrag überwiesen."
    },
    "FLAVOUR_8_WHYSOMUCHTEXT" : {
       "description" : "",
@@ -237,11 +237,11 @@
    },
    "FLAVOUR_9_ADTEXT" : {
       "description" : "",
-      "message" : "PACKET-ABWURF. Dringende Auslieferung von verderblichen Waren nach {starport}."
+      "message" : "PAKET-ABWURF. Dringende Auslieferung von verderblichen Waren nach {starport}."
    },
    "FLAVOUR_9_FAILUREMSG" : {
       "description" : "",
-      "message" : "Alles ist verdorben, alles Abfall! Wir können und wollen dich nicht entlohnen."
+      "message" : "Alles ist verdorben, alles Abfall! Wir können und wollen Sie nicht entlohnen."
    },
    "FLAVOUR_9_INTROTEXT" : {
       "description" : "",
@@ -265,7 +265,7 @@
    },
    "IT_COULD_BE_DANGEROUS_YOU_SHOULD_MAKE_SURE_YOURE_ADEQUATELY_PREPARED" : {
       "description" : "",
-      "message" : "Es könnte gefährlich sein, du solltest besser gut ausgerüstet sein."
+      "message" : "Es könnte gefährlich sein, Sie sollten besser gut ausgerüstet sein."
    },
    "IT_MUST_BE_DELIVERED_BY" : {
       "description" : "",
@@ -289,11 +289,11 @@
    },
    "PIRATE_TAUNTS_0" : {
       "description" : "",
-      "message" : "Du wirst es bedauern, dich mit {client} zusammengetan zu haben"
+      "message" : "Sie werden es bedauern, sich mit {client} zusammengetan zu haben."
    },
    "PIRATE_TAUNTS_1" : {
       "description" : "",
-      "message" : "Sieht so aus, als wäre gerade mein Lohnscheck angekommen!"
+      "message" : "Sieht so aus, als wäre gerade mein Gehaltscheck angekommen!"
    },
    "PIRATE_TAUNTS_2" : {
       "description" : "",
@@ -305,7 +305,7 @@
    },
    "PIRATE_TAUNTS_4" : {
       "description" : "",
-      "message" : "Ich bin sicher, man kann damit auf dem Markt ne Menge Kohle machen."
+      "message" : "Ich bin sicher, man kann damit auf dem Markt ’ne Menge Kohle machen."
    },
    "PIRATE_TAUNTS_5" : {
       "description" : "",
@@ -337,11 +337,11 @@
    },
    "THIS_IS_A_VALUABLE_PACKAGE_YOU_SHOULD_KEEP_YOUR_EYES_OPEN" : {
       "description" : "",
-      "message" : "Das ist ein wertvolles Paket, du solltest die Augen offenhalten."
+      "message" : "Das ist ein wertvolles Paket, Sie sollten die Augen offenhalten."
    },
    "THIS_IS_VERY_RISKY_YOU_WILL_ALMOST_CERTAINLY_RUN_INTO_RESISTANCE" : {
       "description" : "",
-      "message" : "Das ist sehr riskant, du wirst mit hoher Wahrscheinlichkeit auf Wiederstand treffen."
+      "message" : "Das ist sehr riskant, Sie werden mit hoher Wahrscheinlichkeit auf Wiederstand treffen."
    },
    "WHY_SO_MUCH_MONEY" : {
       "description" : "",

--- a/data/lang/module-donatetocranks/de.json
+++ b/data/lang/module-donatetocranks/de.json
@@ -1,11 +1,11 @@
 {
    "FLAVOUR_0_MESSAGE" : {
       "description" : "",
-      "message" : "Bitte wähle eine Summe um an die Kirche des Fliegenden Himmel-Spagettimonster zu spenden."
+      "message" : "Bitte wähle eine Summe, um an die Kirche des Fliegenden Himmel-Spagettimonsters zu spenden."
    },
    "FLAVOUR_0_TITLE" : {
       "description" : "",
-      "message" : "SPENDE! Die Kirche des Fliegenden Himmel-Spagettimonster braucht DEIN Geld, um das Wort von Gott zu verbreiten!"
+      "message" : "SPENDE! Die Kirche des Fliegenden Himmel-Spagettimonsters braucht DEIN Geld, um das Wort Gottes zu verbreiten!"
    },
    "FLAVOUR_1_MESSAGE" : {
       "description" : "",
@@ -13,7 +13,7 @@
    },
    "FLAVOUR_1_TITLE" : {
       "description" : "",
-      "message" : "SPENDE. Die Wächter des Freien Geistes appellieren demütig an Ihre Wohltätigkeit, um unsere Klöster zu unterstützen."
+      "message" : "SPENDE. Die Wächter des Freien Geistes appellieren demütig an deine Wohltätigkeit, um unsere Klöster zu unterstützen."
    },
    "FLAVOUR_2_MESSAGE" : {
       "description" : "",
@@ -21,23 +21,23 @@
    },
    "FLAVOUR_2_TITLE" : {
       "description" : "",
-      "message" : "IN SPENDENLAUNE? Die Kriegswaisen-Unterstützung braucht deine Hilfe um die Lebenswichtige Arbeit weiterzuführen."
+      "message" : "IN SPENDENLAUNE? Die Kriegswaisen-Unterstützung braucht Ihre Hilfe, um die lebenswichtige Arbeit weiterzuführen."
    },
    "FLAVOUR_3_MESSAGE" : {
       "description" : "",
-      "message" : "Bitte wähle eine Summe, die du GreenWatch spenden willst, um die Verschmutzung unserer Galaxie zu beenden."
+      "message" : "Bitte wählen Sie eine Summe, die Sie GreenWatch spenden wollen, um die Verschmutzung unserer Galaxie zu beenden."
    },
    "FLAVOUR_3_TITLE" : {
       "description" : "",
-      "message" : "TRAGE BEI. Die Freundde der Galaktischen 'Verbot Militärischer Antriebe' Kampagne braucht dein Geld."
+      "message" : "SPENDE! Die Freunde der Galaktischen Kampagne »Verbot Militärischer Antriebe« braucht Ihr Geld."
    },
    "FLAVOUR_4_MESSAGE" : {
       "description" : "",
-      "message" : "Bitte wähle aus, wie viel du spenden willst."
+      "message" : "Bitte wähle aus, wie viel Sie spenden wollen."
    },
    "FLAVOUR_4_TITLE" : {
       "description" : "",
-      "message" : "SPENDE! Rette unsere Spezies. Stoppe das Massensterben auf neu besiedelten Welten."
+      "message" : "SPENDE! Rette unsere Art. Stoppe das Massensterben auf neu besiedelten Welten."
    },
    "FLAVOUR_5_MESSAGE" : {
       "description" : "",
@@ -61,6 +61,6 @@
    },
    "YOU_DO_NOT_HAVE_ENOUGH_MONEY" : {
       "description" : "",
-      "message" : "Du hast nicht genug Geld."
+      "message" : "Sie haben nicht genug Geld."
    }
 }

--- a/data/lang/module-fuelclub/de.json
+++ b/data/lang/module-fuelclub/de.json
@@ -5,7 +5,7 @@
    },
    "BEGIN_TRADE" : {
       "description" : "",
-      "message" : "Beginne Handel"
+      "message" : "Handel beginnen"
    },
    "FLAVOUR_0_CLUBNAME" : {
       "description" : "",
@@ -13,11 +13,11 @@
    },
    "FLAVOUR_0_MEMBER_INTRO" : {
       "description" : "",
-      "message" : "Du kannst hier Kraftstoffe kaufen und {radioactives} entsorgen."
+      "message" : "Sie können hier Treibstoffe kaufen und {radioactives} entsorgen."
    },
    "FLAVOUR_0_NONMEMBER_INTRO" : {
       "description" : "",
-      "message" : "{clubname} ist eine unabhängige Organisation mit dem Ziel ihren Mitgliedern\ngünstigen Raumschifftreibstoff zur Verfügung zu stellen. Zweigstellen gibt es in der gesamten Galaxis. Die Vorteile einer Mitgliedschaft umfassen:"
+      "message" : "{clubname} ist eine unabhängige Organisation mit dem Ziel, ihren Mitgliedern\ngünstigen Raumschifftreibstoff zur Verfügung zu stellen. Zweigstellen gibt es in der gesamten Galaxis. Die Vorteile einer Mitgliedschaft umfassen:"
    },
    "FLAVOUR_0_WELCOME" : {
       "description" : "",
@@ -53,7 +53,7 @@
    },
    "WE_WILL_ONLY_DISPOSE_OF" : {
       "description" : "",
-      "message" : "Wir werden die gleiche Menge {radioactives} entsorgen, wie du {military_fuel} von uns gekauft hast."
+      "message" : "Wir werden maximal nur so viel {radioactives} entsorgen, wie Sie {military_fuel} von uns gekauft haben."
    },
    "WHAT_CONDITIONS_APPLY" : {
       "description" : "",
@@ -61,14 +61,14 @@
    },
    "YOUR_MEMBERSHIP_APPLICATION_HAS_BEEN_DECLINED" : {
       "description" : "",
-      "message" : "Deine Bewerbung wurde abgelehnt."
+      "message" : "Ihre Bewerbung wurde abgelehnt."
    },
    "YOU_ARE_NOW_A_MEMBER" : {
       "description" : "",
-      "message" : "Du bist nun Mitglied. Die Mitgliedschaft verfällt am {expiry_date}."
+      "message" : "Sie sind nun Mitglied. Die Mitgliedschaft verfällt am {expiry_date}."
    },
    "YOU_MUST_BUY" : {
       "description" : "",
-      "message" : "Du musst unseren {military_fuel} kaufen, bevor wir deine {radioactives} annehmen"
+      "message" : "Sie müssen unseren {military_fuel} kaufen, bevor wir Ihre {radioactives} annehmen"
    }
 }

--- a/data/lang/module-goodstrader/de.json
+++ b/data/lang/module-goodstrader/de.json
@@ -1,19 +1,19 @@
 {
    "GOODS_TRADER_0" : {
       "description" : "",
-      "message" : "Honest {name}'s Handelsplatz"
+      "message" : "Honest {name}s Handelsplatz"
    },
    "GOODS_TRADER_1" : {
       "description" : "",
-      "message" : "{name}'s Kaufladen"
+      "message" : "{name}s Kaufladen"
    },
    "GOODS_TRADER_2" : {
       "description" : "",
-      "message" : "{name}'s Makazin"
+      "message" : "{name}s Makazin"
    },
    "GOODS_TRADER_3" : {
       "description" : "",
-      "message" : "{name}'s Warenbörse"
+      "message" : "{name}s Warenbörse"
    },
    "GOODS_TRADER_4" : {
       "description" : "",

--- a/data/lang/module-newseventcommodity/de.json
+++ b/data/lang/module-newseventcommodity/de.json
@@ -9,7 +9,7 @@
    },
    "FLAVOUR_10_HEADLINE" : {
       "description" : "",
-      "message" : "NACHRICHTEN {date}: Großunternehmen gefährdet Überleben des {system}-Systems!"
+      "message" : "NACHRICHTEN {date}: Großunternehmen gefährdet Überleben des »{system}«-Systems!"
    },
    "FLAVOUR_10_NEWSBODY" : {
       "description" : "Imply high demand of AIR_PROCESSORS commodity. (Prekall as in Rekall, the fictional company from the Schwarzenegger-movie Total Recall (1990)).",
@@ -17,59 +17,59 @@
    },
    "FLAVOUR_11_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE ({date}): Mysteriöses verschwinden von Weidevieh im {system}- System."
+      "message" : "SCHLAGZEILE ({date}): Mysteriöses Verschwinden von Weidevieh im »{system}«-System."
    },
    "FLAVOUR_11_NEWSBODY" : {
       "description" : "Imply high demand of ANIMAL_MEAT.",
-      "message" : "Als hätte eine höhere Macht zugeschlagen, sind die Bauern im {system}- System ({sectorx}, {sectory}, {sectorz}) auf leeren Höfen aufgewacht. \"Es handelt sich hier um den Viehdiebstahl des Jahrhunderts\", berichtet die Polizei."
+      "message" : "Als hätte eine höhere Macht zugeschlagen, sind die Bauern im »{system}«-System ({sectorx}, {sectory}, {sectorz}) auf leeren Höfen aufgewacht. »Es handelt sich hier um den Viehdiebstahl des Jahrhunderts«, berichtet die Polizei."
    },
    "FLAVOUR_12_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE ({date}): Zusammenbruch der Infrastruktur durch Computerfehler im {system}- System."
+      "message" : "SCHLAGZEILE ({date}): Zusammenbruch der Infrastruktur durch Computerfehler im »{system}«-System."
    },
    "FLAVOUR_12_NEWSBODY" : {
       "description" : "Keep clear of the too obvious names Microsoft, or Macrosoft, etc.",
-      "message" : "Ein zerstörerischer Virus lässt die Festplatten aller Nachosoft- Computer im {system}- System ({sectorx}, {sectory}, {sectorz}) schmelzen. Die defekten Teile eignen sich hervorragend als Briefbeschwerer, wie Informatiker verlauten lassen."
+      "message" : "Ein zerstörerischer Virus lässt die Festplatten aller Nachosoft-Computer im System {system} ({sectorx}, {sectory}, {sectorz}) schmelzen. Die defekten Teile eignen sich hervorragend als Briefbeschwerer, wie Informatiker verlauten lassen."
    },
    "FLAVOUR_13_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE ({date}): Roboteraufstand im {system}- System."
+      "message" : "SCHLAGZEILE ({date}): Roboteraufstand im System {system}."
    },
    "FLAVOUR_13_NEWSBODY" : {
       "description" : "Imply that nobody wants to buy ROBOTS anymore.",
-      "message" : "Nun heißt es Mensch gegen Maschine im {system}- System ({sectorx}, {sectory}, {sectorz}), weil Privatkunden wegen \"Verhaltensstörungen\" das Vertrauen in ihre Roboter verlieren."
+      "message" : "Nun heißt es Mensch gegen Maschine im System {system} ({sectorx}, {sectory}, {sectorz}), weil Privatkunden wegen »Verhaltensstörungen« das Vertrauen in ihre Roboter verlieren."
    },
    "FLAVOUR_14_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE ({date}): Jahrtausend- Blackout durch Sonnensturm im {system}- System."
+      "message" : "SCHLAGZEILE ({date}): Jahrtausend-Blackout durch Sonnensturm im »{system}«-System."
    },
    "FLAVOUR_14_NEWSBODY" : {
       "description" : "Avoid using word Tupperware, say tuppenware, blooperware, tooperwar or plastic containers etc. If translation doesn't work, feel free to be creative, as long as it is implying a high demand of PLASTICS.",
-      "message" : "Der systemweite Stromausfall stürzt das {system}- System ({sectorx}, {sectory}, {sectorz}) ins Chaos. Die Menschen stehen Schlange, um die letzten Blubberware- Bestände als Kühlschrank- Ersatz zu ergattern, weil dem Hersteller die Rohstoffe ausgehen."
+      "message" : "Der systemweite Stromausfall stürzt das »{system}«-System ({sectorx}, {sectory}, {sectorz}) ins Chaos. Die Menschen stehen Schlange, um die letzten Blubberware-Bestände als Kühlschrank-Ersatz zu ergattern, weil dem Hersteller die Rohstoffe ausgehen."
    },
    "FLAVOUR_15_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE ({date}): Schwerer Schlag der Polizei gegen Verbrecher- Syndikat im {system}- System, führende Köpfe verhaftet."
+      "message" : "SCHLAGZEILE ({date}): Schwerer Schlag der Polizei gegen Verbrecher-Syndikat im »{system}«-System, führende Köpfe verhaftet."
    },
    "FLAVOUR_15_NEWSBODY" : {
       "description" : "imply high demand of NARCOTICS.",
-      "message" : "Die Regierung des {system}- Systems ({sectorx}, {sectory}, {sectorz}) hofft auf einen Rückgang der Kriminalität, weil seit der Festnahme mehrerer Dealer keine Drogen mehr am Markt sind."
+      "message" : "Die Regierung des »{system}«-Systems ({sectorx}, {sectory}, {sectorz}) hofft auf einen Rückgang der Kriminalität, weil seit der Festnahme mehrerer Dealer keine Drogen mehr am Markt sind."
    },
    "FLAVOUR_16_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE ({date}): Schwerer Unfall beim jährlichen Dampfmaschinentreffen im {system}- System."
+      "message" : "SCHLAGZEILE ({date}): Schwerer Unfall beim jährlichen Dampfmaschinentreffen im »{system}«-System."
    },
    "FLAVOUR_16_NEWSBODY" : {
       "description" : "Imply high demand of FARM_MACHINERY.",
-      "message" : "Während des großen Dampftreffen im {system}-System ({sectorx}, {sectory}, {sectorz}) ist ein Versuch, den Galaktischen Rekord im größten Traktortauziehen zu schlagen, in einer Katastrophe geendet. Ein Teilnehmer verlor die Kontrolle über sein Fahrzeug und zerstörte alle Maschinen der anderen Teilnehmer. Die Verwaltung fürchtet Probleme für lokale Bauern."
+      "message" : "Während des großen Dampftreffen im System {system} ({sectorx}, {sectory}, {sectorz}) ist ein Versuch, den galaktischen Rekord im größten Traktortauziehen zu schlagen, in einer Katastrophe geendet. Ein Teilnehmer verlor die Kontrolle über sein Fahrzeug und zerstörte alle Maschinen der anderen Teilnehmer. Die Verwaltung fürchtet Probleme für lokale Bauern."
    },
    "FLAVOUR_17_HEADLINE" : {
       "description" : "",
-      "message" : "NACHRICHTEN {date}: Neue Reichtümer im {system}-System entdeckt."
+      "message" : "NACHRICHTEN {date}: Neue Reichtümer im »{system}«-System entdeckt."
    },
    "FLAVOUR_17_NEWSBODY" : {
       "description" : "Imply vast abundance of METAL_ORE.",
-      "message" : "Minenarbeiter im {system}-System ({sectorx}, {sectory}, {sectorz}) haben ein Mineralvorkommen von bisher noch nie dagewesener Größe entdeckt."
+      "message" : "Minenarbeiter im »{system}«-System ({sectorx}, {sectory}, {sectorz}) haben ein Mineralvorkommen von bisher noch nie dagewesener Größe entdeckt."
    },
    "FLAVOUR_18_HEADLINE" : {
       "description" : "",
@@ -77,15 +77,15 @@
    },
    "FLAVOUR_18_NEWSBODY" : {
       "description" : "Imply vast demand of CONSUMER_GOODS.",
-      "message" : "Das {system}-System ({sectorx}, {sectory}, {sectorz})  boomt, da Verbraucher mehr Geld haben."
+      "message" : "Das »{system}«-System ({sectorx}, {sectory}, {sectorz}) boomt, da Endverbraucher mehr Geld haben."
    },
    "FLAVOUR_19_HEADLINE" : {
       "description" : "",
-      "message" : "NACHRICHTEN {date}: Es regnet Gold im {system}-System."
+      "message" : "NACHRICHTEN {date}: Es regnet Gold im »{system}«-System."
    },
    "FLAVOUR_19_NEWSBODY" : {
       "description" : "Imply vast abundance of PRECIOUS_METALS.",
-      "message" : "Ein Mann im {system}-System ({sectorx}, {sectory}, {sectorz}) hat mit einer Erfindung seines Uronkels Gold in Platin fusionieren kännen. Wirtschaftswisssenschaftler erwarten eine destabilisation der Wirschaft im System, wenn die Maschine nicht bald einem Defekt erliegt."
+      "message" : "Ein Mann im »{system}«-System ({sectorx}, {sectory}, {sectorz}) hat mit einer Erfindung seines Uronkels Gold in Platin fusionieren können. Wirtschaftswisssenschaftler erwarten eine Destabilisierung der Wirschaft im System, wenn die Maschine nicht bald einem Defekt erliegt."
    },
    "FLAVOUR_1_HEADLINE" : {
       "description" : "",
@@ -93,7 +93,7 @@
    },
    "FLAVOUR_1_NEWSBODY" : {
       "description" : "Imply high demand of BATTLE_WEAPONS. I.e. the word combat is important.",
-      "message" : "Der lang schwelende Konflikt im System {system} ({sectorx}, {sectory}, {sectorz}) eskaliert als die Armee in voller Stärke den Kampf aufnimmt."
+      "message" : "Der lang schwielende Konflikt im System {system} ({sectorx}, {sectory}, {sectorz}) eskaliert, als die Armee in voller Stärke den Kampf aufnimmt."
    },
    "FLAVOUR_20_HEADLINE" : {
       "description" : "",
@@ -101,23 +101,23 @@
    },
    "FLAVOUR_20_NEWSBODY" : {
       "description" : "Imply vast abundance of FERTILIZER. Soylent is a reference to the book/movie Soylent Green.",
-      "message" : "Nachdem System {system} ({sectorx}, {sectory}, {sectorz}) in eine Phase eingetreten ist, welche das Wachstum der gelben Alge des lokalen Gasriesen beschleunigt, war die Ernte für die Düngerfirma Soylent Yellow Inc aussergewöhnlich gut."
+      "message" : "Nachdem das System {system} ({sectorx}, {sectory}, {sectorz}) in eine Phase eingetreten ist, welche das Wachstum der gelben Alge des örtlichen Gasriesen beschleunigt, war die Ernte für die Düngerfirma Soylent Yellow Inc. aussergewöhnlich gut."
    },
    "FLAVOUR_21_HEADLINE" : {
       "description" : "",
-      "message" : "NEWS {date}: Vereinbarung im {system} System unterzeichnet für \"menschlichere\" Kriegsführung."
+      "message" : "NEWS {date}: Vereinbarung im »{system}«-System unterzeichnet für »menschlichere« Kriegsführung."
    },
    "FLAVOUR_21_NEWSBODY" : {
       "description" : "Imply vast abundance of NERVE_GAS.",
-      "message" : "Obwohl die Kriegsparteien im {system} System ({sectorx}, {sectory}, {sectorz}) keine Waffenstillstandsvereinbarung unterzeichnet haben, sind sie sich darüber einig keine chemischen Waffen mehr einzusetzen."
+      "message" : "Obwohl die Kriegsparteien im »{system}«-System ({sectorx}, {sectory}, {sectorz}) keine Waffenstillstandsvereinbarung unterzeichnet haben, sind sie sich darüber einig, keine chemischen Waffen mehr einzusetzen."
    },
    "FLAVOUR_22_HEADLINE" : {
       "description" : "",
-      "message" : "NEWS {date}: Polizei streikt im {system} System. Bürger müssen selbst für die EInhaltung des Gesetzes sorgen."
+      "message" : "NEWS {date}: Polizei streikt im »{system}«-System. Bürger müssen selbst für die EInhaltung des Gesetzes sorgen."
    },
    "FLAVOUR_22_NEWSBODY" : {
       "description" : "Imply high demand of HAND_WEAPONS.",
-      "message" : "In einem Protest gegen aktuelle Budgetkürzungen im {system} System ({sectorx}, {sectory}, {sectorz}) hat die Polizei die Arbeit niedergelegt. Das Schlimmste befürchtend rufen die Bewohner zur Bildung von Bürgerwehren auf und bewaffnen sich mit Heugabeln und Feuerwaffen."
+      "message" : "In einem Protest gegen aktuelle Budgetkürzungen im »{system}«-System ({sectorx}, {sectory}, {sectorz}) hat die Polizei die Arbeit niedergelegt. Das Schlimmste befürchtend rufen die Bewohner zur Bildung von Bürgerwehren auf und bewaffnen sich mit Heugabeln und Feuerwaffen."
    },
    "FLAVOUR_23_HEADLINE" : {
       "description" : "",
@@ -125,11 +125,11 @@
    },
    "FLAVOUR_23_NEWSBODY" : {
       "description" : "Imply high demand of METAL_ALLOYS. Amissionox is a play on words for Victorinox.",
-      "message" : "The new Amissionox Fabrik im {system} System ({sectorx}, {sectory}, {sectorz}) ist nun fertiggestellt und betriebsbereit.S ie wird hochwertige Messer herstellen, die sogar Weltraumstiefel durchschendien können; allerdings rennt die Produktion nicht auf höchsten Niveau, da Materialen zur Messerherstellung fehlen."
+      "message" : "Die neue Amissionox-Fabrik im »{system}«-System ({sectorx}, {sectory}, {sectorz}) ist nun fertiggestellt und betriebsbereit. Sie wird hochwertige Messer, die sogar Weltraumstiefel durchschendien können, herstellen; allerdings läuft die Produktion nicht auf höchsten Niveau, da Materialen zur Messerherstellung fehlen."
    },
    "FLAVOUR_2_HEADLINE" : {
       "description" : "",
-      "message" : "NEWS {date]: Dürre in System {system}. Ernte ruiniert."
+      "message" : "NEWS {date]: Dürre im System {system}. Ernte ruiniert."
    },
    "FLAVOUR_2_NEWSBODY" : {
       "description" : "Hint there will be high demand of GRAIN.",
@@ -141,71 +141,71 @@
    },
    "FLAVOUR_3_NEWSBODY" : {
       "description" : "Imply high demand of FRUIT_AND_VEG.",
-      "message" : "Die Verwaltung des {system}-Systems ({sectorx}, {sectory}, {sectorz}) erhöht den Import um die hohe Nachfrage an pflanzlichen Nahrungmitteln zu befriedigen."
+      "message" : "Die Verwaltung des »{system}«-Systems ({sectorx}, {sectory}, {sectorz}) erhöht den Import um die hohe Nachfrage an pflanzlichen Nahrungmitteln zu befriedigen."
    },
    "FLAVOUR_4_HEADLINE" : {
       "description" : "About mob rivals competing for selling drugs",
-      "message" : "SCHLAGZEILE ({date}): Drogenkrieg im {system}- System. Die Ordnungskräfte bemühen sich, die Kontrolle über die Lage wiederzuerlangen."
+      "message" : "SCHLAGZEILE ({date}): Drogenkrieg im »{system}«-System. Die Ordnungskräfte bemühen sich, die Kontrolle über die Lage wiederzuerlangen."
    },
    "FLAVOUR_4_NEWSBODY" : {
       "description" : "Imply high abundance of NARCOTICS.",
-      "message" : "Der Markt im {system}- System ({sectorx}, {sectory}, {sectorz}) wird durch rivalisierende Drogenbarone, die ihre Vormachtsstellung ausbauen wollen, mit billigen Drogen geflutet."
+      "message" : "Der Markt im »{system}«-System ({sectorx}, {sectory}, {sectorz}) wird durch rivalisierende Drogenbarone, die ihre Vormachtsstellung ausbauen wollen, mit billigen Drogen geflutet."
    },
    "FLAVOUR_5_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE {date}: Sklavenaufstand im {system}- System. Agrarindustrie stillgelegt."
+      "message" : "SCHLAGZEILE {date}: Sklavenaufstand im »{system}«-System. Agrarindustrie stillgelegt."
    },
    "FLAVOUR_5_NEWSBODY" : {
       "description" : "Imply high demand of SLAVES.",
-      "message" : "Arbeiter im {system}- System ({sectorx}, {sectory}, {sectorz}) sprengen mit einem Aufstand ihre Ketten. Sie weigern sich, die Lotus-Feldern zu bearbeiten. Die Wirtschaft kommt zum erliegen, weil keine billigen Arbeitskräfte zur Verfügung stehen."
+      "message" : "Arbeiter im »{system}«-System ({sectorx}, {sectory}, {sectorz}) sprengen mit einem Aufstand ihre Ketten. Sie weigern sich, die Lotusfelder zu bewirtschafften. Die Wirtschaft kommt zum erliegen, weil keine billigen Arbeitskräfte zur Verfügung stehen."
    },
    "FLAVOUR_6_HEADLINE" : {
       "description" : "(Quibble as a derivative of Tribble from Star Trek TOS)",
-      "message" : "SCHLAGZEILE ({date}): Fröhliches Quibble- Festival im {system}- System."
+      "message" : "SCHLAGZEILE ({date}): Fröhliches Quibble-Festival im »{system}«-System."
    },
    "FLAVOUR_6_NEWSBODY" : {
       "description" : "Stress drunken or intoxicated by alcohol, as this will imply high demand of LIQUOR.",
-      "message" : "Der alkoholreiche Festakt im {system}-System ({sectorx}, {sectory}, {sectorz}), zur Huldigung der kleinen, pelzigen Kreatur, wird unvermindert fortgesetzt."
+      "message" : "Der alkoholreiche Festakt im »{system}«-System ({sectorx}, {sectory}, {sectorz}), zur Huldigung der kleinen, pelzigen Wesen, wird unvermindert fortgesetzt."
    },
    "FLAVOUR_7_HEADLINE" : {
       "description" : "",
-      "message" : "NACHRICHTEN {date}: Die Industrie kommt zu einem Halt im {system}-System."
+      "message" : "NACHRICHTEN {date}: Die Industrie kommt zu einem Stillstand im »{system}«-System."
    },
    "FLAVOUR_7_NEWSBODY" : {
       "description" : "Imply demand of INDUSTRIAL_MACHINERY.",
-      "message" : "Maschinenschäden, ausgelöst durch schlechte Wartung, hat einen Ausfall der Industrie im {system}-System ({sectorx}, {sectory}, {sectorz}) ausgelöst."
+      "message" : "Maschinenschäden, ausgelöst durch schlechte Wartung, haben einen Ausfall der Industrie im »{system}«-System ({sectorx}, {sectory}, {sectorz}) ausgelöst."
    },
    "FLAVOUR_8_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE ({date}): Bergbauunglück im {system}- System gemeldet."
+      "message" : "SCHLAGZEILE ({date}): Bergbauunglück im »{system}«-System gemeldet."
    },
    "FLAVOUR_8_NEWSBODY" : {
       "description" : "Imply high demand of MINING_MACHINERY.",
-      "message" : "Der Einsturz einer Mine im {system}- System ({sectorx}, {sectory}, {sectorz}) tötete hunderte Arbeiter und zerstörte wichtige Bergbaumaschinen, die für die Wirtschaft unabdingbar sind."
+      "message" : "Der Einsturz einer Mine im »{system}«-System ({sectorx}, {sectory}, {sectorz}) tötete hunderte Arbeiter und zerstörte wichtige Bergbaumaschinen, die für die Wirtschaft unabdingbar sind."
    },
    "FLAVOUR_9_HEADLINE" : {
       "description" : "",
-      "message" : "SCHLAGZEILE ({date}): Modewahn im {system}- System."
+      "message" : "SCHLAGZEILE ({date}): Modewahn im »{system}«-System."
    },
    "FLAVOUR_9_NEWSBODY" : {
       "description" : "live pets is important, since it implies high demand of LIVE_ANIMALS commodity.",
-      "message" : "Letzter Schrei im {system}- System ({sectorx}, {sectory}, {sectorz}): Lebende Tiere sind das nächste große Ding."
+      "message" : "Letzter Schrei im »{system}«-System ({sectorx}, {sectory}, {sectorz}): Lebende Tiere sind das nächste große Ding."
    },
    "GRATEFUL_GREETING_0" : {
       "description" : "",
-      "message" : "Willkommen Händler! Wir werden Ihnen einen guten Preis für die Lieferung {cargo} zahlen."
+      "message" : "Willkommen, Händler! Wir werden Ihnen einen guten Preis für die Lieferung {cargo} zahlen."
    },
    "GRATEFUL_GREETING_1" : {
       "description" : "",
-      "message" : "Wir sind hocherfreut über eure Ankunft, genauso wie über eure Ladung [cargo}."
+      "message" : "Wir sind hocherfreut über eure Ankunft, genauso wie über eure Ladung {cargo}."
    },
    "GRATEFUL_GREETING_2" : {
       "description" : "",
-      "message" : "Seid gegüßt! Ihr solltet keine Schwierigkeiten haben Eure Ladung {cargo} hier zu verkaufen."
+      "message" : "Seid gegüßt! Ihr solltet keine Schwierigkeiten haben, Eure Ladung {cargo} hier zu verkaufen."
    },
    "GRATEFUL_GREETING_3" : {
       "description" : "",
-      "message" : "Willkommen! Endlich gibt es wieder [cargo}."
+      "message" : "Willkommen! Endlich gibt es wieder {cargo}."
    },
    "GRATEFUL_GREETING_4" : {
       "description" : "",
@@ -217,19 +217,19 @@
    },
    "NEWSPAPER_CIS" : {
       "description" : "",
-      "message" : "Confederate Chronicle"
+      "message" : "Konföderationsnachrichten"
    },
    "NEWSPAPER_FED" : {
       "description" : "",
-      "message" : "Federal Times"
+      "message" : "Föderaler Bote"
    },
    "NEWSPAPER_IMP" : {
       "description" : "",
-      "message" : "Imperial Herald"
+      "message" : "Imperiale Post"
    },
    "NEWSPAPER_IND_0" : {
       "description" : "",
-      "message" : "Pioneer Kurier"
+      "message" : "Pionier-Kurier"
    },
    "NEWSPAPER_IND_1" : {
       "description" : "",
@@ -237,47 +237,47 @@
    },
    "NEWSPAPER_IND_10" : {
       "description" : "",
-      "message" : "Orbital Observer"
+      "message" : "Der Orbit"
    },
    "NEWSPAPER_IND_2" : {
       "description" : "",
-      "message" : "Galactic Post"
+      "message" : "Galaktische Post"
    },
    "NEWSPAPER_IND_3" : {
       "description" : "",
-      "message" : "Die Universal Sun"
+      "message" : "Bild universal"
    },
    "NEWSPAPER_IND_4" : {
       "description" : "",
-      "message" : "Planetary Press"
+      "message" : "Planetare Presse"
    },
    "NEWSPAPER_IND_5" : {
       "description" : "",
-      "message" : "Royal Gazette"
+      "message" : "Staatsanzeiger"
    },
    "NEWSPAPER_IND_6" : {
       "description" : "",
-      "message" : "Universal Mail"
+      "message" : "Universal-Post"
    },
    "NEWSPAPER_IND_7" : {
       "description" : "",
-      "message" : "Daily Express"
+      "message" : "Tages-Express"
    },
    "NEWSPAPER_IND_8" : {
       "description" : "",
-      "message" : "Tellurian Telegraph"
+      "message" : "Tages-Telegraf"
    },
    "NEWSPAPER_IND_9" : {
       "description" : "",
-      "message" : "Satellite Journal"
+      "message" : "Das Satellitenjournal"
    },
    "TITLE_0" : {
       "description" : "",
-      "message" : "{newspaper} - Frisch aus der Presse"
+      "message" : "{newspaper} – Frisch aus der Presse"
    },
    "TITLE_1" : {
       "description" : "",
-      "message" : "{newspaper} - Neuigkeiten"
+      "message" : "{newspaper} – Neuigkeiten"
    },
    "TITLE_2" : {
       "description" : "",
@@ -285,7 +285,7 @@
    },
    "TITLE_3" : {
       "description" : "",
-      "message" : "{newspaper} - Letzte Neuigkeiten"
+      "message" : "{newspaper} – Letzte Neuigkeiten"
    },
    "TITLE_4" : {
       "description" : "",

--- a/data/lang/module-stationrefuelling/de.json
+++ b/data/lang/module-stationrefuelling/de.json
@@ -1,10 +1,10 @@
 {
    "THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH" : {
       "description" : "",
-      "message" : "Dies ist {station}. Du hast nicht genug Geld, um die Dockgebühren von {fee} zu Zahlen. Dein Treibstoff wurde einbehalten."
+      "message" : "Dies ist {station}. Sie haben nicht genug Geld, um die Dockgebühren von {fee} zu zahlen. Ihr Treibstoff wurde einbehalten."
    },
    "WELCOME_ABOARD_STATION_FEE_DEDUCTED" : {
       "description" : "",
-      "message" : "Wilkommen an Bord von {station}. Deine Dock- und Tankgebühren von {fee} wurden abgerechnet."
+      "message" : "Wilkommen an Bord von {station}. Ihre Dock- und Tankgebühren von {fee} wurden abgebucht."
    }
 }

--- a/data/lang/module-statstracking/de.json
+++ b/data/lang/module-statstracking/de.json
@@ -1,10 +1,10 @@
 {
    "PIONEERING_PILOTS_GUILD" : {
       "description" : "",
-      "message" : "Pioneer Piloten Gilde"
+      "message" : "Pioneer-Pilotengilde"
    },
    "WELL_DONE_COMMANDER_YOUR_COMBAT_RATING_HAS_IMPROVED" : {
       "description" : "",
-      "message" : "Sehr gut Commander! Ihre Gefechtseinstufung hat sich verbessert!"
+      "message" : "Sehr gut, Kommandant! Ihre Gefechtseinstufung hat sich verbessert!"
    }
 }

--- a/data/lang/module-system/de.json
+++ b/data/lang/module-system/de.json
@@ -1,10 +1,10 @@
 {
    "YOUR_FUEL_TANK_IS_ALMOST_EMPTY" : {
       "description" : "",
-      "message" : "Dein Treibstofftank ist fast leer."
+      "message" : "Ihr Treibstofftank ist fast leer."
    },
    "YOUR_FUEL_TANK_IS_EMPTY" : {
       "description" : "",
-      "message" : "Dein Treibstofftank ist leer."
+      "message" : "Ihr Treibstofftank ist leer."
    }
 }

--- a/data/lang/module-taxi/de.json
+++ b/data/lang/module-taxi/de.json
@@ -9,11 +9,11 @@
    },
    "CORPORATIONS_10" : {
       "description" : "",
-      "message" : "Bulk Schiffe"
+      "message" : "Bulk-Schiffe"
    },
    "CORPORATIONS_11" : {
       "description" : "",
-      "message" : "Arment Aerodynamik"
+      "message" : "Arment-Aerodynamik"
    },
    "CORPORATIONS_2" : {
       "description" : "",
@@ -25,7 +25,7 @@
    },
    "CORPORATIONS_4" : {
       "description" : "",
-      "message" : "Aquarian Schiffbau"
+      "message" : "Aquaria-Schiffsbau"
    },
    "CORPORATIONS_5" : {
       "description" : "",
@@ -37,11 +37,11 @@
    },
    "CORPORATIONS_7" : {
       "description" : "",
-      "message" : "Marett Raum"
+      "message" : "Marett-Raum"
    },
    "CORPORATIONS_8" : {
       "description" : "",
-      "message" : "Vega Linie"
+      "message" : "Vega-Linie"
    },
    "CORPORATIONS_9" : {
       "description" : "",
@@ -57,39 +57,39 @@
    },
    "DEADLINE" : {
       "description" : "",
-      "message" : "Deadline:"
+      "message" : "Termin:"
    },
    "DENY_0" : {
       "description" : "",
-      "message" : "Tut mir leid, aber ich glaube nicht, dass ich dir meine Sicherheit anvertrauen kann."
+      "message" : "Tut mir leid, aber ich glaube nicht, dass ich Ihnen meine Sicherheit anvertrauen kann."
    },
    "DENY_1" : {
       "description" : "",
-      "message" : "Komm wieder, wenn du besser qualifiziert bist."
+      "message" : "Kommen Sie wieder, wenn Sie besser qualifiziert sind."
    },
    "DENY_2" : {
       "description" : "",
-      "message" : "Ich glaube nicht, dass du der Pilot bist nach dem ich gesucht habe."
+      "message" : "Ich glaube nicht, dass Sie der Pilot, nach dem ich gesucht habe, sind."
    },
    "DENY_3" : {
       "description" : "",
-      "message" : "Du siehst nicht danach aus, als ob du dazu fähig bist Leute zu transportieren."
+      "message" : "Sie sehen nicht danach aus, als ob Sie dazu fähig sind, Leute zu transportieren."
    },
    "DENY_4" : {
       "description" : "",
-      "message" : "Du bist nicht die Sorte Pilot nach der ich gesucht habe."
+      "message" : "Sie snid nicht die Sorte Pilot, nach der ich gesucht habe."
    },
    "DENY_5" : {
       "description" : "",
-      "message" : "Du scheinst zuwenig Erfahrung zu haben für so einen wichtigen Transport."
+      "message" : "Sie scheinen zu wenig Erfahrung für so einen wichtigen Transport zu haben."
    },
    "DENY_6" : {
       "description" : "",
-      "message" : "Von dir habe ich noch nie gehört. Für diese Reise brauche ich jemanden mit Erfahrung."
+      "message" : "Von Ihnen habe ich noch nie gehört. Für diese Reise brauche ich jemanden mit Erfahrung."
    },
    "DENY_7" : {
       "description" : "",
-      "message" : "Ich habe keine Lust mein Leben durch einen Piloten gefährden zu lassen, der keinerlei Qualifikationen hat."
+      "message" : "Ich habe keine Lust, mein Leben durch einen Piloten gefährden zu lassen, der keinerlei Qualifikationen hat."
    },
    "DISTANCE" : {
       "description" : "",
@@ -101,7 +101,7 @@
    },
    "FLAVOUR_0_ADTEXT" : {
       "description" : "",
-      "message" : "GESUCHT: Passage für eine kleine Gruppe zum {system} System. Wir werden {cash} zahlen."
+      "message" : "GESUCHT: Überfahrt einer kleine Gruppe zum »{system}«-System. Wir werden {cash} zahlen."
    },
    "FLAVOUR_0_DANGER" : {
       "description" : "",
@@ -109,7 +109,7 @@
    },
    "FLAVOUR_0_FAILUREMSG" : {
       "description" : "",
-      "message" : "Unakzeptabel! Du hast ewig gebraucht. Für diese Leistung wollen wir dich nicht zahlen."
+      "message" : "Unakzeptabel! Sie haben ewig gebraucht. Für diese Leistung wollen wir Ihnen nicht zahlen."
    },
    "FLAVOUR_0_HOWMANY" : {
       "description" : "",
@@ -117,15 +117,15 @@
    },
    "FLAVOUR_0_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, Ich bin {name} und ich brauche eine Passage für eine kleine Gruppe zum {system} ({sectorx}, {sectory}, {sectorz}) System, eine Strecke von {dist} ly. Ich werde {cash} zahlen."
+      "message" : "Hi, Ich bin {name} und ich brauche eine Überfahrt für eine kleine Gruppe zum System {system} ({sectorx}, {sectory}, {sectorz}), eine Strecke von {dist} Lj. Ich werde {cash} zahlen."
    },
    "FLAVOUR_0_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für die nette Reise. Du wurdest voll bezahlt."
+      "message" : "Danke für die nette Reise. Sie wurden voll bezahlt."
    },
    "FLAVOUR_0_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Wir haben lange genug gewartet - Bringe uns zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Wir haben lange genug gewartet – Bringe uns zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_0_WHYSOMUCH" : {
       "description" : "",
@@ -133,7 +133,7 @@
    },
    "FLAVOUR_10_ADTEXT" : {
       "description" : "",
-      "message" : "SUCHE SCHIFF: Passage auf einem schnellen schiff zum {system} System."
+      "message" : "SUCHE SCHIFF: Überfahrt auf einem schnellen Schiff zum »{system}«-System."
    },
    "FLAVOUR_10_DANGER" : {
       "description" : "",
@@ -141,7 +141,7 @@
    },
    "FLAVOUR_10_FAILUREMSG" : {
       "description" : "",
-      "message" : "Du bist so ein unerfahrener Pilot. Dafür zahle ich nicht."
+      "message" : "Sie sind so ein unerfahrener Pilot. Dafür zahle ich nicht."
    },
    "FLAVOUR_10_HOWMANY" : {
       "description" : "",
@@ -149,15 +149,15 @@
    },
    "FLAVOUR_10_INTROTEXT" : {
       "description" : "",
-      "message" : "Mein Name ist {name}. Ich brauche eine schnelle Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, etwa {dist} ly entfernt von hier. Zahlung ist {cash}."
+      "message" : "Mein Name ist {name}. Ich brauche einen schnellen Flug zum System {system} ({sectorx}, {sectory}, {sectorz}), etwa {dist} Lj entfernt von hier. Zahlung ist {cash}."
    },
    "FLAVOUR_10_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für den schnellen Flug. Hier ist der abgemachte Lohn."
+      "message" : "Danke für den schnellen Flug. Hier ist die abgemachte Bezahlung."
    },
    "FLAVOUR_10_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet. Bring mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_10_WHYSOMUCH" : {
       "description" : "",
@@ -165,7 +165,7 @@
    },
    "FLAVOUR_11_ADTEXT" : {
       "description" : "",
-      "message" : "SCHNELLES SCHIFF: Passage auf einem schnellen Schiff zum {system} System."
+      "message" : "SCHNELLES SCHIFF: Flug auf einem schnellen Schiff zum »{system}«-System."
    },
    "FLAVOUR_11_DANGER" : {
       "description" : "",
@@ -173,7 +173,7 @@
    },
    "FLAVOUR_11_FAILUREMSG" : {
       "description" : "",
-      "message" : "Wegen deiner Inkompetenz werde ich meinem Job verlieren! Also brauche ich dieses Geld dringender als du."
+      "message" : "Wegen Ihrer Inkompetenz werde ich meinen Job verlieren! Also brauche ich dieses Geld dringender als Sie."
    },
    "FLAVOUR_11_HOWMANY" : {
       "description" : "",
@@ -181,15 +181,15 @@
    },
    "FLAVOUR_11_INTROTEXT" : {
       "description" : "",
-      "message" : "Mein Name ist {name}. Ich brauche eine schnelle Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, etwa {dist} ly entfernt von hier. Ich werde {cash} zahlen."
+      "message" : "Mein Name ist {name}. Ich brauche eine schnelle Reise zum »{system}«-System ({sectorx}, {sectory}, {sectorz}), etwa {dist} Lj entfernt von hier. Ich werde {cash} zahlen."
    },
    "FLAVOUR_11_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für den schnellen Flug. Hier ist der abgemachte Lohn."
+      "message" : "Danke für den schnellen Flug. Hier ist die abgemachte Bezahlung."
    },
    "FLAVOUR_11_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bring mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_11_WHYSOMUCH" : {
       "description" : "",
@@ -197,7 +197,7 @@
    },
    "FLAVOUR_12_ADTEXT" : {
       "description" : "",
-      "message" : "BRAUCHE SCHIFF: Passage zum {system} System."
+      "message" : "BRAUCHE SCHIFF: Reise zum »{system}«-System."
    },
    "FLAVOUR_12_DANGER" : {
       "description" : "",
@@ -213,7 +213,7 @@
    },
    "FLAVOUR_12_INTROTEXT" : {
       "description" : "",
-      "message" : "Mein Name ist {name}. Ich brauche eine Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly entfernt von hier. Ich werde {cash} zahlen."
+      "message" : "Mein Name ist {name}. Ich brauch eine Überfahrt zum System {system} ({sectorx}, {sectory}, {sectorz}), {dist} Lj entfernt von hier. Ich werde {cash} zahlen."
    },
    "FLAVOUR_12_SUCCESSMSG" : {
       "description" : "",
@@ -221,7 +221,7 @@
    },
    "FLAVOUR_12_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bring mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_12_WHYSOMUCH" : {
       "description" : "",
@@ -229,7 +229,7 @@
    },
    "FLAVOUR_1_ADTEXT" : {
       "description" : "",
-      "message" : "GESUCHT: Passage für eine kleine Gruppe zum {system} System. Wir werden {cash} zahlen."
+      "message" : "GESUCHT: Reise für eine kleine Gruppe zum »{system}«-System. Wir werden {cash} zahlen."
    },
    "FLAVOUR_1_DANGER" : {
       "description" : "",
@@ -237,7 +237,7 @@
    },
    "FLAVOUR_1_FAILUREMSG" : {
       "description" : "",
-      "message" : "Unakzeptabel! Du hast ewig gebraucht. Für diese Leistung wollen wir dich nicht zahlen."
+      "message" : "Unakzeptabel! Sie haben ewig gebraucht. Für diese Leistung wollen wir Ihnen nicht zahlen."
    },
    "FLAVOUR_1_HOWMANY" : {
       "description" : "",
@@ -245,23 +245,23 @@
    },
    "FLAVOUR_1_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, ich bin {name} und brauche eine Passage für eine kleine Gruppe zum {system} ({sectorx}, {sectory}, {sectorz}) System,  {dist} ly entfernt von hier. Ich werde {cash} zahlen."
+      "message" : "Hi, ich bin {name} und brauche eine Überfahrt für eine kleine Gruppe zum System {system} ({sectorx}, {sectory}, {sectorz}), {dist} L entfernt von hier. Ich werde {cash} zahlen."
    },
    "FLAVOUR_1_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für die nette Reise. Du wurdest voll bezahlt."
+      "message" : "Danke für die nette Reise. Sie wurden voll bezahlt."
    },
    "FLAVOUR_1_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Wir haben lange genug gewartet - Bringe uns zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Wir haben lange genug gewartet – Bring uns zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_1_WHYSOMUCH" : {
       "description" : "",
-      "message" : "Wir arbeiten für {corp} Unternehmen und sie zahlen."
+      "message" : "Wir arbeiten für das Unternehmen {corp} und sie zahlen."
    },
    "FLAVOUR_2_ADTEXT" : {
       "description" : "",
-      "message" : "GESUCHT: Passage für eine kleine Gruppe zum {system} System. Wir werden {cash} zahlen."
+      "message" : "GESUCHT: Flug für eine kleine Gruppe zum »{system}«-System. Wir werden {cash} zahlen."
    },
    "FLAVOUR_2_DANGER" : {
       "description" : "",
@@ -269,7 +269,7 @@
    },
    "FLAVOUR_2_FAILUREMSG" : {
       "description" : "",
-      "message" : "Unakzeptabel! Du hast ewig gebraucht. Für diese Leistung wollen wir dich nicht zahlen."
+      "message" : "Unakzeptabel! Sie haben gebraucht. Für diese Leistung wollen wir Ihnen nicht zahlen."
    },
    "FLAVOUR_2_HOWMANY" : {
       "description" : "",
@@ -277,15 +277,15 @@
    },
    "FLAVOUR_2_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, Ich bin {name} und ich brauche eine Passage für eine kleine Gruppe zum {system} ({sectorx}, {sectory}, {sectorz}) System, das ist eine Entfernung von {dist} ly. Ich werde will {cash} zahlen."
+      "message" : "Hi, Ich bin {name} und ich brauche einen Flug für eine kleine Gruppe zum »{system}«-System ({sectorx}, {sectory}, {sectorz}), das ist eine Entfernung von {dist} Lj. Ich werde {cash} zahlen."
    },
    "FLAVOUR_2_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke, dass du uns hier her gebracht hast. Wir haben dich in voller Höhe bezahlt. Viel Glück!"
+      "message" : "Danke, dass Sie uns hier her gebracht haben. Wir haben Sie in voller Höhe bezahlt. Viel Glück!"
    },
    "FLAVOUR_2_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Wir haben lange genug gewartet - Bringe uns zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Wir haben lange genug gewartet – Bringe uns zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_2_WHYSOMUCH" : {
       "description" : "",
@@ -293,7 +293,7 @@
    },
    "FLAVOUR_3_ADTEXT" : {
       "description" : "",
-      "message" : "BRAUCHE SCHIFF: Passage zum {system} System. Werde {cash} zahlen."
+      "message" : "BRAUCHE SCHIFF: Überfahrt zum »{system}«-System. Werde {cash} zahlen."
    },
    "FLAVOUR_3_DANGER" : {
       "description" : "",
@@ -301,7 +301,7 @@
    },
    "FLAVOUR_3_FAILUREMSG" : {
       "description" : "",
-      "message" : "Unakzeptabel! Du hast ewig gebraucht. Für diese Leistung wollen wir dich nicht zahlen."
+      "message" : "Unakzeptabel! Sie haben ewig gebraucht. Für diese Leistung wollen wir Ihnen nicht zahlen."
    },
    "FLAVOUR_3_HOWMANY" : {
       "description" : "",
@@ -309,23 +309,23 @@
    },
    "FLAVOUR_3_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, Ich bin {name} und ich brauche eine Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly Entfernung. Ich zahle {cash}."
+      "message" : "Hi, Ich bin {name} und ich brauche eine Überfahrt zum »{system}«-System ({sectorx}, {sectory}, {sectorz}), {dist} Lj Entfernung. Ich zahle {cash}."
    },
    "FLAVOUR_3_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke, du hast mir das Leben gerettet. Du wurdest voll bezahlt."
+      "message" : "Danke, Sie haben mir das Leben gerettet. Sie wurden voll bezahlt."
    },
    "FLAVOUR_3_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bringe mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_3_WHYSOMUCH" : {
       "description" : "",
-      "message" : "Ein alter Rivale versucht mich zu ermorden."
+      "message" : "Ein alter Rivale versucht, mich zu ermorden."
    },
    "FLAVOUR_4_ADTEXT" : {
       "description" : "",
-      "message" : "SUCHE SCHIFF: Passage zum {system} System. Ich zahle {cash}."
+      "message" : "SUCHE SCHIFF: Überfahrt zum »{system}«-System. Ich zahle {cash}."
    },
    "FLAVOUR_4_DANGER" : {
       "description" : "",
@@ -333,7 +333,7 @@
    },
    "FLAVOUR_4_FAILUREMSG" : {
       "description" : "",
-      "message" : "Wage es nicht nach einer Belohnung zu fragen! Ich werde dich der Polizei melden."
+      "message" : "Wagen Sie es nicht, nach einer Belohnung zu fragen! Ich werde Sie der Polizei melden."
    },
    "FLAVOUR_4_HOWMANY" : {
       "description" : "",
@@ -341,15 +341,15 @@
    },
    "FLAVOUR_4_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, Ich bin {name} und ich brauche eine Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly Entfernung. Ich zahle {cash}."
+      "message" : "Hi, Ich bin {name} und ich brauche eine Überfahrt zum System {system} ({sectorx}, {sectory}, {sectorz}), {dist} Lj Entfernung. Ich zahle {cash}."
    },
    "FLAVOUR_4_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke, dass du mich hier her gebracht hast. Ich habe dir den Lohn überwiesen. Viel Glück!"
+      "message" : "Danke, dass Sie mich hier her gebracht haben. Ich habe Ihnen das Geld überwiesen. Viel Glück!"
    },
    "FLAVOUR_4_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bringe mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_4_WHYSOMUCH" : {
       "description" : "",
@@ -357,15 +357,15 @@
    },
    "FLAVOUR_5_ADTEXT" : {
       "description" : "",
-      "message" : "GESUCHT: Passage zum {system} System. Ich zahle {cash}."
+      "message" : "GESUCHT: Überfahrt zum »{system}«-System. Ich zahle {cash}."
    },
    "FLAVOUR_5_DANGER" : {
       "description" : "",
-      "message" : "Du wirst vielleicht von der Presse belästigt. Ignoriere sie einfach."
+      "message" : "Sie werden vielleicht von der Presse belästigt. Ignorieren Sie sie einfach."
    },
    "FLAVOUR_5_FAILUREMSG" : {
       "description" : "",
-      "message" : "Was hast du getan? Meine Tour ist versaut und ich habe die Hälfte meiner Fans verloren."
+      "message" : "Was haben Sie getan? Meine Tour ist versaut und ich habe die Hälfte meiner Fans verloren."
    },
    "FLAVOUR_5_HOWMANY" : {
       "description" : "",
@@ -373,23 +373,23 @@
    },
    "FLAVOUR_5_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, Ich bin {name} und ich brauche eine Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly Entfernung. Ich zahle {cash}."
+      "message" : "Hi, Ich bin {name} und ich brauche eine Überfahrt zum System {system} ({sectorx}, {sectory}, {sectorz}), {dist} Lj Entfernung. Ich zahle {cash}."
    },
    "FLAVOUR_5_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für die nette Reise. Du wurdest voll bezahlt."
+      "message" : "Danke für die nette Reise. Sie wurden voll bezahlt."
    },
    "FLAVOUR_5_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bringe mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_5_WHYSOMUCH" : {
       "description" : "",
-      "message" : "Das weißt du nicht? Ich bin ein bekannter Superstar!"
+      "message" : "Das wissen Sie nicht? Ich bin ein bekannter Superstar!"
    },
    "FLAVOUR_6_ADTEXT" : {
       "description" : "",
-      "message" : "BRAUCHE SCHIFF: Passage zum {system} System. Ich zahle {cash}."
+      "message" : "BRAUCHE SCHIFF: Flug zum »{system}«-System. Ich zahle {cash}."
    },
    "FLAVOUR_6_DANGER" : {
       "description" : "",
@@ -397,7 +397,7 @@
    },
    "FLAVOUR_6_FAILUREMSG" : {
       "description" : "",
-      "message" : "Unakzeptabel! Du hast ewig gebraucht. Für diese Leistung wollen wir dich nicht zahlen."
+      "message" : "Unakzeptabel! Sie haben ewig gebraucht. Für diese Leistung wollen wir Ihnen nicht zahlen."
    },
    "FLAVOUR_6_HOWMANY" : {
       "description" : "",
@@ -405,15 +405,15 @@
    },
    "FLAVOUR_6_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, Ich bin {name} und ich brauche eine Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly Entfernung. Ich zahle {cash}."
+      "message" : "Hi, Ich bin {name} und ich brauche einen Flug zum System {system} ({sectorx}, {sectory}, {sectorz}), {dist} Lj Entfernung. Ich zahle {cash}."
    },
    "FLAVOUR_6_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für die nette Reise. Du wurdest voll bezahlt."
+      "message" : "Danke für die nette Reise. Sie wurden voll bezahlt."
    },
    "FLAVOUR_6_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bring mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_6_WHYSOMUCH" : {
       "description" : "",
@@ -421,7 +421,7 @@
    },
    "FLAVOUR_7_ADTEXT" : {
       "description" : "",
-      "message" : "SCHIFF GESUCHT: Sichere Passage zum {system} System. Ich werde {cash} zahlen."
+      "message" : "SCHIFF GESUCHT: Sichere Überfahrt zum »{system}«-System. Ich werde {cash} zahlen."
    },
    "FLAVOUR_7_DANGER" : {
       "description" : "",
@@ -429,7 +429,7 @@
    },
    "FLAVOUR_7_FAILUREMSG" : {
       "description" : "",
-      "message" : "Unakzeptabel! Du hast ewig gebraucht. Für diese Leistung wollen wir dich nicht zahlen."
+      "message" : "Unakzeptabel! Sie haben ewig gebraucht. Für diese Leistung wollen wir nichts zahlen."
    },
    "FLAVOUR_7_HOWMANY" : {
       "description" : "",
@@ -437,15 +437,15 @@
    },
    "FLAVOUR_7_INTROTEXT" : {
       "description" : "",
-      "message" : "Hi, Ich bin {name} und ich brauche eine Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, {dist} ly Entfernung. Ich zahle {cash}."
+      "message" : "Hi, Ich bin {name} und ich brauche eine Überfahrt zum System {system} ({sectorx}, {sectory}, {sectorz}), {dist} Lj Entfernung. Ich zahle {cash}."
    },
    "FLAVOUR_7_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke, dass du mich sicher hierher gebracht hast. Hier ist dein Lohn. Viel Glück!"
+      "message" : "Danke, dass Sie mich sicher hierher gebracht haben. Hier ist Ihre Entlohnung. Viel Glück!"
    },
    "FLAVOUR_7_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bring mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_7_WHYSOMUCH" : {
       "description" : "",
@@ -453,7 +453,7 @@
    },
    "FLAVOUR_8_ADTEXT" : {
       "description" : "",
-      "message" : "SHIP WANTED: Passage on a fast ship to {system} system."
+      "message" : "SCHIFF GESUCHT: Überfahrt auf einem schnellen Schiff zum »{system}«-System."
    },
    "FLAVOUR_8_DANGER" : {
       "description" : "",
@@ -461,7 +461,7 @@
    },
    "FLAVOUR_8_FAILUREMSG" : {
       "description" : "",
-      "message" : "Unakzeptabel! Du hast ewig gebraucht. Für diese Leistung wollen wir dich nicht zahlen."
+      "message" : "Unakzeptabel! Sie haben ewig gebraucht. Für diese Leistung wollen wir Ihnen nicht zahlen."
    },
    "FLAVOUR_8_HOWMANY" : {
       "description" : "",
@@ -469,15 +469,15 @@
    },
    "FLAVOUR_8_INTROTEXT" : {
       "description" : "",
-      "message" : "Mein Name ist {name}. Ich brauche eine schnelle Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, etwa {dist} ly entfernt von hier. Ich werde dich mit {cash} entlohnen."
+      "message" : "Mein Name ist {name}. Ich brauche eine schnelle Überfahrt zum »{system}«-System ({sectorx}, {sectory}, {sectorz}), etwa {dist} Lj entfernt von hier. Ich werde Sie mit {cash} entlohnen."
    },
    "FLAVOUR_8_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für diesen schnellen Flud. Du wurdest dafür wie abgemacht entlohnt."
+      "message" : "Danke für diesen schnellen Flug. Sie wurden dafür wie abgemacht entlohnt."
    },
    "FLAVOUR_8_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bringe mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_8_WHYSOMUCH" : {
       "description" : "",
@@ -485,15 +485,15 @@
    },
    "FLAVOUR_9_ADTEXT" : {
       "description" : "",
-      "message" : "SCHIFF GESUCHT: Passage auf einem schnellen schiff zum {system} System."
+      "message" : "SCHIFF GESUCHT: Express-Flug zum »{system}«-System."
    },
    "FLAVOUR_9_DANGER" : {
       "description" : "",
-      "message" : "Die Polizei wird vielleicht versuchen, dich zu stoppen."
+      "message" : "Die Polizei wird vielleicht versuchen, Sie zu stoppen."
    },
    "FLAVOUR_9_FAILUREMSG" : {
       "description" : "",
-      "message" : "Nutzlos! Du hast ewig gebraucht. Für diese Leistung wollen wir dich nicht zahlen."
+      "message" : "Nutzlos! Sie haben ewig gebraucht. Für diese Leistung wollen wir Sie nicht entlohnen."
    },
    "FLAVOUR_9_HOWMANY" : {
       "description" : "",
@@ -501,15 +501,15 @@
    },
    "FLAVOUR_9_INTROTEXT" : {
       "description" : "",
-      "message" : "Mein Name ist {name}. Ich brauche eine schnelle Passage zum {system} ({sectorx}, {sectory}, {sectorz}) System, etwa {dist} ly entfernt von hier. Ich zahle dir {cash}."
+      "message" : "Mein Name ist {name}. Ich brauche einen schnellen Flug zum »{system}«-System ({sectorx}, {sectory}, {sectorz}), etwa {dist} Lj von hier entfernt. Ich zahle Ihnen {cash}."
    },
    "FLAVOUR_9_SUCCESSMSG" : {
       "description" : "",
-      "message" : "Danke für den schnellen Flug. Hier ist dein Lohn."
+      "message" : "Danke für den schnellen Flug. Hier ist Ihre Bezahlung."
    },
    "FLAVOUR_9_WHEREAREWE" : {
       "description" : "",
-      "message" : "Wo sind wir? Ich habe lange genug gewartet - Bringe mich zur nächsten Station, SOFORT!"
+      "message" : "Wo sind wir? Ich habe lange genug gewartet – Bringe mich zur nächsten Station, SOFORT!"
    },
    "FLAVOUR_9_WHYSOMUCH" : {
       "description" : "",
@@ -529,7 +529,7 @@
    },
    "HEY_YOU_ARE_GOING_TO_PAY_FOR_THIS" : {
       "description" : "",
-      "message" : "Hey!?! Du wirst dafür bezahlen!!!"
+      "message" : "Hey! Dafür werden Sie bezahlen!"
    },
    "HOW_MANY_OF_YOU_ARE_THERE" : {
       "description" : "",
@@ -537,11 +537,11 @@
    },
    "HOW_SOON_YOU_MUST_BE_THERE" : {
       "description" : "",
-      "message" : "Wie bald musst du da sein?"
+      "message" : "Wie bald müssen Sie da sein?"
    },
    "I_MUST_BE_THERE_BEFORE" : {
       "description" : "",
-      "message" : "Ich mus dort sein vor "
+      "message" : "Ich muss dort sein vor "
    },
    "LY" : {
       "description" : "",
@@ -549,7 +549,7 @@
    },
    "OK_AGREED" : {
       "description" : "",
-      "message" : "Ok, ich werde den Flug übernehmen."
+      "message" : "Okay, ich werde den Flug übernehmen."
    },
    "PIRATE_TAUNTS_0" : {
       "description" : "",
@@ -565,7 +565,7 @@
    },
    "PIRATE_TAUNTS_3" : {
       "description" : "",
-      "message" : "Du wirst heute nicht mehr Docken!"
+      "message" : "Du wirst heute nicht mehr andocken!"
    },
    "TAXI" : {
       "description" : "",
@@ -589,6 +589,6 @@
    },
    "YOU_DO_NOT_HAVE_ENOUGH_CABIN_SPACE_ON_YOUR_SHIP" : {
       "description" : "",
-      "message" : "Du hast nicht genug Raum in deinem Schiff."
+      "message" : "Sie haben in Ihrem Schiff nicht genügend Platz."
    }
 }

--- a/data/lang/ui-core/de.json
+++ b/data/lang/ui-core/de.json
@@ -9,7 +9,7 @@
    },
    "AFTER_TRADE_IN" : {
       "description" : "",
-      "message" : "Nach Inzahlungnahme"
+      "message" : "Nach Inzahlungsnahme"
    },
    "ALLEGIANCE" : {
       "description" : "",
@@ -33,7 +33,7 @@
    },
    "AVAILABLE_FOR_PURCHASE" : {
       "description" : "",
-      "message" : "Zu Kaufen"
+      "message" : "Zu kaufen"
    },
    "AVERAGE" : {
       "description" : "",
@@ -165,7 +165,7 @@
    },
    "COULD_NOT_LOAD_GAME" : {
       "description" : "",
-      "message" : "Kann Spiel nicht laden:"
+      "message" : "Spielstand konnte nicht geladen werden: "
    },
    "CREDIBLE" : {
       "description" : "For player reputation",
@@ -205,7 +205,7 @@
    },
    "DELTA_V_MAX" : {
       "description" : "Delta-v capacity of a ship with cargo bay fully loaded with propellant",
-      "message" : "Delta-v (max)"
+      "message" : "Delta-v (max.)"
    },
    "DESCENT_TO_GROUND_SPEED" : {
       "description" : "",
@@ -221,7 +221,7 @@
    },
    "DISPLAY_HUD_TRAILS" : {
       "description" : "",
-      "message" : "Zeige Schiffsspuren"
+      "message" : "Schiffsspuren zeigen"
    },
    "DISPLAY_NAV_TUNNELS" : {
       "description" : "",
@@ -233,7 +233,7 @@
    },
    "DOCK_AT_CURRENT_TARGET" : {
       "description" : "",
-      "message" : "An aktuellen Ziel anlegen"
+      "message" : "An aktuelles Ziel andocken"
    },
    "DUE" : {
       "description" : "",
@@ -245,7 +245,7 @@
    },
    "ECONOMY_TRADE" : {
       "description" : "",
-      "message" : "Wirtschaft & Handel"
+      "message" : "Wirtschaft und Handel"
    },
    "EFFECTS" : {
       "description" : "",
@@ -317,11 +317,11 @@
    },
    "FORWARD_ACCEL_EMPTY" : {
       "description" : "",
-      "message" : "Vorwärts Beschleunigung (unbeladen)"
+      "message" : "Vorwärts-Beschleunigung (unbeladen)"
    },
    "FORWARD_ACCEL_FULL" : {
       "description" : "",
-      "message" : "Vorwärts Beschleunigung (beladen)"
+      "message" : "Vorwärts-Beschleunigung (beladen)"
    },
    "FRACTAL_DETAIL" : {
       "description" : "",
@@ -357,11 +357,11 @@
    },
    "GIVE_ORDERS_TO_CREW" : {
       "description" : "",
-      "message" : "Gib der Crew Anweisungen"
+      "message" : "Der Crew Anweisungen geben"
    },
    "GOOD_RIDDANCE_TO_YOU_TOO" : {
       "description" : "",
-      "message" : "Dir auch auf Nimmerwiedersehen!"
+      "message" : "Ihnen auch auf Nimmerwiedersehen!"
    },
    "HANG_UP" : {
       "description" : "",
@@ -373,7 +373,7 @@
    },
    "HEAVY_CARGO_SHUTTLE" : {
       "description" : "",
-      "message" : "Schweres Transportshuttle"
+      "message" : "Schwerer Transportshuttle"
    },
    "HEAVY_COURIER" : {
       "description" : "",
@@ -389,7 +389,7 @@
    },
    "HEAVY_PASSENGER_SHUTTLE" : {
       "description" : "",
-      "message" : "Schweres Passagiershuttle"
+      "message" : "Schwerer Passagiershuttle"
    },
    "HEAVY_PASSENGER_TRANSPORT" : {
       "description" : "",
@@ -421,15 +421,15 @@
    },
    "HYPERDRIVE_FITTED" : {
       "description" : "",
-      "message" : "Hyperraumantrieb installiert:"
+      "message" : "Installierter Hyperraumantrieb:"
    },
    "HYPERSPACE_RANGE" : {
       "description" : "",
-      "message" : "Hyperraum Reichweite"
+      "message" : "Hyperraum-Reichweite"
    },
    "IM_TIRED_OF_WORKING_FOR_NOTHING_DONT_YOU_KNOW_WHAT_A_CONTRACT_IS" : {
       "description" : "",
-      "message" : "Ich bin es leid für nichts zu arbeiten. Wissen sie nicht, was ein Vertrag ist?"
+      "message" : "Ich bin es leid, für nichts zu arbeiten. Wissen sie nicht, was ein Vertrag ist?"
    },
    "INACTIVE" : {
       "description" : "",
@@ -445,7 +445,7 @@
    },
    "INVERT_MOUSE_Y" : {
       "description" : "",
-      "message" : "Maus Y-Achse invertieren"
+      "message" : "Maus-Y-Achse invertieren"
    },
    "IN_CARGO_HOLD" : {
       "description" : "",
@@ -489,7 +489,7 @@
    },
    "LAUNCH_PERMISSION_DENIED_FINED" : {
       "description" : "",
-      "message" : "Starterlaubnis verweigert: Sie haben noch ausstehende Strafen."
+      "message" : "Starterlaubnis verweigert: Sie haben noch ausstehende Strafzahlungen."
    },
    "LEGAL_STATUS" : {
       "description" : "",
@@ -497,7 +497,7 @@
    },
    "LIGHT_CARGO_SHUTTLE" : {
       "description" : "",
-      "message" : "Leichtes Transportshuttle"
+      "message" : "Leichter Transportshuttle"
    },
    "LIGHT_COURIER" : {
       "description" : "",
@@ -525,7 +525,7 @@
    },
    "LOAD_GAME" : {
       "description" : "",
-      "message" : "Lade Spiel"
+      "message" : "Spiel laden"
    },
    "LOBBY" : {
       "description" : "",
@@ -533,7 +533,7 @@
    },
    "LOCATED_N_KM_FROM_THE_CENTRE_OF_NAME" : {
       "description" : "",
-      "message" : "{distance}km vom Zentrum von {name} lokalisiert:"
+      "message" : "{distance} km vom Zentrum von {name} lokalisiert:"
    },
    "LOCATION" : {
       "description" : "",
@@ -581,27 +581,27 @@
    },
    "MEDIUM_CARGO_SHUTTLE" : {
       "description" : "",
-      "message" : "Mittleres Transportshuttle"
+      "message" : "Mitellgroßer Transportshuttle"
    },
    "MEDIUM_COURIER" : {
       "description" : "",
-      "message" : " Mittleres Kurierschiff"
+      "message" : " Mittelgroßes Kurierschiff"
    },
    "MEDIUM_FIGHTER" : {
       "description" : "",
-      "message" : "Mittleres Kampfschiff"
+      "message" : "Mittelgroßes Kampfschiff"
    },
    "MEDIUM_FREIGHTER" : {
       "description" : "",
-      "message" : "Mittlerer Frachter"
+      "message" : "Mittelgroßer Frachter"
    },
    "MEDIUM_PASSENGER_SHUTTLE" : {
       "description" : "",
-      "message" : "Mittleres Passagiershuttle"
+      "message" : "Mittelgroßer Passagiershuttle"
    },
    "MEDIUM_PASSENGER_TRANSPORT" : {
       "description" : "",
-      "message" : "Mittlerer Passagiertransporter"
+      "message" : "Mittelgroßer Passagiertransporter"
    },
    "METAL_ALLOYS" : {
       "description" : "",
@@ -653,7 +653,7 @@
    },
    "NAME_OBJECT" : {
       "description" : "For an item or object",
-      "message" : "Name"
+      "message" : "Bezeichnung"
    },
    "NAME_PERSON" : {
       "description" : "For a person",
@@ -669,7 +669,7 @@
    },
    "NEXT_PAID" : {
       "description" : "",
-      "message" : "Nächster Bezahlter"
+      "message" : "Nächster Zahltermin"
    },
    "NO" : {
       "description" : "Negative answer to a question",
@@ -689,7 +689,7 @@
    },
    "NOT_ENOUGH_ALLOY_TO_ATTEMPT_A_REPAIR" : {
       "description" : "",
-      "message" : "Nicht genig {alloy} um eine Reparatur durchzuführen"
+      "message" : "Nicht genig {alloy}, um eine Reparatur durchzuführen"
    },
    "NOT_SUPPORTED_ON_THIS_SHIP" : {
       "description" : "",
@@ -701,11 +701,11 @@
    },
    "N_LIGHT_YEARS_N_MAX" : {
       "description" : "",
-      "message" : "{range} Lichtjahre ({maxRange} max)"
+      "message" : "{range} Lichtjahre ({maxRange} max.)"
    },
    "N_OCCUPIED_PASSENGER_CABINS" : {
       "description" : "",
-      "message" : "{quantity} Belegte Passagierkabinen"
+      "message" : "{quantity} belegte Passagierkabinen"
    },
    "N_SHIELD_GENERATORS" : {
       "description" : "",
@@ -713,7 +713,7 @@
    },
    "N_UNOCCUPIED_PASSENGER_CABINS" : {
       "description" : "",
-      "message" : "{quantity} Unbelegte Passagierkabinen"
+      "message" : "{quantity} unbelegte Passagierkabinen"
    },
    "OFF" : {
       "description" : "",
@@ -721,7 +721,7 @@
    },
    "OK" : {
       "description" : "",
-      "message" : "Ok"
+      "message" : "OK"
    },
    "OPTIONS" : {
       "description" : "",
@@ -737,7 +737,7 @@
    },
    "ORBITAL_ANALYSIS_NOTES" : {
       "description" : "",
-      "message" : "Die Kreisbahn-Geschwindigkeit wird für eine tangentiale Geschwindigkeit angegeben. Das schiff sollte in einem 90°-Winkel zur Schiff/{name}-Achse stehen.\n\nDie Landegeschwindigkeit ist ein absolutes Minimum und ist auch tangential. Eine geringere Geschwindigkeit und ein kleinerer Winkel wird in einem Kurs resultieren, der die Oberfläche von {name} schneidet.\n\nDie Fluchtgeschwindigkeit funktioniert theoretisch gesehen in alle Richtungen, solange das Schiff auf dem Weg mit {name} kollidiert.\n\t\t"
+      "message" : "Die Kreisbahn-Geschwindigkeit wird für eine tangentiale Geschwindigkeit angegeben. Das schiff sollte in einem 90°-Winkel zur Schiff/{name}-Achse stehen.\n\nDie Landegeschwindigkeit ist ein absolutes Minimum und ist auch tangential. Eine geringere Geschwindigkeit und ein kleinerer Winkel wird in einem Kurs, der die Oberfläche von {name} schneidet, resultieren.\n\nDie Fluchtgeschwindigkeit funktioniert theoretisch gesehen in alle Richtungen, solange das Schiff auf dem Weg mit {name} kollidiert.\n\t\t"
    },
    "OWED" : {
       "description" : "",
@@ -745,7 +745,7 @@
    },
    "PAY_FINE_OF_N" : {
       "description" : "",
-      "message" : "Bezahle {amount} Strafe"
+      "message" : "Strafgeld von {amount} bezahlen"
    },
    "PERSONAL_INFORMATION" : {
       "description" : "",
@@ -757,7 +757,7 @@
    },
    "PILOT_SEAT_IS_NOW_OCCUPIED_BY_NAME" : {
       "description" : "",
-      "message" : "Der Pilotensessel ist besetzt von {name}"
+      "message" : "Der Pilotensitz ist von {name} besetzt"
    },
    "PIRACY" : {
       "description" : "",
@@ -769,7 +769,7 @@
    },
    "PLANET_TEXTURES" : {
       "description" : "",
-      "message" : "Planeten Texturen"
+      "message" : "Planeten-Texturen"
    },
    "POLICE" : {
       "description" : "",
@@ -853,11 +853,11 @@
    },
    "REVERSE_ACCEL_EMPTY" : {
       "description" : "",
-      "message" : "Rückwärts Beschleunigung (unbeladen)"
+      "message" : "Rückwärts-Beschleunigung (unbeladen)"
    },
    "REVERSE_ACCEL_FULL" : {
       "description" : "",
-      "message" : "Rückwärts Beschleunigung (beladen)"
+      "message" : "Rückwärts-Beschleunigung (beladen)"
    },
    "REWARD" : {
       "description" : "",
@@ -877,11 +877,11 @@
    },
    "SELECT_FILE" : {
       "description" : "",
-      "message" : "Datei auswählen..."
+      "message" : "Datei auswählen …"
    },
    "SELECT_GAME_TO_LOAD" : {
       "description" : "",
-      "message" : "Spiel zum Laden auswählen..."
+      "message" : "Spiel zum Laden auswählen …"
    },
    "SENSORS" : {
       "description" : "",
@@ -925,15 +925,15 @@
    },
    "START_AT_BARNARDS_STAR" : {
       "description" : "",
-      "message" : "Starte auf Barnard's Star"
+      "message" : "Auf Barnard's Star starten"
    },
    "START_AT_EARTH" : {
       "description" : "",
-      "message" : "Starte auf der Erde"
+      "message" : "Auf der Erde starten"
    },
    "START_AT_NEW_HOPE" : {
       "description" : "",
-      "message" : "Starte auf New Hope"
+      "message" : "Auf New Hope starten"
    },
    "STATION_MANAGER" : {
       "description" : "",
@@ -953,7 +953,7 @@
    },
    "THE_SHIP_IS_UNDER_STATION_CONTROL_COMMANDER" : {
       "description" : "",
-      "message" : "Das Schiff ist unter Kontrolle der Station, Commander"
+      "message" : "Das Schiff ist unter Kontrolle der Station, Kommandant."
    },
    "TOGGLE_MALE_FEMALE" : {
       "description" : "",
@@ -1045,7 +1045,7 @@
    },
    "YOURE_GOING_TO_REGRET_SACKING_ME" : {
       "description" : "",
-      "message" : "Du wirst meinen Rauswurf bedauern"
+      "message" : "Sie werden meinen Rauswurf bedauern."
    },
    "YOUR_HULL_IS_AT_X_INTEGRITY" : {
       "description" : "",


### PR DESCRIPTION
This PR updates the German translation of Pioneer.
This update includes:
- Use of “Sie” instead of “du”, where appropriate
- Typo, poor grammar, poor speech fixes (a lot of them)
- Translated forgotten translations
