### PR TITLE
Fix some GCC build warnings

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -904,7 +904,7 @@ void ModelViewer::SetModel(const std::string &filename)
 				it != loader.GetLogMessages().end(); ++it)
 			{
 				AddLog(*it);
-				Output((*it).c_str());
+				Output("%s\n", (*it).c_str());
 			}
 		}
 

--- a/src/RandomColor.cpp
+++ b/src/RandomColor.cpp
@@ -291,13 +291,13 @@ namespace RandomColorGenerator
 		// this doesn't work for the values of 0 and 360
 		// here's the hacky fix
 		auto h = double(hue);
-		if ( h == 0 )
+		if ( is_equal_exact(h, 0.0) )
 		{
-			h = 1;
+			h = 1.0;
 		}
-		if ( h == 360 )
+		if ( is_equal_exact(h, 360.0) )
 		{
-			h = 359;
+			h = 359.0;
 		}
 
 		// Rebase the h,s,v values

--- a/src/gameui/Face.cpp
+++ b/src/gameui/Face.cpp
@@ -82,7 +82,6 @@ void Face::Draw()
 		va.Add(vector3f(x + sx, y, 0.0f), vector2f(texSize.x, 0.0f));
 		va.Add(vector3f(x + sx, y + sy, 0.0f), vector2f(texSize.x, texSize.y));
 
-		Graphics::Renderer *r = GetContext()->GetRenderer();
 		s_material->texture0 = m_texture.get();
 		auto state = GetContext()->GetSkin().GetAlphaBlendState();
 		m_quad.reset(new Graphics::Drawables::TexturedQuad(r, s_material, va, state));

--- a/src/ui/Image.cpp
+++ b/src/ui/Image.cpp
@@ -66,7 +66,7 @@ Image *Image::SetNaturalSize()
 
 void Image::SetTransform(float scale, const vector2f &centre)
 {
-	if (m_scale != scale || !(m_centre == centre)) {
+	if (!is_equal_exact(m_scale, scale) || !m_centre.ExactlyEqual(centre)) {
 		m_needsRefresh = true;
 		m_scale = scale;
 		m_centre = centre;


### PR DESCRIPTION
Couple of minor warnings, one serious. There are still some -Wold-style-cast and -Wswitch warnings being generated by src/RandomColor.cpp, which I can't be bothered to fix right now.

```
../../pioneer/src/RandomColor.cpp: In static member function ‘static int RandomColorGenerator::RandomColor::PickSaturation(int, RandomColorGenerator::Luminosity, RandomColorGenerator::ColorScheme)’:
../../pioneer/src/RandomColor.cpp:90:10: warning: enumeration value ‘LUMINOSITY_RANDOM’ not handled in switch [-Wswitch]
   switch ( luminosity )
          ^
../../pioneer/src/RandomColor.cpp: In static member function ‘static int RandomColorGenerator::RandomColor::PickBrightness(int, int, RandomColorGenerator::Luminosity)’:
../../pioneer/src/RandomColor.cpp:114:10: warning: enumeration value ‘LUMINOSITY_BRIGHT’ not handled in switch [-Wswitch]
   switch ( luminosity )
          ^
```