### PR TITLE
Calculate the distribution correctly for placing orbitals.

### DIFF
--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1573,7 +1573,7 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody* sbody, StarSys
 
 			sp->m_orbit.SetShapeAroundPrimary(sp->GetSemiMajorAxisAsFixed().ToDouble()*AU, sbody->GetMassAsFixed().ToDouble() * EARTH_MASS, 0.0);
 			if (NumToMake > 1) {
-				sp->m_orbit.SetPlane(matrix3x3d::RotateZ(double(i) * (M_PI / double(NumToMake-1))));
+				sp->m_orbit.SetPlane(matrix3x3d::RotateZ(double(i) * ((M_PI * 2.0) / double(NumToMake-1))));
 			} else {
 				sp->m_orbit.SetPlane(matrix3x3d::Identity());
 			}


### PR DESCRIPTION
It seems that I got my maths a little wrong when placing multiple orbitals originally.

This now distributes them evenly around a whole orbit which is still very artificial (hah!) however it does look better than only doing it over half of the available orbit.

Should fix #3388 and I will create a new feature request for the other items listed in it.