### PR TITLE
Add :space_station_type to CustomSystemBody

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -171,7 +171,7 @@ void SpaceStation::PostLoadFixup(Space *space)
 	}
 }
 
-SpaceStation::SpaceStation(const SystemBody *sbody): ModelBody()
+SpaceStation::SpaceStation(const SystemBody *sbody): ModelBody(), m_type(nullptr)
 {
 	m_sbody = sbody;
 
@@ -188,7 +188,14 @@ void SpaceStation::InitStation()
 	for(int i=0; i<NUM_STATIC_SLOTS; i++) m_staticSlot[i] = false;
 	Random rand(m_sbody->GetSeed());
 	const bool ground = m_sbody->GetType() == SystemBody::TYPE_STARPORT_ORBITAL ? false : true;
-	m_type = SpaceStationType::RandomStationType(rand, ground);
+	const std::string &space_station_type = m_sbody->GetSpaceStationType();
+	if(space_station_type != "") {
+		m_type = SpaceStationType::FindByName(space_station_type);
+		if(m_type == nullptr)
+			Output("WARNING: SpaceStation::InitStation wants to initialize a custom station of type %s, but no station type with that id has been found.\n", space_station_type.c_str());
+	}
+	if(m_type == nullptr)
+		m_type = SpaceStationType::RandomStationType(rand, ground);
 
 	if(m_shipDocking.empty()) {
 		m_shipDocking.reserve(m_type->NumDockingPorts());

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -31,7 +31,7 @@ public:
 
 	// Should point to SystemBody in Pi::currentSystem
 	SpaceStation(const SystemBody *);
-	SpaceStation() {}
+	SpaceStation() : m_type(nullptr) {}
 	virtual ~SpaceStation();
 	virtual vector3d GetAngVelocity() const { return vector3d(0,m_type->AngVel(),0); }
 	virtual bool OnCollision(Object *b, Uint32 flags, double relVel) override;

--- a/src/SpaceStationType.cpp
+++ b/src/SpaceStationType.cpp
@@ -426,3 +426,14 @@ const SpaceStationType* SpaceStationType::RandomStationType(Random &random, cons
 
 	return &orbitalTypes[ random.Int32(SpaceStationType::orbitalTypes.size()) ];
 }
+
+/*static*/
+const SpaceStationType *SpaceStationType::FindByName(const std::string &name) {
+	for(auto &sst : surfaceTypes)
+		if(sst.id == name)
+			return &sst;
+	for(auto &sst : orbitalTypes)
+		if(sst.id == name)
+			return &sst;
+	return nullptr;
+}

--- a/src/SpaceStationType.h
+++ b/src/SpaceStationType.h
@@ -92,6 +92,7 @@ public:
 	static void Init();
 
 	static const SpaceStationType* RandomStationType(Random &random, const bool bIsGround);
+	static const SpaceStationType *FindByName(const std::string &name);
 };
 
 #endif

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -94,6 +94,14 @@ static int l_csb_new(lua_State *L)
 		lua_settop(L, 1); return 1;                        \
 	}
 
+#define CSB_FIELD_SETTER_STRING(luaname, fieldname)        \
+	static int l_csb_ ## luaname (lua_State *L) {          \
+		CustomSystemBody *csb = l_csb_check(L, 1);         \
+		std::string value = luaL_checkstring(L, 2);        \
+		csb->fieldname = value;                            \
+		lua_settop(L, 1); return 1;                        \
+	}
+
 CSB_FIELD_SETTER_FIXED_POSITIVE(radius, radius)
 CSB_FIELD_SETTER_FIXED_POSITIVE(mass, mass)
 CSB_FIELD_SETTER_INT(temp, averageTemp)
@@ -110,6 +118,7 @@ CSB_FIELD_SETTER_FIXED(atmos_oxidizing, atmosOxidizing)
 CSB_FIELD_SETTER_FIXED(ocean_cover, volatileLiquid)
 CSB_FIELD_SETTER_FIXED(ice_cover, volatileIces)
 CSB_FIELD_SETTER_FIXED(life, life)
+CSB_FIELD_SETTER_STRING(space_station_type, spaceStationType)
 
 #undef CSB_FIELD_SETTER_FIXED
 #undef CSB_FIELD_SETTER_FLOAT
@@ -245,6 +254,7 @@ static luaL_Reg LuaCustomSystemBody_meta[] = {
 	{ "atmos_oxidizing", &l_csb_atmos_oxidizing },
 	{ "ocean_cover", &l_csb_ocean_cover },
 	{ "ice_cover", &l_csb_ice_cover },
+	{ "space_station_type", &l_csb_space_station_type },
 	{ "life", &l_csb_life },
 	{ "rings", &l_csb_rings },
 	{ "__gc", &l_csb_gc },

--- a/src/galaxy/CustomSystem.h
+++ b/src/galaxy/CustomSystem.h
@@ -61,6 +61,7 @@ public:
 
 	Uint32 seed;
 	bool   want_rand_seed;
+	std::string spaceStationType;
 };
 
 class CustomSystem {

--- a/src/galaxy/StarSystem.h
+++ b/src/galaxy/StarSystem.h
@@ -224,6 +224,8 @@ public:
 
 	StarSystem* GetStarSystem() const { return m_system; }
 
+	const std::string &GetSpaceStationType() const { return m_space_station_type; }
+
 private:
 	friend class StarSystem;
 	friend class ObjectViewerView;
@@ -280,6 +282,8 @@ private:
 	double m_atmosDensity;
 
 	StarSystem *m_system;
+
+	std::string m_space_station_type;
 };
 
 class StarSystem : public RefCounted {

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -505,7 +505,7 @@ void StarSystemCustomGenerator::CustomGetKidsOf(RefCountedPtr<StarSystem::Genera
 		kid->m_volcanicity    = csbody->volcanicity;
 		kid->m_atmosOxidizing = csbody->atmosOxidizing;
 		kid->m_life           = csbody->life;
-
+    kid->m_space_station_type = csbody->spaceStationType;
 		kid->m_rotationPeriod = csbody->rotationPeriod;
 		kid->m_rotationalPhaseAtStart = csbody->rotationalPhaseAtStart;
 		kid->m_eccentricity = csbody->eccentricity;


### PR DESCRIPTION
You can now use :space_station_type("new_ground") etc. to specify
the exact type of station model to use. The name is the json filename
without the extension.
