### PR TITLE
Don't drop a MessageBox layer if something else dropped it first

### DIFF
--- a/data/libs/ui/MessageBox.lua
+++ b/data/libs/ui/MessageBox.lua
@@ -31,7 +31,13 @@ local function setupLayerAnim (clickWidget)
 			easing = "LINEAR",
 			target = "OPACITY",
 			duration = 0.1,
-			callback = function () ui:DropLayer() end,
+			callback = function ()
+				-- XXX mostly a hack to fix #3110
+				-- something may have dropped our messagebox layer before we get here
+				if ui.layer == layer then
+					ui:DropLayer()
+				end
+			end,
 		})
 	end)
 end


### PR DESCRIPTION
Hack (ish) to fix #3110.

This bug happens because of old-gui event processing and new-ui event processing being done independently.  In new-ui, only the top layer receives events, which means that while the message box is being displayed, nothing else should be clickable, and the messagebox code should have sole control over when it drops itself from the layer stack. However, because the ship cpanel is still using old-gui, it continues to receive events while the MessageBox is up.

So the cause of this bug is:
1. A MessageBox is displayed, and pushes a new UI layer onto the stack.
2. The user clicks on a cpanel button (F1 to F4)
3. The old-gui event handler switches to a different UIView, which forcibly drops all UI layers.
4. The same click event is dispatched to the MessageBox, which starts a quick fade-out animation.
5. When the MessageBox fade-out animation finishes, it tries to pop the MessageBox layer, which fails (and asserts) because there is only one layer.

This patch adds a safety check in MessageBox so that it won't try to drop some other unrelated UI layer.
