### PR TITLE
Resolve the mismatched attribute numbering

### DIFF
--- a/data/shaders/opengl/attributes.glsl
+++ b/data/shaders/opengl/attributes.glsl
@@ -31,9 +31,10 @@ layout (location = 0) in vec4 a_vertex;
 layout (location = 1) in vec3 a_normal;
 layout (location = 2) in vec4 a_color;
 layout (location = 3) in vec4 a_uv0;
-layout (location = 4) in vec3 a_tangent;
-layout (location = 5) in mat4 a_transform;
-// shadows 6, 7, and 8
-// next available is layout (location = 9) 
+layout (location = 4) in vec4 a_uv1;
+layout (location = 5) in vec3 a_tangent;
+layout (location = 6) in mat4 a_transform;
+// a_transform @ 6 shadows (uses) 7, 8, and 9
+// next available is layout (location = 10) 
 
 #endif // VERTEX_SHADER

--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -266,6 +266,8 @@ void Program::LoadShaders(const std::string &name, const std::string &defines)
 	glBindAttribLocation(m_program, 4, "a_uv1");
 	glBindAttribLocation(m_program, 5, "a_tangent");
 	glBindAttribLocation(m_program, 6, "a_transform");
+	// a_transform @ 6 shadows (uses) 7, 8, and 9
+	// next available is layout (location = 10) 
 
 	glBindFragDataLocation(m_program, 0, "frag_color");
 

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -67,10 +67,10 @@ public:
 
 protected:
 	enum InstOffs {
-		INSTOFFS_MAT0 = 5, // these value must match those of a_transform within data/shaders/opengl/attributes.glsl
-		INSTOFFS_MAT1 = 6,
-		INSTOFFS_MAT2 = 7,
-		INSTOFFS_MAT3 = 8
+		INSTOFFS_MAT0 = 6, // these value must match those of a_transform within data/shaders/opengl/attributes.glsl
+		INSTOFFS_MAT1 = 7,
+		INSTOFFS_MAT2 = 8,
+		INSTOFFS_MAT3 = 9
 	};
 	std::unique_ptr<matrix4x4f> m_data;
 };


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Shader attributes use explicit numbering and we match those numbers internally.
However these had gotten mismatched so this PR fixes them.

It's probably not caused a problem but it might have depending on the GPU drivers.
<!-- Please make sure you've read documentation on contributing -->

