### PR TITLE
make Message log font one step bigger

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -667,7 +667,7 @@ void Game::CreateViews()
 
 	UI::Point scrSize = Pi::ui->GetContext()->GetSize();
 	log = new GameLog(
-		Pi::ui->GetContext()->GetFont(UI::Widget::FONT_SMALLEST),
+		Pi::ui->GetContext()->GetFont(UI::Widget::FONT_NORMAL),
 		vector2f(scrSize.x, scrSize.y));
 }
 
@@ -712,7 +712,7 @@ void Game::LoadViews(Serializer::Reader &rd)
 
 	UI::Point scrSize = Pi::ui->GetContext()->GetSize();
 	log = new GameLog(
-		Pi::ui->GetContext()->GetFont(UI::Widget::FONT_SMALLEST),
+		Pi::ui->GetContext()->GetFont(UI::Widget::FONT_NORMAL),
 		vector2f(scrSize.x, scrSize.y));
 }
 


### PR DESCRIPTION
Closes #3139.
I agree that the font size in the message log is too small.

Below are not very good examples, since here it's white text on black, so it is always easy to see. But it's an improvement I think.

**Before:**
![screenshot-20140826-100656](https://cloud.githubusercontent.com/assets/619390/4041580/fc9b9b80-2cf7-11e4-87b5-d3f57c788442.png)

**After:**
![screenshot-20140826-095931](https://cloud.githubusercontent.com/assets/619390/4041567/c7400a84-2cf7-11e4-9e62-d500248af18a.png)
