### PR TITLE
Fix cockpit loading

### DIFF
--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -77,7 +77,7 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 	shipClass = data.get("ship_class", "").asString();
 	manufacturer = data.get("manufacturer", "").asString();
 	modelName = data.get("model", "").asString();
-	cockpitName = data.get("cockpit_model", "").asString();
+	cockpitName = data.get("cockpit", "").asString();
 
 	linThrust[THRUSTER_REVERSE] = data.get("reverse_thrust", 0.0f).asFloat();
 	linThrust[THRUSTER_FORWARD] = data.get("forward_thrust", 0.0f).asFloat();

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -1,7 +1,7 @@
 // Copyright © 2008-2015 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-#define ALLOW_LUA_SHIP_DEF 1
+#define ALLOW_LUA_SHIP_DEF 0
 
 #include "ShipType.h"
 #if ALLOW_LUA_SHIP_DEF


### PR DESCRIPTION
The Lua code used the name `cockpit` to define what cockpit model to load but in the change to the JSON format it was altered too `cockpit_model` only none of the JSON files used that!

So I've reverted it to `cockpit` and now everything should work as intended.

I've also disabled the `ALLOW_LUA_SHIP_DEF` code since all of our ships and models are now in JSON format.