### PR TITLE
Fix system view ship crash

### DIFF
--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -26,7 +26,6 @@ static const float ZOOM_OUT_SPEED = 1.f/ZOOM_IN_SPEED;
 static const float WHEEL_SENSITIVITY = .1f;		// Should be a variable in user settings.
 // i don't know how to name it
 static const double ROUGH_SIZE_OF_TURD = 10.0;
-static const Uint32 SHIP_ORBIT_UPDATE_TICKS = 1000;
 
 TransferPlanner::TransferPlanner() {
 	m_dvPrograde = 0.0;
@@ -560,9 +559,7 @@ void SystemView::Draw3D()
 	glLineWidth(1);
 
 	if(m_shipDrawing != OFF) {
-		if(SDL_GetTicks() - m_lastShipListUpdate > SHIP_ORBIT_UPDATE_TICKS)
-			RefreshShips();
-
+		RefreshShips();
 		DrawShips(m_time - Pi::game->GetTime(), pos);
 	}
 
@@ -638,7 +635,6 @@ void SystemView::RefreshShips(void) {
 
 		}
 	}
-	m_lastShipListUpdate = SDL_GetTicks();
 }
 
 void SystemView::DrawShips(const double t, const vector3d &offset) {

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -76,7 +76,6 @@ private:
 	std::list<std::pair<Ship*, Orbit>> m_contacts;
 	Gui::LabelSet *m_shipLabels;
 	ShipDrawing m_shipDrawing;
-	Uint32 m_lastShipListUpdate;
 	float m_rot_x, m_rot_z;
 	float m_zoom, m_zoomTo;
 	double m_time;


### PR DESCRIPTION
Remove the delay in updating the ship contacts list.
It's cheap to do and if they get out of sync then it can crash.

To repro' the original crash just open the system view (F2 then F6) and accelerate time as fast as possible for a while. The game will crash because one of the ships will leave the system but the contacts list won't be updated so it will try and access a deleted ship object.
