### PR TITLE
Fix orphaned connections in WorldView

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -330,9 +330,9 @@ void WorldView::InitObject()
 		Pi::onMouseWheel.connect(sigc::mem_fun(this, &WorldView::MouseWheel));
 
 	Pi::player->GetPlayerController()->SetMouseForRearView(GetCamType() == CAM_INTERNAL && m_internalCameraController->GetMode() == InternalCameraController::MODE_REAR);
-	KeyBindings::toggleHudMode.onPress.connect(sigc::mem_fun(this, &WorldView::OnToggleLabels));
-	KeyBindings::increaseTimeAcceleration.onPress.connect(sigc::mem_fun(this, &WorldView::OnRequestTimeAccelInc));
-	KeyBindings::decreaseTimeAcceleration.onPress.connect(sigc::mem_fun(this, &WorldView::OnRequestTimeAccelDec));
+	m_onToggleHudModeCon = KeyBindings::toggleHudMode.onPress.connect(sigc::mem_fun(this, &WorldView::OnToggleLabels));
+	m_onIncTimeAccelCon = KeyBindings::increaseTimeAcceleration.onPress.connect(sigc::mem_fun(this, &WorldView::OnRequestTimeAccelInc));
+	m_onDecTimeAccelCon = KeyBindings::decreaseTimeAcceleration.onPress.connect(sigc::mem_fun(this, &WorldView::OnRequestTimeAccelDec));
 }
 
 WorldView::~WorldView()
@@ -341,6 +341,9 @@ WorldView::~WorldView()
 	m_onPlayerChangeTargetCon.disconnect();
 	m_onChangeFlightControlStateCon.disconnect();
 	m_onMouseWheelCon.disconnect();
+	m_onToggleHudModeCon.disconnect();
+	m_onIncTimeAccelCon.disconnect();
+	m_onDecTimeAccelCon.disconnect();
 }
 
 void WorldView::SaveToJson(Json::Value &jsonObj)

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -190,7 +190,10 @@ private:
 	sigc::connection m_onPlayerChangeTargetCon;
 	sigc::connection m_onChangeFlightControlStateCon;
 	sigc::connection m_onMouseWheelCon;
-
+	sigc::connection m_onToggleHudModeCon;
+	sigc::connection m_onIncTimeAccelCon;
+	sigc::connection m_onDecTimeAccelCon;
+	
 	Gui::LabelSet *m_bodyLabels;
 	std::map<Body*,vector3d> m_projectedPos;
 


### PR DESCRIPTION
Fixes the sigc connections for the HUD toggle (tab key) and time accel keyboard shortcuts (PgDn, PgUp) not being disconnected in the WorldView destructor. WorldView is deleted and re-created each time a game is loaded or started, so invalid callbacks would accumulate.

Unlike my initial impression, all three invalid callbacks should be harmless, other than causing #3875. The HUD toggle has no effect unless `Pi::GetView() == this`. It's possible that there are other more dangerous orphaned connections in Pioneer, but I couldn't find any.
