### PR TITLE
Handle assimp major versions greater than 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -302,7 +302,9 @@ if test "x$cross_compiling" = "xno" ; then
 	AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <assimp/defs.h>
 	                                 #include <assimp/version.h>]],
 	                            [[do {
-	                                if (aiGetVersionMajor() >= 3 && aiGetVersionMinor() >= 2)
+	                                if (aiGetVersionMajor() > 3)
+	                                    return 0;
+	                                else if (aiGetVersionMajor() == 3 && aiGetVersionMinor() >= 2)
 	                                    return 0;
 	                                return 1;
 	                              } while(0)]])],


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
This is to fix #4054

Update the configure.ac to handle assimp major versions greater than 3
<!-- Please make sure you've read documentation on contributing -->

