### PR TITLE
Rename event onShipEquipmentChange -> onShipEquipmentChanged

### DIFF
--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -172,7 +172,7 @@ function Ship:AddEquip(item, count, slot)
 	end
 	local ret = self.equipSet:Add(self, item, count, slot)
 	if ret > 0 then
-		Event.Queue("onShipEquipmentChange", self, item)
+		Event.Queue("onShipEquipmentChanged", self, item)
 	end
 	return ret
 end
@@ -319,7 +319,7 @@ Ship.SetEquip = function (self, slot, index, item)
 		item = compat.equip.old2new[item]
 	end
 	self.equipSet:Set(self, slot, index, item)
-	Event.Queue("onShipEquipmentChange", self)
+	Event.Queue("onShipEquipmentChanged", self)
 end
 
 --
@@ -361,7 +361,7 @@ Ship.RemoveEquip = function (self, item, count, slot)
 	end
 	local ret = self.equipSet:Remove(self, item, count, slot)
 	if ret > 0 then
-		Event.Queue("onShipEquipmentChange", self, item)
+		Event.Queue("onShipEquipmentChanged", self, item)
 	end
 	return ret
 end


### PR DESCRIPTION
The name was accidentally changed when equipment was ported to Lua. See commit fb614ea2c1ccc5dbb30237e8d55cc4e7d97b536d.
Fixes #3325.

Sorry for the potentially dodgy commit/PR; I'm doing this through the github online code editor. If someone could check that I haven't broken line-endings/whitespace before merging this, I'd appreciate it.