### PR TITLE
clang only warnings silenced on other platforms.

### DIFF
--- a/src/LuaObject.h
+++ b/src/LuaObject.h
@@ -243,10 +243,14 @@ protected:
 private:
 	// initial lua type string. defined in a specialisation in the appropriate
 	// .cpp file
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundefined-var-template"
+#endif
 	static const char *s_type;
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 };
 
 // wrapper for a "core" object - one owned by c++ (eg Body).

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -10,13 +10,17 @@
 #include "TextSupport.h"
 #include "utils.h"
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wold-style-cast"
+#endif
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_STROKER_H
 #include FT_GLYPH_H
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #undef FT_FILE // defined by FreeType, conflicts with a symbol name from FileSystem
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Does exactly as the title says: clang only warnings silenced on other platforms.
<!-- Please make sure you've read documentation on contributing -->

