### PR TITLE
Attempt to find the nearest matching exact name.

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -417,32 +417,34 @@ void SectorView::OnSearchBoxKeyPress(const SDL_Keysym *keysym)
 		return;
 	} catch (SystemPath::ParseFailure) {}
 
-	bool gotMatch = false, gotStartMatch = false;
+	bool gotMatch = false, gotStartMatch = false, gotExactMatch = false;
 	SystemPath bestMatch;
+	std::vector<std::pair<SystemPath,std::string>> exactMatches;
 	const std::string *bestMatchName = 0;
 
-	for (auto i = m_sectorCache->Begin(); i != m_sectorCache->End(); ++i)
-
-		for (unsigned int systemIndex = 0; systemIndex < (*i).second->m_systems.size(); systemIndex++) {
+	for (auto i = m_sectorCache->Begin(); i != m_sectorCache->End(); ++i) 
+	{
+		for (unsigned int systemIndex = 0; systemIndex < (*i).second->m_systems.size(); systemIndex++) 
+		{
 			const Sector::System *ss = &((*i).second->m_systems[systemIndex]);
 
 			// compare with the start of the current system
-			if (strncasecmp(search.c_str(), ss->GetName().c_str(), search.size()) == 0) {
-
+			if (strncasecmp(search.c_str(), ss->GetName().c_str(), search.size()) == 0) 
+			{
 				// matched, see if they're the same size
-				if (search.size() == ss->GetName().size()) {
-
+				if (search.size() == ss->GetName().size()) 
+				{
 					// exact match, take it and go
 					SystemPath path = (*i).first;
 					path.systemIndex = systemIndex;
-					m_statusLabel->SetText(stringf(Lang::EXACT_MATCH_X, formatarg("system", ss->GetName())));
-					GotoSystem(path);
-					return;
+					exactMatches.push_back(std::make_pair(path,ss->GetName()));
+					gotExactMatch = true;
+					continue;
 				}
 
 				// partial match at start of name
-				if (!gotMatch || !gotStartMatch || bestMatchName->size() > ss->GetName().size()) {
-
+				if (!gotMatch || !gotStartMatch || bestMatchName->size() > ss->GetName().size()) 
+				{
 					// don't already have one or its shorter than the previous
 					// one, take it
 					bestMatch = (*i).first;
@@ -455,11 +457,11 @@ void SectorView::OnSearchBoxKeyPress(const SDL_Keysym *keysym)
 			}
 
 			// look for the search term somewhere within the current system
-			if (pi_strcasestr(ss->GetName().c_str(), search.c_str())) {
-
+			if (pi_strcasestr(ss->GetName().c_str(), search.c_str())) 
+			{
 				// found it
-				if (!gotMatch || !gotStartMatch || bestMatchName->size() > ss->GetName().size()) {
-
+				if (!gotMatch || !gotStartMatch || bestMatchName->size() > ss->GetName().size()) 
+				{
 					// best we've found so far, take it
 					bestMatch = (*i).first;
 					bestMatch.systemIndex = systemIndex;
@@ -468,14 +470,35 @@ void SectorView::OnSearchBoxKeyPress(const SDL_Keysym *keysym)
 				}
 			}
 		}
-
-	if (gotMatch) {
-		m_statusLabel->SetText(stringf(Lang::NOT_FOUND_BEST_MATCH_X, formatarg("system", *bestMatchName)));
-		GotoSystem(bestMatch);
 	}
 
+	if(gotExactMatch) 
+	{
+		// We have some exact matches, sort them by distance and choose the closest to the players current system
+		const SystemPath currentSector = m_current.SectorOnly();
+		double nearest = DBL_MAX;
+		for(auto eM : exactMatches) 
+		{
+			const double dist = SystemPath::SectorDistanceSqr(currentSector, eM.first);
+			if(dist<nearest) 
+			{
+				// this one's closer, store it's details
+				bestMatch = eM.first;
+				bestMatchName = &(eM.second);
+				gotMatch = true;
+			}
+		}
+	}
+
+	if (gotMatch) 
+	{
+		m_statusLabel->SetText(stringf(gotExactMatch ? Lang::EXACT_MATCH_X : Lang::NOT_FOUND_BEST_MATCH_X, formatarg("system", *bestMatchName)));
+		GotoSystem(bestMatch);
+	} 
 	else
+	{
 		m_statusLabel->SetText(Lang::NOT_FOUND);
+	}
 }
 
 #define FFRAC(_x)	((_x)-floor(_x))

--- a/src/galaxy/SystemPath.h
+++ b/src/galaxy/SystemPath.h
@@ -58,6 +58,20 @@ public:
 		return (a.bodyIndex < b.bodyIndex);
 	}
 
+	static inline double SectorDistance(const SystemPath& a, const SystemPath& b) {
+		const Sint32 x = b.sectorX - a.sectorX;
+		const Sint32 y = b.sectorY - a.sectorY;
+		const Sint32 z = b.sectorZ - b.sectorZ;
+		return sqrt (x*x + y*y + z*z);	// sqrt is slow
+	}
+
+	static inline double SectorDistanceSqr(const SystemPath& a, const SystemPath& b) {
+		const Sint32 x = b.sectorX - a.sectorX;
+		const Sint32 y = b.sectorY - a.sectorY;
+		const Sint32 z = b.sectorZ - b.sectorZ;
+		return (x*x + y*y + z*z);	// return the square of the distance
+	}
+
 	class LessSectorOnly {
 	public:
 		bool operator()(const SystemPath& a, const SystemPath& b) const {


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Whilst attempting to repeat [this bug](http://spacesimcentral.com/ssc/topic/5879-newcomer-some-feedback-and-a-problem/) I noticed that I was constantly finding different instances of the system `Liaphi`.

It's a really common one but I wanted the nearest to my current star system.

This patch attempts to always return not just the first exact match, but the one nearest to the players current system. Sadly it can only do this for those within the `SystemCache` and so if the one you're looking has been discarded you will find whichever one (*or none*) that it can.
<!-- Please make sure you've read documentation on contributing -->


