### PR TITLE
Disable the modelcompiler multithreading.

### DIFF
--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -261,6 +261,11 @@ start:
 			}
 
 			SetupRenderer();
+#if 1
+			for (auto &modelName : list_model) {
+				RunCompiler(modelName.first, modelName.second, isInPlace);
+			}
+#else
 			std::deque<Job::Handle> handles;
 			for (auto &modelName : list_model) {
 				handles.push_back( asyncJobQueue->Queue(new CompileJob(modelName.first, modelName.second, isInPlace)) );
@@ -275,6 +280,7 @@ start:
 				if(!hasJobs)
 					break;
 			}
+#endif
 			break;
 		}
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
It's clear that there are some issues with the modelcompilers output when using multithreading so disable it for now.

This leaves the code in place for future re-use or fixing.
<!-- Please make sure you've read documentation on contributing -->


