### PR TITLE
Simple atmospheric crush pressure

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -91,6 +91,24 @@ void Player::InitCockpit()
 		m_cockpit.reset(new ShipCockpit(cockpitModelName));
 }
 
+bool Player::DoCrushDamage(float kgDamage)
+{
+	bool r = Ship::DoCrushDamage(kgDamage);
+	// Don't fire audio on EVERY iteration (aka every 16ms, or 60fps), only when exceeds a value randomly
+	const float dam = kgDamage*0.01f;
+	if (Pi::rng.Double() < dam)
+	{
+		if (!IsDead() && (GetPercentHull() < 25.0f)) {
+			Sound::BodyMakeNoise(this, "warning", .5f);
+		}
+		if (dam < (0.01 * float(GetShipType()->hullMass)))
+			Sound::BodyMakeNoise(this, "Hull_hit_Small", 1.0f);
+		else
+			Sound::BodyMakeNoise(this, "Hull_Hit_Medium", 1.0f);
+	}
+	return r;
+}
+
 //XXX perhaps remove this, the sound is very annoying
 bool Player::OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData)
 {

--- a/src/Player.h
+++ b/src/Player.h
@@ -20,6 +20,7 @@ public:
 	Player(const ShipType::Id &shipId);
 	Player() {}; //default constructor used before Load
 	virtual void SetDockedWith(SpaceStation *, int port) override;
+	virtual bool DoCrushDamage(float kgDamage) override final; // overloaded to add "crush" audio
 	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact& contactData) override;
 	virtual bool SetWheelState(bool down) override; // returns success of state change, NOT state itself
 	virtual Missile * SpawnMissile(ShipType::Id missile_type, int power=-1) override;
@@ -48,7 +49,7 @@ public:
 	sigc::signal<void> onChangeEquipment;
 	virtual vector3d GetManeuverVelocity() const;
 	virtual int GetManeuverTime() const;
-	
+
 protected:
 	virtual void SaveToJson(Json::Value &jsonObj, Space *space) override;
 	virtual void LoadFromJson(const Json::Value &jsonObj, Space *space) override;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1006,6 +1006,20 @@ void Ship::StaticUpdate(const float timeStep)
 	if (GetHullTemperature() > 1.0)
 		Explode();
 
+
+	if (m_flightState == FLYING) {
+		Body *astro = GetFrame()->GetBody();
+		if (astro && astro->IsType(Object::PLANET)) {
+			Planet *p = static_cast<Planet*>(astro);
+			double dist = GetPosition().Length();
+			double pressure, density;
+			p->GetAtmosphericState(dist, &pressure, &density);
+
+			if (pressure > m_type->atmosphericPressureLimit)
+				Explode();
+		}
+	}
+
 	UpdateAlertState();
 
 	/* FUEL SCOOPING!!!!!!!!! */

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1030,16 +1030,16 @@ void Ship::StaticUpdate(const float timeStep)
 		if (astro && astro->IsType(Object::PLANET)) {
 			Planet *p = static_cast<Planet*>(astro);
 			if (p->GetSystemBody()->IsScoopable()) {
-				double dist = GetPosition().Length();
+				const double dist = GetPosition().Length();
 				double pressure, density;
 				p->GetAtmosphericState(dist, &pressure, &density);
 
-				double speed = GetVelocity().Length();
-				vector3d vdir = GetVelocity().Normalized();
-				vector3d pdir = -GetOrient().VectorZ();
-				double dot = vdir.Dot(pdir);
-				if ((m_stats.free_capacity) && (dot > 0.95) && (speed > 2000.0) && (density > 1.0)) {
-					double rate = speed*density*0.00000333f*double(capacity);
+				const double speed = GetVelocity().Length();
+				const vector3d vdir = GetVelocity().Normalized();
+				const vector3d pdir = -GetOrient().VectorZ();
+				const double dot = vdir.Dot(pdir);
+				if ((m_stats.free_capacity) && (dot > 0.90) && (speed > 1000.0) && (density > 0.5)) {
+					const double rate = speed * density * 0.00000333 * double(capacity);
 					if (Pi::rng.Double() < rate) {
 						lua_State *l = Lua::manager->GetLuaState();
 						pi_lua_import(l, "Equipment");

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -86,6 +86,7 @@ public:
 	const shipstats_t &GetStats() const { return m_stats; }
 
 	void Explode();
+	virtual bool DoCrushDamage(float kgDamage); // can be overloaded in Player to add "crush" audio
 	void SetGunState(int idx, int state);
 	void UpdateMass();
 	virtual bool SetWheelState(bool down); // returns success of state change, NOT state itself

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -453,6 +453,11 @@ void ShipCpanel::SetOverlayToolTip(OverlayTextPos pos, const std::string &text)
 	m_overlay[pos]->SetToolTip(text);
 }
 
+void ShipCpanel::SetOverlayTextColour(OverlayTextPos pos, const Color &colour)
+{
+	m_overlay[pos]->Color(colour);
+}
+
 void ShipCpanel::ClearOverlay()
 {
 	for (int i = 0; i < OVERLAY_MAX; i++) {

--- a/src/ShipCpanel.h
+++ b/src/ShipCpanel.h
@@ -41,6 +41,7 @@ public:
 	};
 	void SetOverlayText(OverlayTextPos pos, const std::string &text);
 	void SetOverlayToolTip(OverlayTextPos pos, const std::string &text);
+	void SetOverlayTextColour(OverlayTextPos pos, const Color &colour);
 	void ClearOverlay();
 	// Selects the specified button
 	// @param int gid the buttons group (0 = left, 1 = right)

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -197,6 +197,8 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 		thrusterUpgrades[index] = data["thrust_upgrades"].get(slotname, 0).asDouble();
 	}
 
+	atmosphericPressureLimit = data.get("atmospheric_pressure_limit", 5.0).asDouble();
+
 	{
 		const auto it = slots.find("engine");
 		if (it != slots.end())

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -197,7 +197,7 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 		thrusterUpgrades[index] = data["thrust_upgrades"].get(slotname, 0).asDouble();
 	}
 
-	atmosphericPressureLimit = data.get("atmospheric_pressure_limit", 5.0).asDouble();
+	atmosphericPressureLimit = data.get("atmospheric_pressure_limit", 10.0).asDouble();	// 10 atmosphere is about 90 metres underwater (on Earth)
 
 	{
 		const auto it = slots.find("engine");

--- a/src/ShipType.h
+++ b/src/ShipType.h
@@ -46,6 +46,7 @@ struct ShipType {
 	Color directionThrusterColor[THRUSTER_MAX];
 	bool isDirectionColorDefined[THRUSTER_MAX];
 	double thrusterUpgrades[4];
+	double atmosphericPressureLimit;
 	int capacity; // tonnes
 	int hullMass;
 	float effectiveExhaustVelocity; // velocity at which the propellant escapes the engines

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -793,10 +793,21 @@ void WorldView::RefreshButtonStateAndVisibility()
 				double pressure, density;
 				static_cast<Planet*>(astro)->GetAtmosphericState(center_dist, &pressure, &density);
 
-				if (pressure > 0.001)
+				if (pressure > 0.001) {
 					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_LEFT, stringf(Lang::PRESSURE_N_ATMOSPHERES, formatarg("pressure", pressure)));
-				else
+					const double apl = Pi::player->GetShipType()->atmosphericPressureLimit;
+					if (pressure > (apl * 0.9)) {
+						m_game->GetCpan()->SetOverlayTextColour(ShipCpanel::OVERLAY_BOTTOM_LEFT, Color::RED);
+					} else if (pressure > (apl * 0.75)) {
+						m_game->GetCpan()->SetOverlayTextColour(ShipCpanel::OVERLAY_BOTTOM_LEFT, Color::YELLOW);
+					} else {
+						m_game->GetCpan()->SetOverlayTextColour(ShipCpanel::OVERLAY_BOTTOM_LEFT, s_hudTextColor);
+					}
+				} else {
 					m_game->GetCpan()->SetOverlayText(ShipCpanel::OVERLAY_BOTTOM_LEFT, "");
+					m_game->GetCpan()->SetOverlayTextColour(ShipCpanel::OVERLAY_BOTTOM_LEFT, s_hudTextColor);
+				}
+
 				if (Pi::player->GetHullTemperature() > 0.01) {
 					m_hudHullTemp->SetValue(float(Pi::player->GetHullTemperature()));
 					m_hudHullTemp->Show();


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Crush the ship if it can't take the pressure as, optionally, defined in the ship type.

To set different crush depths for ships add a parameter like, eg: `atmospheric_pressure_limit : 17.0`, to their ship definition. This defaults to 5 * Earths Atmosphere at sea level, aka 5 bar.

Titan should have a surface pressure of 1.45 bar, and should be viable for a ship landing.
Venus should have a surface pressure of 90 bar, and is totally out of landing!

PR formerly known as: "*Pop goes the weasel!*"
<!-- Please make sure you've read documentation on contributing -->

