### PR TITLE
Render the navlights for orbital stations

### DIFF
--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -92,7 +92,8 @@ NavLights::NavLights(SceneGraph::Model *model, float period)
 	const std::vector<Node*> &results = lightFinder.GetResults();
 
 	//attach light billboards
-	for (unsigned int i=0; i < results.size(); i++) {
+	for (unsigned int i=0; i < results.size(); i++) 
+	{
 		MatrixTransform *mt = dynamic_cast<MatrixTransform*>(results.at(i));
 		assert(mt);
 		Billboard *bblight = new Billboard(m_billboardTris, renderer, BILLBOARD_SIZE);

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -602,6 +602,7 @@ void SpaceStation::Render(Graphics::Renderer *r, const Camera *camera, const vec
 	if (!b->IsType(Object::PLANET)) {
 		// orbital spaceport -- don't make city turds or change lighting based on atmosphere
 		RenderModel(r, camera, viewCoords, viewTransform);
+		m_navLights->Render(r);
 		r->GetStats().AddToStatCount(Graphics::Stats::STAT_SPACESTATIONS, 1);
 	} else {
 		// don't render city if too far away


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
This fixes #3873 where somehow the call to render the navlights had gone missing.
This meant that instead of being flushed at the end of each frame they were simply accumulating until the game exceeded the 2GB barrier on 32-bit processes.
<!-- Please make sure you've read documentation on contributing -->


