### PR TITLE
Show BUY and SELL prices not just PRICE-TO-BUY

### DIFF
--- a/data/ui/StationView/CommodityMarket.lua
+++ b/data/ui/StationView/CommodityMarket.lua
@@ -14,7 +14,7 @@ local l = Lang.GetResource("ui-core")
 
 local commodityMarket = function (args)
 	local stationTable, shipTable = EquipmentTableWidgets.Pair({
-		stationColumns = { "icon", "name", "price", "stock" },
+		stationColumns = { "icon", "name", "buy", "sell", "stock" },
 		shipColumns = { "icon", "name", "amount" },
 	})
 


### PR DESCRIPTION
Change to show "buy" and "sell" columns with different prices instead of just "price" column, necessary since they are different by 20%.

Fixes #3152
