### PR TITLE
Set ImgUI shaders to version 140 to work around junk Intel drivers

### DIFF
--- a/contrib/imgui/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
+++ b/contrib/imgui/examples/sdl_opengl3_example/imgui_impl_sdl_gl3.cpp
@@ -209,8 +209,9 @@ bool ImGui_ImplSdlGL3_CreateDeviceObjects()
     glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &last_array_buffer);
     glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &last_vertex_array);
 
+	// Specify version 140 shaders because some trash drivers fail otherwise
     const GLchar *vertex_shader =
-        "#version 330\n"
+        "#version 140\n"
         "uniform mat4 ProjMtx;\n"
         "in vec2 Position;\n"
         "in vec2 UV;\n"
@@ -225,7 +226,7 @@ bool ImGui_ImplSdlGL3_CreateDeviceObjects()
         "}\n";
 
     const GLchar* fragment_shader =
-        "#version 330\n"
+        "#version 140\n"
         "uniform sampler2D Texture;\n"
         "in vec2 Frag_UV;\n"
         "in vec4 Frag_Color;\n"


### PR DESCRIPTION
The GL driver with the following string throws an INVALID_OPERATION on ImgUI's version 330 shaders. This fixes it by setting the shader version to 140. Shouldn't cause any issues elsewhere.

> OpenGL version 3.1 (Core Profile) Mesa 10.1.3, running on Intel Open Source Technology Center Mesa DRI Intel(R) Sandybridge Desktop

Fixes #3881