### PR TITLE
GL_INVALID_OPERATION warning (win32)

### DIFF
--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -307,6 +307,13 @@ void RendererOGL::CheckErrors()
 					<< "Recommend enabling \"Compress Textures\" in game options." << std::endl
 					<< "Also try reducing City and Planet detail settings." << std::endl;
 			}
+#ifdef _WIN32
+			else if (err == GL_INVALID_OPERATION) {
+				ss << "Invalid operations can occur if you are using overlay software." << std::endl
+					<< "Such as FRAPS, RivaTuner, MSI Afterburner etc." << std::endl
+					<< "Please try disabling this kind of software and testing again, thankyou." << std::endl;
+			}
+#endif
 		}
 		Warning("%s", ss.str().c_str());
 	}


### PR DESCRIPTION
Warn about possible cause of a 'GL_INVALID_OPERATION' for Windows platform.

This is in response to #3619 and #3478 which can be a nightmare to diagnose remotely - it does not fix #3478 though which is a separate issue that manifests in a similar way.