### PR TITLE
Fix modelcompiler

### DIFF
--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -17,6 +17,7 @@ GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vect
 , m_numTris(numTris)
 , m_vertices(vertices)
 {
+	assert(vertices.size() == m_numVertices);
 	Profiler::Timer timer;
 	timer.Start();
 
@@ -55,6 +56,7 @@ GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vect
 		std::vector<Uint32> xrefs;
 		nv::Weld<vector3f> weld;
 		weld(m_vertices, xrefs);
+		m_numVertices = m_vertices.size();
 
 		//Output("---   %d vertices welded\n", count - newCount);
 

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -68,8 +68,13 @@ Renderer* Init(Settings vs)
 	}
 
 	WindowSDL *window = new WindowSDL(vs, "Pioneer");
-	width = window->GetWidth();
-	height = window->GetHeight();
+	if (vs.rendererType == Graphics::RENDERER_DUMMY) {
+		width = vs.width;
+		height = vs.height;
+	} else {
+		width = window->GetWidth();
+		height = window->GetHeight();
+	}
 
 	// We deliberately ignore the value from GL_NUM_COMPRESSED_TEXTURE_FORMATS, because some drivers
 	// choose not to list any formats (despite supporting texture compression). See issue #3132.


### PR DESCRIPTION
I noticed that the modelcompiler had been broken due to some of the optimisation and dummy renderer commits recently.

This fixes up the exporter/importer values for the number of vertices and dummies the renderer setup to avoid calling an uninitialised window pointer.