### PR TITLE
Don't hard code strings we already have in translation system

### DIFF
--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -13,6 +13,7 @@ local Serializer = import("Serializer")
 local Equipment = import("Equipment")
 
 local l = Lang.GetResource("module-breakdownservicing")
+local lui = Lang.GetResource("ui-core")
 
 -- Default numeric values --
 ----------------------------
@@ -106,7 +107,7 @@ local onChat = function (form, ref, option)
 
 	-- Replace those tokens into ad's intro text that can change during play
 	local message = string.interp(ad.intro, {
-		drive = hyperdrive and hyperdrive:GetName() or "None",
+		drive = hyperdrive and hyperdrive:GetName() or lui.NONE,
 		price = Format.Money(price),
 	})
 


### PR DESCRIPTION
This PR was going to fix #3722 (yes github, please auto-close it on merge of this).

The issue was that the intro message of "breakdown and service" offers to repair drive "none" for 0 credits.

This module already has a "You don't have a drive" string, which I think is shown when you actually try to repair the non-existing drive (I'm currently unable to run pioneer, so working in the blind here). Anyway, the module does handle the case of no hyperdrive, so that's fine.

We could show that message as intro message, but I think the current way we have it now, where the player is greeted by a flavoured sales pitch is much nicer.

Also, I kind of don't feel it warranted to duplicate all these flavour introduction strings in a version for those without a drive. If you don't have a drive, then that is dealt with when you try to buy the service. I don't want the number of strings in this project to explode for trivial nit-picking things like this, and it's not the end of the world if player sees a "0 credits" offer. (Actually, I recently payed a real-life bill of the amount 0, last month).

I also suspect that 98 of a 100 players clicking the advert will have a hyperdrive to service to begin with.

__However__, the "None" string was hardcoded, so added an already translated version in this PR.

## TO-DO
- [ ] Untested!