### PR TITLE
Configure cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,6 @@ AC_SUBST([OPTIMISE])
 dnl Debug stuff
 AC_ARG_ENABLE([debug], AS_HELP_STRING([--enable-debug], [Enable debugging code (stack checks, debug tools features, etc)]), [EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DDEBUG"])
 AC_ARG_ENABLE([remote-lua-repl], AS_HELP_STRING([--enable-remote-lua-repl], [Enable remote lua repl (tcp port 12345 or -DREMOTE_LUA_REPL_PORT=54321]), [EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DREMOTE_LUA_REPL"])
-AC_ARG_ENABLE([ldb], AS_HELP_STRING([--enable-ldb], [Enable ldb support.]), [EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DENABLE_LDB" ; EXTRA_LIBS="$EXTRA_LIBS -lldbcore"])
 AC_ARG_ENABLE([profiler], AS_HELP_STRING([--enable-profiler], [Enable internal profiler]), [EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DPIONEER_PROFILER"])
 
 AC_ARG_WITH([fno-inline],  AS_HELP_STRING([--with-fno-inline], [Compile without inlining. Helps debugging segaults that occur in STL code]), [PIONEER_C_CXX_FLAG([-fno-inline])])

--- a/configure.ac
+++ b/configure.ac
@@ -312,7 +312,11 @@ if test "x$cross_compiling" = "xno" ; then
 fi
 
 dnl Check for libcurl
-PKG_CHECK_MODULES([CURL], [libcurl])
+AC_ARG_WITH([external-liblua], AS_HELP_STRING([--with-serveragent], [Compile in our server agent, adding libcurl as a dependency]), [], [with_server_agent=no; WITH_SERVER_AGENT=no])
+if test "$with_server_agent" = yes; then
+  EXTRA_CPPFLAGS="$EXTRA_CPPFLAGS -DENABLE_SERVER_AGENT"
+  PKG_CHECK_MODULES([CURL], [libcurl])
+fi
 
 dnl Optionally use external liblua
 AC_ARG_WITH([external-liblua], AS_HELP_STRING([--with-external-liblua], [Use external liblua in place of our internal copy]), [], [with_external_liblua=no; HAVE_LUA=no])

--- a/src/LuaServerAgent.cpp
+++ b/src/LuaServerAgent.cpp
@@ -1,6 +1,8 @@
 // Copyright © 2008-2017 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#ifdef ENABLE_SERVER_AGENT
+
 #include "LuaServerAgent.h"
 #include "LuaObject.h"
 #include "LuaRef.h"
@@ -214,3 +216,5 @@ void LuaServerAgent::Register()
 	LuaObjectBase::CreateObject(l_methods, 0, 0);
 	lua_setglobal(Lua::manager->GetLuaState(), "ServerAgent");
 }
+
+#endif

--- a/src/LuaServerAgent.h
+++ b/src/LuaServerAgent.h
@@ -1,6 +1,7 @@
 // Copyright © 2008-2017 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#ifdef ENABLE_SERVER_AGENT
 #ifndef LUASERVERAGENT_H
 #define LUASERVERAGENT_H
 
@@ -8,4 +9,5 @@ namespace LuaServerAgent {
 	void Register();
 }
 
+#endif
 #endif

--- a/src/LuaUtils.cpp
+++ b/src/LuaUtils.cpp
@@ -6,9 +6,6 @@
 #include "FileSystem.h"
 
 extern "C" {
-#ifdef ENABLE_LDB
-#include <ldbcore.h>
-#endif //ENABLE_LDB
 #include "jenkins/lookup3.h"
 }
 
@@ -353,9 +350,6 @@ static const luaL_Reg STANDARD_LIBS[] = {
 	{ LUA_BITLIBNAME, luaopen_bit32 },
 	{ LUA_MATHLIBNAME, luaopen_math },
 	{ LUA_DBLIBNAME, luaopen_debug },
-#ifdef ENABLE_LDB
-	{ LUA_LDBCORELIBNAME, luaopen_ldbcore},
-#endif //ENABLE_LDB
 	{ "util", luaopen_utils },
 	{ 0, 0 }
 };

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -103,7 +103,9 @@ sigc::signal<void> Pi::onPlayerChangeFlightControlState;
 LuaSerializer *Pi::luaSerializer;
 LuaTimer *Pi::luaTimer;
 LuaNameGen *Pi::luaNameGen;
+#ifdef ENABLE_SERVER_AGENT
 ServerAgent *Pi::serverAgent;
+#endif
 int Pi::keyModState;
 std::map<SDL_Keycode,bool> Pi::keyState; // XXX SDL2 SDLK_LAST
 char Pi::mouseButton[6];
@@ -285,7 +287,9 @@ static void LuaInit()
 	LuaLang::Register();
 	LuaEngine::Register();
 	LuaFileSystem::Register();
+#ifdef ENABLE_SERVER_AGENT
 	LuaServerAgent::Register();
+#endif
 	LuaGame::Register();
 	LuaComms::Register();
 	LuaFormat::Register();
@@ -544,6 +548,7 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 		Graphics::GetScreenHeight(),
 		ui_scale));
 
+#ifdef ENABLE_SERVER_AGENT
 	Pi::serverAgent = 0;
 	if (config->Int("EnableServerAgent")) {
 		const std::string endpoint(config->String("ServerEndpoint"));
@@ -556,6 +561,7 @@ void Pi::Init(const std::map<std::string,std::string> &options, bool no_gui)
 		Output("Server agent disabled\n");
 		Pi::serverAgent = new NullServerAgent();
 	}
+#endif
 
 	LuaInit();
 
@@ -1260,7 +1266,9 @@ void Pi::Start()
 		_time += Pi::frameTime;
 		last_time = SDL_GetTicks();
 
+#ifdef ENABLE_SERVER_AGENT
 		Pi::serverAgent->ProcessResponses();
+#endif
 	}
 
 	ui->DropAllLayers();
@@ -1337,7 +1345,9 @@ void Pi::MainLoop()
 	while (Pi::game) {
 		PROFILE_SCOPED()
 
+#ifdef ENABLE_SERVER_AGENT
 		Pi::serverAgent->ProcessResponses();
+#endif
 
 		const Uint32 newTicks = SDL_GetTicks();
 		double newTime = 0.001 * double(newTicks);

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -32,7 +32,9 @@ class TransferPlanner;
 class UIView;
 class View;
 class SDLGraphics;
+#if ENABLE_SERVER_AGENT
 class ServerAgent;
+#endif
 namespace Graphics { class Renderer; }
 namespace SceneGraph { class Model; }
 namespace Sound { class MusicPlayer; }
@@ -128,7 +130,9 @@ public:
 
 	static LuaNameGen *luaNameGen;
 
+#if ENABLE_SERVER_AGENT
 	static ServerAgent *serverAgent;
+#endif
 
 	static RefCountedPtr<UI::Context> ui;
     static RefCountedPtr<PiGui> pigui;

--- a/src/ServerAgent.cpp
+++ b/src/ServerAgent.cpp
@@ -1,6 +1,8 @@
 // Copyright © 2008-2017 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#ifdef ENABLE_SERVER_AGENT
+
 #if defined(_MSC_VER) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
@@ -218,3 +220,4 @@ const std::string &HTTPServerAgent::UserAgent()
 	return userAgent;
 }
 
+#endif //ENABLE_SERVER_AGENT

--- a/src/ServerAgent.h
+++ b/src/ServerAgent.h
@@ -1,6 +1,7 @@
 // Copyright © 2008-2017 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#ifdef ENABLE_SERVER_AGENT
 #ifndef SERVERAGENT_H
 #define SERVERAGENT_H
 
@@ -116,3 +117,4 @@ private:
 };
 
 #endif
+#endif // ENABLE_SERVER_AGENT


### PR DESCRIPTION
Remove the LDB thingy I wrote back in the days of 1719, and make the Server Agent an opt-in compile-time option.

Note that the agent will also be disabled in the Windows and Mac builds, but I haven't disabled the libcurl dependency for those yet.

The rationale for the server agent thing is quite simple : we don't use it, and the libcurl dependency is a pain because some distros ship with a SONAME of 3 by default (Debian) whereas others only ship the SONAME 4.
For LDB, well, it's just broken and unused.

I didn't actually test the build WITH the server agent, but the default builds fine, and doesn't crash in the first 10 seconds of gameplay.

