### PR TITLE
Only get the SystemBody pointer on system bodies and NOT on ships.

### DIFF
--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -607,7 +607,8 @@ void SystemInfoView::UpdateIconSelections()
 		RefCountedPtr<StarSystem> currentSys = m_game->GetSpace()->GetStarSystem();
 		if (currentSys && currentSys->GetPath() == m_system->GetPath()) {
 			//navtarget can be only set in current system
-			if (Body* navtarget = Pi::player->GetNavTarget()) {
+			Body* navtarget = Pi::player->GetNavTarget();
+			if ( navtarget && !navtarget->IsType(Body::SHIP) ) {
 				const SystemPath& navpath = navtarget->GetSystemBody()->GetPath();
 				if (bodyIcon.first == navpath.bodyIndex) {
 					bodyIcon.second->SetSelectColor(Color(0, 255, 0, 255));


### PR DESCRIPTION
This should fix the #3631 crash which was caused by it dereferencing a nullptr.