### PR TITLE
Simple reduction in memory usage.

### DIFF
--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -227,6 +227,10 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 		// ----------------------------------------------------
 		// end of mapping
 		m_vertexBuffer->Unmap();
+		
+		// Don't need this anymore so throw it away
+		normals.reset();
+		colors.reset();
 
 #ifdef DEBUG_BOUNDING_SPHERES
 		RefCountedPtr<Graphics::Material> mat(Pi::renderer->CreateMaterial(Graphics::MaterialDescriptor()));


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
This is something that I should have done long ago.
We don't need the normals or color information once we've built the vertex buffer, so we can now discard it.

With the terrain details set to `Very High` and starting on Earth the mem drops from 620.5MB to 548.2MB

We could possibly discard the heights as well but I'd have to change some other logic so I'm just doing this part for now.
<!-- Please make sure you've read documentation on contributing -->


