### PR TITLE
Stop tradeships crashing into landing pads while trying to hyperspace

### DIFF
--- a/data/modules/TradeShips.lua
+++ b/data/modules/TradeShips.lua
@@ -307,6 +307,12 @@ local jumpToSystem = function (ship, target_path)
 end
 
 local getSystemAndJump = function (ship)
+	local body = Space.GetBody(trade_ships[ship].starport.path:GetSystemBody().parent.index)
+	local port = trade_ships[ship].starport
+	-- boost away from the starport before jumping if it is too close
+	if (ship:DistanceTo(port) < 20000) then
+		ship:AIEnterLowOrbit(body)
+	end
 	return jumpToSystem(ship, getSystem(ship))
 end
 


### PR DESCRIPTION
Makes things better, for now (their jumps may still be illegal, idk). Maybe we can add a delay so ships can travel even further away from the starport before jumping.

Gotta admit it is enjoyable watching the AI screw up :D