### PR TITLE
Consistent set nav target click

### DIFF
--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -387,13 +387,13 @@ void SystemView::LabelShip(Ship *s, const vector3d &offset) {
 
 	vector3d pos;
 	if (Gui::Screen::Project(offset, pos)) {
-		m_shipLabels->Add(s->GetLabel(), sigc::bind(sigc::mem_fun(this, &SystemView::OnClickShipLabel), s), pos.x, pos.y);
+		m_shipLabels->Add(s->GetLabel(), sigc::bind(sigc::mem_fun(this, &SystemView::OnClickShip), s), pos.x, pos.y);
 	}
 
 	Gui::Screen::LeaveOrtho();
 }
 
-void SystemView::OnClickShipLabel(Ship *s) {
+void SystemView::OnClickShip(Ship *s) {
 	if(!s) { printf("clicked on ship label but ship wasn't there\n"); return; }
 	if(Pi::player->GetNavTarget() == s) {
 		Pi::player->SetNavTarget(0); // remove current

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -68,7 +68,7 @@ private:
 	void RefreshShips(void);
 	void DrawShips(const double t, const vector3d &offset);
 	void LabelShip(Ship *s, const vector3d &offset);
-	void OnClickShipLabel(Ship *s);
+	void OnClickShip(Ship *s);
 
 	RefCountedPtr<StarSystem> m_system;
 	const SystemBody *m_selectedObject;


### PR DESCRIPTION
Makes clicking/un-clicking ships, planets, orbital stations behave the same.
No holding down SHIFT required for bodies anymore.

Fixes not being able to un-click planets.

With this PR the behaviour will be same as in SystemInfoView when clicking star or orbital station.

I also renamed `SystemView::OnClickShipLabel` to `SystemView::OnClickShip` to highlight the similarity with `SystemView::OnClickBody`. There's some code duplication between them, that maybe could be eliminated.
