### PR TITLE
Many point stars on starless galaxy

### DIFF
--- a/src/Background.h
+++ b/src/Background.h
@@ -60,7 +60,7 @@ namespace Background
 
 	private:
 		void Init();
-		static const int BG_STAR_MAX = 10000;
+		static const int BG_STAR_MAX = 100000;
 		std::unique_ptr<Graphics::VertexBuffer> m_vertexBuffer;
 
 		//hyperspace animation vertex data


### PR DESCRIPTION
The title may be confusing.

Some time ago we switched to having the stars baked into the skybox texture. This is great, it allows for a lot more artist control.

On the downside however is that you can get smearing, stretching and deformation of the skybox image which means that stars being point sources don't always have a constant size.

This is a proposed change to use the skybox for just the galaxy image and have the stars drawn using points. To get a similar look to the skybox only approach we must increase the number of stars by **at least** 10 times. From 10,000 to 100,000 points specifically.

Please test, compare, contrast and let me know what you think as this is more of an artistic / design issue. Do mention however if you suffer from poor performance when using it compared to the usual version.

Thanks,

Andy