### PR TITLE
Fixed XCode Project file

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -150,11 +150,23 @@ Note: Compiling from source this way isn't recommended as it doesn't allow you
       bundle). It also isn't the 'Apple way', To do that you need to use XCode.
 
 
-1.5 OS X - XCode 4
+1.5 OS X - XCode 6
 ------------------
 
-* The XCode project isn't as up to date as the 'autotools' method and may
-  be broken.
+You will need the following libraries installed. The best method I found was to install macports (http://www.macports.org/) and install the following ports (sudo port install xxxx):
+
+     autoconf
+     automake
+     pkgconfig
+     assimp
+     freetype
+     libsigcxx2
+     libsdl2
+     libsdl2_image
+     libvorbis
+     libvorbisfile
+	
+Alternatively you can also run the script in the ./osx folder install_ports.sh
 
 The latest XCode project files are located in ./osx. Simply build the
 aplication bundle. The XCode project uses the mac port libraries that you

--- a/contrib/miniz/miniz.h
+++ b/contrib/miniz/miniz.h
@@ -2790,7 +2790,7 @@ void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h, 
   *pLen_out = out_buf.m_size-41;
   {
     mz_uint8 pnghdr[41]={0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a,0x00,0x00,0x00,0x0d,0x49,0x48,0x44,0x52,
-      0,0,(mz_uint8)(w>>8),(mz_uint8)w,0,0,(mz_uint8)(h>>8),(mz_uint8)h,8,"\0\0\04\02\06"[num_chans],0,0,0,0,0,0,0,
+      0,0,(mz_uint8)(w>>8),(mz_uint8)w,0,0,(mz_uint8)(h>>8),(mz_uint8)h,8,static_cast<mz_uint8>("\0\0\04\02\06"[num_chans]),0,0,0,0,0,0,0,
       (mz_uint8)(*pLen_out>>24),(mz_uint8)(*pLen_out>>16),(mz_uint8)(*pLen_out>>8),(mz_uint8)*pLen_out,0x49,0x44,0x41,0x54};
     c=(mz_uint32)mz_crc32(MZ_CRC32_INIT,pnghdr+12,17); for (i=0; i<4; ++i, c<<=8) ((mz_uint8*)(pnghdr+29))[i]=(mz_uint8)(c>>24);
     memcpy(out_buf.m_pBuf, pnghdr, 41);

--- a/osx/SDLMain.h
+++ b/osx/SDLMain.h
@@ -13,7 +13,3 @@
 - (IBAction)openAboutPanel:(id)sender;
 
 @end
-
-@interface SDLApplication : NSApplication
-
-@end

--- a/osx/SDLMain.m
+++ b/osx/SDLMain.m
@@ -5,25 +5,12 @@
 // Objective-C cocoa wrapper for pioneer
 
 #include "buildopts.h"
-#import <SDL/SDL.h>
+#import <SDL2/SDL.h>
 #import "SDLMain.h"
 #import <unistd.h>
 
 static int    gArgc;
 static char  **gArgv;
-
-@implementation SDLApplication
-
-// Invoked from the Quit menu item
-- (void)terminate:(id)sender
-{
-    // Posts a SDL_QUIT event so SDL shutsdown
-    SDL_Event event;
-    event.type = SDL_QUIT;
-    SDL_PushEvent(&event);
-    [super terminate:sender];
-}
-@end
 
 @implementation SDLMain
 

--- a/osx/install_ports.sh
+++ b/osx/install_ports.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+port install autoconf
+port install automake
+port install pkgconfig
+port install assimp
+port install freetype
+port install libsigcxx2

--- a/osx/package/Distribution.xml
+++ b/osx/package/Distribution.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-gui-script minSpecVersion="1">
+    <title>Pioneer</title>
+    <domains enable_localSystem="true"/>
+    <options rootVolumeOnly="true" customize="never" hostArchitectures="i386" require-scripts="false"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="net.pioneerspacesim.pioneer.pkg"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="net.pioneerspacesim.pioneer.pkg" visible="false">
+        <pkg-ref id="net.pioneerspacesim.pioneer.pkg"/>
+    </choice>
+    <pkg-ref id="net.pioneerspacesim.pioneer.pkg" version="0" onConclusion="none">pioneer.pkg</pkg-ref>
+</installer-gui-script>

--- a/osx/package/pioneer.plist
+++ b/osx/package/pioneer.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/osx/pioneer.xcodeproj/project.pbxproj
+++ b/osx/pioneer.xcodeproj/project.pbxproj
@@ -22,9 +22,9 @@
 
 /* Begin PBXBuildFile section */
 		3701C5861B1ABDA2000F4A72 /* libfreetype.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3701C5851B1ABDA2000F4A72 /* libfreetype.6.dylib */; };
-		37074B911B1C653D00AFE2CE /* libbz2.1.0.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 37074B8E1B1C653D00AFE2CE /* libbz2.1.0.6.dylib */; };
+		37074B911B1C653D00AFE2CE /* libbz2.1.0.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 37074B8E1B1C653D00AFE2CE /* libbz2.1.0.6.dylib */; settings = {ATTRIBUTES = (Required, ); }; };
 		37074B921B1C653D00AFE2CE /* libpng16.16.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 37074B8F1B1C653D00AFE2CE /* libpng16.16.dylib */; };
-		37074B931B1C653D00AFE2CE /* libz.1.2.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 37074B901B1C653D00AFE2CE /* libz.1.2.8.dylib */; };
+		37074B931B1C653D00AFE2CE /* libz.1.2.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 37074B901B1C653D00AFE2CE /* libz.1.2.8.dylib */; settings = {ATTRIBUTES = (Required, ); }; };
 		37074B941B1C6DDC00AFE2CE /* libbz2.1.0.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 37074B8E1B1C653D00AFE2CE /* libbz2.1.0.6.dylib */; };
 		37074B951B1C6DDC00AFE2CE /* libpng16.16.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 37074B8F1B1C653D00AFE2CE /* libpng16.16.dylib */; };
 		37074B961B1C6DDC00AFE2CE /* libz.1.2.8.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 37074B901B1C653D00AFE2CE /* libz.1.2.8.dylib */; };
@@ -433,12 +433,13 @@
 		4AFBD7B91641265D002928CB /* PngWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7B71641265D002928CB /* PngWriter.cpp */; };
 		4AFBD7BD16412676002928CB /* LuaTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7BA16412676002928CB /* LuaTextEntry.cpp */; };
 		4AFBD7BE16412676002928CB /* TextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7BB16412676002928CB /* TextEntry.cpp */; };
-		52025F6F1C05B63E00254BB5 /* libcurl.4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F6E1C05B63E00254BB5 /* libcurl.4.dylib */; };
 		52025F741C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F721C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib */; };
 		52025F751C05B74B00254BB5 /* libSDL2-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F731C05B74B00254BB5 /* libSDL2-2.0.0.dylib */; };
 		52025F791C05BA7100254BB5 /* CollMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52025F781C05BA7100254BB5 /* CollMesh.cpp */; };
 		52025F7C1C05BBAC00254BB5 /* libvorbis.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F7A1C05BBAC00254BB5 /* libvorbis.0.dylib */; };
 		52025F7F1C05BD3400254BB5 /* libvorbisfile.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F7E1C05BD3400254BB5 /* libvorbisfile.3.dylib */; };
+		522B22CB1C06323C00109BB0 /* libcurl.4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 522B22CA1C06323C00109BB0 /* libcurl.4.dylib */; };
+		522B22CC1C06324A00109BB0 /* libcurl.4.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 522B22CA1C06323C00109BB0 /* libcurl.4.dylib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -485,6 +486,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				522B22CC1C06324A00109BB0 /* libcurl.4.dylib in Copy Libraries */,
 			);
 			name = "Copy Libraries";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1258,12 +1260,12 @@
 		4AFBD7BA16412676002928CB /* LuaTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaTextEntry.cpp; sourceTree = "<group>"; };
 		4AFBD7BB16412676002928CB /* TextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextEntry.cpp; sourceTree = "<group>"; };
 		4AFBD7BC16412676002928CB /* TextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextEntry.h; sourceTree = "<group>"; };
-		52025F6E1C05B63E00254BB5 /* libcurl.4.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcurl.4.dylib; path = /opt/local/lib/libcurl.4.dylib; sourceTree = "<absolute>"; };
 		52025F721C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2_image-2.0.0.dylib"; path = "../../../../../opt/local/lib/libSDL2_image-2.0.0.dylib"; sourceTree = "<group>"; };
 		52025F731C05B74B00254BB5 /* libSDL2-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2-2.0.0.dylib"; path = "../../../../../opt/local/lib/libSDL2-2.0.0.dylib"; sourceTree = "<group>"; };
 		52025F781C05BA7100254BB5 /* CollMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollMesh.cpp; sourceTree = "<group>"; };
 		52025F7A1C05BBAC00254BB5 /* libvorbis.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbis.0.dylib; path = ../../../../../opt/local/lib/libvorbis.0.dylib; sourceTree = "<group>"; };
 		52025F7E1C05BD3400254BB5 /* libvorbisfile.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbisfile.3.dylib; path = ../../../../../opt/local/lib/libvorbisfile.3.dylib; sourceTree = "<group>"; };
+		522B22CA1C06323C00109BB0 /* libcurl.4.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcurl.4.dylib; path = ../../../../../opt/local/lib/libcurl.4.dylib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1272,11 +1274,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				37074B911B1C653D00AFE2CE /* libbz2.1.0.6.dylib in Frameworks */,
-				52025F7C1C05BBAC00254BB5 /* libvorbis.0.dylib in Frameworks */,
 				37074B921B1C653D00AFE2CE /* libpng16.16.dylib in Frameworks */,
+				522B22CB1C06323C00109BB0 /* libcurl.4.dylib in Frameworks */,
 				37074B931B1C653D00AFE2CE /* libz.1.2.8.dylib in Frameworks */,
+				52025F7C1C05BBAC00254BB5 /* libvorbis.0.dylib in Frameworks */,
 				52025F751C05B74B00254BB5 /* libSDL2-2.0.0.dylib in Frameworks */,
-				52025F6F1C05B63E00254BB5 /* libcurl.4.dylib in Frameworks */,
 				3701C5861B1ABDA2000F4A72 /* libfreetype.6.dylib in Frameworks */,
 				378563521B19769A0039F2BC /* OpenGL.framework in Frameworks */,
 				52025F741C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib in Frameworks */,
@@ -1543,11 +1545,11 @@
 		4A20B0E1135319770020F43E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				522B22CA1C06323C00109BB0 /* libcurl.4.dylib */,
 				52025F7E1C05BD3400254BB5 /* libvorbisfile.3.dylib */,
 				52025F7A1C05BBAC00254BB5 /* libvorbis.0.dylib */,
 				52025F721C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib */,
 				52025F731C05B74B00254BB5 /* libSDL2-2.0.0.dylib */,
-				52025F6E1C05B63E00254BB5 /* libcurl.4.dylib */,
 				4A20B0E4135319770020F43E /* Other Frameworks */,
 				4A671B851388C04700657F38 /* SubLibraries */,
 			);
@@ -2319,7 +2321,7 @@
 			attributes = {
 				LastUpgradeCheck = 0460;
 			};
-			buildConfigurationList = 4A20B0D31353194B0020F43E /* Build configuration list for PBXProject "pioneer" */;
+			buildConfigurationList = 4A20B0D31353194B0020F43E /* Build configuration list for PBXProject "Pioneer" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -2821,6 +2823,8 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CXX0X_EXTENSIONS = YES;
 				HEADER_SEARCH_PATHS = "";
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME)";
+				PRODUCT_NAME = "${PRODUCT_NAME:c99extidentifier}";
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -2832,6 +2836,8 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CXX0X_EXTENSIONS = YES;
 				HEADER_SEARCH_PATHS = "";
+				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME)";
+				PRODUCT_NAME = "${PRODUCT_NAME:c99extidentifier}";
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -2885,7 +2891,7 @@
 					"\"$(SRCROOT)/../contrib/lua\"",
 					/opt/local/lib,
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_LDFLAGS = "-headerpad_max_install_names";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
@@ -2941,7 +2947,7 @@
 					/opt/local/lib,
 				);
 				LLVM_LTO = NO;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_LDFLAGS = "-headerpad_max_install_names";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
@@ -2966,7 +2972,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		4A20B0D31353194B0020F43E /* Build configuration list for PBXProject "pioneer" */ = {
+		4A20B0D31353194B0020F43E /* Build configuration list for PBXProject "Pioneer" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4A20B0D51353194B0020F43E /* Debug */,

--- a/osx/pioneer.xcodeproj/project.pbxproj
+++ b/osx/pioneer.xcodeproj/project.pbxproj
@@ -215,7 +215,6 @@
 		521EDA231C00D3430092B2E9 /* GasGiantMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9DD1C00D3430092B2E9 /* GasGiantMaterial.cpp */; };
 		521EDA241C00D3430092B2E9 /* GeoSphereMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9DF1C00D3430092B2E9 /* GeoSphereMaterial.cpp */; };
 		521EDA251C00D3430092B2E9 /* gl_core_3_x.c in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */; };
-		521EDA261C00D3430092B2E9 /* LineMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E41C00D3430092B2E9 /* LineMaterial.cpp */; };
 		521EDA281C00D3430092B2E9 /* MaterialGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */; };
 		521EDA291C00D3430092B2E9 /* MultiMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E91C00D3430092B2E9 /* MultiMaterial.cpp */; };
 		521EDA2A1C00D3430092B2E9 /* Program.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9EC1C00D3430092B2E9 /* Program.cpp */; };
@@ -921,8 +920,6 @@
 		521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gl_core_3_x.c; sourceTree = "<group>"; };
 		521ED9E21C00D3430092B2E9 /* gl_core_3_x.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gl_core_3_x.h; sourceTree = "<group>"; };
 		521ED9E31C00D3430092B2E9 /* GLDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLDebug.h; sourceTree = "<group>"; };
-		521ED9E41C00D3430092B2E9 /* LineMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LineMaterial.cpp; sourceTree = "<group>"; };
-		521ED9E51C00D3430092B2E9 /* LineMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LineMaterial.h; sourceTree = "<group>"; };
 		521ED9E61C00D3430092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
 		521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MaterialGL.cpp; sourceTree = "<group>"; };
 		521ED9E81C00D3430092B2E9 /* MaterialGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialGL.h; sourceTree = "<group>"; };
@@ -2238,8 +2235,6 @@
 				521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */,
 				521ED9E21C00D3430092B2E9 /* gl_core_3_x.h */,
 				521ED9E31C00D3430092B2E9 /* GLDebug.h */,
-				521ED9E41C00D3430092B2E9 /* LineMaterial.cpp */,
-				521ED9E51C00D3430092B2E9 /* LineMaterial.h */,
 				521ED9E61C00D3430092B2E9 /* Makefile.am */,
 				521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */,
 				521ED9E81C00D3430092B2E9 /* MaterialGL.h */,
@@ -2585,7 +2580,6 @@
 				521EDC011C00D3A20092B2E9 /* LuaSingle.cpp in Sources */,
 				521EDC061C00D3A20092B2E9 /* LuaWidget.cpp in Sources */,
 				521ED9311C00D14E0092B2E9 /* LuaRef.cpp in Sources */,
-				521EDA261C00D3430092B2E9 /* LineMaterial.cpp in Sources */,
 				521ED9B71C00D3240092B2E9 /* SystemPath.cpp in Sources */,
 				521ED9471C00D14E0092B2E9 /* NavLights.cpp in Sources */,
 				521ED95E1C00D14E0092B2E9 /* ShipController.cpp in Sources */,

--- a/osx/pioneer.xcodeproj/project.pbxproj
+++ b/osx/pioneer.xcodeproj/project.pbxproj
@@ -21,454 +21,424 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		3701C5861B1ABDA2000F4A72 /* libfreetype.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3701C5851B1ABDA2000F4A72 /* libfreetype.6.dylib */; };
+		37074B911B1C653D00AFE2CE /* libbz2.1.0.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 37074B8E1B1C653D00AFE2CE /* libbz2.1.0.6.dylib */; };
+		37074B921B1C653D00AFE2CE /* libpng16.16.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 37074B8F1B1C653D00AFE2CE /* libpng16.16.dylib */; };
+		37074B931B1C653D00AFE2CE /* libz.1.2.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 37074B901B1C653D00AFE2CE /* libz.1.2.8.dylib */; };
+		37074B941B1C6DDC00AFE2CE /* libbz2.1.0.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 37074B8E1B1C653D00AFE2CE /* libbz2.1.0.6.dylib */; };
+		37074B951B1C6DDC00AFE2CE /* libpng16.16.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 37074B8F1B1C653D00AFE2CE /* libpng16.16.dylib */; };
+		37074B961B1C6DDC00AFE2CE /* libz.1.2.8.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 37074B901B1C653D00AFE2CE /* libz.1.2.8.dylib */; };
+		378563521B19769A0039F2BC /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 378563511B19769A0039F2BC /* OpenGL.framework */; };
+		3785635D1B197CF90039F2BC /* JsonUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563581B197CF90039F2BC /* JsonUtils.cpp */; };
+		3785635F1B197CF90039F2BC /* jsoncpp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785635C1B197CF90039F2BC /* jsoncpp.cpp */; };
+		378563911B197D740039F2BC /* BaseSphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563601B197D740039F2BC /* BaseSphere.cpp */; };
+		378563921B197D740039F2BC /* DateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563621B197D740039F2BC /* DateTime.cpp */; };
+		378563931B197D740039F2BC /* FaceParts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563641B197D740039F2BC /* FaceParts.cpp */; };
+		378563941B197D740039F2BC /* GameLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563661B197D740039F2BC /* GameLog.cpp */; };
+		378563951B197D740039F2BC /* GasGiant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563681B197D740039F2BC /* GasGiant.cpp */; };
+		378563961B197D740039F2BC /* GeoPatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785636A1B197D740039F2BC /* GeoPatch.cpp */; };
+		378563971B197D740039F2BC /* GeoPatchContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785636C1B197D740039F2BC /* GeoPatchContext.cpp */; };
+		378563981B197D740039F2BC /* GeoPatchID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785636E1B197D740039F2BC /* GeoPatchID.cpp */; };
+		378563991B197D740039F2BC /* GeoPatchJobs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563701B197D740039F2BC /* GeoPatchJobs.cpp */; };
+		3785639A1B197D740039F2BC /* HudTrail.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563721B197D740039F2BC /* HudTrail.cpp */; };
+		3785639B1B197D740039F2BC /* JobQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563751B197D740039F2BC /* JobQueue.cpp */; };
+		3785639C1B197D740039F2BC /* LuaModelBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563771B197D740039F2BC /* LuaModelBody.cpp */; };
+		3785639F1B197D740039F2BC /* Plane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785637B1B197D740039F2BC /* Plane.cpp */; };
+		378563A01B197D740039F2BC /* Sensors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785637D1B197D740039F2BC /* Sensors.cpp */; };
+		378563A21B197D740039F2BC /* Shields.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563811B197D740039F2BC /* Shields.cpp */; };
+		378563A31B197D740039F2BC /* ShipCockpit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563831B197D740039F2BC /* ShipCockpit.cpp */; };
+		378563A41B197D740039F2BC /* SpeedLines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563851B197D740039F2BC /* SpeedLines.cpp */; };
+		378563A51B197D740039F2BC /* Sphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563871B197D740039F2BC /* Sphere.cpp */; };
+		378563B01B197D9C0039F2BC /* FontConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563AE1B197D9C0039F2BC /* FontConfig.cpp */; };
+		378563C11B197DBB0039F2BC /* Animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563B11B197DBB0039F2BC /* Animation.cpp */; };
+		378563C21B197DBB0039F2BC /* Gauge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563B31B197DBB0039F2BC /* Gauge.cpp */; };
+		378563C31B197DBB0039F2BC /* Layer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563B51B197DBB0039F2BC /* Layer.cpp */; };
+		378563C41B197DBB0039F2BC /* LuaAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563B71B197DBB0039F2BC /* LuaAnimation.cpp */; };
+		378563C51B197DBB0039F2BC /* LuaGauge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563B81B197DBB0039F2BC /* LuaGauge.cpp */; };
+		378563C61B197DBB0039F2BC /* LuaLayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563B91B197DBB0039F2BC /* LuaLayer.cpp */; };
+		378563C71B197DBB0039F2BC /* LuaNumberLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563BA1B197DBB0039F2BC /* LuaNumberLabel.cpp */; };
+		378563C81B197DBB0039F2BC /* LuaTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563BB1B197DBB0039F2BC /* LuaTable.cpp */; };
+		378563C91B197DBB0039F2BC /* NumberLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563BD1B197DBB0039F2BC /* NumberLabel.cpp */; };
+		378563CA1B197DBB0039F2BC /* Table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563BF1B197DBB0039F2BC /* Table.cpp */; };
+		378563CC1B197DC90039F2BC /* TerrainColorEarthLikeHeightmapped.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563CB1B197DC90039F2BC /* TerrainColorEarthLikeHeightmapped.cpp */; };
+		378563D21B197DDE0039F2BC /* BaseLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563CD1B197DDE0039F2BC /* BaseLoader.cpp */; };
+		378563D31B197DDE0039F2BC /* BinaryConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563CF1B197DDE0039F2BC /* BinaryConverter.cpp */; };
+		378563D41B197DDE0039F2BC /* LuaModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563D11B197DDE0039F2BC /* LuaModel.cpp */; };
+		378564121B197E600039F2BC /* RendererDummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563DA1B197E600039F2BC /* RendererDummy.cpp */; };
+		378564131B197E600039F2BC /* FresnelColourMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563DF1B197E600039F2BC /* FresnelColourMaterial.cpp */; };
+		378564141B197E600039F2BC /* GasGiantMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563E21B197E600039F2BC /* GasGiantMaterial.cpp */; };
+		378564151B197E600039F2BC /* GeoSphereMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563E41B197E600039F2BC /* GeoSphereMaterial.cpp */; };
+		378564181B197E600039F2BC /* MaterialGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563E91B197E600039F2BC /* MaterialGL.cpp */; };
+		378564191B197E600039F2BC /* MultiMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563EB1B197E600039F2BC /* MultiMaterial.cpp */; };
+		3785641A1B197E600039F2BC /* Program.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563ED1B197E600039F2BC /* Program.cpp */; };
+		3785641B1B197E600039F2BC /* RenderStateGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563EF1B197E600039F2BC /* RenderStateGL.cpp */; };
+		3785641C1B197E600039F2BC /* RenderTargetGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563F11B197E600039F2BC /* RenderTargetGL.cpp */; };
+		3785641D1B197E600039F2BC /* RendererGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563F31B197E600039F2BC /* RendererGL.cpp */; };
+		3785641E1B197E600039F2BC /* RingMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563F51B197E600039F2BC /* RingMaterial.cpp */; };
+		3785641F1B197E600039F2BC /* ShieldMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563F71B197E600039F2BC /* ShieldMaterial.cpp */; };
+		378564201B197E600039F2BC /* TextureGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563FC1B197E600039F2BC /* TextureGL.cpp */; };
+		378564211B197E600039F2BC /* UIMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378563FE1B197E600039F2BC /* UIMaterial.cpp */; };
+		378564221B197E600039F2BC /* Uniform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564001B197E600039F2BC /* Uniform.cpp */; };
+		378564231B197E600039F2BC /* VertexBufferGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564021B197E600039F2BC /* VertexBufferGL.cpp */; };
+		378564241B197E600039F2BC /* VtxColorMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564041B197E600039F2BC /* VtxColorMaterial.cpp */; };
+		378564251B197E600039F2BC /* gl_core_3_x.c in Sources */ = {isa = PBXBuildFile; fileRef = 378564061B197E600039F2BC /* gl_core_3_x.c */; };
+		378564261B197E600039F2BC /* Stats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785640A1B197E600039F2BC /* Stats.cpp */; };
+		378564271B197E600039F2BC /* VertexBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785640D1B197E600039F2BC /* VertexBuffer.cpp */; };
+		378564281B197E600039F2BC /* WindowSDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785640F1B197E600039F2BC /* WindowSDL.cpp */; };
+		3785642C1B197E7A0039F2BC /* BindingCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564291B197E7A0039F2BC /* BindingCapture.cpp */; };
+		3785642D1B197E7A0039F2BC /* LuaBindingCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785642B1B197E7A0039F2BC /* LuaBindingCapture.cpp */; };
+		378564381B197E8B0039F2BC /* Economy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785642E1B197E8B0039F2BC /* Economy.cpp */; };
+		378564391B197E8B0039F2BC /* GalaxyCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564301B197E8B0039F2BC /* GalaxyCache.cpp */; };
+		3785643A1B197E8B0039F2BC /* GalaxyGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564321B197E8B0039F2BC /* GalaxyGenerator.cpp */; };
+		3785643B1B197E8B0039F2BC /* SectorGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564341B197E8B0039F2BC /* SectorGenerator.cpp */; };
+		3785643C1B197E8B0039F2BC /* StarSystemGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564361B197E8B0039F2BC /* StarSystemGenerator.cpp */; };
+		3785644B1B197EB60039F2BC /* PicoDDS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564431B197EB60039F2BC /* PicoDDS.cpp */; };
+		3785644D1B197EB60039F2BC /* Profiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564471B197EB60039F2BC /* Profiler.cpp */; };
+		378564521B197FAE0039F2BC /* LuaServerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3785644E1B197FAE0039F2BC /* LuaServerAgent.cpp */; };
+		378564531B197FAE0039F2BC /* ServerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 378564501B197FAE0039F2BC /* ServerAgent.cpp */; };
+		44B75A971B1C259200EC500F /* libfreetype.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 3701C5851B1ABDA2000F4A72 /* libfreetype.6.dylib */; };
+		44B75A981B1C259500EC500F /* libassimp.3.0.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */; };
+		44B75A991B1C259600EC500F /* libsigc-2.0.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */; };
+		4A01889715A59908002F540B /* SystemPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A01889615A59908002F540B /* SystemPath.cpp */; };
+		4A0F25CE165CF00D00208507 /* LuaSmallButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A0F25CB165CF00D00208507 /* LuaSmallButton.cpp */; };
+		4A0F25CF165CF00D00208507 /* SmallButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A0F25CC165CF00D00208507 /* SmallButton.cpp */; };
+		4A107C2F1525AB0D00EF9FAC /* CRC32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A107C2B1525AB0D00EF9FAC /* CRC32.cpp */; };
+		4A107C301525AB0D00EF9FAC /* ShipController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A107C2D1525AB0D00EF9FAC /* ShipController.cpp */; };
+		4A19038C138AA33300E0229C /* Gui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190325138AA33300E0229C /* Gui.cpp */; };
+		4A19038E138AA33300E0229C /* GuiBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190329138AA33300E0229C /* GuiBox.cpp */; };
+		4A190390138AA33300E0229C /* GuiButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19032C138AA33300E0229C /* GuiButton.cpp */; };
+		4A190392138AA33300E0229C /* GuiContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19032F138AA33300E0229C /* GuiContainer.cpp */; };
+		4A190394138AA33300E0229C /* GuiFixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190333138AA33300E0229C /* GuiFixed.cpp */; };
+		4A190396138AA33300E0229C /* GuiImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190336138AA33300E0229C /* GuiImage.cpp */; };
+		4A190398138AA33300E0229C /* GuiImageButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190339138AA33300E0229C /* GuiImageButton.cpp */; };
+		4A19039A138AA33300E0229C /* GuiImageRadioButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19033C138AA33300E0229C /* GuiImageRadioButton.cpp */; };
+		4A19039C138AA33300E0229C /* GuiLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190340138AA33300E0229C /* GuiLabel.cpp */; };
+		4A19039E138AA33300E0229C /* GuiLabelSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190343138AA33300E0229C /* GuiLabelSet.cpp */; };
+		4A1903A0138AA33300E0229C /* GuiMeterBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190346138AA33300E0229C /* GuiMeterBar.cpp */; };
+		4A1903A2138AA33300E0229C /* GuiMultiStateImageButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190349138AA33300E0229C /* GuiMultiStateImageButton.cpp */; };
+		4A1903A4138AA33300E0229C /* GuiRadioButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19034C138AA33300E0229C /* GuiRadioButton.cpp */; };
+		4A1903A6138AA33300E0229C /* GuiRadioGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19034F138AA33300E0229C /* GuiRadioGroup.cpp */; };
+		4A1903AA138AA33300E0229C /* GuiScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190355138AA33300E0229C /* GuiScreen.cpp */; };
+		4A1903AC138AA33300E0229C /* GuiTabbed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190358138AA33300E0229C /* GuiTabbed.cpp */; };
+		4A1903AE138AA33300E0229C /* GuiTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19035B138AA33300E0229C /* GuiTextEntry.cpp */; };
+		4A1903B0138AA33300E0229C /* GuiTextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19035E138AA33300E0229C /* GuiTextLayout.cpp */; };
+		4A1903B2138AA33300E0229C /* GuiToggleButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190361138AA33300E0229C /* GuiToggleButton.cpp */; };
+		4A1903B4138AA33300E0229C /* GuiToolTip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190364138AA33300E0229C /* GuiToolTip.cpp */; };
+		4A1903B6138AA33300E0229C /* GuiVScrollBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190367138AA33300E0229C /* GuiVScrollBar.cpp */; };
+		4A1903B8138AA33300E0229C /* GuiVScrollPortal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19036A138AA33300E0229C /* GuiVScrollPortal.cpp */; };
+		4A1903BA138AA33300E0229C /* GuiWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19036D138AA33300E0229C /* GuiWidget.cpp */; };
+		4A1904A8138AA39C00E0229C /* lapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903E2138AA39C00E0229C /* lapi.c */; };
+		4A1904AA138AA39C00E0229C /* lauxlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903E5138AA39C00E0229C /* lauxlib.c */; };
+		4A1904AC138AA39C00E0229C /* lbaselib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903E8138AA39C00E0229C /* lbaselib.c */; };
+		4A1904AE138AA39C00E0229C /* lcode.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903EA138AA39C00E0229C /* lcode.c */; };
+		4A1904B0138AA39C00E0229C /* ldblib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903ED138AA39C00E0229C /* ldblib.c */; };
+		4A1904B2138AA39C00E0229C /* ldebug.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903EF138AA39C00E0229C /* ldebug.c */; };
+		4A1904B4138AA39C00E0229C /* ldo.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903F2138AA39C00E0229C /* ldo.c */; };
+		4A1904B6138AA39C00E0229C /* ldump.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903F5138AA39C00E0229C /* ldump.c */; };
+		4A1904B8138AA39C00E0229C /* lfunc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903F7138AA39C00E0229C /* lfunc.c */; };
+		4A1904BA138AA39C00E0229C /* lgc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903FA138AA39C00E0229C /* lgc.c */; };
+		4A1904BD138AA39C00E0229C /* linit.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903FE138AA39C00E0229C /* linit.c */; };
+		4A1904BF138AA39C00E0229C /* liolib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190400138AA39C00E0229C /* liolib.c */; };
+		4A1904C1138AA39C00E0229C /* llex.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190402138AA39C00E0229C /* llex.c */; };
+		4A1904C3138AA39C00E0229C /* lmathlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190406138AA39C00E0229C /* lmathlib.c */; };
+		4A1904C5138AA39C00E0229C /* lmem.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190408138AA39C00E0229C /* lmem.c */; };
+		4A1904C7138AA39C00E0229C /* loadlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19040B138AA39C00E0229C /* loadlib.c */; };
+		4A1904C9138AA39C00E0229C /* lobject.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19040D138AA39C00E0229C /* lobject.c */; };
+		4A1904CB138AA39C00E0229C /* lopcodes.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190410138AA39C00E0229C /* lopcodes.c */; };
+		4A1904CD138AA39C00E0229C /* loslib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190413138AA39C00E0229C /* loslib.c */; };
+		4A1904CF138AA39C00E0229C /* lparser.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190415138AA39C00E0229C /* lparser.c */; };
+		4A1904D1138AA39C00E0229C /* lstate.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190418138AA39C00E0229C /* lstate.c */; };
+		4A1904D3138AA39C00E0229C /* lstring.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19041B138AA39C00E0229C /* lstring.c */; };
+		4A1904D5138AA39C00E0229C /* lstrlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19041E138AA39C00E0229C /* lstrlib.c */; };
+		4A1904D7138AA39C00E0229C /* ltable.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190420138AA39C00E0229C /* ltable.c */; };
+		4A1904D9138AA39C00E0229C /* ltablib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190423138AA39C00E0229C /* ltablib.c */; };
+		4A1904DB138AA39C00E0229C /* ltm.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190425138AA39C00E0229C /* ltm.c */; };
+		4A1904DF138AA39C00E0229C /* lundump.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19042D138AA39C00E0229C /* lundump.c */; };
+		4A1904E1138AA39C00E0229C /* lvm.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190430138AA39C00E0229C /* lvm.c */; };
+		4A1904E3138AA39C00E0229C /* lzio.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190433138AA39C00E0229C /* lzio.c */; };
 		4A20B0E3135319770020F43E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A20B0E2135319770020F43E /* Cocoa.framework */; };
 		4A20B11C13531CD10020F43E /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 4A20B11613531CD10020F43E /* Credits.rtf */; };
 		4A20B11D13531CD10020F43E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4A20B11813531CD10020F43E /* InfoPlist.strings */; };
 		4A20B12013531E950020F43E /* pioneerApp.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A20B11F13531E950020F43E /* pioneerApp.xib */; };
-		4A5619CF13866622002A904C /* libfreetype.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A5619CE13866622002A904C /* libfreetype.6.dylib */; };
-		4A5619D313866B5B002A904C /* libfreetype.6.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4A5619CE13866622002A904C /* libfreetype.6.dylib */; };
-		4A5619D513867033002A904C /* libvorbisfile.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A5619D413867033002A904C /* libvorbisfile.3.dylib */; };
-		4A5619D813867661002A904C /* libvorbisfile.3.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4A5619D413867033002A904C /* libvorbisfile.3.dylib */; };
-		4A671B8A1388C08500657F38 /* libogg.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B861388C07700657F38 /* libogg.0.dylib */; };
-		4A671B8B1388C08500657F38 /* libvorbis.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B871388C07700657F38 /* libvorbis.0.dylib */; };
-		4A671B9A1388C62800657F38 /* libsmpeg-0.4.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B981388C61F00657F38 /* libsmpeg-0.4.0.dylib */; };
-		4A671B9D1388C6C400657F38 /* libmodplug.1.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B9B1388C6B700657F38 /* libmodplug.1.dylib */; };
-		4A671BA31388CA3F00657F38 /* libspeex.1.5.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671BA11388CA3200657F38 /* libspeex.1.5.0.dylib */; };
+		4A239FCB163E78D60037BE24 /* LuaFaction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A239FC9163E78D60037BE24 /* LuaFaction.cpp */; };
+		4A24077413F5240F002A5C12 /* Lang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24075A13F5240F002A5C12 /* Lang.cpp */; };
+		4A24078513F524E6002A5C12 /* GuiStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24078213F524E6002A5C12 /* GuiStack.cpp */; };
+		4A24FD5E1650F4B700DE7B0F /* UIView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24FD5C1650F4B700DE7B0F /* UIView.cpp */; };
+		4A24FD671650F4D100DE7B0F /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24FD621650F4D100DE7B0F /* Lua.cpp */; };
+		4A24FD691650F4D100DE7B0F /* Panel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24FD651650F4D100DE7B0F /* Panel.cpp */; };
+		4A305FD1151341170076D414 /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A305FCC151341170076D414 /* FileSystem.cpp */; };
+		4A37073615A879D100E7E5F6 /* lookup3.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A37073315A879D100E7E5F6 /* lookup3.c */; };
+		4A3AE8E5158FD22200EB13DE /* LuaComms.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A3AE8E3158FD22200EB13DE /* LuaComms.cpp */; };
+		4A4A86E916A992D600F81F18 /* CameraController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A86E716A992D600F81F18 /* CameraController.cpp */; };
+		4A4D25D8167335D9003BC9D5 /* Face.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D25D2167335D9003BC9D5 /* Face.cpp */; };
+		4A4D25D9167335D9003BC9D5 /* LuaFace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D25D4167335D9003BC9D5 /* LuaFace.cpp */; };
+		4A4D25DF167335F5003BC9D5 /* Icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D25DC167335F5003BC9D5 /* Icon.cpp */; };
+		4A4D25E0167335F5003BC9D5 /* LuaIcon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D25DE167335F5003BC9D5 /* LuaIcon.cpp */; };
+		4A4F25D214F524D400FD14A6 /* Drawables.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25B914F524D400FD14A6 /* Drawables.cpp */; };
+		4A4F25D314F524D400FD14A6 /* Frustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25BB14F524D400FD14A6 /* Frustum.cpp */; };
+		4A4F25D414F524D400FD14A6 /* Graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25BD14F524D400FD14A6 /* Graphics.cpp */; };
+		4A4F25D614F524D400FD14A6 /* Material.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25C014F524D400FD14A6 /* Material.cpp */; };
+		4A4F25D714F524D400FD14A6 /* Renderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25C214F524D400FD14A6 /* Renderer.cpp */; };
+		4A4F25DD14F524D400FD14A6 /* VertexArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25D014F524D400FD14A6 /* VertexArray.cpp */; };
+		4A59B4DA1557EAF5009926E5 /* lbitlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B4D51557EAF5009926E5 /* lbitlib.c */; };
+		4A59B4DB1557EAF5009926E5 /* lcorolib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B4D61557EAF5009926E5 /* lcorolib.c */; };
+		4A59B4DC1557EAF5009926E5 /* lctype.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B4D71557EAF5009926E5 /* lctype.c */; };
+		4A61E15E13978F1000193E43 /* Background.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A61E15C13978F1000193E43 /* Background.cpp */; };
+		4A6B59CC1429F14500ADC7C8 /* StringF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B59CA1429F14500ADC7C8 /* StringF.cpp */; };
+		4A6C4DD113532FC300FDD53F /* AmbientSounds.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4BFF13532FC300FDD53F /* AmbientSounds.cpp */; };
+		4A6C4DD213532FC300FDD53F /* Body.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C0213532FC300FDD53F /* Body.cpp */; };
+		4A6C4DD313532FC300FDD53F /* CargoBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C0513532FC300FDD53F /* CargoBody.cpp */; };
+		4A6C4DD413532FC300FDD53F /* CityOnPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C0713532FC300FDD53F /* CityOnPlanet.cpp */; };
+		4A6C4DD913532FC300FDD53F /* BVHTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C0F13532FC300FDD53F /* BVHTree.cpp */; };
+		4A6C4DDA13532FC300FDD53F /* CollisionSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C1313532FC300FDD53F /* CollisionSpace.cpp */; };
+		4A6C4DDB13532FC300FDD53F /* Geom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C1513532FC300FDD53F /* Geom.cpp */; };
+		4A6C4DDC13532FC300FDD53F /* GeomTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C1713532FC300FDD53F /* GeomTree.cpp */; };
+		4A6C4DE213532FC300FDD53F /* DynamicBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C2113532FC300FDD53F /* DynamicBody.cpp */; };
+		4A6C4DE413532FC300FDD53F /* Frame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C2613532FC300FDD53F /* Frame.cpp */; };
+		4A6C4DE513532FC300FDD53F /* GalacticView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C2813532FC300FDD53F /* GalacticView.cpp */; };
+		4A6C4DE913532FC300FDD53F /* GeoSphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C3113532FC300FDD53F /* GeoSphere.cpp */; };
+		4A6C4E0413532FC300FDD53F /* HyperspaceCloud.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C6A13532FC300FDD53F /* HyperspaceCloud.cpp */; };
+		4A6C4E0613532FC300FDD53F /* IniConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C6E13532FC300FDD53F /* IniConfig.cpp */; };
+		4A6C4E0713532FC300FDD53F /* KeyBindings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C7013532FC300FDD53F /* KeyBindings.cpp */; };
+		4A6C4E4D13532FC300FDD53F /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CD313532FC300FDD53F /* main.cpp */; };
+		4A6C4E5213532FC300FDD53F /* Missile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CDA13532FC300FDD53F /* Missile.cpp */; };
+		4A6C4E5413532FC300FDD53F /* ModelBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CDE13532FC300FDD53F /* ModelBody.cpp */; };
+		4A6C4E5913532FC300FDD53F /* ObjectViewerView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CE913532FC300FDD53F /* ObjectViewerView.cpp */; };
+		4A6C4E7113532FC300FDD53F /* perlin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D2C13532FC300FDD53F /* perlin.cpp */; };
+		4A6C4E7213532FC300FDD53F /* Pi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D2F13532FC300FDD53F /* Pi.cpp */; };
+		4A6C4E7713532FC300FDD53F /* Planet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D3913532FC300FDD53F /* Planet.cpp */; };
+		4A6C4E7813532FC300FDD53F /* Player.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D3B13532FC300FDD53F /* Player.cpp */; };
+		4A6C4E7A13532FC300FDD53F /* Polit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D3F13532FC300FDD53F /* Polit.cpp */; };
+		4A6C4E7B13532FC300FDD53F /* Projectile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4113532FC300FDD53F /* Projectile.cpp */; };
+		4A6C4E7E13532FC300FDD53F /* SectorView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4813532FC300FDD53F /* SectorView.cpp */; };
+		4A6C4E7F13532FC300FDD53F /* Serializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4A13532FC300FDD53F /* Serializer.cpp */; };
+		4A6C4E8013532FC300FDD53F /* Sfx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4C13532FC300FDD53F /* Sfx.cpp */; };
+		4A6C4E8113532FC300FDD53F /* Ship-AI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4E13532FC300FDD53F /* Ship-AI.cpp */; };
+		4A6C4E8213532FC300FDD53F /* Ship.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4F13532FC300FDD53F /* Ship.cpp */; };
+		4A6C4E8313532FC300FDD53F /* ShipAICmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5113532FC300FDD53F /* ShipAICmd.cpp */; };
+		4A6C4E8413532FC300FDD53F /* ShipCpanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5313532FC300FDD53F /* ShipCpanel.cpp */; };
+		4A6C4E8513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp */; };
+		4A6C4E8713532FC300FDD53F /* ShipType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5913532FC300FDD53F /* ShipType.cpp */; };
+		4A6C4E8813532FC300FDD53F /* Sound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5B13532FC300FDD53F /* Sound.cpp */; };
+		4A6C4E8913532FC300FDD53F /* Space.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5D13532FC300FDD53F /* Space.cpp */; };
+		4A6C4E8A13532FC300FDD53F /* SpaceStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5F13532FC300FDD53F /* SpaceStation.cpp */; };
+		4A6C4E8C13532FC300FDD53F /* Star.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6313532FC300FDD53F /* Star.cpp */; };
+		4A6C4E8F13532FC300FDD53F /* SystemInfoView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6913532FC300FDD53F /* SystemInfoView.cpp */; };
+		4A6C4E9013532FC300FDD53F /* SystemView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6B13532FC300FDD53F /* SystemView.cpp */; };
+		4A6C4E9213532FC300FDD53F /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6E13532FC300FDD53F /* utils.cpp */; };
+		4A6C4E9313532FC300FDD53F /* WorldView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D7213532FC300FDD53F /* WorldView.cpp */; };
 		4A6C4EA2135452FF00FDD53F /* libsigc-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */; };
 		4A6C55151354655000FDD53F /* data in Copy Data files and folders */ = {isa = PBXBuildFile; fileRef = 4A6C55141354655000FDD53F /* data */; };
-		4A76112A1611A92400A06F79 /* libFLAC.8.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A7611281611A90B00A06F79 /* libFLAC.8.dylib */; };
+		4A712413170EC89000BB9BCC /* Orbit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A712411170EC89000BB9BCC /* Orbit.cpp */; };
+		4A82AA861386969B0028CCED /* GameConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A82AA7D1386969B0028CCED /* GameConfig.cpp */; };
+		4A84CB7D14595D850051C848 /* enum_table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A84CB7B14595D850051C848 /* enum_table.cpp */; };
+		4A84CB84146027DC0051C848 /* Camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A84CB82146027DC0051C848 /* Camera.cpp */; };
 		4A8563FD148655DA008121E1 /* pioneer-logo.icns in Resources */ = {isa = PBXBuildFile; fileRef = 4A8563FC148655DA008121E1 /* pioneer-logo.icns */; };
+		4A85A86A13C4631D00C2B986 /* LuaMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A85A86313C4631D00C2B986 /* LuaMusic.cpp */; };
+		4A85A86B13C4631D00C2B986 /* LuaSystemPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A85A86513C4631D00C2B986 /* LuaSystemPath.cpp */; };
+		4A85A86C13C4631D00C2B986 /* SoundMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A85A86713C4631D00C2B986 /* SoundMusic.cpp */; };
+		4A8AE19617208CE50005C2D9 /* LuaPropertiedObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AE19217208CE40005C2D9 /* LuaPropertiedObject.cpp */; };
+		4A8AE19717208CE50005C2D9 /* PropertyMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AE19417208CE40005C2D9 /* PropertyMap.cpp */; };
+		4A8DD53B142E19B6006DD821 /* LuaConsole.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A8DD539142E19B6006DD821 /* LuaConsole.cpp */; };
+		4A9174F415187B69006A15A9 /* GuiTexturedQuad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9174F215187B69006A15A9 /* GuiTexturedQuad.cpp */; };
+		4A9174FB15187B97006A15A9 /* TextureBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9174F715187B97006A15A9 /* TextureBuilder.cpp */; };
+		4A9174FE15187C17006A15A9 /* Color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9174FD15187C17006A15A9 /* Color.cpp */; };
+		4A94CA4514F26875002CA792 /* FontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A94CA4114F26875002CA792 /* FontCache.cpp */; };
+		4A973BF71618688F0029562D /* DeathView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A973BF31618688F0029562D /* DeathView.cpp */; };
+		4A973BF81618688F0029562D /* LuaDev.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A973BF51618688F0029562D /* LuaDev.cpp */; };
+		4A9937511368355500EA0EE5 /* LuaBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99371B1368355400EA0EE5 /* LuaBody.cpp */; };
+		4A9937521368355500EA0EE5 /* LuaCargoBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99371D1368355400EA0EE5 /* LuaCargoBody.cpp */; };
+		4A9937531368355500EA0EE5 /* LuaConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99371F1368355500EA0EE5 /* LuaConstants.cpp */; };
+		4A9937541368355500EA0EE5 /* LuaEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937211368355500EA0EE5 /* LuaEngine.cpp */; };
+		4A9937571368355500EA0EE5 /* LuaFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937271368355500EA0EE5 /* LuaFormat.cpp */; };
+		4A9937581368355500EA0EE5 /* LuaGame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937291368355500EA0EE5 /* LuaGame.cpp */; };
+		4A9937591368355500EA0EE5 /* LuaManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99372B1368355500EA0EE5 /* LuaManager.cpp */; };
+		4A99375A1368355500EA0EE5 /* LuaNameGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99372D1368355500EA0EE5 /* LuaNameGen.cpp */; };
+		4A99375B1368355500EA0EE5 /* LuaObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99372F1368355500EA0EE5 /* LuaObject.cpp */; };
+		4A99375C1368355500EA0EE5 /* LuaPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937301368355500EA0EE5 /* LuaPlanet.cpp */; };
+		4A99375D1368355500EA0EE5 /* LuaPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937321368355500EA0EE5 /* LuaPlayer.cpp */; };
+		4A99375E1368355500EA0EE5 /* LuaRand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937341368355500EA0EE5 /* LuaRand.cpp */; };
+		4A9937611368355500EA0EE5 /* LuaSerializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99373A1368355500EA0EE5 /* LuaSerializer.cpp */; };
+		4A9937621368355500EA0EE5 /* LuaShip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99373C1368355500EA0EE5 /* LuaShip.cpp */; };
+		4A9937641368355500EA0EE5 /* LuaSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937401368355500EA0EE5 /* LuaSpace.cpp */; };
+		4A9937651368355500EA0EE5 /* LuaSpaceStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937421368355500EA0EE5 /* LuaSpaceStation.cpp */; };
+		4A9937661368355500EA0EE5 /* LuaStar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937441368355500EA0EE5 /* LuaStar.cpp */; };
+		4A9937671368355500EA0EE5 /* LuaStarSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937461368355500EA0EE5 /* LuaStarSystem.cpp */; };
+		4A9937681368355500EA0EE5 /* LuaTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937481368355500EA0EE5 /* LuaTimer.cpp */; };
+		4A99376A1368355500EA0EE5 /* LuaUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99374C1368355500EA0EE5 /* LuaUtils.cpp */; };
+		4AA4A8DA164D0EB10006C3BF /* Expand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4A8D4164D0EB10006C3BF /* Expand.cpp */; };
+		4AA4A8DB164D0EB10006C3BF /* Gradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4A8D6164D0EB10006C3BF /* Gradient.cpp */; };
+		4AA4A8DC164D0EB10006C3BF /* LuaExpand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4A8D8164D0EB10006C3BF /* LuaExpand.cpp */; };
+		4AA4A8DD164D0EB10006C3BF /* LuaGradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4A8D9164D0EB10006C3BF /* LuaGradient.cpp */; };
+		4AA527FA16E9EABA0036D4CB /* NavLights.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA527F816E9EABA0036D4CB /* NavLights.cpp */; };
+		4AA527FE16E9EB650036D4CB /* LuaModelSpinner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA527FB16E9EB650036D4CB /* LuaModelSpinner.cpp */; };
+		4AA527FF16E9EB650036D4CB /* ModelSpinner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA527FC16E9EB650036D4CB /* ModelSpinner.cpp */; };
+		4AA5280516E9EB980036D4CB /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5280016E9EB980036D4CB /* Lua.cpp */; };
+		4AA5280616E9EB980036D4CB /* ModelSkin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5280216E9EB980036D4CB /* ModelSkin.cpp */; };
+		4AA5280816E9EBD60036D4CB /* LuaModelSkin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5280716E9EBD60036D4CB /* LuaModelSkin.cpp */; };
+		4AA84A2816D0E18700220311 /* LuaShipDef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA84A2316D0E18700220311 /* LuaShipDef.cpp */; };
+		4AA9F6CC17288E0900124C2E /* TerrainHeightEllipsoid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA9F6CB17288E0900124C2E /* TerrainHeightEllipsoid.cpp */; };
+		4AAB881D15F4AD7700AAF8A8 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB881A15F4AD7700AAF8A8 /* Lua.cpp */; };
+		4AAB884815FDEA6F00AAF8A8 /* LuaRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB884515FDEA6E00AAF8A8 /* LuaRef.cpp */; };
+		4AAC9FE91545901D00116131 /* FileSourceZip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAC9FE51545901D00116131 /* FileSourceZip.cpp */; };
+		4AAC9FEA1545901D00116131 /* ModManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAC9FE71545901D00116131 /* ModManager.cpp */; };
+		4AB3DF8914346952001B783A /* TerrainBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB3DF8714346952001B783A /* TerrainBody.cpp */; };
+		4AB7D6031472A83E00158DE4 /* Terrain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D11472A83E00158DE4 /* Terrain.cpp */; };
+		4AB7D6041472A83E00158DE4 /* TerrainColorAsteroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D31472A83E00158DE4 /* TerrainColorAsteroid.cpp */; };
+		4AB7D6051472A83E00158DE4 /* TerrainColorBandedRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D41472A83E00158DE4 /* TerrainColorBandedRock.cpp */; };
+		4AB7D6061472A83E00158DE4 /* TerrainColorDeadWithWater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D51472A83E00158DE4 /* TerrainColorDeadWithWater.cpp */; };
+		4AB7D6071472A83E00158DE4 /* TerrainColorDesert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D61472A83E00158DE4 /* TerrainColorDesert.cpp */; };
+		4AB7D6081472A83E00158DE4 /* TerrainColorEarthLike.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D71472A83E00158DE4 /* TerrainColorEarthLike.cpp */; };
+		4AB7D6091472A83E00158DE4 /* TerrainColorGGJupiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D81472A83E00158DE4 /* TerrainColorGGJupiter.cpp */; };
+		4AB7D60A1472A83E00158DE4 /* TerrainColorGGNeptune.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D91472A83E00158DE4 /* TerrainColorGGNeptune.cpp */; };
+		4AB7D60B1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DA1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp */; };
+		4AB7D60C1472A83E00158DE4 /* TerrainColorGGSaturn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DB1472A83E00158DE4 /* TerrainColorGGSaturn.cpp */; };
+		4AB7D60D1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DC1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp */; };
+		4AB7D60E1472A83E00158DE4 /* TerrainColorGGUranus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DD1472A83E00158DE4 /* TerrainColorGGUranus.cpp */; };
+		4AB7D60F1472A83E00158DE4 /* TerrainColorIce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DE1472A83E00158DE4 /* TerrainColorIce.cpp */; };
+		4AB7D6101472A83E00158DE4 /* TerrainColorMethane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DF1472A83E00158DE4 /* TerrainColorMethane.cpp */; };
+		4AB7D6111472A83E00158DE4 /* TerrainColorRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E01472A83E00158DE4 /* TerrainColorRock.cpp */; };
+		4AB7D6121472A83E00158DE4 /* TerrainColorRock2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E11472A83E00158DE4 /* TerrainColorRock2.cpp */; };
+		4AB7D6131472A83E00158DE4 /* TerrainColorSolid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E21472A83E00158DE4 /* TerrainColorSolid.cpp */; };
+		4AB7D6141472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E31472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp */; };
+		4AB7D6151472A83E00158DE4 /* TerrainColorStarG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E41472A83E00158DE4 /* TerrainColorStarG.cpp */; };
+		4AB7D6161472A83E00158DE4 /* TerrainColorStarK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E51472A83E00158DE4 /* TerrainColorStarK.cpp */; };
+		4AB7D6171472A83E00158DE4 /* TerrainColorStarM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E61472A83E00158DE4 /* TerrainColorStarM.cpp */; };
+		4AB7D6181472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E71472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp */; };
+		4AB7D6191472A83E00158DE4 /* TerrainColorTFGood.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E81472A83E00158DE4 /* TerrainColorTFGood.cpp */; };
+		4AB7D61A1472A83E00158DE4 /* TerrainColorTFPoor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E91472A83E00158DE4 /* TerrainColorTFPoor.cpp */; };
+		4AB7D61B1472A83E00158DE4 /* TerrainColorVolcanic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5EA1472A83E00158DE4 /* TerrainColorVolcanic.cpp */; };
+		4AB7D61C1472A83E00158DE4 /* TerrainFeature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5EB1472A83E00158DE4 /* TerrainFeature.cpp */; };
+		4AB7D61D1472A83E00158DE4 /* TerrainHeightAsteroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5ED1472A83E00158DE4 /* TerrainHeightAsteroid.cpp */; };
+		4AB7D61E1472A83E00158DE4 /* TerrainHeightFlat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5EE1472A83E00158DE4 /* TerrainHeightFlat.cpp */; };
+		4AB7D61F1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5EF1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp */; };
+		4AB7D6201472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F01472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp */; };
+		4AB7D6211472A83E00158DE4 /* TerrainHeightHillsDunes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F11472A83E00158DE4 /* TerrainHeightHillsDunes.cpp */; };
+		4AB7D6221472A83E00158DE4 /* TerrainHeightHillsNormal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F21472A83E00158DE4 /* TerrainHeightHillsNormal.cpp */; };
+		4AB7D6231472A83E00158DE4 /* TerrainHeightHillsRidged.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F31472A83E00158DE4 /* TerrainHeightHillsRidged.cpp */; };
+		4AB7D6241472A83E00158DE4 /* TerrainHeightHillsRivers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F41472A83E00158DE4 /* TerrainHeightHillsRivers.cpp */; };
+		4AB7D6251472A83E00158DE4 /* TerrainHeightMapped.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F51472A83E00158DE4 /* TerrainHeightMapped.cpp */; };
+		4AB7D6261472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F61472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp */; };
+		4AB7D6271472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F71472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp */; };
+		4AB7D6281472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F81472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp */; };
+		4AB7D6291472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F91472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp */; };
+		4AB7D62A1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FA1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp */; };
+		4AB7D62B1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FB1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp */; };
+		4AB7D62C1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FC1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp */; };
+		4AB7D62D1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FD1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp */; };
+		4AB7D62E1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FE1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp */; };
+		4AB7D62F1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FF1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp */; };
+		4AB7D6301472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D6001472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp */; };
+		4ABF307916335A1100664653 /* Align.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF302E16335A1100664653 /* Align.cpp */; };
+		4ABF307A16335A1100664653 /* Background.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303016335A1100664653 /* Background.cpp */; };
+		4ABF307B16335A1100664653 /* Box.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303216335A1100664653 /* Box.cpp */; };
+		4ABF307C16335A1100664653 /* Button.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303416335A1100664653 /* Button.cpp */; };
+		4ABF307D16335A1100664653 /* CellSpec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303616335A1100664653 /* CellSpec.cpp */; };
+		4ABF307E16335A1100664653 /* CheckBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303816335A1100664653 /* CheckBox.cpp */; };
+		4ABF307F16335A1100664653 /* ColorBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303A16335A1100664653 /* ColorBackground.cpp */; };
+		4ABF308016335A1100664653 /* Container.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303C16335A1100664653 /* Container.cpp */; };
+		4ABF308116335A1100664653 /* Context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303E16335A1100664653 /* Context.cpp */; };
+		4ABF308216335A1100664653 /* DropDown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304016335A1100664653 /* DropDown.cpp */; };
+		4ABF308316335A1100664653 /* Event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304216335A1100664653 /* Event.cpp */; };
+		4ABF308416335A1100664653 /* EventDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304416335A1100664653 /* EventDispatcher.cpp */; };
+		4ABF308616335A1100664653 /* Grid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304816335A1100664653 /* Grid.cpp */; };
+		4ABF308716335A1100664653 /* Image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304A16335A1100664653 /* Image.cpp */; };
+		4ABF308816335A1100664653 /* Label.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304C16335A1100664653 /* Label.cpp */; };
+		4ABF308916335A1100664653 /* List.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304E16335A1100664653 /* List.cpp */; };
+		4ABF308A16335A1100664653 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305016335A1100664653 /* Lua.cpp */; };
+		4ABF308B16335A1100664653 /* LuaAlign.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305216335A1100664653 /* LuaAlign.cpp */; };
+		4ABF308C16335A1100664653 /* LuaBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305316335A1100664653 /* LuaBackground.cpp */; };
+		4ABF308D16335A1100664653 /* LuaBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305416335A1100664653 /* LuaBox.cpp */; };
+		4ABF308E16335A1100664653 /* LuaButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305516335A1100664653 /* LuaButton.cpp */; };
+		4ABF308F16335A1100664653 /* LuaCheckBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305616335A1100664653 /* LuaCheckBox.cpp */; };
+		4ABF309016335A1100664653 /* LuaColorBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305716335A1100664653 /* LuaColorBackground.cpp */; };
+		4ABF309116335A1100664653 /* LuaContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305816335A1100664653 /* LuaContainer.cpp */; };
+		4ABF309216335A1100664653 /* LuaContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305916335A1100664653 /* LuaContext.cpp */; };
+		4ABF309316335A1100664653 /* LuaDropDown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305A16335A1100664653 /* LuaDropDown.cpp */; };
+		4ABF309416335A1100664653 /* LuaGrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305B16335A1100664653 /* LuaGrid.cpp */; };
+		4ABF309516335A1100664653 /* LuaImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305C16335A1100664653 /* LuaImage.cpp */; };
+		4ABF309616335A1100664653 /* LuaLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305D16335A1100664653 /* LuaLabel.cpp */; };
+		4ABF309716335A1100664653 /* LuaList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305E16335A1100664653 /* LuaList.cpp */; };
+		4ABF309816335A1100664653 /* LuaMargin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305F16335A1100664653 /* LuaMargin.cpp */; };
+		4ABF309916335A1100664653 /* LuaMultiLineText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306016335A1100664653 /* LuaMultiLineText.cpp */; };
+		4ABF309A16335A1100664653 /* LuaScroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306116335A1100664653 /* LuaScroller.cpp */; };
+		4ABF309B16335A1100664653 /* LuaSingle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306316335A1100664653 /* LuaSingle.cpp */; };
+		4ABF309C16335A1100664653 /* LuaSlider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306416335A1100664653 /* LuaSlider.cpp */; };
+		4ABF309D16335A1100664653 /* LuaWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306516335A1100664653 /* LuaWidget.cpp */; };
+		4ABF309F16335A1100664653 /* Margin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306716335A1100664653 /* Margin.cpp */; };
+		4ABF30A016335A1100664653 /* MultiLineText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306916335A1100664653 /* MultiLineText.cpp */; };
+		4ABF30A116335A1100664653 /* Scroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306C16335A1100664653 /* Scroller.cpp */; };
+		4ABF30A216335A1100664653 /* Single.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306E16335A1100664653 /* Single.cpp */; };
+		4ABF30A316335A1100664653 /* Skin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF307016335A1100664653 /* Skin.cpp */; };
+		4ABF30A416335A1100664653 /* Slider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF307216335A1100664653 /* Slider.cpp */; };
+		4ABF30A516335A1100664653 /* TextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF307416335A1100664653 /* TextLayout.cpp */; };
+		4ABF30A616335A1100664653 /* Widget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF307616335A1100664653 /* Widget.cpp */; };
+		4ACC6D1E15401E7000C59914 /* TextSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACC6D1615401E7000C59914 /* TextSupport.cpp */; };
+		4ACC6D1F15401E7000C59914 /* TextureFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACC6D1815401E7000C59914 /* TextureFont.cpp */; };
+		4ACDB6B1167878620069FA03 /* Animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB684167878610069FA03 /* Animation.cpp */; };
+		4ACDB6B2167878620069FA03 /* Billboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB688167878620069FA03 /* Billboard.cpp */; };
+		4ACDB6B3167878620069FA03 /* CollisionGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB68A167878620069FA03 /* CollisionGeometry.cpp */; };
+		4ACDB6B4167878620069FA03 /* CollisionVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB68C167878620069FA03 /* CollisionVisitor.cpp */; };
+		4ACDB6B5167878620069FA03 /* ColorMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB68E167878620069FA03 /* ColorMap.cpp */; };
+		4ACDB6B6167878620069FA03 /* DumpVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB690167878620069FA03 /* DumpVisitor.cpp */; };
+		4ACDB6B7167878620069FA03 /* FindNodeVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB692167878620069FA03 /* FindNodeVisitor.cpp */; };
+		4ACDB6B8167878620069FA03 /* Group.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB694167878620069FA03 /* Group.cpp */; };
+		4ACDB6B9167878620069FA03 /* Label3D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB696167878620069FA03 /* Label3D.cpp */; };
+		4ACDB6BA167878620069FA03 /* Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB698167878620069FA03 /* Loader.cpp */; };
+		4ACDB6BB167878620069FA03 /* LOD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB69B167878620069FA03 /* LOD.cpp */; };
+		4ACDB6BD167878620069FA03 /* MatrixTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB69E167878620069FA03 /* MatrixTransform.cpp */; };
+		4ACDB6BE167878620069FA03 /* Model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A0167878620069FA03 /* Model.cpp */; };
+		4ACDB6BF167878620069FA03 /* ModelNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A2167878620069FA03 /* ModelNode.cpp */; };
+		4ACDB6C0167878620069FA03 /* Node.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A4167878620069FA03 /* Node.cpp */; };
+		4ACDB6C1167878620069FA03 /* NodeVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A6167878620069FA03 /* NodeVisitor.cpp */; };
+		4ACDB6C2167878620069FA03 /* Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A8167878620069FA03 /* Parser.cpp */; };
+		4ACDB6C3167878620069FA03 /* Pattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6AA167878620069FA03 /* Pattern.cpp */; };
+		4ACDB6C4167878620069FA03 /* StaticGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6AD167878620069FA03 /* StaticGeometry.cpp */; };
+		4ACDB6C5167878620069FA03 /* Thruster.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6AF167878620069FA03 /* Thruster.cpp */; };
+		4ACDB6CE167878CE0069FA03 /* ModelCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6CA167878CE0069FA03 /* ModelCache.cpp */; };
+		4ACDB6CF167878CE0069FA03 /* ModelViewer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6CC167878CE0069FA03 /* ModelViewer.cpp */; };
+		4ACDB6D2167879AF0069FA03 /* DistanceFieldFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6D0167879AF0069FA03 /* DistanceFieldFont.cpp */; };
 		4ACDB6D416787A6A0069FA03 /* libassimp.3.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */; };
-		4ACDB6D5167881AF0069FA03 /* libassimp.3.0.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */; };
-		4AE5CA441383E6AA00B55DEB /* libsigc-2.0.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */; };
-		4AEEBC4A162A4A5700C6EA6F /* libXrandr.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC49162A4A5700C6EA6F /* libXrandr.2.dylib */; };
-		4AEEBC4C162A4ADC00C6EA6F /* libXext.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC4B162A4ADC00C6EA6F /* libXext.6.dylib */; };
-		4AEEBC4D162A4B2000C6EA6F /* libXext.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC4B162A4ADC00C6EA6F /* libXext.6.dylib */; };
-		4AEEBC4E162A4B2000C6EA6F /* libXrandr.2.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC49162A4A5700C6EA6F /* libXrandr.2.dylib */; };
-		4AEEBC50162A4B9B00C6EA6F /* libXrender.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC4F162A4B9B00C6EA6F /* libXrender.1.dylib */; };
-		4AEEBC51162A4BA700C6EA6F /* libXrender.1.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC4F162A4B9B00C6EA6F /* libXrender.1.dylib */; };
-		4AEEBC55162A4BF700C6EA6F /* libX11.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC52162A4BF700C6EA6F /* libX11.6.dylib */; };
-		4AEEBC56162A4BF700C6EA6F /* libXau.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC53162A4BF700C6EA6F /* libXau.6.dylib */; };
-		4AEEBC57162A4BF700C6EA6F /* libXdmcp.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC54162A4BF700C6EA6F /* libXdmcp.6.dylib */; };
-		4AEEBC58162A4C0700C6EA6F /* libX11.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC52162A4BF700C6EA6F /* libX11.6.dylib */; };
-		4AEEBC59162A4C0700C6EA6F /* libXau.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC53162A4BF700C6EA6F /* libXau.6.dylib */; };
-		4AEEBC5A162A4C0700C6EA6F /* libXdmcp.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC54162A4BF700C6EA6F /* libXdmcp.6.dylib */; };
-		4AEEBC5C162A4C7800C6EA6F /* libxcb.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC5B162A4C7800C6EA6F /* libxcb.1.dylib */; };
-		4AEEBC5D162A4CA600C6EA6F /* libxcb.1.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC5B162A4C7800C6EA6F /* libxcb.1.dylib */; };
-		4AEEBC5F162A4F5B00C6EA6F /* libbz2.1.0.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC5E162A4F5B00C6EA6F /* libbz2.1.0.6.dylib */; };
-		4AEEBC60162A4FA300C6EA6F /* libbz2.1.0.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC5E162A4F5B00C6EA6F /* libbz2.1.0.6.dylib */; };
-		521ED8F01C00D14E0092B2E9 /* AmbientSounds.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7D51C00D14D0092B2E9 /* AmbientSounds.cpp */; };
-		521ED8F11C00D14E0092B2E9 /* Background.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7D81C00D14D0092B2E9 /* Background.cpp */; };
-		521ED8F21C00D14E0092B2E9 /* BaseSphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7DA1C00D14D0092B2E9 /* BaseSphere.cpp */; };
-		521ED8F31C00D14E0092B2E9 /* Body.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7DC1C00D14D0092B2E9 /* Body.cpp */; };
-		521ED8F41C00D14E0092B2E9 /* Camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E01C00D14D0092B2E9 /* Camera.cpp */; };
-		521ED8F51C00D14E0092B2E9 /* CameraController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E21C00D14D0092B2E9 /* CameraController.cpp */; };
-		521ED8F61C00D14E0092B2E9 /* CargoBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E41C00D14D0092B2E9 /* CargoBody.cpp */; };
-		521ED8F71C00D14E0092B2E9 /* CityOnPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E61C00D14D0092B2E9 /* CityOnPlanet.cpp */; };
-		521ED8F81C00D14E0092B2E9 /* CollMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E81C00D14D0092B2E9 /* CollMesh.cpp */; };
-		521ED8F91C00D14E0092B2E9 /* Color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7EA1C00D14D0092B2E9 /* Color.cpp */; };
-		521ED8FA1C00D14E0092B2E9 /* CRC32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7EC1C00D14D0092B2E9 /* CRC32.cpp */; };
-		521ED8FB1C00D14E0092B2E9 /* DateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7EF1C00D14D0092B2E9 /* DateTime.cpp */; };
-		521ED8FC1C00D14E0092B2E9 /* DeathView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7F11C00D14D0092B2E9 /* DeathView.cpp */; };
-		521ED8FD1C00D14E0092B2E9 /* DynamicBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7F41C00D14D0092B2E9 /* DynamicBody.cpp */; };
-		521ED8FE1C00D14E0092B2E9 /* enum_table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7F71C00D14D0092B2E9 /* enum_table.cpp */; };
-		521ED8FF1C00D14E0092B2E9 /* EnumStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7F91C00D14D0092B2E9 /* EnumStrings.cpp */; };
-		521ED9001C00D14E0092B2E9 /* FaceParts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7FB1C00D14D0092B2E9 /* FaceParts.cpp */; };
-		521ED9011C00D14E0092B2E9 /* Factions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7FD1C00D14D0092B2E9 /* Factions.cpp */; };
-		521ED9021C00D14E0092B2E9 /* FileSourceZip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7FF1C00D14D0092B2E9 /* FileSourceZip.cpp */; };
-		521ED9031C00D14E0092B2E9 /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8011C00D14D0092B2E9 /* FileSystem.cpp */; };
-		521ED9041C00D14E0092B2E9 /* FontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8051C00D14D0092B2E9 /* FontCache.cpp */; };
-		521ED9051C00D14E0092B2E9 /* Frame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8071C00D14D0092B2E9 /* Frame.cpp */; };
-		521ED9061C00D14E0092B2E9 /* GalacticView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8091C00D14D0092B2E9 /* GalacticView.cpp */; };
-		521ED9071C00D14E0092B2E9 /* Game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED80B1C00D14D0092B2E9 /* Game.cpp */; };
-		521ED9081C00D14E0092B2E9 /* GameConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED80D1C00D14D0092B2E9 /* GameConfig.cpp */; };
-		521ED9091C00D14E0092B2E9 /* GameLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8101C00D14D0092B2E9 /* GameLog.cpp */; };
-		521ED90A1C00D14E0092B2E9 /* GasGiant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8121C00D14D0092B2E9 /* GasGiant.cpp */; };
-		521ED90B1C00D14E0092B2E9 /* GeoPatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8141C00D14D0092B2E9 /* GeoPatch.cpp */; };
-		521ED90C1C00D14E0092B2E9 /* GeoPatchContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8161C00D14D0092B2E9 /* GeoPatchContext.cpp */; };
-		521ED90D1C00D14E0092B2E9 /* GeoPatchID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8181C00D14D0092B2E9 /* GeoPatchID.cpp */; };
-		521ED90E1C00D14E0092B2E9 /* GeoPatchJobs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED81A1C00D14D0092B2E9 /* GeoPatchJobs.cpp */; };
-		521ED90F1C00D14E0092B2E9 /* GeoSphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED81C1C00D14D0092B2E9 /* GeoSphere.cpp */; };
-		521ED9101C00D14E0092B2E9 /* HudTrail.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED81E1C00D14D0092B2E9 /* HudTrail.cpp */; };
-		521ED9111C00D14E0092B2E9 /* HyperspaceCloud.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8201C00D14D0092B2E9 /* HyperspaceCloud.cpp */; };
-		521ED9121C00D14E0092B2E9 /* IniConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8221C00D14D0092B2E9 /* IniConfig.cpp */; };
-		521ED9131C00D14E0092B2E9 /* Intro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8241C00D14D0092B2E9 /* Intro.cpp */; };
-		521ED9141C00D14E0092B2E9 /* JobQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8271C00D14D0092B2E9 /* JobQueue.cpp */; };
-		521ED9151C00D14E0092B2E9 /* KeyBindings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8291C00D14D0092B2E9 /* KeyBindings.cpp */; };
-		521ED9161C00D14E0092B2E9 /* Lang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED82C1C00D14D0092B2E9 /* Lang.cpp */; };
-		521ED9171C00D14E0092B2E9 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8301C00D14D0092B2E9 /* Lua.cpp */; };
-		521ED9181C00D14E0092B2E9 /* LuaBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8321C00D14D0092B2E9 /* LuaBody.cpp */; };
-		521ED9191C00D14E0092B2E9 /* LuaCargoBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8331C00D14D0092B2E9 /* LuaCargoBody.cpp */; };
-		521ED91A1C00D14E0092B2E9 /* LuaComms.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8341C00D14D0092B2E9 /* LuaComms.cpp */; };
-		521ED91B1C00D14E0092B2E9 /* LuaConsole.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8361C00D14D0092B2E9 /* LuaConsole.cpp */; };
-		521ED91C1C00D14E0092B2E9 /* LuaConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8381C00D14D0092B2E9 /* LuaConstants.cpp */; };
-		521ED91D1C00D14E0092B2E9 /* LuaDev.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED83A1C00D14D0092B2E9 /* LuaDev.cpp */; };
-		521ED91E1C00D14E0092B2E9 /* LuaEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED83C1C00D14D0092B2E9 /* LuaEngine.cpp */; };
-		521ED91F1C00D14E0092B2E9 /* LuaEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED83E1C00D14D0092B2E9 /* LuaEvent.cpp */; };
-		521ED9201C00D14E0092B2E9 /* LuaFaction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8401C00D14D0092B2E9 /* LuaFaction.cpp */; };
-		521ED9211C00D14E0092B2E9 /* LuaFileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8411C00D14D0092B2E9 /* LuaFileSystem.cpp */; };
-		521ED9221C00D14E0092B2E9 /* LuaFixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8431C00D14D0092B2E9 /* LuaFixed.cpp */; };
-		521ED9231C00D14E0092B2E9 /* LuaFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8451C00D14D0092B2E9 /* LuaFormat.cpp */; };
-		521ED9241C00D14E0092B2E9 /* LuaGame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8471C00D14D0092B2E9 /* LuaGame.cpp */; };
-		521ED9251C00D14E0092B2E9 /* LuaLang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8491C00D14D0092B2E9 /* LuaLang.cpp */; };
-		521ED9261C00D14E0092B2E9 /* LuaManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED84B1C00D14D0092B2E9 /* LuaManager.cpp */; };
-		521ED9271C00D14E0092B2E9 /* LuaMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED84D1C00D14D0092B2E9 /* LuaMatrix.cpp */; };
-		521ED9281C00D14E0092B2E9 /* LuaMissile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED84F1C00D14D0092B2E9 /* LuaMissile.cpp */; };
-		521ED9291C00D14E0092B2E9 /* LuaModelBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8511C00D14D0092B2E9 /* LuaModelBody.cpp */; };
-		521ED92A1C00D14E0092B2E9 /* LuaMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8521C00D14E0092B2E9 /* LuaMusic.cpp */; };
-		521ED92B1C00D14E0092B2E9 /* LuaNameGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8541C00D14E0092B2E9 /* LuaNameGen.cpp */; };
-		521ED92C1C00D14E0092B2E9 /* LuaObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8561C00D14E0092B2E9 /* LuaObject.cpp */; };
-		521ED92D1C00D14E0092B2E9 /* LuaPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8581C00D14E0092B2E9 /* LuaPlanet.cpp */; };
-		521ED92E1C00D14E0092B2E9 /* LuaPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8591C00D14E0092B2E9 /* LuaPlayer.cpp */; };
-		521ED92F1C00D14E0092B2E9 /* LuaPropertiedObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED85A1C00D14E0092B2E9 /* LuaPropertiedObject.cpp */; };
-		521ED9301C00D14E0092B2E9 /* LuaRand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED85C1C00D14E0092B2E9 /* LuaRand.cpp */; };
-		521ED9311C00D14E0092B2E9 /* LuaRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED85D1C00D14E0092B2E9 /* LuaRef.cpp */; };
-		521ED9321C00D14E0092B2E9 /* LuaSerializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED85F1C00D14E0092B2E9 /* LuaSerializer.cpp */; };
-		521ED9331C00D14E0092B2E9 /* LuaServerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8611C00D14E0092B2E9 /* LuaServerAgent.cpp */; };
-		521ED9341C00D14E0092B2E9 /* LuaShip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8631C00D14E0092B2E9 /* LuaShip.cpp */; };
-		521ED9351C00D14E0092B2E9 /* LuaShipDef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8641C00D14E0092B2E9 /* LuaShipDef.cpp */; };
-		521ED9361C00D14E0092B2E9 /* LuaSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8661C00D14E0092B2E9 /* LuaSpace.cpp */; };
-		521ED9371C00D14E0092B2E9 /* LuaSpaceStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8681C00D14E0092B2E9 /* LuaSpaceStation.cpp */; };
-		521ED9381C00D14E0092B2E9 /* LuaStar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8691C00D14E0092B2E9 /* LuaStar.cpp */; };
-		521ED9391C00D14E0092B2E9 /* LuaStarSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED86A1C00D14E0092B2E9 /* LuaStarSystem.cpp */; };
-		521ED93A1C00D14E0092B2E9 /* LuaSystemBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED86B1C00D14E0092B2E9 /* LuaSystemBody.cpp */; };
-		521ED93B1C00D14E0092B2E9 /* LuaSystemPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED86C1C00D14E0092B2E9 /* LuaSystemPath.cpp */; };
-		521ED93C1C00D14E0092B2E9 /* LuaTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED86E1C00D14E0092B2E9 /* LuaTimer.cpp */; };
-		521ED93D1C00D14E0092B2E9 /* LuaUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8701C00D14E0092B2E9 /* LuaUtils.cpp */; };
-		521ED93E1C00D14E0092B2E9 /* LuaVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8721C00D14E0092B2E9 /* LuaVector.cpp */; };
-		521ED93F1C00D14E0092B2E9 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8751C00D14E0092B2E9 /* main.cpp */; };
-		521ED9401C00D14E0092B2E9 /* MathUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8761C00D14E0092B2E9 /* MathUtil.cpp */; };
-		521ED9411C00D14E0092B2E9 /* Missile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED87A1C00D14E0092B2E9 /* Missile.cpp */; };
-		521ED9421C00D14E0092B2E9 /* ModelBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED87C1C00D14E0092B2E9 /* ModelBody.cpp */; };
-		521ED9431C00D14E0092B2E9 /* ModelCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED87E1C00D14E0092B2E9 /* ModelCache.cpp */; };
-		521ED9451C00D14E0092B2E9 /* ModelViewer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8811C00D14E0092B2E9 /* ModelViewer.cpp */; };
-		521ED9461C00D14E0092B2E9 /* ModManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8831C00D14E0092B2E9 /* ModManager.cpp */; };
-		521ED9471C00D14E0092B2E9 /* NavLights.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8851C00D14E0092B2E9 /* NavLights.cpp */; };
-		521ED9481C00D14E0092B2E9 /* ObjectViewerView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8881C00D14E0092B2E9 /* ObjectViewerView.cpp */; };
-		521ED9491C00D14E0092B2E9 /* Orbit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED88A1C00D14E0092B2E9 /* Orbit.cpp */; };
-		521ED94A1C00D14E0092B2E9 /* perlin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED88D1C00D14E0092B2E9 /* perlin.cpp */; };
-		521ED94B1C00D14E0092B2E9 /* Pi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8901C00D14E0092B2E9 /* Pi.cpp */; };
-		521ED94C1C00D14E0092B2E9 /* Plane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8921C00D14E0092B2E9 /* Plane.cpp */; };
-		521ED94D1C00D14E0092B2E9 /* Planet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8941C00D14E0092B2E9 /* Planet.cpp */; };
-		521ED94E1C00D14E0092B2E9 /* Player.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8961C00D14E0092B2E9 /* Player.cpp */; };
-		521ED94F1C00D14E0092B2E9 /* PngWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8981C00D14E0092B2E9 /* PngWriter.cpp */; };
-		521ED9501C00D14E0092B2E9 /* Polit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED89A1C00D14E0092B2E9 /* Polit.cpp */; };
-		521ED9511C00D14E0092B2E9 /* Projectile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED89C1C00D14E0092B2E9 /* Projectile.cpp */; };
-		521ED9521C00D14E0092B2E9 /* PropertyMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED89F1C00D14E0092B2E9 /* PropertyMap.cpp */; };
-		521ED9531C00D14E0092B2E9 /* SDLWrappers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8A41C00D14E0092B2E9 /* SDLWrappers.cpp */; };
-		521ED9541C00D14E0092B2E9 /* SectorView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8A61C00D14E0092B2E9 /* SectorView.cpp */; };
-		521ED9551C00D14E0092B2E9 /* Sensors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8A81C00D14E0092B2E9 /* Sensors.cpp */; };
-		521ED9561C00D14E0092B2E9 /* Serializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8AA1C00D14E0092B2E9 /* Serializer.cpp */; };
-		521ED9571C00D14E0092B2E9 /* ServerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8AC1C00D14E0092B2E9 /* ServerAgent.cpp */; };
-		521ED9581C00D14E0092B2E9 /* Sfx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8AE1C00D14E0092B2E9 /* Sfx.cpp */; };
-		521ED9591C00D14E0092B2E9 /* Shields.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B01C00D14E0092B2E9 /* Shields.cpp */; };
-		521ED95A1C00D14E0092B2E9 /* Ship-AI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B21C00D14E0092B2E9 /* Ship-AI.cpp */; };
-		521ED95B1C00D14E0092B2E9 /* Ship.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B31C00D14E0092B2E9 /* Ship.cpp */; };
-		521ED95C1C00D14E0092B2E9 /* ShipAICmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B51C00D14E0092B2E9 /* ShipAICmd.cpp */; };
-		521ED95D1C00D14E0092B2E9 /* ShipCockpit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B71C00D14E0092B2E9 /* ShipCockpit.cpp */; };
-		521ED95E1C00D14E0092B2E9 /* ShipController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B91C00D14E0092B2E9 /* ShipController.cpp */; };
-		521ED95F1C00D14E0092B2E9 /* ShipCpanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8BB1C00D14E0092B2E9 /* ShipCpanel.cpp */; };
-		521ED9601C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8BD1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp */; };
-		521ED9611C00D14E0092B2E9 /* ShipType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8BF1C00D14E0092B2E9 /* ShipType.cpp */; };
-		521ED9621C00D14E0092B2E9 /* Sound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8C21C00D14E0092B2E9 /* Sound.cpp */; };
-		521ED9631C00D14E0092B2E9 /* SoundMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8C41C00D14E0092B2E9 /* SoundMusic.cpp */; };
-		521ED9641C00D14E0092B2E9 /* Space.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8C61C00D14E0092B2E9 /* Space.cpp */; };
-		521ED9651C00D14E0092B2E9 /* SpaceStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8C81C00D14E0092B2E9 /* SpaceStation.cpp */; };
-		521ED9661C00D14E0092B2E9 /* SpaceStationType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8CA1C00D14E0092B2E9 /* SpaceStationType.cpp */; };
-		521ED9671C00D14E0092B2E9 /* SpeedLines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8CC1C00D14E0092B2E9 /* SpeedLines.cpp */; };
-		521ED9681C00D14E0092B2E9 /* Sphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8CE1C00D14E0092B2E9 /* Sphere.cpp */; };
-		521ED9691C00D14E0092B2E9 /* Star.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D01C00D14E0092B2E9 /* Star.cpp */; };
-		521ED96A1C00D14E0092B2E9 /* StringF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D21C00D14E0092B2E9 /* StringF.cpp */; };
-		521ED96B1C00D14E0092B2E9 /* SystemInfoView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D51C00D14E0092B2E9 /* SystemInfoView.cpp */; };
-		521ED96C1C00D14E0092B2E9 /* SystemView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D71C00D14E0092B2E9 /* SystemView.cpp */; };
-		521ED96D1C00D14E0092B2E9 /* TerrainBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D91C00D14E0092B2E9 /* TerrainBody.cpp */; };
-		521ED9751C00D14E0092B2E9 /* Tombstone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8E21C00D14E0092B2E9 /* Tombstone.cpp */; };
-		521ED9771C00D14E0092B2E9 /* UIView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8E51C00D14E0092B2E9 /* UIView.cpp */; };
-		521ED9781C00D14E0092B2E9 /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8E71C00D14E0092B2E9 /* utils.cpp */; };
-		521ED9791C00D14E0092B2E9 /* View.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8EC1C00D14E0092B2E9 /* View.cpp */; };
-		521ED97A1C00D14E0092B2E9 /* WorldView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8EE1C00D14E0092B2E9 /* WorldView.cpp */; };
-		521ED9921C00D2ED0092B2E9 /* BVHTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9861C00D2ED0092B2E9 /* BVHTree.cpp */; };
-		521ED9931C00D2ED0092B2E9 /* CollisionSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED98A1C00D2ED0092B2E9 /* CollisionSpace.cpp */; };
-		521ED9941C00D2ED0092B2E9 /* Geom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED98C1C00D2ED0092B2E9 /* Geom.cpp */; };
-		521ED9951C00D2ED0092B2E9 /* GeomTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED98E1C00D2ED0092B2E9 /* GeomTree.cpp */; };
-		521ED9981C00D2FC0092B2E9 /* Makefile.am in Resources */ = {isa = PBXBuildFile; fileRef = 521ED9971C00D2FC0092B2E9 /* Makefile.am */; };
-		521ED9AE1C00D3240092B2E9 /* CustomSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9991C00D3240092B2E9 /* CustomSystem.cpp */; };
-		521ED9AF1C00D3240092B2E9 /* Economy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED99B1C00D3240092B2E9 /* Economy.cpp */; };
-		521ED9B01C00D3240092B2E9 /* Galaxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED99D1C00D3240092B2E9 /* Galaxy.cpp */; };
-		521ED9B11C00D3240092B2E9 /* GalaxyCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED99F1C00D3240092B2E9 /* GalaxyCache.cpp */; };
-		521ED9B21C00D3240092B2E9 /* GalaxyGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A11C00D3240092B2E9 /* GalaxyGenerator.cpp */; };
-		521ED9B31C00D3240092B2E9 /* Sector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A31C00D3240092B2E9 /* Sector.cpp */; };
-		521ED9B41C00D3240092B2E9 /* SectorGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A51C00D3240092B2E9 /* SectorGenerator.cpp */; };
-		521ED9B51C00D3240092B2E9 /* StarSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A71C00D3240092B2E9 /* StarSystem.cpp */; };
-		521ED9B61C00D3240092B2E9 /* StarSystemGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A91C00D3240092B2E9 /* StarSystemGenerator.cpp */; };
-		521ED9B71C00D3240092B2E9 /* SystemPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9AB1C00D3240092B2E9 /* SystemPath.cpp */; };
-		521ED9C81C00D3310092B2E9 /* BindingCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9B91C00D3310092B2E9 /* BindingCapture.cpp */; };
-		521ED9C91C00D3310092B2E9 /* Face.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9BB1C00D3310092B2E9 /* Face.cpp */; };
-		521ED9CA1C00D3310092B2E9 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9BE1C00D3310092B2E9 /* Lua.cpp */; };
-		521ED9CB1C00D3310092B2E9 /* LuaBindingCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C01C00D3310092B2E9 /* LuaBindingCapture.cpp */; };
-		521ED9CC1C00D3310092B2E9 /* LuaFace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C11C00D3310092B2E9 /* LuaFace.cpp */; };
-		521ED9CD1C00D3310092B2E9 /* LuaModelSpinner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C21C00D3310092B2E9 /* LuaModelSpinner.cpp */; };
-		521ED9CE1C00D3310092B2E9 /* ModelSpinner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C31C00D3310092B2E9 /* ModelSpinner.cpp */; };
-		521ED9CF1C00D3310092B2E9 /* Panel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C51C00D3310092B2E9 /* Panel.cpp */; };
-		521EDA211C00D3430092B2E9 /* RendererDummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9D41C00D3430092B2E9 /* RendererDummy.cpp */; };
-		521EDA221C00D3430092B2E9 /* FresnelColourMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9DB1C00D3430092B2E9 /* FresnelColourMaterial.cpp */; };
-		521EDA231C00D3430092B2E9 /* GasGiantMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9DD1C00D3430092B2E9 /* GasGiantMaterial.cpp */; };
-		521EDA241C00D3430092B2E9 /* GeoSphereMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9DF1C00D3430092B2E9 /* GeoSphereMaterial.cpp */; };
-		521EDA251C00D3430092B2E9 /* gl_core_3_x.c in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */; };
-		521EDA281C00D3430092B2E9 /* MaterialGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */; };
-		521EDA291C00D3430092B2E9 /* MultiMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E91C00D3430092B2E9 /* MultiMaterial.cpp */; };
-		521EDA2A1C00D3430092B2E9 /* Program.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9EC1C00D3430092B2E9 /* Program.cpp */; };
-		521EDA2B1C00D3430092B2E9 /* RendererGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9EE1C00D3430092B2E9 /* RendererGL.cpp */; };
-		521EDA2C1C00D3430092B2E9 /* RenderStateGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9F01C00D3430092B2E9 /* RenderStateGL.cpp */; };
-		521EDA2D1C00D3430092B2E9 /* RenderTargetGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9F21C00D3430092B2E9 /* RenderTargetGL.cpp */; };
-		521EDA2E1C00D3430092B2E9 /* RingMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9F41C00D3430092B2E9 /* RingMaterial.cpp */; };
-		521EDA2F1C00D3430092B2E9 /* ShieldMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9F61C00D3430092B2E9 /* ShieldMaterial.cpp */; };
-		521EDA301C00D3430092B2E9 /* TextureGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9FB1C00D3430092B2E9 /* TextureGL.cpp */; };
-		521EDA311C00D3430092B2E9 /* UIMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9FD1C00D3430092B2E9 /* UIMaterial.cpp */; };
-		521EDA321C00D3430092B2E9 /* Uniform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9FF1C00D3430092B2E9 /* Uniform.cpp */; };
-		521EDA331C00D3430092B2E9 /* VertexBufferGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA011C00D3430092B2E9 /* VertexBufferGL.cpp */; };
-		521EDA341C00D3430092B2E9 /* VtxColorMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA031C00D3430092B2E9 /* VtxColorMaterial.cpp */; };
-		521EDA351C00D3430092B2E9 /* Drawables.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA051C00D3430092B2E9 /* Drawables.cpp */; };
-		521EDA361C00D3430092B2E9 /* Frustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA071C00D3430092B2E9 /* Frustum.cpp */; };
-		521EDA371C00D3430092B2E9 /* Graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA091C00D3430092B2E9 /* Graphics.cpp */; };
-		521EDA381C00D3430092B2E9 /* Light.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA0B1C00D3430092B2E9 /* Light.cpp */; };
-		521EDA391C00D3430092B2E9 /* Material.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA0D1C00D3430092B2E9 /* Material.cpp */; };
-		521EDA3A1C00D3430092B2E9 /* Renderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA0F1C00D3430092B2E9 /* Renderer.cpp */; };
-		521EDA3B1C00D3430092B2E9 /* Stats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA131C00D3430092B2E9 /* Stats.cpp */; };
-		521EDA3C1C00D3430092B2E9 /* TextureBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA161C00D3430092B2E9 /* TextureBuilder.cpp */; };
-		521EDA3D1C00D3430092B2E9 /* VertexArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA191C00D3430092B2E9 /* VertexArray.cpp */; };
-		521EDA3E1C00D3430092B2E9 /* VertexBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA1B1C00D3430092B2E9 /* VertexBuffer.cpp */; };
-		521EDA3F1C00D3430092B2E9 /* WindowSDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA1D1C00D3430092B2E9 /* WindowSDL.cpp */; };
-		521EDA771C00D3550092B2E9 /* Gui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA411C00D3550092B2E9 /* Gui.cpp */; };
-		521EDA781C00D3550092B2E9 /* GuiBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA441C00D3550092B2E9 /* GuiBox.cpp */; };
-		521EDA791C00D3550092B2E9 /* GuiButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA461C00D3550092B2E9 /* GuiButton.cpp */; };
-		521EDA7A1C00D3550092B2E9 /* GuiContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA481C00D3550092B2E9 /* GuiContainer.cpp */; };
-		521EDA7B1C00D3550092B2E9 /* GuiFixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA4B1C00D3550092B2E9 /* GuiFixed.cpp */; };
-		521EDA7C1C00D3550092B2E9 /* GuiImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA4D1C00D3550092B2E9 /* GuiImage.cpp */; };
-		521EDA7D1C00D3550092B2E9 /* GuiImageButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA4F1C00D3550092B2E9 /* GuiImageButton.cpp */; };
-		521EDA7E1C00D3550092B2E9 /* GuiImageRadioButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA511C00D3550092B2E9 /* GuiImageRadioButton.cpp */; };
-		521EDA7F1C00D3550092B2E9 /* GuiLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA541C00D3550092B2E9 /* GuiLabel.cpp */; };
-		521EDA801C00D3550092B2E9 /* GuiLabelSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA561C00D3550092B2E9 /* GuiLabelSet.cpp */; };
-		521EDA811C00D3550092B2E9 /* GuiMeterBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA581C00D3550092B2E9 /* GuiMeterBar.cpp */; };
-		521EDA821C00D3550092B2E9 /* GuiMultiStateImageButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA5A1C00D3550092B2E9 /* GuiMultiStateImageButton.cpp */; };
-		521EDA831C00D3550092B2E9 /* GuiRadioButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA5C1C00D3550092B2E9 /* GuiRadioButton.cpp */; };
-		521EDA841C00D3550092B2E9 /* GuiRadioGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA5E1C00D3550092B2E9 /* GuiRadioGroup.cpp */; };
-		521EDA851C00D3550092B2E9 /* GuiScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA601C00D3550092B2E9 /* GuiScreen.cpp */; };
-		521EDA861C00D3550092B2E9 /* GuiStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA621C00D3550092B2E9 /* GuiStack.cpp */; };
-		521EDA871C00D3550092B2E9 /* GuiTabbed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA641C00D3550092B2E9 /* GuiTabbed.cpp */; };
-		521EDA881C00D3550092B2E9 /* GuiTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA661C00D3550092B2E9 /* GuiTextEntry.cpp */; };
-		521EDA891C00D3550092B2E9 /* GuiTextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA681C00D3550092B2E9 /* GuiTextLayout.cpp */; };
-		521EDA8A1C00D3550092B2E9 /* GuiTexturedQuad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA6A1C00D3550092B2E9 /* GuiTexturedQuad.cpp */; };
-		521EDA8B1C00D3550092B2E9 /* GuiToggleButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA6C1C00D3550092B2E9 /* GuiToggleButton.cpp */; };
-		521EDA8C1C00D3550092B2E9 /* GuiToolTip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA6E1C00D3550092B2E9 /* GuiToolTip.cpp */; };
-		521EDA8D1C00D3550092B2E9 /* GuiVScrollBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA701C00D3550092B2E9 /* GuiVScrollBar.cpp */; };
-		521EDA8E1C00D3550092B2E9 /* GuiVScrollPortal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA721C00D3550092B2E9 /* GuiVScrollPortal.cpp */; };
-		521EDA8F1C00D3550092B2E9 /* GuiWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA741C00D3550092B2E9 /* GuiWidget.cpp */; };
-		521EDA941C00D3610092B2E9 /* FileSystemPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA911C00D3610092B2E9 /* FileSystemPosix.cpp */; };
-		521EDA951C00D3610092B2E9 /* OSPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA921C00D3610092B2E9 /* OSPosix.cpp */; };
-		521EDACF1C00D36D0092B2E9 /* Animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA971C00D36D0092B2E9 /* Animation.cpp */; };
-		521EDAD01C00D36D0092B2E9 /* BaseLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA9B1C00D36D0092B2E9 /* BaseLoader.cpp */; };
-		521EDAD11C00D36D0092B2E9 /* Billboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA9D1C00D36D0092B2E9 /* Billboard.cpp */; };
-		521EDAD21C00D36D0092B2E9 /* BinaryConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA9F1C00D36D0092B2E9 /* BinaryConverter.cpp */; };
-		521EDAD31C00D36D0092B2E9 /* CollisionGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA11C00D36D0092B2E9 /* CollisionGeometry.cpp */; };
-		521EDAD41C00D36D0092B2E9 /* CollisionVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA31C00D36D0092B2E9 /* CollisionVisitor.cpp */; };
-		521EDAD51C00D36D0092B2E9 /* ColorMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA51C00D36D0092B2E9 /* ColorMap.cpp */; };
-		521EDAD61C00D36D0092B2E9 /* DumpVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA71C00D36D0092B2E9 /* DumpVisitor.cpp */; };
-		521EDAD71C00D36D0092B2E9 /* FindNodeVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA91C00D36D0092B2E9 /* FindNodeVisitor.cpp */; };
-		521EDAD81C00D36D0092B2E9 /* Group.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAAB1C00D36D0092B2E9 /* Group.cpp */; };
-		521EDAD91C00D36D0092B2E9 /* Label3D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAAD1C00D36D0092B2E9 /* Label3D.cpp */; };
-		521EDADA1C00D36D0092B2E9 /* Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAAF1C00D36D0092B2E9 /* Loader.cpp */; };
-		521EDADB1C00D36D0092B2E9 /* LOD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB21C00D36D0092B2E9 /* LOD.cpp */; };
-		521EDADC1C00D36D0092B2E9 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB41C00D36D0092B2E9 /* Lua.cpp */; };
-		521EDADD1C00D36D0092B2E9 /* LuaModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB61C00D36D0092B2E9 /* LuaModel.cpp */; };
-		521EDADE1C00D36D0092B2E9 /* LuaModelSkin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB71C00D36D0092B2E9 /* LuaModelSkin.cpp */; };
-		521EDADF1C00D36D0092B2E9 /* MatrixTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB81C00D36D0092B2E9 /* MatrixTransform.cpp */; };
-		521EDAE01C00D36D0092B2E9 /* Model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDABA1C00D36D0092B2E9 /* Model.cpp */; };
-		521EDAE11C00D36D0092B2E9 /* ModelNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDABC1C00D36D0092B2E9 /* ModelNode.cpp */; };
-		521EDAE21C00D36D0092B2E9 /* ModelSkin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDABE1C00D36D0092B2E9 /* ModelSkin.cpp */; };
-		521EDAE31C00D36D0092B2E9 /* Node.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAC01C00D36D0092B2E9 /* Node.cpp */; };
-		521EDAE41C00D36D0092B2E9 /* NodeVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAC31C00D36D0092B2E9 /* NodeVisitor.cpp */; };
-		521EDAE51C00D36D0092B2E9 /* Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAC51C00D36D0092B2E9 /* Parser.cpp */; };
-		521EDAE61C00D36D0092B2E9 /* Pattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAC71C00D36D0092B2E9 /* Pattern.cpp */; };
-		521EDAE71C00D36D0092B2E9 /* StaticGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDACA1C00D36D0092B2E9 /* StaticGeometry.cpp */; };
-		521EDAE81C00D36D0092B2E9 /* Thruster.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDACC1C00D36D0092B2E9 /* Thruster.cpp */; };
-		521EDB251C00D37B0092B2E9 /* Terrain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAEA1C00D37B0092B2E9 /* Terrain.cpp */; };
-		521EDB261C00D37B0092B2E9 /* TerrainColorAsteroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAEC1C00D37B0092B2E9 /* TerrainColorAsteroid.cpp */; };
-		521EDB271C00D37B0092B2E9 /* TerrainColorBandedRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAED1C00D37B0092B2E9 /* TerrainColorBandedRock.cpp */; };
-		521EDB281C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAEE1C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp */; };
-		521EDB291C00D37B0092B2E9 /* TerrainColorDesert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAEF1C00D37B0092B2E9 /* TerrainColorDesert.cpp */; };
-		521EDB2A1C00D37B0092B2E9 /* TerrainColorEarthLike.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF01C00D37B0092B2E9 /* TerrainColorEarthLike.cpp */; };
-		521EDB2B1C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF11C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp */; };
-		521EDB2C1C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF21C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp */; };
-		521EDB2D1C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF31C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp */; };
-		521EDB2E1C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF41C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp */; };
-		521EDB2F1C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF51C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp */; };
-		521EDB301C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF61C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp */; };
-		521EDB311C00D37B0092B2E9 /* TerrainColorGGUranus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF71C00D37B0092B2E9 /* TerrainColorGGUranus.cpp */; };
-		521EDB321C00D37B0092B2E9 /* TerrainColorIce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF81C00D37B0092B2E9 /* TerrainColorIce.cpp */; };
-		521EDB331C00D37B0092B2E9 /* TerrainColorMethane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF91C00D37B0092B2E9 /* TerrainColorMethane.cpp */; };
-		521EDB341C00D37B0092B2E9 /* TerrainColorRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFA1C00D37B0092B2E9 /* TerrainColorRock.cpp */; };
-		521EDB351C00D37B0092B2E9 /* TerrainColorRock2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFB1C00D37B0092B2E9 /* TerrainColorRock2.cpp */; };
-		521EDB361C00D37B0092B2E9 /* TerrainColorSolid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFC1C00D37B0092B2E9 /* TerrainColorSolid.cpp */; };
-		521EDB371C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFD1C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp */; };
-		521EDB381C00D37B0092B2E9 /* TerrainColorStarG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFE1C00D37B0092B2E9 /* TerrainColorStarG.cpp */; };
-		521EDB391C00D37B0092B2E9 /* TerrainColorStarK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFF1C00D37B0092B2E9 /* TerrainColorStarK.cpp */; };
-		521EDB3A1C00D37B0092B2E9 /* TerrainColorStarM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB001C00D37B0092B2E9 /* TerrainColorStarM.cpp */; };
-		521EDB3B1C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB011C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp */; };
-		521EDB3C1C00D37B0092B2E9 /* TerrainColorTFGood.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB021C00D37B0092B2E9 /* TerrainColorTFGood.cpp */; };
-		521EDB3D1C00D37B0092B2E9 /* TerrainColorTFPoor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB031C00D37B0092B2E9 /* TerrainColorTFPoor.cpp */; };
-		521EDB3E1C00D37B0092B2E9 /* TerrainColorVolcanic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB041C00D37B0092B2E9 /* TerrainColorVolcanic.cpp */; };
-		521EDB3F1C00D37B0092B2E9 /* TerrainFeature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB051C00D37B0092B2E9 /* TerrainFeature.cpp */; };
-		521EDB401C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB071C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp */; };
-		521EDB411C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB081C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp */; };
-		521EDB421C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB091C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp */; };
-		521EDB431C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0A1C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp */; };
-		521EDB441C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0B1C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp */; };
-		521EDB451C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0C1C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp */; };
-		521EDB461C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0D1C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp */; };
-		521EDB471C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0E1C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp */; };
-		521EDB481C00D37B0092B2E9 /* TerrainHeightFlat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0F1C00D37B0092B2E9 /* TerrainHeightFlat.cpp */; };
-		521EDB491C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB101C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp */; };
-		521EDB4A1C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB111C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp */; };
-		521EDB4B1C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB121C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp */; };
-		521EDB4C1C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB131C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp */; };
-		521EDB4D1C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB141C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp */; };
-		521EDB4E1C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB151C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp */; };
-		521EDB4F1C00D37B0092B2E9 /* TerrainHeightMapped.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB161C00D37B0092B2E9 /* TerrainHeightMapped.cpp */; };
-		521EDB501C00D37B0092B2E9 /* TerrainHeightMapped2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB171C00D37B0092B2E9 /* TerrainHeightMapped2.cpp */; };
-		521EDB511C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB181C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp */; };
-		521EDB521C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB191C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp */; };
-		521EDB531C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1A1C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp */; };
-		521EDB541C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1B1C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp */; };
-		521EDB551C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1C1C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp */; };
-		521EDB561C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1D1C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp */; };
-		521EDB571C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1E1C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp */; };
-		521EDB581C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1F1C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp */; };
-		521EDB591C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB201C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp */; };
-		521EDB5A1C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB211C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp */; };
-		521EDB5B1C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB221C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp */; };
-		521EDB661C00D38B0092B2E9 /* DistanceFieldFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB5D1C00D38B0092B2E9 /* DistanceFieldFont.cpp */; };
-		521EDB671C00D38B0092B2E9 /* FontConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB5F1C00D38B0092B2E9 /* FontConfig.cpp */; };
-		521EDB681C00D38B0092B2E9 /* TextSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB611C00D38B0092B2E9 /* TextSupport.cpp */; };
-		521EDB691C00D38B0092B2E9 /* TextureFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB631C00D38B0092B2E9 /* TextureFont.cpp */; };
-		521EDBD31C00D3A20092B2E9 /* Align.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB6B1C00D3A20092B2E9 /* Align.cpp */; };
-		521EDBD41C00D3A20092B2E9 /* Animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB6D1C00D3A20092B2E9 /* Animation.cpp */; };
-		521EDBD51C00D3A20092B2E9 /* Background.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB6F1C00D3A20092B2E9 /* Background.cpp */; };
-		521EDBD61C00D3A20092B2E9 /* Box.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB711C00D3A20092B2E9 /* Box.cpp */; };
-		521EDBD71C00D3A20092B2E9 /* Button.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB731C00D3A20092B2E9 /* Button.cpp */; };
-		521EDBD81C00D3A20092B2E9 /* CellSpec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB751C00D3A20092B2E9 /* CellSpec.cpp */; };
-		521EDBD91C00D3A20092B2E9 /* CheckBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB771C00D3A20092B2E9 /* CheckBox.cpp */; };
-		521EDBDA1C00D3A20092B2E9 /* ColorBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB791C00D3A20092B2E9 /* ColorBackground.cpp */; };
-		521EDBDB1C00D3A20092B2E9 /* Container.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB7B1C00D3A20092B2E9 /* Container.cpp */; };
-		521EDBDC1C00D3A20092B2E9 /* Context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB7D1C00D3A20092B2E9 /* Context.cpp */; };
-		521EDBDD1C00D3A20092B2E9 /* DropDown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB7F1C00D3A20092B2E9 /* DropDown.cpp */; };
-		521EDBDE1C00D3A20092B2E9 /* Event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB811C00D3A20092B2E9 /* Event.cpp */; };
-		521EDBDF1C00D3A20092B2E9 /* EventDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB831C00D3A20092B2E9 /* EventDispatcher.cpp */; };
-		521EDBE01C00D3A20092B2E9 /* Expand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB851C00D3A20092B2E9 /* Expand.cpp */; };
-		521EDBE11C00D3A20092B2E9 /* Gauge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB871C00D3A20092B2E9 /* Gauge.cpp */; };
-		521EDBE21C00D3A20092B2E9 /* Gradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB891C00D3A20092B2E9 /* Gradient.cpp */; };
-		521EDBE31C00D3A20092B2E9 /* Grid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB8B1C00D3A20092B2E9 /* Grid.cpp */; };
-		521EDBE41C00D3A20092B2E9 /* Icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB8D1C00D3A20092B2E9 /* Icon.cpp */; };
-		521EDBE51C00D3A20092B2E9 /* Image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB8F1C00D3A20092B2E9 /* Image.cpp */; };
-		521EDBE61C00D3A20092B2E9 /* Label.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB911C00D3A20092B2E9 /* Label.cpp */; };
-		521EDBE71C00D3A20092B2E9 /* Layer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB931C00D3A20092B2E9 /* Layer.cpp */; };
-		521EDBE81C00D3A20092B2E9 /* List.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB951C00D3A20092B2E9 /* List.cpp */; };
-		521EDBE91C00D3A20092B2E9 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB971C00D3A20092B2E9 /* Lua.cpp */; };
-		521EDBEA1C00D3A20092B2E9 /* LuaAlign.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB991C00D3A20092B2E9 /* LuaAlign.cpp */; };
-		521EDBEB1C00D3A20092B2E9 /* LuaAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9A1C00D3A20092B2E9 /* LuaAnimation.cpp */; };
-		521EDBEC1C00D3A20092B2E9 /* LuaBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9B1C00D3A20092B2E9 /* LuaBackground.cpp */; };
-		521EDBED1C00D3A20092B2E9 /* LuaBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9C1C00D3A20092B2E9 /* LuaBox.cpp */; };
-		521EDBEE1C00D3A20092B2E9 /* LuaButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9D1C00D3A20092B2E9 /* LuaButton.cpp */; };
-		521EDBEF1C00D3A20092B2E9 /* LuaCheckBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9E1C00D3A20092B2E9 /* LuaCheckBox.cpp */; };
-		521EDBF01C00D3A20092B2E9 /* LuaColorBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9F1C00D3A20092B2E9 /* LuaColorBackground.cpp */; };
-		521EDBF11C00D3A20092B2E9 /* LuaContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA01C00D3A20092B2E9 /* LuaContainer.cpp */; };
-		521EDBF21C00D3A20092B2E9 /* LuaContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA11C00D3A20092B2E9 /* LuaContext.cpp */; };
-		521EDBF31C00D3A20092B2E9 /* LuaDropDown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA21C00D3A20092B2E9 /* LuaDropDown.cpp */; };
-		521EDBF41C00D3A20092B2E9 /* LuaExpand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA31C00D3A20092B2E9 /* LuaExpand.cpp */; };
-		521EDBF51C00D3A20092B2E9 /* LuaGauge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA41C00D3A20092B2E9 /* LuaGauge.cpp */; };
-		521EDBF61C00D3A20092B2E9 /* LuaGradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA51C00D3A20092B2E9 /* LuaGradient.cpp */; };
-		521EDBF71C00D3A20092B2E9 /* LuaGrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA61C00D3A20092B2E9 /* LuaGrid.cpp */; };
-		521EDBF81C00D3A20092B2E9 /* LuaIcon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA71C00D3A20092B2E9 /* LuaIcon.cpp */; };
-		521EDBF91C00D3A20092B2E9 /* LuaImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA81C00D3A20092B2E9 /* LuaImage.cpp */; };
-		521EDBFA1C00D3A20092B2E9 /* LuaLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA91C00D3A20092B2E9 /* LuaLabel.cpp */; };
-		521EDBFB1C00D3A20092B2E9 /* LuaLayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAA1C00D3A20092B2E9 /* LuaLayer.cpp */; };
-		521EDBFC1C00D3A20092B2E9 /* LuaList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAB1C00D3A20092B2E9 /* LuaList.cpp */; };
-		521EDBFD1C00D3A20092B2E9 /* LuaMargin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAC1C00D3A20092B2E9 /* LuaMargin.cpp */; };
-		521EDBFE1C00D3A20092B2E9 /* LuaMultiLineText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAD1C00D3A20092B2E9 /* LuaMultiLineText.cpp */; };
-		521EDBFF1C00D3A20092B2E9 /* LuaNumberLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAE1C00D3A20092B2E9 /* LuaNumberLabel.cpp */; };
-		521EDC001C00D3A20092B2E9 /* LuaScroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAF1C00D3A20092B2E9 /* LuaScroller.cpp */; };
-		521EDC011C00D3A20092B2E9 /* LuaSingle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB11C00D3A20092B2E9 /* LuaSingle.cpp */; };
-		521EDC021C00D3A20092B2E9 /* LuaSlider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB21C00D3A20092B2E9 /* LuaSlider.cpp */; };
-		521EDC031C00D3A20092B2E9 /* LuaSmallButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB31C00D3A20092B2E9 /* LuaSmallButton.cpp */; };
-		521EDC041C00D3A20092B2E9 /* LuaTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB41C00D3A20092B2E9 /* LuaTable.cpp */; };
-		521EDC051C00D3A20092B2E9 /* LuaTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB51C00D3A20092B2E9 /* LuaTextEntry.cpp */; };
-		521EDC061C00D3A20092B2E9 /* LuaWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB61C00D3A20092B2E9 /* LuaWidget.cpp */; };
-		521EDC071C00D3A20092B2E9 /* Margin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB71C00D3A20092B2E9 /* Margin.cpp */; };
-		521EDC081C00D3A20092B2E9 /* MultiLineText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBBA1C00D3A20092B2E9 /* MultiLineText.cpp */; };
-		521EDC091C00D3A20092B2E9 /* NumberLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBBC1C00D3A20092B2E9 /* NumberLabel.cpp */; };
-		521EDC0A1C00D3A20092B2E9 /* Scroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBBF1C00D3A20092B2E9 /* Scroller.cpp */; };
-		521EDC0B1C00D3A20092B2E9 /* Single.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC11C00D3A20092B2E9 /* Single.cpp */; };
-		521EDC0C1C00D3A20092B2E9 /* Skin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC31C00D3A20092B2E9 /* Skin.cpp */; };
-		521EDC0D1C00D3A20092B2E9 /* Slider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC51C00D3A20092B2E9 /* Slider.cpp */; };
-		521EDC0E1C00D3A20092B2E9 /* SmallButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC71C00D3A20092B2E9 /* SmallButton.cpp */; };
-		521EDC0F1C00D3A20092B2E9 /* Table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC91C00D3A20092B2E9 /* Table.cpp */; };
-		521EDC101C00D3A20092B2E9 /* TextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBCB1C00D3A20092B2E9 /* TextEntry.cpp */; };
-		521EDC111C00D3A20092B2E9 /* TextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBCD1C00D3A20092B2E9 /* TextLayout.cpp */; };
-		521EDC121C00D3A20092B2E9 /* Widget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBCF1C00D3A20092B2E9 /* Widget.cpp */; };
-		521EDC2B1C00D4720092B2E9 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC2A1C00D4720092B2E9 /* OpenGL.framework */; };
-		521EDC2D1C00D7950092B2E9 /* libGLEW.1.13.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC2C1C00D7950092B2E9 /* libGLEW.1.13.0.dylib */; };
-		521EDC2F1C00D7F40092B2E9 /* libjpeg.9.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC2E1C00D7F40092B2E9 /* libjpeg.9.dylib */; };
-		521EDC311C00D8AB0092B2E9 /* libpng16.16.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC301C00D8AB0092B2E9 /* libpng16.16.dylib */; };
-		521EDC341C00D8CA0092B2E9 /* libtiff.5.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC321C00D8CA0092B2E9 /* libtiff.5.dylib */; };
-		521EDC351C00D8CA0092B2E9 /* libz.1.2.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC331C00D8CA0092B2E9 /* libz.1.2.8.dylib */; };
-		52C6DBF91C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 52C6DBF71C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib */; };
-		52C6DBFA1C0250CC00B6CB63 /* libSDL2-2.0.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 52C6DBF81C0250CC00B6CB63 /* libSDL2-2.0.0.dylib */; };
-		52D125741C033A4200E6E4C2 /* libSDL2-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52C6DBF81C0250CC00B6CB63 /* libSDL2-2.0.0.dylib */; };
-		52D125751C033A5100E6E4C2 /* libSDL2_image-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52C6DBF71C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib */; };
-		52D125EC1C0351FB00E6E4C2 /* jsoncpp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D125941C0351FB00E6E4C2 /* jsoncpp.cpp */; };
-		52D125ED1C0351FB00E6E4C2 /* JsonUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D125951C0351FB00E6E4C2 /* JsonUtils.cpp */; };
-		52D126161C0351FB00E6E4C2 /* PicoDDS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D125E01C0351FB00E6E4C2 /* PicoDDS.cpp */; };
-		52D126571C03538F00E6E4C2 /* lapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1261B1C03538F00E6E4C2 /* lapi.c */; };
-		52D126581C03538F00E6E4C2 /* lauxlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1261D1C03538F00E6E4C2 /* lauxlib.c */; };
-		52D126591C03538F00E6E4C2 /* lbaselib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1261F1C03538F00E6E4C2 /* lbaselib.c */; };
-		52D1265A1C03538F00E6E4C2 /* lbitlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126201C03538F00E6E4C2 /* lbitlib.c */; };
-		52D1265B1C03538F00E6E4C2 /* lcode.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126211C03538F00E6E4C2 /* lcode.c */; };
-		52D1265C1C03538F00E6E4C2 /* lcorolib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126231C03538F00E6E4C2 /* lcorolib.c */; };
-		52D1265D1C03538F00E6E4C2 /* lctype.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126241C03538F00E6E4C2 /* lctype.c */; };
-		52D1265E1C03538F00E6E4C2 /* ldblib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126261C03538F00E6E4C2 /* ldblib.c */; };
-		52D1265F1C03538F00E6E4C2 /* ldebug.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126271C03538F00E6E4C2 /* ldebug.c */; };
-		52D126601C03538F00E6E4C2 /* ldo.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126291C03538F00E6E4C2 /* ldo.c */; };
-		52D126611C03538F00E6E4C2 /* ldump.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1262B1C03538F00E6E4C2 /* ldump.c */; };
-		52D126621C03538F00E6E4C2 /* lfunc.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1262C1C03538F00E6E4C2 /* lfunc.c */; };
-		52D126631C03538F00E6E4C2 /* lgc.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1262E1C03538F00E6E4C2 /* lgc.c */; };
-		52D126641C03538F00E6E4C2 /* linit.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126301C03538F00E6E4C2 /* linit.c */; };
-		52D126651C03538F00E6E4C2 /* liolib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126311C03538F00E6E4C2 /* liolib.c */; };
-		52D126661C03538F00E6E4C2 /* llex.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126321C03538F00E6E4C2 /* llex.c */; };
-		52D126671C03538F00E6E4C2 /* lmathlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126351C03538F00E6E4C2 /* lmathlib.c */; };
-		52D126681C03538F00E6E4C2 /* lmem.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126361C03538F00E6E4C2 /* lmem.c */; };
-		52D126691C03538F00E6E4C2 /* loadlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126381C03538F00E6E4C2 /* loadlib.c */; };
-		52D1266A1C03538F00E6E4C2 /* lobject.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126391C03538F00E6E4C2 /* lobject.c */; };
-		52D1266B1C03538F00E6E4C2 /* lopcodes.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1263B1C03538F00E6E4C2 /* lopcodes.c */; };
-		52D1266C1C03538F00E6E4C2 /* loslib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1263D1C03538F00E6E4C2 /* loslib.c */; };
-		52D1266D1C03538F00E6E4C2 /* lparser.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1263E1C03538F00E6E4C2 /* lparser.c */; };
-		52D1266E1C03538F00E6E4C2 /* lstate.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126401C03538F00E6E4C2 /* lstate.c */; };
-		52D1266F1C03538F00E6E4C2 /* lstring.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126421C03538F00E6E4C2 /* lstring.c */; };
-		52D126701C03538F00E6E4C2 /* lstrlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126441C03538F00E6E4C2 /* lstrlib.c */; };
-		52D126711C03538F00E6E4C2 /* ltable.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126451C03538F00E6E4C2 /* ltable.c */; };
-		52D126721C03538F00E6E4C2 /* ltablib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126471C03538F00E6E4C2 /* ltablib.c */; };
-		52D126731C03538F00E6E4C2 /* ltm.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126481C03538F00E6E4C2 /* ltm.c */; };
-		52D126761C03538F00E6E4C2 /* lundump.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126501C03538F00E6E4C2 /* lundump.c */; };
-		52D126771C03538F00E6E4C2 /* lvm.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126521C03538F00E6E4C2 /* lvm.c */; };
-		52D126781C03538F00E6E4C2 /* lzio.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126541C03538F00E6E4C2 /* lzio.c */; };
-		52E5FADC1C0356F2001F4F89 /* libcurl.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52E5FADB1C0356F2001F4F89 /* libcurl.dylib */; };
-		52E5FAE11C03589F001F4F89 /* lookup3.c in Sources */ = {isa = PBXBuildFile; fileRef = 52E5FADE1C03589F001F4F89 /* lookup3.c */; };
-		52E5FAE31C036A67001F4F89 /* libGLEW.1.13.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 521EDC2C1C00D7950092B2E9 /* libGLEW.1.13.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		52E5FAE71C036CBE001F4F89 /* libjpeg.9.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 521EDC2E1C00D7F40092B2E9 /* libjpeg.9.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		52E5FAE81C036CF0001F4F89 /* libpng16.16.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 521EDC301C00D8AB0092B2E9 /* libpng16.16.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		52E5FAE91C036D56001F4F89 /* libtiff.5.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 521EDC321C00D8CA0092B2E9 /* libtiff.5.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		52E5FAEA1C036D8A001F4F89 /* libz.1.2.8.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 521EDC331C00D8CA0092B2E9 /* libz.1.2.8.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		52E5FAF51C0375F2001F4F89 /* Makefile.am in Resources */ = {isa = PBXBuildFile; fileRef = 52E5FAF21C0375F2001F4F89 /* Makefile.am */; };
-		52E5FAF61C0375F2001F4F89 /* README in Resources */ = {isa = PBXBuildFile; fileRef = 52E5FAF41C0375F2001F4F89 /* README */; };
+		4ACE132F16B4B19D00CAE524 /* EnumStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACE132C16B4B19D00CAE524 /* EnumStrings.cpp */; };
+		4ACED56A16BBCC7200E53808 /* LuaMissile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACED56816BBCC7200E53808 /* LuaMissile.cpp */; };
+		4ADB0D0C15C50DD900AE2123 /* TerrainHeightAsteroid2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0615C50DD900AE2123 /* TerrainHeightAsteroid2.cpp */; };
+		4ADB0D0D15C50DD900AE2123 /* TerrainHeightAsteroid3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0715C50DD900AE2123 /* TerrainHeightAsteroid3.cpp */; };
+		4ADB0D0E15C50DD900AE2123 /* TerrainHeightAsteroid4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0815C50DD900AE2123 /* TerrainHeightAsteroid4.cpp */; };
+		4ADB0D0F15C50DD900AE2123 /* TerrainHeightBarrenRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0915C50DD900AE2123 /* TerrainHeightBarrenRock.cpp */; };
+		4ADB0D1015C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0A15C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp */; };
+		4ADB0D1115C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0B15C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp */; };
+		4ADB0D1615C50DF000AE2123 /* FileSystemPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D1315C50DF000AE2123 /* FileSystemPosix.cpp */; };
+		4ADB0D1815C50DF000AE2123 /* OSPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D1515C50DF000AE2123 /* OSPosix.cpp */; };
+		4ADC7B82152C703200E359B5 /* SDLWrappers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADC7B7F152C703200E359B5 /* SDLWrappers.cpp */; };
+		4ADC7B83152C703200E359B5 /* View.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADC7B81152C703200E359B5 /* View.cpp */; };
+		4ADF518A1557473400ACF5A0 /* CustomSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51801557473400ACF5A0 /* CustomSystem.cpp */; };
+		4ADF518B1557473400ACF5A0 /* Galaxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51821557473400ACF5A0 /* Galaxy.cpp */; };
+		4ADF518D1557473400ACF5A0 /* Sector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51851557473400ACF5A0 /* Sector.cpp */; };
+		4ADF518E1557473400ACF5A0 /* StarSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51871557473400ACF5A0 /* StarSystem.cpp */; };
+		4ADF51971557477400ACF5A0 /* LuaFixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF518F1557477400ACF5A0 /* LuaFixed.cpp */; };
+		4ADF51981557477400ACF5A0 /* LuaMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51911557477400ACF5A0 /* LuaMatrix.cpp */; };
+		4ADF51991557477400ACF5A0 /* LuaSystemBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51931557477400ACF5A0 /* LuaSystemBody.cpp */; };
+		4ADF519A1557477400ACF5A0 /* LuaVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51951557477400ACF5A0 /* LuaVector.cpp */; };
+		4AE9706714369D7500424F91 /* LuaLang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AE9706514369D7500424F91 /* LuaLang.cpp */; };
+		4AEC8A1A15C7886A00B281C3 /* Light.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AEC8A1815C7886A00B281C3 /* Light.cpp */; };
+		4AED721D14E1501D004D171E /* TerrainHeightMapped2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AED721C14E1501D004D171E /* TerrainHeightMapped2.cpp */; };
+		4AEE56DD16A44CD800AA1C53 /* SpaceStationType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AEE56DB16A44CD800AA1C53 /* SpaceStationType.cpp */; };
+		4AF0058B15F0F30400CC19C0 /* LuaEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF0058915F0F30400CC19C0 /* LuaEvent.cpp */; };
+		4AF0059315F17C6700CC19C0 /* LuaFileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF0059115F17C6700CC19C0 /* LuaFileSystem.cpp */; };
+		4AF222E7162103EA00BED38E /* Factions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF222E0162103EA00BED38E /* Factions.cpp */; };
+		4AF222E8162103EA00BED38E /* Intro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF222E2162103EA00BED38E /* Intro.cpp */; };
+		4AF222E9162103EA00BED38E /* Tombstone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF222E5162103EA00BED38E /* Tombstone.cpp */; };
+		4AF999A41496D51F009821AF /* Game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF9999D1496D51F009821AF /* Game.cpp */; };
+		4AF999A61496D51F009821AF /* MathUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF999A11496D51F009821AF /* MathUtil.cpp */; };
+		4AFBD7B91641265D002928CB /* PngWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7B71641265D002928CB /* PngWriter.cpp */; };
+		4AFBD7BD16412676002928CB /* LuaTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7BA16412676002928CB /* LuaTextEntry.cpp */; };
+		4AFBD7BE16412676002928CB /* TextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7BB16412676002928CB /* TextEntry.cpp */; };
+		52025F6F1C05B63E00254BB5 /* libcurl.4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F6E1C05B63E00254BB5 /* libcurl.4.dylib */; };
+		52025F741C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F721C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib */; };
+		52025F751C05B74B00254BB5 /* libSDL2-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F731C05B74B00254BB5 /* libSDL2-2.0.0.dylib */; };
+		52025F791C05BA7100254BB5 /* CollMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52025F781C05BA7100254BB5 /* CollMesh.cpp */; };
+		52025F7C1C05BBAC00254BB5 /* libvorbis.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F7A1C05BBAC00254BB5 /* libvorbis.0.dylib */; };
+		52025F7F1C05BD3400254BB5 /* libvorbisfile.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52025F7E1C05BD3400254BB5 /* libvorbisfile.3.dylib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -488,22 +458,12 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				52E5FAE81C036CF0001F4F89 /* libpng16.16.dylib in Copy SubLibraries */,
-				52E5FAE71C036CBE001F4F89 /* libjpeg.9.dylib in Copy SubLibraries */,
-				4AEEBC60162A4FA300C6EA6F /* libbz2.1.0.6.dylib in Copy SubLibraries */,
-				4AEEBC5D162A4CA600C6EA6F /* libxcb.1.dylib in Copy SubLibraries */,
-				4AEEBC58162A4C0700C6EA6F /* libX11.6.dylib in Copy SubLibraries */,
-				4AEEBC59162A4C0700C6EA6F /* libXau.6.dylib in Copy SubLibraries */,
-				4AEEBC5A162A4C0700C6EA6F /* libXdmcp.6.dylib in Copy SubLibraries */,
-				4AEEBC51162A4BA700C6EA6F /* libXrender.1.dylib in Copy SubLibraries */,
-				4AEEBC4D162A4B2000C6EA6F /* libXext.6.dylib in Copy SubLibraries */,
-				4AEEBC4E162A4B2000C6EA6F /* libXrandr.2.dylib in Copy SubLibraries */,
-				4A76112A1611A92400A06F79 /* libFLAC.8.dylib in Copy SubLibraries */,
-				4A671BA31388CA3F00657F38 /* libspeex.1.5.0.dylib in Copy SubLibraries */,
-				4A671B9D1388C6C400657F38 /* libmodplug.1.dylib in Copy SubLibraries */,
-				4A671B9A1388C62800657F38 /* libsmpeg-0.4.0.dylib in Copy SubLibraries */,
-				4A671B8A1388C08500657F38 /* libogg.0.dylib in Copy SubLibraries */,
-				4A671B8B1388C08500657F38 /* libvorbis.0.dylib in Copy SubLibraries */,
+				37074B941B1C6DDC00AFE2CE /* libbz2.1.0.6.dylib in Copy SubLibraries */,
+				37074B951B1C6DDC00AFE2CE /* libpng16.16.dylib in Copy SubLibraries */,
+				37074B961B1C6DDC00AFE2CE /* libz.1.2.8.dylib in Copy SubLibraries */,
+				44B75A981B1C259500EC500F /* libassimp.3.0.0.dylib in Copy SubLibraries */,
+				44B75A991B1C259600EC500F /* libsigc-2.0.0.dylib in Copy SubLibraries */,
+				44B75A971B1C259200EC500F /* libfreetype.6.dylib in Copy SubLibraries */,
 			);
 			name = "Copy SubLibraries";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -525,15 +485,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				52E5FAEA1C036D8A001F4F89 /* libz.1.2.8.dylib in Copy Libraries */,
-				52E5FAE91C036D56001F4F89 /* libtiff.5.dylib in Copy Libraries */,
-				52E5FAE31C036A67001F4F89 /* libGLEW.1.13.0.dylib in Copy Libraries */,
-				52C6DBF91C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib in Copy Libraries */,
-				52C6DBFA1C0250CC00B6CB63 /* libSDL2-2.0.0.dylib in Copy Libraries */,
-				4ACDB6D5167881AF0069FA03 /* libassimp.3.0.0.dylib in Copy Libraries */,
-				4A5619D813867661002A904C /* libvorbisfile.3.dylib in Copy Libraries */,
-				4A5619D313866B5B002A904C /* libfreetype.6.dylib in Copy Libraries */,
-				4AE5CA441383E6AA00B55DEB /* libsigc-2.0.0.dylib in Copy Libraries */,
 			);
 			name = "Copy Libraries";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -541,6 +492,263 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3701C5851B1ABDA2000F4A72 /* libfreetype.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libfreetype.6.dylib; path = /opt/local/lib/libfreetype.6.dylib; sourceTree = "<absolute>"; };
+		37074B8E1B1C653D00AFE2CE /* libbz2.1.0.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.1.0.6.dylib; path = /opt/local/lib/libbz2.1.0.6.dylib; sourceTree = "<absolute>"; };
+		37074B8F1B1C653D00AFE2CE /* libpng16.16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpng16.16.dylib; path = /opt/local/lib/libpng16.16.dylib; sourceTree = "<absolute>"; };
+		37074B901B1C653D00AFE2CE /* libz.1.2.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.2.8.dylib; path = /opt/local/lib/libz.1.2.8.dylib; sourceTree = "<absolute>"; };
+		378563511B19769A0039F2BC /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		378563581B197CF90039F2BC /* JsonUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JsonUtils.cpp; sourceTree = "<group>"; };
+		378563591B197CF90039F2BC /* JsonUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JsonUtils.h; sourceTree = "<group>"; };
+		3785635B1B197CF90039F2BC /* json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = json.h; sourceTree = "<group>"; };
+		3785635C1B197CF90039F2BC /* jsoncpp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsoncpp.cpp; sourceTree = "<group>"; };
+		378563601B197D740039F2BC /* BaseSphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BaseSphere.cpp; sourceTree = "<group>"; };
+		378563611B197D740039F2BC /* BaseSphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseSphere.h; sourceTree = "<group>"; };
+		378563621B197D740039F2BC /* DateTime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DateTime.cpp; sourceTree = "<group>"; };
+		378563631B197D740039F2BC /* DateTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DateTime.h; sourceTree = "<group>"; };
+		378563641B197D740039F2BC /* FaceParts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FaceParts.cpp; sourceTree = "<group>"; };
+		378563651B197D740039F2BC /* FaceParts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FaceParts.h; sourceTree = "<group>"; };
+		378563661B197D740039F2BC /* GameLog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameLog.cpp; sourceTree = "<group>"; };
+		378563671B197D740039F2BC /* GameLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameLog.h; sourceTree = "<group>"; };
+		378563681B197D740039F2BC /* GasGiant.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GasGiant.cpp; sourceTree = "<group>"; };
+		378563691B197D740039F2BC /* GasGiant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GasGiant.h; sourceTree = "<group>"; };
+		3785636A1B197D740039F2BC /* GeoPatch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoPatch.cpp; sourceTree = "<group>"; };
+		3785636B1B197D740039F2BC /* GeoPatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoPatch.h; sourceTree = "<group>"; };
+		3785636C1B197D740039F2BC /* GeoPatchContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoPatchContext.cpp; sourceTree = "<group>"; };
+		3785636D1B197D740039F2BC /* GeoPatchContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoPatchContext.h; sourceTree = "<group>"; };
+		3785636E1B197D740039F2BC /* GeoPatchID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoPatchID.cpp; sourceTree = "<group>"; };
+		3785636F1B197D740039F2BC /* GeoPatchID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoPatchID.h; sourceTree = "<group>"; };
+		378563701B197D740039F2BC /* GeoPatchJobs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoPatchJobs.cpp; sourceTree = "<group>"; };
+		378563711B197D740039F2BC /* GeoPatchJobs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoPatchJobs.h; sourceTree = "<group>"; };
+		378563721B197D740039F2BC /* HudTrail.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HudTrail.cpp; sourceTree = "<group>"; };
+		378563731B197D740039F2BC /* HudTrail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HudTrail.h; sourceTree = "<group>"; };
+		378563741B197D740039F2BC /* IterationProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IterationProxy.h; sourceTree = "<group>"; };
+		378563751B197D740039F2BC /* JobQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JobQueue.cpp; sourceTree = "<group>"; };
+		378563761B197D740039F2BC /* JobQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JobQueue.h; sourceTree = "<group>"; };
+		378563771B197D740039F2BC /* LuaModelBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaModelBody.cpp; sourceTree = "<group>"; };
+		3785637B1B197D740039F2BC /* Plane.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Plane.cpp; sourceTree = "<group>"; };
+		3785637C1B197D740039F2BC /* Plane.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Plane.h; sourceTree = "<group>"; };
+		3785637D1B197D740039F2BC /* Sensors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sensors.cpp; sourceTree = "<group>"; };
+		3785637E1B197D740039F2BC /* Sensors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sensors.h; sourceTree = "<group>"; };
+		378563811B197D740039F2BC /* Shields.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Shields.cpp; sourceTree = "<group>"; };
+		378563821B197D740039F2BC /* Shields.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Shields.h; sourceTree = "<group>"; };
+		378563831B197D740039F2BC /* ShipCockpit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipCockpit.cpp; sourceTree = "<group>"; };
+		378563841B197D740039F2BC /* ShipCockpit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipCockpit.h; sourceTree = "<group>"; };
+		378563851B197D740039F2BC /* SpeedLines.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpeedLines.cpp; sourceTree = "<group>"; };
+		378563861B197D740039F2BC /* SpeedLines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpeedLines.h; sourceTree = "<group>"; };
+		378563871B197D740039F2BC /* Sphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sphere.cpp; sourceTree = "<group>"; };
+		378563881B197D740039F2BC /* Sphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sphere.h; sourceTree = "<group>"; };
+		378563AE1B197D9C0039F2BC /* FontConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontConfig.cpp; sourceTree = "<group>"; };
+		378563AF1B197D9C0039F2BC /* FontConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontConfig.h; sourceTree = "<group>"; };
+		378563B11B197DBB0039F2BC /* Animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Animation.cpp; sourceTree = "<group>"; };
+		378563B21B197DBB0039F2BC /* Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Animation.h; sourceTree = "<group>"; };
+		378563B31B197DBB0039F2BC /* Gauge.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Gauge.cpp; sourceTree = "<group>"; };
+		378563B41B197DBB0039F2BC /* Gauge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gauge.h; sourceTree = "<group>"; };
+		378563B51B197DBB0039F2BC /* Layer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Layer.cpp; sourceTree = "<group>"; };
+		378563B61B197DBB0039F2BC /* Layer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Layer.h; sourceTree = "<group>"; };
+		378563B71B197DBB0039F2BC /* LuaAnimation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaAnimation.cpp; sourceTree = "<group>"; };
+		378563B81B197DBB0039F2BC /* LuaGauge.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaGauge.cpp; sourceTree = "<group>"; };
+		378563B91B197DBB0039F2BC /* LuaLayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaLayer.cpp; sourceTree = "<group>"; };
+		378563BA1B197DBB0039F2BC /* LuaNumberLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaNumberLabel.cpp; sourceTree = "<group>"; };
+		378563BB1B197DBB0039F2BC /* LuaTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaTable.cpp; sourceTree = "<group>"; };
+		378563BC1B197DBB0039F2BC /* MousePointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MousePointer.h; sourceTree = "<group>"; };
+		378563BD1B197DBB0039F2BC /* NumberLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NumberLabel.cpp; sourceTree = "<group>"; };
+		378563BE1B197DBB0039F2BC /* NumberLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NumberLabel.h; sourceTree = "<group>"; };
+		378563BF1B197DBB0039F2BC /* Table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Table.cpp; sourceTree = "<group>"; };
+		378563C01B197DBB0039F2BC /* Table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Table.h; sourceTree = "<group>"; };
+		378563CB1B197DC90039F2BC /* TerrainColorEarthLikeHeightmapped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorEarthLikeHeightmapped.cpp; sourceTree = "<group>"; };
+		378563CD1B197DDE0039F2BC /* BaseLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BaseLoader.cpp; sourceTree = "<group>"; };
+		378563CE1B197DDE0039F2BC /* BaseLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseLoader.h; sourceTree = "<group>"; };
+		378563CF1B197DDE0039F2BC /* BinaryConverter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BinaryConverter.cpp; sourceTree = "<group>"; };
+		378563D01B197DDE0039F2BC /* BinaryConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BinaryConverter.h; sourceTree = "<group>"; };
+		378563D11B197DDE0039F2BC /* LuaModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaModel.cpp; sourceTree = "<group>"; };
+		378563D71B197E600039F2BC /* MaterialDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialDummy.h; sourceTree = "<group>"; };
+		378563D81B197E600039F2BC /* RenderStateDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderStateDummy.h; sourceTree = "<group>"; };
+		378563D91B197E600039F2BC /* RenderTargetDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderTargetDummy.h; sourceTree = "<group>"; };
+		378563DA1B197E600039F2BC /* RendererDummy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RendererDummy.cpp; sourceTree = "<group>"; };
+		378563DB1B197E600039F2BC /* RendererDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererDummy.h; sourceTree = "<group>"; };
+		378563DC1B197E600039F2BC /* TextureDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureDummy.h; sourceTree = "<group>"; };
+		378563DD1B197E600039F2BC /* VertexBufferDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexBufferDummy.h; sourceTree = "<group>"; };
+		378563DF1B197E600039F2BC /* FresnelColourMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FresnelColourMaterial.cpp; sourceTree = "<group>"; };
+		378563E01B197E600039F2BC /* FresnelColourMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FresnelColourMaterial.h; sourceTree = "<group>"; };
+		378563E11B197E600039F2BC /* GLDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLDebug.h; sourceTree = "<group>"; };
+		378563E21B197E600039F2BC /* GasGiantMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GasGiantMaterial.cpp; sourceTree = "<group>"; };
+		378563E31B197E600039F2BC /* GasGiantMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GasGiantMaterial.h; sourceTree = "<group>"; };
+		378563E41B197E600039F2BC /* GeoSphereMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoSphereMaterial.cpp; sourceTree = "<group>"; };
+		378563E51B197E600039F2BC /* GeoSphereMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoSphereMaterial.h; sourceTree = "<group>"; };
+		378563E91B197E600039F2BC /* MaterialGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MaterialGL.cpp; sourceTree = "<group>"; };
+		378563EA1B197E600039F2BC /* MaterialGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialGL.h; sourceTree = "<group>"; };
+		378563EB1B197E600039F2BC /* MultiMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MultiMaterial.cpp; sourceTree = "<group>"; };
+		378563EC1B197E600039F2BC /* MultiMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiMaterial.h; sourceTree = "<group>"; };
+		378563ED1B197E600039F2BC /* Program.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Program.cpp; sourceTree = "<group>"; };
+		378563EE1B197E600039F2BC /* Program.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Program.h; sourceTree = "<group>"; };
+		378563EF1B197E600039F2BC /* RenderStateGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderStateGL.cpp; sourceTree = "<group>"; };
+		378563F01B197E600039F2BC /* RenderStateGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderStateGL.h; sourceTree = "<group>"; };
+		378563F11B197E600039F2BC /* RenderTargetGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderTargetGL.cpp; sourceTree = "<group>"; };
+		378563F21B197E600039F2BC /* RenderTargetGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderTargetGL.h; sourceTree = "<group>"; };
+		378563F31B197E600039F2BC /* RendererGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RendererGL.cpp; sourceTree = "<group>"; };
+		378563F41B197E600039F2BC /* RendererGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererGL.h; sourceTree = "<group>"; };
+		378563F51B197E600039F2BC /* RingMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RingMaterial.cpp; sourceTree = "<group>"; };
+		378563F61B197E600039F2BC /* RingMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RingMaterial.h; sourceTree = "<group>"; };
+		378563F71B197E600039F2BC /* ShieldMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShieldMaterial.cpp; sourceTree = "<group>"; };
+		378563F81B197E600039F2BC /* ShieldMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShieldMaterial.h; sourceTree = "<group>"; };
+		378563F91B197E600039F2BC /* SkyboxMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SkyboxMaterial.h; sourceTree = "<group>"; };
+		378563FA1B197E600039F2BC /* SphereImpostorMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SphereImpostorMaterial.h; sourceTree = "<group>"; };
+		378563FB1B197E600039F2BC /* StarfieldMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StarfieldMaterial.h; sourceTree = "<group>"; };
+		378563FC1B197E600039F2BC /* TextureGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureGL.cpp; sourceTree = "<group>"; };
+		378563FD1B197E600039F2BC /* TextureGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureGL.h; sourceTree = "<group>"; };
+		378563FE1B197E600039F2BC /* UIMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIMaterial.cpp; sourceTree = "<group>"; };
+		378563FF1B197E600039F2BC /* UIMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIMaterial.h; sourceTree = "<group>"; };
+		378564001B197E600039F2BC /* Uniform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Uniform.cpp; sourceTree = "<group>"; };
+		378564011B197E600039F2BC /* Uniform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Uniform.h; sourceTree = "<group>"; };
+		378564021B197E600039F2BC /* VertexBufferGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VertexBufferGL.cpp; sourceTree = "<group>"; };
+		378564031B197E600039F2BC /* VertexBufferGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexBufferGL.h; sourceTree = "<group>"; };
+		378564041B197E600039F2BC /* VtxColorMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VtxColorMaterial.cpp; sourceTree = "<group>"; };
+		378564051B197E600039F2BC /* VtxColorMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VtxColorMaterial.h; sourceTree = "<group>"; };
+		378564061B197E600039F2BC /* gl_core_3_x.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gl_core_3_x.c; sourceTree = "<group>"; };
+		378564071B197E600039F2BC /* gl_core_3_x.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gl_core_3_x.h; sourceTree = "<group>"; };
+		378564081B197E600039F2BC /* RenderState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderState.h; sourceTree = "<group>"; };
+		378564091B197E600039F2BC /* RenderTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderTarget.h; sourceTree = "<group>"; };
+		3785640A1B197E600039F2BC /* Stats.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Stats.cpp; sourceTree = "<group>"; };
+		3785640B1B197E600039F2BC /* Stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Stats.h; sourceTree = "<group>"; };
+		3785640C1B197E600039F2BC /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Types.h; sourceTree = "<group>"; };
+		3785640D1B197E600039F2BC /* VertexBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VertexBuffer.cpp; sourceTree = "<group>"; };
+		3785640E1B197E600039F2BC /* VertexBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexBuffer.h; sourceTree = "<group>"; };
+		3785640F1B197E600039F2BC /* WindowSDL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WindowSDL.cpp; sourceTree = "<group>"; };
+		378564101B197E600039F2BC /* WindowSDL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WindowSDL.h; sourceTree = "<group>"; };
+		378564291B197E7A0039F2BC /* BindingCapture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BindingCapture.cpp; sourceTree = "<group>"; };
+		3785642A1B197E7A0039F2BC /* BindingCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BindingCapture.h; sourceTree = "<group>"; };
+		3785642B1B197E7A0039F2BC /* LuaBindingCapture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaBindingCapture.cpp; sourceTree = "<group>"; };
+		3785642E1B197E8B0039F2BC /* Economy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Economy.cpp; sourceTree = "<group>"; };
+		3785642F1B197E8B0039F2BC /* Economy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Economy.h; sourceTree = "<group>"; };
+		378564301B197E8B0039F2BC /* GalaxyCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GalaxyCache.cpp; sourceTree = "<group>"; };
+		378564311B197E8B0039F2BC /* GalaxyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GalaxyCache.h; sourceTree = "<group>"; };
+		378564321B197E8B0039F2BC /* GalaxyGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GalaxyGenerator.cpp; sourceTree = "<group>"; };
+		378564331B197E8B0039F2BC /* GalaxyGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GalaxyGenerator.h; sourceTree = "<group>"; };
+		378564341B197E8B0039F2BC /* SectorGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SectorGenerator.cpp; sourceTree = "<group>"; };
+		378564351B197E8B0039F2BC /* SectorGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SectorGenerator.h; sourceTree = "<group>"; };
+		378564361B197E8B0039F2BC /* StarSystemGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StarSystemGenerator.cpp; sourceTree = "<group>"; };
+		378564371B197E8B0039F2BC /* StarSystemGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StarSystemGenerator.h; sourceTree = "<group>"; };
+		3785643D1B197E960039F2BC /* Weld.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Weld.h; sourceTree = "<group>"; };
+		378564431B197EB60039F2BC /* PicoDDS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PicoDDS.cpp; sourceTree = "<group>"; };
+		378564441B197EB60039F2BC /* PicoDDS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PicoDDS.h; sourceTree = "<group>"; };
+		378564471B197EB60039F2BC /* Profiler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Profiler.cpp; sourceTree = "<group>"; };
+		378564481B197EB60039F2BC /* Profiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Profiler.h; sourceTree = "<group>"; };
+		3785644E1B197FAE0039F2BC /* LuaServerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaServerAgent.cpp; sourceTree = "<group>"; };
+		3785644F1B197FAE0039F2BC /* LuaServerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaServerAgent.h; sourceTree = "<group>"; };
+		378564501B197FAE0039F2BC /* ServerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServerAgent.cpp; sourceTree = "<group>"; };
+		378564511B197FAE0039F2BC /* ServerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServerAgent.h; sourceTree = "<group>"; };
+		4A01889615A59908002F540B /* SystemPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemPath.cpp; sourceTree = "<group>"; };
+		4A0F25CB165CF00D00208507 /* LuaSmallButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSmallButton.cpp; sourceTree = "<group>"; };
+		4A0F25CC165CF00D00208507 /* SmallButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SmallButton.cpp; sourceTree = "<group>"; };
+		4A0F25CD165CF00D00208507 /* SmallButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmallButton.h; sourceTree = "<group>"; };
+		4A107C2B1525AB0D00EF9FAC /* CRC32.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CRC32.cpp; sourceTree = "<group>"; };
+		4A107C2C1525AB0D00EF9FAC /* CRC32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRC32.h; sourceTree = "<group>"; };
+		4A107C2D1525AB0D00EF9FAC /* ShipController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipController.cpp; sourceTree = "<group>"; };
+		4A107C2E1525AB0D00EF9FAC /* ShipController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipController.h; sourceTree = "<group>"; };
+		4A190325138AA33300E0229C /* Gui.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Gui.cpp; sourceTree = "<group>"; };
+		4A190326138AA33300E0229C /* Gui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gui.h; sourceTree = "<group>"; };
+		4A190328138AA33300E0229C /* GuiAdjustment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiAdjustment.h; sourceTree = "<group>"; };
+		4A190329138AA33300E0229C /* GuiBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiBox.cpp; sourceTree = "<group>"; };
+		4A19032A138AA33300E0229C /* GuiBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiBox.h; sourceTree = "<group>"; };
+		4A19032C138AA33300E0229C /* GuiButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiButton.cpp; sourceTree = "<group>"; };
+		4A19032D138AA33300E0229C /* GuiButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiButton.h; sourceTree = "<group>"; };
+		4A19032F138AA33300E0229C /* GuiContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiContainer.cpp; sourceTree = "<group>"; };
+		4A190330138AA33300E0229C /* GuiContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiContainer.h; sourceTree = "<group>"; };
+		4A190332138AA33300E0229C /* GuiEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiEvents.h; sourceTree = "<group>"; };
+		4A190333138AA33300E0229C /* GuiFixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiFixed.cpp; sourceTree = "<group>"; };
+		4A190334138AA33300E0229C /* GuiFixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiFixed.h; sourceTree = "<group>"; };
+		4A190336138AA33300E0229C /* GuiImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiImage.cpp; sourceTree = "<group>"; };
+		4A190337138AA33300E0229C /* GuiImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiImage.h; sourceTree = "<group>"; };
+		4A190339138AA33300E0229C /* GuiImageButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiImageButton.cpp; sourceTree = "<group>"; };
+		4A19033A138AA33300E0229C /* GuiImageButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiImageButton.h; sourceTree = "<group>"; };
+		4A19033C138AA33300E0229C /* GuiImageRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiImageRadioButton.cpp; sourceTree = "<group>"; };
+		4A19033D138AA33300E0229C /* GuiImageRadioButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiImageRadioButton.h; sourceTree = "<group>"; };
+		4A19033F138AA33300E0229C /* GuiISelectable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiISelectable.h; sourceTree = "<group>"; };
+		4A190340138AA33300E0229C /* GuiLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiLabel.cpp; sourceTree = "<group>"; };
+		4A190341138AA33300E0229C /* GuiLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiLabel.h; sourceTree = "<group>"; };
+		4A190343138AA33300E0229C /* GuiLabelSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiLabelSet.cpp; sourceTree = "<group>"; };
+		4A190344138AA33300E0229C /* GuiLabelSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiLabelSet.h; sourceTree = "<group>"; };
+		4A190346138AA33300E0229C /* GuiMeterBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiMeterBar.cpp; sourceTree = "<group>"; };
+		4A190347138AA33300E0229C /* GuiMeterBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiMeterBar.h; sourceTree = "<group>"; };
+		4A190349138AA33300E0229C /* GuiMultiStateImageButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiMultiStateImageButton.cpp; sourceTree = "<group>"; };
+		4A19034A138AA33300E0229C /* GuiMultiStateImageButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiMultiStateImageButton.h; sourceTree = "<group>"; };
+		4A19034C138AA33300E0229C /* GuiRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiRadioButton.cpp; sourceTree = "<group>"; };
+		4A19034D138AA33300E0229C /* GuiRadioButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiRadioButton.h; sourceTree = "<group>"; };
+		4A19034F138AA33300E0229C /* GuiRadioGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiRadioGroup.cpp; sourceTree = "<group>"; };
+		4A190350138AA33300E0229C /* GuiRadioGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiRadioGroup.h; sourceTree = "<group>"; };
+		4A190355138AA33300E0229C /* GuiScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiScreen.cpp; sourceTree = "<group>"; };
+		4A190356138AA33300E0229C /* GuiScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiScreen.h; sourceTree = "<group>"; };
+		4A190358138AA33300E0229C /* GuiTabbed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiTabbed.cpp; sourceTree = "<group>"; };
+		4A190359138AA33300E0229C /* GuiTabbed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiTabbed.h; sourceTree = "<group>"; };
+		4A19035B138AA33300E0229C /* GuiTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiTextEntry.cpp; sourceTree = "<group>"; };
+		4A19035C138AA33300E0229C /* GuiTextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiTextEntry.h; sourceTree = "<group>"; };
+		4A19035E138AA33300E0229C /* GuiTextLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiTextLayout.cpp; sourceTree = "<group>"; };
+		4A19035F138AA33300E0229C /* GuiTextLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiTextLayout.h; sourceTree = "<group>"; };
+		4A190361138AA33300E0229C /* GuiToggleButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiToggleButton.cpp; sourceTree = "<group>"; };
+		4A190362138AA33300E0229C /* GuiToggleButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiToggleButton.h; sourceTree = "<group>"; };
+		4A190364138AA33300E0229C /* GuiToolTip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiToolTip.cpp; sourceTree = "<group>"; };
+		4A190365138AA33300E0229C /* GuiToolTip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiToolTip.h; sourceTree = "<group>"; };
+		4A190367138AA33300E0229C /* GuiVScrollBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiVScrollBar.cpp; sourceTree = "<group>"; };
+		4A190368138AA33300E0229C /* GuiVScrollBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiVScrollBar.h; sourceTree = "<group>"; };
+		4A19036A138AA33300E0229C /* GuiVScrollPortal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiVScrollPortal.cpp; sourceTree = "<group>"; };
+		4A19036B138AA33300E0229C /* GuiVScrollPortal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiVScrollPortal.h; sourceTree = "<group>"; };
+		4A19036D138AA33300E0229C /* GuiWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiWidget.cpp; sourceTree = "<group>"; };
+		4A19036E138AA33300E0229C /* GuiWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiWidget.h; sourceTree = "<group>"; };
+		4A1903E2138AA39C00E0229C /* lapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lapi.c; sourceTree = "<group>"; };
+		4A1903E3138AA39C00E0229C /* lapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lapi.h; sourceTree = "<group>"; };
+		4A1903E5138AA39C00E0229C /* lauxlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lauxlib.c; sourceTree = "<group>"; };
+		4A1903E6138AA39C00E0229C /* lauxlib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lauxlib.h; sourceTree = "<group>"; };
+		4A1903E8138AA39C00E0229C /* lbaselib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lbaselib.c; sourceTree = "<group>"; };
+		4A1903EA138AA39C00E0229C /* lcode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcode.c; sourceTree = "<group>"; };
+		4A1903EB138AA39C00E0229C /* lcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcode.h; sourceTree = "<group>"; };
+		4A1903ED138AA39C00E0229C /* ldblib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldblib.c; sourceTree = "<group>"; };
+		4A1903EF138AA39C00E0229C /* ldebug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldebug.c; sourceTree = "<group>"; };
+		4A1903F0138AA39C00E0229C /* ldebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ldebug.h; sourceTree = "<group>"; };
+		4A1903F2138AA39C00E0229C /* ldo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldo.c; sourceTree = "<group>"; };
+		4A1903F3138AA39C00E0229C /* ldo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ldo.h; sourceTree = "<group>"; };
+		4A1903F5138AA39C00E0229C /* ldump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldump.c; sourceTree = "<group>"; };
+		4A1903F7138AA39C00E0229C /* lfunc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lfunc.c; sourceTree = "<group>"; };
+		4A1903F8138AA39C00E0229C /* lfunc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lfunc.h; sourceTree = "<group>"; };
+		4A1903FA138AA39C00E0229C /* lgc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lgc.c; sourceTree = "<group>"; };
+		4A1903FB138AA39C00E0229C /* lgc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lgc.h; sourceTree = "<group>"; };
+		4A1903FE138AA39C00E0229C /* linit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = linit.c; sourceTree = "<group>"; };
+		4A190400138AA39C00E0229C /* liolib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = liolib.c; sourceTree = "<group>"; };
+		4A190402138AA39C00E0229C /* llex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = llex.c; sourceTree = "<group>"; };
+		4A190403138AA39C00E0229C /* llex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llex.h; sourceTree = "<group>"; };
+		4A190405138AA39C00E0229C /* llimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llimits.h; sourceTree = "<group>"; };
+		4A190406138AA39C00E0229C /* lmathlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lmathlib.c; sourceTree = "<group>"; };
+		4A190408138AA39C00E0229C /* lmem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lmem.c; sourceTree = "<group>"; };
+		4A190409138AA39C00E0229C /* lmem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lmem.h; sourceTree = "<group>"; };
+		4A19040B138AA39C00E0229C /* loadlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loadlib.c; sourceTree = "<group>"; };
+		4A19040D138AA39C00E0229C /* lobject.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lobject.c; sourceTree = "<group>"; };
+		4A19040E138AA39C00E0229C /* lobject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lobject.h; sourceTree = "<group>"; };
+		4A190410138AA39C00E0229C /* lopcodes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lopcodes.c; sourceTree = "<group>"; };
+		4A190411138AA39C00E0229C /* lopcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lopcodes.h; sourceTree = "<group>"; };
+		4A190413138AA39C00E0229C /* loslib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loslib.c; sourceTree = "<group>"; };
+		4A190415138AA39C00E0229C /* lparser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lparser.c; sourceTree = "<group>"; };
+		4A190416138AA39C00E0229C /* lparser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lparser.h; sourceTree = "<group>"; };
+		4A190418138AA39C00E0229C /* lstate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstate.c; sourceTree = "<group>"; };
+		4A190419138AA39C00E0229C /* lstate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstate.h; sourceTree = "<group>"; };
+		4A19041B138AA39C00E0229C /* lstring.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstring.c; sourceTree = "<group>"; };
+		4A19041C138AA39C00E0229C /* lstring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstring.h; sourceTree = "<group>"; };
+		4A19041E138AA39C00E0229C /* lstrlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstrlib.c; sourceTree = "<group>"; };
+		4A190420138AA39C00E0229C /* ltable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltable.c; sourceTree = "<group>"; };
+		4A190421138AA39C00E0229C /* ltable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ltable.h; sourceTree = "<group>"; };
+		4A190423138AA39C00E0229C /* ltablib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltablib.c; sourceTree = "<group>"; };
+		4A190425138AA39C00E0229C /* ltm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltm.c; sourceTree = "<group>"; };
+		4A190426138AA39C00E0229C /* ltm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ltm.h; sourceTree = "<group>"; };
+		4A190428138AA39C00E0229C /* lua.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lua.c; sourceTree = "<group>"; };
+		4A190429138AA39C00E0229C /* lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lua.h; sourceTree = "<group>"; };
+		4A19042A138AA39C00E0229C /* luac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = luac.c; sourceTree = "<group>"; };
+		4A19042B138AA39C00E0229C /* luaconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = luaconf.h; sourceTree = "<group>"; };
+		4A19042C138AA39C00E0229C /* lualib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lualib.h; sourceTree = "<group>"; };
+		4A19042D138AA39C00E0229C /* lundump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lundump.c; sourceTree = "<group>"; };
+		4A19042E138AA39C00E0229C /* lundump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lundump.h; sourceTree = "<group>"; };
+		4A190430138AA39C00E0229C /* lvm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lvm.c; sourceTree = "<group>"; };
+		4A190431138AA39C00E0229C /* lvm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lvm.h; sourceTree = "<group>"; };
+		4A190433138AA39C00E0229C /* lzio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lzio.c; sourceTree = "<group>"; };
+		4A190434138AA39C00E0229C /* lzio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lzio.h; sourceTree = "<group>"; };
+		4A1E9EBE144EEA8A009243D2 /* FloatComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FloatComparison.h; sourceTree = "<group>"; };
 		4A20B0DE135319770020F43E /* pioneer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = pioneer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A20B0E2135319770020F43E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		4A20B0E5135319770020F43E /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -552,798 +760,510 @@
 		4A20B11713531CD10020F43E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = en; path = pioneer/en.lproj/Credits.rtf; sourceTree = "<group>"; };
 		4A20B11913531CD10020F43E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = pioneer/en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		4A20B11F13531E950020F43E /* pioneerApp.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = pioneerApp.xib; sourceTree = "<group>"; };
-		4A5619CE13866622002A904C /* libfreetype.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libfreetype.6.dylib; path = /opt/local/lib/libfreetype.6.dylib; sourceTree = "<absolute>"; };
-		4A5619D413867033002A904C /* libvorbisfile.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbisfile.3.dylib; path = /opt/local/lib/libvorbisfile.3.dylib; sourceTree = "<absolute>"; };
-		4A671B861388C07700657F38 /* libogg.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libogg.0.dylib; path = ../../../../../opt/local/lib/libogg.0.dylib; sourceTree = "<group>"; };
-		4A671B871388C07700657F38 /* libvorbis.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbis.0.dylib; path = ../../../../../opt/local/lib/libvorbis.0.dylib; sourceTree = "<group>"; };
-		4A671B981388C61F00657F38 /* libsmpeg-0.4.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libsmpeg-0.4.0.dylib"; path = "../../../../../opt/local/lib/libsmpeg-0.4.0.dylib"; sourceTree = "<group>"; };
-		4A671B9B1388C6B700657F38 /* libmodplug.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmodplug.1.dylib; path = ../../../../../opt/local/lib/libmodplug.1.dylib; sourceTree = "<group>"; };
-		4A671BA11388CA3200657F38 /* libspeex.1.5.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libspeex.1.5.0.dylib; path = ../../../../../opt/local/lib/libspeex.1.5.0.dylib; sourceTree = "<group>"; };
+		4A239FC9163E78D60037BE24 /* LuaFaction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFaction.cpp; sourceTree = "<group>"; };
+		4A24075A13F5240F002A5C12 /* Lang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lang.cpp; sourceTree = "<group>"; };
+		4A24075B13F5240F002A5C12 /* Lang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lang.h; sourceTree = "<group>"; };
+		4A24078213F524E6002A5C12 /* GuiStack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiStack.cpp; sourceTree = "<group>"; };
+		4A24078313F524E6002A5C12 /* GuiStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiStack.h; sourceTree = "<group>"; };
+		4A24FD5C1650F4B700DE7B0F /* UIView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIView.cpp; sourceTree = "<group>"; };
+		4A24FD5D1650F4B700DE7B0F /* UIView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIView.h; sourceTree = "<group>"; };
+		4A24FD611650F4D100DE7B0F /* GameUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameUI.h; sourceTree = "<group>"; };
+		4A24FD621650F4D100DE7B0F /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lua.cpp; sourceTree = "<group>"; };
+		4A24FD631650F4D100DE7B0F /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lua.h; sourceTree = "<group>"; };
+		4A24FD651650F4D100DE7B0F /* Panel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Panel.cpp; sourceTree = "<group>"; };
+		4A24FD661650F4D100DE7B0F /* Panel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Panel.h; sourceTree = "<group>"; };
+		4A305FCB151341170076D414 /* ByteRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByteRange.h; sourceTree = "<group>"; };
+		4A305FCC151341170076D414 /* FileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystem.cpp; sourceTree = "<group>"; };
+		4A305FCD151341170076D414 /* FileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileSystem.h; sourceTree = "<group>"; };
+		4A305FCF151341170076D414 /* LangStrings.inc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LangStrings.inc.h; sourceTree = "<group>"; };
+		4A305FD0151341170076D414 /* StringRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringRange.h; sourceTree = "<group>"; };
+		4A37073315A879D100E7E5F6 /* lookup3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lookup3.c; sourceTree = "<group>"; };
+		4A37073415A879D100E7E5F6 /* lookup3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lookup3.h; sourceTree = "<group>"; };
+		4A3AE8E3158FD22200EB13DE /* LuaComms.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaComms.cpp; sourceTree = "<group>"; };
+		4A3AE8E4158FD22200EB13DE /* LuaComms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaComms.h; sourceTree = "<group>"; };
+		4A4A86E716A992D600F81F18 /* CameraController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CameraController.cpp; sourceTree = "<group>"; };
+		4A4A86E816A992D600F81F18 /* CameraController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CameraController.h; sourceTree = "<group>"; };
+		4A4D25D2167335D9003BC9D5 /* Face.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Face.cpp; sourceTree = "<group>"; };
+		4A4D25D3167335D9003BC9D5 /* Face.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Face.h; sourceTree = "<group>"; };
+		4A4D25D4167335D9003BC9D5 /* LuaFace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFace.cpp; sourceTree = "<group>"; };
+		4A4D25DC167335F5003BC9D5 /* Icon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Icon.cpp; sourceTree = "<group>"; };
+		4A4D25DD167335F5003BC9D5 /* Icon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Icon.h; sourceTree = "<group>"; };
+		4A4D25DE167335F5003BC9D5 /* LuaIcon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaIcon.cpp; sourceTree = "<group>"; };
+		4A4F25B914F524D400FD14A6 /* Drawables.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Drawables.cpp; sourceTree = "<group>"; };
+		4A4F25BA14F524D400FD14A6 /* Drawables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Drawables.h; sourceTree = "<group>"; };
+		4A4F25BB14F524D400FD14A6 /* Frustum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Frustum.cpp; sourceTree = "<group>"; };
+		4A4F25BC14F524D400FD14A6 /* Frustum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Frustum.h; sourceTree = "<group>"; };
+		4A4F25BD14F524D400FD14A6 /* Graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Graphics.cpp; sourceTree = "<group>"; };
+		4A4F25BE14F524D400FD14A6 /* Graphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Graphics.h; sourceTree = "<group>"; };
+		4A4F25C014F524D400FD14A6 /* Material.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Material.cpp; sourceTree = "<group>"; };
+		4A4F25C114F524D400FD14A6 /* Material.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Material.h; sourceTree = "<group>"; };
+		4A4F25C214F524D400FD14A6 /* Renderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Renderer.cpp; sourceTree = "<group>"; };
+		4A4F25C314F524D400FD14A6 /* Renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Renderer.h; sourceTree = "<group>"; };
+		4A4F25D014F524D400FD14A6 /* VertexArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VertexArray.cpp; sourceTree = "<group>"; };
+		4A4F25D114F524D400FD14A6 /* VertexArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexArray.h; sourceTree = "<group>"; };
+		4A4F25E014F524F600FD14A6 /* SmartPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmartPtr.h; sourceTree = "<group>"; };
+		4A4F25E114F524F600FD14A6 /* vector2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vector2.h; sourceTree = "<group>"; };
+		4A59B4D51557EAF5009926E5 /* lbitlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lbitlib.c; sourceTree = "<group>"; };
+		4A59B4D61557EAF5009926E5 /* lcorolib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcorolib.c; sourceTree = "<group>"; };
+		4A59B4D71557EAF5009926E5 /* lctype.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lctype.c; sourceTree = "<group>"; };
+		4A59B4D81557EAF5009926E5 /* lctype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lctype.h; sourceTree = "<group>"; };
+		4A59B4D91557EAF5009926E5 /* lua.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lua.hpp; sourceTree = "<group>"; };
+		4A61E15C13978F1000193E43 /* Background.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Background.cpp; sourceTree = "<group>"; };
+		4A61E15D13978F1000193E43 /* Background.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Background.h; sourceTree = "<group>"; };
+		4A62EF2B136979E000919EBB /* VideoLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLink.h; sourceTree = "<group>"; };
+		4A6392C4136BD51E008352F1 /* buildopts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buildopts.h; sourceTree = "<group>"; };
+		4A6B59CA1429F14500ADC7C8 /* StringF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringF.cpp; sourceTree = "<group>"; };
+		4A6B59CB1429F14500ADC7C8 /* StringF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringF.h; sourceTree = "<group>"; };
+		4A6C4BFE13532FC300FDD53F /* Aabb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Aabb.h; sourceTree = "<group>"; };
+		4A6C4BFF13532FC300FDD53F /* AmbientSounds.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AmbientSounds.cpp; sourceTree = "<group>"; };
+		4A6C4C0013532FC300FDD53F /* AmbientSounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AmbientSounds.h; sourceTree = "<group>"; };
+		4A6C4C0213532FC300FDD53F /* Body.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Body.cpp; sourceTree = "<group>"; };
+		4A6C4C0313532FC300FDD53F /* Body.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Body.h; sourceTree = "<group>"; };
+		4A6C4C0513532FC300FDD53F /* CargoBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CargoBody.cpp; sourceTree = "<group>"; };
+		4A6C4C0613532FC300FDD53F /* CargoBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CargoBody.h; sourceTree = "<group>"; };
+		4A6C4C0713532FC300FDD53F /* CityOnPlanet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CityOnPlanet.cpp; sourceTree = "<group>"; };
+		4A6C4C0813532FC300FDD53F /* CityOnPlanet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CityOnPlanet.h; sourceTree = "<group>"; };
+		4A6C4C0F13532FC300FDD53F /* BVHTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BVHTree.cpp; sourceTree = "<group>"; };
+		4A6C4C1013532FC300FDD53F /* BVHTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BVHTree.h; sourceTree = "<group>"; };
+		4A6C4C1113532FC300FDD53F /* collider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = collider.h; sourceTree = "<group>"; };
+		4A6C4C1213532FC300FDD53F /* CollisionContact.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollisionContact.h; sourceTree = "<group>"; };
+		4A6C4C1313532FC300FDD53F /* CollisionSpace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollisionSpace.cpp; sourceTree = "<group>"; };
+		4A6C4C1413532FC300FDD53F /* CollisionSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollisionSpace.h; sourceTree = "<group>"; };
+		4A6C4C1513532FC300FDD53F /* Geom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Geom.cpp; sourceTree = "<group>"; };
+		4A6C4C1613532FC300FDD53F /* Geom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Geom.h; sourceTree = "<group>"; };
+		4A6C4C1713532FC300FDD53F /* GeomTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeomTree.cpp; sourceTree = "<group>"; };
+		4A6C4C1813532FC300FDD53F /* GeomTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeomTree.h; sourceTree = "<group>"; };
+		4A6C4C1C13532FC300FDD53F /* Color.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Color.h; sourceTree = "<group>"; };
+		4A6C4C2113532FC300FDD53F /* DynamicBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DynamicBody.cpp; sourceTree = "<group>"; };
+		4A6C4C2213532FC300FDD53F /* DynamicBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DynamicBody.h; sourceTree = "<group>"; };
+		4A6C4C2513532FC300FDD53F /* fixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fixed.h; sourceTree = "<group>"; };
+		4A6C4C2613532FC300FDD53F /* Frame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Frame.cpp; sourceTree = "<group>"; };
+		4A6C4C2713532FC300FDD53F /* Frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Frame.h; sourceTree = "<group>"; };
+		4A6C4C2813532FC300FDD53F /* GalacticView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GalacticView.cpp; sourceTree = "<group>"; };
+		4A6C4C2913532FC300FDD53F /* GalacticView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GalacticView.h; sourceTree = "<group>"; };
+		4A6C4C2C13532FC300FDD53F /* gameconsts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gameconsts.h; sourceTree = "<group>"; };
+		4A6C4C3113532FC300FDD53F /* GeoSphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoSphere.cpp; sourceTree = "<group>"; };
+		4A6C4C3213532FC300FDD53F /* GeoSphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoSphere.h; sourceTree = "<group>"; };
+		4A6C4C6A13532FC300FDD53F /* HyperspaceCloud.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HyperspaceCloud.cpp; sourceTree = "<group>"; };
+		4A6C4C6B13532FC300FDD53F /* HyperspaceCloud.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HyperspaceCloud.h; sourceTree = "<group>"; };
+		4A6C4C6E13532FC300FDD53F /* IniConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IniConfig.cpp; sourceTree = "<group>"; };
+		4A6C4C6F13532FC300FDD53F /* IniConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IniConfig.h; sourceTree = "<group>"; };
+		4A6C4C7013532FC300FDD53F /* KeyBindings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyBindings.cpp; sourceTree = "<group>"; };
+		4A6C4C7113532FC300FDD53F /* KeyBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyBindings.h; sourceTree = "<group>"; };
+		4A6C4C7213532FC300FDD53F /* libs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libs.h; sourceTree = "<group>"; };
+		4A6C4CD313532FC300FDD53F /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+		4A6C4CD913532FC300FDD53F /* matrix4x4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = matrix4x4.h; sourceTree = "<group>"; };
+		4A6C4CDA13532FC300FDD53F /* Missile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Missile.cpp; sourceTree = "<group>"; };
+		4A6C4CDB13532FC300FDD53F /* Missile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Missile.h; sourceTree = "<group>"; };
+		4A6C4CDE13532FC300FDD53F /* ModelBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelBody.cpp; sourceTree = "<group>"; };
+		4A6C4CDF13532FC300FDD53F /* ModelBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelBody.h; sourceTree = "<group>"; };
+		4A6C4CE813532FC300FDD53F /* Object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Object.h; sourceTree = "<group>"; };
+		4A6C4CE913532FC300FDD53F /* ObjectViewerView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjectViewerView.cpp; sourceTree = "<group>"; };
+		4A6C4CEA13532FC300FDD53F /* ObjectViewerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectViewerView.h; sourceTree = "<group>"; };
+		4A6C4D2C13532FC300FDD53F /* perlin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = perlin.cpp; sourceTree = "<group>"; };
+		4A6C4D2D13532FC300FDD53F /* perlin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = perlin.h; sourceTree = "<group>"; };
+		4A6C4D2E13532FC300FDD53F /* PersistSystemData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PersistSystemData.h; sourceTree = "<group>"; };
+		4A6C4D2F13532FC300FDD53F /* Pi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Pi.cpp; sourceTree = "<group>"; };
+		4A6C4D3013532FC300FDD53F /* Pi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Pi.h; sourceTree = "<group>"; };
+		4A6C4D3913532FC300FDD53F /* Planet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Planet.cpp; sourceTree = "<group>"; };
+		4A6C4D3A13532FC300FDD53F /* Planet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Planet.h; sourceTree = "<group>"; };
+		4A6C4D3B13532FC300FDD53F /* Player.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Player.cpp; sourceTree = "<group>"; };
+		4A6C4D3C13532FC300FDD53F /* Player.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Player.h; sourceTree = "<group>"; };
+		4A6C4D3F13532FC300FDD53F /* Polit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Polit.cpp; sourceTree = "<group>"; };
+		4A6C4D4013532FC300FDD53F /* Polit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Polit.h; sourceTree = "<group>"; };
+		4A6C4D4113532FC300FDD53F /* Projectile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Projectile.cpp; sourceTree = "<group>"; };
+		4A6C4D4213532FC300FDD53F /* Projectile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Projectile.h; sourceTree = "<group>"; };
+		4A6C4D4313532FC300FDD53F /* Quaternion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Quaternion.h; sourceTree = "<group>"; };
+		4A6C4D4813532FC300FDD53F /* SectorView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SectorView.cpp; sourceTree = "<group>"; };
+		4A6C4D4913532FC300FDD53F /* SectorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SectorView.h; sourceTree = "<group>"; };
+		4A6C4D4A13532FC300FDD53F /* Serializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Serializer.cpp; sourceTree = "<group>"; };
+		4A6C4D4B13532FC300FDD53F /* Serializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Serializer.h; sourceTree = "<group>"; };
+		4A6C4D4C13532FC300FDD53F /* Sfx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sfx.cpp; sourceTree = "<group>"; };
+		4A6C4D4D13532FC300FDD53F /* Sfx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sfx.h; sourceTree = "<group>"; };
+		4A6C4D4E13532FC300FDD53F /* Ship-AI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "Ship-AI.cpp"; sourceTree = "<group>"; };
+		4A6C4D4F13532FC300FDD53F /* Ship.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Ship.cpp; sourceTree = "<group>"; };
+		4A6C4D5013532FC300FDD53F /* Ship.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ship.h; sourceTree = "<group>"; };
+		4A6C4D5113532FC300FDD53F /* ShipAICmd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipAICmd.cpp; sourceTree = "<group>"; };
+		4A6C4D5213532FC300FDD53F /* ShipAICmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipAICmd.h; sourceTree = "<group>"; };
+		4A6C4D5313532FC300FDD53F /* ShipCpanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipCpanel.cpp; sourceTree = "<group>"; };
+		4A6C4D5413532FC300FDD53F /* ShipCpanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipCpanel.h; sourceTree = "<group>"; };
+		4A6C4D5513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipCpanelMultiFuncDisplays.cpp; sourceTree = "<group>"; };
+		4A6C4D5613532FC300FDD53F /* ShipCpanelMultiFuncDisplays.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipCpanelMultiFuncDisplays.h; sourceTree = "<group>"; };
+		4A6C4D5913532FC300FDD53F /* ShipType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipType.cpp; sourceTree = "<group>"; };
+		4A6C4D5A13532FC300FDD53F /* ShipType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipType.h; sourceTree = "<group>"; };
+		4A6C4D5B13532FC300FDD53F /* Sound.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sound.cpp; sourceTree = "<group>"; };
+		4A6C4D5C13532FC300FDD53F /* Sound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sound.h; sourceTree = "<group>"; };
+		4A6C4D5D13532FC300FDD53F /* Space.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Space.cpp; sourceTree = "<group>"; };
+		4A6C4D5E13532FC300FDD53F /* Space.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Space.h; sourceTree = "<group>"; };
+		4A6C4D5F13532FC300FDD53F /* SpaceStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpaceStation.cpp; sourceTree = "<group>"; };
+		4A6C4D6013532FC300FDD53F /* SpaceStation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpaceStation.h; sourceTree = "<group>"; };
+		4A6C4D6313532FC300FDD53F /* Star.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Star.cpp; sourceTree = "<group>"; };
+		4A6C4D6413532FC300FDD53F /* Star.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Star.h; sourceTree = "<group>"; };
+		4A6C4D6913532FC300FDD53F /* SystemInfoView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemInfoView.cpp; sourceTree = "<group>"; };
+		4A6C4D6A13532FC300FDD53F /* SystemInfoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemInfoView.h; sourceTree = "<group>"; };
+		4A6C4D6B13532FC300FDD53F /* SystemView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemView.cpp; sourceTree = "<group>"; };
+		4A6C4D6C13532FC300FDD53F /* SystemView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemView.h; sourceTree = "<group>"; };
+		4A6C4D6E13532FC300FDD53F /* utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = utils.cpp; sourceTree = "<group>"; };
+		4A6C4D6F13532FC300FDD53F /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
+		4A6C4D7013532FC300FDD53F /* vector3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vector3.h; sourceTree = "<group>"; };
+		4A6C4D7113532FC300FDD53F /* View.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = View.h; sourceTree = "<group>"; };
+		4A6C4D7213532FC300FDD53F /* WorldView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorldView.cpp; sourceTree = "<group>"; };
+		4A6C4D7313532FC300FDD53F /* WorldView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorldView.h; sourceTree = "<group>"; };
 		4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libsigc-2.0.0.dylib"; path = "/opt/local/lib/libsigc-2.0.0.dylib"; sourceTree = "<absolute>"; };
 		4A6C55141354655000FDD53F /* data */ = {isa = PBXFileReference; lastKnownFileType = folder; name = data; path = ../data; sourceTree = "<group>"; };
-		4A7611281611A90B00A06F79 /* libFLAC.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libFLAC.8.dylib; path = /opt/local/lib/libFLAC.8.dylib; sourceTree = "<absolute>"; };
+		4A712411170EC89000BB9BCC /* Orbit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Orbit.cpp; sourceTree = "<group>"; };
+		4A712412170EC89000BB9BCC /* Orbit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Orbit.h; sourceTree = "<group>"; };
 		4A76112B1611AA5F00A06F79 /* CC-BY-SA-3.0.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "CC-BY-SA-3.0.txt"; path = "../licenses/CC-BY-SA-3.0.txt"; sourceTree = "<group>"; };
 		4A76112C1611AA5F00A06F79 /* GPL-3.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "GPL-3.txt"; path = "../licenses/GPL-3.txt"; sourceTree = "<group>"; };
 		4A76112D1611AA5F00A06F79 /* SIL-1.1.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "SIL-1.1.txt"; path = "../licenses/SIL-1.1.txt"; sourceTree = "<group>"; };
+		4A82AA7D1386969B0028CCED /* GameConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameConfig.cpp; sourceTree = "<group>"; };
+		4A82AA7E1386969B0028CCED /* GameConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameConfig.h; sourceTree = "<group>"; };
+		4A82AA7F1386969B0028CCED /* LuaObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaObject.h; sourceTree = "<group>"; };
+		4A84CB7B14595D850051C848 /* enum_table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = enum_table.cpp; sourceTree = "<group>"; };
+		4A84CB7C14595D850051C848 /* enum_table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enum_table.h; sourceTree = "<group>"; };
+		4A84CB82146027DC0051C848 /* Camera.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Camera.cpp; sourceTree = "<group>"; };
+		4A84CB83146027DC0051C848 /* Camera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Camera.h; sourceTree = "<group>"; };
 		4A8563FC148655DA008121E1 /* pioneer-logo.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = "pioneer-logo.icns"; sourceTree = "<group>"; };
+		4A85A86313C4631D00C2B986 /* LuaMusic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMusic.cpp; sourceTree = "<group>"; };
+		4A85A86413C4631D00C2B986 /* LuaMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaMusic.h; sourceTree = "<group>"; };
+		4A85A86513C4631D00C2B986 /* LuaSystemPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSystemPath.cpp; sourceTree = "<group>"; };
+		4A85A86713C4631D00C2B986 /* SoundMusic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SoundMusic.cpp; sourceTree = "<group>"; };
+		4A85A86813C4631D00C2B986 /* SoundMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundMusic.h; sourceTree = "<group>"; };
+		4A8AE19217208CE40005C2D9 /* LuaPropertiedObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaPropertiedObject.cpp; sourceTree = "<group>"; };
+		4A8AE19317208CE40005C2D9 /* PropertiedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PropertiedObject.h; sourceTree = "<group>"; };
+		4A8AE19417208CE40005C2D9 /* PropertyMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PropertyMap.cpp; sourceTree = "<group>"; };
+		4A8AE19517208CE50005C2D9 /* PropertyMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PropertyMap.h; sourceTree = "<group>"; };
+		4A8DD539142E19B6006DD821 /* LuaConsole.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaConsole.cpp; sourceTree = "<group>"; };
+		4A8DD53A142E19B6006DD821 /* LuaConsole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaConsole.h; sourceTree = "<group>"; };
+		4A9174F215187B69006A15A9 /* GuiTexturedQuad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiTexturedQuad.cpp; sourceTree = "<group>"; };
+		4A9174F315187B69006A15A9 /* GuiTexturedQuad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiTexturedQuad.h; sourceTree = "<group>"; };
+		4A9174F615187B97006A15A9 /* Texture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Texture.h; sourceTree = "<group>"; };
+		4A9174F715187B97006A15A9 /* TextureBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureBuilder.cpp; sourceTree = "<group>"; };
+		4A9174F815187B97006A15A9 /* TextureBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureBuilder.h; sourceTree = "<group>"; };
+		4A9174FD15187C17006A15A9 /* Color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Color.cpp; sourceTree = "<group>"; };
+		4A94CA4114F26875002CA792 /* FontCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontCache.cpp; sourceTree = "<group>"; };
+		4A94CA4214F26875002CA792 /* FontCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontCache.h; sourceTree = "<group>"; };
+		4A973BF31618688F0029562D /* DeathView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeathView.cpp; sourceTree = "<group>"; };
+		4A973BF41618688F0029562D /* DeathView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeathView.h; sourceTree = "<group>"; };
+		4A973BF51618688F0029562D /* LuaDev.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaDev.cpp; sourceTree = "<group>"; };
+		4A973BF61618688F0029562D /* LuaDev.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaDev.h; sourceTree = "<group>"; };
 		4A9822AA142DF93D00B423F1 /* AUTHORS.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = AUTHORS.txt; path = ../AUTHORS.txt; sourceTree = "<group>"; };
 		4A9822AD142E00B100B423F1 /* Quickstart.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Quickstart.txt; path = ../Quickstart.txt; sourceTree = "<group>"; };
-		4A9822AE142E00B100B423F1 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.txt; path = ../README.txt; sourceTree = "<group>"; };
 		4A9822B3142E02AF00B423F1 /* Changelog.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Changelog.txt; path = ../Changelog.txt; sourceTree = "<group>"; };
+		4A99371A1368355400EA0EE5 /* DeleteEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeleteEmitter.h; sourceTree = "<group>"; };
+		4A99371B1368355400EA0EE5 /* LuaBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaBody.cpp; sourceTree = "<group>"; };
+		4A99371D1368355400EA0EE5 /* LuaCargoBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaCargoBody.cpp; sourceTree = "<group>"; };
+		4A99371F1368355500EA0EE5 /* LuaConstants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaConstants.cpp; sourceTree = "<group>"; };
+		4A9937201368355500EA0EE5 /* LuaConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaConstants.h; sourceTree = "<group>"; };
+		4A9937211368355500EA0EE5 /* LuaEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaEngine.cpp; sourceTree = "<group>"; };
+		4A9937221368355500EA0EE5 /* LuaEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaEngine.h; sourceTree = "<group>"; };
+		4A9937271368355500EA0EE5 /* LuaFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFormat.cpp; sourceTree = "<group>"; };
+		4A9937281368355500EA0EE5 /* LuaFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaFormat.h; sourceTree = "<group>"; };
+		4A9937291368355500EA0EE5 /* LuaGame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaGame.cpp; sourceTree = "<group>"; };
+		4A99372A1368355500EA0EE5 /* LuaGame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaGame.h; sourceTree = "<group>"; };
+		4A99372B1368355500EA0EE5 /* LuaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaManager.cpp; sourceTree = "<group>"; };
+		4A99372C1368355500EA0EE5 /* LuaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaManager.h; sourceTree = "<group>"; };
+		4A99372D1368355500EA0EE5 /* LuaNameGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaNameGen.cpp; sourceTree = "<group>"; };
+		4A99372E1368355500EA0EE5 /* LuaNameGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaNameGen.h; sourceTree = "<group>"; };
+		4A99372F1368355500EA0EE5 /* LuaObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaObject.cpp; sourceTree = "<group>"; };
+		4A9937301368355500EA0EE5 /* LuaPlanet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaPlanet.cpp; sourceTree = "<group>"; };
+		4A9937321368355500EA0EE5 /* LuaPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaPlayer.cpp; sourceTree = "<group>"; };
+		4A9937341368355500EA0EE5 /* LuaRand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaRand.cpp; sourceTree = "<group>"; };
+		4A99373A1368355500EA0EE5 /* LuaSerializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSerializer.cpp; sourceTree = "<group>"; };
+		4A99373B1368355500EA0EE5 /* LuaSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaSerializer.h; sourceTree = "<group>"; };
+		4A99373C1368355500EA0EE5 /* LuaShip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaShip.cpp; sourceTree = "<group>"; };
+		4A9937401368355500EA0EE5 /* LuaSpace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSpace.cpp; sourceTree = "<group>"; };
+		4A9937411368355500EA0EE5 /* LuaSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaSpace.h; sourceTree = "<group>"; };
+		4A9937421368355500EA0EE5 /* LuaSpaceStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSpaceStation.cpp; sourceTree = "<group>"; };
+		4A9937441368355500EA0EE5 /* LuaStar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaStar.cpp; sourceTree = "<group>"; };
+		4A9937461368355500EA0EE5 /* LuaStarSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaStarSystem.cpp; sourceTree = "<group>"; };
+		4A9937481368355500EA0EE5 /* LuaTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaTimer.cpp; sourceTree = "<group>"; };
+		4A9937491368355500EA0EE5 /* LuaTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaTimer.h; sourceTree = "<group>"; };
+		4A99374C1368355500EA0EE5 /* LuaUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaUtils.cpp; sourceTree = "<group>"; };
+		4A99374D1368355500EA0EE5 /* LuaUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaUtils.h; sourceTree = "<group>"; };
+		4A99374E1368355500EA0EE5 /* RefCounted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RefCounted.h; sourceTree = "<group>"; };
+		4AA4A8D4164D0EB10006C3BF /* Expand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Expand.cpp; sourceTree = "<group>"; };
+		4AA4A8D5164D0EB10006C3BF /* Expand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Expand.h; sourceTree = "<group>"; };
+		4AA4A8D6164D0EB10006C3BF /* Gradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Gradient.cpp; sourceTree = "<group>"; };
+		4AA4A8D7164D0EB10006C3BF /* Gradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gradient.h; sourceTree = "<group>"; };
+		4AA4A8D8164D0EB10006C3BF /* LuaExpand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaExpand.cpp; sourceTree = "<group>"; };
+		4AA4A8D9164D0EB10006C3BF /* LuaGradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaGradient.cpp; sourceTree = "<group>"; };
+		4AA527F716E9EABA0036D4CB /* Easing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Easing.h; sourceTree = "<group>"; };
+		4AA527F816E9EABA0036D4CB /* NavLights.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NavLights.cpp; sourceTree = "<group>"; };
+		4AA527F916E9EABA0036D4CB /* NavLights.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NavLights.h; sourceTree = "<group>"; };
+		4AA527FB16E9EB650036D4CB /* LuaModelSpinner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaModelSpinner.cpp; sourceTree = "<group>"; };
+		4AA527FC16E9EB650036D4CB /* ModelSpinner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelSpinner.cpp; sourceTree = "<group>"; };
+		4AA527FD16E9EB650036D4CB /* ModelSpinner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelSpinner.h; sourceTree = "<group>"; };
+		4AA5280016E9EB980036D4CB /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lua.cpp; sourceTree = "<group>"; };
+		4AA5280116E9EB980036D4CB /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lua.h; sourceTree = "<group>"; };
+		4AA5280216E9EB980036D4CB /* ModelSkin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelSkin.cpp; sourceTree = "<group>"; };
+		4AA5280316E9EB980036D4CB /* ModelSkin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelSkin.h; sourceTree = "<group>"; };
+		4AA5280416E9EB980036D4CB /* NodeCopyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NodeCopyCache.h; sourceTree = "<group>"; };
+		4AA5280716E9EBD60036D4CB /* LuaModelSkin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaModelSkin.cpp; sourceTree = "<group>"; };
+		4AA84A2316D0E18700220311 /* LuaShipDef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaShipDef.cpp; sourceTree = "<group>"; };
+		4AA84A2416D0E18700220311 /* LuaShipDef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaShipDef.h; sourceTree = "<group>"; };
+		4AA84A2516D0E18700220311 /* LuaWrappable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaWrappable.h; sourceTree = "<group>"; };
+		4AA84A2616D0E18700220311 /* Random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Random.h; sourceTree = "<group>"; };
+		4AA9F6CB17288E0900124C2E /* TerrainHeightEllipsoid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightEllipsoid.cpp; sourceTree = "<group>"; };
+		4AAB881A15F4AD7700AAF8A8 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lua.cpp; sourceTree = "<group>"; };
+		4AAB881B15F4AD7700AAF8A8 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lua.h; sourceTree = "<group>"; };
+		4AAB881C15F4AD7700AAF8A8 /* OS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OS.h; sourceTree = "<group>"; };
+		4AAB884415FDEA6E00AAF8A8 /* LuaPushPull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaPushPull.h; sourceTree = "<group>"; };
+		4AAB884515FDEA6E00AAF8A8 /* LuaRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaRef.cpp; sourceTree = "<group>"; };
+		4AAB884615FDEA6F00AAF8A8 /* LuaRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaRef.h; sourceTree = "<group>"; };
+		4AAB884715FDEA6F00AAF8A8 /* LuaTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaTable.h; sourceTree = "<group>"; };
+		4AAB884A15FE070900AAF8A8 /* AnimationCurves.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnimationCurves.h; sourceTree = "<group>"; };
+		4AAC9FDF15458FE400116131 /* miniz.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = miniz.h; sourceTree = "<group>"; };
+		4AAC9FE51545901D00116131 /* FileSourceZip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSourceZip.cpp; sourceTree = "<group>"; };
+		4AAC9FE61545901D00116131 /* FileSourceZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileSourceZip.h; sourceTree = "<group>"; };
+		4AAC9FE71545901D00116131 /* ModManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModManager.cpp; sourceTree = "<group>"; };
+		4AAC9FE81545901D00116131 /* ModManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModManager.h; sourceTree = "<group>"; };
+		4AB3DF8714346952001B783A /* TerrainBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainBody.cpp; sourceTree = "<group>"; };
+		4AB3DF8814346952001B783A /* TerrainBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TerrainBody.h; sourceTree = "<group>"; };
+		4AB7D5D11472A83E00158DE4 /* Terrain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Terrain.cpp; sourceTree = "<group>"; };
+		4AB7D5D21472A83E00158DE4 /* Terrain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Terrain.h; sourceTree = "<group>"; };
+		4AB7D5D31472A83E00158DE4 /* TerrainColorAsteroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorAsteroid.cpp; sourceTree = "<group>"; };
+		4AB7D5D41472A83E00158DE4 /* TerrainColorBandedRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorBandedRock.cpp; sourceTree = "<group>"; };
+		4AB7D5D51472A83E00158DE4 /* TerrainColorDeadWithWater.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorDeadWithWater.cpp; sourceTree = "<group>"; };
+		4AB7D5D61472A83E00158DE4 /* TerrainColorDesert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorDesert.cpp; sourceTree = "<group>"; };
+		4AB7D5D71472A83E00158DE4 /* TerrainColorEarthLike.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorEarthLike.cpp; sourceTree = "<group>"; };
+		4AB7D5D81472A83E00158DE4 /* TerrainColorGGJupiter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGJupiter.cpp; sourceTree = "<group>"; };
+		4AB7D5D91472A83E00158DE4 /* TerrainColorGGNeptune.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGNeptune.cpp; sourceTree = "<group>"; };
+		4AB7D5DA1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGNeptune2.cpp; sourceTree = "<group>"; };
+		4AB7D5DB1472A83E00158DE4 /* TerrainColorGGSaturn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGSaturn.cpp; sourceTree = "<group>"; };
+		4AB7D5DC1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGSaturn2.cpp; sourceTree = "<group>"; };
+		4AB7D5DD1472A83E00158DE4 /* TerrainColorGGUranus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGUranus.cpp; sourceTree = "<group>"; };
+		4AB7D5DE1472A83E00158DE4 /* TerrainColorIce.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorIce.cpp; sourceTree = "<group>"; };
+		4AB7D5DF1472A83E00158DE4 /* TerrainColorMethane.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorMethane.cpp; sourceTree = "<group>"; };
+		4AB7D5E01472A83E00158DE4 /* TerrainColorRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorRock.cpp; sourceTree = "<group>"; };
+		4AB7D5E11472A83E00158DE4 /* TerrainColorRock2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorRock2.cpp; sourceTree = "<group>"; };
+		4AB7D5E21472A83E00158DE4 /* TerrainColorSolid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorSolid.cpp; sourceTree = "<group>"; };
+		4AB7D5E31472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarBrownDwarf.cpp; sourceTree = "<group>"; };
+		4AB7D5E41472A83E00158DE4 /* TerrainColorStarG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarG.cpp; sourceTree = "<group>"; };
+		4AB7D5E51472A83E00158DE4 /* TerrainColorStarK.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarK.cpp; sourceTree = "<group>"; };
+		4AB7D5E61472A83E00158DE4 /* TerrainColorStarM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarM.cpp; sourceTree = "<group>"; };
+		4AB7D5E71472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarWhiteDwarf.cpp; sourceTree = "<group>"; };
+		4AB7D5E81472A83E00158DE4 /* TerrainColorTFGood.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorTFGood.cpp; sourceTree = "<group>"; };
+		4AB7D5E91472A83E00158DE4 /* TerrainColorTFPoor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorTFPoor.cpp; sourceTree = "<group>"; };
+		4AB7D5EA1472A83E00158DE4 /* TerrainColorVolcanic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorVolcanic.cpp; sourceTree = "<group>"; };
+		4AB7D5EB1472A83E00158DE4 /* TerrainFeature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainFeature.cpp; sourceTree = "<group>"; };
+		4AB7D5EC1472A83E00158DE4 /* TerrainFeature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TerrainFeature.h; sourceTree = "<group>"; };
+		4AB7D5ED1472A83E00158DE4 /* TerrainHeightAsteroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightAsteroid.cpp; sourceTree = "<group>"; };
+		4AB7D5EE1472A83E00158DE4 /* TerrainHeightFlat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightFlat.cpp; sourceTree = "<group>"; };
+		4AB7D5EF1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsCraters.cpp; sourceTree = "<group>"; };
+		4AB7D5F01472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsCraters2.cpp; sourceTree = "<group>"; };
+		4AB7D5F11472A83E00158DE4 /* TerrainHeightHillsDunes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsDunes.cpp; sourceTree = "<group>"; };
+		4AB7D5F21472A83E00158DE4 /* TerrainHeightHillsNormal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsNormal.cpp; sourceTree = "<group>"; };
+		4AB7D5F31472A83E00158DE4 /* TerrainHeightHillsRidged.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsRidged.cpp; sourceTree = "<group>"; };
+		4AB7D5F41472A83E00158DE4 /* TerrainHeightHillsRivers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsRivers.cpp; sourceTree = "<group>"; };
+		4AB7D5F51472A83E00158DE4 /* TerrainHeightMapped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMapped.cpp; sourceTree = "<group>"; };
+		4AB7D5F61472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsCraters.cpp; sourceTree = "<group>"; };
+		4AB7D5F71472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsCraters2.cpp; sourceTree = "<group>"; };
+		4AB7D5F81472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsNormal.cpp; sourceTree = "<group>"; };
+		4AB7D5F91472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsRidged.cpp; sourceTree = "<group>"; };
+		4AB7D5FA1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsRivers.cpp; sourceTree = "<group>"; };
+		4AB7D5FB1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsRiversVolcano.cpp; sourceTree = "<group>"; };
+		4AB7D5FC1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsVolcano.cpp; sourceTree = "<group>"; };
+		4AB7D5FD1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightRuggedDesert.cpp; sourceTree = "<group>"; };
+		4AB7D5FE1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightRuggedLava.cpp; sourceTree = "<group>"; };
+		4AB7D5FF1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightWaterSolid.cpp; sourceTree = "<group>"; };
+		4AB7D6001472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightWaterSolidCanyons.cpp; sourceTree = "<group>"; };
+		4AB7D6011472A83E00158DE4 /* TerrainNoise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TerrainNoise.h; sourceTree = "<group>"; };
+		4ABF302E16335A1100664653 /* Align.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Align.cpp; sourceTree = "<group>"; };
+		4ABF302F16335A1100664653 /* Align.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Align.h; sourceTree = "<group>"; };
+		4ABF303016335A1100664653 /* Background.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Background.cpp; sourceTree = "<group>"; };
+		4ABF303116335A1100664653 /* Background.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Background.h; sourceTree = "<group>"; };
+		4ABF303216335A1100664653 /* Box.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Box.cpp; sourceTree = "<group>"; };
+		4ABF303316335A1100664653 /* Box.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Box.h; sourceTree = "<group>"; };
+		4ABF303416335A1100664653 /* Button.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Button.cpp; sourceTree = "<group>"; };
+		4ABF303516335A1100664653 /* Button.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Button.h; sourceTree = "<group>"; };
+		4ABF303616335A1100664653 /* CellSpec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CellSpec.cpp; sourceTree = "<group>"; };
+		4ABF303716335A1100664653 /* CellSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CellSpec.h; sourceTree = "<group>"; };
+		4ABF303816335A1100664653 /* CheckBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CheckBox.cpp; sourceTree = "<group>"; };
+		4ABF303916335A1100664653 /* CheckBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CheckBox.h; sourceTree = "<group>"; };
+		4ABF303A16335A1100664653 /* ColorBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColorBackground.cpp; sourceTree = "<group>"; };
+		4ABF303B16335A1100664653 /* ColorBackground.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorBackground.h; sourceTree = "<group>"; };
+		4ABF303C16335A1100664653 /* Container.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Container.cpp; sourceTree = "<group>"; };
+		4ABF303D16335A1100664653 /* Container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Container.h; sourceTree = "<group>"; };
+		4ABF303E16335A1100664653 /* Context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Context.cpp; sourceTree = "<group>"; };
+		4ABF303F16335A1100664653 /* Context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Context.h; sourceTree = "<group>"; };
+		4ABF304016335A1100664653 /* DropDown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DropDown.cpp; sourceTree = "<group>"; };
+		4ABF304116335A1100664653 /* DropDown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DropDown.h; sourceTree = "<group>"; };
+		4ABF304216335A1100664653 /* Event.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Event.cpp; sourceTree = "<group>"; };
+		4ABF304316335A1100664653 /* Event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Event.h; sourceTree = "<group>"; };
+		4ABF304416335A1100664653 /* EventDispatcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventDispatcher.cpp; sourceTree = "<group>"; };
+		4ABF304516335A1100664653 /* EventDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventDispatcher.h; sourceTree = "<group>"; };
+		4ABF304816335A1100664653 /* Grid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Grid.cpp; sourceTree = "<group>"; };
+		4ABF304916335A1100664653 /* Grid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Grid.h; sourceTree = "<group>"; };
+		4ABF304A16335A1100664653 /* Image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Image.cpp; sourceTree = "<group>"; };
+		4ABF304B16335A1100664653 /* Image.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Image.h; sourceTree = "<group>"; };
+		4ABF304C16335A1100664653 /* Label.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Label.cpp; sourceTree = "<group>"; };
+		4ABF304D16335A1100664653 /* Label.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Label.h; sourceTree = "<group>"; };
+		4ABF304E16335A1100664653 /* List.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = List.cpp; sourceTree = "<group>"; };
+		4ABF304F16335A1100664653 /* List.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = List.h; sourceTree = "<group>"; };
+		4ABF305016335A1100664653 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lua.cpp; sourceTree = "<group>"; };
+		4ABF305116335A1100664653 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lua.h; sourceTree = "<group>"; };
+		4ABF305216335A1100664653 /* LuaAlign.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaAlign.cpp; sourceTree = "<group>"; };
+		4ABF305316335A1100664653 /* LuaBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaBackground.cpp; sourceTree = "<group>"; };
+		4ABF305416335A1100664653 /* LuaBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaBox.cpp; sourceTree = "<group>"; };
+		4ABF305516335A1100664653 /* LuaButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaButton.cpp; sourceTree = "<group>"; };
+		4ABF305616335A1100664653 /* LuaCheckBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaCheckBox.cpp; sourceTree = "<group>"; };
+		4ABF305716335A1100664653 /* LuaColorBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaColorBackground.cpp; sourceTree = "<group>"; };
+		4ABF305816335A1100664653 /* LuaContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaContainer.cpp; sourceTree = "<group>"; };
+		4ABF305916335A1100664653 /* LuaContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaContext.cpp; sourceTree = "<group>"; };
+		4ABF305A16335A1100664653 /* LuaDropDown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaDropDown.cpp; sourceTree = "<group>"; };
+		4ABF305B16335A1100664653 /* LuaGrid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaGrid.cpp; sourceTree = "<group>"; };
+		4ABF305C16335A1100664653 /* LuaImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaImage.cpp; sourceTree = "<group>"; };
+		4ABF305D16335A1100664653 /* LuaLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaLabel.cpp; sourceTree = "<group>"; };
+		4ABF305E16335A1100664653 /* LuaList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaList.cpp; sourceTree = "<group>"; };
+		4ABF305F16335A1100664653 /* LuaMargin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMargin.cpp; sourceTree = "<group>"; };
+		4ABF306016335A1100664653 /* LuaMultiLineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMultiLineText.cpp; sourceTree = "<group>"; };
+		4ABF306116335A1100664653 /* LuaScroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaScroller.cpp; sourceTree = "<group>"; };
+		4ABF306216335A1100664653 /* LuaSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaSignal.h; sourceTree = "<group>"; };
+		4ABF306316335A1100664653 /* LuaSingle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSingle.cpp; sourceTree = "<group>"; };
+		4ABF306416335A1100664653 /* LuaSlider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSlider.cpp; sourceTree = "<group>"; };
+		4ABF306516335A1100664653 /* LuaWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaWidget.cpp; sourceTree = "<group>"; };
+		4ABF306716335A1100664653 /* Margin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Margin.cpp; sourceTree = "<group>"; };
+		4ABF306816335A1100664653 /* Margin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Margin.h; sourceTree = "<group>"; };
+		4ABF306916335A1100664653 /* MultiLineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MultiLineText.cpp; sourceTree = "<group>"; };
+		4ABF306A16335A1100664653 /* MultiLineText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiLineText.h; sourceTree = "<group>"; };
+		4ABF306B16335A1100664653 /* Point.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Point.h; sourceTree = "<group>"; };
+		4ABF306C16335A1100664653 /* Scroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Scroller.cpp; sourceTree = "<group>"; };
+		4ABF306D16335A1100664653 /* Scroller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scroller.h; sourceTree = "<group>"; };
+		4ABF306E16335A1100664653 /* Single.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Single.cpp; sourceTree = "<group>"; };
+		4ABF306F16335A1100664653 /* Single.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Single.h; sourceTree = "<group>"; };
+		4ABF307016335A1100664653 /* Skin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Skin.cpp; sourceTree = "<group>"; };
+		4ABF307116335A1100664653 /* Skin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Skin.h; sourceTree = "<group>"; };
+		4ABF307216335A1100664653 /* Slider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Slider.cpp; sourceTree = "<group>"; };
+		4ABF307316335A1100664653 /* Slider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Slider.h; sourceTree = "<group>"; };
+		4ABF307416335A1100664653 /* TextLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextLayout.cpp; sourceTree = "<group>"; };
+		4ABF307516335A1100664653 /* TextLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextLayout.h; sourceTree = "<group>"; };
+		4ABF307616335A1100664653 /* Widget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Widget.cpp; sourceTree = "<group>"; };
+		4ABF307716335A1100664653 /* Widget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Widget.h; sourceTree = "<group>"; };
+		4ABF307816335A1100664653 /* WidgetSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WidgetSet.h; sourceTree = "<group>"; };
+		4ACC6D1615401E7000C59914 /* TextSupport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextSupport.cpp; sourceTree = "<group>"; };
+		4ACC6D1715401E7000C59914 /* TextSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextSupport.h; sourceTree = "<group>"; };
+		4ACC6D1815401E7000C59914 /* TextureFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureFont.cpp; sourceTree = "<group>"; };
+		4ACC6D1915401E7000C59914 /* TextureFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureFont.h; sourceTree = "<group>"; };
+		4ACDB684167878610069FA03 /* Animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Animation.cpp; sourceTree = "<group>"; };
+		4ACDB685167878610069FA03 /* Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Animation.h; sourceTree = "<group>"; };
+		4ACDB686167878610069FA03 /* AnimationChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnimationChannel.h; sourceTree = "<group>"; };
+		4ACDB687167878610069FA03 /* AnimationKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnimationKey.h; sourceTree = "<group>"; };
+		4ACDB688167878620069FA03 /* Billboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Billboard.cpp; sourceTree = "<group>"; };
+		4ACDB689167878620069FA03 /* Billboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Billboard.h; sourceTree = "<group>"; };
+		4ACDB68A167878620069FA03 /* CollisionGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollisionGeometry.cpp; sourceTree = "<group>"; };
+		4ACDB68B167878620069FA03 /* CollisionGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollisionGeometry.h; sourceTree = "<group>"; };
+		4ACDB68C167878620069FA03 /* CollisionVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollisionVisitor.cpp; sourceTree = "<group>"; };
+		4ACDB68D167878620069FA03 /* CollisionVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollisionVisitor.h; sourceTree = "<group>"; };
+		4ACDB68E167878620069FA03 /* ColorMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColorMap.cpp; sourceTree = "<group>"; };
+		4ACDB68F167878620069FA03 /* ColorMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorMap.h; sourceTree = "<group>"; };
+		4ACDB690167878620069FA03 /* DumpVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DumpVisitor.cpp; sourceTree = "<group>"; };
+		4ACDB691167878620069FA03 /* DumpVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DumpVisitor.h; sourceTree = "<group>"; };
+		4ACDB692167878620069FA03 /* FindNodeVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindNodeVisitor.cpp; sourceTree = "<group>"; };
+		4ACDB693167878620069FA03 /* FindNodeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindNodeVisitor.h; sourceTree = "<group>"; };
+		4ACDB694167878620069FA03 /* Group.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Group.cpp; sourceTree = "<group>"; };
+		4ACDB695167878620069FA03 /* Group.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Group.h; sourceTree = "<group>"; };
+		4ACDB696167878620069FA03 /* Label3D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Label3D.cpp; sourceTree = "<group>"; };
+		4ACDB697167878620069FA03 /* Label3D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Label3D.h; sourceTree = "<group>"; };
+		4ACDB698167878620069FA03 /* Loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Loader.cpp; sourceTree = "<group>"; };
+		4ACDB699167878620069FA03 /* Loader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Loader.h; sourceTree = "<group>"; };
+		4ACDB69A167878620069FA03 /* LoaderDefinitions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoaderDefinitions.h; sourceTree = "<group>"; };
+		4ACDB69B167878620069FA03 /* LOD.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LOD.cpp; sourceTree = "<group>"; };
+		4ACDB69C167878620069FA03 /* LOD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LOD.h; sourceTree = "<group>"; };
+		4ACDB69E167878620069FA03 /* MatrixTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MatrixTransform.cpp; sourceTree = "<group>"; };
+		4ACDB69F167878620069FA03 /* MatrixTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatrixTransform.h; sourceTree = "<group>"; };
+		4ACDB6A0167878620069FA03 /* Model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Model.cpp; sourceTree = "<group>"; };
+		4ACDB6A1167878620069FA03 /* Model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Model.h; sourceTree = "<group>"; };
+		4ACDB6A2167878620069FA03 /* ModelNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelNode.cpp; sourceTree = "<group>"; };
+		4ACDB6A3167878620069FA03 /* ModelNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelNode.h; sourceTree = "<group>"; };
+		4ACDB6A4167878620069FA03 /* Node.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Node.cpp; sourceTree = "<group>"; };
+		4ACDB6A5167878620069FA03 /* Node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Node.h; sourceTree = "<group>"; };
+		4ACDB6A6167878620069FA03 /* NodeVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NodeVisitor.cpp; sourceTree = "<group>"; };
+		4ACDB6A7167878620069FA03 /* NodeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NodeVisitor.h; sourceTree = "<group>"; };
+		4ACDB6A8167878620069FA03 /* Parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Parser.cpp; sourceTree = "<group>"; };
+		4ACDB6A9167878620069FA03 /* Parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Parser.h; sourceTree = "<group>"; };
+		4ACDB6AA167878620069FA03 /* Pattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Pattern.cpp; sourceTree = "<group>"; };
+		4ACDB6AB167878620069FA03 /* Pattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Pattern.h; sourceTree = "<group>"; };
+		4ACDB6AC167878620069FA03 /* SceneGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneGraph.h; sourceTree = "<group>"; };
+		4ACDB6AD167878620069FA03 /* StaticGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticGeometry.cpp; sourceTree = "<group>"; };
+		4ACDB6AE167878620069FA03 /* StaticGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StaticGeometry.h; sourceTree = "<group>"; };
+		4ACDB6AF167878620069FA03 /* Thruster.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Thruster.cpp; sourceTree = "<group>"; };
+		4ACDB6B0167878620069FA03 /* Thruster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Thruster.h; sourceTree = "<group>"; };
+		4ACDB6C7167878CE0069FA03 /* CollMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollMesh.h; sourceTree = "<group>"; };
+		4ACDB6CA167878CE0069FA03 /* ModelCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelCache.cpp; sourceTree = "<group>"; };
+		4ACDB6CB167878CE0069FA03 /* ModelCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelCache.h; sourceTree = "<group>"; };
+		4ACDB6CC167878CE0069FA03 /* ModelViewer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelViewer.cpp; sourceTree = "<group>"; };
+		4ACDB6CD167878CE0069FA03 /* ModelViewer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelViewer.h; sourceTree = "<group>"; };
+		4ACDB6D0167879AF0069FA03 /* DistanceFieldFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DistanceFieldFont.cpp; sourceTree = "<group>"; };
+		4ACDB6D1167879AF0069FA03 /* DistanceFieldFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DistanceFieldFont.h; sourceTree = "<group>"; };
 		4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libassimp.3.0.0.dylib; path = /opt/local/lib/libassimp.3.0.0.dylib; sourceTree = "<absolute>"; };
-		4AEEBC49162A4A5700C6EA6F /* libXrandr.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXrandr.2.dylib; path = ../../../../../opt/local/lib/libXrandr.2.dylib; sourceTree = "<group>"; };
-		4AEEBC4B162A4ADC00C6EA6F /* libXext.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXext.6.dylib; path = ../../../../../opt/local/lib/libXext.6.dylib; sourceTree = "<group>"; };
-		4AEEBC4F162A4B9B00C6EA6F /* libXrender.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXrender.1.dylib; path = ../../../../../opt/local/lib/libXrender.1.dylib; sourceTree = "<group>"; };
-		4AEEBC52162A4BF700C6EA6F /* libX11.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libX11.6.dylib; path = ../../../../../opt/local/lib/libX11.6.dylib; sourceTree = "<group>"; };
-		4AEEBC53162A4BF700C6EA6F /* libXau.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXau.6.dylib; path = ../../../../../opt/local/lib/libXau.6.dylib; sourceTree = "<group>"; };
-		4AEEBC54162A4BF700C6EA6F /* libXdmcp.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXdmcp.6.dylib; path = ../../../../../opt/local/lib/libXdmcp.6.dylib; sourceTree = "<group>"; };
-		4AEEBC5B162A4C7800C6EA6F /* libxcb.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxcb.1.dylib; path = ../../../../../opt/local/lib/libxcb.1.dylib; sourceTree = "<group>"; };
-		4AEEBC5E162A4F5B00C6EA6F /* libbz2.1.0.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.1.0.6.dylib; path = ../../../../../opt/local/lib/libbz2.1.0.6.dylib; sourceTree = "<group>"; };
-		521ED7D41C00D14D0092B2E9 /* Aabb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Aabb.h; path = ../src/Aabb.h; sourceTree = "<group>"; };
-		521ED7D51C00D14D0092B2E9 /* AmbientSounds.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AmbientSounds.cpp; path = ../src/AmbientSounds.cpp; sourceTree = "<group>"; };
-		521ED7D61C00D14D0092B2E9 /* AmbientSounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AmbientSounds.h; path = ../src/AmbientSounds.h; sourceTree = "<group>"; };
-		521ED7D71C00D14D0092B2E9 /* AnimationCurves.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AnimationCurves.h; path = ../src/AnimationCurves.h; sourceTree = "<group>"; };
-		521ED7D81C00D14D0092B2E9 /* Background.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Background.cpp; path = ../src/Background.cpp; sourceTree = "<group>"; };
-		521ED7D91C00D14D0092B2E9 /* Background.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Background.h; path = ../src/Background.h; sourceTree = "<group>"; };
-		521ED7DA1C00D14D0092B2E9 /* BaseSphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BaseSphere.cpp; path = ../src/BaseSphere.cpp; sourceTree = "<group>"; };
-		521ED7DB1C00D14D0092B2E9 /* BaseSphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BaseSphere.h; path = ../src/BaseSphere.h; sourceTree = "<group>"; };
-		521ED7DC1C00D14D0092B2E9 /* Body.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Body.cpp; path = ../src/Body.cpp; sourceTree = "<group>"; };
-		521ED7DD1C00D14D0092B2E9 /* Body.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Body.h; path = ../src/Body.h; sourceTree = "<group>"; };
-		521ED7DE1C00D14D0092B2E9 /* buildopts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = buildopts.h; path = ../src/buildopts.h; sourceTree = "<group>"; };
-		521ED7DF1C00D14D0092B2E9 /* ByteRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByteRange.h; path = ../src/ByteRange.h; sourceTree = "<group>"; };
-		521ED7E01C00D14D0092B2E9 /* Camera.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Camera.cpp; path = ../src/Camera.cpp; sourceTree = "<group>"; };
-		521ED7E11C00D14D0092B2E9 /* Camera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Camera.h; path = ../src/Camera.h; sourceTree = "<group>"; };
-		521ED7E21C00D14D0092B2E9 /* CameraController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CameraController.cpp; path = ../src/CameraController.cpp; sourceTree = "<group>"; };
-		521ED7E31C00D14D0092B2E9 /* CameraController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CameraController.h; path = ../src/CameraController.h; sourceTree = "<group>"; };
-		521ED7E41C00D14D0092B2E9 /* CargoBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CargoBody.cpp; path = ../src/CargoBody.cpp; sourceTree = "<group>"; };
-		521ED7E51C00D14D0092B2E9 /* CargoBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CargoBody.h; path = ../src/CargoBody.h; sourceTree = "<group>"; };
-		521ED7E61C00D14D0092B2E9 /* CityOnPlanet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CityOnPlanet.cpp; path = ../src/CityOnPlanet.cpp; sourceTree = "<group>"; };
-		521ED7E71C00D14D0092B2E9 /* CityOnPlanet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CityOnPlanet.h; path = ../src/CityOnPlanet.h; sourceTree = "<group>"; };
-		521ED7E81C00D14D0092B2E9 /* CollMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollMesh.cpp; path = ../src/CollMesh.cpp; sourceTree = "<group>"; };
-		521ED7E91C00D14D0092B2E9 /* CollMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollMesh.h; path = ../src/CollMesh.h; sourceTree = "<group>"; };
-		521ED7EA1C00D14D0092B2E9 /* Color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Color.cpp; path = ../src/Color.cpp; sourceTree = "<group>"; };
-		521ED7EB1C00D14D0092B2E9 /* Color.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Color.h; path = ../src/Color.h; sourceTree = "<group>"; };
-		521ED7EC1C00D14D0092B2E9 /* CRC32.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRC32.cpp; path = ../src/CRC32.cpp; sourceTree = "<group>"; };
-		521ED7ED1C00D14D0092B2E9 /* CRC32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CRC32.h; path = ../src/CRC32.h; sourceTree = "<group>"; };
-		521ED7EE1C00D14D0092B2E9 /* Cutscene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Cutscene.h; path = ../src/Cutscene.h; sourceTree = "<group>"; };
-		521ED7EF1C00D14D0092B2E9 /* DateTime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DateTime.cpp; path = ../src/DateTime.cpp; sourceTree = "<group>"; };
-		521ED7F01C00D14D0092B2E9 /* DateTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DateTime.h; path = ../src/DateTime.h; sourceTree = "<group>"; };
-		521ED7F11C00D14D0092B2E9 /* DeathView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeathView.cpp; path = ../src/DeathView.cpp; sourceTree = "<group>"; };
-		521ED7F21C00D14D0092B2E9 /* DeathView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeathView.h; path = ../src/DeathView.h; sourceTree = "<group>"; };
-		521ED7F31C00D14D0092B2E9 /* DeleteEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeleteEmitter.h; path = ../src/DeleteEmitter.h; sourceTree = "<group>"; };
-		521ED7F41C00D14D0092B2E9 /* DynamicBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DynamicBody.cpp; path = ../src/DynamicBody.cpp; sourceTree = "<group>"; };
-		521ED7F51C00D14D0092B2E9 /* DynamicBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DynamicBody.h; path = ../src/DynamicBody.h; sourceTree = "<group>"; };
-		521ED7F61C00D14D0092B2E9 /* Easing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Easing.h; path = ../src/Easing.h; sourceTree = "<group>"; };
-		521ED7F71C00D14D0092B2E9 /* enum_table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = enum_table.cpp; path = ../src/enum_table.cpp; sourceTree = "<group>"; };
-		521ED7F81C00D14D0092B2E9 /* enum_table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = enum_table.h; path = ../src/enum_table.h; sourceTree = "<group>"; };
-		521ED7F91C00D14D0092B2E9 /* EnumStrings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EnumStrings.cpp; path = ../src/EnumStrings.cpp; sourceTree = "<group>"; };
-		521ED7FA1C00D14D0092B2E9 /* EnumStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EnumStrings.h; path = ../src/EnumStrings.h; sourceTree = "<group>"; };
-		521ED7FB1C00D14D0092B2E9 /* FaceParts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FaceParts.cpp; path = ../src/FaceParts.cpp; sourceTree = "<group>"; };
-		521ED7FC1C00D14D0092B2E9 /* FaceParts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FaceParts.h; path = ../src/FaceParts.h; sourceTree = "<group>"; };
-		521ED7FD1C00D14D0092B2E9 /* Factions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Factions.cpp; path = ../src/Factions.cpp; sourceTree = "<group>"; };
-		521ED7FE1C00D14D0092B2E9 /* Factions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Factions.h; path = ../src/Factions.h; sourceTree = "<group>"; };
-		521ED7FF1C00D14D0092B2E9 /* FileSourceZip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FileSourceZip.cpp; path = ../src/FileSourceZip.cpp; sourceTree = "<group>"; };
-		521ED8001C00D14D0092B2E9 /* FileSourceZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileSourceZip.h; path = ../src/FileSourceZip.h; sourceTree = "<group>"; };
-		521ED8011C00D14D0092B2E9 /* FileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FileSystem.cpp; path = ../src/FileSystem.cpp; sourceTree = "<group>"; };
-		521ED8021C00D14D0092B2E9 /* FileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileSystem.h; path = ../src/FileSystem.h; sourceTree = "<group>"; };
-		521ED8031C00D14D0092B2E9 /* fixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fixed.h; path = ../src/fixed.h; sourceTree = "<group>"; };
-		521ED8041C00D14D0092B2E9 /* FloatComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FloatComparison.h; path = ../src/FloatComparison.h; sourceTree = "<group>"; };
-		521ED8051C00D14D0092B2E9 /* FontCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FontCache.cpp; path = ../src/FontCache.cpp; sourceTree = "<group>"; };
-		521ED8061C00D14D0092B2E9 /* FontCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FontCache.h; path = ../src/FontCache.h; sourceTree = "<group>"; };
-		521ED8071C00D14D0092B2E9 /* Frame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Frame.cpp; path = ../src/Frame.cpp; sourceTree = "<group>"; };
-		521ED8081C00D14D0092B2E9 /* Frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Frame.h; path = ../src/Frame.h; sourceTree = "<group>"; };
-		521ED8091C00D14D0092B2E9 /* GalacticView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GalacticView.cpp; path = ../src/GalacticView.cpp; sourceTree = "<group>"; };
-		521ED80A1C00D14D0092B2E9 /* GalacticView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GalacticView.h; path = ../src/GalacticView.h; sourceTree = "<group>"; };
-		521ED80B1C00D14D0092B2E9 /* Game.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Game.cpp; path = ../src/Game.cpp; sourceTree = "<group>"; };
-		521ED80C1C00D14D0092B2E9 /* Game.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Game.h; path = ../src/Game.h; sourceTree = "<group>"; };
-		521ED80D1C00D14D0092B2E9 /* GameConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameConfig.cpp; path = ../src/GameConfig.cpp; sourceTree = "<group>"; };
-		521ED80E1C00D14D0092B2E9 /* GameConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameConfig.h; path = ../src/GameConfig.h; sourceTree = "<group>"; };
-		521ED80F1C00D14D0092B2E9 /* gameconsts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gameconsts.h; path = ../src/gameconsts.h; sourceTree = "<group>"; };
-		521ED8101C00D14D0092B2E9 /* GameLog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameLog.cpp; path = ../src/GameLog.cpp; sourceTree = "<group>"; };
-		521ED8111C00D14D0092B2E9 /* GameLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameLog.h; path = ../src/GameLog.h; sourceTree = "<group>"; };
-		521ED8121C00D14D0092B2E9 /* GasGiant.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GasGiant.cpp; path = ../src/GasGiant.cpp; sourceTree = "<group>"; };
-		521ED8131C00D14D0092B2E9 /* GasGiant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GasGiant.h; path = ../src/GasGiant.h; sourceTree = "<group>"; };
-		521ED8141C00D14D0092B2E9 /* GeoPatch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoPatch.cpp; path = ../src/GeoPatch.cpp; sourceTree = "<group>"; };
-		521ED8151C00D14D0092B2E9 /* GeoPatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoPatch.h; path = ../src/GeoPatch.h; sourceTree = "<group>"; };
-		521ED8161C00D14D0092B2E9 /* GeoPatchContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoPatchContext.cpp; path = ../src/GeoPatchContext.cpp; sourceTree = "<group>"; };
-		521ED8171C00D14D0092B2E9 /* GeoPatchContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoPatchContext.h; path = ../src/GeoPatchContext.h; sourceTree = "<group>"; };
-		521ED8181C00D14D0092B2E9 /* GeoPatchID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoPatchID.cpp; path = ../src/GeoPatchID.cpp; sourceTree = "<group>"; };
-		521ED8191C00D14D0092B2E9 /* GeoPatchID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoPatchID.h; path = ../src/GeoPatchID.h; sourceTree = "<group>"; };
-		521ED81A1C00D14D0092B2E9 /* GeoPatchJobs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoPatchJobs.cpp; path = ../src/GeoPatchJobs.cpp; sourceTree = "<group>"; };
-		521ED81B1C00D14D0092B2E9 /* GeoPatchJobs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoPatchJobs.h; path = ../src/GeoPatchJobs.h; sourceTree = "<group>"; };
-		521ED81C1C00D14D0092B2E9 /* GeoSphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoSphere.cpp; path = ../src/GeoSphere.cpp; sourceTree = "<group>"; };
-		521ED81D1C00D14D0092B2E9 /* GeoSphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoSphere.h; path = ../src/GeoSphere.h; sourceTree = "<group>"; };
-		521ED81E1C00D14D0092B2E9 /* HudTrail.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HudTrail.cpp; path = ../src/HudTrail.cpp; sourceTree = "<group>"; };
-		521ED81F1C00D14D0092B2E9 /* HudTrail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HudTrail.h; path = ../src/HudTrail.h; sourceTree = "<group>"; };
-		521ED8201C00D14D0092B2E9 /* HyperspaceCloud.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HyperspaceCloud.cpp; path = ../src/HyperspaceCloud.cpp; sourceTree = "<group>"; };
-		521ED8211C00D14D0092B2E9 /* HyperspaceCloud.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HyperspaceCloud.h; path = ../src/HyperspaceCloud.h; sourceTree = "<group>"; };
-		521ED8221C00D14D0092B2E9 /* IniConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IniConfig.cpp; path = ../src/IniConfig.cpp; sourceTree = "<group>"; };
-		521ED8231C00D14D0092B2E9 /* IniConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IniConfig.h; path = ../src/IniConfig.h; sourceTree = "<group>"; };
-		521ED8241C00D14D0092B2E9 /* Intro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Intro.cpp; path = ../src/Intro.cpp; sourceTree = "<group>"; };
-		521ED8251C00D14D0092B2E9 /* Intro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Intro.h; path = ../src/Intro.h; sourceTree = "<group>"; };
-		521ED8261C00D14D0092B2E9 /* IterationProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IterationProxy.h; path = ../src/IterationProxy.h; sourceTree = "<group>"; };
-		521ED8271C00D14D0092B2E9 /* JobQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = JobQueue.cpp; path = ../src/JobQueue.cpp; sourceTree = "<group>"; };
-		521ED8281C00D14D0092B2E9 /* JobQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JobQueue.h; path = ../src/JobQueue.h; sourceTree = "<group>"; };
-		521ED8291C00D14D0092B2E9 /* KeyBindings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = KeyBindings.cpp; path = ../src/KeyBindings.cpp; sourceTree = "<group>"; };
-		521ED82A1C00D14D0092B2E9 /* KeyBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KeyBindings.h; path = ../src/KeyBindings.h; sourceTree = "<group>"; };
-		521ED82B1C00D14D0092B2E9 /* KeyBindings.inc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KeyBindings.inc.h; path = ../src/KeyBindings.inc.h; sourceTree = "<group>"; };
-		521ED82C1C00D14D0092B2E9 /* Lang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lang.cpp; path = ../src/Lang.cpp; sourceTree = "<group>"; };
-		521ED82D1C00D14D0092B2E9 /* Lang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lang.h; path = ../src/Lang.h; sourceTree = "<group>"; };
-		521ED82E1C00D14D0092B2E9 /* LangStrings.inc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LangStrings.inc.h; path = ../src/LangStrings.inc.h; sourceTree = "<group>"; };
-		521ED82F1C00D14D0092B2E9 /* libs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = libs.h; path = ../src/libs.h; sourceTree = "<group>"; };
-		521ED8301C00D14D0092B2E9 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lua.cpp; path = ../src/Lua.cpp; sourceTree = "<group>"; };
-		521ED8311C00D14D0092B2E9 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lua.h; path = ../src/Lua.h; sourceTree = "<group>"; };
-		521ED8321C00D14D0092B2E9 /* LuaBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaBody.cpp; path = ../src/LuaBody.cpp; sourceTree = "<group>"; };
-		521ED8331C00D14D0092B2E9 /* LuaCargoBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaCargoBody.cpp; path = ../src/LuaCargoBody.cpp; sourceTree = "<group>"; };
-		521ED8341C00D14D0092B2E9 /* LuaComms.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaComms.cpp; path = ../src/LuaComms.cpp; sourceTree = "<group>"; };
-		521ED8351C00D14D0092B2E9 /* LuaComms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaComms.h; path = ../src/LuaComms.h; sourceTree = "<group>"; };
-		521ED8361C00D14D0092B2E9 /* LuaConsole.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaConsole.cpp; path = ../src/LuaConsole.cpp; sourceTree = "<group>"; };
-		521ED8371C00D14D0092B2E9 /* LuaConsole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaConsole.h; path = ../src/LuaConsole.h; sourceTree = "<group>"; };
-		521ED8381C00D14D0092B2E9 /* LuaConstants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaConstants.cpp; path = ../src/LuaConstants.cpp; sourceTree = "<group>"; };
-		521ED8391C00D14D0092B2E9 /* LuaConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaConstants.h; path = ../src/LuaConstants.h; sourceTree = "<group>"; };
-		521ED83A1C00D14D0092B2E9 /* LuaDev.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaDev.cpp; path = ../src/LuaDev.cpp; sourceTree = "<group>"; };
-		521ED83B1C00D14D0092B2E9 /* LuaDev.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaDev.h; path = ../src/LuaDev.h; sourceTree = "<group>"; };
-		521ED83C1C00D14D0092B2E9 /* LuaEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaEngine.cpp; path = ../src/LuaEngine.cpp; sourceTree = "<group>"; };
-		521ED83D1C00D14D0092B2E9 /* LuaEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaEngine.h; path = ../src/LuaEngine.h; sourceTree = "<group>"; };
-		521ED83E1C00D14D0092B2E9 /* LuaEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaEvent.cpp; path = ../src/LuaEvent.cpp; sourceTree = "<group>"; };
-		521ED83F1C00D14D0092B2E9 /* LuaEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaEvent.h; path = ../src/LuaEvent.h; sourceTree = "<group>"; };
-		521ED8401C00D14D0092B2E9 /* LuaFaction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFaction.cpp; path = ../src/LuaFaction.cpp; sourceTree = "<group>"; };
-		521ED8411C00D14D0092B2E9 /* LuaFileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFileSystem.cpp; path = ../src/LuaFileSystem.cpp; sourceTree = "<group>"; };
-		521ED8421C00D14D0092B2E9 /* LuaFileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaFileSystem.h; path = ../src/LuaFileSystem.h; sourceTree = "<group>"; };
-		521ED8431C00D14D0092B2E9 /* LuaFixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFixed.cpp; path = ../src/LuaFixed.cpp; sourceTree = "<group>"; };
-		521ED8441C00D14D0092B2E9 /* LuaFixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaFixed.h; path = ../src/LuaFixed.h; sourceTree = "<group>"; };
-		521ED8451C00D14D0092B2E9 /* LuaFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFormat.cpp; path = ../src/LuaFormat.cpp; sourceTree = "<group>"; };
-		521ED8461C00D14D0092B2E9 /* LuaFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaFormat.h; path = ../src/LuaFormat.h; sourceTree = "<group>"; };
-		521ED8471C00D14D0092B2E9 /* LuaGame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaGame.cpp; path = ../src/LuaGame.cpp; sourceTree = "<group>"; };
-		521ED8481C00D14D0092B2E9 /* LuaGame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaGame.h; path = ../src/LuaGame.h; sourceTree = "<group>"; };
-		521ED8491C00D14D0092B2E9 /* LuaLang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaLang.cpp; path = ../src/LuaLang.cpp; sourceTree = "<group>"; };
-		521ED84A1C00D14D0092B2E9 /* LuaLang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaLang.h; path = ../src/LuaLang.h; sourceTree = "<group>"; };
-		521ED84B1C00D14D0092B2E9 /* LuaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaManager.cpp; path = ../src/LuaManager.cpp; sourceTree = "<group>"; };
-		521ED84C1C00D14D0092B2E9 /* LuaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaManager.h; path = ../src/LuaManager.h; sourceTree = "<group>"; };
-		521ED84D1C00D14D0092B2E9 /* LuaMatrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMatrix.cpp; path = ../src/LuaMatrix.cpp; sourceTree = "<group>"; };
-		521ED84E1C00D14D0092B2E9 /* LuaMatrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaMatrix.h; path = ../src/LuaMatrix.h; sourceTree = "<group>"; };
-		521ED84F1C00D14D0092B2E9 /* LuaMissile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMissile.cpp; path = ../src/LuaMissile.cpp; sourceTree = "<group>"; };
-		521ED8501C00D14D0092B2E9 /* LuaMissile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaMissile.h; path = ../src/LuaMissile.h; sourceTree = "<group>"; };
-		521ED8511C00D14D0092B2E9 /* LuaModelBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaModelBody.cpp; path = ../src/LuaModelBody.cpp; sourceTree = "<group>"; };
-		521ED8521C00D14E0092B2E9 /* LuaMusic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMusic.cpp; path = ../src/LuaMusic.cpp; sourceTree = "<group>"; };
-		521ED8531C00D14E0092B2E9 /* LuaMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaMusic.h; path = ../src/LuaMusic.h; sourceTree = "<group>"; };
-		521ED8541C00D14E0092B2E9 /* LuaNameGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaNameGen.cpp; path = ../src/LuaNameGen.cpp; sourceTree = "<group>"; };
-		521ED8551C00D14E0092B2E9 /* LuaNameGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaNameGen.h; path = ../src/LuaNameGen.h; sourceTree = "<group>"; };
-		521ED8561C00D14E0092B2E9 /* LuaObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaObject.cpp; path = ../src/LuaObject.cpp; sourceTree = "<group>"; };
-		521ED8571C00D14E0092B2E9 /* LuaObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaObject.h; path = ../src/LuaObject.h; sourceTree = "<group>"; };
-		521ED8581C00D14E0092B2E9 /* LuaPlanet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaPlanet.cpp; path = ../src/LuaPlanet.cpp; sourceTree = "<group>"; };
-		521ED8591C00D14E0092B2E9 /* LuaPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaPlayer.cpp; path = ../src/LuaPlayer.cpp; sourceTree = "<group>"; };
-		521ED85A1C00D14E0092B2E9 /* LuaPropertiedObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaPropertiedObject.cpp; path = ../src/LuaPropertiedObject.cpp; sourceTree = "<group>"; };
-		521ED85B1C00D14E0092B2E9 /* LuaPushPull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaPushPull.h; path = ../src/LuaPushPull.h; sourceTree = "<group>"; };
-		521ED85C1C00D14E0092B2E9 /* LuaRand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaRand.cpp; path = ../src/LuaRand.cpp; sourceTree = "<group>"; };
-		521ED85D1C00D14E0092B2E9 /* LuaRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaRef.cpp; path = ../src/LuaRef.cpp; sourceTree = "<group>"; };
-		521ED85E1C00D14E0092B2E9 /* LuaRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaRef.h; path = ../src/LuaRef.h; sourceTree = "<group>"; };
-		521ED85F1C00D14E0092B2E9 /* LuaSerializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSerializer.cpp; path = ../src/LuaSerializer.cpp; sourceTree = "<group>"; };
-		521ED8601C00D14E0092B2E9 /* LuaSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaSerializer.h; path = ../src/LuaSerializer.h; sourceTree = "<group>"; };
-		521ED8611C00D14E0092B2E9 /* LuaServerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaServerAgent.cpp; path = ../src/LuaServerAgent.cpp; sourceTree = "<group>"; };
-		521ED8621C00D14E0092B2E9 /* LuaServerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaServerAgent.h; path = ../src/LuaServerAgent.h; sourceTree = "<group>"; };
-		521ED8631C00D14E0092B2E9 /* LuaShip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaShip.cpp; path = ../src/LuaShip.cpp; sourceTree = "<group>"; };
-		521ED8641C00D14E0092B2E9 /* LuaShipDef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaShipDef.cpp; path = ../src/LuaShipDef.cpp; sourceTree = "<group>"; };
-		521ED8651C00D14E0092B2E9 /* LuaShipDef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaShipDef.h; path = ../src/LuaShipDef.h; sourceTree = "<group>"; };
-		521ED8661C00D14E0092B2E9 /* LuaSpace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSpace.cpp; path = ../src/LuaSpace.cpp; sourceTree = "<group>"; };
-		521ED8671C00D14E0092B2E9 /* LuaSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaSpace.h; path = ../src/LuaSpace.h; sourceTree = "<group>"; };
-		521ED8681C00D14E0092B2E9 /* LuaSpaceStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSpaceStation.cpp; path = ../src/LuaSpaceStation.cpp; sourceTree = "<group>"; };
-		521ED8691C00D14E0092B2E9 /* LuaStar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaStar.cpp; path = ../src/LuaStar.cpp; sourceTree = "<group>"; };
-		521ED86A1C00D14E0092B2E9 /* LuaStarSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaStarSystem.cpp; path = ../src/LuaStarSystem.cpp; sourceTree = "<group>"; };
-		521ED86B1C00D14E0092B2E9 /* LuaSystemBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSystemBody.cpp; path = ../src/LuaSystemBody.cpp; sourceTree = "<group>"; };
-		521ED86C1C00D14E0092B2E9 /* LuaSystemPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSystemPath.cpp; path = ../src/LuaSystemPath.cpp; sourceTree = "<group>"; };
-		521ED86D1C00D14E0092B2E9 /* LuaTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaTable.h; path = ../src/LuaTable.h; sourceTree = "<group>"; };
-		521ED86E1C00D14E0092B2E9 /* LuaTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaTimer.cpp; path = ../src/LuaTimer.cpp; sourceTree = "<group>"; };
-		521ED86F1C00D14E0092B2E9 /* LuaTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaTimer.h; path = ../src/LuaTimer.h; sourceTree = "<group>"; };
-		521ED8701C00D14E0092B2E9 /* LuaUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaUtils.cpp; path = ../src/LuaUtils.cpp; sourceTree = "<group>"; };
-		521ED8711C00D14E0092B2E9 /* LuaUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaUtils.h; path = ../src/LuaUtils.h; sourceTree = "<group>"; };
-		521ED8721C00D14E0092B2E9 /* LuaVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaVector.cpp; path = ../src/LuaVector.cpp; sourceTree = "<group>"; };
-		521ED8731C00D14E0092B2E9 /* LuaVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaVector.h; path = ../src/LuaVector.h; sourceTree = "<group>"; };
-		521ED8741C00D14E0092B2E9 /* LuaWrappable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaWrappable.h; path = ../src/LuaWrappable.h; sourceTree = "<group>"; };
-		521ED8751C00D14E0092B2E9 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = ../src/main.cpp; sourceTree = "<group>"; };
-		521ED8761C00D14E0092B2E9 /* MathUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MathUtil.cpp; path = ../src/MathUtil.cpp; sourceTree = "<group>"; };
-		521ED8771C00D14E0092B2E9 /* MathUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MathUtil.h; path = ../src/MathUtil.h; sourceTree = "<group>"; };
-		521ED8781C00D14E0092B2E9 /* matrix3x3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = matrix3x3.h; path = ../src/matrix3x3.h; sourceTree = "<group>"; };
-		521ED8791C00D14E0092B2E9 /* matrix4x4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = matrix4x4.h; path = ../src/matrix4x4.h; sourceTree = "<group>"; };
-		521ED87A1C00D14E0092B2E9 /* Missile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Missile.cpp; path = ../src/Missile.cpp; sourceTree = "<group>"; };
-		521ED87B1C00D14E0092B2E9 /* Missile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Missile.h; path = ../src/Missile.h; sourceTree = "<group>"; };
-		521ED87C1C00D14E0092B2E9 /* ModelBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelBody.cpp; path = ../src/ModelBody.cpp; sourceTree = "<group>"; };
-		521ED87D1C00D14E0092B2E9 /* ModelBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelBody.h; path = ../src/ModelBody.h; sourceTree = "<group>"; };
-		521ED87E1C00D14E0092B2E9 /* ModelCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelCache.cpp; path = ../src/ModelCache.cpp; sourceTree = "<group>"; };
-		521ED87F1C00D14E0092B2E9 /* ModelCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelCache.h; path = ../src/ModelCache.h; sourceTree = "<group>"; };
-		521ED8811C00D14E0092B2E9 /* ModelViewer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelViewer.cpp; path = ../src/ModelViewer.cpp; sourceTree = "<group>"; };
-		521ED8821C00D14E0092B2E9 /* ModelViewer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelViewer.h; path = ../src/ModelViewer.h; sourceTree = "<group>"; };
-		521ED8831C00D14E0092B2E9 /* ModManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModManager.cpp; path = ../src/ModManager.cpp; sourceTree = "<group>"; };
-		521ED8841C00D14E0092B2E9 /* ModManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModManager.h; path = ../src/ModManager.h; sourceTree = "<group>"; };
-		521ED8851C00D14E0092B2E9 /* NavLights.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NavLights.cpp; path = ../src/NavLights.cpp; sourceTree = "<group>"; };
-		521ED8861C00D14E0092B2E9 /* NavLights.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NavLights.h; path = ../src/NavLights.h; sourceTree = "<group>"; };
-		521ED8871C00D14E0092B2E9 /* Object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Object.h; path = ../src/Object.h; sourceTree = "<group>"; };
-		521ED8881C00D14E0092B2E9 /* ObjectViewerView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ObjectViewerView.cpp; path = ../src/ObjectViewerView.cpp; sourceTree = "<group>"; };
-		521ED8891C00D14E0092B2E9 /* ObjectViewerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ObjectViewerView.h; path = ../src/ObjectViewerView.h; sourceTree = "<group>"; };
-		521ED88A1C00D14E0092B2E9 /* Orbit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Orbit.cpp; path = ../src/Orbit.cpp; sourceTree = "<group>"; };
-		521ED88B1C00D14E0092B2E9 /* Orbit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Orbit.h; path = ../src/Orbit.h; sourceTree = "<group>"; };
-		521ED88C1C00D14E0092B2E9 /* OS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OS.h; path = ../src/OS.h; sourceTree = "<group>"; };
-		521ED88D1C00D14E0092B2E9 /* perlin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = perlin.cpp; path = ../src/perlin.cpp; sourceTree = "<group>"; };
-		521ED88E1C00D14E0092B2E9 /* perlin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = perlin.h; path = ../src/perlin.h; sourceTree = "<group>"; };
-		521ED88F1C00D14E0092B2E9 /* PersistSystemData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PersistSystemData.h; path = ../src/PersistSystemData.h; sourceTree = "<group>"; };
-		521ED8901C00D14E0092B2E9 /* Pi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Pi.cpp; path = ../src/Pi.cpp; sourceTree = "<group>"; };
-		521ED8911C00D14E0092B2E9 /* Pi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Pi.h; path = ../src/Pi.h; sourceTree = "<group>"; };
-		521ED8921C00D14E0092B2E9 /* Plane.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Plane.cpp; path = ../src/Plane.cpp; sourceTree = "<group>"; };
-		521ED8931C00D14E0092B2E9 /* Plane.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Plane.h; path = ../src/Plane.h; sourceTree = "<group>"; };
-		521ED8941C00D14E0092B2E9 /* Planet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Planet.cpp; path = ../src/Planet.cpp; sourceTree = "<group>"; };
-		521ED8951C00D14E0092B2E9 /* Planet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Planet.h; path = ../src/Planet.h; sourceTree = "<group>"; };
-		521ED8961C00D14E0092B2E9 /* Player.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Player.cpp; path = ../src/Player.cpp; sourceTree = "<group>"; };
-		521ED8971C00D14E0092B2E9 /* Player.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Player.h; path = ../src/Player.h; sourceTree = "<group>"; };
-		521ED8981C00D14E0092B2E9 /* PngWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PngWriter.cpp; path = ../src/PngWriter.cpp; sourceTree = "<group>"; };
-		521ED8991C00D14E0092B2E9 /* PngWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PngWriter.h; path = ../src/PngWriter.h; sourceTree = "<group>"; };
-		521ED89A1C00D14E0092B2E9 /* Polit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Polit.cpp; path = ../src/Polit.cpp; sourceTree = "<group>"; };
-		521ED89B1C00D14E0092B2E9 /* Polit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Polit.h; path = ../src/Polit.h; sourceTree = "<group>"; };
-		521ED89C1C00D14E0092B2E9 /* Projectile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Projectile.cpp; path = ../src/Projectile.cpp; sourceTree = "<group>"; };
-		521ED89D1C00D14E0092B2E9 /* Projectile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Projectile.h; path = ../src/Projectile.h; sourceTree = "<group>"; };
-		521ED89E1C00D14E0092B2E9 /* PropertiedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PropertiedObject.h; path = ../src/PropertiedObject.h; sourceTree = "<group>"; };
-		521ED89F1C00D14E0092B2E9 /* PropertyMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PropertyMap.cpp; path = ../src/PropertyMap.cpp; sourceTree = "<group>"; };
-		521ED8A01C00D14E0092B2E9 /* PropertyMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PropertyMap.h; path = ../src/PropertyMap.h; sourceTree = "<group>"; };
-		521ED8A11C00D14E0092B2E9 /* Quaternion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Quaternion.h; path = ../src/Quaternion.h; sourceTree = "<group>"; };
-		521ED8A21C00D14E0092B2E9 /* Random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Random.h; path = ../src/Random.h; sourceTree = "<group>"; };
-		521ED8A31C00D14E0092B2E9 /* RefCounted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RefCounted.h; path = ../src/RefCounted.h; sourceTree = "<group>"; };
-		521ED8A41C00D14E0092B2E9 /* SDLWrappers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SDLWrappers.cpp; path = ../src/SDLWrappers.cpp; sourceTree = "<group>"; };
-		521ED8A51C00D14E0092B2E9 /* SDLWrappers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDLWrappers.h; path = ../src/SDLWrappers.h; sourceTree = "<group>"; };
-		521ED8A61C00D14E0092B2E9 /* SectorView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SectorView.cpp; path = ../src/SectorView.cpp; sourceTree = "<group>"; };
-		521ED8A71C00D14E0092B2E9 /* SectorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SectorView.h; path = ../src/SectorView.h; sourceTree = "<group>"; };
-		521ED8A81C00D14E0092B2E9 /* Sensors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sensors.cpp; path = ../src/Sensors.cpp; sourceTree = "<group>"; };
-		521ED8A91C00D14E0092B2E9 /* Sensors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sensors.h; path = ../src/Sensors.h; sourceTree = "<group>"; };
-		521ED8AA1C00D14E0092B2E9 /* Serializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Serializer.cpp; path = ../src/Serializer.cpp; sourceTree = "<group>"; };
-		521ED8AB1C00D14E0092B2E9 /* Serializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Serializer.h; path = ../src/Serializer.h; sourceTree = "<group>"; };
-		521ED8AC1C00D14E0092B2E9 /* ServerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ServerAgent.cpp; path = ../src/ServerAgent.cpp; sourceTree = "<group>"; };
-		521ED8AD1C00D14E0092B2E9 /* ServerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerAgent.h; path = ../src/ServerAgent.h; sourceTree = "<group>"; };
-		521ED8AE1C00D14E0092B2E9 /* Sfx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sfx.cpp; path = ../src/Sfx.cpp; sourceTree = "<group>"; };
-		521ED8AF1C00D14E0092B2E9 /* Sfx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sfx.h; path = ../src/Sfx.h; sourceTree = "<group>"; };
-		521ED8B01C00D14E0092B2E9 /* Shields.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Shields.cpp; path = ../src/Shields.cpp; sourceTree = "<group>"; };
-		521ED8B11C00D14E0092B2E9 /* Shields.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Shields.h; path = ../src/Shields.h; sourceTree = "<group>"; };
-		521ED8B21C00D14E0092B2E9 /* Ship-AI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "Ship-AI.cpp"; path = "../src/Ship-AI.cpp"; sourceTree = "<group>"; };
-		521ED8B31C00D14E0092B2E9 /* Ship.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Ship.cpp; path = ../src/Ship.cpp; sourceTree = "<group>"; };
-		521ED8B41C00D14E0092B2E9 /* Ship.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Ship.h; path = ../src/Ship.h; sourceTree = "<group>"; };
-		521ED8B51C00D14E0092B2E9 /* ShipAICmd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipAICmd.cpp; path = ../src/ShipAICmd.cpp; sourceTree = "<group>"; };
-		521ED8B61C00D14E0092B2E9 /* ShipAICmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipAICmd.h; path = ../src/ShipAICmd.h; sourceTree = "<group>"; };
-		521ED8B71C00D14E0092B2E9 /* ShipCockpit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipCockpit.cpp; path = ../src/ShipCockpit.cpp; sourceTree = "<group>"; };
-		521ED8B81C00D14E0092B2E9 /* ShipCockpit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipCockpit.h; path = ../src/ShipCockpit.h; sourceTree = "<group>"; };
-		521ED8B91C00D14E0092B2E9 /* ShipController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipController.cpp; path = ../src/ShipController.cpp; sourceTree = "<group>"; };
-		521ED8BA1C00D14E0092B2E9 /* ShipController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipController.h; path = ../src/ShipController.h; sourceTree = "<group>"; };
-		521ED8BB1C00D14E0092B2E9 /* ShipCpanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipCpanel.cpp; path = ../src/ShipCpanel.cpp; sourceTree = "<group>"; };
-		521ED8BC1C00D14E0092B2E9 /* ShipCpanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipCpanel.h; path = ../src/ShipCpanel.h; sourceTree = "<group>"; };
-		521ED8BD1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipCpanelMultiFuncDisplays.cpp; path = ../src/ShipCpanelMultiFuncDisplays.cpp; sourceTree = "<group>"; };
-		521ED8BE1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipCpanelMultiFuncDisplays.h; path = ../src/ShipCpanelMultiFuncDisplays.h; sourceTree = "<group>"; };
-		521ED8BF1C00D14E0092B2E9 /* ShipType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipType.cpp; path = ../src/ShipType.cpp; sourceTree = "<group>"; };
-		521ED8C01C00D14E0092B2E9 /* ShipType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipType.h; path = ../src/ShipType.h; sourceTree = "<group>"; };
-		521ED8C11C00D14E0092B2E9 /* SmartPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SmartPtr.h; path = ../src/SmartPtr.h; sourceTree = "<group>"; };
-		521ED8C21C00D14E0092B2E9 /* Sound.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sound.cpp; path = ../src/Sound.cpp; sourceTree = "<group>"; };
-		521ED8C31C00D14E0092B2E9 /* Sound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sound.h; path = ../src/Sound.h; sourceTree = "<group>"; };
-		521ED8C41C00D14E0092B2E9 /* SoundMusic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SoundMusic.cpp; path = ../src/SoundMusic.cpp; sourceTree = "<group>"; };
-		521ED8C51C00D14E0092B2E9 /* SoundMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SoundMusic.h; path = ../src/SoundMusic.h; sourceTree = "<group>"; };
-		521ED8C61C00D14E0092B2E9 /* Space.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Space.cpp; path = ../src/Space.cpp; sourceTree = "<group>"; };
-		521ED8C71C00D14E0092B2E9 /* Space.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Space.h; path = ../src/Space.h; sourceTree = "<group>"; };
-		521ED8C81C00D14E0092B2E9 /* SpaceStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SpaceStation.cpp; path = ../src/SpaceStation.cpp; sourceTree = "<group>"; };
-		521ED8C91C00D14E0092B2E9 /* SpaceStation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpaceStation.h; path = ../src/SpaceStation.h; sourceTree = "<group>"; };
-		521ED8CA1C00D14E0092B2E9 /* SpaceStationType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SpaceStationType.cpp; path = ../src/SpaceStationType.cpp; sourceTree = "<group>"; };
-		521ED8CB1C00D14E0092B2E9 /* SpaceStationType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpaceStationType.h; path = ../src/SpaceStationType.h; sourceTree = "<group>"; };
-		521ED8CC1C00D14E0092B2E9 /* SpeedLines.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SpeedLines.cpp; path = ../src/SpeedLines.cpp; sourceTree = "<group>"; };
-		521ED8CD1C00D14E0092B2E9 /* SpeedLines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpeedLines.h; path = ../src/SpeedLines.h; sourceTree = "<group>"; };
-		521ED8CE1C00D14E0092B2E9 /* Sphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sphere.cpp; path = ../src/Sphere.cpp; sourceTree = "<group>"; };
-		521ED8CF1C00D14E0092B2E9 /* Sphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sphere.h; path = ../src/Sphere.h; sourceTree = "<group>"; };
-		521ED8D01C00D14E0092B2E9 /* Star.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Star.cpp; path = ../src/Star.cpp; sourceTree = "<group>"; };
-		521ED8D11C00D14E0092B2E9 /* Star.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Star.h; path = ../src/Star.h; sourceTree = "<group>"; };
-		521ED8D21C00D14E0092B2E9 /* StringF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StringF.cpp; path = ../src/StringF.cpp; sourceTree = "<group>"; };
-		521ED8D31C00D14E0092B2E9 /* StringF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StringF.h; path = ../src/StringF.h; sourceTree = "<group>"; };
-		521ED8D41C00D14E0092B2E9 /* StringRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StringRange.h; path = ../src/StringRange.h; sourceTree = "<group>"; };
-		521ED8D51C00D14E0092B2E9 /* SystemInfoView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SystemInfoView.cpp; path = ../src/SystemInfoView.cpp; sourceTree = "<group>"; };
-		521ED8D61C00D14E0092B2E9 /* SystemInfoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SystemInfoView.h; path = ../src/SystemInfoView.h; sourceTree = "<group>"; };
-		521ED8D71C00D14E0092B2E9 /* SystemView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SystemView.cpp; path = ../src/SystemView.cpp; sourceTree = "<group>"; };
-		521ED8D81C00D14E0092B2E9 /* SystemView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SystemView.h; path = ../src/SystemView.h; sourceTree = "<group>"; };
-		521ED8D91C00D14E0092B2E9 /* TerrainBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainBody.cpp; path = ../src/TerrainBody.cpp; sourceTree = "<group>"; };
-		521ED8DA1C00D14E0092B2E9 /* TerrainBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TerrainBody.h; path = ../src/TerrainBody.h; sourceTree = "<group>"; };
-		521ED8E21C00D14E0092B2E9 /* Tombstone.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Tombstone.cpp; path = ../src/Tombstone.cpp; sourceTree = "<group>"; };
-		521ED8E31C00D14E0092B2E9 /* Tombstone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Tombstone.h; path = ../src/Tombstone.h; sourceTree = "<group>"; };
-		521ED8E51C00D14E0092B2E9 /* UIView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UIView.cpp; path = ../src/UIView.cpp; sourceTree = "<group>"; };
-		521ED8E61C00D14E0092B2E9 /* UIView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UIView.h; path = ../src/UIView.h; sourceTree = "<group>"; };
-		521ED8E71C00D14E0092B2E9 /* utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = utils.cpp; path = ../src/utils.cpp; sourceTree = "<group>"; };
-		521ED8E81C00D14E0092B2E9 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = utils.h; path = ../src/utils.h; sourceTree = "<group>"; };
-		521ED8E91C00D14E0092B2E9 /* vector2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vector2.h; path = ../src/vector2.h; sourceTree = "<group>"; };
-		521ED8EA1C00D14E0092B2E9 /* vector3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vector3.h; path = ../src/vector3.h; sourceTree = "<group>"; };
-		521ED8EB1C00D14E0092B2E9 /* VideoLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VideoLink.h; path = ../src/VideoLink.h; sourceTree = "<group>"; };
-		521ED8EC1C00D14E0092B2E9 /* View.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = View.cpp; path = ../src/View.cpp; sourceTree = "<group>"; };
-		521ED8ED1C00D14E0092B2E9 /* View.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = View.h; path = ../src/View.h; sourceTree = "<group>"; };
-		521ED8EE1C00D14E0092B2E9 /* WorldView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WorldView.cpp; path = ../src/WorldView.cpp; sourceTree = "<group>"; };
-		521ED8EF1C00D14E0092B2E9 /* WorldView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WorldView.h; path = ../src/WorldView.h; sourceTree = "<group>"; };
-		521ED9861C00D2ED0092B2E9 /* BVHTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BVHTree.cpp; path = ../src/collider/BVHTree.cpp; sourceTree = "<group>"; };
-		521ED9871C00D2ED0092B2E9 /* BVHTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BVHTree.h; path = ../src/collider/BVHTree.h; sourceTree = "<group>"; };
-		521ED9881C00D2ED0092B2E9 /* collider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = collider.h; path = ../src/collider/collider.h; sourceTree = "<group>"; };
-		521ED9891C00D2ED0092B2E9 /* CollisionContact.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionContact.h; path = ../src/collider/CollisionContact.h; sourceTree = "<group>"; };
-		521ED98A1C00D2ED0092B2E9 /* CollisionSpace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollisionSpace.cpp; path = ../src/collider/CollisionSpace.cpp; sourceTree = "<group>"; };
-		521ED98B1C00D2ED0092B2E9 /* CollisionSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionSpace.h; path = ../src/collider/CollisionSpace.h; sourceTree = "<group>"; };
-		521ED98C1C00D2ED0092B2E9 /* Geom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Geom.cpp; path = ../src/collider/Geom.cpp; sourceTree = "<group>"; };
-		521ED98D1C00D2ED0092B2E9 /* Geom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Geom.h; path = ../src/collider/Geom.h; sourceTree = "<group>"; };
-		521ED98E1C00D2ED0092B2E9 /* GeomTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeomTree.cpp; path = ../src/collider/GeomTree.cpp; sourceTree = "<group>"; };
-		521ED98F1C00D2ED0092B2E9 /* GeomTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeomTree.h; path = ../src/collider/GeomTree.h; sourceTree = "<group>"; };
-		521ED9901C00D2ED0092B2E9 /* Weld.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Weld.h; path = ../src/collider/Weld.h; sourceTree = "<group>"; };
-		521ED9911C00D2ED0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/collider/Makefile.am; sourceTree = "<group>"; };
-		521ED9971C00D2FC0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/Makefile.am; sourceTree = "<group>"; };
-		521ED9991C00D3240092B2E9 /* CustomSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CustomSystem.cpp; path = ../src/galaxy/CustomSystem.cpp; sourceTree = "<group>"; };
-		521ED99A1C00D3240092B2E9 /* CustomSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CustomSystem.h; path = ../src/galaxy/CustomSystem.h; sourceTree = "<group>"; };
-		521ED99B1C00D3240092B2E9 /* Economy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Economy.cpp; path = ../src/galaxy/Economy.cpp; sourceTree = "<group>"; };
-		521ED99C1C00D3240092B2E9 /* Economy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Economy.h; path = ../src/galaxy/Economy.h; sourceTree = "<group>"; };
-		521ED99D1C00D3240092B2E9 /* Galaxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Galaxy.cpp; path = ../src/galaxy/Galaxy.cpp; sourceTree = "<group>"; };
-		521ED99E1C00D3240092B2E9 /* Galaxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Galaxy.h; path = ../src/galaxy/Galaxy.h; sourceTree = "<group>"; };
-		521ED99F1C00D3240092B2E9 /* GalaxyCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GalaxyCache.cpp; path = ../src/galaxy/GalaxyCache.cpp; sourceTree = "<group>"; };
-		521ED9A01C00D3240092B2E9 /* GalaxyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GalaxyCache.h; path = ../src/galaxy/GalaxyCache.h; sourceTree = "<group>"; };
-		521ED9A11C00D3240092B2E9 /* GalaxyGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GalaxyGenerator.cpp; path = ../src/galaxy/GalaxyGenerator.cpp; sourceTree = "<group>"; };
-		521ED9A21C00D3240092B2E9 /* GalaxyGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GalaxyGenerator.h; path = ../src/galaxy/GalaxyGenerator.h; sourceTree = "<group>"; };
-		521ED9A31C00D3240092B2E9 /* Sector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sector.cpp; path = ../src/galaxy/Sector.cpp; sourceTree = "<group>"; };
-		521ED9A41C00D3240092B2E9 /* Sector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sector.h; path = ../src/galaxy/Sector.h; sourceTree = "<group>"; };
-		521ED9A51C00D3240092B2E9 /* SectorGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SectorGenerator.cpp; path = ../src/galaxy/SectorGenerator.cpp; sourceTree = "<group>"; };
-		521ED9A61C00D3240092B2E9 /* SectorGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SectorGenerator.h; path = ../src/galaxy/SectorGenerator.h; sourceTree = "<group>"; };
-		521ED9A71C00D3240092B2E9 /* StarSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StarSystem.cpp; path = ../src/galaxy/StarSystem.cpp; sourceTree = "<group>"; };
-		521ED9A81C00D3240092B2E9 /* StarSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StarSystem.h; path = ../src/galaxy/StarSystem.h; sourceTree = "<group>"; };
-		521ED9A91C00D3240092B2E9 /* StarSystemGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StarSystemGenerator.cpp; path = ../src/galaxy/StarSystemGenerator.cpp; sourceTree = "<group>"; };
-		521ED9AA1C00D3240092B2E9 /* StarSystemGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StarSystemGenerator.h; path = ../src/galaxy/StarSystemGenerator.h; sourceTree = "<group>"; };
-		521ED9AB1C00D3240092B2E9 /* SystemPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SystemPath.cpp; path = ../src/galaxy/SystemPath.cpp; sourceTree = "<group>"; };
-		521ED9AC1C00D3240092B2E9 /* SystemPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SystemPath.h; path = ../src/galaxy/SystemPath.h; sourceTree = "<group>"; };
-		521ED9AD1C00D3240092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/galaxy/Makefile.am; sourceTree = "<group>"; };
-		521ED9B91C00D3310092B2E9 /* BindingCapture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BindingCapture.cpp; path = ../src/gameui/BindingCapture.cpp; sourceTree = "<group>"; };
-		521ED9BA1C00D3310092B2E9 /* BindingCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BindingCapture.h; path = ../src/gameui/BindingCapture.h; sourceTree = "<group>"; };
-		521ED9BB1C00D3310092B2E9 /* Face.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Face.cpp; path = ../src/gameui/Face.cpp; sourceTree = "<group>"; };
-		521ED9BC1C00D3310092B2E9 /* Face.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Face.h; path = ../src/gameui/Face.h; sourceTree = "<group>"; };
-		521ED9BD1C00D3310092B2E9 /* GameUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameUI.h; path = ../src/gameui/GameUI.h; sourceTree = "<group>"; };
-		521ED9BE1C00D3310092B2E9 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lua.cpp; path = ../src/gameui/Lua.cpp; sourceTree = "<group>"; };
-		521ED9BF1C00D3310092B2E9 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lua.h; path = ../src/gameui/Lua.h; sourceTree = "<group>"; };
-		521ED9C01C00D3310092B2E9 /* LuaBindingCapture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaBindingCapture.cpp; path = ../src/gameui/LuaBindingCapture.cpp; sourceTree = "<group>"; };
-		521ED9C11C00D3310092B2E9 /* LuaFace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFace.cpp; path = ../src/gameui/LuaFace.cpp; sourceTree = "<group>"; };
-		521ED9C21C00D3310092B2E9 /* LuaModelSpinner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaModelSpinner.cpp; path = ../src/gameui/LuaModelSpinner.cpp; sourceTree = "<group>"; };
-		521ED9C31C00D3310092B2E9 /* ModelSpinner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelSpinner.cpp; path = ../src/gameui/ModelSpinner.cpp; sourceTree = "<group>"; };
-		521ED9C41C00D3310092B2E9 /* ModelSpinner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelSpinner.h; path = ../src/gameui/ModelSpinner.h; sourceTree = "<group>"; };
-		521ED9C51C00D3310092B2E9 /* Panel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Panel.cpp; path = ../src/gameui/Panel.cpp; sourceTree = "<group>"; };
-		521ED9C61C00D3310092B2E9 /* Panel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Panel.h; path = ../src/gameui/Panel.h; sourceTree = "<group>"; };
-		521ED9C71C00D3310092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/gameui/Makefile.am; sourceTree = "<group>"; };
-		521ED9D21C00D3430092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		521ED9D31C00D3430092B2E9 /* MaterialDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialDummy.h; sourceTree = "<group>"; };
-		521ED9D41C00D3430092B2E9 /* RendererDummy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RendererDummy.cpp; sourceTree = "<group>"; };
-		521ED9D51C00D3430092B2E9 /* RendererDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererDummy.h; sourceTree = "<group>"; };
-		521ED9D61C00D3430092B2E9 /* RenderStateDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderStateDummy.h; sourceTree = "<group>"; };
-		521ED9D71C00D3430092B2E9 /* RenderTargetDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderTargetDummy.h; sourceTree = "<group>"; };
-		521ED9D81C00D3430092B2E9 /* TextureDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureDummy.h; sourceTree = "<group>"; };
-		521ED9D91C00D3430092B2E9 /* VertexBufferDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexBufferDummy.h; sourceTree = "<group>"; };
-		521ED9DB1C00D3430092B2E9 /* FresnelColourMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FresnelColourMaterial.cpp; sourceTree = "<group>"; };
-		521ED9DC1C00D3430092B2E9 /* FresnelColourMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FresnelColourMaterial.h; sourceTree = "<group>"; };
-		521ED9DD1C00D3430092B2E9 /* GasGiantMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GasGiantMaterial.cpp; sourceTree = "<group>"; };
-		521ED9DE1C00D3430092B2E9 /* GasGiantMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GasGiantMaterial.h; sourceTree = "<group>"; };
-		521ED9DF1C00D3430092B2E9 /* GeoSphereMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoSphereMaterial.cpp; sourceTree = "<group>"; };
-		521ED9E01C00D3430092B2E9 /* GeoSphereMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoSphereMaterial.h; sourceTree = "<group>"; };
-		521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gl_core_3_x.c; sourceTree = "<group>"; };
-		521ED9E21C00D3430092B2E9 /* gl_core_3_x.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gl_core_3_x.h; sourceTree = "<group>"; };
-		521ED9E31C00D3430092B2E9 /* GLDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLDebug.h; sourceTree = "<group>"; };
-		521ED9E61C00D3430092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MaterialGL.cpp; sourceTree = "<group>"; };
-		521ED9E81C00D3430092B2E9 /* MaterialGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialGL.h; sourceTree = "<group>"; };
-		521ED9E91C00D3430092B2E9 /* MultiMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MultiMaterial.cpp; sourceTree = "<group>"; };
-		521ED9EA1C00D3430092B2E9 /* MultiMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiMaterial.h; sourceTree = "<group>"; };
-		521ED9EB1C00D3430092B2E9 /* OpenGLLibs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenGLLibs.h; sourceTree = "<group>"; };
-		521ED9EC1C00D3430092B2E9 /* Program.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Program.cpp; sourceTree = "<group>"; };
-		521ED9ED1C00D3430092B2E9 /* Program.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Program.h; sourceTree = "<group>"; };
-		521ED9EE1C00D3430092B2E9 /* RendererGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RendererGL.cpp; sourceTree = "<group>"; };
-		521ED9EF1C00D3430092B2E9 /* RendererGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererGL.h; sourceTree = "<group>"; };
-		521ED9F01C00D3430092B2E9 /* RenderStateGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderStateGL.cpp; sourceTree = "<group>"; };
-		521ED9F11C00D3430092B2E9 /* RenderStateGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderStateGL.h; sourceTree = "<group>"; };
-		521ED9F21C00D3430092B2E9 /* RenderTargetGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderTargetGL.cpp; sourceTree = "<group>"; };
-		521ED9F31C00D3430092B2E9 /* RenderTargetGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderTargetGL.h; sourceTree = "<group>"; };
-		521ED9F41C00D3430092B2E9 /* RingMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RingMaterial.cpp; sourceTree = "<group>"; };
-		521ED9F51C00D3430092B2E9 /* RingMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RingMaterial.h; sourceTree = "<group>"; };
-		521ED9F61C00D3430092B2E9 /* ShieldMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShieldMaterial.cpp; sourceTree = "<group>"; };
-		521ED9F71C00D3430092B2E9 /* ShieldMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShieldMaterial.h; sourceTree = "<group>"; };
-		521ED9F81C00D3430092B2E9 /* SkyboxMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SkyboxMaterial.h; sourceTree = "<group>"; };
-		521ED9F91C00D3430092B2E9 /* SphereImpostorMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SphereImpostorMaterial.h; sourceTree = "<group>"; };
-		521ED9FA1C00D3430092B2E9 /* StarfieldMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StarfieldMaterial.h; sourceTree = "<group>"; };
-		521ED9FB1C00D3430092B2E9 /* TextureGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureGL.cpp; sourceTree = "<group>"; };
-		521ED9FC1C00D3430092B2E9 /* TextureGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureGL.h; sourceTree = "<group>"; };
-		521ED9FD1C00D3430092B2E9 /* UIMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIMaterial.cpp; sourceTree = "<group>"; };
-		521ED9FE1C00D3430092B2E9 /* UIMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIMaterial.h; sourceTree = "<group>"; };
-		521ED9FF1C00D3430092B2E9 /* Uniform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Uniform.cpp; sourceTree = "<group>"; };
-		521EDA001C00D3430092B2E9 /* Uniform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Uniform.h; sourceTree = "<group>"; };
-		521EDA011C00D3430092B2E9 /* VertexBufferGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VertexBufferGL.cpp; sourceTree = "<group>"; };
-		521EDA021C00D3430092B2E9 /* VertexBufferGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexBufferGL.h; sourceTree = "<group>"; };
-		521EDA031C00D3430092B2E9 /* VtxColorMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VtxColorMaterial.cpp; sourceTree = "<group>"; };
-		521EDA041C00D3430092B2E9 /* VtxColorMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VtxColorMaterial.h; sourceTree = "<group>"; };
-		521EDA051C00D3430092B2E9 /* Drawables.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Drawables.cpp; path = ../src/graphics/Drawables.cpp; sourceTree = "<group>"; };
-		521EDA061C00D3430092B2E9 /* Drawables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Drawables.h; path = ../src/graphics/Drawables.h; sourceTree = "<group>"; };
-		521EDA071C00D3430092B2E9 /* Frustum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Frustum.cpp; path = ../src/graphics/Frustum.cpp; sourceTree = "<group>"; };
-		521EDA081C00D3430092B2E9 /* Frustum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Frustum.h; path = ../src/graphics/Frustum.h; sourceTree = "<group>"; };
-		521EDA091C00D3430092B2E9 /* Graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Graphics.cpp; path = ../src/graphics/Graphics.cpp; sourceTree = "<group>"; };
-		521EDA0A1C00D3430092B2E9 /* Graphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Graphics.h; path = ../src/graphics/Graphics.h; sourceTree = "<group>"; };
-		521EDA0B1C00D3430092B2E9 /* Light.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Light.cpp; path = ../src/graphics/Light.cpp; sourceTree = "<group>"; };
-		521EDA0C1C00D3430092B2E9 /* Light.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Light.h; path = ../src/graphics/Light.h; sourceTree = "<group>"; };
-		521EDA0D1C00D3430092B2E9 /* Material.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Material.cpp; path = ../src/graphics/Material.cpp; sourceTree = "<group>"; };
-		521EDA0E1C00D3430092B2E9 /* Material.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Material.h; path = ../src/graphics/Material.h; sourceTree = "<group>"; };
-		521EDA0F1C00D3430092B2E9 /* Renderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Renderer.cpp; path = ../src/graphics/Renderer.cpp; sourceTree = "<group>"; };
-		521EDA101C00D3430092B2E9 /* Renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Renderer.h; path = ../src/graphics/Renderer.h; sourceTree = "<group>"; };
-		521EDA111C00D3430092B2E9 /* RenderState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RenderState.h; path = ../src/graphics/RenderState.h; sourceTree = "<group>"; };
-		521EDA121C00D3430092B2E9 /* RenderTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RenderTarget.h; path = ../src/graphics/RenderTarget.h; sourceTree = "<group>"; };
-		521EDA131C00D3430092B2E9 /* Stats.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Stats.cpp; path = ../src/graphics/Stats.cpp; sourceTree = "<group>"; };
-		521EDA141C00D3430092B2E9 /* Stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Stats.h; path = ../src/graphics/Stats.h; sourceTree = "<group>"; };
-		521EDA151C00D3430092B2E9 /* Texture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Texture.h; path = ../src/graphics/Texture.h; sourceTree = "<group>"; };
-		521EDA161C00D3430092B2E9 /* TextureBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextureBuilder.cpp; path = ../src/graphics/TextureBuilder.cpp; sourceTree = "<group>"; };
-		521EDA171C00D3430092B2E9 /* TextureBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextureBuilder.h; path = ../src/graphics/TextureBuilder.h; sourceTree = "<group>"; };
-		521EDA181C00D3430092B2E9 /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Types.h; path = ../src/graphics/Types.h; sourceTree = "<group>"; };
-		521EDA191C00D3430092B2E9 /* VertexArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VertexArray.cpp; path = ../src/graphics/VertexArray.cpp; sourceTree = "<group>"; };
-		521EDA1A1C00D3430092B2E9 /* VertexArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VertexArray.h; path = ../src/graphics/VertexArray.h; sourceTree = "<group>"; };
-		521EDA1B1C00D3430092B2E9 /* VertexBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VertexBuffer.cpp; path = ../src/graphics/VertexBuffer.cpp; sourceTree = "<group>"; };
-		521EDA1C1C00D3430092B2E9 /* VertexBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VertexBuffer.h; path = ../src/graphics/VertexBuffer.h; sourceTree = "<group>"; };
-		521EDA1D1C00D3430092B2E9 /* WindowSDL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WindowSDL.cpp; path = ../src/graphics/WindowSDL.cpp; sourceTree = "<group>"; };
-		521EDA1E1C00D3430092B2E9 /* WindowSDL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WindowSDL.h; path = ../src/graphics/WindowSDL.h; sourceTree = "<group>"; };
-		521EDA1F1C00D3430092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/graphics/Makefile.am; sourceTree = "<group>"; };
-		521EDA411C00D3550092B2E9 /* Gui.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Gui.cpp; path = ../src/gui/Gui.cpp; sourceTree = "<group>"; };
-		521EDA421C00D3550092B2E9 /* Gui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Gui.h; path = ../src/gui/Gui.h; sourceTree = "<group>"; };
-		521EDA431C00D3550092B2E9 /* GuiAdjustment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiAdjustment.h; path = ../src/gui/GuiAdjustment.h; sourceTree = "<group>"; };
-		521EDA441C00D3550092B2E9 /* GuiBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiBox.cpp; path = ../src/gui/GuiBox.cpp; sourceTree = "<group>"; };
-		521EDA451C00D3550092B2E9 /* GuiBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiBox.h; path = ../src/gui/GuiBox.h; sourceTree = "<group>"; };
-		521EDA461C00D3550092B2E9 /* GuiButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiButton.cpp; path = ../src/gui/GuiButton.cpp; sourceTree = "<group>"; };
-		521EDA471C00D3550092B2E9 /* GuiButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiButton.h; path = ../src/gui/GuiButton.h; sourceTree = "<group>"; };
-		521EDA481C00D3550092B2E9 /* GuiContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiContainer.cpp; path = ../src/gui/GuiContainer.cpp; sourceTree = "<group>"; };
-		521EDA491C00D3550092B2E9 /* GuiContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiContainer.h; path = ../src/gui/GuiContainer.h; sourceTree = "<group>"; };
-		521EDA4A1C00D3550092B2E9 /* GuiEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiEvents.h; path = ../src/gui/GuiEvents.h; sourceTree = "<group>"; };
-		521EDA4B1C00D3550092B2E9 /* GuiFixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiFixed.cpp; path = ../src/gui/GuiFixed.cpp; sourceTree = "<group>"; };
-		521EDA4C1C00D3550092B2E9 /* GuiFixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiFixed.h; path = ../src/gui/GuiFixed.h; sourceTree = "<group>"; };
-		521EDA4D1C00D3550092B2E9 /* GuiImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiImage.cpp; path = ../src/gui/GuiImage.cpp; sourceTree = "<group>"; };
-		521EDA4E1C00D3550092B2E9 /* GuiImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiImage.h; path = ../src/gui/GuiImage.h; sourceTree = "<group>"; };
-		521EDA4F1C00D3550092B2E9 /* GuiImageButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiImageButton.cpp; path = ../src/gui/GuiImageButton.cpp; sourceTree = "<group>"; };
-		521EDA501C00D3550092B2E9 /* GuiImageButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiImageButton.h; path = ../src/gui/GuiImageButton.h; sourceTree = "<group>"; };
-		521EDA511C00D3550092B2E9 /* GuiImageRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiImageRadioButton.cpp; path = ../src/gui/GuiImageRadioButton.cpp; sourceTree = "<group>"; };
-		521EDA521C00D3550092B2E9 /* GuiImageRadioButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiImageRadioButton.h; path = ../src/gui/GuiImageRadioButton.h; sourceTree = "<group>"; };
-		521EDA531C00D3550092B2E9 /* GuiISelectable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiISelectable.h; path = ../src/gui/GuiISelectable.h; sourceTree = "<group>"; };
-		521EDA541C00D3550092B2E9 /* GuiLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiLabel.cpp; path = ../src/gui/GuiLabel.cpp; sourceTree = "<group>"; };
-		521EDA551C00D3550092B2E9 /* GuiLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiLabel.h; path = ../src/gui/GuiLabel.h; sourceTree = "<group>"; };
-		521EDA561C00D3550092B2E9 /* GuiLabelSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiLabelSet.cpp; path = ../src/gui/GuiLabelSet.cpp; sourceTree = "<group>"; };
-		521EDA571C00D3550092B2E9 /* GuiLabelSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiLabelSet.h; path = ../src/gui/GuiLabelSet.h; sourceTree = "<group>"; };
-		521EDA581C00D3550092B2E9 /* GuiMeterBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiMeterBar.cpp; path = ../src/gui/GuiMeterBar.cpp; sourceTree = "<group>"; };
-		521EDA591C00D3550092B2E9 /* GuiMeterBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiMeterBar.h; path = ../src/gui/GuiMeterBar.h; sourceTree = "<group>"; };
-		521EDA5A1C00D3550092B2E9 /* GuiMultiStateImageButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiMultiStateImageButton.cpp; path = ../src/gui/GuiMultiStateImageButton.cpp; sourceTree = "<group>"; };
-		521EDA5B1C00D3550092B2E9 /* GuiMultiStateImageButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiMultiStateImageButton.h; path = ../src/gui/GuiMultiStateImageButton.h; sourceTree = "<group>"; };
-		521EDA5C1C00D3550092B2E9 /* GuiRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiRadioButton.cpp; path = ../src/gui/GuiRadioButton.cpp; sourceTree = "<group>"; };
-		521EDA5D1C00D3550092B2E9 /* GuiRadioButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiRadioButton.h; path = ../src/gui/GuiRadioButton.h; sourceTree = "<group>"; };
-		521EDA5E1C00D3550092B2E9 /* GuiRadioGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiRadioGroup.cpp; path = ../src/gui/GuiRadioGroup.cpp; sourceTree = "<group>"; };
-		521EDA5F1C00D3550092B2E9 /* GuiRadioGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiRadioGroup.h; path = ../src/gui/GuiRadioGroup.h; sourceTree = "<group>"; };
-		521EDA601C00D3550092B2E9 /* GuiScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiScreen.cpp; path = ../src/gui/GuiScreen.cpp; sourceTree = "<group>"; };
-		521EDA611C00D3550092B2E9 /* GuiScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiScreen.h; path = ../src/gui/GuiScreen.h; sourceTree = "<group>"; };
-		521EDA621C00D3550092B2E9 /* GuiStack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiStack.cpp; path = ../src/gui/GuiStack.cpp; sourceTree = "<group>"; };
-		521EDA631C00D3550092B2E9 /* GuiStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiStack.h; path = ../src/gui/GuiStack.h; sourceTree = "<group>"; };
-		521EDA641C00D3550092B2E9 /* GuiTabbed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiTabbed.cpp; path = ../src/gui/GuiTabbed.cpp; sourceTree = "<group>"; };
-		521EDA651C00D3550092B2E9 /* GuiTabbed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiTabbed.h; path = ../src/gui/GuiTabbed.h; sourceTree = "<group>"; };
-		521EDA661C00D3550092B2E9 /* GuiTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiTextEntry.cpp; path = ../src/gui/GuiTextEntry.cpp; sourceTree = "<group>"; };
-		521EDA671C00D3550092B2E9 /* GuiTextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiTextEntry.h; path = ../src/gui/GuiTextEntry.h; sourceTree = "<group>"; };
-		521EDA681C00D3550092B2E9 /* GuiTextLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiTextLayout.cpp; path = ../src/gui/GuiTextLayout.cpp; sourceTree = "<group>"; };
-		521EDA691C00D3550092B2E9 /* GuiTextLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiTextLayout.h; path = ../src/gui/GuiTextLayout.h; sourceTree = "<group>"; };
-		521EDA6A1C00D3550092B2E9 /* GuiTexturedQuad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiTexturedQuad.cpp; path = ../src/gui/GuiTexturedQuad.cpp; sourceTree = "<group>"; };
-		521EDA6B1C00D3550092B2E9 /* GuiTexturedQuad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiTexturedQuad.h; path = ../src/gui/GuiTexturedQuad.h; sourceTree = "<group>"; };
-		521EDA6C1C00D3550092B2E9 /* GuiToggleButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiToggleButton.cpp; path = ../src/gui/GuiToggleButton.cpp; sourceTree = "<group>"; };
-		521EDA6D1C00D3550092B2E9 /* GuiToggleButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiToggleButton.h; path = ../src/gui/GuiToggleButton.h; sourceTree = "<group>"; };
-		521EDA6E1C00D3550092B2E9 /* GuiToolTip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiToolTip.cpp; path = ../src/gui/GuiToolTip.cpp; sourceTree = "<group>"; };
-		521EDA6F1C00D3550092B2E9 /* GuiToolTip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiToolTip.h; path = ../src/gui/GuiToolTip.h; sourceTree = "<group>"; };
-		521EDA701C00D3550092B2E9 /* GuiVScrollBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiVScrollBar.cpp; path = ../src/gui/GuiVScrollBar.cpp; sourceTree = "<group>"; };
-		521EDA711C00D3550092B2E9 /* GuiVScrollBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiVScrollBar.h; path = ../src/gui/GuiVScrollBar.h; sourceTree = "<group>"; };
-		521EDA721C00D3550092B2E9 /* GuiVScrollPortal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiVScrollPortal.cpp; path = ../src/gui/GuiVScrollPortal.cpp; sourceTree = "<group>"; };
-		521EDA731C00D3550092B2E9 /* GuiVScrollPortal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiVScrollPortal.h; path = ../src/gui/GuiVScrollPortal.h; sourceTree = "<group>"; };
-		521EDA741C00D3550092B2E9 /* GuiWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiWidget.cpp; path = ../src/gui/GuiWidget.cpp; sourceTree = "<group>"; };
-		521EDA751C00D3550092B2E9 /* GuiWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiWidget.h; path = ../src/gui/GuiWidget.h; sourceTree = "<group>"; };
-		521EDA761C00D3550092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/gui/Makefile.am; sourceTree = "<group>"; };
-		521EDA911C00D3610092B2E9 /* FileSystemPosix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FileSystemPosix.cpp; path = ../src/posix/FileSystemPosix.cpp; sourceTree = "<group>"; };
-		521EDA921C00D3610092B2E9 /* OSPosix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OSPosix.cpp; path = ../src/posix/OSPosix.cpp; sourceTree = "<group>"; };
-		521EDA931C00D3610092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/posix/Makefile.am; sourceTree = "<group>"; };
-		521EDA971C00D36D0092B2E9 /* Animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Animation.cpp; path = ../src/scenegraph/Animation.cpp; sourceTree = "<group>"; };
-		521EDA981C00D36D0092B2E9 /* Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Animation.h; path = ../src/scenegraph/Animation.h; sourceTree = "<group>"; };
-		521EDA991C00D36D0092B2E9 /* AnimationChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AnimationChannel.h; path = ../src/scenegraph/AnimationChannel.h; sourceTree = "<group>"; };
-		521EDA9A1C00D36D0092B2E9 /* AnimationKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AnimationKey.h; path = ../src/scenegraph/AnimationKey.h; sourceTree = "<group>"; };
-		521EDA9B1C00D36D0092B2E9 /* BaseLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BaseLoader.cpp; path = ../src/scenegraph/BaseLoader.cpp; sourceTree = "<group>"; };
-		521EDA9C1C00D36D0092B2E9 /* BaseLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BaseLoader.h; path = ../src/scenegraph/BaseLoader.h; sourceTree = "<group>"; };
-		521EDA9D1C00D36D0092B2E9 /* Billboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Billboard.cpp; path = ../src/scenegraph/Billboard.cpp; sourceTree = "<group>"; };
-		521EDA9E1C00D36D0092B2E9 /* Billboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Billboard.h; path = ../src/scenegraph/Billboard.h; sourceTree = "<group>"; };
-		521EDA9F1C00D36D0092B2E9 /* BinaryConverter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BinaryConverter.cpp; path = ../src/scenegraph/BinaryConverter.cpp; sourceTree = "<group>"; };
-		521EDAA01C00D36D0092B2E9 /* BinaryConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BinaryConverter.h; path = ../src/scenegraph/BinaryConverter.h; sourceTree = "<group>"; };
-		521EDAA11C00D36D0092B2E9 /* CollisionGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollisionGeometry.cpp; path = ../src/scenegraph/CollisionGeometry.cpp; sourceTree = "<group>"; };
-		521EDAA21C00D36D0092B2E9 /* CollisionGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionGeometry.h; path = ../src/scenegraph/CollisionGeometry.h; sourceTree = "<group>"; };
-		521EDAA31C00D36D0092B2E9 /* CollisionVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollisionVisitor.cpp; path = ../src/scenegraph/CollisionVisitor.cpp; sourceTree = "<group>"; };
-		521EDAA41C00D36D0092B2E9 /* CollisionVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionVisitor.h; path = ../src/scenegraph/CollisionVisitor.h; sourceTree = "<group>"; };
-		521EDAA51C00D36D0092B2E9 /* ColorMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ColorMap.cpp; path = ../src/scenegraph/ColorMap.cpp; sourceTree = "<group>"; };
-		521EDAA61C00D36D0092B2E9 /* ColorMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ColorMap.h; path = ../src/scenegraph/ColorMap.h; sourceTree = "<group>"; };
-		521EDAA71C00D36D0092B2E9 /* DumpVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DumpVisitor.cpp; path = ../src/scenegraph/DumpVisitor.cpp; sourceTree = "<group>"; };
-		521EDAA81C00D36D0092B2E9 /* DumpVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DumpVisitor.h; path = ../src/scenegraph/DumpVisitor.h; sourceTree = "<group>"; };
-		521EDAA91C00D36D0092B2E9 /* FindNodeVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FindNodeVisitor.cpp; path = ../src/scenegraph/FindNodeVisitor.cpp; sourceTree = "<group>"; };
-		521EDAAA1C00D36D0092B2E9 /* FindNodeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FindNodeVisitor.h; path = ../src/scenegraph/FindNodeVisitor.h; sourceTree = "<group>"; };
-		521EDAAB1C00D36D0092B2E9 /* Group.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Group.cpp; path = ../src/scenegraph/Group.cpp; sourceTree = "<group>"; };
-		521EDAAC1C00D36D0092B2E9 /* Group.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Group.h; path = ../src/scenegraph/Group.h; sourceTree = "<group>"; };
-		521EDAAD1C00D36D0092B2E9 /* Label3D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Label3D.cpp; path = ../src/scenegraph/Label3D.cpp; sourceTree = "<group>"; };
-		521EDAAE1C00D36D0092B2E9 /* Label3D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Label3D.h; path = ../src/scenegraph/Label3D.h; sourceTree = "<group>"; };
-		521EDAAF1C00D36D0092B2E9 /* Loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Loader.cpp; path = ../src/scenegraph/Loader.cpp; sourceTree = "<group>"; };
-		521EDAB01C00D36D0092B2E9 /* Loader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Loader.h; path = ../src/scenegraph/Loader.h; sourceTree = "<group>"; };
-		521EDAB11C00D36D0092B2E9 /* LoaderDefinitions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LoaderDefinitions.h; path = ../src/scenegraph/LoaderDefinitions.h; sourceTree = "<group>"; };
-		521EDAB21C00D36D0092B2E9 /* LOD.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LOD.cpp; path = ../src/scenegraph/LOD.cpp; sourceTree = "<group>"; };
-		521EDAB31C00D36D0092B2E9 /* LOD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LOD.h; path = ../src/scenegraph/LOD.h; sourceTree = "<group>"; };
-		521EDAB41C00D36D0092B2E9 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lua.cpp; path = ../src/scenegraph/Lua.cpp; sourceTree = "<group>"; };
-		521EDAB51C00D36D0092B2E9 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lua.h; path = ../src/scenegraph/Lua.h; sourceTree = "<group>"; };
-		521EDAB61C00D36D0092B2E9 /* LuaModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaModel.cpp; path = ../src/scenegraph/LuaModel.cpp; sourceTree = "<group>"; };
-		521EDAB71C00D36D0092B2E9 /* LuaModelSkin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaModelSkin.cpp; path = ../src/scenegraph/LuaModelSkin.cpp; sourceTree = "<group>"; };
-		521EDAB81C00D36D0092B2E9 /* MatrixTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MatrixTransform.cpp; path = ../src/scenegraph/MatrixTransform.cpp; sourceTree = "<group>"; };
-		521EDAB91C00D36D0092B2E9 /* MatrixTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MatrixTransform.h; path = ../src/scenegraph/MatrixTransform.h; sourceTree = "<group>"; };
-		521EDABA1C00D36D0092B2E9 /* Model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Model.cpp; path = ../src/scenegraph/Model.cpp; sourceTree = "<group>"; };
-		521EDABB1C00D36D0092B2E9 /* Model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Model.h; path = ../src/scenegraph/Model.h; sourceTree = "<group>"; };
-		521EDABC1C00D36D0092B2E9 /* ModelNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelNode.cpp; path = ../src/scenegraph/ModelNode.cpp; sourceTree = "<group>"; };
-		521EDABD1C00D36D0092B2E9 /* ModelNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelNode.h; path = ../src/scenegraph/ModelNode.h; sourceTree = "<group>"; };
-		521EDABE1C00D36D0092B2E9 /* ModelSkin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelSkin.cpp; path = ../src/scenegraph/ModelSkin.cpp; sourceTree = "<group>"; };
-		521EDABF1C00D36D0092B2E9 /* ModelSkin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelSkin.h; path = ../src/scenegraph/ModelSkin.h; sourceTree = "<group>"; };
-		521EDAC01C00D36D0092B2E9 /* Node.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Node.cpp; path = ../src/scenegraph/Node.cpp; sourceTree = "<group>"; };
-		521EDAC11C00D36D0092B2E9 /* Node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Node.h; path = ../src/scenegraph/Node.h; sourceTree = "<group>"; };
-		521EDAC21C00D36D0092B2E9 /* NodeCopyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NodeCopyCache.h; path = ../src/scenegraph/NodeCopyCache.h; sourceTree = "<group>"; };
-		521EDAC31C00D36D0092B2E9 /* NodeVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NodeVisitor.cpp; path = ../src/scenegraph/NodeVisitor.cpp; sourceTree = "<group>"; };
-		521EDAC41C00D36D0092B2E9 /* NodeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NodeVisitor.h; path = ../src/scenegraph/NodeVisitor.h; sourceTree = "<group>"; };
-		521EDAC51C00D36D0092B2E9 /* Parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Parser.cpp; path = ../src/scenegraph/Parser.cpp; sourceTree = "<group>"; };
-		521EDAC61C00D36D0092B2E9 /* Parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Parser.h; path = ../src/scenegraph/Parser.h; sourceTree = "<group>"; };
-		521EDAC71C00D36D0092B2E9 /* Pattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Pattern.cpp; path = ../src/scenegraph/Pattern.cpp; sourceTree = "<group>"; };
-		521EDAC81C00D36D0092B2E9 /* Pattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Pattern.h; path = ../src/scenegraph/Pattern.h; sourceTree = "<group>"; };
-		521EDAC91C00D36D0092B2E9 /* SceneGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SceneGraph.h; path = ../src/scenegraph/SceneGraph.h; sourceTree = "<group>"; };
-		521EDACA1C00D36D0092B2E9 /* StaticGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StaticGeometry.cpp; path = ../src/scenegraph/StaticGeometry.cpp; sourceTree = "<group>"; };
-		521EDACB1C00D36D0092B2E9 /* StaticGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StaticGeometry.h; path = ../src/scenegraph/StaticGeometry.h; sourceTree = "<group>"; };
-		521EDACC1C00D36D0092B2E9 /* Thruster.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Thruster.cpp; path = ../src/scenegraph/Thruster.cpp; sourceTree = "<group>"; };
-		521EDACD1C00D36D0092B2E9 /* Thruster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Thruster.h; path = ../src/scenegraph/Thruster.h; sourceTree = "<group>"; };
-		521EDACE1C00D36D0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/scenegraph/Makefile.am; sourceTree = "<group>"; };
-		521EDAEA1C00D37B0092B2E9 /* Terrain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Terrain.cpp; path = ../src/terrain/Terrain.cpp; sourceTree = "<group>"; };
-		521EDAEB1C00D37B0092B2E9 /* Terrain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Terrain.h; path = ../src/terrain/Terrain.h; sourceTree = "<group>"; };
-		521EDAEC1C00D37B0092B2E9 /* TerrainColorAsteroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorAsteroid.cpp; path = ../src/terrain/TerrainColorAsteroid.cpp; sourceTree = "<group>"; };
-		521EDAED1C00D37B0092B2E9 /* TerrainColorBandedRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorBandedRock.cpp; path = ../src/terrain/TerrainColorBandedRock.cpp; sourceTree = "<group>"; };
-		521EDAEE1C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorDeadWithWater.cpp; path = ../src/terrain/TerrainColorDeadWithWater.cpp; sourceTree = "<group>"; };
-		521EDAEF1C00D37B0092B2E9 /* TerrainColorDesert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorDesert.cpp; path = ../src/terrain/TerrainColorDesert.cpp; sourceTree = "<group>"; };
-		521EDAF01C00D37B0092B2E9 /* TerrainColorEarthLike.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorEarthLike.cpp; path = ../src/terrain/TerrainColorEarthLike.cpp; sourceTree = "<group>"; };
-		521EDAF11C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorEarthLikeHeightmapped.cpp; path = ../src/terrain/TerrainColorEarthLikeHeightmapped.cpp; sourceTree = "<group>"; };
-		521EDAF21C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGJupiter.cpp; path = ../src/terrain/TerrainColorGGJupiter.cpp; sourceTree = "<group>"; };
-		521EDAF31C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGNeptune.cpp; path = ../src/terrain/TerrainColorGGNeptune.cpp; sourceTree = "<group>"; };
-		521EDAF41C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGNeptune2.cpp; path = ../src/terrain/TerrainColorGGNeptune2.cpp; sourceTree = "<group>"; };
-		521EDAF51C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGSaturn.cpp; path = ../src/terrain/TerrainColorGGSaturn.cpp; sourceTree = "<group>"; };
-		521EDAF61C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGSaturn2.cpp; path = ../src/terrain/TerrainColorGGSaturn2.cpp; sourceTree = "<group>"; };
-		521EDAF71C00D37B0092B2E9 /* TerrainColorGGUranus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGUranus.cpp; path = ../src/terrain/TerrainColorGGUranus.cpp; sourceTree = "<group>"; };
-		521EDAF81C00D37B0092B2E9 /* TerrainColorIce.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorIce.cpp; path = ../src/terrain/TerrainColorIce.cpp; sourceTree = "<group>"; };
-		521EDAF91C00D37B0092B2E9 /* TerrainColorMethane.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorMethane.cpp; path = ../src/terrain/TerrainColorMethane.cpp; sourceTree = "<group>"; };
-		521EDAFA1C00D37B0092B2E9 /* TerrainColorRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorRock.cpp; path = ../src/terrain/TerrainColorRock.cpp; sourceTree = "<group>"; };
-		521EDAFB1C00D37B0092B2E9 /* TerrainColorRock2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorRock2.cpp; path = ../src/terrain/TerrainColorRock2.cpp; sourceTree = "<group>"; };
-		521EDAFC1C00D37B0092B2E9 /* TerrainColorSolid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorSolid.cpp; path = ../src/terrain/TerrainColorSolid.cpp; sourceTree = "<group>"; };
-		521EDAFD1C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarBrownDwarf.cpp; path = ../src/terrain/TerrainColorStarBrownDwarf.cpp; sourceTree = "<group>"; };
-		521EDAFE1C00D37B0092B2E9 /* TerrainColorStarG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarG.cpp; path = ../src/terrain/TerrainColorStarG.cpp; sourceTree = "<group>"; };
-		521EDAFF1C00D37B0092B2E9 /* TerrainColorStarK.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarK.cpp; path = ../src/terrain/TerrainColorStarK.cpp; sourceTree = "<group>"; };
-		521EDB001C00D37B0092B2E9 /* TerrainColorStarM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarM.cpp; path = ../src/terrain/TerrainColorStarM.cpp; sourceTree = "<group>"; };
-		521EDB011C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarWhiteDwarf.cpp; path = ../src/terrain/TerrainColorStarWhiteDwarf.cpp; sourceTree = "<group>"; };
-		521EDB021C00D37B0092B2E9 /* TerrainColorTFGood.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorTFGood.cpp; path = ../src/terrain/TerrainColorTFGood.cpp; sourceTree = "<group>"; };
-		521EDB031C00D37B0092B2E9 /* TerrainColorTFPoor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorTFPoor.cpp; path = ../src/terrain/TerrainColorTFPoor.cpp; sourceTree = "<group>"; };
-		521EDB041C00D37B0092B2E9 /* TerrainColorVolcanic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorVolcanic.cpp; path = ../src/terrain/TerrainColorVolcanic.cpp; sourceTree = "<group>"; };
-		521EDB051C00D37B0092B2E9 /* TerrainFeature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainFeature.cpp; path = ../src/terrain/TerrainFeature.cpp; sourceTree = "<group>"; };
-		521EDB061C00D37B0092B2E9 /* TerrainFeature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TerrainFeature.h; path = ../src/terrain/TerrainFeature.h; sourceTree = "<group>"; };
-		521EDB071C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightAsteroid.cpp; path = ../src/terrain/TerrainHeightAsteroid.cpp; sourceTree = "<group>"; };
-		521EDB081C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightAsteroid2.cpp; path = ../src/terrain/TerrainHeightAsteroid2.cpp; sourceTree = "<group>"; };
-		521EDB091C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightAsteroid3.cpp; path = ../src/terrain/TerrainHeightAsteroid3.cpp; sourceTree = "<group>"; };
-		521EDB0A1C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightAsteroid4.cpp; path = ../src/terrain/TerrainHeightAsteroid4.cpp; sourceTree = "<group>"; };
-		521EDB0B1C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightBarrenRock.cpp; path = ../src/terrain/TerrainHeightBarrenRock.cpp; sourceTree = "<group>"; };
-		521EDB0C1C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightBarrenRock2.cpp; path = ../src/terrain/TerrainHeightBarrenRock2.cpp; sourceTree = "<group>"; };
-		521EDB0D1C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightBarrenRock3.cpp; path = ../src/terrain/TerrainHeightBarrenRock3.cpp; sourceTree = "<group>"; };
-		521EDB0E1C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightEllipsoid.cpp; path = ../src/terrain/TerrainHeightEllipsoid.cpp; sourceTree = "<group>"; };
-		521EDB0F1C00D37B0092B2E9 /* TerrainHeightFlat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightFlat.cpp; path = ../src/terrain/TerrainHeightFlat.cpp; sourceTree = "<group>"; };
-		521EDB101C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsCraters.cpp; path = ../src/terrain/TerrainHeightHillsCraters.cpp; sourceTree = "<group>"; };
-		521EDB111C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsCraters2.cpp; path = ../src/terrain/TerrainHeightHillsCraters2.cpp; sourceTree = "<group>"; };
-		521EDB121C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsDunes.cpp; path = ../src/terrain/TerrainHeightHillsDunes.cpp; sourceTree = "<group>"; };
-		521EDB131C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsNormal.cpp; path = ../src/terrain/TerrainHeightHillsNormal.cpp; sourceTree = "<group>"; };
-		521EDB141C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsRidged.cpp; path = ../src/terrain/TerrainHeightHillsRidged.cpp; sourceTree = "<group>"; };
-		521EDB151C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsRivers.cpp; path = ../src/terrain/TerrainHeightHillsRivers.cpp; sourceTree = "<group>"; };
-		521EDB161C00D37B0092B2E9 /* TerrainHeightMapped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMapped.cpp; path = ../src/terrain/TerrainHeightMapped.cpp; sourceTree = "<group>"; };
-		521EDB171C00D37B0092B2E9 /* TerrainHeightMapped2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMapped2.cpp; path = ../src/terrain/TerrainHeightMapped2.cpp; sourceTree = "<group>"; };
-		521EDB181C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsCraters.cpp; path = ../src/terrain/TerrainHeightMountainsCraters.cpp; sourceTree = "<group>"; };
-		521EDB191C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsCraters2.cpp; path = ../src/terrain/TerrainHeightMountainsCraters2.cpp; sourceTree = "<group>"; };
-		521EDB1A1C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsNormal.cpp; path = ../src/terrain/TerrainHeightMountainsNormal.cpp; sourceTree = "<group>"; };
-		521EDB1B1C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsRidged.cpp; path = ../src/terrain/TerrainHeightMountainsRidged.cpp; sourceTree = "<group>"; };
-		521EDB1C1C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsRivers.cpp; path = ../src/terrain/TerrainHeightMountainsRivers.cpp; sourceTree = "<group>"; };
-		521EDB1D1C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsRiversVolcano.cpp; path = ../src/terrain/TerrainHeightMountainsRiversVolcano.cpp; sourceTree = "<group>"; };
-		521EDB1E1C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsVolcano.cpp; path = ../src/terrain/TerrainHeightMountainsVolcano.cpp; sourceTree = "<group>"; };
-		521EDB1F1C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightRuggedDesert.cpp; path = ../src/terrain/TerrainHeightRuggedDesert.cpp; sourceTree = "<group>"; };
-		521EDB201C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightRuggedLava.cpp; path = ../src/terrain/TerrainHeightRuggedLava.cpp; sourceTree = "<group>"; };
-		521EDB211C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightWaterSolid.cpp; path = ../src/terrain/TerrainHeightWaterSolid.cpp; sourceTree = "<group>"; };
-		521EDB221C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightWaterSolidCanyons.cpp; path = ../src/terrain/TerrainHeightWaterSolidCanyons.cpp; sourceTree = "<group>"; };
-		521EDB231C00D37B0092B2E9 /* TerrainNoise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TerrainNoise.h; path = ../src/terrain/TerrainNoise.h; sourceTree = "<group>"; };
-		521EDB241C00D37B0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/terrain/Makefile.am; sourceTree = "<group>"; };
-		521EDB5D1C00D38B0092B2E9 /* DistanceFieldFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DistanceFieldFont.cpp; path = ../src/text/DistanceFieldFont.cpp; sourceTree = "<group>"; };
-		521EDB5E1C00D38B0092B2E9 /* DistanceFieldFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DistanceFieldFont.h; path = ../src/text/DistanceFieldFont.h; sourceTree = "<group>"; };
-		521EDB5F1C00D38B0092B2E9 /* FontConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FontConfig.cpp; path = ../src/text/FontConfig.cpp; sourceTree = "<group>"; };
-		521EDB601C00D38B0092B2E9 /* FontConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FontConfig.h; path = ../src/text/FontConfig.h; sourceTree = "<group>"; };
-		521EDB611C00D38B0092B2E9 /* TextSupport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextSupport.cpp; path = ../src/text/TextSupport.cpp; sourceTree = "<group>"; };
-		521EDB621C00D38B0092B2E9 /* TextSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextSupport.h; path = ../src/text/TextSupport.h; sourceTree = "<group>"; };
-		521EDB631C00D38B0092B2E9 /* TextureFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextureFont.cpp; path = ../src/text/TextureFont.cpp; sourceTree = "<group>"; };
-		521EDB641C00D38B0092B2E9 /* TextureFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextureFont.h; path = ../src/text/TextureFont.h; sourceTree = "<group>"; };
-		521EDB651C00D38B0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/text/Makefile.am; sourceTree = "<group>"; };
-		521EDB6B1C00D3A20092B2E9 /* Align.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Align.cpp; path = ../src/ui/Align.cpp; sourceTree = "<group>"; };
-		521EDB6C1C00D3A20092B2E9 /* Align.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Align.h; path = ../src/ui/Align.h; sourceTree = "<group>"; };
-		521EDB6D1C00D3A20092B2E9 /* Animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Animation.cpp; path = ../src/ui/Animation.cpp; sourceTree = "<group>"; };
-		521EDB6E1C00D3A20092B2E9 /* Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Animation.h; path = ../src/ui/Animation.h; sourceTree = "<group>"; };
-		521EDB6F1C00D3A20092B2E9 /* Background.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Background.cpp; path = ../src/ui/Background.cpp; sourceTree = "<group>"; };
-		521EDB701C00D3A20092B2E9 /* Background.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Background.h; path = ../src/ui/Background.h; sourceTree = "<group>"; };
-		521EDB711C00D3A20092B2E9 /* Box.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Box.cpp; path = ../src/ui/Box.cpp; sourceTree = "<group>"; };
-		521EDB721C00D3A20092B2E9 /* Box.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Box.h; path = ../src/ui/Box.h; sourceTree = "<group>"; };
-		521EDB731C00D3A20092B2E9 /* Button.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Button.cpp; path = ../src/ui/Button.cpp; sourceTree = "<group>"; };
-		521EDB741C00D3A20092B2E9 /* Button.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Button.h; path = ../src/ui/Button.h; sourceTree = "<group>"; };
-		521EDB751C00D3A20092B2E9 /* CellSpec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CellSpec.cpp; path = ../src/ui/CellSpec.cpp; sourceTree = "<group>"; };
-		521EDB761C00D3A20092B2E9 /* CellSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CellSpec.h; path = ../src/ui/CellSpec.h; sourceTree = "<group>"; };
-		521EDB771C00D3A20092B2E9 /* CheckBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CheckBox.cpp; path = ../src/ui/CheckBox.cpp; sourceTree = "<group>"; };
-		521EDB781C00D3A20092B2E9 /* CheckBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CheckBox.h; path = ../src/ui/CheckBox.h; sourceTree = "<group>"; };
-		521EDB791C00D3A20092B2E9 /* ColorBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ColorBackground.cpp; path = ../src/ui/ColorBackground.cpp; sourceTree = "<group>"; };
-		521EDB7A1C00D3A20092B2E9 /* ColorBackground.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ColorBackground.h; path = ../src/ui/ColorBackground.h; sourceTree = "<group>"; };
-		521EDB7B1C00D3A20092B2E9 /* Container.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Container.cpp; path = ../src/ui/Container.cpp; sourceTree = "<group>"; };
-		521EDB7C1C00D3A20092B2E9 /* Container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Container.h; path = ../src/ui/Container.h; sourceTree = "<group>"; };
-		521EDB7D1C00D3A20092B2E9 /* Context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Context.cpp; path = ../src/ui/Context.cpp; sourceTree = "<group>"; };
-		521EDB7E1C00D3A20092B2E9 /* Context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Context.h; path = ../src/ui/Context.h; sourceTree = "<group>"; };
-		521EDB7F1C00D3A20092B2E9 /* DropDown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DropDown.cpp; path = ../src/ui/DropDown.cpp; sourceTree = "<group>"; };
-		521EDB801C00D3A20092B2E9 /* DropDown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DropDown.h; path = ../src/ui/DropDown.h; sourceTree = "<group>"; };
-		521EDB811C00D3A20092B2E9 /* Event.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Event.cpp; path = ../src/ui/Event.cpp; sourceTree = "<group>"; };
-		521EDB821C00D3A20092B2E9 /* Event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Event.h; path = ../src/ui/Event.h; sourceTree = "<group>"; };
-		521EDB831C00D3A20092B2E9 /* EventDispatcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EventDispatcher.cpp; path = ../src/ui/EventDispatcher.cpp; sourceTree = "<group>"; };
-		521EDB841C00D3A20092B2E9 /* EventDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EventDispatcher.h; path = ../src/ui/EventDispatcher.h; sourceTree = "<group>"; };
-		521EDB851C00D3A20092B2E9 /* Expand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Expand.cpp; path = ../src/ui/Expand.cpp; sourceTree = "<group>"; };
-		521EDB861C00D3A20092B2E9 /* Expand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Expand.h; path = ../src/ui/Expand.h; sourceTree = "<group>"; };
-		521EDB871C00D3A20092B2E9 /* Gauge.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Gauge.cpp; path = ../src/ui/Gauge.cpp; sourceTree = "<group>"; };
-		521EDB881C00D3A20092B2E9 /* Gauge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Gauge.h; path = ../src/ui/Gauge.h; sourceTree = "<group>"; };
-		521EDB891C00D3A20092B2E9 /* Gradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Gradient.cpp; path = ../src/ui/Gradient.cpp; sourceTree = "<group>"; };
-		521EDB8A1C00D3A20092B2E9 /* Gradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Gradient.h; path = ../src/ui/Gradient.h; sourceTree = "<group>"; };
-		521EDB8B1C00D3A20092B2E9 /* Grid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Grid.cpp; path = ../src/ui/Grid.cpp; sourceTree = "<group>"; };
-		521EDB8C1C00D3A20092B2E9 /* Grid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Grid.h; path = ../src/ui/Grid.h; sourceTree = "<group>"; };
-		521EDB8D1C00D3A20092B2E9 /* Icon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Icon.cpp; path = ../src/ui/Icon.cpp; sourceTree = "<group>"; };
-		521EDB8E1C00D3A20092B2E9 /* Icon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Icon.h; path = ../src/ui/Icon.h; sourceTree = "<group>"; };
-		521EDB8F1C00D3A20092B2E9 /* Image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Image.cpp; path = ../src/ui/Image.cpp; sourceTree = "<group>"; };
-		521EDB901C00D3A20092B2E9 /* Image.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Image.h; path = ../src/ui/Image.h; sourceTree = "<group>"; };
-		521EDB911C00D3A20092B2E9 /* Label.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Label.cpp; path = ../src/ui/Label.cpp; sourceTree = "<group>"; };
-		521EDB921C00D3A20092B2E9 /* Label.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Label.h; path = ../src/ui/Label.h; sourceTree = "<group>"; };
-		521EDB931C00D3A20092B2E9 /* Layer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Layer.cpp; path = ../src/ui/Layer.cpp; sourceTree = "<group>"; };
-		521EDB941C00D3A20092B2E9 /* Layer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Layer.h; path = ../src/ui/Layer.h; sourceTree = "<group>"; };
-		521EDB951C00D3A20092B2E9 /* List.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = List.cpp; path = ../src/ui/List.cpp; sourceTree = "<group>"; };
-		521EDB961C00D3A20092B2E9 /* List.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = List.h; path = ../src/ui/List.h; sourceTree = "<group>"; };
-		521EDB971C00D3A20092B2E9 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lua.cpp; path = ../src/ui/Lua.cpp; sourceTree = "<group>"; };
-		521EDB981C00D3A20092B2E9 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lua.h; path = ../src/ui/Lua.h; sourceTree = "<group>"; };
-		521EDB991C00D3A20092B2E9 /* LuaAlign.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaAlign.cpp; path = ../src/ui/LuaAlign.cpp; sourceTree = "<group>"; };
-		521EDB9A1C00D3A20092B2E9 /* LuaAnimation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaAnimation.cpp; path = ../src/ui/LuaAnimation.cpp; sourceTree = "<group>"; };
-		521EDB9B1C00D3A20092B2E9 /* LuaBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaBackground.cpp; path = ../src/ui/LuaBackground.cpp; sourceTree = "<group>"; };
-		521EDB9C1C00D3A20092B2E9 /* LuaBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaBox.cpp; path = ../src/ui/LuaBox.cpp; sourceTree = "<group>"; };
-		521EDB9D1C00D3A20092B2E9 /* LuaButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaButton.cpp; path = ../src/ui/LuaButton.cpp; sourceTree = "<group>"; };
-		521EDB9E1C00D3A20092B2E9 /* LuaCheckBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaCheckBox.cpp; path = ../src/ui/LuaCheckBox.cpp; sourceTree = "<group>"; };
-		521EDB9F1C00D3A20092B2E9 /* LuaColorBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaColorBackground.cpp; path = ../src/ui/LuaColorBackground.cpp; sourceTree = "<group>"; };
-		521EDBA01C00D3A20092B2E9 /* LuaContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaContainer.cpp; path = ../src/ui/LuaContainer.cpp; sourceTree = "<group>"; };
-		521EDBA11C00D3A20092B2E9 /* LuaContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaContext.cpp; path = ../src/ui/LuaContext.cpp; sourceTree = "<group>"; };
-		521EDBA21C00D3A20092B2E9 /* LuaDropDown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaDropDown.cpp; path = ../src/ui/LuaDropDown.cpp; sourceTree = "<group>"; };
-		521EDBA31C00D3A20092B2E9 /* LuaExpand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaExpand.cpp; path = ../src/ui/LuaExpand.cpp; sourceTree = "<group>"; };
-		521EDBA41C00D3A20092B2E9 /* LuaGauge.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaGauge.cpp; path = ../src/ui/LuaGauge.cpp; sourceTree = "<group>"; };
-		521EDBA51C00D3A20092B2E9 /* LuaGradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaGradient.cpp; path = ../src/ui/LuaGradient.cpp; sourceTree = "<group>"; };
-		521EDBA61C00D3A20092B2E9 /* LuaGrid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaGrid.cpp; path = ../src/ui/LuaGrid.cpp; sourceTree = "<group>"; };
-		521EDBA71C00D3A20092B2E9 /* LuaIcon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaIcon.cpp; path = ../src/ui/LuaIcon.cpp; sourceTree = "<group>"; };
-		521EDBA81C00D3A20092B2E9 /* LuaImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaImage.cpp; path = ../src/ui/LuaImage.cpp; sourceTree = "<group>"; };
-		521EDBA91C00D3A20092B2E9 /* LuaLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaLabel.cpp; path = ../src/ui/LuaLabel.cpp; sourceTree = "<group>"; };
-		521EDBAA1C00D3A20092B2E9 /* LuaLayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaLayer.cpp; path = ../src/ui/LuaLayer.cpp; sourceTree = "<group>"; };
-		521EDBAB1C00D3A20092B2E9 /* LuaList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaList.cpp; path = ../src/ui/LuaList.cpp; sourceTree = "<group>"; };
-		521EDBAC1C00D3A20092B2E9 /* LuaMargin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMargin.cpp; path = ../src/ui/LuaMargin.cpp; sourceTree = "<group>"; };
-		521EDBAD1C00D3A20092B2E9 /* LuaMultiLineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMultiLineText.cpp; path = ../src/ui/LuaMultiLineText.cpp; sourceTree = "<group>"; };
-		521EDBAE1C00D3A20092B2E9 /* LuaNumberLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaNumberLabel.cpp; path = ../src/ui/LuaNumberLabel.cpp; sourceTree = "<group>"; };
-		521EDBAF1C00D3A20092B2E9 /* LuaScroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaScroller.cpp; path = ../src/ui/LuaScroller.cpp; sourceTree = "<group>"; };
-		521EDBB01C00D3A20092B2E9 /* LuaSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaSignal.h; path = ../src/ui/LuaSignal.h; sourceTree = "<group>"; };
-		521EDBB11C00D3A20092B2E9 /* LuaSingle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSingle.cpp; path = ../src/ui/LuaSingle.cpp; sourceTree = "<group>"; };
-		521EDBB21C00D3A20092B2E9 /* LuaSlider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSlider.cpp; path = ../src/ui/LuaSlider.cpp; sourceTree = "<group>"; };
-		521EDBB31C00D3A20092B2E9 /* LuaSmallButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSmallButton.cpp; path = ../src/ui/LuaSmallButton.cpp; sourceTree = "<group>"; };
-		521EDBB41C00D3A20092B2E9 /* LuaTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaTable.cpp; path = ../src/ui/LuaTable.cpp; sourceTree = "<group>"; };
-		521EDBB51C00D3A20092B2E9 /* LuaTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaTextEntry.cpp; path = ../src/ui/LuaTextEntry.cpp; sourceTree = "<group>"; };
-		521EDBB61C00D3A20092B2E9 /* LuaWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaWidget.cpp; path = ../src/ui/LuaWidget.cpp; sourceTree = "<group>"; };
-		521EDBB71C00D3A20092B2E9 /* Margin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Margin.cpp; path = ../src/ui/Margin.cpp; sourceTree = "<group>"; };
-		521EDBB81C00D3A20092B2E9 /* Margin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Margin.h; path = ../src/ui/Margin.h; sourceTree = "<group>"; };
-		521EDBB91C00D3A20092B2E9 /* MousePointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MousePointer.h; path = ../src/ui/MousePointer.h; sourceTree = "<group>"; };
-		521EDBBA1C00D3A20092B2E9 /* MultiLineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MultiLineText.cpp; path = ../src/ui/MultiLineText.cpp; sourceTree = "<group>"; };
-		521EDBBB1C00D3A20092B2E9 /* MultiLineText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MultiLineText.h; path = ../src/ui/MultiLineText.h; sourceTree = "<group>"; };
-		521EDBBC1C00D3A20092B2E9 /* NumberLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NumberLabel.cpp; path = ../src/ui/NumberLabel.cpp; sourceTree = "<group>"; };
-		521EDBBD1C00D3A20092B2E9 /* NumberLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NumberLabel.h; path = ../src/ui/NumberLabel.h; sourceTree = "<group>"; };
-		521EDBBE1C00D3A20092B2E9 /* Point.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Point.h; path = ../src/ui/Point.h; sourceTree = "<group>"; };
-		521EDBBF1C00D3A20092B2E9 /* Scroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Scroller.cpp; path = ../src/ui/Scroller.cpp; sourceTree = "<group>"; };
-		521EDBC01C00D3A20092B2E9 /* Scroller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Scroller.h; path = ../src/ui/Scroller.h; sourceTree = "<group>"; };
-		521EDBC11C00D3A20092B2E9 /* Single.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Single.cpp; path = ../src/ui/Single.cpp; sourceTree = "<group>"; };
-		521EDBC21C00D3A20092B2E9 /* Single.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Single.h; path = ../src/ui/Single.h; sourceTree = "<group>"; };
-		521EDBC31C00D3A20092B2E9 /* Skin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Skin.cpp; path = ../src/ui/Skin.cpp; sourceTree = "<group>"; };
-		521EDBC41C00D3A20092B2E9 /* Skin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Skin.h; path = ../src/ui/Skin.h; sourceTree = "<group>"; };
-		521EDBC51C00D3A20092B2E9 /* Slider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Slider.cpp; path = ../src/ui/Slider.cpp; sourceTree = "<group>"; };
-		521EDBC61C00D3A20092B2E9 /* Slider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Slider.h; path = ../src/ui/Slider.h; sourceTree = "<group>"; };
-		521EDBC71C00D3A20092B2E9 /* SmallButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SmallButton.cpp; path = ../src/ui/SmallButton.cpp; sourceTree = "<group>"; };
-		521EDBC81C00D3A20092B2E9 /* SmallButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SmallButton.h; path = ../src/ui/SmallButton.h; sourceTree = "<group>"; };
-		521EDBC91C00D3A20092B2E9 /* Table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Table.cpp; path = ../src/ui/Table.cpp; sourceTree = "<group>"; };
-		521EDBCA1C00D3A20092B2E9 /* Table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Table.h; path = ../src/ui/Table.h; sourceTree = "<group>"; };
-		521EDBCB1C00D3A20092B2E9 /* TextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextEntry.cpp; path = ../src/ui/TextEntry.cpp; sourceTree = "<group>"; };
-		521EDBCC1C00D3A20092B2E9 /* TextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextEntry.h; path = ../src/ui/TextEntry.h; sourceTree = "<group>"; };
-		521EDBCD1C00D3A20092B2E9 /* TextLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextLayout.cpp; path = ../src/ui/TextLayout.cpp; sourceTree = "<group>"; };
-		521EDBCE1C00D3A20092B2E9 /* TextLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextLayout.h; path = ../src/ui/TextLayout.h; sourceTree = "<group>"; };
-		521EDBCF1C00D3A20092B2E9 /* Widget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Widget.cpp; path = ../src/ui/Widget.cpp; sourceTree = "<group>"; };
-		521EDBD01C00D3A20092B2E9 /* Widget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Widget.h; path = ../src/ui/Widget.h; sourceTree = "<group>"; };
-		521EDBD11C00D3A20092B2E9 /* WidgetSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WidgetSet.h; path = ../src/ui/WidgetSet.h; sourceTree = "<group>"; };
-		521EDBD21C00D3A20092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/ui/Makefile.am; sourceTree = "<group>"; };
-		521EDC2A1C00D4720092B2E9 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = ../../../../../System/Library/Frameworks/OpenGL.framework; sourceTree = "<group>"; };
-		521EDC2C1C00D7950092B2E9 /* libGLEW.1.13.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libGLEW.1.13.0.dylib; path = ../../../../../opt/local/lib/libGLEW.1.13.0.dylib; sourceTree = "<group>"; };
-		521EDC2E1C00D7F40092B2E9 /* libjpeg.9.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjpeg.9.dylib; path = ../../../../../opt/local/lib/libjpeg.9.dylib; sourceTree = "<group>"; };
-		521EDC301C00D8AB0092B2E9 /* libpng16.16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpng16.16.dylib; path = ../../../../../opt/local/lib/libpng16.16.dylib; sourceTree = "<group>"; };
-		521EDC321C00D8CA0092B2E9 /* libtiff.5.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libtiff.5.dylib; path = ../../../../../opt/local/lib/libtiff.5.dylib; sourceTree = "<group>"; };
-		521EDC331C00D8CA0092B2E9 /* libz.1.2.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.2.8.dylib; path = ../../../../../opt/local/lib/libz.1.2.8.dylib; sourceTree = "<group>"; };
-		52C6DBF71C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2_image-2.0.0.dylib"; path = "/opt/local/lib/libSDL2_image-2.0.0.dylib"; sourceTree = "<absolute>"; };
-		52C6DBF81C0250CC00B6CB63 /* libSDL2-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2-2.0.0.dylib"; path = "/opt/local/lib/libSDL2-2.0.0.dylib"; sourceTree = "<absolute>"; };
-		52D125931C0351FB00E6E4C2 /* json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = json.h; sourceTree = "<group>"; };
-		52D125941C0351FB00E6E4C2 /* jsoncpp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsoncpp.cpp; sourceTree = "<group>"; };
-		52D125951C0351FB00E6E4C2 /* JsonUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JsonUtils.cpp; sourceTree = "<group>"; };
-		52D125961C0351FB00E6E4C2 /* JsonUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JsonUtils.h; sourceTree = "<group>"; };
-		52D125971C0351FB00E6E4C2 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		52D125DF1C0351FB00E6E4C2 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		52D125E01C0351FB00E6E4C2 /* PicoDDS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PicoDDS.cpp; sourceTree = "<group>"; };
-		52D125E11C0351FB00E6E4C2 /* PicoDDS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PicoDDS.h; sourceTree = "<group>"; };
-		52D1261B1C03538F00E6E4C2 /* lapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lapi.c; sourceTree = "<group>"; };
-		52D1261C1C03538F00E6E4C2 /* lapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lapi.h; sourceTree = "<group>"; };
-		52D1261D1C03538F00E6E4C2 /* lauxlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lauxlib.c; sourceTree = "<group>"; };
-		52D1261E1C03538F00E6E4C2 /* lauxlib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lauxlib.h; sourceTree = "<group>"; };
-		52D1261F1C03538F00E6E4C2 /* lbaselib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lbaselib.c; sourceTree = "<group>"; };
-		52D126201C03538F00E6E4C2 /* lbitlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lbitlib.c; sourceTree = "<group>"; };
-		52D126211C03538F00E6E4C2 /* lcode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcode.c; sourceTree = "<group>"; };
-		52D126221C03538F00E6E4C2 /* lcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcode.h; sourceTree = "<group>"; };
-		52D126231C03538F00E6E4C2 /* lcorolib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcorolib.c; sourceTree = "<group>"; };
-		52D126241C03538F00E6E4C2 /* lctype.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lctype.c; sourceTree = "<group>"; };
-		52D126251C03538F00E6E4C2 /* lctype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lctype.h; sourceTree = "<group>"; };
-		52D126261C03538F00E6E4C2 /* ldblib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldblib.c; sourceTree = "<group>"; };
-		52D126271C03538F00E6E4C2 /* ldebug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldebug.c; sourceTree = "<group>"; };
-		52D126281C03538F00E6E4C2 /* ldebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ldebug.h; sourceTree = "<group>"; };
-		52D126291C03538F00E6E4C2 /* ldo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldo.c; sourceTree = "<group>"; };
-		52D1262A1C03538F00E6E4C2 /* ldo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ldo.h; sourceTree = "<group>"; };
-		52D1262B1C03538F00E6E4C2 /* ldump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldump.c; sourceTree = "<group>"; };
-		52D1262C1C03538F00E6E4C2 /* lfunc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lfunc.c; sourceTree = "<group>"; };
-		52D1262D1C03538F00E6E4C2 /* lfunc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lfunc.h; sourceTree = "<group>"; };
-		52D1262E1C03538F00E6E4C2 /* lgc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lgc.c; sourceTree = "<group>"; };
-		52D1262F1C03538F00E6E4C2 /* lgc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lgc.h; sourceTree = "<group>"; };
-		52D126301C03538F00E6E4C2 /* linit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = linit.c; sourceTree = "<group>"; };
-		52D126311C03538F00E6E4C2 /* liolib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = liolib.c; sourceTree = "<group>"; };
-		52D126321C03538F00E6E4C2 /* llex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = llex.c; sourceTree = "<group>"; };
-		52D126331C03538F00E6E4C2 /* llex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llex.h; sourceTree = "<group>"; };
-		52D126341C03538F00E6E4C2 /* llimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llimits.h; sourceTree = "<group>"; };
-		52D126351C03538F00E6E4C2 /* lmathlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lmathlib.c; sourceTree = "<group>"; };
-		52D126361C03538F00E6E4C2 /* lmem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lmem.c; sourceTree = "<group>"; };
-		52D126371C03538F00E6E4C2 /* lmem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lmem.h; sourceTree = "<group>"; };
-		52D126381C03538F00E6E4C2 /* loadlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loadlib.c; sourceTree = "<group>"; };
-		52D126391C03538F00E6E4C2 /* lobject.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lobject.c; sourceTree = "<group>"; };
-		52D1263A1C03538F00E6E4C2 /* lobject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lobject.h; sourceTree = "<group>"; };
-		52D1263B1C03538F00E6E4C2 /* lopcodes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lopcodes.c; sourceTree = "<group>"; };
-		52D1263C1C03538F00E6E4C2 /* lopcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lopcodes.h; sourceTree = "<group>"; };
-		52D1263D1C03538F00E6E4C2 /* loslib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loslib.c; sourceTree = "<group>"; };
-		52D1263E1C03538F00E6E4C2 /* lparser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lparser.c; sourceTree = "<group>"; };
-		52D1263F1C03538F00E6E4C2 /* lparser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lparser.h; sourceTree = "<group>"; };
-		52D126401C03538F00E6E4C2 /* lstate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstate.c; sourceTree = "<group>"; };
-		52D126411C03538F00E6E4C2 /* lstate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstate.h; sourceTree = "<group>"; };
-		52D126421C03538F00E6E4C2 /* lstring.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstring.c; sourceTree = "<group>"; };
-		52D126431C03538F00E6E4C2 /* lstring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstring.h; sourceTree = "<group>"; };
-		52D126441C03538F00E6E4C2 /* lstrlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstrlib.c; sourceTree = "<group>"; };
-		52D126451C03538F00E6E4C2 /* ltable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltable.c; sourceTree = "<group>"; };
-		52D126461C03538F00E6E4C2 /* ltable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ltable.h; sourceTree = "<group>"; };
-		52D126471C03538F00E6E4C2 /* ltablib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltablib.c; sourceTree = "<group>"; };
-		52D126481C03538F00E6E4C2 /* ltm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltm.c; sourceTree = "<group>"; };
-		52D126491C03538F00E6E4C2 /* ltm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ltm.h; sourceTree = "<group>"; };
-		52D1264B1C03538F00E6E4C2 /* lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lua.h; sourceTree = "<group>"; };
-		52D1264C1C03538F00E6E4C2 /* lua.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lua.hpp; sourceTree = "<group>"; };
-		52D1264E1C03538F00E6E4C2 /* luaconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = luaconf.h; sourceTree = "<group>"; };
-		52D1264F1C03538F00E6E4C2 /* lualib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lualib.h; sourceTree = "<group>"; };
-		52D126501C03538F00E6E4C2 /* lundump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lundump.c; sourceTree = "<group>"; };
-		52D126511C03538F00E6E4C2 /* lundump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lundump.h; sourceTree = "<group>"; };
-		52D126521C03538F00E6E4C2 /* lvm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lvm.c; sourceTree = "<group>"; };
-		52D126531C03538F00E6E4C2 /* lvm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lvm.h; sourceTree = "<group>"; };
-		52D126541C03538F00E6E4C2 /* lzio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lzio.c; sourceTree = "<group>"; };
-		52D126551C03538F00E6E4C2 /* lzio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lzio.h; sourceTree = "<group>"; };
-		52D126561C03538F00E6E4C2 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		52E5FADB1C0356F2001F4F89 /* libcurl.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcurl.dylib; path = ../../../../../usr/lib/libcurl.dylib; sourceTree = "<group>"; };
-		52E5FADE1C03589F001F4F89 /* lookup3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lookup3.c; sourceTree = "<group>"; };
-		52E5FADF1C03589F001F4F89 /* lookup3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lookup3.h; sourceTree = "<group>"; };
-		52E5FAE01C03589F001F4F89 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		52E5FAF21C0375F2001F4F89 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
-		52E5FAF31C0375F2001F4F89 /* miniz.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = miniz.h; sourceTree = "<group>"; };
-		52E5FAF41C0375F2001F4F89 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
+		4ACE132C16B4B19D00CAE524 /* EnumStrings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EnumStrings.cpp; sourceTree = "<group>"; };
+		4ACE132D16B4B19D00CAE524 /* EnumStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumStrings.h; sourceTree = "<group>"; };
+		4ACE132E16B4B19D00CAE524 /* matrix3x3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = matrix3x3.h; sourceTree = "<group>"; };
+		4ACED56816BBCC7200E53808 /* LuaMissile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMissile.cpp; sourceTree = "<group>"; };
+		4ACED56916BBCC7200E53808 /* LuaMissile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaMissile.h; sourceTree = "<group>"; };
+		4ADB0D0615C50DD900AE2123 /* TerrainHeightAsteroid2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightAsteroid2.cpp; sourceTree = "<group>"; };
+		4ADB0D0715C50DD900AE2123 /* TerrainHeightAsteroid3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightAsteroid3.cpp; sourceTree = "<group>"; };
+		4ADB0D0815C50DD900AE2123 /* TerrainHeightAsteroid4.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightAsteroid4.cpp; sourceTree = "<group>"; };
+		4ADB0D0915C50DD900AE2123 /* TerrainHeightBarrenRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightBarrenRock.cpp; sourceTree = "<group>"; };
+		4ADB0D0A15C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightBarrenRock2.cpp; sourceTree = "<group>"; };
+		4ADB0D0B15C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightBarrenRock3.cpp; sourceTree = "<group>"; };
+		4ADB0D1315C50DF000AE2123 /* FileSystemPosix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystemPosix.cpp; sourceTree = "<group>"; };
+		4ADB0D1515C50DF000AE2123 /* OSPosix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OSPosix.cpp; sourceTree = "<group>"; };
+		4ADC7B7F152C703200E359B5 /* SDLWrappers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SDLWrappers.cpp; sourceTree = "<group>"; };
+		4ADC7B80152C703200E359B5 /* SDLWrappers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLWrappers.h; sourceTree = "<group>"; };
+		4ADC7B81152C703200E359B5 /* View.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = View.cpp; sourceTree = "<group>"; };
+		4ADF51801557473400ACF5A0 /* CustomSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CustomSystem.cpp; sourceTree = "<group>"; };
+		4ADF51811557473400ACF5A0 /* CustomSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomSystem.h; sourceTree = "<group>"; };
+		4ADF51821557473400ACF5A0 /* Galaxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Galaxy.cpp; sourceTree = "<group>"; };
+		4ADF51831557473400ACF5A0 /* Galaxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Galaxy.h; sourceTree = "<group>"; };
+		4ADF51851557473400ACF5A0 /* Sector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sector.cpp; sourceTree = "<group>"; };
+		4ADF51861557473400ACF5A0 /* Sector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sector.h; sourceTree = "<group>"; };
+		4ADF51871557473400ACF5A0 /* StarSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StarSystem.cpp; sourceTree = "<group>"; };
+		4ADF51881557473400ACF5A0 /* StarSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StarSystem.h; sourceTree = "<group>"; };
+		4ADF51891557473400ACF5A0 /* SystemPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemPath.h; sourceTree = "<group>"; };
+		4ADF518F1557477400ACF5A0 /* LuaFixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFixed.cpp; sourceTree = "<group>"; };
+		4ADF51901557477400ACF5A0 /* LuaFixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaFixed.h; sourceTree = "<group>"; };
+		4ADF51911557477400ACF5A0 /* LuaMatrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMatrix.cpp; sourceTree = "<group>"; };
+		4ADF51921557477400ACF5A0 /* LuaMatrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaMatrix.h; sourceTree = "<group>"; };
+		4ADF51931557477400ACF5A0 /* LuaSystemBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSystemBody.cpp; sourceTree = "<group>"; };
+		4ADF51951557477400ACF5A0 /* LuaVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaVector.cpp; sourceTree = "<group>"; };
+		4ADF51961557477400ACF5A0 /* LuaVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaVector.h; sourceTree = "<group>"; };
+		4AE46C491607513400308C22 /* vcacheopt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vcacheopt.h; sourceTree = "<group>"; };
+		4AE9706514369D7500424F91 /* LuaLang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaLang.cpp; sourceTree = "<group>"; };
+		4AE9706614369D7500424F91 /* LuaLang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaLang.h; sourceTree = "<group>"; };
+		4AEC8A1815C7886A00B281C3 /* Light.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Light.cpp; sourceTree = "<group>"; };
+		4AEC8A1915C7886A00B281C3 /* Light.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Light.h; sourceTree = "<group>"; };
+		4AED721C14E1501D004D171E /* TerrainHeightMapped2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMapped2.cpp; sourceTree = "<group>"; };
+		4AEE56DB16A44CD800AA1C53 /* SpaceStationType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpaceStationType.cpp; sourceTree = "<group>"; };
+		4AEE56DC16A44CD800AA1C53 /* SpaceStationType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpaceStationType.h; sourceTree = "<group>"; };
+		4AF0058915F0F30400CC19C0 /* LuaEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaEvent.cpp; sourceTree = "<group>"; };
+		4AF0058A15F0F30400CC19C0 /* LuaEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaEvent.h; sourceTree = "<group>"; };
+		4AF0059115F17C6700CC19C0 /* LuaFileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFileSystem.cpp; sourceTree = "<group>"; };
+		4AF0059215F17C6700CC19C0 /* LuaFileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaFileSystem.h; sourceTree = "<group>"; };
+		4AF222DF162103EA00BED38E /* Cutscene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Cutscene.h; sourceTree = "<group>"; };
+		4AF222E0162103EA00BED38E /* Factions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Factions.cpp; sourceTree = "<group>"; };
+		4AF222E1162103EA00BED38E /* Factions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Factions.h; sourceTree = "<group>"; };
+		4AF222E2162103EA00BED38E /* Intro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Intro.cpp; sourceTree = "<group>"; };
+		4AF222E3162103EA00BED38E /* Intro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Intro.h; sourceTree = "<group>"; };
+		4AF222E4162103EA00BED38E /* KeyBindings.inc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyBindings.inc.h; sourceTree = "<group>"; };
+		4AF222E5162103EA00BED38E /* Tombstone.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Tombstone.cpp; sourceTree = "<group>"; };
+		4AF222E6162103EA00BED38E /* Tombstone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Tombstone.h; sourceTree = "<group>"; };
+		4AF9999D1496D51F009821AF /* Game.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Game.cpp; sourceTree = "<group>"; };
+		4AF9999E1496D51F009821AF /* Game.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Game.h; sourceTree = "<group>"; };
+		4AF999A11496D51F009821AF /* MathUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MathUtil.cpp; sourceTree = "<group>"; };
+		4AF999A21496D51F009821AF /* MathUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MathUtil.h; sourceTree = "<group>"; };
+		4AFBD7B71641265D002928CB /* PngWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PngWriter.cpp; sourceTree = "<group>"; };
+		4AFBD7B81641265D002928CB /* PngWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PngWriter.h; sourceTree = "<group>"; };
+		4AFBD7BA16412676002928CB /* LuaTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaTextEntry.cpp; sourceTree = "<group>"; };
+		4AFBD7BB16412676002928CB /* TextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextEntry.cpp; sourceTree = "<group>"; };
+		4AFBD7BC16412676002928CB /* TextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextEntry.h; sourceTree = "<group>"; };
+		52025F6E1C05B63E00254BB5 /* libcurl.4.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcurl.4.dylib; path = /opt/local/lib/libcurl.4.dylib; sourceTree = "<absolute>"; };
+		52025F721C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2_image-2.0.0.dylib"; path = "../../../../../opt/local/lib/libSDL2_image-2.0.0.dylib"; sourceTree = "<group>"; };
+		52025F731C05B74B00254BB5 /* libSDL2-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2-2.0.0.dylib"; path = "../../../../../opt/local/lib/libSDL2-2.0.0.dylib"; sourceTree = "<group>"; };
+		52025F781C05BA7100254BB5 /* CollMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollMesh.cpp; sourceTree = "<group>"; };
+		52025F7A1C05BBAC00254BB5 /* libvorbis.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbis.0.dylib; path = ../../../../../opt/local/lib/libvorbis.0.dylib; sourceTree = "<group>"; };
+		52025F7E1C05BD3400254BB5 /* libvorbisfile.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbisfile.3.dylib; path = ../../../../../opt/local/lib/libvorbisfile.3.dylib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1351,40 +1271,260 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52D125751C033A5100E6E4C2 /* libSDL2_image-2.0.0.dylib in Frameworks */,
-				52D125741C033A4200E6E4C2 /* libSDL2-2.0.0.dylib in Frameworks */,
+				37074B911B1C653D00AFE2CE /* libbz2.1.0.6.dylib in Frameworks */,
+				52025F7C1C05BBAC00254BB5 /* libvorbis.0.dylib in Frameworks */,
+				37074B921B1C653D00AFE2CE /* libpng16.16.dylib in Frameworks */,
+				37074B931B1C653D00AFE2CE /* libz.1.2.8.dylib in Frameworks */,
+				52025F751C05B74B00254BB5 /* libSDL2-2.0.0.dylib in Frameworks */,
+				52025F6F1C05B63E00254BB5 /* libcurl.4.dylib in Frameworks */,
+				3701C5861B1ABDA2000F4A72 /* libfreetype.6.dylib in Frameworks */,
+				378563521B19769A0039F2BC /* OpenGL.framework in Frameworks */,
+				52025F741C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib in Frameworks */,
+				52025F7F1C05BD3400254BB5 /* libvorbisfile.3.dylib in Frameworks */,
 				4ACDB6D416787A6A0069FA03 /* libassimp.3.0.0.dylib in Frameworks */,
-				521EDC351C00D8CA0092B2E9 /* libz.1.2.8.dylib in Frameworks */,
-				52E5FADC1C0356F2001F4F89 /* libcurl.dylib in Frameworks */,
 				4A20B0E3135319770020F43E /* Cocoa.framework in Frameworks */,
-				4A5619D513867033002A904C /* libvorbisfile.3.dylib in Frameworks */,
-				4A5619CF13866622002A904C /* libfreetype.6.dylib in Frameworks */,
 				4A6C4EA2135452FF00FDD53F /* libsigc-2.0.0.dylib in Frameworks */,
-				521EDC2F1C00D7F40092B2E9 /* libjpeg.9.dylib in Frameworks */,
-				4AEEBC4A162A4A5700C6EA6F /* libXrandr.2.dylib in Frameworks */,
-				4AEEBC4C162A4ADC00C6EA6F /* libXext.6.dylib in Frameworks */,
-				521EDC2B1C00D4720092B2E9 /* OpenGL.framework in Frameworks */,
-				4AEEBC50162A4B9B00C6EA6F /* libXrender.1.dylib in Frameworks */,
-				4AEEBC55162A4BF700C6EA6F /* libX11.6.dylib in Frameworks */,
-				4AEEBC56162A4BF700C6EA6F /* libXau.6.dylib in Frameworks */,
-				521EDC311C00D8AB0092B2E9 /* libpng16.16.dylib in Frameworks */,
-				4AEEBC57162A4BF700C6EA6F /* libXdmcp.6.dylib in Frameworks */,
-				4AEEBC5C162A4C7800C6EA6F /* libxcb.1.dylib in Frameworks */,
-				4AEEBC5F162A4F5B00C6EA6F /* libbz2.1.0.6.dylib in Frameworks */,
-				521EDC341C00D8CA0092B2E9 /* libtiff.5.dylib in Frameworks */,
-				521EDC2D1C00D7950092B2E9 /* libGLEW.1.13.0.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		378563571B197CF90039F2BC /* json */ = {
+			isa = PBXGroup;
+			children = (
+				378563581B197CF90039F2BC /* JsonUtils.cpp */,
+				378563591B197CF90039F2BC /* JsonUtils.h */,
+				3785635B1B197CF90039F2BC /* json.h */,
+				3785635C1B197CF90039F2BC /* jsoncpp.cpp */,
+			);
+			path = json;
+			sourceTree = "<group>";
+		};
+		378563D51B197E600039F2BC /* dummy */ = {
+			isa = PBXGroup;
+			children = (
+				378563D71B197E600039F2BC /* MaterialDummy.h */,
+				378563D81B197E600039F2BC /* RenderStateDummy.h */,
+				378563D91B197E600039F2BC /* RenderTargetDummy.h */,
+				378563DA1B197E600039F2BC /* RendererDummy.cpp */,
+				378563DB1B197E600039F2BC /* RendererDummy.h */,
+				378563DC1B197E600039F2BC /* TextureDummy.h */,
+				378563DD1B197E600039F2BC /* VertexBufferDummy.h */,
+			);
+			path = dummy;
+			sourceTree = "<group>";
+		};
+		378563DE1B197E600039F2BC /* opengl */ = {
+			isa = PBXGroup;
+			children = (
+				378563DF1B197E600039F2BC /* FresnelColourMaterial.cpp */,
+				378563E01B197E600039F2BC /* FresnelColourMaterial.h */,
+				378563E11B197E600039F2BC /* GLDebug.h */,
+				378563E21B197E600039F2BC /* GasGiantMaterial.cpp */,
+				378563E31B197E600039F2BC /* GasGiantMaterial.h */,
+				378563E41B197E600039F2BC /* GeoSphereMaterial.cpp */,
+				378563E51B197E600039F2BC /* GeoSphereMaterial.h */,
+				378563E91B197E600039F2BC /* MaterialGL.cpp */,
+				378563EA1B197E600039F2BC /* MaterialGL.h */,
+				378563EB1B197E600039F2BC /* MultiMaterial.cpp */,
+				378563EC1B197E600039F2BC /* MultiMaterial.h */,
+				378563ED1B197E600039F2BC /* Program.cpp */,
+				378563EE1B197E600039F2BC /* Program.h */,
+				378563EF1B197E600039F2BC /* RenderStateGL.cpp */,
+				378563F01B197E600039F2BC /* RenderStateGL.h */,
+				378563F11B197E600039F2BC /* RenderTargetGL.cpp */,
+				378563F21B197E600039F2BC /* RenderTargetGL.h */,
+				378563F31B197E600039F2BC /* RendererGL.cpp */,
+				378563F41B197E600039F2BC /* RendererGL.h */,
+				378563F51B197E600039F2BC /* RingMaterial.cpp */,
+				378563F61B197E600039F2BC /* RingMaterial.h */,
+				378563F71B197E600039F2BC /* ShieldMaterial.cpp */,
+				378563F81B197E600039F2BC /* ShieldMaterial.h */,
+				378563F91B197E600039F2BC /* SkyboxMaterial.h */,
+				378563FA1B197E600039F2BC /* SphereImpostorMaterial.h */,
+				378563FB1B197E600039F2BC /* StarfieldMaterial.h */,
+				378563FC1B197E600039F2BC /* TextureGL.cpp */,
+				378563FD1B197E600039F2BC /* TextureGL.h */,
+				378563FE1B197E600039F2BC /* UIMaterial.cpp */,
+				378563FF1B197E600039F2BC /* UIMaterial.h */,
+				378564001B197E600039F2BC /* Uniform.cpp */,
+				378564011B197E600039F2BC /* Uniform.h */,
+				378564021B197E600039F2BC /* VertexBufferGL.cpp */,
+				378564031B197E600039F2BC /* VertexBufferGL.h */,
+				378564041B197E600039F2BC /* VtxColorMaterial.cpp */,
+				378564051B197E600039F2BC /* VtxColorMaterial.h */,
+				378564061B197E600039F2BC /* gl_core_3_x.c */,
+				378564071B197E600039F2BC /* gl_core_3_x.h */,
+			);
+			path = opengl;
+			sourceTree = "<group>";
+		};
+		378564411B197EB50039F2BC /* PicoDDS */ = {
+			isa = PBXGroup;
+			children = (
+				378564431B197EB60039F2BC /* PicoDDS.cpp */,
+				378564441B197EB60039F2BC /* PicoDDS.h */,
+			);
+			path = PicoDDS;
+			sourceTree = "<group>";
+		};
+		378564451B197EB60039F2BC /* profiler */ = {
+			isa = PBXGroup;
+			children = (
+				378564471B197EB60039F2BC /* Profiler.cpp */,
+				378564481B197EB60039F2BC /* Profiler.h */,
+			);
+			path = profiler;
+			sourceTree = "<group>";
+		};
+		4A19030B138AA33300E0229C /* gui */ = {
+			isa = PBXGroup;
+			children = (
+				4A9174F215187B69006A15A9 /* GuiTexturedQuad.cpp */,
+				4A9174F315187B69006A15A9 /* GuiTexturedQuad.h */,
+				4A190325138AA33300E0229C /* Gui.cpp */,
+				4A190326138AA33300E0229C /* Gui.h */,
+				4A190328138AA33300E0229C /* GuiAdjustment.h */,
+				4A190329138AA33300E0229C /* GuiBox.cpp */,
+				4A19032A138AA33300E0229C /* GuiBox.h */,
+				4A19032C138AA33300E0229C /* GuiButton.cpp */,
+				4A19032D138AA33300E0229C /* GuiButton.h */,
+				4A19032F138AA33300E0229C /* GuiContainer.cpp */,
+				4A190330138AA33300E0229C /* GuiContainer.h */,
+				4A190332138AA33300E0229C /* GuiEvents.h */,
+				4A190333138AA33300E0229C /* GuiFixed.cpp */,
+				4A190334138AA33300E0229C /* GuiFixed.h */,
+				4A190336138AA33300E0229C /* GuiImage.cpp */,
+				4A190337138AA33300E0229C /* GuiImage.h */,
+				4A190339138AA33300E0229C /* GuiImageButton.cpp */,
+				4A19033A138AA33300E0229C /* GuiImageButton.h */,
+				4A19033C138AA33300E0229C /* GuiImageRadioButton.cpp */,
+				4A19033D138AA33300E0229C /* GuiImageRadioButton.h */,
+				4A19033F138AA33300E0229C /* GuiISelectable.h */,
+				4A190340138AA33300E0229C /* GuiLabel.cpp */,
+				4A190341138AA33300E0229C /* GuiLabel.h */,
+				4A190343138AA33300E0229C /* GuiLabelSet.cpp */,
+				4A190344138AA33300E0229C /* GuiLabelSet.h */,
+				4A190346138AA33300E0229C /* GuiMeterBar.cpp */,
+				4A190347138AA33300E0229C /* GuiMeterBar.h */,
+				4A190349138AA33300E0229C /* GuiMultiStateImageButton.cpp */,
+				4A19034A138AA33300E0229C /* GuiMultiStateImageButton.h */,
+				4A19034C138AA33300E0229C /* GuiRadioButton.cpp */,
+				4A19034D138AA33300E0229C /* GuiRadioButton.h */,
+				4A19034F138AA33300E0229C /* GuiRadioGroup.cpp */,
+				4A190350138AA33300E0229C /* GuiRadioGroup.h */,
+				4A190355138AA33300E0229C /* GuiScreen.cpp */,
+				4A190356138AA33300E0229C /* GuiScreen.h */,
+				4A24078213F524E6002A5C12 /* GuiStack.cpp */,
+				4A24078313F524E6002A5C12 /* GuiStack.h */,
+				4A190358138AA33300E0229C /* GuiTabbed.cpp */,
+				4A190359138AA33300E0229C /* GuiTabbed.h */,
+				4A19035B138AA33300E0229C /* GuiTextEntry.cpp */,
+				4A19035C138AA33300E0229C /* GuiTextEntry.h */,
+				4A19035E138AA33300E0229C /* GuiTextLayout.cpp */,
+				4A19035F138AA33300E0229C /* GuiTextLayout.h */,
+				4A190361138AA33300E0229C /* GuiToggleButton.cpp */,
+				4A190362138AA33300E0229C /* GuiToggleButton.h */,
+				4A190364138AA33300E0229C /* GuiToolTip.cpp */,
+				4A190365138AA33300E0229C /* GuiToolTip.h */,
+				4A190367138AA33300E0229C /* GuiVScrollBar.cpp */,
+				4A190368138AA33300E0229C /* GuiVScrollBar.h */,
+				4A19036A138AA33300E0229C /* GuiVScrollPortal.cpp */,
+				4A19036B138AA33300E0229C /* GuiVScrollPortal.h */,
+				4A19036D138AA33300E0229C /* GuiWidget.cpp */,
+				4A19036E138AA33300E0229C /* GuiWidget.h */,
+			);
+			path = gui;
+			sourceTree = "<group>";
+		};
+		4A1903C1138AA39C00E0229C /* contrib */ = {
+			isa = PBXGroup;
+			children = (
+				378564411B197EB50039F2BC /* PicoDDS */,
+				378564451B197EB60039F2BC /* profiler */,
+				378563571B197CF90039F2BC /* json */,
+				4A37073215A879D100E7E5F6 /* jenkins */,
+				4A1903C2138AA39C00E0229C /* lua */,
+				4AAC9FDC15458FE400116131 /* miniz */,
+				4AE46C471607513400308C22 /* vcacheopt */,
+			);
+			name = contrib;
+			path = ../contrib;
+			sourceTree = "<group>";
+		};
+		4A1903C2138AA39C00E0229C /* lua */ = {
+			isa = PBXGroup;
+			children = (
+				4A59B4D51557EAF5009926E5 /* lbitlib.c */,
+				4A59B4D61557EAF5009926E5 /* lcorolib.c */,
+				4A59B4D71557EAF5009926E5 /* lctype.c */,
+				4A59B4D81557EAF5009926E5 /* lctype.h */,
+				4A59B4D91557EAF5009926E5 /* lua.hpp */,
+				4A1903E2138AA39C00E0229C /* lapi.c */,
+				4A1903E3138AA39C00E0229C /* lapi.h */,
+				4A1903E5138AA39C00E0229C /* lauxlib.c */,
+				4A1903E6138AA39C00E0229C /* lauxlib.h */,
+				4A1903E8138AA39C00E0229C /* lbaselib.c */,
+				4A1903EA138AA39C00E0229C /* lcode.c */,
+				4A1903EB138AA39C00E0229C /* lcode.h */,
+				4A1903ED138AA39C00E0229C /* ldblib.c */,
+				4A1903EF138AA39C00E0229C /* ldebug.c */,
+				4A1903F0138AA39C00E0229C /* ldebug.h */,
+				4A1903F2138AA39C00E0229C /* ldo.c */,
+				4A1903F3138AA39C00E0229C /* ldo.h */,
+				4A1903F5138AA39C00E0229C /* ldump.c */,
+				4A1903F7138AA39C00E0229C /* lfunc.c */,
+				4A1903F8138AA39C00E0229C /* lfunc.h */,
+				4A1903FA138AA39C00E0229C /* lgc.c */,
+				4A1903FB138AA39C00E0229C /* lgc.h */,
+				4A1903FE138AA39C00E0229C /* linit.c */,
+				4A190400138AA39C00E0229C /* liolib.c */,
+				4A190402138AA39C00E0229C /* llex.c */,
+				4A190403138AA39C00E0229C /* llex.h */,
+				4A190405138AA39C00E0229C /* llimits.h */,
+				4A190406138AA39C00E0229C /* lmathlib.c */,
+				4A190408138AA39C00E0229C /* lmem.c */,
+				4A190409138AA39C00E0229C /* lmem.h */,
+				4A19040B138AA39C00E0229C /* loadlib.c */,
+				4A19040D138AA39C00E0229C /* lobject.c */,
+				4A19040E138AA39C00E0229C /* lobject.h */,
+				4A190410138AA39C00E0229C /* lopcodes.c */,
+				4A190411138AA39C00E0229C /* lopcodes.h */,
+				4A190413138AA39C00E0229C /* loslib.c */,
+				4A190415138AA39C00E0229C /* lparser.c */,
+				4A190416138AA39C00E0229C /* lparser.h */,
+				4A190418138AA39C00E0229C /* lstate.c */,
+				4A190419138AA39C00E0229C /* lstate.h */,
+				4A19041B138AA39C00E0229C /* lstring.c */,
+				4A19041C138AA39C00E0229C /* lstring.h */,
+				4A19041E138AA39C00E0229C /* lstrlib.c */,
+				4A190420138AA39C00E0229C /* ltable.c */,
+				4A190421138AA39C00E0229C /* ltable.h */,
+				4A190423138AA39C00E0229C /* ltablib.c */,
+				4A190425138AA39C00E0229C /* ltm.c */,
+				4A190426138AA39C00E0229C /* ltm.h */,
+				4A190428138AA39C00E0229C /* lua.c */,
+				4A190429138AA39C00E0229C /* lua.h */,
+				4A19042A138AA39C00E0229C /* luac.c */,
+				4A19042B138AA39C00E0229C /* luaconf.h */,
+				4A19042C138AA39C00E0229C /* lualib.h */,
+				4A19042D138AA39C00E0229C /* lundump.c */,
+				4A19042E138AA39C00E0229C /* lundump.h */,
+				4A190430138AA39C00E0229C /* lvm.c */,
+				4A190431138AA39C00E0229C /* lvm.h */,
+				4A190433138AA39C00E0229C /* lzio.c */,
+				4A190434138AA39C00E0229C /* lzio.h */,
+			);
+			path = lua;
+			sourceTree = "<group>";
+		};
 		4A20B0CE1353194B0020F43E = {
 			isa = PBXGroup;
 			children = (
-				52D1258A1C0351FB00E6E4C2 /* contrib */,
-				521ED7D31C00D1280092B2E9 /* src */,
+				4A1903C1138AA39C00E0229C /* contrib */,
 				4A6C55141354655000FDD53F /* data */,
+				4A6C4B9F13532FC300FDD53F /* src */,
 				4A20B11213531CAF0020F43E /* Cocoa Support Files */,
 				4A20B0E1135319770020F43E /* Frameworks */,
 				4A9822A9142DF91B00B423F1 /* Misc TXT files */,
@@ -1403,14 +1543,11 @@
 		4A20B0E1135319770020F43E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				52E5FADB1C0356F2001F4F89 /* libcurl.dylib */,
-				52C6DBF71C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib */,
-				52C6DBF81C0250CC00B6CB63 /* libSDL2-2.0.0.dylib */,
-				521EDC2C1C00D7950092B2E9 /* libGLEW.1.13.0.dylib */,
-				4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */,
-				4A5619CE13866622002A904C /* libfreetype.6.dylib */,
-				4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */,
-				4A5619D413867033002A904C /* libvorbisfile.3.dylib */,
+				52025F7E1C05BD3400254BB5 /* libvorbisfile.3.dylib */,
+				52025F7A1C05BBAC00254BB5 /* libvorbis.0.dylib */,
+				52025F721C05B74B00254BB5 /* libSDL2_image-2.0.0.dylib */,
+				52025F731C05B74B00254BB5 /* libSDL2-2.0.0.dylib */,
+				52025F6E1C05B63E00254BB5 /* libcurl.4.dylib */,
 				4A20B0E4135319770020F43E /* Other Frameworks */,
 				4A671B851388C04700657F38 /* SubLibraries */,
 			);
@@ -1420,7 +1557,7 @@
 		4A20B0E4135319770020F43E /* Other Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				521EDC2A1C00D4720092B2E9 /* OpenGL.framework */,
+				378563511B19769A0039F2BC /* OpenGL.framework */,
 				4A20B0E2135319770020F43E /* Cocoa.framework */,
 				4A20B0E5135319770020F43E /* AppKit.framework */,
 				4A20B0E6135319770020F43E /* CoreData.framework */,
@@ -1443,29 +1580,393 @@
 			name = "Cocoa Support Files";
 			sourceTree = "<group>";
 		};
+		4A24FD601650F4D100DE7B0F /* gameui */ = {
+			isa = PBXGroup;
+			children = (
+				378564291B197E7A0039F2BC /* BindingCapture.cpp */,
+				3785642A1B197E7A0039F2BC /* BindingCapture.h */,
+				3785642B1B197E7A0039F2BC /* LuaBindingCapture.cpp */,
+				4AA527FB16E9EB650036D4CB /* LuaModelSpinner.cpp */,
+				4AA527FC16E9EB650036D4CB /* ModelSpinner.cpp */,
+				4AA527FD16E9EB650036D4CB /* ModelSpinner.h */,
+				4A4D25D2167335D9003BC9D5 /* Face.cpp */,
+				4A4D25D3167335D9003BC9D5 /* Face.h */,
+				4A24FD611650F4D100DE7B0F /* GameUI.h */,
+				4A24FD621650F4D100DE7B0F /* Lua.cpp */,
+				4A24FD631650F4D100DE7B0F /* Lua.h */,
+				4A4D25D4167335D9003BC9D5 /* LuaFace.cpp */,
+				4A24FD651650F4D100DE7B0F /* Panel.cpp */,
+				4A24FD661650F4D100DE7B0F /* Panel.h */,
+			);
+			path = gameui;
+			sourceTree = "<group>";
+		};
+		4A37073215A879D100E7E5F6 /* jenkins */ = {
+			isa = PBXGroup;
+			children = (
+				4A37073315A879D100E7E5F6 /* lookup3.c */,
+				4A37073415A879D100E7E5F6 /* lookup3.h */,
+			);
+			path = jenkins;
+			sourceTree = "<group>";
+		};
+		4A4F25B814F524D400FD14A6 /* graphics */ = {
+			isa = PBXGroup;
+			children = (
+				378563D51B197E600039F2BC /* dummy */,
+				378563DE1B197E600039F2BC /* opengl */,
+				378564081B197E600039F2BC /* RenderState.h */,
+				378564091B197E600039F2BC /* RenderTarget.h */,
+				3785640A1B197E600039F2BC /* Stats.cpp */,
+				3785640B1B197E600039F2BC /* Stats.h */,
+				3785640C1B197E600039F2BC /* Types.h */,
+				3785640D1B197E600039F2BC /* VertexBuffer.cpp */,
+				3785640E1B197E600039F2BC /* VertexBuffer.h */,
+				3785640F1B197E600039F2BC /* WindowSDL.cpp */,
+				378564101B197E600039F2BC /* WindowSDL.h */,
+				4A4F25B914F524D400FD14A6 /* Drawables.cpp */,
+				4A4F25BA14F524D400FD14A6 /* Drawables.h */,
+				4A4F25BB14F524D400FD14A6 /* Frustum.cpp */,
+				4A4F25BC14F524D400FD14A6 /* Frustum.h */,
+				4A4F25BD14F524D400FD14A6 /* Graphics.cpp */,
+				4A4F25BE14F524D400FD14A6 /* Graphics.h */,
+				4AEC8A1815C7886A00B281C3 /* Light.cpp */,
+				4AEC8A1915C7886A00B281C3 /* Light.h */,
+				4A4F25C014F524D400FD14A6 /* Material.cpp */,
+				4A4F25C114F524D400FD14A6 /* Material.h */,
+				4A4F25C214F524D400FD14A6 /* Renderer.cpp */,
+				4A4F25C314F524D400FD14A6 /* Renderer.h */,
+				4A9174F615187B97006A15A9 /* Texture.h */,
+				4A9174F715187B97006A15A9 /* TextureBuilder.cpp */,
+				4A9174F815187B97006A15A9 /* TextureBuilder.h */,
+				4A4F25D014F524D400FD14A6 /* VertexArray.cpp */,
+				4A4F25D114F524D400FD14A6 /* VertexArray.h */,
+			);
+			path = graphics;
+			sourceTree = "<group>";
+		};
 		4A671B851388C04700657F38 /* SubLibraries */ = {
 			isa = PBXGroup;
 			children = (
-				521EDC321C00D8CA0092B2E9 /* libtiff.5.dylib */,
-				521EDC331C00D8CA0092B2E9 /* libz.1.2.8.dylib */,
-				521EDC301C00D8AB0092B2E9 /* libpng16.16.dylib */,
-				521EDC2E1C00D7F40092B2E9 /* libjpeg.9.dylib */,
-				4AEEBC5E162A4F5B00C6EA6F /* libbz2.1.0.6.dylib */,
-				4A7611281611A90B00A06F79 /* libFLAC.8.dylib */,
-				4A671B9B1388C6B700657F38 /* libmodplug.1.dylib */,
-				4A671B861388C07700657F38 /* libogg.0.dylib */,
-				4A671B981388C61F00657F38 /* libsmpeg-0.4.0.dylib */,
-				4A671BA11388CA3200657F38 /* libspeex.1.5.0.dylib */,
-				4A671B871388C07700657F38 /* libvorbis.0.dylib */,
-				4AEEBC52162A4BF700C6EA6F /* libX11.6.dylib */,
-				4AEEBC53162A4BF700C6EA6F /* libXau.6.dylib */,
-				4AEEBC5B162A4C7800C6EA6F /* libxcb.1.dylib */,
-				4AEEBC54162A4BF700C6EA6F /* libXdmcp.6.dylib */,
-				4AEEBC4B162A4ADC00C6EA6F /* libXext.6.dylib */,
-				4AEEBC49162A4A5700C6EA6F /* libXrandr.2.dylib */,
-				4AEEBC4F162A4B9B00C6EA6F /* libXrender.1.dylib */,
+				37074B8E1B1C653D00AFE2CE /* libbz2.1.0.6.dylib */,
+				37074B8F1B1C653D00AFE2CE /* libpng16.16.dylib */,
+				37074B901B1C653D00AFE2CE /* libz.1.2.8.dylib */,
+				3701C5851B1ABDA2000F4A72 /* libfreetype.6.dylib */,
+				4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */,
+				4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */,
 			);
 			name = SubLibraries;
+			sourceTree = "<group>";
+		};
+		4A6C4B9F13532FC300FDD53F /* src */ = {
+			isa = PBXGroup;
+			children = (
+				4A6C4BFE13532FC300FDD53F /* Aabb.h */,
+				4A6C4BFF13532FC300FDD53F /* AmbientSounds.cpp */,
+				4A6C4C0013532FC300FDD53F /* AmbientSounds.h */,
+				4AAB884A15FE070900AAF8A8 /* AnimationCurves.h */,
+				4A61E15C13978F1000193E43 /* Background.cpp */,
+				4A61E15D13978F1000193E43 /* Background.h */,
+				378563601B197D740039F2BC /* BaseSphere.cpp */,
+				378563611B197D740039F2BC /* BaseSphere.h */,
+				4A6C4C0213532FC300FDD53F /* Body.cpp */,
+				4A6C4C0313532FC300FDD53F /* Body.h */,
+				4A6392C4136BD51E008352F1 /* buildopts.h */,
+				4A305FCB151341170076D414 /* ByteRange.h */,
+				4A84CB82146027DC0051C848 /* Camera.cpp */,
+				4A84CB83146027DC0051C848 /* Camera.h */,
+				4A4A86E716A992D600F81F18 /* CameraController.cpp */,
+				4A4A86E816A992D600F81F18 /* CameraController.h */,
+				4A6C4C0513532FC300FDD53F /* CargoBody.cpp */,
+				4A6C4C0613532FC300FDD53F /* CargoBody.h */,
+				4A6C4C0713532FC300FDD53F /* CityOnPlanet.cpp */,
+				4A6C4C0813532FC300FDD53F /* CityOnPlanet.h */,
+				4A6C4C0913532FC300FDD53F /* collider */,
+				52025F781C05BA7100254BB5 /* CollMesh.cpp */,
+				4ACDB6C7167878CE0069FA03 /* CollMesh.h */,
+				4A9174FD15187C17006A15A9 /* Color.cpp */,
+				4A6C4C1C13532FC300FDD53F /* Color.h */,
+				4A107C2B1525AB0D00EF9FAC /* CRC32.cpp */,
+				4A107C2C1525AB0D00EF9FAC /* CRC32.h */,
+				4AF222DF162103EA00BED38E /* Cutscene.h */,
+				378563621B197D740039F2BC /* DateTime.cpp */,
+				378563631B197D740039F2BC /* DateTime.h */,
+				4A973BF31618688F0029562D /* DeathView.cpp */,
+				4A973BF41618688F0029562D /* DeathView.h */,
+				4A99371A1368355400EA0EE5 /* DeleteEmitter.h */,
+				4A6C4C2113532FC300FDD53F /* DynamicBody.cpp */,
+				4A6C4C2213532FC300FDD53F /* DynamicBody.h */,
+				4AA527F716E9EABA0036D4CB /* Easing.h */,
+				4A84CB7B14595D850051C848 /* enum_table.cpp */,
+				4A84CB7C14595D850051C848 /* enum_table.h */,
+				4ACE132C16B4B19D00CAE524 /* EnumStrings.cpp */,
+				4ACE132D16B4B19D00CAE524 /* EnumStrings.h */,
+				378563641B197D740039F2BC /* FaceParts.cpp */,
+				378563651B197D740039F2BC /* FaceParts.h */,
+				4AF222E0162103EA00BED38E /* Factions.cpp */,
+				4AF222E1162103EA00BED38E /* Factions.h */,
+				4AAC9FE51545901D00116131 /* FileSourceZip.cpp */,
+				4AAC9FE61545901D00116131 /* FileSourceZip.h */,
+				4A305FCC151341170076D414 /* FileSystem.cpp */,
+				4A305FCD151341170076D414 /* FileSystem.h */,
+				4A6C4C2513532FC300FDD53F /* fixed.h */,
+				4A1E9EBE144EEA8A009243D2 /* FloatComparison.h */,
+				4A94CA4114F26875002CA792 /* FontCache.cpp */,
+				4A94CA4214F26875002CA792 /* FontCache.h */,
+				4A6C4C2613532FC300FDD53F /* Frame.cpp */,
+				4A6C4C2713532FC300FDD53F /* Frame.h */,
+				4A6C4C2813532FC300FDD53F /* GalacticView.cpp */,
+				4A6C4C2913532FC300FDD53F /* GalacticView.h */,
+				4ADF517F1557473400ACF5A0 /* galaxy */,
+				4AF9999D1496D51F009821AF /* Game.cpp */,
+				4AF9999E1496D51F009821AF /* Game.h */,
+				4A82AA7D1386969B0028CCED /* GameConfig.cpp */,
+				4A82AA7E1386969B0028CCED /* GameConfig.h */,
+				4A6C4C2C13532FC300FDD53F /* gameconsts.h */,
+				378563661B197D740039F2BC /* GameLog.cpp */,
+				378563671B197D740039F2BC /* GameLog.h */,
+				4A24FD601650F4D100DE7B0F /* gameui */,
+				378563681B197D740039F2BC /* GasGiant.cpp */,
+				378563691B197D740039F2BC /* GasGiant.h */,
+				3785636A1B197D740039F2BC /* GeoPatch.cpp */,
+				3785636B1B197D740039F2BC /* GeoPatch.h */,
+				3785636C1B197D740039F2BC /* GeoPatchContext.cpp */,
+				3785636D1B197D740039F2BC /* GeoPatchContext.h */,
+				3785636E1B197D740039F2BC /* GeoPatchID.cpp */,
+				3785636F1B197D740039F2BC /* GeoPatchID.h */,
+				378563701B197D740039F2BC /* GeoPatchJobs.cpp */,
+				378563711B197D740039F2BC /* GeoPatchJobs.h */,
+				4A6C4C3113532FC300FDD53F /* GeoSphere.cpp */,
+				4A6C4C3213532FC300FDD53F /* GeoSphere.h */,
+				4A4F25B814F524D400FD14A6 /* graphics */,
+				4A19030B138AA33300E0229C /* gui */,
+				378563721B197D740039F2BC /* HudTrail.cpp */,
+				378563731B197D740039F2BC /* HudTrail.h */,
+				4A6C4C6A13532FC300FDD53F /* HyperspaceCloud.cpp */,
+				4A6C4C6B13532FC300FDD53F /* HyperspaceCloud.h */,
+				4A6C4C6E13532FC300FDD53F /* IniConfig.cpp */,
+				4A6C4C6F13532FC300FDD53F /* IniConfig.h */,
+				4AF222E2162103EA00BED38E /* Intro.cpp */,
+				4AF222E3162103EA00BED38E /* Intro.h */,
+				378563741B197D740039F2BC /* IterationProxy.h */,
+				378563751B197D740039F2BC /* JobQueue.cpp */,
+				378563761B197D740039F2BC /* JobQueue.h */,
+				4A6C4C7013532FC300FDD53F /* KeyBindings.cpp */,
+				4A6C4C7113532FC300FDD53F /* KeyBindings.h */,
+				4AF222E4162103EA00BED38E /* KeyBindings.inc.h */,
+				4A24075A13F5240F002A5C12 /* Lang.cpp */,
+				4A24075B13F5240F002A5C12 /* Lang.h */,
+				4A305FCF151341170076D414 /* LangStrings.inc.h */,
+				4A6C4C7213532FC300FDD53F /* libs.h */,
+				4AAB881A15F4AD7700AAF8A8 /* Lua.cpp */,
+				4AAB881B15F4AD7700AAF8A8 /* Lua.h */,
+				4A99371B1368355400EA0EE5 /* LuaBody.cpp */,
+				4A99371D1368355400EA0EE5 /* LuaCargoBody.cpp */,
+				4A3AE8E3158FD22200EB13DE /* LuaComms.cpp */,
+				4A3AE8E4158FD22200EB13DE /* LuaComms.h */,
+				4A8DD539142E19B6006DD821 /* LuaConsole.cpp */,
+				4A8DD53A142E19B6006DD821 /* LuaConsole.h */,
+				4A99371F1368355500EA0EE5 /* LuaConstants.cpp */,
+				4A9937201368355500EA0EE5 /* LuaConstants.h */,
+				4A973BF51618688F0029562D /* LuaDev.cpp */,
+				4A973BF61618688F0029562D /* LuaDev.h */,
+				4A9937211368355500EA0EE5 /* LuaEngine.cpp */,
+				4A9937221368355500EA0EE5 /* LuaEngine.h */,
+				4AF0058915F0F30400CC19C0 /* LuaEvent.cpp */,
+				4AF0058A15F0F30400CC19C0 /* LuaEvent.h */,
+				4A239FC9163E78D60037BE24 /* LuaFaction.cpp */,
+				4AF0059115F17C6700CC19C0 /* LuaFileSystem.cpp */,
+				4AF0059215F17C6700CC19C0 /* LuaFileSystem.h */,
+				4ADF518F1557477400ACF5A0 /* LuaFixed.cpp */,
+				4ADF51901557477400ACF5A0 /* LuaFixed.h */,
+				4A9937271368355500EA0EE5 /* LuaFormat.cpp */,
+				4A9937281368355500EA0EE5 /* LuaFormat.h */,
+				4A9937291368355500EA0EE5 /* LuaGame.cpp */,
+				4A99372A1368355500EA0EE5 /* LuaGame.h */,
+				4AE9706514369D7500424F91 /* LuaLang.cpp */,
+				4AE9706614369D7500424F91 /* LuaLang.h */,
+				4A99372B1368355500EA0EE5 /* LuaManager.cpp */,
+				4A99372C1368355500EA0EE5 /* LuaManager.h */,
+				4ADF51911557477400ACF5A0 /* LuaMatrix.cpp */,
+				4ADF51921557477400ACF5A0 /* LuaMatrix.h */,
+				4ACED56816BBCC7200E53808 /* LuaMissile.cpp */,
+				4ACED56916BBCC7200E53808 /* LuaMissile.h */,
+				378563771B197D740039F2BC /* LuaModelBody.cpp */,
+				4A85A86313C4631D00C2B986 /* LuaMusic.cpp */,
+				4A85A86413C4631D00C2B986 /* LuaMusic.h */,
+				4A99372D1368355500EA0EE5 /* LuaNameGen.cpp */,
+				4A99372E1368355500EA0EE5 /* LuaNameGen.h */,
+				4A99372F1368355500EA0EE5 /* LuaObject.cpp */,
+				4A82AA7F1386969B0028CCED /* LuaObject.h */,
+				4A9937301368355500EA0EE5 /* LuaPlanet.cpp */,
+				4A9937321368355500EA0EE5 /* LuaPlayer.cpp */,
+				4A8AE19217208CE40005C2D9 /* LuaPropertiedObject.cpp */,
+				4AAB884415FDEA6E00AAF8A8 /* LuaPushPull.h */,
+				4A9937341368355500EA0EE5 /* LuaRand.cpp */,
+				4AAB884515FDEA6E00AAF8A8 /* LuaRef.cpp */,
+				4AAB884615FDEA6F00AAF8A8 /* LuaRef.h */,
+				4A99373A1368355500EA0EE5 /* LuaSerializer.cpp */,
+				4A99373B1368355500EA0EE5 /* LuaSerializer.h */,
+				3785644E1B197FAE0039F2BC /* LuaServerAgent.cpp */,
+				3785644F1B197FAE0039F2BC /* LuaServerAgent.h */,
+				4A99373C1368355500EA0EE5 /* LuaShip.cpp */,
+				4AA84A2316D0E18700220311 /* LuaShipDef.cpp */,
+				4AA84A2416D0E18700220311 /* LuaShipDef.h */,
+				4A9937401368355500EA0EE5 /* LuaSpace.cpp */,
+				4A9937411368355500EA0EE5 /* LuaSpace.h */,
+				4A9937421368355500EA0EE5 /* LuaSpaceStation.cpp */,
+				4A9937441368355500EA0EE5 /* LuaStar.cpp */,
+				4A9937461368355500EA0EE5 /* LuaStarSystem.cpp */,
+				4ADF51931557477400ACF5A0 /* LuaSystemBody.cpp */,
+				4A85A86513C4631D00C2B986 /* LuaSystemPath.cpp */,
+				4AAB884715FDEA6F00AAF8A8 /* LuaTable.h */,
+				4A9937481368355500EA0EE5 /* LuaTimer.cpp */,
+				4A9937491368355500EA0EE5 /* LuaTimer.h */,
+				4A99374C1368355500EA0EE5 /* LuaUtils.cpp */,
+				4A99374D1368355500EA0EE5 /* LuaUtils.h */,
+				4ADF51951557477400ACF5A0 /* LuaVector.cpp */,
+				4ADF51961557477400ACF5A0 /* LuaVector.h */,
+				4AA84A2516D0E18700220311 /* LuaWrappable.h */,
+				4A6C4CD313532FC300FDD53F /* main.cpp */,
+				4AF999A11496D51F009821AF /* MathUtil.cpp */,
+				4AF999A21496D51F009821AF /* MathUtil.h */,
+				4ACE132E16B4B19D00CAE524 /* matrix3x3.h */,
+				4A6C4CD913532FC300FDD53F /* matrix4x4.h */,
+				4A6C4CDA13532FC300FDD53F /* Missile.cpp */,
+				4A6C4CDB13532FC300FDD53F /* Missile.h */,
+				4A6C4CDE13532FC300FDD53F /* ModelBody.cpp */,
+				4A6C4CDF13532FC300FDD53F /* ModelBody.h */,
+				4ACDB6CA167878CE0069FA03 /* ModelCache.cpp */,
+				4ACDB6CB167878CE0069FA03 /* ModelCache.h */,
+				4ACDB6CC167878CE0069FA03 /* ModelViewer.cpp */,
+				4ACDB6CD167878CE0069FA03 /* ModelViewer.h */,
+				4AAC9FE71545901D00116131 /* ModManager.cpp */,
+				4AAC9FE81545901D00116131 /* ModManager.h */,
+				4AA527F816E9EABA0036D4CB /* NavLights.cpp */,
+				4AA527F916E9EABA0036D4CB /* NavLights.h */,
+				4A6C4CE813532FC300FDD53F /* Object.h */,
+				4A6C4CE913532FC300FDD53F /* ObjectViewerView.cpp */,
+				4A6C4CEA13532FC300FDD53F /* ObjectViewerView.h */,
+				4A712411170EC89000BB9BCC /* Orbit.cpp */,
+				4A712412170EC89000BB9BCC /* Orbit.h */,
+				4AAB881C15F4AD7700AAF8A8 /* OS.h */,
+				4A6C4D2C13532FC300FDD53F /* perlin.cpp */,
+				4A6C4D2D13532FC300FDD53F /* perlin.h */,
+				4A6C4D2E13532FC300FDD53F /* PersistSystemData.h */,
+				4A6C4D2F13532FC300FDD53F /* Pi.cpp */,
+				4A6C4D3013532FC300FDD53F /* Pi.h */,
+				3785637B1B197D740039F2BC /* Plane.cpp */,
+				3785637C1B197D740039F2BC /* Plane.h */,
+				4A6C4D3913532FC300FDD53F /* Planet.cpp */,
+				4A6C4D3A13532FC300FDD53F /* Planet.h */,
+				4A6C4D3B13532FC300FDD53F /* Player.cpp */,
+				4A6C4D3C13532FC300FDD53F /* Player.h */,
+				4AFBD7B71641265D002928CB /* PngWriter.cpp */,
+				4AFBD7B81641265D002928CB /* PngWriter.h */,
+				4A6C4D3F13532FC300FDD53F /* Polit.cpp */,
+				4A6C4D4013532FC300FDD53F /* Polit.h */,
+				4ADB0D1215C50DF000AE2123 /* posix */,
+				4A6C4D4113532FC300FDD53F /* Projectile.cpp */,
+				4A6C4D4213532FC300FDD53F /* Projectile.h */,
+				4A8AE19317208CE40005C2D9 /* PropertiedObject.h */,
+				4A8AE19417208CE40005C2D9 /* PropertyMap.cpp */,
+				4A8AE19517208CE50005C2D9 /* PropertyMap.h */,
+				4A6C4D4313532FC300FDD53F /* Quaternion.h */,
+				4AA84A2616D0E18700220311 /* Random.h */,
+				4A99374E1368355500EA0EE5 /* RefCounted.h */,
+				4ACDB683167878610069FA03 /* scenegraph */,
+				4ADC7B7F152C703200E359B5 /* SDLWrappers.cpp */,
+				4ADC7B80152C703200E359B5 /* SDLWrappers.h */,
+				4A6C4D4813532FC300FDD53F /* SectorView.cpp */,
+				4A6C4D4913532FC300FDD53F /* SectorView.h */,
+				3785637D1B197D740039F2BC /* Sensors.cpp */,
+				3785637E1B197D740039F2BC /* Sensors.h */,
+				4A6C4D4A13532FC300FDD53F /* Serializer.cpp */,
+				4A6C4D4B13532FC300FDD53F /* Serializer.h */,
+				378564501B197FAE0039F2BC /* ServerAgent.cpp */,
+				378564511B197FAE0039F2BC /* ServerAgent.h */,
+				4A6C4D4C13532FC300FDD53F /* Sfx.cpp */,
+				4A6C4D4D13532FC300FDD53F /* Sfx.h */,
+				378563811B197D740039F2BC /* Shields.cpp */,
+				378563821B197D740039F2BC /* Shields.h */,
+				4A6C4D4E13532FC300FDD53F /* Ship-AI.cpp */,
+				4A6C4D4F13532FC300FDD53F /* Ship.cpp */,
+				4A6C4D5013532FC300FDD53F /* Ship.h */,
+				4A6C4D5113532FC300FDD53F /* ShipAICmd.cpp */,
+				4A6C4D5213532FC300FDD53F /* ShipAICmd.h */,
+				378563831B197D740039F2BC /* ShipCockpit.cpp */,
+				378563841B197D740039F2BC /* ShipCockpit.h */,
+				4A107C2D1525AB0D00EF9FAC /* ShipController.cpp */,
+				4A107C2E1525AB0D00EF9FAC /* ShipController.h */,
+				4A6C4D5313532FC300FDD53F /* ShipCpanel.cpp */,
+				4A6C4D5413532FC300FDD53F /* ShipCpanel.h */,
+				4A6C4D5513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp */,
+				4A6C4D5613532FC300FDD53F /* ShipCpanelMultiFuncDisplays.h */,
+				4A6C4D5913532FC300FDD53F /* ShipType.cpp */,
+				4A6C4D5A13532FC300FDD53F /* ShipType.h */,
+				4A4F25E014F524F600FD14A6 /* SmartPtr.h */,
+				4A6C4D5B13532FC300FDD53F /* Sound.cpp */,
+				4A6C4D5C13532FC300FDD53F /* Sound.h */,
+				4A85A86713C4631D00C2B986 /* SoundMusic.cpp */,
+				4A85A86813C4631D00C2B986 /* SoundMusic.h */,
+				4A6C4D5D13532FC300FDD53F /* Space.cpp */,
+				4A6C4D5E13532FC300FDD53F /* Space.h */,
+				4A6C4D5F13532FC300FDD53F /* SpaceStation.cpp */,
+				4A6C4D6013532FC300FDD53F /* SpaceStation.h */,
+				4AEE56DB16A44CD800AA1C53 /* SpaceStationType.cpp */,
+				4AEE56DC16A44CD800AA1C53 /* SpaceStationType.h */,
+				378563851B197D740039F2BC /* SpeedLines.cpp */,
+				378563861B197D740039F2BC /* SpeedLines.h */,
+				378563871B197D740039F2BC /* Sphere.cpp */,
+				378563881B197D740039F2BC /* Sphere.h */,
+				4A6C4D6313532FC300FDD53F /* Star.cpp */,
+				4A6C4D6413532FC300FDD53F /* Star.h */,
+				4A6B59CA1429F14500ADC7C8 /* StringF.cpp */,
+				4A6B59CB1429F14500ADC7C8 /* StringF.h */,
+				4A305FD0151341170076D414 /* StringRange.h */,
+				4A6C4D6913532FC300FDD53F /* SystemInfoView.cpp */,
+				4A6C4D6A13532FC300FDD53F /* SystemInfoView.h */,
+				4A6C4D6B13532FC300FDD53F /* SystemView.cpp */,
+				4A6C4D6C13532FC300FDD53F /* SystemView.h */,
+				4AB7D5CF1472A83E00158DE4 /* terrain */,
+				4AB3DF8714346952001B783A /* TerrainBody.cpp */,
+				4AB3DF8814346952001B783A /* TerrainBody.h */,
+				4ACC6D1115401E7000C59914 /* text */,
+				4AF222E5162103EA00BED38E /* Tombstone.cpp */,
+				4AF222E6162103EA00BED38E /* Tombstone.h */,
+				4ABF302D16335A1100664653 /* ui */,
+				4A24FD5C1650F4B700DE7B0F /* UIView.cpp */,
+				4A24FD5D1650F4B700DE7B0F /* UIView.h */,
+				4A6C4D6E13532FC300FDD53F /* utils.cpp */,
+				4A6C4D6F13532FC300FDD53F /* utils.h */,
+				4A4F25E114F524F600FD14A6 /* vector2.h */,
+				4A6C4D7013532FC300FDD53F /* vector3.h */,
+				4A62EF2B136979E000919EBB /* VideoLink.h */,
+				4ADC7B81152C703200E359B5 /* View.cpp */,
+				4A6C4D7113532FC300FDD53F /* View.h */,
+				4A6C4D7213532FC300FDD53F /* WorldView.cpp */,
+				4A6C4D7313532FC300FDD53F /* WorldView.h */,
+			);
+			name = src;
+			path = ../src;
+			sourceTree = "<group>";
+		};
+		4A6C4C0913532FC300FDD53F /* collider */ = {
+			isa = PBXGroup;
+			children = (
+				3785643D1B197E960039F2BC /* Weld.h */,
+				4A6C4C0F13532FC300FDD53F /* BVHTree.cpp */,
+				4A6C4C1013532FC300FDD53F /* BVHTree.h */,
+				4A6C4C1113532FC300FDD53F /* collider.h */,
+				4A6C4C1213532FC300FDD53F /* CollisionContact.h */,
+				4A6C4C1313532FC300FDD53F /* CollisionSpace.cpp */,
+				4A6C4C1413532FC300FDD53F /* CollisionSpace.h */,
+				4A6C4C1513532FC300FDD53F /* Geom.cpp */,
+				4A6C4C1613532FC300FDD53F /* Geom.h */,
+				4A6C4C1713532FC300FDD53F /* GeomTree.cpp */,
+				4A6C4C1813532FC300FDD53F /* GeomTree.h */,
+			);
+			path = collider;
 			sourceTree = "<group>";
 		};
 		4A9822A9142DF91B00B423F1 /* Misc TXT files */ = {
@@ -1476,919 +1977,313 @@
 				4A76112D1611AA5F00A06F79 /* SIL-1.1.txt */,
 				4A9822B3142E02AF00B423F1 /* Changelog.txt */,
 				4A9822AD142E00B100B423F1 /* Quickstart.txt */,
-				4A9822AE142E00B100B423F1 /* README.txt */,
 				4A9822AA142DF93D00B423F1 /* AUTHORS.txt */,
 			);
 			name = "Misc TXT files";
 			sourceTree = "<group>";
 		};
-		521ED7D31C00D1280092B2E9 /* src */ = {
+		4AAC9FDC15458FE400116131 /* miniz */ = {
 			isa = PBXGroup;
 			children = (
-				521ED97B1C00D23F0092B2E9 /* collider */,
-				521ED97C1C00D24C0092B2E9 /* galaxy */,
-				521ED97D1C00D25E0092B2E9 /* gameui */,
-				521ED97E1C00D2650092B2E9 /* graphics */,
-				521ED97F1C00D26B0092B2E9 /* gui */,
-				521ED9801C00D2740092B2E9 /* posix */,
-				521ED9811C00D2790092B2E9 /* scenegraph */,
-				521ED9821C00D2880092B2E9 /* terrain */,
-				521ED9831C00D28F0092B2E9 /* text */,
-				521ED9841C00D29E0092B2E9 /* ui */,
-				521ED7D41C00D14D0092B2E9 /* Aabb.h */,
-				521ED7D51C00D14D0092B2E9 /* AmbientSounds.cpp */,
-				521ED7D61C00D14D0092B2E9 /* AmbientSounds.h */,
-				521ED7D71C00D14D0092B2E9 /* AnimationCurves.h */,
-				521ED7D81C00D14D0092B2E9 /* Background.cpp */,
-				521ED7D91C00D14D0092B2E9 /* Background.h */,
-				521ED7DA1C00D14D0092B2E9 /* BaseSphere.cpp */,
-				521ED7DB1C00D14D0092B2E9 /* BaseSphere.h */,
-				521ED7DC1C00D14D0092B2E9 /* Body.cpp */,
-				521ED7DD1C00D14D0092B2E9 /* Body.h */,
-				521ED7DE1C00D14D0092B2E9 /* buildopts.h */,
-				521ED7DF1C00D14D0092B2E9 /* ByteRange.h */,
-				521ED7E01C00D14D0092B2E9 /* Camera.cpp */,
-				521ED7E11C00D14D0092B2E9 /* Camera.h */,
-				521ED7E21C00D14D0092B2E9 /* CameraController.cpp */,
-				521ED7E31C00D14D0092B2E9 /* CameraController.h */,
-				521ED7E41C00D14D0092B2E9 /* CargoBody.cpp */,
-				521ED7E51C00D14D0092B2E9 /* CargoBody.h */,
-				521ED7E61C00D14D0092B2E9 /* CityOnPlanet.cpp */,
-				521ED7E71C00D14D0092B2E9 /* CityOnPlanet.h */,
-				521ED7E81C00D14D0092B2E9 /* CollMesh.cpp */,
-				521ED7E91C00D14D0092B2E9 /* CollMesh.h */,
-				521ED7EA1C00D14D0092B2E9 /* Color.cpp */,
-				521ED7EB1C00D14D0092B2E9 /* Color.h */,
-				521ED7EC1C00D14D0092B2E9 /* CRC32.cpp */,
-				521ED7ED1C00D14D0092B2E9 /* CRC32.h */,
-				521ED7EE1C00D14D0092B2E9 /* Cutscene.h */,
-				521ED7EF1C00D14D0092B2E9 /* DateTime.cpp */,
-				521ED7F01C00D14D0092B2E9 /* DateTime.h */,
-				521ED7F11C00D14D0092B2E9 /* DeathView.cpp */,
-				521ED7F21C00D14D0092B2E9 /* DeathView.h */,
-				521ED7F31C00D14D0092B2E9 /* DeleteEmitter.h */,
-				521ED7F41C00D14D0092B2E9 /* DynamicBody.cpp */,
-				521ED7F51C00D14D0092B2E9 /* DynamicBody.h */,
-				521ED7F61C00D14D0092B2E9 /* Easing.h */,
-				521ED7F71C00D14D0092B2E9 /* enum_table.cpp */,
-				521ED7F81C00D14D0092B2E9 /* enum_table.h */,
-				521ED7F91C00D14D0092B2E9 /* EnumStrings.cpp */,
-				521ED7FA1C00D14D0092B2E9 /* EnumStrings.h */,
-				521ED7FB1C00D14D0092B2E9 /* FaceParts.cpp */,
-				521ED7FC1C00D14D0092B2E9 /* FaceParts.h */,
-				521ED7FD1C00D14D0092B2E9 /* Factions.cpp */,
-				521ED7FE1C00D14D0092B2E9 /* Factions.h */,
-				521ED7FF1C00D14D0092B2E9 /* FileSourceZip.cpp */,
-				521ED8001C00D14D0092B2E9 /* FileSourceZip.h */,
-				521ED8011C00D14D0092B2E9 /* FileSystem.cpp */,
-				521ED8021C00D14D0092B2E9 /* FileSystem.h */,
-				521ED8031C00D14D0092B2E9 /* fixed.h */,
-				521ED8041C00D14D0092B2E9 /* FloatComparison.h */,
-				521ED8051C00D14D0092B2E9 /* FontCache.cpp */,
-				521ED8061C00D14D0092B2E9 /* FontCache.h */,
-				521ED8071C00D14D0092B2E9 /* Frame.cpp */,
-				521ED8081C00D14D0092B2E9 /* Frame.h */,
-				521ED8091C00D14D0092B2E9 /* GalacticView.cpp */,
-				521ED80A1C00D14D0092B2E9 /* GalacticView.h */,
-				521ED80B1C00D14D0092B2E9 /* Game.cpp */,
-				521ED80C1C00D14D0092B2E9 /* Game.h */,
-				521ED80D1C00D14D0092B2E9 /* GameConfig.cpp */,
-				521ED80E1C00D14D0092B2E9 /* GameConfig.h */,
-				521ED80F1C00D14D0092B2E9 /* gameconsts.h */,
-				521ED8101C00D14D0092B2E9 /* GameLog.cpp */,
-				521ED8111C00D14D0092B2E9 /* GameLog.h */,
-				521ED8121C00D14D0092B2E9 /* GasGiant.cpp */,
-				521ED8131C00D14D0092B2E9 /* GasGiant.h */,
-				521ED8141C00D14D0092B2E9 /* GeoPatch.cpp */,
-				521ED8151C00D14D0092B2E9 /* GeoPatch.h */,
-				521ED8161C00D14D0092B2E9 /* GeoPatchContext.cpp */,
-				521ED8171C00D14D0092B2E9 /* GeoPatchContext.h */,
-				521ED8181C00D14D0092B2E9 /* GeoPatchID.cpp */,
-				521ED8191C00D14D0092B2E9 /* GeoPatchID.h */,
-				521ED81A1C00D14D0092B2E9 /* GeoPatchJobs.cpp */,
-				521ED81B1C00D14D0092B2E9 /* GeoPatchJobs.h */,
-				521ED81C1C00D14D0092B2E9 /* GeoSphere.cpp */,
-				521ED81D1C00D14D0092B2E9 /* GeoSphere.h */,
-				521ED81E1C00D14D0092B2E9 /* HudTrail.cpp */,
-				521ED81F1C00D14D0092B2E9 /* HudTrail.h */,
-				521ED8201C00D14D0092B2E9 /* HyperspaceCloud.cpp */,
-				521ED8211C00D14D0092B2E9 /* HyperspaceCloud.h */,
-				521ED8221C00D14D0092B2E9 /* IniConfig.cpp */,
-				521ED8231C00D14D0092B2E9 /* IniConfig.h */,
-				521ED8241C00D14D0092B2E9 /* Intro.cpp */,
-				521ED8251C00D14D0092B2E9 /* Intro.h */,
-				521ED8261C00D14D0092B2E9 /* IterationProxy.h */,
-				521ED8271C00D14D0092B2E9 /* JobQueue.cpp */,
-				521ED8281C00D14D0092B2E9 /* JobQueue.h */,
-				521ED8291C00D14D0092B2E9 /* KeyBindings.cpp */,
-				521ED82A1C00D14D0092B2E9 /* KeyBindings.h */,
-				521ED82B1C00D14D0092B2E9 /* KeyBindings.inc.h */,
-				521ED82C1C00D14D0092B2E9 /* Lang.cpp */,
-				521ED82D1C00D14D0092B2E9 /* Lang.h */,
-				521ED82E1C00D14D0092B2E9 /* LangStrings.inc.h */,
-				521ED82F1C00D14D0092B2E9 /* libs.h */,
-				521ED8301C00D14D0092B2E9 /* Lua.cpp */,
-				521ED8311C00D14D0092B2E9 /* Lua.h */,
-				521ED8321C00D14D0092B2E9 /* LuaBody.cpp */,
-				521ED8331C00D14D0092B2E9 /* LuaCargoBody.cpp */,
-				521ED8341C00D14D0092B2E9 /* LuaComms.cpp */,
-				521ED8351C00D14D0092B2E9 /* LuaComms.h */,
-				521ED8361C00D14D0092B2E9 /* LuaConsole.cpp */,
-				521ED8371C00D14D0092B2E9 /* LuaConsole.h */,
-				521ED8381C00D14D0092B2E9 /* LuaConstants.cpp */,
-				521ED8391C00D14D0092B2E9 /* LuaConstants.h */,
-				521ED83A1C00D14D0092B2E9 /* LuaDev.cpp */,
-				521ED83B1C00D14D0092B2E9 /* LuaDev.h */,
-				521ED83C1C00D14D0092B2E9 /* LuaEngine.cpp */,
-				521ED83D1C00D14D0092B2E9 /* LuaEngine.h */,
-				521ED83E1C00D14D0092B2E9 /* LuaEvent.cpp */,
-				521ED83F1C00D14D0092B2E9 /* LuaEvent.h */,
-				521ED8401C00D14D0092B2E9 /* LuaFaction.cpp */,
-				521ED8411C00D14D0092B2E9 /* LuaFileSystem.cpp */,
-				521ED8421C00D14D0092B2E9 /* LuaFileSystem.h */,
-				521ED8431C00D14D0092B2E9 /* LuaFixed.cpp */,
-				521ED8441C00D14D0092B2E9 /* LuaFixed.h */,
-				521ED8451C00D14D0092B2E9 /* LuaFormat.cpp */,
-				521ED8461C00D14D0092B2E9 /* LuaFormat.h */,
-				521ED8471C00D14D0092B2E9 /* LuaGame.cpp */,
-				521ED8481C00D14D0092B2E9 /* LuaGame.h */,
-				521ED8491C00D14D0092B2E9 /* LuaLang.cpp */,
-				521ED84A1C00D14D0092B2E9 /* LuaLang.h */,
-				521ED84B1C00D14D0092B2E9 /* LuaManager.cpp */,
-				521ED84C1C00D14D0092B2E9 /* LuaManager.h */,
-				521ED84D1C00D14D0092B2E9 /* LuaMatrix.cpp */,
-				521ED84E1C00D14D0092B2E9 /* LuaMatrix.h */,
-				521ED84F1C00D14D0092B2E9 /* LuaMissile.cpp */,
-				521ED8501C00D14D0092B2E9 /* LuaMissile.h */,
-				521ED8511C00D14D0092B2E9 /* LuaModelBody.cpp */,
-				521ED8521C00D14E0092B2E9 /* LuaMusic.cpp */,
-				521ED8531C00D14E0092B2E9 /* LuaMusic.h */,
-				521ED8541C00D14E0092B2E9 /* LuaNameGen.cpp */,
-				521ED8551C00D14E0092B2E9 /* LuaNameGen.h */,
-				521ED8561C00D14E0092B2E9 /* LuaObject.cpp */,
-				521ED8571C00D14E0092B2E9 /* LuaObject.h */,
-				521ED8581C00D14E0092B2E9 /* LuaPlanet.cpp */,
-				521ED8591C00D14E0092B2E9 /* LuaPlayer.cpp */,
-				521ED85A1C00D14E0092B2E9 /* LuaPropertiedObject.cpp */,
-				521ED85B1C00D14E0092B2E9 /* LuaPushPull.h */,
-				521ED85C1C00D14E0092B2E9 /* LuaRand.cpp */,
-				521ED85D1C00D14E0092B2E9 /* LuaRef.cpp */,
-				521ED85E1C00D14E0092B2E9 /* LuaRef.h */,
-				521ED85F1C00D14E0092B2E9 /* LuaSerializer.cpp */,
-				521ED8601C00D14E0092B2E9 /* LuaSerializer.h */,
-				521ED8611C00D14E0092B2E9 /* LuaServerAgent.cpp */,
-				521ED8621C00D14E0092B2E9 /* LuaServerAgent.h */,
-				521ED8631C00D14E0092B2E9 /* LuaShip.cpp */,
-				521ED8641C00D14E0092B2E9 /* LuaShipDef.cpp */,
-				521ED8651C00D14E0092B2E9 /* LuaShipDef.h */,
-				521ED8661C00D14E0092B2E9 /* LuaSpace.cpp */,
-				521ED8671C00D14E0092B2E9 /* LuaSpace.h */,
-				521ED8681C00D14E0092B2E9 /* LuaSpaceStation.cpp */,
-				521ED8691C00D14E0092B2E9 /* LuaStar.cpp */,
-				521ED86A1C00D14E0092B2E9 /* LuaStarSystem.cpp */,
-				521ED86B1C00D14E0092B2E9 /* LuaSystemBody.cpp */,
-				521ED86C1C00D14E0092B2E9 /* LuaSystemPath.cpp */,
-				521ED86D1C00D14E0092B2E9 /* LuaTable.h */,
-				521ED86E1C00D14E0092B2E9 /* LuaTimer.cpp */,
-				521ED86F1C00D14E0092B2E9 /* LuaTimer.h */,
-				521ED8701C00D14E0092B2E9 /* LuaUtils.cpp */,
-				521ED8711C00D14E0092B2E9 /* LuaUtils.h */,
-				521ED8721C00D14E0092B2E9 /* LuaVector.cpp */,
-				521ED8731C00D14E0092B2E9 /* LuaVector.h */,
-				521ED8741C00D14E0092B2E9 /* LuaWrappable.h */,
-				521ED8751C00D14E0092B2E9 /* main.cpp */,
-				521ED8761C00D14E0092B2E9 /* MathUtil.cpp */,
-				521ED8771C00D14E0092B2E9 /* MathUtil.h */,
-				521ED8781C00D14E0092B2E9 /* matrix3x3.h */,
-				521ED8791C00D14E0092B2E9 /* matrix4x4.h */,
-				521ED87A1C00D14E0092B2E9 /* Missile.cpp */,
-				521ED87B1C00D14E0092B2E9 /* Missile.h */,
-				521ED87C1C00D14E0092B2E9 /* ModelBody.cpp */,
-				521ED87D1C00D14E0092B2E9 /* ModelBody.h */,
-				521ED87E1C00D14E0092B2E9 /* ModelCache.cpp */,
-				521ED87F1C00D14E0092B2E9 /* ModelCache.h */,
-				521ED8811C00D14E0092B2E9 /* ModelViewer.cpp */,
-				521ED8821C00D14E0092B2E9 /* ModelViewer.h */,
-				521ED8831C00D14E0092B2E9 /* ModManager.cpp */,
-				521ED8841C00D14E0092B2E9 /* ModManager.h */,
-				521ED8851C00D14E0092B2E9 /* NavLights.cpp */,
-				521ED8861C00D14E0092B2E9 /* NavLights.h */,
-				521ED8871C00D14E0092B2E9 /* Object.h */,
-				521ED8881C00D14E0092B2E9 /* ObjectViewerView.cpp */,
-				521ED8891C00D14E0092B2E9 /* ObjectViewerView.h */,
-				521ED88A1C00D14E0092B2E9 /* Orbit.cpp */,
-				521ED88B1C00D14E0092B2E9 /* Orbit.h */,
-				521ED88C1C00D14E0092B2E9 /* OS.h */,
-				521ED88D1C00D14E0092B2E9 /* perlin.cpp */,
-				521ED88E1C00D14E0092B2E9 /* perlin.h */,
-				521ED88F1C00D14E0092B2E9 /* PersistSystemData.h */,
-				521ED8901C00D14E0092B2E9 /* Pi.cpp */,
-				521ED8911C00D14E0092B2E9 /* Pi.h */,
-				521ED8921C00D14E0092B2E9 /* Plane.cpp */,
-				521ED8931C00D14E0092B2E9 /* Plane.h */,
-				521ED8941C00D14E0092B2E9 /* Planet.cpp */,
-				521ED8951C00D14E0092B2E9 /* Planet.h */,
-				521ED8961C00D14E0092B2E9 /* Player.cpp */,
-				521ED8971C00D14E0092B2E9 /* Player.h */,
-				521ED8981C00D14E0092B2E9 /* PngWriter.cpp */,
-				521ED8991C00D14E0092B2E9 /* PngWriter.h */,
-				521ED89A1C00D14E0092B2E9 /* Polit.cpp */,
-				521ED89B1C00D14E0092B2E9 /* Polit.h */,
-				521ED89C1C00D14E0092B2E9 /* Projectile.cpp */,
-				521ED89D1C00D14E0092B2E9 /* Projectile.h */,
-				521ED89E1C00D14E0092B2E9 /* PropertiedObject.h */,
-				521ED89F1C00D14E0092B2E9 /* PropertyMap.cpp */,
-				521ED8A01C00D14E0092B2E9 /* PropertyMap.h */,
-				521ED8A11C00D14E0092B2E9 /* Quaternion.h */,
-				521ED8A21C00D14E0092B2E9 /* Random.h */,
-				521ED8A31C00D14E0092B2E9 /* RefCounted.h */,
-				521ED8A41C00D14E0092B2E9 /* SDLWrappers.cpp */,
-				521ED8A51C00D14E0092B2E9 /* SDLWrappers.h */,
-				521ED8A61C00D14E0092B2E9 /* SectorView.cpp */,
-				521ED8A71C00D14E0092B2E9 /* SectorView.h */,
-				521ED8A81C00D14E0092B2E9 /* Sensors.cpp */,
-				521ED8A91C00D14E0092B2E9 /* Sensors.h */,
-				521ED8AA1C00D14E0092B2E9 /* Serializer.cpp */,
-				521ED8AB1C00D14E0092B2E9 /* Serializer.h */,
-				521ED8AC1C00D14E0092B2E9 /* ServerAgent.cpp */,
-				521ED8AD1C00D14E0092B2E9 /* ServerAgent.h */,
-				521ED8AE1C00D14E0092B2E9 /* Sfx.cpp */,
-				521ED8AF1C00D14E0092B2E9 /* Sfx.h */,
-				521ED8B01C00D14E0092B2E9 /* Shields.cpp */,
-				521ED8B11C00D14E0092B2E9 /* Shields.h */,
-				521ED8B21C00D14E0092B2E9 /* Ship-AI.cpp */,
-				521ED8B31C00D14E0092B2E9 /* Ship.cpp */,
-				521ED8B41C00D14E0092B2E9 /* Ship.h */,
-				521ED8B51C00D14E0092B2E9 /* ShipAICmd.cpp */,
-				521ED8B61C00D14E0092B2E9 /* ShipAICmd.h */,
-				521ED8B71C00D14E0092B2E9 /* ShipCockpit.cpp */,
-				521ED8B81C00D14E0092B2E9 /* ShipCockpit.h */,
-				521ED8B91C00D14E0092B2E9 /* ShipController.cpp */,
-				521ED8BA1C00D14E0092B2E9 /* ShipController.h */,
-				521ED8BB1C00D14E0092B2E9 /* ShipCpanel.cpp */,
-				521ED8BC1C00D14E0092B2E9 /* ShipCpanel.h */,
-				521ED8BD1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp */,
-				521ED8BE1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.h */,
-				521ED8BF1C00D14E0092B2E9 /* ShipType.cpp */,
-				521ED8C01C00D14E0092B2E9 /* ShipType.h */,
-				521ED8C11C00D14E0092B2E9 /* SmartPtr.h */,
-				521ED8C21C00D14E0092B2E9 /* Sound.cpp */,
-				521ED8C31C00D14E0092B2E9 /* Sound.h */,
-				521ED8C41C00D14E0092B2E9 /* SoundMusic.cpp */,
-				521ED8C51C00D14E0092B2E9 /* SoundMusic.h */,
-				521ED8C61C00D14E0092B2E9 /* Space.cpp */,
-				521ED8C71C00D14E0092B2E9 /* Space.h */,
-				521ED8C81C00D14E0092B2E9 /* SpaceStation.cpp */,
-				521ED8C91C00D14E0092B2E9 /* SpaceStation.h */,
-				521ED8CA1C00D14E0092B2E9 /* SpaceStationType.cpp */,
-				521ED8CB1C00D14E0092B2E9 /* SpaceStationType.h */,
-				521ED8CC1C00D14E0092B2E9 /* SpeedLines.cpp */,
-				521ED8CD1C00D14E0092B2E9 /* SpeedLines.h */,
-				521ED8CE1C00D14E0092B2E9 /* Sphere.cpp */,
-				521ED8CF1C00D14E0092B2E9 /* Sphere.h */,
-				521ED8D01C00D14E0092B2E9 /* Star.cpp */,
-				521ED8D11C00D14E0092B2E9 /* Star.h */,
-				521ED8D21C00D14E0092B2E9 /* StringF.cpp */,
-				521ED8D31C00D14E0092B2E9 /* StringF.h */,
-				521ED8D41C00D14E0092B2E9 /* StringRange.h */,
-				521ED8D51C00D14E0092B2E9 /* SystemInfoView.cpp */,
-				521ED8D61C00D14E0092B2E9 /* SystemInfoView.h */,
-				521ED8D71C00D14E0092B2E9 /* SystemView.cpp */,
-				521ED8D81C00D14E0092B2E9 /* SystemView.h */,
-				521ED8D91C00D14E0092B2E9 /* TerrainBody.cpp */,
-				521ED8DA1C00D14E0092B2E9 /* TerrainBody.h */,
-				521ED8E21C00D14E0092B2E9 /* Tombstone.cpp */,
-				521ED8E31C00D14E0092B2E9 /* Tombstone.h */,
-				521ED8E51C00D14E0092B2E9 /* UIView.cpp */,
-				521ED8E61C00D14E0092B2E9 /* UIView.h */,
-				521ED8E71C00D14E0092B2E9 /* utils.cpp */,
-				521ED8E81C00D14E0092B2E9 /* utils.h */,
-				521ED8E91C00D14E0092B2E9 /* vector2.h */,
-				521ED8EA1C00D14E0092B2E9 /* vector3.h */,
-				521ED8EB1C00D14E0092B2E9 /* VideoLink.h */,
-				521ED8EC1C00D14E0092B2E9 /* View.cpp */,
-				521ED8ED1C00D14E0092B2E9 /* View.h */,
-				521ED8EE1C00D14E0092B2E9 /* WorldView.cpp */,
-				521ED8EF1C00D14E0092B2E9 /* WorldView.h */,
-				521ED9971C00D2FC0092B2E9 /* Makefile.am */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		521ED97B1C00D23F0092B2E9 /* collider */ = {
-			isa = PBXGroup;
-			children = (
-				521ED9861C00D2ED0092B2E9 /* BVHTree.cpp */,
-				521ED9871C00D2ED0092B2E9 /* BVHTree.h */,
-				521ED9881C00D2ED0092B2E9 /* collider.h */,
-				521ED9891C00D2ED0092B2E9 /* CollisionContact.h */,
-				521ED98A1C00D2ED0092B2E9 /* CollisionSpace.cpp */,
-				521ED98B1C00D2ED0092B2E9 /* CollisionSpace.h */,
-				521ED98C1C00D2ED0092B2E9 /* Geom.cpp */,
-				521ED98D1C00D2ED0092B2E9 /* Geom.h */,
-				521ED98E1C00D2ED0092B2E9 /* GeomTree.cpp */,
-				521ED98F1C00D2ED0092B2E9 /* GeomTree.h */,
-				521ED9901C00D2ED0092B2E9 /* Weld.h */,
-				521ED9911C00D2ED0092B2E9 /* Makefile.am */,
-			);
-			name = collider;
-			sourceTree = "<group>";
-		};
-		521ED97C1C00D24C0092B2E9 /* galaxy */ = {
-			isa = PBXGroup;
-			children = (
-				521ED9991C00D3240092B2E9 /* CustomSystem.cpp */,
-				521ED99A1C00D3240092B2E9 /* CustomSystem.h */,
-				521ED99B1C00D3240092B2E9 /* Economy.cpp */,
-				521ED99C1C00D3240092B2E9 /* Economy.h */,
-				521ED99D1C00D3240092B2E9 /* Galaxy.cpp */,
-				521ED99E1C00D3240092B2E9 /* Galaxy.h */,
-				521ED99F1C00D3240092B2E9 /* GalaxyCache.cpp */,
-				521ED9A01C00D3240092B2E9 /* GalaxyCache.h */,
-				521ED9A11C00D3240092B2E9 /* GalaxyGenerator.cpp */,
-				521ED9A21C00D3240092B2E9 /* GalaxyGenerator.h */,
-				521ED9A31C00D3240092B2E9 /* Sector.cpp */,
-				521ED9A41C00D3240092B2E9 /* Sector.h */,
-				521ED9A51C00D3240092B2E9 /* SectorGenerator.cpp */,
-				521ED9A61C00D3240092B2E9 /* SectorGenerator.h */,
-				521ED9A71C00D3240092B2E9 /* StarSystem.cpp */,
-				521ED9A81C00D3240092B2E9 /* StarSystem.h */,
-				521ED9A91C00D3240092B2E9 /* StarSystemGenerator.cpp */,
-				521ED9AA1C00D3240092B2E9 /* StarSystemGenerator.h */,
-				521ED9AB1C00D3240092B2E9 /* SystemPath.cpp */,
-				521ED9AC1C00D3240092B2E9 /* SystemPath.h */,
-				521ED9AD1C00D3240092B2E9 /* Makefile.am */,
-			);
-			name = galaxy;
-			sourceTree = "<group>";
-		};
-		521ED97D1C00D25E0092B2E9 /* gameui */ = {
-			isa = PBXGroup;
-			children = (
-				521ED9B91C00D3310092B2E9 /* BindingCapture.cpp */,
-				521ED9BA1C00D3310092B2E9 /* BindingCapture.h */,
-				521ED9BB1C00D3310092B2E9 /* Face.cpp */,
-				521ED9BC1C00D3310092B2E9 /* Face.h */,
-				521ED9BD1C00D3310092B2E9 /* GameUI.h */,
-				521ED9BE1C00D3310092B2E9 /* Lua.cpp */,
-				521ED9BF1C00D3310092B2E9 /* Lua.h */,
-				521ED9C01C00D3310092B2E9 /* LuaBindingCapture.cpp */,
-				521ED9C11C00D3310092B2E9 /* LuaFace.cpp */,
-				521ED9C21C00D3310092B2E9 /* LuaModelSpinner.cpp */,
-				521ED9C31C00D3310092B2E9 /* ModelSpinner.cpp */,
-				521ED9C41C00D3310092B2E9 /* ModelSpinner.h */,
-				521ED9C51C00D3310092B2E9 /* Panel.cpp */,
-				521ED9C61C00D3310092B2E9 /* Panel.h */,
-				521ED9C71C00D3310092B2E9 /* Makefile.am */,
-			);
-			name = gameui;
-			sourceTree = "<group>";
-		};
-		521ED97E1C00D2650092B2E9 /* graphics */ = {
-			isa = PBXGroup;
-			children = (
-				521ED9D11C00D3430092B2E9 /* dummy */,
-				521ED9DA1C00D3430092B2E9 /* opengl */,
-				521EDA051C00D3430092B2E9 /* Drawables.cpp */,
-				521EDA061C00D3430092B2E9 /* Drawables.h */,
-				521EDA071C00D3430092B2E9 /* Frustum.cpp */,
-				521EDA081C00D3430092B2E9 /* Frustum.h */,
-				521EDA091C00D3430092B2E9 /* Graphics.cpp */,
-				521EDA0A1C00D3430092B2E9 /* Graphics.h */,
-				521EDA0B1C00D3430092B2E9 /* Light.cpp */,
-				521EDA0C1C00D3430092B2E9 /* Light.h */,
-				521EDA0D1C00D3430092B2E9 /* Material.cpp */,
-				521EDA0E1C00D3430092B2E9 /* Material.h */,
-				521EDA0F1C00D3430092B2E9 /* Renderer.cpp */,
-				521EDA101C00D3430092B2E9 /* Renderer.h */,
-				521EDA111C00D3430092B2E9 /* RenderState.h */,
-				521EDA121C00D3430092B2E9 /* RenderTarget.h */,
-				521EDA131C00D3430092B2E9 /* Stats.cpp */,
-				521EDA141C00D3430092B2E9 /* Stats.h */,
-				521EDA151C00D3430092B2E9 /* Texture.h */,
-				521EDA161C00D3430092B2E9 /* TextureBuilder.cpp */,
-				521EDA171C00D3430092B2E9 /* TextureBuilder.h */,
-				521EDA181C00D3430092B2E9 /* Types.h */,
-				521EDA191C00D3430092B2E9 /* VertexArray.cpp */,
-				521EDA1A1C00D3430092B2E9 /* VertexArray.h */,
-				521EDA1B1C00D3430092B2E9 /* VertexBuffer.cpp */,
-				521EDA1C1C00D3430092B2E9 /* VertexBuffer.h */,
-				521EDA1D1C00D3430092B2E9 /* WindowSDL.cpp */,
-				521EDA1E1C00D3430092B2E9 /* WindowSDL.h */,
-				521EDA1F1C00D3430092B2E9 /* Makefile.am */,
-			);
-			name = graphics;
-			sourceTree = "<group>";
-		};
-		521ED97F1C00D26B0092B2E9 /* gui */ = {
-			isa = PBXGroup;
-			children = (
-				521EDA411C00D3550092B2E9 /* Gui.cpp */,
-				521EDA421C00D3550092B2E9 /* Gui.h */,
-				521EDA431C00D3550092B2E9 /* GuiAdjustment.h */,
-				521EDA441C00D3550092B2E9 /* GuiBox.cpp */,
-				521EDA451C00D3550092B2E9 /* GuiBox.h */,
-				521EDA461C00D3550092B2E9 /* GuiButton.cpp */,
-				521EDA471C00D3550092B2E9 /* GuiButton.h */,
-				521EDA481C00D3550092B2E9 /* GuiContainer.cpp */,
-				521EDA491C00D3550092B2E9 /* GuiContainer.h */,
-				521EDA4A1C00D3550092B2E9 /* GuiEvents.h */,
-				521EDA4B1C00D3550092B2E9 /* GuiFixed.cpp */,
-				521EDA4C1C00D3550092B2E9 /* GuiFixed.h */,
-				521EDA4D1C00D3550092B2E9 /* GuiImage.cpp */,
-				521EDA4E1C00D3550092B2E9 /* GuiImage.h */,
-				521EDA4F1C00D3550092B2E9 /* GuiImageButton.cpp */,
-				521EDA501C00D3550092B2E9 /* GuiImageButton.h */,
-				521EDA511C00D3550092B2E9 /* GuiImageRadioButton.cpp */,
-				521EDA521C00D3550092B2E9 /* GuiImageRadioButton.h */,
-				521EDA531C00D3550092B2E9 /* GuiISelectable.h */,
-				521EDA541C00D3550092B2E9 /* GuiLabel.cpp */,
-				521EDA551C00D3550092B2E9 /* GuiLabel.h */,
-				521EDA561C00D3550092B2E9 /* GuiLabelSet.cpp */,
-				521EDA571C00D3550092B2E9 /* GuiLabelSet.h */,
-				521EDA581C00D3550092B2E9 /* GuiMeterBar.cpp */,
-				521EDA591C00D3550092B2E9 /* GuiMeterBar.h */,
-				521EDA5A1C00D3550092B2E9 /* GuiMultiStateImageButton.cpp */,
-				521EDA5B1C00D3550092B2E9 /* GuiMultiStateImageButton.h */,
-				521EDA5C1C00D3550092B2E9 /* GuiRadioButton.cpp */,
-				521EDA5D1C00D3550092B2E9 /* GuiRadioButton.h */,
-				521EDA5E1C00D3550092B2E9 /* GuiRadioGroup.cpp */,
-				521EDA5F1C00D3550092B2E9 /* GuiRadioGroup.h */,
-				521EDA601C00D3550092B2E9 /* GuiScreen.cpp */,
-				521EDA611C00D3550092B2E9 /* GuiScreen.h */,
-				521EDA621C00D3550092B2E9 /* GuiStack.cpp */,
-				521EDA631C00D3550092B2E9 /* GuiStack.h */,
-				521EDA641C00D3550092B2E9 /* GuiTabbed.cpp */,
-				521EDA651C00D3550092B2E9 /* GuiTabbed.h */,
-				521EDA661C00D3550092B2E9 /* GuiTextEntry.cpp */,
-				521EDA671C00D3550092B2E9 /* GuiTextEntry.h */,
-				521EDA681C00D3550092B2E9 /* GuiTextLayout.cpp */,
-				521EDA691C00D3550092B2E9 /* GuiTextLayout.h */,
-				521EDA6A1C00D3550092B2E9 /* GuiTexturedQuad.cpp */,
-				521EDA6B1C00D3550092B2E9 /* GuiTexturedQuad.h */,
-				521EDA6C1C00D3550092B2E9 /* GuiToggleButton.cpp */,
-				521EDA6D1C00D3550092B2E9 /* GuiToggleButton.h */,
-				521EDA6E1C00D3550092B2E9 /* GuiToolTip.cpp */,
-				521EDA6F1C00D3550092B2E9 /* GuiToolTip.h */,
-				521EDA701C00D3550092B2E9 /* GuiVScrollBar.cpp */,
-				521EDA711C00D3550092B2E9 /* GuiVScrollBar.h */,
-				521EDA721C00D3550092B2E9 /* GuiVScrollPortal.cpp */,
-				521EDA731C00D3550092B2E9 /* GuiVScrollPortal.h */,
-				521EDA741C00D3550092B2E9 /* GuiWidget.cpp */,
-				521EDA751C00D3550092B2E9 /* GuiWidget.h */,
-				521EDA761C00D3550092B2E9 /* Makefile.am */,
-			);
-			name = gui;
-			sourceTree = "<group>";
-		};
-		521ED9801C00D2740092B2E9 /* posix */ = {
-			isa = PBXGroup;
-			children = (
-				521EDA911C00D3610092B2E9 /* FileSystemPosix.cpp */,
-				521EDA921C00D3610092B2E9 /* OSPosix.cpp */,
-				521EDA931C00D3610092B2E9 /* Makefile.am */,
-			);
-			name = posix;
-			sourceTree = "<group>";
-		};
-		521ED9811C00D2790092B2E9 /* scenegraph */ = {
-			isa = PBXGroup;
-			children = (
-				521EDA971C00D36D0092B2E9 /* Animation.cpp */,
-				521EDA981C00D36D0092B2E9 /* Animation.h */,
-				521EDA991C00D36D0092B2E9 /* AnimationChannel.h */,
-				521EDA9A1C00D36D0092B2E9 /* AnimationKey.h */,
-				521EDA9B1C00D36D0092B2E9 /* BaseLoader.cpp */,
-				521EDA9C1C00D36D0092B2E9 /* BaseLoader.h */,
-				521EDA9D1C00D36D0092B2E9 /* Billboard.cpp */,
-				521EDA9E1C00D36D0092B2E9 /* Billboard.h */,
-				521EDA9F1C00D36D0092B2E9 /* BinaryConverter.cpp */,
-				521EDAA01C00D36D0092B2E9 /* BinaryConverter.h */,
-				521EDAA11C00D36D0092B2E9 /* CollisionGeometry.cpp */,
-				521EDAA21C00D36D0092B2E9 /* CollisionGeometry.h */,
-				521EDAA31C00D36D0092B2E9 /* CollisionVisitor.cpp */,
-				521EDAA41C00D36D0092B2E9 /* CollisionVisitor.h */,
-				521EDAA51C00D36D0092B2E9 /* ColorMap.cpp */,
-				521EDAA61C00D36D0092B2E9 /* ColorMap.h */,
-				521EDAA71C00D36D0092B2E9 /* DumpVisitor.cpp */,
-				521EDAA81C00D36D0092B2E9 /* DumpVisitor.h */,
-				521EDAA91C00D36D0092B2E9 /* FindNodeVisitor.cpp */,
-				521EDAAA1C00D36D0092B2E9 /* FindNodeVisitor.h */,
-				521EDAAB1C00D36D0092B2E9 /* Group.cpp */,
-				521EDAAC1C00D36D0092B2E9 /* Group.h */,
-				521EDAAD1C00D36D0092B2E9 /* Label3D.cpp */,
-				521EDAAE1C00D36D0092B2E9 /* Label3D.h */,
-				521EDAAF1C00D36D0092B2E9 /* Loader.cpp */,
-				521EDAB01C00D36D0092B2E9 /* Loader.h */,
-				521EDAB11C00D36D0092B2E9 /* LoaderDefinitions.h */,
-				521EDAB21C00D36D0092B2E9 /* LOD.cpp */,
-				521EDAB31C00D36D0092B2E9 /* LOD.h */,
-				521EDAB41C00D36D0092B2E9 /* Lua.cpp */,
-				521EDAB51C00D36D0092B2E9 /* Lua.h */,
-				521EDAB61C00D36D0092B2E9 /* LuaModel.cpp */,
-				521EDAB71C00D36D0092B2E9 /* LuaModelSkin.cpp */,
-				521EDAB81C00D36D0092B2E9 /* MatrixTransform.cpp */,
-				521EDAB91C00D36D0092B2E9 /* MatrixTransform.h */,
-				521EDABA1C00D36D0092B2E9 /* Model.cpp */,
-				521EDABB1C00D36D0092B2E9 /* Model.h */,
-				521EDABC1C00D36D0092B2E9 /* ModelNode.cpp */,
-				521EDABD1C00D36D0092B2E9 /* ModelNode.h */,
-				521EDABE1C00D36D0092B2E9 /* ModelSkin.cpp */,
-				521EDABF1C00D36D0092B2E9 /* ModelSkin.h */,
-				521EDAC01C00D36D0092B2E9 /* Node.cpp */,
-				521EDAC11C00D36D0092B2E9 /* Node.h */,
-				521EDAC21C00D36D0092B2E9 /* NodeCopyCache.h */,
-				521EDAC31C00D36D0092B2E9 /* NodeVisitor.cpp */,
-				521EDAC41C00D36D0092B2E9 /* NodeVisitor.h */,
-				521EDAC51C00D36D0092B2E9 /* Parser.cpp */,
-				521EDAC61C00D36D0092B2E9 /* Parser.h */,
-				521EDAC71C00D36D0092B2E9 /* Pattern.cpp */,
-				521EDAC81C00D36D0092B2E9 /* Pattern.h */,
-				521EDAC91C00D36D0092B2E9 /* SceneGraph.h */,
-				521EDACA1C00D36D0092B2E9 /* StaticGeometry.cpp */,
-				521EDACB1C00D36D0092B2E9 /* StaticGeometry.h */,
-				521EDACC1C00D36D0092B2E9 /* Thruster.cpp */,
-				521EDACD1C00D36D0092B2E9 /* Thruster.h */,
-				521EDACE1C00D36D0092B2E9 /* Makefile.am */,
-			);
-			name = scenegraph;
-			sourceTree = "<group>";
-		};
-		521ED9821C00D2880092B2E9 /* terrain */ = {
-			isa = PBXGroup;
-			children = (
-				521EDAEA1C00D37B0092B2E9 /* Terrain.cpp */,
-				521EDAEB1C00D37B0092B2E9 /* Terrain.h */,
-				521EDAEC1C00D37B0092B2E9 /* TerrainColorAsteroid.cpp */,
-				521EDAED1C00D37B0092B2E9 /* TerrainColorBandedRock.cpp */,
-				521EDAEE1C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp */,
-				521EDAEF1C00D37B0092B2E9 /* TerrainColorDesert.cpp */,
-				521EDAF01C00D37B0092B2E9 /* TerrainColorEarthLike.cpp */,
-				521EDAF11C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp */,
-				521EDAF21C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp */,
-				521EDAF31C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp */,
-				521EDAF41C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp */,
-				521EDAF51C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp */,
-				521EDAF61C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp */,
-				521EDAF71C00D37B0092B2E9 /* TerrainColorGGUranus.cpp */,
-				521EDAF81C00D37B0092B2E9 /* TerrainColorIce.cpp */,
-				521EDAF91C00D37B0092B2E9 /* TerrainColorMethane.cpp */,
-				521EDAFA1C00D37B0092B2E9 /* TerrainColorRock.cpp */,
-				521EDAFB1C00D37B0092B2E9 /* TerrainColorRock2.cpp */,
-				521EDAFC1C00D37B0092B2E9 /* TerrainColorSolid.cpp */,
-				521EDAFD1C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp */,
-				521EDAFE1C00D37B0092B2E9 /* TerrainColorStarG.cpp */,
-				521EDAFF1C00D37B0092B2E9 /* TerrainColorStarK.cpp */,
-				521EDB001C00D37B0092B2E9 /* TerrainColorStarM.cpp */,
-				521EDB011C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp */,
-				521EDB021C00D37B0092B2E9 /* TerrainColorTFGood.cpp */,
-				521EDB031C00D37B0092B2E9 /* TerrainColorTFPoor.cpp */,
-				521EDB041C00D37B0092B2E9 /* TerrainColorVolcanic.cpp */,
-				521EDB051C00D37B0092B2E9 /* TerrainFeature.cpp */,
-				521EDB061C00D37B0092B2E9 /* TerrainFeature.h */,
-				521EDB071C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp */,
-				521EDB081C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp */,
-				521EDB091C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp */,
-				521EDB0A1C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp */,
-				521EDB0B1C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp */,
-				521EDB0C1C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp */,
-				521EDB0D1C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp */,
-				521EDB0E1C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp */,
-				521EDB0F1C00D37B0092B2E9 /* TerrainHeightFlat.cpp */,
-				521EDB101C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp */,
-				521EDB111C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp */,
-				521EDB121C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp */,
-				521EDB131C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp */,
-				521EDB141C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp */,
-				521EDB151C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp */,
-				521EDB161C00D37B0092B2E9 /* TerrainHeightMapped.cpp */,
-				521EDB171C00D37B0092B2E9 /* TerrainHeightMapped2.cpp */,
-				521EDB181C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp */,
-				521EDB191C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp */,
-				521EDB1A1C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp */,
-				521EDB1B1C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp */,
-				521EDB1C1C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp */,
-				521EDB1D1C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp */,
-				521EDB1E1C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp */,
-				521EDB1F1C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp */,
-				521EDB201C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp */,
-				521EDB211C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp */,
-				521EDB221C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp */,
-				521EDB231C00D37B0092B2E9 /* TerrainNoise.h */,
-				521EDB241C00D37B0092B2E9 /* Makefile.am */,
-			);
-			name = terrain;
-			sourceTree = "<group>";
-		};
-		521ED9831C00D28F0092B2E9 /* text */ = {
-			isa = PBXGroup;
-			children = (
-				521EDB5D1C00D38B0092B2E9 /* DistanceFieldFont.cpp */,
-				521EDB5E1C00D38B0092B2E9 /* DistanceFieldFont.h */,
-				521EDB5F1C00D38B0092B2E9 /* FontConfig.cpp */,
-				521EDB601C00D38B0092B2E9 /* FontConfig.h */,
-				521EDB611C00D38B0092B2E9 /* TextSupport.cpp */,
-				521EDB621C00D38B0092B2E9 /* TextSupport.h */,
-				521EDB631C00D38B0092B2E9 /* TextureFont.cpp */,
-				521EDB641C00D38B0092B2E9 /* TextureFont.h */,
-				521EDB651C00D38B0092B2E9 /* Makefile.am */,
-			);
-			name = text;
-			sourceTree = "<group>";
-		};
-		521ED9841C00D29E0092B2E9 /* ui */ = {
-			isa = PBXGroup;
-			children = (
-				521EDB6B1C00D3A20092B2E9 /* Align.cpp */,
-				521EDB6C1C00D3A20092B2E9 /* Align.h */,
-				521EDB6D1C00D3A20092B2E9 /* Animation.cpp */,
-				521EDB6E1C00D3A20092B2E9 /* Animation.h */,
-				521EDB6F1C00D3A20092B2E9 /* Background.cpp */,
-				521EDB701C00D3A20092B2E9 /* Background.h */,
-				521EDB711C00D3A20092B2E9 /* Box.cpp */,
-				521EDB721C00D3A20092B2E9 /* Box.h */,
-				521EDB731C00D3A20092B2E9 /* Button.cpp */,
-				521EDB741C00D3A20092B2E9 /* Button.h */,
-				521EDB751C00D3A20092B2E9 /* CellSpec.cpp */,
-				521EDB761C00D3A20092B2E9 /* CellSpec.h */,
-				521EDB771C00D3A20092B2E9 /* CheckBox.cpp */,
-				521EDB781C00D3A20092B2E9 /* CheckBox.h */,
-				521EDB791C00D3A20092B2E9 /* ColorBackground.cpp */,
-				521EDB7A1C00D3A20092B2E9 /* ColorBackground.h */,
-				521EDB7B1C00D3A20092B2E9 /* Container.cpp */,
-				521EDB7C1C00D3A20092B2E9 /* Container.h */,
-				521EDB7D1C00D3A20092B2E9 /* Context.cpp */,
-				521EDB7E1C00D3A20092B2E9 /* Context.h */,
-				521EDB7F1C00D3A20092B2E9 /* DropDown.cpp */,
-				521EDB801C00D3A20092B2E9 /* DropDown.h */,
-				521EDB811C00D3A20092B2E9 /* Event.cpp */,
-				521EDB821C00D3A20092B2E9 /* Event.h */,
-				521EDB831C00D3A20092B2E9 /* EventDispatcher.cpp */,
-				521EDB841C00D3A20092B2E9 /* EventDispatcher.h */,
-				521EDB851C00D3A20092B2E9 /* Expand.cpp */,
-				521EDB861C00D3A20092B2E9 /* Expand.h */,
-				521EDB871C00D3A20092B2E9 /* Gauge.cpp */,
-				521EDB881C00D3A20092B2E9 /* Gauge.h */,
-				521EDB891C00D3A20092B2E9 /* Gradient.cpp */,
-				521EDB8A1C00D3A20092B2E9 /* Gradient.h */,
-				521EDB8B1C00D3A20092B2E9 /* Grid.cpp */,
-				521EDB8C1C00D3A20092B2E9 /* Grid.h */,
-				521EDB8D1C00D3A20092B2E9 /* Icon.cpp */,
-				521EDB8E1C00D3A20092B2E9 /* Icon.h */,
-				521EDB8F1C00D3A20092B2E9 /* Image.cpp */,
-				521EDB901C00D3A20092B2E9 /* Image.h */,
-				521EDB911C00D3A20092B2E9 /* Label.cpp */,
-				521EDB921C00D3A20092B2E9 /* Label.h */,
-				521EDB931C00D3A20092B2E9 /* Layer.cpp */,
-				521EDB941C00D3A20092B2E9 /* Layer.h */,
-				521EDB951C00D3A20092B2E9 /* List.cpp */,
-				521EDB961C00D3A20092B2E9 /* List.h */,
-				521EDB971C00D3A20092B2E9 /* Lua.cpp */,
-				521EDB981C00D3A20092B2E9 /* Lua.h */,
-				521EDB991C00D3A20092B2E9 /* LuaAlign.cpp */,
-				521EDB9A1C00D3A20092B2E9 /* LuaAnimation.cpp */,
-				521EDB9B1C00D3A20092B2E9 /* LuaBackground.cpp */,
-				521EDB9C1C00D3A20092B2E9 /* LuaBox.cpp */,
-				521EDB9D1C00D3A20092B2E9 /* LuaButton.cpp */,
-				521EDB9E1C00D3A20092B2E9 /* LuaCheckBox.cpp */,
-				521EDB9F1C00D3A20092B2E9 /* LuaColorBackground.cpp */,
-				521EDBA01C00D3A20092B2E9 /* LuaContainer.cpp */,
-				521EDBA11C00D3A20092B2E9 /* LuaContext.cpp */,
-				521EDBA21C00D3A20092B2E9 /* LuaDropDown.cpp */,
-				521EDBA31C00D3A20092B2E9 /* LuaExpand.cpp */,
-				521EDBA41C00D3A20092B2E9 /* LuaGauge.cpp */,
-				521EDBA51C00D3A20092B2E9 /* LuaGradient.cpp */,
-				521EDBA61C00D3A20092B2E9 /* LuaGrid.cpp */,
-				521EDBA71C00D3A20092B2E9 /* LuaIcon.cpp */,
-				521EDBA81C00D3A20092B2E9 /* LuaImage.cpp */,
-				521EDBA91C00D3A20092B2E9 /* LuaLabel.cpp */,
-				521EDBAA1C00D3A20092B2E9 /* LuaLayer.cpp */,
-				521EDBAB1C00D3A20092B2E9 /* LuaList.cpp */,
-				521EDBAC1C00D3A20092B2E9 /* LuaMargin.cpp */,
-				521EDBAD1C00D3A20092B2E9 /* LuaMultiLineText.cpp */,
-				521EDBAE1C00D3A20092B2E9 /* LuaNumberLabel.cpp */,
-				521EDBAF1C00D3A20092B2E9 /* LuaScroller.cpp */,
-				521EDBB01C00D3A20092B2E9 /* LuaSignal.h */,
-				521EDBB11C00D3A20092B2E9 /* LuaSingle.cpp */,
-				521EDBB21C00D3A20092B2E9 /* LuaSlider.cpp */,
-				521EDBB31C00D3A20092B2E9 /* LuaSmallButton.cpp */,
-				521EDBB41C00D3A20092B2E9 /* LuaTable.cpp */,
-				521EDBB51C00D3A20092B2E9 /* LuaTextEntry.cpp */,
-				521EDBB61C00D3A20092B2E9 /* LuaWidget.cpp */,
-				521EDBB71C00D3A20092B2E9 /* Margin.cpp */,
-				521EDBB81C00D3A20092B2E9 /* Margin.h */,
-				521EDBB91C00D3A20092B2E9 /* MousePointer.h */,
-				521EDBBA1C00D3A20092B2E9 /* MultiLineText.cpp */,
-				521EDBBB1C00D3A20092B2E9 /* MultiLineText.h */,
-				521EDBBC1C00D3A20092B2E9 /* NumberLabel.cpp */,
-				521EDBBD1C00D3A20092B2E9 /* NumberLabel.h */,
-				521EDBBE1C00D3A20092B2E9 /* Point.h */,
-				521EDBBF1C00D3A20092B2E9 /* Scroller.cpp */,
-				521EDBC01C00D3A20092B2E9 /* Scroller.h */,
-				521EDBC11C00D3A20092B2E9 /* Single.cpp */,
-				521EDBC21C00D3A20092B2E9 /* Single.h */,
-				521EDBC31C00D3A20092B2E9 /* Skin.cpp */,
-				521EDBC41C00D3A20092B2E9 /* Skin.h */,
-				521EDBC51C00D3A20092B2E9 /* Slider.cpp */,
-				521EDBC61C00D3A20092B2E9 /* Slider.h */,
-				521EDBC71C00D3A20092B2E9 /* SmallButton.cpp */,
-				521EDBC81C00D3A20092B2E9 /* SmallButton.h */,
-				521EDBC91C00D3A20092B2E9 /* Table.cpp */,
-				521EDBCA1C00D3A20092B2E9 /* Table.h */,
-				521EDBCB1C00D3A20092B2E9 /* TextEntry.cpp */,
-				521EDBCC1C00D3A20092B2E9 /* TextEntry.h */,
-				521EDBCD1C00D3A20092B2E9 /* TextLayout.cpp */,
-				521EDBCE1C00D3A20092B2E9 /* TextLayout.h */,
-				521EDBCF1C00D3A20092B2E9 /* Widget.cpp */,
-				521EDBD01C00D3A20092B2E9 /* Widget.h */,
-				521EDBD11C00D3A20092B2E9 /* WidgetSet.h */,
-				521EDBD21C00D3A20092B2E9 /* Makefile.am */,
-			);
-			name = ui;
-			sourceTree = "<group>";
-		};
-		521ED9D11C00D3430092B2E9 /* dummy */ = {
-			isa = PBXGroup;
-			children = (
-				521ED9D21C00D3430092B2E9 /* Makefile.am */,
-				521ED9D31C00D3430092B2E9 /* MaterialDummy.h */,
-				521ED9D41C00D3430092B2E9 /* RendererDummy.cpp */,
-				521ED9D51C00D3430092B2E9 /* RendererDummy.h */,
-				521ED9D61C00D3430092B2E9 /* RenderStateDummy.h */,
-				521ED9D71C00D3430092B2E9 /* RenderTargetDummy.h */,
-				521ED9D81C00D3430092B2E9 /* TextureDummy.h */,
-				521ED9D91C00D3430092B2E9 /* VertexBufferDummy.h */,
-			);
-			name = dummy;
-			path = ../src/graphics/dummy;
-			sourceTree = "<group>";
-		};
-		521ED9DA1C00D3430092B2E9 /* opengl */ = {
-			isa = PBXGroup;
-			children = (
-				521ED9DB1C00D3430092B2E9 /* FresnelColourMaterial.cpp */,
-				521ED9DC1C00D3430092B2E9 /* FresnelColourMaterial.h */,
-				521ED9DD1C00D3430092B2E9 /* GasGiantMaterial.cpp */,
-				521ED9DE1C00D3430092B2E9 /* GasGiantMaterial.h */,
-				521ED9DF1C00D3430092B2E9 /* GeoSphereMaterial.cpp */,
-				521ED9E01C00D3430092B2E9 /* GeoSphereMaterial.h */,
-				521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */,
-				521ED9E21C00D3430092B2E9 /* gl_core_3_x.h */,
-				521ED9E31C00D3430092B2E9 /* GLDebug.h */,
-				521ED9E61C00D3430092B2E9 /* Makefile.am */,
-				521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */,
-				521ED9E81C00D3430092B2E9 /* MaterialGL.h */,
-				521ED9E91C00D3430092B2E9 /* MultiMaterial.cpp */,
-				521ED9EA1C00D3430092B2E9 /* MultiMaterial.h */,
-				521ED9EB1C00D3430092B2E9 /* OpenGLLibs.h */,
-				521ED9EC1C00D3430092B2E9 /* Program.cpp */,
-				521ED9ED1C00D3430092B2E9 /* Program.h */,
-				521ED9EE1C00D3430092B2E9 /* RendererGL.cpp */,
-				521ED9EF1C00D3430092B2E9 /* RendererGL.h */,
-				521ED9F01C00D3430092B2E9 /* RenderStateGL.cpp */,
-				521ED9F11C00D3430092B2E9 /* RenderStateGL.h */,
-				521ED9F21C00D3430092B2E9 /* RenderTargetGL.cpp */,
-				521ED9F31C00D3430092B2E9 /* RenderTargetGL.h */,
-				521ED9F41C00D3430092B2E9 /* RingMaterial.cpp */,
-				521ED9F51C00D3430092B2E9 /* RingMaterial.h */,
-				521ED9F61C00D3430092B2E9 /* ShieldMaterial.cpp */,
-				521ED9F71C00D3430092B2E9 /* ShieldMaterial.h */,
-				521ED9F81C00D3430092B2E9 /* SkyboxMaterial.h */,
-				521ED9F91C00D3430092B2E9 /* SphereImpostorMaterial.h */,
-				521ED9FA1C00D3430092B2E9 /* StarfieldMaterial.h */,
-				521ED9FB1C00D3430092B2E9 /* TextureGL.cpp */,
-				521ED9FC1C00D3430092B2E9 /* TextureGL.h */,
-				521ED9FD1C00D3430092B2E9 /* UIMaterial.cpp */,
-				521ED9FE1C00D3430092B2E9 /* UIMaterial.h */,
-				521ED9FF1C00D3430092B2E9 /* Uniform.cpp */,
-				521EDA001C00D3430092B2E9 /* Uniform.h */,
-				521EDA011C00D3430092B2E9 /* VertexBufferGL.cpp */,
-				521EDA021C00D3430092B2E9 /* VertexBufferGL.h */,
-				521EDA031C00D3430092B2E9 /* VtxColorMaterial.cpp */,
-				521EDA041C00D3430092B2E9 /* VtxColorMaterial.h */,
-			);
-			name = opengl;
-			path = ../src/graphics/opengl;
-			sourceTree = "<group>";
-		};
-		52D1258A1C0351FB00E6E4C2 /* contrib */ = {
-			isa = PBXGroup;
-			children = (
-				52E5FAF11C0375F2001F4F89 /* miniz */,
-				52E5FADD1C03589F001F4F89 /* jenkins */,
-				52D1261A1C03538F00E6E4C2 /* lua */,
-				52D125921C0351FB00E6E4C2 /* json */,
-				52D125DE1C0351FB00E6E4C2 /* PicoDDS */,
-			);
-			name = contrib;
-			path = ../contrib;
-			sourceTree = "<group>";
-		};
-		52D125921C0351FB00E6E4C2 /* json */ = {
-			isa = PBXGroup;
-			children = (
-				52D125931C0351FB00E6E4C2 /* json.h */,
-				52D125941C0351FB00E6E4C2 /* jsoncpp.cpp */,
-				52D125951C0351FB00E6E4C2 /* JsonUtils.cpp */,
-				52D125961C0351FB00E6E4C2 /* JsonUtils.h */,
-				52D125971C0351FB00E6E4C2 /* Makefile.am */,
-			);
-			path = json;
-			sourceTree = "<group>";
-		};
-		52D125DE1C0351FB00E6E4C2 /* PicoDDS */ = {
-			isa = PBXGroup;
-			children = (
-				52D125DF1C0351FB00E6E4C2 /* Makefile.am */,
-				52D125E01C0351FB00E6E4C2 /* PicoDDS.cpp */,
-				52D125E11C0351FB00E6E4C2 /* PicoDDS.h */,
-			);
-			path = PicoDDS;
-			sourceTree = "<group>";
-		};
-		52D1261A1C03538F00E6E4C2 /* lua */ = {
-			isa = PBXGroup;
-			children = (
-				52D1261B1C03538F00E6E4C2 /* lapi.c */,
-				52D1261C1C03538F00E6E4C2 /* lapi.h */,
-				52D1261D1C03538F00E6E4C2 /* lauxlib.c */,
-				52D1261E1C03538F00E6E4C2 /* lauxlib.h */,
-				52D1261F1C03538F00E6E4C2 /* lbaselib.c */,
-				52D126201C03538F00E6E4C2 /* lbitlib.c */,
-				52D126211C03538F00E6E4C2 /* lcode.c */,
-				52D126221C03538F00E6E4C2 /* lcode.h */,
-				52D126231C03538F00E6E4C2 /* lcorolib.c */,
-				52D126241C03538F00E6E4C2 /* lctype.c */,
-				52D126251C03538F00E6E4C2 /* lctype.h */,
-				52D126261C03538F00E6E4C2 /* ldblib.c */,
-				52D126271C03538F00E6E4C2 /* ldebug.c */,
-				52D126281C03538F00E6E4C2 /* ldebug.h */,
-				52D126291C03538F00E6E4C2 /* ldo.c */,
-				52D1262A1C03538F00E6E4C2 /* ldo.h */,
-				52D1262B1C03538F00E6E4C2 /* ldump.c */,
-				52D1262C1C03538F00E6E4C2 /* lfunc.c */,
-				52D1262D1C03538F00E6E4C2 /* lfunc.h */,
-				52D1262E1C03538F00E6E4C2 /* lgc.c */,
-				52D1262F1C03538F00E6E4C2 /* lgc.h */,
-				52D126301C03538F00E6E4C2 /* linit.c */,
-				52D126311C03538F00E6E4C2 /* liolib.c */,
-				52D126321C03538F00E6E4C2 /* llex.c */,
-				52D126331C03538F00E6E4C2 /* llex.h */,
-				52D126341C03538F00E6E4C2 /* llimits.h */,
-				52D126351C03538F00E6E4C2 /* lmathlib.c */,
-				52D126361C03538F00E6E4C2 /* lmem.c */,
-				52D126371C03538F00E6E4C2 /* lmem.h */,
-				52D126381C03538F00E6E4C2 /* loadlib.c */,
-				52D126391C03538F00E6E4C2 /* lobject.c */,
-				52D1263A1C03538F00E6E4C2 /* lobject.h */,
-				52D1263B1C03538F00E6E4C2 /* lopcodes.c */,
-				52D1263C1C03538F00E6E4C2 /* lopcodes.h */,
-				52D1263D1C03538F00E6E4C2 /* loslib.c */,
-				52D1263E1C03538F00E6E4C2 /* lparser.c */,
-				52D1263F1C03538F00E6E4C2 /* lparser.h */,
-				52D126401C03538F00E6E4C2 /* lstate.c */,
-				52D126411C03538F00E6E4C2 /* lstate.h */,
-				52D126421C03538F00E6E4C2 /* lstring.c */,
-				52D126431C03538F00E6E4C2 /* lstring.h */,
-				52D126441C03538F00E6E4C2 /* lstrlib.c */,
-				52D126451C03538F00E6E4C2 /* ltable.c */,
-				52D126461C03538F00E6E4C2 /* ltable.h */,
-				52D126471C03538F00E6E4C2 /* ltablib.c */,
-				52D126481C03538F00E6E4C2 /* ltm.c */,
-				52D126491C03538F00E6E4C2 /* ltm.h */,
-				52D1264B1C03538F00E6E4C2 /* lua.h */,
-				52D1264C1C03538F00E6E4C2 /* lua.hpp */,
-				52D1264E1C03538F00E6E4C2 /* luaconf.h */,
-				52D1264F1C03538F00E6E4C2 /* lualib.h */,
-				52D126501C03538F00E6E4C2 /* lundump.c */,
-				52D126511C03538F00E6E4C2 /* lundump.h */,
-				52D126521C03538F00E6E4C2 /* lvm.c */,
-				52D126531C03538F00E6E4C2 /* lvm.h */,
-				52D126541C03538F00E6E4C2 /* lzio.c */,
-				52D126551C03538F00E6E4C2 /* lzio.h */,
-				52D126561C03538F00E6E4C2 /* Makefile.am */,
-			);
-			path = lua;
-			sourceTree = "<group>";
-		};
-		52E5FADD1C03589F001F4F89 /* jenkins */ = {
-			isa = PBXGroup;
-			children = (
-				52E5FADE1C03589F001F4F89 /* lookup3.c */,
-				52E5FADF1C03589F001F4F89 /* lookup3.h */,
-				52E5FAE01C03589F001F4F89 /* Makefile.am */,
-			);
-			path = jenkins;
-			sourceTree = "<group>";
-		};
-		52E5FAF11C0375F2001F4F89 /* miniz */ = {
-			isa = PBXGroup;
-			children = (
-				52E5FAF21C0375F2001F4F89 /* Makefile.am */,
-				52E5FAF31C0375F2001F4F89 /* miniz.h */,
-				52E5FAF41C0375F2001F4F89 /* README */,
+				4AAC9FDF15458FE400116131 /* miniz.h */,
 			);
 			path = miniz;
+			sourceTree = "<group>";
+		};
+		4AB7D5CF1472A83E00158DE4 /* terrain */ = {
+			isa = PBXGroup;
+			children = (
+				378563CB1B197DC90039F2BC /* TerrainColorEarthLikeHeightmapped.cpp */,
+				4AB7D5D11472A83E00158DE4 /* Terrain.cpp */,
+				4AB7D5D21472A83E00158DE4 /* Terrain.h */,
+				4AB7D5D31472A83E00158DE4 /* TerrainColorAsteroid.cpp */,
+				4AB7D5D41472A83E00158DE4 /* TerrainColorBandedRock.cpp */,
+				4AB7D5D51472A83E00158DE4 /* TerrainColorDeadWithWater.cpp */,
+				4AB7D5D61472A83E00158DE4 /* TerrainColorDesert.cpp */,
+				4AB7D5D71472A83E00158DE4 /* TerrainColorEarthLike.cpp */,
+				4AB7D5D81472A83E00158DE4 /* TerrainColorGGJupiter.cpp */,
+				4AB7D5D91472A83E00158DE4 /* TerrainColorGGNeptune.cpp */,
+				4AB7D5DA1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp */,
+				4AB7D5DB1472A83E00158DE4 /* TerrainColorGGSaturn.cpp */,
+				4AB7D5DC1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp */,
+				4AB7D5DD1472A83E00158DE4 /* TerrainColorGGUranus.cpp */,
+				4AB7D5DE1472A83E00158DE4 /* TerrainColorIce.cpp */,
+				4AB7D5DF1472A83E00158DE4 /* TerrainColorMethane.cpp */,
+				4AB7D5E01472A83E00158DE4 /* TerrainColorRock.cpp */,
+				4AB7D5E11472A83E00158DE4 /* TerrainColorRock2.cpp */,
+				4AB7D5E21472A83E00158DE4 /* TerrainColorSolid.cpp */,
+				4AB7D5E31472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp */,
+				4AB7D5E41472A83E00158DE4 /* TerrainColorStarG.cpp */,
+				4AB7D5E51472A83E00158DE4 /* TerrainColorStarK.cpp */,
+				4AB7D5E61472A83E00158DE4 /* TerrainColorStarM.cpp */,
+				4AB7D5E71472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp */,
+				4AB7D5E81472A83E00158DE4 /* TerrainColorTFGood.cpp */,
+				4AB7D5E91472A83E00158DE4 /* TerrainColorTFPoor.cpp */,
+				4AB7D5EA1472A83E00158DE4 /* TerrainColorVolcanic.cpp */,
+				4AB7D5EB1472A83E00158DE4 /* TerrainFeature.cpp */,
+				4AB7D5EC1472A83E00158DE4 /* TerrainFeature.h */,
+				4AB7D5ED1472A83E00158DE4 /* TerrainHeightAsteroid.cpp */,
+				4ADB0D0615C50DD900AE2123 /* TerrainHeightAsteroid2.cpp */,
+				4ADB0D0715C50DD900AE2123 /* TerrainHeightAsteroid3.cpp */,
+				4ADB0D0815C50DD900AE2123 /* TerrainHeightAsteroid4.cpp */,
+				4ADB0D0915C50DD900AE2123 /* TerrainHeightBarrenRock.cpp */,
+				4ADB0D0A15C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp */,
+				4ADB0D0B15C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp */,
+				4AA9F6CB17288E0900124C2E /* TerrainHeightEllipsoid.cpp */,
+				4AB7D5EE1472A83E00158DE4 /* TerrainHeightFlat.cpp */,
+				4AB7D5EF1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp */,
+				4AB7D5F01472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp */,
+				4AB7D5F11472A83E00158DE4 /* TerrainHeightHillsDunes.cpp */,
+				4AB7D5F21472A83E00158DE4 /* TerrainHeightHillsNormal.cpp */,
+				4AB7D5F31472A83E00158DE4 /* TerrainHeightHillsRidged.cpp */,
+				4AB7D5F41472A83E00158DE4 /* TerrainHeightHillsRivers.cpp */,
+				4AB7D5F51472A83E00158DE4 /* TerrainHeightMapped.cpp */,
+				4AED721C14E1501D004D171E /* TerrainHeightMapped2.cpp */,
+				4AB7D5F61472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp */,
+				4AB7D5F71472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp */,
+				4AB7D5F81472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp */,
+				4AB7D5F91472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp */,
+				4AB7D5FA1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp */,
+				4AB7D5FB1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp */,
+				4AB7D5FC1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp */,
+				4AB7D5FD1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp */,
+				4AB7D5FE1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp */,
+				4AB7D5FF1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp */,
+				4AB7D6001472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp */,
+				4AB7D6011472A83E00158DE4 /* TerrainNoise.h */,
+			);
+			path = terrain;
+			sourceTree = "<group>";
+		};
+		4ABF302D16335A1100664653 /* ui */ = {
+			isa = PBXGroup;
+			children = (
+				378563B11B197DBB0039F2BC /* Animation.cpp */,
+				378563B21B197DBB0039F2BC /* Animation.h */,
+				378563B31B197DBB0039F2BC /* Gauge.cpp */,
+				378563B41B197DBB0039F2BC /* Gauge.h */,
+				378563B51B197DBB0039F2BC /* Layer.cpp */,
+				378563B61B197DBB0039F2BC /* Layer.h */,
+				378563B71B197DBB0039F2BC /* LuaAnimation.cpp */,
+				378563B81B197DBB0039F2BC /* LuaGauge.cpp */,
+				378563B91B197DBB0039F2BC /* LuaLayer.cpp */,
+				378563BA1B197DBB0039F2BC /* LuaNumberLabel.cpp */,
+				378563BB1B197DBB0039F2BC /* LuaTable.cpp */,
+				378563BC1B197DBB0039F2BC /* MousePointer.h */,
+				378563BD1B197DBB0039F2BC /* NumberLabel.cpp */,
+				378563BE1B197DBB0039F2BC /* NumberLabel.h */,
+				378563BF1B197DBB0039F2BC /* Table.cpp */,
+				378563C01B197DBB0039F2BC /* Table.h */,
+				4ABF302E16335A1100664653 /* Align.cpp */,
+				4ABF302F16335A1100664653 /* Align.h */,
+				4ABF303016335A1100664653 /* Background.cpp */,
+				4ABF303116335A1100664653 /* Background.h */,
+				4ABF303216335A1100664653 /* Box.cpp */,
+				4ABF303316335A1100664653 /* Box.h */,
+				4ABF303416335A1100664653 /* Button.cpp */,
+				4ABF303516335A1100664653 /* Button.h */,
+				4ABF303616335A1100664653 /* CellSpec.cpp */,
+				4ABF303716335A1100664653 /* CellSpec.h */,
+				4ABF303816335A1100664653 /* CheckBox.cpp */,
+				4ABF303916335A1100664653 /* CheckBox.h */,
+				4ABF303A16335A1100664653 /* ColorBackground.cpp */,
+				4ABF303B16335A1100664653 /* ColorBackground.h */,
+				4ABF303C16335A1100664653 /* Container.cpp */,
+				4ABF303D16335A1100664653 /* Container.h */,
+				4ABF303E16335A1100664653 /* Context.cpp */,
+				4ABF303F16335A1100664653 /* Context.h */,
+				4ABF304016335A1100664653 /* DropDown.cpp */,
+				4ABF304116335A1100664653 /* DropDown.h */,
+				4ABF304216335A1100664653 /* Event.cpp */,
+				4ABF304316335A1100664653 /* Event.h */,
+				4ABF304416335A1100664653 /* EventDispatcher.cpp */,
+				4ABF304516335A1100664653 /* EventDispatcher.h */,
+				4AA4A8D4164D0EB10006C3BF /* Expand.cpp */,
+				4AA4A8D5164D0EB10006C3BF /* Expand.h */,
+				4AA4A8D6164D0EB10006C3BF /* Gradient.cpp */,
+				4AA4A8D7164D0EB10006C3BF /* Gradient.h */,
+				4ABF304816335A1100664653 /* Grid.cpp */,
+				4ABF304916335A1100664653 /* Grid.h */,
+				4A4D25DC167335F5003BC9D5 /* Icon.cpp */,
+				4A4D25DD167335F5003BC9D5 /* Icon.h */,
+				4ABF304A16335A1100664653 /* Image.cpp */,
+				4ABF304B16335A1100664653 /* Image.h */,
+				4ABF304C16335A1100664653 /* Label.cpp */,
+				4ABF304D16335A1100664653 /* Label.h */,
+				4ABF304E16335A1100664653 /* List.cpp */,
+				4ABF304F16335A1100664653 /* List.h */,
+				4ABF305016335A1100664653 /* Lua.cpp */,
+				4ABF305116335A1100664653 /* Lua.h */,
+				4ABF305216335A1100664653 /* LuaAlign.cpp */,
+				4ABF305316335A1100664653 /* LuaBackground.cpp */,
+				4ABF305416335A1100664653 /* LuaBox.cpp */,
+				4ABF305516335A1100664653 /* LuaButton.cpp */,
+				4ABF305616335A1100664653 /* LuaCheckBox.cpp */,
+				4ABF305716335A1100664653 /* LuaColorBackground.cpp */,
+				4ABF305816335A1100664653 /* LuaContainer.cpp */,
+				4ABF305916335A1100664653 /* LuaContext.cpp */,
+				4ABF305A16335A1100664653 /* LuaDropDown.cpp */,
+				4AA4A8D8164D0EB10006C3BF /* LuaExpand.cpp */,
+				4AA4A8D9164D0EB10006C3BF /* LuaGradient.cpp */,
+				4ABF305B16335A1100664653 /* LuaGrid.cpp */,
+				4A4D25DE167335F5003BC9D5 /* LuaIcon.cpp */,
+				4ABF305C16335A1100664653 /* LuaImage.cpp */,
+				4ABF305D16335A1100664653 /* LuaLabel.cpp */,
+				4ABF305E16335A1100664653 /* LuaList.cpp */,
+				4ABF305F16335A1100664653 /* LuaMargin.cpp */,
+				4ABF306016335A1100664653 /* LuaMultiLineText.cpp */,
+				4ABF306116335A1100664653 /* LuaScroller.cpp */,
+				4ABF306216335A1100664653 /* LuaSignal.h */,
+				4ABF306316335A1100664653 /* LuaSingle.cpp */,
+				4ABF306416335A1100664653 /* LuaSlider.cpp */,
+				4A0F25CB165CF00D00208507 /* LuaSmallButton.cpp */,
+				4AFBD7BA16412676002928CB /* LuaTextEntry.cpp */,
+				4ABF306516335A1100664653 /* LuaWidget.cpp */,
+				4ABF306716335A1100664653 /* Margin.cpp */,
+				4ABF306816335A1100664653 /* Margin.h */,
+				4ABF306916335A1100664653 /* MultiLineText.cpp */,
+				4ABF306A16335A1100664653 /* MultiLineText.h */,
+				4ABF306B16335A1100664653 /* Point.h */,
+				4ABF306C16335A1100664653 /* Scroller.cpp */,
+				4ABF306D16335A1100664653 /* Scroller.h */,
+				4ABF306E16335A1100664653 /* Single.cpp */,
+				4ABF306F16335A1100664653 /* Single.h */,
+				4ABF307016335A1100664653 /* Skin.cpp */,
+				4ABF307116335A1100664653 /* Skin.h */,
+				4ABF307216335A1100664653 /* Slider.cpp */,
+				4ABF307316335A1100664653 /* Slider.h */,
+				4A0F25CC165CF00D00208507 /* SmallButton.cpp */,
+				4A0F25CD165CF00D00208507 /* SmallButton.h */,
+				4AFBD7BB16412676002928CB /* TextEntry.cpp */,
+				4AFBD7BC16412676002928CB /* TextEntry.h */,
+				4ABF307416335A1100664653 /* TextLayout.cpp */,
+				4ABF307516335A1100664653 /* TextLayout.h */,
+				4ABF307616335A1100664653 /* Widget.cpp */,
+				4ABF307716335A1100664653 /* Widget.h */,
+				4ABF307816335A1100664653 /* WidgetSet.h */,
+			);
+			path = ui;
+			sourceTree = "<group>";
+		};
+		4ACC6D1115401E7000C59914 /* text */ = {
+			isa = PBXGroup;
+			children = (
+				378563AE1B197D9C0039F2BC /* FontConfig.cpp */,
+				378563AF1B197D9C0039F2BC /* FontConfig.h */,
+				4ACDB6D0167879AF0069FA03 /* DistanceFieldFont.cpp */,
+				4ACDB6D1167879AF0069FA03 /* DistanceFieldFont.h */,
+				4ACC6D1615401E7000C59914 /* TextSupport.cpp */,
+				4ACC6D1715401E7000C59914 /* TextSupport.h */,
+				4ACC6D1815401E7000C59914 /* TextureFont.cpp */,
+				4ACC6D1915401E7000C59914 /* TextureFont.h */,
+			);
+			path = text;
+			sourceTree = "<group>";
+		};
+		4ACDB683167878610069FA03 /* scenegraph */ = {
+			isa = PBXGroup;
+			children = (
+				378563CD1B197DDE0039F2BC /* BaseLoader.cpp */,
+				378563CE1B197DDE0039F2BC /* BaseLoader.h */,
+				378563CF1B197DDE0039F2BC /* BinaryConverter.cpp */,
+				378563D01B197DDE0039F2BC /* BinaryConverter.h */,
+				378563D11B197DDE0039F2BC /* LuaModel.cpp */,
+				4AA5280716E9EBD60036D4CB /* LuaModelSkin.cpp */,
+				4AA5280016E9EB980036D4CB /* Lua.cpp */,
+				4AA5280116E9EB980036D4CB /* Lua.h */,
+				4AA5280216E9EB980036D4CB /* ModelSkin.cpp */,
+				4AA5280316E9EB980036D4CB /* ModelSkin.h */,
+				4AA5280416E9EB980036D4CB /* NodeCopyCache.h */,
+				4ACDB684167878610069FA03 /* Animation.cpp */,
+				4ACDB685167878610069FA03 /* Animation.h */,
+				4ACDB686167878610069FA03 /* AnimationChannel.h */,
+				4ACDB687167878610069FA03 /* AnimationKey.h */,
+				4ACDB688167878620069FA03 /* Billboard.cpp */,
+				4ACDB689167878620069FA03 /* Billboard.h */,
+				4ACDB68A167878620069FA03 /* CollisionGeometry.cpp */,
+				4ACDB68B167878620069FA03 /* CollisionGeometry.h */,
+				4ACDB68C167878620069FA03 /* CollisionVisitor.cpp */,
+				4ACDB68D167878620069FA03 /* CollisionVisitor.h */,
+				4ACDB68E167878620069FA03 /* ColorMap.cpp */,
+				4ACDB68F167878620069FA03 /* ColorMap.h */,
+				4ACDB690167878620069FA03 /* DumpVisitor.cpp */,
+				4ACDB691167878620069FA03 /* DumpVisitor.h */,
+				4ACDB692167878620069FA03 /* FindNodeVisitor.cpp */,
+				4ACDB693167878620069FA03 /* FindNodeVisitor.h */,
+				4ACDB694167878620069FA03 /* Group.cpp */,
+				4ACDB695167878620069FA03 /* Group.h */,
+				4ACDB696167878620069FA03 /* Label3D.cpp */,
+				4ACDB697167878620069FA03 /* Label3D.h */,
+				4ACDB698167878620069FA03 /* Loader.cpp */,
+				4ACDB699167878620069FA03 /* Loader.h */,
+				4ACDB69A167878620069FA03 /* LoaderDefinitions.h */,
+				4ACDB69B167878620069FA03 /* LOD.cpp */,
+				4ACDB69C167878620069FA03 /* LOD.h */,
+				4ACDB69E167878620069FA03 /* MatrixTransform.cpp */,
+				4ACDB69F167878620069FA03 /* MatrixTransform.h */,
+				4ACDB6A0167878620069FA03 /* Model.cpp */,
+				4ACDB6A1167878620069FA03 /* Model.h */,
+				4ACDB6A2167878620069FA03 /* ModelNode.cpp */,
+				4ACDB6A3167878620069FA03 /* ModelNode.h */,
+				4ACDB6A4167878620069FA03 /* Node.cpp */,
+				4ACDB6A5167878620069FA03 /* Node.h */,
+				4ACDB6A6167878620069FA03 /* NodeVisitor.cpp */,
+				4ACDB6A7167878620069FA03 /* NodeVisitor.h */,
+				4ACDB6A8167878620069FA03 /* Parser.cpp */,
+				4ACDB6A9167878620069FA03 /* Parser.h */,
+				4ACDB6AA167878620069FA03 /* Pattern.cpp */,
+				4ACDB6AB167878620069FA03 /* Pattern.h */,
+				4ACDB6AC167878620069FA03 /* SceneGraph.h */,
+				4ACDB6AD167878620069FA03 /* StaticGeometry.cpp */,
+				4ACDB6AE167878620069FA03 /* StaticGeometry.h */,
+				4ACDB6AF167878620069FA03 /* Thruster.cpp */,
+				4ACDB6B0167878620069FA03 /* Thruster.h */,
+			);
+			path = scenegraph;
+			sourceTree = "<group>";
+		};
+		4ADB0D1215C50DF000AE2123 /* posix */ = {
+			isa = PBXGroup;
+			children = (
+				4ADB0D1315C50DF000AE2123 /* FileSystemPosix.cpp */,
+				4ADB0D1515C50DF000AE2123 /* OSPosix.cpp */,
+			);
+			path = posix;
+			sourceTree = "<group>";
+		};
+		4ADF517F1557473400ACF5A0 /* galaxy */ = {
+			isa = PBXGroup;
+			children = (
+				3785642E1B197E8B0039F2BC /* Economy.cpp */,
+				3785642F1B197E8B0039F2BC /* Economy.h */,
+				378564301B197E8B0039F2BC /* GalaxyCache.cpp */,
+				378564311B197E8B0039F2BC /* GalaxyCache.h */,
+				378564321B197E8B0039F2BC /* GalaxyGenerator.cpp */,
+				378564331B197E8B0039F2BC /* GalaxyGenerator.h */,
+				378564341B197E8B0039F2BC /* SectorGenerator.cpp */,
+				378564351B197E8B0039F2BC /* SectorGenerator.h */,
+				378564361B197E8B0039F2BC /* StarSystemGenerator.cpp */,
+				378564371B197E8B0039F2BC /* StarSystemGenerator.h */,
+				4A01889615A59908002F540B /* SystemPath.cpp */,
+				4ADF51801557473400ACF5A0 /* CustomSystem.cpp */,
+				4ADF51811557473400ACF5A0 /* CustomSystem.h */,
+				4ADF51821557473400ACF5A0 /* Galaxy.cpp */,
+				4ADF51831557473400ACF5A0 /* Galaxy.h */,
+				4ADF51851557473400ACF5A0 /* Sector.cpp */,
+				4ADF51861557473400ACF5A0 /* Sector.h */,
+				4ADF51871557473400ACF5A0 /* StarSystem.cpp */,
+				4ADF51881557473400ACF5A0 /* StarSystem.h */,
+				4ADF51891557473400ACF5A0 /* SystemPath.h */,
+			);
+			path = galaxy;
+			sourceTree = "<group>";
+		};
+		4AE46C471607513400308C22 /* vcacheopt */ = {
+			isa = PBXGroup;
+			children = (
+				4AE46C491607513400308C22 /* vcacheopt.h */,
+			);
+			path = vcacheopt;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2422,7 +2317,7 @@
 		4A20B0D01353194B0020F43E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0460;
 			};
 			buildConfigurationList = 4A20B0D31353194B0020F43E /* Build configuration list for PBXProject "pioneer" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -2449,11 +2344,8 @@
 			files = (
 				4A20B11C13531CD10020F43E /* Credits.rtf in Resources */,
 				4A20B11D13531CD10020F43E /* InfoPlist.strings in Resources */,
-				521ED9981C00D2FC0092B2E9 /* Makefile.am in Resources */,
-				52E5FAF51C0375F2001F4F89 /* Makefile.am in Resources */,
 				4A20B12013531E950020F43E /* pioneerApp.xib in Resources */,
 				4A8563FD148655DA008121E1 /* pioneer-logo.icns in Resources */,
-				52E5FAF61C0375F2001F4F89 /* README in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2472,7 +2364,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#\n# The following script is used to update all the included libraries with the install_name_tool so that we can create a self\n# contained app bundle with all the included libraries without the user having to hunt down extra libraries etc. Just launch\n# and go! (its the apple way!).\n#\nfunction relocateLibInApp() {\n    install_name_tool -change $1$2 @executable_path/../Frameworks/$2 $CONFIGURATION_BUILD_DIR/$EXECUTABLE_PATH\n    install_name_tool -id @executable_path/../Frameworks/$2 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2\n}\n\nfunction idLib() {\n    install_name_tool -id @executable_path/../Frameworks/$1 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1\n}\n\nfunction relocateSubLib() {\n    install_name_tool -change $1$3 @executable_path/../Frameworks/$3 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2   \n}\n\nfunction lnk() {\n    ln -f $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2\n}\n\n# freetype dylibs\nrelocateLibInApp /opt/local/lib/ libfreetype.6.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libz.1.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libbz2.1.0.dylib\n\n# GLEW dylibs\nrelocateLibInApp /opt/local/lib/ libGLEW.1.13.0.dylib\n\n# libassimp\nlnk libassimp.3.0.0.dylib libassimp.3.dylib\nrelocateLibInApp /opt/local/lib/ libassimp.3.dylib\nrelocateSubLib /opt/local/lib/ libassimp.3.0.0.dylib libz.1.dylib\n\n# sigcxx\nrelocateLibInApp /opt/local/lib/ libsigc-2.0.0.dylib\n\n# SDL\nrelocateLibInApp /opt/local/lib/ libSDL2-2.0.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXdmcp.6.dylib\n\n# SDL_image\nrelocateLibInApp /opt/local/lib/ libSDL2_image-2.0.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libpng15.15.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libtiff.3.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libjpeg.8.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libz.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libSDL2-2.0.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXdmcp.6.dylib\n\n# SDL_sound\n#lnk libSDL_sound-1.0.1.0.2.dylib libSDL_sound-1.0.1.dylib\n#relocateLibInApp /opt/local/lib/ libSDL_sound-1.0.1.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libSDL2-2.0.0.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libsmpeg-0.4.0.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libmodplug.1.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libvorbis.0.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libvorbisfile.3.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libFLAC.8.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libogg.0.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libspeex.1.dylib\n\n# vorbisfile\nrelocateLibInApp /opt/local/lib/ libvorbisfile.3.dylib\nrelocateSubLib /opt/local/lib/ libvorbisfile.3.dylib libvorbis.0.dylib\nrelocateSubLib /opt/local/lib/ libvorbisfile.3.dylib libogg.0.dylib\n\n#\n# EXTRA LIBS\n#\n\n#bz2\nlnk libbz2.1.0.6.dylib libbz2.1.0.dylib\nrelocateLibInApp /opt/local/lib/ libbz2.1.0.dylib\n\n# FLAC\nidLib libFLAC.8.dylib\nrelocateSubLib /opt/local/lib/ libFLAC.8.dylib libogg.0.dylib\n\n# jpeg\nidLib libjpeg.9.dylib\n\n# modplug\nidLib libmodplug.1.dylib\n\n# ogg\nidLib libogg.0.dylib\n\n# png\nidLib libpng16.16.dylib\nrelocateSubLib /opt/local/lib/ libpng16.16.dylib libz.1.dylib\nrelocateLibInApp /opt/local/lib/ libpng16.16.dylib\n\n# smpeg\nidLib libsmpeg-0.4.0.dylib\nrelocateSubLib /opt/local/lib/ libsmpeg-0.4.0.dylib libSDL-1.2.0.dylib\n\n#speex\nlnk libspeex.1.5.0.dylib libspeex.1.dylib\nidLib libspeex.1.dylib\n\n# tiff\nidLib libtiff.5.dylib\nrelocateSubLib /opt/local/lib/ libtiff.5.dylib libjpeg.8.dylib\nrelocateSubLib /opt/local/lib/ libtiff.5.dylib libz.1.dylib\n\n# vorbis\nidLib libvorbis.0.dylib\nrelocateSubLib /opt/local/lib/ libvorbis.0.dylib libogg.0.dylib\n\n# libX11\nrelocateLibInApp /opt/local/lib/ libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libXdmcp.6.dylib\n\n# libXau\nrelocateLibInApp /opt/local/lib/ libXau.6.dylib\n\n# libxcd\nrelocateLibInApp /opt/local/lib/ libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libxcb.1.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libxcb.1.dylib libXdmcp.6.dylib\n\n# libXdmcp\nrelocateLibInApp /opt/local/lib/ libXdmcp.6.dylib\n\n# libext\nrelocateLibInApp /opt/local/lib/ libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libXdmcp.6.dylib\n\n# libXrandr\nrelocateLibInApp /opt/local/lib/ libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXdmcp.6.dylib\n\n# libXrender\nrelocateLibInApp /opt/local/lib/ libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libXdmcp.6.dylib\n\n# zlib\nlnk libz.1.2.8.dylib libz.1.dylib\nrelocateLibInApp /opt/local/lib/ libz.1.dylib\nidLib libz.1.2.8.dylib\n";
+			shellScript = "#\n# The following script is used to update all the included libraries with the install_name_tool so that we can create a self\n# contained app bundle with all the included libraries without the user having to hunt down extra libraries etc. Just launch\n# and go! (its the apple way!).\n#\nfunction relocateLibInApp() {\n    install_name_tool -change $1$2 @executable_path/../Frameworks/$2 $CONFIGURATION_BUILD_DIR/$EXECUTABLE_PATH\n    install_name_tool -id @executable_path/../Frameworks/$2 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2\n}\n\nfunction idLib() {\n    install_name_tool -id @executable_path/../Frameworks/$1 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1\n}\n\nfunction relocateSubLib() {\n    install_name_tool -change $1$3 @executable_path/../Frameworks/$3 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2   \n}\n\nfunction lnk() {\n    ln -f $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2\n}\n\n# freetype dylibs\nrelocateLibInApp /opt/local/lib/ libfreetype.6.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libz.1.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libbz2.1.0.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libpng16.16.dylib\n\n# libassimp\nlnk libassimp.3.0.0.dylib libassimp.3.dylib\nrelocateLibInApp /opt/local/lib/ libassimp.3.dylib\nrelocateSubLib /opt/local/lib/ libassimp.3.0.0.dylib libz.1.dylib\n\n# sigcxx\nrelocateLibInApp /opt/local/lib/ libsigc-2.0.0.dylib\n\n#\n# EXTRA LIBS\n#\n\n#bz2\nlnk libbz2.1.0.6.dylib libbz2.1.0.dylib\nrelocateLibInApp /opt/local/lib/ libbz2.1.0.dylib\n\n# FLAC\n#idLib libFLAC.8.dylib\n#relocateSubLib /opt/local/lib/ libFLAC.8.dylib libogg.0.dylib\n\n# jpeg\n#idLib libjpeg.8.dylib\n\n# modplug\n#idLib libmodplug.1.dylib\n\n# ogg\n#idLib libogg.0.dylib\n\n# png\nidLib libpng16.16.dylib\nrelocateSubLib /opt/local/lib/ libpng16.16.dylib libz.1.dylib\nrelocateLibInApp /opt/local/lib/ libpng16.16.dylib\n\n# smpeg\n#idLib libsmpeg-0.4.0.dylib\n#relocateSubLib /opt/local/lib/ libsmpeg-0.4.0.dylib libSDL-1.2.0.dylib\n\n#speex\n#lnk libspeex.1.5.0.dylib libspeex.1.dylib\n#idLib libspeex.1.dylib\n\n# tiff\n#idLib libtiff.3.dylib\n#relocateSubLib /opt/local/lib/ libtiff.3.dylib libjpeg.8.dylib\n#relocateSubLib /opt/local/lib/ libtiff.3.dylib libz.1.dylib\n\n# vorbis\n#idLib libvorbis.0.dylib\n#relocateSubLib /opt/local/lib/ libvorbis.0.dylib libogg.0.dylib\n\n# libX11\n#relocateLibInApp /opt/local/lib/ libX11.6.dylib\n#relocateSubLib /opt/local/lib/ libX11.6.dylib libxcb.1.dylib\n#relocateSubLib /opt/local/lib/ libX11.6.dylib libXau.6.dylib\n#relocateSubLib /opt/local/lib/ libX11.6.dylib libXdmcp.6.dylib\n\n# libXau\n#relocateLibInApp /opt/local/lib/ libXau.6.dylib\n\n# libxcd\n#relocateLibInApp /opt/local/lib/ libxcb.1.dylib\n#relocateSubLib /opt/local/lib/ libxcb.1.dylib libXau.6.dylib\n#relocateSubLib /opt/local/lib/ libxcb.1.dylib libXdmcp.6.dylib\n\n# libXdmcp\n#relocateLibInApp /opt/local/lib/ libXdmcp.6.dylib\n\n# libext\n#relocateLibInApp /opt/local/lib/ libXext.6.dylib\n#relocateSubLib /opt/local/lib/ libXext.6.dylib libX11.6.dylib\n#relocateSubLib /opt/local/lib/ libXext.6.dylib libXau.6.dylib\n#relocateSubLib /opt/local/lib/ libXext.6.dylib libxcb.1.dylib\n#relocateSubLib /opt/local/lib/ libXext.6.dylib libXdmcp.6.dylib\n\n# libXrandr\n#relocateLibInApp /opt/local/lib/ libXrandr.2.dylib\n#relocateSubLib /opt/local/lib/ libXrandr.2.dylib libXext.6.dylib\n#relocateSubLib /opt/local/lib/ libXrandr.2.dylib libXrender.1.dylib\n#relocateSubLib /opt/local/lib/ libXrandr.2.dylib libX11.6.dylib\n#relocateSubLib /opt/local/lib/ libXrandr.2.dylib libxcb.1.dylib\n#relocateSubLib /opt/local/lib/ libXrandr.2.dylib libXau.6.dylib\n#relocateSubLib /opt/local/lib/ libXrandr.2.dylib libXdmcp.6.dylib\n\n# libXrender\n#relocateLibInApp /opt/local/lib/ libXrender.1.dylib\n#relocateSubLib /opt/local/lib/ libXrender.1.dylib libX11.6.dylib\n#relocateSubLib /opt/local/lib/ libXrender.1.dylib libxcb.1.dylib\n#relocateSubLib /opt/local/lib/ libXrender.1.dylib libXau.6.dylib\n#relocateSubLib /opt/local/lib/ libXrender.1.dylib libXdmcp.6.dylib\n\n# zlib\nlnk libz.1.2.8.dylib libz.1.dylib\nrelocateLibInApp /opt/local/lib/ libz.1.dylib\nidLib libz.1.2.8.dylib\n\n";
 		};
 		4AE970701436A65D00424F91 /* GenGitVersion */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2495,399 +2387,400 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				521EDBF91C00D3A20092B2E9 /* LuaImage.cpp in Sources */,
-				521ED9291C00D14E0092B2E9 /* LuaModelBody.cpp in Sources */,
-				521ED8F61C00D14E0092B2E9 /* CargoBody.cpp in Sources */,
-				521ED93F1C00D14E0092B2E9 /* main.cpp in Sources */,
-				521EDB501C00D37B0092B2E9 /* TerrainHeightMapped2.cpp in Sources */,
-				52D126781C03538F00E6E4C2 /* lzio.c in Sources */,
-				521EDBEC1C00D3A20092B2E9 /* LuaBackground.cpp in Sources */,
-				521ED9331C00D14E0092B2E9 /* LuaServerAgent.cpp in Sources */,
-				521EDB441C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp in Sources */,
-				521ED95F1C00D14E0092B2E9 /* ShipCpanel.cpp in Sources */,
-				521ED94D1C00D14E0092B2E9 /* Planet.cpp in Sources */,
-				521EDB691C00D38B0092B2E9 /* TextureFont.cpp in Sources */,
-				521ED9041C00D14E0092B2E9 /* FontCache.cpp in Sources */,
-				521ED8F11C00D14E0092B2E9 /* Background.cpp in Sources */,
-				521EDA211C00D3430092B2E9 /* RendererDummy.cpp in Sources */,
-				521EDB371C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp in Sources */,
-				521ED9B61C00D3240092B2E9 /* StarSystemGenerator.cpp in Sources */,
-				521ED9221C00D14E0092B2E9 /* LuaFixed.cpp in Sources */,
-				521ED94E1C00D14E0092B2E9 /* Player.cpp in Sources */,
-				521ED91F1C00D14E0092B2E9 /* LuaEvent.cpp in Sources */,
-				521EDA3D1C00D3430092B2E9 /* VertexArray.cpp in Sources */,
-				521EDA241C00D3430092B2E9 /* GeoSphereMaterial.cpp in Sources */,
-				52D126701C03538F00E6E4C2 /* lstrlib.c in Sources */,
-				521ED9CF1C00D3310092B2E9 /* Panel.cpp in Sources */,
-				521ED9621C00D14E0092B2E9 /* Sound.cpp in Sources */,
-				521EDB561C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp in Sources */,
-				521ED8F21C00D14E0092B2E9 /* BaseSphere.cpp in Sources */,
-				521EDB671C00D38B0092B2E9 /* FontConfig.cpp in Sources */,
-				521ED9571C00D14E0092B2E9 /* ServerAgent.cpp in Sources */,
-				521ED9061C00D14E0092B2E9 /* GalacticView.cpp in Sources */,
-				521ED9131C00D14E0092B2E9 /* Intro.cpp in Sources */,
-				521EDBF31C00D3A20092B2E9 /* LuaDropDown.cpp in Sources */,
-				521EDAD21C00D36D0092B2E9 /* BinaryConverter.cpp in Sources */,
-				521ED91A1C00D14E0092B2E9 /* LuaComms.cpp in Sources */,
-				521ED9451C00D14E0092B2E9 /* ModelViewer.cpp in Sources */,
-				521EDBDD1C00D3A20092B2E9 /* DropDown.cpp in Sources */,
-				521ED8FC1C00D14E0092B2E9 /* DeathView.cpp in Sources */,
-				521EDBE81C00D3A20092B2E9 /* List.cpp in Sources */,
-				521EDA3F1C00D3430092B2E9 /* WindowSDL.cpp in Sources */,
-				521EDA2B1C00D3430092B2E9 /* RendererGL.cpp in Sources */,
-				521ED8F71C00D14E0092B2E9 /* CityOnPlanet.cpp in Sources */,
-				521EDBF61C00D3A20092B2E9 /* LuaGradient.cpp in Sources */,
-				521EDB3D1C00D37B0092B2E9 /* TerrainColorTFPoor.cpp in Sources */,
-				521EDC041C00D3A20092B2E9 /* LuaTable.cpp in Sources */,
-				52D126661C03538F00E6E4C2 /* llex.c in Sources */,
-				521EDBFE1C00D3A20092B2E9 /* LuaMultiLineText.cpp in Sources */,
-				521EDA801C00D3550092B2E9 /* GuiLabelSet.cpp in Sources */,
-				521EDBFF1C00D3A20092B2E9 /* LuaNumberLabel.cpp in Sources */,
-				521EDB401C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp in Sources */,
-				52D126641C03538F00E6E4C2 /* linit.c in Sources */,
-				521ED92A1C00D14E0092B2E9 /* LuaMusic.cpp in Sources */,
-				521ED93D1C00D14E0092B2E9 /* LuaUtils.cpp in Sources */,
-				52D1266E1C03538F00E6E4C2 /* lstate.c in Sources */,
-				521EDB411C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp in Sources */,
-				521EDBD51C00D3A20092B2E9 /* Background.cpp in Sources */,
-				521EDB5A1C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp in Sources */,
-				521ED9AF1C00D3240092B2E9 /* Economy.cpp in Sources */,
-				521EDB3E1C00D37B0092B2E9 /* TerrainColorVolcanic.cpp in Sources */,
-				521EDB451C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp in Sources */,
-				521EDC051C00D3A20092B2E9 /* LuaTextEntry.cpp in Sources */,
-				521EDA8E1C00D3550092B2E9 /* GuiVScrollPortal.cpp in Sources */,
-				521ED9671C00D14E0092B2E9 /* SpeedLines.cpp in Sources */,
-				521EDBE41C00D3A20092B2E9 /* Icon.cpp in Sources */,
-				521EDA2A1C00D3430092B2E9 /* Program.cpp in Sources */,
-				521ED92E1C00D14E0092B2E9 /* LuaPlayer.cpp in Sources */,
-				521EDB331C00D37B0092B2E9 /* TerrainColorMethane.cpp in Sources */,
-				521ED9691C00D14E0092B2E9 /* Star.cpp in Sources */,
-				521EDC001C00D3A20092B2E9 /* LuaScroller.cpp in Sources */,
-				521ED9611C00D14E0092B2E9 /* ShipType.cpp in Sources */,
-				521ED9941C00D2ED0092B2E9 /* Geom.cpp in Sources */,
-				52D126571C03538F00E6E4C2 /* lapi.c in Sources */,
-				521EDB251C00D37B0092B2E9 /* Terrain.cpp in Sources */,
-				521EDC111C00D3A20092B2E9 /* TextLayout.cpp in Sources */,
-				521ED90A1C00D14E0092B2E9 /* GasGiant.cpp in Sources */,
-				521EDC0F1C00D3A20092B2E9 /* Table.cpp in Sources */,
-				521ED9001C00D14E0092B2E9 /* FaceParts.cpp in Sources */,
-				521EDB591C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp in Sources */,
-				521EDB421C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp in Sources */,
-				521ED9501C00D14E0092B2E9 /* Polit.cpp in Sources */,
-				521EDB311C00D37B0092B2E9 /* TerrainColorGGUranus.cpp in Sources */,
-				521ED9281C00D14E0092B2E9 /* LuaMissile.cpp in Sources */,
-				52D1265F1C03538F00E6E4C2 /* ldebug.c in Sources */,
-				521EDC011C00D3A20092B2E9 /* LuaSingle.cpp in Sources */,
-				521EDC061C00D3A20092B2E9 /* LuaWidget.cpp in Sources */,
-				521ED9311C00D14E0092B2E9 /* LuaRef.cpp in Sources */,
-				521ED9B71C00D3240092B2E9 /* SystemPath.cpp in Sources */,
-				521ED9471C00D14E0092B2E9 /* NavLights.cpp in Sources */,
-				521ED95E1C00D14E0092B2E9 /* ShipController.cpp in Sources */,
-				521ED92F1C00D14E0092B2E9 /* LuaPropertiedObject.cpp in Sources */,
-				521ED9641C00D14E0092B2E9 /* Space.cpp in Sources */,
-				521EDB281C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp in Sources */,
-				521ED9631C00D14E0092B2E9 /* SoundMusic.cpp in Sources */,
-				521EDA8F1C00D3550092B2E9 /* GuiWidget.cpp in Sources */,
-				521EDACF1C00D36D0092B2E9 /* Animation.cpp in Sources */,
-				521EDA351C00D3430092B2E9 /* Drawables.cpp in Sources */,
-				521EDA841C00D3550092B2E9 /* GuiRadioGroup.cpp in Sources */,
-				521EDADA1C00D36D0092B2E9 /* Loader.cpp in Sources */,
-				521EDC0C1C00D3A20092B2E9 /* Skin.cpp in Sources */,
-				521ED9151C00D14E0092B2E9 /* KeyBindings.cpp in Sources */,
-				521EDAD71C00D36D0092B2E9 /* FindNodeVisitor.cpp in Sources */,
-				521EDB2E1C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp in Sources */,
-				52D1266F1C03538F00E6E4C2 /* lstring.c in Sources */,
-				521ED9481C00D14E0092B2E9 /* ObjectViewerView.cpp in Sources */,
-				521ED9201C00D14E0092B2E9 /* LuaFaction.cpp in Sources */,
-				521EDA781C00D3550092B2E9 /* GuiBox.cpp in Sources */,
-				521EDBEF1C00D3A20092B2E9 /* LuaCheckBox.cpp in Sources */,
-				521ED9661C00D14E0092B2E9 /* SpaceStationType.cpp in Sources */,
-				521ED8F81C00D14E0092B2E9 /* CollMesh.cpp in Sources */,
-				521ED9211C00D14E0092B2E9 /* LuaFileSystem.cpp in Sources */,
-				521EDB481C00D37B0092B2E9 /* TerrainHeightFlat.cpp in Sources */,
-				521ED9491C00D14E0092B2E9 /* Orbit.cpp in Sources */,
-				52D1266C1C03538F00E6E4C2 /* loslib.c in Sources */,
-				521ED90B1C00D14E0092B2E9 /* GeoPatch.cpp in Sources */,
-				521ED9B21C00D3240092B2E9 /* GalaxyGenerator.cpp in Sources */,
-				521EDADB1C00D36D0092B2E9 /* LOD.cpp in Sources */,
-				521EDA2E1C00D3430092B2E9 /* RingMaterial.cpp in Sources */,
-				521EDA3B1C00D3430092B2E9 /* Stats.cpp in Sources */,
-				521ED9CB1C00D3310092B2E9 /* LuaBindingCapture.cpp in Sources */,
-				521EDB3A1C00D37B0092B2E9 /* TerrainColorStarM.cpp in Sources */,
-				521EDA8B1C00D3550092B2E9 /* GuiToggleButton.cpp in Sources */,
-				521ED9411C00D14E0092B2E9 /* Missile.cpp in Sources */,
-				521EDB2C1C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp in Sources */,
-				521ED9301C00D14E0092B2E9 /* LuaRand.cpp in Sources */,
-				521ED93C1C00D14E0092B2E9 /* LuaTimer.cpp in Sources */,
-				521EDC091C00D3A20092B2E9 /* NumberLabel.cpp in Sources */,
-				521ED9541C00D14E0092B2E9 /* SectorView.cpp in Sources */,
-				521ED9391C00D14E0092B2E9 /* LuaStarSystem.cpp in Sources */,
-				521EDB3B1C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp in Sources */,
-				521EDB431C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp in Sources */,
-				521ED9381C00D14E0092B2E9 /* LuaStar.cpp in Sources */,
-				52D126591C03538F00E6E4C2 /* lbaselib.c in Sources */,
-				521EDA7A1C00D3550092B2E9 /* GuiContainer.cpp in Sources */,
-				521ED9461C00D14E0092B2E9 /* ModManager.cpp in Sources */,
-				521EDB551C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp in Sources */,
-				521ED9071C00D14E0092B2E9 /* Game.cpp in Sources */,
-				521ED9921C00D2ED0092B2E9 /* BVHTree.cpp in Sources */,
-				521EDBF21C00D3A20092B2E9 /* LuaContext.cpp in Sources */,
-				521EDBEB1C00D3A20092B2E9 /* LuaAnimation.cpp in Sources */,
-				521EDBDB1C00D3A20092B2E9 /* Container.cpp in Sources */,
-				521EDA7F1C00D3550092B2E9 /* GuiLabel.cpp in Sources */,
-				521ED9431C00D14E0092B2E9 /* ModelCache.cpp in Sources */,
-				521EDAE21C00D36D0092B2E9 /* ModelSkin.cpp in Sources */,
-				521EDC0D1C00D3A20092B2E9 /* Slider.cpp in Sources */,
-				521EDB461C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp in Sources */,
-				521EDB4F1C00D37B0092B2E9 /* TerrainHeightMapped.cpp in Sources */,
-				521EDC071C00D3A20092B2E9 /* Margin.cpp in Sources */,
-				52D126611C03538F00E6E4C2 /* ldump.c in Sources */,
-				521ED94C1C00D14E0092B2E9 /* Plane.cpp in Sources */,
-				521ED9101C00D14E0092B2E9 /* HudTrail.cpp in Sources */,
-				521EDB291C00D37B0092B2E9 /* TerrainColorDesert.cpp in Sources */,
-				521ED9581C00D14E0092B2E9 /* Sfx.cpp in Sources */,
-				521EDB681C00D38B0092B2E9 /* TextSupport.cpp in Sources */,
-				521ED9B41C00D3240092B2E9 /* SectorGenerator.cpp in Sources */,
-				52D126731C03538F00E6E4C2 /* ltm.c in Sources */,
-				521ED8F91C00D14E0092B2E9 /* Color.cpp in Sources */,
-				521ED9C81C00D3310092B2E9 /* BindingCapture.cpp in Sources */,
-				521EDA331C00D3430092B2E9 /* VertexBufferGL.cpp in Sources */,
-				521EDBE01C00D3A20092B2E9 /* Expand.cpp in Sources */,
-				521EDB4B1C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp in Sources */,
-				521EDAD01C00D36D0092B2E9 /* BaseLoader.cpp in Sources */,
-				521EDA861C00D3550092B2E9 /* GuiStack.cpp in Sources */,
-				52D126771C03538F00E6E4C2 /* lvm.c in Sources */,
-				521EDB2F1C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp in Sources */,
-				521EDAD61C00D36D0092B2E9 /* DumpVisitor.cpp in Sources */,
-				521EDB4D1C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp in Sources */,
-				521EDBD31C00D3A20092B2E9 /* Align.cpp in Sources */,
-				521ED9141C00D14E0092B2E9 /* JobQueue.cpp in Sources */,
-				521EDAD51C00D36D0092B2E9 /* ColorMap.cpp in Sources */,
-				521EDA291C00D3430092B2E9 /* MultiMaterial.cpp in Sources */,
-				521ED9191C00D14E0092B2E9 /* LuaCargoBody.cpp in Sources */,
-				521ED93E1C00D14E0092B2E9 /* LuaVector.cpp in Sources */,
-				521ED9011C00D14E0092B2E9 /* Factions.cpp in Sources */,
-				521ED94F1C00D14E0092B2E9 /* PngWriter.cpp in Sources */,
-				521ED9951C00D2ED0092B2E9 /* GeomTree.cpp in Sources */,
-				521ED9681C00D14E0092B2E9 /* Sphere.cpp in Sources */,
-				521ED9231C00D14E0092B2E9 /* LuaFormat.cpp in Sources */,
-				521EDA361C00D3430092B2E9 /* Frustum.cpp in Sources */,
-				521EDADD1C00D36D0092B2E9 /* LuaModel.cpp in Sources */,
-				521EDB391C00D37B0092B2E9 /* TerrainColorStarK.cpp in Sources */,
-				521EDBDA1C00D3A20092B2E9 /* ColorBackground.cpp in Sources */,
-				521EDA7C1C00D3550092B2E9 /* GuiImage.cpp in Sources */,
-				521EDA3C1C00D3430092B2E9 /* TextureBuilder.cpp in Sources */,
-				521EDA381C00D3430092B2E9 /* Light.cpp in Sources */,
-				52D1265B1C03538F00E6E4C2 /* lcode.c in Sources */,
-				521ED91B1C00D14E0092B2E9 /* LuaConsole.cpp in Sources */,
-				521EDA3A1C00D3430092B2E9 /* Renderer.cpp in Sources */,
-				521EDA811C00D3550092B2E9 /* GuiMeterBar.cpp in Sources */,
-				521ED90D1C00D14E0092B2E9 /* GeoPatchID.cpp in Sources */,
-				521EDB4A1C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp in Sources */,
-				521ED9161C00D14E0092B2E9 /* Lang.cpp in Sources */,
-				521EDB521C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp in Sources */,
-				521ED9171C00D14E0092B2E9 /* Lua.cpp in Sources */,
-				521EDA2F1C00D3430092B2E9 /* ShieldMaterial.cpp in Sources */,
-				521EDBE71C00D3A20092B2E9 /* Layer.cpp in Sources */,
-				521EDC101C00D3A20092B2E9 /* TextEntry.cpp in Sources */,
-				521ED95A1C00D14E0092B2E9 /* Ship-AI.cpp in Sources */,
-				521EDB361C00D37B0092B2E9 /* TerrainColorSolid.cpp in Sources */,
-				521EDB321C00D37B0092B2E9 /* TerrainColorIce.cpp in Sources */,
-				521EDAE71C00D36D0092B2E9 /* StaticGeometry.cpp in Sources */,
-				521ED9401C00D14E0092B2E9 /* MathUtil.cpp in Sources */,
-				521ED9C91C00D3310092B2E9 /* Face.cpp in Sources */,
-				521EDBE11C00D3A20092B2E9 /* Gauge.cpp in Sources */,
-				521ED90F1C00D14E0092B2E9 /* GeoSphere.cpp in Sources */,
-				521EDB471C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp in Sources */,
-				521EDB4C1C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp in Sources */,
-				521ED9591C00D14E0092B2E9 /* Shields.cpp in Sources */,
-				521EDA8D1C00D3550092B2E9 /* GuiVScrollBar.cpp in Sources */,
-				521EDBF11C00D3A20092B2E9 /* LuaContainer.cpp in Sources */,
-				52D126581C03538F00E6E4C2 /* lauxlib.c in Sources */,
-				521ED9791C00D14E0092B2E9 /* View.cpp in Sources */,
-				521EDA821C00D3550092B2E9 /* GuiMultiStateImageButton.cpp in Sources */,
-				521ED9181C00D14E0092B2E9 /* LuaBody.cpp in Sources */,
-				521ED9AE1C00D3240092B2E9 /* CustomSystem.cpp in Sources */,
-				521EDBFC1C00D3A20092B2E9 /* LuaList.cpp in Sources */,
-				521ED8FB1C00D14E0092B2E9 /* DateTime.cpp in Sources */,
-				521ED9B01C00D3240092B2E9 /* Galaxy.cpp in Sources */,
-				521EDBF41C00D3A20092B2E9 /* LuaExpand.cpp in Sources */,
-				521ED9B11C00D3240092B2E9 /* GalaxyCache.cpp in Sources */,
-				521EDA851C00D3550092B2E9 /* GuiScreen.cpp in Sources */,
-				521ED96C1C00D14E0092B2E9 /* SystemView.cpp in Sources */,
-				521ED9531C00D14E0092B2E9 /* SDLWrappers.cpp in Sources */,
-				521ED93B1C00D14E0092B2E9 /* LuaSystemPath.cpp in Sources */,
-				521ED9CA1C00D3310092B2E9 /* Lua.cpp in Sources */,
-				521ED9601C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp in Sources */,
-				521EDAD91C00D36D0092B2E9 /* Label3D.cpp in Sources */,
-				521EDA341C00D3430092B2E9 /* VtxColorMaterial.cpp in Sources */,
-				521EDBD71C00D3A20092B2E9 /* Button.cpp in Sources */,
-				521EDA941C00D3610092B2E9 /* FileSystemPosix.cpp in Sources */,
-				521ED92C1C00D14E0092B2E9 /* LuaObject.cpp in Sources */,
-				521EDB5B1C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp in Sources */,
-				521ED9B31C00D3240092B2E9 /* Sector.cpp in Sources */,
-				521EDB301C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp in Sources */,
-				521EDB271C00D37B0092B2E9 /* TerrainColorBandedRock.cpp in Sources */,
-				521EDC0A1C00D3A20092B2E9 /* Scroller.cpp in Sources */,
-				521ED9031C00D14E0092B2E9 /* FileSystem.cpp in Sources */,
-				521ED90C1C00D14E0092B2E9 /* GeoPatchContext.cpp in Sources */,
-				521ED9361C00D14E0092B2E9 /* LuaSpace.cpp in Sources */,
-				521ED94B1C00D14E0092B2E9 /* Pi.cpp in Sources */,
-				52D1265D1C03538F00E6E4C2 /* lctype.c in Sources */,
-				52D126651C03538F00E6E4C2 /* liolib.c in Sources */,
-				521EDA2C1C00D3430092B2E9 /* RenderStateGL.cpp in Sources */,
-				521EDA301C00D3430092B2E9 /* TextureGL.cpp in Sources */,
-				521EDAD81C00D36D0092B2E9 /* Group.cpp in Sources */,
-				521EDC0E1C00D3A20092B2E9 /* SmallButton.cpp in Sources */,
-				521EDAD41C00D36D0092B2E9 /* CollisionVisitor.cpp in Sources */,
-				521ED9321C00D14E0092B2E9 /* LuaSerializer.cpp in Sources */,
-				521EDBF71C00D3A20092B2E9 /* LuaGrid.cpp in Sources */,
-				521ED95D1C00D14E0092B2E9 /* ShipCockpit.cpp in Sources */,
-				52D1266B1C03538F00E6E4C2 /* lopcodes.c in Sources */,
-				521ED92D1C00D14E0092B2E9 /* LuaPlanet.cpp in Sources */,
-				521ED9931C00D2ED0092B2E9 /* CollisionSpace.cpp in Sources */,
-				52D126721C03538F00E6E4C2 /* ltablib.c in Sources */,
-				521ED92B1C00D14E0092B2E9 /* LuaNameGen.cpp in Sources */,
-				52D126631C03538F00E6E4C2 /* lgc.c in Sources */,
-				521EDBFA1C00D3A20092B2E9 /* LuaLabel.cpp in Sources */,
-				521EDAE31C00D36D0092B2E9 /* Node.cpp in Sources */,
-				521EDA221C00D3430092B2E9 /* FresnelColourMaterial.cpp in Sources */,
-				521EDADE1C00D36D0092B2E9 /* LuaModelSkin.cpp in Sources */,
-				521EDBF81C00D3A20092B2E9 /* LuaIcon.cpp in Sources */,
-				521EDA7D1C00D3550092B2E9 /* GuiImageButton.cpp in Sources */,
-				521ED9271C00D14E0092B2E9 /* LuaMatrix.cpp in Sources */,
-				521ED9421C00D14E0092B2E9 /* ModelBody.cpp in Sources */,
-				521EDA311C00D3430092B2E9 /* UIMaterial.cpp in Sources */,
-				521ED9111C00D14E0092B2E9 /* HyperspaceCloud.cpp in Sources */,
-				521ED9CE1C00D3310092B2E9 /* ModelSpinner.cpp in Sources */,
-				521ED8F01C00D14E0092B2E9 /* AmbientSounds.cpp in Sources */,
-				521EDA7B1C00D3550092B2E9 /* GuiFixed.cpp in Sources */,
-				521ED9261C00D14E0092B2E9 /* LuaManager.cpp in Sources */,
-				521EDC121C00D3A20092B2E9 /* Widget.cpp in Sources */,
-				521ED9081C00D14E0092B2E9 /* GameConfig.cpp in Sources */,
-				52D1265A1C03538F00E6E4C2 /* lbitlib.c in Sources */,
-				521EDB511C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp in Sources */,
-				521EDB491C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp in Sources */,
-				521EDA281C00D3430092B2E9 /* MaterialGL.cpp in Sources */,
-				521ED9121C00D14E0092B2E9 /* IniConfig.cpp in Sources */,
-				521EDA8C1C00D3550092B2E9 /* GuiToolTip.cpp in Sources */,
-				521ED9511C00D14E0092B2E9 /* Projectile.cpp in Sources */,
-				521EDA3E1C00D3430092B2E9 /* VertexBuffer.cpp in Sources */,
-				521ED91D1C00D14E0092B2E9 /* LuaDev.cpp in Sources */,
-				521EDBED1C00D3A20092B2E9 /* LuaBox.cpp in Sources */,
-				52D1265C1C03538F00E6E4C2 /* lcorolib.c in Sources */,
-				521EDBE21C00D3A20092B2E9 /* Gradient.cpp in Sources */,
-				521EDA831C00D3550092B2E9 /* GuiRadioButton.cpp in Sources */,
-				521ED96B1C00D14E0092B2E9 /* SystemInfoView.cpp in Sources */,
-				521ED8FF1C00D14E0092B2E9 /* EnumStrings.cpp in Sources */,
-				521EDB571C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp in Sources */,
-				521ED9251C00D14E0092B2E9 /* LuaLang.cpp in Sources */,
-				52D126691C03538F00E6E4C2 /* loadlib.c in Sources */,
-				521EDA2D1C00D3430092B2E9 /* RenderTargetGL.cpp in Sources */,
-				521EDBFB1C00D3A20092B2E9 /* LuaLayer.cpp in Sources */,
-				521ED8FD1C00D14E0092B2E9 /* DynamicBody.cpp in Sources */,
-				521EDAE61C00D36D0092B2E9 /* Pattern.cpp in Sources */,
-				521ED95B1C00D14E0092B2E9 /* Ship.cpp in Sources */,
-				521ED9751C00D14E0092B2E9 /* Tombstone.cpp in Sources */,
-				521EDBE91C00D3A20092B2E9 /* Lua.cpp in Sources */,
-				521EDA321C00D3430092B2E9 /* Uniform.cpp in Sources */,
-				521EDADF1C00D36D0092B2E9 /* MatrixTransform.cpp in Sources */,
-				521EDAE51C00D36D0092B2E9 /* Parser.cpp in Sources */,
-				521ED9091C00D14E0092B2E9 /* GameLog.cpp in Sources */,
-				52D126681C03538F00E6E4C2 /* lmem.c in Sources */,
-				521EDB531C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp in Sources */,
-				521EDB581C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp in Sources */,
-				521EDBF01C00D3A20092B2E9 /* LuaColorBackground.cpp in Sources */,
-				521EDA881C00D3550092B2E9 /* GuiTextEntry.cpp in Sources */,
-				521EDA391C00D3430092B2E9 /* Material.cpp in Sources */,
-				521EDA8A1C00D3550092B2E9 /* GuiTexturedQuad.cpp in Sources */,
-				521EDBDE1C00D3A20092B2E9 /* Event.cpp in Sources */,
-				52D125EC1C0351FB00E6E4C2 /* jsoncpp.cpp in Sources */,
-				521EDB2B1C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp in Sources */,
-				521EDB2A1C00D37B0092B2E9 /* TerrainColorEarthLike.cpp in Sources */,
-				521ED97A1C00D14E0092B2E9 /* WorldView.cpp in Sources */,
-				521EDBD91C00D3A20092B2E9 /* CheckBox.cpp in Sources */,
-				521ED9351C00D14E0092B2E9 /* LuaShipDef.cpp in Sources */,
-				52D1266D1C03538F00E6E4C2 /* lparser.c in Sources */,
-				521EDB4E1C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp in Sources */,
-				52D126761C03538F00E6E4C2 /* lundump.c in Sources */,
-				521EDB3C1C00D37B0092B2E9 /* TerrainColorTFGood.cpp in Sources */,
-				521EDBD41C00D3A20092B2E9 /* Animation.cpp in Sources */,
-				521ED94A1C00D14E0092B2E9 /* perlin.cpp in Sources */,
-				521EDB381C00D37B0092B2E9 /* TerrainColorStarG.cpp in Sources */,
-				521EDC021C00D3A20092B2E9 /* LuaSlider.cpp in Sources */,
-				521EDBE51C00D3A20092B2E9 /* Image.cpp in Sources */,
-				521ED9771C00D14E0092B2E9 /* UIView.cpp in Sources */,
-				521EDBE61C00D3A20092B2E9 /* Label.cpp in Sources */,
-				521EDBEA1C00D3A20092B2E9 /* LuaAlign.cpp in Sources */,
-				521ED9551C00D14E0092B2E9 /* Sensors.cpp in Sources */,
-				521ED9781C00D14E0092B2E9 /* utils.cpp in Sources */,
-				521EDAD31C00D36D0092B2E9 /* CollisionGeometry.cpp in Sources */,
-				521EDAE81C00D36D0092B2E9 /* Thruster.cpp in Sources */,
-				521EDAE41C00D36D0092B2E9 /* NodeVisitor.cpp in Sources */,
-				521EDB661C00D38B0092B2E9 /* DistanceFieldFont.cpp in Sources */,
-				521EDBD61C00D3A20092B2E9 /* Box.cpp in Sources */,
-				521ED9371C00D14E0092B2E9 /* LuaSpaceStation.cpp in Sources */,
-				521EDB351C00D37B0092B2E9 /* TerrainColorRock2.cpp in Sources */,
-				521EDB2D1C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp in Sources */,
-				521ED9561C00D14E0092B2E9 /* Serializer.cpp in Sources */,
-				521EDBE31C00D3A20092B2E9 /* Grid.cpp in Sources */,
-				521EDB541C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp in Sources */,
-				521EDA871C00D3550092B2E9 /* GuiTabbed.cpp in Sources */,
-				52D126601C03538F00E6E4C2 /* ldo.c in Sources */,
-				521EDA251C00D3430092B2E9 /* gl_core_3_x.c in Sources */,
-				521ED93A1C00D14E0092B2E9 /* LuaSystemBody.cpp in Sources */,
-				521EDAE11C00D36D0092B2E9 /* ModelNode.cpp in Sources */,
-				521EDA231C00D3430092B2E9 /* GasGiantMaterial.cpp in Sources */,
-				521ED95C1C00D14E0092B2E9 /* ShipAICmd.cpp in Sources */,
-				521ED91E1C00D14E0092B2E9 /* LuaEngine.cpp in Sources */,
-				521EDB261C00D37B0092B2E9 /* TerrainColorAsteroid.cpp in Sources */,
-				521EDA791C00D3550092B2E9 /* GuiButton.cpp in Sources */,
-				521EDC081C00D3A20092B2E9 /* MultiLineText.cpp in Sources */,
-				521EDB3F1C00D37B0092B2E9 /* TerrainFeature.cpp in Sources */,
-				521ED9021C00D14E0092B2E9 /* FileSourceZip.cpp in Sources */,
-				521EDA371C00D3430092B2E9 /* Graphics.cpp in Sources */,
-				521EDBD81C00D3A20092B2E9 /* CellSpec.cpp in Sources */,
-				52D126711C03538F00E6E4C2 /* ltable.c in Sources */,
-				52D125ED1C0351FB00E6E4C2 /* JsonUtils.cpp in Sources */,
-				52D126161C0351FB00E6E4C2 /* PicoDDS.cpp in Sources */,
-				521ED8FE1C00D14E0092B2E9 /* enum_table.cpp in Sources */,
-				521ED90E1C00D14E0092B2E9 /* GeoPatchJobs.cpp in Sources */,
-				521EDBFD1C00D3A20092B2E9 /* LuaMargin.cpp in Sources */,
-				521ED8F51C00D14E0092B2E9 /* CameraController.cpp in Sources */,
-				52D126621C03538F00E6E4C2 /* lfunc.c in Sources */,
-				52D1266A1C03538F00E6E4C2 /* lobject.c in Sources */,
-				52D1265E1C03538F00E6E4C2 /* ldblib.c in Sources */,
-				521EDBDC1C00D3A20092B2E9 /* Context.cpp in Sources */,
-				521EDBEE1C00D3A20092B2E9 /* LuaButton.cpp in Sources */,
-				521ED8F41C00D14E0092B2E9 /* Camera.cpp in Sources */,
-				521ED8F31C00D14E0092B2E9 /* Body.cpp in Sources */,
-				521ED9B51C00D3240092B2E9 /* StarSystem.cpp in Sources */,
-				521EDA7E1C00D3550092B2E9 /* GuiImageRadioButton.cpp in Sources */,
-				521ED9651C00D14E0092B2E9 /* SpaceStation.cpp in Sources */,
-				521ED9CD1C00D3310092B2E9 /* LuaModelSpinner.cpp in Sources */,
-				521EDA951C00D3610092B2E9 /* OSPosix.cpp in Sources */,
-				521EDADC1C00D36D0092B2E9 /* Lua.cpp in Sources */,
-				521ED96A1C00D14E0092B2E9 /* StringF.cpp in Sources */,
-				52E5FAE11C03589F001F4F89 /* lookup3.c in Sources */,
-				521EDAD11C00D36D0092B2E9 /* Billboard.cpp in Sources */,
-				521ED8FA1C00D14E0092B2E9 /* CRC32.cpp in Sources */,
-				521ED96D1C00D14E0092B2E9 /* TerrainBody.cpp in Sources */,
-				521EDB341C00D37B0092B2E9 /* TerrainColorRock.cpp in Sources */,
-				521ED9521C00D14E0092B2E9 /* PropertyMap.cpp in Sources */,
-				521ED91C1C00D14E0092B2E9 /* LuaConstants.cpp in Sources */,
-				521EDC031C00D3A20092B2E9 /* LuaSmallButton.cpp in Sources */,
-				521ED9241C00D14E0092B2E9 /* LuaGame.cpp in Sources */,
-				521EDA771C00D3550092B2E9 /* Gui.cpp in Sources */,
-				521EDBDF1C00D3A20092B2E9 /* EventDispatcher.cpp in Sources */,
-				521ED9341C00D14E0092B2E9 /* LuaShip.cpp in Sources */,
-				521EDC0B1C00D3A20092B2E9 /* Single.cpp in Sources */,
-				521ED9CC1C00D3310092B2E9 /* LuaFace.cpp in Sources */,
-				521EDAE01C00D36D0092B2E9 /* Model.cpp in Sources */,
-				52D126671C03538F00E6E4C2 /* lmathlib.c in Sources */,
-				521EDA891C00D3550092B2E9 /* GuiTextLayout.cpp in Sources */,
-				521ED9051C00D14E0092B2E9 /* Frame.cpp in Sources */,
-				521EDBF51C00D3A20092B2E9 /* LuaGauge.cpp in Sources */,
+				4A6C4DD113532FC300FDD53F /* AmbientSounds.cpp in Sources */,
+				4A6C4DD213532FC300FDD53F /* Body.cpp in Sources */,
+				4A6C4DD313532FC300FDD53F /* CargoBody.cpp in Sources */,
+				3785635D1B197CF90039F2BC /* JsonUtils.cpp in Sources */,
+				4A6C4DD413532FC300FDD53F /* CityOnPlanet.cpp in Sources */,
+				4A6C4DD913532FC300FDD53F /* BVHTree.cpp in Sources */,
+				4A6C4DDA13532FC300FDD53F /* CollisionSpace.cpp in Sources */,
+				378563A21B197D740039F2BC /* Shields.cpp in Sources */,
+				378563D21B197DDE0039F2BC /* BaseLoader.cpp in Sources */,
+				4A6C4DDB13532FC300FDD53F /* Geom.cpp in Sources */,
+				4A6C4DDC13532FC300FDD53F /* GeomTree.cpp in Sources */,
+				4A6C4DE213532FC300FDD53F /* DynamicBody.cpp in Sources */,
+				4A6C4DE413532FC300FDD53F /* Frame.cpp in Sources */,
+				3785639F1B197D740039F2BC /* Plane.cpp in Sources */,
+				4A6C4DE513532FC300FDD53F /* GalacticView.cpp in Sources */,
+				4A6C4DE913532FC300FDD53F /* GeoSphere.cpp in Sources */,
+				4A6C4E0413532FC300FDD53F /* HyperspaceCloud.cpp in Sources */,
+				4A6C4E0613532FC300FDD53F /* IniConfig.cpp in Sources */,
+				4A6C4E0713532FC300FDD53F /* KeyBindings.cpp in Sources */,
+				4A6C4E4D13532FC300FDD53F /* main.cpp in Sources */,
+				4A6C4E5213532FC300FDD53F /* Missile.cpp in Sources */,
+				4A6C4E5413532FC300FDD53F /* ModelBody.cpp in Sources */,
+				4A6C4E5913532FC300FDD53F /* ObjectViewerView.cpp in Sources */,
+				4A6C4E7113532FC300FDD53F /* perlin.cpp in Sources */,
+				4A6C4E7213532FC300FDD53F /* Pi.cpp in Sources */,
+				4A6C4E7713532FC300FDD53F /* Planet.cpp in Sources */,
+				4A6C4E7813532FC300FDD53F /* Player.cpp in Sources */,
+				4A6C4E7A13532FC300FDD53F /* Polit.cpp in Sources */,
+				4A6C4E7B13532FC300FDD53F /* Projectile.cpp in Sources */,
+				4A6C4E7E13532FC300FDD53F /* SectorView.cpp in Sources */,
+				4A6C4E7F13532FC300FDD53F /* Serializer.cpp in Sources */,
+				4A6C4E8013532FC300FDD53F /* Sfx.cpp in Sources */,
+				4A6C4E8113532FC300FDD53F /* Ship-AI.cpp in Sources */,
+				378564521B197FAE0039F2BC /* LuaServerAgent.cpp in Sources */,
+				378563C11B197DBB0039F2BC /* Animation.cpp in Sources */,
+				4A6C4E8213532FC300FDD53F /* Ship.cpp in Sources */,
+				4A6C4E8313532FC300FDD53F /* ShipAICmd.cpp in Sources */,
+				4A6C4E8413532FC300FDD53F /* ShipCpanel.cpp in Sources */,
+				4A6C4E8513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp in Sources */,
+				4A6C4E8713532FC300FDD53F /* ShipType.cpp in Sources */,
+				4A6C4E8813532FC300FDD53F /* Sound.cpp in Sources */,
+				378564141B197E600039F2BC /* GasGiantMaterial.cpp in Sources */,
+				4A6C4E8913532FC300FDD53F /* Space.cpp in Sources */,
+				4A6C4E8A13532FC300FDD53F /* SpaceStation.cpp in Sources */,
+				4A6C4E8C13532FC300FDD53F /* Star.cpp in Sources */,
+				4A6C4E8F13532FC300FDD53F /* SystemInfoView.cpp in Sources */,
+				4A6C4E9013532FC300FDD53F /* SystemView.cpp in Sources */,
+				4A6C4E9213532FC300FDD53F /* utils.cpp in Sources */,
+				4A6C4E9313532FC300FDD53F /* WorldView.cpp in Sources */,
+				4A9937511368355500EA0EE5 /* LuaBody.cpp in Sources */,
+				4A9937521368355500EA0EE5 /* LuaCargoBody.cpp in Sources */,
+				3785639A1B197D740039F2BC /* HudTrail.cpp in Sources */,
+				4A9937531368355500EA0EE5 /* LuaConstants.cpp in Sources */,
+				4A9937541368355500EA0EE5 /* LuaEngine.cpp in Sources */,
+				378563B01B197D9C0039F2BC /* FontConfig.cpp in Sources */,
+				4A9937571368355500EA0EE5 /* LuaFormat.cpp in Sources */,
+				4A9937581368355500EA0EE5 /* LuaGame.cpp in Sources */,
+				4A9937591368355500EA0EE5 /* LuaManager.cpp in Sources */,
+				4A99375A1368355500EA0EE5 /* LuaNameGen.cpp in Sources */,
+				4A99375B1368355500EA0EE5 /* LuaObject.cpp in Sources */,
+				4A99375C1368355500EA0EE5 /* LuaPlanet.cpp in Sources */,
+				378563921B197D740039F2BC /* DateTime.cpp in Sources */,
+				4A99375D1368355500EA0EE5 /* LuaPlayer.cpp in Sources */,
+				4A99375E1368355500EA0EE5 /* LuaRand.cpp in Sources */,
+				3785643A1B197E8B0039F2BC /* GalaxyGenerator.cpp in Sources */,
+				4A9937611368355500EA0EE5 /* LuaSerializer.cpp in Sources */,
+				4A9937621368355500EA0EE5 /* LuaShip.cpp in Sources */,
+				4A9937641368355500EA0EE5 /* LuaSpace.cpp in Sources */,
+				4A9937651368355500EA0EE5 /* LuaSpaceStation.cpp in Sources */,
+				4A9937661368355500EA0EE5 /* LuaStar.cpp in Sources */,
+				4A9937671368355500EA0EE5 /* LuaStarSystem.cpp in Sources */,
+				3785639C1B197D740039F2BC /* LuaModelBody.cpp in Sources */,
+				4A9937681368355500EA0EE5 /* LuaTimer.cpp in Sources */,
+				4A99376A1368355500EA0EE5 /* LuaUtils.cpp in Sources */,
+				4A82AA861386969B0028CCED /* GameConfig.cpp in Sources */,
+				4A19038C138AA33300E0229C /* Gui.cpp in Sources */,
+				378563CA1B197DBB0039F2BC /* Table.cpp in Sources */,
+				4A19038E138AA33300E0229C /* GuiBox.cpp in Sources */,
+				4A190390138AA33300E0229C /* GuiButton.cpp in Sources */,
+				4A190392138AA33300E0229C /* GuiContainer.cpp in Sources */,
+				4A190394138AA33300E0229C /* GuiFixed.cpp in Sources */,
+				378563C51B197DBB0039F2BC /* LuaGauge.cpp in Sources */,
+				4A190396138AA33300E0229C /* GuiImage.cpp in Sources */,
+				4A190398138AA33300E0229C /* GuiImageButton.cpp in Sources */,
+				4A19039A138AA33300E0229C /* GuiImageRadioButton.cpp in Sources */,
+				4A19039C138AA33300E0229C /* GuiLabel.cpp in Sources */,
+				4A19039E138AA33300E0229C /* GuiLabelSet.cpp in Sources */,
+				4A1903A0138AA33300E0229C /* GuiMeterBar.cpp in Sources */,
+				378563D31B197DDE0039F2BC /* BinaryConverter.cpp in Sources */,
+				4A1903A2138AA33300E0229C /* GuiMultiStateImageButton.cpp in Sources */,
+				4A1903A4138AA33300E0229C /* GuiRadioButton.cpp in Sources */,
+				4A1903A6138AA33300E0229C /* GuiRadioGroup.cpp in Sources */,
+				4A1903AA138AA33300E0229C /* GuiScreen.cpp in Sources */,
+				4A1903AC138AA33300E0229C /* GuiTabbed.cpp in Sources */,
+				4A1903AE138AA33300E0229C /* GuiTextEntry.cpp in Sources */,
+				4A1903B0138AA33300E0229C /* GuiTextLayout.cpp in Sources */,
+				4A1903B2138AA33300E0229C /* GuiToggleButton.cpp in Sources */,
+				4A1903B4138AA33300E0229C /* GuiToolTip.cpp in Sources */,
+				4A1903B6138AA33300E0229C /* GuiVScrollBar.cpp in Sources */,
+				4A1903B8138AA33300E0229C /* GuiVScrollPortal.cpp in Sources */,
+				4A1903BA138AA33300E0229C /* GuiWidget.cpp in Sources */,
+				4A1904A8138AA39C00E0229C /* lapi.c in Sources */,
+				4A1904AA138AA39C00E0229C /* lauxlib.c in Sources */,
+				4A1904AC138AA39C00E0229C /* lbaselib.c in Sources */,
+				4A1904AE138AA39C00E0229C /* lcode.c in Sources */,
+				4A1904B0138AA39C00E0229C /* ldblib.c in Sources */,
+				4A1904B2138AA39C00E0229C /* ldebug.c in Sources */,
+				378563CC1B197DC90039F2BC /* TerrainColorEarthLikeHeightmapped.cpp in Sources */,
+				378563C21B197DBB0039F2BC /* Gauge.cpp in Sources */,
+				4A1904B4138AA39C00E0229C /* ldo.c in Sources */,
+				4A1904B6138AA39C00E0229C /* ldump.c in Sources */,
+				4A1904B8138AA39C00E0229C /* lfunc.c in Sources */,
+				4A1904BA138AA39C00E0229C /* lgc.c in Sources */,
+				4A1904BD138AA39C00E0229C /* linit.c in Sources */,
+				4A1904BF138AA39C00E0229C /* liolib.c in Sources */,
+				378564261B197E600039F2BC /* Stats.cpp in Sources */,
+				3785644B1B197EB60039F2BC /* PicoDDS.cpp in Sources */,
+				378564191B197E600039F2BC /* MultiMaterial.cpp in Sources */,
+				4A1904C1138AA39C00E0229C /* llex.c in Sources */,
+				4A1904C3138AA39C00E0229C /* lmathlib.c in Sources */,
+				4A1904C5138AA39C00E0229C /* lmem.c in Sources */,
+				4A1904C7138AA39C00E0229C /* loadlib.c in Sources */,
+				4A1904C9138AA39C00E0229C /* lobject.c in Sources */,
+				3785639B1B197D740039F2BC /* JobQueue.cpp in Sources */,
+				4A1904CB138AA39C00E0229C /* lopcodes.c in Sources */,
+				4A1904CD138AA39C00E0229C /* loslib.c in Sources */,
+				4A1904CF138AA39C00E0229C /* lparser.c in Sources */,
+				4A1904D1138AA39C00E0229C /* lstate.c in Sources */,
+				378564391B197E8B0039F2BC /* GalaxyCache.cpp in Sources */,
+				4A1904D3138AA39C00E0229C /* lstring.c in Sources */,
+				4A1904D5138AA39C00E0229C /* lstrlib.c in Sources */,
+				3785644D1B197EB60039F2BC /* Profiler.cpp in Sources */,
+				4A1904D7138AA39C00E0229C /* ltable.c in Sources */,
+				4A1904D9138AA39C00E0229C /* ltablib.c in Sources */,
+				4A1904DB138AA39C00E0229C /* ltm.c in Sources */,
+				4A1904DF138AA39C00E0229C /* lundump.c in Sources */,
+				4A1904E1138AA39C00E0229C /* lvm.c in Sources */,
+				4A1904E3138AA39C00E0229C /* lzio.c in Sources */,
+				4A61E15E13978F1000193E43 /* Background.cpp in Sources */,
+				4A85A86A13C4631D00C2B986 /* LuaMusic.cpp in Sources */,
+				4A85A86B13C4631D00C2B986 /* LuaSystemPath.cpp in Sources */,
+				4A85A86C13C4631D00C2B986 /* SoundMusic.cpp in Sources */,
+				378563A51B197D740039F2BC /* Sphere.cpp in Sources */,
+				378563981B197D740039F2BC /* GeoPatchID.cpp in Sources */,
+				4A24077413F5240F002A5C12 /* Lang.cpp in Sources */,
+				378564531B197FAE0039F2BC /* ServerAgent.cpp in Sources */,
+				4A24078513F524E6002A5C12 /* GuiStack.cpp in Sources */,
+				4A6B59CC1429F14500ADC7C8 /* StringF.cpp in Sources */,
+				4A8DD53B142E19B6006DD821 /* LuaConsole.cpp in Sources */,
+				4AB3DF8914346952001B783A /* TerrainBody.cpp in Sources */,
+				4AE9706714369D7500424F91 /* LuaLang.cpp in Sources */,
+				4A84CB7D14595D850051C848 /* enum_table.cpp in Sources */,
+				4A84CB84146027DC0051C848 /* Camera.cpp in Sources */,
+				4AB7D6031472A83E00158DE4 /* Terrain.cpp in Sources */,
+				4AB7D6041472A83E00158DE4 /* TerrainColorAsteroid.cpp in Sources */,
+				4AB7D6051472A83E00158DE4 /* TerrainColorBandedRock.cpp in Sources */,
+				4AB7D6061472A83E00158DE4 /* TerrainColorDeadWithWater.cpp in Sources */,
+				4AB7D6071472A83E00158DE4 /* TerrainColorDesert.cpp in Sources */,
+				4AB7D6081472A83E00158DE4 /* TerrainColorEarthLike.cpp in Sources */,
+				4AB7D6091472A83E00158DE4 /* TerrainColorGGJupiter.cpp in Sources */,
+				4AB7D60A1472A83E00158DE4 /* TerrainColorGGNeptune.cpp in Sources */,
+				4AB7D60B1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp in Sources */,
+				4AB7D60C1472A83E00158DE4 /* TerrainColorGGSaturn.cpp in Sources */,
+				4AB7D60D1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp in Sources */,
+				4AB7D60E1472A83E00158DE4 /* TerrainColorGGUranus.cpp in Sources */,
+				4AB7D60F1472A83E00158DE4 /* TerrainColorIce.cpp in Sources */,
+				3785643B1B197E8B0039F2BC /* SectorGenerator.cpp in Sources */,
+				4AB7D6101472A83E00158DE4 /* TerrainColorMethane.cpp in Sources */,
+				4AB7D6111472A83E00158DE4 /* TerrainColorRock.cpp in Sources */,
+				4AB7D6121472A83E00158DE4 /* TerrainColorRock2.cpp in Sources */,
+				4AB7D6131472A83E00158DE4 /* TerrainColorSolid.cpp in Sources */,
+				4AB7D6141472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp in Sources */,
+				4AB7D6151472A83E00158DE4 /* TerrainColorStarG.cpp in Sources */,
+				4AB7D6161472A83E00158DE4 /* TerrainColorStarK.cpp in Sources */,
+				52025F791C05BA7100254BB5 /* CollMesh.cpp in Sources */,
+				4AB7D6171472A83E00158DE4 /* TerrainColorStarM.cpp in Sources */,
+				4AB7D6181472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp in Sources */,
+				378563C91B197DBB0039F2BC /* NumberLabel.cpp in Sources */,
+				4AB7D6191472A83E00158DE4 /* TerrainColorTFGood.cpp in Sources */,
+				4AB7D61A1472A83E00158DE4 /* TerrainColorTFPoor.cpp in Sources */,
+				4AB7D61B1472A83E00158DE4 /* TerrainColorVolcanic.cpp in Sources */,
+				4AB7D61C1472A83E00158DE4 /* TerrainFeature.cpp in Sources */,
+				378564221B197E600039F2BC /* Uniform.cpp in Sources */,
+				4AB7D61D1472A83E00158DE4 /* TerrainHeightAsteroid.cpp in Sources */,
+				4AB7D61E1472A83E00158DE4 /* TerrainHeightFlat.cpp in Sources */,
+				4AB7D61F1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp in Sources */,
+				378564151B197E600039F2BC /* GeoSphereMaterial.cpp in Sources */,
+				4AB7D6201472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp in Sources */,
+				4AB7D6211472A83E00158DE4 /* TerrainHeightHillsDunes.cpp in Sources */,
+				3785641A1B197E600039F2BC /* Program.cpp in Sources */,
+				4AB7D6221472A83E00158DE4 /* TerrainHeightHillsNormal.cpp in Sources */,
+				4AB7D6231472A83E00158DE4 /* TerrainHeightHillsRidged.cpp in Sources */,
+				378563D41B197DDE0039F2BC /* LuaModel.cpp in Sources */,
+				4AB7D6241472A83E00158DE4 /* TerrainHeightHillsRivers.cpp in Sources */,
+				4AB7D6251472A83E00158DE4 /* TerrainHeightMapped.cpp in Sources */,
+				4AB7D6261472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp in Sources */,
+				4AB7D6271472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp in Sources */,
+				4AB7D6281472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp in Sources */,
+				4AB7D6291472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp in Sources */,
+				4AB7D62A1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp in Sources */,
+				4AB7D62B1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp in Sources */,
+				4AB7D62C1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp in Sources */,
+				378563A31B197D740039F2BC /* ShipCockpit.cpp in Sources */,
+				4AB7D62D1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp in Sources */,
+				3785641D1B197E600039F2BC /* RendererGL.cpp in Sources */,
+				4AB7D62E1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp in Sources */,
+				4AB7D62F1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp in Sources */,
+				4AB7D6301472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp in Sources */,
+				4AF999A41496D51F009821AF /* Game.cpp in Sources */,
+				4AF999A61496D51F009821AF /* MathUtil.cpp in Sources */,
+				4AED721D14E1501D004D171E /* TerrainHeightMapped2.cpp in Sources */,
+				4A94CA4514F26875002CA792 /* FontCache.cpp in Sources */,
+				4A4F25D214F524D400FD14A6 /* Drawables.cpp in Sources */,
+				378564381B197E8B0039F2BC /* Economy.cpp in Sources */,
+				3785642D1B197E7A0039F2BC /* LuaBindingCapture.cpp in Sources */,
+				378564241B197E600039F2BC /* VtxColorMaterial.cpp in Sources */,
+				4A4F25D314F524D400FD14A6 /* Frustum.cpp in Sources */,
+				4A4F25D414F524D400FD14A6 /* Graphics.cpp in Sources */,
+				4A4F25D614F524D400FD14A6 /* Material.cpp in Sources */,
+				4A4F25D714F524D400FD14A6 /* Renderer.cpp in Sources */,
+				4A4F25DD14F524D400FD14A6 /* VertexArray.cpp in Sources */,
+				4A305FD1151341170076D414 /* FileSystem.cpp in Sources */,
+				4A9174F415187B69006A15A9 /* GuiTexturedQuad.cpp in Sources */,
+				4A9174FB15187B97006A15A9 /* TextureBuilder.cpp in Sources */,
+				4A9174FE15187C17006A15A9 /* Color.cpp in Sources */,
+				4A107C2F1525AB0D00EF9FAC /* CRC32.cpp in Sources */,
+				4A107C301525AB0D00EF9FAC /* ShipController.cpp in Sources */,
+				4ADC7B82152C703200E359B5 /* SDLWrappers.cpp in Sources */,
+				4ADC7B83152C703200E359B5 /* View.cpp in Sources */,
+				378564251B197E600039F2BC /* gl_core_3_x.c in Sources */,
+				4ACC6D1E15401E7000C59914 /* TextSupport.cpp in Sources */,
+				4ACC6D1F15401E7000C59914 /* TextureFont.cpp in Sources */,
+				4AAC9FE91545901D00116131 /* FileSourceZip.cpp in Sources */,
+				4AAC9FEA1545901D00116131 /* ModManager.cpp in Sources */,
+				4ADF518A1557473400ACF5A0 /* CustomSystem.cpp in Sources */,
+				378563961B197D740039F2BC /* GeoPatch.cpp in Sources */,
+				4ADF518B1557473400ACF5A0 /* Galaxy.cpp in Sources */,
+				4ADF518D1557473400ACF5A0 /* Sector.cpp in Sources */,
+				4ADF518E1557473400ACF5A0 /* StarSystem.cpp in Sources */,
+				4ADF51971557477400ACF5A0 /* LuaFixed.cpp in Sources */,
+				378563C61B197DBB0039F2BC /* LuaLayer.cpp in Sources */,
+				4ADF51981557477400ACF5A0 /* LuaMatrix.cpp in Sources */,
+				4ADF51991557477400ACF5A0 /* LuaSystemBody.cpp in Sources */,
+				4ADF519A1557477400ACF5A0 /* LuaVector.cpp in Sources */,
+				4A59B4DA1557EAF5009926E5 /* lbitlib.c in Sources */,
+				4A59B4DB1557EAF5009926E5 /* lcorolib.c in Sources */,
+				4A59B4DC1557EAF5009926E5 /* lctype.c in Sources */,
+				4A3AE8E5158FD22200EB13DE /* LuaComms.cpp in Sources */,
+				4A01889715A59908002F540B /* SystemPath.cpp in Sources */,
+				378563C81B197DBB0039F2BC /* LuaTable.cpp in Sources */,
+				378563931B197D740039F2BC /* FaceParts.cpp in Sources */,
+				4A37073615A879D100E7E5F6 /* lookup3.c in Sources */,
+				4ADB0D0C15C50DD900AE2123 /* TerrainHeightAsteroid2.cpp in Sources */,
+				4ADB0D0D15C50DD900AE2123 /* TerrainHeightAsteroid3.cpp in Sources */,
+				4ADB0D0E15C50DD900AE2123 /* TerrainHeightAsteroid4.cpp in Sources */,
+				4ADB0D0F15C50DD900AE2123 /* TerrainHeightBarrenRock.cpp in Sources */,
+				4ADB0D1015C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp in Sources */,
+				4ADB0D1115C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp in Sources */,
+				4ADB0D1615C50DF000AE2123 /* FileSystemPosix.cpp in Sources */,
+				4ADB0D1815C50DF000AE2123 /* OSPosix.cpp in Sources */,
+				378564181B197E600039F2BC /* MaterialGL.cpp in Sources */,
+				4AEC8A1A15C7886A00B281C3 /* Light.cpp in Sources */,
+				4AF0058B15F0F30400CC19C0 /* LuaEvent.cpp in Sources */,
+				4AF0059315F17C6700CC19C0 /* LuaFileSystem.cpp in Sources */,
+				4AAB881D15F4AD7700AAF8A8 /* Lua.cpp in Sources */,
+				4AAB884815FDEA6F00AAF8A8 /* LuaRef.cpp in Sources */,
+				378564121B197E600039F2BC /* RendererDummy.cpp in Sources */,
+				378564281B197E600039F2BC /* WindowSDL.cpp in Sources */,
+				4A973BF71618688F0029562D /* DeathView.cpp in Sources */,
+				4A973BF81618688F0029562D /* LuaDev.cpp in Sources */,
+				4AF222E7162103EA00BED38E /* Factions.cpp in Sources */,
+				4AF222E8162103EA00BED38E /* Intro.cpp in Sources */,
+				4AF222E9162103EA00BED38E /* Tombstone.cpp in Sources */,
+				4ABF307916335A1100664653 /* Align.cpp in Sources */,
+				378563971B197D740039F2BC /* GeoPatchContext.cpp in Sources */,
+				4ABF307A16335A1100664653 /* Background.cpp in Sources */,
+				4ABF307B16335A1100664653 /* Box.cpp in Sources */,
+				4ABF307C16335A1100664653 /* Button.cpp in Sources */,
+				4ABF307D16335A1100664653 /* CellSpec.cpp in Sources */,
+				4ABF307E16335A1100664653 /* CheckBox.cpp in Sources */,
+				4ABF307F16335A1100664653 /* ColorBackground.cpp in Sources */,
+				4ABF308016335A1100664653 /* Container.cpp in Sources */,
+				4ABF308116335A1100664653 /* Context.cpp in Sources */,
+				4ABF308216335A1100664653 /* DropDown.cpp in Sources */,
+				378563C41B197DBB0039F2BC /* LuaAnimation.cpp in Sources */,
+				4ABF308316335A1100664653 /* Event.cpp in Sources */,
+				4ABF308416335A1100664653 /* EventDispatcher.cpp in Sources */,
+				4ABF308616335A1100664653 /* Grid.cpp in Sources */,
+				4ABF308716335A1100664653 /* Image.cpp in Sources */,
+				4ABF308816335A1100664653 /* Label.cpp in Sources */,
+				4ABF308916335A1100664653 /* List.cpp in Sources */,
+				4ABF308A16335A1100664653 /* Lua.cpp in Sources */,
+				378564231B197E600039F2BC /* VertexBufferGL.cpp in Sources */,
+				4ABF308B16335A1100664653 /* LuaAlign.cpp in Sources */,
+				378563A01B197D740039F2BC /* Sensors.cpp in Sources */,
+				4ABF308C16335A1100664653 /* LuaBackground.cpp in Sources */,
+				4ABF308D16335A1100664653 /* LuaBox.cpp in Sources */,
+				378563991B197D740039F2BC /* GeoPatchJobs.cpp in Sources */,
+				4ABF308E16335A1100664653 /* LuaButton.cpp in Sources */,
+				4ABF308F16335A1100664653 /* LuaCheckBox.cpp in Sources */,
+				4ABF309016335A1100664653 /* LuaColorBackground.cpp in Sources */,
+				3785641C1B197E600039F2BC /* RenderTargetGL.cpp in Sources */,
+				4ABF309116335A1100664653 /* LuaContainer.cpp in Sources */,
+				4ABF309216335A1100664653 /* LuaContext.cpp in Sources */,
+				4ABF309316335A1100664653 /* LuaDropDown.cpp in Sources */,
+				4ABF309416335A1100664653 /* LuaGrid.cpp in Sources */,
+				4ABF309516335A1100664653 /* LuaImage.cpp in Sources */,
+				378564201B197E600039F2BC /* TextureGL.cpp in Sources */,
+				4ABF309616335A1100664653 /* LuaLabel.cpp in Sources */,
+				4ABF309716335A1100664653 /* LuaList.cpp in Sources */,
+				4ABF309816335A1100664653 /* LuaMargin.cpp in Sources */,
+				4ABF309916335A1100664653 /* LuaMultiLineText.cpp in Sources */,
+				4ABF309A16335A1100664653 /* LuaScroller.cpp in Sources */,
+				4ABF309B16335A1100664653 /* LuaSingle.cpp in Sources */,
+				4ABF309C16335A1100664653 /* LuaSlider.cpp in Sources */,
+				4ABF309D16335A1100664653 /* LuaWidget.cpp in Sources */,
+				4ABF309F16335A1100664653 /* Margin.cpp in Sources */,
+				3785641F1B197E600039F2BC /* ShieldMaterial.cpp in Sources */,
+				4ABF30A016335A1100664653 /* MultiLineText.cpp in Sources */,
+				4ABF30A116335A1100664653 /* Scroller.cpp in Sources */,
+				4ABF30A216335A1100664653 /* Single.cpp in Sources */,
+				378563941B197D740039F2BC /* GameLog.cpp in Sources */,
+				4ABF30A316335A1100664653 /* Skin.cpp in Sources */,
+				4ABF30A416335A1100664653 /* Slider.cpp in Sources */,
+				4ABF30A516335A1100664653 /* TextLayout.cpp in Sources */,
+				378563A41B197D740039F2BC /* SpeedLines.cpp in Sources */,
+				4ABF30A616335A1100664653 /* Widget.cpp in Sources */,
+				4A239FCB163E78D60037BE24 /* LuaFaction.cpp in Sources */,
+				4AFBD7B91641265D002928CB /* PngWriter.cpp in Sources */,
+				378564131B197E600039F2BC /* FresnelColourMaterial.cpp in Sources */,
+				4AFBD7BD16412676002928CB /* LuaTextEntry.cpp in Sources */,
+				4AFBD7BE16412676002928CB /* TextEntry.cpp in Sources */,
+				3785641B1B197E600039F2BC /* RenderStateGL.cpp in Sources */,
+				4AA4A8DA164D0EB10006C3BF /* Expand.cpp in Sources */,
+				4AA4A8DB164D0EB10006C3BF /* Gradient.cpp in Sources */,
+				4AA4A8DC164D0EB10006C3BF /* LuaExpand.cpp in Sources */,
+				378564211B197E600039F2BC /* UIMaterial.cpp in Sources */,
+				4AA4A8DD164D0EB10006C3BF /* LuaGradient.cpp in Sources */,
+				4A24FD5E1650F4B700DE7B0F /* UIView.cpp in Sources */,
+				4A24FD671650F4D100DE7B0F /* Lua.cpp in Sources */,
+				3785642C1B197E7A0039F2BC /* BindingCapture.cpp in Sources */,
+				4A24FD691650F4D100DE7B0F /* Panel.cpp in Sources */,
+				4A0F25CE165CF00D00208507 /* LuaSmallButton.cpp in Sources */,
+				378563951B197D740039F2BC /* GasGiant.cpp in Sources */,
+				4A0F25CF165CF00D00208507 /* SmallButton.cpp in Sources */,
+				4A4D25D8167335D9003BC9D5 /* Face.cpp in Sources */,
+				4A4D25D9167335D9003BC9D5 /* LuaFace.cpp in Sources */,
+				378564271B197E600039F2BC /* VertexBuffer.cpp in Sources */,
+				3785641E1B197E600039F2BC /* RingMaterial.cpp in Sources */,
+				4A4D25DF167335F5003BC9D5 /* Icon.cpp in Sources */,
+				4A4D25E0167335F5003BC9D5 /* LuaIcon.cpp in Sources */,
+				4ACDB6B1167878620069FA03 /* Animation.cpp in Sources */,
+				4ACDB6B2167878620069FA03 /* Billboard.cpp in Sources */,
+				4ACDB6B3167878620069FA03 /* CollisionGeometry.cpp in Sources */,
+				4ACDB6B4167878620069FA03 /* CollisionVisitor.cpp in Sources */,
+				3785643C1B197E8B0039F2BC /* StarSystemGenerator.cpp in Sources */,
+				4ACDB6B5167878620069FA03 /* ColorMap.cpp in Sources */,
+				4ACDB6B6167878620069FA03 /* DumpVisitor.cpp in Sources */,
+				4ACDB6B7167878620069FA03 /* FindNodeVisitor.cpp in Sources */,
+				4ACDB6B8167878620069FA03 /* Group.cpp in Sources */,
+				4ACDB6B9167878620069FA03 /* Label3D.cpp in Sources */,
+				4ACDB6BA167878620069FA03 /* Loader.cpp in Sources */,
+				4ACDB6BB167878620069FA03 /* LOD.cpp in Sources */,
+				4ACDB6BD167878620069FA03 /* MatrixTransform.cpp in Sources */,
+				4ACDB6BE167878620069FA03 /* Model.cpp in Sources */,
+				4ACDB6BF167878620069FA03 /* ModelNode.cpp in Sources */,
+				4ACDB6C0167878620069FA03 /* Node.cpp in Sources */,
+				4ACDB6C1167878620069FA03 /* NodeVisitor.cpp in Sources */,
+				4ACDB6C2167878620069FA03 /* Parser.cpp in Sources */,
+				4ACDB6C3167878620069FA03 /* Pattern.cpp in Sources */,
+				4ACDB6C4167878620069FA03 /* StaticGeometry.cpp in Sources */,
+				4ACDB6C5167878620069FA03 /* Thruster.cpp in Sources */,
+				4ACDB6CE167878CE0069FA03 /* ModelCache.cpp in Sources */,
+				4ACDB6CF167878CE0069FA03 /* ModelViewer.cpp in Sources */,
+				4ACDB6D2167879AF0069FA03 /* DistanceFieldFont.cpp in Sources */,
+				378563C31B197DBB0039F2BC /* Layer.cpp in Sources */,
+				4AEE56DD16A44CD800AA1C53 /* SpaceStationType.cpp in Sources */,
+				3785635F1B197CF90039F2BC /* jsoncpp.cpp in Sources */,
+				4A4A86E916A992D600F81F18 /* CameraController.cpp in Sources */,
+				4ACE132F16B4B19D00CAE524 /* EnumStrings.cpp in Sources */,
+				4ACED56A16BBCC7200E53808 /* LuaMissile.cpp in Sources */,
+				4AA84A2816D0E18700220311 /* LuaShipDef.cpp in Sources */,
+				4AA527FA16E9EABA0036D4CB /* NavLights.cpp in Sources */,
+				4AA527FE16E9EB650036D4CB /* LuaModelSpinner.cpp in Sources */,
+				4AA527FF16E9EB650036D4CB /* ModelSpinner.cpp in Sources */,
+				378563C71B197DBB0039F2BC /* LuaNumberLabel.cpp in Sources */,
+				4AA5280516E9EB980036D4CB /* Lua.cpp in Sources */,
+				4AA5280616E9EB980036D4CB /* ModelSkin.cpp in Sources */,
+				4AA5280816E9EBD60036D4CB /* LuaModelSkin.cpp in Sources */,
+				4A712413170EC89000BB9BCC /* Orbit.cpp in Sources */,
+				378563911B197D740039F2BC /* BaseSphere.cpp in Sources */,
+				4A8AE19617208CE50005C2D9 /* LuaPropertiedObject.cpp in Sources */,
+				4A8AE19717208CE50005C2D9 /* PropertyMap.cpp in Sources */,
+				4AA9F6CC17288E0900124C2E /* TerrainHeightEllipsoid.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2924,16 +2817,22 @@
 		4A20B0D51353194B0020F43E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ENABLE_TESTABILITY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_CXX0X_EXTENSIONS = YES;
 				HEADER_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		4A20B0D61353194B0020F43E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_CXX0X_EXTENSIONS = YES;
 				HEADER_SEARCH_PATHS = "";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -2941,16 +2840,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(TARGET_BUILD_DIR)",
+					"$(PROJECT_DIR)",
 					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
-				GCC_C_LANGUAGE_STANDARD = c11;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
@@ -2979,22 +2877,17 @@
 				INFOPLIST_FILE = "pioneer/pioneer-Info.plist";
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				INFOPLIST_PREPROCESS = YES;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					/opt/local/lib,
+					"/opt/local/lib/**",
 					"\"$(SRCROOT)/../src/gui\"",
 					"\"$(SRCROOT)/../contrib/lua\"",
-					"\"$(SRCROOT)/../contrib/oolua\"",
-					"\"$(SRCROOT)/../src/render\"",
+					/opt/local/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_LDFLAGS = (
-					"-headerpad_max_install_names",
-					"-v",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "net.pioneerspacesim.${PRODUCT_NAME:rfc1034identifier}";
+				OTHER_LDFLAGS = "-headerpad_max_install_names";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
 				WRAPPER_EXTENSION = app;
 			};
@@ -3004,16 +2897,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(TARGET_BUILD_DIR)",
+					"$(PROJECT_DIR)",
+					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/pioneer-ezidovdnkvmaqigenmdknrfjdoju/Build/Products/Debug",
 					"$(LOCAL_LIBRARY_DIR)/Frameworks",
 				);
-				GCC_C_LANGUAGE_STANDARD = c11;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
@@ -3039,23 +2932,18 @@
 				INFOPLIST_FILE = "pioneer/pioneer-Info.plist";
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				INFOPLIST_PREPROCESS = YES;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					/opt/local/lib,
+					"/opt/local/lib/**",
 					"\"$(SRCROOT)/../src/gui\"",
 					"\"$(SRCROOT)/../contrib/lua\"",
-					"\"$(SRCROOT)/../contrib/oolua\"",
-					"\"$(SRCROOT)/../src/render\"",
+					/opt/local/lib,
 				);
 				LLVM_LTO = NO;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_LDFLAGS = (
-					"-headerpad_max_install_names",
-					"-v",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "net.pioneerspacesim.${PRODUCT_NAME:rfc1034identifier}";
+				OTHER_LDFLAGS = "-headerpad_max_install_names";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
 				WRAPPER_EXTENSION = app;
 			};

--- a/osx/pioneer.xcodeproj/project.pbxproj
+++ b/osx/pioneer.xcodeproj/project.pbxproj
@@ -21,396 +21,26 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		4A01889715A59908002F540B /* SystemPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A01889615A59908002F540B /* SystemPath.cpp */; };
-		4A0F25CE165CF00D00208507 /* LuaSmallButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A0F25CB165CF00D00208507 /* LuaSmallButton.cpp */; };
-		4A0F25CF165CF00D00208507 /* SmallButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A0F25CC165CF00D00208507 /* SmallButton.cpp */; };
-		4A107C2F1525AB0D00EF9FAC /* CRC32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A107C2B1525AB0D00EF9FAC /* CRC32.cpp */; };
-		4A107C301525AB0D00EF9FAC /* ShipController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A107C2D1525AB0D00EF9FAC /* ShipController.cpp */; };
-		4A19038C138AA33300E0229C /* Gui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190325138AA33300E0229C /* Gui.cpp */; };
-		4A19038E138AA33300E0229C /* GuiBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190329138AA33300E0229C /* GuiBox.cpp */; };
-		4A190390138AA33300E0229C /* GuiButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19032C138AA33300E0229C /* GuiButton.cpp */; };
-		4A190392138AA33300E0229C /* GuiContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19032F138AA33300E0229C /* GuiContainer.cpp */; };
-		4A190394138AA33300E0229C /* GuiFixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190333138AA33300E0229C /* GuiFixed.cpp */; };
-		4A190396138AA33300E0229C /* GuiImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190336138AA33300E0229C /* GuiImage.cpp */; };
-		4A190398138AA33300E0229C /* GuiImageButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190339138AA33300E0229C /* GuiImageButton.cpp */; };
-		4A19039A138AA33300E0229C /* GuiImageRadioButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19033C138AA33300E0229C /* GuiImageRadioButton.cpp */; };
-		4A19039C138AA33300E0229C /* GuiLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190340138AA33300E0229C /* GuiLabel.cpp */; };
-		4A19039E138AA33300E0229C /* GuiLabelSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190343138AA33300E0229C /* GuiLabelSet.cpp */; };
-		4A1903A0138AA33300E0229C /* GuiMeterBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190346138AA33300E0229C /* GuiMeterBar.cpp */; };
-		4A1903A2138AA33300E0229C /* GuiMultiStateImageButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190349138AA33300E0229C /* GuiMultiStateImageButton.cpp */; };
-		4A1903A4138AA33300E0229C /* GuiRadioButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19034C138AA33300E0229C /* GuiRadioButton.cpp */; };
-		4A1903A6138AA33300E0229C /* GuiRadioGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19034F138AA33300E0229C /* GuiRadioGroup.cpp */; };
-		4A1903A8138AA33300E0229C /* GuiRepeaterButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190352138AA33300E0229C /* GuiRepeaterButton.cpp */; };
-		4A1903AA138AA33300E0229C /* GuiScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190355138AA33300E0229C /* GuiScreen.cpp */; };
-		4A1903AC138AA33300E0229C /* GuiTabbed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190358138AA33300E0229C /* GuiTabbed.cpp */; };
-		4A1903AE138AA33300E0229C /* GuiTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19035B138AA33300E0229C /* GuiTextEntry.cpp */; };
-		4A1903B0138AA33300E0229C /* GuiTextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19035E138AA33300E0229C /* GuiTextLayout.cpp */; };
-		4A1903B2138AA33300E0229C /* GuiToggleButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190361138AA33300E0229C /* GuiToggleButton.cpp */; };
-		4A1903B4138AA33300E0229C /* GuiToolTip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190364138AA33300E0229C /* GuiToolTip.cpp */; };
-		4A1903B6138AA33300E0229C /* GuiVScrollBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A190367138AA33300E0229C /* GuiVScrollBar.cpp */; };
-		4A1903B8138AA33300E0229C /* GuiVScrollPortal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19036A138AA33300E0229C /* GuiVScrollPortal.cpp */; };
-		4A1903BA138AA33300E0229C /* GuiWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A19036D138AA33300E0229C /* GuiWidget.cpp */; };
-		4A1904A8138AA39C00E0229C /* lapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903E2138AA39C00E0229C /* lapi.c */; };
-		4A1904AA138AA39C00E0229C /* lauxlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903E5138AA39C00E0229C /* lauxlib.c */; };
-		4A1904AC138AA39C00E0229C /* lbaselib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903E8138AA39C00E0229C /* lbaselib.c */; };
-		4A1904AE138AA39C00E0229C /* lcode.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903EA138AA39C00E0229C /* lcode.c */; };
-		4A1904B0138AA39C00E0229C /* ldblib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903ED138AA39C00E0229C /* ldblib.c */; };
-		4A1904B2138AA39C00E0229C /* ldebug.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903EF138AA39C00E0229C /* ldebug.c */; };
-		4A1904B4138AA39C00E0229C /* ldo.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903F2138AA39C00E0229C /* ldo.c */; };
-		4A1904B6138AA39C00E0229C /* ldump.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903F5138AA39C00E0229C /* ldump.c */; };
-		4A1904B8138AA39C00E0229C /* lfunc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903F7138AA39C00E0229C /* lfunc.c */; };
-		4A1904BA138AA39C00E0229C /* lgc.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903FA138AA39C00E0229C /* lgc.c */; };
-		4A1904BD138AA39C00E0229C /* linit.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A1903FE138AA39C00E0229C /* linit.c */; };
-		4A1904BF138AA39C00E0229C /* liolib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190400138AA39C00E0229C /* liolib.c */; };
-		4A1904C1138AA39C00E0229C /* llex.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190402138AA39C00E0229C /* llex.c */; };
-		4A1904C3138AA39C00E0229C /* lmathlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190406138AA39C00E0229C /* lmathlib.c */; };
-		4A1904C5138AA39C00E0229C /* lmem.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190408138AA39C00E0229C /* lmem.c */; };
-		4A1904C7138AA39C00E0229C /* loadlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19040B138AA39C00E0229C /* loadlib.c */; };
-		4A1904C9138AA39C00E0229C /* lobject.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19040D138AA39C00E0229C /* lobject.c */; };
-		4A1904CB138AA39C00E0229C /* lopcodes.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190410138AA39C00E0229C /* lopcodes.c */; };
-		4A1904CD138AA39C00E0229C /* loslib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190413138AA39C00E0229C /* loslib.c */; };
-		4A1904CF138AA39C00E0229C /* lparser.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190415138AA39C00E0229C /* lparser.c */; };
-		4A1904D1138AA39C00E0229C /* lstate.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190418138AA39C00E0229C /* lstate.c */; };
-		4A1904D3138AA39C00E0229C /* lstring.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19041B138AA39C00E0229C /* lstring.c */; };
-		4A1904D5138AA39C00E0229C /* lstrlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19041E138AA39C00E0229C /* lstrlib.c */; };
-		4A1904D7138AA39C00E0229C /* ltable.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190420138AA39C00E0229C /* ltable.c */; };
-		4A1904D9138AA39C00E0229C /* ltablib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190423138AA39C00E0229C /* ltablib.c */; };
-		4A1904DB138AA39C00E0229C /* ltm.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190425138AA39C00E0229C /* ltm.c */; };
-		4A1904DF138AA39C00E0229C /* lundump.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A19042D138AA39C00E0229C /* lundump.c */; };
-		4A1904E1138AA39C00E0229C /* lvm.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190430138AA39C00E0229C /* lvm.c */; };
-		4A1904E3138AA39C00E0229C /* lzio.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A190433138AA39C00E0229C /* lzio.c */; };
 		4A20B0E3135319770020F43E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A20B0E2135319770020F43E /* Cocoa.framework */; };
-		4A20B11113531C040020F43E /* SDLMain.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A20B10F13531C040020F43E /* SDLMain.m */; };
 		4A20B11C13531CD10020F43E /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 4A20B11613531CD10020F43E /* Credits.rtf */; };
 		4A20B11D13531CD10020F43E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4A20B11813531CD10020F43E /* InfoPlist.strings */; };
 		4A20B12013531E950020F43E /* pioneerApp.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A20B11F13531E950020F43E /* pioneerApp.xib */; };
-		4A239FCB163E78D60037BE24 /* LuaFaction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A239FC9163E78D60037BE24 /* LuaFaction.cpp */; };
-		4A24077213F5240F002A5C12 /* ChatForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24075513F5240F002A5C12 /* ChatForm.cpp */; };
-		4A24077313F5240F002A5C12 /* FormController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24075813F5240F002A5C12 /* FormController.cpp */; };
-		4A24077413F5240F002A5C12 /* Lang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24075A13F5240F002A5C12 /* Lang.cpp */; };
-		4A24077513F5240F002A5C12 /* ShipSpinnerWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24075C13F5240F002A5C12 /* ShipSpinnerWidget.cpp */; };
-		4A24077613F5240F002A5C12 /* StationAdvertForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24075E13F5240F002A5C12 /* StationAdvertForm.cpp */; };
-		4A24077713F5240F002A5C12 /* StationBulletinBoardForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24076013F5240F002A5C12 /* StationBulletinBoardForm.cpp */; };
-		4A24077813F5240F002A5C12 /* StationCommodityMarketForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24076213F5240F002A5C12 /* StationCommodityMarketForm.cpp */; };
-		4A24077913F5240F002A5C12 /* StationPoliceForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24076413F5240F002A5C12 /* StationPoliceForm.cpp */; };
-		4A24077A13F5240F002A5C12 /* StationServicesForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24076613F5240F002A5C12 /* StationServicesForm.cpp */; };
-		4A24077B13F5240F002A5C12 /* StationShipEquipmentForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24076813F5240F002A5C12 /* StationShipEquipmentForm.cpp */; };
-		4A24077C13F5240F002A5C12 /* StationShipMarketForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24076A13F5240F002A5C12 /* StationShipMarketForm.cpp */; };
-		4A24077D13F5240F002A5C12 /* StationShipRepairForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24076C13F5240F002A5C12 /* StationShipRepairForm.cpp */; };
-		4A24077E13F5240F002A5C12 /* StationShipViewForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24076E13F5240F002A5C12 /* StationShipViewForm.cpp */; };
-		4A24077F13F5240F002A5C12 /* StationShipyardForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24077013F5240F002A5C12 /* StationShipyardForm.cpp */; };
-		4A24078413F524E6002A5C12 /* GuiGradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24078013F524E6002A5C12 /* GuiGradient.cpp */; };
-		4A24078513F524E6002A5C12 /* GuiStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24078213F524E6002A5C12 /* GuiStack.cpp */; };
-		4A24FD5E1650F4B700DE7B0F /* UIView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24FD5C1650F4B700DE7B0F /* UIView.cpp */; };
-		4A24FD671650F4D100DE7B0F /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24FD621650F4D100DE7B0F /* Lua.cpp */; };
-		4A24FD691650F4D100DE7B0F /* Panel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A24FD651650F4D100DE7B0F /* Panel.cpp */; };
-		4A305FD1151341170076D414 /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A305FCC151341170076D414 /* FileSystem.cpp */; };
-		4A37073615A879D100E7E5F6 /* lookup3.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A37073315A879D100E7E5F6 /* lookup3.c */; };
-		4A3AE8E5158FD22200EB13DE /* LuaComms.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A3AE8E3158FD22200EB13DE /* LuaComms.cpp */; };
-		4A4A86E916A992D600F81F18 /* CameraController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A86E716A992D600F81F18 /* CameraController.cpp */; };
-		4A4D25D8167335D9003BC9D5 /* Face.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D25D2167335D9003BC9D5 /* Face.cpp */; };
-		4A4D25D9167335D9003BC9D5 /* LuaFace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D25D4167335D9003BC9D5 /* LuaFace.cpp */; };
-		4A4D25DF167335F5003BC9D5 /* Icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D25DC167335F5003BC9D5 /* Icon.cpp */; };
-		4A4D25E0167335F5003BC9D5 /* LuaIcon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4D25DE167335F5003BC9D5 /* LuaIcon.cpp */; };
-		4A4F25D214F524D400FD14A6 /* Drawables.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25B914F524D400FD14A6 /* Drawables.cpp */; };
-		4A4F25D314F524D400FD14A6 /* Frustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25BB14F524D400FD14A6 /* Frustum.cpp */; };
-		4A4F25D414F524D400FD14A6 /* Graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25BD14F524D400FD14A6 /* Graphics.cpp */; };
-		4A4F25D614F524D400FD14A6 /* Material.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25C014F524D400FD14A6 /* Material.cpp */; };
-		4A4F25D714F524D400FD14A6 /* Renderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25C214F524D400FD14A6 /* Renderer.cpp */; };
-		4A4F25D814F524D400FD14A6 /* RendererGL2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25C414F524D400FD14A6 /* RendererGL2.cpp */; };
-		4A4F25D914F524D400FD14A6 /* RendererLegacy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25C714F524D400FD14A6 /* RendererLegacy.cpp */; };
-		4A4F25DC14F524D400FD14A6 /* StaticMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25CD14F524D400FD14A6 /* StaticMesh.cpp */; };
-		4A4F25DD14F524D400FD14A6 /* VertexArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4F25D014F524D400FD14A6 /* VertexArray.cpp */; };
 		4A5619CF13866622002A904C /* libfreetype.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A5619CE13866622002A904C /* libfreetype.6.dylib */; };
 		4A5619D313866B5B002A904C /* libfreetype.6.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4A5619CE13866622002A904C /* libfreetype.6.dylib */; };
 		4A5619D513867033002A904C /* libvorbisfile.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A5619D413867033002A904C /* libvorbisfile.3.dylib */; };
 		4A5619D813867661002A904C /* libvorbisfile.3.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4A5619D413867033002A904C /* libvorbisfile.3.dylib */; };
-		4A59B4DA1557EAF5009926E5 /* lbitlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B4D51557EAF5009926E5 /* lbitlib.c */; };
-		4A59B4DB1557EAF5009926E5 /* lcorolib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B4D61557EAF5009926E5 /* lcorolib.c */; };
-		4A59B4DC1557EAF5009926E5 /* lctype.c in Sources */ = {isa = PBXBuildFile; fileRef = 4A59B4D71557EAF5009926E5 /* lctype.c */; };
-		4A61E15E13978F1000193E43 /* Background.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A61E15C13978F1000193E43 /* Background.cpp */; };
-		4A62EF2C136979E000919EBB /* DeadVideoLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A62EF27136979E000919EBB /* DeadVideoLink.cpp */; };
-		4A62EF2D136979E000919EBB /* FaceVideoLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A62EF29136979E000919EBB /* FaceVideoLink.cpp */; };
 		4A671B8A1388C08500657F38 /* libogg.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B861388C07700657F38 /* libogg.0.dylib */; };
 		4A671B8B1388C08500657F38 /* libvorbis.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B871388C07700657F38 /* libvorbis.0.dylib */; };
-		4A671B941388C3E500657F38 /* libtiff.3.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B921388C3DC00657F38 /* libtiff.3.dylib */; };
-		4A671B971388C47A00657F38 /* libjpeg.8.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B951388C47200657F38 /* libjpeg.8.dylib */; };
 		4A671B9A1388C62800657F38 /* libsmpeg-0.4.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B981388C61F00657F38 /* libsmpeg-0.4.0.dylib */; };
 		4A671B9D1388C6C400657F38 /* libmodplug.1.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671B9B1388C6B700657F38 /* libmodplug.1.dylib */; };
 		4A671BA31388CA3F00657F38 /* libspeex.1.5.0.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A671BA11388CA3200657F38 /* libspeex.1.5.0.dylib */; };
-		4A6B59CC1429F14500ADC7C8 /* StringF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B59CA1429F14500ADC7C8 /* StringF.cpp */; };
-		4A6C4DD113532FC300FDD53F /* AmbientSounds.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4BFF13532FC300FDD53F /* AmbientSounds.cpp */; };
-		4A6C4DD213532FC300FDD53F /* Body.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C0213532FC300FDD53F /* Body.cpp */; };
-		4A6C4DD313532FC300FDD53F /* CargoBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C0513532FC300FDD53F /* CargoBody.cpp */; };
-		4A6C4DD413532FC300FDD53F /* CityOnPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C0713532FC300FDD53F /* CityOnPlanet.cpp */; };
-		4A6C4DD913532FC300FDD53F /* BVHTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C0F13532FC300FDD53F /* BVHTree.cpp */; };
-		4A6C4DDA13532FC300FDD53F /* CollisionSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C1313532FC300FDD53F /* CollisionSpace.cpp */; };
-		4A6C4DDB13532FC300FDD53F /* Geom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C1513532FC300FDD53F /* Geom.cpp */; };
-		4A6C4DDC13532FC300FDD53F /* GeomTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C1713532FC300FDD53F /* GeomTree.cpp */; };
-		4A6C4DE013532FC300FDD53F /* CommodityTradeWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C1D13532FC300FDD53F /* CommodityTradeWidget.cpp */; };
-		4A6C4DE213532FC300FDD53F /* DynamicBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C2113532FC300FDD53F /* DynamicBody.cpp */; };
-		4A6C4DE313532FC300FDD53F /* EquipType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C2313532FC300FDD53F /* EquipType.cpp */; };
-		4A6C4DE413532FC300FDD53F /* Frame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C2613532FC300FDD53F /* Frame.cpp */; };
-		4A6C4DE513532FC300FDD53F /* GalacticView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C2813532FC300FDD53F /* GalacticView.cpp */; };
-		4A6C4DE713532FC300FDD53F /* GameMenuView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C2D13532FC300FDD53F /* GameMenuView.cpp */; };
-		4A6C4DE913532FC300FDD53F /* GeoSphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C3113532FC300FDD53F /* GeoSphere.cpp */; };
-		4A6C4E0413532FC300FDD53F /* HyperspaceCloud.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C6A13532FC300FDD53F /* HyperspaceCloud.cpp */; };
-		4A6C4E0613532FC300FDD53F /* IniConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C6E13532FC300FDD53F /* IniConfig.cpp */; };
-		4A6C4E0713532FC300FDD53F /* KeyBindings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4C7013532FC300FDD53F /* KeyBindings.cpp */; };
-		4A6C4E4B13532FC300FDD53F /* LuaChatForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CD013532FC300FDD53F /* LuaChatForm.cpp */; };
-		4A6C4E4D13532FC300FDD53F /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CD313532FC300FDD53F /* main.cpp */; };
-		4A6C4E5113532FC300FDD53F /* MarketAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CD713532FC300FDD53F /* MarketAgent.cpp */; };
-		4A6C4E5213532FC300FDD53F /* Missile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CDA13532FC300FDD53F /* Missile.cpp */; };
-		4A6C4E5413532FC300FDD53F /* ModelBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CDE13532FC300FDD53F /* ModelBody.cpp */; };
-		4A6C4E5913532FC300FDD53F /* ObjectViewerView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4CE913532FC300FDD53F /* ObjectViewerView.cpp */; };
-		4A6C4E7113532FC300FDD53F /* perlin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D2C13532FC300FDD53F /* perlin.cpp */; };
-		4A6C4E7213532FC300FDD53F /* Pi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D2F13532FC300FDD53F /* Pi.cpp */; };
-		4A6C4E7713532FC300FDD53F /* Planet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D3913532FC300FDD53F /* Planet.cpp */; };
-		4A6C4E7813532FC300FDD53F /* Player.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D3B13532FC300FDD53F /* Player.cpp */; };
-		4A6C4E7A13532FC300FDD53F /* Polit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D3F13532FC300FDD53F /* Polit.cpp */; };
-		4A6C4E7B13532FC300FDD53F /* Projectile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4113532FC300FDD53F /* Projectile.cpp */; };
-		4A6C4E7E13532FC300FDD53F /* SectorView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4813532FC300FDD53F /* SectorView.cpp */; };
-		4A6C4E7F13532FC300FDD53F /* Serializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4A13532FC300FDD53F /* Serializer.cpp */; };
-		4A6C4E8013532FC300FDD53F /* Sfx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4C13532FC300FDD53F /* Sfx.cpp */; };
-		4A6C4E8113532FC300FDD53F /* Ship-AI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4E13532FC300FDD53F /* Ship-AI.cpp */; };
-		4A6C4E8213532FC300FDD53F /* Ship.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D4F13532FC300FDD53F /* Ship.cpp */; };
-		4A6C4E8313532FC300FDD53F /* ShipAICmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5113532FC300FDD53F /* ShipAICmd.cpp */; };
-		4A6C4E8413532FC300FDD53F /* ShipCpanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5313532FC300FDD53F /* ShipCpanel.cpp */; };
-		4A6C4E8513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp */; };
-		4A6C4E8713532FC300FDD53F /* ShipType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5913532FC300FDD53F /* ShipType.cpp */; };
-		4A6C4E8813532FC300FDD53F /* Sound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5B13532FC300FDD53F /* Sound.cpp */; };
-		4A6C4E8913532FC300FDD53F /* Space.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5D13532FC300FDD53F /* Space.cpp */; };
-		4A6C4E8A13532FC300FDD53F /* SpaceStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D5F13532FC300FDD53F /* SpaceStation.cpp */; };
-		4A6C4E8B13532FC300FDD53F /* SpaceStationView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6113532FC300FDD53F /* SpaceStationView.cpp */; };
-		4A6C4E8C13532FC300FDD53F /* Star.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6313532FC300FDD53F /* Star.cpp */; };
-		4A6C4E8F13532FC300FDD53F /* SystemInfoView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6913532FC300FDD53F /* SystemInfoView.cpp */; };
-		4A6C4E9013532FC300FDD53F /* SystemView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6B13532FC300FDD53F /* SystemView.cpp */; };
-		4A6C4E9213532FC300FDD53F /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D6E13532FC300FDD53F /* utils.cpp */; };
-		4A6C4E9313532FC300FDD53F /* WorldView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C4D7213532FC300FDD53F /* WorldView.cpp */; };
 		4A6C4EA2135452FF00FDD53F /* libsigc-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */; };
 		4A6C55151354655000FDD53F /* data in Copy Data files and folders */ = {isa = PBXBuildFile; fileRef = 4A6C55141354655000FDD53F /* data */; };
-		4A712413170EC89000BB9BCC /* Orbit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A712411170EC89000BB9BCC /* Orbit.cpp */; };
-		4A76111D1611A76C00A06F79 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A76111C1611A76C00A06F79 /* OpenGL.framework */; };
-		4A7611201611A7B000A06F79 /* libpng15.15.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A76111F1611A7B000A06F79 /* libpng15.15.dylib */; };
-		4A7611221611A80C00A06F79 /* libz.1.2.7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A7611211611A80C00A06F79 /* libz.1.2.7.dylib */; };
-		4A7611231611A88C00A06F79 /* libz.1.2.7.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A7611211611A80C00A06F79 /* libz.1.2.7.dylib */; };
-		4A7611261611A8C800A06F79 /* libGLEW.1.9.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A7611251611A8C800A06F79 /* libGLEW.1.9.0.dylib */; };
-		4A7611271611A8DB00A06F79 /* libGLEW.1.9.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4A7611251611A8C800A06F79 /* libGLEW.1.9.0.dylib */; };
 		4A76112A1611A92400A06F79 /* libFLAC.8.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A7611281611A90B00A06F79 /* libFLAC.8.dylib */; };
-		4A82AA861386969B0028CCED /* GameConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A82AA7D1386969B0028CCED /* GameConfig.cpp */; };
-		4A84CB7D14595D850051C848 /* enum_table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A84CB7B14595D850051C848 /* enum_table.cpp */; };
-		4A84CB84146027DC0051C848 /* Camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A84CB82146027DC0051C848 /* Camera.cpp */; };
 		4A8563FD148655DA008121E1 /* pioneer-logo.icns in Resources */ = {isa = PBXBuildFile; fileRef = 4A8563FC148655DA008121E1 /* pioneer-logo.icns */; };
-		4A85A86A13C4631D00C2B986 /* LuaMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A85A86313C4631D00C2B986 /* LuaMusic.cpp */; };
-		4A85A86B13C4631D00C2B986 /* LuaSystemPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A85A86513C4631D00C2B986 /* LuaSystemPath.cpp */; };
-		4A85A86C13C4631D00C2B986 /* SoundMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A85A86713C4631D00C2B986 /* SoundMusic.cpp */; };
-		4A8AE19617208CE50005C2D9 /* LuaPropertiedObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AE19217208CE40005C2D9 /* LuaPropertiedObject.cpp */; };
-		4A8AE19717208CE50005C2D9 /* PropertyMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A8AE19417208CE40005C2D9 /* PropertyMap.cpp */; };
-		4A8DD53B142E19B6006DD821 /* LuaConsole.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A8DD539142E19B6006DD821 /* LuaConsole.cpp */; };
-		4A9174F415187B69006A15A9 /* GuiTexturedQuad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9174F215187B69006A15A9 /* GuiTexturedQuad.cpp */; };
-		4A9174FB15187B97006A15A9 /* TextureBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9174F715187B97006A15A9 /* TextureBuilder.cpp */; };
-		4A9174FC15187B97006A15A9 /* TextureGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9174F915187B97006A15A9 /* TextureGL.cpp */; };
-		4A9174FE15187C17006A15A9 /* Color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9174FD15187C17006A15A9 /* Color.cpp */; };
-		4A94CA4514F26875002CA792 /* FontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A94CA4114F26875002CA792 /* FontCache.cpp */; };
-		4A973BF71618688F0029562D /* DeathView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A973BF31618688F0029562D /* DeathView.cpp */; };
-		4A973BF81618688F0029562D /* LuaDev.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A973BF51618688F0029562D /* LuaDev.cpp */; };
-		4A9937511368355500EA0EE5 /* LuaBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99371B1368355400EA0EE5 /* LuaBody.cpp */; };
-		4A9937521368355500EA0EE5 /* LuaCargoBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99371D1368355400EA0EE5 /* LuaCargoBody.cpp */; };
-		4A9937531368355500EA0EE5 /* LuaConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99371F1368355500EA0EE5 /* LuaConstants.cpp */; };
-		4A9937541368355500EA0EE5 /* LuaEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937211368355500EA0EE5 /* LuaEngine.cpp */; };
-		4A9937571368355500EA0EE5 /* LuaFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937271368355500EA0EE5 /* LuaFormat.cpp */; };
-		4A9937581368355500EA0EE5 /* LuaGame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937291368355500EA0EE5 /* LuaGame.cpp */; };
-		4A9937591368355500EA0EE5 /* LuaManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99372B1368355500EA0EE5 /* LuaManager.cpp */; };
-		4A99375A1368355500EA0EE5 /* LuaNameGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99372D1368355500EA0EE5 /* LuaNameGen.cpp */; };
-		4A99375B1368355500EA0EE5 /* LuaObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99372F1368355500EA0EE5 /* LuaObject.cpp */; };
-		4A99375C1368355500EA0EE5 /* LuaPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937301368355500EA0EE5 /* LuaPlanet.cpp */; };
-		4A99375D1368355500EA0EE5 /* LuaPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937321368355500EA0EE5 /* LuaPlayer.cpp */; };
-		4A99375E1368355500EA0EE5 /* LuaRand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937341368355500EA0EE5 /* LuaRand.cpp */; };
-		4A9937611368355500EA0EE5 /* LuaSerializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99373A1368355500EA0EE5 /* LuaSerializer.cpp */; };
-		4A9937621368355500EA0EE5 /* LuaShip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99373C1368355500EA0EE5 /* LuaShip.cpp */; };
-		4A9937641368355500EA0EE5 /* LuaSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937401368355500EA0EE5 /* LuaSpace.cpp */; };
-		4A9937651368355500EA0EE5 /* LuaSpaceStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937421368355500EA0EE5 /* LuaSpaceStation.cpp */; };
-		4A9937661368355500EA0EE5 /* LuaStar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937441368355500EA0EE5 /* LuaStar.cpp */; };
-		4A9937671368355500EA0EE5 /* LuaStarSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937461368355500EA0EE5 /* LuaStarSystem.cpp */; };
-		4A9937681368355500EA0EE5 /* LuaTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A9937481368355500EA0EE5 /* LuaTimer.cpp */; };
-		4A99376A1368355500EA0EE5 /* LuaUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A99374C1368355500EA0EE5 /* LuaUtils.cpp */; };
-		4AA4A8DA164D0EB10006C3BF /* Expand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4A8D4164D0EB10006C3BF /* Expand.cpp */; };
-		4AA4A8DB164D0EB10006C3BF /* Gradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4A8D6164D0EB10006C3BF /* Gradient.cpp */; };
-		4AA4A8DC164D0EB10006C3BF /* LuaExpand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4A8D8164D0EB10006C3BF /* LuaExpand.cpp */; };
-		4AA4A8DD164D0EB10006C3BF /* LuaGradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4A8D9164D0EB10006C3BF /* LuaGradient.cpp */; };
-		4AA527FA16E9EABA0036D4CB /* NavLights.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA527F816E9EABA0036D4CB /* NavLights.cpp */; };
-		4AA527FE16E9EB650036D4CB /* LuaModelSpinner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA527FB16E9EB650036D4CB /* LuaModelSpinner.cpp */; };
-		4AA527FF16E9EB650036D4CB /* ModelSpinner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA527FC16E9EB650036D4CB /* ModelSpinner.cpp */; };
-		4AA5280516E9EB980036D4CB /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5280016E9EB980036D4CB /* Lua.cpp */; };
-		4AA5280616E9EB980036D4CB /* ModelSkin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5280216E9EB980036D4CB /* ModelSkin.cpp */; };
-		4AA5280816E9EBD60036D4CB /* LuaModelSkin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5280716E9EBD60036D4CB /* LuaModelSkin.cpp */; };
-		4AA84A2716D0E18700220311 /* LuaEquipDef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA84A2116D0E18700220311 /* LuaEquipDef.cpp */; };
-		4AA84A2816D0E18700220311 /* LuaShipDef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA84A2316D0E18700220311 /* LuaShipDef.cpp */; };
-		4AA9F6CC17288E0900124C2E /* TerrainHeightEllipsoid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AA9F6CB17288E0900124C2E /* TerrainHeightEllipsoid.cpp */; };
-		4AAB881315F4AD3500AAF8A8 /* GeoSphereMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB880415F4AD3500AAF8A8 /* GeoSphereMaterial.cpp */; };
-		4AAB881415F4AD3500AAF8A8 /* GL2Material.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB880615F4AD3500AAF8A8 /* GL2Material.cpp */; };
-		4AAB881515F4AD3500AAF8A8 /* MultiMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB880815F4AD3500AAF8A8 /* MultiMaterial.cpp */; };
-		4AAB881615F4AD3500AAF8A8 /* Program.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB880A15F4AD3500AAF8A8 /* Program.cpp */; };
-		4AAB881715F4AD3500AAF8A8 /* RingMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB880C15F4AD3500AAF8A8 /* RingMaterial.cpp */; };
-		4AAB881815F4AD3500AAF8A8 /* Uniform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB880F15F4AD3500AAF8A8 /* Uniform.cpp */; };
-		4AAB881915F4AD3500AAF8A8 /* MaterialLegacy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB881115F4AD3500AAF8A8 /* MaterialLegacy.cpp */; };
-		4AAB881D15F4AD7700AAF8A8 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB881A15F4AD7700AAF8A8 /* Lua.cpp */; };
-		4AAB884815FDEA6F00AAF8A8 /* LuaRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAB884515FDEA6E00AAF8A8 /* LuaRef.cpp */; };
-		4AAC9FE215458FE400116131 /* miniz.c in Sources */ = {isa = PBXBuildFile; fileRef = 4AAC9FDE15458FE400116131 /* miniz.c */; settings = {COMPILER_FLAGS = "-Wno-unused"; }; };
-		4AAC9FE91545901D00116131 /* FileSourceZip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAC9FE51545901D00116131 /* FileSourceZip.cpp */; };
-		4AAC9FEA1545901D00116131 /* ModManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AAC9FE71545901D00116131 /* ModManager.cpp */; };
-		4AB3DF8914346952001B783A /* TerrainBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB3DF8714346952001B783A /* TerrainBody.cpp */; };
-		4AB7D6031472A83E00158DE4 /* Terrain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D11472A83E00158DE4 /* Terrain.cpp */; };
-		4AB7D6041472A83E00158DE4 /* TerrainColorAsteroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D31472A83E00158DE4 /* TerrainColorAsteroid.cpp */; };
-		4AB7D6051472A83E00158DE4 /* TerrainColorBandedRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D41472A83E00158DE4 /* TerrainColorBandedRock.cpp */; };
-		4AB7D6061472A83E00158DE4 /* TerrainColorDeadWithWater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D51472A83E00158DE4 /* TerrainColorDeadWithWater.cpp */; };
-		4AB7D6071472A83E00158DE4 /* TerrainColorDesert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D61472A83E00158DE4 /* TerrainColorDesert.cpp */; };
-		4AB7D6081472A83E00158DE4 /* TerrainColorEarthLike.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D71472A83E00158DE4 /* TerrainColorEarthLike.cpp */; };
-		4AB7D6091472A83E00158DE4 /* TerrainColorGGJupiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D81472A83E00158DE4 /* TerrainColorGGJupiter.cpp */; };
-		4AB7D60A1472A83E00158DE4 /* TerrainColorGGNeptune.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5D91472A83E00158DE4 /* TerrainColorGGNeptune.cpp */; };
-		4AB7D60B1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DA1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp */; };
-		4AB7D60C1472A83E00158DE4 /* TerrainColorGGSaturn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DB1472A83E00158DE4 /* TerrainColorGGSaturn.cpp */; };
-		4AB7D60D1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DC1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp */; };
-		4AB7D60E1472A83E00158DE4 /* TerrainColorGGUranus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DD1472A83E00158DE4 /* TerrainColorGGUranus.cpp */; };
-		4AB7D60F1472A83E00158DE4 /* TerrainColorIce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DE1472A83E00158DE4 /* TerrainColorIce.cpp */; };
-		4AB7D6101472A83E00158DE4 /* TerrainColorMethane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5DF1472A83E00158DE4 /* TerrainColorMethane.cpp */; };
-		4AB7D6111472A83E00158DE4 /* TerrainColorRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E01472A83E00158DE4 /* TerrainColorRock.cpp */; };
-		4AB7D6121472A83E00158DE4 /* TerrainColorRock2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E11472A83E00158DE4 /* TerrainColorRock2.cpp */; };
-		4AB7D6131472A83E00158DE4 /* TerrainColorSolid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E21472A83E00158DE4 /* TerrainColorSolid.cpp */; };
-		4AB7D6141472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E31472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp */; };
-		4AB7D6151472A83E00158DE4 /* TerrainColorStarG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E41472A83E00158DE4 /* TerrainColorStarG.cpp */; };
-		4AB7D6161472A83E00158DE4 /* TerrainColorStarK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E51472A83E00158DE4 /* TerrainColorStarK.cpp */; };
-		4AB7D6171472A83E00158DE4 /* TerrainColorStarM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E61472A83E00158DE4 /* TerrainColorStarM.cpp */; };
-		4AB7D6181472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E71472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp */; };
-		4AB7D6191472A83E00158DE4 /* TerrainColorTFGood.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E81472A83E00158DE4 /* TerrainColorTFGood.cpp */; };
-		4AB7D61A1472A83E00158DE4 /* TerrainColorTFPoor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5E91472A83E00158DE4 /* TerrainColorTFPoor.cpp */; };
-		4AB7D61B1472A83E00158DE4 /* TerrainColorVolcanic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5EA1472A83E00158DE4 /* TerrainColorVolcanic.cpp */; };
-		4AB7D61C1472A83E00158DE4 /* TerrainFeature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5EB1472A83E00158DE4 /* TerrainFeature.cpp */; };
-		4AB7D61D1472A83E00158DE4 /* TerrainHeightAsteroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5ED1472A83E00158DE4 /* TerrainHeightAsteroid.cpp */; };
-		4AB7D61E1472A83E00158DE4 /* TerrainHeightFlat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5EE1472A83E00158DE4 /* TerrainHeightFlat.cpp */; };
-		4AB7D61F1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5EF1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp */; };
-		4AB7D6201472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F01472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp */; };
-		4AB7D6211472A83E00158DE4 /* TerrainHeightHillsDunes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F11472A83E00158DE4 /* TerrainHeightHillsDunes.cpp */; };
-		4AB7D6221472A83E00158DE4 /* TerrainHeightHillsNormal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F21472A83E00158DE4 /* TerrainHeightHillsNormal.cpp */; };
-		4AB7D6231472A83E00158DE4 /* TerrainHeightHillsRidged.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F31472A83E00158DE4 /* TerrainHeightHillsRidged.cpp */; };
-		4AB7D6241472A83E00158DE4 /* TerrainHeightHillsRivers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F41472A83E00158DE4 /* TerrainHeightHillsRivers.cpp */; };
-		4AB7D6251472A83E00158DE4 /* TerrainHeightMapped.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F51472A83E00158DE4 /* TerrainHeightMapped.cpp */; };
-		4AB7D6261472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F61472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp */; };
-		4AB7D6271472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F71472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp */; };
-		4AB7D6281472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F81472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp */; };
-		4AB7D6291472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5F91472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp */; };
-		4AB7D62A1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FA1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp */; };
-		4AB7D62B1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FB1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp */; };
-		4AB7D62C1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FC1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp */; };
-		4AB7D62D1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FD1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp */; };
-		4AB7D62E1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FE1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp */; };
-		4AB7D62F1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D5FF1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp */; };
-		4AB7D6301472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7D6001472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp */; };
-		4ABF307916335A1100664653 /* Align.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF302E16335A1100664653 /* Align.cpp */; };
-		4ABF307A16335A1100664653 /* Background.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303016335A1100664653 /* Background.cpp */; };
-		4ABF307B16335A1100664653 /* Box.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303216335A1100664653 /* Box.cpp */; };
-		4ABF307C16335A1100664653 /* Button.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303416335A1100664653 /* Button.cpp */; };
-		4ABF307D16335A1100664653 /* CellSpec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303616335A1100664653 /* CellSpec.cpp */; };
-		4ABF307E16335A1100664653 /* CheckBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303816335A1100664653 /* CheckBox.cpp */; };
-		4ABF307F16335A1100664653 /* ColorBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303A16335A1100664653 /* ColorBackground.cpp */; };
-		4ABF308016335A1100664653 /* Container.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303C16335A1100664653 /* Container.cpp */; };
-		4ABF308116335A1100664653 /* Context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF303E16335A1100664653 /* Context.cpp */; };
-		4ABF308216335A1100664653 /* DropDown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304016335A1100664653 /* DropDown.cpp */; };
-		4ABF308316335A1100664653 /* Event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304216335A1100664653 /* Event.cpp */; };
-		4ABF308416335A1100664653 /* EventDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304416335A1100664653 /* EventDispatcher.cpp */; };
-		4ABF308516335A1100664653 /* FloatContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304616335A1100664653 /* FloatContainer.cpp */; };
-		4ABF308616335A1100664653 /* Grid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304816335A1100664653 /* Grid.cpp */; };
-		4ABF308716335A1100664653 /* Image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304A16335A1100664653 /* Image.cpp */; };
-		4ABF308816335A1100664653 /* Label.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304C16335A1100664653 /* Label.cpp */; };
-		4ABF308916335A1100664653 /* List.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF304E16335A1100664653 /* List.cpp */; };
-		4ABF308A16335A1100664653 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305016335A1100664653 /* Lua.cpp */; };
-		4ABF308B16335A1100664653 /* LuaAlign.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305216335A1100664653 /* LuaAlign.cpp */; };
-		4ABF308C16335A1100664653 /* LuaBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305316335A1100664653 /* LuaBackground.cpp */; };
-		4ABF308D16335A1100664653 /* LuaBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305416335A1100664653 /* LuaBox.cpp */; };
-		4ABF308E16335A1100664653 /* LuaButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305516335A1100664653 /* LuaButton.cpp */; };
-		4ABF308F16335A1100664653 /* LuaCheckBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305616335A1100664653 /* LuaCheckBox.cpp */; };
-		4ABF309016335A1100664653 /* LuaColorBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305716335A1100664653 /* LuaColorBackground.cpp */; };
-		4ABF309116335A1100664653 /* LuaContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305816335A1100664653 /* LuaContainer.cpp */; };
-		4ABF309216335A1100664653 /* LuaContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305916335A1100664653 /* LuaContext.cpp */; };
-		4ABF309316335A1100664653 /* LuaDropDown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305A16335A1100664653 /* LuaDropDown.cpp */; };
-		4ABF309416335A1100664653 /* LuaGrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305B16335A1100664653 /* LuaGrid.cpp */; };
-		4ABF309516335A1100664653 /* LuaImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305C16335A1100664653 /* LuaImage.cpp */; };
-		4ABF309616335A1100664653 /* LuaLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305D16335A1100664653 /* LuaLabel.cpp */; };
-		4ABF309716335A1100664653 /* LuaList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305E16335A1100664653 /* LuaList.cpp */; };
-		4ABF309816335A1100664653 /* LuaMargin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF305F16335A1100664653 /* LuaMargin.cpp */; };
-		4ABF309916335A1100664653 /* LuaMultiLineText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306016335A1100664653 /* LuaMultiLineText.cpp */; };
-		4ABF309A16335A1100664653 /* LuaScroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306116335A1100664653 /* LuaScroller.cpp */; };
-		4ABF309B16335A1100664653 /* LuaSingle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306316335A1100664653 /* LuaSingle.cpp */; };
-		4ABF309C16335A1100664653 /* LuaSlider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306416335A1100664653 /* LuaSlider.cpp */; };
-		4ABF309D16335A1100664653 /* LuaWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306516335A1100664653 /* LuaWidget.cpp */; };
-		4ABF309F16335A1100664653 /* Margin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306716335A1100664653 /* Margin.cpp */; };
-		4ABF30A016335A1100664653 /* MultiLineText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306916335A1100664653 /* MultiLineText.cpp */; };
-		4ABF30A116335A1100664653 /* Scroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306C16335A1100664653 /* Scroller.cpp */; };
-		4ABF30A216335A1100664653 /* Single.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF306E16335A1100664653 /* Single.cpp */; };
-		4ABF30A316335A1100664653 /* Skin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF307016335A1100664653 /* Skin.cpp */; };
-		4ABF30A416335A1100664653 /* Slider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF307216335A1100664653 /* Slider.cpp */; };
-		4ABF30A516335A1100664653 /* TextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF307416335A1100664653 /* TextLayout.cpp */; };
-		4ABF30A616335A1100664653 /* Widget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ABF307616335A1100664653 /* Widget.cpp */; };
-		4ACC6D1C15401E7000C59914 /* Font.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACC6D1215401E7000C59914 /* Font.cpp */; };
-		4ACC6D1E15401E7000C59914 /* TextSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACC6D1615401E7000C59914 /* TextSupport.cpp */; };
-		4ACC6D1F15401E7000C59914 /* TextureFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACC6D1815401E7000C59914 /* TextureFont.cpp */; };
-		4ACDB6B1167878620069FA03 /* Animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB684167878610069FA03 /* Animation.cpp */; };
-		4ACDB6B2167878620069FA03 /* Billboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB688167878620069FA03 /* Billboard.cpp */; };
-		4ACDB6B3167878620069FA03 /* CollisionGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB68A167878620069FA03 /* CollisionGeometry.cpp */; };
-		4ACDB6B4167878620069FA03 /* CollisionVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB68C167878620069FA03 /* CollisionVisitor.cpp */; };
-		4ACDB6B5167878620069FA03 /* ColorMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB68E167878620069FA03 /* ColorMap.cpp */; };
-		4ACDB6B6167878620069FA03 /* DumpVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB690167878620069FA03 /* DumpVisitor.cpp */; };
-		4ACDB6B7167878620069FA03 /* FindNodeVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB692167878620069FA03 /* FindNodeVisitor.cpp */; };
-		4ACDB6B8167878620069FA03 /* Group.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB694167878620069FA03 /* Group.cpp */; };
-		4ACDB6B9167878620069FA03 /* Label3D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB696167878620069FA03 /* Label3D.cpp */; };
-		4ACDB6BA167878620069FA03 /* Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB698167878620069FA03 /* Loader.cpp */; };
-		4ACDB6BB167878620069FA03 /* LOD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB69B167878620069FA03 /* LOD.cpp */; };
-		4ACDB6BD167878620069FA03 /* MatrixTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB69E167878620069FA03 /* MatrixTransform.cpp */; };
-		4ACDB6BE167878620069FA03 /* Model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A0167878620069FA03 /* Model.cpp */; };
-		4ACDB6BF167878620069FA03 /* ModelNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A2167878620069FA03 /* ModelNode.cpp */; };
-		4ACDB6C0167878620069FA03 /* Node.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A4167878620069FA03 /* Node.cpp */; };
-		4ACDB6C1167878620069FA03 /* NodeVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A6167878620069FA03 /* NodeVisitor.cpp */; };
-		4ACDB6C2167878620069FA03 /* Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6A8167878620069FA03 /* Parser.cpp */; };
-		4ACDB6C3167878620069FA03 /* Pattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6AA167878620069FA03 /* Pattern.cpp */; };
-		4ACDB6C4167878620069FA03 /* StaticGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6AD167878620069FA03 /* StaticGeometry.cpp */; };
-		4ACDB6C5167878620069FA03 /* Thruster.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6AF167878620069FA03 /* Thruster.cpp */; };
-		4ACDB6CE167878CE0069FA03 /* ModelCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6CA167878CE0069FA03 /* ModelCache.cpp */; };
-		4ACDB6CF167878CE0069FA03 /* ModelViewer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6CC167878CE0069FA03 /* ModelViewer.cpp */; };
-		4ACDB6D2167879AF0069FA03 /* DistanceFieldFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACDB6D0167879AF0069FA03 /* DistanceFieldFont.cpp */; };
 		4ACDB6D416787A6A0069FA03 /* libassimp.3.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */; };
 		4ACDB6D5167881AF0069FA03 /* libassimp.3.0.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */; };
-		4ACE132F16B4B19D00CAE524 /* EnumStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACE132C16B4B19D00CAE524 /* EnumStrings.cpp */; };
-		4ACED56A16BBCC7200E53808 /* LuaMissile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ACED56816BBCC7200E53808 /* LuaMissile.cpp */; };
-		4ADB0D0C15C50DD900AE2123 /* TerrainHeightAsteroid2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0615C50DD900AE2123 /* TerrainHeightAsteroid2.cpp */; };
-		4ADB0D0D15C50DD900AE2123 /* TerrainHeightAsteroid3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0715C50DD900AE2123 /* TerrainHeightAsteroid3.cpp */; };
-		4ADB0D0E15C50DD900AE2123 /* TerrainHeightAsteroid4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0815C50DD900AE2123 /* TerrainHeightAsteroid4.cpp */; };
-		4ADB0D0F15C50DD900AE2123 /* TerrainHeightBarrenRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0915C50DD900AE2123 /* TerrainHeightBarrenRock.cpp */; };
-		4ADB0D1015C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0A15C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp */; };
-		4ADB0D1115C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D0B15C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp */; };
-		4ADB0D1615C50DF000AE2123 /* FileSystemPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D1315C50DF000AE2123 /* FileSystemPosix.cpp */; };
-		4ADB0D1815C50DF000AE2123 /* OSPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB0D1515C50DF000AE2123 /* OSPosix.cpp */; };
-		4ADC7B82152C703200E359B5 /* SDLWrappers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADC7B7F152C703200E359B5 /* SDLWrappers.cpp */; };
-		4ADC7B83152C703200E359B5 /* View.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADC7B81152C703200E359B5 /* View.cpp */; };
-		4ADF518A1557473400ACF5A0 /* CustomSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51801557473400ACF5A0 /* CustomSystem.cpp */; };
-		4ADF518B1557473400ACF5A0 /* Galaxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51821557473400ACF5A0 /* Galaxy.cpp */; };
-		4ADF518D1557473400ACF5A0 /* Sector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51851557473400ACF5A0 /* Sector.cpp */; };
-		4ADF518E1557473400ACF5A0 /* StarSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51871557473400ACF5A0 /* StarSystem.cpp */; };
-		4ADF51971557477400ACF5A0 /* LuaFixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF518F1557477400ACF5A0 /* LuaFixed.cpp */; };
-		4ADF51981557477400ACF5A0 /* LuaMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51911557477400ACF5A0 /* LuaMatrix.cpp */; };
-		4ADF51991557477400ACF5A0 /* LuaSystemBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51931557477400ACF5A0 /* LuaSystemBody.cpp */; };
-		4ADF519A1557477400ACF5A0 /* LuaVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4ADF51951557477400ACF5A0 /* LuaVector.cpp */; };
-		4AE5CA3B1383E2D000B55DEB /* libSDL-1.2.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AE5CA3A1383E2D000B55DEB /* libSDL-1.2.0.dylib */; };
-		4AE5CA3C1383E2EC00B55DEB /* libSDL-1.2.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4AE5CA3A1383E2D000B55DEB /* libSDL-1.2.0.dylib */; };
-		4AE5CA3E1383E63C00B55DEB /* libSDL_image-1.2.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AE5CA3D1383E63C00B55DEB /* libSDL_image-1.2.0.dylib */; };
-		4AE5CA401383E65B00B55DEB /* libSDL_sound-1.0.1.0.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AE5CA3F1383E65B00B55DEB /* libSDL_sound-1.0.1.0.2.dylib */; };
-		4AE5CA411383E6AA00B55DEB /* libSDL_image-1.2.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4AE5CA3D1383E63C00B55DEB /* libSDL_image-1.2.0.dylib */; };
-		4AE5CA421383E6AA00B55DEB /* libSDL_sound-1.0.1.0.2.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4AE5CA3F1383E65B00B55DEB /* libSDL_sound-1.0.1.0.2.dylib */; };
 		4AE5CA441383E6AA00B55DEB /* libsigc-2.0.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */; };
-		4AE9706714369D7500424F91 /* LuaLang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AE9706514369D7500424F91 /* LuaLang.cpp */; };
-		4AEC8A1A15C7886A00B281C3 /* Light.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AEC8A1815C7886A00B281C3 /* Light.cpp */; };
-		4AED721D14E1501D004D171E /* TerrainHeightMapped2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AED721C14E1501D004D171E /* TerrainHeightMapped2.cpp */; };
-		4AEE56DD16A44CD800AA1C53 /* SpaceStationType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AEE56DB16A44CD800AA1C53 /* SpaceStationType.cpp */; };
-		4AEEBC48162A499400C6EA6F /* libpng15.15.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4A76111F1611A7B000A06F79 /* libpng15.15.dylib */; };
 		4AEEBC4A162A4A5700C6EA6F /* libXrandr.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC49162A4A5700C6EA6F /* libXrandr.2.dylib */; };
 		4AEEBC4C162A4ADC00C6EA6F /* libXext.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC4B162A4ADC00C6EA6F /* libXext.6.dylib */; };
 		4AEEBC4D162A4B2000C6EA6F /* libXext.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC4B162A4ADC00C6EA6F /* libXext.6.dylib */; };
@@ -427,18 +57,419 @@
 		4AEEBC5D162A4CA600C6EA6F /* libxcb.1.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC5B162A4C7800C6EA6F /* libxcb.1.dylib */; };
 		4AEEBC5F162A4F5B00C6EA6F /* libbz2.1.0.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AEEBC5E162A4F5B00C6EA6F /* libbz2.1.0.6.dylib */; };
 		4AEEBC60162A4FA300C6EA6F /* libbz2.1.0.6.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 4AEEBC5E162A4F5B00C6EA6F /* libbz2.1.0.6.dylib */; };
-		4AF0058B15F0F30400CC19C0 /* LuaEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF0058915F0F30400CC19C0 /* LuaEvent.cpp */; };
-		4AF0059315F17C6700CC19C0 /* LuaFileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF0059115F17C6700CC19C0 /* LuaFileSystem.cpp */; };
-		4AF222E7162103EA00BED38E /* Factions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF222E0162103EA00BED38E /* Factions.cpp */; };
-		4AF222E8162103EA00BED38E /* Intro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF222E2162103EA00BED38E /* Intro.cpp */; };
-		4AF222E9162103EA00BED38E /* Tombstone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF222E5162103EA00BED38E /* Tombstone.cpp */; };
-		4AF999A31496D51F009821AF /* FileSelectorWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF9999B1496D51F009821AF /* FileSelectorWidget.cpp */; };
-		4AF999A41496D51F009821AF /* Game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF9999D1496D51F009821AF /* Game.cpp */; };
-		4AF999A61496D51F009821AF /* MathUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AF999A11496D51F009821AF /* MathUtil.cpp */; };
-		4AFBD7B91641265D002928CB /* PngWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7B71641265D002928CB /* PngWriter.cpp */; };
-		4AFBD7BD16412676002928CB /* LuaTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7BA16412676002928CB /* LuaTextEntry.cpp */; };
-		4AFBD7BE16412676002928CB /* TextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7BB16412676002928CB /* TextEntry.cpp */; };
-		4AFBD7C016412688002928CB /* FontDescriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBD7BF16412688002928CB /* FontDescriptor.cpp */; };
+		521ED8F01C00D14E0092B2E9 /* AmbientSounds.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7D51C00D14D0092B2E9 /* AmbientSounds.cpp */; };
+		521ED8F11C00D14E0092B2E9 /* Background.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7D81C00D14D0092B2E9 /* Background.cpp */; };
+		521ED8F21C00D14E0092B2E9 /* BaseSphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7DA1C00D14D0092B2E9 /* BaseSphere.cpp */; };
+		521ED8F31C00D14E0092B2E9 /* Body.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7DC1C00D14D0092B2E9 /* Body.cpp */; };
+		521ED8F41C00D14E0092B2E9 /* Camera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E01C00D14D0092B2E9 /* Camera.cpp */; };
+		521ED8F51C00D14E0092B2E9 /* CameraController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E21C00D14D0092B2E9 /* CameraController.cpp */; };
+		521ED8F61C00D14E0092B2E9 /* CargoBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E41C00D14D0092B2E9 /* CargoBody.cpp */; };
+		521ED8F71C00D14E0092B2E9 /* CityOnPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E61C00D14D0092B2E9 /* CityOnPlanet.cpp */; };
+		521ED8F81C00D14E0092B2E9 /* CollMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7E81C00D14D0092B2E9 /* CollMesh.cpp */; };
+		521ED8F91C00D14E0092B2E9 /* Color.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7EA1C00D14D0092B2E9 /* Color.cpp */; };
+		521ED8FA1C00D14E0092B2E9 /* CRC32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7EC1C00D14D0092B2E9 /* CRC32.cpp */; };
+		521ED8FB1C00D14E0092B2E9 /* DateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7EF1C00D14D0092B2E9 /* DateTime.cpp */; };
+		521ED8FC1C00D14E0092B2E9 /* DeathView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7F11C00D14D0092B2E9 /* DeathView.cpp */; };
+		521ED8FD1C00D14E0092B2E9 /* DynamicBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7F41C00D14D0092B2E9 /* DynamicBody.cpp */; };
+		521ED8FE1C00D14E0092B2E9 /* enum_table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7F71C00D14D0092B2E9 /* enum_table.cpp */; };
+		521ED8FF1C00D14E0092B2E9 /* EnumStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7F91C00D14D0092B2E9 /* EnumStrings.cpp */; };
+		521ED9001C00D14E0092B2E9 /* FaceParts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7FB1C00D14D0092B2E9 /* FaceParts.cpp */; };
+		521ED9011C00D14E0092B2E9 /* Factions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7FD1C00D14D0092B2E9 /* Factions.cpp */; };
+		521ED9021C00D14E0092B2E9 /* FileSourceZip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED7FF1C00D14D0092B2E9 /* FileSourceZip.cpp */; };
+		521ED9031C00D14E0092B2E9 /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8011C00D14D0092B2E9 /* FileSystem.cpp */; };
+		521ED9041C00D14E0092B2E9 /* FontCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8051C00D14D0092B2E9 /* FontCache.cpp */; };
+		521ED9051C00D14E0092B2E9 /* Frame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8071C00D14D0092B2E9 /* Frame.cpp */; };
+		521ED9061C00D14E0092B2E9 /* GalacticView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8091C00D14D0092B2E9 /* GalacticView.cpp */; };
+		521ED9071C00D14E0092B2E9 /* Game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED80B1C00D14D0092B2E9 /* Game.cpp */; };
+		521ED9081C00D14E0092B2E9 /* GameConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED80D1C00D14D0092B2E9 /* GameConfig.cpp */; };
+		521ED9091C00D14E0092B2E9 /* GameLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8101C00D14D0092B2E9 /* GameLog.cpp */; };
+		521ED90A1C00D14E0092B2E9 /* GasGiant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8121C00D14D0092B2E9 /* GasGiant.cpp */; };
+		521ED90B1C00D14E0092B2E9 /* GeoPatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8141C00D14D0092B2E9 /* GeoPatch.cpp */; };
+		521ED90C1C00D14E0092B2E9 /* GeoPatchContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8161C00D14D0092B2E9 /* GeoPatchContext.cpp */; };
+		521ED90D1C00D14E0092B2E9 /* GeoPatchID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8181C00D14D0092B2E9 /* GeoPatchID.cpp */; };
+		521ED90E1C00D14E0092B2E9 /* GeoPatchJobs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED81A1C00D14D0092B2E9 /* GeoPatchJobs.cpp */; };
+		521ED90F1C00D14E0092B2E9 /* GeoSphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED81C1C00D14D0092B2E9 /* GeoSphere.cpp */; };
+		521ED9101C00D14E0092B2E9 /* HudTrail.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED81E1C00D14D0092B2E9 /* HudTrail.cpp */; };
+		521ED9111C00D14E0092B2E9 /* HyperspaceCloud.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8201C00D14D0092B2E9 /* HyperspaceCloud.cpp */; };
+		521ED9121C00D14E0092B2E9 /* IniConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8221C00D14D0092B2E9 /* IniConfig.cpp */; };
+		521ED9131C00D14E0092B2E9 /* Intro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8241C00D14D0092B2E9 /* Intro.cpp */; };
+		521ED9141C00D14E0092B2E9 /* JobQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8271C00D14D0092B2E9 /* JobQueue.cpp */; };
+		521ED9151C00D14E0092B2E9 /* KeyBindings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8291C00D14D0092B2E9 /* KeyBindings.cpp */; };
+		521ED9161C00D14E0092B2E9 /* Lang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED82C1C00D14D0092B2E9 /* Lang.cpp */; };
+		521ED9171C00D14E0092B2E9 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8301C00D14D0092B2E9 /* Lua.cpp */; };
+		521ED9181C00D14E0092B2E9 /* LuaBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8321C00D14D0092B2E9 /* LuaBody.cpp */; };
+		521ED9191C00D14E0092B2E9 /* LuaCargoBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8331C00D14D0092B2E9 /* LuaCargoBody.cpp */; };
+		521ED91A1C00D14E0092B2E9 /* LuaComms.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8341C00D14D0092B2E9 /* LuaComms.cpp */; };
+		521ED91B1C00D14E0092B2E9 /* LuaConsole.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8361C00D14D0092B2E9 /* LuaConsole.cpp */; };
+		521ED91C1C00D14E0092B2E9 /* LuaConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8381C00D14D0092B2E9 /* LuaConstants.cpp */; };
+		521ED91D1C00D14E0092B2E9 /* LuaDev.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED83A1C00D14D0092B2E9 /* LuaDev.cpp */; };
+		521ED91E1C00D14E0092B2E9 /* LuaEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED83C1C00D14D0092B2E9 /* LuaEngine.cpp */; };
+		521ED91F1C00D14E0092B2E9 /* LuaEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED83E1C00D14D0092B2E9 /* LuaEvent.cpp */; };
+		521ED9201C00D14E0092B2E9 /* LuaFaction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8401C00D14D0092B2E9 /* LuaFaction.cpp */; };
+		521ED9211C00D14E0092B2E9 /* LuaFileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8411C00D14D0092B2E9 /* LuaFileSystem.cpp */; };
+		521ED9221C00D14E0092B2E9 /* LuaFixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8431C00D14D0092B2E9 /* LuaFixed.cpp */; };
+		521ED9231C00D14E0092B2E9 /* LuaFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8451C00D14D0092B2E9 /* LuaFormat.cpp */; };
+		521ED9241C00D14E0092B2E9 /* LuaGame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8471C00D14D0092B2E9 /* LuaGame.cpp */; };
+		521ED9251C00D14E0092B2E9 /* LuaLang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8491C00D14D0092B2E9 /* LuaLang.cpp */; };
+		521ED9261C00D14E0092B2E9 /* LuaManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED84B1C00D14D0092B2E9 /* LuaManager.cpp */; };
+		521ED9271C00D14E0092B2E9 /* LuaMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED84D1C00D14D0092B2E9 /* LuaMatrix.cpp */; };
+		521ED9281C00D14E0092B2E9 /* LuaMissile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED84F1C00D14D0092B2E9 /* LuaMissile.cpp */; };
+		521ED9291C00D14E0092B2E9 /* LuaModelBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8511C00D14D0092B2E9 /* LuaModelBody.cpp */; };
+		521ED92A1C00D14E0092B2E9 /* LuaMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8521C00D14E0092B2E9 /* LuaMusic.cpp */; };
+		521ED92B1C00D14E0092B2E9 /* LuaNameGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8541C00D14E0092B2E9 /* LuaNameGen.cpp */; };
+		521ED92C1C00D14E0092B2E9 /* LuaObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8561C00D14E0092B2E9 /* LuaObject.cpp */; };
+		521ED92D1C00D14E0092B2E9 /* LuaPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8581C00D14E0092B2E9 /* LuaPlanet.cpp */; };
+		521ED92E1C00D14E0092B2E9 /* LuaPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8591C00D14E0092B2E9 /* LuaPlayer.cpp */; };
+		521ED92F1C00D14E0092B2E9 /* LuaPropertiedObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED85A1C00D14E0092B2E9 /* LuaPropertiedObject.cpp */; };
+		521ED9301C00D14E0092B2E9 /* LuaRand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED85C1C00D14E0092B2E9 /* LuaRand.cpp */; };
+		521ED9311C00D14E0092B2E9 /* LuaRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED85D1C00D14E0092B2E9 /* LuaRef.cpp */; };
+		521ED9321C00D14E0092B2E9 /* LuaSerializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED85F1C00D14E0092B2E9 /* LuaSerializer.cpp */; };
+		521ED9331C00D14E0092B2E9 /* LuaServerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8611C00D14E0092B2E9 /* LuaServerAgent.cpp */; };
+		521ED9341C00D14E0092B2E9 /* LuaShip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8631C00D14E0092B2E9 /* LuaShip.cpp */; };
+		521ED9351C00D14E0092B2E9 /* LuaShipDef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8641C00D14E0092B2E9 /* LuaShipDef.cpp */; };
+		521ED9361C00D14E0092B2E9 /* LuaSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8661C00D14E0092B2E9 /* LuaSpace.cpp */; };
+		521ED9371C00D14E0092B2E9 /* LuaSpaceStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8681C00D14E0092B2E9 /* LuaSpaceStation.cpp */; };
+		521ED9381C00D14E0092B2E9 /* LuaStar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8691C00D14E0092B2E9 /* LuaStar.cpp */; };
+		521ED9391C00D14E0092B2E9 /* LuaStarSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED86A1C00D14E0092B2E9 /* LuaStarSystem.cpp */; };
+		521ED93A1C00D14E0092B2E9 /* LuaSystemBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED86B1C00D14E0092B2E9 /* LuaSystemBody.cpp */; };
+		521ED93B1C00D14E0092B2E9 /* LuaSystemPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED86C1C00D14E0092B2E9 /* LuaSystemPath.cpp */; };
+		521ED93C1C00D14E0092B2E9 /* LuaTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED86E1C00D14E0092B2E9 /* LuaTimer.cpp */; };
+		521ED93D1C00D14E0092B2E9 /* LuaUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8701C00D14E0092B2E9 /* LuaUtils.cpp */; };
+		521ED93E1C00D14E0092B2E9 /* LuaVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8721C00D14E0092B2E9 /* LuaVector.cpp */; };
+		521ED93F1C00D14E0092B2E9 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8751C00D14E0092B2E9 /* main.cpp */; };
+		521ED9401C00D14E0092B2E9 /* MathUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8761C00D14E0092B2E9 /* MathUtil.cpp */; };
+		521ED9411C00D14E0092B2E9 /* Missile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED87A1C00D14E0092B2E9 /* Missile.cpp */; };
+		521ED9421C00D14E0092B2E9 /* ModelBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED87C1C00D14E0092B2E9 /* ModelBody.cpp */; };
+		521ED9431C00D14E0092B2E9 /* ModelCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED87E1C00D14E0092B2E9 /* ModelCache.cpp */; };
+		521ED9451C00D14E0092B2E9 /* ModelViewer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8811C00D14E0092B2E9 /* ModelViewer.cpp */; };
+		521ED9461C00D14E0092B2E9 /* ModManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8831C00D14E0092B2E9 /* ModManager.cpp */; };
+		521ED9471C00D14E0092B2E9 /* NavLights.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8851C00D14E0092B2E9 /* NavLights.cpp */; };
+		521ED9481C00D14E0092B2E9 /* ObjectViewerView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8881C00D14E0092B2E9 /* ObjectViewerView.cpp */; };
+		521ED9491C00D14E0092B2E9 /* Orbit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED88A1C00D14E0092B2E9 /* Orbit.cpp */; };
+		521ED94A1C00D14E0092B2E9 /* perlin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED88D1C00D14E0092B2E9 /* perlin.cpp */; };
+		521ED94B1C00D14E0092B2E9 /* Pi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8901C00D14E0092B2E9 /* Pi.cpp */; };
+		521ED94C1C00D14E0092B2E9 /* Plane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8921C00D14E0092B2E9 /* Plane.cpp */; };
+		521ED94D1C00D14E0092B2E9 /* Planet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8941C00D14E0092B2E9 /* Planet.cpp */; };
+		521ED94E1C00D14E0092B2E9 /* Player.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8961C00D14E0092B2E9 /* Player.cpp */; };
+		521ED94F1C00D14E0092B2E9 /* PngWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8981C00D14E0092B2E9 /* PngWriter.cpp */; };
+		521ED9501C00D14E0092B2E9 /* Polit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED89A1C00D14E0092B2E9 /* Polit.cpp */; };
+		521ED9511C00D14E0092B2E9 /* Projectile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED89C1C00D14E0092B2E9 /* Projectile.cpp */; };
+		521ED9521C00D14E0092B2E9 /* PropertyMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED89F1C00D14E0092B2E9 /* PropertyMap.cpp */; };
+		521ED9531C00D14E0092B2E9 /* SDLWrappers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8A41C00D14E0092B2E9 /* SDLWrappers.cpp */; };
+		521ED9541C00D14E0092B2E9 /* SectorView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8A61C00D14E0092B2E9 /* SectorView.cpp */; };
+		521ED9551C00D14E0092B2E9 /* Sensors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8A81C00D14E0092B2E9 /* Sensors.cpp */; };
+		521ED9561C00D14E0092B2E9 /* Serializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8AA1C00D14E0092B2E9 /* Serializer.cpp */; };
+		521ED9571C00D14E0092B2E9 /* ServerAgent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8AC1C00D14E0092B2E9 /* ServerAgent.cpp */; };
+		521ED9581C00D14E0092B2E9 /* Sfx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8AE1C00D14E0092B2E9 /* Sfx.cpp */; };
+		521ED9591C00D14E0092B2E9 /* Shields.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B01C00D14E0092B2E9 /* Shields.cpp */; };
+		521ED95A1C00D14E0092B2E9 /* Ship-AI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B21C00D14E0092B2E9 /* Ship-AI.cpp */; };
+		521ED95B1C00D14E0092B2E9 /* Ship.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B31C00D14E0092B2E9 /* Ship.cpp */; };
+		521ED95C1C00D14E0092B2E9 /* ShipAICmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B51C00D14E0092B2E9 /* ShipAICmd.cpp */; };
+		521ED95D1C00D14E0092B2E9 /* ShipCockpit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B71C00D14E0092B2E9 /* ShipCockpit.cpp */; };
+		521ED95E1C00D14E0092B2E9 /* ShipController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8B91C00D14E0092B2E9 /* ShipController.cpp */; };
+		521ED95F1C00D14E0092B2E9 /* ShipCpanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8BB1C00D14E0092B2E9 /* ShipCpanel.cpp */; };
+		521ED9601C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8BD1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp */; };
+		521ED9611C00D14E0092B2E9 /* ShipType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8BF1C00D14E0092B2E9 /* ShipType.cpp */; };
+		521ED9621C00D14E0092B2E9 /* Sound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8C21C00D14E0092B2E9 /* Sound.cpp */; };
+		521ED9631C00D14E0092B2E9 /* SoundMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8C41C00D14E0092B2E9 /* SoundMusic.cpp */; };
+		521ED9641C00D14E0092B2E9 /* Space.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8C61C00D14E0092B2E9 /* Space.cpp */; };
+		521ED9651C00D14E0092B2E9 /* SpaceStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8C81C00D14E0092B2E9 /* SpaceStation.cpp */; };
+		521ED9661C00D14E0092B2E9 /* SpaceStationType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8CA1C00D14E0092B2E9 /* SpaceStationType.cpp */; };
+		521ED9671C00D14E0092B2E9 /* SpeedLines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8CC1C00D14E0092B2E9 /* SpeedLines.cpp */; };
+		521ED9681C00D14E0092B2E9 /* Sphere.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8CE1C00D14E0092B2E9 /* Sphere.cpp */; };
+		521ED9691C00D14E0092B2E9 /* Star.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D01C00D14E0092B2E9 /* Star.cpp */; };
+		521ED96A1C00D14E0092B2E9 /* StringF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D21C00D14E0092B2E9 /* StringF.cpp */; };
+		521ED96B1C00D14E0092B2E9 /* SystemInfoView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D51C00D14E0092B2E9 /* SystemInfoView.cpp */; };
+		521ED96C1C00D14E0092B2E9 /* SystemView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D71C00D14E0092B2E9 /* SystemView.cpp */; };
+		521ED96D1C00D14E0092B2E9 /* TerrainBody.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8D91C00D14E0092B2E9 /* TerrainBody.cpp */; };
+		521ED9751C00D14E0092B2E9 /* Tombstone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8E21C00D14E0092B2E9 /* Tombstone.cpp */; };
+		521ED9771C00D14E0092B2E9 /* UIView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8E51C00D14E0092B2E9 /* UIView.cpp */; };
+		521ED9781C00D14E0092B2E9 /* utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8E71C00D14E0092B2E9 /* utils.cpp */; };
+		521ED9791C00D14E0092B2E9 /* View.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8EC1C00D14E0092B2E9 /* View.cpp */; };
+		521ED97A1C00D14E0092B2E9 /* WorldView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED8EE1C00D14E0092B2E9 /* WorldView.cpp */; };
+		521ED9921C00D2ED0092B2E9 /* BVHTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9861C00D2ED0092B2E9 /* BVHTree.cpp */; };
+		521ED9931C00D2ED0092B2E9 /* CollisionSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED98A1C00D2ED0092B2E9 /* CollisionSpace.cpp */; };
+		521ED9941C00D2ED0092B2E9 /* Geom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED98C1C00D2ED0092B2E9 /* Geom.cpp */; };
+		521ED9951C00D2ED0092B2E9 /* GeomTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED98E1C00D2ED0092B2E9 /* GeomTree.cpp */; };
+		521ED9981C00D2FC0092B2E9 /* Makefile.am in Resources */ = {isa = PBXBuildFile; fileRef = 521ED9971C00D2FC0092B2E9 /* Makefile.am */; };
+		521ED9AE1C00D3240092B2E9 /* CustomSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9991C00D3240092B2E9 /* CustomSystem.cpp */; };
+		521ED9AF1C00D3240092B2E9 /* Economy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED99B1C00D3240092B2E9 /* Economy.cpp */; };
+		521ED9B01C00D3240092B2E9 /* Galaxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED99D1C00D3240092B2E9 /* Galaxy.cpp */; };
+		521ED9B11C00D3240092B2E9 /* GalaxyCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED99F1C00D3240092B2E9 /* GalaxyCache.cpp */; };
+		521ED9B21C00D3240092B2E9 /* GalaxyGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A11C00D3240092B2E9 /* GalaxyGenerator.cpp */; };
+		521ED9B31C00D3240092B2E9 /* Sector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A31C00D3240092B2E9 /* Sector.cpp */; };
+		521ED9B41C00D3240092B2E9 /* SectorGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A51C00D3240092B2E9 /* SectorGenerator.cpp */; };
+		521ED9B51C00D3240092B2E9 /* StarSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A71C00D3240092B2E9 /* StarSystem.cpp */; };
+		521ED9B61C00D3240092B2E9 /* StarSystemGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9A91C00D3240092B2E9 /* StarSystemGenerator.cpp */; };
+		521ED9B71C00D3240092B2E9 /* SystemPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9AB1C00D3240092B2E9 /* SystemPath.cpp */; };
+		521ED9C81C00D3310092B2E9 /* BindingCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9B91C00D3310092B2E9 /* BindingCapture.cpp */; };
+		521ED9C91C00D3310092B2E9 /* Face.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9BB1C00D3310092B2E9 /* Face.cpp */; };
+		521ED9CA1C00D3310092B2E9 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9BE1C00D3310092B2E9 /* Lua.cpp */; };
+		521ED9CB1C00D3310092B2E9 /* LuaBindingCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C01C00D3310092B2E9 /* LuaBindingCapture.cpp */; };
+		521ED9CC1C00D3310092B2E9 /* LuaFace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C11C00D3310092B2E9 /* LuaFace.cpp */; };
+		521ED9CD1C00D3310092B2E9 /* LuaModelSpinner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C21C00D3310092B2E9 /* LuaModelSpinner.cpp */; };
+		521ED9CE1C00D3310092B2E9 /* ModelSpinner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C31C00D3310092B2E9 /* ModelSpinner.cpp */; };
+		521ED9CF1C00D3310092B2E9 /* Panel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9C51C00D3310092B2E9 /* Panel.cpp */; };
+		521EDA211C00D3430092B2E9 /* RendererDummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9D41C00D3430092B2E9 /* RendererDummy.cpp */; };
+		521EDA221C00D3430092B2E9 /* FresnelColourMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9DB1C00D3430092B2E9 /* FresnelColourMaterial.cpp */; };
+		521EDA231C00D3430092B2E9 /* GasGiantMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9DD1C00D3430092B2E9 /* GasGiantMaterial.cpp */; };
+		521EDA241C00D3430092B2E9 /* GeoSphereMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9DF1C00D3430092B2E9 /* GeoSphereMaterial.cpp */; };
+		521EDA251C00D3430092B2E9 /* gl_core_3_x.c in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */; };
+		521EDA261C00D3430092B2E9 /* LineMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E41C00D3430092B2E9 /* LineMaterial.cpp */; };
+		521EDA281C00D3430092B2E9 /* MaterialGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */; };
+		521EDA291C00D3430092B2E9 /* MultiMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9E91C00D3430092B2E9 /* MultiMaterial.cpp */; };
+		521EDA2A1C00D3430092B2E9 /* Program.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9EC1C00D3430092B2E9 /* Program.cpp */; };
+		521EDA2B1C00D3430092B2E9 /* RendererGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9EE1C00D3430092B2E9 /* RendererGL.cpp */; };
+		521EDA2C1C00D3430092B2E9 /* RenderStateGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9F01C00D3430092B2E9 /* RenderStateGL.cpp */; };
+		521EDA2D1C00D3430092B2E9 /* RenderTargetGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9F21C00D3430092B2E9 /* RenderTargetGL.cpp */; };
+		521EDA2E1C00D3430092B2E9 /* RingMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9F41C00D3430092B2E9 /* RingMaterial.cpp */; };
+		521EDA2F1C00D3430092B2E9 /* ShieldMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9F61C00D3430092B2E9 /* ShieldMaterial.cpp */; };
+		521EDA301C00D3430092B2E9 /* TextureGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9FB1C00D3430092B2E9 /* TextureGL.cpp */; };
+		521EDA311C00D3430092B2E9 /* UIMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9FD1C00D3430092B2E9 /* UIMaterial.cpp */; };
+		521EDA321C00D3430092B2E9 /* Uniform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521ED9FF1C00D3430092B2E9 /* Uniform.cpp */; };
+		521EDA331C00D3430092B2E9 /* VertexBufferGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA011C00D3430092B2E9 /* VertexBufferGL.cpp */; };
+		521EDA341C00D3430092B2E9 /* VtxColorMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA031C00D3430092B2E9 /* VtxColorMaterial.cpp */; };
+		521EDA351C00D3430092B2E9 /* Drawables.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA051C00D3430092B2E9 /* Drawables.cpp */; };
+		521EDA361C00D3430092B2E9 /* Frustum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA071C00D3430092B2E9 /* Frustum.cpp */; };
+		521EDA371C00D3430092B2E9 /* Graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA091C00D3430092B2E9 /* Graphics.cpp */; };
+		521EDA381C00D3430092B2E9 /* Light.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA0B1C00D3430092B2E9 /* Light.cpp */; };
+		521EDA391C00D3430092B2E9 /* Material.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA0D1C00D3430092B2E9 /* Material.cpp */; };
+		521EDA3A1C00D3430092B2E9 /* Renderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA0F1C00D3430092B2E9 /* Renderer.cpp */; };
+		521EDA3B1C00D3430092B2E9 /* Stats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA131C00D3430092B2E9 /* Stats.cpp */; };
+		521EDA3C1C00D3430092B2E9 /* TextureBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA161C00D3430092B2E9 /* TextureBuilder.cpp */; };
+		521EDA3D1C00D3430092B2E9 /* VertexArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA191C00D3430092B2E9 /* VertexArray.cpp */; };
+		521EDA3E1C00D3430092B2E9 /* VertexBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA1B1C00D3430092B2E9 /* VertexBuffer.cpp */; };
+		521EDA3F1C00D3430092B2E9 /* WindowSDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA1D1C00D3430092B2E9 /* WindowSDL.cpp */; };
+		521EDA771C00D3550092B2E9 /* Gui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA411C00D3550092B2E9 /* Gui.cpp */; };
+		521EDA781C00D3550092B2E9 /* GuiBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA441C00D3550092B2E9 /* GuiBox.cpp */; };
+		521EDA791C00D3550092B2E9 /* GuiButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA461C00D3550092B2E9 /* GuiButton.cpp */; };
+		521EDA7A1C00D3550092B2E9 /* GuiContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA481C00D3550092B2E9 /* GuiContainer.cpp */; };
+		521EDA7B1C00D3550092B2E9 /* GuiFixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA4B1C00D3550092B2E9 /* GuiFixed.cpp */; };
+		521EDA7C1C00D3550092B2E9 /* GuiImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA4D1C00D3550092B2E9 /* GuiImage.cpp */; };
+		521EDA7D1C00D3550092B2E9 /* GuiImageButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA4F1C00D3550092B2E9 /* GuiImageButton.cpp */; };
+		521EDA7E1C00D3550092B2E9 /* GuiImageRadioButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA511C00D3550092B2E9 /* GuiImageRadioButton.cpp */; };
+		521EDA7F1C00D3550092B2E9 /* GuiLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA541C00D3550092B2E9 /* GuiLabel.cpp */; };
+		521EDA801C00D3550092B2E9 /* GuiLabelSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA561C00D3550092B2E9 /* GuiLabelSet.cpp */; };
+		521EDA811C00D3550092B2E9 /* GuiMeterBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA581C00D3550092B2E9 /* GuiMeterBar.cpp */; };
+		521EDA821C00D3550092B2E9 /* GuiMultiStateImageButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA5A1C00D3550092B2E9 /* GuiMultiStateImageButton.cpp */; };
+		521EDA831C00D3550092B2E9 /* GuiRadioButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA5C1C00D3550092B2E9 /* GuiRadioButton.cpp */; };
+		521EDA841C00D3550092B2E9 /* GuiRadioGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA5E1C00D3550092B2E9 /* GuiRadioGroup.cpp */; };
+		521EDA851C00D3550092B2E9 /* GuiScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA601C00D3550092B2E9 /* GuiScreen.cpp */; };
+		521EDA861C00D3550092B2E9 /* GuiStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA621C00D3550092B2E9 /* GuiStack.cpp */; };
+		521EDA871C00D3550092B2E9 /* GuiTabbed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA641C00D3550092B2E9 /* GuiTabbed.cpp */; };
+		521EDA881C00D3550092B2E9 /* GuiTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA661C00D3550092B2E9 /* GuiTextEntry.cpp */; };
+		521EDA891C00D3550092B2E9 /* GuiTextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA681C00D3550092B2E9 /* GuiTextLayout.cpp */; };
+		521EDA8A1C00D3550092B2E9 /* GuiTexturedQuad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA6A1C00D3550092B2E9 /* GuiTexturedQuad.cpp */; };
+		521EDA8B1C00D3550092B2E9 /* GuiToggleButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA6C1C00D3550092B2E9 /* GuiToggleButton.cpp */; };
+		521EDA8C1C00D3550092B2E9 /* GuiToolTip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA6E1C00D3550092B2E9 /* GuiToolTip.cpp */; };
+		521EDA8D1C00D3550092B2E9 /* GuiVScrollBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA701C00D3550092B2E9 /* GuiVScrollBar.cpp */; };
+		521EDA8E1C00D3550092B2E9 /* GuiVScrollPortal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA721C00D3550092B2E9 /* GuiVScrollPortal.cpp */; };
+		521EDA8F1C00D3550092B2E9 /* GuiWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA741C00D3550092B2E9 /* GuiWidget.cpp */; };
+		521EDA941C00D3610092B2E9 /* FileSystemPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA911C00D3610092B2E9 /* FileSystemPosix.cpp */; };
+		521EDA951C00D3610092B2E9 /* OSPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA921C00D3610092B2E9 /* OSPosix.cpp */; };
+		521EDACF1C00D36D0092B2E9 /* Animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA971C00D36D0092B2E9 /* Animation.cpp */; };
+		521EDAD01C00D36D0092B2E9 /* BaseLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA9B1C00D36D0092B2E9 /* BaseLoader.cpp */; };
+		521EDAD11C00D36D0092B2E9 /* Billboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA9D1C00D36D0092B2E9 /* Billboard.cpp */; };
+		521EDAD21C00D36D0092B2E9 /* BinaryConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDA9F1C00D36D0092B2E9 /* BinaryConverter.cpp */; };
+		521EDAD31C00D36D0092B2E9 /* CollisionGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA11C00D36D0092B2E9 /* CollisionGeometry.cpp */; };
+		521EDAD41C00D36D0092B2E9 /* CollisionVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA31C00D36D0092B2E9 /* CollisionVisitor.cpp */; };
+		521EDAD51C00D36D0092B2E9 /* ColorMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA51C00D36D0092B2E9 /* ColorMap.cpp */; };
+		521EDAD61C00D36D0092B2E9 /* DumpVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA71C00D36D0092B2E9 /* DumpVisitor.cpp */; };
+		521EDAD71C00D36D0092B2E9 /* FindNodeVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAA91C00D36D0092B2E9 /* FindNodeVisitor.cpp */; };
+		521EDAD81C00D36D0092B2E9 /* Group.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAAB1C00D36D0092B2E9 /* Group.cpp */; };
+		521EDAD91C00D36D0092B2E9 /* Label3D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAAD1C00D36D0092B2E9 /* Label3D.cpp */; };
+		521EDADA1C00D36D0092B2E9 /* Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAAF1C00D36D0092B2E9 /* Loader.cpp */; };
+		521EDADB1C00D36D0092B2E9 /* LOD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB21C00D36D0092B2E9 /* LOD.cpp */; };
+		521EDADC1C00D36D0092B2E9 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB41C00D36D0092B2E9 /* Lua.cpp */; };
+		521EDADD1C00D36D0092B2E9 /* LuaModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB61C00D36D0092B2E9 /* LuaModel.cpp */; };
+		521EDADE1C00D36D0092B2E9 /* LuaModelSkin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB71C00D36D0092B2E9 /* LuaModelSkin.cpp */; };
+		521EDADF1C00D36D0092B2E9 /* MatrixTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAB81C00D36D0092B2E9 /* MatrixTransform.cpp */; };
+		521EDAE01C00D36D0092B2E9 /* Model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDABA1C00D36D0092B2E9 /* Model.cpp */; };
+		521EDAE11C00D36D0092B2E9 /* ModelNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDABC1C00D36D0092B2E9 /* ModelNode.cpp */; };
+		521EDAE21C00D36D0092B2E9 /* ModelSkin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDABE1C00D36D0092B2E9 /* ModelSkin.cpp */; };
+		521EDAE31C00D36D0092B2E9 /* Node.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAC01C00D36D0092B2E9 /* Node.cpp */; };
+		521EDAE41C00D36D0092B2E9 /* NodeVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAC31C00D36D0092B2E9 /* NodeVisitor.cpp */; };
+		521EDAE51C00D36D0092B2E9 /* Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAC51C00D36D0092B2E9 /* Parser.cpp */; };
+		521EDAE61C00D36D0092B2E9 /* Pattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAC71C00D36D0092B2E9 /* Pattern.cpp */; };
+		521EDAE71C00D36D0092B2E9 /* StaticGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDACA1C00D36D0092B2E9 /* StaticGeometry.cpp */; };
+		521EDAE81C00D36D0092B2E9 /* Thruster.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDACC1C00D36D0092B2E9 /* Thruster.cpp */; };
+		521EDB251C00D37B0092B2E9 /* Terrain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAEA1C00D37B0092B2E9 /* Terrain.cpp */; };
+		521EDB261C00D37B0092B2E9 /* TerrainColorAsteroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAEC1C00D37B0092B2E9 /* TerrainColorAsteroid.cpp */; };
+		521EDB271C00D37B0092B2E9 /* TerrainColorBandedRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAED1C00D37B0092B2E9 /* TerrainColorBandedRock.cpp */; };
+		521EDB281C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAEE1C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp */; };
+		521EDB291C00D37B0092B2E9 /* TerrainColorDesert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAEF1C00D37B0092B2E9 /* TerrainColorDesert.cpp */; };
+		521EDB2A1C00D37B0092B2E9 /* TerrainColorEarthLike.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF01C00D37B0092B2E9 /* TerrainColorEarthLike.cpp */; };
+		521EDB2B1C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF11C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp */; };
+		521EDB2C1C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF21C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp */; };
+		521EDB2D1C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF31C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp */; };
+		521EDB2E1C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF41C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp */; };
+		521EDB2F1C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF51C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp */; };
+		521EDB301C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF61C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp */; };
+		521EDB311C00D37B0092B2E9 /* TerrainColorGGUranus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF71C00D37B0092B2E9 /* TerrainColorGGUranus.cpp */; };
+		521EDB321C00D37B0092B2E9 /* TerrainColorIce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF81C00D37B0092B2E9 /* TerrainColorIce.cpp */; };
+		521EDB331C00D37B0092B2E9 /* TerrainColorMethane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAF91C00D37B0092B2E9 /* TerrainColorMethane.cpp */; };
+		521EDB341C00D37B0092B2E9 /* TerrainColorRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFA1C00D37B0092B2E9 /* TerrainColorRock.cpp */; };
+		521EDB351C00D37B0092B2E9 /* TerrainColorRock2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFB1C00D37B0092B2E9 /* TerrainColorRock2.cpp */; };
+		521EDB361C00D37B0092B2E9 /* TerrainColorSolid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFC1C00D37B0092B2E9 /* TerrainColorSolid.cpp */; };
+		521EDB371C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFD1C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp */; };
+		521EDB381C00D37B0092B2E9 /* TerrainColorStarG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFE1C00D37B0092B2E9 /* TerrainColorStarG.cpp */; };
+		521EDB391C00D37B0092B2E9 /* TerrainColorStarK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDAFF1C00D37B0092B2E9 /* TerrainColorStarK.cpp */; };
+		521EDB3A1C00D37B0092B2E9 /* TerrainColorStarM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB001C00D37B0092B2E9 /* TerrainColorStarM.cpp */; };
+		521EDB3B1C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB011C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp */; };
+		521EDB3C1C00D37B0092B2E9 /* TerrainColorTFGood.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB021C00D37B0092B2E9 /* TerrainColorTFGood.cpp */; };
+		521EDB3D1C00D37B0092B2E9 /* TerrainColorTFPoor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB031C00D37B0092B2E9 /* TerrainColorTFPoor.cpp */; };
+		521EDB3E1C00D37B0092B2E9 /* TerrainColorVolcanic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB041C00D37B0092B2E9 /* TerrainColorVolcanic.cpp */; };
+		521EDB3F1C00D37B0092B2E9 /* TerrainFeature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB051C00D37B0092B2E9 /* TerrainFeature.cpp */; };
+		521EDB401C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB071C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp */; };
+		521EDB411C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB081C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp */; };
+		521EDB421C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB091C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp */; };
+		521EDB431C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0A1C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp */; };
+		521EDB441C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0B1C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp */; };
+		521EDB451C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0C1C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp */; };
+		521EDB461C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0D1C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp */; };
+		521EDB471C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0E1C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp */; };
+		521EDB481C00D37B0092B2E9 /* TerrainHeightFlat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB0F1C00D37B0092B2E9 /* TerrainHeightFlat.cpp */; };
+		521EDB491C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB101C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp */; };
+		521EDB4A1C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB111C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp */; };
+		521EDB4B1C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB121C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp */; };
+		521EDB4C1C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB131C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp */; };
+		521EDB4D1C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB141C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp */; };
+		521EDB4E1C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB151C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp */; };
+		521EDB4F1C00D37B0092B2E9 /* TerrainHeightMapped.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB161C00D37B0092B2E9 /* TerrainHeightMapped.cpp */; };
+		521EDB501C00D37B0092B2E9 /* TerrainHeightMapped2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB171C00D37B0092B2E9 /* TerrainHeightMapped2.cpp */; };
+		521EDB511C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB181C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp */; };
+		521EDB521C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB191C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp */; };
+		521EDB531C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1A1C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp */; };
+		521EDB541C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1B1C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp */; };
+		521EDB551C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1C1C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp */; };
+		521EDB561C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1D1C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp */; };
+		521EDB571C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1E1C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp */; };
+		521EDB581C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB1F1C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp */; };
+		521EDB591C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB201C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp */; };
+		521EDB5A1C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB211C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp */; };
+		521EDB5B1C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB221C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp */; };
+		521EDB661C00D38B0092B2E9 /* DistanceFieldFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB5D1C00D38B0092B2E9 /* DistanceFieldFont.cpp */; };
+		521EDB671C00D38B0092B2E9 /* FontConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB5F1C00D38B0092B2E9 /* FontConfig.cpp */; };
+		521EDB681C00D38B0092B2E9 /* TextSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB611C00D38B0092B2E9 /* TextSupport.cpp */; };
+		521EDB691C00D38B0092B2E9 /* TextureFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB631C00D38B0092B2E9 /* TextureFont.cpp */; };
+		521EDBD31C00D3A20092B2E9 /* Align.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB6B1C00D3A20092B2E9 /* Align.cpp */; };
+		521EDBD41C00D3A20092B2E9 /* Animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB6D1C00D3A20092B2E9 /* Animation.cpp */; };
+		521EDBD51C00D3A20092B2E9 /* Background.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB6F1C00D3A20092B2E9 /* Background.cpp */; };
+		521EDBD61C00D3A20092B2E9 /* Box.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB711C00D3A20092B2E9 /* Box.cpp */; };
+		521EDBD71C00D3A20092B2E9 /* Button.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB731C00D3A20092B2E9 /* Button.cpp */; };
+		521EDBD81C00D3A20092B2E9 /* CellSpec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB751C00D3A20092B2E9 /* CellSpec.cpp */; };
+		521EDBD91C00D3A20092B2E9 /* CheckBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB771C00D3A20092B2E9 /* CheckBox.cpp */; };
+		521EDBDA1C00D3A20092B2E9 /* ColorBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB791C00D3A20092B2E9 /* ColorBackground.cpp */; };
+		521EDBDB1C00D3A20092B2E9 /* Container.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB7B1C00D3A20092B2E9 /* Container.cpp */; };
+		521EDBDC1C00D3A20092B2E9 /* Context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB7D1C00D3A20092B2E9 /* Context.cpp */; };
+		521EDBDD1C00D3A20092B2E9 /* DropDown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB7F1C00D3A20092B2E9 /* DropDown.cpp */; };
+		521EDBDE1C00D3A20092B2E9 /* Event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB811C00D3A20092B2E9 /* Event.cpp */; };
+		521EDBDF1C00D3A20092B2E9 /* EventDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB831C00D3A20092B2E9 /* EventDispatcher.cpp */; };
+		521EDBE01C00D3A20092B2E9 /* Expand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB851C00D3A20092B2E9 /* Expand.cpp */; };
+		521EDBE11C00D3A20092B2E9 /* Gauge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB871C00D3A20092B2E9 /* Gauge.cpp */; };
+		521EDBE21C00D3A20092B2E9 /* Gradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB891C00D3A20092B2E9 /* Gradient.cpp */; };
+		521EDBE31C00D3A20092B2E9 /* Grid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB8B1C00D3A20092B2E9 /* Grid.cpp */; };
+		521EDBE41C00D3A20092B2E9 /* Icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB8D1C00D3A20092B2E9 /* Icon.cpp */; };
+		521EDBE51C00D3A20092B2E9 /* Image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB8F1C00D3A20092B2E9 /* Image.cpp */; };
+		521EDBE61C00D3A20092B2E9 /* Label.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB911C00D3A20092B2E9 /* Label.cpp */; };
+		521EDBE71C00D3A20092B2E9 /* Layer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB931C00D3A20092B2E9 /* Layer.cpp */; };
+		521EDBE81C00D3A20092B2E9 /* List.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB951C00D3A20092B2E9 /* List.cpp */; };
+		521EDBE91C00D3A20092B2E9 /* Lua.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB971C00D3A20092B2E9 /* Lua.cpp */; };
+		521EDBEA1C00D3A20092B2E9 /* LuaAlign.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB991C00D3A20092B2E9 /* LuaAlign.cpp */; };
+		521EDBEB1C00D3A20092B2E9 /* LuaAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9A1C00D3A20092B2E9 /* LuaAnimation.cpp */; };
+		521EDBEC1C00D3A20092B2E9 /* LuaBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9B1C00D3A20092B2E9 /* LuaBackground.cpp */; };
+		521EDBED1C00D3A20092B2E9 /* LuaBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9C1C00D3A20092B2E9 /* LuaBox.cpp */; };
+		521EDBEE1C00D3A20092B2E9 /* LuaButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9D1C00D3A20092B2E9 /* LuaButton.cpp */; };
+		521EDBEF1C00D3A20092B2E9 /* LuaCheckBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9E1C00D3A20092B2E9 /* LuaCheckBox.cpp */; };
+		521EDBF01C00D3A20092B2E9 /* LuaColorBackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDB9F1C00D3A20092B2E9 /* LuaColorBackground.cpp */; };
+		521EDBF11C00D3A20092B2E9 /* LuaContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA01C00D3A20092B2E9 /* LuaContainer.cpp */; };
+		521EDBF21C00D3A20092B2E9 /* LuaContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA11C00D3A20092B2E9 /* LuaContext.cpp */; };
+		521EDBF31C00D3A20092B2E9 /* LuaDropDown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA21C00D3A20092B2E9 /* LuaDropDown.cpp */; };
+		521EDBF41C00D3A20092B2E9 /* LuaExpand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA31C00D3A20092B2E9 /* LuaExpand.cpp */; };
+		521EDBF51C00D3A20092B2E9 /* LuaGauge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA41C00D3A20092B2E9 /* LuaGauge.cpp */; };
+		521EDBF61C00D3A20092B2E9 /* LuaGradient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA51C00D3A20092B2E9 /* LuaGradient.cpp */; };
+		521EDBF71C00D3A20092B2E9 /* LuaGrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA61C00D3A20092B2E9 /* LuaGrid.cpp */; };
+		521EDBF81C00D3A20092B2E9 /* LuaIcon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA71C00D3A20092B2E9 /* LuaIcon.cpp */; };
+		521EDBF91C00D3A20092B2E9 /* LuaImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA81C00D3A20092B2E9 /* LuaImage.cpp */; };
+		521EDBFA1C00D3A20092B2E9 /* LuaLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBA91C00D3A20092B2E9 /* LuaLabel.cpp */; };
+		521EDBFB1C00D3A20092B2E9 /* LuaLayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAA1C00D3A20092B2E9 /* LuaLayer.cpp */; };
+		521EDBFC1C00D3A20092B2E9 /* LuaList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAB1C00D3A20092B2E9 /* LuaList.cpp */; };
+		521EDBFD1C00D3A20092B2E9 /* LuaMargin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAC1C00D3A20092B2E9 /* LuaMargin.cpp */; };
+		521EDBFE1C00D3A20092B2E9 /* LuaMultiLineText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAD1C00D3A20092B2E9 /* LuaMultiLineText.cpp */; };
+		521EDBFF1C00D3A20092B2E9 /* LuaNumberLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAE1C00D3A20092B2E9 /* LuaNumberLabel.cpp */; };
+		521EDC001C00D3A20092B2E9 /* LuaScroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBAF1C00D3A20092B2E9 /* LuaScroller.cpp */; };
+		521EDC011C00D3A20092B2E9 /* LuaSingle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB11C00D3A20092B2E9 /* LuaSingle.cpp */; };
+		521EDC021C00D3A20092B2E9 /* LuaSlider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB21C00D3A20092B2E9 /* LuaSlider.cpp */; };
+		521EDC031C00D3A20092B2E9 /* LuaSmallButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB31C00D3A20092B2E9 /* LuaSmallButton.cpp */; };
+		521EDC041C00D3A20092B2E9 /* LuaTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB41C00D3A20092B2E9 /* LuaTable.cpp */; };
+		521EDC051C00D3A20092B2E9 /* LuaTextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB51C00D3A20092B2E9 /* LuaTextEntry.cpp */; };
+		521EDC061C00D3A20092B2E9 /* LuaWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB61C00D3A20092B2E9 /* LuaWidget.cpp */; };
+		521EDC071C00D3A20092B2E9 /* Margin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBB71C00D3A20092B2E9 /* Margin.cpp */; };
+		521EDC081C00D3A20092B2E9 /* MultiLineText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBBA1C00D3A20092B2E9 /* MultiLineText.cpp */; };
+		521EDC091C00D3A20092B2E9 /* NumberLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBBC1C00D3A20092B2E9 /* NumberLabel.cpp */; };
+		521EDC0A1C00D3A20092B2E9 /* Scroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBBF1C00D3A20092B2E9 /* Scroller.cpp */; };
+		521EDC0B1C00D3A20092B2E9 /* Single.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC11C00D3A20092B2E9 /* Single.cpp */; };
+		521EDC0C1C00D3A20092B2E9 /* Skin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC31C00D3A20092B2E9 /* Skin.cpp */; };
+		521EDC0D1C00D3A20092B2E9 /* Slider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC51C00D3A20092B2E9 /* Slider.cpp */; };
+		521EDC0E1C00D3A20092B2E9 /* SmallButton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC71C00D3A20092B2E9 /* SmallButton.cpp */; };
+		521EDC0F1C00D3A20092B2E9 /* Table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBC91C00D3A20092B2E9 /* Table.cpp */; };
+		521EDC101C00D3A20092B2E9 /* TextEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBCB1C00D3A20092B2E9 /* TextEntry.cpp */; };
+		521EDC111C00D3A20092B2E9 /* TextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBCD1C00D3A20092B2E9 /* TextLayout.cpp */; };
+		521EDC121C00D3A20092B2E9 /* Widget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 521EDBCF1C00D3A20092B2E9 /* Widget.cpp */; };
+		521EDC2B1C00D4720092B2E9 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC2A1C00D4720092B2E9 /* OpenGL.framework */; };
+		521EDC2D1C00D7950092B2E9 /* libGLEW.1.13.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC2C1C00D7950092B2E9 /* libGLEW.1.13.0.dylib */; };
+		521EDC2F1C00D7F40092B2E9 /* libjpeg.9.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC2E1C00D7F40092B2E9 /* libjpeg.9.dylib */; };
+		521EDC311C00D8AB0092B2E9 /* libpng16.16.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC301C00D8AB0092B2E9 /* libpng16.16.dylib */; };
+		521EDC341C00D8CA0092B2E9 /* libtiff.5.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC321C00D8CA0092B2E9 /* libtiff.5.dylib */; };
+		521EDC351C00D8CA0092B2E9 /* libz.1.2.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 521EDC331C00D8CA0092B2E9 /* libz.1.2.8.dylib */; };
+		52C6DBF91C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 52C6DBF71C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib */; };
+		52C6DBFA1C0250CC00B6CB63 /* libSDL2-2.0.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 52C6DBF81C0250CC00B6CB63 /* libSDL2-2.0.0.dylib */; };
+		52D125741C033A4200E6E4C2 /* libSDL2-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52C6DBF81C0250CC00B6CB63 /* libSDL2-2.0.0.dylib */; };
+		52D125751C033A5100E6E4C2 /* libSDL2_image-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52C6DBF71C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib */; };
+		52D125EC1C0351FB00E6E4C2 /* jsoncpp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D125941C0351FB00E6E4C2 /* jsoncpp.cpp */; };
+		52D125ED1C0351FB00E6E4C2 /* JsonUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D125951C0351FB00E6E4C2 /* JsonUtils.cpp */; };
+		52D126161C0351FB00E6E4C2 /* PicoDDS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D125E01C0351FB00E6E4C2 /* PicoDDS.cpp */; };
+		52D126571C03538F00E6E4C2 /* lapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1261B1C03538F00E6E4C2 /* lapi.c */; };
+		52D126581C03538F00E6E4C2 /* lauxlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1261D1C03538F00E6E4C2 /* lauxlib.c */; };
+		52D126591C03538F00E6E4C2 /* lbaselib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1261F1C03538F00E6E4C2 /* lbaselib.c */; };
+		52D1265A1C03538F00E6E4C2 /* lbitlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126201C03538F00E6E4C2 /* lbitlib.c */; };
+		52D1265B1C03538F00E6E4C2 /* lcode.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126211C03538F00E6E4C2 /* lcode.c */; };
+		52D1265C1C03538F00E6E4C2 /* lcorolib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126231C03538F00E6E4C2 /* lcorolib.c */; };
+		52D1265D1C03538F00E6E4C2 /* lctype.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126241C03538F00E6E4C2 /* lctype.c */; };
+		52D1265E1C03538F00E6E4C2 /* ldblib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126261C03538F00E6E4C2 /* ldblib.c */; };
+		52D1265F1C03538F00E6E4C2 /* ldebug.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126271C03538F00E6E4C2 /* ldebug.c */; };
+		52D126601C03538F00E6E4C2 /* ldo.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126291C03538F00E6E4C2 /* ldo.c */; };
+		52D126611C03538F00E6E4C2 /* ldump.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1262B1C03538F00E6E4C2 /* ldump.c */; };
+		52D126621C03538F00E6E4C2 /* lfunc.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1262C1C03538F00E6E4C2 /* lfunc.c */; };
+		52D126631C03538F00E6E4C2 /* lgc.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1262E1C03538F00E6E4C2 /* lgc.c */; };
+		52D126641C03538F00E6E4C2 /* linit.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126301C03538F00E6E4C2 /* linit.c */; };
+		52D126651C03538F00E6E4C2 /* liolib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126311C03538F00E6E4C2 /* liolib.c */; };
+		52D126661C03538F00E6E4C2 /* llex.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126321C03538F00E6E4C2 /* llex.c */; };
+		52D126671C03538F00E6E4C2 /* lmathlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126351C03538F00E6E4C2 /* lmathlib.c */; };
+		52D126681C03538F00E6E4C2 /* lmem.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126361C03538F00E6E4C2 /* lmem.c */; };
+		52D126691C03538F00E6E4C2 /* loadlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126381C03538F00E6E4C2 /* loadlib.c */; };
+		52D1266A1C03538F00E6E4C2 /* lobject.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126391C03538F00E6E4C2 /* lobject.c */; };
+		52D1266B1C03538F00E6E4C2 /* lopcodes.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1263B1C03538F00E6E4C2 /* lopcodes.c */; };
+		52D1266C1C03538F00E6E4C2 /* loslib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1263D1C03538F00E6E4C2 /* loslib.c */; };
+		52D1266D1C03538F00E6E4C2 /* lparser.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D1263E1C03538F00E6E4C2 /* lparser.c */; };
+		52D1266E1C03538F00E6E4C2 /* lstate.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126401C03538F00E6E4C2 /* lstate.c */; };
+		52D1266F1C03538F00E6E4C2 /* lstring.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126421C03538F00E6E4C2 /* lstring.c */; };
+		52D126701C03538F00E6E4C2 /* lstrlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126441C03538F00E6E4C2 /* lstrlib.c */; };
+		52D126711C03538F00E6E4C2 /* ltable.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126451C03538F00E6E4C2 /* ltable.c */; };
+		52D126721C03538F00E6E4C2 /* ltablib.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126471C03538F00E6E4C2 /* ltablib.c */; };
+		52D126731C03538F00E6E4C2 /* ltm.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126481C03538F00E6E4C2 /* ltm.c */; };
+		52D126761C03538F00E6E4C2 /* lundump.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126501C03538F00E6E4C2 /* lundump.c */; };
+		52D126771C03538F00E6E4C2 /* lvm.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126521C03538F00E6E4C2 /* lvm.c */; };
+		52D126781C03538F00E6E4C2 /* lzio.c in Sources */ = {isa = PBXBuildFile; fileRef = 52D126541C03538F00E6E4C2 /* lzio.c */; };
+		52E5FADC1C0356F2001F4F89 /* libcurl.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 52E5FADB1C0356F2001F4F89 /* libcurl.dylib */; };
+		52E5FAE11C03589F001F4F89 /* lookup3.c in Sources */ = {isa = PBXBuildFile; fileRef = 52E5FADE1C03589F001F4F89 /* lookup3.c */; };
+		52E5FAE31C036A67001F4F89 /* libGLEW.1.13.0.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 521EDC2C1C00D7950092B2E9 /* libGLEW.1.13.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		52E5FAE71C036CBE001F4F89 /* libjpeg.9.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 521EDC2E1C00D7F40092B2E9 /* libjpeg.9.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		52E5FAE81C036CF0001F4F89 /* libpng16.16.dylib in Copy SubLibraries */ = {isa = PBXBuildFile; fileRef = 521EDC301C00D8AB0092B2E9 /* libpng16.16.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		52E5FAE91C036D56001F4F89 /* libtiff.5.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 521EDC321C00D8CA0092B2E9 /* libtiff.5.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		52E5FAEA1C036D8A001F4F89 /* libz.1.2.8.dylib in Copy Libraries */ = {isa = PBXBuildFile; fileRef = 521EDC331C00D8CA0092B2E9 /* libz.1.2.8.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		52E5FAF51C0375F2001F4F89 /* Makefile.am in Resources */ = {isa = PBXBuildFile; fileRef = 52E5FAF21C0375F2001F4F89 /* Makefile.am */; };
+		52E5FAF61C0375F2001F4F89 /* README in Resources */ = {isa = PBXBuildFile; fileRef = 52E5FAF41C0375F2001F4F89 /* README */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -458,6 +489,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				52E5FAE81C036CF0001F4F89 /* libpng16.16.dylib in Copy SubLibraries */,
+				52E5FAE71C036CBE001F4F89 /* libjpeg.9.dylib in Copy SubLibraries */,
 				4AEEBC60162A4FA300C6EA6F /* libbz2.1.0.6.dylib in Copy SubLibraries */,
 				4AEEBC5D162A4CA600C6EA6F /* libxcb.1.dylib in Copy SubLibraries */,
 				4AEEBC58162A4C0700C6EA6F /* libX11.6.dylib in Copy SubLibraries */,
@@ -466,14 +499,10 @@
 				4AEEBC51162A4BA700C6EA6F /* libXrender.1.dylib in Copy SubLibraries */,
 				4AEEBC4D162A4B2000C6EA6F /* libXext.6.dylib in Copy SubLibraries */,
 				4AEEBC4E162A4B2000C6EA6F /* libXrandr.2.dylib in Copy SubLibraries */,
-				4AEEBC48162A499400C6EA6F /* libpng15.15.dylib in Copy SubLibraries */,
 				4A76112A1611A92400A06F79 /* libFLAC.8.dylib in Copy SubLibraries */,
-				4A7611231611A88C00A06F79 /* libz.1.2.7.dylib in Copy SubLibraries */,
 				4A671BA31388CA3F00657F38 /* libspeex.1.5.0.dylib in Copy SubLibraries */,
 				4A671B9D1388C6C400657F38 /* libmodplug.1.dylib in Copy SubLibraries */,
 				4A671B9A1388C62800657F38 /* libsmpeg-0.4.0.dylib in Copy SubLibraries */,
-				4A671B971388C47A00657F38 /* libjpeg.8.dylib in Copy SubLibraries */,
-				4A671B941388C3E500657F38 /* libtiff.3.dylib in Copy SubLibraries */,
 				4A671B8A1388C08500657F38 /* libogg.0.dylib in Copy SubLibraries */,
 				4A671B8B1388C08500657F38 /* libvorbis.0.dylib in Copy SubLibraries */,
 			);
@@ -497,14 +526,15 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				52E5FAEA1C036D8A001F4F89 /* libz.1.2.8.dylib in Copy Libraries */,
+				52E5FAE91C036D56001F4F89 /* libtiff.5.dylib in Copy Libraries */,
+				52E5FAE31C036A67001F4F89 /* libGLEW.1.13.0.dylib in Copy Libraries */,
+				52C6DBF91C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib in Copy Libraries */,
+				52C6DBFA1C0250CC00B6CB63 /* libSDL2-2.0.0.dylib in Copy Libraries */,
 				4ACDB6D5167881AF0069FA03 /* libassimp.3.0.0.dylib in Copy Libraries */,
-				4A7611271611A8DB00A06F79 /* libGLEW.1.9.0.dylib in Copy Libraries */,
 				4A5619D813867661002A904C /* libvorbisfile.3.dylib in Copy Libraries */,
 				4A5619D313866B5B002A904C /* libfreetype.6.dylib in Copy Libraries */,
-				4AE5CA411383E6AA00B55DEB /* libSDL_image-1.2.0.dylib in Copy Libraries */,
-				4AE5CA421383E6AA00B55DEB /* libSDL_sound-1.0.1.0.2.dylib in Copy Libraries */,
 				4AE5CA441383E6AA00B55DEB /* libsigc-2.0.0.dylib in Copy Libraries */,
-				4AE5CA3C1383E2EC00B55DEB /* libSDL-1.2.0.dylib in Copy Libraries */,
 			);
 			name = "Copy Libraries";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -512,708 +542,36 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		4A01889615A59908002F540B /* SystemPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemPath.cpp; sourceTree = "<group>"; };
-		4A0F25CB165CF00D00208507 /* LuaSmallButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSmallButton.cpp; sourceTree = "<group>"; };
-		4A0F25CC165CF00D00208507 /* SmallButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SmallButton.cpp; sourceTree = "<group>"; };
-		4A0F25CD165CF00D00208507 /* SmallButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmallButton.h; sourceTree = "<group>"; };
-		4A107C2B1525AB0D00EF9FAC /* CRC32.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CRC32.cpp; sourceTree = "<group>"; };
-		4A107C2C1525AB0D00EF9FAC /* CRC32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRC32.h; sourceTree = "<group>"; };
-		4A107C2D1525AB0D00EF9FAC /* ShipController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipController.cpp; sourceTree = "<group>"; };
-		4A107C2E1525AB0D00EF9FAC /* ShipController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipController.h; sourceTree = "<group>"; };
-		4A190325138AA33300E0229C /* Gui.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Gui.cpp; sourceTree = "<group>"; };
-		4A190326138AA33300E0229C /* Gui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gui.h; sourceTree = "<group>"; };
-		4A190328138AA33300E0229C /* GuiAdjustment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiAdjustment.h; sourceTree = "<group>"; };
-		4A190329138AA33300E0229C /* GuiBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiBox.cpp; sourceTree = "<group>"; };
-		4A19032A138AA33300E0229C /* GuiBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiBox.h; sourceTree = "<group>"; };
-		4A19032C138AA33300E0229C /* GuiButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiButton.cpp; sourceTree = "<group>"; };
-		4A19032D138AA33300E0229C /* GuiButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiButton.h; sourceTree = "<group>"; };
-		4A19032F138AA33300E0229C /* GuiContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiContainer.cpp; sourceTree = "<group>"; };
-		4A190330138AA33300E0229C /* GuiContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiContainer.h; sourceTree = "<group>"; };
-		4A190332138AA33300E0229C /* GuiEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiEvents.h; sourceTree = "<group>"; };
-		4A190333138AA33300E0229C /* GuiFixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiFixed.cpp; sourceTree = "<group>"; };
-		4A190334138AA33300E0229C /* GuiFixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiFixed.h; sourceTree = "<group>"; };
-		4A190336138AA33300E0229C /* GuiImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiImage.cpp; sourceTree = "<group>"; };
-		4A190337138AA33300E0229C /* GuiImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiImage.h; sourceTree = "<group>"; };
-		4A190339138AA33300E0229C /* GuiImageButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiImageButton.cpp; sourceTree = "<group>"; };
-		4A19033A138AA33300E0229C /* GuiImageButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiImageButton.h; sourceTree = "<group>"; };
-		4A19033C138AA33300E0229C /* GuiImageRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiImageRadioButton.cpp; sourceTree = "<group>"; };
-		4A19033D138AA33300E0229C /* GuiImageRadioButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiImageRadioButton.h; sourceTree = "<group>"; };
-		4A19033F138AA33300E0229C /* GuiISelectable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiISelectable.h; sourceTree = "<group>"; };
-		4A190340138AA33300E0229C /* GuiLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiLabel.cpp; sourceTree = "<group>"; };
-		4A190341138AA33300E0229C /* GuiLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiLabel.h; sourceTree = "<group>"; };
-		4A190343138AA33300E0229C /* GuiLabelSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiLabelSet.cpp; sourceTree = "<group>"; };
-		4A190344138AA33300E0229C /* GuiLabelSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiLabelSet.h; sourceTree = "<group>"; };
-		4A190346138AA33300E0229C /* GuiMeterBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiMeterBar.cpp; sourceTree = "<group>"; };
-		4A190347138AA33300E0229C /* GuiMeterBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiMeterBar.h; sourceTree = "<group>"; };
-		4A190349138AA33300E0229C /* GuiMultiStateImageButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiMultiStateImageButton.cpp; sourceTree = "<group>"; };
-		4A19034A138AA33300E0229C /* GuiMultiStateImageButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiMultiStateImageButton.h; sourceTree = "<group>"; };
-		4A19034C138AA33300E0229C /* GuiRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiRadioButton.cpp; sourceTree = "<group>"; };
-		4A19034D138AA33300E0229C /* GuiRadioButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiRadioButton.h; sourceTree = "<group>"; };
-		4A19034F138AA33300E0229C /* GuiRadioGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiRadioGroup.cpp; sourceTree = "<group>"; };
-		4A190350138AA33300E0229C /* GuiRadioGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiRadioGroup.h; sourceTree = "<group>"; };
-		4A190352138AA33300E0229C /* GuiRepeaterButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiRepeaterButton.cpp; sourceTree = "<group>"; };
-		4A190353138AA33300E0229C /* GuiRepeaterButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiRepeaterButton.h; sourceTree = "<group>"; };
-		4A190355138AA33300E0229C /* GuiScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiScreen.cpp; sourceTree = "<group>"; };
-		4A190356138AA33300E0229C /* GuiScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiScreen.h; sourceTree = "<group>"; };
-		4A190358138AA33300E0229C /* GuiTabbed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiTabbed.cpp; sourceTree = "<group>"; };
-		4A190359138AA33300E0229C /* GuiTabbed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiTabbed.h; sourceTree = "<group>"; };
-		4A19035B138AA33300E0229C /* GuiTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiTextEntry.cpp; sourceTree = "<group>"; };
-		4A19035C138AA33300E0229C /* GuiTextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiTextEntry.h; sourceTree = "<group>"; };
-		4A19035E138AA33300E0229C /* GuiTextLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiTextLayout.cpp; sourceTree = "<group>"; };
-		4A19035F138AA33300E0229C /* GuiTextLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiTextLayout.h; sourceTree = "<group>"; };
-		4A190361138AA33300E0229C /* GuiToggleButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiToggleButton.cpp; sourceTree = "<group>"; };
-		4A190362138AA33300E0229C /* GuiToggleButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiToggleButton.h; sourceTree = "<group>"; };
-		4A190364138AA33300E0229C /* GuiToolTip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiToolTip.cpp; sourceTree = "<group>"; };
-		4A190365138AA33300E0229C /* GuiToolTip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiToolTip.h; sourceTree = "<group>"; };
-		4A190367138AA33300E0229C /* GuiVScrollBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiVScrollBar.cpp; sourceTree = "<group>"; };
-		4A190368138AA33300E0229C /* GuiVScrollBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiVScrollBar.h; sourceTree = "<group>"; };
-		4A19036A138AA33300E0229C /* GuiVScrollPortal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiVScrollPortal.cpp; sourceTree = "<group>"; };
-		4A19036B138AA33300E0229C /* GuiVScrollPortal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiVScrollPortal.h; sourceTree = "<group>"; };
-		4A19036D138AA33300E0229C /* GuiWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiWidget.cpp; sourceTree = "<group>"; };
-		4A19036E138AA33300E0229C /* GuiWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiWidget.h; sourceTree = "<group>"; };
-		4A1903E2138AA39C00E0229C /* lapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lapi.c; sourceTree = "<group>"; };
-		4A1903E3138AA39C00E0229C /* lapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lapi.h; sourceTree = "<group>"; };
-		4A1903E5138AA39C00E0229C /* lauxlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lauxlib.c; sourceTree = "<group>"; };
-		4A1903E6138AA39C00E0229C /* lauxlib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lauxlib.h; sourceTree = "<group>"; };
-		4A1903E8138AA39C00E0229C /* lbaselib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lbaselib.c; sourceTree = "<group>"; };
-		4A1903EA138AA39C00E0229C /* lcode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcode.c; sourceTree = "<group>"; };
-		4A1903EB138AA39C00E0229C /* lcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcode.h; sourceTree = "<group>"; };
-		4A1903ED138AA39C00E0229C /* ldblib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldblib.c; sourceTree = "<group>"; };
-		4A1903EF138AA39C00E0229C /* ldebug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldebug.c; sourceTree = "<group>"; };
-		4A1903F0138AA39C00E0229C /* ldebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ldebug.h; sourceTree = "<group>"; };
-		4A1903F2138AA39C00E0229C /* ldo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldo.c; sourceTree = "<group>"; };
-		4A1903F3138AA39C00E0229C /* ldo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ldo.h; sourceTree = "<group>"; };
-		4A1903F5138AA39C00E0229C /* ldump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldump.c; sourceTree = "<group>"; };
-		4A1903F7138AA39C00E0229C /* lfunc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lfunc.c; sourceTree = "<group>"; };
-		4A1903F8138AA39C00E0229C /* lfunc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lfunc.h; sourceTree = "<group>"; };
-		4A1903FA138AA39C00E0229C /* lgc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lgc.c; sourceTree = "<group>"; };
-		4A1903FB138AA39C00E0229C /* lgc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lgc.h; sourceTree = "<group>"; };
-		4A1903FE138AA39C00E0229C /* linit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = linit.c; sourceTree = "<group>"; };
-		4A190400138AA39C00E0229C /* liolib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = liolib.c; sourceTree = "<group>"; };
-		4A190402138AA39C00E0229C /* llex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = llex.c; sourceTree = "<group>"; };
-		4A190403138AA39C00E0229C /* llex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llex.h; sourceTree = "<group>"; };
-		4A190405138AA39C00E0229C /* llimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llimits.h; sourceTree = "<group>"; };
-		4A190406138AA39C00E0229C /* lmathlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lmathlib.c; sourceTree = "<group>"; };
-		4A190408138AA39C00E0229C /* lmem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lmem.c; sourceTree = "<group>"; };
-		4A190409138AA39C00E0229C /* lmem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lmem.h; sourceTree = "<group>"; };
-		4A19040B138AA39C00E0229C /* loadlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loadlib.c; sourceTree = "<group>"; };
-		4A19040D138AA39C00E0229C /* lobject.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lobject.c; sourceTree = "<group>"; };
-		4A19040E138AA39C00E0229C /* lobject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lobject.h; sourceTree = "<group>"; };
-		4A190410138AA39C00E0229C /* lopcodes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lopcodes.c; sourceTree = "<group>"; };
-		4A190411138AA39C00E0229C /* lopcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lopcodes.h; sourceTree = "<group>"; };
-		4A190413138AA39C00E0229C /* loslib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loslib.c; sourceTree = "<group>"; };
-		4A190415138AA39C00E0229C /* lparser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lparser.c; sourceTree = "<group>"; };
-		4A190416138AA39C00E0229C /* lparser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lparser.h; sourceTree = "<group>"; };
-		4A190418138AA39C00E0229C /* lstate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstate.c; sourceTree = "<group>"; };
-		4A190419138AA39C00E0229C /* lstate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstate.h; sourceTree = "<group>"; };
-		4A19041B138AA39C00E0229C /* lstring.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstring.c; sourceTree = "<group>"; };
-		4A19041C138AA39C00E0229C /* lstring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstring.h; sourceTree = "<group>"; };
-		4A19041E138AA39C00E0229C /* lstrlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstrlib.c; sourceTree = "<group>"; };
-		4A190420138AA39C00E0229C /* ltable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltable.c; sourceTree = "<group>"; };
-		4A190421138AA39C00E0229C /* ltable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ltable.h; sourceTree = "<group>"; };
-		4A190423138AA39C00E0229C /* ltablib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltablib.c; sourceTree = "<group>"; };
-		4A190425138AA39C00E0229C /* ltm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltm.c; sourceTree = "<group>"; };
-		4A190426138AA39C00E0229C /* ltm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ltm.h; sourceTree = "<group>"; };
-		4A190428138AA39C00E0229C /* lua.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lua.c; sourceTree = "<group>"; };
-		4A190429138AA39C00E0229C /* lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lua.h; sourceTree = "<group>"; };
-		4A19042A138AA39C00E0229C /* luac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = luac.c; sourceTree = "<group>"; };
-		4A19042B138AA39C00E0229C /* luaconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = luaconf.h; sourceTree = "<group>"; };
-		4A19042C138AA39C00E0229C /* lualib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lualib.h; sourceTree = "<group>"; };
-		4A19042D138AA39C00E0229C /* lundump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lundump.c; sourceTree = "<group>"; };
-		4A19042E138AA39C00E0229C /* lundump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lundump.h; sourceTree = "<group>"; };
-		4A190430138AA39C00E0229C /* lvm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lvm.c; sourceTree = "<group>"; };
-		4A190431138AA39C00E0229C /* lvm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lvm.h; sourceTree = "<group>"; };
-		4A190433138AA39C00E0229C /* lzio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lzio.c; sourceTree = "<group>"; };
-		4A190434138AA39C00E0229C /* lzio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lzio.h; sourceTree = "<group>"; };
-		4A1E9EBE144EEA8A009243D2 /* FloatComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FloatComparison.h; sourceTree = "<group>"; };
 		4A20B0DE135319770020F43E /* pioneer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = pioneer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A20B0E2135319770020F43E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		4A20B0E5135319770020F43E /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		4A20B0E6135319770020F43E /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		4A20B0E7135319770020F43E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		4A20B10E13531C040020F43E /* SDLMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLMain.h; sourceTree = "<group>"; };
-		4A20B10F13531C040020F43E /* SDLMain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDLMain.m; sourceTree = "<group>"; };
 		4A20B11313531CC40020F43E /* pioneer-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "pioneer-Info.plist"; path = "pioneer/pioneer-Info.plist"; sourceTree = "<group>"; };
 		4A20B11413531CC40020F43E /* pioneer-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "pioneer-Prefix.pch"; path = "pioneer/pioneer-Prefix.pch"; sourceTree = "<group>"; };
 		4A20B11713531CD10020F43E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = en; path = pioneer/en.lproj/Credits.rtf; sourceTree = "<group>"; };
 		4A20B11913531CD10020F43E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = pioneer/en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		4A20B11F13531E950020F43E /* pioneerApp.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = pioneerApp.xib; sourceTree = "<group>"; };
-		4A239FC9163E78D60037BE24 /* LuaFaction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFaction.cpp; sourceTree = "<group>"; };
-		4A24075513F5240F002A5C12 /* ChatForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ChatForm.cpp; sourceTree = "<group>"; };
-		4A24075613F5240F002A5C12 /* ChatForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChatForm.h; sourceTree = "<group>"; };
-		4A24075713F5240F002A5C12 /* Form.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Form.h; sourceTree = "<group>"; };
-		4A24075813F5240F002A5C12 /* FormController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FormController.cpp; sourceTree = "<group>"; };
-		4A24075913F5240F002A5C12 /* FormController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FormController.h; sourceTree = "<group>"; };
-		4A24075A13F5240F002A5C12 /* Lang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lang.cpp; sourceTree = "<group>"; };
-		4A24075B13F5240F002A5C12 /* Lang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lang.h; sourceTree = "<group>"; };
-		4A24075C13F5240F002A5C12 /* ShipSpinnerWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipSpinnerWidget.cpp; sourceTree = "<group>"; };
-		4A24075D13F5240F002A5C12 /* ShipSpinnerWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipSpinnerWidget.h; sourceTree = "<group>"; };
-		4A24075E13F5240F002A5C12 /* StationAdvertForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationAdvertForm.cpp; sourceTree = "<group>"; };
-		4A24075F13F5240F002A5C12 /* StationAdvertForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationAdvertForm.h; sourceTree = "<group>"; };
-		4A24076013F5240F002A5C12 /* StationBulletinBoardForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationBulletinBoardForm.cpp; sourceTree = "<group>"; };
-		4A24076113F5240F002A5C12 /* StationBulletinBoardForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationBulletinBoardForm.h; sourceTree = "<group>"; };
-		4A24076213F5240F002A5C12 /* StationCommodityMarketForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationCommodityMarketForm.cpp; sourceTree = "<group>"; };
-		4A24076313F5240F002A5C12 /* StationCommodityMarketForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationCommodityMarketForm.h; sourceTree = "<group>"; };
-		4A24076413F5240F002A5C12 /* StationPoliceForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationPoliceForm.cpp; sourceTree = "<group>"; };
-		4A24076513F5240F002A5C12 /* StationPoliceForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationPoliceForm.h; sourceTree = "<group>"; };
-		4A24076613F5240F002A5C12 /* StationServicesForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationServicesForm.cpp; sourceTree = "<group>"; };
-		4A24076713F5240F002A5C12 /* StationServicesForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationServicesForm.h; sourceTree = "<group>"; };
-		4A24076813F5240F002A5C12 /* StationShipEquipmentForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationShipEquipmentForm.cpp; sourceTree = "<group>"; };
-		4A24076913F5240F002A5C12 /* StationShipEquipmentForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationShipEquipmentForm.h; sourceTree = "<group>"; };
-		4A24076A13F5240F002A5C12 /* StationShipMarketForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationShipMarketForm.cpp; sourceTree = "<group>"; };
-		4A24076B13F5240F002A5C12 /* StationShipMarketForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationShipMarketForm.h; sourceTree = "<group>"; };
-		4A24076C13F5240F002A5C12 /* StationShipRepairForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationShipRepairForm.cpp; sourceTree = "<group>"; };
-		4A24076D13F5240F002A5C12 /* StationShipRepairForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationShipRepairForm.h; sourceTree = "<group>"; };
-		4A24076E13F5240F002A5C12 /* StationShipViewForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationShipViewForm.cpp; sourceTree = "<group>"; };
-		4A24076F13F5240F002A5C12 /* StationShipViewForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationShipViewForm.h; sourceTree = "<group>"; };
-		4A24077013F5240F002A5C12 /* StationShipyardForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StationShipyardForm.cpp; sourceTree = "<group>"; };
-		4A24077113F5240F002A5C12 /* StationShipyardForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StationShipyardForm.h; sourceTree = "<group>"; };
-		4A24078013F524E6002A5C12 /* GuiGradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiGradient.cpp; sourceTree = "<group>"; };
-		4A24078113F524E6002A5C12 /* GuiGradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiGradient.h; sourceTree = "<group>"; };
-		4A24078213F524E6002A5C12 /* GuiStack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiStack.cpp; sourceTree = "<group>"; };
-		4A24078313F524E6002A5C12 /* GuiStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiStack.h; sourceTree = "<group>"; };
-		4A24FD5C1650F4B700DE7B0F /* UIView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIView.cpp; sourceTree = "<group>"; };
-		4A24FD5D1650F4B700DE7B0F /* UIView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIView.h; sourceTree = "<group>"; };
-		4A24FD611650F4D100DE7B0F /* GameUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameUI.h; sourceTree = "<group>"; };
-		4A24FD621650F4D100DE7B0F /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lua.cpp; sourceTree = "<group>"; };
-		4A24FD631650F4D100DE7B0F /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lua.h; sourceTree = "<group>"; };
-		4A24FD651650F4D100DE7B0F /* Panel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Panel.cpp; sourceTree = "<group>"; };
-		4A24FD661650F4D100DE7B0F /* Panel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Panel.h; sourceTree = "<group>"; };
-		4A305FCB151341170076D414 /* ByteRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByteRange.h; sourceTree = "<group>"; };
-		4A305FCC151341170076D414 /* FileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystem.cpp; sourceTree = "<group>"; };
-		4A305FCD151341170076D414 /* FileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileSystem.h; sourceTree = "<group>"; };
-		4A305FCF151341170076D414 /* LangStrings.inc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LangStrings.inc.h; sourceTree = "<group>"; };
-		4A305FD0151341170076D414 /* StringRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringRange.h; sourceTree = "<group>"; };
-		4A37073315A879D100E7E5F6 /* lookup3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lookup3.c; sourceTree = "<group>"; };
-		4A37073415A879D100E7E5F6 /* lookup3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lookup3.h; sourceTree = "<group>"; };
-		4A3AE8E3158FD22200EB13DE /* LuaComms.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaComms.cpp; sourceTree = "<group>"; };
-		4A3AE8E4158FD22200EB13DE /* LuaComms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaComms.h; sourceTree = "<group>"; };
-		4A4A86E716A992D600F81F18 /* CameraController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CameraController.cpp; sourceTree = "<group>"; };
-		4A4A86E816A992D600F81F18 /* CameraController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CameraController.h; sourceTree = "<group>"; };
-		4A4D25D2167335D9003BC9D5 /* Face.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Face.cpp; sourceTree = "<group>"; };
-		4A4D25D3167335D9003BC9D5 /* Face.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Face.h; sourceTree = "<group>"; };
-		4A4D25D4167335D9003BC9D5 /* LuaFace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFace.cpp; sourceTree = "<group>"; };
-		4A4D25DC167335F5003BC9D5 /* Icon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Icon.cpp; sourceTree = "<group>"; };
-		4A4D25DD167335F5003BC9D5 /* Icon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Icon.h; sourceTree = "<group>"; };
-		4A4D25DE167335F5003BC9D5 /* LuaIcon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaIcon.cpp; sourceTree = "<group>"; };
-		4A4F25B914F524D400FD14A6 /* Drawables.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Drawables.cpp; sourceTree = "<group>"; };
-		4A4F25BA14F524D400FD14A6 /* Drawables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Drawables.h; sourceTree = "<group>"; };
-		4A4F25BB14F524D400FD14A6 /* Frustum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Frustum.cpp; sourceTree = "<group>"; };
-		4A4F25BC14F524D400FD14A6 /* Frustum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Frustum.h; sourceTree = "<group>"; };
-		4A4F25BD14F524D400FD14A6 /* Graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Graphics.cpp; sourceTree = "<group>"; };
-		4A4F25BE14F524D400FD14A6 /* Graphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Graphics.h; sourceTree = "<group>"; };
-		4A4F25C014F524D400FD14A6 /* Material.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Material.cpp; sourceTree = "<group>"; };
-		4A4F25C114F524D400FD14A6 /* Material.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Material.h; sourceTree = "<group>"; };
-		4A4F25C214F524D400FD14A6 /* Renderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Renderer.cpp; sourceTree = "<group>"; };
-		4A4F25C314F524D400FD14A6 /* Renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Renderer.h; sourceTree = "<group>"; };
-		4A4F25C414F524D400FD14A6 /* RendererGL2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RendererGL2.cpp; sourceTree = "<group>"; };
-		4A4F25C514F524D400FD14A6 /* RendererGL2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererGL2.h; sourceTree = "<group>"; };
-		4A4F25C614F524D400FD14A6 /* RendererGLBuffers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererGLBuffers.h; sourceTree = "<group>"; };
-		4A4F25C714F524D400FD14A6 /* RendererLegacy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RendererLegacy.cpp; sourceTree = "<group>"; };
-		4A4F25C814F524D400FD14A6 /* RendererLegacy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererLegacy.h; sourceTree = "<group>"; };
-		4A4F25CD14F524D400FD14A6 /* StaticMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticMesh.cpp; sourceTree = "<group>"; };
-		4A4F25CE14F524D400FD14A6 /* StaticMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StaticMesh.h; sourceTree = "<group>"; };
-		4A4F25CF14F524D400FD14A6 /* Surface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Surface.h; sourceTree = "<group>"; };
-		4A4F25D014F524D400FD14A6 /* VertexArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VertexArray.cpp; sourceTree = "<group>"; };
-		4A4F25D114F524D400FD14A6 /* VertexArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexArray.h; sourceTree = "<group>"; };
-		4A4F25E014F524F600FD14A6 /* SmartPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmartPtr.h; sourceTree = "<group>"; };
-		4A4F25E114F524F600FD14A6 /* vector2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vector2.h; sourceTree = "<group>"; };
 		4A5619CE13866622002A904C /* libfreetype.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libfreetype.6.dylib; path = /opt/local/lib/libfreetype.6.dylib; sourceTree = "<absolute>"; };
 		4A5619D413867033002A904C /* libvorbisfile.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbisfile.3.dylib; path = /opt/local/lib/libvorbisfile.3.dylib; sourceTree = "<absolute>"; };
-		4A59B4D51557EAF5009926E5 /* lbitlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lbitlib.c; sourceTree = "<group>"; };
-		4A59B4D61557EAF5009926E5 /* lcorolib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcorolib.c; sourceTree = "<group>"; };
-		4A59B4D71557EAF5009926E5 /* lctype.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lctype.c; sourceTree = "<group>"; };
-		4A59B4D81557EAF5009926E5 /* lctype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lctype.h; sourceTree = "<group>"; };
-		4A59B4D91557EAF5009926E5 /* lua.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lua.hpp; sourceTree = "<group>"; };
-		4A61E15C13978F1000193E43 /* Background.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Background.cpp; sourceTree = "<group>"; };
-		4A61E15D13978F1000193E43 /* Background.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Background.h; sourceTree = "<group>"; };
-		4A62EF27136979E000919EBB /* DeadVideoLink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeadVideoLink.cpp; sourceTree = "<group>"; };
-		4A62EF28136979E000919EBB /* DeadVideoLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeadVideoLink.h; sourceTree = "<group>"; };
-		4A62EF29136979E000919EBB /* FaceVideoLink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FaceVideoLink.cpp; sourceTree = "<group>"; };
-		4A62EF2A136979E000919EBB /* FaceVideoLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FaceVideoLink.h; sourceTree = "<group>"; };
-		4A62EF2B136979E000919EBB /* VideoLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoLink.h; sourceTree = "<group>"; };
-		4A6392C4136BD51E008352F1 /* buildopts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buildopts.h; sourceTree = "<group>"; };
 		4A671B861388C07700657F38 /* libogg.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libogg.0.dylib; path = ../../../../../opt/local/lib/libogg.0.dylib; sourceTree = "<group>"; };
 		4A671B871388C07700657F38 /* libvorbis.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvorbis.0.dylib; path = ../../../../../opt/local/lib/libvorbis.0.dylib; sourceTree = "<group>"; };
-		4A671B921388C3DC00657F38 /* libtiff.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libtiff.3.dylib; path = ../../../../../opt/local/lib/libtiff.3.dylib; sourceTree = "<group>"; };
-		4A671B951388C47200657F38 /* libjpeg.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjpeg.8.dylib; path = ../../../../../opt/local/lib/libjpeg.8.dylib; sourceTree = "<group>"; };
 		4A671B981388C61F00657F38 /* libsmpeg-0.4.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libsmpeg-0.4.0.dylib"; path = "../../../../../opt/local/lib/libsmpeg-0.4.0.dylib"; sourceTree = "<group>"; };
 		4A671B9B1388C6B700657F38 /* libmodplug.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmodplug.1.dylib; path = ../../../../../opt/local/lib/libmodplug.1.dylib; sourceTree = "<group>"; };
 		4A671BA11388CA3200657F38 /* libspeex.1.5.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libspeex.1.5.0.dylib; path = ../../../../../opt/local/lib/libspeex.1.5.0.dylib; sourceTree = "<group>"; };
-		4A6B59CA1429F14500ADC7C8 /* StringF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringF.cpp; sourceTree = "<group>"; };
-		4A6B59CB1429F14500ADC7C8 /* StringF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringF.h; sourceTree = "<group>"; };
-		4A6C4BFE13532FC300FDD53F /* Aabb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Aabb.h; sourceTree = "<group>"; };
-		4A6C4BFF13532FC300FDD53F /* AmbientSounds.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AmbientSounds.cpp; sourceTree = "<group>"; };
-		4A6C4C0013532FC300FDD53F /* AmbientSounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AmbientSounds.h; sourceTree = "<group>"; };
-		4A6C4C0113532FC300FDD53F /* BezierCurve.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BezierCurve.h; sourceTree = "<group>"; };
-		4A6C4C0213532FC300FDD53F /* Body.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Body.cpp; sourceTree = "<group>"; };
-		4A6C4C0313532FC300FDD53F /* Body.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Body.h; sourceTree = "<group>"; };
-		4A6C4C0513532FC300FDD53F /* CargoBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CargoBody.cpp; sourceTree = "<group>"; };
-		4A6C4C0613532FC300FDD53F /* CargoBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CargoBody.h; sourceTree = "<group>"; };
-		4A6C4C0713532FC300FDD53F /* CityOnPlanet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CityOnPlanet.cpp; sourceTree = "<group>"; };
-		4A6C4C0813532FC300FDD53F /* CityOnPlanet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CityOnPlanet.h; sourceTree = "<group>"; };
-		4A6C4C0F13532FC300FDD53F /* BVHTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BVHTree.cpp; sourceTree = "<group>"; };
-		4A6C4C1013532FC300FDD53F /* BVHTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BVHTree.h; sourceTree = "<group>"; };
-		4A6C4C1113532FC300FDD53F /* collider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = collider.h; sourceTree = "<group>"; };
-		4A6C4C1213532FC300FDD53F /* CollisionContact.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollisionContact.h; sourceTree = "<group>"; };
-		4A6C4C1313532FC300FDD53F /* CollisionSpace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollisionSpace.cpp; sourceTree = "<group>"; };
-		4A6C4C1413532FC300FDD53F /* CollisionSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollisionSpace.h; sourceTree = "<group>"; };
-		4A6C4C1513532FC300FDD53F /* Geom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Geom.cpp; sourceTree = "<group>"; };
-		4A6C4C1613532FC300FDD53F /* Geom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Geom.h; sourceTree = "<group>"; };
-		4A6C4C1713532FC300FDD53F /* GeomTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeomTree.cpp; sourceTree = "<group>"; };
-		4A6C4C1813532FC300FDD53F /* GeomTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeomTree.h; sourceTree = "<group>"; };
-		4A6C4C1C13532FC300FDD53F /* Color.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Color.h; sourceTree = "<group>"; };
-		4A6C4C1D13532FC300FDD53F /* CommodityTradeWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CommodityTradeWidget.cpp; sourceTree = "<group>"; };
-		4A6C4C1E13532FC300FDD53F /* CommodityTradeWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommodityTradeWidget.h; sourceTree = "<group>"; };
-		4A6C4C2113532FC300FDD53F /* DynamicBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DynamicBody.cpp; sourceTree = "<group>"; };
-		4A6C4C2213532FC300FDD53F /* DynamicBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DynamicBody.h; sourceTree = "<group>"; };
-		4A6C4C2313532FC300FDD53F /* EquipType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EquipType.cpp; sourceTree = "<group>"; };
-		4A6C4C2413532FC300FDD53F /* EquipType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EquipType.h; sourceTree = "<group>"; };
-		4A6C4C2513532FC300FDD53F /* fixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fixed.h; sourceTree = "<group>"; };
-		4A6C4C2613532FC300FDD53F /* Frame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Frame.cpp; sourceTree = "<group>"; };
-		4A6C4C2713532FC300FDD53F /* Frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Frame.h; sourceTree = "<group>"; };
-		4A6C4C2813532FC300FDD53F /* GalacticView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GalacticView.cpp; sourceTree = "<group>"; };
-		4A6C4C2913532FC300FDD53F /* GalacticView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GalacticView.h; sourceTree = "<group>"; };
-		4A6C4C2C13532FC300FDD53F /* gameconsts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gameconsts.h; sourceTree = "<group>"; };
-		4A6C4C2D13532FC300FDD53F /* GameMenuView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameMenuView.cpp; sourceTree = "<group>"; };
-		4A6C4C2E13532FC300FDD53F /* GameMenuView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameMenuView.h; sourceTree = "<group>"; };
-		4A6C4C3113532FC300FDD53F /* GeoSphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoSphere.cpp; sourceTree = "<group>"; };
-		4A6C4C3213532FC300FDD53F /* GeoSphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoSphere.h; sourceTree = "<group>"; };
-		4A6C4C6A13532FC300FDD53F /* HyperspaceCloud.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HyperspaceCloud.cpp; sourceTree = "<group>"; };
-		4A6C4C6B13532FC300FDD53F /* HyperspaceCloud.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HyperspaceCloud.h; sourceTree = "<group>"; };
-		4A6C4C6E13532FC300FDD53F /* IniConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IniConfig.cpp; sourceTree = "<group>"; };
-		4A6C4C6F13532FC300FDD53F /* IniConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IniConfig.h; sourceTree = "<group>"; };
-		4A6C4C7013532FC300FDD53F /* KeyBindings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyBindings.cpp; sourceTree = "<group>"; };
-		4A6C4C7113532FC300FDD53F /* KeyBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyBindings.h; sourceTree = "<group>"; };
-		4A6C4C7213532FC300FDD53F /* libs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libs.h; sourceTree = "<group>"; };
-		4A6C4CD013532FC300FDD53F /* LuaChatForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaChatForm.cpp; sourceTree = "<group>"; };
-		4A6C4CD113532FC300FDD53F /* LuaChatForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaChatForm.h; sourceTree = "<group>"; };
-		4A6C4CD313532FC300FDD53F /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
-		4A6C4CD713532FC300FDD53F /* MarketAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MarketAgent.cpp; sourceTree = "<group>"; };
-		4A6C4CD813532FC300FDD53F /* MarketAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MarketAgent.h; sourceTree = "<group>"; };
-		4A6C4CD913532FC300FDD53F /* matrix4x4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = matrix4x4.h; sourceTree = "<group>"; };
-		4A6C4CDA13532FC300FDD53F /* Missile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Missile.cpp; sourceTree = "<group>"; };
-		4A6C4CDB13532FC300FDD53F /* Missile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Missile.h; sourceTree = "<group>"; };
-		4A6C4CDE13532FC300FDD53F /* ModelBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelBody.cpp; sourceTree = "<group>"; };
-		4A6C4CDF13532FC300FDD53F /* ModelBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelBody.h; sourceTree = "<group>"; };
-		4A6C4CE813532FC300FDD53F /* Object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Object.h; sourceTree = "<group>"; };
-		4A6C4CE913532FC300FDD53F /* ObjectViewerView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjectViewerView.cpp; sourceTree = "<group>"; };
-		4A6C4CEA13532FC300FDD53F /* ObjectViewerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectViewerView.h; sourceTree = "<group>"; };
-		4A6C4D2C13532FC300FDD53F /* perlin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = perlin.cpp; sourceTree = "<group>"; };
-		4A6C4D2D13532FC300FDD53F /* perlin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = perlin.h; sourceTree = "<group>"; };
-		4A6C4D2E13532FC300FDD53F /* PersistSystemData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PersistSystemData.h; sourceTree = "<group>"; };
-		4A6C4D2F13532FC300FDD53F /* Pi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Pi.cpp; sourceTree = "<group>"; };
-		4A6C4D3013532FC300FDD53F /* Pi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Pi.h; sourceTree = "<group>"; };
-		4A6C4D3913532FC300FDD53F /* Planet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Planet.cpp; sourceTree = "<group>"; };
-		4A6C4D3A13532FC300FDD53F /* Planet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Planet.h; sourceTree = "<group>"; };
-		4A6C4D3B13532FC300FDD53F /* Player.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Player.cpp; sourceTree = "<group>"; };
-		4A6C4D3C13532FC300FDD53F /* Player.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Player.h; sourceTree = "<group>"; };
-		4A6C4D3F13532FC300FDD53F /* Polit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Polit.cpp; sourceTree = "<group>"; };
-		4A6C4D4013532FC300FDD53F /* Polit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Polit.h; sourceTree = "<group>"; };
-		4A6C4D4113532FC300FDD53F /* Projectile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Projectile.cpp; sourceTree = "<group>"; };
-		4A6C4D4213532FC300FDD53F /* Projectile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Projectile.h; sourceTree = "<group>"; };
-		4A6C4D4313532FC300FDD53F /* Quaternion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Quaternion.h; sourceTree = "<group>"; };
-		4A6C4D4813532FC300FDD53F /* SectorView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SectorView.cpp; sourceTree = "<group>"; };
-		4A6C4D4913532FC300FDD53F /* SectorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SectorView.h; sourceTree = "<group>"; };
-		4A6C4D4A13532FC300FDD53F /* Serializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Serializer.cpp; sourceTree = "<group>"; };
-		4A6C4D4B13532FC300FDD53F /* Serializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Serializer.h; sourceTree = "<group>"; };
-		4A6C4D4C13532FC300FDD53F /* Sfx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sfx.cpp; sourceTree = "<group>"; };
-		4A6C4D4D13532FC300FDD53F /* Sfx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sfx.h; sourceTree = "<group>"; };
-		4A6C4D4E13532FC300FDD53F /* Ship-AI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "Ship-AI.cpp"; sourceTree = "<group>"; };
-		4A6C4D4F13532FC300FDD53F /* Ship.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Ship.cpp; sourceTree = "<group>"; };
-		4A6C4D5013532FC300FDD53F /* Ship.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ship.h; sourceTree = "<group>"; };
-		4A6C4D5113532FC300FDD53F /* ShipAICmd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipAICmd.cpp; sourceTree = "<group>"; };
-		4A6C4D5213532FC300FDD53F /* ShipAICmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipAICmd.h; sourceTree = "<group>"; };
-		4A6C4D5313532FC300FDD53F /* ShipCpanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipCpanel.cpp; sourceTree = "<group>"; };
-		4A6C4D5413532FC300FDD53F /* ShipCpanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipCpanel.h; sourceTree = "<group>"; };
-		4A6C4D5513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipCpanelMultiFuncDisplays.cpp; sourceTree = "<group>"; };
-		4A6C4D5613532FC300FDD53F /* ShipCpanelMultiFuncDisplays.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipCpanelMultiFuncDisplays.h; sourceTree = "<group>"; };
-		4A6C4D5913532FC300FDD53F /* ShipType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShipType.cpp; sourceTree = "<group>"; };
-		4A6C4D5A13532FC300FDD53F /* ShipType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShipType.h; sourceTree = "<group>"; };
-		4A6C4D5B13532FC300FDD53F /* Sound.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sound.cpp; sourceTree = "<group>"; };
-		4A6C4D5C13532FC300FDD53F /* Sound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sound.h; sourceTree = "<group>"; };
-		4A6C4D5D13532FC300FDD53F /* Space.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Space.cpp; sourceTree = "<group>"; };
-		4A6C4D5E13532FC300FDD53F /* Space.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Space.h; sourceTree = "<group>"; };
-		4A6C4D5F13532FC300FDD53F /* SpaceStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpaceStation.cpp; sourceTree = "<group>"; };
-		4A6C4D6013532FC300FDD53F /* SpaceStation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpaceStation.h; sourceTree = "<group>"; };
-		4A6C4D6113532FC300FDD53F /* SpaceStationView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpaceStationView.cpp; sourceTree = "<group>"; };
-		4A6C4D6213532FC300FDD53F /* SpaceStationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpaceStationView.h; sourceTree = "<group>"; };
-		4A6C4D6313532FC300FDD53F /* Star.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Star.cpp; sourceTree = "<group>"; };
-		4A6C4D6413532FC300FDD53F /* Star.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Star.h; sourceTree = "<group>"; };
-		4A6C4D6913532FC300FDD53F /* SystemInfoView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemInfoView.cpp; sourceTree = "<group>"; };
-		4A6C4D6A13532FC300FDD53F /* SystemInfoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemInfoView.h; sourceTree = "<group>"; };
-		4A6C4D6B13532FC300FDD53F /* SystemView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemView.cpp; sourceTree = "<group>"; };
-		4A6C4D6C13532FC300FDD53F /* SystemView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemView.h; sourceTree = "<group>"; };
-		4A6C4D6E13532FC300FDD53F /* utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = utils.cpp; sourceTree = "<group>"; };
-		4A6C4D6F13532FC300FDD53F /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
-		4A6C4D7013532FC300FDD53F /* vector3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vector3.h; sourceTree = "<group>"; };
-		4A6C4D7113532FC300FDD53F /* View.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = View.h; sourceTree = "<group>"; };
-		4A6C4D7213532FC300FDD53F /* WorldView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorldView.cpp; sourceTree = "<group>"; };
-		4A6C4D7313532FC300FDD53F /* WorldView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorldView.h; sourceTree = "<group>"; };
 		4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libsigc-2.0.0.dylib"; path = "/opt/local/lib/libsigc-2.0.0.dylib"; sourceTree = "<absolute>"; };
 		4A6C55141354655000FDD53F /* data */ = {isa = PBXFileReference; lastKnownFileType = folder; name = data; path = ../data; sourceTree = "<group>"; };
-		4A712411170EC89000BB9BCC /* Orbit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Orbit.cpp; sourceTree = "<group>"; };
-		4A712412170EC89000BB9BCC /* Orbit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Orbit.h; sourceTree = "<group>"; };
-		4A76111C1611A76C00A06F79 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/OpenGL.framework; sourceTree = DEVELOPER_DIR; };
-		4A76111F1611A7B000A06F79 /* libpng15.15.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpng15.15.dylib; path = /opt/local/lib/libpng15.15.dylib; sourceTree = "<absolute>"; };
-		4A7611211611A80C00A06F79 /* libz.1.2.7.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.2.7.dylib; path = /opt/local/lib/libz.1.2.7.dylib; sourceTree = "<absolute>"; };
-		4A7611251611A8C800A06F79 /* libGLEW.1.9.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libGLEW.1.9.0.dylib; path = /opt/local/lib/libGLEW.1.9.0.dylib; sourceTree = "<absolute>"; };
 		4A7611281611A90B00A06F79 /* libFLAC.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libFLAC.8.dylib; path = /opt/local/lib/libFLAC.8.dylib; sourceTree = "<absolute>"; };
 		4A76112B1611AA5F00A06F79 /* CC-BY-SA-3.0.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "CC-BY-SA-3.0.txt"; path = "../licenses/CC-BY-SA-3.0.txt"; sourceTree = "<group>"; };
 		4A76112C1611AA5F00A06F79 /* GPL-3.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "GPL-3.txt"; path = "../licenses/GPL-3.txt"; sourceTree = "<group>"; };
 		4A76112D1611AA5F00A06F79 /* SIL-1.1.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "SIL-1.1.txt"; path = "../licenses/SIL-1.1.txt"; sourceTree = "<group>"; };
-		4A82AA7D1386969B0028CCED /* GameConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GameConfig.cpp; sourceTree = "<group>"; };
-		4A82AA7E1386969B0028CCED /* GameConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GameConfig.h; sourceTree = "<group>"; };
-		4A82AA7F1386969B0028CCED /* LuaObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaObject.h; sourceTree = "<group>"; };
-		4A84CB7B14595D850051C848 /* enum_table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = enum_table.cpp; sourceTree = "<group>"; };
-		4A84CB7C14595D850051C848 /* enum_table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enum_table.h; sourceTree = "<group>"; };
-		4A84CB82146027DC0051C848 /* Camera.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Camera.cpp; sourceTree = "<group>"; };
-		4A84CB83146027DC0051C848 /* Camera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Camera.h; sourceTree = "<group>"; };
 		4A8563FC148655DA008121E1 /* pioneer-logo.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = "pioneer-logo.icns"; sourceTree = "<group>"; };
-		4A85A86313C4631D00C2B986 /* LuaMusic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMusic.cpp; sourceTree = "<group>"; };
-		4A85A86413C4631D00C2B986 /* LuaMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaMusic.h; sourceTree = "<group>"; };
-		4A85A86513C4631D00C2B986 /* LuaSystemPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSystemPath.cpp; sourceTree = "<group>"; };
-		4A85A86713C4631D00C2B986 /* SoundMusic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SoundMusic.cpp; sourceTree = "<group>"; };
-		4A85A86813C4631D00C2B986 /* SoundMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundMusic.h; sourceTree = "<group>"; };
-		4A8AE19217208CE40005C2D9 /* LuaPropertiedObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaPropertiedObject.cpp; sourceTree = "<group>"; };
-		4A8AE19317208CE40005C2D9 /* PropertiedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PropertiedObject.h; sourceTree = "<group>"; };
-		4A8AE19417208CE40005C2D9 /* PropertyMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PropertyMap.cpp; sourceTree = "<group>"; };
-		4A8AE19517208CE50005C2D9 /* PropertyMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PropertyMap.h; sourceTree = "<group>"; };
-		4A8DD539142E19B6006DD821 /* LuaConsole.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaConsole.cpp; sourceTree = "<group>"; };
-		4A8DD53A142E19B6006DD821 /* LuaConsole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaConsole.h; sourceTree = "<group>"; };
-		4A9174F215187B69006A15A9 /* GuiTexturedQuad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GuiTexturedQuad.cpp; sourceTree = "<group>"; };
-		4A9174F315187B69006A15A9 /* GuiTexturedQuad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuiTexturedQuad.h; sourceTree = "<group>"; };
-		4A9174F615187B97006A15A9 /* Texture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Texture.h; sourceTree = "<group>"; };
-		4A9174F715187B97006A15A9 /* TextureBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureBuilder.cpp; sourceTree = "<group>"; };
-		4A9174F815187B97006A15A9 /* TextureBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureBuilder.h; sourceTree = "<group>"; };
-		4A9174F915187B97006A15A9 /* TextureGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureGL.cpp; sourceTree = "<group>"; };
-		4A9174FA15187B97006A15A9 /* TextureGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureGL.h; sourceTree = "<group>"; };
-		4A9174FD15187C17006A15A9 /* Color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Color.cpp; sourceTree = "<group>"; };
-		4A94CA4014F26875002CA792 /* EquipSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EquipSet.h; sourceTree = "<group>"; };
-		4A94CA4114F26875002CA792 /* FontCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontCache.cpp; sourceTree = "<group>"; };
-		4A94CA4214F26875002CA792 /* FontCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontCache.h; sourceTree = "<group>"; };
-		4A973BF31618688F0029562D /* DeathView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeathView.cpp; sourceTree = "<group>"; };
-		4A973BF41618688F0029562D /* DeathView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeathView.h; sourceTree = "<group>"; };
-		4A973BF51618688F0029562D /* LuaDev.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaDev.cpp; sourceTree = "<group>"; };
-		4A973BF61618688F0029562D /* LuaDev.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaDev.h; sourceTree = "<group>"; };
 		4A9822AA142DF93D00B423F1 /* AUTHORS.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = AUTHORS.txt; path = ../AUTHORS.txt; sourceTree = "<group>"; };
 		4A9822AD142E00B100B423F1 /* Quickstart.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Quickstart.txt; path = ../Quickstart.txt; sourceTree = "<group>"; };
 		4A9822AE142E00B100B423F1 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.txt; path = ../README.txt; sourceTree = "<group>"; };
 		4A9822B3142E02AF00B423F1 /* Changelog.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Changelog.txt; path = ../Changelog.txt; sourceTree = "<group>"; };
-		4A99371A1368355400EA0EE5 /* DeleteEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeleteEmitter.h; sourceTree = "<group>"; };
-		4A99371B1368355400EA0EE5 /* LuaBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaBody.cpp; sourceTree = "<group>"; };
-		4A99371D1368355400EA0EE5 /* LuaCargoBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaCargoBody.cpp; sourceTree = "<group>"; };
-		4A99371F1368355500EA0EE5 /* LuaConstants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaConstants.cpp; sourceTree = "<group>"; };
-		4A9937201368355500EA0EE5 /* LuaConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaConstants.h; sourceTree = "<group>"; };
-		4A9937211368355500EA0EE5 /* LuaEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaEngine.cpp; sourceTree = "<group>"; };
-		4A9937221368355500EA0EE5 /* LuaEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaEngine.h; sourceTree = "<group>"; };
-		4A9937271368355500EA0EE5 /* LuaFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFormat.cpp; sourceTree = "<group>"; };
-		4A9937281368355500EA0EE5 /* LuaFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaFormat.h; sourceTree = "<group>"; };
-		4A9937291368355500EA0EE5 /* LuaGame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaGame.cpp; sourceTree = "<group>"; };
-		4A99372A1368355500EA0EE5 /* LuaGame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaGame.h; sourceTree = "<group>"; };
-		4A99372B1368355500EA0EE5 /* LuaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaManager.cpp; sourceTree = "<group>"; };
-		4A99372C1368355500EA0EE5 /* LuaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaManager.h; sourceTree = "<group>"; };
-		4A99372D1368355500EA0EE5 /* LuaNameGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaNameGen.cpp; sourceTree = "<group>"; };
-		4A99372E1368355500EA0EE5 /* LuaNameGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaNameGen.h; sourceTree = "<group>"; };
-		4A99372F1368355500EA0EE5 /* LuaObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaObject.cpp; sourceTree = "<group>"; };
-		4A9937301368355500EA0EE5 /* LuaPlanet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaPlanet.cpp; sourceTree = "<group>"; };
-		4A9937321368355500EA0EE5 /* LuaPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaPlayer.cpp; sourceTree = "<group>"; };
-		4A9937341368355500EA0EE5 /* LuaRand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaRand.cpp; sourceTree = "<group>"; };
-		4A99373A1368355500EA0EE5 /* LuaSerializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSerializer.cpp; sourceTree = "<group>"; };
-		4A99373B1368355500EA0EE5 /* LuaSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaSerializer.h; sourceTree = "<group>"; };
-		4A99373C1368355500EA0EE5 /* LuaShip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaShip.cpp; sourceTree = "<group>"; };
-		4A9937401368355500EA0EE5 /* LuaSpace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSpace.cpp; sourceTree = "<group>"; };
-		4A9937411368355500EA0EE5 /* LuaSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaSpace.h; sourceTree = "<group>"; };
-		4A9937421368355500EA0EE5 /* LuaSpaceStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSpaceStation.cpp; sourceTree = "<group>"; };
-		4A9937441368355500EA0EE5 /* LuaStar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaStar.cpp; sourceTree = "<group>"; };
-		4A9937461368355500EA0EE5 /* LuaStarSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaStarSystem.cpp; sourceTree = "<group>"; };
-		4A9937481368355500EA0EE5 /* LuaTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaTimer.cpp; sourceTree = "<group>"; };
-		4A9937491368355500EA0EE5 /* LuaTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaTimer.h; sourceTree = "<group>"; };
-		4A99374C1368355500EA0EE5 /* LuaUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaUtils.cpp; sourceTree = "<group>"; };
-		4A99374D1368355500EA0EE5 /* LuaUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaUtils.h; sourceTree = "<group>"; };
-		4A99374E1368355500EA0EE5 /* RefCounted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RefCounted.h; sourceTree = "<group>"; };
-		4A99374F1368355500EA0EE5 /* RefList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RefList.h; sourceTree = "<group>"; };
-		4AA4A8D4164D0EB10006C3BF /* Expand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Expand.cpp; sourceTree = "<group>"; };
-		4AA4A8D5164D0EB10006C3BF /* Expand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Expand.h; sourceTree = "<group>"; };
-		4AA4A8D6164D0EB10006C3BF /* Gradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Gradient.cpp; sourceTree = "<group>"; };
-		4AA4A8D7164D0EB10006C3BF /* Gradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gradient.h; sourceTree = "<group>"; };
-		4AA4A8D8164D0EB10006C3BF /* LuaExpand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaExpand.cpp; sourceTree = "<group>"; };
-		4AA4A8D9164D0EB10006C3BF /* LuaGradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaGradient.cpp; sourceTree = "<group>"; };
-		4AA527F716E9EABA0036D4CB /* Easing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Easing.h; sourceTree = "<group>"; };
-		4AA527F816E9EABA0036D4CB /* NavLights.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NavLights.cpp; sourceTree = "<group>"; };
-		4AA527F916E9EABA0036D4CB /* NavLights.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NavLights.h; sourceTree = "<group>"; };
-		4AA527FB16E9EB650036D4CB /* LuaModelSpinner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaModelSpinner.cpp; sourceTree = "<group>"; };
-		4AA527FC16E9EB650036D4CB /* ModelSpinner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelSpinner.cpp; sourceTree = "<group>"; };
-		4AA527FD16E9EB650036D4CB /* ModelSpinner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelSpinner.h; sourceTree = "<group>"; };
-		4AA5280016E9EB980036D4CB /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lua.cpp; sourceTree = "<group>"; };
-		4AA5280116E9EB980036D4CB /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lua.h; sourceTree = "<group>"; };
-		4AA5280216E9EB980036D4CB /* ModelSkin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelSkin.cpp; sourceTree = "<group>"; };
-		4AA5280316E9EB980036D4CB /* ModelSkin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelSkin.h; sourceTree = "<group>"; };
-		4AA5280416E9EB980036D4CB /* NodeCopyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NodeCopyCache.h; sourceTree = "<group>"; };
-		4AA5280716E9EBD60036D4CB /* LuaModelSkin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaModelSkin.cpp; sourceTree = "<group>"; };
-		4AA84A2116D0E18700220311 /* LuaEquipDef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaEquipDef.cpp; sourceTree = "<group>"; };
-		4AA84A2216D0E18700220311 /* LuaEquipDef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaEquipDef.h; sourceTree = "<group>"; };
-		4AA84A2316D0E18700220311 /* LuaShipDef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaShipDef.cpp; sourceTree = "<group>"; };
-		4AA84A2416D0E18700220311 /* LuaShipDef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaShipDef.h; sourceTree = "<group>"; };
-		4AA84A2516D0E18700220311 /* LuaWrappable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaWrappable.h; sourceTree = "<group>"; };
-		4AA84A2616D0E18700220311 /* Random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Random.h; sourceTree = "<group>"; };
-		4AA9F6CB17288E0900124C2E /* TerrainHeightEllipsoid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightEllipsoid.cpp; sourceTree = "<group>"; };
-		4AAB880415F4AD3500AAF8A8 /* GeoSphereMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoSphereMaterial.cpp; sourceTree = "<group>"; };
-		4AAB880515F4AD3500AAF8A8 /* GeoSphereMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoSphereMaterial.h; sourceTree = "<group>"; };
-		4AAB880615F4AD3500AAF8A8 /* GL2Material.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GL2Material.cpp; sourceTree = "<group>"; };
-		4AAB880715F4AD3500AAF8A8 /* GL2Material.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GL2Material.h; sourceTree = "<group>"; };
-		4AAB880815F4AD3500AAF8A8 /* MultiMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MultiMaterial.cpp; sourceTree = "<group>"; };
-		4AAB880915F4AD3500AAF8A8 /* MultiMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiMaterial.h; sourceTree = "<group>"; };
-		4AAB880A15F4AD3500AAF8A8 /* Program.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Program.cpp; sourceTree = "<group>"; };
-		4AAB880B15F4AD3500AAF8A8 /* Program.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Program.h; sourceTree = "<group>"; };
-		4AAB880C15F4AD3500AAF8A8 /* RingMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RingMaterial.cpp; sourceTree = "<group>"; };
-		4AAB880D15F4AD3500AAF8A8 /* RingMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RingMaterial.h; sourceTree = "<group>"; };
-		4AAB880E15F4AD3500AAF8A8 /* StarfieldMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StarfieldMaterial.h; sourceTree = "<group>"; };
-		4AAB880F15F4AD3500AAF8A8 /* Uniform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Uniform.cpp; sourceTree = "<group>"; };
-		4AAB881015F4AD3500AAF8A8 /* Uniform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Uniform.h; sourceTree = "<group>"; };
-		4AAB881115F4AD3500AAF8A8 /* MaterialLegacy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MaterialLegacy.cpp; sourceTree = "<group>"; };
-		4AAB881215F4AD3500AAF8A8 /* MaterialLegacy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialLegacy.h; sourceTree = "<group>"; };
-		4AAB881A15F4AD7700AAF8A8 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lua.cpp; sourceTree = "<group>"; };
-		4AAB881B15F4AD7700AAF8A8 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lua.h; sourceTree = "<group>"; };
-		4AAB881C15F4AD7700AAF8A8 /* OS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OS.h; sourceTree = "<group>"; };
-		4AAB884415FDEA6E00AAF8A8 /* LuaPushPull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaPushPull.h; sourceTree = "<group>"; };
-		4AAB884515FDEA6E00AAF8A8 /* LuaRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaRef.cpp; sourceTree = "<group>"; };
-		4AAB884615FDEA6F00AAF8A8 /* LuaRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaRef.h; sourceTree = "<group>"; };
-		4AAB884715FDEA6F00AAF8A8 /* LuaTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaTable.h; sourceTree = "<group>"; };
-		4AAB884A15FE070900AAF8A8 /* AnimationCurves.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnimationCurves.h; sourceTree = "<group>"; };
-		4AAC9FDE15458FE400116131 /* miniz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = miniz.c; sourceTree = "<group>"; };
-		4AAC9FDF15458FE400116131 /* miniz.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = miniz.h; sourceTree = "<group>"; };
-		4AAC9FE51545901D00116131 /* FileSourceZip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSourceZip.cpp; sourceTree = "<group>"; };
-		4AAC9FE61545901D00116131 /* FileSourceZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileSourceZip.h; sourceTree = "<group>"; };
-		4AAC9FE71545901D00116131 /* ModManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModManager.cpp; sourceTree = "<group>"; };
-		4AAC9FE81545901D00116131 /* ModManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModManager.h; sourceTree = "<group>"; };
-		4AB3DF8714346952001B783A /* TerrainBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainBody.cpp; sourceTree = "<group>"; };
-		4AB3DF8814346952001B783A /* TerrainBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TerrainBody.h; sourceTree = "<group>"; };
-		4AB7D5D11472A83E00158DE4 /* Terrain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Terrain.cpp; sourceTree = "<group>"; };
-		4AB7D5D21472A83E00158DE4 /* Terrain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Terrain.h; sourceTree = "<group>"; };
-		4AB7D5D31472A83E00158DE4 /* TerrainColorAsteroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorAsteroid.cpp; sourceTree = "<group>"; };
-		4AB7D5D41472A83E00158DE4 /* TerrainColorBandedRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorBandedRock.cpp; sourceTree = "<group>"; };
-		4AB7D5D51472A83E00158DE4 /* TerrainColorDeadWithWater.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorDeadWithWater.cpp; sourceTree = "<group>"; };
-		4AB7D5D61472A83E00158DE4 /* TerrainColorDesert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorDesert.cpp; sourceTree = "<group>"; };
-		4AB7D5D71472A83E00158DE4 /* TerrainColorEarthLike.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorEarthLike.cpp; sourceTree = "<group>"; };
-		4AB7D5D81472A83E00158DE4 /* TerrainColorGGJupiter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGJupiter.cpp; sourceTree = "<group>"; };
-		4AB7D5D91472A83E00158DE4 /* TerrainColorGGNeptune.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGNeptune.cpp; sourceTree = "<group>"; };
-		4AB7D5DA1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGNeptune2.cpp; sourceTree = "<group>"; };
-		4AB7D5DB1472A83E00158DE4 /* TerrainColorGGSaturn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGSaturn.cpp; sourceTree = "<group>"; };
-		4AB7D5DC1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGSaturn2.cpp; sourceTree = "<group>"; };
-		4AB7D5DD1472A83E00158DE4 /* TerrainColorGGUranus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorGGUranus.cpp; sourceTree = "<group>"; };
-		4AB7D5DE1472A83E00158DE4 /* TerrainColorIce.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorIce.cpp; sourceTree = "<group>"; };
-		4AB7D5DF1472A83E00158DE4 /* TerrainColorMethane.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorMethane.cpp; sourceTree = "<group>"; };
-		4AB7D5E01472A83E00158DE4 /* TerrainColorRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorRock.cpp; sourceTree = "<group>"; };
-		4AB7D5E11472A83E00158DE4 /* TerrainColorRock2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorRock2.cpp; sourceTree = "<group>"; };
-		4AB7D5E21472A83E00158DE4 /* TerrainColorSolid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorSolid.cpp; sourceTree = "<group>"; };
-		4AB7D5E31472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarBrownDwarf.cpp; sourceTree = "<group>"; };
-		4AB7D5E41472A83E00158DE4 /* TerrainColorStarG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarG.cpp; sourceTree = "<group>"; };
-		4AB7D5E51472A83E00158DE4 /* TerrainColorStarK.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarK.cpp; sourceTree = "<group>"; };
-		4AB7D5E61472A83E00158DE4 /* TerrainColorStarM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarM.cpp; sourceTree = "<group>"; };
-		4AB7D5E71472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorStarWhiteDwarf.cpp; sourceTree = "<group>"; };
-		4AB7D5E81472A83E00158DE4 /* TerrainColorTFGood.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorTFGood.cpp; sourceTree = "<group>"; };
-		4AB7D5E91472A83E00158DE4 /* TerrainColorTFPoor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorTFPoor.cpp; sourceTree = "<group>"; };
-		4AB7D5EA1472A83E00158DE4 /* TerrainColorVolcanic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainColorVolcanic.cpp; sourceTree = "<group>"; };
-		4AB7D5EB1472A83E00158DE4 /* TerrainFeature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainFeature.cpp; sourceTree = "<group>"; };
-		4AB7D5EC1472A83E00158DE4 /* TerrainFeature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TerrainFeature.h; sourceTree = "<group>"; };
-		4AB7D5ED1472A83E00158DE4 /* TerrainHeightAsteroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightAsteroid.cpp; sourceTree = "<group>"; };
-		4AB7D5EE1472A83E00158DE4 /* TerrainHeightFlat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightFlat.cpp; sourceTree = "<group>"; };
-		4AB7D5EF1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsCraters.cpp; sourceTree = "<group>"; };
-		4AB7D5F01472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsCraters2.cpp; sourceTree = "<group>"; };
-		4AB7D5F11472A83E00158DE4 /* TerrainHeightHillsDunes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsDunes.cpp; sourceTree = "<group>"; };
-		4AB7D5F21472A83E00158DE4 /* TerrainHeightHillsNormal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsNormal.cpp; sourceTree = "<group>"; };
-		4AB7D5F31472A83E00158DE4 /* TerrainHeightHillsRidged.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsRidged.cpp; sourceTree = "<group>"; };
-		4AB7D5F41472A83E00158DE4 /* TerrainHeightHillsRivers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightHillsRivers.cpp; sourceTree = "<group>"; };
-		4AB7D5F51472A83E00158DE4 /* TerrainHeightMapped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMapped.cpp; sourceTree = "<group>"; };
-		4AB7D5F61472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsCraters.cpp; sourceTree = "<group>"; };
-		4AB7D5F71472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsCraters2.cpp; sourceTree = "<group>"; };
-		4AB7D5F81472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsNormal.cpp; sourceTree = "<group>"; };
-		4AB7D5F91472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsRidged.cpp; sourceTree = "<group>"; };
-		4AB7D5FA1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsRivers.cpp; sourceTree = "<group>"; };
-		4AB7D5FB1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsRiversVolcano.cpp; sourceTree = "<group>"; };
-		4AB7D5FC1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMountainsVolcano.cpp; sourceTree = "<group>"; };
-		4AB7D5FD1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightRuggedDesert.cpp; sourceTree = "<group>"; };
-		4AB7D5FE1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightRuggedLava.cpp; sourceTree = "<group>"; };
-		4AB7D5FF1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightWaterSolid.cpp; sourceTree = "<group>"; };
-		4AB7D6001472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightWaterSolidCanyons.cpp; sourceTree = "<group>"; };
-		4AB7D6011472A83E00158DE4 /* TerrainNoise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TerrainNoise.h; sourceTree = "<group>"; };
-		4ABF302E16335A1100664653 /* Align.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Align.cpp; sourceTree = "<group>"; };
-		4ABF302F16335A1100664653 /* Align.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Align.h; sourceTree = "<group>"; };
-		4ABF303016335A1100664653 /* Background.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Background.cpp; sourceTree = "<group>"; };
-		4ABF303116335A1100664653 /* Background.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Background.h; sourceTree = "<group>"; };
-		4ABF303216335A1100664653 /* Box.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Box.cpp; sourceTree = "<group>"; };
-		4ABF303316335A1100664653 /* Box.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Box.h; sourceTree = "<group>"; };
-		4ABF303416335A1100664653 /* Button.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Button.cpp; sourceTree = "<group>"; };
-		4ABF303516335A1100664653 /* Button.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Button.h; sourceTree = "<group>"; };
-		4ABF303616335A1100664653 /* CellSpec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CellSpec.cpp; sourceTree = "<group>"; };
-		4ABF303716335A1100664653 /* CellSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CellSpec.h; sourceTree = "<group>"; };
-		4ABF303816335A1100664653 /* CheckBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CheckBox.cpp; sourceTree = "<group>"; };
-		4ABF303916335A1100664653 /* CheckBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CheckBox.h; sourceTree = "<group>"; };
-		4ABF303A16335A1100664653 /* ColorBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColorBackground.cpp; sourceTree = "<group>"; };
-		4ABF303B16335A1100664653 /* ColorBackground.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorBackground.h; sourceTree = "<group>"; };
-		4ABF303C16335A1100664653 /* Container.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Container.cpp; sourceTree = "<group>"; };
-		4ABF303D16335A1100664653 /* Container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Container.h; sourceTree = "<group>"; };
-		4ABF303E16335A1100664653 /* Context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Context.cpp; sourceTree = "<group>"; };
-		4ABF303F16335A1100664653 /* Context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Context.h; sourceTree = "<group>"; };
-		4ABF304016335A1100664653 /* DropDown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DropDown.cpp; sourceTree = "<group>"; };
-		4ABF304116335A1100664653 /* DropDown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DropDown.h; sourceTree = "<group>"; };
-		4ABF304216335A1100664653 /* Event.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Event.cpp; sourceTree = "<group>"; };
-		4ABF304316335A1100664653 /* Event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Event.h; sourceTree = "<group>"; };
-		4ABF304416335A1100664653 /* EventDispatcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventDispatcher.cpp; sourceTree = "<group>"; };
-		4ABF304516335A1100664653 /* EventDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventDispatcher.h; sourceTree = "<group>"; };
-		4ABF304616335A1100664653 /* FloatContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatContainer.cpp; sourceTree = "<group>"; };
-		4ABF304716335A1100664653 /* FloatContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FloatContainer.h; sourceTree = "<group>"; };
-		4ABF304816335A1100664653 /* Grid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Grid.cpp; sourceTree = "<group>"; };
-		4ABF304916335A1100664653 /* Grid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Grid.h; sourceTree = "<group>"; };
-		4ABF304A16335A1100664653 /* Image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Image.cpp; sourceTree = "<group>"; };
-		4ABF304B16335A1100664653 /* Image.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Image.h; sourceTree = "<group>"; };
-		4ABF304C16335A1100664653 /* Label.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Label.cpp; sourceTree = "<group>"; };
-		4ABF304D16335A1100664653 /* Label.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Label.h; sourceTree = "<group>"; };
-		4ABF304E16335A1100664653 /* List.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = List.cpp; sourceTree = "<group>"; };
-		4ABF304F16335A1100664653 /* List.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = List.h; sourceTree = "<group>"; };
-		4ABF305016335A1100664653 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lua.cpp; sourceTree = "<group>"; };
-		4ABF305116335A1100664653 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Lua.h; sourceTree = "<group>"; };
-		4ABF305216335A1100664653 /* LuaAlign.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaAlign.cpp; sourceTree = "<group>"; };
-		4ABF305316335A1100664653 /* LuaBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaBackground.cpp; sourceTree = "<group>"; };
-		4ABF305416335A1100664653 /* LuaBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaBox.cpp; sourceTree = "<group>"; };
-		4ABF305516335A1100664653 /* LuaButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaButton.cpp; sourceTree = "<group>"; };
-		4ABF305616335A1100664653 /* LuaCheckBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaCheckBox.cpp; sourceTree = "<group>"; };
-		4ABF305716335A1100664653 /* LuaColorBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaColorBackground.cpp; sourceTree = "<group>"; };
-		4ABF305816335A1100664653 /* LuaContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaContainer.cpp; sourceTree = "<group>"; };
-		4ABF305916335A1100664653 /* LuaContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaContext.cpp; sourceTree = "<group>"; };
-		4ABF305A16335A1100664653 /* LuaDropDown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaDropDown.cpp; sourceTree = "<group>"; };
-		4ABF305B16335A1100664653 /* LuaGrid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaGrid.cpp; sourceTree = "<group>"; };
-		4ABF305C16335A1100664653 /* LuaImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaImage.cpp; sourceTree = "<group>"; };
-		4ABF305D16335A1100664653 /* LuaLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaLabel.cpp; sourceTree = "<group>"; };
-		4ABF305E16335A1100664653 /* LuaList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaList.cpp; sourceTree = "<group>"; };
-		4ABF305F16335A1100664653 /* LuaMargin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMargin.cpp; sourceTree = "<group>"; };
-		4ABF306016335A1100664653 /* LuaMultiLineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMultiLineText.cpp; sourceTree = "<group>"; };
-		4ABF306116335A1100664653 /* LuaScroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaScroller.cpp; sourceTree = "<group>"; };
-		4ABF306216335A1100664653 /* LuaSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaSignal.h; sourceTree = "<group>"; };
-		4ABF306316335A1100664653 /* LuaSingle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSingle.cpp; sourceTree = "<group>"; };
-		4ABF306416335A1100664653 /* LuaSlider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSlider.cpp; sourceTree = "<group>"; };
-		4ABF306516335A1100664653 /* LuaWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaWidget.cpp; sourceTree = "<group>"; };
-		4ABF306716335A1100664653 /* Margin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Margin.cpp; sourceTree = "<group>"; };
-		4ABF306816335A1100664653 /* Margin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Margin.h; sourceTree = "<group>"; };
-		4ABF306916335A1100664653 /* MultiLineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MultiLineText.cpp; sourceTree = "<group>"; };
-		4ABF306A16335A1100664653 /* MultiLineText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiLineText.h; sourceTree = "<group>"; };
-		4ABF306B16335A1100664653 /* Point.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Point.h; sourceTree = "<group>"; };
-		4ABF306C16335A1100664653 /* Scroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Scroller.cpp; sourceTree = "<group>"; };
-		4ABF306D16335A1100664653 /* Scroller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scroller.h; sourceTree = "<group>"; };
-		4ABF306E16335A1100664653 /* Single.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Single.cpp; sourceTree = "<group>"; };
-		4ABF306F16335A1100664653 /* Single.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Single.h; sourceTree = "<group>"; };
-		4ABF307016335A1100664653 /* Skin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Skin.cpp; sourceTree = "<group>"; };
-		4ABF307116335A1100664653 /* Skin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Skin.h; sourceTree = "<group>"; };
-		4ABF307216335A1100664653 /* Slider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Slider.cpp; sourceTree = "<group>"; };
-		4ABF307316335A1100664653 /* Slider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Slider.h; sourceTree = "<group>"; };
-		4ABF307416335A1100664653 /* TextLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextLayout.cpp; sourceTree = "<group>"; };
-		4ABF307516335A1100664653 /* TextLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextLayout.h; sourceTree = "<group>"; };
-		4ABF307616335A1100664653 /* Widget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Widget.cpp; sourceTree = "<group>"; };
-		4ABF307716335A1100664653 /* Widget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Widget.h; sourceTree = "<group>"; };
-		4ABF307816335A1100664653 /* WidgetSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WidgetSet.h; sourceTree = "<group>"; };
-		4ACC6D1215401E7000C59914 /* Font.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Font.cpp; sourceTree = "<group>"; };
-		4ACC6D1315401E7000C59914 /* Font.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Font.h; sourceTree = "<group>"; };
-		4ACC6D1415401E7000C59914 /* FontDescriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FontDescriptor.h; sourceTree = "<group>"; };
-		4ACC6D1615401E7000C59914 /* TextSupport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextSupport.cpp; sourceTree = "<group>"; };
-		4ACC6D1715401E7000C59914 /* TextSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextSupport.h; sourceTree = "<group>"; };
-		4ACC6D1815401E7000C59914 /* TextureFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureFont.cpp; sourceTree = "<group>"; };
-		4ACC6D1915401E7000C59914 /* TextureFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureFont.h; sourceTree = "<group>"; };
-		4ACDB684167878610069FA03 /* Animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Animation.cpp; sourceTree = "<group>"; };
-		4ACDB685167878610069FA03 /* Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Animation.h; sourceTree = "<group>"; };
-		4ACDB686167878610069FA03 /* AnimationChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnimationChannel.h; sourceTree = "<group>"; };
-		4ACDB687167878610069FA03 /* AnimationKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnimationKey.h; sourceTree = "<group>"; };
-		4ACDB688167878620069FA03 /* Billboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Billboard.cpp; sourceTree = "<group>"; };
-		4ACDB689167878620069FA03 /* Billboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Billboard.h; sourceTree = "<group>"; };
-		4ACDB68A167878620069FA03 /* CollisionGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollisionGeometry.cpp; sourceTree = "<group>"; };
-		4ACDB68B167878620069FA03 /* CollisionGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollisionGeometry.h; sourceTree = "<group>"; };
-		4ACDB68C167878620069FA03 /* CollisionVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CollisionVisitor.cpp; sourceTree = "<group>"; };
-		4ACDB68D167878620069FA03 /* CollisionVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollisionVisitor.h; sourceTree = "<group>"; };
-		4ACDB68E167878620069FA03 /* ColorMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColorMap.cpp; sourceTree = "<group>"; };
-		4ACDB68F167878620069FA03 /* ColorMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColorMap.h; sourceTree = "<group>"; };
-		4ACDB690167878620069FA03 /* DumpVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DumpVisitor.cpp; sourceTree = "<group>"; };
-		4ACDB691167878620069FA03 /* DumpVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DumpVisitor.h; sourceTree = "<group>"; };
-		4ACDB692167878620069FA03 /* FindNodeVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindNodeVisitor.cpp; sourceTree = "<group>"; };
-		4ACDB693167878620069FA03 /* FindNodeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindNodeVisitor.h; sourceTree = "<group>"; };
-		4ACDB694167878620069FA03 /* Group.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Group.cpp; sourceTree = "<group>"; };
-		4ACDB695167878620069FA03 /* Group.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Group.h; sourceTree = "<group>"; };
-		4ACDB696167878620069FA03 /* Label3D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Label3D.cpp; sourceTree = "<group>"; };
-		4ACDB697167878620069FA03 /* Label3D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Label3D.h; sourceTree = "<group>"; };
-		4ACDB698167878620069FA03 /* Loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Loader.cpp; sourceTree = "<group>"; };
-		4ACDB699167878620069FA03 /* Loader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Loader.h; sourceTree = "<group>"; };
-		4ACDB69A167878620069FA03 /* LoaderDefinitions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoaderDefinitions.h; sourceTree = "<group>"; };
-		4ACDB69B167878620069FA03 /* LOD.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LOD.cpp; sourceTree = "<group>"; };
-		4ACDB69C167878620069FA03 /* LOD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LOD.h; sourceTree = "<group>"; };
-		4ACDB69E167878620069FA03 /* MatrixTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MatrixTransform.cpp; sourceTree = "<group>"; };
-		4ACDB69F167878620069FA03 /* MatrixTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatrixTransform.h; sourceTree = "<group>"; };
-		4ACDB6A0167878620069FA03 /* Model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Model.cpp; sourceTree = "<group>"; };
-		4ACDB6A1167878620069FA03 /* Model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Model.h; sourceTree = "<group>"; };
-		4ACDB6A2167878620069FA03 /* ModelNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelNode.cpp; sourceTree = "<group>"; };
-		4ACDB6A3167878620069FA03 /* ModelNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelNode.h; sourceTree = "<group>"; };
-		4ACDB6A4167878620069FA03 /* Node.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Node.cpp; sourceTree = "<group>"; };
-		4ACDB6A5167878620069FA03 /* Node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Node.h; sourceTree = "<group>"; };
-		4ACDB6A6167878620069FA03 /* NodeVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NodeVisitor.cpp; sourceTree = "<group>"; };
-		4ACDB6A7167878620069FA03 /* NodeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NodeVisitor.h; sourceTree = "<group>"; };
-		4ACDB6A8167878620069FA03 /* Parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Parser.cpp; sourceTree = "<group>"; };
-		4ACDB6A9167878620069FA03 /* Parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Parser.h; sourceTree = "<group>"; };
-		4ACDB6AA167878620069FA03 /* Pattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Pattern.cpp; sourceTree = "<group>"; };
-		4ACDB6AB167878620069FA03 /* Pattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Pattern.h; sourceTree = "<group>"; };
-		4ACDB6AC167878620069FA03 /* SceneGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneGraph.h; sourceTree = "<group>"; };
-		4ACDB6AD167878620069FA03 /* StaticGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StaticGeometry.cpp; sourceTree = "<group>"; };
-		4ACDB6AE167878620069FA03 /* StaticGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StaticGeometry.h; sourceTree = "<group>"; };
-		4ACDB6AF167878620069FA03 /* Thruster.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Thruster.cpp; sourceTree = "<group>"; };
-		4ACDB6B0167878620069FA03 /* Thruster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Thruster.h; sourceTree = "<group>"; };
-		4ACDB6C7167878CE0069FA03 /* CollMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollMesh.h; sourceTree = "<group>"; };
-		4ACDB6CA167878CE0069FA03 /* ModelCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelCache.cpp; sourceTree = "<group>"; };
-		4ACDB6CB167878CE0069FA03 /* ModelCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelCache.h; sourceTree = "<group>"; };
-		4ACDB6CC167878CE0069FA03 /* ModelViewer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModelViewer.cpp; sourceTree = "<group>"; };
-		4ACDB6CD167878CE0069FA03 /* ModelViewer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModelViewer.h; sourceTree = "<group>"; };
-		4ACDB6D0167879AF0069FA03 /* DistanceFieldFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DistanceFieldFont.cpp; sourceTree = "<group>"; };
-		4ACDB6D1167879AF0069FA03 /* DistanceFieldFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DistanceFieldFont.h; sourceTree = "<group>"; };
 		4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libassimp.3.0.0.dylib; path = /opt/local/lib/libassimp.3.0.0.dylib; sourceTree = "<absolute>"; };
-		4ACE132C16B4B19D00CAE524 /* EnumStrings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EnumStrings.cpp; sourceTree = "<group>"; };
-		4ACE132D16B4B19D00CAE524 /* EnumStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumStrings.h; sourceTree = "<group>"; };
-		4ACE132E16B4B19D00CAE524 /* matrix3x3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = matrix3x3.h; sourceTree = "<group>"; };
-		4ACED56816BBCC7200E53808 /* LuaMissile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMissile.cpp; sourceTree = "<group>"; };
-		4ACED56916BBCC7200E53808 /* LuaMissile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaMissile.h; sourceTree = "<group>"; };
-		4ADB0D0615C50DD900AE2123 /* TerrainHeightAsteroid2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightAsteroid2.cpp; sourceTree = "<group>"; };
-		4ADB0D0715C50DD900AE2123 /* TerrainHeightAsteroid3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightAsteroid3.cpp; sourceTree = "<group>"; };
-		4ADB0D0815C50DD900AE2123 /* TerrainHeightAsteroid4.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightAsteroid4.cpp; sourceTree = "<group>"; };
-		4ADB0D0915C50DD900AE2123 /* TerrainHeightBarrenRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightBarrenRock.cpp; sourceTree = "<group>"; };
-		4ADB0D0A15C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightBarrenRock2.cpp; sourceTree = "<group>"; };
-		4ADB0D0B15C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightBarrenRock3.cpp; sourceTree = "<group>"; };
-		4ADB0D1315C50DF000AE2123 /* FileSystemPosix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystemPosix.cpp; sourceTree = "<group>"; };
-		4ADB0D1515C50DF000AE2123 /* OSPosix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OSPosix.cpp; sourceTree = "<group>"; };
-		4ADC7B7F152C703200E359B5 /* SDLWrappers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SDLWrappers.cpp; sourceTree = "<group>"; };
-		4ADC7B80152C703200E359B5 /* SDLWrappers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDLWrappers.h; sourceTree = "<group>"; };
-		4ADC7B81152C703200E359B5 /* View.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = View.cpp; sourceTree = "<group>"; };
-		4ADF51801557473400ACF5A0 /* CustomSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CustomSystem.cpp; sourceTree = "<group>"; };
-		4ADF51811557473400ACF5A0 /* CustomSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomSystem.h; sourceTree = "<group>"; };
-		4ADF51821557473400ACF5A0 /* Galaxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Galaxy.cpp; sourceTree = "<group>"; };
-		4ADF51831557473400ACF5A0 /* Galaxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Galaxy.h; sourceTree = "<group>"; };
-		4ADF51851557473400ACF5A0 /* Sector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Sector.cpp; sourceTree = "<group>"; };
-		4ADF51861557473400ACF5A0 /* Sector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Sector.h; sourceTree = "<group>"; };
-		4ADF51871557473400ACF5A0 /* StarSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StarSystem.cpp; sourceTree = "<group>"; };
-		4ADF51881557473400ACF5A0 /* StarSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StarSystem.h; sourceTree = "<group>"; };
-		4ADF51891557473400ACF5A0 /* SystemPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemPath.h; sourceTree = "<group>"; };
-		4ADF518F1557477400ACF5A0 /* LuaFixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFixed.cpp; sourceTree = "<group>"; };
-		4ADF51901557477400ACF5A0 /* LuaFixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaFixed.h; sourceTree = "<group>"; };
-		4ADF51911557477400ACF5A0 /* LuaMatrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaMatrix.cpp; sourceTree = "<group>"; };
-		4ADF51921557477400ACF5A0 /* LuaMatrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaMatrix.h; sourceTree = "<group>"; };
-		4ADF51931557477400ACF5A0 /* LuaSystemBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaSystemBody.cpp; sourceTree = "<group>"; };
-		4ADF51951557477400ACF5A0 /* LuaVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaVector.cpp; sourceTree = "<group>"; };
-		4ADF51961557477400ACF5A0 /* LuaVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaVector.h; sourceTree = "<group>"; };
-		4AE46C491607513400308C22 /* vcacheopt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vcacheopt.h; sourceTree = "<group>"; };
-		4AE5CA3A1383E2D000B55DEB /* libSDL-1.2.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL-1.2.0.dylib"; path = "/opt/local/lib/libSDL-1.2.0.dylib"; sourceTree = "<absolute>"; };
-		4AE5CA3D1383E63C00B55DEB /* libSDL_image-1.2.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL_image-1.2.0.dylib"; path = "/opt/local/lib/libSDL_image-1.2.0.dylib"; sourceTree = "<absolute>"; };
-		4AE5CA3F1383E65B00B55DEB /* libSDL_sound-1.0.1.0.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL_sound-1.0.1.0.2.dylib"; path = "/opt/local/lib/libSDL_sound-1.0.1.0.2.dylib"; sourceTree = "<absolute>"; };
-		4AE9706514369D7500424F91 /* LuaLang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaLang.cpp; sourceTree = "<group>"; };
-		4AE9706614369D7500424F91 /* LuaLang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaLang.h; sourceTree = "<group>"; };
-		4AEC8A1815C7886A00B281C3 /* Light.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Light.cpp; sourceTree = "<group>"; };
-		4AEC8A1915C7886A00B281C3 /* Light.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Light.h; sourceTree = "<group>"; };
-		4AED721C14E1501D004D171E /* TerrainHeightMapped2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerrainHeightMapped2.cpp; sourceTree = "<group>"; };
-		4AEE56DB16A44CD800AA1C53 /* SpaceStationType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpaceStationType.cpp; sourceTree = "<group>"; };
-		4AEE56DC16A44CD800AA1C53 /* SpaceStationType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpaceStationType.h; sourceTree = "<group>"; };
 		4AEEBC49162A4A5700C6EA6F /* libXrandr.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXrandr.2.dylib; path = ../../../../../opt/local/lib/libXrandr.2.dylib; sourceTree = "<group>"; };
 		4AEEBC4B162A4ADC00C6EA6F /* libXext.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXext.6.dylib; path = ../../../../../opt/local/lib/libXext.6.dylib; sourceTree = "<group>"; };
 		4AEEBC4F162A4B9B00C6EA6F /* libXrender.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXrender.1.dylib; path = ../../../../../opt/local/lib/libXrender.1.dylib; sourceTree = "<group>"; };
@@ -1222,30 +580,773 @@
 		4AEEBC54162A4BF700C6EA6F /* libXdmcp.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXdmcp.6.dylib; path = ../../../../../opt/local/lib/libXdmcp.6.dylib; sourceTree = "<group>"; };
 		4AEEBC5B162A4C7800C6EA6F /* libxcb.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxcb.1.dylib; path = ../../../../../opt/local/lib/libxcb.1.dylib; sourceTree = "<group>"; };
 		4AEEBC5E162A4F5B00C6EA6F /* libbz2.1.0.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.1.0.6.dylib; path = ../../../../../opt/local/lib/libbz2.1.0.6.dylib; sourceTree = "<group>"; };
-		4AF0058915F0F30400CC19C0 /* LuaEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaEvent.cpp; sourceTree = "<group>"; };
-		4AF0058A15F0F30400CC19C0 /* LuaEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaEvent.h; sourceTree = "<group>"; };
-		4AF0059115F17C6700CC19C0 /* LuaFileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaFileSystem.cpp; sourceTree = "<group>"; };
-		4AF0059215F17C6700CC19C0 /* LuaFileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LuaFileSystem.h; sourceTree = "<group>"; };
-		4AF222DF162103EA00BED38E /* Cutscene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Cutscene.h; sourceTree = "<group>"; };
-		4AF222E0162103EA00BED38E /* Factions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Factions.cpp; sourceTree = "<group>"; };
-		4AF222E1162103EA00BED38E /* Factions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Factions.h; sourceTree = "<group>"; };
-		4AF222E2162103EA00BED38E /* Intro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Intro.cpp; sourceTree = "<group>"; };
-		4AF222E3162103EA00BED38E /* Intro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Intro.h; sourceTree = "<group>"; };
-		4AF222E4162103EA00BED38E /* KeyBindings.inc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyBindings.inc.h; sourceTree = "<group>"; };
-		4AF222E5162103EA00BED38E /* Tombstone.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Tombstone.cpp; sourceTree = "<group>"; };
-		4AF222E6162103EA00BED38E /* Tombstone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Tombstone.h; sourceTree = "<group>"; };
-		4AF9999B1496D51F009821AF /* FileSelectorWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSelectorWidget.cpp; sourceTree = "<group>"; };
-		4AF9999C1496D51F009821AF /* FileSelectorWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileSelectorWidget.h; sourceTree = "<group>"; };
-		4AF9999D1496D51F009821AF /* Game.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Game.cpp; sourceTree = "<group>"; };
-		4AF9999E1496D51F009821AF /* Game.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Game.h; sourceTree = "<group>"; };
-		4AF999A11496D51F009821AF /* MathUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MathUtil.cpp; sourceTree = "<group>"; };
-		4AF999A21496D51F009821AF /* MathUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MathUtil.h; sourceTree = "<group>"; };
-		4AFBD7B71641265D002928CB /* PngWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PngWriter.cpp; sourceTree = "<group>"; };
-		4AFBD7B81641265D002928CB /* PngWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PngWriter.h; sourceTree = "<group>"; };
-		4AFBD7BA16412676002928CB /* LuaTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LuaTextEntry.cpp; sourceTree = "<group>"; };
-		4AFBD7BB16412676002928CB /* TextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextEntry.cpp; sourceTree = "<group>"; };
-		4AFBD7BC16412676002928CB /* TextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextEntry.h; sourceTree = "<group>"; };
-		4AFBD7BF16412688002928CB /* FontDescriptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontDescriptor.cpp; sourceTree = "<group>"; };
+		521ED7D41C00D14D0092B2E9 /* Aabb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Aabb.h; path = ../src/Aabb.h; sourceTree = "<group>"; };
+		521ED7D51C00D14D0092B2E9 /* AmbientSounds.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AmbientSounds.cpp; path = ../src/AmbientSounds.cpp; sourceTree = "<group>"; };
+		521ED7D61C00D14D0092B2E9 /* AmbientSounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AmbientSounds.h; path = ../src/AmbientSounds.h; sourceTree = "<group>"; };
+		521ED7D71C00D14D0092B2E9 /* AnimationCurves.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AnimationCurves.h; path = ../src/AnimationCurves.h; sourceTree = "<group>"; };
+		521ED7D81C00D14D0092B2E9 /* Background.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Background.cpp; path = ../src/Background.cpp; sourceTree = "<group>"; };
+		521ED7D91C00D14D0092B2E9 /* Background.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Background.h; path = ../src/Background.h; sourceTree = "<group>"; };
+		521ED7DA1C00D14D0092B2E9 /* BaseSphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BaseSphere.cpp; path = ../src/BaseSphere.cpp; sourceTree = "<group>"; };
+		521ED7DB1C00D14D0092B2E9 /* BaseSphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BaseSphere.h; path = ../src/BaseSphere.h; sourceTree = "<group>"; };
+		521ED7DC1C00D14D0092B2E9 /* Body.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Body.cpp; path = ../src/Body.cpp; sourceTree = "<group>"; };
+		521ED7DD1C00D14D0092B2E9 /* Body.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Body.h; path = ../src/Body.h; sourceTree = "<group>"; };
+		521ED7DE1C00D14D0092B2E9 /* buildopts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = buildopts.h; path = ../src/buildopts.h; sourceTree = "<group>"; };
+		521ED7DF1C00D14D0092B2E9 /* ByteRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ByteRange.h; path = ../src/ByteRange.h; sourceTree = "<group>"; };
+		521ED7E01C00D14D0092B2E9 /* Camera.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Camera.cpp; path = ../src/Camera.cpp; sourceTree = "<group>"; };
+		521ED7E11C00D14D0092B2E9 /* Camera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Camera.h; path = ../src/Camera.h; sourceTree = "<group>"; };
+		521ED7E21C00D14D0092B2E9 /* CameraController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CameraController.cpp; path = ../src/CameraController.cpp; sourceTree = "<group>"; };
+		521ED7E31C00D14D0092B2E9 /* CameraController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CameraController.h; path = ../src/CameraController.h; sourceTree = "<group>"; };
+		521ED7E41C00D14D0092B2E9 /* CargoBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CargoBody.cpp; path = ../src/CargoBody.cpp; sourceTree = "<group>"; };
+		521ED7E51C00D14D0092B2E9 /* CargoBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CargoBody.h; path = ../src/CargoBody.h; sourceTree = "<group>"; };
+		521ED7E61C00D14D0092B2E9 /* CityOnPlanet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CityOnPlanet.cpp; path = ../src/CityOnPlanet.cpp; sourceTree = "<group>"; };
+		521ED7E71C00D14D0092B2E9 /* CityOnPlanet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CityOnPlanet.h; path = ../src/CityOnPlanet.h; sourceTree = "<group>"; };
+		521ED7E81C00D14D0092B2E9 /* CollMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollMesh.cpp; path = ../src/CollMesh.cpp; sourceTree = "<group>"; };
+		521ED7E91C00D14D0092B2E9 /* CollMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollMesh.h; path = ../src/CollMesh.h; sourceTree = "<group>"; };
+		521ED7EA1C00D14D0092B2E9 /* Color.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Color.cpp; path = ../src/Color.cpp; sourceTree = "<group>"; };
+		521ED7EB1C00D14D0092B2E9 /* Color.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Color.h; path = ../src/Color.h; sourceTree = "<group>"; };
+		521ED7EC1C00D14D0092B2E9 /* CRC32.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRC32.cpp; path = ../src/CRC32.cpp; sourceTree = "<group>"; };
+		521ED7ED1C00D14D0092B2E9 /* CRC32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CRC32.h; path = ../src/CRC32.h; sourceTree = "<group>"; };
+		521ED7EE1C00D14D0092B2E9 /* Cutscene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Cutscene.h; path = ../src/Cutscene.h; sourceTree = "<group>"; };
+		521ED7EF1C00D14D0092B2E9 /* DateTime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DateTime.cpp; path = ../src/DateTime.cpp; sourceTree = "<group>"; };
+		521ED7F01C00D14D0092B2E9 /* DateTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DateTime.h; path = ../src/DateTime.h; sourceTree = "<group>"; };
+		521ED7F11C00D14D0092B2E9 /* DeathView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeathView.cpp; path = ../src/DeathView.cpp; sourceTree = "<group>"; };
+		521ED7F21C00D14D0092B2E9 /* DeathView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeathView.h; path = ../src/DeathView.h; sourceTree = "<group>"; };
+		521ED7F31C00D14D0092B2E9 /* DeleteEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeleteEmitter.h; path = ../src/DeleteEmitter.h; sourceTree = "<group>"; };
+		521ED7F41C00D14D0092B2E9 /* DynamicBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DynamicBody.cpp; path = ../src/DynamicBody.cpp; sourceTree = "<group>"; };
+		521ED7F51C00D14D0092B2E9 /* DynamicBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DynamicBody.h; path = ../src/DynamicBody.h; sourceTree = "<group>"; };
+		521ED7F61C00D14D0092B2E9 /* Easing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Easing.h; path = ../src/Easing.h; sourceTree = "<group>"; };
+		521ED7F71C00D14D0092B2E9 /* enum_table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = enum_table.cpp; path = ../src/enum_table.cpp; sourceTree = "<group>"; };
+		521ED7F81C00D14D0092B2E9 /* enum_table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = enum_table.h; path = ../src/enum_table.h; sourceTree = "<group>"; };
+		521ED7F91C00D14D0092B2E9 /* EnumStrings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EnumStrings.cpp; path = ../src/EnumStrings.cpp; sourceTree = "<group>"; };
+		521ED7FA1C00D14D0092B2E9 /* EnumStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EnumStrings.h; path = ../src/EnumStrings.h; sourceTree = "<group>"; };
+		521ED7FB1C00D14D0092B2E9 /* FaceParts.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FaceParts.cpp; path = ../src/FaceParts.cpp; sourceTree = "<group>"; };
+		521ED7FC1C00D14D0092B2E9 /* FaceParts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FaceParts.h; path = ../src/FaceParts.h; sourceTree = "<group>"; };
+		521ED7FD1C00D14D0092B2E9 /* Factions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Factions.cpp; path = ../src/Factions.cpp; sourceTree = "<group>"; };
+		521ED7FE1C00D14D0092B2E9 /* Factions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Factions.h; path = ../src/Factions.h; sourceTree = "<group>"; };
+		521ED7FF1C00D14D0092B2E9 /* FileSourceZip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FileSourceZip.cpp; path = ../src/FileSourceZip.cpp; sourceTree = "<group>"; };
+		521ED8001C00D14D0092B2E9 /* FileSourceZip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileSourceZip.h; path = ../src/FileSourceZip.h; sourceTree = "<group>"; };
+		521ED8011C00D14D0092B2E9 /* FileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FileSystem.cpp; path = ../src/FileSystem.cpp; sourceTree = "<group>"; };
+		521ED8021C00D14D0092B2E9 /* FileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileSystem.h; path = ../src/FileSystem.h; sourceTree = "<group>"; };
+		521ED8031C00D14D0092B2E9 /* fixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fixed.h; path = ../src/fixed.h; sourceTree = "<group>"; };
+		521ED8041C00D14D0092B2E9 /* FloatComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FloatComparison.h; path = ../src/FloatComparison.h; sourceTree = "<group>"; };
+		521ED8051C00D14D0092B2E9 /* FontCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FontCache.cpp; path = ../src/FontCache.cpp; sourceTree = "<group>"; };
+		521ED8061C00D14D0092B2E9 /* FontCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FontCache.h; path = ../src/FontCache.h; sourceTree = "<group>"; };
+		521ED8071C00D14D0092B2E9 /* Frame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Frame.cpp; path = ../src/Frame.cpp; sourceTree = "<group>"; };
+		521ED8081C00D14D0092B2E9 /* Frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Frame.h; path = ../src/Frame.h; sourceTree = "<group>"; };
+		521ED8091C00D14D0092B2E9 /* GalacticView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GalacticView.cpp; path = ../src/GalacticView.cpp; sourceTree = "<group>"; };
+		521ED80A1C00D14D0092B2E9 /* GalacticView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GalacticView.h; path = ../src/GalacticView.h; sourceTree = "<group>"; };
+		521ED80B1C00D14D0092B2E9 /* Game.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Game.cpp; path = ../src/Game.cpp; sourceTree = "<group>"; };
+		521ED80C1C00D14D0092B2E9 /* Game.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Game.h; path = ../src/Game.h; sourceTree = "<group>"; };
+		521ED80D1C00D14D0092B2E9 /* GameConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameConfig.cpp; path = ../src/GameConfig.cpp; sourceTree = "<group>"; };
+		521ED80E1C00D14D0092B2E9 /* GameConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameConfig.h; path = ../src/GameConfig.h; sourceTree = "<group>"; };
+		521ED80F1C00D14D0092B2E9 /* gameconsts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gameconsts.h; path = ../src/gameconsts.h; sourceTree = "<group>"; };
+		521ED8101C00D14D0092B2E9 /* GameLog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameLog.cpp; path = ../src/GameLog.cpp; sourceTree = "<group>"; };
+		521ED8111C00D14D0092B2E9 /* GameLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameLog.h; path = ../src/GameLog.h; sourceTree = "<group>"; };
+		521ED8121C00D14D0092B2E9 /* GasGiant.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GasGiant.cpp; path = ../src/GasGiant.cpp; sourceTree = "<group>"; };
+		521ED8131C00D14D0092B2E9 /* GasGiant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GasGiant.h; path = ../src/GasGiant.h; sourceTree = "<group>"; };
+		521ED8141C00D14D0092B2E9 /* GeoPatch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoPatch.cpp; path = ../src/GeoPatch.cpp; sourceTree = "<group>"; };
+		521ED8151C00D14D0092B2E9 /* GeoPatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoPatch.h; path = ../src/GeoPatch.h; sourceTree = "<group>"; };
+		521ED8161C00D14D0092B2E9 /* GeoPatchContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoPatchContext.cpp; path = ../src/GeoPatchContext.cpp; sourceTree = "<group>"; };
+		521ED8171C00D14D0092B2E9 /* GeoPatchContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoPatchContext.h; path = ../src/GeoPatchContext.h; sourceTree = "<group>"; };
+		521ED8181C00D14D0092B2E9 /* GeoPatchID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoPatchID.cpp; path = ../src/GeoPatchID.cpp; sourceTree = "<group>"; };
+		521ED8191C00D14D0092B2E9 /* GeoPatchID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoPatchID.h; path = ../src/GeoPatchID.h; sourceTree = "<group>"; };
+		521ED81A1C00D14D0092B2E9 /* GeoPatchJobs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoPatchJobs.cpp; path = ../src/GeoPatchJobs.cpp; sourceTree = "<group>"; };
+		521ED81B1C00D14D0092B2E9 /* GeoPatchJobs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoPatchJobs.h; path = ../src/GeoPatchJobs.h; sourceTree = "<group>"; };
+		521ED81C1C00D14D0092B2E9 /* GeoSphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeoSphere.cpp; path = ../src/GeoSphere.cpp; sourceTree = "<group>"; };
+		521ED81D1C00D14D0092B2E9 /* GeoSphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeoSphere.h; path = ../src/GeoSphere.h; sourceTree = "<group>"; };
+		521ED81E1C00D14D0092B2E9 /* HudTrail.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HudTrail.cpp; path = ../src/HudTrail.cpp; sourceTree = "<group>"; };
+		521ED81F1C00D14D0092B2E9 /* HudTrail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HudTrail.h; path = ../src/HudTrail.h; sourceTree = "<group>"; };
+		521ED8201C00D14D0092B2E9 /* HyperspaceCloud.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HyperspaceCloud.cpp; path = ../src/HyperspaceCloud.cpp; sourceTree = "<group>"; };
+		521ED8211C00D14D0092B2E9 /* HyperspaceCloud.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HyperspaceCloud.h; path = ../src/HyperspaceCloud.h; sourceTree = "<group>"; };
+		521ED8221C00D14D0092B2E9 /* IniConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IniConfig.cpp; path = ../src/IniConfig.cpp; sourceTree = "<group>"; };
+		521ED8231C00D14D0092B2E9 /* IniConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IniConfig.h; path = ../src/IniConfig.h; sourceTree = "<group>"; };
+		521ED8241C00D14D0092B2E9 /* Intro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Intro.cpp; path = ../src/Intro.cpp; sourceTree = "<group>"; };
+		521ED8251C00D14D0092B2E9 /* Intro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Intro.h; path = ../src/Intro.h; sourceTree = "<group>"; };
+		521ED8261C00D14D0092B2E9 /* IterationProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IterationProxy.h; path = ../src/IterationProxy.h; sourceTree = "<group>"; };
+		521ED8271C00D14D0092B2E9 /* JobQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = JobQueue.cpp; path = ../src/JobQueue.cpp; sourceTree = "<group>"; };
+		521ED8281C00D14D0092B2E9 /* JobQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JobQueue.h; path = ../src/JobQueue.h; sourceTree = "<group>"; };
+		521ED8291C00D14D0092B2E9 /* KeyBindings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = KeyBindings.cpp; path = ../src/KeyBindings.cpp; sourceTree = "<group>"; };
+		521ED82A1C00D14D0092B2E9 /* KeyBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KeyBindings.h; path = ../src/KeyBindings.h; sourceTree = "<group>"; };
+		521ED82B1C00D14D0092B2E9 /* KeyBindings.inc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KeyBindings.inc.h; path = ../src/KeyBindings.inc.h; sourceTree = "<group>"; };
+		521ED82C1C00D14D0092B2E9 /* Lang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lang.cpp; path = ../src/Lang.cpp; sourceTree = "<group>"; };
+		521ED82D1C00D14D0092B2E9 /* Lang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lang.h; path = ../src/Lang.h; sourceTree = "<group>"; };
+		521ED82E1C00D14D0092B2E9 /* LangStrings.inc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LangStrings.inc.h; path = ../src/LangStrings.inc.h; sourceTree = "<group>"; };
+		521ED82F1C00D14D0092B2E9 /* libs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = libs.h; path = ../src/libs.h; sourceTree = "<group>"; };
+		521ED8301C00D14D0092B2E9 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lua.cpp; path = ../src/Lua.cpp; sourceTree = "<group>"; };
+		521ED8311C00D14D0092B2E9 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lua.h; path = ../src/Lua.h; sourceTree = "<group>"; };
+		521ED8321C00D14D0092B2E9 /* LuaBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaBody.cpp; path = ../src/LuaBody.cpp; sourceTree = "<group>"; };
+		521ED8331C00D14D0092B2E9 /* LuaCargoBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaCargoBody.cpp; path = ../src/LuaCargoBody.cpp; sourceTree = "<group>"; };
+		521ED8341C00D14D0092B2E9 /* LuaComms.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaComms.cpp; path = ../src/LuaComms.cpp; sourceTree = "<group>"; };
+		521ED8351C00D14D0092B2E9 /* LuaComms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaComms.h; path = ../src/LuaComms.h; sourceTree = "<group>"; };
+		521ED8361C00D14D0092B2E9 /* LuaConsole.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaConsole.cpp; path = ../src/LuaConsole.cpp; sourceTree = "<group>"; };
+		521ED8371C00D14D0092B2E9 /* LuaConsole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaConsole.h; path = ../src/LuaConsole.h; sourceTree = "<group>"; };
+		521ED8381C00D14D0092B2E9 /* LuaConstants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaConstants.cpp; path = ../src/LuaConstants.cpp; sourceTree = "<group>"; };
+		521ED8391C00D14D0092B2E9 /* LuaConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaConstants.h; path = ../src/LuaConstants.h; sourceTree = "<group>"; };
+		521ED83A1C00D14D0092B2E9 /* LuaDev.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaDev.cpp; path = ../src/LuaDev.cpp; sourceTree = "<group>"; };
+		521ED83B1C00D14D0092B2E9 /* LuaDev.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaDev.h; path = ../src/LuaDev.h; sourceTree = "<group>"; };
+		521ED83C1C00D14D0092B2E9 /* LuaEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaEngine.cpp; path = ../src/LuaEngine.cpp; sourceTree = "<group>"; };
+		521ED83D1C00D14D0092B2E9 /* LuaEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaEngine.h; path = ../src/LuaEngine.h; sourceTree = "<group>"; };
+		521ED83E1C00D14D0092B2E9 /* LuaEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaEvent.cpp; path = ../src/LuaEvent.cpp; sourceTree = "<group>"; };
+		521ED83F1C00D14D0092B2E9 /* LuaEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaEvent.h; path = ../src/LuaEvent.h; sourceTree = "<group>"; };
+		521ED8401C00D14D0092B2E9 /* LuaFaction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFaction.cpp; path = ../src/LuaFaction.cpp; sourceTree = "<group>"; };
+		521ED8411C00D14D0092B2E9 /* LuaFileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFileSystem.cpp; path = ../src/LuaFileSystem.cpp; sourceTree = "<group>"; };
+		521ED8421C00D14D0092B2E9 /* LuaFileSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaFileSystem.h; path = ../src/LuaFileSystem.h; sourceTree = "<group>"; };
+		521ED8431C00D14D0092B2E9 /* LuaFixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFixed.cpp; path = ../src/LuaFixed.cpp; sourceTree = "<group>"; };
+		521ED8441C00D14D0092B2E9 /* LuaFixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaFixed.h; path = ../src/LuaFixed.h; sourceTree = "<group>"; };
+		521ED8451C00D14D0092B2E9 /* LuaFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFormat.cpp; path = ../src/LuaFormat.cpp; sourceTree = "<group>"; };
+		521ED8461C00D14D0092B2E9 /* LuaFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaFormat.h; path = ../src/LuaFormat.h; sourceTree = "<group>"; };
+		521ED8471C00D14D0092B2E9 /* LuaGame.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaGame.cpp; path = ../src/LuaGame.cpp; sourceTree = "<group>"; };
+		521ED8481C00D14D0092B2E9 /* LuaGame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaGame.h; path = ../src/LuaGame.h; sourceTree = "<group>"; };
+		521ED8491C00D14D0092B2E9 /* LuaLang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaLang.cpp; path = ../src/LuaLang.cpp; sourceTree = "<group>"; };
+		521ED84A1C00D14D0092B2E9 /* LuaLang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaLang.h; path = ../src/LuaLang.h; sourceTree = "<group>"; };
+		521ED84B1C00D14D0092B2E9 /* LuaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaManager.cpp; path = ../src/LuaManager.cpp; sourceTree = "<group>"; };
+		521ED84C1C00D14D0092B2E9 /* LuaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaManager.h; path = ../src/LuaManager.h; sourceTree = "<group>"; };
+		521ED84D1C00D14D0092B2E9 /* LuaMatrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMatrix.cpp; path = ../src/LuaMatrix.cpp; sourceTree = "<group>"; };
+		521ED84E1C00D14D0092B2E9 /* LuaMatrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaMatrix.h; path = ../src/LuaMatrix.h; sourceTree = "<group>"; };
+		521ED84F1C00D14D0092B2E9 /* LuaMissile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMissile.cpp; path = ../src/LuaMissile.cpp; sourceTree = "<group>"; };
+		521ED8501C00D14D0092B2E9 /* LuaMissile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaMissile.h; path = ../src/LuaMissile.h; sourceTree = "<group>"; };
+		521ED8511C00D14D0092B2E9 /* LuaModelBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaModelBody.cpp; path = ../src/LuaModelBody.cpp; sourceTree = "<group>"; };
+		521ED8521C00D14E0092B2E9 /* LuaMusic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMusic.cpp; path = ../src/LuaMusic.cpp; sourceTree = "<group>"; };
+		521ED8531C00D14E0092B2E9 /* LuaMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaMusic.h; path = ../src/LuaMusic.h; sourceTree = "<group>"; };
+		521ED8541C00D14E0092B2E9 /* LuaNameGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaNameGen.cpp; path = ../src/LuaNameGen.cpp; sourceTree = "<group>"; };
+		521ED8551C00D14E0092B2E9 /* LuaNameGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaNameGen.h; path = ../src/LuaNameGen.h; sourceTree = "<group>"; };
+		521ED8561C00D14E0092B2E9 /* LuaObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaObject.cpp; path = ../src/LuaObject.cpp; sourceTree = "<group>"; };
+		521ED8571C00D14E0092B2E9 /* LuaObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaObject.h; path = ../src/LuaObject.h; sourceTree = "<group>"; };
+		521ED8581C00D14E0092B2E9 /* LuaPlanet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaPlanet.cpp; path = ../src/LuaPlanet.cpp; sourceTree = "<group>"; };
+		521ED8591C00D14E0092B2E9 /* LuaPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaPlayer.cpp; path = ../src/LuaPlayer.cpp; sourceTree = "<group>"; };
+		521ED85A1C00D14E0092B2E9 /* LuaPropertiedObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaPropertiedObject.cpp; path = ../src/LuaPropertiedObject.cpp; sourceTree = "<group>"; };
+		521ED85B1C00D14E0092B2E9 /* LuaPushPull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaPushPull.h; path = ../src/LuaPushPull.h; sourceTree = "<group>"; };
+		521ED85C1C00D14E0092B2E9 /* LuaRand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaRand.cpp; path = ../src/LuaRand.cpp; sourceTree = "<group>"; };
+		521ED85D1C00D14E0092B2E9 /* LuaRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaRef.cpp; path = ../src/LuaRef.cpp; sourceTree = "<group>"; };
+		521ED85E1C00D14E0092B2E9 /* LuaRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaRef.h; path = ../src/LuaRef.h; sourceTree = "<group>"; };
+		521ED85F1C00D14E0092B2E9 /* LuaSerializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSerializer.cpp; path = ../src/LuaSerializer.cpp; sourceTree = "<group>"; };
+		521ED8601C00D14E0092B2E9 /* LuaSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaSerializer.h; path = ../src/LuaSerializer.h; sourceTree = "<group>"; };
+		521ED8611C00D14E0092B2E9 /* LuaServerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaServerAgent.cpp; path = ../src/LuaServerAgent.cpp; sourceTree = "<group>"; };
+		521ED8621C00D14E0092B2E9 /* LuaServerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaServerAgent.h; path = ../src/LuaServerAgent.h; sourceTree = "<group>"; };
+		521ED8631C00D14E0092B2E9 /* LuaShip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaShip.cpp; path = ../src/LuaShip.cpp; sourceTree = "<group>"; };
+		521ED8641C00D14E0092B2E9 /* LuaShipDef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaShipDef.cpp; path = ../src/LuaShipDef.cpp; sourceTree = "<group>"; };
+		521ED8651C00D14E0092B2E9 /* LuaShipDef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaShipDef.h; path = ../src/LuaShipDef.h; sourceTree = "<group>"; };
+		521ED8661C00D14E0092B2E9 /* LuaSpace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSpace.cpp; path = ../src/LuaSpace.cpp; sourceTree = "<group>"; };
+		521ED8671C00D14E0092B2E9 /* LuaSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaSpace.h; path = ../src/LuaSpace.h; sourceTree = "<group>"; };
+		521ED8681C00D14E0092B2E9 /* LuaSpaceStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSpaceStation.cpp; path = ../src/LuaSpaceStation.cpp; sourceTree = "<group>"; };
+		521ED8691C00D14E0092B2E9 /* LuaStar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaStar.cpp; path = ../src/LuaStar.cpp; sourceTree = "<group>"; };
+		521ED86A1C00D14E0092B2E9 /* LuaStarSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaStarSystem.cpp; path = ../src/LuaStarSystem.cpp; sourceTree = "<group>"; };
+		521ED86B1C00D14E0092B2E9 /* LuaSystemBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSystemBody.cpp; path = ../src/LuaSystemBody.cpp; sourceTree = "<group>"; };
+		521ED86C1C00D14E0092B2E9 /* LuaSystemPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSystemPath.cpp; path = ../src/LuaSystemPath.cpp; sourceTree = "<group>"; };
+		521ED86D1C00D14E0092B2E9 /* LuaTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaTable.h; path = ../src/LuaTable.h; sourceTree = "<group>"; };
+		521ED86E1C00D14E0092B2E9 /* LuaTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaTimer.cpp; path = ../src/LuaTimer.cpp; sourceTree = "<group>"; };
+		521ED86F1C00D14E0092B2E9 /* LuaTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaTimer.h; path = ../src/LuaTimer.h; sourceTree = "<group>"; };
+		521ED8701C00D14E0092B2E9 /* LuaUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaUtils.cpp; path = ../src/LuaUtils.cpp; sourceTree = "<group>"; };
+		521ED8711C00D14E0092B2E9 /* LuaUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaUtils.h; path = ../src/LuaUtils.h; sourceTree = "<group>"; };
+		521ED8721C00D14E0092B2E9 /* LuaVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaVector.cpp; path = ../src/LuaVector.cpp; sourceTree = "<group>"; };
+		521ED8731C00D14E0092B2E9 /* LuaVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaVector.h; path = ../src/LuaVector.h; sourceTree = "<group>"; };
+		521ED8741C00D14E0092B2E9 /* LuaWrappable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaWrappable.h; path = ../src/LuaWrappable.h; sourceTree = "<group>"; };
+		521ED8751C00D14E0092B2E9 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = ../src/main.cpp; sourceTree = "<group>"; };
+		521ED8761C00D14E0092B2E9 /* MathUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MathUtil.cpp; path = ../src/MathUtil.cpp; sourceTree = "<group>"; };
+		521ED8771C00D14E0092B2E9 /* MathUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MathUtil.h; path = ../src/MathUtil.h; sourceTree = "<group>"; };
+		521ED8781C00D14E0092B2E9 /* matrix3x3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = matrix3x3.h; path = ../src/matrix3x3.h; sourceTree = "<group>"; };
+		521ED8791C00D14E0092B2E9 /* matrix4x4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = matrix4x4.h; path = ../src/matrix4x4.h; sourceTree = "<group>"; };
+		521ED87A1C00D14E0092B2E9 /* Missile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Missile.cpp; path = ../src/Missile.cpp; sourceTree = "<group>"; };
+		521ED87B1C00D14E0092B2E9 /* Missile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Missile.h; path = ../src/Missile.h; sourceTree = "<group>"; };
+		521ED87C1C00D14E0092B2E9 /* ModelBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelBody.cpp; path = ../src/ModelBody.cpp; sourceTree = "<group>"; };
+		521ED87D1C00D14E0092B2E9 /* ModelBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelBody.h; path = ../src/ModelBody.h; sourceTree = "<group>"; };
+		521ED87E1C00D14E0092B2E9 /* ModelCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelCache.cpp; path = ../src/ModelCache.cpp; sourceTree = "<group>"; };
+		521ED87F1C00D14E0092B2E9 /* ModelCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelCache.h; path = ../src/ModelCache.h; sourceTree = "<group>"; };
+		521ED8811C00D14E0092B2E9 /* ModelViewer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelViewer.cpp; path = ../src/ModelViewer.cpp; sourceTree = "<group>"; };
+		521ED8821C00D14E0092B2E9 /* ModelViewer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelViewer.h; path = ../src/ModelViewer.h; sourceTree = "<group>"; };
+		521ED8831C00D14E0092B2E9 /* ModManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModManager.cpp; path = ../src/ModManager.cpp; sourceTree = "<group>"; };
+		521ED8841C00D14E0092B2E9 /* ModManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModManager.h; path = ../src/ModManager.h; sourceTree = "<group>"; };
+		521ED8851C00D14E0092B2E9 /* NavLights.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NavLights.cpp; path = ../src/NavLights.cpp; sourceTree = "<group>"; };
+		521ED8861C00D14E0092B2E9 /* NavLights.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NavLights.h; path = ../src/NavLights.h; sourceTree = "<group>"; };
+		521ED8871C00D14E0092B2E9 /* Object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Object.h; path = ../src/Object.h; sourceTree = "<group>"; };
+		521ED8881C00D14E0092B2E9 /* ObjectViewerView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ObjectViewerView.cpp; path = ../src/ObjectViewerView.cpp; sourceTree = "<group>"; };
+		521ED8891C00D14E0092B2E9 /* ObjectViewerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ObjectViewerView.h; path = ../src/ObjectViewerView.h; sourceTree = "<group>"; };
+		521ED88A1C00D14E0092B2E9 /* Orbit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Orbit.cpp; path = ../src/Orbit.cpp; sourceTree = "<group>"; };
+		521ED88B1C00D14E0092B2E9 /* Orbit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Orbit.h; path = ../src/Orbit.h; sourceTree = "<group>"; };
+		521ED88C1C00D14E0092B2E9 /* OS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OS.h; path = ../src/OS.h; sourceTree = "<group>"; };
+		521ED88D1C00D14E0092B2E9 /* perlin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = perlin.cpp; path = ../src/perlin.cpp; sourceTree = "<group>"; };
+		521ED88E1C00D14E0092B2E9 /* perlin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = perlin.h; path = ../src/perlin.h; sourceTree = "<group>"; };
+		521ED88F1C00D14E0092B2E9 /* PersistSystemData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PersistSystemData.h; path = ../src/PersistSystemData.h; sourceTree = "<group>"; };
+		521ED8901C00D14E0092B2E9 /* Pi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Pi.cpp; path = ../src/Pi.cpp; sourceTree = "<group>"; };
+		521ED8911C00D14E0092B2E9 /* Pi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Pi.h; path = ../src/Pi.h; sourceTree = "<group>"; };
+		521ED8921C00D14E0092B2E9 /* Plane.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Plane.cpp; path = ../src/Plane.cpp; sourceTree = "<group>"; };
+		521ED8931C00D14E0092B2E9 /* Plane.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Plane.h; path = ../src/Plane.h; sourceTree = "<group>"; };
+		521ED8941C00D14E0092B2E9 /* Planet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Planet.cpp; path = ../src/Planet.cpp; sourceTree = "<group>"; };
+		521ED8951C00D14E0092B2E9 /* Planet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Planet.h; path = ../src/Planet.h; sourceTree = "<group>"; };
+		521ED8961C00D14E0092B2E9 /* Player.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Player.cpp; path = ../src/Player.cpp; sourceTree = "<group>"; };
+		521ED8971C00D14E0092B2E9 /* Player.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Player.h; path = ../src/Player.h; sourceTree = "<group>"; };
+		521ED8981C00D14E0092B2E9 /* PngWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PngWriter.cpp; path = ../src/PngWriter.cpp; sourceTree = "<group>"; };
+		521ED8991C00D14E0092B2E9 /* PngWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PngWriter.h; path = ../src/PngWriter.h; sourceTree = "<group>"; };
+		521ED89A1C00D14E0092B2E9 /* Polit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Polit.cpp; path = ../src/Polit.cpp; sourceTree = "<group>"; };
+		521ED89B1C00D14E0092B2E9 /* Polit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Polit.h; path = ../src/Polit.h; sourceTree = "<group>"; };
+		521ED89C1C00D14E0092B2E9 /* Projectile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Projectile.cpp; path = ../src/Projectile.cpp; sourceTree = "<group>"; };
+		521ED89D1C00D14E0092B2E9 /* Projectile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Projectile.h; path = ../src/Projectile.h; sourceTree = "<group>"; };
+		521ED89E1C00D14E0092B2E9 /* PropertiedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PropertiedObject.h; path = ../src/PropertiedObject.h; sourceTree = "<group>"; };
+		521ED89F1C00D14E0092B2E9 /* PropertyMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PropertyMap.cpp; path = ../src/PropertyMap.cpp; sourceTree = "<group>"; };
+		521ED8A01C00D14E0092B2E9 /* PropertyMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PropertyMap.h; path = ../src/PropertyMap.h; sourceTree = "<group>"; };
+		521ED8A11C00D14E0092B2E9 /* Quaternion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Quaternion.h; path = ../src/Quaternion.h; sourceTree = "<group>"; };
+		521ED8A21C00D14E0092B2E9 /* Random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Random.h; path = ../src/Random.h; sourceTree = "<group>"; };
+		521ED8A31C00D14E0092B2E9 /* RefCounted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RefCounted.h; path = ../src/RefCounted.h; sourceTree = "<group>"; };
+		521ED8A41C00D14E0092B2E9 /* SDLWrappers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SDLWrappers.cpp; path = ../src/SDLWrappers.cpp; sourceTree = "<group>"; };
+		521ED8A51C00D14E0092B2E9 /* SDLWrappers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDLWrappers.h; path = ../src/SDLWrappers.h; sourceTree = "<group>"; };
+		521ED8A61C00D14E0092B2E9 /* SectorView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SectorView.cpp; path = ../src/SectorView.cpp; sourceTree = "<group>"; };
+		521ED8A71C00D14E0092B2E9 /* SectorView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SectorView.h; path = ../src/SectorView.h; sourceTree = "<group>"; };
+		521ED8A81C00D14E0092B2E9 /* Sensors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sensors.cpp; path = ../src/Sensors.cpp; sourceTree = "<group>"; };
+		521ED8A91C00D14E0092B2E9 /* Sensors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sensors.h; path = ../src/Sensors.h; sourceTree = "<group>"; };
+		521ED8AA1C00D14E0092B2E9 /* Serializer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Serializer.cpp; path = ../src/Serializer.cpp; sourceTree = "<group>"; };
+		521ED8AB1C00D14E0092B2E9 /* Serializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Serializer.h; path = ../src/Serializer.h; sourceTree = "<group>"; };
+		521ED8AC1C00D14E0092B2E9 /* ServerAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ServerAgent.cpp; path = ../src/ServerAgent.cpp; sourceTree = "<group>"; };
+		521ED8AD1C00D14E0092B2E9 /* ServerAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerAgent.h; path = ../src/ServerAgent.h; sourceTree = "<group>"; };
+		521ED8AE1C00D14E0092B2E9 /* Sfx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sfx.cpp; path = ../src/Sfx.cpp; sourceTree = "<group>"; };
+		521ED8AF1C00D14E0092B2E9 /* Sfx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sfx.h; path = ../src/Sfx.h; sourceTree = "<group>"; };
+		521ED8B01C00D14E0092B2E9 /* Shields.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Shields.cpp; path = ../src/Shields.cpp; sourceTree = "<group>"; };
+		521ED8B11C00D14E0092B2E9 /* Shields.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Shields.h; path = ../src/Shields.h; sourceTree = "<group>"; };
+		521ED8B21C00D14E0092B2E9 /* Ship-AI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "Ship-AI.cpp"; path = "../src/Ship-AI.cpp"; sourceTree = "<group>"; };
+		521ED8B31C00D14E0092B2E9 /* Ship.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Ship.cpp; path = ../src/Ship.cpp; sourceTree = "<group>"; };
+		521ED8B41C00D14E0092B2E9 /* Ship.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Ship.h; path = ../src/Ship.h; sourceTree = "<group>"; };
+		521ED8B51C00D14E0092B2E9 /* ShipAICmd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipAICmd.cpp; path = ../src/ShipAICmd.cpp; sourceTree = "<group>"; };
+		521ED8B61C00D14E0092B2E9 /* ShipAICmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipAICmd.h; path = ../src/ShipAICmd.h; sourceTree = "<group>"; };
+		521ED8B71C00D14E0092B2E9 /* ShipCockpit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipCockpit.cpp; path = ../src/ShipCockpit.cpp; sourceTree = "<group>"; };
+		521ED8B81C00D14E0092B2E9 /* ShipCockpit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipCockpit.h; path = ../src/ShipCockpit.h; sourceTree = "<group>"; };
+		521ED8B91C00D14E0092B2E9 /* ShipController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipController.cpp; path = ../src/ShipController.cpp; sourceTree = "<group>"; };
+		521ED8BA1C00D14E0092B2E9 /* ShipController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipController.h; path = ../src/ShipController.h; sourceTree = "<group>"; };
+		521ED8BB1C00D14E0092B2E9 /* ShipCpanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipCpanel.cpp; path = ../src/ShipCpanel.cpp; sourceTree = "<group>"; };
+		521ED8BC1C00D14E0092B2E9 /* ShipCpanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipCpanel.h; path = ../src/ShipCpanel.h; sourceTree = "<group>"; };
+		521ED8BD1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipCpanelMultiFuncDisplays.cpp; path = ../src/ShipCpanelMultiFuncDisplays.cpp; sourceTree = "<group>"; };
+		521ED8BE1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipCpanelMultiFuncDisplays.h; path = ../src/ShipCpanelMultiFuncDisplays.h; sourceTree = "<group>"; };
+		521ED8BF1C00D14E0092B2E9 /* ShipType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ShipType.cpp; path = ../src/ShipType.cpp; sourceTree = "<group>"; };
+		521ED8C01C00D14E0092B2E9 /* ShipType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ShipType.h; path = ../src/ShipType.h; sourceTree = "<group>"; };
+		521ED8C11C00D14E0092B2E9 /* SmartPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SmartPtr.h; path = ../src/SmartPtr.h; sourceTree = "<group>"; };
+		521ED8C21C00D14E0092B2E9 /* Sound.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sound.cpp; path = ../src/Sound.cpp; sourceTree = "<group>"; };
+		521ED8C31C00D14E0092B2E9 /* Sound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sound.h; path = ../src/Sound.h; sourceTree = "<group>"; };
+		521ED8C41C00D14E0092B2E9 /* SoundMusic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SoundMusic.cpp; path = ../src/SoundMusic.cpp; sourceTree = "<group>"; };
+		521ED8C51C00D14E0092B2E9 /* SoundMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SoundMusic.h; path = ../src/SoundMusic.h; sourceTree = "<group>"; };
+		521ED8C61C00D14E0092B2E9 /* Space.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Space.cpp; path = ../src/Space.cpp; sourceTree = "<group>"; };
+		521ED8C71C00D14E0092B2E9 /* Space.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Space.h; path = ../src/Space.h; sourceTree = "<group>"; };
+		521ED8C81C00D14E0092B2E9 /* SpaceStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SpaceStation.cpp; path = ../src/SpaceStation.cpp; sourceTree = "<group>"; };
+		521ED8C91C00D14E0092B2E9 /* SpaceStation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpaceStation.h; path = ../src/SpaceStation.h; sourceTree = "<group>"; };
+		521ED8CA1C00D14E0092B2E9 /* SpaceStationType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SpaceStationType.cpp; path = ../src/SpaceStationType.cpp; sourceTree = "<group>"; };
+		521ED8CB1C00D14E0092B2E9 /* SpaceStationType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpaceStationType.h; path = ../src/SpaceStationType.h; sourceTree = "<group>"; };
+		521ED8CC1C00D14E0092B2E9 /* SpeedLines.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SpeedLines.cpp; path = ../src/SpeedLines.cpp; sourceTree = "<group>"; };
+		521ED8CD1C00D14E0092B2E9 /* SpeedLines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpeedLines.h; path = ../src/SpeedLines.h; sourceTree = "<group>"; };
+		521ED8CE1C00D14E0092B2E9 /* Sphere.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sphere.cpp; path = ../src/Sphere.cpp; sourceTree = "<group>"; };
+		521ED8CF1C00D14E0092B2E9 /* Sphere.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sphere.h; path = ../src/Sphere.h; sourceTree = "<group>"; };
+		521ED8D01C00D14E0092B2E9 /* Star.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Star.cpp; path = ../src/Star.cpp; sourceTree = "<group>"; };
+		521ED8D11C00D14E0092B2E9 /* Star.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Star.h; path = ../src/Star.h; sourceTree = "<group>"; };
+		521ED8D21C00D14E0092B2E9 /* StringF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StringF.cpp; path = ../src/StringF.cpp; sourceTree = "<group>"; };
+		521ED8D31C00D14E0092B2E9 /* StringF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StringF.h; path = ../src/StringF.h; sourceTree = "<group>"; };
+		521ED8D41C00D14E0092B2E9 /* StringRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StringRange.h; path = ../src/StringRange.h; sourceTree = "<group>"; };
+		521ED8D51C00D14E0092B2E9 /* SystemInfoView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SystemInfoView.cpp; path = ../src/SystemInfoView.cpp; sourceTree = "<group>"; };
+		521ED8D61C00D14E0092B2E9 /* SystemInfoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SystemInfoView.h; path = ../src/SystemInfoView.h; sourceTree = "<group>"; };
+		521ED8D71C00D14E0092B2E9 /* SystemView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SystemView.cpp; path = ../src/SystemView.cpp; sourceTree = "<group>"; };
+		521ED8D81C00D14E0092B2E9 /* SystemView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SystemView.h; path = ../src/SystemView.h; sourceTree = "<group>"; };
+		521ED8D91C00D14E0092B2E9 /* TerrainBody.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainBody.cpp; path = ../src/TerrainBody.cpp; sourceTree = "<group>"; };
+		521ED8DA1C00D14E0092B2E9 /* TerrainBody.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TerrainBody.h; path = ../src/TerrainBody.h; sourceTree = "<group>"; };
+		521ED8E21C00D14E0092B2E9 /* Tombstone.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Tombstone.cpp; path = ../src/Tombstone.cpp; sourceTree = "<group>"; };
+		521ED8E31C00D14E0092B2E9 /* Tombstone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Tombstone.h; path = ../src/Tombstone.h; sourceTree = "<group>"; };
+		521ED8E51C00D14E0092B2E9 /* UIView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UIView.cpp; path = ../src/UIView.cpp; sourceTree = "<group>"; };
+		521ED8E61C00D14E0092B2E9 /* UIView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UIView.h; path = ../src/UIView.h; sourceTree = "<group>"; };
+		521ED8E71C00D14E0092B2E9 /* utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = utils.cpp; path = ../src/utils.cpp; sourceTree = "<group>"; };
+		521ED8E81C00D14E0092B2E9 /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = utils.h; path = ../src/utils.h; sourceTree = "<group>"; };
+		521ED8E91C00D14E0092B2E9 /* vector2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vector2.h; path = ../src/vector2.h; sourceTree = "<group>"; };
+		521ED8EA1C00D14E0092B2E9 /* vector3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vector3.h; path = ../src/vector3.h; sourceTree = "<group>"; };
+		521ED8EB1C00D14E0092B2E9 /* VideoLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VideoLink.h; path = ../src/VideoLink.h; sourceTree = "<group>"; };
+		521ED8EC1C00D14E0092B2E9 /* View.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = View.cpp; path = ../src/View.cpp; sourceTree = "<group>"; };
+		521ED8ED1C00D14E0092B2E9 /* View.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = View.h; path = ../src/View.h; sourceTree = "<group>"; };
+		521ED8EE1C00D14E0092B2E9 /* WorldView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WorldView.cpp; path = ../src/WorldView.cpp; sourceTree = "<group>"; };
+		521ED8EF1C00D14E0092B2E9 /* WorldView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WorldView.h; path = ../src/WorldView.h; sourceTree = "<group>"; };
+		521ED9861C00D2ED0092B2E9 /* BVHTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BVHTree.cpp; path = ../src/collider/BVHTree.cpp; sourceTree = "<group>"; };
+		521ED9871C00D2ED0092B2E9 /* BVHTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BVHTree.h; path = ../src/collider/BVHTree.h; sourceTree = "<group>"; };
+		521ED9881C00D2ED0092B2E9 /* collider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = collider.h; path = ../src/collider/collider.h; sourceTree = "<group>"; };
+		521ED9891C00D2ED0092B2E9 /* CollisionContact.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionContact.h; path = ../src/collider/CollisionContact.h; sourceTree = "<group>"; };
+		521ED98A1C00D2ED0092B2E9 /* CollisionSpace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollisionSpace.cpp; path = ../src/collider/CollisionSpace.cpp; sourceTree = "<group>"; };
+		521ED98B1C00D2ED0092B2E9 /* CollisionSpace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionSpace.h; path = ../src/collider/CollisionSpace.h; sourceTree = "<group>"; };
+		521ED98C1C00D2ED0092B2E9 /* Geom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Geom.cpp; path = ../src/collider/Geom.cpp; sourceTree = "<group>"; };
+		521ED98D1C00D2ED0092B2E9 /* Geom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Geom.h; path = ../src/collider/Geom.h; sourceTree = "<group>"; };
+		521ED98E1C00D2ED0092B2E9 /* GeomTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GeomTree.cpp; path = ../src/collider/GeomTree.cpp; sourceTree = "<group>"; };
+		521ED98F1C00D2ED0092B2E9 /* GeomTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GeomTree.h; path = ../src/collider/GeomTree.h; sourceTree = "<group>"; };
+		521ED9901C00D2ED0092B2E9 /* Weld.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Weld.h; path = ../src/collider/Weld.h; sourceTree = "<group>"; };
+		521ED9911C00D2ED0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/collider/Makefile.am; sourceTree = "<group>"; };
+		521ED9971C00D2FC0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/Makefile.am; sourceTree = "<group>"; };
+		521ED9991C00D3240092B2E9 /* CustomSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CustomSystem.cpp; path = ../src/galaxy/CustomSystem.cpp; sourceTree = "<group>"; };
+		521ED99A1C00D3240092B2E9 /* CustomSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CustomSystem.h; path = ../src/galaxy/CustomSystem.h; sourceTree = "<group>"; };
+		521ED99B1C00D3240092B2E9 /* Economy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Economy.cpp; path = ../src/galaxy/Economy.cpp; sourceTree = "<group>"; };
+		521ED99C1C00D3240092B2E9 /* Economy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Economy.h; path = ../src/galaxy/Economy.h; sourceTree = "<group>"; };
+		521ED99D1C00D3240092B2E9 /* Galaxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Galaxy.cpp; path = ../src/galaxy/Galaxy.cpp; sourceTree = "<group>"; };
+		521ED99E1C00D3240092B2E9 /* Galaxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Galaxy.h; path = ../src/galaxy/Galaxy.h; sourceTree = "<group>"; };
+		521ED99F1C00D3240092B2E9 /* GalaxyCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GalaxyCache.cpp; path = ../src/galaxy/GalaxyCache.cpp; sourceTree = "<group>"; };
+		521ED9A01C00D3240092B2E9 /* GalaxyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GalaxyCache.h; path = ../src/galaxy/GalaxyCache.h; sourceTree = "<group>"; };
+		521ED9A11C00D3240092B2E9 /* GalaxyGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GalaxyGenerator.cpp; path = ../src/galaxy/GalaxyGenerator.cpp; sourceTree = "<group>"; };
+		521ED9A21C00D3240092B2E9 /* GalaxyGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GalaxyGenerator.h; path = ../src/galaxy/GalaxyGenerator.h; sourceTree = "<group>"; };
+		521ED9A31C00D3240092B2E9 /* Sector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Sector.cpp; path = ../src/galaxy/Sector.cpp; sourceTree = "<group>"; };
+		521ED9A41C00D3240092B2E9 /* Sector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Sector.h; path = ../src/galaxy/Sector.h; sourceTree = "<group>"; };
+		521ED9A51C00D3240092B2E9 /* SectorGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SectorGenerator.cpp; path = ../src/galaxy/SectorGenerator.cpp; sourceTree = "<group>"; };
+		521ED9A61C00D3240092B2E9 /* SectorGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SectorGenerator.h; path = ../src/galaxy/SectorGenerator.h; sourceTree = "<group>"; };
+		521ED9A71C00D3240092B2E9 /* StarSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StarSystem.cpp; path = ../src/galaxy/StarSystem.cpp; sourceTree = "<group>"; };
+		521ED9A81C00D3240092B2E9 /* StarSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StarSystem.h; path = ../src/galaxy/StarSystem.h; sourceTree = "<group>"; };
+		521ED9A91C00D3240092B2E9 /* StarSystemGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StarSystemGenerator.cpp; path = ../src/galaxy/StarSystemGenerator.cpp; sourceTree = "<group>"; };
+		521ED9AA1C00D3240092B2E9 /* StarSystemGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StarSystemGenerator.h; path = ../src/galaxy/StarSystemGenerator.h; sourceTree = "<group>"; };
+		521ED9AB1C00D3240092B2E9 /* SystemPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SystemPath.cpp; path = ../src/galaxy/SystemPath.cpp; sourceTree = "<group>"; };
+		521ED9AC1C00D3240092B2E9 /* SystemPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SystemPath.h; path = ../src/galaxy/SystemPath.h; sourceTree = "<group>"; };
+		521ED9AD1C00D3240092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/galaxy/Makefile.am; sourceTree = "<group>"; };
+		521ED9B91C00D3310092B2E9 /* BindingCapture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BindingCapture.cpp; path = ../src/gameui/BindingCapture.cpp; sourceTree = "<group>"; };
+		521ED9BA1C00D3310092B2E9 /* BindingCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BindingCapture.h; path = ../src/gameui/BindingCapture.h; sourceTree = "<group>"; };
+		521ED9BB1C00D3310092B2E9 /* Face.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Face.cpp; path = ../src/gameui/Face.cpp; sourceTree = "<group>"; };
+		521ED9BC1C00D3310092B2E9 /* Face.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Face.h; path = ../src/gameui/Face.h; sourceTree = "<group>"; };
+		521ED9BD1C00D3310092B2E9 /* GameUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameUI.h; path = ../src/gameui/GameUI.h; sourceTree = "<group>"; };
+		521ED9BE1C00D3310092B2E9 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lua.cpp; path = ../src/gameui/Lua.cpp; sourceTree = "<group>"; };
+		521ED9BF1C00D3310092B2E9 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lua.h; path = ../src/gameui/Lua.h; sourceTree = "<group>"; };
+		521ED9C01C00D3310092B2E9 /* LuaBindingCapture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaBindingCapture.cpp; path = ../src/gameui/LuaBindingCapture.cpp; sourceTree = "<group>"; };
+		521ED9C11C00D3310092B2E9 /* LuaFace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaFace.cpp; path = ../src/gameui/LuaFace.cpp; sourceTree = "<group>"; };
+		521ED9C21C00D3310092B2E9 /* LuaModelSpinner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaModelSpinner.cpp; path = ../src/gameui/LuaModelSpinner.cpp; sourceTree = "<group>"; };
+		521ED9C31C00D3310092B2E9 /* ModelSpinner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelSpinner.cpp; path = ../src/gameui/ModelSpinner.cpp; sourceTree = "<group>"; };
+		521ED9C41C00D3310092B2E9 /* ModelSpinner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelSpinner.h; path = ../src/gameui/ModelSpinner.h; sourceTree = "<group>"; };
+		521ED9C51C00D3310092B2E9 /* Panel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Panel.cpp; path = ../src/gameui/Panel.cpp; sourceTree = "<group>"; };
+		521ED9C61C00D3310092B2E9 /* Panel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Panel.h; path = ../src/gameui/Panel.h; sourceTree = "<group>"; };
+		521ED9C71C00D3310092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/gameui/Makefile.am; sourceTree = "<group>"; };
+		521ED9D21C00D3430092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		521ED9D31C00D3430092B2E9 /* MaterialDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialDummy.h; sourceTree = "<group>"; };
+		521ED9D41C00D3430092B2E9 /* RendererDummy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RendererDummy.cpp; sourceTree = "<group>"; };
+		521ED9D51C00D3430092B2E9 /* RendererDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererDummy.h; sourceTree = "<group>"; };
+		521ED9D61C00D3430092B2E9 /* RenderStateDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderStateDummy.h; sourceTree = "<group>"; };
+		521ED9D71C00D3430092B2E9 /* RenderTargetDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderTargetDummy.h; sourceTree = "<group>"; };
+		521ED9D81C00D3430092B2E9 /* TextureDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureDummy.h; sourceTree = "<group>"; };
+		521ED9D91C00D3430092B2E9 /* VertexBufferDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexBufferDummy.h; sourceTree = "<group>"; };
+		521ED9DB1C00D3430092B2E9 /* FresnelColourMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FresnelColourMaterial.cpp; sourceTree = "<group>"; };
+		521ED9DC1C00D3430092B2E9 /* FresnelColourMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FresnelColourMaterial.h; sourceTree = "<group>"; };
+		521ED9DD1C00D3430092B2E9 /* GasGiantMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GasGiantMaterial.cpp; sourceTree = "<group>"; };
+		521ED9DE1C00D3430092B2E9 /* GasGiantMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GasGiantMaterial.h; sourceTree = "<group>"; };
+		521ED9DF1C00D3430092B2E9 /* GeoSphereMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GeoSphereMaterial.cpp; sourceTree = "<group>"; };
+		521ED9E01C00D3430092B2E9 /* GeoSphereMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoSphereMaterial.h; sourceTree = "<group>"; };
+		521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gl_core_3_x.c; sourceTree = "<group>"; };
+		521ED9E21C00D3430092B2E9 /* gl_core_3_x.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gl_core_3_x.h; sourceTree = "<group>"; };
+		521ED9E31C00D3430092B2E9 /* GLDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLDebug.h; sourceTree = "<group>"; };
+		521ED9E41C00D3430092B2E9 /* LineMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LineMaterial.cpp; sourceTree = "<group>"; };
+		521ED9E51C00D3430092B2E9 /* LineMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LineMaterial.h; sourceTree = "<group>"; };
+		521ED9E61C00D3430092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MaterialGL.cpp; sourceTree = "<group>"; };
+		521ED9E81C00D3430092B2E9 /* MaterialGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialGL.h; sourceTree = "<group>"; };
+		521ED9E91C00D3430092B2E9 /* MultiMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MultiMaterial.cpp; sourceTree = "<group>"; };
+		521ED9EA1C00D3430092B2E9 /* MultiMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiMaterial.h; sourceTree = "<group>"; };
+		521ED9EB1C00D3430092B2E9 /* OpenGLLibs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenGLLibs.h; sourceTree = "<group>"; };
+		521ED9EC1C00D3430092B2E9 /* Program.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Program.cpp; sourceTree = "<group>"; };
+		521ED9ED1C00D3430092B2E9 /* Program.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Program.h; sourceTree = "<group>"; };
+		521ED9EE1C00D3430092B2E9 /* RendererGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RendererGL.cpp; sourceTree = "<group>"; };
+		521ED9EF1C00D3430092B2E9 /* RendererGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RendererGL.h; sourceTree = "<group>"; };
+		521ED9F01C00D3430092B2E9 /* RenderStateGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderStateGL.cpp; sourceTree = "<group>"; };
+		521ED9F11C00D3430092B2E9 /* RenderStateGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderStateGL.h; sourceTree = "<group>"; };
+		521ED9F21C00D3430092B2E9 /* RenderTargetGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderTargetGL.cpp; sourceTree = "<group>"; };
+		521ED9F31C00D3430092B2E9 /* RenderTargetGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderTargetGL.h; sourceTree = "<group>"; };
+		521ED9F41C00D3430092B2E9 /* RingMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RingMaterial.cpp; sourceTree = "<group>"; };
+		521ED9F51C00D3430092B2E9 /* RingMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RingMaterial.h; sourceTree = "<group>"; };
+		521ED9F61C00D3430092B2E9 /* ShieldMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShieldMaterial.cpp; sourceTree = "<group>"; };
+		521ED9F71C00D3430092B2E9 /* ShieldMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShieldMaterial.h; sourceTree = "<group>"; };
+		521ED9F81C00D3430092B2E9 /* SkyboxMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SkyboxMaterial.h; sourceTree = "<group>"; };
+		521ED9F91C00D3430092B2E9 /* SphereImpostorMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SphereImpostorMaterial.h; sourceTree = "<group>"; };
+		521ED9FA1C00D3430092B2E9 /* StarfieldMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StarfieldMaterial.h; sourceTree = "<group>"; };
+		521ED9FB1C00D3430092B2E9 /* TextureGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureGL.cpp; sourceTree = "<group>"; };
+		521ED9FC1C00D3430092B2E9 /* TextureGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureGL.h; sourceTree = "<group>"; };
+		521ED9FD1C00D3430092B2E9 /* UIMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UIMaterial.cpp; sourceTree = "<group>"; };
+		521ED9FE1C00D3430092B2E9 /* UIMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIMaterial.h; sourceTree = "<group>"; };
+		521ED9FF1C00D3430092B2E9 /* Uniform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Uniform.cpp; sourceTree = "<group>"; };
+		521EDA001C00D3430092B2E9 /* Uniform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Uniform.h; sourceTree = "<group>"; };
+		521EDA011C00D3430092B2E9 /* VertexBufferGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VertexBufferGL.cpp; sourceTree = "<group>"; };
+		521EDA021C00D3430092B2E9 /* VertexBufferGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexBufferGL.h; sourceTree = "<group>"; };
+		521EDA031C00D3430092B2E9 /* VtxColorMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VtxColorMaterial.cpp; sourceTree = "<group>"; };
+		521EDA041C00D3430092B2E9 /* VtxColorMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VtxColorMaterial.h; sourceTree = "<group>"; };
+		521EDA051C00D3430092B2E9 /* Drawables.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Drawables.cpp; path = ../src/graphics/Drawables.cpp; sourceTree = "<group>"; };
+		521EDA061C00D3430092B2E9 /* Drawables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Drawables.h; path = ../src/graphics/Drawables.h; sourceTree = "<group>"; };
+		521EDA071C00D3430092B2E9 /* Frustum.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Frustum.cpp; path = ../src/graphics/Frustum.cpp; sourceTree = "<group>"; };
+		521EDA081C00D3430092B2E9 /* Frustum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Frustum.h; path = ../src/graphics/Frustum.h; sourceTree = "<group>"; };
+		521EDA091C00D3430092B2E9 /* Graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Graphics.cpp; path = ../src/graphics/Graphics.cpp; sourceTree = "<group>"; };
+		521EDA0A1C00D3430092B2E9 /* Graphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Graphics.h; path = ../src/graphics/Graphics.h; sourceTree = "<group>"; };
+		521EDA0B1C00D3430092B2E9 /* Light.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Light.cpp; path = ../src/graphics/Light.cpp; sourceTree = "<group>"; };
+		521EDA0C1C00D3430092B2E9 /* Light.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Light.h; path = ../src/graphics/Light.h; sourceTree = "<group>"; };
+		521EDA0D1C00D3430092B2E9 /* Material.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Material.cpp; path = ../src/graphics/Material.cpp; sourceTree = "<group>"; };
+		521EDA0E1C00D3430092B2E9 /* Material.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Material.h; path = ../src/graphics/Material.h; sourceTree = "<group>"; };
+		521EDA0F1C00D3430092B2E9 /* Renderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Renderer.cpp; path = ../src/graphics/Renderer.cpp; sourceTree = "<group>"; };
+		521EDA101C00D3430092B2E9 /* Renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Renderer.h; path = ../src/graphics/Renderer.h; sourceTree = "<group>"; };
+		521EDA111C00D3430092B2E9 /* RenderState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RenderState.h; path = ../src/graphics/RenderState.h; sourceTree = "<group>"; };
+		521EDA121C00D3430092B2E9 /* RenderTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RenderTarget.h; path = ../src/graphics/RenderTarget.h; sourceTree = "<group>"; };
+		521EDA131C00D3430092B2E9 /* Stats.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Stats.cpp; path = ../src/graphics/Stats.cpp; sourceTree = "<group>"; };
+		521EDA141C00D3430092B2E9 /* Stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Stats.h; path = ../src/graphics/Stats.h; sourceTree = "<group>"; };
+		521EDA151C00D3430092B2E9 /* Texture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Texture.h; path = ../src/graphics/Texture.h; sourceTree = "<group>"; };
+		521EDA161C00D3430092B2E9 /* TextureBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextureBuilder.cpp; path = ../src/graphics/TextureBuilder.cpp; sourceTree = "<group>"; };
+		521EDA171C00D3430092B2E9 /* TextureBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextureBuilder.h; path = ../src/graphics/TextureBuilder.h; sourceTree = "<group>"; };
+		521EDA181C00D3430092B2E9 /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Types.h; path = ../src/graphics/Types.h; sourceTree = "<group>"; };
+		521EDA191C00D3430092B2E9 /* VertexArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VertexArray.cpp; path = ../src/graphics/VertexArray.cpp; sourceTree = "<group>"; };
+		521EDA1A1C00D3430092B2E9 /* VertexArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VertexArray.h; path = ../src/graphics/VertexArray.h; sourceTree = "<group>"; };
+		521EDA1B1C00D3430092B2E9 /* VertexBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VertexBuffer.cpp; path = ../src/graphics/VertexBuffer.cpp; sourceTree = "<group>"; };
+		521EDA1C1C00D3430092B2E9 /* VertexBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VertexBuffer.h; path = ../src/graphics/VertexBuffer.h; sourceTree = "<group>"; };
+		521EDA1D1C00D3430092B2E9 /* WindowSDL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WindowSDL.cpp; path = ../src/graphics/WindowSDL.cpp; sourceTree = "<group>"; };
+		521EDA1E1C00D3430092B2E9 /* WindowSDL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WindowSDL.h; path = ../src/graphics/WindowSDL.h; sourceTree = "<group>"; };
+		521EDA1F1C00D3430092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/graphics/Makefile.am; sourceTree = "<group>"; };
+		521EDA411C00D3550092B2E9 /* Gui.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Gui.cpp; path = ../src/gui/Gui.cpp; sourceTree = "<group>"; };
+		521EDA421C00D3550092B2E9 /* Gui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Gui.h; path = ../src/gui/Gui.h; sourceTree = "<group>"; };
+		521EDA431C00D3550092B2E9 /* GuiAdjustment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiAdjustment.h; path = ../src/gui/GuiAdjustment.h; sourceTree = "<group>"; };
+		521EDA441C00D3550092B2E9 /* GuiBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiBox.cpp; path = ../src/gui/GuiBox.cpp; sourceTree = "<group>"; };
+		521EDA451C00D3550092B2E9 /* GuiBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiBox.h; path = ../src/gui/GuiBox.h; sourceTree = "<group>"; };
+		521EDA461C00D3550092B2E9 /* GuiButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiButton.cpp; path = ../src/gui/GuiButton.cpp; sourceTree = "<group>"; };
+		521EDA471C00D3550092B2E9 /* GuiButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiButton.h; path = ../src/gui/GuiButton.h; sourceTree = "<group>"; };
+		521EDA481C00D3550092B2E9 /* GuiContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiContainer.cpp; path = ../src/gui/GuiContainer.cpp; sourceTree = "<group>"; };
+		521EDA491C00D3550092B2E9 /* GuiContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiContainer.h; path = ../src/gui/GuiContainer.h; sourceTree = "<group>"; };
+		521EDA4A1C00D3550092B2E9 /* GuiEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiEvents.h; path = ../src/gui/GuiEvents.h; sourceTree = "<group>"; };
+		521EDA4B1C00D3550092B2E9 /* GuiFixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiFixed.cpp; path = ../src/gui/GuiFixed.cpp; sourceTree = "<group>"; };
+		521EDA4C1C00D3550092B2E9 /* GuiFixed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiFixed.h; path = ../src/gui/GuiFixed.h; sourceTree = "<group>"; };
+		521EDA4D1C00D3550092B2E9 /* GuiImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiImage.cpp; path = ../src/gui/GuiImage.cpp; sourceTree = "<group>"; };
+		521EDA4E1C00D3550092B2E9 /* GuiImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiImage.h; path = ../src/gui/GuiImage.h; sourceTree = "<group>"; };
+		521EDA4F1C00D3550092B2E9 /* GuiImageButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiImageButton.cpp; path = ../src/gui/GuiImageButton.cpp; sourceTree = "<group>"; };
+		521EDA501C00D3550092B2E9 /* GuiImageButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiImageButton.h; path = ../src/gui/GuiImageButton.h; sourceTree = "<group>"; };
+		521EDA511C00D3550092B2E9 /* GuiImageRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiImageRadioButton.cpp; path = ../src/gui/GuiImageRadioButton.cpp; sourceTree = "<group>"; };
+		521EDA521C00D3550092B2E9 /* GuiImageRadioButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiImageRadioButton.h; path = ../src/gui/GuiImageRadioButton.h; sourceTree = "<group>"; };
+		521EDA531C00D3550092B2E9 /* GuiISelectable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiISelectable.h; path = ../src/gui/GuiISelectable.h; sourceTree = "<group>"; };
+		521EDA541C00D3550092B2E9 /* GuiLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiLabel.cpp; path = ../src/gui/GuiLabel.cpp; sourceTree = "<group>"; };
+		521EDA551C00D3550092B2E9 /* GuiLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiLabel.h; path = ../src/gui/GuiLabel.h; sourceTree = "<group>"; };
+		521EDA561C00D3550092B2E9 /* GuiLabelSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiLabelSet.cpp; path = ../src/gui/GuiLabelSet.cpp; sourceTree = "<group>"; };
+		521EDA571C00D3550092B2E9 /* GuiLabelSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiLabelSet.h; path = ../src/gui/GuiLabelSet.h; sourceTree = "<group>"; };
+		521EDA581C00D3550092B2E9 /* GuiMeterBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiMeterBar.cpp; path = ../src/gui/GuiMeterBar.cpp; sourceTree = "<group>"; };
+		521EDA591C00D3550092B2E9 /* GuiMeterBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiMeterBar.h; path = ../src/gui/GuiMeterBar.h; sourceTree = "<group>"; };
+		521EDA5A1C00D3550092B2E9 /* GuiMultiStateImageButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiMultiStateImageButton.cpp; path = ../src/gui/GuiMultiStateImageButton.cpp; sourceTree = "<group>"; };
+		521EDA5B1C00D3550092B2E9 /* GuiMultiStateImageButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiMultiStateImageButton.h; path = ../src/gui/GuiMultiStateImageButton.h; sourceTree = "<group>"; };
+		521EDA5C1C00D3550092B2E9 /* GuiRadioButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiRadioButton.cpp; path = ../src/gui/GuiRadioButton.cpp; sourceTree = "<group>"; };
+		521EDA5D1C00D3550092B2E9 /* GuiRadioButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiRadioButton.h; path = ../src/gui/GuiRadioButton.h; sourceTree = "<group>"; };
+		521EDA5E1C00D3550092B2E9 /* GuiRadioGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiRadioGroup.cpp; path = ../src/gui/GuiRadioGroup.cpp; sourceTree = "<group>"; };
+		521EDA5F1C00D3550092B2E9 /* GuiRadioGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiRadioGroup.h; path = ../src/gui/GuiRadioGroup.h; sourceTree = "<group>"; };
+		521EDA601C00D3550092B2E9 /* GuiScreen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiScreen.cpp; path = ../src/gui/GuiScreen.cpp; sourceTree = "<group>"; };
+		521EDA611C00D3550092B2E9 /* GuiScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiScreen.h; path = ../src/gui/GuiScreen.h; sourceTree = "<group>"; };
+		521EDA621C00D3550092B2E9 /* GuiStack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiStack.cpp; path = ../src/gui/GuiStack.cpp; sourceTree = "<group>"; };
+		521EDA631C00D3550092B2E9 /* GuiStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiStack.h; path = ../src/gui/GuiStack.h; sourceTree = "<group>"; };
+		521EDA641C00D3550092B2E9 /* GuiTabbed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiTabbed.cpp; path = ../src/gui/GuiTabbed.cpp; sourceTree = "<group>"; };
+		521EDA651C00D3550092B2E9 /* GuiTabbed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiTabbed.h; path = ../src/gui/GuiTabbed.h; sourceTree = "<group>"; };
+		521EDA661C00D3550092B2E9 /* GuiTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiTextEntry.cpp; path = ../src/gui/GuiTextEntry.cpp; sourceTree = "<group>"; };
+		521EDA671C00D3550092B2E9 /* GuiTextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiTextEntry.h; path = ../src/gui/GuiTextEntry.h; sourceTree = "<group>"; };
+		521EDA681C00D3550092B2E9 /* GuiTextLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiTextLayout.cpp; path = ../src/gui/GuiTextLayout.cpp; sourceTree = "<group>"; };
+		521EDA691C00D3550092B2E9 /* GuiTextLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiTextLayout.h; path = ../src/gui/GuiTextLayout.h; sourceTree = "<group>"; };
+		521EDA6A1C00D3550092B2E9 /* GuiTexturedQuad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiTexturedQuad.cpp; path = ../src/gui/GuiTexturedQuad.cpp; sourceTree = "<group>"; };
+		521EDA6B1C00D3550092B2E9 /* GuiTexturedQuad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiTexturedQuad.h; path = ../src/gui/GuiTexturedQuad.h; sourceTree = "<group>"; };
+		521EDA6C1C00D3550092B2E9 /* GuiToggleButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiToggleButton.cpp; path = ../src/gui/GuiToggleButton.cpp; sourceTree = "<group>"; };
+		521EDA6D1C00D3550092B2E9 /* GuiToggleButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiToggleButton.h; path = ../src/gui/GuiToggleButton.h; sourceTree = "<group>"; };
+		521EDA6E1C00D3550092B2E9 /* GuiToolTip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiToolTip.cpp; path = ../src/gui/GuiToolTip.cpp; sourceTree = "<group>"; };
+		521EDA6F1C00D3550092B2E9 /* GuiToolTip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiToolTip.h; path = ../src/gui/GuiToolTip.h; sourceTree = "<group>"; };
+		521EDA701C00D3550092B2E9 /* GuiVScrollBar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiVScrollBar.cpp; path = ../src/gui/GuiVScrollBar.cpp; sourceTree = "<group>"; };
+		521EDA711C00D3550092B2E9 /* GuiVScrollBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiVScrollBar.h; path = ../src/gui/GuiVScrollBar.h; sourceTree = "<group>"; };
+		521EDA721C00D3550092B2E9 /* GuiVScrollPortal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiVScrollPortal.cpp; path = ../src/gui/GuiVScrollPortal.cpp; sourceTree = "<group>"; };
+		521EDA731C00D3550092B2E9 /* GuiVScrollPortal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiVScrollPortal.h; path = ../src/gui/GuiVScrollPortal.h; sourceTree = "<group>"; };
+		521EDA741C00D3550092B2E9 /* GuiWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GuiWidget.cpp; path = ../src/gui/GuiWidget.cpp; sourceTree = "<group>"; };
+		521EDA751C00D3550092B2E9 /* GuiWidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GuiWidget.h; path = ../src/gui/GuiWidget.h; sourceTree = "<group>"; };
+		521EDA761C00D3550092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/gui/Makefile.am; sourceTree = "<group>"; };
+		521EDA911C00D3610092B2E9 /* FileSystemPosix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FileSystemPosix.cpp; path = ../src/posix/FileSystemPosix.cpp; sourceTree = "<group>"; };
+		521EDA921C00D3610092B2E9 /* OSPosix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OSPosix.cpp; path = ../src/posix/OSPosix.cpp; sourceTree = "<group>"; };
+		521EDA931C00D3610092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/posix/Makefile.am; sourceTree = "<group>"; };
+		521EDA971C00D36D0092B2E9 /* Animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Animation.cpp; path = ../src/scenegraph/Animation.cpp; sourceTree = "<group>"; };
+		521EDA981C00D36D0092B2E9 /* Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Animation.h; path = ../src/scenegraph/Animation.h; sourceTree = "<group>"; };
+		521EDA991C00D36D0092B2E9 /* AnimationChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AnimationChannel.h; path = ../src/scenegraph/AnimationChannel.h; sourceTree = "<group>"; };
+		521EDA9A1C00D36D0092B2E9 /* AnimationKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AnimationKey.h; path = ../src/scenegraph/AnimationKey.h; sourceTree = "<group>"; };
+		521EDA9B1C00D36D0092B2E9 /* BaseLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BaseLoader.cpp; path = ../src/scenegraph/BaseLoader.cpp; sourceTree = "<group>"; };
+		521EDA9C1C00D36D0092B2E9 /* BaseLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BaseLoader.h; path = ../src/scenegraph/BaseLoader.h; sourceTree = "<group>"; };
+		521EDA9D1C00D36D0092B2E9 /* Billboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Billboard.cpp; path = ../src/scenegraph/Billboard.cpp; sourceTree = "<group>"; };
+		521EDA9E1C00D36D0092B2E9 /* Billboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Billboard.h; path = ../src/scenegraph/Billboard.h; sourceTree = "<group>"; };
+		521EDA9F1C00D36D0092B2E9 /* BinaryConverter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BinaryConverter.cpp; path = ../src/scenegraph/BinaryConverter.cpp; sourceTree = "<group>"; };
+		521EDAA01C00D36D0092B2E9 /* BinaryConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BinaryConverter.h; path = ../src/scenegraph/BinaryConverter.h; sourceTree = "<group>"; };
+		521EDAA11C00D36D0092B2E9 /* CollisionGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollisionGeometry.cpp; path = ../src/scenegraph/CollisionGeometry.cpp; sourceTree = "<group>"; };
+		521EDAA21C00D36D0092B2E9 /* CollisionGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionGeometry.h; path = ../src/scenegraph/CollisionGeometry.h; sourceTree = "<group>"; };
+		521EDAA31C00D36D0092B2E9 /* CollisionVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CollisionVisitor.cpp; path = ../src/scenegraph/CollisionVisitor.cpp; sourceTree = "<group>"; };
+		521EDAA41C00D36D0092B2E9 /* CollisionVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CollisionVisitor.h; path = ../src/scenegraph/CollisionVisitor.h; sourceTree = "<group>"; };
+		521EDAA51C00D36D0092B2E9 /* ColorMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ColorMap.cpp; path = ../src/scenegraph/ColorMap.cpp; sourceTree = "<group>"; };
+		521EDAA61C00D36D0092B2E9 /* ColorMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ColorMap.h; path = ../src/scenegraph/ColorMap.h; sourceTree = "<group>"; };
+		521EDAA71C00D36D0092B2E9 /* DumpVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DumpVisitor.cpp; path = ../src/scenegraph/DumpVisitor.cpp; sourceTree = "<group>"; };
+		521EDAA81C00D36D0092B2E9 /* DumpVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DumpVisitor.h; path = ../src/scenegraph/DumpVisitor.h; sourceTree = "<group>"; };
+		521EDAA91C00D36D0092B2E9 /* FindNodeVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FindNodeVisitor.cpp; path = ../src/scenegraph/FindNodeVisitor.cpp; sourceTree = "<group>"; };
+		521EDAAA1C00D36D0092B2E9 /* FindNodeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FindNodeVisitor.h; path = ../src/scenegraph/FindNodeVisitor.h; sourceTree = "<group>"; };
+		521EDAAB1C00D36D0092B2E9 /* Group.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Group.cpp; path = ../src/scenegraph/Group.cpp; sourceTree = "<group>"; };
+		521EDAAC1C00D36D0092B2E9 /* Group.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Group.h; path = ../src/scenegraph/Group.h; sourceTree = "<group>"; };
+		521EDAAD1C00D36D0092B2E9 /* Label3D.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Label3D.cpp; path = ../src/scenegraph/Label3D.cpp; sourceTree = "<group>"; };
+		521EDAAE1C00D36D0092B2E9 /* Label3D.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Label3D.h; path = ../src/scenegraph/Label3D.h; sourceTree = "<group>"; };
+		521EDAAF1C00D36D0092B2E9 /* Loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Loader.cpp; path = ../src/scenegraph/Loader.cpp; sourceTree = "<group>"; };
+		521EDAB01C00D36D0092B2E9 /* Loader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Loader.h; path = ../src/scenegraph/Loader.h; sourceTree = "<group>"; };
+		521EDAB11C00D36D0092B2E9 /* LoaderDefinitions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LoaderDefinitions.h; path = ../src/scenegraph/LoaderDefinitions.h; sourceTree = "<group>"; };
+		521EDAB21C00D36D0092B2E9 /* LOD.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LOD.cpp; path = ../src/scenegraph/LOD.cpp; sourceTree = "<group>"; };
+		521EDAB31C00D36D0092B2E9 /* LOD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LOD.h; path = ../src/scenegraph/LOD.h; sourceTree = "<group>"; };
+		521EDAB41C00D36D0092B2E9 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lua.cpp; path = ../src/scenegraph/Lua.cpp; sourceTree = "<group>"; };
+		521EDAB51C00D36D0092B2E9 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lua.h; path = ../src/scenegraph/Lua.h; sourceTree = "<group>"; };
+		521EDAB61C00D36D0092B2E9 /* LuaModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaModel.cpp; path = ../src/scenegraph/LuaModel.cpp; sourceTree = "<group>"; };
+		521EDAB71C00D36D0092B2E9 /* LuaModelSkin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaModelSkin.cpp; path = ../src/scenegraph/LuaModelSkin.cpp; sourceTree = "<group>"; };
+		521EDAB81C00D36D0092B2E9 /* MatrixTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MatrixTransform.cpp; path = ../src/scenegraph/MatrixTransform.cpp; sourceTree = "<group>"; };
+		521EDAB91C00D36D0092B2E9 /* MatrixTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MatrixTransform.h; path = ../src/scenegraph/MatrixTransform.h; sourceTree = "<group>"; };
+		521EDABA1C00D36D0092B2E9 /* Model.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Model.cpp; path = ../src/scenegraph/Model.cpp; sourceTree = "<group>"; };
+		521EDABB1C00D36D0092B2E9 /* Model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Model.h; path = ../src/scenegraph/Model.h; sourceTree = "<group>"; };
+		521EDABC1C00D36D0092B2E9 /* ModelNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelNode.cpp; path = ../src/scenegraph/ModelNode.cpp; sourceTree = "<group>"; };
+		521EDABD1C00D36D0092B2E9 /* ModelNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelNode.h; path = ../src/scenegraph/ModelNode.h; sourceTree = "<group>"; };
+		521EDABE1C00D36D0092B2E9 /* ModelSkin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ModelSkin.cpp; path = ../src/scenegraph/ModelSkin.cpp; sourceTree = "<group>"; };
+		521EDABF1C00D36D0092B2E9 /* ModelSkin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ModelSkin.h; path = ../src/scenegraph/ModelSkin.h; sourceTree = "<group>"; };
+		521EDAC01C00D36D0092B2E9 /* Node.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Node.cpp; path = ../src/scenegraph/Node.cpp; sourceTree = "<group>"; };
+		521EDAC11C00D36D0092B2E9 /* Node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Node.h; path = ../src/scenegraph/Node.h; sourceTree = "<group>"; };
+		521EDAC21C00D36D0092B2E9 /* NodeCopyCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NodeCopyCache.h; path = ../src/scenegraph/NodeCopyCache.h; sourceTree = "<group>"; };
+		521EDAC31C00D36D0092B2E9 /* NodeVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NodeVisitor.cpp; path = ../src/scenegraph/NodeVisitor.cpp; sourceTree = "<group>"; };
+		521EDAC41C00D36D0092B2E9 /* NodeVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NodeVisitor.h; path = ../src/scenegraph/NodeVisitor.h; sourceTree = "<group>"; };
+		521EDAC51C00D36D0092B2E9 /* Parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Parser.cpp; path = ../src/scenegraph/Parser.cpp; sourceTree = "<group>"; };
+		521EDAC61C00D36D0092B2E9 /* Parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Parser.h; path = ../src/scenegraph/Parser.h; sourceTree = "<group>"; };
+		521EDAC71C00D36D0092B2E9 /* Pattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Pattern.cpp; path = ../src/scenegraph/Pattern.cpp; sourceTree = "<group>"; };
+		521EDAC81C00D36D0092B2E9 /* Pattern.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Pattern.h; path = ../src/scenegraph/Pattern.h; sourceTree = "<group>"; };
+		521EDAC91C00D36D0092B2E9 /* SceneGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SceneGraph.h; path = ../src/scenegraph/SceneGraph.h; sourceTree = "<group>"; };
+		521EDACA1C00D36D0092B2E9 /* StaticGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = StaticGeometry.cpp; path = ../src/scenegraph/StaticGeometry.cpp; sourceTree = "<group>"; };
+		521EDACB1C00D36D0092B2E9 /* StaticGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StaticGeometry.h; path = ../src/scenegraph/StaticGeometry.h; sourceTree = "<group>"; };
+		521EDACC1C00D36D0092B2E9 /* Thruster.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Thruster.cpp; path = ../src/scenegraph/Thruster.cpp; sourceTree = "<group>"; };
+		521EDACD1C00D36D0092B2E9 /* Thruster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Thruster.h; path = ../src/scenegraph/Thruster.h; sourceTree = "<group>"; };
+		521EDACE1C00D36D0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/scenegraph/Makefile.am; sourceTree = "<group>"; };
+		521EDAEA1C00D37B0092B2E9 /* Terrain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Terrain.cpp; path = ../src/terrain/Terrain.cpp; sourceTree = "<group>"; };
+		521EDAEB1C00D37B0092B2E9 /* Terrain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Terrain.h; path = ../src/terrain/Terrain.h; sourceTree = "<group>"; };
+		521EDAEC1C00D37B0092B2E9 /* TerrainColorAsteroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorAsteroid.cpp; path = ../src/terrain/TerrainColorAsteroid.cpp; sourceTree = "<group>"; };
+		521EDAED1C00D37B0092B2E9 /* TerrainColorBandedRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorBandedRock.cpp; path = ../src/terrain/TerrainColorBandedRock.cpp; sourceTree = "<group>"; };
+		521EDAEE1C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorDeadWithWater.cpp; path = ../src/terrain/TerrainColorDeadWithWater.cpp; sourceTree = "<group>"; };
+		521EDAEF1C00D37B0092B2E9 /* TerrainColorDesert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorDesert.cpp; path = ../src/terrain/TerrainColorDesert.cpp; sourceTree = "<group>"; };
+		521EDAF01C00D37B0092B2E9 /* TerrainColorEarthLike.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorEarthLike.cpp; path = ../src/terrain/TerrainColorEarthLike.cpp; sourceTree = "<group>"; };
+		521EDAF11C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorEarthLikeHeightmapped.cpp; path = ../src/terrain/TerrainColorEarthLikeHeightmapped.cpp; sourceTree = "<group>"; };
+		521EDAF21C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGJupiter.cpp; path = ../src/terrain/TerrainColorGGJupiter.cpp; sourceTree = "<group>"; };
+		521EDAF31C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGNeptune.cpp; path = ../src/terrain/TerrainColorGGNeptune.cpp; sourceTree = "<group>"; };
+		521EDAF41C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGNeptune2.cpp; path = ../src/terrain/TerrainColorGGNeptune2.cpp; sourceTree = "<group>"; };
+		521EDAF51C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGSaturn.cpp; path = ../src/terrain/TerrainColorGGSaturn.cpp; sourceTree = "<group>"; };
+		521EDAF61C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGSaturn2.cpp; path = ../src/terrain/TerrainColorGGSaturn2.cpp; sourceTree = "<group>"; };
+		521EDAF71C00D37B0092B2E9 /* TerrainColorGGUranus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorGGUranus.cpp; path = ../src/terrain/TerrainColorGGUranus.cpp; sourceTree = "<group>"; };
+		521EDAF81C00D37B0092B2E9 /* TerrainColorIce.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorIce.cpp; path = ../src/terrain/TerrainColorIce.cpp; sourceTree = "<group>"; };
+		521EDAF91C00D37B0092B2E9 /* TerrainColorMethane.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorMethane.cpp; path = ../src/terrain/TerrainColorMethane.cpp; sourceTree = "<group>"; };
+		521EDAFA1C00D37B0092B2E9 /* TerrainColorRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorRock.cpp; path = ../src/terrain/TerrainColorRock.cpp; sourceTree = "<group>"; };
+		521EDAFB1C00D37B0092B2E9 /* TerrainColorRock2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorRock2.cpp; path = ../src/terrain/TerrainColorRock2.cpp; sourceTree = "<group>"; };
+		521EDAFC1C00D37B0092B2E9 /* TerrainColorSolid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorSolid.cpp; path = ../src/terrain/TerrainColorSolid.cpp; sourceTree = "<group>"; };
+		521EDAFD1C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarBrownDwarf.cpp; path = ../src/terrain/TerrainColorStarBrownDwarf.cpp; sourceTree = "<group>"; };
+		521EDAFE1C00D37B0092B2E9 /* TerrainColorStarG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarG.cpp; path = ../src/terrain/TerrainColorStarG.cpp; sourceTree = "<group>"; };
+		521EDAFF1C00D37B0092B2E9 /* TerrainColorStarK.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarK.cpp; path = ../src/terrain/TerrainColorStarK.cpp; sourceTree = "<group>"; };
+		521EDB001C00D37B0092B2E9 /* TerrainColorStarM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarM.cpp; path = ../src/terrain/TerrainColorStarM.cpp; sourceTree = "<group>"; };
+		521EDB011C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorStarWhiteDwarf.cpp; path = ../src/terrain/TerrainColorStarWhiteDwarf.cpp; sourceTree = "<group>"; };
+		521EDB021C00D37B0092B2E9 /* TerrainColorTFGood.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorTFGood.cpp; path = ../src/terrain/TerrainColorTFGood.cpp; sourceTree = "<group>"; };
+		521EDB031C00D37B0092B2E9 /* TerrainColorTFPoor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorTFPoor.cpp; path = ../src/terrain/TerrainColorTFPoor.cpp; sourceTree = "<group>"; };
+		521EDB041C00D37B0092B2E9 /* TerrainColorVolcanic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainColorVolcanic.cpp; path = ../src/terrain/TerrainColorVolcanic.cpp; sourceTree = "<group>"; };
+		521EDB051C00D37B0092B2E9 /* TerrainFeature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainFeature.cpp; path = ../src/terrain/TerrainFeature.cpp; sourceTree = "<group>"; };
+		521EDB061C00D37B0092B2E9 /* TerrainFeature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TerrainFeature.h; path = ../src/terrain/TerrainFeature.h; sourceTree = "<group>"; };
+		521EDB071C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightAsteroid.cpp; path = ../src/terrain/TerrainHeightAsteroid.cpp; sourceTree = "<group>"; };
+		521EDB081C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightAsteroid2.cpp; path = ../src/terrain/TerrainHeightAsteroid2.cpp; sourceTree = "<group>"; };
+		521EDB091C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightAsteroid3.cpp; path = ../src/terrain/TerrainHeightAsteroid3.cpp; sourceTree = "<group>"; };
+		521EDB0A1C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightAsteroid4.cpp; path = ../src/terrain/TerrainHeightAsteroid4.cpp; sourceTree = "<group>"; };
+		521EDB0B1C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightBarrenRock.cpp; path = ../src/terrain/TerrainHeightBarrenRock.cpp; sourceTree = "<group>"; };
+		521EDB0C1C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightBarrenRock2.cpp; path = ../src/terrain/TerrainHeightBarrenRock2.cpp; sourceTree = "<group>"; };
+		521EDB0D1C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightBarrenRock3.cpp; path = ../src/terrain/TerrainHeightBarrenRock3.cpp; sourceTree = "<group>"; };
+		521EDB0E1C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightEllipsoid.cpp; path = ../src/terrain/TerrainHeightEllipsoid.cpp; sourceTree = "<group>"; };
+		521EDB0F1C00D37B0092B2E9 /* TerrainHeightFlat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightFlat.cpp; path = ../src/terrain/TerrainHeightFlat.cpp; sourceTree = "<group>"; };
+		521EDB101C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsCraters.cpp; path = ../src/terrain/TerrainHeightHillsCraters.cpp; sourceTree = "<group>"; };
+		521EDB111C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsCraters2.cpp; path = ../src/terrain/TerrainHeightHillsCraters2.cpp; sourceTree = "<group>"; };
+		521EDB121C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsDunes.cpp; path = ../src/terrain/TerrainHeightHillsDunes.cpp; sourceTree = "<group>"; };
+		521EDB131C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsNormal.cpp; path = ../src/terrain/TerrainHeightHillsNormal.cpp; sourceTree = "<group>"; };
+		521EDB141C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsRidged.cpp; path = ../src/terrain/TerrainHeightHillsRidged.cpp; sourceTree = "<group>"; };
+		521EDB151C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightHillsRivers.cpp; path = ../src/terrain/TerrainHeightHillsRivers.cpp; sourceTree = "<group>"; };
+		521EDB161C00D37B0092B2E9 /* TerrainHeightMapped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMapped.cpp; path = ../src/terrain/TerrainHeightMapped.cpp; sourceTree = "<group>"; };
+		521EDB171C00D37B0092B2E9 /* TerrainHeightMapped2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMapped2.cpp; path = ../src/terrain/TerrainHeightMapped2.cpp; sourceTree = "<group>"; };
+		521EDB181C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsCraters.cpp; path = ../src/terrain/TerrainHeightMountainsCraters.cpp; sourceTree = "<group>"; };
+		521EDB191C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsCraters2.cpp; path = ../src/terrain/TerrainHeightMountainsCraters2.cpp; sourceTree = "<group>"; };
+		521EDB1A1C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsNormal.cpp; path = ../src/terrain/TerrainHeightMountainsNormal.cpp; sourceTree = "<group>"; };
+		521EDB1B1C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsRidged.cpp; path = ../src/terrain/TerrainHeightMountainsRidged.cpp; sourceTree = "<group>"; };
+		521EDB1C1C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsRivers.cpp; path = ../src/terrain/TerrainHeightMountainsRivers.cpp; sourceTree = "<group>"; };
+		521EDB1D1C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsRiversVolcano.cpp; path = ../src/terrain/TerrainHeightMountainsRiversVolcano.cpp; sourceTree = "<group>"; };
+		521EDB1E1C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightMountainsVolcano.cpp; path = ../src/terrain/TerrainHeightMountainsVolcano.cpp; sourceTree = "<group>"; };
+		521EDB1F1C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightRuggedDesert.cpp; path = ../src/terrain/TerrainHeightRuggedDesert.cpp; sourceTree = "<group>"; };
+		521EDB201C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightRuggedLava.cpp; path = ../src/terrain/TerrainHeightRuggedLava.cpp; sourceTree = "<group>"; };
+		521EDB211C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightWaterSolid.cpp; path = ../src/terrain/TerrainHeightWaterSolid.cpp; sourceTree = "<group>"; };
+		521EDB221C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TerrainHeightWaterSolidCanyons.cpp; path = ../src/terrain/TerrainHeightWaterSolidCanyons.cpp; sourceTree = "<group>"; };
+		521EDB231C00D37B0092B2E9 /* TerrainNoise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TerrainNoise.h; path = ../src/terrain/TerrainNoise.h; sourceTree = "<group>"; };
+		521EDB241C00D37B0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/terrain/Makefile.am; sourceTree = "<group>"; };
+		521EDB5D1C00D38B0092B2E9 /* DistanceFieldFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DistanceFieldFont.cpp; path = ../src/text/DistanceFieldFont.cpp; sourceTree = "<group>"; };
+		521EDB5E1C00D38B0092B2E9 /* DistanceFieldFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DistanceFieldFont.h; path = ../src/text/DistanceFieldFont.h; sourceTree = "<group>"; };
+		521EDB5F1C00D38B0092B2E9 /* FontConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FontConfig.cpp; path = ../src/text/FontConfig.cpp; sourceTree = "<group>"; };
+		521EDB601C00D38B0092B2E9 /* FontConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FontConfig.h; path = ../src/text/FontConfig.h; sourceTree = "<group>"; };
+		521EDB611C00D38B0092B2E9 /* TextSupport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextSupport.cpp; path = ../src/text/TextSupport.cpp; sourceTree = "<group>"; };
+		521EDB621C00D38B0092B2E9 /* TextSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextSupport.h; path = ../src/text/TextSupport.h; sourceTree = "<group>"; };
+		521EDB631C00D38B0092B2E9 /* TextureFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextureFont.cpp; path = ../src/text/TextureFont.cpp; sourceTree = "<group>"; };
+		521EDB641C00D38B0092B2E9 /* TextureFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextureFont.h; path = ../src/text/TextureFont.h; sourceTree = "<group>"; };
+		521EDB651C00D38B0092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/text/Makefile.am; sourceTree = "<group>"; };
+		521EDB6B1C00D3A20092B2E9 /* Align.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Align.cpp; path = ../src/ui/Align.cpp; sourceTree = "<group>"; };
+		521EDB6C1C00D3A20092B2E9 /* Align.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Align.h; path = ../src/ui/Align.h; sourceTree = "<group>"; };
+		521EDB6D1C00D3A20092B2E9 /* Animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Animation.cpp; path = ../src/ui/Animation.cpp; sourceTree = "<group>"; };
+		521EDB6E1C00D3A20092B2E9 /* Animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Animation.h; path = ../src/ui/Animation.h; sourceTree = "<group>"; };
+		521EDB6F1C00D3A20092B2E9 /* Background.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Background.cpp; path = ../src/ui/Background.cpp; sourceTree = "<group>"; };
+		521EDB701C00D3A20092B2E9 /* Background.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Background.h; path = ../src/ui/Background.h; sourceTree = "<group>"; };
+		521EDB711C00D3A20092B2E9 /* Box.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Box.cpp; path = ../src/ui/Box.cpp; sourceTree = "<group>"; };
+		521EDB721C00D3A20092B2E9 /* Box.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Box.h; path = ../src/ui/Box.h; sourceTree = "<group>"; };
+		521EDB731C00D3A20092B2E9 /* Button.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Button.cpp; path = ../src/ui/Button.cpp; sourceTree = "<group>"; };
+		521EDB741C00D3A20092B2E9 /* Button.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Button.h; path = ../src/ui/Button.h; sourceTree = "<group>"; };
+		521EDB751C00D3A20092B2E9 /* CellSpec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CellSpec.cpp; path = ../src/ui/CellSpec.cpp; sourceTree = "<group>"; };
+		521EDB761C00D3A20092B2E9 /* CellSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CellSpec.h; path = ../src/ui/CellSpec.h; sourceTree = "<group>"; };
+		521EDB771C00D3A20092B2E9 /* CheckBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CheckBox.cpp; path = ../src/ui/CheckBox.cpp; sourceTree = "<group>"; };
+		521EDB781C00D3A20092B2E9 /* CheckBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CheckBox.h; path = ../src/ui/CheckBox.h; sourceTree = "<group>"; };
+		521EDB791C00D3A20092B2E9 /* ColorBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ColorBackground.cpp; path = ../src/ui/ColorBackground.cpp; sourceTree = "<group>"; };
+		521EDB7A1C00D3A20092B2E9 /* ColorBackground.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ColorBackground.h; path = ../src/ui/ColorBackground.h; sourceTree = "<group>"; };
+		521EDB7B1C00D3A20092B2E9 /* Container.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Container.cpp; path = ../src/ui/Container.cpp; sourceTree = "<group>"; };
+		521EDB7C1C00D3A20092B2E9 /* Container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Container.h; path = ../src/ui/Container.h; sourceTree = "<group>"; };
+		521EDB7D1C00D3A20092B2E9 /* Context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Context.cpp; path = ../src/ui/Context.cpp; sourceTree = "<group>"; };
+		521EDB7E1C00D3A20092B2E9 /* Context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Context.h; path = ../src/ui/Context.h; sourceTree = "<group>"; };
+		521EDB7F1C00D3A20092B2E9 /* DropDown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DropDown.cpp; path = ../src/ui/DropDown.cpp; sourceTree = "<group>"; };
+		521EDB801C00D3A20092B2E9 /* DropDown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DropDown.h; path = ../src/ui/DropDown.h; sourceTree = "<group>"; };
+		521EDB811C00D3A20092B2E9 /* Event.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Event.cpp; path = ../src/ui/Event.cpp; sourceTree = "<group>"; };
+		521EDB821C00D3A20092B2E9 /* Event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Event.h; path = ../src/ui/Event.h; sourceTree = "<group>"; };
+		521EDB831C00D3A20092B2E9 /* EventDispatcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EventDispatcher.cpp; path = ../src/ui/EventDispatcher.cpp; sourceTree = "<group>"; };
+		521EDB841C00D3A20092B2E9 /* EventDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EventDispatcher.h; path = ../src/ui/EventDispatcher.h; sourceTree = "<group>"; };
+		521EDB851C00D3A20092B2E9 /* Expand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Expand.cpp; path = ../src/ui/Expand.cpp; sourceTree = "<group>"; };
+		521EDB861C00D3A20092B2E9 /* Expand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Expand.h; path = ../src/ui/Expand.h; sourceTree = "<group>"; };
+		521EDB871C00D3A20092B2E9 /* Gauge.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Gauge.cpp; path = ../src/ui/Gauge.cpp; sourceTree = "<group>"; };
+		521EDB881C00D3A20092B2E9 /* Gauge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Gauge.h; path = ../src/ui/Gauge.h; sourceTree = "<group>"; };
+		521EDB891C00D3A20092B2E9 /* Gradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Gradient.cpp; path = ../src/ui/Gradient.cpp; sourceTree = "<group>"; };
+		521EDB8A1C00D3A20092B2E9 /* Gradient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Gradient.h; path = ../src/ui/Gradient.h; sourceTree = "<group>"; };
+		521EDB8B1C00D3A20092B2E9 /* Grid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Grid.cpp; path = ../src/ui/Grid.cpp; sourceTree = "<group>"; };
+		521EDB8C1C00D3A20092B2E9 /* Grid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Grid.h; path = ../src/ui/Grid.h; sourceTree = "<group>"; };
+		521EDB8D1C00D3A20092B2E9 /* Icon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Icon.cpp; path = ../src/ui/Icon.cpp; sourceTree = "<group>"; };
+		521EDB8E1C00D3A20092B2E9 /* Icon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Icon.h; path = ../src/ui/Icon.h; sourceTree = "<group>"; };
+		521EDB8F1C00D3A20092B2E9 /* Image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Image.cpp; path = ../src/ui/Image.cpp; sourceTree = "<group>"; };
+		521EDB901C00D3A20092B2E9 /* Image.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Image.h; path = ../src/ui/Image.h; sourceTree = "<group>"; };
+		521EDB911C00D3A20092B2E9 /* Label.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Label.cpp; path = ../src/ui/Label.cpp; sourceTree = "<group>"; };
+		521EDB921C00D3A20092B2E9 /* Label.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Label.h; path = ../src/ui/Label.h; sourceTree = "<group>"; };
+		521EDB931C00D3A20092B2E9 /* Layer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Layer.cpp; path = ../src/ui/Layer.cpp; sourceTree = "<group>"; };
+		521EDB941C00D3A20092B2E9 /* Layer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Layer.h; path = ../src/ui/Layer.h; sourceTree = "<group>"; };
+		521EDB951C00D3A20092B2E9 /* List.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = List.cpp; path = ../src/ui/List.cpp; sourceTree = "<group>"; };
+		521EDB961C00D3A20092B2E9 /* List.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = List.h; path = ../src/ui/List.h; sourceTree = "<group>"; };
+		521EDB971C00D3A20092B2E9 /* Lua.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Lua.cpp; path = ../src/ui/Lua.cpp; sourceTree = "<group>"; };
+		521EDB981C00D3A20092B2E9 /* Lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Lua.h; path = ../src/ui/Lua.h; sourceTree = "<group>"; };
+		521EDB991C00D3A20092B2E9 /* LuaAlign.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaAlign.cpp; path = ../src/ui/LuaAlign.cpp; sourceTree = "<group>"; };
+		521EDB9A1C00D3A20092B2E9 /* LuaAnimation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaAnimation.cpp; path = ../src/ui/LuaAnimation.cpp; sourceTree = "<group>"; };
+		521EDB9B1C00D3A20092B2E9 /* LuaBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaBackground.cpp; path = ../src/ui/LuaBackground.cpp; sourceTree = "<group>"; };
+		521EDB9C1C00D3A20092B2E9 /* LuaBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaBox.cpp; path = ../src/ui/LuaBox.cpp; sourceTree = "<group>"; };
+		521EDB9D1C00D3A20092B2E9 /* LuaButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaButton.cpp; path = ../src/ui/LuaButton.cpp; sourceTree = "<group>"; };
+		521EDB9E1C00D3A20092B2E9 /* LuaCheckBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaCheckBox.cpp; path = ../src/ui/LuaCheckBox.cpp; sourceTree = "<group>"; };
+		521EDB9F1C00D3A20092B2E9 /* LuaColorBackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaColorBackground.cpp; path = ../src/ui/LuaColorBackground.cpp; sourceTree = "<group>"; };
+		521EDBA01C00D3A20092B2E9 /* LuaContainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaContainer.cpp; path = ../src/ui/LuaContainer.cpp; sourceTree = "<group>"; };
+		521EDBA11C00D3A20092B2E9 /* LuaContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaContext.cpp; path = ../src/ui/LuaContext.cpp; sourceTree = "<group>"; };
+		521EDBA21C00D3A20092B2E9 /* LuaDropDown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaDropDown.cpp; path = ../src/ui/LuaDropDown.cpp; sourceTree = "<group>"; };
+		521EDBA31C00D3A20092B2E9 /* LuaExpand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaExpand.cpp; path = ../src/ui/LuaExpand.cpp; sourceTree = "<group>"; };
+		521EDBA41C00D3A20092B2E9 /* LuaGauge.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaGauge.cpp; path = ../src/ui/LuaGauge.cpp; sourceTree = "<group>"; };
+		521EDBA51C00D3A20092B2E9 /* LuaGradient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaGradient.cpp; path = ../src/ui/LuaGradient.cpp; sourceTree = "<group>"; };
+		521EDBA61C00D3A20092B2E9 /* LuaGrid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaGrid.cpp; path = ../src/ui/LuaGrid.cpp; sourceTree = "<group>"; };
+		521EDBA71C00D3A20092B2E9 /* LuaIcon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaIcon.cpp; path = ../src/ui/LuaIcon.cpp; sourceTree = "<group>"; };
+		521EDBA81C00D3A20092B2E9 /* LuaImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaImage.cpp; path = ../src/ui/LuaImage.cpp; sourceTree = "<group>"; };
+		521EDBA91C00D3A20092B2E9 /* LuaLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaLabel.cpp; path = ../src/ui/LuaLabel.cpp; sourceTree = "<group>"; };
+		521EDBAA1C00D3A20092B2E9 /* LuaLayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaLayer.cpp; path = ../src/ui/LuaLayer.cpp; sourceTree = "<group>"; };
+		521EDBAB1C00D3A20092B2E9 /* LuaList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaList.cpp; path = ../src/ui/LuaList.cpp; sourceTree = "<group>"; };
+		521EDBAC1C00D3A20092B2E9 /* LuaMargin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMargin.cpp; path = ../src/ui/LuaMargin.cpp; sourceTree = "<group>"; };
+		521EDBAD1C00D3A20092B2E9 /* LuaMultiLineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaMultiLineText.cpp; path = ../src/ui/LuaMultiLineText.cpp; sourceTree = "<group>"; };
+		521EDBAE1C00D3A20092B2E9 /* LuaNumberLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaNumberLabel.cpp; path = ../src/ui/LuaNumberLabel.cpp; sourceTree = "<group>"; };
+		521EDBAF1C00D3A20092B2E9 /* LuaScroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaScroller.cpp; path = ../src/ui/LuaScroller.cpp; sourceTree = "<group>"; };
+		521EDBB01C00D3A20092B2E9 /* LuaSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LuaSignal.h; path = ../src/ui/LuaSignal.h; sourceTree = "<group>"; };
+		521EDBB11C00D3A20092B2E9 /* LuaSingle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSingle.cpp; path = ../src/ui/LuaSingle.cpp; sourceTree = "<group>"; };
+		521EDBB21C00D3A20092B2E9 /* LuaSlider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSlider.cpp; path = ../src/ui/LuaSlider.cpp; sourceTree = "<group>"; };
+		521EDBB31C00D3A20092B2E9 /* LuaSmallButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaSmallButton.cpp; path = ../src/ui/LuaSmallButton.cpp; sourceTree = "<group>"; };
+		521EDBB41C00D3A20092B2E9 /* LuaTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaTable.cpp; path = ../src/ui/LuaTable.cpp; sourceTree = "<group>"; };
+		521EDBB51C00D3A20092B2E9 /* LuaTextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaTextEntry.cpp; path = ../src/ui/LuaTextEntry.cpp; sourceTree = "<group>"; };
+		521EDBB61C00D3A20092B2E9 /* LuaWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LuaWidget.cpp; path = ../src/ui/LuaWidget.cpp; sourceTree = "<group>"; };
+		521EDBB71C00D3A20092B2E9 /* Margin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Margin.cpp; path = ../src/ui/Margin.cpp; sourceTree = "<group>"; };
+		521EDBB81C00D3A20092B2E9 /* Margin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Margin.h; path = ../src/ui/Margin.h; sourceTree = "<group>"; };
+		521EDBB91C00D3A20092B2E9 /* MousePointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MousePointer.h; path = ../src/ui/MousePointer.h; sourceTree = "<group>"; };
+		521EDBBA1C00D3A20092B2E9 /* MultiLineText.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MultiLineText.cpp; path = ../src/ui/MultiLineText.cpp; sourceTree = "<group>"; };
+		521EDBBB1C00D3A20092B2E9 /* MultiLineText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MultiLineText.h; path = ../src/ui/MultiLineText.h; sourceTree = "<group>"; };
+		521EDBBC1C00D3A20092B2E9 /* NumberLabel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NumberLabel.cpp; path = ../src/ui/NumberLabel.cpp; sourceTree = "<group>"; };
+		521EDBBD1C00D3A20092B2E9 /* NumberLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NumberLabel.h; path = ../src/ui/NumberLabel.h; sourceTree = "<group>"; };
+		521EDBBE1C00D3A20092B2E9 /* Point.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Point.h; path = ../src/ui/Point.h; sourceTree = "<group>"; };
+		521EDBBF1C00D3A20092B2E9 /* Scroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Scroller.cpp; path = ../src/ui/Scroller.cpp; sourceTree = "<group>"; };
+		521EDBC01C00D3A20092B2E9 /* Scroller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Scroller.h; path = ../src/ui/Scroller.h; sourceTree = "<group>"; };
+		521EDBC11C00D3A20092B2E9 /* Single.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Single.cpp; path = ../src/ui/Single.cpp; sourceTree = "<group>"; };
+		521EDBC21C00D3A20092B2E9 /* Single.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Single.h; path = ../src/ui/Single.h; sourceTree = "<group>"; };
+		521EDBC31C00D3A20092B2E9 /* Skin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Skin.cpp; path = ../src/ui/Skin.cpp; sourceTree = "<group>"; };
+		521EDBC41C00D3A20092B2E9 /* Skin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Skin.h; path = ../src/ui/Skin.h; sourceTree = "<group>"; };
+		521EDBC51C00D3A20092B2E9 /* Slider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Slider.cpp; path = ../src/ui/Slider.cpp; sourceTree = "<group>"; };
+		521EDBC61C00D3A20092B2E9 /* Slider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Slider.h; path = ../src/ui/Slider.h; sourceTree = "<group>"; };
+		521EDBC71C00D3A20092B2E9 /* SmallButton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SmallButton.cpp; path = ../src/ui/SmallButton.cpp; sourceTree = "<group>"; };
+		521EDBC81C00D3A20092B2E9 /* SmallButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SmallButton.h; path = ../src/ui/SmallButton.h; sourceTree = "<group>"; };
+		521EDBC91C00D3A20092B2E9 /* Table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Table.cpp; path = ../src/ui/Table.cpp; sourceTree = "<group>"; };
+		521EDBCA1C00D3A20092B2E9 /* Table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Table.h; path = ../src/ui/Table.h; sourceTree = "<group>"; };
+		521EDBCB1C00D3A20092B2E9 /* TextEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextEntry.cpp; path = ../src/ui/TextEntry.cpp; sourceTree = "<group>"; };
+		521EDBCC1C00D3A20092B2E9 /* TextEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextEntry.h; path = ../src/ui/TextEntry.h; sourceTree = "<group>"; };
+		521EDBCD1C00D3A20092B2E9 /* TextLayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TextLayout.cpp; path = ../src/ui/TextLayout.cpp; sourceTree = "<group>"; };
+		521EDBCE1C00D3A20092B2E9 /* TextLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TextLayout.h; path = ../src/ui/TextLayout.h; sourceTree = "<group>"; };
+		521EDBCF1C00D3A20092B2E9 /* Widget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Widget.cpp; path = ../src/ui/Widget.cpp; sourceTree = "<group>"; };
+		521EDBD01C00D3A20092B2E9 /* Widget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Widget.h; path = ../src/ui/Widget.h; sourceTree = "<group>"; };
+		521EDBD11C00D3A20092B2E9 /* WidgetSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WidgetSet.h; path = ../src/ui/WidgetSet.h; sourceTree = "<group>"; };
+		521EDBD21C00D3A20092B2E9 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Makefile.am; path = ../src/ui/Makefile.am; sourceTree = "<group>"; };
+		521EDC2A1C00D4720092B2E9 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = ../../../../../System/Library/Frameworks/OpenGL.framework; sourceTree = "<group>"; };
+		521EDC2C1C00D7950092B2E9 /* libGLEW.1.13.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libGLEW.1.13.0.dylib; path = ../../../../../opt/local/lib/libGLEW.1.13.0.dylib; sourceTree = "<group>"; };
+		521EDC2E1C00D7F40092B2E9 /* libjpeg.9.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjpeg.9.dylib; path = ../../../../../opt/local/lib/libjpeg.9.dylib; sourceTree = "<group>"; };
+		521EDC301C00D8AB0092B2E9 /* libpng16.16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpng16.16.dylib; path = ../../../../../opt/local/lib/libpng16.16.dylib; sourceTree = "<group>"; };
+		521EDC321C00D8CA0092B2E9 /* libtiff.5.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libtiff.5.dylib; path = ../../../../../opt/local/lib/libtiff.5.dylib; sourceTree = "<group>"; };
+		521EDC331C00D8CA0092B2E9 /* libz.1.2.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.2.8.dylib; path = ../../../../../opt/local/lib/libz.1.2.8.dylib; sourceTree = "<group>"; };
+		52C6DBF71C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2_image-2.0.0.dylib"; path = "/opt/local/lib/libSDL2_image-2.0.0.dylib"; sourceTree = "<absolute>"; };
+		52C6DBF81C0250CC00B6CB63 /* libSDL2-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2-2.0.0.dylib"; path = "/opt/local/lib/libSDL2-2.0.0.dylib"; sourceTree = "<absolute>"; };
+		52D125931C0351FB00E6E4C2 /* json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = json.h; sourceTree = "<group>"; };
+		52D125941C0351FB00E6E4C2 /* jsoncpp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsoncpp.cpp; sourceTree = "<group>"; };
+		52D125951C0351FB00E6E4C2 /* JsonUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JsonUtils.cpp; sourceTree = "<group>"; };
+		52D125961C0351FB00E6E4C2 /* JsonUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JsonUtils.h; sourceTree = "<group>"; };
+		52D125971C0351FB00E6E4C2 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		52D125DF1C0351FB00E6E4C2 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		52D125E01C0351FB00E6E4C2 /* PicoDDS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PicoDDS.cpp; sourceTree = "<group>"; };
+		52D125E11C0351FB00E6E4C2 /* PicoDDS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PicoDDS.h; sourceTree = "<group>"; };
+		52D1261B1C03538F00E6E4C2 /* lapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lapi.c; sourceTree = "<group>"; };
+		52D1261C1C03538F00E6E4C2 /* lapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lapi.h; sourceTree = "<group>"; };
+		52D1261D1C03538F00E6E4C2 /* lauxlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lauxlib.c; sourceTree = "<group>"; };
+		52D1261E1C03538F00E6E4C2 /* lauxlib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lauxlib.h; sourceTree = "<group>"; };
+		52D1261F1C03538F00E6E4C2 /* lbaselib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lbaselib.c; sourceTree = "<group>"; };
+		52D126201C03538F00E6E4C2 /* lbitlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lbitlib.c; sourceTree = "<group>"; };
+		52D126211C03538F00E6E4C2 /* lcode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcode.c; sourceTree = "<group>"; };
+		52D126221C03538F00E6E4C2 /* lcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lcode.h; sourceTree = "<group>"; };
+		52D126231C03538F00E6E4C2 /* lcorolib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lcorolib.c; sourceTree = "<group>"; };
+		52D126241C03538F00E6E4C2 /* lctype.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lctype.c; sourceTree = "<group>"; };
+		52D126251C03538F00E6E4C2 /* lctype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lctype.h; sourceTree = "<group>"; };
+		52D126261C03538F00E6E4C2 /* ldblib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldblib.c; sourceTree = "<group>"; };
+		52D126271C03538F00E6E4C2 /* ldebug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldebug.c; sourceTree = "<group>"; };
+		52D126281C03538F00E6E4C2 /* ldebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ldebug.h; sourceTree = "<group>"; };
+		52D126291C03538F00E6E4C2 /* ldo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldo.c; sourceTree = "<group>"; };
+		52D1262A1C03538F00E6E4C2 /* ldo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ldo.h; sourceTree = "<group>"; };
+		52D1262B1C03538F00E6E4C2 /* ldump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ldump.c; sourceTree = "<group>"; };
+		52D1262C1C03538F00E6E4C2 /* lfunc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lfunc.c; sourceTree = "<group>"; };
+		52D1262D1C03538F00E6E4C2 /* lfunc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lfunc.h; sourceTree = "<group>"; };
+		52D1262E1C03538F00E6E4C2 /* lgc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lgc.c; sourceTree = "<group>"; };
+		52D1262F1C03538F00E6E4C2 /* lgc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lgc.h; sourceTree = "<group>"; };
+		52D126301C03538F00E6E4C2 /* linit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = linit.c; sourceTree = "<group>"; };
+		52D126311C03538F00E6E4C2 /* liolib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = liolib.c; sourceTree = "<group>"; };
+		52D126321C03538F00E6E4C2 /* llex.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = llex.c; sourceTree = "<group>"; };
+		52D126331C03538F00E6E4C2 /* llex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llex.h; sourceTree = "<group>"; };
+		52D126341C03538F00E6E4C2 /* llimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = llimits.h; sourceTree = "<group>"; };
+		52D126351C03538F00E6E4C2 /* lmathlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lmathlib.c; sourceTree = "<group>"; };
+		52D126361C03538F00E6E4C2 /* lmem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lmem.c; sourceTree = "<group>"; };
+		52D126371C03538F00E6E4C2 /* lmem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lmem.h; sourceTree = "<group>"; };
+		52D126381C03538F00E6E4C2 /* loadlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loadlib.c; sourceTree = "<group>"; };
+		52D126391C03538F00E6E4C2 /* lobject.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lobject.c; sourceTree = "<group>"; };
+		52D1263A1C03538F00E6E4C2 /* lobject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lobject.h; sourceTree = "<group>"; };
+		52D1263B1C03538F00E6E4C2 /* lopcodes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lopcodes.c; sourceTree = "<group>"; };
+		52D1263C1C03538F00E6E4C2 /* lopcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lopcodes.h; sourceTree = "<group>"; };
+		52D1263D1C03538F00E6E4C2 /* loslib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = loslib.c; sourceTree = "<group>"; };
+		52D1263E1C03538F00E6E4C2 /* lparser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lparser.c; sourceTree = "<group>"; };
+		52D1263F1C03538F00E6E4C2 /* lparser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lparser.h; sourceTree = "<group>"; };
+		52D126401C03538F00E6E4C2 /* lstate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstate.c; sourceTree = "<group>"; };
+		52D126411C03538F00E6E4C2 /* lstate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstate.h; sourceTree = "<group>"; };
+		52D126421C03538F00E6E4C2 /* lstring.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstring.c; sourceTree = "<group>"; };
+		52D126431C03538F00E6E4C2 /* lstring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lstring.h; sourceTree = "<group>"; };
+		52D126441C03538F00E6E4C2 /* lstrlib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lstrlib.c; sourceTree = "<group>"; };
+		52D126451C03538F00E6E4C2 /* ltable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltable.c; sourceTree = "<group>"; };
+		52D126461C03538F00E6E4C2 /* ltable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ltable.h; sourceTree = "<group>"; };
+		52D126471C03538F00E6E4C2 /* ltablib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltablib.c; sourceTree = "<group>"; };
+		52D126481C03538F00E6E4C2 /* ltm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ltm.c; sourceTree = "<group>"; };
+		52D126491C03538F00E6E4C2 /* ltm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ltm.h; sourceTree = "<group>"; };
+		52D1264B1C03538F00E6E4C2 /* lua.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lua.h; sourceTree = "<group>"; };
+		52D1264C1C03538F00E6E4C2 /* lua.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lua.hpp; sourceTree = "<group>"; };
+		52D1264E1C03538F00E6E4C2 /* luaconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = luaconf.h; sourceTree = "<group>"; };
+		52D1264F1C03538F00E6E4C2 /* lualib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lualib.h; sourceTree = "<group>"; };
+		52D126501C03538F00E6E4C2 /* lundump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lundump.c; sourceTree = "<group>"; };
+		52D126511C03538F00E6E4C2 /* lundump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lundump.h; sourceTree = "<group>"; };
+		52D126521C03538F00E6E4C2 /* lvm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lvm.c; sourceTree = "<group>"; };
+		52D126531C03538F00E6E4C2 /* lvm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lvm.h; sourceTree = "<group>"; };
+		52D126541C03538F00E6E4C2 /* lzio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lzio.c; sourceTree = "<group>"; };
+		52D126551C03538F00E6E4C2 /* lzio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lzio.h; sourceTree = "<group>"; };
+		52D126561C03538F00E6E4C2 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		52E5FADB1C0356F2001F4F89 /* libcurl.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcurl.dylib; path = ../../../../../usr/lib/libcurl.dylib; sourceTree = "<group>"; };
+		52E5FADE1C03589F001F4F89 /* lookup3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lookup3.c; sourceTree = "<group>"; };
+		52E5FADF1C03589F001F4F89 /* lookup3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lookup3.h; sourceTree = "<group>"; };
+		52E5FAE01C03589F001F4F89 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		52E5FAF21C0375F2001F4F89 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		52E5FAF31C0375F2001F4F89 /* miniz.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = miniz.h; sourceTree = "<group>"; };
+		52E5FAF41C0375F2001F4F89 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1253,179 +1354,40 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				52D125751C033A5100E6E4C2 /* libSDL2_image-2.0.0.dylib in Frameworks */,
+				52D125741C033A4200E6E4C2 /* libSDL2-2.0.0.dylib in Frameworks */,
 				4ACDB6D416787A6A0069FA03 /* libassimp.3.0.0.dylib in Frameworks */,
-				4A7611261611A8C800A06F79 /* libGLEW.1.9.0.dylib in Frameworks */,
-				4A7611221611A80C00A06F79 /* libz.1.2.7.dylib in Frameworks */,
-				4A7611201611A7B000A06F79 /* libpng15.15.dylib in Frameworks */,
-				4A76111D1611A76C00A06F79 /* OpenGL.framework in Frameworks */,
+				521EDC351C00D8CA0092B2E9 /* libz.1.2.8.dylib in Frameworks */,
+				52E5FADC1C0356F2001F4F89 /* libcurl.dylib in Frameworks */,
 				4A20B0E3135319770020F43E /* Cocoa.framework in Frameworks */,
 				4A5619D513867033002A904C /* libvorbisfile.3.dylib in Frameworks */,
 				4A5619CF13866622002A904C /* libfreetype.6.dylib in Frameworks */,
-				4AE5CA401383E65B00B55DEB /* libSDL_sound-1.0.1.0.2.dylib in Frameworks */,
-				4AE5CA3E1383E63C00B55DEB /* libSDL_image-1.2.0.dylib in Frameworks */,
-				4AE5CA3B1383E2D000B55DEB /* libSDL-1.2.0.dylib in Frameworks */,
 				4A6C4EA2135452FF00FDD53F /* libsigc-2.0.0.dylib in Frameworks */,
+				521EDC2F1C00D7F40092B2E9 /* libjpeg.9.dylib in Frameworks */,
 				4AEEBC4A162A4A5700C6EA6F /* libXrandr.2.dylib in Frameworks */,
 				4AEEBC4C162A4ADC00C6EA6F /* libXext.6.dylib in Frameworks */,
+				521EDC2B1C00D4720092B2E9 /* OpenGL.framework in Frameworks */,
 				4AEEBC50162A4B9B00C6EA6F /* libXrender.1.dylib in Frameworks */,
 				4AEEBC55162A4BF700C6EA6F /* libX11.6.dylib in Frameworks */,
 				4AEEBC56162A4BF700C6EA6F /* libXau.6.dylib in Frameworks */,
+				521EDC311C00D8AB0092B2E9 /* libpng16.16.dylib in Frameworks */,
 				4AEEBC57162A4BF700C6EA6F /* libXdmcp.6.dylib in Frameworks */,
 				4AEEBC5C162A4C7800C6EA6F /* libxcb.1.dylib in Frameworks */,
 				4AEEBC5F162A4F5B00C6EA6F /* libbz2.1.0.6.dylib in Frameworks */,
+				521EDC341C00D8CA0092B2E9 /* libtiff.5.dylib in Frameworks */,
+				521EDC2D1C00D7950092B2E9 /* libGLEW.1.13.0.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		4A19030B138AA33300E0229C /* gui */ = {
-			isa = PBXGroup;
-			children = (
-				4A9174F215187B69006A15A9 /* GuiTexturedQuad.cpp */,
-				4A9174F315187B69006A15A9 /* GuiTexturedQuad.h */,
-				4A190325138AA33300E0229C /* Gui.cpp */,
-				4A190326138AA33300E0229C /* Gui.h */,
-				4A190328138AA33300E0229C /* GuiAdjustment.h */,
-				4A190329138AA33300E0229C /* GuiBox.cpp */,
-				4A19032A138AA33300E0229C /* GuiBox.h */,
-				4A19032C138AA33300E0229C /* GuiButton.cpp */,
-				4A19032D138AA33300E0229C /* GuiButton.h */,
-				4A19032F138AA33300E0229C /* GuiContainer.cpp */,
-				4A190330138AA33300E0229C /* GuiContainer.h */,
-				4A190332138AA33300E0229C /* GuiEvents.h */,
-				4A190333138AA33300E0229C /* GuiFixed.cpp */,
-				4A190334138AA33300E0229C /* GuiFixed.h */,
-				4A24078013F524E6002A5C12 /* GuiGradient.cpp */,
-				4A24078113F524E6002A5C12 /* GuiGradient.h */,
-				4A190336138AA33300E0229C /* GuiImage.cpp */,
-				4A190337138AA33300E0229C /* GuiImage.h */,
-				4A190339138AA33300E0229C /* GuiImageButton.cpp */,
-				4A19033A138AA33300E0229C /* GuiImageButton.h */,
-				4A19033C138AA33300E0229C /* GuiImageRadioButton.cpp */,
-				4A19033D138AA33300E0229C /* GuiImageRadioButton.h */,
-				4A19033F138AA33300E0229C /* GuiISelectable.h */,
-				4A190340138AA33300E0229C /* GuiLabel.cpp */,
-				4A190341138AA33300E0229C /* GuiLabel.h */,
-				4A190343138AA33300E0229C /* GuiLabelSet.cpp */,
-				4A190344138AA33300E0229C /* GuiLabelSet.h */,
-				4A190346138AA33300E0229C /* GuiMeterBar.cpp */,
-				4A190347138AA33300E0229C /* GuiMeterBar.h */,
-				4A190349138AA33300E0229C /* GuiMultiStateImageButton.cpp */,
-				4A19034A138AA33300E0229C /* GuiMultiStateImageButton.h */,
-				4A19034C138AA33300E0229C /* GuiRadioButton.cpp */,
-				4A19034D138AA33300E0229C /* GuiRadioButton.h */,
-				4A19034F138AA33300E0229C /* GuiRadioGroup.cpp */,
-				4A190350138AA33300E0229C /* GuiRadioGroup.h */,
-				4A190352138AA33300E0229C /* GuiRepeaterButton.cpp */,
-				4A190353138AA33300E0229C /* GuiRepeaterButton.h */,
-				4A190355138AA33300E0229C /* GuiScreen.cpp */,
-				4A190356138AA33300E0229C /* GuiScreen.h */,
-				4A24078213F524E6002A5C12 /* GuiStack.cpp */,
-				4A24078313F524E6002A5C12 /* GuiStack.h */,
-				4A190358138AA33300E0229C /* GuiTabbed.cpp */,
-				4A190359138AA33300E0229C /* GuiTabbed.h */,
-				4A19035B138AA33300E0229C /* GuiTextEntry.cpp */,
-				4A19035C138AA33300E0229C /* GuiTextEntry.h */,
-				4A19035E138AA33300E0229C /* GuiTextLayout.cpp */,
-				4A19035F138AA33300E0229C /* GuiTextLayout.h */,
-				4A190361138AA33300E0229C /* GuiToggleButton.cpp */,
-				4A190362138AA33300E0229C /* GuiToggleButton.h */,
-				4A190364138AA33300E0229C /* GuiToolTip.cpp */,
-				4A190365138AA33300E0229C /* GuiToolTip.h */,
-				4A190367138AA33300E0229C /* GuiVScrollBar.cpp */,
-				4A190368138AA33300E0229C /* GuiVScrollBar.h */,
-				4A19036A138AA33300E0229C /* GuiVScrollPortal.cpp */,
-				4A19036B138AA33300E0229C /* GuiVScrollPortal.h */,
-				4A19036D138AA33300E0229C /* GuiWidget.cpp */,
-				4A19036E138AA33300E0229C /* GuiWidget.h */,
-			);
-			path = gui;
-			sourceTree = "<group>";
-		};
-		4A1903C1138AA39C00E0229C /* contrib */ = {
-			isa = PBXGroup;
-			children = (
-				4A37073215A879D100E7E5F6 /* jenkins */,
-				4A1903C2138AA39C00E0229C /* lua */,
-				4AAC9FDC15458FE400116131 /* miniz */,
-				4AE46C471607513400308C22 /* vcacheopt */,
-			);
-			name = contrib;
-			path = ../contrib;
-			sourceTree = "<group>";
-		};
-		4A1903C2138AA39C00E0229C /* lua */ = {
-			isa = PBXGroup;
-			children = (
-				4A59B4D51557EAF5009926E5 /* lbitlib.c */,
-				4A59B4D61557EAF5009926E5 /* lcorolib.c */,
-				4A59B4D71557EAF5009926E5 /* lctype.c */,
-				4A59B4D81557EAF5009926E5 /* lctype.h */,
-				4A59B4D91557EAF5009926E5 /* lua.hpp */,
-				4A1903E2138AA39C00E0229C /* lapi.c */,
-				4A1903E3138AA39C00E0229C /* lapi.h */,
-				4A1903E5138AA39C00E0229C /* lauxlib.c */,
-				4A1903E6138AA39C00E0229C /* lauxlib.h */,
-				4A1903E8138AA39C00E0229C /* lbaselib.c */,
-				4A1903EA138AA39C00E0229C /* lcode.c */,
-				4A1903EB138AA39C00E0229C /* lcode.h */,
-				4A1903ED138AA39C00E0229C /* ldblib.c */,
-				4A1903EF138AA39C00E0229C /* ldebug.c */,
-				4A1903F0138AA39C00E0229C /* ldebug.h */,
-				4A1903F2138AA39C00E0229C /* ldo.c */,
-				4A1903F3138AA39C00E0229C /* ldo.h */,
-				4A1903F5138AA39C00E0229C /* ldump.c */,
-				4A1903F7138AA39C00E0229C /* lfunc.c */,
-				4A1903F8138AA39C00E0229C /* lfunc.h */,
-				4A1903FA138AA39C00E0229C /* lgc.c */,
-				4A1903FB138AA39C00E0229C /* lgc.h */,
-				4A1903FE138AA39C00E0229C /* linit.c */,
-				4A190400138AA39C00E0229C /* liolib.c */,
-				4A190402138AA39C00E0229C /* llex.c */,
-				4A190403138AA39C00E0229C /* llex.h */,
-				4A190405138AA39C00E0229C /* llimits.h */,
-				4A190406138AA39C00E0229C /* lmathlib.c */,
-				4A190408138AA39C00E0229C /* lmem.c */,
-				4A190409138AA39C00E0229C /* lmem.h */,
-				4A19040B138AA39C00E0229C /* loadlib.c */,
-				4A19040D138AA39C00E0229C /* lobject.c */,
-				4A19040E138AA39C00E0229C /* lobject.h */,
-				4A190410138AA39C00E0229C /* lopcodes.c */,
-				4A190411138AA39C00E0229C /* lopcodes.h */,
-				4A190413138AA39C00E0229C /* loslib.c */,
-				4A190415138AA39C00E0229C /* lparser.c */,
-				4A190416138AA39C00E0229C /* lparser.h */,
-				4A190418138AA39C00E0229C /* lstate.c */,
-				4A190419138AA39C00E0229C /* lstate.h */,
-				4A19041B138AA39C00E0229C /* lstring.c */,
-				4A19041C138AA39C00E0229C /* lstring.h */,
-				4A19041E138AA39C00E0229C /* lstrlib.c */,
-				4A190420138AA39C00E0229C /* ltable.c */,
-				4A190421138AA39C00E0229C /* ltable.h */,
-				4A190423138AA39C00E0229C /* ltablib.c */,
-				4A190425138AA39C00E0229C /* ltm.c */,
-				4A190426138AA39C00E0229C /* ltm.h */,
-				4A190428138AA39C00E0229C /* lua.c */,
-				4A190429138AA39C00E0229C /* lua.h */,
-				4A19042A138AA39C00E0229C /* luac.c */,
-				4A19042B138AA39C00E0229C /* luaconf.h */,
-				4A19042C138AA39C00E0229C /* lualib.h */,
-				4A19042D138AA39C00E0229C /* lundump.c */,
-				4A19042E138AA39C00E0229C /* lundump.h */,
-				4A190430138AA39C00E0229C /* lvm.c */,
-				4A190431138AA39C00E0229C /* lvm.h */,
-				4A190433138AA39C00E0229C /* lzio.c */,
-				4A190434138AA39C00E0229C /* lzio.h */,
-			);
-			path = lua;
-			sourceTree = "<group>";
-		};
 		4A20B0CE1353194B0020F43E = {
 			isa = PBXGroup;
 			children = (
+				52D1258A1C0351FB00E6E4C2 /* contrib */,
+				521ED7D31C00D1280092B2E9 /* src */,
 				4A6C55141354655000FDD53F /* data */,
-				4A6C4B9F13532FC300FDD53F /* src */,
 				4A20B11213531CAF0020F43E /* Cocoa Support Files */,
 				4A20B0E1135319770020F43E /* Frameworks */,
 				4A9822A9142DF91B00B423F1 /* Misc TXT files */,
@@ -1444,12 +1406,12 @@
 		4A20B0E1135319770020F43E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				52E5FADB1C0356F2001F4F89 /* libcurl.dylib */,
+				52C6DBF71C0250CC00B6CB63 /* libSDL2_image-2.0.0.dylib */,
+				52C6DBF81C0250CC00B6CB63 /* libSDL2-2.0.0.dylib */,
+				521EDC2C1C00D7950092B2E9 /* libGLEW.1.13.0.dylib */,
 				4ACDB6D316787A6A0069FA03 /* libassimp.3.0.0.dylib */,
 				4A5619CE13866622002A904C /* libfreetype.6.dylib */,
-				4A7611251611A8C800A06F79 /* libGLEW.1.9.0.dylib */,
-				4AE5CA3A1383E2D000B55DEB /* libSDL-1.2.0.dylib */,
-				4AE5CA3D1383E63C00B55DEB /* libSDL_image-1.2.0.dylib */,
-				4AE5CA3F1383E65B00B55DEB /* libSDL_sound-1.0.1.0.2.dylib */,
 				4A6C4EA1135452FF00FDD53F /* libsigc-2.0.0.dylib */,
 				4A5619D413867033002A904C /* libvorbisfile.3.dylib */,
 				4A20B0E4135319770020F43E /* Other Frameworks */,
@@ -1461,7 +1423,7 @@
 		4A20B0E4135319770020F43E /* Other Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				4A76111C1611A76C00A06F79 /* OpenGL.framework */,
+				521EDC2A1C00D4720092B2E9 /* OpenGL.framework */,
 				4A20B0E2135319770020F43E /* Cocoa.framework */,
 				4A20B0E5135319770020F43E /* AppKit.framework */,
 				4A20B0E6135319770020F43E /* CoreData.framework */,
@@ -1476,7 +1438,6 @@
 				4A8563FC148655DA008121E1 /* pioneer-logo.icns */,
 				4A20B11F13531E950020F43E /* pioneerApp.xib */,
 				4A20B10E13531C040020F43E /* SDLMain.h */,
-				4A20B10F13531C040020F43E /* SDLMain.m */,
 				4A20B11613531CD10020F43E /* Credits.rtf */,
 				4A20B11813531CD10020F43E /* InfoPlist.strings */,
 				4A20B11313531CC40020F43E /* pioneer-Info.plist */,
@@ -1485,82 +1446,19 @@
 			name = "Cocoa Support Files";
 			sourceTree = "<group>";
 		};
-		4A24FD601650F4D100DE7B0F /* gameui */ = {
-			isa = PBXGroup;
-			children = (
-				4AA527FB16E9EB650036D4CB /* LuaModelSpinner.cpp */,
-				4AA527FC16E9EB650036D4CB /* ModelSpinner.cpp */,
-				4AA527FD16E9EB650036D4CB /* ModelSpinner.h */,
-				4A4D25D2167335D9003BC9D5 /* Face.cpp */,
-				4A4D25D3167335D9003BC9D5 /* Face.h */,
-				4A24FD611650F4D100DE7B0F /* GameUI.h */,
-				4A24FD621650F4D100DE7B0F /* Lua.cpp */,
-				4A24FD631650F4D100DE7B0F /* Lua.h */,
-				4A4D25D4167335D9003BC9D5 /* LuaFace.cpp */,
-				4A24FD651650F4D100DE7B0F /* Panel.cpp */,
-				4A24FD661650F4D100DE7B0F /* Panel.h */,
-			);
-			path = gameui;
-			sourceTree = "<group>";
-		};
-		4A37073215A879D100E7E5F6 /* jenkins */ = {
-			isa = PBXGroup;
-			children = (
-				4A37073315A879D100E7E5F6 /* lookup3.c */,
-				4A37073415A879D100E7E5F6 /* lookup3.h */,
-			);
-			path = jenkins;
-			sourceTree = "<group>";
-		};
-		4A4F25B814F524D400FD14A6 /* graphics */ = {
-			isa = PBXGroup;
-			children = (
-				4AAB880315F4AD3500AAF8A8 /* gl2 */,
-				4AAB881115F4AD3500AAF8A8 /* MaterialLegacy.cpp */,
-				4AAB881215F4AD3500AAF8A8 /* MaterialLegacy.h */,
-				4A4F25B914F524D400FD14A6 /* Drawables.cpp */,
-				4A4F25BA14F524D400FD14A6 /* Drawables.h */,
-				4A4F25BB14F524D400FD14A6 /* Frustum.cpp */,
-				4A4F25BC14F524D400FD14A6 /* Frustum.h */,
-				4A4F25BD14F524D400FD14A6 /* Graphics.cpp */,
-				4A4F25BE14F524D400FD14A6 /* Graphics.h */,
-				4AEC8A1815C7886A00B281C3 /* Light.cpp */,
-				4AEC8A1915C7886A00B281C3 /* Light.h */,
-				4A4F25C014F524D400FD14A6 /* Material.cpp */,
-				4A4F25C114F524D400FD14A6 /* Material.h */,
-				4A4F25C214F524D400FD14A6 /* Renderer.cpp */,
-				4A4F25C314F524D400FD14A6 /* Renderer.h */,
-				4A4F25C414F524D400FD14A6 /* RendererGL2.cpp */,
-				4A4F25C514F524D400FD14A6 /* RendererGL2.h */,
-				4A4F25C614F524D400FD14A6 /* RendererGLBuffers.h */,
-				4A4F25C714F524D400FD14A6 /* RendererLegacy.cpp */,
-				4A4F25C814F524D400FD14A6 /* RendererLegacy.h */,
-				4A4F25CD14F524D400FD14A6 /* StaticMesh.cpp */,
-				4A4F25CE14F524D400FD14A6 /* StaticMesh.h */,
-				4A4F25CF14F524D400FD14A6 /* Surface.h */,
-				4A9174F615187B97006A15A9 /* Texture.h */,
-				4A9174F715187B97006A15A9 /* TextureBuilder.cpp */,
-				4A9174F815187B97006A15A9 /* TextureBuilder.h */,
-				4A9174F915187B97006A15A9 /* TextureGL.cpp */,
-				4A9174FA15187B97006A15A9 /* TextureGL.h */,
-				4A4F25D014F524D400FD14A6 /* VertexArray.cpp */,
-				4A4F25D114F524D400FD14A6 /* VertexArray.h */,
-			);
-			path = graphics;
-			sourceTree = "<group>";
-		};
 		4A671B851388C04700657F38 /* SubLibraries */ = {
 			isa = PBXGroup;
 			children = (
+				521EDC321C00D8CA0092B2E9 /* libtiff.5.dylib */,
+				521EDC331C00D8CA0092B2E9 /* libz.1.2.8.dylib */,
+				521EDC301C00D8AB0092B2E9 /* libpng16.16.dylib */,
+				521EDC2E1C00D7F40092B2E9 /* libjpeg.9.dylib */,
 				4AEEBC5E162A4F5B00C6EA6F /* libbz2.1.0.6.dylib */,
 				4A7611281611A90B00A06F79 /* libFLAC.8.dylib */,
-				4A671B951388C47200657F38 /* libjpeg.8.dylib */,
 				4A671B9B1388C6B700657F38 /* libmodplug.1.dylib */,
 				4A671B861388C07700657F38 /* libogg.0.dylib */,
-				4A76111F1611A7B000A06F79 /* libpng15.15.dylib */,
 				4A671B981388C61F00657F38 /* libsmpeg-0.4.0.dylib */,
 				4A671BA11388CA3200657F38 /* libspeex.1.5.0.dylib */,
-				4A671B921388C3DC00657F38 /* libtiff.3.dylib */,
 				4A671B871388C07700657F38 /* libvorbis.0.dylib */,
 				4AEEBC52162A4BF700C6EA6F /* libX11.6.dylib */,
 				4AEEBC53162A4BF700C6EA6F /* libXau.6.dylib */,
@@ -1569,329 +1467,8 @@
 				4AEEBC4B162A4ADC00C6EA6F /* libXext.6.dylib */,
 				4AEEBC49162A4A5700C6EA6F /* libXrandr.2.dylib */,
 				4AEEBC4F162A4B9B00C6EA6F /* libXrender.1.dylib */,
-				4A7611211611A80C00A06F79 /* libz.1.2.7.dylib */,
 			);
 			name = SubLibraries;
-			sourceTree = "<group>";
-		};
-		4A6C4B9F13532FC300FDD53F /* src */ = {
-			isa = PBXGroup;
-			children = (
-				4A6C4BFE13532FC300FDD53F /* Aabb.h */,
-				4A6C4BFF13532FC300FDD53F /* AmbientSounds.cpp */,
-				4A6C4C0013532FC300FDD53F /* AmbientSounds.h */,
-				4AAB884A15FE070900AAF8A8 /* AnimationCurves.h */,
-				4A61E15C13978F1000193E43 /* Background.cpp */,
-				4A61E15D13978F1000193E43 /* Background.h */,
-				4A6C4C0113532FC300FDD53F /* BezierCurve.h */,
-				4A6C4C0213532FC300FDD53F /* Body.cpp */,
-				4A6C4C0313532FC300FDD53F /* Body.h */,
-				4A6392C4136BD51E008352F1 /* buildopts.h */,
-				4A305FCB151341170076D414 /* ByteRange.h */,
-				4A84CB82146027DC0051C848 /* Camera.cpp */,
-				4A84CB83146027DC0051C848 /* Camera.h */,
-				4A4A86E716A992D600F81F18 /* CameraController.cpp */,
-				4A4A86E816A992D600F81F18 /* CameraController.h */,
-				4A6C4C0513532FC300FDD53F /* CargoBody.cpp */,
-				4A6C4C0613532FC300FDD53F /* CargoBody.h */,
-				4A24075513F5240F002A5C12 /* ChatForm.cpp */,
-				4A24075613F5240F002A5C12 /* ChatForm.h */,
-				4A6C4C0713532FC300FDD53F /* CityOnPlanet.cpp */,
-				4A6C4C0813532FC300FDD53F /* CityOnPlanet.h */,
-				4A6C4C0913532FC300FDD53F /* collider */,
-				4ACDB6C7167878CE0069FA03 /* CollMesh.h */,
-				4A9174FD15187C17006A15A9 /* Color.cpp */,
-				4A6C4C1C13532FC300FDD53F /* Color.h */,
-				4A6C4C1D13532FC300FDD53F /* CommodityTradeWidget.cpp */,
-				4A6C4C1E13532FC300FDD53F /* CommodityTradeWidget.h */,
-				4A1903C1138AA39C00E0229C /* contrib */,
-				4A107C2B1525AB0D00EF9FAC /* CRC32.cpp */,
-				4A107C2C1525AB0D00EF9FAC /* CRC32.h */,
-				4AF222DF162103EA00BED38E /* Cutscene.h */,
-				4A62EF27136979E000919EBB /* DeadVideoLink.cpp */,
-				4A62EF28136979E000919EBB /* DeadVideoLink.h */,
-				4A973BF31618688F0029562D /* DeathView.cpp */,
-				4A973BF41618688F0029562D /* DeathView.h */,
-				4A99371A1368355400EA0EE5 /* DeleteEmitter.h */,
-				4A6C4C2113532FC300FDD53F /* DynamicBody.cpp */,
-				4A6C4C2213532FC300FDD53F /* DynamicBody.h */,
-				4AA527F716E9EABA0036D4CB /* Easing.h */,
-				4A84CB7B14595D850051C848 /* enum_table.cpp */,
-				4A84CB7C14595D850051C848 /* enum_table.h */,
-				4ACE132C16B4B19D00CAE524 /* EnumStrings.cpp */,
-				4ACE132D16B4B19D00CAE524 /* EnumStrings.h */,
-				4A94CA4014F26875002CA792 /* EquipSet.h */,
-				4A6C4C2313532FC300FDD53F /* EquipType.cpp */,
-				4A6C4C2413532FC300FDD53F /* EquipType.h */,
-				4A62EF29136979E000919EBB /* FaceVideoLink.cpp */,
-				4A62EF2A136979E000919EBB /* FaceVideoLink.h */,
-				4AF222E0162103EA00BED38E /* Factions.cpp */,
-				4AF222E1162103EA00BED38E /* Factions.h */,
-				4AF9999B1496D51F009821AF /* FileSelectorWidget.cpp */,
-				4AF9999C1496D51F009821AF /* FileSelectorWidget.h */,
-				4AAC9FE51545901D00116131 /* FileSourceZip.cpp */,
-				4AAC9FE61545901D00116131 /* FileSourceZip.h */,
-				4A305FCC151341170076D414 /* FileSystem.cpp */,
-				4A305FCD151341170076D414 /* FileSystem.h */,
-				4A6C4C2513532FC300FDD53F /* fixed.h */,
-				4A1E9EBE144EEA8A009243D2 /* FloatComparison.h */,
-				4A94CA4114F26875002CA792 /* FontCache.cpp */,
-				4A94CA4214F26875002CA792 /* FontCache.h */,
-				4A24075713F5240F002A5C12 /* Form.h */,
-				4A24075813F5240F002A5C12 /* FormController.cpp */,
-				4A24075913F5240F002A5C12 /* FormController.h */,
-				4A6C4C2613532FC300FDD53F /* Frame.cpp */,
-				4A6C4C2713532FC300FDD53F /* Frame.h */,
-				4A6C4C2813532FC300FDD53F /* GalacticView.cpp */,
-				4A6C4C2913532FC300FDD53F /* GalacticView.h */,
-				4ADF517F1557473400ACF5A0 /* galaxy */,
-				4AF9999D1496D51F009821AF /* Game.cpp */,
-				4AF9999E1496D51F009821AF /* Game.h */,
-				4A82AA7D1386969B0028CCED /* GameConfig.cpp */,
-				4A82AA7E1386969B0028CCED /* GameConfig.h */,
-				4A6C4C2C13532FC300FDD53F /* gameconsts.h */,
-				4A6C4C2D13532FC300FDD53F /* GameMenuView.cpp */,
-				4A6C4C2E13532FC300FDD53F /* GameMenuView.h */,
-				4A24FD601650F4D100DE7B0F /* gameui */,
-				4A6C4C3113532FC300FDD53F /* GeoSphere.cpp */,
-				4A6C4C3213532FC300FDD53F /* GeoSphere.h */,
-				4A4F25B814F524D400FD14A6 /* graphics */,
-				4A19030B138AA33300E0229C /* gui */,
-				4A6C4C6A13532FC300FDD53F /* HyperspaceCloud.cpp */,
-				4A6C4C6B13532FC300FDD53F /* HyperspaceCloud.h */,
-				4A6C4C6E13532FC300FDD53F /* IniConfig.cpp */,
-				4A6C4C6F13532FC300FDD53F /* IniConfig.h */,
-				4AF222E2162103EA00BED38E /* Intro.cpp */,
-				4AF222E3162103EA00BED38E /* Intro.h */,
-				4A6C4C7013532FC300FDD53F /* KeyBindings.cpp */,
-				4A6C4C7113532FC300FDD53F /* KeyBindings.h */,
-				4AF222E4162103EA00BED38E /* KeyBindings.inc.h */,
-				4A24075A13F5240F002A5C12 /* Lang.cpp */,
-				4A24075B13F5240F002A5C12 /* Lang.h */,
-				4A305FCF151341170076D414 /* LangStrings.inc.h */,
-				4A6C4C7213532FC300FDD53F /* libs.h */,
-				4AAB881A15F4AD7700AAF8A8 /* Lua.cpp */,
-				4AAB881B15F4AD7700AAF8A8 /* Lua.h */,
-				4A99371B1368355400EA0EE5 /* LuaBody.cpp */,
-				4A99371D1368355400EA0EE5 /* LuaCargoBody.cpp */,
-				4A6C4CD013532FC300FDD53F /* LuaChatForm.cpp */,
-				4A6C4CD113532FC300FDD53F /* LuaChatForm.h */,
-				4A3AE8E3158FD22200EB13DE /* LuaComms.cpp */,
-				4A3AE8E4158FD22200EB13DE /* LuaComms.h */,
-				4A8DD539142E19B6006DD821 /* LuaConsole.cpp */,
-				4A8DD53A142E19B6006DD821 /* LuaConsole.h */,
-				4A99371F1368355500EA0EE5 /* LuaConstants.cpp */,
-				4A9937201368355500EA0EE5 /* LuaConstants.h */,
-				4A973BF51618688F0029562D /* LuaDev.cpp */,
-				4A973BF61618688F0029562D /* LuaDev.h */,
-				4A9937211368355500EA0EE5 /* LuaEngine.cpp */,
-				4A9937221368355500EA0EE5 /* LuaEngine.h */,
-				4AA84A2116D0E18700220311 /* LuaEquipDef.cpp */,
-				4AA84A2216D0E18700220311 /* LuaEquipDef.h */,
-				4AF0058915F0F30400CC19C0 /* LuaEvent.cpp */,
-				4AF0058A15F0F30400CC19C0 /* LuaEvent.h */,
-				4A239FC9163E78D60037BE24 /* LuaFaction.cpp */,
-				4AF0059115F17C6700CC19C0 /* LuaFileSystem.cpp */,
-				4AF0059215F17C6700CC19C0 /* LuaFileSystem.h */,
-				4ADF518F1557477400ACF5A0 /* LuaFixed.cpp */,
-				4ADF51901557477400ACF5A0 /* LuaFixed.h */,
-				4A9937271368355500EA0EE5 /* LuaFormat.cpp */,
-				4A9937281368355500EA0EE5 /* LuaFormat.h */,
-				4A9937291368355500EA0EE5 /* LuaGame.cpp */,
-				4A99372A1368355500EA0EE5 /* LuaGame.h */,
-				4AE9706514369D7500424F91 /* LuaLang.cpp */,
-				4AE9706614369D7500424F91 /* LuaLang.h */,
-				4A99372B1368355500EA0EE5 /* LuaManager.cpp */,
-				4A99372C1368355500EA0EE5 /* LuaManager.h */,
-				4ADF51911557477400ACF5A0 /* LuaMatrix.cpp */,
-				4ADF51921557477400ACF5A0 /* LuaMatrix.h */,
-				4ACED56816BBCC7200E53808 /* LuaMissile.cpp */,
-				4ACED56916BBCC7200E53808 /* LuaMissile.h */,
-				4A85A86313C4631D00C2B986 /* LuaMusic.cpp */,
-				4A85A86413C4631D00C2B986 /* LuaMusic.h */,
-				4A99372D1368355500EA0EE5 /* LuaNameGen.cpp */,
-				4A99372E1368355500EA0EE5 /* LuaNameGen.h */,
-				4A99372F1368355500EA0EE5 /* LuaObject.cpp */,
-				4A82AA7F1386969B0028CCED /* LuaObject.h */,
-				4A9937301368355500EA0EE5 /* LuaPlanet.cpp */,
-				4A9937321368355500EA0EE5 /* LuaPlayer.cpp */,
-				4A8AE19217208CE40005C2D9 /* LuaPropertiedObject.cpp */,
-				4AAB884415FDEA6E00AAF8A8 /* LuaPushPull.h */,
-				4A9937341368355500EA0EE5 /* LuaRand.cpp */,
-				4AAB884515FDEA6E00AAF8A8 /* LuaRef.cpp */,
-				4AAB884615FDEA6F00AAF8A8 /* LuaRef.h */,
-				4A99373A1368355500EA0EE5 /* LuaSerializer.cpp */,
-				4A99373B1368355500EA0EE5 /* LuaSerializer.h */,
-				4A99373C1368355500EA0EE5 /* LuaShip.cpp */,
-				4AA84A2316D0E18700220311 /* LuaShipDef.cpp */,
-				4AA84A2416D0E18700220311 /* LuaShipDef.h */,
-				4A9937401368355500EA0EE5 /* LuaSpace.cpp */,
-				4A9937411368355500EA0EE5 /* LuaSpace.h */,
-				4A9937421368355500EA0EE5 /* LuaSpaceStation.cpp */,
-				4A9937441368355500EA0EE5 /* LuaStar.cpp */,
-				4A9937461368355500EA0EE5 /* LuaStarSystem.cpp */,
-				4ADF51931557477400ACF5A0 /* LuaSystemBody.cpp */,
-				4A85A86513C4631D00C2B986 /* LuaSystemPath.cpp */,
-				4AAB884715FDEA6F00AAF8A8 /* LuaTable.h */,
-				4A9937481368355500EA0EE5 /* LuaTimer.cpp */,
-				4A9937491368355500EA0EE5 /* LuaTimer.h */,
-				4A99374C1368355500EA0EE5 /* LuaUtils.cpp */,
-				4A99374D1368355500EA0EE5 /* LuaUtils.h */,
-				4ADF51951557477400ACF5A0 /* LuaVector.cpp */,
-				4ADF51961557477400ACF5A0 /* LuaVector.h */,
-				4AA84A2516D0E18700220311 /* LuaWrappable.h */,
-				4A6C4CD313532FC300FDD53F /* main.cpp */,
-				4A6C4CD713532FC300FDD53F /* MarketAgent.cpp */,
-				4A6C4CD813532FC300FDD53F /* MarketAgent.h */,
-				4AF999A11496D51F009821AF /* MathUtil.cpp */,
-				4AF999A21496D51F009821AF /* MathUtil.h */,
-				4ACE132E16B4B19D00CAE524 /* matrix3x3.h */,
-				4A6C4CD913532FC300FDD53F /* matrix4x4.h */,
-				4A6C4CDA13532FC300FDD53F /* Missile.cpp */,
-				4A6C4CDB13532FC300FDD53F /* Missile.h */,
-				4A6C4CDE13532FC300FDD53F /* ModelBody.cpp */,
-				4A6C4CDF13532FC300FDD53F /* ModelBody.h */,
-				4ACDB6CA167878CE0069FA03 /* ModelCache.cpp */,
-				4ACDB6CB167878CE0069FA03 /* ModelCache.h */,
-				4ACDB6CC167878CE0069FA03 /* ModelViewer.cpp */,
-				4ACDB6CD167878CE0069FA03 /* ModelViewer.h */,
-				4AAC9FE71545901D00116131 /* ModManager.cpp */,
-				4AAC9FE81545901D00116131 /* ModManager.h */,
-				4AA527F816E9EABA0036D4CB /* NavLights.cpp */,
-				4AA527F916E9EABA0036D4CB /* NavLights.h */,
-				4A6C4CE813532FC300FDD53F /* Object.h */,
-				4A6C4CE913532FC300FDD53F /* ObjectViewerView.cpp */,
-				4A6C4CEA13532FC300FDD53F /* ObjectViewerView.h */,
-				4A712411170EC89000BB9BCC /* Orbit.cpp */,
-				4A712412170EC89000BB9BCC /* Orbit.h */,
-				4AAB881C15F4AD7700AAF8A8 /* OS.h */,
-				4A6C4D2C13532FC300FDD53F /* perlin.cpp */,
-				4A6C4D2D13532FC300FDD53F /* perlin.h */,
-				4A6C4D2E13532FC300FDD53F /* PersistSystemData.h */,
-				4A6C4D2F13532FC300FDD53F /* Pi.cpp */,
-				4A6C4D3013532FC300FDD53F /* Pi.h */,
-				4A6C4D3913532FC300FDD53F /* Planet.cpp */,
-				4A6C4D3A13532FC300FDD53F /* Planet.h */,
-				4A6C4D3B13532FC300FDD53F /* Player.cpp */,
-				4A6C4D3C13532FC300FDD53F /* Player.h */,
-				4AFBD7B71641265D002928CB /* PngWriter.cpp */,
-				4AFBD7B81641265D002928CB /* PngWriter.h */,
-				4A6C4D3F13532FC300FDD53F /* Polit.cpp */,
-				4A6C4D4013532FC300FDD53F /* Polit.h */,
-				4ADB0D1215C50DF000AE2123 /* posix */,
-				4A6C4D4113532FC300FDD53F /* Projectile.cpp */,
-				4A6C4D4213532FC300FDD53F /* Projectile.h */,
-				4A8AE19317208CE40005C2D9 /* PropertiedObject.h */,
-				4A8AE19417208CE40005C2D9 /* PropertyMap.cpp */,
-				4A8AE19517208CE50005C2D9 /* PropertyMap.h */,
-				4A6C4D4313532FC300FDD53F /* Quaternion.h */,
-				4AA84A2616D0E18700220311 /* Random.h */,
-				4A99374E1368355500EA0EE5 /* RefCounted.h */,
-				4A99374F1368355500EA0EE5 /* RefList.h */,
-				4ACDB683167878610069FA03 /* scenegraph */,
-				4ADC7B7F152C703200E359B5 /* SDLWrappers.cpp */,
-				4ADC7B80152C703200E359B5 /* SDLWrappers.h */,
-				4A6C4D4813532FC300FDD53F /* SectorView.cpp */,
-				4A6C4D4913532FC300FDD53F /* SectorView.h */,
-				4A6C4D4A13532FC300FDD53F /* Serializer.cpp */,
-				4A6C4D4B13532FC300FDD53F /* Serializer.h */,
-				4A6C4D4C13532FC300FDD53F /* Sfx.cpp */,
-				4A6C4D4D13532FC300FDD53F /* Sfx.h */,
-				4A6C4D4E13532FC300FDD53F /* Ship-AI.cpp */,
-				4A6C4D4F13532FC300FDD53F /* Ship.cpp */,
-				4A6C4D5013532FC300FDD53F /* Ship.h */,
-				4A6C4D5113532FC300FDD53F /* ShipAICmd.cpp */,
-				4A6C4D5213532FC300FDD53F /* ShipAICmd.h */,
-				4A107C2D1525AB0D00EF9FAC /* ShipController.cpp */,
-				4A107C2E1525AB0D00EF9FAC /* ShipController.h */,
-				4A6C4D5313532FC300FDD53F /* ShipCpanel.cpp */,
-				4A6C4D5413532FC300FDD53F /* ShipCpanel.h */,
-				4A6C4D5513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp */,
-				4A6C4D5613532FC300FDD53F /* ShipCpanelMultiFuncDisplays.h */,
-				4A24075C13F5240F002A5C12 /* ShipSpinnerWidget.cpp */,
-				4A24075D13F5240F002A5C12 /* ShipSpinnerWidget.h */,
-				4A6C4D5913532FC300FDD53F /* ShipType.cpp */,
-				4A6C4D5A13532FC300FDD53F /* ShipType.h */,
-				4A4F25E014F524F600FD14A6 /* SmartPtr.h */,
-				4A6C4D5B13532FC300FDD53F /* Sound.cpp */,
-				4A6C4D5C13532FC300FDD53F /* Sound.h */,
-				4A85A86713C4631D00C2B986 /* SoundMusic.cpp */,
-				4A85A86813C4631D00C2B986 /* SoundMusic.h */,
-				4A6C4D5D13532FC300FDD53F /* Space.cpp */,
-				4A6C4D5E13532FC300FDD53F /* Space.h */,
-				4A6C4D5F13532FC300FDD53F /* SpaceStation.cpp */,
-				4A6C4D6013532FC300FDD53F /* SpaceStation.h */,
-				4AEE56DB16A44CD800AA1C53 /* SpaceStationType.cpp */,
-				4AEE56DC16A44CD800AA1C53 /* SpaceStationType.h */,
-				4A6C4D6113532FC300FDD53F /* SpaceStationView.cpp */,
-				4A6C4D6213532FC300FDD53F /* SpaceStationView.h */,
-				4A6C4D6313532FC300FDD53F /* Star.cpp */,
-				4A6C4D6413532FC300FDD53F /* Star.h */,
-				4A24075E13F5240F002A5C12 /* StationAdvertForm.cpp */,
-				4A24075F13F5240F002A5C12 /* StationAdvertForm.h */,
-				4A24076013F5240F002A5C12 /* StationBulletinBoardForm.cpp */,
-				4A24076113F5240F002A5C12 /* StationBulletinBoardForm.h */,
-				4A24076213F5240F002A5C12 /* StationCommodityMarketForm.cpp */,
-				4A24076313F5240F002A5C12 /* StationCommodityMarketForm.h */,
-				4A24076413F5240F002A5C12 /* StationPoliceForm.cpp */,
-				4A24076513F5240F002A5C12 /* StationPoliceForm.h */,
-				4A24076613F5240F002A5C12 /* StationServicesForm.cpp */,
-				4A24076713F5240F002A5C12 /* StationServicesForm.h */,
-				4A24076813F5240F002A5C12 /* StationShipEquipmentForm.cpp */,
-				4A24076913F5240F002A5C12 /* StationShipEquipmentForm.h */,
-				4A24076A13F5240F002A5C12 /* StationShipMarketForm.cpp */,
-				4A24076B13F5240F002A5C12 /* StationShipMarketForm.h */,
-				4A24076C13F5240F002A5C12 /* StationShipRepairForm.cpp */,
-				4A24076D13F5240F002A5C12 /* StationShipRepairForm.h */,
-				4A24076E13F5240F002A5C12 /* StationShipViewForm.cpp */,
-				4A24076F13F5240F002A5C12 /* StationShipViewForm.h */,
-				4A24077013F5240F002A5C12 /* StationShipyardForm.cpp */,
-				4A24077113F5240F002A5C12 /* StationShipyardForm.h */,
-				4A6B59CA1429F14500ADC7C8 /* StringF.cpp */,
-				4A6B59CB1429F14500ADC7C8 /* StringF.h */,
-				4A305FD0151341170076D414 /* StringRange.h */,
-				4A6C4D6913532FC300FDD53F /* SystemInfoView.cpp */,
-				4A6C4D6A13532FC300FDD53F /* SystemInfoView.h */,
-				4A6C4D6B13532FC300FDD53F /* SystemView.cpp */,
-				4A6C4D6C13532FC300FDD53F /* SystemView.h */,
-				4AB7D5CF1472A83E00158DE4 /* terrain */,
-				4AB3DF8714346952001B783A /* TerrainBody.cpp */,
-				4AB3DF8814346952001B783A /* TerrainBody.h */,
-				4ACC6D1115401E7000C59914 /* text */,
-				4AF222E5162103EA00BED38E /* Tombstone.cpp */,
-				4AF222E6162103EA00BED38E /* Tombstone.h */,
-				4ABF302D16335A1100664653 /* ui */,
-				4A24FD5C1650F4B700DE7B0F /* UIView.cpp */,
-				4A24FD5D1650F4B700DE7B0F /* UIView.h */,
-				4A6C4D6E13532FC300FDD53F /* utils.cpp */,
-				4A6C4D6F13532FC300FDD53F /* utils.h */,
-				4A4F25E114F524F600FD14A6 /* vector2.h */,
-				4A6C4D7013532FC300FDD53F /* vector3.h */,
-				4A62EF2B136979E000919EBB /* VideoLink.h */,
-				4ADC7B81152C703200E359B5 /* View.cpp */,
-				4A6C4D7113532FC300FDD53F /* View.h */,
-				4A6C4D7213532FC300FDD53F /* WorldView.cpp */,
-				4A6C4D7313532FC300FDD53F /* WorldView.h */,
-			);
-			name = src;
-			path = ../src;
-			sourceTree = "<group>";
-		};
-		4A6C4C0913532FC300FDD53F /* collider */ = {
-			isa = PBXGroup;
-			children = (
-				4A6C4C0F13532FC300FDD53F /* BVHTree.cpp */,
-				4A6C4C1013532FC300FDD53F /* BVHTree.h */,
-				4A6C4C1113532FC300FDD53F /* collider.h */,
-				4A6C4C1213532FC300FDD53F /* CollisionContact.h */,
-				4A6C4C1313532FC300FDD53F /* CollisionSpace.cpp */,
-				4A6C4C1413532FC300FDD53F /* CollisionSpace.h */,
-				4A6C4C1513532FC300FDD53F /* Geom.cpp */,
-				4A6C4C1613532FC300FDD53F /* Geom.h */,
-				4A6C4C1713532FC300FDD53F /* GeomTree.cpp */,
-				4A6C4C1813532FC300FDD53F /* GeomTree.h */,
-			);
-			path = collider;
 			sourceTree = "<group>";
 		};
 		4A9822A9142DF91B00B423F1 /* Misc TXT files */ = {
@@ -1908,301 +1485,915 @@
 			name = "Misc TXT files";
 			sourceTree = "<group>";
 		};
-		4AAB880315F4AD3500AAF8A8 /* gl2 */ = {
+		521ED7D31C00D1280092B2E9 /* src */ = {
 			isa = PBXGroup;
 			children = (
-				4AAB880415F4AD3500AAF8A8 /* GeoSphereMaterial.cpp */,
-				4AAB880515F4AD3500AAF8A8 /* GeoSphereMaterial.h */,
-				4AAB880615F4AD3500AAF8A8 /* GL2Material.cpp */,
-				4AAB880715F4AD3500AAF8A8 /* GL2Material.h */,
-				4AAB880815F4AD3500AAF8A8 /* MultiMaterial.cpp */,
-				4AAB880915F4AD3500AAF8A8 /* MultiMaterial.h */,
-				4AAB880A15F4AD3500AAF8A8 /* Program.cpp */,
-				4AAB880B15F4AD3500AAF8A8 /* Program.h */,
-				4AAB880C15F4AD3500AAF8A8 /* RingMaterial.cpp */,
-				4AAB880D15F4AD3500AAF8A8 /* RingMaterial.h */,
-				4AAB880E15F4AD3500AAF8A8 /* StarfieldMaterial.h */,
-				4AAB880F15F4AD3500AAF8A8 /* Uniform.cpp */,
-				4AAB881015F4AD3500AAF8A8 /* Uniform.h */,
+				521ED97B1C00D23F0092B2E9 /* collider */,
+				521ED97C1C00D24C0092B2E9 /* galaxy */,
+				521ED97D1C00D25E0092B2E9 /* gameui */,
+				521ED97E1C00D2650092B2E9 /* graphics */,
+				521ED97F1C00D26B0092B2E9 /* gui */,
+				521ED9801C00D2740092B2E9 /* posix */,
+				521ED9811C00D2790092B2E9 /* scenegraph */,
+				521ED9821C00D2880092B2E9 /* terrain */,
+				521ED9831C00D28F0092B2E9 /* text */,
+				521ED9841C00D29E0092B2E9 /* ui */,
+				521ED7D41C00D14D0092B2E9 /* Aabb.h */,
+				521ED7D51C00D14D0092B2E9 /* AmbientSounds.cpp */,
+				521ED7D61C00D14D0092B2E9 /* AmbientSounds.h */,
+				521ED7D71C00D14D0092B2E9 /* AnimationCurves.h */,
+				521ED7D81C00D14D0092B2E9 /* Background.cpp */,
+				521ED7D91C00D14D0092B2E9 /* Background.h */,
+				521ED7DA1C00D14D0092B2E9 /* BaseSphere.cpp */,
+				521ED7DB1C00D14D0092B2E9 /* BaseSphere.h */,
+				521ED7DC1C00D14D0092B2E9 /* Body.cpp */,
+				521ED7DD1C00D14D0092B2E9 /* Body.h */,
+				521ED7DE1C00D14D0092B2E9 /* buildopts.h */,
+				521ED7DF1C00D14D0092B2E9 /* ByteRange.h */,
+				521ED7E01C00D14D0092B2E9 /* Camera.cpp */,
+				521ED7E11C00D14D0092B2E9 /* Camera.h */,
+				521ED7E21C00D14D0092B2E9 /* CameraController.cpp */,
+				521ED7E31C00D14D0092B2E9 /* CameraController.h */,
+				521ED7E41C00D14D0092B2E9 /* CargoBody.cpp */,
+				521ED7E51C00D14D0092B2E9 /* CargoBody.h */,
+				521ED7E61C00D14D0092B2E9 /* CityOnPlanet.cpp */,
+				521ED7E71C00D14D0092B2E9 /* CityOnPlanet.h */,
+				521ED7E81C00D14D0092B2E9 /* CollMesh.cpp */,
+				521ED7E91C00D14D0092B2E9 /* CollMesh.h */,
+				521ED7EA1C00D14D0092B2E9 /* Color.cpp */,
+				521ED7EB1C00D14D0092B2E9 /* Color.h */,
+				521ED7EC1C00D14D0092B2E9 /* CRC32.cpp */,
+				521ED7ED1C00D14D0092B2E9 /* CRC32.h */,
+				521ED7EE1C00D14D0092B2E9 /* Cutscene.h */,
+				521ED7EF1C00D14D0092B2E9 /* DateTime.cpp */,
+				521ED7F01C00D14D0092B2E9 /* DateTime.h */,
+				521ED7F11C00D14D0092B2E9 /* DeathView.cpp */,
+				521ED7F21C00D14D0092B2E9 /* DeathView.h */,
+				521ED7F31C00D14D0092B2E9 /* DeleteEmitter.h */,
+				521ED7F41C00D14D0092B2E9 /* DynamicBody.cpp */,
+				521ED7F51C00D14D0092B2E9 /* DynamicBody.h */,
+				521ED7F61C00D14D0092B2E9 /* Easing.h */,
+				521ED7F71C00D14D0092B2E9 /* enum_table.cpp */,
+				521ED7F81C00D14D0092B2E9 /* enum_table.h */,
+				521ED7F91C00D14D0092B2E9 /* EnumStrings.cpp */,
+				521ED7FA1C00D14D0092B2E9 /* EnumStrings.h */,
+				521ED7FB1C00D14D0092B2E9 /* FaceParts.cpp */,
+				521ED7FC1C00D14D0092B2E9 /* FaceParts.h */,
+				521ED7FD1C00D14D0092B2E9 /* Factions.cpp */,
+				521ED7FE1C00D14D0092B2E9 /* Factions.h */,
+				521ED7FF1C00D14D0092B2E9 /* FileSourceZip.cpp */,
+				521ED8001C00D14D0092B2E9 /* FileSourceZip.h */,
+				521ED8011C00D14D0092B2E9 /* FileSystem.cpp */,
+				521ED8021C00D14D0092B2E9 /* FileSystem.h */,
+				521ED8031C00D14D0092B2E9 /* fixed.h */,
+				521ED8041C00D14D0092B2E9 /* FloatComparison.h */,
+				521ED8051C00D14D0092B2E9 /* FontCache.cpp */,
+				521ED8061C00D14D0092B2E9 /* FontCache.h */,
+				521ED8071C00D14D0092B2E9 /* Frame.cpp */,
+				521ED8081C00D14D0092B2E9 /* Frame.h */,
+				521ED8091C00D14D0092B2E9 /* GalacticView.cpp */,
+				521ED80A1C00D14D0092B2E9 /* GalacticView.h */,
+				521ED80B1C00D14D0092B2E9 /* Game.cpp */,
+				521ED80C1C00D14D0092B2E9 /* Game.h */,
+				521ED80D1C00D14D0092B2E9 /* GameConfig.cpp */,
+				521ED80E1C00D14D0092B2E9 /* GameConfig.h */,
+				521ED80F1C00D14D0092B2E9 /* gameconsts.h */,
+				521ED8101C00D14D0092B2E9 /* GameLog.cpp */,
+				521ED8111C00D14D0092B2E9 /* GameLog.h */,
+				521ED8121C00D14D0092B2E9 /* GasGiant.cpp */,
+				521ED8131C00D14D0092B2E9 /* GasGiant.h */,
+				521ED8141C00D14D0092B2E9 /* GeoPatch.cpp */,
+				521ED8151C00D14D0092B2E9 /* GeoPatch.h */,
+				521ED8161C00D14D0092B2E9 /* GeoPatchContext.cpp */,
+				521ED8171C00D14D0092B2E9 /* GeoPatchContext.h */,
+				521ED8181C00D14D0092B2E9 /* GeoPatchID.cpp */,
+				521ED8191C00D14D0092B2E9 /* GeoPatchID.h */,
+				521ED81A1C00D14D0092B2E9 /* GeoPatchJobs.cpp */,
+				521ED81B1C00D14D0092B2E9 /* GeoPatchJobs.h */,
+				521ED81C1C00D14D0092B2E9 /* GeoSphere.cpp */,
+				521ED81D1C00D14D0092B2E9 /* GeoSphere.h */,
+				521ED81E1C00D14D0092B2E9 /* HudTrail.cpp */,
+				521ED81F1C00D14D0092B2E9 /* HudTrail.h */,
+				521ED8201C00D14D0092B2E9 /* HyperspaceCloud.cpp */,
+				521ED8211C00D14D0092B2E9 /* HyperspaceCloud.h */,
+				521ED8221C00D14D0092B2E9 /* IniConfig.cpp */,
+				521ED8231C00D14D0092B2E9 /* IniConfig.h */,
+				521ED8241C00D14D0092B2E9 /* Intro.cpp */,
+				521ED8251C00D14D0092B2E9 /* Intro.h */,
+				521ED8261C00D14D0092B2E9 /* IterationProxy.h */,
+				521ED8271C00D14D0092B2E9 /* JobQueue.cpp */,
+				521ED8281C00D14D0092B2E9 /* JobQueue.h */,
+				521ED8291C00D14D0092B2E9 /* KeyBindings.cpp */,
+				521ED82A1C00D14D0092B2E9 /* KeyBindings.h */,
+				521ED82B1C00D14D0092B2E9 /* KeyBindings.inc.h */,
+				521ED82C1C00D14D0092B2E9 /* Lang.cpp */,
+				521ED82D1C00D14D0092B2E9 /* Lang.h */,
+				521ED82E1C00D14D0092B2E9 /* LangStrings.inc.h */,
+				521ED82F1C00D14D0092B2E9 /* libs.h */,
+				521ED8301C00D14D0092B2E9 /* Lua.cpp */,
+				521ED8311C00D14D0092B2E9 /* Lua.h */,
+				521ED8321C00D14D0092B2E9 /* LuaBody.cpp */,
+				521ED8331C00D14D0092B2E9 /* LuaCargoBody.cpp */,
+				521ED8341C00D14D0092B2E9 /* LuaComms.cpp */,
+				521ED8351C00D14D0092B2E9 /* LuaComms.h */,
+				521ED8361C00D14D0092B2E9 /* LuaConsole.cpp */,
+				521ED8371C00D14D0092B2E9 /* LuaConsole.h */,
+				521ED8381C00D14D0092B2E9 /* LuaConstants.cpp */,
+				521ED8391C00D14D0092B2E9 /* LuaConstants.h */,
+				521ED83A1C00D14D0092B2E9 /* LuaDev.cpp */,
+				521ED83B1C00D14D0092B2E9 /* LuaDev.h */,
+				521ED83C1C00D14D0092B2E9 /* LuaEngine.cpp */,
+				521ED83D1C00D14D0092B2E9 /* LuaEngine.h */,
+				521ED83E1C00D14D0092B2E9 /* LuaEvent.cpp */,
+				521ED83F1C00D14D0092B2E9 /* LuaEvent.h */,
+				521ED8401C00D14D0092B2E9 /* LuaFaction.cpp */,
+				521ED8411C00D14D0092B2E9 /* LuaFileSystem.cpp */,
+				521ED8421C00D14D0092B2E9 /* LuaFileSystem.h */,
+				521ED8431C00D14D0092B2E9 /* LuaFixed.cpp */,
+				521ED8441C00D14D0092B2E9 /* LuaFixed.h */,
+				521ED8451C00D14D0092B2E9 /* LuaFormat.cpp */,
+				521ED8461C00D14D0092B2E9 /* LuaFormat.h */,
+				521ED8471C00D14D0092B2E9 /* LuaGame.cpp */,
+				521ED8481C00D14D0092B2E9 /* LuaGame.h */,
+				521ED8491C00D14D0092B2E9 /* LuaLang.cpp */,
+				521ED84A1C00D14D0092B2E9 /* LuaLang.h */,
+				521ED84B1C00D14D0092B2E9 /* LuaManager.cpp */,
+				521ED84C1C00D14D0092B2E9 /* LuaManager.h */,
+				521ED84D1C00D14D0092B2E9 /* LuaMatrix.cpp */,
+				521ED84E1C00D14D0092B2E9 /* LuaMatrix.h */,
+				521ED84F1C00D14D0092B2E9 /* LuaMissile.cpp */,
+				521ED8501C00D14D0092B2E9 /* LuaMissile.h */,
+				521ED8511C00D14D0092B2E9 /* LuaModelBody.cpp */,
+				521ED8521C00D14E0092B2E9 /* LuaMusic.cpp */,
+				521ED8531C00D14E0092B2E9 /* LuaMusic.h */,
+				521ED8541C00D14E0092B2E9 /* LuaNameGen.cpp */,
+				521ED8551C00D14E0092B2E9 /* LuaNameGen.h */,
+				521ED8561C00D14E0092B2E9 /* LuaObject.cpp */,
+				521ED8571C00D14E0092B2E9 /* LuaObject.h */,
+				521ED8581C00D14E0092B2E9 /* LuaPlanet.cpp */,
+				521ED8591C00D14E0092B2E9 /* LuaPlayer.cpp */,
+				521ED85A1C00D14E0092B2E9 /* LuaPropertiedObject.cpp */,
+				521ED85B1C00D14E0092B2E9 /* LuaPushPull.h */,
+				521ED85C1C00D14E0092B2E9 /* LuaRand.cpp */,
+				521ED85D1C00D14E0092B2E9 /* LuaRef.cpp */,
+				521ED85E1C00D14E0092B2E9 /* LuaRef.h */,
+				521ED85F1C00D14E0092B2E9 /* LuaSerializer.cpp */,
+				521ED8601C00D14E0092B2E9 /* LuaSerializer.h */,
+				521ED8611C00D14E0092B2E9 /* LuaServerAgent.cpp */,
+				521ED8621C00D14E0092B2E9 /* LuaServerAgent.h */,
+				521ED8631C00D14E0092B2E9 /* LuaShip.cpp */,
+				521ED8641C00D14E0092B2E9 /* LuaShipDef.cpp */,
+				521ED8651C00D14E0092B2E9 /* LuaShipDef.h */,
+				521ED8661C00D14E0092B2E9 /* LuaSpace.cpp */,
+				521ED8671C00D14E0092B2E9 /* LuaSpace.h */,
+				521ED8681C00D14E0092B2E9 /* LuaSpaceStation.cpp */,
+				521ED8691C00D14E0092B2E9 /* LuaStar.cpp */,
+				521ED86A1C00D14E0092B2E9 /* LuaStarSystem.cpp */,
+				521ED86B1C00D14E0092B2E9 /* LuaSystemBody.cpp */,
+				521ED86C1C00D14E0092B2E9 /* LuaSystemPath.cpp */,
+				521ED86D1C00D14E0092B2E9 /* LuaTable.h */,
+				521ED86E1C00D14E0092B2E9 /* LuaTimer.cpp */,
+				521ED86F1C00D14E0092B2E9 /* LuaTimer.h */,
+				521ED8701C00D14E0092B2E9 /* LuaUtils.cpp */,
+				521ED8711C00D14E0092B2E9 /* LuaUtils.h */,
+				521ED8721C00D14E0092B2E9 /* LuaVector.cpp */,
+				521ED8731C00D14E0092B2E9 /* LuaVector.h */,
+				521ED8741C00D14E0092B2E9 /* LuaWrappable.h */,
+				521ED8751C00D14E0092B2E9 /* main.cpp */,
+				521ED8761C00D14E0092B2E9 /* MathUtil.cpp */,
+				521ED8771C00D14E0092B2E9 /* MathUtil.h */,
+				521ED8781C00D14E0092B2E9 /* matrix3x3.h */,
+				521ED8791C00D14E0092B2E9 /* matrix4x4.h */,
+				521ED87A1C00D14E0092B2E9 /* Missile.cpp */,
+				521ED87B1C00D14E0092B2E9 /* Missile.h */,
+				521ED87C1C00D14E0092B2E9 /* ModelBody.cpp */,
+				521ED87D1C00D14E0092B2E9 /* ModelBody.h */,
+				521ED87E1C00D14E0092B2E9 /* ModelCache.cpp */,
+				521ED87F1C00D14E0092B2E9 /* ModelCache.h */,
+				521ED8811C00D14E0092B2E9 /* ModelViewer.cpp */,
+				521ED8821C00D14E0092B2E9 /* ModelViewer.h */,
+				521ED8831C00D14E0092B2E9 /* ModManager.cpp */,
+				521ED8841C00D14E0092B2E9 /* ModManager.h */,
+				521ED8851C00D14E0092B2E9 /* NavLights.cpp */,
+				521ED8861C00D14E0092B2E9 /* NavLights.h */,
+				521ED8871C00D14E0092B2E9 /* Object.h */,
+				521ED8881C00D14E0092B2E9 /* ObjectViewerView.cpp */,
+				521ED8891C00D14E0092B2E9 /* ObjectViewerView.h */,
+				521ED88A1C00D14E0092B2E9 /* Orbit.cpp */,
+				521ED88B1C00D14E0092B2E9 /* Orbit.h */,
+				521ED88C1C00D14E0092B2E9 /* OS.h */,
+				521ED88D1C00D14E0092B2E9 /* perlin.cpp */,
+				521ED88E1C00D14E0092B2E9 /* perlin.h */,
+				521ED88F1C00D14E0092B2E9 /* PersistSystemData.h */,
+				521ED8901C00D14E0092B2E9 /* Pi.cpp */,
+				521ED8911C00D14E0092B2E9 /* Pi.h */,
+				521ED8921C00D14E0092B2E9 /* Plane.cpp */,
+				521ED8931C00D14E0092B2E9 /* Plane.h */,
+				521ED8941C00D14E0092B2E9 /* Planet.cpp */,
+				521ED8951C00D14E0092B2E9 /* Planet.h */,
+				521ED8961C00D14E0092B2E9 /* Player.cpp */,
+				521ED8971C00D14E0092B2E9 /* Player.h */,
+				521ED8981C00D14E0092B2E9 /* PngWriter.cpp */,
+				521ED8991C00D14E0092B2E9 /* PngWriter.h */,
+				521ED89A1C00D14E0092B2E9 /* Polit.cpp */,
+				521ED89B1C00D14E0092B2E9 /* Polit.h */,
+				521ED89C1C00D14E0092B2E9 /* Projectile.cpp */,
+				521ED89D1C00D14E0092B2E9 /* Projectile.h */,
+				521ED89E1C00D14E0092B2E9 /* PropertiedObject.h */,
+				521ED89F1C00D14E0092B2E9 /* PropertyMap.cpp */,
+				521ED8A01C00D14E0092B2E9 /* PropertyMap.h */,
+				521ED8A11C00D14E0092B2E9 /* Quaternion.h */,
+				521ED8A21C00D14E0092B2E9 /* Random.h */,
+				521ED8A31C00D14E0092B2E9 /* RefCounted.h */,
+				521ED8A41C00D14E0092B2E9 /* SDLWrappers.cpp */,
+				521ED8A51C00D14E0092B2E9 /* SDLWrappers.h */,
+				521ED8A61C00D14E0092B2E9 /* SectorView.cpp */,
+				521ED8A71C00D14E0092B2E9 /* SectorView.h */,
+				521ED8A81C00D14E0092B2E9 /* Sensors.cpp */,
+				521ED8A91C00D14E0092B2E9 /* Sensors.h */,
+				521ED8AA1C00D14E0092B2E9 /* Serializer.cpp */,
+				521ED8AB1C00D14E0092B2E9 /* Serializer.h */,
+				521ED8AC1C00D14E0092B2E9 /* ServerAgent.cpp */,
+				521ED8AD1C00D14E0092B2E9 /* ServerAgent.h */,
+				521ED8AE1C00D14E0092B2E9 /* Sfx.cpp */,
+				521ED8AF1C00D14E0092B2E9 /* Sfx.h */,
+				521ED8B01C00D14E0092B2E9 /* Shields.cpp */,
+				521ED8B11C00D14E0092B2E9 /* Shields.h */,
+				521ED8B21C00D14E0092B2E9 /* Ship-AI.cpp */,
+				521ED8B31C00D14E0092B2E9 /* Ship.cpp */,
+				521ED8B41C00D14E0092B2E9 /* Ship.h */,
+				521ED8B51C00D14E0092B2E9 /* ShipAICmd.cpp */,
+				521ED8B61C00D14E0092B2E9 /* ShipAICmd.h */,
+				521ED8B71C00D14E0092B2E9 /* ShipCockpit.cpp */,
+				521ED8B81C00D14E0092B2E9 /* ShipCockpit.h */,
+				521ED8B91C00D14E0092B2E9 /* ShipController.cpp */,
+				521ED8BA1C00D14E0092B2E9 /* ShipController.h */,
+				521ED8BB1C00D14E0092B2E9 /* ShipCpanel.cpp */,
+				521ED8BC1C00D14E0092B2E9 /* ShipCpanel.h */,
+				521ED8BD1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp */,
+				521ED8BE1C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.h */,
+				521ED8BF1C00D14E0092B2E9 /* ShipType.cpp */,
+				521ED8C01C00D14E0092B2E9 /* ShipType.h */,
+				521ED8C11C00D14E0092B2E9 /* SmartPtr.h */,
+				521ED8C21C00D14E0092B2E9 /* Sound.cpp */,
+				521ED8C31C00D14E0092B2E9 /* Sound.h */,
+				521ED8C41C00D14E0092B2E9 /* SoundMusic.cpp */,
+				521ED8C51C00D14E0092B2E9 /* SoundMusic.h */,
+				521ED8C61C00D14E0092B2E9 /* Space.cpp */,
+				521ED8C71C00D14E0092B2E9 /* Space.h */,
+				521ED8C81C00D14E0092B2E9 /* SpaceStation.cpp */,
+				521ED8C91C00D14E0092B2E9 /* SpaceStation.h */,
+				521ED8CA1C00D14E0092B2E9 /* SpaceStationType.cpp */,
+				521ED8CB1C00D14E0092B2E9 /* SpaceStationType.h */,
+				521ED8CC1C00D14E0092B2E9 /* SpeedLines.cpp */,
+				521ED8CD1C00D14E0092B2E9 /* SpeedLines.h */,
+				521ED8CE1C00D14E0092B2E9 /* Sphere.cpp */,
+				521ED8CF1C00D14E0092B2E9 /* Sphere.h */,
+				521ED8D01C00D14E0092B2E9 /* Star.cpp */,
+				521ED8D11C00D14E0092B2E9 /* Star.h */,
+				521ED8D21C00D14E0092B2E9 /* StringF.cpp */,
+				521ED8D31C00D14E0092B2E9 /* StringF.h */,
+				521ED8D41C00D14E0092B2E9 /* StringRange.h */,
+				521ED8D51C00D14E0092B2E9 /* SystemInfoView.cpp */,
+				521ED8D61C00D14E0092B2E9 /* SystemInfoView.h */,
+				521ED8D71C00D14E0092B2E9 /* SystemView.cpp */,
+				521ED8D81C00D14E0092B2E9 /* SystemView.h */,
+				521ED8D91C00D14E0092B2E9 /* TerrainBody.cpp */,
+				521ED8DA1C00D14E0092B2E9 /* TerrainBody.h */,
+				521ED8E21C00D14E0092B2E9 /* Tombstone.cpp */,
+				521ED8E31C00D14E0092B2E9 /* Tombstone.h */,
+				521ED8E51C00D14E0092B2E9 /* UIView.cpp */,
+				521ED8E61C00D14E0092B2E9 /* UIView.h */,
+				521ED8E71C00D14E0092B2E9 /* utils.cpp */,
+				521ED8E81C00D14E0092B2E9 /* utils.h */,
+				521ED8E91C00D14E0092B2E9 /* vector2.h */,
+				521ED8EA1C00D14E0092B2E9 /* vector3.h */,
+				521ED8EB1C00D14E0092B2E9 /* VideoLink.h */,
+				521ED8EC1C00D14E0092B2E9 /* View.cpp */,
+				521ED8ED1C00D14E0092B2E9 /* View.h */,
+				521ED8EE1C00D14E0092B2E9 /* WorldView.cpp */,
+				521ED8EF1C00D14E0092B2E9 /* WorldView.h */,
+				521ED9971C00D2FC0092B2E9 /* Makefile.am */,
 			);
-			path = gl2;
+			name = src;
 			sourceTree = "<group>";
 		};
-		4AAC9FDC15458FE400116131 /* miniz */ = {
+		521ED97B1C00D23F0092B2E9 /* collider */ = {
 			isa = PBXGroup;
 			children = (
-				4AAC9FDE15458FE400116131 /* miniz.c */,
-				4AAC9FDF15458FE400116131 /* miniz.h */,
+				521ED9861C00D2ED0092B2E9 /* BVHTree.cpp */,
+				521ED9871C00D2ED0092B2E9 /* BVHTree.h */,
+				521ED9881C00D2ED0092B2E9 /* collider.h */,
+				521ED9891C00D2ED0092B2E9 /* CollisionContact.h */,
+				521ED98A1C00D2ED0092B2E9 /* CollisionSpace.cpp */,
+				521ED98B1C00D2ED0092B2E9 /* CollisionSpace.h */,
+				521ED98C1C00D2ED0092B2E9 /* Geom.cpp */,
+				521ED98D1C00D2ED0092B2E9 /* Geom.h */,
+				521ED98E1C00D2ED0092B2E9 /* GeomTree.cpp */,
+				521ED98F1C00D2ED0092B2E9 /* GeomTree.h */,
+				521ED9901C00D2ED0092B2E9 /* Weld.h */,
+				521ED9911C00D2ED0092B2E9 /* Makefile.am */,
+			);
+			name = collider;
+			sourceTree = "<group>";
+		};
+		521ED97C1C00D24C0092B2E9 /* galaxy */ = {
+			isa = PBXGroup;
+			children = (
+				521ED9991C00D3240092B2E9 /* CustomSystem.cpp */,
+				521ED99A1C00D3240092B2E9 /* CustomSystem.h */,
+				521ED99B1C00D3240092B2E9 /* Economy.cpp */,
+				521ED99C1C00D3240092B2E9 /* Economy.h */,
+				521ED99D1C00D3240092B2E9 /* Galaxy.cpp */,
+				521ED99E1C00D3240092B2E9 /* Galaxy.h */,
+				521ED99F1C00D3240092B2E9 /* GalaxyCache.cpp */,
+				521ED9A01C00D3240092B2E9 /* GalaxyCache.h */,
+				521ED9A11C00D3240092B2E9 /* GalaxyGenerator.cpp */,
+				521ED9A21C00D3240092B2E9 /* GalaxyGenerator.h */,
+				521ED9A31C00D3240092B2E9 /* Sector.cpp */,
+				521ED9A41C00D3240092B2E9 /* Sector.h */,
+				521ED9A51C00D3240092B2E9 /* SectorGenerator.cpp */,
+				521ED9A61C00D3240092B2E9 /* SectorGenerator.h */,
+				521ED9A71C00D3240092B2E9 /* StarSystem.cpp */,
+				521ED9A81C00D3240092B2E9 /* StarSystem.h */,
+				521ED9A91C00D3240092B2E9 /* StarSystemGenerator.cpp */,
+				521ED9AA1C00D3240092B2E9 /* StarSystemGenerator.h */,
+				521ED9AB1C00D3240092B2E9 /* SystemPath.cpp */,
+				521ED9AC1C00D3240092B2E9 /* SystemPath.h */,
+				521ED9AD1C00D3240092B2E9 /* Makefile.am */,
+			);
+			name = galaxy;
+			sourceTree = "<group>";
+		};
+		521ED97D1C00D25E0092B2E9 /* gameui */ = {
+			isa = PBXGroup;
+			children = (
+				521ED9B91C00D3310092B2E9 /* BindingCapture.cpp */,
+				521ED9BA1C00D3310092B2E9 /* BindingCapture.h */,
+				521ED9BB1C00D3310092B2E9 /* Face.cpp */,
+				521ED9BC1C00D3310092B2E9 /* Face.h */,
+				521ED9BD1C00D3310092B2E9 /* GameUI.h */,
+				521ED9BE1C00D3310092B2E9 /* Lua.cpp */,
+				521ED9BF1C00D3310092B2E9 /* Lua.h */,
+				521ED9C01C00D3310092B2E9 /* LuaBindingCapture.cpp */,
+				521ED9C11C00D3310092B2E9 /* LuaFace.cpp */,
+				521ED9C21C00D3310092B2E9 /* LuaModelSpinner.cpp */,
+				521ED9C31C00D3310092B2E9 /* ModelSpinner.cpp */,
+				521ED9C41C00D3310092B2E9 /* ModelSpinner.h */,
+				521ED9C51C00D3310092B2E9 /* Panel.cpp */,
+				521ED9C61C00D3310092B2E9 /* Panel.h */,
+				521ED9C71C00D3310092B2E9 /* Makefile.am */,
+			);
+			name = gameui;
+			sourceTree = "<group>";
+		};
+		521ED97E1C00D2650092B2E9 /* graphics */ = {
+			isa = PBXGroup;
+			children = (
+				521ED9D11C00D3430092B2E9 /* dummy */,
+				521ED9DA1C00D3430092B2E9 /* opengl */,
+				521EDA051C00D3430092B2E9 /* Drawables.cpp */,
+				521EDA061C00D3430092B2E9 /* Drawables.h */,
+				521EDA071C00D3430092B2E9 /* Frustum.cpp */,
+				521EDA081C00D3430092B2E9 /* Frustum.h */,
+				521EDA091C00D3430092B2E9 /* Graphics.cpp */,
+				521EDA0A1C00D3430092B2E9 /* Graphics.h */,
+				521EDA0B1C00D3430092B2E9 /* Light.cpp */,
+				521EDA0C1C00D3430092B2E9 /* Light.h */,
+				521EDA0D1C00D3430092B2E9 /* Material.cpp */,
+				521EDA0E1C00D3430092B2E9 /* Material.h */,
+				521EDA0F1C00D3430092B2E9 /* Renderer.cpp */,
+				521EDA101C00D3430092B2E9 /* Renderer.h */,
+				521EDA111C00D3430092B2E9 /* RenderState.h */,
+				521EDA121C00D3430092B2E9 /* RenderTarget.h */,
+				521EDA131C00D3430092B2E9 /* Stats.cpp */,
+				521EDA141C00D3430092B2E9 /* Stats.h */,
+				521EDA151C00D3430092B2E9 /* Texture.h */,
+				521EDA161C00D3430092B2E9 /* TextureBuilder.cpp */,
+				521EDA171C00D3430092B2E9 /* TextureBuilder.h */,
+				521EDA181C00D3430092B2E9 /* Types.h */,
+				521EDA191C00D3430092B2E9 /* VertexArray.cpp */,
+				521EDA1A1C00D3430092B2E9 /* VertexArray.h */,
+				521EDA1B1C00D3430092B2E9 /* VertexBuffer.cpp */,
+				521EDA1C1C00D3430092B2E9 /* VertexBuffer.h */,
+				521EDA1D1C00D3430092B2E9 /* WindowSDL.cpp */,
+				521EDA1E1C00D3430092B2E9 /* WindowSDL.h */,
+				521EDA1F1C00D3430092B2E9 /* Makefile.am */,
+			);
+			name = graphics;
+			sourceTree = "<group>";
+		};
+		521ED97F1C00D26B0092B2E9 /* gui */ = {
+			isa = PBXGroup;
+			children = (
+				521EDA411C00D3550092B2E9 /* Gui.cpp */,
+				521EDA421C00D3550092B2E9 /* Gui.h */,
+				521EDA431C00D3550092B2E9 /* GuiAdjustment.h */,
+				521EDA441C00D3550092B2E9 /* GuiBox.cpp */,
+				521EDA451C00D3550092B2E9 /* GuiBox.h */,
+				521EDA461C00D3550092B2E9 /* GuiButton.cpp */,
+				521EDA471C00D3550092B2E9 /* GuiButton.h */,
+				521EDA481C00D3550092B2E9 /* GuiContainer.cpp */,
+				521EDA491C00D3550092B2E9 /* GuiContainer.h */,
+				521EDA4A1C00D3550092B2E9 /* GuiEvents.h */,
+				521EDA4B1C00D3550092B2E9 /* GuiFixed.cpp */,
+				521EDA4C1C00D3550092B2E9 /* GuiFixed.h */,
+				521EDA4D1C00D3550092B2E9 /* GuiImage.cpp */,
+				521EDA4E1C00D3550092B2E9 /* GuiImage.h */,
+				521EDA4F1C00D3550092B2E9 /* GuiImageButton.cpp */,
+				521EDA501C00D3550092B2E9 /* GuiImageButton.h */,
+				521EDA511C00D3550092B2E9 /* GuiImageRadioButton.cpp */,
+				521EDA521C00D3550092B2E9 /* GuiImageRadioButton.h */,
+				521EDA531C00D3550092B2E9 /* GuiISelectable.h */,
+				521EDA541C00D3550092B2E9 /* GuiLabel.cpp */,
+				521EDA551C00D3550092B2E9 /* GuiLabel.h */,
+				521EDA561C00D3550092B2E9 /* GuiLabelSet.cpp */,
+				521EDA571C00D3550092B2E9 /* GuiLabelSet.h */,
+				521EDA581C00D3550092B2E9 /* GuiMeterBar.cpp */,
+				521EDA591C00D3550092B2E9 /* GuiMeterBar.h */,
+				521EDA5A1C00D3550092B2E9 /* GuiMultiStateImageButton.cpp */,
+				521EDA5B1C00D3550092B2E9 /* GuiMultiStateImageButton.h */,
+				521EDA5C1C00D3550092B2E9 /* GuiRadioButton.cpp */,
+				521EDA5D1C00D3550092B2E9 /* GuiRadioButton.h */,
+				521EDA5E1C00D3550092B2E9 /* GuiRadioGroup.cpp */,
+				521EDA5F1C00D3550092B2E9 /* GuiRadioGroup.h */,
+				521EDA601C00D3550092B2E9 /* GuiScreen.cpp */,
+				521EDA611C00D3550092B2E9 /* GuiScreen.h */,
+				521EDA621C00D3550092B2E9 /* GuiStack.cpp */,
+				521EDA631C00D3550092B2E9 /* GuiStack.h */,
+				521EDA641C00D3550092B2E9 /* GuiTabbed.cpp */,
+				521EDA651C00D3550092B2E9 /* GuiTabbed.h */,
+				521EDA661C00D3550092B2E9 /* GuiTextEntry.cpp */,
+				521EDA671C00D3550092B2E9 /* GuiTextEntry.h */,
+				521EDA681C00D3550092B2E9 /* GuiTextLayout.cpp */,
+				521EDA691C00D3550092B2E9 /* GuiTextLayout.h */,
+				521EDA6A1C00D3550092B2E9 /* GuiTexturedQuad.cpp */,
+				521EDA6B1C00D3550092B2E9 /* GuiTexturedQuad.h */,
+				521EDA6C1C00D3550092B2E9 /* GuiToggleButton.cpp */,
+				521EDA6D1C00D3550092B2E9 /* GuiToggleButton.h */,
+				521EDA6E1C00D3550092B2E9 /* GuiToolTip.cpp */,
+				521EDA6F1C00D3550092B2E9 /* GuiToolTip.h */,
+				521EDA701C00D3550092B2E9 /* GuiVScrollBar.cpp */,
+				521EDA711C00D3550092B2E9 /* GuiVScrollBar.h */,
+				521EDA721C00D3550092B2E9 /* GuiVScrollPortal.cpp */,
+				521EDA731C00D3550092B2E9 /* GuiVScrollPortal.h */,
+				521EDA741C00D3550092B2E9 /* GuiWidget.cpp */,
+				521EDA751C00D3550092B2E9 /* GuiWidget.h */,
+				521EDA761C00D3550092B2E9 /* Makefile.am */,
+			);
+			name = gui;
+			sourceTree = "<group>";
+		};
+		521ED9801C00D2740092B2E9 /* posix */ = {
+			isa = PBXGroup;
+			children = (
+				521EDA911C00D3610092B2E9 /* FileSystemPosix.cpp */,
+				521EDA921C00D3610092B2E9 /* OSPosix.cpp */,
+				521EDA931C00D3610092B2E9 /* Makefile.am */,
+			);
+			name = posix;
+			sourceTree = "<group>";
+		};
+		521ED9811C00D2790092B2E9 /* scenegraph */ = {
+			isa = PBXGroup;
+			children = (
+				521EDA971C00D36D0092B2E9 /* Animation.cpp */,
+				521EDA981C00D36D0092B2E9 /* Animation.h */,
+				521EDA991C00D36D0092B2E9 /* AnimationChannel.h */,
+				521EDA9A1C00D36D0092B2E9 /* AnimationKey.h */,
+				521EDA9B1C00D36D0092B2E9 /* BaseLoader.cpp */,
+				521EDA9C1C00D36D0092B2E9 /* BaseLoader.h */,
+				521EDA9D1C00D36D0092B2E9 /* Billboard.cpp */,
+				521EDA9E1C00D36D0092B2E9 /* Billboard.h */,
+				521EDA9F1C00D36D0092B2E9 /* BinaryConverter.cpp */,
+				521EDAA01C00D36D0092B2E9 /* BinaryConverter.h */,
+				521EDAA11C00D36D0092B2E9 /* CollisionGeometry.cpp */,
+				521EDAA21C00D36D0092B2E9 /* CollisionGeometry.h */,
+				521EDAA31C00D36D0092B2E9 /* CollisionVisitor.cpp */,
+				521EDAA41C00D36D0092B2E9 /* CollisionVisitor.h */,
+				521EDAA51C00D36D0092B2E9 /* ColorMap.cpp */,
+				521EDAA61C00D36D0092B2E9 /* ColorMap.h */,
+				521EDAA71C00D36D0092B2E9 /* DumpVisitor.cpp */,
+				521EDAA81C00D36D0092B2E9 /* DumpVisitor.h */,
+				521EDAA91C00D36D0092B2E9 /* FindNodeVisitor.cpp */,
+				521EDAAA1C00D36D0092B2E9 /* FindNodeVisitor.h */,
+				521EDAAB1C00D36D0092B2E9 /* Group.cpp */,
+				521EDAAC1C00D36D0092B2E9 /* Group.h */,
+				521EDAAD1C00D36D0092B2E9 /* Label3D.cpp */,
+				521EDAAE1C00D36D0092B2E9 /* Label3D.h */,
+				521EDAAF1C00D36D0092B2E9 /* Loader.cpp */,
+				521EDAB01C00D36D0092B2E9 /* Loader.h */,
+				521EDAB11C00D36D0092B2E9 /* LoaderDefinitions.h */,
+				521EDAB21C00D36D0092B2E9 /* LOD.cpp */,
+				521EDAB31C00D36D0092B2E9 /* LOD.h */,
+				521EDAB41C00D36D0092B2E9 /* Lua.cpp */,
+				521EDAB51C00D36D0092B2E9 /* Lua.h */,
+				521EDAB61C00D36D0092B2E9 /* LuaModel.cpp */,
+				521EDAB71C00D36D0092B2E9 /* LuaModelSkin.cpp */,
+				521EDAB81C00D36D0092B2E9 /* MatrixTransform.cpp */,
+				521EDAB91C00D36D0092B2E9 /* MatrixTransform.h */,
+				521EDABA1C00D36D0092B2E9 /* Model.cpp */,
+				521EDABB1C00D36D0092B2E9 /* Model.h */,
+				521EDABC1C00D36D0092B2E9 /* ModelNode.cpp */,
+				521EDABD1C00D36D0092B2E9 /* ModelNode.h */,
+				521EDABE1C00D36D0092B2E9 /* ModelSkin.cpp */,
+				521EDABF1C00D36D0092B2E9 /* ModelSkin.h */,
+				521EDAC01C00D36D0092B2E9 /* Node.cpp */,
+				521EDAC11C00D36D0092B2E9 /* Node.h */,
+				521EDAC21C00D36D0092B2E9 /* NodeCopyCache.h */,
+				521EDAC31C00D36D0092B2E9 /* NodeVisitor.cpp */,
+				521EDAC41C00D36D0092B2E9 /* NodeVisitor.h */,
+				521EDAC51C00D36D0092B2E9 /* Parser.cpp */,
+				521EDAC61C00D36D0092B2E9 /* Parser.h */,
+				521EDAC71C00D36D0092B2E9 /* Pattern.cpp */,
+				521EDAC81C00D36D0092B2E9 /* Pattern.h */,
+				521EDAC91C00D36D0092B2E9 /* SceneGraph.h */,
+				521EDACA1C00D36D0092B2E9 /* StaticGeometry.cpp */,
+				521EDACB1C00D36D0092B2E9 /* StaticGeometry.h */,
+				521EDACC1C00D36D0092B2E9 /* Thruster.cpp */,
+				521EDACD1C00D36D0092B2E9 /* Thruster.h */,
+				521EDACE1C00D36D0092B2E9 /* Makefile.am */,
+			);
+			name = scenegraph;
+			sourceTree = "<group>";
+		};
+		521ED9821C00D2880092B2E9 /* terrain */ = {
+			isa = PBXGroup;
+			children = (
+				521EDAEA1C00D37B0092B2E9 /* Terrain.cpp */,
+				521EDAEB1C00D37B0092B2E9 /* Terrain.h */,
+				521EDAEC1C00D37B0092B2E9 /* TerrainColorAsteroid.cpp */,
+				521EDAED1C00D37B0092B2E9 /* TerrainColorBandedRock.cpp */,
+				521EDAEE1C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp */,
+				521EDAEF1C00D37B0092B2E9 /* TerrainColorDesert.cpp */,
+				521EDAF01C00D37B0092B2E9 /* TerrainColorEarthLike.cpp */,
+				521EDAF11C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp */,
+				521EDAF21C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp */,
+				521EDAF31C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp */,
+				521EDAF41C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp */,
+				521EDAF51C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp */,
+				521EDAF61C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp */,
+				521EDAF71C00D37B0092B2E9 /* TerrainColorGGUranus.cpp */,
+				521EDAF81C00D37B0092B2E9 /* TerrainColorIce.cpp */,
+				521EDAF91C00D37B0092B2E9 /* TerrainColorMethane.cpp */,
+				521EDAFA1C00D37B0092B2E9 /* TerrainColorRock.cpp */,
+				521EDAFB1C00D37B0092B2E9 /* TerrainColorRock2.cpp */,
+				521EDAFC1C00D37B0092B2E9 /* TerrainColorSolid.cpp */,
+				521EDAFD1C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp */,
+				521EDAFE1C00D37B0092B2E9 /* TerrainColorStarG.cpp */,
+				521EDAFF1C00D37B0092B2E9 /* TerrainColorStarK.cpp */,
+				521EDB001C00D37B0092B2E9 /* TerrainColorStarM.cpp */,
+				521EDB011C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp */,
+				521EDB021C00D37B0092B2E9 /* TerrainColorTFGood.cpp */,
+				521EDB031C00D37B0092B2E9 /* TerrainColorTFPoor.cpp */,
+				521EDB041C00D37B0092B2E9 /* TerrainColorVolcanic.cpp */,
+				521EDB051C00D37B0092B2E9 /* TerrainFeature.cpp */,
+				521EDB061C00D37B0092B2E9 /* TerrainFeature.h */,
+				521EDB071C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp */,
+				521EDB081C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp */,
+				521EDB091C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp */,
+				521EDB0A1C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp */,
+				521EDB0B1C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp */,
+				521EDB0C1C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp */,
+				521EDB0D1C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp */,
+				521EDB0E1C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp */,
+				521EDB0F1C00D37B0092B2E9 /* TerrainHeightFlat.cpp */,
+				521EDB101C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp */,
+				521EDB111C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp */,
+				521EDB121C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp */,
+				521EDB131C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp */,
+				521EDB141C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp */,
+				521EDB151C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp */,
+				521EDB161C00D37B0092B2E9 /* TerrainHeightMapped.cpp */,
+				521EDB171C00D37B0092B2E9 /* TerrainHeightMapped2.cpp */,
+				521EDB181C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp */,
+				521EDB191C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp */,
+				521EDB1A1C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp */,
+				521EDB1B1C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp */,
+				521EDB1C1C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp */,
+				521EDB1D1C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp */,
+				521EDB1E1C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp */,
+				521EDB1F1C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp */,
+				521EDB201C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp */,
+				521EDB211C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp */,
+				521EDB221C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp */,
+				521EDB231C00D37B0092B2E9 /* TerrainNoise.h */,
+				521EDB241C00D37B0092B2E9 /* Makefile.am */,
+			);
+			name = terrain;
+			sourceTree = "<group>";
+		};
+		521ED9831C00D28F0092B2E9 /* text */ = {
+			isa = PBXGroup;
+			children = (
+				521EDB5D1C00D38B0092B2E9 /* DistanceFieldFont.cpp */,
+				521EDB5E1C00D38B0092B2E9 /* DistanceFieldFont.h */,
+				521EDB5F1C00D38B0092B2E9 /* FontConfig.cpp */,
+				521EDB601C00D38B0092B2E9 /* FontConfig.h */,
+				521EDB611C00D38B0092B2E9 /* TextSupport.cpp */,
+				521EDB621C00D38B0092B2E9 /* TextSupport.h */,
+				521EDB631C00D38B0092B2E9 /* TextureFont.cpp */,
+				521EDB641C00D38B0092B2E9 /* TextureFont.h */,
+				521EDB651C00D38B0092B2E9 /* Makefile.am */,
+			);
+			name = text;
+			sourceTree = "<group>";
+		};
+		521ED9841C00D29E0092B2E9 /* ui */ = {
+			isa = PBXGroup;
+			children = (
+				521EDB6B1C00D3A20092B2E9 /* Align.cpp */,
+				521EDB6C1C00D3A20092B2E9 /* Align.h */,
+				521EDB6D1C00D3A20092B2E9 /* Animation.cpp */,
+				521EDB6E1C00D3A20092B2E9 /* Animation.h */,
+				521EDB6F1C00D3A20092B2E9 /* Background.cpp */,
+				521EDB701C00D3A20092B2E9 /* Background.h */,
+				521EDB711C00D3A20092B2E9 /* Box.cpp */,
+				521EDB721C00D3A20092B2E9 /* Box.h */,
+				521EDB731C00D3A20092B2E9 /* Button.cpp */,
+				521EDB741C00D3A20092B2E9 /* Button.h */,
+				521EDB751C00D3A20092B2E9 /* CellSpec.cpp */,
+				521EDB761C00D3A20092B2E9 /* CellSpec.h */,
+				521EDB771C00D3A20092B2E9 /* CheckBox.cpp */,
+				521EDB781C00D3A20092B2E9 /* CheckBox.h */,
+				521EDB791C00D3A20092B2E9 /* ColorBackground.cpp */,
+				521EDB7A1C00D3A20092B2E9 /* ColorBackground.h */,
+				521EDB7B1C00D3A20092B2E9 /* Container.cpp */,
+				521EDB7C1C00D3A20092B2E9 /* Container.h */,
+				521EDB7D1C00D3A20092B2E9 /* Context.cpp */,
+				521EDB7E1C00D3A20092B2E9 /* Context.h */,
+				521EDB7F1C00D3A20092B2E9 /* DropDown.cpp */,
+				521EDB801C00D3A20092B2E9 /* DropDown.h */,
+				521EDB811C00D3A20092B2E9 /* Event.cpp */,
+				521EDB821C00D3A20092B2E9 /* Event.h */,
+				521EDB831C00D3A20092B2E9 /* EventDispatcher.cpp */,
+				521EDB841C00D3A20092B2E9 /* EventDispatcher.h */,
+				521EDB851C00D3A20092B2E9 /* Expand.cpp */,
+				521EDB861C00D3A20092B2E9 /* Expand.h */,
+				521EDB871C00D3A20092B2E9 /* Gauge.cpp */,
+				521EDB881C00D3A20092B2E9 /* Gauge.h */,
+				521EDB891C00D3A20092B2E9 /* Gradient.cpp */,
+				521EDB8A1C00D3A20092B2E9 /* Gradient.h */,
+				521EDB8B1C00D3A20092B2E9 /* Grid.cpp */,
+				521EDB8C1C00D3A20092B2E9 /* Grid.h */,
+				521EDB8D1C00D3A20092B2E9 /* Icon.cpp */,
+				521EDB8E1C00D3A20092B2E9 /* Icon.h */,
+				521EDB8F1C00D3A20092B2E9 /* Image.cpp */,
+				521EDB901C00D3A20092B2E9 /* Image.h */,
+				521EDB911C00D3A20092B2E9 /* Label.cpp */,
+				521EDB921C00D3A20092B2E9 /* Label.h */,
+				521EDB931C00D3A20092B2E9 /* Layer.cpp */,
+				521EDB941C00D3A20092B2E9 /* Layer.h */,
+				521EDB951C00D3A20092B2E9 /* List.cpp */,
+				521EDB961C00D3A20092B2E9 /* List.h */,
+				521EDB971C00D3A20092B2E9 /* Lua.cpp */,
+				521EDB981C00D3A20092B2E9 /* Lua.h */,
+				521EDB991C00D3A20092B2E9 /* LuaAlign.cpp */,
+				521EDB9A1C00D3A20092B2E9 /* LuaAnimation.cpp */,
+				521EDB9B1C00D3A20092B2E9 /* LuaBackground.cpp */,
+				521EDB9C1C00D3A20092B2E9 /* LuaBox.cpp */,
+				521EDB9D1C00D3A20092B2E9 /* LuaButton.cpp */,
+				521EDB9E1C00D3A20092B2E9 /* LuaCheckBox.cpp */,
+				521EDB9F1C00D3A20092B2E9 /* LuaColorBackground.cpp */,
+				521EDBA01C00D3A20092B2E9 /* LuaContainer.cpp */,
+				521EDBA11C00D3A20092B2E9 /* LuaContext.cpp */,
+				521EDBA21C00D3A20092B2E9 /* LuaDropDown.cpp */,
+				521EDBA31C00D3A20092B2E9 /* LuaExpand.cpp */,
+				521EDBA41C00D3A20092B2E9 /* LuaGauge.cpp */,
+				521EDBA51C00D3A20092B2E9 /* LuaGradient.cpp */,
+				521EDBA61C00D3A20092B2E9 /* LuaGrid.cpp */,
+				521EDBA71C00D3A20092B2E9 /* LuaIcon.cpp */,
+				521EDBA81C00D3A20092B2E9 /* LuaImage.cpp */,
+				521EDBA91C00D3A20092B2E9 /* LuaLabel.cpp */,
+				521EDBAA1C00D3A20092B2E9 /* LuaLayer.cpp */,
+				521EDBAB1C00D3A20092B2E9 /* LuaList.cpp */,
+				521EDBAC1C00D3A20092B2E9 /* LuaMargin.cpp */,
+				521EDBAD1C00D3A20092B2E9 /* LuaMultiLineText.cpp */,
+				521EDBAE1C00D3A20092B2E9 /* LuaNumberLabel.cpp */,
+				521EDBAF1C00D3A20092B2E9 /* LuaScroller.cpp */,
+				521EDBB01C00D3A20092B2E9 /* LuaSignal.h */,
+				521EDBB11C00D3A20092B2E9 /* LuaSingle.cpp */,
+				521EDBB21C00D3A20092B2E9 /* LuaSlider.cpp */,
+				521EDBB31C00D3A20092B2E9 /* LuaSmallButton.cpp */,
+				521EDBB41C00D3A20092B2E9 /* LuaTable.cpp */,
+				521EDBB51C00D3A20092B2E9 /* LuaTextEntry.cpp */,
+				521EDBB61C00D3A20092B2E9 /* LuaWidget.cpp */,
+				521EDBB71C00D3A20092B2E9 /* Margin.cpp */,
+				521EDBB81C00D3A20092B2E9 /* Margin.h */,
+				521EDBB91C00D3A20092B2E9 /* MousePointer.h */,
+				521EDBBA1C00D3A20092B2E9 /* MultiLineText.cpp */,
+				521EDBBB1C00D3A20092B2E9 /* MultiLineText.h */,
+				521EDBBC1C00D3A20092B2E9 /* NumberLabel.cpp */,
+				521EDBBD1C00D3A20092B2E9 /* NumberLabel.h */,
+				521EDBBE1C00D3A20092B2E9 /* Point.h */,
+				521EDBBF1C00D3A20092B2E9 /* Scroller.cpp */,
+				521EDBC01C00D3A20092B2E9 /* Scroller.h */,
+				521EDBC11C00D3A20092B2E9 /* Single.cpp */,
+				521EDBC21C00D3A20092B2E9 /* Single.h */,
+				521EDBC31C00D3A20092B2E9 /* Skin.cpp */,
+				521EDBC41C00D3A20092B2E9 /* Skin.h */,
+				521EDBC51C00D3A20092B2E9 /* Slider.cpp */,
+				521EDBC61C00D3A20092B2E9 /* Slider.h */,
+				521EDBC71C00D3A20092B2E9 /* SmallButton.cpp */,
+				521EDBC81C00D3A20092B2E9 /* SmallButton.h */,
+				521EDBC91C00D3A20092B2E9 /* Table.cpp */,
+				521EDBCA1C00D3A20092B2E9 /* Table.h */,
+				521EDBCB1C00D3A20092B2E9 /* TextEntry.cpp */,
+				521EDBCC1C00D3A20092B2E9 /* TextEntry.h */,
+				521EDBCD1C00D3A20092B2E9 /* TextLayout.cpp */,
+				521EDBCE1C00D3A20092B2E9 /* TextLayout.h */,
+				521EDBCF1C00D3A20092B2E9 /* Widget.cpp */,
+				521EDBD01C00D3A20092B2E9 /* Widget.h */,
+				521EDBD11C00D3A20092B2E9 /* WidgetSet.h */,
+				521EDBD21C00D3A20092B2E9 /* Makefile.am */,
+			);
+			name = ui;
+			sourceTree = "<group>";
+		};
+		521ED9D11C00D3430092B2E9 /* dummy */ = {
+			isa = PBXGroup;
+			children = (
+				521ED9D21C00D3430092B2E9 /* Makefile.am */,
+				521ED9D31C00D3430092B2E9 /* MaterialDummy.h */,
+				521ED9D41C00D3430092B2E9 /* RendererDummy.cpp */,
+				521ED9D51C00D3430092B2E9 /* RendererDummy.h */,
+				521ED9D61C00D3430092B2E9 /* RenderStateDummy.h */,
+				521ED9D71C00D3430092B2E9 /* RenderTargetDummy.h */,
+				521ED9D81C00D3430092B2E9 /* TextureDummy.h */,
+				521ED9D91C00D3430092B2E9 /* VertexBufferDummy.h */,
+			);
+			name = dummy;
+			path = ../src/graphics/dummy;
+			sourceTree = "<group>";
+		};
+		521ED9DA1C00D3430092B2E9 /* opengl */ = {
+			isa = PBXGroup;
+			children = (
+				521ED9DB1C00D3430092B2E9 /* FresnelColourMaterial.cpp */,
+				521ED9DC1C00D3430092B2E9 /* FresnelColourMaterial.h */,
+				521ED9DD1C00D3430092B2E9 /* GasGiantMaterial.cpp */,
+				521ED9DE1C00D3430092B2E9 /* GasGiantMaterial.h */,
+				521ED9DF1C00D3430092B2E9 /* GeoSphereMaterial.cpp */,
+				521ED9E01C00D3430092B2E9 /* GeoSphereMaterial.h */,
+				521ED9E11C00D3430092B2E9 /* gl_core_3_x.c */,
+				521ED9E21C00D3430092B2E9 /* gl_core_3_x.h */,
+				521ED9E31C00D3430092B2E9 /* GLDebug.h */,
+				521ED9E41C00D3430092B2E9 /* LineMaterial.cpp */,
+				521ED9E51C00D3430092B2E9 /* LineMaterial.h */,
+				521ED9E61C00D3430092B2E9 /* Makefile.am */,
+				521ED9E71C00D3430092B2E9 /* MaterialGL.cpp */,
+				521ED9E81C00D3430092B2E9 /* MaterialGL.h */,
+				521ED9E91C00D3430092B2E9 /* MultiMaterial.cpp */,
+				521ED9EA1C00D3430092B2E9 /* MultiMaterial.h */,
+				521ED9EB1C00D3430092B2E9 /* OpenGLLibs.h */,
+				521ED9EC1C00D3430092B2E9 /* Program.cpp */,
+				521ED9ED1C00D3430092B2E9 /* Program.h */,
+				521ED9EE1C00D3430092B2E9 /* RendererGL.cpp */,
+				521ED9EF1C00D3430092B2E9 /* RendererGL.h */,
+				521ED9F01C00D3430092B2E9 /* RenderStateGL.cpp */,
+				521ED9F11C00D3430092B2E9 /* RenderStateGL.h */,
+				521ED9F21C00D3430092B2E9 /* RenderTargetGL.cpp */,
+				521ED9F31C00D3430092B2E9 /* RenderTargetGL.h */,
+				521ED9F41C00D3430092B2E9 /* RingMaterial.cpp */,
+				521ED9F51C00D3430092B2E9 /* RingMaterial.h */,
+				521ED9F61C00D3430092B2E9 /* ShieldMaterial.cpp */,
+				521ED9F71C00D3430092B2E9 /* ShieldMaterial.h */,
+				521ED9F81C00D3430092B2E9 /* SkyboxMaterial.h */,
+				521ED9F91C00D3430092B2E9 /* SphereImpostorMaterial.h */,
+				521ED9FA1C00D3430092B2E9 /* StarfieldMaterial.h */,
+				521ED9FB1C00D3430092B2E9 /* TextureGL.cpp */,
+				521ED9FC1C00D3430092B2E9 /* TextureGL.h */,
+				521ED9FD1C00D3430092B2E9 /* UIMaterial.cpp */,
+				521ED9FE1C00D3430092B2E9 /* UIMaterial.h */,
+				521ED9FF1C00D3430092B2E9 /* Uniform.cpp */,
+				521EDA001C00D3430092B2E9 /* Uniform.h */,
+				521EDA011C00D3430092B2E9 /* VertexBufferGL.cpp */,
+				521EDA021C00D3430092B2E9 /* VertexBufferGL.h */,
+				521EDA031C00D3430092B2E9 /* VtxColorMaterial.cpp */,
+				521EDA041C00D3430092B2E9 /* VtxColorMaterial.h */,
+			);
+			name = opengl;
+			path = ../src/graphics/opengl;
+			sourceTree = "<group>";
+		};
+		52D1258A1C0351FB00E6E4C2 /* contrib */ = {
+			isa = PBXGroup;
+			children = (
+				52E5FAF11C0375F2001F4F89 /* miniz */,
+				52E5FADD1C03589F001F4F89 /* jenkins */,
+				52D1261A1C03538F00E6E4C2 /* lua */,
+				52D125921C0351FB00E6E4C2 /* json */,
+				52D125DE1C0351FB00E6E4C2 /* PicoDDS */,
+			);
+			name = contrib;
+			path = ../contrib;
+			sourceTree = "<group>";
+		};
+		52D125921C0351FB00E6E4C2 /* json */ = {
+			isa = PBXGroup;
+			children = (
+				52D125931C0351FB00E6E4C2 /* json.h */,
+				52D125941C0351FB00E6E4C2 /* jsoncpp.cpp */,
+				52D125951C0351FB00E6E4C2 /* JsonUtils.cpp */,
+				52D125961C0351FB00E6E4C2 /* JsonUtils.h */,
+				52D125971C0351FB00E6E4C2 /* Makefile.am */,
+			);
+			path = json;
+			sourceTree = "<group>";
+		};
+		52D125DE1C0351FB00E6E4C2 /* PicoDDS */ = {
+			isa = PBXGroup;
+			children = (
+				52D125DF1C0351FB00E6E4C2 /* Makefile.am */,
+				52D125E01C0351FB00E6E4C2 /* PicoDDS.cpp */,
+				52D125E11C0351FB00E6E4C2 /* PicoDDS.h */,
+			);
+			path = PicoDDS;
+			sourceTree = "<group>";
+		};
+		52D1261A1C03538F00E6E4C2 /* lua */ = {
+			isa = PBXGroup;
+			children = (
+				52D1261B1C03538F00E6E4C2 /* lapi.c */,
+				52D1261C1C03538F00E6E4C2 /* lapi.h */,
+				52D1261D1C03538F00E6E4C2 /* lauxlib.c */,
+				52D1261E1C03538F00E6E4C2 /* lauxlib.h */,
+				52D1261F1C03538F00E6E4C2 /* lbaselib.c */,
+				52D126201C03538F00E6E4C2 /* lbitlib.c */,
+				52D126211C03538F00E6E4C2 /* lcode.c */,
+				52D126221C03538F00E6E4C2 /* lcode.h */,
+				52D126231C03538F00E6E4C2 /* lcorolib.c */,
+				52D126241C03538F00E6E4C2 /* lctype.c */,
+				52D126251C03538F00E6E4C2 /* lctype.h */,
+				52D126261C03538F00E6E4C2 /* ldblib.c */,
+				52D126271C03538F00E6E4C2 /* ldebug.c */,
+				52D126281C03538F00E6E4C2 /* ldebug.h */,
+				52D126291C03538F00E6E4C2 /* ldo.c */,
+				52D1262A1C03538F00E6E4C2 /* ldo.h */,
+				52D1262B1C03538F00E6E4C2 /* ldump.c */,
+				52D1262C1C03538F00E6E4C2 /* lfunc.c */,
+				52D1262D1C03538F00E6E4C2 /* lfunc.h */,
+				52D1262E1C03538F00E6E4C2 /* lgc.c */,
+				52D1262F1C03538F00E6E4C2 /* lgc.h */,
+				52D126301C03538F00E6E4C2 /* linit.c */,
+				52D126311C03538F00E6E4C2 /* liolib.c */,
+				52D126321C03538F00E6E4C2 /* llex.c */,
+				52D126331C03538F00E6E4C2 /* llex.h */,
+				52D126341C03538F00E6E4C2 /* llimits.h */,
+				52D126351C03538F00E6E4C2 /* lmathlib.c */,
+				52D126361C03538F00E6E4C2 /* lmem.c */,
+				52D126371C03538F00E6E4C2 /* lmem.h */,
+				52D126381C03538F00E6E4C2 /* loadlib.c */,
+				52D126391C03538F00E6E4C2 /* lobject.c */,
+				52D1263A1C03538F00E6E4C2 /* lobject.h */,
+				52D1263B1C03538F00E6E4C2 /* lopcodes.c */,
+				52D1263C1C03538F00E6E4C2 /* lopcodes.h */,
+				52D1263D1C03538F00E6E4C2 /* loslib.c */,
+				52D1263E1C03538F00E6E4C2 /* lparser.c */,
+				52D1263F1C03538F00E6E4C2 /* lparser.h */,
+				52D126401C03538F00E6E4C2 /* lstate.c */,
+				52D126411C03538F00E6E4C2 /* lstate.h */,
+				52D126421C03538F00E6E4C2 /* lstring.c */,
+				52D126431C03538F00E6E4C2 /* lstring.h */,
+				52D126441C03538F00E6E4C2 /* lstrlib.c */,
+				52D126451C03538F00E6E4C2 /* ltable.c */,
+				52D126461C03538F00E6E4C2 /* ltable.h */,
+				52D126471C03538F00E6E4C2 /* ltablib.c */,
+				52D126481C03538F00E6E4C2 /* ltm.c */,
+				52D126491C03538F00E6E4C2 /* ltm.h */,
+				52D1264B1C03538F00E6E4C2 /* lua.h */,
+				52D1264C1C03538F00E6E4C2 /* lua.hpp */,
+				52D1264E1C03538F00E6E4C2 /* luaconf.h */,
+				52D1264F1C03538F00E6E4C2 /* lualib.h */,
+				52D126501C03538F00E6E4C2 /* lundump.c */,
+				52D126511C03538F00E6E4C2 /* lundump.h */,
+				52D126521C03538F00E6E4C2 /* lvm.c */,
+				52D126531C03538F00E6E4C2 /* lvm.h */,
+				52D126541C03538F00E6E4C2 /* lzio.c */,
+				52D126551C03538F00E6E4C2 /* lzio.h */,
+				52D126561C03538F00E6E4C2 /* Makefile.am */,
+			);
+			path = lua;
+			sourceTree = "<group>";
+		};
+		52E5FADD1C03589F001F4F89 /* jenkins */ = {
+			isa = PBXGroup;
+			children = (
+				52E5FADE1C03589F001F4F89 /* lookup3.c */,
+				52E5FADF1C03589F001F4F89 /* lookup3.h */,
+				52E5FAE01C03589F001F4F89 /* Makefile.am */,
+			);
+			path = jenkins;
+			sourceTree = "<group>";
+		};
+		52E5FAF11C0375F2001F4F89 /* miniz */ = {
+			isa = PBXGroup;
+			children = (
+				52E5FAF21C0375F2001F4F89 /* Makefile.am */,
+				52E5FAF31C0375F2001F4F89 /* miniz.h */,
+				52E5FAF41C0375F2001F4F89 /* README */,
 			);
 			path = miniz;
-			sourceTree = "<group>";
-		};
-		4AB7D5CF1472A83E00158DE4 /* terrain */ = {
-			isa = PBXGroup;
-			children = (
-				4AB7D5D11472A83E00158DE4 /* Terrain.cpp */,
-				4AB7D5D21472A83E00158DE4 /* Terrain.h */,
-				4AB7D5D31472A83E00158DE4 /* TerrainColorAsteroid.cpp */,
-				4AB7D5D41472A83E00158DE4 /* TerrainColorBandedRock.cpp */,
-				4AB7D5D51472A83E00158DE4 /* TerrainColorDeadWithWater.cpp */,
-				4AB7D5D61472A83E00158DE4 /* TerrainColorDesert.cpp */,
-				4AB7D5D71472A83E00158DE4 /* TerrainColorEarthLike.cpp */,
-				4AB7D5D81472A83E00158DE4 /* TerrainColorGGJupiter.cpp */,
-				4AB7D5D91472A83E00158DE4 /* TerrainColorGGNeptune.cpp */,
-				4AB7D5DA1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp */,
-				4AB7D5DB1472A83E00158DE4 /* TerrainColorGGSaturn.cpp */,
-				4AB7D5DC1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp */,
-				4AB7D5DD1472A83E00158DE4 /* TerrainColorGGUranus.cpp */,
-				4AB7D5DE1472A83E00158DE4 /* TerrainColorIce.cpp */,
-				4AB7D5DF1472A83E00158DE4 /* TerrainColorMethane.cpp */,
-				4AB7D5E01472A83E00158DE4 /* TerrainColorRock.cpp */,
-				4AB7D5E11472A83E00158DE4 /* TerrainColorRock2.cpp */,
-				4AB7D5E21472A83E00158DE4 /* TerrainColorSolid.cpp */,
-				4AB7D5E31472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp */,
-				4AB7D5E41472A83E00158DE4 /* TerrainColorStarG.cpp */,
-				4AB7D5E51472A83E00158DE4 /* TerrainColorStarK.cpp */,
-				4AB7D5E61472A83E00158DE4 /* TerrainColorStarM.cpp */,
-				4AB7D5E71472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp */,
-				4AB7D5E81472A83E00158DE4 /* TerrainColorTFGood.cpp */,
-				4AB7D5E91472A83E00158DE4 /* TerrainColorTFPoor.cpp */,
-				4AB7D5EA1472A83E00158DE4 /* TerrainColorVolcanic.cpp */,
-				4AB7D5EB1472A83E00158DE4 /* TerrainFeature.cpp */,
-				4AB7D5EC1472A83E00158DE4 /* TerrainFeature.h */,
-				4AB7D5ED1472A83E00158DE4 /* TerrainHeightAsteroid.cpp */,
-				4ADB0D0615C50DD900AE2123 /* TerrainHeightAsteroid2.cpp */,
-				4ADB0D0715C50DD900AE2123 /* TerrainHeightAsteroid3.cpp */,
-				4ADB0D0815C50DD900AE2123 /* TerrainHeightAsteroid4.cpp */,
-				4ADB0D0915C50DD900AE2123 /* TerrainHeightBarrenRock.cpp */,
-				4ADB0D0A15C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp */,
-				4ADB0D0B15C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp */,
-				4AA9F6CB17288E0900124C2E /* TerrainHeightEllipsoid.cpp */,
-				4AB7D5EE1472A83E00158DE4 /* TerrainHeightFlat.cpp */,
-				4AB7D5EF1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp */,
-				4AB7D5F01472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp */,
-				4AB7D5F11472A83E00158DE4 /* TerrainHeightHillsDunes.cpp */,
-				4AB7D5F21472A83E00158DE4 /* TerrainHeightHillsNormal.cpp */,
-				4AB7D5F31472A83E00158DE4 /* TerrainHeightHillsRidged.cpp */,
-				4AB7D5F41472A83E00158DE4 /* TerrainHeightHillsRivers.cpp */,
-				4AB7D5F51472A83E00158DE4 /* TerrainHeightMapped.cpp */,
-				4AED721C14E1501D004D171E /* TerrainHeightMapped2.cpp */,
-				4AB7D5F61472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp */,
-				4AB7D5F71472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp */,
-				4AB7D5F81472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp */,
-				4AB7D5F91472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp */,
-				4AB7D5FA1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp */,
-				4AB7D5FB1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp */,
-				4AB7D5FC1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp */,
-				4AB7D5FD1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp */,
-				4AB7D5FE1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp */,
-				4AB7D5FF1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp */,
-				4AB7D6001472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp */,
-				4AB7D6011472A83E00158DE4 /* TerrainNoise.h */,
-			);
-			path = terrain;
-			sourceTree = "<group>";
-		};
-		4ABF302D16335A1100664653 /* ui */ = {
-			isa = PBXGroup;
-			children = (
-				4ABF302E16335A1100664653 /* Align.cpp */,
-				4ABF302F16335A1100664653 /* Align.h */,
-				4ABF303016335A1100664653 /* Background.cpp */,
-				4ABF303116335A1100664653 /* Background.h */,
-				4ABF303216335A1100664653 /* Box.cpp */,
-				4ABF303316335A1100664653 /* Box.h */,
-				4ABF303416335A1100664653 /* Button.cpp */,
-				4ABF303516335A1100664653 /* Button.h */,
-				4ABF303616335A1100664653 /* CellSpec.cpp */,
-				4ABF303716335A1100664653 /* CellSpec.h */,
-				4ABF303816335A1100664653 /* CheckBox.cpp */,
-				4ABF303916335A1100664653 /* CheckBox.h */,
-				4ABF303A16335A1100664653 /* ColorBackground.cpp */,
-				4ABF303B16335A1100664653 /* ColorBackground.h */,
-				4ABF303C16335A1100664653 /* Container.cpp */,
-				4ABF303D16335A1100664653 /* Container.h */,
-				4ABF303E16335A1100664653 /* Context.cpp */,
-				4ABF303F16335A1100664653 /* Context.h */,
-				4ABF304016335A1100664653 /* DropDown.cpp */,
-				4ABF304116335A1100664653 /* DropDown.h */,
-				4ABF304216335A1100664653 /* Event.cpp */,
-				4ABF304316335A1100664653 /* Event.h */,
-				4ABF304416335A1100664653 /* EventDispatcher.cpp */,
-				4ABF304516335A1100664653 /* EventDispatcher.h */,
-				4AA4A8D4164D0EB10006C3BF /* Expand.cpp */,
-				4AA4A8D5164D0EB10006C3BF /* Expand.h */,
-				4ABF304616335A1100664653 /* FloatContainer.cpp */,
-				4ABF304716335A1100664653 /* FloatContainer.h */,
-				4AA4A8D6164D0EB10006C3BF /* Gradient.cpp */,
-				4AA4A8D7164D0EB10006C3BF /* Gradient.h */,
-				4ABF304816335A1100664653 /* Grid.cpp */,
-				4ABF304916335A1100664653 /* Grid.h */,
-				4A4D25DC167335F5003BC9D5 /* Icon.cpp */,
-				4A4D25DD167335F5003BC9D5 /* Icon.h */,
-				4ABF304A16335A1100664653 /* Image.cpp */,
-				4ABF304B16335A1100664653 /* Image.h */,
-				4ABF304C16335A1100664653 /* Label.cpp */,
-				4ABF304D16335A1100664653 /* Label.h */,
-				4ABF304E16335A1100664653 /* List.cpp */,
-				4ABF304F16335A1100664653 /* List.h */,
-				4ABF305016335A1100664653 /* Lua.cpp */,
-				4ABF305116335A1100664653 /* Lua.h */,
-				4ABF305216335A1100664653 /* LuaAlign.cpp */,
-				4ABF305316335A1100664653 /* LuaBackground.cpp */,
-				4ABF305416335A1100664653 /* LuaBox.cpp */,
-				4ABF305516335A1100664653 /* LuaButton.cpp */,
-				4ABF305616335A1100664653 /* LuaCheckBox.cpp */,
-				4ABF305716335A1100664653 /* LuaColorBackground.cpp */,
-				4ABF305816335A1100664653 /* LuaContainer.cpp */,
-				4ABF305916335A1100664653 /* LuaContext.cpp */,
-				4ABF305A16335A1100664653 /* LuaDropDown.cpp */,
-				4AA4A8D8164D0EB10006C3BF /* LuaExpand.cpp */,
-				4AA4A8D9164D0EB10006C3BF /* LuaGradient.cpp */,
-				4ABF305B16335A1100664653 /* LuaGrid.cpp */,
-				4A4D25DE167335F5003BC9D5 /* LuaIcon.cpp */,
-				4ABF305C16335A1100664653 /* LuaImage.cpp */,
-				4ABF305D16335A1100664653 /* LuaLabel.cpp */,
-				4ABF305E16335A1100664653 /* LuaList.cpp */,
-				4ABF305F16335A1100664653 /* LuaMargin.cpp */,
-				4ABF306016335A1100664653 /* LuaMultiLineText.cpp */,
-				4ABF306116335A1100664653 /* LuaScroller.cpp */,
-				4ABF306216335A1100664653 /* LuaSignal.h */,
-				4ABF306316335A1100664653 /* LuaSingle.cpp */,
-				4ABF306416335A1100664653 /* LuaSlider.cpp */,
-				4A0F25CB165CF00D00208507 /* LuaSmallButton.cpp */,
-				4AFBD7BA16412676002928CB /* LuaTextEntry.cpp */,
-				4ABF306516335A1100664653 /* LuaWidget.cpp */,
-				4ABF306716335A1100664653 /* Margin.cpp */,
-				4ABF306816335A1100664653 /* Margin.h */,
-				4ABF306916335A1100664653 /* MultiLineText.cpp */,
-				4ABF306A16335A1100664653 /* MultiLineText.h */,
-				4ABF306B16335A1100664653 /* Point.h */,
-				4ABF306C16335A1100664653 /* Scroller.cpp */,
-				4ABF306D16335A1100664653 /* Scroller.h */,
-				4ABF306E16335A1100664653 /* Single.cpp */,
-				4ABF306F16335A1100664653 /* Single.h */,
-				4ABF307016335A1100664653 /* Skin.cpp */,
-				4ABF307116335A1100664653 /* Skin.h */,
-				4ABF307216335A1100664653 /* Slider.cpp */,
-				4ABF307316335A1100664653 /* Slider.h */,
-				4A0F25CC165CF00D00208507 /* SmallButton.cpp */,
-				4A0F25CD165CF00D00208507 /* SmallButton.h */,
-				4AFBD7BB16412676002928CB /* TextEntry.cpp */,
-				4AFBD7BC16412676002928CB /* TextEntry.h */,
-				4ABF307416335A1100664653 /* TextLayout.cpp */,
-				4ABF307516335A1100664653 /* TextLayout.h */,
-				4ABF307616335A1100664653 /* Widget.cpp */,
-				4ABF307716335A1100664653 /* Widget.h */,
-				4ABF307816335A1100664653 /* WidgetSet.h */,
-			);
-			path = ui;
-			sourceTree = "<group>";
-		};
-		4ACC6D1115401E7000C59914 /* text */ = {
-			isa = PBXGroup;
-			children = (
-				4ACDB6D0167879AF0069FA03 /* DistanceFieldFont.cpp */,
-				4ACDB6D1167879AF0069FA03 /* DistanceFieldFont.h */,
-				4ACC6D1215401E7000C59914 /* Font.cpp */,
-				4ACC6D1315401E7000C59914 /* Font.h */,
-				4AFBD7BF16412688002928CB /* FontDescriptor.cpp */,
-				4ACC6D1415401E7000C59914 /* FontDescriptor.h */,
-				4ACC6D1615401E7000C59914 /* TextSupport.cpp */,
-				4ACC6D1715401E7000C59914 /* TextSupport.h */,
-				4ACC6D1815401E7000C59914 /* TextureFont.cpp */,
-				4ACC6D1915401E7000C59914 /* TextureFont.h */,
-			);
-			path = text;
-			sourceTree = "<group>";
-		};
-		4ACDB683167878610069FA03 /* scenegraph */ = {
-			isa = PBXGroup;
-			children = (
-				4AA5280716E9EBD60036D4CB /* LuaModelSkin.cpp */,
-				4AA5280016E9EB980036D4CB /* Lua.cpp */,
-				4AA5280116E9EB980036D4CB /* Lua.h */,
-				4AA5280216E9EB980036D4CB /* ModelSkin.cpp */,
-				4AA5280316E9EB980036D4CB /* ModelSkin.h */,
-				4AA5280416E9EB980036D4CB /* NodeCopyCache.h */,
-				4ACDB684167878610069FA03 /* Animation.cpp */,
-				4ACDB685167878610069FA03 /* Animation.h */,
-				4ACDB686167878610069FA03 /* AnimationChannel.h */,
-				4ACDB687167878610069FA03 /* AnimationKey.h */,
-				4ACDB688167878620069FA03 /* Billboard.cpp */,
-				4ACDB689167878620069FA03 /* Billboard.h */,
-				4ACDB68A167878620069FA03 /* CollisionGeometry.cpp */,
-				4ACDB68B167878620069FA03 /* CollisionGeometry.h */,
-				4ACDB68C167878620069FA03 /* CollisionVisitor.cpp */,
-				4ACDB68D167878620069FA03 /* CollisionVisitor.h */,
-				4ACDB68E167878620069FA03 /* ColorMap.cpp */,
-				4ACDB68F167878620069FA03 /* ColorMap.h */,
-				4ACDB690167878620069FA03 /* DumpVisitor.cpp */,
-				4ACDB691167878620069FA03 /* DumpVisitor.h */,
-				4ACDB692167878620069FA03 /* FindNodeVisitor.cpp */,
-				4ACDB693167878620069FA03 /* FindNodeVisitor.h */,
-				4ACDB694167878620069FA03 /* Group.cpp */,
-				4ACDB695167878620069FA03 /* Group.h */,
-				4ACDB696167878620069FA03 /* Label3D.cpp */,
-				4ACDB697167878620069FA03 /* Label3D.h */,
-				4ACDB698167878620069FA03 /* Loader.cpp */,
-				4ACDB699167878620069FA03 /* Loader.h */,
-				4ACDB69A167878620069FA03 /* LoaderDefinitions.h */,
-				4ACDB69B167878620069FA03 /* LOD.cpp */,
-				4ACDB69C167878620069FA03 /* LOD.h */,
-				4ACDB69E167878620069FA03 /* MatrixTransform.cpp */,
-				4ACDB69F167878620069FA03 /* MatrixTransform.h */,
-				4ACDB6A0167878620069FA03 /* Model.cpp */,
-				4ACDB6A1167878620069FA03 /* Model.h */,
-				4ACDB6A2167878620069FA03 /* ModelNode.cpp */,
-				4ACDB6A3167878620069FA03 /* ModelNode.h */,
-				4ACDB6A4167878620069FA03 /* Node.cpp */,
-				4ACDB6A5167878620069FA03 /* Node.h */,
-				4ACDB6A6167878620069FA03 /* NodeVisitor.cpp */,
-				4ACDB6A7167878620069FA03 /* NodeVisitor.h */,
-				4ACDB6A8167878620069FA03 /* Parser.cpp */,
-				4ACDB6A9167878620069FA03 /* Parser.h */,
-				4ACDB6AA167878620069FA03 /* Pattern.cpp */,
-				4ACDB6AB167878620069FA03 /* Pattern.h */,
-				4ACDB6AC167878620069FA03 /* SceneGraph.h */,
-				4ACDB6AD167878620069FA03 /* StaticGeometry.cpp */,
-				4ACDB6AE167878620069FA03 /* StaticGeometry.h */,
-				4ACDB6AF167878620069FA03 /* Thruster.cpp */,
-				4ACDB6B0167878620069FA03 /* Thruster.h */,
-			);
-			path = scenegraph;
-			sourceTree = "<group>";
-		};
-		4ADB0D1215C50DF000AE2123 /* posix */ = {
-			isa = PBXGroup;
-			children = (
-				4ADB0D1315C50DF000AE2123 /* FileSystemPosix.cpp */,
-				4ADB0D1515C50DF000AE2123 /* OSPosix.cpp */,
-			);
-			path = posix;
-			sourceTree = "<group>";
-		};
-		4ADF517F1557473400ACF5A0 /* galaxy */ = {
-			isa = PBXGroup;
-			children = (
-				4A01889615A59908002F540B /* SystemPath.cpp */,
-				4ADF51801557473400ACF5A0 /* CustomSystem.cpp */,
-				4ADF51811557473400ACF5A0 /* CustomSystem.h */,
-				4ADF51821557473400ACF5A0 /* Galaxy.cpp */,
-				4ADF51831557473400ACF5A0 /* Galaxy.h */,
-				4ADF51851557473400ACF5A0 /* Sector.cpp */,
-				4ADF51861557473400ACF5A0 /* Sector.h */,
-				4ADF51871557473400ACF5A0 /* StarSystem.cpp */,
-				4ADF51881557473400ACF5A0 /* StarSystem.h */,
-				4ADF51891557473400ACF5A0 /* SystemPath.h */,
-			);
-			path = galaxy;
-			sourceTree = "<group>";
-		};
-		4AE46C471607513400308C22 /* vcacheopt */ = {
-			isa = PBXGroup;
-			children = (
-				4AE46C491607513400308C22 /* vcacheopt.h */,
-			);
-			path = vcacheopt;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2236,7 +2427,7 @@
 		4A20B0D01353194B0020F43E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0710;
 			};
 			buildConfigurationList = 4A20B0D31353194B0020F43E /* Build configuration list for PBXProject "pioneer" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -2263,8 +2454,11 @@
 			files = (
 				4A20B11C13531CD10020F43E /* Credits.rtf in Resources */,
 				4A20B11D13531CD10020F43E /* InfoPlist.strings in Resources */,
+				521ED9981C00D2FC0092B2E9 /* Makefile.am in Resources */,
+				52E5FAF51C0375F2001F4F89 /* Makefile.am in Resources */,
 				4A20B12013531E950020F43E /* pioneerApp.xib in Resources */,
 				4A8563FD148655DA008121E1 /* pioneer-logo.icns in Resources */,
+				52E5FAF61C0375F2001F4F89 /* README in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2283,7 +2477,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#\n# The following script is used to update all the included libraries with the install_name_tool so that we can create a self\n# contained app bundle with all the included libraries without the user having to hunt down extra libraries etc. Just launch\n# and go! (its the apple way!).\n#\nfunction relocateLibInApp() {\n    install_name_tool -change $1$2 @executable_path/../Frameworks/$2 $CONFIGURATION_BUILD_DIR/$EXECUTABLE_PATH\n    install_name_tool -id @executable_path/../Frameworks/$2 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2\n}\n\nfunction idLib() {\n    install_name_tool -id @executable_path/../Frameworks/$1 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1\n}\n\nfunction relocateSubLib() {\n    install_name_tool -change $1$3 @executable_path/../Frameworks/$3 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2   \n}\n\nfunction lnk() {\n    ln -f $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2\n}\n\n# freetype dylibs\nrelocateLibInApp /opt/local/lib/ libfreetype.6.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libz.1.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libbz2.1.0.dylib\n\n# GLEW dylibs\nrelocateLibInApp /opt/local/lib/ libGLEW.1.9.0.dylib\n\n# libassimp\nlnk libassimp.3.0.0.dylib libassimp.3.dylib\nrelocateLibInApp /opt/local/lib/ libassimp.3.dylib\nrelocateSubLib /opt/local/lib/ libassimp.3.0.0.dylib libz.1.dylib\n\n# sigcxx\nrelocateLibInApp /opt/local/lib/ libsigc-2.0.0.dylib\n\n# SDL\nrelocateLibInApp /opt/local/lib/ libSDL-1.2.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL-1.2.0.dylib libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libSDL-1.2.0.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL-1.2.0.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL-1.2.0.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL-1.2.0.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL-1.2.0.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL-1.2.0.dylib libXdmcp.6.dylib\n\n# SDL_image\nrelocateLibInApp /opt/local/lib/ libSDL_image-1.2.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libpng15.15.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libtiff.3.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libjpeg.8.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libz.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libSDL-1.2.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL_image-1.2.0.dylib libXdmcp.6.dylib\n\n# SDL_sound\nlnk libSDL_sound-1.0.1.0.2.dylib libSDL_sound-1.0.1.dylib\nrelocateLibInApp /opt/local/lib/ libSDL_sound-1.0.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libSDL-1.2.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libsmpeg-0.4.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libmodplug.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libvorbis.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libvorbisfile.3.dylib\nrelocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libFLAC.8.dylib\nrelocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libogg.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libspeex.1.dylib\n\n# vorbisfile\nrelocateLibInApp /opt/local/lib/ libvorbisfile.3.dylib\nrelocateSubLib /opt/local/lib/ libvorbisfile.3.dylib libvorbis.0.dylib\nrelocateSubLib /opt/local/lib/ libvorbisfile.3.dylib libogg.0.dylib\n\n#\n# EXTRA LIBS\n#\n\n#bz2\nlnk libbz2.1.0.6.dylib libbz2.1.0.dylib\nrelocateLibInApp /opt/local/lib/ libbz2.1.0.dylib\n\n# FLAC\nidLib libFLAC.8.dylib\nrelocateSubLib /opt/local/lib/ libFLAC.8.dylib libogg.0.dylib\n\n# jpeg\nidLib libjpeg.8.dylib\n\n# modplug\nidLib libmodplug.1.dylib\n\n# ogg\nidLib libogg.0.dylib\n\n# png\nidLib libpng15.15.dylib\nrelocateSubLib /opt/local/lib/ libpng15.15.dylib libz.1.dylib\nrelocateLibInApp /opt/local/lib/ libpng15.15.dylib\n\n# smpeg\nidLib libsmpeg-0.4.0.dylib\nrelocateSubLib /opt/local/lib/ libsmpeg-0.4.0.dylib libSDL-1.2.0.dylib\n\n#speex\nlnk libspeex.1.5.0.dylib libspeex.1.dylib\nidLib libspeex.1.dylib\n\n# tiff\nidLib libtiff.3.dylib\nrelocateSubLib /opt/local/lib/ libtiff.3.dylib libjpeg.8.dylib\nrelocateSubLib /opt/local/lib/ libtiff.3.dylib libz.1.dylib\n\n# vorbis\nidLib libvorbis.0.dylib\nrelocateSubLib /opt/local/lib/ libvorbis.0.dylib libogg.0.dylib\n\n# libX11\nrelocateLibInApp /opt/local/lib/ libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libXdmcp.6.dylib\n\n# libXau\nrelocateLibInApp /opt/local/lib/ libXau.6.dylib\n\n# libxcd\nrelocateLibInApp /opt/local/lib/ libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libxcb.1.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libxcb.1.dylib libXdmcp.6.dylib\n\n# libXdmcp\nrelocateLibInApp /opt/local/lib/ libXdmcp.6.dylib\n\n# libext\nrelocateLibInApp /opt/local/lib/ libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libXdmcp.6.dylib\n\n# libXrandr\nrelocateLibInApp /opt/local/lib/ libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXdmcp.6.dylib\n\n# libXrender\nrelocateLibInApp /opt/local/lib/ libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libXdmcp.6.dylib\n\n# zlib\nlnk libz.1.2.7.dylib libz.1.dylib\nrelocateLibInApp /opt/local/lib/ libz.1.dylib\nidLib libz.1.2.7.dylib\n";
+			shellScript = "#\n# The following script is used to update all the included libraries with the install_name_tool so that we can create a self\n# contained app bundle with all the included libraries without the user having to hunt down extra libraries etc. Just launch\n# and go! (its the apple way!).\n#\nfunction relocateLibInApp() {\n    install_name_tool -change $1$2 @executable_path/../Frameworks/$2 $CONFIGURATION_BUILD_DIR/$EXECUTABLE_PATH\n    install_name_tool -id @executable_path/../Frameworks/$2 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2\n}\n\nfunction idLib() {\n    install_name_tool -id @executable_path/../Frameworks/$1 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1\n}\n\nfunction relocateSubLib() {\n    install_name_tool -change $1$3 @executable_path/../Frameworks/$3 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2   \n}\n\nfunction lnk() {\n    ln -f $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$1 $CONFIGURATION_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$2\n}\n\n# freetype dylibs\nrelocateLibInApp /opt/local/lib/ libfreetype.6.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libz.1.dylib\nrelocateSubLib /opt/local/lib/ libfreetype.6.dylib libbz2.1.0.dylib\n\n# GLEW dylibs\nrelocateLibInApp /opt/local/lib/ libGLEW.1.13.0.dylib\n\n# libassimp\nlnk libassimp.3.0.0.dylib libassimp.3.dylib\nrelocateLibInApp /opt/local/lib/ libassimp.3.dylib\nrelocateSubLib /opt/local/lib/ libassimp.3.0.0.dylib libz.1.dylib\n\n# sigcxx\nrelocateLibInApp /opt/local/lib/ libsigc-2.0.0.dylib\n\n# SDL\nrelocateLibInApp /opt/local/lib/ libSDL2-2.0.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2-2.0.0.dylib libXdmcp.6.dylib\n\n# SDL_image\nrelocateLibInApp /opt/local/lib/ libSDL2_image-2.0.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libpng15.15.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libtiff.3.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libjpeg.8.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libz.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libSDL2-2.0.0.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libSDL2_image-2.0.0.dylib libXdmcp.6.dylib\n\n# SDL_sound\n#lnk libSDL_sound-1.0.1.0.2.dylib libSDL_sound-1.0.1.dylib\n#relocateLibInApp /opt/local/lib/ libSDL_sound-1.0.1.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libSDL2-2.0.0.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libsmpeg-0.4.0.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libmodplug.1.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libvorbis.0.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libvorbisfile.3.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libFLAC.8.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libogg.0.dylib\n#relocateSubLib /opt/local/lib/ libSDL_sound-1.0.1.0.2.dylib libspeex.1.dylib\n\n# vorbisfile\nrelocateLibInApp /opt/local/lib/ libvorbisfile.3.dylib\nrelocateSubLib /opt/local/lib/ libvorbisfile.3.dylib libvorbis.0.dylib\nrelocateSubLib /opt/local/lib/ libvorbisfile.3.dylib libogg.0.dylib\n\n#\n# EXTRA LIBS\n#\n\n#bz2\nlnk libbz2.1.0.6.dylib libbz2.1.0.dylib\nrelocateLibInApp /opt/local/lib/ libbz2.1.0.dylib\n\n# FLAC\nidLib libFLAC.8.dylib\nrelocateSubLib /opt/local/lib/ libFLAC.8.dylib libogg.0.dylib\n\n# jpeg\nidLib libjpeg.9.dylib\n\n# modplug\nidLib libmodplug.1.dylib\n\n# ogg\nidLib libogg.0.dylib\n\n# png\nidLib libpng16.16.dylib\nrelocateSubLib /opt/local/lib/ libpng16.16.dylib libz.1.dylib\nrelocateLibInApp /opt/local/lib/ libpng16.16.dylib\n\n# smpeg\nidLib libsmpeg-0.4.0.dylib\nrelocateSubLib /opt/local/lib/ libsmpeg-0.4.0.dylib libSDL-1.2.0.dylib\n\n#speex\nlnk libspeex.1.5.0.dylib libspeex.1.dylib\nidLib libspeex.1.dylib\n\n# tiff\nidLib libtiff.5.dylib\nrelocateSubLib /opt/local/lib/ libtiff.5.dylib libjpeg.8.dylib\nrelocateSubLib /opt/local/lib/ libtiff.5.dylib libz.1.dylib\n\n# vorbis\nidLib libvorbis.0.dylib\nrelocateSubLib /opt/local/lib/ libvorbis.0.dylib libogg.0.dylib\n\n# libX11\nrelocateLibInApp /opt/local/lib/ libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libX11.6.dylib libXdmcp.6.dylib\n\n# libXau\nrelocateLibInApp /opt/local/lib/ libXau.6.dylib\n\n# libxcd\nrelocateLibInApp /opt/local/lib/ libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libxcb.1.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libxcb.1.dylib libXdmcp.6.dylib\n\n# libXdmcp\nrelocateLibInApp /opt/local/lib/ libXdmcp.6.dylib\n\n# libext\nrelocateLibInApp /opt/local/lib/ libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXext.6.dylib libXdmcp.6.dylib\n\n# libXrandr\nrelocateLibInApp /opt/local/lib/ libXrandr.2.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXext.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXrandr.2.dylib libXdmcp.6.dylib\n\n# libXrender\nrelocateLibInApp /opt/local/lib/ libXrender.1.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libX11.6.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libxcb.1.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libXau.6.dylib\nrelocateSubLib /opt/local/lib/ libXrender.1.dylib libXdmcp.6.dylib\n\n# zlib\nlnk libz.1.2.8.dylib libz.1.dylib\nrelocateLibInApp /opt/local/lib/ libz.1.dylib\nidLib libz.1.2.8.dylib\n";
 		};
 		4AE970701436A65D00424F91 /* GenGitVersion */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2306,373 +2500,400 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4A20B11113531C040020F43E /* SDLMain.m in Sources */,
-				4A6C4DD113532FC300FDD53F /* AmbientSounds.cpp in Sources */,
-				4A6C4DD213532FC300FDD53F /* Body.cpp in Sources */,
-				4A6C4DD313532FC300FDD53F /* CargoBody.cpp in Sources */,
-				4A6C4DD413532FC300FDD53F /* CityOnPlanet.cpp in Sources */,
-				4A6C4DD913532FC300FDD53F /* BVHTree.cpp in Sources */,
-				4A6C4DDA13532FC300FDD53F /* CollisionSpace.cpp in Sources */,
-				4A6C4DDB13532FC300FDD53F /* Geom.cpp in Sources */,
-				4A6C4DDC13532FC300FDD53F /* GeomTree.cpp in Sources */,
-				4A6C4DE013532FC300FDD53F /* CommodityTradeWidget.cpp in Sources */,
-				4A6C4DE213532FC300FDD53F /* DynamicBody.cpp in Sources */,
-				4A6C4DE313532FC300FDD53F /* EquipType.cpp in Sources */,
-				4A6C4DE413532FC300FDD53F /* Frame.cpp in Sources */,
-				4A6C4DE513532FC300FDD53F /* GalacticView.cpp in Sources */,
-				4A6C4DE713532FC300FDD53F /* GameMenuView.cpp in Sources */,
-				4A6C4DE913532FC300FDD53F /* GeoSphere.cpp in Sources */,
-				4A6C4E0413532FC300FDD53F /* HyperspaceCloud.cpp in Sources */,
-				4A6C4E0613532FC300FDD53F /* IniConfig.cpp in Sources */,
-				4A6C4E0713532FC300FDD53F /* KeyBindings.cpp in Sources */,
-				4A6C4E4B13532FC300FDD53F /* LuaChatForm.cpp in Sources */,
-				4A6C4E4D13532FC300FDD53F /* main.cpp in Sources */,
-				4A6C4E5113532FC300FDD53F /* MarketAgent.cpp in Sources */,
-				4A6C4E5213532FC300FDD53F /* Missile.cpp in Sources */,
-				4A6C4E5413532FC300FDD53F /* ModelBody.cpp in Sources */,
-				4A6C4E5913532FC300FDD53F /* ObjectViewerView.cpp in Sources */,
-				4A6C4E7113532FC300FDD53F /* perlin.cpp in Sources */,
-				4A6C4E7213532FC300FDD53F /* Pi.cpp in Sources */,
-				4A6C4E7713532FC300FDD53F /* Planet.cpp in Sources */,
-				4A6C4E7813532FC300FDD53F /* Player.cpp in Sources */,
-				4A6C4E7A13532FC300FDD53F /* Polit.cpp in Sources */,
-				4A6C4E7B13532FC300FDD53F /* Projectile.cpp in Sources */,
-				4A6C4E7E13532FC300FDD53F /* SectorView.cpp in Sources */,
-				4A6C4E7F13532FC300FDD53F /* Serializer.cpp in Sources */,
-				4A6C4E8013532FC300FDD53F /* Sfx.cpp in Sources */,
-				4A6C4E8113532FC300FDD53F /* Ship-AI.cpp in Sources */,
-				4A6C4E8213532FC300FDD53F /* Ship.cpp in Sources */,
-				4A6C4E8313532FC300FDD53F /* ShipAICmd.cpp in Sources */,
-				4A6C4E8413532FC300FDD53F /* ShipCpanel.cpp in Sources */,
-				4A6C4E8513532FC300FDD53F /* ShipCpanelMultiFuncDisplays.cpp in Sources */,
-				4A6C4E8713532FC300FDD53F /* ShipType.cpp in Sources */,
-				4A6C4E8813532FC300FDD53F /* Sound.cpp in Sources */,
-				4A6C4E8913532FC300FDD53F /* Space.cpp in Sources */,
-				4A6C4E8A13532FC300FDD53F /* SpaceStation.cpp in Sources */,
-				4A6C4E8B13532FC300FDD53F /* SpaceStationView.cpp in Sources */,
-				4A6C4E8C13532FC300FDD53F /* Star.cpp in Sources */,
-				4A6C4E8F13532FC300FDD53F /* SystemInfoView.cpp in Sources */,
-				4A6C4E9013532FC300FDD53F /* SystemView.cpp in Sources */,
-				4A6C4E9213532FC300FDD53F /* utils.cpp in Sources */,
-				4A6C4E9313532FC300FDD53F /* WorldView.cpp in Sources */,
-				4A9937511368355500EA0EE5 /* LuaBody.cpp in Sources */,
-				4A9937521368355500EA0EE5 /* LuaCargoBody.cpp in Sources */,
-				4A9937531368355500EA0EE5 /* LuaConstants.cpp in Sources */,
-				4A9937541368355500EA0EE5 /* LuaEngine.cpp in Sources */,
-				4A9937571368355500EA0EE5 /* LuaFormat.cpp in Sources */,
-				4A9937581368355500EA0EE5 /* LuaGame.cpp in Sources */,
-				4A9937591368355500EA0EE5 /* LuaManager.cpp in Sources */,
-				4A99375A1368355500EA0EE5 /* LuaNameGen.cpp in Sources */,
-				4A99375B1368355500EA0EE5 /* LuaObject.cpp in Sources */,
-				4A99375C1368355500EA0EE5 /* LuaPlanet.cpp in Sources */,
-				4A99375D1368355500EA0EE5 /* LuaPlayer.cpp in Sources */,
-				4A99375E1368355500EA0EE5 /* LuaRand.cpp in Sources */,
-				4A9937611368355500EA0EE5 /* LuaSerializer.cpp in Sources */,
-				4A9937621368355500EA0EE5 /* LuaShip.cpp in Sources */,
-				4A9937641368355500EA0EE5 /* LuaSpace.cpp in Sources */,
-				4A9937651368355500EA0EE5 /* LuaSpaceStation.cpp in Sources */,
-				4A9937661368355500EA0EE5 /* LuaStar.cpp in Sources */,
-				4A9937671368355500EA0EE5 /* LuaStarSystem.cpp in Sources */,
-				4A9937681368355500EA0EE5 /* LuaTimer.cpp in Sources */,
-				4A99376A1368355500EA0EE5 /* LuaUtils.cpp in Sources */,
-				4A62EF2C136979E000919EBB /* DeadVideoLink.cpp in Sources */,
-				4A62EF2D136979E000919EBB /* FaceVideoLink.cpp in Sources */,
-				4A82AA861386969B0028CCED /* GameConfig.cpp in Sources */,
-				4A19038C138AA33300E0229C /* Gui.cpp in Sources */,
-				4A19038E138AA33300E0229C /* GuiBox.cpp in Sources */,
-				4A190390138AA33300E0229C /* GuiButton.cpp in Sources */,
-				4A190392138AA33300E0229C /* GuiContainer.cpp in Sources */,
-				4A190394138AA33300E0229C /* GuiFixed.cpp in Sources */,
-				4A190396138AA33300E0229C /* GuiImage.cpp in Sources */,
-				4A190398138AA33300E0229C /* GuiImageButton.cpp in Sources */,
-				4A19039A138AA33300E0229C /* GuiImageRadioButton.cpp in Sources */,
-				4A19039C138AA33300E0229C /* GuiLabel.cpp in Sources */,
-				4A19039E138AA33300E0229C /* GuiLabelSet.cpp in Sources */,
-				4A1903A0138AA33300E0229C /* GuiMeterBar.cpp in Sources */,
-				4A1903A2138AA33300E0229C /* GuiMultiStateImageButton.cpp in Sources */,
-				4A1903A4138AA33300E0229C /* GuiRadioButton.cpp in Sources */,
-				4A1903A6138AA33300E0229C /* GuiRadioGroup.cpp in Sources */,
-				4A1903A8138AA33300E0229C /* GuiRepeaterButton.cpp in Sources */,
-				4A1903AA138AA33300E0229C /* GuiScreen.cpp in Sources */,
-				4A1903AC138AA33300E0229C /* GuiTabbed.cpp in Sources */,
-				4A1903AE138AA33300E0229C /* GuiTextEntry.cpp in Sources */,
-				4A1903B0138AA33300E0229C /* GuiTextLayout.cpp in Sources */,
-				4A1903B2138AA33300E0229C /* GuiToggleButton.cpp in Sources */,
-				4A1903B4138AA33300E0229C /* GuiToolTip.cpp in Sources */,
-				4A1903B6138AA33300E0229C /* GuiVScrollBar.cpp in Sources */,
-				4A1903B8138AA33300E0229C /* GuiVScrollPortal.cpp in Sources */,
-				4A1903BA138AA33300E0229C /* GuiWidget.cpp in Sources */,
-				4A1904A8138AA39C00E0229C /* lapi.c in Sources */,
-				4A1904AA138AA39C00E0229C /* lauxlib.c in Sources */,
-				4A1904AC138AA39C00E0229C /* lbaselib.c in Sources */,
-				4A1904AE138AA39C00E0229C /* lcode.c in Sources */,
-				4A1904B0138AA39C00E0229C /* ldblib.c in Sources */,
-				4A1904B2138AA39C00E0229C /* ldebug.c in Sources */,
-				4A1904B4138AA39C00E0229C /* ldo.c in Sources */,
-				4A1904B6138AA39C00E0229C /* ldump.c in Sources */,
-				4A1904B8138AA39C00E0229C /* lfunc.c in Sources */,
-				4A1904BA138AA39C00E0229C /* lgc.c in Sources */,
-				4A1904BD138AA39C00E0229C /* linit.c in Sources */,
-				4A1904BF138AA39C00E0229C /* liolib.c in Sources */,
-				4A1904C1138AA39C00E0229C /* llex.c in Sources */,
-				4A1904C3138AA39C00E0229C /* lmathlib.c in Sources */,
-				4A1904C5138AA39C00E0229C /* lmem.c in Sources */,
-				4A1904C7138AA39C00E0229C /* loadlib.c in Sources */,
-				4A1904C9138AA39C00E0229C /* lobject.c in Sources */,
-				4A1904CB138AA39C00E0229C /* lopcodes.c in Sources */,
-				4A1904CD138AA39C00E0229C /* loslib.c in Sources */,
-				4A1904CF138AA39C00E0229C /* lparser.c in Sources */,
-				4A1904D1138AA39C00E0229C /* lstate.c in Sources */,
-				4A1904D3138AA39C00E0229C /* lstring.c in Sources */,
-				4A1904D5138AA39C00E0229C /* lstrlib.c in Sources */,
-				4A1904D7138AA39C00E0229C /* ltable.c in Sources */,
-				4A1904D9138AA39C00E0229C /* ltablib.c in Sources */,
-				4A1904DB138AA39C00E0229C /* ltm.c in Sources */,
-				4A1904DF138AA39C00E0229C /* lundump.c in Sources */,
-				4A1904E1138AA39C00E0229C /* lvm.c in Sources */,
-				4A1904E3138AA39C00E0229C /* lzio.c in Sources */,
-				4A61E15E13978F1000193E43 /* Background.cpp in Sources */,
-				4A85A86A13C4631D00C2B986 /* LuaMusic.cpp in Sources */,
-				4A85A86B13C4631D00C2B986 /* LuaSystemPath.cpp in Sources */,
-				4A85A86C13C4631D00C2B986 /* SoundMusic.cpp in Sources */,
-				4A24077213F5240F002A5C12 /* ChatForm.cpp in Sources */,
-				4A24077313F5240F002A5C12 /* FormController.cpp in Sources */,
-				4A24077413F5240F002A5C12 /* Lang.cpp in Sources */,
-				4A24077513F5240F002A5C12 /* ShipSpinnerWidget.cpp in Sources */,
-				4A24077613F5240F002A5C12 /* StationAdvertForm.cpp in Sources */,
-				4A24077713F5240F002A5C12 /* StationBulletinBoardForm.cpp in Sources */,
-				4A24077813F5240F002A5C12 /* StationCommodityMarketForm.cpp in Sources */,
-				4A24077913F5240F002A5C12 /* StationPoliceForm.cpp in Sources */,
-				4A24077A13F5240F002A5C12 /* StationServicesForm.cpp in Sources */,
-				4A24077B13F5240F002A5C12 /* StationShipEquipmentForm.cpp in Sources */,
-				4A24077C13F5240F002A5C12 /* StationShipMarketForm.cpp in Sources */,
-				4A24077D13F5240F002A5C12 /* StationShipRepairForm.cpp in Sources */,
-				4A24077E13F5240F002A5C12 /* StationShipViewForm.cpp in Sources */,
-				4A24077F13F5240F002A5C12 /* StationShipyardForm.cpp in Sources */,
-				4A24078413F524E6002A5C12 /* GuiGradient.cpp in Sources */,
-				4A24078513F524E6002A5C12 /* GuiStack.cpp in Sources */,
-				4A6B59CC1429F14500ADC7C8 /* StringF.cpp in Sources */,
-				4A8DD53B142E19B6006DD821 /* LuaConsole.cpp in Sources */,
-				4AB3DF8914346952001B783A /* TerrainBody.cpp in Sources */,
-				4AE9706714369D7500424F91 /* LuaLang.cpp in Sources */,
-				4A84CB7D14595D850051C848 /* enum_table.cpp in Sources */,
-				4A84CB84146027DC0051C848 /* Camera.cpp in Sources */,
-				4AB7D6031472A83E00158DE4 /* Terrain.cpp in Sources */,
-				4AB7D6041472A83E00158DE4 /* TerrainColorAsteroid.cpp in Sources */,
-				4AB7D6051472A83E00158DE4 /* TerrainColorBandedRock.cpp in Sources */,
-				4AB7D6061472A83E00158DE4 /* TerrainColorDeadWithWater.cpp in Sources */,
-				4AB7D6071472A83E00158DE4 /* TerrainColorDesert.cpp in Sources */,
-				4AB7D6081472A83E00158DE4 /* TerrainColorEarthLike.cpp in Sources */,
-				4AB7D6091472A83E00158DE4 /* TerrainColorGGJupiter.cpp in Sources */,
-				4AB7D60A1472A83E00158DE4 /* TerrainColorGGNeptune.cpp in Sources */,
-				4AB7D60B1472A83E00158DE4 /* TerrainColorGGNeptune2.cpp in Sources */,
-				4AB7D60C1472A83E00158DE4 /* TerrainColorGGSaturn.cpp in Sources */,
-				4AB7D60D1472A83E00158DE4 /* TerrainColorGGSaturn2.cpp in Sources */,
-				4AB7D60E1472A83E00158DE4 /* TerrainColorGGUranus.cpp in Sources */,
-				4AB7D60F1472A83E00158DE4 /* TerrainColorIce.cpp in Sources */,
-				4AB7D6101472A83E00158DE4 /* TerrainColorMethane.cpp in Sources */,
-				4AB7D6111472A83E00158DE4 /* TerrainColorRock.cpp in Sources */,
-				4AB7D6121472A83E00158DE4 /* TerrainColorRock2.cpp in Sources */,
-				4AB7D6131472A83E00158DE4 /* TerrainColorSolid.cpp in Sources */,
-				4AB7D6141472A83E00158DE4 /* TerrainColorStarBrownDwarf.cpp in Sources */,
-				4AB7D6151472A83E00158DE4 /* TerrainColorStarG.cpp in Sources */,
-				4AB7D6161472A83E00158DE4 /* TerrainColorStarK.cpp in Sources */,
-				4AB7D6171472A83E00158DE4 /* TerrainColorStarM.cpp in Sources */,
-				4AB7D6181472A83E00158DE4 /* TerrainColorStarWhiteDwarf.cpp in Sources */,
-				4AB7D6191472A83E00158DE4 /* TerrainColorTFGood.cpp in Sources */,
-				4AB7D61A1472A83E00158DE4 /* TerrainColorTFPoor.cpp in Sources */,
-				4AB7D61B1472A83E00158DE4 /* TerrainColorVolcanic.cpp in Sources */,
-				4AB7D61C1472A83E00158DE4 /* TerrainFeature.cpp in Sources */,
-				4AB7D61D1472A83E00158DE4 /* TerrainHeightAsteroid.cpp in Sources */,
-				4AB7D61E1472A83E00158DE4 /* TerrainHeightFlat.cpp in Sources */,
-				4AB7D61F1472A83E00158DE4 /* TerrainHeightHillsCraters.cpp in Sources */,
-				4AB7D6201472A83E00158DE4 /* TerrainHeightHillsCraters2.cpp in Sources */,
-				4AB7D6211472A83E00158DE4 /* TerrainHeightHillsDunes.cpp in Sources */,
-				4AB7D6221472A83E00158DE4 /* TerrainHeightHillsNormal.cpp in Sources */,
-				4AB7D6231472A83E00158DE4 /* TerrainHeightHillsRidged.cpp in Sources */,
-				4AB7D6241472A83E00158DE4 /* TerrainHeightHillsRivers.cpp in Sources */,
-				4AB7D6251472A83E00158DE4 /* TerrainHeightMapped.cpp in Sources */,
-				4AB7D6261472A83E00158DE4 /* TerrainHeightMountainsCraters.cpp in Sources */,
-				4AB7D6271472A83E00158DE4 /* TerrainHeightMountainsCraters2.cpp in Sources */,
-				4AB7D6281472A83E00158DE4 /* TerrainHeightMountainsNormal.cpp in Sources */,
-				4AB7D6291472A83E00158DE4 /* TerrainHeightMountainsRidged.cpp in Sources */,
-				4AB7D62A1472A83E00158DE4 /* TerrainHeightMountainsRivers.cpp in Sources */,
-				4AB7D62B1472A83E00158DE4 /* TerrainHeightMountainsRiversVolcano.cpp in Sources */,
-				4AB7D62C1472A83E00158DE4 /* TerrainHeightMountainsVolcano.cpp in Sources */,
-				4AB7D62D1472A83E00158DE4 /* TerrainHeightRuggedDesert.cpp in Sources */,
-				4AB7D62E1472A83E00158DE4 /* TerrainHeightRuggedLava.cpp in Sources */,
-				4AB7D62F1472A83E00158DE4 /* TerrainHeightWaterSolid.cpp in Sources */,
-				4AB7D6301472A83E00158DE4 /* TerrainHeightWaterSolidCanyons.cpp in Sources */,
-				4AF999A31496D51F009821AF /* FileSelectorWidget.cpp in Sources */,
-				4AF999A41496D51F009821AF /* Game.cpp in Sources */,
-				4AF999A61496D51F009821AF /* MathUtil.cpp in Sources */,
-				4AED721D14E1501D004D171E /* TerrainHeightMapped2.cpp in Sources */,
-				4A94CA4514F26875002CA792 /* FontCache.cpp in Sources */,
-				4A4F25D214F524D400FD14A6 /* Drawables.cpp in Sources */,
-				4A4F25D314F524D400FD14A6 /* Frustum.cpp in Sources */,
-				4A4F25D414F524D400FD14A6 /* Graphics.cpp in Sources */,
-				4A4F25D614F524D400FD14A6 /* Material.cpp in Sources */,
-				4A4F25D714F524D400FD14A6 /* Renderer.cpp in Sources */,
-				4A4F25D814F524D400FD14A6 /* RendererGL2.cpp in Sources */,
-				4A4F25D914F524D400FD14A6 /* RendererLegacy.cpp in Sources */,
-				4A4F25DC14F524D400FD14A6 /* StaticMesh.cpp in Sources */,
-				4A4F25DD14F524D400FD14A6 /* VertexArray.cpp in Sources */,
-				4A305FD1151341170076D414 /* FileSystem.cpp in Sources */,
-				4A9174F415187B69006A15A9 /* GuiTexturedQuad.cpp in Sources */,
-				4A9174FB15187B97006A15A9 /* TextureBuilder.cpp in Sources */,
-				4A9174FC15187B97006A15A9 /* TextureGL.cpp in Sources */,
-				4A9174FE15187C17006A15A9 /* Color.cpp in Sources */,
-				4A107C2F1525AB0D00EF9FAC /* CRC32.cpp in Sources */,
-				4A107C301525AB0D00EF9FAC /* ShipController.cpp in Sources */,
-				4ADC7B82152C703200E359B5 /* SDLWrappers.cpp in Sources */,
-				4ADC7B83152C703200E359B5 /* View.cpp in Sources */,
-				4ACC6D1C15401E7000C59914 /* Font.cpp in Sources */,
-				4ACC6D1E15401E7000C59914 /* TextSupport.cpp in Sources */,
-				4ACC6D1F15401E7000C59914 /* TextureFont.cpp in Sources */,
-				4AAC9FE215458FE400116131 /* miniz.c in Sources */,
-				4AAC9FE91545901D00116131 /* FileSourceZip.cpp in Sources */,
-				4AAC9FEA1545901D00116131 /* ModManager.cpp in Sources */,
-				4ADF518A1557473400ACF5A0 /* CustomSystem.cpp in Sources */,
-				4ADF518B1557473400ACF5A0 /* Galaxy.cpp in Sources */,
-				4ADF518D1557473400ACF5A0 /* Sector.cpp in Sources */,
-				4ADF518E1557473400ACF5A0 /* StarSystem.cpp in Sources */,
-				4ADF51971557477400ACF5A0 /* LuaFixed.cpp in Sources */,
-				4ADF51981557477400ACF5A0 /* LuaMatrix.cpp in Sources */,
-				4ADF51991557477400ACF5A0 /* LuaSystemBody.cpp in Sources */,
-				4ADF519A1557477400ACF5A0 /* LuaVector.cpp in Sources */,
-				4A59B4DA1557EAF5009926E5 /* lbitlib.c in Sources */,
-				4A59B4DB1557EAF5009926E5 /* lcorolib.c in Sources */,
-				4A59B4DC1557EAF5009926E5 /* lctype.c in Sources */,
-				4A3AE8E5158FD22200EB13DE /* LuaComms.cpp in Sources */,
-				4A01889715A59908002F540B /* SystemPath.cpp in Sources */,
-				4A37073615A879D100E7E5F6 /* lookup3.c in Sources */,
-				4ADB0D0C15C50DD900AE2123 /* TerrainHeightAsteroid2.cpp in Sources */,
-				4ADB0D0D15C50DD900AE2123 /* TerrainHeightAsteroid3.cpp in Sources */,
-				4ADB0D0E15C50DD900AE2123 /* TerrainHeightAsteroid4.cpp in Sources */,
-				4ADB0D0F15C50DD900AE2123 /* TerrainHeightBarrenRock.cpp in Sources */,
-				4ADB0D1015C50DD900AE2123 /* TerrainHeightBarrenRock2.cpp in Sources */,
-				4ADB0D1115C50DD900AE2123 /* TerrainHeightBarrenRock3.cpp in Sources */,
-				4ADB0D1615C50DF000AE2123 /* FileSystemPosix.cpp in Sources */,
-				4ADB0D1815C50DF000AE2123 /* OSPosix.cpp in Sources */,
-				4AEC8A1A15C7886A00B281C3 /* Light.cpp in Sources */,
-				4AF0058B15F0F30400CC19C0 /* LuaEvent.cpp in Sources */,
-				4AF0059315F17C6700CC19C0 /* LuaFileSystem.cpp in Sources */,
-				4AAB881315F4AD3500AAF8A8 /* GeoSphereMaterial.cpp in Sources */,
-				4AAB881415F4AD3500AAF8A8 /* GL2Material.cpp in Sources */,
-				4AAB881515F4AD3500AAF8A8 /* MultiMaterial.cpp in Sources */,
-				4AAB881615F4AD3500AAF8A8 /* Program.cpp in Sources */,
-				4AAB881715F4AD3500AAF8A8 /* RingMaterial.cpp in Sources */,
-				4AAB881815F4AD3500AAF8A8 /* Uniform.cpp in Sources */,
-				4AAB881915F4AD3500AAF8A8 /* MaterialLegacy.cpp in Sources */,
-				4AAB881D15F4AD7700AAF8A8 /* Lua.cpp in Sources */,
-				4AAB884815FDEA6F00AAF8A8 /* LuaRef.cpp in Sources */,
-				4A973BF71618688F0029562D /* DeathView.cpp in Sources */,
-				4A973BF81618688F0029562D /* LuaDev.cpp in Sources */,
-				4AF222E7162103EA00BED38E /* Factions.cpp in Sources */,
-				4AF222E8162103EA00BED38E /* Intro.cpp in Sources */,
-				4AF222E9162103EA00BED38E /* Tombstone.cpp in Sources */,
-				4ABF307916335A1100664653 /* Align.cpp in Sources */,
-				4ABF307A16335A1100664653 /* Background.cpp in Sources */,
-				4ABF307B16335A1100664653 /* Box.cpp in Sources */,
-				4ABF307C16335A1100664653 /* Button.cpp in Sources */,
-				4ABF307D16335A1100664653 /* CellSpec.cpp in Sources */,
-				4ABF307E16335A1100664653 /* CheckBox.cpp in Sources */,
-				4ABF307F16335A1100664653 /* ColorBackground.cpp in Sources */,
-				4ABF308016335A1100664653 /* Container.cpp in Sources */,
-				4ABF308116335A1100664653 /* Context.cpp in Sources */,
-				4ABF308216335A1100664653 /* DropDown.cpp in Sources */,
-				4ABF308316335A1100664653 /* Event.cpp in Sources */,
-				4ABF308416335A1100664653 /* EventDispatcher.cpp in Sources */,
-				4ABF308516335A1100664653 /* FloatContainer.cpp in Sources */,
-				4ABF308616335A1100664653 /* Grid.cpp in Sources */,
-				4ABF308716335A1100664653 /* Image.cpp in Sources */,
-				4ABF308816335A1100664653 /* Label.cpp in Sources */,
-				4ABF308916335A1100664653 /* List.cpp in Sources */,
-				4ABF308A16335A1100664653 /* Lua.cpp in Sources */,
-				4ABF308B16335A1100664653 /* LuaAlign.cpp in Sources */,
-				4ABF308C16335A1100664653 /* LuaBackground.cpp in Sources */,
-				4ABF308D16335A1100664653 /* LuaBox.cpp in Sources */,
-				4ABF308E16335A1100664653 /* LuaButton.cpp in Sources */,
-				4ABF308F16335A1100664653 /* LuaCheckBox.cpp in Sources */,
-				4ABF309016335A1100664653 /* LuaColorBackground.cpp in Sources */,
-				4ABF309116335A1100664653 /* LuaContainer.cpp in Sources */,
-				4ABF309216335A1100664653 /* LuaContext.cpp in Sources */,
-				4ABF309316335A1100664653 /* LuaDropDown.cpp in Sources */,
-				4ABF309416335A1100664653 /* LuaGrid.cpp in Sources */,
-				4ABF309516335A1100664653 /* LuaImage.cpp in Sources */,
-				4ABF309616335A1100664653 /* LuaLabel.cpp in Sources */,
-				4ABF309716335A1100664653 /* LuaList.cpp in Sources */,
-				4ABF309816335A1100664653 /* LuaMargin.cpp in Sources */,
-				4ABF309916335A1100664653 /* LuaMultiLineText.cpp in Sources */,
-				4ABF309A16335A1100664653 /* LuaScroller.cpp in Sources */,
-				4ABF309B16335A1100664653 /* LuaSingle.cpp in Sources */,
-				4ABF309C16335A1100664653 /* LuaSlider.cpp in Sources */,
-				4ABF309D16335A1100664653 /* LuaWidget.cpp in Sources */,
-				4ABF309F16335A1100664653 /* Margin.cpp in Sources */,
-				4ABF30A016335A1100664653 /* MultiLineText.cpp in Sources */,
-				4ABF30A116335A1100664653 /* Scroller.cpp in Sources */,
-				4ABF30A216335A1100664653 /* Single.cpp in Sources */,
-				4ABF30A316335A1100664653 /* Skin.cpp in Sources */,
-				4ABF30A416335A1100664653 /* Slider.cpp in Sources */,
-				4ABF30A516335A1100664653 /* TextLayout.cpp in Sources */,
-				4ABF30A616335A1100664653 /* Widget.cpp in Sources */,
-				4A239FCB163E78D60037BE24 /* LuaFaction.cpp in Sources */,
-				4AFBD7B91641265D002928CB /* PngWriter.cpp in Sources */,
-				4AFBD7BD16412676002928CB /* LuaTextEntry.cpp in Sources */,
-				4AFBD7BE16412676002928CB /* TextEntry.cpp in Sources */,
-				4AFBD7C016412688002928CB /* FontDescriptor.cpp in Sources */,
-				4AA4A8DA164D0EB10006C3BF /* Expand.cpp in Sources */,
-				4AA4A8DB164D0EB10006C3BF /* Gradient.cpp in Sources */,
-				4AA4A8DC164D0EB10006C3BF /* LuaExpand.cpp in Sources */,
-				4AA4A8DD164D0EB10006C3BF /* LuaGradient.cpp in Sources */,
-				4A24FD5E1650F4B700DE7B0F /* UIView.cpp in Sources */,
-				4A24FD671650F4D100DE7B0F /* Lua.cpp in Sources */,
-				4A24FD691650F4D100DE7B0F /* Panel.cpp in Sources */,
-				4A0F25CE165CF00D00208507 /* LuaSmallButton.cpp in Sources */,
-				4A0F25CF165CF00D00208507 /* SmallButton.cpp in Sources */,
-				4A4D25D8167335D9003BC9D5 /* Face.cpp in Sources */,
-				4A4D25D9167335D9003BC9D5 /* LuaFace.cpp in Sources */,
-				4A4D25DF167335F5003BC9D5 /* Icon.cpp in Sources */,
-				4A4D25E0167335F5003BC9D5 /* LuaIcon.cpp in Sources */,
-				4ACDB6B1167878620069FA03 /* Animation.cpp in Sources */,
-				4ACDB6B2167878620069FA03 /* Billboard.cpp in Sources */,
-				4ACDB6B3167878620069FA03 /* CollisionGeometry.cpp in Sources */,
-				4ACDB6B4167878620069FA03 /* CollisionVisitor.cpp in Sources */,
-				4ACDB6B5167878620069FA03 /* ColorMap.cpp in Sources */,
-				4ACDB6B6167878620069FA03 /* DumpVisitor.cpp in Sources */,
-				4ACDB6B7167878620069FA03 /* FindNodeVisitor.cpp in Sources */,
-				4ACDB6B8167878620069FA03 /* Group.cpp in Sources */,
-				4ACDB6B9167878620069FA03 /* Label3D.cpp in Sources */,
-				4ACDB6BA167878620069FA03 /* Loader.cpp in Sources */,
-				4ACDB6BB167878620069FA03 /* LOD.cpp in Sources */,
-				4ACDB6BD167878620069FA03 /* MatrixTransform.cpp in Sources */,
-				4ACDB6BE167878620069FA03 /* Model.cpp in Sources */,
-				4ACDB6BF167878620069FA03 /* ModelNode.cpp in Sources */,
-				4ACDB6C0167878620069FA03 /* Node.cpp in Sources */,
-				4ACDB6C1167878620069FA03 /* NodeVisitor.cpp in Sources */,
-				4ACDB6C2167878620069FA03 /* Parser.cpp in Sources */,
-				4ACDB6C3167878620069FA03 /* Pattern.cpp in Sources */,
-				4ACDB6C4167878620069FA03 /* StaticGeometry.cpp in Sources */,
-				4ACDB6C5167878620069FA03 /* Thruster.cpp in Sources */,
-				4ACDB6CE167878CE0069FA03 /* ModelCache.cpp in Sources */,
-				4ACDB6CF167878CE0069FA03 /* ModelViewer.cpp in Sources */,
-				4ACDB6D2167879AF0069FA03 /* DistanceFieldFont.cpp in Sources */,
-				4AEE56DD16A44CD800AA1C53 /* SpaceStationType.cpp in Sources */,
-				4A4A86E916A992D600F81F18 /* CameraController.cpp in Sources */,
-				4ACE132F16B4B19D00CAE524 /* EnumStrings.cpp in Sources */,
-				4ACED56A16BBCC7200E53808 /* LuaMissile.cpp in Sources */,
-				4AA84A2716D0E18700220311 /* LuaEquipDef.cpp in Sources */,
-				4AA84A2816D0E18700220311 /* LuaShipDef.cpp in Sources */,
-				4AA527FA16E9EABA0036D4CB /* NavLights.cpp in Sources */,
-				4AA527FE16E9EB650036D4CB /* LuaModelSpinner.cpp in Sources */,
-				4AA527FF16E9EB650036D4CB /* ModelSpinner.cpp in Sources */,
-				4AA5280516E9EB980036D4CB /* Lua.cpp in Sources */,
-				4AA5280616E9EB980036D4CB /* ModelSkin.cpp in Sources */,
-				4AA5280816E9EBD60036D4CB /* LuaModelSkin.cpp in Sources */,
-				4A712413170EC89000BB9BCC /* Orbit.cpp in Sources */,
-				4A8AE19617208CE50005C2D9 /* LuaPropertiedObject.cpp in Sources */,
-				4A8AE19717208CE50005C2D9 /* PropertyMap.cpp in Sources */,
-				4AA9F6CC17288E0900124C2E /* TerrainHeightEllipsoid.cpp in Sources */,
+				521EDBF91C00D3A20092B2E9 /* LuaImage.cpp in Sources */,
+				521ED9291C00D14E0092B2E9 /* LuaModelBody.cpp in Sources */,
+				521ED8F61C00D14E0092B2E9 /* CargoBody.cpp in Sources */,
+				521ED93F1C00D14E0092B2E9 /* main.cpp in Sources */,
+				521EDB501C00D37B0092B2E9 /* TerrainHeightMapped2.cpp in Sources */,
+				52D126781C03538F00E6E4C2 /* lzio.c in Sources */,
+				521EDBEC1C00D3A20092B2E9 /* LuaBackground.cpp in Sources */,
+				521ED9331C00D14E0092B2E9 /* LuaServerAgent.cpp in Sources */,
+				521EDB441C00D37B0092B2E9 /* TerrainHeightBarrenRock.cpp in Sources */,
+				521ED95F1C00D14E0092B2E9 /* ShipCpanel.cpp in Sources */,
+				521ED94D1C00D14E0092B2E9 /* Planet.cpp in Sources */,
+				521EDB691C00D38B0092B2E9 /* TextureFont.cpp in Sources */,
+				521ED9041C00D14E0092B2E9 /* FontCache.cpp in Sources */,
+				521ED8F11C00D14E0092B2E9 /* Background.cpp in Sources */,
+				521EDA211C00D3430092B2E9 /* RendererDummy.cpp in Sources */,
+				521EDB371C00D37B0092B2E9 /* TerrainColorStarBrownDwarf.cpp in Sources */,
+				521ED9B61C00D3240092B2E9 /* StarSystemGenerator.cpp in Sources */,
+				521ED9221C00D14E0092B2E9 /* LuaFixed.cpp in Sources */,
+				521ED94E1C00D14E0092B2E9 /* Player.cpp in Sources */,
+				521ED91F1C00D14E0092B2E9 /* LuaEvent.cpp in Sources */,
+				521EDA3D1C00D3430092B2E9 /* VertexArray.cpp in Sources */,
+				521EDA241C00D3430092B2E9 /* GeoSphereMaterial.cpp in Sources */,
+				52D126701C03538F00E6E4C2 /* lstrlib.c in Sources */,
+				521ED9CF1C00D3310092B2E9 /* Panel.cpp in Sources */,
+				521ED9621C00D14E0092B2E9 /* Sound.cpp in Sources */,
+				521EDB561C00D37B0092B2E9 /* TerrainHeightMountainsRiversVolcano.cpp in Sources */,
+				521ED8F21C00D14E0092B2E9 /* BaseSphere.cpp in Sources */,
+				521EDB671C00D38B0092B2E9 /* FontConfig.cpp in Sources */,
+				521ED9571C00D14E0092B2E9 /* ServerAgent.cpp in Sources */,
+				521ED9061C00D14E0092B2E9 /* GalacticView.cpp in Sources */,
+				521ED9131C00D14E0092B2E9 /* Intro.cpp in Sources */,
+				521EDBF31C00D3A20092B2E9 /* LuaDropDown.cpp in Sources */,
+				521EDAD21C00D36D0092B2E9 /* BinaryConverter.cpp in Sources */,
+				521ED91A1C00D14E0092B2E9 /* LuaComms.cpp in Sources */,
+				521ED9451C00D14E0092B2E9 /* ModelViewer.cpp in Sources */,
+				521EDBDD1C00D3A20092B2E9 /* DropDown.cpp in Sources */,
+				521ED8FC1C00D14E0092B2E9 /* DeathView.cpp in Sources */,
+				521EDBE81C00D3A20092B2E9 /* List.cpp in Sources */,
+				521EDA3F1C00D3430092B2E9 /* WindowSDL.cpp in Sources */,
+				521EDA2B1C00D3430092B2E9 /* RendererGL.cpp in Sources */,
+				521ED8F71C00D14E0092B2E9 /* CityOnPlanet.cpp in Sources */,
+				521EDBF61C00D3A20092B2E9 /* LuaGradient.cpp in Sources */,
+				521EDB3D1C00D37B0092B2E9 /* TerrainColorTFPoor.cpp in Sources */,
+				521EDC041C00D3A20092B2E9 /* LuaTable.cpp in Sources */,
+				52D126661C03538F00E6E4C2 /* llex.c in Sources */,
+				521EDBFE1C00D3A20092B2E9 /* LuaMultiLineText.cpp in Sources */,
+				521EDA801C00D3550092B2E9 /* GuiLabelSet.cpp in Sources */,
+				521EDBFF1C00D3A20092B2E9 /* LuaNumberLabel.cpp in Sources */,
+				521EDB401C00D37B0092B2E9 /* TerrainHeightAsteroid.cpp in Sources */,
+				52D126641C03538F00E6E4C2 /* linit.c in Sources */,
+				521ED92A1C00D14E0092B2E9 /* LuaMusic.cpp in Sources */,
+				521ED93D1C00D14E0092B2E9 /* LuaUtils.cpp in Sources */,
+				52D1266E1C03538F00E6E4C2 /* lstate.c in Sources */,
+				521EDB411C00D37B0092B2E9 /* TerrainHeightAsteroid2.cpp in Sources */,
+				521EDBD51C00D3A20092B2E9 /* Background.cpp in Sources */,
+				521EDB5A1C00D37B0092B2E9 /* TerrainHeightWaterSolid.cpp in Sources */,
+				521ED9AF1C00D3240092B2E9 /* Economy.cpp in Sources */,
+				521EDB3E1C00D37B0092B2E9 /* TerrainColorVolcanic.cpp in Sources */,
+				521EDB451C00D37B0092B2E9 /* TerrainHeightBarrenRock2.cpp in Sources */,
+				521EDC051C00D3A20092B2E9 /* LuaTextEntry.cpp in Sources */,
+				521EDA8E1C00D3550092B2E9 /* GuiVScrollPortal.cpp in Sources */,
+				521ED9671C00D14E0092B2E9 /* SpeedLines.cpp in Sources */,
+				521EDBE41C00D3A20092B2E9 /* Icon.cpp in Sources */,
+				521EDA2A1C00D3430092B2E9 /* Program.cpp in Sources */,
+				521ED92E1C00D14E0092B2E9 /* LuaPlayer.cpp in Sources */,
+				521EDB331C00D37B0092B2E9 /* TerrainColorMethane.cpp in Sources */,
+				521ED9691C00D14E0092B2E9 /* Star.cpp in Sources */,
+				521EDC001C00D3A20092B2E9 /* LuaScroller.cpp in Sources */,
+				521ED9611C00D14E0092B2E9 /* ShipType.cpp in Sources */,
+				521ED9941C00D2ED0092B2E9 /* Geom.cpp in Sources */,
+				52D126571C03538F00E6E4C2 /* lapi.c in Sources */,
+				521EDB251C00D37B0092B2E9 /* Terrain.cpp in Sources */,
+				521EDC111C00D3A20092B2E9 /* TextLayout.cpp in Sources */,
+				521ED90A1C00D14E0092B2E9 /* GasGiant.cpp in Sources */,
+				521EDC0F1C00D3A20092B2E9 /* Table.cpp in Sources */,
+				521ED9001C00D14E0092B2E9 /* FaceParts.cpp in Sources */,
+				521EDB591C00D37B0092B2E9 /* TerrainHeightRuggedLava.cpp in Sources */,
+				521EDB421C00D37B0092B2E9 /* TerrainHeightAsteroid3.cpp in Sources */,
+				521ED9501C00D14E0092B2E9 /* Polit.cpp in Sources */,
+				521EDB311C00D37B0092B2E9 /* TerrainColorGGUranus.cpp in Sources */,
+				521ED9281C00D14E0092B2E9 /* LuaMissile.cpp in Sources */,
+				52D1265F1C03538F00E6E4C2 /* ldebug.c in Sources */,
+				521EDC011C00D3A20092B2E9 /* LuaSingle.cpp in Sources */,
+				521EDC061C00D3A20092B2E9 /* LuaWidget.cpp in Sources */,
+				521ED9311C00D14E0092B2E9 /* LuaRef.cpp in Sources */,
+				521EDA261C00D3430092B2E9 /* LineMaterial.cpp in Sources */,
+				521ED9B71C00D3240092B2E9 /* SystemPath.cpp in Sources */,
+				521ED9471C00D14E0092B2E9 /* NavLights.cpp in Sources */,
+				521ED95E1C00D14E0092B2E9 /* ShipController.cpp in Sources */,
+				521ED92F1C00D14E0092B2E9 /* LuaPropertiedObject.cpp in Sources */,
+				521ED9641C00D14E0092B2E9 /* Space.cpp in Sources */,
+				521EDB281C00D37B0092B2E9 /* TerrainColorDeadWithWater.cpp in Sources */,
+				521ED9631C00D14E0092B2E9 /* SoundMusic.cpp in Sources */,
+				521EDA8F1C00D3550092B2E9 /* GuiWidget.cpp in Sources */,
+				521EDACF1C00D36D0092B2E9 /* Animation.cpp in Sources */,
+				521EDA351C00D3430092B2E9 /* Drawables.cpp in Sources */,
+				521EDA841C00D3550092B2E9 /* GuiRadioGroup.cpp in Sources */,
+				521EDADA1C00D36D0092B2E9 /* Loader.cpp in Sources */,
+				521EDC0C1C00D3A20092B2E9 /* Skin.cpp in Sources */,
+				521ED9151C00D14E0092B2E9 /* KeyBindings.cpp in Sources */,
+				521EDAD71C00D36D0092B2E9 /* FindNodeVisitor.cpp in Sources */,
+				521EDB2E1C00D37B0092B2E9 /* TerrainColorGGNeptune2.cpp in Sources */,
+				52D1266F1C03538F00E6E4C2 /* lstring.c in Sources */,
+				521ED9481C00D14E0092B2E9 /* ObjectViewerView.cpp in Sources */,
+				521ED9201C00D14E0092B2E9 /* LuaFaction.cpp in Sources */,
+				521EDA781C00D3550092B2E9 /* GuiBox.cpp in Sources */,
+				521EDBEF1C00D3A20092B2E9 /* LuaCheckBox.cpp in Sources */,
+				521ED9661C00D14E0092B2E9 /* SpaceStationType.cpp in Sources */,
+				521ED8F81C00D14E0092B2E9 /* CollMesh.cpp in Sources */,
+				521ED9211C00D14E0092B2E9 /* LuaFileSystem.cpp in Sources */,
+				521EDB481C00D37B0092B2E9 /* TerrainHeightFlat.cpp in Sources */,
+				521ED9491C00D14E0092B2E9 /* Orbit.cpp in Sources */,
+				52D1266C1C03538F00E6E4C2 /* loslib.c in Sources */,
+				521ED90B1C00D14E0092B2E9 /* GeoPatch.cpp in Sources */,
+				521ED9B21C00D3240092B2E9 /* GalaxyGenerator.cpp in Sources */,
+				521EDADB1C00D36D0092B2E9 /* LOD.cpp in Sources */,
+				521EDA2E1C00D3430092B2E9 /* RingMaterial.cpp in Sources */,
+				521EDA3B1C00D3430092B2E9 /* Stats.cpp in Sources */,
+				521ED9CB1C00D3310092B2E9 /* LuaBindingCapture.cpp in Sources */,
+				521EDB3A1C00D37B0092B2E9 /* TerrainColorStarM.cpp in Sources */,
+				521EDA8B1C00D3550092B2E9 /* GuiToggleButton.cpp in Sources */,
+				521ED9411C00D14E0092B2E9 /* Missile.cpp in Sources */,
+				521EDB2C1C00D37B0092B2E9 /* TerrainColorGGJupiter.cpp in Sources */,
+				521ED9301C00D14E0092B2E9 /* LuaRand.cpp in Sources */,
+				521ED93C1C00D14E0092B2E9 /* LuaTimer.cpp in Sources */,
+				521EDC091C00D3A20092B2E9 /* NumberLabel.cpp in Sources */,
+				521ED9541C00D14E0092B2E9 /* SectorView.cpp in Sources */,
+				521ED9391C00D14E0092B2E9 /* LuaStarSystem.cpp in Sources */,
+				521EDB3B1C00D37B0092B2E9 /* TerrainColorStarWhiteDwarf.cpp in Sources */,
+				521EDB431C00D37B0092B2E9 /* TerrainHeightAsteroid4.cpp in Sources */,
+				521ED9381C00D14E0092B2E9 /* LuaStar.cpp in Sources */,
+				52D126591C03538F00E6E4C2 /* lbaselib.c in Sources */,
+				521EDA7A1C00D3550092B2E9 /* GuiContainer.cpp in Sources */,
+				521ED9461C00D14E0092B2E9 /* ModManager.cpp in Sources */,
+				521EDB551C00D37B0092B2E9 /* TerrainHeightMountainsRivers.cpp in Sources */,
+				521ED9071C00D14E0092B2E9 /* Game.cpp in Sources */,
+				521ED9921C00D2ED0092B2E9 /* BVHTree.cpp in Sources */,
+				521EDBF21C00D3A20092B2E9 /* LuaContext.cpp in Sources */,
+				521EDBEB1C00D3A20092B2E9 /* LuaAnimation.cpp in Sources */,
+				521EDBDB1C00D3A20092B2E9 /* Container.cpp in Sources */,
+				521EDA7F1C00D3550092B2E9 /* GuiLabel.cpp in Sources */,
+				521ED9431C00D14E0092B2E9 /* ModelCache.cpp in Sources */,
+				521EDAE21C00D36D0092B2E9 /* ModelSkin.cpp in Sources */,
+				521EDC0D1C00D3A20092B2E9 /* Slider.cpp in Sources */,
+				521EDB461C00D37B0092B2E9 /* TerrainHeightBarrenRock3.cpp in Sources */,
+				521EDB4F1C00D37B0092B2E9 /* TerrainHeightMapped.cpp in Sources */,
+				521EDC071C00D3A20092B2E9 /* Margin.cpp in Sources */,
+				52D126611C03538F00E6E4C2 /* ldump.c in Sources */,
+				521ED94C1C00D14E0092B2E9 /* Plane.cpp in Sources */,
+				521ED9101C00D14E0092B2E9 /* HudTrail.cpp in Sources */,
+				521EDB291C00D37B0092B2E9 /* TerrainColorDesert.cpp in Sources */,
+				521ED9581C00D14E0092B2E9 /* Sfx.cpp in Sources */,
+				521EDB681C00D38B0092B2E9 /* TextSupport.cpp in Sources */,
+				521ED9B41C00D3240092B2E9 /* SectorGenerator.cpp in Sources */,
+				52D126731C03538F00E6E4C2 /* ltm.c in Sources */,
+				521ED8F91C00D14E0092B2E9 /* Color.cpp in Sources */,
+				521ED9C81C00D3310092B2E9 /* BindingCapture.cpp in Sources */,
+				521EDA331C00D3430092B2E9 /* VertexBufferGL.cpp in Sources */,
+				521EDBE01C00D3A20092B2E9 /* Expand.cpp in Sources */,
+				521EDB4B1C00D37B0092B2E9 /* TerrainHeightHillsDunes.cpp in Sources */,
+				521EDAD01C00D36D0092B2E9 /* BaseLoader.cpp in Sources */,
+				521EDA861C00D3550092B2E9 /* GuiStack.cpp in Sources */,
+				52D126771C03538F00E6E4C2 /* lvm.c in Sources */,
+				521EDB2F1C00D37B0092B2E9 /* TerrainColorGGSaturn.cpp in Sources */,
+				521EDAD61C00D36D0092B2E9 /* DumpVisitor.cpp in Sources */,
+				521EDB4D1C00D37B0092B2E9 /* TerrainHeightHillsRidged.cpp in Sources */,
+				521EDBD31C00D3A20092B2E9 /* Align.cpp in Sources */,
+				521ED9141C00D14E0092B2E9 /* JobQueue.cpp in Sources */,
+				521EDAD51C00D36D0092B2E9 /* ColorMap.cpp in Sources */,
+				521EDA291C00D3430092B2E9 /* MultiMaterial.cpp in Sources */,
+				521ED9191C00D14E0092B2E9 /* LuaCargoBody.cpp in Sources */,
+				521ED93E1C00D14E0092B2E9 /* LuaVector.cpp in Sources */,
+				521ED9011C00D14E0092B2E9 /* Factions.cpp in Sources */,
+				521ED94F1C00D14E0092B2E9 /* PngWriter.cpp in Sources */,
+				521ED9951C00D2ED0092B2E9 /* GeomTree.cpp in Sources */,
+				521ED9681C00D14E0092B2E9 /* Sphere.cpp in Sources */,
+				521ED9231C00D14E0092B2E9 /* LuaFormat.cpp in Sources */,
+				521EDA361C00D3430092B2E9 /* Frustum.cpp in Sources */,
+				521EDADD1C00D36D0092B2E9 /* LuaModel.cpp in Sources */,
+				521EDB391C00D37B0092B2E9 /* TerrainColorStarK.cpp in Sources */,
+				521EDBDA1C00D3A20092B2E9 /* ColorBackground.cpp in Sources */,
+				521EDA7C1C00D3550092B2E9 /* GuiImage.cpp in Sources */,
+				521EDA3C1C00D3430092B2E9 /* TextureBuilder.cpp in Sources */,
+				521EDA381C00D3430092B2E9 /* Light.cpp in Sources */,
+				52D1265B1C03538F00E6E4C2 /* lcode.c in Sources */,
+				521ED91B1C00D14E0092B2E9 /* LuaConsole.cpp in Sources */,
+				521EDA3A1C00D3430092B2E9 /* Renderer.cpp in Sources */,
+				521EDA811C00D3550092B2E9 /* GuiMeterBar.cpp in Sources */,
+				521ED90D1C00D14E0092B2E9 /* GeoPatchID.cpp in Sources */,
+				521EDB4A1C00D37B0092B2E9 /* TerrainHeightHillsCraters2.cpp in Sources */,
+				521ED9161C00D14E0092B2E9 /* Lang.cpp in Sources */,
+				521EDB521C00D37B0092B2E9 /* TerrainHeightMountainsCraters2.cpp in Sources */,
+				521ED9171C00D14E0092B2E9 /* Lua.cpp in Sources */,
+				521EDA2F1C00D3430092B2E9 /* ShieldMaterial.cpp in Sources */,
+				521EDBE71C00D3A20092B2E9 /* Layer.cpp in Sources */,
+				521EDC101C00D3A20092B2E9 /* TextEntry.cpp in Sources */,
+				521ED95A1C00D14E0092B2E9 /* Ship-AI.cpp in Sources */,
+				521EDB361C00D37B0092B2E9 /* TerrainColorSolid.cpp in Sources */,
+				521EDB321C00D37B0092B2E9 /* TerrainColorIce.cpp in Sources */,
+				521EDAE71C00D36D0092B2E9 /* StaticGeometry.cpp in Sources */,
+				521ED9401C00D14E0092B2E9 /* MathUtil.cpp in Sources */,
+				521ED9C91C00D3310092B2E9 /* Face.cpp in Sources */,
+				521EDBE11C00D3A20092B2E9 /* Gauge.cpp in Sources */,
+				521ED90F1C00D14E0092B2E9 /* GeoSphere.cpp in Sources */,
+				521EDB471C00D37B0092B2E9 /* TerrainHeightEllipsoid.cpp in Sources */,
+				521EDB4C1C00D37B0092B2E9 /* TerrainHeightHillsNormal.cpp in Sources */,
+				521ED9591C00D14E0092B2E9 /* Shields.cpp in Sources */,
+				521EDA8D1C00D3550092B2E9 /* GuiVScrollBar.cpp in Sources */,
+				521EDBF11C00D3A20092B2E9 /* LuaContainer.cpp in Sources */,
+				52D126581C03538F00E6E4C2 /* lauxlib.c in Sources */,
+				521ED9791C00D14E0092B2E9 /* View.cpp in Sources */,
+				521EDA821C00D3550092B2E9 /* GuiMultiStateImageButton.cpp in Sources */,
+				521ED9181C00D14E0092B2E9 /* LuaBody.cpp in Sources */,
+				521ED9AE1C00D3240092B2E9 /* CustomSystem.cpp in Sources */,
+				521EDBFC1C00D3A20092B2E9 /* LuaList.cpp in Sources */,
+				521ED8FB1C00D14E0092B2E9 /* DateTime.cpp in Sources */,
+				521ED9B01C00D3240092B2E9 /* Galaxy.cpp in Sources */,
+				521EDBF41C00D3A20092B2E9 /* LuaExpand.cpp in Sources */,
+				521ED9B11C00D3240092B2E9 /* GalaxyCache.cpp in Sources */,
+				521EDA851C00D3550092B2E9 /* GuiScreen.cpp in Sources */,
+				521ED96C1C00D14E0092B2E9 /* SystemView.cpp in Sources */,
+				521ED9531C00D14E0092B2E9 /* SDLWrappers.cpp in Sources */,
+				521ED93B1C00D14E0092B2E9 /* LuaSystemPath.cpp in Sources */,
+				521ED9CA1C00D3310092B2E9 /* Lua.cpp in Sources */,
+				521ED9601C00D14E0092B2E9 /* ShipCpanelMultiFuncDisplays.cpp in Sources */,
+				521EDAD91C00D36D0092B2E9 /* Label3D.cpp in Sources */,
+				521EDA341C00D3430092B2E9 /* VtxColorMaterial.cpp in Sources */,
+				521EDBD71C00D3A20092B2E9 /* Button.cpp in Sources */,
+				521EDA941C00D3610092B2E9 /* FileSystemPosix.cpp in Sources */,
+				521ED92C1C00D14E0092B2E9 /* LuaObject.cpp in Sources */,
+				521EDB5B1C00D37B0092B2E9 /* TerrainHeightWaterSolidCanyons.cpp in Sources */,
+				521ED9B31C00D3240092B2E9 /* Sector.cpp in Sources */,
+				521EDB301C00D37B0092B2E9 /* TerrainColorGGSaturn2.cpp in Sources */,
+				521EDB271C00D37B0092B2E9 /* TerrainColorBandedRock.cpp in Sources */,
+				521EDC0A1C00D3A20092B2E9 /* Scroller.cpp in Sources */,
+				521ED9031C00D14E0092B2E9 /* FileSystem.cpp in Sources */,
+				521ED90C1C00D14E0092B2E9 /* GeoPatchContext.cpp in Sources */,
+				521ED9361C00D14E0092B2E9 /* LuaSpace.cpp in Sources */,
+				521ED94B1C00D14E0092B2E9 /* Pi.cpp in Sources */,
+				52D1265D1C03538F00E6E4C2 /* lctype.c in Sources */,
+				52D126651C03538F00E6E4C2 /* liolib.c in Sources */,
+				521EDA2C1C00D3430092B2E9 /* RenderStateGL.cpp in Sources */,
+				521EDA301C00D3430092B2E9 /* TextureGL.cpp in Sources */,
+				521EDAD81C00D36D0092B2E9 /* Group.cpp in Sources */,
+				521EDC0E1C00D3A20092B2E9 /* SmallButton.cpp in Sources */,
+				521EDAD41C00D36D0092B2E9 /* CollisionVisitor.cpp in Sources */,
+				521ED9321C00D14E0092B2E9 /* LuaSerializer.cpp in Sources */,
+				521EDBF71C00D3A20092B2E9 /* LuaGrid.cpp in Sources */,
+				521ED95D1C00D14E0092B2E9 /* ShipCockpit.cpp in Sources */,
+				52D1266B1C03538F00E6E4C2 /* lopcodes.c in Sources */,
+				521ED92D1C00D14E0092B2E9 /* LuaPlanet.cpp in Sources */,
+				521ED9931C00D2ED0092B2E9 /* CollisionSpace.cpp in Sources */,
+				52D126721C03538F00E6E4C2 /* ltablib.c in Sources */,
+				521ED92B1C00D14E0092B2E9 /* LuaNameGen.cpp in Sources */,
+				52D126631C03538F00E6E4C2 /* lgc.c in Sources */,
+				521EDBFA1C00D3A20092B2E9 /* LuaLabel.cpp in Sources */,
+				521EDAE31C00D36D0092B2E9 /* Node.cpp in Sources */,
+				521EDA221C00D3430092B2E9 /* FresnelColourMaterial.cpp in Sources */,
+				521EDADE1C00D36D0092B2E9 /* LuaModelSkin.cpp in Sources */,
+				521EDBF81C00D3A20092B2E9 /* LuaIcon.cpp in Sources */,
+				521EDA7D1C00D3550092B2E9 /* GuiImageButton.cpp in Sources */,
+				521ED9271C00D14E0092B2E9 /* LuaMatrix.cpp in Sources */,
+				521ED9421C00D14E0092B2E9 /* ModelBody.cpp in Sources */,
+				521EDA311C00D3430092B2E9 /* UIMaterial.cpp in Sources */,
+				521ED9111C00D14E0092B2E9 /* HyperspaceCloud.cpp in Sources */,
+				521ED9CE1C00D3310092B2E9 /* ModelSpinner.cpp in Sources */,
+				521ED8F01C00D14E0092B2E9 /* AmbientSounds.cpp in Sources */,
+				521EDA7B1C00D3550092B2E9 /* GuiFixed.cpp in Sources */,
+				521ED9261C00D14E0092B2E9 /* LuaManager.cpp in Sources */,
+				521EDC121C00D3A20092B2E9 /* Widget.cpp in Sources */,
+				521ED9081C00D14E0092B2E9 /* GameConfig.cpp in Sources */,
+				52D1265A1C03538F00E6E4C2 /* lbitlib.c in Sources */,
+				521EDB511C00D37B0092B2E9 /* TerrainHeightMountainsCraters.cpp in Sources */,
+				521EDB491C00D37B0092B2E9 /* TerrainHeightHillsCraters.cpp in Sources */,
+				521EDA281C00D3430092B2E9 /* MaterialGL.cpp in Sources */,
+				521ED9121C00D14E0092B2E9 /* IniConfig.cpp in Sources */,
+				521EDA8C1C00D3550092B2E9 /* GuiToolTip.cpp in Sources */,
+				521ED9511C00D14E0092B2E9 /* Projectile.cpp in Sources */,
+				521EDA3E1C00D3430092B2E9 /* VertexBuffer.cpp in Sources */,
+				521ED91D1C00D14E0092B2E9 /* LuaDev.cpp in Sources */,
+				521EDBED1C00D3A20092B2E9 /* LuaBox.cpp in Sources */,
+				52D1265C1C03538F00E6E4C2 /* lcorolib.c in Sources */,
+				521EDBE21C00D3A20092B2E9 /* Gradient.cpp in Sources */,
+				521EDA831C00D3550092B2E9 /* GuiRadioButton.cpp in Sources */,
+				521ED96B1C00D14E0092B2E9 /* SystemInfoView.cpp in Sources */,
+				521ED8FF1C00D14E0092B2E9 /* EnumStrings.cpp in Sources */,
+				521EDB571C00D37B0092B2E9 /* TerrainHeightMountainsVolcano.cpp in Sources */,
+				521ED9251C00D14E0092B2E9 /* LuaLang.cpp in Sources */,
+				52D126691C03538F00E6E4C2 /* loadlib.c in Sources */,
+				521EDA2D1C00D3430092B2E9 /* RenderTargetGL.cpp in Sources */,
+				521EDBFB1C00D3A20092B2E9 /* LuaLayer.cpp in Sources */,
+				521ED8FD1C00D14E0092B2E9 /* DynamicBody.cpp in Sources */,
+				521EDAE61C00D36D0092B2E9 /* Pattern.cpp in Sources */,
+				521ED95B1C00D14E0092B2E9 /* Ship.cpp in Sources */,
+				521ED9751C00D14E0092B2E9 /* Tombstone.cpp in Sources */,
+				521EDBE91C00D3A20092B2E9 /* Lua.cpp in Sources */,
+				521EDA321C00D3430092B2E9 /* Uniform.cpp in Sources */,
+				521EDADF1C00D36D0092B2E9 /* MatrixTransform.cpp in Sources */,
+				521EDAE51C00D36D0092B2E9 /* Parser.cpp in Sources */,
+				521ED9091C00D14E0092B2E9 /* GameLog.cpp in Sources */,
+				52D126681C03538F00E6E4C2 /* lmem.c in Sources */,
+				521EDB531C00D37B0092B2E9 /* TerrainHeightMountainsNormal.cpp in Sources */,
+				521EDB581C00D37B0092B2E9 /* TerrainHeightRuggedDesert.cpp in Sources */,
+				521EDBF01C00D3A20092B2E9 /* LuaColorBackground.cpp in Sources */,
+				521EDA881C00D3550092B2E9 /* GuiTextEntry.cpp in Sources */,
+				521EDA391C00D3430092B2E9 /* Material.cpp in Sources */,
+				521EDA8A1C00D3550092B2E9 /* GuiTexturedQuad.cpp in Sources */,
+				521EDBDE1C00D3A20092B2E9 /* Event.cpp in Sources */,
+				52D125EC1C0351FB00E6E4C2 /* jsoncpp.cpp in Sources */,
+				521EDB2B1C00D37B0092B2E9 /* TerrainColorEarthLikeHeightmapped.cpp in Sources */,
+				521EDB2A1C00D37B0092B2E9 /* TerrainColorEarthLike.cpp in Sources */,
+				521ED97A1C00D14E0092B2E9 /* WorldView.cpp in Sources */,
+				521EDBD91C00D3A20092B2E9 /* CheckBox.cpp in Sources */,
+				521ED9351C00D14E0092B2E9 /* LuaShipDef.cpp in Sources */,
+				52D1266D1C03538F00E6E4C2 /* lparser.c in Sources */,
+				521EDB4E1C00D37B0092B2E9 /* TerrainHeightHillsRivers.cpp in Sources */,
+				52D126761C03538F00E6E4C2 /* lundump.c in Sources */,
+				521EDB3C1C00D37B0092B2E9 /* TerrainColorTFGood.cpp in Sources */,
+				521EDBD41C00D3A20092B2E9 /* Animation.cpp in Sources */,
+				521ED94A1C00D14E0092B2E9 /* perlin.cpp in Sources */,
+				521EDB381C00D37B0092B2E9 /* TerrainColorStarG.cpp in Sources */,
+				521EDC021C00D3A20092B2E9 /* LuaSlider.cpp in Sources */,
+				521EDBE51C00D3A20092B2E9 /* Image.cpp in Sources */,
+				521ED9771C00D14E0092B2E9 /* UIView.cpp in Sources */,
+				521EDBE61C00D3A20092B2E9 /* Label.cpp in Sources */,
+				521EDBEA1C00D3A20092B2E9 /* LuaAlign.cpp in Sources */,
+				521ED9551C00D14E0092B2E9 /* Sensors.cpp in Sources */,
+				521ED9781C00D14E0092B2E9 /* utils.cpp in Sources */,
+				521EDAD31C00D36D0092B2E9 /* CollisionGeometry.cpp in Sources */,
+				521EDAE81C00D36D0092B2E9 /* Thruster.cpp in Sources */,
+				521EDAE41C00D36D0092B2E9 /* NodeVisitor.cpp in Sources */,
+				521EDB661C00D38B0092B2E9 /* DistanceFieldFont.cpp in Sources */,
+				521EDBD61C00D3A20092B2E9 /* Box.cpp in Sources */,
+				521ED9371C00D14E0092B2E9 /* LuaSpaceStation.cpp in Sources */,
+				521EDB351C00D37B0092B2E9 /* TerrainColorRock2.cpp in Sources */,
+				521EDB2D1C00D37B0092B2E9 /* TerrainColorGGNeptune.cpp in Sources */,
+				521ED9561C00D14E0092B2E9 /* Serializer.cpp in Sources */,
+				521EDBE31C00D3A20092B2E9 /* Grid.cpp in Sources */,
+				521EDB541C00D37B0092B2E9 /* TerrainHeightMountainsRidged.cpp in Sources */,
+				521EDA871C00D3550092B2E9 /* GuiTabbed.cpp in Sources */,
+				52D126601C03538F00E6E4C2 /* ldo.c in Sources */,
+				521EDA251C00D3430092B2E9 /* gl_core_3_x.c in Sources */,
+				521ED93A1C00D14E0092B2E9 /* LuaSystemBody.cpp in Sources */,
+				521EDAE11C00D36D0092B2E9 /* ModelNode.cpp in Sources */,
+				521EDA231C00D3430092B2E9 /* GasGiantMaterial.cpp in Sources */,
+				521ED95C1C00D14E0092B2E9 /* ShipAICmd.cpp in Sources */,
+				521ED91E1C00D14E0092B2E9 /* LuaEngine.cpp in Sources */,
+				521EDB261C00D37B0092B2E9 /* TerrainColorAsteroid.cpp in Sources */,
+				521EDA791C00D3550092B2E9 /* GuiButton.cpp in Sources */,
+				521EDC081C00D3A20092B2E9 /* MultiLineText.cpp in Sources */,
+				521EDB3F1C00D37B0092B2E9 /* TerrainFeature.cpp in Sources */,
+				521ED9021C00D14E0092B2E9 /* FileSourceZip.cpp in Sources */,
+				521EDA371C00D3430092B2E9 /* Graphics.cpp in Sources */,
+				521EDBD81C00D3A20092B2E9 /* CellSpec.cpp in Sources */,
+				52D126711C03538F00E6E4C2 /* ltable.c in Sources */,
+				52D125ED1C0351FB00E6E4C2 /* JsonUtils.cpp in Sources */,
+				52D126161C0351FB00E6E4C2 /* PicoDDS.cpp in Sources */,
+				521ED8FE1C00D14E0092B2E9 /* enum_table.cpp in Sources */,
+				521ED90E1C00D14E0092B2E9 /* GeoPatchJobs.cpp in Sources */,
+				521EDBFD1C00D3A20092B2E9 /* LuaMargin.cpp in Sources */,
+				521ED8F51C00D14E0092B2E9 /* CameraController.cpp in Sources */,
+				52D126621C03538F00E6E4C2 /* lfunc.c in Sources */,
+				52D1266A1C03538F00E6E4C2 /* lobject.c in Sources */,
+				52D1265E1C03538F00E6E4C2 /* ldblib.c in Sources */,
+				521EDBDC1C00D3A20092B2E9 /* Context.cpp in Sources */,
+				521EDBEE1C00D3A20092B2E9 /* LuaButton.cpp in Sources */,
+				521ED8F41C00D14E0092B2E9 /* Camera.cpp in Sources */,
+				521ED8F31C00D14E0092B2E9 /* Body.cpp in Sources */,
+				521ED9B51C00D3240092B2E9 /* StarSystem.cpp in Sources */,
+				521EDA7E1C00D3550092B2E9 /* GuiImageRadioButton.cpp in Sources */,
+				521ED9651C00D14E0092B2E9 /* SpaceStation.cpp in Sources */,
+				521ED9CD1C00D3310092B2E9 /* LuaModelSpinner.cpp in Sources */,
+				521EDA951C00D3610092B2E9 /* OSPosix.cpp in Sources */,
+				521EDADC1C00D36D0092B2E9 /* Lua.cpp in Sources */,
+				521ED96A1C00D14E0092B2E9 /* StringF.cpp in Sources */,
+				52E5FAE11C03589F001F4F89 /* lookup3.c in Sources */,
+				521EDAD11C00D36D0092B2E9 /* Billboard.cpp in Sources */,
+				521ED8FA1C00D14E0092B2E9 /* CRC32.cpp in Sources */,
+				521ED96D1C00D14E0092B2E9 /* TerrainBody.cpp in Sources */,
+				521EDB341C00D37B0092B2E9 /* TerrainColorRock.cpp in Sources */,
+				521ED9521C00D14E0092B2E9 /* PropertyMap.cpp in Sources */,
+				521ED91C1C00D14E0092B2E9 /* LuaConstants.cpp in Sources */,
+				521EDC031C00D3A20092B2E9 /* LuaSmallButton.cpp in Sources */,
+				521ED9241C00D14E0092B2E9 /* LuaGame.cpp in Sources */,
+				521EDA771C00D3550092B2E9 /* Gui.cpp in Sources */,
+				521EDBDF1C00D3A20092B2E9 /* EventDispatcher.cpp in Sources */,
+				521ED9341C00D14E0092B2E9 /* LuaShip.cpp in Sources */,
+				521EDC0B1C00D3A20092B2E9 /* Single.cpp in Sources */,
+				521ED9CC1C00D3310092B2E9 /* LuaFace.cpp in Sources */,
+				521EDAE01C00D36D0092B2E9 /* Model.cpp in Sources */,
+				52D126671C03538F00E6E4C2 /* lmathlib.c in Sources */,
+				521EDA891C00D3550092B2E9 /* GuiTextLayout.cpp in Sources */,
+				521ED9051C00D14E0092B2E9 /* Frame.cpp in Sources */,
+				521EDBF51C00D3A20092B2E9 /* LuaGauge.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2709,7 +2930,9 @@
 		4A20B0D51353194B0020F43E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				HEADER_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -2724,9 +2947,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
+				);
+				GCC_C_LANGUAGE_STANDARD = c11;
 				GCC_DYNAMIC_NO_PIC = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
@@ -2750,7 +2980,7 @@
 					"/opt/local/lib/sigc++-2.0/include",
 					/opt/local/include,
 					/opt/local/include/freetype2,
-					/opt/local/include/SDL,
+					/opt/local/include/SDL2,
 				);
 				INFOPLIST_FILE = "pioneer/pioneer-Info.plist";
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
@@ -2763,10 +2993,14 @@
 					"\"$(SRCROOT)/../contrib/oolua\"",
 					"\"$(SRCROOT)/../src/render\"",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
-				OTHER_LDFLAGS = "-headerpad_max_install_names";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_LDFLAGS = (
+					"-headerpad_max_install_names",
+					"-v",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.pioneerspacesim.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.7;
+				SDKROOT = macosx;
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
 				WRAPPER_EXTENSION = app;
 			};
@@ -2776,9 +3010,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
+				);
+				GCC_C_LANGUAGE_STANDARD = c11;
 				GCC_DYNAMIC_NO_PIC = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
@@ -2799,7 +3040,7 @@
 					"/opt/local/lib/sigc++-2.0/include",
 					/opt/local/include,
 					/opt/local/include/freetype2,
-					/opt/local/include/SDL,
+					/opt/local/include/SDL2,
 				);
 				INFOPLIST_FILE = "pioneer/pioneer-Info.plist";
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
@@ -2813,10 +3054,14 @@
 					"\"$(SRCROOT)/../src/render\"",
 				);
 				LLVM_LTO = NO;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
-				OTHER_LDFLAGS = "-headerpad_max_install_names";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_LDFLAGS = (
+					"-headerpad_max_install_names",
+					"-v",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "net.pioneerspacesim.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.7;
+				SDKROOT = macosx;
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = static;
 				WRAPPER_EXTENSION = app;
 			};

--- a/osx/pioneer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/osx/pioneer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:pioneer.xcodeproj">
+      location = "self:/Users/salborrelli/sites/pioneer/osx/Pioneer.xcodeproj">
    </FileRef>
 </Workspace>

--- a/osx/pioneer.xcodeproj/xcshareddata/xcschemes/GenGitVersion.xcscheme
+++ b/osx/pioneer.xcodeproj/xcshareddata/xcschemes/GenGitVersion.xcscheme
@@ -17,27 +17,30 @@
                BlueprintIdentifier = "4AE9706A1436A64000424F91"
                BuildableName = "GenGitVersion"
                BlueprintName = "GenGitVersion"
-               ReferencedContainer = "container:pioneer.xcodeproj">
+               ReferencedContainer = "container:Pioneer.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -45,17 +48,17 @@
             BlueprintIdentifier = "4AE9706A1436A64000424F91"
             BuildableName = "GenGitVersion"
             BlueprintName = "GenGitVersion"
-            ReferencedContainer = "container:pioneer.xcodeproj">
+            ReferencedContainer = "container:Pioneer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -63,7 +66,7 @@
             BlueprintIdentifier = "4AE9706A1436A64000424F91"
             BuildableName = "GenGitVersion"
             BlueprintName = "GenGitVersion"
-            ReferencedContainer = "container:pioneer.xcodeproj">
+            ReferencedContainer = "container:Pioneer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>

--- a/osx/pioneer.xcodeproj/xcshareddata/xcschemes/GenGitVersion.xcscheme
+++ b/osx/pioneer.xcodeproj/xcshareddata/xcschemes/GenGitVersion.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4AE9706A1436A64000424F91"
+               BuildableName = "GenGitVersion"
+               BlueprintName = "GenGitVersion"
+               ReferencedContainer = "container:pioneer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AE9706A1436A64000424F91"
+            BuildableName = "GenGitVersion"
+            BlueprintName = "GenGitVersion"
+            ReferencedContainer = "container:pioneer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AE9706A1436A64000424F91"
+            BuildableName = "GenGitVersion"
+            BlueprintName = "GenGitVersion"
+            ReferencedContainer = "container:pioneer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/osx/pioneer.xcodeproj/xcshareddata/xcschemes/pioneer.xcscheme
+++ b/osx/pioneer.xcodeproj/xcshareddata/xcschemes/pioneer.xcscheme
@@ -73,7 +73,7 @@
                BlueprintIdentifier = "4A20B0DD135319770020F43E"
                BuildableName = "pioneer.app"
                BlueprintName = "pioneer"
-               ReferencedContainer = "container:pioneer.xcodeproj">
+               ReferencedContainer = "container:Pioneer.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -91,14 +91,14 @@
             BlueprintIdentifier = "4A20B0DD135319770020F43E"
             BuildableName = "pioneer.app"
             BlueprintName = "pioneer"
-            ReferencedContainer = "container:pioneer.xcodeproj">
+            ReferencedContainer = "container:Pioneer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -116,7 +116,7 @@
             BlueprintIdentifier = "4A20B0DD135319770020F43E"
             BuildableName = "pioneer.app"
             BlueprintName = "pioneer"
-            ReferencedContainer = "container:pioneer.xcodeproj">
+            ReferencedContainer = "container:Pioneer.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <AdditionalOptions>
@@ -135,7 +135,7 @@
             BlueprintIdentifier = "4A20B0DD135319770020F43E"
             BuildableName = "pioneer.app"
             BlueprintName = "pioneer"
-            ReferencedContainer = "container:pioneer.xcodeproj">
+            ReferencedContainer = "container:Pioneer.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/osx/pioneer.xcodeproj/xcshareddata/xcschemes/pioneer.xcscheme
+++ b/osx/pioneer.xcodeproj/xcshareddata/xcschemes/pioneer.xcscheme
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8D07F2BC0486CC7A007CD1D0"
+               BuildableName = "Ogg.framework"
+               BlueprintName = "Ogg"
+               ReferencedContainer = "container:../../pioneer-thirdparty/source/libogg/macosx/Ogg.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BECDF5FE0761BA81005FE872"
+               BuildableName = "SDL2.framework"
+               BlueprintName = "Framework"
+               ReferencedContainer = "container:../../pioneer-thirdparty/source/sdl2/Xcode/SDL/SDL.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BE1FA71807AF4C44004B6283"
+               BuildableName = "SDL2_image.framework"
+               BlueprintName = "Framework"
+               ReferencedContainer = "container:../../pioneer-thirdparty/source/sdl2_image/Xcode/SDL_image.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "730F23A1091827B100AB638C"
+               BuildableName = "Vorbis.framework"
+               BlueprintName = "Vorbis"
+               ReferencedContainer = "container:../../pioneer-thirdparty/source/libvorbis-1.3.3/macosx/Vorbis.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A20B0DD135319770020F43E"
+               BuildableName = "pioneer.app"
+               BlueprintName = "pioneer"
+               ReferencedContainer = "container:pioneer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A20B0DD135319770020F43E"
+            BuildableName = "pioneer.app"
+            BlueprintName = "pioneer"
+            ReferencedContainer = "container:pioneer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "NO"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A20B0DD135319770020F43E"
+            BuildableName = "pioneer.app"
+            BlueprintName = "pioneer"
+            ReferencedContainer = "container:pioneer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A20B0DD135319770020F43E"
+            BuildableName = "pioneer.app"
+            BlueprintName = "pioneer"
+            ReferencedContainer = "container:pioneer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/osx/pioneer.xcworkspace/contents.xcworkspacedata
+++ b/osx/pioneer.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:../../pioneer-thirdparty/source/libogg/macosx/Ogg.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:../../pioneer-thirdparty/source/libvorbis-1.3.3/macosx/Vorbis.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:../../pioneer-thirdparty/source/sdl2/Xcode/SDL/SDL.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:../../pioneer-thirdparty/source/sdl2_image/Xcode/SDL_image.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "container:pioneer.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/osx/pioneer.xcworkspace/xcshareddata/pioneer.xccheckout
+++ b/osx/pioneer.xcworkspace/xcshareddata/pioneer.xccheckout
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>489F6EAB-4599-4922-95BB-10B7BDFCCF8C</string>
+	<key>IDESourceControlProjectName</key>
+	<string>pioneer</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>CEB9386F2744B9C86681D599A1A9B6D6ADBFB2A8</key>
+		<string>github.com:SilkyPantsDan/pioneer.git</string>
+		<key>DA6F661DD649F78B3D5A22E52AD1F5102743FEDB</key>
+		<string>github.com:SilkyPantsDan/pioneer-thirdparty.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>osx/pioneer.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>CEB9386F2744B9C86681D599A1A9B6D6ADBFB2A8</key>
+		<string>../..</string>
+		<key>DA6F661DD649F78B3D5A22E52AD1F5102743FEDB</key>
+		<string>../..-thirdparty</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>github.com:SilkyPantsDan/pioneer.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>111</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>CEB9386F2744B9C86681D599A1A9B6D6ADBFB2A8</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>CEB9386F2744B9C86681D599A1A9B6D6ADBFB2A8</string>
+			<key>IDESourceControlWCCName</key>
+			<string>pioneer</string>
+		</dict>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>DA6F661DD649F78B3D5A22E52AD1F5102743FEDB</string>
+			<key>IDESourceControlWCCName</key>
+			<string>pioneer-thirdparty</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/osx/pioneer/pioneer-Info.plist
+++ b/osx/pioneer/pioneer-Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIconFile</key>
 	<string>pioneer-logo.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.pioneerspacesim.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>net.pioneerspacesim.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/src/graphics/opengl/LineMaterial.cpp
+++ b/src/graphics/opengl/LineMaterial.cpp
@@ -13,7 +13,7 @@ namespace Graphics {
 namespace OGL {
 
 // LineProgram -------------------------------------------
-LineProgram::LineProgram(const std::string &filename, const std::string &defines) : Program(filename, defines)
+LineProgram::LineProgram(const std::string &filename, const std::string &defines) : Program(filename, defines, true)
 {
 }
 
@@ -26,7 +26,7 @@ void LineProgram::InitUniforms()
 // LineMaterial -----------------------------------
 Program *LineMaterial::CreateProgram(const MaterialDescriptor &desc)
 {
-	//assert(desc.effect == EFFECT_LINE);
+	assert(desc.effect == EFFECT_LINE);
 	return new Graphics::OGL::LineProgram("line", "");
 }
 

--- a/src/graphics/opengl/LineMaterial.cpp
+++ b/src/graphics/opengl/LineMaterial.cpp
@@ -13,7 +13,7 @@ namespace Graphics {
 namespace OGL {
 
 // LineProgram -------------------------------------------
-LineProgram::LineProgram(const std::string &filename, const std::string &defines) : Program(filename, defines, true)
+LineProgram::LineProgram(const std::string &filename, const std::string &defines) : Program(filename, defines)
 {
 }
 
@@ -26,7 +26,7 @@ void LineProgram::InitUniforms()
 // LineMaterial -----------------------------------
 Program *LineMaterial::CreateProgram(const MaterialDescriptor &desc)
 {
-	assert(desc.effect == EFFECT_LINE);
+	//assert(desc.effect == EFFECT_LINE);
 	return new Graphics::OGL::LineProgram("line", "");
 }
 


### PR DESCRIPTION
Hi guys,
 this is my first commit to Pioneer so feel free to hit me with your comments and requests if I did something the wrong way. 

The main goal of this commit is to update the project file for XCode on Mac OS X. The old version was clearly outdated as several files that were listed in the project were missing from the file system, and vice-versa. I've spent some time fixing the project by synchronising it with the file system, upgrading references to the latest version of the relevant libraries, etc.

The project now builds without errors on Mac OSX 10.10 (Yosemite) and XCode 6. The resulting App runs smoothly and seems even better than the official Mac OS X build that I have downloaded from the web site, since the compiled version does not crash if I try to start from a station different from the "Barnard's Star" (as the binary version did).

Note that in order to avoid weird compilation problems, I have also had to do the following minor changes to files out of the "OS X" directory:

1. contrib/miniz/miniz.h - added static cast to mz_uint8 to real header structure, in order to avoid the following compiler error: "Non-constant-expression cannot be narrowed from type 'char' to 'mz_uint8' (aka 'unsigned char') in initializer list"
2. graphics/opengl/LineMaterial.cpp - commented line "assert(desc.effect == EFFECT_LINE);" as there is no EFFECT_LINE constant defined anywhere in the project (or at least, I haven't been able to find it). For a similar reason I removed the third parameter from the constructor: there is no three parameters constructor defined in Graphics:OGL:Program class.

Let me know if you need me to change anything in order to accept the commit. If this commit is accepted I'll try to dig into the code further to see if I can someway help with the development of this wonderful project.

King Regards,
Sal.