### PR TITLE
Don't fail assassins when entering mission system

### DIFF
--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -358,7 +358,11 @@ local onShipDocked = function (ship, station)
 			Event.Queue("onReputationChanged", oldReputation, Character.persistent.player.killcount,
 				Character.persistent.player.reputation, Character.persistent.player.killcount)
 		else
-			if mission.ship == ship then
+			-- Fail occurs when mission ship either lands or jumps,
+			-- after taking off at said mission time point. Spawned
+			-- docked ship will trigger an onShipDocked event, thus
+			-- check mission.due
+			if mission.ship == ship and mission.due < Game.time then
 				mission.status = 'FAILED'
 			end
 		end


### PR DESCRIPTION
'FAILED' occurs when mission ship either lands or jumps, after taking off at
said mission time point.

But for some reason it looks like a spawned dock ship now will trigger a
`OnShipDocked` event, as the ship is spawned when the player enters the target
system, they will immediately get failed.

Closes #4154.

I'll remove the debug printout commits when I get confirmation this is
working, and ideally, we'll understand why this bug is triggered to begin
with, all of a sudden.
