### PR TITLE
Disable instancing for city buildings, and enable idle animations.

### DIFF
--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -192,6 +192,7 @@ void CityOnPlanet::LookupBuildingListModels(citybuildinglist_t *list)
 	for (auto m = models.begin(), itEnd = models.end(); m != itEnd; ++m, i++) {
 		list->buildings[i].instIndex = i;
 		list->buildings[i].resolvedModel = *m;
+		list->buildings[i].idle = (*m)->FindAnimation("idle");
 		list->buildings[i].collMesh = (*m)->CreateCollisionMesh();
 		const Aabb &aabb = list->buildings[i].collMesh->GetAabb();
 		const double maxx = std::max(fabs(aabb.max.x), fabs(aabb.min.x));
@@ -379,6 +380,15 @@ void CityOnPlanet::Render(Graphics::Renderer *r, const Graphics::Frustum &frustu
 		}
 	}
 
+	// update any idle animations
+	for(Uint32 i=0; i<s_buildingList.numBuildings; i++) {
+		SceneGraph::Animation *pAnim = s_buildingList.buildings[i].idle;
+		if(pAnim) {
+			pAnim->SetProgress(fmod(pAnim->GetProgress() + (Pi::game->GetTimeStep() / pAnim->GetDuration()), 1.0));
+			pAnim->Interpolate();
+		}
+	}
+	
 	Uint32 uCount = 0;
 	std::vector<Uint32> instCount;
 	std::vector< std::vector<matrix4x4f> > transform;
@@ -408,7 +418,10 @@ void CityOnPlanet::Render(Graphics::Renderer *r, const Graphics::Frustum &frustu
 	
 	// render the building models using instancing
 	for(Uint32 i=0; i<s_buildingList.numBuildings; i++) {
-		s_buildingList.buildings[i].resolvedModel->Render(transform[i]);
+		SceneGraph::Model *pModel = s_buildingList.buildings[i].resolvedModel;
+		for(size_t wtf = 0; wtf<transform[i].size(); wtf++) {
+			pModel->Render(transform[i][wtf]);
+		}
 	}
 
 	r->GetStats().AddToStatCount(Graphics::Stats::STAT_BUILDINGS, uCount);

--- a/src/CityOnPlanet.h
+++ b/src/CityOnPlanet.h
@@ -15,7 +15,7 @@ class Planet;
 class SpaceStation;
 class Frame;
 namespace Graphics { class Renderer; class Frustum; }
-namespace SceneGraph { class Model; }
+namespace SceneGraph { class Model; class Animation; }
 
 #define CITY_ON_PLANET_RADIUS 5000.0
 
@@ -60,6 +60,7 @@ private:
 		const char *modelname;
 		double xzradius;
 		SceneGraph::Model *resolvedModel;
+		SceneGraph::Animation *idle;
 		RefCountedPtr<CollMesh> collMesh;
 		Uint32 instIndex;
 	};


### PR DESCRIPTION
Disable instancing for city buildings, and enable idle animations.

Does exactly what it says. It seems to be more efficient to submit a few thousand draw calls to the GPU than 14 instanced calls? No idea why but the results are solid, in the worst/best case when viewing an entire city at maximum detail I see the framerate go from 45fps to 90fps.

This also enable's idle animations for City buildings.

EDIT:
One other things this does is batch the drawing of the models to minimise switching between the types of models. So it draws all of one kind, then all of the next. This is what instancing should also do but for some reason it performs poorly.