### PR TITLE
Removed unnecessary symlink + pioner now executes from any place

### DIFF
--- a/generic-exec
+++ b/generic-exec
@@ -1,8 +1,0 @@
-#!/bin/sh
-# Executable wrapper script
-# Ensures the program is up-to-date, then hands over
-
-PROGRAM_NAME=$0
-
-EXEC_BIN=src/$PROGRAM_NAME
-make && exec $EXEC_BIN $*

--- a/pioneer
+++ b/pioneer
@@ -1,1 +1,13 @@
-generic-exec
+#!/bin/sh
+# Executable wrapper script
+# Ensures the program is up-to-date, then hands over
+
+PROGRAM_NAME=$(basename $0)
+
+EXEC_BIN=src/$PROGRAM_NAME
+START_DIR=$(pwd)
+WORK_DIR=$(dirname $0)
+
+cd $WORK_DIR
+make && exec $EXEC_BIN $*
+cd $START_DIR


### PR DESCRIPTION
Symlink did not work by default from custom repo directory (not in /home/). Im think it fixes that problem.
Also you can to move, in example, `data/pigui/` and run `../../pioneer` from there.