### PR TITLE
Dummy renderer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -396,6 +396,8 @@ AC_CONFIG_FILES([
 	src/gameui/Makefile
 	src/gui/Makefile
 	src/graphics/Makefile
+	src/graphics/opengl/Makefile
+	src/graphics/dummy/Makefile
 	src/scenegraph/Makefile
 	src/galaxy/Makefile
 	src/terrain/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -286,6 +286,7 @@ pioneer_LDADD = \
 	collider/libcollider.a \
 	gui/libgui.a \
 	graphics/libgraphics.a \
+	graphics/opengl/libgraphicsopengl.a \
 	galaxy/libgalaxy.a \
 	scenegraph/libscenegraph.a \
 	text/libtext.a \
@@ -542,6 +543,8 @@ modelcompiler_LDADD = \
 	collider/libcollider.a \
 	gui/libgui.a \
 	graphics/libgraphics.a \
+	graphics/dummy/libgraphicsdummy.a \
+	graphics/opengl/libgraphicsopengl.a \
 	galaxy/libgalaxy.a \
 	scenegraph/libscenegraph.a \
 	text/libtext.a \

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -3,6 +3,7 @@
 
 #include "ModelViewer.h"
 #include "FileSystem.h"
+#include "graphics/opengl/RendererGL.h"
 #include "graphics/Graphics.h"
 #include "graphics/Light.h"
 #include "graphics/TextureBuilder.h"
@@ -140,6 +141,8 @@ void ModelViewer::Run(const std::string &modelName)
 	Lua::Init();
 
 	ModManager::Init();
+
+	Graphics::RendererOGL::RegisterRenderer();
 
 	//video
 	Graphics::Settings videoSettings = {};

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -143,6 +143,7 @@ void ModelViewer::Run(const std::string &modelName)
 
 	//video
 	Graphics::Settings videoSettings = {};
+	videoSettings.rendererType = Graphics::RENDERER_OPENGL;
 	videoSettings.width = config->Int("ScrWidth");
 	videoSettings.height = config->Int("ScrHeight");
 	videoSettings.fullscreen = (config->Int("StartFullscreen") != 0);

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -788,7 +788,9 @@ void ModelViewer::Screenshot()
 	const time_t t = time(0);
 	const struct tm *_tm = localtime(&t);
 	strftime(buf, sizeof(buf), "modelviewer-%Y%m%d-%H%M%S.png", _tm);
-	Screendump(buf, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+	Graphics::ScreendumpState sd;
+	m_renderer->Screendump(sd);
+	write_screenshot(sd, buf);
 	AddLog(stringf("Screenshot %0 saved", buf));
 }
 

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -388,6 +388,7 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 
 	// Do rest of SDL video initialization and create Renderer
 	Graphics::Settings videoSettings = {};
+	videoSettings.rendererType = Graphics::RENDERER_OPENGL;
 	videoSettings.width = config->Int("ScrWidth");
 	videoSettings.height = config->Int("ScrHeight");
 	videoSettings.fullscreen = (config->Int("StartFullscreen") != 0);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -778,7 +778,9 @@ void Pi::HandleEvents()
 							const time_t t = time(0);
 							struct tm *_tm = localtime(&t);
 							strftime(buf, sizeof(buf), "screenshot-%Y%m%d-%H%M%S.png", _tm);
-							Screendump(buf, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+							Graphics::ScreendumpState sd;
+							Pi::renderer->Screendump(sd);
+							write_screenshot(sd, buf);
 							break;
 						}
 #if WITH_DEVKEYS

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -66,6 +66,7 @@
 #include "galaxy/GalaxyGenerator.h"
 #include "galaxy/StarSystem.h"
 #include "gameui/Lua.h"
+#include "graphics/opengl/RendererGL.h"
 #include "graphics/Graphics.h"
 #include "graphics/Light.h"
 #include "graphics/Renderer.h"
@@ -385,6 +386,8 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 	SDL_version ver;
 	SDL_GetVersion(&ver);
 	Output("SDL Version %d.%d.%d\n", ver.major, ver.minor, ver.patch);
+
+	Graphics::RendererOGL::RegisterRenderer();
 
 	// Do rest of SDL video initialization and create Renderer
 	Graphics::Settings videoSettings = {};

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -665,7 +665,7 @@ void SectorView::PutFactionLabels(const vector3f &origin)
 {
 	PROFILE_SCOPED()
 
-	glDepthRange(0,1);
+	m_renderer->SetDepthRange(0,1);
 	Gui::Screen::EnterOrtho();
 
 	if (!m_material)
@@ -901,7 +901,7 @@ void SectorView::DrawNearSectors(const matrix4x4f& modelview)
 	const vector3f secOrigin = vector3f(int(floorf(m_pos.x)), int(floorf(m_pos.y)), int(floorf(m_pos.z)));
 
 	m_renderer->SetTransform(modelview);
-	glDepthRange(0,1);
+	m_renderer->SetDepthRange(0,1);
 	Gui::Screen::EnterOrtho();
 	for (int sx = -DRAW_RAD; sx <= DRAW_RAD; sx++) {
 		for (int sy = -DRAW_RAD; sy <= DRAW_RAD; sy++) {
@@ -1058,21 +1058,21 @@ void SectorView::DrawNearSector(const int sx, const int sy, const int sz, const 
 
 		// player location indicator
 		if (m_inSystem && bIsCurrentSystem) {
-			glDepthRange(0.2,1.0);
+			m_renderer->SetDepthRange(0.2,1.0);
 			m_disk->SetColor(Color(0, 0, 204));
 			m_renderer->SetTransform(systrans * matrix4x4f::ScaleMatrix(3.f));
 			m_disk->Draw(m_renderer);
 		}
 		// selected indicator
 		if (bIsCurrentSystem) {
-			glDepthRange(0.1,1.0);
+			m_renderer->SetDepthRange(0.1,1.0);
 			m_disk->SetColor(Color(0, 204, 0));
 			m_renderer->SetTransform(systrans * matrix4x4f::ScaleMatrix(2.f));
 			m_disk->Draw(m_renderer);
 		}
 		// hyperspace target indicator (if different from selection)
 		if (i->IsSameSystem(m_hyperspaceTarget) && m_hyperspaceTarget != m_selected && (!m_inSystem || m_hyperspaceTarget != m_current)) {
-			glDepthRange(0.1,1.0);
+			m_renderer->SetDepthRange(0.1,1.0);
 			m_disk->SetColor(Color(77));
 			m_renderer->SetTransform(systrans * matrix4x4f::ScaleMatrix(2.f));
 			m_disk->Draw(m_renderer);

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1877,7 +1877,7 @@ void WorldView::Draw()
 	DrawCombatTargetIndicator(m_combatTargetIndicator, m_targetLeadIndicator, red);
 
 	// glLineWidth(1.0f);
-	Graphics::CheckRenderErrors();
+	m_renderer->CheckRenderErrors();
 
 	// normal crosshairs
 	if (GetCamType() == CAM_INTERNAL) {

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -4,7 +4,6 @@
 #include "Graphics.h"
 #include "FileSystem.h"
 #include "Material.h"
-#include "opengl/gl_core_3_x.h"
 #include "opengl/RendererGL.h"
 #include "dummy/RendererDummy.h"
 #include "OS.h"
@@ -46,133 +45,6 @@ float GetFovFactor()
 	return g_fovFactor;
 }
 
-static const char *gl_error_to_string(GLenum err)
-{
-	switch (err) {
-		case GL_NO_ERROR: return "(no error)";
-		case GL_INVALID_ENUM: return "invalid enum";
-		case GL_INVALID_VALUE: return "invalid value";
-		case GL_INVALID_OPERATION: return "invalid operation";
-		case GL_INVALID_FRAMEBUFFER_OPERATION: return "invalid framebuffer operation";
-		case GL_OUT_OF_MEMORY: return "out of memory";
-		default: return "(unknown error)";
-	}
-}
-
-static void dump_and_clear_opengl_errors(std::ostream &out, GLenum first_error = GL_NO_ERROR)
-{
-	GLenum err = ((first_error == GL_NO_ERROR) ? glGetError() : first_error);
-	if (err != GL_NO_ERROR) {
-		out << "errors: ";
-		do {
-			out << gl_error_to_string(err) << " ";
-			err = glGetError();
-		} while (err != GL_NO_ERROR);
-		out << std::endl;
-	}
-}
-
-static void dump_opengl_value(std::ostream &out, const char *name, GLenum id, int num_elems)
-{
-	assert(num_elems > 0 && num_elems <= 4);
-	assert(name);
-
-	GLdouble e[4];
-	glGetDoublev(id, e);
-
-	GLenum err = glGetError();
-	if (err == GL_NO_ERROR) {
-		out << name << " = " << e[0];
-		for (int i = 1; i < num_elems; ++i)
-			out << ", " << e[i];
-		out << "\n";
-	} else {
-		while (err != GL_NO_ERROR) {
-			if (err == GL_INVALID_ENUM) { out << name << " -- not supported\n"; }
-			else { out << name << " -- unexpected error (" << err << ") retrieving value\n"; }
-			err = glGetError();
-		}
-	}
-}
-
-static void write_opengl_info(std::ostream &out)
-{
-	out << "OpenGL version " << glGetString(GL_VERSION);
-	out << ", running on " << glGetString(GL_VENDOR);
-	out << " " << glGetString(GL_RENDERER) << "\n";
-
-	out << "Available extensions:" << "\n";
-	{
-		out << "Shading language version: " <<  glGetString(GL_SHADING_LANGUAGE_VERSION) << "\n";
-		GLint numext = 0;
-		glGetIntegerv(GL_NUM_EXTENSIONS, &numext);
-		for (int i = 0; i < numext; ++i) {
-			out << "  " << glGetStringi(GL_EXTENSIONS, i) << "\n";
-		}
-	}
-
-	out << "\nImplementation Limits:\n";
-
-	// first, clear all OpenGL error flags
-	dump_and_clear_opengl_errors(out);
-
-#define DUMP_GL_VALUE(name) dump_opengl_value(out, #name, name, 1)
-#define DUMP_GL_VALUE2(name) dump_opengl_value(out, #name, name, 2)
-
-	DUMP_GL_VALUE(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS);
-	DUMP_GL_VALUE(GL_MAX_CUBE_MAP_TEXTURE_SIZE);
-	DUMP_GL_VALUE(GL_MAX_DRAW_BUFFERS);
-	DUMP_GL_VALUE(GL_MAX_ELEMENTS_INDICES);
-	DUMP_GL_VALUE(GL_MAX_ELEMENTS_VERTICES);
-	DUMP_GL_VALUE(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS);
-	DUMP_GL_VALUE(GL_MAX_TEXTURE_IMAGE_UNITS);
-	DUMP_GL_VALUE(GL_MAX_TEXTURE_LOD_BIAS);
-	DUMP_GL_VALUE(GL_MAX_TEXTURE_SIZE);
-	DUMP_GL_VALUE(GL_MAX_VERTEX_ATTRIBS);
-	DUMP_GL_VALUE(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS);
-	DUMP_GL_VALUE(GL_MAX_VERTEX_UNIFORM_COMPONENTS);
-	DUMP_GL_VALUE(GL_NUM_COMPRESSED_TEXTURE_FORMATS);
-	DUMP_GL_VALUE(GL_SAMPLE_BUFFERS);
-	DUMP_GL_VALUE(GL_SAMPLES);
-	DUMP_GL_VALUE2(GL_ALIASED_LINE_WIDTH_RANGE);
-	DUMP_GL_VALUE2(GL_MAX_VIEWPORT_DIMS);
-	DUMP_GL_VALUE2(GL_SMOOTH_LINE_WIDTH_RANGE);
-	DUMP_GL_VALUE2(GL_SMOOTH_POINT_SIZE_RANGE);
-
-#undef DUMP_GL_VALUE
-#undef DUMP_GL_VALUE2
-
-	// enumerate compressed texture formats
-	{
-		dump_and_clear_opengl_errors(out);
-		out << "\nCompressed texture formats:\n";
-
-		GLint nformats;
-		GLint formats[128]; // XXX 128 should be enough, right?
-
-		glGetIntegerv(GL_NUM_COMPRESSED_TEXTURE_FORMATS, &nformats);
-		GLenum err = glGetError();
-		if (err != GL_NO_ERROR) {
-			out << "Get NUM_COMPRESSED_TEXTURE_FORMATS failed\n";
-			dump_and_clear_opengl_errors(out, err);
-		} else {
-			assert(nformats >= 0 && nformats < int(COUNTOF(formats)));
-			glGetIntegerv(GL_COMPRESSED_TEXTURE_FORMATS, formats);
-			err = glGetError();
-			if (err != GL_NO_ERROR) {
-				out << "Get COMPRESSED_TEXTURE_FORMATS failed\n";
-				dump_and_clear_opengl_errors(out, err);
-			} else {
-				for (int i = 0; i < nformats; ++i) {
-					out << stringf("  %0{x#}\n", unsigned(formats[i]));
-				}
-			}
-		}
-	}
-	// one last time
-	dump_and_clear_opengl_errors(out);
-}
-
 Renderer* Init(Settings vs)
 {
 	assert(!initted);
@@ -191,26 +63,6 @@ Renderer* Init(Settings vs)
 	width = window->GetWidth();
 	height = window->GetHeight();
 
-	const int didLoad = ogl_LoadFunctions();
-	if (!didLoad)
-		Error("glLoadGen failed to load functions.\n");
-
-	{
-		std::ostringstream buf;
-		write_opengl_info(buf);
-
-		FILE *f = FileSystem::userFiles.OpenWriteStream("opengl.txt", FileSystem::FileSourceFS::WRITE_TEXT);
-		if (!f)
-			Output("Could not open 'opengl.txt'\n");
-		const std::string &s = buf.str();
-		fwrite(s.c_str(), 1, s.size(), f);
-		fclose(f);
-	}
-
-	if (ogl_ext_EXT_texture_compression_s3tc == ogl_LOAD_FAILED) {
-		Error("OpenGL extension GL_EXT_texture_compression_s3tc not supported.\nPioneer can not run on your graphics card as it does not support compressed (DXTn/S3TC) format textures.");
-	}
-
 	// We deliberately ignore the value from GL_NUM_COMPRESSED_TEXTURE_FORMATS, because some drivers
 	// choose not to list any formats (despite supporting texture compression). See issue #3132.
 	// This is (probably) allowed by the spec, which states that only formats which are "suitable
@@ -224,8 +76,17 @@ Renderer* Init(Settings vs)
 
 	Output("Initialized %s\n", renderer->GetName());
 
-	std::ostringstream dummy;
-	dump_and_clear_opengl_errors(dummy);
+	{
+		std::ostringstream buf;
+		renderer->WriteRendererInfo(buf);
+
+		FILE *f = FileSystem::userFiles.OpenWriteStream("opengl.txt", FileSystem::FileSourceFS::WRITE_TEXT);
+		if (!f)
+			Output("Could not open 'opengl.txt'\n");
+		const std::string &s = buf.str();
+		fwrite(s.c_str(), 1, s.size(), f);
+		fclose(f);
+	}
 
 	initted = true;
 

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -13,6 +13,14 @@
 
 namespace Graphics {
 
+static RendererCreateFunc rendererCreateFunc[MAX_RENDERER_TYPE] = {};
+
+void RegisterRenderer(RendererType type, RendererCreateFunc fn) {
+	assert(type < MAX_RENDERER_TYPE);
+	assert(fn);
+	rendererCreateFunc[type] = fn;
+}
+
 static bool initted = false;
 Material *vtxColorMaterial;
 static int width, height;
@@ -68,11 +76,9 @@ Renderer* Init(Settings vs)
 	// This is (probably) allowed by the spec, which states that only formats which are "suitable
 	// for general-purpose usage" should be enumerated.
 
-	Renderer *renderer =
-		vs.rendererType == Graphics::RENDERER_OPENGL ? new RendererOGL(window, vs) :
-		vs.rendererType == Graphics::RENDERER_DUMMY  ? new RendererDummy() :
-		static_cast<Renderer*>(nullptr);
-	assert(renderer);
+	assert(vs.rendererType < MAX_RENDERER_TYPE);
+	assert(rendererCreateFunc[vs.rendererType]);
+	Renderer *renderer = rendererCreateFunc[vs.rendererType](window, vs);
 
 	Output("Initialized %s\n", renderer->GetName());
 

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -6,6 +6,7 @@
 #include "Material.h"
 #include "opengl/gl_core_3_x.h"
 #include "opengl/RendererGL.h"
+#include "dummy/RendererDummy.h"
 #include "OS.h"
 #include "StringF.h"
 #include <sstream>
@@ -214,8 +215,12 @@ Renderer* Init(Settings vs)
 	// choose not to list any formats (despite supporting texture compression). See issue #3132.
 	// This is (probably) allowed by the spec, which states that only formats which are "suitable
 	// for general-purpose usage" should be enumerated.
-	
-	Renderer *renderer = new RendererOGL(window, vs);
+
+	Renderer *renderer =
+		vs.rendererType == Graphics::RENDERER_OPENGL ? new RendererOGL(window, vs) :
+		vs.rendererType == Graphics::RENDERER_DUMMY  ? new RendererDummy() :
+		static_cast<Renderer*>(nullptr);
+	assert(renderer);
 
 	Output("Initialized %s\n", renderer->GetName());
 

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -59,6 +59,14 @@ namespace Graphics {
 	Renderer* Init(Settings);
 	void Uninit();
 	std::vector<VideoMode> GetAvailableVideoModes();
+
+	struct ScreendumpState {
+		std::unique_ptr<Uint8[]> pixels;
+		Uint32 width;
+		Uint32 height;
+		Uint32 stride;
+		Uint32 bpp;
+	};
 }
 
 #endif /* _RENDER_H */

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -16,8 +16,15 @@ namespace Graphics {
 	class Renderer;
 	class Material;
 
+	enum RendererType {
+		RENDERER_NONE = 0,
+		RENDERER_DUMMY,
+		RENDERER_OPENGL
+	};
+
 	// requested video settings
 	struct Settings {
+		RendererType rendererType;
 		bool fullscreen;
 		bool hidden;
 		bool useTextureCompression;

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -13,13 +13,10 @@
  */
 namespace Graphics {
 
-	class Renderer;
-	class Material;
-
 	enum RendererType {
-		RENDERER_NONE = 0,
 		RENDERER_DUMMY,
-		RENDERER_OPENGL
+		RENDERER_OPENGL,
+		MAX_RENDERER_TYPE
 	};
 
 	// requested video settings
@@ -37,6 +34,12 @@ namespace Graphics {
 		const char *title;
 	};
 
+	class Renderer;
+	class WindowSDL;
+
+	typedef Renderer* (*RendererCreateFunc)(WindowSDL *window, const Settings &vs);
+	void RegisterRenderer(RendererType type, RendererCreateFunc fn);
+
 	//for querying available modes
 	struct VideoMode {
 		VideoMode(int w, int h)
@@ -46,6 +49,7 @@ namespace Graphics {
 		int height;
 	};
 
+	class Material;
 	extern Material *vtxColorMaterial;
 
 	int GetScreenWidth();

--- a/src/graphics/Makefile.am
+++ b/src/graphics/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS = opengl dummy
+
 include $(top_srcdir)/Makefile.common
 
 AM_CFLAGS += $(WARN_CFLAGS)
@@ -21,33 +23,7 @@ noinst_HEADERS = \
 	TextureBuilder.h \
 	Drawables.h \
 	Types.h \
-	VertexBuffer.h \
-	opengl/gl_core_3_x.h \
-	opengl/GLDebug.h \
-	opengl/MaterialGL.h \
-	opengl/RenderStateGL.h \
-	opengl/RenderTargetGL.h \
-	opengl/VertexBufferGL.h \
-	opengl/FresnelColourMaterial.h \
-	opengl/GasGiantMaterial.h \
-	opengl/GeoSphereMaterial.h \
-	opengl/MultiMaterial.h \
-	opengl/Program.h \
-	opengl/RendererGL.h \
-	opengl/RingMaterial.h \
-	opengl/ShieldMaterial.h \
-	opengl/StarfieldMaterial.h \
-	opengl/SkyboxMaterial.h \
-	opengl/TextureGL.h \
-	opengl/UIMaterial.h \
-	opengl/Uniform.h \
-	opengl/VtxColorMaterial.h \
-	dummy/RendererDummy.h \
-	dummy/MaterialDummy.h \
-	dummy/TextureDummy.h \
-	dummy/RenderStateDummy.h \
-	dummy/RenderTargetDummy.h \
-	dummy/VertexBufferDummy.h
+	VertexBuffer.h
 
 libgraphics_a_SOURCES = \
 	Graphics.cpp \
@@ -59,21 +35,4 @@ libgraphics_a_SOURCES = \
 	VertexArray.cpp \
 	TextureBuilder.cpp \
 	Drawables.cpp \
-	VertexBuffer.cpp \
-	opengl/gl_core_3_x.c \
-	opengl/MaterialGL.cpp \
-	opengl/RenderStateGL.cpp \
-	opengl/RenderTargetGL.cpp \
-	opengl/VertexBufferGL.cpp \
-	opengl/FresnelColourMaterial.cpp \
-	opengl/GasGiantMaterial.cpp \
-	opengl/GeoSphereMaterial.cpp \
-	opengl/MultiMaterial.cpp \
-	opengl/Program.cpp \
-	opengl/ShieldMaterial.cpp \
-	opengl/RendererGL.cpp \
-	opengl/RingMaterial.cpp \
-	opengl/TextureGL.cpp \
-	opengl/UIMaterial.cpp \
-	opengl/Uniform.cpp \
-	opengl/VtxColorMaterial.cpp
+	VertexBuffer.cpp

--- a/src/graphics/Makefile.am
+++ b/src/graphics/Makefile.am
@@ -41,7 +41,13 @@ noinst_HEADERS = \
 	opengl/TextureGL.h \
 	opengl/UIMaterial.h \
 	opengl/Uniform.h \
-	opengl/VtxColorMaterial.h
+	opengl/VtxColorMaterial.h \
+	dummy/RendererDummy.h \
+	dummy/MaterialDummy.h \
+	dummy/TextureDummy.h \
+	dummy/RenderStateDummy.h \
+	dummy/RenderTargetDummy.h \
+	dummy/VertexBufferDummy.h
 
 libgraphics_a_SOURCES = \
 	Graphics.cpp \

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -49,6 +49,8 @@ public:
 
 	virtual const char* GetName() const = 0;
 
+	virtual void WriteRendererInfo(std::ostream &out) const {}
+
 	WindowSDL *GetWindow() const { return m_window.get(); }
 	float GetDisplayAspect() const { return static_cast<float>(m_width) / static_cast<float>(m_height); }
 

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -83,6 +83,9 @@ public:
 
 	virtual bool SetRenderState(RenderState*) = 0;
 
+	// XXX maybe GL-specific. maybe should be part of the render state
+	virtual bool SetDepthRange(double near, double far) = 0;
+
 	virtual bool SetWireFrameMode(bool enabled) = 0;
 
 	virtual bool SetLights(Uint32 numlights, const Light *l) = 0;

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -13,8 +13,6 @@
 
 namespace Graphics {
 
-extern void CheckRenderErrors();
-
 /*
  * Renderer base class. A Renderer draws points, lines, triangles.
  * It is also used to create render states, materials and vertex/index buffers.
@@ -50,6 +48,8 @@ public:
 	virtual const char* GetName() const = 0;
 
 	virtual void WriteRendererInfo(std::ostream &out) const {}
+
+	virtual void CheckRenderErrors() const {}
 
 	WindowSDL *GetWindow() const { return m_window.get(); }
 	float GetDisplayAspect() const { return static_cast<float>(m_width) / static_cast<float>(m_height); }

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -167,6 +167,8 @@ public:
 		MatrixMode m_matrixMode;
 	};
 
+	virtual bool Screendump(ScreendumpState &sd) { return false; }
+
 protected:
 	int m_width;
 	int m_height;

--- a/src/graphics/VertexBuffer.h
+++ b/src/graphics/VertexBuffer.h
@@ -68,6 +68,7 @@ protected:
 
 class VertexBuffer : public RefCounted, public Mappable {
 public:
+	VertexBuffer(const VertexBufferDesc &desc) : m_desc(desc) {}
 	virtual ~VertexBuffer();
 	const VertexBufferDesc &GetDesc() const { return m_desc; }
 

--- a/src/graphics/dummy/Makefile.am
+++ b/src/graphics/dummy/Makefile.am
@@ -15,4 +15,5 @@ noinst_HEADERS = \
 	RenderTargetDummy.h \
 	VertexBufferDummy.h
 
-libgraphicsdummy_a_SOURCES =
+libgraphicsdummy_a_SOURCES = \
+	RendererDummy.cpp

--- a/src/graphics/dummy/Makefile.am
+++ b/src/graphics/dummy/Makefile.am
@@ -1,0 +1,18 @@
+include $(top_srcdir)/Makefile.common
+
+AM_CFLAGS += $(WARN_CFLAGS)
+AM_CPPFLAGS += $(WARN_CPPFLAGS)
+AM_CXXFLAGS += $(STD_CXXFLAGS) $(WARN_CXXFLAGS)
+
+AM_CPPFLAGS += -I$(srcdir)/../.. -isystem $(top_srcdir)/contrib
+
+noinst_LIBRARIES = libgraphicsdummy.a
+noinst_HEADERS = \
+	RendererDummy.h \
+	MaterialDummy.h \
+	TextureDummy.h \
+	RenderStateDummy.h \
+	RenderTargetDummy.h \
+	VertexBufferDummy.h
+
+libgraphicsdummy_a_SOURCES =

--- a/src/graphics/dummy/MaterialDummy.h
+++ b/src/graphics/dummy/MaterialDummy.h
@@ -1,0 +1,31 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef _DUMMY_MATERIAL_H
+#define _DUMMY_MATERIAL_H
+
+#include "graphics/Material.h"
+
+namespace Graphics {
+
+	class RendererDummy;
+
+	namespace Dummy {
+
+		class Program;
+
+		class Material : public Graphics::Material {
+		public:
+			Material() { }
+			// Create an appropriate program for this material.
+			virtual Program *CreateProgram(const MaterialDescriptor &) { return nullptr; }
+			// bind textures, set uniforms
+			virtual void Apply() {}
+			virtual void Unapply() {}
+			virtual void SetProgram(Program *p) { }
+			virtual void SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj) {}
+		};
+	}
+}
+
+#endif

--- a/src/graphics/dummy/RenderStateDummy.h
+++ b/src/graphics/dummy/RenderStateDummy.h
@@ -1,0 +1,20 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef _DUMMY_RENDERSTATE_H
+#define _DUMMY_RENDERSTATE_H
+
+#include "graphics/RenderState.h"
+
+namespace Graphics {
+namespace Dummy {
+
+class RenderState : public Graphics::RenderState {
+public:
+	RenderState(const RenderStateDesc &d) : Graphics::RenderState(d) {}
+	void Apply() {}
+};
+
+}
+}
+#endif

--- a/src/graphics/dummy/RenderTargetDummy.h
+++ b/src/graphics/dummy/RenderTargetDummy.h
@@ -1,0 +1,35 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef _DUMMY_RENDERTARGET_H
+#define _DUMMY_RENDERTARGET_H
+
+#include "graphics/RenderTarget.h"
+
+namespace Graphics {
+
+class RendererDummy;
+
+namespace Dummy {
+
+class RenderTarget : public Graphics::RenderTarget {
+public:
+	virtual Texture *GetColorTexture() const { return m_colorTexture.Get(); }
+	virtual Texture *GetDepthTexture() const { return m_depthTexture.Get(); }
+	virtual void SetColorTexture(Texture* t) { m_colorTexture.Reset(t); }
+	virtual void SetDepthTexture(Texture* t) { m_depthTexture.Reset(t); }
+
+protected:
+	friend class Graphics::RendererDummy;
+	RenderTarget(const RenderTargetDesc &d) : Graphics::RenderTarget(d) {}
+
+private:
+	RefCountedPtr<Texture> m_colorTexture;
+	RefCountedPtr<Texture> m_depthTexture;
+};
+
+}
+
+}
+
+#endif

--- a/src/graphics/dummy/RendererDummy.cpp
+++ b/src/graphics/dummy/RendererDummy.cpp
@@ -1,0 +1,16 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "RendererDummy.h"
+
+namespace Graphics {
+
+static Renderer *CreateRenderer(WindowSDL *win, const Settings &vs) {
+    return new RendererDummy();
+}
+
+void RendererDummy::RegisterRenderer() {
+    Graphics::RegisterRenderer(Graphics::RENDERER_DUMMY, CreateRenderer);
+}
+
+}

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -1,0 +1,91 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#ifndef _RENDERER_DUMMY_H
+#define _RENDERER_DUMMY_H
+
+#include "graphics/Renderer.h"
+#include "graphics/dummy/MaterialDummy.h"
+#include "graphics/dummy/TextureDummy.h"
+#include "graphics/dummy/RenderStateDummy.h"
+#include "graphics/dummy/RenderTargetDummy.h"
+#include "graphics/dummy/VertexBufferDummy.h"
+
+namespace Graphics {
+
+class RendererDummy : public Renderer
+{
+public:
+	RendererDummy() : Renderer(0, 0, 0),
+	m_identity(matrix4x4f::Identity())
+	{}
+
+	virtual const char *GetName() const { return "Dummy"; }
+	virtual bool GetNearFarRange(float &near_, float &far_) const { return true; }
+
+	virtual bool BeginFrame() { return true; }
+	virtual bool EndFrame() { return true; }
+	virtual bool SwapBuffers() { return true; }
+
+	virtual bool SetRenderState(RenderState*) override { return true; }
+	virtual bool SetRenderTarget(RenderTarget*) override { return true; }
+
+	virtual bool ClearScreen() { return true; }
+	virtual bool ClearDepthBuffer() { return true; }
+	virtual bool SetClearColor(const Color &c) { return true; }
+
+	virtual bool SetViewport(int x, int y, int width, int height) { return true; }
+
+	virtual bool SetTransform(const matrix4x4d &m) { return true; }
+	virtual bool SetTransform(const matrix4x4f &m) { return true; }
+	virtual bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) { return true; }
+	virtual bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) { return true; }
+	virtual bool SetProjection(const matrix4x4f &m) { return true; }
+
+	virtual bool SetWireFrameMode(bool enabled) { return true; }
+
+	virtual bool SetLights(Uint32 numlights, const Light *l) { return true; }
+	virtual Uint32 GetNumLights() const { return 1; }
+	virtual bool SetAmbientColor(const Color &c) { return true; }
+
+	virtual bool SetScissor(bool enabled, const vector2f &pos = vector2f(0.0f), const vector2f &size = vector2f(0.0f)) { return true; }
+
+	virtual bool DrawTriangles(const VertexArray *vertices, RenderState *state, Material *material, PrimitiveType type=TRIANGLES) override { return true; }
+	virtual bool DrawPointSprites(int count, const vector3f *positions, RenderState *rs, Material *material, float size) override { return true; }
+	virtual bool DrawBuffer(VertexBuffer*, RenderState*, Material*, PrimitiveType) override { return true; }
+	virtual bool DrawBufferIndexed(VertexBuffer*, IndexBuffer*, RenderState*, Material*, PrimitiveType) override { return true; }
+
+	virtual Material *CreateMaterial(const MaterialDescriptor &d) override { return new Graphics::Dummy::Material(); }
+	virtual Texture *CreateTexture(const TextureDescriptor &d) override { return new Graphics::TextureDummy(d); }
+	virtual RenderState *CreateRenderState(const RenderStateDesc &d) override { return new Graphics::Dummy::RenderState(d); }
+	virtual RenderTarget *CreateRenderTarget(const RenderTargetDesc &d) override { return new Graphics::Dummy::RenderTarget(d); }
+	virtual VertexBuffer *CreateVertexBuffer(const VertexBufferDesc &d) override { return new Graphics::Dummy::VertexBuffer(d); }
+	virtual IndexBuffer *CreateIndexBuffer(Uint32 size, BufferUsage bu) override { return new Graphics::Dummy::IndexBuffer(size, bu); }
+
+	virtual bool ReloadShaders() { return true; }
+
+	virtual const matrix4x4f& GetCurrentModelView() const { return m_identity; }
+	virtual const matrix4x4f& GetCurrentProjection() const { return m_identity; }
+	virtual void GetCurrentViewport(Sint32 *vp) const { }
+
+	virtual void SetMatrixMode(MatrixMode mm) {}
+	virtual void PushMatrix() {}
+	virtual void PopMatrix() {}
+	virtual void LoadIdentity() {}
+	virtual void LoadMatrix(const matrix4x4f &m) {}
+	virtual void Translate( const float x, const float y, const float z ) {}
+	virtual void Scale( const float x, const float y, const float z ) {}
+
+protected:
+	virtual void PushState() {}
+	virtual void PopState() {}
+
+private:
+	const matrix4x4f m_identity;
+};
+
+}
+
+#endif

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -32,6 +32,8 @@ public:
 	virtual bool SetRenderState(RenderState*) override { return true; }
 	virtual bool SetRenderTarget(RenderTarget*) override { return true; }
 
+	virtual bool SetDepthRange(double near, double far) override { return true; }
+
 	virtual bool ClearScreen() { return true; }
 	virtual bool ClearDepthBuffer() { return true; }
 	virtual bool SetClearColor(const Color &c) { return true; }

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -18,6 +18,8 @@ namespace Graphics {
 class RendererDummy : public Renderer
 {
 public:
+	static void RegisterRenderer();
+
 	RendererDummy() : Renderer(0, 0, 0),
 	m_identity(matrix4x4f::Identity())
 	{}

--- a/src/graphics/dummy/TextureDummy.h
+++ b/src/graphics/dummy/TextureDummy.h
@@ -1,0 +1,29 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef _TEXTUREDUMMY_H
+#define _TEXTUREDUMMY_H
+
+#include "graphics/Texture.h"
+
+namespace Graphics {
+
+class TextureDummy : public Texture {
+public:
+	virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) {}
+	virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) {}
+
+	void Bind() {}
+	void Unbind() {}
+
+	virtual void SetSampleMode(TextureSampleMode) {}
+	GLuint GetTexture() const { return 0; }
+
+private:
+	friend class RendererDummy;
+	TextureDummy(const TextureDescriptor &descriptor) : Texture(descriptor) {}
+};
+
+}
+
+#endif

--- a/src/graphics/dummy/VertexBufferDummy.h
+++ b/src/graphics/dummy/VertexBufferDummy.h
@@ -1,0 +1,50 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef DUMMY_VERTEXBUFFER_H
+#define DUMMY_VERTEXBUFFER_H
+
+#include "graphics/VertexBuffer.h"
+
+namespace Graphics {
+
+namespace Dummy {
+
+class VertexBuffer : public Graphics::VertexBuffer {
+public:
+	VertexBuffer(const VertexBufferDesc &d) : Graphics::VertexBuffer(d),
+	m_buffer(new Uint8[m_desc.numVertices * m_desc.stride])
+	{}
+
+	// copies the contents of the VertexArray into the buffer
+	virtual bool Populate(const VertexArray &) override { return true; }
+
+	virtual void Bind() {}
+	virtual void Release() {}
+
+	virtual void Unmap() override {}
+
+protected:
+	virtual Uint8 *MapInternal(BufferMapMode) { return m_buffer.get(); }
+
+private:
+	std::unique_ptr<Uint8[]> m_buffer;
+};
+
+class IndexBuffer : public Graphics::IndexBuffer {
+public:
+	IndexBuffer(Uint32 size, BufferUsage bu) : Graphics::IndexBuffer(size, bu),
+	m_buffer(new Uint16[size])
+	{};
+
+	virtual Uint16 *Map(BufferMapMode) override { return m_buffer.get(); }
+
+	virtual void Unmap() override {}
+
+private:
+    std::unique_ptr<Uint16[]> m_buffer;
+};
+
+} }
+
+#endif

--- a/src/graphics/opengl/Makefile.am
+++ b/src/graphics/opengl/Makefile.am
@@ -1,0 +1,49 @@
+include $(top_srcdir)/Makefile.common
+
+AM_CFLAGS += $(WARN_CFLAGS)
+AM_CPPFLAGS += $(WARN_CPPFLAGS)
+AM_CXXFLAGS += $(STD_CXXFLAGS) $(WARN_CXXFLAGS)
+
+AM_CPPFLAGS += -I$(srcdir)/../.. -isystem $(top_srcdir)/contrib
+
+noinst_LIBRARIES = libgraphicsopengl.a
+noinst_HEADERS = \
+	gl_core_3_x.h \
+	GLDebug.h \
+	MaterialGL.h \
+	RenderStateGL.h \
+	RenderTargetGL.h \
+	VertexBufferGL.h \
+	FresnelColourMaterial.h \
+	GasGiantMaterial.h \
+	GeoSphereMaterial.h \
+	MultiMaterial.h \
+	Program.h \
+	RendererGL.h \
+	RingMaterial.h \
+	ShieldMaterial.h \
+	StarfieldMaterial.h \
+	SkyboxMaterial.h \
+	TextureGL.h \
+	UIMaterial.h \
+	Uniform.h \
+	VtxColorMaterial.h
+
+libgraphicsopengl_a_SOURCES = \
+	gl_core_3_x.c \
+	MaterialGL.cpp \
+	RenderStateGL.cpp \
+	RenderTargetGL.cpp \
+	VertexBufferGL.cpp \
+	FresnelColourMaterial.cpp \
+	GasGiantMaterial.cpp \
+	GeoSphereMaterial.cpp \
+	MultiMaterial.cpp \
+	Program.cpp \
+	ShieldMaterial.cpp \
+	RendererGL.cpp \
+	RingMaterial.cpp \
+	TextureGL.cpp \
+	UIMaterial.cpp \
+	Uniform.cpp \
+	VtxColorMaterial.cpp

--- a/src/graphics/opengl/MaterialGL.cpp
+++ b/src/graphics/opengl/MaterialGL.cpp
@@ -30,7 +30,7 @@ void Material::SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj)
 	m_program->uViewMatrixInverse.Set( mv.Inverse() );
 	m_program->uViewProjectionMatrix.Set( ViewProjection );
 	m_program->uNormalMatrix.Set( NormalMatrix );
-	CheckRenderErrors();
+	RendererOGL::CheckErrors();
 }
 
 }

--- a/src/graphics/opengl/MultiMaterial.cpp
+++ b/src/graphics/opengl/MultiMaterial.cpp
@@ -128,7 +128,7 @@ void LitMultiMaterial::Apply()
 		const vector3f pos = Light.GetPosition();
 		p->lights[i].position.Set( pos.x, pos.y, pos.z, (Light.GetType() == Light::LIGHT_DIRECTIONAL ? 0.f : 1.f));
 	}
-	CheckRenderErrors();
+	RendererOGL::CheckErrors();
 }
 
 void MultiMaterial::Unapply()

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -336,6 +336,12 @@ bool RendererOGL::SetRenderTarget(RenderTarget *rt)
 	return true;
 }
 
+bool RendererOGL::SetDepthRange(double near, double far)
+{
+	glDepthRange(near, far);
+	return true;
+}
+
 bool RendererOGL::ClearScreen()
 {
 	m_activeRenderState = nullptr;

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -35,6 +35,15 @@
 
 namespace Graphics {
 
+static Renderer *CreateRenderer(WindowSDL *win, const Settings &vs) {
+    return new RendererOGL(win, vs);
+}
+
+void RendererOGL::RegisterRenderer() {
+    Graphics::RegisterRenderer(Graphics::RENDERER_OPENGL, CreateRenderer);
+}
+
+
 bool RendererOGL::initted = false;
 
 typedef std::vector<std::pair<MaterialDescriptor, OGL::Program*> >::const_iterator ProgramIterator;

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -264,8 +264,7 @@ static std::string glerr_to_string(GLenum err)
 	}
 }
 
-//extern 
-void CheckRenderErrors()
+void RendererOGL::CheckErrors()
 {
 	GLenum err = glGetError();
 	if( err ) {

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -987,4 +987,24 @@ void RendererOGL::Scale( const float x, const float y, const float z )
 	}
 }
 
+bool RendererOGL::Screendump(ScreendumpState &sd)
+{
+	sd.width = GetWindow()->GetWidth();
+	sd.height = GetWindow()->GetHeight();
+	sd.bpp = 3; // XXX get from window
+
+	// pad rows to 4 bytes, which is the default row alignment for OpenGL
+	sd.stride = (3*sd.width + 3) & ~3;
+
+	sd.pixels.reset(new Uint8[sd.stride * sd.height]);
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glPixelStorei(GL_PACK_ALIGNMENT, 4); // never trust defaults
+	glReadBuffer(GL_FRONT);
+	glReadPixels(0, 0, sd.width, sd.height, GL_RGB, GL_UNSIGNED_BYTE, sd.pixels.get());
+	glFinish();
+
+	return true;
+}
+
 }

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -35,6 +35,8 @@
 
 namespace Graphics {
 
+bool RendererOGL::initted = false;
+
 typedef std::vector<std::pair<MaterialDescriptor, OGL::Program*> >::const_iterator ProgramIterator;
 
 RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
@@ -51,6 +53,19 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 , m_activeRenderState(nullptr)
 , m_matrixMode(MatrixMode::MODELVIEW)
 {
+	if (!initted) {
+		initted = true;
+
+		if (!ogl_LoadFunctions())
+			Error("glLoadGen failed to load functions.\n");
+
+		if (ogl_ext_EXT_texture_compression_s3tc == ogl_LOAD_FAILED)
+			Error(
+				"OpenGL extension GL_EXT_texture_compression_s3tc not supported.\n"
+				"Pioneer can not run on your graphics card as it does not support compressed (DXTn/S3TC) format textures."
+			);
+	}
+
 	m_viewportStack.push(Viewport());
 
 	const bool useDXTnTextures = vs.useTextureCompression;
@@ -83,6 +98,133 @@ RendererOGL::~RendererOGL()
 	//while (!m_programs.empty()) delete m_programs.back().second, m_programs.pop_back();
 	for (auto state : m_renderStates)
 		delete state.second;
+}
+
+static const char *gl_error_to_string(GLenum err)
+{
+	switch (err) {
+		case GL_NO_ERROR: return "(no error)";
+		case GL_INVALID_ENUM: return "invalid enum";
+		case GL_INVALID_VALUE: return "invalid value";
+		case GL_INVALID_OPERATION: return "invalid operation";
+		case GL_INVALID_FRAMEBUFFER_OPERATION: return "invalid framebuffer operation";
+		case GL_OUT_OF_MEMORY: return "out of memory";
+		default: return "(unknown error)";
+	}
+}
+
+static void dump_and_clear_opengl_errors(std::ostream &out, GLenum first_error = GL_NO_ERROR)
+{
+	GLenum err = ((first_error == GL_NO_ERROR) ? glGetError() : first_error);
+	if (err != GL_NO_ERROR) {
+		out << "errors: ";
+		do {
+			out << gl_error_to_string(err) << " ";
+			err = glGetError();
+		} while (err != GL_NO_ERROR);
+		out << std::endl;
+	}
+}
+
+static void dump_opengl_value(std::ostream &out, const char *name, GLenum id, int num_elems)
+{
+	assert(num_elems > 0 && num_elems <= 4);
+	assert(name);
+
+	GLdouble e[4];
+	glGetDoublev(id, e);
+
+	GLenum err = glGetError();
+	if (err == GL_NO_ERROR) {
+		out << name << " = " << e[0];
+		for (int i = 1; i < num_elems; ++i)
+			out << ", " << e[i];
+		out << "\n";
+	} else {
+		while (err != GL_NO_ERROR) {
+			if (err == GL_INVALID_ENUM) { out << name << " -- not supported\n"; }
+			else { out << name << " -- unexpected error (" << err << ") retrieving value\n"; }
+			err = glGetError();
+		}
+	}
+}
+
+void RendererOGL::WriteRendererInfo(std::ostream &out) const
+{
+	out << "OpenGL version " << glGetString(GL_VERSION);
+	out << ", running on " << glGetString(GL_VENDOR);
+	out << " " << glGetString(GL_RENDERER) << "\n";
+
+	out << "Available extensions:" << "\n";
+	{
+		out << "Shading language version: " <<  glGetString(GL_SHADING_LANGUAGE_VERSION) << "\n";
+		GLint numext = 0;
+		glGetIntegerv(GL_NUM_EXTENSIONS, &numext);
+		for (int i = 0; i < numext; ++i) {
+			out << "  " << glGetStringi(GL_EXTENSIONS, i) << "\n";
+		}
+	}
+
+	out << "\nImplementation Limits:\n";
+
+	// first, clear all OpenGL error flags
+	dump_and_clear_opengl_errors(out);
+
+#define DUMP_GL_VALUE(name) dump_opengl_value(out, #name, name, 1)
+#define DUMP_GL_VALUE2(name) dump_opengl_value(out, #name, name, 2)
+
+	DUMP_GL_VALUE(GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS);
+	DUMP_GL_VALUE(GL_MAX_CUBE_MAP_TEXTURE_SIZE);
+	DUMP_GL_VALUE(GL_MAX_DRAW_BUFFERS);
+	DUMP_GL_VALUE(GL_MAX_ELEMENTS_INDICES);
+	DUMP_GL_VALUE(GL_MAX_ELEMENTS_VERTICES);
+	DUMP_GL_VALUE(GL_MAX_FRAGMENT_UNIFORM_COMPONENTS);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_IMAGE_UNITS);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_LOD_BIAS);
+	DUMP_GL_VALUE(GL_MAX_TEXTURE_SIZE);
+	DUMP_GL_VALUE(GL_MAX_VERTEX_ATTRIBS);
+	DUMP_GL_VALUE(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS);
+	DUMP_GL_VALUE(GL_MAX_VERTEX_UNIFORM_COMPONENTS);
+	DUMP_GL_VALUE(GL_NUM_COMPRESSED_TEXTURE_FORMATS);
+	DUMP_GL_VALUE(GL_SAMPLE_BUFFERS);
+	DUMP_GL_VALUE(GL_SAMPLES);
+	DUMP_GL_VALUE2(GL_ALIASED_LINE_WIDTH_RANGE);
+	DUMP_GL_VALUE2(GL_MAX_VIEWPORT_DIMS);
+	DUMP_GL_VALUE2(GL_SMOOTH_LINE_WIDTH_RANGE);
+	DUMP_GL_VALUE2(GL_SMOOTH_POINT_SIZE_RANGE);
+
+#undef DUMP_GL_VALUE
+#undef DUMP_GL_VALUE2
+
+	// enumerate compressed texture formats
+	{
+		dump_and_clear_opengl_errors(out);
+		out << "\nCompressed texture formats:\n";
+
+		GLint nformats;
+		GLint formats[128]; // XXX 128 should be enough, right?
+
+		glGetIntegerv(GL_NUM_COMPRESSED_TEXTURE_FORMATS, &nformats);
+		GLenum err = glGetError();
+		if (err != GL_NO_ERROR) {
+			out << "Get NUM_COMPRESSED_TEXTURE_FORMATS failed\n";
+			dump_and_clear_opengl_errors(out, err);
+		} else {
+			assert(nformats >= 0 && nformats < int(COUNTOF(formats)));
+			glGetIntegerv(GL_COMPRESSED_TEXTURE_FORMATS, formats);
+			err = glGetError();
+			if (err != GL_NO_ERROR) {
+				out << "Get COMPRESSED_TEXTURE_FORMATS failed\n";
+				dump_and_clear_opengl_errors(out, err);
+			} else {
+				for (int i = 0; i < nformats; ++i) {
+					out << stringf("  %0{x#}\n", unsigned(formats[i]));
+				}
+			}
+		}
+	}
+	// one last time
+	dump_and_clear_opengl_errors(out);
 }
 
 bool RendererOGL::GetNearFarRange(float &near_, float &far_) const

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -45,6 +45,9 @@ public:
 	virtual ~RendererOGL();
 
 	virtual const char* GetName() const { return "OpenGL 3.1, with extensions, renderer"; }
+
+	virtual void WriteRendererInfo(std::ostream &out) const;
+
 	virtual bool GetNearFarRange(float &near_, float &far_) const;
 
 	virtual bool BeginFrame();
@@ -151,6 +154,9 @@ protected:
 		Sint32 x, y, w, h;
 	};
 	std::stack<Viewport> m_viewportStack;
+
+private:
+	static bool initted;
 };
 
 }

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -41,6 +41,8 @@ namespace OGL {
 class RendererOGL : public Renderer
 {
 public:
+	static void RegisterRenderer();
+
 	RendererOGL(WindowSDL *window, const Graphics::Settings &vs);
 	virtual ~RendererOGL();
 

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -106,6 +106,8 @@ public:
 	virtual void Translate( const float x, const float y, const float z );
 	virtual void Scale( const float x, const float y, const float z );
 
+	virtual bool Screendump(ScreendumpState &sd);
+
 protected:
 	virtual void PushState();
 	virtual void PopState();

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -60,6 +60,8 @@ public:
 	virtual bool SetRenderState(RenderState*) override;
 	virtual bool SetRenderTarget(RenderTarget*) override;
 
+	virtual bool SetDepthRange(double near, double far) override;
+
 	virtual bool ClearScreen();
 	virtual bool ClearDepthBuffer();
 	virtual bool SetClearColor(const Color &c);

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -48,6 +48,9 @@ public:
 
 	virtual void WriteRendererInfo(std::ostream &out) const;
 
+	virtual void CheckRenderErrors() const { CheckErrors(); }
+	static void CheckErrors();
+
 	virtual bool GetNearFarRange(float &near_, float &far_) const;
 
 	virtual bool BeginFrame();

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "graphics/Renderer.h"
+#include "RendererGL.h"
 #include "TextureGL.h"
 #include <cassert>
 #include "utils.h"
@@ -81,7 +82,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 
 	glGenTextures(1, &m_texture);
 	glBindTexture(m_target, m_texture);
-	CheckRenderErrors();
+	RendererOGL::CheckErrors();
 
 
 	// useCompressed is the global scope flag whereas descriptor.allowCompression is the local texture mode flag
@@ -93,17 +94,17 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 			if (!IsCompressed(descriptor.format)) {
 				if (!descriptor.generateMipmaps)
 					glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, 0);
-				CheckRenderErrors();
+				RendererOGL::CheckErrors();
 
 				glTexImage2D(
 					m_target, 0, compressTexture ? GLCompressedInternalFormat(descriptor.format) : GLInternalFormat(descriptor.format),
 					descriptor.dataSize.x, descriptor.dataSize.y, 0,
 					GLImageFormat(descriptor.format),
 					GLImageType(descriptor.format), 0);
-				CheckRenderErrors();
+				RendererOGL::CheckErrors();
 				if (descriptor.generateMipmaps)
 					glGenerateMipmap(m_target);
-				CheckRenderErrors();
+				RendererOGL::CheckErrors();
 			} else {
 				const GLint oglFormatMinSize = GetMinSize(descriptor.format);
 				size_t Width = descriptor.dataSize.x;
@@ -122,7 +123,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 					Height /= 2;
 				}
 				glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, maxMip);
-				CheckRenderErrors();
+				RendererOGL::CheckErrors();
 			}
 			break;
 
@@ -130,7 +131,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 			if(!IsCompressed(descriptor.format)) {
 				if(descriptor.generateMipmaps)
 					glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, 0);
-				CheckRenderErrors();
+				RendererOGL::CheckErrors();
 
 				glTexImage2D(
 					GL_TEXTURE_CUBE_MAP_POSITIVE_X, 0, compressTexture ? GLCompressedInternalFormat(descriptor.format) : GLInternalFormat(descriptor.format),
@@ -162,10 +163,10 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 					descriptor.dataSize.x, descriptor.dataSize.y, 0,
 					GLImageFormat(descriptor.format),
 					GLImageType(descriptor.format), 0);
-				CheckRenderErrors();
+				RendererOGL::CheckErrors();
 				if (descriptor.generateMipmaps)
 					glGenerateMipmap(m_target);
-				CheckRenderErrors();
+				RendererOGL::CheckErrors();
 			} else {
 				const GLint oglFormatMinSize = GetMinSize(descriptor.format);
 				size_t Width = descriptor.dataSize.x;
@@ -189,14 +190,14 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 					Height /= 2;
 				}
 				glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, maxMip);
-				CheckRenderErrors();
+				RendererOGL::CheckErrors();
 			}
 			break;
 
 		default:
 			assert(0);
 	}
-	CheckRenderErrors();
+	RendererOGL::CheckErrors();
 
 	GLenum magFilter, minFilter, wrapS, wrapT;
 	switch (descriptor.sampleMode) {
@@ -231,7 +232,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 	glTexParameteri(m_target, GL_TEXTURE_WRAP_T, wrapS);
 	glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, magFilter);
 	glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, minFilter);
-	CheckRenderErrors();
+	RendererOGL::CheckErrors();
 
 }
 

--- a/src/graphics/opengl/UIMaterial.cpp
+++ b/src/graphics/opengl/UIMaterial.cpp
@@ -15,7 +15,7 @@ namespace OGL {
 UIProgram::UIProgram(const MaterialDescriptor &desc)
 {
 	m_name = "ui";
-	CheckRenderErrors();
+	RendererOGL::CheckErrors();
 
 	LoadShaders(m_name, m_defines);
 	InitUniforms();

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -36,9 +36,9 @@ GLenum get_component_type(VertexAttribFormat fmt)
 	}
 }
 
-VertexBuffer::VertexBuffer(const VertexBufferDesc &desc)
+VertexBuffer::VertexBuffer(const VertexBufferDesc &desc) :
+	Graphics::VertexBuffer(desc)
 {
-	m_desc = desc;
 	//update offsets in desc
 	for (Uint32 i = 0; i < MAX_ATTRIBS; i++) {
 		if (m_desc.attrib[i].offset == 0)

--- a/src/graphics/opengl/VtxColorMaterial.cpp
+++ b/src/graphics/opengl/VtxColorMaterial.cpp
@@ -15,7 +15,7 @@ namespace OGL {
 VtxColorProgram::VtxColorProgram(const MaterialDescriptor &desc)
 {
 	m_name = "vtxColor";
-	CheckRenderErrors();
+	RendererOGL::CheckErrors();
 
 	LoadShaders(m_name, m_defines);
 	InitUniforms();

--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -45,6 +45,7 @@ void SetupRenderer()
 
 	//video
 	Graphics::Settings videoSettings = {};
+	videoSettings.rendererType = Graphics::RENDERER_DUMMY;
 	videoSettings.width = s_config->Int("ScrWidth");
 	videoSettings.height = s_config->Int("ScrHeight");
 	videoSettings.fullscreen = false;

--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -10,6 +10,7 @@
 
 #include "FileSystem.h"
 #include "GameConfig.h"
+#include "graphics/dummy/RendererDummy.h"
 #include "graphics/Graphics.h"
 #include "graphics/Light.h"
 #include "graphics/Renderer.h"
@@ -42,6 +43,8 @@ void SetupRenderer()
 		Error("SDL initialization failed: %s\n", SDL_GetError());
 
 	ModManager::Init();
+
+	Graphics::RendererDummy::RegisterRenderer();
 
 	//video
 	Graphics::Settings videoSettings = {};

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -480,7 +480,7 @@ TextureFont::TextureFont(const FontConfig &config, Graphics::Renderer *renderer,
 	, m_atlasV(0)
 	, m_atlasVIncrement(0)
 {
-	Graphics::CheckRenderErrors();
+	renderer->CheckRenderErrors();
 
 	FT_Error err; // used to store freetype error return codes
 
@@ -500,12 +500,12 @@ TextureFont::TextureFont(const FontConfig &config, Graphics::Renderer *renderer,
 		FT_Stroker_Set(m_stroker, 1*64, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0);
 	}
 
-	Graphics::CheckRenderErrors();
+	renderer->CheckRenderErrors();
 
 	m_texFormat = m_config.IsOutline() ? Graphics::TEXTURE_LUMINANCE_ALPHA_88 : Graphics::TEXTURE_INTENSITY_8;
 	m_bpp = m_config.IsOutline() ? 2 : 1;
 
-	Graphics::CheckRenderErrors();
+	renderer->CheckRenderErrors();
 
 	Graphics::RenderStateDesc rsd;
 	rsd.blendMode = Graphics::BLEND_ALPHA_PREMULT;

--- a/src/textstress.cpp
+++ b/src/textstress.cpp
@@ -23,6 +23,7 @@ int main(int argc, char **argv)
 	}
 
 	Graphics::Settings videoSettings;
+	videoSettings.rendererType = Graphics::RENDERER_OPENGL;
 	videoSettings.width = WIDTH;
 	videoSettings.height = HEIGHT;
 	videoSettings.fullscreen = false;

--- a/src/uitest.cpp
+++ b/src/uitest.cpp
@@ -120,6 +120,7 @@ int main(int argc, char **argv)
 	}
 
 	Graphics::Settings videoSettings;
+	videoSettings.rendererType = Graphics::RENDERER_OPENGL;
 	videoSettings.width = WIDTH;
 	videoSettings.height = HEIGHT;
 	videoSettings.fullscreen = false;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -168,23 +168,13 @@ std::string format_distance(double dist, int precision)
 	return ss.str();
 }
 
-void Screendump(const char* destFile, const int width, const int height)
+void write_screenshot(const Graphics::ScreendumpState &sd, const char* destFile)
 {
 	const std::string dir = "screenshots";
 	FileSystem::userFiles.MakeDirectory(dir);
 	const std::string fname = FileSystem::JoinPathBelow(dir, destFile);
 
-	// pad rows to 4 bytes, which is the default row alignment for OpenGL
-	const int stride = (3*width + 3) & ~3;
-
-	std::vector<Uint8> pixel_data(stride * height);
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glPixelStorei(GL_PACK_ALIGNMENT, 4); // never trust defaults
-	glReadBuffer(GL_FRONT);
-	glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, &pixel_data[0]);
-	glFinish();
-
-	write_png(FileSystem::userFiles, fname, &pixel_data[0], width, height, stride, 3);
+	write_png(FileSystem::userFiles, fname, sd.pixels.get(), sd.width, sd.height, sd.stride, sd.bpp);
 
 	Output("Screenshot %s saved\n", fname.c_str());
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -72,7 +72,11 @@ static inline Sint64 isqrt(Sint64 a)
 	return ret;
 }
 
-void Screendump(const char* destFile, const int w, const int h);
+namespace Graphics {
+    struct ScreendumpState;
+}
+
+void write_screenshot(const Graphics::ScreendumpState &sd, const char* destFile);
 
 // find string in bigger string, ignoring case
 const char *pi_strcasestr(const char *haystack, const char *needle);


### PR DESCRIPTION
Adds a dummy renderer, which does nothing but returns true for pretty much every call. The motivation for this is to allow things that require a renderer (eg modelcompiler) to run in environments where OpenGL is not available.

This also moves remaining GL calls from core & graphics into the GL renderer itself. This is various error checks, screendump and glDepthRange. I do not claim that these are good-quality APIs and I'm happy for them to be changed or removed in the future. Right now they're just decoupling.

There's also a basic registration system that allows the program entry points (Pi, ModelViewer and modelcompiler) to prepare the renderers they want to make available. Its whole purpose it to make it so that graphics doesn't link directly to the individual renderer constructors. Sort of a static-build plugin system, egads.

Right now modelcompiler still has to link the GL renderer to satisfy indirect dependencies (scenegraph -> Color -> LuaRef -> Pi (for Pi::serializer) -> RendererOGL. That's a fairly simple chain to break, but its not really part of this PR and I'm almost certain I won't need it on the build machine anyway. I have OpenGL there, so link succeeds, I just can't run OpenGL, which I now won't have to.