### PR TITLE
Added pump down button to the EconTrade screen

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -859,6 +859,10 @@
       "description" : "For player reputation",
       "message" : "Professional"
    },
+   "PUMP_DOWN" : {
+      "description" : "Drain the fuel tank",
+      "message" : "Pump down"
+   },
    "QUALIFICATION_SCORES" : {
       "description" : "",
       "message" : "Qualification scores"

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -605,7 +605,7 @@ Ship.Refuel = function (self,amount)
 		return 0
 	end
 	local fuelTankMass = ShipDef[self.shipId].fuelTankMass
-	local needed = math.clamp(math.ceil(fuelTankMass - self.fuelMassLeft), 0, amount)
+	local needed = math.clamp(math.floor(fuelTankMass - self.fuelMassLeft), 0, amount)
 	local removed = self:RemoveEquip(Equipment.cargo.hydrogen, needed)
 	self:SetFuelPercent(math.clamp(self.fuel + removed * 100 / fuelTankMass, 0, 100))
 	return removed

--- a/data/ui/InfoView/EconTrade.lua
+++ b/data/ui/InfoView/EconTrade.lua
@@ -95,22 +95,31 @@ local econTrade = function ()
 	fuelGauge.gauge:Bind("valuePercent", Game.player, "fuel")
 
 	-- Define the refuel button
-	local refuelButton = SmallLabeledButton.New(l.REFUEL)
-	local refuelMaxButton = SmallLabeledButton.New(l.REFUEL_FULL)
-	local pumpDownButton = SmallLabeledButton.New(l.PUMP_DOWN)
+	local refuelOne = ui:Button("+1")
+	local refuelTen = ui:Button("+10")
+	local refuel100 = ui:Button("+100")
+	local pumpDownOne = ui:Button("-1")
+	local pumpDownTen = ui:Button("-10")
+	local pumpDown100 = ui:Button("-100")
 
 	local refuelButtonRefresh = function ()
 		if Game.player.fuel == 100 or Game.player:CountEquip(Equipment.cargo.hydrogen) == 0 then
-			refuelButton.widget:Disable()
-			refuelMaxButton.widget:Disable()
+			refuelOne:Disable()
+			refuelTen:Disable()
+			refuel100:Disable()
 		else
-			refuelButton.widget:Enable()
-			refuelMaxButton.widget:Enable()
+			refuelOne:Enable()
+			refuelTen:Enable()
+			refuel100:Enable()
 		end
 		if Game.player.fuel == 0 or Game.player:GetEquipFree("cargo") == 0 then
-			pumpDownButton.widget:Disable()
+			pumpDownOne:Disable()
+			pumpDownTen:Disable()
+			pumpDown100:Disable()
 		else
-			pumpDownButton.widget:Enable()
+			pumpDownOne:Enable()
+			pumpDownTen:Enable()
+			pumpDown100:Enable()
 		end
 		local fuel_percent = Game.player.fuel/100
 		fuelGauge.gauge:SetValue(fuel_percent)
@@ -118,38 +127,30 @@ local econTrade = function ()
 	end
 	refuelButtonRefresh()
 
-	local refuel = function ()
+	local refuel = function (fuel)
 		-- UI button where the player clicks to refuel...
-		Game.player:Refuel(1)
+		Game.player:Refuel(fuel)
 		-- ...then we update the cargo list widget...
 		cargoListWidget:SetInnerWidget(updateCargoListWidget())
 
 		refuelButtonRefresh()
 	end
-	local refuelMax = function ()
-		while Game.player.fuel < 100 do
-			local removed = Game.player:Refuel(1)
-			if removed == 0 then
-				break
-			end
-		end
-		cargoListWidget:SetInnerWidget(updateCargoListWidget())
 
-		refuelButtonRefresh()
-	end
-
-	local pumpDown = function ()
+	local pumpDown = function (fuel)
 		local fuelTankMass = ShipDef[Game.player.shipId].fuelTankMass
-		local drainedFuel = Game.player:AddEquip(Equipment.cargo.hydrogen, 1)
+		local drainedFuel = Game.player:AddEquip(Equipment.cargo.hydrogen, fuel)
 		Game.player:SetFuelPercent(Game.player.fuel - drainedFuel * 100 / fuelTankMass)
 		cargoListWidget:SetInnerWidget(updateCargoListWidget())
 
 		refuelButtonRefresh()
 	end
 
-	refuelButton.button.onClick:Connect(refuel)
-	refuelMaxButton.button.onClick:Connect(refuelMax)
-	pumpDownButton.button.onClick:Connect(pumpDown)
+	refuelOne.onClick:Connect(function () refuel(1) end)
+	refuelTen.onClick:Connect(function () refuel(10) end)
+	refuel100.onClick:Connect(function () refuel(100) end)
+	pumpDownOne.onClick:Connect(function () pumpDown(1) end)
+	pumpDownTen.onClick:Connect(function () pumpDown(10) end)
+	pumpDown100.onClick:Connect(function () pumpDown(100) end)
 
 	return ui:Expand():SetInnerWidget(
 		ui:Grid({48,4,48},1)
@@ -196,9 +197,18 @@ local econTrade = function ()
 								}),
 								nil,
 								ui:VBox(5):PackEnd({
-									refuelButton.widget,
-									refuelMaxButton.widget,
-									pumpDownButton.widget,
+									ui:Label(l.REFUEL),
+									ui:HBox(5):PackEnd({
+										refuelOne,
+										refuelTen,
+										refuel100,
+									}):SetFont("XSMALL"),
+									ui:Label(l.PUMP_DOWN),
+									ui:HBox(5):PackEnd({
+										pumpDownOne,
+										pumpDownTen,
+										pumpDown100,
+									}):SetFont("XSMALL"),
 								}),
 							})
 					})

--- a/data/ui/InfoView/EconTrade.lua
+++ b/data/ui/InfoView/EconTrade.lua
@@ -138,8 +138,10 @@ local econTrade = function ()
 
 	local pumpDown = function (fuel)
 		local fuelTankMass = ShipDef[Game.player.shipId].fuelTankMass
+		local availableFuel = math.floor(Game.player.fuel / 100 * fuelTankMass)
+		if fuel > availableFuel then fuel = availableFuel end
 		local drainedFuel = Game.player:AddEquip(Equipment.cargo.hydrogen, fuel)
-		Game.player:SetFuelPercent(Game.player.fuel - drainedFuel * 100 / fuelTankMass)
+		Game.player:SetFuelPercent(math.clamp(Game.player.fuel - drainedFuel * 100 / fuelTankMass, 0, 100))
 		cargoListWidget:SetInnerWidget(updateCargoListWidget())
 
 		refuelButtonRefresh()

--- a/data/ui/InfoView/EconTrade.lua
+++ b/data/ui/InfoView/EconTrade.lua
@@ -103,8 +103,14 @@ local econTrade = function ()
 		if Game.player.fuel == 100 or Game.player:CountEquip(Equipment.cargo.hydrogen) == 0 then
 			refuelButton.widget:Disable()
 			refuelMaxButton.widget:Disable()
-		elseif Game.player.fuel == 0 then
+		else
+			refuelButton.widget:Enable()
+			refuelMaxButton.widget:Enable()
+		end
+		if Game.player.fuel == 0 or Game.player:GetEquipFree("cargo") == 0 then
 			pumpDownButton.widget:Disable()
+		else
+			pumpDownButton.widget:Enable()
 		end
 		local fuel_percent = Game.player.fuel/100
 		fuelGauge.gauge:SetValue(fuel_percent)

--- a/data/ui/InfoView/EconTrade.lua
+++ b/data/ui/InfoView/EconTrade.lua
@@ -5,6 +5,7 @@ local Engine = import("Engine")
 local Lang = import("Lang")
 local Game = import("Game")
 local Equipment = import("Equipment")
+local ShipDef = import("ShipDef")
 
 local SmallLabeledButton = import("ui/SmallLabeledButton")
 local InfoGauge = import("ui/InfoGauge")
@@ -96,11 +97,14 @@ local econTrade = function ()
 	-- Define the refuel button
 	local refuelButton = SmallLabeledButton.New(l.REFUEL)
 	local refuelMaxButton = SmallLabeledButton.New(l.REFUEL_FULL)
+	local pumpDownButton = SmallLabeledButton.New(l.PUMP_DOWN)
 
 	local refuelButtonRefresh = function ()
 		if Game.player.fuel == 100 or Game.player:CountEquip(Equipment.cargo.hydrogen) == 0 then
 			refuelButton.widget:Disable()
 			refuelMaxButton.widget:Disable()
+		elseif Game.player.fuel == 0 then
+			pumpDownButton.widget:Disable()
 		end
 		local fuel_percent = Game.player.fuel/100
 		fuelGauge.gauge:SetValue(fuel_percent)
@@ -128,8 +132,18 @@ local econTrade = function ()
 		refuelButtonRefresh()
 	end
 
+	local pumpDown = function ()
+		local fuelTankMass = ShipDef[Game.player.shipId].fuelTankMass
+		local drainedFuel = Game.player:AddEquip(Equipment.cargo.hydrogen, 1)
+		Game.player:SetFuelPercent(Game.player.fuel - drainedFuel * 100 / fuelTankMass)
+		cargoListWidget:SetInnerWidget(updateCargoListWidget())
+
+		refuelButtonRefresh()
+	end
+
 	refuelButton.button.onClick:Connect(refuel)
 	refuelMaxButton.button.onClick:Connect(refuelMax)
+	pumpDownButton.button.onClick:Connect(pumpDown)
 
 	return ui:Expand():SetInnerWidget(
 		ui:Grid({48,4,48},1)
@@ -178,6 +192,7 @@ local econTrade = function ()
 								ui:VBox(5):PackEnd({
 									refuelButton.widget,
 									refuelMaxButton.widget,
+									pumpDownButton.widget,
 								}),
 							})
 					})

--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -180,17 +180,17 @@ static int l_ship_set_fuel_percent(lua_State *l)
 
 	Ship *s = LuaObject<Ship>::CheckFromLua(1);
 
-	float percent = 100;
+	double percent = 100;
 	if (lua_isnumber(l, 2)) {
-		percent = float(luaL_checknumber(l, 2));
-		if (percent < 0.0f || percent > 100.0f) {
+		percent = luaL_checknumber(l, 2);
+		if (percent < 0.0 || percent > 100.0) {
 			pi_lua_warn(l,
 				"argument out of range: Ship{%s}:SetFuelPercent(%g)",
 				s->GetLabel().c_str(), percent);
 		}
 	}
 
-	s->SetFuel(percent/100.f);
+	s->SetFuel(percent/100.0);
 
 	LUA_DEBUG_END(l, 0);
 


### PR DESCRIPTION
This PR adds a pump down button the EconTrade screen.
The player can pump fuel to the cargo slot to save fuel for a return route or jettison fuel to reduce mass if gravity is to high to land.
