### PR TITLE
Fix autopilot tooltip when (nav)targeting other ships

### DIFF
--- a/data/pigui/modules/autopilot-window.lua
+++ b/data/pigui/modules/autopilot-window.lua
@@ -93,6 +93,7 @@ local flightstate_info = {
 local aicommand_info = {
 	["CMD_DOCK"] = { icon = icons.autopilot_dock, tooltip = lui.HUD_BUTTON_AUTOPILOT_DOCKING },
 	["CMD_FLYTO"] = { icon = icons.autopilot_fly_to, tooltip = lui.HUD_BUTTON_AUTOPILOT_FLYING_TO_TARGET },
+	["CMD_FORMATION"] = { icon = icons.autopilot_fly_to, tooltip = lui.HUD_BUTTON_AUTOPILOT_FLYING_TO_TARGET },
 	["CMD_FLYAROUND"] = { icon = icons.autopilot_medium_orbit, tooltip = lui.HUD_BUTTON_AUTOPILOT_ENTERING_ORBIT },
 }
 


### PR DESCRIPTION
Autopilot currently doesn't have any icon for formation flying,
if indeed that is a nomenclature we want to use for the tooltip.

Closes #4163

Possibly, I'll update this if we get/want a "formation" icon.