### PR TITLE
Invisible disabled button for commodity market

### DIFF
--- a/data/ui/StationView/CommodityMarket.lua
+++ b/data/ui/StationView/CommodityMarket.lua
@@ -346,7 +346,7 @@ local commodityMarket = function (args)
 		if Game.player:CountEquip(tradecommodity) == 0 then
 			trade_mode = trade_mode_buy
 			showbuysellbutton = confirmtradebuy
-			buyfrommarket:Disable()
+			buyfrommarket:Hide()
 			buyfrommarket:SetFont("LARGE")
 			sellfromcargo:Enable()
 			sellfromcargo:SetFont("SMALL")
@@ -364,7 +364,7 @@ local commodityMarket = function (args)
 		trade_mode = trade_mode_sell
 		tradeamount = 0
 		showbuysellbutton = confirmtradesell --change which confirm button to show
-		sellfromcargo:Disable()
+		sellfromcargo:Hide()
 		sellfromcargo:SetFont("LARGE")
 		buyfrommarket:Enable()
 		buyfrommarket:SetFont("SMALL")
@@ -377,7 +377,7 @@ local commodityMarket = function (args)
 		trade_mode = trade_mode_buy
 		tradeamount = 0
 		showbuysellbutton = confirmtradebuy --change which confirm button to show
-		buyfrommarket:Disable()
+		buyfrommarket:Hide()
 		buyfrommarket:SetFont("LARGE")
 		sellfromcargo:Enable()
 		sellfromcargo:SetFont("SMALL")
@@ -423,7 +423,7 @@ local commodityMarket = function (args)
 			})
 		end
 		showbuysellbutton = confirmtradebuy
-		buyfrommarket:Disable()
+		buyfrommarket:Hide()
 		buyfrommarket:SetFont("LARGE")
 		sellfromcargo:Enable()
 		sellfromcargo:SetFont("SMALL")

--- a/src/ui/Button.cpp
+++ b/src/ui/Button.cpp
@@ -57,6 +57,8 @@ void Button::Draw()
 {
 	if (IsDisabled())
 		GetContext()->GetSkin().DrawButtonDisabled(GetActiveOffset(), GetActiveArea());
+	else if (IsHidden())
+		GetContext()->GetSkin().DrawButtonHidden(GetActiveOffset(), GetActiveArea());
 	else if (IsMouseActive())
 		GetContext()->GetSkin().DrawButtonActive(GetActiveOffset(), GetActiveArea());
 	else if (IsMouseOver())

--- a/src/ui/LuaWidget.cpp
+++ b/src/ui/LuaWidget.cpp
@@ -36,6 +36,12 @@ public:
 		return 0;
 	}
 
+	static int l_hide(lua_State *l) {
+		UI::Widget *w = LuaObject<UI::Widget>::CheckFromLua(1);
+		w->Hidden();
+		return 0;
+	}
+
 	static int l_enable(lua_State *l) {
 		UI::Widget *w = LuaObject<UI::Widget>::CheckFromLua(1);
 		w->Enable();
@@ -166,6 +172,7 @@ template <> void LuaObject<UI::Widget>::RegisterClass()
 
 		{ "SetEnabled", LuaWidget::l_set_enabled },
 		{ "Disable", LuaWidget::l_disable       },
+		{ "Hide", LuaWidget::l_hide             },
 		{ "Enable",  LuaWidget::l_enable        },
 
 		{ "AddShortcut",    LuaWidget::l_add_shortcut    },

--- a/src/ui/Skin.cpp
+++ b/src/ui/Skin.cpp
@@ -56,6 +56,9 @@ Skin::Skin(const std::string &filename, Graphics::Renderer *renderer, float scal
 	m_buttonHover             = LoadBorderedRectElement(cfg.String("ButtonHover"));
 	m_buttonActive            = LoadBorderedRectElement(cfg.String("ButtonActive"));
 
+	m_buttonHidden         = LoadSkinColor(cfg.String("NormalColorRGBA"));
+	m_smallButtonHidden    = LoadSkinColor(cfg.String("NormalColorRGBA"));
+
 	m_smallButtonDisabled     = LoadRectElement(cfg.String("SmallButtonDisabled"));
 	m_smallButtonNormal       = LoadRectElement(cfg.String("SmallButtonNormal"));
 	m_smallButtonHover        = LoadRectElement(cfg.String("SmallButtonHover"));

--- a/src/ui/Skin.h
+++ b/src/ui/Skin.h
@@ -44,6 +44,13 @@ public:
 		DrawBorderedRectElement(m_buttonActive, pos, size);
 	}
 
+	void DrawButtonHidden(const Point &pos, const Point &size) const {
+		DrawRectColor(m_buttonHidden, pos, size);
+	}
+	void DrawSmallButtonHidden(const Point &pos, const Point &size) const {
+		DrawRectColor(m_smallButtonHidden, pos, size);
+	}
+
 	void DrawSmallButtonDisabled(const Point &pos, const Point &size) const {
 		DrawRectElement(m_smallButtonDisabled, pos, size);
 	}
@@ -146,7 +153,7 @@ public:
 	struct BorderedRectElement : public RectElement {
 		BorderedRectElement() : borderWidth(0), borderHeight(0), paddingX(0), paddingY(0) {}
 		BorderedRectElement(unsigned int x, unsigned int y, unsigned int w, unsigned int h,
-				            unsigned int _borderWidth, unsigned int _borderHeight, unsigned int _paddingX, unsigned int _paddingY) :
+								unsigned int _borderWidth, unsigned int _borderHeight, unsigned int _paddingX, unsigned int _paddingY) :
 			RectElement(x, y, w, h), borderWidth(_borderWidth), borderHeight(_borderHeight), paddingX(_paddingX), paddingY(_paddingY) {}
 		unsigned int borderWidth;
 		unsigned int borderHeight;
@@ -168,6 +175,9 @@ public:
 	const BorderedRectElement &ButtonNormal()   const { return m_buttonNormal; }
 	const BorderedRectElement &ButtonHover()    const { return m_buttonHover; }
 	const BorderedRectElement &ButtonActive()   const { return m_buttonActive; }
+
+	const Color &ButtonHidden() const { return m_buttonHidden; }
+	const Color &SmallButtonHidden() const { return m_smallButtonHidden; }
 
 	const RectElement &SmallButtonDisabled() const { return m_smallButtonDisabled; }
 	const RectElement &SmallButtonNormal()   const { return m_smallButtonNormal; }
@@ -239,6 +249,10 @@ private:
 	BorderedRectElement m_buttonNormal;
 	BorderedRectElement m_buttonHover;
 	BorderedRectElement m_buttonActive;
+
+	// Used by Disable() button, to also hide border, and fill color
+	Color m_buttonHidden;
+	Color m_smallButtonHidden;
 
 	RectElement m_smallButtonDisabled;
 	RectElement m_smallButtonNormal;

--- a/src/ui/SmallButton.cpp
+++ b/src/ui/SmallButton.cpp
@@ -21,6 +21,8 @@ void SmallButton::Draw()
 {
 	if (IsDisabled())
 		GetContext()->GetSkin().DrawSmallButtonDisabled(GetActiveOffset(), GetActiveArea());
+	else if (IsHidden())
+		GetContext()->GetSkin().DrawSmallButtonHidden(GetActiveOffset(), GetActiveArea());
 	else if (IsMouseActive())
 		GetContext()->GetSkin().DrawSmallButtonActive(GetActiveOffset(), GetActiveArea());
 	else if (IsMouseOver())

--- a/src/ui/Widget.cpp
+++ b/src/ui/Widget.cpp
@@ -18,6 +18,7 @@ Widget::Widget(Context *context) :
 	m_activeArea(0),
 	m_font(FONT_INHERIT),
 	m_disabled(false),
+	m_hidden(false),
 	m_mouseOver(false),
 	m_visible(false),
 	m_animatedOpacity(1.0f),
@@ -161,8 +162,8 @@ bool Widget::IsOnTopLayer() const
 	while (scan) {
 		if (scan == topLayer)
 			return true;
-        scan = scan->GetContainer();
-    }
+		  scan = scan->GetContainer();
+	 }
 	return false;
 }
 
@@ -172,9 +173,16 @@ void Widget::Disable()
 	GetContext()->DisableWidget(this);
 }
 
+void Widget::Hidden()
+{
+	SetHidden(true);
+	GetContext()->DisableWidget(this);
+}
+
 void Widget::Enable()
 {
 	SetDisabled(false);
+	SetHidden(false);
 	GetContext()->EnableWidget(this);
 }
 

--- a/src/ui/Widget.h
+++ b/src/ui/Widget.h
@@ -157,7 +157,11 @@ public:
 	// disabled widgets do not receive input
 	virtual void Disable();
 	virtual void Enable();
+	virtual void Hidden();
+
 	bool IsDisabled() const { return m_disabled; }
+
+	bool IsHidden() const { return m_hidden; }
 
 	bool IsMouseOver() const { return m_mouseOver; }
 
@@ -285,6 +289,7 @@ protected:
 	bool IsVisible() const { return m_visible; }
 
 	void SetDisabled(bool disabled) { m_disabled = disabled; }
+	void SetHidden(bool hidden) { m_hidden = hidden; }
 
 	// internal event handlers. override to handle events. unlike the external
 	// on* signals, every widget in the stack is guaranteed to receive a call
@@ -422,6 +427,7 @@ private:
 	Font m_font;
 
 	bool m_disabled;
+	bool m_hidden;
 
 	bool m_mouseOver;
 	bool m_visible;


### PR DESCRIPTION
## Purpose

At the moment disabled buttons are always grey. This implements a state where disabled buttons just "blend" into the background. This is needed to make the suggested PR #3603 look like @nozmajner's mockups in #3602.


## Before / After Example
(applied to #3603 )
![screenshot-20160123-145627](https://cloud.githubusercontent.com/assets/619390/12530525/d52b074a-c1e1-11e5-9452-852e1c920036.png)

![screenshot-20160123-165920](https://cloud.githubusercontent.com/assets/619390/12531105/3370b42e-c1f3-11e5-9f57-cf8da8a64bec.png)

## Implementation

No more than 3 brain cells were harmed during this implementation. It's a pure copy-paste-rename operation on the `Disabled()` state of `ui/Widget.{cpp,h}`, in the most stupid way possible.

Now Invisible state is done by not having the widget being a `BorderedRectBox` but a  `Color` instead.

## Implement sanity into the code

Like I said, it works, but feels as wrong as those funny feelings you had when seeing that distant hot cousin each Christmas. so I think this should be considered before merge:

- [x] 0. Use more than 3 brain cells

- [ ] 1. How should it be used in Lua? Right now you do `button:Invisible()` instead of `button:Disable()`. Perhaps `button:Disable(arg)` where `arg` sets what kind of disable you want: (grey, or invisible)?

- [x] 2. Does the Skin.ini even need to be edited at all? Just use the flat background colour from code directly? __Done__, (use `Color` instead of `BorderedRectBox`)

- [x] 3. most likely some dead code in there, due to stupid copy-paste-rename operation on my part. Remove it

- [x] 4. Rename member functions and attributes from `Invisible()` (to `Hide`? `DisableHide()`?) to something that doesn't clash with how that word is already used in the code for other things.

- [x] 5. Clean up commit history. 

_PS. I don't have any cousins, but it's better this way_