### PR TITLE
Fix undefined renderer bug in SGM LOD loader

### DIFF
--- a/src/scenegraph/LOD.cpp
+++ b/src/scenegraph/LOD.cpp
@@ -3,6 +3,7 @@
 
 #include "LOD.h"
 #include "NodeVisitor.h"
+#include "BaseLoader.h"
 #include "NodeCopyCache.h"
 #include "StringF.h"
 #include "graphics/Graphics.h"
@@ -113,7 +114,7 @@ void LOD::Save(NodeDatabase &db)
 
 LOD* LOD::Load(NodeDatabase &db)
 {
-    LOD* lod = new LOD(db.renderer);
+	LOD* lod = new LOD(db.loader->GetRenderer());
 	const Uint32 numLevels = db.rd->Int32();
 	for (Uint32 i = 0; i < numLevels; i++)
 		lod->m_pixelSizes.push_back(db.rd->Int32());

--- a/src/scenegraph/Node.h
+++ b/src/scenegraph/Node.h
@@ -59,7 +59,7 @@ struct RenderData
 struct NodeDatabase {
 	Serializer::Writer *wr;
 	Serializer::Reader *rd;
-	Graphics::Renderer *renderer;
+//	Graphics::Renderer *renderer;
 	Model *model;
 	std::vector<std::pair<std::string, RefCountedPtr<Graphics::Material> > > *materials;
 	BaseLoader *loader;


### PR DESCRIPTION
`BinaryConverter::LoadNode` never sets `db.renderer`, but `Scenegraph::LOD::Load` uses it. Other scenegraph loaders use `db.loader->GetRenderer()` instead, which is valid.

Because `Scenegraph::LOD` only accesses its renderer parameter as a null-check, the only effect of this bug is to cause buildings to disappear in some release builds. Debug builds wipe allocated memory with a non-zero value and so don't trigger the problem.
