### PR TITLE
Avoid division by zero doing AABB ray test

### DIFF
--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -257,7 +257,10 @@ void GeomTree::TraceRay(const BVHNode *currnode, const vector3f &a_origin, const
 	PROFILE_SCOPED()
 	BVHNode *stack[32];
 	int stackpos = -1;
-	vector3f invDir(1.0f/a_dir.x, 1.0f/a_dir.y, 1.0f/a_dir.z);
+	const vector3f invDir( // avoid division by zero please
+		is_zero_exact(a_dir.x) ? 0.0f : (1.0f / a_dir.x),
+		is_zero_exact(a_dir.y) ? 0.0f : (1.0f / a_dir.y),
+		is_zero_exact(a_dir.z) ? 0.0f : (1.0f / a_dir.z));
 
 	for (;;) {
 		while (!currnode->IsLeaf()) {


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Why didn't I do a PR of this before? I thought I had!

I've been noticing the odd divide by zero which appears to be entirely possible from this function so checked before using the value.
<!-- Please make sure you've read documentation on contributing -->

