### PR TITLE
Fix engineers constantly repairing engines, and negative jump counter

### DIFF
--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -244,7 +244,7 @@ end
 
 local onEnterSystem = function (ship)
 	if ship:IsPlayer() then
-		print(('DEBUG: Jumps since warranty: %d, chance of failure (if > 0): 1/%d\nWarranty expires: %s'):format(service_history.jumpcount,max_jumps_unserviced-service_history.jumpcount,Format.Date(service_history.lastdate + service_history.service_period)))
+		print(('DEBUG: Jumps since warranty: %d\nWarranty expires: %s'):format(service_history.jumpcount,Format.Date(service_history.lastdate + service_history.service_period)))
 	else
 		return -- Don't care about NPC ships
 	end


### PR DESCRIPTION
Fixes #4158

Problem is the better the engineer the more the engine will break down and be
fixed,  spamming the player with "your drive was fixed" messages.

This bug must have been there for many years, but only noticable when player has a (good) Engineer, leading to more "true" dice rolls. So, the code used to do a dice roll at each jump for each crew member  and check if they should repair the engines, if yes/true, they repair it, even if it hasn't broken down, and even if warranty hasn't expired yet.

In addition, when the jumpcount is set back, it can reach negative values.

I also changed how probability approaches unity for breakdown after warranty expires.

## EDIT 
A little plot to show how probability of engine breakdown increases after service warranty expired (about after 1 year):
![jump](https://user-images.githubusercontent.com/619390/30637038-874454c0-9df7-11e7-988d-77fc7ae700bc.png)
 
Now let's see that on a lin-log-scale, to better resolve the old method:
![jump_log](https://user-images.githubusercontent.com/619390/30637169-da74e31c-9df7-11e7-99c6-02e0ed56b16c.png)

(Then subtract from that the crew that can fix it.)