### PR TITLE
Fix grammar error in module-cargorun

### DIFF
--- a/data/lang/module-cargorun/en.json
+++ b/data/lang/module-cargorun/en.json
@@ -577,7 +577,7 @@
    },
    "WHYSOMUCH_INFRASTRUCTURE_1" : {
       "description" : "",
-      "message" : "These goods crucial for a construction project."
+      "message" : "These goods are crucial for a construction project."
    },
    "WHYSOMUCH_MINING_1" : {
       "description" : "",


### PR DESCRIPTION
The [Translations guide](http://pioneerwiki.com/wiki/Translations) says translations should go through Transifex, but the error is in the original English source string and I couldn't find an English language option on Transifex.