### PR TITLE
Docking fee Text update (since station won't refuel you)

### DIFF
--- a/data/lang/module-stationrefuelling/en.json
+++ b/data/lang/module-stationrefuelling/en.json
@@ -1,10 +1,10 @@
 {
    "THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH" : {
       "description" : "",
-      "message" : "This is {station}. You do not have enough for your docking fee of {fee}. Your fuel has been witheld."
+      "message" : "This is {station}. You do not have enough money for your docking fee of {fee}."
    },
    "WELCOME_ABOARD_STATION_FEE_DEDUCTED" : {
       "description" : "",
-      "message" : "Welcome aboard {station}. Your docking and fuelling fee of {fee} has been deducted."
+      "message" : "Welcome aboard {station}. Your docking of {fee} has been deducted."
    }
 }


### PR DESCRIPTION
This fixes the english lang file for the autorefuel module, so the station doesn't talk about fuel fee, only docking fee. Translations will need to be updated on transifex.
Because since #3837 the stations won't fill your tanks, just greet you since they are greedy and want to sell you their precious Hydrogen. :) Which makes sense.
There was an imgui.ini file in the first commit, because my git-fu is still weak, but it should be removed now.

One design question that relates here: should anything happen if you don't have the money to pay for the docking fee? It's a very rare case anyhow, but not entirely pointless.

closes #3862 

