### PR TITLE
Make love to cargo code

### DIFF
--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -269,7 +269,7 @@ bool DynamicBody::OnCollision(Object *o, Uint32 flags, double relVel)
 	// damage (kineticEnergy is being passed as a damage value) is measured in kilograms
 	// ignore damage less than a gram except for cargo, which is very fragile.
 	CollisionContact dummy;
-	if (o->IsType(Object::CARGOBODY)){
+	if (this->IsType(Object::CARGOBODY)){
 		OnDamage(o, float(kineticEnergy), dummy);
 	}
 	else if (kineticEnergy > 1e-3){


### PR DESCRIPTION
Closes #3247 ("Cargo body collisions has code that needs some love")

This replaces code that was plain wrong with code that is correct.

However, I suspect this "correct" code is also redundant code. The idea for it being there in the first place was to have cargo containers be fragile, and be destroyed when falling to a planet, thus even very small collisions should count for cargo. 

So I tried dropping a container from 8 km altitude at Earth, and when it hit the ground, but unlike Humpty Dumpty's great fall off the wall, the `m_hitpoint` went from 1.0 to (1.0 - 7e-6). So pretty negligible and no kings men nor any of the kings horses were needed to put Humpty Dumpty back again.

The whole if statement for cargo could be removed. Opinions on that?

We could of course have `m_hitpoints` be 0.1 or 0.001 if we wanted. But then the question is of how hard should be be able to fly into cargo with out it begin destroyed (for ships with out cargo scoop). Right now, I can ram it pretty hard twice, and only then is it destroyed.
