### PR TITLE
Optimise VertexBuffer usage for SG Nodes.

### DIFF
--- a/src/scenegraph/Billboard.cpp
+++ b/src/scenegraph/Billboard.cpp
@@ -6,6 +6,9 @@
 #include "graphics/Graphics.h"
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
+#include "graphics/VertexBuffer.h"
+#include "graphics/Material.h"
+#include "graphics/RenderState.h"
 
 namespace SceneGraph {
 
@@ -42,6 +45,7 @@ void Billboard::Accept(NodeVisitor &nv)
 
 void Billboard::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	Graphics::Renderer *r = GetRenderer();
 
 	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0, 6);
@@ -62,8 +66,22 @@ void Billboard::Render(const matrix4x4f &trans, const RenderData *rd)
 	va.Add(m_offset-rotv2, vector2f(0.f, 1.f)); //bottom left
 	va.Add(m_offset+rotv1, vector2f(1.f, 1.f)); //bottom right
 
+	if( !m_vbuffer.Valid() )
+	{
+		//create buffer and upload data
+		Graphics::VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.attrib[1].semantic = Graphics::ATTRIB_UV0;
+		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
+		vbd.numVertices = va.GetNumVerts();
+		vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;	// we could be updating this per-frame
+		m_vbuffer.Reset( r->CreateVertexBuffer(vbd) );
+	}
+	m_vbuffer->Populate( va );
+
 	r->SetTransform(trans);
-	r->DrawTriangles(&va, m_renderState, m_material.Get());
+	r->DrawBuffer(m_vbuffer.Get(), m_renderState, m_material.Get());
 }
 
 }

--- a/src/scenegraph/Billboard.h
+++ b/src/scenegraph/Billboard.h
@@ -7,8 +7,12 @@
  * One or more billboard sprites, meant for lights mostly
  */
 #include "Node.h"
-#include "graphics/Material.h"
-#include "graphics/RenderState.h"
+
+namespace Graphics {
+	class Material;
+	class VertexBuffer;
+	class RenderState;
+}
 
 namespace SceneGraph {
 
@@ -25,6 +29,7 @@ public:
 private:
 	float m_size;
 	RefCountedPtr<Graphics::Material> m_material;
+	RefCountedPtr<Graphics::VertexBuffer> m_vbuffer;
 	Graphics::RenderState *m_renderState;
 	vector3f m_offset;
 };

--- a/src/scenegraph/Group.cpp
+++ b/src/scenegraph/Group.cpp
@@ -116,11 +116,13 @@ void Group::Traverse(NodeVisitor &nv)
 
 void Group::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	RenderChildren(trans, rd);
 }
 
 void Group::RenderChildren(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	for(std::vector<Node*>::iterator itr = m_children.begin(), itEnd = m_children.end(); itr != itEnd; ++itr)
 	{
 		if((*itr)->GetNodeMask() & rd->nodemask)

--- a/src/scenegraph/LOD.cpp
+++ b/src/scenegraph/LOD.cpp
@@ -40,6 +40,7 @@ void LOD::AddLevel(float pixelSize, Node *nod)
 
 void LOD::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	//figure out approximate pixel size of object's bounding radius
 	//on screen and pick a child to render
 	const vector3f cameraPos(-trans[12], -trans[13], -trans[14]);

--- a/src/scenegraph/Label3D.cpp
+++ b/src/scenegraph/Label3D.cpp
@@ -5,6 +5,7 @@
 #include "NodeVisitor.h"
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
+#include "graphics/VertexBuffer.h"
 
 namespace SceneGraph {
 
@@ -46,15 +47,31 @@ void Label3D::SetText(const std::string &text)
 {
 	//regenerate geometry
 	m_geometry->Clear();
-	if (!text.empty())
+	if (!text.empty()) {
 		m_font->GetGeometry(*m_geometry, text, vector2f(0.f));
+		
+		//create buffer and upload data
+		Graphics::VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.attrib[1].semantic = Graphics::ATTRIB_NORMAL;
+		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.attrib[2].semantic = Graphics::ATTRIB_UV0;
+		vbd.attrib[2].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
+		vbd.numVertices = m_geometry->GetNumVerts();
+		vbd.usage = Graphics::BUFFER_USAGE_STATIC;
+
+		m_vbuffer.reset( m_renderer->CreateVertexBuffer(vbd) );
+		m_vbuffer->Populate(*m_geometry);
+	}
 }
 
 void Label3D::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	Graphics::Renderer *r = GetRenderer();
 	r->SetTransform(trans);
-	r->DrawTriangles(m_geometry.get(), m_renderState, m_material.Get());
+	r->DrawBuffer(m_vbuffer.get(), m_renderState, m_material.Get());
 }
 
 void Label3D::Accept(NodeVisitor &nv)

--- a/src/scenegraph/Label3D.h
+++ b/src/scenegraph/Label3D.h
@@ -30,6 +30,7 @@ public:
 private:
 	RefCountedPtr<Graphics::Material> m_material;
 	std::unique_ptr<Graphics::VertexArray> m_geometry;
+	std::unique_ptr<Graphics::VertexBuffer> m_vbuffer;
 	RefCountedPtr<Text::DistanceFieldFont> m_font;
 	Graphics::RenderState *m_renderState;
 };

--- a/src/scenegraph/MatrixTransform.cpp
+++ b/src/scenegraph/MatrixTransform.cpp
@@ -32,7 +32,10 @@ void MatrixTransform::Accept(NodeVisitor &nv)
 
 void MatrixTransform::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	const matrix4x4f t = trans * m_transform;
+	//renderer->SetTransform(t);
+	//DrawAxes();
 	RenderChildren(t, rd);
 }
 

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -92,6 +92,7 @@ Model *Model::MakeInstance() const
 
 void Model::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	//update color parameters (materials are shared by model instances)
 	if (m_curPattern) {
 		for (MaterialContainer::const_iterator it = m_materials.begin(); it != m_materials.end(); ++it) {
@@ -155,11 +156,12 @@ void Model::Render(const matrix4x4f &trans, const RenderData *rd)
 	}
 }
 
-void Model::DrawAabb()
+void Model::CreateAabbVB()
 {
+	PROFILE_SCOPED()
 	if (!m_collMesh) return;
 
-	Aabb aabb = m_collMesh->GetAabb();
+	const Aabb aabb = m_collMesh->GetAabb();
 
 	const vector3f verts[16] = {
 		vector3f(aabb.min.x, aabb.min.y, aabb.min.z),
@@ -181,36 +183,88 @@ void Model::DrawAabb()
 		vector3f(aabb.min.x, aabb.max.y, aabb.max.z),
 	};
 
-	auto state = m_renderer->CreateRenderState(Graphics::RenderStateDesc());
-	m_renderer->DrawLines(8, verts + 0, Color::GREEN, state, Graphics::LINE_STRIP);
-	m_renderer->DrawLines(8, verts + 8, Color::GREEN, state, Graphics::LINE_STRIP);
+	if( !m_aabbVB.Valid() )
+	{
+		Graphics::VertexArray va(Graphics::ATTRIB_POSITION, 28);
+		for(unsigned int i = 0; i < 7; i++) {
+			va.Add(verts[i]);
+			va.Add(verts[i+1]);
+		}
+		
+		for(unsigned int i = 8; i < 15; i++) {
+			va.Add(verts[i]);
+			va.Add(verts[i+1]);
+		}
+
+		Graphics::MaterialDescriptor desc;
+		m_aabbMat.Reset(m_renderer->CreateMaterial(desc));
+		m_aabbMat->diffuse = Color::GREEN;
+
+		//create buffer and upload data
+		Graphics::VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.numVertices = va.GetNumVerts();
+		vbd.usage = Graphics::BUFFER_USAGE_STATIC;
+		m_aabbVB.Reset( m_renderer->CreateVertexBuffer(vbd) );
+		m_aabbVB->Populate( va );
+	}
+
+	m_state = m_renderer->CreateRenderState(Graphics::RenderStateDesc());
+}
+
+void Model::DrawAabb()
+{
+	if (!m_collMesh) return;
+
+	if( !m_aabbVB.Valid() ) {
+		CreateAabbVB();
+	}
+
+	m_renderer->DrawBuffer( m_aabbVB.Get(), m_state, m_aabbMat.Get(), Graphics::LINE_SINGLE);
+	
 }
 
 // Draw collision mesh as a wireframe overlay
 void Model::DrawCollisionMesh()
 {
+	PROFILE_SCOPED()
 	if (!m_collMesh) return;
 
-	const vector3f *vertices = reinterpret_cast<const vector3f*>(m_collMesh->GetGeomTree()->GetVertices());
-	const Uint16 *indices = m_collMesh->GetGeomTree()->GetIndices();
-	const unsigned int *triFlags = m_collMesh->GetGeomTree()->GetTriFlags();
-	const unsigned int numIndices = m_collMesh->GetGeomTree()->GetNumTris() * 3;
+	if( !m_collisionMeshVB.Valid() )
+	{
+		const vector3f *vertices = reinterpret_cast<const vector3f*>(m_collMesh->GetGeomTree()->GetVertices());
+		const Uint16 *indices = m_collMesh->GetGeomTree()->GetIndices();
+		const unsigned int *triFlags = m_collMesh->GetGeomTree()->GetTriFlags();
+		const unsigned int numIndices = m_collMesh->GetGeomTree()->GetNumTris() * 3;
 
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE, numIndices * 3);
-	int trindex = -1;
-	for(unsigned int i = 0; i < numIndices; i++) {
-		if (i % 3 == 0)
-			trindex++;
-		const unsigned int flag = triFlags[trindex];
-		//show special geomflags in red
-		va.Add(vertices[indices[i]], flag > 0 ? Color::RED : Color::WHITE);
+		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE, numIndices * 3);
+		int trindex = -1;
+		for(unsigned int i = 0; i < numIndices; i++) {
+			if (i % 3 == 0)
+				trindex++;
+			const unsigned int flag = triFlags[trindex];
+			//show special geomflags in red
+			va.Add(vertices[indices[i]], flag > 0 ? Color::RED : Color::WHITE);
+		}
+
+		//create buffer and upload data
+		Graphics::VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.attrib[1].semantic = Graphics::ATTRIB_DIFFUSE;
+		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_UBYTE4;
+		vbd.numVertices = va.GetNumVerts();
+		vbd.usage = Graphics::BUFFER_USAGE_STATIC;
+		m_collisionMeshVB.Reset( m_renderer->CreateVertexBuffer(vbd) );
+		m_collisionMeshVB->Populate( va );
 	}
 
 	//might want to add some offset
 	m_renderer->SetWireFrameMode(true);
 	Graphics::RenderStateDesc rsd;
 	rsd.cullMode = Graphics::CULL_NONE;
-	m_renderer->DrawTriangles(&va, m_renderer->CreateRenderState(rsd), Graphics::vtxColorMaterial);
+	m_renderer->DrawBuffer(m_collisionMeshVB.Get(), m_renderer->CreateRenderState(rsd), Graphics::vtxColorMaterial);
 	m_renderer->SetWireFrameMode(false);
 }
 

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -72,7 +72,10 @@
 #include "DeleteEmitter.h"
 #include <stdexcept>
 
-namespace Graphics { class Renderer; }
+namespace Graphics { 
+	class Renderer; 
+	class VertexBuffer;
+}
 
 namespace SceneGraph
 {
@@ -181,6 +184,7 @@ private:
 	Graphics::Texture *m_curDecals[MAX_DECAL_MATERIALS];
 
 	// debug support
+	void CreateAabbVB();
 	void DrawAabb();
 	void DrawCollisionMesh();
 	void DrawAxisIndicators(std::vector<Graphics::Drawables::Line3D> &lines);
@@ -189,6 +193,10 @@ private:
 	Uint32 m_debugFlags;
 	std::vector<Graphics::Drawables::Line3D> m_tagPoints;
 	std::vector<Graphics::Drawables::Line3D> m_dockingPoints;
+	RefCountedPtr<Graphics::VertexBuffer> m_collisionMeshVB;
+	RefCountedPtr<Graphics::VertexBuffer> m_aabbVB;
+	RefCountedPtr<Graphics::Material> m_aabbMat;
+	Graphics::RenderState* m_state;
 };
 
 }

--- a/src/scenegraph/ModelNode.cpp
+++ b/src/scenegraph/ModelNode.cpp
@@ -25,6 +25,7 @@ Node* ModelNode::Clone(NodeCopyCache *cache)
 
 void ModelNode::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	//slight hack here
 	RenderData newrd = *rd;
 	newrd.nodemask |= MASK_IGNORE;

--- a/src/scenegraph/Node.cpp
+++ b/src/scenegraph/Node.cpp
@@ -3,6 +3,7 @@
 
 #include "Node.h"
 #include "NodeVisitor.h"
+#include "graphics/Drawables.h"
 #include "graphics/Renderer.h"
 
 namespace SceneGraph {
@@ -50,6 +51,12 @@ Node* Node::FindNode(const std::string &name)
 		return this;
 	else
 		return 0;
+}
+
+void Node::DrawAxes()
+{
+	Graphics::Drawables::Axes3D *axes = Graphics::Drawables::GetAxes3DDrawable(m_renderer);
+	axes->Draw(m_renderer);
 }
 
 void Node::Save(NodeDatabase &db)

--- a/src/scenegraph/Node.h
+++ b/src/scenegraph/Node.h
@@ -78,6 +78,7 @@ public:
 	virtual void Accept(NodeVisitor &v);
 	virtual void Traverse(NodeVisitor &v);
 	virtual void Render(const matrix4x4f &trans, const RenderData *rd) { }
+	void DrawAxes();
 	void SetName(const std::string &name) { m_name = name; }
 	const std::string &GetName() const { return m_name; }
 

--- a/src/scenegraph/StaticGeometry.cpp
+++ b/src/scenegraph/StaticGeometry.cpp
@@ -43,6 +43,7 @@ void StaticGeometry::Accept(NodeVisitor &nv)
 
 void StaticGeometry::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	SDL_assert(m_renderState);
 	Graphics::Renderer *r = GetRenderer();
 	r->SetTransform(trans);
@@ -264,8 +265,20 @@ void StaticGeometry::DrawBoundingBox(const Aabb &bb)
 	Graphics::RenderStateDesc rsd;
 	rsd.cullMode = Graphics::CULL_NONE;
 
+	RefCountedPtr<Graphics::VertexBuffer> vb;
+	//create buffer and upload data
+	Graphics::VertexBufferDesc vbd;
+	vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+	vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+	vbd.attrib[1].semantic = Graphics::ATTRIB_DIFFUSE;
+	vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_UBYTE4;
+	vbd.numVertices = vts->GetNumVerts();
+	vbd.usage = Graphics::BUFFER_USAGE_STATIC;
+	vb.Reset( m_renderer->CreateVertexBuffer(vbd) );
+	vb->Populate( *vts );
+
 	r->SetWireFrameMode(true);
-	r->DrawTriangles(vts.get(), r->CreateRenderState(rsd), Graphics::vtxColorMaterial);
+	r->DrawBuffer(vb.Get(), r->CreateRenderState(rsd), Graphics::vtxColorMaterial);
 	r->SetWireFrameMode(false);
 }
 

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -23,9 +23,6 @@ Thruster::Thruster(Graphics::Renderer *r, bool _linear, const vector3f &_pos, co
 , dir(_dir)
 , pos(_pos)
 {
-	m_tVerts.reset(CreateThrusterGeometry());
-	m_glowVerts.reset(CreateGlowGeometry());
-
 	//set up materials
 	Graphics::MaterialDescriptor desc;
 	desc.textures = 1;
@@ -53,8 +50,6 @@ Thruster::Thruster(const Thruster &thruster, NodeCopyCache *cache)
 , dir(thruster.dir)
 , pos(thruster.pos)
 {
-	m_tVerts.reset(CreateThrusterGeometry());
-	m_glowVerts.reset(CreateGlowGeometry());
 }
 
 Node* Thruster::Clone(NodeCopyCache *cache)
@@ -69,6 +64,7 @@ void Thruster::Accept(NodeVisitor &nv)
 
 void Thruster::Render(const matrix4x4f &trans, const RenderData *rd)
 {
+	PROFILE_SCOPED()
 	float power = -dir.Dot(vector3f(rd->linthrust));
 
 	if (!linearOnly) {
@@ -101,9 +97,14 @@ void Thruster::Render(const matrix4x4f &trans, const RenderData *rd)
 	m_tMat->diffuse.a = 255 - m_glowMat->diffuse.a;
 
 	Graphics::Renderer *r = GetRenderer();
+	if( !m_tBuffer.Valid() ) {
+		m_tBuffer.Reset(CreateThrusterGeometry(r, m_tMat.Get()));
+		m_glowBuffer.Reset(CreateGlowGeometry(r, m_glowMat.Get()));
+	}
+
 	r->SetTransform(trans);
-	r->DrawTriangles(m_tVerts.get(), m_renderState, m_tMat.Get());
-	r->DrawTriangles(m_glowVerts.get(), m_renderState, m_glowMat.Get());
+	r->DrawBuffer(m_tBuffer.Get(), m_renderState, m_tMat.Get());
+	r->DrawBuffer(m_glowBuffer.Get(), m_renderState, m_glowMat.Get());
 }
 
 void Thruster::Save(NodeDatabase &db)
@@ -123,10 +124,9 @@ Thruster *Thruster::Load(NodeDatabase &db)
 	return t;
 }
 
-Graphics::VertexArray *Thruster::CreateThrusterGeometry()
+Graphics::VertexBuffer *Thruster::CreateThrusterGeometry(Graphics::Renderer *r, Graphics::Material *mat)
 {
-	Graphics::VertexArray *verts =
-		new Graphics::VertexArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
+	Graphics::VertexArray verts(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
 
 	//zero at thruster center
 	//+x down
@@ -147,13 +147,13 @@ Graphics::VertexArray *Thruster::CreateThrusterGeometry()
 
 	//add four intersecting planes to create a volumetric effect
 	for (int i=0; i < 4; i++) {
-		verts->Add(one, topLeft);
-		verts->Add(two, topRight);
-		verts->Add(three, botRight);
+		verts.Add(one, topLeft);
+		verts.Add(two, topRight);
+		verts.Add(three, botRight);
 
-		verts->Add(three, botRight);
-		verts->Add(four, botLeft);
-		verts->Add(one, topLeft);
+		verts.Add(three, botRight);
+		verts.Add(four, botLeft);
+		verts.Add(one, topLeft);
 
 		one.ArbRotate(vector3f(0.f, 0.f, 1.f), DEG2RAD(45.f));
 		two.ArbRotate(vector3f(0.f, 0.f, 1.f), DEG2RAD(45.f));
@@ -161,13 +161,23 @@ Graphics::VertexArray *Thruster::CreateThrusterGeometry()
 		four.ArbRotate(vector3f(0.f, 0.f, 1.f), DEG2RAD(45.f));
 	}
 
-	return verts;
+	//create buffer and upload data
+	Graphics::VertexBufferDesc vbd;
+	vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+	vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+	vbd.attrib[1].semantic = Graphics::ATTRIB_UV0;
+	vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
+	vbd.numVertices = verts.GetNumVerts();
+	vbd.usage = Graphics::BUFFER_USAGE_STATIC;
+	Graphics::VertexBuffer *vb = r->CreateVertexBuffer(vbd);
+	vb->Populate(verts);
+
+	return vb;
 }
 
-Graphics::VertexArray *Thruster::CreateGlowGeometry()
+Graphics::VertexBuffer *Thruster::CreateGlowGeometry(Graphics::Renderer *r, Graphics::Material *mat)
 {
-	Graphics::VertexArray *verts =
-		new Graphics::VertexArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
+	Graphics::VertexArray verts(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
 
 	//create glow billboard for linear thrusters
 	const float w = 0.2;
@@ -184,19 +194,30 @@ Graphics::VertexArray *Thruster::CreateGlowGeometry()
 	const vector2f botRight(1.f, 0.f);
 
 	for (int i = 0; i < 5; i++) {
-		verts->Add(one, topLeft);
-		verts->Add(two, topRight);
-		verts->Add(three, botRight);
+		verts.Add(one, topLeft);
+		verts.Add(two, topRight);
+		verts.Add(three, botRight);
 
-		verts->Add(three, botRight);
-		verts->Add(four, botLeft);
-		verts->Add(one, topLeft);
+		verts.Add(three, botRight);
+		verts.Add(four, botLeft);
+		verts.Add(one, topLeft);
 
 		one.z += .1f;
 		two.z = three.z = four.z = one.z;
 	}
 
-	return verts;
+	//create buffer and upload data
+	Graphics::VertexBufferDesc vbd;
+	vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+	vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+	vbd.attrib[1].semantic = Graphics::ATTRIB_UV0;
+	vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
+	vbd.numVertices = verts.GetNumVerts();
+	vbd.usage = Graphics::BUFFER_USAGE_STATIC;
+	Graphics::VertexBuffer *vb = r->CreateVertexBuffer(vbd);
+	vb->Populate(verts);
+
+	return vb;
 }
 
 }

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -11,7 +11,7 @@
 
 namespace Graphics {
 	class Renderer;
-	class VertexArray;
+	class VertexBuffer;
 	class Material;
 	class RenderState;
 }
@@ -30,12 +30,12 @@ public:
 	static Thruster *Load(NodeDatabase&);
 
 private:
-	static Graphics::VertexArray* CreateThrusterGeometry();
-	static Graphics::VertexArray* CreateGlowGeometry();
+	static Graphics::VertexBuffer* CreateThrusterGeometry(Graphics::Renderer*, Graphics::Material*);
+	static Graphics::VertexBuffer* CreateGlowGeometry(Graphics::Renderer*, Graphics::Material*);
 	RefCountedPtr<Graphics::Material> m_tMat;
 	RefCountedPtr<Graphics::Material> m_glowMat;
-	std::unique_ptr<Graphics::VertexArray> m_tVerts;
-	std::unique_ptr<Graphics::VertexArray> m_glowVerts;
+	RefCountedPtr<Graphics::VertexBuffer> m_tBuffer;
+	RefCountedPtr<Graphics::VertexBuffer> m_glowBuffer;
 	Graphics::RenderState *m_renderState;
 	bool linearOnly;
 	vector3f dir;


### PR DESCRIPTION
Cache VertexBuffer buffers for most of the SceneGraph node types that can render.

This is intended to fix #3296 which several people have commented on. @walterar you should be able to see a big improvement with these changes.

Andy