### PR TITLE
Refactor buffers to have a capacity and size

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -333,7 +333,7 @@ void ModelViewer::HitImpl()
 			// Please don't do this in game, no speed guarantee
 			const Uint32 posOffs = mesh.vertexBuffer->GetDesc().GetOffset(Graphics::ATTRIB_POSITION);
 			const Uint32 stride  = mesh.vertexBuffer->GetDesc().stride;
-			const Uint32 vtxIdx = m_rng.Int32() % mesh.vertexBuffer->GetVertexCount();
+			const Uint32 vtxIdx = m_rng.Int32() % mesh.vertexBuffer->GetSize();
 
 			const Uint8 *vtxPtr = mesh.vertexBuffer->Map<Uint8>(Graphics::BUFFER_MAP_READ);
 			const vector3f pos = *reinterpret_cast<const vector3f*>(vtxPtr + vtxIdx * stride + posOffs);

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -200,7 +200,7 @@ void NavLights::Render(Graphics::Renderer *renderer)
 
 	const bool bVBValid = m_billboardVB.Valid();
 	const bool bHasVerts = !m_billboardTris.IsEmpty();
-	const bool bVertCountEqual = bVBValid && (m_billboardVB->GetVertexCount() == m_billboardTris.GetNumVerts());
+	const bool bVertCountEqual = bVBValid && (m_billboardVB->GetSize() == m_billboardTris.GetNumVerts());
 	if( bHasVerts && (!bVBValid || !bVertCountEqual) )
 	{
 		//create buffer

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -198,10 +198,10 @@ void NavLights::Render(Graphics::Renderer *renderer)
 		m_billboardRS = renderer->CreateRenderState(rsd);
 	}
 
-	const bool bVBValid = m_billboardVB.Valid();
-	const bool bHasVerts = !m_billboardTris.IsEmpty();
-	const bool bVertCountEnough = bVBValid && (m_billboardTris.GetNumVerts() <= m_billboardVB->GetCapacity());
-	if( bHasVerts && (!bVBValid || !bVertCountEnough) )
+	const bool isVBValid = m_billboardVB.Valid();
+	const bool hasVerts = !m_billboardTris.IsEmpty();
+	const bool isVertCountEnough = isVBValid && (m_billboardTris.GetNumVerts() <= m_billboardVB->GetCapacity());
+	if( hasVerts && (!isVBValid || !isVertCountEnough) )
 	{
 		//create buffer
 		// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
@@ -217,7 +217,7 @@ void NavLights::Render(Graphics::Renderer *renderer)
 
 	if(m_billboardVB.Valid())
 	{
-		if(bHasVerts) {
+		if(hasVerts) {
 			m_billboardVB->Populate(m_billboardTris);
 			renderer->SetTransform(matrix4x4f::Identity());
 			renderer->DrawBuffer(m_billboardVB.Get(), m_billboardRS, matHalos4x4.Get(), Graphics::POINTS);

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -200,8 +200,8 @@ void NavLights::Render(Graphics::Renderer *renderer)
 
 	const bool bVBValid = m_billboardVB.Valid();
 	const bool bHasVerts = !m_billboardTris.IsEmpty();
-	const bool bVertCountEqual = bVBValid && (m_billboardVB->GetSize() == m_billboardTris.GetNumVerts());
-	if( bHasVerts && (!bVBValid || !bVertCountEqual) )
+	const bool bVertCountEnough = bVBValid && (m_billboardTris.GetNumVerts() <= m_billboardVB->GetCapacity());
+	if( bHasVerts && (!bVBValid || !bVertCountEnough) )
 	{
 		//create buffer
 		// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1516,17 +1516,6 @@ void Pi::MainLoop()
 			Pi::ui->Draw();
 		}
 
-#if WITH_DEVKEYS
-		if (Pi::showDebugInfo) {
-			Gui::Screen::EnterOrtho();
-			Gui::Screen::PushFont("ConsoleFont");
-			static RefCountedPtr<Graphics::VertexBuffer> s_debugInfovb;
-			Gui::Screen::RenderStringBuffer(s_debugInfovb, fps_readout, 0, 0);
-			Gui::Screen::PopFont();
-			Gui::Screen::LeaveOrtho();
-		}
-#endif
-
 		Pi::EndRenderTarget();
 		Pi::DrawRenderTarget();
 		bool endCameraFrame = false;
@@ -1541,6 +1530,19 @@ void Pi::MainLoop()
 				Pi::game->GetWorldView()->EndCameraFrame();
 			}
 		}
+
+#if WITH_DEVKEYS
+		// NB: this needs to be rendered last so that it appears over all other game elements
+		//	preferrably like this where it is just before the buffer swap
+		if (Pi::showDebugInfo) {
+			Gui::Screen::EnterOrtho();
+			Gui::Screen::PushFont("ConsoleFont");
+			static RefCountedPtr<Graphics::VertexBuffer> s_debugInfovb;
+			Gui::Screen::RenderStringBuffer(s_debugInfovb, fps_readout, 0, 0);
+			Gui::Screen::PopFont();
+			Gui::Screen::LeaveOrtho();
+		}
+#endif
 
 		Pi::renderer->SwapBuffers();
 

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -231,7 +231,7 @@ void Lines::SetData(const Uint32 vertCount, const vector3f *vertices, const Colo
 	m_refreshVertexBuffer = true;
 
 	// if the number of vert mismatches then clear the current vertex buffer
-	if( m_vertexBuffer.Valid() && m_vertexBuffer->GetSize() != vertCount ) {
+	if( m_vertexBuffer.Valid() && m_vertexBuffer->GetCapacity() < vertCount ) {
 		// a new one will be created when it is drawn
 		m_vertexBuffer.Reset();
 	}

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -231,7 +231,7 @@ void Lines::SetData(const Uint32 vertCount, const vector3f *vertices, const Colo
 	m_refreshVertexBuffer = true;
 
 	// if the number of vert mismatches then clear the current vertex buffer
-	if( m_vertexBuffer.Valid() && m_vertexBuffer->GetVertexCount() != vertCount ) {
+	if( m_vertexBuffer.Valid() && m_vertexBuffer->GetSize() != vertCount ) {
 		// a new one will be created when it is drawn
 		m_vertexBuffer.Reset();
 	}
@@ -252,7 +252,7 @@ void Lines::SetData(const Uint32 vertCount, const vector3f *vertices, const Colo
 	m_refreshVertexBuffer = true;
 
 	// if the number of vert mismatches then clear the current vertex buffer
-	if( m_vertexBuffer.Valid() && m_vertexBuffer->GetVertexCount() != vertCount ) {
+	if( m_vertexBuffer.Valid() && m_vertexBuffer->GetCapacity() < vertCount ) {
 		// a new one will be created when it is drawn
 		m_vertexBuffer.Reset();
 	}
@@ -271,7 +271,7 @@ void Lines::Draw(Renderer *r, RenderState *rs, const PrimitiveType pt)
 		return;
 
 	if( !m_vertexBuffer.Valid() ) {
-		CreateVertexBuffer(r, m_va->GetNumVerts());
+		CreateVertexBuffer(r, m_va->GetNumVerts() * 2); // ask for twice as many as we need to reduce buffer thrashing
 	}
 	if( m_refreshVertexBuffer ) {
 		m_refreshVertexBuffer = false;
@@ -456,7 +456,7 @@ void Points::Draw(Renderer *r, RenderState *rs)
 	if (m_va->GetNumVerts() == 0)
 		return;
 
-	if (!m_vertexBuffer.Valid() || (m_va->GetNumVerts() != m_vertexBuffer->GetVertexCount())) {
+	if (!m_vertexBuffer.Valid() || (m_va->GetNumVerts() != m_vertexBuffer->GetSize())) {
 		CreateVertexBuffer(r, m_va->GetNumVerts());
 	}
 	if( m_refreshVertexBuffer ) {

--- a/src/graphics/VertexBuffer.cpp
+++ b/src/graphics/VertexBuffer.cpp
@@ -67,15 +67,10 @@ VertexBuffer::~VertexBuffer()
 {
 }
 
-Uint32 VertexBuffer::GetVertexCount() const
-{
-	return m_numVertices;
-}
-
 bool VertexBuffer::SetVertexCount(Uint32 v)
 {
 	if (v <= m_desc.numVertices) {
-		m_numVertices = v;
+		m_size = v;
 		return true;
 	}
 	return false;
@@ -83,7 +78,7 @@ bool VertexBuffer::SetVertexCount(Uint32 v)
 
 // ------------------------------------------------------------
 IndexBuffer::IndexBuffer(Uint32 size, BufferUsage usage)
-	: m_size(size)
+	: Mappable(size)
 	, m_indexCount(size)
 	, m_usage(usage)
 {
@@ -101,7 +96,7 @@ void IndexBuffer::SetIndexCount(Uint32 ic)
 
 // ------------------------------------------------------------
 InstanceBuffer::InstanceBuffer(Uint32 size, BufferUsage usage)
-	: m_size(size)
+	: Mappable(size)
 	, m_usage(usage)
 {
 }

--- a/src/graphics/VertexBuffer.h
+++ b/src/graphics/VertexBuffer.h
@@ -65,16 +65,13 @@ public:
 	inline Uint32 GetCapacity() const { return m_capacity; }
 
 protected:
-	Mappable(const Uint32 size) : m_mapMode(BUFFER_MAP_NONE), m_size(size), m_capacity(size) { }
+	explicit Mappable(const Uint32 size) : m_mapMode(BUFFER_MAP_NONE), m_size(size), m_capacity(size) { }
 	BufferMapMode m_mapMode; //tracking map state
 
 	// size is the current number of elements in the buffer
 	Uint32 m_size;
 	// capacity is the maximum number of elements that can be put in the buffer
 	Uint32 m_capacity;
-
-private:
-	Mappable() {}
 };
 
 class VertexBuffer : public Mappable {

--- a/src/graphics/VertexBuffer.h
+++ b/src/graphics/VertexBuffer.h
@@ -56,19 +56,30 @@ struct VertexBufferDesc {
 	BufferUsage usage;
 };
 
-class Mappable {
+class Mappable : public RefCounted {
 public:
 	virtual ~Mappable() { }
 	virtual void Unmap() = 0;
 
+	inline Uint32 GetSize() const { return m_size; }
+	inline Uint32 GetCapacity() const { return m_capacity; }
+
 protected:
-	Mappable() : m_mapMode(BUFFER_MAP_NONE) { }
+	Mappable(const Uint32 size) : m_mapMode(BUFFER_MAP_NONE), m_size(size), m_capacity(size) { }
 	BufferMapMode m_mapMode; //tracking map state
+
+	// size is the current number of elements in the buffer
+	Uint32 m_size;
+	// capacity is the maximum number of elements that can be put in the buffer
+	Uint32 m_capacity;
+
+private:
+	Mappable() {}
 };
 
-class VertexBuffer : public RefCounted, public Mappable {
+class VertexBuffer : public Mappable {
 public:
-	VertexBuffer(const VertexBufferDesc &desc) : m_desc(desc), m_numVertices(0) {}
+	VertexBuffer(const VertexBufferDesc &desc) : Mappable(desc.numVertices), m_desc(desc) {}
 	virtual ~VertexBuffer();
 	const VertexBufferDesc &GetDesc() const { return m_desc; }
 
@@ -79,7 +90,6 @@ public:
 	//Vertex count used for rendering.
 	//By default the maximum set in description, but
 	//you may set a smaller count for partial rendering
-	Uint32 GetVertexCount() const;
 	bool SetVertexCount(Uint32);
 
 	// copies the contents of the VertexArray into the buffer
@@ -94,11 +104,10 @@ public:
 protected:
 	virtual Uint8 *MapInternal(BufferMapMode) = 0;
 	VertexBufferDesc m_desc;
-	Uint32 m_numVertices;
 };
 
 // Index buffer
-class IndexBuffer : public RefCounted, public Mappable {
+class IndexBuffer : public Mappable {
 public:
 	IndexBuffer(Uint32 size, BufferUsage);
 	virtual ~IndexBuffer();
@@ -107,7 +116,6 @@ public:
 	// change the buffer data without mapping
 	virtual void BufferData(const size_t, void*) = 0;
 
-	Uint32 GetSize() const { return m_size; }
 	Uint32 GetIndexCount() const { return m_indexCount; }
 	void SetIndexCount(Uint32);
 	BufferUsage GetUsage() const { return m_usage; }
@@ -116,19 +124,17 @@ public:
 	virtual void Release() = 0;
 
 protected:
-	Uint32 m_size;
 	Uint32 m_indexCount;
 	BufferUsage m_usage;
 };
 
 // Instance buffer
-class InstanceBuffer : public RefCounted, public Mappable {
+class InstanceBuffer : public Mappable {
 public:
 	InstanceBuffer(Uint32 size, BufferUsage);
 	virtual ~InstanceBuffer();
 	virtual matrix4x4f* Map(BufferMapMode) = 0;
 
-	Uint32 GetSize() const { return m_size; }
 	Uint32 GetInstanceCount() const { return m_instanceCount; }
 	void SetInstanceCount(const Uint32);
 	BufferUsage GetUsage() const { return m_usage; }
@@ -137,7 +143,6 @@ public:
 	virtual void Release() = 0;
 
 protected:
-	Uint32 m_size;
 	Uint32 m_instanceCount;
 	BufferUsage m_usage;
 };

--- a/src/graphics/gl2/GL2Renderer.cpp
+++ b/src/graphics/gl2/GL2Renderer.cpp
@@ -790,7 +790,7 @@ bool RendererGL2::DrawBuffer(VertexBuffer* vb, RenderState* state, Material* mat
 	gvb->Bind();
 	EnableVertexAttributes(gvb);
 
-	glDrawArrays(pt, 0, gvb->GetVertexCount());
+	glDrawArrays(pt, 0, gvb->GetSize());
 
 	DisableVertexAttributes(gvb);
 	gvb->Release();
@@ -838,7 +838,7 @@ bool RendererGL2::DrawBufferInstanced(VertexBuffer* vb, RenderState* state, Mate
 
 	vb->Bind();
 	instb->Bind();
-	glDrawArraysInstancedARB(pt, 0, vb->GetVertexCount(), instb->GetInstanceCount());
+	glDrawArraysInstancedARB(pt, 0, vb->GetSize(), instb->GetInstanceCount());
 	instb->Release();
 	vb->Release();
 

--- a/src/graphics/gl2/GL2VertexBuffer.cpp
+++ b/src/graphics/gl2/GL2VertexBuffer.cpp
@@ -62,7 +62,7 @@ VertexBuffer::VertexBuffer(const VertexBufferDesc &desc) :
 	assert(m_desc.stride > 0);
 	assert(m_desc.numVertices > 0);
 
-	SetVertexCount(m_desc.numVertices);
+	//SetVertexCount(m_desc.numVertices);
 
 	glGenVertexArrays(1, &m_vao);
 	glBindVertexArray(m_vao);
@@ -298,7 +298,7 @@ static inline void CopyPosNormCol(Graphics::VertexBuffer *vb, const Graphics::Ve
 bool VertexBuffer::Populate(const VertexArray &va)
 {
 	assert(va.GetNumVerts()>0);
-	assert(va.GetNumVerts()==m_numVertices);
+	assert(va.GetNumVerts()<=m_capacity);
 	bool result = false;
 	const Graphics::AttributeSet as = va.GetAttributeSet();
 	switch( as ) {
@@ -310,6 +310,7 @@ bool VertexBuffer::Populate(const VertexArray &va)
 	case Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL | Graphics::ATTRIB_UV0:	CopyPosNormUV0(this, va);	result = true;	break;
 	case Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL | Graphics::ATTRIB_DIFFUSE:CopyPosNormCol(this, va);	result = true;	break;
 	}
+	SetVertexCount(va.GetNumVerts());
 	return result;
 }
 

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -848,7 +848,7 @@ bool RendererOGL::DrawBuffer(VertexBuffer* vb, RenderState* state, Material* mat
 	SetMaterialShaderTransforms(mat);
 
 	vb->Bind();
-	glDrawArrays(pt, 0, vb->GetVertexCount());
+	glDrawArrays(pt, 0, vb->GetSize());
 	vb->Release();
 	CheckRenderErrors(__FUNCTION__,__LINE__);
 
@@ -887,7 +887,7 @@ bool RendererOGL::DrawBufferInstanced(VertexBuffer* vb, RenderState* state, Mate
 
 	vb->Bind();
 	instb->Bind();
-	glDrawArraysInstanced(pt, 0, vb->GetVertexCount(), instb->GetInstanceCount());
+	glDrawArraysInstanced(pt, 0, vb->GetSize(), instb->GetInstanceCount());
 	instb->Release();
 	vb->Release();
 	CheckRenderErrors(__FUNCTION__,__LINE__);

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -61,7 +61,7 @@ VertexBuffer::VertexBuffer(const VertexBufferDesc &desc) :
 	assert(m_desc.stride > 0);
 	assert(m_desc.numVertices > 0);
 
-	SetVertexCount(m_desc.numVertices);
+	//SetVertexCount(m_desc.numVertices);
 
 	glGenVertexArrays(1, &m_vao);
 	glBindVertexArray(m_vao);
@@ -299,7 +299,7 @@ bool VertexBuffer::Populate(const VertexArray &va)
 {
 	PROFILE_SCOPED()
 	assert(va.GetNumVerts()>0);
-	assert(va.GetNumVerts()==m_numVertices);
+	assert(va.GetNumVerts()<=m_capacity);
 	bool result = false;
 	const Graphics::AttributeSet as = va.GetAttributeSet();
 	switch( as ) {
@@ -311,6 +311,7 @@ bool VertexBuffer::Populate(const VertexArray &va)
 	case Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL | Graphics::ATTRIB_UV0:	CopyPosNormUV0(this, va);	result = true;	break;
 	case Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL | Graphics::ATTRIB_DIFFUSE:CopyPosNormCol(this, va);	result = true;	break;
 	}
+	SetVertexCount(va.GetNumVerts());
 	return result;
 }
 

--- a/src/gui/GuiLabel.cpp
+++ b/src/gui/GuiLabel.cpp
@@ -29,6 +29,7 @@ void Label::Init(const std::string &text, TextLayout::ColourMarkupMode colourMar
 	m_dlist = 0;
 	m_font = Gui::Screen::GetFont();
 	m_color = ::Color::WHITE;
+	UpdateLayout();
 	SetText(text);
 }
 
@@ -50,7 +51,6 @@ Label *Label::Color(Uint8 r, Uint8 g, Uint8 b)
 	::Color c(r, g, b);
 	if (m_color != c) {
 		m_color = c;
-		m_needsUpdate = true;
 	}
 	return this;
 }
@@ -59,7 +59,6 @@ Label *Label::Color(const ::Color &c)
 {
 	if (m_color != c) {
 		m_color = c;
-		m_needsUpdate = true;
 	}
 	return this;
 }
@@ -73,8 +72,7 @@ void Label::SetText(const std::string &text)
 {
 	if (m_text != text || m_needsUpdate) {
 		m_text = text;
-		m_needsUpdate = true;
-		UpdateLayout();
+		m_layout->SetText(m_text.c_str());
 		RecalcSize();
 	}
 }

--- a/src/gui/GuiScreen.cpp
+++ b/src/gui/GuiScreen.cpp
@@ -319,7 +319,7 @@ void Screen::RenderStringBuffer(RefCountedPtr<Graphics::VertexBuffer> vb, const 
 		font->PopulateString(va, s.c_str(), 0, 0, color);
 
 		if (va.GetNumVerts() > 0) {
-			if (!vb.Valid() || vb->GetVertexCount() != va.GetNumVerts()) {
+			if (!vb.Valid() || vb->GetCapacity() < va.GetNumVerts()) {
 				vb.Reset(font->CreateVertexBuffer(va, s, true));
 			}
 
@@ -359,7 +359,7 @@ void Screen::RenderMarkupBuffer(RefCountedPtr<Graphics::VertexBuffer> vb, const 
 		font->PopulateMarkup(va, s.c_str(), 0, 0, color);
 
 		if (va.GetNumVerts() > 0) {
-			if (!vb.Valid() || vb->GetVertexCount() != va.GetNumVerts()) {
+			if (!vb.Valid() || vb->GetCapacity() < va.GetNumVerts()) {
 				vb.Reset(font->CreateVertexBuffer(va, s, true));
 			}
 

--- a/src/gui/GuiTextLayout.cpp
+++ b/src/gui/GuiTextLayout.cpp
@@ -17,12 +17,20 @@ TextLayout::TextLayout(const char *_str, RefCountedPtr<Text::TextureFont> font, 
 	m_colourMarkup = markup;
 	m_font = font ? font : Gui::Screen::GetFont();
 
-	str = static_cast<char *>(malloc(strlen(_str)+1));
-	strcpy(str, _str);
+	SetText(_str);
+
+	prevWidth = -1.0f;
+	prevColor = Color::WHITE;
+}
+
+void TextLayout::SetText(const char *_str)
+{
+	str = std::string(_str);
 
 	m_justify = false;
 	float wordWidth = 0;
-	char *wordstart = str;
+	const char *wordstart = str.c_str();
+	words.clear();
 
 	int i = 0;
 	while (str[i]) {
@@ -31,7 +39,7 @@ TextLayout::TextLayout(const char *_str, RefCountedPtr<Text::TextureFont> font, 
 
 		while (str[i] && str[i] != ' ' && str[i] != '\r' && str[i] != '\n') {
 			/* skip color control code things! */
-			if ((markup != ColourMarkupNone) && (str[i] == '#')) {
+			if ((m_colourMarkup != ColourMarkupNone) && (str[i] == '#')) {
 				unsigned int hexcol;
 				if (sscanf(&str[i], "#%3x", &hexcol)==1) {
 					i+=4;
@@ -195,7 +203,7 @@ void TextLayout::Update(const float width, const Color &color)
 	}
 
 	if( va.GetNumVerts() > 0 ) {
-		if( !m_vbuffer.Valid() || m_vbuffer->GetVertexCount() != va.GetNumVerts() ) {
+		if( !m_vbuffer.Valid() || m_vbuffer->GetCapacity() < va.GetNumVerts() ) {
 			//create buffer and upload data
 			Graphics::VertexBufferDesc vbd;
 			vbd.attrib[0].semantic = Graphics::ATTRIB_POSITION;

--- a/src/gui/GuiTextLayout.h
+++ b/src/gui/GuiTextLayout.h
@@ -21,18 +21,18 @@ public:
 	explicit TextLayout(const char *_str, RefCountedPtr<Text::TextureFont> font = RefCountedPtr<Text::TextureFont>(0), ColourMarkupMode markup = ColourMarkupUse);
 	void Render(const float layoutWidth, const Color &color = Color::WHITE) const;
 	void Update(const float layoutWidth, const Color &color = Color::WHITE);
+	void SetText(const char *_str);
 	void MeasureSize(const float layoutWidth, float outSize[2]) const;
 	void _MeasureSizeRaw(const float layoutWidth, float outSize[2]) const;
-	~TextLayout() { free(str); }
 	void SetJustified(bool v) { m_justify = v; }
 private:
 	struct word_t {
-		char *word;
-		float advx;
-		word_t(char *_word, float _advx): word(_word), advx(_advx) {}
+		const char *word;
+		const float advx;
+		word_t(const char *_word, const float _advx): word(_word), advx(_advx) {}
 	};
 	std::list<word_t> words;
-	char *str;
+	std::string str;
 	bool m_justify;
 	ColourMarkupMode m_colourMarkup;
 

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -187,7 +187,7 @@ int TextureFont::PickCharacter(const std::string &str, float mouseX, float mouse
 
 void TextureFont::RenderBuffer(Graphics::VertexBuffer *vb, const Color &color)
 {
-	if( vb && vb->GetVertexCount() > 0 )
+	if( vb && vb->GetSize() > 0 )
 	{
 		m_mat->diffuse = color;
 		m_renderer->DrawBuffer(vb, m_renderState, m_mat.get());

--- a/src/ui/Label.cpp
+++ b/src/ui/Label.cpp
@@ -58,7 +58,10 @@ void Label::Draw()
 		m_font = GetContext()->GetFont(GetFont());
 		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 		m_font->PopulateString(va, m_text, 0.0f, 0.0f, finalColor);
-		m_vbuffer.Reset( m_font->CreateVertexBuffer(va, false) );		// too frequent for static
+		if(!m_vbuffer || m_vbuffer->GetCapacity() < va.GetNumVerts()) {
+			m_vbuffer.Reset( m_font->CreateVertexBuffer(va, false) );		// too frequent for static
+		}
+		m_vbuffer->Populate(va);
 		m_bNeedsUpdating = false;
 		m_bPrevDisabled = IsDisabled();
 		m_prevOpacity = opacity;

--- a/src/ui/TextLayout.cpp
+++ b/src/ui/TextLayout.cpp
@@ -125,7 +125,7 @@ void TextLayout::Draw(const Point &layoutSize, const Point &drawPos, const Point
 			}
 		}
 
-		if (!m_vbuffer.Valid() || (m_vbuffer->GetVertexCount() != va.GetNumVerts())) {
+		if (!m_vbuffer.Valid() || (m_vbuffer->GetCapacity() < va.GetNumVerts())) {
 			m_vbuffer.Reset(m_font->CreateVertexBuffer(va, true));
 		}
 		else {


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Refactor buffers to have a capacity and size so they can be reused instead of discarded.

The idea is to reuse Vertex/Index/Instance buffers when the data they're to be populated with is smaller than their current capacity. If the buffer is too small then it must still be discarded and a new one created.

This helps to avoid thrashing the drivers to create and destroy buffers all the time which can be very expensive.

This might alleviate performance problems on some ATi/AMD GPU drivers that have been reported in the past. Although we did a lot of work to fix those with @jaj22 already tuning up our OpenGL usage.
<!-- Please make sure you've read documentation on contributing -->

