### PR TITLE
Fix ModelViewer crash

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -184,8 +184,7 @@ void ModelViewer::Run(const std::string &modelName)
 
 bool ModelViewer::OnPickModel(UI::List *list)
 {
-	SetModel(list->GetSelectedOption());
-	ResetCamera();
+	m_requestedModelName = list->GetSelectedOption();
 	return true;
 }
 
@@ -595,6 +594,13 @@ void ModelViewer::MainLoop()
 
 		// end scene
 		m_renderer->SwapBuffers();
+
+		// if we've requested a different model then switch too it
+		if(!m_requestedModelName.empty()) {
+			SetModel(m_requestedModelName);
+			m_requestedModelName.clear();
+			ResetCamera();
+		}
 	}
 }
 

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -105,6 +105,7 @@ private:
 	std::unique_ptr<SceneGraph::Model> m_gunModel;
 	std::unique_ptr<SceneGraph::Model> m_scaleModel;
 	std::string m_modelName;
+	std::string m_requestedModelName;
 	RefCountedPtr<UI::Context> m_ui;
 	Graphics::RenderState *m_bgState;
 	RefCountedPtr<Graphics::VertexBuffer> m_bgBuffer;


### PR DESCRIPTION
Request a model, don't just switch and destroy the UI whilst we're in it's processing stage.

This fixes a crash that I frequently see when the UI is destroyed as a result of `SetModel` calling the `onModelChanged.emit()` as a result of a UI list being handled.

Now I can change models until the cows come home.