### PR TITLE
Move parentheses to correct position for ATLAS_SIZE test.

### DIFF
--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -428,7 +428,7 @@ TextureFont::Glyph TextureFont::BakeGlyph(Uint32 chr)
 
 		//don't run off atlas borders
 		m_atlasVIncrement = std::max(m_atlasVIncrement, static_cast<unsigned int>(bmGlyph->bitmap.rows));
-		if (m_atlasU + static_cast<unsigned int>(bmGlyph->bitmap.width >= ATLAS_SIZE)) {
+		if (m_atlasU + static_cast<unsigned int>(bmGlyph->bitmap.width) >= ATLAS_SIZE) {
 			m_atlasU = 0;
 			m_atlasV += m_atlasVIncrement;
 			m_atlasVIncrement = 0;


### PR DESCRIPTION
This is to fix #3298 found by @johnbartholomew earlier today.

@radius75 if you could build and test that would be great thankyou.

Andy
