### PR TITLE
Stricter check for complex ecosystems (...and I need help)

### DIFF
--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -186,7 +186,8 @@ const float StarSystem::starScale[] = {  // Used in sector view
 	4.0f  // Supermassive blackhole
 };
 
-bool supportComplexLife;
+int supportComplexLife;
+int LifeChanceMultiplier = (rand() % static_cast<int>(4)); //random value between 0 and 3
 
 SystemBody::BodySuperType SystemBody::GetSuperType() const
 {
@@ -338,35 +339,37 @@ std::string SystemBody::GetAstroDescription() const
 			else thickness = Lang::VERY_DENSE;
 
 			if (m_atmosOxidizing > fixed(95,100)) {
-				supportComplexLife = true;
+				supportComplexLife = 9/10 * LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::O2_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(7,10)) {
-				supportComplexLife = true;
+				supportComplexLife = 7/10* LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::CO2_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(65,100)) {
-				supportComplexLife = true;
+				supportComplexLife = 6/10* LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::CO_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(55,100)) {
-				supportComplexLife = true;
+				supportComplexLife = 6/10;
 				s += Lang::WITH_A+thickness+Lang::CH4_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(3,10)) {
-				supportComplexLife = true;
+				supportComplexLife = 3/10;
 				s += Lang::WITH_A+thickness+Lang::H_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(2,10)) {
-				supportComplexLife = true;
+				supportComplexLife = 0;
 				s += Lang::WITH_A+thickness+Lang::HE_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(15,100)) {
-				supportComplexLife = false;
+				supportComplexLife = 0;
 				s += Lang::WITH_A+thickness+Lang::AR_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(1,10)) {
-				supportComplexLife = false;
+				supportComplexLife = 0;
 				s += Lang::WITH_A+thickness+Lang::S_ATMOSPHERE;
 			} else {
-				supportComplexLife = true;
+				supportComplexLife = 2/10;
 				s += Lang::WITH_A+thickness+Lang::N_ATMOSPHERE;
 			}
 		}
-		if (m_life > fixed(1,2) && supportComplexLife) {
+		
+		lifeCahnceMultiplier
+		if (m_life > fixed(1,2)) {
 			s += Lang::AND_HIGHLY_COMPLEX_ECOSYSTEM;
 		} else if (m_life > fixed(1,10)) {
 			s += Lang::AND_INDIGENOUS_PLANT_LIFE;

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -186,6 +186,8 @@ const float StarSystem::starScale[] = {  // Used in sector view
 	4.0f  // Supermassive blackhole
 };
 
+bool supportComplexLife;
+
 SystemBody::BodySuperType SystemBody::GetSuperType() const
 {
 	PROFILE_SCOPED()
@@ -336,27 +338,35 @@ std::string SystemBody::GetAstroDescription() const
 			else thickness = Lang::VERY_DENSE;
 
 			if (m_atmosOxidizing > fixed(95,100)) {
+				supportComplexLife = true;
 				s += Lang::WITH_A+thickness+Lang::O2_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(7,10)) {
+				supportComplexLife = true;
 				s += Lang::WITH_A+thickness+Lang::CO2_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(65,100)) {
+				supportComplexLife = true;
 				s += Lang::WITH_A+thickness+Lang::CO_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(55,100)) {
+				supportComplexLife = true;
 				s += Lang::WITH_A+thickness+Lang::CH4_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(3,10)) {
+				supportComplexLife = true;
 				s += Lang::WITH_A+thickness+Lang::H_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(2,10)) {
+				supportComplexLife = true;
 				s += Lang::WITH_A+thickness+Lang::HE_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(15,100)) {
+				supportComplexLife = false;
 				s += Lang::WITH_A+thickness+Lang::AR_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(1,10)) {
+				supportComplexLife = false;
 				s += Lang::WITH_A+thickness+Lang::S_ATMOSPHERE;
 			} else {
+				supportComplexLife = true;
 				s += Lang::WITH_A+thickness+Lang::N_ATMOSPHERE;
 			}
 		}
-
-		if (m_life > fixed(1,2)) {
+		if (m_life > fixed(1,2) && supportComplexLife) {
 			s += Lang::AND_HIGHLY_COMPLEX_ECOSYSTEM;
 		} else if (m_life > fixed(1,10)) {
 			s += Lang::AND_INDIGENOUS_PLANT_LIFE;

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -339,19 +339,19 @@ std::string SystemBody::GetAstroDescription() const
 			else thickness = Lang::VERY_DENSE;
 
 			if (m_atmosOxidizing > fixed(95,100)) {
-				supportComplexLife = 9/10 * LifeChanceMultiplier;
+				supportComplexLife = 9 * LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::O2_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(7,10)) {
-				supportComplexLife = 7/10* LifeChanceMultiplier;
+				supportComplexLife = 7 * LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::CO2_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(65,100)) {
-				supportComplexLife = 6/10* LifeChanceMultiplier;
+				supportComplexLife = 6 * LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::CO_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(55,100)) {
-				supportComplexLife = 6/10;
+				supportComplexLife = 6 * LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::CH4_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(3,10)) {
-				supportComplexLife = 3/10;
+				supportComplexLife = 3 * LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::H_ATMOSPHERE;
 			} else if (m_atmosOxidizing > fixed(2,10)) {
 				supportComplexLife = 0;
@@ -363,15 +363,14 @@ std::string SystemBody::GetAstroDescription() const
 				supportComplexLife = 0;
 				s += Lang::WITH_A+thickness+Lang::S_ATMOSPHERE;
 			} else {
-				supportComplexLife = 2/10;
+				supportComplexLife = 2 * LifeChanceMultiplier;
 				s += Lang::WITH_A+thickness+Lang::N_ATMOSPHERE;
 			}
 		}
 		
-		lifeCahnceMultiplier
-		if (m_life > fixed(1,2)) {
+		if (m_life > fixed(1,2) && supportComplexLife > 7) {
 			s += Lang::AND_HIGHLY_COMPLEX_ECOSYSTEM;
-		} else if (m_life > fixed(1,10)) {
+		} else if (m_life > fixed(1,10) && supportComplexLife > 3) {
 			s += Lang::AND_INDIGENOUS_PLANT_LIFE;
 		} else if (m_life > fixed()) {
 			s += Lang::AND_INDIGENOUS_MICROBIAL_LIFE;

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -370,12 +370,14 @@ std::string SystemBody::GetAstroDescription() const
 		
 		if (m_life > fixed(1,2) && supportComplexLife > 7) {
 			s += Lang::AND_HIGHLY_COMPLEX_ECOSYSTEM;
-		} else if (m_life > fixed(1,10) && supportComplexLife > 3) {
+		} else if (m_life > fixed(1,10) && supportComplexLife > 4) {
 			s += Lang::AND_INDIGENOUS_PLANT_LIFE;
+		} else if (m_life > fixed() && supportComplexLife > 2) {
+			s += Lang::AND_PRIMITIVE_MULTICELLULAR_LIFE;
 		} else if (m_life > fixed()) {
 			s += Lang::AND_INDIGENOUS_MICROBIAL_LIFE;
 		} else {
-			s += ".";
+			s += "."
 		}
 
 		return s;


### PR DESCRIPTION
Complex ecosystems can no longer appear on worlds with atmospheres that cannot support "complex" life as we know it (photosyntetic/kemosyntethic plants, multicellular animals with specialised segments and organs etc... Biology, you know...). Some forms of life may still exist; perhaps we need a new description for these worlds. Also, some optimization for the code would be nice. I am not very good at working in a clean way. Throwing a random boolean value into the code feels really absurd.

I got no errors with the build but you may want to check again, just in case.

I examined StarSystemGeneration.cpp/.h and found a part that checks if life can exist or not on some planet; but I couldn't figure out where I could add THIS to that part. If someone can do this, it would be better to keep the project better organised.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

