### PR TITLE
Fade orbits faster and darker

### DIFF
--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -22,6 +22,7 @@
 using namespace Graphics;
 
 const double SystemView::PICK_OBJECT_RECT_SIZE = 12.0;
+const Uint16 SystemView::N_VERTICES_MAX = 100;
 static const float MIN_ZOOM = 1e-30f;		// Just to avoid having 0
 static const float MAX_ZOOM = 1e30f;
 static const float ZOOM_IN_SPEED = 2;
@@ -385,6 +386,9 @@ SystemView::SystemView(Game* game) : UIView(), m_game(game)
 	RefreshShips();
 	m_shipDrawing = OFF;
 	m_planner = Pi::planner;
+
+	m_orbitVts.reset( new vector3f[N_VERTICES_MAX] );
+	m_orbitColors.reset( new Color[N_VERTICES_MAX] );
 }
 
 SystemView::~SystemView()
@@ -429,12 +433,10 @@ void SystemView::ResetViewpoint()
 
 void SystemView::PutOrbit(const Orbit *orbit, const vector3d &offset, const Color &color, double planetRadius)
 {
-	static const unsigned short n_vertices_max = 100;
-
 	double maxT = 1.;
 	unsigned short num_vertices = 0;
-	for (unsigned short i = 0; i < n_vertices_max; ++i) {
-		const double t = double(i) / double(n_vertices_max);
+	for (unsigned short i = 0; i < N_VERTICES_MAX; ++i) {
+		const double t = double(i) / double(N_VERTICES_MAX);
 		const vector3d pos = orbit->EvenSpacedPosTrajectory(t);
 		if (pos.Length() < planetRadius)
 		{
@@ -446,33 +448,31 @@ void SystemView::PutOrbit(const Orbit *orbit, const vector3d &offset, const Colo
 	static const float startTrailPercent = 0.75;
 	static const float fadedColorParameter = 0.4;
 
-	vector3f vts[n_vertices_max];
 	Uint16 fadingColors = 0;
 	double t0 = m_game->GetTime();
-	for (unsigned short i = 0; i < n_vertices_max; ++i) {
-		const double t = double(i) / double(n_vertices_max) * maxT;
+	for (unsigned short i = 0; i < N_VERTICES_MAX; ++i) {
+		const double t = double(i) / double(N_VERTICES_MAX) * maxT;
 		if(fadingColors == 0 && t >= startTrailPercent * maxT)
 			fadingColors = i;
 		const vector3d pos = orbit->EvenSpacedPosTrajectory(t, m_time - t0);
-		vts[i] = vector3f(offset + pos * double(m_zoom));
+		m_orbitVts[i] = vector3f(offset + pos * double(m_zoom));
 		++num_vertices;
 		if (pos.Length() < planetRadius)
 			break;
 	}
 
-	std::unique_ptr<Color[]> colors(new Color[num_vertices]);
 	Color fadedColor = color * fadedColorParameter;
-	std::fill_n(colors.get(), num_vertices, fadedColor);
+	std::fill_n(m_orbitColors.get(), num_vertices, fadedColor);
 	Uint16 trailLength = num_vertices - fadingColors;
 
 	for (Uint16 currentColor = 0; currentColor < trailLength; ++currentColor)	
 	{
 		float scalingParameter = fadedColorParameter + static_cast<float>(currentColor) / trailLength * (1.f - fadedColorParameter);
-		colors[currentColor + fadingColors] = color * scalingParameter;
+		m_orbitColors[currentColor + fadingColors] = color * scalingParameter;
 	}
 
 	if (num_vertices > 1) {
-		m_orbits.SetData(num_vertices, vts, colors.get());
+		m_orbits.SetData(num_vertices, m_orbitVts.get(), m_orbitColors.get());
 
 		// don't close the loop for hyperbolas and parabolas and crashed ellipses
 		if (maxT < 1. || (orbit->GetEccentricity() > 1.0)) {
@@ -481,7 +481,6 @@ void SystemView::PutOrbit(const Orbit *orbit, const vector3d &offset, const Colo
 			m_orbits.Draw(m_renderer, m_lineState, LINE_LOOP);
 		}
 	}
-	colors.reset();
 
 	Gui::Screen::EnterOrtho();
 	vector3d pos;

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -445,8 +445,8 @@ void SystemView::PutOrbit(const Orbit *orbit, const vector3d &offset, const Colo
 		}
 	}
 
-	static const float startTrailPercent = 0.75;
-	static const float fadedColorParameter = 0.4;
+	static const float startTrailPercent = 0.85;
+	static const float fadedColorParameter = 0.05;
 
 	Uint16 fadingColors = 0;
 	double t0 = m_game->GetTime();
@@ -463,7 +463,7 @@ void SystemView::PutOrbit(const Orbit *orbit, const vector3d &offset, const Colo
 
 	Color fadedColor = color * fadedColorParameter;
 	std::fill_n(m_orbitColors.get(), num_vertices, fadedColor);
-	Uint16 trailLength = num_vertices - fadingColors;
+	const Uint16 trailLength = num_vertices - fadingColors;
 
 	for (Uint16 currentColor = 0; currentColor < trailLength; ++currentColor)	
 	{

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -63,6 +63,7 @@ public:
 	virtual void Draw3D();
 private:
 	static const double PICK_OBJECT_RECT_SIZE;
+	static const Uint16 N_VERTICES_MAX;
 	void PutOrbit(const Orbit *orb, const vector3d &offset, const Color &color, double planetRadius = 0.0);
 	void PutBody(const SystemBody *b, const vector3d &offset, const matrix4x4f &trans);
 	void PutLabel(const SystemBody *b, const vector3d &offset);
@@ -120,6 +121,9 @@ private:
 	Graphics::RenderState *m_lineState;
 	Graphics::Drawables::Lines m_orbits;
 	Graphics::Drawables::Lines m_selectBox;
+
+	std::unique_ptr<vector3f[]> m_orbitVts;
+	std::unique_ptr<Color[]> m_orbitColors;
 };
 
 #endif /* _SYSTEMVIEW_H */


### PR DESCRIPTION
This is really 3 changes. 2 minor and one a little bigger.

The bigger change is avoiding the allocation and deletion of the former 'colors' buffer per-orbit / per-frame.
This is now a member variable that is initialised to the maximum number of vertices during construction. I also replaced the 'vts' array with a similar arrangement. The buffer is allocated once, fixed in size, and the code just uses as much of it as it needs.

The other 2 changes are that I've shortened the distance before the orbit fades out from 25% of the orbit to 15% and then I've made it fade to a much darker colour.

Personally I think that this looks much nicer and shows the direction thanks to the fading much better.