### PR TITLE
Bugfix for issue #3967 related to PR #3948

### DIFF
--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -117,9 +117,10 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 		}
 	}
 	if (error==true) {
-		isGlobalColorDefined = false;
 		Output("In file \"%s.json\" global thrusters custom color must be \"r\",\"g\" and \"b\"\n", modelName.c_str());
-	} else {
+	} else if (parse>0&&parse<3) {
+		Output("In file \"%s.json\" global thrusters custom color is malformed\n", modelName.c_str());
+	} else if (parse==3) {
 		globalThrusterColor.a = 255;
 		isGlobalColorDefined = true;
 	}


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Correct the behavior when no customized global color thruster for a model is specified

Closes #3967