### PR TITLE
Add a TCP Lua console.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,7 @@ AC_SUBST([OPTIMISE])
 
 dnl Debug stuff
 AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug], [Enable debugging code (stack checks, debug tools features, etc)]), [EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DDEBUG"])
+AC_ARG_ENABLE([remote-lua-repl], AS_HELP_STRING([--enable-remote-lua-repl], [Enable remote lua repl (tcp port 12345 or -DREMOTE_LUA_REPL_PORT=54321]), [EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DREMOTE_LUA_REPL"])
 AC_ARG_ENABLE([ldb], AS_HELP_STRING([--enable-ldb], [Enable ldb support.]), [EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DENABLE_LDB" ; EXTRA_LIBS="$EXTRA_LIBS -lldbcore"])
 AC_ARG_ENABLE([profiler], AS_HELP_STRING([--enable-profiler], [Enable internal profiler]), [EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DPIONEER_PROFILER"])
 

--- a/src/LuaConsole.cpp
+++ b/src/LuaConsole.cpp
@@ -14,6 +14,20 @@
 #include <stack>
 #include <algorithm>
 
+#ifdef REMOTE_LUA_REPL
+// for networking
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <fcntl.h>
+#include <netinet/tcp.h>
+// end networking
+#endif
+
 #define TRUSTED_CONSOLE 1
 
 #if TRUSTED_CONSOLE
@@ -25,7 +39,11 @@ static const char CONSOLE_CHUNK_NAME[] = "console";
 LuaConsole::LuaConsole():
 	m_active(false),
 	m_precompletionStatement(),
-	m_completionList() {
+	m_completionList()
+#ifdef REMOTE_LUA_REPL
+	, m_debugSocket(0)
+#endif
+{
 
 	m_output = Pi::ui->MultiLineText("");
 	m_entry = Pi::ui->TextEntry();
@@ -307,14 +325,18 @@ void LuaConsole::UpdateCompletion(const std::string & statement) {
 }
 
 void LuaConsole::AddOutput(const std::string &line) {
-	m_output->AppendText(line + "\n");
+	std::string actualLine = line + "\n";
+	m_output->AppendText(actualLine);
+#ifdef REMOTE_LUA_REPL
+	BroadcastToDebuggers(actualLine);
+#endif
 }
 
-void LuaConsole::ExecOrContinue(const std::string &stmt) {
+void LuaConsole::ExecOrContinue(const std::string &stmt, bool repeatStatement) {
 	int result;
 	lua_State *L = Lua::manager->GetLuaState();
 
-    // If the statement is an expression, print its final value.
+	// If the statement is an expression, print its final value.
 	result = luaL_loadbuffer(L, ("return " + stmt).c_str(), stmt.size()+7, CONSOLE_CHUNK_NAME);
 	if (result == LUA_ERRSYNTAX)
 		result = luaL_loadbuffer(L, stmt.c_str(), stmt.size(), CONSOLE_CHUNK_NAME);
@@ -358,12 +380,14 @@ void LuaConsole::ExecOrContinue(const std::string &stmt) {
 	std::istringstream stmt_stream(stmt);
 	std::string string_buffer;
 
-	std::getline(stmt_stream, string_buffer);
-	AddOutput("> " + string_buffer);
-
-	while(!stmt_stream.eof()) {
+	if (repeatStatement) {
 		std::getline(stmt_stream, string_buffer);
-		AddOutput("  " + string_buffer);
+		AddOutput("> " + string_buffer);
+
+		while(!stmt_stream.eof()) {
+			std::getline(stmt_stream, string_buffer);
+			AddOutput("  " + string_buffer);
+		}
 	}
 
 	// perform a protected call
@@ -510,3 +534,120 @@ void LuaConsole::Register()
 
 	LUA_DEBUG_END(l, 0);
 }
+
+#ifdef REMOTE_LUA_REPL
+void LuaConsole::OpenTCPDebugConnection(int portnumber) {
+	m_debugSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (m_debugSocket < 0) {
+		Output("Error opening socket");
+		return;
+	}
+	struct sockaddr_in destination;
+	destination.sin_family = AF_INET;
+	destination.sin_port = htons(portnumber);
+	destination.sin_addr.s_addr = INADDR_ANY; // this should be localhost only!
+	if (bind(m_debugSocket, (struct sockaddr*)&destination, sizeof(destination)) < 0) {
+		Output("Binding socket failed.\n");
+		if(m_debugSocket) {
+			close(m_debugSocket);
+			m_debugSocket = 0;
+			return;
+		}
+	}
+	Output("Listening on TCP port %d.\n", portnumber);
+	if (listen(m_debugSocket, 2) < 0) {
+		Output("Listening failed.\n");
+		if (m_debugSocket) {
+			close(m_debugSocket);
+			m_debugSocket = 0;
+			return;
+		}
+	}
+}
+
+void LuaConsole::HandleTCPDebugConnections() {
+	if (m_debugSocket) {
+		fd_set read_fds;
+		FD_ZERO(&read_fds);
+		FD_SET(m_debugSocket, &read_fds);
+		struct timespec timeout = {0,0};
+
+		int res = pselect(m_debugSocket + 1, &read_fds, NULL, NULL, &timeout, NULL);
+		if (res < 0 && errno != EINTR) {
+			Output("pselect error %d.\n", errno);
+		}
+		if (FD_ISSET(m_debugSocket, &read_fds)) {
+			HandleNewDebugTCPConnection(m_debugSocket);
+		}
+	}
+	for(int sock : m_debugConnections) {
+		HandleDebugTCPConnection(sock);
+	}
+}
+
+void LuaConsole::HandleNewDebugTCPConnection(int socket) {
+	int sock = accept(socket, NULL, 0);
+	if (sock < 0) {
+		Output("Error accepting on socket.\n");
+		return;
+	}
+	// set to non-blocking
+	int status = fcntl(sock, F_SETFL, fcntl(sock, F_GETFL, 0) | O_NONBLOCK);
+	if (status == -1) {
+		Output("Error setting socket to non-blocking.");
+	}
+	// set to no buffering
+	int flag = 1;
+	setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int));
+
+	m_debugConnections.push_back(sock);
+	std::string welcome = "** Welcome to the Pioneer Remote Debugging Console!\n> ";
+	BroadcastToDebuggers(welcome);
+	Output("Successfully accepted connection.\n");
+}
+
+// TODO: these should not be here, do we need them generally? Maybe in utils.cpp?
+static std::string &ltrim(std::string & str)
+{
+	auto it2 =  std::find_if( str.begin() , str.end() , [](char ch){ return !std::isspace<char>(ch , std::locale::classic() ) ; } );
+	str.erase( str.begin() , it2);
+	return str;
+}
+
+static std::string &rtrim(std::string & str)
+{
+	auto it1 =  std::find_if( str.rbegin() , str.rend() , [](char ch){ return !std::isspace<char>(ch , std::locale::classic() ) ; } );
+	str.erase( it1.base() , str.end() );
+	return str;
+}
+
+static std::string &trim(std::string &str) {
+	return ltrim(rtrim(str));
+}
+
+void LuaConsole::HandleDebugTCPConnection(int sock) {
+	char buffer[4097];
+	int count = read(sock, buffer, 4096);
+	if (count < 0 && errno != EAGAIN) {
+		Output("Error reading from socket: %d.\n", errno);
+		close(sock);
+		m_debugConnections.erase(std::remove(m_debugConnections.begin(), m_debugConnections.end(), sock), m_debugConnections.end());
+	} else if (count > 0) {
+		buffer[count] = 0;
+		std::string text(buffer);
+		trim(text);
+		ExecOrContinue(text, false);
+		BroadcastToDebuggers("\n> ");
+	}
+}
+
+void LuaConsole::BroadcastToDebuggers(const std::string &message) {
+	 for(int sock : m_debugConnections) {
+		 if(send(sock, message.c_str(), message.size(), MSG_NOSIGNAL) < 0) {
+			 Output("Closing debug socket, error %d.\n", errno);
+			 close(sock);
+			 m_debugConnections.erase(std::remove(m_debugConnections.begin(), m_debugConnections.end(), sock), m_debugConnections.end());
+		 };
+	 }
+}
+#endif

--- a/src/LuaConsole.h
+++ b/src/LuaConsole.h
@@ -25,18 +25,29 @@ public:
 	bool IsActive() const { return m_active; }
 	void AddOutput(const std::string &line);
 
+#ifdef REMOTE_LUA_REPL
+	void OpenTCPDebugConnection(int portnumber);
+	void HandleTCPDebugConnections();
+#endif
+
 	static void Register();
 private:
 	bool OnKeyDown(const UI::KeyboardEvent &event);
 	void OnChange(const std::string &text);
 	void OnEnter(const std::string &text);
 
-	void ExecOrContinue(const std::string &stmt);
+	void ExecOrContinue(const std::string &stmt, bool repeatStatement=true);
 
 	void OnKeyPressed(const SDL_Keysym*);
 	void OnTextChanged();
 	void UpdateCompletion(const std::string & statement);
 	void RegisterAutoexec();
+
+#ifdef REMOTE_LUA_REPL
+	void HandleNewDebugTCPConnection(int socket);
+	void HandleDebugTCPConnection(int socket);
+	void BroadcastToDebuggers(const std::string &message);
+#endif
 
 	bool m_active;
 
@@ -53,6 +64,11 @@ private:
 	std::string m_precompletionStatement;
 	std::vector<std::string> m_completionList;
 	unsigned int m_currentCompletion;
+
+#ifdef REMOTE_LUA_REPL
+	int m_debugSocket;
+	std::vector<int> m_debugConnections;
+#endif
 };
 
 #endif /* _LUACONSOLE_H */

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1145,6 +1145,13 @@ void Pi::StartGame()
 	Pi::game->GetCpan()->SetAlertState(Ship::ALERT_NONE);
 	SetView(game->GetWorldView());
 
+#ifdef REMOTE_LUA_REPL
+	#ifndef REMOTE_LUA_REPL_PORT
+	#define REMOTE_LUA_REPL_PORT 12345
+	#endif
+	luaConsole->OpenTCPDebugConnection(REMOTE_LUA_REPL_PORT);
+#endif
+
 	// fire event before the first frame
 	LuaEvent::Queue("onGameStart");
 	LuaEvent::Emit();
@@ -1353,6 +1360,11 @@ void Pi::MainLoop()
 		// Gui::Draw so that labels drawn to screen can have mouse events correctly
 		// detected. Gui::Draw wipes memory of label positions.
 		Pi::HandleEvents();
+
+#ifdef REMOTE_LUA_REPL
+		Pi::luaConsole->HandleTCPDebugConnections();
+#endif
+
 		if( Pi::bRequestEndGame ) {
 			Pi::EndGame();
 		}


### PR DESCRIPTION
This patch adds a new configure option --enable-remote-lua-repl. If that
is given, When starting a game (not in the menu), pioneer listens to
port 12345 (can be changed with -DREMOTE_LUA_REPL_PORT=...). Connect to
it (telnet 127.0.0.1 12345), and you can evaluate expressions like in
the in-game console. This can be used to interface an external lua IDE
to a running game.

At the moment, the code only works on Linux, but the changes for Windows
should be small (mostly including other header files). This is only relevant if
--enable-remote-lua-repl is given when configuring!