### PR TITLE
Change laser to weapon in some core en.json

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -421,7 +421,7 @@
    },
    "FIRE_LASER" : {
       "description" : "",
-      "message" : "Fire laser"
+      "message" : "Fire weapon"
    },
    "FIRE_MISSILE" : {
       "description" : "",
@@ -693,7 +693,7 @@
    },
    "LASER_FIRE_DETECTED" : {
       "description" : "",
-      "message" : "Laser fire detected."
+      "message" : "Weapons fire detected."
    },
    "LATITUDE" : {
       "description" : "Short for latitude",


### PR DESCRIPTION
It changes "Fire laser" to "Fire weapon" in the key bindings options screen and
changes "Laser fire detected" HUD message to "Weapons fire detected".
Made with the builtin editor of github, but I'm not sure if it created the branch here or on my fork.
