### PR TITLE
fix navbutton crash without target

### DIFF
--- a/data/libs/ui/NavButton.lua
+++ b/data/libs/ui/NavButton.lua
@@ -17,19 +17,21 @@ function NavButton.New (text, target)
 	}
 	self.widget = ui:HBox(10):PackEnd({ self.button, self.label })
 
-	self.widget.onClick:Connect(function ()
-			if self.target:isa("Body") and self.target:IsDynamic() then
-				Game.player:SetNavTarget(self.target)
-			elseif self.target:IsSameSystem(Game.system.path) then
-				if self.target.bodyIndex then
-					Game.player:SetNavTarget(Space.GetBody(self.target.bodyIndex))
+	if target then
+		self.widget.onClick:Connect(function ()
+				if self.target:isa("Body") and self.target:IsDynamic() then
+					Game.player:SetNavTarget(self.target)
+				elseif self.target:IsSameSystem(Game.system.path) then
+					if self.target.bodyIndex then
+						Game.player:SetNavTarget(Space.GetBody(self.target.bodyIndex))
+					end
+				else
+					Game.player:SetHyperspaceTarget(self.target:GetStarSystem().path)
+					-- XXX we should do something useful here
+					-- e.g. switch to the sector map or just beep
 				end
-			else
-				Game.player:SetHyperspaceTarget(self.target:GetStarSystem().path)
-				-- XXX we should do something useful here
-				-- e.g. switch to the sector map or just beep
-			end
-	end)
+		end)
+	end
 
 	setmetatable(self, {
 		__index	= NavButton,

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -2119,7 +2119,7 @@ local onClick = function (mission)
 
 	-- navbutton target (system if out-of-system jump, target ship if in system)
 	local navbutton_target
-	if mission.planet_target:IsSameSystem(Game.system.path) then
+	if not Game.system or mission.planet_target:IsSameSystem(Game.system.path) then
 		navbutton_target = mission.target
 	else
 		navbutton_target = mission.planet_target


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

NavButton was causing a game crash when created without a valid target (for example when you click on it during a long hyperjump), as was the Search&Rescue script (when checking mission details during hyperjump).

This fixes both scripts.

