### PR TITLE
Fix handling of negativ coord numbers for DecimalToDegMinSec function

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -428,10 +428,10 @@ void StrToAuto(double *pVal, const std::string &str)
 */
 std::string DecimalToDegMinSec(float dec)
 {
-	int degrees = floor(dec);
-	int minutes = floor(60*(dec - degrees));
-	int seconds = floor(3600 * ((dec - degrees) - static_cast<float>(minutes) / 60));
-	std::string str = stringf("%0° %1' %2\"", degrees, minutes, seconds);
+	int degrees = dec;
+	int minutes = 60 * (dec - degrees);
+	int seconds = 3600 * ((dec - degrees) - static_cast<float>(minutes) / 60);
+	std::string str = stringf("%0° %1' %2\"", degrees, std::abs(minutes), std::abs(seconds));
 	return str;
 }
 


### PR DESCRIPTION
As @nozmajner pointed out yesterday in IRC - negative lat/long coordinates were not transformed correctly from decimal to degree/minute/second format. This was due to my incorrect use of the floor() function to get the integer part of a number. For positive numbers it doesn't matter, but for negative numbers returning the smallest following integer throws everything off by a little bit.

This merge request fixes the coordinate conversion.