### PR TITLE
Fix stderr redirection

### DIFF
--- a/src/posix/OSPosix.cpp
+++ b/src/posix/OSPosix.cpp
@@ -41,13 +41,9 @@ void RedirectStdio()
 
 	f = freopen(output_path.c_str(), "w", stderr);
 	if (!f)
-		f = fopen(output_path.c_str(), "w");
-	if (!f)
 		Output("ERROR: Couldn't redirect output to '%s': %s\n", output_path.c_str(), strerror(errno));
-	else {
+	else
 		setvbuf(f, 0, _IOLBF, BUFSIZ);
-		*stderr = *f;
-	}
 }
 
 void EnableFPE()


### PR DESCRIPTION
You cannot modify dereferenced FILE, this is UB. FILE may also be
opaque type so this code may not compile (and in fact it doesn't
compile on DragonFlyBSD). freopen is quite enough to do the thing.