### PR TITLE
Adding base to Moon (JAXA lava cave location)

### DIFF
--- a/data/systems/00_sol.lua
+++ b/data/systems/00_sol.lua
@@ -123,8 +123,12 @@ local moon = {
 	{
 		CustomSystemBody:new('Tranquility Base', 'STARPORT_SURFACE')
 			:latitude(math.deg2rad(0.6875))
-			:longitude(math.deg2rad(23.4334))
-	},
+			:longitude(math.deg2rad(23.4334)),
+		CustomSystemBody:new('Mariasurīru', 'STARPORT_SURFACE')
+			:latitude(math.deg2rad(14.000))
+			:longitude(math.deg2rad(-303.2))
+			:space_station_type("ground_station"),
+	}
 }
 
 local mars = CustomSystemBody:new('Mars', 'PLANET_TERRESTRIAL')


### PR DESCRIPTION
Adding a ground station to the moon, called Mariasurīru (Marius Rille, in japaneese, hopefully google translate got it right).
[It's at the location of that huge lava cave that the JAXA discovered with SELENE/Kaguya program.](http://www.isas.jaxa.jp/en/topics/001159.html). It's a quite nice looking place with a bunch of huge craters, the base is situated at a hillside.
![screenshot-20171019-161308](https://user-images.githubusercontent.com/4182678/31775255-64cac64c-b4e8-11e7-9681-4db6520cb2f1.png)



