### PR TITLE
Fix missing specular highlights

### DIFF
--- a/data/shaders/opengl/FresnelColour.vert
+++ b/data/shaders/opengl/FresnelColour.vert
@@ -9,5 +9,5 @@ void main(void)
 	gl_Position = logarithmicTransform();
 
 	varyingEyepos = vec3(uViewMatrix * a_vertex);
-	varyingNormal = vec3(normalize(uNormalMatrix * vec4(a_normal, 0.0)));
+	varyingNormal = normalize(uNormalMatrix * a_normal);
 }

--- a/data/shaders/opengl/attributes.glsl
+++ b/data/shaders/opengl/attributes.glsl
@@ -5,7 +5,7 @@ uniform mat4 uProjectionMatrix;
 uniform mat4 uViewMatrix;
 uniform mat4 uViewMatrixInverse;
 uniform mat4 uViewProjectionMatrix;
-uniform mat4 uNormalMatrix;
+uniform mat3 uNormalMatrix;
 
 //Light uniform parameters
 struct Light {
@@ -28,6 +28,6 @@ struct Material {
 in vec4 a_vertex;
 in vec3 a_normal;
 in vec4 a_color;
-in vec2 a_uv0;
+in vec4 a_uv0;
 
 #endif // VERTEX_SHADER

--- a/data/shaders/opengl/gassphere_base.vert
+++ b/data/shaders/opengl/gassphere_base.vert
@@ -9,6 +9,6 @@ void main(void)
 {
 	gl_Position = logarithmicTransform();
 	varyingEyepos = vec3(uViewMatrix * a_vertex);
-	varyingNormal = vec3(uNormalMatrix * vec4(a_normal, 1.0));
+	varyingNormal = normalize(uNormalMatrix * a_normal);
 	varyingTexCoord0 = a_normal.xyz;
 }

--- a/data/shaders/opengl/geosphere_terrain.vert
+++ b/data/shaders/opengl/geosphere_terrain.vert
@@ -18,7 +18,7 @@ void main(void)
 	gl_Position = logarithmicTransform();
 	vertexColor = a_color;
 	varyingEyepos = vec3(uViewMatrix * a_vertex);
-	varyingNormal = vec3(uNormalMatrix * vec4(a_normal, 1.0));
+	varyingNormal = normalize(uNormalMatrix * a_normal);
 
 #ifdef TERRAIN_WITH_LAVA
 	varyingEmission = material.emission;

--- a/data/shaders/opengl/multi.frag
+++ b/data/shaders/opengl/multi.frag
@@ -39,9 +39,9 @@ void ads(in int lightNum, in vec3 pos, in vec3 n, inout vec4 light, inout vec4 s
 	vec3 h = normalize(v + s);
 	light += uLight[lightNum].diffuse * material.diffuse * max(dot(s, n), 0.0);
 #ifdef MAP_SPECULAR
-	specular += texture(texture1, texCoord0) * material.specular * uLight[lightNum].diffuse * pow(max(dot(h, n), 0.0), material.shininess);
+	specular += texture(texture1, texCoord0) * material.specular * uLight[lightNum].specular * pow(max(dot(h, n), 0.0), material.shininess);
 #else
-	specular += material.specular * uLight[lightNum].diffuse * pow(max(dot(h, n), 0.0), material.shininess);
+	specular += material.specular * uLight[lightNum].specular * pow(max(dot(h, n), 0.0), material.shininess);
 #endif
 	specular.a = 0.0;
 	light.a = 1.0;

--- a/data/shaders/opengl/multi.vert
+++ b/data/shaders/opengl/multi.vert
@@ -1,6 +1,8 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+// #extension GL_ARB_gpu_shader5 : enable
+
 #ifdef TEXTURE0
 out vec2 texCoord0;
 #endif
@@ -28,7 +30,10 @@ void main(void)
 #endif
 #if (NUM_LIGHTS > 0)
 	eyePos = vec3(uViewMatrix * a_vertex);
-	normal = normalize(uNormalMatrix * vec4(a_normal, 1.0)).xyz;
+	normal = normalize(uNormalMatrix * a_normal);
+	
+	//mat3 mn = mat3(transpose(inverse(uViewMatrix)));
+	//normal = normalize(mn * a_normal);
 #ifdef HEAT_COLOURING
 	heatingDir = normalize(heatingMatrix * heatingNormal);
 #endif

--- a/data/shaders/opengl/shield.vert
+++ b/data/shaders/opengl/shield.vert
@@ -10,6 +10,6 @@ void main(void)
 	gl_Position = logarithmicTransform();
 
 	varyingEyepos = vec3(uViewMatrix * a_vertex);
-	varyingNormal = normalize(uNormalMatrix * vec4(a_normal, 1.0)).xyz;
+	varyingNormal = normalize(uNormalMatrix * a_normal);
 	varyingVertex = a_vertex.xyz;
 }

--- a/src/MathUtil.cpp
+++ b/src/MathUtil.cpp
@@ -6,27 +6,213 @@
 
 namespace MathUtil {
 
-vector3d RandomPointOnSphere(double minRadius, double maxRadius)
-{
-	// see http://mathworld.wolfram.com/SpherePointPicking.html
-	// or a Google search for further information
-	const double dist = Pi::rng.Double(minRadius, maxRadius);
-	const double z = Pi::rng.Double_closed(-1.0, 1.0);
-	const double theta = Pi::rng.Double(2.0*M_PI);
-	const double r = sqrt(1.0 - z*z) * dist;
-	return vector3d(r*cos(theta), r*sin(theta), z*dist);
-}
+	vector3d RandomPointOnSphere(double minRadius,double maxRadius)
+	{
+		// see http://mathworld.wolfram.com/SpherePointPicking.html
+		// or a Google search for further information
+		const double dist = Pi::rng.Double(minRadius,maxRadius);
+		const double z = Pi::rng.Double_closed(-1.0,1.0);
+		const double theta = Pi::rng.Double(2.0*M_PI);
+		const double r = sqrt(1.0 - z*z) * dist;
+		return vector3d(r*cos(theta),r*sin(theta),z*dist);
+	}
 
-vector3d RandomPointInCircle(double minRadius, double maxRadius)
-{
-	// m: minRadius, M: maxRadius, r: random radius
-	// PDF(r) = 2/(M^2 - m^2) * r  for m <= r < M
-	// CDF(r) = 1/(M^2 - m^2) * (r^2 - m^2)
-	// per inversion method (http://en.wikipedia.org/wiki/Inversion_method): CDF(r) := Uniform{0..1}
-	// r = sqrt(Uniform{0..1} * (M^2 - m^2) + m^2) = sqrt(Uniform{m^2..M^2})
-	const double r = sqrt(Pi::rng.Double(minRadius*minRadius, maxRadius*maxRadius));
-	const double phi = Pi::rng.Double(2.0*M_PI);
-	return vector3d(r*cos(phi), r*sin(phi), 0.0);
-}
+	vector3d RandomPointInCircle(double minRadius,double maxRadius)
+	{
+		// m: minRadius, M: maxRadius, r: random radius
+		// PDF(r) = 2/(M^2 - m^2) * r  for m <= r < M
+		// CDF(r) = 1/(M^2 - m^2) * (r^2 - m^2)
+		// per inversion method (http://en.wikipedia.org/wiki/Inversion_method): CDF(r) := Uniform{0..1}
+		// r = sqrt(Uniform{0..1} * (M^2 - m^2) + m^2) = sqrt(Uniform{m^2..M^2})
+		const double r = sqrt(Pi::rng.Double(minRadius*minRadius,maxRadius*maxRadius));
+		const double phi = Pi::rng.Double(2.0*M_PI);
+		return vector3d(r*cos(phi),r*sin(phi),0.0);
+	}
 
+	// matrix4x4f utility functions
+	matrix4x4f Inverse(const matrix4x4f &cell) {
+		matrix4x4f m;
+		// this only works for matrices containing only rotation and transform
+		m[0] = cell[0]; m[1] = cell[4]; m[2] = cell[8];
+		m[4] = cell[1]; m[5] = cell[5]; m[6] = cell[9];
+		m[8] = cell[2]; m[9] = cell[6]; m[10] = cell[10];
+		m[12] = -(cell[0]*cell[12] + cell[1]*cell[13] + cell[2]*cell[14]);
+		m[13] = -(cell[4]*cell[12] + cell[5]*cell[13] + cell[6]*cell[14]);
+		m[14] = -(cell[8]*cell[12] + cell[9]*cell[13] + cell[10]*cell[14]);
+		m[3] = m[7] = m[11] = 0;
+		m[15] = 1.0f;
+
+		return m;
+	}
+	matrix4x4f InverseSlow(const matrix4x4f &cell)
+	{
+		matrix4x4f inv;
+
+		inv[0] = cell[5]  * cell[10] * cell[15] -
+			cell[5]  * cell[11] * cell[14] -
+			cell[9]  * cell[6]  * cell[15] +
+			cell[9]  * cell[7]  * cell[14] +
+			cell[13] * cell[6]  * cell[11] -
+			cell[13] * cell[7]  * cell[10];
+
+		inv[4] = -cell[4]  * cell[10] * cell[15] +
+			cell[4]  * cell[11] * cell[14] +
+			cell[8]  * cell[6]  * cell[15] -
+			cell[8]  * cell[7]  * cell[14] -
+			cell[12] * cell[6]  * cell[11] +
+			cell[12] * cell[7]  * cell[10];
+
+		inv[8] = cell[4]  * cell[9] * cell[15] -
+			cell[4]  * cell[11] * cell[13] -
+			cell[8]  * cell[5] * cell[15] +
+			cell[8]  * cell[7] * cell[13] +
+			cell[12] * cell[5] * cell[11] -
+			cell[12] * cell[7] * cell[9];
+
+		inv[12] = -cell[4]  * cell[9] * cell[14] +
+			cell[4]  * cell[10] * cell[13] +
+			cell[8]  * cell[5] * cell[14] -
+			cell[8]  * cell[6] * cell[13] -
+			cell[12] * cell[5] * cell[10] +
+			cell[12] * cell[6] * cell[9];
+
+		inv[1] = -cell[1]  * cell[10] * cell[15] +
+			cell[1]  * cell[11] * cell[14] +
+			cell[9]  * cell[2] * cell[15] -
+			cell[9]  * cell[3] * cell[14] -
+			cell[13] * cell[2] * cell[11] +
+			cell[13] * cell[3] * cell[10];
+
+		inv[5] = cell[0]  * cell[10] * cell[15] -
+			cell[0]  * cell[11] * cell[14] -
+			cell[8]  * cell[2] * cell[15] +
+			cell[8]  * cell[3] * cell[14] +
+			cell[12] * cell[2] * cell[11] -
+			cell[12] * cell[3] * cell[10];
+
+		inv[9] = -cell[0]  * cell[9] * cell[15] +
+			cell[0]  * cell[11] * cell[13] +
+			cell[8]  * cell[1] * cell[15] -
+			cell[8]  * cell[3] * cell[13] -
+			cell[12] * cell[1] * cell[11] +
+			cell[12] * cell[3] * cell[9];
+
+		inv[13] = cell[0]  * cell[9] * cell[14] -
+			cell[0]  * cell[10] * cell[13] -
+			cell[8]  * cell[1] * cell[14] +
+			cell[8]  * cell[2] * cell[13] +
+			cell[12] * cell[1] * cell[10] -
+			cell[12] * cell[2] * cell[9];
+
+		inv[2] = cell[1]  * cell[6] * cell[15] -
+			cell[1]  * cell[7] * cell[14] -
+			cell[5]  * cell[2] * cell[15] +
+			cell[5]  * cell[3] * cell[14] +
+			cell[13] * cell[2] * cell[7] -
+			cell[13] * cell[3] * cell[6];
+
+		inv[6] = -cell[0]  * cell[6] * cell[15] +
+			cell[0]  * cell[7] * cell[14] +
+			cell[4]  * cell[2] * cell[15] -
+			cell[4]  * cell[3] * cell[14] -
+			cell[12] * cell[2] * cell[7] +
+			cell[12] * cell[3] * cell[6];
+
+		inv[10] = cell[0]  * cell[5] * cell[15] -
+			cell[0]  * cell[7] * cell[13] -
+			cell[4]  * cell[1] * cell[15] +
+			cell[4]  * cell[3] * cell[13] +
+			cell[12] * cell[1] * cell[7] -
+			cell[12] * cell[3] * cell[5];
+
+		inv[14] = -cell[0]  * cell[5] * cell[14] +
+			cell[0]  * cell[6] * cell[13] +
+			cell[4]  * cell[1] * cell[14] -
+			cell[4]  * cell[2] * cell[13] -
+			cell[12] * cell[1] * cell[6] +
+			cell[12] * cell[2] * cell[5];
+
+		inv[3] = -cell[1] * cell[6] * cell[11] +
+			cell[1] * cell[7] * cell[10] +
+			cell[5] * cell[2] * cell[11] -
+			cell[5] * cell[3] * cell[10] -
+			cell[9] * cell[2] * cell[7] +
+			cell[9] * cell[3] * cell[6];
+
+		inv[7] = cell[0] * cell[6] * cell[11] -
+			cell[0] * cell[7] * cell[10] -
+			cell[4] * cell[2] * cell[11] +
+			cell[4] * cell[3] * cell[10] +
+			cell[8] * cell[2] * cell[7] -
+			cell[8] * cell[3] * cell[6];
+
+		inv[11] = -cell[0] * cell[5] * cell[11] +
+			cell[0] * cell[7] * cell[9] +
+			cell[4] * cell[1] * cell[11] -
+			cell[4] * cell[3] * cell[9] -
+			cell[8] * cell[1] * cell[7] +
+			cell[8] * cell[3] * cell[5];
+
+		inv[15] = cell[0] * cell[5] * cell[10] -
+			cell[0] * cell[6] * cell[9] -
+			cell[4] * cell[1] * cell[10] +
+			cell[4] * cell[2] * cell[9] +
+			cell[8] * cell[1] * cell[6] -
+			cell[8] * cell[2] * cell[5];
+
+		float det = cell[0] * inv[0] + cell[1] * inv[4] + cell[2] * inv[8] + cell[3] * inv[12];
+
+		if(det == 0)
+			return matrix4x4f::Identity();
+
+		det = 1.0f / det;
+		
+		matrix4x4f m;
+		for(int i = 0; i < 16; i++)
+			m[i] = inv[i] * det;
+
+		return m;
+	}
+	matrix4x4f Transpose(const matrix4x4f &cell) 
+	{
+		matrix4x4f m;
+		m[0] = cell[0];		m[1] = cell[4];		m[2] = cell[8];		m[3] = cell[12];
+		m[4] = cell[1];		m[5] = cell[5];		m[6] = cell[9];		m[7] = cell[13];
+		m[8] = cell[2];		m[9] = cell[6];		m[10] = cell[10];	m[11] = cell[14];
+		m[12] = cell[3];	m[13] = cell[7];	m[14] = cell[11];	m[15] = cell[15];
+		return m;
+	}
+	
+	// matrix3x3f utility functions
+	matrix3x3f Transpose(const matrix3x3f &cell) 
+	{
+		matrix3x3f m;
+		m[0] = cell[0]; m[1] = cell[3]; m[2] = cell[6];
+		m[3] = cell[1]; m[4] = cell[4]; m[5] = cell[7];
+		m[6] = cell[2]; m[7] = cell[5]; m[8] = cell[8];
+		return m;
+	}
+	matrix3x3f Inverse(const matrix3x3f &cell) 
+	{
+		// computes the inverse of a matrix m
+		#define cell2d(x,y)    cell[((y*3) + x)]
+		const float det = cell2d(0, 0) * (cell2d(1, 1) * cell2d(2, 2) - cell2d(2, 1) * cell2d(1, 2)) -
+					  cell2d(0, 1) * (cell2d(1, 0) * cell2d(2, 2) - cell2d(1, 2) * cell2d(2, 0)) +
+					  cell2d(0, 2) * (cell2d(1, 0) * cell2d(2, 1) - cell2d(1, 1) * cell2d(2, 0));
+
+		const float invdet = 1.0f / det;
+
+		matrix3x3f minv; // inverse of matrix m
+		#define idx2d(x,y)    ((y*3) + x)
+		minv[idx2d(0, 0)] = (cell2d(1, 1) * cell2d(2, 2) - cell2d(2, 1) * cell2d(1, 2)) * invdet;
+		minv[idx2d(0, 1)] = (cell2d(0, 2) * cell2d(2, 1) - cell2d(0, 1) * cell2d(2, 2)) * invdet;
+		minv[idx2d(0, 2)] = (cell2d(0, 1) * cell2d(1, 2) - cell2d(0, 2) * cell2d(1, 1)) * invdet;
+		minv[idx2d(1, 0)] = (cell2d(1, 2) * cell2d(2, 0) - cell2d(1, 0) * cell2d(2, 2)) * invdet;
+		minv[idx2d(1, 1)] = (cell2d(0, 0) * cell2d(2, 2) - cell2d(0, 2) * cell2d(2, 0)) * invdet;
+		minv[idx2d(1, 2)] = (cell2d(1, 0) * cell2d(0, 2) - cell2d(0, 0) * cell2d(1, 2)) * invdet;
+		minv[idx2d(2, 0)] = (cell2d(1, 0) * cell2d(2, 1) - cell2d(2, 0) * cell2d(1, 1)) * invdet;
+		minv[idx2d(2, 1)] = (cell2d(2, 0) * cell2d(0, 1) - cell2d(0, 0) * cell2d(2, 1)) * invdet;
+		minv[idx2d(2, 2)] = (cell2d(0, 0) * cell2d(1, 1) - cell2d(1, 0) * cell2d(0, 1)) * invdet;
+		return minv;
+	}
 }

--- a/src/MathUtil.cpp
+++ b/src/MathUtil.cpp
@@ -162,7 +162,7 @@ namespace MathUtil {
 
 		float det = cell[0] * inv[0] + cell[1] * inv[4] + cell[2] * inv[8] + cell[3] * inv[12];
 
-		if(det == 0)
+		if(is_equal_exact(det, 0.0f))
 			return matrix4x4f::Identity();
 
 		det = 1.0f / det;

--- a/src/MathUtil.h
+++ b/src/MathUtil.h
@@ -5,6 +5,8 @@
 #define _MATHUTIL_H
 
 #include "vector3.h"
+#include "matrix3x3.h"
+#include "matrix4x4.h"
 
 namespace MathUtil {
 

--- a/src/MathUtil.h
+++ b/src/MathUtil.h
@@ -23,6 +23,15 @@ namespace MathUtil {
 	}
 
 	inline float Dot(const vector3f &a, const vector3f &b) { return a.x*b.x + a.y*b.y + a.z*b.z; }
+
+	// matrix4x4f utility functions
+	matrix4x4f Inverse(const matrix4x4f &);
+	matrix4x4f InverseSlow(const matrix4x4f &);
+	matrix4x4f Transpose(const matrix4x4f &);
+	
+	// matrix3x3f utility functions
+	matrix3x3f Inverse(const matrix3x3f &);
+	matrix3x3f Transpose(const matrix3x3f &);
 }
 
 #endif

--- a/src/graphics/opengl/MaterialGL.cpp
+++ b/src/graphics/opengl/MaterialGL.cpp
@@ -4,7 +4,6 @@
 #include "MaterialGL.h"
 #include "Program.h"
 #include "RendererGL.h"
-#include "MathUtil.h"
 
 namespace Graphics {
 namespace OGL {
@@ -19,17 +18,11 @@ void Material::Unapply()
 {
 }
 
-using namespace MathUtil;
 void Material::SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj)
 {
 	const matrix4x4f ViewProjection = proj * mv;
-	//const matrix3x3f orient(mv.GetOrient().Inverse());
-	//const matrix3x3f NormalMatrix(orient.Transpose());
-	const matrix3x3f mvo(mv.GetOrient());
-	const matrix3x3f NormalMatrix(Transpose(Inverse(mvo)));
-	
-	//const matrix3x3f mvo2(Transpose(Transpose(mvo)));
-	//assert(0==memcmp(&mvo, &mvo2, sizeof(matrix3x3f)));
+	const matrix3x3f orient(mv.GetOrient());
+	const matrix3x3f NormalMatrix(orient.Inverse());
 
 	m_program->uProjectionMatrix.Set( proj );
 	m_program->uViewMatrix.Set( mv );

--- a/src/graphics/opengl/MaterialGL.cpp
+++ b/src/graphics/opengl/MaterialGL.cpp
@@ -4,6 +4,7 @@
 #include "MaterialGL.h"
 #include "Program.h"
 #include "RendererGL.h"
+#include "MathUtil.h"
 
 namespace Graphics {
 namespace OGL {
@@ -18,12 +19,17 @@ void Material::Unapply()
 {
 }
 
+using namespace MathUtil;
 void Material::SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj)
 {
 	const matrix4x4f ViewProjection = proj * mv;
-	const matrix3x3f orient(mv.GetOrient());
-	const matrix4x4f NormalMatrix(orient.Inverse().Transpose());
-	//const matrix4x4f NormalMatrix(mv.Inverse().Transpose());
+	//const matrix3x3f orient(mv.GetOrient().Inverse());
+	//const matrix3x3f NormalMatrix(orient.Transpose());
+	const matrix3x3f mvo(mv.GetOrient());
+	const matrix3x3f NormalMatrix(Transpose(Inverse(mvo)));
+	
+	//const matrix3x3f mvo2(Transpose(Transpose(mvo)));
+	//assert(0==memcmp(&mvo, &mvo2, sizeof(matrix3x3f)));
 
 	m_program->uProjectionMatrix.Set( proj );
 	m_program->uViewMatrix.Set( mv );

--- a/src/graphics/opengl/Uniform.cpp
+++ b/src/graphics/opengl/Uniform.cpp
@@ -63,19 +63,19 @@ void Uniform::Set(const float x, const float y, const float z, const float w)
 void Uniform::Set(const float m[9])
 {
 	if (m_location != -1)
-		glUniformMatrix3fv(m_location, 1, false, m);
+		glUniformMatrix3fv(m_location, 1, GL_FALSE, m);
 }
 
 void Uniform::Set(const matrix3x3f &m)
 {
 	if (m_location != -1)
-		glUniformMatrix3fv(m_location, 1, false, &m[0]);
+		glUniformMatrix3fv(m_location, 1, GL_FALSE, &m[0]);
 }
 
 void Uniform::Set(const matrix4x4f &m)
 {
 	if (m_location != -1)
-		glUniformMatrix4fv(m_location, 1, false, &m[0]);
+		glUniformMatrix4fv(m_location, 1, GL_FALSE, &m[0]);
 }
 
 void Uniform::Set(Texture *tex, unsigned int unit)

--- a/src/matrix3x3.h
+++ b/src/matrix3x3.h
@@ -135,7 +135,7 @@ class matrix3x3 {
 					  cell2d(0, 1) * (cell2d(1, 0) * cell2d(2, 2) - cell2d(1, 2) * cell2d(2, 0)) +
 					  cell2d(0, 2) * (cell2d(1, 0) * cell2d(2, 1) - cell2d(1, 1) * cell2d(2, 0));
 
-		const T invdet = 1 / det;
+		const T invdet = T(1.0) / det;
 
 		matrix3x3 minv; // inverse of matrix m
 		#define idx2d(x,y)    ((y*3) + x)


### PR DESCRIPTION
This bug fixes #3366 and cleans up the attributes for `uNormalMatrix` and promotes `a_uv0` too a full `vec4` as it should have been already.

It adds some new utility functions to the MathUtil namespace that I needed during debugging and it seems we should have for greater flexibility anyway.

@nozmajner good catch on this, thank your student for me!

Andy