### PR TITLE
Use a function to access the s_patchFaces to silence a gcc warning

### DIFF
--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -544,7 +544,7 @@ void GasGiant::GenerateTexture()
 					const double vstep = double(v) * fracStep;
 
 					// get point on the surface of the sphere
-					const vector3d p = GetSpherePointFromCorners(ustep, vstep, &s_patchFaces[i][0]);
+					const vector3d p = GetSpherePointFromCorners(ustep, vstep, &GetPatchFaces(i,0));
 					// get colour using `p`
 					const vector3d colour = pTerrain->GetColor(p, 0.0, p);
 
@@ -577,7 +577,7 @@ void GasGiant::GenerateTexture()
 			assert(!m_hasJobRequest[i]);
 			assert(!m_job[i].HasJob());
 			m_hasJobRequest[i] = true;
-			GasGiantJobs::STextureFaceRequest *ssrd = new GasGiantJobs::STextureFaceRequest(&s_patchFaces[i][0], GetSystemBody()->GetPath(), i, s_texture_size_cpu[Pi::detail.planets], GetTerrain());
+			GasGiantJobs::STextureFaceRequest *ssrd = new GasGiantJobs::STextureFaceRequest(&GetPatchFaces(i,0), GetSystemBody()->GetPath(), i, s_texture_size_cpu[Pi::detail.planets], GetTerrain());
 			m_job[i] = Pi::GetAsyncJobQueue()->Queue(new GasGiantJobs::SingleTextureFaceJob(ssrd));
 		}
 	}

--- a/src/GasGiantJobs.cpp
+++ b/src/GasGiantJobs.cpp
@@ -23,6 +23,18 @@
 
 namespace GasGiantJobs
 {
+	static const vector3d s_patchFaces[NUM_PATCHES][4] =
+	{
+		{ p5, p1, p4, p8 }, // +x
+		{ p2, p6, p7, p3 }, // -x
+
+		{ p2, p1, p5, p6 }, // +y
+		{ p7, p8, p4, p3 }, // -y
+
+		{ p6, p5, p8, p7 }, // +z - NB: these are actually reversed!
+		{ p1, p2, p3, p4 }  // -z
+	};
+	const vector3d& GetPatchFaces(const Uint32 patch,const Uint32 face) { return s_patchFaces[patch][face]; }
 
 	STextureFaceRequest::STextureFaceRequest(const vector3d *v_, const SystemPath &sysPath_, const Sint32 face_, const Sint32 uvDIMs_, Terrain *pTerrain_) :
 		corners(v_), sysPath(sysPath_), face(face_), uvDIMs(uvDIMs_), pTerrain(pTerrain_)
@@ -172,7 +184,7 @@ namespace GasGiantJobs
 	void SGPUGenRequest::SetupMaterialParams(const int face)
 	{
 		PROFILE_SCOPED()
-		m_specialParams.v = &s_patchFaces[face][0];
+		m_specialParams.v = &GetPatchFaces(face,0);
 		m_specialParams.fracStep = 1.0f / float(uvDIMs);
 		m_specialParams.planetRadius = planetRadius;
 		m_specialParams.time = 0.0f;

--- a/src/GasGiantJobs.h
+++ b/src/GasGiantJobs.h
@@ -34,17 +34,7 @@ namespace GasGiantJobs
 	static const vector3d p7 = (vector3d(-1, -1, -1)).Normalized();
 	static const vector3d p8 = (vector3d(1, -1, -1)).Normalized();
 
-	static const vector3d s_patchFaces[NUM_PATCHES][4] =
-	{
-		{ p5, p1, p4, p8 }, // +x
-		{ p2, p6, p7, p3 }, // -x
-
-		{ p2, p1, p5, p6 }, // +y
-		{ p7, p8, p4, p3 }, // -y
-
-		{ p6, p5, p8, p7 }, // +z - NB: these are actually reversed!
-		{ p1, p2, p3, p4 }  // -z
-	};
+	const vector3d& GetPatchFaces(const Uint32 patch,const Uint32 face);
 
 	class STextureFaceRequest {
 	public:


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
I got tired of seeing a warning about `s_patchFaces` not being used, when it bloody well is, when digging through the build logs for gcc.
<!-- Please make sure you've read documentation on contributing -->


