### PR TITLE
Match the BeginFrame with an EndFrame.

### DIFF
--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -113,7 +113,8 @@ void ObjectViewerView::Draw3D()
 	Graphics::Light light;
 	light.SetType(Graphics::Light::LIGHT_DIRECTIONAL);
 
-	if (Pi::MouseButtonState(SDL_BUTTON_RIGHT)) {
+	const int btnState = Pi::MouseButtonState(SDL_BUTTON_RIGHT);
+	if (btnState) {
 		int m[2];
 		Pi::GetMouseMotion(m);
 		m_camRot = matrix4x4d::RotateXMatrix(-0.002*m[1]) *
@@ -136,6 +137,9 @@ void ObjectViewerView::Draw3D()
 	}
 
 	UIView::Draw3D();
+	if (btnState) {
+		m_cameraContext->EndFrame();
+	}
 }
 
 void ObjectViewerView::OnSwitchTo()


### PR DESCRIPTION
Match the BeginFrame with an EndFrame to avoid leaking memory and asserting.

I hand't run in a build with asserts so hadn't noticed this before.
