### PR TITLE
Fix CargoRun stuffing.

### DIFF
--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -768,8 +768,10 @@ end
 local onShipDocked = function (player, station)
 	if not player:IsPlayer() then return end
 
+	-- First drop off cargo (if any such missions)
 	for ref,mission in pairs(missions) do
-		if (mission.location == station.path and not mission.pickup) or (mission.domicile == station.path and mission.pickup and mission.cargo_picked_up) then
+		if (mission.location == station.path and not mission.pickup) or
+			(mission.domicile == station.path and mission.pickup and mission.cargo_picked_up) then
 			local reputation = mission.localdelivery and 1 or 1.5
 			local oldReputation = Character.persistent.player.reputation
 			local amount = Game.player:RemoveEquip(mission.cargotype, mission.amount, "cargo")
@@ -804,7 +806,14 @@ local onShipDocked = function (player, station)
 			mission:Remove()
 			missions[ref] = nil
 
-		elseif mission.location == station.path and mission.pickup and not mission.cargo_picked_up then
+		elseif mission.status == "ACTIVE" and Game.time > mission.due then
+			mission.status = 'FAILED'
+		end
+	end
+
+	-- Now we have space pick up cargo as well
+	for ref,mission in pairs(missions) do
+		if mission.location == station.path and mission.pickup and not mission.cargo_picked_up then
 			if Game.player.freeCapacity < mission.amount then
 				Comms.ImportantMessage(l.YOU_DO_NOT_HAVE_ENOUGH_EMPTY_CARGO_SPACE, mission.client.name)
 			else
@@ -812,9 +821,6 @@ local onShipDocked = function (player, station)
 				mission.cargo_picked_up = true
 				Comms.ImportantMessage(l.WE_HAVE_LOADED_UP_THE_CARGO_ON_YOUR_SHIP, mission.client.name)
 			end
-
-		elseif mission.status == "ACTIVE" and Game.time > mission.due then
-			mission.status = 'FAILED'
 		end
 	end
 end


### PR DESCRIPTION
When landing first check what mission cargo should be unloaded,
before trying to load potential new mission cargo.

Should solve issue described at [SSC](http://spacesimcentral.com/ssc/topic/5282-announcement-big-update-adventurous-test-pilots-needed/#entry55869):

> 8. Almost forgot. It'd be nice if starports first unloaded all mission wares before attempting to load new ones. For example, if I'm due to pick up 5t of cargo on station A, but arrive there short a couple tonnes of space, they will say "come back when you have space". But I might be carrying mission cargo to that station A at the same time. So they unload me, cargo hold frees up, but now I have to undock/dock (and pay the fees again!) only to be able to load those 5t.

__NOTE:__ I have not tested this, other than in my head.