### PR TITLE
Making linebreaks possible in model labels

### DIFF
--- a/src/text/DistanceFieldFont.cpp
+++ b/src/text/DistanceFieldFont.cpp
@@ -49,8 +49,8 @@ void DistanceFieldFont::GetGeometry(Graphics::VertexArray &va, const std::string
 	vector2f cursor = offset;
 	vector2f bounds(0.f);
 	for(unsigned int i=0; i<text.length(); i++) {
-		//If there is a '|', do a linebreak
-		if (text.at(i)=='|') {
+		//Look for \n and do a linebreak
+		if (text.at(i)=='\n') {
 			cursor.y--;
 			cursor.x=0;
 		} else {


### PR DESCRIPTION
This change enables you to add linebreaks in model labels.
Just add a '|' in the text to go to a new line.
This might be useful for translated labels, like the tombstone one, where in some languages the text is longer than the model. Could also be used for a few other things.
