### PR TITLE
Modify jump range so time is linear, not quadratic with distance

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -212,7 +212,7 @@ end
 HyperdriveType.GetDuration = function (self, ship, distance, range_max)
 	range_max = range_max or self:GetMaximumRange(ship)
 	local hyperclass = self.capabilities.hyperclass
-	return 0.36*distance^2/(range_max*hyperclass) * (3600*24*math.sqrt(ship.staticMass + ship.fuelMassLeft))
+	return 0.36*distance/hyperclass * (3600*24*math.sqrt(ship.staticMass + ship.fuelMassLeft))
 end
 
 -- range_max is optional, distance defaults to the maximal range.

--- a/src/LuaBody.cpp
+++ b/src/LuaBody.cpp
@@ -224,10 +224,10 @@ static int l_body_is_more_important_than(lua_State *l)
 	bool result = false;
 
 	if(a == b && a != Object::Type::PLANET) result = body->GetLabel() < other->GetLabel();
-	else if(a == Object::Type::STAR) result = true;
 	else if(b == Object::Type::STAR) result = false;
-	else if(a_gas_giant) result = true;
+	else if(a == Object::Type::STAR) result = true;
 	else if(b_gas_giant) result = false;
+	else if(a_gas_giant) result = true;
 	else if(a == Object::Type::HYPERSPACECLOUD) result = false;
 	else if(b == Object::Type::HYPERSPACECLOUD) result = true;
 	else if(a == Object::Type::MISSILE) result = false;
@@ -240,8 +240,8 @@ static int l_body_is_more_important_than(lua_State *l)
 	else if(b == Object::Type::SPACESTATION) result = true;
 	else if(a_planet && b_planet) result = body->GetLabel() < other->GetLabel();
 	else if(a_moon && b_moon) result = body->GetLabel() < other->GetLabel();
-	else if(sb_a && sb_a->IsPlanet()) result = true;
 	else if(sb_b && sb_b->IsPlanet()) result = false;
+	else if(sb_a && sb_a->IsPlanet()) result = true;
 	else Error("don't know how to compare %i and %i\n", a, b);
 
 	LuaPush<bool>(l, result);


### PR DESCRIPTION
I found it a bit silly micromanaging small jumps to get to my destination on time, so I've just modified the jump time formula to be a simple linear function of distance. It's set so that the distance to jump the max range is the same as previously, but as the function is quadratic all smaller jumps now take longer. This does make the game slightly more difficult although I'm having no trouble completing missions in the early game with the hard start at Barnard's Star.

This behavior more closely matches what was previously in Frontier and FFE and hence will probably be less surprising to those who have experience from them games.
