### PR TITLE
Provide config flag and warning to work around Intel pointsprite bug

### DIFF
--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -54,6 +54,7 @@ GameConfig::GameConfig(const map_string &override_)
 #endif
 	map["EnableGLDebug"] = "0";
 	map["EnableGPUJobs"] = "1";
+	map["GL3ForwardCompatible"] = "1";
 
 	Load();
 

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -467,6 +467,7 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 	videoSettings.useTextureCompression = (config->Int("UseTextureCompression") != 0);
 	videoSettings.useAnisotropicFiltering = (config->Int("UseAnisotropicFiltering") != 0);
 	videoSettings.enableDebugMessages = (config->Int("EnableGLDebug") != 0);
+	videoSettings.gl3ForwardCompatible = (config->Int("GL3ForwardCompatible") != 0);
 	videoSettings.iconFile = OS::GetIconFilename();
 	videoSettings.title = "Pioneer";
 

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -27,6 +27,7 @@ namespace Graphics {
 		bool useTextureCompression;
 		bool useAnisotropicFiltering;
 		bool enableDebugMessages;
+		bool gl3ForwardCompatible;
 		int vsync;
 		int requestedSamples;
 		int height;

--- a/src/graphics/WindowSDL.h
+++ b/src/graphics/WindowSDL.h
@@ -22,7 +22,7 @@ public:
 
     SDL_Window *GetSDLWindow() const { return m_window; }
 private:
-	bool CreateWindowAndContext(const char *name, int w, int h, bool fullscreen, bool hidden, int samples, int depth_bits);
+	bool CreateWindowAndContext(const char *name, const Graphics::Settings &settings, int samples, int depth_bits);
 
 	SDL_Window *m_window;
 	SDL_GLContext m_glContext;

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -86,6 +86,11 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 			);
 	}
 
+	const char *ver = (const char *)glGetString(GL_VERSION);
+	if (vs.gl3ForwardCompatible && strstr(ver, "9.17.10.4229")) {
+		Warning("Driver needs GL3ForwardCompatible=0 in config.ini to display billboards (stars, navlights etc.)");
+	}
+
 	TextureBuilder::Init();
 
 	m_viewportStack.push(Viewport());
@@ -107,6 +112,7 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 	glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
 	glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
 	glEnable(GL_PROGRAM_POINT_SIZE);
+	if (!vs.gl3ForwardCompatible) glEnable(0x8861);				// GL_POINT_SPRITE hack for compatibility contexts
 
 	glHint(GL_TEXTURE_COMPRESSION_HINT, GL_NICEST);
 	glHint(GL_FRAGMENT_SHADER_DERIVATIVE_HINT, GL_NICEST);


### PR DESCRIPTION
Fixes #3888. It's a bit messy because there's no way to detect the faulty GL driver until the context has been created, which is currently a separate code branch. It also doesn't set the config parameter itself, to avoid adding a Pi.h dependency in RendererGL.

Another approach would be to move a bunch of init code out of Graphics.cpp and give RendererGL the responsibility for creating the SDL window. In this case, the SDL window can be immediately recreated without the forward compatibility flag after the faulty driver is detected. This would also clear up some of the hacks used for the null renderer.

Another issue is that the code only detects the known-faulty Intel driver. It's quite possible that other Intel drivers have the same fault, and in this case the user will be expected to figure out that the correct workaround. The alternative detection method would require writing a point sprite to a frame buffer texture and then reading it, which may fail on various drivers for other reasons. There's also a question of how much effort we want to expend working around a driver bug.