### PR TITLE
Make orbit radius relative to GetPhysRadius, clamp to frame radius

### DIFF
--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -1414,7 +1414,7 @@ static int l_ship_ai_enter_high_orbit(lua_State *l)
 	Body *target = LuaObject<Body>::CheckFromLua(2);
 	if (!target->IsType(Object::PLANET) && !target->IsType(Object::STAR))
 		luaL_argerror(l, 2, "expected a Planet or a Star");
-	s->AIOrbit(target, 3.2);
+	s->AIOrbit(target, 3.5);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes #4088.

Clamps orbit radius to 0.95x non-rotating frame radius, which prevents FlyAround from trying to do something impossible, bugging out and burning fuel.

Switched autopilot to use GetPhysRadius more generally, as GetPhysRadius now replicates the old autopilot behaviour. Effect radius now used as a minimum orbit radius rather than a multiplier. 

Results may be different in some high-gravity navigation edge cases, but I don't think any of them will be _worse_. 0.95 is a little marginal for maintaining an orbit with max time accel and large moonless planets (eg Venus) but the consequences aren't major if a ship does drift out.
