### PR TITLE
Release discarded_ships on entering or leaving systems

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1836,19 +1836,20 @@ local onLeaveSystem = function (ship)
 end
 
 local onShipDocked = function (ship, station)
-   if ship:IsPlayer() then
-      for _,mission in pairs(missions) do
-	 if Space.GetBody(mission.station_local.bodyIndex) == station then
-	    closeMission(mission)
-	 end
-      end
-   else
-	for i,discarded_ship in pairs(discarded_ships) do
-	if ship == discarded_ship then
-		discardShip(ship)
-		table.remove(discarded_ship,i)
+	if ship:IsPlayer() then
+		for _,mission in pairs(missions) do
+			if Space.GetBody(mission.station_local.bodyIndex) == station then
+				closeMission(mission)
+			end
+		end
+	else
+		for i,discarded_ship in pairs(discarded_ships) do
+			if ship == discarded_ship then
+				discardShip(ship)
+				table.remove(discarded_ship,i)
+			end
+		end
 	end
-   end
 end
 
 local onReputationChanged = function (oldRep, oldKills, newRep, newKills)

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -750,7 +750,7 @@ local onChat = function (form, ref, option)
 	 problem            = ad.problem,
 	 dist               = ad.dist,
 	 flavour            = ad.flavour,
-	 target             = "NIL",
+	 target             = nil,
 	 lat                = ad.lat,
 	 long               = ad.long,
 	 shipdef_name       = ad.shipdef_name,
@@ -1569,7 +1569,7 @@ local interactWithTarget = function (mission)
 		      
 		      -- abort if interaciton distance was not held or target ship destroyed
 		      -- TODO: set the check mark for each mission right
-		      if not targetInteractionDistance(mission) or mission.target == "NIL" then
+		      if not targetInteractionDistance(mission) or mission.target == nil then
 			 Comms.ImportantMessage(l.INTERACTION_ABORTED)
 			 searchForTarget(mission)
 			 return true
@@ -1651,7 +1651,7 @@ end
 function searchForTarget (mission)
    -- Measure distance to target every second until interaction distance reached.
 
-   if mission.searching == true or mission.target == "NIL" then return end
+   if mission.searching == true or mission.target == nil then return end
    mission.searching = true
 
    -- Counter to show messages only once and not every loop
@@ -1813,6 +1813,10 @@ local onEnterSystem = function (player)
 	 mission.target = createTargetShip(mission)
       end
    end
+	  
+      for _,discarded_ship in pairs(discarded_ships) do
+		table.remove(discarded_ships, discarded_ship)
+	  end
 end
 
 local onLeaveSystem = function (ship)
@@ -1824,10 +1828,13 @@ local onLeaveSystem = function (ship)
       -- remove references to ships that are left behind (cause serialization crash otherwise)
       for _,mission in pairs(missions) do
 	 if mission.system_target:IsSameSystem(syspath) then
-	    mission.target = 'NIL'
+	    mission.target = nil
 	 end
       end
-      
+	  
+      for _,discarded_ship in pairs(discarded_ships) do
+		table.remove(discarded_ships, discarded_ship)
+	  end
       -- TODO: put in tracker to recreate mission targets (already transferred personnel, cargo, etc.)
    end
 end
@@ -1889,7 +1896,7 @@ local onGameStart = function ()
 
    -- check if player is within frame of any mission targets to resume search
    for _,mission in pairs(missions) do
-      if Game.player.frameBody == mission.target.frameBody then
+      if mission.target and Game.player.frameBody == mission.target.frameBody then
 	 searchForTarget(mission)
       end
    end
@@ -2017,7 +2024,7 @@ end
 local onShipDestroyed = function (ship, attacker)
    for _,mission in pairs(missions) do
       if ship == mission.target then
-	 mission.target = "NIL"
+	 mission.target = nil
       end
    end
 end

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1846,7 +1846,7 @@ local onShipDocked = function (ship, station)
 		for i,discarded_ship in pairs(discarded_ships) do
 			if ship == discarded_ship then
 				discardShip(ship)
-				table.remove(discarded_ship,i)
+				table.remove(discarded_ships,i)
 			end
 		end
 	end

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1814,9 +1814,7 @@ local onEnterSystem = function (player)
       end
    end
 	  
-      for _,discarded_ship in pairs(discarded_ships) do
-		table.remove(discarded_ships, discarded_ship)
-	  end
+      discarded_ships = {}
 end
 
 local onLeaveSystem = function (ship)
@@ -1832,9 +1830,7 @@ local onLeaveSystem = function (ship)
 	 end
       end
 	  
-      for _,discarded_ship in pairs(discarded_ships) do
-		table.remove(discarded_ships, discarded_ship)
-	  end
+      discarded_ships = {}
       -- TODO: put in tracker to recreate mission targets (already transferred personnel, cargo, etc.)
    end
 end
@@ -1847,11 +1843,11 @@ local onShipDocked = function (ship, station)
 	 end
       end
    else
-      for _,discarded_ship in pairs(discarded_ships) do
-	 if ship == discarded_ship then
-	    discardShip(ship)
-	 end
-      end
+	for i,discarded_ship in pairs(discarded_ships) do
+	if ship == discarded_ship then
+		discardShip(ship)
+		table.remove(discarded_ship,i)
+	end
    end
 end
 


### PR DESCRIPTION
This does three things :
- use nil instead of "NIL"
- release any discarded_ships when entering or leaving a system
- check that we have a target before trying to use it

The first is just me being pedantic, the second I think fixes the problem but may have side effects, and the third stops it crashing which is one of the side effects.

@clausimu this is your baby I just got distracted by it so if you could take a look and tell me what you think then that'd be great :)