### PR TITLE
Decreased density for speedlines

### DIFF
--- a/src/SpeedLines.cpp
+++ b/src/SpeedLines.cpp
@@ -7,8 +7,8 @@
 #include "Pi.h"
 
 const float BOUNDS     = 2000.f;
-const int   DEPTH      = 8;
-const float SPACING    = 500.f;
+const int   DEPTH      = 9;
+const float SPACING    = 750.f;
 const float MAX_VEL    = 100.f;
 
 SpeedLines::SpeedLines(Ship *s)


### PR DESCRIPTION
Incredibly minor change; less denser generation for speedlines, avoiding speedlines to look like they appear at the same relative location to the ship. Looks almost the same as before. Let's avoid making the area too large though, it also looks bad.
As you see I didn't touch the velocity-relevant parts.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

