### PR TITLE
Remove remaining legacy camera button

### DIFF
--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -34,9 +34,6 @@ m_game(game)
 	m_radar = new RadarWidget(r, shipCPanelObj);
 
 	InitObject();
-
-	if (!shipCPanelObj.isMember("cam_button_state")) throw SavedGameCorruptException();
-	m_camButton->SetActiveState(shipCPanelObj["cam_button_state"].asInt());
 }
 
 void ShipCpanel::InitObject()
@@ -268,7 +265,6 @@ void ShipCpanel::SaveToJson(Json::Value &jsonObj)
 {
 	Json::Value shipCPanelObj(Json::objectValue); // Create JSON object to contain ship control panel data.
 	m_radar->SaveToJson(shipCPanelObj);
-	shipCPanelObj["cam_button_state"] = m_camButton->GetState();
 	jsonObj["ship_c_panel"] = shipCPanelObj; // Add ship control panel object to supplied object.
 }
 

--- a/src/ShipCpanel.h
+++ b/src/ShipCpanel.h
@@ -68,7 +68,6 @@ private:
 
 	RadarWidget *m_radar;
 	UseEquipWidget *m_useEquipWidget;
-	Gui::MultiStateImageButton *m_camButton;
 	Gui::ImageRadioButton *m_timeAccelButtons[6];
 	Gui::Widget *m_mapViewButtons[4];
 	Gui::Image *m_alertLights[3];


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Fix #4013 crash.

There was an uninitalised and _mostly_ unused pointer hanging around, only used in an unused ctor and when saving.
<!-- Please make sure you've read documentation on contributing -->

