### PR TITLE
Introduce Tech Level to stations - makes them more unique

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -983,6 +983,10 @@
       "description" : "",
       "message" : "Status"
    },
+   "TECH_CERTIFIED" : {
+      "description" : "Lobby screen shows the tech level (an integer number) of the station",
+      "message" : "This station holds a level {tech_level} technology certificate."
+   },
    "THANKS_AND_REMEMBER_TO_BUY_FUEL" : {
       "description" : "",
       "message" : "Thank you for your purchase. Remember to fit equipment and buy fuel before you depart."

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -987,6 +987,10 @@
       "description" : "Lobby screen shows the tech level (an integer number) of the station",
       "message" : "This station holds a level {tech_level} technology certificate."
    },
+   "TECH_CERTIFIED_MILITARY" : {
+      "description" : "Lobby screen shows the tech level of the station",
+      "message" : "This installation holds a military technology clearance."
+   },
    "THANKS_AND_REMEMBER_TO_BUY_FUEL" : {
       "description" : "",
       "message" : "Thank you for your purchase. Remember to fit equipment and buy fuel before you depart."

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -658,7 +658,7 @@ misc.missile_smart = EquipType.New({
 })
 misc.missile_naval = EquipType.New({
 	l10n_key="MISSILE_NAVAL", slots="missile", price=160,
-	missile_type="missile_naval", tech_level=11,
+	missile_type="missile_naval", tech_level="MILITARY",
 	capabilities={mass=1}, purchasable=true,
 	icon_name="missile_naval"
 })
@@ -675,7 +675,7 @@ misc.ecm_basic = EquipType.New({
 misc.ecm_advanced = EquipType.New({
 	l10n_key="ECM_ADVANCED", slots="ecm", price=15200,
 	capabilities={mass=2, ecm_power=3, ecm_recharge=5},
-	purchasable=true, tech_level=11
+	purchasable=true, tech_level="MILITARY"
 })
 misc.scanner = EquipType.New({
 	l10n_key="SCANNER", slots="scanner", price=680,
@@ -713,7 +713,7 @@ misc.radar_mapper = EquipType.New({
 })
 misc.advanced_radar_mapper = EquipType.New({
 	l10n_key="ADVANCED_RADAR_MAPPER", slots="radar", price=1200,
-	capabilities={mass=1, radar_mapper_level=2}, purchasable=true, tech_level=11
+	capabilities={mass=1, radar_mapper_level=2}, purchasable=true, tech_level="MILITARY"
 })
 misc.fuel_scoop = EquipType.New({
 	l10n_key="FUEL_SCOOP", slots="scoop", price=3500,
@@ -737,7 +737,7 @@ misc.shield_energy_booster = EquipType.New({
 })
 misc.hull_autorepair = EquipType.New({
 	l10n_key="HULL_AUTOREPAIR", slots="hull_autorepair", price=16000,
-	capabilities={mass=40, hull_autorepair=1}, purchasable=true, tech_level=11
+	capabilities={mass=40, hull_autorepair=1}, purchasable=true, tech_level="MILITARY"
 })
 misc.trade_analyzer = EquipType.New({
 	l10n_key="TRADE_ANALYZER", slots="trade_analyzer", price=400,
@@ -794,7 +794,7 @@ hyperspace.hyperdrive_mil1 = HyperdriveType.New({
 })
 hyperspace.hyperdrive_mil2 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL2", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=47000, capabilities={mass=8, hyperclass=2}, purchasable=true, tech_level=11
+	price=47000, capabilities={mass=8, hyperclass=2}, purchasable=true, tech_level="MILITARY"
 })
 hyperspace.hyperdrive_mil3 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL3", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
@@ -853,7 +853,7 @@ laser.pulsecannon_20mw = LaserType.New({
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=20000, rechargeTime=0.25, length=30,
 		width=5, dual=0, mining=0, rgba_r = 0.1, rgba_g = 51, rgba_b = 255, rgba_a = 255
-	}, purchasable=true, tech_level=11
+	}, purchasable=true, tech_level="MILITARY"
 })
 laser.miningcannon_17mw = LaserType.New({
 	l10n_key="MININGCANNON_17MW", price=10600, capabilities={mass=10},

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -640,107 +640,112 @@ cargo.consumer_goods.requirements = { cargo.plastics, cargo.textiles }
 local misc = {}
 misc.missile_unguided = EquipType.New({
 	l10n_key="MISSILE_UNGUIDED", slots="missile", price=30,
-	missile_type="missile_unguided",
+	missile_type="missile_unguided", tech_level=1,
 	capabilities={mass=1, missile=1}, purchasable=true,
 	icon_name="missile_unguided"
 })
 misc.missile_guided = EquipType.New({
 	l10n_key="MISSILE_GUIDED", slots="missile", price=50,
-	missile_type="missile_guided",
+	missile_type="missile_guided", tech_level=5,
 	capabilities={mass=1}, purchasable=true,
 	icon_name="missile_guided"
 })
 misc.missile_smart = EquipType.New({
 	l10n_key="MISSILE_SMART", slots="missile", price=95,
-	missile_type="missile_smart",
+	missile_type="missile_smart", tech_level=10,
 	capabilities={mass=1}, purchasable=true,
 	icon_name="missile_smart"
 })
 misc.missile_naval = EquipType.New({
 	l10n_key="MISSILE_NAVAL", slots="missile", price=160,
-	missile_type="missile_naval",
+	missile_type="missile_naval", tech_level=11,
 	capabilities={mass=1}, purchasable=true,
 	icon_name="missile_naval"
 })
 misc.atmospheric_shielding = EquipType.New({
 	l10n_key="ATMOSPHERIC_SHIELDING", slots="atmo_shield", price=200,
-	capabilities={mass=1, atmo_shield=1}, purchasable=true
+	capabilities={mass=1, atmo_shield=1},
+	purchasable=true, tech_level=3
 })
 misc.ecm_basic = EquipType.New({
 	l10n_key="ECM_BASIC", slots="ecm", price=6000,
-	capabilities={mass=2, ecm_power=2, ecm_recharge=5}, purchasable=true
+	capabilities={mass=2, ecm_power=2, ecm_recharge=5},
+	purchasable=true, tech_level=9
 })
 misc.ecm_advanced = EquipType.New({
 	l10n_key="ECM_ADVANCED", slots="ecm", price=15200,
-	capabilities={mass=2, ecm_power=3, ecm_recharge=5}, purchasable=true
+	capabilities={mass=2, ecm_power=3, ecm_recharge=5},
+	purchasable=true, tech_level=11
 })
 misc.scanner = EquipType.New({
 	l10n_key="SCANNER", slots="scanner", price=680,
-	capabilities={mass=1, scanner=1}, purchasable=true
+	capabilities={mass=1, scanner=1},
+	purchasable=true, tech_level=3
 })
 misc.cabin = EquipType.New({
 	l10n_key="UNOCCUPIED_CABIN", slots="cabin", price=1350,
-	capabilities={mass=1, cabin=1}, purchasable=true
+	capabilities={mass=1, cabin=1},
+	purchasable=true,  tech_level=1
 })
 misc.cabin_occupied = EquipType.New({
 	l10n_key="PASSENGER_CABIN", slots="cabin", price=0,
-	capabilities={mass=1}, purchasable=false
+	capabilities={mass=1}, purchasable=false, tech_level=1
 })
 misc.shield_generator = EquipType.New({
 	l10n_key="SHIELD_GENERATOR", slots="shield", price=2500,
-	capabilities={mass=4, shield=1}, purchasable=true
+	capabilities={mass=4, shield=1}, purchasable=true, tech_level=8
 })
 misc.laser_cooling_booster = EquipType.New({
 	l10n_key="LASER_COOLING_BOOSTER", slots="laser_cooler", price=380,
-	capabilities={mass=1, laser_cooler=2}, purchasable=true
+	capabilities={mass=1, laser_cooler=2}, purchasable=true, tech_level=8
 })
 misc.cargo_life_support = EquipType.New({
 	l10n_key="CARGO_LIFE_SUPPORT", slots="cargo_life_support", price=700,
-	capabilities={mass=1, cargo_life_support=1}, purchasable=true
+	capabilities={mass=1, cargo_life_support=1}, purchasable=true, tech_level=2
 })
 misc.autopilot = EquipType.New({
 	l10n_key="AUTOPILOT", slots="autopilot", price=1400,
-	capabilities={mass=1, set_speed=1, autopilot=1}, purchasable=true
+	capabilities={mass=1, set_speed=1, autopilot=1}, purchasable=true, tech_level=6
 })
 misc.radar_mapper = EquipType.New({
 	l10n_key="RADAR_MAPPER", slots="radar", price=900,
-	capabilities={mass=1, radar_mapper_level=1}, purchasable=true
+	capabilities={mass=1, radar_mapper_level=1}, purchasable=true, tech_level=9
 })
 misc.advanced_radar_mapper = EquipType.New({
 	l10n_key="ADVANCED_RADAR_MAPPER", slots="radar", price=1200,
-	capabilities={mass=1, radar_mapper_level=2}, purchasable=true
+	capabilities={mass=1, radar_mapper_level=2}, purchasable=true, tech_level=11
 })
 misc.fuel_scoop = EquipType.New({
 	l10n_key="FUEL_SCOOP", slots="scoop", price=3500,
-	capabilities={mass=6, fuel_scoop=3}, purchasable=true
+	capabilities={mass=6, fuel_scoop=3}, purchasable=true, tech_level=4
 })
 misc.cargo_scoop = EquipType.New({
 	l10n_key="CARGO_SCOOP", slots="scoop", price=3900,
-	capabilities={mass=7, cargo_scoop=1}, purchasable=true
+	capabilities={mass=7, cargo_scoop=1}, purchasable=true, tech_level=5
 })
 misc.multi_scoop = EquipType.New({
 	l10n_key="MULTI_SCOOP", slots="scoop", price=12000,
-	capabilities={mass=9, cargo_scoop=1, fuel_scoop=2}, purchasable=true
+	capabilities={mass=9, cargo_scoop=1, fuel_scoop=2}, purchasable=true, tech_level=9
 })
 misc.hypercloud_analyzer = EquipType.New({
 	l10n_key="HYPERCLOUD_ANALYZER", slots="hypercloud", price=1500,
-	capabilities={mass=1, hypercloud_analyzer=1}, purchasable=true
+	capabilities={mass=1, hypercloud_analyzer=1}, purchasable=true, tech_level=10
 })
 misc.shield_energy_booster = EquipType.New({
 	l10n_key="SHIELD_ENERGY_BOOSTER", slots="energy_booster", price=10000,
-	capabilities={mass=8, shield_energy_booster=1}, purchasable=true
+	capabilities={mass=8, shield_energy_booster=1}, purchasable=true, tech_level=11
 })
 misc.hull_autorepair = EquipType.New({
 	l10n_key="HULL_AUTOREPAIR", slots="hull_autorepair", price=16000,
-	capabilities={mass=40, hull_autorepair=1}, purchasable=true
+	capabilities={mass=40, hull_autorepair=1}, purchasable=true, tech_level=11
 })
 misc.trade_analyzer = EquipType.New({
 	l10n_key="TRADE_ANALYZER", slots="trade_analyzer", price=400,
-	capabilities={mass=0, trade_analyzer=1, software=1}, purchasable=true
+	capabilities={mass=0, trade_analyzer=1, software=1}, purchasable=true, tech_level=9
 })
 misc.planetscanner = BodyScannerType.New({
 	l10n_key = 'PLANETSCANNER', slots="sensor", price=15000,
-	capabilities={mass=1,sensor=1}, purchasable=false,
+	capabilities={mass=1,sensor=1}, purchasable=false, tech_level=1,
 	icon_on_name="body_scanner_on", icon_off_name="body_scanner_off",
 	max_range=100000000, target_altitude=0, state="HALTED", progress=0,
 	bodyscanner_stats={scan_speed=3, scan_tolerance=0.05}
@@ -749,55 +754,55 @@ misc.planetscanner = BodyScannerType.New({
 local hyperspace = {}
 hyperspace.hyperdrive_1 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS1", fuel=cargo.hydrogen, slots="engine",
-	price=700, capabilities={mass=4, hyperclass=1}, purchasable=true
+	price=700, capabilities={mass=4, hyperclass=1}, purchasable=true, tech_level=3
 })
 hyperspace.hyperdrive_2 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS2", fuel=cargo.hydrogen, slots="engine",
-	price=1300, capabilities={mass=10, hyperclass=2}, purchasable=true
+	price=1300, capabilities={mass=10, hyperclass=2}, purchasable=true, tech_level=4
 })
 hyperspace.hyperdrive_3 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS3", fuel=cargo.hydrogen, slots="engine",
-	price=2500, capabilities={mass=20, hyperclass=3}, purchasable=true
+	price=2500, capabilities={mass=20, hyperclass=3}, purchasable=true, tech_level=4
 })
 hyperspace.hyperdrive_4 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS4", fuel=cargo.hydrogen, slots="engine",
-	price=5000, capabilities={mass=40, hyperclass=4}, purchasable=true
+	price=5000, capabilities={mass=40, hyperclass=4}, purchasable=true, tech_level=5
 })
 hyperspace.hyperdrive_5 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS5", fuel=cargo.hydrogen, slots="engine",
-	price=10000, capabilities={mass=120, hyperclass=5}, purchasable=true
+	price=10000, capabilities={mass=120, hyperclass=5}, purchasable=true, tech_level=5
 })
 hyperspace.hyperdrive_6 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS6", fuel=cargo.hydrogen, slots="engine",
-	price=20000, capabilities={mass=225, hyperclass=6}, purchasable=true
+	price=20000, capabilities={mass=225, hyperclass=6}, purchasable=true, tech_level=6
 })
 hyperspace.hyperdrive_7 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS7", fuel=cargo.hydrogen, slots="engine",
-	price=30000, capabilities={mass=400, hyperclass=7}, purchasable=true
+	price=30000, capabilities={mass=400, hyperclass=7}, purchasable=true, tech_level=8
 })
 hyperspace.hyperdrive_8 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS8", fuel=cargo.hydrogen, slots="engine",
-	price=60000, capabilities={mass=580, hyperclass=8}, purchasable=true
+	price=60000, capabilities={mass=580, hyperclass=8}, purchasable=true, tech_level=9
 })
 hyperspace.hyperdrive_9 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS9", fuel=cargo.hydrogen, slots="engine",
-	price=120000, capabilities={mass=740, hyperclass=9}, purchasable=true
+	price=120000, capabilities={mass=740, hyperclass=9}, purchasable=true, tech_level=10
 })
 hyperspace.hyperdrive_mil1 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL1", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=23000, capabilities={mass=3, hyperclass=1}, purchasable=true
+	price=23000, capabilities={mass=3, hyperclass=1}, purchasable=true, tech_level=10
 })
 hyperspace.hyperdrive_mil2 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL2", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=47000, capabilities={mass=8, hyperclass=2}, purchasable=true
+	price=47000, capabilities={mass=8, hyperclass=2}, purchasable=true, tech_level=11
 })
 hyperspace.hyperdrive_mil3 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL3", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=85000, capabilities={mass=16, hyperclass=3}, purchasable=true
+	price=85000, capabilities={mass=16, hyperclass=3}, purchasable=true, tech_level=11
 })
 hyperspace.hyperdrive_mil4 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL4", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=214000, capabilities={mass=30, hyperclass=4}, purchasable=true
+	price=214000, capabilities={mass=30, hyperclass=4}, purchasable=true, tech_level=12
 })
 
 local laser = {}
@@ -806,70 +811,70 @@ laser.pulsecannon_1mw = LaserType.New({
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=1000, rechargeTime=0.25, length=30,
 		width=5, dual=0, mining=0, rgba_r = 255, rgba_g = 51, rgba_b = 51, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=3
 })
 laser.pulsecannon_dual_1mw = LaserType.New({
 	l10n_key="PULSECANNON_DUAL_1MW", price=1100, capabilities={mass=4},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=1000, rechargeTime=0.25, length=30,
 		width=5, dual=1, mining=0, rgba_r = 255, rgba_g = 51, rgba_b = 51, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=4
 })
 laser.pulsecannon_2mw = LaserType.New({
 	l10n_key="PULSECANNON_2MW", price=1000, capabilities={mass=3},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=2000, rechargeTime=0.25, length=30,
 		width=5, dual=0, mining=0, rgba_r = 255, rgba_g = 127, rgba_b = 51, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=5
 })
 laser.pulsecannon_rapid_2mw = LaserType.New({
 	l10n_key="PULSECANNON_RAPID_2MW", price=1800, capabilities={mass=7},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=2000, rechargeTime=0.13, length=30,
 		width=5, dual=0, mining=0, rgba_r = 255, rgba_g = 127, rgba_b = 51, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=5
 })
 laser.pulsecannon_4mw = LaserType.New({
 	l10n_key="PULSECANNON_4MW", price=2200, capabilities={mass=10},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=4000, rechargeTime=0.25, length=30,
 		width=5, dual=0, mining=0, rgba_r = 255, rgba_g = 255, rgba_b = 51, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=6
 })
 laser.pulsecannon_10mw = LaserType.New({
 	l10n_key="PULSECANNON_10MW", price=4900, capabilities={mass=30},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=10000, rechargeTime=0.25, length=30,
 		width=5, dual=0, mining=0, rgba_r = 51, rgba_g = 255, rgba_b = 51, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=7
 })
 laser.pulsecannon_20mw = LaserType.New({
 	l10n_key="PULSECANNON_20MW", price=12000, capabilities={mass=65},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=20000, rechargeTime=0.25, length=30,
 		width=5, dual=0, mining=0, rgba_r = 0.1, rgba_g = 51, rgba_b = 255, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=11
 })
 laser.miningcannon_17mw = LaserType.New({
 	l10n_key="MININGCANNON_17MW", price=10600, capabilities={mass=10},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=17000, rechargeTime=2, length=30,
 		width=5, dual=0, mining=1, rgba_r = 51, rgba_g = 127, rgba_b = 0, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=8
 })
 laser.small_plasma_accelerator = LaserType.New({
 	l10n_key="SMALL_PLASMA_ACCEL", price=120000, capabilities={mass=22},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=50000, rechargeTime=0.3, length=42,
 		width=7, dual=0, mining=0, rgba_r = 51, rgba_g = 255, rgba_b = 255, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=10
 })
 laser.large_plasma_accelerator = LaserType.New({
 	l10n_key="LARGE_PLASMA_ACCEL", price=390000, capabilities={mass=50},
 	slots = {"laser_front", "laser_rear"}, laser_stats = {
 		lifespan=8, speed=1000, damage=100000, rechargeTime=0.3, length=42,
 		width=7, dual=0, mining=0, rgba_r = 127, rgba_g = 255, rgba_b = 255, rgba_a = 255
-	}, purchasable=true
+	}, purchasable=true, tech_level=12
 })
 local equipment = {
 	cargo=cargo,

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -3,6 +3,7 @@
 
 local SpaceStation = import_core("SpaceStation")
 local Event = import("Event")
+local Rand = import("Rand")
 local Space = import("Space")
 local utils = import("utils")
 local ShipDef = import("ShipDef")
@@ -18,6 +19,15 @@ local Equipment = import("Equipment")
 --
 -- Class: SpaceStation
 --
+
+
+function SpaceStation:Constructor()
+	-- Use a variation of the space station seed itself to ensure consistency
+	local rand = Rand.New(util.hash_random(self.seed .. '-techLevel', 2^31)-1)
+	local techLevel = rand:Integer(1, 6) + rand:Integer(0,6)
+	self:setprop("techLevel", techLevel)
+end
+
 
 local equipmentStock = {}
 

--- a/data/libs/autoload.lua
+++ b/data/libs/autoload.lua
@@ -4,6 +4,8 @@
 -- this is the only library automatically loaded at startup
 -- its the right place to extend core Lua tables
 
+import("SpaceStation")
+
 math.clamp = function(v, min, max)
 	return math.min(max, math.max(v,min))
 end

--- a/data/ui/StationView/EquipmentMarket.lua
+++ b/data/ui/StationView/EquipmentMarket.lua
@@ -12,13 +12,18 @@ local l = Lang.GetResource("ui-core")
 
 local ui = Engine.ui
 
+local hasTech = function (e)
+	local station = Game.player:GetDockedWith()
+	local equip_tech_level = e.tech_level or 1 -- default to 1
+	return station.techLevel >= equip_tech_level
+end
 
 local equipmentMarket = function (args)
 	local stationTable, shipTable = EquipmentTableWidgets.Pair({
 		stationColumns = { "name", "buy", "sell", "mass", "stock" },
 		shipColumns = { "name", "amount", "mass", "massTotal" },
 
-		canTrade = function (e) return e.purchasable and not e:IsValidSlot("cargo", Game.player) end,
+		canTrade = function (e) return e.purchasable and hasTech(e) and not e:IsValidSlot("cargo", Game.player) end,
 	})
 
 	return

--- a/data/ui/StationView/EquipmentMarket.lua
+++ b/data/ui/StationView/EquipmentMarket.lua
@@ -15,6 +15,16 @@ local ui = Engine.ui
 local hasTech = function (e)
 	local station = Game.player:GetDockedWith()
 	local equip_tech_level = e.tech_level or 1 -- default to 1
+
+	if type(equip_tech_level) == "string" then
+		if equip_tech_level == "MILITARY" then
+			return station.techLevel == 11
+		else
+			error("Unknown tech level:\t"..equip_tech_level)
+		end
+	end
+
+	assert(type(equip_tech_level) == "number")
 	return station.techLevel >= equip_tech_level
 end
 

--- a/data/ui/StationView/Lobby.lua
+++ b/data/ui/StationView/Lobby.lua
@@ -35,11 +35,15 @@ local lobby = function (tab)
 		end
 	end)
 
+	local tech_certified
+	tech_certified = string.interp(l.TECH_CERTIFIED, { tech_level = station.techLevel})
+
 	return
 		ui:Grid({48,4,48},1)
 			:SetColumn(0, {
 				ui:VBox(10):PackEnd({
 					ui:Label(station.label):SetFont("HEADING_LARGE"),
+					ui:Align("LEFT", tech_certified),
 					ui:Expand(),
 					ui:Align("MIDDLE", launchButton),
 				})

--- a/data/ui/StationView/Lobby.lua
+++ b/data/ui/StationView/Lobby.lua
@@ -36,7 +36,12 @@ local lobby = function (tab)
 	end)
 
 	local tech_certified
-	tech_certified = string.interp(l.TECH_CERTIFIED, { tech_level = station.techLevel})
+
+	if station.techLevel == 11 then
+		tech_certified = l.TECH_CERTIFIED_MILITARY
+	else
+		tech_certified = string.interp(l.TECH_CERTIFIED, { tech_level = station.techLevel})
+	end
 
 	return
 		ui:Grid({48,4,48},1)


### PR DESCRIPTION
# Tech Levels

Here I go again with one of my "limit game content exposure to player", but I'm very happy with this one as it really improves the game I think, making each station a bit more unique. This implements what I discussed in the top post on the dev-forum [Tech Levels for ship equipment](http://pioneerspacesim.net/forum/viewtopic.php?f=3&t=235), by giving each station a tech level, with some distribution (the [convolution](https://en.wikipedia.org/wiki/Convolution) of two square waves), which then influences what equipment is supported (bought/sold) on in the equipment market. (Note: this does not affect the Second Hand market module on the BBS, which I think is as it should be).

Tech levels lead to more interesting game play I think (pretty much exactly like in Frontier):
- "Oh, this was a good station!"
- "Wow, there's an _Advanced_ ECM as well? Never seen that before!"
And of course:
- "Blast! This station doesn't have <gadget> I desperately need, maybe one city over has it?"

Caveat: last commit adds a "Military" tech level, just like in frontier. And just like in frontier it's "Tech Level 11" that is "special" in being "military", thus no station will show "tech level 11 in the Lobby", since they will instead show "military installation" or what ever (see screen shot).

![screenshot-20151027-150622](https://cloud.githubusercontent.com/assets/619390/10819421/3b097bba-7e48-11e5-8e4e-4470d7c36ff4.png)
(I think the text doesn't fit on my 640x800 resolution, but you get the idea.)


## Table of levels

I used the system from Frontier as base mainly because it was (in my opinion) a well constructed system, and also it's what many/most of the pioneer players are used to, and how they expect it to work. So at tech level 12 all equipment is available except those with level "MILITARY" ("MIL" in table below), which are only available at tech level 11 stations. A bit quirky, that Military drive class 2 is only available at these military installations. Just like Frontier. I liked it, so I kept it like that.

```
| Equiptype             | Description                                | pioneer | frontier |
|                       |                                            |    tech |     tech |
|-----------------------+--------------------------------------------+---------+----------|
| MISSILE_UNGUIDED      | unguided rocket (MISSILE)                  |       1 |        - |
| MISSILE_GUIDED        | guided missile (MISSILE)                   |       5 |        5 |
| MISSILE_SMART         | smart missile (MISSILE)                    |      10 |       10 |
| MISSILE_NAVAL         | naval missile (MISSILE)                    |     MIL | 11 / MIL |
| ATMOSPHERIC_SHIELDING | atmospheric shielding (ATMOSHIELD)         |       3 |        3 |
| ECM_BASIC             | basic ECM system (ECM)                     |       9 |        9 |
| SCANNER               | scanner (SCANNER)                          |       3 |        4 |
| ECM_ADVANCED          | advanced ECM system (ECM)                  |     MIL | 11 / MIL |
| UNOCCUPIED_CABIN      | unoccupied passenger cabin (CABIN)         |       1 |        1 |
| PASSENGER_CABIN       | occupied passenger cabin (CABIN)           |       1 |        1 |
| SHIELD_GENERATOR      | shield generator (SHIELD)                  |       8 |        8 |
| LASER_COOLING_BOOSTER | laser cooling booster (LASERCOOLER)        |       8 |        8 |
| CARGO_LIFE_SUPPORT    | cargo bay life support (CARGOLIFESUPPORT)  |       2 |        2 |
| AUTOPILOT             | autopilot (AUTOPILOT)                      |       6 |        6 |
| RADAR_MAPPER          | radar mapper (RADARMAPPER)                 |       9 |        9 |
| ADVANCED RADAR_MAPPER | Advanced radar_mapper                      |      11 |        - |
| fuel_scoop            | fuel scoop (FUELSCOOP)                     |       4 |        4 |
| CARGO_SCOOP           | cargo scoop (CARGOSCOOP)                   |       5 |        5 |
| MULTI_SCOOP           | multi scoop                                |       9 |        - |
| HYPERCLOUD_ANALYZER   | hyperspace cloud analyser (HYPERCLOUD)     |      10 |       10 |
| HULL_AUTOREPAIR       | hull auto-repair system (HULLAUTOREPAIR)   |     MIL | 11 / MIL |
| SHIELD_ENERGY_BOOSTER | shield energy booster unit (ENERGYBOOSTER) |      11 |       11 |
| DRIVE_CLASS1          | class 1 hyperdrive (ENGINE)                |       3 |        5 |
| DRIVE_CLASS2          | class 2 hyperdrive (ENGINE)                |       4 |        7 |
| DRIVE_CLASS3          | class 3 hyperdrive (ENGINE)                |       4 |        9 |
| DRIVE_CLASS4          | class 4 hyperdrive (ENGINE)                |       5 |       10 |
| DRIVE_CLASS5          | class 5 hyperdrive (ENGINE)                |       5 |       12 |
| DRIVE_CLASS6          | class 6 hyperdrive (ENGINE)                |       6 |       12 |
| DRIVE_CLASS7          | class 7 hyperdrive (ENGINE)                |       8 |       12 |
| DRIVE_CLASS8          | class 8 hyperdrive (ENGINE)                |       9 |        - |
| DRIVE_CLASS9          | class 9 hyperdrive (ENGINE)                |      10 |        - |
| DRIVE_MIL1            | class 1 military drive (ENGINE)            |      10 |       11 |
| DRIVE_MIL2            | class 2 military drive (ENGINE)            |     MIL | 11 / MIL |
| DRIVE_MIL3            | class 3 military drive (ENGINE)            |      11 |       12 |
| DRIVE_MIL4            | class 4 military drive (ENGINE)            |      12 |        - |
| PULSECANNON_1MW       | 1MW pulse cannon (LASER)                   |       3 |        4 |
| PULSECANNON_DUAL_1MW  | 1MW dual-fire pulse cannon (LASER)         |       4 |        - |
| PULSECANNON_2MW       | 2MW pulse cannon (LASER)                   |       5 |        - |
| PULSECANNON_RAPID_2MW | 2MW rapid-fire pulse cannon (LASER)        |       5 |        - |
| PULSECANNON_4MW       | 4MW pulse cannon (LASER)                   |       6 |        5 |
| PULSECANNON_10MW      | 10MW pulse cannon (LASER)                  |       7 |        - |
| PULSECANNON_20MW      | 20MW pulse cannon (LASER)                  |     MIL | 11 / MIL |
| MININGCANNON_17MW     | 17MW blast-mining cannon (LASER)           |       8 |        8 |
| SMALL_PLASMA_ACCEL    | small plasma accelerator (LASER)           |      10 |       12 |
| LARGE_PLASMA_ACCEL    | large plasma accelerator (LASER)           |      12 |       12 |
| TRADE_ANALYZER        | Trade Computer                             |       9 |        - |
```


## Tech level distribution in Frontier

I don't know where I got the data for this from, but it shows that most stations in Frontier were just level 2 stations.

![histrogram](http://s16.postimg.org/o8w6z7pud/tech_hist_frontier.png)


## Tech level distribution in Pioneer

(I first thought a Poisson distribution would be fun (dashed line), but turns out the probability for stations above 8 was next to zero. Ideally, I'd like to make low tech level stations a bit more common. But this (full line) will do for now)
![tech_level](https://cloud.githubusercontent.com/assets/619390/10819364/dc0f02c4-7e47-11e5-8144-33cac3ef87e4.png)

Which is what you get when you add two independent random numbers from uniform (square) distribution of different width:

![convolution](https://upload.wikimedia.org/wikipedia/commons/6/6a/Convolution_of_box_signal_with_itself2.gif)


## Future

- With this addition, I think there's a strong need to be able to set tech level manually from custom scripts, so that tech level of say, Earth (London, etc.), is high. Or better: stations have a `size`, from which station model is selected, and this `size` also influences BBS adverts, tech_level, ship adverts, etc.

- Also, open question: is there some system wide tech level, that in some way guarantees the level of individual stations, like:
  1. minimum tech level?
  2. maximum tech level?
  3. highest techlevel found in system?

## FIN

- I'll clean up the branch, looks a bit weird atm, with commits from Andy (DONE).
- I'd like this to be merged with our BIG SAVE BUMP build together with #3485.