### PR TITLE
Normal Mapping for objects (ships, stations etc)

### DIFF
--- a/data/shaders/opengl/attributes.glsl
+++ b/data/shaders/opengl/attributes.glsl
@@ -31,8 +31,9 @@ layout (location = 0) in vec4 a_vertex;
 layout (location = 1) in vec3 a_normal;
 layout (location = 2) in vec4 a_color;
 layout (location = 3) in vec4 a_uv0;
-layout (location = 4) in mat4 a_transform;
-// shadows 5, 6, and 7
-// next available is layout (location = 8) 
+layout (location = 4) in vec3 a_tangent;
+layout (location = 5) in mat4 a_transform;
+// shadows 6, 7, and 8
+// next available is layout (location = 9) 
 
 #endif // VERTEX_SHADER

--- a/data/shaders/opengl/multi.frag
+++ b/data/shaders/opengl/multi.frag
@@ -12,6 +12,7 @@ uniform sampler2D texture2; //glow
 uniform sampler2D texture3; //ambient
 uniform sampler2D texture4; //pattern
 uniform sampler2D texture5; //color
+uniform sampler2D texture6; //normal
 in vec2 texCoord0;
 #endif
 
@@ -21,11 +22,15 @@ in vec4 vertexColor;
 #if (NUM_LIGHTS > 0)
 in vec3 eyePos;
 in vec3 normal;
-	#ifdef HEAT_COLOURING
-		uniform sampler2D heatGradient;
-		uniform float heatingAmount; // 0.0 to 1.0 used for `u` component of heatGradient texture
-		in vec3 heatingDir;
-	#endif // HEAT_COLOURING
+#ifdef MAP_NORMAL
+	in vec3 tangent;
+	in vec3 bitangent;
+#endif
+#ifdef HEAT_COLOURING
+	uniform sampler2D heatGradient;
+	uniform float heatingAmount; // 0.0 to 1.0 used for `u` component of heatGradient texture
+	in vec3 heatingDir;
+#endif // HEAT_COLOURING
 #endif // (NUM_LIGHTS > 0)
 
 uniform Scene scene;
@@ -77,11 +82,18 @@ void main(void)
 
 //directional lighting
 #if (NUM_LIGHTS > 0)
+#ifdef MAP_NORMAL
+	vec3 bump = (texture2D(texture6, texCoord0).xyz * 2.0) - vec3(1.0);
+	mat3 tangentFrame = mat3(tangent, bitangent, normal);
+	vec3 vNormal = tangentFrame * bump;
+#else
+	vec3 vNormal = normal;
+#endif
 	//ambient only make sense with lighting
 	vec4 light = scene.ambient;
 	vec4 specular = vec4(0.0);
 	for (int i=0; i<NUM_LIGHTS; ++i) {
-		ads(i, eyePos, normal, light, specular);
+		ads(i, eyePos, vNormal, light, specular);
 	}
 
 #ifdef MAP_AMBIENT
@@ -102,7 +114,7 @@ void main(void)
 	#ifdef HEAT_COLOURING
 		if (heatingAmount > 0.0)
 		{
-			float dphNn = clamp(dot(heatingDir, normal), 0.0, 1.0);
+			float dphNn = clamp(dot(heatingDir, vNormal), 0.0, 1.0);
 			float heatDot = heatingAmount * (dphNn * dphNn * dphNn);
 			vec4 heatColour = texture(heatGradient, vec2(heatDot, 0.5)); //heat gradient blend
 			frag_color = color * light + specular;

--- a/data/shaders/opengl/multi.vert
+++ b/data/shaders/opengl/multi.vert
@@ -16,11 +16,15 @@ out vec4 vertexColor;
 #if (NUM_LIGHTS > 0)
 out vec3 eyePos;
 out vec3 normal;
-	#ifdef HEAT_COLOURING
-		uniform mat3 heatingMatrix;
-		uniform vec3 heatingNormal; // normalised
-		out vec3 heatingDir;
-	#endif // HEAT_COLOURING
+#ifdef MAP_NORMAL
+	out vec3 tangent;
+	out vec3 bitangent;
+#endif
+#ifdef HEAT_COLOURING
+	uniform mat3 heatingMatrix;
+	uniform vec3 heatingNormal; // normalised
+	out vec3 heatingDir;
+#endif // HEAT_COLOURING
 #endif
 
 void main(void)
@@ -40,9 +44,17 @@ void main(void)
 	eyePos = vec3(uViewMatrix * a_vertex);
 	normal = normalize(uNormalMatrix * a_normal);
 #endif
-	
-	//mat3 mn = mat3(transpose(inverse(uViewMatrix)));
-	//normal = normalize(mn * a_normal);
+
+#ifdef MAP_NORMAL
+#ifdef USE_INSTANCING
+	tangent = uNormalMatrix * (mat3(a_transform) * a_tangent);
+	bitangent = uNormalMatrix * (mat3(a_transform) * cross(a_normal, a_tangent));
+#else
+	tangent = uNormalMatrix * a_tangent;
+	bitangent = uNormalMatrix * cross(a_normal, a_tangent);
+#endif
+#endif
+
 #ifdef HEAT_COLOURING
 	heatingDir = normalize(heatingMatrix * heatingNormal);
 #endif

--- a/data/shaders/opengl/multi.vert
+++ b/data/shaders/opengl/multi.vert
@@ -40,19 +40,17 @@ void main(void)
 #ifdef USE_INSTANCING
 	eyePos = vec3(uViewMatrix * (a_transform * a_vertex));
 	normal = normalize(uNormalMatrix * (mat3(a_transform) * a_normal));
+	#ifdef MAP_NORMAL
+		tangent = uNormalMatrix * (mat3(a_transform) * a_tangent);
+		bitangent = uNormalMatrix * (mat3(a_transform) * cross(a_normal, a_tangent));
+	#endif
 #else
 	eyePos = vec3(uViewMatrix * a_vertex);
 	normal = normalize(uNormalMatrix * a_normal);
-#endif
-
-#ifdef MAP_NORMAL
-#ifdef USE_INSTANCING
-	tangent = uNormalMatrix * (mat3(a_transform) * a_tangent);
-	bitangent = uNormalMatrix * (mat3(a_transform) * cross(a_normal, a_tangent));
-#else
-	tangent = uNormalMatrix * a_tangent;
-	bitangent = uNormalMatrix * cross(a_normal, a_tangent);
-#endif
+	#ifdef MAP_NORMAL
+		tangent = uNormalMatrix * a_tangent;
+		bitangent = uNormalMatrix * cross(a_normal, a_tangent);
+	#endif
 #endif
 
 #ifdef HEAT_COLOURING

--- a/src/graphics/Material.cpp
+++ b/src/graphics/Material.cpp
@@ -12,6 +12,7 @@ Material::Material() :
 	texture3(nullptr),
 	texture4(nullptr),
 	texture5(nullptr),
+	texture6(nullptr),
 	heatGradient(nullptr),
 	diffuse(Color::WHITE),
 	specular(Color::BLACK),
@@ -27,6 +28,7 @@ MaterialDescriptor::MaterialDescriptor()
 , glowMap(false)
 , ambientMap(false)
 , lighting(false)
+, normalMap(false)
 , specularMap(false)
 , usePatterns(false)
 , vertexColors(false)
@@ -45,6 +47,7 @@ bool operator==(const MaterialDescriptor &a, const MaterialDescriptor &b)
 		a.glowMap == b.glowMap &&
 		a.ambientMap == b.ambientMap &&
 		a.lighting == b.lighting &&
+		a.normalMap == b.normalMap &&
 		a.specularMap == b.specularMap &&
 		a.usePatterns == b.usePatterns &&
 		a.vertexColors == b.vertexColors &&

--- a/src/graphics/Material.h
+++ b/src/graphics/Material.h
@@ -60,6 +60,7 @@ public:
 	bool glowMap;
 	bool ambientMap;
 	bool lighting;
+	bool normalMap;
 	bool specularMap;
 	bool usePatterns; //pattern/color system
 	bool vertexColors;
@@ -85,6 +86,7 @@ public:
 	Texture *texture3;
 	Texture *texture4;
 	Texture *texture5;
+	Texture *texture6;
 	Texture *heatGradient;
 
 	Color diffuse;

--- a/src/graphics/Types.h
+++ b/src/graphics/Types.h
@@ -15,7 +15,7 @@ enum VertexAttrib {
 	ATTRIB_DIFFUSE   = (1u << 2),
 	ATTRIB_UV0       = (1u << 3),
 	//ATTRIB_UV1       = (1u << 4),
-	//ATTRIB_TANGENT   = (1u << 5),
+	ATTRIB_TANGENT   = (1u << 5),
 	//ATTRIB_BITANGENT = (1u << 6)
 	//etc.
 };

--- a/src/graphics/VertexArray.cpp
+++ b/src/graphics/VertexArray.cpp
@@ -20,6 +20,8 @@ VertexArray::VertexArray(AttributeSet attribs, int size)
 			normal.reserve(size);
 		if (attribs & ATTRIB_UV0)
 			uv0.reserve(size);
+		if (attribs & ATTRIB_TANGENT)
+			tangent.reserve(size);
 	}
 }
 
@@ -44,6 +46,7 @@ void VertexArray::Clear()
 	diffuse.clear();
 	normal.clear();
 	uv0.clear();
+	tangent.clear();
 }
 
 void VertexArray::Add(const vector3f &v)
@@ -84,6 +87,14 @@ void VertexArray::Add(const vector3f &v, const vector3f &n, const vector2f &uv)
 	uv0.push_back(uv);
 }
 
+void VertexArray::Add(const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang)
+{
+	position.push_back(v);
+	normal.push_back(n);
+	uv0.push_back(uv);
+	tangent.push_back(tang);
+}
+
 void VertexArray::Set(const Uint32 idx, const vector3f &v)
 {
 	position[idx] = v;
@@ -120,6 +131,14 @@ void VertexArray::Set(const Uint32 idx, const vector3f &v, const vector3f &n, co
 	position[idx] = v;
 	normal[idx] = n;
 	uv0[idx] = uv;
+}
+
+void VertexArray::Set(const Uint32 idx, const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang)
+{
+	position[idx] = v;
+	normal[idx] = n;
+	uv0[idx] = uv;
+	tangent[idx] = tang;
 }
 
 }

--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -41,6 +41,7 @@ public:
 	void Add(const vector3f &v, const Color &c, const vector2f &uv);
 	void Add(const vector3f &v, const vector2f &uv);
 	void Add(const vector3f &v, const vector3f &normal, const vector2f &uv);
+	void Add(const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang);
 	//virtual void Reserve(unsigned int howmuch)
 
 	// don't mix these
@@ -50,13 +51,15 @@ public:
 	void Set(const Uint32 idx, const vector3f &v, const Color &c, const vector2f &uv);
 	void Set(const Uint32 idx, const vector3f &v, const vector2f &uv);
 	void Set(const Uint32 idx, const vector3f &v, const vector3f &normal, const vector2f &uv);
+	void Set(const Uint32 idx, const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang);
 
 	//could make these private, but it is nice to be able to
 	//add attributes separately...
-	std::vector<vector3f> position;
-	std::vector<vector3f> normal;
-	std::vector<Color> diffuse;
-	std::vector<vector2f> uv0;
+	std::vector<vector3f>	position;
+	std::vector<vector3f>	normal;
+	std::vector<Color>		diffuse;
+	std::vector<vector2f>	uv0;
+	std::vector<vector3f>	tangent;
 
 private:
 	AttributeSet m_attribs;

--- a/src/graphics/opengl/MultiMaterial.cpp
+++ b/src/graphics/opengl/MultiMaterial.cpp
@@ -30,7 +30,8 @@ MultiProgram::MultiProgram(const MaterialDescriptor &desc, int numLights)
 		ss << stringf("#define NUM_LIGHTS %0{d}\n", numLights);
 	else
 		ss << "#define NUM_LIGHTS 0\n";
-
+	if (desc.normalMap && desc.lighting && numLights > 0)
+		ss << "#define MAP_NORMAL\n";
 	if (desc.specularMap)
 		ss << "#define MAP_SPECULAR\n";
 	if (desc.glowMap)
@@ -41,7 +42,6 @@ MultiProgram::MultiProgram(const MaterialDescriptor &desc, int numLights)
 		ss << "#define MAP_COLOR\n";
 	if (desc.quality & HAS_HEAT_GRADIENT)
 		ss << "#define HEAT_COLOURING\n";
-	
 	if (desc.instanced) 
 		ss << "#define USE_INSTANCING\n";
 
@@ -89,8 +89,9 @@ void MultiMaterial::Apply()
 	p->texture3.Set(this->texture3, 3);
 	p->texture4.Set(this->texture4, 4);
 	p->texture5.Set(this->texture5, 5);
+	p->texture6.Set(this->texture6, 6);
 
-	p->heatGradient.Set(this->heatGradient, 6);
+	p->heatGradient.Set(this->heatGradient, 7);
 	if(nullptr!=specialParameter0) {
 		HeatGradientParameters_t *pMGP = static_cast<HeatGradientParameters_t*>(specialParameter0);
 		p->heatingMatrix.Set(pMGP->heatingMatrix);
@@ -139,6 +140,10 @@ void MultiMaterial::Unapply()
 	// Might not be necessary to unbind textures, but let's not old graphics code (eg, old-UI)
 	if (heatGradient) {
 		static_cast<TextureGL*>(heatGradient)->Unbind();
+		glActiveTexture(GL_TEXTURE6);
+	}
+	if (texture6) {
+		static_cast<TextureGL*>(texture6)->Unbind();
 		glActiveTexture(GL_TEXTURE5);
 	}
 	if (texture5) {

--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -301,6 +301,7 @@ void Program::InitUniforms()
 	texture3.Init("texture3", m_program);
 	texture4.Init("texture4", m_program);
 	texture5.Init("texture5", m_program);
+	texture6.Init("texture6", m_program);
 	heatGradient.Init("heatGradient", m_program);
 	heatingMatrix.Init("heatingMatrix", m_program);
 	heatingNormal.Init("heatingNormal", m_program);

--- a/src/graphics/opengl/Program.h
+++ b/src/graphics/opengl/Program.h
@@ -45,6 +45,7 @@ namespace Graphics {
 			Uniform texture3;
 			Uniform texture4;
 			Uniform texture5;
+			Uniform texture6;
 			Uniform heatGradient;
 			Uniform heatingMatrix;
 			Uniform heatingNormal;

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -530,6 +530,11 @@ bool RendererOGL::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 		vbd.attrib[attribIdx].format	= ATTRIB_FORMAT_FLOAT2;
 		++attribIdx;
 	}
+	if (v->HasAttrib(ATTRIB_TANGENT)) {
+		vbd.attrib[attribIdx].semantic = ATTRIB_TANGENT;
+		vbd.attrib[attribIdx].format = ATTRIB_FORMAT_FLOAT3;
+		++attribIdx;
+	}
 	vbd.numVertices = v->position.size();
 	vbd.usage = BUFFER_USAGE_STATIC;
 	

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -101,6 +101,10 @@ VertexBuffer::VertexBuffer(const VertexBufferDesc &desc) :
 			glEnableVertexAttribArray(3);	// Enable the attribute at that location
 			glVertexAttribPointer(3, get_num_components(attr.format), get_component_type(attr.format), GL_FALSE, m_desc.stride, offset);
 			break;
+		case ATTRIB_TANGENT:
+			glEnableVertexAttribArray(4);	// Enable the attribute at that location
+			glVertexAttribPointer(4, get_num_components(attr.format), get_component_type(attr.format), GL_FALSE, m_desc.stride, offset);
+			break;
 		case ATTRIB_NONE:
 		default:
 			break;
@@ -278,6 +282,7 @@ void VertexBuffer::Bind() {
 		case ATTRIB_NORMAL:			glEnableVertexAttribArray(1);		break;
 		case ATTRIB_DIFFUSE:		glEnableVertexAttribArray(2);		break;
 		case ATTRIB_UV0:			glEnableVertexAttribArray(3);		break;
+		case ATTRIB_TANGENT:		glEnableVertexAttribArray(4);		break;
 		case ATTRIB_NONE:
 		default:
 			return;
@@ -290,10 +295,11 @@ void VertexBuffer::Release() {
 	for (Uint8 i = 0; i < MAX_ATTRIBS; i++) {
 		const auto& attr = m_desc.attrib[i];
 		switch (attr.semantic) {
-		case ATTRIB_POSITION:		glDisableVertexAttribArray(0);			break;
-		case ATTRIB_NORMAL:			glDisableVertexAttribArray(1);			break;
-		case ATTRIB_DIFFUSE:		glDisableVertexAttribArray(2);			break;
-		case ATTRIB_UV0:			glDisableVertexAttribArray(3);			break;
+		case ATTRIB_POSITION:		glDisableVertexAttribArray(0);		break;
+		case ATTRIB_NORMAL:			glDisableVertexAttribArray(1);		break;
+		case ATTRIB_DIFFUSE:		glDisableVertexAttribArray(2);		break;
+		case ATTRIB_UV0:			glDisableVertexAttribArray(3);		break;
+		case ATTRIB_TANGENT:		glDisableVertexAttribArray(4);		break;
 		case ATTRIB_NONE:
 		default:
 			return;

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -442,27 +442,27 @@ void InstanceBuffer::Bind() {
 
 	// used to pass a matrix4x4f in, however each attrib array is max size of (GLSL) vec4 so must enable 4 arrays
 	const size_t sizeVec4 = (sizeof(float)*4);
-	glEnableVertexAttribArray(4);
-	glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, 4 * sizeVec4, reinterpret_cast<const GLvoid*>(0));
-	glEnableVertexAttribArray(5);
-	glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, 4 * sizeVec4, reinterpret_cast<const GLvoid*>(sizeVec4));
-	glEnableVertexAttribArray(6);
-	glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, 4 * sizeVec4, reinterpret_cast<const GLvoid*>(2 * sizeVec4));
-	glEnableVertexAttribArray(7);
-	glVertexAttribPointer(7, 4, GL_FLOAT, GL_FALSE, 4 * sizeVec4, reinterpret_cast<const GLvoid*>(3 * sizeVec4));
+	glEnableVertexAttribArray(INSTOFFS_MAT0);
+	glVertexAttribPointer(INSTOFFS_MAT0, 4, GL_FLOAT, GL_FALSE, 4 * sizeVec4, reinterpret_cast<const GLvoid*>(0));
+	glEnableVertexAttribArray(INSTOFFS_MAT1);
+	glVertexAttribPointer(INSTOFFS_MAT1, 4, GL_FLOAT, GL_FALSE, 4 * sizeVec4, reinterpret_cast<const GLvoid*>(sizeVec4));
+	glEnableVertexAttribArray(INSTOFFS_MAT2);
+	glVertexAttribPointer(INSTOFFS_MAT2, 4, GL_FLOAT, GL_FALSE, 4 * sizeVec4, reinterpret_cast<const GLvoid*>(2 * sizeVec4));
+	glEnableVertexAttribArray(INSTOFFS_MAT3);
+	glVertexAttribPointer(INSTOFFS_MAT3, 4, GL_FLOAT, GL_FALSE, 4 * sizeVec4, reinterpret_cast<const GLvoid*>(3 * sizeVec4));
 
-	glVertexAttribDivisor(4, 1);
-	glVertexAttribDivisor(5, 1);
-	glVertexAttribDivisor(6, 1);
-	glVertexAttribDivisor(7, 1);
+	glVertexAttribDivisor(INSTOFFS_MAT0, 1);
+	glVertexAttribDivisor(INSTOFFS_MAT1, 1);
+	glVertexAttribDivisor(INSTOFFS_MAT2, 1);
+	glVertexAttribDivisor(INSTOFFS_MAT3, 1);
 }
 
 void InstanceBuffer::Release() {
 	// see enable comment above
-	glDisableVertexAttribArray(4);
-	glDisableVertexAttribArray(5);
-	glDisableVertexAttribArray(6);
-	glDisableVertexAttribArray(7);
+	glDisableVertexAttribArray(INSTOFFS_MAT0);
+	glDisableVertexAttribArray(INSTOFFS_MAT1);
+	glDisableVertexAttribArray(INSTOFFS_MAT2);
+	glDisableVertexAttribArray(INSTOFFS_MAT3);
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -63,6 +63,12 @@ public:
 	virtual void Release() override;
 
 protected:
+	enum InstOffs {
+		INSTOFFS_MAT0 = 5, // these value must match those of a_transform within data/shaders/opengl/attributes.glsl
+		INSTOFFS_MAT1 = 6,
+		INSTOFFS_MAT2 = 7,
+		INSTOFFS_MAT3 = 8
+	};
 	std::unique_ptr<matrix4x4f> m_data;
 };
 

--- a/src/scenegraph/BaseLoader.cpp
+++ b/src/scenegraph/BaseLoader.cpp
@@ -23,6 +23,7 @@ void BaseLoader::ConvertMaterialDefinition(const MaterialDefinition &mdef)
 	const std::string &specTex = mdef.tex_spec;
 	const std::string &glowTex = mdef.tex_glow;
 	const std::string &ambiTex = mdef.tex_ambi;
+	const std::string &normTex = mdef.tex_norm;
 
 	Graphics::MaterialDescriptor matDesc;
 	matDesc.lighting = !mdef.unlit;
@@ -35,6 +36,7 @@ void BaseLoader::ConvertMaterialDefinition(const MaterialDefinition &mdef)
 	matDesc.specularMap = !specTex.empty();
 	matDesc.glowMap = !glowTex.empty();
 	matDesc.ambientMap = !ambiTex.empty();
+	matDesc.normalMap = !normTex.empty();
 	matDesc.quality = Graphics::HAS_HEAT_GRADIENT;
 
 	//Create material and set parameters
@@ -60,9 +62,11 @@ void BaseLoader::ConvertMaterialDefinition(const MaterialDefinition &mdef)
 		mat->texture2 = Graphics::TextureBuilder::Model(glowTex).GetOrCreateTexture(m_renderer, "model");
 	if (!ambiTex.empty())
 		mat->texture3 = Graphics::TextureBuilder::Model(ambiTex).GetOrCreateTexture(m_renderer, "model");
-	
 	//texture4 is reserved for pattern
 	//texture5 is reserved for color gradient
+	if (!normTex.empty())
+		mat->texture6 = Graphics::TextureBuilder::Model(normTex).GetOrCreateTexture(m_renderer, "model");
+	
 
 	m_model->m_materials.push_back(std::make_pair(mdef.name, mat));
 }

--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -17,7 +17,13 @@ using namespace SceneGraph;
 // 2: converted StaticMesh to VertexBuffer
 // 3: store processed collision mesh
 // 4: compressed SGM files and instancing support
-const Uint32 SGM_VERSION = 4;
+// 5: normal mapping
+const Uint32 SGM_VERSION = 5;
+union SGM_STRING_VALUE{
+	char name[4];
+	Uint32 value;
+};
+const SGM_STRING_VALUE SGM_STRING_ID = { 's', 'g', 'm', SGM_VERSION };
 const std::string SGM_EXTENSION = ".sgm";
 const std::string SAVE_TARGET_DIR = "binarymodels";
 
@@ -101,10 +107,7 @@ void BinaryConverter::Save(const std::string& filename, const std::string& savep
 
 	Serializer::Writer wr;
 
-	wr.Byte('S');
-	wr.Byte('G');
-	wr.Byte('M');
-	wr.Byte('4');
+	wr.Int32(SGM_STRING_ID.value);
 
 	wr.Int32(SGM_VERSION);
 
@@ -192,7 +195,7 @@ Model *BinaryConverter::CreateModel(Serializer::Reader &rd)
 {
 	//verify signature
 	const Uint32 sig = rd.Int32();
-	if (sig != 0x344D4753) //'SGM4'
+	if (sig != SGM_STRING_ID.value) //'SGM#'
 		throw LoadingError("Not a binary model file");
 
 	const Uint32 version = rd.Int32();

--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -237,6 +237,8 @@ void BinaryConverter::SaveMaterials(Serializer::Writer& wr, Model* model)
 		wr.String(m.tex_diff);
 		wr.String(m.tex_spec);
 		wr.String(m.tex_glow);
+		wr.String(m.tex_ambi);
+		wr.String(m.tex_norm);
 		wr.Color4UB(m.diffuse);
 		wr.Color4UB(m.specular);
 		wr.Color4UB(m.ambient);
@@ -257,6 +259,8 @@ void BinaryConverter::LoadMaterials(Serializer::Reader &rd)
 		m.tex_diff = rd.String();
 		m.tex_spec = rd.String();
 		m.tex_glow = rd.String();
+		m.tex_ambi = rd.String();
+		m.tex_norm = rd.String();
 		m.diffuse = rd.Color4UB();
 		m.specular = rd.Color4UB();
 		m.ambient = rd.Color4UB();

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -332,6 +332,7 @@ RefCountedPtr<Node> Loader::LoadMesh(const std::string &filename, const AnimList
 		aiProcess_GenUVCoords		|
 		aiProcess_FlipUVs			|
 		aiProcess_SplitLargeMeshes	|
+		aiProcess_CalcTangentSpace	|
 		aiProcess_GenSmoothNormals);  //only if normals not specified
 
 	if(!scene)
@@ -419,6 +420,13 @@ struct ModelVtx {
 	vector3f nrm;
 	vector2f uv0;
 };
+
+struct ModelTangentVtx {
+	vector3f pos;
+	vector3f nrm;
+	vector2f uv0;
+	vector3f tangent;
+};
 #pragma pack(pop)
 
 void Loader::ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry> > &geoms, const aiScene *scene)
@@ -438,7 +446,11 @@ void Loader::ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry> > &geoms,
 		geom->SetName(stringf("sgMesh%0{u}", i));
 
 		const bool hasUVs = mesh->HasTextureCoords(0);
-		if (!hasUVs) AddLog(stringf("%0: missing UV coordinates", m_curMeshDef));
+		const bool hasTangents = mesh->HasTangentsAndBitangents();
+		if (!hasUVs) 
+			AddLog(stringf("%0: missing UV coordinates", m_curMeshDef));
+		if (!hasTangents) 
+			AddLog(stringf("%0: missing Tangents and Bitangents coordinates", m_curMeshDef));
 		//sadly, aimesh name is usually empty so no help for logging
 
 		//Material names are not consistent throughout formats.
@@ -471,14 +483,19 @@ void Loader::ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry> > &geoms,
 		Graphics::VertexBufferDesc vbd;
 		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
 		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
-		vbd.attrib[0].offset   = offsetof(ModelVtx, pos);
+		vbd.attrib[0].offset   = hasTangents ? offsetof(ModelTangentVtx, pos) : offsetof(ModelVtx, pos);
 		vbd.attrib[1].semantic = Graphics::ATTRIB_NORMAL;
 		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
-		vbd.attrib[1].offset   = offsetof(ModelVtx, nrm);
+		vbd.attrib[1].offset   = hasTangents ? offsetof(ModelTangentVtx, nrm) : offsetof(ModelVtx, nrm);
 		vbd.attrib[2].semantic = Graphics::ATTRIB_UV0;
 		vbd.attrib[2].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
-		vbd.attrib[2].offset   = offsetof(ModelVtx, uv0);
-		vbd.stride = sizeof(ModelVtx);
+		vbd.attrib[2].offset   = hasTangents ? offsetof(ModelTangentVtx, uv0) : offsetof(ModelVtx, uv0);
+		if (hasTangents) {
+			vbd.attrib[3].semantic = Graphics::ATTRIB_TANGENT;
+			vbd.attrib[3].format = Graphics::ATTRIB_FORMAT_FLOAT3;
+			vbd.attrib[3].offset = offsetof(ModelTangentVtx, tangent);
+		}
+		vbd.stride = hasTangents ? sizeof(ModelTangentVtx) : sizeof(ModelVtx);
 		vbd.numVertices = mesh->mNumVertices;
 		vbd.usage = Graphics::BUFFER_USAGE_STATIC;
 
@@ -514,20 +531,42 @@ void Loader::ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry> > &geoms,
 
 		//copy vertices, always assume normals
 		//replace nonexistent UVs with zeros
-		ModelVtx *vtxPtr = vb->Map<ModelVtx>(Graphics::BUFFER_MAP_WRITE);
-		for (unsigned int v = 0; v < mesh->mNumVertices; v++) {
-			const aiVector3D &vtx = mesh->mVertices[v];
-			const aiVector3D &norm = mesh->mNormals[v];
-			const aiVector3D &uv0 = hasUVs ? mesh->mTextureCoords[0][v] : aiVector3D(0.f);
-			vtxPtr[v].pos = vector3f(vtx.x, vtx.y, vtx.z);
-			vtxPtr[v].nrm = vector3f(norm.x, norm.y, norm.z);
-			vtxPtr[v].uv0 = vector2f(uv0.x, uv0.y);
+		if (!hasTangents)
+		{
+			ModelVtx *vtxPtr = vb->Map<ModelVtx>(Graphics::BUFFER_MAP_WRITE);
+			for (unsigned int v = 0; v < mesh->mNumVertices; v++) {
+				const aiVector3D &vtx = mesh->mVertices[v];
+				const aiVector3D &norm = mesh->mNormals[v];
+				const aiVector3D &uv0 = hasUVs ? mesh->mTextureCoords[0][v] : aiVector3D(0.f);
+				vtxPtr[v].pos = vector3f(vtx.x, vtx.y, vtx.z);
+				vtxPtr[v].nrm = vector3f(norm.x, norm.y, norm.z);
+				vtxPtr[v].uv0 = vector2f(uv0.x, uv0.y);
 
-			//update bounding box
-			//untransformed points, collision visitor will transform
-			geom->m_boundingBox.Update(vtx.x, vtx.y, vtx.z);
+				//update bounding box
+				//untransformed points, collision visitor will transform
+				geom->m_boundingBox.Update(vtx.x, vtx.y, vtx.z);
+			}
+			vb->Unmap();
 		}
-		vb->Unmap();
+		else
+		{
+			ModelTangentVtx *vtxPtr = vb->Map<ModelTangentVtx>(Graphics::BUFFER_MAP_WRITE);
+			for (unsigned int v = 0; v < mesh->mNumVertices; v++) {
+				const aiVector3D &vtx = mesh->mVertices[v];
+				const aiVector3D &norm = mesh->mNormals[v];
+				const aiVector3D &uv0 = hasUVs ? mesh->mTextureCoords[0][v] : aiVector3D(0.f);
+				const aiVector3D &tangents = mesh->mTangents[v];
+				vtxPtr[v].pos = vector3f(vtx.x, vtx.y, vtx.z);
+				vtxPtr[v].nrm = vector3f(norm.x, norm.y, norm.z);
+				vtxPtr[v].uv0 = vector2f(uv0.x, uv0.y);
+				vtxPtr[v].tangent = vector3f(tangents.x, tangents.y, tangents.z);
+				
+				//update bounding box
+				//untransformed points, collision visitor will transform
+				geom->m_boundingBox.Update(vtx.x, vtx.y, vtx.z);
+			}
+			vb->Unmap();
+		}
 
 		geom->AddMesh(vb, ib, mat);
 

--- a/src/scenegraph/LoaderDefinitions.h
+++ b/src/scenegraph/LoaderDefinitions.h
@@ -16,6 +16,7 @@ struct MaterialDefinition {
 		tex_spec(""),
 		tex_glow(""),
 		tex_ambi(""),
+		tex_norm(""),
 		diffuse(Color(255)),
 		specular(Color(255)),
 		ambient(Color(0)),
@@ -31,6 +32,7 @@ struct MaterialDefinition {
 	std::string tex_spec;
 	std::string tex_glow;
 	std::string tex_ambi;
+	std::string tex_norm;
 	Color diffuse;
 	Color specular;
 	Color ambient;

--- a/src/scenegraph/Parser.cpp
+++ b/src/scenegraph/Parser.cpp
@@ -185,6 +185,8 @@ bool Parser::parseLine(const std::string &line)
 					return checkTexture(ss, m_curMat->tex_glow);
 				else if (match(token, "tex_ambi"))
 					return checkTexture(ss, m_curMat->tex_ambi);
+				else if (match(token, "tex_norm"))
+					return checkTexture(ss, m_curMat->tex_norm);
 				else if (match(token, "diffuse"))
 					return checkColor(ss, m_curMat->diffuse);
 				else if (match(token, "specular"))

--- a/src/scenegraph/StaticGeometry.cpp
+++ b/src/scenegraph/StaticGeometry.cpp
@@ -133,6 +133,7 @@ void StaticGeometry::Save(NodeDatabase &db)
 		const Uint32 posOffset = vbDesc.GetOffset(Graphics::ATTRIB_POSITION);
 		const Uint32 nrmOffset = vbDesc.GetOffset(Graphics::ATTRIB_NORMAL);
 		const Uint32 uv0Offset = vbDesc.GetOffset(Graphics::ATTRIB_UV0);
+		const Uint32 tanOffset = vbDesc.GetOffset(Graphics::ATTRIB_TANGENT);
 		const Uint32 stride    = vbDesc.stride;
 		db.wr->Int32(vbDesc.numVertices);
 		Uint8 *vtxPtr = mesh.vertexBuffer->Map<Uint8>(Graphics::BUFFER_MAP_READ);
@@ -141,6 +142,7 @@ void StaticGeometry::Save(NodeDatabase &db)
             db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + nrmOffset));
             db.wr->Float(reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset)->x);
             db.wr->Float(reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset)->y);
+			db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + tanOffset));
 		}
 		mesh.vertexBuffer->Unmap();
 
@@ -183,7 +185,7 @@ StaticGeometry *StaticGeometry::Load(NodeDatabase &db)
 
 		//vertex format check
 		const Uint32 vtxFormat = db.rd->Int32();
-		if (vtxFormat != (ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0))
+		if (vtxFormat != (ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0 | ATTRIB_TANGENT))
 			throw LoadingError("Unsupported vertex format");
 
 		//vertex buffer
@@ -194,6 +196,8 @@ StaticGeometry *StaticGeometry::Load(NodeDatabase &db)
 		vbDesc.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
 		vbDesc.attrib[2].semantic = Graphics::ATTRIB_UV0;
 		vbDesc.attrib[2].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
+		vbDesc.attrib[3].semantic = Graphics::ATTRIB_TANGENT;
+		vbDesc.attrib[3].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
 		vbDesc.usage = Graphics::BUFFER_USAGE_STATIC;
 		vbDesc.numVertices = db.rd->Int32();
 
@@ -201,6 +205,7 @@ StaticGeometry *StaticGeometry::Load(NodeDatabase &db)
 		const Uint32 posOffset = vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_POSITION);
 		const Uint32 nrmOffset = vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_NORMAL);
 		const Uint32 uv0Offset = vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_UV0);
+		const Uint32 tanOffset = vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_TANGENT);
 		const Uint32 stride = vtxBuffer->GetDesc().stride;
 		Uint8 *vtxPtr = vtxBuffer->Map<Uint8>(BUFFER_MAP_WRITE);
 		for (Uint32 i = 0; i < vbDesc.numVertices; i++) {
@@ -209,6 +214,7 @@ StaticGeometry *StaticGeometry::Load(NodeDatabase &db)
 			const float uvx = db.rd->Float();
 			const float uvy = db.rd->Float();
 			*reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset) = vector2f(uvx, uvy);
+			*reinterpret_cast<vector3f*>(vtxPtr + i * stride + tanOffset) = db.rd->Vector3f();
 		}
 		vtxBuffer->Unmap();
 

--- a/src/scenegraph/StaticGeometry.cpp
+++ b/src/scenegraph/StaticGeometry.cpp
@@ -96,6 +96,7 @@ void StaticGeometry::Render(const std::vector<matrix4x4f> &trans, const RenderDa
 		mat->texture3 = it.material->texture3;
 		mat->texture4 = it.material->texture4;
 		mat->texture5 = it.material->texture5;
+		mat->texture6 = it.material->texture5;
 		mat->heatGradient = it.material->heatGradient;
 		mat->diffuse = it.material->diffuse;
 		mat->specular = it.material->specular;

--- a/src/scenegraph/StaticGeometry.cpp
+++ b/src/scenegraph/StaticGeometry.cpp
@@ -128,22 +128,37 @@ void StaticGeometry::Save(NodeDatabase &db)
 		Uint32 attribCombo = 0;
 		for (Uint32 i = 0; i < Graphics::MAX_ATTRIBS; i++)
 			attribCombo |= vbDesc.attrib[i].semantic;
+		
 		db.wr->Int32(attribCombo);
+
+		const bool hasTangents = (attribCombo & Graphics::ATTRIB_TANGENT);
 
 		//save positions, normals and uvs interleaved (only known format now)
 		const Uint32 posOffset = vbDesc.GetOffset(Graphics::ATTRIB_POSITION);
 		const Uint32 nrmOffset = vbDesc.GetOffset(Graphics::ATTRIB_NORMAL);
 		const Uint32 uv0Offset = vbDesc.GetOffset(Graphics::ATTRIB_UV0);
-		const Uint32 tanOffset = vbDesc.GetOffset(Graphics::ATTRIB_TANGENT);
+		const Uint32 tanOffset = hasTangents ? vbDesc.GetOffset(Graphics::ATTRIB_TANGENT) : 0;
 		const Uint32 stride    = vbDesc.stride;
 		db.wr->Int32(vbDesc.numVertices);
 		Uint8 *vtxPtr = mesh.vertexBuffer->Map<Uint8>(Graphics::BUFFER_MAP_READ);
-		for (Uint32 i = 0; i < vbDesc.numVertices; i++) {
-            db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + posOffset));
-            db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + nrmOffset));
-            db.wr->Float(reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset)->x);
-            db.wr->Float(reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset)->y);
-			db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + tanOffset));
+		if (hasTangents)
+		{
+			for (Uint32 i = 0; i < vbDesc.numVertices; i++) {
+				db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + posOffset));
+				db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + nrmOffset));
+				db.wr->Float(reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset)->x);
+				db.wr->Float(reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset)->y);
+				db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + tanOffset));
+			}
+		}
+		else
+		{
+			for (Uint32 i = 0; i < vbDesc.numVertices; i++) {
+				db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + posOffset));
+				db.wr->Vector3f(*reinterpret_cast<vector3f*>(vtxPtr + i * stride + nrmOffset));
+				db.wr->Float(reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset)->x);
+				db.wr->Float(reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset)->y);
+			}
 		}
 		mesh.vertexBuffer->Unmap();
 
@@ -186,8 +201,12 @@ StaticGeometry *StaticGeometry::Load(NodeDatabase &db)
 
 		//vertex format check
 		const Uint32 vtxFormat = db.rd->Int32();
-		if (vtxFormat != (ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0 | ATTRIB_TANGENT))
+		if (vtxFormat != (ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0 | ATTRIB_TANGENT) &&	vtxFormat != (ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0))
+		{
 			throw LoadingError("Unsupported vertex format");
+		}
+
+		const bool hasTangents = (vtxFormat & Graphics::ATTRIB_TANGENT);
 
 		//vertex buffer
 		Graphics::VertexBufferDesc vbDesc;
@@ -197,8 +216,10 @@ StaticGeometry *StaticGeometry::Load(NodeDatabase &db)
 		vbDesc.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
 		vbDesc.attrib[2].semantic = Graphics::ATTRIB_UV0;
 		vbDesc.attrib[2].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
-		vbDesc.attrib[3].semantic = Graphics::ATTRIB_TANGENT;
-		vbDesc.attrib[3].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		if (hasTangents) {
+			vbDesc.attrib[3].semantic = Graphics::ATTRIB_TANGENT;
+			vbDesc.attrib[3].format = Graphics::ATTRIB_FORMAT_FLOAT3;
+		}
 		vbDesc.usage = Graphics::BUFFER_USAGE_STATIC;
 		vbDesc.numVertices = db.rd->Int32();
 
@@ -206,16 +227,29 @@ StaticGeometry *StaticGeometry::Load(NodeDatabase &db)
 		const Uint32 posOffset = vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_POSITION);
 		const Uint32 nrmOffset = vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_NORMAL);
 		const Uint32 uv0Offset = vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_UV0);
-		const Uint32 tanOffset = vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_TANGENT);
+		const Uint32 tanOffset = hasTangents ? vtxBuffer->GetDesc().GetOffset(Graphics::ATTRIB_TANGENT) : 0;
 		const Uint32 stride = vtxBuffer->GetDesc().stride;
 		Uint8 *vtxPtr = vtxBuffer->Map<Uint8>(BUFFER_MAP_WRITE);
-		for (Uint32 i = 0; i < vbDesc.numVertices; i++) {
-			*reinterpret_cast<vector3f*>(vtxPtr + i * stride + posOffset) = db.rd->Vector3f();
-			*reinterpret_cast<vector3f*>(vtxPtr + i * stride + nrmOffset) = db.rd->Vector3f();
-			const float uvx = db.rd->Float();
-			const float uvy = db.rd->Float();
-			*reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset) = vector2f(uvx, uvy);
-			*reinterpret_cast<vector3f*>(vtxPtr + i * stride + tanOffset) = db.rd->Vector3f();
+		if (hasTangents)
+		{
+			for (Uint32 i = 0; i < vbDesc.numVertices; i++) {
+				*reinterpret_cast<vector3f*>(vtxPtr + i * stride + posOffset) = db.rd->Vector3f();
+				*reinterpret_cast<vector3f*>(vtxPtr + i * stride + nrmOffset) = db.rd->Vector3f();
+				const float uvx = db.rd->Float();
+				const float uvy = db.rd->Float();
+				*reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset) = vector2f(uvx, uvy);
+				*reinterpret_cast<vector3f*>(vtxPtr + i * stride + tanOffset) = db.rd->Vector3f();
+			}
+		}
+		else
+		{
+			for (Uint32 i = 0; i < vbDesc.numVertices; i++) {
+				*reinterpret_cast<vector3f*>(vtxPtr + i * stride + posOffset) = db.rd->Vector3f();
+				*reinterpret_cast<vector3f*>(vtxPtr + i * stride + nrmOffset) = db.rd->Vector3f();
+				const float uvx = db.rd->Float();
+				const float uvy = db.rd->Float();
+				*reinterpret_cast<vector2f*>(vtxPtr + i * stride + uv0Offset) = vector2f(uvx, uvy);
+			}
 		}
 		vtxBuffer->Unmap();
 


### PR DESCRIPTION
Updated (*optional*) normal mapping based on work that Luomu did several years ago.

To use normal mapping on an object just open it's `.model` file and add a line like `tex_norm NormalMap.dds` too it and of course the normal map with that name.

Job done, object is now normal mapped.

To test this you can delete the `wave.sgm` file within `data/models/ships/wave` and then try my [wave-normap-map.zip](http://quantum-thoughts.net/Pioneer/wave-normal-map.zip) mod which looks really ugly and will prompt @nozmajner into an artist frenzy :P

Andy