### PR TITLE
Thruster colors can be modified globally or per direction

### DIFF
--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -37,6 +37,20 @@ Intro::Intro(Graphics::Renderer *r, int width, int height)
 	for (auto i : ShipType::player_ships) {
 		SceneGraph::Model *model = Pi::FindModel(ShipType::types[i].modelName)->MakeInstance();
 		model->SetThrust(vector3f(0.f, 0.f, -0.6f), vector3f(0.f));
+		if (ShipType::types[i].isGlobalColorDefined) model->SetThrusterColor(ShipType::types[i].globalThrusterColor);
+		for (int j=0; j<THRUSTER_MAX; j++) {
+			if (!ShipType::types[i].isDirectionColorDefined[j]) continue;
+			vector3f dir;
+			switch (j) {
+				case THRUSTER_FORWARD: dir = vector3f(0.0, 0.0, 1.0); break;
+				case THRUSTER_REVERSE: dir = vector3f(0.0, 0.0, -1.0); break;
+				case THRUSTER_LEFT: dir = vector3f(1.0, 0.0, 0.0); break;
+				case THRUSTER_RIGHT: dir = vector3f(-1.0, 0.0, 0.0); break;
+				case THRUSTER_UP: dir = vector3f(1.0, 0.0, 0.0); break;
+				case THRUSTER_DOWN: dir = vector3f(-1.0, 0.0, 0.0); break;
+			}
+			model->SetThrusterColor(dir, ShipType::types[i].directionThrusterColor[j]);
+		}
 		const Uint32 numMats = model->GetNumMaterials();
 		for( Uint32 m=0; m<numMats; m++ ) {
 			RefCountedPtr<Graphics::Material> mat = model->GetMaterialByIndex(m);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -229,7 +229,6 @@ void Ship::Init()
 	p.Set("fuelMassLeft", m_stats.fuel_tank_mass_left);
 
 	// Init of Propulsion:
-	// TODO: Separe the enum used in ShipType and use it both on Propulsion and ShipType
 	Propulsion::Init( this, GetModel(), m_type->fuelTankMass, m_type->effectiveExhaustVelocity, m_type->linThrust, m_type->angThrust );
 
 	p.Set("shipName", m_shipName);
@@ -300,6 +299,21 @@ Ship::Ship(const ShipType::Id &shipId): DynamicBody(),
 	m_decelerating = false;
 
 	SetModel(m_type->modelName.c_str());
+	// Setting thrusters colors
+	if (m_type->isGlobalColorDefined) GetModel()->SetThrusterColor(m_type->globalThrusterColor);
+	for (int i=0; i<THRUSTER_MAX; i++) {
+		if (!m_type->isDirectionColorDefined[i]) continue;
+		vector3f dir;
+		switch (i) {
+			case THRUSTER_FORWARD: dir = vector3f(0.0, 0.0, 1.0); break;
+			case THRUSTER_REVERSE: dir = vector3f(0.0, 0.0, -1.0); break;
+			case THRUSTER_LEFT: dir = vector3f(1.0, 0.0, 0.0); break;
+			case THRUSTER_RIGHT: dir = vector3f(-1.0, 0.0, 0.0); break;
+			case THRUSTER_UP: dir = vector3f(1.0, 0.0, 0.0); break;
+			case THRUSTER_DOWN: dir = vector3f(-1.0, 0.0, 0.0); break;
+		}
+		GetModel()->SetThrusterColor(dir, m_type->directionThrusterColor[i]);
+	}
 	SetLabel("UNLABELED_SHIP");
 	m_skin.SetRandomColors(Pi::rng);
 	m_skin.SetDecal(m_type->manufacturer);

--- a/src/ShipType.h
+++ b/src/ShipType.h
@@ -41,6 +41,10 @@ struct ShipType {
 	float angThrust;
 	std::map<std::string, int> slots;
 	std::map<std::string, bool> roles;
+	Color globalThrusterColor; // Override default color for thrusters
+	bool isGlobalColorDefined; // If globalThrusterColor is filled with... a color :)
+	Color directionThrusterColor[THRUSTER_MAX];
+	bool isDirectionColorDefined[THRUSTER_MAX];
 	double thrusterUpgrades[4];
 	int capacity; // tonnes
 	int hullMass;

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -9,6 +9,8 @@
 #include "graphics/VertexArray.h"
 #include "StringF.h"
 #include "json/JsonUtils.h"
+#include "FindNodeVisitor.h"
+#include "Thruster.h"
 
 namespace SceneGraph {
 
@@ -470,6 +472,54 @@ void Model::SetThrust(const vector3f &lin, const vector3f &ang)
 	m_renderData.angthrust[0] = ang.x;
 	m_renderData.angthrust[1] = ang.y;
 	m_renderData.angthrust[2] = ang.z;
+}
+
+void Model::SetThrusterColor(const vector3f &dir, const Color &color)
+{
+	assert(m_root!=nullptr);
+
+	FindNodeVisitor thrusterFinder(FindNodeVisitor::MATCH_NAME_FULL, "thrusters");
+	m_root->Accept(thrusterFinder);
+	const std::vector<Node*> &results = thrusterFinder.GetResults();
+	Group* thrusters = static_cast<Group*>(results.at(0));
+
+	for (unsigned int i=0; i<thrusters->GetNumChildren(); i++) {
+		MatrixTransform *mt = static_cast<MatrixTransform*>(thrusters->GetChildAt(i));
+		Thruster* my_thruster = static_cast<Thruster*>(mt->GetChildAt(0));
+		if (my_thruster==nullptr) continue;
+		float dot = my_thruster->GetDirection().Dot(dir);
+		if (dot>0.99) my_thruster->SetColor(color);
+	}
+}
+
+void Model::SetThrusterColor(const std::string &name, const Color &color)
+{
+    assert(m_root!=nullptr);
+
+	FindNodeVisitor thrusterFinder(FindNodeVisitor::MATCH_NAME_FULL, name);
+	m_root->Accept(thrusterFinder);
+	const std::vector<Node*> &results = thrusterFinder.GetResults();
+
+	//Hope there's only 1 result...
+	Thruster* my_thruster = static_cast<Thruster*>(results.at(0));
+	if (my_thruster!=nullptr) my_thruster->SetColor(color);
+}
+
+void Model::SetThrusterColor(const Color &color)
+{
+    assert(m_root!=nullptr);
+
+	FindNodeVisitor thrusterFinder(FindNodeVisitor::MATCH_NAME_FULL, "thrusters");
+	m_root->Accept(thrusterFinder);
+	const std::vector<Node*> &results = thrusterFinder.GetResults();
+	Group* thrusters = static_cast<Group*>(results.at(0));
+
+	for (unsigned int i=0; i<thrusters->GetNumChildren(); i++) {
+		MatrixTransform *mt = static_cast<MatrixTransform*>(thrusters->GetChildAt(i));
+		Thruster* my_thruster = static_cast<Thruster*>(mt->GetChildAt(0));
+		assert(my_thruster!=nullptr);
+		my_thruster->SetColor(color);
+	}
 }
 
 class SaveVisitorJson : public NodeVisitor {

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -153,6 +153,10 @@ public:
 	//special for ship model use
 	void SetThrust(const vector3f &linear, const vector3f &angular);
 
+	void SetThrusterColor(const vector3f &dir, const Color &color);
+	void SetThrusterColor(const std::string &name, const Color &color);
+	void SetThrusterColor(const Color &color);
+
 	void SaveToJson(Json::Value &jsonObj) const;
 	void LoadFromJson(const Json::Value &jsonObj);
 

--- a/src/scenegraph/Node.h
+++ b/src/scenegraph/Node.h
@@ -41,6 +41,7 @@ struct RenderData
 {
 	float linthrust[3];		// 1.0 to -1.0
 	float angthrust[3];		// 1.0 to -1.0
+	Color customColor;
 
 	float boundingRadius;	//updated by model and passed to submodels
 	unsigned int nodemask;

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -22,6 +22,7 @@ Thruster::Thruster(Graphics::Renderer *r, bool _linear, const vector3f &_pos, co
 , linearOnly(_linear)
 , dir(_dir)
 , pos(_pos)
+, currentColor(baseColor)
 {
 	//set up materials
 	Graphics::MaterialDescriptor desc;
@@ -49,6 +50,7 @@ Thruster::Thruster(const Thruster &thruster, NodeCopyCache *cache)
 , linearOnly(thruster.linearOnly)
 , dir(thruster.dir)
 , pos(thruster.pos)
+, currentColor(thruster.currentColor)
 {
 }
 
@@ -87,7 +89,7 @@ void Thruster::Render(const matrix4x4f &trans, const RenderData *rd)
 	}
 	if (power < 0.001f) return;
 
-	m_tMat->diffuse = m_glowMat->diffuse = baseColor * power;
+	m_tMat->diffuse = m_glowMat->diffuse = currentColor * power;
 
 	//directional fade
 	vector3f cdir = vector3f(trans * -dir).Normalized();

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -28,6 +28,8 @@ public:
 	virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
 	virtual void Save(NodeDatabase&) override;
 	static Thruster *Load(NodeDatabase&);
+	void SetColor(const Color c) { currentColor = c; }
+	const vector3f &GetDirection() { return dir; }
 
 private:
 	static Graphics::VertexBuffer* CreateThrusterGeometry(Graphics::Renderer*, Graphics::Material*);
@@ -40,6 +42,7 @@ private:
 	bool linearOnly;
 	vector3f dir;
 	vector3f pos;
+	Color currentColor;
 };
 
 }


### PR DESCRIPTION
![coloredthrusters](https://cloud.githubusercontent.com/assets/13293916/23908576/b3989bb6-08d4-11e7-9ff0-5de9e4dc1683.png)

This add customizable thrusters color for each model (partially close #961) and
also allow to choose customized colors *per direction*, as in screenshot.

...Ping @nozmajner to provide feedback about colors: mine are too
much psychedelic :D 

As you can see in sinonatrix.json, a structure in which each value is a channel
is used (standard "r", "g", "b" are used, values are [0,255] ).

Two global keyword are provided to choose the settings you wish to customize:
- `thruster_global_color` for global color
- `thruster_direction_color` to define colors per direction

Inside `thruster_global_color` you then have values for each channel,
inside `thruster_direction_color` you need to define a struct value for
direction(s) you will overwrite, like:
```
thruster_direction_color {
    [keyword] : {
        "r" : value_for_red,
        "g": value_for_green,
        "b": value_for_blue
    }
    .....
}

```
Recognized keywords are:

1. forward
2. retro
3. left
4. right
5. up
6. down
