### PR TITLE
Anisotropic Texture Filtering

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -291,6 +291,10 @@
       "description" : "",
       "message" : "Employment"
    },
+   "ENABLE_ANISOTROPIC_FILTERING" : {
+      "description" : "Use Anisotropic Filtering",
+      "message" : "Anisotropic Filtering"
+   },
    "ENABLE_AUTOSAVE" : {
       "description" : "Allow the game to autosave when docking",
       "message" : "Enable Autosave"

--- a/data/ui/Settings.lua
+++ b/data/ui/Settings.lua
@@ -127,6 +127,10 @@ ui.templates.Settings = function (args)
 		local fullScreenCheckBox = optionCheckBox(
 			Engine.GetFullscreen, Engine.SetFullscreen,
 			l.FULL_SCREEN)
+			
+		local anisoCheckBox = optionCheckBox(
+			Engine.GetAnisoFiltering, Engine.SetAnisoFiltering,
+			l.ENABLE_ANISOTROPIC_FILTERING)
 
 		local starDensity = function (caption, getter, setter)
 			local initial_value = getter()
@@ -147,6 +151,7 @@ ui.templates.Settings = function (args)
 				aaDropDown,
 				fullScreenCheckBox,
 				vsyncCheckBox,
+				anisoCheckBox,
 			})))
 			:SetCell(1,0, ui:Margin(5, 'ALL', ui:VBox(5):PackEnd({
 				planetDetailDropDown,

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -45,6 +45,7 @@ GameConfig::GameConfig(const std::map<std::string,std::string> &override_)
 	map["HudTrails"] = "0";
 	map["EnableServerAgent"] = "0";
 	map["AmountOfBackgroundStars"] = "1.0";
+	map["UseAnisotropicFiltering"] = "0";
 
 #ifdef _WIN32
 	map["RedirectStdio"] = "1";

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -362,6 +362,22 @@ static int l_engine_set_cockpit_enabled(lua_State *l)
 	return 0;
 }
 
+static int l_engine_get_aniso_enabled(lua_State *l)
+{
+	lua_pushboolean(l, Pi::config->Int("UseAnisotropicFiltering") != 0);
+	return 1;
+}
+
+static int l_engine_set_aniso_enabled(lua_State *l)
+{
+	if (lua_isnone(l, 1))
+		return luaL_error(l, "SetAnisoEnabled takes one boolean argument");
+	const bool enabled = lua_toboolean(l, 1);
+	Pi::config->SetInt("UseAnisotropicFiltering", (enabled ? 1 : 0));
+	Pi::config->Save();
+	return 0;
+}
+
 static int l_engine_get_autosave_enabled(lua_State *l)
 {
 	lua_pushboolean(l, Pi::config->Int("EnableAutosave") != 0);
@@ -821,6 +837,9 @@ void LuaEngine::Register()
 
 		{ "GetCockpitEnabled", l_engine_get_cockpit_enabled },
 		{ "SetCockpitEnabled", l_engine_set_cockpit_enabled },
+
+		{ "GetAnisoFiltering", l_engine_get_aniso_enabled },
+		{ "SetAnisoFiltering", l_engine_set_aniso_enabled },
 
 		{ "GetAutosaveEnabled", l_engine_get_autosave_enabled },
 		{ "SetAutosaveEnabled", l_engine_set_autosave_enabled },

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -154,6 +154,7 @@ void ModelViewer::Run(const std::string &modelName)
 	videoSettings.requestedSamples = config->Int("AntiAliasingMode");
 	videoSettings.vsync = (config->Int("VSync") != 0);
 	videoSettings.useTextureCompression = (config->Int("UseTextureCompression") != 0);
+	videoSettings.useAnisotropicFiltering = (config->Int("UseAnisotropicFiltering") != 0);
 	videoSettings.iconFile = OS::GetIconFilename();
 	videoSettings.title = "Model viewer";
 	Graphics::Renderer *renderer = Graphics::Init(videoSettings);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -413,6 +413,7 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 	videoSettings.requestedSamples = config->Int("AntiAliasingMode");
 	videoSettings.vsync = (config->Int("VSync") != 0);
 	videoSettings.useTextureCompression = (config->Int("UseTextureCompression") != 0);
+	videoSettings.useAnisotropicFiltering = (config->Int("UseAnisotropicFiltering") != 0);
 	videoSettings.enableDebugMessages = (config->Int("EnableGLDebug") != 0);
 	videoSettings.iconFile = OS::GetIconFilename();
 	videoSettings.title = "Pioneer";

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -25,6 +25,7 @@ namespace Graphics {
 		bool fullscreen;
 		bool hidden;
 		bool useTextureCompression;
+		bool useAnisotropicFiltering;
 		bool enableDebugMessages;
 		int vsync;
 		int requestedSamples;

--- a/src/graphics/Texture.h
+++ b/src/graphics/Texture.h
@@ -50,15 +50,15 @@ struct TextureCubeData {
 class TextureDescriptor {
 public:
 	TextureDescriptor() :
-		format(TEXTURE_RGBA_8888), dataSize(1.0f), texSize(1.0f), sampleMode(LINEAR_CLAMP), generateMipmaps(false), allowCompression(true), numberOfMipMaps(0), type(TEXTURE_2D)
+		format(TEXTURE_RGBA_8888), dataSize(1.0f), texSize(1.0f), sampleMode(LINEAR_CLAMP), generateMipmaps(false), allowCompression(true), useAnisotropicFiltering(true), numberOfMipMaps(0), type(TEXTURE_2D)
 	{}
 
-	TextureDescriptor(TextureFormat _format, const vector2f &_dataSize, TextureSampleMode _sampleMode = LINEAR_CLAMP, bool _generateMipmaps = false, bool _allowCompression = true, unsigned int _numberOfMipMaps = 0, TextureType _textureType = TEXTURE_2D) :
-		format(_format), dataSize(_dataSize), texSize(1.0f), sampleMode(_sampleMode), generateMipmaps(_generateMipmaps), allowCompression(_allowCompression), numberOfMipMaps(_numberOfMipMaps), type(_textureType)
+	TextureDescriptor(TextureFormat _format, const vector2f &_dataSize, TextureSampleMode _sampleMode = LINEAR_CLAMP, bool _generateMipmaps = false, bool _allowCompression = true, bool _useAnisotropicFiltering = true, unsigned int _numberOfMipMaps = 0, TextureType _textureType = TEXTURE_2D) :
+		format(_format), dataSize(_dataSize), texSize(1.0f), sampleMode(_sampleMode), generateMipmaps(_generateMipmaps), allowCompression(_allowCompression), useAnisotropicFiltering(_useAnisotropicFiltering), numberOfMipMaps(_numberOfMipMaps), type(_textureType)
 	{}
 
-	TextureDescriptor(TextureFormat _format, const vector2f &_dataSize, const vector2f &_texSize, TextureSampleMode _sampleMode = LINEAR_CLAMP, bool _generateMipmaps = false, bool _allowCompression = true, unsigned int _numberOfMipMaps = 0, TextureType _textureType = TEXTURE_2D) :
-		format(_format), dataSize(_dataSize), texSize(_texSize), sampleMode(_sampleMode), generateMipmaps(_generateMipmaps), allowCompression(_allowCompression), numberOfMipMaps(_numberOfMipMaps), type(_textureType)
+	TextureDescriptor(TextureFormat _format, const vector2f &_dataSize, const vector2f &_texSize, TextureSampleMode _sampleMode = LINEAR_CLAMP, bool _generateMipmaps = false, bool _allowCompression = true, bool _useAnisotropicFiltering = true, unsigned int _numberOfMipMaps = 0, TextureType _textureType = TEXTURE_2D) :
+		format(_format), dataSize(_dataSize), texSize(_texSize), sampleMode(_sampleMode), generateMipmaps(_generateMipmaps), allowCompression(_allowCompression), useAnisotropicFiltering(_useAnisotropicFiltering), numberOfMipMaps(_numberOfMipMaps), type(_textureType)
 	{}
 
 	vector2f GetOriginalSize() const { return vector2f(dataSize.x * texSize.x, dataSize.y * texSize.y); }
@@ -69,6 +69,7 @@ public:
 	const TextureSampleMode sampleMode;
 	const bool generateMipmaps;
 	const bool allowCompression;
+	const bool useAnisotropicFiltering;
 	const unsigned int numberOfMipMaps;
 	const TextureType type;
 
@@ -79,6 +80,7 @@ public:
 		const_cast<TextureSampleMode&>(sampleMode) = o.sampleMode;
 		const_cast<bool&>(generateMipmaps) = o.generateMipmaps;
 		const_cast<bool&>(allowCompression) = o.allowCompression;
+		const_cast<bool&>(useAnisotropicFiltering) = o.useAnisotropicFiltering;
 		const_cast<unsigned int&>(numberOfMipMaps) = o.numberOfMipMaps;
 		const_cast<TextureType&>(type) = o.type;
 		return *this;

--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -12,13 +12,13 @@
 
 namespace Graphics {
 
-TextureBuilder::TextureBuilder(const SDLSurfacePtr &surface, TextureSampleMode sampleMode, bool generateMipmaps, bool potExtend, bool forceRGBA, bool compressTextures) :
-    m_surface(surface), m_sampleMode(sampleMode), m_generateMipmaps(generateMipmaps), m_potExtend(potExtend), m_forceRGBA(forceRGBA), m_compressTextures(compressTextures), m_textureType(TEXTURE_2D), m_prepared(false)
+TextureBuilder::TextureBuilder(const SDLSurfacePtr &surface, TextureSampleMode sampleMode, bool generateMipmaps, bool potExtend, bool forceRGBA, bool compressTextures, bool anisoFiltering) :
+    m_surface(surface), m_sampleMode(sampleMode), m_generateMipmaps(generateMipmaps), m_potExtend(potExtend), m_forceRGBA(forceRGBA), m_compressTextures(compressTextures), m_anisotropicFiltering(anisoFiltering), m_textureType(TEXTURE_2D), m_prepared(false)
 {
 }
 
-TextureBuilder::TextureBuilder(const std::string &filename, TextureSampleMode sampleMode, bool generateMipmaps, bool potExtend, bool forceRGBA, bool compressTextures, TextureType textureType) :
-    m_filename(filename), m_sampleMode(sampleMode), m_generateMipmaps(generateMipmaps), m_potExtend(potExtend), m_forceRGBA(forceRGBA), m_compressTextures(compressTextures), m_textureType(textureType), m_prepared(false)
+TextureBuilder::TextureBuilder(const std::string &filename, TextureSampleMode sampleMode, bool generateMipmaps, bool potExtend, bool forceRGBA, bool compressTextures, bool anisoFiltering, TextureType textureType) :
+    m_filename(filename), m_sampleMode(sampleMode), m_generateMipmaps(generateMipmaps), m_potExtend(potExtend), m_forceRGBA(forceRGBA), m_compressTextures(compressTextures), m_anisotropicFiltering(anisoFiltering), m_textureType(textureType), m_prepared(false)
 {
 }
 
@@ -181,7 +181,7 @@ void TextureBuilder::PrepareSurface()
 		targetTextureFormat,
 		vector2f(actualWidth,actualHeight),
 		vector2f(float(virtualWidth)/float(actualWidth),float(virtualHeight)/float(actualHeight)),
-		m_sampleMode, m_generateMipmaps, m_compressTextures, numberOfMipMaps, m_textureType);
+		m_sampleMode, m_generateMipmaps, m_compressTextures, m_anisotropicFiltering, numberOfMipMaps, m_textureType);
 
 	m_prepared = true;
 }

--- a/src/graphics/TextureBuilder.h
+++ b/src/graphics/TextureBuilder.h
@@ -16,25 +16,25 @@ namespace Graphics {
 
 class TextureBuilder {
 public:
-	TextureBuilder(const SDLSurfacePtr &surface, TextureSampleMode sampleMode = LINEAR_CLAMP, bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true);
-	TextureBuilder(const std::string &filename, TextureSampleMode sampleMode = LINEAR_CLAMP, bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true, TextureType textureType = TEXTURE_2D);
+	TextureBuilder(const SDLSurfacePtr &surface, TextureSampleMode sampleMode = LINEAR_CLAMP, bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true, bool anisoFiltering = true);
+	TextureBuilder(const std::string &filename, TextureSampleMode sampleMode = LINEAR_CLAMP, bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true, bool anisoFiltering = true, TextureType textureType = TEXTURE_2D);
 	~TextureBuilder();
 
 	// convenience constructors for common texture types
 	static TextureBuilder Model(const std::string &filename) {
-		return TextureBuilder(filename, LINEAR_REPEAT, true, false, false, true);
+		return TextureBuilder(filename, LINEAR_REPEAT, true, false, false, true, true);
 	}
 	static TextureBuilder Billboard(const std::string &filename) {
-		return TextureBuilder(filename, LINEAR_CLAMP, true, false, false, true);
+		return TextureBuilder(filename, LINEAR_CLAMP, true, false, false, true, false);
 	}
 	static TextureBuilder UI(const std::string &filename) {
-		return TextureBuilder(filename, LINEAR_CLAMP, false, true, true, false);
+		return TextureBuilder(filename, LINEAR_CLAMP, false, true, true, false, false);
 	}
 	static TextureBuilder Decal(const std::string &filename) {
-		return TextureBuilder(filename, LINEAR_CLAMP, true, true, false, true);
+		return TextureBuilder(filename, LINEAR_CLAMP, true, true, false, true, true);
 	}
 	static TextureBuilder Cube(const std::string &filename) {
-		return TextureBuilder(filename, LINEAR_CLAMP, true, true, false, true, TEXTURE_CUBE_MAP);
+		return TextureBuilder(filename, LINEAR_CLAMP, true, true, false, true, false, TEXTURE_CUBE_MAP);
 	}
 
 	const TextureDescriptor &GetDescriptor() { PrepareSurface(); return m_descriptor; }
@@ -72,6 +72,7 @@ private:
 	bool m_potExtend;
 	bool m_forceRGBA;
 	bool m_compressTextures;
+	bool m_anisotropicFiltering;
 	TextureType m_textureType;
 
 	TextureDescriptor m_descriptor;

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -84,6 +84,9 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 	const bool useDXTnTextures = vs.useTextureCompression;
 	m_useCompressedTextures = useDXTnTextures;
 
+	const bool useAnisotropicFiltering = vs.useAnisotropicFiltering;
+	m_useAnisotropicFiltering = useAnisotropicFiltering;
+
 	//XXX bunch of fixed function states here!
 	glCullFace(GL_BACK);
 	glFrontFace(GL_CCW);
@@ -789,7 +792,7 @@ OGL::Program* RendererOGL::GetOrCreateProgram(OGL::Material *mat)
 Texture *RendererOGL::CreateTexture(const TextureDescriptor &descriptor)
 {
 	CheckRenderErrors();
-	return new TextureGL(descriptor, m_useCompressedTextures);
+	return new TextureGL(descriptor, m_useCompressedTextures, m_useAnisotropicFiltering);
 }
 
 RenderState *RendererOGL::CreateRenderState(const RenderStateDesc &desc)
@@ -821,7 +824,7 @@ RenderTarget *RendererOGL::CreateRenderTarget(const RenderTargetDesc &desc)
 			LINEAR_CLAMP,
 			false,
 			false);
-		TextureGL *colorTex = new TextureGL(cdesc, false);
+		TextureGL *colorTex = new TextureGL(cdesc, false, false);
 		rt->SetColorTexture(colorTex);
 	}
 	if (desc.depthFormat != TEXTURE_NONE) {
@@ -833,7 +836,7 @@ RenderTarget *RendererOGL::CreateRenderTarget(const RenderTargetDesc &desc)
 				LINEAR_CLAMP,
 				false,
 				false);
-			TextureGL *depthTex = new TextureGL(ddesc, false);
+			TextureGL *depthTex = new TextureGL(ddesc, false, false);
 			rt->SetDepthTexture(depthTex);
 		} else {
 			rt->CreateDepthRenderbuffer();

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -130,6 +130,7 @@ protected:
 	float m_minZNear;
 	float m_maxZFar;
 	bool m_useCompressedTextures;
+	bool m_useAnisotropicFiltering;
 	
 	void SetMaterialShaderTransforms(Material *);
 

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -75,15 +75,14 @@ inline bool IsCompressed(TextureFormat format) {
 	return (format == TEXTURE_DXT1 || format == TEXTURE_DXT5);
 }
 
-TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompressed) :
-	Texture(descriptor)
+TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering) :
+	Texture(descriptor), m_useAnisoFiltering(useAnisoFiltering)
 {
 	m_target = GLTextureType(descriptor.type);
 
 	glGenTextures(1, &m_texture);
 	glBindTexture(m_target, m_texture);
 	RendererOGL::CheckErrors();
-
 
 	// useCompressed is the global scope flag whereas descriptor.allowCompression is the local texture mode flag
 	// either both or neither might be true however only compress the texture when both are true.
@@ -234,11 +233,13 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 	glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, minFilter);
 
 	// Anisotropic texture filtering
-	GLfloat maxAniso = 0.0f;
-	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
-	glTexParameterf(m_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
-	RendererOGL::CheckErrors();
+	if (m_useAnisoFiltering) {
+		GLfloat maxAniso = 0.0f;
+		glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
+		glTexParameterf(m_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
+	}
 
+	RendererOGL::CheckErrors();
 }
 
 TextureGL::~TextureGL()
@@ -376,7 +377,7 @@ void TextureGL::SetSampleMode(TextureSampleMode mode)
 
 		case NEAREST_REPEAT:
 			magFilter = GL_NEAREST;
-			minFilter =mipmaps ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST;
+			minFilter = mipmaps ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST;
 			break;
 	}
 	glBindTexture(m_target, m_texture);
@@ -384,9 +385,11 @@ void TextureGL::SetSampleMode(TextureSampleMode mode)
 	glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, minFilter);
 
 	// Anisotropic texture filtering
-	GLfloat maxAniso = 0.0f;
-	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
-	glTexParameterf(m_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
+	if (m_useAnisoFiltering) {
+		GLfloat maxAniso = 0.0f;
+		glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
+		glTexParameterf(m_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
+	}
 
 	glBindTexture(m_target, 0);
 }

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -232,6 +232,11 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 	glTexParameteri(m_target, GL_TEXTURE_WRAP_T, wrapS);
 	glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, magFilter);
 	glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, minFilter);
+
+	// Anisotropic texture filtering
+	GLfloat maxAniso = 0.0f;
+	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
+	glTexParameterf(m_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
 	RendererOGL::CheckErrors();
 
 }
@@ -377,6 +382,12 @@ void TextureGL::SetSampleMode(TextureSampleMode mode)
 	glBindTexture(m_target, m_texture);
 	glTexParameteri(m_target, GL_TEXTURE_MAG_FILTER, magFilter);
 	glTexParameteri(m_target, GL_TEXTURE_MIN_FILTER, minFilter);
+
+	// Anisotropic texture filtering
+	GLfloat maxAniso = 0.0f;
+	glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
+	glTexParameterf(m_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
+
 	glBindTexture(m_target, 0);
 }
 

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -76,7 +76,7 @@ inline bool IsCompressed(TextureFormat format) {
 }
 
 TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering) :
-	Texture(descriptor), m_useAnisoFiltering(useAnisoFiltering)
+	Texture(descriptor), m_useAnisoFiltering(useAnisoFiltering && descriptor.useAnisotropicFiltering)
 {
 	m_target = GLTextureType(descriptor.type);
 

--- a/src/graphics/opengl/TextureGL.h
+++ b/src/graphics/opengl/TextureGL.h
@@ -24,10 +24,11 @@ public:
 
 private:
 	friend class RendererOGL;
-	TextureGL(const TextureDescriptor &descriptor, const bool useCompressed);
+	TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering);
 
 	GLenum m_target;
 	GLuint m_texture;
+	const bool m_useAnisoFiltering;
 };
 
 }

--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -56,6 +56,7 @@ void SetupRenderer()
 	videoSettings.requestedSamples = s_config->Int("AntiAliasingMode");
 	videoSettings.vsync = false;
 	videoSettings.useTextureCompression = true;
+	videoSettings.useAnisotropicFiltering = true;
 	videoSettings.iconFile = OS::GetIconFilename();
 	videoSettings.title = "Model Compiler";
 	s_renderer.reset(Graphics::Init(videoSettings));


### PR DESCRIPTION
This adds (_optional_) [Anisotropic Texture Filtering](https://en.wikipedia.org/wiki/Anisotropic_filtering) so that our texture remain crisp and beautiful as the day our hardworking artists crafted them despite viewing them from shallow angles.

This is optional because on my little Linux test machine it reduces the framerate from __20 fps__ to __11 fps__ which some people may not enjoy.