### PR TITLE
Convert geometry to use 32-bit indices

### DIFF
--- a/contrib/vcacheopt/vcacheopt.h
+++ b/contrib/vcacheopt/vcacheopt.h
@@ -67,6 +67,7 @@ public:
 	}
 };
 typedef TVertexCacheData<int, INT_MAX >					VertexCacheDataInt;
+typedef TVertexCacheData<unsigned int, UINT_MAX >		VertexCacheDataUInt;
 typedef TVertexCacheData<unsigned short, USHRT_MAX >	VertexCacheDataUShort;
 
 template <typename T, int ERR_VAL>
@@ -83,6 +84,7 @@ public:
 	}
 };
 typedef TTriangleCacheData<int, INT_MAX >				TriangleCacheDataInt;
+typedef TTriangleCacheData<unsigned int, UINT_MAX >		TriangleCacheDataUInt;
 typedef TTriangleCacheData<unsigned short, USHRT_MAX >	TriangleCacheDataUShort;
 
 template <typename T, int N, int ERR_VAL>
@@ -166,6 +168,7 @@ public:
 	}
 };
 typedef TVertexCache<int, 40, INT_MAX >					VertexCacheInt;
+typedef TVertexCache<unsigned int, 40, UINT_MAX >		VertexCacheUInt;
 typedef TVertexCache<unsigned short, 40, USHRT_MAX >	VertexCacheUShort;
 
 template <typename T, int N, int ERR_VAL>
@@ -478,7 +481,7 @@ public:
 	Result Optimize(T *inds, int tri_count)
 	{
 		// find vertex count
-		int max_vert = -1;
+		Sint64 max_vert = -1;
 		for (int i=0; i<tri_count * 3; i++)	{
 			if (inds[i] > max_vert) max_vert = inds[i];
 		}
@@ -502,6 +505,7 @@ public:
 	}
 };
 typedef TVertexCacheOptimizer<int, 40, INT_MAX >				VertexCacheOptimizerInt;
+typedef TVertexCacheOptimizer<unsigned int, 40, UINT_MAX >		VertexCacheOptimizerUInt;
 typedef TVertexCacheOptimizer<unsigned short, 40, USHRT_MAX >	VertexCacheOptimizerUShort;
 
 #endif // ndef _VCACHEOPT_H_

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -188,7 +188,7 @@ public:
 
 	double frac;
 
-	std::unique_ptr<unsigned short[]> indices;
+	std::unique_ptr<Uint32[]> indices;
 	RefCountedPtr<Graphics::IndexBuffer> indexBuffer;
 
 	GasPatchContext(const int _edgeLen) : edgeLen(_edgeLen) {
@@ -208,7 +208,7 @@ public:
 		indices.reset();
 	}
 
-	int GetIndices(std::vector<unsigned short> &pl)
+	int GetIndices(std::vector<Uint32> &pl)
 	{
 		// calculate how many tri's there are
 		const int tri_count = IDX_VBO_COUNT_ALL_IDX()/3;
@@ -229,8 +229,8 @@ public:
 		frac = 1.0 / double(edgeLen-1);
 
 		// also want vtx indices for tris not touching edge of patch 
-		indices.reset(new unsigned short[IDX_VBO_COUNT_ALL_IDX()]);
-		unsigned short *idx = indices.get();
+		indices.reset(new Uint32[IDX_VBO_COUNT_ALL_IDX()]);
+		Uint32 *idx = indices.get();
 		for (int x=0; x<edgeLen-1; x++) {
 			for (int y=0; y<edgeLen-1; y++) {
 				idx[0] = x + edgeLen*y;
@@ -246,18 +246,18 @@ public:
 		}
 
 		// these will hold the optimised indices
-		std::vector<unsigned short> pl_short;
+		std::vector<Uint32> pl_short;
 
 		// populate the N indices lists from the arrays built during InitTerrainIndices()
 		// iterate over each index list and optimize it
-		unsigned int tri_count = GetIndices(pl_short);
-		VertexCacheOptimizerUShort vco;
-		VertexCacheOptimizerUShort::Result res = vco.Optimize(&pl_short[0], tri_count);
+		Uint32 tri_count = GetIndices(pl_short);
+		VertexCacheOptimizerUInt vco;
+		VertexCacheOptimizerUInt::Result res = vco.Optimize(&pl_short[0], tri_count);
 		assert(0 == res);
 
 		//create buffer & copy
 		indexBuffer.Reset(Pi::renderer->CreateIndexBuffer(pl_short.size(), Graphics::BUFFER_USAGE_STATIC));
-		Uint16* idxPtr = indexBuffer->Map(Graphics::BUFFER_MAP_WRITE);
+		Uint32* idxPtr = indexBuffer->Map(Graphics::BUFFER_MAP_WRITE);
 		for (Uint32 j = 0; j < pl_short.size(); j++) {
 			idxPtr[j] = pl_short[j];
 		}

--- a/src/GeoPatchContext.cpp
+++ b/src/GeoPatchContext.cpp
@@ -29,8 +29,8 @@ void GeoPatchContext::GenerateIndices()
 		return;
 
 	//
-	unsigned short *idx;
-	std::vector<unsigned short> pl_short;
+	Uint32 *idx;
+	std::vector<Uint32> pl_short;
 
 	int tri_count = 0;
 	{
@@ -75,12 +75,12 @@ void GeoPatchContext::GenerateIndices()
 	// populate the N indices lists from the arrays built during InitTerrainIndices()
 	// iterate over each index list and optimize it
 	{
-		VertexCacheOptimizerUShort vco;
-		VertexCacheOptimizerUShort::Result res = vco.Optimize(&pl_short[0], tri_count);
+		VertexCacheOptimizerUInt vco;
+		VertexCacheOptimizerUInt::Result res = vco.Optimize(&pl_short[0], tri_count);
 		assert(0 == res);
 		//create buffer & copy
 		indices.Reset(Pi::renderer->CreateIndexBuffer(pl_short.size(), Graphics::BUFFER_USAGE_STATIC));
-		Uint16* idxPtr = indices->Map(Graphics::BUFFER_MAP_WRITE);
+		Uint32* idxPtr = indices->Map(Graphics::BUFFER_MAP_WRITE);
 		for (Uint32 j = 0; j < pl_short.size(); j++) {
 			idxPtr[j] = pl_short[j];
 		}

--- a/src/GeoPatchContext.h
+++ b/src/GeoPatchContext.h
@@ -35,8 +35,8 @@ private:
 	static inline int VBO_COUNT_MID_IDX() { return (4*3*(edgeLen-3)) + 2*(edgeLen-3)*(edgeLen-3)*3; }
 	//                                            ^^ serrated teeth bit  ^^^ square inner bit
 
-	static inline int IDX_VBO_LO_OFFSET(const int i) { return i*sizeof(unsigned short)*3*(edgeLen/2); }
-	static inline int IDX_VBO_HI_OFFSET(const int i) { return (i*sizeof(unsigned short)*VBO_COUNT_HI_EDGE())+IDX_VBO_LO_OFFSET(4); }
+	static inline int IDX_VBO_LO_OFFSET(const int i) { return i*sizeof(Uint32)*3*(edgeLen/2); }
+	static inline int IDX_VBO_HI_OFFSET(const int i) { return (i*sizeof(Uint32)*VBO_COUNT_HI_EDGE())+IDX_VBO_LO_OFFSET(4); }
 
 	static RefCountedPtr<Graphics::IndexBuffer> indices;
 	static int prevEdgeLen;

--- a/src/SpeedLines.cpp
+++ b/src/SpeedLines.cpp
@@ -76,7 +76,7 @@ void SpeedLines::Update(float time)
 	if (d > MAX_VEL)
 		vel = m_dir * MAX_VEL;
 
-	for (Uint16 i = 0; i < m_points.size(); i++) {
+	for (size_t i = 0; i < m_points.size(); i++) {
 
 		vector3f &pt = m_points[i];
 

--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -6,13 +6,13 @@
 #include "BVHTree.h"
 #include "Weld.h"
 
-static const unsigned int IGNORE_FLAG = 0x8000;
+static const Uint32 IGNORE_FLAG = 0x8000;
 
 GeomTree::~GeomTree()
 {
 }
 
-GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vector3f> &vertices, const Uint16 *indices, const unsigned int *triflags)
+GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vector3f> &vertices, const Uint32 *indices, const Uint32 *triflags)
 : m_numVertices(numVerts)
 , m_numTris(numTris)
 , m_vertices(vertices)
@@ -75,7 +75,7 @@ GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vect
 	m_radius = 0;
 	for (int i=0; i<numTris; i++)
 	{
-		const unsigned int triflag = m_triFlags[i];
+		const Uint32 triflag = m_triFlags[i];
 		if (triflag < IGNORE_FLAG)
 		{
 			const int vi1 = m_indices[3*i+0];
@@ -103,7 +103,7 @@ GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vect
 
 	{
 		Aabb *aabbs = new Aabb[activeTris.size()];
-		for (unsigned int i = 0; i < activeTris.size(); i++)
+		for (Uint32 i = 0; i < activeTris.size(); i++)
 		{
 			const vector3d v1 = vector3d(m_vertices[m_indices[activeTris[i] + 0]]);
 			const vector3d v2 = vector3d(m_vertices[m_indices[activeTris[i] + 1]]);
@@ -190,7 +190,7 @@ GeomTree::GeomTree(Serializer::Reader &rd)
 	const int numIndicies(m_numTris * 3);
 	m_indices.resize(numIndicies);
 	for (Sint32 iIndi = 0; iIndi < numIndicies; ++iIndi) {
-		m_indices[iIndi] = rd.Int16();
+		m_indices[iIndi] = rd.Int32();
 	}
 
 	m_triFlags.resize(m_numTris);
@@ -209,7 +209,7 @@ GeomTree::GeomTree(Serializer::Reader &rd)
 	}
 	// regenerate the aabb data
 	Aabb *aabbs = new Aabb[activeTris.size()];
-	for (unsigned int i = 0; i<activeTris.size(); i++)
+	for (Uint32 i = 0; i<activeTris.size(); i++)
 	{
 		const vector3d v1 = vector3d(m_vertices[m_indices[activeTris[i] + 0]]);
 		const vector3d v2 = vector3d(m_vertices[m_indices[activeTris[i] + 1]]);
@@ -396,7 +396,7 @@ void GeomTree::Save(Serializer::Writer &wr) const
 	}
 
 	for (Sint32 iIndi = 0; iIndi < (m_numTris * 3); ++iIndi) {
-		wr.Int16(m_indices[iIndi]);
+		wr.Int32(m_indices[iIndi]);
 	}
 
 	for (Sint32 iTri = 0; iTri < m_numTris; ++iTri) {

--- a/src/collider/GeomTree.h
+++ b/src/collider/GeomTree.h
@@ -19,7 +19,7 @@ struct BVHNode;
 
 class GeomTree {
 public:
-	GeomTree(const int numVerts, const int numTris, const std::vector<vector3f> &vertices, const Uint16 *indices, const unsigned int *triflags);
+	GeomTree(const int numVerts, const int numTris, const std::vector<vector3f> &vertices, const Uint32 *indices, const Uint32 *triflags);
 	GeomTree(Serializer::Reader &rd);
 	~GeomTree();
 
@@ -33,7 +33,7 @@ public:
 	//void TraceCoherentRays(int numRays, const vector3f &a_origin, const vector3f *a_dirs, isect_t *isects) const;
 	//void TraceCoherentRays(const BVHNode *startNode, int numRays, const vector3f &a_origin, const vector3f *a_dirs, isect_t *isects) const;
 	vector3f GetTriNormal(int triIdx) const;
-	unsigned int GetTriFlag(int triIdx) const { return m_triFlags[triIdx]; }
+	Uint32 GetTriFlag(int triIdx) const { return m_triFlags[triIdx]; }
 	double GetRadius() const { return m_radius; }
 	struct Edge {
 		int v1i, v2i;
@@ -67,8 +67,8 @@ public:
 	BVHTree* GetEdgeTree() const { return m_edgeTree.get(); }
 
 	const std::vector<vector3f>& GetVertices() const { return m_vertices; }
-	const Uint16 *GetIndices() const { return &m_indices[0]; }
-	const unsigned int *GetTriFlags() const { return &m_triFlags[0]; }
+	const Uint32 *GetIndices() const { return &m_indices[0]; }
+	const Uint32 *GetTriFlags() const { return &m_triFlags[0]; }
 	int GetNumVertices() const { return m_numVertices; }
 	int GetNumTris() const { return m_numTris; }
 
@@ -91,8 +91,8 @@ private:
 	std::vector<Edge> m_edges;
 
 	std::vector<vector3f> m_vertices;
-	std::vector<Uint16> m_indices;
-	std::vector<unsigned int> m_triFlags;
+	std::vector<Uint32> m_indices;
+	std::vector<Uint32> m_triFlags;
 };
 
 #endif /* _GEOMTREE_H */

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -535,7 +535,7 @@ Sphere3D::Sphere3D(Renderer *renderer, RefCountedPtr<Material> mat, Graphics::Re
 	//m_surface.reset(new Surface(TRIANGLES, new VertexArray(ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0), mat));
 	//reserve some data
 	VertexArray vts(ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0, 256);
-	std::vector<Uint16> indices;
+	std::vector<Uint32> indices;
 
 	//initial vertices
 	int vi[12];
@@ -569,7 +569,7 @@ Sphere3D::Sphere3D(Renderer *renderer, RefCountedPtr<Material> mat, Graphics::Re
 	m_vertexBuffer->Populate(vts);
 
 	m_indexBuffer.reset(renderer->CreateIndexBuffer(indices.size(), BUFFER_USAGE_STATIC));
-	Uint16 *idxPtr = m_indexBuffer->Map(Graphics::BUFFER_MAP_WRITE);
+	Uint32 *idxPtr = m_indexBuffer->Map(Graphics::BUFFER_MAP_WRITE);
 	for (auto it : indices) {
 		*idxPtr = it;
 		idxPtr++;
@@ -593,7 +593,7 @@ int Sphere3D::AddVertex(VertexArray &vts, const vector3f &v, const vector3f &n)
 	return vts.GetNumVerts() - 1;
 }
 
-void Sphere3D::AddTriangle(std::vector<Uint16> &indices, int i1, int i2, int i3)
+void Sphere3D::AddTriangle(std::vector<Uint32> &indices, int i1, int i2, int i3)
 {
 	PROFILE_SCOPED()
 	indices.push_back(i1);
@@ -601,7 +601,7 @@ void Sphere3D::AddTriangle(std::vector<Uint16> &indices, int i1, int i2, int i3)
 	indices.push_back(i3);
 }
 
-void Sphere3D::Subdivide(VertexArray &vts, std::vector<Uint16> &indices,
+void Sphere3D::Subdivide(VertexArray &vts, std::vector<Uint32> &indices,
 		const matrix4x4f &trans, const vector3f &v1, const vector3f &v2, const vector3f &v3,
 		const int i1, const int i2, const int i3, int depth)
 {

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -143,8 +143,8 @@ private:
 	//add a new vertex, return the index
 	int AddVertex(VertexArray&, const vector3f &v, const vector3f &n);
 	//add three vertex indices to form a triangle
-	void AddTriangle(std::vector<Uint16>&, int i1, int i2, int i3);
-	void Subdivide(VertexArray&, std::vector<Uint16>&,
+	void AddTriangle(std::vector<Uint32>&, int i1, int i2, int i3);
+	void Subdivide(VertexArray&, std::vector<Uint32>&,
 		const matrix4x4f &trans, const vector3f &v1, const vector3f &v2, const vector3f &v3,
 		int i1, int i2, int i3, int depth);
 };

--- a/src/graphics/VertexBuffer.h
+++ b/src/graphics/VertexBuffer.h
@@ -94,12 +94,12 @@ protected:
 	Uint32 m_numVertices;
 };
 
-// Index buffer, limited to Uint16 index format for better portability
+// Index buffer
 class IndexBuffer : public RefCounted, public Mappable {
 public:
 	IndexBuffer(Uint32 size, BufferUsage);
 	virtual ~IndexBuffer();
-	virtual Uint16 *Map(BufferMapMode) = 0;
+	virtual Uint32 *Map(BufferMapMode) = 0;
 
 	Uint32 GetSize() const { return m_size; }
 	Uint32 GetIndexCount() const { return m_indexCount; }

--- a/src/graphics/dummy/VertexBufferDummy.h
+++ b/src/graphics/dummy/VertexBufferDummy.h
@@ -34,10 +34,10 @@ private:
 class IndexBuffer : public Graphics::IndexBuffer {
 public:
 	IndexBuffer(Uint32 size, BufferUsage bu) : Graphics::IndexBuffer(size, bu),
-	m_buffer(new Uint16[size])
+	m_buffer(new Uint32[size])
 	{};
 
-	virtual Uint16 *Map(BufferMapMode) override { return m_buffer.get(); }
+	virtual Uint32 *Map(BufferMapMode) override { return m_buffer.get(); }
 
 	virtual void Unmap() override {}
 
@@ -45,7 +45,7 @@ public:
 	virtual void Release() {}
 
 private:
-    std::unique_ptr<Uint16[]> m_buffer;
+    std::unique_ptr<Uint32[]> m_buffer;
 };
 
 // Instance buffer

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -628,7 +628,7 @@ bool RendererOGL::DrawBufferIndexed(VertexBuffer *vb, IndexBuffer *ib, RenderSta
 
 	vb->Bind();
 	ib->Bind();
-	glDrawElements(pt, ib->GetIndexCount(), GL_UNSIGNED_SHORT, 0);
+	glDrawElements(pt, ib->GetIndexCount(), GL_UNSIGNED_INT, 0);
 	ib->Release();
 	vb->Release();
 	CheckRenderErrors();
@@ -669,7 +669,7 @@ bool RendererOGL::DrawBufferIndexedInstanced(VertexBuffer *vb, IndexBuffer *ib, 
 	vb->Bind();
 	ib->Bind();
 	instb->Bind();
-	glDrawElementsInstanced(pt, ib->GetIndexCount(), GL_UNSIGNED_SHORT, 0, instb->GetInstanceCount());
+	glDrawElementsInstanced(pt, ib->GetIndexCount(), GL_UNSIGNED_INT, 0, instb->GetInstanceCount());
 	instb->Release();
 	ib->Release();
 	vb->Release();

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -318,9 +318,9 @@ IndexBuffer::IndexBuffer(Uint32 size, BufferUsage hint)
 	const GLenum usage = (hint == BUFFER_USAGE_STATIC) ? GL_STATIC_DRAW : GL_DYNAMIC_DRAW;
 	glGenBuffers(1, &m_buffer);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_buffer);
-	m_data = new Uint16[size];
-	memset(m_data, 0, sizeof(Uint16) * size);
-	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(Uint16) * m_size, m_data, usage);
+	m_data = new Uint32[size];
+	memset(m_data, 0, sizeof(Uint32) * size);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(Uint32) * m_size, m_data, usage);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
 	//Don't keep client data around for static buffers
@@ -336,7 +336,7 @@ IndexBuffer::~IndexBuffer()
 	delete[] m_data;
 }
 
-Uint16 *IndexBuffer::Map(BufferMapMode mode)
+Uint32 *IndexBuffer::Map(BufferMapMode mode)
 {
 	assert(mode != BUFFER_MAP_NONE); //makes no sense
 	assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
@@ -344,9 +344,9 @@ Uint16 *IndexBuffer::Map(BufferMapMode mode)
 	if (GetUsage() == BUFFER_USAGE_STATIC) {
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_buffer);
 		if (mode == BUFFER_MAP_READ)
-			return reinterpret_cast<Uint16*>(glMapBuffer(GL_ELEMENT_ARRAY_BUFFER, GL_READ_ONLY));
+			return reinterpret_cast<Uint32*>(glMapBuffer(GL_ELEMENT_ARRAY_BUFFER, GL_READ_ONLY));
 		else if (mode == BUFFER_MAP_WRITE)
-			return reinterpret_cast<Uint16*>(glMapBuffer(GL_ELEMENT_ARRAY_BUFFER, GL_WRITE_ONLY));
+			return reinterpret_cast<Uint32*>(glMapBuffer(GL_ELEMENT_ARRAY_BUFFER, GL_WRITE_ONLY));
 	}
 
 	return m_data;
@@ -362,7 +362,7 @@ void IndexBuffer::Unmap()
 	} else {
 		if (m_mapMode == BUFFER_MAP_WRITE) {
 			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_buffer);
-			glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(Uint16) * m_size, m_data);
+			glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(Uint32) * m_size, m_data);
 			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 		}
 	}

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -42,14 +42,14 @@ public:
 	IndexBuffer(Uint32 size, BufferUsage);
 	~IndexBuffer();
 
-	virtual Uint16 *Map(BufferMapMode) override;
+	virtual Uint32 *Map(BufferMapMode) override;
 	virtual void Unmap() override;
 	
 	virtual void Bind() override;
 	virtual void Release() override;
 
 private:
-	Uint16 *m_data;
+	Uint32 *m_data;
 };
 
 // Instance buffer

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -149,7 +149,7 @@ namespace Theme {
 	/* 6 */	vector3f(size[0]-BORDER_WIDTH,size[1]-BORDER_WIDTH,0),
 	/* 7 */	vector3f(size[0]-BORDER_WIDTH,BORDER_WIDTH,0)
 		};
-		const Uint16 indices[] = {
+		const Uint32 indices[] = {
 			0,1,5, 0,5,4, 0,4,7, 0,7,3,
 			3,7,6, 3,6,2, 1,2,6, 1,6,5 };
 
@@ -174,7 +174,7 @@ namespace Theme {
 		//create index buffer & copy
 		std::unique_ptr<Graphics::IndexBuffer> ib;
 		ib.reset(Screen::GetRenderer()->CreateIndexBuffer(24, Graphics::BUFFER_USAGE_STATIC));
-		Uint16* idxPtr = ib->Map(Graphics::BUFFER_MAP_WRITE);
+		Uint32* idxPtr = ib->Map(Graphics::BUFFER_MAP_WRITE);
 		for (Uint32 j = 0; j < 24; j++) {
 			idxPtr[j] = indices[j];
 		}
@@ -184,10 +184,10 @@ namespace Theme {
 		Screen::GetRenderer()->DrawBufferIndexed(vb.get(), ib.get(), state, Screen::flatColorMaterial);
 	}
 
-	Graphics::IndexBuffer* CreateIndexBuffer(const Uint16 indices[], const Uint32 IndexStart, const Uint32 IndexEnd, const Uint32 NumIndices)
+	Graphics::IndexBuffer* CreateIndexBuffer(const Uint32 indices[], const Uint32 IndexStart, const Uint32 IndexEnd, const Uint32 NumIndices)
 	{
 		Graphics::IndexBuffer *ib = Screen::GetRenderer()->CreateIndexBuffer(NumIndices, Graphics::BUFFER_USAGE_STATIC);
-		Uint16* idxPtr = ib->Map(Graphics::BUFFER_MAP_WRITE);
+		Uint32* idxPtr = ib->Map(Graphics::BUFFER_MAP_WRITE);
 		for (Uint32 j = 0; j < NumIndices; j++) {
 			idxPtr[j] = indices[j + IndexStart];
 		}
@@ -234,7 +234,7 @@ namespace Theme {
 				/* 6 */	vector3f(size[0] - BORDER_WIDTH, size[1] - BORDER_WIDTH, 0),
 				/* 7 */	vector3f(size[0] - BORDER_WIDTH, BORDER_WIDTH, 0)
 			};
-			const Uint16 indices[] = {
+			const Uint32 indices[] = {
 				0, 1, 5, 0, 5, 4, 0, 4, 7, 0, 7, 3,
 				3, 7, 6, 3, 6, 2, 1, 2, 6, 1, 6, 5,
 				4, 5, 6, 4, 6, 7 };
@@ -329,7 +329,7 @@ namespace Theme {
 				/* 6 */	vector3f(size[0] - BORDER_WIDTH, size[1] - BORDER_WIDTH, 0),
 				/* 7 */	vector3f(size[0] - BORDER_WIDTH, BORDER_WIDTH, 0)
 			};
-			const Uint16 indices[] = {
+			const Uint32 indices[] = {
 				0, 1, 5, 0, 5, 4, 0, 4, 7, 0, 7, 3,
 				3, 7, 6, 3, 6, 2, 1, 2, 6, 1, 6, 5,
 				4, 5, 6, 4, 6, 7 };

--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -18,7 +18,8 @@ using namespace SceneGraph;
 // 3: store processed collision mesh
 // 4: compressed SGM files and instancing support
 // 5: normal mapping
-const Uint32 SGM_VERSION = 5;
+// 6: 32-bit indicies
+const Uint32 SGM_VERSION = 6;
 union SGM_STRING_VALUE{
 	char name[4];
 	Uint32 value;

--- a/src/scenegraph/CollisionGeometry.cpp
+++ b/src/scenegraph/CollisionGeometry.cpp
@@ -8,7 +8,7 @@
 
 namespace SceneGraph {
 
-CollisionGeometry::CollisionGeometry(Graphics::Renderer *r, const std::vector<vector3f> &vts, const std::vector<unsigned short> &idx,
+CollisionGeometry::CollisionGeometry(Graphics::Renderer *r, const std::vector<vector3f> &vts, const std::vector<Uint32> &idx,
 	unsigned int geomflag)
 : Node(r)
 , m_triFlag(geomflag)
@@ -57,7 +57,7 @@ void CollisionGeometry::Save(NodeDatabase &db)
 		db.wr->Vector3f(pos);
     db.wr->Int32(m_indices.size());
     for (const auto idx : m_indices)
-		db.wr->Int16(idx);
+		db.wr->Int32(idx);
     db.wr->Int32(m_triFlag);
     db.wr->Bool(m_dynamic);
 }
@@ -65,7 +65,7 @@ void CollisionGeometry::Save(NodeDatabase &db)
 CollisionGeometry *CollisionGeometry::Load(NodeDatabase &db)
 {
 	std::vector<vector3f> pos;
-	std::vector<unsigned short> idx;
+	std::vector<Uint32> idx;
 	Serializer::Reader &rd = *db.rd;
 
 	Uint32 n = rd.Int32();
@@ -76,7 +76,7 @@ CollisionGeometry *CollisionGeometry::Load(NodeDatabase &db)
 	n = rd.Int32();
 	idx.reserve(n);
 	for (Uint32 i = 0; i < n; i++)
-		idx.push_back(rd.Int16());
+		idx.push_back(rd.Int32());
 
 	const Uint32 flag  = rd.Int32();
 	const bool dynamic = rd.Bool();
@@ -87,7 +87,7 @@ CollisionGeometry *CollisionGeometry::Load(NodeDatabase &db)
 	return cg;
 }
 
-void CollisionGeometry::CopyData(const std::vector<vector3f> &vts, const std::vector<unsigned short> &idx)
+void CollisionGeometry::CopyData(const std::vector<vector3f> &vts, const std::vector<Uint32> &idx)
 {
 	//copy vertices and indices from surface. Add flag for every three indices.
 	using std::vector;
@@ -95,7 +95,7 @@ void CollisionGeometry::CopyData(const std::vector<vector3f> &vts, const std::ve
 	for (vector<vector3f>::const_iterator it = vts.begin(); it != vts.end(); ++it)
 		m_vertices.push_back(*it);
 
-	for (vector<unsigned short>::const_iterator it = idx.begin(); it != idx.end(); ++it)
+	for (vector<Uint32>::const_iterator it = idx.begin(); it != idx.end(); ++it)
 		m_indices.push_back(*it);
 }
 }

--- a/src/scenegraph/CollisionGeometry.h
+++ b/src/scenegraph/CollisionGeometry.h
@@ -19,7 +19,7 @@ class Geom;
 namespace SceneGraph {
 class CollisionGeometry : public Node {
 public:
-	CollisionGeometry(Graphics::Renderer *r, const std::vector<vector3f>&, const std::vector<unsigned short>&, unsigned int flag);
+	CollisionGeometry(Graphics::Renderer *r, const std::vector<vector3f>&, const std::vector<Uint32>&, unsigned int flag);
 	CollisionGeometry(const CollisionGeometry&, NodeCopyCache *cache = 0);
 	virtual Node *Clone(NodeCopyCache *cache = 0);
 	virtual const char *GetTypeName() const { return "CollisionGeometry"; }
@@ -28,7 +28,7 @@ public:
 	static CollisionGeometry *Load(NodeDatabase&);
 
 	const std::vector<vector3f> &GetVertices() const { return m_vertices; }
-	const std::vector<Uint16> &GetIndices() const { return m_indices; }
+	const std::vector<Uint32> &GetIndices() const { return m_indices; }
 	unsigned int GetTriFlag() const { return m_triFlag; }
 
 	bool IsDynamic() const { return m_dynamic; }
@@ -45,9 +45,9 @@ protected:
 	~CollisionGeometry();
 
 private:
-	void CopyData(const std::vector<vector3f>&, const std::vector<unsigned short>&);
+	void CopyData(const std::vector<vector3f>&, const std::vector<Uint32>&);
 	std::vector<vector3f> m_vertices;
-	std::vector<Uint16> m_indices;
+	std::vector<Uint32> m_indices;
 	unsigned int m_triFlag; //only one per node
 	bool m_dynamic;
 

--- a/src/scenegraph/CollisionVisitor.cpp
+++ b/src/scenegraph/CollisionVisitor.cpp
@@ -59,7 +59,7 @@ void CollisionVisitor::ApplyCollisionGeometry(CollisionGeometry &cg)
 		m_collMesh->GetAabb().Update(pos.x, pos.y, pos.z);
 	}
 
-	for (vector<Uint16>::const_iterator it = cg.GetIndices().begin(); it != cg.GetIndices().end(); ++it)
+	for (vector<Uint32>::const_iterator it = cg.GetIndices().begin(); it != cg.GetIndices().end(); ++it)
 		m_indices.push_back(*it + idxOffset);
 
 	//at least some of the geoms should be default collision
@@ -78,7 +78,7 @@ void CollisionVisitor::ApplyDynamicCollisionGeometry(CollisionGeometry &cg)
 	const int numIndices = cg.GetIndices().size();
 	const int numTris = numIndices / 3;
 	std::vector<vector3f> vertices(numVertices);
-	Uint16 *indices = new Uint16[numIndices];
+	Uint32 *indices = new Uint32[numIndices];
 	unsigned int *triFlags = new unsigned int[numTris];
 
 	for (int i = 0; i < numVertices; i++)
@@ -106,7 +106,7 @@ void CollisionVisitor::ApplyDynamicCollisionGeometry(CollisionGeometry &cg)
 void CollisionVisitor::AabbToMesh(const Aabb &bb)
 {
 	std::vector<vector3f> &vts = m_vertices;
-	std::vector<Uint16> &ind = m_indices;
+	std::vector<Uint32> &ind = m_indices;
 	const int offs = vts.size();
 
 	const vector3f min(bb.min.x, bb.min.y, bb.min.z);
@@ -175,25 +175,24 @@ RefCountedPtr<CollMesh> CollisionVisitor::CreateCollisionMesh()
 
 	assert(m_collMesh->GetGeomTree() == 0);
 	assert(!m_vertices.empty() && !m_indices.empty());
-	assert(m_vertices.size() < 65536);
 
 	//duplicate data again for geomtree...
-	const int numVertices = m_vertices.size();
-	const int numIndices = m_indices.size();
-	const int numTris = numIndices / 3;
+	const size_t numVertices = m_vertices.size();
+	const size_t numIndices = m_indices.size();
+	const size_t numTris = numIndices / 3;
 	std::vector<vector3f> vertices(numVertices);
-	Uint16 *indices = new Uint16[numIndices];
-	unsigned int *triFlags = new unsigned int[numTris];
+	Uint32 *indices = new Uint32[numIndices];
+	Uint32 *triFlags = new Uint32[numTris];
 
 	m_totalTris += numTris;
 
-	for (int i = 0; i < numVertices; i++)
+	for (size_t i = 0; i < numVertices; i++)
 		vertices[i] = m_vertices[i];
 
-	for (int i = 0; i < numIndices; i++)
+	for (size_t i = 0; i < numIndices; i++)
 		indices[i] = m_indices[i];
 
-	for (int i = 0; i < numTris; i++)
+	for (size_t i = 0; i < numTris; i++)
 		triFlags[i] = m_flags[i];
 
 	//create geomtree

--- a/src/scenegraph/CollisionVisitor.h
+++ b/src/scenegraph/CollisionVisitor.h
@@ -39,10 +39,10 @@ private:
 
 	//temporary arrays for static geometry
 	std::vector<vector3f> m_vertices;
-	std::vector<Uint16> m_indices;
-	std::vector<unsigned int> m_flags;
+	std::vector<Uint32> m_indices;
+	std::vector<Uint32> m_flags;
 
-	unsigned int m_totalTris;
+	Uint32 m_totalTris;
 };
 }
 #endif

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -278,7 +278,7 @@ void Model::DrawCollisionMesh()
 	if( !m_collisionMeshVB.Valid() )
 	{
 		const std::vector<vector3f> &vertices = m_collMesh->GetGeomTree()->GetVertices();
-		const Uint16 *indices = m_collMesh->GetGeomTree()->GetIndices();
+		const Uint32 *indices = m_collMesh->GetGeomTree()->GetIndices();
 		const unsigned int *triFlags = m_collMesh->GetGeomTree()->GetTriFlags();
 		const unsigned int numIndices = m_collMesh->GetGeomTree()->GetNumTris() * 3;
 

--- a/src/scenegraph/StaticGeometry.cpp
+++ b/src/scenegraph/StaticGeometry.cpp
@@ -163,11 +163,11 @@ void StaticGeometry::Save(NodeDatabase &db)
 		mesh.vertexBuffer->Unmap();
 
 		//indices
-		const Uint16 *indexPtr = mesh.indexBuffer->Map(Graphics::BUFFER_MAP_READ);
+		const Uint32 *indexPtr = mesh.indexBuffer->Map(Graphics::BUFFER_MAP_READ);
 		const Uint32 numIndices = mesh.indexBuffer->GetSize();
 		db.wr->Int32(numIndices);
 		for (Uint32 i = 0; i < numIndices; i++)
-			db.wr->Int16(indexPtr[i]);
+			db.wr->Int32(indexPtr[i]);
 		mesh.indexBuffer->Unmap();
     }
 }
@@ -256,9 +256,9 @@ StaticGeometry *StaticGeometry::Load(NodeDatabase &db)
 		//index buffer
 		const Uint32 numIndices = db.rd->Int32();
 		RefCountedPtr<Graphics::IndexBuffer> idxBuffer(db.loader->GetRenderer()->CreateIndexBuffer(numIndices, Graphics::BUFFER_USAGE_STATIC));
-		Uint16 *idxPtr = idxBuffer->Map(BUFFER_MAP_WRITE);
+		Uint32 *idxPtr = idxBuffer->Map(BUFFER_MAP_WRITE);
 		for (Uint32 i = 0; i < numIndices; i++)
-			idxPtr[i] = db.rd->Int16();
+			idxPtr[i] = db.rd->Int32();
 		idxBuffer->Unmap();
 
 		sg->AddMesh(vtxBuffer, idxBuffer, material);


### PR DESCRIPTION
Currently we're limited to 65536 vertices in a models mesh due to using 16-bit indices.

This PR changes the rendering to use 32-bit (_unsigned_) indices which allows for many more vertices in a single mesh.

- [ ] test with a mesh that has that many vertices!!!

Andy