### PR TITLE
Fix an Exit Game widget crash.

### DIFF
--- a/src/LuaGame.cpp
+++ b/src/LuaGame.cpp
@@ -183,7 +183,9 @@ static int l_game_save_game(lua_State *l)
 static int l_game_end_game(lua_State *l)
 {
 	if (Pi::game) {
-		Pi::EndGame();
+		// Request to end the game as soon as possible.
+		// Previously could be called from Lua UI and delete the object doing the calling causing a crash.
+		Pi::RequestEndGame();
 	}
 	return 0;
 }

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -142,6 +142,7 @@ Graphics::RenderTarget *Pi::renderTarget;
 RefCountedPtr<Graphics::Texture> Pi::renderTexture;
 std::unique_ptr<Graphics::Drawables::TexturedQuad> Pi::renderQuad;
 Graphics::RenderState *Pi::quadRenderState = nullptr;
+bool Pi::bRequestEndGame = false;
 
 #if WITH_OBJECTVIEWER
 ObjectViewerView *Pi::objectViewerView;
@@ -1031,6 +1032,8 @@ void Pi::StartGame()
 
 void Pi::Start()
 {
+	Pi::bRequestEndGame = false;
+
 	Pi::intro = new Intro(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
 
 	ui->DropAllLayers();
@@ -1090,8 +1093,17 @@ void Pi::Start()
 	MainLoop();
 }
 
+// request that the game is ended as soon as safely possible
+void Pi::RequestEndGame()
+{
+	Pi::bRequestEndGame = true;
+}
+
 void Pi::EndGame()
 {
+	// always reset this, otherwise we can never play again
+	Pi::bRequestEndGame = false;
+
 	Pi::SetMouseGrab(false);
 
 	Pi::musicPlayer.Stop();
@@ -1219,6 +1231,9 @@ void Pi::MainLoop()
 		// Gui::Draw so that labels drawn to screen can have mouse events correctly
 		// detected. Gui::Draw wipes memory of label positions.
 		Pi::HandleEvents();
+		if( Pi::bRequestEndGame ) {
+			Pi::EndGame();
+		}
 		// hide cursor for ship control.
 
 		SetMouseGrab(Pi::MouseButtonState(SDL_BUTTON_RIGHT));

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -63,6 +63,7 @@ public:
 	static void InitGame();
 	static void StarportStart(Uint32 starport);
 	static void StartGame();
+	static void RequestEndGame(); // request that the game is ended as soon as safely possible
 	static void EndGame();
 	static void Start();
 	static void MainLoop();
@@ -223,6 +224,8 @@ private:
 	static RefCountedPtr<Graphics::Texture> renderTexture;
 	static std::unique_ptr<Graphics::Drawables::TexturedQuad> renderQuad;
 	static Graphics::RenderState *quadRenderState;
+
+	static bool bRequestEndGame;
 };
 
 #endif /* _PI_H */


### PR DESCRIPTION
Delay calling Pi::EndGame() until it's safe to do so by adding a bool and RequestEndGame method.

Prior to this the call to EndGame was destroying the UI which was calling the function which destroyed the UI!

I don't know how we got away with this working.
