### PR TITLE
Mouselook for internal camera

### DIFF
--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -34,8 +34,14 @@ void CameraController::Update()
 
 
 InternalCameraController::InternalCameraController(RefCountedPtr<CameraContext> camera, const Ship *ship) :
-	CameraController(camera, ship),
-	m_mode(MODE_FRONT)
+	MoveableCameraController(camera, ship),
+	m_mode(MODE_FRONT),
+	m_rotX(0),
+	m_rotY(0),
+       m_viewRotX(0),
+       m_viewRotY(0),
+	m_intOrient(matrix3x3d::Identity()),
+	m_viewOrient(matrix3x3d::Identity())
 {
 	Reset();
 }
@@ -87,6 +93,22 @@ void InternalCameraController::Reset()
 	SetMode(m_mode);
 }
 
+void InternalCameraController::Update()
+{
+    m_viewOrient =
+        matrix3x3d::RotateY(-DEG2RAD(m_rotY)) *
+        matrix3x3d::RotateX(-DEG2RAD(m_rotX));
+
+    SetOrient(m_intOrient * m_viewOrient);
+
+    CameraController::Update();
+}
+
+void InternalCameraController::getRots(double &rX, double &rY) {
+        rX = m_viewRotX;
+        rY = m_viewRotY;
+}
+
 void InternalCameraController::SetMode(Mode m)
 {
 	m_mode = m;
@@ -94,34 +116,62 @@ void InternalCameraController::SetMode(Mode m)
 		case MODE_FRONT:
 			m_name = Lang::CAMERA_FRONT_VIEW;
 			SetPosition(m_frontPos);
-			SetOrient(m_frontOrient);
+                       m_intOrient = m_frontOrient;
 			break;
 		case MODE_REAR:
 			m_name = Lang::CAMERA_REAR_VIEW;
 			SetPosition(m_rearPos);
-			SetOrient(m_rearOrient);
+                       m_intOrient = m_rearOrient;
 			break;
 		case MODE_LEFT:
 			m_name = Lang::CAMERA_LEFT_VIEW;
 			SetPosition(m_leftPos);
-			SetOrient(m_leftOrient);
+                       m_intOrient = m_leftOrient;
 			break;
 		case MODE_RIGHT:
 			m_name = Lang::CAMERA_RIGHT_VIEW;
 			SetPosition(m_rightPos);
-			SetOrient(m_rightOrient);
+                       m_intOrient = m_rightOrient;
 			break;
 		case MODE_TOP:
 			m_name = Lang::CAMERA_TOP_VIEW;
 			SetPosition(m_topPos);
-			SetOrient(m_topOrient);
+                       m_intOrient = m_topOrient;
 			break;
 		case MODE_BOTTOM:
 			m_name = Lang::CAMERA_BOTTOM_VIEW;
 			SetPosition(m_bottomPos);
-			SetOrient(m_bottomOrient);
+                       m_intOrient = m_bottomOrient;
 			break;
 	}
+       m_rotX = 0;
+       m_rotY = 0;
+       m_viewRotX = 0;
+       m_viewRotY = 0;
+}
+
+void InternalCameraController::RotateUp(float frameTime)
+{
+       m_viewRotX -= frameTime;
+       m_rotX -= 45*frameTime;
+}
+
+void InternalCameraController::RotateDown(float frameTime)
+{
+       m_viewRotX += frameTime;
+	m_rotX += 45*frameTime;
+}
+
+void InternalCameraController::RotateLeft(float frameTime)
+{
+       m_viewRotY -= frameTime;
+	m_rotY -= 45*frameTime;
+}
+
+void InternalCameraController::RotateRight(float frameTime)
+{
+       m_viewRotY += frameTime;
+	m_rotY += 45*frameTime;
 }
 
 void InternalCameraController::Save(Serializer::Writer &wr)

--- a/src/CameraController.h
+++ b/src/CameraController.h
@@ -51,41 +51,6 @@ private:
 	matrix3x3d m_orient;
 };
 
-
-class InternalCameraController : public CameraController {
-public:
-	enum Mode {
-		MODE_FRONT,
-		MODE_REAR,
-		MODE_LEFT,
-		MODE_RIGHT,
-		MODE_TOP,
-		MODE_BOTTOM
-	};
-
-	InternalCameraController(RefCountedPtr<CameraContext> camera, const Ship *ship);
-	virtual void Reset();
-
-	Type GetType() const { return INTERNAL; }
-	const char *GetName() const { return m_name; }
-	void SetMode(Mode m);
-	Mode GetMode() const { return m_mode; }
-	void Save(Serializer::Writer &wr);
-	void Load(Serializer::Reader &rd);
-
-private:
-	Mode m_mode;
-	const char *m_name;
-
-	vector3d m_frontPos;  matrix3x3d m_frontOrient;
-	vector3d m_rearPos;   matrix3x3d m_rearOrient;
-	vector3d m_leftPos;   matrix3x3d m_leftOrient;
-	vector3d m_rightPos;  matrix3x3d m_rightOrient;
-	vector3d m_topPos;    matrix3x3d m_topOrient;
-	vector3d m_bottomPos; matrix3x3d m_bottomOrient;
-};
-
-
 class MoveableCameraController : public CameraController {
 public:
 	MoveableCameraController(RefCountedPtr<CameraContext> camera, const Ship *ship) :
@@ -109,6 +74,54 @@ public:
 	virtual void ZoomEventUpdate(float frameTime) { }
 };
 
+class InternalCameraController : public MoveableCameraController {
+public:
+	enum Mode {
+		MODE_FRONT,
+		MODE_REAR,
+		MODE_LEFT,
+		MODE_RIGHT,
+		MODE_TOP,
+		MODE_BOTTOM
+	};
+
+	InternalCameraController(RefCountedPtr<CameraContext> camera, const Ship *ship);
+	virtual void Reset();
+       virtual void Update();
+
+	Type GetType() const { return INTERNAL; }
+	const char *GetName() const { return m_name; }
+	void SetMode(Mode m);
+	Mode GetMode() const { return m_mode; }
+	void Save(Serializer::Writer &wr);
+	void Load(Serializer::Reader &rd);
+
+	void RotateDown(float frameTime);
+	void RotateLeft(float frameTime);
+	void RotateRight(float frameTime);
+	void RotateUp(float frameTime);
+
+       void getRots(double &rotX, double &rotY);
+
+ private:
+	Mode m_mode;
+	const char *m_name;
+
+	vector3d m_frontPos;  matrix3x3d m_frontOrient;
+	vector3d m_rearPos;   matrix3x3d m_rearOrient;
+	vector3d m_leftPos;   matrix3x3d m_leftOrient;
+	vector3d m_rightPos;  matrix3x3d m_rightOrient;
+	vector3d m_topPos;    matrix3x3d m_topOrient;
+	vector3d m_bottomPos; matrix3x3d m_bottomOrient;
+
+	double m_rotX; //vertical rot
+	double m_rotY; //horizontal rot
+        // cache for ShipCockpit to avoid divisions
+	double m_viewRotX; //vertical rot
+	double m_viewRotY; //horizontal rot
+	matrix3x3d m_intOrient;
+	matrix3x3d m_viewOrient;
+};
 
 // Zoomable, rotatable orbit camera, always looks at the ship
 class ExternalCameraController : public MoveableCameraController {

--- a/src/ShipCockpit.h
+++ b/src/ShipCockpit.h
@@ -7,6 +7,8 @@
 #include "libs.h"
 #include "ModelBody.h"
 #include "scenegraph/Model.h"
+#include "CameraController.h"
+#include "WorldView.h"
 
 static const float COCKPIT_LAG_MAX_ANGLE = 7.5f;
 static const float COCKPIT_ROTATION_INTERP_MULTIPLIER = 5.0f;
@@ -25,6 +27,7 @@ public:
 	void Update(float timeStep);
 	void RenderCockpit(Graphics::Renderer* renderer, const Camera* camera, Frame* frame);
 	void OnActivated();
+       void resetInternalCameraController(void);
 
 protected:
 	float CalculateSignedForwardVelocity(vector3d forward, vector3d velocity);
@@ -44,6 +47,6 @@ private:
 	float m_shipVel;           // current ship velocity
 	vector3d m_translate;      // cockpit translation
 	matrix4x4d m_transform;    // cockpit transformation
+       InternalCameraController* m_icc;
 };
-
 #endif

--- a/src/ShipController.cpp
+++ b/src/ShipController.cpp
@@ -94,17 +94,14 @@ void PlayerShipController::StaticUpdate(const float timeStep)
 
 	// external camera mouselook
 	if (Pi::MouseButtonState(SDL_BUTTON_MIDDLE)) {
-		// not internal camera
-		if (Pi::game->GetWorldView()->GetCamType() != WorldView::CAM_INTERNAL) {
-			MoveableCameraController *mcc = static_cast<MoveableCameraController*>(Pi::game->GetWorldView()->GetCameraController());
-			const double accel = 0.01; // XXX configurable?
-			mcc->RotateLeft(mouseMotion[0] * accel);
-			mcc->RotateUp(  mouseMotion[1] * accel);
-			// only mouselook if the player presses both mmb and rmb
-			mouseMotion[0] = 0;
-			mouseMotion[1] = 0;
-		}
-	}
+            MoveableCameraController *mcc = static_cast<MoveableCameraController*>(Pi::game->GetWorldView()->GetCameraController());
+            const double accel = 0.01; // XXX configurable?
+            mcc->RotateLeft(mouseMotion[0] * accel);
+            mcc->RotateUp(  mouseMotion[1] * accel);
+            // only mouselook if the player presses both mmb and rmb
+            mouseMotion[0] = 0;
+            mouseMotion[1] = 0;
+        }
 
 	if (m_ship->GetFlightState() == Ship::FLYING) {
 		switch (m_flightControlState) {

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -368,9 +368,8 @@ void WorldView::SetCamType(enum CamType c)
 
 void WorldView::ChangeInternalCameraMode(InternalCameraController::Mode m)
 {
-	if (m_internalCameraController->GetMode() == m) return;
-
-	Pi::BoinkNoise();
+       if (m_internalCameraController->GetMode() != m)
+               Pi::BoinkNoise();
 	m_internalCameraController->SetMode(m);
 	Pi::player->GetPlayerController()->SetMouseForRearView(m_camType == CAM_INTERNAL && m_internalCameraController->GetMode() == InternalCameraController::MODE_REAR);
 	UpdateCameraName();


### PR DESCRIPTION
This add mouselook for the internal camera. Intended to be used with the cockpit, but works without too.

Doesn't have any rotational bounds so the cockpit model will probably need to be updated.

Could use more testing too.