### PR TITLE
Disable shader validation due to OSX bug.

### DIFF
--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -43,6 +43,7 @@ static bool check_glsl_errors(const char *filename, GLuint obj)
 		return false;
 	}
 
+#if 0
 	if (!isShader) {
 		// perform general validation that the program is usable
 		glValidateProgram(obj);
@@ -55,6 +56,7 @@ static bool check_glsl_errors(const char *filename, GLuint obj)
 			return false;
 		}
 	}
+#endif
 
 	// Log warnings even if successfully compiled
 	// Sometimes the log is full of junk "success" messages so


### PR DESCRIPTION
Apparently checking if a shader is valid is invalid on OSX.
Disable it for now.

@eloquentmess this should get OSX working again and fix #3259

Will merge immediately.
