### PR TITLE
Hide mouse pointer when GUI is not being drawn

### DIFF
--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -1,3 +1,4 @@
+
 // Copyright © 2008-2017 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
@@ -336,6 +337,13 @@ void PiGui::EndFrame() {
 }
 
 void PiGui::NewFrame(SDL_Window *window) {
+	// Ask ImGui to hide OS cursor if GUI is not being drawn:
+	// it will do this if MouseDrawCursor is true. After the frame
+	// is created, we set the actual cursor draw state.
+	if (!Pi::DrawGUI)
+	{
+		ImGui::GetIO().MouseDrawCursor = true;
+	}
 	switch(Pi::renderer->GetRendererType())
 		{
 		default:
@@ -351,7 +359,7 @@ void PiGui::NewFrame(SDL_Window *window) {
 		}
 	Pi::renderer->CheckRenderErrors(__FUNCTION__, __LINE__);
 	ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
-	if(Pi::DoingMouseGrab())
+	if(Pi::DoingMouseGrab() || !Pi::DrawGUI)
 		{
 			ImGui::GetIO().MouseDrawCursor = false;
 		}

--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -1,4 +1,3 @@
-
 // Copyright © 2008-2017 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 


### PR DESCRIPTION
Mouse pointer with no UI has little practical use, and just gets in the way of screenshots/capture.
