### PR TITLE
Remove DrawPoints & DrawLines methods

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -202,6 +202,15 @@ void Starfield::Init()
 	desc.vertexColors = true;
 	m_material.Reset(m_renderer->CreateMaterial(desc));
 	m_material->emissive = Color::WHITE;
+
+	Graphics::VertexBufferDesc vbd;
+	vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+	vbd.attrib[0].format = Graphics::ATTRIB_FORMAT_FLOAT3;
+	vbd.attrib[1].semantic = Graphics::ATTRIB_DIFFUSE;
+	vbd.attrib[1].format = Graphics::ATTRIB_FORMAT_UBYTE4;
+	vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;
+	vbd.numVertices = BG_STAR_MAX*2;
+	m_animBuffer.reset(m_renderer->CreateVertexBuffer(vbd));
 }
 
 void Starfield::Fill(Random &rand)
@@ -247,25 +256,30 @@ void Starfield::Draw(Graphics::RenderState *rs)
 	if (!Pi::game || Pi::player->GetFlightState() != Ship::HYPERSPACE) {
 		m_renderer->DrawBuffer(m_vertexBuffer.get(), rs, m_material.Get(), Graphics::POINTS);
 	} else {
+		assert(sizeof(StarVert) == 16);
+		assert(m_animBuffer->GetDesc().stride == sizeof(StarVert));
+		auto vtxPtr = m_animBuffer->Map<StarVert>(Graphics::BUFFER_MAP_WRITE);
+
 		// roughly, the multiplier gets smaller as the duration gets larger.
 		// the time-looking bits in this are completely arbitrary - I figured
 		// it out by tweaking the numbers until it looked sort of right
-		double mult = 0.0015 / (Pi::player->GetHyperspaceDuration() / (60.0*60.0*24.0*7.0));
+		const double mult = 0.0015 / (Pi::player->GetHyperspaceDuration() / (60.0*60.0*24.0*7.0));
 
-		double hyperspaceProgress = Pi::game->GetHyperspaceProgress();
+		const double hyperspaceProgress = Pi::game->GetHyperspaceProgress();
 
 		const vector3d pz = Pi::player->GetOrient().VectorZ();	//back vector
 		for (int i=0; i<BG_STAR_MAX; i++) {
 			vector3f v = m_hyperVtx[BG_STAR_MAX * 2 + i] + vector3f(pz*hyperspaceProgress*mult);
 			const Color &c = m_hyperCol[BG_STAR_MAX * 2 + i];
 
-			m_hyperVtx[i*2] = m_hyperVtx[BG_STAR_MAX * 2 + i] + v;
-			m_hyperCol[i*2] = c;
+			vtxPtr[i*2].pos = m_hyperVtx[i*2] = m_hyperVtx[BG_STAR_MAX * 2 + i] + v;
+			vtxPtr[i*2].col = m_hyperCol[i*2] = c;
 
-			m_hyperVtx[i*2+1] = v;
-			m_hyperCol[i*2+1] = c;
+			vtxPtr[i*2+1].pos = m_hyperVtx[i*2+1] = v;
+			vtxPtr[i*2+1].col = m_hyperCol[i*2+1] = c;
 		}
-		m_renderer->DrawLines(BG_STAR_MAX*2, m_hyperVtx, m_hyperCol, rs);
+		m_animBuffer->Unmap();
+		m_renderer->DrawBuffer(m_animBuffer.get(), rs, m_material.Get(), Graphics::LINE_SINGLE);
 	}
 }
 

--- a/src/Background.h
+++ b/src/Background.h
@@ -66,6 +66,7 @@ namespace Background
 		//hyperspace animation vertex data
 		vector3f m_hyperVtx[BG_STAR_MAX*3];
 		Color m_hyperCol[BG_STAR_MAX*3];
+		std::unique_ptr<Graphics::VertexBuffer> m_animBuffer;
 	};
 
 	class MilkyWay : public BackgroundElement

--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -55,6 +55,7 @@ GalacticView::GalacticView(Game* game) : UIView(), m_game(game), m_galaxy(game->
 	Graphics::RenderStateDesc rsd;
 	rsd.depthTest  = false;
 	rsd.depthWrite = false;
+	rsd.cullMode   = CULL_NONE;
 	m_renderState = Gui::Screen::GetRenderer()->CreateRenderState(rsd);
 
 	// setup scale lines
@@ -135,7 +136,7 @@ void GalacticView::Draw3D()
 
 	// "you are here" dot
 	const vector3f offs(offset_x, offset_y, 0.f);
-	m_youAreHere.SetData(1, &offs, matrix4x4f::Identity(), Color::GREEN, pointsize);
+	m_youAreHere.SetData(m_renderer, 1, &offs, matrix4x4f::Identity(), Color::GREEN, pointsize);
 	m_youAreHere.Draw(m_renderer, m_renderState);
 
 	// scale at the top

--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -27,7 +27,6 @@ static const float WHEEL_SENSITIVITY = .2f;		// Should be a variable in user set
 GalacticView::GalacticView(Game* game) : UIView(), m_game(game), m_galaxy(game->GetGalaxy()),
 	m_quad(Graphics::TextureBuilder::UI("galaxy_colour.png").CreateTexture(Gui::Screen::GetRenderer()))
 {
-
 	SetTransparency(true);
 	m_zoom = 1.0f;
 	m_zoomTo = m_zoom;
@@ -57,6 +56,15 @@ GalacticView::GalacticView(Game* game) : UIView(), m_game(game), m_galaxy(game->
 	rsd.depthTest  = false;
 	rsd.depthWrite = false;
 	m_renderState = Gui::Screen::GetRenderer()->CreateRenderState(rsd);
+
+	// setup scale lines
+	const vector3f vts[] = {
+		vector3f(-0.25f,-0.93f, 0.0f),
+		vector3f(-0.25f,-0.94f, 0.0f),
+		vector3f(0.25f,-0.94f, 0.0f),
+		vector3f(0.25f,-0.93f, 0.0f)
+	};
+	m_scalelines.SetData(4, vts, Color::WHITE);
 }
 
 GalacticView::~GalacticView()
@@ -132,14 +140,7 @@ void GalacticView::Draw3D()
 
 	// scale at the top
 	m_renderer->SetTransform(matrix4x4f::Identity());
-	//Color white(255);
-	const vector3f vts[] = {
-		vector3f(-0.25f,-0.93f, 0.0f),
-		vector3f(-0.25f,-0.94f, 0.0f),
-		vector3f(0.25f,-0.94f, 0.0f),
-		vector3f(0.25f,-0.93f, 0.0f)
-	};
-	m_renderer->DrawLines(4, vts, Color::WHITE, m_renderState, LINE_STRIP);
+	m_scalelines.Draw(m_renderer, m_renderState, LINE_STRIP);
 
 	m_labels->Clear();
 	PutLabels(-vector3d(offset_x, offset_y, 0.0));

--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -116,9 +116,9 @@ void GalacticView::PutLabels(vector3d offset)
 void GalacticView::Draw3D()
 {
 	PROFILE_SCOPED()
-	vector3f pos = m_game->GetSectorView()->GetPosition();
-	float offset_x = (pos.x*Sector::SIZE + m_galaxy->SOL_OFFSET_X)/m_galaxy->GALAXY_RADIUS;
-	float offset_y = (-pos.y*Sector::SIZE + m_galaxy->SOL_OFFSET_Y)/m_galaxy->GALAXY_RADIUS;
+	const vector3f pos = m_game->GetSectorView()->GetPosition();
+	const float offset_x = (pos.x*Sector::SIZE + m_galaxy->SOL_OFFSET_X)/m_galaxy->GALAXY_RADIUS;
+	const float offset_y = (-pos.y*Sector::SIZE + m_galaxy->SOL_OFFSET_Y)/m_galaxy->GALAXY_RADIUS;
 
 	const float aspect = m_renderer->GetDisplayAspect();
 	m_renderer->SetOrthographicProjection(-aspect, aspect, 1.f, -1.f, -1.f, 1.f);
@@ -135,8 +135,8 @@ void GalacticView::Draw3D()
 
 	// "you are here" dot
 	//Color green(0, 255, 0, 255);
-	vector3f offs(offset_x, offset_y, 0.f);
-	m_renderer->DrawPoints(1, &offs, &Color::GREEN, m_renderState, 3.f);
+	const vector3f offs(offset_x, offset_y, 0.f);
+	m_youAreHere.SetData(1, &offs, matrix4x4f::Identity(), Color::GREEN, 3.f);
 
 	// scale at the top
 	m_renderer->SetTransform(matrix4x4f::Identity());

--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -112,7 +112,7 @@ void GalacticView::PutLabels(vector3d offset)
 	Gui::Screen::LeaveOrtho();
 }
 
-
+static const float pointsize(0.005f);
 void GalacticView::Draw3D()
 {
 	PROFILE_SCOPED()
@@ -134,9 +134,9 @@ void GalacticView::Draw3D()
 	m_quad.Draw(m_renderer, vector2f(-1.0f), vector2f(2.0f));
 
 	// "you are here" dot
-	//Color green(0, 255, 0, 255);
 	const vector3f offs(offset_x, offset_y, 0.f);
-	m_youAreHere.SetData(1, &offs, matrix4x4f::Identity(), Color::GREEN, 3.f);
+	m_youAreHere.SetData(1, &offs, matrix4x4f::Identity(), Color::GREEN, pointsize);
+	m_youAreHere.Draw(m_renderer, m_renderState);
 
 	// scale at the top
 	m_renderer->SetTransform(matrix4x4f::Identity());

--- a/src/GalacticView.h
+++ b/src/GalacticView.h
@@ -43,6 +43,7 @@ private:
 	Gui::TexturedQuad m_quad;
 	sigc::connection m_onMouseWheelCon;
 	Graphics::RenderState *m_renderState;
+	Drawables::Lines m_scalelines;
 };
 
 #endif /* _GALACTICVIEW_H */

--- a/src/GalacticView.h
+++ b/src/GalacticView.h
@@ -43,7 +43,7 @@ private:
 	Gui::TexturedQuad m_quad;
 	sigc::connection m_onMouseWheelCon;
 	Graphics::RenderState *m_renderState;
-	Drawables::Lines m_scalelines;
+	Graphics::Drawables::Lines m_scalelines;
 };
 
 #endif /* _GALACTICVIEW_H */

--- a/src/GalacticView.h
+++ b/src/GalacticView.h
@@ -43,6 +43,7 @@ private:
 	Gui::TexturedQuad m_quad;
 	sigc::connection m_onMouseWheelCon;
 	Graphics::RenderState *m_renderState;
+	Graphics::Drawables::Points m_youAreHere;
 	Graphics::Drawables::Lines m_scalelines;
 };
 

--- a/src/HudTrail.cpp
+++ b/src/HudTrail.cpp
@@ -57,6 +57,8 @@ void HudTrail::Render(Graphics::Renderer *r)
 		tvts.clear();
 		colors.clear();
 		const vector3d curpos = m_body->GetInterpPosition();
+		tvts.reserve(MAX_POINTS);
+		colors.reserve(MAX_POINTS);
 		tvts.push_back(vector3f(0.f));
 		colors.push_back(Color(0.f));
 		float alpha = 1.f;
@@ -70,7 +72,8 @@ void HudTrail::Render(Graphics::Renderer *r)
 		}
 
 		r->SetTransform(m_transform);
-		r->DrawLines(tvts.size(), &tvts[0], &colors[0], m_renderState, Graphics::LINE_STRIP);
+		m_lines.SetData(tvts.size(), &tvts[0], &colors[0]);
+		m_lines.Draw(r, m_renderState, Graphics::LINE_STRIP);
 	}
 }
 

--- a/src/HudTrail.h
+++ b/src/HudTrail.h
@@ -9,6 +9,7 @@
 #include "libs.h"
 #include "Body.h"
 #include "graphics/Renderer.h"
+#include "graphics/Drawables.h"
 
 class HudTrail
 {
@@ -29,6 +30,7 @@ private:
 	matrix4x4d m_transform;
 	std::deque<vector3d> m_trailPoints;
 	Graphics::RenderState *m_renderState;
+	Graphics::Drawables::Lines m_lines;
 };
 
 #endif

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -449,35 +449,12 @@ void ModelViewer::DrawGrid(const matrix4x4f &trans, float radius)
 	}
 
 	m_renderer->SetTransform(trans);
-	m_renderer->DrawLines(points.size(), &points[0], Color(128), m_bgState);//Color(0.0f,0.2f,0.0f,1.0f));
+	m_gridLines.SetData(points.size(), &points[0], Color(128));
+	m_gridLines.Draw(m_renderer, m_bgState);
 
-	//industry-standard red/green/blue XYZ axis indiactor
-	const int numAxVerts = 6;
-	const vector3f vts[numAxVerts] = {
-		//X
-		vector3f(0.f, 0.f, 0.f),
-		vector3f(radius, 0.f, 0.f),
-
-		//Y
-		vector3f(0.f, 0.f, 0.f),
-		vector3f(0.f, radius, 0.f),
-
-		//Z
-		vector3f(0.f, 0.f, 0.f),
-		vector3f(0.f, 0.f, radius),
-	};
-	const Color col[numAxVerts] = {
-		Color(255, 0, 0),
-		Color(255, 0, 0),
-
-		Color(0, 0, 255),
-		Color(0, 0, 255),
-
-		Color(0, 255, 0),
-		Color(0, 255, 0)
-	};
-
-	m_renderer->DrawLines(numAxVerts, &vts[0], &col[0], m_bgState);
+	// industry-standard red/green/blue XYZ axis indiactor
+	m_renderer->SetTransform(trans * matrix4x4f::ScaleMatrix(radius));
+	Graphics::Drawables::GetAxes3DDrawable(m_renderer)->Draw(m_renderer);
 }
 
 void ModelViewer::DrawModel()

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -128,6 +128,8 @@ private:
 	UI::Slider *thrustSliders[2*3]; //thruster sliders 2*xyz (linear & angular)
 
 	sigc::signal<void> onModelChanged;
+
+	Graphics::Drawables::Lines m_gridLines;
 };
 
 #endif

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -501,11 +501,13 @@ void SectorView::Draw3D()
 	m_renderer->DrawTriangles(m_starVerts.get(), m_solidState, m_starMaterial.Get());
 
 	//draw sector legs in one go
-	if (m_lineVerts->GetNumVerts() > 2)
-		m_renderer->DrawLines(m_lineVerts->GetNumVerts(), &m_lineVerts->position[0], &m_lineVerts->diffuse[0], m_alphaBlendState);
+	if (m_lineVerts->GetNumVerts() > 2) {
+		m_lines.Draw(m_renderer, m_alphaBlendState);
+	}
 
-	if (m_secLineVerts->GetNumVerts() > 2)
-		m_renderer->DrawLines(m_secLineVerts->GetNumVerts(), &m_secLineVerts->position[0], &m_secLineVerts->diffuse[0], m_alphaBlendState);
+	if (m_secLineVerts->GetNumVerts() > 2) {
+		m_sectorlines.Draw(m_renderer, m_alphaBlendState);
+	}
 
 	UpdateFactionToggles();
 
@@ -929,6 +931,8 @@ void SectorView::DrawNearSector(const int sx, const int sy, const int sz, const 
 		m_secLineVerts->Add(vts[3], darkgreen);
 		m_secLineVerts->Add(vts[3], darkgreen);	// line segment 4
 		m_secLineVerts->Add(vts[0], darkgreen);
+
+		m_sectorlines.SetData( m_secLineVerts->GetNumVerts(), &m_secLineVerts->position[0], &m_secLineVerts->diffuse[0]);
 	}
 
 	Uint32 sysIdx = 0;
@@ -1002,6 +1006,8 @@ void SectorView::DrawNearSector(const int sx, const int sy, const int sz, const 
 			m_lineVerts->Add(systrans * vector3f(0.1f, 0.1f, z), light);
 			m_lineVerts->Add(systrans * vector3f(-0.1f, 0.1f, z), light);
 			m_lineVerts->Add(systrans * vector3f(0.1f, -0.1f, z), light);
+
+			m_lines.SetData(m_lineVerts->GetNumVerts(), &m_lineVerts->position[0], &m_lineVerts->diffuse[0]);
 		}
 
 		if (i->IsSameSystem(m_selected)) {

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -671,7 +671,6 @@ void SectorView::PutFactionLabels(const vector3f &origin)
 	if (!m_material)
 		m_material.Reset(m_renderer->CreateMaterial(Graphics::MaterialDescriptor()));
 
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE, (m_visibleFactions.size() - m_hiddenFactions.size()) * 12);
 	static const Color labelBorder(13, 13, 31, 166);
 	const auto renderState = Gui::Screen::alphaBlendState;
 
@@ -693,33 +692,23 @@ void SectorView::PutFactionLabels(const vector3f &origin)
 
 				
 				{
-					//va.Add(vector3f(pos.x - 5.f,              pos.y - 5.f,               0), labelBorder); // 1
-					//va.Add(vector3f(pos.x - 5.f,              pos.y - 5.f + labelHeight, 0), labelBorder); // 2
-					//va.Add(vector3f(pos.x + labelWidth + 5.f, pos.y - 5.f,               0), labelBorder); // 3
-					//va.Add(vector3f(pos.x + labelWidth + 5.f, pos.y - 5.f + labelHeight, 0), labelBorder); // 4
-
-					va.Add(vector3f(pos.x - 5.f,				pos.y - 5.f + labelHeight,	0), labelBorder); // 2
-					va.Add(vector3f(pos.x - 5.f,				pos.y - 5.f,				0), labelBorder); // 1
-					va.Add(vector3f(pos.x + labelWidth + 5.f,	pos.y - 5.f + labelHeight,	0), labelBorder); // 4
-
-					va.Add(vector3f(pos.x + labelWidth + 5.f,	pos.y - 5.f + labelHeight,	0), labelBorder); // 4
-					va.Add(vector3f(pos.x - 5.f,				pos.y - 5.f + labelHeight,	0), labelBorder); // 1
-					va.Add(vector3f(pos.x + labelWidth + 5.f,	pos.y - 5.f,				0), labelBorder); // 3
+					Graphics::VertexArray va(Graphics::ATTRIB_POSITION);
+					va.Add(vector3f(pos.x - 5.f,              pos.y - 5.f,               0));
+					va.Add(vector3f(pos.x - 5.f,              pos.y - 5.f + labelHeight, 0));
+					va.Add(vector3f(pos.x + labelWidth + 5.f, pos.y - 5.f,               0));
+					va.Add(vector3f(pos.x + labelWidth + 5.f, pos.y - 5.f + labelHeight, 0));
+					m_material->diffuse = labelBorder;
+					m_renderer->DrawTriangles(&va, renderState, m_material.Get(), Graphics::TRIANGLE_STRIP);
 				}
 
 				{
-					// va.Add(vector3f(pos.x - 8.f, pos.y,       0), labelColor); // 1
-					// va.Add(vector3f(pos.x      , pos.y + 8.f, 0), labelColor); // 2
-					// va.Add(vector3f(pos.x,       pos.y - 8.f, 0), labelColor); // 3
-					// va.Add(vector3f(pos.x + 8.f, pos.y,		 0), labelColor); // 4
-
-					va.Add(vector3f(pos.x, pos.y + 8.f, 0), labelColor); // 2
-					va.Add(vector3f(pos.x - 8.f, pos.y, 0), labelColor); // 1
-					va.Add(vector3f(pos.x + 8.f, pos.y, 0), labelColor); // 4
-
-					va.Add(vector3f(pos.x + 8.f, pos.y, 0), labelColor); // 4
-					va.Add(vector3f(pos.x - 8.f, pos.y, 0), labelColor); // 1
-					va.Add(vector3f(pos.x, pos.y - 8.f, 0), labelColor); // 3
+					Graphics::VertexArray va(Graphics::ATTRIB_POSITION);
+					va.Add(vector3f(pos.x - 8.f, pos.y,       0));
+					va.Add(vector3f(pos.x      , pos.y + 8.f, 0));
+					va.Add(vector3f(pos.x,       pos.y - 8.f, 0));
+					va.Add(vector3f(pos.x + 8.f, pos.y,       0));
+					m_material->diffuse = labelColor;
+					m_renderer->DrawTriangles(&va, renderState, m_material.Get(), Graphics::TRIANGLE_STRIP);
 				}
 
 				if (labelColor.GetLuminance() > 191) labelColor.a = 204;    // luminance is sometimes a bit overly
@@ -727,8 +716,6 @@ void SectorView::PutFactionLabels(const vector3f &origin)
 			}
 		}
 	}
-
-	m_renderer->DrawTriangles(&va, renderState, m_material.Get(), Graphics::TRIANGLES);
 	Gui::Screen::LeaveOrtho();
 }
 

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -1095,12 +1095,12 @@ void SectorView::DrawFarSectors(const matrix4x4f& modelview)
 		for (int sx = secOrigin.x-buildRadius; sx <= secOrigin.x+buildRadius; sx++) {
 			for (int sy = secOrigin.y-buildRadius; sy <= secOrigin.y+buildRadius; sy++) {
 				for (int sz = secOrigin.z-buildRadius; sz <= secOrigin.z+buildRadius; sz++) {
-						if ((vector3f(sx,sy,sz) - secOrigin).Length() <= buildRadius){
-							BuildFarSector(GetCached(SystemPath(sx, sy, sz)), Sector::SIZE * secOrigin, m_farstars, m_farstarsColor);
-						}
+					if ((vector3f(sx,sy,sz) - secOrigin).Length() <= buildRadius){
+						BuildFarSector(GetCached(SystemPath(sx, sy, sz)), Sector::SIZE * secOrigin, m_farstars, m_farstarsColor);
 					}
 				}
 			}
+		}
 
 		m_secPosFar      = secOrigin;
 		m_radiusFar      = buildRadius;
@@ -1109,8 +1109,8 @@ void SectorView::DrawFarSectors(const matrix4x4f& modelview)
 
 	// always draw the stars, slightly altering their size for different different resolutions, so they still look okay
 	if (m_farstars.size() > 0) {
-		m_renderer->DrawPoints(m_farstars.size(), &m_farstars[0], &m_farstarsColor[0],
-			m_alphaBlendState, 1.f + (Graphics::GetScreenHeight() / 720.f));
+		m_farstarsPoints.SetData(m_farstars.size(), &m_farstars[0], &m_farstarsColor[0], matrix4x4f::Identity(), 1.f + (Graphics::GetScreenHeight() / 720.f));
+		m_farstarsPoints.Draw(m_renderer, m_alphaBlendState);
 	}
 
 	// also add labels for any faction homeworlds among the systems we've drawn

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -193,6 +193,7 @@ private:
 
 	Graphics::Drawables::Lines m_lines;
 	Graphics::Drawables::Lines m_sectorlines;
+	Graphics::Drawables::Points m_farstarsPoints;
 };
 
 #endif /* _SECTORVIEW_H */

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -190,6 +190,9 @@ private:
 	RefCountedPtr<Graphics::Material> m_fresnelMat;
 	std::unique_ptr<Graphics::Drawables::Sphere3D> m_jumpSphere;
 	std::unique_ptr<Graphics::VertexArray> m_starVerts;
+
+	Graphics::Drawables::Lines m_lines;
+	Graphics::Drawables::Lines m_sectorlines;
 };
 
 #endif /* _SECTORVIEW_H */

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -76,6 +76,7 @@ void ScannerWidget::InitObject()
 	rsd.blendMode = Graphics::BLEND_ALPHA;
 	rsd.depthWrite = false;
 	rsd.depthTest = false;
+	rsd.cullMode = CULL_NONE;
 	m_renderState = m_renderer->CreateRenderState(rsd);
 }
 
@@ -392,7 +393,7 @@ void ScannerWidget::DrawBlobs(bool below)
 		m_contactLines.SetData(vts.size(), &vts[0], &colors[0]);
 		m_contactLines.Draw(m_renderer, m_renderState);
 
-		m_contactBlobs.SetData(blobs.size(), &blobs[0], &blobcolors[0], matrix4x4f::Identity(), 3.f);
+		m_contactBlobs.SetData(m_renderer, blobs.size(), &blobs[0], &blobcolors[0], matrix4x4f::Identity(), 3.f);
 		m_contactBlobs.Draw(m_renderer, m_renderState);
 	}
 }

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -296,6 +296,18 @@ void ScannerWidget::Update()
 
 void ScannerWidget::DrawBlobs(bool below)
 {
+	assert( !m_contacts.empty() );
+
+	static const Uint32 MAX_CONTACTS(100);
+	std::vector<vector3f> blobs;
+	std::vector<vector3f> vts;
+	std::vector<Color> blobcolors;
+	std::vector<Color> colors;
+	blobs.reserve(MAX_CONTACTS);
+	vts.reserve(MAX_CONTACTS);
+	blobcolors.reserve(MAX_CONTACTS);
+	colors.reserve(MAX_CONTACTS);
+
 	for (std::list<Contact>::iterator i = m_contacts.begin(); i != m_contacts.end(); ++i) {
 		ScannerBlobWeight weight = WEIGHT_LIGHT;
 
@@ -365,11 +377,23 @@ void ScannerWidget::DrawBlobs(bool below)
 		const float y_base = m_y + m_y * SCANNER_YSHRINK * float(pos.z) * m_scale;
 		const float y_blob = y_base - m_y * SCANNER_YSHRINK * float(pos.y) * m_scale;
 
-		const vector3f verts[] = { vector3f(x, y_base, 0.f), vector3f(x, y_blob, 0.f) };
-		m_renderer->DrawLines(2, &verts[0], *color, m_renderState);
+		// store this stalk
+		vts.push_back(vector3f(x, y_base, 0.f));
+		vts.push_back(vector3f(x, y_blob, 0.f));
+		colors.push_back(*color);
+		colors.push_back(*color);
 
-		vector3f blob(x, y_blob, 0.f);
-		m_renderer->DrawPoints(1, &blob, color, m_renderState, pointSize);
+		// blob!
+		blobs.push_back(vector3f(x, y_blob, 0.f));
+		blobcolors.push_back(*color);
+	}
+
+	if( !vts.empty() ) {
+		m_contactLines.SetData(vts.size(), &vts[0], &colors[0]);
+		m_contactLines.Draw(m_renderer, m_renderState);
+
+		m_contactBlobs.SetData(blobs.size(), &blobs[0], &blobcolors[0], matrix4x4f::Identity(), 3.f);
+		m_contactBlobs.Draw(m_renderer, m_renderState);
 	}
 }
 
@@ -398,8 +422,8 @@ void ScannerWidget::GenerateBaseGeometry()
 
 void ScannerWidget::GenerateRingsAndSpokes()
 {
-	int csize = m_circle.size();
-	int ssize = m_spokes.size();
+	const int csize = m_circle.size();
+	const int ssize = m_spokes.size();
 	m_vts.clear();
 
 	// inner circle
@@ -424,11 +448,7 @@ void ScannerWidget::GenerateRingsAndSpokes()
 	vector3f vn(sin(a), SCANNER_YSHRINK * cos(a), 0.0f);
 
 	// bright part
-	Color col = Color(178, 178, 0, 128);
-	if (m_mode == SCANNER_MODE_AUTO) {
-		// green like the scanner to indicate that the scanner is controlling the range
-		col = Color(0, 178, 0, 128);
-	}
+	Color col = (m_mode == SCANNER_MODE_AUTO) ? Color(0, 178, 0, 128) : Color(178, 178, 0, 128);
 	for (int i=0; i<=dimstart; i++) {
 		if (i == csize) return;			// whole circle bright case
 		m_edgeVts.push_back(vector3f(m_circle[i].x, m_circle[i].y, 0.0f));
@@ -443,13 +463,16 @@ void ScannerWidget::GenerateRingsAndSpokes()
 		m_edgeVts.push_back(vector3f(m_circle[i].x, m_circle[i].y, 0.0f));
 		m_edgeCols.push_back(col);
 	}
+
+	static const Color vtscol(0, 102, 0, 128);
+	m_scanLines.SetData(m_vts.size(), &m_vts[0], vtscol);
+	m_edgeLines.SetData(m_edgeVts.size(), &m_edgeVts[0], &m_edgeCols[0]);
 }
 
 void ScannerWidget::DrawRingsAndSpokes(bool blend)
 {
-	Color col(0, 102, 0, 128);
-	m_renderer->DrawLines(m_vts.size(), &m_vts[0], col, m_renderState);
-	m_renderer->DrawLines(m_edgeVts.size(), &m_edgeVts[0], &m_edgeCols[0], m_renderState);
+	m_scanLines.Draw(m_renderer, m_renderState);
+	m_edgeLines.Draw(m_renderer, m_renderState);
 }
 
 void ScannerWidget::TimeStepUpdate(float step)

--- a/src/ShipCpanelMultiFuncDisplays.h
+++ b/src/ShipCpanelMultiFuncDisplays.h
@@ -55,6 +55,8 @@ private:
 		bool isSpecial;
 	};
 	std::list<Contact> m_contacts;
+	Graphics::Drawables::Lines m_contactLines;
+	Graphics::Drawables::Points m_contactBlobs;
 
 	enum ScannerMode { SCANNER_MODE_AUTO, SCANNER_MODE_MANUAL };
 	ScannerMode m_mode;
@@ -78,6 +80,9 @@ private:
 
 	Graphics::Renderer *m_renderer;
 	Graphics::RenderState *m_renderState;
+	
+	Graphics::Drawables::Lines m_scanLines;
+	Graphics::Drawables::Lines m_edgeLines;
 };
 
 class UseEquipWidget: public IMultiFunc, public Gui::Fixed {

--- a/src/SpeedLines.cpp
+++ b/src/SpeedLines.cpp
@@ -25,13 +25,16 @@ SpeedLines::SpeedLines(Ship *s)
 		}
 	}
 
-	m_vertices.resize(m_points.size() * 2);
-	m_vtxColors.resize(m_vertices.size());
+	m_varray.reset(new Graphics::VertexArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE, (m_points.size() * 2)));
+	for( Uint32 i = 0; i < (m_points.size() * 2); i++ )
+		m_varray->Add(vector3f(0.0f), Color::BLACK);
 
 	Graphics::RenderStateDesc rsd;
 	rsd.blendMode = Graphics::BLEND_ALPHA_ONE;
 	rsd.depthWrite = false;
 	m_renderState = Pi::renderer->CreateRenderState(rsd);
+
+	CreateVertexBuffer( Pi::renderer, (m_points.size() * 2) );
 }
 
 void SpeedLines::Update(float time)
@@ -95,24 +98,40 @@ void SpeedLines::Update(float time)
 
 void SpeedLines::Render(Graphics::Renderer *r)
 {
-	if (!m_visible) return;
+	if (!m_visible || m_points.empty()) return;
 
 	const vector3f dir = m_dir * m_lineLength;
 
 	Uint16 vtx = 0;
+	//distance fade
+	Color col(Color::GRAY);
 	for (auto it = m_points.begin(); it != m_points.end(); ++it) {
-		m_vertices[vtx]   = *it - dir;
-		m_vertices[vtx+1] = *it + dir;
+		col.a = Clamp((1.f - it->Length() / BOUNDS),0.f,1.f) * 255;	
 
-		//distance fade
-		const Color col = Color(Color::GRAY.r, Color::GRAY.g, Color::GRAY.b,
-				Clamp((1.f - it->Length() / BOUNDS),0.f,1.f) * 255);
-		m_vtxColors[vtx]   = col;
-		m_vtxColors[vtx+1] = col;
+		m_varray->Set(vtx, *it - dir, col);
+		m_varray->Set(vtx+1,*it + dir, col);
 
 		vtx += 2;
 	}
 
+	m_vbuffer->Populate( *m_varray );
+
 	r->SetTransform(m_transform);
-	r->DrawLines(m_vertices.size(), &m_vertices[0], &m_vtxColors[0], m_renderState);
+	r->DrawBuffer(m_vbuffer.get(), m_renderState, m_material.Get(), Graphics::LINE_SINGLE);
+}
+
+void SpeedLines::CreateVertexBuffer(Graphics::Renderer *r, const Uint32 size)
+{
+	Graphics::MaterialDescriptor desc;
+	desc.vertexColors = true;
+	m_material.Reset(r->CreateMaterial(desc));
+
+	Graphics::VertexBufferDesc vbd;
+	vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+	vbd.attrib[0].format = Graphics::ATTRIB_FORMAT_FLOAT3;
+	vbd.attrib[1].semantic = Graphics::ATTRIB_DIFFUSE;
+	vbd.attrib[1].format = Graphics::ATTRIB_FORMAT_UBYTE4;
+	vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;
+	vbd.numVertices = size;
+	m_vbuffer.reset(r->CreateVertexBuffer(vbd));
 }

--- a/src/SpeedLines.h
+++ b/src/SpeedLines.h
@@ -24,16 +24,19 @@ public:
 	Ship *GetShip() const { return m_ship; }
 
 private:
+	void CreateVertexBuffer(Graphics::Renderer *r, const Uint32 size);
+
 	Ship *m_ship;
 
 	std::vector<vector3f> m_points;
-
-	std::vector<vector3f> m_vertices;
-	std::vector<Color> m_vtxColors;
+	
 	Graphics::RenderState *m_renderState;
+	RefCountedPtr<Graphics::Material> m_material;
+	std::unique_ptr<Graphics::VertexArray> m_varray;
+	std::unique_ptr<Graphics::VertexBuffer> m_vbuffer;
 
 	matrix4x4d m_transform;
-
+	
 	bool m_visible;
 	float m_lineLength;
 	vector3f m_dir;

--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -637,6 +637,17 @@ SystemInfoView::BodyIcon::BodyIcon(const char *img, Graphics::Renderer *r)
 	//no blending
 	Graphics::RenderStateDesc rsd;
 	m_renderState = r->CreateRenderState(rsd);
+
+	float size[2];
+	GetSize(size);
+	const vector3f vts[] = {
+		vector3f(0.f, 0.f, 0.f),
+		vector3f(size[0], 0.f, 0.f),
+		vector3f(size[0], size[1], 0.f),
+		vector3f(0.f, size[1], 0.f),
+	};
+	m_selectBox.SetData(COUNTOF(vts), vts, m_selectColor);
+	
 }
 
 void SystemInfoView::BodyIcon::Draw()
@@ -655,13 +666,7 @@ void SystemInfoView::BodyIcon::Draw()
 	    circle.Draw(m_renderer);
 	}
 	if (GetSelected()) {
-	    const vector3f vts[] = {
-		    vector3f(0.f, 0.f, 0.f),
-		    vector3f(size[0], 0.f, 0.f),
-		    vector3f(size[0], size[1], 0.f),
-		    vector3f(0.f, size[1], 0.f),
-	    };
-	    m_renderer->DrawLines(COUNTOF(vts), vts, m_selectColor, m_renderState, Graphics::LINE_LOOP);
+		m_selectBox.Draw(m_renderer, m_renderState, Graphics::LINE_LOOP);
 	}
 }
 

--- a/src/SystemInfoView.h
+++ b/src/SystemInfoView.h
@@ -34,9 +34,9 @@ private:
 	private:
 		Graphics::Renderer *m_renderer;
 		Graphics::RenderState *m_renderState;
+		Graphics::Drawables::Lines m_selectBox;
 		bool m_hasStarport;
 		Color m_selectColor;
-
 	};
 
 	enum RefreshType {

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -319,11 +319,13 @@ void SystemView::PutOrbit(const Orbit *orbit, const vector3d &offset, const Colo
 	}
 
 	if (num_vertices > 1) {
+		m_orbits.SetData(num_vertices, vts, color);
 		// don't close the loop for hyperbolas and parabolas and crashed ellipses
-		if ((orbit->GetEccentricity() > 1.0) || (num_vertices < int(COUNTOF(vts))))
-			m_renderer->DrawLines(num_vertices, vts, color, m_lineState, LINE_STRIP);
-		else
-			m_renderer->DrawLines(num_vertices, vts, color, m_lineState, LINE_LOOP);
+		if ((orbit->GetEccentricity() > 1.0) || (num_vertices < int(COUNTOF(vts)))) {
+			m_orbits.Draw(m_renderer, m_lineState, LINE_STRIP);
+		} else {
+			m_orbits.Draw(m_renderer, m_lineState, LINE_LOOP);
+		}
 	}
 
 	Gui::Screen::EnterOrtho();
@@ -556,7 +558,8 @@ void SystemView::PutSelectionBox(const vector3d &worldPos, const Color &col)
                 vector3f(x2, y2, 0.f),
                 vector3f(x1, y2, 0.f)
         };
-		m_renderer->DrawLines(4, &verts[0], col, m_lineState, Graphics::LINE_LOOP);
+		m_selectBox.SetData(4, &verts[0], col);
+		m_selectBox.Draw(m_renderer, m_lineState, Graphics::LINE_LOOP);
 	}
 
 	Gui::Screen::LeaveOrtho();

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -106,6 +106,8 @@ private:
 	std::unique_ptr<Gui::TexturedQuad> m_periapsisIcon;
 	std::unique_ptr<Gui::TexturedQuad> m_apoapsisIcon;
 	Graphics::RenderState *m_lineState;
+	Graphics::Drawables::Lines m_orbits;
+	Graphics::Drawables::Lines m_selectBox;
 };
 
 #endif /* _SYSTEMVIEW_H */

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1941,10 +1941,12 @@ void WorldView::DrawCombatTargetIndicator(const Indicator &target, const Indicat
 			vector3f(x1+20*xd, y1+20*yd, 0.0f),
 			vector3f(x2-10*xd, y2-10*yd, 0.0f)
 		};
-		if (lead.side == INDICATOR_ONSCREEN)
-			m_renderer->DrawLines(14, vts, c, m_blendState); //draw all
-		else
-			m_renderer->DrawLines(8, vts, c, m_blendState); //only crosshair
+		if (lead.side == INDICATOR_ONSCREEN) {
+			m_indicator.SetData(14, vts, c);
+		} else {
+			m_indicator.SetData(8, vts, c);
+		}
+		m_indicator.Draw(m_renderer, m_blendState);
 	} else {
 		DrawEdgeMarker(target, c);
 	}

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1903,8 +1903,8 @@ void WorldView::DrawCombatTargetIndicator(const Indicator &target, const Indicat
 	if (target.side == INDICATOR_HIDDEN) return;
 
 	if (target.side == INDICATOR_ONSCREEN) {
-		float x1 = target.pos.x, y1 = target.pos.y;
-		float x2 = lead.pos.x, y2 = lead.pos.y;
+		const float x1 = target.pos.x, y1 = target.pos.y;
+		const float x2 = lead.pos.x, y2 = lead.pos.y;
 
 		float xd = x2 - x1, yd = y2 - y1;
 		if (lead.side != INDICATOR_ONSCREEN) {

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -217,6 +217,7 @@ private:
 
 	Graphics::Drawables::Line3D m_edgeMarker;
 	Graphics::Drawables::Lines m_crossHair;
+	Graphics::Drawables::Lines m_indicator;
 };
 
 class NavTunnelWidget: public Gui::Widget {

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -402,10 +402,10 @@ void Points::SetData(const int count, const vector3f *positions, const matrix4x4
 	for (int i=0; i<count; i++) {
 		const vector3f &pos = positions[i];
 
-		m_va->Add(pos+rotv3, color[i]);
-		m_va->Add(pos+rotv4, color[i]);
-		m_va->Add(pos+rotv2, color[i]);
-		m_va->Add(pos+rotv1, color[i]);
+		m_va->Add(pos+rotv3, color);
+		m_va->Add(pos+rotv4, color);
+		m_va->Add(pos+rotv2, color);
+		m_va->Add(pos+rotv1, color);
 	}
 
 	m_refreshVertexBuffer = true;

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -380,7 +380,11 @@ void Points::SetData(const int count, const vector3f *positions, const matrix4x4
 
 	assert(positions);
 
-	m_va.reset( new VertexArray(ATTRIB_POSITION | ATTRIB_DIFFUSE, count * 6) );
+	if( m_va.get() && m_va->GetNumVerts() == (count * 4) ) {
+		m_va->Clear();
+	} else {
+		m_va.reset( new VertexArray(ATTRIB_POSITION | ATTRIB_DIFFUSE, count * 4) );
+	}
 
 	matrix4x4f rot(trans);
 	rot.ClearToRotOnly();
@@ -398,13 +402,10 @@ void Points::SetData(const int count, const vector3f *positions, const matrix4x4
 	for (int i=0; i<count; i++) {
 		const vector3f &pos = positions[i];
 
-		m_va->Add(pos+rotv4, color); //top left
-		m_va->Add(pos+rotv3, color); //bottom left
-		m_va->Add(pos+rotv1, color); //top right
-
-		m_va->Add(pos+rotv1, color); //top right
-		m_va->Add(pos+rotv3, color); //bottom left
-		m_va->Add(pos+rotv2, color); //bottom right
+		m_va->Add(pos+rotv3, color[i]);
+		m_va->Add(pos+rotv4, color[i]);
+		m_va->Add(pos+rotv2, color[i]);
+		m_va->Add(pos+rotv1, color[i]);
 	}
 
 	m_refreshVertexBuffer = true;
@@ -418,10 +419,10 @@ void Points::SetData(const int count, const vector3f *positions, const Color *co
 
 	assert(positions);
 
-	if( m_va.get() && m_va->GetNumVerts() == (count * 6) ) {
+	if( m_va.get() && m_va->GetNumVerts() == (count * 4) ) {
 		m_va->Clear();
 	} else {
-		m_va.reset( new VertexArray(ATTRIB_POSITION | ATTRIB_DIFFUSE, count * 6) );
+		m_va.reset( new VertexArray(ATTRIB_POSITION | ATTRIB_DIFFUSE, count * 4) );
 	}
 
 	matrix4x4f rot(trans);
@@ -440,13 +441,10 @@ void Points::SetData(const int count, const vector3f *positions, const Color *co
 	for (int i=0; i<count; i++) {
 		const vector3f &pos = positions[i];
 
-		m_va->Add(pos+rotv4, color[i]); //top left
-		m_va->Add(pos+rotv3, color[i]); //bottom left
-		m_va->Add(pos+rotv1, color[i]); //top right
-
-		m_va->Add(pos+rotv1, color[i]); //top right
-		m_va->Add(pos+rotv3, color[i]); //bottom left
-		m_va->Add(pos+rotv2, color[i]); //bottom right
+		m_va->Add(pos+rotv3, color[i]);
+		m_va->Add(pos+rotv4, color[i]);
+		m_va->Add(pos+rotv2, color[i]);
+		m_va->Add(pos+rotv1, color[i]);
 	}
 
 	m_refreshVertexBuffer = true;
@@ -463,8 +461,7 @@ void Points::Draw(Renderer *r, RenderState *rs)
 		m_vertexBuffer->Populate( *m_va );
 	}
 
-	// XXX would be nicer to draw this as a textured triangle strip
-	r->DrawBuffer(m_vertexBuffer.Get(), rs, m_material.Get(), Graphics::TRIANGLES);
+	r->DrawBuffer(m_vertexBuffer.Get(), rs, m_material.Get(), Graphics::TRIANGLE_STRIP);
 }
 
 void Points::CreateVertexBuffer(Graphics::Renderer *r, const Uint32 size)

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -111,8 +111,8 @@ private:
 class Points {
 public:
 	Points();
-	void SetData(const int count, const vector3f *positions, const matrix4x4f &trans, const Color &color, const float size);
-	void SetData(const int count, const vector3f *positions, const Color *color, const matrix4x4f &trans, const float size);
+	void SetData(Renderer*, const int count, const vector3f *positions, const matrix4x4f &trans, const Color &color, const float size);
+	void SetData(Renderer*, const int count, const vector3f *positions, const Color *color, const matrix4x4f &trans, const float size);
 	void Draw(Renderer*, RenderState*);
 private:
 	void CreateVertexBuffer(Graphics::Renderer *r, const Uint32 size);

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -107,6 +107,23 @@ private:
 };
 //------------------------------------------------------------
 
+// Screen aligned quad / billboard / pointsprite
+class Points {
+public:
+	Points();
+	void SetData(const int count, const vector3f *positions, const matrix4x4f &trans, const Color &color, const float size);
+	void SetData(const int count, const vector3f *positions, const Color *color, const matrix4x4f &trans, const float size);
+	void Draw(Renderer*, RenderState*);
+private:
+	void CreateVertexBuffer(Graphics::Renderer *r, const Uint32 size);
+	
+	bool m_refreshVertexBuffer;
+	RefCountedPtr<Material> m_material;
+	RefCountedPtr<VertexBuffer> m_vertexBuffer;
+	std::unique_ptr<VertexArray> m_va;
+};
+//------------------------------------------------------------
+
 // Three dimensional sphere (subdivided icosahedron) with normals
 // and spherical texture coordinates.
 class Sphere3D {

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -93,11 +93,6 @@ public:
 
 	//drawing functions
 	//2d drawing is generally understood to be for gui use (unlit, ortho projection)
-	//per-vertex colour lines
-	virtual bool DrawLines(int vertCount, const vector3f *vertices, const Color *colors, RenderState*, PrimitiveType type=LINE_SINGLE) = 0;
-	//flat colour lines
-	virtual bool DrawLines(int vertCount, const vector3f *vertices, const Color &color, RenderState*, PrimitiveType type=LINE_SINGLE) = 0;
-	virtual bool DrawPoints(int count, const vector3f *points, const Color *colors, RenderState*, float pointSize=1.f) = 0;
 	//unindexed triangle draw
 	virtual bool DrawTriangles(const VertexArray *vertices, RenderState *state, Material *material, PrimitiveType type=TRIANGLES) = 0;
 	//high amount of textured quads for particles etc

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -339,59 +339,6 @@ void RendererOGL::SetMaterialShaderTransforms(Material *m)
 	CheckRenderErrors();
 }
 
-bool RendererOGL::DrawLines(int count, const vector3f *v, const Color *c, RenderState* state, PrimitiveType t)
-{
-	PROFILE_SCOPED()
-	Drawables::Lines lines;
-	lines.SetData(count, v, c);
-	lines.Draw(this, state, t);
-	return true;
-}
-
-bool RendererOGL::DrawLines(int count, const vector3f *v, const Color &c, RenderState *state, PrimitiveType t)
-{
-	PROFILE_SCOPED()
-	Drawables::Lines lines;
-	lines.SetData(count, v, c);
-	lines.Draw(this, state, t);
-	return true;
-}
-
-bool RendererOGL::DrawPoints(int count, const vector3f *points, const Color *colors, Graphics::RenderState *state, float size)
-{
-	struct TPos {
-		vector3f pos;
-		Color4ub col;
-	};
-
-	MaterialDescriptor md;
-	md.vertexColors = true;
-	static std::unique_ptr<Material> mat(CreateMaterial(md));
-	
-	// Create vtx & index buffers and copy data
-	VertexBufferDesc vbd;
-	vbd.attrib[0].semantic	= ATTRIB_POSITION;
-	vbd.attrib[0].format	= ATTRIB_FORMAT_FLOAT3;
-	vbd.attrib[1].semantic	= ATTRIB_DIFFUSE;
-	vbd.attrib[1].format	= ATTRIB_FORMAT_UBYTE4;
-	vbd.numVertices = count;
-	vbd.usage = BUFFER_USAGE_STATIC;
-	
-	// VertexBuffer
-	std::unique_ptr<VertexBuffer> vb;
-	vb.reset(CreateVertexBuffer(vbd));
-	TPos* vtxPtr = vb->Map<TPos>(BUFFER_MAP_WRITE);
-	assert(vb->GetDesc().stride == sizeof(TPos));
-	for(Sint32 i=0 ; i<count ; i++)
-	{
-		vtxPtr[i].pos = points[i];
-		vtxPtr[i].col = colors[i];
-	}
-	vb->Unmap();
-
-	return DrawBuffer(vb.get(), state, mat.get(), POINTS);
-}
-
 bool RendererOGL::DrawTriangles(const VertexArray *v, RenderState *rs, Material *m, PrimitiveType t)
 {
 	PROFILE_SCOPED()

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -74,9 +74,6 @@ public:
 
 	virtual bool SetScissor(bool enabled, const vector2f &pos = vector2f(0.0f), const vector2f &size = vector2f(0.0f));
 
-	virtual bool DrawLines(int vertCount, const vector3f *vertices, const Color *colors, RenderState*, PrimitiveType type=LINE_SINGLE) override;
-	virtual bool DrawLines(int vertCount, const vector3f *vertices, const Color &color, RenderState*, PrimitiveType type=LINE_SINGLE) override;
-	virtual bool DrawPoints(int count, const vector3f *points, const Color *colors, RenderState*, float pointSize=1.f) override;
 	virtual bool DrawTriangles(const VertexArray *vertices, RenderState *state, Material *material, PrimitiveType type=TRIANGLES) override;
 	virtual bool DrawPointSprites(int count, const vector3f *positions, RenderState *rs, Material *material, float size) override;
 	virtual bool DrawBuffer(VertexBuffer*, RenderState*, Material*, PrimitiveType) override;

--- a/src/gui/GuiTextEntry.cpp
+++ b/src/gui/GuiTextEntry.cpp
@@ -206,6 +206,8 @@ void TextEntry::Draw()
 	PROFILE_SCOPED()
 	m_justFocused = false;
 
+	Graphics::Renderer *pRenderer = Screen::GetRenderer();
+
 	float size[2];
 	GetSize(size);
 
@@ -231,7 +233,8 @@ void TextEntry::Draw()
 		vector3f(size[0],size[1], 0.f),
 		vector3f(0,size[1], 0.f)
 	};
-	Screen::GetRenderer()->DrawLines(4, &boxVts[0], c, Screen::alphaBlendState, Graphics::LINE_LOOP);
+	m_outlines.SetData(2, &boxVts[0], c);
+	m_outlines.Draw(pRenderer, Screen::alphaBlendState, Graphics::LINE_LOOP);
 
 	//text
 	SetScissor(true);
@@ -243,7 +246,8 @@ void TextEntry::Draw()
 		vector3f(curs_x + 1.0f - m_scroll, curs_y + Gui::Screen::GetFontDescender(m_font.Get()) - Gui::Screen::GetFontHeight(m_font.Get()), 0.f),
 		vector3f(curs_x + 1.0f - m_scroll, curs_y + Gui::Screen::GetFontDescender(m_font.Get()), 0.f),
 	};
-	Screen::GetRenderer()->DrawLines(2, &cursorVts[0], Color(128), Screen::alphaBlendState);
+	m_cursorLines.SetData(2, &cursorVts[0], Color(128));
+	m_cursorLines.Draw(pRenderer, Screen::alphaBlendState);
 }
 
 } /* namespace Gui */

--- a/src/gui/GuiTextEntry.h
+++ b/src/gui/GuiTextEntry.h
@@ -50,6 +50,9 @@ namespace Gui {
 
 		bool m_justFocused;
 		sigc::connection m_clickout;
+
+		Graphics::Drawables::Lines m_cursorLines;
+		Graphics::Drawables::Lines m_outlines;
 	};
 }
 

--- a/src/gui/GuiTexturedQuad.cpp
+++ b/src/gui/GuiTexturedQuad.cpp
@@ -28,10 +28,11 @@ void TexturedQuad::Draw(Graphics::Renderer *renderer, const vector2f &pos, const
 		PROFILE_SCOPED_RAW("!m_vb.get()")
 		Graphics::VertexArray va(ATTRIB_POSITION | ATTRIB_UV0);
 
-		va.Add(vector3f(pos.x,        pos.y,        0.0f), vector2f(texPos.x,           texPos.y));
-		va.Add(vector3f(pos.x,        pos.y+size.y, 0.0f), vector2f(texPos.x,           texPos.y+texSize.y));
-		va.Add(vector3f(pos.x+size.x, pos.y,        0.0f), vector2f(texPos.x+texSize.x, texPos.y));
-		va.Add(vector3f(pos.x+size.x, pos.y+size.y, 0.0f), vector2f(texPos.x+texSize.x, texPos.y+texSize.y));
+		// Size is always the same, modify it's position using the transform
+		va.Add(vector3f(0.0f,		0.0f,      0.0f), vector2f(texPos.x,           texPos.y));
+		va.Add(vector3f(0.0f,		0.0f+1.0f, 0.0f), vector2f(texPos.x,           texPos.y+texSize.y));
+		va.Add(vector3f(0.0f+1.0f,	0.0f,      0.0f), vector2f(texPos.x+texSize.x, texPos.y));
+		va.Add(vector3f(0.0f+1.0f,	0.0f+1.0f, 0.0f), vector2f(texPos.x+texSize.x, texPos.y+texSize.y));
 
 		//create buffer and upload data
 		Graphics::VertexBufferDesc vbd;
@@ -46,8 +47,18 @@ void TexturedQuad::Draw(Graphics::Renderer *renderer, const vector2f &pos, const
 
 		m_vb->Populate(va);
 	}
-	m_material->diffuse = tint;
-	renderer->DrawBuffer(m_vb.Get(), Gui::Screen::alphaBlendState, m_material.get(), TRIANGLE_STRIP);
+
+	{
+		// move and scale the quad on-screen
+		Graphics::Renderer::MatrixTicket mt(renderer, Graphics::MatrixMode::MODELVIEW);
+		const matrix4x4f& mv = renderer->GetCurrentModelView();
+		matrix4x4f trans(matrix4x4f::Translation(vector3f(pos.x, pos.y, 0.0f)));
+		trans.Scale(size.x, size.y, 0.0f);
+		renderer->SetTransform(mv * trans);
+
+		m_material->diffuse = tint;
+		renderer->DrawBuffer(m_vb.Get(), Gui::Screen::alphaBlendState, m_material.get(), TRIANGLE_STRIP);
+	}
 }
 
 }

--- a/src/gui/GuiTexturedQuad.cpp
+++ b/src/gui/GuiTexturedQuad.cpp
@@ -14,20 +14,6 @@ namespace Gui {
 void TexturedQuad::Draw(Graphics::Renderer *renderer, const vector2f &pos, const vector2f &size, const vector2f &texPos, const vector2f &texSize, const Color &tint)
 {
 	PROFILE_SCOPED()
-	if(!m_va.get()) {
-		PROFILE_SCOPED_RAW("!m_va.get()")
-		m_va.reset(new Graphics::VertexArray(ATTRIB_POSITION | ATTRIB_UV0));
-
-		m_va->Add(vector3f(pos.x,        pos.y,        0.0f), vector2f(texPos.x,           texPos.y));
-		m_va->Add(vector3f(pos.x,        pos.y+size.y, 0.0f), vector2f(texPos.x,           texPos.y+texSize.y));
-		m_va->Add(vector3f(pos.x+size.x, pos.y,        0.0f), vector2f(texPos.x+texSize.x, texPos.y));
-		m_va->Add(vector3f(pos.x+size.x, pos.y+size.y, 0.0f), vector2f(texPos.x+texSize.x, texPos.y+texSize.y));
-	} else {
-		m_va->Set(0, vector3f(pos.x,        pos.y,        0.0f), vector2f(texPos.x,           texPos.y));
-		m_va->Set(1, vector3f(pos.x,        pos.y+size.y, 0.0f), vector2f(texPos.x,           texPos.y+texSize.y));
-		m_va->Set(2, vector3f(pos.x+size.x, pos.y,        0.0f), vector2f(texPos.x+texSize.x, texPos.y));
-		m_va->Set(3, vector3f(pos.x+size.x, pos.y+size.y, 0.0f), vector2f(texPos.x+texSize.x, texPos.y+texSize.y));
-	}
 
 	// Create material on first use. Bit of a hack.
 	if (!m_material) {
@@ -37,8 +23,31 @@ void TexturedQuad::Draw(Graphics::Renderer *renderer, const vector2f &pos, const
 		m_material.reset(renderer->CreateMaterial(desc));
 		m_material->texture0 = m_texture.Get();
 	}
+
+	if(!m_vb.Get()) {
+		PROFILE_SCOPED_RAW("!m_vb.get()")
+		Graphics::VertexArray va(ATTRIB_POSITION | ATTRIB_UV0);
+
+		va.Add(vector3f(pos.x,        pos.y,        0.0f), vector2f(texPos.x,           texPos.y));
+		va.Add(vector3f(pos.x,        pos.y+size.y, 0.0f), vector2f(texPos.x,           texPos.y+texSize.y));
+		va.Add(vector3f(pos.x+size.x, pos.y,        0.0f), vector2f(texPos.x+texSize.x, texPos.y));
+		va.Add(vector3f(pos.x+size.x, pos.y+size.y, 0.0f), vector2f(texPos.x+texSize.x, texPos.y+texSize.y));
+
+		//create buffer and upload data
+		Graphics::VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.attrib[1].semantic = Graphics::ATTRIB_UV0;
+		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
+		vbd.numVertices = 4;
+		vbd.usage = Graphics::BUFFER_USAGE_STATIC;
+
+		m_vb.Reset(renderer->CreateVertexBuffer(vbd));
+
+		m_vb->Populate(va);
+	}
 	m_material->diffuse = tint;
-	renderer->DrawTriangles(m_va.get(), Gui::Screen::alphaBlendState, m_material.get(), TRIANGLE_STRIP);
+	renderer->DrawBuffer(m_vb.Get(), Gui::Screen::alphaBlendState, m_material.get(), TRIANGLE_STRIP);
 }
 
 }

--- a/src/gui/GuiTexturedQuad.h
+++ b/src/gui/GuiTexturedQuad.h
@@ -12,7 +12,7 @@
 namespace Graphics {
 	class Renderer;
 	class Material;
-	class VertexArray;
+	class VertexBuffer;
 }
 
 namespace Gui {
@@ -33,7 +33,7 @@ public:
 private:
 	RefCountedPtr<Graphics::Texture> m_texture;
 	std::unique_ptr<Graphics::Material> m_material;
-	std::unique_ptr<Graphics::VertexArray> m_va;
+	RefCountedPtr<Graphics::VertexBuffer> m_vb;
 };
 
 }

--- a/src/gui/GuiToolTip.cpp
+++ b/src/gui/GuiToolTip.cpp
@@ -57,8 +57,8 @@ void ToolTip::Draw()
 		return;
 
 	float size[2];
-	int age = SDL_GetTicks() - m_createdTime;
-	float alpha = std::min(age / FADE_TIME_MS, 0.75f);
+	const int age = SDL_GetTicks() - m_createdTime;
+	const float alpha = std::min(age / FADE_TIME_MS, 0.75f);
 
 	Graphics::Renderer *r = Gui::Screen::GetRenderer();
 	r->SetRenderState(Gui::Screen::alphaBlendState);
@@ -74,7 +74,8 @@ void ToolTip::Draw()
 		vector3f(0, 0, 0)
 	};
 	const Color outlineColor(Color4f(0,0,.8f,alpha));
-	r->DrawLines(4, &outlineVts[0], outlineColor, Screen::alphaBlendState, Graphics::LINE_LOOP);
+	m_outlines.SetData(2, &outlineVts[0], outlineColor);
+	m_outlines.Draw(r, Screen::alphaBlendState, Graphics::LINE_LOOP);
 
 	Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
 

--- a/src/gui/GuiToolTip.h
+++ b/src/gui/GuiToolTip.h
@@ -23,6 +23,7 @@ namespace Gui {
 		std::string m_text;
 		TextLayout *m_layout;
 		Uint32 m_createdTime;
+		Graphics::Drawables::Lines m_outlines;
 	};
 }
 

--- a/src/gui/GuiVScrollBar.cpp
+++ b/src/gui/GuiVScrollBar.cpp
@@ -82,7 +82,8 @@ void ScrollBar::Draw()
 		lines[0] = vector3f(BORDER, BORDER+(size[1]-2*BORDER)*pos, 0.f);
 		lines[1] = vector3f(size[0]-BORDER, BORDER+(size[1]-2*BORDER)*pos, 0.f);
 	}
-	Screen::GetRenderer()->DrawLines(2, &lines[0], Color::WHITE, Screen::alphaBlendState);
+	m_lines.SetData(2, &lines[0], Color::WHITE);
+	m_lines.Draw(Screen::GetRenderer(), Screen::alphaBlendState);
 }
 
 void ScrollBar::GetSizeRequested(float size[2])

--- a/src/gui/GuiVScrollBar.h
+++ b/src/gui/GuiVScrollBar.h
@@ -25,6 +25,7 @@ namespace Gui {
 		void OnRawMouseMotion(MouseMotionEvent *e);
 		bool m_isPressed, m_isHoriz;
 		sigc::connection _m_release, _m_motion;
+		Graphics::Drawables::Lines m_lines;
 	};
 
 	class VScrollBar: public ScrollBar {

--- a/src/ui/TextEntry.cpp
+++ b/src/ui/TextEntry.cpp
@@ -78,8 +78,8 @@ void TextEntry::Draw()
 	Container::Draw();
 
 	if (IsSelected()) {
-		GetContext()->GetRenderer()->DrawLines(2, m_cursorVertices,
-			Color::WHITE, GetContext()->GetSkin().GetAlphaBlendState());
+		m_lines.SetData(2, &m_cursorVertices[0], Color::WHITE);
+		m_lines.Draw(GetContext()->GetRenderer(), GetContext()->GetSkin().GetAlphaBlendState());
 	}
 }
 

--- a/src/ui/TextEntry.h
+++ b/src/ui/TextEntry.h
@@ -6,6 +6,7 @@
 
 #include "Container.h"
 #include "Label.h"
+#include "graphics/Drawables.h"
 
 namespace UI {
 
@@ -36,6 +37,7 @@ private:
 
 	Uint32 m_cursor;
 	vector3f m_cursorVertices[2];
+	Graphics::Drawables::Lines m_lines;
 };
 
 }


### PR DESCRIPTION
This removes the `DrawPoints` and `DrawLines` methods from the renderer replacing all of the calls to them with a new `Drawables::Points` class and the existing `Drawables::Lines` class.

It affects the Scanner widget, the SectorView, targetting crosshairs, SystemView selection boxes, the GalacticView "You Are here" green indicator, HudTrails, SpeedLines, TextEntry and probably a few other bits I've forgotten to list.

I.e: everything it changes should be quite visible, so if you would like to test then please take a look and compare how it used to look to how it currently does. 
I've tried to do this as I've gone along but some of the changes affect a number of areas and I might have missed them.

On some platforms / combinations of hardware / drivers it might improve performance due to it reusing buffers instead of allocating and releasing them constantly but this is difficult to measure as I don't have a wide enough range of equipment to test on.

Andy