### PR TITLE
Improve the error message when a save game cannot be opened

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -433,7 +433,7 @@
    },
    "GAME_LOAD_CANNOT_OPEN" : {
       "description" : "",
-      "message" : "This saved game file could not be opened due to permissions or something..."
+      "message" : "Save file '%filename' could not be found (or the game does not have access to open it)."
    },
    "GAME_LOAD_CORRUPT" : {
       "description" : "",

--- a/src/LuaGame.cpp
+++ b/src/LuaGame.cpp
@@ -103,7 +103,9 @@ static int l_game_load_game(lua_State *l)
 		luaL_error(l, Lang::GAME_LOAD_WRONG_VERSION);
 	}
 	catch (CouldNotOpenFileException) {
-		luaL_error(l, Lang::GAME_LOAD_CANNOT_OPEN);
+		const std::string msg = stringf(Lang::GAME_LOAD_CANNOT_OPEN,
+			formatarg("filename", filename));
+		luaL_error(l, msg.c_str());
 	}
 
 	return 0;


### PR DESCRIPTION
Make the GAME_LOAD_CANNOT_OPEN error message more useful. The error message mentions permissions, but 99.99% of times the problem is that the requested file doesn't exist.

For #3576.