### PR TITLE
fix pattern selection if no pattern present

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -701,7 +701,7 @@ local createTargetShip = function (mission)
 	ship:SetSkin(skin)
 	local model = Engine.GetModel(shipdef.modelName)
 	local pattern
-	if model.numPatterns == 1 then
+	if model.numPatterns <= 1 then
 		pattern = 0
 	else
 		local pattern = rand:Integer(0,model.numPatterns-1)


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This fixes a bug mentioned in #3852 (but is unrelated to #3852), whereby ships that don't have any patterns associated with them crash the game when used as SAR mission targets. It was an oversight by me initially. I thought I had checked to see that every (non-police) ship has at least one pattern. But the Bowfin fighter and the Deep Space Miner do not.
