### PR TITLE
Restrict FreeType headers to a single translation unit

### DIFF
--- a/src/FileSourceZip.cpp
+++ b/src/FileSourceZip.cpp
@@ -11,8 +11,6 @@ extern "C" {
 #include "miniz/miniz.h"
 }
 
-#undef FT_FILE // TODO FileInfo::FT_FILE is conflicting with a FreeType def; undefine it for now
-
 namespace FileSystem {
 
 FileSourceZip::FileSourceZip(FileSourceFS &fs, const std::string &zipPath) : FileSource(zipPath), m_archive(0)

--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -10,8 +10,6 @@
 #include <iterator>
 #include <stdexcept>
 
-#undef FT_FILE // XXX FileInfo::FT_FILE is conflicting with a FreeType def; undefine it for now
-
 namespace FileSystem {
 
 	static FileSourceFS dataFilesApp(GetDataDir(), true);

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -8,9 +8,15 @@
 #include "graphics/VertexArray.h"
 #include "TextSupport.h"
 #include "utils.h"
-#include <algorithm>
 
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_STROKER_H
 #include FT_GLYPH_H
+
+#undef FT_FILE // defined by FreeType, conflicts with a symbol name from FileSystem
+
+#include <algorithm>
 
 static const int ATLAS_SIZE = 1024;
 

--- a/src/text/TextureFont.h
+++ b/src/text/TextureFont.h
@@ -12,11 +12,15 @@
 #include "graphics/VertexArray.h"
 #include "graphics/RenderState.h"
 
-#include <ft2build.h>
-#include FT_FREETYPE_H
-#include FT_STROKER_H
-
 namespace FileSystem { class FileData; }
+
+// forward declarations for FreeType types
+struct FT_FaceRec_;
+struct FT_LibraryRec_;
+struct FT_StrokerRec_;
+typedef struct FT_FaceRec_ *FT_Face;
+typedef struct FT_LibraryRec_ *FT_Library;
+typedef struct FT_StrokerRec_ *FT_Stroker;
 
 namespace Text {
 

--- a/src/win32/FileSystemWin32.cpp
+++ b/src/win32/FileSystemWin32.cpp
@@ -11,9 +11,6 @@
 #include <algorithm>
 #include <cerrno>
 
-// I hate macros. I just hate them. Hate hate hate.
-#undef FT_FILE
-
 #include <windows.h>
 // GetPiUserDir() needs these
 #include <shlobj.h>


### PR DESCRIPTION
Trivial change. This means we can remove some ugly #undefs from other files, and generally avoid polluting the global namespace so much.

Fixes #1203.
