### PR TITLE
Fix crash when using Chinese languge

### DIFF
--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -29,6 +29,8 @@ public:
 	unsigned int GetNumVerts() const;
 	AttributeSet GetAttributeSet() const { return m_attribs; }
 
+	bool IsEmpty() const { return position.empty(); }
+
 	//removes vertices, does not deallocate space
 	void Clear();
 

--- a/src/scenegraph/Label3D.cpp
+++ b/src/scenegraph/Label3D.cpp
@@ -49,6 +49,11 @@ void Label3D::SetText(const std::string &text)
 	m_geometry->Clear();
 	if (!text.empty()) {
 		m_font->GetGeometry(*m_geometry, text, vector2f(0.f));
+
+		// Happens if none of the characters in the string have glyphs in the SDF font.
+		// Most noticeably, this means text consisting of entirely Cyrillic
+		// or Chinese characters will vanish when rendered on a Label3D.
+		if (m_geometry->IsEmpty()) { return; }
 		
 		//create buffer and upload data
 		Graphics::VertexBufferDesc vbd;


### PR DESCRIPTION
Fixes #3391.

This does not solve the underlying problem that we can't render Chinese characters on 3D models. For that we will need to implement on-demand SDF glyph generation. It looks like there's some code to do this in [freetype-gl](https://github.com/rougier/freetype-gl), which we should be able to use.