### PR TITLE
Don't compress normal maps

### DIFF
--- a/src/graphics/TextureBuilder.h
+++ b/src/graphics/TextureBuilder.h
@@ -24,6 +24,9 @@ public:
 	static TextureBuilder Model(const std::string &filename) {
 		return TextureBuilder(filename, LINEAR_REPEAT, true, false, false, true, true);
 	}
+	static TextureBuilder Normal(const std::string &filename) {
+		return TextureBuilder(filename, LINEAR_REPEAT, true, false, false, false, true);
+	}
 	static TextureBuilder Billboard(const std::string &filename) {
 		return TextureBuilder(filename, LINEAR_CLAMP, true, false, false, true, false);
 	}

--- a/src/scenegraph/BaseLoader.cpp
+++ b/src/scenegraph/BaseLoader.cpp
@@ -65,7 +65,7 @@ void BaseLoader::ConvertMaterialDefinition(const MaterialDefinition &mdef)
 	//texture4 is reserved for pattern
 	//texture5 is reserved for color gradient
 	if (!normTex.empty())
-		mat->texture6 = Graphics::TextureBuilder::Model(normTex).GetOrCreateTexture(m_renderer, "model");
+		mat->texture6 = Graphics::TextureBuilder::Normal(normTex).GetOrCreateTexture(m_renderer, "model");
 	
 
 	m_model->m_materials.push_back(std::make_pair(mdef.name, mat));


### PR DESCRIPTION
This PR avoid compressing normal maps that are not already in DDS format.
DXTn is pretty bad at handling normal maps and so for now we will simply sidestep the issue and use them without it.

Add TextureBuilder::Normal which will not compress a texture if it isn't already compressed.
Use it for all normal maps, existing DDS normal maps will still be compressed.

ping @nozmajner