### PR TITLE
 Adding an editorconfig file to define coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# all files, globally use these rules:
+[*]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This is used by github when displaying code in browser

E.g. this fixes a very long standing issue when glancing through code on
github, be that for review or online source files: they insist on 8 char tabs,
while we use 4 char tabs.

This can also be used by any self-respecting editor (read: Emacs), but also by
lesser ones (read: vim), and the rest (atom, geany, netbeans, eclipse, xcode,
sublime, textmate, visual studio, etc.)

See http://editorconfig.org/ for full list, and more.

I bet @laarmen will be happy now!

Learned it from:
https://github.com/isaacs/github/issues/170#issuecomment-150489692

Also, the tab issue can be fixed/worked around through a chrome extension. For those using chrome, that is:
https://github.com/sindresorhus/tab-size-on-github