### PR TITLE
Update attrib binding locations

### DIFF
--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -263,7 +263,9 @@ void Program::LoadShaders(const std::string &name, const std::string &defines)
 	glBindAttribLocation(m_program, 1, "a_normal");
 	glBindAttribLocation(m_program, 2, "a_color");
 	glBindAttribLocation(m_program, 3, "a_uv0");
-	glBindAttribLocation(m_program, 4, "a_transform");
+	glBindAttribLocation(m_program, 4, "a_uv1");
+	glBindAttribLocation(m_program, 5, "a_tangent");
+	glBindAttribLocation(m_program, 6, "a_transform");
 
 	glBindFragDataLocation(m_program, 0, "frag_color");
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->

The shader attribute binding locations changed some time ago, this just updates them to match those in the glsl files.

These might actually be defunct now but updating them just in case.

<!-- Please make sure you've read documentation on contributing -->
