### PR TITLE
Remove the neighbour system from GeoPatch

### DIFF
--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -304,11 +304,11 @@ void GeoPatch::LODUpdate(const vector3d &campos, const Graphics::Frustum &frustu
 
 	if (canSplit) {
 		if (!kids[0]) {
-			// ...before doing the frustum culling that relies on it.
+			// Test if this patch is visible
 			if (!frustum.TestPoint(clipCentroid, clipRadius))
 				return; // nothing below this patch is visible
 
-						// only want to horizon cull patches that can actually be over the horizon!
+			// only want to horizon cull patches that can actually be over the horizon!
 			const vector3d camDir(campos - clipCentroid);
 			const vector3d camDirNorm(camDir.Normalized());
 			const vector3d cenDir(clipCentroid.Normalized());
@@ -324,6 +324,7 @@ void GeoPatch::LODUpdate(const vector3d &campos, const Graphics::Frustum &frustu
 				}
 			}
 
+			// we can see this patch so submit the jobs!
 			assert(!mHasJobRequest);
 			mHasJobRequest = true;
 

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -9,6 +9,7 @@
 #include "vector3.h"
 #include "Random.h"
 #include "galaxy/StarSystem.h"
+#include "graphics/Frustum.h"
 #include "graphics/Material.h"
 #include "terrain/Terrain.h"
 #include "GeoPatchID.h"
@@ -18,7 +19,7 @@
 
 // #define DEBUG_BOUNDING_SPHERES
 
-namespace Graphics { class Renderer; class Frustum; }
+namespace Graphics { class Renderer; }
 class SystemBody;
 class GeoPatchContext;
 class GeoSphere;
@@ -91,7 +92,7 @@ public:
 		return merge;
 	}
 
-	void LODUpdate(const vector3d &campos);
+	void LODUpdate(const vector3d &campos, const Graphics::Frustum &frustum);
 
 	void RequestSinglePatch();
 	void ReceiveHeightmaps(SQuadSplitResult *psr);

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -28,8 +28,7 @@ class SSingleSplitResult;
 
 class GeoPatch {
 private:
-	static const int NUM_EDGES = 4;
-	static const int NUM_KIDS = NUM_EDGES;
+	static const int NUM_KIDS = 4;
 
 	RefCountedPtr<GeoPatchContext> ctx;
 	const vector3d v0, v1, v2, v3;
@@ -39,7 +38,6 @@ private:
 	std::unique_ptr<Graphics::VertexBuffer> m_vertexBuffer;
 	std::unique_ptr<GeoPatch> kids[NUM_KIDS];
 	GeoPatch *parent;
-	GeoPatch *edgeFriend[NUM_EDGES]; // [0]=v01, [1]=v12, [2]=v20
 	GeoSphere *geosphere;
 	double m_roughLength;
 	vector3d clipCentroid, centroid;
@@ -67,12 +65,6 @@ public:
 
 	void UpdateVBOs(Graphics::Renderer *renderer);
 
-	inline int GetEdgeIdxOf(const GeoPatch *e) const {
-		for (int i=0; i<NUM_KIDS; i++) {if (edgeFriend[i] == e) {return i;}}
-		abort();
-		return -1;
-	}
-
 	int GetChildIdx(const GeoPatch *child) const {
 		for (int i=0; i<NUM_KIDS; i++) {
 			if (kids[i].get() == child) return i;
@@ -84,44 +76,6 @@ public:
 	// in patch surface coords, [0,1]
 	inline vector3d GetSpherePoint(const double x, const double y) const {
 		return (v0 + x*(1.0-y)*(v1-v0) + x*y*(v2-v0) + (1.0-x)*y*(v3-v0)).Normalized();
-	}
-
-	inline void OnEdgeFriendChanged(const int edge, GeoPatch *e) {
-		edgeFriend[edge] = e;
-	}
-
-	inline void NotifyEdgeFriendSplit(GeoPatch *e) {
-		if (!kids[0]) {return;}
-		const int idx = GetEdgeIdxOf(e);
-		const int we_are = e->GetEdgeIdxOf(this);
-		// match e's new kids to our own... :/
-		kids[idx]->OnEdgeFriendChanged(idx, e->kids[(we_are+1)%NUM_KIDS].get());
-		kids[(idx+1)%NUM_KIDS]->OnEdgeFriendChanged(idx, e->kids[we_are].get());
-	}
-
-	void NotifyEdgeFriendDeleted(const GeoPatch *e) {
-		const int idx = GetEdgeIdxOf(e);
-		assert(idx>=0 && idx<NUM_EDGES);
-		edgeFriend[idx] = NULL;
-	}
-
-	inline GeoPatch *GetEdgeFriendForKid(const int kid, const int edge) const {
-		const GeoPatch *e = edgeFriend[edge];
-		if (!e) return NULL;
-		//assert (e);// && (e->m_depth >= m_depth));
-		const int we_are = e->GetEdgeIdxOf(this);
-		// neighbour patch has not split yet (is at depth of this patch), so kids of this patch do
-		// not have same detail level neighbours yet
-		if (edge == kid) return e->kids[(we_are+1)%NUM_KIDS].get();
-		else return e->kids[we_are].get();
-	}
-
-	inline Uint32 DetermineIndexbuffer() const {
-		return // index buffers are ordered by edge resolution flags
-			(edgeFriend[0] ? 1u : 0u) |
-			(edgeFriend[1] ? 2u : 0u) |
-			(edgeFriend[2] ? 4u : 0u) |
-			(edgeFriend[3] ? 8u : 0u);
 	}
 
 	void Render(Graphics::Renderer *r, const vector3d &campos, const matrix4x4d &modelView, const Graphics::Frustum &frustum);
@@ -144,7 +98,6 @@ public:
 	void ReceiveHeightmap(const SSingleSplitResult *psr);
 	void ReceiveJobHandle(Job::Handle job);
 
-	inline void SetEdgeFriend(const int idx, GeoPatch *pPatch) { edgeFriend[idx] = pPatch; }
 	inline bool HasHeightData() const { return (heights.get()!=nullptr); }
 };
 

--- a/src/GeoPatchContext.cpp
+++ b/src/GeoPatchContext.cpp
@@ -22,23 +22,6 @@ double GeoPatchContext::frac = 0.0;
 RefCountedPtr<Graphics::IndexBuffer> GeoPatchContext::indices;
 int GeoPatchContext::prevEdgeLen = 0;
 
-void GeoPatchContext::Cleanup() {
-}
-
-int GeoPatchContext::GetIndices(std::vector<unsigned short> &pl)
-{
-	// calculate how many tri's there are
-	int tri_count = (VBO_COUNT_MID_IDX() / 3);
-	for( int i=0; i<4; ++i ) {
-		tri_count += (VBO_COUNT_HI_EDGE() / 3);
-	}
-
-	// pre-allocate enough space
-	pl.reserve(tri_count);
-
-	return tri_count;
-}
-
 //static 
 void GeoPatchContext::GenerateIndices()
 {
@@ -109,7 +92,7 @@ void GeoPatchContext::GenerateIndices()
 
 void GeoPatchContext::Init() 
 {
-	frac = 1.0 / double(edgeLen-1);
+	frac = 1.0 / double(edgeLen-3);
 	numTris = 2*(edgeLen-1)*(edgeLen-1);
 
 	GenerateIndices();

--- a/src/GeoPatchContext.cpp
+++ b/src/GeoPatchContext.cpp
@@ -19,51 +19,22 @@
 int GeoPatchContext::edgeLen = 0;
 int GeoPatchContext::numTris = 0;
 double GeoPatchContext::frac = 0.0;
-std::unique_ptr<unsigned short[]> GeoPatchContext::midIndices;
-std::unique_ptr<unsigned short[]> GeoPatchContext::loEdgeIndices[4];
-std::unique_ptr<unsigned short[]> GeoPatchContext::hiEdgeIndices[4];
-RefCountedPtr<Graphics::IndexBuffer> GeoPatchContext::indices_list[NUM_INDEX_LISTS];
+RefCountedPtr<Graphics::IndexBuffer> GeoPatchContext::indices;
 int GeoPatchContext::prevEdgeLen = 0;
 
 void GeoPatchContext::Cleanup() {
-	midIndices.reset();
-	for (int i=0; i<4; i++) {
-		loEdgeIndices[i].reset();
-		hiEdgeIndices[i].reset();
-	}
 }
 
-int GeoPatchContext::GetIndices(std::vector<unsigned short> &pl, const unsigned int edge_hi_flags)
+int GeoPatchContext::GetIndices(std::vector<unsigned short> &pl)
 {
 	// calculate how many tri's there are
 	int tri_count = (VBO_COUNT_MID_IDX() / 3);
 	for( int i=0; i<4; ++i ) {
-		if( edge_hi_flags & (1 << i) ) {
-			tri_count += (VBO_COUNT_HI_EDGE() / 3);
-		} else {
-			tri_count += (VBO_COUNT_LO_EDGE() / 3);
-		}
+		tri_count += (VBO_COUNT_HI_EDGE() / 3);
 	}
 
 	// pre-allocate enough space
 	pl.reserve(tri_count);
-
-	// add all of the middle indices
-	for(int i=0; i<VBO_COUNT_MID_IDX(); ++i) {
-		pl.push_back(midIndices[i]);
-	}
-	// selectively add the HI or LO detail indices
-	for (int i=0; i<4; i++) {
-		if( edge_hi_flags & (1 << i) ) {
-			for(int j=0; j<VBO_COUNT_HI_EDGE(); ++j) {
-				pl.push_back(hiEdgeIndices[i][j]);
-			}
-		} else {
-			for(int j=0; j<VBO_COUNT_LO_EDGE(); ++j) {
-				pl.push_back(loEdgeIndices[i][j]);
-			}
-		}
-	}
 
 	return tri_count;
 }
@@ -76,173 +47,61 @@ void GeoPatchContext::GenerateIndices()
 
 	//
 	unsigned short *idx;
-	midIndices.reset(new unsigned short[VBO_COUNT_MID_IDX()]);
-	for (int i = 0; i<4; i++) {
-		loEdgeIndices[i].reset(new unsigned short[VBO_COUNT_LO_EDGE()]);
-		hiEdgeIndices[i].reset(new unsigned short[VBO_COUNT_HI_EDGE()]);
+	std::vector<unsigned short> pl_short;
+
+	int tri_count = 0;
+	{
+		// calculate how many tri's there are
+		tri_count = (VBO_COUNT_MID_IDX() / 3);
+		for (int i = 0; i<4; ++i) {
+			tri_count += (VBO_COUNT_HI_EDGE() / 3);
+		}
+
+		// pre-allocate enough space
+		pl_short.reserve(tri_count);
+
+		// add all of the middle indices
+		for (int i = 0; i<VBO_COUNT_MID_IDX(); ++i) {
+			pl_short.push_back(0);
+		}
+		// add the HI detail indices
+		for (int i = 0; i<4; i++) {
+			for (int j = 0; j<VBO_COUNT_HI_EDGE(); ++j) {
+				pl_short.push_back(0);
+			}
+		}
 	}
-	/* also want vtx indices for tris not touching edge of patch */
-	idx = midIndices.get();
-	for (int x = 1; x<edgeLen - 2; x++) {
-		for (int y = 1; y<edgeLen - 2; y++) {
+	// want vtx indices for tris
+	idx = &pl_short[0];
+	for (int x = 0; x<edgeLen - 1; x++) {
+		for (int y = 0; y<edgeLen - 1; y++) {
+			// 1st tri
 			idx[0] = x + edgeLen*y;
 			idx[1] = x + 1 + edgeLen*y;
 			idx[2] = x + edgeLen*(y + 1);
 			idx += 3;
 
+			// 2nd tri
 			idx[0] = x + 1 + edgeLen*y;
 			idx[1] = x + 1 + edgeLen*(y + 1);
 			idx[2] = x + edgeLen*(y + 1);
 			idx += 3;
 		}
 	}
-	{
-		for (int x = 1; x<edgeLen - 3; x += 2) {
-			// razor teeth near edge 0
-			idx[0] = x + edgeLen;
-			idx[1] = x + 1;
-			idx[2] = x + 1 + edgeLen;
-			idx += 3;
-			idx[0] = x + 1;
-			idx[1] = x + 2 + edgeLen;
-			idx[2] = x + 1 + edgeLen;
-			idx += 3;
-		}
-		for (int x = 1; x<edgeLen - 3; x += 2) {
-			// near edge 2
-			idx[0] = x + edgeLen*(edgeLen - 2);
-			idx[1] = x + 1 + edgeLen*(edgeLen - 2);
-			idx[2] = x + 1 + edgeLen*(edgeLen - 1);
-			idx += 3;
-			idx[0] = x + 1 + edgeLen*(edgeLen - 2);
-			idx[1] = x + 2 + edgeLen*(edgeLen - 2);
-			idx[2] = x + 1 + edgeLen*(edgeLen - 1);
-			idx += 3;
-		}
-		for (int y = 1; y<edgeLen - 3; y += 2) {
-			// near edge 1
-			idx[0] = edgeLen - 2 + y*edgeLen;
-			idx[1] = edgeLen - 1 + (y + 1)*edgeLen;
-			idx[2] = edgeLen - 2 + (y + 1)*edgeLen;
-			idx += 3;
-			idx[0] = edgeLen - 2 + (y + 1)*edgeLen;
-			idx[1] = edgeLen - 1 + (y + 1)*edgeLen;
-			idx[2] = edgeLen - 2 + (y + 2)*edgeLen;
-			idx += 3;
-		}
-		for (int y = 1; y<edgeLen - 3; y += 2) {
-			// near edge 3
-			idx[0] = 1 + y*edgeLen;
-			idx[1] = 1 + (y + 1)*edgeLen;
-			idx[2] = (y + 1)*edgeLen;
-			idx += 3;
-			idx[0] = 1 + (y + 1)*edgeLen;
-			idx[1] = 1 + (y + 2)*edgeLen;
-			idx[2] = (y + 1)*edgeLen;
-			idx += 3;
-		}
-	}
-	// full detail edge triangles
-	{
-		idx = hiEdgeIndices[0].get();
-		for (int x = 0; x<edgeLen - 1; x += 2) {
-			idx[0] = x; idx[1] = x + 1; idx[2] = x + 1 + edgeLen;
-			idx += 3;
-			idx[0] = x + 1; idx[1] = x + 2; idx[2] = x + 1 + edgeLen;
-			idx += 3;
-		}
-		idx = hiEdgeIndices[1].get();
-		for (int y = 0; y<edgeLen - 1; y += 2) {
-			idx[0] = edgeLen - 1 + y*edgeLen;
-			idx[1] = edgeLen - 1 + (y + 1)*edgeLen;
-			idx[2] = edgeLen - 2 + (y + 1)*edgeLen;
-			idx += 3;
-			idx[0] = edgeLen - 1 + (y + 1)*edgeLen;
-			idx[1] = edgeLen - 1 + (y + 2)*edgeLen;
-			idx[2] = edgeLen - 2 + (y + 1)*edgeLen;
-			idx += 3;
-		}
-		idx = hiEdgeIndices[2].get();
-		for (int x = 0; x<edgeLen - 1; x += 2) {
-			idx[0] = x + (edgeLen - 1)*edgeLen;
-			idx[1] = x + 1 + (edgeLen - 2)*edgeLen;
-			idx[2] = x + 1 + (edgeLen - 1)*edgeLen;
-			idx += 3;
-			idx[0] = x + 1 + (edgeLen - 2)*edgeLen;
-			idx[1] = x + 2 + (edgeLen - 1)*edgeLen;
-			idx[2] = x + 1 + (edgeLen - 1)*edgeLen;
-			idx += 3;
-		}
-		idx = hiEdgeIndices[3].get();
-		for (int y = 0; y<edgeLen - 1; y += 2) {
-			idx[0] = y*edgeLen;
-			idx[1] = 1 + (y + 1)*edgeLen;
-			idx[2] = (y + 1)*edgeLen;
-			idx += 3;
-			idx[0] = (y + 1)*edgeLen;
-			idx[1] = 1 + (y + 1)*edgeLen;
-			idx[2] = (y + 2)*edgeLen;
-			idx += 3;
-		}
-	}
-	// these edge indices are for patches with no
-	// neighbour of equal or greater detail -- they reduce
-	// their edge complexity by 1 division
-	{
-		idx = loEdgeIndices[0].get();
-		for (int x = 0; x<edgeLen - 2; x += 2) {
-			idx[0] = x;
-			idx[1] = x + 2;
-			idx[2] = x + 1 + edgeLen;
-			idx += 3;
-		}
-		idx = loEdgeIndices[1].get();
-		for (int y = 0; y<edgeLen - 2; y += 2) {
-			idx[0] = (edgeLen - 1) + y*edgeLen;
-			idx[1] = (edgeLen - 1) + (y + 2)*edgeLen;
-			idx[2] = (edgeLen - 2) + (y + 1)*edgeLen;
-			idx += 3;
-		}
-		idx = loEdgeIndices[2].get();
-		for (int x = 0; x<edgeLen - 2; x += 2) {
-			idx[0] = x + edgeLen*(edgeLen - 1);
-			idx[2] = x + 2 + edgeLen*(edgeLen - 1);
-			idx[1] = x + 1 + edgeLen*(edgeLen - 2);
-			idx += 3;
-		}
-		idx = loEdgeIndices[3].get();
-		for (int y = 0; y<edgeLen - 2; y += 2) {
-			idx[0] = y*edgeLen;
-			idx[2] = (y + 2)*edgeLen;
-			idx[1] = 1 + (y + 1)*edgeLen;
-			idx += 3;
-		}
-	}
 
-	// these will hold the optimised indices
-	std::vector<unsigned short> pl_short[NUM_INDEX_LISTS];
 	// populate the N indices lists from the arrays built during InitTerrainIndices()
 	// iterate over each index list and optimize it
-	for (unsigned int i = 0; i<NUM_INDEX_LISTS; ++i) {
-		const unsigned int tri_count = GetIndices(pl_short[i], i);
+	{
 		VertexCacheOptimizerUShort vco;
-		VertexCacheOptimizerUShort::Result res = vco.Optimize(&pl_short[i][0], tri_count);
+		VertexCacheOptimizerUShort::Result res = vco.Optimize(&pl_short[0], tri_count);
 		assert(0 == res);
 		//create buffer & copy
-		indices_list[i].Reset(Pi::renderer->CreateIndexBuffer(pl_short[i].size(), Graphics::BUFFER_USAGE_STATIC));
-		Uint16* idxPtr = indices_list[i]->Map(Graphics::BUFFER_MAP_WRITE);
-		for (Uint32 j = 0; j < pl_short[i].size(); j++) {
-			idxPtr[j] = pl_short[i][j];
+		indices.Reset(Pi::renderer->CreateIndexBuffer(pl_short.size(), Graphics::BUFFER_USAGE_STATIC));
+		Uint16* idxPtr = indices->Map(Graphics::BUFFER_MAP_WRITE);
+		for (Uint32 j = 0; j < pl_short.size(); j++) {
+			idxPtr[j] = pl_short[j];
 		}
-		indices_list[i]->Unmap();
-	}
-
-	if (midIndices) {
-		midIndices.reset();
-		for (int i = 0; i<4; i++) {
-			loEdgeIndices[i].reset();
-			hiEdgeIndices[i].reset();
-		}
+		indices->Unmap();
 	}
 
 	prevEdgeLen = edgeLen;

--- a/src/GeoPatchContext.h
+++ b/src/GeoPatchContext.h
@@ -41,7 +41,6 @@ private:
 	static RefCountedPtr<Graphics::IndexBuffer> indices;
 	static int prevEdgeLen;
 
-	static int GetIndices(std::vector<unsigned short> &pl);
 	static void GenerateIndices();
 
 public:
@@ -54,20 +53,14 @@ public:
 	};
 
 	GeoPatchContext(const int _edgeLen) {
-		edgeLen = _edgeLen;
+		edgeLen = _edgeLen + 2; // +2 for the skirt
 		Init();
-	}
-
-	~GeoPatchContext() {
-		Cleanup();
 	}
 
 	static void Refresh() {
-		Cleanup();
 		Init();
 	}
 
-	static void Cleanup();
 	static void Init();
 
 	static inline Graphics::IndexBuffer* GetIndexBuffer() { return indices.Get(); }

--- a/src/GeoPatchContext.h
+++ b/src/GeoPatchContext.h
@@ -16,9 +16,6 @@
 
 #include <deque>
 
-// hold the 16 possible terrain edge connections
-static const unsigned NUM_INDEX_LISTS = 16;
-
 // maximumpatch depth
 #define GEOPATCH_MAX_DEPTH  15 + (2*Pi::detail.fracmult) //15
 
@@ -34,7 +31,6 @@ private:
 
 	static double frac;
 
-	static inline int VBO_COUNT_LO_EDGE() { return 3*(edgeLen/2); }
 	static inline int VBO_COUNT_HI_EDGE() { return 3*(edgeLen-1); }
 	static inline int VBO_COUNT_MID_IDX() { return (4*3*(edgeLen-3)) + 2*(edgeLen-3)*(edgeLen-3)*3; }
 	//                                            ^^ serrated teeth bit  ^^^ square inner bit
@@ -42,13 +38,10 @@ private:
 	static inline int IDX_VBO_LO_OFFSET(const int i) { return i*sizeof(unsigned short)*3*(edgeLen/2); }
 	static inline int IDX_VBO_HI_OFFSET(const int i) { return (i*sizeof(unsigned short)*VBO_COUNT_HI_EDGE())+IDX_VBO_LO_OFFSET(4); }
 
-	static std::unique_ptr<unsigned short[]> midIndices;
-	static std::unique_ptr<unsigned short[]> loEdgeIndices[4];
-	static std::unique_ptr<unsigned short[]> hiEdgeIndices[4];
-	static RefCountedPtr<Graphics::IndexBuffer> indices_list[NUM_INDEX_LISTS];
+	static RefCountedPtr<Graphics::IndexBuffer> indices;
 	static int prevEdgeLen;
 
-	static int GetIndices(std::vector<unsigned short> &pl, const unsigned int edge_hi_flags);
+	static int GetIndices(std::vector<unsigned short> &pl);
 	static void GenerateIndices();
 
 public:
@@ -77,7 +70,7 @@ public:
 	static void Cleanup();
 	static void Init();
 
-	static inline Graphics::IndexBuffer* GetIndexBuffer(const Uint32 idx) { return indices_list[idx].Get(); }
+	static inline Graphics::IndexBuffer* GetIndexBuffer() { return indices.Get(); }
 
 	static inline int NUMVERTICES() { return edgeLen*edgeLen; }
 

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -183,7 +183,8 @@ void GeoSphere::Reset()
 #define GEOSPHERE_TYPE	(GetSystemBody()->type)
 
 GeoSphere::GeoSphere(const SystemBody *body) : BaseSphere(body),
-	m_hasTempCampos(false), m_tempCampos(0.0), m_initStage(eBuildFirstPatches), m_maxDepth(0)
+	m_hasTempCampos(false), m_tempCampos(0.0), m_tempFrustum(800, 600, 0.5, 1.0, 1000.0),
+	m_initStage(eBuildFirstPatches), m_maxDepth(0)
 {
 	print_info(body, m_terrain.Get());
 
@@ -353,7 +354,7 @@ void GeoSphere::Update()
 		if(m_hasTempCampos) {
 			ProcessSplitResults();
 			for (int i=0; i<NUM_PATCHES; i++) {
-				m_patches[i]->LODUpdate(m_tempCampos);
+				m_patches[i]->LODUpdate(m_tempCampos, m_tempFrustum);
 			}
 			ProcessQuadSplitRequests();
 		}
@@ -401,6 +402,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 	matrix4x4ftod(renderer->GetCurrentModelView(), modv);
 	matrix4x4ftod(renderer->GetCurrentProjection(), proj);
 	Graphics::Frustum frustum( modv, proj );
+	m_tempFrustum = frustum;
 
 	// no frustum test of entire geosphere, since Space::Render does this
 	// for each body using its GetBoundingRadius() value

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -304,11 +304,6 @@ void GeoSphere::BuildFirstPatches()
 	m_patches[3].reset(new GeoPatch(s_patchContext, this, p2, p1, p5, p6, 0, (3ULL << maxShiftDepth)));
 	m_patches[4].reset(new GeoPatch(s_patchContext, this, p3, p2, p6, p7, 0, (4ULL << maxShiftDepth)));
 	m_patches[5].reset(new GeoPatch(s_patchContext, this, p8, p7, p6, p5, 0, (5ULL << maxShiftDepth)));
-	for (int i=0; i<NUM_PATCHES; i++) {
-		for (int j=0; j<4; j++) {
-			m_patches[i]->SetEdgeFriend(j, m_patches[geo_sphere_edge_friends[i][j]].get());
-		}
-	}
 
 	for (int i=0; i<NUM_PATCHES; i++) {
 		m_patches[i]->RequestSinglePatch();

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -94,6 +94,7 @@ private:
 
 	bool m_hasTempCampos;
 	vector3d m_tempCampos;
+	Graphics::Frustum m_tempFrustum;
 
 	static RefCountedPtr<GeoPatchContext> s_patchContext;
 


### PR DESCRIPTION
To avoid costly checking and maintenance of the state of neighbouring GeoPatches I have removed that information from them. This means that each patch only knows about it's parents and it's children.

This simplifies the creation of the GeoPatchContext indices but makes filling each patches vertexbuffer a little more complex. It can probably all be simplified further in the future.

- [x] Gather terrain generation requests before dispatch
- [x] Sort requests by distance, prioritise closest
- [x] Add clip test to generation request, ignore invisible patches

NB: Just realised that it already adds them to a queue and sorts them by distance, and who wrote that? ... I did!