### PR TITLE
Make DetailLevel a class and initial all members by default.

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -124,7 +124,7 @@ bool Pi::doProfileOne = false;
 int Pi::statSceneTris = 0;
 int Pi::statNumPatches = 0;
 GameConfig *Pi::config;
-struct DetailLevel Pi::detail = { 0, 0 };
+DetailLevel Pi::detail;
 bool Pi::joystickEnabled;
 bool Pi::mouseYInvert;
 bool Pi::compactScanner;

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -41,7 +41,9 @@ namespace UI { class Context; }
 class ObjectViewerView;
 #endif
 
-struct DetailLevel {
+class DetailLevel {
+public:
+	DetailLevel() : planets(0), textures(0), fracmult(0), cities(0) {}
 	int planets;
 	int textures;
 	int fracmult;
@@ -165,7 +167,7 @@ public:
 
 	static Game *game;
 
-	static struct DetailLevel detail;
+	static DetailLevel detail;
 	static GameConfig *config;
 
 	static JobQueue *GetAsyncJobQueue() { return asyncJobQueue.get();}


### PR DESCRIPTION
Whilst investigating #3574 I noticed that the DetailLevel struct was not being fully initialised so I've changed it too a class and fully initialise all members to `0` within the default constructor.