### PR TITLE
Output the SDL version number.

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -406,6 +406,9 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 	if (SDL_Init(sdlInitFlags) < 0) {
 		Error("SDL initialization failed: %s\n", SDL_GetError());
 	}
+	SDL_version ver;
+	SDL_GetVersion(&ver);
+	Output("SDL Version %d.%d.%d\n", ver.major, ver.minor, ver.patch);
 
 	// Do rest of SDL video initialization and create Renderer
 	Graphics::Settings videoSettings = {};


### PR DESCRIPTION
This is to go along with my update to the [Win32 SDL version to 2.0.3](https://github.com/pioneerspacesim/pioneer-thirdparty/pull/8) and because it's useful info to have when people are reporting issues.
