### PR TITLE
Switch font texture U/V coordinates to unsigned int

### DIFF
--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -362,8 +362,8 @@ TextureFont::Glyph TextureFont::BakeGlyph(Uint32 chr)
 		const FT_BitmapGlyph bmStrokeGlyph = FT_BitmapGlyph(strokeGlyph);
 
 		//don't run off atlas borders
-		m_atlasVIncrement = std::max(m_atlasVIncrement, bmStrokeGlyph->bitmap.rows);
-		if (m_atlasU + bmStrokeGlyph->bitmap.width > ATLAS_SIZE) {
+		m_atlasVIncrement = std::max(m_atlasVIncrement, (unsigned int)bmStrokeGlyph->bitmap.rows);
+		if (m_atlasU + (unsigned int)bmStrokeGlyph->bitmap.width > ATLAS_SIZE) {
 			m_atlasU = 0;
 			m_atlasV += m_atlasVIncrement;
 			m_atlasVIncrement = 0;
@@ -427,8 +427,8 @@ TextureFont::Glyph TextureFont::BakeGlyph(Uint32 chr)
 	else {
 
 		//don't run off atlas borders
-		m_atlasVIncrement = std::max(m_atlasVIncrement, bmGlyph->bitmap.rows);
-		if (m_atlasU + bmGlyph->bitmap.width >= ATLAS_SIZE) {
+		m_atlasVIncrement = std::max(m_atlasVIncrement, (unsigned int)bmGlyph->bitmap.rows);
+		if (m_atlasU + (unsigned int)bmGlyph->bitmap.width >= ATLAS_SIZE) {
 			m_atlasU = 0;
 			m_atlasV += m_atlasVIncrement;
 			m_atlasVIncrement = 0;

--- a/src/text/TextureFont.h
+++ b/src/text/TextureFont.h
@@ -90,9 +90,9 @@ private:
 	std::map<Uint32,Glyph> m_glyphs;
 
 	// UV offsets for glyphs
-	int m_atlasU;
-	int m_atlasV;
-	int m_atlasVIncrement;
+	unsigned int m_atlasU;
+	unsigned int m_atlasV;
+	unsigned int m_atlasVIncrement;
 
 	RefCountedPtr<Graphics::Texture> m_texture;
 	Graphics::TextureFormat m_texFormat;


### PR DESCRIPTION
This fixes build with freetype 2.5.4, in which FT_Bitmap::rows,
FT_Bitmap::width types were changed from int to unsigned int. Because
of that, max(int, unsigned int) failed to compile. And since U/V
coordinates are essentially unsigned, this also improves code
consistency.
