### PR TITLE
Fix missile death notifications, clear thrusters and AI on target death

### DIFF
--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -113,9 +113,16 @@ void Missile::PostLoadFixup(Space *space)
 
 void Missile::StaticUpdate(const float timeStep)
 {
-
 	// Note: direct call to AI->TimeStepUpdate
-	if (m_curAICmd!=nullptr) m_curAICmd->TimeStepUpdate();
+
+	if (!m_curAICmd) {
+		GetPropulsion()->ClearLinThrusterState();
+		GetPropulsion()->ClearAngThrusterState();
+	}
+	else if (m_curAICmd->TimeStepUpdate()) {
+		delete m_curAICmd;
+		m_curAICmd = nullptr;
+	}
 	//Add smoke trails for missiles on thruster state
 	static double s_timeAccum = 0.0;
 	s_timeAccum += timeStep;
@@ -196,6 +203,7 @@ void Missile::Explode()
 
 void Missile::NotifyRemoved(const Body* const removedBody)
 {
+	if (m_curAICmd) m_curAICmd->OnDeleted(removedBody);
 	if (m_owner == removedBody) {
 		m_owner = 0;
 	}


### PR DESCRIPTION
Fixes #4155 

Belt-and-braces fix for crashes some time after a missile's target dies. The critical part is the one-liner in Missile::NotifyRemoved, which was an omission introduced when Missile was separated from Ship. The additions to StaticUpdate cause the AICmd object to be deleted once the target is dead and clear the thruster state, so the missile doesn't spin around at full power afterwards.