### PR TITLE
Fix rare crash.

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1017,13 +1017,15 @@ void Pi::HandleEscKey() {
 			if (view) {
 				// checks the template name
 				const char* tname = view->GetTemplateName();
-				if (!strcmp(tname, "GalacticView")) {
-					Pi::game->GetCpan()->SelectGroupButton(1, 0);
-					SetView(Pi::game->GetSectorView());
-				}
-				else if (!strcmp(tname, "InfoView") || !strcmp(tname, "StationView")) {
-					Pi::game->GetCpan()->SelectGroupButton(0, 0);
-					SetView(Pi::game->GetWorldView());
+				if(tname) {
+					if (!strcmp(tname, "GalacticView")) {
+						Pi::game->GetCpan()->SelectGroupButton(1, 0);
+						SetView(Pi::game->GetSectorView());
+					}
+					else if (!strcmp(tname, "InfoView") || !strcmp(tname, "StationView")) {
+						Pi::game->GetCpan()->SelectGroupButton(0, 0);
+						SetView(Pi::game->GetWorldView());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I maaged to get this crash where `tname` was somehow `nullptr`, I think this depends on you switching from the `objectviewer` mode straight into one of the `F2` subscreens.

Never could reproduce it but this was an obvious crash and an easy fix.