### PR TITLE
fixes for bodyscanner

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -55,9 +55,7 @@ function EquipType:Serialize()
 	local tmp = EquipType.Super().Serialize(self)
 	local ret = {}
 	for k,v in pairs(tmp) do
-		if type(v) ~= "function" then
-			ret[k] = v
-		end
+		ret[k] = v
 	end
 	ret.volatile = nil
 	return ret
@@ -369,6 +367,18 @@ end
 
 function SensorType:DoCallBack()
 	if self.callback then self.callback(self.progress, self.state) end
+end
+
+function SensorType:Serialize()
+	local tmp = SensorType.Super().Serialize(self)
+	local ret = {}
+	for k,v in pairs(tmp) do
+		if type(v) ~= "function" then
+			ret[k] = v
+		end
+	end
+	ret.volatile = nil
+	return ret
 end
 
 local BodyScannerType = utils.inherits(SensorType, "BodyScannerType")

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -538,7 +538,10 @@ end
 -- Starts the equipped sensor
 --
 -- Parameters:
---   idx - the index of the sensor in the equipment slots
+--   idx - The index of the sensor in the equipment slots
+--   callback - optional. Callback function to monitor the sensor progress taking two arguments: progress and state
+--       progress - Number or table. When state is "DONE" a table with the results else the precentual progress
+--       state - String representing the state of the scan. this can be DONE, PAUSED, RUNNING or HALTED
 --
 -- Availability:
 --
@@ -549,9 +552,12 @@ end
 --   experimental
 --
 
-function Ship:StartSensor(idx)
+function Ship:StartSensor(idx, callback)
+	if callback == nil then
+		callback = function(progress, state) end
+	end
 	local sensor = self:GetEquip("sensor", idx)
-	sensor:BeginAcquisition(function(progress, state) end)
+	sensor:BeginAcquisition(callback)
 end
 
 -- Method: StopSensor


### PR DESCRIPTION
Fixes for #3396 as requested by @laarmen 
I moved the 'not function' check for serialization to a new SensorType.Serialize function.
It is now possible to pass a callback function to the StartSensor function of Ship.