### PR TITLE
Fix #ifdef to allow compilation on various BSDs.

### DIFF
--- a/src/posix/OSPosix.cpp
+++ b/src/posix/OSPosix.cpp
@@ -107,7 +107,7 @@ const std::string GetOSInfoString()
 	}
 
 	char infoString[2048];
-#if defined(__APPLE__)
+#if !defined(_GNU_SOURCE)
 	snprintf(infoString, 2048, "System Name: %s\nHost Name: %s\nRelease(Kernel) Version: %s\nKernel Build Timestamp: %s\nMachine Arch: %s\n",
 		uts.sysname, uts.nodename, uts.release, uts.version, uts.machine);
 #else


### PR DESCRIPTION
The "domain" field of struct utsname is a GNU extension. OS X is not the only system which does not have the "domain" field (actually, almost no systems do). So, it makes more sense to check if we're GNU-like instead.