### PR TITLE
_import() rework and fix for #4124

### DIFF
--- a/src/LuaUtils.cpp
+++ b/src/LuaUtils.cpp
@@ -171,126 +171,361 @@ static bool _import_core(lua_State *L, const std::string &importName)
 
 #undef DEBUG_IMPORT
 #ifdef DEBUG_IMPORT
-#define DEBUG_PRINTF Output
+	#define DEBUG_PRINTF Output
+	#define DEBUG_INDENTED_PRINTF IndentedOutput
+	#define DEBUG_INDENT_INCREASE IndentIncrease
+	#define DEBUG_INDENT_DECREASE IndentDecrease
 #else
-#define DEBUG_PRINTF(...)
+	#define DEBUG_PRINTF(...)
+	#define DEBUG_INDENTED_PRINTF(...)
+	#define DEBUG_INDENT_INCREASE(...)
+	#define DEBUG_INDENT_DECREASE(...)
 #endif
 
-static bool _import(lua_State *L, const std::string &importName)
+// simple struct to pass data between functions
+struct ImportInfo
+{
+	const std::string& importName; // original name argument from "import(importName)"
+	std::string& fileName; // name of the existing file
+	const bool& isFullName; // if true import will no try to load relative to the importDirectories
+	std::vector<std::string>& importDirectories; // contans list of paths where file can be imported
+};
+
+/**
+* Returns path of last element in the lua stack
+*/
+static std::string get_caller(lua_State *L)
+{
+	// XXX: Extraneous copy
+	assert(L);
+	LUA_DEBUG_START(L);
+
+	std::string caller;
+	lua_Debug ar;
+
+	// if have stack and caller in the stack
+	if (lua_getstack(L, 1, &ar) && lua_getinfo(L, "S", &ar) && ar.source)
+	{
+		int start = 0;
+		int end = strlen(ar.source);
+
+		if ((ar.source[start] != '@') && (end > 5))
+			start = 4;
+
+		if (ar.source[start] == '@') {
+			start++;
+
+			static char source[1024];
+			strncpy(source, &ar.source[start], end - start + 1);
+
+			caller = std::string(source);
+		}
+	}
+
+	LUA_DEBUG_END(L, 0);
+	return caller;
+}
+
+/**
+* Finds field in table.
+* Requires a existing table in the stack at index -1.
+* Returns true if field exists and not nil, puts value to lua stack.
+*/
+static bool get_cached(lua_State *L, const std::string& name)
+{
+	LUA_DEBUG_START(L);
+	assert(lua_istable(L, -1));
+
+	// try to get it
+	lua_getfield(L, -1, name.c_str());
+
+	// if got cached field
+	bool isCached = !lua_isnil(L, -1);
+
+	if (!isCached)
+		lua_pop(L, 1); // remove found "nil" from stack
+
+	LUA_DEBUG_END(L, (isCached ? 1 : 0));
+	return isCached;
+}
+
+/**
+* Finds field in the cache.
+* Require a existing cache table in the stack at index -1.
+* Returns true if field not nil (exists), puts value to lua stack.
+*/
+static bool import_from_cache(lua_State *L, const ImportInfo& importInfo)
+{
+	LUA_DEBUG_START(L);
+	assert(lua_istable(L, -1));
+	DEBUG_INDENTED_PRINTF("import [%s]: trying to load from cache...", importInfo.importName.c_str());
+
+	bool isImported = false;
+	std::string cacheName;
+
+	size_t dirsToCheck = 1; // check by original name
+	if (!importInfo.isFullName)
+		dirsToCheck += importInfo.importDirectories.size(); // check also relative names
+
+	// check original name, with lua extension and relative by dirs by same rule
+	// if isFullName is true, loop pass once and check only original importName
+	for (size_t i = 0; i < dirsToCheck; i++)
+	{
+		if (i == 0) cacheName = importInfo.importName;
+		else cacheName = FileSystem::NormalisePath( // normalize for relative paths as "../target"
+			FileSystem::JoinPath(importInfo.importDirectories[i - 1], importInfo.importName));
+
+		// check original name
+		isImported = get_cached(L, cacheName);
+
+		// check name with extension
+		if (!isImported && !importInfo.isFullName)
+		{
+			cacheName += ".lua";
+			isImported = get_cached(L, cacheName);
+		}
+
+		if (isImported)
+		{
+			DEBUG_PRINTF(" found cached %s\n", cacheName.c_str());
+			break;
+		}
+	}
+
+	if (!isImported)
+		DEBUG_PRINTF(" not cached\n");
+
+	LUA_DEBUG_END(L, (isImported ? 1 : 0));
+	return isImported;
+}
+
+/**
+* Tries to load file.
+* Returns true if file exists and puts return of dofile to stack.
+*/
+static bool load_file(lua_State *L, const std::string& name)
 {
 	LUA_DEBUG_START(L);
 
-	DEBUG_PRINTF("import: request for %s\n", importName.c_str());
+	RefCountedPtr<FileSystem::FileData> fileData = FileSystem::gameDataFiles.ReadFile(name);
 
-	// get the cache of previously imported things
+	// if file exists
+	if (fileData)
+	{
+		DEBUG_PRINTF(" loading %s...\n", name.c_str());
+		pi_lua_dofile(L, *fileData, 1);
+	}
+
+	LUA_DEBUG_END(L, (fileData ? 1 : 0));
+	return static_cast<bool>(fileData);
+}
+
+/**
+* Tries to load file.
+* If file found returns true, puts return of dofile to stack, no matter nil it or value.
+* If import was successful, changes fileName in the importInfo to the filename that was found.
+*/
+static bool import_from_file(lua_State *L, ImportInfo& importInfo)
+{
+	LUA_DEBUG_START(L);
+	DEBUG_INDENTED_PRINTF("import [%s]: trying to load a file...", importInfo.importName.c_str());
+
+	bool isImported = false;
+	std::string fileName;
+
+	size_t dirsToCheck = 1; // check by original name
+	if (!importInfo.isFullName)
+		dirsToCheck += importInfo.importDirectories.size(); // check also relative names
+
+	// load file with original name, with lua extension and relative by dirs by same rule
+	// if isFullName is true, loop pass once and check only original importName
+	for (size_t i = 0; i < dirsToCheck; i++)
+	{
+		if (i == 0) fileName = importInfo.importName;
+		else fileName = FileSystem::NormalisePath( // normalize for relative paths as "../target"
+			FileSystem::JoinPath(importInfo.importDirectories[i - 1], importInfo.importName));
+
+		// check original name
+		isImported = load_file(L, fileName);
+
+		// check name with extension
+		if (!isImported && !importInfo.isFullName)
+		{
+			fileName += ".lua";
+			isImported = load_file(L, fileName);
+		}
+
+		if (isImported)
+		{
+			DEBUG_INDENTED_PRINTF("import [%s]: file %s loaded\n", importInfo.importName.c_str(), fileName.c_str());
+			importInfo.fileName = fileName;
+			break;
+		}
+	}
+
+	if (!isImported)
+		DEBUG_PRINTF(" file not found\n");
+
+	LUA_DEBUG_END(L, (isImported ? 1 : 0));
+	return isImported;
+}
+
+/**
+* Tries to import from core.
+* Returns true if imported, puts value to the stack.
+*/
+static bool import_from_core(lua_State *L, const ImportInfo& importInfo)
+{
+	LUA_DEBUG_START(L);
+	DEBUG_INDENTED_PRINTF("import [%s]: trying core import...", importInfo.importName.c_str());
+
+	bool isImported = _import_core(L, importInfo.importName);
+
+	// remove import_core error
+	if (!isImported)
+		lua_pop(L, 1);
+
+	DEBUG_PRINTF(" %s\n", (isImported ? "imported" : "not imported"));
+	LUA_DEBUG_END(L, (isImported ? 1 : 0));
+	return isImported;
+}
+
+/**
+* Saves value with index -1 to table with index -2
+*/
+static void save_to_cache(lua_State *L, const ImportInfo& importInfo)
+{
+	LUA_DEBUG_START(L);
+
+	DEBUG_INDENTED_PRINTF("import [%s]: entering into cache...", importInfo.importName.c_str());
+
+	// cache if got not nil
+	if (!lua_isnil(L, -1))
+	{
+		lua_pushvalue(L, -1);
+		lua_setfield(L, -3, importInfo.fileName.c_str());
+		DEBUG_PRINTF(" saved with name %s\n", importInfo.fileName.c_str());
+	}
+	else
+		DEBUG_PRINTF(" aborted because imported module returned nil\n");
+
+	LUA_DEBUG_END(L, 0); // function does not change the stack
+}
+
+
+/**
+* Imports from file or loads from cache lua module.
+* Also tries to import from core.
+* Returns true if module imported, puts return of module to lua stack.
+* Returns false if module not loaded and puts error string to the stack.
+* If isFullName disabled tries to check with .lua extension and also
+* relative by importDirectories. Else checks only by importName.
+*/
+static bool _import(lua_State *L, const std::string& importName, bool isFullName = false)
+{
+	LUA_DEBUG_START(L);
+
+	bool isImported = false;
+	std::string fileName;
+
+	const std::string& caller = get_caller(L);
+	std::string callerDirectory;
+
+	if (!caller.empty())
+		callerDirectory = caller.substr(0, caller.find_last_of('/'));
+
+	std::vector<std::string> importDirectories
+	{
+		"libs"
+	};
+
+	// main data for passing to functions
+	ImportInfo importInfo = {
+		importName,
+		fileName,
+		isFullName,
+		importDirectories
+	};
+
+	if (!callerDirectory.empty()) DEBUG_INDENT_INCREASE();
+	DEBUG_INDENTED_PRINTF("import [%s]: import started, caller: %s\n",
+		importInfo.importName.c_str(), caller.empty() ? "core" : caller.c_str());
+
+	// add caller directory to import directories if exists
+	if (!isFullName && !callerDirectory.empty())
+	{
+		bool directoryExists = false;
+
+		// check if caller not exists in import directory
+		for (auto it = importInfo.importDirectories.begin(); it != importInfo.importDirectories.end(); ++it)
+		{
+			if (*it == callerDirectory)
+			{
+				directoryExists = true;
+				break;
+			}
+		}
+
+		// if not exists already
+		if (!directoryExists)
+			importInfo.importDirectories.push_back(callerDirectory);
+	}
+
+	// load cache table
 	lua_getfield(L, LUA_REGISTRYINDEX, "Imports");
 	assert(lua_istable(L, -1));
 
-	// first check the cache for the explicit name (its there if it was
-	// previously imported from core)
-	std::string cacheName = importName;
-	lua_getfield(L, -1, cacheName.c_str());
-	if (!lua_isnil(L, -1)) {
-		// found it, use it
-		DEBUG_PRINTF("import: found cached %s\n", cacheName.c_str());
-		lua_remove(L, -2);
-		return 1;
+	// import and save to cache
+	{
+		isImported = import_from_cache(L, importInfo);
+
+		if (!isImported)
+			// if imported, this also changes fileName in importInfo
+			isImported = import_from_file(L, importInfo);
+
+		if (!isImported)
+			isImported = import_from_core(L, importInfo);
+
+		// save to cache only when imported from file
+		if (isImported && !importInfo.fileName.empty())
+			save_to_cache(L, importInfo);
 	}
-	lua_pop(L, 1);
-	DEBUG_PRINTF("import: not cached %s\n", cacheName.c_str());
 
-	// next we're going to look in libs/
-	cacheName = FileSystem::JoinPath("libs", importName+".lua");
-	lua_getfield(L, -1, cacheName.c_str());
-	if (!lua_isnil(L, -1)) {
-		// found it, use it
-		DEBUG_PRINTF("import: found cached %s\n", cacheName.c_str());
-		lua_remove(L, -2);
-		return 1;
-	}
-	lua_pop(L, 1);
-	DEBUG_PRINTF("import: not cached %s\n", cacheName.c_str());
+	// cache table and optional value
+	LUA_DEBUG_CHECK(L, (isImported ? 2 : 1));
 
-	RefCountedPtr<FileSystem::FileData> code = FileSystem::gameDataFiles.ReadFile(cacheName);
+	// remove Imports table from stack
+	lua_remove(L, isImported ? -2 : -1);
 
-	// if its not found then we try to find the lib relative to the calling file
-	if (!code) {
-		DEBUG_PRINTF("import: not found %s, trying relative\n", cacheName.c_str());
-
-		lua_Debug ar;
-		lua_getstack(L, 1, &ar);
-		lua_getinfo(L, "S", &ar);
-
-		if (ar.source) {
-			int start = 0;
-			int end = strlen(ar.source);
-
-			if (ar.source[start] != '@' && end > 5)
-				start = 4;
-
-			if (ar.source[start] == '@') {
-				start++;
-
-				static char source[1024];
-				strncpy(source, &ar.source[start], end-start+1);
-				DEBUG_PRINTF("import: called from %s\n", source);
-
-				for (end = end-start-1; end >= 0; end--)
-					if (source[end] == '/') {
-						source[end] = '\0';
-						break;
-					}
-
-				DEBUG_PRINTF("import: relative path %s\n", source);
-
-				cacheName = FileSystem::JoinPath(source, importName+".lua");
-				lua_getfield(L, -1, cacheName.c_str());
-				if (!lua_isnil(L, -1)) {
-					// found it, use it
-					DEBUG_PRINTF("import: found cached %s\n", cacheName.c_str());
-					lua_remove(L, -2);
-					return 1;
-				}
-				lua_pop(L, 1);
-				DEBUG_PRINTF("import: not cached %s\n", cacheName.c_str());
-
-				code = FileSystem::gameDataFiles.ReadFile(cacheName);
-			}
+	// generate error messages
+	DEBUG_INDENTED_PRINTF("import [%s]: generating error messages...", importInfo.importName.c_str());
+	if (isImported)
+	{
+		// usually happens when file not returns nothing or nil
+		if (lua_isnil(L, -1))
+		{
+			lua_pop(L, 1);
+			DEBUG_PRINTF(" got error: %s did not return anything\n", importInfo.fileName.c_str());
+			lua_pushfstring(L, "import [%s]: %s did not return anything", importInfo.importName.c_str(), importInfo.fileName.c_str());
+			isImported = false;
 		}
+		else
+			DEBUG_PRINTF(" no errors\n");
+	}
+	else
+	{
+		// if just not imported
+		DEBUG_PRINTF(" got error: not found\n");
+		lua_pushfstring(L, "import [%s]: not found", importInfo.importName.c_str());
 	}
 
-	if (code) {
-		DEBUG_PRINTF("import: found %s, running\n", cacheName.c_str());
-		pi_lua_dofile(L, *code, 1);
-	}
-
-	else {
-		// file not foudn, try for a core import
-		DEBUG_PRINTF("import: not found %s, trying core\n", cacheName.c_str());
-		if (!_import_core(L, importName)) {
-			lua_pop(L, 1); // remove import_core error
-			lua_pushfstring(L, "import: %s: not found", importName.c_str());
-			return false;
-		}
-		cacheName = importName;
-	}
-
-	if (lua_isnil(L, -1)) {
-		lua_pushfstring(L, "import: %s: did not return anything", cacheName.c_str());
-		return false;
-	}
-
-	DEBUG_PRINTF("import: entering %s into cache\n", cacheName.c_str());
-
-	lua_pushvalue(L, -1);
-	lua_setfield(L, -3, cacheName.c_str());
-
-	lua_remove(L, -2);
-
+	DEBUG_INDENTED_PRINTF("import [%s]: import status: %s\n\n", importInfo.importName.c_str(), isImported ? "success" : "fail");
+	if (!callerDirectory.empty()) DEBUG_INDENT_DECREASE();
 	LUA_DEBUG_END(L, 1);
 
-	return true;
+	return isImported;
 }
+
 
 static int l_d_null_userdata(lua_State *L)
 {
@@ -305,14 +540,44 @@ static int l_base_import(lua_State *L)
 	return 1;
 }
 
-bool pi_lua_import(lua_State *L, const std::string &importName)
+bool pi_lua_import(lua_State *L, const std::string &importName, bool isFullName)
 {
-	if (!_import(L, importName)) {
+	if (!_import(L, importName, isFullName)) {
+		#ifndef DEBUG_IMPORT // already have extended info
 		Output("%s\n", lua_tostring(L, -1));
+		#endif
 		lua_pop(L, 1);
 		return false;
 	}
 	return true;
+}
+
+void pi_lua_import_recursive(lua_State *L, const std::string &basepath)
+{
+	LUA_DEBUG_START(L);
+	DEBUG_INDENTED_PRINTF("import recursive [%s]: started\n", basepath.c_str());
+	DEBUG_INDENT_INCREASE();
+
+	for (FileSystem::FileEnumerator files(FileSystem::gameDataFiles, basepath, FileSystem::FileEnumerator::IncludeDirs); !files.Finished(); files.Next())
+	{
+		const FileSystem::FileInfo &info = files.Current();
+		const std::string &fpath = info.GetPath();
+		if (info.IsDir()) {
+			pi_lua_import_recursive(L, fpath);
+		}
+		else {
+			assert(info.IsFile());
+			if (ends_with_ci(fpath, ".lua")) {
+				if (pi_lua_import(L, fpath, true))
+					lua_pop(L, 1); // pop imported value
+			}
+		}
+		LUA_DEBUG_CHECK(L, 0);
+	}
+
+	DEBUG_INDENT_DECREASE();
+	DEBUG_INDENTED_PRINTF("import recursive [%s]: ended\n\n", basepath.c_str());
+	LUA_DEBUG_END(L, 0);
 }
 
 static int l_base_import_core(lua_State *L)
@@ -407,7 +672,6 @@ void pi_lua_open_standard_base(lua_State *L)
 	lua_setfield(L, LUA_REGISTRYINDEX, "CoreImports");
 	lua_pushcfunction(L, l_base_import_core);
 	lua_setglobal(L, "import_core");
-
 
 	// standard library adjustments (math library)
 	lua_getglobal(L, LUA_MATHLIBNAME);

--- a/src/LuaUtils.h
+++ b/src/LuaUtils.h
@@ -66,7 +66,8 @@ void pi_lua_readonly_table_proxy(lua_State *l, int index);
 // pushes the underlying (read-write) table pointed to by the proxy at <index>
 void pi_lua_readonly_table_original(lua_State *l, int index);
 
-bool pi_lua_import(lua_State *l, const std::string &importName);
+bool pi_lua_import(lua_State *l, const std::string &importName, bool isFullName = false);
+void pi_lua_import_recursive(lua_State *L, const std::string &basepath);
 
 int  pi_lua_panic(lua_State *l) __attribute((noreturn));
 void pi_lua_protected_call(lua_State* state, int nargs, int nresults);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -279,7 +279,7 @@ static void LuaInit()
 	LuaObject<CargoBody>::RegisterClass();
 	LuaObject<ModelBody>::RegisterClass();
 	LuaObject<HyperspaceCloud>::RegisterClass();
-	
+
 	LuaObject<StarSystem>::RegisterClass();
 	LuaObject<SystemPath>::RegisterClass();
 	LuaObject<SystemBody>::RegisterClass();
@@ -317,13 +317,13 @@ static void LuaInit()
 
 	// XXX load everything. for now, just modules
 	lua_State *l = Lua::manager->GetLuaState();
-	pi_lua_dofile(l, "libs/autoload.lua");
-	pi_lua_dofile_recursive(l, "ui");
-	pi_lua_dofile(l, "pigui/pigui.lua");
-	pi_lua_dofile(l, "pigui/game.lua");
-	pi_lua_dofile(l, "pigui/init.lua");
-	pi_lua_dofile_recursive(l, "pigui/modules");
-	pi_lua_dofile_recursive(l, "modules");
+	pi_lua_import(l, "libs/autoload.lua", true);
+	pi_lua_import_recursive(l, "ui");
+	pi_lua_import(l, "pigui/pigui.lua", true);
+	pi_lua_import(l, "pigui/game.lua", true);
+	pi_lua_import(l, "pigui/init.lua", true);
+	pi_lua_import_recursive(l, "pigui/modules");
+	pi_lua_import_recursive(l, "modules");
 
 	Pi::luaNameGen = new LuaNameGen(Lua::manager);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -150,6 +150,23 @@ void OpenGLDebugMsg(const char *format, ...)
 	fputs(buf, stderr);
 }
 
+static unsigned int __indentationLevel = 0;
+void IndentIncrease() { __indentationLevel++; }
+void IndentDecrease() { assert(__indentationLevel > 0); __indentationLevel--; }
+void IndentedOutput(const char *format, ...)
+{
+	std::string indentation (__indentationLevel, '\t');
+	char buf[1024];
+	va_list ap;
+	va_start(ap, format);
+	strcpy(buf, indentation.c_str());
+	int indentationSize = indentation.size();
+	vsnprintf(buf + indentationSize, sizeof(buf)-indentationSize, format, ap);
+	va_end(ap);
+
+	fputs(buf, stderr);
+}
+
 std::string format_duration(double seconds)
 {
 	std::ostringstream ss;

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,6 +36,14 @@ void Warning(const char *format, ...)  __attribute((format(printf,1,2)));
 void Output(const char *format, ...)  __attribute((format(printf,1,2)));
 void OpenGLDebugMsg(const char *format, ...)  __attribute((format(printf,1,2)));
 
+/**
+* Works like Output, but adds indent before message.
+* Call IndentIncrease and IndentDecrease to control indent level.
+*/
+void IndentedOutput(const char *format, ...) __attribute((format(printf,1,2)));
+void IndentIncrease();
+void IndentDecrease();
+
 // Helper for timing functions with multiple stages
 // Used on a branch to help time loading.
 struct MsgTimer {


### PR DESCRIPTION
Now _import tries to load by name, tries to load with ".lua" extension, then tries
to load from import directories and then relative by caller directory (if it
exists) with and without extension.
Imported files saves in the cache with full path key to avoid
duplicates.
New import should to work little slower than old, but it more
intuitive and support more variations.

Fixes multiinstance trouble, In future better to use import instead a dofile.

@ecraven you can to add own directories like "pigui" to load with import("pigui") here:
https://github.com/ColdSpirit0/pioneer/blob/320b16f84017d233e526121467bff2b54a7662d8/src/LuaUtils.cpp#L291

fixes #4124