### PR TITLE
Include <lua.hpp> instead of "lua/lua.hpp"

### DIFF
--- a/src/LuaPushPull.h
+++ b/src/LuaPushPull.h
@@ -4,7 +4,8 @@
 #ifndef _LUAPUSHPULL_H
 #define _LUAPUSHPULL_H
 
-#include "lua/lua.hpp"
+#include <lua.hpp>
+
 #include "Lua.h"
 #include <string>
 #include <tuple>

--- a/src/LuaRef.h
+++ b/src/LuaRef.h
@@ -4,7 +4,8 @@
 #ifndef _LUAREF_H
 #define _LUAREF_H
 
-#include "lua/lua.hpp"
+#include <lua.hpp>
+
 #include "Serializer.h"
 #include "json/json.h"
 #include <vector>

--- a/src/LuaTable.h
+++ b/src/LuaTable.h
@@ -7,7 +7,8 @@
 #include <cassert>
 #include <iterator>
 
-#include "lua/lua.hpp"
+#include <lua.hpp>
+
 #include "LuaRef.h"
 #include "LuaPushPull.h"
 #include "LuaUtils.h"

--- a/src/LuaUtils.h
+++ b/src/LuaUtils.h
@@ -5,7 +5,7 @@
 #define _LUAUTILS_H
 
 #include <string>
-#include "lua/lua.hpp"
+#include <lua.hpp>
 #include "utils.h"
 
 namespace FileSystem { class FileData; }

--- a/src/graphics/Makefile.am
+++ b/src/graphics/Makefile.am
@@ -7,6 +7,9 @@ AM_CPPFLAGS += $(WARN_CPPFLAGS)
 AM_CXXFLAGS += $(STD_CXXFLAGS) $(WARN_CXXFLAGS)
 
 AM_CPPFLAGS += -I$(srcdir)/.. -isystem $(top_srcdir)/contrib
+if !HAVE_LUA
+AM_CPPFLAGS += -isystem @top_srcdir@/contrib/lua
+endif
 
 noinst_LIBRARIES = libgraphics.a
 noinst_HEADERS = \

--- a/src/graphics/gl2/Makefile.am
+++ b/src/graphics/gl2/Makefile.am
@@ -5,6 +5,9 @@ AM_CPPFLAGS += $(WARN_CPPFLAGS)
 AM_CXXFLAGS += $(STD_CXXFLAGS) $(WARN_CXXFLAGS)
 
 AM_CPPFLAGS += -I$(srcdir)/../.. -isystem $(top_srcdir)/contrib
+if !HAVE_LUA
+AM_CPPFLAGS += -isystem @top_srcdir@/contrib/lua
+endif
 
 noinst_LIBRARIES = libgraphicsgl2.a
 noinst_HEADERS = \

--- a/src/graphics/opengl/Makefile.am
+++ b/src/graphics/opengl/Makefile.am
@@ -5,6 +5,9 @@ AM_CPPFLAGS += $(WARN_CPPFLAGS)
 AM_CXXFLAGS += $(STD_CXXFLAGS) $(WARN_CXXFLAGS)
 
 AM_CPPFLAGS += -I$(srcdir)/../.. -isystem $(top_srcdir)/contrib
+if !HAVE_LUA
+AM_CPPFLAGS += -isystem @top_srcdir@/contrib/lua
+endif
 
 noinst_LIBRARIES = libgraphicsopengl.a
 noinst_HEADERS = \


### PR DESCRIPTION
Since contrib/ is added to the include folders unconditionally,
including "lua/lua.hpp" would always include contrib/lua/lua.hpp even if
the build was configured to use an external liblua.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

