### PR TITLE
Fix the construction of the Circle drawables.

### DIFF
--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -632,7 +632,7 @@ void SystemInfoView::BodyIcon::Draw()
 	    // The -0.1f offset seems to be the best compromise to make the circles closed (e.g. around Mars), symmetric, fitting with selection
 	    // and not overlapping to much with asteroids
 	    Graphics::Drawables::Circle circle =
-			Graphics::Drawables::Circle(size[0]*0.5f, size[0]*0.5f-0.1f, size[1]*0.5f, 0.f,
+			Graphics::Drawables::Circle(m_renderer, size[0]*0.5f, size[0]*0.5f-0.1f, size[1]*0.5f, 0.f,
 			portColor, m_renderState);
 	    circle.Draw(m_renderer);
 	}

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -8,19 +8,21 @@ namespace Graphics {
 
 namespace Drawables {
 
-Circle::Circle(const float radius, const Color &c, RenderState *state) : m_color(c) {
+Circle::Circle(Renderer *renderer, const float radius, const Color &c, RenderState *state) : m_color(c) {
 	m_renderState = state;
 	VertexArray vertices (ATTRIB_POSITION);
 	for (float theta=0; theta < 2*float(M_PI); theta += 0.05f*float(M_PI)) {
 		vertices.Add(vector3f(radius*sin(theta), radius*cos(theta), 0));
 	}
+	SetupVertexBuffer(vertices, renderer);
 }
-Circle::Circle(const float radius, const float x, const float y, const float z, const Color &c, RenderState *state) : m_color(c) {
+Circle::Circle(Renderer *renderer, const float radius, const float x, const float y, const float z, const Color &c, RenderState *state) : m_color(c) {
 	m_renderState = state;
 	VertexArray vertices (ATTRIB_POSITION);
 	for (float theta=0; theta < 2*float(M_PI); theta += 0.05f*float(M_PI)) {
 		vertices.Add(vector3f(radius*sin(theta) + x, radius*cos(theta) + y, z));
 	}
+	SetupVertexBuffer(vertices, renderer);
 }
 Circle::Circle(Renderer *renderer, const float radius, const vector3f &center, const Color &c, RenderState *state) : m_color(c) {
 	m_renderState = state;

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -21,8 +21,8 @@ namespace Drawables {
 
 class Circle {
 public:
-	Circle(const float radius, const Color &c, RenderState *state);
-	Circle(const float radius, const float x, const float y, const float z, const Color &c, RenderState *state);
+	Circle(Renderer *renderer, const float radius, const Color &c, RenderState *state);
+	Circle(Renderer *renderer, const float radius, const float x, const float y, const float z, const Color &c, RenderState *state);
 	Circle(Renderer *renderer, const float radius, const vector3f &center, const Color &c, RenderState *state);
 	virtual void Draw(Renderer *renderer);
 


### PR DESCRIPTION
Fix the construction of the Circle drawables. 
Two of the constructors were non-functional and only used in one place that I had missed during testing.

Fixes issue #3191
