### PR TITLE
gun locator tag fix

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -245,19 +245,21 @@ bool ModelViewer::OnToggleGuns(UI::CheckBox *w)
 	}
 
 	m_options.attachGuns = !m_options.attachGuns;
-	SceneGraph::Group *tagL = m_model->FindTagByName("tag_gun_left");
-	SceneGraph::Group *tagR = m_model->FindTagByName("tag_gun_right");
-	if (!tagL || !tagR) {
-		AddLog("Missing tags gun_left and gun_right in model");
+	SceneGraph::Model::TVecMT tags;
+	m_model->FindTagsByStartOfName("tag_gun_", tags);
+	if (tags.empty()) {
+		AddLog("Missing tags \"tag_gun_XXX\" in model");
 		return false;
 	}
 	if (m_options.attachGuns) {
-		tagL->AddChild(new SceneGraph::ModelNode(m_gunModel.get()));
-		tagR->AddChild(new SceneGraph::ModelNode(m_gunModel.get()));
+		for (auto tag : tags) {
+			tag->AddChild(new SceneGraph::ModelNode(m_gunModel.get()));
+		}
 	} else { //detach
 		//we know there's nothing else
-		tagL->RemoveChildAt(0);
-		tagR->RemoveChildAt(0);
+		for (auto tag : tags) {
+			tag->RemoveChildAt(0);
+		}
 	}
 	return true;
 }


### PR DESCRIPTION
Commit: `A more flexible use of tag_gun_ to support any number of gun mount points.`

The only ship setup to use the experimental, `modelviewer` only, `tag_gun_` is the `dsminer` and it got the names wrong in the `.dae` file :) probably due to an exporter/converter issue.

It was doing an exact match on the names `tag_gun_left` & `tag_gun_right` which were both suffixed with `001` in the `.dae` meaning that it didn't work anymore (_if it ever did_).

I was doing something else when I figured this out, it remains a good example of attaching/removing objects to a ships scenegraph at runtime. This may also be a good base for adding externally visible weapons etc.