### PR TITLE
Search&Rescue: bugfix for #3797

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1864,7 +1864,7 @@ end
 local onShipDocked = function (ship, station)
 	if ship:IsPlayer() then
 		for _,mission in pairs(missions) do
-			if Space.GetBody(mission.station_local.bodyIndex) == station then
+			if Game.time > mission.due or mission.station_local:IsSameSystem(Game.system.path) and Space.GetBody(mission.station_local.bodyIndex) == station then
 				closeMission(mission)
 			end
 		end


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Bug fix for #3797.

There were actually two things wrong right there (one pointed out by @walterar):

1) Missions were never closed if they were ever overdue until the player landed at the station where the original mission was accepted. Kind of a style choice to now terminate them wherever the player lands. But might be nicer to not clutter the mission screen with failed missions? What if the player never intends to return to the original station? Can't make them suffer forever... :)

2) If the player landed at a station in a different system while a SAR mission was active in the background the game could crash.
