### PR TITLE
Allow up to 3 orbits a spacestation can occupy.

### DIFF
--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1545,46 +1545,93 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody* sbody, StarSys
 
 	fixed orbMaxS = fixed(1,4)*CalcHillRadius(sbody);
 	fixed orbMinS = 4 * sbody->GetRadiusAsFixed() * AU_EARTH_RADIUS;
-	if (sbody->GetNumChildren()) orbMaxS = std::min(orbMaxS, fixed(1,2) * sbody->GetChildren()[0]->GetOrbMinAsFixed());
+	if (sbody->GetNumChildren() > 0) 
+		orbMaxS = std::min(orbMaxS, fixed(1,2) * sbody->GetChildren()[0]->GetOrbMinAsFixed());
 
 	// starports - orbital
 	fixed pop = sbody->GetPopulationAsFixed() + rand.Fixed();
 	if( orbMinS < orbMaxS )
 	{
+		// How many stations do we need?
 		pop -= rand.Fixed();
 		Uint32 NumToMake = 0;
 		while(pop >= 0) {
 			++NumToMake;
 			pop -= rand.Fixed();
 		}
-		for( Uint32 i=0; i<NumToMake; i++ ) {
-			SystemBody *sp = system->NewBody();
-			sp->m_type = SystemBody::TYPE_STARPORT_ORBITAL;
-			sp->m_seed = rand.Int32();
-			sp->m_parent = sbody;
-			sp->m_rotationPeriod = fixed(1,3600);
-			sp->m_averageTemp = sbody->GetAverageTemp();
-			sp->m_mass = 0;
 
-			// place stations between min and max orbits to reduce the number of extremely close/fast orbits
-			sp->m_semiMajorAxis = orbMinS + ((orbMaxS - orbMinS) / 4);
-			sp->m_eccentricity = fixed();
-			sp->m_axialTilt = fixed();
+		// Any to position?
+		if( NumToMake > 0 )
+		{
+			// What is our innermost orbit?
+			fixed innerOrbit = orbMinS + ((orbMaxS - orbMinS) / 4);
 
-			sp->m_orbit.SetShapeAroundPrimary(sp->GetSemiMajorAxisAsFixed().ToDouble()*AU, sbody->GetMassAsFixed().ToDouble() * EARTH_MASS, 0.0);
-			if (NumToMake > 1) {
-				sp->m_orbit.SetPlane(matrix3x3d::RotateZ(double(i) * ((M_PI * 2.0) / double(NumToMake-1))));
-			} else {
-				sp->m_orbit.SetPlane(matrix3x3d::Identity());
+			// Try to limit the inner orbit to at least one day.
+			{
+				Orbit orb;
+				orb.SetShapeAroundPrimary(innerOrbit.ToDouble() * AU, 0.0, 0.0);
+				orb.SetPlane(matrix3x3d::RotateZ(((M_PI * 2.0) / double(NumToMake-1))));
+				float days = float(orb.Period()) / float(60*60*24);
+				if(days<1.0)
+				{
+					// We can't go higher than our maximum so set it to that.
+					innerOrbit = orbMaxS;
+				}
 			}
 
-			sp->m_inclination = fixed();
-			sbody->m_children.insert(sbody->m_children.begin(), sp);
-			system->AddSpaceStation(sp);
-			sp->m_orbMin = sp->GetSemiMajorAxisAsFixed();
-			sp->m_orbMax = sp->GetSemiMajorAxisAsFixed();
+			// I like to think that we'd fill several "shells" of orbits at once rather than fill one and move out further
+			static const Uint32 MAX_ORBIT_SHELLS = 3;
+			fixed shells[MAX_ORBIT_SHELLS];
+			if( innerOrbit != orbMaxS )
+			{
+				shells[0] = innerOrbit; // low
+				shells[1] = innerOrbit + ((orbMaxS - innerOrbit) * fixed(1,2)); // med
+				shells[2] = orbMaxS; // high
+			}
+			else
+			{
+				shells[0] = shells[1] = shells[2] = innerOrbit;
+			}
+			Uint32 orbitIdx = 0;
 
-			sp->m_name = gen_unique_station_name(sp, system, namerand);
+			for( Uint32 i=0; i<NumToMake; i++ ) 
+			{
+				// Pick the orbit we've currently placing a station into.
+				const fixed currOrbit = shells[orbitIdx];
+				++orbitIdx; 
+				orbitIdx = orbitIdx % MAX_ORBIT_SHELLS; // wrap it
+
+				// Begin creation of the new station
+				SystemBody *sp = system->NewBody();
+				sp->m_type = SystemBody::TYPE_STARPORT_ORBITAL;
+				sp->m_seed = rand.Int32();
+				sp->m_parent = sbody;
+				sp->m_rotationPeriod = fixed(1,3600);
+				sp->m_averageTemp = sbody->GetAverageTemp();
+				sp->m_mass = 0;
+
+				// place stations between min and max orbits to reduce the number of extremely close/fast orbits
+				sp->m_semiMajorAxis = currOrbit;
+				sp->m_eccentricity = fixed();
+				sp->m_axialTilt = fixed();
+
+				sp->m_orbit.SetShapeAroundPrimary(sp->GetSemiMajorAxisAsFixed().ToDouble()*AU, sbody->GetMassAsFixed().ToDouble() * EARTH_MASS, 0.0);
+				if (NumToMake > 1) {
+					// The rotations around X & Y perturb the orbits just a little bit so that not all stations are exactly within the same plane
+					// The Z rotation is what gives them the separation in their orbit around the parent body as a whole.
+					sp->m_orbit.SetPlane(matrix3x3d::RotateX(rand.Double(M_PI * 0.03125)) * matrix3x3d::RotateY(rand.Double(M_PI * 0.03125)) * matrix3x3d::RotateZ(double(i) * ((M_PI * 2.0) / double(NumToMake-1))));
+				} else {
+					sp->m_orbit.SetPlane(matrix3x3d::Identity());
+				}
+
+				sp->m_inclination = fixed();
+				sbody->m_children.insert(sbody->m_children.begin(), sp);
+				system->AddSpaceStation(sp);
+				sp->m_orbMin = sp->GetSemiMajorAxisAsFixed();
+				sp->m_orbMax = sp->GetSemiMajorAxisAsFixed();
+
+				sp->m_name = gen_unique_station_name(sp, system, namerand);
+			}
 		}
 	}
 	// starports - surface


### PR DESCRIPTION
Allow up to 3 orbits a spacestation can occupy, perturb their orbits gently for visual effect.

This is to fix #3390 though it really only satisfies the variation part of it. Actually checking that stations won't collide with other things is mostly taken care of before we reach the relevant methods.

This adds some variations to the orbits of each station which hopefully doesn't mean they will collide, I guess I'll wait for the bug reports to see how that goes ;)

Andy