### PR TITLE
Bad Terrain, no cookie!

### DIFF
--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -190,9 +190,9 @@ void Body::OrientOnSurface(double radius, double latitude, double longitude)
 
 void Body::SwitchToFrame(Frame *newFrame)
 {
-	vector3d vel = GetVelocityRelTo(newFrame);		// do this first because it uses position
-	vector3d fpos = m_frame->GetPositionRelTo(newFrame);
-	matrix3x3d forient = m_frame->GetOrientRelTo(newFrame);
+	const vector3d vel = GetVelocityRelTo(newFrame);		// do this first because it uses position
+	const vector3d fpos = m_frame->GetPositionRelTo(newFrame);
+	const matrix3x3d forient = m_frame->GetOrientRelTo(newFrame);
 	SetPosition(forient * GetPosition() + fpos);
 	SetOrient(forient * GetOrient());
 	SetVelocity(vel + newFrame->GetStasisVelocity(GetPosition()));
@@ -217,7 +217,7 @@ void Body::UpdateFrame()
 
 	// entering into frames
 	for (Frame* kid : m_frame->GetChildren()) {
-		vector3d pos = GetPositionRelTo(kid);
+		const vector3d pos = GetPositionRelTo(kid);
 		if (pos.Length() >= kid->GetRadius()) continue;
 		SwitchToFrame(kid);
 		Output("%s enters frame %s\n", GetLabel().c_str(), kid->GetLabel().c_str());

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -110,7 +110,6 @@ private:
 	const SpaceStationType *m_type;
 	const SystemBody *m_sbody;
 	CityOnPlanet *m_adjacentCity;
-	double m_distFromPlanet;
 	int m_numPoliceDocked;
 	enum { NUM_STATIC_SLOTS = 4 };
 	bool m_staticSlot[NUM_STATIC_SLOTS];

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -716,15 +716,17 @@ void WorldView::RefreshButtonStateAndVisibility()
 			vector3d pos = Pi::player->GetPosition();
 			vector3d abs_pos = Pi::player->GetPositionRelTo(m_game->GetSpace()->GetRootFrame());
 
+			const Frame *playerFrame = Pi::player->GetFrame();
+
 			ss << stringf("Pos: %0{f.2}, %1{f.2}, %2{f.2}\n", pos.x, pos.y, pos.z);
 			ss << stringf("AbsPos: %0{f.2}, %1{f.2}, %2{f.2}\n", abs_pos.x, abs_pos.y, abs_pos.z);
 
-			const SystemPath &path(Pi::player->GetFrame()->GetSystemBody()->GetPath());
+			const SystemPath &path(playerFrame->GetSystemBody()->GetPath());
 			ss << stringf("Rel-to: %0 [%1{d},%2{d},%3{d},%4{u},%5{u}] ",
-				Pi::player->GetFrame()->GetLabel(),
+				playerFrame->GetLabel(),
 				path.sectorX, path.sectorY, path.sectorZ, path.systemIndex, path.bodyIndex);
-			ss << stringf("(%0{f.2} km), rotating: %1\n",
-				pos.Length()/1000, (Pi::player->GetFrame()->IsRotFrame() ? "yes" : "no"));
+			ss << stringf("(%0{f.2} km), rotating: %1, has rotation: %2\n",
+				pos.Length()/1000, (playerFrame->IsRotFrame() ? "yes" : "no"), (playerFrame->HasRotFrame() ? "yes" : "no"));
 
 			//Calculate lat/lon for ship position
 			const vector3d dir = pos.NormalizedSafe();

--- a/src/terrain/TerrainHeightBarrenRock.cpp
+++ b/src/terrain/TerrainHeightBarrenRock.cpp
@@ -28,7 +28,6 @@ double TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeight(const vector3d &
 			GetFracDef(1).amplitude * crater_function(GetFracDef(1), p)));*/
 			//fuck the fracdefs, direct control is better:
 	double n = ridged_octavenoise(16, 0.5*octavenoise(8, 0.4, 2.5, p),Clamp(5.0*octavenoise(8, 0.257, 4.0, p), 1.0, 5.0), p);
-	n = m_maxHeight*2.0*n*n;
 
-	return (n > 0.0? n : 0.0);
+	return (n > 0.0 ? m_maxHeight*n : 0.0);
 }


### PR DESCRIPTION
This was a pain to diagnose but this PR should fix #3441

Unlike all of the other terrain generation values the final value of `n` was being calculated like this:
`n = m_maxHeight*2.0*n*n;`

Which seems to have been producing values which caused us NOT to transition to the correct `Frame` as we approached the planet.

The planet is still as flat as a pancake though, it's very odd and I'm wondering if the fractals are behaving as expected or if something is broken with them.