### PR TITLE
Keep cargo if buying a new ship

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1095,6 +1095,10 @@
       "description" : "",
       "message" : "Ship is too small for the current crew."
    },
+   "TOO_SMALL_TO_TRANSSHIP" : {
+      "description" : "",
+      "message" : "Ship is too small to transship your cargo."
+   },
    "TOTAL" : {
       "description" : "",
       "message" : "Total: "

--- a/data/ui/StationView/ShipMarket.lua
+++ b/data/ui/StationView/ShipMarket.lua
@@ -90,6 +90,13 @@ local function buyShip (sos)
 		return
 	end
 
+	local hdrive = def.hyperdriveClass > 0 and Equipment.hyperspace["hyperdrive_" .. def.hyperdriveClass].capabilities.mass or 0
+	if def.equipSlotCapacity.cargo < player.usedCargo or def.capacity < (player.usedCargo + hdrive) then
+		MessageBox.Message(l.TOO_SMALL_TO_TRANSSHIP)
+		return
+	end
+
+	local manifest = player:GetEquip("cargo")
 	player:AddMoney(-cost)
 
 	station:ReplaceShipOnSale(sos, {
@@ -105,6 +112,9 @@ local function buyShip (sos)
 	player:SetLabel(sos.label)
 	if def.hyperdriveClass > 0 then
 		player:AddEquip(Equipment.hyperspace["hyperdrive_" .. def.hyperdriveClass])
+	end
+	for _, e in pairs(manifest) do
+		player:AddEquip(e)
 	end
 	player:SetFuelPercent(100)
 


### PR DESCRIPTION
The loaded cargo disappears if the player buys a new ship.
The player loses the money and if there is an active mission with already loaded custom cargo the mission cannot succeed.

This PR should solve this problems.
