### PR TITLE
Fix number of police ships not being spawned in right amount

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -339,7 +339,7 @@ function SpaceStation:LaunchPolice(targetShip)
 		-- decide how many to create
 		local lawlessness = Game.system.lawlessness
 		local maxPolice = math.min(9, self.numDocks)
-		local numberPolice = math.ceil(Engine.rand:Integer(1,maxPolice)*lawlessness)
+		local numberPolice = math.ceil(Engine.rand:Integer(1,maxPolice)*(1-lawlessness))
 		local shiptype = ShipDef[Game.system.faction.policeShip]
 
 		-- create and equip them


### PR DESCRIPTION
@clausimu  pointed out this bug.

Police were spwning in opposite probability as they should, with respect to `lawlessness`.

Just to check sanity: here is the new _average_ number of spawned police ships for a stion with five pads, and a station with nine or more (caped). x-axis stops at 0.99, thus not shown is `lawlessnss=1`, in which case no police will be spawned.
![ships](https://cloud.githubusercontent.com/assets/619390/12623669/7d7c11ea-c52b-11e5-99e3-bf61b709d1a7.png)
