### PR TITLE
Fixed color of labels starting with empty strings

### DIFF
--- a/src/gui/GuiTextLayout.cpp
+++ b/src/gui/GuiTextLayout.cpp
@@ -168,7 +168,11 @@ void TextLayout::Update(const float width, const Color &color)
 				if ((*wpos).word) {
 					const std::string word( (*wpos).word );
 					if (m_colourMarkup == ColourMarkupUse)
-						c = m_font->PopulateMarkup(va, word, round(px), round(py), c);
+					{
+						Color newColor = m_font->PopulateMarkup(va, word, round(px), round(py), c);
+						if(not word.empty())
+							c = std::move(newColor);
+					}
 					else
 						m_font->PopulateString(va, word, round(px), round(py), c);
 				}


### PR DESCRIPTION
Labels with some empty words set their colour to black. This avoid this
behaviour, just checking if the word is empty. Only if not, the color
is updated.