### PR TITLE
More realistic star colouring ini file

### DIFF
--- a/data/configs/Starfield.ini
+++ b/data/configs/Starfield.ini
@@ -1,6 +1,6 @@
-rMin=0.2
+rMin=0.7
 rMax=0.9
-gMin=0.2
-gMax=0.7
-bMin=0.2
+gMin=0.7
+gMax=0.9
+bMin=0.7
 bMax=0.9


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
In #3774 I restored and extended the ability to colour the random stars in the background.
However I also set those values to rather psychedelic effect.

This PR restores the range of colours to a narrower range of white. Instead of 0.2|0.9, it's now 0.7|0.9 which produces stars that are always whiter.

This does not affect the ability of mods/forks to override their own star colours so @walterar can have Scout+ however he likes etc :)