### PR TITLE
Eclipse tidy

### DIFF
--- a/data/shaders/opengl/eclipse.glsl
+++ b/data/shaders/opengl/eclipse.glsl
@@ -1,0 +1,118 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifdef ECLIPSE
+
+uniform int shadows;
+uniform ivec3 occultedLight;
+uniform vec3 shadowCentreX;
+uniform vec3 shadowCentreY;
+uniform vec3 shadowCentreZ;
+uniform vec3 srad;
+uniform vec3 lrad;
+uniform vec3 sdivlrad;
+
+#define PI 3.141592653589793
+
+float discCovered(const in float dist, const in float rad) {
+	// proportion of unit disc covered by a second disc of radius rad placed
+	// dist from centre of first disc.
+	//
+	// XXX: same function is in Camera.cpp
+	//
+	// WLOG, the second disc is displaced horizontally to the right.
+	// xl = rightwards distance to intersection of the two circles.
+	// xs = normalised leftwards distance from centre of second disc to intersection.
+	// d = vertical distance to an intersection point
+	//
+	// The clamps on xl,xs handle the cases where one disc contains the other.
+
+	float radsq = rad*rad;
+
+	float xl = clamp((dist*dist + 1.0 - radsq) / (2.0*max(0.001,dist)), -1.0, 1.0);
+	float xs = clamp((dist - xl)/max(0.001,rad), -1.0, 1.0);
+	float d = sqrt(max(0.0, 1.0 - xl*xl));
+
+	float th = clamp(acos(xl), 0.0, PI);
+	float th2 = clamp(acos(xs), 0.0, PI);
+
+	// covered area can be calculated as the sum of segments from the two
+	// discs plus/minus some triangles, and it works out as follows:
+	return clamp((th + radsq*th2 - dist*d)/PI, 0.0, 1.0);
+}
+
+// integral used in shadow calculations:
+// \Int (m - \sqrt(d^2+t^2)) dt = (t\sqrt(d^2+t^2) + d^2 log(\sqrt(d^2+t^2)+t))/2
+float shadowInt(const in float t1, const in float t2, const in float dsq, const in float m)
+{
+	float s1 = sqrt(dsq+t1*t1);
+	float s2 = sqrt(dsq+t2*t2);
+	return m*(t2-t1) - (t2*s2 - t1*s1 + dsq*( log(max(0.000001, s2+t2)) - log(max(0.000001, s1+t1)))) * 0.5;
+}
+
+float calcUneclipsed(const in int i, const in vec3 v, const in vec3 lightDir) 
+{
+	float uneclipsed = 1.0;
+	for (int j=0; j<shadows; j++) {
+		if (i != occultedLight[j])
+			continue;
+			
+		vec3 centre = vec3( shadowCentreX[j], shadowCentreY[j], shadowCentreZ[j] );
+		
+		// Apply eclipse:
+		vec3 projectedPoint = v - dot(lightDir,v)*lightDir;
+		// By our assumptions, the proportion of light blocked at this point by
+		// this sphere is the proportion of the disc of radius lrad around
+		// projectedPoint covered by the disc of radius srad around shadowCentre.
+		float dist = length(projectedPoint - centre);
+		uneclipsed *= 1.0 - discCovered(dist/lrad[j], sdivlrad[j]);
+	}
+	return uneclipsed;
+}
+
+float calcUneclipsedSky(const in int i, const in vec3 a, const in vec3 b, const in vec3 lightDir) 
+{
+	float uneclipsed = 1.0;
+	for (int j=0; j<shadows; j++) {
+		if (i != occultedLight[j])
+			continue;
+
+		// Eclipse handling:
+		// Calculate proportion of the in-atmosphere eyeline which is shadowed,
+		// weighting according to completeness of the shadow (penumbra vs umbra).
+		// This ignores variation in atmosphere density, and ignores outscatter along
+		// the eyeline, so is not very accurate. But it gives decent results.
+
+		vec3 centre = vec3( shadowCentreX[j], shadowCentreY[j], shadowCentreZ[j] );
+
+		vec3 ap = a - dot(a,lightDir)*lightDir - centre;
+		vec3 bp = b - dot(b,lightDir)*lightDir - centre;
+
+		vec3 dirp = normalize(bp-ap);
+		float ad = dot(ap,dirp);
+		float bd = dot(bp,dirp);
+		vec3 p = ap - dot(ap,dirp)*dirp;
+		float perpsq = dot(p,p);
+
+		// we now want to calculate the proportion of shadow on the horizontal line
+		// segment from ad to bd, shifted vertically from centre by \sqrt(perpsq). For
+		// the partially occluded segments, to have an analytic solution to the integral
+		// we estimate the light intensity to drop off linearly with radius between
+		// maximal occlusion and none.
+
+		float minr = srad[j]-lrad[j];
+		float maxr = srad[j]+lrad[j];
+		float maxd = sqrt( max(0.0, maxr*maxr - perpsq) );
+		float mind = sqrt( max(0.0, minr*minr - perpsq) );
+
+		float shadow = ( shadowInt(clamp(ad, -maxd, -mind), clamp(bd, -maxd, -mind), perpsq, maxr)
+			+ shadowInt(clamp(ad, mind, maxd), clamp(bd, mind, maxd), perpsq, maxr) )
+			/ (maxr-minr) + (clamp(bd, -mind, mind) - clamp(ad, -mind, mind));
+
+		float maxOcclusion = min(1.0, (sdivlrad[j])*(sdivlrad[j]));
+
+		uneclipsed -= maxOcclusion * shadow / (bd-ad);
+	}
+	return uneclipsed;
+}
+#endif // ECLIPSE

--- a/data/shaders/opengl/eclipse.glsl
+++ b/data/shaders/opengl/eclipse.glsl
@@ -115,4 +115,10 @@ float calcUneclipsedSky(const in int i, const in vec3 a, const in vec3 b, const 
 	}
 	return uneclipsed;
 }
+
+#else
+
+#define calcUneclipsed(a,b,c) 1.0
+#define calcUneclipsedSky(a,b,c,d) 1.0
+
 #endif // ECLIPSE

--- a/data/shaders/opengl/gassphere_base.frag
+++ b/data/shaders/opengl/gassphere_base.frag
@@ -4,6 +4,7 @@
 #include "attributes.glsl"
 #include "logz.glsl"
 #include "lib.glsl"
+#include "eclipse.glsl"
 
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
@@ -13,17 +14,6 @@ uniform float geosphereAtmosTopRad;
 uniform vec3 geosphereCenter;
 uniform float geosphereAtmosFogDensity;
 uniform float geosphereAtmosInvScaleHeight;
-
-#ifdef ECLIPSE
-uniform int shadows;
-uniform ivec3 occultedLight;
-uniform vec3 shadowCentreX;
-uniform vec3 shadowCentreY;
-uniform vec3 shadowCentreZ;
-uniform vec3 srad;
-uniform vec3 lrad;
-uniform vec3 sdivlrad;
-#endif // ECLIPSE
 
 uniform Material material;
 uniform Scene scene;
@@ -35,37 +25,6 @@ in vec3 varyingTexCoord0;
 uniform samplerCube texture0; //diffuse
 
 out vec4 frag_color;
-
-#ifdef ECLIPSE
-#define PI 3.141592653589793
-
-float discCovered(const in float dist, const in float rad) {
-	// proportion of unit disc covered by a second disc of radius rad placed
-	// dist from centre of first disc.
-	//
-	// XXX: same function is in Camera.cpp
-	//
-	// WLOG, the second disc is displaced horizontally to the right.
-	// xl = rightwards distance to intersection of the two circles.
-	// xs = normalised leftwards distance from centre of second disc to intersection.
-	// d = vertical distance to an intersection point
-	//
-	// The clamps on xl,xs handle the cases where one disc contains the other.
-
-	float radsq = rad*rad;
-
-	float xl = clamp((dist*dist + 1.0 - radsq) / (2.0*max(0.001,dist)), -1.0, 1.0);
-	float xs = clamp((dist - xl)/max(0.001,rad), -1.0, 1.0);
-	float d = sqrt(max(0.0, 1.0 - xl*xl));
-
-	float th = clamp(acos(xl), 0.0, PI);
-	float th2 = clamp(acos(xs), 0.0, PI);
-
-	// covered area can be calculated as the sum of segments from the two
-	// discs plus/minus some triangles, and it works out as follows:
-	return clamp((th + radsq*th2 - dist*d)/PI, 0.0, 1.0);
-}
-#endif // ECLIPSE
 
 void main(void)
 {
@@ -79,28 +38,10 @@ void main(void)
 	vec3 v = (eyepos - geosphereCenter)/geosphereRadius;
 	float lenInvSq = 1.0/(dot(v,v));
 	for (int i=0; i<NUM_LIGHTS; ++i) {
-		vec3 lightDir = normalize(vec3(uLight[i].position));
-		float unshadowed = 1.0;
-#ifdef ECLIPSE
-		for (int j=0; j<shadows; j++) {
-			if (i != occultedLight[j])
-				continue;
-				
-			vec3 centre = vec3( shadowCentreX[j], shadowCentreY[j], shadowCentreZ[j] );
-			
-			// Apply eclipse:
-			vec3 projectedPoint = v - dot(lightDir,v)*lightDir;
-			// By our assumptions, the proportion of light blocked at this point by
-			// this sphere is the proportion of the disc of radius lrad around
-			// projectedPoint covered by the disc of radius srad around shadowCentre.
-			float dist = length(projectedPoint - centre);
-			unshadowed *= 1.0 - discCovered(dist/lrad[j], sdivlrad[j]);
-		}
-#endif // ECLIPSE
-		unshadowed = clamp(unshadowed, 0.0, 1.0);
+		float uneclipsed = clamp(calcUneclipsed(i, v, normalize(vec3(uLight[i].position))), 0.0, 1.0);
 		nDotVP  = max(0.0, dot(tnorm, normalize(vec3(uLight[i].position))));
 		nnDotVP = max(0.0, dot(tnorm, normalize(-vec3(uLight[i].position)))); //need backlight to increase horizon
-		diff += uLight[i].diffuse * unshadowed * 0.5*(nDotVP+0.5*clamp(1.0-nnDotVP*4.0,0.0,1.0) * INV_NUM_LIGHTS);
+		diff += uLight[i].diffuse * uneclipsed * 0.5*(nDotVP+0.5*clamp(1.0-nnDotVP*4.0,0.0,1.0) * INV_NUM_LIGHTS);
 	}
 
 	// when does the eye ray intersect atmosphere

--- a/data/shaders/opengl/geosphere_sky.frag
+++ b/data/shaders/opengl/geosphere_sky.frag
@@ -4,6 +4,7 @@
 #include "attributes.glsl"
 #include "logz.glsl"
 #include "lib.glsl"
+#include "eclipse.glsl"
 
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
@@ -13,17 +14,6 @@ uniform float geosphereAtmosTopRad;
 uniform vec3 geosphereCenter;
 uniform float geosphereAtmosFogDensity;
 uniform float geosphereAtmosInvScaleHeight;
-
-#ifdef ECLIPSE
-uniform int shadows;
-uniform ivec3 occultedLight;
-uniform vec3 shadowCentreX;
-uniform vec3 shadowCentreY;
-uniform vec3 shadowCentreZ;
-uniform vec3 srad;
-uniform vec3 lrad;
-uniform vec3 sdivlrad;
-#endif // ECLIPSE
 
 in vec4 varyingEyepos;
 
@@ -47,15 +37,6 @@ void sphereEntryExitDist(out float near, out float far, const in vec3 sphereCent
 			far = i2;
 		}
 	}
-}
-
-// integral used in shadow calculations:
-// \Int (m - \sqrt(d^2+t^2)) dt = (t\sqrt(d^2+t^2) + d^2 log(\sqrt(d^2+t^2)+t))/2
-float shadowInt(const in float t1, const in float t2, const in float dsq, const in float m)
-{
-	float s1 = sqrt(dsq+t1*t1);
-	float s2 = sqrt(dsq+t2*t2);
-	return m*(t2-t1) - (t2*s2 - t1*s1 + dsq*( log(max(0.000001, s2+t2)) - log(max(0.000001, s1+t1)))) * 0.5;
 }
 
 void main(void)
@@ -82,50 +63,7 @@ void main(void)
 
 		vec3 lightDir = normalize(vec3(uLight[i].position));
 
-		float uneclipsed = 1.0;
-#ifdef ECLIPSE
-		for (int j=0; j<shadows; j++) {
-			if (i != occultedLight[j])
-				continue;
-
-			// Eclipse handling:
-			// Calculate proportion of the in-atmosphere eyeline which is shadowed,
-			// weighting according to completeness of the shadow (penumbra vs umbra).
-			// This ignores variation in atmosphere density, and ignores outscatter along
-			// the eyeline, so is not very accurate. But it gives decent results.
-
-			vec3 centre = vec3( shadowCentreX[j], shadowCentreY[j], shadowCentreZ[j] );
-
-			vec3 ap = a - dot(a,lightDir)*lightDir - centre;
-			vec3 bp = b - dot(b,lightDir)*lightDir - centre;
-
-			vec3 dirp = normalize(bp-ap);
-			float ad = dot(ap,dirp);
-			float bd = dot(bp,dirp);
-			vec3 p = ap - dot(ap,dirp)*dirp;
-			float perpsq = dot(p,p);
-
-			// we now want to calculate the proportion of shadow on the horizontal line
-			// segment from ad to bd, shifted vertically from centre by \sqrt(perpsq). For
-			// the partially occluded segments, to have an analytic solution to the integral
-			// we estimate the light intensity to drop off linearly with radius between
-			// maximal occlusion and none.
-
-			float minr = srad[j]-lrad[j];
-			float maxr = srad[j]+lrad[j];
-			float maxd = sqrt( max(0.0, maxr*maxr - perpsq) );
-			float mind = sqrt( max(0.0, minr*minr - perpsq) );
-
-			float shadow = ( shadowInt(clamp(ad, -maxd, -mind), clamp(bd, -maxd, -mind), perpsq, maxr)
-				+ shadowInt(clamp(ad, mind, maxd), clamp(bd, mind, maxd), perpsq, maxr) )
-				/ (maxr-minr) + (clamp(bd, -mind, mind) - clamp(ad, -mind, mind));
-
-			float maxOcclusion = min(1.0, (sdivlrad[j])*(sdivlrad[j]));
-
-			uneclipsed -= maxOcclusion * shadow / (bd-ad);
-		}
-#endif // ECLIPSE
-		uneclipsed = clamp(uneclipsed, 0.0, 1.0);
+		float uneclipsed = clamp(calcUneclipsedSky(i, a, b, lightDir), 0.0, 1.0);
 
 		float nDotVP =  max(0.0, dot(surfaceNorm, lightDir));
 		float nnDotVP = max(0.0, dot(surfaceNorm, -lightDir));  //need backlight to increase horizon

--- a/data/shaders/opengl/geosphere_terrain.frag
+++ b/data/shaders/opengl/geosphere_terrain.frag
@@ -4,6 +4,7 @@
 #include "attributes.glsl"
 #include "logz.glsl"
 #include "lib.glsl"
+#include "eclipse.glsl"
 
 uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
@@ -24,18 +25,6 @@ in float dist;
 uniform float detailScaleHi;
 uniform float detailScaleLo;
 
-
-#ifdef ECLIPSE
-uniform int shadows;
-uniform ivec3 occultedLight;
-uniform vec3 shadowCentreX;
-uniform vec3 shadowCentreY;
-uniform vec3 shadowCentreZ;
-uniform vec3 srad;
-uniform vec3 lrad;
-uniform vec3 sdivlrad;
-#endif // ECLIPSE
-
 uniform Material material;
 uniform Scene scene;
 
@@ -48,37 +37,6 @@ in vec4 varyingEmission;
 #endif
 
 out vec4 frag_color;
-
-#ifdef ECLIPSE
-#define PI 3.141592653589793
-
-float discCovered(const in float dist, const in float rad) {
-	// proportion of unit disc covered by a second disc of radius rad placed
-	// dist from centre of first disc.
-	//
-	// XXX: same function is in Camera.cpp
-	//
-	// WLOG, the second disc is displaced horizontally to the right.
-	// xl = rightwards distance to intersection of the two circles.
-	// xs = normalised leftwards distance from centre of second disc to intersection.
-	// d = vertical distance to an intersection point
-	//
-	// The clamps on xl,xs handle the cases where one disc contains the other.
-
-	float radsq = rad*rad;
-
-	float xl = clamp((dist*dist + 1.0 - radsq) / (2.0*max(0.001,dist)), -1.0, 1.0);
-	float xs = clamp((dist - xl)/max(0.001,rad), -1.0, 1.0);
-	float d = sqrt(max(0.0, 1.0 - xl*xl));
-
-	float th = clamp(acos(xl), 0.0, PI);
-	float th2 = clamp(acos(xs), 0.0, PI);
-
-	// covered area can be calculated as the sum of segments from the two
-	// discs plus/minus some triangles, and it works out as follows:
-	return clamp((th + radsq*th2 - dist*d)/PI, 0.0, 1.0);
-}
-#endif // ECLIPSE
 
 void main(void)
 {
@@ -109,28 +67,10 @@ void main(void)
 	vec3 v = (eyepos - geosphereCenter)/geosphereRadius;
 	float lenInvSq = 1.0/(dot(v,v));
 	for (int i=0; i<NUM_LIGHTS; ++i) {
-		vec3 lightDir = normalize(vec3(uLight[i].position));
-		float unshadowed = 1.0;
-#ifdef ECLIPSE
-		for (int j=0; j<shadows; j++) {
-			if (i != occultedLight[j])
-				continue;
-				
-			vec3 centre = vec3( shadowCentreX[j], shadowCentreY[j], shadowCentreZ[j] );
-			
-			// Apply eclipse:
-			vec3 projectedPoint = v - dot(lightDir,v)*lightDir;
-			// By our assumptions, the proportion of light blocked at this point by
-			// this sphere is the proportion of the disc of radius lrad around
-			// projectedPoint covered by the disc of radius srad around shadowCentre.
-			float dist = length(projectedPoint - centre);
-			unshadowed *= 1.0 - discCovered(dist/lrad[j], sdivlrad[j]);
-		}
-#endif // ECLIPSE
-		unshadowed = clamp(unshadowed, 0.0, 1.0);
+		float uneclipsed = clamp(calcUneclipsed(i, v, normalize(vec3(uLight[i].position))), 0.0, 1.0);
 		nDotVP  = max(0.0, dot(tnorm, normalize(vec3(uLight[i].position))));
 		nnDotVP = max(0.0, dot(tnorm, normalize(-vec3(uLight[i].position)))); //need backlight to increase horizon
-		diff += uLight[i].diffuse * unshadowed * 0.5*(nDotVP+0.5*clamp(1.0-nnDotVP*4.0,0.0,1.0) * INV_NUM_LIGHTS);
+		diff += uLight[i].diffuse * uneclipsed * 0.5*(nDotVP+0.5*clamp(1.0-nnDotVP*4.0,0.0,1.0) * INV_NUM_LIGHTS);
 
 #ifdef TERRAIN_WITH_WATER
 		//Specular reflection


### PR DESCRIPTION
This moves most of the code for the Eclipse stuff into a separate `eclipse.glsl` library file that can be included with our `#include` macro.

Eventually I would like to change this to use [OpenGL Uniform Buffers](https://www.opengl.org/wiki/Uniform_Buffer_Object) but that's a more extensive rewrite and this is just a neat cleanup to make that future work easier.

All functionality should be exactly the same.

Andy