### PR TITLE
Change the GetCommodityBasePriceAlteration interface

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -68,7 +68,7 @@ function SpaceStation:GetEquipmentPrice (e)
 	if equipmentPrice[self][e] then
 		return equipmentPrice[self][e]
 	end
-	local mul = e:IsValidSlot("cargo") and ((100 + Game.system:GetCommodityBasePriceAlterations()[e]) / 100) or 1
+	local mul = e:IsValidSlot("cargo") and ((100 + Game.system:GetCommodityBasePriceAlterations(e)) / 100) or 1
 	return mul * e.price
 end
 


### PR DESCRIPTION
This might allow for better diagnosis of what's going on in the various
recent crashes. Or not. But at least we don't build a whole new table
every time this method gets called, which is a win to me. Plus, the code
is simpler.
