### PR TITLE
Made NavLights responsible for their billboard rendering

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -519,6 +519,7 @@ void ModelViewer::DrawModel(const matrix4x4f &mv)
 	);
 
 	m_model->Render(mv);
+	m_navLights->Render(m_renderer);
 }
 
 void ModelViewer::MainLoop()

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -10,6 +10,9 @@
 
 const float BILLBOARD_SIZE = 2.5f;
 
+static RefCountedPtr<Graphics::Texture> texHalos4x4;
+static RefCountedPtr<Graphics::Material> matHalos4x4;
+
 static bool g_initted = false;
 static vector2f m_lightColorsUVoffsets[(NavLights::NAVLIGHT_YELLOW+1)] = {
 	vector2f(0.0f,0.0f),
@@ -71,6 +74,8 @@ NavLights::NavLights(SceneGraph::Model *model, float period)
 : m_time(0.f)
 , m_period(period)
 , m_enabled(false)
+, m_billboardTris(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL)
+, m_billboardRS(nullptr)
 {
 	PROFILE_SCOPED();
 	assert(g_initted);
@@ -90,7 +95,7 @@ NavLights::NavLights(SceneGraph::Model *model, float period)
 	for (unsigned int i=0; i < results.size(); i++) {
 		MatrixTransform *mt = dynamic_cast<MatrixTransform*>(results.at(i));
 		assert(mt);
-		Billboard *bblight = new Billboard(model, renderer, BILLBOARD_SIZE);
+		Billboard *bblight = new Billboard(m_billboardTris, renderer, BILLBOARD_SIZE);
 		Uint32 group = 0;
 		Uint8 mask  = 0xff; //always on
 		Uint8 color = NAVLIGHT_BLUE;
@@ -173,6 +178,51 @@ void NavLights::Update(float time)
 			else
 				it->billboard->SetNodeMask(0x0);
 		}
+	}
+}
+
+void NavLights::Render(Graphics::Renderer *renderer)
+{
+	if(!m_billboardRS) {
+		Graphics::MaterialDescriptor desc;
+		desc.effect = Graphics::EFFECT_BILLBOARD_ATLAS;
+		desc.textures = 1;
+		matHalos4x4.Reset(renderer->CreateMaterial(desc));
+		texHalos4x4.Reset(Graphics::TextureBuilder::Billboard("textures/halo_4x4.dds").GetOrCreateTexture(renderer, std::string("billboard")));
+		matHalos4x4->texture0 = texHalos4x4.Get();
+	
+		Graphics::RenderStateDesc rsd;
+		rsd.blendMode = Graphics::BLEND_ADDITIVE;
+		rsd.depthWrite = false;
+		m_billboardRS = renderer->CreateRenderState(rsd);
+	}
+
+	const bool bVBValid = m_billboardVB.Valid();
+	const bool bHasVerts = !m_billboardTris.IsEmpty();
+	const bool bVertCountEqual = bVBValid && (m_billboardVB->GetVertexCount() == m_billboardTris.GetNumVerts());
+	if( bHasVerts && (!bVBValid || !bVertCountEqual) )
+	{
+		//create buffer
+		// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
+		Graphics::VertexBufferDesc vbd;
+		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
+		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.attrib[1].semantic = Graphics::ATTRIB_NORMAL;
+		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
+		vbd.numVertices = m_billboardTris.GetNumVerts();
+		vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;	// we could be updating this per-frame
+		m_billboardVB.Reset( renderer->CreateVertexBuffer(vbd) );
+	}
+	
+	if(m_billboardVB.Valid())
+	{
+		if(bHasVerts) {
+			m_billboardVB->Populate(m_billboardTris);
+			renderer->SetTransform(matrix4x4f::Identity());
+			renderer->DrawBuffer(m_billboardVB.Get(), m_billboardRS, matHalos4x4.Get(), Graphics::POINTS);
+			renderer->GetStats().AddToStatCount(Graphics::Stats::STAT_BILLBOARD, 1);
+		}
+		m_billboardTris.Clear();
 	}
 }
 

--- a/src/NavLights.h
+++ b/src/NavLights.h
@@ -9,6 +9,9 @@
 #include "libs.h"
 #include "Serializer.h"
 #include "json/json.h"
+#include "graphics/RenderState.h"
+#include "graphics/VertexArray.h"
+#include "graphics/VertexBuffer.h"
 
 namespace Graphics { class Renderer; }
 namespace SceneGraph { class Model; class Billboard; }
@@ -39,6 +42,7 @@ public:
 
 	void SetEnabled(bool on) { m_enabled = on; }
 	void Update(float time);
+	void Render(Graphics::Renderer *renderer);
 	void SetColor(unsigned int group, LightColor);
 
 	static void Init(Graphics::Renderer*);
@@ -72,6 +76,10 @@ protected:
 	float m_time;
 	float m_period;
 	bool m_enabled;
+	
+	Graphics::VertexArray m_billboardTris;
+	RefCountedPtr<Graphics::VertexBuffer> m_billboardVB;
+	Graphics::RenderState *m_billboardRS;
 };
 
 #endif

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1323,7 +1323,7 @@ void Ship::Render(Graphics::Renderer *renderer, const Camera *camera, const vect
 
 	//strncpy(params.pText[0], GetLabel().c_str(), sizeof(params.pText));
 	RenderModel(renderer, camera, viewCoords, viewTransform);
-
+	m_navLights->Render(renderer);
 	renderer->GetStats().AddToStatCount(Graphics::Stats::STAT_SHIPS, 1);
 
 	if (m_ecmRecharge > 0.0f) {

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -620,6 +620,7 @@ void SpaceStation::Render(Graphics::Renderer *r, const Camera *camera, const vec
 		m_adjacentCity->Render(r, camera->GetContext()->GetFrustum(), this, viewCoords, viewTransform);
 
 		RenderModel(r, camera, viewCoords, viewTransform, false);
+		m_navLights->Render(r);
 
 		ResetLighting(r, oldLights, oldAmbient);
 

--- a/src/scenegraph/Billboard.cpp
+++ b/src/scenegraph/Billboard.cpp
@@ -14,16 +14,16 @@
 
 namespace SceneGraph {
 
-Billboard::Billboard(SceneGraph::Model *model, Graphics::Renderer *r, float size)
+Billboard::Billboard(Graphics::VertexArray& bbVA, Graphics::Renderer *r, float size)
 : Node(r, NODE_TRANSPARENT)
-, m_model(model)
+, m_bbVA(bbVA)
 , m_size(size)
 {
 }
 
 Billboard::Billboard(const Billboard &billboard, NodeCopyCache *cache)
 : Node(billboard, cache)
-, m_model(billboard.m_model)
+, m_bbVA(billboard.m_bbVA)
 , m_size(billboard.m_size)
 {
 }
@@ -42,11 +42,10 @@ void Billboard::Render(const matrix4x4f &trans, const RenderData *rd)
 {
 	PROFILE_SCOPED()
 
-	Graphics::VertexArray& bbVA = m_model->GetBillboardVA();
 	//some hand-tweaked scaling, to make the lights seem larger from distance (final size is in pixels)
 	const float pixrad = Clamp(Graphics::GetScreenHeight() / trans.GetTranslate().Length(), 1.0f, 15.0f);
 	const float size = (m_size * Graphics::GetFovFactor()) * pixrad;
-	bbVA.Add(trans * vector3f(0.0f), vector3f(m_colorUVoffset, size));
+	m_bbVA.Add(trans * vector3f(0.0f), vector3f(m_colorUVoffset, size));
 }
 
 }

--- a/src/scenegraph/Billboard.h
+++ b/src/scenegraph/Billboard.h
@@ -18,7 +18,7 @@ namespace SceneGraph {
 
 class Billboard : public Node {
 public:
-	Billboard(SceneGraph::Model *model, Graphics::Renderer *r, float size);
+	Billboard(Graphics::VertexArray& bbVA, Graphics::Renderer *r, float size);
 	Billboard(const Billboard&, NodeCopyCache *cache = 0);
 	virtual Node *Clone(NodeCopyCache *cache = 0);
 	virtual void Accept(NodeVisitor &v);
@@ -27,7 +27,7 @@ public:
 	void SetColorUVoffset(const vector2f& c) { m_colorUVoffset = c; }
 
 private:
-	SceneGraph::Model *m_model;
+	Graphics::VertexArray& m_bbVA;
 	float m_size;
 	vector2f m_colorUVoffset;
 };

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -12,9 +12,6 @@
 
 namespace SceneGraph {
 
-static RefCountedPtr<Graphics::Texture> texHalos4x4;
-static RefCountedPtr<Graphics::Material> matHalos4x4;
-
 class LabelUpdateVisitor : public NodeVisitor {
 public:
 	virtual void ApplyLabel(Label3D &l) {
@@ -31,8 +28,6 @@ Model::Model(Graphics::Renderer *r, const std::string &name)
 , m_curPatternIndex(0)
 , m_curPattern(0)
 , m_debugFlags(0)
-, m_billboardTris(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL)
-, m_billboardRS(nullptr)
 {
 	m_root.Reset(new Group(m_renderer));
 	m_root->SetName(name);
@@ -49,8 +44,6 @@ Model::Model(const Model &model)
 , m_curPatternIndex(model.m_curPatternIndex)
 , m_curPattern(model.m_curPattern)
 , m_debugFlags(0)
-, m_billboardTris(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL)
-, m_billboardRS(nullptr)
 {
 	//selective copying of node structure
 	NodeCopyCache cache;
@@ -136,8 +129,6 @@ void Model::Render(const matrix4x4f &trans, const RenderData *rd)
 		m_root->Render(trans, &params);
 		params.nodemask = NODE_TRANSPARENT;
 		m_root->Render(trans, &params);
-
-		DrawBillboards();
 	}
 
 	if (!m_debugFlags)
@@ -204,51 +195,6 @@ void Model::Render(const std::vector<matrix4x4f> &trans, const RenderData *rd)
 		m_root->Render(trans, &params);
 		params.nodemask = NODE_TRANSPARENT;
 		m_root->Render(trans, &params);
-	}
-}
-
-void Model::DrawBillboards()
-{
-	if(!m_billboardRS) {
-		Graphics::MaterialDescriptor desc;
-		desc.effect = Graphics::EFFECT_BILLBOARD_ATLAS;
-		desc.textures = 1;
-		matHalos4x4.Reset(m_renderer->CreateMaterial(desc));
-		texHalos4x4.Reset(Graphics::TextureBuilder::Billboard("textures/halo_4x4.dds").GetOrCreateTexture(m_renderer, std::string("billboard")));
-		matHalos4x4->texture0 = texHalos4x4.Get();
-	
-		Graphics::RenderStateDesc rsd;
-		rsd.blendMode = Graphics::BLEND_ADDITIVE;
-		rsd.depthWrite = false;
-		m_billboardRS = m_renderer->CreateRenderState(rsd);
-	}
-
-	const bool bVBValid = m_billboardVB.Valid();
-	const bool bHasVerts = !m_billboardTris.IsEmpty();
-	const bool bVertCountEqual = bVBValid && (m_billboardVB->GetVertexCount() == m_billboardTris.GetNumVerts());
-	if( bHasVerts && (!bVBValid || !bVertCountEqual) )
-	{
-		//create buffer
-		// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
-		Graphics::VertexBufferDesc vbd;
-		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
-		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
-		vbd.attrib[1].semantic = Graphics::ATTRIB_NORMAL;
-		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
-		vbd.numVertices = m_billboardTris.GetNumVerts();
-		vbd.usage = Graphics::BUFFER_USAGE_DYNAMIC;	// we could be updating this per-frame
-		m_billboardVB.Reset( m_renderer->CreateVertexBuffer(vbd) );
-	}
-	
-	if(m_billboardVB.Valid())
-	{
-		if(bHasVerts) {
-			m_billboardVB->Populate(m_billboardTris);
-			m_renderer->SetTransform(matrix4x4f::Identity());
-			m_renderer->DrawBuffer(m_billboardVB.Get(), m_billboardRS, matHalos4x4.Get(), Graphics::POINTS);
-			m_renderer->GetStats().AddToStatCount(Graphics::Stats::STAT_BILLBOARD, 1);
-		}
-		m_billboardTris.Clear();
 	}
 }
 

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -156,8 +156,6 @@ public:
 	void SaveToJson(Json::Value &jsonObj) const;
 	void LoadFromJson(const Json::Value &jsonObj);
 
-	Graphics::VertexArray& GetBillboardVA() { return m_billboardTris; }
-
 	//serialization aid
 	std::string GetNameForMaterial(Graphics::Material*) const;
 
@@ -173,7 +171,6 @@ public:
 
 private:
 	Model(const Model&);
-	void DrawBillboards();
 
 	static const unsigned int MAX_DECAL_MATERIALS = 4;
 	ColorMap m_colorMap;
@@ -208,9 +205,6 @@ private:
 	RefCountedPtr<Graphics::VertexBuffer> m_aabbVB;
 	RefCountedPtr<Graphics::Material> m_aabbMat;
 	Graphics::RenderState* m_state;
-	Graphics::VertexArray m_billboardTris;
-	RefCountedPtr<Graphics::VertexBuffer> m_billboardVB;
-	Graphics::RenderState *m_billboardRS;
 };
 
 }


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
I've made some odd late-night programming decisions in the past but I don't know what made me put the responsibility for rendering NavLight billboards into the Scenegraph::Model class.

This fixes that questionable decision and moves the responsibility for rendering NavLight billboards from scenegraph/Model into NavLights itself.
<!-- Please make sure you've read documentation on contributing -->

