### PR TITLE
Fix inconsistent types for 'imports' and 'exports' variables in TradeShips.lua

### DIFF
--- a/data/modules/TradeShips.lua
+++ b/data/modules/TradeShips.lua
@@ -60,7 +60,7 @@ local e = import ("Equipment")
 		approached without atmospheric shields,	updated by spawnInitialShips
 
 	imports, exports - in the current system, indexed array of
-		Constants.EquipType strings, updated by spawnInitialShips
+		equipment objects (from the 'Equipment' module), updated by spawnInitialShips
 --]]
 local trade_ships, system_updated, from_paths, starports, vacuum_starports, imports, exports
 
@@ -897,9 +897,9 @@ local onGameStart = function ()
 				local v = Game.system:GetCommodityBasePriceAlterations(equip)
 				if key ~= 'rubbish' and key ~= 'radioactives' and Game.system:IsCommodityLegal(equip) then
 					if v > 2 then
-						table.insert(imports, key)
+						table.insert(imports, equip)
 					elseif v < -2 then
-						table.insert(exports, key)
+						table.insert(exports, equip)
 					end
 				end
 			end

--- a/src/LuaStarSystem.cpp
+++ b/src/LuaStarSystem.cpp
@@ -148,6 +148,9 @@ static int l_starsystem_get_commodity_base_price_alterations(lua_State *l)
 	LUA_DEBUG_START(l);
 
 	StarSystem *s = LuaObject<StarSystem>::CheckFromLua(1);
+	if (!lua_istable(l, 2)) {
+		return luaL_error(l, "GetCommodityBasePriceAlterations takes a cargo object as and argument.");
+	}
 	LuaTable equip(l, 2);
 
 	if (!equip.CallMethod<bool>("IsValidSlot", "cargo")) {


### PR DESCRIPTION
For the problem reported in #3387.