### PR TITLE
Fix crash when player explodes in-dock.

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1962,7 +1962,6 @@ void WorldView::Draw()
 {
 	assert(m_game);
 	assert(Pi::player);
-	assert(!Pi::player->IsDead());
 
 	m_renderer->ClearDepthBuffer();
 


### PR DESCRIPTION
Remove bogus assert, it is not necessary to check that the player is alive.
This fixes #2116