### PR TITLE
Update to whole new Assimp

### DIFF
--- a/data/models/misc/cargo/cargo.model
+++ b/data/models/misc/cargo/cargo.model
@@ -1,4 +1,4 @@
-material cargo-material
+material cargo
 tex_diff cargopod.dds
 tex_glow glow.dds
 tex_spec specular.dds

--- a/data/models/misc/default_cockpit/default_cockpit.model
+++ b/data/models/misc/default_cockpit/default_cockpit.model
@@ -1,4 +1,4 @@
-material cockpit-material
+material cockpit
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 23
@@ -6,7 +6,7 @@ shininess 23
 tex_diff default_cockpit_diff.dds
 tex_glow default_cockpit_diff.dds
 
-material glass-material
+material glass
 diffuse 1.0 1.0 1.0
 specular 0.6 0.6 0.6
 shininess 69
@@ -14,7 +14,7 @@ opacity 4
 tex_diff bigscreen.dds
 tex_glow bigscreen.dds
 
-material screen_speed-material
+material screen_speed
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
@@ -22,21 +22,21 @@ tex_diff speedstuff.dds
 tex_glow speedstuff.dds
 
 
-material screen-material
+material screen
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
 tex_diff orbit_big.dds
 tex_glow orbit_big.dds
 
-material screen_navball-material
+material screen_navball
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
 tex_diff navball.dds
 tex_glow navball.dds
 
-material screen_scanner-material
+material screen_scanner
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
@@ -44,42 +44,42 @@ tex_diff scanner.dds
 tex_glow scanner.dds
 
 
-material screen_contactlist-material
+material screen_contactlist
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
 tex_diff contactlist.dds
 tex_glow contactlist.dds
 
-material screen_nav-material
+material screen_nav
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
 tex_diff orbit_big.dds
 tex_glow orbit_big.dds
 
-material screen_status-material
+material screen_status
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
 tex_diff status.dds
 tex_glow status.dds
 
-material screen_circ-material
+material screen_circ
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
 tex_diff circular_small.dds
 tex_glow circular_small.dds
 
-material screen_circ_001-material
+material screen_circ_001
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69
 tex_diff circular_small2.dds
 tex_glow circular_small2.dds
 
-material screen_circ_002-material
+material screen_circ_002
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 69

--- a/data/models/misc/scale/scale.model
+++ b/data/models/misc/scale/scale.model
@@ -1,18 +1,18 @@
-material Scale-material
+material Scale
 tex_diff scale.dds
 diffuse 1.0 1.0 1.0
 unlit
 
-material Misc-material
+material Misc
 diffuse 1.0 0.0 0.0
 specular 0.0 0.0 0.0
 
-material Shuttle-material
+material Shuttle
 tex_diff shuttle.dds
 alpha_test
 unlit
 
-material Shuttle_top-material
+material Shuttle_top
 tex_diff shuttle_top.dds
 alpha_test
 unlit

--- a/data/models/misc/tombstone/tombstone.model
+++ b/data/models/misc/tombstone/tombstone.model
@@ -1,4 +1,4 @@
-material Default-material
+material Default
 diffuse 0.8 0.8 0.8
 specular 0.3 0.3 0.3
 shininess 40

--- a/data/models/ships/ac33/ac33.model
+++ b/data/models/ships/ac33/ac33.model
@@ -1,4 +1,4 @@
-material Body_Hi-material
+material Body_Hi
 
 tex_diff ac33.dds
 tex_spec ac33_spec.dds

--- a/data/models/ships/amphiesma/amphiesma.model
+++ b/data/models/ships/amphiesma/amphiesma.model
@@ -1,4 +1,4 @@
-material Amph_hull-material
+material Amph_hull
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 69

--- a/data/models/ships/bowfin/bowfin.model
+++ b/data/models/ships/bowfin/bowfin.model
@@ -1,4 +1,4 @@
-material Fuselage-material
+material Fuselage
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 69
@@ -8,7 +8,7 @@ tex_diff bowfin_diff.dds
 tex_spec bowfin_spec.dds
 tex_norm bowfin_norm.dds
 
-material Canopy-material
+material Canopy
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 69

--- a/data/models/ships/deneb/deneb.model
+++ b/data/models/ships/deneb/deneb.model
@@ -1,4 +1,4 @@
-material Body-material
+material Body
 
 tex_diff deneb.dds
 tex_glow deneb_glow.dds

--- a/data/models/ships/dsminer/dsminer.model
+++ b/data/models/ships/dsminer/dsminer.model
@@ -1,4 +1,4 @@
-material fuselage-material
+material fuselage
 tex_diff dsminer_diff.dds
 tex_spec dsminer_spec.dds
 tex_glow dsminer_glow.dds

--- a/data/models/ships/kanara/kanara.model
+++ b/data/models/ships/kanara/kanara.model
@@ -1,4 +1,4 @@
-material fuselage-material
+material fuselage
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 69

--- a/data/models/ships/kanara/kanara_civ.model
+++ b/data/models/ships/kanara/kanara_civ.model
@@ -1,4 +1,4 @@
-material fuselage-material
+material fuselage
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 69

--- a/data/models/ships/lunarshuttle/lunarshuttle.model
+++ b/data/models/ships/lunarshuttle/lunarshuttle.model
@@ -1,6 +1,6 @@
 # Lunar Shuttle
 
-material lunarshuttle_fuselage-material
+material lunarshuttle_fuselage
 tex_diff lunarshuttle_diff.dds
 tex_spec lunarshuttle_spec.dds
 tex_glow lunarshuttle_glow.dds

--- a/data/models/ships/malabar/malabar.model
+++ b/data/models/ships/malabar/malabar.model
@@ -1,4 +1,4 @@
-material malabar-material
+material malabar
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 100

--- a/data/models/ships/malabar/vatakara.model
+++ b/data/models/ships/malabar/vatakara.model
@@ -1,4 +1,4 @@
-material malabar-material
+material malabar_001
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 100

--- a/data/models/ships/molamola/molamola.model
+++ b/data/models/ships/molamola/molamola.model
@@ -1,4 +1,4 @@
-material Fuselage-material
+material Fuselage
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 69

--- a/data/models/ships/natrix/natrix.model
+++ b/data/models/ships/natrix/natrix.model
@@ -1,4 +1,4 @@
-material Hull-material
+material Hull
 tex_diff hull_diff.dds
 tex_spec hull_spec.dds
 tex_glow emit.dds
@@ -6,7 +6,7 @@ diffuse 1.0 1.0 1.0
 specular 1.0 1.0 1.0
 use_patterns
 
-material Gear-material
+material Gear
 tex_diff gear_diff.dds
 diffuse 0.8 0.8 0.8
 specular 1.0 1.0 1.0

--- a/data/models/ships/nerodia/nerodia.model
+++ b/data/models/ships/nerodia/nerodia.model
@@ -1,4 +1,4 @@
-material Material-material
+material Material
 diffuse 1.0 1.0 1.0
 specular 0.8 0.8 0.8
 use_patterns

--- a/data/models/ships/pumpkinseed/pumpkinseed.model
+++ b/data/models/ships/pumpkinseed/pumpkinseed.model
@@ -1,4 +1,4 @@
-material smallship_fuselage-material
+material smallship_fuselage
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 70

--- a/data/models/ships/pumpkinseed/pumpkinseed_police.model
+++ b/data/models/ships/pumpkinseed/pumpkinseed_police.model
@@ -1,4 +1,4 @@
-material smallship_fuselage-material
+material smallship_fuselage
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 70

--- a/data/models/ships/sinonatrix/sinonatrix.model
+++ b/data/models/ships/sinonatrix/sinonatrix.model
@@ -1,4 +1,4 @@
-material Material-material
+material Material
 diffuse 1.0 1.0 1.0
 specular 0.8 0.8 0.8
 use_patterns

--- a/data/models/ships/sinonatrix/sinonatrix_police.model
+++ b/data/models/ships/sinonatrix/sinonatrix_police.model
@@ -1,4 +1,4 @@
-material Material-material
+material Material
 diffuse 1.0 1.0 1.0
 specular 0.8 0.8 0.8
 tex_diff sinonatrix_tex_police.dds

--- a/data/models/ships/storeria/storeria.model
+++ b/data/models/ships/storeria/storeria.model
@@ -1,4 +1,4 @@
-material Material-material
+material Material
 diffuse 1.0 1.0 1.0
 specular 0.8 0.8 0.8
 use_patterns

--- a/data/models/ships/varada/varada.model
+++ b/data/models/ships/varada/varada.model
@@ -1,4 +1,4 @@
-material keszeg_fuselage-material
+material keszeg_fuselage
 diffuse 1.0 1.0 1.0
 specular 0.9 0.9 0.9
 shininess 69

--- a/data/models/ships/venturestar/venturestar.model
+++ b/data/models/ships/venturestar/venturestar.model
@@ -1,4 +1,4 @@
-material Body_Hi-material
+material Body_Hi
 
 tex_diff venturestar.dds
 tex_spec venturestar_spec.dds

--- a/data/models/ships/wave/wave.model
+++ b/data/models/ships/wave/wave.model
@@ -1,21 +1,21 @@
 # Wave
 
-material wave-material
+material wave
 diffuse 0.9 0.9 0.9
 specular 0.05 0.05 0.05
 shininess 100
 tex_diff wave.dds
 tex_spec wave_spec.dds
 use_patterns
-material glow-material
+material glow
 diffuse 0.9 0.9 0.9
 specular 0.7 0.7 0.7
 emissive 0.85 0.85 0.85
 tex_diff glow.dds
 tex_glow glow.dds
 
-# note: landing gear should be put into the UV map and use wave-material
-material landing-gear-material
+# note: landing gear should be put into the UV map and use wave
+material landing-gear
 diffuse 0.3 0.3 0.3
 specular 0 0 0
 

--- a/data/models/ships/xylophis/xylophis.model
+++ b/data/models/ships/xylophis/xylophis.model
@@ -1,4 +1,4 @@
-material Material-material
+material Material
 diffuse 1.0 1.0 1.0
 specular 0.7 0.7 0.7
 shininess 69
@@ -7,7 +7,7 @@ tex_diff xylophis_diff.dds
 tex_spec xylophis_spec.dds
 tex_glow xylophis_glow.dds
 
-material Exaust-material
+material Exaust
 diffuse 1.0 1.0 1.0
 specular 0.1 0.1 0.1
 shininess 40

--- a/data/models/stations/ground_station/ground_station.model
+++ b/data/models/stations/ground_station/ground_station.model
@@ -1,4 +1,4 @@
-material Starport-material
+material Starport
 diffuse 1.0 1.0 1.0
 specular 0.3 0.3 0.3
 shininess 40
@@ -7,7 +7,7 @@ tex_diff station_diff.dds
 tex_glow station_glow.dds
 tex_spec station_spec.dds
 
-material Pipes-material
+material Pipes
 diffuse 0.7 0.7 0.7
 specular 0.0 0.0 0.0
 shininess 10
@@ -15,7 +15,7 @@ tex_diff station_diff.dds
 tex_glow station_glow.dds
 tex_spec station_spec.dds
 
-material Tanks-material
+material Tanks
 diffuse 1.0 1.0 1.0
 specular 0.1 0.1 0.1
 shininess 40

--- a/data/models/stations/new_ground/new_ground.model
+++ b/data/models/stations/new_ground/new_ground.model
@@ -8,24 +8,24 @@
 #
 # New textures and materials were made by me and new geometry for the 4 lifts.
 
-material rim-material
+material rim
 diffuse 1.0 1.0 1.0
 specular 0.5 0.5 0.5
 tex_diff Steelplt.dds
 
-material column-material
+material column
 diffuse 1.0 1.0 1.0
 specular 0.5 0.5 0.5
 tex_diff LiftColumn.dds
 tex_glow LiftColumn_illum.dds
 
-material lamp_glow-material
+material lamp_glow
 diffuse 1.0 1.0 1.0
 specular 0.5 0.5 0.5
 tex_diff LiftColumn.dds
 tex_glow LiftColumn_illum.dds
 
-material pad-material
+material pad
 diffuse 1.0 1.0 1.0
 specular 0.5 0.5 0.5
 tex_diff c_metall.dds

--- a/data/models/stations/orbital_station/orbital_station_2-10k.model
+++ b/data/models/stations/orbital_station/orbital_station_2-10k.model
@@ -1,42 +1,42 @@
-material facade-material
+material facade
 tex_diff facades_diff.dds
 tex_glow facades_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material floor-material
+material floor
 tex_diff floors_diff.dds
 tex_glow floors_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material tunnels-material
+material tunnels
 tex_diff spoke_n_misc_diff.dds
 tex_glow spoke_n_misc_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material facade_window-material
+material facade_window
 tex_diff facades_diff.dds
 tex_glow facades_diff.dds
 specular 0.6 0.6 0.6
 opacity 13
 
-material ring-material
+material ring
 tex_diff ring_diff.dds
 tex_glow ring_glow.dds
 specular 0.1 0.1 0.1
 
-material ring_glass-material
+material ring_glass
 tex_diff ring_diff.dds
 specular 0.7 0.7 0.7
 opacity 20
 
-material strut-material
+material strut
 tex_diff struts_diff.dds
 specular 0.1 0.1 0.1
 
-material spokes-material
+material spokes
 tex_diff spoke_n_misc_diff.dds
 specular 0.1 0.1 0.1
 

--- a/data/models/stations/orbital_station/orbital_station_2-2k.model
+++ b/data/models/stations/orbital_station/orbital_station_2-2k.model
@@ -1,42 +1,42 @@
-material facade-material
+material facade
 tex_diff facades_diff.dds
 tex_glow facades_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material floor-material
+material floor
 tex_diff floors_diff.dds
 tex_glow floors_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material tunnels-material
+material tunnels
 tex_diff spoke_n_misc_diff.dds
 tex_glow spoke_n_misc_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material facade_window-material
+material facade_window
 tex_diff facades_diff.dds
 tex_glow facades_diff.dds
 specular 0.6 0.6 0.6
 opacity 13
 
-material ring-material
+material ring
 tex_diff ring_diff.dds
 tex_glow ring_glow.dds
 specular 0.1 0.1 0.1
 
-material ring_glass-material
+material ring_glass
 tex_diff ring_diff.dds
 specular 0.7 0.7 0.7
 opacity 20
 
-material strut-material
+material strut
 tex_diff struts_diff.dds
 specular 0.1 0.1 0.1
 
-material spokes-material
+material spokes
 tex_diff spoke_n_misc_diff.dds
 specular 0.1 0.1 0.1
 

--- a/data/models/stations/orbital_station/orbital_station_2-5k.model
+++ b/data/models/stations/orbital_station/orbital_station_2-5k.model
@@ -1,42 +1,42 @@
-material facade-material
+material facade
 tex_diff facades_diff.dds
 tex_glow facades_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material floor-material
+material floor
 tex_diff floors_diff.dds
 tex_glow floors_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material tunnels-material
+material tunnels
 tex_diff spoke_n_misc_diff.dds
 tex_glow spoke_n_misc_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material facade_window-material
+material facade_window
 tex_diff facades_diff.dds
 tex_glow facades_diff.dds
 specular 0.6 0.6 0.6
 opacity 13
 
-material ring-material
+material ring
 tex_diff ring_diff.dds
 tex_glow ring_glow.dds
 specular 0.1 0.1 0.1
 
-material ring_glass-material
+material ring_glass
 tex_diff ring_diff.dds
 specular 0.7 0.7 0.7
 opacity 20
 
-material strut-material
+material strut
 tex_diff struts_diff.dds
 specular 0.1 0.1 0.1
 
-material spokes-material
+material spokes
 tex_diff spoke_n_misc_diff.dds
 specular 0.1 0.1 0.1
 

--- a/data/models/stations/orbital_station/orbital_station_2-5k10k.model
+++ b/data/models/stations/orbital_station/orbital_station_2-5k10k.model
@@ -1,42 +1,42 @@
-material facade-material
+material facade
 tex_diff facades_diff.dds
 tex_glow facades_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material floor-material
+material floor
 tex_diff floors_diff.dds
 tex_glow floors_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material tunnels-material
+material tunnels
 tex_diff spoke_n_misc_diff.dds
 tex_glow spoke_n_misc_diff.dds
 specular 0.1 0.1 0.1
 unlit
 
-material facade_window-material
+material facade_window
 tex_diff facades_diff.dds
 tex_glow facades_diff.dds
 specular 0.6 0.6 0.6
 opacity 13
 
-material ring-material
+material ring
 tex_diff ring_diff.dds
 tex_glow ring_glow.dds
 specular 0.1 0.1 0.1
 
-material ring_glass-material
+material ring_glass
 tex_diff ring_diff.dds
 specular 0.7 0.7 0.7
 opacity 20
 
-material strut-material
+material strut
 tex_diff struts_diff.dds
 specular 0.1 0.1 0.1
 
-material spokes-material
+material spokes
 tex_diff spoke_n_misc_diff.dds
 specular 0.1 0.1 0.1
 

--- a/data/models/weapons/missile/missile.model
+++ b/data/models/weapons/missile/missile.model
@@ -1,4 +1,4 @@
-material Missile-material
+material Missile
 tex_diff diffuse.dds
 
 mesh missile.dae

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -269,7 +269,7 @@ bool ModelViewer::OnToggleGuns(UI::CheckBox *w)
 
 bool ModelViewer::OnRandomColor(UI::Widget*)
 {
-	if (!m_model) return false;
+	if (!m_model || !m_model->SupportsPatterns()) return false;
 
 	SceneGraph::ModelSkin skin;
 	skin.SetRandomColors(m_rng);
@@ -281,7 +281,8 @@ bool ModelViewer::OnRandomColor(UI::Widget*)
 	for(unsigned int i=0; i<3; i++) {
 		for(unsigned int j=0; j<3; j++) {
 			// use ToColor4f to get the colours in 0..1 range required
-			colorSliders[(i*3)+j]->SetValue(colors[i].ToColor4f()[j]);
+			if( colorSliders[(i*3)+j] )
+				colorSliders[(i*3)+j]->SetValue(colors[i].ToColor4f()[j]);
 		}
 	}
 	m_settingColourSliders = false;

--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -74,8 +74,14 @@ void RunCompiler(const std::string &modelName, const std::string &filepath, cons
 	//and then save it into binary
 	std::unique_ptr<SceneGraph::Model> model;
 	try {
-		SceneGraph::Loader ld(s_renderer.get(), false, false);
+		SceneGraph::Loader ld(s_renderer.get(), true, false);
 		model.reset(ld.LoadModel(modelName));
+		//dump warnings
+		for (std::vector<std::string>::const_iterator it = ld.GetLogMessages().begin();
+			it != ld.GetLogMessages().end(); ++it)
+		{
+			Output("%s\n", (*it).c_str());
+		}
 	} catch (...) {
 		//minimal error handling, this is not expected to happen since we got this far.
 		return;

--- a/win32/vs2015/modelcompiler.vcxproj
+++ b/win32/vs2015/modelcompiler.vcxproj
@@ -156,7 +156,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>../../win32/lib;../../../pioneer-thirdparty/win32/lib/vs2015;$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>json.lib;assimp.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>json.lib;assimp-vc140-mt.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='PreRelease|Win32'">
@@ -177,7 +177,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>../../win32/lib;../../../pioneer-thirdparty/win32/lib/vs2015;$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>json.lib;assimp.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>json.lib;assimp-vc140-mt.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
@@ -201,7 +201,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>../../win32/lib;../../../pioneer-thirdparty/win32/lib/vs2015;$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>json.lib;assimp.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>json.lib;assimp-vc140-mt.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'">
@@ -224,7 +224,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>../../win32/lib;../../../pioneer-thirdparty/win32/lib/vs2015;$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>json.lib;assimp.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>json.lib;assimp-vc140-mt.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/win32/vs2015/pioneer.vcxproj
+++ b/win32/vs2015/pioneer.vcxproj
@@ -106,7 +106,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>libcurl.lib;profiler.lib;json.lib;assimp.lib;shlwapi.lib;libogg_static_vc2015_debug.lib;libvorbis_static_v140_debug.lib;libvorbisfile_static_v140_debug.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-d-2_0.lib;libpng15.lib;zlib.lib;collider.lib;galaxy.lib;graphics.lib;gui.lib;ui.lib;jenkins.lib;lua.lib;terrain.lib;text.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurl.lib;profiler.lib;json.lib;assimp-vc140-mt.lib;shlwapi.lib;libogg_static_vc2015_debug.lib;libvorbis_static_v140_debug.lib;libvorbisfile_static_v140_debug.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-d-2_0.lib;libpng15.lib;zlib.lib;collider.lib;galaxy.lib;graphics.lib;gui.lib;ui.lib;jenkins.lib;lua.lib;terrain.lib;text.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../../win32/lib;../../../pioneer-thirdparty/win32/lib/vs2015;$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>msvcrt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <LargeAddressAware>true</LargeAddressAware>
@@ -120,7 +120,7 @@
     <ClCompile />
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>libcurl.lib;profiler.lib;json.lib;assimp.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-d-2_0.lib;libpng15.lib;zlib.lib;collider.lib;galaxy.lib;graphics.lib;gui.lib;ui.lib;jenkins.lib;lua.lib;terrain.lib;text.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurl.lib;profiler.lib;json.lib;assimp-vc140-mt.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-d-2_0.lib;libpng15.lib;zlib.lib;collider.lib;galaxy.lib;graphics.lib;gui.lib;ui.lib;jenkins.lib;lua.lib;terrain.lib;text.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../../win32/lib;../../../pioneer-thirdparty/win32/lib/vs2015;$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>msvcrt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
@@ -141,7 +141,7 @@
     <ClCompile />
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>libcurl.lib;profiler.lib;json.lib;assimp.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurl.lib;profiler.lib;json.lib;assimp-vc140-mt.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../../win32/lib;../../../pioneer-thirdparty/win32/lib/vs2015;$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
@@ -165,7 +165,7 @@
     <ClCompile />
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>libcurl.lib;common.lib;crash_generation_client.lib;exception_handler.lib;profiler.lib;json.lib;assimp.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurl.lib;common.lib;crash_generation_client.lib;exception_handler.lib;profiler.lib;json.lib;assimp-vc140-mt.lib;lua.lib;jenkins.lib;shlwapi.lib;libogg_static_vc2015_release.lib;libvorbis_static_v140_release.lib;libvorbisfile_static_v140_release.lib;sdl2.lib;sdl2main.lib;opengl32.lib;glu32.lib;SDL2_image.lib;freetype2312MT.lib;sigc-v140-2_0.lib;libpng15.lib;zlib.lib;text.lib;galaxy.lib;collider.lib;graphics.lib;terrain.lib;gui.lib;ui.lib;scenegraph.lib;gameui.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../../win32/lib;../../../pioneer-thirdparty/win32/lib/vs2015;$(SolutionDir)$(Configuration)</AdditionalLibraryDirectories>
       <LargeAddressAware>true</LargeAddressAware>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>


### PR DESCRIPTION
This updates us to use the new Assimp library in pioneer-thirdparty.

Then I added dumping the warnings found when the modelcompiler is used, then I fixed up the bowfin and orbital station `.model` material names.
There are [many warnings](http://pioneerspacesim.net/forum/viewtopic.php?f=3&t=27&start=50#p4692)

**EDIT:** Also it's a fix for #3654