### PR TITLE
Navigation button update to allow for dynamicBodies as nav targets (SAR and general)

### DIFF
--- a/data/libs/ui/NavButton.lua
+++ b/data/libs/ui/NavButton.lua
@@ -18,7 +18,7 @@ function NavButton.New (text, target)
 	self.widget = ui:HBox(10):PackEnd({ self.button, self.label })
 
 	self.widget.onClick:Connect(function ()
-			if self.target:IsDynamic() then
+			if self.target:isa("Body") and self.target:IsDynamic() then
 				Game.player:SetNavTarget(self.target)
 			elseif self.target:IsSameSystem(Game.system.path) then
 				if self.target.bodyIndex then

--- a/data/libs/ui/NavButton.lua
+++ b/data/libs/ui/NavButton.lua
@@ -18,15 +18,17 @@ function NavButton.New (text, target)
 	self.widget = ui:HBox(10):PackEnd({ self.button, self.label })
 
 	self.widget.onClick:Connect(function ()
-		if self.target:IsSameSystem(Game.system.path) then
-			if self.target.bodyIndex then
-				Game.player:SetNavTarget(Space.GetBody(self.target.bodyIndex))
+			if self.target:IsDynamic() then
+				Game.player:SetNavTarget(self.target)
+			elseif self.target:IsSameSystem(Game.system.path) then
+				if self.target.bodyIndex then
+					Game.player:SetNavTarget(Space.GetBody(self.target.bodyIndex))
+				end
+			else
+				Game.player:SetHyperspaceTarget(self.target:GetStarSystem().path)
+				-- XXX we should do something useful here
+				-- e.g. switch to the sector map or just beep
 			end
-		else
-			Game.player:SetHyperspaceTarget(self.target:GetStarSystem().path)
-			-- XXX we should do something useful here
-			-- e.g. switch to the sector map or just beep
-		end
 	end)
 
 	setmetatable(self, {

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -51,7 +51,8 @@ local ui = Engine.ui
 
 -- basic variables for mission creation
 local max_mission_dist = 30          -- max distance for long distance mission target location [ly]
-local max_close_dist = 5000          -- max distance for "CLOSE_PLANET" target location [km]
+--debug
+local max_close_dist = 100          -- max distance for "CLOSE_PLANET" target location [km]
 local max_close_space_dist = 10000   -- max distance for "CLOSE_SPACE" target location [km]
 local far_space_orbit_dist = 100000  -- orbital distance around planet for "FAR_SPACE" target location [km]
 local min_interaction_dist = 50      -- min distance for successful interaction with target [meters]
@@ -678,8 +679,6 @@ local onChat = function (form, ref, option)
 	--      return
 	--   end
 
-	form:AddNavButton(ad.planet_target)
-
 	if option == 0 then
 		local introtext = string.interp(ad.flavour.introtext, {
 			                                name         = ad.client.name,
@@ -821,6 +820,7 @@ local onChat = function (form, ref, option)
 
 		form:SetMessage(l.THANK_YOU_ACCEPTANCE_TXT)
 		addMission(mission)
+		form:AddNavButton(mission.target)
 		return
 	end
 
@@ -1775,17 +1775,17 @@ local onCreateBB = function (station)
 	-- more efficient to determine closest planets per station once per banter board creation
 	closestplanets = findClosestPlanets()
 
-	-- -- force ad creation for debugging
-	-- local num = 3
-	-- for _ = 1,num do
-	--    makeAdvert(station, 1, closestplanets)
-	--    makeAdvert(station, 2, closestplanets)
-	--    makeAdvert(station, 3, closestplanets)
-	--    makeAdvert(station, 4, closestplanets)
-	--    makeAdvert(station, 5, closestplanets)
-	--    makeAdvert(station, 6, closestplanets)
-	--    makeAdvert(station, 7, closestplanets)
-	-- end
+	-- force ad creation for debugging
+	local num = 3
+	for _ = 1,num do
+	   makeAdvert(station, 1, closestplanets)
+	   makeAdvert(station, 2, closestplanets)
+	   makeAdvert(station, 3, closestplanets)
+	   makeAdvert(station, 4, closestplanets)
+	   makeAdvert(station, 5, closestplanets)
+	   makeAdvert(station, 6, closestplanets)
+	   makeAdvert(station, 7, closestplanets)
+	end
 
 	if triggerAdCreation() then makeAdvert(station, nil, closestplanets) end
 end

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -51,8 +51,7 @@ local ui = Engine.ui
 
 -- basic variables for mission creation
 local max_mission_dist = 30          -- max distance for long distance mission target location [ly]
---debug
-local max_close_dist = 100          -- max distance for "CLOSE_PLANET" target location [km]
+local max_close_dist = 5000          -- max distance for "CLOSE_PLANET" target location [km]
 local max_close_space_dist = 10000   -- max distance for "CLOSE_SPACE" target location [km]
 local far_space_orbit_dist = 100000  -- orbital distance around planet for "FAR_SPACE" target location [km]
 local min_interaction_dist = 50      -- min distance for successful interaction with target [meters]
@@ -820,7 +819,15 @@ local onChat = function (form, ref, option)
 
 		form:SetMessage(l.THANK_YOU_ACCEPTANCE_TXT)
 		addMission(mission)
-		form:AddNavButton(mission.target)
+
+		-- setup navbutton target (ships in other system don't exist yet!)
+		local navbutton_target
+		if mission.planet_target:IsSameSystem(Game.system.path) then
+			navbutton_target = mission.target
+		else
+			navbutton_target = mission.planet_target
+		end
+		form:AddNavButton(navbutton_target)
 		return
 	end
 
@@ -1776,16 +1783,16 @@ local onCreateBB = function (station)
 	closestplanets = findClosestPlanets()
 
 	-- force ad creation for debugging
-	local num = 3
-	for _ = 1,num do
-	   makeAdvert(station, 1, closestplanets)
-	   makeAdvert(station, 2, closestplanets)
-	   makeAdvert(station, 3, closestplanets)
-	   makeAdvert(station, 4, closestplanets)
-	   makeAdvert(station, 5, closestplanets)
-	   makeAdvert(station, 6, closestplanets)
-	   makeAdvert(station, 7, closestplanets)
-	end
+	-- local num = 3
+	-- for _ = 1,num do
+	--    makeAdvert(station, 1, closestplanets)
+	--    makeAdvert(station, 2, closestplanets)
+	--    makeAdvert(station, 3, closestplanets)
+	--    makeAdvert(station, 4, closestplanets)
+	--    makeAdvert(station, 5, closestplanets)
+	--    makeAdvert(station, 6, closestplanets)
+	--    makeAdvert(station, 7, closestplanets)
+	-- end
 
 	if triggerAdCreation() then makeAdvert(station, nil, closestplanets) end
 end
@@ -1953,6 +1960,14 @@ local onClick = function (mission)
 		navbutton = NavButton.New(l.SET_RETURN_ROUTE, mission.station_local)
 	end
 
+	-- navbutton target (system if out-of-system jump, target ship if in system)
+	local navbutton_target
+	if mission.planet_target:IsSameSystem(Game.system.path) then
+		navbutton_target = mission.target
+	else
+		navbutton_target = mission.planet_target
+	end
+
 	local pickup_comm_text = 0
 	local count = 0
 	for commodity, amount in pairs(mission.pickup_comm) do
@@ -1994,7 +2009,7 @@ local onClick = function (mission)
 					              :SetColumn(0, {ui:VBox():PackEnd({ui:Label(l.DISTANCE)})})
 					              :SetColumn(1, {ui:VBox():PackEnd({ui:Label(dist_for_text)})}),
 				              ui:Margin(5),
-				              NavButton.New(l.SET_AS_TARGET, mission.planet_target),
+				              NavButton.New(l.SET_AS_TARGET, navbutton_target),
 				              ui:Margin(10),
 				              ui:Grid(2,1)
 					              :SetColumn(0, {ui:VBox():PackEnd({ui:Label(l.REWARD)})})


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This PR does three things:

1) It updates NavButton.lua to allow setting dynamic objects (such as ships) as nav targets.

2) It allows setting Search&Rescue target ships as nav targets directly either from the BBS ad or from the mission details screen. Before, only the closest planet was selected as nav target.

3) It moves the navbutton in the BBS ad to after mission acceptance, because only then will target ships actually be created.

I know, this changes the original philosophy of the Search&Rescue missions by basically eliminating the "search". But opposed to what I had thought, searching was never really any fun. Especially for out-of-system missions, where one had to go into the F2=>F6 system overview to find the ship (which was usually placed wrongly right on top of the sun of that system), it caused me to lose immersion into the game.