### PR TITLE
Fix bad faction colour only being applied to uninhabited

### DIFF
--- a/src/Factions.cpp
+++ b/src/Factions.cpp
@@ -495,7 +495,8 @@ const Color Faction::AdjustedColour(fixed population, bool inRange) const
 {
 	PROFILE_SCOPED()
 	Color result;
-	result   = population == 0 ? BAD_FACTION_COLOUR : colour;
+	// Unexplored: population = -1, Uninhabited: population = 0.
+	result   = population <= 0 ? BAD_FACTION_COLOUR : colour;
 	result.a = population > 0  ? (FACTION_BASE_ALPHA + (M_E + (logf(population.ToFloat() / 1.25))) / ((2 * M_E) + FACTION_BASE_ALPHA)) * 255 : FACTION_BASE_ALPHA * 255;
 	result.a = inRange         ? 255 : result.a;
 	return result;


### PR DESCRIPTION
This applies the fix suggested in #2380, thus it only fixes faction colour of star name, not faction colour in zoom out view.

(For testing, rememer: Shift+arrow for fast movement in sector view)

Unexplored system name turns up as yellow:
![screenshot-20140808-130402](https://cloud.githubusercontent.com/assets/619390/3855884/816b57ac-1eec-11e4-8a55-803679dd6cfd.png)

This PR unexplored system name turns up as gray:
![screenshot-20140808-130145](https://cloud.githubusercontent.com/assets/619390/3855883/7deecf00-1eec-11e4-8bf3-2bcabf77c229.png)
