### PR TITLE
Redirect stdout for modelviewer mode

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -99,6 +99,7 @@ ModelViewer::ModelViewer(Graphics::Renderer *r, LuaManager *lm)
 , m_model(0)
 , m_modelName("")
 {
+	OS::RedirectStdio();
 	m_ui.Reset(new UI::Context(lm, r, Graphics::GetScreenWidth(), Graphics::GetScreenHeight()));
 	m_ui->SetMousePointer("icons/cursors/mouse_cursor_2.png", UI::Point(15, 8));
 
@@ -878,6 +879,7 @@ void ModelViewer::SetModel(const std::string &filename)
 				it != loader.GetLogMessages().end(); ++it)
 			{
 				AddLog(*it);
+				Output((*it).c_str());
 			}
 		}
 

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -888,6 +888,7 @@ void ModelViewer::SetModel(const std::string &filename)
 		//set decal textures, max 4 supported.
 		//Identical texture at the moment
 		OnDecalChanged(0, "pioneer");
+		Output("\n\n");
 
 		SceneGraph::DumpVisitor d(m_model);
 		m_model->GetRoot()->Accept(d);


### PR DESCRIPTION
Redirect stdio output for errors and out to output.txt file so that errors and warnings can be found after it shuts down.