### PR TITLE
Ye, tabs be gone!

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,17 @@ root = true
 
 # all files, globally use these rules:
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
+trim_trailing_whitespace = true
+
+# but definitly tabs for:
+[*.{cpp,h,lua,am}]
+indent_style = tab
+
+# we apparently use spaces for:
+[*.{json,txt,md,yml}]
+indent_style = space


### PR DESCRIPTION
It appears that most of our non-C++/Lua source files are using spaces for
indentation, (except Makefile.am). Added rules to accommodate that, and fix
wrong indentation in Changelog.txt when using github editor.