### PR TITLE
Removing some include of ship.h

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -9,7 +9,6 @@
 #include "Pi.h"
 #include "Sfx.h"
 #include "Game.h"
-#include "Planet.h"
 #include "graphics/Graphics.h"
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"

--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -68,7 +68,6 @@ ImTextureID PiGui::RenderSVG(std::string svgFilename, int width, int height) {
 	NSVGimage *image = NULL;
 	NSVGrasterizer *rast = NULL;
 	unsigned char* img = NULL;
-	int w, h;
 	// size of each icon
 	//	int size = 64;
 	// 16 columns
@@ -83,8 +82,7 @@ ImTextureID PiGui::RenderSVG(std::string svgFilename, int width, int height) {
 	if (image == NULL) {
 		Error("Could not open SVG image.\n");
 	}
-	w = static_cast<int>(image->width);
-	h = static_cast<int>(image->height);
+	int w = static_cast<int>(image->width);
 
 	rast = nsvgCreateRasterizer();
 	if (rast == NULL) {

--- a/src/Shields.cpp
+++ b/src/Shields.cpp
@@ -6,7 +6,6 @@
 #include "scenegraph/FindNodeVisitor.h"
 #include "scenegraph/SceneGraph.h"
 #include "scenegraph/CollisionGeometry.h"
-#include "Ship.h"
 #include "Pi.h"
 #include "json/JsonUtils.h"
 #include <sstream>

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -19,6 +19,7 @@
 #include "LuaTable.h"
 #include <list>
 #include <unordered_map>
+#include "graphics/opengl/MultiMaterial.h"
 
 #include "Propulsion.h"
 #include "FixedGuns.h"
@@ -30,12 +31,6 @@ class ShipController;
 class CargoBody;
 class Missile;
 namespace Graphics { class Renderer; }
-
-struct HeatGradientParameters_t {
-	matrix3x3f heatingMatrix;
-	vector3f heatingNormal; // normalised
-	float heatingAmount; // 0.0 to 1.0 used for `u` component of heatGradient texture
-};
 
 struct shipstats_t {
 	int used_capacity;

--- a/src/gameui/ModelSpinner.cpp
+++ b/src/gameui/ModelSpinner.cpp
@@ -3,7 +3,6 @@
 
 #include "ModelSpinner.h"
 #include "Shields.h"
-#include "Ship.h"
 #include "Pi.h"
 #include "Game.h"
 #include "scenegraph/Model.h"

--- a/src/graphics/gl2/GL2MultiMaterial.cpp
+++ b/src/graphics/gl2/GL2MultiMaterial.cpp
@@ -8,9 +8,8 @@
 #include "GL2Renderer.h"
 #include <sstream>
 #include "StringF.h"
-#include "Ship.h"
 
-
+#include "graphics/opengl/MultiMaterial.h"
 
 namespace Graphics {
 namespace GL2 {

--- a/src/graphics/opengl/GenGasGiantColourMaterial.cpp
+++ b/src/graphics/opengl/GenGasGiantColourMaterial.cpp
@@ -7,7 +7,6 @@
 #include "RendererGL.h"
 #include <sstream>
 #include "StringF.h"
-#include "Ship.h"
 #include "galaxy/StarSystem.h"
 
 namespace Graphics {

--- a/src/graphics/opengl/MultiMaterial.cpp
+++ b/src/graphics/opengl/MultiMaterial.cpp
@@ -8,7 +8,6 @@
 #include "TextureGL.h"
 #include <sstream>
 #include "StringF.h"
-#include "Ship.h"
 
 namespace Graphics {
 namespace OGL {

--- a/src/graphics/opengl/MultiMaterial.h
+++ b/src/graphics/opengl/MultiMaterial.h
@@ -11,6 +11,12 @@
 #include "MaterialGL.h"
 #include "Program.h"
 
+struct HeatGradientParameters_t {
+	matrix3x3f heatingMatrix;
+	vector3f heatingNormal; // normalised
+	float heatingAmount; // 0.0 to 1.0 used for `u` component of heatGradient texture
+};
+
 namespace Graphics {
 
 	namespace OGL {


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Here and there I saw `#include "Ship.h"` in unexpected places, and after removing these lines
Pioneer still compiling... So I removed these lines.

I did also some additional things:
- HeatParameter_t moved in "src/graphics/opengl/MultiMaterial.h", because I think ships (and not only them) could use a material, not the material be a "slave" of the ship. But I did something not completely good, because then I created a dependencies in  "src/graphics/gl2/GL2MultiMaterial.cpp".
I feel this is the way and the problem with *dependency* could be solved with a separate file shared from renderers, but I ping @fluffyfreak to share thoughts (also because I don't know how it works...).
- Removed a line generating a warning in PiGui.cpp.

...Some thought I had were about how `#include` is used: to me and IMHO seems there are some case in which `#include` is not used *exactly* the right way: the fact is that without the lines I removed, the files involved weren't recompiled. I think I could do a better job if I'm aware of reasons or the way you (devs) are *including*.

Here a link in order to have some clue:
http://www.cplusplus.com/forum/articles/10627/

What do you think?
