### PR TITLE
Fix references to icons/goods/missile_*.png

### DIFF
--- a/data/ui/StationView/EquipmentTableWidgets.lua
+++ b/data/ui/StationView/EquipmentTableWidgets.lua
@@ -207,7 +207,6 @@ function EquipmentTableWidgets.Pair (config)
 		for i,e in ipairs(equipTypes) do
 			local n = Game.player:CountEquip(e)
 			if n > 0 then
-				local icon = e.icon_name and ui:Image("icons/goods/"..e.icon_name..".png") or ""
 				shipTable:AddRow(utils.build_table(utils.map(function (k,v) return k,shipColumnValue[v](e, funcs) end, ipairs(config.shipColumns))))
 				table.insert(rowEquip, e)
 			end


### PR DESCRIPTION
These references come from the equipment market screen. Specifically, when the ship's equipment table is updated, each row gets an icon. If the equipment type (in libs/Equipment.lua) does not specify an icon_name value, then the icon is left empty (this is what happens for most equipment types). If the equipment type does specify an icon_name (which the missiles do, because missile icons are needed elsewhere in the UI), then the code attempts to load `"icons/goods/" .. icon_name .. ".png"`. This outputs a warning message when trying to load the missile icons, because those icons are in data/icons, not data/icons/goods.

But... having done all that work to construct a UI Image widget and (try to) load an icon file, that widget is never actually used, and will just be destroyed again by the Lua garbage collector (at least, it _should_ be destroyed again -- I haven't tried to check this).
