### PR TITLE
JSONSerialise: migrating the save-game serialisation from a binary flat file to JSON

### DIFF
--- a/contrib/json/JsonUtils.cpp
+++ b/contrib/json/JsonUtils.cpp
@@ -1,0 +1,362 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "JsonUtils.h"
+#include "utils.h"
+#include "Serializer.h" // Need this for the exceptions
+
+void VectorToJson(Json::Value &jsonObj, const vector3f &vec, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value vecArray(Json::arrayValue); // Create JSON array to contain vector data.
+	vecArray[0] = FloatToStr(vec.x);
+	vecArray[1] = FloatToStr(vec.y);
+	vecArray[2] = FloatToStr(vec.z);
+	jsonObj[name] = vecArray; // Add vector array to supplied object.
+}
+
+void VectorToJson(Json::Value &jsonObj, const vector3d &vec, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value vecArray(Json::arrayValue); // Create JSON array to contain vector data.
+	vecArray[0] = DoubleToStr(vec.x);
+	vecArray[1] = DoubleToStr(vec.y);
+	vecArray[2] = DoubleToStr(vec.z);
+	jsonObj[name] = vecArray; // Add vector array to supplied object.
+}
+
+void QuaternionToJson(Json::Value &jsonObj, const Quaternionf &quat, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value quatArray(Json::arrayValue); // Create JSON array to contain quaternion data.
+	quatArray[0] = FloatToStr(quat.w);
+	quatArray[1] = FloatToStr(quat.x);
+	quatArray[2] = FloatToStr(quat.y);
+	quatArray[3] = FloatToStr(quat.z);
+	jsonObj[name] = quatArray; // Add quaternion array to supplied object.
+}
+
+void QuaternionToJson(Json::Value &jsonObj, const Quaterniond &quat, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value quatArray(Json::arrayValue); // Create JSON array to contain quaternion data.
+	quatArray[0] = DoubleToStr(quat.w);
+	quatArray[1] = DoubleToStr(quat.x);
+	quatArray[2] = DoubleToStr(quat.y);
+	quatArray[3] = DoubleToStr(quat.z);
+	jsonObj[name] = quatArray; // Add quaternion array to supplied object.
+}
+
+void MatrixToJson(Json::Value &jsonObj, const matrix3x3f &mat, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
+	matArray[0] = FloatToStr(mat[0]);
+	matArray[1] = FloatToStr(mat[1]);
+	matArray[2] = FloatToStr(mat[2]);
+	matArray[3] = FloatToStr(mat[3]);
+	matArray[4] = FloatToStr(mat[4]);
+	matArray[5] = FloatToStr(mat[5]);
+	matArray[6] = FloatToStr(mat[6]);
+	matArray[7] = FloatToStr(mat[7]);
+	matArray[8] = FloatToStr(mat[8]);
+	jsonObj[name] = matArray; // Add matrix array to supplied object.
+}
+
+void MatrixToJson(Json::Value &jsonObj, const matrix3x3d &mat, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
+	matArray[0] = DoubleToStr(mat[0]);
+	matArray[1] = DoubleToStr(mat[1]);
+	matArray[2] = DoubleToStr(mat[2]);
+	matArray[3] = DoubleToStr(mat[3]);
+	matArray[4] = DoubleToStr(mat[4]);
+	matArray[5] = DoubleToStr(mat[5]);
+	matArray[6] = DoubleToStr(mat[6]);
+	matArray[7] = DoubleToStr(mat[7]);
+	matArray[8] = DoubleToStr(mat[8]);
+	jsonObj[name] = matArray; // Add matrix array to supplied object.
+}
+
+void MatrixToJson(Json::Value &jsonObj, const matrix4x4f &mat, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
+	matArray[0] = FloatToStr(mat[0]);
+	matArray[1] = FloatToStr(mat[1]);
+	matArray[2] = FloatToStr(mat[2]);
+	matArray[3] = FloatToStr(mat[3]);
+	matArray[4] = FloatToStr(mat[4]);
+	matArray[5] = FloatToStr(mat[5]);
+	matArray[6] = FloatToStr(mat[6]);
+	matArray[7] = FloatToStr(mat[7]);
+	matArray[8] = FloatToStr(mat[8]);
+	matArray[9] = FloatToStr(mat[9]);
+	matArray[10] = FloatToStr(mat[10]);
+	matArray[11] = FloatToStr(mat[11]);
+	matArray[12] = FloatToStr(mat[12]);
+	matArray[13] = FloatToStr(mat[13]);
+	matArray[14] = FloatToStr(mat[14]);
+	matArray[15] = FloatToStr(mat[15]);
+	jsonObj[name] = matArray; // Add matrix array to supplied object.
+}
+
+void MatrixToJson(Json::Value &jsonObj, const matrix4x4d &mat, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
+	matArray[0] = DoubleToStr(mat[0]);
+	matArray[1] = DoubleToStr(mat[1]);
+	matArray[2] = DoubleToStr(mat[2]);
+	matArray[3] = DoubleToStr(mat[3]);
+	matArray[4] = DoubleToStr(mat[4]);
+	matArray[5] = DoubleToStr(mat[5]);
+	matArray[6] = DoubleToStr(mat[6]);
+	matArray[7] = DoubleToStr(mat[7]);
+	matArray[8] = DoubleToStr(mat[8]);
+	matArray[9] = DoubleToStr(mat[9]);
+	matArray[10] = DoubleToStr(mat[10]);
+	matArray[11] = DoubleToStr(mat[11]);
+	matArray[12] = DoubleToStr(mat[12]);
+	matArray[13] = DoubleToStr(mat[13]);
+	matArray[14] = DoubleToStr(mat[14]);
+	matArray[15] = DoubleToStr(mat[15]);
+	jsonObj[name] = matArray; // Add matrix array to supplied object.
+}
+
+void ColorToJson(Json::Value &jsonObj, const Color3ub &col, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value colArray(Json::arrayValue); // Create JSON array to contain color data.
+	colArray[0] = col.r;
+	colArray[1] = col.g;
+	colArray[2] = col.b;
+	jsonObj[name] = colArray; // Add color array to supplied object.
+}
+
+void ColorToJson(Json::Value &jsonObj, const Color4ub &col, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value colArray(Json::arrayValue); // Create JSON array to contain color data.
+	colArray[0] = col.r;
+	colArray[1] = col.g;
+	colArray[2] = col.b;
+	colArray[3] = col.a;
+	jsonObj[name] = colArray; // Add color array to supplied object.
+}
+
+void BinStrToJson(Json::Value &jsonObj, const std::string &binStr, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	Json::Value binStrArray(Json::arrayValue); // Create JSON array to contain binary string data.
+	for (unsigned int charIndex = 0; charIndex < binStr.size(); ++charIndex)
+		binStrArray[charIndex] = int(binStr[charIndex]);
+	jsonObj[name] = binStrArray; // Add binary string array to supplied object.
+}
+
+void JsonToVector(vector3f *pVec, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+	
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value vecArray = jsonObj[name.c_str()];
+	if (!vecArray.isArray()) throw SavedGameCorruptException();
+	if (vecArray.size() != 3) throw SavedGameCorruptException();
+
+	pVec->x = StrToFloat(vecArray[0].asString());
+	pVec->y = StrToFloat(vecArray[1].asString());
+	pVec->z = StrToFloat(vecArray[2].asString());
+}
+
+void JsonToVector(vector3d *pVec, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value vecArray = jsonObj[name.c_str()];
+	if (!vecArray.isArray()) throw SavedGameCorruptException();
+	if (vecArray.size() != 3) throw SavedGameCorruptException();
+
+	pVec->x = StrToDouble(vecArray[0].asString());
+	pVec->y = StrToDouble(vecArray[1].asString());
+	pVec->z = StrToDouble(vecArray[2].asString());
+}
+
+void JsonToQuaternion(Quaternionf *pQuat, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value quatArray = jsonObj[name.c_str()];
+	if (!quatArray.isArray()) throw SavedGameCorruptException();
+	if (quatArray.size() != 4) throw SavedGameCorruptException();
+
+	pQuat->w = StrToFloat(quatArray[0].asString());
+	pQuat->x = StrToFloat(quatArray[1].asString());
+	pQuat->y = StrToFloat(quatArray[2].asString());
+	pQuat->z = StrToFloat(quatArray[3].asString());
+}
+
+void JsonToQuaternion(Quaterniond *pQuat, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value quatArray = jsonObj[name.c_str()];
+	if (!quatArray.isArray()) throw SavedGameCorruptException();
+	if (quatArray.size() != 4) throw SavedGameCorruptException();
+
+	pQuat->w = StrToDouble(quatArray[0].asString());
+	pQuat->x = StrToDouble(quatArray[1].asString());
+	pQuat->y = StrToDouble(quatArray[2].asString());
+	pQuat->z = StrToDouble(quatArray[3].asString());
+}
+
+void JsonToMatrix(matrix3x3f *pMat, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value matArray = jsonObj[name.c_str()];
+	if (!matArray.isArray()) throw SavedGameCorruptException();
+	if (matArray.size() != 9) throw SavedGameCorruptException();
+
+	(*pMat)[0] = StrToFloat(matArray[0].asString());
+	(*pMat)[1] = StrToFloat(matArray[1].asString());
+	(*pMat)[2] = StrToFloat(matArray[2].asString());
+	(*pMat)[3] = StrToFloat(matArray[3].asString());
+	(*pMat)[4] = StrToFloat(matArray[4].asString());
+	(*pMat)[5] = StrToFloat(matArray[5].asString());
+	(*pMat)[6] = StrToFloat(matArray[6].asString());
+	(*pMat)[7] = StrToFloat(matArray[7].asString());
+	(*pMat)[8] = StrToFloat(matArray[8].asString());
+}
+
+void JsonToMatrix(matrix3x3d *pMat, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value matArray = jsonObj[name.c_str()];
+	if (!matArray.isArray()) throw SavedGameCorruptException();
+	if (matArray.size() != 9) throw SavedGameCorruptException();
+
+	(*pMat)[0] = StrToDouble(matArray[0].asString());
+	(*pMat)[1] = StrToDouble(matArray[1].asString());
+	(*pMat)[2] = StrToDouble(matArray[2].asString());
+	(*pMat)[3] = StrToDouble(matArray[3].asString());
+	(*pMat)[4] = StrToDouble(matArray[4].asString());
+	(*pMat)[5] = StrToDouble(matArray[5].asString());
+	(*pMat)[6] = StrToDouble(matArray[6].asString());
+	(*pMat)[7] = StrToDouble(matArray[7].asString());
+	(*pMat)[8] = StrToDouble(matArray[8].asString());
+}
+
+void JsonToMatrix(matrix4x4f *pMat, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value matArray = jsonObj[name.c_str()];
+	if (!matArray.isArray()) throw SavedGameCorruptException();
+	if (matArray.size() != 16) throw SavedGameCorruptException();
+
+	(*pMat)[0] = StrToFloat(matArray[0].asString());
+	(*pMat)[1] = StrToFloat(matArray[1].asString());
+	(*pMat)[2] = StrToFloat(matArray[2].asString());
+	(*pMat)[3] = StrToFloat(matArray[3].asString());
+	(*pMat)[4] = StrToFloat(matArray[4].asString());
+	(*pMat)[5] = StrToFloat(matArray[5].asString());
+	(*pMat)[6] = StrToFloat(matArray[6].asString());
+	(*pMat)[7] = StrToFloat(matArray[7].asString());
+	(*pMat)[8] = StrToFloat(matArray[8].asString());
+	(*pMat)[9] = StrToFloat(matArray[9].asString());
+	(*pMat)[10] = StrToFloat(matArray[10].asString());
+	(*pMat)[11] = StrToFloat(matArray[11].asString());
+	(*pMat)[12] = StrToFloat(matArray[12].asString());
+	(*pMat)[13] = StrToFloat(matArray[13].asString());
+	(*pMat)[14] = StrToFloat(matArray[14].asString());
+	(*pMat)[15] = StrToFloat(matArray[15].asString());
+}
+
+void JsonToMatrix(matrix4x4d *pMat, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value matArray = jsonObj[name.c_str()];
+	if (!matArray.isArray()) throw SavedGameCorruptException();
+	if (matArray.size() != 16) throw SavedGameCorruptException();
+
+	(*pMat)[0] = StrToDouble(matArray[0].asString());
+	(*pMat)[1] = StrToDouble(matArray[1].asString());
+	(*pMat)[2] = StrToDouble(matArray[2].asString());
+	(*pMat)[3] = StrToDouble(matArray[3].asString());
+	(*pMat)[4] = StrToDouble(matArray[4].asString());
+	(*pMat)[5] = StrToDouble(matArray[5].asString());
+	(*pMat)[6] = StrToDouble(matArray[6].asString());
+	(*pMat)[7] = StrToDouble(matArray[7].asString());
+	(*pMat)[8] = StrToDouble(matArray[8].asString());
+	(*pMat)[9] = StrToDouble(matArray[9].asString());
+	(*pMat)[10] = StrToDouble(matArray[10].asString());
+	(*pMat)[11] = StrToDouble(matArray[11].asString());
+	(*pMat)[12] = StrToDouble(matArray[12].asString());
+	(*pMat)[13] = StrToDouble(matArray[13].asString());
+	(*pMat)[14] = StrToDouble(matArray[14].asString());
+	(*pMat)[15] = StrToDouble(matArray[15].asString());
+}
+
+void JsonToColor(Color3ub *pCol, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value colArray = jsonObj[name.c_str()];
+	if (!colArray.isArray()) throw SavedGameCorruptException();
+	if (colArray.size() != 3) throw SavedGameCorruptException();
+
+	pCol->r = colArray[0].asUInt();
+	pCol->g = colArray[1].asUInt();
+	pCol->b = colArray[2].asUInt();
+}
+
+void JsonToColor(Color4ub *pCol, const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value colArray = jsonObj[name.c_str()];
+	if (!colArray.isArray()) throw SavedGameCorruptException();
+	if (colArray.size() != 4) throw SavedGameCorruptException();
+
+	pCol->r = colArray[0].asUInt();
+	pCol->g = colArray[1].asUInt();
+	pCol->b = colArray[2].asUInt();
+	pCol->a = colArray[3].asUInt();
+}
+
+std::string JsonToBinStr(const Json::Value &jsonObj, const std::string &name)
+{
+	assert(!name.empty()); // Can't do anything if no name supplied.
+
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value binStrArray = jsonObj[name.c_str()];
+	if (!binStrArray.isArray()) throw SavedGameCorruptException();
+
+	std::string binStr;
+	for (unsigned int charIndex = 0; charIndex < binStrArray.size(); ++charIndex)
+		binStr += char(binStrArray[charIndex].asInt());
+	return binStr;
+}

--- a/contrib/json/JsonUtils.cpp
+++ b/contrib/json/JsonUtils.cpp
@@ -2,8 +2,8 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "JsonUtils.h"
-#include "utils.h"
-#include "Serializer.h" // Need this for the exceptions
+#include "../../src/utils.h"
+#include "../../src/Serializer.h" // Need this for the exceptions
 
 void VectorToJson(Json::Value &jsonObj, const vector3f &vec, const std::string &name)
 {

--- a/contrib/json/JsonUtils.h
+++ b/contrib/json/JsonUtils.h
@@ -1,0 +1,40 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef _JSON_UTILS_H
+#define _JSON_UTILS_H
+
+#include "json/json.h"
+#include "vector3.h"
+#include "Quaternion.h"
+#include "matrix3x3.h"
+#include "matrix4x4.h"
+#include "Color.h"
+
+// To-JSON functions.
+void VectorToJson(Json::Value &jsonObj, const vector3f &vec, const std::string &name);
+void VectorToJson(Json::Value &jsonObj, const vector3d &vec, const std::string &name);
+void QuaternionToJson(Json::Value &jsonObj, const Quaternionf &quat, const std::string &name);
+void QuaternionToJson(Json::Value &jsonObj, const Quaterniond &quat, const std::string &name);
+void MatrixToJson(Json::Value &jsonObj, const matrix3x3f &mat, const std::string &name);
+void MatrixToJson(Json::Value &jsonObj, const matrix3x3d &mat, const std::string &name);
+void MatrixToJson(Json::Value &jsonObj, const matrix4x4f &mat, const std::string &name);
+void MatrixToJson(Json::Value &jsonObj, const matrix4x4d &mat, const std::string &name);
+void ColorToJson(Json::Value &jsonObj, const Color3ub &col, const std::string &name);
+void ColorToJson(Json::Value &jsonObj, const Color4ub &col, const std::string &name);
+void BinStrToJson(Json::Value &jsonObj, const std::string &str, const std::string &name);
+
+// Parse JSON functions.
+void JsonToVector(vector3f *pVec, const Json::Value &jsonObj, const std::string &name);
+void JsonToVector(vector3d *pVec, const Json::Value &jsonObj, const std::string &name);
+void JsonToQuaternion(Quaternionf *pQuat, const Json::Value &jsonObj, const std::string &name);
+void JsonToQuaternion(Quaterniond *pQuat, const Json::Value &jsonObj, const std::string &name);
+void JsonToMatrix(matrix3x3f *pMat, const Json::Value &jsonObj, const std::string &name);
+void JsonToMatrix(matrix3x3d *pMat, const Json::Value &jsonObj, const std::string &name);
+void JsonToMatrix(matrix4x4f *pMat, const Json::Value &jsonObj, const std::string &name);
+void JsonToMatrix(matrix4x4d *pMat, const Json::Value &jsonObj, const std::string &name);
+void JsonToColor(Color3ub *pCol, const Json::Value &jsonObj, const std::string &name);
+void JsonToColor(Color4ub *pCol, const Json::Value &jsonObj, const std::string &name);
+std::string JsonToBinStr(const Json::Value &jsonObj, const std::string &name);
+
+#endif /* _JSON_UTILS_H */

--- a/contrib/json/JsonUtils.h
+++ b/contrib/json/JsonUtils.h
@@ -5,11 +5,11 @@
 #define _JSON_UTILS_H
 
 #include "json/json.h"
-#include "vector3.h"
-#include "Quaternion.h"
-#include "matrix3x3.h"
-#include "matrix4x4.h"
-#include "Color.h"
+#include "../../src/vector3.h"
+#include "../../src/Quaternion.h"
+#include "../../src/matrix3x3.h"
+#include "../../src/matrix4x4.h"
+#include "../../src/Color.h"
 
 // To-JSON functions.
 void VectorToJson(Json::Value &jsonObj, const vector3f &vec, const std::string &name);

--- a/contrib/json/Makefile.am
+++ b/contrib/json/Makefile.am
@@ -1,7 +1,7 @@
 #  Process this file with automake to produce Makefile.in
 include $(top_srcdir)/Makefile.common
 
-AM_CPPFLAGS += -I @top_srcdir@/contrib
+AM_CPPFLAGS += -I @top_srcdir@/contrib -std=c++11
 
 noinst_LIBRARIES = libjson.a
 libjson_a_SOURCES = jsoncpp.cpp JsonUtils.cpp

--- a/contrib/json/Makefile.am
+++ b/contrib/json/Makefile.am
@@ -4,5 +4,5 @@ include $(top_srcdir)/Makefile.common
 AM_CPPFLAGS += -I @top_srcdir@/contrib
 
 noinst_LIBRARIES = libjson.a
-libjson_a_SOURCES = jsoncpp.cpp
-noinst_HEADERS = json.h
+libjson_a_SOURCES = jsoncpp.cpp JsonUtils.cpp
+noinst_HEADERS = json.h JsonUtils.h

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -17,6 +17,7 @@
 #include "Space.h"
 #include "Game.h"
 #include "LuaEvent.h"
+#include "json/JsonUtils.h"
 
 Body::Body() : PropertiedObject(Lua::manager)
 	, m_flags(0)
@@ -49,6 +50,23 @@ void Body::Save(Serializer::Writer &wr, Space *space)
 	wr.Double(m_clipRadius);
 }
 
+void Body::SaveToJson(Json::Value &jsonObj, Space *space)
+{
+	Json::Value bodyObj(Json::objectValue); // Create JSON object to contain body data.
+
+	Properties().SaveToJson(bodyObj);
+	bodyObj["index_for_frame"] = space->GetIndexForFrame(m_frame);
+	bodyObj["label"] = m_label;
+	bodyObj["dead"] = m_dead;
+
+	VectorToJson(bodyObj, m_pos, "pos");
+	MatrixToJson(bodyObj, m_orient, "orient");
+	bodyObj["phys_radius"] = DoubleToStr(m_physRadius);
+	bodyObj["clip_radius"] = DoubleToStr(m_clipRadius);
+
+	jsonObj["body"] = bodyObj; // Add body object to supplied object.
+}
+
 void Body::Load(Serializer::Reader &rd, Space *space)
 {
 	Properties().Load(rd);
@@ -61,6 +79,29 @@ void Body::Load(Serializer::Reader &rd, Space *space)
 	for (int i=0; i<9; i++) m_orient[i] = rd.Double();
 	m_physRadius = rd.Double();
 	m_clipRadius = rd.Double();
+}
+
+void Body::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	if (!jsonObj.isMember("body")) throw SavedGameCorruptException();
+	Json::Value bodyObj = jsonObj["body"];
+
+	if (!bodyObj.isMember("index_for_frame")) throw SavedGameCorruptException();
+	if (!bodyObj.isMember("label")) throw SavedGameCorruptException();
+	if (!bodyObj.isMember("dead")) throw SavedGameCorruptException();
+	if (!bodyObj.isMember("phys_radius")) throw SavedGameCorruptException();
+	if (!bodyObj.isMember("clip_radius")) throw SavedGameCorruptException();
+
+	Properties().LoadFromJson(bodyObj);
+	m_frame = space->GetFrameByIndex(bodyObj["index_for_frame"].asInt());
+	m_label = bodyObj["label"].asString();
+	Properties().Set("label", m_label);
+	m_dead = bodyObj["dead"].asBool();
+
+	JsonToVector(&m_pos, bodyObj, "pos");
+	JsonToMatrix(&m_orient, bodyObj, "orient");
+	m_physRadius = StrToDouble(bodyObj["phys_radius"].asString());
+	m_clipRadius = StrToDouble(bodyObj["clip_radius"].asString());
 }
 
 void Body::Serialize(Serializer::Writer &_wr, Space *space)
@@ -83,6 +124,27 @@ void Body::Serialize(Serializer::Writer &_wr, Space *space)
 			assert(0);
 	}
 	_wr.WrSection("Body", wr.GetData());
+}
+
+void Body::ToJson(Json::Value &jsonObj, Space *space)
+{
+	jsonObj["body_type"] = int(GetType());
+
+	switch (GetType()) {
+	case Object::STAR:
+	case Object::PLANET:
+	case Object::SPACESTATION:
+	case Object::SHIP:
+	case Object::PLAYER:
+	case Object::MISSILE:
+	case Object::CARGOBODY:
+	case Object::PROJECTILE:
+	case Object::HYPERSPACECLOUD:
+		SaveToJson(jsonObj, space);
+		break;
+	default:
+		assert(0);
+	}
 }
 
 Body *Body::Unserialize(Serializer::Reader &_rd, Space *space)
@@ -114,6 +176,38 @@ Body *Body::Unserialize(Serializer::Reader &_rd, Space *space)
 			assert(0);
 	}
 	b->Load(rd, space);
+	return b;
+}
+
+Body *Body::FromJson(const Json::Value &jsonObj, Space *space)
+{
+	if (!jsonObj.isMember("body_type")) throw SavedGameCorruptException();
+
+	Body *b = 0;
+	Object::Type type = Object::Type(jsonObj["body_type"].asInt());
+	switch (type) {
+	case Object::STAR:
+		b = new Star(); break;
+	case Object::PLANET:
+		b = new Planet(); break;
+	case Object::SPACESTATION:
+		b = new SpaceStation(); break;
+	case Object::SHIP:
+		b = new Ship(); break;
+	case Object::PLAYER:
+		b = new Player(); break;
+	case Object::MISSILE:
+		b = new Missile(); break;
+	case Object::PROJECTILE:
+		b = new Projectile(); break;
+	case Object::CARGOBODY:
+		b = new CargoBody(); break;
+	case Object::HYPERSPACECLOUD:
+		b = new HyperspaceCloud(); break;
+	default:
+		assert(0);
+	}
+	b->LoadFromJson(jsonObj, space);
 	return b;
 }
 

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -66,7 +66,7 @@ void Body::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	if (!bodyObj.isMember("clip_radius")) throw SavedGameCorruptException();
 
 	Properties().LoadFromJson(bodyObj);
-	m_frame = space->GetFrameByIndex(bodyObj["index_for_frame"].asInt());
+	m_frame = space->GetFrameByIndex(bodyObj["index_for_frame"].asUInt());
 	m_label = bodyObj["label"].asString();
 	Properties().Set("label", m_label);
 	m_dead = bodyObj["dead"].asBool();

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -37,19 +37,6 @@ Body::~Body()
 {
 }
 
-void Body::Save(Serializer::Writer &wr, Space *space)
-{
-	Properties().Save(wr);
-	wr.Int32(space->GetIndexForFrame(m_frame));
-	wr.String(m_label);
-	wr.Bool(m_dead);
-
-	wr.Vector3d(m_pos);
-	for (int i=0; i<9; i++) wr.Double(m_orient[i]);
-	wr.Double(m_physRadius);
-	wr.Double(m_clipRadius);
-}
-
 void Body::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	Json::Value bodyObj(Json::objectValue); // Create JSON object to contain body data.
@@ -65,20 +52,6 @@ void Body::SaveToJson(Json::Value &jsonObj, Space *space)
 	bodyObj["clip_radius"] = DoubleToStr(m_clipRadius);
 
 	jsonObj["body"] = bodyObj; // Add body object to supplied object.
-}
-
-void Body::Load(Serializer::Reader &rd, Space *space)
-{
-	Properties().Load(rd);
-	m_frame = space->GetFrameByIndex(rd.Int32());
-	m_label = rd.String();
-	Properties().Set("label", m_label);
-	m_dead = rd.Bool();
-
-	m_pos = rd.Vector3d();
-	for (int i=0; i<9; i++) m_orient[i] = rd.Double();
-	m_physRadius = rd.Double();
-	m_clipRadius = rd.Double();
 }
 
 void Body::LoadFromJson(const Json::Value &jsonObj, Space *space)
@@ -104,28 +77,6 @@ void Body::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	m_clipRadius = StrToDouble(bodyObj["clip_radius"].asString());
 }
 
-void Body::Serialize(Serializer::Writer &_wr, Space *space)
-{
-	Serializer::Writer wr;
-	wr.Int32(int(GetType()));
-	switch (GetType()) {
-		case Object::STAR:
-		case Object::PLANET:
-		case Object::SPACESTATION:
-		case Object::SHIP:
-		case Object::PLAYER:
-		case Object::MISSILE:
-		case Object::CARGOBODY:
-		case Object::PROJECTILE:
-		case Object::HYPERSPACECLOUD:
-			Save(wr, space);
-			break;
-		default:
-			assert(0);
-	}
-	_wr.WrSection("Body", wr.GetData());
-}
-
 void Body::ToJson(Json::Value &jsonObj, Space *space)
 {
 	jsonObj["body_type"] = int(GetType());
@@ -145,38 +96,6 @@ void Body::ToJson(Json::Value &jsonObj, Space *space)
 	default:
 		assert(0);
 	}
-}
-
-Body *Body::Unserialize(Serializer::Reader &_rd, Space *space)
-{
-	Serializer::Reader rd = _rd.RdSection("Body");
-	Body *b = 0;
-	Object::Type type = Object::Type(rd.Int32());
-	switch (type) {
-		case Object::STAR:
-			b = new Star(); break;
-		case Object::PLANET:
-			b = new Planet();
-			break;
-		case Object::SPACESTATION:
-			b = new SpaceStation(); break;
-		case Object::SHIP:
-			b = new Ship(); break;
-		case Object::PLAYER:
-			b = new Player(); break;
-		case Object::MISSILE:
-			b = new Missile(); break;
-		case Object::PROJECTILE:
-			b = new Projectile(); break;
-		case Object::CARGOBODY:
-			b = new CargoBody(); break;
-		case Object::HYPERSPACECLOUD:
-			b = new HyperspaceCloud(); break;
-		default:
-			assert(0);
-	}
-	b->Load(rd, space);
-	return b;
 }
 
 Body *Body::FromJson(const Json::Value &jsonObj, Space *space)

--- a/src/Body.h
+++ b/src/Body.h
@@ -24,7 +24,9 @@ public:
 	Body();
 	virtual ~Body();
 	void Serialize(Serializer::Writer &wr, Space *space);
+	void ToJson(Json::Value &jsonObj, Space *space);
 	static Body *Unserialize(Serializer::Reader &rd, Space *space);
+	static Body *FromJson(const Json::Value &jsonObj, Space *space);
 	virtual void PostLoadFixup(Space *space) {};
 
 	virtual void SetPosition(const vector3d &p) { m_pos = p; }
@@ -103,7 +105,9 @@ public:
 
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 	unsigned int m_flags;
 
 	// Interpolated draw orientation-position

--- a/src/Body.h
+++ b/src/Body.h
@@ -23,9 +23,7 @@ public:
 	OBJDEF(Body, Object, BODY);
 	Body();
 	virtual ~Body();
-	void Serialize(Serializer::Writer &wr, Space *space);
 	void ToJson(Json::Value &jsonObj, Space *space);
-	static Body *Unserialize(Serializer::Reader &rd, Space *space);
 	static Body *FromJson(const Json::Value &jsonObj, Space *space);
 	virtual void PostLoadFixup(Space *space) {};
 
@@ -104,9 +102,7 @@ public:
 			FLAG_DRAW_LAST = (1<<2) };		// causes the body drawn after other bodies in the z-sort
 
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 	unsigned int m_flags;
 

--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -6,6 +6,7 @@
 #include "AnimationCurves.h"
 #include "Pi.h"
 #include "Game.h"
+#include "json/JsonUtils.h"
 
 CameraController::CameraController(RefCountedPtr<CameraContext> camera, const Ship *ship) :
 	m_camera(camera),
@@ -129,11 +130,28 @@ void InternalCameraController::Save(Serializer::Writer &wr)
 	wr.Int32(m_mode);
 }
 
+void InternalCameraController::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value internalCameraObj(Json::objectValue); // Create JSON object to contain internal camera data.
+
+	internalCameraObj["mode"] = m_mode;
+
+	jsonObj["internal"] = internalCameraObj; // Add internal camera object to supplied object.
+}
+
 void InternalCameraController::Load(Serializer::Reader &rd)
 {
 	SetMode(static_cast<Mode>(rd.Int32()));
 }
 
+void InternalCameraController::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("internal")) throw SavedGameCorruptException();
+	Json::Value internalCameraObj = jsonObj["internal"];
+	if (!internalCameraObj.isMember("mode")) throw SavedGameCorruptException();
+
+	SetMode(static_cast<Mode>(internalCameraObj["mode"].asInt()));
+}
 
 ExternalCameraController::ExternalCameraController(RefCountedPtr<CameraContext> camera, const Ship *ship) :
 	MoveableCameraController(camera, ship),
@@ -225,6 +243,17 @@ void ExternalCameraController::Save(Serializer::Writer &wr)
 	wr.Double(m_dist);
 }
 
+void ExternalCameraController::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value externalCameraObj(Json::objectValue); // Create JSON object to contain external camera data.
+
+	externalCameraObj["rot_x"] = DoubleToStr(m_rotX);
+	externalCameraObj["rot_y"] = DoubleToStr(m_rotY);
+	externalCameraObj["dist"] = DoubleToStr(m_dist);
+
+	jsonObj["external"] = externalCameraObj; // Add external camera object to supplied object.
+}
+
 void ExternalCameraController::Load(Serializer::Reader &rd)
 {
 	m_rotX = rd.Double();
@@ -233,6 +262,19 @@ void ExternalCameraController::Load(Serializer::Reader &rd)
 	m_distTo = m_dist;
 }
 
+void ExternalCameraController::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("external")) throw SavedGameCorruptException();
+	Json::Value externalCameraObj = jsonObj["external"];
+	if (!externalCameraObj.isMember("rot_x")) throw SavedGameCorruptException();
+	if (!externalCameraObj.isMember("rot_y")) throw SavedGameCorruptException();
+	if (!externalCameraObj.isMember("dist")) throw SavedGameCorruptException();
+
+	m_rotX = StrToDouble(externalCameraObj["rot_x"].asString());
+	m_rotY = StrToDouble(externalCameraObj["rot_y"].asString());
+	m_dist = StrToDouble(externalCameraObj["dist"].asString());
+	m_distTo = m_dist;
+}
 
 SiderealCameraController::SiderealCameraController(RefCountedPtr<CameraContext> camera, const Ship *ship) :
 	MoveableCameraController(camera, ship),
@@ -326,9 +368,30 @@ void SiderealCameraController::Save(Serializer::Writer &wr)
 	wr.Double(m_dist);
 }
 
+void SiderealCameraController::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value siderealCameraObj(Json::objectValue); // Create JSON object to contain sidereal camera data.
+
+	MatrixToJson(siderealCameraObj, m_sidOrient, "sid_orient");
+	siderealCameraObj["dist"] = DoubleToStr(m_dist);
+
+	jsonObj["sidereal"] = siderealCameraObj; // Add sidereal camera object to supplied object.
+}
+
 void SiderealCameraController::Load(Serializer::Reader &rd)
 {
 	for (int i = 0; i < 9; i++) m_sidOrient[i] = rd.Double();
 	m_dist = rd.Double();
+	m_distTo = m_dist;
+}
+
+void SiderealCameraController::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("sidereal")) throw SavedGameCorruptException();
+	Json::Value siderealCameraObj = jsonObj["sidereal"];
+	if (!siderealCameraObj.isMember("dist")) throw SavedGameCorruptException();
+
+	JsonToMatrix(&m_sidOrient, siderealCameraObj, "sid_orient");
+	m_dist = StrToDouble(siderealCameraObj["dist"].asString());
 	m_distTo = m_dist;
 }

--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -125,11 +125,6 @@ void InternalCameraController::SetMode(Mode m)
 	}
 }
 
-void InternalCameraController::Save(Serializer::Writer &wr)
-{
-	wr.Int32(m_mode);
-}
-
 void InternalCameraController::SaveToJson(Json::Value &jsonObj)
 {
 	Json::Value internalCameraObj(Json::objectValue); // Create JSON object to contain internal camera data.
@@ -137,11 +132,6 @@ void InternalCameraController::SaveToJson(Json::Value &jsonObj)
 	internalCameraObj["mode"] = m_mode;
 
 	jsonObj["internal"] = internalCameraObj; // Add internal camera object to supplied object.
-}
-
-void InternalCameraController::Load(Serializer::Reader &rd)
-{
-	SetMode(static_cast<Mode>(rd.Int32()));
 }
 
 void InternalCameraController::LoadFromJson(const Json::Value &jsonObj)
@@ -236,13 +226,6 @@ void ExternalCameraController::Update()
 	CameraController::Update();
 }
 
-void ExternalCameraController::Save(Serializer::Writer &wr)
-{
-	wr.Double(m_rotX);
-	wr.Double(m_rotY);
-	wr.Double(m_dist);
-}
-
 void ExternalCameraController::SaveToJson(Json::Value &jsonObj)
 {
 	Json::Value externalCameraObj(Json::objectValue); // Create JSON object to contain external camera data.
@@ -252,14 +235,6 @@ void ExternalCameraController::SaveToJson(Json::Value &jsonObj)
 	externalCameraObj["dist"] = DoubleToStr(m_dist);
 
 	jsonObj["external"] = externalCameraObj; // Add external camera object to supplied object.
-}
-
-void ExternalCameraController::Load(Serializer::Reader &rd)
-{
-	m_rotX = rd.Double();
-	m_rotY = rd.Double();
-	m_dist = rd.Double();
-	m_distTo = m_dist;
 }
 
 void ExternalCameraController::LoadFromJson(const Json::Value &jsonObj)
@@ -362,12 +337,6 @@ void SiderealCameraController::Update()
 	CameraController::Update();
 }
 
-void SiderealCameraController::Save(Serializer::Writer &wr)
-{
-	for (int i = 0; i < 9; i++) wr.Double(m_sidOrient[i]);
-	wr.Double(m_dist);
-}
-
 void SiderealCameraController::SaveToJson(Json::Value &jsonObj)
 {
 	Json::Value siderealCameraObj(Json::objectValue); // Create JSON object to contain sidereal camera data.
@@ -376,13 +345,6 @@ void SiderealCameraController::SaveToJson(Json::Value &jsonObj)
 	siderealCameraObj["dist"] = DoubleToStr(m_dist);
 
 	jsonObj["sidereal"] = siderealCameraObj; // Add sidereal camera object to supplied object.
-}
-
-void SiderealCameraController::Load(Serializer::Reader &rd)
-{
-	for (int i = 0; i < 9; i++) m_sidOrient[i] = rd.Double();
-	m_dist = rd.Double();
-	m_distTo = m_dist;
 }
 
 void SiderealCameraController::LoadFromJson(const Json::Value &jsonObj)

--- a/src/CameraController.h
+++ b/src/CameraController.h
@@ -29,7 +29,9 @@ public:
 	virtual Type GetType() const = 0;
 	virtual const char *GetName() const { return ""; }
 	virtual void Save(Serializer::Writer &wr) { }
+	virtual void SaveToJson(Json::Value &jsonObj) { }
 	virtual void Load(Serializer::Reader &rd) { }
+	virtual void LoadFromJson(const Json::Value &jsonObj) { }
 	virtual bool IsExternal() const { return false; }
 
 	// camera position relative to the body
@@ -71,7 +73,9 @@ public:
 	void SetMode(Mode m);
 	Mode GetMode() const { return m_mode; }
 	void Save(Serializer::Writer &wr);
+	void SaveToJson(Json::Value &jsonObj);
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 
 private:
 	Mode m_mode;
@@ -134,7 +138,9 @@ public:
 	}
 
 	void Save(Serializer::Writer &wr);
+	void SaveToJson(Json::Value &jsonObj);
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 
 	void Update();
 
@@ -168,7 +174,9 @@ public:
 	bool IsExternal() const { return true; }
 
 	void Save(Serializer::Writer &wr);
+	void SaveToJson(Json::Value &jsonObj);
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 
 	void Update();
 

--- a/src/CameraController.h
+++ b/src/CameraController.h
@@ -28,9 +28,7 @@ public:
 
 	virtual Type GetType() const = 0;
 	virtual const char *GetName() const { return ""; }
-	virtual void Save(Serializer::Writer &wr) { }
 	virtual void SaveToJson(Json::Value &jsonObj) { }
-	virtual void Load(Serializer::Reader &rd) { }
 	virtual void LoadFromJson(const Json::Value &jsonObj) { }
 	virtual bool IsExternal() const { return false; }
 
@@ -72,9 +70,7 @@ public:
 	const char *GetName() const { return m_name; }
 	void SetMode(Mode m);
 	Mode GetMode() const { return m_mode; }
-	void Save(Serializer::Writer &wr);
 	void SaveToJson(Json::Value &jsonObj);
-	void Load(Serializer::Reader &rd);
 	void LoadFromJson(const Json::Value &jsonObj);
 
 private:
@@ -137,9 +133,7 @@ public:
 		m_rotY = y;
 	}
 
-	void Save(Serializer::Writer &wr);
 	void SaveToJson(Json::Value &jsonObj);
-	void Load(Serializer::Reader &rd);
 	void LoadFromJson(const Json::Value &jsonObj);
 
 	void Update();
@@ -173,9 +167,7 @@ public:
 	void Reset();
 	bool IsExternal() const { return true; }
 
-	void Save(Serializer::Writer &wr);
 	void SaveToJson(Json::Value &jsonObj);
-	void Load(Serializer::Reader &rd);
 	void LoadFromJson(const Json::Value &jsonObj);
 
 	void Update();

--- a/src/CameraController.h
+++ b/src/CameraController.h
@@ -9,6 +9,7 @@
 #include "Lang.h"
 #include "Serializer.h"
 #include "Camera.h"
+#include "json/json.h"
 
 class Ship;
 

--- a/src/CargoBody.cpp
+++ b/src/CargoBody.cpp
@@ -23,6 +23,20 @@ void CargoBody::Save(Serializer::Writer &wr, Space *space)
 	wr.Bool(m_hasSelfdestruct);
 }
 
+void CargoBody::SaveToJson(Json::Value &jsonObj, Space *space)
+{
+	DynamicBody::SaveToJson(jsonObj, space);
+
+	Json::Value cargoBodyObj(Json::objectValue); // Create JSON object to contain cargo body data.
+
+	m_cargo.SaveToJson(cargoBodyObj);
+	cargoBodyObj["hit_points"] = FloatToStr(m_hitpoints);
+	cargoBodyObj["self_destruct_timer"] = FloatToStr(m_selfdestructTimer);
+	cargoBodyObj["has_self_destruct"] = m_hasSelfdestruct;
+
+	jsonObj["cargo_body"] = cargoBodyObj; // Add cargo body object to supplied object.
+}
+
 void CargoBody::Load(Serializer::Reader &rd, Space *space)
 {
 	DynamicBody::Load(rd, space);
@@ -31,6 +45,24 @@ void CargoBody::Load(Serializer::Reader &rd, Space *space)
 	m_hitpoints = rd.Float();
 	m_selfdestructTimer = rd.Float();
 	m_hasSelfdestruct = rd.Bool();
+}
+
+void CargoBody::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	DynamicBody::LoadFromJson(jsonObj, space);
+
+	if (!jsonObj.isMember("cargo_body")) throw SavedGameCorruptException();
+	Json::Value cargoBodyObj = jsonObj["cargo_body"];
+
+	if (!cargoBodyObj.isMember("hit_points")) throw SavedGameCorruptException();
+	if (!cargoBodyObj.isMember("self_destruct_timer")) throw SavedGameCorruptException();
+	if (!cargoBodyObj.isMember("has_self_destruct")) throw SavedGameCorruptException();
+
+	m_cargo.LoadFromJson(cargoBodyObj);
+	Init();
+	m_hitpoints = StrToFloat(cargoBodyObj["hit_points"].asString());
+	m_selfdestructTimer = StrToFloat(cargoBodyObj["self_destruct_timer"].asString());
+	m_hasSelfdestruct = cargoBodyObj["has_self_destruct"].asBool();
 }
 
 void CargoBody::Init()

--- a/src/CargoBody.cpp
+++ b/src/CargoBody.cpp
@@ -14,15 +14,6 @@
 #include "scenegraph/SceneGraph.h"
 #include "scenegraph/ModelSkin.h"
 
-void CargoBody::Save(Serializer::Writer &wr, Space *space)
-{
-	DynamicBody::Save(wr, space);
-	m_cargo.Save(wr);
-	wr.Float(m_hitpoints);
-	wr.Float(m_selfdestructTimer);
-	wr.Bool(m_hasSelfdestruct);
-}
-
 void CargoBody::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	DynamicBody::SaveToJson(jsonObj, space);
@@ -35,16 +26,6 @@ void CargoBody::SaveToJson(Json::Value &jsonObj, Space *space)
 	cargoBodyObj["has_self_destruct"] = m_hasSelfdestruct;
 
 	jsonObj["cargo_body"] = cargoBodyObj; // Add cargo body object to supplied object.
-}
-
-void CargoBody::Load(Serializer::Reader &rd, Space *space)
-{
-	DynamicBody::Load(rd, space);
-	m_cargo.Load(rd);
-	Init();
-	m_hitpoints = rd.Float();
-	m_selfdestructTimer = rd.Float();
-	m_hasSelfdestruct = rd.Bool();
 }
 
 void CargoBody::LoadFromJson(const Json::Value &jsonObj, Space *space)

--- a/src/CargoBody.h
+++ b/src/CargoBody.h
@@ -22,9 +22,7 @@ public:
 	virtual bool OnCollision(Object *o, Uint32 flags, double relVel);
 	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData);
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 private:
 	void Init();

--- a/src/CargoBody.h
+++ b/src/CargoBody.h
@@ -23,7 +23,9 @@ public:
 	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData);
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 private:
 	void Init();
 	LuaRef m_cargo;

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -59,19 +59,6 @@ void DynamicBody::AddRelTorque(const vector3d &t)
 	m_torque += GetOrient() * t;
 }
 
-void DynamicBody::Save(Serializer::Writer &wr, Space *space)
-{
-	ModelBody::Save(wr, space);
-	wr.Vector3d(m_force);
-	wr.Vector3d(m_torque);
-	wr.Vector3d(m_vel);
-	wr.Vector3d(m_angVel);
-	wr.Double(m_mass);
-	wr.Double(m_massRadius);
-	wr.Double(m_angInertia);
-	wr.Bool(m_isMoving);
-}
-
 void DynamicBody::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	ModelBody::SaveToJson(jsonObj, space);
@@ -88,19 +75,6 @@ void DynamicBody::SaveToJson(Json::Value &jsonObj, Space *space)
 	dynamicBodyObj["is_moving"] = m_isMoving;
 
 	jsonObj["dynamic_body"] = dynamicBodyObj; // Add dynamic body object to supplied object.
-}
-
-void DynamicBody::Load(Serializer::Reader &rd, Space *space)
-{
-	ModelBody::Load(rd, space);
-	m_force = rd.Vector3d();
-	m_torque = rd.Vector3d();
-	m_vel = rd.Vector3d();
-	m_angVel = rd.Vector3d();
-	m_mass = rd.Double();
-	m_massRadius = rd.Double();
-	m_angInertia = rd.Double();
-	m_isMoving = rd.Bool();
 }
 
 void DynamicBody::LoadFromJson(const Json::Value &jsonObj, Space *space)

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -8,6 +8,7 @@
 #include "Serializer.h"
 #include "Planet.h"
 #include "Pi.h"
+#include "json/JsonUtils.h"
 
 static const float KINETIC_ENERGY_MULT = 0.00001f;
 const double DynamicBody::DEFAULT_DRAG_COEFF = 0.1; // 'smooth sphere'
@@ -71,6 +72,24 @@ void DynamicBody::Save(Serializer::Writer &wr, Space *space)
 	wr.Bool(m_isMoving);
 }
 
+void DynamicBody::SaveToJson(Json::Value &jsonObj, Space *space)
+{
+	ModelBody::SaveToJson(jsonObj, space);
+
+	Json::Value dynamicBodyObj(Json::objectValue); // Create JSON object to contain dynamic body data.
+
+	VectorToJson(dynamicBodyObj, m_force, "force");
+	VectorToJson(dynamicBodyObj, m_torque, "torque");
+	VectorToJson(dynamicBodyObj, m_vel, "vel");
+	VectorToJson(dynamicBodyObj, m_angVel, "ang_vel");
+	dynamicBodyObj["mass"] = DoubleToStr(m_mass);
+	dynamicBodyObj["mass_radius"] = DoubleToStr(m_massRadius);
+	dynamicBodyObj["ang_inertia"] = DoubleToStr(m_angInertia);
+	dynamicBodyObj["is_moving"] = m_isMoving;
+
+	jsonObj["dynamic_body"] = dynamicBodyObj; // Add dynamic body object to supplied object.
+}
+
 void DynamicBody::Load(Serializer::Reader &rd, Space *space)
 {
 	ModelBody::Load(rd, space);
@@ -82,6 +101,32 @@ void DynamicBody::Load(Serializer::Reader &rd, Space *space)
 	m_massRadius = rd.Double();
 	m_angInertia = rd.Double();
 	m_isMoving = rd.Bool();
+}
+
+void DynamicBody::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	ModelBody::LoadFromJson(jsonObj, space);
+
+	if (!jsonObj.isMember("dynamic_body")) throw SavedGameCorruptException();
+	Json::Value dynamicBodyObj = jsonObj["dynamic_body"];
+
+	if (!dynamicBodyObj.isMember("force")) throw SavedGameCorruptException();
+	if (!dynamicBodyObj.isMember("torque")) throw SavedGameCorruptException();
+	if (!dynamicBodyObj.isMember("vel")) throw SavedGameCorruptException();
+	if (!dynamicBodyObj.isMember("ang_vel")) throw SavedGameCorruptException();
+	if (!dynamicBodyObj.isMember("mass")) throw SavedGameCorruptException();
+	if (!dynamicBodyObj.isMember("mass_radius")) throw SavedGameCorruptException();
+	if (!dynamicBodyObj.isMember("ang_inertia")) throw SavedGameCorruptException();
+	if (!dynamicBodyObj.isMember("is_moving")) throw SavedGameCorruptException();
+
+	JsonToVector(&m_force, dynamicBodyObj, "force");
+	JsonToVector(&m_torque, dynamicBodyObj, "torque");
+	JsonToVector(&m_vel, dynamicBodyObj, "vel");
+	JsonToVector(&m_angVel, dynamicBodyObj, "ang_vel");
+	m_mass = StrToDouble(dynamicBodyObj["mass"].asString());
+	m_massRadius = StrToDouble(dynamicBodyObj["mass_radius"].asString());
+	m_angInertia = StrToDouble(dynamicBodyObj["ang_inertia"].asString());
+	m_isMoving = dynamicBodyObj["is_moving"].asBool();
 }
 
 void DynamicBody::PostLoadFixup(Space *space)

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -53,7 +53,9 @@ public:
 	Orbit ComputeOrbit() const;
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 	static const double DEFAULT_DRAG_COEFF;
 	double m_dragCoeff;

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -52,9 +52,7 @@ public:
 
 	Orbit ComputeOrbit() const;
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 	static const double DEFAULT_DRAG_COEFF;

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -9,6 +9,7 @@
 #include "galaxy/StarSystem.h"
 #include "Pi.h"
 #include "Game.h"
+#include "json/JsonUtils.h"
 #include <algorithm>
 
 Frame::Frame()
@@ -42,6 +43,33 @@ void Frame::Serialize(Serializer::Writer &wr, Frame *f, Space *space)
 	Sfx::Serialize(wr, f);
 }
 
+void Frame::ToJson(Json::Value &jsonObj, Frame *f, Space *space)
+{
+	Json::Value frameObj(Json::objectValue); // Create JSON object to contain frame data.
+
+	frameObj["flags"] = f->m_flags;
+	frameObj["radius"] = DoubleToStr(f->m_radius);
+	frameObj["label"] = f->m_label;
+	VectorToJson(frameObj, f->m_pos, "pos");
+	frameObj["ang_speed"] = DoubleToStr(f->m_angSpeed);
+	MatrixToJson(frameObj, f->m_initialOrient, "init_orient");
+	frameObj["index_for_system_body"] = space->GetIndexForSystemBody(f->m_sbody);
+	frameObj["index_for_astro_body"] = space->GetIndexForBody(f->m_astroBody);
+
+	Json::Value childFrameArray(Json::arrayValue); // Create JSON array to contain child frame data.
+	for (Frame* kid : f->GetChildren())
+	{
+		Json::Value childFrameArrayEl(Json::objectValue); // Create JSON object to contain child frame.
+		Frame::ToJson(childFrameArrayEl, kid, space);
+		childFrameArray.append(childFrameArrayEl); // Append child frame object to array.
+	}
+	frameObj["child_frames"] = childFrameArray; // Add child frame array to frame object.
+
+	Sfx::ToJson(frameObj, f);
+
+	jsonObj["frame"] = frameObj; // Add frame object to supplied object.
+}
+
 Frame *Frame::Unserialize(Serializer::Reader &rd, Space *space, Frame *parent, double at_time)
 {
 	Frame *f = new Frame();
@@ -61,6 +89,47 @@ Frame *Frame::Unserialize(Serializer::Reader &rd, Space *space, Frame *parent, d
 		f->m_children.push_back(Unserialize(rd, space, f, at_time));
 	}
 	Sfx::Unserialize(rd, f);
+
+	f->ClearMovement();
+	return f;
+}
+
+Frame *Frame::FromJson(const Json::Value &jsonObj, Space *space, Frame *parent, double at_time)
+{
+	Frame *f = new Frame();
+	f->m_parent = parent;
+
+	if (!jsonObj.isMember("frame")) throw SavedGameCorruptException();
+	Json::Value frameObj = jsonObj["frame"];
+
+	if (!frameObj.isMember("flags")) throw SavedGameCorruptException();
+	if (!frameObj.isMember("radius")) throw SavedGameCorruptException();
+	if (!frameObj.isMember("label")) throw SavedGameCorruptException();
+	if (!frameObj.isMember("pos")) throw SavedGameCorruptException();
+	if (!frameObj.isMember("ang_speed")) throw SavedGameCorruptException();
+	if (!frameObj.isMember("init_orient")) throw SavedGameCorruptException();
+	if (!frameObj.isMember("index_for_system_body")) throw SavedGameCorruptException();
+	if (!frameObj.isMember("index_for_astro_body")) throw SavedGameCorruptException();
+
+	f->m_flags = frameObj["flags"].asInt();
+	f->m_radius = StrToDouble(frameObj["radius"].asString());
+	f->m_label = frameObj["label"].asString();
+	JsonToVector(&(f->m_pos), frameObj, "pos");
+	f->m_angSpeed = StrToDouble(frameObj["ang_speed"].asString());
+	matrix3x3d orient;
+	JsonToMatrix(&orient, frameObj, "init_orient");
+	f->SetInitialOrient(orient, at_time);
+	f->m_sbody = space->GetSystemBodyByIndex(frameObj["index_for_system_body"].asUInt());
+	f->m_astroBodyIndex = frameObj["index_for_astro_body"].asUInt();
+	f->m_vel = vector3d(0.0); // m_vel is set to zero.
+
+	if (!frameObj.isMember("child_frames")) throw SavedGameCorruptException();
+	Json::Value childFrameArray = frameObj["child_frames"];
+	if (!childFrameArray.isArray()) throw SavedGameCorruptException();
+	for (unsigned int i = 0; i < childFrameArray.size(); ++i) {
+		f->m_children.push_back(FromJson(childFrameArray[i], space, f, at_time));
+	}
+	Sfx::FromJson(frameObj, f);
 
 	f->ClearMovement();
 	return f;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -7,6 +7,7 @@
 #include "libs.h"
 #include "Serializer.h"
 #include "IterationProxy.h"
+#include "json/json.h"
 #include <string>
 #include <list>
 
@@ -28,8 +29,10 @@ public:
 	Frame(Frame *parent, const char *label, unsigned int flags);
 	~Frame();
 	static void Serialize(Serializer::Writer &wr, Frame *f, Space *space);
+	static void ToJson(Json::Value &jsonObj, Frame *f, Space *space);
 	static void PostUnserializeFixup(Frame *f, Space *space);
 	static Frame *Unserialize(Serializer::Reader &rd, Space *space, Frame *parent, double at_time);
+	static Frame *FromJson(const Json::Value &jsonObj, Space *space, Frame *parent, double at_time);
 	const std::string &GetLabel() const { return m_label; }
 	void SetLabel(const char *label) { m_label = label; }
 

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -28,10 +28,8 @@ public:
 	Frame(Frame *parent, const char *label);
 	Frame(Frame *parent, const char *label, unsigned int flags);
 	~Frame();
-	static void Serialize(Serializer::Writer &wr, Frame *f, Space *space);
 	static void ToJson(Json::Value &jsonObj, Frame *f, Space *space);
 	static void PostUnserializeFixup(Frame *f, Space *space);
-	static Frame *Unserialize(Serializer::Reader &rd, Space *space, Frame *parent, double at_time);
 	static Frame *FromJson(const Json::Value &jsonObj, Space *space, Frame *parent, double at_time);
 	const std::string &GetLabel() const { return m_label; }
 	void SetLabel(const char *label) { m_label = label; }

--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -77,10 +77,17 @@ void GalacticView::Save(Serializer::Writer &wr)
 {
 }
 
+void GalacticView::SaveToJson(Json::Value &jsonObj)
+{
+}
+
 void GalacticView::Load(Serializer::Reader &rd)
 {
 }
 
+void GalacticView::LoadFromJson(const Json::Value &jsonObj)
+{
+}
 
 struct galaclabel_t {
 	const char *label;

--- a/src/GalacticView.cpp
+++ b/src/GalacticView.cpp
@@ -73,15 +73,7 @@ GalacticView::~GalacticView()
 	m_onMouseWheelCon.disconnect();
 }
 
-void GalacticView::Save(Serializer::Writer &wr)
-{
-}
-
 void GalacticView::SaveToJson(Json::Value &jsonObj)
-{
-}
-
-void GalacticView::Load(Serializer::Reader &rd)
 {
 }
 

--- a/src/GalacticView.h
+++ b/src/GalacticView.h
@@ -22,9 +22,7 @@ public:
 	virtual ~GalacticView();
 	virtual void Update();
 	virtual void Draw3D();
-	virtual void Save(Serializer::Writer &wr);
 	virtual void SaveToJson(Json::Value &jsonObj);
-	virtual void Load(Serializer::Reader &rd);
 	virtual void LoadFromJson(const Json::Value &jsonObj);
 
 protected:

--- a/src/GalacticView.h
+++ b/src/GalacticView.h
@@ -23,7 +23,9 @@ public:
 	virtual void Update();
 	virtual void Draw3D();
 	virtual void Save(Serializer::Writer &wr);
+	virtual void SaveToJson(Json::Value &jsonObj);
 	virtual void Load(Serializer::Reader &rd);
+	virtual void LoadFromJson(const Json::Value &jsonObj);
 
 protected:
 	virtual void OnSwitchTo() {}

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -181,6 +181,84 @@ Game::Game(Serializer::Reader &rd) :
 	EmitPauseState(IsPaused());
 }
 
+Game::Game(const Json::Value &jsonObj) :
+m_timeAccel(TIMEACCEL_PAUSED),
+m_requestedTimeAccel(TIMEACCEL_PAUSED),
+m_forceTimeAccel(false)
+{
+	// signature check
+	if (!jsonObj.isMember("signature")) throw SavedGameCorruptException();
+	Json::Value signature = jsonObj["signature"];
+	if (signature.isString() && signature.asString().compare(s_saveStart) == 0) {}
+	else throw SavedGameCorruptException();
+
+	// version check
+	if (!jsonObj.isMember("version")) throw SavedGameCorruptException();
+	Json::Value version = jsonObj["version"];
+	if (!version.isInt()) throw SavedGameCorruptException();
+	Output("savefile version: %d\n", version.asInt());
+	if (version.asInt() == s_saveVersion) {}
+	else
+	{
+		Output("can't load savefile, expected version: %d\n", s_saveVersion);
+		throw SavedGameWrongVersionException();
+	}
+
+	// Preparing the Lua stuff
+	Pi::luaSerializer->InitTableRefs();
+
+	// galaxy generator
+	m_galaxy = Galaxy::LoadFromJson(jsonObj);
+
+	// game state
+	if (!jsonObj.isMember("time")) throw SavedGameCorruptException();
+	if (!jsonObj.isMember("state")) throw SavedGameCorruptException();
+	m_time = StrToDouble(jsonObj["time"].asString());
+	m_state = State(jsonObj["state"].asInt());
+
+	if (!jsonObj.isMember("want_hyperspace")) throw SavedGameCorruptException();
+	if (!jsonObj.isMember("hyperspace_progress")) throw SavedGameCorruptException();
+	if (!jsonObj.isMember("hyperspace_duration")) throw SavedGameCorruptException();
+	if (!jsonObj.isMember("hyperspace_end_time")) throw SavedGameCorruptException();
+	m_wantHyperspace = jsonObj["want_hyperspace"].asBool();
+	m_hyperspaceProgress = StrToDouble(jsonObj["hyperspace_progress"].asString());
+	m_hyperspaceDuration = StrToDouble(jsonObj["hyperspace_duration"].asString());
+	m_hyperspaceEndTime = StrToDouble(jsonObj["hyperspace_end_time"].asString());
+
+	// space, all the bodies and things
+	if (!jsonObj.isMember("player")) throw SavedGameCorruptException();
+	m_space.reset(new Space(this, m_galaxy, jsonObj, m_time));
+	m_player.reset(static_cast<Player*>(m_space->GetBodyByIndex(jsonObj["player"].asUInt())));
+
+	assert(!m_player->IsDead()); // Pioneer does not support necromancy
+
+	// hyperspace clouds being brought over from the previous system
+	if (!jsonObj.isMember("hyperspace_clouds")) throw SavedGameCorruptException();
+	Json::Value hyperspaceCloudArray = jsonObj["hyperspace_clouds"];
+	if (!hyperspaceCloudArray.isArray()) throw SavedGameCorruptException();
+	for (Uint32 i = 0; i < hyperspaceCloudArray.size(); i++)
+		m_hyperspaceClouds.push_back(static_cast<HyperspaceCloud*>(Body::FromJson(hyperspaceCloudArray[i], 0)));
+
+	// system political stuff
+	Polit::FromJson(jsonObj, m_galaxy);
+
+	// views
+	LoadViewsFromJson(jsonObj);
+
+	// lua
+	Pi::luaSerializer->FromJson(jsonObj);
+
+	Pi::luaSerializer->UninitTableRefs();
+
+	// signature check (don't really need this anymore)
+	if (!jsonObj.isMember("trailing_signature")) throw SavedGameCorruptException();
+	Json::Value trailingSignature = jsonObj["trailing_signature"];
+	if (trailingSignature.isString() && trailingSignature.asString().compare(s_saveEnd) == 0) {}
+	else throw SavedGameCorruptException();
+
+	EmitPauseState(IsPaused());
+}
+
 void Game::Serialize(Serializer::Writer &wr)
 {
 	// preparing the lua serializer
@@ -257,6 +335,60 @@ void Game::Serialize(Serializer::Writer &wr)
 	// trailing signature
 	for (Uint32 i = 0; i < strlen(s_saveEnd)+1; i++)
 		wr.Byte(s_saveEnd[i]);
+
+	Pi::luaSerializer->UninitTableRefs();
+}
+
+void Game::ToJson(Json::Value &jsonObj)
+{
+	// preparing the lua serializer
+	Pi::luaSerializer->InitTableRefs();
+
+	// signature
+	jsonObj["signature"] = s_saveStart;
+
+	// version
+	jsonObj["version"] = s_saveVersion;
+
+	// galaxy generator
+	m_galaxy->ToJson(jsonObj);
+
+	// game state
+	jsonObj["time"] = DoubleToStr(m_time);
+	jsonObj["state"] = Uint32(m_state);
+
+	jsonObj["want_hyperspace"] = m_wantHyperspace;
+	jsonObj["hyperspace_progress"] = DoubleToStr(m_hyperspaceProgress);
+	jsonObj["hyperspace_duration"] = DoubleToStr(m_hyperspaceDuration);
+	jsonObj["hyperspace_end_time"] = DoubleToStr(m_hyperspaceEndTime);
+
+	// space, all the bodies and things
+	m_space->ToJson(jsonObj);
+	jsonObj["player"] = m_space->GetIndexForBody(m_player.get());
+
+	// hyperspace clouds being brought over from the previous system
+	Json::Value hyperspaceCloudArray(Json::arrayValue); // Create JSON array to contain hyperspace cloud data.
+	for (std::list<HyperspaceCloud*>::const_iterator i = m_hyperspaceClouds.begin(); i != m_hyperspaceClouds.end(); ++i)
+	{
+		Json::Value hyperspaceCloudArrayEl(Json::objectValue); // Create JSON object to contain hyperspace cloud.
+		(*i)->ToJson(hyperspaceCloudArrayEl, m_space.get());
+		hyperspaceCloudArray.append(hyperspaceCloudArrayEl); // Append hyperspace cloud object to array.
+	}
+	jsonObj["hyperspace_clouds"] = hyperspaceCloudArray; // Add hyperspace cloud array to supplied object.
+
+	// system political data (crime etc)
+	Polit::ToJson(jsonObj);
+
+	// views. must be saved in init order
+	m_gameViews->m_cpan->SaveToJson(jsonObj);
+	m_gameViews->m_sectorView->SaveToJson(jsonObj);
+	m_gameViews->m_worldView->SaveToJson(jsonObj);
+
+	// lua
+	Pi::luaSerializer->ToJson(jsonObj);
+
+	// trailing signature
+	jsonObj["trailing_signature"] = s_saveEnd; // Don't really need this anymore.
 
 	Pi::luaSerializer->UninitTableRefs();
 }
@@ -717,6 +849,27 @@ void Game::Views::Load(Serializer::Reader &rd, Game* game)
 	SetRenderer(Pi::renderer);
 }
 
+void Game::Views::LoadFromJson(const Json::Value &jsonObj, Game* game)
+{
+	m_cpan = new ShipCpanel(jsonObj, Pi::renderer, game);
+	m_sectorView = new SectorView(jsonObj, game);
+	m_worldView = new WorldView(jsonObj, game);
+
+	m_galacticView = new GalacticView(game);
+	m_systemView = new SystemView(game);
+	m_systemInfoView = new SystemInfoView(game);
+	m_spaceStationView = new UIView("StationView");
+	m_infoView = new UIView("InfoView");
+	m_deathView = new DeathView(game);
+	m_settingsView = new UIView("SettingsInGame");
+
+#if WITH_OBJECTVIEWER
+	m_objectViewerView = new ObjectViewerView();
+#endif
+
+	SetRenderer(Pi::renderer);
+}
+
 Game::Views::~Views()
 {
 #if WITH_OBJECTVIEWER
@@ -776,6 +929,23 @@ void Game::LoadViews(Serializer::Reader &rd)
 		vector2f(scrSize.x, scrSize.y));
 }
 
+void Game::LoadViewsFromJson(const Json::Value &jsonObj)
+{
+	Pi::SetView(0);
+
+	// XXX views expect Pi::game and Pi::player to exist
+	Pi::game = this;
+	Pi::player = m_player.get();
+
+	m_gameViews.reset(new Views);
+	m_gameViews->LoadFromJson(jsonObj, this);
+
+	UI::Point scrSize = Pi::ui->GetContext()->GetSize();
+	log = new GameLog(
+		Pi::ui->GetContext()->GetFont(UI::Widget::FONT_NORMAL),
+		vector2f(scrSize.x, scrSize.y));
+}
+
 void Game::DestroyViews()
 {
 	Pi::SetView(0);
@@ -803,8 +973,13 @@ Game *Game::LoadGame(const std::string &filename)
 	Output("Game::LoadGame('%s')\n", filename.c_str());
 	auto file = FileSystem::userFiles.ReadFile(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
 	if (!file) throw CouldNotOpenFileException();
-	Serializer::Reader rd(file->AsByteRange());
-	return new Game(rd);
+	//Serializer::Reader rd(file->AsByteRange());
+	//return new Game(rd);
+	Json::Value rootNode; // Create the root JSON value for receiving the game data.
+	Json::Reader jsonReader; // Create reader for parsing the JSON string.
+	jsonReader.parse(file->GetData(), rootNode); // Parse the JSON string.
+	if (!rootNode.isObject()) throw SavedGameCorruptException();
+	return new Game(rootNode); // Decode the game data from JSON and create the game.
 	// file data is freed here
 }
 
@@ -822,15 +997,21 @@ void Game::SaveGame(const std::string &filename, Game *game)
 		throw CouldNotOpenFileException();
 	}
 
-	Serializer::Writer wr;
-	game->Serialize(wr);
+	//Serializer::Writer wr;
+	//game->Serialize(wr);
 
-	const std::string data = wr.GetData();
+	//const std::string data = wr.GetData();
+
+	Json::Value rootNode; // Create the root JSON value for receiving the game data.
+	game->ToJson(rootNode); // Encode the game data as JSON and give to the root value.
+	Json::StyledWriter jsonWriter; // Create writer for writing the JSON data to string.
+	const std::string jsonDataStr = jsonWriter.write(rootNode); // Write the JSON data.
 
 	FILE *f = FileSystem::userFiles.OpenWriteStream(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
 	if (!f) throw CouldNotOpenFileException();
 
-	size_t nwritten = fwrite(data.data(), data.length(), 1, f);
+	//size_t nwritten = fwrite(data.data(), data.length(), 1, f);
+	size_t nwritten = fwrite(jsonDataStr.data(), jsonDataStr.length(), 1, f);
 	fclose(f);
 
 	if (nwritten != 1) throw CouldNotWriteToFileException();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -671,32 +671,6 @@ void Game::Views::Init(Game* game)
 	SetRenderer(Pi::renderer);
 }
 
-void Game::Views::Load(Serializer::Reader &rd, Game* game)
-{
-	Serializer::Reader section = rd.RdSection("ShipCpanel");
-	m_cpan = new ShipCpanel(section, Pi::renderer, game);
-
-	section = rd.RdSection("SectorView");
-	m_sectorView = new SectorView(section, game);
-
-	section = rd.RdSection("WorldView");
-	m_worldView = new WorldView(section, game);
-
-	m_galacticView = new GalacticView(game);
-	m_systemView = new SystemView(game);
-	m_systemInfoView = new SystemInfoView(game);
-	m_spaceStationView = new UIView("StationView");
-	m_infoView = new UIView("InfoView");
-	m_deathView = new DeathView(game);
-	m_settingsView = new UIView("SettingsInGame");
-
-#if WITH_OBJECTVIEWER
-	m_objectViewerView = new ObjectViewerView();
-#endif
-
-	SetRenderer(Pi::renderer);
-}
-
 void Game::Views::LoadFromJson(const Json::Value &jsonObj, Game* game)
 {
 	m_cpan = new ShipCpanel(jsonObj, Pi::renderer, game);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -778,8 +778,6 @@ Game *Game::LoadGame(const std::string &filename)
 	Output("Game::LoadGame('%s')\n", filename.c_str());
 	auto file = FileSystem::userFiles.ReadFile(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
 	if (!file) throw CouldNotOpenFileException();
-	//Serializer::Reader rd(file->AsByteRange());
-	//return new Game(rd);
 	Json::Value rootNode; // Create the root JSON value for receiving the game data.
 	Json::Reader jsonReader; // Create reader for parsing the JSON string.
 	jsonReader.parse(file->GetData(), rootNode); // Parse the JSON string.
@@ -802,11 +800,6 @@ void Game::SaveGame(const std::string &filename, Game *game)
 		throw CouldNotOpenFileException();
 	}
 
-	//Serializer::Writer wr;
-	//game->Serialize(wr);
-
-	//const std::string data = wr.GetData();
-
 	Json::Value rootNode; // Create the root JSON value for receiving the game data.
 	game->ToJson(rootNode); // Encode the game data as JSON and give to the root value.
 	Json::StyledWriter jsonWriter; // Create writer for writing the JSON data to string.
@@ -815,7 +808,6 @@ void Game::SaveGame(const std::string &filename, Game *game)
 	FILE *f = FileSystem::userFiles.OpenWriteStream(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
 	if (!f) throw CouldNotOpenFileException();
 
-	//size_t nwritten = fwrite(data.data(), data.length(), 1, f);
 	size_t nwritten = fwrite(jsonDataStr.data(), jsonDataStr.length(), 1, f);
 	fclose(f);
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -52,11 +52,13 @@ public:
 
 	// load game
 	Game(Serializer::Reader &rd);
+	Game(const Json::Value &jsonObj);
 
 	~Game();
 
 	// save game
 	void Serialize(Serializer::Writer &wr);
+	void ToJson(Json::Value &jsonObj);
 
 	// various game states
 	bool IsNormalSpace() const { return m_state == STATE_NORMAL; }
@@ -130,6 +132,7 @@ private:
 		Views();
 		void Init(Game* game);
 		void Load(Serializer::Reader &rd, Game* game);
+		void LoadFromJson(const Json::Value &jsonObj, Game* game);
 		~Views();
 
 		void SetRenderer(Graphics::Renderer *r);
@@ -151,6 +154,7 @@ private:
 
 	void CreateViews();
 	void LoadViews(Serializer::Reader &rd);
+	void LoadViewsFromJson(const Json::Value &jsonObj);
 	void DestroyViews();
 
 	static void EmitPauseState(bool paused);

--- a/src/Game.h
+++ b/src/Game.h
@@ -129,7 +129,6 @@ private:
 	public:
 		Views();
 		void Init(Game* game);
-		void Load(Serializer::Reader &rd, Game* game);
 		void LoadFromJson(const Json::Value &jsonObj, Game* game);
 		~Views();
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -51,13 +51,11 @@ public:
 	Game(const SystemPath &path, double time = 0.0);
 
 	// load game
-	Game(Serializer::Reader &rd);
 	Game(const Json::Value &jsonObj);
 
 	~Game();
 
 	// save game
-	void Serialize(Serializer::Writer &wr);
 	void ToJson(Json::Value &jsonObj);
 
 	// various game states
@@ -153,7 +151,6 @@ private:
 	};
 
 	void CreateViews();
-	void LoadViews(Serializer::Reader &rd);
 	void LoadViewsFromJson(const Json::Value &jsonObj);
 	void DestroyViews();
 

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -70,17 +70,6 @@ void HyperspaceCloud::SetIsArrival(bool isArrival)
 	SetLabel(isArrival ? Lang::HYPERSPACE_ARRIVAL_CLOUD : Lang::HYPERSPACE_DEPARTURE_CLOUD);
 }
 
-void HyperspaceCloud::Save(Serializer::Writer &wr, Space *space)
-{
-	Body::Save(wr, space);
-	wr.Vector3d(m_vel);
-	wr.Double(m_birthdate);
-	wr.Double(m_due);
-	wr.Bool(m_isArrival);
-	wr.Bool(m_ship != 0);
-	if (m_ship) m_ship->Serialize(wr, space);
-}
-
 void HyperspaceCloud::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	Body::SaveToJson(jsonObj, space);
@@ -99,18 +88,6 @@ void HyperspaceCloud::SaveToJson(Json::Value &jsonObj, Space *space)
 	}
 
 	jsonObj["hyperspace_cloud"] = hyperspaceCloudObj; // Add hyperspace cloud object to supplied object.
-}
-
-void HyperspaceCloud::Load(Serializer::Reader &rd, Space *space)
-{
-	Body::Load(rd, space);
-	m_vel = rd.Vector3d();
-	m_birthdate = rd.Double();
-	m_due = rd.Double();
-	m_isArrival = rd.Bool();
-	if (rd.Bool()) {
-		m_ship = static_cast<Ship*>(Body::Unserialize(rd, space));
-	}
 }
 
 void HyperspaceCloud::LoadFromJson(const Json::Value &jsonObj, Space *space)

--- a/src/HyperspaceCloud.h
+++ b/src/HyperspaceCloud.h
@@ -34,7 +34,9 @@ public:
 	virtual void UpdateInterpTransform(double alpha);
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:
 	void InitGraphics();

--- a/src/HyperspaceCloud.h
+++ b/src/HyperspaceCloud.h
@@ -33,9 +33,7 @@ public:
 	bool IsArrival() const { return m_isArrival; }
 	virtual void UpdateInterpTransform(double alpha);
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:

--- a/src/LuaRef.cpp
+++ b/src/LuaRef.cpp
@@ -82,30 +82,6 @@ void LuaRef::PushCopyToStack() const {
 	lua_remove(m_lua, -2);
 }
 
-void LuaRef::Save(Serializer::Writer &wr)
-{
-	assert(m_lua && m_id != LUA_NOREF);
-
-	LUA_DEBUG_START(m_lua);
-
-	lua_getfield(m_lua, LUA_REGISTRYINDEX, "PiSerializer");
-	LuaSerializer *serializer = static_cast<LuaSerializer*>(lua_touserdata(m_lua, -1));
-	lua_pop(m_lua, 1);
-
-	if (!serializer) {
-		LUA_DEBUG_END(m_lua, 0);
-		return;
-	}
-
-	std::string out;
-	PushCopyToStack();
-	serializer->pickle(m_lua, -1, out);
-	lua_pop(m_lua, 1);
-	wr.String(out);
-
-	LUA_DEBUG_END(m_lua, 0);
-}
-
 void LuaRef::SaveToJson(Json::Value &jsonObj)
 {
 	assert(m_lua && m_id != LUA_NOREF);
@@ -126,42 +102,6 @@ void LuaRef::SaveToJson(Json::Value &jsonObj)
 	serializer->pickle(m_lua, -1, out);
 	lua_pop(m_lua, 1);
 	jsonObj["lua_ref"] = out;
-
-	LUA_DEBUG_END(m_lua, 0);
-}
-
-void LuaRef::Load(Serializer::Reader &rd)
-{
-	std::string pickled = rd.String();
-
-	LUA_DEBUG_START(m_lua);
-
-	lua_getfield(m_lua, LUA_REGISTRYINDEX, "PiSerializer");
-	LuaSerializer *serializer = static_cast<LuaSerializer*>(lua_touserdata(m_lua, -1));
-	lua_pop(m_lua, 1);
-
-	if (!serializer) {
-		LUA_DEBUG_END(m_lua, 0);
-		return;
-	}
-
-	serializer->unpickle(m_lua, pickled.c_str()); // loaded
-	lua_getfield(m_lua, LUA_REGISTRYINDEX, "PiLuaRefLoadTable"); // loaded, reftable
-	lua_pushvalue(m_lua, -2); // loaded, reftable, copy
-	lua_gettable(m_lua, -2);  // loaded, reftable, luaref
-	// Check whether this table has been referenced before
-	if (lua_isnil(m_lua, -1)) {
-		// If not, mark it as referenced
-		*this = LuaRef(m_lua, -3);
-		lua_pushvalue(m_lua, -3);
-		lua_pushlightuserdata(m_lua, this);
-		lua_settable(m_lua, -4);
-	} else {
-		LuaRef *origin = static_cast<LuaRef *>(lua_touserdata(m_lua, -1));
-		*this = *origin;
-	}
-
-	lua_pop(m_lua, 3);
 
 	LUA_DEBUG_END(m_lua, 0);
 }

--- a/src/LuaRef.h
+++ b/src/LuaRef.h
@@ -6,6 +6,7 @@
 
 #include "lua/lua.hpp"
 #include "Serializer.h"
+#include "json/json.h"
 #include <vector>
 #include <cassert>
 
@@ -25,7 +26,9 @@ public:
 	bool IsValid() const { return m_lua && m_id != LUA_NOREF; }
 
 	void Save(Serializer::Writer &wr);
+	void SaveToJson(Json::Value &jsonObj);
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 
 private:
 	lua_State * m_lua;

--- a/src/LuaRef.h
+++ b/src/LuaRef.h
@@ -25,9 +25,7 @@ public:
 
 	bool IsValid() const { return m_lua && m_id != LUA_NOREF; }
 
-	void Save(Serializer::Writer &wr);
 	void SaveToJson(Json::Value &jsonObj);
-	void Load(Serializer::Reader &rd);
 	void LoadFromJson(const Json::Value &jsonObj);
 
 private:

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -12,15 +12,11 @@
 
 class LuaSerializer : public DeleteEmitter {
 	friend class LuaObject<LuaSerializer>;
-	friend void LuaRef::Save(Serializer::Writer &wr);
 	friend void LuaRef::SaveToJson(Json::Value &jsonObj);
-	friend void LuaRef::Load(Serializer::Reader &rd);
 	friend void LuaRef::LoadFromJson(const Json::Value &jsonObj);
 
 public:
-	void Serialize(Serializer::Writer &wr);
 	void ToJson(Json::Value &jsonObj);
-	void Unserialize(Serializer::Reader &rd);
 	void FromJson(const Json::Value &jsonObj);
 
 	void WrLuaRef(LuaRef &ref, Serializer::Writer &wr);

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -13,7 +13,9 @@
 class LuaSerializer : public DeleteEmitter {
 	friend class LuaObject<LuaSerializer>;
 	friend void LuaRef::Save(Serializer::Writer &wr);
+	friend void LuaRef::SaveToJson(Json::Value &jsonObj);
 	friend void LuaRef::Load(Serializer::Reader &rd);
+	friend void LuaRef::LoadFromJson(const Json::Value &jsonObj);
 
 public:
 	void Serialize(Serializer::Writer &wr);

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -19,7 +19,9 @@ class LuaSerializer : public DeleteEmitter {
 
 public:
 	void Serialize(Serializer::Writer &wr);
+	void ToJson(Json::Value &jsonObj);
 	void Unserialize(Serializer::Reader &rd);
+	void FromJson(const Json::Value &jsonObj);
 
 	void WrLuaRef(LuaRef &ref, Serializer::Writer &wr);
 	void RdLuaRef(LuaRef &ref, Serializer::Reader &rd);

--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -48,12 +48,41 @@ void Missile::Save(Serializer::Writer &wr, Space *space)
 	wr.Bool(m_armed);
 }
 
+void Missile::SaveToJson(Json::Value &jsonObj, Space *space)
+{
+	Ship::SaveToJson(jsonObj, space);
+
+	Json::Value missileObj(Json::objectValue); // Create JSON object to contain missile data.
+
+	missileObj["index_for_body"] = space->GetIndexForBody(m_owner);
+	missileObj["power"] = m_power;
+	missileObj["armed"] = m_armed;
+
+	jsonObj["missile"] = missileObj; // Add missile object to supplied object.
+}
+
 void Missile::Load(Serializer::Reader &rd, Space *space)
 {
 	Ship::Load(rd, space);
 	m_ownerIndex = rd.Int32();
 	m_power = rd.Int32();
 	m_armed = rd.Bool();
+}
+
+void Missile::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	Ship::LoadFromJson(jsonObj, space);
+
+	if (!jsonObj.isMember("missile")) throw SavedGameCorruptException();
+	Json::Value missileObj = jsonObj["missile"];
+
+	if (!missileObj.isMember("index_for_body")) throw SavedGameCorruptException();
+	if (!missileObj.isMember("power")) throw SavedGameCorruptException();
+	if (!missileObj.isMember("armed")) throw SavedGameCorruptException();
+
+	m_ownerIndex = missileObj["index_for_body"].asUInt();
+	m_power = missileObj["power"].asInt();
+	m_armed = missileObj["armed"].asBool();
 }
 
 void Missile::TimeStepUpdate(const float timeStep)

--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -40,14 +40,6 @@ void Missile::PostLoadFixup(Space *space)
 	m_owner = space->GetBodyByIndex(m_ownerIndex);
 }
 
-void Missile::Save(Serializer::Writer &wr, Space *space)
-{
-	Ship::Save(wr, space);
-	wr.Int32(space->GetIndexForBody(m_owner));
-	wr.Int32(m_power);
-	wr.Bool(m_armed);
-}
-
 void Missile::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	Ship::SaveToJson(jsonObj, space);
@@ -59,14 +51,6 @@ void Missile::SaveToJson(Json::Value &jsonObj, Space *space)
 	missileObj["armed"] = m_armed;
 
 	jsonObj["missile"] = missileObj; // Add missile object to supplied object.
-}
-
-void Missile::Load(Serializer::Reader &rd, Space *space)
-{
-	Ship::Load(rd, space);
-	m_ownerIndex = rd.Int32();
-	m_power = rd.Int32();
-	m_armed = rd.Bool();
 }
 
 void Missile::LoadFromJson(const Json::Value &jsonObj, Space *space)

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -27,7 +27,9 @@ public:
 
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 private:
 	void Explode();
 

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -26,9 +26,7 @@ public:
 	void Disarm();
 
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 private:
 	void Explode();

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -78,16 +78,6 @@ ModelBody::~ModelBody()
 	delete m_model;
 }
 
-void ModelBody::Save(Serializer::Writer &wr, Space *space)
-{
-	Body::Save(wr, space);
-	wr.Bool(m_isStatic);
-	wr.Bool(m_colliding);
-	wr.String(m_modelName);
-	m_model->Save(wr);
-	m_shields->Save(wr);
-}
-
 void ModelBody::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	Body::SaveToJson(jsonObj, space);
@@ -101,16 +91,6 @@ void ModelBody::SaveToJson(Json::Value &jsonObj, Space *space)
 	m_shields->SaveToJson(modelBodyObj);
 
 	jsonObj["model_body"] = modelBodyObj; // Add model body object to supplied object.
-}
-
-void ModelBody::Load(Serializer::Reader &rd, Space *space)
-{
-	Body::Load(rd, space);
-	m_isStatic = rd.Bool();
-	m_colliding = rd.Bool();
-	SetModel(rd.String().c_str());
-	m_model->Load(rd);
-	m_shields->Load(rd);
 }
 
 void ModelBody::SetStatic(bool isStatic)

--- a/src/ModelBody.h
+++ b/src/ModelBody.h
@@ -40,9 +40,7 @@ public:
 	virtual void TimeStepUpdate(const float timeStep);
 
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 	void SetLighting(Graphics::Renderer *r, const Camera *camera, std::vector<Graphics::Light> &oldLights, Color &oldAmbient);

--- a/src/ModelBody.h
+++ b/src/ModelBody.h
@@ -41,7 +41,9 @@ public:
 
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 	void SetLighting(Graphics::Renderer *r, const Camera *camera, std::vector<Graphics::Light> &oldLights, Color &oldAmbient);
 	void ResetLighting(Graphics::Renderer *r, const std::vector<Graphics::Light> &oldLights, const Color &oldAmbient);

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -125,15 +125,6 @@ NavLights::~NavLights()
 {
 }
 
-void NavLights::Save(Serializer::Writer &wr)
-{
-	wr.Float(m_time);
-	wr.Bool(m_enabled);
-
-	for (LightIterator it = m_lights.begin(); it != m_lights.end(); ++it)
-		wr.Byte(it->color);
-}
-
 void NavLights::SaveToJson(Json::Value &jsonObj)
 {
 	Json::Value navLightsObj(Json::objectValue); // Create JSON object to contain nav lights data.
@@ -147,18 +138,6 @@ void NavLights::SaveToJson(Json::Value &jsonObj)
 	navLightsObj["lights"] = lightsArray; // Add lights array to nav lights object.
 
 	jsonObj["nav_lights"] = navLightsObj; // Add nav lights object to supplied object.
-}
-
-void NavLights::Load(Serializer::Reader &rd)
-{
-	m_time    = rd.Float();
-	m_enabled = rd.Bool();
-
-	RefCountedPtr<Graphics::Material> mat;
-	for (LightIterator it = m_lights.begin(); it != m_lights.end(); ++it) {
-		Uint8 c = rd.Byte();
-		it->billboard->SetMaterial(get_material(c));
-	}
 }
 
 void NavLights::LoadFromJson(const Json::Value &jsonObj)

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -134,6 +134,21 @@ void NavLights::Save(Serializer::Writer &wr)
 		wr.Byte(it->color);
 }
 
+void NavLights::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value navLightsObj(Json::objectValue); // Create JSON object to contain nav lights data.
+
+	navLightsObj["time"] = FloatToStr(m_time);
+	navLightsObj["enabled"] = m_enabled;
+
+	Json::Value lightsArray(Json::arrayValue); // Create JSON array to contain lights data.
+	for (LightIterator it = m_lights.begin(); it != m_lights.end(); ++it)
+		lightsArray.append(it->color);
+	navLightsObj["lights"] = lightsArray; // Add lights array to nav lights object.
+
+	jsonObj["nav_lights"] = navLightsObj; // Add nav lights object to supplied object.
+}
+
 void NavLights::Load(Serializer::Reader &rd)
 {
 	m_time    = rd.Float();
@@ -142,6 +157,30 @@ void NavLights::Load(Serializer::Reader &rd)
 	RefCountedPtr<Graphics::Material> mat;
 	for (LightIterator it = m_lights.begin(); it != m_lights.end(); ++it) {
 		Uint8 c = rd.Byte();
+		it->billboard->SetMaterial(get_material(c));
+	}
+}
+
+void NavLights::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("nav_lights")) throw SavedGameCorruptException();
+	Json::Value navLightsObj = jsonObj["nav_lights"];
+
+	if (!navLightsObj.isMember("time")) throw SavedGameCorruptException();
+	if (!navLightsObj.isMember("enabled")) throw SavedGameCorruptException();
+	if (!navLightsObj.isMember("lights")) throw SavedGameCorruptException();
+
+	m_time = StrToFloat(navLightsObj["time"].asString());
+	m_enabled = navLightsObj["enabled"].asBool();
+
+	Json::Value lightsArray = navLightsObj["lights"];
+	if (!lightsArray.isArray()) throw SavedGameCorruptException();
+	RefCountedPtr<Graphics::Material> mat;
+	assert(m_lights.size() == lightsArray.size());
+	unsigned int arrayIndex = 0;
+	for (LightIterator it = m_lights.begin(); it != m_lights.end(); ++it)
+	{
+		Uint8 c = lightsArray[arrayIndex++].asUInt();
 		it->billboard->SetMaterial(get_material(c));
 	}
 }

--- a/src/NavLights.h
+++ b/src/NavLights.h
@@ -34,7 +34,9 @@ public:
 	NavLights(SceneGraph::Model*, float period = 2.f);
 	virtual ~NavLights();
 	virtual void Save(Serializer::Writer &wr);
+	virtual void SaveToJson(Json::Value &jsonObj);
 	virtual void Load(Serializer::Reader &rd);
+	virtual void LoadFromJson(const Json::Value &jsonObj);
 
 	void SetEnabled(bool on) { m_enabled = on; }
 	void Update(float time);

--- a/src/NavLights.h
+++ b/src/NavLights.h
@@ -33,9 +33,7 @@ public:
 
 	NavLights(SceneGraph::Model*, float period = 2.f);
 	virtual ~NavLights();
-	virtual void Save(Serializer::Writer &wr);
 	virtual void SaveToJson(Json::Value &jsonObj);
-	virtual void Load(Serializer::Reader &rd);
 	virtual void LoadFromJson(const Json::Value &jsonObj);
 
 	void SetEnabled(bool on) { m_enabled = on; }

--- a/src/NavLights.h
+++ b/src/NavLights.h
@@ -8,6 +8,7 @@
  */
 #include "libs.h"
 #include "Serializer.h"
+#include "json/json.h"
 
 namespace Graphics { class Renderer; }
 namespace SceneGraph { class Model; class Billboard; }

--- a/src/PersistSystemData.h
+++ b/src/PersistSystemData.h
@@ -29,12 +29,37 @@ public:
 			wr.Auto((*i).second);
 		}
 	}
+	void ToJson(Json::Value &jsonObj) const {
+		Json::Value dictArray(Json::arrayValue); // Create JSON array to contain dict data.
+		for (typename std::map<SystemPath, T>::const_iterator i = m_dict.begin(); i != m_dict.end(); ++i)
+		{
+			Json::Value dictArrayEl(Json::objectValue); // Create JSON object to contain dict element.
+			(*i).first.ToJson(dictArrayEl);
+			dictArrayEl["value"] = AutoToStr((*i).second);
+			dictArray.append(dictArrayEl); // Append dict object to array.
+		}
+		jsonObj["dict"] = dictArray; // Add dict array to supplied object.
+	}
 	static void Unserialize(Serializer::Reader &rd, PersistSystemData<T> *pd) {
 		int num = rd.Int32();
 		while (num-- > 0) {
 			SystemPath path = SystemPath::Unserialize(rd);
 			T val;
 			rd.Auto(&val);
+			pd->m_dict[path] = val;
+		}
+	}
+	static void FromJson(const Json::Value &jsonObj, PersistSystemData<T> *pd) {
+		if (!jsonObj.isMember("dict")) throw SavedGameCorruptException();
+		Json::Value dictArray = jsonObj["dict"];
+		if (!dictArray.isArray()) throw SavedGameCorruptException();
+		for (unsigned int arrayIndex = 0; arrayIndex < dictArray.size(); ++arrayIndex)
+		{
+			Json::Value dictArrayEl = dictArray[arrayIndex];
+			if (!dictArrayEl.isMember("value")) throw SavedGameCorruptException();
+			SystemPath path = SystemPath::FromJson(dictArrayEl);
+			T val;
+			StrToAuto(&val, dictArrayEl["value"].asString());
 			pd->m_dict[path] = val;
 		}
 	}

--- a/src/PersistSystemData.h
+++ b/src/PersistSystemData.h
@@ -22,13 +22,6 @@ public:
 	void Set(const SystemPath &path, T val) {
 		m_dict[path.SystemOnly()] = val;
 	}
-	void Serialize(Serializer::Writer &wr) const {
-		wr.Int32(m_dict.size());
-		for (typename std::map<SystemPath, T>::const_iterator i = m_dict.begin(); i != m_dict.end(); ++i) {
-			(*i).first.Serialize(wr);
-			wr.Auto((*i).second);
-		}
-	}
 	void ToJson(Json::Value &jsonObj) const {
 		Json::Value dictArray(Json::arrayValue); // Create JSON array to contain dict data.
 		for (typename std::map<SystemPath, T>::const_iterator i = m_dict.begin(); i != m_dict.end(); ++i)
@@ -39,15 +32,6 @@ public:
 			dictArray.append(dictArrayEl); // Append dict object to array.
 		}
 		jsonObj["dict"] = dictArray; // Add dict array to supplied object.
-	}
-	static void Unserialize(Serializer::Reader &rd, PersistSystemData<T> *pd) {
-		int num = rd.Int32();
-		while (num-- > 0) {
-			SystemPath path = SystemPath::Unserialize(rd);
-			T val;
-			rd.Auto(&val);
-			pd->m_dict[path] = val;
-		}
 	}
 	static void FromJson(const Json::Value &jsonObj, PersistSystemData<T> *pd) {
 		if (!jsonObj.isMember("dict")) throw SavedGameCorruptException();

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -49,6 +49,15 @@ void Planet::Load(Serializer::Reader &rd, Space *space)
 	InitParams(sbody);
 }
 
+void Planet::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	TerrainBody::LoadFromJson(jsonObj, space);
+
+	const SystemBody *sbody = GetSystemBody();
+	assert(sbody);
+	InitParams(sbody);
+}
+
 void Planet::InitParams(const SystemBody *sbody)
 {
 	double specificHeatCp;

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -40,15 +40,6 @@ Planet::Planet(SystemBody *sbody)
 	InitParams(sbody);
 }
 
-void Planet::Load(Serializer::Reader &rd, Space *space)
-{
-	TerrainBody::Load(rd, space);
-
-	const SystemBody *sbody = GetSystemBody();
-	assert(sbody);
-	InitParams(sbody);
-}
-
 void Planet::LoadFromJson(const Json::Value &jsonObj, Space *space)
 {
 	TerrainBody::LoadFromJson(jsonObj, space);

--- a/src/Planet.h
+++ b/src/Planet.h
@@ -31,7 +31,6 @@ public:
 #endif
 
 protected:
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:

--- a/src/Planet.h
+++ b/src/Planet.h
@@ -32,6 +32,7 @@ public:
 
 protected:
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:
 	void InitParams(const SystemBody*);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -51,15 +51,15 @@ void Player::SetShipType(const ShipType::Id &shipId) {
 	InitCockpit();
 }
 
-void Player::Save(Serializer::Writer &wr, Space *space)
+void Player::SaveToJson(Json::Value &jsonObj, Space *space)
 {
-	Ship::Save(wr, space);
+	Ship::SaveToJson(jsonObj, space);
 }
 
-void Player::Load(Serializer::Reader &rd, Space *space)
+void Player::LoadFromJson(const Json::Value &jsonObj, Space *space)
 {
 	Pi::player = this;
-	Ship::Load(rd, space);
+	Ship::LoadFromJson(jsonObj, space);
 	InitCockpit();
 	registerEquipChangeListener(this);
 }

--- a/src/Player.h
+++ b/src/Player.h
@@ -48,8 +48,8 @@ public:
 	sigc::signal<void> onChangeEquipment;
 
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 	virtual void OnEnterSystem();
 	virtual void OnEnterHyperspace();

--- a/src/Polit.cpp
+++ b/src/Polit.cpp
@@ -88,17 +88,6 @@ void Init(RefCountedPtr<Galaxy> galaxy)
 	s_playerPerBlocCrimeRecord.resize( numFactions );
 }
 
-void Serialize(Serializer::Writer &wr)
-{
-	s_criminalRecord.Serialize(wr);
-	s_outstandingFine.Serialize(wr);
-	wr.Int32(s_playerPerBlocCrimeRecord.size());
-	for (Uint32 i=0; i < s_playerPerBlocCrimeRecord.size(); i++) {
-		wr.Int64(s_playerPerBlocCrimeRecord[i].record);
-		wr.Int64(s_playerPerBlocCrimeRecord[i].fine);
-	}
-}
-
 void ToJson(Json::Value &jsonObj)
 {
 	Json::Value politObj(Json::objectValue); // Create JSON object to contain polit data.
@@ -122,19 +111,6 @@ void ToJson(Json::Value &jsonObj)
 	politObj["crime_record"] = crimeRecordArray; // Add crime record array to polit object.
 
 	jsonObj["polit"] = politObj; // Add polit object to supplied object.
-}
-
-void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy)
-{
-	Init(galaxy);
-	PersistSystemData<Sint64>::Unserialize(rd, &s_criminalRecord);
-	PersistSystemData<Sint64>::Unserialize(rd, &s_outstandingFine);
-	const Uint32 numFactions = rd.Int32();
-	assert(s_playerPerBlocCrimeRecord.size() == numFactions);
-	for (Uint32 i=0; i < numFactions; i++) {
-		s_playerPerBlocCrimeRecord[i].record = rd.Int64();
-		s_playerPerBlocCrimeRecord[i].fine = rd.Int64();
-	}
 }
 
 void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)

--- a/src/Polit.cpp
+++ b/src/Polit.cpp
@@ -99,6 +99,31 @@ void Serialize(Serializer::Writer &wr)
 	}
 }
 
+void ToJson(Json::Value &jsonObj)
+{
+	Json::Value politObj(Json::objectValue); // Create JSON object to contain polit data.
+
+	Json::Value criminalRecordObj(Json::objectValue); // Create JSON object to contain criminal record data.
+	s_criminalRecord.ToJson(criminalRecordObj);
+	politObj["criminal_record"] = criminalRecordObj; // Add criminal record object to polit object.
+
+	Json::Value outstandingFineObj(Json::objectValue); // Create JSON object to contain outstanding fine data.
+	s_outstandingFine.ToJson(outstandingFineObj);
+	politObj["outstanding_fine"] = outstandingFineObj; // Add outstanding fine object to polit object.
+
+	Json::Value crimeRecordArray(Json::arrayValue); // Create JSON array to contain crime record data.
+	for (Uint32 i = 0; i < s_playerPerBlocCrimeRecord.size(); i++)
+	{
+		Json::Value crimeRecordArrayEl(Json::objectValue); // Create JSON object to contain crime record element.
+		crimeRecordArrayEl["record"] = SInt64ToStr(s_playerPerBlocCrimeRecord[i].record);
+		crimeRecordArrayEl["fine"] = SInt64ToStr(s_playerPerBlocCrimeRecord[i].fine);
+		crimeRecordArray.append(crimeRecordArrayEl); // Append crime record object to array.
+	}
+	politObj["crime_record"] = crimeRecordArray; // Add crime record array to polit object.
+
+	jsonObj["polit"] = politObj; // Add polit object to supplied object.
+}
+
 void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy)
 {
 	Init(galaxy);
@@ -109,6 +134,36 @@ void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy)
 	for (Uint32 i=0; i < numFactions; i++) {
 		s_playerPerBlocCrimeRecord[i].record = rd.Int64();
 		s_playerPerBlocCrimeRecord[i].fine = rd.Int64();
+	}
+}
+
+void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)
+{
+	Init(galaxy);
+
+	if (!jsonObj.isMember("polit")) throw SavedGameCorruptException();
+	Json::Value politObj = jsonObj["polit"];
+
+	if (!politObj.isMember("criminal_record")) throw SavedGameCorruptException();
+	if (!politObj.isMember("outstanding_fine")) throw SavedGameCorruptException();
+	if (!politObj.isMember("crime_record")) throw SavedGameCorruptException();
+
+	Json::Value criminalRecordObj = politObj["criminal_record"];
+	PersistSystemData<Sint64>::FromJson(criminalRecordObj, &s_criminalRecord);
+
+	Json::Value outstandingFineObj = politObj["outstanding_fine"];
+	PersistSystemData<Sint64>::FromJson(outstandingFineObj, &s_outstandingFine);
+
+	Json::Value crimeRecordArray = politObj["crime_record"];
+	if (!crimeRecordArray.isArray()) throw SavedGameCorruptException();
+	assert(s_playerPerBlocCrimeRecord.size() == crimeRecordArray.size());
+	for (Uint32 i = 0; i < s_playerPerBlocCrimeRecord.size(); i++)
+	{
+		Json::Value crimeRecordArrayEl = crimeRecordArray[i];
+		if (!crimeRecordArrayEl.isMember("record")) throw SavedGameCorruptException();
+		if (!crimeRecordArrayEl.isMember("fine")) throw SavedGameCorruptException();
+		s_playerPerBlocCrimeRecord[i].record = StrToSInt64(crimeRecordArrayEl["record"].asString());
+		s_playerPerBlocCrimeRecord[i].fine = StrToSInt64(crimeRecordArrayEl["fine"].asString());
 	}
 }
 

--- a/src/Polit.h
+++ b/src/Polit.h
@@ -55,9 +55,7 @@ namespace Polit {
 
 	void NotifyOfCrime(Ship *s, enum Crime c);
 	void Init(RefCountedPtr<Galaxy> galaxy);
-	void Serialize(Serializer::Writer &wr);
 	void ToJson(Json::Value &jsonObj);
-	void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy);
 	void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
 	void AddCrime(Sint64 crimeBitset, Sint64 addFine);
 	void GetCrime(Sint64 *crimeBitset, Sint64 *fine);

--- a/src/Polit.h
+++ b/src/Polit.h
@@ -6,6 +6,7 @@
 
 #include "galaxy/Economy.h"
 #include "Serializer.h"
+#include "json/json.h"
 
 class Galaxy;
 class StarSystem;
@@ -55,7 +56,9 @@ namespace Polit {
 	void NotifyOfCrime(Ship *s, enum Crime c);
 	void Init(RefCountedPtr<Galaxy> galaxy);
 	void Serialize(Serializer::Writer &wr);
+	void ToJson(Json::Value &jsonObj);
 	void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy);
+	void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
 	void AddCrime(Sint64 crimeBitset, Sint64 addFine);
 	void GetCrime(Sint64 *crimeBitset, Sint64 *fine);
 	fixed GetBaseLawlessness(GovType gov);

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -126,21 +126,6 @@ Projectile::~Projectile()
 {
 }
 
-void Projectile::Save(Serializer::Writer &wr, Space *space)
-{
-	Body::Save(wr, space);
-	wr.Vector3d(m_baseVel);
-	wr.Vector3d(m_dirVel);
-	wr.Float(m_age);
-	wr.Float(m_lifespan);
-	wr.Float(m_baseDam);
-	wr.Float(m_length);
-	wr.Float(m_width);
-	wr.Bool(m_mining);
-	wr.Color4UB(m_color);
-	wr.Int32(space->GetIndexForBody(m_parent));
-}
-
 void Projectile::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	Body::SaveToJson(jsonObj, space);
@@ -159,21 +144,6 @@ void Projectile::SaveToJson(Json::Value &jsonObj, Space *space)
 	projectileObj["index_for_body"] = space->GetIndexForBody(m_parent);
 
 	jsonObj["projectile"] = projectileObj; // Add projectile object to supplied object.
-}
-
-void Projectile::Load(Serializer::Reader &rd, Space *space)
-{
-	Body::Load(rd, space);
-	m_baseVel = rd.Vector3d();
-	m_dirVel = rd.Vector3d();
-	m_age = rd.Float();
-	m_lifespan = rd.Float();
-	m_baseDam = rd.Float();
-	m_length = rd.Float();
-	m_width = rd.Float();
-	m_mining = rd.Bool();
-	m_color = rd.Color4UB();
-	m_parentIndex = rd.Int32();
 }
 
 void Projectile::LoadFromJson(const Json::Value &jsonObj, Space *space)

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -22,6 +22,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
 #include "graphics/TextureBuilder.h"
+#include "json/JsonUtils.h"
 
 std::unique_ptr<Graphics::VertexArray> Projectile::s_sideVerts;
 std::unique_ptr<Graphics::VertexArray> Projectile::s_glowVerts;
@@ -140,6 +141,26 @@ void Projectile::Save(Serializer::Writer &wr, Space *space)
 	wr.Int32(space->GetIndexForBody(m_parent));
 }
 
+void Projectile::SaveToJson(Json::Value &jsonObj, Space *space)
+{
+	Body::SaveToJson(jsonObj, space);
+
+	Json::Value projectileObj(Json::objectValue); // Create JSON object to contain projectile data.
+
+	VectorToJson(projectileObj, m_baseVel, "base_vel");
+	VectorToJson(projectileObj, m_dirVel, "dir_vel");
+	projectileObj["age"] = FloatToStr(m_age);
+	projectileObj["life_span"] = FloatToStr(m_lifespan);
+	projectileObj["base_dam"] = FloatToStr(m_baseDam);
+	projectileObj["length"] = FloatToStr(m_length);
+	projectileObj["width"] = FloatToStr(m_width);
+	projectileObj["mining"] = m_mining;
+	ColorToJson(projectileObj, m_color, "color");
+	projectileObj["index_for_body"] = space->GetIndexForBody(m_parent);
+
+	jsonObj["projectile"] = projectileObj; // Add projectile object to supplied object.
+}
+
 void Projectile::Load(Serializer::Reader &rd, Space *space)
 {
 	Body::Load(rd, space);
@@ -153,6 +174,36 @@ void Projectile::Load(Serializer::Reader &rd, Space *space)
 	m_mining = rd.Bool();
 	m_color = rd.Color4UB();
 	m_parentIndex = rd.Int32();
+}
+
+void Projectile::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	Body::LoadFromJson(jsonObj, space);
+
+	if (!jsonObj.isMember("projectile")) throw SavedGameCorruptException();
+	Json::Value projectileObj = jsonObj["projectile"];
+
+	if (!projectileObj.isMember("base_vel")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("dir_vel")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("age")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("life_span")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("base_dam")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("length")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("width")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("mining")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("color")) throw SavedGameCorruptException();
+	if (!projectileObj.isMember("index_for_body")) throw SavedGameCorruptException();
+
+	JsonToVector(&m_baseVel, projectileObj, "base_vel");
+	JsonToVector(&m_dirVel, projectileObj, "dir_vel");
+	m_age = StrToFloat(projectileObj["age"].asString());
+	m_lifespan = StrToFloat(projectileObj["life_span"].asString());
+	m_baseDam = StrToFloat(projectileObj["base_dam"].asString());
+	m_length = StrToFloat(projectileObj["length"].asString());
+	m_width = StrToFloat(projectileObj["width"].asString());
+	m_mining = projectileObj["mining"].asBool();
+	JsonToColor(&m_color, projectileObj, "color");
+	m_parentIndex = projectileObj["index_for_body"].asInt();
 }
 
 void Projectile::PostLoadFixup(Space *space)

--- a/src/Projectile.h
+++ b/src/Projectile.h
@@ -33,9 +33,7 @@ public:
 	static void FreeModel();
 
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:

--- a/src/Projectile.h
+++ b/src/Projectile.h
@@ -34,7 +34,10 @@ public:
 
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+
 private:
 	float GetDamage() const;
 	double GetRadius() const;

--- a/src/PropertyMap.cpp
+++ b/src/PropertyMap.cpp
@@ -34,8 +34,17 @@ void PropertyMap::Save(Serializer::Writer &wr)
 	m_table.Save(wr);
 }
 
+void PropertyMap::SaveToJson(Json::Value &jsonObj)
+{
+	m_table.SaveToJson(jsonObj);
+}
 
 void PropertyMap::Load(Serializer::Reader &rd)
 {
 	m_table.Load(rd);
+}
+
+void PropertyMap::LoadFromJson(const Json::Value &jsonObj)
+{
+	m_table.LoadFromJson(jsonObj);
 }

--- a/src/PropertyMap.cpp
+++ b/src/PropertyMap.cpp
@@ -29,19 +29,9 @@ void PropertyMap::PushLuaTable()
 	m_table.PushCopyToStack();
 }
 
-void PropertyMap::Save(Serializer::Writer &wr)
-{
-	m_table.Save(wr);
-}
-
 void PropertyMap::SaveToJson(Json::Value &jsonObj)
 {
 	m_table.SaveToJson(jsonObj);
-}
-
-void PropertyMap::Load(Serializer::Reader &rd)
-{
-	m_table.Load(rd);
 }
 
 void PropertyMap::LoadFromJson(const Json::Value &jsonObj)

--- a/src/PropertyMap.h
+++ b/src/PropertyMap.h
@@ -32,7 +32,9 @@ public:
 	}
 
 	void Save(Serializer::Writer &wr);
+	void SaveToJson(Json::Value &jsonObj);
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 
 private:
 	LuaRef m_table;

--- a/src/PropertyMap.h
+++ b/src/PropertyMap.h
@@ -31,9 +31,7 @@ public:
 		return m_signals[k].connect(fn);
 	}
 
-	void Save(Serializer::Writer &wr);
 	void SaveToJson(Json::Value &jsonObj);
-	void Load(Serializer::Reader &rd);
 	void LoadFromJson(const Json::Value &jsonObj);
 
 private:

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -76,30 +76,6 @@ SectorView::SectorView(Game* game) : UIView(), m_game(game), m_galaxy(game->GetG
 	InitObject();
 }
 
-SectorView::SectorView(Serializer::Reader &rd, Game* game) : UIView(), m_game(game), m_galaxy(game->GetGalaxy())
-{
-	InitDefaults();
-
-	m_pos.x = m_posMovingTo.x = rd.Float();
-	m_pos.y = m_posMovingTo.y = rd.Float();
-	m_pos.z = m_posMovingTo.z = rd.Float();
-	m_rotX = m_rotXMovingTo = rd.Float();
-	m_rotZ = m_rotZMovingTo = rd.Float();
-	m_zoom = m_zoomMovingTo = rd.Float();
-	// XXX I have no idea if this is correct,
-	// I just copied it from the one other place m_zoomClamped is set
-	m_zoomClamped = Clamp(m_zoom, 1.f, FAR_LIMIT);
-	m_inSystem = rd.Bool();
-	m_current = SystemPath::Unserialize(rd);
-	m_selected = SystemPath::Unserialize(rd);
-	m_hyperspaceTarget = SystemPath::Unserialize(rd);
-	m_matchTargetToSelection = rd.Bool();
-	m_automaticSystemSelection = rd.Bool();
-	m_detailBoxVisible = rd.Byte();
-
-	InitObject();
-}
-
 SectorView::SectorView(const Json::Value &jsonObj, Game* game) : UIView(), m_game(game), m_galaxy(game->GetGalaxy())
 {
 	InitDefaults();
@@ -387,23 +363,6 @@ SectorView::~SectorView()
 {
 	m_onMouseWheelCon.disconnect();
 	if (m_onKeyPressConnection.connected()) m_onKeyPressConnection.disconnect();
-}
-
-void SectorView::Save(Serializer::Writer &wr)
-{
-	wr.Float(m_pos.x);
-	wr.Float(m_pos.y);
-	wr.Float(m_pos.z);
-	wr.Float(m_rotX);
-	wr.Float(m_rotZ);
-	wr.Float(m_zoom);
-	wr.Bool(m_inSystem);
-	m_current.Serialize(wr);
-	m_selected.Serialize(wr);
-	m_hyperspaceTarget.Serialize(wr);
-	wr.Bool(m_matchTargetToSelection);
-	wr.Bool(m_automaticSystemSelection);
-	wr.Byte(m_detailBoxVisible);
 }
 
 void SectorView::SaveToJson(Json::Value &jsonObj)

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -100,6 +100,47 @@ SectorView::SectorView(Serializer::Reader &rd, Game* game) : UIView(), m_game(ga
 	InitObject();
 }
 
+SectorView::SectorView(const Json::Value &jsonObj, Game* game) : UIView(), m_game(game), m_galaxy(game->GetGalaxy())
+{
+	InitDefaults();
+
+	if (!jsonObj.isMember("sector_view")) throw SavedGameCorruptException();
+	Json::Value sectorViewObj = jsonObj["sector_view"];
+
+	if (!sectorViewObj.isMember("pos_x")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("pos_y")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("pos_z")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("rot_x")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("rot_z")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("zoom")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("in_system")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("current")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("selected")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("hyperspace")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("match_target_to_selection")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("automatic_system_selection")) throw SavedGameCorruptException();
+	if (!sectorViewObj.isMember("detail_box_visible")) throw SavedGameCorruptException();
+
+	m_pos.x = m_posMovingTo.x = StrToFloat(sectorViewObj["pos_x"].asString());
+	m_pos.y = m_posMovingTo.y = StrToFloat(sectorViewObj["pos_y"].asString());
+	m_pos.z = m_posMovingTo.z = StrToFloat(sectorViewObj["pos_z"].asString());
+	m_rotX = m_rotXMovingTo = StrToFloat(sectorViewObj["rot_x"].asString());
+	m_rotZ = m_rotZMovingTo = StrToFloat(sectorViewObj["rot_z"].asString());
+	m_zoom = m_zoomMovingTo = StrToFloat(sectorViewObj["zoom"].asString());
+	// XXX I have no idea if this is correct,
+	// I just copied it from the one other place m_zoomClamped is set
+	m_zoomClamped = Clamp(m_zoom, 1.f, FAR_LIMIT);
+	m_inSystem = sectorViewObj["in_system"].asBool();
+	m_current = SystemPath::FromJson(sectorViewObj["current"]);
+	m_selected = SystemPath::FromJson(sectorViewObj["selected"]);
+	m_hyperspaceTarget = SystemPath::FromJson(sectorViewObj["hyperspace"]);
+	m_matchTargetToSelection = sectorViewObj["match_target_to_selection"].asBool();
+	m_automaticSystemSelection = sectorViewObj["automatic_system_selection"].asBool();
+	m_detailBoxVisible = sectorViewObj["detail_box_visible"].asUInt();
+
+	InitObject();
+}
+
 void SectorView::InitDefaults()
 {
 	m_rotXDefault = Pi::config->Float("SectorViewXRotation");
@@ -363,6 +404,37 @@ void SectorView::Save(Serializer::Writer &wr)
 	wr.Bool(m_matchTargetToSelection);
 	wr.Bool(m_automaticSystemSelection);
 	wr.Byte(m_detailBoxVisible);
+}
+
+void SectorView::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value sectorViewObj(Json::objectValue); // Create JSON object to contain sector view data.
+
+	sectorViewObj["pos_x"] = FloatToStr(m_pos.x);
+	sectorViewObj["pos_y"] = FloatToStr(m_pos.y);
+	sectorViewObj["pos_z"] = FloatToStr(m_pos.z);
+	sectorViewObj["rot_x"] = FloatToStr(m_rotX);
+	sectorViewObj["rot_z"] = FloatToStr(m_rotZ);
+	sectorViewObj["zoom"] = FloatToStr(m_zoom);
+	sectorViewObj["in_system"] = m_inSystem;
+
+	Json::Value currentSystemObj(Json::objectValue); // Create JSON object to contain current system data.
+	m_current.ToJson(currentSystemObj);
+	sectorViewObj["current"] = currentSystemObj; // Add current system object to sector view object.
+
+	Json::Value selectedSystemObj(Json::objectValue); // Create JSON object to contain selected system data.
+	m_selected.ToJson(selectedSystemObj);
+	sectorViewObj["selected"] = selectedSystemObj; // Add selected system object to sector view object.
+
+	Json::Value hyperspaceSystemObj(Json::objectValue); // Create JSON object to contain hyperspace system data.
+	m_hyperspaceTarget.ToJson(hyperspaceSystemObj);
+	sectorViewObj["hyperspace"] = hyperspaceSystemObj; // Add hyperspace system object to sector view object.
+
+	sectorViewObj["match_target_to_selection"] = m_matchTargetToSelection;
+	sectorViewObj["automatic_system_selection"] = m_automaticSystemSelection;
+	sectorViewObj["detail_box_visible"] = m_detailBoxVisible;
+
+	jsonObj["sector_view"] = sectorViewObj; // Add sector view object to supplied object.
 }
 
 void SectorView::OnSearchBoxKeyPress(const SDL_Keysym *keysym)

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -23,7 +23,6 @@ class Galaxy;
 class SectorView: public UIView {
 public:
 	SectorView(Game* game);
-	SectorView(Serializer::Reader &rd, Game* game);
 	SectorView(const Json::Value &jsonObj, Game* game);
 	virtual ~SectorView();
 
@@ -42,7 +41,6 @@ public:
 	void GotoCurrentSystem() { GotoSystem(m_current); }
 	void GotoSelectedSystem() { GotoSystem(m_selected); }
 	void GotoHyperspaceTarget() { GotoSystem(m_hyperspaceTarget); }
-	virtual void Save(Serializer::Writer &wr);
 	virtual void SaveToJson(Json::Value &jsonObj);
 
 	sigc::signal<void> onHyperspaceTargetChanged;

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -24,6 +24,7 @@ class SectorView: public UIView {
 public:
 	SectorView(Game* game);
 	SectorView(Serializer::Reader &rd, Game* game);
+	SectorView(const Json::Value &jsonObj, Game* game);
 	virtual ~SectorView();
 
 	virtual void Update();
@@ -42,6 +43,7 @@ public:
 	void GotoSelectedSystem() { GotoSystem(m_selected); }
 	void GotoHyperspaceTarget() { GotoSystem(m_hyperspaceTarget); }
 	virtual void Save(Serializer::Writer &wr);
+	virtual void SaveToJson(Json::Value &jsonObj);
 
 	sigc::signal<void> onHyperspaceTargetChanged;
 

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -14,6 +14,7 @@
 #include "graphics/Material.h"
 #include "graphics/Renderer.h"
 #include "graphics/TextureBuilder.h"
+#include "json/JsonUtils.h"
 
 using namespace Graphics;
 
@@ -42,12 +43,39 @@ void Sfx::Save(Serializer::Writer &wr)
 	wr.Int32(m_type);
 }
 
+void Sfx::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value sfxObj(Json::objectValue); // Create JSON object to contain sfx data.
+
+	VectorToJson(sfxObj, m_pos, "pos");
+	VectorToJson(sfxObj, m_vel, "vel");
+	sfxObj["age"] = FloatToStr(m_age);
+	sfxObj["type"] = m_type;
+
+	jsonObj["sfx"] = sfxObj; // Add sfx object to supplied object.
+}
+
 void Sfx::Load(Serializer::Reader &rd)
 {
 	m_pos = rd.Vector3d();
 	m_vel = rd.Vector3d();
 	m_age = rd.Float();
 	m_type = static_cast<Sfx::TYPE>(rd.Int32());
+}
+
+void Sfx::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("sfx")) throw SavedGameCorruptException();
+	Json::Value sfxObj = jsonObj["sfx"];
+	if (!sfxObj.isMember("pos")) throw SavedGameCorruptException();
+	if (!sfxObj.isMember("vel")) throw SavedGameCorruptException();
+	if (!sfxObj.isMember("age")) throw SavedGameCorruptException();
+	if (!sfxObj.isMember("type")) throw SavedGameCorruptException();
+
+	JsonToVector(&m_pos, sfxObj, "pos");
+	JsonToVector(&m_vel, sfxObj, "vel");
+	m_age = StrToFloat(sfxObj["age"].asString());
+	m_type = static_cast<Sfx::TYPE>(sfxObj["type"].asInt());
 }
 
 void Sfx::Serialize(Serializer::Writer &wr, const Frame *f)
@@ -68,6 +96,26 @@ void Sfx::Serialize(Serializer::Writer &wr, const Frame *f)
 	}
 }
 
+void Sfx::ToJson(Json::Value &jsonObj, const Frame *f)
+{
+	Json::Value sfxArray(Json::arrayValue); // Create JSON array to contain sfx data.
+
+	if (f->m_sfx)
+	{
+		for (int i = 0; i < MAX_SFX_PER_FRAME; i++)
+		{
+			if (f->m_sfx[i].m_type != TYPE_NONE)
+			{
+				Json::Value sfxArrayEl(Json::objectValue); // Create JSON object to contain sfx element.
+				f->m_sfx[i].SaveToJson(sfxArrayEl);
+				sfxArray.append(sfxArrayEl); // Append sfx object to array.
+			}
+		}
+	}
+
+	jsonObj["sfx_array"] = sfxArray; // Add sfx array to supplied object.
+}
+
 void Sfx::Unserialize(Serializer::Reader &rd, Frame *f)
 {
 	int numActive = rd.Int32();
@@ -76,6 +124,19 @@ void Sfx::Unserialize(Serializer::Reader &rd, Frame *f)
 		for (int i=0; i<numActive; i++) {
 			f->m_sfx[i].Load(rd);
 		}
+	}
+}
+
+void Sfx::FromJson(const Json::Value &jsonObj, Frame *f)
+{
+	if (!jsonObj.isMember("sfx_array")) throw SavedGameCorruptException();
+	Json::Value sfxArray = jsonObj["sfx_array"];
+	if (!sfxArray.isArray()) throw SavedGameCorruptException();
+
+	if (sfxArray.size()) f->m_sfx = new Sfx[MAX_SFX_PER_FRAME];
+	for (unsigned int i = 0; i < sfxArray.size(); ++i)
+	{
+		f->m_sfx[i].LoadFromJson(sfxArray[i]);
 	}
 }
 

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -35,14 +35,6 @@ Sfx::Sfx()
 	m_type = TYPE_NONE;
 }
 
-void Sfx::Save(Serializer::Writer &wr)
-{
-	wr.Vector3d(m_pos);
-	wr.Vector3d(m_vel);
-	wr.Float(m_age);
-	wr.Int32(m_type);
-}
-
 void Sfx::SaveToJson(Json::Value &jsonObj)
 {
 	Json::Value sfxObj(Json::objectValue); // Create JSON object to contain sfx data.
@@ -53,14 +45,6 @@ void Sfx::SaveToJson(Json::Value &jsonObj)
 	sfxObj["type"] = m_type;
 
 	jsonObj["sfx"] = sfxObj; // Add sfx object to supplied object.
-}
-
-void Sfx::Load(Serializer::Reader &rd)
-{
-	m_pos = rd.Vector3d();
-	m_vel = rd.Vector3d();
-	m_age = rd.Float();
-	m_type = static_cast<Sfx::TYPE>(rd.Int32());
 }
 
 void Sfx::LoadFromJson(const Json::Value &jsonObj)
@@ -76,24 +60,6 @@ void Sfx::LoadFromJson(const Json::Value &jsonObj)
 	JsonToVector(&m_vel, sfxObj, "vel");
 	m_age = StrToFloat(sfxObj["age"].asString());
 	m_type = static_cast<Sfx::TYPE>(sfxObj["type"].asInt());
-}
-
-void Sfx::Serialize(Serializer::Writer &wr, const Frame *f)
-{
-	// how many sfx turds are active in frame?
-	int numActive = 0;
-	if (f->m_sfx) {
-		for (int i=0; i<MAX_SFX_PER_FRAME; i++) {
-			if (f->m_sfx[i].m_type != TYPE_NONE) numActive++;
-		}
-	}
-	wr.Int32(numActive);
-
-	if (numActive) for (int i=0; i<MAX_SFX_PER_FRAME; i++) {
-		if (f->m_sfx[i].m_type != TYPE_NONE) {
-			f->m_sfx[i].Save(wr);
-		}
-	}
 }
 
 void Sfx::ToJson(Json::Value &jsonObj, const Frame *f)
@@ -114,17 +80,6 @@ void Sfx::ToJson(Json::Value &jsonObj, const Frame *f)
 	}
 
 	jsonObj["sfx_array"] = sfxArray; // Add sfx array to supplied object.
-}
-
-void Sfx::Unserialize(Serializer::Reader &rd, Frame *f)
-{
-	int numActive = rd.Int32();
-	if (numActive) {
-		f->m_sfx = new Sfx[MAX_SFX_PER_FRAME];
-		for (int i=0; i<numActive; i++) {
-			f->m_sfx[i].Load(rd);
-		}
-	}
 }
 
 void Sfx::FromJson(const Json::Value &jsonObj, Frame *f)

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -27,7 +27,9 @@ public:
 	static void TimeStepAll(const float timeStep, Frame *f);
 	static void RenderAll(Graphics::Renderer *r, Frame *f, const Frame *camFrame);
 	static void Serialize(Serializer::Writer &wr, const Frame *f);
+	static void ToJson(Json::Value &jsonObj, const Frame *f);
 	static void Unserialize(Serializer::Reader &rd, Frame *f);
+	static void FromJson(const Json::Value &jsonObj, Frame *f);
 
 	Sfx();
 	void SetPosition(const vector3d &p);
@@ -52,7 +54,9 @@ private:
 	void Render(Graphics::Renderer *r, const matrix4x4d &transform);
 	void TimeStepUpdate(const float timeStep);
 	void Save(Serializer::Writer &wr);
+	void SaveToJson(Json::Value &jsonObj);
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 
 	vector3d m_pos;
 	vector3d m_vel;

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -26,9 +26,7 @@ public:
 	static void AddThrustSmoke(const Body *b, TYPE, float speed, vector3d adjustpos);
 	static void TimeStepAll(const float timeStep, Frame *f);
 	static void RenderAll(Graphics::Renderer *r, Frame *f, const Frame *camFrame);
-	static void Serialize(Serializer::Writer &wr, const Frame *f);
 	static void ToJson(Json::Value &jsonObj, const Frame *f);
-	static void Unserialize(Serializer::Reader &rd, Frame *f);
 	static void FromJson(const Json::Value &jsonObj, Frame *f);
 
 	Sfx();
@@ -53,9 +51,7 @@ private:
 
 	void Render(Graphics::Renderer *r, const matrix4x4d &transform);
 	void TimeStepUpdate(const float timeStep);
-	void Save(Serializer::Writer &wr);
 	void SaveToJson(Json::Value &jsonObj);
-	void Load(Serializer::Reader &rd);
 	void LoadFromJson(const Json::Value &jsonObj);
 
 	vector3d m_pos;

--- a/src/Shields.cpp
+++ b/src/Shields.cpp
@@ -217,19 +217,6 @@ Shields::~Shields()
 {
 }
 
-void Shields::Save(Serializer::Writer &wr)
-{
-	wr.Bool(m_enabled);
-
-	wr.Int32(m_shields.size());
-	for (ShieldIterator it = m_shields.begin(); it != m_shields.end(); ++it) {
-		wr.Byte(it->m_colour.r);
-		wr.Byte(it->m_colour.g);
-		wr.Byte(it->m_colour.b);
-		wr.String(it->m_mesh->GetName());
-	}
-}
-
 void Shields::SaveToJson(Json::Value &jsonObj)
 {
 	Json::Value shieldsObj(Json::objectValue); // Create JSON object to contain shields data.
@@ -248,26 +235,6 @@ void Shields::SaveToJson(Json::Value &jsonObj)
 	shieldsObj["shield_array"] = shieldArray; // Add shield array to shields object.
 
 	jsonObj["shields"] = shieldsObj; // Add shields object to supplied object.
-}
-
-void Shields::Load(Serializer::Reader &rd)
-{
-	m_enabled = rd.Bool();
-
-	const Uint32 NumShields = rd.Int32();
-	assert(NumShields == m_shields.size());
-	for (Uint32 iRead = 0; iRead < NumShields; iRead++ ) {
-		const Uint8 r = rd.Byte();
-		const Uint8 g = rd.Byte();
-		const Uint8 b = rd.Byte();
-		const std::string name = rd.String();
-		for (ShieldIterator it = m_shields.begin(); it != m_shields.end(); ++it) {
-			if(name==it->m_mesh->GetName()) {
-				it->m_colour = Color3ub(r, g, b);
-				break;
-			}
-		}
-	}
 }
 
 void Shields::LoadFromJson(const Json::Value &jsonObj)

--- a/src/Shields.cpp
+++ b/src/Shields.cpp
@@ -222,7 +222,7 @@ void Shields::SaveToJson(Json::Value &jsonObj)
 	Json::Value shieldsObj(Json::objectValue); // Create JSON object to contain shields data.
 
 	shieldsObj["enabled"] = m_enabled;
-	shieldsObj["num_shields"] = m_shields.size();
+	shieldsObj["num_shields"] = Json::Value::UInt(m_shields.size());
 
 	Json::Value shieldArray(Json::arrayValue); // Create JSON array to contain shield data.
 	for (ShieldIterator it = m_shields.begin(); it != m_shields.end(); ++it)

--- a/src/Shields.h
+++ b/src/Shields.h
@@ -35,9 +35,7 @@ public:
 
 	Shields(SceneGraph::Model*);
 	virtual ~Shields();
-	virtual void Save(Serializer::Writer &wr);
 	virtual void SaveToJson(Json::Value &jsonObj);
-	virtual void Load(Serializer::Reader &rd);
 	virtual void LoadFromJson(const Json::Value &jsonObj);
 
 	void SetEnabled(const bool on) { m_enabled = on; }

--- a/src/Shields.h
+++ b/src/Shields.h
@@ -8,6 +8,7 @@
  */
 #include "libs.h"
 #include "Serializer.h"
+#include "json/json.h"
 #include <deque>
 
 namespace Graphics { class Renderer; }

--- a/src/Shields.h
+++ b/src/Shields.h
@@ -36,7 +36,9 @@ public:
 	Shields(SceneGraph::Model*);
 	virtual ~Shields();
 	virtual void Save(Serializer::Writer &wr);
+	virtual void SaveToJson(Json::Value &jsonObj);
 	virtual void Load(Serializer::Reader &rd);
+	virtual void LoadFromJson(const Json::Value &jsonObj);
 
 	void SetEnabled(const bool on) { m_enabled = on; }
 	void Update(const float coolDown, const float shieldStrength);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -79,6 +79,61 @@ void Ship::Save(Serializer::Writer &wr, Space *space)
 	wr.String(m_shipName);
 }
 
+void Ship::SaveToJson(Json::Value &jsonObj, Space *space)
+{
+	DynamicBody::SaveToJson(jsonObj, space);
+
+	Json::Value shipObj(Json::objectValue); // Create JSON object to contain ship data.
+
+	m_skin.SaveToJson(shipObj);
+	VectorToJson(shipObj, m_angThrusters, "ang_thrusters");
+	VectorToJson(shipObj, m_thrusters, "thrusters");
+	shipObj["wheel_transition"] = m_wheelTransition;
+	shipObj["wheel_state"] = FloatToStr(m_wheelState);
+	shipObj["launch_lock_timeout"] = FloatToStr(m_launchLockTimeout);
+	shipObj["test_landed"] = m_testLanded;
+	shipObj["flight_state"] = int(m_flightState);
+	shipObj["alert_state"] = int(m_alertState);
+	shipObj["last_firing_alert"] = DoubleToStr(m_lastFiringAlert);
+
+	// XXX make sure all hyperspace attrs and the cloud get saved
+	Json::Value hyperspaceDestObj(Json::objectValue); // Create JSON object to contain hyperspace destination data.
+	m_hyperspace.dest.ToJson(hyperspaceDestObj);
+	shipObj["hyperspace_destination"] = hyperspaceDestObj; // Add hyperspace destination object to ship object.
+	shipObj["hyperspace_countdown"] = FloatToStr(m_hyperspace.countdown);
+
+	Json::Value gunArray(Json::arrayValue); // Create JSON array to contain gun data.
+	for (int i = 0; i<ShipType::GUNMOUNT_MAX; i++)
+	{
+		Json::Value gunArrayEl(Json::objectValue); // Create JSON object to contain gun.
+		gunArrayEl["state"] = m_gun[i].state;
+		gunArrayEl["recharge"] = FloatToStr(m_gun[i].recharge);
+		gunArrayEl["temperature"] = FloatToStr(m_gun[i].temperature);
+		gunArray.append(gunArrayEl); // Append gun object to array.
+	}
+	shipObj["guns"] = gunArray; // Add gun array to ship object.
+	shipObj["ecm_recharge"] = FloatToStr(m_ecmRecharge);
+	shipObj["ship_type_id"] = m_type->id;
+	shipObj["docked_with_port"] = m_dockedWithPort;
+	shipObj["index_for_body_docked_with"] = space->GetIndexForBody(m_dockedWith);
+	shipObj["hull_mass_left"] = FloatToStr(m_stats.hull_mass_left);
+	shipObj["shield_mass_left"] = FloatToStr(m_stats.shield_mass_left);
+	shipObj["shield_cooldown"] = FloatToStr(m_shieldCooldown);
+	if (m_curAICmd) m_curAICmd->SaveToJson(shipObj);
+	shipObj["ai_message"] = int(m_aiMessage);
+	shipObj["thruster_fuel"] = DoubleToStr(m_thrusterFuel);
+	shipObj["reserve_fuel"] = DoubleToStr(m_reserveFuel);
+
+	shipObj["controller_type"] = static_cast<int>(m_controller->GetType());
+	m_controller->SaveToJson(shipObj, space);
+
+	m_navLights->SaveToJson(shipObj);
+
+	shipObj["name"] = m_shipName;
+
+	jsonObj["ship"] = shipObj; // Add ship object to supplied object.
+}
+
 void Ship::Load(Serializer::Reader &rd, Space *space)
 {
 	DynamicBody::Load(rd, space);
@@ -145,6 +200,114 @@ void Ship::Load(Serializer::Reader &rd, Space *space)
 	m_navLights->Load(rd);
 
 	m_shipName = rd.String();
+	Properties().Set("shipName", m_shipName);
+}
+
+void Ship::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	DynamicBody::LoadFromJson(jsonObj, space);
+
+	if (!jsonObj.isMember("ship")) throw SavedGameCorruptException();
+	Json::Value shipObj = jsonObj["ship"];
+
+	if (!shipObj.isMember("ang_thrusters")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("thrusters")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("wheel_transition")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("wheel_state")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("launch_lock_timeout")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("test_landed")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("flight_state")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("alert_state")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("last_firing_alert")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("hyperspace_destination")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("hyperspace_countdown")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("guns")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("ecm_recharge")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("ship_type_id")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("docked_with_port")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("index_for_body_docked_with")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("hull_mass_left")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("shield_mass_left")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("shield_cooldown")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("ai_message")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("thruster_fuel")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("reserve_fuel")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("controller_type")) throw SavedGameCorruptException();
+	if (!shipObj.isMember("name")) throw SavedGameCorruptException();
+
+	m_skin.LoadFromJson(shipObj);
+	m_skin.Apply(GetModel());
+	// needs fixups
+	JsonToVector(&m_angThrusters, shipObj, "ang_thrusters");
+	JsonToVector(&m_thrusters, shipObj, "thrusters");
+	m_wheelTransition = shipObj["wheel_transition"].asInt();
+	m_wheelState = StrToFloat(shipObj["wheel_state"].asString());
+	m_launchLockTimeout = StrToFloat(shipObj["launch_lock_timeout"].asString());
+	m_testLanded = shipObj["test_landed"].asBool();
+	m_flightState = static_cast<FlightState>(shipObj["flight_state"].asInt());
+	m_alertState = static_cast<AlertState>(shipObj["alert_state"].asInt());
+	Properties().Set("flightState", EnumStrings::GetString("ShipFlightState", m_flightState));
+	Properties().Set("alertStatus", EnumStrings::GetString("ShipAlertStatus", m_alertState));
+	m_lastFiringAlert = StrToDouble(shipObj["last_firing_alert"].asString());
+
+	Json::Value hyperspaceDestObj = shipObj["hyperspace_destination"];
+	SystemPath::FromJson(hyperspaceDestObj);
+	m_hyperspace.countdown = StrToFloat(shipObj["hyperspace_countdown"].asString());
+	m_hyperspace.duration = 0;
+
+	Json::Value gunArray = shipObj["guns"];
+	if (!gunArray.isArray()) throw SavedGameCorruptException();
+	assert(ShipType::GUNMOUNT_MAX == gunArray.size());
+	for (unsigned int i = 0; i < ShipType::GUNMOUNT_MAX; i++)
+	{
+		Json::Value gunArrayEl = gunArray[i];
+		if (!gunArrayEl.isMember("state")) throw SavedGameCorruptException();
+		if (!gunArrayEl.isMember("recharge")) throw SavedGameCorruptException();
+		if (!gunArrayEl.isMember("temperature")) throw SavedGameCorruptException();
+
+		m_gun[i].state = gunArrayEl["state"].asUInt();
+		m_gun[i].recharge = StrToFloat(gunArrayEl["recharge"].asString());
+		m_gun[i].temperature = StrToFloat(gunArrayEl["temperature"].asString());
+	}
+	m_ecmRecharge = StrToFloat(shipObj["ecm_recharge"].asString());
+	SetShipId(shipObj["ship_type_id"].asString()); // XXX handle missing thirdparty ship
+	m_dockedWithPort = shipObj["docked_with_port"].asInt();
+	m_dockedWithIndex = shipObj["index_for_body_docked_with"].asUInt();
+	Init();
+	m_stats.hull_mass_left = StrToFloat(shipObj["hull_mass_left"].asString()); // must be after Init()...
+	m_stats.shield_mass_left = StrToFloat(shipObj["shield_mass_left"].asString());
+	m_shieldCooldown = StrToFloat(shipObj["shield_cooldown"].asString());
+	m_curAICmd = 0;
+	m_curAICmd = AICommand::LoadFromJson(shipObj);
+	m_aiMessage = AIError(shipObj["ai_message"].asInt());
+	SetFuel(StrToDouble(shipObj["thruster_fuel"].asString()));
+	m_stats.fuel_tank_mass_left = GetShipType()->fuelTankMass * GetFuel();
+	m_reserveFuel = StrToDouble(shipObj["reserve_fuel"].asString());
+
+	PropertyMap &p = Properties();
+	p.Set("hullMassLeft", m_stats.hull_mass_left);
+	p.Set("hullPercent", 100.0f * (m_stats.hull_mass_left / float(m_type->hullMass)));
+	p.Set("shieldMassLeft", m_stats.shield_mass_left);
+	p.Set("fuelMassLeft", m_stats.fuel_tank_mass_left);
+	p.PushLuaTable();
+	lua_State *l = Lua::manager->GetLuaState();
+	lua_getfield(l, -1, "equipSet");
+	m_equipSet = LuaRef(l, -1);
+	lua_pop(l, 2);
+
+	UpdateLuaStats();
+
+	m_controller = 0;
+	const ShipController::Type ctype = static_cast<ShipController::Type>(shipObj["controller_type"].asInt());
+	if (ctype == ShipController::PLAYER)
+		SetController(new PlayerShipController());
+	else
+		SetController(new ShipController());
+	m_controller->LoadFromJson(shipObj);
+
+	m_navLights->LoadFromJson(shipObj);
+
+	m_shipName = shipObj["name"].asString();
 	Properties().Set("shipName", m_shipName);
 }
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -138,7 +138,7 @@ void Ship::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	m_lastFiringAlert = StrToDouble(shipObj["last_firing_alert"].asString());
 
 	Json::Value hyperspaceDestObj = shipObj["hyperspace_destination"];
-	SystemPath::FromJson(hyperspaceDestObj);
+	m_hyperspace.dest = SystemPath::FromJson(hyperspaceDestObj);
 	m_hyperspace.countdown = StrToFloat(shipObj["hyperspace_countdown"].asString());
 	m_hyperspace.duration = 0;
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -263,9 +263,7 @@ public:
 	double GetLandingPosOffset() const { return m_landingMinOffset; }
 
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 	void RenderLaserfire();
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -264,7 +264,9 @@ public:
 
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 	void RenderLaserfire();
 
 	bool AITimeStep(float timeStep); // Called by controller. Returns true if complete

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -16,21 +16,6 @@
 static const double VICINITY_MIN = 15000.0;
 static const double VICINITY_MUL = 4.0;
 
-AICommand *AICommand::Load(Serializer::Reader &rd)
-{
-	CmdName name = CmdName(rd.Int32());
-	switch (name) {
-		case CMD_NONE: default: return 0;
-		case CMD_DOCK: return new AICmdDock(rd);
-		case CMD_FLYTO: return new AICmdFlyTo(rd);
-		case CMD_FLYAROUND: return new AICmdFlyAround(rd);
-		case CMD_KILL: return new AICmdKill(rd);
-		case CMD_KAMIKAZE: return new AICmdKamikaze(rd);
-		case CMD_HOLDPOSITION: return new AICmdHoldPosition(rd);
-		case CMD_FORMATION: return new AICmdFormation(rd);
-	}
-}
-
 AICommand *AICommand::LoadFromJson(const Json::Value &jsonObj)
 {
 	if (jsonObj.isMember("ai_command"))
@@ -55,15 +40,6 @@ AICommand *AICommand::LoadFromJson(const Json::Value &jsonObj)
 	return 0; // Return 0 if supplied object doesn't contain an "ai_command" object.
 }
 
-void AICommand::Save(Serializer::Writer &wr)
-{
-	Space *space = Pi::game->GetSpace();
-	wr.Int32(m_cmdName);
-	wr.Int32(space->GetIndexForBody(m_ship));
-	if (m_child) m_child->Save(wr);
-	else wr.Int32(CMD_NONE);
-}
-
 void AICommand::SaveToJson(Json::Value &jsonObj)
 {
 	// AICommand is an abstract base class, so it is guaranteed that the supplied object
@@ -79,13 +55,6 @@ void AICommand::SaveToJson(Json::Value &jsonObj)
 	commonAiCommandObj["index_for_body"] = space->GetIndexForBody(m_ship);
 	if (m_child) m_child->SaveToJson(commonAiCommandObj);
 	jsonObj["common_ai_command"] = commonAiCommandObj; // Add common ai command object to supplied object.
-}
-
-AICommand::AICommand(Serializer::Reader &rd, CmdName name)
-{
-	m_cmdName = name;
-	m_shipIndex = rd.Int32();
-	m_child = Load(rd);
 }
 
 AICommand::AICommand(const Json::Value &jsonObj, CmdName name)

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -31,6 +31,30 @@ AICommand *AICommand::Load(Serializer::Reader &rd)
 	}
 }
 
+AICommand *AICommand::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (jsonObj.isMember("ai_command"))
+	{
+		Json::Value aiCommandObj = jsonObj["ai_command"];
+		if (!aiCommandObj.isMember("common_ai_command")) throw SavedGameCorruptException();
+		Json::Value commonAiCommandObj = aiCommandObj["common_ai_command"];
+		if (!commonAiCommandObj.isMember("command_name")) throw SavedGameCorruptException();
+		CmdName name = CmdName(commonAiCommandObj["command_name"].asInt());
+		switch (name)
+		{
+		case CMD_NONE: default: return 0; // No longer need CMD_NONE (see AICommand::SaveToJson notes).
+		case CMD_DOCK: return new AICmdDock(aiCommandObj);
+		case CMD_FLYTO: return new AICmdFlyTo(aiCommandObj);
+		case CMD_FLYAROUND: return new AICmdFlyAround(aiCommandObj);
+		case CMD_KILL: return new AICmdKill(aiCommandObj);
+		case CMD_KAMIKAZE: return new AICmdKamikaze(aiCommandObj);
+		case CMD_HOLDPOSITION: return new AICmdHoldPosition(aiCommandObj);
+		case CMD_FORMATION: return new AICmdFormation(aiCommandObj);
+		}
+	}
+	return 0; // Return 0 if supplied object doesn't contain an "ai_command" object.
+}
+
 void AICommand::Save(Serializer::Writer &wr)
 {
 	Space *space = Pi::game->GetSpace();
@@ -40,11 +64,41 @@ void AICommand::Save(Serializer::Writer &wr)
 	else wr.Int32(CMD_NONE);
 }
 
+void AICommand::SaveToJson(Json::Value &jsonObj)
+{
+	// AICommand is an abstract base class, so it is guaranteed that the supplied object
+	// is the top-level JSON object (always named "ai_command") encoding the specific ai command.
+	// The top-level ai command object will contain:
+	// (1) the specific ai command data (already created and added in the overriding concrete class function), and
+	// (2) the common ai command object (created and added in this base class function).
+	// The command name (enum CmdName) and a child ai command (if this ai command has one) are added to the common ai command object.
+	// No longer need to save CMD_NONE when a child ai command does not exist (just don't add a child ai command object).
+	Space *space = Pi::game->GetSpace();
+	Json::Value commonAiCommandObj(Json::objectValue); // Create JSON object to contain common ai command data.
+	commonAiCommandObj["command_name"] = m_cmdName;
+	commonAiCommandObj["index_for_body"] = space->GetIndexForBody(m_ship);
+	if (m_child) m_child->SaveToJson(commonAiCommandObj);
+	jsonObj["common_ai_command"] = commonAiCommandObj; // Add common ai command object to supplied object.
+}
+
 AICommand::AICommand(Serializer::Reader &rd, CmdName name)
 {
 	m_cmdName = name;
 	m_shipIndex = rd.Int32();
 	m_child = Load(rd);
+}
+
+AICommand::AICommand(const Json::Value &jsonObj, CmdName name)
+{
+	m_cmdName = name;
+
+	if (!jsonObj.isMember("common_ai_command")) throw SavedGameCorruptException();
+	Json::Value commonAiCommandObj = jsonObj["common_ai_command"];
+
+	if (!commonAiCommandObj.isMember("index_for_body")) throw SavedGameCorruptException();
+	m_shipIndex = commonAiCommandObj["index_for_body"].asInt();
+
+	m_child = LoadFromJson(commonAiCommandObj);
 }
 
 void AICommand::PostLoadFixup(Space *space)

--- a/src/ShipController.cpp
+++ b/src/ShipController.cpp
@@ -54,17 +54,6 @@ PlayerShipController::~PlayerShipController()
 	m_fireMissileKey.disconnect();
 }
 
-void PlayerShipController::Save(Serializer::Writer &wr, Space *space)
-{
-	wr.Int32(static_cast<int>(m_flightControlState));
-	wr.Double(m_setSpeed);
-	wr.Float(m_lowThrustPower);
-	wr.Bool(m_rotationDamping);
-	wr.Int32(space->GetIndexForBody(m_combatTarget));
-	wr.Int32(space->GetIndexForBody(m_navTarget));
-	wr.Int32(space->GetIndexForBody(m_setSpeedTarget));
-}
-
 void PlayerShipController::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	Json::Value playerShipControllerObj(Json::objectValue); // Create JSON object to contain player ship controller data.
@@ -76,18 +65,6 @@ void PlayerShipController::SaveToJson(Json::Value &jsonObj, Space *space)
 	playerShipControllerObj["index_for_nav_target"] = space->GetIndexForBody(m_navTarget);
 	playerShipControllerObj["index_for_set_speed_target"] = space->GetIndexForBody(m_setSpeedTarget);
 	jsonObj["player_ship_controller"] = playerShipControllerObj; // Add player ship controller object to supplied object.
-}
-
-void PlayerShipController::Load(Serializer::Reader &rd)
-{
-	m_flightControlState = static_cast<FlightControlState>(rd.Int32());
-	m_setSpeed = rd.Double();
-	m_lowThrustPower = rd.Float();
-	m_rotationDamping = rd.Bool();
-	//figure out actual bodies in PostLoadFixup - after Space body index has been built
-	m_combatTargetIndex = rd.Int32();
-	m_navTargetIndex = rd.Int32();
-	m_setSpeedTargetIndex = rd.Int32();
 }
 
 void PlayerShipController::LoadFromJson(const Json::Value &jsonObj)

--- a/src/ShipController.h
+++ b/src/ShipController.h
@@ -41,7 +41,9 @@ public:
 	virtual ~ShipController() { }
 	virtual Type GetType() { return AI; }
 	virtual void Save(Serializer::Writer &wr, Space *s) { }
+	virtual void SaveToJson(Json::Value &jsonObj, Space *s) { }
 	virtual void Load(Serializer::Reader &rd) { }
+	virtual void LoadFromJson(const Json::Value &jsonObj) { }
 	virtual void PostLoadFixup(Space *) { }
 	virtual void StaticUpdate(float timeStep);
 	virtual void SetFlightControlState(FlightControlState s) { }
@@ -56,7 +58,9 @@ public:
 	~PlayerShipController();
 	virtual Type GetType() { return PLAYER; }
 	void Save(Serializer::Writer &wr, Space *s);
+	void SaveToJson(Json::Value &jsonObj, Space *s);
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 	void PostLoadFixup(Space *s);
 	void StaticUpdate(float timeStep);
 	// Poll controls, set thruster states, gun states and target velocity

--- a/src/ShipController.h
+++ b/src/ShipController.h
@@ -9,6 +9,7 @@
  */
 #include "libs.h"
 #include "Serializer.h"
+#include "json/json.h"
 
 class Ship;
 class Space;

--- a/src/ShipController.h
+++ b/src/ShipController.h
@@ -40,9 +40,7 @@ public:
 	ShipController() { }
 	virtual ~ShipController() { }
 	virtual Type GetType() { return AI; }
-	virtual void Save(Serializer::Writer &wr, Space *s) { }
 	virtual void SaveToJson(Json::Value &jsonObj, Space *s) { }
-	virtual void Load(Serializer::Reader &rd) { }
 	virtual void LoadFromJson(const Json::Value &jsonObj) { }
 	virtual void PostLoadFixup(Space *) { }
 	virtual void StaticUpdate(float timeStep);
@@ -57,9 +55,7 @@ public:
 	PlayerShipController();
 	~PlayerShipController();
 	virtual Type GetType() { return PLAYER; }
-	void Save(Serializer::Writer &wr, Space *s);
 	void SaveToJson(Json::Value &jsonObj, Space *s);
-	void Load(Serializer::Reader &rd);
 	void LoadFromJson(const Json::Value &jsonObj);
 	void PostLoadFixup(Space *s);
 	void StaticUpdate(float timeStep);

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -26,16 +26,6 @@ ShipCpanel::ShipCpanel(Graphics::Renderer *r, Game* game): Gui::Fixed(float(Gui:
 	InitObject();
 }
 
-ShipCpanel::ShipCpanel(Serializer::Reader &rd, Graphics::Renderer *r, Game* game): Gui::Fixed(float(Gui::Screen::GetWidth()), 80),
-	m_game(game)
-{
-	m_scanner = new ScannerWidget(r, rd);
-
-	InitObject();
-
-	m_camButton->SetActiveState(rd.Int32());
-}
-
 ShipCpanel::ShipCpanel(const Json::Value &jsonObj, Graphics::Renderer *r, Game* game) : Gui::Fixed(float(Gui::Screen::GetWidth()), 80),
 m_game(game)
 {
@@ -414,12 +404,6 @@ void ShipCpanel::TimeStepUpdate(float step)
 {
 	PROFILE_SCOPED()
 	m_scanner->TimeStepUpdate(step);
-}
-
-void ShipCpanel::Save(Serializer::Writer &wr)
-{
-	m_scanner->Save(wr);
-	wr.Int32(m_camButton->GetState());
 }
 
 void ShipCpanel::SaveToJson(Json::Value &jsonObj)

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -36,6 +36,20 @@ ShipCpanel::ShipCpanel(Serializer::Reader &rd, Graphics::Renderer *r, Game* game
 	m_camButton->SetActiveState(rd.Int32());
 }
 
+ShipCpanel::ShipCpanel(const Json::Value &jsonObj, Graphics::Renderer *r, Game* game) : Gui::Fixed(float(Gui::Screen::GetWidth()), 80),
+m_game(game)
+{
+	if (!jsonObj.isMember("ship_c_panel")) throw SavedGameCorruptException();
+	Json::Value shipCPanelObj = jsonObj["ship_c_panel"];
+
+	m_scanner = new ScannerWidget(r, shipCPanelObj);
+
+	InitObject();
+
+	if (!shipCPanelObj.isMember("cam_button_state")) throw SavedGameCorruptException();
+	m_camButton->SetActiveState(shipCPanelObj["cam_button_state"].asInt());
+}
+
 void ShipCpanel::InitObject()
 {
 	SetTransparency(true);
@@ -406,6 +420,14 @@ void ShipCpanel::Save(Serializer::Writer &wr)
 {
 	m_scanner->Save(wr);
 	wr.Int32(m_camButton->GetState());
+}
+
+void ShipCpanel::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value shipCPanelObj(Json::objectValue); // Create JSON object to contain ship control panel data.
+	m_scanner->SaveToJson(shipCPanelObj);
+	shipCPanelObj["cam_button_state"] = m_camButton->GetState();
+	jsonObj["ship_c_panel"] = shipCPanelObj; // Add ship control panel object to supplied object.
 }
 
 void ShipCpanel::SetOverlayText(OverlayTextPos pos, const std::string &text)

--- a/src/ShipCpanel.h
+++ b/src/ShipCpanel.h
@@ -19,7 +19,6 @@ namespace Graphics { class Renderer; }
 class ShipCpanel: public Gui::Fixed {
 public:
 	ShipCpanel(Graphics::Renderer *r, Game* game);
-    ShipCpanel(Serializer::Reader &rd, Graphics::Renderer *r, Game* game);
 	ShipCpanel(const Json::Value &jsonObj, Graphics::Renderer *r, Game* game);
 	virtual ~ShipCpanel();
 	virtual void Draw();
@@ -28,7 +27,6 @@ public:
 
 	void TimeStepUpdate(float step);
 
-	void Save(Serializer::Writer &wr);
 	void SaveToJson(Json::Value &jsonObj);
 
 	enum OverlayTextPos {

--- a/src/ShipCpanel.h
+++ b/src/ShipCpanel.h
@@ -20,6 +20,7 @@ class ShipCpanel: public Gui::Fixed {
 public:
 	ShipCpanel(Graphics::Renderer *r, Game* game);
     ShipCpanel(Serializer::Reader &rd, Graphics::Renderer *r, Game* game);
+	ShipCpanel(const Json::Value &jsonObj, Graphics::Renderer *r, Game* game);
 	virtual ~ShipCpanel();
 	virtual void Draw();
 	void Update();
@@ -28,6 +29,7 @@ public:
 	void TimeStepUpdate(float step);
 
 	void Save(Serializer::Writer &wr);
+	void SaveToJson(Json::Value &jsonObj);
 
 	enum OverlayTextPos {
 		OVERLAY_TOP_LEFT,

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -50,17 +50,6 @@ ScannerWidget::ScannerWidget(Graphics::Renderer *r) :
 	InitObject();
 }
 
-ScannerWidget::ScannerWidget(Graphics::Renderer *r, Serializer::Reader &rd) :
-	m_renderer(r)
-{
-	m_mode = ScannerMode(rd.Int32());
-	m_currentRange = rd.Float();
-	m_manualRange = rd.Float();
-	m_targetRange = rd.Float();
-
-	InitObject();
-}
-
 ScannerWidget::ScannerWidget(Graphics::Renderer *r, const Json::Value &jsonObj) :
 m_renderer(r)
 {
@@ -491,14 +480,6 @@ void ScannerWidget::TimeStepUpdate(float step)
 		m_currentRange = Clamp(m_currentRange + (m_currentRange*step), SCANNER_RANGE_MIN, m_targetRange);
 
 	m_scale = SCANNER_SCALE * (SCANNER_RANGE_MAX / m_currentRange);
-}
-
-void ScannerWidget::Save(Serializer::Writer &wr)
-{
-	wr.Int32(Sint32(m_mode));
-	wr.Float(m_currentRange);
-	wr.Float(m_manualRange);
-	wr.Float(m_targetRange);
 }
 
 void ScannerWidget::SaveToJson(Json::Value &jsonObj)

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -61,6 +61,25 @@ ScannerWidget::ScannerWidget(Graphics::Renderer *r, Serializer::Reader &rd) :
 	InitObject();
 }
 
+ScannerWidget::ScannerWidget(Graphics::Renderer *r, const Json::Value &jsonObj) :
+m_renderer(r)
+{
+	if (!jsonObj.isMember("scanner")) throw SavedGameCorruptException();
+	Json::Value scannerObj = jsonObj["scanner"];
+
+	if (!scannerObj.isMember("mode")) throw SavedGameCorruptException();
+	if (!scannerObj.isMember("current_range")) throw SavedGameCorruptException();
+	if (!scannerObj.isMember("manual_range")) throw SavedGameCorruptException();
+	if (!scannerObj.isMember("target_range")) throw SavedGameCorruptException();
+
+	m_mode = ScannerMode(scannerObj["mode"].asInt());
+	m_currentRange = StrToFloat(scannerObj["current_range"].asString());
+	m_manualRange = StrToFloat(scannerObj["manual_range"].asString());
+	m_targetRange = StrToFloat(scannerObj["target_range"].asString());
+
+	InitObject();
+}
+
 void ScannerWidget::InitObject()
 {
 	InitScaling();
@@ -480,6 +499,18 @@ void ScannerWidget::Save(Serializer::Writer &wr)
 	wr.Float(m_currentRange);
 	wr.Float(m_manualRange);
 	wr.Float(m_targetRange);
+}
+
+void ScannerWidget::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value scannerObj(Json::objectValue); // Create JSON object to contain scanner data.
+
+	scannerObj["mode"] = Sint32(m_mode);
+	scannerObj["current_range"] = FloatToStr(m_currentRange);
+	scannerObj["manual_range"] = FloatToStr(m_manualRange);
+	scannerObj["target_range"] = FloatToStr(m_targetRange);
+
+	jsonObj["scanner"] = scannerObj; // Add scanner object to supplied object.
 }
 
 /////////////////////////////////

--- a/src/ShipCpanelMultiFuncDisplays.h
+++ b/src/ShipCpanelMultiFuncDisplays.h
@@ -27,7 +27,6 @@ public:
 class ScannerWidget: public IMultiFunc, public Gui::Widget {
 public:
 	ScannerWidget(Graphics::Renderer *r);
-	ScannerWidget(Graphics::Renderer *r, Serializer::Reader &rd);
 	ScannerWidget(Graphics::Renderer *r, const Json::Value &jsonObj);
 	virtual ~ScannerWidget();
 	void GetSizeRequested(float size[2]);
@@ -38,7 +37,6 @@ public:
 
 	void TimeStepUpdate(float step);
 
-	void Save(Serializer::Writer &wr);
 	void SaveToJson(Json::Value &jsonObj);
 
 private:

--- a/src/ShipCpanelMultiFuncDisplays.h
+++ b/src/ShipCpanelMultiFuncDisplays.h
@@ -7,6 +7,7 @@
 #include "gui/Gui.h"
 #include "Serializer.h"
 #include "Object.h"
+#include "json/json.h"
 
 class Body;
 namespace Graphics { class Renderer; }

--- a/src/ShipCpanelMultiFuncDisplays.h
+++ b/src/ShipCpanelMultiFuncDisplays.h
@@ -28,6 +28,7 @@ class ScannerWidget: public IMultiFunc, public Gui::Widget {
 public:
 	ScannerWidget(Graphics::Renderer *r);
 	ScannerWidget(Graphics::Renderer *r, Serializer::Reader &rd);
+	ScannerWidget(Graphics::Renderer *r, const Json::Value &jsonObj);
 	virtual ~ScannerWidget();
 	void GetSizeRequested(float size[2]);
 	void ToggleMode();
@@ -38,6 +39,7 @@ public:
 	void TimeStepUpdate(float step);
 
 	void Save(Serializer::Writer &wr);
+	void SaveToJson(Json::Value &jsonObj);
 
 private:
 	void InitObject();

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -147,6 +147,48 @@ Space::Space(Game *game, RefCountedPtr<Galaxy> galaxy, Serializer::Reader &rd, d
 	GenSectorCache(galaxy, &path);
 }
 
+Space::Space(Game *game, RefCountedPtr<Galaxy> galaxy, const Json::Value &jsonObj, double at_time)
+	: m_starSystemCache(galaxy->NewStarSystemSlaveCache())
+	, m_game(game)
+	, m_frameIndexValid(false)
+	, m_bodyIndexValid(false)
+	, m_sbodyIndexValid(false)
+	, m_bodyNearFinder(this)
+#ifndef NDEBUG
+	, m_processingFinalizationQueue(false)
+#endif
+{
+	if (!jsonObj.isMember("space")) throw SavedGameCorruptException();
+	Json::Value spaceObj = jsonObj["space"];
+
+	m_starSystem = StarSystem::FromJson(galaxy, spaceObj);
+
+	const SystemPath &path = m_starSystem->GetPath();
+	Uint32 _init[5] = { path.systemIndex, Uint32(path.sectorX), Uint32(path.sectorY), Uint32(path.sectorZ), UNIVERSE_SEED };
+	Random rand(_init, 5);
+	m_background.reset(new Background::Container(Pi::renderer, rand));
+
+	RebuildSystemBodyIndex();
+
+	CityOnPlanet::SetCityModelPatterns(m_starSystem->GetPath());
+
+	m_rootFrame.reset(Frame::FromJson(spaceObj, this, 0, at_time));
+	RebuildFrameIndex();
+
+	if (!spaceObj.isMember("bodies")) throw SavedGameCorruptException();
+	Json::Value bodyArray = spaceObj["bodies"];
+	if (!bodyArray.isArray()) throw SavedGameCorruptException();
+	for (Uint32 i = 0; i < bodyArray.size(); i++)
+		m_bodies.push_back(Body::FromJson(bodyArray[i], this));
+	RebuildBodyIndex();
+
+	Frame::PostUnserializeFixup(m_rootFrame.get(), this);
+	for (Body* b : m_bodies)
+		b->PostLoadFixup(this);
+
+	GenSectorCache(galaxy, &path);
+}
+
 Space::~Space()
 {
 	UpdateBodies(); // make sure anything waiting to be removed gets removed before we go and kill everything else

--- a/src/Space.h
+++ b/src/Space.h
@@ -30,10 +30,12 @@ public:
 
 	// initialise from save file
 	Space(Game *game, RefCountedPtr<Galaxy> galaxy, Serializer::Reader &rd, double at_time);
+	Space(Game *game, RefCountedPtr<Galaxy> galaxy, const Json::Value &jsonObj, double at_time);
 
 	virtual ~Space();
 
 	void Serialize(Serializer::Writer &wr);
+	void ToJson(Json::Value &jsonObj);
 
 	// frame/body/sbody indexing for save/load. valid after
 	// construction/Serialize(), invalidated by TimeStep(). they will assert

--- a/src/Space.h
+++ b/src/Space.h
@@ -36,7 +36,7 @@ public:
 	void ToJson(Json::Value &jsonObj);
 
 	// frame/body/sbody indexing for save/load. valid after
-	// construction/Serialize(), invalidated by TimeStep(). they will assert
+	// construction/ToJson(), invalidated by TimeStep(). they will assert
 	// if called while invalid
 	Frame *GetFrameByIndex(Uint32 idx) const;
 	Body  *GetBodyByIndex(Uint32 idx) const;

--- a/src/Space.h
+++ b/src/Space.h
@@ -29,12 +29,10 @@ public:
 	Space(Game *game, RefCountedPtr<Galaxy> galaxy, const SystemPath &path, Space* oldSpace = nullptr);
 
 	// initialise from save file
-	Space(Game *game, RefCountedPtr<Galaxy> galaxy, Serializer::Reader &rd, double at_time);
 	Space(Game *game, RefCountedPtr<Galaxy> galaxy, const Json::Value &jsonObj, double at_time);
 
 	virtual ~Space();
 
-	void Serialize(Serializer::Writer &wr);
 	void ToJson(Json::Value &jsonObj);
 
 	// frame/body/sbody indexing for save/load. valid after

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -40,7 +40,7 @@ void SpaceStation::SaveToJson(Json::Value &jsonObj, Space *space)
 	for (Uint32 i = 0; i<m_shipDocking.size(); i++)
 	{
 		Json::Value shipDockingArrayEl(Json::objectValue); // Create JSON object to contain ship docking.
-		shipDockingArrayEl["index_for_body"] = m_shipDocking[i].ship;
+		shipDockingArrayEl["index_for_body"] = space->GetIndexForBody(m_shipDocking[i].ship);
 		shipDockingArrayEl["stage"] = m_shipDocking[i].stage;
 		shipDockingArrayEl["stage_pos"] = DoubleToStr(m_shipDocking[i].stagePos); // stagePos is a double but was saved as a float in pre-JSON system for some reason (saved as double here).
 		VectorToJson(shipDockingArrayEl, m_shipDocking[i].fromPos, "from_pos");

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -22,6 +22,7 @@
 #include "galaxy/StarSystem.h"
 #include "graphics/Graphics.h"
 #include "scenegraph/ModelSkin.h"
+#include "json/JsonUtils.h"
 #include <algorithm>
 
 void SpaceStation::Init()
@@ -60,6 +61,60 @@ void SpaceStation::Save(Serializer::Writer &wr, Space *space)
 	wr.Double(m_doorAnimationState);
 
 	m_navLights->Save(wr);
+}
+
+void SpaceStation::SaveToJson(Json::Value &jsonObj, Space *space)
+{
+	ModelBody::SaveToJson(jsonObj, space);
+
+	Json::Value spaceStationObj(Json::objectValue); // Create JSON object to contain space station data.
+
+	Json::Value shipDockingArray(Json::arrayValue); // Create JSON array to contain ship docking data.
+	for (Uint32 i = 0; i<m_shipDocking.size(); i++)
+	{
+		Json::Value shipDockingArrayEl(Json::objectValue); // Create JSON object to contain ship docking.
+		shipDockingArrayEl["index_for_body"] = m_shipDocking[i].ship;
+		shipDockingArrayEl["stage"] = m_shipDocking[i].stage;
+		shipDockingArrayEl["stage_pos"] = DoubleToStr(m_shipDocking[i].stagePos); // stagePos is a double but was saved as a float in pre-JSON system for some reason (saved as double here).
+		VectorToJson(shipDockingArrayEl, m_shipDocking[i].fromPos, "from_pos");
+		QuaternionToJson(shipDockingArrayEl, m_shipDocking[i].fromRot, "from_rot");
+		shipDockingArray.append(shipDockingArrayEl); // Append ship docking object to array.
+	}
+	spaceStationObj["ship_docking"] = shipDockingArray; // Add ship docking array to space station object.
+
+	// store each of the port details and bay IDs
+	Json::Value portArray(Json::arrayValue); // Create JSON array to contain port data.
+	for (Uint32 i = 0; i < m_ports.size(); i++)
+	{
+		Json::Value portArrayEl(Json::objectValue); // Create JSON object to contain port.
+
+		portArrayEl["min_ship_size"] = m_ports[i].minShipSize;
+		portArrayEl["max_ship_size"] = m_ports[i].maxShipSize;
+		portArrayEl["in_use"] = m_ports[i].inUse;
+
+		Json::Value bayArray(Json::arrayValue); // Create JSON array to contain bay data.
+		for (Uint32 j = 0; j<m_ports[i].bayIDs.size(); j++)
+		{
+			Json::Value bayArrayEl(Json::objectValue); // Create JSON object to contain bay.
+			bayArrayEl["bay_id"] = m_ports[i].bayIDs[j].first;
+			bayArrayEl["name"] = m_ports[i].bayIDs[j].second;
+			bayArray.append(bayArrayEl); // Append bay object to array.
+		}
+		portArrayEl["bays"] = bayArray; // Add bay array to port object.
+
+		portArray.append(portArrayEl); // Append port object to array.
+	}
+	spaceStationObj["ports"] = portArray; // Add port array to space station object.
+
+	spaceStationObj["index_for_system_body"] = space->GetIndexForSystemBody(m_sbody);
+	spaceStationObj["num_police_docked"] = m_numPoliceDocked;
+
+	spaceStationObj["door_animation_step"] = DoubleToStr(m_doorAnimationStep);
+	spaceStationObj["door_animation_state"] = DoubleToStr(m_doorAnimationState);
+
+	m_navLights->SaveToJson(spaceStationObj);
+
+	jsonObj["space_station"] = spaceStationObj; // Add space station object to supplied object.
 }
 
 void SpaceStation::Load(Serializer::Reader &rd, Space *space)
@@ -106,6 +161,87 @@ void SpaceStation::Load(Serializer::Reader &rd, Space *space)
 	InitStation();
 
 	m_navLights->Load(rd);
+}
+
+void SpaceStation::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	ModelBody::LoadFromJson(jsonObj, space);
+
+	if (!jsonObj.isMember("space_station")) throw SavedGameCorruptException();
+	Json::Value spaceStationObj = jsonObj["space_station"];
+
+	if (!spaceStationObj.isMember("ship_docking")) throw SavedGameCorruptException();
+	if (!spaceStationObj.isMember("ports")) throw SavedGameCorruptException();
+	if (!spaceStationObj.isMember("index_for_system_body")) throw SavedGameCorruptException();
+	if (!spaceStationObj.isMember("num_police_docked")) throw SavedGameCorruptException();
+	if (!spaceStationObj.isMember("door_animation_step")) throw SavedGameCorruptException();
+	if (!spaceStationObj.isMember("door_animation_state")) throw SavedGameCorruptException();
+
+	m_oldAngDisplacement = 0.0;
+
+	Json::Value shipDockingArray = spaceStationObj["ship_docking"];
+	if (!shipDockingArray.isArray()) throw SavedGameCorruptException();
+	m_shipDocking.reserve(shipDockingArray.size());
+	for (Uint32 i = 0; i < shipDockingArray.size(); i++)
+	{
+		m_shipDocking.push_back(shipDocking_t());
+		shipDocking_t &sd = m_shipDocking.back();
+
+		Json::Value shipDockingArrayEl = shipDockingArray[i];
+		if (!shipDockingArrayEl.isMember("index_for_body")) throw SavedGameCorruptException();
+		if (!shipDockingArrayEl.isMember("stage")) throw SavedGameCorruptException();
+		if (!shipDockingArrayEl.isMember("stage_pos")) throw SavedGameCorruptException();
+		if (!shipDockingArrayEl.isMember("from_pos")) throw SavedGameCorruptException();
+		if (!shipDockingArrayEl.isMember("from_rot")) throw SavedGameCorruptException();
+
+		sd.shipIndex = shipDockingArrayEl["index_for_body"].asInt();
+		sd.stage = shipDockingArrayEl["stage"].asInt();
+		sd.stagePos = StrToDouble(shipDockingArrayEl["stage_pos"].asString()); // For some reason stagePos was saved as a float in pre-JSON system (saved & loaded as double here).
+		JsonToVector(&(sd.fromPos), shipDockingArrayEl, "from_pos");
+		JsonToQuaternion(&(sd.fromRot), shipDockingArrayEl, "from_rot");
+	}
+
+	// retrieve each of the port details and bay IDs
+	Json::Value portArray = spaceStationObj["ports"];
+	if (!portArray.isArray()) throw SavedGameCorruptException();
+	m_ports.reserve(portArray.size());
+	for (Uint32 i = 0; i < portArray.size(); i++)
+	{
+		m_ports.push_back(SpaceStationType::SPort());
+		SpaceStationType::SPort &port = m_ports.back();
+
+		Json::Value portArrayEl = portArray[i];
+		if (!portArrayEl.isMember("min_ship_size")) throw SavedGameCorruptException();
+		if (!portArrayEl.isMember("max_ship_size")) throw SavedGameCorruptException();
+		if (!portArrayEl.isMember("in_use")) throw SavedGameCorruptException();
+		if (!portArrayEl.isMember("bays")) throw SavedGameCorruptException();
+
+		port.minShipSize = portArrayEl["min_ship_size"].asInt();
+		port.maxShipSize = portArrayEl["max_ship_size"].asInt();
+		port.inUse = portArrayEl["in_use"].asBool();
+
+		Json::Value bayArray = portArrayEl["bays"];
+		if (!bayArray.isArray()) throw SavedGameCorruptException();
+		port.bayIDs.reserve(bayArray.size());
+		for (Uint32 j = 0; j < bayArray.size(); j++)
+		{
+			Json::Value bayArrayEl = bayArray[j];
+			if (!bayArrayEl.isMember("bay_id")) throw SavedGameCorruptException();
+			if (!bayArrayEl.isMember("name")) throw SavedGameCorruptException();
+
+			port.bayIDs.push_back(std::make_pair(bayArrayEl["bay_id"].asInt(), bayArrayEl["name"].asString()));
+		}
+	}
+
+	m_sbody = space->GetSystemBodyByIndex(spaceStationObj["index_for_system_body"].asUInt());
+	m_numPoliceDocked = spaceStationObj["num_police_docked"].asInt();
+
+	m_doorAnimationStep = StrToDouble(spaceStationObj["door_animation_step"].asString());
+	m_doorAnimationState = StrToDouble(spaceStationObj["door_animation_state"].asString());
+
+	InitStation();
+
+	m_navLights->LoadFromJson(spaceStationObj);
 }
 
 void SpaceStation::PostLoadFixup(Space *space)

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -70,7 +70,9 @@ public:
 
 protected:
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:
 	void DockingUpdate(const double timeStep);

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -69,9 +69,7 @@ public:
 	virtual void UpdateInterpTransform(double alpha);
 
 protected:
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -20,12 +20,6 @@ Star::Star(SystemBody *sbody): TerrainBody(sbody)
 	InitStar();
 }
 
-void Star::Load(Serializer::Reader &rd, Space *space)
-{
-	TerrainBody::Load(rd, space);		// to get sbody
-	InitStar();
-}
-
 void Star::LoadFromJson(const Json::Value &jsonObj, Space *space)
 {
 	TerrainBody::LoadFromJson(jsonObj, space);		// to get sbody

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -26,6 +26,12 @@ void Star::Load(Serializer::Reader &rd, Space *space)
 	InitStar();
 }
 
+void Star::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	TerrainBody::LoadFromJson(jsonObj, space);		// to get sbody
+	InitStar();
+}
+
 void Star::InitStar()
 {
 	// this one should be atmosphere radius when stars have atmosphere

--- a/src/Star.h
+++ b/src/Star.h
@@ -19,7 +19,6 @@ public:
 	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
 protected:
 	void InitStar();
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 	Graphics::RenderState *m_haloState;

--- a/src/Star.h
+++ b/src/Star.h
@@ -20,6 +20,7 @@ public:
 protected:
 	void InitStar();
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 	Graphics::RenderState *m_haloState;
 };

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -45,12 +45,6 @@ void TerrainBody::InitTerrainBody()
 	m_maxFeatureHeight = (m_baseSphere->GetMaxFeatureHeight() + 1.0) * m_sbody->GetRadius();
 }
 
-void TerrainBody::Save(Serializer::Writer &wr, Space *space)
-{
-	Body::Save(wr, space);
-	wr.Int32(space->GetIndexForSystemBody(m_sbody));
-}
-
 void TerrainBody::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	Body::SaveToJson(jsonObj, space);
@@ -60,13 +54,6 @@ void TerrainBody::SaveToJson(Json::Value &jsonObj, Space *space)
 	terrainBodyObj["index_for_system_body"] = space->GetIndexForSystemBody(m_sbody);
 
 	jsonObj["terrain_body"] = terrainBodyObj; // Add terrain body object to supplied object.
-}
-
-void TerrainBody::Load(Serializer::Reader &rd, Space *space)
-{
-	Body::Load(rd, space);
-	m_sbody = space->GetSystemBodyByIndex(rd.Int32());
-	InitTerrainBody();
 }
 
 void TerrainBody::LoadFromJson(const Json::Value &jsonObj, Space *space)

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -51,10 +51,34 @@ void TerrainBody::Save(Serializer::Writer &wr, Space *space)
 	wr.Int32(space->GetIndexForSystemBody(m_sbody));
 }
 
+void TerrainBody::SaveToJson(Json::Value &jsonObj, Space *space)
+{
+	Body::SaveToJson(jsonObj, space);
+
+	Json::Value terrainBodyObj(Json::objectValue); // Create JSON object to contain terrain body data.
+
+	terrainBodyObj["index_for_system_body"] = space->GetIndexForSystemBody(m_sbody);
+
+	jsonObj["terrain_body"] = terrainBodyObj; // Add terrain body object to supplied object.
+}
+
 void TerrainBody::Load(Serializer::Reader &rd, Space *space)
 {
 	Body::Load(rd, space);
 	m_sbody = space->GetSystemBodyByIndex(rd.Int32());
+	InitTerrainBody();
+}
+
+void TerrainBody::LoadFromJson(const Json::Value &jsonObj, Space *space)
+{
+	Body::LoadFromJson(jsonObj, space);
+
+	if (!jsonObj.isMember("terrain_body")) throw SavedGameCorruptException();
+	Json::Value terrainBodyObj = jsonObj["terrain_body"];
+
+	if (!terrainBodyObj.isMember("index_for_system_body")) throw SavedGameCorruptException();
+
+	m_sbody = space->GetSystemBodyByIndex(terrainBodyObj["index_for_system_body"].asInt());
 	InitTerrainBody();
 }
 

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -39,7 +39,9 @@ protected:
 	void InitTerrainBody();
 
 	virtual void Save(Serializer::Writer &wr, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
 	virtual void Load(Serializer::Reader &rd, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:
 	const SystemBody *m_sbody;

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -38,9 +38,7 @@ protected:
 
 	void InitTerrainBody();
 
-	virtual void Save(Serializer::Writer &wr, Space *space);
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void Load(Serializer::Reader &rd, Space *space);
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 private:

--- a/src/View.h
+++ b/src/View.h
@@ -7,6 +7,7 @@
 #include "libs.h"
 #include "Serializer.h"
 #include "gui/Gui.h"
+#include "json/json.h"
 
 namespace Graphics { class Renderer; }
 

--- a/src/View.h
+++ b/src/View.h
@@ -27,9 +27,7 @@ public:
 	virtual void Draw3D() = 0;
 	// for checking key states, mouse crud
 	virtual void Update() = 0;
-	virtual void Save(Serializer::Writer &wr) {}
 	virtual void SaveToJson(Json::Value &jsonObj) {}
-	virtual void Load(Serializer::Reader &rd) {}
 	virtual void LoadFromJson(const Json::Value &jsonObj) {}
 
 	void Attach();

--- a/src/View.h
+++ b/src/View.h
@@ -28,7 +28,9 @@ public:
 	// for checking key states, mouse crud
 	virtual void Update() = 0;
 	virtual void Save(Serializer::Writer &wr) {}
+	virtual void SaveToJson(Json::Value &jsonObj) {}
 	virtual void Load(Serializer::Reader &rd) {}
+	virtual void LoadFromJson(const Json::Value &jsonObj) {}
 
 	void Attach();
 	void Detach();

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -67,6 +67,20 @@ WorldView::WorldView(Serializer::Reader &rd, Game* game): UIView(), m_game(game)
 	m_siderealCameraController->Load(rd);
 }
 
+WorldView::WorldView(const Json::Value &jsonObj, Game* game) : UIView(), m_game(game)
+{
+	if (!jsonObj.isMember("world_view")) throw SavedGameCorruptException();
+	Json::Value worldViewObj = jsonObj["world_view"];
+
+	if (!worldViewObj.isMember("cam_type")) throw SavedGameCorruptException();
+	m_camType = CamType(worldViewObj["cam_type"].asInt());
+	InitObject();
+
+	m_internalCameraController->LoadFromJson(worldViewObj);
+	m_externalCameraController->LoadFromJson(worldViewObj);
+	m_siderealCameraController->LoadFromJson(worldViewObj);
+}
+
 static const float LOW_THRUST_LEVELS[] = { 0.75, 0.5, 0.25, 0.1, 0.05, 0.01 };
 
 void WorldView::InitObject()

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -347,6 +347,18 @@ void WorldView::Save(Serializer::Writer &wr)
 	m_siderealCameraController->Save(wr);
 }
 
+void WorldView::SaveToJson(Json::Value &jsonObj)
+{
+	Json::Value worldViewObj(Json::objectValue); // Create JSON object to contain world view data.
+
+	worldViewObj["cam_type"] = int(m_camType);
+	m_internalCameraController->SaveToJson(worldViewObj);
+	m_externalCameraController->SaveToJson(worldViewObj);
+	m_siderealCameraController->SaveToJson(worldViewObj);
+
+	jsonObj["world_view"] = worldViewObj; // Add world view object to supplied object.
+}
+
 void WorldView::SetCamType(enum CamType c)
 {
 	Pi::BoinkNoise();

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -58,15 +58,6 @@ WorldView::WorldView(Game* game): UIView(), m_game(game)
 	InitObject();
 }
 
-WorldView::WorldView(Serializer::Reader &rd, Game* game): UIView(), m_game(game)
-{
-	m_camType = CamType(rd.Int32());
-	InitObject();
-	m_internalCameraController->Load(rd);
-	m_externalCameraController->Load(rd);
-	m_siderealCameraController->Load(rd);
-}
-
 WorldView::WorldView(const Json::Value &jsonObj, Game* game) : UIView(), m_game(game)
 {
 	if (!jsonObj.isMember("world_view")) throw SavedGameCorruptException();
@@ -337,14 +328,6 @@ WorldView::~WorldView()
 	m_onPlayerChangeTargetCon.disconnect();
 	m_onChangeFlightControlStateCon.disconnect();
 	m_onMouseWheelCon.disconnect();
-}
-
-void WorldView::Save(Serializer::Writer &wr)
-{
-	wr.Int32(int(m_camType));
-	m_internalCameraController->Save(wr);
-	m_externalCameraController->Save(wr);
-	m_siderealCameraController->Save(wr);
 }
 
 void WorldView::SaveToJson(Json::Value &jsonObj)

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -46,6 +46,7 @@ public:
 	friend class NavTunnelWidget;
 	WorldView(Game* game);
 	WorldView(Serializer::Reader &reader, Game* game);
+	WorldView(const Json::Value &jsonObj, Game* game);
 	virtual ~WorldView();
 	virtual void ShowAll();
 	virtual void Update();
@@ -53,6 +54,7 @@ public:
 	virtual void Draw();
 	static const double PICK_OBJECT_RECT_SIZE;
 	virtual void Save(Serializer::Writer &wr);
+	virtual void SaveToJson(Json::Value &jsonObj); // npw - new code
 	enum CamType {
 		CAM_INTERNAL,
 		CAM_EXTERNAL,

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -45,7 +45,6 @@ class WorldView: public UIView {
 public:
 	friend class NavTunnelWidget;
 	WorldView(Game* game);
-	WorldView(Serializer::Reader &reader, Game* game);
 	WorldView(const Json::Value &jsonObj, Game* game);
 	virtual ~WorldView();
 	virtual void ShowAll();
@@ -53,7 +52,6 @@ public:
 	virtual void Draw3D();
 	virtual void Draw();
 	static const double PICK_OBJECT_RECT_SIZE;
-	virtual void Save(Serializer::Writer &wr);
 	virtual void SaveToJson(Json::Value &jsonObj);
 	enum CamType {
 		CAM_INTERNAL,

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -54,7 +54,7 @@ public:
 	virtual void Draw();
 	static const double PICK_OBJECT_RECT_SIZE;
 	virtual void Save(Serializer::Writer &wr);
-	virtual void SaveToJson(Json::Value &jsonObj); // npw - new code
+	virtual void SaveToJson(Json::Value &jsonObj);
 	enum CamType {
 		CAM_INTERNAL,
 		CAM_EXTERNAL,

--- a/src/galaxy/Galaxy.cpp
+++ b/src/galaxy/Galaxy.cpp
@@ -25,9 +25,25 @@ RefCountedPtr<Galaxy> Galaxy::Load(Serializer::Reader &rd)
 	return galaxy;
 }
 
+//static
+RefCountedPtr<Galaxy> Galaxy::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("galaxy_generator")) throw SavedGameCorruptException();
+	Json::Value galaxyGenObj = jsonObj["galaxy_generator"];
+
+	RefCountedPtr<Galaxy> galaxy = GalaxyGenerator::CreateFromJson(galaxyGenObj);
+	galaxy->m_galaxyGenerator->FromJson(galaxyGenObj, galaxy);
+	return galaxy;
+}
+
 void Galaxy::Serialize(Serializer::Writer &wr)
 {
 	m_galaxyGenerator->Serialize(wr, RefCountedPtr<Galaxy>(this));
+}
+
+void Galaxy::ToJson(Json::Value &jsonObj)
+{
+	m_galaxyGenerator->ToJson(jsonObj, RefCountedPtr<Galaxy>(this));
 }
 
 void Galaxy::SetGalaxyGenerator(RefCountedPtr<GalaxyGenerator> galaxyGenerator)

--- a/src/galaxy/Galaxy.cpp
+++ b/src/galaxy/Galaxy.cpp
@@ -18,14 +18,6 @@ Galaxy::Galaxy(RefCountedPtr<GalaxyGenerator> galaxyGenerator, float radius, flo
 }
 
 //static
-RefCountedPtr<Galaxy> Galaxy::Load(Serializer::Reader &rd)
-{
-	RefCountedPtr<Galaxy> galaxy = GalaxyGenerator::Create(rd);
-	galaxy->m_galaxyGenerator->Unserialize(rd, galaxy);
-	return galaxy;
-}
-
-//static
 RefCountedPtr<Galaxy> Galaxy::LoadFromJson(const Json::Value &jsonObj)
 {
 	if (!jsonObj.isMember("galaxy_generator")) throw SavedGameCorruptException();
@@ -34,11 +26,6 @@ RefCountedPtr<Galaxy> Galaxy::LoadFromJson(const Json::Value &jsonObj)
 	RefCountedPtr<Galaxy> galaxy = GalaxyGenerator::CreateFromJson(galaxyGenObj);
 	galaxy->m_galaxyGenerator->FromJson(galaxyGenObj, galaxy);
 	return galaxy;
-}
-
-void Galaxy::Serialize(Serializer::Writer &wr)
-{
-	m_galaxyGenerator->Serialize(wr, RefCountedPtr<Galaxy>(this));
 }
 
 void Galaxy::ToJson(Json::Value &jsonObj)

--- a/src/galaxy/Galaxy.h
+++ b/src/galaxy/Galaxy.h
@@ -10,6 +10,7 @@
 #include "Factions.h"
 #include "CustomSystem.h"
 #include "GalaxyCache.h"
+#include "json/json.h"
 
 struct SDL_Surface;
 class GalaxyGenerator;

--- a/src/galaxy/Galaxy.h
+++ b/src/galaxy/Galaxy.h
@@ -29,7 +29,9 @@ public:
 	const float SOL_OFFSET_Y;
 
 	static RefCountedPtr<Galaxy> Load(Serializer::Reader &rd);
+	static RefCountedPtr<Galaxy> LoadFromJson(const Json::Value &jsonObj);
 	void Serialize(Serializer::Writer &wr);
+	void ToJson(Json::Value &jsonObj);
 
 	~Galaxy();
 

--- a/src/galaxy/Galaxy.h
+++ b/src/galaxy/Galaxy.h
@@ -28,9 +28,7 @@ public:
 	const float SOL_OFFSET_X;
 	const float SOL_OFFSET_Y;
 
-	static RefCountedPtr<Galaxy> Load(Serializer::Reader &rd);
 	static RefCountedPtr<Galaxy> LoadFromJson(const Json::Value &jsonObj);
-	void Serialize(Serializer::Writer &wr);
 	void ToJson(Json::Value &jsonObj);
 
 	~Galaxy();

--- a/src/galaxy/GalaxyGenerator.cpp
+++ b/src/galaxy/GalaxyGenerator.cpp
@@ -106,19 +106,6 @@ RefCountedPtr<Galaxy> GalaxyGenerator::CreateFromJson(const Json::Value &jsonObj
 	return galaxy;
 }
 
-void GalaxyGenerator::Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy)
-{
-	wr.String(m_name);
-	if (m_name == "legacy" && m_version == 0)
-		wr.Int32(1); // Promote savegame
-	else
-		wr.Int32(m_version);
-	for (SectorGeneratorStage* secgen : m_sectorStage)
-		secgen->Serialize(wr, galaxy);
-	for (StarSystemGeneratorStage* sysgen : m_starSystemStage)
-		sysgen->Serialize(wr, galaxy);
-}
-
 void GalaxyGenerator::ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)
 {
 	Json::Value galaxyGenObj(Json::objectValue); // Create JSON object to contain galaxy data.
@@ -148,14 +135,6 @@ void GalaxyGenerator::ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)
 	galaxyGenObj["star_system_stage"] = starSystemStageArray; // Add system stage array to galaxy generator object.
 
 	jsonObj["galaxy_generator"] = galaxyGenObj; // Add galaxy generator object to supplied object.
-}
-
-void GalaxyGenerator::Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy)
-{
-	for (SectorGeneratorStage* secgen : m_sectorStage)
-		secgen->Unserialize(rd, galaxy);
-	for (StarSystemGeneratorStage* sysgen : m_starSystemStage)
-		sysgen->Unserialize(rd, galaxy);
 }
 
 void GalaxyGenerator::FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)

--- a/src/galaxy/GalaxyGenerator.cpp
+++ b/src/galaxy/GalaxyGenerator.cpp
@@ -90,6 +90,22 @@ RefCountedPtr<Galaxy> GalaxyGenerator::Create(Serializer::Reader& rd)
 	return galaxy;
 }
 
+// static
+RefCountedPtr<Galaxy> GalaxyGenerator::CreateFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("name")) throw SavedGameCorruptException();
+	if (!jsonObj.isMember("version")) throw SavedGameCorruptException();
+
+	std::string genName = jsonObj["name"].asString();
+	GalaxyGenerator::Version genVersion = jsonObj["version"].asInt();
+	RefCountedPtr<Galaxy> galaxy = GalaxyGenerator::Create(genName, genVersion);
+	if (!galaxy) {
+		Output("can't load savefile, unsupported galaxy generator %s, version %d\n", genName.c_str(), genVersion);
+		throw SavedGameWrongVersionException();
+	}
+	return galaxy;
+}
+
 void GalaxyGenerator::Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy)
 {
 	wr.String(m_name);
@@ -103,12 +119,60 @@ void GalaxyGenerator::Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> ga
 		sysgen->Serialize(wr, galaxy);
 }
 
+void GalaxyGenerator::ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)
+{
+	Json::Value galaxyGenObj(Json::objectValue); // Create JSON object to contain galaxy data.
+
+	galaxyGenObj["name"] = m_name;
+
+	if (m_name == "legacy" && m_version == 0)
+		galaxyGenObj["version"] = 1; // Promote savegame
+	else
+		galaxyGenObj["version"] = m_version;
+
+	Json::Value sectorStageArray(Json::arrayValue); // Create JSON array to contain sector stage data.
+	for (SectorGeneratorStage* secgen : m_sectorStage)
+	{
+		Json::Value sectorStageArrayEl(Json::objectValue); // Create JSON object to contain sector stage element.
+		secgen->ToJson(sectorStageArrayEl, galaxy);
+		sectorStageArray.append(sectorStageArrayEl); // Append sector stage object to array.
+	}
+	Json::Value starSystemStageArray(Json::arrayValue); // Create JSON array to contain system stage data.
+	for (StarSystemGeneratorStage* sysgen : m_starSystemStage)
+	{
+		Json::Value starSystemStageArrayEl(Json::objectValue); // Create JSON object to contain system stage element.
+		sysgen->ToJson(starSystemStageArrayEl, galaxy);
+		starSystemStageArray.append(starSystemStageArrayEl); // Append system stage object to array.
+	}
+	galaxyGenObj["sector_stage"] = sectorStageArray; // Add sector stage array to galaxy generator object.
+	galaxyGenObj["star_system_stage"] = starSystemStageArray; // Add system stage array to galaxy generator object.
+
+	jsonObj["galaxy_generator"] = galaxyGenObj; // Add galaxy generator object to supplied object.
+}
+
 void GalaxyGenerator::Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy)
 {
 	for (SectorGeneratorStage* secgen : m_sectorStage)
 		secgen->Unserialize(rd, galaxy);
 	for (StarSystemGeneratorStage* sysgen : m_starSystemStage)
 		sysgen->Unserialize(rd, galaxy);
+}
+
+void GalaxyGenerator::FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)
+{
+	if (!jsonObj.isMember("sector_stage")) throw SavedGameCorruptException();
+	if (!jsonObj.isMember("star_system_stage")) throw SavedGameCorruptException();
+	Json::Value sectorStageArray = jsonObj["sector_stage"];
+	Json::Value starSystemStageArray = jsonObj["star_system_stage"];
+	if (!sectorStageArray.isArray()) throw SavedGameCorruptException();
+	if (!starSystemStageArray.isArray()) throw SavedGameCorruptException();
+
+	unsigned int arrayIndex = 0;
+	for (SectorGeneratorStage* secgen : m_sectorStage)
+		secgen->FromJson(sectorStageArray[arrayIndex++], galaxy);
+	arrayIndex = 0;
+	for (StarSystemGeneratorStage* sysgen : m_starSystemStage)
+		sysgen->FromJson(starSystemStageArray[arrayIndex++], galaxy);
 }
 
 GalaxyGenerator::~GalaxyGenerator()

--- a/src/galaxy/GalaxyGenerator.h
+++ b/src/galaxy/GalaxyGenerator.h
@@ -41,9 +41,7 @@ public:
 
 	bool IsDefault() const { return m_name == s_defaultGenerator && m_version == s_defaultVersion; }
 
-	void Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy);
 	void ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
-	void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy);
 	void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
 
 	// Templated for the template cache class.

--- a/src/galaxy/GalaxyGenerator.h
+++ b/src/galaxy/GalaxyGenerator.h
@@ -94,9 +94,7 @@ class GalaxyGeneratorStage {
 public:
 	virtual ~GalaxyGeneratorStage() { }
 
-	virtual void Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy) { }
 	virtual void ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy) { }
-	virtual void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy) { }
 	virtual void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy) { }
 
 protected:

--- a/src/galaxy/GalaxyGenerator.h
+++ b/src/galaxy/GalaxyGenerator.h
@@ -28,6 +28,7 @@ public:
 		return Create(s_defaultGenerator, s_defaultVersion);
 	}
 	static RefCountedPtr<Galaxy> Create(Serializer::Reader& rd);
+	static RefCountedPtr<Galaxy> CreateFromJson(const Json::Value &jsonObj);
 
 	static std::string GetDefaultGeneratorName() { return s_defaultGenerator; }
 	static Version GetDefaultGeneratorVersion() { return s_defaultVersion; }
@@ -41,7 +42,9 @@ public:
 	bool IsDefault() const { return m_name == s_defaultGenerator && m_version == s_defaultVersion; }
 
 	void Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy);
+	void ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
 	void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy);
+	void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
 
 	// Templated for the template cache class.
 	template <typename T, typename Cache>
@@ -94,7 +97,9 @@ public:
 	virtual ~GalaxyGeneratorStage() { }
 
 	virtual void Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy) { }
+	virtual void ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy) { }
 	virtual void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy) { }
+	virtual void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy) { }
 
 protected:
 	GalaxyGeneratorStage() : m_galaxyGenerator(nullptr) { }

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -361,23 +361,11 @@ bool SectorPersistenceGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> galaxy
 	return true;
 }
 
-void SectorPersistenceGenerator::Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy)
-{
-	m_exploredSystems.Clear();
-	if (m_version >= 1)
-		m_exploredSystems.Unserialize(rd, &m_exploredSystems);
-}
-
 void SectorPersistenceGenerator::FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)
 {
 	m_exploredSystems.Clear();
 	if (m_version >= 1)
 		m_exploredSystems.FromJson(jsonObj, &m_exploredSystems);
-}
-
-void SectorPersistenceGenerator::Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy)
-{
-	m_exploredSystems.Serialize(wr);
 }
 
 void SectorPersistenceGenerator::ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -368,7 +368,19 @@ void SectorPersistenceGenerator::Unserialize(Serializer::Reader &rd, RefCountedP
 		m_exploredSystems.Unserialize(rd, &m_exploredSystems);
 }
 
+void SectorPersistenceGenerator::FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)
+{
+	m_exploredSystems.Clear();
+	if (m_version >= 1)
+		m_exploredSystems.FromJson(jsonObj, &m_exploredSystems);
+}
+
 void SectorPersistenceGenerator::Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy)
 {
 	m_exploredSystems.Serialize(wr);
+}
+
+void SectorPersistenceGenerator::ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy)
+{
+	m_exploredSystems.ToJson(jsonObj);
 }

--- a/src/galaxy/SectorGenerator.h
+++ b/src/galaxy/SectorGenerator.h
@@ -31,9 +31,7 @@ class SectorPersistenceGenerator : public SectorGeneratorStage {
 public:
 	SectorPersistenceGenerator(GalaxyGenerator::Version version) : m_version(version) { }
 	virtual bool Apply(Random& rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<Sector> sector, GalaxyGenerator::SectorConfig* config);
-	virtual void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy);
 	virtual void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
-	virtual void Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy);
 	virtual void ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
 
 private:

--- a/src/galaxy/SectorGenerator.h
+++ b/src/galaxy/SectorGenerator.h
@@ -32,7 +32,9 @@ public:
 	SectorPersistenceGenerator(GalaxyGenerator::Version version) : m_version(version) { }
 	virtual bool Apply(Random& rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<Sector> sector, GalaxyGenerator::SectorConfig* config);
 	virtual void Unserialize(Serializer::Reader &rd, RefCountedPtr<Galaxy> galaxy);
+	virtual void FromJson(const Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
 	virtual void Serialize(Serializer::Writer &wr, RefCountedPtr<Galaxy> galaxy);
+	virtual void ToJson(Json::Value &jsonObj, RefCountedPtr<Galaxy> galaxy);
 
 private:
 	void SetExplored(Sector::System* sys, StarSystem::ExplorationState e, double time);

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -830,19 +830,6 @@ StarSystem::~StarSystem()
 		m_cache->RemoveFromAttic(m_path);
 }
 
-void StarSystem::Serialize(Serializer::Writer &wr, StarSystem *s)
-{
-	if (s) {
-		wr.Byte(1);
-		wr.Int32(s->m_path.sectorX);
-		wr.Int32(s->m_path.sectorY);
-		wr.Int32(s->m_path.sectorZ);
-		wr.Int32(s->m_path.systemIndex);
-	} else {
-		wr.Byte(0);
-	}
-}
-
 void StarSystem::ToJson(Json::Value &jsonObj, StarSystem *s)
 {
 	if (s)
@@ -853,19 +840,6 @@ void StarSystem::ToJson(Json::Value &jsonObj, StarSystem *s)
 		starSystemObj["sector_z"] = s->m_path.sectorZ;
 		starSystemObj["system_index"] = s->m_path.systemIndex;
 		jsonObj["star_system"] = starSystemObj; // Add star system object to supplied object.
-	}
-}
-
-RefCountedPtr<StarSystem> StarSystem::Unserialize(RefCountedPtr<Galaxy> galaxy, Serializer::Reader &rd)
-{
-	if (rd.Byte()) {
-		int sec_x = rd.Int32();
-		int sec_y = rd.Int32();
-		int sec_z = rd.Int32();
-		int sys_idx = rd.Int32();
-		return galaxy->GetStarSystem(SystemPath(sec_x, sec_y, sec_z, sys_idx));
-	} else {
-		return RefCountedPtr<StarSystem>(0);
 	}
 }
 

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -843,6 +843,19 @@ void StarSystem::Serialize(Serializer::Writer &wr, StarSystem *s)
 	}
 }
 
+void StarSystem::ToJson(Json::Value &jsonObj, StarSystem *s)
+{
+	if (s)
+	{
+		Json::Value starSystemObj(Json::objectValue); // Create JSON object to contain star system data.
+		starSystemObj["sector_x"] = s->m_path.sectorX;
+		starSystemObj["sector_y"] = s->m_path.sectorY;
+		starSystemObj["sector_z"] = s->m_path.sectorZ;
+		starSystemObj["system_index"] = s->m_path.systemIndex;
+		jsonObj["star_system"] = starSystemObj; // Add star system object to supplied object.
+	}
+}
+
 RefCountedPtr<StarSystem> StarSystem::Unserialize(RefCountedPtr<Galaxy> galaxy, Serializer::Reader &rd)
 {
 	if (rd.Byte()) {
@@ -854,6 +867,24 @@ RefCountedPtr<StarSystem> StarSystem::Unserialize(RefCountedPtr<Galaxy> galaxy, 
 	} else {
 		return RefCountedPtr<StarSystem>(0);
 	}
+}
+
+RefCountedPtr<StarSystem> StarSystem::FromJson(RefCountedPtr<Galaxy> galaxy, const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("star_system")) return RefCountedPtr<StarSystem>(0); // No star system
+
+	Json::Value starSystemObj = jsonObj["star_system"];
+
+	if (!starSystemObj.isMember("sector_x")) throw SavedGameCorruptException();
+	if (!starSystemObj.isMember("sector_y")) throw SavedGameCorruptException();
+	if (!starSystemObj.isMember("sector_z")) throw SavedGameCorruptException();
+	if (!starSystemObj.isMember("system_index")) throw SavedGameCorruptException();
+
+	int sec_x = starSystemObj["sector_x"].asInt();
+	int sec_y = starSystemObj["sector_y"].asInt();
+	int sec_z = starSystemObj["sector_z"].asInt();
+	int sys_idx = starSystemObj["system_index"].asUInt();
+	return galaxy->GetStarSystem(SystemPath(sec_x, sec_y, sec_z, sys_idx));
 }
 
 std::string StarSystem::ExportBodyToLua(FILE *f, SystemBody *body) {

--- a/src/galaxy/StarSystem.h
+++ b/src/galaxy/StarSystem.h
@@ -301,7 +301,9 @@ public:
 	SystemPath GetPathOf(const SystemBody *sbody) const;
 	SystemBody *GetBodyByPath(const SystemPath &path) const;
 	static void Serialize(Serializer::Writer &wr, StarSystem *);
+	static void ToJson(Json::Value &jsonObj, StarSystem *);
 	static RefCountedPtr<StarSystem> Unserialize(RefCountedPtr<Galaxy> galaxy, Serializer::Reader &rd);
+	static RefCountedPtr<StarSystem> FromJson(RefCountedPtr<Galaxy> galaxy, const Json::Value &jsonObj);
 	const SystemPath &GetPath() const { return m_path; }
 	const std::string& GetShortDescription() const { return m_shortDesc; }
 	const std::string& GetLongDescription() const { return m_longDesc; }

--- a/src/galaxy/StarSystem.h
+++ b/src/galaxy/StarSystem.h
@@ -300,9 +300,7 @@ public:
 	const std::string &GetName() const { return m_name; }
 	SystemPath GetPathOf(const SystemBody *sbody) const;
 	SystemBody *GetBodyByPath(const SystemPath &path) const;
-	static void Serialize(Serializer::Writer &wr, StarSystem *);
 	static void ToJson(Json::Value &jsonObj, StarSystem *);
-	static RefCountedPtr<StarSystem> Unserialize(RefCountedPtr<Galaxy> galaxy, Serializer::Reader &rd);
 	static RefCountedPtr<StarSystem> FromJson(RefCountedPtr<Galaxy> galaxy, const Json::Value &jsonObj);
 	const SystemPath &GetPath() const { return m_path; }
 	const std::string& GetShortDescription() const { return m_shortDesc; }

--- a/src/galaxy/SystemPath.h
+++ b/src/galaxy/SystemPath.h
@@ -6,6 +6,7 @@
 
 #include "Serializer.h"
 #include "LuaWrappable.h"
+#include "json/json.h"
 #include <stdexcept>
 
 class SystemPath : public LuaWrappable {
@@ -128,12 +129,36 @@ public:
 		wr.Int32(Uint32(systemIndex));
 		wr.Int32(Uint32(bodyIndex));
 	}
+	void ToJson(Json::Value &jsonObj) const {
+		Json::Value systemPathObj(Json::objectValue); // Create JSON object to contain system path data.
+		systemPathObj["sector_x"] = sectorX;
+		systemPathObj["sector_y"] = sectorY;
+		systemPathObj["sector_z"] = sectorZ;
+		systemPathObj["system_index"] = systemIndex;
+		systemPathObj["body_index"] = bodyIndex;
+		jsonObj["system_path"] = systemPathObj; // Add system path object to supplied object.
+	}
 	static SystemPath Unserialize(Serializer::Reader &rd) {
 		Uint32 x = rd.Int32();
 		Uint32 y = rd.Int32();
 		Uint32 z = rd.Int32();
 		Sint32 si = Sint32(rd.Int32());
 		Sint32 bi = Sint32(rd.Int32());
+		return SystemPath(x, y, z, si, bi);
+	}
+	static SystemPath FromJson(const Json::Value &jsonObj) {
+		if (!jsonObj.isMember("system_path")) throw SavedGameCorruptException();
+		Json::Value systemPathObj = jsonObj["system_path"];
+		if (!systemPathObj.isMember("sector_x")) throw SavedGameCorruptException();
+		if (!systemPathObj.isMember("sector_y")) throw SavedGameCorruptException();
+		if (!systemPathObj.isMember("sector_z")) throw SavedGameCorruptException();
+		if (!systemPathObj.isMember("system_index")) throw SavedGameCorruptException();
+		if (!systemPathObj.isMember("body_index")) throw SavedGameCorruptException();
+		Sint32 x = systemPathObj["sector_x"].asInt();
+		Sint32 y = systemPathObj["sector_y"].asInt();
+		Sint32 z = systemPathObj["sector_z"].asInt();
+		Uint32 si = systemPathObj["system_index"].asUInt();
+		Uint32 bi = systemPathObj["body_index"].asUInt();
 		return SystemPath(x, y, z, si, bi);
 	}
 

--- a/src/galaxy/SystemPath.h
+++ b/src/galaxy/SystemPath.h
@@ -122,13 +122,6 @@ public:
 		return SystemPath(sectorX, sectorY, sectorZ, systemIndex);
 	}
 
-	void Serialize(Serializer::Writer &wr) const {
-		wr.Int32(sectorX);
-		wr.Int32(sectorY);
-		wr.Int32(sectorZ);
-		wr.Int32(Uint32(systemIndex));
-		wr.Int32(Uint32(bodyIndex));
-	}
 	void ToJson(Json::Value &jsonObj) const {
 		Json::Value systemPathObj(Json::objectValue); // Create JSON object to contain system path data.
 		systemPathObj["sector_x"] = sectorX;
@@ -137,14 +130,6 @@ public:
 		systemPathObj["system_index"] = systemIndex;
 		systemPathObj["body_index"] = bodyIndex;
 		jsonObj["system_path"] = systemPathObj; // Add system path object to supplied object.
-	}
-	static SystemPath Unserialize(Serializer::Reader &rd) {
-		Uint32 x = rd.Int32();
-		Uint32 y = rd.Int32();
-		Uint32 z = rd.Int32();
-		Sint32 si = Sint32(rd.Int32());
-		Sint32 bi = Sint32(rd.Int32());
-		return SystemPath(x, y, z, si, bi);
 	}
 	static SystemPath FromJson(const Json::Value &jsonObj) {
 		if (!jsonObj.isMember("system_path")) throw SavedGameCorruptException();

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -8,6 +8,7 @@
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
 #include "StringF.h"
+#include "json/JsonUtils.h"
 
 namespace SceneGraph {
 
@@ -445,6 +446,22 @@ private:
 	Serializer::Writer *wr;
 };
 
+class SaveVisitorJson : public NodeVisitor {
+public:
+	SaveVisitorJson(Json::Value &jsonObj) : m_jsonArray(jsonObj) {}
+
+	void ApplyMatrixTransform(MatrixTransform &node)
+	{
+		const matrix4x4f &m = node.GetTransform();
+		Json::Value matrixTransformObj(Json::objectValue); // Create JSON object to contain matrix transform data.
+		MatrixToJson(matrixTransformObj, m, "matrix_transform");
+		m_jsonArray.append(matrixTransformObj); // Append matrix transform object to array.
+	}
+
+private:
+	Json::Value &m_jsonArray;
+};
+
 void Model::Save(Serializer::Writer &wr) const
 {
 	SaveVisitor sv(&wr);
@@ -454,6 +471,25 @@ void Model::Save(Serializer::Writer &wr) const
 		wr.Double((*i)->GetProgress());
 
 	wr.Int32(m_curPatternIndex);
+}
+
+void Model::SaveToJson(Json::Value &jsonObj) const
+{
+	Json::Value modelObj(Json::objectValue); // Create JSON object to contain model data.
+
+	Json::Value visitorArray(Json::arrayValue); // Create JSON array to contain visitor data.
+	SaveVisitorJson sv(visitorArray);
+	m_root->Accept(sv);
+	modelObj["visitor"] = visitorArray; // Add visitor array to model object.
+
+	Json::Value animationArray(Json::arrayValue); // Create JSON array to contain animation data.
+	for (AnimationContainer::const_iterator i = m_animations.begin(); i != m_animations.end(); ++i)
+		animationArray.append(DoubleToStr((*i)->GetProgress()));
+	modelObj["animations"] = animationArray; // Add animation array to model object.
+
+	modelObj["cur_pattern_index"] = m_curPatternIndex;
+
+	jsonObj["model"] = modelObj; // Add model object to supplied object.
 }
 
 class LoadVisitor : public NodeVisitor {
@@ -471,6 +507,22 @@ private:
 	Serializer::Reader *rd;
 };
 
+class LoadVisitorJson : public NodeVisitor {
+public:
+	LoadVisitorJson(const Json::Value &jsonObj) : m_jsonArray(jsonObj), m_arrayIndex(0) {}
+
+	void ApplyMatrixTransform(MatrixTransform &node)
+	{
+		matrix4x4f m;
+		JsonToMatrix(&m, m_jsonArray[m_arrayIndex++], "matrix_transform");
+		node.SetTransform(m);
+	}
+
+private:
+	const Json::Value &m_jsonArray;
+	unsigned int m_arrayIndex;
+};
+
 void Model::Load(Serializer::Reader &rd)
 {
 	LoadVisitor lv(&rd);
@@ -481,6 +533,30 @@ void Model::Load(Serializer::Reader &rd)
 	UpdateAnimations();
 
 	SetPattern(rd.Int32());
+}
+
+void Model::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("model")) throw SavedGameCorruptException();
+	Json::Value modelObj = jsonObj["model"];
+	if (!modelObj.isMember("visitor")) throw SavedGameCorruptException();
+	if (!modelObj.isMember("animations")) throw SavedGameCorruptException();
+	if (!modelObj.isMember("cur_pattern_index")) throw SavedGameCorruptException();
+
+	Json::Value visitorArray = modelObj["visitor"];
+	if (!visitorArray.isArray()) throw SavedGameCorruptException();
+	LoadVisitorJson lv(visitorArray);
+	m_root->Accept(lv);
+
+	Json::Value animationArray = modelObj["animations"];
+	if (!animationArray.isArray()) throw SavedGameCorruptException();
+	assert(m_animations.size() == animationArray.size());
+	unsigned int arrayIndex = 0;
+	for (AnimationContainer::const_iterator i = m_animations.begin(); i != m_animations.end(); ++i)
+		(*i)->SetProgress(StrToDouble(animationArray[arrayIndex++].asString()));
+	UpdateAnimations();
+
+	SetPattern(modelObj["cur_pattern_index"].asUInt());
 }
 
 std::string Model::GetNameForMaterial(Graphics::Material *mat) const

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -70,6 +70,7 @@
 #include "graphics/Drawables.h"
 #include "Serializer.h"
 #include "DeleteEmitter.h"
+#include "json/json.h"
 #include <stdexcept>
 
 namespace Graphics { 
@@ -148,7 +149,9 @@ public:
 	void SetThrust(const vector3f &linear, const vector3f &angular);
 
 	void Save(Serializer::Writer &wr) const;
+	void SaveToJson(Json::Value &jsonObj) const;
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 
 	//serialization aid
 	std::string GetNameForMaterial(Graphics::Material*) const;

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -148,9 +148,7 @@ public:
 	//special for ship model use
 	void SetThrust(const vector3f &linear, const vector3f &angular);
 
-	void Save(Serializer::Writer &wr) const;
 	void SaveToJson(Json::Value &jsonObj) const;
-	void Load(Serializer::Reader &rd);
 	void LoadFromJson(const Json::Value &jsonObj);
 
 	//serialization aid

--- a/src/scenegraph/ModelSkin.cpp
+++ b/src/scenegraph/ModelSkin.cpp
@@ -5,6 +5,7 @@
 #include "Model.h"
 #include "StringF.h"
 #include "graphics/TextureBuilder.h"
+#include "json/JsonUtils.h"
 #include <SDL_stdinc.h>
 
 namespace SceneGraph {
@@ -98,6 +99,38 @@ void ModelSkin::Load(Serializer::Reader &rd)
 	m_label = rd.String();
 }
 
+void ModelSkin::LoadFromJson(const Json::Value &jsonObj)
+{
+	if (!jsonObj.isMember("model_skin")) throw SavedGameCorruptException();
+	Json::Value modelSkinObj = jsonObj["model_skin"];
+
+	if (!modelSkinObj.isMember("colors")) throw SavedGameCorruptException();
+	if (!modelSkinObj.isMember("decals")) throw SavedGameCorruptException();
+	if (!modelSkinObj.isMember("label")) throw SavedGameCorruptException();
+
+	Json::Value colorsArray = modelSkinObj["colors"];
+	if (!colorsArray.isArray()) throw SavedGameCorruptException();
+	if (colorsArray.size() != 3) throw SavedGameCorruptException();
+	for (unsigned int i = 0; i < 3; i++)
+	{
+		Json::Value colorsArrayEl = colorsArray[i];
+		if (!colorsArrayEl.isMember("color")) throw SavedGameCorruptException();
+		JsonToColor(&(m_colors[i]), colorsArrayEl, "color");
+	}
+
+	Json::Value decalsArray = modelSkinObj["decals"];
+	if (!decalsArray.isArray()) throw SavedGameCorruptException();
+	if (decalsArray.size() != MAX_DECAL_MATERIALS) throw SavedGameCorruptException();
+	for (unsigned int i = 0; i < MAX_DECAL_MATERIALS; i++)
+	{
+		Json::Value decalsArrayEl = decalsArray[i];
+		if (!decalsArrayEl.isMember("decal")) throw SavedGameCorruptException();
+		m_decals[i] = decalsArrayEl["decal"].asString();
+	}
+
+	m_label = modelSkinObj["label"].asString();
+}
+
 void ModelSkin::Save(Serializer::Writer &wr) const
 {
 	for (unsigned int i = 0; i < 3; i++) {
@@ -108,6 +141,33 @@ void ModelSkin::Save(Serializer::Writer &wr) const
 	for (unsigned int i = 0; i < MAX_DECAL_MATERIALS; i++)
 		wr.String(m_decals[i]);
 	wr.String(m_label);
+}
+
+void ModelSkin::SaveToJson(Json::Value &jsonObj) const
+{
+	Json::Value modelSkinObj(Json::objectValue); // Create JSON object to contain model skin data.
+
+	Json::Value colorsArray(Json::arrayValue); // Create JSON array to contain colors data.
+	for (unsigned int i = 0; i < 3; i++)
+	{
+		Json::Value colorsArrayEl(Json::objectValue); // Create JSON object to contain color.
+		ColorToJson(colorsArrayEl, m_colors[i], "color");
+		colorsArray.append(colorsArrayEl); // Append color object to colors array.
+	}
+	modelSkinObj["colors"] = colorsArray; // Add colors array to model skin object.
+
+	Json::Value decalsArray(Json::arrayValue); // Create JSON array to contain decals data.
+	for (unsigned int i = 0; i < MAX_DECAL_MATERIALS; i++)
+	{
+		Json::Value decalsArrayEl(Json::objectValue); // Create JSON object to contain decal.
+		decalsArrayEl["decal"] = m_decals[i];
+		decalsArray.append(decalsArrayEl); // Append decal object to decals array.
+	}
+	modelSkinObj["decals"] = decalsArray; // Add decals array to model skin object.
+
+	modelSkinObj["label"] = m_label;
+
+	jsonObj["model_skin"] = modelSkinObj; // Add model skin object to supplied object.
 }
 
 }

--- a/src/scenegraph/ModelSkin.h
+++ b/src/scenegraph/ModelSkin.h
@@ -8,6 +8,7 @@
 #include "Serializer.h"
 #include "Random.h"
 #include "LuaWrappable.h"
+#include "json/json.h"
 #include <string>
 
 namespace SceneGraph {

--- a/src/scenegraph/ModelSkin.h
+++ b/src/scenegraph/ModelSkin.h
@@ -33,7 +33,9 @@ public:
 	void SetLabel(const std::string &label);
 
 	void Load(Serializer::Reader &rd);
+	void LoadFromJson(const Json::Value &jsonObj);
 	void Save(Serializer::Writer &wr) const;
+	void SaveToJson(Json::Value &jsonObj) const;
 
 private:
 	static const unsigned int MAX_DECAL_MATERIALS = 4;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -215,6 +215,220 @@ const char *pi_strcasestr (const char *haystack, const char *needle)
 	}
 }
 
+std::string SInt64ToStr(Sint64 val)
+{
+	char str[32];
+	sprintf(str, "%I64d", val);
+	return str;
+}
+
+std::string UInt64ToStr(Uint64 val)
+{
+	char str[32];
+	sprintf(str, "%I64u", val);
+	return str;
+}
+
+std::string FloatToStr(float val)
+{
+	// Can't get hexfloats to work.
+	//char hex[128]; // Probably don't need such a large char array.
+	//std::sprintf(hex, "%a", val);
+	//return hex;
+
+	// Lossy method storing as decimal and exponent.
+	//char str[128]; // Probably don't need such a large char array.
+	//std::sprintf(str, "%.7e", val);
+	//return str;
+
+	// Exact representation (but not human readable).
+	static_assert(sizeof(float) == 4 || sizeof(float) == 8, "float isn't 4 or 8 bytes");
+	if (sizeof(float) == 4)
+	{
+		uint32_t intVal;
+		memcpy(&intVal, &val, 4);
+		char str[16];
+		std::sprintf(str, "%I32u", intVal);
+		//std::sprintf(str, "%lu", intVal); // Also works
+		return str;
+	}
+	else // sizeof(float) == 8
+	{
+		uint64_t intVal;
+		memcpy(&intVal, &val, 8);
+		char str[32];
+		std::sprintf(str, "%I64u", intVal);
+		//std::sprintf(str, "%llu", intVal); // Also works
+		return str;
+	}
+}
+
+std::string DoubleToStr(double val)
+{
+	// Can't get hexfloats to work.
+	//char hex[128]; // Probably don't need such a large char array.
+	//std::sprintf(hex, "%la", val);
+	//return hex;
+
+	// Lossy method storing as decimal and exponent.
+	//char str[128]; // Probably don't need such a large char array.
+	//std::sprintf(str, "%.15le", val);
+	//return str;
+
+	// Exact representation (but not human readable).
+	static_assert(sizeof(double) == 4 || sizeof(double) == 8, "double isn't 4 or 8 bytes");
+	if (sizeof(double) == 4)
+	{
+		uint32_t intVal;
+		memcpy(&intVal, &val, 4);
+		char str[16];
+		std::sprintf(str, "%I32u", intVal);
+		//std::sprintf(str, "%lu", intVal); // Also works
+		return str;
+	}
+	else // sizeof(double) == 8
+	{
+		uint64_t intVal;
+		memcpy(&intVal, &val, 8);
+		char str[32];
+		std::sprintf(str, "%I64u", intVal);
+		//std::sprintf(str, "%llu", intVal); // Also works
+		return str;
+	}
+}
+
+std::string AutoToStr(Sint32 val)
+{
+	char str[16];
+	sprintf(str, "%I32d", val);
+	return str;
+}
+
+std::string AutoToStr(Sint64 val)
+{
+	char str[32];
+	sprintf(str, "%I64d", val);
+	return str;
+}
+
+std::string AutoToStr(float val)
+{
+	return FloatToStr(val);
+}
+
+std::string AutoToStr(double val)
+{
+	return DoubleToStr(val);
+}
+
+Sint64 StrToSInt64(const std::string &str)
+{
+	Sint64 val;
+	std::sscanf(str.c_str(), "%I64d", &val);
+	return val;
+}
+
+Uint64 StrToUInt64(const std::string &str)
+{
+	Uint64 val;
+	std::sscanf(str.c_str(), "%I64u", &val);
+	return val;
+}
+
+float StrToFloat(const std::string &str)
+{
+	// Can't get hexfloats to work.
+	//return std::strtof(str.c_str(), 0);
+
+	// Can't get hexfloats to work.
+	//float val;
+	//std::sscanf(str.c_str(), "%a", &val);
+	//return val;
+
+	// Lossy method storing as decimal and exponent.
+	//float val;
+	//std::sscanf(str.c_str(), "%e", &val);
+	//return val;
+
+	// Exact representation (but not human readable).
+	static_assert(sizeof(float) == 4 || sizeof(float) == 8, "float isn't 4 or 8 bytes");
+	if (sizeof(float) == 4)
+	{
+		uint32_t intVal;
+		std::sscanf(str.c_str(), "%I32u", &intVal);
+		//std::sscanf(str.c_str(), "%lu", &intVal); // Also works
+		float val;
+		memcpy(&val, &intVal, 4);
+		return val;
+	}
+	else // sizeof(float) == 8
+	{
+		uint64_t intVal;
+		std::sscanf(str.c_str(), "%I64u", &intVal);
+		//std::sscanf(str.c_str(), "%llu", &intVal); // Also works
+		float val;
+		memcpy(&val, &intVal, 8);
+		return val;
+	}
+}
+
+double StrToDouble(const std::string &str)
+{
+	// Can't get hexfloats to work.
+	//return std::strtod(str.c_str(), 0);
+
+	// Can't get hexfloats to work.
+	//double val;
+	//std::sscanf(str.c_str(), "%la", &val);
+	//return val;
+
+	// Lossy method storing as decimal and exponent.
+	//double val;
+	//std::sscanf(str.c_str(), "%le", &val);
+	//return val;
+
+	// Exact representation (but not human readable).
+	static_assert(sizeof(double) == 4 || sizeof(double) == 8, "double isn't 4 or 8 bytes");
+	if (sizeof(double) == 4)
+	{
+		uint32_t intVal;
+		std::sscanf(str.c_str(), "%I32u", &intVal);
+		//std::sscanf(str.c_str(), "%lu", &intVal); // Also works
+		double val;
+		memcpy(&val, &intVal, 4);
+		return val;
+	}
+	else // sizeof(double) == 8
+	{
+		uint64_t intVal;
+		std::sscanf(str.c_str(), "%I64u", &intVal);
+		//std::sscanf(str.c_str(), "%llu", &intVal); // Also works
+		double val;
+		memcpy(&val, &intVal, 8);
+		return val;
+	}
+}
+
+void StrToAuto(Sint32 *pVal, const std::string &str)
+{
+	std::sscanf(str.c_str(), "%I32d", pVal);
+}
+
+void StrToAuto(Sint64 *pVal, const std::string &str)
+{
+	std::sscanf(str.c_str(), "%I64d", pVal);
+}
+
+void StrToAuto(float *pVal, const std::string &str)
+{
+	*pVal = StrToFloat(str);
+}
+
+void StrToAuto(double *pVal, const std::string &str)
+{
+	*pVal = StrToDouble(str);
+}
+
 static const int HEXDUMP_CHUNK = 16;
 void hexdump(const unsigned char *buf, int len)
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -218,14 +218,16 @@ const char *pi_strcasestr (const char *haystack, const char *needle)
 std::string SInt64ToStr(Sint64 val)
 {
 	char str[128];
-	sprintf(str, "%I64d", val);
+	//sprintf(str, "%I64d", val); // Windows
+	sprintf(str, "%lld", val);
 	return str;
 }
 
 std::string UInt64ToStr(Uint64 val)
 {
 	char str[128];
-	sprintf(str, "%I64u", val);
+	//sprintf(str, "%I64u", val); // Windows
+	sprintf(str, "%llu", val);
 	return str;
 }
 
@@ -248,8 +250,8 @@ std::string FloatToStr(float val)
 		uint32_t intVal;
 		memcpy(&intVal, &val, 4);
 		char str[64];
-		std::sprintf(str, "%I32u", intVal);
-		//std::sprintf(str, "%lu", intVal); // Also works
+		//sprintf(str, "%I32u", intVal); // Windows
+		sprintf(str, "%lu", intVal);
 		return str;
 	}
 	else // sizeof(float) == 8
@@ -257,8 +259,8 @@ std::string FloatToStr(float val)
 		uint64_t intVal;
 		memcpy(&intVal, &val, 8);
 		char str[128];
-		std::sprintf(str, "%I64u", intVal);
-		//std::sprintf(str, "%llu", intVal); // Also works
+		//sprintf(str, "%I64u", intVal); // Windows
+		sprintf(str, "%llu", intVal);
 		return str;
 	}
 }
@@ -282,8 +284,8 @@ std::string DoubleToStr(double val)
 		uint32_t intVal;
 		memcpy(&intVal, &val, 4);
 		char str[64];
-		std::sprintf(str, "%I32u", intVal);
-		//std::sprintf(str, "%lu", intVal); // Also works
+		//sprintf(str, "%I32u", intVal); // Windows
+		sprintf(str, "%lu", intVal);
 		return str;
 	}
 	else // sizeof(double) == 8
@@ -291,8 +293,8 @@ std::string DoubleToStr(double val)
 		uint64_t intVal;
 		memcpy(&intVal, &val, 8);
 		char str[128];
-		std::sprintf(str, "%I64u", intVal);
-		//std::sprintf(str, "%llu", intVal); // Also works
+		//sprintf(str, "%I64u", intVal); // Windows
+		sprintf(str, "%llu", intVal);
 		return str;
 	}
 }
@@ -300,14 +302,16 @@ std::string DoubleToStr(double val)
 std::string AutoToStr(Sint32 val)
 {
 	char str[64];
-	sprintf(str, "%I32d", val);
+	//sprintf(str, "%I32d", val); // Windows
+	sprintf(str, "%ld", val);
 	return str;
 }
 
 std::string AutoToStr(Sint64 val)
 {
 	char str[128];
-	sprintf(str, "%I64d", val);
+	//sprintf(str, "%I64d", val); // Windows
+	sprintf(str, "%lld", val);
 	return str;
 }
 
@@ -324,14 +328,16 @@ std::string AutoToStr(double val)
 Sint64 StrToSInt64(const std::string &str)
 {
 	Sint64 val;
-	std::sscanf(str.c_str(), "%I64d", &val);
+	//sscanf(str.c_str(), "%I64d", &val); // Windows
+	sscanf(str.c_str(), "%lld", &val);
 	return val;
 }
 
 Uint64 StrToUInt64(const std::string &str)
 {
 	Uint64 val;
-	std::sscanf(str.c_str(), "%I64u", &val);
+	//sscanf(str.c_str(), "%I64u", &val); // Windows
+	sscanf(str.c_str(), "%llu", &val);
 	return val;
 }
 
@@ -355,8 +361,8 @@ float StrToFloat(const std::string &str)
 	if (sizeof(float) == 4)
 	{
 		uint32_t intVal;
-		std::sscanf(str.c_str(), "%I32u", &intVal);
-		//std::sscanf(str.c_str(), "%lu", &intVal); // Also works
+		//sscanf(str.c_str(), "%I32u", &intVal); // Windows
+		sscanf(str.c_str(), "%lu", &intVal);
 		float val;
 		memcpy(&val, &intVal, 4);
 		return val;
@@ -364,8 +370,8 @@ float StrToFloat(const std::string &str)
 	else // sizeof(float) == 8
 	{
 		uint64_t intVal;
-		std::sscanf(str.c_str(), "%I64u", &intVal);
-		//std::sscanf(str.c_str(), "%llu", &intVal); // Also works
+		//sscanf(str.c_str(), "%I64u", &intVal); // Windows
+		sscanf(str.c_str(), "%llu", &intVal);
 		float val;
 		memcpy(&val, &intVal, 8);
 		return val;
@@ -392,8 +398,8 @@ double StrToDouble(const std::string &str)
 	if (sizeof(double) == 4)
 	{
 		uint32_t intVal;
-		std::sscanf(str.c_str(), "%I32u", &intVal);
-		//std::sscanf(str.c_str(), "%lu", &intVal); // Also works
+		//sscanf(str.c_str(), "%I32u", &intVal); // Windows
+		sscanf(str.c_str(), "%lu", &intVal);
 		double val;
 		memcpy(&val, &intVal, 4);
 		return val;
@@ -401,8 +407,8 @@ double StrToDouble(const std::string &str)
 	else // sizeof(double) == 8
 	{
 		uint64_t intVal;
-		std::sscanf(str.c_str(), "%I64u", &intVal);
-		//std::sscanf(str.c_str(), "%llu", &intVal); // Also works
+		//sscanf(str.c_str(), "%I64u", &intVal); // Windows
+		sscanf(str.c_str(), "%llu", &intVal);
 		double val;
 		memcpy(&val, &intVal, 8);
 		return val;
@@ -411,12 +417,14 @@ double StrToDouble(const std::string &str)
 
 void StrToAuto(Sint32 *pVal, const std::string &str)
 {
-	std::sscanf(str.c_str(), "%I32d", pVal);
+	//sscanf(str.c_str(), "%I32d", pVal); // Windows
+	sscanf(str.c_str(), "%ld", pVal);
 }
 
 void StrToAuto(Sint64 *pVal, const std::string &str)
 {
-	std::sscanf(str.c_str(), "%I64d", pVal);
+	//sscanf(str.c_str(), "%I64d", pVal); // Windows
+	sscanf(str.c_str(), "%lld", pVal);
 }
 
 void StrToAuto(float *pVal, const std::string &str)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -217,14 +217,14 @@ const char *pi_strcasestr (const char *haystack, const char *needle)
 
 std::string SInt64ToStr(Sint64 val)
 {
-	char str[32];
+	char str[128];
 	sprintf(str, "%I64d", val);
 	return str;
 }
 
 std::string UInt64ToStr(Uint64 val)
 {
-	char str[32];
+	char str[128];
 	sprintf(str, "%I64u", val);
 	return str;
 }
@@ -247,7 +247,7 @@ std::string FloatToStr(float val)
 	{
 		uint32_t intVal;
 		memcpy(&intVal, &val, 4);
-		char str[16];
+		char str[64];
 		std::sprintf(str, "%I32u", intVal);
 		//std::sprintf(str, "%lu", intVal); // Also works
 		return str;
@@ -256,7 +256,7 @@ std::string FloatToStr(float val)
 	{
 		uint64_t intVal;
 		memcpy(&intVal, &val, 8);
-		char str[32];
+		char str[128];
 		std::sprintf(str, "%I64u", intVal);
 		//std::sprintf(str, "%llu", intVal); // Also works
 		return str;
@@ -281,7 +281,7 @@ std::string DoubleToStr(double val)
 	{
 		uint32_t intVal;
 		memcpy(&intVal, &val, 4);
-		char str[16];
+		char str[64];
 		std::sprintf(str, "%I32u", intVal);
 		//std::sprintf(str, "%lu", intVal); // Also works
 		return str;
@@ -290,7 +290,7 @@ std::string DoubleToStr(double val)
 	{
 		uint64_t intVal;
 		memcpy(&intVal, &val, 8);
-		char str[32];
+		char str[128];
 		std::sprintf(str, "%I64u", intVal);
 		//std::sprintf(str, "%llu", intVal); // Also works
 		return str;
@@ -299,14 +299,14 @@ std::string DoubleToStr(double val)
 
 std::string AutoToStr(Sint32 val)
 {
-	char str[16];
+	char str[64];
 	sprintf(str, "%I32d", val);
 	return str;
 }
 
 std::string AutoToStr(Sint64 val)
 {
-	char str[32];
+	char str[128];
 	sprintf(str, "%I64d", val);
 	return str;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -132,6 +132,26 @@ inline bool ends_with_ci(const std::string &s, const std::string &t) {
 	return ends_with_ci(s.c_str(), s.size(), t.c_str(), t.size());
 }
 
+// 'Numeric type' to string conversions.
+std::string SInt64ToStr(Sint64 val);
+std::string UInt64ToStr(Uint64 val);
+std::string FloatToStr(float val);
+std::string DoubleToStr(double val);
+std::string AutoToStr(Sint32 val);
+std::string AutoToStr(Sint64 val);
+std::string AutoToStr(float val);
+std::string AutoToStr(double val);
+
+// String to 'Numeric type' conversions.
+Sint64 StrToSInt64(const std::string &str);
+Uint64 StrToUInt64(const std::string &str);
+float StrToFloat(const std::string &str);
+double StrToDouble(const std::string &str);
+void StrToAuto(Sint32 *pVal, const std::string &str);
+void StrToAuto(Sint64 *pVal, const std::string &str);
+void StrToAuto(float *pVal, const std::string &str);
+void StrToAuto(double *pVal, const std::string &str);
+
 // add a few things that MSVC is missing
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
 

--- a/win32/vc2013Express/json/json.vcxproj
+++ b/win32/vc2013Express/json/json.vcxproj
@@ -20,9 +20,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\contrib\json\json.h" />
+    <ClInclude Include="..\..\..\contrib\json\JsonUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\contrib\json\jsoncpp.cpp" />
+    <ClCompile Include="..\..\..\contrib\json\JsonUtils.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{026FC030-0192-4582-B1AF-F9AADF4D73AD}</ProjectGuid>

--- a/win32/vc2013Express/json/json.vcxproj.filters
+++ b/win32/vc2013Express/json/json.vcxproj.filters
@@ -2,8 +2,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClInclude Include="..\..\..\contrib\json\json.h" />
+    <ClInclude Include="..\..\..\contrib\json\JsonUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\contrib\json\jsoncpp.cpp" />
+    <ClCompile Include="..\..\..\contrib\json\JsonUtils.cpp" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The branch JSONSerialise contains the JSON serialisation code.

The JSON serialisation saves precisely the same data as the original serialisation. There is a one-to-one correspondance between the original and JSON serialisation code. Part of the review should be a cross-check between the two.

There are two new files: JsonUtils.h and JsonUtils.cpp

Essentially, the relevant "Serialize" and "Unserialize" functions have been replaced by "ToJson" and "FromJson" functions. The relevant "Save" and "Load" functions have been replaced by "SaveToJson" and "LoadFromJson" functions. However, "ModelSkin::Save" and "ModelSkin::Load" are called by code other than the savegame process, so they remain (next to their corresponding "SaveToJson" and "LoadFromJson" functions).

The structure of the original serialisation code has been preserved. Relevant comments have also been carried over to the JSON serialisation code.

All JSON serialisation functions pass a reference to a JSON Value that is a JSON object. The only exception to this is "Model::SaveToJson" and "Model::LoadFromJson" where the SaveVisitor/LoadVisitor (now SaveVisitorJson/LoadVisitorJson) is passed a JSON Value that is a JSON array.

The save code typically passes a reference to the current JSON object into a function where other JSON objects and/or primitives are created and attached to the supplied object. Some serialisation functions are called recursively (as does the original serialisation).

The load code navigates the JSON tree as expected. All load functions begin by checking the contents of their supplied JSON object for appropriately named sub-objects/values. In the future, when the serialisation code has settled into a future-proof state, it is here that checks on missing objects can be put, and appropriate action taken for backwards compatibility.

JSON arrays of objects are used as follows:
When saving, the array is created and a loop entered, where for each iteration, an element object is created and passed into the JSON function which then populates it. The object is then appended to the array. Finally, when the loop is done, the array is added to the current object. The process can be easily followed.

Issues to be addressed/considered:

(1) Hexfloats
I couldn't get them to work (see forum topic "Hexfloats"), so floats and doubles are saved by memcopying them to an int of the same size, then the int is saved. The reverse is done to load the float/double. Although the data suffers no loss of precision, this is not ideal because the data in the JSON save file is not human readable (although float 0.000000 is written as integer "0").

(2) Lua data
This large string is not preserved when saved and loaded due to the non-printable characters at or near the end. The current solution is to save as a JSON array of integers (each integer is a char of the string). This works, but increases the size of the save file. The data is also not human readable.

(3) #include "Serialiser.h"
These remain, because the JSON serialisation code uses the exceptions. Perhaps the exceptions should be moved? Other code may also require functions declared in "Serialiser.h".

I have come across issues that (for me) also occur in pioneer from upstream. Please check this is not the case before flagging the issue as a JSONSerialise bug :)

Thanks :)
Nick