### PR TITLE
Sort order fix

### DIFF
--- a/src/LuaBody.cpp
+++ b/src/LuaBody.cpp
@@ -212,7 +212,10 @@ static int l_body_is_more_important_than(lua_State *l)
 	// bodies are sorted by importance in menus
 
 	if(body == other)
-		return false;
+	{
+		LuaPush<bool>(l, false);
+		return 1;
+	}
 
 	Object::Type a = body->GetType();
 	const SystemBody *sb_a = body->GetSystemBody();
@@ -236,8 +239,10 @@ static int l_body_is_more_important_than(lua_State *l)
 	else if(a == Object::Type::STAR) result = true;
 	// any (non-star) object is smaller than a star
 	else if(b == Object::Type::STAR) result = false;
-	// a gas giant is larger than anything but a star
-	else if(a_gas_giant) result = true;
+	// a gas giant is larger than anything but a star,
+	// but remember to keep total order in mind: if both are
+	// gas giants, order alphabetically
+	else if(a_gas_giant) result = !b_gas_giant || body->GetLabel() < other->GetLabel();
 	// any (non-star, non-gas giant) object is smaller than a gas giant
 	else if(b_gas_giant) result = false;
 	// between two planets or moons, alphabetic
@@ -251,13 +256,11 @@ static int l_body_is_more_important_than(lua_State *l)
 	else if(a_moon) result = true;
 	// a non-moon is smaller than any moon
 	else if(b_moon) result = false;
-	// spacestation > ship > hyperspace cloud > cargo body > missile > projectile
+	// spacestation > city > ship > hyperspace cloud > cargo body > missile > projectile
 	else if(a == Object::Type::SPACESTATION) result = true;
 	else if(b == Object::Type::SPACESTATION) result = false;
     else if(a == Object::Type::CITYONPLANET) result = true;
     else if(b == Object::Type::CITYONPLANET) result = false;
-    else if(a == Object::Type::TERRAINBODY) result = true;
-    else if(b == Object::Type::TERRAINBODY) result = false;
 	else if(a == Object::Type::SHIP) result = true;
 	else if(b == Object::Type::SHIP) result = false;
 	else if(a == Object::Type::HYPERSPACECLOUD) result = true;

--- a/src/LuaBody.cpp
+++ b/src/LuaBody.cpp
@@ -254,6 +254,10 @@ static int l_body_is_more_important_than(lua_State *l)
 	// spacestation > ship > hyperspace cloud > cargo body > missile > projectile
 	else if(a == Object::Type::SPACESTATION) result = true;
 	else if(b == Object::Type::SPACESTATION) result = false;
+    else if(a == Object::Type::CITYONPLANET) result = true;
+    else if(b == Object::Type::CITYONPLANET) result = false;
+    else if(a == Object::Type::TERRAINBODY) result = true;
+    else if(b == Object::Type::TERRAINBODY) result = false;
 	else if(a == Object::Type::SHIP) result = true;
 	else if(b == Object::Type::SHIP) result = false;
 	else if(a == Object::Type::HYPERSPACECLOUD) result = true;


### PR DESCRIPTION
A continuation of #4053: it didn't account ordering guarantees expected by Lua sort, resulting in Lua "invalid order function" when comparing two gas giants.

