### PR TITLE
Make trade analyzer removable again. Undo #3474, close #3742

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -64,7 +64,7 @@ function EquipType:Serialize()
 			ret[k] = v
 		end
 	end
-	
+
 	if debug.dmodeenabled() and self.slots == "cargo" then
 		for _,v in pairs(cargo) do
 			if (v.l10n_key == self.key and v.l10n_resource == self.l10n_resource) then
@@ -73,7 +73,7 @@ function EquipType:Serialize()
 			end
 		end
 	end
-	
+
 	ret.volatile = nil
 	return ret
 end
@@ -756,7 +756,7 @@ misc.hull_autorepair = EquipType.New({
 })
 misc.trade_analyzer = EquipType.New({
 	l10n_key="TRADE_ANALYZER", slots="trade_analyzer", price=400,
-	capabilities={mass=0, trade_analyzer=1, software=1}, purchasable=true, tech_level=9
+	capabilities={mass=0, trade_analyzer=1}, purchasable=true, tech_level=9
 })
 misc.planetscanner = BodyScannerType.New({
 	l10n_key = 'PLANETSCANNER', slots="sensor", price=15000,

--- a/data/ui/StationView/EquipmentTableWidgets.lua
+++ b/data/ui/StationView/EquipmentTableWidgets.lua
@@ -273,11 +273,6 @@ function EquipmentTableWidgets.Pair (config)
 	local function onSell (e)
 		if not funcs.onClickSell(e) then return end
 
-		if e.capabilities.software then
-			MessageBox.Message("System software upgrades can not be uninstalled and resold. Visit a ship service station if you want to purge the upgrade from your on board computer.")
-			return
-		end
-
 		local player = Game.player
 
 		-- remove from last free slot (reverse table)


### PR DESCRIPTION
Re-enable selling of Trade analyzer. As I mentioned in #3742:

> It was implemented by someone who had the distinct idea that this must be "software", and that you can't sell software back. I say: it could be a cartrige, or license, or subscription, or whatever. I want it to have the same behavior as other equipment, just like it used to be. I don't see how the game becomes more "fun" by not being able to sell some equipment that you've bought.

Since this touches some equipment philosophy, ping @laarmen 