### PR TITLE
Avoid crash on ESCaping a UI Dropdown.

### DIFF
--- a/src/ui/Context.cpp
+++ b/src/ui/Context.cpp
@@ -96,10 +96,12 @@ Layer *Context::NewLayer()
 void Context::DropLayer()
 {
 	// dropping the last layer would be bad
-	assert(m_layers.size() > 1);
-	RemoveWidget(m_layers.back());
-	m_layers.pop_back();
-	m_needsLayout = true;
+	if(m_layers.size() > 1)
+	{
+		RemoveWidget(m_layers.back());
+		m_layers.pop_back();
+		m_needsLayout = true;
+	}
 }
 
 void Context::DropAllLayers()


### PR DESCRIPTION
Changed an assert to an if check. It prevents the crash but there is still a UI issue.

It fixes #4059 in that it prevents a crash but it leaves the dropdown in the wrong state and you must double click it the subsequent time to reactivate it.
