### PR TITLE
Support modifier keys in lua.

### DIFF
--- a/data/pigui/modules/fx-window.lua
+++ b/data/pigui/modules/fx-window.lua
@@ -62,12 +62,12 @@ local next_cam_type = { ["internal"] = "external", ["external"] = "sidereal", ["
 local function button_world(current_view)
 	ui.sameLine()
 	if current_view ~= "world" then
-		if mainMenuButton(icons.view_internal, false, "world view") or ui.isKeyReleased(ui.keys.f1) then
+		if mainMenuButton(icons.view_internal, false, "world view") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f1)) then
 			Game.SetView("world")
 		end
 	else
 		local camtype = Game.GetWorldCamType()
-		if mainMenuButton(icons["view_" .. camtype], true, camtype .. " view") or ui.isKeyReleased(ui.keys.f1) then
+		if mainMenuButton(icons["view_" .. camtype], true, camtype .. " view") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f1)) then
 			Game.SetWorldCamType(next_cam_type[camtype])
 		end
 	end
@@ -78,7 +78,7 @@ local function buttons_map(current_view)
 	local onmap = current_view == "sector" or current_view == "system" or current_view == "system_info" or current_view == "galaxy"
 
 	ui.sameLine()
-	if mainMenuButton(icons.sector_map, current_view == "sector", "sector map") or (onmap and ui.isKeyReleased(ui.keys.f5)) then
+	if mainMenuButton(icons.sector_map, current_view == "sector", "sector map") or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f5)) then
 		if current_view == "sector" then
 			Game.SetView("world")
 		else
@@ -88,7 +88,7 @@ local function buttons_map(current_view)
 	end
 
 	ui.sameLine()
-	if mainMenuButton(icons.system_map, current_view == "system", "system map") or (onmap and ui.isKeyReleased(ui.keys.f6)) then
+	if mainMenuButton(icons.system_map, current_view == "system", "system map") or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f6)) then
 		if current_view == "system" then
 			Game.SetView("world")
 		else
@@ -98,7 +98,7 @@ local function buttons_map(current_view)
 	end
 
 	ui.sameLine()
-	if mainMenuButton(icons.system_overview, current_view == "system_info", "system overview") or (onmap and ui.isKeyReleased(ui.keys.f7)) then
+	if mainMenuButton(icons.system_overview, current_view == "system_info", "system overview") or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f7)) then
 		if current_view == "system_info" then
 			ui.systemInfoViewNextPage()
 		else
@@ -108,7 +108,7 @@ local function buttons_map(current_view)
 	end
 
 	ui.sameLine()
-	if mainMenuButton(icons.galaxy_map, current_view == "galaxy", "galaxy map") or (onmap and ui.isKeyReleased(ui.keys.f8)) then
+	if mainMenuButton(icons.galaxy_map, current_view == "galaxy", "galaxy map") or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f8)) then
 		if current_view == "galaxy" then
 			Game.SetView("world")
 		else
@@ -116,7 +116,7 @@ local function buttons_map(current_view)
 			current_map_view = "galaxy"
 		end
 	end
-	if ui.isKeyReleased(ui.keys.f2) then
+	if ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f2) then
 		if onmap then
 			Game.SetView("world")
 		else
@@ -127,7 +127,7 @@ end
 
 local function button_info(current_view)
 	ui.sameLine()
-	if (mainMenuButton(icons.personal_info, current_view == "info", "personal info") or ui.isKeyReleased(ui.keys.f3)) then
+	if (mainMenuButton(icons.personal_info, current_view == "info", "personal info") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f3))) then
 		if current_view ~= "info" then
 			Game.SetView("info")
 		else
@@ -138,7 +138,7 @@ end
 
 local function button_comms(current_view)
 	ui.sameLine()
-	if mainMenuButton(icons.comms, current_view == "space_station", "comms") or ui.isKeyReleased(ui.keys.f4) then
+	if mainMenuButton(icons.comms, current_view == "space_station", "comms") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f4)) then
 		if player:IsDocked() then
 			if current_view == "space_station" then
 				Game.SetView("world")
@@ -154,12 +154,12 @@ end
 local function button_undock()
 	if player:IsLanded() then
 		ui.sameLine()
-		if mainMenuButton(icons.autopilot_blastoff, false, "blastoff") or ui.isKeyReleased(ui.keys.f5) then
+		if mainMenuButton(icons.autopilot_blastoff, false, "blastoff") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f5)) then
 			player:BlastOff()
 		end
 	elseif player:IsDocked() then
 		ui.sameLine()
-		if mainMenuButton(icons.autopilot_undock, false, "undock") or ui.isKeyReleased(ui.keys.f5) then
+		if mainMenuButton(icons.autopilot_undock, false, "undock") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f5)) then
 			player:Undock()
 		end
 	end
@@ -169,12 +169,12 @@ local function button_wheelstate()
 	local wheelstate = player:GetWheelState() -- 0.0 is up, 1.0 is down
 	if wheelstate == 0.0 then -- gear is up
 		ui.sameLine()
-		if mainMenuButton(icons.landing_gear_down, false, "landing gear is up") or ui.isKeyReleased(ui.keys.f6) then
+		if mainMenuButton(icons.landing_gear_down, false, "landing gear is up") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f6)) then
 			player:ToggleWheelState()
 		end
 	elseif wheelstate == 1.0 then -- gear is down
 		ui.sameLine()
-		if mainMenuButton(icons.landing_gear_up, false, "landing gear is down") or ui.isKeyReleased(ui.keys.f6) then
+		if mainMenuButton(icons.landing_gear_up, false, "landing gear is down") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f6)) then
 			player:ToggleWheelState()
 		end
 	else
@@ -202,12 +202,12 @@ local current_mfd = "scanner"
 local function button_mfd()
 	ui.sameLine()
 	if current_mfd == "scanner" then
-		if mainMenuButton(icons.scanner, false, "scanner") or ui.isKeyReleased(ui.keys.f9) then
+		if mainMenuButton(icons.scanner, false, "scanner") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f9)) then
 			Game.ChangeMFD("equipment")
 			current_mfd = "equipment"
 		end
 	else
-		if mainMenuButton(icons.repairs, false, "equipment") or ui.isKeyReleased(ui.keys.f9) then
+		if mainMenuButton(icons.repairs, false, "equipment") or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f9)) then
 			Game.ChangeMFD("scanner")
 			current_mfd = "scanner"
 		end
@@ -257,7 +257,7 @@ local function button_flight_control()
 		local distance, unit = ui.Format.Speed(player:GetSetSpeed())
 		tooltip = tooltip .. " " .. distance .. unit
   end
-	if mainMenuButton(icon, false, tooltip) or (flightstate == "FLYING" and ui.isKeyReleased(ui.keys.f5)) then
+	if mainMenuButton(icon, false, tooltip) or (flightstate == "FLYING" and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f5)) then
 		Game.ChangeFlightState()
 	end
 end
@@ -290,7 +290,7 @@ local function displayFxWindow()
 
 								button_flight_control()
 
-								if ui.isKeyReleased(ui.keys.f8) then
+								if ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f8) then
 									Game.ToggleLowThrustPowerOptions()
 								end
 

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -423,6 +423,9 @@ ui.systemInfoViewNextPage = pigui.SystemInfoViewNextPage -- deprecated
 ui.isKeyReleased = pigui.IsKeyReleased
 ui.playSfx = pigui.PlaySfx
 ui.ctrlHeld = function() return pigui.key_ctrl end
+ui.altHeld = function() return pigui.key_alt end
+ui.shiftHeld = function() return pigui.key_shift end
+ui.noModifierHeld = function() return pigui.key_none end
 ui.coloredSelectedIconButton = function(icon, size, is_selected, frame_padding, bg_color, fg_color, tooltip)
 	if is_selected then
 		pigui.PushStyleColor("Button", bg_color)

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -968,6 +968,21 @@ static int l_attr_key_ctrl(lua_State *l) {
 	return 1;
 }
 
+static int l_attr_key_none(lua_State *l) {
+	LuaPush<bool>(l, !ImGui::GetIO().KeyCtrl & !ImGui::GetIO().KeyShift & !ImGui::GetIO().KeyAlt);
+	return 1;
+}
+
+static int l_attr_key_shift(lua_State *l) {
+	LuaPush<bool>(l, ImGui::GetIO().KeyShift);
+	return 1;
+}
+
+static int l_attr_key_alt(lua_State *l) {
+	LuaPush<bool>(l, ImGui::GetIO().KeyAlt);
+	return 1;
+}
+
 static int l_attr_screen_height(lua_State *l) {
 	//	PiGui *pigui = LuaObject<PiGui>::CheckFromLua(1);
 	LuaPush<int>(l,Graphics::GetScreenHeight());
@@ -1241,6 +1256,9 @@ template <> void LuaObject<PiGui>::RegisterClass()
 		{ "screen_width",  l_attr_screen_width },
 		{ "screen_height", l_attr_screen_height },
 		{ "key_ctrl",      l_attr_key_ctrl },
+		{ "key_none",      l_attr_key_none },
+		{ "key_shift",     l_attr_key_shift },
+		{ "key_alt",       l_attr_key_alt },
 		{ "keys",          l_attr_keys },
 		{ 0, 0 }
 	};


### PR DESCRIPTION
Add support for the missing modifier keys in lua.

Only run the main menu keys when pressed without any modifier (as a preparation for S-F1 etc. for time accelleration).
