### PR TITLE
cap maximum number of police GoodsTraders

### DIFF
--- a/data/modules/GoodsTrader/GoodsTrader.lua
+++ b/data/modules/GoodsTrader/GoodsTrader.lua
@@ -101,34 +101,46 @@ local onCreateBB = function (station)
 
 	local rand = Rand.New(station.seed)
 	local num = rand:Integer(1,3)
+
+	local numPolice = 0
+	local maxPolice = 1
+
 	for i = 1,num do
 		local ispolice = rand:Integer(1) == 1
 
-		local flavour = string.interp(l["GOODS_TRADER_"..rand:Integer(1, num_names)-1], {name = NameGen.Surname(rand)})
+		-- if too many fake police, don't place the ad
+		if not ispolice or numPolice < maxPolice then
 
-		local ad = {
-			station  = station,
-			flavour  = flavour,
-			ispolice = ispolice,
-			faceseed = rand:Integer(),
-		}
-
-		ad.stock = {}
-		ad.price = {}
-		for _,e in pairs(Equipment.cargo) do
-			if not Game.system:IsCommodityLegal(e) then
-				ad.stock[e] = Engine.rand:Integer(1,50)
-				-- going rate on the black market will be twice normal
-				ad.price[e] = ad.station:GetEquipmentPrice(e) * 2
+			if ispolice then
+				numPolice = numPolice + 1
 			end
-		end
 
-		local ref = ad.station:AddAdvert({
-			description = ad.flavour,
-			icon        = "goods_trader",
-			onChat      = onChat,
-			onDelete    = onDelete})
-		ads[ref] = ad
+			local flavour = string.interp(l["GOODS_TRADER_"..rand:Integer(1, num_names)-1], {name = NameGen.Surname(rand)})
+
+			local ad = {
+				station  = station,
+				flavour  = flavour,
+				ispolice = ispolice,
+				faceseed = rand:Integer(),
+			}
+
+			ad.stock = {}
+			ad.price = {}
+			for _,e in pairs(Equipment.cargo) do
+				if not Game.system:IsCommodityLegal(e) then
+					ad.stock[e] = Engine.rand:Integer(1,50)
+					-- going rate on the black market will be twice normal
+					ad.price[e] = ad.station:GetEquipmentPrice(e) * 2
+				end
+			end
+
+			local ref = ad.station:AddAdvert({
+				description = ad.flavour,
+				icon        = "goods_trader",
+				onChat      = onChat,
+				onDelete    = onDelete})
+			ads[ref] = ad
+		end
 	end
 end
 


### PR DESCRIPTION
## Description

This prevents placing too many `ispolice` Goodstraders, so with the parameters I've chosen, `maxPolice=1`, one can not have two police goods traders, since it will skip placing the ad if it turned out to be a police again.

So this just removes the 
- total of 2 goodstrader, both are police

But the following will still be possible:
- total of 1 goodstrader, who is police
- total of 1 goodstrader, who is not police
- total of 2 goodstrader, none are police
- total of 2 goodstrader, one is police

(I just wraped the code in an if-statement, and re-indented.)

Closes #3158 
## To do in the future

I noticed that _number_ of GoodsTraders or _fraction_ of them that will be police is not affected by `lawelssness`, only fine is. Nor is _price_ affected. Before that is fixed I think `lawlessness` needs to be able to be set for custom system, since I think Sol should be close to 0, and not the random non-zero value it now has.
