### PR TITLE
Clean up OpenGL pollution

### DIFF
--- a/contrib/profiler/Profiler.cpp
+++ b/contrib/profiler/Profiler.cpp
@@ -8,6 +8,8 @@
 
 #if defined(_WIN32)
 	#define _CRT_SECURE_NO_WARNINGS
+	#define WIN32_LEAN_AND_MEAN 
+	#define NOMINMAX
 	#define copystring _strdup
 	#include <windows.h>
 #else

--- a/src/CollMesh.cpp
+++ b/src/CollMesh.cpp
@@ -1,0 +1,40 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "CollMesh.h"
+
+//This simply stores the collision GeomTrees
+//and AABB.
+
+void CollMesh::Save(Serializer::Writer &wr) const
+{
+	wr.Vector3d(m_aabb.max);
+	wr.Vector3d(m_aabb.min);
+	wr.Double(m_aabb.radius);
+
+	m_geomTree->Save(wr);
+
+	wr.Int32(m_dynGeomTrees.size());
+	for (auto it : m_dynGeomTrees) {
+		it->Save(wr);
+	}
+
+	wr.Int32(m_totalTris);
+}
+
+void CollMesh::Load(Serializer::Reader &rd)
+{
+	m_aabb.max = rd.Vector3d();
+	m_aabb.min = rd.Vector3d();
+	m_aabb.radius = rd.Double();
+
+	m_geomTree = new GeomTree(rd);
+
+	const Uint32 numDynGeomTrees = rd.Int32();
+	m_dynGeomTrees.reserve(numDynGeomTrees);
+	for (Uint32 it = 0; it < numDynGeomTrees; ++it) {
+		m_dynGeomTrees.push_back(new GeomTree(rd));
+	}
+
+	m_totalTris = rd.Int32();
+}

--- a/src/CollMesh.h
+++ b/src/CollMesh.h
@@ -21,62 +21,32 @@ public:
 			delete *it;
 		delete m_geomTree;
 	}
-	virtual Aabb &GetAabb() { return m_aabb; }
+	inline Aabb &GetAabb() { return m_aabb; }
 
-	virtual double GetRadius() const { return m_aabb.GetRadius(); }
-	virtual void SetRadius(double v) {
+	inline double GetRadius() const { return m_aabb.GetRadius(); }
+	inline void SetRadius(double v) {
 		//0 radius = trouble
 		m_aabb.radius = std::max(v, 0.1);
 	}
 
-	virtual GeomTree *GetGeomTree() const { return m_geomTree; }
-	void SetGeomTree(GeomTree *t) {
+	inline GeomTree *GetGeomTree() const { return m_geomTree; }
+	inline void SetGeomTree(GeomTree *t) {
 		assert(t);
 		m_geomTree = t;
 	}
 
-	const std::vector<GeomTree*> &GetDynGeomTrees() const { return m_dynGeomTrees; }
-	void AddDynGeomTree(GeomTree *t) {
+	inline const std::vector<GeomTree*> &GetDynGeomTrees() const { return m_dynGeomTrees; }
+	inline void AddDynGeomTree(GeomTree *t) {
 		assert(t);
 		m_dynGeomTrees.push_back(t);
 	}
 
 	//for statistics
-	unsigned int GetNumTriangles() const { return m_totalTris; }
-	void SetNumTriangles(unsigned int i) { m_totalTris = i; }
+	inline unsigned int GetNumTriangles() const { return m_totalTris; }
+	inline void SetNumTriangles(unsigned int i) { m_totalTris = i; }
 
-	void Save(Serializer::Writer &wr) const
-	{
-		wr.Vector3d(m_aabb.max);
-		wr.Vector3d(m_aabb.min);
-		wr.Double(m_aabb.radius);
-
-		m_geomTree->Save(wr);
-
-		wr.Int32(m_dynGeomTrees.size());
-		for (auto it : m_dynGeomTrees) {
-			it->Save(wr);
-		}
-
-		wr.Int32(m_totalTris);
-	}
-
-	void Load(Serializer::Reader &rd)
-	{
-		m_aabb.max = rd.Vector3d();
-		m_aabb.min = rd.Vector3d();
-		m_aabb.radius = rd.Double();
-
-		m_geomTree = new GeomTree(rd);
-
-		const Uint32 numDynGeomTrees = rd.Int32();
-		m_dynGeomTrees.reserve(numDynGeomTrees);
-		for (Uint32 it = 0; it < numDynGeomTrees; ++it) {
-			m_dynGeomTrees.push_back(new GeomTree(rd));
-		}
-
-		m_totalTris = rd.Int32();
-	}
+	void Save(Serializer::Writer &wr) const;
+	void Load(Serializer::Reader &rd);
 
 protected:
 	Aabb m_aabb;

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -116,7 +116,7 @@ public:
 		else return e->kids[we_are].get();
 	}
 
-	inline GLuint DetermineIndexbuffer() const {
+	inline Uint32 DetermineIndexbuffer() const {
 		return // index buffers are ordered by edge resolution flags
 			(edgeFriend[0] ? 1u : 0u) |
 			(edgeFriend[1] ? 2u : 0u) |

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -163,6 +163,7 @@ pioneer_SOURCES	= \
 	CameraController.cpp \
 	CargoBody.cpp \
 	Color.cpp \
+	CollMesh.cpp \
 	CityOnPlanet.cpp \
 	CRC32.cpp \
 	DateTime.cpp \
@@ -418,6 +419,7 @@ endif
 modelcompiler_SOURCES = \
 	modelcompiler.cpp \
 	Color.cpp \
+	CollMesh.cpp \
 	DateTime.cpp \
 	FileSourceZip.cpp \
 	FileSystem.cpp \

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -81,6 +81,13 @@
 #include <algorithm>
 #include <sstream>
 
+#ifdef _MSC_VER
+	// RegisterClassA and RegisterClassW are defined as macros in WinUser.h
+	#ifdef RegisterClass
+	#undef RegisterClass
+	#endif
+#endif
+
 float Pi::gameTickAlpha;
 sigc::signal<void, SDL_Keysym*> Pi::onKeyPress;
 sigc::signal<void, SDL_Keysym*> Pi::onKeyRelease;

--- a/src/ServerAgent.cpp
+++ b/src/ServerAgent.cpp
@@ -1,6 +1,10 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#if defined(_MSC_VER) && !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #include "ServerAgent.h"
 #include "StringF.h"
 #include <curl/curl.h>

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -725,9 +725,6 @@ void SystemView::PutSelectionBox(const vector3d &worldPos, const Color &col)
 	Gui::Screen::LeaveOrtho();
 }
 
-static const GLfloat fogDensity = 0.1f;
-static const GLfloat fogColor[4] = { 0,0,0,1.0f };
-
 void SystemView::GetTransformTo(const SystemBody *b, vector3d &pos)
 {
 	if (b->GetParent()) {

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -6,8 +6,8 @@
 
 #include "WindowSDL.h"
 #include "libs.h"
-#include "graphics/Types.h"
-#include "graphics/Light.h"
+#include "Types.h"
+#include "Light.h"
 #include "Stats.h"
 #include <map>
 #include <memory>

--- a/src/graphics/Types.h
+++ b/src/graphics/Types.h
@@ -40,13 +40,13 @@ enum BufferMapMode {
 };
 
 enum PrimitiveType {
-	TRIANGLES = GL_TRIANGLES,
-	TRIANGLE_STRIP = GL_TRIANGLE_STRIP,
-	TRIANGLE_FAN = GL_TRIANGLE_FAN,
-	POINTS = GL_POINTS,
-	LINE_SINGLE = GL_LINES,			//draw one line per two vertices
-	LINE_STRIP = GL_LINE_STRIP,		//connect vertices
-	LINE_LOOP = GL_LINE_LOOP		//connect vertices,  connect start & end
+	POINTS = 0,		//GL_POINTS,
+	LINE_SINGLE,	//GL_LINES,				//draw one line per two vertices
+	LINE_LOOP,		//GL_LINE_LOOP,			//connect vertices,  connect start & end
+	LINE_STRIP,		//GL_LINE_STRIP,		//connect vertices
+	TRIANGLES,		//GL_TRIANGLES,
+	TRIANGLE_STRIP, //GL_TRIANGLE_STRIP,
+	TRIANGLE_FAN,	//GL_TRIANGLE_FAN
 };
 
 enum BlendMode {

--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -5,7 +5,7 @@
 #define _VERTEXARRAY_H
 
 #include "libs.h"
-#include "graphics/Types.h"
+#include "Types.h"
 
 namespace Graphics {
 

--- a/src/graphics/VertexBuffer.h
+++ b/src/graphics/VertexBuffer.h
@@ -19,7 +19,7 @@
  * Expansion possibilities: range-based Map
  */
 #include "libs.h"
-#include "graphics/Types.h"
+#include "Types.h"
 
 namespace Graphics {
 

--- a/src/graphics/dummy/TextureDummy.h
+++ b/src/graphics/dummy/TextureDummy.h
@@ -17,7 +17,7 @@ public:
 	void Unbind() {}
 
 	virtual void SetSampleMode(TextureSampleMode) {}
-	GLuint GetTexture() const { return 0; }
+	Uint32 GetTexture() const { return 0U; }
 
 private:
 	friend class RendererDummy;

--- a/src/graphics/opengl/GLDebug.h
+++ b/src/graphics/opengl/GLDebug.h
@@ -11,7 +11,7 @@
  * https://github.com/OpenGLInsights/ (Chapter 33)
  * which also includes stack printout
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
 
 #ifdef _WIN32
 #define STDCALL __stdcall

--- a/src/graphics/opengl/GasGiantMaterial.h
+++ b/src/graphics/opengl/GasGiantMaterial.h
@@ -6,7 +6,7 @@
 /*
  * Programs & Materials used by terrain
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
 #include "MaterialGL.h"
 #include "Program.h"
 #include "galaxy/StarSystem.h"

--- a/src/graphics/opengl/GeoSphereMaterial.h
+++ b/src/graphics/opengl/GeoSphereMaterial.h
@@ -6,7 +6,7 @@
 /*
  * Programs & Materials used by terrain
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
 #include "MaterialGL.h"
 #include "Program.h"
 #include "galaxy/StarSystem.h"

--- a/src/graphics/opengl/Makefile.am
+++ b/src/graphics/opengl/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS += -I$(srcdir)/../.. -isystem $(top_srcdir)/contrib
 noinst_LIBRARIES = libgraphicsopengl.a
 noinst_HEADERS = \
 	gl_core_3_x.h \
+	OpenGLLibs.h \
 	GLDebug.h \
 	MaterialGL.h \
 	RenderStateGL.h \

--- a/src/graphics/opengl/MaterialGL.h
+++ b/src/graphics/opengl/MaterialGL.h
@@ -12,7 +12,7 @@
  *
  * Programs are owned by the renderer, since they are shared between materials.
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
 #include "graphics/Material.h"
 
 namespace Graphics {

--- a/src/graphics/opengl/OpenGLLibs.h
+++ b/src/graphics/opengl/OpenGLLibs.h
@@ -1,0 +1,13 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#ifndef _OGL_OPENGLIBS_H
+#define _OGL_OPENGLIBS_H
+
+// The glLoadGen header was generated using the following command line:
+// lua LoadGen.lua -style=pointer_c -spec=gl -version=3.3 -profile=core core_3_x -stdext=gl_ubiquitous.txt -stdext=gl_core_post_3_3.txt -ext ARB_seamless_cube_map ARB_seamless_cubemap_per_texture ARB_draw_instanced ARB_uniform_buffer_object ARB_instanced_arrays
+#include "graphics/opengl/gl_core_3_x.h"
+
+#endif

--- a/src/graphics/opengl/Program.h
+++ b/src/graphics/opengl/Program.h
@@ -1,14 +1,16 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-#ifndef _GRAPHICS_GL2PROGRAM_H
-#define _GRAPHICS_GL2PROGRAM_H
+#ifndef _GRAPHICS_OGLPROGRAM_H
+#define _GRAPHICS_OGLPROGRAM_H
 /*
  * The new 'Shader' class
  * This is a base class without specific uniforms
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
 #include "Uniform.h"
+
+#include <string>
 
 namespace Graphics {
 

--- a/src/graphics/opengl/RenderStateGL.cpp
+++ b/src/graphics/opengl/RenderStateGL.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "graphics/opengl/RenderStateGL.h"
+#include "OpenGLLibs.h"
 
 namespace Graphics
 {

--- a/src/graphics/opengl/RenderTargetGL.h
+++ b/src/graphics/opengl/RenderTargetGL.h
@@ -8,6 +8,7 @@
  * In theory you should use one texture format and size per FBO
  * 2013-May-05 left out stencil buffer because we don't need it now
  */
+#include "OpenGLLibs.h"
 #include "graphics/RenderTarget.h"
 
 namespace Graphics {

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -103,6 +103,15 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 
 	if (vs.enableDebugMessages)
 		GLDebug::Enable();
+
+	// check enum PrimitiveType matches OpenGL values
+	assert(POINTS == GL_POINTS);
+	assert(LINE_SINGLE == GL_LINES);
+	assert(LINE_LOOP == GL_LINE_LOOP);
+	assert(LINE_STRIP == GL_LINE_STRIP);
+	assert(TRIANGLES == GL_TRIANGLES);
+	assert(TRIANGLE_STRIP == GL_TRIANGLE_STRIP);
+	assert(TRIANGLE_FAN == GL_TRIANGLE_FAN);
 }
 
 RendererOGL::~RendererOGL()

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -13,6 +13,7 @@
  *  - use glvertexattribpointer instead of glvertexpointer etc
  *  - get rid of built-in glMaterial, glMatrix use
  */
+#include "OpenGLLibs.h"
 #include "graphics/Renderer.h"
 #include <stack>
 #include <unordered_map>

--- a/src/graphics/opengl/RingMaterial.h
+++ b/src/graphics/opengl/RingMaterial.h
@@ -6,7 +6,7 @@
 /*
  * Planet ring material
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
 #include "MaterialGL.h"
 #include "Program.h"
 namespace Graphics {

--- a/src/graphics/opengl/SkyboxMaterial.h
+++ b/src/graphics/opengl/SkyboxMaterial.h
@@ -7,7 +7,7 @@
 /*
  * Renders a cube map as a skybox.
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
 #include "Program.h"
 
 namespace Graphics {

--- a/src/graphics/opengl/StarfieldMaterial.h
+++ b/src/graphics/opengl/StarfieldMaterial.h
@@ -8,7 +8,7 @@
  * This does nothing very special except toggle POINT_SIZE
  * The Program requires setting intensity using the generic emission parameter
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
 #include "graphics/Material.h"
 #include "Program.h"
 

--- a/src/graphics/opengl/Uniform.cpp
+++ b/src/graphics/opengl/Uniform.cpp
@@ -38,7 +38,7 @@ void Uniform::Set(const vector3f &v)
 void Uniform::Set(const vector3d &v)
 {
 	if (m_location != -1)
-		glUniform3f(m_location, v.x, v.y, v.z); //yes, 3f
+		glUniform3f(m_location, static_cast<float>(v.x), static_cast<float>(v.y), static_cast<float>(v.z)); //yes, 3f
 }
 
 void Uniform::Set(const Color &c)

--- a/src/graphics/opengl/Uniform.h
+++ b/src/graphics/opengl/Uniform.h
@@ -6,7 +6,13 @@
 /*
  * Shader uniform
  */
-#include "libs.h"
+#include "OpenGLLibs.h"
+
+#include "vector3.h"
+#include "matrix3x3.h"
+#include "matrix4x4.h"
+#include "Color.h"
+
 namespace Graphics {
 
 	class Texture;

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -1,8 +1,9 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-#ifndef GL2_VERTEXBUFFER_H
-#define GL2_VERTEXBUFFER_H
+#ifndef OGL_VERTEXBUFFER_H
+#define OGL_VERTEXBUFFER_H
+#include "OpenGLLibs.h"
 #include "graphics/VertexBuffer.h"
 
 namespace Graphics { namespace OGL {
@@ -74,4 +75,4 @@ protected:
 
 } }
 
-#endif // GL2_VERTEXBUFFER_H
+#endif // OGL_VERTEXBUFFER_H

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -149,7 +149,7 @@ namespace Theme {
 	/* 6 */	vector3f(size[0]-BORDER_WIDTH,size[1]-BORDER_WIDTH,0),
 	/* 7 */	vector3f(size[0]-BORDER_WIDTH,BORDER_WIDTH,0)
 		};
-		const GLushort indices[] = {
+		const Uint16 indices[] = {
 			0,1,5, 0,5,4, 0,4,7, 0,7,3,
 			3,7,6, 3,6,2, 1,2,6, 1,6,5 };
 
@@ -184,7 +184,7 @@ namespace Theme {
 		Screen::GetRenderer()->DrawBufferIndexed(vb.get(), ib.get(), state, Screen::flatColorMaterial);
 	}
 
-	Graphics::IndexBuffer* CreateIndexBuffer(const GLushort indices[], const Uint32 IndexStart, const Uint32 IndexEnd, const Uint32 NumIndices)
+	Graphics::IndexBuffer* CreateIndexBuffer(const Uint16 indices[], const Uint32 IndexStart, const Uint32 IndexEnd, const Uint32 NumIndices)
 	{
 		Graphics::IndexBuffer *ib = Screen::GetRenderer()->CreateIndexBuffer(NumIndices, Graphics::BUFFER_USAGE_STATIC);
 		Uint16* idxPtr = ib->Map(Graphics::BUFFER_MAP_WRITE);
@@ -234,7 +234,7 @@ namespace Theme {
 				/* 6 */	vector3f(size[0] - BORDER_WIDTH, size[1] - BORDER_WIDTH, 0),
 				/* 7 */	vector3f(size[0] - BORDER_WIDTH, BORDER_WIDTH, 0)
 			};
-			const GLushort indices[] = {
+			const Uint16 indices[] = {
 				0, 1, 5, 0, 5, 4, 0, 4, 7, 0, 7, 3,
 				3, 7, 6, 3, 6, 2, 1, 2, 6, 1, 6, 5,
 				4, 5, 6, 4, 6, 7 };
@@ -329,7 +329,7 @@ namespace Theme {
 				/* 6 */	vector3f(size[0] - BORDER_WIDTH, size[1] - BORDER_WIDTH, 0),
 				/* 7 */	vector3f(size[0] - BORDER_WIDTH, BORDER_WIDTH, 0)
 			};
-			const GLushort indices[] = {
+			const Uint16 indices[] = {
 				0, 1, 5, 0, 5, 4, 0, 4, 7, 0, 7, 3,
 				3, 7, 6, 3, 6, 2, 1, 2, 6, 1, 6, 5,
 				4, 5, 6, 4, 6, 7 };

--- a/src/gui/GuiLabel.h
+++ b/src/gui/GuiLabel.h
@@ -31,7 +31,7 @@ namespace Gui {
 		std::string m_text;
 		::Color m_color;
 		bool m_shadow;
-		GLuint m_dlist;
+		Uint32 m_dlist;
 		RefCountedPtr<Text::TextureFont> m_font;
 		std::unique_ptr<TextLayout> m_layout;
 		TextLayout::ColourMarkupMode m_colourMarkupMode;

--- a/src/gui/GuiScreen.cpp
+++ b/src/gui/GuiScreen.cpp
@@ -20,7 +20,7 @@ Gui::Fixed *Screen::baseContainer;
 Gui::Widget *Screen::focusedWidget;
 matrix4x4f Screen::modelMatrix;
 matrix4x4f Screen::projMatrix;
-GLint Screen::viewport[4];
+Sint32 Screen::viewport[4];
 
 FontCache Screen::s_fontCache;
 std::stack< RefCountedPtr<Text::TextureFont> > Screen::s_fontStack;

--- a/src/gui/GuiScreen.h
+++ b/src/gui/GuiScreen.h
@@ -83,7 +83,7 @@ namespace Gui {
 		static void OnDeleteFocusedWidget();
 		static matrix4x4f modelMatrix;
 		static matrix4x4f projMatrix;
-		static GLint viewport[4];
+		static Sint32 viewport[4];
 
 		static FontCache s_fontCache;
 		static std::stack< RefCountedPtr<Text::TextureFont> > s_fontStack;

--- a/src/libs.h
+++ b/src/libs.h
@@ -26,10 +26,6 @@
 #include <algorithm>
 #include <memory>
 
-// The glLoadGen header was generated using the following command line:
-// lua LoadGen.lua -style=pointer_c -spec=gl -version=3.3 -profile=core core_3_x -stdext=gl_ubiquitous.txt -stdext=gl_core_post_3_3.txt -ext ARB_seamless_cube_map ARB_seamless_cubemap_per_texture ARB_draw_instanced ARB_uniform_buffer_object ARB_instanced_arrays
-#include "graphics/opengl/gl_core_3_x.h"
-
 #ifdef _WIN32
 #	include <malloc.h>
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -4,6 +4,10 @@
 #ifndef _UTILS_H
 #define _UTILS_H
 
+#if defined(_MSC_VER) && !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #include <string>
 #include <vector>
 #include <stdio.h>

--- a/src/win32/FileSystemWin32.cpp
+++ b/src/win32/FileSystemWin32.cpp
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <cerrno>
 
+#define WIN32_LEAN_AND_MEAN 
+#define NOMINMAX
 #include <windows.h>
 // GetPiUserDir() needs these
 #include <shlobj.h>

--- a/src/win32/Makefile.am
+++ b/src/win32/Makefile.am
@@ -9,4 +9,5 @@ AM_CPPFLAGS += -I$(srcdir)/.. -isystem $(top_srcdir)/contrib
 noinst_LIBRARIES = libwin32.a
 libwin32_a_SOURCES = \
 	FileSystemWin32.cpp \
-	OSWin32.cpp
+	OSWin32.cpp \
+	TextUtils.cpp 

--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -1,6 +1,8 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#define WIN32_LEAN_AND_MEAN 
+#define NOMINMAX
 #include "Win32Setup.h"
 
 #include "OS.h"
@@ -13,6 +15,10 @@
 #include <stdio.h>
 #include <wchar.h>
 #include <windows.h>
+
+#ifdef RegisterClass
+#undef RegisterClass
+#endif
 
 #ifdef WITH_BREAKPAD
 using namespace google_breakpad;

--- a/src/win32/TextUtils.cpp
+++ b/src/win32/TextUtils.cpp
@@ -1,0 +1,36 @@
+// Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "TextUtils.h"
+#include "Win32Setup.h"
+#define WIN32_LEAN_AND_MEAN 
+#define NOMINMAX
+#include <windows.h>
+
+std::wstring transcode_utf8_to_utf16(const char *s, size_t nbytes)
+{
+	std::wstring buf(nbytes, L'x');
+	int reqchars = MultiByteToWideChar(CP_UTF8, 0, s, nbytes, &buf[0], buf.size());
+	if (!reqchars) { fprintf(stderr, "failed to transcode UTF-8 to UTF-16\n"); abort(); }
+	buf.resize(reqchars);
+	return buf;
+}
+
+std::wstring transcode_utf8_to_utf16(const std::string &s)
+{
+	return transcode_utf8_to_utf16(s.c_str(), s.size());
+}
+
+std::string transcode_utf16_to_utf8(const wchar_t *s, size_t nchars)
+{
+	std::string buf(nchars * 2, 'x');
+	int reqbytes = WideCharToMultiByte(CP_UTF8, 0, s, nchars, &buf[0], buf.size(), 0, 0);
+	if (!reqbytes) { fprintf(stderr, "failed to transcode UTF-16 to UTF-8\n"); abort(); }
+	buf.resize(reqbytes);
+	return buf;
+}
+
+std::string transcode_utf16_to_utf8(const std::wstring &s)
+{
+	return transcode_utf16_to_utf8(s.c_str(), s.size());
+}

--- a/src/win32/TextUtils.h
+++ b/src/win32/TextUtils.h
@@ -4,36 +4,11 @@
 #ifndef _WIN32_TEXTUTILS_H
 #define _WIN32_TEXTUTILS_H
 
-#include "Win32Setup.h"
+#include <string>
 
-#include <windows.h>
-
-static std::wstring transcode_utf8_to_utf16(const char *s, size_t nbytes)
-{
-	std::wstring buf(nbytes, L'x');
-	int reqchars = MultiByteToWideChar(CP_UTF8, 0, s, nbytes, &buf[0], buf.size());
-	if (!reqchars) { fprintf(stderr, "failed to transcode UTF-8 to UTF-16\n"); abort(); }
-	buf.resize(reqchars);
-	return buf;
-}
-
-static std::wstring transcode_utf8_to_utf16(const std::string &s)
-{
-	return transcode_utf8_to_utf16(s.c_str(), s.size());
-}
-
-static std::string transcode_utf16_to_utf8(const wchar_t *s, size_t nchars)
-{
-	std::string buf(nchars * 2, 'x');
-	int reqbytes = WideCharToMultiByte(CP_UTF8, 0, s, nchars, &buf[0], buf.size(), 0, 0);
-	if (!reqbytes) { fprintf(stderr, "failed to transcode UTF-16 to UTF-8\n"); abort(); }
-	buf.resize(reqbytes);
-	return buf;
-}
-
-static std::string transcode_utf16_to_utf8(const std::wstring &s)
-{
-	return transcode_utf16_to_utf8(s.c_str(), s.size());
-}
+std::wstring transcode_utf8_to_utf16(const char *s, size_t nbytes);
+std::wstring transcode_utf8_to_utf16(const std::string &s);
+std::string transcode_utf16_to_utf8(const wchar_t *s, size_t nchars);
+std::string transcode_utf16_to_utf8(const std::wstring &s);
 
 #endif // _WIN32_TEXTUTILS_H

--- a/win32/vs2015/graphics/graphics.vcxproj
+++ b/win32/vs2015/graphics/graphics.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="..\..\..\src\graphics\opengl\gl_core_3_x.h" />
     <ClInclude Include="..\..\..\src\graphics\opengl\MaterialGL.h" />
     <ClInclude Include="..\..\..\src\graphics\opengl\MultiMaterial.h" />
+    <ClInclude Include="..\..\..\src\graphics\opengl\OpenGLLibs.h" />
     <ClInclude Include="..\..\..\src\graphics\opengl\Program.h" />
     <ClInclude Include="..\..\..\src\graphics\opengl\RendererGL.h" />
     <ClInclude Include="..\..\..\src\graphics\opengl\RenderStateGL.h" />

--- a/win32/vs2015/graphics/graphics.vcxproj
+++ b/win32/vs2015/graphics/graphics.vcxproj
@@ -200,6 +200,7 @@
     <ClInclude Include="..\..\..\src\graphics\Stats.h" />
     <ClInclude Include="..\..\..\src\graphics\Texture.h" />
     <ClInclude Include="..\..\..\src\graphics\TextureBuilder.h" />
+    <ClInclude Include="..\..\..\src\graphics\Types.h" />
     <ClInclude Include="..\..\..\src\graphics\VertexArray.h" />
     <ClInclude Include="..\..\..\src\graphics\VertexBuffer.h" />
     <ClInclude Include="..\..\..\src\graphics\WindowSDL.h" />

--- a/win32/vs2015/graphics/graphics.vcxproj.filters
+++ b/win32/vs2015/graphics/graphics.vcxproj.filters
@@ -166,6 +166,7 @@
     <ClInclude Include="..\..\..\src\graphics\opengl\OpenGLLibs.h">
       <Filter>opengl</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\graphics\Types.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="win32">

--- a/win32/vs2015/graphics/graphics.vcxproj.filters
+++ b/win32/vs2015/graphics/graphics.vcxproj.filters
@@ -163,6 +163,9 @@
       <Filter>dummy</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\graphics\Stats.h" />
+    <ClInclude Include="..\..\..\src\graphics\opengl\OpenGLLibs.h">
+      <Filter>opengl</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="win32">

--- a/win32/vs2015/modelcompiler.vcxproj
+++ b/win32/vs2015/modelcompiler.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\contrib\PicoDDS\PicoDDS.cpp" />
+    <ClCompile Include="..\..\src\CollMesh.cpp" />
     <ClCompile Include="..\..\src\Color.cpp" />
     <ClCompile Include="..\..\src\DateTime.cpp" />
     <ClCompile Include="..\..\src\FileSourceZip.cpp" />
@@ -36,6 +37,7 @@
     <ClCompile Include="..\..\src\utils.cpp" />
     <ClCompile Include="..\..\src\win32\FileSystemWin32.cpp" />
     <ClCompile Include="..\..\src\win32\OSWin32.cpp" />
+    <ClCompile Include="..\..\src\win32\TextUtils.cpp" />
     <ClCompile Include="..\..\src\win32\WinMath.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/win32/vs2015/modelcompiler.vcxproj.filters
+++ b/win32/vs2015/modelcompiler.vcxproj.filters
@@ -72,6 +72,12 @@
     <ClCompile Include="..\..\src\DateTime.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\CollMesh.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\win32\TextUtils.cpp">
+      <Filter>Win32</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\IniConfig.h">

--- a/win32/vs2015/pioneer.vcxproj
+++ b/win32/vs2015/pioneer.vcxproj
@@ -195,6 +195,7 @@
     <ClCompile Include="..\..\src\CameraController.cpp" />
     <ClCompile Include="..\..\src\CargoBody.cpp" />
     <ClCompile Include="..\..\src\CityOnPlanet.cpp" />
+    <ClCompile Include="..\..\src\CollMesh.cpp" />
     <ClCompile Include="..\..\src\Color.cpp" />
     <ClCompile Include="..\..\src\CRC32.cpp" />
     <ClCompile Include="..\..\src\DateTime.cpp" />
@@ -330,6 +331,7 @@
     <ClCompile Include="..\..\src\View.cpp" />
     <ClCompile Include="..\..\src\win32\FileSystemWin32.cpp" />
     <ClCompile Include="..\..\src\win32\OSWin32.cpp" />
+    <ClCompile Include="..\..\src\win32\TextUtils.cpp" />
     <ClCompile Include="..\..\src\win32\WinMath.cpp" />
     <ClCompile Include="..\..\src\WorldView.cpp" />
   </ItemGroup>

--- a/win32/vs2015/pioneer.vcxproj.filters
+++ b/win32/vs2015/pioneer.vcxproj.filters
@@ -426,6 +426,12 @@
     <ClCompile Include="..\..\src\LuaServerAgent.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\win32\TextUtils.cpp">
+      <Filter>src\win32</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\CollMesh.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Aabb.h">


### PR DESCRIPTION
I decided to look into what would be required to resurrect an OpenGL 2.1 option but found that there was still quite a lot of OpenGL polluting things outside of the `graphics/opengl` code.

All of the OpenGL code needs to be purged before trying anything. This should also help with porting to another renderer like BGFX or implementing EGL/GLES for the RaspberryPi.

Unfortunately I ran into some problem due to windows header files... what a load of shite that all is. Therefore I have also tried to isolate some of that a little better. Not all of it can be contained though so I have had to add a instances of `#define NOMINMAX` and `#define WIN32_LEAN_AND_MEAN` in a few places :(

Finally whilst trying to fathom out what was causing some compile issues I found that the `CollMesh` was using a bunch of `virtual` methods, but it's not overloading or overloaded so they're pointless and I've made them `inline`.

I hope most of the worst stuff is confined to Win32 specific files.

Andy