### PR TITLE
Refactor the Vertex, Index, etc buffers

### DIFF
--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -59,7 +59,7 @@ ImTextureID PiGui::RenderSVG(std::string svgFilename, int width, int height) {
 		if(strTex.first == svgFilename) {
 			// nasty bit as I invoke the TextureGL
 			Graphics::OGL::TextureGL *pGLTex = reinterpret_cast<Graphics::OGL::TextureGL*>(strTex.second);
-			Uint32 result = pGLTex->GetTexture();
+			Uint32 result = pGLTex->GetTextureID();
  			Output("Re-used existing texture with id: %i\n", result);
 			return reinterpret_cast<void*>(result);
 		}
@@ -284,7 +284,7 @@ void *PiGui::makeTexture(const std::string &filename, unsigned char *pixels, int
 	Pi::renderer->CheckRenderErrors(__FUNCTION__, __LINE__);
 	// nasty bit as I invoke the TextureGL
 	Graphics::OGL::TextureGL *pGLTex = reinterpret_cast<Graphics::OGL::TextureGL*>(pTex);
-	Uint32 result = pGLTex->GetTexture();
+	Uint32 result = pGLTex->GetTextureID();
  	Output("texture id: %i\n", result);
 	m_svg_textures.push_back( std::make_pair(filename,pTex) );	// store for cleanup later
  	return reinterpret_cast<void*>(result);

--- a/src/graphics/Texture.h
+++ b/src/graphics/Texture.h
@@ -98,6 +98,10 @@ public:
 	virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips = 0) = 0;
 	virtual void SetSampleMode(TextureSampleMode) = 0;
 	virtual void BuildMipmaps() = 0;
+	virtual uint32_t GetTextureID() const = 0;
+
+	virtual void Bind() = 0;
+	virtual void Unbind() = 0;
 
 	virtual ~Texture() {}
 

--- a/src/graphics/VertexBuffer.h
+++ b/src/graphics/VertexBuffer.h
@@ -85,6 +85,9 @@ public:
 	// copies the contents of the VertexArray into the buffer
 	virtual bool Populate(const VertexArray &) = 0;
 
+	// change the buffer data without mapping
+	virtual void BufferData(const size_t, void*) = 0;
+
 	virtual void Bind() = 0;
 	virtual void Release() = 0;
 
@@ -100,6 +103,9 @@ public:
 	IndexBuffer(Uint32 size, BufferUsage);
 	virtual ~IndexBuffer();
 	virtual Uint32 *Map(BufferMapMode) = 0;
+
+	// change the buffer data without mapping
+	virtual void BufferData(const size_t, void*) = 0;
 
 	Uint32 GetSize() const { return m_size; }
 	Uint32 GetIndexCount() const { return m_indexCount; }

--- a/src/graphics/dummy/TextureDummy.h
+++ b/src/graphics/dummy/TextureDummy.h
@@ -18,7 +18,7 @@ public:
 
 	virtual void SetSampleMode(TextureSampleMode) {}
 	virtual void BuildMipmaps() {}
-	Uint32 GetTexture() const { return 0U; }
+	virtual uint32_t GetTextureID() const override final { return 0U; }
 
 private:
 	friend class RendererDummy;

--- a/src/graphics/dummy/VertexBufferDummy.h
+++ b/src/graphics/dummy/VertexBufferDummy.h
@@ -17,15 +17,18 @@ public:
 	{}
 
 	// copies the contents of the VertexArray into the buffer
-	virtual bool Populate(const VertexArray &) override { return true; }
+	virtual bool Populate(const VertexArray &) override final { return true; }
 
-	virtual void Bind() override {}
-	virtual void Release() override {}
+	// change the buffer data without mapping
+	virtual void BufferData(const size_t, void*) override final {}
 
-	virtual void Unmap() override {}
+	virtual void Bind() override final {}
+	virtual void Release() override final {}
+
+	virtual void Unmap() override final {}
 
 protected:
-	virtual Uint8 *MapInternal(BufferMapMode) override { return m_buffer.get(); }
+	virtual Uint8 *MapInternal(BufferMapMode) override final { return m_buffer.get(); }
 
 private:
 	std::unique_ptr<Uint8[]> m_buffer;
@@ -37,12 +40,13 @@ public:
 	m_buffer(new Uint32[size])
 	{};
 
-	virtual Uint32 *Map(BufferMapMode) override { return m_buffer.get(); }
+	virtual Uint32 *Map(BufferMapMode) override final { return m_buffer.get(); }
+	virtual void Unmap() override final {}
 
-	virtual void Unmap() override {}
+	virtual void BufferData(const size_t, void*) override final {}
 
-	virtual void Bind() override {}
-	virtual void Release() override {}
+	virtual void Bind() override final {}
+	virtual void Release() override final {}
 
 private:
     std::unique_ptr<Uint32[]> m_buffer;
@@ -55,14 +59,14 @@ public:
 		: Graphics::InstanceBuffer(size, hint), m_data(new matrix4x4f[size])
 	{}
 	virtual ~InstanceBuffer() {};
-	virtual matrix4x4f* Map(BufferMapMode) override { return m_data.get(); }
-	virtual void Unmap() override {}
+	virtual matrix4x4f* Map(BufferMapMode) override final { return m_data.get(); }
+	virtual void Unmap() override final {}
 
 	Uint32 GetSize() const { return m_size; }
 	BufferUsage GetUsage() const { return m_usage; }
 
-	virtual void Bind() override {}
-	virtual void Release() override {}
+	virtual void Bind() override final {}
+	virtual void Release() override final {}
 
 protected:
 	std::unique_ptr<matrix4x4f> m_data;

--- a/src/graphics/gl2/GL2FresnelColourMaterial.h
+++ b/src/graphics/gl2/GL2FresnelColourMaterial.h
@@ -21,8 +21,8 @@ namespace Graphics {
 
 		class FresnelColourMaterial : public Material { //unlit
 		public:
-			virtual Program *CreateProgram(const MaterialDescriptor &);
-			virtual void Apply();
+			virtual Program *CreateProgram(const MaterialDescriptor &) override final;
+			virtual void Apply() override final;
 		};
 	}
 }

--- a/src/graphics/gl2/GL2Material.h
+++ b/src/graphics/gl2/GL2Material.h
@@ -29,11 +29,11 @@ namespace Graphics {
 			// Create an appropriate program for this material.
 			virtual Program *CreateProgram(const MaterialDescriptor &) = 0;
 			// bind textures, set uniforms
-			virtual void Apply();
-			virtual void Unapply();
+			virtual void Apply() override;
+			virtual void Unapply() override;
 			virtual void SetProgram(Program *p) { m_program = p; }
 			virtual bool IsProgramLoaded() const override final { return true; }
-			virtual void SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj);
+			virtual void SetCommonUniforms(const matrix4x4f& mv, const matrix4x4f& proj) override final;
 
 		protected:
 			friend class Graphics::RendererGL2;

--- a/src/graphics/gl2/GL2RenderTarget.cpp
+++ b/src/graphics/gl2/GL2RenderTarget.cpp
@@ -62,7 +62,7 @@ void RenderTarget::SetCubeFaceTexture(const Uint32 face, Texture* t)
 	if (!bound) Bind();
 	//texture format should match the intended fbo format (aka. the one attached first)
 	GLuint texId = 0;
-	if (t) texId = static_cast<GL2Texture*>(t)->GetTexture();
+	if (t) texId = static_cast<GL2Texture*>(t)->GetTextureID();
 	glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, texId, 0);
 	m_colorTexture.Reset(t);
 	if (!bound) Unbind();
@@ -74,7 +74,7 @@ void RenderTarget::SetColorTexture(Texture* t)
 	if (!bound) Bind();
 	//texture format should match the intended fbo format (aka. the one attached first)
 	GLuint texId = 0;
-	if (t) texId = static_cast<GL2Texture*>(t)->GetTexture();
+	if (t) texId = static_cast<GL2Texture*>(t)->GetTextureID();
 	glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, texId, 0);
 	m_colorTexture.Reset(t);
 	if (!bound) Unbind();
@@ -87,7 +87,7 @@ void RenderTarget::SetDepthTexture(Texture* t)
 	if (!bound) Bind();
 	if (!GetDesc().allowDepthTexture) return;
 	GLuint texId = 0;
-	if (t) texId = static_cast<GL2Texture*>(t)->GetTexture();
+	if (t) texId = static_cast<GL2Texture*>(t)->GetTextureID();
 	glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, GL_TEXTURE_2D, texId, 0);
 	m_depthTexture.Reset(t);
 	if (!bound) Unbind();

--- a/src/graphics/gl2/GL2Renderer.cpp
+++ b/src/graphics/gl2/GL2Renderer.cpp
@@ -135,7 +135,7 @@ RendererGL2::RendererGL2(WindowSDL *window, const Graphics::Settings &vs)
 
 	// pump this once as glewExperimental is necessary but spews a single error
 	GLenum err = glGetError();
-	
+
 	if (!glewIsSupported("GL_VERSION_2_1") )
 	{
 		Error(
@@ -562,7 +562,7 @@ bool RendererGL2::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 
 	const bool res = DrawBuffer(drawVB.Get(), rs, m, t);
 	CheckRenderErrors(__FUNCTION__,__LINE__);
-	
+
 	m_stats.AddToStatCount(Stats::STAT_DRAWTRIS, 1);
 
 	return res;
@@ -571,7 +571,7 @@ bool RendererGL2::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 bool RendererGL2::DrawPointSprites(const Uint32 count, const vector3f *positions, RenderState *rs, Material *material, float size)
 {
 	PROFILE_SCOPED()
-	if (count == 0 || !material || !material->texture0) 
+	if (count == 0 || !material || !material->texture0)
 		return false;
 
 	size = Clamp(size, 0.1f, FLT_MAX);
@@ -582,10 +582,10 @@ bool RendererGL2::DrawPointSprites(const Uint32 count, const vector3f *positions
 		vector3f norm;
 	};
 	#pragma pack(pop)
-	
+
 	RefCountedPtr<VertexBuffer> drawVB;
 	AttribBufferIter iter = s_AttribBufferMap.find(std::make_pair(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL, count));
-	if (iter == s_AttribBufferMap.end()) 
+	if (iter == s_AttribBufferMap.end())
 	{
 		// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
 		Graphics::VertexBufferDesc vbd;
@@ -630,7 +630,7 @@ bool RendererGL2::DrawPointSprites(const Uint32 count, const vector3f *positions
 bool RendererGL2::DrawPointSprites(const Uint32 count, const vector3f *positions, const vector2f *offsets, const float *sizes, RenderState *rs, Material *material)
 {
 	PROFILE_SCOPED()
-	if (count == 0 || !material || !material->texture0) 
+	if (count == 0 || !material || !material->texture0)
 		return false;
 
 	#pragma pack(push, 4)
@@ -639,10 +639,10 @@ bool RendererGL2::DrawPointSprites(const Uint32 count, const vector3f *positions
 		vector3f norm;
 	};
 	#pragma pack(pop)
-	
+
 	RefCountedPtr<VertexBuffer> drawVB;
 	AttribBufferIter iter = s_AttribBufferMap.find(std::make_pair(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL, count));
-	if (iter == s_AttribBufferMap.end()) 
+	if (iter == s_AttribBufferMap.end())
 	{
 		// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
 		Graphics::VertexBufferDesc vbd;
@@ -728,7 +728,7 @@ bool RendererGL2::DrawBufferIndexed(VertexBuffer *vb, IndexBuffer *ib, RenderSta
 	DisableVertexAttributes(gvb);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 	gvb->Release();
-	
+
 	CheckRenderErrors(__FUNCTION__,__LINE__);
 	m_stats.AddToStatCount(Stats::STAT_DRAWCALL, 1);
 
@@ -748,7 +748,7 @@ bool RendererGL2::DrawBufferInstanced(VertexBuffer* vb, RenderState* state, Mate
 	glDrawArraysInstancedARB(pt, 0, vb->GetVertexCount(), instb->GetInstanceCount());
 	instb->Release();
 	vb->Release();
-	
+
 	CheckRenderErrors(__FUNCTION__,__LINE__);
 	m_stats.AddToStatCount(Stats::STAT_DRAWCALL, 1);
 

--- a/src/graphics/gl2/GL2Texture.h
+++ b/src/graphics/gl2/GL2Texture.h
@@ -13,17 +13,17 @@ namespace GL2 {
 
 class GL2Texture : public Texture {
 public:
-	virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips);
-	virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips);
-	
+	virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override final;
+	virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override final;
+
 	GL2Texture(const TextureDescriptor &descriptor, const bool useCompressed);
 	virtual ~GL2Texture();
 
-	void Bind();
-	void Unbind();
+	virtual void Bind() override final;
+	virtual void Unbind() override final;
 
-	virtual void SetSampleMode(TextureSampleMode);
-	GLuint GetTexture() const { return m_texture; }
+	virtual void SetSampleMode(TextureSampleMode) override final;
+	virtual uint32_t GetTextureID() const override final { assert(sizeof(uint32_t)==sizeof(GLuint)); return m_texture; }
 
 	void BuildMipmaps();
 

--- a/src/graphics/gl2/GL2UIMaterial.cpp
+++ b/src/graphics/gl2/GL2UIMaterial.cpp
@@ -9,49 +9,47 @@
 #include <sstream>
 #include "StringF.h"
 
-namespace Graphics {
-namespace GL2 {
-
-
-
-UIProgram::UIProgram(const MaterialDescriptor &desc)
+namespace Graphics
 {
-	m_name = "ui";
-	RENDERER_CHECK_ERRORS();
+	namespace GL2
+	{
+		///////////////////////////////////////////////////////////////////////
+		UIProgram::UIProgram(const MaterialDescriptor &desc)
+		{
+			m_name = "ui";
+			RENDERER_CHECK_ERRORS();
 
-	LoadShaders(m_name, m_defines);
-	InitUniforms();
-}
+			LoadShaders(m_name, m_defines);
+			InitUniforms();
+		}
 
-Program *UIMaterial::CreateProgram(const MaterialDescriptor &desc)
-{
-	return new UIProgram(desc);
-}
+		Program *UIMaterial::CreateProgram(const MaterialDescriptor &desc)
+		{
+			return new UIProgram(desc);
+		}
 
-void UIMaterial::Apply()
-{
-	GL2::Material::Apply();
+		void UIMaterial::Apply()
+		{
+			GL2::Material::Apply();
 
-	UIProgram *p = static_cast<UIProgram*>(m_program);
+			UIProgram *p = static_cast<UIProgram*>(m_program);
 
-	p->diffuse.Set(this->diffuse);
+			p->diffuse.Set(this->diffuse);
 
-	p->texture0.Set(this->texture0, 0);
-	p->texture1.Set(this->texture1, 1);
-}
+			p->texture0.Set(this->texture0, 0);
+			p->texture1.Set(this->texture1, 1);
+		}
 
-void UIMaterial::Unapply()
-{
-	// Might not be necessary to unbind textures, but let's not old graphics code (eg, old-UI)
-	
-	if (texture1) {
-		static_cast<GL2Texture*>(texture1)->Unbind();
-		glActiveTexture(GL_TEXTURE0);
+		void UIMaterial::Unapply()
+		{
+			// Might not be necessary to unbind textures, but let's not old graphics code (eg, old-UI)
+			if ( texture1 ) {
+				static_cast<GL2Texture*>(texture1)->Unbind();
+				glActiveTexture(GL_TEXTURE0);
+			}
+			if ( texture0 ) {
+				static_cast<GL2Texture*>(texture0)->Unbind();
+			}
+		}
 	}
-	if (texture0) {
-		static_cast<GL2Texture*>(texture0)->Unbind();
-	}
-}
-
-}
 }

--- a/src/graphics/gl2/GL2UIMaterial.h
+++ b/src/graphics/gl2/GL2UIMaterial.h
@@ -14,6 +14,7 @@
 namespace Graphics {
 
 	namespace GL2 {
+		///////////////////////////////////////////////////////////////////////
 		class UIProgram : public Program {
 		public:
 			UIProgram(const MaterialDescriptor &);
@@ -21,9 +22,9 @@ namespace Graphics {
 
 		class UIMaterial : public Material {
 		public:
-			virtual Program *CreateProgram(const MaterialDescriptor &);
-			virtual void Apply();
-			virtual void Unapply();
+			virtual Program *CreateProgram(const MaterialDescriptor &) override final;
+			virtual void Apply() override final;
+			virtual void Unapply() override final;
 		};
 	}
 }

--- a/src/graphics/gl2/GL2VertexBuffer.cpp
+++ b/src/graphics/gl2/GL2VertexBuffer.cpp
@@ -89,7 +89,7 @@ VertexBuffer::VertexBuffer(const VertexBufferDesc &desc) :
 		switch (attr.semantic) {
 		case ATTRIB_POSITION:
 			glEnableVertexAttribArray(0);	// Enable the attribute at that location
-			glVertexAttribPointer(0, get_num_components(attr.format), get_component_type(attr.format), GL_FALSE, m_desc.stride, offset);	
+			glVertexAttribPointer(0, get_num_components(attr.format), get_component_type(attr.format), GL_FALSE, m_desc.stride, offset);
 			break;
 		case ATTRIB_NORMAL:
 			glEnableVertexAttribArray(1);	// Enable the attribute at that location
@@ -313,6 +313,16 @@ bool VertexBuffer::Populate(const VertexArray &va)
 	return result;
 }
 
+void VertexBuffer::BufferData(const size_t size, void *data)
+{
+	assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
+	if (GetDesc().usage == BUFFER_USAGE_DYNAMIC) {
+		glBindVertexArray(m_vao);
+		glBindBuffer(GL_ARRAY_BUFFER, m_buffer);
+		glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)size, (GLvoid*)data, GL_DYNAMIC_DRAW);
+	}
+}
+
 void VertexBuffer::Bind() {
 	glBindVertexArray(m_vao);
 
@@ -410,6 +420,15 @@ void IndexBuffer::Unmap()
 	}
 
 	m_mapMode = BUFFER_MAP_NONE;
+}
+
+void IndexBuffer::BufferData(const size_t size, void *data)
+{
+	assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
+	if (GetUsage() == BUFFER_USAGE_DYNAMIC) {
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_buffer);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)size, (GLvoid*)data, GL_DYNAMIC_DRAW);
+	}
 }
 
 void IndexBuffer::Bind() {

--- a/src/graphics/gl2/GL2VertexBuffer.h
+++ b/src/graphics/gl2/GL2VertexBuffer.h
@@ -21,16 +21,19 @@ public:
 	VertexBuffer(const VertexBufferDesc&);
 	~VertexBuffer();
 
-	virtual void Unmap() override;
+	virtual void Unmap() override final;
 
 	// copies the contents of the VertexArray into the buffer
-	virtual bool Populate(const VertexArray &) override;
-	
-	virtual void Bind() override;
-	virtual void Release() override;
+	virtual bool Populate(const VertexArray &) override final;
+
+	// change the buffer data without mapping
+	virtual void BufferData(const size_t, void*) override final;
+
+	virtual void Bind() override final;
+	virtual void Release() override final;
 
 protected:
-	virtual Uint8 *MapInternal(BufferMapMode) override;
+	virtual Uint8 *MapInternal(BufferMapMode) override final;
 
 private:
 	GLuint m_vao;
@@ -42,11 +45,14 @@ public:
 	IndexBuffer(Uint32 size, BufferUsage);
 	~IndexBuffer();
 
-	virtual Uint32 *Map(BufferMapMode) override;
-	virtual void Unmap() override;
-	
-	virtual void Bind() override;
-	virtual void Release() override;
+	virtual Uint32 *Map(BufferMapMode) override final;
+	virtual void Unmap() override final;
+
+	// change the buffer data without mapping
+	virtual void BufferData(const size_t, void*) override final;
+
+	virtual void Bind() override final;
+	virtual void Release() override final;
 
 private:
 	Uint32 *m_data;
@@ -56,12 +62,12 @@ private:
 class InstanceBuffer : public Graphics::InstanceBuffer, public GLBufferBase {
 public:
 	InstanceBuffer(Uint32 size, BufferUsage);
-	virtual ~InstanceBuffer() override;
-	virtual matrix4x4f* Map(BufferMapMode) override;
-	virtual void Unmap() override;
+	virtual ~InstanceBuffer() override final;
+	virtual matrix4x4f* Map(BufferMapMode) override final;
+	virtual void Unmap() override final;
 
-	virtual void Bind() override;
-	virtual void Release() override;
+	virtual void Bind() override final;
+	virtual void Release() override final;
 
 protected:
 	enum InstOffs {

--- a/src/graphics/opengl/GenGasGiantColourMaterial.h
+++ b/src/graphics/opengl/GenGasGiantColourMaterial.h
@@ -6,7 +6,7 @@
 #ifndef _OGL_GENGASGIANTCOLOURMATERIAL_H
 #define _OGL_GENGASGIANTCOLOURMATERIAL_H
 /*
- * Material(s) used to generate 
+ * Material(s) used to generate
  *
  */
 #include "MaterialGL.h"
@@ -48,14 +48,14 @@ namespace Graphics {
 			Uniform hueAdjust;
 
 		protected:
-			virtual void InitUniforms();
+			virtual void InitUniforms() override final;
 		};
 
 		class GenGasGiantColourMaterial : public Material { //unlit
 		public:
-			virtual Program *CreateProgram(const MaterialDescriptor &);
-			virtual void Apply();
-			virtual void Unapply();
+			virtual Program *CreateProgram(const MaterialDescriptor &) override final;
+			virtual void Apply() override final;
+			virtual void Unapply() override final;
 		};
 	}
 }

--- a/src/graphics/opengl/RenderTargetGL.cpp
+++ b/src/graphics/opengl/RenderTargetGL.cpp
@@ -60,7 +60,7 @@ void RenderTarget::SetCubeFaceTexture(const Uint32 face, Texture* t)
 	if (!bound) Bind();
 	//texture format should match the intended fbo format (aka. the one attached first)
 	GLuint texId = 0;
-	if (t) texId = static_cast<TextureGL*>(t)->GetTexture();
+	if (t) texId = static_cast<TextureGL*>(t)->GetTextureID();
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, texId, 0);
 	m_colorTexture.Reset(t);
 	if (!bound) Unbind();
@@ -72,7 +72,7 @@ void RenderTarget::SetColorTexture(Texture* t)
 	if (!bound) Bind();
 	//texture format should match the intended fbo format (aka. the one attached first)
 	GLuint texId = 0;
-	if (t) texId = static_cast<TextureGL*>(t)->GetTexture();
+	if (t) texId = static_cast<TextureGL*>(t)->GetTextureID();
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texId, 0);
 	m_colorTexture.Reset(t);
 	if (!bound) Unbind();
@@ -85,7 +85,7 @@ void RenderTarget::SetDepthTexture(Texture* t)
 	if (!bound) Bind();
 	if (!GetDesc().allowDepthTexture) return;
 	GLuint texId = 0;
-	if (t) texId = static_cast<TextureGL*>(t)->GetTexture();
+	if (t) texId = static_cast<TextureGL*>(t)->GetTextureID();
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texId, 0);
 	m_depthTexture.Reset(t);
 	if (!bound) Unbind();

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -77,7 +77,7 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 
 	// pump this once as glewExperimental is necessary but spews a single error
 	GLenum err = glGetError();
-	
+
 	if (!glewIsSupported("GL_VERSION_3_1") )
 	{
 		Error(
@@ -227,7 +227,7 @@ void RendererOGL::WriteRendererInfo(std::ostream &out) const
 			out << "  " << glGetStringi(GL_EXTENSIONS, i) << "\n";
 		}
 	}
-	else 
+	else
 	{
 		out << "  ";
 		std::istringstream ext(reinterpret_cast<const char *>(glGetString(GL_EXTENSIONS)));
@@ -624,7 +624,7 @@ bool RendererOGL::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 
 	const bool res = DrawBuffer(drawVB.Get(), rs, m, t);
 	CheckRenderErrors(__FUNCTION__,__LINE__);
-	
+
 	m_stats.AddToStatCount(Stats::STAT_DRAWTRIS, 1);
 
 	return res;
@@ -633,7 +633,7 @@ bool RendererOGL::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 bool RendererOGL::DrawPointSprites(const Uint32 count, const vector3f *positions, RenderState *rs, Material *material, float size)
 {
 	PROFILE_SCOPED()
-	if (count == 0 || !material || !material->texture0) 
+	if (count == 0 || !material || !material->texture0)
 		return false;
 
 	size = Clamp(size, 0.1f, FLT_MAX);
@@ -644,10 +644,10 @@ bool RendererOGL::DrawPointSprites(const Uint32 count, const vector3f *positions
 		vector3f norm;
 	};
 	#pragma pack(pop)
-	
+
 	RefCountedPtr<VertexBuffer> drawVB;
 	AttribBufferIter iter = s_AttribBufferMap.find(std::make_pair(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL, count));
-	if (iter == s_AttribBufferMap.end()) 
+	if (iter == s_AttribBufferMap.end())
 	{
 		// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
 		Graphics::VertexBufferDesc vbd;
@@ -692,7 +692,7 @@ bool RendererOGL::DrawPointSprites(const Uint32 count, const vector3f *positions
 bool RendererOGL::DrawPointSprites(const Uint32 count, const vector3f *positions, const vector2f *offsets, const float *sizes, RenderState *rs, Material *material)
 {
 	PROFILE_SCOPED()
-	if (count == 0 || !material || !material->texture0) 
+	if (count == 0 || !material || !material->texture0)
 		return false;
 
 	#pragma pack(push, 4)
@@ -701,10 +701,10 @@ bool RendererOGL::DrawPointSprites(const Uint32 count, const vector3f *positions
 		vector3f norm;
 	};
 	#pragma pack(pop)
-	
+
 	RefCountedPtr<VertexBuffer> drawVB;
 	AttribBufferIter iter = s_AttribBufferMap.find(std::make_pair(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL, count));
-	if (iter == s_AttribBufferMap.end()) 
+	if (iter == s_AttribBufferMap.end())
 	{
 		// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
 		Graphics::VertexBufferDesc vbd;
@@ -973,7 +973,7 @@ RenderTarget *RendererOGL::CreateRenderTarget(const RenderTargetDesc &desc)
 			vector2f(desc.width, desc.height),
 			LINEAR_CLAMP,
 			false,
-			false, 
+			false,
 			false,
 			0, Graphics::TEXTURE_2D);
 		OGL::TextureGL *colorTex = new OGL::TextureGL(cdesc, false, false);

--- a/src/graphics/opengl/TextureGL.h
+++ b/src/graphics/opengl/TextureGL.h
@@ -7,24 +7,24 @@
 #include "OpenGLLibs.h"
 #include "graphics/Texture.h"
 
-namespace Graphics 
+namespace Graphics
 {
-	namespace OGL 
+	namespace OGL
 	{
 		class TextureGL : public Texture {
 		public:
-			virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips);
-			virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips);
+			virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override final;
+			virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override final;
 
 			TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering);
 			virtual ~TextureGL();
 
-			void Bind();
-			void Unbind();
+			virtual void Bind() override final;
+			virtual void Unbind() override final;
 
-			virtual void SetSampleMode(TextureSampleMode);
-			virtual void BuildMipmaps();
-			GLuint GetTexture() const { return m_texture; }
+			virtual void SetSampleMode(TextureSampleMode) override final;
+			virtual void BuildMipmaps() override final;
+			virtual uint32_t GetTextureID() const override final { assert(sizeof(uint32_t)==sizeof(GLuint)); return m_texture; }
 
 		private:
 			GLenum m_target;

--- a/src/graphics/opengl/UIMaterial.cpp
+++ b/src/graphics/opengl/UIMaterial.cpp
@@ -10,46 +10,44 @@
 #include "StringF.h"
 
 namespace Graphics {
-namespace OGL {
+	namespace OGL {
+		///////////////////////////////////////////////////////////////////////
+		UIProgram::UIProgram(const MaterialDescriptor &desc)
+		{
+			m_name = "ui";
+			CHECKERRORS();
 
-UIProgram::UIProgram(const MaterialDescriptor &desc)
-{
-	m_name = "ui";
-	CHECKERRORS();
+			LoadShaders(m_name, m_defines);
+			InitUniforms();
+		}
 
-	LoadShaders(m_name, m_defines);
-	InitUniforms();
-}
+		Program *UIMaterial::CreateProgram(const MaterialDescriptor &desc)
+		{
+			return new UIProgram(desc);
+		}
 
-Program *UIMaterial::CreateProgram(const MaterialDescriptor &desc)
-{
-	return new UIProgram(desc);
-}
+		void UIMaterial::Apply()
+		{
+			OGL::Material::Apply();
 
-void UIMaterial::Apply()
-{
-	OGL::Material::Apply();
+			UIProgram *p = static_cast<UIProgram*>(m_program);
 
-	UIProgram *p = static_cast<UIProgram*>(m_program);
+			p->diffuse.Set(this->diffuse);
 
-	p->diffuse.Set(this->diffuse);
+			p->texture0.Set(this->texture0, 0);
+			p->texture1.Set(this->texture1, 1);
+		}
 
-	p->texture0.Set(this->texture0, 0);
-	p->texture1.Set(this->texture1, 1);
-}
-
-void UIMaterial::Unapply()
-{
-	// Might not be necessary to unbind textures, but let's not old graphics code (eg, old-UI)
-	
-	if (texture1) {
-		static_cast<TextureGL*>(texture1)->Unbind();
-		glActiveTexture(GL_TEXTURE0);
+		void UIMaterial::Unapply()
+		{
+			// Might not be necessary to unbind textures, but let's not old graphics code (eg, old-UI)
+			if ( texture1 ) {
+				static_cast<TextureGL*>(texture1)->Unbind();
+				glActiveTexture(GL_TEXTURE0);
+			}
+			if ( texture0 ) {
+				static_cast<TextureGL*>(texture0)->Unbind();
+			}
+		}
 	}
-	if (texture0) {
-		static_cast<TextureGL*>(texture0)->Unbind();
-	}
-}
-
-}
 }

--- a/src/graphics/opengl/UIMaterial.h
+++ b/src/graphics/opengl/UIMaterial.h
@@ -14,6 +14,7 @@
 namespace Graphics {
 
 	namespace OGL {
+		///////////////////////////////////////////////////////////////////////
 		class UIProgram : public Program {
 		public:
 			UIProgram(const MaterialDescriptor &);
@@ -21,9 +22,9 @@ namespace Graphics {
 
 		class UIMaterial : public Material {
 		public:
-			virtual Program *CreateProgram(const MaterialDescriptor &);
-			virtual void Apply();
-			virtual void Unapply();
+			virtual Program *CreateProgram(const MaterialDescriptor &) override final;
+			virtual void Apply() override final;
+			virtual void Unapply() override final;
 		};
 	}
 }

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -86,7 +86,7 @@ VertexBuffer::VertexBuffer(const VertexBufferDesc &desc) :
 		switch (attr.semantic) {
 		case ATTRIB_POSITION:
 			glEnableVertexAttribArray(0);	// Enable the attribute at that location
-			glVertexAttribPointer(0, get_num_components(attr.format), get_component_type(attr.format), GL_FALSE, m_desc.stride, offset);	
+			glVertexAttribPointer(0, get_num_components(attr.format), get_component_type(attr.format), GL_FALSE, m_desc.stride, offset);
 			break;
 		case ATTRIB_NORMAL:
 			glEnableVertexAttribArray(1);	// Enable the attribute at that location
@@ -314,6 +314,17 @@ bool VertexBuffer::Populate(const VertexArray &va)
 	return result;
 }
 
+void VertexBuffer::BufferData(const size_t size, void *data)
+{
+	PROFILE_SCOPED()
+	assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
+	if (GetDesc().usage == BUFFER_USAGE_DYNAMIC) {
+		glBindVertexArray(m_vao);
+		glBindBuffer(GL_ARRAY_BUFFER, m_buffer);
+		glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)size, (GLvoid*)data, GL_DYNAMIC_DRAW);
+	}
+}
+
 void VertexBuffer::Bind() {
 	assert(m_written);
 	glBindVertexArray(m_vao);
@@ -412,6 +423,16 @@ void IndexBuffer::Unmap()
 
 	m_mapMode = BUFFER_MAP_NONE;
 	m_written = true;
+}
+
+void IndexBuffer::BufferData(const size_t size, void *data)
+{
+	PROFILE_SCOPED()
+	assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
+	if (GetUsage() == BUFFER_USAGE_DYNAMIC) {
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_buffer);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)size, (GLvoid*)data, GL_DYNAMIC_DRAW);
+	}
 }
 
 void IndexBuffer::Bind() {

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -23,16 +23,19 @@ public:
 	VertexBuffer(const VertexBufferDesc&);
 	~VertexBuffer();
 
-	virtual void Unmap() override;
+	virtual void Unmap() override final;
 
 	// copies the contents of the VertexArray into the buffer
-	virtual bool Populate(const VertexArray &) override;
-	
-	virtual void Bind() override;
-	virtual void Release() override;
+	virtual bool Populate(const VertexArray &) override final;
+
+	// change the buffer data without mapping
+	virtual void BufferData(const size_t, void*) override final;
+
+	virtual void Bind() override final;
+	virtual void Release() override final;
 
 protected:
-	virtual Uint8 *MapInternal(BufferMapMode) override;
+	virtual Uint8 *MapInternal(BufferMapMode) override final;
 
 private:
 	GLuint m_vao;
@@ -44,11 +47,14 @@ public:
 	IndexBuffer(Uint32 size, BufferUsage);
 	~IndexBuffer();
 
-	virtual Uint32 *Map(BufferMapMode) override;
-	virtual void Unmap() override;
-	
-	virtual void Bind() override;
-	virtual void Release() override;
+	virtual Uint32 *Map(BufferMapMode) override final;
+	virtual void Unmap() override final;
+
+	// change the buffer data without mapping
+	virtual void BufferData(const size_t, void*) override final;
+
+	virtual void Bind() override final;
+	virtual void Release() override final;
 
 private:
 	Uint32 *m_data;
@@ -58,12 +64,12 @@ private:
 class InstanceBuffer : public Graphics::InstanceBuffer, public GLBufferBase {
 public:
 	InstanceBuffer(Uint32 size, BufferUsage);
-	virtual ~InstanceBuffer() override;
-	virtual matrix4x4f* Map(BufferMapMode) override;
-	virtual void Unmap() override;
+	virtual ~InstanceBuffer() override final;
+	virtual matrix4x4f* Map(BufferMapMode) override final;
+	virtual void Unmap() override final;
 
-	virtual void Bind() override;
-	virtual void Release() override;
+	virtual void Bind() override final;
+	virtual void Release() override final;
 
 protected:
 	enum InstOffs {

--- a/src/graphics/opengl/VtxColorMaterial.h
+++ b/src/graphics/opengl/VtxColorMaterial.h
@@ -21,7 +21,7 @@ namespace Graphics {
 
 		class VtxColorMaterial : public Material {
 		public:
-			virtual Program *CreateProgram(const MaterialDescriptor &);
+			virtual Program *CreateProgram(const MaterialDescriptor &) override final;
 		};
 	}
 }

--- a/src/scenegraph/Label3D.cpp
+++ b/src/scenegraph/Label3D.cpp
@@ -54,7 +54,7 @@ void Label3D::SetText(const std::string &text)
 		// Most noticeably, this means text consisting of entirely Cyrillic
 		// or Chinese characters will vanish when rendered on a Label3D.
 		if (m_geometry->IsEmpty()) { return; }
-		
+
 		//create buffer and upload data
 		Graphics::VertexBufferDesc vbd;
 		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;


### PR DESCRIPTION
This is some generic refactoring, fixing, cleaning of the VertexBuffer, IndexBuffer, Texture classes along wiht more `override final` usage etc.

- Exposing generic textureID accessor, 
- virtual Bind/Unbind methods, 
- override final, 
- naming tweaks 
- BufferData methods

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

