### PR TITLE
Fix memory trampling of m_program on MXE/Linux.

### DIFF
--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -257,7 +257,7 @@ void Program::InitUniforms()
 
 	//Light uniform parameters
 	char cLight[64];
-	for( int i=0 ; i<=4 ; i++ ) {
+	for( int i=0 ; i<4 ; i++ ) {
 		snprintf(cLight, 64, "uLight[%d]", i);
 		const std::string strLight( cLight );
 		lights[i].diffuse.Init( (strLight + ".diffuse").c_str(), m_program );


### PR DESCRIPTION
Should fix #3251, #3262

It was running off the end of an array trampling other values. For some reason this was fine in all of my builds across all platforms and using VS2013. However it killed the MXE version.

@robn got it!
