### PR TITLE
Keep quit confirmation messages modern and stylish

### DIFF
--- a/data/lang/quitconfirmation-core/en.json
+++ b/data/lang/quitconfirmation-core/en.json
@@ -35,6 +35,10 @@
       "description" : "WIMP could mean Weakly Interacting Massive Particle, good luck translating that! Just go with the other meaning of the word, or make something else up, e.g.\"Magellan didn't quit\".",
       "message" : "Quitting is for WIMPs!"
    },
+   "MSG_18" : {
+      "description" : "Catch phrase of 2016?",
+      "message" : "Make Pioneer great again! Only losers quit, sure about this?"
+   },
    "MSG_2" : {
       "description" : "",
       "message" : "Don't go now, there's a pirate waiting for you in the other program."

--- a/data/ui/QuitConfirmation.lua
+++ b/data/ui/QuitConfirmation.lua
@@ -7,7 +7,7 @@ local Lang = import("Lang")
 local ui = Engine.ui
 local l = Lang.GetResource("quitconfirmation-core")
 
-local max_flavours = 17
+local max_flavours = 18
 
 ui.templates.QuitConfirmation = function (args)
 	local title        = l.QUIT


### PR DESCRIPTION
Also, this is not just relevant for keeping up to date with 2016 but also for
the year 2020 (if we're still here by then), when there will be a presidential
election one more time!