### PR TITLE
modelcompiler no GL, no SDL, build support for compiled models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 compiler:
   - gcc
-script: ./bootstrap && ./configure --with-thirdparty=$(pwd)/pioneer-thirdparty && make
+script: ./bootstrap && ./configure --with-thirdparty=$(pwd)/pioneer-thirdparty LIBS="-ldl -lrt" && make
 before_install:
      - git clone --depth 1 git://github.com/pioneerspacesim/pioneer-thirdparty.git pioneer-thirdparty
      - cd pioneer-thirdparty/ && autoconf && ./configure && make assimp && make sdl2 && make sdl2_image && cd ../

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ enums:
 
 .PHONY: sgm
 sgm:
-	./src/modelcompiler$(EXEEXT) -b inplace
+	env SDL_VIDEODRIVER=dummy ./src/modelcompiler$(EXEEXT) -b inplace
 
 EXTRA_DIST = \
 	AUTHORS.txt \

--- a/configure.ac
+++ b/configure.ac
@@ -68,10 +68,11 @@ dnl ###########################################################################
 
 STD_CXXFLAGS=
 
-EXTRA_CFLAGS=
-EXTRA_CXXFLAGS=
-EXTRA_CPPFLAGS=
-EXTRA_LIBS=
+dnl allow extra stuff from environment too
+EXTRA_CFLAGS="$CFLAGS"
+EXTRA_CXXFLAGS="$CXXFLAGS"
+EXTRA_CPPFLAGS="$CPPFLAGS"
+EXTRA_LIBS="$LIBS"
 
 WARN_CFLAGS=
 WARN_CXXFLAGS=

--- a/scripts/nightly-build.pl
+++ b/scripts/nightly-build.pl
@@ -10,7 +10,7 @@ use Date::Format qw(time2str);
 use Date::Calc qw(Today Date_to_Time Add_Delta_Days);
 
 use constant SOURCE_DIR            => q{/home/robn/p/pioneer};
-use constant TEMP_DIR              => q{/tmp};
+use constant TEMP_DIR              => q{/home/robn/p/tmp};
 use constant OUT_DIR               => q{/home/robn/p};
 use constant CHROOT_DIR            => q{/home/robn/p/wheezy};
 use constant THIRDPARTY_DIR        => q{/home/robn/p/pioneer-thirdparty};
@@ -21,51 +21,58 @@ use constant UPLOAD_PATH           => q{robertnorris,pioneerspacesim@frs.sf.net:
 use constant URL_FORMAT            => q{http://sourceforge.net/projects/pioneerspacesim/files/%s/download};
 
 use constant PLATFORM => {
-	linux64 => {
-		suffix => "",
-		configure_opts => "",
-	builder => \&build_chroot,
-		archiver => \&archive_bz2,
-	},
-	linux32 => {
-		suffix => "",
-		configure_opts => "",
-	builder => \&build_chroot,
-		archiver => \&archive_bz2,
-	},
-	win32 => {
-		suffix => ".exe",
-		configure_opts => "--with-mxe=".MXE_DIR,
-		build_dir => SOURCE_DIR,
-		thirdparty_dir => THIRDPARTY_DIR,
-		builder => \&build_local,
-		archiver => \&archive_7z,
-	},
-	#osx => {
-	#},
+    linux64 => {
+        suffix => "",
+        configure_opts => "",
+        builder => \&build_chroot,
+        archiver => \&archive_bz2,
+    },
+    linux32 => {
+        suffix => "",
+        configure_opts => "",
+        builder => \&build_chroot,
+        archiver => \&archive_bz2,
+    },
+    win32 => {
+        suffix => ".exe",
+        configure_opts => "--with-mxe=".MXE_DIR,
+        build_dir => SOURCE_DIR,
+        builder => \&build_local,
+        archiver => \&archive_7z,
+    },
+    #osx => {
+    #},
 };
 
-my $branch = shift @ARGV || "master";
+my ($branch, $platforms) = @ARGV;
+$branch //= "master";
+
+my @platforms = grep { exists PLATFORM->{$_} } ($platforms ? (split ',', $platforms) : (keys %{PLATFORM()}));
 
 my ($ref, $date, $buildno) = update_source($branch);
 my $version = $branch eq "master" ? $date : $branch;#"$date.$buildno" : $branch;
 
 my %archives;
-for my $platform (keys %{PLATFORM()}) {
-	if ($platform ne "osx") {
-		my $build_dir = build($platform);
-		my $copy_dir = copy($platform, $build_dir);
-		$archives{$platform} = archive($platform, $copy_dir);
-	}
-	else {
-		# osx, screw it
-		system qq{ssh 10.50.0.107 "bash -lc './build-osx.sh $ref $version'"};
-		system "scp 10.50.0.107:pioneer/pioneer-$version-osx.tar.bz2 ".OUT_DIR;
-		$archives{$platform} = "pioneer-$version-osx.tar.bz2";
-	}
+for my $platform (@platforms) {
+    if ($platform ne "osx") {
+        my $build_dir = build($platform);
+        my $copy_dir = copy($platform, $build_dir);
+        if (check($platform, $copy_dir)) {
+            $archives{$platform} = archive($platform, $copy_dir);
+        } else {
+            # should notify someone somehow...?
+            say ">>> build $platform failed";
+        }
+    }
+    else {
+        # osx, screw it
+        system qq{ssh 10.50.0.107 "bash -lc './build-osx.sh $ref $version'"};
+        system "scp 10.50.0.107:pioneer/pioneer-$version-osx.tar.bz2 ".OUT_DIR;
+        $archives{$platform} = "pioneer-$version-osx.tar.bz2";
+    }
 }
 
-print "sleeping for 300 before uploading...\n";
+say STDERR "sleeping for 300 before uploading...";
 sleep 300;
 
 upload(values %archives);
@@ -75,172 +82,197 @@ tweet(%archives);
 tag($version) if $branch eq "master";
 
 sub update_source {
-	my ($branch) = @_;
+    my ($branch) = @_;
 
-	say STDERR ">>> updating source";
+    say STDERR ">>> updating source";
 
-	chdir SOURCE_DIR;
-	system "git fetch --tags --all -p";
-	system "git checkout origin/$branch || git checkout $branch";
+    chdir SOURCE_DIR;
+    system "git fetch --tags --all -p";
+    system "git checkout origin/$branch || git checkout $branch";
 
-	my $ref = `git log -n1 --pretty=%h origin/$branch`;
-	chomp $ref;
+    my $ref = `git log -n1 --pretty=%h origin/$branch`;
+    chomp $ref;
 
-	my $date = `date +%Y%m%d`;
-	chomp $date;
+    my $date = `date +%Y%m%d`;
+    chomp $date;
 
-	my $since = time2str("%Y-%m-%d", Date_to_Time(Add_Delta_Days((Today())[0,1],1,-1),0,0,0));
-	my $count = `git rev-list --since=$since --count HEAD`;
-	chomp $count;
+    my $since = time2str("%Y-%m-%d", Date_to_Time(Add_Delta_Days((Today())[0,1],1,-1),0,0,0));
+    my $count = `git rev-list --since=$since --count HEAD`;
+    chomp $count;
 
-	return ($ref, $date, $count);
+    return ($ref, $date, $count);
 }
 
 sub build_local {
-	my ($platform, $configure_opts) = @_;
+    my ($platform, $configure_opts) = @_;
 
-	say STDERR ">>> local build: ".PLATFORM->{$platform}->{build_dir};
+    say STDERR ">>> local build: ".PLATFORM->{$platform}->{build_dir};
 
-	$configure_opts .= " --with-thirdparty=".PLATFORM->{$platform}->{thirdparty_dir};
+    $configure_opts .= " --with-thirdparty=".PLATFORM->{$platform}->{thirdparty_dir} if PLATFORM->{$platform}->{thirdparty_dir};
 
-	chdir PLATFORM->{$platform}->{build_dir};
+    chdir PLATFORM->{$platform}->{build_dir};
 
-	{
-		no autodie;
-		system "make distclean";
-	}
-	system "./bootstrap";
-	system "./configure $configure_opts";
-	system "make clean";
-	system "make ".MAKE_OPTS;
+    {
+        no autodie;
+        system "make distclean";
+    }
+    system "./bootstrap";
+    system "./configure $configure_opts";
+    system "make clean";
+    system "make ".MAKE_OPTS;
 
-	return PLATFORM->{$platform}->{build_dir};
+    return PLATFORM->{$platform}->{build_dir};
 }
 
 sub build_chroot {
-	my ($platform, $configure_opts) = @_;
+    my ($platform, $configure_opts) = @_;
 
-	say STDERR ">>> chroot build";
+    say STDERR ">>> chroot build";
 
-	system sprintf("sudo rsync -av --delete --exclude=pioneer/.git %s %s/%s", SOURCE_DIR, CHROOT_DIR, $platform);
+    system sprintf("sudo rsync -av --delete --exclude=pioneer/.git %s %s/%s", SOURCE_DIR, CHROOT_DIR, $platform);
 
-	$configure_opts .= " --with-thirdparty=/pioneer-thirdparty";
-	system sprintf("sudo chroot %s/%s sh -c 'cd pioneer && ./configure $configure_opts && make distclean && ./configure %s && make %s'", CHROOT_DIR, $platform, $configure_opts, MAKE_OPTS);
+    $configure_opts .= " --with-thirdparty=/pioneer-thirdparty LIBS=\"-ldl -lrt\"";
+    system sprintf("sudo chroot %s/%s sh -c 'cd pioneer && ./configure $configure_opts && make distclean && ./configure %s && make %s'", CHROOT_DIR, $platform, $configure_opts, MAKE_OPTS);
 
-	return sprintf("%s/%s/pioneer", CHROOT_DIR, $platform);
+    # special case for build host, compile the sgm models as well
+    if ($platform eq 'linux64') {
+        system sprintf("sudo chroot %s/%s sh -c 'cd pioneer && make sgm'", CHROOT_DIR, $platform);
+    }
+
+    return sprintf("%s/%s/pioneer", CHROOT_DIR, $platform);
 }
 
 sub build {
-	my ($platform) = @_;
+    my ($platform) = @_;
 
-	say STDERR ">>> $platform: building";
+    say STDERR ">>> $platform: building";
 
-	my @configure_opts = (CONFIGURE_OPTS, PLATFORM->{$platform}->{configure_opts});
-	push @configure_opts, "--with-version=$version";
-	push @configure_opts, "--with-extra-version=$ref";
+    my @configure_opts = (CONFIGURE_OPTS, PLATFORM->{$platform}->{configure_opts});
+    push @configure_opts, "--with-version=$version";
+    push @configure_opts, "--with-extra-version=$ref";
 
-	my $configure_opts = join ' ', @configure_opts;
+    my $configure_opts = join ' ', @configure_opts;
 
-	return PLATFORM->{$platform}->{builder}($platform, $configure_opts);
+    return PLATFORM->{$platform}->{builder}($platform, $configure_opts);
 }
 
 sub filename_base {
-	my ($platform) = @_;
-	return $branch eq "master" ? "pioneer-$version-$platform" : "pioneer-$version-$ref-$platform";
+    my ($platform) = @_;
+    return $branch eq "master" ? "pioneer-$version-$platform" : "pioneer-$version-$ref-$platform";
 }
 
 sub copy {
-	my ($platform, $source_dir) = @_;
+    my ($platform, $source_dir) = @_;
 
-	say ">>> $platform: copying";
+    say ">>> $platform: copying";
 
-	chdir $source_dir;
+    chdir $source_dir;
 
-	my $copy_dir = TEMP_DIR.'/'.filename_base($platform);
-	system "mkdir -p $copy_dir";
+    my $copy_dir = TEMP_DIR.'/'.filename_base($platform);
+    system "mkdir -p $copy_dir";
 
-	my $suffix = PLATFORM->{$platform}->{suffix};
+    my $suffix = PLATFORM->{$platform}->{suffix};
 
-	system "cp -v src/pioneer$suffix $copy_dir";
-	system "cp -v src/pioneer.map $copy_dir" if $platform eq 'win32';
-	system "ls *.txt | /usr/bin/grep -v -E '(COMPILING\.txt|SAVEBUMP\.txt)' | xargs cp -v -t $copy_dir";
-	system "cp -rv licenses $copy_dir/licenses";
-	system "cp -rv data $copy_dir/data";
+    system "cp -v src/pioneer$suffix $copy_dir";
+    system "cp -v src/modelcompiler$suffix $copy_dir";
+    system "cp -v src/pioneer.map $copy_dir" if $platform eq 'win32';
+    system "cp -v src/modelcompiler.map $copy_dir" if $platform eq 'win32';
+    system "cp -v *.txt $copy_dir";
+    system "cp -rv licenses $copy_dir/licenses";
+    system "cp -rv data $copy_dir/data";
 
-	system "find $copy_dir/data/lang -name cmn.json -delete";
-	system "find $copy_dir/data '(' -name .gitignore -o -name Makefile\\\* ')' -delete";
+    system "find $copy_dir/data/lang -name cmn.json -delete";
+    system "find $copy_dir/data '(' -name .gitignore -o -name Makefile\\\* ')' -delete";
 
-	return $copy_dir;
+    # if we did a linux64 build we should have sgm files, copy those to the target
+    if (-d CHROOT_DIR."/linux64") {
+        system sprintf("cd %s/linux64/pioneer && find -name \*.sgm -exec cp -v '{}' %s/'{}' ';'", CHROOT_DIR, $copy_dir);
+    }
+
+    return $copy_dir;
+}
+
+sub check {
+    my ($platform, $binary_dir) = @_;
+
+    say ">>> $platform: checking";
+
+    my $suffix = PLATFORM->{$platform}->{suffix};
+
+    if (! -x "$binary_dir/pioneer$suffix") { return 0; }
+    if (! -x "$binary_dir/modelcompiler$suffix") { return 0; }
+
+    return 1;
 }
 
 sub archive {
-	my ($platform, $source_dir) = @_;
+    my ($platform, $source_dir) = @_;
 
-	say STDERR ">>> $platform: archiving";
+    say STDERR ">>> $platform: archiving";
 
-	chdir "$source_dir/..";
+    chdir "$source_dir/..";
 
-	my $archive = PLATFORM->{$platform}->{archiver}($platform);
+    my $archive = PLATFORM->{$platform}->{archiver}($platform);
 
-	system "rm -rf $source_dir";
+    system "rm -rf $source_dir";
 
-	return $archive;
+    return $archive;
 }
 
 sub archive_bz2 {
-	my ($platform) = @_;
+    my ($platform) = @_;
 
-	my $base = filename_base($platform);
-	my $out = OUT_DIR."/$base.tar";
+    my $base = filename_base($platform);
+    my $out = OUT_DIR."/$base.tar";
 
-	system "tar cvf $out $base";
-	system "bzip2 $out";
+    system "tar cvf $out $base";
+    system "bzip2 $out";
 
-	my $arc = "$base.tar.bz2";
-	say STDERR ">>> $platform: archived to $arc";
-	return $arc;
+    my $arc = "$base.tar.bz2";
+    say STDERR ">>> $platform: archived to $arc";
+    return $arc;
 }
 
 sub archive_7z {
-	my ($platform) = @_;
+    my ($platform) = @_;
 
-	my $base = filename_base($platform);
-	my $out = OUT_DIR."/$base.7z";
+    my $base = filename_base($platform);
+    my $out = OUT_DIR."/$base.7z";
 
-	system "7za a $out $base";
+    system "7za a $out $base";
 
-	my $arc = "$base.7z";
-	say STDERR ">>> $platform: archived to $arc";
-	return $arc;
+    my $arc = "$base.7z";
+    say STDERR ">>> $platform: archived to $arc";
+    return $arc;
 }
 
 sub upload {
-	my @files = @_;
+    my @files = @_;
 
-	chdir OUT_DIR;
+    chdir OUT_DIR;
 
-	say STDERR ">>> uploading ", join(' ', @files);
-	system join(' ', "scp", @files, UPLOAD_PATH);
+    say STDERR ">>> uploading ", join(' ', @files);
+    system join(' ', "scp", @files, UPLOAD_PATH);
 }
 
 sub tweet {
-	my %archives = @_;
+    my %archives = @_;
 
-	my $links = join '', map { sprintf " %s ".URL_FORMAT, $_, $archives{$_} } sort keys %archives;
+    my $links = join '', map { sprintf " %s ".URL_FORMAT, $_, $archives{$_} } sort keys %archives;
 
-	say STDERR ">>> tweeting";
-	system "ttytter -linelength=500 -status='new build available!$links #pioneerspacesim'";
+    say STDERR ">>> tweeting";
+    system "ttytter -linelength=500 -status='new build available!$links #pioneerspacesim'";
 
-	say STDERR ">>> sending to pusher";
-	system "/home/robn/p/pusher-event jameson:builder pioneer 'new build available ($version $ref):$links'";
+    say STDERR ">>> sending to pusher";
+    system "/home/robn/p/pusher-event jameson:builder pioneer 'new build available ($version $ref):$links'";
 }
 
 sub tag {
-	my ($version) = @_;
+    my ($version) = @_;
 
-	say STDERR ">>> tagging $version";
+    say STDERR ">>> tagging $version";
 
-	chdir SOURCE_DIR;
-	system "git tag $version";
-	system "git push origin $version";
+    chdir SOURCE_DIR;
+    system "git tag $version";
+    system "git push origin $version";
 }

--- a/src/CargoBody.cpp
+++ b/src/CargoBody.cpp
@@ -17,7 +17,7 @@
 void CargoBody::Save(Serializer::Writer &wr, Space *space)
 {
 	DynamicBody::Save(wr, space);
-	m_cargo.Save(wr);
+	Pi::luaSerializer->WrLuaRef(m_cargo, wr);
 	wr.Float(m_hitpoints);
 	wr.Float(m_selfdestructTimer);
 	wr.Bool(m_hasSelfdestruct);
@@ -26,7 +26,7 @@ void CargoBody::Save(Serializer::Writer &wr, Space *space)
 void CargoBody::Load(Serializer::Reader &rd, Space *space)
 {
 	DynamicBody::Load(rd, space);
-	m_cargo.Load(rd);
+	Pi::luaSerializer->RdLuaRef(m_cargo, rd);
 	Init();
 	m_hitpoints = rd.Float();
 	m_selfdestructTimer = rd.Float();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -129,7 +129,6 @@ Game::Game(Serializer::Reader &rd) :
 	Serializer::Reader section;
 
 	// Preparing the Lua stuff
-	LuaRef::InitLoad();
 	Pi::luaSerializer->InitTableRefs();
 
 	// galaxy generator
@@ -175,7 +174,6 @@ Game::Game(Serializer::Reader &rd) :
 	Pi::luaSerializer->Unserialize(section);
 
 	Pi::luaSerializer->UninitTableRefs();
-	LuaRef::UninitLoad();
 	// signature check
 	for (Uint32 i = 0; i < strlen(s_saveEnd)+1; i++)
 		if (rd.Byte() != s_saveEnd[i]) throw SavedGameCorruptException();

--- a/src/LuaRef.cpp
+++ b/src/LuaRef.cpp
@@ -33,51 +33,6 @@ LuaRef::~LuaRef() {
 	}
 }
 
-void LuaRef::Save(Serializer::Writer &wr) {
-	assert(m_lua == Lua::manager->GetLuaState());
-	std::string out;
-	LUA_DEBUG_START(m_lua);
-	PushCopyToStack();
-	Pi::luaSerializer->pickle(m_lua, -1, out);
-	lua_pop(m_lua, 1);
-	wr.String(out);
-	LUA_DEBUG_END(m_lua, 0);
-}
-
-void LuaRef::Load(Serializer::Reader &rd) {
-	lua_State *l = Lua::manager->GetLuaState();
-	std::string pickled = rd.String();
-	Pi::luaSerializer->unpickle(l, pickled.c_str()); // loaded
-	lua_getfield(l, LUA_REGISTRYINDEX, "PiLuaRefLoadTable"); // loaded, reftable
-	lua_pushvalue(l, -2); // loaded, reftable, copy
-	lua_gettable(l, -2);  // loaded, reftable, luaref
-	// Check whether this table has been referenced before
-	if (lua_isnil(l, -1)) {
-		// If not, mark it as referenced
-		*this = LuaRef(l, -3);
-		lua_pushvalue(l, -3);
-		lua_pushlightuserdata(l, this);
-		lua_settable(l, -4);
-	} else {
-		LuaRef *origin = static_cast<LuaRef *>(lua_touserdata(l, -1));
-		*this = *origin;
-	}
-
-	lua_pop(l, 3);
-}
-
-void LuaRef::InitLoad() {
-	lua_State *l = Lua::manager->GetLuaState();
-	lua_newtable(l);
-	lua_setfield(l, LUA_REGISTRYINDEX, "PiLuaRefLoadTable");
-}
-
-void LuaRef::UninitLoad() {
-	lua_State *l = Lua::manager->GetLuaState();
-	lua_pushnil(l);
-	lua_setfield(l, LUA_REGISTRYINDEX, "PiLuaRefLoadTable");
-}
-
 bool LuaRef::operator==(const LuaRef & ref) const {
 	if (ref.m_lua != m_lua)
 		return false;

--- a/src/LuaRef.h
+++ b/src/LuaRef.h
@@ -22,12 +22,6 @@ public:
 
 	lua_State * GetLua() const { return m_lua; }
 
-	void Save(Serializer::Writer &wr);
-	void Load(Serializer::Reader &rd);
-
-	static void InitLoad();
-	static void UninitLoad();
-
 private:
 	lua_State * m_lua;
 	int m_id;

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -455,6 +455,9 @@ void LuaSerializer::InitTableRefs() {
 
 	lua_newtable(l);
 	lua_setfield(l, LUA_REGISTRYINDEX, "PiSerializerTableRefs");
+
+	lua_newtable(l);
+	lua_setfield(l, LUA_REGISTRYINDEX, "PiLuaRefLoadTable");
 }
 
 void LuaSerializer::UninitTableRefs() {
@@ -462,6 +465,9 @@ void LuaSerializer::UninitTableRefs() {
 
 	lua_pushnil(l);
 	lua_setfield(l, LUA_REGISTRYINDEX, "PiSerializerTableRefs");
+
+	lua_pushnil(l);
+	lua_setfield(l, LUA_REGISTRYINDEX, "PiLuaRefLoadTable");
 }
 
 void LuaSerializer::Serialize(Serializer::Writer &wr)
@@ -542,6 +548,41 @@ void LuaSerializer::Unserialize(Serializer::Reader &rd)
 	lua_pop(l, 2);
 
 	LUA_DEBUG_END(l, 0);
+}
+
+void LuaSerializer::WrLuaRef(LuaRef &ref, Serializer::Writer &wr)
+{
+	lua_State *l = Lua::manager->GetLuaState();
+	std::string out;
+	LUA_DEBUG_START(l);
+	ref.PushCopyToStack();
+	pickle(l, -1, out);
+	lua_pop(l, 1);
+	wr.String(out);
+	LUA_DEBUG_END(l, 0);
+}
+
+void LuaSerializer::RdLuaRef(LuaRef &ref, Serializer::Reader &rd)
+{
+	lua_State *l = Lua::manager->GetLuaState();
+	std::string pickled = rd.String();
+	unpickle(l, pickled.c_str()); // loaded
+	lua_getfield(l, LUA_REGISTRYINDEX, "PiLuaRefLoadTable"); // loaded, reftable
+	lua_pushvalue(l, -2); // loaded, reftable, copy
+	lua_gettable(l, -2);  // loaded, reftable, luaref
+	// Check whether this table has been referenced before
+	if (lua_isnil(l, -1)) {
+		// If not, mark it as referenced
+		ref = LuaRef(l, -3);
+		lua_pushvalue(l, -3);
+		lua_pushlightuserdata(l, this);
+		lua_settable(l, -4);
+	} else {
+		LuaRef *origin = static_cast<LuaRef *>(lua_touserdata(l, -1));
+		ref = *origin;
+	}
+
+	lua_pop(l, 3);
 }
 
 int LuaSerializer::l_register(lua_State *l)

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -12,12 +12,14 @@
 
 class LuaSerializer : public DeleteEmitter {
 	friend class LuaObject<LuaSerializer>;
-	friend void LuaRef::Save(Serializer::Writer &wr);
-	friend void LuaRef::Load(Serializer::Reader &rd);
 
 public:
 	void Serialize(Serializer::Writer &wr);
 	void Unserialize(Serializer::Reader &rd);
+
+	void WrLuaRef(LuaRef &ref, Serializer::Writer &wr);
+	void RdLuaRef(LuaRef &ref, Serializer::Reader &rd);
+
 	void InitTableRefs();
 	void UninitTableRefs();
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -411,154 +411,36 @@ endif
 
 modelcompiler_SOURCES = \
 	modelcompiler.cpp \
-	AmbientSounds.cpp \
-	Background.cpp \
-	BaseSphere.cpp \
-	Body.cpp \
-	Camera.cpp \
-	CameraController.cpp \
-	CargoBody.cpp \
 	Color.cpp \
-	CityOnPlanet.cpp \
-	CRC32.cpp \
 	DateTime.cpp \
-	DeathView.cpp \
-	DynamicBody.cpp \
-	EnumStrings.cpp \
-	FaceParts.cpp \
-	Factions.cpp \
 	FileSourceZip.cpp \
 	FileSystem.cpp \
 	FontCache.cpp \
-	FormController.cpp \
-	Frame.cpp \
-	GalacticView.cpp \
-	Game.cpp \
-	GameLog.cpp \
-	GasGiant.cpp \
-	GeoPatch.cpp \
-	GeoPatchContext.cpp \
-	GeoPatchID.cpp \
-	GeoPatchJobs.cpp \
-	GeoSphere.cpp \
-	HudTrail.cpp \
-	HyperspaceCloud.cpp \
 	IniConfig.cpp \
-	Intro.cpp \
-	JobQueue.cpp \
 	GameConfig.cpp \
-	KeyBindings.cpp \
 	Lang.cpp \
-	Lua.cpp \
-	LuaBody.cpp \
-	LuaCargoBody.cpp \
-	LuaComms.cpp \
-	LuaConsole.cpp \
-	LuaConstants.cpp \
-	LuaDev.cpp \
-	LuaEngine.cpp \
-	LuaEvent.cpp \
-	LuaFaction.cpp \
-	LuaFileSystem.cpp \
-	LuaFormat.cpp \
-	LuaGame.cpp \
-	LuaLang.cpp \
-	LuaMatrix.cpp \
-	LuaVector.cpp \
-	LuaFixed.cpp \
-	LuaManager.cpp \
-	LuaMissile.cpp \
-	LuaModelBody.cpp \
-	LuaMusic.cpp \
-	LuaNameGen.cpp \
-	LuaObject.cpp \
-	LuaPlanet.cpp \
-	LuaPlayer.cpp \
-	LuaPropertiedObject.cpp \
-	LuaRand.cpp \
-	LuaRef.cpp \
-	LuaSystemBody.cpp \
-	LuaSystemPath.cpp \
-	LuaSerializer.cpp \
-	LuaShip.cpp \
-	LuaShipDef.cpp \
-	LuaSpace.cpp \
-	LuaSpaceStation.cpp \
-	LuaStar.cpp \
-	LuaStarSystem.cpp \
-	LuaTimer.cpp \
-	LuaUtils.cpp \
-	MathUtil.cpp \
-	Missile.cpp \
-	ModelBody.cpp \
-	ModelCache.cpp \
 	ModManager.cpp \
-	ModelViewer.cpp \
 	NavLights.cpp \
-	ObjectViewerView.cpp \
-	Orbit.cpp \
-	Pi.cpp \
-	Plane.cpp \
-	Planet.cpp \
-	Player.cpp \
 	PngWriter.cpp \
-	Polit.cpp \
-	Projectile.cpp \
-	PropertyMap.cpp \
 	SDLWrappers.cpp \
-	SectorView.cpp \
-	Sensors.cpp \
 	Serializer.cpp \
 	StringF.cpp \
-	Sfx.cpp \
-	Shields.cpp \
-	Ship-AI.cpp \
-	Ship.cpp \
-	ShipAICmd.cpp \
-	ShipCockpit.cpp \
-	ShipController.cpp \
-	ShipCpanel.cpp \
-	ShipCpanelMultiFuncDisplays.cpp \
-	ShipType.cpp \
-	Sound.cpp \
-	SoundMusic.cpp \
-	Space.cpp \
-	SpaceStation.cpp \
-	SpaceStationType.cpp \
-	SpeedLines.cpp \
-	Sphere.cpp \
-	Star.cpp \
-	SystemInfoView.cpp \
-	SystemView.cpp \
-	TerrainBody.cpp \
-	Tombstone.cpp \
-	UIView.cpp \
-	View.cpp \
-	WorldView.cpp \
-	perlin.cpp \
-	utils.cpp \
-	enum_table.cpp
+	utils.cpp
 
 modelcompiler_LDADD = \
-	collider/libcollider.a \
 	gui/libgui.a \
 	graphics/libgraphics.a \
 	graphics/dummy/libgraphicsdummy.a \
-	graphics/opengl/libgraphicsopengl.a \
-	galaxy/libgalaxy.a \
 	scenegraph/libscenegraph.a \
+	collider/libcollider.a \
 	text/libtext.a \
-	terrain/libterrain.a \
-	ui/libui.a \
-	gameui/libgameui.a \
 	../contrib/PicoDDS/libpicodds.a \
-	../contrib/jenkins/libjenkins.a \
 	../contrib/json/libjson.a \
 	../contrib/profiler/libprofiler.a
 
 modelcompiler_LDADD += \
-	$(FREETYPE_LIBS) $(GL_LIBS) \
-	$(SDL2_LIBS) $(SIGC_LIBS) $(LUA_LIBS) $(VORBIS_LIBS) \
+	$(FREETYPE_LIBS) \
+	$(SDL2_LIBS) $(SIGC_LIBS) $(LUA_LIBS) \
 	$(PNG_LIBS) $(ASSIMP_LIBS) $(EXTRA_LIBS)
 
 if !HAVE_LUA

--- a/src/PropertyMap.cpp
+++ b/src/PropertyMap.cpp
@@ -3,6 +3,7 @@
 
 #include "PropertyMap.h"
 #include "LuaUtils.h"
+#include "Pi.h"
 
 PropertyMap::PropertyMap(LuaManager *lua)
 {
@@ -26,4 +27,15 @@ void PropertyMap::SendSignal(const std::string &k)
 void PropertyMap::PushLuaTable()
 {
 	m_table.PushCopyToStack();
+}
+
+void PropertyMap::Save(Serializer::Writer &wr)
+{
+	Pi::luaSerializer->WrLuaRef(m_table, wr);
+}
+
+
+void PropertyMap::Load(Serializer::Reader &rd)
+{
+	Pi::luaSerializer->RdLuaRef(m_table, rd);
 }

--- a/src/PropertyMap.h
+++ b/src/PropertyMap.h
@@ -31,12 +31,8 @@ public:
 		return m_signals[k].connect(fn);
 	}
 
-    void Save(Serializer::Writer &wr) {
-        m_table.Save(wr);
-    }
-    void Load(Serializer::Reader &rd) {
-        m_table.Load(rd);
-    }
+	void Save(Serializer::Writer &wr);
+	void Load(Serializer::Reader &rd);
 
 private:
 	LuaRef m_table;

--- a/src/graphics/WindowSDL.cpp
+++ b/src/graphics/WindowSDL.cpp
@@ -46,8 +46,19 @@ bool WindowSDL::CreateWindowAndContext(const char *name, int w, int h, bool full
 	return true;
 }
 
-WindowSDL::WindowSDL(const Graphics::Settings &vs, const std::string &name)
-{
+WindowSDL::WindowSDL(const Graphics::Settings &vs, const std::string &name) {
+
+	// XXX horrible hack. if we don't want a renderer, we might be in an
+	// environment that doesn't actually have graphics available. since we're
+	// not going to draw anything anyway, there's not much point initialising a
+	// window (which will fail in aforementioned headless environment)
+	//
+	// the "right" way would be to have a dummy window class as well, and move
+	// a lot of this initialisation into the GL renderer. this is much easier
+	// right now though
+	if (vs.rendererType == Graphics::RENDERER_DUMMY)
+		return;
+
 	bool ok;
 
 	// attempt sequence is:


### PR DESCRIPTION
Bit of a grab bag here. I started thinking that it was the GL linkage that was stopping the modelcomiler running headless, and just kept running with it.

The first thing is to no longer require linking the GL remderer. That happened because we had to link `Pi.cpp` to get `Pi::luaSerializer` for `LuaRef`, which is used in the scenegraph. Its just a bit of refactoring to pass serializer context around where needed. After that the modelcompiler is able to compile without the GL renderer.

So even after that, it still didn't run on a headless machine. That's because SDL couldn't create a GL-enabled window - apparently even SDL's dummy driver still tries to do real GL work. The "right" way to fix this would be to both to a dummy window class and to move the GL setup down into the GL renderer. That's more effort that I want to spend right now, since its actually a bit harder than splitting out the renderer because we make a lot of assumptions about SDL all over the place. So I've just made it not bring up a window if you want the dummy renderer, which isn't as nice an abstraction but serves our purposes for the moment.

Finally, there's a couple of support items for the nightly builds. Not linking GL has caused some of its implicit shared library dependencies to be lost. SDL however still needs libdl and librt. Really its a bug in SDL's package config, but getting that fixed is going to take some effort with upstream, I think. Easier for now is just to explicitly have the build add `-ldl -lrt` but we need to be able to pass that through to configure. So now we can.

Finally, we're totally headless, so the default SDL driver won't work. So for `make sgm`, we force the dummy SDL driver. Its safe for non-headless too, if anyone wants to actually use that target.

And that's it! I've tested the whole build process with this patchset and it builds packages with compiled models included. So as soon as this is merged, we can have nice things :)