### PR TITLE
Don't show 'None' for drive specs when asking to service engine

### DIFF
--- a/data/lang/module-breakdownservicing/en.json
+++ b/data/lang/module-breakdownservicing/en.json
@@ -1,7 +1,11 @@
 {
    "FLAVOUR_0_INTRO" : {
       "description" : "",
-      "message" : "Avoid the inconvenience of a broken-down hyperspace engine.  Get yours serviced today, by the officially endorsed {name} Engine Servicing Company.\n\nEngine: {drive}\nService: {price}\nGuarantee: 18 months\n{lasttime}"
+      "message" : "Avoid the inconvenience of a broken-down hyperspace engine.  Get yours serviced today, by the officially endorsed {name} Engine Servicing Company.\n"
+   },
+   "FLAVOUR_0_PRICE" : {
+      "description" : "",
+      "message" : "\nEngine: {drive}\nService: {price}\nGuarantee: 18 months\n{lasttime}"
    },
    "FLAVOUR_0_RESPONSE" : {
       "description" : "",
@@ -17,7 +21,11 @@
    },
    "FLAVOUR_1_INTRO" : {
       "description" : "",
-      "message" : "I'm {proprietor}.  I can service your {drive}, guaranteeing at least a year of trouble-free performance.  The cost for this service will be {price}\n{lasttime}"
+      "message" : "I'm {proprietor}. I can service your hyperdrive, guaranteeing at least a year of trouble-free performance. "
+   },
+   "FLAVOUR_1_PRICE" : {
+      "description" : "",
+      "message" : "The cost for servicing your {drive} will be {price}\n{lasttime}"
    },
    "FLAVOUR_1_RESPONSE" : {
       "description" : "",
@@ -33,7 +41,11 @@
    },
    "FLAVOUR_2_INTRO" : {
       "description" : "",
-      "message" : "Hi there.  We at {proprietor} & Co stake our reputation on our work.\n\n{lasttime}\nWe can tune your ship's {drive}, ensuring 12 months of trouble-free operation, for the sum of {price}.  I'll be supervising the work myself, so you can be sure that a good job will be done."
+      "message" : "Hi there.  We at {proprietor} & Co stake our reputation on our work.\nWe can tune your ship's hyperdrive, ensuring 12 months of trouble-free operation. "
+   },
+   "FLAVOUR_2_PRICE" : {
+      "description" : "",
+      "message" : "\n\n{lasttime}\nFor your {drive}, I'll be supervising the work myself, so you can be sure that a good job will be done, for the sum of {price}."
    },
    "FLAVOUR_2_RESPONSE" : {
       "description" : "",
@@ -45,11 +57,15 @@
    },
    "FLAVOUR_2_YESPLEASE" : {
       "description" : "",
-      "message" : "Please tune my drive at the quoted price"
+      "message" : "Please tune my hyperdrive at the quoted price"
    },
    "FLAVOUR_3_INTRO" : {
       "description" : "",
-      "message" : "Welcome SuperFix Maintenance.\n\n{lasttime}\nTime for your biannual maintenance? Let us SuperFix your hyperdrive!\nWe can tune your {drive} for just {price}.  There's nobody cheaper!"
+      "message" : "Welcome SuperFix Maintenance. Time for your biannual maintenance? Let us SuperFix your hyperdrive! "
+   },
+   "FLAVOUR_3_PRICE" : {
+      "description" : "",
+      "message" : "\n\n{lasttime}\nWe can tune your {drive} for just {price}.  There's nobody cheaper!"
    },
    "FLAVOUR_3_RESPONSE" : {
       "description" : "",
@@ -65,7 +81,11 @@
    },
    "FLAVOUR_4_INTRO" : {
       "description" : "",
-      "message" : "Welcome to Time and Space.\n\nWe specialise in interstellar engines. All maintenance work guaranteed for two years.\n{lasttime}\nServicing your {drive} will cost {price}.  Would you like to proceed?"
+      "message" : "Welcome to Time and Space.\n\nWe specialise in interstellar engines. All maintenance work guaranteed for two years."
+   },
+   "FLAVOUR_4_PRICE" : {
+      "description" : "",
+      "message" : "\n{lasttime}\nServicing your {drive} will cost {price}.  Would you like to proceed?"
    },
    "FLAVOUR_4_RESPONSE" : {
       "description" : "",
@@ -81,7 +101,11 @@
    },
    "FLAVOUR_5_INTRO" : {
       "description" : "",
-      "message" : "Avoid the inconvenience of a broken-down hyperspace engine.  Get yours serviced today.\n\nEngine: {drive}\nService: {price}\n{lasttime}"
+      "message" : "Avoid the inconvenience of a broken-down hyperspace engine.  Get yours serviced today.\n"
+   },
+   "FLAVOUR_5_PRICE" : {
+      "description" : "",
+      "message" : "\nEngine: {drive}\nService: {price}\n{lasttime}"
    },
    "FLAVOUR_5_RESPONSE" : {
       "description" : "",

--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -53,6 +53,7 @@ for i = 1,#flavours do
 	local f = flavours[i]
 	f.title     = l["FLAVOUR_" .. i-1 .. "_TITLE"]
 	f.intro     = l["FLAVOUR_" .. i-1 .. "_INTRO"]
+	f.price     = l["FLAVOUR_" .. i-1 .. "_PRICE"]
 	f.yesplease = l["FLAVOUR_" .. i-1 .. "_YESPLEASE"]
 	f.response  = l["FLAVOUR_" .. i-1 .. "_RESPONSE"]
 end
@@ -106,10 +107,16 @@ local onChat = function (form, ref, option)
 	price = price * 10
 
 	-- Replace those tokens into ad's intro text that can change during play
-	local message = string.interp(ad.intro, {
+	local pricesuggestion = string.interp(ad.price, {
 		drive = hyperdrive and hyperdrive:GetName() or lui.NONE,
 		price = Format.Money(price),
 	})
+
+	if not hyperdrive then
+		pricesuggestion = "\n"..l.YOU_DO_NOT_HAVE_A_DRIVE_TO_SERVICE
+	end
+
+	local message = ad.intro..pricesuggestion
 
 	if option == -1 then
 		-- Hang up
@@ -191,6 +198,7 @@ local onCreateBB = function (station)
 			name = station.label,
 			proprietor = name,
 		}),
+		price = flavours[n].price,
 		yesplease = flavours[n].yesplease,
 		response = flavours[n].response,
 		station = station,


### PR DESCRIPTION
## Problem
When asking for service but without a drive (as in Bernards):
![2017-09-25-171251_942x666_scrot](https://user-images.githubusercontent.com/619390/30815918-d4b41f1c-a214-11e7-8c8d-627a9b795ea0.png)

## Solution

I split the intro message for "Break down and service" module, to separate the string that specifies the `drive` of the player, so that this sentence can be replaced by the "you don't have a drive" message.
![2017-09-25-171144_939x666_scrot](https://user-images.githubusercontent.com/619390/30815935-e1d52132-a214-11e7-8287-29410bc4519d.png)
