### PR TITLE
Fix PhysRadius calculation for low orbiting bodies.

### DIFF
--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -86,7 +86,9 @@ void Planet::InitParams(const SystemBody *sbody)
 	}
 	m_atmosphereRadius = h + sbody->GetRadius();
 
-	SetPhysRadius(std::max(m_atmosphereRadius, std::max(GetMaxFeatureRadius() * 2.0 + 2000, sbody->GetRadius() * 1.05)));
+	SetPhysRadius(std::max(m_atmosphereRadius, GetMaxFeatureRadius()+1000));
+	// NB: Below abandoned due to docking problems with low altitude orbiting space stations
+	// SetPhysRadius(std::max(m_atmosphereRadius, std::max(GetMaxFeatureRadius() * 2.0 + 2000, sbody->GetRadius() * 1.05)));
 	if (sbody->HasRings()) {
 		SetClipRadius(sbody->GetRadius() * sbody->GetRings().maxRadius.ToDouble());
 	} else {


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
This fixes #3946 by returning to the older PhysRadius calculation which was far less generous.

As a results some bodies, especially those with small differences in average and maximum height, will become more difficult to land upon.

Commit: _Return to the older PhysRadius calculation._
<!-- Please make sure you've read documentation on contributing -->

