### PR TITLE
Direct buffer population

### DIFF
--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -37,16 +37,14 @@ void BaseSphere::OnChangeDetailLevel()
 	GeoSphere::OnChangeDetailLevel();
 }
 
-//static 
 void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
 	const matrix4x4d &modelView, const vector3d &campos, float rad,
 	Graphics::RenderState *rs, Graphics::Material *mat)
 {
-	const int LAT_SEGS = 20;
-	const int LONG_SEGS = 20;
-	vector3d yaxis = campos.Normalized();
-	vector3d zaxis = vector3d(1.0,0.0,0.0).Cross(yaxis).Normalized();
-	vector3d xaxis = yaxis.Cross(zaxis);
+	using namespace Graphics;
+	const vector3d yaxis = campos.Normalized();
+	const vector3d zaxis = vector3d(1.0, 0.0, 0.0).Cross(yaxis).Normalized();
+	const vector3d xaxis = yaxis.Cross(zaxis);
 	const matrix4x4d invrot = matrix4x4d::MakeRotMatrix(xaxis, yaxis, zaxis).Inverse();
 
 	renderer->SetTransform(modelView * matrix4x4d::ScaleMatrix(rad, rad, rad) * invrot);
@@ -55,40 +53,72 @@ void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
 	// acos(planetRadius/viewerDistFromSphereCentre)
 	// and angle from this tangent on to atmosphere is:
 	// acos(planetRadius/atmosphereRadius) ie acos(1.0/1.01244blah)
-	double endAng = acos(1.0/campos.Length())+acos(1.0/rad);
-	double latDiff = endAng / double(LAT_SEGS);
+	const double endAng = acos(1.0 / campos.Length()) + acos(1.0 / rad);
+	const double latDiff = endAng / double(LAT_SEGS);
 
 	double rot = 0.0;
-	float sinCosTable[LONG_SEGS+1][2];
-	for (int i=0; i<=LONG_SEGS; i++, rot += 2.0*M_PI/double(LONG_SEGS)) {
-		sinCosTable[i][0] = float(sin(rot));
-		sinCosTable[i][1] = float(cos(rot));
+	float sinTable[LONG_SEGS + 1];
+	float cosTable[LONG_SEGS + 1];
+	for (int i = 0; i <= LONG_SEGS; i++, rot += 2.0*M_PI / double(LONG_SEGS)) {
+		sinTable[i] = float(sin(rot));
+		cosTable[i] = float(cos(rot));
 	}
 
-	/* Tri-fan above viewer */
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION);
-	va.Add(vector3f(0.f, 1.f, 0.f));
-	for (int i=0; i<=LONG_SEGS; i++) {
-		va.Add(vector3f(
-			sin(latDiff)*sinCosTable[i][0],
+	// Tri-fan above viewer
+	if(!m_TriFanAbove.Valid())
+	{
+		// VertexBuffer
+		VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = ATTRIB_POSITION;
+		vbd.attrib[0].format = ATTRIB_FORMAT_FLOAT3;
+		vbd.numVertices = LONG_SEGS + 2;
+		vbd.usage = BUFFER_USAGE_STATIC;
+		m_TriFanAbove.Reset(renderer->CreateVertexBuffer(vbd));
+	}
+#pragma pack(push, 4)
+	struct PosVert {
+		vector3f pos;
+	};
+#pragma pack(pop)
+	PosVert* vtxPtr = m_TriFanAbove->Map<PosVert>(Graphics::BUFFER_MAP_WRITE);
+	vtxPtr[0].pos = vector3f(0.f, 1.f, 0.f);
+	for (int i = 0; i <= LONG_SEGS; i++)
+	{
+		vtxPtr[i + 1].pos = vector3f(
+			sin(latDiff)*sinTable[i],
 			cos(latDiff),
-			-sin(latDiff)*sinCosTable[i][1]));
+			-sin(latDiff)*cosTable[i]);
 	}
-	renderer->DrawTriangles(&va, rs, mat, Graphics::TRIANGLE_FAN);
+	m_TriFanAbove->Unmap();
+	renderer->DrawBuffer(m_TriFanAbove.Get(), rs, mat, Graphics::TRIANGLE_FAN);
 
-	/* and wound latitudinal strips */
+	// and wound latitudinal strips
+	if (!m_LatitudinalStrips[0].Valid())
+	{
+		VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = ATTRIB_POSITION;
+		vbd.attrib[0].format = ATTRIB_FORMAT_FLOAT3;
+		vbd.numVertices = (LONG_SEGS + 1) * 2;
+		vbd.usage = BUFFER_USAGE_DYNAMIC;
+		for (int j = 0; j < LAT_SEGS; j++) {
+			// VertexBuffer
+			m_LatitudinalStrips[j].Reset(renderer->CreateVertexBuffer(vbd));
+		}
+	}
 	double lat = latDiff;
 	for (int j=1; j<LAT_SEGS; j++, lat += latDiff) {
-		Graphics::VertexArray v(Graphics::ATTRIB_POSITION);
-		float cosLat = cos(lat);
-		float sinLat = sin(lat);
-		float cosLat2 = cos(lat+latDiff);
-		float sinLat2 = sin(lat+latDiff);
+		const float cosLat = cos(lat);
+		const float sinLat = sin(lat);
+		const float cosLat2 = cos(lat+latDiff);
+		const float sinLat2 = sin(lat+latDiff);
+		PosVert* vtxPtr = m_LatitudinalStrips[j]->Map<PosVert>(Graphics::BUFFER_MAP_WRITE);
+		vtxPtr[0].pos = vector3f(0.f, 1.f, 0.f);
 		for (int i=0; i<=LONG_SEGS; i++) {
-			v.Add(vector3f(sinLat*sinCosTable[i][0], cosLat, -sinLat*sinCosTable[i][1]));
-			v.Add(vector3f(sinLat2*sinCosTable[i][0], cosLat2, -sinLat2*sinCosTable[i][1]));
+			vtxPtr[(i*2)+0].pos = vector3f(sinLat*sinTable[i], cosLat, -sinLat*cosTable[i]);
+			vtxPtr[(i*2)+1].pos = vector3f(sinLat2*sinTable[i], cosLat2, -sinLat2*cosTable[i]);
 		}
-		renderer->DrawTriangles(&v, rs, mat, Graphics::TRIANGLE_STRIP);
+		m_LatitudinalStrips[j]->Unmap();
+		renderer->DrawBuffer(m_LatitudinalStrips[j].Get(), rs, mat, Graphics::TRIANGLE_STRIP);
 	}
 
 	renderer->GetStats().AddToStatCount(Graphics::Stats::STAT_ATMOSPHERES, 1);

--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -34,7 +34,8 @@ public:
 	static void Uninit();
 	static void UpdateAllBaseSphereDerivatives();
 	static void OnChangeDetailLevel();
-	static void DrawAtmosphereSurface(Graphics::Renderer *renderer,
+
+	void DrawAtmosphereSurface(Graphics::Renderer *renderer,
 		const matrix4x4d &modelView, const vector3d &campos, float rad,
 		Graphics::RenderState *rs, Graphics::Material *mat);
 
@@ -69,6 +70,12 @@ protected:
 	Graphics::RenderState *m_atmosRenderState;
 	std::unique_ptr<Graphics::Material> m_surfaceMaterial;
 	std::unique_ptr<Graphics::Material> m_atmosphereMaterial;
+
+	// atmosphere geometry
+	static const int LAT_SEGS = 20;
+	static const int LONG_SEGS = 20;
+	RefCountedPtr<Graphics::VertexBuffer> m_TriFanAbove;
+	RefCountedPtr<Graphics::VertexBuffer> m_LatitudinalStrips[LAT_SEGS];
 
 	//special parameters for shaders
 	MaterialParameters m_materialParameters;

--- a/src/scenegraph/Billboard.cpp
+++ b/src/scenegraph/Billboard.cpp
@@ -49,8 +49,6 @@ void Billboard::Render(const matrix4x4f &trans, const RenderData *rd)
 	PROFILE_SCOPED()
 	Graphics::Renderer *r = GetRenderer();
 
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0, 6);
-
 	const matrix3x3f rot = trans.GetOrient().Transpose();
 
 	//some hand-tweaked scaling, to make the lights seem larger from distance
@@ -58,14 +56,6 @@ void Billboard::Render(const matrix4x4f &trans, const RenderData *rd)
 
 	const vector3f rotv1 = rot * vector3f(size*0.5f, -size*0.5f, 0.0f);
 	const vector3f rotv2 = rot * vector3f(size*0.5f, size*0.5f, 0.0f);
-
-	va.Add(m_offset-rotv1, vector2f(0.f, 0.f)); //top left
-	va.Add(m_offset-rotv2, vector2f(0.f, 1.f)); //bottom left
-	va.Add(m_offset+rotv2, vector2f(1.f, 0.f)); //top right
-
-	va.Add(m_offset+rotv2, vector2f(1.f, 0.f)); //top right
-	va.Add(m_offset-rotv2, vector2f(0.f, 1.f)); //bottom left
-	va.Add(m_offset+rotv1, vector2f(1.f, 1.f)); //bottom right
 
 	if( !m_vbuffer.Valid() )
 	{
@@ -75,11 +65,25 @@ void Billboard::Render(const matrix4x4f &trans, const RenderData *rd)
 		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
 		vbd.attrib[1].semantic = Graphics::ATTRIB_UV0;
 		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
-		vbd.numVertices = va.GetNumVerts();
+		vbd.numVertices = 6;
 		vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;	// we could be updating this per-frame
 		m_vbuffer.Reset( r->CreateVertexBuffer(vbd) );
 	}
-	m_vbuffer->Populate( va );
+
+#pragma pack(push, 4)
+	struct PosUVVert {
+		vector3f pos;
+		vector2f uv;
+	};
+#pragma pack(pop)
+	PosUVVert* vtxPtr = m_vbuffer->Map<PosUVVert>(Graphics::BUFFER_MAP_WRITE);
+	vtxPtr[0].pos = (m_offset - rotv1); vtxPtr[0].uv = vector2f(0.f, 0.f); //top left
+	vtxPtr[1].pos = (m_offset - rotv2); vtxPtr[1].uv = vector2f(0.f, 1.f); //bottom left
+	vtxPtr[2].pos = (m_offset + rotv2); vtxPtr[2].uv = vector2f(1.f, 0.f); //top right
+	vtxPtr[3].pos = (m_offset + rotv2); vtxPtr[3].uv = vector2f(1.f, 0.f); //top right
+	vtxPtr[4].pos = (m_offset - rotv2); vtxPtr[4].uv = vector2f(0.f, 1.f); //bottom left
+	vtxPtr[5].pos = (m_offset + rotv1); vtxPtr[5].uv = vector2f(1.f, 1.f); //bottom right
+	m_vbuffer->Unmap();
 
 	r->SetTransform(trans);
 	r->DrawBuffer(m_vbuffer.Get(), m_renderState, m_material.Get());


### PR DESCRIPTION
There are a lot of places where we use the `VertexArray` class as an intermediary buffer whilst building the geometry that we wish to display. 

This is really helpful in some places, such as string buffers, however it can come with some downsides such as:
* Rendering requires `VertexBuffer` objects which must be created, populated, rendered & destroyed per-frame.
* Needless copying, we fill one buffer then copy it straight to another.
* Missed optimisation opportunities, there's a lot of places where we could be using `PointSprites` or other ways of grouping billboard type objects.

There's probably more too, some of these go through multiple stages which could be applied more directly and thus more efficiently.

So far I've identified this lot to change:
- [x] Atmosphere rendering
- [x] Billboard class

Andy