### PR TITLE
Add button to Settings menus so user can open their Pioneer folder.

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -795,6 +795,10 @@
       "description" : "",
       "message" : "Ok"
    },
+   "OPEN_USER_FOLDER" : {
+      "description" : "",
+      "message" : "User Folder"
+   },
    "OPTIONS" : {
       "description" : "",
       "message" : "Options"

--- a/data/ui/MainMenu.lua
+++ b/data/ui/MainMenu.lua
@@ -77,7 +77,8 @@ local doSettingsScreen = function()
 	ui.layer:SetInnerWidget(
 		ui.templates.Settings({
 			closeButtons = {
-				{ text = l.RETURN_TO_MENU, onClick = function () ui.layer:SetInnerWidget(ui.templates.MainMenu()) end }
+				{ text = l.RETURN_TO_MENU, onClick = function () ui.layer:SetInnerWidget(ui.templates.MainMenu()) end },
+				{ text = l.OPEN_USER_FOLDER, onClick = Engine.OpenBrowseUserFolder, toDisable = function () return Engine.CanBrowseUserFolder==false end }
 			}
 		})
 	)

--- a/data/ui/Settings.lua
+++ b/data/ui/Settings.lua
@@ -387,13 +387,7 @@ ui.templates.Settings = function (args)
 		end
 	end
 
-	if #close_buttons > 1 then
-		close_buttons = ui:HBox(5):PackEnd(close_buttons)
-	else
-		close_buttons = close_buttons[1]
-	end
-
-	return ui:VBox():PackEnd({setTabs, ui:Margin(10, "ALL", close_buttons)})
+	return ui:VBox():PackEnd({setTabs, ui:Margin(10, "ALL", ui:HBox(5):PackEnd(close_buttons))})
 end
 
 ui.templates.SettingsInGame = function ()
@@ -428,7 +422,8 @@ ui.templates.SettingsInGame = function ()
 				end
 			},
 			{ text = l.RETURN_TO_GAME, onClick = Game.SwitchView },
-			{ text = l.EXIT_THIS_GAME, onClick = Game.EndGame }
+			{ text = l.EXIT_THIS_GAME, onClick = Game.EndGame },
+			{ text = l.OPEN_USER_FOLDER, onClick = Engine.OpenBrowseUserFolder, toDisable = function () return Engine.CanBrowseUserFolder==false end }
 		}
 	})
 end

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -7,6 +7,7 @@
 #include "LuaConstants.h"
 #include "EnumStrings.h"
 #include "Random.h"
+#include "OS.h"
 #include "Pi.h"
 #include "utils.h"
 #include "FloatComparison.h"
@@ -815,6 +816,18 @@ static int l_engine_get_model(lua_State *l)
 	return 1;
 }
 
+static int l_get_can_browse_user_folders(lua_State *l)
+{
+	lua_pushboolean(l, OS::SupportsFolderBrowser());
+	return 1;
+}
+
+static int l_browse_user_folders(lua_State *l)
+{
+	OS::OpenUserFolderBrowser();
+	return 0;
+}
+
 void LuaEngine::Register()
 {
 	lua_State *l = Lua::manager->GetLuaState();
@@ -894,6 +907,9 @@ void LuaEngine::Register()
 		{ "SetMouseYInverted", l_engine_set_mouse_y_inverted },
 		{ "GetJoystickEnabled", l_engine_get_joystick_enabled },
 		{ "SetJoystickEnabled", l_engine_set_joystick_enabled },
+		
+		{ "CanBrowseUserFolder", l_get_can_browse_user_folders },
+		{ "OpenBrowseUserFolder", l_browse_user_folders },
 
 		{ "GetModel", l_engine_get_model },
 

--- a/src/OS.h
+++ b/src/OS.h
@@ -36,6 +36,10 @@ namespace OS {
 
 	// Enable Google breakpad for crash minidumps
 	void EnableBreakpad();
+
+	// Open the Explorer/Finder/etc
+	bool SupportsFolderBrowser();
+	void OpenUserFolderBrowser();
 }
 
 #endif

--- a/src/posix/OSPosix.cpp
+++ b/src/posix/OSPosix.cpp
@@ -132,6 +132,8 @@ bool SupportsFolderBrowser()
 void OpenUserFolderBrowser()
 {
 	// Support for Mac and Linux should be added
+	// Display the path instead for now
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Pioneer", FileSystem::userFiles.GetRoot().c_str(), 0);
 }
 
 } // namespace OS

--- a/src/posix/OSPosix.cpp
+++ b/src/posix/OSPosix.cpp
@@ -123,4 +123,15 @@ void EnableBreakpad()
 	// Support for Mac and Linux should be added
 }
 
+// Open the Explorer/Finder/etc
+bool SupportsFolderBrowser()
+{
+	return false;
+}
+
+void OpenUserFolderBrowser()
+{
+	// Support for Mac and Linux should be added
+}
+
 } // namespace OS

--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <wchar.h>
 #include <windows.h>
+#include <shellapi.h>
 
 
 extern "C" {
@@ -172,7 +173,7 @@ const std::string GetOSInfoString()
 	OSVERSIONINFOA osv;
 	osv.dwOSVersionInfoSize = sizeof(OSVERSIONINFOA);
 	GetVersionExA(&osv);
-
+	
 	std::string name;
 	for (const OSVersion *scan = osVersions; scan->name; scan++) {
 		if (osv.dwMajorVersion == scan->major && osv.dwMinorVersion == scan->minor) {
@@ -238,6 +239,19 @@ void EnableBreakpad()
 		L"",														// Minidump server pipe name
 		&cci);														// Custom client information
 #endif
+}
+
+// Open the Explorer/Finder/etc
+bool SupportsFolderBrowser()
+{
+	return true;
+}
+
+void OpenUserFolderBrowser()
+{
+	std::wstring dumps_path;
+	dumps_path = transcode_utf8_to_utf16(FileSystem::userFiles.GetRoot());
+	ShellExecute(NULL, L"open", dumps_path.c_str(), NULL, NULL, SW_SHOWNORMAL);
 }
 
 } // namespace OS


### PR DESCRIPTION
After numerous situations where the user cannot find their `Pioneer` folder with `config.ini`, `output.txt` and `opengl.txt` files in it I realised that of course we already have that information.

This adds a button to the settings screen that will ask the system to open the folder directly so they do not have to search for it.

I've only implemented the Windows call necessary as that's all I have access too right now.

