### PR TITLE
Fix nav and combat target removal cleaning

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -160,7 +160,7 @@ void Player::NotifyRemoved(const Body* const removedBody)
 	if (GetNavTarget() == removedBody)
 		SetNavTarget(0);
 
-	else if (GetCombatTarget() == removedBody) {
+	if (GetCombatTarget() == removedBody) {
 		SetCombatTarget(0);
 
 		if (!GetNavTarget() && removedBody->IsType(Object::SHIP))


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->


There is nothing preventing the navigation target to be the same as the combat target. Whether that is a good thing or not is not the goal of this patch, which is just to take this possibility into account when the target body is indeed removed.

My apologies for comitting on the master repo, but I don't have my SSH key on this computer and GH didn't let me do that on my (outdated) repo.