### PR TITLE
Allow to set lawlessness for custom systems

### DIFF
--- a/src/Polit.cpp
+++ b/src/Polit.cpp
@@ -193,12 +193,13 @@ void GetSysPolitStarSystem(const StarSystem *s, const fixed &human_infestedness,
 	Random rand(_init, 5);
 
 	RefCountedPtr<const Sector> sec = Pi::GetGalaxy()->GetSector(path);
+	const CustomSystem* customSystem = sec->m_systems[path.systemIndex].GetCustomSystem();
 
 	GovType a = GOV_INVALID;
 
 	/* from custom system definition */
-	if (sec->m_systems[path.systemIndex].GetCustomSystem()) {
-		Polit::GovType t = sec->m_systems[path.systemIndex].GetCustomSystem()->govType;
+	if (customSystem) {
+		Polit::GovType t = customSystem->govType;
 		a = t;
 	}
 	if (a == GOV_INVALID) {
@@ -218,7 +219,10 @@ void GetSysPolitStarSystem(const StarSystem *s, const fixed &human_infestedness,
 	}
 
 	outSysPolit.govType = a;
-	outSysPolit.lawlessness = s_govDesc[a].baseLawlessness * rand.Fixed();
+	if (customSystem && !customSystem->want_rand_lawlessness)
+		outSysPolit.lawlessness = customSystem->lawlessness;
+	else
+		outSysPolit.lawlessness = s_govDesc[a].baseLawlessness * rand.Fixed();
 }
 
 bool IsCommodityLegal(const StarSystem *s, const GalacticEconomy::Commodity t)

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -362,6 +362,16 @@ static int l_csys_govtype(lua_State *L)
 	return 1;
 }
 
+static int l_csys_lawlessness(lua_State *L)
+{
+	CustomSystem *cs = l_csys_check(L, 1);
+	const fixed *value = LuaFixed::CheckFromLua(L, 2);
+	cs->lawlessness = *value;
+	cs->want_rand_lawlessness = false;
+	lua_settop(L, 1);
+	return 1;
+}
+
 static void _add_children_to_sbody(lua_State *L, CustomSystemBody *sbody)
 {
 	lua_checkstack(L, 5); // grow the stack if necessary
@@ -483,6 +493,7 @@ static luaL_Reg LuaCustomSystem_meta[] = {
 	{ "long_desc", &l_csys_long_desc },
 	{ "faction", &l_csys_faction },
 	{ "govtype", &l_csys_govtype },
+	{ "lawlessness", &l_csys_lawlessness },
 	{ "bodies", &l_csys_bodies },
 	{ "add_to_sector", &l_csys_add_to_sector },
 	{ "__gc", &l_csys_gc },
@@ -582,7 +593,8 @@ CustomSystem::CustomSystem():
 	seed(0),
 	want_rand_explored(true),
 	faction(0),
-	govType(Polit::GOV_INVALID)
+	govType(Polit::GOV_INVALID),
+	want_rand_lawlessness(true)
 {
 	PROFILE_SCOPED()
 	for (int i = 0; i < 4; ++i)

--- a/src/galaxy/CustomSystem.h
+++ b/src/galaxy/CustomSystem.h
@@ -80,6 +80,8 @@ public:
 	bool                   explored;
 	Faction*               faction;
 	Polit::GovType         govType;
+	bool                   want_rand_lawlessness;
+	fixed                  lawlessness; // 0.0 = lawful, 1.0 = totally lawless
 	std::string            shortDesc;
 	std::string            longDesc;
 


### PR DESCRIPTION
This was inspired by a comment by @impaktor in #3165

You can now use `lawlessness(fixed_value)` in custom systems. If you don't, the lawlessness will be random as before (so now bump needed as long as we don't use it in custom systems).

To test:
- Add `:lawlessness(f(1,100))` to Sol
- Start game at Earth
- In Lua console: `print(Game.system.lawlessness)` (beware of rounding errors ;))
