### PR TITLE
Orbital stations provide (some) orbit info in lobby

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1387,6 +1387,10 @@
       "description" : "",
       "message" : "Station manager"
    },
+   "STATION_ORBIT" : {
+      "description" : "Information shown in the station loby",
+      "message" : "We are in a {orbit_period} day period orbit around {parent_body}."
+   },
    "STATUS" : {
       "description" : "",
       "message" : "Status"

--- a/data/ui/StationView/Lobby.lua
+++ b/data/ui/StationView/Lobby.lua
@@ -216,12 +216,22 @@ local lobby = function (tab)
 		tech_certified = string.interp(l.TECH_CERTIFIED, { tech_level = station.techLevel})
 	end
 
+	local orbit_period = station.path:GetSystemBody().orbitPeriod
+
+	local station_orbit_info = ""
+	if station.type == "STARPORT_ORBITAL" then
+		station_orbit_info =
+			string.interp(l.STATION_ORBIT, { orbit_period = string.format("%.2f", orbit_period),
+											 parent_body = station.path:GetSystemBody().parent.name})
+	end
+
 	return
 		ui:Grid({60,1,39},1)
 			:SetColumn(0, {
 				ui:VBox(10):PackEnd({
 					ui:Label(station.label):SetFont("HEADING_LARGE"),
 					ui:Align("LEFT", tech_certified),
+					ui:Align("LEFT", station_orbit_info),
 					ui:Expand(),
 					ui:VBox(10):PackEnd({
 						ui:HBox(10):PackEnd({

--- a/src/LuaSystemBody.cpp
+++ b/src/LuaSystemBody.cpp
@@ -276,6 +276,28 @@ static int l_sbody_attr_apoapsis(lua_State *l)
 	return 1;
 }
 
+
+/*
+ * Attribute: orbitPeriod
+ *
+ * The orbit of the body, around its parent, in days, as a float
+ *
+ * Availability:
+ *
+ *   201708
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_sbody_attr_orbital_period(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetOrbit().Period() / float(60*60*24));
+	return 1;
+}
+
+
 /*
  * Attribute: rotationPeriod
  *
@@ -435,6 +457,7 @@ template <> void LuaObject<SystemBody>::RegisterClass()
 		{ "gravity",        l_sbody_attr_gravity         },
 		{ "periapsis",      l_sbody_attr_periapsis       },
 		{ "apoapsis",       l_sbody_attr_apoapsis        },
+		{ "orbitPeriod",    l_sbody_attr_orbital_period  },
 		{ "rotationPeriod", l_sbody_attr_rotation_period },
 		{ "semiMajorAxis",  l_sbody_attr_semi_major_axis },
 		{ "eccentricity",   l_sbody_attr_eccentricty     },


### PR DESCRIPTION
This is "nice to have", as it differentiates stations a bit more,
and you become more aware of being in an orbital station.

I wanted to show it here, to see if this is something we want, before I start fixing the time format.
![screenshot-20170816-180235](https://user-images.githubusercontent.com/619390/29373221-d5df5842-82ad-11e7-81b8-f7cc3e570137.png)
