### PR TITLE
Added lua attribute to get faction->idx as an faction id

### DIFF
--- a/src/LuaFaction.cpp
+++ b/src/LuaFaction.cpp
@@ -35,6 +35,27 @@ static int l_faction_attr_name(lua_State *l)
 }
 
 /*
+ * Attribute: id
+ *
+ * A unique identification number of the faction
+ *
+ * Availability:
+ *
+ *  2014-06
+ *
+ * Status:
+ *
+ *  experimental
+ */
+static int l_faction_attr_id(lua_State *l)
+{
+	const Faction *faction = LuaObject<Faction>::CheckFromLua(1);
+	lua_pushnumber(l, faction->idx);
+
+	return 1;
+}
+
+/*
  * Attribute: descriptionShort
  *
  * The short description of the faction
@@ -252,6 +273,7 @@ template <> void LuaObject<Faction>::RegisterClass()
 {
 	static const luaL_Reg l_attrs[] = {
 		{ "name",               l_faction_attr_name               },
+		{ "id",                 l_faction_attr_id                 },
 		{ "descriptionShort",   l_faction_attr_description_short  },
 		{ "description",        l_faction_attr_description        },
 		{ "hasHomeworld",       l_faction_attr_has_homeworld      },


### PR DESCRIPTION
**Background:** I needed some unique "id" for factions to use as keys in Lua-tables that contain faction specific information, like the crime record of the player, etc.

I looked into the faction-code, and if I'm not way off, this looks like it's doing what I want.

I know, "factions will be remade, and thrown out", etc. But until/even at that point, there should be a Lua method for getting some unique id for a faction, to be used in this way, instead of using the faction name as key (which is how I solved it until this PR).

I guess as long as factions aren't remade the id will not change for a faction. If it were to change then a save bump would be needed I guess.

Putting this for review, since I'm not sure about the validity of what I've done.
