### PR TITLE
Switch UI labels to dynamic VBs

### DIFF
--- a/src/ui/Label.cpp
+++ b/src/ui/Label.cpp
@@ -58,7 +58,7 @@ void Label::Draw()
 		m_font = GetContext()->GetFont(GetFont());
 		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 		m_font->PopulateString(va, m_text, 0.0f, 0.0f, finalColor);
-		m_vbuffer.Reset( m_font->CreateVertexBuffer(va, true) );
+		m_vbuffer.Reset( m_font->CreateVertexBuffer(va, false) );		// too frequent for static
 		m_bNeedsUpdating = false;
 		m_bPrevDisabled = IsDisabled();
 		m_prevOpacity = opacity;


### PR DESCRIPTION
The (new-)UI labels currently use static vertex buffers for text, but replace them each frame regardless of whether they were changed or moved. Writing to static vertex buffers is extremely slow on AMD GL drivers. It's so bad that the two WorldView labels (heading & pitch) drop overall frame rates by ~40% without this patch.

NVidia drivers probably don't care: Last time I checked, they simply ignored buffer hints, and if they did use a static buffer then they'd probably use it in a less retarded manner.

This is part-workaround, as the layout code shouldn't be causing the labels to be updated each frame when nothing changes. However, when flying, the labels would often need to be updated regularly anyway, so static buffers are inappropriate.

Fixes #3417, maybe. Patch #3878 also sped up most text rendering substantially, and #3877 is necessary on AMD drivers in addition to this patch.