### PR TITLE
Make POSIX FileSourceFS::ReadDirectory more robust

### DIFF
--- a/src/posix/FileSystemPosix.cpp
+++ b/src/posix/FileSystemPosix.cpp
@@ -187,7 +187,7 @@ namespace FileSystem {
 				default: ty = FileInfo::FT_SPECIAL; break;
 			}
 
-			output.push_back(MakeFileInfo(fullpath.substr(GetRoot().size() + 1), ty));
+			output.push_back(MakeFileInfo(JoinPath(dirpath, entry->d_name), ty));
 		}
 
 		closedir(dir);


### PR DESCRIPTION
Instead of being 'clever' and trying to avoid an unnecessary path construction when finding the FileSource-root-relative path to a directory entry, just use JoinPath.  This avoids problems caused by the FileSource root unexpectedly having a trailing slash.

This should fix #2545, but I haven't tested it (I'll test it later today unless I forget or someone else tests it first...)
