### PR TITLE
Add combat target pro- and retrograde indicators

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -487,6 +487,14 @@
        "description" : "Indicator: Prograde direction relative to the current navigational target.",
        "message" : "Prograde relative to current navigational target"
    },
+   "HUD_INDICATOR_COMBAT_TARGET_RETROGRADE" : {
+       "description" : "Indicator: Retrograde direction relative to the current combat target.",
+       "message" : "Retrograde relative to current combat target"
+   },
+   "HUD_INDICATOR_COMBAT_TARGET_PROGRADE" : {
+       "description" : "Indicator: Prograde direction relative to the current combat target.",
+       "message" : "Prograde relative to current combat target"
+   },
    "HUD_INDICATOR_MANEUVER_PROGRADE" : {
        "description" : "Indicator: The prograde direction for the maneuver burn.",
        "message" : "Prograde for maneuver burn"

--- a/data/pigui/game.lua
+++ b/data/pigui/game.lua
@@ -378,9 +378,14 @@ end
 
 -- display the indicator pointing at the combat target
 local function displayCombatTargetIndicator(combatTarget)
-	local pos = combatTarget:GetPositionRelTo(Game.player)
+	local pos = combatTarget:GetPositionRelTo(player)
+	local vel = -combatTarget:GetVelocityRelTo(player)
 	local onscreen,position,direction = Engine.WorldSpaceToScreenSpace(pos)
 	displayIndicator(onscreen, position, direction, icons.square, colors.combatTarget, true)
+	onscreen,position,direction = Engine.WorldSpaceToScreenSpace(vel)
+	displayIndicator(onscreen, position, direction, icons.prograde, colors.combatTarget, true, lui.HUD_INDICATOR_COMBAT_TARGET_PROGRADE)
+	onscreen,position,direction = Engine.WorldSpaceToScreenSpace(-vel)
+	displayIndicator(onscreen, position, direction, icons.retrograde, colors.combatTarget, false, lui.HUD_INDICATOR_COMBAT_TARGET_RETROGRADE)
 end
 
 -- display indicators relative to frame

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1527,13 +1527,10 @@ void WorldView::UpdateProjectedObjects()
 	// update combat HUD
 	Ship *enemy = static_cast<Ship *>(Pi::player->GetCombatTarget());
 	if (enemy) {
-		char buf[128];
 		const vector3d targpos = enemy->GetInterpPositionRelTo(Pi::player) * cam_rot;
 		const double dist = targpos.Length();
 		const vector3d targScreenPos = enemy->GetInterpPositionRelTo(cam_frame);
 
-		snprintf(buf, sizeof(buf), "%.0fm", dist);
-		m_combatTargetIndicator.label->SetText(buf);
 		UpdateIndicator(m_combatTargetIndicator, targScreenPos);
 
 		// calculate firing solution and relative velocity along our z axis
@@ -1569,8 +1566,6 @@ void WorldView::UpdateProjectedObjects()
 			m_combatTargetIndicator.label->Color(r*255, 0, b*255);
 			m_targetLeadIndicator.label->Color(r*255, 0, b*255);
 
-			snprintf(buf, sizeof(buf), "%0.fm/s", vel);
-			m_targetLeadIndicator.label->SetText(buf);
 			UpdateIndicator(m_targetLeadIndicator, leadpos);
 
 			if ((m_targetLeadIndicator.side != INDICATOR_ONSCREEN) || (m_combatTargetIndicator.side != INDICATOR_ONSCREEN))


### PR DESCRIPTION
Also remove redundant text (combat target speed / distance) that is shown
already near the reticule.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

