### PR TITLE
Fix warnings

### DIFF
--- a/src/FixedGuns.cpp
+++ b/src/FixedGuns.cpp
@@ -41,7 +41,7 @@ void FixedGuns::Init(DynamicBody *b)
 	b->AddFeature( DynamicBody::FIXED_GUNS );
 }
 
-void FixedGuns::SaveToJson( Json::Value &jsonObj )
+void FixedGuns::SaveToJson( Json::Value &jsonObj, Space *space )
 {
 
 	Json::Value gunArray(Json::arrayValue); // Create JSON array to contain gun data.
@@ -57,7 +57,7 @@ void FixedGuns::SaveToJson( Json::Value &jsonObj )
 	jsonObj["guns"] = gunArray; // Add gun array to ship object.
 };
 
-void FixedGuns::LoadFromJson(const Json::Value &jsonObj )
+void FixedGuns::LoadFromJson( const Json::Value &jsonObj, Space *space )
 {
 	Json::Value gunArray = jsonObj["guns"];
 

--- a/src/FixedGuns.h
+++ b/src/FixedGuns.h
@@ -39,8 +39,8 @@ class FixedGuns
 		inline void SetCoolingBoost( float cooler ) { m_cooler_boost = cooler; };
 		inline void SetGunFiringState( int idx, int s ) { if (m_gun_present[idx]) m_state[idx] = s; };
 	protected:
-		virtual void SaveToJson( Json::Value &jsonObj );
-		virtual void LoadFromJson( const Json::Value &jsonObj );
+		virtual void SaveToJson( Json::Value &jsonObj, Space *space);
+		virtual void LoadFromJson( const Json::Value &jsonObj, Space *space);
 	private:
 
 		struct GunData {

--- a/src/LuaObject.h
+++ b/src/LuaObject.h
@@ -241,12 +241,13 @@ protected:
 	LuaObject() : LuaObjectBase(s_type) {}
 
 private:
-
 	// initial lua type string. defined in a specialisation in the appropriate
 	// .cpp file
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundefined-var-template"
 	static const char *s_type;
+#pragma clang diagnostic pop
 };
-
 
 // wrapper for a "core" object - one owned by c++ (eg Body).
 // Lua needs to know when the object is deleted so that it can handle

--- a/src/RandomColor.cpp
+++ b/src/RandomColor.cpp
@@ -4,6 +4,7 @@
 #include "RandomColor.h"
 #include "libs.h"
 #include <algorithm>
+#include "utils.h"
 
 namespace RandomColorGenerator
 {
@@ -100,6 +101,9 @@ namespace RandomColorGenerator
 		case Luminosity::LUMINOSITY_LIGHT:
 			sMax = 55;
 			break;
+		default:
+			Output("RandomColor::PickSaturation: Unhandled case in switch: %i\n", luminosity);
+			break;
 		}
 
 		return RandomWithin(sMin, sMax);
@@ -125,6 +129,9 @@ namespace RandomColorGenerator
 			bMin = 0;
 			bMax = 100;
 			break;
+		default:
+			Output("RandomColor::PickSaturation: Unhandled case in switch: %i\n", luminosity);
+			break;
 		}
 
 		return RandomWithin(bMin, bMax);
@@ -148,7 +155,7 @@ namespace RandomColorGenerator
 				auto m = (v2 - v1) / (s2 - s1);
 				auto b = v1 - m * s1;
 
-				return (int)(m * S + b);
+				return static_cast<int>(m * S + b);
 			}
 		}
 
@@ -305,7 +312,7 @@ namespace RandomColorGenerator
 		auto s = saturation / 100.0;
 		auto v = value / 100.0;
 
-		auto hInt = (int)floor(h * 6.0);
+		auto hInt = static_cast<int>(floor(h * 6.0));
 		auto f = h * 6 - hInt;
 		auto p = v * (1 - s);
 		auto q = v * (1 - f * s);
@@ -323,10 +330,10 @@ namespace RandomColorGenerator
 		case 4: r = t; g = p; b = v; break;
 		case 5: r = v; g = p; b = q; break;
 		}
-		auto c = Color((Uint8)floor(r * 255.0),
-			(Uint8)floor(g * 255.0),
-			(Uint8)floor(b * 255.0),
-			255);
+		auto c = Color(static_cast<Uint8>(floor(r * 255.0)),
+									 static_cast<Uint8>(floor(g * 255.0)),
+									 static_cast<Uint8>(floor(b * 255.0)),
+									 255);
 
 		return c;
 	}

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -262,9 +262,9 @@ void Ship::PostLoadFixup(Space *space)
 }
 
 Ship::Ship(const ShipType::Id &shipId): DynamicBody(),
-	m_flightState(FLYING),
-	m_alertState(ALERT_NONE),
 	m_controller(0),
+  m_flightState(FLYING),
+  m_alertState(ALERT_NONE),
 	m_landingGearAnimation(nullptr)
 {
 	Properties().Set("flightState", EnumStrings::GetString("ShipFlightState", m_flightState));

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -57,7 +57,7 @@ void Ship::SaveToJson(Json::Value &jsonObj, Space *space)
 	shipObj["hyperspace_destination"] = hyperspaceDestObj; // Add hyperspace destination object to ship object.
 	shipObj["hyperspace_countdown"] = FloatToStr(m_hyperspace.countdown);
 
-	FixedGuns::SaveToJson( shipObj );
+	FixedGuns::SaveToJson( shipObj, space );
 
 	shipObj["ecm_recharge"] = FloatToStr(m_ecmRecharge);
 	shipObj["ship_type_id"] = m_type->id;
@@ -131,7 +131,7 @@ void Ship::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	m_hyperspace.countdown = StrToFloat(shipObj["hyperspace_countdown"].asString());
 	m_hyperspace.duration = 0;
 
-	FixedGuns::LoadFromJson( shipObj );
+	FixedGuns::LoadFromJson( shipObj, space );
 
 	m_ecmRecharge = StrToFloat(shipObj["ecm_recharge"].asString());
 	SetShipId(shipObj["ship_type_id"].asString()); // XXX handle missing thirdparty ship

--- a/src/SpaceStationType.cpp
+++ b/src/SpaceStationType.cpp
@@ -131,8 +131,8 @@ void SpaceStationType::OnSetupComplete()
 
 		// find the port and setup the rest of it's information
 		bool bFoundPort = false;
-		matrix4x4f approach1;
-		matrix4x4f approach2;
+		matrix4x4f approach1(0.0);
+		matrix4x4f approach2(0.0);
 		for(auto &rPort : m_ports) {
 			if(rPort.portId == portId) {
 				rPort.minShipSize = std::min(minSize,rPort.minShipSize);

--- a/src/graphics/WindowSDL.cpp
+++ b/src/graphics/WindowSDL.cpp
@@ -107,7 +107,7 @@ WindowSDL::WindowSDL(Graphics::Settings &vs, const std::string &name) {
 
 	if (!ok && vs.rendererType != Graphics::RENDERER_OPENGL_21)
 	{
-		Output("Retrying all previous modes using an OpenGL 2.1 context\n", SDL_GetError());
+		Output("Retrying all previous modes using an OpenGL 2.1 context: %s\n", SDL_GetError());
 		vs.rendererType = Graphics::RENDERER_OPENGL_21;
 
 		// attempt sequence is:

--- a/src/graphics/dummy/TextureDummy.h
+++ b/src/graphics/dummy/TextureDummy.h
@@ -10,14 +10,14 @@ namespace Graphics {
 
 class TextureDummy : public Texture {
 public:
-	virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) {}
-	virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) {}
+	virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override {}
+	virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override {}
 
-	void Bind() {}
-	void Unbind() {}
+	void Bind() override {}
+	void Unbind() override {}
 
-	virtual void SetSampleMode(TextureSampleMode) {}
-	virtual void BuildMipmaps() {}
+	virtual void SetSampleMode(TextureSampleMode) override {}
+	virtual void BuildMipmaps() override {}
 	virtual uint32_t GetTextureID() const override final { return 0U; }
 
 private:

--- a/src/graphics/gl2/GL2FresnelColourMaterial.cpp
+++ b/src/graphics/gl2/GL2FresnelColourMaterial.cpp
@@ -12,7 +12,7 @@
 namespace Graphics {
 namespace GL2 {
 
-FresnelColourProgram::FresnelColourProgram(const MaterialDescriptor &desc, int lights)
+FresnelColourProgram::FresnelColourProgram(const MaterialDescriptor &desc, int the_lights)
 {
 	//build some defines
 	std::stringstream ss;

--- a/src/graphics/gl2/GL2FresnelColourMaterial.h
+++ b/src/graphics/gl2/GL2FresnelColourMaterial.h
@@ -16,7 +16,7 @@ namespace Graphics {
 	namespace GL2 {
 		class FresnelColourProgram : public Program {
 		public:
-			FresnelColourProgram(const MaterialDescriptor &, int lights=0);
+			FresnelColourProgram(const MaterialDescriptor &, int the_lights=0);
 		};
 
 		class FresnelColourMaterial : public Material { //unlit

--- a/src/graphics/gl2/GL2GasGiantMaterial.cpp
+++ b/src/graphics/gl2/GL2GasGiantMaterial.cpp
@@ -141,7 +141,7 @@ void GasGiantSurfaceMaterial::SetGSUniforms()
 void GasGiantSurfaceMaterial::SwitchShadowVariant()
 {
 	const GeoSphere::MaterialParameters params = *static_cast<GeoSphere::MaterialParameters*>(this->specialParameter0);
-	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
+	//	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	//request a new shadow variation
 	if (m_curNumShadows != params.shadows.size()) {
 		m_curNumShadows = std::min(Uint32(params.shadows.size()), 4U);

--- a/src/graphics/gl2/GL2GeoSphereMaterial.cpp
+++ b/src/graphics/gl2/GL2GeoSphereMaterial.cpp
@@ -165,7 +165,7 @@ void GeoSphereSurfaceMaterial::SetGSUniforms()
 void GeoSphereSurfaceMaterial::SwitchShadowVariant()
 {
 	const GeoSphere::MaterialParameters params = *static_cast<GeoSphere::MaterialParameters*>(this->specialParameter0);
-	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
+	// std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	//request a new shadow variation
 	if (m_curNumShadows != params.shadows.size()) {
 		m_curNumShadows = std::min(Uint32(params.shadows.size()), 4U);

--- a/src/graphics/gl2/GL2Renderer.cpp
+++ b/src/graphics/gl2/GL2Renderer.cpp
@@ -134,7 +134,7 @@ RendererGL2::RendererGL2(WindowSDL *window, const Graphics::Settings &vs)
 		Error("GLEW initialisation failed: %s", glewGetErrorString(glew_err));
 
 	// pump this once as glewExperimental is necessary but spews a single error
-	GLenum err = glGetError();
+	glGetError();
 
 	if (!glewIsSupported("GL_VERSION_2_1") )
 	{

--- a/src/graphics/gl2/GL2Renderer.h
+++ b/src/graphics/gl2/GL2Renderer.h
@@ -132,7 +132,7 @@ protected:
 	void DisableVertexAttributes(const VertexBuffer*);
 	void DisableVertexAttributes();
 	int m_numLights;
-	int m_numDirLights;
+	unsigned int m_numDirLights;
 	std::vector<GLuint> m_vertexAttribsSet;
 	float m_minZNear;
 	float m_maxZFar;

--- a/src/graphics/gl2/GL2Renderer.h
+++ b/src/graphics/gl2/GL2Renderer.h
@@ -101,7 +101,7 @@ public:
 	virtual IndexBuffer *CreateIndexBuffer(Uint32 size, BufferUsage) override final;
 	virtual InstanceBuffer *CreateInstanceBuffer(Uint32 size, BufferUsage) override final;
 
-	virtual bool ReloadShaders();
+	virtual bool ReloadShaders() override;
 
 	virtual const matrix4x4f& GetCurrentModelView() const  override final { return m_modelViewStack.top(); }
 	virtual const matrix4x4f& GetCurrentProjection() const  override final { return m_projectionStack.top(); }

--- a/src/graphics/gl2/GL2SphereImpostorMaterial.h
+++ b/src/graphics/gl2/GL2SphereImpostorMaterial.h
@@ -14,7 +14,7 @@ namespace Graphics {
 
 		class SphereImpostorMaterial : public Material {
 		public:
-			Program *CreateProgram(const MaterialDescriptor &) {
+			Program *CreateProgram(const MaterialDescriptor &) override {
 				return new Program("billboard_sphereimpostor", "");
 			}
 

--- a/src/graphics/gl2/GL2Texture.h
+++ b/src/graphics/gl2/GL2Texture.h
@@ -25,7 +25,7 @@ public:
 	virtual void SetSampleMode(TextureSampleMode) override final;
 	virtual uint32_t GetTextureID() const override final { assert(sizeof(uint32_t)==sizeof(GLuint)); return m_texture; }
 
-	void BuildMipmaps();
+	void BuildMipmaps() override;
 
 private:
 	GLenum m_target;

--- a/src/graphics/gl2/GL2VertexBuffer.cpp
+++ b/src/graphics/gl2/GL2VertexBuffer.cpp
@@ -319,7 +319,7 @@ void VertexBuffer::BufferData(const size_t size, void *data)
 	if (GetDesc().usage == BUFFER_USAGE_DYNAMIC) {
 		glBindVertexArray(m_vao);
 		glBindBuffer(GL_ARRAY_BUFFER, m_buffer);
-		glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)size, (GLvoid*)data, GL_DYNAMIC_DRAW);
+		glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(size), static_cast<GLvoid*>(data), GL_DYNAMIC_DRAW);
 	}
 }
 
@@ -427,7 +427,7 @@ void IndexBuffer::BufferData(const size_t size, void *data)
 	assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
 	if (GetUsage() == BUFFER_USAGE_DYNAMIC) {
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_buffer);
-		glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)size, (GLvoid*)data, GL_DYNAMIC_DRAW);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, static_cast<GLsizeiptr>(size), static_cast<GLvoid*>(data), GL_DYNAMIC_DRAW);
 	}
 }
 

--- a/src/graphics/opengl/GasGiantMaterial.cpp
+++ b/src/graphics/opengl/GasGiantMaterial.cpp
@@ -141,7 +141,7 @@ void GasGiantSurfaceMaterial::SetGSUniforms()
 void GasGiantSurfaceMaterial::SwitchShadowVariant()
 {
 	const GeoSphere::MaterialParameters params = *static_cast<GeoSphere::MaterialParameters*>(this->specialParameter0);
-	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
+	// std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	//request a new shadow variation
 	if (m_curNumShadows != params.shadows.size()) {
 		m_curNumShadows = std::min(Uint32(params.shadows.size()), 4U);

--- a/src/graphics/opengl/GeoSphereMaterial.cpp
+++ b/src/graphics/opengl/GeoSphereMaterial.cpp
@@ -166,7 +166,7 @@ void GeoSphereSurfaceMaterial::SetGSUniforms()
 void GeoSphereSurfaceMaterial::SwitchShadowVariant()
 {
 	const GeoSphere::MaterialParameters params = *static_cast<GeoSphere::MaterialParameters*>(this->specialParameter0);
-	std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
+	// std::vector<Camera::Shadow>::const_iterator it = params.shadows.begin(), itEnd = params.shadows.end();
 	//request a new shadow variation
 	if (m_curNumShadows != params.shadows.size()) {
 		m_curNumShadows = std::min(Uint32(params.shadows.size()), 4U);

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -76,7 +76,7 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 		Error("GLEW initialisation failed: %s", glewGetErrorString(glew_err));
 
 	// pump this once as glewExperimental is necessary but spews a single error
-	GLenum err = glGetError();
+	glGetError();
 
 	if (!glewIsSupported("GL_VERSION_3_1") )
 	{
@@ -102,7 +102,7 @@ RendererOGL::RendererOGL(WindowSDL *window, const Graphics::Settings &vs)
 		}
 	}
 
-	const char *ver = (const char *)glGetString(GL_VERSION);
+	const char *ver = reinterpret_cast<const char *>(glGetString(GL_VERSION));
 	if (vs.gl3ForwardCompatible && strstr(ver, "9.17.10.4229")) {
 		Warning("Driver needs GL3ForwardCompatible=0 in config.ini to display billboards (stars, navlights etc.)");
 	}

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -321,7 +321,7 @@ void VertexBuffer::BufferData(const size_t size, void *data)
 	if (GetDesc().usage == BUFFER_USAGE_DYNAMIC) {
 		glBindVertexArray(m_vao);
 		glBindBuffer(GL_ARRAY_BUFFER, m_buffer);
-		glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)size, (GLvoid*)data, GL_DYNAMIC_DRAW);
+		glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(size), static_cast<GLvoid*>(data), GL_DYNAMIC_DRAW);
 	}
 }
 
@@ -431,7 +431,7 @@ void IndexBuffer::BufferData(const size_t size, void *data)
 	assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
 	if (GetUsage() == BUFFER_USAGE_DYNAMIC) {
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_buffer);
-		glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)size, (GLvoid*)data, GL_DYNAMIC_DRAW);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, static_cast<GLsizeiptr>(size), static_cast<GLvoid*>(data), GL_DYNAMIC_DRAW);
 	}
 }
 

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -10,10 +10,13 @@
 #include "TextSupport.h"
 #include "utils.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_STROKER_H
 #include FT_GLYPH_H
+#pragma clang diagnostic pop
 
 #undef FT_FILE // defined by FreeType, conflicts with a symbol name from FileSystem
 


### PR DESCRIPTION
Fix all warnings for gcc and all but one for clang.

Clang warning is:
In file included from StarSystem.cpp:12:
In file included from ./../Pi.h:12:
In file included from ./../LuaSerializer.h:8:
./../LuaObject.h:241:30: warning: instantiation of variable 'LuaObject<StarSystem>::s_type' required here, but no definition is available
      [-Wundefined-var-template]
        LuaObject() : LuaObjectBase(s_type) {}
                                    ^
./../LuaObject.h:289:2: note: in instantiation of member function 'LuaObject<StarSystem>::LuaObject' requested here
        LuaSharedObject(T *o) : m_object(o) {}
        ^
./../LuaObject.h:337:70: note: in instantiation of member function 'LuaSharedObject<StarSystem>::LuaSharedObject' requested here
                Register(new (LuaObjectBase::Allocate(sizeof(LuaSharedObject<T>))) LuaSharedObject<T>(static_cast<T*>(o)));
                                                                                   ^
./../LuaEvent.h:45:19: note: in instantiation of member function 'LuaObject<StarSystem>::PushToLua' requested here
                        LuaObject<T0>::PushToLua(arg0);
                                       ^
./../LuaEvent.h:39:3: note: in instantiation of member function 'LuaEvent::Args<StarSystem, void>::PrepareStack' requested here
                Args(T0 *_arg0) : arg0(_arg0) { }
                ^
./../LuaEvent.h:90:16: note: in instantiation of member function 'LuaEvent::Args<StarSystem, void>::Args' requested here
                Queue(event, Args<T0>(arg0));
                             ^
StarSystem.cpp:769:12: note: in instantiation of function template specialization 'LuaEvent::Queue<StarSystem>' requested here
        LuaEvent::Queue("onSystemExplored", this);
                  ^
./../LuaObject.h:248:21: note: forward declaration of template entity is here
        static const char *s_type;
                           ^
./../LuaObject.h:241:30: note: add an explicit instantiation declaration to suppress this warning if 'LuaObject<StarSystem>::s_type' is explicitly
      instantiated in another translation unit
        LuaObject() : LuaObjectBase(s_type) {}

I'm having a hard time understanding how to correctly fix this.