### PR TITLE
Fix editing the gas giants in ObjectViewer editor mode

### DIFF
--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -31,18 +31,19 @@ public:
 	GasGiant(const SystemBody *body);
 	virtual ~GasGiant();
 
-	virtual void Update();
-	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows);
+	virtual void Update() override;
+	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
 
-	virtual double GetHeight(const vector3d &p) const { return 0.0; }
+	virtual double GetHeight(const vector3d &p) const override { return 0.0; }
 
 	// in sbody radii
-	virtual double GetMaxFeatureHeight() const { return 0.0; }
+	virtual double GetMaxFeatureHeight() const override { return 0.0; }
 
-	virtual void Reset() {};
+	virtual void Reset() override;
 
 	static bool OnAddTextureFaceResult(const SystemPath &path, STextureFaceResult *res);
 	static void UpdateAllGasGiants();
+	static void OnChangeDetailLevel();
 
 private:
 	void BuildFirstPatches();
@@ -57,7 +58,7 @@ private:
 	bool m_hasTempCampos;
 	vector3d m_tempCampos;
 
-	virtual void SetUpMaterials();
+	virtual void SetUpMaterials() override;
 	RefCountedPtr<Graphics::Texture> m_surfaceTextureSmall;
 	RefCountedPtr<Graphics::Texture> m_surfaceTexture;
 	

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -33,10 +33,10 @@ public:
 	GeoSphere(const SystemBody *body);
 	virtual ~GeoSphere();
 
-	virtual void Update();
-	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows);
+	virtual void Update() override;
+	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
 
-	virtual double GetHeight(const vector3d &p) const {
+	virtual double GetHeight(const vector3d &p) const override {
 		const double h = m_terrain->GetHeight(p);
 #ifdef DEBUG
 		// XXX don't remove this. Fix your fractals instead
@@ -64,7 +64,7 @@ public:
 	bool AddSingleSplitResult(SSingleSplitResult *res);
 	void ProcessSplitResults();
 
-	virtual void Reset();
+	virtual void Reset() override;
 
 	inline Sint32 GetMaxDepth() const { return m_maxDepth; }
 
@@ -98,7 +98,7 @@ private:
 
 	static RefCountedPtr<GeoPatchContext> s_patchContext;
 
-	virtual void SetUpMaterials();
+	virtual void SetUpMaterials() override;
 
 	RefCountedPtr<Graphics::Texture> m_texHi;
 	RefCountedPtr<Graphics::Texture> m_texLo;

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -133,4 +133,5 @@ bool TerrainBody::IsSuperType(SystemBody::BodySuperType t) const
 void TerrainBody::OnChangeDetailLevel()
 {
 	GeoSphere::OnChangeDetailLevel();
+	GasGiant::OnChangeDetailLevel();
 }


### PR DESCRIPTION
Gas Giants lacked the `OnChangeDetailLevel()` method and their `Reset()` was empty so you could not make any changes within the `ObjectViewer` and see them.

To access the `ObjectViewer` just target a gas giant, for example F2->F7->click on Jupiter then press CTRL+F10.

You cna now change the seeds and see it regenerate.