### PR TITLE
Fixed narrowing conversion problem when compiling with C++11 support

### DIFF
--- a/contrib/vcacheopt/vcacheopt.h
+++ b/contrib/vcacheopt/vcacheopt.h
@@ -67,7 +67,7 @@ public:
 	}
 };
 typedef TVertexCacheData<int, INT_MAX >					VertexCacheDataInt;
-typedef TVertexCacheData<unsigned int, UINT_MAX >		VertexCacheDataUInt;
+typedef TVertexCacheData<unsigned int, static_cast<int>(UINT_MAX) >		VertexCacheDataUInt;
 typedef TVertexCacheData<unsigned short, USHRT_MAX >	VertexCacheDataUShort;
 
 template <typename T, int ERR_VAL>
@@ -84,7 +84,7 @@ public:
 	}
 };
 typedef TTriangleCacheData<int, INT_MAX >				TriangleCacheDataInt;
-typedef TTriangleCacheData<unsigned int, UINT_MAX >		TriangleCacheDataUInt;
+typedef TTriangleCacheData<unsigned int, static_cast<int>(UINT_MAX) >		TriangleCacheDataUInt;
 typedef TTriangleCacheData<unsigned short, USHRT_MAX >	TriangleCacheDataUShort;
 
 template <typename T, int N, int ERR_VAL>
@@ -168,7 +168,7 @@ public:
 	}
 };
 typedef TVertexCache<int, 40, INT_MAX >					VertexCacheInt;
-typedef TVertexCache<unsigned int, 40, UINT_MAX >		VertexCacheUInt;
+typedef TVertexCache<unsigned int, 40, static_cast<int>(UINT_MAX) >		VertexCacheUInt;
 typedef TVertexCache<unsigned short, 40, USHRT_MAX >	VertexCacheUShort;
 
 template <typename T, int N, int ERR_VAL>
@@ -505,7 +505,7 @@ public:
 	}
 };
 typedef TVertexCacheOptimizer<int, 40, INT_MAX >				VertexCacheOptimizerInt;
-typedef TVertexCacheOptimizer<unsigned int, 40, UINT_MAX >		VertexCacheOptimizerUInt;
+typedef TVertexCacheOptimizer<unsigned int, 40, static_cast<int>(UINT_MAX) >		VertexCacheOptimizerUInt;
 typedef TVertexCacheOptimizer<unsigned short, 40, USHRT_MAX >	VertexCacheOptimizerUShort;
 
 #endif // ndef _VCACHEOPT_H_


### PR DESCRIPTION
When compiling using the C++ Standard Library with C++11 support (environment: xCode on Mac OS X 10.10 - Yosemite), I recently started getting the following errors on several lines of "../contrib/vcacheopt/vcacheopt.h":

**Non-type template argument evaluates to 4294967295, which cannot be narrowed to type 'int'**

After some analysis I found that the error is caused by the narrowing conversions required to convert UINT_MAX to int in several typedef instructions, for example:

*typedef TVertexCacheData<unsigned int, UINT_MAX >		VertexCacheDataUInt;*

The problem is related to the c++11 standard which at 8.5.4 item 3 says:

*If a narrowing conversion (see below) is required to convert any of the  arguments, the program is ill-formed.*

and item 7:

*A narrowing conversion is an implicit conversion ... from long double to double or float, or from double to float, except where the source is a constant  expression and the actual value after conversion is within the range of values that can be represented  (even if it cannot be represented exactly)*

My solution to this problem has been to set an explicit type cast on the UINT_MAX value, wherever it is used as a template argument. 