### PR TITLE
add "override" to silence warnings in clang

### DIFF
--- a/src/CargoBody.h
+++ b/src/CargoBody.h
@@ -16,14 +16,14 @@ public:
 	CargoBody(const LuaRef& cargo, float selfdestructTimer=86400.0f); // default to 24 h lifetime
 	CargoBody() {}
 	LuaRef GetCargoType() const { return m_cargo; }
-	virtual void SetLabel(const std::string &label);
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
-	virtual void TimeStepUpdate(const float timeStep);
-	virtual bool OnCollision(Object *o, Uint32 flags, double relVel);
-	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData);
+	virtual void SetLabel(const std::string &label) override;
+	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	virtual void TimeStepUpdate(const float timeStep) override;
+	virtual bool OnCollision(Object *o, Uint32 flags, double relVel) override;
+	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData) override;
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 private:
 	void Init();
 	LuaRef m_cargo;

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -15,20 +15,20 @@ public:
 	OBJDEF(DynamicBody, ModelBody, DYNAMICBODY);
 	DynamicBody();
 	virtual ~DynamicBody();
-	virtual vector3d GetVelocity() const;
-	virtual void SetVelocity(const vector3d &v);
-	virtual void SetFrame(Frame *f);
+	virtual vector3d GetVelocity() const override;
+	virtual void SetVelocity(const vector3d &v) override;
+	virtual void SetFrame(Frame *f) override;
 	vector3d GetAngVelocity() const;
 	void SetAngVelocity(const vector3d &v);
 	void SetMesh(ObjMesh *m);
-	virtual bool OnCollision(Object *o, Uint32 flags, double relVel);
+	virtual bool OnCollision(Object *o, Uint32 flags, double relVel) override;
 	vector3d GetAngularMomentum() const;
 	double GetAngularInertia() const { return m_angInertia; }
 	void SetMassDistributionFromModel();
 	void SetMoving(bool isMoving) { m_isMoving = isMoving; }
 	bool IsMoving() const { return m_isMoving; }
-	virtual double GetMass() const { return m_mass; }	// XXX don't override this
-	virtual void TimeStepUpdate(const float timeStep);
+	virtual double GetMass() const override { return m_mass; }	// XXX don't override this
+	virtual void TimeStepUpdate(const float timeStep) override;
 	double CalcAtmosphericForce(double dragCoeff) const;
 	void CalcExternalForce();
 	void UndoTimestep();
@@ -46,14 +46,14 @@ public:
 	vector3d GetExternalForce() const { return m_externalForce; }
 	vector3d GetAtmosForce() const { return m_atmosForce; }
 	vector3d GetGravityForce() const { return m_gravityForce; }
-	virtual void UpdateInterpTransform(double alpha);
+	virtual void UpdateInterpTransform(double alpha) override;
 
-	virtual void PostLoadFixup(Space *space);
+	virtual void PostLoadFixup(Space *space) override;
 
 	Orbit ComputeOrbit() const;
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
 	static const double DEFAULT_DRAG_COEFF;
 	double m_dragCoeff;

--- a/src/HyperspaceCloud.h
+++ b/src/HyperspaceCloud.h
@@ -21,20 +21,20 @@ public:
 	HyperspaceCloud(Ship *, double dateDue, bool isArrival);
 	HyperspaceCloud();
 	virtual ~HyperspaceCloud();
-	virtual void SetVelocity(const vector3d &v) { m_vel = v; }
-	virtual vector3d GetVelocity() const { return m_vel; }
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
-	virtual void PostLoadFixup(Space *space);
-	virtual void TimeStepUpdate(const float timeStep);
+	virtual void SetVelocity(const vector3d &v) override { m_vel = v; }
+	virtual vector3d GetVelocity() const override { return m_vel; }
+	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	virtual void PostLoadFixup(Space *space) override;
+	virtual void TimeStepUpdate(const float timeStep) override;
 	Ship *GetShip() { return m_ship; }
 	Ship *EvictShip();
 	double GetDueDate() const { return m_due; }
 	void SetIsArrival(bool isArrival);
 	bool IsArrival() const { return m_isArrival; }
-	virtual void UpdateInterpTransform(double alpha);
+	virtual void UpdateInterpTransform(double alpha) override;
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
 private:
 	void InitGraphics();

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -14,11 +14,11 @@ public:
 	Missile(const ShipType::Id &type, Body *owner, int power=-1);
 	Missile() {}
 	virtual ~Missile() {}
-	void TimeStepUpdate(const float timeStep);
-	virtual bool OnCollision(Object *o, Uint32 flags, double relVel);
-	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData);
-	virtual void NotifyRemoved(const Body* const removedBody);
-	virtual void PostLoadFixup(Space *space);
+	void TimeStepUpdate(const float timeStep) override;
+	virtual bool OnCollision(Object *o, Uint32 flags, double relVel) override;
+	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData) override;
+	virtual void NotifyRemoved(const Body* const removedBody) override;
+	virtual void PostLoadFixup(Space *space) override;
 	void ECMAttack(int power_val);
 	Body *GetOwner() const { return m_owner; }
 	bool IsArmed() const {return m_armed;}
@@ -26,8 +26,8 @@ public:
 	void Disarm();
 
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 private:
 	void Explode();
 

--- a/src/ModelBody.h
+++ b/src/ModelBody.h
@@ -19,10 +19,10 @@ public:
 	OBJDEF(ModelBody, Body, MODELBODY);
 	ModelBody();
 	virtual ~ModelBody();
-	void SetPosition(const vector3d &p);
-	void SetOrient(const matrix3x3d &r);
+	void SetPosition(const vector3d &p) override;
+	void SetOrient(const matrix3x3d &r) override;
 	void TransformToModelCoords(const Frame *camFrame);
-	virtual void SetFrame(Frame *f);
+	virtual void SetFrame(Frame *f) override;
 	// Colliding: geoms are checked against collision space
 	void SetColliding(bool colliding);
 	bool IsColliding() const { return m_colliding; }
@@ -37,11 +37,11 @@ public:
 
 	void RenderModel(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform, const bool setLighting=true);
 
-	virtual void TimeStepUpdate(const float timeStep);
+	virtual void TimeStepUpdate(const float timeStep) override;
 
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
 	void SetLighting(Graphics::Renderer *r, const Camera *camera, std::vector<Graphics::Light> &oldLights, Color &oldAmbient);
 	void ResetLighting(Graphics::Renderer *r, const std::vector<Graphics::Light> &oldLights, const Color &oldAmbient);

--- a/src/Object.h
+++ b/src/Object.h
@@ -31,8 +31,8 @@ public:
 	virtual bool IsType(Type c) const { return GetType() == c; }
 };
 #define OBJDEF(__thisClass,__parentClass,__TYPE) \
-	virtual Object::Type GetType() const { return Object::__TYPE; } \
-	virtual bool IsType(Type c) const { \
+	virtual Object::Type GetType() const override { return Object::__TYPE; } \
+	virtual bool IsType(Type c) const override { \
 	if (__thisClass::GetType() == (c)) return true; \
 	else return __parentClass::IsType(c); }
 #endif /* _OBJECT_H */

--- a/src/Planet.h
+++ b/src/Planet.h
@@ -21,7 +21,7 @@ public:
 	Planet(SystemBody*);
 	Planet();
 
-	virtual void SubRender(Graphics::Renderer *r, const matrix4x4d &viewTran, const vector3d &camPos);
+	virtual void SubRender(Graphics::Renderer *r, const matrix4x4d &viewTran, const vector3d &camPos) override;
 
 	void GetAtmosphericState(double dist, double *outPressure, double *outDensity) const;
 	double GetAtmosphereRadius() const { return m_atmosphereRadius; }
@@ -31,7 +31,7 @@ public:
 #endif
 
 protected:
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
 private:
 	void InitParams(const SystemBody*);

--- a/src/Player.h
+++ b/src/Player.h
@@ -19,12 +19,12 @@ public:
 	OBJDEF(Player, Ship, PLAYER);
 	Player(const ShipType::Id &shipId);
 	Player() {}; //default constructor used before Load
-	virtual void SetDockedWith(SpaceStation *, int port);
-	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData);
-	virtual bool SetWheelState(bool down); // returns success of state change, NOT state itself
-	virtual Missile * SpawnMissile(ShipType::Id missile_type, int power=-1);
-	virtual void SetAlertState(Ship::AlertState as);
-	virtual void NotifyRemoved(const Body* const removedBody);
+	virtual void SetDockedWith(SpaceStation *, int port) override;
+	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData) override;
+	virtual bool SetWheelState(bool down) override; // returns success of state change, NOT state itself
+	virtual Missile * SpawnMissile(ShipType::Id missile_type, int power=-1) override;
+	virtual void SetAlertState(Ship::AlertState as) override;
+	virtual void NotifyRemoved(const Body* const removedBody) override;
 
 	virtual void SetShipType(const ShipType::Id &shipId) override;
 
@@ -36,23 +36,23 @@ public:
 	void SetCombatTarget(Body* const target, bool setSpeedTo = false);
 	void SetNavTarget(Body* const target, bool setSpeedTo = false);
 
-	virtual Ship::HyperjumpStatus InitiateHyperjumpTo(const SystemPath &dest, int warmup_time, double duration, LuaRef checks);
-	virtual void AbortHyperjump();
+	virtual Ship::HyperjumpStatus InitiateHyperjumpTo(const SystemPath &dest, int warmup_time, double duration, LuaRef checks) override;
+	virtual void AbortHyperjump() override;
 
 	// XXX cockpit is here for now because it has a physics component
 	void InitCockpit();
 	ShipCockpit* GetCockpit() const {return m_cockpit.get();}
 	void OnCockpitActivated();
 
-	virtual void StaticUpdate(const float timeStep);
+	virtual void StaticUpdate(const float timeStep) override;
 	sigc::signal<void> onChangeEquipment;
 
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
-	virtual void OnEnterSystem();
-	virtual void OnEnterHyperspace();
+	virtual void OnEnterSystem() override;
+	virtual void OnEnterHyperspace() override;
 
 private:
 	std::unique_ptr<ShipCockpit> m_cockpit;

--- a/src/Projectile.h
+++ b/src/Projectile.h
@@ -23,18 +23,18 @@ public:
 
 	Projectile();
 	virtual ~Projectile();
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
-	void TimeStepUpdate(const float timeStep);
-	void StaticUpdate(const float timeStep);
-	virtual void NotifyRemoved(const Body* const removedBody);
-	virtual void UpdateInterpTransform(double alpha);
-	virtual void PostLoadFixup(Space *space);
+	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	void TimeStepUpdate(const float timeStep) override;
+	void StaticUpdate(const float timeStep) override;
+	virtual void NotifyRemoved(const Body* const removedBody) override;
+	virtual void UpdateInterpTransform(double alpha) override;
+	virtual void PostLoadFixup(Space *space) override;
 
 	static void FreeModel();
 
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
 private:
 	float GetDamage() const;

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -56,7 +56,7 @@ public:
 	Ship() {} //default constructor used before Load
 	virtual ~Ship();
 
-	virtual void SetFrame(Frame *f);
+	virtual void SetFrame(Frame *f) override;
 
 	void SetController(ShipController *c); //deletes existing
 	ShipController *GetController() const { return m_controller; }
@@ -69,7 +69,7 @@ public:
 
 	virtual void SetLandedOn(Planet *p, float latitude, float longitude);
 
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
+	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 
 	void SetThrusterState(int axis, double level) {
 		if (m_thrusterFuel <= 0.f) level = 0.0;
@@ -99,16 +99,16 @@ public:
 	virtual bool SetWheelState(bool down); // returns success of state change, NOT state itself
 	void Blastoff();
 	bool Undock();
-	virtual void TimeStepUpdate(const float timeStep);
-	virtual void StaticUpdate(const float timeStep);
+	virtual void TimeStepUpdate(const float timeStep) override;
+	virtual void StaticUpdate(const float timeStep) override;
 
 	void TimeAccelAdjust(const float timeStep);
 	void SetDecelerating(bool decel) { m_decelerating = decel; }
 	bool IsDecelerating() const { return m_decelerating; }
 
-	virtual void NotifyRemoved(const Body* const removedBody);
-	virtual bool OnCollision(Object *o, Uint32 flags, double relVel);
-	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData);
+	virtual void NotifyRemoved(const Body* const removedBody) override;
+	virtual bool OnCollision(Object *o, Uint32 flags, double relVel) override;
+	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData) override;
 
 	enum FlightState { // <enum scope='Ship' name=ShipFlightState public>
 		FLYING,     // open flight (includes autopilot)
@@ -128,7 +128,7 @@ public:
 
 	LuaRef GetEquipSet() const { return m_equipSet; }
 
-	virtual bool IsInSpace() const { return (m_flightState != HYPERSPACE); }
+	virtual bool IsInSpace() const override { return (m_flightState != HYPERSPACE); }
 
 	void SetHyperspaceDest(const SystemPath &dest) { m_hyperspace.dest = dest; }
 	const SystemPath &GetHyperspaceDest() const { return m_hyperspace.dest; }
@@ -210,7 +210,7 @@ public:
 
 	void AIBodyDeleted(const Body* const body) {};		// todo: signals
 
-	virtual void PostLoadFixup(Space *space);
+	virtual void PostLoadFixup(Space *space) override;
 
 	const ShipType *GetShipType() const { return m_type; }
 	virtual void SetShipType(const ShipType::Id &shipId);
@@ -220,7 +220,7 @@ public:
 
 	void SetPattern(unsigned int num);
 
-	void SetLabel(const std::string &label);
+	void SetLabel(const std::string &label) override;
 	void SetShipName(const std::string &shipName);
 
 	float GetPercentShields() const;
@@ -267,8 +267,8 @@ public:
 	double GetLandingPosOffset() const { return m_landingMinOffset; }
 
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 	void RenderLaserfire();
 
 	bool AITimeStep(float timeStep); // Called by controller. Returns true if complete

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -34,16 +34,16 @@ public:
 	SpaceStation() {}
 	virtual ~SpaceStation();
 	virtual vector3d GetAngVelocity() const { return vector3d(0,m_type->AngVel(),0); }
-	virtual bool OnCollision(Object *b, Uint32 flags, double relVel);
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
-	virtual void StaticUpdate(const float timeStep);
-	virtual void TimeStepUpdate(const float timeStep);
+	virtual bool OnCollision(Object *b, Uint32 flags, double relVel) override;
+	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	virtual void StaticUpdate(const float timeStep) override;
+	virtual void TimeStepUpdate(const float timeStep) override;
 
-	virtual const SystemBody *GetSystemBody() const { return m_sbody; }
-	virtual void PostLoadFixup(Space *space);
-	virtual void NotifyRemoved(const Body* const removedBody);
+	virtual const SystemBody *GetSystemBody() const override { return m_sbody; }
+	virtual void PostLoadFixup(Space *space) override;
+	virtual void NotifyRemoved(const Body* const removedBody) override;
 
-	virtual void SetLabel(const std::string &label);
+	virtual void SetLabel(const std::string &label) override;
 
 	// should call Ship::Undock and Ship::SetDockedWith instead
 	// Returns true on success, false if permission denied
@@ -63,14 +63,14 @@ public:
 	bool AllocateStaticSlot(int& slot);
 
 	// use docking bay position, if player has been granted permission
-	virtual vector3d GetTargetIndicatorPosition(const Frame *relTo) const;
+	virtual vector3d GetTargetIndicatorPosition(const Frame *relTo) const override;
 
 	// need this now because stations rotate in their frame
-	virtual void UpdateInterpTransform(double alpha);
+	virtual void UpdateInterpTransform(double alpha) override;
 
 protected:
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
 private:
 	void DockingUpdate(const double timeStep);

--- a/src/Star.h
+++ b/src/Star.h
@@ -16,10 +16,10 @@ public:
 	Star();
 	virtual ~Star() {};
 
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
+	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 protected:
 	void InitStar();
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
 	Graphics::RenderState *m_haloState;
 };

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -16,14 +16,14 @@ class TerrainBody : public Body {
 public:
 	OBJDEF(TerrainBody, Body, TERRAINBODY);
 
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
+	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 	virtual void SubRender(Graphics::Renderer *r, const matrix4x4d &modelView, const vector3d &camPos) {}
-	virtual void SetFrame(Frame *f);
-	virtual bool OnCollision(Object *b, Uint32 flags, double relVel) { return true; }
-	virtual double GetMass() const { return m_mass; }
+	virtual void SetFrame(Frame *f) override;
+	virtual bool OnCollision(Object *b, Uint32 flags, double relVel) override { return true; }
+	virtual double GetMass() const override { return m_mass; }
 	double GetTerrainHeight(const vector3d &pos) const;
 	bool IsSuperType(SystemBody::BodySuperType t) const;
-	virtual const SystemBody *GetSystemBody() const { return m_sbody; }
+	virtual const SystemBody *GetSystemBody() const override { return m_sbody; }
 
 	// returns value in metres
 	double GetMaxFeatureRadius() const { return m_maxFeatureHeight; }
@@ -38,8 +38,8 @@ protected:
 
 	void InitTerrainBody();
 
-	virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
+	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
+	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;
 
 private:
 	const SystemBody *m_sbody;

--- a/src/graphics/dummy/MaterialDummy.h
+++ b/src/graphics/dummy/MaterialDummy.h
@@ -20,11 +20,11 @@ namespace Graphics {
 			// Create an appropriate program for this material.
 			virtual Program *CreateProgram(const MaterialDescriptor &) { return nullptr; }
 			// bind textures, set uniforms
-			virtual void Apply() {}
-			virtual void Unapply() {}
+			virtual void Apply() override {}
+			virtual void Unapply() override {}
 			virtual bool IsProgramLoaded() const override final { return false; }
 			virtual void SetProgram(Program *p) { }
-			virtual void SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj) {}
+			virtual void SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj) override {}
 		};
 	}
 }

--- a/src/graphics/dummy/VertexBufferDummy.h
+++ b/src/graphics/dummy/VertexBufferDummy.h
@@ -19,13 +19,13 @@ public:
 	// copies the contents of the VertexArray into the buffer
 	virtual bool Populate(const VertexArray &) override { return true; }
 
-	virtual void Bind() {}
-	virtual void Release() {}
+	virtual void Bind() override {}
+	virtual void Release() override {}
 
 	virtual void Unmap() override {}
 
 protected:
-	virtual Uint8 *MapInternal(BufferMapMode) { return m_buffer.get(); }
+	virtual Uint8 *MapInternal(BufferMapMode) override { return m_buffer.get(); }
 
 private:
 	std::unique_ptr<Uint8[]> m_buffer;
@@ -41,8 +41,8 @@ public:
 
 	virtual void Unmap() override {}
 
-	virtual void Bind() {}
-	virtual void Release() {}
+	virtual void Bind() override {}
+	virtual void Release() override {}
 
 private:
     std::unique_ptr<Uint32[]> m_buffer;
@@ -61,8 +61,8 @@ public:
 	Uint32 GetSize() const { return m_size; }
 	BufferUsage GetUsage() const { return m_usage; }
 
-	virtual void Bind() {}
-	virtual void Release() {}
+	virtual void Bind() override {}
+	virtual void Release() override {}
 
 protected:
 	std::unique_ptr<matrix4x4f> m_data;

--- a/src/graphics/opengl/MaterialGL.h
+++ b/src/graphics/opengl/MaterialGL.h
@@ -29,11 +29,11 @@ namespace Graphics {
 			// Create an appropriate program for this material.
 			virtual Program *CreateProgram(const MaterialDescriptor &) = 0;
 			// bind textures, set uniforms
-			virtual void Apply();
-			virtual void Unapply();
+			virtual void Apply() override;
+			virtual void Unapply() override;
 			virtual bool IsProgramLoaded() const override final;
 			virtual void SetProgram(Program *p) { m_program = p; }
-			virtual void SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj);
+			virtual void SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj) override;
 
 		protected:
 			friend class Graphics::RendererOGL;

--- a/src/graphics/opengl/SphereImpostorMaterial.h
+++ b/src/graphics/opengl/SphereImpostorMaterial.h
@@ -14,7 +14,7 @@ namespace Graphics {
 
 		class SphereImpostorMaterial : public Material {
 		public:
-			Program *CreateProgram(const MaterialDescriptor &) {
+			Program *CreateProgram(const MaterialDescriptor &) override {
 				return new Program("billboard_sphereimpostor", "");
 			}
 

--- a/src/scenegraph/CollisionGeometry.h
+++ b/src/scenegraph/CollisionGeometry.h
@@ -21,9 +21,9 @@ class CollisionGeometry : public Node {
 public:
 	CollisionGeometry(Graphics::Renderer *r, const std::vector<vector3f>&, const std::vector<Uint32>&, unsigned int flag);
 	CollisionGeometry(const CollisionGeometry&, NodeCopyCache *cache = 0);
-	virtual Node *Clone(NodeCopyCache *cache = 0);
-	virtual const char *GetTypeName() const { return "CollisionGeometry"; }
-	virtual void Accept(NodeVisitor &nv);
+	virtual Node *Clone(NodeCopyCache *cache = 0) override;
+	virtual const char *GetTypeName() const override { return "CollisionGeometry"; }
+	virtual void Accept(NodeVisitor &nv) override;
 	virtual void Save(NodeDatabase&) override;
 	static CollisionGeometry *Load(NodeDatabase&);
 

--- a/src/scenegraph/Group.h
+++ b/src/scenegraph/Group.h
@@ -14,8 +14,8 @@ class Group : public Node
 public:
 	Group(Graphics::Renderer *r);
 	Group(const Group&, NodeCopyCache *cache = 0);
-	virtual Node *Clone(NodeCopyCache *cache = 0);
-	virtual const char *GetTypeName() const { return "Group"; }
+	virtual Node *Clone(NodeCopyCache *cache = 0) override;
+	virtual const char *GetTypeName() const override { return "Group"; }
 	virtual void Save(NodeDatabase&) override;
 	static Group *Load(NodeDatabase&);
 
@@ -24,11 +24,11 @@ public:
 	virtual bool RemoveChildAt(unsigned int position); //true on success
 	unsigned int GetNumChildren() const { return m_children.size(); }
 	Node* GetChildAt(unsigned int);
-	virtual void Accept(NodeVisitor &v);
-	virtual void Traverse(NodeVisitor &v);
-	virtual void Render(const matrix4x4f &trans, const RenderData *rd);
-	virtual void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd);
-	virtual Node* FindNode(const std::string &);
+	virtual void Accept(NodeVisitor &v) override;
+	virtual void Traverse(NodeVisitor &v) override;
+	virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
+	virtual void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
+	virtual Node* FindNode(const std::string &) override;
 
 protected:
 	virtual ~Group();

--- a/src/scenegraph/LOD.h
+++ b/src/scenegraph/LOD.h
@@ -14,11 +14,11 @@ class LOD : public Group {
 public:
 	LOD(Graphics::Renderer *r);
 	LOD(const LOD&, NodeCopyCache *cache = 0);
-	virtual Node *Clone(NodeCopyCache *cache = 0);
-	virtual const char *GetTypeName() const { return "LOD"; }
-	virtual void Accept(NodeVisitor &v);
-	virtual void Render(const matrix4x4f &trans, const RenderData *rd);
-	virtual void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd);
+	virtual Node *Clone(NodeCopyCache *cache = 0) override;
+	virtual const char *GetTypeName() const override { return "LOD"; }
+	virtual void Accept(NodeVisitor &v) override;
+	virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
+	virtual void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
 	void AddLevel(float pixelRadius, Node *child);
 	virtual void Save(NodeDatabase&) override;
 	static LOD* Load(NodeDatabase&);

--- a/src/scenegraph/MatrixTransform.h
+++ b/src/scenegraph/MatrixTransform.h
@@ -16,15 +16,15 @@ public:
 	MatrixTransform(Graphics::Renderer *r, const matrix4x4f &m);
 	MatrixTransform(const MatrixTransform&, NodeCopyCache *cache = 0);
 
-	virtual Node *Clone(NodeCopyCache *cache = 0);
-	virtual const char *GetTypeName() const { return "MatrixTransform"; }
-	virtual void Accept(NodeVisitor &v);
+	virtual Node *Clone(NodeCopyCache *cache = 0) override;
+	virtual const char *GetTypeName() const override { return "MatrixTransform"; }
+	virtual void Accept(NodeVisitor &v) override;
 
 	virtual void Save(NodeDatabase&) override;
 	static MatrixTransform *Load(NodeDatabase&);
 
-	virtual void Render(const matrix4x4f &trans, const RenderData *rd);
-	virtual void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd);
+	virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
+	virtual void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
 
 	const matrix4x4f &GetTransform() const { return m_transform; }
 	void SetTransform(const matrix4x4f &m) { m_transform = m; }

--- a/src/scenegraph/StaticGeometry.h
+++ b/src/scenegraph/StaticGeometry.h
@@ -26,11 +26,11 @@ public:
 	};
 	StaticGeometry(Graphics::Renderer *r);
 	StaticGeometry(const StaticGeometry&, NodeCopyCache *cache = 0);
-	virtual Node *Clone(NodeCopyCache *cache = 0);
-	virtual const char *GetTypeName() const { return "StaticGeometry"; }
-	virtual void Accept(NodeVisitor &nv);
-	virtual void Render(const matrix4x4f &trans, const RenderData *rd);
-	virtual void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd);
+	virtual Node *Clone(NodeCopyCache *cache = 0) override;
+	virtual const char *GetTypeName() const override { return "StaticGeometry"; }
+	virtual void Accept(NodeVisitor &nv) override;
+	virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
+	virtual void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
 
 	virtual void Save(NodeDatabase&) override;
 	static StaticGeometry *Load(NodeDatabase&);

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -22,10 +22,10 @@ class Thruster : public Node {
 public:
 	Thruster(Graphics::Renderer *, bool linear, const vector3f &pos, const vector3f &dir);
 	Thruster(const Thruster&, NodeCopyCache *cache = 0);
-	Node *Clone(NodeCopyCache *cache = 0);
-	virtual void Accept(NodeVisitor &v);
-	virtual const char *GetTypeName() const { return "Thruster"; }
-	virtual void Render(const matrix4x4f &trans, const RenderData *rd);
+	Node *Clone(NodeCopyCache *cache = 0) override;
+	virtual void Accept(NodeVisitor &v) override;
+	virtual const char *GetTypeName() const override { return "Thruster"; }
+	virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
 	virtual void Save(NodeDatabase&) override;
 	static Thruster *Load(NodeDatabase&);
 


### PR DESCRIPTION
add "override" to all functions where clang++ says it's missing
````
grep override * -R
````
before: 307
after: 445
