### PR TITLE
Optimise Eclipse Calculations

### DIFF
--- a/data/shaders/opengl/gassphere_base.frag
+++ b/data/shaders/opengl/gassphere_base.frag
@@ -10,6 +10,7 @@ uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made
 uniform float geosphereRadius;
+uniform float geosphereInvRadius;
 uniform float geosphereAtmosTopRad;
 uniform vec3 geosphereCenter;
 uniform float geosphereAtmosFogDensity;
@@ -35,7 +36,7 @@ void main(void)
 	float nDotVP=0.0;
 	float nnDotVP=0.0;
 
-	vec3 v = (eyepos - geosphereCenter)/geosphereRadius;
+	vec3 v = (eyepos - geosphereCenter) * geosphereInvRadius;
 	float lenInvSq = 1.0/(dot(v,v));
 	for (int i=0; i<NUM_LIGHTS; ++i) {
 		float uneclipsed = clamp(calcUneclipsed(i, v, normalize(vec3(uLight[i].position))), 0.0, 1.0);
@@ -52,8 +53,8 @@ void main(void)
 		float atmosDist = (length(eyepos) - atmosStart);
 		
 		// a&b scaled so length of 1.0 means planet surface.
-		vec3 a = (atmosStart * eyenorm - geosphereCenter) / geosphereRadius;
-		vec3 b = (eyepos - geosphereCenter) / geosphereRadius;
+		vec3 a = (atmosStart * eyenorm - geosphereCenter) * geosphereInvRadius;
+		vec3 b = (eyepos - geosphereCenter) * geosphereInvRadius;
 		ldprod = AtmosLengthDensityProduct(a, b, atmosColor.w*geosphereAtmosFogDensity, atmosDist, geosphereAtmosInvScaleHeight);
 		fogFactor = clamp( 1.5 / exp(ldprod),0.0,1.0); 
 	}

--- a/data/shaders/opengl/geosphere_sky.frag
+++ b/data/shaders/opengl/geosphere_sky.frag
@@ -10,6 +10,7 @@ uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made
 uniform float geosphereRadius;
+uniform float geosphereInvRadius;
 uniform float geosphereAtmosTopRad;
 uniform vec3 geosphereCenter;
 uniform float geosphereAtmosFogDensity;
@@ -50,8 +51,8 @@ void main(void)
 	float ldprod=0.0;
 	
 	// a&b scaled so length of 1.0 means planet surface.
-	vec3 a = (skyNear * eyenorm - geosphereCenter) / geosphereRadius;
-	vec3 b = (skyFar * eyenorm - geosphereCenter) / geosphereRadius;
+	vec3 a = (skyNear * eyenorm - geosphereCenter) * geosphereInvRadius;
+	vec3 b = (skyFar * eyenorm - geosphereCenter) * geosphereInvRadius;
 	ldprod = AtmosLengthDensityProduct(a, b, atmosColor.a * geosphereAtmosFogDensity, atmosDist, geosphereAtmosInvScaleHeight);
 	
 	float fogFactor = 1.0 / exp(ldprod);

--- a/data/shaders/opengl/geosphere_terrain.frag
+++ b/data/shaders/opengl/geosphere_terrain.frag
@@ -10,6 +10,7 @@ uniform vec4 atmosColor;
 // to keep distances sane we do a nearer, smaller scam. this is how many times
 // smaller the geosphere has been made
 uniform float geosphereRadius;
+uniform float geosphereInvRadius;
 uniform float geosphereAtmosTopRad;
 uniform vec3 geosphereCenter;
 uniform float geosphereAtmosFogDensity;
@@ -64,7 +65,7 @@ void main(void)
 #endif
 
 #if (NUM_LIGHTS > 0)
-	vec3 v = (eyepos - geosphereCenter)/geosphereRadius;
+	vec3 v = (eyepos - geosphereCenter) * geosphereInvRadius;
 	float lenInvSq = 1.0/(dot(v,v));
 	for (int i=0; i<NUM_LIGHTS; ++i) {
 		float uneclipsed = clamp(calcUneclipsed(i, v, normalize(vec3(uLight[i].position))), 0.0, 1.0);
@@ -100,8 +101,8 @@ void main(void)
 		float atmosDist = (length(eyepos) - atmosStart);
 		
 		// a&b scaled so length of 1.0 means planet surface.
-		vec3 a = (atmosStart * eyenorm - geosphereCenter) / geosphereRadius;
-		vec3 b = (eyepos - geosphereCenter) / geosphereRadius;
+		vec3 a = (atmosStart * eyenorm - geosphereCenter) * geosphereInvRadius;
+		vec3 b = (eyepos - geosphereCenter) * geosphereInvRadius;
 		ldprod = AtmosLengthDensityProduct(a, b, atmosColor.w*geosphereAtmosFogDensity, atmosDist, geosphereAtmosInvScaleHeight);
 		fogFactor = clamp( 1.5 / exp(ldprod),0.0,1.0); 
 	}

--- a/src/graphics/opengl/GasGiantMaterial.cpp
+++ b/src/graphics/opengl/GasGiantMaterial.cpp
@@ -30,6 +30,7 @@ void GasGiantProgram::InitUniforms()
 	geosphereAtmosTopRad.Init("geosphereAtmosTopRad", m_program);
 	geosphereCenter.Init("geosphereCenter", m_program);
 	geosphereRadius.Init("geosphereRadius", m_program);
+	geosphereInvRadius.Init("geosphereInvRadius", m_program);
 
 	shadows.Init("shadows", m_program);
 	occultedLight.Init("occultedLight", m_program);
@@ -82,6 +83,7 @@ void GasGiantSurfaceMaterial::SetGSUniforms()
 	p->geosphereAtmosTopRad.Set(ap.atmosRadius);
 	p->geosphereCenter.Set(ap.center);
 	p->geosphereRadius.Set(ap.planetRadius);
+	p->geosphereInvRadius.Set(1.0f / ap.planetRadius);
 
 	//Light uniform parameters
 	for( Uint32 i=0 ; i<m_renderer->GetNumLights() ; i++ ) {

--- a/src/graphics/opengl/GasGiantMaterial.h
+++ b/src/graphics/opengl/GasGiantMaterial.h
@@ -23,6 +23,7 @@ namespace Graphics {
 			Uniform geosphereAtmosTopRad; // in planet radii
 			Uniform geosphereCenter;
 			Uniform geosphereRadius; // planet radius
+			Uniform geosphereInvRadius; // 1.0 / (planet radius)
 
 			Uniform shadows;
 			Uniform occultedLight;

--- a/src/graphics/opengl/GeoSphereMaterial.cpp
+++ b/src/graphics/opengl/GeoSphereMaterial.cpp
@@ -30,6 +30,7 @@ void GeoSphereProgram::InitUniforms()
 	geosphereAtmosTopRad.Init("geosphereAtmosTopRad", m_program);
 	geosphereCenter.Init("geosphereCenter", m_program);
 	geosphereRadius.Init("geosphereRadius", m_program);
+	geosphereInvRadius.Init("geosphereInvRadius", m_program);
 	
 	detailScaleHi.Init("detailScaleHi", m_program);
 	detailScaleLo.Init("detailScaleLo", m_program);
@@ -101,6 +102,7 @@ void GeoSphereSurfaceMaterial::SetGSUniforms()
 	p->geosphereAtmosTopRad.Set(ap.atmosRadius);
 	p->geosphereCenter.Set(ap.center);
 	p->geosphereRadius.Set(ap.planetRadius);
+	p->geosphereInvRadius.Set(1.0f / ap.planetRadius);
 
 	if(this->texture0) {
 		p->texture0.Set(this->texture0, 0);

--- a/src/graphics/opengl/GeoSphereMaterial.h
+++ b/src/graphics/opengl/GeoSphereMaterial.h
@@ -23,6 +23,7 @@ namespace Graphics {
 			Uniform geosphereAtmosTopRad; // in planet radii
 			Uniform geosphereCenter;
 			Uniform geosphereRadius; // (planet radius)
+			Uniform geosphereInvRadius; // 1.0 / (planet radius)
 			
 			Uniform detailScaleHi;
 			Uniform detailScaleLo;


### PR DESCRIPTION
Calculate the inverse of the radius to avoid some divisions within the shaders.

Minor optimisation.