### PR TITLE
Fix ship systeminfo crash

### DIFF
--- a/src/Body.h
+++ b/src/Body.h
@@ -66,7 +66,7 @@ public:
 	matrix3x3d GetOrientRelTo(const Frame *) const;
 
 	// Should return pointer in Pi::currentSystem
-	virtual const SystemBody *GetSystemBody() const { return 0; }
+	virtual const SystemBody *GetSystemBody() const { return nullptr; }
 	// for putting on planet surface, oriented +y up
 	void OrientOnSurface(double radius, double latitude, double longitude);
 

--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -508,6 +508,7 @@ void SystemInfoView::Draw3D()
 
 static bool IsShownInInfoView(const SystemBody* sb)
 {
+	if(!sb) return false; // sanity check
 	SystemBody::BodySuperType superType = sb->GetSuperType();
 	return superType == SystemBody::SUPERTYPE_STAR || superType == SystemBody::SUPERTYPE_GAS_GIANT ||
 		superType == SystemBody::SUPERTYPE_ROCKY_PLANET ||
@@ -546,7 +547,7 @@ SystemInfoView::RefreshType SystemInfoView::NeedsRefresh()
 		}
 	} else {
 		Body *navTarget = Pi::player->GetNavTarget();
-		if (navTarget && IsShownInInfoView(navTarget->GetSystemBody())) {
+		if (navTarget && (navTarget->GetSystemBody()!=nullptr) && IsShownInInfoView(navTarget->GetSystemBody())) {
 			// Navigation target is something we show in the info view
 			if (navTarget->GetSystemBody()->GetPath() != m_selectedBodyPath)
 				return REFRESH_SELECTED_BODY; // and wasn't selected, yet


### PR DESCRIPTION
This fixes #3698 that @aloyisiusp found earlier.

We could dereference a null pointer as we only checked that we had a `NavTarget` and not that it had a valid `SystemBody`.