### PR TITLE
Use fabs for double instead of abs for cross-platform compatibility

### DIFF
--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1373,10 +1373,11 @@ void PopulateStarSystemGenerator::PositionSettlementOnPlanet(SystemBody* sbody, 
 	double r1 = r.Double();		// can't put two rands in the same expression
 
 	// try to ensure that stations are far enough apart
-	for (size_t i=0; i<prevOrbits.size(); i++)
+	
+	for (size_t i = 0, iterations = 0; i<prevOrbits.size() && iterations<128; i++)
 	{
 		const double &orev = prevOrbits[i];
-		const double len = abs(r1 - orev);
+		const double len = fabs(r1 - orev);
 		if(len < 0.05)
 		{
 			r2 = r.Double();


### PR DESCRIPTION
Use fabs for double instead of abs for cross-platform compatibility.
Also limit iterations so that the loop will always break eventually.

fixes #4143 

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

