### PR TITLE
Update GasGiant config, detail and initialisation timing

### DIFF
--- a/data/configs/GasGiants.ini
+++ b/data/configs/GasGiants.ini
@@ -1,7 +1,17 @@
 texture_size_small=16
 #CPU settings, texture size (limited to 4096) and delay before generating textures when game starts
-texture_size_cpu=512
+texture_size_cpu_very_low=64
+texture_size_cpu_low=64
+texture_size_cpu_medium=256
+texture_size_cpu_high=512
+texture_size_cpu_very_high=1024
 cpu_delay_time=60.0
 #GPU settings, texture size (limited to 4096) and delay before generating textures when game starts
-texture_size_gpu=1024
+texture_size_gpu_very_low=128
+texture_size_gpu_low=128
+texture_size_gpu_medium=512
+texture_size_gpu_high=512
+texture_size_gpu_very_high=1024
 gpu_delay_time=5.0
+# GPU noise octaves, clamped 1 to 16, NB: 16 is a lot!
+noise_octaves=8

--- a/data/configs/GasGiants.ini
+++ b/data/configs/GasGiants.ini
@@ -1,17 +1,13 @@
+# Initial Gas Giant texture resolution, small as it's generated on CPU
 texture_size_small=16
-#CPU settings, texture size (limited to 4096) and delay before generating textures when game starts
-texture_size_cpu_very_low=64
-texture_size_cpu_low=64
-texture_size_cpu_medium=256
-texture_size_cpu_high=512
-texture_size_cpu_very_high=1024
+# CPU/GPU/Octaves, texture sizes (limited to 4096) and delay before generating textures when game starts
+texture_size_0=64,128,3
+texture_size_1=128,256,4
+texture_size_2=256,512,5
+texture_size_3=512,512,7
+texture_size_4=1024,1024,8
+# time limits before Gas Giant textures are auto pre-generated
 cpu_delay_time=60.0
-#GPU settings, texture size (limited to 4096) and delay before generating textures when game starts
-texture_size_gpu_very_low=128
-texture_size_gpu_low=128
-texture_size_gpu_medium=512
-texture_size_gpu_high=512
-texture_size_gpu_very_high=1024
 gpu_delay_time=5.0
 # GPU noise octaves, clamped 1 to 16, NB: 16 is a lot!
 noise_octaves=8

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -294,7 +294,7 @@ void GasGiant::OnChangeDetailLevel()
 }
 
 GasGiant::GasGiant(const SystemBody *body) : BaseSphere(body),
-	m_hasTempCampos(false), m_tempCampos(0.0), m_timeDelay(s_initialCPUDelayTime), m_hasGpuJobRequest(false)
+	m_hasTempCampos(false), m_tempCampos(0.0), m_hasGpuJobRequest(false), m_timeDelay(s_initialCPUDelayTime)
 {
 	s_allGasGiants.push_back(this);
 	

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -26,10 +26,10 @@ RefCountedPtr<GasPatchContext> GasGiant::s_patchContext;
 
 namespace
 {
-	static Uint32 TEXTURE_SIZE_SMALL = 16;
+	static Uint32 s_texture_size_small = 16;
 	static Uint32 s_texture_size_cpu[5];
 	static Uint32 s_texture_size_gpu[5];
-	static Uint32 s_noiseOctaves = 8;
+	static Uint32 s_noiseOctaves[5];
 	static float s_initialCPUDelayTime = 60.0f; // (perhaps) 60 seconds seems like a reasonable default
 	static float s_initialGPUDelayTime = 5.0f; // (perhaps) 5 seconds seems like a reasonable default
 	static std::vector<GasGiant*> s_allGasGiants;
@@ -40,6 +40,50 @@ namespace
 	static const std::string GGSaturn("GGSaturn");
 	static const std::string GGSaturn2("GGSaturn2");
 	static const std::string GGUranus("GGUranus");
+
+	bool SplitData(const std::string &spec, Uint32 &cpuOut, Uint32 &gpuOut, Uint32 &octavesOut)
+	{
+		static const std::string delim(",");
+
+		enum dataEntries {
+			eCPU=0,
+			eGPU,
+			eOCTAVES
+		};
+
+		size_t i = 0, start = 0, end = 0;
+		while (end != std::string::npos) {
+			// get to the first non-delim char
+			start = spec.find_first_not_of(delim, end);
+
+			// read the end, no more to do
+			if (start == std::string::npos)
+				break;
+
+			// find the end - next delim or end of string
+			end = spec.find_first_of(delim, start);
+
+			// extract the fragment and remember it
+			switch(i)
+			{
+			case eCPU:
+				cpuOut = ceil_pow2(Clamp(atoi(spec.substr(start, (end == std::string::npos) ? std::string::npos : end - start).c_str()), 64, 4096));
+				break;
+			case eGPU:
+				gpuOut = ceil_pow2(Clamp(atoi(spec.substr(start, (end == std::string::npos) ? std::string::npos : end - start).c_str()), 64, 4096));
+				break;
+			case eOCTAVES:
+				octavesOut = Clamp(atoi(spec.substr(start, (end == std::string::npos) ? std::string::npos : end - start).c_str()), 1, 16);
+				break;
+			default:
+				assert(false);
+				break;
+			}
+			i++;
+		}
+
+		return i==4;
+	}
 };
 
 
@@ -248,7 +292,7 @@ void GasGiant::OnChangeDetailLevel()
 		(*i)->m_terrain.Reset(Terrain::InstanceTerrain((*i)->GetSystemBody()));
 	}
 }
-#pragma optimize("",off)
+
 GasGiant::GasGiant(const SystemBody *body) : BaseSphere(body),
 	m_hasTempCampos(false), m_tempCampos(0.0), m_timeDelay(s_initialCPUDelayTime), m_hasGpuJobRequest(false)
 {
@@ -479,7 +523,7 @@ void GasGiant::GenerateTexture()
 	// scope the small texture generation
 	{
 		const vector2f texSize(1.0f, 1.0f);
-		const vector2f dataSize(TEXTURE_SIZE_SMALL, TEXTURE_SIZE_SMALL);
+		const vector2f dataSize(s_texture_size_small, s_texture_size_small);
 		const Graphics::TextureDescriptor texDesc(
 			Graphics::TEXTURE_RGBA_8888, 
 			dataSize, texSize, Graphics::LINEAR_CLAMP, 
@@ -487,14 +531,14 @@ void GasGiant::GenerateTexture()
 		m_surfaceTextureSmall.Reset(Pi::renderer->CreateTexture(texDesc));
 
 		const Terrain *pTerrain = GetTerrain();
-		const double fracStep = 1.0 / double(TEXTURE_SIZE_SMALL-1);
+		const double fracStep = 1.0 / double(s_texture_size_small-1);
 
 		Graphics::TextureCubeData tcd;
 		std::unique_ptr<Color> bufs[NUM_PATCHES];
 		for(int i=0; i<NUM_PATCHES; i++) {
-			Color *colors = new Color[ (TEXTURE_SIZE_SMALL*TEXTURE_SIZE_SMALL) ];
-			for( Uint32 v=0; v<TEXTURE_SIZE_SMALL; v++ ) {
-				for( Uint32 u=0; u<TEXTURE_SIZE_SMALL; u++ ) {
+			Color *colors = new Color[ (s_texture_size_small*s_texture_size_small) ];
+			for( Uint32 v=0; v<s_texture_size_small; v++ ) {
+				for( Uint32 u=0; u<s_texture_size_small; u++ ) {
 					// where in this row & colum are we now.
 					const double ustep = double(u) * fracStep;
 					const double vstep = double(v) * fracStep;
@@ -505,7 +549,7 @@ void GasGiant::GenerateTexture()
 					const vector3d colour = pTerrain->GetColor(p, 0.0, p);
 
 					// convert to ubyte and store
-					Color* col = colors + (u + (v * TEXTURE_SIZE_SMALL));
+					Color* col = colors + (u + (v * s_texture_size_small));
 					col[0].r = Uint8(colour.x * 255.0);
 					col[0].g = Uint8(colour.y * 255.0);
 					col[0].b = Uint8(colour.z * 255.0);
@@ -564,7 +608,7 @@ void GasGiant::GenerateTexture()
 		} else if( ColorFracName == GGUranus ) {
 			GasGiantType = Graphics::OGL::GEN_URANUS_TEXTURE;
 		}
-		const Uint32 octaves = (Pi::config->Int("AMD_MESA_HACKS") == 0) ? 8 : 5;
+		const Uint32 octaves = (Pi::config->Int("AMD_MESA_HACKS") == 0) ? s_noiseOctaves[Pi::detail.planets] : std::min(5U, s_noiseOctaves[Pi::detail.planets]);
 		GasGiantType = (octaves << 16) | GasGiantType;
 
 		assert(!m_hasGpuJobRequest);
@@ -750,22 +794,16 @@ void GasGiant::Init()
 	cfg.Read(FileSystem::gameDataFiles, "configs/GasGiants.ini");
 	// NB: limit the ranges of all values loaded from the file
 	// NB: round to the nearest power of 2 for all texture sizes
-	TEXTURE_SIZE_SMALL		= ceil_pow2(Clamp(cfg.Int("texture_size_small", 16), 16, 64));
-	s_texture_size_cpu[0]	= ceil_pow2(Clamp(cfg.Int("texture_size_cpu_very_low", 64), 64, 4096));
-	s_texture_size_cpu[1]	= ceil_pow2(Clamp(cfg.Int("texture_size_cpu_low", 64), 64, 4096));
-	s_texture_size_cpu[2]	= ceil_pow2(Clamp(cfg.Int("texture_size_cpu_medium", 128), 64, 4096));
-	s_texture_size_cpu[3]	= ceil_pow2(Clamp(cfg.Int("texture_size_cpu_high", 256), 64, 4096));
-	s_texture_size_cpu[4]	= ceil_pow2(Clamp(cfg.Int("texture_size_cpu_very_high", 512), 64, 4096));
+	s_texture_size_small = ceil_pow2(Clamp(cfg.Int("texture_size_small", 16), 16, 64));
+	
+	SplitData(cfg.String("texture_size_0"), s_texture_size_cpu[0], s_texture_size_gpu[0], s_noiseOctaves[0]);
+	SplitData(cfg.String("texture_size_1"), s_texture_size_cpu[1], s_texture_size_gpu[1], s_noiseOctaves[1]);
+	SplitData(cfg.String("texture_size_2"), s_texture_size_cpu[2], s_texture_size_gpu[2], s_noiseOctaves[2]);
+	SplitData(cfg.String("texture_size_3"), s_texture_size_cpu[3], s_texture_size_gpu[3], s_noiseOctaves[3]);
+	SplitData(cfg.String("texture_size_4"), s_texture_size_cpu[4], s_texture_size_gpu[4], s_noiseOctaves[4]);
+
 	s_initialCPUDelayTime	= Clamp(cfg.Float("cpu_delay_time", 60.0f), 0.0f, 120.0f);
-	//
-	s_texture_size_gpu[0]	= ceil_pow2(Clamp(cfg.Int("texture_size_gpu_very_low", 128), 128, 4096));
-	s_texture_size_gpu[1]	= ceil_pow2(Clamp(cfg.Int("texture_size_gpu_low", 128), 128, 4096));
-	s_texture_size_gpu[2]	= ceil_pow2(Clamp(cfg.Int("texture_size_gpu_medium", 512), 128, 4096));
-	s_texture_size_gpu[3]	= ceil_pow2(Clamp(cfg.Int("texture_size_gpu_high", 512), 128, 4096));
-	s_texture_size_gpu[4]	= ceil_pow2(Clamp(cfg.Int("texture_size_gpu_very_high", 1024), 128, 4096));
 	s_initialGPUDelayTime	= Clamp(cfg.Float("gpu_delay_time", 5.0f), 0.0f, 120.0f);
-	// NB: 16 is a lot
-	s_noiseOctaves	= Clamp(cfg.Int("noise_octaves", 5), 1, 16);
 
 	if( s_patchContext.Get() == nullptr ) {
 		s_patchContext.Reset(new GasPatchContext(127));

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -247,7 +247,7 @@ void GasGiant::OnChangeDetailLevel()
 		(*i)->m_terrain.Reset(Terrain::InstanceTerrain((*i)->GetSystemBody()));
 	}
 }
-
+#pragma optimize("",off)
 GasGiant::GasGiant(const SystemBody *body) : BaseSphere(body),
 	m_hasTempCampos(false), m_tempCampos(0.0), m_timeDelay(s_initialCPUDelayTime), m_hasGpuJobRequest(false)
 {
@@ -257,9 +257,11 @@ GasGiant::GasGiant(const SystemBody *body) : BaseSphere(body),
 		m_hasJobRequest[i] = false;
 	}
 
+	Random rng(GetSystemBody()->GetSeed()+4609837);
+
 	const bool bEnableGPUJobs = (Pi::config->Int("EnableGPUJobs") == 1);
 	if(bEnableGPUJobs)
-		m_timeDelay = s_initialGPUDelayTime;
+		m_timeDelay = s_initialGPUDelayTime + (rng.Double() * (s_initialGPUDelayTime * 0.5));
 
 	//SetUpMaterials is not called until first Render since light count is zero :)
 

--- a/src/GasGiantJobs.cpp
+++ b/src/GasGiantJobs.cpp
@@ -104,8 +104,7 @@ namespace GasGiantJobs
 
 		Graphics::MaterialDescriptor desc;
 		desc.effect = Graphics::EFFECT_GEN_GASGIANT_TEXTURE;
-		const Uint32 octaves = (Pi::config->Int("AMD_MESA_HACKS") == 0) ? 8 : 5;
-		desc.quality = (octaves << 16) | GGQuality;
+		desc.quality = GGQuality;
 		desc.textures = 3;
 		m_material.reset(r->CreateMaterial(desc));
 
@@ -114,7 +113,7 @@ namespace GasGiantJobs
 		m_material->texture1 = Graphics::TextureBuilder::Raw("textures/gradTexture.png").GetOrCreateTexture(Pi::renderer, "noise");
 
 		// pick the correct colour basis texture for the planet
-		switch (GGQuality) {
+		switch (0x0000FFFF & GGQuality) {
 		case Graphics::OGL::GEN_JUPITER_TEXTURE:
 			m_material->texture2 = Graphics::TextureBuilder::Billboard("textures/gasgiants/jupiterramp.png").GetOrCreateTexture(Pi::renderer, "gasgiant");
 			break;

--- a/src/GasGiantJobs.cpp
+++ b/src/GasGiantJobs.cpp
@@ -178,7 +178,7 @@ namespace GasGiantJobs
 		m_specialParams.time = 0.0f;
 			
 		for(Uint32 i=0; i<3; i++) {
-			m_specialParams.frequency[i] = (float)pTerrain->GetFracDef(i).frequency;
+			m_specialParams.frequency[i] = float(pTerrain->GetFracDef(i).frequency);
 		}
 
 		m_specialParams.hueAdjust = hueAdjust;

--- a/src/GasGiantJobs.h
+++ b/src/GasGiantJobs.h
@@ -61,7 +61,7 @@ namespace GasGiantJobs
 
 	protected:
 		// deliberately prevent copy constructor access
-		STextureFaceRequest(const STextureFaceRequest &r);
+		STextureFaceRequest(const STextureFaceRequest &r) = delete;
 
 		inline Sint32 NumTexels() const { return uvDIMs*uvDIMs; }
 
@@ -106,7 +106,7 @@ namespace GasGiantJobs
 
 	protected:
 		// deliberately prevent copy constructor access
-		STextureFaceResult(const STextureFaceResult &r);
+		STextureFaceResult(const STextureFaceResult &r) = delete;
 
 		const int32_t mFace;
 		STextureFaceData mData;
@@ -127,7 +127,7 @@ namespace GasGiantJobs
 
 	private:
 		// deliberately prevent copy constructor access
-		SingleTextureFaceJob(const SingleTextureFaceJob &r);
+		SingleTextureFaceJob(const SingleTextureFaceJob &r) = delete;
 
 		std::unique_ptr<STextureFaceRequest> mData;
 		STextureFaceResult *mpResults;
@@ -161,7 +161,7 @@ namespace GasGiantJobs
 
 	protected:
 		// deliberately prevent copy constructor access
-		SGPUGenRequest(const SGPUGenRequest &r);
+		SGPUGenRequest(const SGPUGenRequest &r) = delete;
 
 		inline Sint32 NumTexels() const { return uvDIMs*uvDIMs; }
 
@@ -198,7 +198,7 @@ namespace GasGiantJobs
 
 	protected:
 		// deliberately prevent copy constructor access
-		SGPUGenResult(const SGPUGenResult &r);
+		SGPUGenResult(const SGPUGenResult &r) = delete;
 
 		SGPUGenData mData;
 	};
@@ -219,7 +219,7 @@ namespace GasGiantJobs
 	private:
 		SingleGPUGenJob() {}
 		// deliberately prevent copy constructor access
-		SingleGPUGenJob(const SingleGPUGenJob &r);
+		SingleGPUGenJob(const SingleGPUGenJob &r) = delete;
 
 		std::unique_ptr<SGPUGenRequest> mData;
 		SGPUGenResult *mpResults;


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
This varies when the Gas Giant GPU jobs are submitted to prevent them all being requested at once.
The intention is to avoid a large chug happening as all of the 6 cubemap faces are generated for every single Gas Giant in a star system.

I've also taken the opportunity to add different sized texture generation depending on the requested planet detail level, and to control the number of octaves from the config file.

The size of textures used on CPU and GPU can be controlled independently per-detail level (**5**) as can the number of octaves of noise used in the GPU generation.

This should generally improve the performance, but degrade the appearance, on lower detail settings.