### PR TITLE
Begin removing direct libpng usage

### DIFF
--- a/src/PngWriter.cpp
+++ b/src/PngWriter.cpp
@@ -21,11 +21,31 @@ void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint
 	bmask = 0x00ff0000;
 	amask = (bytes_per_pixel == 3) ? 0 : 0xff000000;
 #endif
+
 	// create a surface
-	SDL_Surface *surface = SDL_CreateRGBSurfaceFrom((void*)bytes, width, height, bytes_per_pixel * 8, width * bytes_per_pixel, rmask, gmask, bmask, amask);
-	const std::string fname = FileSystem::JoinPathBelow(fs.GetRoot(), path);
+	//SDL_Surface *surface = SDL_CreateRGBSurfaceFrom((void*)bytes, width, height, bytes_per_pixel * 8, width * bytes_per_pixel, rmask, gmask, bmask, amask);
+	SDL_Surface *surface = SDL_CreateRGBSurface(0, width, height, bytes_per_pixel * 8, rmask, gmask, bmask, amask);
+
+	// flip the image vertically
+	int srcy = height - 1;
+	for (int y = 0; y < height; y++)
+	{
+		for (int x = 0; x < stride; x++)
+		{
+			const int src_index = (srcy * stride) + x;
+			const int dst_index = (y * stride) + x;
+			for (int channel = 0; channel < bytes_per_pixel; channel++)
+			{
+				((Uint8*)surface->pixels)[dst_index + channel] = bytes[src_index + channel];
+			}
+		}
+		srcy--;
+	}
+	
 	// do the actual saving
+	const std::string fname = FileSystem::JoinPathBelow(fs.GetRoot(), path);
 	IMG_SavePNG(surface, fname.c_str());
+
 	//cleanup after ourselves
 	SDL_FreeSurface(surface);
 	surface = nullptr;

--- a/src/PngWriter.cpp
+++ b/src/PngWriter.cpp
@@ -5,64 +5,28 @@
 #include "FileSystem.h"
 #include "utils.h"
 
-#define PNG_SKIP_SETJMP_CHECK
-#include <png.h>
-
-void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint8 *bytes, int width, int height, int stride, int bytes_per_pixel) {
-	png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, 0, 0, 0);
-	if (!png_ptr) {
-		Output("Couldn't create png_write_struct\n");
-		return;
-	}
-
-	png_infop info_ptr = png_create_info_struct(png_ptr);
-	if (!info_ptr) {
-		png_destroy_write_struct(&png_ptr, 0);
-		Output("Couldn't create png_info_struct\n");
-		return;
-	}
-
-	//http://www.libpng.org/pub/png/libpng-1.2.5-manual.html#section-3.1
-	if (setjmp(png_jmpbuf(png_ptr))) {
-		png_destroy_write_struct(&png_ptr, &info_ptr);
-		Output("Couldn't set png jump buffer\n");
-		return;
-	}
-
-	FILE *out = fs.OpenWriteStream(path);
-	if (!out) {
-		png_destroy_write_struct(&png_ptr, &info_ptr);
-		Output("Couldn't open '%s/%s' for writing\n", fs.GetRoot().c_str(), path.c_str());
-		return;
-	}
-
-	int colour_type;
-	switch (bytes_per_pixel) {
-		case 1: colour_type = PNG_COLOR_TYPE_GRAY; break;
-		case 2: colour_type = PNG_COLOR_TYPE_GRAY_ALPHA; break;
-		case 3: colour_type = PNG_COLOR_TYPE_RGB; break;
-		case 4: colour_type = PNG_COLOR_TYPE_RGB_ALPHA; break;
-		default: assert(0); return;
-	}
-
-	png_init_io(png_ptr, out);
-	png_set_filter(png_ptr, 0, PNG_FILTER_NONE);
-	png_set_IHDR(png_ptr, info_ptr, width, height, 8, colour_type,
-		PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT,
-		PNG_FILTER_TYPE_DEFAULT);
-
-	png_bytepp rows = new png_bytep[height];
-
-	for (int i = 0; i < height; ++i) {
-		const Uint8 *row = bytes + ((height-i-1) * stride);
-		rows[i] = const_cast<Uint8*>(row);
-	}
-	png_set_rows(png_ptr, info_ptr, rows);
-	png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, 0);
-
-	png_destroy_write_struct(&png_ptr, &info_ptr);
-
-	delete[] rows;
-
-	fclose(out);
+void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint8 *bytes, int width, int height, int stride, int bytes_per_pixel)
+{
+	// Set up the pixel format color masks for RGB(A) byte arrays.
+	Uint32 rmask, gmask, bmask, amask;
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	int shift = ((sd.bpp == 3) ? 8 : 0;
+	rmask = 0xff000000 >> shift;
+	gmask = 0x00ff0000 >> shift;
+	bmask = 0x0000ff00 >> shift;
+	amask = 0x000000ff >> shift;
+#else // little endian, like x86
+	rmask = 0x000000ff;
+	gmask = 0x0000ff00;
+	bmask = 0x00ff0000;
+	amask = (bytes_per_pixel == 3) ? 0 : 0xff000000;
+#endif
+	// create a surface
+	SDL_Surface *surface = SDL_CreateRGBSurfaceFrom((void*)bytes, width, height, bytes_per_pixel * 8, width * bytes_per_pixel, rmask, gmask, bmask, amask);
+	const std::string fname = FileSystem::JoinPathBelow(fs.GetRoot(), path);
+	// do the actual saving
+	IMG_SavePNG(surface, fname.c_str());
+	//cleanup after ourselves
+	SDL_FreeSurface(surface);
+	surface = nullptr;
 }

--- a/src/graphics/gl2/GL2Renderer.cpp
+++ b/src/graphics/gl2/GL2Renderer.cpp
@@ -1259,17 +1259,17 @@ bool RendererGL2::Screendump(ScreendumpState &sd)
 	SDL_GetWindowSize(m_window, &w, &h);
 	sd.width = w;
 	sd.height = h;
-	sd.bpp = 3; // XXX get from window
+	sd.bpp = 4; // XXX get from window
 
 	// pad rows to 4 bytes, which is the default row alignment for OpenGL
-	sd.stride = (3 * sd.width + 3) & ~3;
+	sd.stride = ((sd.bpp * sd.width) + 3) & ~3;
 
 	sd.pixels.reset(new Uint8[sd.stride * sd.height]);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	glPixelStorei(GL_PACK_ALIGNMENT, 4); // never trust defaults
 	glReadBuffer(GL_FRONT);
-	glReadPixels(0, 0, sd.width, sd.height, GL_RGB, GL_UNSIGNED_BYTE, sd.pixels.get());
+	glReadPixels(0, 0, sd.width, sd.height, GL_RGBA, GL_UNSIGNED_BYTE, sd.pixels.get());
 	glFinish();
 
 	return true;

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -1225,17 +1225,17 @@ bool RendererOGL::Screendump(ScreendumpState &sd)
 	SDL_GetWindowSize(m_window, &w, &h);
 	sd.width = w;
 	sd.height = h;
-	sd.bpp = 3; // XXX get from window
+	sd.bpp = 4; // XXX get from window
 
 	// pad rows to 4 bytes, which is the default row alignment for OpenGL
-	sd.stride = (3*sd.width + 3) & ~3;
+	sd.stride = ((sd.bpp * sd.width) + 3) & ~3;
 
 	sd.pixels.reset(new Uint8[sd.stride * sd.height]);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	glPixelStorei(GL_PACK_ALIGNMENT, 4); // never trust defaults
 	glReadBuffer(GL_FRONT);
-	glReadPixels(0, 0, sd.width, sd.height, GL_RGB, GL_UNSIGNED_BYTE, sd.pixels.get());
+	glReadPixels(0, 0, sd.width, sd.height, GL_RGBA, GL_UNSIGNED_BYTE, sd.pixels.get());
 	glFinish();
 
 	return true;


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
We have a dependency on `libpng` but we also use `SDL_image`, this seems to work ok on Linux machines where there is a single global version of liubpng. 

However for the Windows (VS2015/et al) version we have different versions of libpng that are linked against and different version of the DLLs get loaded!
At time this causes screenshots to fail, along with several other uses and warnings which can interfere with development.

This is pretty nasty and given that there is a function in SDL_image to save PNG files it also seems unnecessary.

So this PR uses the `IMG_SavePNG` to save an image instead of doing all the work ourselves using libpng.
<!-- Please make sure you've read documentation on contributing -->

