### PR TITLE
Remove GL buffer init fills, add init checks

### DIFF
--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -158,6 +158,7 @@ void VertexBuffer::Unmap()
 		if (m_mapMode == BUFFER_MAP_WRITE) {
 			const GLsizei dataSize = m_desc.numVertices * m_desc.stride;
 			glBindBuffer(GL_ARRAY_BUFFER, m_buffer);
+			glBufferData(GL_ARRAY_BUFFER, dataSize, 0, GL_DYNAMIC_DRAW);
 			glBufferSubData(GL_ARRAY_BUFFER, 0, dataSize, m_data);
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 		}
@@ -403,6 +404,7 @@ void IndexBuffer::Unmap()
 	} else {
 		if (m_mapMode == BUFFER_MAP_WRITE) {
 			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_buffer);
+			glBufferData(GL_ARRAY_BUFFER, sizeof(Uint32) * m_size, 0, GL_DYNAMIC_DRAW);
 			glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, sizeof(Uint32) * m_size, m_data);
 			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 		}
@@ -470,6 +472,7 @@ void InstanceBuffer::Unmap()
 	} else {
 		if (m_mapMode == BUFFER_MAP_WRITE) {
 			glBindBuffer(GL_ARRAY_BUFFER, m_buffer);
+			glBufferData(GL_ARRAY_BUFFER, sizeof(matrix4x4f) * m_size, 0, GL_DYNAMIC_DRAW);
 			glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(matrix4x4f) * m_size, m_data.get());
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 		}

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -10,10 +10,12 @@ namespace Graphics { namespace OGL {
 
 class GLBufferBase {
 public:
+	GLBufferBase() : m_written(false) {}
 	GLuint GetBuffer() const { return m_buffer; }
 
 protected:
 	GLuint m_buffer;
+	bool m_written;			// to check for invalid data rendering
 };
 
 class VertexBuffer : public Graphics::VertexBuffer, public GLBufferBase {


### PR DESCRIPTION
## Purpose
Fixes a severe performance problem on at least some AMD GL drivers. To avoid potential undefined behaviour, the GL buffer code used to zero-fill the buffers on creation. This meant that a newly-created buffer was often written multiple times per frame, which causes a synchronization stall on some GL drivers even when the buffer wasn't used in a draw call.

To replace the undefined behaviour functionality, asserts were added to the Bind calls to check whether buffers are used before being written.

## Related problems
The two heading labels are forced to update every frame by the `UI::Label::Layout` function. `UI::Label::Draw` then creates a new vertex buffer and draws with it immediately. This patch works around the performance problem, but UI elements should not be updated unnecessarily.

`StaticGeometry::Render` causes a related problem by writing to the same instance buffer each frame. This wouldn't be a problem if frame times were reasonably constant, but Pioneer has asynchronous rendering and physics, so a common pattern looks like this:

1. Short render frame
2. Long render frame due to GPU sync stall
3. Physics frame x3 or x4
4. Repeat 

Double-buffering the instance buffers (or even recreating them every frame as a dirty hack) partially works around the problem and increases nominal frame rates, but a more rigorous approach to physics/render interleaving is necessary for smooth rendering.