### PR TITLE
NaN in your numbers

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -2278,5 +2278,7 @@ static std::pair<double, double> calculateHeadingPitch(PlaneType pt) {
 	const double hedEast = groundHed.Dot(east);
 	const double heading = wrapAngleToPositive(atan2(hedEast, hedNorth));
 
-	return std::make_pair(heading, pitch);
+	return std::make_pair(
+		isnan(heading) ? 0.0 : heading, 
+		isnan(pitch) ? 0.0 : pitch);
 }

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -214,7 +214,8 @@ void TextureFont::PopulateString(Graphics::VertexArray &va, const std::string &s
 		} else {
 			Uint32 chr;
 			int n = utf8_decode_char(&chr, &str[i]);
-			assert(n);
+			if(n<=0)
+				break;
 			i += n;
 
 			const Glyph &glyph = GetGlyph(chr);
@@ -223,7 +224,8 @@ void TextureFont::PopulateString(Graphics::VertexArray &va, const std::string &s
 			if (str[i]) {
 				Uint32 chr2;
 				n = utf8_decode_char(&chr2, &str[i]);
-				assert(n);
+				if(n<=0)
+					break;
 
 				px += GetKern(glyph, GetGlyph(chr2));
 			}
@@ -275,7 +277,8 @@ Color TextureFont::PopulateMarkup(Graphics::VertexArray &va, const std::string &
 		} else {
 			Uint32 chr;
 			int n = utf8_decode_char(&chr, &str[i]);
-			assert(n);
+			if(n<=0)
+				break;
 			i += n;
 
 			const Glyph &glyph = GetGlyph(chr);
@@ -285,7 +288,8 @@ Color TextureFont::PopulateMarkup(Graphics::VertexArray &va, const std::string &
 			if (str[i]) {
 				Uint32 chr2;
 				n = utf8_decode_char(&chr2, &str[i]);
-				assert(n);
+				if(n<=0)
+					break;
 
 				px += GetKern(glyph, GetGlyph(chr2));
 			}


### PR DESCRIPTION
I was seeing a crash quite frequently where it was trying to allocate space for millions of characters due to an infinite loop.

This handles the NaN cause of the string that looped, and attempts to avoid future loops.

I think that the TextureFont needs a bit more work and some nicer logic, perhaps avoiding some of the duplication of code in that class. However I'm not going to do that in this PR.