### PR TITLE
SAR: fix fuel transfer

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -6,7 +6,8 @@
 -- - All station/planet location references in ad/mission are stored as paths for consistency because
 --   some can't be accessed as bodies until the player enters the respective system and getting a path from
 --   systembody needs to go through body. Variable "location" is a SystemsBody.
-
+-- - Any cargo commodity that needs to be delivered/picked up needs to be intered into "verifyCommodity" function.
+--   Some users have issues with commodities not beeing recognized otherwise. 
 
 -- TODO:
 -- - add degToDegMinSec function to src/LuaFormat.cpp
@@ -292,6 +293,15 @@ end
 -- basic mission functions
 -- =======================
 
+local verifyCommodity = function (item)
+   -- Reloads the actual cargo equipment as object. Somehow that can get lost in some
+   -- setups and for some users. All commodities used for any mission flavor have to
+   -- be accounted for here.
+   if item.l10n_key == 'HYDROGEN' then
+      return Equipment.cargo.hydrogen
+   end
+end
+
 local triggerAdCreation = function ()
    -- Return if ad should be created based on lawlessness and min/max frequency values.
    -- Ad number per system is based on how many stations a system has so a player will
@@ -419,7 +429,8 @@ end
 
 local cargoPresent = function (ship, item)
    -- Check if this cargo item is present on the ship.
-   if ship:CountEquip(item) > 0 then
+   cargotype = verifyCommodity(item)  -- necessary for some users
+   if ship:CountEquip(cargotype) > 0 then
       return true
    else
       return false
@@ -474,13 +485,15 @@ end
 local addCargo = function (ship, item)
    -- Add a ton of the supplied cargo item to the ship.
    if not cargoSpace(ship) then return end
-   ship:AddEquip(item, 1)
+   cargotype = verifyCommodity(item)  -- necessary for some users
+   ship:AddEquip(cargotype, 1)
 end
 
 local removeCargo = function (ship, item)
    -- Remove a ton of the supplied cargo item from the ship.
    if not cargoPresent(ship, item) then return end
-   ship:RemoveEquip(item, 1)
+   cargotype = verifyCommodity(item)  -- necessary for some users
+   ship:RemoveEquip(cargotype, 1)
 end
 
 local passEquipmentRequirements = function (requirements)
@@ -1826,8 +1839,7 @@ local onLeaveSystem = function (ship)
 	 if mission.system_target:IsSameSystem(syspath) then
 	    mission.target = 'NIL'
 	 end
-      end
-      
+      end      
       -- TODO: put in tracker to recreate mission targets (already transferred personnel, cargo, etc.)
    end
 end
@@ -1843,6 +1855,7 @@ local onShipDocked = function (ship, station)
       for _,discarded_ship in pairs(discarded_ships) do
 	 if ship == discarded_ship then
 	    discardShip(ship)
+	    
 	 end
       end
    end


### PR DESCRIPTION
This is in response to one of the issues raised in #3627 - that fuel transfer is not working for some users. I went with a solution based on what @walterar suggested (re-loading the actual cargo equipment object), but packed it a little differently. That way you only have to change one place in the script if you ever add more mission flavors and more types of cargo.

I still don't know why this workaround is necessary, or why it works for some users (such as me...) and doesn't for others. Due to a lack of common language :) @walterar can't explain it to me. If someone else understands, please share. But I tested it with the save game supplied by @sfence and it works.