### PR TITLE
Move game start location for Earth back to London

### DIFF
--- a/data/systems/00_sol.lua
+++ b/data/systems/00_sol.lua
@@ -77,7 +77,8 @@ local earth_starports = {
 		:longitude(math.deg2rad(99)),
 	CustomSystemBody:new('London', 'STARPORT_SURFACE')
 		:latitude(math.deg2rad(51))
-		:longitude(0),
+		:longitude(0)
+		:space_station_type("ground_station"),
 	CustomSystemBody:new('Moscow', 'STARPORT_SURFACE')
 		:latitude(math.deg2rad(55))
 		:longitude(math.deg2rad(-37.5)),

--- a/data/ui/MainMenu.lua
+++ b/data/ui/MainMenu.lua
@@ -99,7 +99,7 @@ end
 
 local buttonDefs = {
 	{ l.CONTINUE_GAME,          function () loadGame("_exit") end },
-	{ l.START_AT_EARTH,         function () Game.StartGame(SystemPath.New(0,0,0,0,9),48600)   setupPlayerSol() end },
+	{ l.START_AT_EARTH,         function () Game.StartGame(SystemPath.New(0,0,0,0,6),48600)   setupPlayerSol() end },
 	{ l.START_AT_NEW_HOPE,      function () Game.StartGame(SystemPath.New(1,-1,-1,0,4)) setupPlayerEridani() end },
 	{ l.START_AT_BARNARDS_STAR, function () Game.StartGame(SystemPath.New(-1,0,0,0,16))  setupPlayerBarnard() end },
 	{ l.LOAD_GAME,              doLoadDialog },


### PR DESCRIPTION
__Primary reason:__ make use of the `space_station_type()` from #3990

__Secondary reason:__ In 2014, when Nyankosensei made the new ground station, we
moved starting location from the more original Elite/Frontier/European start
of London, to L.A (#3485); because that's where the random number generator
happened to give us the new octagonal station. Well, now we can specify
explicitly the station type, so no reason to be in L.A. anymore (other than
celebrity spotting?).

Also, development contributions from US have been minimal, so why be there?

__Reason against:__ Unnecessary save bump (I suspect?), 25% of our downloads are
from US, last time I looked.