### PR TITLE
Fix or silence 64-bit warnings in VS2015

### DIFF
--- a/src/Camera.h
+++ b/src/Camera.h
@@ -103,7 +103,7 @@ public:
 
 	// lights with properties in camera space
 	const std::vector<LightSource> &GetLightSources() const { return m_lightSources; }
-	const int GetNumLightSources() const { return m_lightSources.size(); }
+	const size_t GetNumLightSources() const { return m_lightSources.size(); }
 
 private:
 	RefCountedPtr<CameraContext> m_context;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -62,7 +62,7 @@ public:
 	void AddChild(Frame *f) { m_children.push_back(f); }
 	void RemoveChild(Frame *f);
 	bool HasChildren() const { return !m_children.empty(); }
-	unsigned GetNumChildren() const { return m_children.size(); }
+	size_t GetNumChildren() const { return m_children.size(); }
 	IterationProxy<std::vector<Frame*> > GetChildren() { return MakeIterationProxy(m_children); }
 	const IterationProxy<const std::vector<Frame*> > GetChildren() const { return MakeIterationProxy(m_children); }
 

--- a/src/Lang.h
+++ b/src/Lang.h
@@ -22,7 +22,7 @@ public:
 
 	bool Load();
 
-	Uint32 GetNumStrings() const { return m_strings.size(); }
+	size_t GetNumStrings() const { return m_strings.size(); }
 
 	const std::string &Get(const std::string &token) const;
 

--- a/src/LuaConsole.cpp
+++ b/src/LuaConsole.cpp
@@ -189,7 +189,7 @@ bool LuaConsole::OnKeyDown(const UI::KeyboardEvent &event) {
 		case SDLK_DOWN: {
 			if (m_historyPosition == -1) {
 				if (event.keysym.sym == SDLK_UP) {
-					m_historyPosition = (m_statementHistory.size() - 1);
+					m_historyPosition = static_cast<Uint32>(m_statementHistory.size() - 1);
 					if (m_historyPosition != -1) {
 						m_stashedStatement = m_entry->GetText();
 						m_entry->SetText(m_statementHistory[m_historyPosition]);
@@ -240,11 +240,11 @@ bool LuaConsole::OnKeyDown(const UI::KeyboardEvent &event) {
 			if (!m_completionList.empty()) { // We still need to test whether it failed or not.
 				if (event.keysym.mod & KMOD_SHIFT) {
 					if (m_currentCompletion == 0)
-						m_currentCompletion = m_completionList.size();
+						m_currentCompletion = static_cast<Uint32>(m_completionList.size());
 					m_currentCompletion--;
 				} else {
 					m_currentCompletion++;
-					if (m_currentCompletion == m_completionList.size())
+					if (m_currentCompletion == static_cast<Uint32>(m_completionList.size()))
 						m_currentCompletion = 0;
 				}
 				m_entry->SetText(m_precompletionStatement + m_completionList[m_currentCompletion]);
@@ -319,7 +319,7 @@ void LuaConsole::UpdateCompletion(const std::string & statement) {
 		std::sort(m_completionList.begin(), m_completionList.end());
 		m_completionList.erase(std::unique(m_completionList.begin(), m_completionList.end()), m_completionList.end());
 		// Add blank completion at the end of the list and point to it.
-		m_currentCompletion = m_completionList.size();
+		m_currentCompletion = static_cast<Uint32>(m_completionList.size());
 		m_completionList.push_back("");
 
 		m_precompletionStatement = statement;

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -178,7 +178,7 @@ static int l_engine_get_video_mode_list(lua_State *l)
 	LUA_DEBUG_START(l);
 
 	const std::vector<Graphics::VideoMode> modes = Graphics::GetAvailableVideoModes();
-	const int N = modes.size();
+	const int N = static_cast<Sint32>(modes.size());
 	lua_createtable(l, N, 0);
 	for (int i = 0; i < N; ++i) {
 		lua_createtable(l, 0, 2);

--- a/src/LuaTable.h
+++ b/src/LuaTable.h
@@ -141,7 +141,7 @@ public:
 
 	lua_State * GetLua() const { return m_lua; }
 	int GetIndex() const { return m_index; }
-	int Size() const {return lua_rawlen(m_lua, m_index);}
+	size_t Size() const {return lua_rawlen(m_lua, m_index);}
 
 	/* VecIter, as in VectorIterator (only shorter to type :-)
 	 *

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -511,7 +511,7 @@ void ModelViewer::DrawGrid(const matrix4x4f &trans, float radius)
 	}
 
 	m_renderer->SetTransform(trans);
-	m_gridLines.SetData(points.size(), &points[0], Color(128, 128, 128));
+	m_gridLines.SetData(static_cast<Uint32>(points.size()), &points[0], Color(128, 128, 128));
 	m_gridLines.Draw(m_renderer, m_bgState);
 
 	// industry-standard red/green/blue XYZ axis indiactor

--- a/src/Space.h
+++ b/src/Space.h
@@ -63,7 +63,7 @@ public:
 	Body *FindNearestTo(const Body *b, Object::Type t) const;
 	Body *FindBodyForPath(const SystemPath *path) const;
 
-	unsigned GetNumBodies() const { return m_bodies.size(); }
+	size_t GetNumBodies() const { return m_bodies.size(); }
 	IterationProxy<std::list<Body*> > GetBodies() { return MakeIterationProxy(m_bodies); }
 	const IterationProxy<const std::list<Body*> > GetBodies() const { return MakeIterationProxy(m_bodies); }
 

--- a/src/galaxy/Galaxy.cpp
+++ b/src/galaxy/Galaxy.cpp
@@ -116,7 +116,7 @@ DensityMapGalaxy::DensityMapGalaxy(RefCountedPtr<GalaxyGenerator> galaxyGenerato
 		Pi::Quit();
 	}
 
-	SDL_RWops *datastream = SDL_RWFromConstMem(filedata->GetData(), filedata->GetSize());
+	SDL_RWops *datastream = SDL_RWFromConstMem(filedata->GetData(), static_cast<Uint32>(filedata->GetSize()));
 	SDL_Surface *galaxyImg = SDL_LoadBMP_RW(datastream, 1);
 	if (!galaxyImg) {
 		Output("Galaxy: couldn't load: %s (%s)\n", mapfile.c_str(), SDL_GetError());

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -138,7 +138,7 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 	const int sx = sector->sx;
 	const int sy = sector->sy;
 	const int sz = sector->sz;
-	const int customCount = sector->m_systems.size();
+	const int customCount = static_cast<Uint32>(sector->m_systems.size());
 
 	int numSystems = (rng.Int32(4,20) * galaxy->GetSectorDensity(sx, sy, sz)) >> 8;
 

--- a/src/galaxy/StarSystem.h
+++ b/src/galaxy/StarSystem.h
@@ -106,7 +106,7 @@ public:
 	bool IsMoon() const { return GetSuperType() == SUPERTYPE_ROCKY_PLANET && !IsPlanet(); }
 
 	bool HasChildren() const { return !m_children.empty(); }
-	unsigned GetNumChildren() const { return m_children.size(); }
+	size_t GetNumChildren() const { return m_children.size(); }
 	IterationProxy<std::vector<SystemBody*> > GetChildren() { return MakeIterationProxy(m_children); }
 	const IterationProxy<const std::vector<SystemBody*> > GetChildren() const { return MakeIterationProxy(m_children); }
 
@@ -322,12 +322,12 @@ public:
 	RefCountedPtr<const SystemBody> GetRootBody() const { return m_rootBody; }
 	RefCountedPtr<SystemBody> GetRootBody() { return m_rootBody; }
 	bool HasSpaceStations() const { return !m_spaceStations.empty(); }
-	unsigned GetNumSpaceStations() const { return m_spaceStations.size(); }
+	size_t GetNumSpaceStations() const { return m_spaceStations.size(); }
 	IterationProxy<std::vector<SystemBody*> > GetSpaceStations() { return MakeIterationProxy(m_spaceStations); }
 	const IterationProxy<const std::vector<SystemBody*> > GetSpaceStations() const { return MakeIterationProxy(m_spaceStations); }
 	IterationProxy<std::vector<SystemBody*> > GetStars() { return MakeIterationProxy(m_stars); }
 	const IterationProxy<const std::vector<SystemBody*> > GetStars() const { return MakeIterationProxy(m_stars); }
-	unsigned GetNumBodies() const { return m_bodies.size(); }
+	size_t GetNumBodies() const { return m_bodies.size(); }
 	IterationProxy<std::vector<RefCountedPtr<SystemBody> > > GetBodies() { return MakeIterationProxy(m_bodies); }
 	const IterationProxy<const std::vector<RefCountedPtr<SystemBody> > > GetBodies() const { return MakeIterationProxy(m_bodies); }
 
@@ -363,7 +363,7 @@ protected:
 	virtual ~StarSystem();
 
 	SystemBody *NewBody() {
-		SystemBody *body = new SystemBody(SystemPath(m_path.sectorX, m_path.sectorY, m_path.sectorZ, m_path.systemIndex, m_bodies.size()), this);
+		SystemBody *body = new SystemBody(SystemPath(m_path.sectorX, m_path.sectorY, m_path.sectorZ, m_path.systemIndex, static_cast<Uint32>(m_bodies.size())), this);
 		m_bodies.push_back(RefCountedPtr<SystemBody>(body));
 		return body;
 	}

--- a/src/graphics/gl2/GL2Renderer.cpp
+++ b/src/graphics/gl2/GL2Renderer.cpp
@@ -634,7 +634,7 @@ bool RendererGL2::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 			vbd.attrib[attribIdx].format = ATTRIB_FORMAT_FLOAT3;
 			++attribIdx;
 		}
-		vbd.numVertices = v->position.size();
+		vbd.numVertices = static_cast<Uint32>(v->position.size());
 		vbd.usage = BUFFER_USAGE_DYNAMIC;	// dynamic since we'll be reusing these buffers if possible
 
 		// VertexBuffer

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -696,7 +696,7 @@ bool RendererOGL::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 			vbd.attrib[attribIdx].format = ATTRIB_FORMAT_FLOAT3;
 			++attribIdx;
 		}
-		vbd.numVertices = v->position.size();
+		vbd.numVertices = static_cast<Uint32>(v->position.size());
 		vbd.usage = BUFFER_USAGE_DYNAMIC;	// dynamic since we'll be reusing these buffers if possible
 
 		// VertexBuffer

--- a/src/gui/GuiContainer.h
+++ b/src/gui/GuiContainer.h
@@ -22,7 +22,7 @@ namespace Gui {
 		void RemoveAllChildren();
 		void DeleteAllChildren();
 		void GetChildPosition(const Widget *child, float outPos[2]) const;
-		int GetNumChildren() { return m_children.size(); }
+		size_t GetNumChildren() { return m_children.size(); }
 		virtual void Draw();
 		void ShowChildren();
 		void HideChildren();

--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -46,7 +46,7 @@ public:
 	virtual void ApplyGroup(Group &g) override
 	{
 		ApplyNode(static_cast<Node&>(g));
-		db.wr->Int32(g.GetNumChildren());
+		db.wr->Int32(static_cast<Uint32>(g.GetNumChildren()));
 		g.Traverse(*this);
 	}
 
@@ -127,7 +127,7 @@ void BinaryConverter::Save(const std::string& filename, const std::string& savep
 	SaveAnimations(wr, m);
 
 	//save tags
-	wr.Int32(m->GetNumTags());
+	wr.Int32(static_cast<Uint32>(m->GetNumTags()));
 	for (unsigned int i = 0; i < m->GetNumTags(); i++)
 		wr.String(m->GetTagByIndex(i)->GetName().c_str());
 
@@ -244,7 +244,7 @@ void BinaryConverter::SaveMaterials(Serializer::Writer& wr, Model* model)
 	//for material definitions
 	const ModelDefinition &modelDef = FindModelDefinition(model->GetName());
 
-	wr.Int32(modelDef.matDefs.size());
+	wr.Int32(static_cast<Uint32>(modelDef.matDefs.size()));
 
 	for (const auto& m : modelDef.matDefs) {
 		wr.String(m.name);
@@ -296,25 +296,25 @@ void BinaryConverter::SaveAnimations(Serializer::Writer &wr, Model *m)
 {
 	PROFILE_SCOPED()
 	const auto& anims = m->GetAnimations();
-	wr.Int32(anims.size());
+	wr.Int32(static_cast<Uint32>(anims.size()));
 	for (const auto& anim : anims) {
 		wr.String(anim->GetName());
 		wr.Double(anim->GetDuration());
-		wr.Int32(anim->GetChannels().size());
+		wr.Int32(static_cast<Uint32>(anim->GetChannels().size()));
 		for (const auto &chan : anim->GetChannels()) {
 			wr.String(chan.node->GetName());
 			//write pos/rot/scale keys
-			wr.Int32(chan.positionKeys.size());
+			wr.Int32(static_cast<Uint32>(chan.positionKeys.size()));
 			for (const auto &pkey : chan.positionKeys) {
 				wr.Double(pkey.time);
 				wr.Vector3f(pkey.position);
 			}
-			wr.Int32(chan.rotationKeys.size());
+			wr.Int32(static_cast<Uint32>(chan.rotationKeys.size()));
 			for (const auto &rkey : chan.rotationKeys) {
 				wr.Double(rkey.time);
 				wr.WrQuaternionf(rkey.rotation);
 			}
-			wr.Int32(chan.scaleKeys.size());
+			wr.Int32(static_cast<Uint32>(chan.scaleKeys.size()));
 			for (const auto &skey : chan.scaleKeys) {
 				wr.Double(skey.time);
 				wr.Vector3f(skey.scale);

--- a/src/scenegraph/DumpVisitor.cpp
+++ b/src/scenegraph/DumpVisitor.cpp
@@ -17,7 +17,7 @@ DumpVisitor::DumpVisitor(const Model *m)
 {
 	//model statistics that cannot be visited)
 	m_modelStats.collTriCount = m->GetCollisionMesh() ? m->GetCollisionMesh()->GetNumTriangles() : 0;
-	m_modelStats.materialCount = m->GetNumMaterials();
+	m_modelStats.materialCount = static_cast<Uint32>(m->GetNumMaterials());
 }
 
 std::string DumpVisitor::GetModelStatistics()

--- a/src/scenegraph/Group.h
+++ b/src/scenegraph/Group.h
@@ -22,7 +22,7 @@ public:
 	virtual void AddChild(Node *child);
 	virtual bool RemoveChild(Node *node); //true on success
 	virtual bool RemoveChildAt(unsigned int position); //true on success
-	unsigned int GetNumChildren() const { return m_children.size(); }
+	size_t GetNumChildren() const { return m_children.size(); }
 	Node* GetChildAt(unsigned int);
 	virtual void Accept(NodeVisitor &v) override;
 	virtual void Traverse(NodeVisitor &v) override;

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -534,9 +534,9 @@ void Loader::ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry> > &geoms,
 		assert(indices.size() > 0);
 
 		//create buffer & copy
-		RefCountedPtr<Graphics::IndexBuffer> ib(m_renderer->CreateIndexBuffer(indices.size(), Graphics::BUFFER_USAGE_STATIC));
+		RefCountedPtr<Graphics::IndexBuffer> ib(m_renderer->CreateIndexBuffer(static_cast<Uint32>(indices.size()), Graphics::BUFFER_USAGE_STATIC));
 		Uint32* idxPtr = ib->Map(Graphics::BUFFER_MAP_WRITE);
-		for (Uint32 j = 0; j < indices.size(); j++)
+		for (size_t j = 0; j < indices.size(); j++)
 			idxPtr[j] = indices[j];
 		ib->Unmap();
 

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -248,7 +248,7 @@ void Model::CreateAabbVB()
 		Graphics::VertexBufferDesc vbd;
 		vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;
 		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
-		vbd.numVertices = va.GetNumVerts();
+		vbd.numVertices = static_cast<Uint32>(va.GetNumVerts());
 		vbd.usage = Graphics::BUFFER_USAGE_STATIC;
 		m_aabbVB.Reset( m_renderer->CreateVertexBuffer(vbd) );
 		m_aabbVB->Populate( va );
@@ -298,7 +298,7 @@ void Model::DrawCollisionMesh()
 		vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
 		vbd.attrib[1].semantic = Graphics::ATTRIB_DIFFUSE;
 		vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_UBYTE4;
-		vbd.numVertices = va.GetNumVerts();
+		vbd.numVertices = static_cast<Uint32>(va.GetNumVerts());
 		vbd.usage = Graphics::BUFFER_USAGE_STATIC;
 		m_collisionMeshVB.Reset( m_renderer->CreateVertexBuffer(vbd) );
 		m_collisionMeshVB->Populate( va );

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -121,9 +121,9 @@ public:
 	//materials used in the nodes should be accessible from here for convenience
 	RefCountedPtr<Graphics::Material> GetMaterialByName(const std::string &name) const;
 	RefCountedPtr<Graphics::Material> GetMaterialByIndex(const int) const;
-	unsigned int GetNumMaterials() const { return m_materials.size(); }
+	size_t GetNumMaterials() const { return m_materials.size(); }
 
-	unsigned int GetNumTags() const { return m_tags.size(); }
+	size_t GetNumTags() const { return m_tags.size(); }
 	MatrixTransform *const GetTagByIndex(unsigned int index) const;
 	MatrixTransform *const FindTagByName(const std::string &name) const;
 	typedef std::vector<MatrixTransform *> TVecMT;
@@ -131,7 +131,7 @@ public:
 	void AddTag(const std::string &name, MatrixTransform *node);
 
 	const PatternContainer &GetPatterns() const { return m_patterns; }
-	unsigned int GetNumPatterns() const { return m_patterns.size(); }
+	size_t GetNumPatterns() const { return m_patterns.size(); }
 	void SetPattern(unsigned int index);
 	unsigned int GetPattern() const { return m_curPatternIndex; }
 	void SetColors(const std::vector<Color> &colors);

--- a/src/scenegraph/StaticGeometry.cpp
+++ b/src/scenegraph/StaticGeometry.cpp
@@ -59,7 +59,7 @@ void StaticGeometry::Render(const std::vector<matrix4x4f> &trans, const RenderDa
 	SDL_assert(m_renderState);
 	Graphics::Renderer *r = GetRenderer();
 
-	const size_t numTrans = trans.size();
+	const Uint32 numTrans = static_cast<Uint32>(trans.size());
 	if (!m_instBuffer.Valid() || (numTrans > m_instBuffer->GetSize()))
 	{
 		// create the InstanceBuffer with the maximum number of transformations we might use within it.
@@ -125,7 +125,7 @@ void StaticGeometry::Save(NodeDatabase &db)
     db.wr->Vector3d(m_boundingBox.min);
     db.wr->Vector3d(m_boundingBox.max);
 
-    db.wr->Int32(m_meshes.size());
+    db.wr->Int32(static_cast<Uint32>(m_meshes.size()));
 
     for (auto mesh : m_meshes) {
 		//do ptr to material name mapping
@@ -375,7 +375,7 @@ void StaticGeometry::DrawBoundingBox(const Aabb &bb)
 	vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
 	vbd.attrib[1].semantic = Graphics::ATTRIB_DIFFUSE;
 	vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_UBYTE4;
-	vbd.numVertices = vts->GetNumVerts();
+	vbd.numVertices = static_cast<Uint32>(vts->GetNumVerts());
 	vbd.usage = Graphics::BUFFER_USAGE_STATIC;
 	vb.Reset( m_renderer->CreateVertexBuffer(vbd) );
 	vb->Populate( *vts );

--- a/src/scenegraph/StaticGeometry.h
+++ b/src/scenegraph/StaticGeometry.h
@@ -38,7 +38,7 @@ public:
 	void AddMesh(RefCountedPtr<Graphics::VertexBuffer>,
 		RefCountedPtr<Graphics::IndexBuffer>,
 		RefCountedPtr<Graphics::Material>);
-	unsigned int GetNumMeshes() const { return m_meshes.size(); }
+	size_t GetNumMeshes() const { return m_meshes.size(); }
 	Mesh &GetMeshAt(unsigned int i);
 
 	void SetRenderState(Graphics::RenderState *s) { m_renderState = s; }

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -169,7 +169,7 @@ Graphics::VertexBuffer *Thruster::CreateThrusterGeometry(Graphics::Renderer *r, 
 	vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
 	vbd.attrib[1].semantic = Graphics::ATTRIB_UV0;
 	vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
-	vbd.numVertices = verts.GetNumVerts();
+	vbd.numVertices = static_cast<Uint32>(verts.GetNumVerts());
 	vbd.usage = Graphics::BUFFER_USAGE_STATIC;
 	Graphics::VertexBuffer *vb = r->CreateVertexBuffer(vbd);
 	vb->Populate(verts);
@@ -214,7 +214,7 @@ Graphics::VertexBuffer *Thruster::CreateGlowGeometry(Graphics::Renderer *r, Grap
 	vbd.attrib[0].format   = Graphics::ATTRIB_FORMAT_FLOAT3;
 	vbd.attrib[1].semantic = Graphics::ATTRIB_UV0;
 	vbd.attrib[1].format   = Graphics::ATTRIB_FORMAT_FLOAT2;
-	vbd.numVertices = verts.GetNumVerts();
+	vbd.numVertices = static_cast<Uint32>(verts.GetNumVerts());
 	vbd.usage = Graphics::BUFFER_USAGE_STATIC;
 	Graphics::VertexBuffer *vb = r->CreateVertexBuffer(vbd);
 	vb->Populate(verts);

--- a/src/ui/Box.cpp
+++ b/src/ui/Box.cpp
@@ -96,7 +96,7 @@ Point Box::PreferredSize()
 	// if there was no variable ones, and thus we're asking for a specific
 	// amount of space, add sufficient padding
 	if (m_numVariable == 0)
-		m_preferredSize[vc] += m_spacing*m_children.size();
+		m_preferredSize[vc] += m_spacing * static_cast<Uint32>(m_children.size());
 
 	return m_preferredSize;
 }
@@ -127,8 +127,8 @@ void Box::Layout()
 		// didn't get enough, so we have share it around
 		else {
 			// we can certainly afford to give everyone this much
-			int availSize = boxSize[vc] - (m_spacing * (m_children.size()-1));
-			int minSize = availSize / m_children.size();
+			int availSize = boxSize[vc] - (m_spacing * static_cast<Uint32>(m_children.size()-1));
+			int minSize = availSize / static_cast<Uint32>(m_children.size());
 			int remaining = availSize;
 			int wantMore = 0;
 
@@ -159,13 +159,13 @@ void Box::Layout()
 	// we have one or more children that have requested the maximum size possible
 	else {
 
-		int availSize = boxSize[vc] - (m_spacing * (m_children.size()-1));
+		int availSize = boxSize[vc] - (m_spacing * static_cast<Sint32>((m_children.size()-1)));
 		int remaining = availSize;
 
 		// fixed ones first
 		if (m_children.size() > m_numVariable) {
 			// distribute evenly among the fixed ones
-			int minSize = availSize / (m_children.size() - m_numVariable);
+			int minSize = availSize / (static_cast<Uint32>(m_children.size()) - m_numVariable);
 
 			// loop and hand it out
 			for (std::list<Child>::iterator i = m_children.begin(); i != m_children.end(); ++i) {

--- a/src/ui/Container.h
+++ b/src/ui/Container.h
@@ -42,7 +42,7 @@ public:
 	virtual void Disable();
 	virtual void Enable();
 
-	unsigned GetNumWidgets() const { return m_widgets.size(); }
+	size_t GetNumWidgets() const { return m_widgets.size(); }
 	IterationProxy<std::vector<RefCountedPtr<Widget> > > GetWidgets() { return MakeIterationProxy(m_widgets); }
 	const IterationProxy<const std::vector<RefCountedPtr<Widget> > > GetWidgets() const { return MakeIterationProxy(m_widgets); }
 

--- a/src/ui/Grid.cpp
+++ b/src/ui/Grid.cpp
@@ -8,8 +8,8 @@ namespace UI {
 Grid::Grid(Context *context, const CellSpec &rowSpec, const CellSpec &colSpec) : Container(context),
 	m_rowSpec(rowSpec),
 	m_colSpec(colSpec),
-	m_numRows(colSpec.numCells),
-	m_numCols(rowSpec.numCells),
+	m_numRows(static_cast<Uint32>(colSpec.numCells)),
+	m_numCols(static_cast<Uint32>(rowSpec.numCells)),
 	m_widgets(m_rowSpec.numCells*m_colSpec.numCells)
 {
 	Clear();

--- a/src/ui/List.cpp
+++ b/src/ui/List.cpp
@@ -32,7 +32,7 @@ List *List::AddOption(const std::string &text)
 
 	VBox *vbox = static_cast<VBox*>(m_container->GetInnerWidget());
 
-	int index = m_optionBackgrounds.size();
+	int index = static_cast<int>(m_optionBackgrounds.size());
 
 	ColorBackground *background = c->ColorBackground(m_selected == index ? c->GetSkin().GetSelectColor() : c->GetSkin().GetNormalColor());
 	vbox->PackEnd(background->SetInnerWidget(c->Label(text)));

--- a/src/ui/LuaGrid.cpp
+++ b/src/ui/LuaGrid.cpp
@@ -13,7 +13,7 @@ public:
 		UI::Grid *g = LuaObject<UI::Grid>::CheckFromLua(1);
 		UI::Context *c = g->GetContext();
 
-		size_t rowNum = luaL_checkinteger(l, 2);
+		Uint32 rowNum = luaL_checkinteger(l, 2);
 		luaL_checktype(l, 3, LUA_TTABLE);
 
 		if (rowNum >= g->GetNumRows()) {
@@ -21,7 +21,7 @@ public:
 			return 0;
 		}
 
-		for (size_t i = 0; i < g->GetNumCols() && i < lua_rawlen(l, 3); i++) {
+		for (Uint32 i = 0; i < g->GetNumCols() && i < static_cast<Uint32>(lua_rawlen(l, 3)); i++) {
 			lua_rawgeti(l, 3, i+1);
 			if (lua_isnil(l, -1))
 				g->ClearCell(i, rowNum);
@@ -38,7 +38,7 @@ public:
 		UI::Grid *g = LuaObject<UI::Grid>::CheckFromLua(1);
 		UI::Context *c = g->GetContext();
 
-		size_t colNum = luaL_checkinteger(l, 2);
+		Uint32 colNum = luaL_checkinteger(l, 2);
 		luaL_checktype(l, 3, LUA_TTABLE);
 
 		if (colNum >= g->GetNumCols()) {
@@ -46,7 +46,7 @@ public:
 			return 0;
 		}
 
-		for (size_t i = 0; i < g->GetNumRows() && i < lua_rawlen(l, 3); i++) {
+		for (Uint32 i = 0; i < g->GetNumRows() && i < lua_rawlen(l, 3); i++) {
 			lua_rawgeti(l, 3, i+1);
 			if (lua_isnil(l, -1))
 				g->ClearCell(colNum, i);
@@ -63,8 +63,8 @@ public:
 		UI::Grid *g = LuaObject<UI::Grid>::CheckFromLua(1);
 		UI::Context *c = g->GetContext();
 
-		size_t colNum = luaL_checkinteger(l, 2);
-		size_t rowNum = luaL_checkinteger(l, 3);
+		Uint32 colNum = luaL_checkinteger(l, 2);
+		Uint32 rowNum = luaL_checkinteger(l, 3);
 		UI::Widget *w = UI::Lua::CheckWidget(c, l, 4);
 
 		if (colNum >= g->GetNumCols()) {

--- a/src/ui/LuaSignal.h
+++ b/src/ui/LuaSignal.h
@@ -92,7 +92,7 @@ protected:
 			lua_setfield(l, LUA_REGISTRYINDEX, "PiUISignal");
 		}
 
-		idx = lua_rawlen(l, -1)+1;
+		idx = static_cast<Sint32>(lua_rawlen(l, -1)+1);
 		lua_pushvalue(l, 2);
 		lua_rawseti(l, -2, idx);
 

--- a/src/ui/LuaTable.cpp
+++ b/src/ui/LuaTable.cpp
@@ -23,7 +23,7 @@ public:
 				widgets.push_back(w);
 			else
 				for (size_t i = 0; i < lua_rawlen(l, 2); i++) {
-					lua_rawgeti(l, 2, i+1);
+					lua_rawgeti(l, 2, static_cast<Sint32>(i+1));
 					widgets.push_back(UI::Lua::CheckWidget(c, l, -1));
 					lua_pop(l, 1);
 				}
@@ -50,7 +50,7 @@ public:
 				widgets.push_back(w);
 			else
 				for (size_t i = 0; i < lua_rawlen(l, idx); i++) {
-					lua_rawgeti(l, idx, i+1);
+					lua_rawgeti(l, idx, static_cast<Sint32>(i+1));
 					widgets.push_back(UI::Lua::CheckWidget(c, l, -1));
 					lua_pop(l, 1);
 				}

--- a/src/ui/Table.cpp
+++ b/src/ui/Table.cpp
@@ -44,7 +44,7 @@ void Table::LayoutAccumulator::ComputeForWidth(int availWidth) {
 		return;
 
 	if (m_preferredWidth == SIZE_EXPAND) {
-		int fixedSize = m_columnSpacing * (m_columnWidth.size()-1);
+		int fixedSize = m_columnSpacing * static_cast<Uint32>(m_columnWidth.size()-1);
 		int numExpand = 0;
 		for (std::size_t i = 0; i < m_columnWidth.size(); i++)
 			if (m_columnWidth[i] == SIZE_EXPAND)
@@ -80,7 +80,7 @@ void Table::LayoutAccumulator::ComputeForWidth(int availWidth) {
 		case COLUMN_RIGHT: {
 			m_columnLeft.back() = availWidth - m_columnWidth.back();
 			if (m_columnWidth.size() > 1)
-				for (int i = m_columnWidth.size()-2; i >= 0; i--)
+				for (size_t i = m_columnWidth.size()-2; i >= 0; i--)
 					m_columnLeft[i] = m_columnLeft[i+1] - m_columnSpacing - m_columnWidth[i];
 			break;
 		}
@@ -88,7 +88,7 @@ void Table::LayoutAccumulator::ComputeForWidth(int availWidth) {
 		case COLUMN_JUSTIFY: {
 			m_columnLeft[0] = 0;
 			if (m_columnWidth.size() > 1) {
-				int pad = availWidth > m_preferredWidth ? (availWidth-m_preferredWidth) / (m_columnWidth.size()-1) : 0;
+				int pad = availWidth > m_preferredWidth ? (availWidth-m_preferredWidth) / static_cast<Uint32>(m_columnWidth.size()-1) : 0;
 				for (std::size_t i = 1; i < m_columnWidth.size(); i++)
 					m_columnLeft[i] = m_columnLeft[i-1] + m_columnWidth[i-1] + m_columnSpacing + pad;
 			}
@@ -134,7 +134,7 @@ Point Table::Inner::PreferredSize()
 	}
 
 	if (!m_rows.empty() && m_rowSpacing)
-		m_preferredSize.y += (m_rows.size()-1)*m_rowSpacing;
+		m_preferredSize.y += static_cast<Uint32>(m_rows.size()-1) * m_rowSpacing;
 
 	m_dirty = false;
 	return m_preferredSize;
@@ -254,7 +254,7 @@ void Table::Inner::HandleClick()
 
 int Table::Inner::RowUnderPoint(const Point &pt, int *out_row_top, int *out_row_bottom) const
 {
-	int start = 0, end = m_rows.size()-1, mid = 0;
+	int start = 0, end = static_cast<Uint32>(m_rows.size()-1), mid = 0;
 	while (start <= end) {
 		mid = start+((end-start)/2);
 

--- a/src/ui/TextEntry.cpp
+++ b/src/ui/TextEntry.cpp
@@ -115,7 +115,7 @@ void TextEntry::HandleKeyDown(const KeyboardEvent &event)
 			break;
 
 		case SDLK_END:
-			m_cursor = text.size();
+			m_cursor = static_cast<Uint32>(text.size());
 			break;
 
 		case SDLK_BACKSPACE:
@@ -157,7 +157,7 @@ void TextEntry::HandleKeyDown(const KeyboardEvent &event)
 					case SDLK_w: {
 						size_t pos = text.find_last_not_of(' ', m_cursor);
 						if (pos != std::string::npos) pos = text.find_last_of(' ', pos);
-						m_cursor = pos != std::string::npos ? pos+1 : 0;
+						m_cursor = static_cast<Uint32>(pos != std::string::npos ? pos+1 : 0);
 						text.erase(m_cursor);
 						m_label->SetText(text);
 						onChange.emit(text);
@@ -167,10 +167,10 @@ void TextEntry::HandleKeyDown(const KeyboardEvent &event)
 					case SDLK_v: { // XXX SDLK_PASTE?
 						if (SDL_HasClipboardText()) {
 							char *paste = SDL_GetClipboardText();
-							int len = strlen(paste); // XXX strlen not utf8-aware
+							size_t len = strlen(paste); // XXX strlen not utf8-aware
 							text.insert(m_cursor, paste, len);
 							m_label->SetText(text);
-							m_cursor += len;
+							m_cursor += static_cast<Uint32>(len);
 							SDL_free(paste);
 						}
 					}


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Mostly a case of doing the following.
- return size_t where appropriate
- cast to Uint32/Sint32 where necessary

miniz still has some 64-bit portability warnings but I'll do them at another time.
<!-- Please make sure you've read documentation on contributing -->

