### PR TITLE
New behaviour of ESC button

### DIFF
--- a/src/LuaConsole.cpp
+++ b/src/LuaConsole.cpp
@@ -159,6 +159,11 @@ LuaConsole::~LuaConsole() {}
 bool LuaConsole::OnKeyDown(const UI::KeyboardEvent &event) {
 
 	switch (event.keysym.sym) {
+		case SDLK_ESCAPE: {
+			// pressing the ESC key will drop our layer, but we still have to make sure we are marked as not active anymore
+			m_active = false;
+			break;
+		}
 		case SDLK_UP:
 		case SDLK_DOWN: {
 			if (m_historyPosition == -1) {

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -796,11 +796,15 @@ void Pi::HandleEvents()
 					if (Pi::game) {
 						// only accessible once game started
 						if (currentView != 0) {
-							if (currentView != Pi::game->GetSettingsView()) {
-								Pi::game->SetTimeAccel(Game::TIMEACCEL_PAUSED);
-								SetView(Pi::game->GetSettingsView());
+							if (currentView == Pi::game->GetWorldView()) {
+								if (!Pi::game->IsPaused()) {
+									Pi::game->SetTimeAccel(Game::TIMEACCEL_PAUSED);
+								}
+								else {
+									SetView(Pi::game->GetSettingsView());
+								}
 							}
-							else {
+							else if (currentView == Pi::game->GetSettingsView()){
 								Pi::game->RequestTimeAccel(Game::TIMEACCEL_1X);
 								SetView(Pi::player->IsDead()
 										? static_cast<View*>(Pi::game->GetDeathView())

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1017,6 +1017,10 @@ void Pi::HandleEscKey() {
 					Pi::game->GetCpan()->SelectGroupButton(1, 0);
 					SetView(Pi::game->GetSectorView());
 				}
+				else if (!strcmp(tname, "InfoView") || !strcmp(tname, "StationView")) {
+					Pi::game->GetCpan()->SelectGroupButton(0, 0);
+					SetView(Pi::game->GetWorldView());
+				}
 			}
 		}
 	}

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -795,22 +795,7 @@ void Pi::HandleEvents()
 				if (event.key.keysym.sym == SDLK_ESCAPE) {
 					if (Pi::game) {
 						// only accessible once game started
-						if (currentView != 0) {
-							if (currentView == Pi::game->GetWorldView()) {
-								if (!Pi::game->IsPaused()) {
-									Pi::game->SetTimeAccel(Game::TIMEACCEL_PAUSED);
-								}
-								else {
-									SetView(Pi::game->GetSettingsView());
-								}
-							}
-							else if (currentView == Pi::game->GetSettingsView()){
-								Pi::game->RequestTimeAccel(Game::TIMEACCEL_1X);
-								SetView(Pi::player->IsDead()
-										? static_cast<View*>(Pi::game->GetDeathView())
-										: static_cast<View*>(Pi::game->GetWorldView()));
-							}
-						}
+						HandleEscKey();
 					}
 					break;
 				}
@@ -994,6 +979,45 @@ void Pi::HandleEvents()
 					break;
 				joysticks[event.jhat.which].hats[event.jhat.hat] = event.jhat.value;
 				break;
+		}
+	}
+}
+
+void Pi::HandleEscKey() {
+	if (currentView != 0) {
+		if (currentView == Pi::game->GetWorldView()) {
+			static_cast<WorldView*>(currentView)->HideTargetActions();
+			if (!Pi::game->IsPaused()) {
+				Pi::game->SetTimeAccel(Game::TIMEACCEL_PAUSED);
+			}
+			else {
+				SetView(Pi::game->GetSettingsView());
+			}
+		}
+		else if (currentView == Pi::game->GetSectorView()) {
+			Pi::game->GetCpan()->SelectGroupButton(0, 0);
+			SetView(Pi::game->GetWorldView());
+		}
+		else if ((currentView == Pi::game->GetSystemView()) || (currentView == Pi::game->GetSystemInfoView())) {
+			Pi::game->GetCpan()->SelectGroupButton(1, 0);
+			SetView(Pi::game->GetSectorView());
+		}
+		else if (currentView == Pi::game->GetSettingsView()){
+			Pi::game->RequestTimeAccel(Game::TIMEACCEL_1X);
+			SetView(Pi::player->IsDead()
+					? static_cast<View*>(Pi::game->GetDeathView())
+					: static_cast<View*>(Pi::game->GetWorldView()));
+		}
+		else {
+			UIView* view = dynamic_cast<UIView*>(currentView);
+			if (view) {
+				// checks the template name
+				const char* tname = view->GetTemplateName();
+				if (!strcmp(tname, "GalacticView")) {
+					Pi::game->GetCpan()->SelectGroupButton(1, 0);
+					SetView(Pi::game->GetSectorView());
+				}
+			}
 		}
 	}
 }

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -177,6 +177,8 @@ public:
 
 private:
 	static void HandleEvents();
+	// Handler for ESC key press
+	static void HandleEscKey();
 	static void InitJoysticks();
 
 	static const Uint32 SYNC_JOBS_PER_LOOP = 1;

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -456,3 +456,10 @@ void ShipCpanel::ClearOverlay()
 		m_overlay[i]->SetToolTip("");
 	}
 }
+
+void ShipCpanel::SelectGroupButton(int gid, int idx)
+{
+	Pi::BoinkNoise();
+	Gui::RadioGroup* group = (gid==1) ? m_rightButtonGroup : m_leftButtonGroup;
+	group->SetSelected(idx);
+}

--- a/src/ShipCpanel.h
+++ b/src/ShipCpanel.h
@@ -43,6 +43,10 @@ public:
 	void SetOverlayText(OverlayTextPos pos, const std::string &text);
 	void SetOverlayToolTip(OverlayTextPos pos, const std::string &text);
 	void ClearOverlay();
+	// Selects the specified button
+	// @param int gid the buttons group (0 = left, 1 = right)
+	// @param int idx the 0-based button index within the specified group
+	void SelectGroupButton(int gid, int idx);
 
 private:
 	void InitObject();

--- a/src/UIView.h
+++ b/src/UIView.h
@@ -20,6 +20,7 @@ public:
 
 	virtual void Update() {}
 	virtual void Draw3D() {}
+	const char* GetTemplateName() { return m_templateName; }
 
 protected:
 	virtual void BuildUI(UI::Single *container);

--- a/src/ui/Context.cpp
+++ b/src/ui/Context.cpp
@@ -102,7 +102,6 @@ void Context::DropLayer()
 	m_needsLayout = true;
 }
 
-
 void Context::DropAllLayers()
 {
 	for (std::vector<Layer*>::iterator i = m_layers.begin(); i != m_layers.end(); ++i)

--- a/src/ui/Context.cpp
+++ b/src/ui/Context.cpp
@@ -102,6 +102,7 @@ void Context::DropLayer()
 	m_needsLayout = true;
 }
 
+
 void Context::DropAllLayers()
 {
 	for (std::vector<Layer*>::iterator i = m_layers.begin(); i != m_layers.end(); ++i)
@@ -109,6 +110,15 @@ void Context::DropAllLayers()
 	m_layers.clear();
 	NewLayer();
 	m_needsLayout = true;
+}
+	
+void Context::HandleKeyDown(const KeyboardEvent &event) {
+	if (event.keysym.sym == SDLK_ESCAPE) {
+		if (m_layers.size()>1) {
+			// go back to previous layer
+			DropLayer();
+		}
+	}
 }
 
 Widget *Context::GetWidgetAt(const Point &pos)

--- a/src/ui/Context.h
+++ b/src/ui/Context.h
@@ -128,7 +128,7 @@ public:
 
 	void SetMousePointer(const std::string &filename, const Point &hotspot);
 	void SetMousePointerEnabled(bool enabled) { m_mousePointerEnabled = enabled; }
-	
+	// handler for keydown events
 	void HandleKeyDown(const KeyboardEvent &event);
 
 	// event dispatch delegates

--- a/src/ui/Context.h
+++ b/src/ui/Context.h
@@ -128,6 +128,8 @@ public:
 
 	void SetMousePointer(const std::string &filename, const Point &hotspot);
 	void SetMousePointerEnabled(bool enabled) { m_mousePointerEnabled = enabled; }
+	
+	void HandleKeyDown(const KeyboardEvent &event);
 
 	// event dispatch delegates
 	bool Dispatch(const Event &event) { return m_eventDispatcher.Dispatch(event); }


### PR DESCRIPTION
This request is the natural follow-up to a discussion we recently had in the Dev forum, namely:

http://pioneerspacesim.net/forum/viewtopic.php?f=3&t=385

In short: so far the effect of pressing the ESC key has been to pause the game and open the Settings View, regardless of the context we are in at the moment. I have changed this so as pressing the ESC button is now someway closer to what normal users might expect, and probably more useful as well.

Please review the attached Excel file for a description of the new effect of pressing the ESC key depending on the current context. Let me know if you find any problem or bug in the implementation.
[esc_key.xlsx](https://github.com/pioneerspacesim/pioneer/files/112465/esc_key.xlsx)
