### PR TITLE
Compact Use Equip Widget

### DIFF
--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -535,7 +535,7 @@ void UseEquipWidget::UpdateEquip()
 	int numSlots = LuaObject<Ship>::CallMethod<int>(Pi::player, "GetEquipSlotCapacity", "missile");
 
 	if (numSlots) {
-		float spacing = 380.0f / numSlots;
+		const float spacing = Pi::IsScannerCompact() ? 16 : (380.0f / numSlots);
 		lua_pushnil(l);
 		while(lua_next(l, -2)) {
 			if (lua_type(l, -2) == LUA_TNUMBER) {
@@ -556,8 +556,10 @@ void UseEquipWidget::UpdateEquip()
 		Pi::player->Properties().Get("ecm_power_cap", ecm_power_cap);
 		if (ecm_power_cap > 0) {
 			Gui::ImageButton *b = 0;
-			if (ecm_power_cap == 3) b = new Gui::ImageButton("icons/ecm_basic.png");
-			else b = new Gui::ImageButton("icons/ecm_advanced.png");
+			if (ecm_power_cap == 3) 
+				b = new Gui::ImageButton("icons/ecm_basic.png");
+			else 
+				b = new Gui::ImageButton("icons/ecm_advanced.png");
 
 			// Note, FireECM() is a wrapper around Ship::UseECM() and is only used here
 			b->onClick.connect(sigc::ptr_fun(&FireECM));
@@ -568,34 +570,32 @@ void UseEquipWidget::UpdateEquip()
 	}
 
 	LuaObject<Ship>::CallMethod<LuaRef>(Pi::player, "GetEquip", "sensor").PushCopyToStack();
-	int numSensorSlots = LuaObject<Ship>::CallMethod<int>(Pi::player, "GetEquipSlotCapacity", "sensor");
+	const int numSensorSlots = LuaObject<Ship>::CallMethod<int>(Pi::player, "GetEquipSlotCapacity", "sensor");
 	if (numSensorSlots) {
-	float spacing = 32.0f ;
-	lua_pushnil(l);
-	while(lua_next(l, -2)) {
-		if (lua_type(l, -2) == LUA_TNUMBER) {
-			int i = lua_tointeger(l, -2);
-			LuaTable sensor(l, -1);
-			Gui::MultiStateImageButton *b = new Gui::MultiStateImageButton();
-			b->AddState(0, (std::string("icons/")+sensor.Get<std::string>("icon_off_name", "")+".png").c_str());
-			b->AddState(1, (std::string("icons/")+sensor.Get<std::string>("icon_on_name", "")+".png").c_str());
-			const std::string sensor_label = sensor.CallMethod<std::string>("GetName");
-			b->SetToolTip(sensor_label);
-			b->onClick.connect([i](Gui::MultiStateImageButton *button){
-				if (button->GetState() == 1) {
-					LuaObject<Ship>::CallMethod(Pi::player, "StartSensor", i);
-				} else {
-					LuaObject<Ship>::CallMethod(Pi::player, "StopSensor", i);
-				}
-			});
-			b->SetRenderDimensions(30.0f, 22.0f);
-			Add(b, spacing*i, 38.0f);
+		const float spacing = 32.0f ;
+		lua_pushnil(l);
+		while(lua_next(l, -2)) {
+			if (lua_type(l, -2) == LUA_TNUMBER) {
+				int i = lua_tointeger(l, -2);
+				LuaTable sensor(l, -1);
+				Gui::MultiStateImageButton *b = new Gui::MultiStateImageButton();
+				b->AddState(0, (std::string("icons/")+sensor.Get<std::string>("icon_off_name", "")+".png").c_str());
+				b->AddState(1, (std::string("icons/")+sensor.Get<std::string>("icon_on_name", "")+".png").c_str());
+				const std::string sensor_label = sensor.CallMethod<std::string>("GetName");
+				b->SetToolTip(sensor_label);
+				b->onClick.connect([i](Gui::MultiStateImageButton *button){
+					if (button->GetState() == 1) {
+						LuaObject<Ship>::CallMethod(Pi::player, "StartSensor", i);
+					} else {
+						LuaObject<Ship>::CallMethod(Pi::player, "StopSensor", i);
+					}
+				});
+				b->SetRenderDimensions(30.0f, 22.0f);
+				Add(b, spacing*i, 38.0f);
+			}
+			lua_pop(l, 1);
 		}
-		lua_pop(l, 1);
 	}
-}
-
-
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
Separate the missile icons by a fixed size if using the compact scanner for equally compact equip usage page.

Inspired by seeing how fulgy it currently is, also fixed some indentation.