### PR TITLE
Fix compilation of planetrings shader

### DIFF
--- a/data/shaders/opengl/planetrings.vert
+++ b/data/shaders/opengl/planetrings.vert
@@ -8,6 +8,6 @@ void main(void)
 {
 	gl_Position = logarithmicTransform();
 
-	texCoord0 = a_uv0;
+	texCoord0 = a_uv0.xy;
 	texCoord1 = a_vertex;
 }


### PR DESCRIPTION
This fixes #3369 which was caused by the change of `a_uv0` from `vec2` to `vec4`