### PR TITLE
Search&Rescue Script: fix serialization issue (#3606)

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -343,14 +343,14 @@ local decToDegMinSec = function (coord_orig)
    return str
 end
 
-local getAircontrolChar = function (spacestation)
-   -- Get the correct aircontrol character for the supplied spacestation. If it does not exist
+local getAircontrolChar = function (station)
+   -- Get the correct aircontrol character for the supplied station. If it does not exist
    -- create one and store it.
-   if containerContainsKey(aircontrol_chars, spacestation) then
-      return aircontrol_chars[spacestation]
+   if containerContainsKey(aircontrol_chars, station.path) then
+      return aircontrol_chars[station.path]
    else
       local char = Character.New()
-      aircontrol_chars[spacestation] = char
+      aircontrol_chars[station.path] = char
       return char
    end
 end


### PR DESCRIPTION
During the last update to the script I realized that aircontrol characters were never saved. Fixing this surfaced an old bug with the original script that was hidden before (using station object as table key instead of station.path object).

This should fix  #3606 and allow saving the game again.