### PR TITLE
Increased drag when flying with lowered gears

### DIFF
--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -29,6 +29,7 @@ public:
 	bool IsMoving() const { return m_isMoving; }
 	virtual double GetMass() const { return m_mass; }	// XXX don't override this
 	virtual void TimeStepUpdate(const float timeStep);
+	double CalcAtmosphericForce(double dragCoeff) const;
 	void CalcExternalForce();
 	void UndoTimestep();
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -876,6 +876,13 @@ void Ship::FireWeapon(int num)
 	LuaEvent::Queue("onShipFiring", this);
 }
 
+double Ship::ExtrapolateHullTemperature() const
+{
+	const double dragCoeff = DynamicBody::DEFAULT_DRAG_COEFF * 1.25;
+	const double dragGs = CalcAtmosphericForce(dragCoeff) / (GetMass() * 9.81);
+	return dragGs / 5.0;
+}
+
 double Ship::GetHullTemperature() const
 {
 	double dragGs = GetAtmosForce().Length() / (GetMass() * 9.81);

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -152,6 +152,8 @@ public:
 
 	// 0 to 1.0 is alive, > 1.0 = death
 	double GetHullTemperature() const;
+	// Calculate temperature we would have with wheels down
+	double ExtrapolateHullTemperature() const;
 
 	enum ECMResult {
 		ECM_NOT_INSTALLED,

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -567,6 +567,10 @@ void WorldView::RefreshButtonStateAndVisibility()
 		m_game->GetCpan()->SetOverlayToolTip(ShipCpanel::OVERLAY_BOTTOM_RIGHT, Lang::SHIP_ALTITUDE_ABOVE_TERRAIN);
 	}
 
+	if (is_equal_exact(Pi::player->GetWheelState(), 0.0f) && Pi::player->ExtrapolateHullTemperature() > 0.7)
+		m_wheelsButton->Hide();
+	else
+		m_wheelsButton->Show();
 	m_wheelsButton->SetActiveState(int(Pi::player->GetWheelState()) || Pi::player->GetWheelTransition() == 1);
 
 	RefreshHyperspaceButton();


### PR DESCRIPTION
Fixes #2509

As discussed in the above issue this increases atmospheric drag by 25% and disables the atmoshield if flying with lowered gears.

To avoid the self-destruct effect when lowering the wheels at high speeds in atmospheres, the wheel button is disabled (hidden) when lowering would cause a hull temperature > 0.7 (the ship explodes at 1.0).
