### PR TITLE
Introduce faction specific fuel clubs

### DIFF
--- a/data/lang/module-fuelclub/en.json
+++ b/data/lang/module-fuelclub/en.json
@@ -11,13 +11,49 @@
       "description" : "",
       "message" : "Interstellar Pilots' Fuel Co-operative"
    },
+   "FLAVOUR_1_CLUBNAME" : {
+      "description" : "Fuel club for the Federation faction",
+      "message" : "The Federal Fuel Foundation"
+   },
+   "FLAVOUR_2_CLUBNAME" : {
+      "description" : "Fuel club for the CIW (Commonwealth of Independent Worlds) faction",
+      "message" : "The Confederate Fuel Union"
+   },
+   "FLAVOUR_3_CLUBNAME" : {
+      "description" : "Fuel club for the Haber faction",
+      "message" : "Haber Propellant and Perishables Division"
+   },
    "FLAVOUR_0_MEMBER_INTRO" : {
       "description" : "",
       "message" : "You may purhase fuel and dispose of {radioactives} here."
    },
+   "FLAVOUR_3_MEMBER_INTRO" : {
+      "description" : "For the greedy Haber faction, very corporate formulated",
+      "message" : "Greetings pilot. Your refueling and conditional side-product disposal privileges are granted."
+   },
    "FLAVOUR_0_NONMEMBER_INTRO" : {
       "description" : "",
       "message" : "{clubname} is an independent organisation dedicated to providing discounted starship fuel to its members. Branches can be found throughout the galaxy. Benefits of membership include:"
+   },
+   "FLAVOUR_1_NONMEMBER_INTRO" : {
+      "description" : "For the Solar Federation faction",
+      "message" : "{clubname} is the leading provider of discounted fuel to its members' starships in the Solar Federation. A membership will entitle you for the following:"
+   },
+   "FLAVOUR_2_NONMEMBER_INTRO" : {
+      "description" : "Commonwealth of Independent Worlds is the name of the CIW faction",
+      "message" : "Throughout the vast reach of the free Commonwealth of Independent Worlds you will find {clubname} as the best provider of discounted fuel and waste management services. For our members, we do:"
+   },
+   "FLAVOUR_3_NONMEMBER_INTRO" : {
+      "description" : "for the Haber faction",
+      "message" : "Greetings pilot. This is the Haber Propellant and Perishables Division, entrusted with managing the fuel distribution throughout Haber owned space."
+   },
+   "FLAVOUR_0_WELCOME" : {
+      "description" : "",
+      "message" : "Welcome to {clubname}"
+   },
+   "FLAVOUR_2_WELCOME" : {
+      "description" : "",
+      "message" : "Greetings and salutations! We hope you enjoy our services."
    },
    "LIST_BENEFITS_FUEL_INTRO" : {
       "description" : "",
@@ -39,10 +75,6 @@
       "description" : "",
       "message" : "Join now! Annual membership costs only {membership_fee}"
     },
-   "FLAVOUR_0_WELCOME" : {
-      "description" : "",
-      "message" : "Welcome to {clubname}"
-   },
    "GO_BACK" : {
       "description" : "",
       "message" : "Go back"

--- a/data/modules/FuelClub/FuelClub.lua
+++ b/data/modules/FuelClub/FuelClub.lua
@@ -43,16 +43,38 @@ local memberships = {
 -- }
 }
 
--- 1 / probability that you'll see one in a BBS
-local chance_of_availability = 3
-
 local flavours = {
-	{
+	{    -- Independent club
 		clubname = l.FLAVOUR_0_CLUBNAME,
 		welcome = l.FLAVOUR_0_WELCOME,
 		nonmember_intro = l.FLAVOUR_0_NONMEMBER_INTRO,
 		member_intro = l.FLAVOUR_0_MEMBER_INTRO,
 		annual_fee = 400,
+		availability = {FED = 0.1, CIW = 0.1, HABER = 0, IND = 0.4} -- probability for these factions
+	},
+	{   -- SolFed club (reuse some messages)
+		clubname = l.FLAVOUR_1_CLUBNAME,
+		welcome = l.FLAVOUR_0_WELCOME,
+		nonmember_intro = l.FLAVOUR_1_NONMEMBER_INTRO,
+		member_intro = l.FLAVOUR_0_MEMBER_INTRO,
+		annual_fee = 400,
+		availability = {FED = 0.4, CIW = 0, HABER = 0, IND = 0}
+	},
+	{   -- Confederation club
+		clubname = l.FLAVOUR_2_CLUBNAME,
+		welcome = l.FLAVOUR_2_WELCOME,
+		nonmember_intro = l.FLAVOUR_2_NONMEMBER_INTRO,
+		member_intro = l.FLAVOUR_0_MEMBER_INTRO,
+		annual_fee = 300,
+		availability = {FED = 0, CIW = 0.4, HABER = 0, IND = 0}
+	},
+	{   -- Haber fuel division
+		clubname = l.FLAVOUR_3_CLUBNAME,
+		welcome = l.FLAVOUR_0_WELCOME,
+		nonmember_intro = l.FLAVOUR_3_NONMEMBER_INTRO,
+		member_intro = l.FLAVOUR_3_MEMBER_INTRO,
+		annual_fee = 600,
+		availability = {FED = 0, CIW = 0, HABER=1, IND = 0}
 	}
 }
 
@@ -192,21 +214,39 @@ onChat = function (form, ref, option)
 end
 
 local onCreateBB = function (station)
+
+	local faction = Game.system.faction.name
+
+	-- For convenes, map long faction name to shorter table key
+	local faction_key
+	if faction == "Solar Federation" then
+		faction_key = "FED"
+	elseif faction == "Commonwealth of Independent Worlds" then
+		faction_key = "CIW"
+	elseif faction == "Haber Corporation" then
+		faction_key = "HABER"
+	else
+		faction_key = "IND"
+	end
+
 	-- deterministically generate our instance
 	local rand = Rand.New(station.seed + seedbump)
-	if rand:Integer(1,chance_of_availability) == 1 then
-		-- Create our bulletin board ad
-		local ad = {station = station, stock = {}, price = {}}
-		ad.flavour = flavours[rand:Integer(1,#flavours)]
-		ad.character = Character.New({
-			title = ad.flavour.clubname,
-			armour = false,
-		})
-		ads[station:AddAdvert({
-			description = ad.flavour.clubname,
-			icon        = "fuel_club",
-			onChat      = onChat,
-			onDelete    = onDelete})] = ad
+
+	for k,flavour in pairs(flavours) do
+		if rand:Number(0,1) < flavour.availability[faction_key] then
+			-- Create our bulletin board ad
+			local ad = {station = station, stock = {}, price = {}}
+			ad.flavour = flavour
+			ad.character = Character.New({
+					title = ad.flavour.clubname,
+					armour = false,
+			})
+			ads[station:AddAdvert({
+						description = ad.flavour.clubname,
+						icon        = "fuel_club",
+						onChat      = onChat,
+						onDelete    = onDelete})] = ad
+		end
 	end
 end
 


### PR DESCRIPTION
## Faction specific fuel clubs

Adds three new fuel clubs (we only had one):
- _The Federal Fuel Foundation_ 400 credits/y, (spawn rate in fed space: 40%)
- _The Confederate Fuel Union_ 300 credits/y, (spawn rate in CIW space: 40%)
- _Haber Propellant and Perishables Division_ 600 credits/y, (spawn rate in Haber space: 100%)

Now we can specify how common (spawn probability) each flavour is depending on faction.

The three new fuel clubs only exist in their own faction space. For other factions they get Interstellar Pilots' Fuel Co-operative (40%).

(In current master, it's Interstellar Pilots' Fuel Co-operative (30%) for all BBS's)

In some SolFed and CIW space, some stations can have two fuel clubs, the other being Interstellar Pilots' Fuel Co-operative. However, Interstellar Pilots' Fuel Co-operative spawns 0% in Haber space, because Haber doesn't allow competition.


## Review

It's good if the text is right, and doesn't need to be changed after merge. The different messages should "feel" like Federation or CIW, or Haber. Suggestions for improvements are welcome.


## Future

There should probably be some kind of list under F3 that shows player memberships, since the player can be member of several fuel clubs. Should also show time remaining on the membership.