### PR TITLE
WIP: show latitude/longitude

### DIFF
--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -211,10 +211,12 @@ void ShipCpanel::InitObject()
 
 	m_overlay[OVERLAY_TOP_LEFT]     = (new Gui::Label(""))->Color(s_hudTextColor);
 	m_overlay[OVERLAY_TOP_RIGHT]    = (new Gui::Label(""))->Color(s_hudTextColor);
+    m_overlay[OVERLAY_TOP_CENTER]   = (new Gui::Label(""))->Color(s_hudTextColor);
 	m_overlay[OVERLAY_BOTTOM_LEFT]  = (new Gui::Label(""))->Color(s_hudTextColor);
 	m_overlay[OVERLAY_BOTTOM_RIGHT] = (new Gui::Label(""))->Color(s_hudTextColor);
 	Add(m_overlay[OVERLAY_TOP_LEFT],     170.0f, 2.0f);
 	Add(m_overlay[OVERLAY_TOP_RIGHT],    500.0f, 2.0f);
+    Add(m_overlay[OVERLAY_TOP_CENTER],   315.0f, 1.0f);
 	Add(m_overlay[OVERLAY_BOTTOM_LEFT],  150.0f, 62.0f);
 	Add(m_overlay[OVERLAY_BOTTOM_RIGHT], 520.0f, 62.0f);
 

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -211,18 +211,20 @@ void ShipCpanel::InitObject()
 
 	m_overlay[OVERLAY_TOP_LEFT]     = (new Gui::Label(""))->Color(s_hudTextColor);
 	m_overlay[OVERLAY_TOP_RIGHT]    = (new Gui::Label(""))->Color(s_hudTextColor);
-    m_overlay[OVERLAY_TOP_CENTER]   = (new Gui::Label(""))->Color(s_hudTextColor);
 	m_overlay[OVERLAY_BOTTOM_LEFT]  = (new Gui::Label(""))->Color(s_hudTextColor);
 	m_overlay[OVERLAY_BOTTOM_RIGHT] = (new Gui::Label(""))->Color(s_hudTextColor);
-	m_overlay[OVERLAY_TEST_1] = (new Gui::Label(""))->Color(s_hudTextColor);
-	m_overlay[OVERLAY_TEST_2] = (new Gui::Label(""))->Color(s_hudTextColor);
+	m_overlay[OVERLAY_OVER_PANEL_RIGHT_1] = (new Gui::Label(""))->Color(s_hudTextColor);
+	m_overlay[OVERLAY_OVER_PANEL_RIGHT_2] = (new Gui::Label(""))->Color(s_hudTextColor);
+	m_overlay[OVERLAY_OVER_PANEL_RIGHT_3] = (new Gui::Label(""))->Color(s_hudTextColor);
+	m_overlay[OVERLAY_OVER_PANEL_RIGHT_4] = (new Gui::Label(""))->Color(s_hudTextColor);
 	Add(m_overlay[OVERLAY_TOP_LEFT],     170.0f, 2.0f);
 	Add(m_overlay[OVERLAY_TOP_RIGHT],    500.0f, 2.0f);
-    Add(m_overlay[OVERLAY_TOP_CENTER],   328.0f, 0.0f);
 	Add(m_overlay[OVERLAY_BOTTOM_LEFT],  150.0f, 62.0f);
 	Add(m_overlay[OVERLAY_BOTTOM_RIGHT], 520.0f, 62.0f);
-	Add(m_overlay[OVERLAY_TEST_1], 691.0f, -13.0f);
-	Add(m_overlay[OVERLAY_TEST_2], 691.0f, 0.0f);
+	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_1], 691.0f, -13.0f);
+	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_2], 722.0f, -13.0f);
+	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_3], 691.0f, 0.0f);
+	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_4], 722.0f, 0.0f);
 
 	View::SetCpanel(this);
 }

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -214,11 +214,15 @@ void ShipCpanel::InitObject()
     m_overlay[OVERLAY_TOP_CENTER]   = (new Gui::Label(""))->Color(s_hudTextColor);
 	m_overlay[OVERLAY_BOTTOM_LEFT]  = (new Gui::Label(""))->Color(s_hudTextColor);
 	m_overlay[OVERLAY_BOTTOM_RIGHT] = (new Gui::Label(""))->Color(s_hudTextColor);
+	m_overlay[OVERLAY_TEST_1] = (new Gui::Label(""))->Color(s_hudTextColor);
+	m_overlay[OVERLAY_TEST_2] = (new Gui::Label(""))->Color(s_hudTextColor);
 	Add(m_overlay[OVERLAY_TOP_LEFT],     170.0f, 2.0f);
 	Add(m_overlay[OVERLAY_TOP_RIGHT],    500.0f, 2.0f);
-    Add(m_overlay[OVERLAY_TOP_CENTER],   315.0f, 1.0f);
+    Add(m_overlay[OVERLAY_TOP_CENTER],   328.0f, 0.0f);
 	Add(m_overlay[OVERLAY_BOTTOM_LEFT],  150.0f, 62.0f);
 	Add(m_overlay[OVERLAY_BOTTOM_RIGHT], 520.0f, 62.0f);
+	Add(m_overlay[OVERLAY_TEST_1], 691.0f, -13.0f);
+	Add(m_overlay[OVERLAY_TEST_2], 691.0f, 0.0f);
 
 	View::SetCpanel(this);
 }

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -221,10 +221,10 @@ void ShipCpanel::InitObject()
 	Add(m_overlay[OVERLAY_TOP_RIGHT],    500.0f, 2.0f);
 	Add(m_overlay[OVERLAY_BOTTOM_LEFT],  150.0f, 62.0f);
 	Add(m_overlay[OVERLAY_BOTTOM_RIGHT], 520.0f, 62.0f);
-	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_1], 691.0f, -13.0f);
-	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_2], 722.0f, -13.0f);
-	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_3], 691.0f, 0.0f);
-	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_4], 722.0f, 0.0f);
+	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_1], 691.0f, -17.0f);
+	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_2], 723.0f, -17.0f);
+	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_3], 691.0f, -4.0f);
+	Add(m_overlay[OVERLAY_OVER_PANEL_RIGHT_4], 723.0f, -4.0f);
 
 	View::SetCpanel(this);
 }

--- a/src/ShipCpanel.h
+++ b/src/ShipCpanel.h
@@ -32,6 +32,7 @@ public:
 	enum OverlayTextPos {
 		OVERLAY_TOP_LEFT,
 		OVERLAY_TOP_RIGHT,
+		OVERLAY_TOP_CENTER,
 		OVERLAY_BOTTOM_LEFT,
 		OVERLAY_BOTTOM_RIGHT
 	};
@@ -77,7 +78,7 @@ private:
 	Gui::MultiStateImageButton *m_rotationDampingButton;
 	Gui::Image *m_alertLights[3];
 
-	Gui::Label *m_overlay[4];
+	Gui::Label *m_overlay[5];
 };
 
 #endif /* _SHIP_CPANEL_H */

--- a/src/ShipCpanel.h
+++ b/src/ShipCpanel.h
@@ -32,11 +32,12 @@ public:
 	enum OverlayTextPos {
 		OVERLAY_TOP_LEFT,
 		OVERLAY_TOP_RIGHT,
-		OVERLAY_TOP_CENTER,
 		OVERLAY_BOTTOM_LEFT,
 		OVERLAY_BOTTOM_RIGHT,
-		OVERLAY_TEST_1,
-		OVERLAY_TEST_2
+		OVERLAY_OVER_PANEL_RIGHT_1,
+		OVERLAY_OVER_PANEL_RIGHT_2,
+		OVERLAY_OVER_PANEL_RIGHT_3,
+		OVERLAY_OVER_PANEL_RIGHT_4,
 	};
 	void SetOverlayText(OverlayTextPos pos, const std::string &text);
 	void SetOverlayToolTip(OverlayTextPos pos, const std::string &text);
@@ -80,7 +81,7 @@ private:
 	Gui::MultiStateImageButton *m_rotationDampingButton;
 	Gui::Image *m_alertLights[3];
 
-	Gui::Label *m_overlay[7];
+	Gui::Label *m_overlay[8];
 };
 
 #endif /* _SHIP_CPANEL_H */

--- a/src/ShipCpanel.h
+++ b/src/ShipCpanel.h
@@ -34,7 +34,9 @@ public:
 		OVERLAY_TOP_RIGHT,
 		OVERLAY_TOP_CENTER,
 		OVERLAY_BOTTOM_LEFT,
-		OVERLAY_BOTTOM_RIGHT
+		OVERLAY_BOTTOM_RIGHT,
+		OVERLAY_TEST_1,
+		OVERLAY_TEST_2
 	};
 	void SetOverlayText(OverlayTextPos pos, const std::string &text);
 	void SetOverlayToolTip(OverlayTextPos pos, const std::string &text);
@@ -78,7 +80,7 @@ private:
 	Gui::MultiStateImageButton *m_rotationDampingButton;
 	Gui::Image *m_alertLights[3];
 
-	Gui::Label *m_overlay[5];
+	Gui::Label *m_overlay[7];
 };
 
 #endif /* _SHIP_CPANEL_H */

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -600,7 +600,7 @@ void UseEquipWidget::UpdateEquip()
 
 ///////////////////////////////////////////////
 
-MultiFuncSelectorWidget::MultiFuncSelectorWidget(): Gui::Fixed(144, 17)
+MultiFuncSelectorWidget::MultiFuncSelectorWidget(): Gui::Fixed(104, 17)
 {
 	m_active = 0;
 	m_rg = new Gui::RadioGroup();
@@ -614,7 +614,7 @@ MultiFuncSelectorWidget::MultiFuncSelectorWidget(): Gui::Fixed(144, 17)
 	m_buttons[1] = new Gui::ImageRadioButton(m_rg, "icons/multifunc_equip.png", "icons/multifunc_equip_on.png");
 	m_buttons[1]->onSelect.connect(sigc::bind(sigc::mem_fun(this, &MultiFuncSelectorWidget::OnClickButton), MFUNC_EQUIPMENT));
 	m_buttons[1]->SetShortcut(SDLK_F10, KMOD_NONE);
-	m_buttons[1]->SetRenderDimensions(34, 17);
+	m_buttons[0]->SetRenderDimensions(34, 17);
 
 	UpdateButtons();
 

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -823,6 +823,11 @@ void WorldView::RefreshButtonStateAndVisibility()
 					else
 						m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, stringf(Lang::ALT_IN_METRES, formatarg("altitude", altitude),
 							formatarg("vspeed", vspeed)));
+
+                        // show lat/long when within 10 km of planet/star
+                        const float lat = RAD2DEG(asin(surface_pos.y));
+                        const float lon = RAD2DEG(atan2(surface_pos.x, surface_pos.z));
+                        m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TOP_CENTER, stringf("Lat: %0{f.6} / Lon: %1{f.6}", lat, lon));
 				} else {
 					// XXX does this need to be repeated 3 times?
 					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, "");

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -837,10 +837,10 @@ void WorldView::RefreshButtonStateAndVisibility()
 				} else {
 					// XXX does this need to be repeated 3 times?
 					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, "");
-                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_1, "");
-                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_2, "");
-                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_3, "");
-                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_4, "");
+					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_1, "");
+					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_2, "");
+					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_3, "");
+					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_4, "");
 					if(m_curPlane != NONE) {
 						m_curPlane = NONE;
 						m_hudDockTop->RemoveInnerWidget();
@@ -849,10 +849,10 @@ void WorldView::RefreshButtonStateAndVisibility()
 				}
 			} else {
 				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, "");
-                m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_1, "");
-                m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_2, "");
-                m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_3, "");
-                m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_4, "");
+				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_1, "");
+				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_2, "");
+				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_3, "");
+				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_4, "");
 				if(m_curPlane != NONE) {
 					m_curPlane = NONE;
 					m_hudDockTop->RemoveInnerWidget();

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -35,7 +35,7 @@
 #include "matrix4x4.h"
 #include "Quaternion.h"
 #include "LuaObject.h"
-//#include "utils.h"
+#include "utils.h"
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
@@ -231,8 +231,8 @@ void WorldView::InitObject()
 	Add(m_hudHullTemp, 5.0f, Gui::Screen::GetHeight() - 144.0f);
 	Add(m_hudWeaponTemp, 5.0f, Gui::Screen::GetHeight() - 184.0f);
 	Add(m_hudSensorGaugeStack, 5.0f, 5.0f);
-	Add(m_hudHullIntegrity, Gui::Screen::GetWidth() - 105.0f, Gui::Screen::GetHeight() - 124.0f);
-	Add(m_hudShieldIntegrity, Gui::Screen::GetWidth() - 105.0f, Gui::Screen::GetHeight() - 164.0f);
+	Add(m_hudHullIntegrity, Gui::Screen::GetWidth() - 105.0f, Gui::Screen::GetHeight() - 135.0f);
+	Add(m_hudShieldIntegrity, Gui::Screen::GetWidth() - 105.0f, Gui::Screen::GetHeight() - 175.0f);
 
 	m_hudTargetHullIntegrity = new Gui::MeterBar(100.0f, Lang::HULL_INTEGRITY, Color(255,255,0,204));
 	m_hudTargetShieldIntegrity = new Gui::MeterBar(100.0f, Lang::SHIELD_INTEGRITY, Color(255,255,0,204));

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -35,6 +35,7 @@
 #include "matrix4x4.h"
 #include "Quaternion.h"
 #include "LuaObject.h"
+//#include "utils.h"
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
@@ -230,8 +231,8 @@ void WorldView::InitObject()
 	Add(m_hudHullTemp, 5.0f, Gui::Screen::GetHeight() - 144.0f);
 	Add(m_hudWeaponTemp, 5.0f, Gui::Screen::GetHeight() - 184.0f);
 	Add(m_hudSensorGaugeStack, 5.0f, 5.0f);
-	Add(m_hudHullIntegrity, Gui::Screen::GetWidth() - 105.0f, Gui::Screen::GetHeight() - 104.0f);
-	Add(m_hudShieldIntegrity, Gui::Screen::GetWidth() - 105.0f, Gui::Screen::GetHeight() - 144.0f);
+	Add(m_hudHullIntegrity, Gui::Screen::GetWidth() - 105.0f, Gui::Screen::GetHeight() - 124.0f);
+	Add(m_hudShieldIntegrity, Gui::Screen::GetWidth() - 105.0f, Gui::Screen::GetHeight() - 164.0f);
 
 	m_hudTargetHullIntegrity = new Gui::MeterBar(100.0f, Lang::HULL_INTEGRITY, Color(255,255,0,204));
 	m_hudTargetShieldIntegrity = new Gui::MeterBar(100.0f, Lang::SHIELD_INTEGRITY, Color(255,255,0,204));
@@ -824,16 +825,22 @@ void WorldView::RefreshButtonStateAndVisibility()
 						m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, stringf(Lang::ALT_IN_METRES, formatarg("altitude", altitude),
 							formatarg("vspeed", vspeed)));
 
-                        // show lat/long when within 10 km of planet/star
-                        const float lat = RAD2DEG(asin(surface_pos.y));
-                        const float lon = RAD2DEG(atan2(surface_pos.x, surface_pos.z));
-                        m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TOP_CENTER, stringf("Lat: %0{f.4} / Lon: %1{f.4}", lat, lon));
-                        m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TEST_1, stringf("Lat: %0{f.6}", lat));
-                        m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TEST_2, stringf("Lon: %0{f.6}", lon));
+                    // show lat/long when altitude is shownr
+                    const float lat = RAD2DEG(asin(surface_pos.y));
+                    const float lon = RAD2DEG(atan2(surface_pos.x, surface_pos.z));
+                    std::string lat_str = DecimalToDegMinSec(lat);
+                    std::string lon_str = DecimalToDegMinSec(lon);
+                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_1, "Lat:");
+                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_2, lat_str);
+                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_3, "Long:");
+                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_4, lon_str);
 				} else {
 					// XXX does this need to be repeated 3 times?
 					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, "");
-					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TOP_CENTER, "");
+                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_1, "");
+                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_2, "");
+                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_3, "");
+                    m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_4, "");
 					if(m_curPlane != NONE) {
 						m_curPlane = NONE;
 						m_hudDockTop->RemoveInnerWidget();
@@ -842,7 +849,10 @@ void WorldView::RefreshButtonStateAndVisibility()
 				}
 			} else {
 				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, "");
-				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TOP_CENTER, "");
+                m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_1, "");
+                m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_2, "");
+                m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_3, "");
+                m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_OVER_PANEL_RIGHT_4, "");
 				if(m_curPlane != NONE) {
 					m_curPlane = NONE;
 					m_hudDockTop->RemoveInnerWidget();

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -827,10 +827,13 @@ void WorldView::RefreshButtonStateAndVisibility()
                         // show lat/long when within 10 km of planet/star
                         const float lat = RAD2DEG(asin(surface_pos.y));
                         const float lon = RAD2DEG(atan2(surface_pos.x, surface_pos.z));
-                        m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TOP_CENTER, stringf("Lat: %0{f.6} / Lon: %1{f.6}", lat, lon));
+                        m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TOP_CENTER, stringf("Lat: %0{f.4} / Lon: %1{f.4}", lat, lon));
+                        m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TEST_1, stringf("Lat: %0{f.6}", lat));
+                        m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TEST_2, stringf("Lon: %0{f.6}", lon));
 				} else {
 					// XXX does this need to be repeated 3 times?
 					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, "");
+					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TOP_CENTER, "");
 					if(m_curPlane != NONE) {
 						m_curPlane = NONE;
 						m_hudDockTop->RemoveInnerWidget();
@@ -839,6 +842,7 @@ void WorldView::RefreshButtonStateAndVisibility()
 				}
 			} else {
 				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_RIGHT, "");
+				m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_TOP_CENTER, "");
 				if(m_curPlane != NONE) {
 					m_curPlane = NONE;
 					m_hudDockTop->RemoveInnerWidget();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -422,6 +422,19 @@ void StrToAuto(double *pVal, const std::string &str)
 	*pVal = StrToDouble(str);
 }
 
+/**
+    Converts geographic coordinates from decimal to degree/minutes/seconds format
+    and returns a string.
+*/
+std::string DecimalToDegMinSec(float dec)
+{
+	int degrees = floor(dec);
+	int minutes = floor(60*(dec - degrees));
+	int seconds = floor(3600 * ((dec - degrees) - static_cast<float>(minutes) / 60));
+	std::string str = stringf("%0° %1' %2\"", degrees, minutes, seconds);
+	return str;
+}
+
 static const int HEXDUMP_CHUNK = 16;
 void hexdump(const unsigned char *buf, int len)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -152,6 +152,9 @@ void StrToAuto(Sint64 *pVal, const std::string &str);
 void StrToAuto(float *pVal, const std::string &str);
 void StrToAuto(double *pVal, const std::string &str);
 
+// Convert decimal coordinates to degree/minute/second format and return as string
+std::string DecimalToDegMinSec(float dec);
+
 // add a few things that MSVC is missing
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
 


### PR DESCRIPTION
##### Reason for this pull request
I would like to add a latitude/longitude display to the player hud. This will be useful for any mission that requires finding or returning to a specific location on a planet. Currently, I use lat/lon for my search & rescue mission script where ships have crashed and the player is asked to go to the crash site and rescue personnel, deliver fuel, etc.

##### Feedback requested
I need some feedback on where the lat/lon info should be placed. Lat/Lon info is shown whenever the player is close enough to a planet to also show altitude. This pull request puts it in two places (just for testing) - centrally above the scanner, and on the right of the screen right above the panel (see screenshots below). The position above the scanner is problematic though because the relative speed info can run into it (see second screenshot).

![lat_lon_3](https://cloud.githubusercontent.com/assets/10633178/10587602/dd97bab2-766f-11e5-836f-a9e5289c1c55.png)

![lat_lon_5](https://cloud.githubusercontent.com/assets/10633178/10587606/e2c35da2-766f-11e5-864c-edd706deaf96.png)
