### PR TITLE
Fix for console window crash.

### DIFF
--- a/src/ui/TextLayout.cpp
+++ b/src/ui/TextLayout.cpp
@@ -125,7 +125,7 @@ void TextLayout::Draw(const Point &layoutSize, const Point &drawPos, const Point
 			}
 		}
 
-		if (!m_vbuffer.Valid()) {
+		if (!m_vbuffer.Valid() || (m_vbuffer->GetVertexCount() != va.GetNumVerts())) {
 			m_vbuffer.Reset(m_font->CreateVertexBuffer(va, true));
 		}
 		else {


### PR DESCRIPTION
Rebuild the vbuffer if the vertex count doesn't match new and old text.

Hopefully this should fix #3609 although I couldn't reproduce it myself.

If @walterar could take a look that would be great!