### PR TITLE
Fix heading jump when switching reference frames with RMB held down

### DIFF
--- a/src/ShipController.cpp
+++ b/src/ShipController.cpp
@@ -188,6 +188,12 @@ void PlayerShipController::CheckControlsLock()
 		|| (Pi::GetView() != Pi::game->GetWorldView()); //to prevent moving the ship in starmap etc.
 }
 
+vector3d PlayerShipController::GetMouseDir() const
+{
+	// translate from system to local frame
+	return m_mouseDir * m_ship->GetFrame()->GetOrient();
+}
+
 // mouse wraparound control function
 static double clipmouse(double cur, double inp)
 {
@@ -217,9 +223,10 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 		// have to use this function. SDL mouse position event is bugged in windows
 		if (Pi::MouseButtonState(SDL_BUTTON_RIGHT))
 		{
-			const matrix3x3d &rot = m_ship->GetOrient();
+			// use ship rotation relative to system, unchanged by frame transitions
+			matrix3x3d rot = m_ship->GetOrientRelTo(m_ship->GetFrame()->GetNonRotFrame());
 			if (!m_mouseActive) {
-				m_mouseDir = -rot.VectorZ();	// in world space
+				m_mouseDir = -rot.VectorZ();
 				m_mouseX = m_mouseY = 0;
 				m_mouseActive = true;
 			}
@@ -324,7 +331,7 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 			m_ship->AIModelCoordsMatchAngVel(wantAngVel, angThrustSoftness);
 		}
 
-		if (m_mouseActive) m_ship->AIFaceDirection(m_mouseDir);
+		if (m_mouseActive) m_ship->AIFaceDirection(GetMouseDir());
 	}
 }
 

--- a/src/ShipController.h
+++ b/src/ShipController.h
@@ -68,7 +68,7 @@ public:
 	bool IsMouseActive() const { return m_mouseActive; }
 	double GetSetSpeed() const override { return m_setSpeed; }
 	FlightControlState GetFlightControlState() const override { return m_flightControlState; }
-	vector3d GetMouseDir() const { return m_mouseDir; }
+	vector3d GetMouseDir() const;		// in local frame
 	void SetMouseForRearView(bool enable) { m_invertMouse = enable; }
 	void SetFlightControlState(FlightControlState s) override;
 	float GetLowThrustPower() const { return m_lowThrustPower; }


### PR DESCRIPTION
ShipController stored the mouse direction relative to the local frame orientation, so it was invalidated by frame switches. Easily demonstrated by flying out of Earth's rotational frame with the RMB held down.

This patch uses a mouse direction relative to root frame (identity) orientation instead, so it's not sensitive to frame switches. The externally accessible mouse direction (used to draw the mouse direction on the HUD) is translated to the local frame on call to maintain the previous functionality.

Because the mouse direction is no longer translated by planet rotation, there's a side effect where if you hover in an atmosphere with RMB held down (and no mouse movement), you'll maintain system-relative rather than planet surface-relative orientation. I can't see a practical situation where anyone would notice the difference.