### PR TITLE
SGM graceful failure

### DIFF
--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -178,7 +178,7 @@ Model *BinaryConverter::Load(const std::string &shortname, const std::string &ba
 					if (pDecompressedData) {
 						// now parse in-memory representation as new ByteRange.
 						Serializer::Reader rd(ByteRange(static_cast<char*>(pDecompressedData), outSize));
-						model = CreateModel(rd);
+						model = CreateModel(name, rd);
 						mz_free(pDecompressedData);
 					}
 					return model;
@@ -191,16 +191,19 @@ Model *BinaryConverter::Load(const std::string &shortname, const std::string &ba
 	return nullptr;
 }
 
-Model *BinaryConverter::CreateModel(Serializer::Reader &rd)
+Model *BinaryConverter::CreateModel(const std::string& filename, Serializer::Reader &rd)
 {
 	//verify signature
 	const Uint32 sig = rd.Int32();
-	if (sig != SGM_STRING_ID.value) //'SGM#'
-		throw LoadingError("Not a binary model file");
+	if (sig != SGM_STRING_ID.value) { //'SGM#'
+		Warning("Error whilst loading %s\nSGM versioning (%u) did not match the supported SGM STRING ID (%u)\nSGM file will be ignored\n", filename.c_str(), sig, SGM_STRING_ID.value);
+		return nullptr;
+	}
 
 	const Uint32 version = rd.Int32();
 	if (version != SGM_VERSION)
-		throw LoadingError("Unsupported file version");
+		Warning("Error whilst loading %s\nSGM versioning (%u) did not match the supported SGM_VERSION (%u)\nSGM file will be ignored\n", filename.c_str(), version, SGM_VERSION);
+		return nullptr;
 
 	const std::string modelName = rd.String();
 

--- a/src/scenegraph/BinaryConverter.h
+++ b/src/scenegraph/BinaryConverter.h
@@ -35,7 +35,7 @@ public:
 	void RegisterLoader(const std::string &typeName, std::function<Node*(NodeDatabase&)>);
 
 private:
-	Model *CreateModel(Serializer::Reader&);
+	Model *CreateModel(const std::string& filename, Serializer::Reader&);
 	void SaveMaterials(Serializer::Writer&, Model* m);
 	void LoadMaterials(Serializer::Reader&);
 	void SaveAnimations(Serializer::Writer&, Model* m);

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -156,7 +156,10 @@ Model *Loader::LoadModel(const std::string &shortname, const std::string &basepa
 				//binary loader expects extension-less name. Might want to change this.
 				SceneGraph::BinaryConverter bc(m_renderer);
 				m_model = bc.Load(shortname);
-				return m_model;
+				if (m_model)
+					return m_model;
+				else
+					break; // we'll have to load the non-sgm file
 			}
 		}
 	}


### PR DESCRIPTION
Fail-back to the model definition files with a warning when we hit a bad SGM file instead of throwing an exception.

As we change the __SGM_VERSION__  we don't want to break mods and other things that can be simply updated or fixed. Especially when we have all the data we need to keep running in the original `.model`, `.dae` and other files present.

So instead of raising and exception we first try to fail-back and load the original data, only if that fails will we raise an exception.

Andy