### PR TITLE
Fix #3377 - broken cockpit rotations using headlook.

### DIFF
--- a/src/CameraController.h
+++ b/src/CameraController.h
@@ -117,9 +117,6 @@ public:
 
 	double m_rotX; //vertical rot
 	double m_rotY; //horizontal rot
-        // cache for ShipCockpit to avoid divisions
-	double m_viewRotX; //vertical rot
-	double m_viewRotY; //horizontal rot
 	matrix3x3d m_intOrient;
 	matrix3x3d m_viewOrient;
 };

--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -11,23 +11,23 @@
 #include "WorldView.h"
 
 ShipCockpit::ShipCockpit(const std::string &modelName) :
-	m_shipDir(0.0),
-	m_shipYaw(0.0),
-	m_dir(0.0),
-	m_yaw(0.0),
-	m_rotInterp(0.f),
-	m_transInterp(0.f),
-	m_gForce(0.f),
-	m_offset(0.f),
-	m_shipVel(0.f),
-	m_translate(0.0),
-	m_transform(matrix4x4d::Identity())
+m_shipDir(0.0),
+m_shipYaw(0.0),
+m_dir(0.0),
+m_yaw(0.0),
+m_rotInterp(0.f),
+m_transInterp(0.f),
+m_gForce(0.f),
+m_offset(0.f),
+m_shipVel(0.f),
+m_translate(0.0),
+m_transform(matrix4x4d::Identity())
 {
 	assert(!modelName.empty());
 	SetModel(modelName.c_str());
 	assert(GetModel());
 	SetColliding(false);
-        m_icc = nullptr;
+	m_icc = nullptr;
 }
 
 ShipCockpit::~ShipCockpit()
@@ -41,24 +41,26 @@ void ShipCockpit::Render(Graphics::Renderer *renderer, const Camera *camera, con
 }
 
 inline void ShipCockpit::resetInternalCameraController() {
-        m_icc = static_cast<InternalCameraController*>(Pi::game->GetWorldView()->GetCameraController());
+	m_icc = static_cast<InternalCameraController*>(Pi::game->GetWorldView()->GetCameraController());
 }
 
 void ShipCockpit::Update(float timeStep)
 {
-        m_transform = matrix4x4d::Identity();
+	m_transform = matrix4x4d::Identity();
 
-       double rotX;
-       double rotY;
-       if(m_icc == nullptr)
-           // I don't know where to put this
-           resetInternalCameraController();
-       m_icc->getRots(rotX, rotY);
-       m_transform.RotateX(rotX);
-       m_transform.RotateY(rotY);
+	if (m_icc == nullptr) {
+		// I don't know where to put this
+		resetInternalCameraController();
+	}
+
+	double rotX;
+	double rotY;
+	m_icc->getRots(rotX, rotY);
+	m_transform.RotateX(rotX);
+	m_transform.RotateY(rotY);
 
 	vector3d cur_dir = Pi::player->GetOrient().VectorZ().Normalized();
-	if(cur_dir.Dot(m_shipDir) < 1.0f) {
+	if (cur_dir.Dot(m_shipDir) < 1.0f) {
 		m_rotInterp = 0.0f;
 		m_shipDir = cur_dir;
 	}
@@ -66,23 +68,23 @@ void ShipCockpit::Update(float timeStep)
 	//---------------------------------------- Acceleration
 	float cur_vel = CalculateSignedForwardVelocity(-cur_dir, Pi::player->GetVelocity()); // Forward is -Z
 	float gforce = Clamp(floorf(((abs(cur_vel) - m_shipVel) / timeStep) / 9.8f), -COCKPIT_MAX_GFORCE, COCKPIT_MAX_GFORCE);
-	if(abs(cur_vel) > 500000.0f ||      // Limit gforce measurement so we don't get astronomical fluctuations
-	   abs(gforce - m_gForce) > 100.0) { // Smooth out gforce one frame spikes, sometimes happens when hitting max speed due to the thrust limiters
+	if (abs(cur_vel) > 500000.0f ||      // Limit gforce measurement so we don't get astronomical fluctuations
+		abs(gforce - m_gForce) > 100.0) { // Smooth out gforce one frame spikes, sometimes happens when hitting max speed due to the thrust limiters
 		gforce = 0.0f;
 	}
-	if(abs(gforce - m_gForce) > 100.0) {
+	if (abs(gforce - m_gForce) > 100.0) {
 		gforce = 0.0f;
 	}
-	if(abs(m_translate.z - m_offset) < 0.001f) {
+	if (abs(m_translate.z - m_offset) < 0.001f) {
 		m_transInterp = 0.0f;
 	}
-	float offset = (gforce > 14.0f? -1.0f : (gforce < -14.0f? 1.0f : 0.0f)) * COCKPIT_ACCEL_OFFSET;
+	float offset = (gforce > 14.0f ? -1.0f : (gforce < -14.0f ? 1.0f : 0.0f)) * COCKPIT_ACCEL_OFFSET;
 	m_transInterp += timeStep * COCKPIT_ACCEL_INTERP_MULTIPLIER;
-	if(m_transInterp > 1.0f) {
+	if (m_transInterp > 1.0f) {
 		m_transInterp = 1.0f;
 		m_translate.z = offset;
 	}
-	m_translate.z = Easing::Quad::EaseIn(double(m_transInterp), m_translate.z, offset-m_translate.z, 1.0);
+	m_translate.z = Easing::Quad::EaseIn(double(m_transInterp), m_translate.z, offset - m_translate.z, 1.0);
 	m_gForce = gforce;
 	m_offset = offset;
 	m_shipVel = cur_vel;
@@ -95,7 +97,7 @@ void ShipCockpit::Update(float timeStep)
 	float dot = cur_dir.Dot(m_dir);
 	float angle = acos(dot);
 	// For roll
-	if(yaw_axis.Dot(m_shipYaw) < 1.0f) {
+	if (yaw_axis.Dot(m_shipYaw) < 1.0f) {
 		m_rotInterp = 0.0f;
 		m_shipYaw = yaw_axis;
 	}
@@ -103,29 +105,29 @@ void ShipCockpit::Update(float timeStep)
 	float dot_yaw = yaw_axis.Dot(m_yaw);
 	float angle_yaw = acos(dot_yaw);
 
-	if(dot < 1.0f || dot_yaw < 1.0f) {
+	if (dot < 1.0f || dot_yaw < 1.0f) {
 		// Lag/Recovery interpolation
 		m_rotInterp += timeStep * COCKPIT_ROTATION_INTERP_MULTIPLIER;
-		if(m_rotInterp > 1.0f) {
+		if (m_rotInterp > 1.0f) {
 			m_rotInterp = 1.0f;
 		}
 
 		// Yaw and Pitch
-		if(dot < 1.0f) {
-			if(angle > DEG2RAD(COCKPIT_LAG_MAX_ANGLE)) {
+		if (dot < 1.0f) {
+			if (angle > DEG2RAD(COCKPIT_LAG_MAX_ANGLE)) {
 				angle = DEG2RAD(COCKPIT_LAG_MAX_ANGLE);
 			}
 			angle = Easing::Quad::EaseOut(m_rotInterp, angle, -angle, 1.0f);
 			m_dir = cur_dir;
-			if(angle >= 0.0f) {
+			if (angle >= 0.0f) {
 				m_dir.ArbRotate(rot_axis, angle);
 				// Apply pitch
 				vector3d yz_proj = (m_dir - (m_dir.Dot(pitch_axis) * pitch_axis)).Normalized();
 				float pitch_cos = yz_proj.Dot(cur_dir);
 				float pitch_angle = 0.0f;
-				if(pitch_cos < 1.0f) {
+				if (pitch_cos < 1.0f) {
 					pitch_angle = acos(pitch_cos);
-					if(rot_axis.Dot(pitch_axis) < 0) {
+					if (rot_axis.Dot(pitch_axis) < 0) {
 						pitch_angle = -pitch_angle;
 					}
 					m_transform.RotateX(-pitch_angle);
@@ -134,45 +136,48 @@ void ShipCockpit::Update(float timeStep)
 				vector3d xz_proj = (m_dir - (m_dir.Dot(yaw_axis) * yaw_axis)).Normalized();
 				float yaw_cos = xz_proj.Dot(cur_dir);
 				float yaw_angle = 0.0f;
-				if(yaw_cos < 1.0f) {
+				if (yaw_cos < 1.0f) {
 					yaw_angle = acos(yaw_cos);
-					if(rot_axis.Dot(yaw_axis) < 0) {
+					if (rot_axis.Dot(yaw_axis) < 0) {
 						yaw_angle = -yaw_angle;
 					}
 					m_transform.RotateY(-yaw_angle);
 				}
-			} else {
+			}
+			else {
 				angle = 0.0f;
 			}
 		}
 
 		// Roll
-		if(dot_yaw < 1.0f) {
-			if(angle_yaw > DEG2RAD(COCKPIT_LAG_MAX_ANGLE)) {
+		if (dot_yaw < 1.0f) {
+			if (angle_yaw > DEG2RAD(COCKPIT_LAG_MAX_ANGLE)) {
 				angle_yaw = DEG2RAD(COCKPIT_LAG_MAX_ANGLE);
 			}
-			if(dot_yaw < 1.0f) {
+			if (dot_yaw < 1.0f) {
 				angle_yaw = Easing::Quad::EaseOut(m_rotInterp, angle_yaw, -angle_yaw, 1.0f);
 			}
 			m_yaw = yaw_axis;
-			if(angle_yaw >= 0.0f) {
+			if (angle_yaw >= 0.0f) {
 				m_yaw.ArbRotate(rot_yaw_axis, angle_yaw);
 				// Apply roll
 				vector3d xy_proj = (m_yaw - (m_yaw.Dot(cur_dir) * cur_dir)).Normalized();
 				float roll_cos = xy_proj.Dot(yaw_axis);
 				float roll_angle = 0.0f;
-				if(roll_cos < 1.0f) {
+				if (roll_cos < 1.0f) {
 					roll_angle = acos(roll_cos);
-					if(rot_yaw_axis.Dot(cur_dir) < 0) {
+					if (rot_yaw_axis.Dot(cur_dir) < 0) {
 						roll_angle = -roll_angle;
 					}
 					m_transform.RotateZ(-roll_angle);
 				}
-			} else {
+			}
+			else {
 				angle_yaw = 0.0f;
 			}
 		}
-	} else {
+	}
+	else {
 		m_rotInterp = 0.0f;
 	}
 }
@@ -197,5 +202,5 @@ void ShipCockpit::OnActivated()
 
 float ShipCockpit::CalculateSignedForwardVelocity(vector3d normalized_forward, vector3d velocity) {
 	float velz_cos = velocity.Dot(normalized_forward);
-	return (velz_cos * normalized_forward).Length() * (velz_cos < 0.0? -1.0 : 1.0);
+	return (velz_cos * normalized_forward).Length() * (velz_cos < 0.0 ? -1.0 : 1.0);
 }


### PR DESCRIPTION
This fixes #3377 by removing the "cached" values and just converting the actual values using 'DEG2RAD' that are correctly calculated.

I also noticed that some bad formatting had crept in so just blanket reformatted the files involved.