### PR TITLE
hull damage bar - cosmetic

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -727,7 +727,7 @@ void WorldView::RefreshButtonStateAndVisibility()
 	}
 
 	float hull = Pi::player->GetPercentHull();
-	if (hull < 100.0f) {
+	if (hull <= 99.9f) { //visible when hull integrity <= 99.9%
 		m_hudHullIntegrity->SetColor(get_color_for_warning_meter_bar(hull));
 		m_hudHullIntegrity->SetValue(hull*0.01f);
 		m_hudHullIntegrity->Show();


### PR DESCRIPTION
`< 100.0f` shows (in world view) the condition of damaged hull earlier than the possibility of repair.
Related to #2901
