### PR TITLE
Rename bodyscanner, and set it as not purchasable for now,

### DIFF
--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -175,6 +175,14 @@
       "description" : "",
       "message" : "Although less effective than a fuel scoop it permits scooping of both cargo and fuel"
    },
+   "PLANETSCANNER" : {
+      "description" : "Scans the nearest body for resources",
+      "message" : "Body scan"
+   },
+   "PLANETSCANNER_DESCRIPTION" : {
+      "description" : "",
+      "message" : "Scan nearest body for resources."
+   },
    "PULSECANNON_10MW" : {
       "description" : "",
       "message" : "10MW pulse cannon"
@@ -254,18 +262,6 @@
    "UNOCCUPIED_CABIN_DESCRIPTION" : {
       "description" : "",
       "message" : "Required for transport of a single passenger"
-   },
-   "BODYSCANNER" : {
-      "description" : "Scans the nearest body for resources",
-      "message" : "Body scan"
-   },
-   "BODYSCANNER_FAST" : {
-      "description" : "Faster body scanner but has less scan altitude tolerance",
-      "message" : "Fast body scan"
-   },
-   "BODYSCANNER_DESCRIPTION" : {
-      "description" : "",
-      "message" : "Scan nearest body for resources."
    },
    "STARTING_SCAN" : {
       "description" : "",

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -738,21 +738,12 @@ misc.trade_analyzer = EquipType.New({
 	l10n_key="TRADE_ANALYZER", slots="trade_analyzer", price=400,
 	capabilities={mass=0, trade_analyzer=1}, purchasable=true
 })
-
-misc.bodyscanner = BodyScannerType.New({
-	l10n_key = 'BODYSCANNER', slots="sensor", price=1,
-	capabilities={mass=1,sensor=1}, purchasable=true,
+misc.planetscanner = BodyScannerType.New({
+	l10n_key = 'PLANETSCANNER', slots="sensor", price=15000,
+	capabilities={mass=1,sensor=1}, purchasable=false,
 	icon_on_name="body_scanner_on", icon_off_name="body_scanner_off",
 	max_range=100000000, target_altitude=0, state="HALTED", progress=0,
 	bodyscanner_stats={scan_speed=3, scan_tolerance=0.05}
-})
-
-misc.bodyscanner2 = BodyScannerType.New({
-	l10n_key = 'BODYSCANNER_FAST', slots="sensor", price=1.5,
-	capabilities={mass=1,sensor=1}, purchasable=true,
-	icon_on_name="body_scanner_on", icon_off_name="body_scanner_off",
-	max_range=100000000, target_altitude=0, state="HALTED", progress=0,
-	bodyscanner_stats={scan_speed=6, scan_tolerance=0.025}
 })
 
 local hyperspace = {}


### PR DESCRIPTION
I'll make use of #3396 soon enough*, but for now, we don't need to see it in the equipment market.

The code that was there was for testing purposes.

__EDIT:__ (*) https://github.com/impaktor/pioneer/tree/scout-mission