### PR TITLE
Initialise the TextureFont to 0

### DIFF
--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -624,6 +624,13 @@ TextureFont::TextureFont(const FontConfig &config, Graphics::Renderer *renderer,
 	m_mat.reset(m_renderer->CreateMaterial(desc));
 	Graphics::TextureDescriptor textureDescriptor(m_texFormat, vector2f(ATLAS_SIZE), Graphics::NEAREST_CLAMP, false, false, false, 0, Graphics::TEXTURE_2D);
 	m_texture.Reset(m_renderer->CreateTexture(textureDescriptor));
+	{
+		const size_t sz = m_bpp * ATLAS_SIZE * ATLAS_SIZE;
+		char *buf = static_cast<char*>(malloc(sz));
+		memset(buf, 0, sz);
+		m_texture->Update(buf, vector2f(0.0f, 0.0f), vector2f(ATLAS_SIZE, ATLAS_SIZE), m_texFormat);
+		free(buf);
+	}
 	m_mat->texture0 = m_texture.Get();
 
 	// font-wide metrics. we assume that these match for all faces


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Initialise the TextureFont to 0 to eliminate underlining even at high AA levels.

Fixes #2954 acceptably.
<!-- Please make sure you've read documentation on contributing -->

