### PR TITLE
Expose ship::Blastoff() to Lua API

### DIFF
--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -416,6 +416,31 @@ static int l_ship_undock(lua_State *l)
 	return 1;
 }
 
+/*
+ * Method: Blastoff
+ *
+ * Blast off, in normal direction to the ground, and retract landingear
+ *
+ * > ship:Blastoff()
+ *
+ * Availability:
+ *
+ *  20151005
+ *
+ * Status:
+ *
+ *  experimental
+ */
+static int l_ship_blastoff(lua_State *l)
+{
+	Ship *s = LuaObject<Ship>::CheckFromLua(1);
+	if (s->GetFlightState() != Ship::LANDED)
+		luaL_error(l, "Can't blastoff if not landed");
+	s->Blastoff();
+	s->SetWheelState(false);
+	return 1;
+}
+
 /* Method: SpawnMissile
  *
  * Spawn a missile near the ship.
@@ -943,6 +968,7 @@ template <> void LuaObject<Ship>::RegisterClass()
 
 		{ "GetDockedWith", l_ship_get_docked_with },
 		{ "Undock",        l_ship_undock          },
+		{ "Blastoff",      l_ship_blastoff        },
 
 		{ "Explode", l_ship_explode },
 


### PR DESCRIPTION
@clausimu requested this on the [forum](http://pioneerspacesim.net/forum/viewtopic.php?f=3&t=363), since he's placing ships with

    ship = Space.SpawnShipLanded(shipdef.id, Space.GetBody(planet_systembody.index), ad.lat, ad.long)

But we have no method to make them move (!), since hyperjump will not work in
landed state, and `AIFlyTo()` doesn't work (maybe we should look into that instead/also?)

This method:
- [x] Blasts off ship in normal direction
- [x] Retract landing wheels
- [ ] Set speed to 0 relative planet
- [x] Ponder on expected behaviour of `AIFlyTo`