### PR TITLE
Fix Star/planet/gas giants popping into view.

### DIFF
--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -152,8 +152,8 @@ RendererOGL::RendererOGL(SDL_Window *window, const Graphics::Settings &vs, SDL_G
 //the range is very large due to a "logarithmic z-buffer" trick used
 //http://outerra.blogspot.com/2009/08/logarithmic-z-buffer.html
 //http://www.gamedev.net/blog/73/entry-2006307-tip-of-the-day-logarithmic-zbuffer-artifacts-fix/
-, m_minZNear(0.0001f)
-, m_maxZFar(10000000.0f)
+, m_minZNear(0.001f)
+, m_maxZFar(100000000.0f)
 , m_useCompressedTextures(false)
 , m_invLogZfarPlus1(0.f)
 , m_activeRenderTarget(0)
@@ -219,7 +219,7 @@ RendererOGL::RendererOGL(SDL_Window *window, const Graphics::Settings &vs, SDL_G
 	glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
 	glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
 	glEnable(GL_PROGRAM_POINT_SIZE);
-	if (!vs.gl3ForwardCompatible) glEnable(0x8861);				// GL_POINT_SPRITE hack for compatibility contexts
+	if (!vs.gl3ForwardCompatible) glEnable(GL_POINT_SPRITE);				// GL_POINT_SPRITE hack for compatibility contexts
 
 	glHint(GL_TEXTURE_COMPRESSION_HINT, GL_NICEST);
 	glHint(GL_FRAGMENT_SHADER_DERIVATIVE_HINT, GL_NICEST);


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
I have extended the far clip plane to 100,000,000 units, and reduced the near plane to 0.001 units. In truth the near plane could probably go out even further than that but I've tested this and it works so am leaving it alone.

This fixes #4077 as the star is no longer clipped against the far plane, increasing the near plane keeps the range the similar and so avoids precision issues (_I hope_).
<!-- Please make sure you've read documentation on contributing -->

