### PR TITLE
Ever damage ship when docking

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -385,7 +385,7 @@ bool SpaceStation::OnCollision(Object *b, Uint32 flags, double relVel)
 		if (IsPortLocked(port)) {
 			return DoShipDamage(s, flags, relVel);
 		}
-		if (m_shipDocking[port].stage != 1) return false;	// already docking?
+		if (m_shipDocking[port].stage != 1) return DoShipDamage(s, flags, relVel);	// already docking?
 
 		SpaceStationType::positionOrient_t dport;
 
@@ -401,7 +401,7 @@ bool SpaceStation::OnCollision(Object *b, Uint32 flags, double relVel)
 			float dist = (s->GetPosition() - GetPosition() - GetOrient()*dport.pos).LengthSqr();
 			// docking allowed only if inside a circle 70% greater than pad itself (*1.7)
 			float maxDist = static_cast<float>(m_type->FindPortByBay(port)->maxShipSize/2)*1.7;
-			if (dist > (maxDist*maxDist)) return false;
+			if (dist > (maxDist*maxDist)) return DoShipDamage(s, flags, relVel);
 		}
 
 		// why stage 2? Because stage 1 is permission to dock
@@ -426,7 +426,7 @@ bool SpaceStation::OnCollision(Object *b, Uint32 flags, double relVel)
 			s->SetDockedWith(this, port);				// bounces back to SS::SetDocked()
 			LuaEvent::Queue("onShipDocked", s, this);
 		}
-		return false;
+		return DoShipDamage(s, flags, relVel);
 	} else {
 		return true;
 	}


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

As seen by @jaj22 , this is the bugfix he asked for...

It's not tested but the meaning is: if a collision with docking surface happens,
then *probably* you want the ship bounced back...

Waiting for review
