### PR TITLE
Use EquipType:GetName() instead of the obsolete name attribute when cargo scooping

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -415,7 +415,7 @@ bool Ship::OnCollision(Object *b, Uint32 flags, double relVel)
 		if (LuaObject<Ship>::CallMethod<int>(this, "AddEquip", item) > 0) { // try to add it to the ship cargo.
 			Pi::game->GetSpace()->KillBody(dynamic_cast<Body*>(b));
 			if (this->IsType(Object::PLAYER))
-				Pi::Message(stringf(Lang::CARGO_SCOOP_ACTIVE_1_TONNE_X_COLLECTED, formatarg("item", ScopedTable(item).Get<std::string>("name"))));
+				Pi::Message(stringf(Lang::CARGO_SCOOP_ACTIVE_1_TONNE_X_COLLECTED, formatarg("item", ScopedTable(item).CallMethod<std::string>("GetName"))));
 			// XXX Sfx::Add(this, Sfx::TYPE_SCOOP);
 			UpdateEquipStats();
 			return true;


### PR DESCRIPTION
(Closes #3041)
