### PR TITLE
Fix terrain max depth calculation.

### DIFF
--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -67,7 +67,7 @@ GeoPatch::~GeoPatch() {
 	colors.reset();
 }
 
-void GeoPatch::_UpdateVBOs(Graphics::Renderer *renderer) 
+void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 {
 	if (m_needUpdateVBOs) {
 		assert(renderer);
@@ -130,7 +130,7 @@ static const SSphere s_sph;
 void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, const matrix4x4d &modelView, const Graphics::Frustum &frustum)
 {
 	// must update the VBOs to calculate the clipRadius...
-	_UpdateVBOs(renderer);
+	UpdateVBOs(renderer);
 	// ...before doing the furstum culling that relies on it.
 	if (!frustum.TestPoint(clipCentroid, clipRadius))
 		return; // nothing below this patch is visible
@@ -295,7 +295,7 @@ void GeoPatch::ReceiveHeightmaps(SQuadSplitResult *psr)
 		}
 		for (int i=0; i<NUM_EDGES; i++) { if(edgeFriend[i]) edgeFriend[i]->NotifyEdgeFriendSplit(this); }
 		for (int i=0; i<NUM_KIDS; i++) {
-			kids[i]->UpdateVBOs();
+			kids[i]->NeedToUpdateVBOs();
 		}
 		mHasJobRequest = false;
 	}

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -61,11 +61,11 @@ public:
 
 	~GeoPatch();
 
-	inline void UpdateVBOs() {
+	inline void NeedToUpdateVBOs() {
 		m_needUpdateVBOs = (nullptr != heights);
 	}
 
-	void _UpdateVBOs(Graphics::Renderer *renderer);
+	void UpdateVBOs(Graphics::Renderer *renderer);
 
 	inline int GetEdgeIdxOf(const GeoPatch *e) const {
 		for (int i=0; i<NUM_KIDS; i++) {if (edgeFriend[i] == e) {return i;}}

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -282,6 +282,8 @@ void GeoSphere::BuildFirstPatches()
 	if(m_patches[0])
 		return;
 
+	CalculateMaxPatchDepth();
+
 	// generate root face patches of the cube/sphere
 	static const vector3d p1 = (vector3d( 1, 1, 1)).Normalized();
 	static const vector3d p2 = (vector3d(-1, 1, 1)).Normalized();
@@ -346,7 +348,7 @@ void GeoSphere::Update()
 	case eReceivedFirstPatches:
 		{
 			for (int i=0; i<NUM_PATCHES; i++) {
-				m_patches[i]->UpdateVBOs();
+				m_patches[i]->NeedToUpdateVBOs();
 			}
 			m_initStage = eDefaultUpdateState;
 		} break;


### PR DESCRIPTION
Call CalculateMaxPatchDepth at start of BuildFirstPatches method.
Rename some old methods.

This should fix the case where the terrain doesn't seem to generate enough detail when the game first starts.