### PR TITLE
Fix the last real Clang warning

### DIFF
--- a/src/JobQueue.h
+++ b/src/JobQueue.h
@@ -247,7 +247,7 @@ public:
 	JobSet& operator=(const JobSet& other) = delete;
 
 	virtual void Order(Job* job) {
-		auto x = m_jobs.insert(std::move(m_queue->Queue(job, this)));
+		auto x = m_jobs.insert(m_queue->Queue(job, this));
 		assert(x.second);
 	}
 	virtual void RemoveJob(Job::Handle* handle) { m_jobs.erase(*handle); }


### PR DESCRIPTION
Usage of `std::move` was being warned against in one place as an anti-optimisation so I have removed it. Which fixes #3523 again :P