### PR TITLE
Remove redundant LuaAPI function for Disable/Enable buttons.

### DIFF
--- a/data/ui/FileDialog.lua
+++ b/data/ui/FileDialog.lua
@@ -39,10 +39,10 @@ ui.templates.FileDialog = function (args)
 	cancelButton.onClick:Connect(onCancel)
 
 	if #files > 0 then
-		selectButton:SetEnabled(true)
+		selectButton:Enable()
 		list:SetSelectedIndex(1)
 	else
-		selectButton:SetEnabled(false)
+		selectButton:Disable()
 	end
 
 	local fileEntry
@@ -53,7 +53,11 @@ ui.templates.FileDialog = function (args)
 		end
 		fileEntry.onChange:Connect(function (fileName)
 			fileName = util.trim(fileName)
-			selectButton:SetEnabled(fileName ~= '')
+			if fileName ~= '' then
+				selectButton:Enable()
+			else
+				selectButton:Disable()
+			end
 		end)
 		list.onOptionSelected:Connect(function (index, fileName)
 			if fileName ~= '' then

--- a/src/ui/LuaWidget.cpp
+++ b/src/ui/LuaWidget.cpp
@@ -19,17 +19,6 @@ public:
 		return 1;
 	}
 
-	static int l_set_enabled(lua_State *l) {
-		UI::Widget *w = LuaObject<UI::Widget>::CheckFromLua(1);
-		const bool enable = lua_toboolean(l, 2);
-		if (enable) {
-			w->Enable();
-		} else {
-			w->Disable();
-		}
-		return 0;
-	}
-
 	static int l_disable(lua_State *l) {
 		UI::Widget *w = LuaObject<UI::Widget>::CheckFromLua(1);
 		w->Disable();
@@ -164,7 +153,6 @@ template <> void LuaObject<UI::Widget>::RegisterClass()
 	static const luaL_Reg l_methods[] = {
 		{ "SetFont", LuaWidget::l_set_font_size },
 
-		{ "SetEnabled", LuaWidget::l_set_enabled },
 		{ "Disable", LuaWidget::l_disable       },
 		{ "Enable",  LuaWidget::l_enable        },
 


### PR DESCRIPTION
 This PR has three purposes:

1. Show that I'm still alive.
2. Remove code that I think is redundant
3. an excuse to poke at @johnbartholomew, and see if he still lives :smile:

So on point 3: In October 2013 you added an additional way to disable/enable buttons, with `button:SetEnabled(bool)` @bc73254f0252c855751e56fe4532d46be8518020 but I don't see how that method adds anything that isn't already there with `button:Disable()`, and `button:Enable()`. Sure, that method saves you the need to wrap the Disable/Enable in an if-statement in some cases, but two different API functions for doing the same thing seems odd to me, just for that one-line trick in Lua. I could be completely wrong of course.