### PR TITLE
Disable Continue button if no saved game to load.

### DIFF
--- a/data/ui/MainMenu.lua
+++ b/data/ui/MainMenu.lua
@@ -115,6 +115,11 @@ for i = 1,#buttonDefs do
 	button.onClick:Connect(def[2])
 	if i < 10 then button:AddShortcut(i) end
 	if i == 10 then button:AddShortcut("0") end
+	if 1 == i then
+		if not Game.CanLoadGame("_exit") then
+			button:Disable()
+		end
+	end
 	buttonSet[i] = button
 	table.insert(anims, {
 		widget = button,

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -845,6 +845,17 @@ Game *Game::LoadGame(const std::string &filename)
 	// file data is freed here
 }
 
+bool Game::CanLoadGame(const std::string &filename)
+{
+	Output("Game::CanLoadGame('%s')\n", filename.c_str());
+	auto file = FileSystem::userFiles.ReadFile(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
+	if (!file) 
+		return false;
+
+	return true;
+	// file data is freed here
+}
+
 void Game::SaveGame(const std::string &filename, Game *game)
 {
 	PROFILE_SCOPED()

--- a/src/Game.h
+++ b/src/Game.h
@@ -42,6 +42,7 @@ class Game {
 public:
 	// LoadGame and SaveGame throw exceptions on failure
 	static Game *LoadGame(const std::string &filename);
+	static bool CanLoadGame(const std::string &filename);
 	// XXX game arg should be const, and this should probably be a member function
 	// (or LoadGame/SaveGame should be somewhere else entirely)
 	static void SaveGame(const std::string &filename, Game *game);

--- a/src/LuaGame.cpp
+++ b/src/LuaGame.cpp
@@ -112,6 +112,40 @@ static int l_game_load_game(lua_State *l)
 }
 
 /*
+ * Function: CanLoadGame
+ *
+ * Does file exist for loading.
+ *
+ * > Game.CanLoadGame(filename)
+ *
+ * Parameters:
+ *
+ *   filename - Filename to find. 
+ *
+ * Return:
+ *
+ *   bool - can the filename be found to load
+ *
+ * Availability:
+ *
+ *   YYYY - MM - DD
+ *   2016 - 06 - 25
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_game_can_load_game(lua_State *l)
+{
+	const std::string filename(luaL_checkstring(l, 1));
+
+	bool success = Game::CanLoadGame(filename);
+	lua_pushboolean(l, success);
+
+	return 1;
+}
+
+/*
  * Function: SaveGame
  *
  * Save the current game.
@@ -298,10 +332,11 @@ void LuaGame::Register()
 	LUA_DEBUG_START(l);
 
 	static const luaL_Reg l_methods[] = {
-		{ "StartGame", l_game_start_game },
-		{ "LoadGame",  l_game_load_game  },
-		{ "SaveGame",  l_game_save_game  },
-		{ "EndGame",   l_game_end_game   },
+		{ "StartGame",      l_game_start_game       },
+		{ "LoadGame",       l_game_load_game        },
+		{ "CanLoadGame",    l_game_can_load_game    },
+		{ "SaveGame",       l_game_save_game        },
+		{ "EndGame",        l_game_end_game         },
 
 		{ "SwitchView", l_game_switch_view },
 


### PR DESCRIPTION
Add method to test if a save game file exists for loading. Use it in the main menu.

Should fix #3727