### PR TITLE
Fix for incorrectly implemented comparison function crashing Pioneer upon entering system

### DIFF
--- a/src/LuaBody.cpp
+++ b/src/LuaBody.cpp
@@ -224,10 +224,10 @@ static int l_body_is_more_important_than(lua_State *l)
 	bool result = false;
 
 	if(a == b && a != Object::Type::PLANET) result = body->GetLabel() < other->GetLabel();
-	else if(a == Object::Type::STAR) result = true;
 	else if(b == Object::Type::STAR) result = false;
-	else if(a_gas_giant) result = true;
+	else if(a == Object::Type::STAR) result = true;
 	else if(b_gas_giant) result = false;
+	else if(a_gas_giant) result = true;
 	else if(a == Object::Type::HYPERSPACECLOUD) result = false;
 	else if(b == Object::Type::HYPERSPACECLOUD) result = true;
 	else if(a == Object::Type::MISSILE) result = false;
@@ -240,8 +240,8 @@ static int l_body_is_more_important_than(lua_State *l)
 	else if(b == Object::Type::SPACESTATION) result = true;
 	else if(a_planet && b_planet) result = body->GetLabel() < other->GetLabel();
 	else if(a_moon && b_moon) result = body->GetLabel() < other->GetLabel();
-	else if(sb_a && sb_a->IsPlanet()) result = true;
 	else if(sb_b && sb_b->IsPlanet()) result = false;
+	else if(sb_a && sb_a->IsPlanet()) result = true;
 	else Error("don't know how to compare %i and %i\n", a, b);
 
 	LuaPush<bool>(l, result);


### PR DESCRIPTION
Entering certain systems (it seemed to be binary ones) caused Pioneer to crash with this message:

error: [string "[T] @pigui/game.lua"]:674: invalid order function for sorting
stack traceback:
	[C]: in function 'sort'
	[string "[T] @pigui/game.lua"]:674: in function 'displayOnScreenObjects'
	[string "[T] @pigui/game.lua"]:746: in function 'fun'
	[string "[T] @pigui/pigui.lua"]:42: in function 'window'
	[string "[T] @pigui/game.lua"]:739: in function 'fun'
	[string "[T] @pigui/pigui.lua"]:71: in function 'withStyleColors'
	[string "[T] @pigui/game.lua"]:738: in function 'game'
	[string "[T] @pigui/pigui.lua"]:83: in function <[string "[T] @pigui/pigui.lua"]:81>

I haven't coded in Lua before, but it seems the error is regarding the sorting function.
A quick google search revealed the sorting function should return false when the items are equal.

I've reordered the cases in "l_body_is_more_important_than" and this seems to resolve the issue.

