### PR TITLE
Re-init the cockpit when we buy a new ship

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -48,6 +48,7 @@ Player::Player(ShipType::Id shipId): Ship(shipId)
 void Player::SetShipType(const ShipType::Id &shipId) {
 	Ship::SetShipType(shipId);
 	registerEquipChangeListener(this);
+	InitCockpit();
 }
 
 void Player::Save(Serializer::Writer &wr, Space *space)


### PR DESCRIPTION
This fixes #3222 by reinitialising the cockpit model when the player buys a new ship.

@nozmajner there you go :)
