### PR TITLE
Fix iteration of wrong dequeue in JobQueue::Cancel.

### DIFF
--- a/src/JobQueue.cpp
+++ b/src/JobQueue.cpp
@@ -341,7 +341,7 @@ void JobQueue::Cancel(Job *job) {
 	// check the finshed list. if its there then it can't be cancelled, because
 	// its alread finished! we remove it because the caller is saying "I don't care"
 	for( uint32_t iRunner=0; iRunner<numRunners ; ++iRunner) {
-		for (std::deque<Job*>::iterator i = m_queue.begin(); i != m_queue.end(); ++i) {
+		for (std::deque<Job*>::iterator i = m_finished[iRunner].begin(); i != m_finished[iRunner].end(); ++i) {
 			if (*i == job) {
 				i = m_finished[iRunner].erase(i);
 				delete job;


### PR DESCRIPTION
Discovered while working on another `JobQueue` feature.

It seems pretty clear that this is a copy-paste error from the loop a few lines above. It doesn't make sense to try to delete from the same dequeue again and again ;)
