### PR TITLE
Fix crash when jumping into empty system

### DIFF
--- a/data/modules/CrimeTracking/CrimeTracking.lua
+++ b/data/modules/CrimeTracking/CrimeTracking.lua
@@ -24,7 +24,8 @@ local function doLawAndOrder ()
 		Game.player.flightState == "FLYING" and
 		Engine.rand:Integer(0,1) > Game.system.lawlessness then
 			local station = Game.player:FindNearestTo("SPACESTATION")
-			if station.lawEnforcedRange >= station:DistanceTo(Game.player) then
+			-- check that station exists, since apparently empty systems can have lawlessness > 0
+			if station and station.lawEnforcedRange >= station:DistanceTo(Game.player) then
 				station:LaunchPolice(Game.player)
 				policeDispatched = station
 			end


### PR DESCRIPTION
The crash happens because apparently empty
systems can have a lawlessness > 0
Closes #3788