### PR TITLE
Galaxy customization

### DIFF
--- a/src/Factions.cpp
+++ b/src/Factions.cpp
@@ -328,7 +328,7 @@ void FactionsDatabase::Init()
 	RegisterFactionsAPI(L);
 
 	LUA_DEBUG_CHECK(L, 0);
-	pi_lua_dofile_recursive(L, "factions");
+	pi_lua_dofile_recursive(L, m_factionDirectory);
 
 	LUA_DEBUG_END(L, 0);
 	lua_close(L);

--- a/src/Factions.h
+++ b/src/Factions.h
@@ -80,7 +80,7 @@ private:
 
 class FactionsDatabase {
 public:
-	FactionsDatabase(Galaxy* galaxy) : m_galaxy(galaxy), m_no_faction(galaxy), m_may_assign_factions(false), m_initialized(false) { }
+	FactionsDatabase(Galaxy* galaxy, const std::string& factionDir) : m_galaxy(galaxy), m_factionDirectory(factionDir), m_no_faction(galaxy), m_may_assign_factions(false), m_initialized(false) { }
 	~FactionsDatabase();
 
 	void Init();
@@ -123,6 +123,7 @@ private:
 	void SetHomeSectors();
 
 	Galaxy* const     m_galaxy;
+	const std::string m_factionDirectory;
 	Faction           m_no_faction;    // instead of answering null, we often want to answer a working faction object for no faction
 	FactionList       m_factions;
 	FactionMap        m_factions_byName;

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -559,7 +559,7 @@ void CustomSystemsDatabase::Init()
 	RegisterCustomSystemsAPI(L);
 
 	LUA_DEBUG_CHECK(L, 0);
-	pi_lua_dofile_recursive(L, "systems");
+	pi_lua_dofile_recursive(L, m_customSysDirectory);
 
 	LUA_DEBUG_END(L, 0);
 	lua_close(L);

--- a/src/galaxy/CustomSystem.h
+++ b/src/galaxy/CustomSystem.h
@@ -90,7 +90,7 @@ public:
 
 class CustomSystemsDatabase {
 public:
-	CustomSystemsDatabase(Galaxy* galaxy) : m_galaxy(galaxy) { }
+	CustomSystemsDatabase(Galaxy* galaxy, const std::string& customSysDir) : m_galaxy(galaxy), m_customSysDirectory(customSysDir) { }
 	~CustomSystemsDatabase();
 
 	void Init();
@@ -105,6 +105,7 @@ private:
 	typedef std::map<SystemPath, CustomSystemsDatabase::SystemList> SectorMap;
 
 	Galaxy* const m_galaxy;
+	const std::string m_customSysDirectory;
 	SectorMap m_sectorMap;
 	static const CustomSystemsDatabase::SystemList s_emptySystemList; // see: Null Object pattern
 };

--- a/src/galaxy/Galaxy.cpp
+++ b/src/galaxy/Galaxy.cpp
@@ -9,10 +9,11 @@
 #include "Pi.h"
 #include "FileSystem.h"
 
-Galaxy::Galaxy(RefCountedPtr<GalaxyGenerator> galaxyGenerator, float radius, float sol_offset_x, float sol_offset_y)
+Galaxy::Galaxy(RefCountedPtr<GalaxyGenerator> galaxyGenerator, float radius, float sol_offset_x, float sol_offset_y,
+	const std::string& factionsDir, const std::string& customSysDir)
 	: GALAXY_RADIUS(radius), SOL_OFFSET_X(sol_offset_x), SOL_OFFSET_Y(sol_offset_y),
 	m_galaxyGenerator(galaxyGenerator), m_sectorCache(this, galaxyGenerator),
-	m_starSystemCache(this, galaxyGenerator), m_factions(this), m_customSystems(this)
+	m_starSystemCache(this, galaxyGenerator), m_factions(this, factionsDir), m_customSystems(this, customSysDir)
 {
 }
 
@@ -83,8 +84,8 @@ int Galaxy::GetGeneratorVersion() const
 }
 
 DensityMapGalaxy::DensityMapGalaxy(RefCountedPtr<GalaxyGenerator> galaxyGenerator, const std::string& mapfile,
-	float radius, float sol_offset_x, float sol_offset_y)
-	: Galaxy(galaxyGenerator, radius, sol_offset_x, sol_offset_y),
+	float radius, float sol_offset_x, float sol_offset_y, const std::string& factionsDir, const std::string& customSysDir)
+	: Galaxy(galaxyGenerator, radius, sol_offset_x, sol_offset_y, factionsDir, customSysDir),
 	  m_mapWidth(0), m_mapHeight(0)
 {
 	RefCountedPtr<FileSystem::FileData> filedata = FileSystem::gameDataFiles.ReadFile(mapfile);

--- a/src/galaxy/Galaxy.h
+++ b/src/galaxy/Galaxy.h
@@ -16,7 +16,8 @@ class GalaxyGenerator;
 class Galaxy : public RefCounted {
 protected:
 	friend class GalaxyGenerator;
-	Galaxy(RefCountedPtr<GalaxyGenerator> galaxyGenerator, float radius, float sol_offset_x, float sol_offset_y);
+	Galaxy(RefCountedPtr<GalaxyGenerator> galaxyGenerator, float radius, float sol_offset_x, float sol_offset_y,
+		const std::string& factionsDir, const std::string& customSysDir);
 	virtual void Init();
 
 public:
@@ -57,7 +58,7 @@ class DensityMapGalaxy : public Galaxy {
 private:
 	friend class GalaxyGenerator;
 	DensityMapGalaxy(RefCountedPtr<GalaxyGenerator> galaxyGenerator, const std::string& mapfile,
-		float radius, float sol_offset_x, float sol_offset_y);
+		float radius, float sol_offset_x, float sol_offset_y,	const std::string& factionsDir, const std::string& customSysDir);
 
 public:
 	virtual Uint8 GetSectorDensity(const int sx, const int sy, const int sz) const;

--- a/src/galaxy/GalaxyGenerator.cpp
+++ b/src/galaxy/GalaxyGenerator.cpp
@@ -61,7 +61,7 @@ RefCountedPtr<Galaxy> GalaxyGenerator::Create(const std::string& name, Version v
 				->AddStarSystemStage(new PopulateStarSystemGenerator));
 
 			// NB : The galaxy density image MUST be in BMP format due to OSX failing to load pngs the same as Linux/Windows
-			s_galaxy = RefCountedPtr<Galaxy>(new DensityMapGalaxy(galgen, "galaxy_dense.bmp", 50000.0, 25000.0, 0.0));
+			s_galaxy = RefCountedPtr<Galaxy>(new DensityMapGalaxy(galgen, "galaxy_dense.bmp", 50000.0, 25000.0, 0.0, "factions", "systems"));
 			s_galaxy->Init();
 			return s_galaxy;
 		}


### PR DESCRIPTION
Okay, I couldn't resist, but this _really_ is a small refactoring and the last on my list for galaxy.

It moves control over a few galaxy customization points to the `GalaxyGenerator`:
1. Factor out the code how sector density is calculated into a sub-class of `Galaxy`, so that `Galaxy` is generic. Which sub-class is initiated is under the control of `GalaxyGenerator` (okay there is only one, but you get the point ;)). The file to be used is passed as an argument.
2. The base directory to be used for factions is passed as a parameter to the `FactionsDatabase` as an argument instead of being hard-coded there.
3. The same is true for `CustomSystemsDatabase`.

This now allows us to have different galaxy density maps (or even algorithms), factions and custom systems for different galaxy generators. Due to the versioning support in `GalaxyGenerator` this might save us some savegame bumps in future.
