### PR TITLE
Error on non-existing translations.

### DIFF
--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -199,6 +199,10 @@
       "description" : "",
       "message" : "Max scan range exceeded:"
    },
+   "PASSENGER_CABIN" : {
+      "description" : "",
+      "message" : "Passenger cabin"
+   },
    "PLANETSCANNER" : {
       "description" : "Scans the nearest body for resources",
       "message" : "Body scan"

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -46,7 +46,7 @@ function EquipType.New (specs)
 	end
 	local l = Lang.GetResource(obj.l10n_resource)
 	obj.volatile = {
-		description = l[obj.l10n_key.."_DESCRIPTION"] or "",
+		description = l:get(obj.l10n_key.."_DESCRIPTION") or "",
 		name = l[obj.l10n_key] or ""
 	}
 	setmetatable(obj, EquipType.meta)

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -272,7 +272,7 @@ end
 local getNumberOfFlavours = function (str)
 	local num = 1
 
-	while l[str .. "_" .. num] do
+	while l:get(str .. "_" .. num) do
 		num = num + 1
 	end
 	return num - 1

--- a/data/modules/CrewContracts/CrewContracts.lua
+++ b/data/modules/CrewContracts/CrewContracts.lua
@@ -14,6 +14,7 @@ local Timer = import("Timer")
 -- on stations, and handles periodic events such as their wages.
 
 local l = Lang.GetResource("module-crewcontracts")
+local lui = Lang.GetResource("ui-core")
 
 local wage_period = 604800 -- a week of seconds
 
@@ -397,10 +398,10 @@ local onCreateBB = function (station)
 									hopefulCrew.navigation,
 									hopefulCrew.sensors)
 		if maxScore > 45 then
-			if hopefulCrew.engineering == maxScore then hopefulCrew.title = l.SHIPS_ENGINEER end
-			if hopefulCrew.piloting == maxScore then hopefulCrew.title = l.PILOT end
-			if hopefulCrew.navigation == maxScore then hopefulCrew.title = l.NAVIGATOR end
-			if hopefulCrew.sensors == maxScore then hopefulCrew.title = l.SENSORS_AND_DEFENCE end
+			if hopefulCrew.engineering == maxScore then hopefulCrew.title = lui.SHIPS_ENGINEER end
+			if hopefulCrew.piloting == maxScore then hopefulCrew.title = lui.PILOT end
+			if hopefulCrew.navigation == maxScore then hopefulCrew.title = lui.NAVIGATOR end
+			if hopefulCrew.sensors == maxScore then hopefulCrew.title = lui.SENSORS_AND_DEFENCE end
 		end
 		table.insert(nonPersistentCharactersForCrew[station],hopefulCrew)
 	end

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -328,7 +328,7 @@ local getNumberOfFlavours = function (str)
 	-- Returns the number of flavours of the given string (assuming first flavour has suffix '_1').
 	-- Taken from CargoRun.lua.
 	local num = 1
-	while l[str .. "_" .. num] do
+	while l:get(str .. "_" .. num) do
 		num = num + 1
 	end
 	return num - 1

--- a/src/LuaLang.cpp
+++ b/src/LuaLang.cpp
@@ -10,7 +10,27 @@
 
 static int _resource_index(lua_State *l)
 {
-	return luaL_error(l, "unknown translation token: %s", lua_tostring(l, 2));
+	const char *token = lua_tostring(l, 2);
+	lua_pushstring(l, "resourceName");
+	lua_gettable(l, -3);
+	const char *resourceName = lua_tostring(l, -1);
+	lua_pop(l, 1);
+	lua_pushstring(l, "langCode");
+	lua_gettable(l, -3);
+	const char *langCode = lua_tostring(l, -1);
+	lua_pop(l, 1);
+	return luaL_error(l, "missing translation token: `%s' in resource `%s', language code `%s'.", token, resourceName, langCode);
+}
+
+static int _resource_newindex(lua_State *l)
+{
+	return luaL_error(l, "not allowed to add new translation tokens on-the-fly");
+}
+
+static int _get(lua_State *l)
+{
+	lua_rawget(l, -2);
+	return 1;
 }
 
 static int l_lang_get_resource(lua_State *l)
@@ -45,6 +65,12 @@ static int l_lang_get_resource(lua_State *l)
 	}
 
 	lua_newtable(l);
+	lua_pushstring(l, "langCode");
+	lua_pushstring(l, langCode.c_str());
+	lua_settable(l, -3);
+	lua_pushstring(l, "resourceName");
+	lua_pushstring(l, resourceName.c_str());
+	lua_settable(l, -3);
 
 	for (auto i : res.GetStrings()) {
 		const std::string token(i.first);
@@ -54,9 +80,16 @@ static int l_lang_get_resource(lua_State *l)
 		lua_rawset(l, -3);
 	}
 
+	lua_pushstring(l, "get");
+	lua_pushcfunction(l, _get);
+	lua_rawset(l, -3);
+
 	lua_newtable(l);
-	lua_pushstring(l, "__newindex");
+	lua_pushstring(l, "__index");
 	lua_pushcfunction(l, _resource_index);
+	lua_rawset(l, -3);
+	lua_pushstring(l, "__newindex");
+	lua_pushcfunction(l, _resource_newindex);
 	lua_rawset(l, -3);
 	lua_setmetatable(l, -2);
 


### PR DESCRIPTION
Add missing token PASSENGER_CABIN to equipment-core.

Use l:get from now on to get the translation or nil (no error if an entry
doesn't exist)

If a translation doesn't exist, the missing token and the resource and language
code it was supposed to be in are shown:

error: [string "[T] @modules/CrewContracts/CrewContracts.lua"]:402: missing translation token: `NAVIGATOR' in resource `module-crewcontracts', language code `en'.
stack traceback:
	[C]: in function '__index'
	[string "[T] @modules/CrewContracts/CrewContracts.lua"]:402: in function 'cb'
	[string "[T] @libs/Event.lua"]:34: in function '?'
	[string "[T] @libs/Event.lua"]:185: in function <[string "[T] @libs/Event.lua"]:180>