### PR TITLE
Add confirmation for quitting the game

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -16,6 +16,11 @@ file_filter = data/lang/equipment-core/<lang>.json
 source_file = data/lang/equipment-core/en.json
 source_lang = en
 
+[pioneer.quitconfirmation-core]
+file_filter = data/lang/quitconfirmation-core/<lang>.json
+source_file = data/lang/quitconfirmation-core/en.json
+source_lang = en
+
 [pioneer.module-aiwarning]
 file_filter = data/lang/module-aiwarning/<lang>.json
 source_file = data/lang/module-aiwarning/en.json

--- a/data/lang/quitconfirmation-core/en.json
+++ b/data/lang/quitconfirmation-core/en.json
@@ -1,0 +1,82 @@
+{
+   "NO" : {
+      "description" : "No, don't quit program",
+      "message" : "No"
+   },
+   "YES" : {
+      "description" : "Yes, quit program",
+      "message" : "Yes"
+   },
+   "QUIT" : {
+      "description" : "Quit game, as a question",
+      "message" : "Quit?"
+   },
+   "MSG_1" : {
+      "description" : "",
+      "message" : "Say {yes} to get out of here and go back to your boring programs?"
+   },
+   "MSG_2" : {
+      "description" : "",
+      "message" : "Don't go now, there's a pirate waiting for you in the other program."
+   },
+   "MSG_3" : {
+      "description" : "",
+      "message" : "Are you sure you want to quit this great game that cost you nothing?"
+   },
+   "MSG_4" : {
+      "description" : "",
+      "message" : "Doest thou wish to leave with such hasty abandon?"
+   },
+   "MSG_5" : {
+      "description" : "(Inspired by Wolfenstein 3D)",
+      "message" : "Choose {no} for guns and glory, {yes} for work and worry."
+   },
+   "MSG_6" : {
+      "description" : "",
+      "message" : "Click {no} to be brave, click {yes} to cower in shame."
+   },
+   "MSG_7" : {
+      "description" : "Doom 1 anyone? Although it said DOS instead of Command line",
+      "message" : "I wouldn't leave if I were you. The command line is much worse."
+   },
+   "MSG_8" : {
+      "description" : "",
+      "message" : "I'm thinking you want to click {no} to play more. You do it."
+   },
+   "MSG_9" : {
+      "description" : "",
+      "message" : "Clicking {yes} means you must return to the humdrum workday world."
+   },
+   "MSG_10" : {
+      "description" : "",
+      "message" : "Please choose {no} to waste a few more productive hours. Please?"
+   },
+   "MSG_11" : {
+      "description" : "",
+      "message" : "Explorers don't quit, but go ahead and click {yes} if you aren't one."
+   },
+   "MSG_12" : {
+      "description" : "",
+      "message" : "Choose {no} If you are a tough bounty hunter, if not, click {yes} daintily."
+   },
+   "MSG_13" : {
+      "description" : "\"Seeing\" as in having an affair / being unfaithful",
+      "message" : "We never talk anymore. Are you seeing someone else?"
+   },
+   "MSG_14" : {
+      "description" : "",
+      "message" : "Do you really have something better to do?"
+   },
+   "MSG_15" : {
+      "description" : "",
+      "message" : "Giving up already?"
+   },
+   "MSG_16" : {
+      "description" : "A little homage to the movie 2001 A Space Odyssey",
+      "message" : "Just what do you think you're doing, Dave?"
+   },
+   "MSG_17" : {
+      "description" : "WIMP could mean Weakly Interacting Massive Particle, good luck translating that! Just go with the other meaning of the word, or make something else up, e.g.\"Magellan didn't quit\".",
+      "message" : "Quitting is for WIMPs!"
+   }
+}

--- a/data/ui/MainMenu.lua
+++ b/data/ui/MainMenu.lua
@@ -84,12 +84,16 @@ local doSettingsScreen = function()
 end
 
 local doQuitConfirmation = function()
-	ui:NewLayer(
-		ui.templates.QuitConfirmation({
-			onConfirm = function () Engine.Quit() end,
-			onCancel  = function () ui:DropLayer() end
-		})
-	)
+	if Engine.GetConfirmQuit() then
+		ui:NewLayer(
+			ui.templates.QuitConfirmation({
+				onConfirm = function () Engine.Quit() end,
+				onCancel  = function () ui:DropLayer() end
+			})
+		)
+	else
+		Engine.Quit()
+	end
 end
 
 local buttonDefs = {

--- a/data/ui/MainMenu.lua
+++ b/data/ui/MainMenu.lua
@@ -83,6 +83,15 @@ local doSettingsScreen = function()
 	)
 end
 
+local doQuitConfirmation = function()
+	ui:NewLayer(
+		ui.templates.QuitConfirmation({
+			onConfirm = function () Engine.Quit() end,
+			onCancel  = function () ui:DropLayer() end
+		})
+	)
+end
+
 local buttonDefs = {
 	{ l.CONTINUE_GAME,          function () loadGame("_exit") end },
 	{ l.START_AT_EARTH,         function () Game.StartGame(SystemPath.New(0,0,0,0,6),48600)   setupPlayerSol() end },
@@ -90,7 +99,7 @@ local buttonDefs = {
 	{ l.START_AT_BARNARDS_STAR, function () Game.StartGame(SystemPath.New(-1,0,0,0,1))  setupPlayerBarnard() end },
 	{ l.LOAD_GAME,              doLoadDialog },
 	{ l.OPTIONS,                doSettingsScreen },
-	{ l.QUIT,                   function () Engine.Quit() end },
+	{ l.QUIT,                   doQuitConfirmation },
 }
 
 local anims = {}
@@ -137,7 +146,7 @@ table.insert(anims, {
 	duration = 0.4,
 })
 
-local menu = 
+local menu =
 	ui:Grid(1, { 0.2, 0.6, 0.2 })
 		:SetRow(0, {
 			ui:Grid({ 0.1, 0.8, 0.1 }, 1)

--- a/data/ui/QuitConfirmation.lua
+++ b/data/ui/QuitConfirmation.lua
@@ -1,0 +1,43 @@
+-- Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Engine = import("Engine")
+local Lang = import("Lang")
+
+local ui = Engine.ui
+local l = Lang.GetResource("quitconfirmation-core")
+
+local max_flavours = 17
+
+ui.templates.QuitConfirmation = function (args)
+	local title        = l.QUIT
+	local confirmLabel = l.YES
+	local cancelLabel  = l.NO
+	local onConfirm    = args.onConfirm
+	local onCancel     = args.onCancel
+
+	local message      = string.interp(l["MSG_" .. Engine.rand:Integer(1, max_flavours)],{yes = l.YES, no = l.NO})
+
+	local confirmButton = ui:Button(ui:Label(confirmLabel):SetFont("HEADING_NORMAL"))
+	local cancelButton = ui:Button(ui:Label(cancelLabel):SetFont("HEADING_NORMAL"))
+	cancelButton.onClick:Connect(onCancel)
+	confirmButton.onClick:Connect(onConfirm)
+
+	local dialog =
+		ui:ColorBackground(0,0,0,0.5,
+			ui:Align("MIDDLE",
+				ui:Background(
+					ui:Table():SetRowSpacing(10)
+						:AddRow(ui:Label(title):SetFont("HEADING_NORMAL"))
+						:AddRow(ui:MultiLineText(message))
+						:AddRow(ui:Grid(2,1)
+									:SetRow(0, {
+										ui:Align("LEFT", confirmButton),
+										ui:Align("RIGHT", cancelButton),
+						}))
+				)
+			)
+		)
+
+	return dialog
+end

--- a/data/ui/Settings.lua
+++ b/data/ui/Settings.lua
@@ -100,6 +100,10 @@ ui.templates.Settings = function (args)
 			Engine.GetCompactScanner, Engine.SetCompactScanner,
 			l.COMPACT_SCANNER)
 
+		local confirmQuit = optionCheckBox(
+			Engine.GetConfirmQuit, Engine.SetConfirmQuit,
+			"Confirm quit")
+
 		local speedLinesCheckBox = optionCheckBox(
 			Engine.GetDisplaySpeedLines, Engine.SetDisplaySpeedLines,
 			l.DISPLAY_SPEED_LINES)
@@ -133,6 +137,7 @@ ui.templates.Settings = function (args)
 				hudTrailsCheckBox,
 				cockpitCheckBox,
 				compactScannerCheckBox,
+				confirmQuit,
 			})))
 	end
 

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -23,6 +23,7 @@ GameConfig::GameConfig(const std::map<std::string,std::string> &override_)
 	map["FOVVertical"] = "65";
 	map["DisplayNavTunnel"] = "0";
 	map["CompactScanner"] = "1";
+	map["ConfirmQuit"] = "1";
 	map["MasterVolume"] = "0.8";
 	map["MusicVolume"] = "0.8";
 	map["MasterMuted"] = "0";

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -107,8 +107,8 @@ static int l_engine_attr_version(lua_State *l)
 {
 	std::string version(PIONEER_VERSION);
 	if (strlen(PIONEER_EXTRAVERSION)) version += " (" PIONEER_EXTRAVERSION ")";
-    lua_pushlstring(l, version.c_str(), version.size());
-    return 1;
+	 lua_pushlstring(l, version.c_str(), version.size());
+	 return 1;
 }
 
 /*
@@ -711,6 +711,22 @@ static int l_engine_set_compact_scanner(lua_State *l)
 	return 0;
 }
 
+static int l_engine_get_confirm_quit(lua_State *l)
+{
+	lua_pushboolean(l, Pi::config->Int("ConfirmQuit") != 0);
+	return 1;
+}
+
+static int l_engine_set_confirm_quit(lua_State *l)
+{
+	if (lua_isnone(l, 1))
+		return luaL_error(l, "ConfirmQuit takes one boolean argument");
+	const bool confirm = lua_toboolean(l, 1);
+	Pi::config->SetInt("ConfirmQuit", (confirm ? 1 : 0));
+	Pi::config->Save();
+	return 0;
+}
+
 static int l_engine_get_joystick_enabled(lua_State *l)
 {
 	lua_pushboolean(l, Pi::config->Int("EnableJoystick") != 0);
@@ -780,6 +796,9 @@ void LuaEngine::Register()
 
 		{ "GetCompactScanner", l_engine_get_compact_scanner },
 		{ "SetCompactScanner", l_engine_set_compact_scanner },
+
+		{ "GetConfirmQuit", l_engine_get_confirm_quit },
+		{ "SetConfirmQuit", l_engine_set_confirm_quit },
 
 		{ "GetMasterMuted", l_engine_get_master_muted },
 		{ "SetMasterMuted", l_engine_set_master_muted },


### PR DESCRIPTION
Add confirmation for quitting the game, in 17 flavours.

A little homage to great game devs of the 90s like ID Software and Apogee (Doom 1-2, Spear of Destiny, Wolfenstein 3D), by having random confirmation questions. It can be disabled, which is perhaps useful when testing and developing.

![2015-03-30-210141_859x528_scrot](https://cloud.githubusercontent.com/assets/619390/6904476/4aba8bea-d721-11e4-8e64-5e0497dfb312.png)

![18](https://cloud.githubusercontent.com/assets/619390/6913880/c3e0e0f2-d774-11e4-8164-b31de5c4ec77.png)


This probably isn't the right place to put this option, please advice:

![2015-03-30-210229_377x128_scrot](https://cloud.githubusercontent.com/assets/619390/6904483/58620534-d721-11e4-85ea-33cb9c453c00.png)

