### PR TITLE
Add support for patterns to space stations

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -175,6 +175,15 @@ void SpaceStation::InitStation()
 	SceneGraph::ModelSkin skin;
 	skin.SetDecal("pioneer");
 	skin.Apply(model);
+
+	if (model->SupportsPatterns()) {
+		Random rand(m_sbody->GetSeed());
+		skin.SetRandomColors(rand);
+		skin.Apply(model);
+		model->SetPattern(rand.Int32(0, model->GetNumPatterns()));
+	} else {
+		skin.Apply(model);
+	}
 }
 
 SpaceStation::~SpaceStation()


### PR DESCRIPTION
Now if the model supports patterns you can have alternative ... well, patterns.

Works just like ships and building.
