### PR TITLE
Fix FileSystemPosix for OS X

### DIFF
--- a/src/posix/FileSystemPosix.cpp
+++ b/src/posix/FileSystemPosix.cpp
@@ -115,9 +115,6 @@ namespace FileSystem {
 			mtime = Time::DateTime(
 				1900 + timeparts.tm_year, timeparts.tm_mon+1, timeparts.tm_mday,
 				timeparts.tm_hour, timeparts.tm_min, timeparts.tm_sec);
-#ifndef __APPLE__
-			mtime += Time::TimeDelta(info.st_mtim.tv_nsec / 1000, Time::Microsecond);
-#endif
 		}
 
 		return ty;


### PR DESCRIPTION
This should fix #3182, but it needs testing. In particular, assuming it builds, it would be good to check that the times listed in the load game dialog match the times reported by the Finder (it's called the Finder, right? I don't even know) for the save files.

/cc @eloquentmess
