### PR TITLE
New UI scaling (HiDPI) support

### DIFF
--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -15,6 +15,7 @@ GameConfig::GameConfig(const std::map<std::string,std::string> &override_)
 	map["StartFullscreen"] = "0";
 	map["ScrWidth"] = "800";
 	map["ScrHeight"] = "600";
+	map["UIScaleFactor"] = "1";
 	map["DetailCities"] = "1";
 	map["DetailPlanets"] = "1";
 	map["SfxVolume"] = "0.8";

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -457,7 +457,12 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 	Output("Lua::Init()\n");
 	Lua::Init();
 
-	Pi::ui.Reset(new UI::Context(Lua::manager, Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight()));
+	Pi::ui.Reset(new UI::Context(
+		Lua::manager,
+		Pi::renderer,
+		Graphics::GetScreenWidth(),
+		Graphics::GetScreenHeight(),
+		config->Float("UIScaleFactor", 1.0f)));
 
 	Pi::serverAgent = 0;
 	if (config->Int("EnableServerAgent")) {

--- a/src/ui/Box.cpp
+++ b/src/ui/Box.cpp
@@ -18,6 +18,12 @@ static inline void GetComponentsForOrient(bool horiz, Point::Component &variable
 	}
 }
 
+Box::Box(Context *context, BoxOrientation orient, int spacing):
+	Container(context),
+	m_orient(orient),
+	m_spacing(context->GetScale() * spacing)
+{}
+
 Point Box::PreferredSize()
 {
 	if (m_children.empty()) return Point();

--- a/src/ui/Box.h
+++ b/src/ui/Box.h
@@ -15,7 +15,7 @@ protected:
 		BOX_VERTICAL
 	};
 
-	Box(Context *context, BoxOrientation orient, int spacing) : Container(context), m_orient(orient), m_spacing(spacing) {}
+	Box(Context *context, BoxOrientation orient, int spacing);
 
 public:
 	virtual Point PreferredSize();

--- a/src/ui/Context.cpp
+++ b/src/ui/Context.cpp
@@ -34,16 +34,20 @@ static const float FONT_SCALE[] = {
 	1.8f   // MONO_XLARGE
 };
 
-Context::Context(LuaManager *lua, Graphics::Renderer *renderer, int width, int height) : Container(this),
+Context::Context(LuaManager *lua, Graphics::Renderer *renderer, int width, int height):
+	Context(lua, renderer, width, height, std::min(float(height)/SCALE_CUTOFF_HEIGHT, 1.0f))
+{}
+
+Context::Context(LuaManager *lua, Graphics::Renderer *renderer, int width, int height, float scale) : Container(this),
 	m_renderer(renderer),
 	m_width(width),
 	m_height(height),
-	m_scale(std::min(float(m_height)/SCALE_CUTOFF_HEIGHT, 1.0f)),
+	m_scale(scale),
 	m_needsLayout(false),
 	m_mousePointer(nullptr),
 	m_mousePointerEnabled(true),
 	m_eventDispatcher(this),
-	m_skin("ui/Skin.ini", renderer, GetScale()),
+	m_skin("ui/Skin.ini", renderer, scale),
 	m_lua(lua)
 {
 	lua_State *l = m_lua->GetLuaState();

--- a/src/ui/Context.h
+++ b/src/ui/Context.h
@@ -72,6 +72,7 @@ namespace UI {
 class Context : public Container {
 public:
 	Context(LuaManager *lua, Graphics::Renderer *renderer, int width, int height);
+	Context(LuaManager *lua, Graphics::Renderer *renderer, int width, int height, float scale);
 
 	// general purpose containers
 	UI::HBox *HBox(float spacing = 0.0f) { return new UI::HBox(this, spacing); }

--- a/src/ui/Image.cpp
+++ b/src/ui/Image.cpp
@@ -7,6 +7,17 @@
 
 namespace UI {
 
+namespace {
+
+static Point CalcDisplayDimensions(const UI::Context *context, const Graphics::Texture *texture)
+{
+	const auto image_size = texture->GetDescriptor().GetOriginalSize();
+	const float scale = context->GetScale();
+	return Point(scale * image_size.x, scale * image_size.y);
+}
+
+}
+
 Image::Image(Context *context, const std::string &filename, Uint32 sizeControlFlags): Widget(context)
 	, m_centre(0.0f, 0.0f)
 	, m_scale(1.0f)
@@ -15,8 +26,7 @@ Image::Image(Context *context, const std::string &filename, Uint32 sizeControlFl
 	Graphics::TextureBuilder b = Graphics::TextureBuilder::UI(filename);
 	m_texture.Reset(b.GetOrCreateTexture(GetContext()->GetRenderer(), "ui"));
 
-	const auto image_size = b.GetDescriptor().GetOriginalSize();
-	m_initialSize = Point(image_size.x, image_size.y);
+	m_initialSize = CalcDisplayDimensions(GetContext(), m_texture.Get());
 
 	Graphics::MaterialDescriptor material_desc;
 	material_desc.textures = 1;
@@ -46,9 +56,7 @@ Image *Image::SetHeightLines(Uint32 lines)
 
 Image *Image::SetNaturalSize()
 {
-	const auto image_size = m_texture->GetDescriptor().GetOriginalSize();
-	m_initialSize = Point(image_size.x, image_size.y);
-
+	m_initialSize = CalcDisplayDimensions(GetContext(), m_texture.Get());
 	GetContext()->RequestLayout();
 	return this;
 }

--- a/src/ui/Image.cpp
+++ b/src/ui/Image.cpp
@@ -31,12 +31,6 @@ Point Image::PreferredSize()
 	return m_initialSize;
 }
 
-Point Image::GetImageSize() const
-{
-	const auto sz = m_texture->GetDescriptor().GetOriginalSize();
-	return Point(sz.x, sz.y);
-}
-
 Image *Image::SetHeightLines(Uint32 lines)
 {
 	const Text::TextureFont *font = GetContext()->GetFont(GetFont()).Get();
@@ -52,7 +46,9 @@ Image *Image::SetHeightLines(Uint32 lines)
 
 Image *Image::SetNaturalSize()
 {
-	m_initialSize = GetImageSize();
+	const auto image_size = m_texture->GetDescriptor().GetOriginalSize();
+	m_initialSize = Point(image_size.x, image_size.y);
+
 	GetContext()->RequestLayout();
 	return this;
 }

--- a/src/ui/Image.h
+++ b/src/ui/Image.h
@@ -14,8 +14,6 @@ namespace UI {
 
 class Image: public Widget {
 public:
-	Point GetImageSize() const;
-
 	virtual Point PreferredSize();
 	virtual void Draw();
 

--- a/src/ui/Margin.cpp
+++ b/src/ui/Margin.cpp
@@ -2,8 +2,15 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Margin.h"
+#include "Context.h"
 
 namespace UI {
+
+Margin::Margin(Context *context, int margin, Direction direction):
+	Single(context),
+	m_margin(context->GetScale() * margin),
+	m_direction(direction)
+{}
 
 Point Margin::PreferredSize()
 {

--- a/src/ui/Margin.h
+++ b/src/ui/Margin.h
@@ -25,7 +25,7 @@ public:
 
 protected:
 	friend class Context;
-	Margin(Context *context, int margin, Direction direction) : Single(context), m_margin(margin), m_direction(direction) {}
+	Margin(Context *context, int margin, Direction direction);
 
 private:
 	int m_margin;

--- a/src/ui/Table.cpp
+++ b/src/ui/Table.cpp
@@ -392,7 +392,7 @@ void Table::ClearRows()
 
 Table *Table::SetRowSpacing(int spacing)
 {
-	m_body->SetRowSpacing(spacing);
+	m_body->SetRowSpacing(GetContext()->GetScale() * spacing);
 	m_dirty = true;
 	GetContext()->RequestLayout();
 	return this;
@@ -400,7 +400,7 @@ Table *Table::SetRowSpacing(int spacing)
 
 Table *Table::SetColumnSpacing(int spacing)
 {
-	m_layout.SetColumnSpacing(spacing);
+	m_layout.SetColumnSpacing(GetContext()->GetScale() * spacing);
 	m_dirty = true;
 	GetContext()->RequestLayout();
 	return this;


### PR DESCRIPTION
Old UI used a uniform 800x600 unit design grid, which meant that if you had more pixels everything would be stretched to fit. New UI uses a fluid layout system and pixel units, which is more flexible but results in some UI components being very small when shown on a high DPI display.

New UI already has some support for applying uniform scaling in the UI 'Skin'. This is principally used to cope with displaying the user interface on low resolution screens -- squeezing the UI if the game window is smaller than 1027x768. This PR extends that scaling support to apply the scaling factor to more things, and to allow it to be set in the pioneer config.ini.