### PR TITLE
Flying empty fix

### DIFF
--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -343,7 +343,8 @@ local onChat = function (form, ref, option)
 		form:SetMessage(howmuch)
 
 	elseif option == 3 then
-		if Game.player.freeCapacity < ad.amount then
+		if (not ad.pickup and Game.player.freeCapacity < ad.amount) or
+			(ad.pickup and Game.player.totalCargo < ad.amount) then
 			form:SetMessage(l.YOU_DO_NOT_HAVE_ENOUGH_CARGO_SPACE_ON_YOUR_SHIP)
 			return
 		end


### PR DESCRIPTION
This fixes the behaviour that the player couldn't take a cargorun pickup mission if he hasn't enough free cargo space at the moment. laarmen advised me to use the equipment API but until the volume/mass thing is improved this PR seems to be the only practical solution IMHO.