### PR TITLE
LuaSerializer refactor

### DIFF
--- a/SAVEBUMP.txt
+++ b/SAVEBUMP.txt
@@ -13,5 +13,5 @@ Regular tasks
 - data/libs/NameGen.lua: Add new authors to name generator
 
 One-time tasks
-
-[ There is nothing we know we need to do at the next savebump. ]
+- Remove serializer registration for ModelSkin (see XXX comment at bottom for
+  scengraph/LuaModelSkin.cpp)

--- a/src/CargoBody.cpp
+++ b/src/CargoBody.cpp
@@ -17,7 +17,7 @@
 void CargoBody::Save(Serializer::Writer &wr, Space *space)
 {
 	DynamicBody::Save(wr, space);
-	Pi::luaSerializer->WrLuaRef(m_cargo, wr);
+	m_cargo.Save(wr);
 	wr.Float(m_hitpoints);
 	wr.Float(m_selfdestructTimer);
 	wr.Bool(m_hasSelfdestruct);
@@ -26,7 +26,7 @@ void CargoBody::Save(Serializer::Writer &wr, Space *space)
 void CargoBody::Load(Serializer::Reader &rd, Space *space)
 {
 	DynamicBody::Load(rd, space);
-	Pi::luaSerializer->RdLuaRef(m_cargo, rd);
+	m_cargo.Load(rd);
 	Init();
 	m_hitpoints = rd.Float();
 	m_selfdestructTimer = rd.Float();

--- a/src/LuaBody.cpp
+++ b/src/LuaBody.cpp
@@ -12,6 +12,15 @@
 #include "Pi.h"
 #include "Game.h"
 
+#include "ModelBody.h"
+#include "Ship.h"
+#include "Player.h"
+#include "SpaceStation.h"
+#include "Planet.h"
+#include "Star.h"
+#include "CargoBody.h"
+#include "Missile.h"
+
 /*
  * Class: Body
  *
@@ -385,6 +394,57 @@ static int l_body_find_nearest_to(lua_State *l)
 	return 1;
 }
 
+static std::string _body_serializer(LuaWrappable *o)
+{
+	static char buf[256];
+	Body *b = static_cast<Body*>(o);
+	snprintf(buf, sizeof(buf), "%u\n", Pi::game->GetSpace()->GetIndexForBody(b));
+	return std::string(buf);
+}
+
+static bool _body_deserializer(const char *pos, const char **next)
+{
+	Uint32 n = strtoul(pos, const_cast<char**>(next), 0);
+	if (pos == *next) return false;
+	(*next)++; // skip newline
+
+	Body *body = Pi::game->GetSpace()->GetBodyByIndex(n);
+
+	switch (body->GetType()) {
+		case Object::BODY:
+			LuaObject<Body>::PushToLua(body);
+			break;
+		case Object::MODELBODY:
+			LuaObject<Body>::PushToLua(dynamic_cast<ModelBody*>(body));
+			break;
+		case Object::SHIP:
+			LuaObject<Ship>::PushToLua(dynamic_cast<Ship*>(body));
+			break;
+		case Object::PLAYER:
+			LuaObject<Player>::PushToLua(dynamic_cast<Player*>(body));
+			break;
+		case Object::SPACESTATION:
+			LuaObject<SpaceStation>::PushToLua(dynamic_cast<SpaceStation*>(body));
+			break;
+		case Object::PLANET:
+			LuaObject<Planet>::PushToLua(dynamic_cast<Planet*>(body));
+			break;
+		case Object::STAR:
+			LuaObject<Star>::PushToLua(dynamic_cast<Star*>(body));
+			break;
+		case Object::CARGOBODY:
+			LuaObject<Star>::PushToLua(dynamic_cast<CargoBody*>(body));
+			break;
+		case Object::MISSILE:
+			LuaObject<Missile>::PushToLua(dynamic_cast<Missile*>(body));
+			break;
+		default:
+			return false;
+	}
+
+	return true;
+}
+
 template <> const char *LuaObject<Body>::s_type = "Body";
 
 template <> void LuaObject<Body>::RegisterClass()
@@ -411,4 +471,15 @@ template <> void LuaObject<Body>::RegisterClass()
 
 	LuaObjectBase::CreateClass(s_type, l_parent, l_methods, l_attrs, 0);
 	LuaObjectBase::RegisterPromotion(l_parent, s_type, LuaObject<Body>::DynamicCastPromotionTest);
+	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_body_serializer, _body_deserializer));
+
+	// we're also the serializer for our subclasses
+	LuaObjectBase::RegisterSerializer("ModelBody",    SerializerPair(_body_serializer, _body_deserializer));
+	LuaObjectBase::RegisterSerializer("Ship",         SerializerPair(_body_serializer, _body_deserializer));
+	LuaObjectBase::RegisterSerializer("Player",       SerializerPair(_body_serializer, _body_deserializer));
+	LuaObjectBase::RegisterSerializer("SpaceStation", SerializerPair(_body_serializer, _body_deserializer));
+	LuaObjectBase::RegisterSerializer("Planet",       SerializerPair(_body_serializer, _body_deserializer));
+	LuaObjectBase::RegisterSerializer("Star",         SerializerPair(_body_serializer, _body_deserializer));
+	LuaObjectBase::RegisterSerializer("CargoBody",    SerializerPair(_body_serializer, _body_deserializer));
+	LuaObjectBase::RegisterSerializer("Missile",      SerializerPair(_body_serializer, _body_deserializer));
 }

--- a/src/LuaObject.cpp
+++ b/src/LuaObject.cpp
@@ -94,14 +94,17 @@
 static bool instantiated = false;
 
 static std::map< std::string, std::map<std::string,PromotionTest> > *promotions;
+static std::map< std::string, SerializerPair > *serializers;
 
 static void _teardown() {
 	delete promotions;
+	delete serializers;
 }
 
 static inline void _instantiate() {
 	if (!instantiated) {
 		promotions = new std::map< std::string, std::map<std::string,PromotionTest> >;
+		serializers = new std::map< std::string, SerializerPair >;
 
 		// XXX atexit is not a very nice way to deal with this in C++
 		atexit(_teardown);
@@ -865,6 +868,49 @@ bool LuaObjectBase::Isa(const char *base) const
 void LuaObjectBase::RegisterPromotion(const char *base_type, const char *target_type, PromotionTest test_fn)
 {
 	(*promotions)[base_type][target_type] = test_fn;
+}
+
+void LuaObjectBase::RegisterSerializer(const char *type, SerializerPair pair)
+{
+	(*serializers)[type] = pair;
+}
+
+std::string LuaObjectBase::Serialize()
+{
+	static char buf[256];
+
+	lua_State *l = Lua::manager->GetLuaState();
+
+	auto i = serializers->find(m_type);
+	if (i == serializers->end()) {
+		luaL_error(l, "No registered serializer for type %s\n", m_type);
+		abort();
+	}
+
+	snprintf(buf, sizeof(buf), "%s\n", m_type);
+
+	return std::string(buf) + (*i).second.serialize(GetObject());
+}
+
+bool LuaObjectBase::Deserialize(const char *stream, const char **next)
+{
+	static char buf[256];
+
+	const char *end = strchr(stream, '\n');
+	int len = end - stream;
+	end++; // skip newline
+
+	snprintf(buf, sizeof(buf), "%.*s", len, stream);
+
+	lua_State *l = Lua::manager->GetLuaState();
+
+	auto i = serializers->find(buf);
+	if (i == serializers->end()) {
+		luaL_error(l, "No registered deserializer for type %s\n", buf);
+		abort();
+	}
+
+	return (*i).second.deserialize(end, next);
 }
 
 void *LuaObjectBase::Allocate(size_t n) {

--- a/src/LuaRef.cpp
+++ b/src/LuaRef.cpp
@@ -82,3 +82,63 @@ void LuaRef::PushCopyToStack() const {
 	lua_remove(m_lua, -2);
 }
 
+void LuaRef::Save(Serializer::Writer &wr)
+{
+	assert(m_lua && m_id != LUA_NOREF);
+
+	LUA_DEBUG_START(m_lua);
+
+	lua_getfield(m_lua, LUA_REGISTRYINDEX, "PiSerializer");
+	LuaSerializer *serializer = static_cast<LuaSerializer*>(lua_touserdata(m_lua, -1));
+	lua_pop(m_lua, 1);
+
+	if (!serializer) {
+		LUA_DEBUG_END(m_lua, 0);
+		return;
+	}
+
+	std::string out;
+	PushCopyToStack();
+	serializer->pickle(m_lua, -1, out);
+	lua_pop(m_lua, 1);
+	wr.String(out);
+
+	LUA_DEBUG_END(m_lua, 0);
+}
+
+void LuaRef::Load(Serializer::Reader &rd)
+{
+	std::string pickled = rd.String();
+
+	LUA_DEBUG_START(m_lua);
+
+	lua_getfield(m_lua, LUA_REGISTRYINDEX, "PiSerializer");
+	LuaSerializer *serializer = static_cast<LuaSerializer*>(lua_touserdata(m_lua, -1));
+	lua_pop(m_lua, 1);
+
+	if (!serializer) {
+		LUA_DEBUG_END(m_lua, 0);
+		return;
+	}
+
+	serializer->unpickle(m_lua, pickled.c_str()); // loaded
+	lua_getfield(m_lua, LUA_REGISTRYINDEX, "PiLuaRefLoadTable"); // loaded, reftable
+	lua_pushvalue(m_lua, -2); // loaded, reftable, copy
+	lua_gettable(m_lua, -2);  // loaded, reftable, luaref
+	// Check whether this table has been referenced before
+	if (lua_isnil(m_lua, -1)) {
+		// If not, mark it as referenced
+		*this = LuaRef(m_lua, -3);
+		lua_pushvalue(m_lua, -3);
+		lua_pushlightuserdata(m_lua, this);
+		lua_settable(m_lua, -4);
+	} else {
+		LuaRef *origin = static_cast<LuaRef *>(lua_touserdata(m_lua, -1));
+		*this = *origin;
+	}
+
+	lua_pop(m_lua, 3);
+
+	LUA_DEBUG_END(m_lua, 0);
+}
+

--- a/src/LuaRef.h
+++ b/src/LuaRef.h
@@ -24,6 +24,9 @@ public:
 
 	bool IsValid() const { return m_lua && m_id != LUA_NOREF; }
 
+	void Save(Serializer::Writer &wr);
+	void Load(Serializer::Reader &rd);
+
 private:
 	lua_State * m_lua;
 	int m_id;

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -3,15 +3,6 @@
 
 #include "LuaSerializer.h"
 #include "LuaObject.h"
-#include "galaxy/StarSystem.h"
-#include "Body.h"
-#include "Ship.h"
-#include "SpaceStation.h"
-#include "Planet.h"
-#include "Star.h"
-#include "Player.h"
-#include "Pi.h"
-#include "Game.h"
 
 // every module can save one object. that will usually be a table.  we call
 // each serializer in turn and capture its return value we build a table like
@@ -33,8 +24,8 @@
 
 
 // pickler can handle simple types (boolean, number, string) and will drill
-// down into tables. it can do userdata for a specific set of types - Body and
-// its kids and SystemPath. anything else will cause a lua error
+// down into tables. it can do userdata assuming the appropriate Lua wrapper
+// class has registered a serializer and deseriaizer
 //
 // pickle format is newline-seperated. each line begins with a type value,
 // followed by data for that type as follows
@@ -46,8 +37,8 @@
 //   n        - end of table
 //   r        - reference to previously-seen table. followed by the table id
 //   uXXXX    - userdata. XXXX is type, followed by newline, followed by data
-//     Body       - data is a single stringified number for Serializer::LookupBody
-//     SystemPath - data is four stringified numbers, newline separated
+//                everything after u is passed down to LuaObject::Serialize to
+//                generate using per-class serializers
 //   oXXXX    - object. XXX is type, followed by newline, followed by one
 //              pickled item (typically t[able])
 
@@ -187,35 +178,7 @@ void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, con
 			if (!o)
 				Error("Lua serializer '%s' tried to serialize an invalid '%s' object", key, lo->GetType());
 
-			// XXX object wrappers should really have Serialize/Unserialize
-			// methods to deal with this
-			if (lo->Isa("SystemPath")) {
-				SystemPath *sbp = static_cast<SystemPath*>(o);
-				snprintf(buf, sizeof(buf), "SystemPath\n%d\n%d\n%d\n%u\n%u\n",
-					sbp->sectorX, sbp->sectorY, sbp->sectorZ, sbp->systemIndex, sbp->bodyIndex);
-				out += buf;
-				break;
-			}
-
-			if (lo->Isa("Body")) {
-				Body *b = static_cast<Body*>(o);
-				snprintf(buf, sizeof(buf), "Body\n%u\n", Pi::game->GetSpace()->GetIndexForBody(b));
-				out += buf;
-				break;
-			}
-
-			if (lo->Isa("SceneGraph.ModelSkin")) {
-				SceneGraph::ModelSkin *skin = static_cast<SceneGraph::ModelSkin*>(o);
-				Serializer::Writer wr;
-				skin->Save(wr);
-				const std::string &ser = wr.GetData();
-				snprintf(buf, sizeof(buf), "ModelSkin\n%lu\n", ser.size());
-				out += buf;
-				out += ser;
-				break;
-			}
-
-			Error("Lua serializer '%s' tried to serialize unsupported '%s' userdata value", key, lo->GetType());
+			out += lo->Serialize();
 			break;
 		}
 
@@ -307,97 +270,11 @@ const char *LuaSerializer::unpickle(lua_State *l, const char *pos)
 		}
 
 		case 'u': {
-			const char *end = strchr(pos, '\n');
-			if (!end) throw SavedGameCorruptException();
-			int len = end - pos;
-			end++; // skip newline
-
-			if (len == 10 && strncmp(pos, "SystemPath", 10) == 0) {
-				pos = end;
-
-				Sint32 sectorX = strtol(pos, const_cast<char**>(&end), 0);
-				if (pos == end) throw SavedGameCorruptException();
-				pos = end+1; // skip newline
-
-				Sint32 sectorY = strtol(pos, const_cast<char**>(&end), 0);
-				if (pos == end) throw SavedGameCorruptException();
-				pos = end+1; // skip newline
-
-				Sint32 sectorZ = strtol(pos, const_cast<char**>(&end), 0);
-				if (pos == end) throw SavedGameCorruptException();
-				pos = end+1; // skip newline
-
-				Uint32 systemNum = strtoul(pos, const_cast<char**>(&end), 0);
-				if (pos == end) throw SavedGameCorruptException();
-				pos = end+1; // skip newline
-
-				Uint32 sbodyId = strtoul(pos, const_cast<char**>(&end), 0);
-				if (pos == end) throw SavedGameCorruptException();
-				pos = end+1; // skip newline
-
-				const SystemPath sbp(sectorX, sectorY, sectorZ, systemNum, sbodyId);
-				LuaObject<SystemPath>::PushToLua(sbp);
-
-				break;
-			}
-
-			if (len == 4 && strncmp(pos, "Body", 4) == 0) {
-				pos = end;
-
-				Uint32 n = strtoul(pos, const_cast<char**>(&end), 0);
-				if (pos == end) throw SavedGameCorruptException();
-				pos = end+1; // skip newline
-
-				Body *body = Pi::game->GetSpace()->GetBodyByIndex(n);
-				if (pos == end) throw SavedGameCorruptException();
-
-				switch (body->GetType()) {
-					case Object::BODY:
-						LuaObject<Body>::PushToLua(body);
-						break;
-					case Object::SHIP:
-						LuaObject<Ship>::PushToLua(dynamic_cast<Ship*>(body));
-						break;
-					case Object::SPACESTATION:
-						LuaObject<SpaceStation>::PushToLua(dynamic_cast<SpaceStation*>(body));
-						break;
-					case Object::PLANET:
-						LuaObject<Planet>::PushToLua(dynamic_cast<Planet*>(body));
-						break;
-					case Object::STAR:
-						LuaObject<Star>::PushToLua(dynamic_cast<Star*>(body));
-						break;
-					case Object::PLAYER:
-						LuaObject<Player>::PushToLua(dynamic_cast<Player*>(body));
-						break;
-					default:
-						throw SavedGameCorruptException();
-				}
-
-				break;
-			}
-
-			if (len == 9 && strncmp(pos, "ModelSkin", 9) == 0) {
-				pos = end;
-
-				Uint32 serlen = strtoul(pos, const_cast<char**>(&end), 0);
-				if (pos == end) throw SavedGameCorruptException();
-				pos = end+1; // skip newline
-
-				std::string buf(pos, serlen);
-				const char *bufp = buf.c_str();
-				Serializer::Reader rd(ByteRange(bufp, bufp + buf.size()));
-				SceneGraph::ModelSkin skin;
-				skin.Load(rd);
-
-				LuaObject<SceneGraph::ModelSkin>::PushToLua(skin);
-
-				pos += serlen;
-
-				break;
-			}
-
-			throw SavedGameCorruptException();
+			const char *end;
+			if (!LuaObjectBase::Deserialize(pos, &end))
+				throw SavedGameCorruptException();
+			pos = end;
+			break;
 		}
 
 		case 'o': {

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -12,6 +12,8 @@
 
 class LuaSerializer : public DeleteEmitter {
 	friend class LuaObject<LuaSerializer>;
+	friend void LuaRef::Save(Serializer::Writer &wr);
+	friend void LuaRef::Load(Serializer::Reader &rd);
 
 public:
 	void Serialize(Serializer::Writer &wr);

--- a/src/LuaSystemPath.cpp
+++ b/src/LuaSystemPath.cpp
@@ -518,6 +518,49 @@ static int l_sbodypath_meta_tostring(lua_State *l)
 	return 1;
 }
 
+static std::string _systempath_serializer(LuaWrappable *o)
+{
+	static char buf[256];
+
+	SystemPath *sbp = static_cast<SystemPath*>(o);
+	snprintf(buf, sizeof(buf), "%d\n%d\n%d\n%u\n%u\n",
+		sbp->sectorX, sbp->sectorY, sbp->sectorZ, sbp->systemIndex, sbp->bodyIndex);
+
+	return std::string(buf);
+}
+
+static bool _systempath_deserializer(const char *pos, const char **next)
+{
+	const char *end;
+
+	Sint32 sectorX = strtol(pos, const_cast<char**>(&end), 0);
+	if (pos == end) return false;
+	pos = end+1; // skip newline
+
+	Sint32 sectorY = strtol(pos, const_cast<char**>(&end), 0);
+	if (pos == end) return false;
+	pos = end+1; // skip newline
+
+	Sint32 sectorZ = strtol(pos, const_cast<char**>(&end), 0);
+	if (pos == end) return false;
+	pos = end+1; // skip newline
+
+	Uint32 systemNum = strtoul(pos, const_cast<char**>(&end), 0);
+	if (pos == end) return false;
+	pos = end+1; // skip newline
+
+	Uint32 sbodyId = strtoul(pos, const_cast<char**>(&end), 0);
+	if (pos == end) return false;
+	pos = end+1; // skip newline
+
+	const SystemPath sbp(sectorX, sectorY, sectorZ, systemNum, sbodyId);
+	LuaObject<SystemPath>::PushToLua(sbp);
+
+	*next = pos;
+
+	return true;
+}
+
 template <> const char *LuaObject<SystemPath>::s_type = "SystemPath";
 
 template <> void LuaObject<SystemPath>::RegisterClass()
@@ -554,4 +597,5 @@ template <> void LuaObject<SystemPath>::RegisterClass()
 	};
 
 	LuaObjectBase::CreateClass(s_type, 0, l_methods, l_attrs, l_meta);
+	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_systempath_serializer, _systempath_deserializer));
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -362,6 +362,7 @@ uitest_SOURCES = \
 	LuaConstants.cpp \
 	LuaRef.cpp \
 	LuaPropertiedObject.cpp \
+	LuaSerializer.cpp \
 	PngWriter.cpp \
 	EnumStrings.cpp \
 	PropertyMap.cpp \

--- a/src/PropertyMap.cpp
+++ b/src/PropertyMap.cpp
@@ -3,7 +3,7 @@
 
 #include "PropertyMap.h"
 #include "LuaUtils.h"
-#include "Pi.h"
+#include "LuaSerializer.h"
 
 PropertyMap::PropertyMap(LuaManager *lua)
 {
@@ -31,11 +31,11 @@ void PropertyMap::PushLuaTable()
 
 void PropertyMap::Save(Serializer::Writer &wr)
 {
-	Pi::luaSerializer->WrLuaRef(m_table, wr);
+	m_table.Save(wr);
 }
 
 
 void PropertyMap::Load(Serializer::Reader &rd)
 {
-	Pi::luaSerializer->RdLuaRef(m_table, rd);
+	m_table.Load(rd);
 }

--- a/src/scenegraph/LuaModelSkin.cpp
+++ b/src/scenegraph/LuaModelSkin.cpp
@@ -93,6 +93,41 @@ public:
 
 }
 
+static std::string _modelskin_serializer(LuaWrappable *o)
+{
+	static char buf[256];
+
+	SceneGraph::ModelSkin *skin = static_cast<SceneGraph::ModelSkin*>(o);
+
+	Serializer::Writer wr;
+	skin->Save(wr);
+	const std::string &ser = wr.GetData();
+	snprintf(buf, sizeof(buf), "%lu\n", ser.size());
+
+	return std::string(buf) + ser;
+}
+
+static bool _modelskin_deserializer(const char *pos, const char **next)
+{
+	const char *end;
+
+	Uint32 serlen = strtoul(pos, const_cast<char**>(&end), 0);
+	if (pos == end) return false;
+	pos = end+1; // skip newline
+
+	std::string buf(pos, serlen);
+	const char *bufp = buf.c_str();
+	Serializer::Reader rd(ByteRange(bufp, bufp + buf.size()));
+	SceneGraph::ModelSkin skin;
+	skin.Load(rd);
+
+	LuaObject<SceneGraph::ModelSkin>::PushToLua(skin);
+
+	*next = pos + serlen;
+
+	return true;
+}
+
 using namespace SceneGraph;
 
 template <> const char *LuaObject<SceneGraph::ModelSkin>::s_type = "SceneGraph.ModelSkin";
@@ -111,5 +146,9 @@ template <> void LuaObject<SceneGraph::ModelSkin>::RegisterClass()
 	};
 
 	LuaObjectBase::CreateClass(s_type, 0, l_methods, 0, 0);
+	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_modelskin_serializer, _modelskin_deserializer));
+
+	// XXX support for old savefiles
+	LuaObjectBase::RegisterSerializer("ModelSkin", SerializerPair(_modelskin_serializer, _modelskin_deserializer));
 }
 


### PR DESCRIPTION
This is fully decoupling the Lua serialization setup from the game proper. The big problem is that LuaSerializer has special knowledge of Lua class wrappers. These should have been hidden away inside the wrappers proper.

So now any class wrapper that wants to be serializable registers a serializer and deserializer with LuaObject. LuaSerializer calls into LuaObject for those. Its all very nice.

And then, if you need to take LuaSerializer as a dependency (eg for simple programs like uitest), you don't need eg Body unless you take LuaBody. And since that depends on Game, you don't need that either :)

I've been careful to keep the savefile format the same. There's a single line we can clean up at next savefile bump. Its noted in SAVEBUMP.txt.

After this, I've got a single commit which will get uitest building again, and then I can get back to UI work!