### PR TITLE
Second footer for Capacity added, shown in equipment market

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -87,6 +87,10 @@
       "description" : "",
       "message" : "Cargo space"
    },
+   "CARGO_SPACE_USED" : {
+      "description" : "",
+      "message" : "Cargo space used"
+   },
    "CARGO_T_FREE" : {
       "description" : "",
       "message" : "{amount}t free"

--- a/data/libs/ui/TabView.lua
+++ b/data/libs/ui/TabView.lua
@@ -59,6 +59,7 @@ function TabView.AddTab (self, args)
 	local title    = args.title
 	local icon     = args.icon
 	local template = args.template
+	local footer   = args.footer
 
 	local tab = {
 		group    = self,
@@ -66,6 +67,7 @@ function TabView.AddTab (self, args)
 		icon     = icon,
 		title    = title,
 		template = template,
+		footer   = footer
 	}
 
 	self:RemoveTab(id)
@@ -126,6 +128,9 @@ function TabView.SwitchToNum (self, num)
 	self.title:SetText(tab.title)
 
 	self.body:SetInnerWidget(tab.template(tab, self))
+	if tab.footer then
+		self:SetFooter(tab.footer)
+	end
 end
 
 function TabView.SwitchTo (self, id)

--- a/data/ui/InfoView/ShipInfo.lua
+++ b/data/ui/InfoView/ShipInfo.lua
@@ -98,6 +98,8 @@ local shipInfo = function (args)
 						"",
 						{ l.WEIGHT_EMPTY..":",  string.format("%dt", player.totalMass - player.usedCapacity) },
 						{ l.CAPACITY_USED..":", string.format("%dt (%dt "..l.FREE..")", player.usedCapacity,  player.freeCapacity) },
+						{ l.CARGO_SPACE..":", string.format("%dt (%dt "..l.MAX..")", player.totalCargo, shipDef.equipSlotCapacity.cargo) },
+						{ l.CARGO_SPACE_USED..":", string.format("%dt (%dt "..l.FREE..")", player.usedCargo, player.totalCargo - player.usedCargo) },
 						{ l.FUEL_WEIGHT..":",   string.format("%dt (%dt "..l.MAX..")", player.fuelMassLeft, shipDef.fuelTankMass ) },
 						{ l.ALL_UP_WEIGHT..":", string.format("%dt", mass_with_fuel ) },
 						"",


### PR DESCRIPTION
Issue3117 implementation.
Summary:
- Added two new lines to ship info screen: Cargo space(available for cargo/ship maximum cargo capacity), Cargo space used(same as on the station view).
- Modified TabView to use unique footers for tabs(maybe not the best solution) so on the equipment market screen the capacity gauge is shown instead of the cargo gauge. Drawback: there are two footers now with duplicated ui elements and subscriptions to value changes because a ui element can be attached to one container only. 

Leftover/to discuss:
- I needed to add a new text entry: CARGO_SPACE_USED, it is only added to en.json atm.
  Any idea to avoid adding this new entry? or just dump this line?
  I tried with another language and there is no fallback to English(so the game crashed) why is that? Ugly text is better than nothing imo :)
