### PR TITLE
Don't call SDL_FreeSurface until refcount is zero

### DIFF
--- a/src/SDLWrappers.h
+++ b/src/SDLWrappers.h
@@ -22,7 +22,9 @@ public:
 	SDLSurfacePtr() {}
 	SDLSurfacePtr(const SDLSurfacePtr& b): base_type(b.Get())
 	{ if (this->m_ptr) this->m_ptr->refcount += 1; }
-	~SDLSurfacePtr() { SDL_FreeSurface(this->Release()); }
+//	~SDLSurfacePtr() { SDL_FreeSurface(this->Release()); }
+	// workaround for SDL 2.0.6 FreeSurface bug
+	~SDLSurfacePtr() { SDL_Surface *p = this->Release(); if (p && --p->refcount <= 0) SDL_FreeSurface(p); }
 
 	SDLSurfacePtr &operator=(const SDLSurfacePtr &b) { SDLSurfacePtr(b).Swap(*this); return *this; }
 


### PR DESCRIPTION
Workaround for a crash bug in SDL 2.0.6, where SDL_FreeSurface doesn't work correctly when called with refcount >1. There's a [development patch for SDL](https://hg.libsdl.org/SDL/rev/a09c3f87a12f) but it may not hit release for a year or more.

This patch changes the behaviour of the SDLSurfacePtr wrapper to not call SDL_FreeSurface until the surface reference count reaches zero. As SDLSurfacePtr already adjusts the refcount manually, there should be no additional side effects with other SDL versions.

I don't fully understand the SDLSurfacePtr code, but this shouldn't make it any worse.

Works around the primary issue in #4174. There's other stuff in there so don't close it yet.