### PR TITLE
zoom out button before zoom in in system,sector,galactic view

### DIFF
--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -31,15 +31,15 @@ GalacticView::GalacticView() : UIView(),
 	m_zoom = 1.0f;
 	m_zoomTo = m_zoom;
 
-	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
-	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
-	m_zoomInButton->SetRenderDimensions(30, 22);
-	Add(m_zoomInButton, 700, 5);
-
 	m_zoomOutButton = new Gui::ImageButton("icons/zoom_out.png");
 	m_zoomOutButton->SetToolTip(Lang::ZOOM_OUT);
 	m_zoomOutButton->SetRenderDimensions(30, 22);
-	Add(m_zoomOutButton, 732, 5);
+	Add(m_zoomOutButton, 700, 5);
+
+	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
+	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
+	m_zoomInButton->SetRenderDimensions(30, 22);
+	Add(m_zoomInButton, 732, 5);
 
 	m_scaleReadout = new Gui::Label("");
 	Add(m_scaleReadout, 500.0f, 10.0f);
@@ -173,4 +173,3 @@ void GalacticView::MouseWheel(bool up)
 			m_zoomTo *= ((ZOOM_IN_SPEED-1) * WHEEL_SENSITIVITY+1) * Pi::GetMoveSpeedShiftModifier();
 	}
 }
-

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -141,18 +141,18 @@ void SectorView::InitObject()
 	m_distanceLabel = new Gui::Label("");
 	Add(m_distanceLabel, 2, Gui::Screen::GetHeight()-Gui::Screen::GetFontHeight()-66);
 
-	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
-	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
-	m_zoomInButton->SetRenderDimensions(30, 22);
-	Add(m_zoomInButton, 700, 5);
+	m_zoomOutButton = new Gui::ImageButton("icons/zoom_out.png");
+	m_zoomOutButton->SetToolTip(Lang::ZOOM_OUT);
+	m_zoomOutButton->SetRenderDimensions(30, 22);
+	Add(m_zoomOutButton, 700, 5);
 
 	m_zoomLevelLabel = (new Gui::Label(""))->Color(69, 219, 235);
 	Add(m_zoomLevelLabel, 640, 5);
 
-	m_zoomOutButton = new Gui::ImageButton("icons/zoom_out.png");
-	m_zoomOutButton->SetToolTip(Lang::ZOOM_OUT);
-	m_zoomOutButton->SetRenderDimensions(30, 22);
-	Add(m_zoomOutButton, 732, 5);
+	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
+	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
+	m_zoomInButton->SetRenderDimensions(30, 22);
+	Add(m_zoomInButton, 732, 5);
 
 	Gui::Screen::PushFont("OverlayFont");
 

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -117,18 +117,18 @@ SystemView::SystemView() : UIView()
 	m_infoText = (new Gui::Label(""))->Color(178, 178, 178);
 	Add(m_infoText, 200, 0);
 
-	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
-	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
-	m_zoomInButton->SetRenderDimensions(30, 22);
-	Add(m_zoomInButton, 700, 5);
-
 	m_zoomOutButton = new Gui::ImageButton("icons/zoom_out.png");
 	m_zoomOutButton->SetToolTip(Lang::ZOOM_OUT);
 	m_zoomOutButton->SetRenderDimensions(30, 22);
-	Add(m_zoomOutButton, 732, 5);
+	Add(m_zoomOutButton, 700, 5);
+
+	m_zoomInButton = new Gui::ImageButton("icons/zoom_in.png");
+	m_zoomInButton->SetToolTip(Lang::ZOOM_IN);
+	m_zoomInButton->SetRenderDimensions(30, 22);
+	Add(m_zoomInButton, 732, 5);
 
 	// orbital transfer planner UI
-        int dx = 670;
+	int dx = 670;
 	int dy = 40;
 
 	m_plannerIncreaseFactorButton = new Gui::ImageButton("icons/orbit_increase_big.png");


### PR DESCRIPTION
I don't know about this, but I made it to see what it looks like. In my mind zoom out (negative) is to the left of zoom in (positive), like on a x-axis.

However, one could argue, that we read from left to right, and you're more likely to want to zoom in to investigate something.

Perhaps some votes/opinions on this? Ping @nozmajner

![screenshot-20140805-080050](https://cloud.githubusercontent.com/assets/619390/3807460/2028a2f6-1c67-11e4-98fe-f8c42fb7343c.png)
![screenshot-20140805-080039](https://cloud.githubusercontent.com/assets/619390/3807461/259dec82-1c67-11e4-87c2-2248f805cb8f.png)
![screenshot-20140805-080009](https://cloud.githubusercontent.com/assets/619390/3807462/293c9a82-1c67-11e4-86e1-fdd02c0794f1.png)
