### PR TITLE
Rounded rewards

### DIFF
--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -176,6 +176,7 @@ local makeAdvert = function (station)
 	local due = Game.time + Engine.rand:Number(7*60*60*24, time * 31*60*60*24)
 	local danger = Engine.rand:Integer(1,4)
 	local reward = Engine.rand:Number(2100, 7000) * danger
+	reward = math.ceil(reward)
 
 	-- XXX hull mass is a bad way to determine suitability for role
 	--local shipdefs = utils.build_array(utils.filter(function (k,def) return def.tag == 'SHIP' and def.hullMass >= (danger * 17) and def.equipSlotCapacity.ATMOSHIELD > 0 end, pairs(ShipDef)))

--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -88,7 +88,7 @@ local onChat = function (form, ref, option)
 
 		local introtext = string.interp(flavours[ad.flavour].introtext, {
 			name	= ad.client.name,
-			cash	= Format.Money(ad.reward),
+			cash	= Format.Money(ad.reward,false),
 			target	= ad.target,
 			system	= sys.name,
 		})
@@ -333,7 +333,7 @@ local onShipDocked = function (ship, station)
 			   mission.backstation == station.path then
 				local text = string.interp(flavours[mission.flavour].successmsg, {
 					target	= mission.target,
-					cash	= Format.Money(mission.reward),
+					cash	= Format.Money(mission.reward,false),
 				})
 				Comms.ImportantMessage(text, mission.client.name)
 				ship:AddMoney(mission.reward)
@@ -485,7 +485,7 @@ local onClick = function (mission)
 														name   = mission.client.name,
 														target = mission.target,
 														system = mission.location:GetStarSystem().name,
-														cash   = Format.Money(mission.reward),
+														cash   = Format.Money(mission.reward,false),
 														dist  = dist})
 										),
 										ui:Margin(10),

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -507,6 +507,7 @@ local makeAdvert = function (station)
 			due = due + Game.time
 		end
 	end
+	reward = math.ceil(reward)
 
 	local n = getNumberOfFlavours("INTROTEXT_" .. missiontype)
 	local introtext

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -303,7 +303,7 @@ local onChat = function (form, ref, option)
 	if option == 0 then
 		local introtext  = string.interp(ad.introtext, {
 			name         = ad.client.name,
-			cash         = Format.Money(ad.reward),
+			cash         = Format.Money(ad.reward,false),
 			cargoname    = ad.cargotype:GetName(),
 			starport     = ad.location:GetSystemBody().name,
 			system       = ad.location:GetStarSystem().name,
@@ -545,7 +545,7 @@ local makeAdvert = function (station)
 	end
 	ad.desc = string.interp(adtext, {
 		system   = nearbysystem.name,
-		cash     = Format.Money(ad.reward),
+		cash     = Format.Money(ad.reward,false),
 		starport = ad.location:GetSystemBody().name,
 	})
 
@@ -891,7 +891,7 @@ local onClick = function (mission)
 											sectorx = mission.location.sectorX,
 											sectory = mission.location.sectorY,
 											sectorz = mission.location.sectorZ,
-											cash = Format.Money(mission.reward),
+											cash = Format.Money(mission.reward,false),
 											dist = dist})
 										),
 										ui:Margin(10),
@@ -991,7 +991,7 @@ local onClick = function (mission)
 											dom_sectorx = mission.domicile.sectorX,
 											dom_sectory = mission.domicile.sectorY,
 											dom_sectorz = mission.domicile.sectorZ,
-											cash = Format.Money(mission.reward),
+											cash = Format.Money(mission.reward,false),
 											dist = dist})
 										),
 										ui:Margin(10),

--- a/data/modules/DeliverPackage/DeliverPackage.lua
+++ b/data/modules/DeliverPackage/DeliverPackage.lua
@@ -146,7 +146,7 @@ local onChat = function (form, ref, option)
 
 		local introtext = string.interp(flavours[ad.flavour].introtext, {
 			name     = ad.client.name,
-			cash     = Format.Money(ad.reward),
+			cash     = Format.Money(ad.reward,false),
 			starport = sbody.name,
 			system   = sys.name,
 			sectorx  = ad.location.sectorX,
@@ -280,7 +280,7 @@ local makeAdvert = function (station, manualFlavour, nearbystations)
 
 	ad.desc = string.interp(flavours[flavour].adtext, {
 		system	= nearbysystem.name,
-		cash	= Format.Money(ad.reward),
+		cash	= Format.Money(ad.reward,false),
 		starport = sbody.name,
 	})
 
@@ -501,7 +501,7 @@ local onClick = function (mission)
 														sectorx = mission.location.sectorX,
 														sectory = mission.location.sectorY,
 														sectorz = mission.location.sectorZ,
-														cash   = Format.Money(mission.reward),
+														cash   = Format.Money(mission.reward,false),
 														dist  = dist})
 										),
 										ui:Margin(10),

--- a/data/modules/DeliverPackage/DeliverPackage.lua
+++ b/data/modules/DeliverPackage/DeliverPackage.lua
@@ -260,6 +260,7 @@ local makeAdvert = function (station, manualFlavour, nearbystations)
 		reward = ((dist / max_delivery_dist) * typical_reward * (1+risk) * (1.5+urgency) * Engine.rand:Number(0.8,1.2))
 		due = Game.time + ((dist / max_delivery_dist) * typical_travel_time * (1.5-urgency) * Engine.rand:Number(0.9,1.1))
 	end
+	reward = math.ceil(reward)
 
 	local ad = {
 		station		= station,

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -562,6 +562,7 @@ local calcReward = function (flavour, pickup_crew, pickup_pass, pickup_comm, del
 		reward = reward + extra
 	end
 
+	reward = math.ceil(reward)
 	return reward
 end
 

--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -159,7 +159,7 @@ local onChat = function (form, ref, option)
 
 		local introtext = string.interp(flavours[ad.flavour].introtext, {
 			name     = ad.client.name,
-			cash     = Format.Money(ad.reward),
+			cash     = Format.Money(ad.reward,false),
 			system   = sys.name,
 			sectorx  = ad.location.sectorX,
 			sectory  = ad.location.sectorY,
@@ -279,7 +279,7 @@ local makeAdvert = function (station)
 
 	ad.desc = string.interp(flavours[flavour].adtext, {
 		system	= location.name,
-		cash	= Format.Money(ad.reward),
+		cash	= Format.Money(ad.reward,false),
 	})
 
 	local ref = station:AddAdvert({
@@ -479,7 +479,7 @@ local onClick = function (mission)
 														sectorx = mission.location.sectorX,
 														sectory = mission.location.sectorY,
 														sectorz = mission.location.sectorZ,
-														cash   = Format.Money(mission.reward),
+														cash   = Format.Money(mission.reward,false),
 														dist  = dist})
 										),
 										ui:Margin(10),

--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -260,6 +260,7 @@ local makeAdvert = function (station)
 	location = nearbysystems[Engine.rand:Integer(1,#nearbysystems)]
 	local dist = location:DistanceTo(Game.system)
 	reward = ((dist / max_taxi_dist) * typical_reward * (group / 2) * (1+risk) * (1+3*urgency) * Engine.rand:Number(0.8,1.2))
+	reward = math.ceil(reward)
 	due = Game.time + ((dist / max_taxi_dist) * typical_travel_time * (1.5-urgency) * Engine.rand:Number(0.9,1.1))
 
 	local ad = {


### PR DESCRIPTION
This (very simple) pull request changes the assassination, cargo run, deliver package, and taxi missions to use rounded (whole dollar) reward amounts. It also changes the amount readouts to truncate the `.00` cent part. In my opinion this feels more "human" and cleans up the look of the BBS somewhat.

![image](https://user-images.githubusercontent.com/6425795/33232894-34df380a-d1cb-11e7-8b05-1106c4438fa2.png)
![image](https://user-images.githubusercontent.com/6425795/33232895-3f16afa6-d1cb-11e7-8638-245ca223185b.png)

The rounding is *upward* in case anyone cares. Extremely slight modification in the player's favor but it's negligible in my opinion.