### PR TITLE
Systeminfoview target box

### DIFF
--- a/data/modules/FuelClub/FuelClub.lua
+++ b/data/modules/FuelClub/FuelClub.lua
@@ -183,7 +183,7 @@ onChat = function (form, ref, option)
 			"\n\t* "..string.interp(l.LIST_BENEFITS_FUEL, {fuel=Equipment.cargo.military_fuel:GetName()})..
 			"\n\t* "..string.interp(l.LIST_BENEFITS_DISPOSAL, {radioactives=Equipment.cargo.radioactives:GetName()})..
 			"\n\t* "..l.LIST_BENEFITS_FUEL_TANK..
-			"\n\n"  ..string.interp(l.LIST_BENEFITS_JOIN, {membership_fee=Format.Money(ad.flavour.annual_fee)})
+			"\n\n"  ..string.interp(l.LIST_BENEFITS_JOIN, {membership_fee=Format.Money(ad.flavour.annual_fee,false)})
 
 		form:SetMessage(message)
 		form:AddOption(l.WHAT_CONDITIONS_APPLY:interp({radioactives = Equipment.cargo.radioactives:GetName()}),1)

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -470,16 +470,8 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 
 	// Gui::Init shouldn't initialise any VBOs, since we haven't tested
 	// that the capability exists. (Gui does not use VBOs so far)
-	int xsize = Graphics::GetScreenWidth();
-	int ysize = Graphics::GetScreenHeight();
-	Gui::Init(renderer, xsize, ysize, 800, 600);
+	Gui::Init(renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), 800, 600);
 
-	int xorigin = 0;
-	if (xsize > 700)
-	{
-		xorigin = (xsize - 700) / 2;
-		xsize = (xsize - (xorigin * 2));
-	}
 	UI::Box *box = Pi::ui->VBox(5);
 	UI::Label *label = Pi::ui->Label("");
 	UI::Gauge *gauge = Pi::ui->Gauge();
@@ -487,16 +479,20 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 	label->SetFont(UI::Widget::FONT_HEADING_NORMAL);
 	
 	Pi::ui->GetTopLayer()->SetInnerWidget(
-		Pi::ui->Margin(10, UI::Margin::HORIZONTAL)->SetInnerWidget(
-			Pi::ui->Expand()->SetInnerWidget(
-				Pi::ui->Align(UI::Align::MIDDLE)->SetInnerWidget(
-					box->PackEnd(UI::WidgetSet(
-					Pi::ui->Align(UI::Align::MIDDLE)->SetInnerWidget(label), gauge))
+		// expand the box to cover the whole screen
+		Pi::ui->Expand()->SetInnerWidget(
+			// align the box with label+gauge to the middle of the screen (horizontally AND vertically)
+			Pi::ui->Align(UI::Align::MIDDLE)->SetInnerWidget(
+				// put label and gauge into one combined box
+				box->PackEnd(UI::WidgetSet(
+					// center the label in the inner box
+					Pi::ui->Align(UI::Align::MIDDLE)->SetInnerWidget(label),
+					// limit the gauge by adding a margin on both sides of (0.1666*screensize) effectively centering it on the screen
+					Pi::ui->Margin(0.1666*Graphics::GetScreenWidth(), UI::Margin::HORIZONTAL)->SetInnerWidget(gauge)
+					)
 				)
 			)
-		),
-		UI::Point(xorigin, 0),
-		UI::Point(xsize, ysize)
+		)
 	);
 	
 	draw_progress(gauge, label, 0.0f);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -470,25 +470,35 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 
 	// Gui::Init shouldn't initialise any VBOs, since we haven't tested
 	// that the capability exists. (Gui does not use VBOs so far)
-	Gui::Init(renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), 800, 600);
+	int xsize = Graphics::GetScreenWidth();
+	int ysize = Graphics::GetScreenHeight();
+	Gui::Init(renderer, xsize, ysize, 800, 600);
 
+	int xorigin = 0;
+	if (xsize > 700)
+	{
+		xorigin = (xsize - 700) / 2;
+		xsize = (xsize - (xorigin * 2));
+	}
 	UI::Box *box = Pi::ui->VBox(5);
 	UI::Label *label = Pi::ui->Label("");
-	label->SetFont(UI::Widget::FONT_HEADING_NORMAL);
 	UI::Gauge *gauge = Pi::ui->Gauge();
+
+	label->SetFont(UI::Widget::FONT_HEADING_NORMAL);
+	
 	Pi::ui->GetTopLayer()->SetInnerWidget(
 		Pi::ui->Margin(10, UI::Margin::HORIZONTAL)->SetInnerWidget(
 			Pi::ui->Expand()->SetInnerWidget(
 				Pi::ui->Align(UI::Align::MIDDLE)->SetInnerWidget(
 					box->PackEnd(UI::WidgetSet(
-						label,
-						gauge
-					))
+					Pi::ui->Align(UI::Align::MIDDLE)->SetInnerWidget(label), gauge))
 				)
 			)
-		)
-    );
-
+		),
+		UI::Point(xorigin, 0),
+		UI::Point(xsize, ysize)
+	);
+	
 	draw_progress(gauge, label, 0.0f);
 
 	Output("GalaxyGenerator::Init()\n");

--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -19,6 +19,10 @@
 #include "Factions.h"
 #include <functional>
 
+#define CANSELECT_ANY		2
+#define CANSELECT_STARS		3
+#define CANSELECT_NOTHING	4
+
 SystemInfoView::SystemInfoView(Game* game) : UIView(), m_game(game)
 {
 	SetTransparency(true);
@@ -279,12 +283,13 @@ void SystemInfoView::UpdateEconomyTab()
 	m_econInfoTab->ResizeRequest();
 }
 
-void SystemInfoView::PutBodies(SystemBody *body, Gui::Fixed *container, int dir, float pos[2], int &majorBodies, int &starports, int &onSurface, float &prevSize)
+void SystemInfoView::PutBodies(SystemBody *body, Gui::Fixed *container, int dir, float pos[2], int canSelect, int &majorBodies, int &starports, int &onSurface, float &prevSize)
 {
 	float size[2];
 	float myPos[2];
 	myPos[0] = pos[0];
 	myPos[1] = pos[1];
+
 	if (body->GetSuperType() == SystemBody::SUPERTYPE_STARPORT) starports++;
 	if (body->GetType() == SystemBody::TYPE_STARPORT_SURFACE) {
 		onSurface++;
@@ -292,6 +297,13 @@ void SystemInfoView::PutBodies(SystemBody *body, Gui::Fixed *container, int dir,
 	}
 	if (body->GetType() != SystemBody::TYPE_GRAVPOINT) {
 		BodyIcon *ib = new BodyIcon(body->GetIcon(), m_renderer);
+		// only show target box in current system and in remote systems with alternative jump targets
+		// dont confuse canSelect (function parameter) with ib->canSelect (object property)
+		if (canSelect == CANSELECT_ANY || (canSelect == CANSELECT_STARS && body->GetSuperType() == SystemBody::SUPERTYPE_STAR))
+			ib->canSelect = true;
+		else
+			ib->canSelect = false;
+		//
 		if (body->GetSuperType() == SystemBody::SUPERTYPE_ROCKY_PLANET) {
 			for (const SystemBody* kid : body->GetChildren()) {
 				if (kid->GetType() == SystemBody::TYPE_STARPORT_SURFACE) {
@@ -322,7 +334,7 @@ void SystemInfoView::PutBodies(SystemBody *body, Gui::Fixed *container, int dir,
 
 	float prevSizeForKids = size[!dir];
 	for (SystemBody* kid : body->GetChildren()) {
-		PutBodies(kid, container, dir, myPos, majorBodies, starports, onSurface, prevSizeForKids);
+		PutBodies(kid, container, dir, myPos, canSelect, majorBodies, starports, onSurface, prevSizeForKids);
 	}
 }
 
@@ -373,22 +385,41 @@ void SystemInfoView::SystemChanged(const SystemPath &path)
 
 	m_sbodyInfoTab->onMouseButtonEvent.connect(sigc::mem_fun(this, &SystemInfoView::OnClickBackground));
 
+	int canSelect = CANSELECT_ANY;
+	
+	RefCountedPtr<StarSystem> currentSys = m_game->GetSpace()->GetStarSystem();
+	if (currentSys && currentSys->GetPath() != m_system->GetPath())
+	{
+		int hyperPoints = 0;
+		SystemBody* rootbody = m_system->GetRootBody().Get();
+		if (rootbody->GetSuperType() == SystemBody::SUPERTYPE_STAR)
+			hyperPoints++;
+		for (SystemBody* kid : rootbody->GetChildren()) {
+			if (kid->GetSuperType() == SystemBody::SUPERTYPE_STAR)
+				hyperPoints++;
+		}
+		if (hyperPoints > 1)
+			canSelect = CANSELECT_STARS;
+		else
+			canSelect = CANSELECT_NOTHING;
+	}
+
 	int majorBodies, starports, onSurface;
 	{
 		float pos[2] = { 0, 0 };
 		float psize = -1;
 		majorBodies = starports = onSurface = 0;
-		PutBodies(m_system->GetRootBody().Get(), m_econInfoTab, 1, pos, majorBodies, starports, onSurface, psize);
+		PutBodies(m_system->GetRootBody().Get(), m_econInfoTab, 1, pos, CANSELECT_NOTHING, majorBodies, starports, onSurface, psize);
 
 		majorBodies = starports = onSurface = 0;
 		pos[0] = pos[1] = 0;
 		psize = -1;
-		PutBodies(m_system->GetRootBody().Get(), m_sbodyInfoTab, 1, pos, majorBodies, starports, onSurface, psize);
+		PutBodies(m_system->GetRootBody().Get(), m_sbodyInfoTab, 1, pos, canSelect, majorBodies, starports, onSurface, psize);
 
 		majorBodies = starports = onSurface = 0;
 		pos[0] = pos[1] = 0;
 		psize = -1;
-		PutBodies(m_system->GetRootBody().Get(), demographicsTab, 1, pos, majorBodies, starports, onSurface, psize);
+		PutBodies(m_system->GetRootBody().Get(), demographicsTab, 1, pos, CANSELECT_NOTHING, majorBodies, starports, onSurface, psize);
 	}
 
 	std::string _info = stringf(
@@ -665,7 +696,7 @@ void SystemInfoView::BodyIcon::Draw()
 			portColor, m_renderState);
 	    circle.Draw(m_renderer);
 	}
-	if (GetSelected()) {
+	if (canSelect && GetSelected()) {
 		m_selectBox.Draw(m_renderer, m_renderState, Graphics::LINE_LOOP);
 	}
 }

--- a/src/SystemInfoView.h
+++ b/src/SystemInfoView.h
@@ -31,6 +31,7 @@ private:
 		bool HasStarport() { return m_hasStarport; }
 		void SetHasStarport() { m_hasStarport = true; }
 		void SetSelectColor(const Color& color) { m_selectColor = color; }
+		bool canSelect;
 	private:
 		Graphics::Renderer *m_renderer;
 		Graphics::RenderState *m_renderState;
@@ -51,7 +52,7 @@ private:
 	void OnBodyViewed(SystemBody *b);
 	void OnBodySelected(SystemBody *b);
 	void OnClickBackground(Gui::MouseButtonEvent *e);
-	void PutBodies(SystemBody *body, Gui::Fixed *container, int dir, float pos[2], int &majorBodies, int &starports, int &onSurface, float &prevSize);
+	void PutBodies(SystemBody *body, Gui::Fixed *container, int dir, float pos[2], int canSelect, int &majorBodies, int &starports, int &onSurface, float &prevSize);
 	void UpdateIconSelections();
 
 	Game* m_game;


### PR DESCRIPTION
Only show target box for
a) current system targets
b) remote hyperspace targets if more than one

Does not show anymore target around a remote systems single star.