### PR TITLE
Rendering cleanup, possible perf improvements.

### DIFF
--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -39,8 +39,9 @@ void BaseSphere::OnChangeDetailLevel()
 
 void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
 	const matrix4x4d &modelView, const vector3d &campos, float rad,
-	Graphics::RenderState *rs, Graphics::Material *mat)
+	Graphics::RenderState *rs, RefCountedPtr<Graphics::Material> mat)
 {
+	PROFILE_SCOPED()
 	using namespace Graphics;
 	const vector3d yaxis = campos.Normalized();
 	const vector3d zaxis = vector3d(1.0, 0.0, 0.0).Cross(yaxis).Normalized();
@@ -49,77 +50,9 @@ void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
 
 	renderer->SetTransform(modelView * matrix4x4d::ScaleMatrix(rad, rad, rad) * invrot);
 
-	// what is this? Well, angle to the horizon is:
-	// acos(planetRadius/viewerDistFromSphereCentre)
-	// and angle from this tangent on to atmosphere is:
-	// acos(planetRadius/atmosphereRadius) ie acos(1.0/1.01244blah)
-	const double endAng = acos(1.0 / campos.Length()) + acos(1.0 / rad);
-	const double latDiff = endAng / double(LAT_SEGS);
-
-	double rot = 0.0;
-	float sinTable[LONG_SEGS + 1];
-	float cosTable[LONG_SEGS + 1];
-	for (int i = 0; i <= LONG_SEGS; i++, rot += 2.0*M_PI / double(LONG_SEGS)) {
-		sinTable[i] = float(sin(rot));
-		cosTable[i] = float(cos(rot));
-	}
-
-	// Tri-fan above viewer
-	if(!m_TriFanAbove.Valid())
-	{
-		// VertexBuffer
-		VertexBufferDesc vbd;
-		vbd.attrib[0].semantic = ATTRIB_POSITION;
-		vbd.attrib[0].format = ATTRIB_FORMAT_FLOAT3;
-		vbd.numVertices = LONG_SEGS + 2;
-		vbd.usage = BUFFER_USAGE_STATIC;
-		m_TriFanAbove.Reset(renderer->CreateVertexBuffer(vbd));
-	}
-#pragma pack(push, 4)
-	struct PosVert {
-		vector3f pos;
-	};
-#pragma pack(pop)
-	PosVert* vtxPtr = m_TriFanAbove->Map<PosVert>(Graphics::BUFFER_MAP_WRITE);
-	vtxPtr[0].pos = vector3f(0.f, 1.f, 0.f);
-	for (int i = 0; i <= LONG_SEGS; i++)
-	{
-		vtxPtr[i + 1].pos = vector3f(
-			sin(latDiff)*sinTable[i],
-			cos(latDiff),
-			-sin(latDiff)*cosTable[i]);
-	}
-	m_TriFanAbove->Unmap();
-	renderer->DrawBuffer(m_TriFanAbove.Get(), rs, mat, Graphics::TRIANGLE_FAN);
-
-	// and wound latitudinal strips
-	if (!m_LatitudinalStrips[0].Valid())
-	{
-		VertexBufferDesc vbd;
-		vbd.attrib[0].semantic = ATTRIB_POSITION;
-		vbd.attrib[0].format = ATTRIB_FORMAT_FLOAT3;
-		vbd.numVertices = (LONG_SEGS + 1) * 2;
-		vbd.usage = BUFFER_USAGE_DYNAMIC;
-		for (int j = 0; j < LAT_SEGS; j++) {
-			// VertexBuffer
-			m_LatitudinalStrips[j].Reset(renderer->CreateVertexBuffer(vbd));
-		}
-	}
-	double lat = latDiff;
-	for (int j=1; j<LAT_SEGS; j++, lat += latDiff) {
-		const float cosLat = cos(lat);
-		const float sinLat = sin(lat);
-		const float cosLat2 = cos(lat+latDiff);
-		const float sinLat2 = sin(lat+latDiff);
-		vtxPtr = m_LatitudinalStrips[j]->Map<PosVert>(Graphics::BUFFER_MAP_WRITE);
-		vtxPtr[0].pos = vector3f(0.f, 1.f, 0.f);
-		for (int i=0; i<=LONG_SEGS; i++) {
-			vtxPtr[(i*2)+0].pos = vector3f(sinLat*sinTable[i], cosLat, -sinLat*cosTable[i]);
-			vtxPtr[(i*2)+1].pos = vector3f(sinLat2*sinTable[i], cosLat2, -sinLat2*cosTable[i]);
-		}
-		m_LatitudinalStrips[j]->Unmap();
-		renderer->DrawBuffer(m_LatitudinalStrips[j].Get(), rs, mat, Graphics::TRIANGLE_STRIP);
-	}
+	if(!m_atmos)
+		m_atmos.reset( new Drawables::Sphere3D(renderer, mat, rs, 4, 1.0f, ATTRIB_POSITION));
+	m_atmos->Draw(renderer);
 
 	renderer->GetStats().AddToStatCount(Graphics::Stats::STAT_ATMOSPHERES, 1);
 }

--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -37,7 +37,7 @@ public:
 
 	void DrawAtmosphereSurface(Graphics::Renderer *renderer,
 		const matrix4x4d &modelView, const vector3d &campos, float rad,
-		Graphics::RenderState *rs, Graphics::Material *mat);
+		Graphics::RenderState *rs, RefCountedPtr<Graphics::Material> mat);
 
 	// in sbody radii
 	virtual double GetMaxFeatureHeight() const { return 0.0; }
@@ -55,7 +55,7 @@ public:
 	Terrain* GetTerrain() const { return m_terrain.Get(); }
 
 	Graphics::RenderState* GetSurfRenderState() const { return m_surfRenderState; }
-	Graphics::Material* GetSurfaceMaterial() const { return m_surfaceMaterial.get(); }
+	RefCountedPtr<Graphics::Material> GetSurfaceMaterial() const { return m_surfaceMaterial; }
 	MaterialParameters& GetMaterialParameters() { return m_materialParameters; }
 
 protected:
@@ -68,14 +68,11 @@ protected:
 
 	Graphics::RenderState *m_surfRenderState;
 	Graphics::RenderState *m_atmosRenderState;
-	std::unique_ptr<Graphics::Material> m_surfaceMaterial;
-	std::unique_ptr<Graphics::Material> m_atmosphereMaterial;
+	RefCountedPtr<Graphics::Material> m_surfaceMaterial;
+	RefCountedPtr<Graphics::Material> m_atmosphereMaterial;
 
 	// atmosphere geometry
-	static const int LAT_SEGS = 20;
-	static const int LONG_SEGS = 20;
-	RefCountedPtr<Graphics::VertexBuffer> m_TriFanAbove;
-	RefCountedPtr<Graphics::VertexBuffer> m_LatitudinalStrips[LAT_SEGS];
+	std::unique_ptr<Graphics::Drawables::Sphere3D> m_atmos;
 
 	//special parameters for shaders
 	MaterialParameters m_materialParameters;

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -62,6 +62,7 @@ GeoPatch::~GeoPatch() {
 
 void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 {
+	PROFILE_SCOPED()
 	if (m_needUpdateVBOs) {
 		assert(renderer);
 		m_needUpdateVBOs = false;
@@ -238,6 +239,7 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 static const SSphere s_sph;
 void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, const matrix4x4d &modelView, const Graphics::Frustum &frustum)
 {
+	PROFILE_SCOPED()
 	// must update the VBOs to calculate the clipRadius...
 	UpdateVBOs(renderer);
 	// ...before doing the furstum culling that relies on it.
@@ -263,7 +265,7 @@ void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, cons
 	if (kids[0]) {
 		for (int i=0; i<NUM_KIDS; i++) kids[i]->Render(renderer, campos, modelView, frustum);
 	} else if (heights) {
-		Graphics::Material *mat = geosphere->GetSurfaceMaterial();
+		RefCountedPtr<Graphics::Material> mat = geosphere->GetSurfaceMaterial();
 		Graphics::RenderState *rs = geosphere->GetSurfRenderState();
 
 		const vector3d relpos = clipCentroid - campos;
@@ -275,7 +277,7 @@ void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, cons
 		// per-patch detail texture scaling value
 		geosphere->GetMaterialParameters().patchDepth = m_depth;
 
-		renderer->DrawBufferIndexed(m_vertexBuffer.get(), ctx->GetIndexBuffer(), rs, mat);
+		renderer->DrawBufferIndexed(m_vertexBuffer.get(), ctx->GetIndexBuffer(), rs, mat.Get());
 #ifdef DEBUG_BOUNDING_SPHERES
 		if(m_boundsphere.get()) {
 			renderer->SetWireFrameMode(true);
@@ -368,6 +370,7 @@ void GeoPatch::RequestSinglePatch()
 
 void GeoPatch::ReceiveHeightmaps(SQuadSplitResult *psr)
 {
+	PROFILE_SCOPED()
 	assert(NULL!=psr);
 	if (m_depth<psr->depth()) {
 		// this should work because each depth should have a common history
@@ -408,6 +411,7 @@ void GeoPatch::ReceiveHeightmaps(SQuadSplitResult *psr)
 
 void GeoPatch::ReceiveHeightmap(const SSingleSplitResult *psr)
 {
+	PROFILE_SCOPED()
 	assert(nullptr == parent);
 	assert(nullptr != psr);
 	assert(mHasJobRequest);

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -385,6 +385,7 @@ void GeoSphere::ProcessQuadSplitRequests()
 
 void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows)
 {
+	PROFILE_SCOPED()
 	// store this for later usage in the update method.
 	m_tempCampos = campos;
 	m_hasTempCampos = true;
@@ -430,7 +431,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 			// show ugly polygonal angles
 			DrawAtmosphereSurface(renderer, trans, campos,
 				m_materialParameters.atmosphere.atmosRadius*1.01,
-				m_atmosRenderState, m_atmosphereMaterial.get());
+				m_atmosRenderState, m_atmosphereMaterial);
 		}
 	}
 
@@ -480,6 +481,7 @@ void GeoSphere::SetUpMaterials()
 
 	//blended
 	rsd.blendMode = Graphics::BLEND_ALPHA_ONE;
+	rsd.cullMode = Graphics::CULL_NONE;
 	rsd.depthWrite = false;
 	m_atmosRenderState = Pi::renderer->CreateRenderState(rsd);
 
@@ -524,7 +526,7 @@ void GeoSphere::SetUpMaterials()
 	if (bEnableDetailMaps) {
 		surfDesc.quality |= Graphics::HAS_DETAIL_MAPS;
 	}
-	m_surfaceMaterial.reset(Pi::renderer->CreateMaterial(surfDesc));
+	m_surfaceMaterial.Reset(Pi::renderer->CreateMaterial(surfDesc));
 
 	m_texHi.Reset( Graphics::TextureBuilder::Model("textures/high.dds").GetOrCreateTexture(Pi::renderer, "model") );
 	m_texLo.Reset( Graphics::TextureBuilder::Model("textures/low.dds").GetOrCreateTexture(Pi::renderer, "model") );
@@ -538,7 +540,7 @@ void GeoSphere::SetUpMaterials()
 		if (bEnableEclipse) {
 			skyDesc.quality |= Graphics::HAS_ECLIPSES;
 		}
-		m_atmosphereMaterial.reset(Pi::renderer->CreateMaterial(skyDesc));
+		m_atmosphereMaterial.Reset(Pi::renderer->CreateMaterial(skyDesc));
 		m_atmosphereMaterial->texture0 = nullptr;
 		m_atmosphereMaterial->texture1 = nullptr;
 	}

--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -37,6 +37,7 @@ ShipCockpit::~ShipCockpit()
 
 void ShipCockpit::Render(Graphics::Renderer *renderer, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform)
 {
+	PROFILE_SCOPED()
 	RenderModel(renderer, camera, viewCoords, viewTransform);
 }
 
@@ -184,6 +185,7 @@ void ShipCockpit::Update(float timeStep)
 
 void ShipCockpit::RenderCockpit(Graphics::Renderer* renderer, const Camera* camera, Frame* frame)
 {
+	PROFILE_SCOPED()
 	renderer->ClearDepthBuffer();
 	SetFrame(frame);
 	Render(renderer, camera, m_translate, m_transform);

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -24,7 +24,7 @@ public:
 	Circle(Renderer *renderer, const float radius, const Color &c, RenderState *state);
 	Circle(Renderer *renderer, const float radius, const float x, const float y, const float z, const Color &c, RenderState *state);
 	Circle(Renderer *renderer, const float radius, const vector3f &center, const Color &c, RenderState *state);
-	virtual void Draw(Renderer *renderer);
+	void Draw(Renderer *renderer);
 
 private:
 	void SetupVertexBuffer(const Graphics::VertexArray&, Graphics::Renderer *);
@@ -40,7 +40,7 @@ class Disk {
 public:
 	Disk(Graphics::Renderer *r, Graphics::RenderState*, const Color &c, float radius);
 	Disk(Graphics::Renderer *r, RefCountedPtr<Material>, Graphics::RenderState*, const int edges=72, const float radius=1.0f);
-	virtual void Draw(Graphics::Renderer *r);
+	void Draw(Graphics::Renderer *r);
 
 	void SetColor(const Color&);
 
@@ -57,11 +57,11 @@ class Line3D {
 public:
 	Line3D();
 	Line3D(const Line3D& b); // this needs an explicit copy constructor due to the std::unique_ptr below
-	virtual ~Line3D() {}
+	~Line3D() {}
 	void SetStart(const vector3f &);
 	void SetEnd(const vector3f &);
 	void SetColor(const Color &);
-	virtual void Draw(Renderer*, RenderState*);
+	void Draw(Renderer*, RenderState*);
 private:
 	void CreateVertexBuffer(Graphics::Renderer *r, const Uint32 size);
 	void Dirty();
@@ -128,8 +128,8 @@ private:
 class Sphere3D {
 public:
 	//subdivisions must be 0-4
-	Sphere3D(Renderer*, RefCountedPtr<Material> material, Graphics::RenderState*, int subdivisions=0, float scale=1.f);
-	virtual void Draw(Renderer *r);
+	Sphere3D(Renderer*, RefCountedPtr<Material> material, Graphics::RenderState*, int subdivisions=0, float scale=1.f, const Uint32 attribs=(ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0));
+	void Draw(Renderer *r);
 
 	RefCountedPtr<Material> GetMaterial() const { return m_material; }
 
@@ -165,8 +165,8 @@ public:
 	TexturedQuad(Graphics::Renderer *r, Graphics::Texture *texture, const vector2f &pos, const vector2f &size, RenderState *state);
 	TexturedQuad(Graphics::Renderer *r, RefCountedPtr<Graphics::Material> &material, const Graphics::VertexArray &va, RenderState *state);
 
-	virtual void Draw(Graphics::Renderer *r);
-	virtual void Draw(Graphics::Renderer *r, const Color4ub &tint);
+	void Draw(Graphics::Renderer *r);
+	void Draw(Graphics::Renderer *r, const Color4ub &tint);
 	const Graphics::Texture* GetTexture() const { return m_texture.Get(); }
 private:
 	RefCountedPtr<Graphics::Texture> m_texture;
@@ -181,7 +181,7 @@ class Rect {
 public:
 	Rect(Graphics::Renderer *r, const vector2f &pos, const vector2f &size, const Color &c, RenderState *state, const bool bIsStatic = true);
 	void Update(const vector2f &pos, const vector2f &size, const Color &c);
-	virtual void Draw(Graphics::Renderer *r);
+	void Draw(Graphics::Renderer *r);
 private:
 	RefCountedPtr<Graphics::Material> m_material;
 	RefCountedPtr<VertexBuffer> m_vertexBuffer;
@@ -194,7 +194,7 @@ class RoundEdgedRect {
 public:
 	RoundEdgedRect(Graphics::Renderer *r, const vector2f &size, const float rad, const Color &c, RenderState *state, const bool bIsStatic = true);
 	void Update(const vector2f &size, float rad, const Color &c);
-	virtual void Draw(Graphics::Renderer *r);
+	void Draw(Graphics::Renderer *r);
 private:
 	static const int STEPS = 6;
 	RefCountedPtr<Graphics::Material> m_material;
@@ -207,7 +207,7 @@ private:
 class Axes3D {
 public:
 	Axes3D(Graphics::Renderer *r, Graphics::RenderState *state = nullptr);
-	virtual void Draw(Graphics::Renderer *r);
+	void Draw(Graphics::Renderer *r);
 private:
 	RefCountedPtr<Graphics::Material> m_material;
 	RefCountedPtr<VertexBuffer> m_vertexBuffer;

--- a/src/graphics/VertexArray.cpp
+++ b/src/graphics/VertexArray.cpp
@@ -30,7 +30,7 @@ VertexArray::~VertexArray()
 
 }
 
-bool VertexArray::HasAttrib(VertexAttrib v) const
+bool VertexArray::HasAttrib(const VertexAttrib v) const
 {
 	return (m_attribs & v) != 0;
 }

--- a/src/graphics/VertexArray.cpp
+++ b/src/graphics/VertexArray.cpp
@@ -30,16 +30,6 @@ VertexArray::~VertexArray()
 
 }
 
-bool VertexArray::HasAttrib(const VertexAttrib v) const
-{
-	return (m_attribs & v) != 0;
-}
-
-unsigned int VertexArray::GetNumVerts() const
-{
-	return position.size();
-}
-
 void VertexArray::Clear()
 {
 	position.clear();

--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -23,11 +23,11 @@ public:
 	~VertexArray();
 
 	//check presence of an attribute
-	bool HasAttrib(VertexAttrib v) const;
-	unsigned int GetNumVerts() const;
-	AttributeSet GetAttributeSet() const { return m_attribs; }
+	__inline bool HasAttrib(const VertexAttrib v) const;
+	__inline unsigned int GetNumVerts() const;
+	__inline AttributeSet GetAttributeSet() const { return m_attribs; }
 
-	bool IsEmpty() const { return position.empty(); }
+	__inline bool IsEmpty() const { return position.empty(); }
 
 	//removes vertices, does not deallocate space
 	void Clear();

--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -23,8 +23,8 @@ public:
 	~VertexArray();
 
 	//check presence of an attribute
-	__inline bool HasAttrib(const VertexAttrib v) const;
-	__inline unsigned int GetNumVerts() const;
+	__inline bool HasAttrib(const VertexAttrib v) const	{ return (m_attribs & v) != 0; }
+	__inline size_t GetNumVerts() const { return position.size(); }
 	__inline AttributeSet GetAttributeSet() const { return m_attribs; }
 
 	__inline bool IsEmpty() const { return position.empty(); }

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -39,6 +39,7 @@ GLenum get_component_type(VertexAttribFormat fmt)
 VertexBuffer::VertexBuffer(const VertexBufferDesc &desc) :
 	Graphics::VertexBuffer(desc)
 {
+	PROFILE_SCOPED()
 	//update offsets in desc
 	for (Uint32 i = 0; i < MAX_ATTRIBS; i++) {
 		if (m_desc.attrib[i].offset == 0)
@@ -130,6 +131,7 @@ VertexBuffer::~VertexBuffer()
 
 Uint8 *VertexBuffer::MapInternal(BufferMapMode mode)
 {
+	PROFILE_SCOPED()
 	assert(mode != BUFFER_MAP_NONE); //makes no sense
 	assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
 	m_mapMode = mode;
@@ -147,6 +149,7 @@ Uint8 *VertexBuffer::MapInternal(BufferMapMode mode)
 
 void VertexBuffer::Unmap()
 {
+	PROFILE_SCOPED()
 	assert(m_mapMode != BUFFER_MAP_NONE); //not currently mapped
 
 	if (GetDesc().usage == BUFFER_USAGE_STATIC) {
@@ -257,6 +260,7 @@ void CopyPosNormUV0(Graphics::VertexBuffer *vb, const Graphics::VertexArray &va)
 // copies the contents of the VertexArray into the buffer
 bool VertexBuffer::Populate(const VertexArray &va)
 {
+	PROFILE_SCOPED()
 	assert(va.GetNumVerts()>0);
 	assert(va.GetNumVerts()==m_numVertices);
 	bool result = false;

--- a/win32/vs2015/pioneer.vcxproj
+++ b/win32/vs2015/pioneer.vcxproj
@@ -97,7 +97,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>HAVE_M_PI;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;HAVE_M_PI;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -128,7 +128,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>HAVE_M_PI;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;HAVE_M_PI;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>
@@ -148,7 +148,7 @@
     <ClCompile />
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>HAVE_M_PI;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;HAVE_M_PI;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <SDLCheck>false</SDLCheck>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -173,7 +173,7 @@
     <ClCompile />
     <ClCompile>
       <AdditionalIncludeDirectories>../../../src;../../src;../../../pioneer-thirdparty/win32/include;../../../../pioneer-thirdparty/win32/include;../../win32/include;../../include;../../../contrib;../../contrib</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>HAVE_M_PI;PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;HAVE_M_PI;PIONEER_PROFILER;WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/Qpar-report:2 /Qvec-report:2 %(AdditionalOptions)</AdditionalOptions>
       <SDLCheck>false</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>


### PR DESCRIPTION
I took a break from my current multi-month projects to profile some performance, this the resulting PR.

- [x] Replace the per-frame atmosphere generation with 'Sphere3D'
- [x] De-virtualise the Drawables classes.
- [x] Allow the creator to define the vertex format of 'Sphere3D'.
- [x] Some inlining and constness.
- [x] More profiling hooks to find where performance was lost.

The main one on the list is the replacemant in 'BaseSphere' of the many tiny pieces of atmosphere geometry with a single call to 'Sphere3D' which puts a solid sphere with no culling around the whole planet. 

It removes 20+ buffer mappings, VertexBuffer updates and rendering with a single draw call of a static chunk of data.

- [x] Testing, I haven't yet tried this on Linux, or OSX, or with that many worlds.
Have now tried a few other worlds and everything looks fine :)

Andy