### PR TITLE
Make GuiTextEntry handle UTF-8 multibyte chars for backspace and delete

### DIFF
--- a/src/gui/GuiTextEntry.cpp
+++ b/src/gui/GuiTextEntry.cpp
@@ -73,13 +73,14 @@ bool TextEntry::OnKeyDown(const SDL_Keysym *sym)
 		accepted = true;
 	}
 
-	// XXX deleting characters is not UTF-8 safe
 	if (sym->sym == SDLK_BACKSPACE) {
 		if (m_cursPos > 0) {
 			if (m_text[m_cursPos-1] == '\n')
 				--m_newlineCount;
-			m_text = m_text.substr(0, m_cursPos-1) + m_text.substr(m_cursPos);
-			SetCursorPos(m_cursPos-1);
+			const char *cstr = m_text.c_str();
+			const int len = Text::utf8_prev_char_offset(cstr + m_cursPos, cstr);
+			m_text = m_text.substr(0, m_cursPos-len) + m_text.substr(m_cursPos);
+			SetCursorPos(m_cursPos-len);
 			changed = true;
 		}
 		accepted = true;
@@ -88,7 +89,9 @@ bool TextEntry::OnKeyDown(const SDL_Keysym *sym)
 		if (m_cursPos < signed(m_text.size())) {
 			if (m_text[m_cursPos] == '\n')
 				--m_newlineCount;
-			m_text = m_text.substr(0, m_cursPos) + m_text.substr(m_cursPos+1);
+			const char *cstr = m_text.c_str();
+			const int len = Text::utf8_next_char_offset(cstr + m_cursPos);
+			m_text = m_text.substr(0, m_cursPos) + m_text.substr(m_cursPos+len);
 			changed = true;
 		}
 		accepted = true;


### PR DESCRIPTION
This should fix #3655 and #2043 (which I think are duplicates?).

However, it's 100% untested (faith-based programming ftw?). So... it would be good if someone could test this before it's merged. If I can remember how to input an accented character on my computer I'll test it myself... :-/