### PR TITLE
Fix all GCC 7.1.1 warnings.

### DIFF
--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -175,7 +175,7 @@ void InternalCameraController::SaveToJson(Json::Value &jsonObj)
 {
 	Json::Value internalCameraObj(Json::objectValue); // Create JSON object to contain internal camera data.
 
-	internalCameraObj["mode"] = m_mode;
+	internalCameraObj["mode"] = Json::Value::Int(m_mode);
 
 	jsonObj["internal"] = internalCameraObj; // Add internal camera object to supplied object.
 }

--- a/src/FloatComparison.h
+++ b/src/FloatComparison.h
@@ -101,6 +101,7 @@ inline typename IEEEFloatTraits<T>::bool_type is_finite(T x) {
 // --- exact comparisons, and checking for NaN
 
 #ifdef __GNUC__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
 inline bool is_equal_exact(float a, float b) { return (a == b); }
@@ -112,7 +113,7 @@ inline bool is_zero_exact(double x) { return (x == 0.0); }
 inline bool is_nan(float x) { return (x != x); }
 inline bool is_nan(double x) { return (x != x); }
 #ifdef __GNUC__
-#pragma GCC diagnostic warning "-Wfloat-equal"
+#pragma GCC diagnostic pop
 #endif
 
 // --- relative & absolute error comparisons

--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -767,12 +767,20 @@ static int l_ship_get_wheel_state(lua_State *l) {
 	lua_pushnumber(l, s->GetWheelState());
 	return 1;
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
 
 static int l_ship_toggle_wheel_state(lua_State *l) {
 	Ship *s = LuaObject<Ship>::CheckFromLua(1);
 	s->SetWheelState(s->GetWheelState() == 0.0);
 	return 0;
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 /*
  * Group: AI methods

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -390,7 +390,7 @@ void SectorView::SaveToJson(Json::Value &jsonObj)
 
 	sectorViewObj["match_target_to_selection"] = m_matchTargetToSelection;
 	sectorViewObj["automatic_system_selection"] = m_automaticSystemSelection;
-	sectorViewObj["detail_box_visible"] = m_detailBoxVisible;
+	sectorViewObj["detail_box_visible"] = Json::Value::Int(m_detailBoxVisible);
 
 	jsonObj["sector_view"] = sectorViewObj; // Add sector view object to supplied object.
 }

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -60,7 +60,7 @@ void Sfx::SaveToJson(Json::Value &jsonObj)
 	VectorToJson(sfxObj, m_pos, "pos");
 	VectorToJson(sfxObj, m_vel, "vel");
 	sfxObj["age"] = FloatToStr(m_age);
-	sfxObj["type"] = m_type;
+	sfxObj["type"] = Json::Value::Int(m_type);
 
 	jsonObj["sfx"] = sfxObj; // Add sfx object to supplied object.
 }

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -50,7 +50,7 @@ void AICommand::SaveToJson(Json::Value &jsonObj)
 	// No longer need to save CMD_NONE when a child ai command does not exist (just don't add a child ai command object).
 	Space *space = Pi::game->GetSpace();
 	Json::Value commonAiCommandObj(Json::objectValue); // Create JSON object to contain common ai command data.
-	commonAiCommandObj["command_name"] = m_cmdName;
+	commonAiCommandObj["command_name"] = Json::Value::Int(m_cmdName);
 	commonAiCommandObj["index_for_body"] = space->GetIndexForBody(m_dBody);
 	if (m_child) m_child->SaveToJson(commonAiCommandObj);
 	jsonObj["common_ai_command"] = commonAiCommandObj; // Add common ai command object to supplied object.

--- a/src/ShipAICmd.h
+++ b/src/ShipAICmd.h
@@ -79,7 +79,7 @@ public:
 		VectorToJson(aiCommandObj, m_dockpos, "dock_pos");
 		VectorToJson(aiCommandObj, m_dockdir, "dock_dir");
 		VectorToJson(aiCommandObj, m_dockupdir, "dock_up_dir");
-		aiCommandObj["state"] = m_state;
+		aiCommandObj["state"] = Json::Value::Int(m_state);
 		jsonObj["ai_command"] = aiCommandObj; // Add ai command object to supplied object.
 	}
 	AICmdDock(const Json::Value &jsonObj) : AICommand(jsonObj, CMD_DOCK) {

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -192,7 +192,7 @@ void TransferPlanner::DecreaseFactor(void) {
 }
 
 std::string TransferPlanner::printFactor(void) {
-	char buf[10];
+	char buf[16];
 	snprintf(buf, sizeof(buf), "%8gx", 10 * m_factor);
 	return std::string(buf);
 }

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1097,7 +1097,7 @@ void StarSystemRandomGenerator::MakePlanetsAround(RefCountedPtr<StarSystem::Gene
 		// planets around a binary pair [gravpoint] -- ignore the stars...
 		if ((*i)->GetSuperType() == SystemBody::SUPERTYPE_STAR) continue;
 		// Turn them into something!!!!!!!
-		char buf[8];
+		char buf[12];
 		if (superType <= SystemBody::SUPERTYPE_STAR) {
 			// planet naming scheme
 			snprintf(buf, sizeof(buf), " %c", 'a'+idx);


### PR DESCRIPTION
- Use explicit Json::Value::Int.
- Resize some snprintf buffers.
- Ignore -Wfloat-equal where necessary.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

