### PR TITLE
Animation interpolation optimisation

### DIFF
--- a/src/scenegraph/Animation.cpp
+++ b/src/scenegraph/Animation.cpp
@@ -13,6 +13,7 @@ typedef ChannelList::iterator ChannelIterator;
 Animation::Animation(const std::string &name, double duration)
 : m_duration(duration)
 , m_time(0.0)
+, m_timePrev(-1.0)
 , m_name(name)
 {
 }
@@ -20,6 +21,7 @@ Animation::Animation(const std::string &name, double duration)
 Animation::Animation(const Animation &anim)
 : m_duration(anim.m_duration)
 , m_time(0.0)
+, m_timePrev(-1.0)
 , m_name(anim.m_name)
 {
 	for(ChannelList::const_iterator chan = anim.m_channels.begin(); chan != anim.m_channels.end(); ++chan) {
@@ -29,6 +31,8 @@ Animation::Animation(const Animation &anim)
 
 void Animation::UpdateChannelTargets(Node *root)
 {
+	m_timePrev = (-1.0);
+
 	for(ChannelList::iterator chan = m_channels.begin(); chan != m_channels.end(); ++chan) {
 		//update channels to point to new node structure
 		MatrixTransform *trans = dynamic_cast<MatrixTransform*>(root->FindNode(chan->node->GetName()));
@@ -39,7 +43,13 @@ void Animation::UpdateChannelTargets(Node *root)
 
 void Animation::Interpolate()
 {
+	PROFILE_SCOPED()
+	if( m_time == m_timePrev ) {
+		return;
+	}
+
 	const double mtime = m_time;
+	m_timePrev = m_time;
 
 	//go through channels and calculate transforms
 	for(ChannelIterator chan = m_channels.begin(); chan != m_channels.end(); ++chan) {

--- a/src/scenegraph/Animation.h
+++ b/src/scenegraph/Animation.h
@@ -33,6 +33,7 @@ private:
 	friend class BinaryConverter;
 	double m_duration;
 	double m_time;
+	double m_timePrev;
 	std::string m_name;
 	std::vector<AnimationChannel> m_channels;
 };


### PR DESCRIPTION
'Animation::Interpolate' was being run even though the animation time hadn't been changed which is an expensive call. Increasing the number of ships caused it to appear heavily in the profiling.

Doing this here instead of #3320 as that has several optimisations one of which is causing issues.