### PR TITLE
Remove planetary scaling during rendering.

### DIFF
--- a/data/shaders/opengl/gassphere_base.frag
+++ b/data/shaders/opengl/gassphere_base.frag
@@ -1,8 +1,7 @@
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made
-uniform float geosphereScale;
-uniform float geosphereScaledRadius;
+uniform float geosphereRadius;
 uniform float geosphereAtmosTopRad;
 uniform vec3 geosphereCenter;
 uniform float geosphereAtmosFogDensity;
@@ -70,7 +69,7 @@ void main(void)
 	float nDotVP=0.0;
 	float nnDotVP=0.0;
 
-	vec3 v = (eyepos - geosphereCenter)/geosphereScaledRadius;
+	vec3 v = (eyepos - geosphereCenter)/geosphereRadius;
 	float lenInvSq = 1.0/(dot(v,v));
 	for (int i=0; i<NUM_LIGHTS; ++i) {
 		vec3 lightDir = normalize(vec3(uLight[i].position));
@@ -98,15 +97,15 @@ void main(void)
 	}
 
 	// when does the eye ray intersect atmosphere
-	float atmosStart = findSphereEyeRayEntryDistance(geosphereCenter, eyepos, geosphereScaledRadius * geosphereAtmosTopRad);
+	float atmosStart = findSphereEyeRayEntryDistance(geosphereCenter, eyepos, geosphereRadius * geosphereAtmosTopRad);
 	float ldprod=0.0;
 	float fogFactor=0.0;
 	{
-		float atmosDist = geosphereScale * (length(eyepos) - atmosStart);
+		float atmosDist = (length(eyepos) - atmosStart);
 		
 		// a&b scaled so length of 1.0 means planet surface.
-		vec3 a = (atmosStart * eyenorm - geosphereCenter) / geosphereScaledRadius;
-		vec3 b = (eyepos - geosphereCenter) / geosphereScaledRadius;
+		vec3 a = (atmosStart * eyenorm - geosphereCenter) / geosphereRadius;
+		vec3 b = (eyepos - geosphereCenter) / geosphereRadius;
 		ldprod = AtmosLengthDensityProduct(a, b, atmosColor.w*geosphereAtmosFogDensity, atmosDist, geosphereAtmosInvScaleHeight);
 		fogFactor = clamp( 1.5 / exp(ldprod),0.0,1.0); 
 	}

--- a/data/shaders/opengl/gassphere_base.vert
+++ b/data/shaders/opengl/gassphere_base.vert
@@ -3,7 +3,7 @@ out vec3 varyingNormal;
 out vec3 varyingTexCoord0;
 
 uniform vec3 geosphereCenter;
-uniform float geosphereScaledRadius;
+uniform float geosphereRadius;
 
 void main(void)
 {

--- a/data/shaders/opengl/geosphere_sky.frag
+++ b/data/shaders/opengl/geosphere_sky.frag
@@ -4,8 +4,7 @@
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made
-uniform float geosphereScale;
-uniform float geosphereScaledRadius;
+uniform float geosphereRadius;
 uniform float geosphereAtmosTopRad;
 uniform vec3 geosphereCenter;
 uniform float geosphereAtmosFogDensity;
@@ -61,13 +60,13 @@ void main(void)
 	vec3 eyenorm = normalize(varyingEyepos.xyz);
 	float specularHighlight=0.0;
 
-	sphereEntryExitDist(skyNear, skyFar, geosphereCenter, varyingEyepos.xyz, geosphereScaledRadius * geosphereAtmosTopRad);
-	float atmosDist = geosphereScale * (skyFar - skyNear);
+	sphereEntryExitDist(skyNear, skyFar, geosphereCenter, varyingEyepos.xyz, geosphereRadius * geosphereAtmosTopRad);
+	float atmosDist = (skyFar - skyNear);
 	float ldprod=0.0;
 	
 	// a&b scaled so length of 1.0 means planet surface.
-	vec3 a = (skyNear * eyenorm - geosphereCenter) / geosphereScaledRadius;
-	vec3 b = (skyFar * eyenorm - geosphereCenter) / geosphereScaledRadius;
+	vec3 a = (skyNear * eyenorm - geosphereCenter) / geosphereRadius;
+	vec3 b = (skyFar * eyenorm - geosphereCenter) / geosphereRadius;
 	ldprod = AtmosLengthDensityProduct(a, b, atmosColor.a * geosphereAtmosFogDensity, atmosDist, geosphereAtmosInvScaleHeight);
 	
 	float fogFactor = 1.0 / exp(ldprod);

--- a/data/shaders/opengl/geosphere_terrain.frag
+++ b/data/shaders/opengl/geosphere_terrain.frag
@@ -4,8 +4,7 @@
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made
-uniform float geosphereScale;
-uniform float geosphereScaledRadius;
+uniform float geosphereRadius;
 uniform float geosphereAtmosTopRad;
 uniform vec3 geosphereCenter;
 uniform float geosphereAtmosFogDensity;
@@ -79,7 +78,7 @@ void main(void)
 #endif
 
 #if (NUM_LIGHTS > 0)
-	vec3 v = (eyepos - geosphereCenter)/geosphereScaledRadius;
+	vec3 v = (eyepos - geosphereCenter)/geosphereRadius;
 	float lenInvSq = 1.0/(dot(v,v));
 	for (int i=0; i<NUM_LIGHTS; ++i) {
 		vec3 lightDir = normalize(vec3(uLight[i].position));
@@ -119,15 +118,15 @@ void main(void)
 
 #ifdef ATMOSPHERE
 	// when does the eye ray intersect atmosphere
-	float atmosStart = findSphereEyeRayEntryDistance(geosphereCenter, eyepos, geosphereScaledRadius * geosphereAtmosTopRad);
+	float atmosStart = findSphereEyeRayEntryDistance(geosphereCenter, eyepos, geosphereRadius * geosphereAtmosTopRad);
 	float ldprod=0.0;
 	float fogFactor=0.0;
 	{
-		float atmosDist = geosphereScale * (length(eyepos) - atmosStart);
+		float atmosDist = (length(eyepos) - atmosStart);
 		
 		// a&b scaled so length of 1.0 means planet surface.
-		vec3 a = (atmosStart * eyenorm - geosphereCenter) / geosphereScaledRadius;
-		vec3 b = (eyepos - geosphereCenter) / geosphereScaledRadius;
+		vec3 a = (atmosStart * eyenorm - geosphereCenter) / geosphereRadius;
+		vec3 b = (eyepos - geosphereCenter) / geosphereRadius;
 		ldprod = AtmosLengthDensityProduct(a, b, atmosColor.w*geosphereAtmosFogDensity, atmosDist, geosphereAtmosInvScaleHeight);
 		fogFactor = clamp( 1.5 / exp(ldprod),0.0,1.0); 
 	}

--- a/data/shaders/opengl/geosphere_terrain.vert
+++ b/data/shaders/opengl/geosphere_terrain.vert
@@ -6,7 +6,7 @@ out vec3 varyingNormal;
 out vec4 vertexColor;
 
 uniform vec3 geosphereCenter;
-uniform float geosphereScaledRadius;
+uniform float geosphereRadius;
 
 #ifdef TERRAIN_WITH_LAVA
 out vec4 varyingEmission;

--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -26,7 +26,7 @@ public:
 	virtual ~BaseSphere();
 
 	virtual void Update()=0;
-	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const float scale, const std::vector<Camera::Shadow> &shadows)=0;
+	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows)=0;
 
 	virtual double GetHeight(const vector3d &p) const { return 0.0; }
 

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -547,7 +547,7 @@ void GasGiant::Update()
 	}
 }
 
-void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const float scale, const std::vector<Camera::Shadow> &shadows)
+void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows)
 {
 	if( !m_surfaceTexture.Valid() )
 	{
@@ -584,7 +584,6 @@ void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView,
 		m_materialParameters.atmosphere = GetSystemBody()->CalcAtmosphereParams();
 		m_materialParameters.atmosphere.center = trans * vector3d(0.0, 0.0, 0.0);
 		m_materialParameters.atmosphere.planetRadius = radius;
-		m_materialParameters.atmosphere.scale = scale;
 
 		m_materialParameters.shadows = shadows;
 

--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -32,7 +32,7 @@ public:
 	virtual ~GasGiant();
 
 	virtual void Update();
-	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const float scale, const std::vector<Camera::Shadow> &shadows);
+	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows);
 
 	virtual double GetHeight(const vector3d &p) const { return 0.0; }
 

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -387,7 +387,7 @@ void GeoSphere::ProcessQuadSplitRequests()
 	mQuadSplitRequests.clear();
 }
 
-void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const float scale, const std::vector<Camera::Shadow> &shadows)
+void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows)
 {
 	// store this for later usage in the update method.
 	m_tempCampos = campos;
@@ -418,7 +418,6 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 		m_materialParameters.atmosphere = GetSystemBody()->CalcAtmosphereParams();
 		m_materialParameters.atmosphere.center = trans * vector3d(0.0, 0.0, 0.0);
 		m_materialParameters.atmosphere.planetRadius = radius;
-		m_materialParameters.atmosphere.scale = scale;
 
 		m_materialParameters.shadows = shadows;
 

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -34,7 +34,7 @@ public:
 	virtual ~GeoSphere();
 
 	virtual void Update();
-	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const float scale, const std::vector<Camera::Shadow> &shadows);
+	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows);
 
 	virtual double GetHeight(const vector3d &p) const {
 		const double h = m_terrain->GetHeight(p);

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -78,26 +78,6 @@ void TerrainBody::Render(Graphics::Renderer *renderer, const Camera *camera, con
 	float znear, zfar;
 	renderer->GetNearFarRange(znear, zfar);
 
-	double len = fpos.Length();
-	//objects very far away are downscaled, because they cannot be
-	//accurately drawn using actual distances
-	int shrink = 0;
-	double scale = 1.0f;
-
-	double dist_to_horizon;
-	for (;;) {
-		if (len < rad) break;		// player inside radius case
-		dist_to_horizon = sqrt(len*len - rad*rad);
-
-		if (dist_to_horizon < zfar*0.5) break;
-
-		rad *= 0.25;
-		fpos = 0.25*fpos;
-		len *= 0.25;
-		scale *= 4.0f;
-		++shrink;
-	}
-
 	vector3d campos = fpos;
 	ftran.ClearToRotOnly();
 	campos = ftran.Inverse() * campos;
@@ -115,15 +95,10 @@ void TerrainBody::Render(Graphics::Renderer *renderer, const Camera *camera, con
 	ftran.Scale(rad, rad, rad);
 
 	// translation not applied until patch render to fix jitter
-	m_baseSphere->Render(renderer, ftran, -campos, m_sbody->GetRadius(), scale, shadows);
+	m_baseSphere->Render(renderer, ftran, -campos, m_sbody->GetRadius(), shadows);
 
 	ftran.Translate(campos.x, campos.y, campos.z);
 	SubRender(renderer, ftran, campos);
-
-	//clear depth buffer, shrunk objects should not interact
-	//with foreground
-	if (shrink)
-		renderer->ClearDepthBuffer();
 }
 
 void TerrainBody::SetFrame(Frame *f)

--- a/src/galaxy/StarSystem.h
+++ b/src/galaxy/StarSystem.h
@@ -214,7 +214,6 @@ public:
 		float planetRadius;
 		Color atmosCol;
 		vector3d center;
-		float scale;
 	};
 
 	AtmosphereParameters CalcAtmosphereParams() const;

--- a/src/graphics/opengl/GasGiantMaterial.cpp
+++ b/src/graphics/opengl/GasGiantMaterial.cpp
@@ -29,8 +29,7 @@ void GasGiantProgram::InitUniforms()
 	geosphereAtmosInvScaleHeight.Init("geosphereAtmosInvScaleHeight", m_program);
 	geosphereAtmosTopRad.Init("geosphereAtmosTopRad", m_program);
 	geosphereCenter.Init("geosphereCenter", m_program);
-	geosphereScale.Init("geosphereScale", m_program);
-	geosphereScaledRadius.Init("geosphereScaledRadius", m_program);
+	geosphereRadius.Init("geosphereRadius", m_program);
 
 	shadows.Init("shadows", m_program);
 	occultedLight.Init("occultedLight", m_program);
@@ -82,8 +81,7 @@ void GasGiantSurfaceMaterial::SetGSUniforms()
 	p->geosphereAtmosInvScaleHeight.Set(ap.atmosInvScaleHeight);
 	p->geosphereAtmosTopRad.Set(ap.atmosRadius);
 	p->geosphereCenter.Set(ap.center);
-	p->geosphereScaledRadius.Set(ap.planetRadius / ap.scale);
-	p->geosphereScale.Set(ap.scale);
+	p->geosphereRadius.Set(ap.planetRadius);
 
 	//Light uniform parameters
 	for( Uint32 i=0 ; i<m_renderer->GetNumLights() ; i++ ) {

--- a/src/graphics/opengl/GasGiantMaterial.h
+++ b/src/graphics/opengl/GasGiantMaterial.h
@@ -22,8 +22,7 @@ namespace Graphics {
 			Uniform geosphereAtmosInvScaleHeight;
 			Uniform geosphereAtmosTopRad; // in planet radii
 			Uniform geosphereCenter;
-			Uniform geosphereScale;
-			Uniform geosphereScaledRadius; // (planet radius) / scale
+			Uniform geosphereRadius; // planet radius
 
 			Uniform shadows;
 			Uniform occultedLight;

--- a/src/graphics/opengl/GeoSphereMaterial.cpp
+++ b/src/graphics/opengl/GeoSphereMaterial.cpp
@@ -28,8 +28,7 @@ void GeoSphereProgram::InitUniforms()
 	geosphereAtmosInvScaleHeight.Init("geosphereAtmosInvScaleHeight", m_program);
 	geosphereAtmosTopRad.Init("geosphereAtmosTopRad", m_program);
 	geosphereCenter.Init("geosphereCenter", m_program);
-	geosphereScale.Init("geosphereScale", m_program);
-	geosphereScaledRadius.Init("geosphereScaledRadius", m_program);
+	geosphereRadius.Init("geosphereRadius", m_program);
 
 	shadows.Init("shadows", m_program);
 	occultedLight.Init("occultedLight", m_program);
@@ -84,8 +83,7 @@ void GeoSphereSurfaceMaterial::SetGSUniforms()
 	p->geosphereAtmosInvScaleHeight.Set(ap.atmosInvScaleHeight);
 	p->geosphereAtmosTopRad.Set(ap.atmosRadius);
 	p->geosphereCenter.Set(ap.center);
-	p->geosphereScaledRadius.Set(ap.planetRadius / ap.scale);
-	p->geosphereScale.Set(ap.scale);
+	p->geosphereRadius.Set(ap.planetRadius);
 
 	//Light uniform parameters
 	for( Uint32 i=0 ; i<m_renderer->GetNumLights() ; i++ ) {

--- a/src/graphics/opengl/GeoSphereMaterial.h
+++ b/src/graphics/opengl/GeoSphereMaterial.h
@@ -22,8 +22,7 @@ namespace Graphics {
 			Uniform geosphereAtmosInvScaleHeight;
 			Uniform geosphereAtmosTopRad; // in planet radii
 			Uniform geosphereCenter;
-			Uniform geosphereScale;
-			Uniform geosphereScaledRadius; // (planet radius) / scale
+			Uniform geosphereRadius; // (planet radius)
 
 			Uniform shadows;
 			Uniform occultedLight;


### PR DESCRIPTION
Eliminate the scaling of planets since we're using a logarithmic z-buffer for rendering.

This is so that we can batch up the drawing of objects in the scene according to their type (eg: opaque/transparent) sort them so that they render correctly and avoid needless state changes.

Presently this isn't possible because the depth buffer is cleared whenever a shrunken planet is rendered.

This also simplifies the shaders a little which should make them easier to understand :)