### PR TITLE
Search&Rescue module: stop searching for destroyed ships

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1682,9 +1682,8 @@ function searchForTarget (mission)
 
 	Timer:CallEvery(1, function ()
 
-		                -- abort if player is about to leave system, player leaves target frame
-		                -- or target ship is destroyed
-		                if leaving_system == true or Game.player.frameBody ~= mission.target.frameBody or not mission.target then
+		                -- abort if player is about to leave system, target ship is destroyed, or player leaves target frame
+		                if leaving_system or not mission.target or Game.player.frameBody ~= mission.target.frameBody then
 			                mission.searching = false
 			                return true
 

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1682,13 +1682,9 @@ function searchForTarget (mission)
 
 	Timer:CallEvery(1, function ()
 
-		                -- abort if player is about to leave system
-		                if leaving_system == true then
-			                mission.searching = false
-			                return true
-
-			                -- abort if player leaves the target frame
-		                elseif Game.player.frameBody ~= mission.target.frameBody then
+		                -- abort if player is about to leave system, player leaves target frame
+		                -- or target ship is destroyed
+		                if leaving_system == true or Game.player.frameBody ~= mission.target.frameBody or not mission.target then
 			                mission.searching = false
 			                return true
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This addresses #3801 partly. The segfault still happens and is still under investigation, but the added check for target ship presence, as @walterar correctly suggested, is necessary here. Otherwise the player ship would continuously search for a possibly already destroyed ship.
