### PR TITLE
GLSL preprocessor includes

### DIFF
--- a/data/shaders/opengl/FresnelColour.frag
+++ b/data/shaders/opengl/FresnelColour.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 in vec3 varyingEyepos;
 in vec3 varyingNormal;
 

--- a/data/shaders/opengl/FresnelColour.vert
+++ b/data/shaders/opengl/FresnelColour.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec3 varyingEyepos;
 out vec3 varyingNormal;
 

--- a/data/shaders/opengl/billboard_sphereimpostor.frag
+++ b/data/shaders/opengl/billboard_sphereimpostor.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 in vec4 color;
 in vec2 uv;
 in vec3 lightDir;

--- a/data/shaders/opengl/billboard_sphereimpostor.vert
+++ b/data/shaders/opengl/billboard_sphereimpostor.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec4 color;
 out vec2 uv;
 out vec3 lightDir;

--- a/data/shaders/opengl/gassphere_base.frag
+++ b/data/shaders/opengl/gassphere_base.frag
@@ -1,3 +1,10 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made

--- a/data/shaders/opengl/gassphere_base.vert
+++ b/data/shaders/opengl/gassphere_base.vert
@@ -1,3 +1,10 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec3 varyingEyepos;
 out vec3 varyingNormal;
 out vec3 varyingTexCoord0;

--- a/data/shaders/opengl/geosphere_sky.frag
+++ b/data/shaders/opengl/geosphere_sky.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made

--- a/data/shaders/opengl/geosphere_sky.vert
+++ b/data/shaders/opengl/geosphere_sky.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec4 varyingEyepos;
 
 void main(void)

--- a/data/shaders/opengl/geosphere_terrain.frag
+++ b/data/shaders/opengl/geosphere_terrain.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made

--- a/data/shaders/opengl/geosphere_terrain.vert
+++ b/data/shaders/opengl/geosphere_terrain.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec3 varyingEyepos;
 out vec3 varyingNormal;
 out vec4 vertexColor;

--- a/data/shaders/opengl/multi.frag
+++ b/data/shaders/opengl/multi.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 #ifdef TEXTURE0
 uniform sampler2D texture0; //diffuse
 uniform sampler2D texture1; //specular

--- a/data/shaders/opengl/multi.vert
+++ b/data/shaders/opengl/multi.vert
@@ -3,6 +3,10 @@
 
 // #extension GL_ARB_gpu_shader5 : enable
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 #ifdef TEXTURE0
 out vec2 texCoord0;
 #endif

--- a/data/shaders/opengl/planetrings.frag
+++ b/data/shaders/opengl/planetrings.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 uniform sampler2D texture0;
 in vec2 texCoord0;
 in vec4 texCoord1;

--- a/data/shaders/opengl/planetrings.vert
+++ b/data/shaders/opengl/planetrings.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec2 texCoord0;
 out vec4 texCoord1;
 

--- a/data/shaders/opengl/shield.frag
+++ b/data/shaders/opengl/shield.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 in vec3 varyingEyepos;
 in vec3 varyingNormal;
 in vec3 varyingVertex;

--- a/data/shaders/opengl/shield.vert
+++ b/data/shaders/opengl/shield.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec3 varyingEyepos;
 out vec3 varyingNormal;
 out vec3 varyingVertex;

--- a/data/shaders/opengl/skybox.frag
+++ b/data/shaders/opengl/skybox.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 uniform samplerCube texture0;
 
 in vec3 v_texCoord;

--- a/data/shaders/opengl/skybox.vert
+++ b/data/shaders/opengl/skybox.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 uniform vec4 u_viewPosition;
 uniform Material material;
 

--- a/data/shaders/opengl/starfield.frag
+++ b/data/shaders/opengl/starfield.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 in vec4 color;
 
 out vec4 frag_color;

--- a/data/shaders/opengl/starfield.vert
+++ b/data/shaders/opengl/starfield.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec4 color;
 
 uniform Material material;

--- a/data/shaders/opengl/ui.frag
+++ b/data/shaders/opengl/ui.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 uniform sampler2D texture0; //diffuse
 in vec2 texCoord0;
 

--- a/data/shaders/opengl/ui.vert
+++ b/data/shaders/opengl/ui.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec2 texCoord0;
 
 out vec4 vertexColor;

--- a/data/shaders/opengl/vtxColor.frag
+++ b/data/shaders/opengl/vtxColor.frag
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 in vec4 vertexColor;
 
 out vec4 frag_color;

--- a/data/shaders/opengl/vtxColor.vert
+++ b/data/shaders/opengl/vtxColor.vert
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "attributes.glsl"
+#include "logz.glsl"
+#include "lib.glsl"
+
 out vec4 vertexColor;
 
 void main(void)

--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -84,7 +84,6 @@ struct Shader {
 
 		std::string strCode(filecode->AsStringRange().ToString());
 		size_t found = strCode.find("#include");
-		char incPathBuffer[4096];
 		while (found != std::string::npos) 
 		{
 			// find the name of the file to include
@@ -103,7 +102,7 @@ struct Shader {
 			}
 
 			// build path for include
-			sprintf(incPathBuffer, "shaders/opengl/%s", incFilename.c_str());
+			const std::string incPathBuffer = stringf("shaders/opengl/%0", incFilename);
 
 			// read included file
 			RefCountedPtr<FileSystem::FileData> incCode = FileSystem::gameDataFiles.ReadFile(incPathBuffer);
@@ -115,7 +114,7 @@ struct Shader {
 				found = strCode.find("#include");
 			}
 			else {
-				Error("Could not load %s", incPathBuffer);
+				Error("Could not load %s", incPathBuffer.c_str());
 			}
 		}
 		// Store the modified text with the included files (if any)

--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -8,6 +8,8 @@
 #include "OS.h"
 #include "graphics/Graphics.h"
 
+#include <set>
+
 namespace Graphics {
 
 namespace OGL {
@@ -73,20 +75,53 @@ static bool check_glsl_errors(const char *filename, GLuint obj)
 }
 
 struct Shader {
-	Shader(GLenum type, const std::string &filename, const std::string &defines) {
-		RefCountedPtr<FileSystem::FileData> code = FileSystem::gameDataFiles.ReadFile(filename);
+	Shader(GLenum type, const std::string &filename, const std::string &defines) 
+	{
+		RefCountedPtr<FileSystem::FileData> filecode = FileSystem::gameDataFiles.ReadFile(filename);
 
-		if (!code.Valid())
+		if (!filecode.Valid())
 			Error("Could not load %s", filename.c_str());
 
-		// Load some common code
-		RefCountedPtr<FileSystem::FileData> attributesCode = FileSystem::gameDataFiles.ReadFile("shaders/opengl/attributes.glsl");
-		assert(attributesCode.Valid());
-		RefCountedPtr<FileSystem::FileData> logzCode = FileSystem::gameDataFiles.ReadFile("shaders/opengl/logz.glsl");
-		assert(logzCode.Valid());
-		RefCountedPtr<FileSystem::FileData> libsCode = FileSystem::gameDataFiles.ReadFile("shaders/opengl/lib.glsl");
-		assert(libsCode.Valid());
+		std::string strCode(filecode->AsStringRange().ToString());
+		size_t found = strCode.find("#include");
+		char incPathBuffer[4096];
+		while (found != std::string::npos) 
+		{
+			// find the name of the file to include
+			const size_t begFilename = strCode.find_first_of("\"", found + 8) + 1;
+			const size_t endFilename = strCode.find_first_of("\"", begFilename + 1);
 
+			const std::string incFilename = strCode.substr(begFilename, endFilename - begFilename);
+
+			// check we haven't it already included it (avoids circular dependencies)
+			const std::set<std::string>::const_iterator foundIt = previousIncludes.find(incFilename);
+			if (foundIt != previousIncludes.end()) {
+				Error("Circular, or multiple, include of %s\n", incFilename.c_str());
+			}
+			else {
+				previousIncludes.insert(incFilename);
+			}
+
+			// build path for include
+			sprintf(incPathBuffer, "shaders/opengl/%s", incFilename.c_str());
+
+			// read included file
+			RefCountedPtr<FileSystem::FileData> incCode = FileSystem::gameDataFiles.ReadFile(incPathBuffer);
+			assert(incCode.Valid());
+
+			if (incCode.Valid()) {
+				// replace the #include and filename with the included files text
+				strCode.replace(found, (endFilename + 1) - found, incCode->GetData(), incCode->GetSize());
+				found = strCode.find("#include");
+			}
+			else {
+				Error("Could not load %s", incPathBuffer);
+			}
+		}
+		// Store the modified text with the included files (if any)
+		const StringRange code(strCode.c_str(), strCode.size());
+
+		// Build the final shader text to be compiled
 		AppendSource(s_glslVersion);
 		AppendSource(defines.c_str());
 		if (type == GL_VERTEX_SHADER) {
@@ -94,10 +129,7 @@ struct Shader {
 		} else {
 			AppendSource("#define FRAGMENT_SHADER\n");
 		}
-		AppendSource(attributesCode->AsStringRange().StripUTF8BOM());
-		AppendSource(logzCode->AsStringRange().StripUTF8BOM());
-		AppendSource(libsCode->AsStringRange().StripUTF8BOM());
-		AppendSource(code->AsStringRange().StripUTF8BOM());
+		AppendSource(code.StripUTF8BOM());
 #if 0
 		static bool s_bDumpShaderSource = true;
 		if (s_bDumpShaderSource) {
@@ -161,6 +193,7 @@ private:
 
 	std::vector<const char*> blocks;
 	std::vector<GLint> block_sizes;
+	std::set<std::string> previousIncludes;
 };
 
 Program::Program()


### PR DESCRIPTION
# Description:
This is a primitive, slightly hacky even, `#include` preprocessor for the shader files.
Currently when building a shader we add the other included glsl files for attirbutes, logz and library methods in hardcoded calls even for shaders that will not use them.

In future therefore when we add GPU noise shaders and their support functions everything would include those as well.

Supporting a simple `#include` macro means that each shader can include only what the shaders author wants including.

# This PR:
I have added the necessary `#include` to each file, probably unnecessary ones too as I just copied and pasted the three usual suspects into each file.

I've been a little lazy with the filename construction and used an `sprintf` which I should probably tidy up but it's late and I couldn't think straight about doing it with Pioneers string stuff.

Comments welcome as always.

Andy