### PR TITLE
Additional mesh optimisation

### DIFF
--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -333,13 +333,18 @@ RefCountedPtr<Node> Loader::LoadMesh(const std::string &filename, const AnimList
 	//There are several optimizations assimp can do, intentionally skipping them now
 	const aiScene *scene = importer.ReadFile(
 		filename,
-		aiProcess_RemoveComponent	|
-		aiProcess_Triangulate		|
-		aiProcess_SortByPType		| //ignore point, line primitive types (collada dummy nodes seem to be fine)
-		aiProcess_GenUVCoords		|
-		aiProcess_FlipUVs			|
-		aiProcess_CalcTangentSpace	|
-		aiProcess_GenSmoothNormals);  //only if normals not specified
+		aiProcess_RemoveComponent			|
+		aiProcess_Triangulate				|
+		aiProcess_SortByPType				| //ignore point, line primitive types (collada dummy nodes seem to be fine)
+		aiProcess_GenUVCoords				|
+		aiProcess_FlipUVs					|
+		aiProcess_CalcTangentSpace  		|
+		aiProcess_JoinIdenticalVertices		|
+		aiProcess_GenSmoothNormals			| //only if normals not specified
+		aiProcess_ImproveCacheLocality      |
+		aiProcess_LimitBoneWeights          |
+		aiProcess_FindDegenerates           |
+		aiProcess_FindInvalidData);
 
 	if(!scene)
 		throw LoadingError("Couldn't load file");

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -338,12 +338,12 @@ RefCountedPtr<Node> Loader::LoadMesh(const std::string &filename, const AnimList
 		aiProcess_SortByPType				| //ignore point, line primitive types (collada dummy nodes seem to be fine)
 		aiProcess_GenUVCoords				|
 		aiProcess_FlipUVs					|
-		aiProcess_CalcTangentSpace  		|
+		aiProcess_CalcTangentSpace			|
 		aiProcess_JoinIdenticalVertices		|
 		aiProcess_GenSmoothNormals			| //only if normals not specified
-		aiProcess_ImproveCacheLocality      |
-		aiProcess_LimitBoneWeights          |
-		aiProcess_FindDegenerates           |
+		aiProcess_ImproveCacheLocality		|
+		aiProcess_LimitBoneWeights			|
+		aiProcess_FindDegenerates			|
 		aiProcess_FindInvalidData);
 
 	if(!scene)


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Some additional optimisations applied upon loading using Assimp.

![smallerer](https://cloud.githubusercontent.com/assets/825083/18686783/250856fe-7f75-11e6-8e41-afa0393f507e.png)

It makes the total size of `.sgm` files about 21MiB smaller.
It should reduce the sheer number of vertices along with potential other changes.
I have tested it with stations & taken a look at a number of ships but I think that @nozmajner might want to take a long look at the models and make sure that nothing obvious has been mangled.
<!-- Please make sure you've read documentation on contributing -->

