### PR TITLE
Account for the fuel mass in hyperspace range calculation.

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -190,7 +190,7 @@ end
 local HyperdriveType = utils.inherits(EquipType, "HyperdriveType")
 
 HyperdriveType.GetMaximumRange = function (self, ship)
-	return 625.0*(self.capabilities.hyperclass ^ 2) / ship.totalMass
+	return 625.0*(self.capabilities.hyperclass ^ 2) / (ship.totalMass + ship.fuelMassLeft)
 end
 
 -- range_max is as usual optional

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -190,14 +190,14 @@ end
 local HyperdriveType = utils.inherits(EquipType, "HyperdriveType")
 
 HyperdriveType.GetMaximumRange = function (self, ship)
-	return 625.0*(self.capabilities.hyperclass ^ 2) / (ship.totalMass + ship.fuelMassLeft)
+	return 625.0*(self.capabilities.hyperclass ^ 2) / (ship.staticMass + ship.fuelMassLeft)
 end
 
 -- range_max is as usual optional
 HyperdriveType.GetDuration = function (self, ship, distance, range_max)
 	range_max = range_max or self:GetMaximumRange(ship)
 	local hyperclass = self.capabilities.hyperclass
-	return 0.36*distance^2/(range_max*hyperclass) * (3600*24*math.sqrt(ship.totalMass))
+	return 0.36*distance^2/(range_max*hyperclass) * (3600*24*math.sqrt(ship.staticMass + ship.fuelMassLeft))
 end
 
 -- range_max is optional, distance defaults to the maximal range.

--- a/data/ui/InfoView/ShipInfo.lua
+++ b/data/ui/InfoView/ShipInfo.lua
@@ -39,7 +39,7 @@ local shipInfo = function (args)
 		player:SetShipName(newName)
 	end )
 
-	local mass_with_fuel = player.totalMass + player.fuelMassLeft
+	local mass_with_fuel = player.staticMass + player.fuelMassLeft
 	local mass_with_fuel_kg = 1000 * mass_with_fuel
 
 	-- ship stats mass is in tonnes; scale by 1000 to convert to kg
@@ -48,7 +48,7 @@ local shipInfo = function (args)
 	local up_acc = shipDef.linearThrust.UP / mass_with_fuel_kg
 
 	-- delta-v calculation according to http://en.wikipedia.org/wiki/Tsiolkovsky_rocket_equation
-	local deltav = shipDef.effectiveExhaustVelocity * math.log((player.totalMass + player.fuelMassLeft) / player.totalMass)
+	local deltav = shipDef.effectiveExhaustVelocity * math.log((player.staticMass + player.fuelMassLeft) / player.staticMass)
 
 	local equipItems = {}
 	local equips = {Equipment.cargo, Equipment.misc, Equipment.hyperspace, Equipment.laser}
@@ -95,7 +95,7 @@ local shipInfo = function (args)
 							),
 						},
 						"",
-						{ l.WEIGHT_EMPTY..":",  string.format("%dt", player.totalMass - player.usedCapacity) },
+						{ l.WEIGHT_EMPTY..":",  string.format("%dt", player.staticMass - player.usedCapacity) },
 						{ l.CAPACITY_USED..":", string.format("%dt (%dt "..l.FREE..")", player.usedCapacity,  player.freeCapacity) },
 						{ l.CARGO_SPACE..":", string.format("%dt (%dt "..l.MAX..")", player.totalCargo, shipDef.equipSlotCapacity.cargo) },
 						{ l.CARGO_SPACE_USED..":", string.format("%dt (%dt "..l.FREE..")", player.usedCargo, player.totalCargo - player.usedCargo) },

--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -1110,7 +1110,7 @@ template <> void LuaObject<Ship>::RegisterClass()
  *   experimental
  *
  *
- * Attribute: totalMass
+ * Attribute: staticMass
  *
  * Mass of the ship including hull, equipment and cargo, but excluding
  * thruster fuel mass. Measured in tonnes.

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -382,7 +382,7 @@ void Ship::SetPercentHull(float p)
 
 void Ship::UpdateMass()
 {
-	SetMass((m_stats.total_mass + GetFuel()*GetShipType()->fuelTankMass)*1000);
+	SetMass((m_stats.static_mass + GetFuel()*GetShipType()->fuelTankMass)*1000);
 }
 
 void Ship::SetFuel(const double f)
@@ -575,12 +575,13 @@ void Ship::UpdateEquipStats()
 	m_stats.used_cargo = 0;
 
 	m_stats.free_capacity = m_type->capacity - m_stats.used_capacity;
-	m_stats.total_mass = m_stats.used_capacity + m_type->hullMass;
+	m_stats.static_mass = m_stats.used_capacity + m_type->hullMass;
 
 	p.Set("usedCapacity", m_stats.used_capacity);
 
 	p.Set("freeCapacity", m_stats.free_capacity);
-	p.Set("totalMass", m_stats.total_mass);
+	p.Set("totalMass", m_stats.static_mass);
+	p.Set("staticMass", m_stats.static_mass);
 
 	int shield_cap = 0;
 	Properties().Get("shield_cap", shield_cap);

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -38,7 +38,7 @@ struct shipstats_t {
 	int used_capacity;
 	int used_cargo;
 	int free_capacity;
-	int total_mass; // cargo, equipment + hull
+	int static_mass; // cargo, equipment + hull
 	float hull_mass_left; // effectively hitpoints
 	float hyperspace_range;
 	float hyperspace_range_max;

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -602,7 +602,7 @@ void SystemView::OnClickShip(Ship *s) {
 			lua_settop(l, clean_stack);
 
 			text += "\n";
-			text += stringf(Lang::MASS_N_TONNES, formatarg("mass", stats.total_mass));
+			text += stringf(Lang::MASS_N_TONNES, formatarg("mass", stats.static_mass));
 			text += "\n";
 			text += stringf(Lang::CARGO_N, formatarg("mass", stats.used_cargo));
 			text += "\n";

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -967,7 +967,7 @@ void WorldView::RefreshButtonStateAndVisibility()
 				lua_settop(l, clean_stack);
 
 				text += "\n";
-				text += stringf(Lang::MASS_N_TONNES, formatarg("mass", stats.total_mass));
+				text += stringf(Lang::MASS_N_TONNES, formatarg("mass", stats.static_mass));
 				text += "\n";
 				text += stringf(Lang::SHIELD_STRENGTH_N, formatarg("shields",
 					(sShields*0.01f) * float(prop_var))); // At that point, it still holds the property for the shields
@@ -1001,7 +1001,7 @@ void WorldView::RefreshButtonStateAndVisibility()
 					RefCountedPtr<const Sector> s = m_game->GetGalaxy()->GetSector(dest);
 					text += (cloud->IsArrival() ? Lang::HYPERSPACE_ARRIVAL_CLOUD : Lang::HYPERSPACE_DEPARTURE_CLOUD);
 					text += "\n";
-					text += stringf(Lang::SHIP_MASS_N_TONNES, formatarg("mass", ship->GetStats().total_mass));
+					text += stringf(Lang::SHIP_MASS_N_TONNES, formatarg("mass", ship->GetStats().static_mass));
 					text += "\n";
 					text += (cloud->IsArrival() ? Lang::SOURCE : Lang::DESTINATION);
 					text += ": ";


### PR DESCRIPTION
This should fix issue #3477 where the jump range was miscalculated as it did not account for the mass of the fuel aboard the ship.

Also takes into account the fuel for the hyperspace duration.

Changed `totalMass` to `staticMass` since it represents the unchanging mass of the ship rather than the dynamic mass of the fuel which will change through usage.
I have kept the old value of `totalMass` around for backwards compatibility with mods and forks of Pioneer like Scout+/Paragon/etc.

Thanks @joonicks for finding the issue and suggesting the fix.