### PR TITLE
Terrain gen cleanup

### DIFF
--- a/src/GeoPatchJobs.cpp
+++ b/src/GeoPatchJobs.cpp
@@ -98,7 +98,7 @@ void BasePatchJob::GenerateBorderedData(
 	const double fracStep,
 	const Terrain *pTerrain) const
 {
-	const int borderedEdgeLen = (edgeLen * 2) + (BORDER_SIZE * 2);
+	const int borderedEdgeLen = (edgeLen * 2) + (BORDER_SIZE * 2) - 1;
 	const int numBorderedVerts = borderedEdgeLen*borderedEdgeLen;
 
 	// generate heights plus a N=BORDER_SIZE unit border
@@ -139,35 +139,35 @@ void BasePatchJob::GenerateSubPatchData(
 	double *hts = heights;
 
 	// step over the small square
-	for (int y=0; y<edgeLen; y++) {
+	for ( int y = 0; y < edgeLen; y++ ) {
 		const int by = (y + BORDER_SIZE) + yoff;
-		for (int x=0; x<edgeLen; x++) {
+		for ( int x = 0; x < edgeLen; x++ ) {
 			const int bx = (x + BORDER_SIZE) + xoff;
 
 			// height
 			const double height = borderHeights[bx + (by * borderedEdgeLen)];
-			assert(hts!=&heights[edgeLen*edgeLen]);
+			assert(hts != &heights[edgeLen * edgeLen]);
 			*(hts++) = height;
 
 			// normal
-			const vector3d &x1 = vrts[(bx - 1) + (by*borderedEdgeLen)];
-			const vector3d &x2 = vrts[(bx + 1) + (by*borderedEdgeLen)];
-			const vector3d &y1 = vrts[bx + ((by - 1)*borderedEdgeLen)];
-			const vector3d &y2 = vrts[bx + ((by + 1)*borderedEdgeLen)];
+			const vector3d &x1 = vrts[(bx - 1) + (by * borderedEdgeLen)];
+			const vector3d &x2 = vrts[(bx + 1) + (by * borderedEdgeLen)];
+			const vector3d &y1 = vrts[bx + ((by - 1) * borderedEdgeLen)];
+			const vector3d &y2 = vrts[bx + ((by + 1) * borderedEdgeLen)];
 			const vector3d n = ((x2 - x1).Cross(y2 - y1)).Normalized();
-			assert(nrm!=&normals[edgeLen*edgeLen]);
+			assert(nrm != &normals[edgeLen * edgeLen]);
 			*(nrm++) = vector3f(n);
 
 			// color
-			const vector3d p = GetSpherePoint(v0, v1, v2, v3, x*fracStep, y*fracStep);
+			const vector3d p = GetSpherePoint(v0, v1, v2, v3, x * fracStep, y * fracStep);
 			setColour(*col, pTerrain->GetColor(p, height, n));
-			assert(col!=&colors[edgeLen*edgeLen]);
+			assert(col != &colors[edgeLen * edgeLen]);
 			++col;
 		}
 	}
-	assert(hts==&heights[edgeLen*edgeLen]);
-	assert(nrm==&normals[edgeLen*edgeLen]);
-	assert(col==&colors[edgeLen*edgeLen]);
+	assert(hts == &heights[edgeLen*edgeLen]);
+	assert(nrm == &normals[edgeLen*edgeLen]);
+	assert(col == &colors[edgeLen*edgeLen]);
 }
 
 // ********************************************************************************
@@ -233,7 +233,6 @@ void QuadPatchJob::OnRun()    // RUNS IN ANOTHER THREAD!! MUST BE THREAD SAFE!
 	const vector3d v23	= (srd.v2+srd.v3).Normalized();
 	const vector3d v30	= (srd.v3+srd.v0).Normalized();
 	const vector3d cn	= (srd.centroid).Normalized();
-
 	const vector3d vecs[4][4] = {
 		{srd.v0,	v01,		cn,			v30},
 		{v01,		srd.v1,		v12,		cn},
@@ -241,13 +240,12 @@ void QuadPatchJob::OnRun()    // RUNS IN ANOTHER THREAD!! MUST BE THREAD SAFE!
 		{v30,		cn,			v23,		srd.v3}
 	};
 
-	const int borderedEdgeLen = (srd.edgeLen*2)+(BORDER_SIZE*2);
-	const int numBorderedVerts = borderedEdgeLen*borderedEdgeLen;
+	const int borderedEdgeLen = (srd.edgeLen*2)+(BORDER_SIZE*2)-1;
 	const int offxy[4][2] = {
 		{0,0},
-		{srd.edgeLen,0},
-		{srd.edgeLen,srd.edgeLen},
-		{0,srd.edgeLen}
+		{srd.edgeLen-1,0},
+		{srd.edgeLen-1,srd.edgeLen-1},
+		{0,srd.edgeLen-1}
 	};
 
 	SQuadSplitResult *sr = new SQuadSplitResult(srd.patchID.GetPatchFaceIdx(), srd.depth);

--- a/src/GeoPatchJobs.cpp
+++ b/src/GeoPatchJobs.cpp
@@ -30,15 +30,15 @@ void BasePatchJob::GenerateMesh(double *heights, vector3f *normals, Color3ub *co
 								const double fracStep,
 								const Terrain *pTerrain) const
 {
-	const int borderedEdgeLen = edgeLen+2;
+	const int borderedEdgeLen = edgeLen+(BORDER_SIZE*2);
 	const int numBorderedVerts = borderedEdgeLen*borderedEdgeLen;
 
 	// generate heights plus a 1 unit border
 	double *bhts = borderHeights;
 	vector3d *vrts = borderVertexs;
-	for (int y=-1; y<borderedEdgeLen-1; y++) {
+	for (int y=-BORDER_SIZE; y<borderedEdgeLen-BORDER_SIZE; y++) {
 		const double yfrac = double(y) * fracStep;
-		for (int x=-1; x<borderedEdgeLen-1; x++) {
+		for (int x=-BORDER_SIZE; x<borderedEdgeLen-BORDER_SIZE; x++) {
 			const double xfrac = double(x) * fracStep;
 			const vector3d p = GetSpherePoint(v0, v1, v2, v3, xfrac, yfrac);
 			const double height = pTerrain->GetHeight(p);
@@ -54,24 +54,24 @@ void BasePatchJob::GenerateMesh(double *heights, vector3f *normals, Color3ub *co
 	vector3f *nrm = normals;
 	double *hts = heights;
 	vrts = borderVertexs;
-	for (int y=1; y<borderedEdgeLen-1; y++) {
-		for (int x=1; x<borderedEdgeLen-1; x++) {
+	for (int y=BORDER_SIZE; y<borderedEdgeLen-BORDER_SIZE; y++) {
+		for (int x=BORDER_SIZE; x<borderedEdgeLen-BORDER_SIZE; x++) {
 			// height
 			const double height = borderHeights[x + y*borderedEdgeLen];
 			assert(hts!=&heights[edgeLen*edgeLen]);
 			*(hts++) = height;
 
 			// normal
-			const vector3d &x1 = vrts[x-1 + y*borderedEdgeLen];
-			const vector3d &x2 = vrts[x+1 + y*borderedEdgeLen];
-			const vector3d &y1 = vrts[x + (y-1)*borderedEdgeLen];
-			const vector3d &y2 = vrts[x + (y+1)*borderedEdgeLen];
+			const vector3d &x1 = vrts[(x-BORDER_SIZE) + y*borderedEdgeLen];
+			const vector3d &x2 = vrts[(x+BORDER_SIZE) + y*borderedEdgeLen];
+			const vector3d &y1 = vrts[x + (y-BORDER_SIZE)*borderedEdgeLen];
+			const vector3d &y2 = vrts[x + (y+BORDER_SIZE)*borderedEdgeLen];
 			const vector3d n = ((x2-x1).Cross(y2-y1)).Normalized();
 			assert(nrm!=&normals[edgeLen*edgeLen]);
 			*(nrm++) = vector3f(n);
 
 			// color
-			const vector3d p = GetSpherePoint(v0, v1, v2, v3, (x-1)*fracStep, (y-1)*fracStep);
+			const vector3d p = GetSpherePoint(v0, v1, v2, v3, (x-BORDER_SIZE)*fracStep, (y-BORDER_SIZE)*fracStep);
 			setColour(*col, pTerrain->GetColor(p, height, n));
 			assert(col!=&colors[edgeLen*edgeLen]);
 			++col;

--- a/src/GeoPatchJobs.cpp
+++ b/src/GeoPatchJobs.cpp
@@ -15,6 +15,11 @@ inline void setColour(Color3ub &r, const vector3d &v) {
 	r.b=static_cast<unsigned char>(Clamp(v.z*255.0, 0.0, 255.0));
 }
 
+// in patch surface coords, [0,1]
+inline vector3d GetSpherePoint(const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3, const double x, const double y) {
+	return (v0 + x*(1.0-y)*(v1-v0) + x*y*(v2-v0) + (1.0-x)*y*(v3-v0)).Normalized();
+}
+
 // ********************************************************************************
 // Overloaded PureJob class to handle generating the mesh for each patch
 // ********************************************************************************
@@ -62,16 +67,99 @@ void BasePatchJob::GenerateMesh(double *heights, vector3f *normals, Color3ub *co
 			*(hts++) = height;
 
 			// normal
-			const vector3d &x1 = vrts[(x-BORDER_SIZE) + y*borderedEdgeLen];
-			const vector3d &x2 = vrts[(x+BORDER_SIZE) + y*borderedEdgeLen];
-			const vector3d &y1 = vrts[x + (y-BORDER_SIZE)*borderedEdgeLen];
-			const vector3d &y2 = vrts[x + (y+BORDER_SIZE)*borderedEdgeLen];
+			const vector3d &x1 = vrts[(x-1) + y*borderedEdgeLen];
+			const vector3d &x2 = vrts[(x+1) + y*borderedEdgeLen];
+			const vector3d &y1 = vrts[x + (y-1)*borderedEdgeLen];
+			const vector3d &y2 = vrts[x + (y+1)*borderedEdgeLen];
 			const vector3d n = ((x2-x1).Cross(y2-y1)).Normalized();
 			assert(nrm!=&normals[edgeLen*edgeLen]);
 			*(nrm++) = vector3f(n);
 
 			// color
 			const vector3d p = GetSpherePoint(v0, v1, v2, v3, (x-BORDER_SIZE)*fracStep, (y-BORDER_SIZE)*fracStep);
+			setColour(*col, pTerrain->GetColor(p, height, n));
+			assert(col!=&colors[edgeLen*edgeLen]);
+			++col;
+		}
+	}
+	assert(hts==&heights[edgeLen*edgeLen]);
+	assert(nrm==&normals[edgeLen*edgeLen]);
+	assert(col==&colors[edgeLen*edgeLen]);
+}
+
+// Generates full-detail vertices, and also non-edge normals and colors 
+void BasePatchJob::GenerateBorderedData(
+	double *borderHeights, vector3d *borderVertexs,
+	const vector3d &v0,
+	const vector3d &v1,
+	const vector3d &v2,
+	const vector3d &v3,
+	const int edgeLen,
+	const double fracStep,
+	const Terrain *pTerrain) const
+{
+	const int borderedEdgeLen = (edgeLen * 2) + (BORDER_SIZE * 2);
+	const int numBorderedVerts = borderedEdgeLen*borderedEdgeLen;
+
+	// generate heights plus a N=BORDER_SIZE unit border
+	double *bhts = borderHeights;
+	vector3d *vrts = borderVertexs;
+	for ( int y = -BORDER_SIZE; y < (borderedEdgeLen - BORDER_SIZE); y++ ) {
+		const double yfrac = double(y) * (fracStep*0.5);
+		for ( int x = -BORDER_SIZE; x < (borderedEdgeLen - BORDER_SIZE); x++ ) {
+			const double xfrac = double(x) * (fracStep*0.5);
+			const vector3d p = GetSpherePoint(v0, v1, v2, v3, xfrac, yfrac);
+			const double height = pTerrain->GetHeight(p);
+			assert(height >= 0.0f && height <= 1.0f);
+			*(bhts++) = height;
+			*(vrts++) = p * (height + 1.0);
+		}
+	}
+	assert(bhts == &borderHeights[numBorderedVerts]);
+}
+
+void BasePatchJob::GenerateSubPatchData(
+	double *heights, vector3f *normals, Color3ub *colors, 
+	double *borderHeights, vector3d *borderVertexs,
+	const vector3d &v0,
+	const vector3d &v1,
+	const vector3d &v2,
+	const vector3d &v3,
+	const int edgeLen,
+	const int xoff, 
+	const int yoff,
+	const int borderedEdgeLen,
+	const double fracStep,
+	const Terrain *pTerrain) const
+{
+	// Generate normals & colors for vertices
+	vector3d *vrts = borderVertexs;
+	Color3ub *col = colors;
+	vector3f *nrm = normals;
+	double *hts = heights;
+
+	// step over the small square
+	for (int y=0; y<edgeLen; y++) {
+		const int by = (y + BORDER_SIZE) + yoff;
+		for (int x=0; x<edgeLen; x++) {
+			const int bx = (x + BORDER_SIZE) + xoff;
+
+			// height
+			const double height = borderHeights[bx + (by * borderedEdgeLen)];
+			assert(hts!=&heights[edgeLen*edgeLen]);
+			*(hts++) = height;
+
+			// normal
+			const vector3d &x1 = vrts[(bx - 1) + (by*borderedEdgeLen)];
+			const vector3d &x2 = vrts[(bx + 1) + (by*borderedEdgeLen)];
+			const vector3d &y1 = vrts[bx + ((by - 1)*borderedEdgeLen)];
+			const vector3d &y2 = vrts[bx + ((by + 1)*borderedEdgeLen)];
+			const vector3d n = ((x2 - x1).Cross(y2 - y1)).Normalized();
+			assert(nrm!=&normals[edgeLen*edgeLen]);
+			*(nrm++) = vector3f(n);
+
+			// color
+			const vector3d p = GetSpherePoint(v0, v1, v2, v3, x*fracStep, y*fracStep);
 			setColour(*col, pTerrain->GetColor(p, height, n));
 			assert(col!=&colors[edgeLen*edgeLen]);
 			++col;
@@ -135,6 +223,11 @@ void QuadPatchJob::OnRun()    // RUNS IN ANOTHER THREAD!! MUST BE THREAD SAFE!
 	BasePatchJob::OnRun();
 
 	const SQuadSplitRequest &srd = *mData;
+
+	GenerateBorderedData(srd.borderHeights.get(), srd.borderVertexs.get(),
+			srd.v0, srd.v1, srd.v2, srd.v3,
+			srd.edgeLen, srd.fracStep, srd.pTerrain.Get());
+
 	const vector3d v01	= (srd.v0+srd.v1).Normalized();
 	const vector3d v12	= (srd.v1+srd.v2).Normalized();
 	const vector3d v23	= (srd.v2+srd.v3).Normalized();
@@ -148,13 +241,24 @@ void QuadPatchJob::OnRun()    // RUNS IN ANOTHER THREAD!! MUST BE THREAD SAFE!
 		{v30,		cn,			v23,		srd.v3}
 	};
 
+	const int borderedEdgeLen = (srd.edgeLen*2)+(BORDER_SIZE*2);
+	const int numBorderedVerts = borderedEdgeLen*borderedEdgeLen;
+	const int offxy[4][2] = {
+		{0,0},
+		{srd.edgeLen,0},
+		{srd.edgeLen,srd.edgeLen},
+		{0,srd.edgeLen}
+	};
+
 	SQuadSplitResult *sr = new SQuadSplitResult(srd.patchID.GetPatchFaceIdx(), srd.depth);
 	for (int i=0; i<4; i++)
 	{
 		// fill out the data
-		GenerateMesh(srd.heights[i], srd.normals[i], srd.colors[i], srd.borderHeights[i].get(), srd.borderVertexs[i].get(),
+		GenerateSubPatchData(srd.heights[i], srd.normals[i], srd.colors[i], srd.borderHeights.get(), srd.borderVertexs.get(),
 			vecs[i][0], vecs[i][1], vecs[i][2], vecs[i][3], 
-			srd.edgeLen, srd.fracStep, srd.pTerrain.Get());
+			srd.edgeLen, offxy[i][0], offxy[i][1], 
+			borderedEdgeLen, srd.fracStep, srd.pTerrain.Get());
+
 		// add this patches data
 		sr->addResult(i, srd.heights[i], srd.normals[i], srd.colors[i], 
 			vecs[i][0], vecs[i][1], vecs[i][2], vecs[i][3], 

--- a/src/GeoPatchJobs.h
+++ b/src/GeoPatchJobs.h
@@ -214,22 +214,6 @@ public:
 	virtual void OnRun() {}    // RUNS IN ANOTHER THREAD!! MUST BE THREAD SAFE!
 	virtual void OnFinish() {}
 	virtual void OnCancel() {}
-
-protected:
-
-	// Generates full-detail vertices, and also non-edge normals and colors 
-	void GenerateMesh(double *heights, vector3f *normals, Color3ub *colors, double *borderHeights, vector3d *borderVertexs,
-		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
-		const int edgeLen, const double fracStep, const Terrain *pTerrain) const;
-
-	// Generates full-detail vertices, and also non-edge normals and colors 
-	void GenerateBorderedData(double *borderHeights, vector3d *borderVertexs,
-		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
-		const int edgeLen, const double fracStep, const Terrain *pTerrain) const;
-	
-	void GenerateSubPatchData(double *heights, vector3f *normals, Color3ub *colors, double *borderHeights, vector3d *borderVertexs,
-		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
-		const int edgeLen, const int xoff, const int yoff, const int borderedEdgeLen, const double fracStep, const Terrain *pTerrain) const;
 };
 
 // ********************************************************************************
@@ -245,6 +229,11 @@ public:
 	virtual void OnFinish();   // runs in primary thread of the context
 
 private:
+	// Generates full-detail vertices, and also non-edge normals and colors 
+	void GenerateMesh(double *heights, vector3f *normals, Color3ub *colors, double *borderHeights, vector3d *borderVertexs,
+		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
+		const int edgeLen, const double fracStep, const Terrain *pTerrain) const;
+
 	std::unique_ptr<SSingleSplitRequest> mData;
 	SSingleSplitResult *mpResults;
 };
@@ -262,6 +251,15 @@ public:
 	virtual void OnFinish();   // runs in primary thread of the context
 
 private:
+	// Generates full-detail vertices, and also non-edge normals and colors 
+	void GenerateBorderedData(double *borderHeights, vector3d *borderVertexs,
+		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
+		const int edgeLen, const double fracStep, const Terrain *pTerrain) const;
+	
+	void GenerateSubPatchData(double *heights, vector3f *normals, Color3ub *colors, double *borderHeights, vector3d *borderVertexs,
+		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
+		const int edgeLen, const int xoff, const int yoff, const int borderedEdgeLen, const double fracStep, const Terrain *pTerrain) const;
+
 	std::unique_ptr<SQuadSplitRequest> mData;
 	SQuadSplitResult *mpResults;
 };

--- a/src/GeoPatchJobs.h
+++ b/src/GeoPatchJobs.h
@@ -15,6 +15,8 @@
 
 class GeoSphere;
 
+#define BORDER_SIZE 1
+
 class SBaseRequest {
 public:
 	SBaseRequest(const vector3d &v0_, const vector3d &v1_, const vector3d &v2_, const vector3d &v3_, const vector3d &cn,
@@ -51,7 +53,7 @@ public:
 		: SBaseRequest(v0_, v1_, v2_, v3_, cn, depth_, sysPath_, patchID_, edgeLen_, fracStep_, pTerrain_)
 	{
 		const int numVerts = NUMVERTICES(edgeLen_);
-		const int numBorderedVerts = NUMVERTICES(edgeLen_+2);
+		const int numBorderedVerts = NUMVERTICES(edgeLen_+(BORDER_SIZE*2));
 		for( int i=0 ; i<4 ; ++i )
 		{
 			heights[i] = new double[numVerts];
@@ -89,7 +91,7 @@ public:
 		normals = new vector3f[numVerts];
 		colors = new Color3ub[numVerts];
 		
-		const int numBorderedVerts = NUMVERTICES(edgeLen_+2);
+		const int numBorderedVerts = NUMVERTICES(edgeLen_+(BORDER_SIZE*2));
 		borderHeights.reset(new double[numBorderedVerts]);
 		borderVertexs.reset(new vector3d[numBorderedVerts]);
 	}

--- a/src/GeoPatchJobs.h
+++ b/src/GeoPatchJobs.h
@@ -53,16 +53,15 @@ public:
 		: SBaseRequest(v0_, v1_, v2_, v3_, cn, depth_, sysPath_, patchID_, edgeLen_, fracStep_, pTerrain_)
 	{
 		const int numVerts = NUMVERTICES(edgeLen_);
-		const int numBorderedVerts = NUMVERTICES(edgeLen_+(BORDER_SIZE*2));
 		for( int i=0 ; i<4 ; ++i )
 		{
 			heights[i] = new double[numVerts];
 			normals[i] = new vector3f[numVerts];
 			colors[i] = new Color3ub[numVerts];
-
-			borderHeights[i].reset(new double[numBorderedVerts]);
-			borderVertexs[i].reset(new vector3d[numBorderedVerts]);
 		}
+		const int numBorderedVerts = NUMVERTICES((edgeLen_*2)+(BORDER_SIZE*2));
+		borderHeights.reset(new double[numBorderedVerts]);
+		borderVertexs.reset(new vector3d[numBorderedVerts]);
 	}
 
 	// these are created with the request and are given to the resulting patches
@@ -71,8 +70,8 @@ public:
 	double *heights[4];
 
 	// these are created with the request but are destroyed when the request is finished
-	std::unique_ptr<double[]> borderHeights[4];
-	std::unique_ptr<vector3d[]> borderVertexs[4];
+	std::unique_ptr<double[]> borderHeights;
+	std::unique_ptr<vector3d[]> borderVertexs;
 
 protected:
 	// deliberately prevent copy constructor access
@@ -218,15 +217,20 @@ public:
 	virtual void OnCancel() {}
 
 protected:
-	// in patch surface coords, [0,1]
-	inline vector3d GetSpherePoint(const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3, const double x, const double y) const {
-		return (v0 + x*(1.0-y)*(v1-v0) + x*y*(v2-v0) + (1.0-x)*y*(v3-v0)).Normalized();
-	}
 
 	// Generates full-detail vertices, and also non-edge normals and colors 
 	void GenerateMesh(double *heights, vector3f *normals, Color3ub *colors, double *borderHeights, vector3d *borderVertexs,
 		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
 		const int edgeLen, const double fracStep, const Terrain *pTerrain) const;
+
+	// Generates full-detail vertices, and also non-edge normals and colors 
+	void GenerateBorderedData(double *borderHeights, vector3d *borderVertexs,
+		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
+		const int edgeLen, const double fracStep, const Terrain *pTerrain) const;
+	
+	void GenerateSubPatchData(double *heights, vector3f *normals, Color3ub *colors, double *borderHeights, vector3d *borderVertexs,
+		const vector3d &v0, const vector3d &v1, const vector3d &v2, const vector3d &v3,
+		const int edgeLen, const int xoff, const int yoff, const int borderedEdgeLen, const double fracStep, const Terrain *pTerrain) const;
 };
 
 // ********************************************************************************

--- a/src/GeoPatchJobs.h
+++ b/src/GeoPatchJobs.h
@@ -28,7 +28,6 @@ public:
 	{
 	}
 
-	inline int NUMVERTICES() const { return edgeLen*edgeLen; }
 	inline int NUMVERTICES(const int el) const { return el*el; }
 
 	const vector3d v0, v1, v2, v3;
@@ -59,7 +58,7 @@ public:
 			normals[i] = new vector3f[numVerts];
 			colors[i] = new Color3ub[numVerts];
 		}
-		const int numBorderedVerts = NUMVERTICES((edgeLen_*2)+(BORDER_SIZE*2));
+		const int numBorderedVerts = NUMVERTICES((edgeLen_*2)+(BORDER_SIZE*2)-1);
 		borderHeights.reset(new double[numBorderedVerts]);
 		borderVertexs.reset(new vector3d[numBorderedVerts]);
 	}


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
I had an idea to reduce the amount of work done in the QuadSplit jobs. 

Instead of generating 4 sets of patches that are `edgeLen + (borderSize * 2)`, it now generates a single large patch that is `(edgeLen * 2) + (borderSize * 2) -1` which eliminates the generation of the inner border data & the generation of one duplicate row and column of vertex data across the whole patch.

It then pulls the sub patches out of that larger soup of data which should reduce duplication and wasted generation of data.

New amount generated:
(55 * 2) + (1 * 2) - 1 = 111
111 * 111 = **12,321**

Old amount generated:
55 + (1 * 2) = 57
57 * 57 = 3,249
3,249 * 4 = **12,996**

Which is a ~5.19% decrease in the number of vertices generated.

I went ahead and did the calculation for the rest of the patch dimensions because I knew that the 5.19% improvement had to be the worst of the range :) 
Look at the improvement for the lowest detail patches which have to run on the lowest end machines!

edgeLen | New | Old | Decrease Verts %
-------------|-------------|-------------|-------------
55 | 12321 | 12996 | 5.193905817
35 | 5041 | 5476 | 7.943754565
25 | 2601 | 2916 | 10.80246914
15 | 961 | 1156 | 16.86851211
7 | 225 | 324 | **30.55555556**

This is now definitely ready for review :)
<!-- Please make sure you've read documentation on contributing -->

