### PR TITLE
Require OpenGL 3.1 context when opening the SDL window

### DIFF
--- a/src/graphics/WindowSDL.cpp
+++ b/src/graphics/WindowSDL.cpp
@@ -14,7 +14,7 @@ bool WindowSDL::CreateWindowAndContext(const char *name, int w, int h, bool full
 	if (!hidden && fullscreen) winFlags |= SDL_WINDOW_FULLSCREEN;
 
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
 	// cannot initialise 3.x content on OSX with anything but CORE profile
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 	// OSX also forces us to use this for 3.2 onwards


### PR DESCRIPTION
Since it appears we've settled for OpenGL 3.1 and not 3.2, ask SDL for
that.
