### PR TITLE
Prevent the galaxy map from crashing if in hyperspace.

### DIFF
--- a/data/ui/GalacticView.lua
+++ b/data/ui/GalacticView.lua
@@ -20,6 +20,7 @@ map.onMapScaleChanged:Connect(function (new_scale)
 end)
 
 local resetCurrentSector = function (map)
+	if not Game.system then return end
 	local sysPath = Game.system.path
 	local x = sysPath.sectorX
 	local y = sysPath.sectorY


### PR DESCRIPTION
Prevent the galaxy map from crashing if in hyperspace using @walterar suggest fix.

Fixes #3713 

Thanks @walterar 