### PR TITLE
Toggle cursor

### DIFF
--- a/src/Pi.h
+++ b/src/Pi.h
@@ -103,6 +103,7 @@ public:
 		memcpy(motion, mouseMotion, sizeof(int)*2);
 	}
 	static void SetMouseGrab(bool on);
+	static bool DoingMouseGrab() { return doingMouseGrab; }
 	static void BoinkNoise();
 	static std::string GetSaveDir();
 	static SceneGraph::Model *FindModel(const std::string&, bool allowPlaceholder = true);

--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -264,7 +264,15 @@ void PiGui::NewFrame(SDL_Window *window) {
 	ImGui_ImplSdlGL3_NewFrame(window);
 	Pi::renderer->CheckRenderErrors(__FUNCTION__, __LINE__);
 	ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
-	ImGui::GetIO().MouseDrawCursor = true;
+	if(Pi::DoingMouseGrab())
+	{
+		ImGui::SetCursorScreenPos(ImVec2(0.5f, 0.5f));
+		ImGui::GetIO().MouseDrawCursor = false;
+	}
+	else
+	{
+		ImGui::GetIO().MouseDrawCursor = true;
+	}
 }
 
 void PiGui::Cleanup() {

--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -266,7 +266,6 @@ void PiGui::NewFrame(SDL_Window *window) {
 	ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
 	if(Pi::DoingMouseGrab())
 	{
-		ImGui::SetCursorScreenPos(ImVec2(0.5f, 0.5f));
 		ImGui::GetIO().MouseDrawCursor = false;
 	}
 	else


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Toggle visibility of the mouse cursor depending on the `Pi::doingMouseGrab` state.

This means that it is hidden and the position fixed (*centered*) when the player is flying the ship with the mouse.
<!-- Please make sure you've read documentation on contributing -->

