### PR TITLE
Use tag_landing instead of Aabb for determining AI docking position

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -276,12 +276,13 @@ void Ship::Init()
 	InitGun("tag_gunmount_0", 0);
 	InitGun("tag_gunmount_1", 1);
 
-	// If we've got the tag_landing set then use it for an offset otherwise grab the AABB
+	// If we've got the tag_landing set then use it for an offset
+	// otherwise use zero so that it will dock but look clearly incorrect
 	const SceneGraph::MatrixTransform *mt = GetModel()->FindTagByName("tag_landing");
 	if( mt ) {
 		m_landingMinOffset = mt->GetTransform().GetTranslate().y;
 	} else {
-		m_landingMinOffset = GetAabb().min.y;
+		m_landingMinOffset = 0.0;		// GetAabb().min.y;
 	}
 
 	InitMaterials();

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -963,7 +963,7 @@ bool AICmdDock::TimeStepUpdate()
 		if (type->IsOrbitalStation()) {
 			m_dockupdir = -m_dockupdir;
 		} else if (m_state == eDockingComplete) {
-			m_dockpos -= m_dockupdir * (m_ship->GetAabb().min.y + 1.0);
+			m_dockpos -= m_dockupdir * (m_ship->GetLandingPosOffset() + 0.1);
 		}
 
 		if (m_state != eDockGetDataEnd) {


### PR DESCRIPTION
Combined with #3912, removes the need to put the pad collision geometry far above the visible pad and associated non-obvious docking dependencies on ship geometry. Should remove any issues with specific ships having difficulty docking or suffering damage. Note that without #3912, most ships will not dock when this patch is used.

All new ships will need a tag_landing, with some static collision geometry extending down to the same height or below. If a ship doesn't have a tag_landing, 0.0 is used instead for the landing position, which should dock but be clearly incorrect. The Aabb is not used as a backup because it may disguise incorrect behaviour.

The 0.1m offset in ShipAICmd.cpp is a somewhat arbitrary epsilon value to ensure that the edge vs tri intersections are reliably detected, and that the autopilot doesn't waste frames repositioning the ship at high time accel values.

There's a potential outstanding issue with the terrain collision. This still uses aabb.min.y, which could cause problems if a pad is very close to the terrain (terrain impact might happen before docking impact). That won't happen with the current station models as they're so far from the ground. The complicating factor for fixing this is that the landing tag only exists for ships, while terrain collision is checked for all dynamic bodies, for example cargo containers. 

Supersedes #3911.