### PR TITLE
use github templates

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Contributions are welcome!
+
+The following text assumes you're about to submit a new pull request.
+For _how_ to contribute, please see [wiki](http://pioneerwiki.com/wiki/How_you_can_contribute).
+
+### Check before submitting
+
+- Have you read [code style](http://pioneerwiki.com/wiki/Code_style) on the wiki?
+- If new to github, make sure you're not opening this pull request from your _master_ branch, but rather a new [separate branch](http://pioneerwiki.com/wiki/Using_git_and_GitHub#Making_a_pull_request)
+- Have you reviewed your code? Don't trust the developers to do it, as they don't have time to read your code.
+- Do you foresee any potential pitfalls or issues? If so please mention them.
+- If a new feature, then please describe it, possibly with screenshot if something graphical.
+- If a bug fix, then please use [key phrases](https://help.github.com/articles/closing-issues-via-commit-messages/) so that the original issue will be auto-closed upon merge. E.g.:
+
+```
+    fix #1234
+    fixes #1234
+    close #1234
+    closes #1234
+    resolve #1234
+    resolves #1234
+```
+
+
+### Consider after submitting
+After a pull request has been submitted, it is more common than not, that the branch keeps being modified, as bugs or issues are raised. If the change is to the latest commit on the branch, use `git add`, followed by `git commit --amend`, followed by a forced push, `git push -f`, to keep commit history clean. See [wiki](http://pioneerwiki.com/wiki/Using_git_and_GitHub) for details on editing/fixing commits.
+
+If you're hungry to contribute more, you'll find some pointers on [How you can contribute](http://pioneerwiki.com/wiki/How_you_can_contribute).
+
+Thanks for your contribution!

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,19 @@
+<!-- This is a suggested template for your issue. (remove as you check)     -->
+<!--   * if graphical: also include opengl.txt from pioneer config dir      -->
+<!--     (consult FAQ on wiki for info on how to find opengl.txt).          -->
+<!--   * Please Include version of your last bug-free Pioneer, if possible. -->
+<!--   * Has the issue been reported before? Search the issue tracker.      -->
+<!--   * Perhaps a screenshot illustrates the bug well?                     -->
+<!--   * Feature request? Please consider IRC, player- or dev-forum instead -->
+
+
+### Observed behaviour
+
+
+### Expected behaviour
+
+
+### Steps to reproduce
+
+
+__My pioneer version (and OS):__

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+<!-- Please describe new feature, possible with screenshot if needed. -->
+<!-- Please make sure you've read documentation on contributing -->
+


### PR DESCRIPTION
Please read, and suggest improvements.

Idea here was that we already have wiki-pages, that are easier to maintain than these templates, thus it links to relevant wiki-pages.

Especially for `contributing` file, this is linked to at the head of a new PR, and thus the info I include is what to consider before pressing "create pull request" button. For _how_ to contribute, we have the wiki, to which also the pioneer home page links.

So, any other "classic" questions to include in issue_template? 

_also, I decided to use lowercase filenames, since these reside in their own folder, and don't need to SHOUT to call attention to them, as README or COMPILING does._