### PR TITLE
Optimisation: Reserve VA capacity correctly for Gui::TextLayout

### DIFF
--- a/src/gui/GuiTextLayout.cpp
+++ b/src/gui/GuiTextLayout.cpp
@@ -129,8 +129,19 @@ void TextLayout::Update(const float width, const Color &color)
 
 		Color c = color;
 
+		// vertex array pre-assignment, because TextureFont botches it
+		// over-reserves for markup, but we don't care
+		int numChars = 0;
 		std::list<word_t>::const_iterator wpos = this->words.begin();
+		for (; wpos != this->words.end(); ++wpos)
+			if ((*wpos).word) numChars += strlen((*wpos).word);
+
+		va.position.reserve(6 * numChars);
+		va.diffuse.reserve(6 * numChars);
+		va.uv0.reserve(6 * numChars);
+
 		// build lines of text
+		wpos = this->words.begin();
 		while (wpos != this->words.end()) {
 			float len = 0;
 			int num = 0;

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -200,11 +200,9 @@ void TextureFont::PopulateString(Graphics::VertexArray &va, const std::string &s
 	float py = y;
 
 	// we know how many we're adding so reserve space ahead of time
-	if (!va.position.capacity()) {
-		va.position.reserve(str.size() * 6);
-		va.diffuse.reserve(str.size() * 6);
-		va.uv0.reserve(str.size() * 6);
-	}
+	va.position.reserve(va.position.size() + str.size() * 6);
+	va.diffuse.reserve(va.diffuse.size() + str.size() * 6);
+	va.uv0.reserve(va.uv0.size() + str.size() * 6);
 
 	// add all of the glyphs individually
 	int i = 0;
@@ -244,11 +242,9 @@ Color TextureFont::PopulateMarkup(Graphics::VertexArray &va, const std::string &
 	if(str.empty()) return Color::BLACK;
 
 	// we know how many we're adding so reserve space ahead of time
-	if (!va.position.capacity()) {
-		va.position.reserve(str.size() * 6);
-		va.diffuse.reserve(str.size() * 6);
-		va.uv0.reserve(str.size() * 6);
-	}
+	va.position.reserve(va.position.size() + str.size() * 6);
+	va.diffuse.reserve(va.diffuse.size() + str.size() * 6);
+	va.uv0.reserve(va.uv0.size() + str.size() * 6);
 
 	float px = x;
 	float py = y;

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -200,9 +200,11 @@ void TextureFont::PopulateString(Graphics::VertexArray &va, const std::string &s
 	float py = y;
 
 	// we know how many we're adding so reserve space ahead of time
-	va.position.reserve(str.size() * 6);
-	va.diffuse.reserve(str.size() * 6);
-	va.uv0.reserve(str.size() * 6);
+	if (!va.position.capacity()) {
+		va.position.reserve(str.size() * 6);
+		va.diffuse.reserve(str.size() * 6);
+		va.uv0.reserve(str.size() * 6);
+	}
 
 	// add all of the glyphs individually
 	int i = 0;
@@ -242,9 +244,11 @@ Color TextureFont::PopulateMarkup(Graphics::VertexArray &va, const std::string &
 	if(str.empty()) return Color::BLACK;
 
 	// we know how many we're adding so reserve space ahead of time
-	va.position.reserve(str.size() * 6);
-	va.diffuse.reserve(str.size() * 6);
-	va.uv0.reserve(str.size() * 6);
+	if (!va.position.capacity()) {
+		va.position.reserve(str.size() * 6);
+		va.diffuse.reserve(str.size() * 6);
+		va.uv0.reserve(str.size() * 6);
+	}
 
 	float px = x;
 	float py = y;


### PR DESCRIPTION
TextureFont attempts to reserve capacity in vertex arrays, but it doesn't work in cases where the Populate functions are called with a vertex array that already contains vertices. `Gui::TextLayout` populates the vertex array word-by-word, so this happens routinely.

It's not a huge gain for WorldView, but it's significant when there's a lot of text on-screen. With the debug text output (the lower five lines use TextLayout), `TextureFont::PopulateMarkup` CPU usage drops from 8% to 5% here.