### PR TITLE
TextureDescriptor usage updated

### DIFF
--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -420,7 +420,7 @@ bool GasGiant::AddTextureFaceResult(STextureFaceResult *res)
 		const Graphics::TextureDescriptor texDesc(
 			Graphics::TEXTURE_RGBA_8888, 
 			dataSize, texSize, Graphics::LINEAR_CLAMP, 
-			true, false, 0, Graphics::TEXTURE_CUBE_MAP);
+			true, false, false, 0, Graphics::TEXTURE_CUBE_MAP);
 		m_surfaceTexture.Reset(Pi::renderer->CreateTexture(texDesc));
 
 		// update with buffer from above
@@ -476,7 +476,7 @@ void GasGiant::GenerateTexture()
 		const Graphics::TextureDescriptor texDesc(
 			Graphics::TEXTURE_RGBA_8888, 
 			dataSize, texSize, Graphics::LINEAR_CLAMP, 
-			false, false, 0, Graphics::TEXTURE_CUBE_MAP);
+			false, false, false, 0, Graphics::TEXTURE_CUBE_MAP);
 		m_surfaceTextureSmall.Reset(Pi::renderer->CreateTexture(texDesc));
 
 		const Terrain *pTerrain = GetTerrain();

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -823,6 +823,7 @@ RenderTarget *RendererOGL::CreateRenderTarget(const RenderTargetDesc &desc)
 			vector2f(desc.width, desc.height),
 			LINEAR_CLAMP,
 			false,
+			false, 
 			false);
 		TextureGL *colorTex = new TextureGL(cdesc, false, false);
 		rt->SetColorTexture(colorTex);
@@ -834,6 +835,7 @@ RenderTarget *RendererOGL::CreateRenderTarget(const RenderTargetDesc &desc)
 				vector2f(desc.width, desc.height),
 				vector2f(desc.width, desc.height),
 				LINEAR_CLAMP,
+				false,
 				false,
 				false);
 			TextureGL *depthTex = new TextureGL(ddesc, false, false);

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -618,7 +618,7 @@ TextureFont::TextureFont(const FontConfig &config, Graphics::Renderer *renderer,
 	desc.vertexColors = true; //to allow per-character colors
 	desc.textures = 1;
 	m_mat.reset(m_renderer->CreateMaterial(desc));
-	Graphics::TextureDescriptor textureDescriptor(m_texFormat, vector2f(ATLAS_SIZE), Graphics::NEAREST_CLAMP, false, false);
+	Graphics::TextureDescriptor textureDescriptor(m_texFormat, vector2f(ATLAS_SIZE), Graphics::NEAREST_CLAMP, false, false, false);
 	m_texture.Reset(m_renderer->CreateTexture(textureDescriptor));
 	m_mat->texture0 = m_texture.Get();
 


### PR DESCRIPTION
TextureDescriptor usage updated to fix off-by-one initialisation problems caused by anisotropic filtering feature.

This should fix #3590