### PR TITLE
Add the ability to extract multiple return values when calling a C++ method

### DIFF
--- a/src/ShipController.cpp
+++ b/src/ShipController.cpp
@@ -347,7 +347,7 @@ void PlayerShipController::FireMissile()
 {
 	if (!Pi::player->GetCombatTarget())
 		return;
-	LuaObject<Ship>::CallMethod<bool>(Pi::player, "FireMissileAt", "any", static_cast<Ship*>(Pi::player->GetCombatTarget()));
+	LuaObject<Ship>::CallMethod(Pi::player, "FireMissileAt", "any", static_cast<Ship*>(Pi::player->GetCombatTarget()));
 }
 
 Body *PlayerShipController::GetCombatTarget() const

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -537,7 +537,7 @@ void UseEquipWidget::FireMissile(int idx)
 		Pi::cpan->MsgLog()->Message("", Lang::SELECT_A_TARGET);
 		return;
 	}
-	LuaObject<Ship>::CallMethod<bool>(Pi::player, "FireMissileAt", idx+1, static_cast<Ship*>(Pi::player->GetCombatTarget()));
+	LuaObject<Ship>::CallMethod(Pi::player, "FireMissileAt", idx+1, static_cast<Ship*>(Pi::player->GetCombatTarget()));
 }
 
 void UseEquipWidget::UpdateEquip()


### PR DESCRIPTION
I've extended the CallMethod methods to return a tuple if (and only if)
strictly more than one return value is expected, and when none is
expected to just do nothing and return void.

There are of course the usual MSVC #ifdef deviations limiting this to 3
return values ATM, but if it ever becomes necessary it is easy to add
new ones as long as the compiler can't really handle variadic templates
(the way I'd want it to, anyway).

@fluffyfreak, sorry to bother you again (I'll try to install MSVC 2013 in a VM this week, I promise), there is a bogus commit on top of that one on the for_fluffy branch to test it thoroughly. Thanks in advance :-)
