### PR TITLE
Cleaup 64-bit warnings in vs2015

### DIFF
--- a/src/Camera.h
+++ b/src/Camera.h
@@ -103,7 +103,7 @@ public:
 
 	// lights with properties in camera space
 	const std::vector<LightSource> &GetLightSources() const { return m_lightSources; }
-	const int GetNumLightSources() const { return m_lightSources.size(); }
+	const int GetNumLightSources() const { return static_cast<Uint32>(m_lightSources.size()); }
 
 private:
 	RefCountedPtr<CameraContext> m_context;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -62,7 +62,7 @@ public:
 	void AddChild(Frame *f) { m_children.push_back(f); }
 	void RemoveChild(Frame *f);
 	bool HasChildren() const { return !m_children.empty(); }
-	unsigned GetNumChildren() const { return m_children.size(); }
+	unsigned GetNumChildren() const { return static_cast<Uint32>(m_children.size()); }
 	IterationProxy<std::vector<Frame*> > GetChildren() { return MakeIterationProxy(m_children); }
 	const IterationProxy<const std::vector<Frame*> > GetChildren() const { return MakeIterationProxy(m_children); }
 

--- a/src/Lang.h
+++ b/src/Lang.h
@@ -22,7 +22,7 @@ public:
 
 	bool Load();
 
-	Uint32 GetNumStrings() const { return m_strings.size(); }
+	Uint32 GetNumStrings() const { return static_cast<Uint32>(m_strings.size()); }
 
 	const std::string &Get(const std::string &token) const;
 

--- a/src/LuaTable.h
+++ b/src/LuaTable.h
@@ -141,7 +141,7 @@ public:
 
 	lua_State * GetLua() const { return m_lua; }
 	int GetIndex() const { return m_index; }
-	int Size() const {return lua_rawlen(m_lua, m_index);}
+	size_t Size() const {return lua_rawlen(m_lua, m_index);}
 
 	/* VecIter, as in VectorIterator (only shorter to type :-)
 	 *

--- a/src/Space.h
+++ b/src/Space.h
@@ -63,7 +63,7 @@ public:
 	Body *FindNearestTo(const Body *b, Object::Type t) const;
 	Body *FindBodyForPath(const SystemPath *path) const;
 
-	unsigned GetNumBodies() const { return m_bodies.size(); }
+	Uint32 GetNumBodies() const { return static_cast<Uint32>(m_bodies.size()); }
 	IterationProxy<std::list<Body*> > GetBodies() { return MakeIterationProxy(m_bodies); }
 	const IterationProxy<const std::list<Body*> > GetBodies() const { return MakeIterationProxy(m_bodies); }
 

--- a/src/SpeedLines.cpp
+++ b/src/SpeedLines.cpp
@@ -33,8 +33,9 @@ SpeedLines::SpeedLines(Ship *s)
 		}
 	}
 
-	m_varray.reset(new Graphics::VertexArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE, (m_points.size() * 2)));
-	for( Uint32 i = 0; i < (m_points.size() * 2); i++ )
+	const Uint32 doubleNumPoints = static_cast<Uint32>(m_points.size()) * 2;
+	m_varray.reset(new Graphics::VertexArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE, doubleNumPoints));
+	for( Uint32 i = 0; i < doubleNumPoints; i++ )
 		m_varray->Add(vector3f(0.0f), Color::BLACK);
 
 	Graphics::RenderStateDesc rsd;
@@ -42,7 +43,7 @@ SpeedLines::SpeedLines(Ship *s)
 	rsd.depthWrite = false;
 	m_renderState = Pi::renderer->CreateRenderState(rsd);
 
-	CreateVertexBuffer( Pi::renderer, (m_points.size() * 2) );
+	CreateVertexBuffer( Pi::renderer, doubleNumPoints );
 }
 
 void SpeedLines::Update(float time)

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -138,7 +138,7 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 	const int sx = sector->sx;
 	const int sy = sector->sy;
 	const int sz = sector->sz;
-	const int customCount = sector->m_systems.size();
+	const int customCount = static_cast<Uint32>(sector->m_systems.size());
 
 	int numSystems = (rng.Int32(4,20) * galaxy->GetSectorDensity(sx, sy, sz)) >> 8;
 

--- a/src/galaxy/StarSystem.h
+++ b/src/galaxy/StarSystem.h
@@ -106,7 +106,7 @@ public:
 	bool IsMoon() const { return GetSuperType() == SUPERTYPE_ROCKY_PLANET && !IsPlanet(); }
 
 	bool HasChildren() const { return !m_children.empty(); }
-	unsigned GetNumChildren() const { return m_children.size(); }
+	Uint32 GetNumChildren() const { return static_cast<Uint32>(m_children.size()); }
 	IterationProxy<std::vector<SystemBody*> > GetChildren() { return MakeIterationProxy(m_children); }
 	const IterationProxy<const std::vector<SystemBody*> > GetChildren() const { return MakeIterationProxy(m_children); }
 
@@ -322,12 +322,12 @@ public:
 	RefCountedPtr<const SystemBody> GetRootBody() const { return m_rootBody; }
 	RefCountedPtr<SystemBody> GetRootBody() { return m_rootBody; }
 	bool HasSpaceStations() const { return !m_spaceStations.empty(); }
-	unsigned GetNumSpaceStations() const { return m_spaceStations.size(); }
+	Uint32 GetNumSpaceStations() const { return static_cast<Uint32>(m_spaceStations.size()); }
 	IterationProxy<std::vector<SystemBody*> > GetSpaceStations() { return MakeIterationProxy(m_spaceStations); }
 	const IterationProxy<const std::vector<SystemBody*> > GetSpaceStations() const { return MakeIterationProxy(m_spaceStations); }
 	IterationProxy<std::vector<SystemBody*> > GetStars() { return MakeIterationProxy(m_stars); }
 	const IterationProxy<const std::vector<SystemBody*> > GetStars() const { return MakeIterationProxy(m_stars); }
-	unsigned GetNumBodies() const { return m_bodies.size(); }
+	Uint32 GetNumBodies() const { return static_cast<Uint32>(m_bodies.size()); }
 	IterationProxy<std::vector<RefCountedPtr<SystemBody> > > GetBodies() { return MakeIterationProxy(m_bodies); }
 	const IterationProxy<const std::vector<RefCountedPtr<SystemBody> > > GetBodies() const { return MakeIterationProxy(m_bodies); }
 
@@ -363,7 +363,7 @@ protected:
 	virtual ~StarSystem();
 
 	SystemBody *NewBody() {
-		SystemBody *body = new SystemBody(SystemPath(m_path.sectorX, m_path.sectorY, m_path.sectorZ, m_path.systemIndex, m_bodies.size()), this);
+		SystemBody *body = new SystemBody(SystemPath(m_path.sectorX, m_path.sectorY, m_path.sectorZ, m_path.systemIndex, static_cast<Uint32>(m_bodies.size())), this);
 		m_bodies.push_back(RefCountedPtr<SystemBody>(body));
 		return body;
 	}

--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -24,7 +24,7 @@ public:
 
 	//check presence of an attribute
 	__inline bool HasAttrib(const VertexAttrib v) const	{ return (m_attribs & v) != 0; }
-	__inline size_t GetNumVerts() const { return position.size(); }
+	__inline Uint32 GetNumVerts() const { return static_cast<Uint32>(position.size()); }
 	__inline AttributeSet GetAttributeSet() const { return m_attribs; }
 
 	__inline bool IsEmpty() const { return position.empty(); }

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -696,7 +696,7 @@ bool RendererOGL::DrawTriangles(const VertexArray *v, RenderState *rs, Material 
 			vbd.attrib[attribIdx].format = ATTRIB_FORMAT_FLOAT3;
 			++attribIdx;
 		}
-		vbd.numVertices = v->position.size();
+		vbd.numVertices = static_cast<Uint32>(v->position.size());
 		vbd.usage = BUFFER_USAGE_DYNAMIC;	// dynamic since we'll be reusing these buffers if possible
 
 		// VertexBuffer

--- a/src/gui/GuiContainer.h
+++ b/src/gui/GuiContainer.h
@@ -22,7 +22,7 @@ namespace Gui {
 		void RemoveAllChildren();
 		void DeleteAllChildren();
 		void GetChildPosition(const Widget *child, float outPos[2]) const;
-		int GetNumChildren() { return m_children.size(); }
+		int GetNumChildren() { return static_cast<Uint32>(m_children.size()); }
 		virtual void Draw();
 		void ShowChildren();
 		void HideChildren();

--- a/src/scenegraph/Group.h
+++ b/src/scenegraph/Group.h
@@ -22,7 +22,7 @@ public:
 	virtual void AddChild(Node *child);
 	virtual bool RemoveChild(Node *node); //true on success
 	virtual bool RemoveChildAt(unsigned int position); //true on success
-	unsigned int GetNumChildren() const { return m_children.size(); }
+	unsigned int GetNumChildren() const { return static_cast<Uint32>(m_children.size()); }
 	Node* GetChildAt(unsigned int);
 	virtual void Accept(NodeVisitor &v) override;
 	virtual void Traverse(NodeVisitor &v) override;

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -121,9 +121,9 @@ public:
 	//materials used in the nodes should be accessible from here for convenience
 	RefCountedPtr<Graphics::Material> GetMaterialByName(const std::string &name) const;
 	RefCountedPtr<Graphics::Material> GetMaterialByIndex(const int) const;
-	unsigned int GetNumMaterials() const { return m_materials.size(); }
+	unsigned int GetNumMaterials() const { return static_cast<Uint32>(m_materials.size()); }
 
-	unsigned int GetNumTags() const { return m_tags.size(); }
+	unsigned int GetNumTags() const { return static_cast<Uint32>(m_tags.size()); }
 	MatrixTransform *const GetTagByIndex(unsigned int index) const;
 	MatrixTransform *const FindTagByName(const std::string &name) const;
 	typedef std::vector<MatrixTransform *> TVecMT;
@@ -131,7 +131,7 @@ public:
 	void AddTag(const std::string &name, MatrixTransform *node);
 
 	const PatternContainer &GetPatterns() const { return m_patterns; }
-	unsigned int GetNumPatterns() const { return m_patterns.size(); }
+	unsigned int GetNumPatterns() const { return static_cast<Uint32>(m_patterns.size()); }
 	void SetPattern(unsigned int index);
 	unsigned int GetPattern() const { return m_curPatternIndex; }
 	void SetColors(const std::vector<Color> &colors);

--- a/src/scenegraph/StaticGeometry.h
+++ b/src/scenegraph/StaticGeometry.h
@@ -38,7 +38,7 @@ public:
 	void AddMesh(RefCountedPtr<Graphics::VertexBuffer>,
 		RefCountedPtr<Graphics::IndexBuffer>,
 		RefCountedPtr<Graphics::Material>);
-	unsigned int GetNumMeshes() const { return m_meshes.size(); }
+	unsigned int GetNumMeshes() const { return static_cast<Uint32>(m_meshes.size()); }
 	Mesh &GetMeshAt(unsigned int i);
 
 	void SetRenderState(Graphics::RenderState *s) { m_renderState = s; }

--- a/src/ui/Container.h
+++ b/src/ui/Container.h
@@ -42,7 +42,7 @@ public:
 	virtual void Disable();
 	virtual void Enable();
 
-	unsigned GetNumWidgets() const { return m_widgets.size(); }
+	Uint32 GetNumWidgets() const { return static_cast<Uint32>(m_widgets.size()); }
 	IterationProxy<std::vector<RefCountedPtr<Widget> > > GetWidgets() { return MakeIterationProxy(m_widgets); }
 	const IterationProxy<const std::vector<RefCountedPtr<Widget> > > GetWidgets() const { return MakeIterationProxy(m_widgets); }
 

--- a/src/ui/TextEntry.cpp
+++ b/src/ui/TextEntry.cpp
@@ -115,7 +115,7 @@ void TextEntry::HandleKeyDown(const KeyboardEvent &event)
 			break;
 
 		case SDLK_END:
-			m_cursor = text.size();
+			m_cursor = static_cast<Uint32>(text.size());
 			break;
 
 		case SDLK_BACKSPACE:
@@ -157,7 +157,7 @@ void TextEntry::HandleKeyDown(const KeyboardEvent &event)
 					case SDLK_w: {
 						size_t pos = text.find_last_not_of(' ', m_cursor);
 						if (pos != std::string::npos) pos = text.find_last_of(' ', pos);
-						m_cursor = pos != std::string::npos ? pos+1 : 0;
+						m_cursor = static_cast<Uint32>(pos != std::string::npos ? pos+1 : 0);
 						text.erase(m_cursor);
 						m_label->SetText(text);
 						onChange.emit(text);
@@ -167,10 +167,10 @@ void TextEntry::HandleKeyDown(const KeyboardEvent &event)
 					case SDLK_v: { // XXX SDLK_PASTE?
 						if (SDL_HasClipboardText()) {
 							char *paste = SDL_GetClipboardText();
-							int len = strlen(paste); // XXX strlen not utf8-aware
+							size_t len = strlen(paste); // XXX strlen not utf8-aware
 							text.insert(m_cursor, paste, len);
 							m_label->SetText(text);
-							m_cursor += len;
+							m_cursor += static_cast<Uint32>(len);
 							SDL_free(paste);
 						}
 					}


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Mostly a case of doing the following.
- return Uint32, using `static_cast`, where appropriate
- cast to Uint32/Sint32/size_t where necessary

There are lingering 64-bit portability warnings but this reduces the bulk of them in vs2015 and hopefully will do on other platforms.
<!-- Please make sure you've read documentation on contributing -->

