### PR TITLE
Attributes for uv coords should be vec4 not vec2

### DIFF
--- a/data/shaders/gl2/attributes.glsl
+++ b/data/shaders/gl2/attributes.glsl
@@ -5,5 +5,5 @@
 attribute vec4 a_vertex;
 attribute vec3 a_normal;
 attribute vec4 a_color;
-attribute vec2 a_uv0;
+attribute vec4 a_uv0;
 #endif


### PR DESCRIPTION
Attributes for uv coords should be vec4 not vec2 fixes #3203
