### PR TITLE
Optional use of std::chrono for Profiler

### DIFF
--- a/contrib/profiler/Makefile.am
+++ b/contrib/profiler/Makefile.am
@@ -1,7 +1,7 @@
 #  Process this file with automake to produce Makefile.in
 include $(top_srcdir)/Makefile.common
 
-AM_CPPFLAGS += -I @top_srcdir@/contrib
+AM_CPPFLAGS += -I @top_srcdir@/contrib -std=c++11
 
 noinst_LIBRARIES = libprofiler.a
 libprofiler_a_SOURCES = Profiler.cpp

--- a/contrib/profiler/Profiler.h
+++ b/contrib/profiler/Profiler.h
@@ -10,6 +10,9 @@
 #undef noinline
 #undef fastcall
 
+//#define USE_CHRONO
+#include <chrono>
+
 #if defined(_MSC_VER)
 	#undef __PRETTY_FUNCTION__
 	#define __PRETTY_FUNCTION__ __FUNCSIG__
@@ -141,15 +144,6 @@ namespace Profiler {
 			calls += b.calls;
 		}
 
-		static inline u64 getticks_serial() {
-	#if defined(__GNUC__)
-			asm volatile("cpuid" : : : "%eax", "%ebx", "%ecx", "%edx" );
-	#else
-			__asm cpuid;
-	#endif
-			return getticks();			
-		}
-
 	#if defined(__GNUC__)
 		static inline u64 getticks() {
 			u32 __a,__d;
@@ -158,8 +152,10 @@ namespace Profiler {
 		}
 	#elif defined(__ICC) || defined(__ICL)
 		static inline u64 getticks() { return _rdtsc(); }
-	#else
+	#elif defined(_MSC_VER) && !defined(USE_CHRONO)
 		static inline u64 getticks() { __asm { rdtsc }; }
+	#else
+		static inline u64 getticks() { return std::chrono::high_resolution_clock::now().time_since_epoch().count(); }
 	#endif
 
 		u64 ticks, started;


### PR DESCRIPTION
The idea here is to make std::chrono available for use in the builtin, intrusive, Profiler we use within Pioneer.

This helps us to get rid of the x86 specific assembler code which makes 64-bit Pioneer easier for all platforms and it means we can build on non-x86 processors. In this case I've tested it by building for my Raspberry Pi 2 - __NB:__ don't get excited, `building` doesn't mean `working`- it's just one more obstacle removed from the road.

From my initial testing it seems that the way I'm using std::chrono might impose a tiny bit more overhead, and possible be a tiny bit less accurate. However all of the measurements are relative to one another and so the overall usability for profiling purposes seems to be unaffected.

Andy