### PR TITLE
Added military drives from 5 to 9.

### DIFF
--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -91,6 +91,26 @@
       "description" : "",
       "message" : "Class 4 Military drive"
    },
+   "DRIVE_MIL5" : {
+      "description" : "",
+      "message" : "Class 5 Military drive"
+   },
+   "DRIVE_MIL6" : {
+      "description" : "",
+      "message" : "Class 6 Military drive"
+   },
+   "DRIVE_MIL7" : {
+      "description" : "",
+      "message" : "Class 7 Military drive"
+   },
+   "DRIVE_MIL8" : {
+      "description" : "",
+      "message" : "Class 8 Military drive"
+   },
+   "DRIVE_MIL9" : {
+      "description" : "",
+      "message" : "Class 9 Military drive"
+   },
    "ECM_ADVANCED" : {
       "description" : "",
       "message" : "Advanced ECM system"

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -820,6 +820,26 @@ hyperspace.hyperdrive_mil4 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL4", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
 	price=214000, capabilities={mass=30, hyperclass=4}, purchasable=true, tech_level=12
 })
+hyperspace.hyperdrive_mil5 = HyperdriveType.New({
+	l10n_key="DRIVE_MIL5", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	price=540000, capabilities={mass=53, hyperclass=5}, purchasable=false, tech_level="MILITARY"
+})
+hyperspace.hyperdrive_mil6 = HyperdriveType.New({
+	l10n_key="DRIVE_MIL6", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	price=1350000, capabilities={mass=78, hyperclass=6}, purchasable=false, tech_level="MILITARY"
+})
+hyperspace.hyperdrive_mil7 = HyperdriveType.New({
+	l10n_key="DRIVE_MIL7", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	price=3500000, capabilities={mass=128, hyperclass=7}, purchasable=false, tech_level="MILITARY"
+})
+hyperspace.hyperdrive_mil8 = HyperdriveType.New({
+	l10n_key="DRIVE_MIL8", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	price=8500000, capabilities={mass=196, hyperclass=8}, purchasable=false, tech_level="MILITARY"
+})
+hyperspace.hyperdrive_mil9 = HyperdriveType.New({
+	l10n_key="DRIVE_MIL9", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	price=22000000, capabilities={mass=285, hyperclass=9}, purchasable=false, tech_level="MILITARY"
+})
 
 laser = {}
 laser.pulsecannon_1mw = LaserType.New({


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
NB: I originally did a PR for this about 5 yeas ago, so I finally got around to redoing it :)

The idea for these is that they cannot be purchased but that military or Police ships could be fitted with them so that escape is not an option, nor is chasing them through hyperspace a realistic one.

Obviously it also makes it possible for a black market in ships with them fitted, which are of dubious origins, to be created on the bulletin boards... though this PR does not implement that.
<!-- Please make sure you've read documentation on contributing -->


