### PR TITLE
Enhance serializer crash output

### DIFF
--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -52,7 +52,7 @@
 // "Deserialize" function under that namespace. that data returned will be
 // given back to the module
 
-void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, const char *key)
+void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, std::string key)
 {
 	static char buf[256];
 
@@ -153,15 +153,15 @@ void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, con
 				lua_pushvalue(l, idx);
 				lua_pushnil(l);
 				while (lua_next(l, -2)) {
-					const char *k = key;
-					if (!k) {
-						lua_pushvalue(l, -2);
-						k = lua_tostring(l, -1);
-						lua_pop(l, 1);
-					}
+
+					lua_pushvalue(l, -2);
+					const char *k = lua_tostring(l, -1);
+					std::string new_key = key + "." + (k? std::string(k) : "<" + std::string(lua_typename(l, lua_type(l, -1))) + ">");
+					lua_pop(l, 1);
+
 					// Copy the values to pickle, as they might be mutated by the pickling process.
-					pickle(l, -2, out, key);
-					pickle(l, -1, out, key);
+					pickle(l, -2, out, new_key);
+					pickle(l, -1, out, new_key);
 					lua_pop(l, 1);
 				}
 				lua_pop(l, 1);
@@ -177,14 +177,14 @@ void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, con
 			LuaObjectBase *lo = static_cast<LuaObjectBase*>(lua_touserdata(l, idx));
 			void *o = lo->GetObject();
 			if (!o)
-				Error("Lua serializer '%s' tried to serialize an invalid '%s' object", key, lo->GetType());
+				Error("Lua serializer '%s' tried to serialize an invalid '%s' object", key.c_str(), lo->GetType());
 
 			out += lo->Serialize();
 			break;
 		}
 
 		default:
-			Error("Lua serializer '%s' tried to serialize %s value", key, lua_typename(l, lua_type(l, idx)));
+			Error("Lua serializer '%s' tried to serialize %s value", key.c_str(), lua_typename(l, lua_type(l, idx)));
 			break;
 	}
 
@@ -374,12 +374,12 @@ void LuaSerializer::ToJson(Json::Value &jsonObj)
 
 	lua_pushnil(l);
 	while (lua_next(l, -2) != 0) {
-		lua_pushinteger(l, 1);
-		lua_gettable(l, -2);
-		pi_lua_protected_call(l, 0, 1);
-		lua_pushvalue(l, -3);
-		lua_insert(l, -2);
-		lua_settable(l, savetable);
+		lua_pushinteger(l, 1); // 1, fntable, key
+		lua_gettable(l, -2); // fn, fntable, key
+		pi_lua_protected_call(l, 0, 1); // table, fntable, key
+		lua_pushvalue(l, -3); // key, table, fntable, key
+		lua_insert(l, -2); // table, key, fntable, key
+		lua_settable(l, savetable); // fntable, key
 		lua_pop(l, 1);
 	}
 

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -29,7 +29,7 @@ private:
 	static int l_register(lua_State *l);
 	static int l_register_class(lua_State *l);
 
-	static void pickle(lua_State *l, int idx, std::string &out, const char *key = 0);
+	static void pickle(lua_State *l, int idx, std::string &out, std::string key = "");
 	static const char *unpickle(lua_State *l, const char *pos);
 };
 

--- a/src/LuaUtils.cpp
+++ b/src/LuaUtils.cpp
@@ -295,6 +295,12 @@ static bool _import(lua_State *L, const std::string &importName)
 	return true;
 }
 
+static int l_d_null_userdata(lua_State *L)
+{
+	lua_pushlightuserdata(L, nullptr);
+	return 1;
+}
+
 static int l_base_import(lua_State *L)
 {
 	if (!_import(L, luaL_checkstring(L, 1)))
@@ -443,6 +449,9 @@ void pi_lua_open_standard_base(lua_State *L)
 	// That one should NOT be trampolined, since it is intended to be used all over.
 	lua_pushcfunction(L, l_d_mode_enabled);
 	lua_setfield(L, -2, "dmodeenabled");
+
+	lua_pushcfunction(L, l_d_null_userdata);
+	lua_setfield(L, -2, "makenull");
 
 	lua_pop(L, 1); // pop the debug table
 }


### PR DESCRIPTION
I've added some output a bit more useful to the serializer crash thingy.

Also, I've added a way to shoot ourselves in the foot (feet) intentionally with the debug.makenull() function to create a NULL light userdata. That's quite useful to provoke a crash.