### PR TITLE
Fix VS2013 profiling configuration

### DIFF
--- a/src/collider/Geom.cpp
+++ b/src/collider/Geom.cpp
@@ -101,7 +101,6 @@ void Geom::Collide(Geom *b, void (*callback)(CollisionContact*))
 
 static bool rotatedAabbIsectsNormalOne(Aabb &a, const matrix4x4d &transA, Aabb &b)
 {
-	PROFILE_SCOPED()
 	Aabb arot;
 	vector3d p[8];
 	p[0] = transA * vector3d(a.min.x, a.min.y, a.min.z);

--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -160,9 +160,6 @@ GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vect
 
 GeomTree::GeomTree(Serializer::Reader &rd)
 {
-	Profiler::Timer timer;
-	timer.Start();
-
 	m_numVertices = rd.Int32();
 	m_numEdges = rd.Int32();
 	m_numTris = rd.Int32();
@@ -231,14 +228,10 @@ GeomTree::GeomTree(Serializer::Reader &rd)
 		edgeIdxs[i] = i;
 	}
 	m_edgeTree.reset(new BVHTree(m_numEdges, edgeIdxs, &m_aabbs[0]));
-
-	timer.Stop();
-	//Output(" - - GeomTree::GeomTree(Serializer::Reader &rd) took: %lf milliseconds\n", timer.millicycles());
 }
 
 static bool SlabsRayAabbTest(const BVHNode *n, const vector3f &start, const vector3f &invDir, isect_t *isect)
 {
-	PROFILE_SCOPED()
 	float
 	l1      = (n->aabb.min.x - start.x) * invDir.x,
 	l2      = (n->aabb.max.x - start.x) * invDir.x,
@@ -260,13 +253,11 @@ static bool SlabsRayAabbTest(const BVHNode *n, const vector3f &start, const vect
 
 void GeomTree::TraceRay(const vector3f &start, const vector3f &dir, isect_t *isect) const
 {
-	PROFILE_SCOPED()
 	TraceRay(m_triTree->GetRoot(), start, dir, isect);
 }
 
 void GeomTree::TraceRay(const BVHNode *currnode, const vector3f &a_origin, const vector3f &a_dir, isect_t *isect) const
 {
-	PROFILE_SCOPED()
 	BVHNode *stack[32];
 	int stackpos = -1;
 	vector3f invDir(1.0f/a_dir.x, 1.0f/a_dir.y, 1.0f/a_dir.z);
@@ -298,7 +289,7 @@ struct bvhstack {
 /*
  * Bundle of rays with common origin
  */
-void GeomTree::TraceCoherentRays(int numRays, const vector3f &a_origin, const vector3f *a_dirs, isect_t *isects) const
+/*void GeomTree::TraceCoherentRays(int numRays, const vector3f &a_origin, const vector3f *a_dirs, isect_t *isects) const
 {
 	PROFILE_SCOPED()
 	TraceCoherentRays(m_triTree->GetRoot(), numRays, a_origin, a_dirs, isects);
@@ -337,11 +328,10 @@ pop_bstack:
 		activeRay = stack[stackpos].activeRay;
 		stackpos--;
 	}
-}
+}*/
 
 void GeomTree::RayTriIntersect(int numRays, const vector3f &origin, const vector3f *dirs, int triIdx, isect_t *isects) const
 {
-	PROFILE_SCOPED()
 	const vector3f a(m_vertices[m_indices[triIdx+0]]);
 	const vector3f b(m_vertices[m_indices[triIdx+1]]);
 	const vector3f c(m_vertices[m_indices[triIdx+2]]);
@@ -372,7 +362,6 @@ void GeomTree::RayTriIntersect(int numRays, const vector3f &origin, const vector
 
 vector3f GeomTree::GetTriNormal(int triIdx) const
 {
-	PROFILE_SCOPED()
 	const vector3f a(m_vertices[m_indices[3*triIdx+0]]);
 	const vector3f b(m_vertices[m_indices[3*triIdx+1]]);
 	const vector3f c(m_vertices[m_indices[3*triIdx+2]]);

--- a/src/collider/GeomTree.h
+++ b/src/collider/GeomTree.h
@@ -30,8 +30,8 @@ public:
 	void CollideEdgesWithTrisOf(const GeomTree *other, const matrix4x4d &transTo, void (*callback)(CollisionContact*)) const;
 	void TraceRay(const vector3f &start, const vector3f &dir, isect_t *isect) const;
 	void TraceRay(const BVHNode *startNode, const vector3f &a_origin, const vector3f &a_dir, isect_t *isect) const;
-	void TraceCoherentRays(int numRays, const vector3f &a_origin, const vector3f *a_dirs, isect_t *isects) const;
-	void TraceCoherentRays(const BVHNode *startNode, int numRays, const vector3f &a_origin, const vector3f *a_dirs, isect_t *isects) const;
+	//void TraceCoherentRays(int numRays, const vector3f &a_origin, const vector3f *a_dirs, isect_t *isects) const;
+	//void TraceCoherentRays(const BVHNode *startNode, int numRays, const vector3f &a_origin, const vector3f *a_dirs, isect_t *isects) const;
 	vector3f GetTriNormal(int triIdx) const;
 	unsigned int GetTriFlag(int triIdx) const { return m_triFlags[triIdx]; }
 	double GetRadius() const { return m_radius; }

--- a/src/graphics/VertexArray.cpp
+++ b/src/graphics/VertexArray.cpp
@@ -30,19 +30,16 @@ VertexArray::~VertexArray()
 
 bool VertexArray::HasAttrib(VertexAttrib v) const
 {
-	PROFILE_SCOPED()
 	return (m_attribs & v) != 0;
 }
 
 unsigned int VertexArray::GetNumVerts() const
 {
-	PROFILE_SCOPED()
 	return position.size();
 }
 
 void VertexArray::Clear()
 {
-	PROFILE_SCOPED()
 	position.clear();
 	diffuse.clear();
 	normal.clear();
@@ -51,20 +48,17 @@ void VertexArray::Clear()
 
 void VertexArray::Add(const vector3f &v)
 {
-	PROFILE_SCOPED()
 	position.push_back(v);
 }
 
 void VertexArray::Add(const vector3f &v, const Color &c)
 {
-	PROFILE_SCOPED()
 	position.push_back(v);
 	diffuse.push_back(c);
 }
 
 void VertexArray::Add(const vector3f &v, const Color &c, const vector3f &n)
 {
-	PROFILE_SCOPED()
 	position.push_back(v);
 	diffuse.push_back(c);
 	normal.push_back(n);
@@ -72,7 +66,6 @@ void VertexArray::Add(const vector3f &v, const Color &c, const vector3f &n)
 
 void VertexArray::Add(const vector3f &v, const Color &c, const vector2f &uv)
 {
-	PROFILE_SCOPED()
 	position.push_back(v);
 	diffuse.push_back(c);
 	uv0.push_back(uv);
@@ -80,14 +73,12 @@ void VertexArray::Add(const vector3f &v, const Color &c, const vector2f &uv)
 
 void VertexArray::Add(const vector3f &v, const vector2f &uv)
 {
-	PROFILE_SCOPED()
 	position.push_back(v);
 	uv0.push_back(uv);
 }
 
 void VertexArray::Add(const vector3f &v, const vector3f &n, const vector2f &uv)
 {
-	PROFILE_SCOPED()
 	position.push_back(v);
 	normal.push_back(n);
 	uv0.push_back(uv);
@@ -95,20 +86,17 @@ void VertexArray::Add(const vector3f &v, const vector3f &n, const vector2f &uv)
 
 void VertexArray::Set(const Uint32 idx, const vector3f &v)
 {
-	PROFILE_SCOPED()
 	position[idx] = v;
 }
 
 void VertexArray::Set(const Uint32 idx, const vector3f &v, const Color &c)
 {
-	PROFILE_SCOPED()
 	position[idx] = v;
 	diffuse[idx] = c;
 }
 
 void VertexArray::Set(const Uint32 idx, const vector3f &v, const Color &c, const vector3f &n)
 {
-	PROFILE_SCOPED()
 	position[idx] = v;
 	diffuse[idx] = c;
 	normal[idx] = n;
@@ -116,7 +104,6 @@ void VertexArray::Set(const Uint32 idx, const vector3f &v, const Color &c, const
 
 void VertexArray::Set(const Uint32 idx, const vector3f &v, const Color &c, const vector2f &uv)
 {
-	PROFILE_SCOPED()
 	position[idx] = v;
 	diffuse[idx] = c;
 	uv0[idx] = uv;
@@ -124,14 +111,12 @@ void VertexArray::Set(const Uint32 idx, const vector3f &v, const Color &c, const
 
 void VertexArray::Set(const Uint32 idx, const vector3f &v, const vector2f &uv)
 {
-	PROFILE_SCOPED()
 	position[idx] = v;
 	uv0[idx] = uv;
 }
 
 void VertexArray::Set(const Uint32 idx, const vector3f &v, const vector3f &n, const vector2f &uv)
 {
-	PROFILE_SCOPED()
 	position[idx] = v;
 	normal[idx] = n;
 	uv0[idx] = uv;

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -122,10 +122,8 @@ protected:
 	//figure out states from a vertex array and enable them
 	//also sets vertex pointers
 	void EnableVertexAttributes(const VertexBuffer*);
-	void EnableVertexAttributes(const VertexArray*);
 	//disable previously enabled
 	void DisableVertexAttributes(const VertexBuffer*);
-	void DisableVertexAttributes();
 	Uint32 m_numLights;
 	Uint32 m_numDirLights;
 	std::vector<GLuint> m_vertexAttribsSet;

--- a/win32/vc2013Express/collider/collider.vcxproj
+++ b/win32/vc2013Express/collider/collider.vcxproj
@@ -82,6 +82,10 @@
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
     </ClCompile>
+    <Lib>
+      <AdditionalDependencies>profiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile />
@@ -94,6 +98,10 @@
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
     </ClCompile>
+    <Lib>
+      <AdditionalDependencies>profiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'">
     <ClCompile />
@@ -105,7 +113,12 @@
     <ClCompile />
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Lib>
+      <AdditionalDependencies>profiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">
     <ClCompile />
@@ -117,6 +130,10 @@
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
     </ClCompile>
+    <Lib>
+      <AdditionalDependencies>profiler.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\collider\BVHTree.cpp" />

--- a/win32/vc2013Express/galaxy/galaxy.vcxproj
+++ b/win32/vc2013Express/galaxy/galaxy.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile />
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">

--- a/win32/vc2013Express/gameui/gameui.vcxproj
+++ b/win32/vc2013Express/gameui/gameui.vcxproj
@@ -103,6 +103,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">

--- a/win32/vc2013Express/graphics/graphics.vcxproj
+++ b/win32/vc2013Express/graphics/graphics.vcxproj
@@ -107,7 +107,7 @@
     <ClCompile />
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>GLEW_STATIC;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PIONEER_PROFILER;GLEW_STATIC;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">

--- a/win32/vc2013Express/gui/gui.vcxproj
+++ b/win32/vc2013Express/gui/gui.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile />
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">

--- a/win32/vc2013Express/jenkins/jenkins.vcxproj
+++ b/win32/vc2013Express/jenkins/jenkins.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/win32/vc2013Express/json/json.vcxproj
+++ b/win32/vc2013Express/json/json.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/win32/vc2013Express/lua.vcxproj
+++ b/win32/vc2013Express/lua.vcxproj
@@ -198,7 +198,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PIONEER_PROFILER;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedIncludeFiles>
       </ForcedIncludeFiles>
       <DisableSpecificWarnings>4146</DisableSpecificWarnings>

--- a/win32/vc2013Express/newmodel/newmodel.vcxproj
+++ b/win32/vc2013Express/newmodel/newmodel.vcxproj
@@ -104,6 +104,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">

--- a/win32/vc2013Express/pioneer.sln
+++ b/win32/vc2013Express/pioneer.sln
@@ -21,26 +21,49 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pioneer", "pioneer.vcxproj"
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "text", "text\text.vcxproj", "{06E6CE3D-9163-453B-BF8D-3B9DECB5AB78}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jenkins", "jenkins\jenkins.vcxproj", "{38C0279B-EB3E-4113-8E3E-29AFC31C3C20}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "galaxy", "galaxy\galaxy.vcxproj", "{82973C2C-FC40-4320-84AE-A47E36868C02}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "collider", "collider\collider.vcxproj", "{A2082451-1B70-47C1-88E1-62A59EB13A44}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "graphics", "graphics\graphics.vcxproj", "{DED0A0AD-E7B8-42EF-83DB-EDAE7E2443EE}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "terrain", "terrain\terrain.vcxproj", "{64F034A3-B40E-4D42-ADDD-E2EE42ED517F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "gui", "gui\gui.vcxproj", "{B19B00BA-F9DE-451F-9E16-C5E582DEEE77}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lua", "lua.vcxproj", "{5085B12D-F9AC-4878-9672-1FD4EB0EFB67}"
 	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
 		{B19B00BA-F9DE-451F-9E16-C5E582DEEE77} = {B19B00BA-F9DE-451F-9E16-C5E582DEEE77}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ui", "ui\ui.vcxproj", "{F604C1BC-C921-4468-8F09-427705AD9D29}"
 	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
 		{5085B12D-F9AC-4878-9672-1FD4EB0EFB67} = {5085B12D-F9AC-4878-9672-1FD4EB0EFB67}
 	EndProjectSection
 EndProject
@@ -51,10 +74,14 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "gameui", "gameui\gameui.vcx
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "scenegraph", "newmodel\newmodel.vcxproj", "{E34F7DBC-F23D-481A-B920-E53F56C53EE8}"
 	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
 		{DED0A0AD-E7B8-42EF-83DB-EDAE7E2443EE} = {DED0A0AD-E7B8-42EF-83DB-EDAE7E2443EE}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "json", "json\json.vcxproj", "{026FC030-0192-4582-B1AF-F9AADF4D73AD}"
+	ProjectSection(ProjectDependencies) = postProject
+		{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E} = {FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "profiler", "profiler\profiler.vcxproj", "{FFDC1809-F67B-4933-B4E0-5298EA5DDB7E}"
 EndProject

--- a/win32/vc2013Express/terrain/terrain.vcxproj
+++ b/win32/vc2013Express/terrain/terrain.vcxproj
@@ -103,6 +103,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">

--- a/win32/vc2013Express/text/text.vcxproj
+++ b/win32/vc2013Express/text/text.vcxproj
@@ -103,6 +103,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">

--- a/win32/vc2013Express/ui/ui.vcxproj
+++ b/win32/vc2013Express/ui/ui.vcxproj
@@ -103,6 +103,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">


### PR DESCRIPTION
Profiling was not setup correctly under the visual studio build so it would not capture everything that happened during a frame. I've had some of these fixes locally for a while but always mixed in with other experiments.

This separates out the profiling fixes, removes some pointless profiling calls and removes some unused functions/methods.