### PR TITLE
Buildscript update

### DIFF
--- a/scripts/nightly-build.pl
+++ b/scripts/nightly-build.pl
@@ -178,6 +178,7 @@ sub copy {
     system "cp -v src/pioneer.map $copy_dir" if $platform eq 'win32';
     system "cp -v src/modelcompiler.map $copy_dir" if $platform eq 'win32';
     system "ls *.txt | /usr/bin/grep -v -E '(COMPILING\.txt|SAVEBUMP\.txt)' | xargs cp -v -t $copy_dir";
+    system "cp -v README.md $copy_dir"
     system "cp -rv licenses $copy_dir/licenses";
     system "cp -rv data $copy_dir/data";
 

--- a/scripts/nightly-build.pl
+++ b/scripts/nightly-build.pl
@@ -177,7 +177,7 @@ sub copy {
     system "cp -v src/modelcompiler$suffix $copy_dir";
     system "cp -v src/pioneer.map $copy_dir" if $platform eq 'win32';
     system "cp -v src/modelcompiler.map $copy_dir" if $platform eq 'win32';
-    system "cp -v *.txt $copy_dir";
+    system "ls *.txt | /usr/bin/grep -v -E '(COMPILING\.txt|SAVEBUMP\.txt)' | xargs cp -v -t $copy_dir";
     system "cp -rv licenses $copy_dir/licenses";
     system "cp -rv data $copy_dir/data";
 


### PR DESCRIPTION
We've seen players trying to compile the build tar file, since it included the COMPILING file.

We've seen players looking for a README file.

Players don't need the SAVEBUMP file.