### PR TITLE
Fix alpha blending and render to texture

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -138,7 +138,7 @@ Sound::MusicPlayer Pi::musicPlayer;
 std::unique_ptr<AsyncJobQueue> Pi::asyncJobQueue;
 std::unique_ptr<SyncJobQueue> Pi::syncJobQueue;
 
-// XXX enabling this breaks UI gauge rendering. see #2627
+// Leaving define in place in case of future rendering problems.
 #define USE_RTT 1
 
 //static


### PR DESCRIPTION
Fix alpha blending and render to texture by clearing the screen after setting the renderTarget

Finally seem to have resolved this. In the future we can turn this into a proper post-processing system with colourisation, blurring etc if we want it.
