### PR TITLE
Enable using dedicated nVidia GPUs in Windows laptops with Optimus.

### DIFF
--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -16,6 +16,13 @@
 #include <wchar.h>
 #include <windows.h>
 
+// This is the quickest and easiest way to enable using the nVidia GPU on a Windows laptop with a dedicated nVidia GPU and Optimus tech.
+// enable optimus!
+extern "C" {
+    _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
+
+
 #ifdef RegisterClass
 #undef RegisterClass
 #endif


### PR DESCRIPTION
Enable using dedicated nVidia GPUs in Windows laptops with Optimus.

This only affects Windows laptops with nVidia GPUs.
Previously I was seeing that we're always picking the Intel GPU in laptops with an integrated Intel GPu and a dedicated nVidia GPU. 
There are ways around this, like forcing _everything_ to use the nVidia GPU, but that's not ideal.