### PR TITLE
Present a clearer warning to the user if OpenGL fails to initialise.

### DIFF
--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -67,7 +67,10 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 		initted = true;
 
 		if (!ogl_LoadFunctions())
-			Error("glLoadGen failed to load functions.\n");
+			Error(
+				"Pioneer can not run on your graphics card as it does not appear to support OpenGL 3.3\n"
+				"Please check to see if your GPU driver vendor has an updated driver - or that drivers are installed correctly."
+			);
 
 		if (ogl_ext_EXT_texture_compression_s3tc == ogl_LOAD_FAILED)
 			Error(


### PR DESCRIPTION
This should help fix #3494

Recently I have noticed that we've had an increase in the number of players asking why the game won't run. I think that this is partly down to the current message saying that something has failed but without giving any explanation.

This new message should be clearer and present the only possible solution, updating their GPU driver.