### PR TITLE
Fix autopilot getting being fed bad data.

### DIFF
--- a/src/Propulsion.cpp
+++ b/src/Propulsion.cpp
@@ -42,7 +42,6 @@ void Propulsion::LoadFromJson(const Json::Value &jsonObj, Space *space)
 
 Propulsion::Propulsion()
 {
-	m_power_mul = 1.0;
 	m_fuelTankMass = 1;
 	for ( int i=0; i< Thruster::THRUSTER_MAX; i++) m_linThrust[i]=0.0;
 	m_angThrust = 0.0;
@@ -64,6 +63,15 @@ void Propulsion::Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass,
 		m_angThrust = ang_Thrust;
 		m_smodel = m;
 		m_dBody = b;
+}
+
+void Propulsion::SetThrustPowerMult(double p, const float lin_Thrust[], const float ang_Thrust)
+{
+	// Init of Propulsion:
+	for (int i = 0; i<Thruster::THRUSTER_MAX; i++)
+		m_linThrust[i] = lin_Thrust[i] * p;
+	m_angThrust = ang_Thrust * p;
+
 }
 
 void Propulsion::SetAngThrusterState(const vector3d &levels)
@@ -91,24 +99,24 @@ void Propulsion::SetThrusterState(const vector3d &levels)
 vector3d Propulsion::GetThrustMax(const vector3d &dir) const
 {
 	vector3d maxThrust;
-	maxThrust.x = ((dir.x > 0) ? m_linThrust[THRUSTER_RIGHT] * m_power_mul : -m_linThrust[THRUSTER_LEFT] * m_power_mul );
-	maxThrust.y = ((dir.y > 0) ? m_linThrust[THRUSTER_UP] * m_power_mul : -m_linThrust[THRUSTER_DOWN] * m_power_mul );
-	maxThrust.z = ((dir.z > 0) ? m_linThrust[THRUSTER_REVERSE] * m_power_mul : -m_linThrust[THRUSTER_FORWARD] * m_power_mul );
+	maxThrust.x = ((dir.x > 0) ? m_linThrust[THRUSTER_RIGHT] : -m_linThrust[THRUSTER_LEFT] );
+	maxThrust.y = ((dir.y > 0) ? m_linThrust[THRUSTER_UP] : -m_linThrust[THRUSTER_DOWN] );
+	maxThrust.z = ((dir.z > 0) ? m_linThrust[THRUSTER_REVERSE] : -m_linThrust[THRUSTER_FORWARD] );
 	return maxThrust;
 }
 
 double Propulsion::GetThrustMin() const
 {
-	double val = m_linThrust[THRUSTER_UP] * m_power_mul ;
-	val = std::min(val, m_linThrust[THRUSTER_RIGHT] * m_power_mul );
-	val = std::min(val, -m_linThrust[THRUSTER_LEFT] * m_power_mul );
+	double val = m_linThrust[THRUSTER_UP];
+	val = std::min(val, static_cast<double>(m_linThrust[THRUSTER_RIGHT]));
+	val = std::min(val, static_cast<double>(-m_linThrust[THRUSTER_LEFT]));
 	return val;
 }
 
 float Propulsion::GetFuelUseRate()
 {
 	const float denominator = m_fuelTankMass * m_effectiveExhaustVelocity * 10;
-	return denominator > 0 ? -(m_linThrust[THRUSTER_FORWARD] * m_power_mul)/denominator : 1e9;
+	return denominator > 0 ? -(m_linThrust[THRUSTER_FORWARD])/denominator : 1e9;
 }
 
 void Propulsion::UpdateFuel(const float timeStep)

--- a/src/Propulsion.h
+++ b/src/Propulsion.h
@@ -31,12 +31,12 @@ class Propulsion
 		void Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass, const double effExVel, const float lin_Thrust[], const float ang_Thrust );
 
 		// Bonus:
-		inline void SetThrustPowerMult( double p ) { m_power_mul = Clamp( p, 1.0, 3.0 ); }
+		void SetThrustPowerMult(double p, const float lin_Thrust[], const float ang_Thrust);
 
 		// Thruster functions
-		inline double GetThrustFwd() const { return -m_linThrust[THRUSTER_FORWARD] * m_power_mul; }
-		inline double GetThrustRev() const { return m_linThrust[THRUSTER_REVERSE] * m_power_mul; }
-		inline double GetThrustUp() const { return m_linThrust[THRUSTER_UP] * m_power_mul; }
+		inline double GetThrustFwd() const { return -m_linThrust[THRUSTER_FORWARD]; }
+		inline double GetThrustRev() const { return m_linThrust[THRUSTER_REVERSE]; }
+		inline double GetThrustUp() const { return m_linThrust[THRUSTER_UP]; }
 		double GetThrustMin() const;
 		vector3d GetThrustMax(const vector3d &dir) const;
 
@@ -44,7 +44,7 @@ class Propulsion
 		inline double GetAccelRev() const { return GetThrustRev() / m_dBody->GetMass(); }
 		inline double GetAccelUp() const { return GetThrustUp() / m_dBody->GetMass(); }
 		inline double GetAccelMin() const { return GetThrustMin() / m_dBody->GetMass(); };
-		inline double GetAccel(Thruster thruster) const { return fabs(m_linThrust[thruster] * m_power_mul / m_dBody->GetMass()); }
+		inline double GetAccel(Thruster thruster) const { return fabs(m_linThrust[thruster] / m_dBody->GetMass()); }
 
 		inline void SetThrusterState(int axis, double level) {
 			if (m_thrusterFuel <= 0.f) level = 0.0;
@@ -58,8 +58,8 @@ class Propulsion
 		inline void ClearLinThrusterState() { m_thrusters = vector3d(0,0,0); }
 		inline void ClearAngThrusterState() { m_angThrusters = vector3d(0,0,0); }
 
-		inline vector3d GetActualLinThrust() const { return m_thrusters * GetThrustMax( m_thrusters ) * m_power_mul; }
-		inline vector3d GetActualAngThrust() const { return m_angThrust * m_angThrusters * m_power_mul; }
+		inline vector3d GetActualLinThrust() const { return m_thrusters * GetThrustMax( m_thrusters ); }
+		inline vector3d GetActualAngThrust() const { return m_angThrust * m_angThrusters; }
 
 		// Fuel
 		enum FuelState { // <enum scope='Propulsion' name=PropulsionFuelStatus prefix=FUEL_ public>
@@ -115,7 +115,6 @@ class Propulsion
 		vector3d m_thrusters;
 		vector3d m_angThrusters;
 
-		double m_power_mul;
 		const DynamicBody *m_dBody;
 		SceneGraph::Model *m_smodel;
 };

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -556,7 +556,7 @@ void Ship::UpdateEquipStats()
 	unsigned int thruster_power_cap = 0;
 	Properties().Get("thruster_power_cap", thruster_power_cap);
 	const double power_mul = m_type->thrusterUpgrades[Clamp(thruster_power_cap, 0U, 3U)];
-	GetPropulsion()->SetThrustPowerMult( power_mul );
+	GetPropulsion()->SetThrustPowerMult(power_mul, m_type->linThrust, m_type->angThrust);
 
 	m_stats.hyperspace_range = m_stats.hyperspace_range_max = 0;
 	p.Set("hyperspaceRange", m_stats.hyperspace_range);


### PR DESCRIPTION
The problem seems to have been caused by incomplete modification of the places that use the thrust values to calculate times, forces and other values.

The fix I've gone with adjusts the linThrust and angThrust instead of trying to modify everywhere that uses them.

This fixes #4100 and I've tested it with bespoke thrusters on the affected planet/system.