### PR TITLE
Faster text buffer rendering

### DIFF
--- a/src/GameLog.h
+++ b/src/GameLog.h
@@ -21,8 +21,12 @@ private:
 		Message(const std::string &s, Uint32 t);
 		std::string msg;
 		Uint32 time;
+		vector2f m_prevoffset;
+		Uint32 m_prevAlpha;
+		RefCountedPtr<Graphics::VertexBuffer> m_vb;
 	};
 	std::list<Message> m_messages;
+	
 	RefCountedPtr<Text::TextureFont> m_font;
 	vector2f m_screenSize;
 	vector2f m_offset;

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1235,7 +1235,8 @@ void Pi::MainLoop()
 				// display pathStr
 				Gui::Screen::EnterOrtho();
 				Gui::Screen::PushFont("ConsoleFont");
-				Gui::Screen::RenderString(pathStr.str(), 0, 0);
+				static RefCountedPtr<Graphics::VertexBuffer> s_pathvb;
+				Gui::Screen::RenderStringBuffer(s_pathvb, pathStr.str(), 0, 0);
 				Gui::Screen::PopFont();
 				Gui::Screen::LeaveOrtho();
 			}
@@ -1254,7 +1255,8 @@ void Pi::MainLoop()
 		if (Pi::showDebugInfo) {
 			Gui::Screen::EnterOrtho();
 			Gui::Screen::PushFont("ConsoleFont");
-			Gui::Screen::RenderString(fps_readout, 0, 0);
+			static RefCountedPtr<Graphics::VertexBuffer> s_debugInfovb;
+			Gui::Screen::RenderStringBuffer(s_debugInfovb, fps_readout, 0, 0);
 			Gui::Screen::PopFont();
 			Gui::Screen::LeaveOrtho();
 		}

--- a/src/gui/GuiLabel.cpp
+++ b/src/gui/GuiLabel.cpp
@@ -17,7 +17,7 @@ Label::Label(const std::string &text, TextLayout::ColourMarkupMode colourMarkupM
 
 Label::~Label()
 {
-	delete m_layout;
+	m_layout.reset();
 }
 
 void Label::Init(const std::string &text, TextLayout::ColourMarkupMode colourMarkupMode)
@@ -33,14 +33,11 @@ void Label::Init(const std::string &text, TextLayout::ColourMarkupMode colourMar
 
 void Label::UpdateLayout()
 {
-	if (m_layout) delete m_layout;
-	m_layout = new TextLayout(m_text.c_str(), m_font, m_colourMarkupMode);
+	m_layout.reset(new TextLayout(m_text.c_str(), m_font, m_colourMarkupMode));
 }
 
 void Label::RecalcSize()
 {
-//	float size[2];
-//	Screen::MeasureLayout(m_text, FLT_MAX, size);
 	ResizeRequest();
 }
 
@@ -73,6 +70,7 @@ void Label::Draw()
 	PROFILE_SCOPED()
 	if (!m_layout) UpdateLayout();
 	float size[2]; GetSize(size);
+	m_layout->Update(size[0], m_color);
 	if (m_shadow) {
 		Graphics::Renderer *r = Gui::Screen::GetRenderer();
 		r->Translate(1,1,0);

--- a/src/gui/GuiLabel.h
+++ b/src/gui/GuiLabel.h
@@ -33,7 +33,7 @@ namespace Gui {
 		bool m_shadow;
 		GLuint m_dlist;
 		RefCountedPtr<Text::TextureFont> m_font;
-		TextLayout *m_layout;
+		std::unique_ptr<TextLayout> m_layout;
 		TextLayout::ColourMarkupMode m_colourMarkupMode;
 	};
 }

--- a/src/gui/GuiLabelSet.cpp
+++ b/src/gui/GuiLabelSet.cpp
@@ -60,8 +60,9 @@ void LabelSet::Draw()
 {
 	PROFILE_SCOPED()
 	if (!m_labelsVisible) return;
-	for (std::vector<LabelSetItem>::iterator i = m_items.begin(); i != m_items.end(); ++i)
-		Gui::Screen::RenderString((*i).text, (*i).screenx, (*i).screeny - Gui::Screen::GetFontHeight()*0.5f, (*i).hasOwnColor ? (*i).color : m_labelColor, m_font.Get());
+	for (std::vector<LabelSetItem>::iterator i = m_items.begin(); i != m_items.end(); ++i) {
+		Gui::Screen::RenderStringBuffer((*i).m_vb, (*i).text, (*i).screenx, (*i).screeny - Gui::Screen::GetFontHeight()*0.5f, (*i).hasOwnColor ? (*i).color : m_labelColor, m_font.Get());
+	}
 }
 
 void LabelSet::GetSizeRequested(float size[2])

--- a/src/gui/GuiLabelSet.h
+++ b/src/gui/GuiLabelSet.h
@@ -36,6 +36,7 @@ public:
 		bool hasOwnColor;
 		sigc::slot<void> onClick;
 		float screenx, screeny;
+		RefCountedPtr<Graphics::VertexBuffer> m_vb;
 	};
 
 	LabelSet();

--- a/src/gui/GuiScreen.cpp
+++ b/src/gui/GuiScreen.cpp
@@ -290,7 +290,7 @@ int Screen::PickCharacterInString(const std::string &s, float x, float y, Text::
 	return font->PickCharacter(s.c_str(), x, y);
 }
 
-void Screen::RenderString(const std::string &s, float xoff, float yoff, const Color &color, Text::TextureFont *font)
+void Screen::RenderStringBuffer(RefCountedPtr<Graphics::VertexBuffer> vb, const std::string &s, float xoff, float yoff, const Color &color, Text::TextureFont *font)
 {
 	PROFILE_SCOPED()
     if (!font) font = GetFont().Get();
@@ -307,10 +307,21 @@ void Screen::RenderString(const std::string &s, float xoff, float yoff, const Co
 	r->Translate(floor(x/Screen::fontScale[0])*Screen::fontScale[0], floor(y/Screen::fontScale[1])*Screen::fontScale[1], 0);
 	r->Scale(Screen::fontScale[0], Screen::fontScale[1], 1);
 
-	font->RenderString(s.c_str(), 0, 0, color);
+	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
+	font->PopulateString(va, s.c_str(), 0, 0, color);
+
+	if( va.GetNumVerts() > 0 ) {
+		if( !vb.Valid() || vb->GetVertexCount() != va.GetNumVerts() ) {
+			vb.Reset( font->CreateVertexBuffer(va) );
+		}
+
+		vb->Populate(va);
+		
+		font->RenderBuffer(vb.Get(), color);
+	} 
 }
 
-void Screen::RenderMarkup(const std::string &s, const Color &color, Text::TextureFont *font)
+void Screen::RenderMarkupBuffer(RefCountedPtr<Graphics::VertexBuffer> vb, const std::string &s, const Color &color, Text::TextureFont *font)
 {
 	PROFILE_SCOPED()
     if (!font) font = GetFont().Get();
@@ -327,7 +338,18 @@ void Screen::RenderMarkup(const std::string &s, const Color &color, Text::Textur
 	r->Translate(floor(x/Screen::fontScale[0])*Screen::fontScale[0], floor(y/Screen::fontScale[1])*Screen::fontScale[1], 0);
 	r->Scale(Screen::fontScale[0], Screen::fontScale[1], 1);
 
-	font->RenderMarkup(s.c_str(), 0, 0, color);
+	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
+	font->PopulateMarkup(va, s.c_str(), 0, 0, color);
+
+	if( va.GetNumVerts() > 0 ) {
+		if( !vb.Valid() || vb->GetVertexCount() != va.GetNumVerts() ) {
+			vb.Reset( font->CreateVertexBuffer(va) );
+		}
+
+		vb->Populate(va);
+		
+		font->RenderBuffer(vb.Get());
+	} 
 }
 
 void Screen::AddShortcutWidget(Widget *w)

--- a/src/gui/GuiScreen.h
+++ b/src/gui/GuiScreen.h
@@ -54,12 +54,12 @@ namespace Gui {
 
 		static float GetFontHeight(Text::TextureFont *font = 0);
 		static float GetFontDescender(Text::TextureFont *font = 0);
-
-		static void RenderString(const std::string &s, float xoff, float yoff, const Color &color = Color::WHITE, Text::TextureFont *font = 0);
+		
+		static void RenderStringBuffer(RefCountedPtr<Graphics::VertexBuffer> vb, const std::string &s, float xoff, float yoff, const Color &color = Color::WHITE, Text::TextureFont *font = 0);
+		static void RenderMarkupBuffer(RefCountedPtr<Graphics::VertexBuffer> vb, const std::string &s, const Color &color = Color::WHITE, Text::TextureFont *font = 0);
 		static void MeasureString(const std::string &s, float &w, float &h, Text::TextureFont *font = 0);
 		static int PickCharacterInString(const std::string &s, float x, float y, Text::TextureFont *font = 0);
 		static void MeasureCharacterPos(const std::string &s, int charIndex, float &x, float &y, Text::TextureFont *font = 0);
-		static void RenderMarkup(const std::string &s, const Color &color = Color::WHITE, Text::TextureFont *font = 0);
 
 		static Graphics::Renderer *GetRenderer() { return s_renderer; }
 

--- a/src/gui/GuiTextEntry.cpp
+++ b/src/gui/GuiTextEntry.cpp
@@ -238,7 +238,7 @@ void TextEntry::Draw()
 
 	//text
 	SetScissor(true);
-	Gui::Screen::RenderString(m_text, 1.0f - m_scroll, 0.0f, c, m_font.Get());
+	Gui::Screen::RenderStringBuffer(m_vb, m_text, 1.0f - m_scroll, 0.0f, c, m_font.Get());
 	SetScissor(false);
 
 	//cursor

--- a/src/gui/GuiTextEntry.h
+++ b/src/gui/GuiTextEntry.h
@@ -53,6 +53,7 @@ namespace Gui {
 
 		Graphics::Drawables::Lines m_cursorLines;
 		Graphics::Drawables::Lines m_outlines;
+		RefCountedPtr<Graphics::VertexBuffer> m_vb;
 	};
 }
 

--- a/src/gui/GuiTextLayout.cpp
+++ b/src/gui/GuiTextLayout.cpp
@@ -71,6 +71,9 @@ void TextLayout::MeasureSize(const float width, float outSize[2]) const
 void TextLayout::Render(const float width, const Color &color) const
 {
 	PROFILE_SCOPED()
+	if(words.empty())
+		return;
+
 	float fontScale[2];
 	Gui::Screen::GetCoords2Pixels(fontScale);
 
@@ -84,68 +87,104 @@ void TextLayout::Render(const float width, const Color &color) const
 		r->LoadIdentity();
 		r->Translate(floor(x/fontScale[0])*fontScale[0], floor(y/fontScale[1])*fontScale[1], 0);
 		r->Scale(fontScale[0], fontScale[1], 1);
-		_RenderRaw(width / fontScale[0], color);
+		m_font->RenderBuffer( m_vbuffer.Get(), color );
 	}
 }
 
-void TextLayout::_RenderRaw(float maxWidth, const Color &color) const
+
+void TextLayout::Update(const float width, const Color &color)
 {
 	PROFILE_SCOPED()
-	float py = 0;
+	if(words.empty())
+		return;
+
+	float fontScale[2];
+	Gui::Screen::GetCoords2Pixels(fontScale);
 
 	Graphics::Renderer *r = Gui::Screen::GetRenderer();
 	Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
+	
+	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 
-	const float spaceWidth = m_font->GetGlyph(' ').advX;
+	if( r )
+	{
+		const float maxWidth = width / fontScale[0];
 
-	Color c = color;
+		float py = 0;
 
-	std::list<word_t>::const_iterator wpos = this->words.begin();
-	// build lines of text
-	while (wpos != this->words.end()) {
-		float len = 0;
-		int num = 0;
+		const float spaceWidth = m_font->GetGlyph(' ').advX;
 
-		std::list<word_t>::const_iterator i = wpos;
-		len += (*i).advx;
-		num++;
-		bool overflow = false;
-		bool explicit_newline = false;
-		if ((*i).word != 0) {
-			++i;
-			for (; i != this->words.end(); ++i) {
-				if ((*i).word == 0) {
-					// newline
-					explicit_newline = true;
+		Color c = color;
+
+		std::list<word_t>::const_iterator wpos = this->words.begin();
+		// build lines of text
+		while (wpos != this->words.end()) {
+			float len = 0;
+			int num = 0;
+
+			std::list<word_t>::const_iterator i = wpos;
+			len += (*i).advx;
+			num++;
+			bool overflow = false;
+			bool explicit_newline = false;
+			if ((*i).word != 0) {
+				++i;
+				for (; i != this->words.end(); ++i) {
+					if ((*i).word == 0) {
+						// newline
+						explicit_newline = true;
+						num++;
+						break;
+					}
+					if (len + spaceWidth + (*i).advx > maxWidth) { overflow = true; break; }
+					len += (*i).advx + spaceWidth;
 					num++;
-					break;
 				}
-				if (len + spaceWidth + (*i).advx > maxWidth) { overflow = true; break; }
-				len += (*i).advx + spaceWidth;
-				num++;
 			}
+
+			float _spaceWidth;
+			if ((m_justify) && (num>1) && overflow) {
+				float spaceleft = maxWidth - len;
+				_spaceWidth = spaceWidth + (spaceleft/float(num-1));
+			} else {
+				_spaceWidth = spaceWidth;
+			}
+
+			float px = 0;
+			for (int j=0; j<num; j++) {
+				if ((*wpos).word) {
+					const std::string word( (*wpos).word );
+					if (m_colourMarkup == ColourMarkupUse)
+						c = m_font->PopulateMarkup(va, word, round(px), round(py), c);
+					else
+						m_font->PopulateString(va, word, round(px), round(py), c);
+				}
+				px += (*wpos).advx + _spaceWidth;
+				++wpos;
+			}
+			py += m_font->GetHeight() * (explicit_newline ? PARAGRAPH_SPACING : 1.0f);
+		}
+	}
+
+	if( va.GetNumVerts() > 0 ) {
+		if( !m_vbuffer.Valid() || m_vbuffer->GetVertexCount() != va.GetNumVerts() ) {
+			//create buffer and upload data
+			Graphics::VertexBufferDesc vbd;
+			vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+			vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+			vbd.attrib[1].semantic = Graphics::ATTRIB_DIFFUSE;
+			vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_UBYTE4;
+			vbd.attrib[2].semantic = Graphics::ATTRIB_UV0;
+			vbd.attrib[2].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
+			vbd.numVertices = va.GetNumVerts();
+			vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;	// we could be updating this per-frame
+			Graphics::Material *mat = m_font->GetMaterial();
+			m_vbuffer.Reset( r->CreateVertexBuffer(vbd) );
 		}
 
-		float _spaceWidth;
-		if ((m_justify) && (num>1) && overflow) {
-			float spaceleft = maxWidth - len;
-			_spaceWidth = spaceWidth + (spaceleft/float(num-1));
-		} else {
-			_spaceWidth = spaceWidth;
-		}
-
-		float px = 0;
-		for (int j=0; j<num; j++) {
-			if ((*wpos).word) {
-				if (m_colourMarkup == ColourMarkupUse)
-					c = m_font->RenderMarkup((*wpos).word, round(px), round(py), c);
-				else
-					m_font->RenderString((*wpos).word, round(px), round(py), c);
-			}
-			px += (*wpos).advx + _spaceWidth;
-			++wpos;
-		}
-		py += m_font->GetHeight() * (explicit_newline ? PARAGRAPH_SPACING : 1.0f);
+		m_vbuffer->Populate(va);
+	} else {
+		m_vbuffer.Reset();
 	}
 }
 

--- a/src/gui/GuiTextLayout.h
+++ b/src/gui/GuiTextLayout.h
@@ -6,6 +6,10 @@
 
 #include "text/TextureFont.h"
 
+namespace Graphics {
+	class Vertexbuffer;
+}
+
 namespace Gui {
 class TextLayout {
 public:
@@ -15,14 +19,13 @@ public:
 		ColourMarkupUse   // interprets markup tags
 	};
 	explicit TextLayout(const char *_str, RefCountedPtr<Text::TextureFont> font = RefCountedPtr<Text::TextureFont>(0), ColourMarkupMode markup = ColourMarkupUse);
-	void Render(float layoutWidth, const Color &color = Color::WHITE) const;
+	void Render(const float layoutWidth, const Color &color = Color::WHITE) const;
+	void Update(const float layoutWidth, const Color &color = Color::WHITE);
 	void MeasureSize(const float layoutWidth, float outSize[2]) const;
 	void _MeasureSizeRaw(const float layoutWidth, float outSize[2]) const;
 	~TextLayout() { free(str); }
 	void SetJustified(bool v) { m_justify = v; }
 private:
-	void _RenderRaw(float layoutWidth, const Color &color) const;
-
 	struct word_t {
 		char *word;
 		float advx;
@@ -34,6 +37,7 @@ private:
 	ColourMarkupMode m_colourMarkup;
 
 	RefCountedPtr<Text::TextureFont> m_font;
+	RefCountedPtr<Graphics::VertexBuffer> m_vbuffer;
 };
 }
 

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -6,6 +6,7 @@
 #include "libs.h"
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
+#include "graphics/VertexBuffer.h"
 #include "TextSupport.h"
 #include "utils.h"
 
@@ -24,7 +25,7 @@ namespace Text {
 
 int TextureFont::s_glyphCount = 0;
 
-void TextureFont::AddGlyphGeometry(Graphics::VertexArray *va, const Glyph &glyph, float x, float y, const Color &c)
+void TextureFont::AddGlyphGeometry(Graphics::VertexArray &va, const Glyph &glyph, const float x, const float y, const Color &c)
 {
 	const float offX = x + float(glyph.offX);
 	const float offY = y + GetHeight() - float(glyph.offY);
@@ -41,18 +42,18 @@ void TextureFont::AddGlyphGeometry(Graphics::VertexArray *va, const Glyph &glyph
 	const vector2f t2(offU+glyph.texWidth, offV                );
 	const vector2f t3(offU+glyph.texWidth, offV+glyph.texHeight);
 
-	va->Add(p0, c, t0);
-	va->Add(p1, c, t1);
-	va->Add(p2, c, t2);
+	va.Add(p0, c, t0);
+	va.Add(p1, c, t1);
+	va.Add(p2, c, t2);
 
-	va->Add(p2, c, t2);
-	va->Add(p1, c, t1);
-	va->Add(p3, c, t3);
+	va.Add(p2, c, t2);
+	va.Add(p1, c, t1);
+	va.Add(p3, c, t3);
 
 	s_glyphCount++;
 }
 
-void TextureFont::MeasureString(const char *str, float &w, float &h)
+void TextureFont::MeasureString(const std::string &str, float &w, float &h)
 {
 	w = h = 0.0f;
 
@@ -65,9 +66,7 @@ void TextureFont::MeasureString(const char *str, float &w, float &h)
 			line_width = 0.0f;
 			h += GetHeight();
 			i++;
-		}
-
-		else {
+		} else {
 			Uint32 chr;
 			int n = utf8_decode_char(&chr, &str[i]);
 			assert(n);
@@ -90,9 +89,9 @@ void TextureFont::MeasureString(const char *str, float &w, float &h)
 	h += GetHeight() + GetDescender();
 }
 
-void TextureFont::MeasureCharacterPos(const char *str, int charIndex, float &charX, float &charY)
+void TextureFont::MeasureCharacterPos(const std::string &str, int charIndex, float &charX, float &charY)
 {
-	assert(str && (charIndex >= 0));
+	assert(charIndex >= 0);
 
 	float x = 0.0f, y = GetHeight();
 	int i = 0;
@@ -124,9 +123,9 @@ void TextureFont::MeasureCharacterPos(const char *str, int charIndex, float &cha
 	charY = y;
 }
 
-int TextureFont::PickCharacter(const char *str, float mouseX, float mouseY)
+int TextureFont::PickCharacter(const std::string &str, float mouseX, float mouseY)
 {
-	assert(str && mouseX >= 0.0f && mouseY >= 0.0f);
+	assert(mouseX >= 0.0f && mouseY >= 0.0f);
 
 	// at the point of the mouse in-box test, the vars have the following values:
 	// i1: the index of the character being tested
@@ -175,10 +174,20 @@ int TextureFont::PickCharacter(const char *str, float mouseX, float mouseY)
 	return i2;
 }
 
-void TextureFont::RenderString(const char *str, float x, float y, const Color &color)
+void TextureFont::RenderBuffer(Graphics::VertexBuffer *vb, const Color &color)
+{
+	if( vb && vb->GetVertexCount() > 0 )
+	{
+		m_mat->diffuse = color;
+		m_renderer->DrawBuffer(vb, m_renderState, m_mat.get());
+	}
+}
+
+void TextureFont::PopulateString(Graphics::VertexArray &va, const std::string &str, const float x, const float y, const Color &color)
 {
 	PROFILE_SCOPED()
-	m_vertices.Clear();
+
+	if(str.empty()) return;
 
 	float alpha_f = color.a / 255.0f;
 	const Color premult_color = Color(color.r * alpha_f, color.g * alpha_f, color.b * alpha_f, color.a);
@@ -192,16 +201,14 @@ void TextureFont::RenderString(const char *str, float x, float y, const Color &c
 			px = x;
 			py += GetHeight();
 			i++;
-		}
-
-		else {
+		} else {
 			Uint32 chr;
 			int n = utf8_decode_char(&chr, &str[i]);
 			assert(n);
 			i += n;
 
 			const Glyph &glyph = GetGlyph(chr);
-			AddGlyphGeometry(&m_vertices, glyph, roundf(px), py, premult_color);
+			AddGlyphGeometry(va, glyph, roundf(px), py, premult_color);
 
 			if (str[i]) {
 				Uint32 chr2;
@@ -214,14 +221,13 @@ void TextureFont::RenderString(const char *str, float x, float y, const Color &c
 			px += glyph.advX;
 		}
 	}
-
-	m_renderer->DrawTriangles(&m_vertices, m_renderState, m_mat.get());
 }
 
-Color TextureFont::RenderMarkup(const char *str, float x, float y, const Color &color)
+Color TextureFont::PopulateMarkup(Graphics::VertexArray &va, const std::string &str, const float x, const float y, const Color &color)
 {
 	PROFILE_SCOPED()
-	m_vertices.Clear();
+
+	if(str.empty()) return Color::BLACK;
 
 	float px = x;
 	float py = y;
@@ -233,8 +239,8 @@ Color TextureFont::RenderMarkup(const char *str, float x, float y, const Color &
 	int i = 0;
 	while (str[i]) {
 		if (str[i] == '#') {
-			unsigned hexcol;
-			if (sscanf(str+i, "#%3x", &hexcol)==1) {
+			Uint32 hexcol;
+			if (sscanf(&str[i], "#%3x", &hexcol)==1) {
 				c.r = float((hexcol&0xf00)>>4);
 				c.g = float((hexcol&0xf0));
 				c.b = float((hexcol&0xf)<<4);
@@ -251,16 +257,14 @@ Color TextureFont::RenderMarkup(const char *str, float x, float y, const Color &
 			px = x;
 			py += GetHeight();
 			i++;
-		}
-
-		else {
+		} else {
 			Uint32 chr;
 			int n = utf8_decode_char(&chr, &str[i]);
 			assert(n);
 			i += n;
 
 			const Glyph &glyph = GetGlyph(chr);
-			AddGlyphGeometry(&m_vertices, glyph, roundf(px), py, premult_c);
+			AddGlyphGeometry(va, glyph, roundf(px), py, premult_c);
 
 			// XXX kerning doesn't skip markup
 			if (str[i]) {
@@ -275,8 +279,29 @@ Color TextureFont::RenderMarkup(const char *str, float x, float y, const Color &
 		}
 	}
 
-	m_renderer->DrawTriangles(&m_vertices, m_renderState, m_mat.get());
 	return c;
+}
+
+Graphics::VertexBuffer* TextureFont::CreateVertexBuffer(const Graphics::VertexArray &va) const 
+{
+	if( va.GetNumVerts() > 0 )
+	{
+		//create buffer and upload data
+		Graphics::VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.attrib[1].semantic = Graphics::ATTRIB_DIFFUSE;
+		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_UBYTE4;
+		vbd.attrib[2].semantic = Graphics::ATTRIB_UV0;
+		vbd.attrib[2].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
+		vbd.numVertices = va.GetNumVerts();
+		vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;	// we could be updating this per-frame
+		Graphics::VertexBuffer *vbuffer = m_renderer->CreateVertexBuffer(vbd);
+		vbuffer->Populate( va );
+
+		return vbuffer;
+	}
+	return nullptr;
 }
 
 const TextureFont::Glyph &TextureFont::GetGlyph(Uint32 chr)
@@ -423,9 +448,8 @@ TextureFont::Glyph TextureFont::BakeGlyph(Uint32 chr)
 
 		FT_Done_Glyph(strokeGlyph);
 	}
-
-	else {
-
+	else 
+	{
 		//don't run off atlas borders
 		m_atlasVIncrement = std::max(m_atlasVIncrement, static_cast<unsigned int>(bmGlyph->bitmap.rows));
 		if (m_atlasU + static_cast<unsigned int>(bmGlyph->bitmap.width) >= ATLAS_SIZE) {
@@ -475,7 +499,6 @@ TextureFont::TextureFont(const FontConfig &config, Graphics::Renderer *renderer,
 	, m_scale(scale)
 	, m_ftLib(nullptr)
 	, m_stroker(nullptr)
-	, m_vertices(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0)
 	, m_atlasU(0)
 	, m_atlasV(0)
 	, m_atlasVIncrement(0)

--- a/src/text/TextureFont.h
+++ b/src/text/TextureFont.h
@@ -9,7 +9,7 @@
 #include "RefCounted.h"
 #include "graphics/Texture.h"
 #include "graphics/Material.h"
-#include "graphics/VertexArray.h"
+#include "graphics/VertexBuffer.h"
 #include "graphics/RenderState.h"
 
 namespace FileSystem { class FileData; }
@@ -30,11 +30,14 @@ public:
 	TextureFont(const FontConfig &config, Graphics::Renderer *renderer, float scale = 1.0f);
 	~TextureFont();
 
-	void RenderString(const char *str, float x, float y, const Color &color = Color::WHITE);
-	Color RenderMarkup(const char *str, float x, float y, const Color &color = Color::WHITE);
-	void MeasureString(const char *str, float &w, float &h);
-	void MeasureCharacterPos(const char *str, int charIndex, float &x, float &y);
-	int PickCharacter(const char *str, float mouseX, float mouseY);
+	void RenderBuffer(Graphics::VertexBuffer *vb, const Color &color = Color::WHITE);
+	void MeasureString(const std::string &str, float &w, float &h);
+	void MeasureCharacterPos(const std::string &str, int charIndex, float &x, float &y);
+	int PickCharacter(const std::string &str, float mouseX, float mouseY);
+
+	void PopulateString(Graphics::VertexArray &va, const std::string &str, const float x, const float y, const Color &color = Color::WHITE);
+	Color PopulateMarkup(Graphics::VertexArray &va, const std::string &str, const float x, const float y, const Color &color = Color::WHITE);
+	Graphics::VertexBuffer* CreateVertexBuffer(const Graphics::VertexArray &va) const;
 
 	// general baseline-to-baseline height
 	float GetHeight() const { return m_height; }
@@ -56,9 +59,8 @@ public:
 	static int GetGlyphCount() { return s_glyphCount; }
 	static void ClearGlyphCount() { s_glyphCount = 0; }
 
-	// fill a vertex array with single-colored text
-	void CreateGeometry(Graphics::VertexArray &, const char *str, float x, float y, const Color &color = Color::WHITE);
-	RefCountedPtr<Graphics::Texture> GetTexture() { return m_texture; }
+	RefCountedPtr<Graphics::Texture> GetTexture() const  { return m_texture; }
+	Graphics::Material* GetMaterial() const { return m_mat.get(); }
 
 private:
 	TextureFont(const TextureFont &);
@@ -78,11 +80,11 @@ private:
 
 	float GetKern(const Glyph &a, const Glyph &b);
 
-	void AddGlyphGeometry(Graphics::VertexArray *va, const Glyph &glyph, float x, float y, const Color &color);
+	void AddGlyphGeometry(Graphics::VertexArray &va, const Glyph &glyph, const float x, const float y, const Color &color);
 	float m_height;
 	float m_descender;
 	std::unique_ptr<Graphics::Material> m_mat;
-	Graphics::VertexArray m_vertices;
+	std::unique_ptr<Graphics::VertexBuffer> m_vertexBuffer;
 	Graphics::RenderState *m_renderState;
 
 	static int s_glyphCount;

--- a/src/ui/Label.cpp
+++ b/src/ui/Label.cpp
@@ -4,18 +4,25 @@
 #include "Label.h"
 #include "Context.h"
 #include "text/TextureFont.h"
+#include "graphics/VertexArray.h"
+#include "graphics/VertexBuffer.h"
 
 namespace UI {
 
-Label::Label(Context *context, const std::string &text) : Widget(context), m_text(text), m_color(Color::WHITE)
+static const Color disabledColor(204, 204, 204, 255);
+
+Label::Label(Context *context, const std::string &text) : Widget(context), m_bNeedsUpdating(true), m_text(text), m_color(Color::WHITE), m_font(GetContext()->GetFont(GetFont()))
 {
 	RegisterBindPoint("text", sigc::mem_fun(this, &Label::BindText));
 }
 
 Point Label::PreferredSize()
 {
+	if( m_font != GetContext()->GetFont(GetFont()) ) {
+		m_font = GetContext()->GetFont(GetFont());
+	}
 	vector2f textSize;
-	GetContext()->GetFont(GetFont())->MeasureString(m_text.c_str(), textSize.x, textSize.y);
+	m_font->MeasureString(m_text, textSize.x, textSize.y);
 	m_preferredSize = Point(ceilf(textSize.x), ceilf(textSize.y));
 	return m_preferredSize;
 }
@@ -27,20 +34,32 @@ void Label::Layout()
 
 	const Point &size = GetSize();
 	SetActiveArea(Point(std::min(m_preferredSize.x,size.x), std::min(m_preferredSize.y,size.y)));
+
+	m_bNeedsUpdating = true;
 }
 
 void Label::Draw()
 {
-	static const Color disabledColor(204, 204, 204, 255);
 	const Color color(IsDisabled() ? disabledColor : m_color);
-	GetContext()->GetFont(GetFont())->RenderString(m_text.c_str(), 0.0f, 0.0f, Color(color.r, color.g, color.b, color.a*GetContext()->GetOpacity()));
+	const Color finalColor(color.r, color.g, color.b, color.a*GetContext()->GetOpacity());
+
+	if( m_bNeedsUpdating || m_font != GetContext()->GetFont(GetFont()) )
+	{
+		m_font = GetContext()->GetFont(GetFont());
+		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
+		m_font->PopulateString(va, m_text, 0.0f, 0.0f, finalColor);
+		m_vbuffer.Reset( m_font->CreateVertexBuffer(va) );
+		m_bNeedsUpdating = false;
+	}
+
+	m_font->RenderBuffer( m_vbuffer.Get() );
 }
 
 Label *Label::SetText(const std::string &text)
 {
-	if (text == m_text) return this;
 	m_text = text;
 	GetContext()->RequestLayout();
+	m_bNeedsUpdating = true;
 	return this;
 }
 

--- a/src/ui/Label.h
+++ b/src/ui/Label.h
@@ -6,6 +6,8 @@
 
 #include "Widget.h"
 #include "SmartPtr.h"
+#include "text/TextureFont.h"
+#include "graphics/VertexBuffer.h"
 
 // single line of text
 
@@ -29,9 +31,12 @@ protected:
 private:
 	void BindText(PropertyMap &p, const std::string &k);
 
+	bool m_bNeedsUpdating;
 	std::string m_text;
 	Color m_color;
 	Point m_preferredSize;
+	RefCountedPtr<Text::TextureFont> m_font;
+	RefCountedPtr<Graphics::VertexBuffer> m_vbuffer;
 };
 
 }

--- a/src/ui/TextLayout.h
+++ b/src/ui/TextLayout.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 namespace Text { class TextureFont; }
-namespace Graphics { class Renderer; }
+namespace Graphics { class Renderer; class VertexBuffer; }
 
 namespace UI {
 
@@ -35,6 +35,7 @@ private:
 	Point m_lastSize;        // and the resulting size
 
 	RefCountedPtr<Text::TextureFont> m_font;
+	RefCountedPtr<Graphics::VertexBuffer> m_vbuffer;
 };
 
 }


### PR DESCRIPTION
# Description:
Create and reuse VertexBuffer objects wherever we can for text rendering.

The idea being that this should be faster than the existing code which creates, renders then destroys a great many `VertexBuffer` objects per-frame.

# WIP:
This actually seems slower at the moment, it is a work-in-progress.

Andy