### PR TITLE
Galaxy [1/4]: Convert the Galaxy namespace to a class

### DIFF
--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -106,8 +106,8 @@ void GalacticView::Draw3D()
 {
 	PROFILE_SCOPED()
 	vector3f pos = Pi::sectorView->GetPosition();
-	float offset_x = (pos.x*Sector::SIZE + Galaxy::SOL_OFFSET_X)/Galaxy::GALAXY_RADIUS;
-	float offset_y = (-pos.y*Sector::SIZE + Galaxy::SOL_OFFSET_Y)/Galaxy::GALAXY_RADIUS;
+	float offset_x = (pos.x*Sector::SIZE + Pi::GetGalaxy()->SOL_OFFSET_X)/Pi::GetGalaxy()->GALAXY_RADIUS;
+	float offset_y = (-pos.y*Sector::SIZE + Pi::GetGalaxy()->SOL_OFFSET_Y)/Pi::GetGalaxy()->GALAXY_RADIUS;
 
 	const float aspect = m_renderer->GetDisplayAspect();
 	m_renderer->SetOrthographicProjection(-aspect, aspect, 1.f, -1.f, -1.f, 1.f);
@@ -159,7 +159,7 @@ void GalacticView::Update()
 	m_zoom = Clamp(m_zoom, 0.5f, 100.0f);
 	AnimationCurves::Approach(m_zoom, m_zoomTo, frameTime);
 
-	m_scaleReadout->SetText(stringf(Lang::INT_LY, formatarg("scale", int(0.5*Galaxy::GALAXY_RADIUS/m_zoom))));
+	m_scaleReadout->SetText(stringf(Lang::INT_LY, formatarg("scale", int(0.5*Pi::GetGalaxy()->GALAXY_RADIUS/m_zoom))));
 
 	UIView::Update();
 }

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -151,6 +151,7 @@ Sound::MusicPlayer Pi::musicPlayer;
 std::unique_ptr<AsyncJobQueue> Pi::asyncJobQueue;
 std::unique_ptr<SyncJobQueue> Pi::syncJobQueue;
 
+Galaxy* Pi::s_galaxy = nullptr;
 // XXX enabling this breaks UI gauge rendering. see #2627
 #define USE_RTT 0
 
@@ -479,7 +480,7 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 
 	draw_progress(gauge, label, 0.1f);
 
-	Galaxy::Init();
+	s_galaxy = new Galaxy;
 	draw_progress(gauge, label, 0.2f);
 
 	FaceGenManager::Init();
@@ -666,7 +667,6 @@ void Pi::Quit()
 	SpaceStation::Uninit();
 	CityOnPlanet::Uninit();
 	BaseSphere::Uninit();
-	Galaxy::Uninit();
 	Faction::Uninit();
 	FaceGenManager::Destroy();
 	CustomSystem::Uninit();
@@ -678,6 +678,7 @@ void Pi::Quit()
 	delete Pi::renderer;
 	delete Pi::config;
 	StarSystem::attic.ClearCache();
+	delete Pi::s_galaxy;
 	SDL_Quit();
 	FileSystem::Uninit();
 	asyncJobQueue.reset();

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -20,6 +20,7 @@
 
 class DeathView;
 class GalacticView;
+class Galaxy;
 class Intro;
 class LuaConsole;
 class LuaNameGen;
@@ -176,6 +177,7 @@ public:
 	static JobQueue *GetAsyncJobQueue() { return asyncJobQueue.get();}
 	static JobQueue *GetSyncJobQueue() { return syncJobQueue.get();}
 
+	static Galaxy* GetGalaxy() { return s_galaxy; }
 	static bool DrawGUI;
 
 private:
@@ -186,6 +188,7 @@ private:
 	static std::unique_ptr<AsyncJobQueue> asyncJobQueue;
 	static std::unique_ptr<SyncJobQueue> syncJobQueue;
 
+	static Galaxy* s_galaxy;
 	static bool menuDone;
 
 	static View *currentView;

--- a/src/galaxy/Galaxy.cpp
+++ b/src/galaxy/Galaxy.cpp
@@ -8,16 +8,7 @@
 #include "Pi.h"
 #include "FileSystem.h"
 
-namespace Galaxy {
-
-// lightyears
-const float GALAXY_RADIUS = 50000.0;
-const float SOL_OFFSET_X = 25000.0;
-const float SOL_OFFSET_Y = 0.0;
-
-static SDL_Surface *s_galaxybmp;
-
-void Init()
+Galaxy::Galaxy() : GALAXY_RADIUS(50000.0), SOL_OFFSET_X(25000.0), SOL_OFFSET_Y(0.0), m_galaxybmp(nullptr)
 {
 	static const std::string filename("galaxy.bmp");
 
@@ -28,24 +19,24 @@ void Init()
 	}
 
 	SDL_RWops *datastream = SDL_RWFromConstMem(filedata->GetData(), filedata->GetSize());
-	s_galaxybmp = SDL_LoadBMP_RW(datastream, 1);
-	if (!s_galaxybmp) {
+	m_galaxybmp = SDL_LoadBMP_RW(datastream, 1);
+	if (!m_galaxybmp) {
 		Output("Galaxy: couldn't load: %s (%s)\n", filename.c_str(), SDL_GetError());
 		Pi::Quit();
 	}
 }
 
-void Uninit()
+Galaxy::~Galaxy()
 {
-	if(s_galaxybmp) SDL_FreeSurface(s_galaxybmp);
+	if(m_galaxybmp) SDL_FreeSurface(m_galaxybmp);
 }
 
-SDL_Surface *GetGalaxyBitmap()
+SDL_Surface* Galaxy::GetGalaxyBitmap()
 {
-	return s_galaxybmp;
+	return m_galaxybmp;
 }
 
-Uint8 GetSectorDensity(int sx, int sy, int sz)
+Uint8 Galaxy::GetSectorDensity(int sx, int sy, int sz)
 {
 	// -1.0 to 1.0
 	float offset_x = (sx*Sector::SIZE + SOL_OFFSET_X)/GALAXY_RADIUS;
@@ -54,12 +45,12 @@ Uint8 GetSectorDensity(int sx, int sy, int sz)
 	offset_x = Clamp((offset_x + 1.0)*0.5, 0.0, 1.0);
 	offset_y = Clamp((offset_y + 1.0)*0.5, 0.0, 1.0);
 
-	int x = int(floor(offset_x * (s_galaxybmp->w - 1)));
-	int y = int(floor(offset_y * (s_galaxybmp->h - 1)));
+	int x = int(floor(offset_x * (m_galaxybmp->w - 1)));
+	int y = int(floor(offset_y * (m_galaxybmp->h - 1)));
 
-	SDL_LockSurface(s_galaxybmp);
-	int val = static_cast<unsigned char*>(s_galaxybmp->pixels)[x + y*s_galaxybmp->pitch];
-	SDL_UnlockSurface(s_galaxybmp);
+	SDL_LockSurface(m_galaxybmp);
+	int val = static_cast<unsigned char*>(m_galaxybmp->pixels)[x + y*m_galaxybmp->pitch];
+	SDL_UnlockSurface(m_galaxybmp);
 	// crappy unrealistic but currently adequate density dropoff with sector z
 	val = val * (256 - std::min(abs(sz),256)) / 256;
 	// reduce density somewhat to match real (gliese) density
@@ -67,7 +58,7 @@ Uint8 GetSectorDensity(int sx, int sy, int sz)
 	return Uint8(val);
 }
 
-void Dump(FILE* file, Sint32 centerX, Sint32 centerY, Sint32 centerZ, Sint32 radius)
+void Galaxy::Dump(FILE* file, Sint32 centerX, Sint32 centerY, Sint32 centerZ, Sint32 radius)
 {
 	for (Sint32 sx = centerX - radius; sx <= centerX + radius; ++sx) {
 		for (Sint32 sy = centerY - radius; sy <= centerY + radius; ++sy) {
@@ -79,5 +70,3 @@ void Dump(FILE* file, Sint32 centerX, Sint32 centerY, Sint32 centerZ, Sint32 rad
 		}
 	}
 }
-
-} /* namespace Galaxy */

--- a/src/galaxy/Galaxy.h
+++ b/src/galaxy/Galaxy.h
@@ -6,20 +6,26 @@
 
 #include <cstdio>
 
-/* Sector density lookup */
-namespace Galaxy {
-	// lightyears
-	extern const float GALAXY_RADIUS;
-	extern const float SOL_OFFSET_X;
-	extern const float SOL_OFFSET_Y;
+class SDL_Surface;
 
-	void Init();
-	void Uninit();
+class Galaxy {
+public:
+	// lightyears
+	const float GALAXY_RADIUS;
+	const float SOL_OFFSET_X;
+	const float SOL_OFFSET_Y;
+
+	Galaxy();
+	~Galaxy();
+
 	SDL_Surface *GetGalaxyBitmap();
 	/* 0 - 255 */
 	Uint8 GetSectorDensity(int sx, int sy, int sz);
 
 	void Dump(FILE* file, Sint32 centerX, Sint32 centerY, Sint32 centerZ, Sint32 radius);
-}
+
+private:
+	SDL_Surface *m_galaxybmp;
+};
 
 #endif /* _GALAXY_H */

--- a/src/galaxy/Sector.cpp
+++ b/src/galaxy/Sector.cpp
@@ -69,7 +69,7 @@ Sector::Sector(const SystemPath& path, SectorCache* cache) : sx(path.sectorX), s
 	if ((path.sectorX < -CUSTOM_ONLY_RADIUS) || (path.sectorX > CUSTOM_ONLY_RADIUS-1) ||
 	    (path.sectorY < -CUSTOM_ONLY_RADIUS) || (path.sectorY > CUSTOM_ONLY_RADIUS-1) ||
 	    (path.sectorZ < -CUSTOM_ONLY_RADIUS) || (path.sectorZ > CUSTOM_ONLY_RADIUS-1)) {
-		int numSystems = (rng.Int32(4,20) * Galaxy::GetSectorDensity(path.sectorX, path.sectorY, path.sectorZ)) >> 8;
+		int numSystems = (rng.Int32(4,20) * Pi::GetGalaxy()->GetSectorDensity(path.sectorX, path.sectorY, path.sectorZ)) >> 8;
 
 		for (int i=0; i<numSystems; i++) {
 			System s(sx, sy, sz, customCount + i);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,7 +132,7 @@ start:
 					Output("pioneer: could not open \"%s\" for writing: %s\n", filename.c_str(), strerror(errno));
 					break;
 				}
-				Galaxy::Dump(file, sx, sy, sz, radius);
+				Pi::GetGalaxy()->Dump(file, sx, sy, sz, radius);
 				if (filename != "-" && fclose(file) != 0) {
 					Output("pioneer: writing to \"%s\" failed: %s\n", filename.c_str(), strerror(errno));
 				}


### PR DESCRIPTION
Seems I have a productive weekend ;)

This is the first PR in a series of four to come. It converts the `Galaxy` namespace to a class so we can properly encapsulate everything that reflects our generated galaxy (and thus changes when different galaxy generators are used):
1. The sector density map (was already part of the `Galaxy` namespace)
2. The factions
3. The custom systems
4. `Sector` and `StarSystem` caches (not finished, yet)
