### PR TITLE
Fix cities overlapping

### DIFF
--- a/src/galaxy/StarSystemGenerator.h
+++ b/src/galaxy/StarSystemGenerator.h
@@ -62,7 +62,7 @@ private:
 	void SetEconType(RefCountedPtr<StarSystem::GeneratorAPI> system);
 
 	void PopulateAddStations(SystemBody* sbody, StarSystem::GeneratorAPI* system);
-	void PositionSettlementOnPlanet(SystemBody* sbody);
+	void PositionSettlementOnPlanet(SystemBody* sbody, std::vector<double> &prevOrbits);
 	void PopulateStage1(SystemBody* sbody, StarSystem::GeneratorAPI* system, fixed &outTotalPop);
 };
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Check previous generated orbits to make sure we don't overlap.

It's enough to check only the `R1` condition of the generated "orbit" to prevent overlapping is it controls for the longitude of the station on the planet.

Fixes #4034
<!-- Please make sure you've read documentation on contributing -->

