### PR TITLE
Fix redundant ':' in comms message when no 'from' arg provided

### DIFF
--- a/src/GameLog.cpp
+++ b/src/GameLog.cpp
@@ -32,7 +32,10 @@ void GameLog::Add(const std::string &msg)
 
 void GameLog::Add(const std::string &from, const std::string &msg)
 {
-	Add(stringf("%0: %1", from, msg));
+	if(from.empty())
+		Add(msg);
+	else
+		Add(stringf("%0: %1", from, msg));
 }
 
 void GameLog::Update(bool paused)


### PR DESCRIPTION
Fixes the extra ":" when the `from` field is missing, as noted in #2527.

alternatively one could fix it down streams in LuaComms, but then both `l_comms_message` and `l_comms_important_message` need to be modified.
