### PR TITLE
Fix compilation issue due to BG_STARS_MAX/MIN

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -204,9 +204,6 @@ void Starfield::Init()
 	m_material->emissive = Color::WHITE;
 }
 
-const int Starfield::BG_STAR_MAX;
-const int Starfield::BG_STAR_MIN;
-
 void Starfield::Fill(Random &rand)
 {
 	const Sint32 NUM_BG_STARS = Clamp(Sint32(Pi::GetAmountBackgroundStars() * BG_STAR_MAX), BG_STAR_MIN, BG_STAR_MAX);

--- a/src/Background.h
+++ b/src/Background.h
@@ -60,8 +60,8 @@ namespace Background
 
 	private:
 		void Init();
-		static const int BG_STAR_MAX = 100000;
-		static const int BG_STAR_MIN = 1000;
+		#define BG_STAR_MAX 100000
+		#define BG_STAR_MIN 1000
 		std::unique_ptr<Graphics::VertexBuffer> m_vertexBuffer;
 
 		//hyperspace animation vertex data


### PR DESCRIPTION
Fed up with static const compile problem, make C-style defines since Linux/OSX/VS2013 all seem to have differing issues with them. Just switch to using define's that always work everywhere! (for this usage).

Should fix #3454, if you could test this branch @joonicks that'd be very helpful as I cannot repeat the problem you are having compiling using VS2013.

Andy