### PR TITLE
Use 'Welcome to' as greeting for Ground stations

### DIFF
--- a/data/lang/module-stationrefuelling/en.json
+++ b/data/lang/module-stationrefuelling/en.json
@@ -4,7 +4,11 @@
       "message" : "This is {station}. You do not have enough money for your docking fee of {fee}."
    },
    "WELCOME_ABOARD_STATION_FEE_DEDUCTED" : {
-      "description" : "",
+      "description" : "Station welcome message, docking in orbit",
       "message" : "Welcome aboard {station}. Your docking fee of {fee} has been deducted."
+   },
+   "WELCOME_TO_STATION_FEE_DEDUCTED" : {
+      "description" : "Station welcome message, ground station landing",
+      "message" : "Welcome to {station}. Your landing fee of {fee} has been deducted."
    }
 }

--- a/data/modules/StationRefuelling/StationRefuelling.lua
+++ b/data/modules/StationRefuelling/StationRefuelling.lua
@@ -34,7 +34,11 @@ local onShipDocked = function (ship, station)
 		Comms.Message(l.THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH:interp({station = station.label,fee = Format.Money(fee)}))
 		ship:SetMoney(0)
 	else
-		Comms.Message(l.WELCOME_ABOARD_STATION_FEE_DEDUCTED:interp({station = station.label,fee = Format.Money(fee)}))
+		if station.isGroundStation == true then
+			Comms.Message(l.WELCOME_TO_STATION_FEE_DEDUCTED:interp({station = station.label,fee = Format.Money(fee)}))
+		else
+			Comms.Message(l.WELCOME_ABOARD_STATION_FEE_DEDUCTED:interp({station = station.label,fee = Format.Money(fee)}))
+		end
 		ship:AddMoney(0 - fee)
 	end
 end


### PR DESCRIPTION
'Welcome aboard' doesn't fit ground stations.

![welcomeaboard](https://user-images.githubusercontent.com/6368949/29754148-95b715f4-8b7f-11e7-9771-f6dee0db7c48.png)

Use 'Welcome to' instead.

![welcometo](https://user-images.githubusercontent.com/6368949/29754149-9d997956-8b7f-11e7-8634-a32c0d825446.png)

PS. The sum (here: $6.00) should probably not be split over multiple lines.



