### PR TITLE
Add AMD Power Xpress performance flag keyword and value.

### DIFF
--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -16,10 +16,14 @@
 #include <wchar.h>
 #include <windows.h>
 
-// This is the quickest and easiest way to enable using the nVidia GPU on a Windows laptop with a dedicated nVidia GPU and Optimus tech.
-// enable optimus!
+
 extern "C" {
-    _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	// This is the quickest and easiest way to enable using the nVidia GPU on a Windows laptop with a dedicated nVidia GPU and Optimus tech.
+	// enable optimus!
+    __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+
+	// AMD have one too!!!
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
 
 


### PR DESCRIPTION
This is equivalent to the nVidia flag added in #3715 earlier today, that causes it to use the dedicated GPU in laptops with multi-gpu setups.