### PR TITLE
Changing the masses of the gasses...

### DIFF
--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -1827,7 +1827,7 @@ const SystemBody* SystemBody::FindStarAndTrueOrbitalRange(fixed &orbMin_, fixed 
 	orbMax_ = planet->m_orbMax;
 	return star;
 }
-#pragma optimize("",off)
+
 void SystemBody::PickPlanetType(Random &rand)
 {
 	PROFILE_SCOPED()


### PR DESCRIPTION
...or is that the gasses of the masses?

Anyway in response to #2959 I have attempted to implement the mass->radius calculation/graph from [this external site](http://phl.upr.edu/library/notes/standardmass-radiusrelationforexoplanets).
# Things that are good:

It seems to work and produce planets with the correct radius!
_I attempted to improve the `CalcSurfaceTemp()` method._
# Things that are bad:

I used `double` values in the SystemBody generation, 8 & 16-bit coders are >> in their graves.
This has to bump the save game version since the planet you may have saved your game on may no longer be the same kind of planet, or the same size, or is now tidally locked, or... you get the idea.
_I attempted to improve the `CalcSurfaceTemp()` method._
# The other things:

Added a method to create a `fixed` value from a double which is called like: `fixed::FromDouble(3.0)` and gives you the fixed value for the number `3.0` in this example.

Needs review. 
