### PR TITLE
vector2 template class

### DIFF
--- a/src/vector2.h
+++ b/src/vector2.h
@@ -1,56 +1,62 @@
 // Copyright © 2008-2016 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#pragma once
+
 #ifndef _VECTOR2_H
 #define _VECTOR2_H
 
 #include "FloatComparison.h"
 #include <math.h>
 
-class vector2f {
+template <typename T>
+class vector2 {
 public:
-	float x,y;
+	T x,y;
 
-	vector2f() : x(0.0f), y(0.0f) {}
-	vector2f(float _x, float _y) : x(_x), y(_y) {}
-	explicit vector2f(int v) : x(float(v)), y(float(v)) {}
-	explicit vector2f(unsigned int v) : x(float(v)), y(float(v)) {}
-	explicit vector2f(float v) : x(v), y(v) {}
-	vector2f(const vector2f &v) : x(v.x), y(v.y) {}
-	explicit vector2f(const float v[2]) : x(v[0]), y(v[1]) {}
+	vector2() : x(0.0f), y(0.0f) {}
+	vector2(T _x, T _y) : x(_x), y(_y) {}
+	explicit vector2(int v) : x(T(v)), y(T(v)) {}
+	explicit vector2(unsigned int v) : x(T(v)), y(T(v)) {}
+	explicit vector2(T v) : x(v), y(v) {}
+	vector2(const vector2 &v) : x(v.x), y(v.y) {}
+	explicit vector2(const T v[2]) : x(v[0]), y(v[1]) {}
 
-	vector2f operator+(const vector2f &v) const { return vector2f(x+v.x,y+v.y); }
-	vector2f operator-(const vector2f &v) const { return vector2f(x-v.x,y-v.y); }
-	vector2f &operator+=(const vector2f &v) { x+=v.x; y+=v.y; return *this; }
-	vector2f &operator-=(const vector2f &v) { x-=v.x; y-=v.y; return *this; }
-	vector2f &operator*=(const float &a) { x*=a; y*=a; return *this; }
-	vector2f operator-() const { return vector2f(-x,-y); }
+	vector2 operator+(const vector2 &v) const { return vector2(x+v.x,y+v.y); }
+	vector2 operator-(const vector2 &v) const { return vector2(x-v.x,y-v.y); }
+	vector2 &operator+=(const vector2 &v) { x+=v.x; y+=v.y; return *this; }
+	vector2 &operator-=(const vector2 &v) { x-=v.x; y-=v.y; return *this; }
+	vector2 &operator*=(const T &a) { x*=a; y*=a; return *this; }
+	vector2 operator-() const { return vector2(-x,-y); }
 
-	bool operator==(const vector2f &a) const { 
+	bool operator==(const vector2 &a) const { 
 		return is_equal_exact(a.x, x) && is_equal_exact(a.y, y);
 	}
-	bool ExactlyEqual(const vector2f &a) const {
+	bool ExactlyEqual(const vector2 &a) const {
 		return is_equal_exact(a.x, x) && is_equal_exact(a.y, y);
 	}
 
-	friend vector2f operator*(const vector2f &v, const float &a) { return vector2f(v.x*a, v.y*a); }
-	friend vector2f operator*(const float &a, const vector2f &v) { return v*a; }
-	friend vector2f operator/(const vector2f &v, const float &a) { return vector2f(v.x / a, v.y / a); }
-	friend bool operator<(const vector2f &va, const vector2f &vb) { return va.LengthSqr() < vb.LengthSqr(); }
+	friend vector2 operator*(const vector2 &v, const T &a) { return vector2(v.x*a, v.y*a); }
+	friend vector2 operator*(const T &a, const vector2 &v) { return v*a; }
+	friend vector2 operator/(const vector2 &v, const T &a) { return vector2(v.x / a, v.y / a); }
+	friend bool operator<(const vector2 &va, const vector2 &vb) { return va.LengthSqr() < vb.LengthSqr(); }
 
 
-	float Length() const { return sqrt(x*x + y*y); }
-	float LengthSqr() const { return x*x + y*y; }
-	vector2f Normalized() const { const float invlen = 1.0f / sqrt(x*x + y*y); return vector2f(x*invlen, y*invlen); }
-	vector2f NormalizedSafe() const {
-		const float lenSqr = x*x + y*y;
+	T Length() const { return sqrt(x*x + y*y); }
+	T LengthSqr() const { return x*x + y*y; }
+	vector2 Normalized() const { const T invlen = 1.0f / sqrt(x*x + y*y); return vector2(x*invlen, y*invlen); }
+	vector2 NormalizedSafe() const {
+		const T lenSqr = x*x + y*y;
 		if (lenSqr < 1e-18) // sqrt(lenSqr) < 1e-9
-			return vector2f(1,0);
+			return vector2(1,0);
 		else {
-			const float invlen = sqrt(lenSqr);
-			return vector2f(x/invlen, y/invlen);
+			const T invlen = sqrt(lenSqr);
+			return vector2(x/invlen, y/invlen);
 		}
 	}
 };
+
+typedef vector2<float > vector2f;
+typedef vector2<double> vector2d;
 
 #endif


### PR DESCRIPTION
I had a need/use for the vector2f class with double precision so I updated this to be template based and then defined `vector2f` and `vector2d`.

Then decided that since the branch won't be ready for a while it would be worth bringing the change over to master separately.