### PR TITLE
add annotations to ShipDef

### DIFF
--- a/src/LuaShipDef.cpp
+++ b/src/LuaShipDef.cpp
@@ -190,6 +190,36 @@
  *   experimental
  */
 
+/*
+ * Attribute: shipClass
+ *
+ * Class of the ship (i.e. "medium_courier").
+ *
+ * Status:
+ *
+ *   experimental
+ */
+
+/*
+ * Attribute: manufacturer
+ *
+ * Manufacturer of the ship (i.e. "kaluri").
+ *
+ * Status:
+ *
+ *   experimental
+ */
+
+/*
+ * Attribute: modelName
+ *
+ * Name for the model of this ship. Important for looking up the actual ship model (Engine.GetModel(ShipDef.modelName)).
+ *
+ * Status:
+ *
+ *   experimental
+ */
+
 void LuaShipDef::Register()
 {
 	lua_State *l = Lua::manager->GetLuaState();


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Added annotation for three more attributes in ShipDef. It took me a while to find out these attributes are actually readily accessible through ShipDef. I decided to add the annotation so other "scripters" won't need to search in the code.
