### PR TITLE
Fix undefined symbols for static const members

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -204,6 +204,9 @@ void Starfield::Init()
 	m_material->emissive = Color::WHITE;
 }
 
+const int Starfield::BG_STAR_MAX;
+const int Starfield::BG_STAR_MIN;
+
 void Starfield::Fill(Random &rand)
 {
 	const Sint32 NUM_BG_STARS = Clamp(Sint32(Pi::GetAmountBackgroundStars() * BG_STAR_MAX), BG_STAR_MIN, BG_STAR_MAX);


### PR DESCRIPTION
The latest version, 20150904, fails to build with clang compiler on OS X platform:

```
Undefined symbols for architecture x86_64:
  "Background::Starfield::BG_STAR_MAX", referenced from:
      Background::Starfield::Fill(Random&) in Background.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The culprit was `BG_STAR_MAX` (and probably `BG_STARMIN` too) were declared `static const` member of the class in the header, but not defined in the source as [stackoverflow](http://stackoverflow.com/questions/4891067/weird-undefined-symbols-of-static-constants-inside-a-struct-class) may describe.

I have no clear idea why it worked with no problem in the previous version, given that the variables have existed for a quite while, it might be due to the recent removal of non-const access to them. I'm also totally unfamiliar with how `pioneer` coding conventions should work here, but at least it fixed build failure on my local machine with Homebrew formula, so please have a look.