### PR TITLE
AIDockShip could use tag_landing

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,4 +1,7 @@
 January 2017
+   * New Features
+     * Toggle cursor position when flying (#3909)
+
    * Internal Changes
      * Correct and clarify a misleading comment (#3898)
      * Use the gas giant textures RAW instead of Billboard (#3897)

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -103,6 +103,7 @@ public:
 		memcpy(motion, mouseMotion, sizeof(int)*2);
 	}
 	static void SetMouseGrab(bool on);
+	static bool DoingMouseGrab() { return doingMouseGrab; }
 	static void BoinkNoise();
 	static std::string GetSaveDir();
 	static SceneGraph::Model *FindModel(const std::string&, bool allowPlaceholder = true);

--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -264,7 +264,14 @@ void PiGui::NewFrame(SDL_Window *window) {
 	ImGui_ImplSdlGL3_NewFrame(window);
 	Pi::renderer->CheckRenderErrors(__FUNCTION__, __LINE__);
 	ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
-	ImGui::GetIO().MouseDrawCursor = true;
+	if(Pi::DoingMouseGrab())
+	{
+		ImGui::GetIO().MouseDrawCursor = false;
+	}
+	else
+	{
+		ImGui::GetIO().MouseDrawCursor = true;
+	}
 }
 
 void PiGui::Cleanup() {

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -736,7 +736,7 @@ bool AICmdFlyTo::TimeStepUpdate()
 	if (m_ship->GetFlightState() == Ship::FLYING) m_ship->SetWheelState(false);
 	else { LaunchShip(m_ship); return false; }
 
-	// generate base target pos (with vicinity adjustment) & vel 
+	// generate base target pos (with vicinity adjustment) & vel
 	double timestep = Pi::game->GetTimeStep();
 	vector3d targpos, targvel;
 	if (m_target) {
@@ -745,7 +745,7 @@ bool AICmdFlyTo::TimeStepUpdate()
 		targvel = m_target->GetVelocityRelTo(m_ship->GetFrame());
 	} else {
 		targpos = GetPosInFrame(m_ship->GetFrame(), m_targframe, m_posoff);
-		targvel = GetVelInFrame(m_ship->GetFrame(), m_targframe, m_posoff);		
+		targvel = GetVelInFrame(m_ship->GetFrame(), m_targframe, m_posoff);
 	}
 	Frame *targframe = m_target ? m_target->GetFrame() : m_targframe;
 	ParentSafetyAdjust(m_ship, targframe, targpos, targvel);
@@ -847,7 +847,7 @@ Output("Autopilot dist = %.1f, speed = %.1f, zthrust = %.2f, state = %i\n",
 
 	// cap perpspeed according to what's needed now
 	perpspeed = std::min(perpspeed, 2.0*sidefactor*timestep);
-	
+
 	// cap sdiff by thrust...
 	double sdiff = ispeed - curspeed;
 	double linaccel = sdiff < 0 ?
@@ -861,7 +861,7 @@ Output("Autopilot dist = %.1f, speed = %.1f, zthrust = %.2f, state = %i\n",
 	if (decel) m_ship->AIChangeVelBy(vdiff * m_ship->GetOrient());
 	else m_ship->AIChangeVelDir(vdiff * m_ship->GetOrient());
 
-	// work out which way to head 
+	// work out which way to head
 	vector3d head = reldir;
 	if (!m_state && sdiff < -1.2*maxdecel*timestep) m_state = 1;
 	// if we're not coasting due to fuel constraints, and we're in the deceleration phase
@@ -884,7 +884,7 @@ Output("Autopilot dist = %.1f, speed = %.1f, zthrust = %.2f, state = %i\n",
 }
 
 
-AICmdDock::AICmdDock(Ship *ship, SpaceStation *target) : AICommand(ship, CMD_DOCK), 
+AICmdDock::AICmdDock(Ship *ship, SpaceStation *target) : AICommand(ship, CMD_DOCK),
 	m_target(target), m_state(eDockGetDataStart)
 {
 	double grav = GetGravityAtPos(m_target->GetFrame(), m_target->GetPosition());
@@ -949,7 +949,7 @@ bool AICmdDock::TimeStepUpdate()
 	// state 0,2: Get docking data
 	if (m_state == eDockGetDataStart
 		|| m_state == eDockGetDataEnd
-		|| m_state == eDockingComplete) 
+		|| m_state == eDockingComplete)
 	{
 		const SpaceStationType *type = m_target->GetStationType();
 		SpaceStationType::positionOrient_t dockpos;
@@ -963,7 +963,7 @@ bool AICmdDock::TimeStepUpdate()
 		if (type->IsOrbitalStation()) {
 			m_dockupdir = -m_dockupdir;
 		} else if (m_state == eDockingComplete) {
-			m_dockpos -= m_dockupdir * (m_ship->GetAabb().min.y + 1.0);
+			m_dockpos -= m_dockupdir * (m_ship->GetLandingPosOffset() + 0.1);
 		}
 
 		if (m_state != eDockGetDataEnd) {


### PR DESCRIPTION
Because tag_landing are added to models, then you need to use them
when you use autopilot.

This let autopilot use them because GetLandingPosOffset() return
tag_landing.y if it's present, else return GetAabb().min.y as usual
(check ship.cpp:280)

Before merge this, there's a need to tweak ships collision geometry
to reach the eight of tag_landing

Note: seems my editor do lot of changes, but the only interesting line
is 966...