### PR TITLE
Many ship optimise

### DIFF
--- a/src/Body.h
+++ b/src/Body.h
@@ -119,4 +119,7 @@ private:
 	double m_physRadius;
 };
 
+
+typedef std::vector<Body*> BodyList;
+
 #endif /* _BODY_H */

--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -64,7 +64,7 @@ void Missile::TimeStepUpdate(const float timeStep)
 	if (!m_owner) {
 		Explode();
 	} else if (m_armed) {
-		Space::BodyNearList nearby;
+		BodyList nearby;
 		Pi::game->GetSpace()->GetBodiesMaybeNear(this, MISSILE_DETECTION_RADIUS, nearby);
 		for (Space::BodyNearIterator i = nearby.begin(); i != nearby.end(); ++i) {
 			if (*i == this) continue;
@@ -101,7 +101,7 @@ void Missile::Explode()
 	const double kgDamage = 10000.0;
 
 	CollisionContact dummy;
-	Space::BodyNearList nearby;
+	BodyList nearby;
 	Pi::game->GetSpace()->GetBodiesMaybeNear(this, damageRadius, nearby);
 	for (Space::BodyNearIterator i = nearby.begin(); i != nearby.end(); ++i) {
 		if ((*i)->GetFrame() != GetFrame()) continue;

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -97,7 +97,7 @@ void Sensors::Update(float time)
 
 	//Find nearby contacts, same range as scanner. Scanner should use these
 	//contacts, worldview labels too.
-	Space::BodyNearList nearby;
+	BodyList nearby;
 	Pi::game->GetSpace()->GetBodiesMaybeNear(m_owner, 100000.0f, nearby);
 	for (Space::BodyNearIterator i = nearby.begin(); i != nearby.end(); ++i) {
 		if ((*i) == m_owner || !(*i)->IsType(Object::SHIP)) continue;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -919,7 +919,7 @@ void Ship::UpdateAlertState()
 		return;
 	}
 
-	bool ship_is_near = m_shipNear, ship_is_firing = m_shipFiring;
+	bool ship_is_near = false, ship_is_firing = false;
 	if (m_lastAlertUpdate + 1.0 <= Pi::game->GetTime())
 	{
 		// time to update the list again, once per second should suffice
@@ -958,6 +958,11 @@ void Ship::UpdateAlertState()
 		// store
 		m_shipNear = ship_is_near;
 		m_shipFiring = ship_is_firing;
+	}
+	else
+	{
+		ship_is_near = m_shipNear;
+		ship_is_firing = m_shipFiring;
 	}
 
 	bool changed = false;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -915,34 +915,42 @@ void Ship::UpdateAlertState()
 		return;
 	}
 
-	static const double ALERT_DISTANCE = 100000.0; // 100km
-
-	Space::BodyNearList nearby;
-	Pi::game->GetSpace()->GetBodiesMaybeNear(this, ALERT_DISTANCE, nearby);
-
 	bool ship_is_near = false, ship_is_firing = false;
-	for (Space::BodyNearIterator i = nearby.begin(); i != nearby.end(); ++i)
+	if (m_lastFiringAlert + 1.0 <= Pi::game->GetTime()) 
 	{
-		if ((*i) == this) continue;
-		if (!(*i)->IsType(Object::SHIP) || (*i)->IsType(Object::MISSILE)) continue;
+		// time to update the list again, once per second should suffice
+		m_lastAlertUpdate = Pi::game->GetTime();
 
-		const Ship *ship = static_cast<const Ship*>(*i);
+		// refresh the list
+		m_nearbyBodies.clear();
+		static const double ALERT_DISTANCE = 100000.0; // 100km
+		Pi::game->GetSpace()->GetBodiesMaybeNear(this, ALERT_DISTANCE, m_nearbyBodies);
 
-		if (ship->GetShipType()->tag == ShipType::TAG_STATIC_SHIP) continue;
-		if (ship->GetFlightState() == LANDED || ship->GetFlightState() == DOCKED) continue;
+		// handle the results
+		for (auto i : m_nearbyBodies)
+		{
+			if ((i) == this) continue;
+			if (!(i)->IsType(Object::SHIP) || (i)->IsType(Object::MISSILE)) continue;
 
-		if (GetPositionRelTo(ship).LengthSqr() < ALERT_DISTANCE*ALERT_DISTANCE) {
-			ship_is_near = true;
+			const Ship *ship = static_cast<const Ship*>(i);
 
-			Uint32 gunstate = 0;
-			for (int j = 0; j < ShipType::GUNMOUNT_MAX; j++)
-				gunstate |= ship->m_gun[j].state;
+			if (ship->GetShipType()->tag == ShipType::TAG_STATIC_SHIP) continue;
+			if (ship->GetFlightState() == LANDED || ship->GetFlightState() == DOCKED) continue;
 
-			if (gunstate) {
-				ship_is_firing = true;
-				break;
+			if (GetPositionRelTo(ship).LengthSqr() < ALERT_DISTANCE*ALERT_DISTANCE) {
+				ship_is_near = true;
+
+				Uint32 gunstate = 0;
+				for (int j = 0; j < ShipType::GUNMOUNT_MAX; j++)
+					gunstate |= ship->m_gun[j].state;
+
+				if (gunstate) {
+					ship_is_firing = true;
+					break;
+				}
 			}
 		}
+		
 	}
 
 	bool changed = false;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -257,7 +257,11 @@ Ship::Ship(ShipType::Id shipId): DynamicBody(),
 	Properties().Set("flightState", EnumStrings::GetString("ShipFlightState", m_flightState));
 	Properties().Set("alertStatus", EnumStrings::GetString("ShipAlertStatus", m_alertState));
 
+	m_lastAlertUpdate = 0.0;
 	m_lastFiringAlert = 0.0;
+	m_shipNear = false;
+	m_shipFiring = false;
+
 	m_testLanded = false;
 	m_launchLockTimeout = 0;
 	m_wheelTransition = 0;
@@ -915,8 +919,8 @@ void Ship::UpdateAlertState()
 		return;
 	}
 
-	bool ship_is_near = false, ship_is_firing = false;
-	if (m_lastFiringAlert + 1.0 <= Pi::game->GetTime()) 
+	bool ship_is_near = m_shipNear, ship_is_firing = m_shipFiring;
+	if (m_lastAlertUpdate + 1.0 <= Pi::game->GetTime())
 	{
 		// time to update the list again, once per second should suffice
 		m_lastAlertUpdate = Pi::game->GetTime();
@@ -950,7 +954,10 @@ void Ship::UpdateAlertState()
 				}
 			}
 		}
-		
+
+		// store
+		m_shipNear = ship_is_near;
+		m_shipFiring = ship_is_firing;
 	}
 
 	bool changed = false;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -621,7 +621,7 @@ Ship::ECMResult Ship::UseECM()
 		// damage neaby missiles
 		const float ECM_RADIUS = 4000.0f;
 
-		Space::BodyNearList nearby;
+		BodyList nearby;
 		Pi::game->GetSpace()->GetBodiesMaybeNear(this, ECM_RADIUS, nearby);
 		for (Space::BodyNearIterator i = nearby.begin(); i != nearby.end(); ++i) {
 			if ((*i)->GetFrame() != GetFrame()) continue;

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -324,7 +324,9 @@ private:
 	vector3d m_angThrusters;
 
 	AlertState m_alertState;
+	double m_lastAlertUpdate;
 	double m_lastFiringAlert;
+	Space::BodyNearList m_nearbyBodies;
 
 	struct HyperspacingOut {
 		SystemPath dest;

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -326,6 +326,8 @@ private:
 	AlertState m_alertState;
 	double m_lastAlertUpdate;
 	double m_lastFiringAlert;
+	bool m_shipNear;
+	bool m_shipFiring;
 	BodyList m_nearbyBodies;
 
 	struct HyperspacingOut {

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -326,7 +326,7 @@ private:
 	AlertState m_alertState;
 	double m_lastAlertUpdate;
 	double m_lastFiringAlert;
-	Space::BodyNearList m_nearbyBodies;
+	BodyList m_nearbyBodies;
 
 	struct HyperspacingOut {
 		SystemPath dest;

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -186,7 +186,7 @@ void ScannerWidget::Update()
 	float combat_dist = 0, far_ship_dist = 0, nav_dist = 0, far_other_dist = 0;
 
 	// collect the bodies to be displayed, and if AUTO, distances
-	Space::BodyNearList nearby;
+	BodyList nearby;
 	Pi::game->GetSpace()->GetBodiesMaybeNear(Pi::player, SCANNER_RANGE_MAX, nearby);
 	for (Space::BodyNearIterator i = nearby.begin(); i != nearby.end(); ++i) {
 		if ((*i) == Pi::player) continue;

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -39,12 +39,12 @@ void Space::BodyNearFinder::Prepare()
 	std::sort(m_bodyDist.begin(), m_bodyDist.end());
 }
 
-void Space::BodyNearFinder::GetBodiesMaybeNear(const Body *b, double dist, BodyNearList &bodies) const
+void Space::BodyNearFinder::GetBodiesMaybeNear(const Body *b, double dist, BodyList &bodies) const
 {
 	GetBodiesMaybeNear(b->GetPositionRelTo(m_space->GetRootFrame()), dist, bodies);
 }
 
-void Space::BodyNearFinder::GetBodiesMaybeNear(const vector3d &pos, double dist, BodyNearList &bodies) const
+void Space::BodyNearFinder::GetBodiesMaybeNear(const vector3d &pos, double dist, BodyList &bodies) const
 {
 	if (m_bodyDist.empty()) return;
 

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -53,7 +53,6 @@ void Space::BodyNearFinder::GetBodiesMaybeNear(const vector3d &pos, double dist,
 	std::vector<BodyDist>::const_iterator min = std::lower_bound(m_bodyDist.begin(), m_bodyDist.end(), len-dist);
 	std::vector<BodyDist>::const_iterator max = std::upper_bound(min, m_bodyDist.end(), len+dist);
 
-	bodies.reserve(m_bodyDist.size());
 	while (min != max) {
 		bodies.push_back((*min).body);
 		++min;
@@ -941,14 +940,14 @@ void Space::UpdateBodies()
 		rmb->SetFrame(0);
 		for (Body* b : m_bodies)
 			b->NotifyRemoved(rmb);
-		ReallyRemoveBody(rmb);
+		m_bodies.remove(rmb);
 	}
 	m_removeBodies.clear();
 
 	for (Body* killb : m_killBodies) {
 		for (Body* b : m_bodies)
 			b->NotifyRemoved(killb);
-		ReallyRemoveBody(killb);
+		m_bodies.remove(killb);
 		delete killb;
 	}
 	m_killBodies.clear();
@@ -956,16 +955,6 @@ void Space::UpdateBodies()
 #ifndef NDEBUG
 	m_processingFinalizationQueue = false;
 #endif
-}
-
-void Space::ReallyRemoveBody(Body* b)
-{
-	PROFILE_SCOPED()
-	auto it = std::find(m_bodies.begin(), m_bodies.end(), b);
-	if( it != m_bodies.end() ) {
-		(*it) = m_bodies.back();
-		m_bodies.pop_back();
-	}
 }
 
 static char space[256];

--- a/src/Space.h
+++ b/src/Space.h
@@ -5,6 +5,7 @@
 #define _SPACE_H
 
 #include <list>
+#include "Body.h"
 #include "Object.h"
 #include "vector3.h"
 #include "Serializer.h"
@@ -14,7 +15,6 @@
 #include "Background.h"
 #include "IterationProxy.h"
 
-class Body;
 class Frame;
 class Ship;
 class HyperspaceCloud;

--- a/src/Space.h
+++ b/src/Space.h
@@ -64,8 +64,8 @@ public:
 	Body *FindBodyForPath(const SystemPath *path) const;
 
 	unsigned GetNumBodies() const { return m_bodies.size(); }
-	IterationProxy<std::vector<Body*> > GetBodies() { return MakeIterationProxy(m_bodies); }
-	const IterationProxy<const std::vector<Body*> > GetBodies() const { return MakeIterationProxy(m_bodies); }
+	IterationProxy<std::list<Body*> > GetBodies() { return MakeIterationProxy(m_bodies); }
+	const IterationProxy<const std::list<Body*> > GetBodies() const { return MakeIterationProxy(m_bodies); }
 
 	Background::Container *GetBackground() { return m_background.get(); }
 
@@ -87,7 +87,6 @@ private:
 	Frame *GetFrameWithSystemBody(const SystemBody *b) const;
 
 	void UpdateBodies();
-	void ReallyRemoveBody(Body*);
 
 	void CollideFrame(Frame *f);
 
@@ -101,11 +100,11 @@ private:
 	Game *m_game;
 
 	// all the bodies we know about
-	std::vector<Body*> m_bodies;
+	std::list<Body*> m_bodies;
 
 	// bodies that were removed/killed this timestep and need pruning at the end
-	std::vector<Body*> m_removeBodies;
-	std::vector<Body*> m_killBodies;
+	std::list<Body*> m_removeBodies;
+	std::list<Body*> m_killBodies;
 
 	void RebuildFrameIndex();
 	void RebuildBodyIndex();

--- a/src/Space.h
+++ b/src/Space.h
@@ -70,12 +70,11 @@ public:
 	Background::Container *GetBackground() { return m_background.get(); }
 
 	// body finder delegates
-	typedef std::vector<Body*> BodyNearList;
-	typedef BodyNearList::iterator BodyNearIterator;
-	void GetBodiesMaybeNear(const Body *b, double dist, BodyNearList &bodies) const {
+	typedef BodyList::iterator BodyNearIterator;
+	void GetBodiesMaybeNear(const Body *b, double dist, BodyList &bodies) const {
 		m_bodyNearFinder.GetBodiesMaybeNear(b, dist, bodies);
 	}
-	void GetBodiesMaybeNear(const vector3d &pos, double dist, BodyNearList &bodies) const {
+	void GetBodiesMaybeNear(const vector3d &pos, double dist, BodyList &bodies) const {
 		m_bodyNearFinder.GetBodiesMaybeNear(pos, dist, bodies);
 	}
 
@@ -129,8 +128,8 @@ private:
 		BodyNearFinder(const Space *space) : m_space(space) {}
 		void Prepare();
 
-		void GetBodiesMaybeNear(const Body *b, double dist, BodyNearList &bodies) const;
-		void GetBodiesMaybeNear(const vector3d &pos, double dist, BodyNearList &bodies) const;
+		void GetBodiesMaybeNear(const Body *b, double dist, BodyList &bodies) const;
+		void GetBodiesMaybeNear(const vector3d &pos, double dist, BodyList &bodies) const;
 
 	private:
 		struct BodyDist {

--- a/src/Space.h
+++ b/src/Space.h
@@ -64,8 +64,8 @@ public:
 	Body *FindBodyForPath(const SystemPath *path) const;
 
 	unsigned GetNumBodies() const { return m_bodies.size(); }
-	IterationProxy<std::list<Body*> > GetBodies() { return MakeIterationProxy(m_bodies); }
-	const IterationProxy<const std::list<Body*> > GetBodies() const { return MakeIterationProxy(m_bodies); }
+	IterationProxy<std::vector<Body*> > GetBodies() { return MakeIterationProxy(m_bodies); }
+	const IterationProxy<const std::vector<Body*> > GetBodies() const { return MakeIterationProxy(m_bodies); }
 
 	Background::Container *GetBackground() { return m_background.get(); }
 
@@ -88,6 +88,7 @@ private:
 	Frame *GetFrameWithSystemBody(const SystemBody *b) const;
 
 	void UpdateBodies();
+	void ReallyRemoveBody(Body*);
 
 	void CollideFrame(Frame *f);
 
@@ -101,11 +102,11 @@ private:
 	Game *m_game;
 
 	// all the bodies we know about
-	std::list<Body*> m_bodies;
+	std::vector<Body*> m_bodies;
 
 	// bodies that were removed/killed this timestep and need pruning at the end
-	std::list<Body*> m_removeBodies;
-	std::list<Body*> m_killBodies;
+	std::vector<Body*> m_removeBodies;
+	std::vector<Body*> m_killBodies;
 
 	void RebuildFrameIndex();
 	void RebuildBodyIndex();

--- a/src/collider/CollisionSpace.h
+++ b/src/collider/CollisionSpace.h
@@ -5,6 +5,7 @@
 #define _COLLISION_SPACE
 
 #include <list>
+#include <vector>
 #include "../vector3.h"
 
 class Geom;

--- a/src/collider/CollisionSpace.h
+++ b/src/collider/CollisionSpace.h
@@ -18,6 +18,7 @@ struct Sphere {
 };
 
 class BvhTree;
+typedef std::vector<Geom*> GeomArray;
 
 /*
  * Collision spaces have a bunch of geoms and at most one sphere (for a planet).
@@ -46,8 +47,8 @@ public:
 private:
 	void CollideGeoms(Geom *a, int minMailboxValue, void (*callback)(CollisionContact*));
 	void CollideRaySphere(const vector3d &start, const vector3d &dir, isect_t *isect);
-	std::list<Geom*> m_geoms;
-	std::list<Geom*> m_staticGeoms;
+	GeomArray m_geoms;
+	GeomArray m_staticGeoms;
 	bool m_needStaticGeomRebuild;
 	BvhTree *m_staticObjectTree;
 	BvhTree *m_dynamicObjectTree;

--- a/src/scenegraph/Animation.cpp
+++ b/src/scenegraph/Animation.cpp
@@ -13,6 +13,7 @@ typedef ChannelList::iterator ChannelIterator;
 Animation::Animation(const std::string &name, double duration)
 : m_duration(duration)
 , m_time(0.0)
+, m_timePrev(-1.0)
 , m_name(name)
 {
 }
@@ -20,6 +21,7 @@ Animation::Animation(const std::string &name, double duration)
 Animation::Animation(const Animation &anim)
 : m_duration(anim.m_duration)
 , m_time(0.0)
+, m_timePrev(-1.0)
 , m_name(anim.m_name)
 {
 	for(ChannelList::const_iterator chan = anim.m_channels.begin(); chan != anim.m_channels.end(); ++chan) {
@@ -29,6 +31,8 @@ Animation::Animation(const Animation &anim)
 
 void Animation::UpdateChannelTargets(Node *root)
 {
+	m_timePrev = (-1.0);
+
 	for(ChannelList::iterator chan = m_channels.begin(); chan != m_channels.end(); ++chan) {
 		//update channels to point to new node structure
 		MatrixTransform *trans = dynamic_cast<MatrixTransform*>(root->FindNode(chan->node->GetName()));
@@ -39,7 +43,13 @@ void Animation::UpdateChannelTargets(Node *root)
 
 void Animation::Interpolate()
 {
+	PROFILE_SCOPED()
+	if( m_time == m_timePrev ) {
+		return;
+	}
+
 	const double mtime = m_time;
+	m_timePrev = m_time;
 
 	//go through channels and calculate transforms
 	for(ChannelIterator chan = m_channels.begin(); chan != m_channels.end(); ++chan) {

--- a/src/scenegraph/Animation.h
+++ b/src/scenegraph/Animation.h
@@ -33,6 +33,7 @@ private:
 	friend class BinaryConverter;
 	double m_duration;
 	double m_time;
+	double m_timePrev;
 	std::string m_name;
 	std::vector<AnimationChannel> m_channels;
 };


### PR DESCRIPTION
After a [forum discussion](http://pioneerspacesim.net/forum/viewtopic.php?f=3&t=300) about running the game with more traffic, i.e. More ships, I decided to look into the performance problems it causes.

The main areas were the ships constant checking to see what's nearby in `Ship::UpdateAlertState` and the `Animation::Interpolate` which was being run even though the animation time hadn't been changed.

I also changed the container types used for `geom` and `body` pointers in `CollisionSpace` and `Space` after recently [reading an article](http://baptiste-wicht.com/posts/2012/12/cpp-benchmark-vector-list-deque.html) about the conditions and situations where `std::list` performs better than `std::vector` or `std::deque`. Although we do some addition and removal from the containers it's relatively rare compared to our constant iteration and accessing of them which vastly dominates their usage. 
Therefore I've switched us from `std::list` to `std::vector` for them both.

Andy