### PR TITLE
Fix UI scaling for small displays (under 1024x768)

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -457,12 +457,17 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 	Output("Lua::Init()\n");
 	Lua::Init();
 
+	float ui_scale = config->Float("UIScaleFactor", 1.0f);
+	if (Graphics::GetScreenHeight() < 768) {
+		ui_scale = float(Graphics::GetScreenHeight()) / 768.0f;
+	}
+
 	Pi::ui.Reset(new UI::Context(
 		Lua::manager,
 		Pi::renderer,
 		Graphics::GetScreenWidth(),
 		Graphics::GetScreenHeight(),
-		config->Float("UIScaleFactor", 1.0f)));
+		ui_scale));
 
 	Pi::serverAgent = 0;
 	if (config->Int("EnableServerAgent")) {


### PR DESCRIPTION
#3552 introduced a regression for new-ui layout on small displays. As reported by magagnarata on IRC, it looks like this:

![small-ui-screenshot](https://cloud.githubusercontent.com/assets/115749/11767915/f6ce7190-a1b4-11e5-8fb0-e206ce159284.png)

Previously, new-ui would automatically use a scale factor less than 1 for displays smaller that 1024x768, but because #3552 made the scale factor explicitly configurable this broke the auto-scale.

This PR forces a more useful scaling factor for small displays (ignoring the UIScaleFactor config value).