### PR TITLE
Add limits when using autopilot SetSpeed

### DIFF
--- a/src/ShipController.cpp
+++ b/src/ShipController.cpp
@@ -255,10 +255,14 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 			}
 
 			if (!stickySpeedKey) {
-				if (KeyBindings::increaseSpeed.IsActive())
+				if (KeyBindings::increaseSpeed.IsActive()) {
 					m_setSpeed += std::max(fabs(m_setSpeed)*0.05, 1.0);
-				if (KeyBindings::decreaseSpeed.IsActive())
+					if ( m_setSpeed > 300000000 ) m_setSpeed = 300000000;
+				}
+				if (KeyBindings::decreaseSpeed.IsActive()) {
 					m_setSpeed -= std::max(fabs(m_setSpeed)*0.05, 1.0);
+					if ( m_setSpeed < -300000000 ) m_setSpeed = -300000000;
+				}
 				if ( ((oldSpeed < 0.0) && (m_setSpeed >= 0.0)) ||
 						((oldSpeed > 0.0) && (m_setSpeed <= 0.0)) ) {
 					// flipped from going forward to backwards. make the speed 'stick' at zero
@@ -308,7 +312,7 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 				changeVec[axis] = (changeVec[axis] - dz) / (1.0f - dz);
 			}
 		}
-		
+
 		wantAngVel += changeVec;
 
 		if (wantAngVel.Length() >= 0.001 || force_rotation_damping || m_rotationDamping) {


### PR DESCRIPTION
nothing more, nothing less...

If you are in SetSpeed mode (flying and with autopilot enabled) if you hold the keys
to increase or decrease speed for more than 5 sec, you ask for this:
https://www.youtube.com/watch?v=ygE01sOhzz0

...So I put limits on playerController.cpp on what you could ask to autopilot