### PR TITLE
Added Advanced Radar Mapper ship equip.

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -1,4 +1,12 @@
 {
+   "ADVANCED_RADAR_MAPPER" : {
+      "description" : "",
+      "message" : "Advanced Radar Mapper"
+   },
+   "ADVANCED_RADAR_MAPPER_DESCRIPTION" : {
+      "description" : "",
+      "message" : "Long range radar mapper with system wide coverage."
+   },
    "AIR_PROCESSORS" : {
       "description" : "",
       "message" : "Air processors"

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -520,7 +520,11 @@ misc.autopilot = EquipType.New({
 })
 misc.radar_mapper = EquipType.New({
 	l10n_key="RADAR_MAPPER", slots="radar", price=900,
-	capabilities={mass=1, radar_mapper=1}, purchasable=true
+	capabilities={mass=1, radar_mapper_level=1}, purchasable=true
+})
+misc.advanced_radar_mapper = EquipType.New({
+	l10n_key="ADVANCED_RADAR_MAPPER", slots="radar", price=1200,
+	capabilities={mass=1, radar_mapper_level=2}, purchasable=true
 })
 misc.fuel_scoop = EquipType.New({
 	l10n_key="FUEL_SCOOP", slots="fuel_scoop", price=3500,

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -858,19 +858,19 @@ void WorldView::RefreshButtonStateAndVisibility()
 	if (b) {
 		if (b->IsType(Object::SHIP)) {
 			int prop_var = 0;
-			Pi::player->Properties().Get("radar_mapper_cap", prop_var);
+			Pi::player->Properties().Get("radar_mapper_level_cap", prop_var);
 			if (prop_var > 0) {
 				assert(b->IsType(Object::SHIP));
 				Ship *s = static_cast<Ship*>(b);
 
 				const shipstats_t &stats = s->GetStats();
 
+				float sShields = 0;
 				float sHull = s->GetPercentHull();
 				m_hudTargetHullIntegrity->SetColor(get_color_for_warning_meter_bar(sHull));
 				m_hudTargetHullIntegrity->SetValue(sHull*0.01f);
 				m_hudTargetHullIntegrity->Show();
 
-				float sShields = 0;
 				prop_var = 0;
 				s->Properties().Get("shield_cap", prop_var);
 				if (prop_var > 0) {


### PR DESCRIPTION
It is a long range radar mapper that has the ability to give information on
ships selected in orbital view. It uses same slot as the normal radar mapper.

Idea is that this is more for pirates/assassins who wants to hunt down ships.

Also, if no advanced radar mapper is present, it still shows the label of the selected ship at top left corner (no screen shot of this).
![screenshot-20140811-170634](https://cloud.githubusercontent.com/assets/619390/3877876/e685468c-2169-11e4-97ee-5eca1caeca53.png)
