### PR TITLE
Orbit fading

### DIFF
--- a/src/Orbit.cpp
+++ b/src/Orbit.cpp
@@ -202,10 +202,10 @@ vector3d Orbit::OrbitalVelocityAtTime(double totalMass, double t) const
 // used for stepping through the orbit in small fractions
 // mean anomaly <-> true anomaly conversion doesn't have
 // to be taken into account
-vector3d Orbit::EvenSpacedPosTrajectory(double t) const
+vector3d Orbit::EvenSpacedPosTrajectory(double t, double timeOffset) const
 {
 	const double e = m_eccentricity;
-	double v = 2*M_PI*t + TrueAnomalyFromMeanAnomaly(m_orbitalPhaseAtStart);
+	double v = 2*M_PI*t + TrueAnomalyFromMeanAnomaly(MeanAnomalyAtTime(timeOffset));
 	double r;
 
 	if (e < 1.0) {

--- a/src/Orbit.h
+++ b/src/Orbit.h
@@ -40,7 +40,7 @@ public:
 	vector3d OrbitalVelocityAtTime(double totalMass, double t) const;
 
 	// 0.0 <= t <= 1.0. Not for finding orbital pos
-	vector3d EvenSpacedPosTrajectory(double t) const;
+	vector3d EvenSpacedPosTrajectory(double t, double timeOffset = 0) const;
 
 	double Period() const;
 	vector3d Apogeum() const;


### PR DESCRIPTION
Orbit fading have been designed to show the direction of the orbit. This should help the user to better understand the layout of a system without using the time controls.

![schermata da 2015-09-20 14-06-14](https://cloud.githubusercontent.com/assets/350168/9980659/551caeac-5fa1-11e5-82a4-9097dec2ee39.png)

Here a simple screenshot. For now, I hardcoded when the fading starts, but it could be put inside the options. Now... we have got a problem:
![schermata da 2015-09-20 14-06-46](https://cloud.githubusercontent.com/assets/350168/9980668/7c39a864-5fa1-11e5-85ed-0f62b3b94b44.png)

As you can see, when two orbits overlap, things start going crazy. Ideas? Probably, the best one is the check for the same orbits before calling `SystemView::PutOrbit`, but, for now, `Orbit` instances of two bodies that occupy the same orbit but not the same space **are** different.

I was working in my spare time on a completely different system to handle orbits, using the *patched conic approximation* model, but it is taking much more time that I expected, and I have been quite busy in the last month. Honestly, I do not know how much hard it could be to perform the check I was talking before, and if things are going to change, I do not know if it is worth doing.

Opinions? Ideas?
