### PR TITLE
Clean up the police tables on ship destruction

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -697,6 +697,17 @@ Event.Register("onLeaveSystem", function (ship)
 	if ship ~= Game.player then return end
 	destroySystem()
 end)
+
+Event.Register("onShipDestroyed", function (ship, _)
+	for _,local_police in pairs(police) do
+		for k,police_ship in pairs(local_police) do
+			if (v == police_ship) then
+				table.remove(local_police, k)
+			end
+		end
+	end
+end)
+
 Event.Register("onGameEnd", function ()
 	destroySystem()
 

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -701,7 +701,7 @@ end)
 Event.Register("onShipDestroyed", function (ship, _)
 	for _,local_police in pairs(police) do
 		for k,police_ship in pairs(local_police) do
-			if (v == police_ship) then
+			if (ship == police_ship) then
 				table.remove(local_police, k)
 			end
 		end


### PR DESCRIPTION
It was not really possible to make the whole module stateless.
Furthermore, I kind of like the idea of doing that in our own modules,
since it shows potential modders (and our future selves) that THOU SHALT
SUBSCRIBE TO onShipDestroyed* FOR THINE SHIP REFERENCES. Nanmého.

(*) OK, and maybe the one for the ships leaving the system, depending on
the context

Fixes #3512