### PR TITLE
Collision with docking surface entirely moved on SpaceStation

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -455,7 +455,9 @@ bool Ship::OnDamage(Object *attacker, float kgDamage, const CollisionContact& co
 
 bool Ship::OnCollision(Object *b, Uint32 flags, double relVel)
 {
-	// hitting space station docking surfaces shouldn't do damage
+	// Collision with SpaceStation docking surface is
+	// completely handled by SpaceStations, you only
+	// need to return a "true" value for Space.cpp bounce
 	if (b->IsType(Object::SPACESTATION) && (flags & 0x10)) {
 		return true;
 	}

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -461,7 +461,7 @@ static void RelocateStarportIfNecessary(SystemBody *sbody, Frame *frame, Planet 
 
 	Random r(sbody->GetSeed());
 
-	for (int tries = 0; tries < 200; tries++) 
+	for (int tries = 0; tries < 200; tries++)
 	{
 		variationWithinLimits = true;
 
@@ -494,7 +494,7 @@ static void RelocateStarportIfNecessary(SystemBody *sbody, Frame *frame, Planet 
 		bool tooCloseToOther = false;
 		for (vector3d oldPos : prevPositions)
 		{
-			// is the distance between points less than the delta distance?	
+			// is the distance between points less than the delta distance?
 			if ((pos_ - oldPos).LengthSqr() < (delta*delta)) {
 				tooCloseToOther = true; // then we're too close so try again
 				break;
@@ -512,7 +512,7 @@ static void RelocateStarportIfNecessary(SystemBody *sbody, Frame *frame, Planet 
 			rotNotUnderwaterWithLeastVariation = rot_;
 		}
 
-		if (variationWithinLimits && !starportUnderwater && !tooCloseToOther) 
+		if (variationWithinLimits && !starportUnderwater && !tooCloseToOther)
 			break;
 
 		// try new random position
@@ -882,7 +882,7 @@ static void hitCallback(CollisionContact *c)
 		const vector3d hitVel1 = linVel1 + angVel1.Cross(hitPos1);
 		const double relVel = hitVel1.Dot(c->normal);
 		// moving away so no collision
-		if (relVel > 0 && !c->geomFlag) return;
+		if (relVel > 0) return;
 		if (!OnCollision(po1, po2, c, -relVel)) return;
 		const double invAngInert = 1.0 / mover->GetAngularInertia();
 		const double numerator = -(1.0 + coeff_rest) * relVel;

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -35,6 +35,7 @@ public:
 	virtual ~SpaceStation();
 	virtual vector3d GetAngVelocity() const { return vector3d(0,m_type->AngVel(),0); }
 	virtual bool OnCollision(Object *b, Uint32 flags, double relVel) override;
+	bool DoShipDamage(Ship* s, Uint32 flags, double relVel);
 	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 	virtual void StaticUpdate(const float timeStep) override;
 	virtual void TimeStepUpdate(const float timeStep) override;


### PR DESCRIPTION
This PR is to correct a new bug, easily reproducible: you start at earth, take-off then try
to hit spaceport landing surface: you can pass through it :/

After last changes, ground station have no more two layers of collision mesh (one not flagged
and one flagged) but only a flagged flat surface.
This means less work for collision system, and also for modellers. More, this not rely on
eight of "mushroom-shaped" collision meshes and is definitely a step ahead.

But this means also you need to bounce (collide) with flagged surfaces if you're not trying
to dock (this is specific for planet starport), OR you need to pass through collision volume
when you aren't docking and you want to fly through the central hole of orbital stations..

To solve this I removed the collision checks for flagged surfaces from Ship and put things
on SpaceStation. Now, if SpaceStation detect an hit with Ships, is entirely responsible for
reaction: if Ships are docking, then:
1. a collision will trigger the docking sequence and
2. OnCollision for SpaceStation return false (this to avoid "bounce"). 

Else (so when Ships aren't docking):
- if SpaceStation is an orbital, do nothing.
- if SpaceStation is ground station, directly call: s->DynamicBody::OnCollision() (which is the
method called actually) and return true, letting Space to "bounce" Ship.

A side effect of this change is that you no longer have damages on Ships even at high time accel
and even if you have *flat* hull or tag_landing not well positioned (under some limit...).
