### PR TITLE
Fire once warnings

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1994,7 +1994,7 @@ void WorldView::Draw()
 	DrawCombatTargetIndicator(m_combatTargetIndicator, m_targetLeadIndicator, red);
 
 	// glLineWidth(1.0f);
-	m_renderer->CheckRenderErrors();
+	m_renderer->CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	// normal crosshairs
 	if (GetCamType() == CAM_INTERNAL) {

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -51,7 +51,7 @@ public:
 
 	virtual void WriteRendererInfo(std::ostream &out) const {}
 
-	virtual void CheckRenderErrors() const {}
+	virtual void CheckRenderErrors(const char *func = nullptr, const int line = -1) const {}
 
 	WindowSDL *GetWindow() const { return m_window.get(); }
 	float GetDisplayAspect() const { return static_cast<float>(m_width) / static_cast<float>(m_height); }

--- a/src/graphics/opengl/MaterialGL.cpp
+++ b/src/graphics/opengl/MaterialGL.cpp
@@ -29,7 +29,7 @@ void Material::SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj)
 	m_program->uViewMatrixInverse.Set( mv.Inverse() );
 	m_program->uViewProjectionMatrix.Set( ViewProjection );
 	m_program->uNormalMatrix.Set( NormalMatrix );
-	RendererOGL::CheckErrors();
+	CHECKERRORS();
 }
 
 }

--- a/src/graphics/opengl/MultiMaterial.cpp
+++ b/src/graphics/opengl/MultiMaterial.cpp
@@ -132,7 +132,7 @@ void LitMultiMaterial::Apply()
 		const vector3f pos = Light.GetPosition();
 		p->lights[i].position.Set( pos.x, pos.y, pos.z, (Light.GetType() == Light::LIGHT_DIRECTIONAL ? 0.f : 1.f));
 	}
-	RendererOGL::CheckErrors();
+	CHECKERRORS();
 }
 
 void MultiMaterial::Unapply()

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -750,7 +750,6 @@ bool RendererOGL::DrawBufferIndexedInstanced(VertexBuffer *vb, IndexBuffer *ib, 
 Material *RendererOGL::CreateMaterial(const MaterialDescriptor &d)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors(__FUNCTION__,__LINE__);
 	MaterialDescriptor desc = d;
 
 	OGL::Material *mat = 0;
@@ -836,7 +835,6 @@ bool RendererOGL::ReloadShaders()
 OGL::Program* RendererOGL::GetOrCreateProgram(OGL::Material *mat)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors(__FUNCTION__,__LINE__);
 	const MaterialDescriptor &desc = mat->GetDescriptor();
 	OGL::Program *p = 0;
 
@@ -861,14 +859,12 @@ OGL::Program* RendererOGL::GetOrCreateProgram(OGL::Material *mat)
 Texture *RendererOGL::CreateTexture(const TextureDescriptor &descriptor)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors(__FUNCTION__,__LINE__);
 	return new TextureGL(descriptor, m_useCompressedTextures, m_useAnisotropicFiltering);
 }
 
 RenderState *RendererOGL::CreateRenderState(const RenderStateDesc &desc)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors(__FUNCTION__,__LINE__);
 	const uint32_t hash = lookup3_hashlittle(&desc, sizeof(RenderStateDesc), 0);
 	auto it = m_renderStates.find(hash);
 	if (it != m_renderStates.end()) {
@@ -885,8 +881,8 @@ RenderState *RendererOGL::CreateRenderState(const RenderStateDesc &desc)
 RenderTarget *RendererOGL::CreateRenderTarget(const RenderTargetDesc &desc)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors(__FUNCTION__,__LINE__);
 	OGL::RenderTarget* rt = new OGL::RenderTarget(desc);
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	rt->Bind();
 	if (desc.colorFormat != TEXTURE_NONE) {
 		Graphics::TextureDescriptor cdesc(

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -295,7 +295,7 @@ static std::string glerr_to_string(GLenum err)
 	}
 }
 
-void RendererOGL::CheckErrors(const char *func /*= nullptr*/)
+void RendererOGL::CheckErrors(const char *func /*= nullptr*/, const int line /*= nullptr*/)
 {
 	PROFILE_SCOPED()
 #ifndef PIONEER_PROFILER
@@ -308,7 +308,7 @@ void RendererOGL::CheckErrors(const char *func /*= nullptr*/)
 		// now build info string
 		std::stringstream ss;
 		if(func) {
-			ss << "In function " << std::string(func) << "\n";
+			ss << "In function " << std::string(func) << "\nOn line " << std::to_string(line) << "\n";
 		}
 		ss << "OpenGL error(s) during frame:\n";
 		while (err != GL_NO_ERROR) {

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -372,7 +372,7 @@ bool RendererOGL::SetRenderState(RenderState *rs)
 		static_cast<OGL::RenderState*>(rs)->Apply();
 		m_activeRenderState = rs;
 	}
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	return true;
 }
 
@@ -385,7 +385,7 @@ bool RendererOGL::SetRenderTarget(RenderTarget *rt)
 		m_activeRenderTarget->Unbind();
 
 	m_activeRenderTarget = static_cast<OGL::RenderTarget*>(rt);
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	return true;
 }
@@ -401,7 +401,7 @@ bool RendererOGL::ClearScreen()
 	m_activeRenderState = nullptr;
 	glDepthMask(GL_TRUE);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	return true;
 }
@@ -411,7 +411,7 @@ bool RendererOGL::ClearDepthBuffer()
 	m_activeRenderState = nullptr;
 	glDepthMask(GL_TRUE);
 	glClear(GL_DEPTH_BUFFER_BIT);
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	return true;
 }
@@ -540,7 +540,7 @@ bool RendererOGL::SetScissor(bool enabled, const vector2f &pos, const vector2f &
 void RendererOGL::SetMaterialShaderTransforms(Material *m)
 {
 	m->SetCommonUniforms(m_modelViewStack.top(), m_projectionStack.top());
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 }
 
 bool RendererOGL::DrawTriangles(const VertexArray *v, RenderState *rs, Material *m, PrimitiveType t)
@@ -601,7 +601,7 @@ bool RendererOGL::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 	}
 
 	const bool res = DrawBuffer(drawVB.Get(), rs, m, t);
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	
 	m_stats.AddToStatCount(Stats::STAT_DRAWTRIS, 1);
 
@@ -662,7 +662,7 @@ bool RendererOGL::DrawPointSprites(const Uint32 count, const vector3f *positions
 	SetTransform(matrix4x4f::Identity());
 	DrawBuffer(drawVB.Get(), rs, material, Graphics::POINTS);
 	GetStats().AddToStatCount(Graphics::Stats::STAT_DRAWPOINTSPRITES, 1);
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	return true;
 }
@@ -678,7 +678,7 @@ bool RendererOGL::DrawBuffer(VertexBuffer* vb, RenderState* state, Material* mat
 	vb->Bind();
 	glDrawArrays(pt, 0, vb->GetVertexCount());
 	vb->Release();
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	m_stats.AddToStatCount(Stats::STAT_DRAWCALL, 1);
 
@@ -698,7 +698,7 @@ bool RendererOGL::DrawBufferIndexed(VertexBuffer *vb, IndexBuffer *ib, RenderSta
 	glDrawElements(pt, ib->GetIndexCount(), GL_UNSIGNED_INT, 0);
 	ib->Release();
 	vb->Release();
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	m_stats.AddToStatCount(Stats::STAT_DRAWCALL, 1);
 
@@ -718,7 +718,7 @@ bool RendererOGL::DrawBufferInstanced(VertexBuffer* vb, RenderState* state, Mate
 	glDrawArraysInstanced(pt, 0, vb->GetVertexCount(), instb->GetInstanceCount());
 	instb->Release();
 	vb->Release();
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	m_stats.AddToStatCount(Stats::STAT_DRAWCALL, 1);
 
@@ -740,7 +740,7 @@ bool RendererOGL::DrawBufferIndexedInstanced(VertexBuffer *vb, IndexBuffer *ib, 
 	instb->Release();
 	ib->Release();
 	vb->Release();
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	m_stats.AddToStatCount(Stats::STAT_DRAWCALL, 1);
 
@@ -750,7 +750,7 @@ bool RendererOGL::DrawBufferIndexedInstanced(VertexBuffer *vb, IndexBuffer *ib, 
 Material *RendererOGL::CreateMaterial(const MaterialDescriptor &d)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	MaterialDescriptor desc = d;
 
 	OGL::Material *mat = 0;
@@ -818,7 +818,7 @@ Material *RendererOGL::CreateMaterial(const MaterialDescriptor &d)
 	p = GetOrCreateProgram(mat); // XXX throws ShaderException on compile/link failure
 
 	mat->SetProgram(p);
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	return mat;
 }
 
@@ -836,7 +836,7 @@ bool RendererOGL::ReloadShaders()
 OGL::Program* RendererOGL::GetOrCreateProgram(OGL::Material *mat)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	const MaterialDescriptor &desc = mat->GetDescriptor();
 	OGL::Program *p = 0;
 
@@ -853,7 +853,7 @@ OGL::Program* RendererOGL::GetOrCreateProgram(OGL::Material *mat)
 		p = mat->CreateProgram(desc);
 		m_programs.push_back(std::make_pair(desc, p));
 	}
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	return p;
 }
@@ -861,23 +861,23 @@ OGL::Program* RendererOGL::GetOrCreateProgram(OGL::Material *mat)
 Texture *RendererOGL::CreateTexture(const TextureDescriptor &descriptor)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	return new TextureGL(descriptor, m_useCompressedTextures, m_useAnisotropicFiltering);
 }
 
 RenderState *RendererOGL::CreateRenderState(const RenderStateDesc &desc)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	const uint32_t hash = lookup3_hashlittle(&desc, sizeof(RenderStateDesc), 0);
 	auto it = m_renderStates.find(hash);
 	if (it != m_renderStates.end()) {
-		CheckRenderErrors();
+		CheckRenderErrors(__FUNCTION__,__LINE__);
 		return it->second;
 	} else {
 		auto *rs = new OGL::RenderState(desc);
 		m_renderStates[hash] = rs;
-		CheckRenderErrors();
+		CheckRenderErrors(__FUNCTION__,__LINE__);
 		return rs;
 	}
 }
@@ -885,7 +885,7 @@ RenderState *RendererOGL::CreateRenderState(const RenderStateDesc &desc)
 RenderTarget *RendererOGL::CreateRenderTarget(const RenderTargetDesc &desc)
 {
 	PROFILE_SCOPED()
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	OGL::RenderTarget* rt = new OGL::RenderTarget(desc);
 	rt->Bind();
 	if (desc.colorFormat != TEXTURE_NONE) {
@@ -920,7 +920,7 @@ RenderTarget *RendererOGL::CreateRenderTarget(const RenderTargetDesc &desc)
 	}
 	rt->CheckStatus();
 	rt->Unbind();
-	CheckRenderErrors();
+	CheckRenderErrors(__FUNCTION__,__LINE__);
 	return rt;
 }
 

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -301,6 +301,11 @@ void RendererOGL::CheckErrors(const char *func /*= nullptr*/)
 #ifndef PIONEER_PROFILER
 	GLenum err = glGetError();
 	if( err ) {
+		// static-cache current err that sparked this
+		static GLenum s_prevErr = GL_NO_ERROR;
+		const bool showWarning = (s_prevErr != err);
+		s_prevErr = err;
+		// now build info string
 		std::stringstream ss;
 		if(func) {
 			ss << "In function " << std::string(func) << "\n";
@@ -322,12 +327,11 @@ void RendererOGL::CheckErrors(const char *func /*= nullptr*/)
 			}
 #endif
 		}
-		static GLenum s_prevErr = GL_NO_ERROR;
-		if(s_prevErr == err)
-			Output("%s", ss.str().c_str());
-		else
+		// show warning dialog or just log to output
+		if(showWarning)
 			Warning("%s", ss.str().c_str());
-		s_prevErr = err;
+		else
+			Output("%s", ss.str().c_str());
 	}
 #endif
 }

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -295,13 +295,16 @@ static std::string glerr_to_string(GLenum err)
 	}
 }
 
-void RendererOGL::CheckErrors()
+void RendererOGL::CheckErrors(const char *func /*= nullptr*/)
 {
 	PROFILE_SCOPED()
 #ifndef PIONEER_PROFILER
 	GLenum err = glGetError();
 	if( err ) {
 		std::stringstream ss;
+		if(func) {
+			ss << "In function " << std::string(func) << "\n";
+		}
 		ss << "OpenGL error(s) during frame:\n";
 		while (err != GL_NO_ERROR) {
 			ss << glerr_to_string(err) << '\n';

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -319,7 +319,12 @@ void RendererOGL::CheckErrors()
 			}
 #endif
 		}
-		Warning("%s", ss.str().c_str());
+		static GLenum s_prevErr = GL_NO_ERROR;
+		if(s_prevErr == err)
+			Output("%s", ss.str().c_str());
+		else
+			Warning("%s", ss.str().c_str());
+		s_prevErr = err;
 	}
 #endif
 }

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -54,7 +54,7 @@ public:
 	virtual void WriteRendererInfo(std::ostream &out) const;
 
 	virtual void CheckRenderErrors() const { CheckErrors(); }
-	static void CheckErrors(const char *func = nullptr);
+	static void CheckErrors(const char *func = nullptr, const int line = -1);
 
 	virtual bool GetNearFarRange(float &near_, float &far_) const;
 
@@ -173,7 +173,7 @@ private:
 	typedef AttribBufferMap::iterator AttribBufferIter;
 	static AttribBufferMap s_AttribBufferMap;
 };
-#define CHECKERRORS() RendererOGL::CheckErrors(__PRETTY_FUNCTION__)
+#define CHECKERRORS() RendererOGL::CheckErrors(__FUNCTION__, __LINE__)
 
 }
 

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -53,7 +53,7 @@ public:
 
 	virtual void WriteRendererInfo(std::ostream &out) const;
 
-	virtual void CheckRenderErrors() const { CheckErrors(); }
+	virtual void CheckRenderErrors(const char *func = nullptr, const int line = -1) const final { CheckErrors(func, line); }
 	static void CheckErrors(const char *func = nullptr, const int line = -1);
 
 	virtual bool GetNearFarRange(float &near_, float &far_) const;

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -54,7 +54,7 @@ public:
 	virtual void WriteRendererInfo(std::ostream &out) const;
 
 	virtual void CheckRenderErrors() const { CheckErrors(); }
-	static void CheckErrors();
+	static void CheckErrors(const char *func = nullptr);
 
 	virtual bool GetNearFarRange(float &near_, float &far_) const;
 
@@ -173,6 +173,7 @@ private:
 	typedef AttribBufferMap::iterator AttribBufferIter;
 	static AttribBufferMap s_AttribBufferMap;
 };
+#define CHECKERRORS() RendererOGL::CheckErrors(__PRETTY_FUNCTION__)
 
 }
 

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -287,6 +287,7 @@ void TextureGL::Update(const void *data, const vector2f &pos, const vector2f &da
 		glGenerateMipmap(m_target);
 
 	glBindTexture(m_target, 0);
+	CHECKERRORS();
 }
 
 void TextureGL::Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips)
@@ -344,6 +345,7 @@ void TextureGL::Update(const TextureCubeData &data, const vector2f &dataSize, Te
 		glGenerateMipmap(m_target);
 
 	glBindTexture(m_target, 0);
+	CHECKERRORS();
 }
 
 void TextureGL::Bind()
@@ -395,6 +397,7 @@ void TextureGL::SetSampleMode(TextureSampleMode mode)
 	}
 
 	glBindTexture(m_target, 0);
+	CHECKERRORS();
 }
 
 }

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -104,7 +104,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 				RendererOGL::CheckErrors();
 				if (descriptor.generateMipmaps)
 					glGenerateMipmap(m_target);
-				RendererOGL::CheckErrors();
+				CHECKERRORS();
 			} else {
 				const GLint oglFormatMinSize = GetMinSize(descriptor.format);
 				size_t Width = descriptor.dataSize.x;

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -83,7 +83,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 
 	glGenTextures(1, &m_texture);
 	glBindTexture(m_target, m_texture);
-	RendererOGL::CheckErrors();
+	CHECKERRORS();
 
 	// useCompressed is the global scope flag whereas descriptor.allowCompression is the local texture mode flag
 	// either both or neither might be true however only compress the texture when both are true.
@@ -94,14 +94,14 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 			if (!IsCompressed(descriptor.format)) {
 				if (!descriptor.generateMipmaps)
 					glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, 0);
-				RendererOGL::CheckErrors();
+				CHECKERRORS();
 
 				glTexImage2D(
 					m_target, 0, compressTexture ? GLCompressedInternalFormat(descriptor.format) : GLInternalFormat(descriptor.format),
 					descriptor.dataSize.x, descriptor.dataSize.y, 0,
 					GLImageFormat(descriptor.format),
 					GLImageType(descriptor.format), 0);
-				RendererOGL::CheckErrors();
+				CHECKERRORS();
 				if (descriptor.generateMipmaps)
 					glGenerateMipmap(m_target);
 				CHECKERRORS();
@@ -123,7 +123,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 					Height /= 2;
 				}
 				glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, maxMip);
-				RendererOGL::CheckErrors();
+				CHECKERRORS();
 			}
 			break;
 
@@ -131,7 +131,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 			if(!IsCompressed(descriptor.format)) {
 				if(descriptor.generateMipmaps)
 					glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, 0);
-				RendererOGL::CheckErrors();
+				CHECKERRORS();
 
 				glTexImage2D(
 					GL_TEXTURE_CUBE_MAP_POSITIVE_X, 0, compressTexture ? GLCompressedInternalFormat(descriptor.format) : GLInternalFormat(descriptor.format),
@@ -163,10 +163,10 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 					descriptor.dataSize.x, descriptor.dataSize.y, 0,
 					GLImageFormat(descriptor.format),
 					GLImageType(descriptor.format), 0);
-				RendererOGL::CheckErrors();
+				CHECKERRORS();
 				if (descriptor.generateMipmaps)
 					glGenerateMipmap(m_target);
-				RendererOGL::CheckErrors();
+				CHECKERRORS();
 			} else {
 				const GLint oglFormatMinSize = GetMinSize(descriptor.format);
 				size_t Width = descriptor.dataSize.x;
@@ -190,14 +190,14 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 					Height /= 2;
 				}
 				glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, maxMip);
-				RendererOGL::CheckErrors();
+				CHECKERRORS();
 			}
 			break;
 
 		default:
 			assert(0);
 	}
-	RendererOGL::CheckErrors();
+	CHECKERRORS();
 
 	GLenum magFilter, minFilter, wrapS, wrapT;
 	switch (descriptor.sampleMode) {
@@ -240,7 +240,7 @@ TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompress
 		glTexParameterf(m_target, GL_TEXTURE_MAX_ANISOTROPY_EXT, maxAniso);
 	}
 
-	RendererOGL::CheckErrors();
+	CHECKERRORS();
 }
 
 TextureGL::~TextureGL()

--- a/src/graphics/opengl/UIMaterial.cpp
+++ b/src/graphics/opengl/UIMaterial.cpp
@@ -15,7 +15,7 @@ namespace OGL {
 UIProgram::UIProgram(const MaterialDescriptor &desc)
 {
 	m_name = "ui";
-	RendererOGL::CheckErrors();
+	CHECKERRORS();
 
 	LoadShaders(m_name, m_defines);
 	InitUniforms();

--- a/src/graphics/opengl/VtxColorMaterial.cpp
+++ b/src/graphics/opengl/VtxColorMaterial.cpp
@@ -15,7 +15,7 @@ namespace OGL {
 VtxColorProgram::VtxColorProgram(const MaterialDescriptor &desc)
 {
 	m_name = "vtxColor";
-	RendererOGL::CheckErrors();
+	CHECKERRORS();
 
 	LoadShaders(m_name, m_defines);
 	InitUniforms();

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -581,7 +581,7 @@ TextureFont::TextureFont(const FontConfig &config, Graphics::Renderer *renderer,
 	, m_atlasVIncrement(0)
 	, m_lfLastCacheCleanTime(0.0)
 {
-	renderer->CheckRenderErrors();
+	renderer->CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	FT_Error err; // used to store freetype error return codes
 
@@ -601,12 +601,12 @@ TextureFont::TextureFont(const FontConfig &config, Graphics::Renderer *renderer,
 		FT_Stroker_Set(m_stroker, 1*64, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0);
 	}
 
-	renderer->CheckRenderErrors();
+	renderer->CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	m_texFormat = m_config.IsOutline() ? Graphics::TEXTURE_LUMINANCE_ALPHA_88 : Graphics::TEXTURE_INTENSITY_8;
 	m_bpp = m_config.IsOutline() ? 2 : 1;
 
-	renderer->CheckRenderErrors();
+	renderer->CheckRenderErrors(__FUNCTION__,__LINE__);
 
 	Graphics::RenderStateDesc rsd;
 	rsd.blendMode = Graphics::BLEND_ALPHA_PREMULT;


### PR DESCRIPTION
When we get errors we get an unstoppable flood of them, this is of no use to anybody.
Users have to force kill the game and developers get bombarded with repeated asserts and dialogs which hinder testing/fixing/development.

Only fire the warning dialog **IF** the previous OpenGL error was different from the current one.

Also attempt to log some more useful information like the funciton name and line number.

**EDIT:** I should have done this ages ago!