### PR TITLE
Add a piece explicitly linking to the FAQ about bug reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Keyboard and mouse control is found at:
 
 For frequently asked questions, please see
   http://pioneerwiki.com/wiki/FAQ
+  
+  
+## BUG Reporting
+
+Please see the section of the FAQ pertaining to bugs, crashs and reporting other issues.
+  http://pioneerwiki.com/wiki/FAQ#How.2Fwhere_do_I_report_my_bug.2Fcrash
 
 
 ## Contributing


### PR DESCRIPTION
We still get very poor quality bug reports and always have to ask for the opengl.txt and output.txt files.
So I thought I'd update [the FAQ](http://pioneerwiki.com/wiki/FAQ#How.2Fwhere_do_I_report_my_bug.2Fcrash) a little bit and add this link directly too it.