### PR TITLE
Sort terrain gen

### DIFF
--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -142,6 +142,7 @@ public:
 	void RequestSinglePatch();
 	void ReceiveHeightmaps(SQuadSplitResult *psr);
 	void ReceiveHeightmap(const SSingleSplitResult *psr);
+	void ReceiveJobHandle(Job::Handle job);
 
 	inline void SetEdgeFriend(const int idx, GeoPatch *pPatch) { edgeFriend[idx] = pPatch; }
 	inline bool HasHeightData() const { return (heights.get()!=nullptr); }

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -68,14 +68,25 @@ public:
 
 	inline Sint32 GetMaxDepth() const { return m_maxDepth; }
 
+	void AddQuadSplitRequest(double, SQuadSplitRequest*, GeoPatch*);
+
 private:
 	void BuildFirstPatches();
 	void CalculateMaxPatchDepth();
 	inline vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const {
 		return m_terrain->GetColor(p, height, norm);
 	}
+	void ProcessQuadSplitRequests();
 
 	std::unique_ptr<GeoPatch> m_patches[6];
+	struct TDistanceRequest {
+		TDistanceRequest(double dist, SQuadSplitRequest *pRequest, GeoPatch *pRequester) :
+			mDistance(dist), mpRequest(pRequest), mpRequester(pRequester) {}
+		double mDistance;
+		SQuadSplitRequest *mpRequest;
+		GeoPatch *mpRequester;
+	};
+	std::deque<TDistanceRequest> mQuadSplitRequests;
 
 	static const uint32_t MAX_SPLIT_OPERATIONS = 128;
 	std::deque<SQuadSplitResult*> mQuadSplitResults;


### PR DESCRIPTION
To follow #3419 (Numerous Optimisations)...

This delays submissions of the terrain generation requests in order to gather them up, sort them by distance from the camera, then submit them.

This is so that they are hopefully processed by those nearest to the camera first.