### PR TITLE
Set ship texture patterns from lua

### DIFF
--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -304,6 +304,10 @@ static int l_ship_set_pattern(lua_State *l)
 {
 	Ship *s = LuaObject<Ship>::CheckFromLua(1);
 	unsigned int num = lua_tointeger(l, 2);
+
+	if (num > s->GetModel()->GetNumPatterns()-1)
+		return luaL_error(l, "This pattern does not exist for this ship");
+
 	s->SetPattern(num);
 	return 0;
 }

--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -227,6 +227,25 @@ static int l_ship_explode(lua_State *l)
 	return 0;
 }
 
+/*
+ * Method: GetSkin
+ *
+ * Get the current skin object of the ship.
+ *
+ * > ship:GetSkin()
+ *
+ * Parameters:
+ *
+ *
+ *
+ * Example:
+ *
+ * > ship:GetSkin()
+ *
+ * Status:
+ *
+ *  experimental
+ */
 static int l_ship_get_skin(lua_State *l)
 {
 	Ship *s = LuaObject<Ship>::CheckFromLua(1);
@@ -234,11 +253,58 @@ static int l_ship_get_skin(lua_State *l)
 	return 1;
 }
 
+/*
+ * Method: SetSkin
+ *
+ * Set the skin of the ship.
+ *
+ * > ship:SetSkin(skin)
+ *
+ * Parameters:
+ *
+ *   skin - the skin object of the ship
+ *   this can be created using SceneGraph.ModelSkin.New()
+ *
+ * Example:
+ *
+ * > ship:GetSkin(skin)
+ *
+ * Status:
+ *
+ *  experimental
+ */
 static int l_ship_set_skin(lua_State *l)
 {
 	Ship *s = LuaObject<Ship>::CheckFromLua(1);
 	const SceneGraph::ModelSkin *skin = LuaObject<SceneGraph::ModelSkin>::CheckFromLua(2);
 	s->SetSkin(*skin);
+	return 0;
+}
+
+/*
+ * Method: SetPattern
+ *
+ * Changes the pattern used for texturing the ship.
+ *
+ * > ship:SetPattern(num)
+ *
+ * Parameters:
+ *
+ *   num - the pattern number
+ *
+ * Example:
+ *
+ * > ship:SetPattern(5)
+ *
+ * Status:
+ *
+ *  experimental
+ */
+static int l_ship_set_pattern(lua_State *l)
+{
+	Ship *s = LuaObject<Ship>::CheckFromLua(1);
+	unsigned int num = lua_tointeger(l, 2);
+	s->SetPattern(num);
 	return 0;
 }
 
@@ -277,7 +343,7 @@ static int l_ship_set_label(lua_State *l)
 /*
  * Method: SetShipName
  *
- * Changes the ship's name text. 
+ * Changes the ship's name text.
  * This is the name text that appears beside the ship in the HUD.
  *
  * > ship:SetShipName(newShipName)
@@ -1006,6 +1072,7 @@ template <> void LuaObject<Ship>::RegisterClass()
 
 		{ "GetSkin",    l_ship_get_skin    },
 		{ "SetSkin",    l_ship_set_skin    },
+		{ "SetPattern", l_ship_set_pattern },
 		{ "SetLabel",   l_ship_set_label   },
 		{ "SetShipName",	l_ship_set_ship_name   },
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1458,6 +1458,11 @@ void Ship::SetSkin(const SceneGraph::ModelSkin &skin)
 	m_skin.Apply(GetModel());
 }
 
+void Ship::SetPattern(const unsigned int num)
+{
+	GetModel()->SetPattern(num);
+}
+
 Uint8 Ship::GetRelations(Body *other) const
 {
 	auto it = m_relationsMap.find(other);

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -218,6 +218,8 @@ public:
 	const SceneGraph::ModelSkin &GetSkin() const { return m_skin; }
 	void SetSkin(const SceneGraph::ModelSkin &skin);
 
+	void SetPattern(unsigned int num);
+
 	void SetLabel(const std::string &label);
 	void SetShipName(const std::string &shipName);
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This allows ship texture patterns to be set from lua. Together with the already present "SetSkin" method you can now recreate a specific look for a ship. This is important for persistence in scripts. For example, in Search and Rescue missions, if you leave a system and come back, the target ship will have a different look because the skin and pattern are created randomly when creating a ship. You can now specify them.

C++ experts like @laarmen, @impaktor and @fluffyfreak should take a close look at the additions I made here. I am a total C++ noob and may have easily made mistakes.

While I was at it I also annotated the SetSkin and GetSkin methods. I only stumbled upon them while digging through code looking for other things.

