### PR TITLE
Saving changes

### DIFF
--- a/contrib/json/JsonUtils.cpp
+++ b/contrib/json/JsonUtils.cpp
@@ -233,7 +233,7 @@ void BinStrToJson(Json::Value &jsonObj, const std::string &binStr, const std::st
 	if (pCompressedData) {
 		Json::Value binStrArray(Json::arrayValue); // Create JSON array to contain binary string data.
 		binStrArray.resize(outSize/4); // Pre-Allocate (packed) space for it
-		const size_t remainder = outSize%4;// Does everything fit into the packing scheme?
+		const uint32_t remainder = outSize%4;// Does everything fit into the packing scheme?
 		size_t charIndex = 0;
 		size_t binStrIdx = 0;
 		// Packed everything that fits into our 4-byte packing
@@ -256,7 +256,7 @@ void BinStrToJson(Json::Value &jsonObj, const std::string &binStr, const std::st
 		}
 		// Add compressed and packed binary string array to supplied object.
 		jsonObj[name] = binStrArray; 
-		jsonObj["remainder"] = remainder;
+		jsonObj["remainder"] = Json::Value(remainder);
 		// release the compressed data
 		mz_free(pCompressedData);
 	}
@@ -500,9 +500,9 @@ std::string JsonToBinStr(const Json::Value &jsonObj, const std::string &name)
 	Json::Value binStrArray = jsonObj[name.c_str()];
 	if (!binStrArray.isArray()) throw SavedGameCorruptException();
 	
-	const size_t arraySize = binStrArray.size();
+	const uint32_t arraySize = binStrArray.size();
 	std::unique_ptr<uint8_t[]> compStr(new uint8_t[arraySize*4]);
-	for (size_t charIndex = 0; charIndex < arraySize; ++charIndex) {
+	for (uint32_t charIndex = 0; charIndex < arraySize; ++charIndex) {
 		const uint32_t packed = binStrArray[charIndex].asUInt();
 		uint8_t a,b,c,d;
 		unpack4char(packed,

--- a/contrib/json/JsonUtils.cpp
+++ b/contrib/json/JsonUtils.cpp
@@ -11,6 +11,7 @@
 
 void VectorToJson(Json::Value &jsonObj, const vector3f &vec, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value vecArray(Json::arrayValue); // Create JSON array to contain vector data.
@@ -22,6 +23,7 @@ void VectorToJson(Json::Value &jsonObj, const vector3f &vec, const std::string &
 
 void VectorToJson(Json::Value &jsonObj, const vector3d &vec, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value vecArray(Json::arrayValue); // Create JSON array to contain vector data.
@@ -33,6 +35,7 @@ void VectorToJson(Json::Value &jsonObj, const vector3d &vec, const std::string &
 
 void QuaternionToJson(Json::Value &jsonObj, const Quaternionf &quat, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value quatArray(Json::arrayValue); // Create JSON array to contain quaternion data.
@@ -45,6 +48,7 @@ void QuaternionToJson(Json::Value &jsonObj, const Quaternionf &quat, const std::
 
 void QuaternionToJson(Json::Value &jsonObj, const Quaterniond &quat, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value quatArray(Json::arrayValue); // Create JSON array to contain quaternion data.
@@ -57,6 +61,7 @@ void QuaternionToJson(Json::Value &jsonObj, const Quaterniond &quat, const std::
 
 void MatrixToJson(Json::Value &jsonObj, const matrix3x3f &mat, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
@@ -74,6 +79,7 @@ void MatrixToJson(Json::Value &jsonObj, const matrix3x3f &mat, const std::string
 
 void MatrixToJson(Json::Value &jsonObj, const matrix3x3d &mat, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
@@ -91,6 +97,7 @@ void MatrixToJson(Json::Value &jsonObj, const matrix3x3d &mat, const std::string
 
 void MatrixToJson(Json::Value &jsonObj, const matrix4x4f &mat, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
@@ -115,6 +122,7 @@ void MatrixToJson(Json::Value &jsonObj, const matrix4x4f &mat, const std::string
 
 void MatrixToJson(Json::Value &jsonObj, const matrix4x4d &mat, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
@@ -139,6 +147,7 @@ void MatrixToJson(Json::Value &jsonObj, const matrix4x4d &mat, const std::string
 
 void ColorToJson(Json::Value &jsonObj, const Color3ub &col, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value colArray(Json::arrayValue); // Create JSON array to contain color data.
@@ -150,6 +159,7 @@ void ColorToJson(Json::Value &jsonObj, const Color3ub &col, const std::string &n
 
 void ColorToJson(Json::Value &jsonObj, const Color4ub &col, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value colArray(Json::arrayValue); // Create JSON array to contain color data.
@@ -162,6 +172,7 @@ void ColorToJson(Json::Value &jsonObj, const Color4ub &col, const std::string &n
 
 void BinStrToJson(Json::Value &jsonObj, const std::string &binStr, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	Json::Value binStrArray(Json::arrayValue); // Create JSON array to contain binary string data.
@@ -172,6 +183,7 @@ void BinStrToJson(Json::Value &jsonObj, const std::string &binStr, const std::st
 
 void JsonToVector(vector3f *pVec, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 	
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -186,6 +198,7 @@ void JsonToVector(vector3f *pVec, const Json::Value &jsonObj, const std::string 
 
 void JsonToVector(vector3d *pVec, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -200,6 +213,7 @@ void JsonToVector(vector3d *pVec, const Json::Value &jsonObj, const std::string 
 
 void JsonToQuaternion(Quaternionf *pQuat, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -215,6 +229,7 @@ void JsonToQuaternion(Quaternionf *pQuat, const Json::Value &jsonObj, const std:
 
 void JsonToQuaternion(Quaterniond *pQuat, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -230,6 +245,7 @@ void JsonToQuaternion(Quaterniond *pQuat, const Json::Value &jsonObj, const std:
 
 void JsonToMatrix(matrix3x3f *pMat, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -250,6 +266,7 @@ void JsonToMatrix(matrix3x3f *pMat, const Json::Value &jsonObj, const std::strin
 
 void JsonToMatrix(matrix3x3d *pMat, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -270,6 +287,7 @@ void JsonToMatrix(matrix3x3d *pMat, const Json::Value &jsonObj, const std::strin
 
 void JsonToMatrix(matrix4x4f *pMat, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -297,6 +315,7 @@ void JsonToMatrix(matrix4x4f *pMat, const Json::Value &jsonObj, const std::strin
 
 void JsonToMatrix(matrix4x4d *pMat, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -324,6 +343,7 @@ void JsonToMatrix(matrix4x4d *pMat, const Json::Value &jsonObj, const std::strin
 
 void JsonToColor(Color3ub *pCol, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -338,6 +358,7 @@ void JsonToColor(Color3ub *pCol, const Json::Value &jsonObj, const std::string &
 
 void JsonToColor(Color4ub *pCol, const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
@@ -353,6 +374,7 @@ void JsonToColor(Color4ub *pCol, const Json::Value &jsonObj, const std::string &
 
 std::string JsonToBinStr(const Json::Value &jsonObj, const std::string &name)
 {
+	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();

--- a/contrib/json/JsonUtils.cpp
+++ b/contrib/json/JsonUtils.cpp
@@ -234,7 +234,7 @@ void BinStrToJson(Json::Value &jsonObj, const std::string &binStr, const std::st
 		Json::Value binStrArray(Json::arrayValue); // Create JSON array to contain binary string data.
 		binStrArray.resize(outSize); // Pre-Allocate (packed) space for it
 		// Packed everything that fits into our 4-byte packing
-		for (size_t charIndex = 0; charIndex < outSize; ++charIndex) {
+		for (uint32_t charIndex = 0; charIndex < outSize; ++charIndex) {
 			binStrArray[charIndex] = int(((uint8_t*)pCompressedData)[charIndex]);
 		}
 		// Add compressed and packed binary string array to supplied object.

--- a/contrib/json/JsonUtils.cpp
+++ b/contrib/json/JsonUtils.cpp
@@ -235,7 +235,7 @@ void BinStrToJson(Json::Value &jsonObj, const std::string &binStr, const std::st
 		binStrArray.resize(outSize/4); // Pre-Allocate (packed) space for it
 		const uint32_t remainder = outSize%4;// Does everything fit into the packing scheme?
 		size_t charIndex = 0;
-		size_t binStrIdx = 0;
+		uint32_t binStrIdx = 0;
 		// Packed everything that fits into our 4-byte packing
 		for (; charIndex < (outSize-remainder); charIndex+=4, ++binStrIdx) {
 			const uint32_t packed = pack4char(

--- a/contrib/json/JsonUtils.cpp
+++ b/contrib/json/JsonUtils.cpp
@@ -9,28 +9,59 @@
 #include "../../src/utils.h"
 #include "../../src/Serializer.h" // Need this for the exceptions
 
+extern "C" {
+#include "miniz/miniz.h"
+}
+
+namespace {
+	uint32_t pack4char(const uint8_t a, const uint8_t b, const uint8_t c, const uint8_t d)
+	{
+		return ((a << 24) | (b << 16) | (c << 8) | d);
+	}
+
+	void unpack4char(const uint32_t packed, uint8_t &a, uint8_t &b, uint8_t &c, uint8_t &d)
+	{
+		a = ((packed >> 24) & 0xff);
+		b = ((packed >> 16) & 0xff);
+		c = ((packed >> 8) & 0xff);
+		d = (packed & 0xff);
+	}
+};
+
+#define USE_STRING_VERSIONS
+
 void VectorToJson(Json::Value &jsonObj, const vector3f &vec, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	char str[128];
+	Vector3fToStr(vec, str, 128);
+	jsonObj[name] = str; // Add vector array to supplied object.
+#else
 	Json::Value vecArray(Json::arrayValue); // Create JSON array to contain vector data.
 	vecArray[0] = FloatToStr(vec.x);
 	vecArray[1] = FloatToStr(vec.y);
 	vecArray[2] = FloatToStr(vec.z);
 	jsonObj[name] = vecArray; // Add vector array to supplied object.
+#endif
 }
 
 void VectorToJson(Json::Value &jsonObj, const vector3d &vec, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	char str[128];
+	Vector3dToStr(vec, str, 128);
+	jsonObj[name] = str; // Add vector array to supplied object.
+#else
 	Json::Value vecArray(Json::arrayValue); // Create JSON array to contain vector data.
 	vecArray[0] = DoubleToStr(vec.x);
 	vecArray[1] = DoubleToStr(vec.y);
 	vecArray[2] = DoubleToStr(vec.z);
 	jsonObj[name] = vecArray; // Add vector array to supplied object.
+#endif
 }
 
 void QuaternionToJson(Json::Value &jsonObj, const Quaternionf &quat, const std::string &name)
@@ -63,7 +94,11 @@ void MatrixToJson(Json::Value &jsonObj, const matrix3x3f &mat, const std::string
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	char str[512];
+	Matrix3x3fToStr(mat, str, 512);
+	jsonObj[name] = str;
+#else
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
 	matArray[0] = FloatToStr(mat[0]);
 	matArray[1] = FloatToStr(mat[1]);
@@ -75,13 +110,18 @@ void MatrixToJson(Json::Value &jsonObj, const matrix3x3f &mat, const std::string
 	matArray[7] = FloatToStr(mat[7]);
 	matArray[8] = FloatToStr(mat[8]);
 	jsonObj[name] = matArray; // Add matrix array to supplied object.
+#endif
 }
 
 void MatrixToJson(Json::Value &jsonObj, const matrix3x3d &mat, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	char str[512];
+	Matrix3x3dToStr(mat, str, 512);
+	jsonObj[name] = str;
+#else
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
 	matArray[0] = DoubleToStr(mat[0]);
 	matArray[1] = DoubleToStr(mat[1]);
@@ -93,13 +133,18 @@ void MatrixToJson(Json::Value &jsonObj, const matrix3x3d &mat, const std::string
 	matArray[7] = DoubleToStr(mat[7]);
 	matArray[8] = DoubleToStr(mat[8]);
 	jsonObj[name] = matArray; // Add matrix array to supplied object.
+#endif
 }
 
 void MatrixToJson(Json::Value &jsonObj, const matrix4x4f &mat, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	char str[512];
+	Matrix4x4fToStr(mat, str, 512);
+	jsonObj[name] = str;
+#else
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
 	matArray[0] = FloatToStr(mat[0]);
 	matArray[1] = FloatToStr(mat[1]);
@@ -118,13 +163,18 @@ void MatrixToJson(Json::Value &jsonObj, const matrix4x4f &mat, const std::string
 	matArray[14] = FloatToStr(mat[14]);
 	matArray[15] = FloatToStr(mat[15]);
 	jsonObj[name] = matArray; // Add matrix array to supplied object.
+#endif
 }
 
 void MatrixToJson(Json::Value &jsonObj, const matrix4x4d &mat, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	char str[512];
+	Matrix4x4dToStr(mat, str, 512);
+	jsonObj[name] = str;
+#else
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
 	matArray[0] = DoubleToStr(mat[0]);
 	matArray[1] = DoubleToStr(mat[1]);
@@ -143,6 +193,7 @@ void MatrixToJson(Json::Value &jsonObj, const matrix4x4d &mat, const std::string
 	matArray[14] = DoubleToStr(mat[14]);
 	matArray[15] = DoubleToStr(mat[15]);
 	jsonObj[name] = matArray; // Add matrix array to supplied object.
+#endif
 }
 
 void ColorToJson(Json::Value &jsonObj, const Color3ub &col, const std::string &name)
@@ -175,17 +226,53 @@ void BinStrToJson(Json::Value &jsonObj, const std::string &binStr, const std::st
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 
-	Json::Value binStrArray(Json::arrayValue); // Create JSON array to contain binary string data.
-	for (unsigned int charIndex = 0; charIndex < binStr.size(); ++charIndex)
-		binStrArray[charIndex] = int(binStr[charIndex]);
-	jsonObj[name] = binStrArray; // Add binary string array to supplied object.
+	// compress in memory, write to open file 
+	size_t outSize = 0;
+	void *pCompressedData = tdefl_compress_mem_to_heap(binStr.data(), binStr.length(), &outSize, 128);
+
+	if (pCompressedData) {
+		Json::Value binStrArray(Json::arrayValue); // Create JSON array to contain binary string data.
+		binStrArray.resize(outSize/4); // Pre-Allocate (packed) space for it
+		const size_t remainder = outSize%4;// Does everything fit into the packing scheme?
+		size_t charIndex = 0;
+		size_t binStrIdx = 0;
+		// Packed everything that fits into our 4-byte packing
+		for (; charIndex < (outSize-remainder); charIndex+=4, ++binStrIdx) {
+			const uint32_t packed = pack4char(
+				((uint8_t*)pCompressedData)[charIndex+0],
+				((uint8_t*)pCompressedData)[charIndex+1],
+				((uint8_t*)pCompressedData)[charIndex+2],
+				((uint8_t*)pCompressedData)[charIndex+3]);
+			binStrArray[binStrIdx] = packed;
+		}
+		if(remainder) {
+			// package the remaining bytes (1-to-3 really) into 4-bytes
+			const uint32_t packed = pack4char(
+				((uint8_t*)pCompressedData)[charIndex+0],
+				(remainder>1) ? ((uint8_t*)pCompressedData)[charIndex+1] : '\0',
+				(remainder>2) ? ((uint8_t*)pCompressedData)[charIndex+2] : '\0',
+				(remainder>3) ? ((uint8_t*)pCompressedData)[charIndex+3] : '\0');
+			binStrArray[binStrIdx] = packed;
+		}
+		// Add compressed and packed binary string array to supplied object.
+		jsonObj[name] = binStrArray; 
+		jsonObj["remainder"] = remainder;
+		// release the compressed data
+		mz_free(pCompressedData);
+	}
 }
 
 void JsonToVector(vector3f *pVec, const Json::Value &jsonObj, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-	
+#ifdef USE_STRING_VERSIONS
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value vecStr = jsonObj[name.c_str()];
+	if (!vecStr.isString()) throw SavedGameCorruptException();
+
+	StrToVector3f(vecStr.asCString(), *pVec);
+#else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value vecArray = jsonObj[name.c_str()];
 	if (!vecArray.isArray()) throw SavedGameCorruptException();
@@ -194,13 +281,20 @@ void JsonToVector(vector3f *pVec, const Json::Value &jsonObj, const std::string 
 	pVec->x = StrToFloat(vecArray[0].asString());
 	pVec->y = StrToFloat(vecArray[1].asString());
 	pVec->z = StrToFloat(vecArray[2].asString());
+#endif
 }
 
 void JsonToVector(vector3d *pVec, const Json::Value &jsonObj, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
+#ifdef USE_STRING_VERSIONS
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value vecStr = jsonObj[name.c_str()];
+	if (!vecStr.isString()) throw SavedGameCorruptException();
 
+	StrToVector3d(vecStr.asCString(), *pVec);
+#else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value vecArray = jsonObj[name.c_str()];
 	if (!vecArray.isArray()) throw SavedGameCorruptException();
@@ -209,6 +303,7 @@ void JsonToVector(vector3d *pVec, const Json::Value &jsonObj, const std::string 
 	pVec->x = StrToDouble(vecArray[0].asString());
 	pVec->y = StrToDouble(vecArray[1].asString());
 	pVec->z = StrToDouble(vecArray[2].asString());
+#endif
 }
 
 void JsonToQuaternion(Quaternionf *pQuat, const Json::Value &jsonObj, const std::string &name)
@@ -247,7 +342,12 @@ void JsonToMatrix(matrix3x3f *pMat, const Json::Value &jsonObj, const std::strin
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value matStr = jsonObj[name.c_str()];
+	if (!matStr.isString()) throw SavedGameCorruptException();
+	StrToMatrix3x3f(matStr.asCString(), *pMat);
+#else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value matArray = jsonObj[name.c_str()];
 	if (!matArray.isArray()) throw SavedGameCorruptException();
@@ -262,13 +362,19 @@ void JsonToMatrix(matrix3x3f *pMat, const Json::Value &jsonObj, const std::strin
 	(*pMat)[6] = StrToFloat(matArray[6].asString());
 	(*pMat)[7] = StrToFloat(matArray[7].asString());
 	(*pMat)[8] = StrToFloat(matArray[8].asString());
+#endif
 }
 
 void JsonToMatrix(matrix3x3d *pMat, const Json::Value &jsonObj, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value matStr = jsonObj[name.c_str()];
+	if (!matStr.isString()) throw SavedGameCorruptException();
+	StrToMatrix3x3d(matStr.asCString(), *pMat);
+#else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value matArray = jsonObj[name.c_str()];
 	if (!matArray.isArray()) throw SavedGameCorruptException();
@@ -283,13 +389,19 @@ void JsonToMatrix(matrix3x3d *pMat, const Json::Value &jsonObj, const std::strin
 	(*pMat)[6] = StrToDouble(matArray[6].asString());
 	(*pMat)[7] = StrToDouble(matArray[7].asString());
 	(*pMat)[8] = StrToDouble(matArray[8].asString());
+#endif
 }
 
 void JsonToMatrix(matrix4x4f *pMat, const Json::Value &jsonObj, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value matStr = jsonObj[name.c_str()];
+	if (!matStr.isString()) throw SavedGameCorruptException();
+	StrToMatrix4x4f(matStr.asCString(), *pMat);
+#else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value matArray = jsonObj[name.c_str()];
 	if (!matArray.isArray()) throw SavedGameCorruptException();
@@ -311,13 +423,19 @@ void JsonToMatrix(matrix4x4f *pMat, const Json::Value &jsonObj, const std::strin
 	(*pMat)[13] = StrToFloat(matArray[13].asString());
 	(*pMat)[14] = StrToFloat(matArray[14].asString());
 	(*pMat)[15] = StrToFloat(matArray[15].asString());
+#endif
 }
 
 void JsonToMatrix(matrix4x4d *pMat, const Json::Value &jsonObj, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
-
+#ifdef USE_STRING_VERSIONS
+	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
+	Json::Value matStr = jsonObj[name.c_str()];
+	if (!matStr.isString()) throw SavedGameCorruptException();
+	StrToMatrix4x4d(matStr.asCString(), *pMat);
+#else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value matArray = jsonObj[name.c_str()];
 	if (!matArray.isArray()) throw SavedGameCorruptException();
@@ -339,6 +457,7 @@ void JsonToMatrix(matrix4x4d *pMat, const Json::Value &jsonObj, const std::strin
 	(*pMat)[13] = StrToDouble(matArray[13].asString());
 	(*pMat)[14] = StrToDouble(matArray[14].asString());
 	(*pMat)[15] = StrToDouble(matArray[15].asString());
+#endif
 }
 
 void JsonToColor(Color3ub *pCol, const Json::Value &jsonObj, const std::string &name)
@@ -380,9 +499,28 @@ std::string JsonToBinStr(const Json::Value &jsonObj, const std::string &name)
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value binStrArray = jsonObj[name.c_str()];
 	if (!binStrArray.isArray()) throw SavedGameCorruptException();
+	
+	const size_t arraySize = binStrArray.size();
+	std::unique_ptr<uint8_t[]> compStr(new uint8_t[arraySize*4]);
+	for (size_t charIndex = 0; charIndex < arraySize; ++charIndex) {
+		const uint32_t packed = binStrArray[charIndex].asUInt();
+		uint8_t a,b,c,d;
+		unpack4char(packed,
+			compStr[(charIndex*4)+0],
+			compStr[(charIndex*4)+1],
+			compStr[(charIndex*4)+2],
+			compStr[(charIndex*4)+3]);
+	}
 
+	const size_t remainder = jsonObj["remainder"].asUInt();
 	std::string binStr;
-	for (unsigned int charIndex = 0; charIndex < binStrArray.size(); ++charIndex)
-		binStr += char(binStrArray[charIndex].asInt());
+	size_t outSize = 0;
+	void *pDecompressedData = tinfl_decompress_mem_to_heap(&compStr[0], (arraySize*4)-remainder, &outSize, 0);
+	if (pDecompressedData) {
+		for (size_t charIndex = 0; charIndex < outSize; ++charIndex) {
+			binStr += static_cast<char*>(pDecompressedData)[charIndex];
+		}
+		mz_free(pDecompressedData);
+	}
 	return binStr;
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -26,7 +26,11 @@
 #include "ui/Context.h"
 #include "galaxy/GalaxyGenerator.h"
 
-static const int  s_saveVersion   = 82;
+extern "C" {
+#include "miniz/miniz.h"
+}
+
+static const int  s_saveVersion   = 83;
 static const char s_saveStart[]   = "PIONEER";
 static const char s_saveEnd[]     = "END";
 
@@ -828,9 +832,16 @@ Game *Game::LoadGame(const std::string &filename)
 	Json::Value rootNode; // Create the root JSON value for receiving the game data.
 	Json::Reader jsonReader; // Create reader for parsing the JSON string.
 	const auto data = file->AsByteRange();
-	jsonReader.parse(data.begin, data.end, rootNode); // Parse the JSON string.
-	if (!rootNode.isObject()) throw SavedGameCorruptException();
-	return new Game(rootNode); // Decode the game data from JSON and create the game.
+	size_t outSize = 0;
+	void *pDecompressedData = tinfl_decompress_mem_to_heap(&data[0], data.Size(), &outSize, 0);
+	if (pDecompressedData) {
+		jsonReader.parse(static_cast<char*>(pDecompressedData), static_cast<char*>(pDecompressedData)+outSize, rootNode); // Parse the JSON string.
+		mz_free(pDecompressedData);
+		if (!rootNode.isObject()) throw SavedGameCorruptException();
+		return new Game(rootNode); // Decode the game data from JSON and create the game.
+	} else {
+		throw SavedGameCorruptException();
+	}
 	// file data is freed here
 }
 
@@ -859,20 +870,27 @@ void Game::SaveGame(const std::string &filename, Game *game)
 
 	Json::Value rootNode; // Create the root JSON value for receiving the game data.
 	game->ToJson(rootNode); // Encode the game data as JSON and give to the root value.
-#if 0
-	Json::StyledWriter jsonWriter; // Create writer for writing the JSON data to string.
-#else
 	Json::FastWriter jsonWriter; // Create writer for writing the JSON data to string.
-#endif
 	const std::string jsonDataStr = jsonWriter.write(rootNode); // Write the JSON data.
 
 	FILE *f = FileSystem::userFiles.OpenWriteStream(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
 	if (!f) throw CouldNotOpenFileException();
 
-	size_t nwritten = fwrite(jsonDataStr.data(), jsonDataStr.length(), 1, f);
-	fclose(f);
-
-	if (nwritten != 1) throw CouldNotWriteToFileException();
+	// compress in memory, write to open file 
+	size_t outSize = 0;
+	void *pCompressedData = tdefl_compress_mem_to_heap(jsonDataStr.data(), jsonDataStr.length(), &outSize, 128);
+	if (pCompressedData) 
+	{
+		size_t nwritten = fwrite(pCompressedData, outSize, 1, f);
+		mz_free(pCompressedData);
+		fclose(f);
+		if (nwritten != 1) throw CouldNotWriteToFileException();
+	}
+	else
+	{
+		fclose(f);
+		throw CouldNotWriteToFileException();
+	}
 	
 #ifdef PIONEER_PROFILER
 	Profiler::dumphtml(profilerPath.c_str());

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -354,7 +354,6 @@ void LuaSerializer::UninitTableRefs() {
 	lua_setfield(l, LUA_REGISTRYINDEX, "PiLuaRefLoadTable");
 }
 
-#define JSON_RAW_STRING
 void LuaSerializer::ToJson(Json::Value &jsonObj)
 {
 	PROFILE_SCOPED()
@@ -389,11 +388,7 @@ void LuaSerializer::ToJson(Json::Value &jsonObj)
 	std::string pickled;
 	pickle(l, savetable, pickled);
 
-#ifdef JSON_RAW_STRING
-	jsonObj["lua_modules"] = pickled;
-#else
 	BinStrToJson(jsonObj, pickled, "lua_modules");
-#endif
 
 	lua_pop(l, 1);
 
@@ -408,12 +403,8 @@ void LuaSerializer::FromJson(const Json::Value &jsonObj)
 
 	LUA_DEBUG_START(l);
 
-	
-#ifdef JSON_RAW_STRING
-	std::string pickled = jsonObj["lua_modules"].asString();
-#else
 	std::string pickled = JsonToBinStr(jsonObj, "lua_modules");
-#endif
+
 	const char *start = pickled.c_str();
 	const char *end = unpickle(l, start);
 	if (size_t(end - start) != pickled.length()) throw SavedGameCorruptException();

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -354,8 +354,10 @@ void LuaSerializer::UninitTableRefs() {
 	lua_setfield(l, LUA_REGISTRYINDEX, "PiLuaRefLoadTable");
 }
 
+#define JSON_RAW_STRING
 void LuaSerializer::ToJson(Json::Value &jsonObj)
 {
+	PROFILE_SCOPED()
 	lua_State *l = Lua::manager->GetLuaState();
 
 	LUA_DEBUG_START(l);
@@ -387,7 +389,11 @@ void LuaSerializer::ToJson(Json::Value &jsonObj)
 	std::string pickled;
 	pickle(l, savetable, pickled);
 
+#ifdef JSON_RAW_STRING
+	jsonObj["lua_modules"] = pickled;
+#else
 	BinStrToJson(jsonObj, pickled, "lua_modules");
+#endif
 
 	lua_pop(l, 1);
 
@@ -402,7 +408,12 @@ void LuaSerializer::FromJson(const Json::Value &jsonObj)
 
 	LUA_DEBUG_START(l);
 
+	
+#ifdef JSON_RAW_STRING
+	std::string pickled = jsonObj["lua_modules"].asString();
+#else
 	std::string pickled = JsonToBinStr(jsonObj, "lua_modules");
+#endif
 	const char *start = pickled.c_str();
 	const char *end = unpickle(l, start);
 	if (size_t(end - start) != pickled.length()) throw SavedGameCorruptException();

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -169,6 +169,7 @@ void Space::RefreshBackground()
 
 void Space::ToJson(Json::Value &jsonObj)
 {
+	PROFILE_SCOPED()
 	RebuildFrameIndex();
 	RebuildBodyIndex();
 	RebuildSystemBodyIndex();

--- a/src/matrix3x3.h
+++ b/src/matrix3x3.h
@@ -10,15 +10,23 @@
 
 template <typename T>
 class matrix3x3 {
-	private:
+private:
 	T cell[9];
-	public:
+public:
 	matrix3x3 () {}
+	matrix3x3 (T val) {
+		cell[0] = cell[1] = cell[2] = cell[3] = cell[4] = cell[5] = cell[6] =
+		cell[7] = cell[8] = val;
+	}
 	matrix3x3 (const T *vals) {
 		memcpy(cell, vals, sizeof(T)*9);
 	}
+
 	T& operator [] (const size_t i) { return cell[i]; }			// used for serializing
 	const T& operator[] (const size_t i) const { return cell[i]; }
+
+	const T* Data() const { return cell; }
+	T* Data() { return cell; }
 
 	vector3<T> VectorX() const { return vector3<T>(cell[0], cell[3], cell[6]); }
 	vector3<T> VectorY() const { return vector3<T>(cell[1], cell[4], cell[7]); }

--- a/src/matrix4x4.h
+++ b/src/matrix4x4.h
@@ -11,9 +11,9 @@
 
 template <typename T>
 class matrix4x4 {
-	private:
+private:
 	T cell[16];
-	public:
+public:
 	matrix4x4 () {}
 	matrix4x4 (T val) {
 		cell[0] = cell[1] = cell[2] = cell[3] = cell[4] = cell[5] = cell[6] =

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -229,74 +229,185 @@ std::string UInt64ToStr(Uint64 val)
 	return str;
 }
 
+//#define USE_HEX_FLOATS
+#ifndef USE_HEX_FLOATS
+union fu32 {
+	fu32() {}
+	fu32(float fIn) : f(fIn) {}
+	fu32(uint32_t uIn) : u(uIn) {}
+	float f;
+	uint32_t u;
+};
+union fu64 {
+	fu64() {}
+	fu64(double dIn) : d(dIn) {}
+	fu64(uint64_t uIn) : u(uIn) {}
+	double d;
+	uint64_t u;
+};
+#endif // USE_HEX_FLOATS
+
 std::string FloatToStr(float val)
 {
-	// Can't get hexfloats to work.
-	//char hex[128]; // Probably don't need such a large char array.
-	//std::sprintf(hex, "%a", val);
-	//return hex;
-
-	// Lossy method storing as decimal and exponent.
-	//char str[128]; // Probably don't need such a large char array.
-	//std::sprintf(str, "%.7e", val);
-	//return str;
-
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	char hex[32]; // Probably don't need such a large char array.
+	std::sprintf(hex, "%a", val);
+	return hex;
+#else
 	// Exact representation (but not human readable).
-	static_assert(sizeof(float) == 4 || sizeof(float) == 8, "float isn't 4 or 8 bytes");
-	if (sizeof(float) == 4)
-	{
-		uint32_t intVal;
-		memcpy(&intVal, &val, 4);
-		char str[64];
-		sprintf(str, "%" PRIu32, intVal);
-		return str;
-	}
-	else // sizeof(float) == 8
-	{
-		uint64_t intVal;
-		memcpy(&intVal, &val, 8);
-		char str[128];
-		sprintf(str, "%" PRIu64, intVal);
-		return str;
-	}
+	static_assert(sizeof(float) == 4, "float isn't 4bytes");
+	fu32 uval(val);
+	char str[64];
+	const int amt = sprintf(str, "%" PRIu32, uval.u);
+	return str;
+#endif
 }
 
 std::string DoubleToStr(double val)
 {
-	// Can't get hexfloats to work.
-	//char hex[128]; // Probably don't need such a large char array.
-	//std::sprintf(hex, "%la", val);
-	//return hex;
-
-	// Lossy method storing as decimal and exponent.
-	//char str[128]; // Probably don't need such a large char array.
-	//std::sprintf(str, "%.15le", val);
-	//return str;
-
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	char hex[64]; // Probably don't need such a large char array.
+	std::sprintf(hex, "%la", val);
+	return hex;
+#else
 	// Exact representation (but not human readable).
-	static_assert(sizeof(double) == 4 || sizeof(double) == 8, "double isn't 4 or 8 bytes");
-	if (sizeof(double) == 4)
-	{
-		uint32_t intVal;
-		memcpy(&intVal, &val, 4);
-		char str[64];
-		sprintf(str, "%" PRIu32, intVal);
-		return str;
-	}
-	else // sizeof(double) == 8
-	{
-		uint64_t intVal;
-		memcpy(&intVal, &val, 8);
-		char str[128];
-		sprintf(str, "%" PRIu64, intVal);
-		return str;
-	}
+	static_assert(sizeof(double) == 8, "double isn't 8 bytes");
+	fu64 uval(val);
+	char str[128];
+	const int amt = sprintf(str, "%" PRIu64, uval.u);
+	return str;
+#endif
+}
+
+void Vector3fToStr(const vector3f &val, char *out, size_t size)
+{
+	PROFILE_SCOPED()
+	static_assert(sizeof(vector3f) == 12, "vector3f isn't 12 bytes");
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sprintf(out, "%a,%a,%a", val.x, val.y, val.z);
+	assert((size_t)amt<=size);
+#else
+	fu32 a(val.x);
+	fu32 b(val.y);
+	fu32 c(val.z);
+	const int amt = sprintf(out, "(%" PRIu32",%" PRIu32",%" PRIu32")", a.u, b.u, c.u);
+	assert((size_t)amt<=size);
+#endif
+}
+
+void Vector3dToStr(const vector3d &val, char *out, size_t size)
+{
+	PROFILE_SCOPED()
+	static_assert(sizeof(vector3d) == 24, "vector3d isn't 24 bytes");
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sprintf(out, "%la,%la,%la", val.x, val.y, val.z);
+	assert((size_t)amt<=size);
+#else
+	fu64 a(val.x);
+	fu64 b(val.y);
+	fu64 c(val.z);
+	const int amt = sprintf(out, "(%" PRIu64",%" PRIu64",%" PRIu64")", a.u, b.u, c.u);
+	assert((size_t)amt<=size);
+#endif
+}
+
+void Matrix3x3fToStr(const matrix3x3f &val, char *out, size_t size)
+{
+	PROFILE_SCOPED()
+	static_assert(sizeof(matrix3x3f) == 36, "matrix3x3f isn't 36 bytes");
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sprintf(out, "%a,%a,%a,%a,%a,%a,%a,%a,%a", val[0], val[1], val[2], val[3], val[4], val[5], val[6], val[7], val[8]);
+	assert((size_t)amt<=size);
+#else
+	fu32 fuvals[9];
+	for(int i=0; i<9; i++)
+		fuvals[i].f = val[i];
+	const int amt = sprintf(out, 
+		"(%" PRIu32",%" PRIu32",%" PRIu32
+		",%" PRIu32",%" PRIu32",%" PRIu32
+		",%" PRIu32",%" PRIu32",%" PRIu32")", 
+		fuvals[0].u, fuvals[1].u, fuvals[2].u, 
+		fuvals[3].u, fuvals[4].u, fuvals[5].u, 
+		fuvals[6].u, fuvals[7].u, fuvals[8].u);
+	assert((size_t)amt<=size);
+#endif
+}
+
+void Matrix3x3dToStr(const matrix3x3d &val, char *out, size_t size)
+{
+	PROFILE_SCOPED()
+	static_assert(sizeof(matrix3x3d) == 72, "matrix3x3d isn't 72 bytes");
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sprintf(out, "%a,%a,%a,%a,%a,%a,%a,%a,%a", val[0], val[1], val[2], val[3], val[4], val[5], val[6], val[7], val[8]);
+	assert((size_t)amt<=size);
+#else
+	fu64 fuvals[9];
+	for(int i=0; i<9; i++)
+		fuvals[i].d = val[i];
+	const int amt = sprintf(out, 
+		"(%" PRIu64",%" PRIu64",%" PRIu64
+		",%" PRIu64",%" PRIu64",%" PRIu64
+		",%" PRIu64",%" PRIu64",%" PRIu64")", 
+		fuvals[0].u, fuvals[1].u, fuvals[2].u, 
+		fuvals[3].u, fuvals[4].u, fuvals[5].u, 
+		fuvals[6].u, fuvals[7].u, fuvals[8].u);
+	assert((size_t)amt<=size);
+#endif
+}
+
+void Matrix4x4fToStr(const matrix4x4f &val, char *out, size_t size)
+{
+	PROFILE_SCOPED()
+	static_assert(sizeof(matrix4x4f) == 64, "matrix4x4f isn't 64 bytes");
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sprintf(out, "%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a", val[0], val[1], val[2], val[3], val[4], val[5], val[6], val[7], val[8], val[9], val[10], val[11], val[12], val[13], val[14], val[15]);
+	assert((size_t)amt<=size);
+#else
+	fu32 fuvals[16];
+	for(int i=0; i<16; i++)
+		fuvals[i].f = val[i];
+	const int amt = sprintf(out, 
+		"(%" PRIu32",%" PRIu32",%" PRIu32",%" PRIu32
+		",%" PRIu32",%" PRIu32",%" PRIu32",%" PRIu32
+		",%" PRIu32",%" PRIu32",%" PRIu32",%" PRIu32
+		",%" PRIu32",%" PRIu32",%" PRIu32",%" PRIu32")", 
+		fuvals[0].u, fuvals[1].u, fuvals[2].u, fuvals[3].u, 
+		fuvals[4].u, fuvals[5].u, fuvals[6].u, fuvals[7].u, 
+		fuvals[8].u, fuvals[9].u, fuvals[10].u, fuvals[11].u, 
+		fuvals[12].u, fuvals[13].u, fuvals[14].u, fuvals[15].u);
+	assert((size_t)amt<=size);
+#endif
+}
+
+void Matrix4x4dToStr(const matrix4x4d &val, char *out, size_t size)
+{
+	PROFILE_SCOPED()
+	static_assert(sizeof(matrix4x4d) == 128, "matrix4x4d isn't 128 bytes");
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sprintf(out, "%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a", val[0], val[1], val[2], val[3], val[4], val[5], val[6], val[7], val[8], val[9], val[10], val[11], val[12], val[13], val[14], val[15]);
+	assert((size_t)amt<=size);
+#else
+	fu64 fuvals[16];
+	for(int i=0; i<16; i++)
+		fuvals[i].d = val[i];
+	const int amt = sprintf(out, 
+		"(%" PRIu64",%" PRIu64",%" PRIu64",%" PRIu64
+		",%" PRIu64",%" PRIu64",%" PRIu64",%" PRIu64
+		",%" PRIu64",%" PRIu64",%" PRIu64",%" PRIu64
+		",%" PRIu64",%" PRIu64",%" PRIu64",%" PRIu64")", 
+		fuvals[0].u, fuvals[1].u, fuvals[2].u, fuvals[3].u, 
+		fuvals[4].u, fuvals[5].u, fuvals[6].u, fuvals[7].u, 
+		fuvals[8].u, fuvals[9].u, fuvals[10].u, fuvals[11].u, 
+		fuvals[12].u, fuvals[13].u, fuvals[14].u, fuvals[15].u);
+	assert((size_t)amt<=size);
+#endif
 }
 
 std::string AutoToStr(Sint32 val)
 {
 	char str[64];
-	//sprintf(str, "%I32d", val); // Windows
 	sprintf(str, "%" PRId32, val);
 	return str;
 }
@@ -334,72 +445,36 @@ Uint64 StrToUInt64(const std::string &str)
 
 float StrToFloat(const std::string &str)
 {
-	// Can't get hexfloats to work.
-	//return std::strtof(str.c_str(), 0);
-
-	// Can't get hexfloats to work.
-	//float val;
-	//std::sscanf(str.c_str(), "%a", &val);
-	//return val;
-
-	// Lossy method storing as decimal and exponent.
-	//float val;
-	//std::sscanf(str.c_str(), "%e", &val);
-	//return val;
-
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	float val;
+	std::sscanf(str.c_str(), "%a", &val);
+	return val;
+#else
 	// Exact representation (but not human readable).
-	static_assert(sizeof(float) == 4 || sizeof(float) == 8, "float isn't 4 or 8 bytes");
-	if (sizeof(float) == 4)
-	{
-		uint32_t intVal;
-		sscanf(str.c_str(), "%" SCNu32, &intVal);
-		float val;
-		memcpy(&val, &intVal, 4);
-		return val;
-	}
-	else // sizeof(float) == 8
-	{
-		uint64_t intVal;
-		sscanf(str.c_str(), "%" SCNu64, &intVal);
-		float val;
-		memcpy(&val, &intVal, 8);
-		return val;
-	}
+	static_assert(sizeof(float) == 4, "float isn't 4 bytes");
+	fu32 uval;
+	const int amt = sscanf(str.c_str(), "%" SCNu32, &uval.u);
+	assert(amt==1);
+	return uval.f;
+#endif
 }
 
 double StrToDouble(const std::string &str)
 {
-	// Can't get hexfloats to work.
-	//return std::strtod(str.c_str(), 0);
-
-	// Can't get hexfloats to work.
-	//double val;
-	//std::sscanf(str.c_str(), "%la", &val);
-	//return val;
-
-	// Lossy method storing as decimal and exponent.
-	//double val;
-	//std::sscanf(str.c_str(), "%le", &val);
-	//return val;
-
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	double val;
+	std::sscanf(str.c_str(), "%la", &val);
+	return val;
+#else
 	// Exact representation (but not human readable).
-	static_assert(sizeof(double) == 4 || sizeof(double) == 8, "double isn't 4 or 8 bytes");
-	if (sizeof(double) == 4)
-	{
-		uint32_t intVal;
-		sscanf(str.c_str(), "%" SCNu32, &intVal);
-		double val;
-		memcpy(&val, &intVal, 4);
-		return val;
-	}
-	else // sizeof(double) == 8
-	{
-		uint64_t intVal;
-		sscanf(str.c_str(), "%" SCNu64, &intVal);
-		double val;
-		memcpy(&val, &intVal, 8);
-		return val;
-	}
+	static_assert(sizeof(double) == 8, "double isn't 8 bytes");
+	fu64 uval;
+	const int amt = sscanf(str.c_str(), "%" SCNu64, &uval.u);
+	assert(amt==1);
+	return uval.d;
+#endif
 }
 
 void StrToAuto(Sint32 *pVal, const std::string &str)
@@ -420,6 +495,112 @@ void StrToAuto(float *pVal, const std::string &str)
 void StrToAuto(double *pVal, const std::string &str)
 {
 	*pVal = StrToDouble(str);
+}
+
+void StrToVector3f(const char *str, vector3f &val)
+{
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sscanf(str, "%a,%a,%a", &val.x, &val.y, &val.z);
+	assert(amt==3);
+#else
+	fu32 a,b,c;
+	const int amt = std::sscanf(str, "(%" SCNu32",%" SCNu32",%" SCNu32")", &a.u, &b.u, &c.u);
+	assert(amt==3);
+	val.x = a.f;
+	val.y = b.f;
+	val.z = c.f;
+#endif
+}
+
+void StrToVector3d(const char *str, vector3d &val)
+{
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sscanf(str, "%la,%la,%la", &val.x, &val.y, &val.z);
+	assert(amt==3);
+#else
+	fu64 a,b,c;
+	const int amt = std::sscanf(str, "(%" SCNu64",%" SCNu64",%" SCNu64")", &a.u, &b.u, &c.u);
+	assert(amt==3);
+	val.x = a.d;
+	val.y = b.d;
+	val.z = c.d;
+#endif
+}
+
+void StrToMatrix3x3f(const char *str, matrix3x3f &val)
+{
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sscanf(str, "%a,%a,%a,%a,%a,%a,%a,%a,%a", &val[0], &val[1], &val[2], &val[3], &val[4], &val[5], &val[6], &val[7], &val[8]);
+	assert(amt==9);
+#else
+	fu32 fu[9];
+	const int amt = std::sscanf(str, "(%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32")", 
+		&fu[0].u, &fu[1].u, &fu[2].u, 
+		&fu[3].u, &fu[4].u, &fu[5].u, 
+		&fu[6].u, &fu[7].u, &fu[8].u);
+	assert(amt==9);
+	for(int i=0; i<9; i++)
+		val[i] = fu[i].f;
+#endif
+}
+
+void StrToMatrix3x3d(const char *str, matrix3x3d &val)
+{
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sscanf(str, "%la,%la,%la,%la,%la,%la,%la,%la,%la", &val[0], &val[1], &val[2], &val[3], &val[4], &val[5], &val[6], &val[7], &val[8]);
+	assert(amt==9);
+#else
+	fu64 fu[9];
+	const int amt = std::sscanf(str, "(%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64")", 
+		&fu[0].u, &fu[1].u, &fu[2].u, 
+		&fu[3].u, &fu[4].u, &fu[5].u, 
+		&fu[6].u, &fu[7].u, &fu[8].u);
+	assert(amt==9);
+	for(int i=0; i<9; i++)
+		val[i] = fu[i].d;
+#endif
+}
+
+void StrToMatrix4x4f(const char *str, matrix4x4f &val)
+{
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sscanf(str, "%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a", &val[0], &val[1], &val[2], &val[3], &val[4], &val[5], &val[6], &val[7], &val[8], &val[9], &val[10], &val[11], &val[12], &val[13], &val[14], &val[15]);
+	assert(amt==16);
+#else
+	fu32 fu[16];
+	const int amt = std::sscanf(str, "(%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32",%" SCNu32")", 
+		&fu[0].u, &fu[1].u, &fu[2].u, &fu[3].u, 
+		&fu[4].u, &fu[5].u, &fu[6].u, &fu[7].u, 
+		&fu[8].u, &fu[9].u, &fu[10].u, &fu[11].u, 
+		&fu[12].u, &fu[13].u, &fu[14].u, &fu[15].u);
+	assert(amt==16);
+	for(int i=0; i<16; i++)
+		val[i] = fu[i].f;
+#endif
+}
+
+void StrToMatrix4x4d(const char *str, matrix4x4d &val)
+{
+	PROFILE_SCOPED()
+#ifdef USE_HEX_FLOATS
+	const int amt = std::sscanf(str, "%la,%la,%la,%la,%la,%la,%la,%la,%la,%la,%la,%la,%la,%la,%la,%la", &val[0], &val[1], &val[2], &val[3], &val[4], &val[5], &val[6], &val[7], &val[8], &val[9], &val[10], &val[11], &val[12], &val[13], &val[14], &val[15]);
+	assert(amt==16);
+#else
+	fu64 fu[16];
+	const int amt = std::sscanf(str, "(%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64",%" SCNu64")", 
+		&fu[0].u, &fu[1].u, &fu[2].u, &fu[3].u, 
+		&fu[4].u, &fu[5].u, &fu[6].u, &fu[7].u, 
+		&fu[8].u, &fu[9].u, &fu[10].u, &fu[11].u, 
+		&fu[12].u, &fu[13].u, &fu[14].u, &fu[15].u);
+	assert(amt==16);
+	for(int i=0; i<16; i++)
+		val[i] = fu[i].d;
+#endif
 }
 
 /**

--- a/src/utils.h
+++ b/src/utils.h
@@ -192,6 +192,13 @@ std::string AutoToStr(Sint64 val);
 std::string AutoToStr(float val);
 std::string AutoToStr(double val);
 
+void Vector3fToStr(const vector3f &val, char *out, size_t size);
+void Vector3dToStr(const vector3d &val, char *out, size_t size);
+void Matrix3x3fToStr(const matrix3x3f &val, char *out, size_t size);
+void Matrix3x3dToStr(const matrix3x3d &val, char *out, size_t size);
+void Matrix4x4fToStr(const matrix4x4f &val, char *out, size_t size);
+void Matrix4x4dToStr(const matrix4x4d &val, char *out, size_t size);
+
 // String to 'Numeric type' conversions.
 Sint64 StrToSInt64(const std::string &str);
 Uint64 StrToUInt64(const std::string &str);
@@ -201,6 +208,13 @@ void StrToAuto(Sint32 *pVal, const std::string &str);
 void StrToAuto(Sint64 *pVal, const std::string &str);
 void StrToAuto(float *pVal, const std::string &str);
 void StrToAuto(double *pVal, const std::string &str);
+
+void StrToVector3f(const char *str, vector3f &val);
+void StrToVector3d(const char *str, vector3d &val);
+void StrToMatrix3x3f(const char *str, matrix3x3f &val);
+void StrToMatrix3x3d(const char *str, matrix3x3d &val);
+void StrToMatrix4x4f(const char *str, matrix4x4f &val);
+void StrToMatrix4x4d(const char *str, matrix4x4d &val);
 
 // Convert decimal coordinates to degree/minute/second format and return as string
 std::string DecimalToDegMinSec(float dec);


### PR DESCRIPTION
# Saving times and sizes:
As pointed out in #3680 our save game files are huge, often on the order of 30MiB.
They also take a noticeable amount of time to save/load even on a good machine.
This PR attempts to address both issues using several methods.

# A note on Hex Floats:
With the latest VS2015.2 (_that's update 2_) I was able to get the Hex floats using `%a` or `%la` to work, however they produce noticeably larger files. Instead I changed the `FloatToStr` and `DoubleToStr` functions to use a union with the appropriate unsigned integer type to avoid all those memcpy calls and stuck that minor modification of the existing conversion.

# JsonUtils:
We previously (de)serialised Vectors and Matrices by writing out each component individually and giving it a separate slot in a Json Array. 
This was horribly inefficient, instead I now just (de)serialise the whole thing in a single call to `sprintf`/`sscanf` and read/write the string directly to Json. This avoids between 100,000 and 110,000 calls to `DoubleToStr`/`FloatToStr` cumulatively.

# BinStrToJson/JsonToBinStr:
@ShadowNinja identified this as a performance hog and he was spot on, profiling shows that it took approximately 30% to 40% of our saving time in some circumstances. There's a number of reason for this but mostly it was a mixture of inefficiances and not seeing how the Json Array would store it.
I did several things:
- preallocate the Json Array.
- compress the BinStr so there's less to store in the first place.
- ~~pack the array into uint32_t so there's even fewer Json Array entries.~~ Skip this.

All of that brings the typical array size down from ~775,000 to ~~32,000~~ ~128,000 each with a uniform sized integer.
It now takes 5% to 7% of the save time.

# Odds and sods:
Like @ShadowNinja suggested I switched to the `Json::FastWriter` which reduced the file size dramatically. Finally I compress the whole file on saving and decompress on loading to reduce the final amount written to disk.

# Results:
I'll update with timings but it certainly feels a lot faster saving, i'd guessestimate between 3 and 5 times faster, the profiling that I have supports that approximate measure but I'll need to do more thorough sampling. The results are difficult to replicate as the game state is always so different between runs that you can have 20,000 function differences in each run.

File size is equally problematic however for Earth with the `2016-4-4` build I get save file size of **15,337KiB**, and with this PR I get **459 KiB** or 1/33rd of the size.

This is obviously also going to be a lot faster when loaded/saved on a phyiscal HDD rather than my fast SSD so others may notice greater performance improvements.

# Save Game Bump:
This many changes breaks any chance of compatibility with older save game files.

@ShadowNinja - I hope that I'm not treading on your toes with this but you peaked my interested and I haven't seen you reply for about 6 days, we get a lot of people passing through and this was an easy win to implement.
Thankyou for pointing out how bloated and slow all of this code was and coming up with concrete suggestions for how to deal with it.

Andy