### PR TITLE
Fix Character.lua / Ship.lua import relationship

### DIFF
--- a/data/libs/Character.lua
+++ b/data/libs/Character.lua
@@ -52,7 +52,6 @@ local Game = import("Game")
 local Event = import("Event")
 local NameGen = import("NameGen")
 local Serializer = import("Serializer")
-local Ship = import("Ship")
 
 local Character;
 Character = {

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -10,6 +10,7 @@ local ShipDef = import("ShipDef")
 local Equipment = import("Equipment")
 local Timer = import("Timer")
 local Lang = import("Lang")
+local Character = import("Character")
 
 local l = Lang.GetResource("ui-core")
 


### PR DESCRIPTION
This is a fix for the Ship:GenerateCrew() method - and the game crash if Character.lua is imported by Ship.lua

Character.lua was importing Ship.lua but didn't use it. Instead, Ship.lua needed to import Character.lua for its Ship:GenerateCrew() method. But importing Character.lua there would cause the game to crash (circular reference...). 

I don't know why this was never noticed before - I guess nobody every used Ship:GenerateCrew(). It is working now.