### PR TITLE
Meager attempt at buildscript

### DIFF
--- a/scripts/nightly-build.pl
+++ b/scripts/nightly-build.pl
@@ -163,7 +163,7 @@ sub copy {
 
 	system "cp -v src/pioneer$suffix $copy_dir";
 	system "cp -v src/pioneer.map $copy_dir" if $platform eq 'win32';
-	system "cp -v *.txt $copy_dir";
+	system "ls *.txt | /usr/bin/grep -v -E '(COMPILING\.txt|SAVEBUMP\.txt)' | xargs cp -v -t $copy_dir";
 	system "cp -rv licenses $copy_dir/licenses";
 	system "cp -rv data $copy_dir/data";
 


### PR DESCRIPTION
A while back someone came by IRC and had been trying to compile pioneer for a long time and failing. It turned out the problem was he had downloaded the pioneer build, and had actually read the documentation _before_ playing. Anyhow, this excludes (I hope) the inclusion of COMPILE.txt and SAVEBUMP.txt.

Ping @robn
