### PR TITLE
WIP: Enable different sell/buy for ship equipment

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -51,6 +51,10 @@
       "description" : "",
       "message" : "Buy Ship"
    },
+   "BUY" : {
+      "description" : "Commodities and equipment prices",
+      "message" : "Buy"
+   },
    "CABINS" : {
       "description" : "",
       "message" : "Cabins"
@@ -882,6 +886,10 @@
    "SELECT_GAME_TO_LOAD" : {
       "description" : "",
       "message" : "Select game to load..."
+   },
+   "SELL" : {
+      "description" : "Commodities and equipment prices",
+      "message" : "Sell"
    },
    "SENSORS" : {
       "description" : "",

--- a/data/ui/StationView/EquipmentMarket.lua
+++ b/data/ui/StationView/EquipmentMarket.lua
@@ -17,15 +17,16 @@ local ui = Engine.ui
 
 local equipmentMarket = function (args)
 	local stationTable, shipTable = EquipmentTableWidgets.Pair({
-		stationColumns = { "name", "price", "mass", "stock" },
+		stationColumns = { "name", "buy", "sell", "mass", "stock" },
 		shipColumns = { "name", "amount", "mass", "massTotal" },
 
 		canTrade = function (e) return EquipDef[e].purchasable and EquipDef[e].slot ~= "CARGO" end,
-		price = function (e, funcs) return Format.Money(funcs.getPrice(e),false) end,
+		buy = function (e, funcs) return Format.Money(funcs.getBuyPrice(e),false) end,
+		sell = function (e, funcs) return Format.Money(funcs.getSellPrice(e),false) end,
 	})
 
 	return
-		ui:Grid({48,4,48},1)
+		ui:Grid({52,2,46},1)
 			:SetColumn(0, {
 				ui:VBox():PackEnd({
 					ui:Label(l.AVAILABLE_FOR_PURCHASE):SetFont("HEADING_LARGE"),


### PR DESCRIPTION
This is to fix #2953

It's the same as #2787, except I've excluded the goods trader and commodity prices (since trading is way to difficult/broken as it is), so just affect the ship equipment prices, so the space station buys the equipment back for 0.8 of the full value.

**NOTE:** I haven't tested this yet, so I wont merge utill I've done so, sometime after the weekend. Possibly then I can dust off my "second hand" module, which allows player to buy used ship equipment at a reduced price (but higher than 0.8) from the BBS.
