### PR TITLE
Show the correct pattern on the ship info screen

### DIFF
--- a/data/ui/InfoView/ShipInfo.lua
+++ b/data/ui/InfoView/ShipInfo.lua
@@ -133,7 +133,7 @@ local shipInfo = function (args)
 							ui:Expand("HORIZONTAL", shipNameEntry),
 						})
 					}))
-					:PackEnd(ModelSpinner.New(ui, shipDef.modelName, Game.player:GetSkin()))
+					:PackEnd(ModelSpinner.New(ui, shipDef.modelName, Game.player:GetSkin(), Game.player.model.pattern))
 			})
 end
 


### PR DESCRIPTION
Sometimes the model spinner shows the wrong ship painting on the ship info screen. This should fix it.