### PR TITLE
Avoid jousting when docking on orbitals at high time steps

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -464,6 +464,14 @@ void SpaceStation::DockingUpdate(const double timeStep)
 			float dist = 0.0;
 			switch ( extraStage ) {
 				case 1: // Level ship & Reposition eval
+					// PS: This is to avoid to float around if dock
+					// at high time steps on an orbital
+					if (!IsGroundStation()) {
+						dt.fromPos = vector3d(0.0); //No offset
+						dt.fromRot = Quaterniond(1.0,0.0,0.0,0.0); //Identity (no rotation)
+						dt.stage += 2;
+						continue;
+					}
 					if ( !LevelShip(dt.ship, i, timeStep) ) continue;
 					PiVerify(m_type->GetDockAnimPositionOrient(i, m_type->NumDockingStages(), 1.0f, dt.fromPos, dport, dt.ship));
 					dist = (dt.ship->GetPosition() - GetPosition() - GetOrient()*dport.pos).LengthSqr();


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This is to avoid a bug (...I put on code :( ...): when ships (even AI) are docking on
orbitals at high time step they remains stuck in "level ship" because,
if in time accel, their position change is less than the movement
of the station itself (due to its rotation).

So you need to jump directly out on the right stage.
