### PR TITLE
Text rendering performance improvements

### DIFF
--- a/src/Color.h
+++ b/src/Color.h
@@ -59,6 +59,7 @@ struct Color4ub {
 	Color4ub operator/(const float f) const		{ return Color4ub(Uint8(r/f), Uint8(g/f), Uint8(b/f), Uint8(a/f)); }
 
 	friend bool operator==(const Color4ub& aIn, const Color4ub& bIn) { return ((aIn.r == bIn.r) && (aIn.g == bIn.g) && (aIn.b == bIn.b) && (aIn.a == bIn.a)); }
+	friend bool operator!=(const Color4ub& aIn, const Color4ub& bIn) { return ((aIn.r != bIn.r) || (aIn.g != bIn.g) || (aIn.b != bIn.b) || (aIn.a != bIn.a)); }
 
 	Color4f ToColor4f() const { return Color4f(r/255.0f, g/255.0f, b/255.0f, a/255.0f); }
 

--- a/src/GameLog.cpp
+++ b/src/GameLog.cpp
@@ -95,7 +95,7 @@ void GameLog::DrawHudMessages(Graphics::Renderer *r)
 			it->m_prevoffset = m_offset;
 			Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 			m_font->PopulateString(va, it->msg.c_str(), m_offset.x, m_offset.y + y, textColour);
-			it->m_vb.Reset( m_font->CreateVertexBuffer(va) );
+			it->m_vb.Reset( m_font->CreateVertexBuffer(va, true) );
 		}
 
 		m_font->RenderBuffer( it->m_vb.Get() );

--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -648,6 +648,10 @@ SystemInfoView::BodyIcon::BodyIcon(const char *img, Graphics::Renderer *r)
 	};
 	m_selectBox.SetData(COUNTOF(vts), vts, m_selectColor);
 	
+	static const Color portColor = Color(64, 128, 128, 255);
+	// The -0.1f offset seems to be the best compromise to make the circles closed (e.g. around Mars), symmetric, fitting with selection
+	// and not overlapping to much with asteroids
+	m_circle.reset(new Graphics::Drawables::Circle(m_renderer, size[0] * 0.5f, size[0] * 0.5f - 0.1f, size[1] * 0.5f, 0.f, portColor, m_renderState));
 }
 
 void SystemInfoView::BodyIcon::Draw()
@@ -657,13 +661,7 @@ void SystemInfoView::BodyIcon::Draw()
 	float size[2];
 	GetSize(size);
 	if (HasStarport()) {
-	    Color portColor = Color(64, 128, 128, 255);
-	    // The -0.1f offset seems to be the best compromise to make the circles closed (e.g. around Mars), symmetric, fitting with selection
-	    // and not overlapping to much with asteroids
-	    Graphics::Drawables::Circle circle =
-			Graphics::Drawables::Circle(m_renderer, size[0]*0.5f, size[0]*0.5f-0.1f, size[1]*0.5f, 0.f,
-			portColor, m_renderState);
-	    circle.Draw(m_renderer);
+		m_circle->Draw(m_renderer);
 	}
 	if (GetSelected()) {
 		m_selectBox.Draw(m_renderer, m_renderState, Graphics::LINE_LOOP);

--- a/src/SystemInfoView.h
+++ b/src/SystemInfoView.h
@@ -35,6 +35,7 @@ private:
 		Graphics::Renderer *m_renderer;
 		Graphics::RenderState *m_renderState;
 		Graphics::Drawables::Lines m_selectBox;
+		std::unique_ptr<Graphics::Drawables::Circle> m_circle;
 		bool m_hasStarport;
 		Color m_selectColor;
 	};

--- a/src/gameui/Face.cpp
+++ b/src/gameui/Face.cpp
@@ -64,26 +64,30 @@ void Face::Layout()
 
 void Face::Draw()
 {
-	const Point &offset = GetActiveOffset();
-	const Point &area = GetActiveArea();
-
-	const float x = offset.x;
-	const float y = offset.y;
-	const float sx = area.x;
-	const float sy = area.y;
-
-	const vector2f texSize = m_texture->GetDescriptor().texSize;
-
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
-	va.Add(vector3f(x,    y,    0.0f), vector2f(0.0f,      0.0f));
-	va.Add(vector3f(x,    y+sy, 0.0f), vector2f(0.0f,      texSize.y));
-	va.Add(vector3f(x+sx, y,    0.0f), vector2f(texSize.x, 0.0f));
-	va.Add(vector3f(x+sx, y+sy, 0.0f), vector2f(texSize.x, texSize.y));
-
 	Graphics::Renderer *r = GetContext()->GetRenderer();
-	s_material->texture0 = m_texture.get();
-	auto state = GetContext()->GetSkin().GetAlphaBlendState();
-	r->DrawTriangles(&va, state, s_material.Get(), Graphics::TRIANGLE_STRIP);
+	if (!m_quad) {
+		const Point &offset = GetActiveOffset();
+		const Point &area = GetActiveArea();
+
+		const float x = offset.x;
+		const float y = offset.y;
+		const float sx = area.x;
+		const float sy = area.y;
+
+		const vector2f texSize = m_texture->GetDescriptor().texSize;
+
+		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
+		va.Add(vector3f(x, y, 0.0f), vector2f(0.0f, 0.0f));
+		va.Add(vector3f(x, y + sy, 0.0f), vector2f(0.0f, texSize.y));
+		va.Add(vector3f(x + sx, y, 0.0f), vector2f(texSize.x, 0.0f));
+		va.Add(vector3f(x + sx, y + sy, 0.0f), vector2f(texSize.x, texSize.y));
+
+		Graphics::Renderer *r = GetContext()->GetRenderer();
+		s_material->texture0 = m_texture.get();
+		auto state = GetContext()->GetSkin().GetAlphaBlendState();
+		m_quad.reset(new Graphics::Drawables::TexturedQuad(r, s_material, va, state));
+	}
+	m_quad->Draw(r);
 
 	Single::Draw();
 }

--- a/src/gameui/Face.h
+++ b/src/gameui/Face.h
@@ -6,6 +6,7 @@
 
 #include "ui/Context.h"
 #include "SmartPtr.h"
+#include "graphics/Drawables.h"
 #include "graphics/Texture.h"
 
 namespace GameUI {
@@ -38,6 +39,7 @@ private:
 	static RefCountedPtr<Graphics::Material> s_material;
 
 	std::unique_ptr<Graphics::Texture> m_texture;
+	std::unique_ptr<Graphics::Drawables::TexturedQuad> m_quad;
 };
 
 }

--- a/src/gameui/LabelOverlay.cpp
+++ b/src/gameui/LabelOverlay.cpp
@@ -125,7 +125,7 @@ void LabelOverlay::DrawLabelText(const Marker &m, const vector2f &screen_pos)
 		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 		m_font->PopulateString(va, m.text, 0.0f, 0.0f, Color::WHITE);
 		if (va.GetNumVerts() > 0) {
-			vb = m_font->CreateVertexBuffer(va, m.text);
+			vb = m_font->CreateVertexBuffer(va, m.text, true);
 			m_font->RenderBuffer(vb, m.color);
 		}
 	}

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -642,7 +642,7 @@ TexturedQuad::TexturedQuad(Graphics::Renderer *r, const std::string &filename)
 	desc.textures = 1;
 	desc.lighting = false;
 	desc.vertexColors = false;
-	m_material.reset(r->CreateMaterial(desc));
+	m_material.Reset(r->CreateMaterial(desc));
 	m_material->texture0 = m_texture.Get();
 
 	// these might need to be reversed
@@ -662,7 +662,7 @@ TexturedQuad::TexturedQuad(Graphics::Renderer *r, const std::string &filename)
 	vbd.attrib[1].format   = ATTRIB_FORMAT_FLOAT2;
 	vbd.numVertices = vertices.GetNumVerts();
 	vbd.usage = BUFFER_USAGE_STATIC;
-	m_vertexBuffer.reset(r->CreateVertexBuffer(vbd));
+	m_vertexBuffer.Reset(r->CreateVertexBuffer(vbd));
 	m_vertexBuffer->Populate(vertices);
 }
 
@@ -677,7 +677,7 @@ TexturedQuad::TexturedQuad(Graphics::Renderer *r, Graphics::Texture *texture, co
 	VertexArray vertices(ATTRIB_POSITION | ATTRIB_UV0);
 	Graphics::MaterialDescriptor desc;
 	desc.textures = 1;
-	m_material.reset(r->CreateMaterial(desc));
+	m_material.Reset(r->CreateMaterial(desc));
 	m_material->texture0 = m_texture.Get();
 
 	// these might need to be reversed
@@ -697,22 +697,65 @@ TexturedQuad::TexturedQuad(Graphics::Renderer *r, Graphics::Texture *texture, co
 	vbd.attrib[1].format   = ATTRIB_FORMAT_FLOAT2;
 	vbd.numVertices = vertices.GetNumVerts();
 	vbd.usage = BUFFER_USAGE_STATIC;
-	m_vertexBuffer.reset(r->CreateVertexBuffer(vbd));
+	m_vertexBuffer.Reset(r->CreateVertexBuffer(vbd));
 	m_vertexBuffer->Populate(vertices);
+}
+
+TexturedQuad::TexturedQuad(Graphics::Renderer *r, RefCountedPtr<Graphics::Material> &material, const Graphics::VertexArray &va, RenderState *state)
+	: m_material(material)
+{
+	PROFILE_SCOPED()
+	assert(state);
+	m_renderState = state;
+
+	//Create vtx & index buffers and copy data
+	VertexBufferDesc vbd;
+	
+	Uint32 attribIdx = 0;
+	assert(va.HasAttrib(ATTRIB_POSITION));
+	vbd.attrib[attribIdx].semantic = ATTRIB_POSITION;
+	vbd.attrib[attribIdx].format = ATTRIB_FORMAT_FLOAT3;
+	++attribIdx;
+
+	if (va.HasAttrib(ATTRIB_NORMAL)) {
+		vbd.attrib[attribIdx].semantic = ATTRIB_NORMAL;
+		vbd.attrib[attribIdx].format = ATTRIB_FORMAT_FLOAT3;
+		++attribIdx;
+	}
+	if (va.HasAttrib(ATTRIB_DIFFUSE)) {
+		vbd.attrib[attribIdx].semantic = ATTRIB_DIFFUSE;
+		vbd.attrib[attribIdx].format = ATTRIB_FORMAT_UBYTE4;
+		++attribIdx;
+	}
+	if (va.HasAttrib(ATTRIB_UV0)) {
+		vbd.attrib[attribIdx].semantic = ATTRIB_UV0;
+		vbd.attrib[attribIdx].format = ATTRIB_FORMAT_FLOAT2;
+		++attribIdx;
+	}
+	if (va.HasAttrib(ATTRIB_TANGENT)) {
+		vbd.attrib[attribIdx].semantic = ATTRIB_TANGENT;
+		vbd.attrib[attribIdx].format = ATTRIB_FORMAT_FLOAT3;
+		++attribIdx;
+	}
+
+	vbd.numVertices = va.GetNumVerts();
+	vbd.usage = BUFFER_USAGE_STATIC;
+	m_vertexBuffer.Reset(r->CreateVertexBuffer(vbd));
+	m_vertexBuffer->Populate(va);
 }
 
 void TexturedQuad::Draw(Graphics::Renderer *r)
 {
 	PROFILE_SCOPED()
-	m_material->diffuse = Color4ub(255, 255, 255, 255);
-	r->DrawBuffer(m_vertexBuffer.get(), m_renderState, m_material.get(), TRIANGLE_STRIP);
+	m_material->diffuse = Color::WHITE;
+	r->DrawBuffer(m_vertexBuffer.Get(), m_renderState, m_material.Get(), TRIANGLE_STRIP);
 }
 
 void TexturedQuad::Draw(Graphics::Renderer *r, const Color4ub &tint)
 {
 	PROFILE_SCOPED()
 	m_material->diffuse = tint;
-	r->DrawBuffer(m_vertexBuffer.get(), m_renderState, m_material.get(), TRIANGLE_STRIP);
+	r->DrawBuffer(m_vertexBuffer.Get(), m_renderState, m_material.Get(), TRIANGLE_STRIP);
 }
 
 //------------------------------------------------------------

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -163,13 +163,15 @@ public:
 
 	// Build a textured quad to display an arbitrary texture.
 	TexturedQuad(Graphics::Renderer *r, Graphics::Texture *texture, const vector2f &pos, const vector2f &size, RenderState *state);
+	TexturedQuad(Graphics::Renderer *r, RefCountedPtr<Graphics::Material> &material, const Graphics::VertexArray &va, RenderState *state);
+
 	virtual void Draw(Graphics::Renderer *r);
 	virtual void Draw(Graphics::Renderer *r, const Color4ub &tint);
 	const Graphics::Texture* GetTexture() const { return m_texture.Get(); }
 private:
 	RefCountedPtr<Graphics::Texture> m_texture;
-	std::unique_ptr<Graphics::Material> m_material;
-	std::unique_ptr<VertexBuffer> m_vertexBuffer;
+	RefCountedPtr<Graphics::Material> m_material;
+	RefCountedPtr<VertexBuffer> m_vertexBuffer;
 	Graphics::RenderState *m_renderState;
 };
 //------------------------------------------------------------

--- a/src/graphics/Types.h
+++ b/src/graphics/Types.h
@@ -7,6 +7,8 @@
 
 namespace Graphics {
 
+typedef Uint32 AttributeSet;
+
 //Vertex attribute semantic
 enum VertexAttrib {
 	ATTRIB_NONE      = 0,

--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -9,8 +9,6 @@
 
 namespace Graphics {
 
-typedef unsigned int AttributeSet;
-
 /*
  * VertexArray is a multi-purpose vertex container. Users specify
  * the attributes they intend to use and then add vertices. Renderers

--- a/src/graphics/VertexBuffer.cpp
+++ b/src/graphics/VertexBuffer.cpp
@@ -72,10 +72,13 @@ Uint32 VertexBuffer::GetVertexCount() const
 	return m_numVertices;
 }
 
-void VertexBuffer::SetVertexCount(Uint32 v)
+bool VertexBuffer::SetVertexCount(Uint32 v)
 {
-	assert(v <= m_desc.numVertices);
-	m_numVertices = v;
+	if (v <= m_desc.numVertices) {
+		m_numVertices = v;
+		return true;
+	}
+	return false;
 }
 
 // ------------------------------------------------------------

--- a/src/graphics/VertexBuffer.h
+++ b/src/graphics/VertexBuffer.h
@@ -80,7 +80,7 @@ public:
 	//By default the maximum set in description, but
 	//you may set a smaller count for partial rendering
 	Uint32 GetVertexCount() const;
-	void SetVertexCount(Uint32);
+	bool SetVertexCount(Uint32);
 
 	// copies the contents of the VertexArray into the buffer
 	virtual bool Populate(const VertexArray &) = 0;

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -166,6 +166,10 @@ protected:
 
 private:
 	static bool initted;
+
+	typedef std::map<std::pair<AttributeSet, size_t>, RefCountedPtr<VertexBuffer>> AttribBufferMap;
+	typedef AttribBufferMap::iterator AttribBufferIter;
+	static AttribBufferMap s_AttribBufferMap;
 };
 
 }

--- a/src/gui/GuiLabel.h
+++ b/src/gui/GuiLabel.h
@@ -35,6 +35,7 @@ namespace Gui {
 		RefCountedPtr<Text::TextureFont> m_font;
 		std::unique_ptr<TextLayout> m_layout;
 		TextLayout::ColourMarkupMode m_colourMarkupMode;
+		bool m_needsUpdate;
 	};
 }
 

--- a/src/gui/GuiScreen.cpp
+++ b/src/gui/GuiScreen.cpp
@@ -320,7 +320,7 @@ void Screen::RenderStringBuffer(RefCountedPtr<Graphics::VertexBuffer> vb, const 
 
 		if (va.GetNumVerts() > 0) {
 			if (!vb.Valid() || vb->GetVertexCount() != va.GetNumVerts()) {
-				vb.Reset(font->CreateVertexBuffer(va, s));
+				vb.Reset(font->CreateVertexBuffer(va, s, true));
 			}
 
 			vb->Populate(va);
@@ -360,7 +360,7 @@ void Screen::RenderMarkupBuffer(RefCountedPtr<Graphics::VertexBuffer> vb, const 
 
 		if (va.GetNumVerts() > 0) {
 			if (!vb.Valid() || vb->GetVertexCount() != va.GetNumVerts()) {
-				vb.Reset(font->CreateVertexBuffer(va, s));
+				vb.Reset(font->CreateVertexBuffer(va, s, true));
 			}
 
 			vb->Populate(va);

--- a/src/gui/GuiToolTip.cpp
+++ b/src/gui/GuiToolTip.cpp
@@ -26,7 +26,7 @@ ToolTip::ToolTip(Widget *owner, std::string &text)
 
 ToolTip::~ToolTip()
 {
-	delete m_layout;
+	m_layout.reset();
 }
 
 void ToolTip::CalcSize()
@@ -40,10 +40,11 @@ void ToolTip::CalcSize()
 
 void ToolTip::SetText(const char *text)
 {
-	m_text = text;
-	if (m_layout) delete m_layout;
-	m_layout = new TextLayout(text);
-	CalcSize();
+	if (m_text != text) {
+		m_text = text;
+		m_layout.reset(new TextLayout(text));
+		CalcSize();
+	}
 }
 
 void ToolTip::SetText(std::string &text)

--- a/src/gui/GuiToolTip.h
+++ b/src/gui/GuiToolTip.h
@@ -21,7 +21,7 @@ namespace Gui {
 		void CalcSize();
 		Widget *m_owner;
 		std::string m_text;
-		TextLayout *m_layout;
+		std::unique_ptr<TextLayout> m_layout;
 		Uint32 m_createdTime;
 		Graphics::Drawables::Lines m_outlines;
 		std::unique_ptr<Graphics::Drawables::Rect> m_background;

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -297,7 +297,7 @@ Color TextureFont::PopulateMarkup(Graphics::VertexArray &va, const std::string &
 	return c;
 }
 
-Graphics::VertexBuffer* TextureFont::CreateVertexBuffer(const Graphics::VertexArray &va) const
+Graphics::VertexBuffer* TextureFont::CreateVertexBuffer(const Graphics::VertexArray &va, const bool bIsStatic) const
 {
 	if (va.GetNumVerts() > 0)
 	{
@@ -310,7 +310,7 @@ Graphics::VertexBuffer* TextureFont::CreateVertexBuffer(const Graphics::VertexAr
 		vbd.attrib[2].semantic = Graphics::ATTRIB_UV0;
 		vbd.attrib[2].format = Graphics::ATTRIB_FORMAT_FLOAT2;
 		vbd.numVertices = va.GetNumVerts();
-		vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;	// we could be updating this per-frame
+		vbd.usage = bIsStatic ? Graphics::BUFFER_USAGE_STATIC : Graphics::BUFFER_USAGE_DYNAMIC;	// we could be updating this per-frame
 		Graphics::VertexBuffer *vbuffer = m_renderer->CreateVertexBuffer(vbd);
 		vbuffer->Populate(va);
 
@@ -319,7 +319,7 @@ Graphics::VertexBuffer* TextureFont::CreateVertexBuffer(const Graphics::VertexAr
 	return nullptr;
 }
 
-Graphics::VertexBuffer* TextureFont::CreateVertexBuffer(const Graphics::VertexArray &va, const std::string &str)
+Graphics::VertexBuffer* TextureFont::CreateVertexBuffer(const Graphics::VertexArray &va, const std::string &str, const bool bIsStatic)
 {
 	if( va.GetNumVerts() > 0 )
 	{
@@ -328,7 +328,7 @@ Graphics::VertexBuffer* TextureFont::CreateVertexBuffer(const Graphics::VertexAr
 			return pVB;
 
 		//create buffer and upload data
-		Graphics::VertexBuffer *vbuffer = CreateVertexBuffer(va);
+		Graphics::VertexBuffer *vbuffer = CreateVertexBuffer(va, bIsStatic);
 		AddCachedVertexBuffer(vbuffer, str);
 
 		return vbuffer;

--- a/src/text/TextureFont.h
+++ b/src/text/TextureFont.h
@@ -39,8 +39,8 @@ public:
 
 	void PopulateString(Graphics::VertexArray &va, const std::string &str, const float x, const float y, const Color &color = Color::WHITE);
 	Color PopulateMarkup(Graphics::VertexArray &va, const std::string &str, const float x, const float y, const Color &color = Color::WHITE);
-	Graphics::VertexBuffer* CreateVertexBuffer(const Graphics::VertexArray &va) const;
-	Graphics::VertexBuffer* CreateVertexBuffer(const Graphics::VertexArray &va, const std::string &str);
+	Graphics::VertexBuffer* CreateVertexBuffer(const Graphics::VertexArray &va, const bool bIsStatic) const;
+	Graphics::VertexBuffer* CreateVertexBuffer(const Graphics::VertexArray &va, const std::string &str, const bool bIsStatic);
 	Graphics::VertexBuffer* GetCachedVertexBuffer(const std::string &str);
 
 	// general baseline-to-baseline height

--- a/src/ui/Gradient.cpp
+++ b/src/ui/Gradient.cpp
@@ -14,29 +14,31 @@ Gradient::Gradient(Context *context, const Color &beginColor, const Color &endCo
 {
 	Graphics::MaterialDescriptor desc;
 	desc.vertexColors = true;
-	m_material.reset(GetContext()->GetRenderer()->CreateMaterial(desc));
+	m_material.Reset(GetContext()->GetRenderer()->CreateMaterial(desc));
 }
 
 void Gradient::Draw()
 {
-	const Point &offset = GetActiveOffset();
-	const Point &area = GetActiveArea();
-
-	const float x = offset.x;
-	const float y = offset.y;
-	const float sx = area.x;
-	const float sy = area.y;
-
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE);
-	va.Add(vector3f(x,    y,    0.0f), m_beginColor);
-	va.Add(vector3f(x,    y+sy, 0.0f), m_direction == HORIZONTAL ? m_beginColor : m_endColor);
-	va.Add(vector3f(x+sx, y,    0.0f), m_direction == HORIZONTAL ? m_endColor : m_beginColor);
-	va.Add(vector3f(x+sx, y+sy, 0.0f), m_endColor);
-
 	Graphics::Renderer *r = GetContext()->GetRenderer();
-	auto renderState = GetContext()->GetSkin().GetAlphaBlendState();
-	m_material->diffuse = Color(Color::WHITE.r, Color::WHITE.g, Color::WHITE.b, GetContext()->GetOpacity()*Color::WHITE.a);
-	r->DrawTriangles(&va, renderState, m_material.get(), Graphics::TRIANGLE_STRIP);
+	if (!m_quad) {
+		const Point &offset = GetActiveOffset();
+		const Point &area = GetActiveArea();
+
+		const float x = offset.x;
+		const float y = offset.y;
+		const float sx = area.x;
+		const float sy = area.y;
+
+		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE);
+		va.Add(vector3f(x, y, 0.0f), m_beginColor);
+		va.Add(vector3f(x, y + sy, 0.0f), m_direction == HORIZONTAL ? m_beginColor : m_endColor);
+		va.Add(vector3f(x + sx, y, 0.0f), m_direction == HORIZONTAL ? m_endColor : m_beginColor);
+		va.Add(vector3f(x + sx, y + sy, 0.0f), m_endColor);
+
+		auto renderState = GetContext()->GetSkin().GetAlphaBlendState();
+		m_quad.reset(new Graphics::Drawables::TexturedQuad(r, m_material, va, renderState));
+	}
+	m_quad->Draw(r, Color(Color::WHITE.r, Color::WHITE.g, Color::WHITE.b, GetContext()->GetOpacity()*Color::WHITE.a));
 
 	Container::Draw();
 }

--- a/src/ui/Gradient.h
+++ b/src/ui/Gradient.h
@@ -6,6 +6,7 @@
 
 #include "Single.h"
 #include "Color.h"
+#include "graphics/Drawables.h"
 #include "graphics/Material.h"
 
 namespace UI {
@@ -29,7 +30,8 @@ private:
 	Color m_endColor;
 	Direction m_direction;
 
-	std::unique_ptr<Graphics::Material> m_material;
+	RefCountedPtr<Graphics::Material> m_material;
+	std::unique_ptr<Graphics::Drawables::TexturedQuad> m_quad;
 };
 
 }

--- a/src/ui/Icon.cpp
+++ b/src/ui/Icon.cpp
@@ -74,25 +74,26 @@ Point Icon::PreferredSize()
 
 void Icon::Draw()
 {
-	const Point &offset = GetActiveOffset();
-	const Point &area = GetActiveArea();
-
-	const float x = offset.x;
-	const float y = offset.y;
-	const float sx = area.x;
-	const float sy = area.y;
-
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
-	va.Add(vector3f(x,    y,    0.0f), vector2f(s_texScale.x*(m_texPos.x),    s_texScale.y*(m_texPos.y)));
-	va.Add(vector3f(x,    y+sy, 0.0f), vector2f(s_texScale.x*(m_texPos.x),    s_texScale.y*(m_texPos.y+48)));
-	va.Add(vector3f(x+sx, y,    0.0f), vector2f(s_texScale.x*(m_texPos.x+48), s_texScale.y*(m_texPos.y)));
-	va.Add(vector3f(x+sx, y+sy, 0.0f), vector2f(s_texScale.x*(m_texPos.x+48), s_texScale.y*(m_texPos.y+48)));
-
 	Graphics::Renderer *r = GetContext()->GetRenderer();
-	s_material->diffuse = m_color;
-	s_material->diffuse = Color(m_color.r, m_color.g, m_color.b, GetContext()->GetOpacity()*m_color.a);
-	auto renderState = GetContext()->GetSkin().GetAlphaBlendState();
-	r->DrawTriangles(&va, renderState, s_material.Get(), Graphics::TRIANGLE_STRIP);
+	if (!m_quad) {
+		const Point &offset = GetActiveOffset();
+		const Point &area = GetActiveArea();
+
+		const float x = offset.x;
+		const float y = offset.y;
+		const float sx = area.x;
+		const float sy = area.y;
+
+		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
+		va.Add(vector3f(x,    y,    0.0f), vector2f(s_texScale.x*(m_texPos.x),    s_texScale.y*(m_texPos.y)));
+		va.Add(vector3f(x,    y+sy, 0.0f), vector2f(s_texScale.x*(m_texPos.x),    s_texScale.y*(m_texPos.y+48)));
+		va.Add(vector3f(x+sx, y,    0.0f), vector2f(s_texScale.x*(m_texPos.x+48), s_texScale.y*(m_texPos.y)));
+		va.Add(vector3f(x+sx, y+sy, 0.0f), vector2f(s_texScale.x*(m_texPos.x+48), s_texScale.y*(m_texPos.y+48)));
+
+		auto renderState = GetContext()->GetSkin().GetAlphaBlendState();
+		m_quad.reset(new Graphics::Drawables::TexturedQuad(r, s_material, va, renderState));
+	}
+	m_quad->Draw(r, Color(m_color.r, m_color.g, m_color.b, GetContext()->GetOpacity()*m_color.a));
 }
 
 }

--- a/src/ui/Icon.h
+++ b/src/ui/Icon.h
@@ -8,6 +8,7 @@
 #include "IniConfig.h"
 #include "SmartPtr.h"
 #include "vector2.h"
+#include "graphics/Drawables.h"
 #include "graphics/Material.h"
 #include "graphics/Texture.h"
 
@@ -34,6 +35,7 @@ private:
 
 	Point m_texPos;
 	Color m_color;
+	std::unique_ptr<Graphics::Drawables::TexturedQuad> m_quad;
 };
 
 }

--- a/src/ui/Image.cpp
+++ b/src/ui/Image.cpp
@@ -22,6 +22,7 @@ Image::Image(Context *context, const std::string &filename, Uint32 sizeControlFl
 	, m_centre(0.0f, 0.0f)
 	, m_scale(1.0f)
 	, m_preserveAspect(false)
+	, m_needsRefresh(false)
 {
 	Graphics::TextureBuilder b = Graphics::TextureBuilder::UI(filename);
 	m_texture.Reset(b.GetOrCreateTexture(GetContext()->GetRenderer(), "ui"));
@@ -43,6 +44,7 @@ Point Image::PreferredSize()
 
 Image *Image::SetHeightLines(Uint32 lines)
 {
+	m_needsRefresh = true;
 	const Text::TextureFont *font = GetContext()->GetFont(GetFont()).Get();
 	const float height = font->GetHeight() * lines;
 
@@ -56,6 +58,7 @@ Image *Image::SetHeightLines(Uint32 lines)
 
 Image *Image::SetNaturalSize()
 {
+	m_needsRefresh = true;
 	m_initialSize = CalcDisplayDimensions(GetContext(), m_texture.Get());
 	GetContext()->RequestLayout();
 	return this;
@@ -63,62 +66,69 @@ Image *Image::SetNaturalSize()
 
 void Image::SetTransform(float scale, const vector2f &centre)
 {
+	m_needsRefresh = true;
 	m_scale = scale;
 	m_centre = centre;
 }
 
 void Image::SetPreserveAspect(bool preserve_aspect)
 {
+	m_needsRefresh = true;
 	m_preserveAspect = preserve_aspect;
 }
 
 void Image::Draw()
 {
-	const Point &offset = GetActiveOffset();
-	const Point &area = GetActiveArea();
-	const auto &descriptor = m_texture->GetDescriptor();
+	Graphics::Renderer *r = GetContext()->GetRenderer();
+	if (!m_quad || m_needsRefresh) {
+		m_needsRefresh = false;
+		const Point &offset = GetActiveOffset();
+		const Point &area = GetActiveArea();
+		const auto &descriptor = m_texture->GetDescriptor();
 
-	const float half_sx = area.x*0.5f;
-	const float half_sy = area.y*0.5f;
+		const float half_sx = area.x*0.5f;
+		const float half_sy = area.y*0.5f;
 
-	float cx = offset.x + half_sx;
-	float cy = offset.y + half_sy;
-	float rx, ry;
+		float cx = offset.x + half_sx;
+		float cy = offset.y + half_sy;
+		float rx, ry;
 
-	if (m_preserveAspect) {
-		const vector2f sz = descriptor.GetOriginalSize();
-		const float wantRatio = sz.x / sz.y;
-		const float haveRatio = float(area.x) / float(area.y);
-		if (wantRatio > haveRatio) {
-			// limited by width
+		if (m_preserveAspect) {
+			const vector2f sz = descriptor.GetOriginalSize();
+			const float wantRatio = sz.x / sz.y;
+			const float haveRatio = float(area.x) / float(area.y);
+			if (wantRatio > haveRatio) {
+				// limited by width
+				rx = half_sx;
+				ry = half_sx / wantRatio;
+			}
+			else {
+				// limited by height
+				rx = half_sy * wantRatio;
+				ry = half_sy;
+			}
+		}
+		else {
 			rx = half_sx;
-			ry = half_sx / wantRatio;
-		} else {
-			// limited by height
-			rx = half_sy * wantRatio;
 			ry = half_sy;
 		}
-	} else {
-		rx = half_sx;
-		ry = half_sy;
+
+		rx *= m_scale;
+		ry *= m_scale;
+		cx -= rx*m_centre.x;
+		cy -= ry*m_centre.y;
+		const vector2f texSize = descriptor.texSize;
+
+		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
+		va.Add(vector3f(cx - rx, cy - ry, 0.0f), vector2f(0.0f, 0.0f));
+		va.Add(vector3f(cx - rx, cy + ry, 0.0f), vector2f(0.0f, texSize.y));
+		va.Add(vector3f(cx + rx, cy - ry, 0.0f), vector2f(texSize.x, 0.0f));
+		va.Add(vector3f(cx + rx, cy + ry, 0.0f), vector2f(texSize.x, texSize.y));
+
+		auto renderState = GetContext()->GetSkin().GetAlphaBlendState();
+		m_quad.reset(new Graphics::Drawables::TexturedQuad(r, m_material, va, renderState));
 	}
-
-	rx *= m_scale;
-	ry *= m_scale;
-	cx -= rx*m_centre.x;
-	cy -= ry*m_centre.y;
-	const vector2f texSize = descriptor.texSize;
-
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
-	va.Add(vector3f(cx-rx, cy-ry, 0.0f), vector2f(0.0f,      0.0f));
-	va.Add(vector3f(cx-rx, cy+ry, 0.0f), vector2f(0.0f,      texSize.y));
-	va.Add(vector3f(cx+rx, cy-ry, 0.0f), vector2f(texSize.x, 0.0f));
-	va.Add(vector3f(cx+rx, cy+ry, 0.0f), vector2f(texSize.x, texSize.y));
-
-	Graphics::Renderer *r = GetContext()->GetRenderer();
-	auto renderState = GetContext()->GetSkin().GetAlphaBlendState();
-	m_material->diffuse = Color(Color::WHITE.r, Color::WHITE.g, Color::WHITE.b, GetContext()->GetOpacity()*Color::WHITE.a);
-	r->DrawTriangles(&va, renderState, m_material.Get(), Graphics::TRIANGLE_STRIP);
+	m_quad->Draw(r, Color(Color::WHITE.r, Color::WHITE.g, Color::WHITE.b, GetContext()->GetOpacity()*Color::WHITE.a));
 }
 
 }

--- a/src/ui/Image.cpp
+++ b/src/ui/Image.cpp
@@ -66,9 +66,11 @@ Image *Image::SetNaturalSize()
 
 void Image::SetTransform(float scale, const vector2f &centre)
 {
-	m_needsRefresh = true;
-	m_scale = scale;
-	m_centre = centre;
+	if (m_scale != scale || !(m_centre == centre)) {
+		m_needsRefresh = true;
+		m_scale = scale;
+		m_centre = centre;
+	}
 }
 
 void Image::SetPreserveAspect(bool preserve_aspect)

--- a/src/ui/Image.h
+++ b/src/ui/Image.h
@@ -6,6 +6,7 @@
 
 #include "Widget.h"
 #include "SmartPtr.h"
+#include "graphics/Drawables.h"
 #include "graphics/Material.h"
 #include "graphics/Texture.h"
 #include "vector2.h"
@@ -49,11 +50,13 @@ protected:
 private:
 	RefCountedPtr<Graphics::Texture> m_texture;
 	RefCountedPtr<Graphics::Material> m_material;
+	std::unique_ptr<Graphics::Drawables::TexturedQuad> m_quad;
 	Point m_initialSize;
 
 	vector2f m_centre;
 	float m_scale;
 	bool m_preserveAspect;
+	bool m_needsRefresh;
 };
 
 }

--- a/src/ui/Label.cpp
+++ b/src/ui/Label.cpp
@@ -58,7 +58,7 @@ void Label::Draw()
 		m_font = GetContext()->GetFont(GetFont());
 		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 		m_font->PopulateString(va, m_text, 0.0f, 0.0f, finalColor);
-		m_vbuffer.Reset( m_font->CreateVertexBuffer(va) );
+		m_vbuffer.Reset( m_font->CreateVertexBuffer(va, true) );
 		m_bNeedsUpdating = false;
 		m_bPrevDisabled = IsDisabled();
 		m_prevOpacity = opacity;

--- a/src/ui/TextLayout.cpp
+++ b/src/ui/TextLayout.cpp
@@ -12,7 +12,7 @@
 namespace UI {
 
 TextLayout::TextLayout(const RefCountedPtr<Text::TextureFont> &font, const std::string &text)
-	: m_font(font), m_prevColor(Color::WHITE)
+	: m_font(font),	m_lastDrawPos(Point(INT_MIN, INT_MIN)), m_lastDrawSize(Point(INT_MIN, INT_MIN)), m_prevColor(Color::BLACK)
 {
 	if (!text.size())
 		return;
@@ -109,26 +109,33 @@ Point TextLayout::ComputeSize(const Point &layoutSize)
 
 void TextLayout::Draw(const Point &layoutSize, const Point &drawPos, const Point &drawSize, const Color &color)
 {
-	// cache this before Computing the size
-	const bool bNewSize = (layoutSize != m_lastRequested);
-	ComputeSize(layoutSize);
+	// Has anything changed between passes
+	const bool bAllNew = (layoutSize != m_lastRequested) || (m_lastDrawPos != drawPos) || (m_lastDrawSize != drawSize) || (m_prevColor != color);
+	if (bAllNew)
+	{
+		ComputeSize(layoutSize);
+		const int top = -drawPos.y - m_font->GetHeight();
+		const int bottom = -drawPos.y + drawSize.y;
 
-	const int top = -drawPos.y - m_font->GetHeight();
-	const int bottom = -drawPos.y + drawSize.y;
+		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 
-	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
+		for (std::vector<Word>::iterator i = m_words.begin(); i != m_words.end(); ++i) {
+			if ((*i).pos.y >= top && (*i).pos.y < bottom) {
+				m_font->PopulateString(va, (*i).text, (*i).pos.x, (*i).pos.y, color);
+			}
+		}
 
-	for (std::vector<Word>::iterator i = m_words.begin(); i != m_words.end(); ++i) {
-		if ((*i).pos.y >= top && (*i).pos.y < bottom) {
-			m_font->PopulateString(va, (*i).text, (*i).pos.x, (*i).pos.y, color);
+		if (!m_vbuffer.Valid()) {
+			m_vbuffer.Reset(m_font->CreateVertexBuffer(va));
 		}
 	}
 
-	if (bNewSize || !m_vbuffer.Valid() || m_prevColor != color) {
-		m_vbuffer.Reset( m_font->CreateVertexBuffer(va) );
-	}
-
 	m_font->RenderBuffer( m_vbuffer.Get() );
+
+	// store current params
+	m_lastRequested = layoutSize;
+	m_lastDrawPos = drawPos;
+	m_lastDrawSize = drawSize;
 	m_prevColor = color;
 }
 

--- a/src/ui/TextLayout.cpp
+++ b/src/ui/TextLayout.cpp
@@ -126,7 +126,7 @@ void TextLayout::Draw(const Point &layoutSize, const Point &drawPos, const Point
 		}
 
 		if (!m_vbuffer.Valid()) {
-			m_vbuffer.Reset(m_font->CreateVertexBuffer(va));
+			m_vbuffer.Reset(m_font->CreateVertexBuffer(va, true));
 		}
 	}
 

--- a/src/ui/TextLayout.h
+++ b/src/ui/TextLayout.h
@@ -37,6 +37,8 @@ private:
 	RefCountedPtr<Text::TextureFont> m_font;
 	RefCountedPtr<Graphics::VertexBuffer> m_vbuffer;
 
+	Point m_lastDrawPos;
+	Point m_lastDrawSize;
 	Color m_prevColor;
 };
 


### PR DESCRIPTION
Another attempt to fix #3417 by improving the performance of our text rendering.

I've discovered that there were several flaws and shortcomings in the attempts to avoid recreating objects. Some things works fine within `TextLayout` for example, however this was rendered useless by the containing object simply deleting it's entire `TextLayout` object.

There is still more work to be done, several uses of `DrawTriangles` need to be remove to really reduce the buffer creation impact for example:
- [x] Gradient.cpp
- [x] Icon.cpp
- [x] Image.cpp
- [x] Skin.cpp - _a bit hacky though_
- [x] Face.cpp

After that I might be able to remove `DrawTriangles` entirely!

Andy