### PR TITLE
Brighter luminosity for random colours

### DIFF
--- a/src/scenegraph/ModelSkin.cpp
+++ b/src/scenegraph/ModelSkin.cpp
@@ -55,7 +55,7 @@ void ModelSkin::SetRandomColors(Random &rand)
 {
 	using namespace RandomColorGenerator;
 	static RandomColor s_randomColor;
-	m_colors = RandomColor::GetColors(rand, SCHEME_RANDOM, LUMINOSITY_RANDOM, 3);
+	m_colors = RandomColor::GetColors(rand, SCHEME_RANDOM, LUMINOSITY_BRIGHT, 3);
 }
 
 void ModelSkin::SetDecal(const std::string &name, unsigned int index)


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
A frequent comment since the random colour generation was changed is that the colours seem darker and less appealing.

The third parameter of `RandomColor::GetColors` controls the luminance and so I have set this to `LUMINOSITY_BRIGHT` instead of `LUMINOSITY_RANDOM`.

Black can still appear as a "colour" and is obviously not enhanced by this.