### PR TITLE
Fixing the civilian Kanara price and model

### DIFF
--- a/data/ships/kanara_civ.json
+++ b/data/ships/kanara_civ.json
@@ -1,12 +1,12 @@
 {
-	"model" : "kanara",
+	"model" : "kanara_civ",
 	"name" : "Kanara Inteceptor",
 	"cockpit" : "",
 	"manufacturer" : "mandarava_csepel",
 	"ship_class" : "light_fighter",
 	"min_crew" : 1,
 	"max_crew" : 2,
-	"price" : 1,
+	"price" : 156000,
 	"hull_mass" : 10,
 	"capacity" : 8,
 	"slots" : {


### PR DESCRIPTION
I made a mistake back then when I resized the Kanara, and updatet its stats. For some reason I set the price to 1, and it used the police model. So here's the fix. Not the price of the civilian Kanara is somewhere between the Lunar Shuttle and the more hefty Bowfin. And points to the proper model which uses patterns and doesn't have the police logo.