### PR TITLE
Eclipse r600

### DIFF
--- a/data/shaders/opengl/eclipse.glsl
+++ b/data/shaders/opengl/eclipse.glsl
@@ -3,8 +3,6 @@
 
 #ifdef ECLIPSE
 
-uniform int shadows;
-uniform ivec3 occultedLight;
 uniform vec3 shadowCentreX;
 uniform vec3 shadowCentreY;
 uniform vec3 shadowCentreZ;
@@ -53,10 +51,8 @@ float shadowInt(const in float t1, const in float t2, const in float dsq, const 
 float calcUneclipsed(const in int i, const in vec3 v, const in vec3 lightDir) 
 {
 	float uneclipsed = 1.0;
-	for (int j=0; j<shadows; j++) {
-		if (i != occultedLight[j])
-			continue;
-			
+	for (int j=0; j<NUM_SHADOWS; j++) 
+	{
 		vec3 centre = vec3( shadowCentreX[j], shadowCentreY[j], shadowCentreZ[j] );
 		
 		// Apply eclipse:
@@ -73,10 +69,8 @@ float calcUneclipsed(const in int i, const in vec3 v, const in vec3 lightDir)
 float calcUneclipsedSky(const in int i, const in vec3 a, const in vec3 b, const in vec3 lightDir) 
 {
 	float uneclipsed = 1.0;
-	for (int j=0; j<shadows; j++) {
-		if (i != occultedLight[j])
-			continue;
-
+	for (int j=0; j<NUM_SHADOWS; j++) 
+	{
 		// Eclipse handling:
 		// Calculate proportion of the in-atmosphere eyeline which is shadowed,
 		// weighting according to completeness of the shadow (penumbra vs umbra).

--- a/data/systems/01_epsilon_eridani.lua
+++ b/data/systems/01_epsilon_eridani.lua
@@ -56,7 +56,7 @@ local atlantica = CustomSystemBody:new('Atlantica', 'PLANET_TERRESTRIAL')
 
 
 local newhope = CustomSystemBody:new('New Hope', 'PLANET_TERRESTRIAL')
-	:seed(0)
+	:seed(79853798543)
 	:radius(f(4,3))
 	:mass(f(5,4))
 	:temp(287)

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -320,7 +320,7 @@ void Camera::CalcShadows(const int lightNum, const Body *b, std::vector<Shadow> 
 		const vector3d projectedCentre = ( b2pos - perpDist*lightDir ) / bRadius;
 		if (projectedCentre.Length() < 1 + srad + lrad) {
 			// some part of b is (partially) eclipsed
-			Camera::Shadow shadow = { lightNum, projectedCentre, static_cast<float>(srad), static_cast<float>(lrad) };
+			Camera::Shadow shadow = { projectedCentre, static_cast<float>(srad), static_cast<float>(lrad) };
 			shadowsOut.push_back(shadow);
 		}
 	}

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -90,7 +90,6 @@ public:
 	};
 
 	struct Shadow {
-		int occultedLight;
 		vector3d centre;
 		float srad;
 		float lrad;

--- a/src/graphics/Material.cpp
+++ b/src/graphics/Material.cpp
@@ -36,6 +36,7 @@ MaterialDescriptor::MaterialDescriptor()
 , textures(0)
 , dirLights(0)
 , quality(0)
+, numShadows(0)
 {
 }
 
@@ -54,7 +55,8 @@ bool operator==(const MaterialDescriptor &a, const MaterialDescriptor &b)
 		a.instanced == b.instanced &&
 		a.textures == b.textures &&
 		a.dirLights == b.dirLights &&
-		a.quality == b.quality
+		a.quality == b.quality &&
+		a.numShadows == b.numShadows
 	);
 }
 

--- a/src/graphics/Material.h
+++ b/src/graphics/Material.h
@@ -70,6 +70,7 @@ public:
 	Sint32 textures; //texture count
 	Uint32 dirLights; //set by RendererOGL if lighting == true
 	Uint32 quality; // see: Graphics::MaterialQuality
+	Uint32 numShadows; //use by GeoSphere/GasGiant for eclipse
 
 	friend bool operator==(const MaterialDescriptor &a, const MaterialDescriptor &b);
 };

--- a/src/graphics/opengl/GasGiantMaterial.cpp
+++ b/src/graphics/opengl/GasGiantMaterial.cpp
@@ -112,7 +112,6 @@ void GasGiantSurfaceMaterial::SetGSUniforms()
 	p->texture0.Set(this->texture0, 0);
 
 	// we handle up to three shadows at a time
-	int occultedLight[3] = {-1,-1,-1};
 	vector3f shadowCentreX;
 	vector3f shadowCentreY;
 	vector3f shadowCentreZ;
@@ -122,7 +121,6 @@ void GasGiantSurfaceMaterial::SetGSUniforms()
 	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	int j = 0;
 	while (j<3 && it != itEnd) {
-		occultedLight[j] = it->occultedLight;
 		shadowCentreX[j] = it->centre[0];
 		shadowCentreY[j] = it->centre[1];
 		shadowCentreZ[j] = it->centre[2];
@@ -146,7 +144,7 @@ void GasGiantSurfaceMaterial::SwitchShadowVariant()
 	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	//request a new shadow variation
 	if (m_curNumShadows != params.shadows.size()) {
-		m_curNumShadows = std::min(params.shadows.size(), 4U);
+		m_curNumShadows = std::min(Uint32(params.shadows.size()), 4U);
 		if (m_programs[m_curNumShadows] == nullptr) {
 			m_descriptor.numShadows = m_curNumShadows; //hax - so that GetOrCreateProgram will create a NEW shader instead of reusing the existing one
 			m_programs[m_curNumShadows] = m_renderer->GetOrCreateProgram(this);

--- a/src/graphics/opengl/GasGiantMaterial.cpp
+++ b/src/graphics/opengl/GasGiantMaterial.cpp
@@ -146,7 +146,7 @@ void GasGiantSurfaceMaterial::SwitchShadowVariant()
 	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	//request a new shadow variation
 	if (m_curNumShadows != params.shadows.size()) {
-		m_curNumShadows = params.shadows.size();
+		m_curNumShadows = std::min(params.shadows.size(), 4U);
 		if (m_programs[m_curNumShadows] == nullptr) {
 			m_descriptor.numShadows = m_curNumShadows; //hax - so that GetOrCreateProgram will create a NEW shader instead of reusing the existing one
 			m_programs[m_curNumShadows] = m_renderer->GetOrCreateProgram(this);

--- a/src/graphics/opengl/GasGiantMaterial.cpp
+++ b/src/graphics/opengl/GasGiantMaterial.cpp
@@ -32,8 +32,6 @@ void GasGiantProgram::InitUniforms()
 	geosphereRadius.Init("geosphereRadius", m_program);
 	geosphereInvRadius.Init("geosphereInvRadius", m_program);
 
-	shadows.Init("shadows", m_program);
-	occultedLight.Init("occultedLight", m_program);
 	shadowCentreX.Init("shadowCentreX", m_program);
 	shadowCentreY.Init("shadowCentreY", m_program);
 	shadowCentreZ.Init("shadowCentreZ", m_program);
@@ -43,6 +41,12 @@ void GasGiantProgram::InitUniforms()
 }
 
 // GasGiantSurfaceMaterial -----------------------------------
+GasGiantSurfaceMaterial::GasGiantSurfaceMaterial() : m_curNumShadows(0)
+{
+	for(int i=0;i<4;i++)
+		m_programs[i] = nullptr;
+}
+
 Program *GasGiantSurfaceMaterial::CreateProgram(const MaterialDescriptor &desc)
 {
 	assert(desc.effect == EFFECT_GASSPHERE_TERRAIN);
@@ -59,11 +63,21 @@ Program *GasGiantSurfaceMaterial::CreateProgram(const MaterialDescriptor &desc)
 		ss << "#define ATMOSPHERE\n";
 	if (desc.quality & HAS_ECLIPSES)
 		ss << "#define ECLIPSE\n";
+
+	ss << stringf("#define NUM_SHADOWS %0{u}\n", m_curNumShadows);
+
 	return new Graphics::OGL::GasGiantProgram("gassphere_base", ss.str());
+}
+
+void GasGiantSurfaceMaterial::SetProgram(Program *p)
+{
+	m_programs[m_curNumShadows] = p;
+	m_program = p;
 }
 
 void GasGiantSurfaceMaterial::Apply()
 {
+	SwitchShadowVariant();
 	SetGSUniforms();
 }
 
@@ -118,14 +132,27 @@ void GasGiantSurfaceMaterial::SetGSUniforms()
 		++it;
 		++j;
 	}
-	p->shadows.Set(j);
-	p->occultedLight.Set(occultedLight);
 	p->shadowCentreX.Set(shadowCentreX);
 	p->shadowCentreY.Set(shadowCentreY);
 	p->shadowCentreZ.Set(shadowCentreZ);
 	p->srad.Set(srad);
 	p->lrad.Set(lrad);
 	p->sdivlrad.Set(sdivlrad);
+}
+
+void GasGiantSurfaceMaterial::SwitchShadowVariant()
+{
+	const GeoSphere::MaterialParameters params = *static_cast<GeoSphere::MaterialParameters*>(this->specialParameter0);
+	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
+	//request a new shadow variation
+	if (m_curNumShadows != params.shadows.size()) {
+		m_curNumShadows = params.shadows.size();
+		if (m_programs[m_curNumShadows] == nullptr) {
+			m_descriptor.numShadows = m_curNumShadows; //hax - so that GetOrCreateProgram will create a NEW shader instead of reusing the existing one
+			m_programs[m_curNumShadows] = m_renderer->GetOrCreateProgram(this);
+		}
+		m_program = m_programs[m_curNumShadows];
+	}
 }
 
 }

--- a/src/graphics/opengl/GasGiantMaterial.h
+++ b/src/graphics/opengl/GasGiantMaterial.h
@@ -25,8 +25,6 @@ namespace Graphics {
 			Uniform geosphereRadius; // planet radius
 			Uniform geosphereInvRadius; // 1.0 / (planet radius)
 
-			Uniform shadows;
-			Uniform occultedLight;
 			Uniform shadowCentreX;
 			Uniform shadowCentreY;
 			Uniform shadowCentreZ;
@@ -39,11 +37,16 @@ namespace Graphics {
 		};
 
 		class GasGiantSurfaceMaterial : public Material {
+			GasGiantSurfaceMaterial();
 			virtual Program *CreateProgram(const MaterialDescriptor &) override;
+			virtual void SetProgram(Program *p) override;
 			virtual void Apply() override;
 
 		protected:
 			void SetGSUniforms();
+			void SwitchShadowVariant();
+			Program* m_programs[4];	// 0 to 3 shadows
+			Uint32 m_curNumShadows;
 		};
 	}
 }

--- a/src/graphics/opengl/GasGiantMaterial.h
+++ b/src/graphics/opengl/GasGiantMaterial.h
@@ -37,6 +37,7 @@ namespace Graphics {
 		};
 
 		class GasGiantSurfaceMaterial : public Material {
+		public:
 			GasGiantSurfaceMaterial();
 			virtual Program *CreateProgram(const MaterialDescriptor &) override;
 			virtual void SetProgram(Program *p) override;

--- a/src/graphics/opengl/GasGiantMaterial.h
+++ b/src/graphics/opengl/GasGiantMaterial.h
@@ -45,6 +45,8 @@ namespace Graphics {
 
 		protected:
 			void SetGSUniforms();
+			// We actually have multiple programs at work here, one compiled for each of the number of shadows.
+			// They are chosen/created based on what the current parameters passed in by the specialParameter0 are.
 			void SwitchShadowVariant();
 			Program* m_programs[4];	// 0 to 3 shadows
 			Uint32 m_curNumShadows;

--- a/src/graphics/opengl/GeoSphereMaterial.cpp
+++ b/src/graphics/opengl/GeoSphereMaterial.cpp
@@ -137,7 +137,6 @@ void GeoSphereSurfaceMaterial::SetGSUniforms()
 	}
 
 	// we handle up to three shadows at a time
-	int occultedLight[3] = {-1,-1,-1};
 	vector3f shadowCentreX;
 	vector3f shadowCentreY;
 	vector3f shadowCentreZ;
@@ -147,7 +146,6 @@ void GeoSphereSurfaceMaterial::SetGSUniforms()
 	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	int j = 0;
 	while (j<3 && it != itEnd) {
-		occultedLight[j] = it->occultedLight;
 		shadowCentreX[j] = it->centre[0];
 		shadowCentreY[j] = it->centre[1];
 		shadowCentreZ[j] = it->centre[2];
@@ -171,7 +169,7 @@ void GeoSphereSurfaceMaterial::SwitchShadowVariant()
 	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	//request a new shadow variation
 	if (m_curNumShadows != params.shadows.size()) {
-		m_curNumShadows = std::min(params.shadows.size(), 4U);
+		m_curNumShadows = std::min(Uint32(params.shadows.size()), 4U);
 		if (m_programs[m_curNumShadows] == nullptr) {
 			m_descriptor.numShadows = m_curNumShadows; //hax - so that GetOrCreateProgram will create a NEW shader instead of reusing the existing one
 			m_programs[m_curNumShadows] = m_renderer->GetOrCreateProgram(this);

--- a/src/graphics/opengl/GeoSphereMaterial.cpp
+++ b/src/graphics/opengl/GeoSphereMaterial.cpp
@@ -35,14 +35,18 @@ void GeoSphereProgram::InitUniforms()
 	detailScaleHi.Init("detailScaleHi", m_program);
 	detailScaleLo.Init("detailScaleLo", m_program);
 
-	shadows.Init("shadows", m_program);
-	occultedLight.Init("occultedLight", m_program);
 	shadowCentreX.Init("shadowCentreX", m_program);
 	shadowCentreY.Init("shadowCentreY", m_program);
 	shadowCentreZ.Init("shadowCentreZ", m_program);
 	srad.Init("srad", m_program);
 	lrad.Init("lrad", m_program);
 	sdivlrad.Init("sdivlrad", m_program);
+}
+
+GeoSphereSurfaceMaterial::GeoSphereSurfaceMaterial() : m_curNumShadows(0)
+{
+	for(int i=0;i<4;i++)
+		m_programs[i] = nullptr;
 }
 
 Program *GeoSphereSurfaceMaterial::CreateProgram(const MaterialDescriptor &desc)
@@ -68,11 +72,20 @@ Program *GeoSphereSurfaceMaterial::CreateProgram(const MaterialDescriptor &desc)
 	if (desc.quality & HAS_DETAIL_MAPS)
 		ss << "#define DETAIL_MAPS\n";
 
+	ss << stringf("#define NUM_SHADOWS %0{u}\n", m_curNumShadows);
+
 	return new Graphics::OGL::GeoSphereProgram("geosphere_terrain", ss.str());
+}
+
+void GeoSphereSurfaceMaterial::SetProgram(Program *p)
+{
+	m_programs[m_curNumShadows] = p;
+	m_program = p;
 }
 
 void GeoSphereSurfaceMaterial::Apply()
 {
+	SwitchShadowVariant();
 	SetGSUniforms();
 }
 
@@ -144,14 +157,31 @@ void GeoSphereSurfaceMaterial::SetGSUniforms()
 		++it;
 		++j;
 	}
-	p->shadows.Set(j);
-	p->occultedLight.Set(occultedLight);
 	p->shadowCentreX.Set(shadowCentreX);
 	p->shadowCentreY.Set(shadowCentreY);
 	p->shadowCentreZ.Set(shadowCentreZ);
 	p->srad.Set(srad);
 	p->lrad.Set(lrad);
 	p->sdivlrad.Set(sdivlrad);
+}
+
+void GeoSphereSurfaceMaterial::SwitchShadowVariant()
+{
+	const GeoSphere::MaterialParameters params = *static_cast<GeoSphere::MaterialParameters*>(this->specialParameter0);
+	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
+	//request a new shadow variation
+	if (m_curNumShadows != params.shadows.size()) {
+		m_curNumShadows = params.shadows.size();
+		if (m_programs[m_curNumShadows] == nullptr) {
+			m_descriptor.numShadows = m_curNumShadows; //hax - so that GetOrCreateProgram will create a NEW shader instead of reusing the existing one
+			m_programs[m_curNumShadows] = m_renderer->GetOrCreateProgram(this);
+		}
+		m_program = m_programs[m_curNumShadows];
+	}
+}
+
+GeoSphereSkyMaterial::GeoSphereSkyMaterial() : GeoSphereSurfaceMaterial()
+{
 }
 
 Program *GeoSphereSkyMaterial::CreateProgram(const MaterialDescriptor &desc)
@@ -167,11 +197,15 @@ Program *GeoSphereSkyMaterial::CreateProgram(const MaterialDescriptor &desc)
 	ss << "#define ATMOSPHERE\n";
 	if (desc.quality & HAS_ECLIPSES)
 		ss << "#define ECLIPSE\n";
+
+	ss << stringf("#define NUM_SHADOWS %0{u}\n", m_curNumShadows);
+	
 	return new Graphics::OGL::GeoSphereProgram("geosphere_sky", ss.str());
 }
 
 void GeoSphereSkyMaterial::Apply()
 {
+	SwitchShadowVariant();
 	SetGSUniforms();
 }
 

--- a/src/graphics/opengl/GeoSphereMaterial.cpp
+++ b/src/graphics/opengl/GeoSphereMaterial.cpp
@@ -171,7 +171,7 @@ void GeoSphereSurfaceMaterial::SwitchShadowVariant()
 	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	//request a new shadow variation
 	if (m_curNumShadows != params.shadows.size()) {
-		m_curNumShadows = params.shadows.size();
+		m_curNumShadows = std::min(params.shadows.size(), 4U);
 		if (m_programs[m_curNumShadows] == nullptr) {
 			m_descriptor.numShadows = m_curNumShadows; //hax - so that GetOrCreateProgram will create a NEW shader instead of reusing the existing one
 			m_programs[m_curNumShadows] = m_renderer->GetOrCreateProgram(this);

--- a/src/graphics/opengl/GeoSphereMaterial.h
+++ b/src/graphics/opengl/GeoSphereMaterial.h
@@ -63,6 +63,7 @@ namespace Graphics {
 
 
 		class GeoSphereStarMaterial : public Material {
+		public:
 			virtual Program *CreateProgram(const MaterialDescriptor &) override;
 			virtual void Apply() override;
 			virtual void Unapply() override;

--- a/src/graphics/opengl/GeoSphereMaterial.h
+++ b/src/graphics/opengl/GeoSphereMaterial.h
@@ -49,6 +49,8 @@ namespace Graphics {
 
 		protected:
 			void SetGSUniforms();
+			// We actually have multiple programs at work here, one compiled for each of the number of shadows.
+			// They are chosen/created based on what the current parameters passed in by the specialParameter0 are.
 			void SwitchShadowVariant();
 			Program* m_programs[4];	// 0 to 3 shadows
 			Uint32 m_curNumShadows;

--- a/src/graphics/opengl/GeoSphereMaterial.h
+++ b/src/graphics/opengl/GeoSphereMaterial.h
@@ -28,8 +28,6 @@ namespace Graphics {
 			Uniform detailScaleHi;
 			Uniform detailScaleLo;
 
-			Uniform shadows;
-			Uniform occultedLight;
 			Uniform shadowCentreX;
 			Uniform shadowCentreY;
 			Uniform shadowCentreZ;
@@ -42,16 +40,23 @@ namespace Graphics {
 		};
 
 		class GeoSphereSurfaceMaterial : public Material {
+		public:
+			GeoSphereSurfaceMaterial();
 			virtual Program *CreateProgram(const MaterialDescriptor &) override;
+			virtual void SetProgram(Program *p) override;
 			virtual void Apply() override;
 			virtual void Unapply() override;
 
 		protected:
 			void SetGSUniforms();
+			void SwitchShadowVariant();
+			Program* m_programs[4];	// 0 to 3 shadows
+			Uint32 m_curNumShadows;
 		};
 
 		class GeoSphereSkyMaterial : public GeoSphereSurfaceMaterial {
 		public:
+			GeoSphereSkyMaterial();
 			virtual Program *CreateProgram(const MaterialDescriptor &) override;
 			virtual void Apply() override;
 		};


### PR DESCRIPTION
Re-write the way the shader is setup to avoid using uniforms to control the number of iterations for the loops. This allows it to avoid the problems of #2176.

Also `Mar 31, 2013` it's taken more than 3 years to get this fixed and the MESA "fix" was supposedly imminent all the way back then... (╯°□°）╯ ┻━┻

# Bad Things:
This means generating the shader several times, once for each variant.
It is a little unintuitive to do this manually.
I've pulled in a change to the `01_epsilon_eridani.lua` seed that puts `Itzalean` back on the equator but I think it needs yet another seed to actually get all 4 stations into their intended locations.

# Todo:
There's some unfinished stuff in here.
- [x] limit the number of shadows / programs that can be created.
- [x] more documentation as to what/why is going on.

Andy