### PR TITLE
Fix scanner drawing post-load.

### DIFF
--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -78,6 +78,8 @@ void ScannerWidget::InitObject()
 	rsd.depthTest = false;
 	rsd.cullMode = CULL_NONE;
 	m_renderState = m_renderer->CreateRenderState(rsd);
+
+	GenerateRingsAndSpokes();
 }
 
 ScannerWidget::~ScannerWidget()
@@ -451,7 +453,7 @@ void ScannerWidget::GenerateRingsAndSpokes()
 	// bright part
 	Color col = (m_mode == SCANNER_MODE_AUTO) ? Color(0, 178, 0, 128) : Color(178, 178, 0, 128);
 	for (int i=0; i<=dimstart; i++) {
-		if (i == csize) return;			// whole circle bright case
+		if (i == csize) break;			// whole circle bright case
 		m_edgeVts.push_back(vector3f(m_circle[i].x, m_circle[i].y, 0.0f));
 		m_edgeCols.push_back(col);
 	}

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -174,6 +174,9 @@ void Line3D::SetColor(const Color &c)
 void Line3D::Draw(Renderer *r, RenderState *rs)
 {
 	PROFILE_SCOPED()
+	if (m_va->GetNumVerts() == 0)
+		return;
+
 	if( !m_vertexBuffer.Valid() ) {
 		CreateVertexBuffer(r, 2);
 	}
@@ -263,6 +266,9 @@ void Lines::SetData(const Uint32 vertCount, const vector3f *vertices, const Colo
 void Lines::Draw(Renderer *r, RenderState *rs, const PrimitiveType pt)
 {
 	PROFILE_SCOPED()
+	if (m_va->GetNumVerts() == 0)
+		return;
+
 	if( !m_vertexBuffer.Valid() ) {
 		CreateVertexBuffer(r, m_va->GetNumVerts());
 	}
@@ -341,6 +347,9 @@ void PointSprites::SetData(const int count, const vector3f *positions, const mat
 void PointSprites::Draw(Renderer *r, RenderState *rs, Material *mat)
 {
 	PROFILE_SCOPED()
+	if (m_va->GetNumVerts() == 0)
+		return;
+
 	if (!m_vertexBuffer.Valid() || (m_va->GetNumVerts() != m_vertexBuffer->GetVertexCount())) {
 		CreateVertexBuffer(r, mat, m_va->GetNumVerts());
 	}
@@ -463,6 +472,9 @@ void Points::SetData(Renderer* r, const int count, const vector3f *positions, co
 void Points::Draw(Renderer *r, RenderState *rs)
 {
 	PROFILE_SCOPED()
+	if (m_va->GetNumVerts() == 0)
+		return;
+
 	if (!m_vertexBuffer.Valid() || (m_va->GetNumVerts() != m_vertexBuffer->GetVertexCount())) {
 		CreateVertexBuffer(r, m_va->GetNumVerts());
 	}


### PR DESCRIPTION
Check we've got verts before drawing and regenerate the scanner properly after loading.

I noticed this was asserting because it was trying to build buffers with zero vertices and draw them.