### PR TITLE
Pickle Lua values to JSON

### DIFF
--- a/src/LuaObject.h
+++ b/src/LuaObject.h
@@ -73,18 +73,29 @@ struct SerializerPair {
 	typedef std::string (*Serializer)(LuaWrappable *o);
 	typedef bool (*Deserializer)(const char *stream, const char **next);
 
+	typedef void (*ToJson)(Json::Value &out, LuaWrappable *o);
+	typedef bool (*FromJson)(const Json::Value &obj);
+
 	SerializerPair() :
 		serialize(nullptr),
-		deserialize(nullptr)
+		deserialize(nullptr),
+		to_json(nullptr),
+		from_json(nullptr)
 	{}
 
-	SerializerPair(Serializer _serialize, Deserializer _deserialize) :
-		serialize(_serialize),
-		deserialize(_deserialize)
+	SerializerPair(
+			Serializer serialize_, Deserializer deserialize_,
+			ToJson to_json_, FromJson from_json_):
+		serialize(serialize_),
+		deserialize(deserialize_),
+		to_json(to_json_),
+		from_json(from_json_)
 	{}
 
 	Serializer serialize;
 	Deserializer deserialize;
+	ToJson to_json;
+	FromJson from_json;
 };
 
 
@@ -147,6 +158,9 @@ protected:
 
 	std::string Serialize();
 	static bool Deserialize(const char *stream, const char **next);
+
+	void ToJson(Json::Value &out);
+	static bool FromJson(const Json::Value &obj);
 
     // allocate n bytes from Lua memory and leave it an associated userdata on
     // the stack. this is a wrapper around lua_newuserdata

--- a/src/LuaRef.cpp
+++ b/src/LuaRef.cpp
@@ -103,11 +103,11 @@ void LuaRef::SaveToJson(Json::Value &jsonObj)
 		return;
 	}
 
-	std::string out;
+	Json::Value out;
 	PushCopyToStack();
-	serializer->pickle(m_lua, -1, out);
+	LuaSerializer::pickle_json(m_lua, -1, out);
 	lua_pop(m_lua, 1);
-	jsonObj["lua_ref"] = out;
+	jsonObj["lua_ref_json"] = out;
 
 	LUA_DEBUG_END(m_lua, 0);
 }
@@ -116,9 +116,7 @@ void LuaRef::LoadFromJson(const Json::Value &jsonObj)
 {
 	if (!m_lua) { m_lua = Lua::manager->GetLuaState(); }
 
-	if (!jsonObj.isMember("lua_ref")) throw SavedGameCorruptException();
-
-	std::string pickled = jsonObj["lua_ref"].asString();
+	if (!jsonObj.isMember("lua_ref_json")) throw SavedGameCorruptException();
 
 	LUA_DEBUG_START(m_lua);
 
@@ -131,7 +129,7 @@ void LuaRef::LoadFromJson(const Json::Value &jsonObj)
 		return;
 	}
 
-	serializer->unpickle(m_lua, pickled.c_str()); // loaded
+	LuaSerializer::unpickle_json(m_lua, jsonObj["lua_ref_json"]); // loaded
 	lua_getfield(m_lua, LUA_REGISTRYINDEX, "PiLuaRefLoadTable"); // loaded, reftable
 	lua_pushvalue(m_lua, -2); // loaded, reftable, copy
 	lua_gettable(m_lua, -2);  // loaded, reftable, luaref

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -518,6 +518,8 @@ void LuaSerializer::unpickle_json(lua_State *l, const Json::Value &value)
 			break;
 		case Json::objectValue:
 			if (value.isMember("number")) {
+				lua_pushnumber(l, StrToDouble(value["number"].asString()));
+				LUA_DEBUG_CHECK(l, 1);
 			} else if (value.isMember("userdata")) {
 				if (!LuaObjectBase::FromJson(value["userdata"])) { throw SavedGameCorruptException(); }
 				LUA_DEBUG_CHECK(l, 1);

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -528,7 +528,7 @@ void LuaSerializer::unpickle_json(lua_State *l, const Json::Value &value)
 
 					const Json::Value &inner = value["inner"];
 					if (inner.size() % 2 != 0) { throw SavedGameCorruptException(); }
-					for (int i = 0; i < inner.size(); i += 2) {
+					for (Json::ArrayIndex i = 0; i < inner.size(); i += 2) {
 						unpickle_json(l, inner[i+0]);
 						unpickle_json(l, inner[i+1]);
 						lua_rawset(l, -3);

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -27,6 +27,8 @@ private:
 
 	static void pickle(lua_State *l, int idx, std::string &out, std::string key = "");
 	static const char *unpickle(lua_State *l, const char *pos);
+
+	static void pickle_json(lua_State *l, int idx, Json::Value &out, std::string key = "");
 };
 
 #endif

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -29,6 +29,7 @@ private:
 	static const char *unpickle(lua_State *l, const char *pos);
 
 	static void pickle_json(lua_State *l, int idx, Json::Value &out, std::string key = "");
+	static void unpickle_json(lua_State *l, const Json::Value &value);
 };
 
 #endif

--- a/src/LuaSystemPath.cpp
+++ b/src/LuaSystemPath.cpp
@@ -616,6 +616,35 @@ static bool _systempath_deserializer(const char *pos, const char **next)
 	return true;
 }
 
+static void _systempath_to_json(Json::Value &out, LuaWrappable *o)
+{
+	SystemPath *p = static_cast<SystemPath*>(o);
+	out = Json::Value(Json::arrayValue);
+	out.resize(5);
+	out[0] = Json::Value(p->sectorX);
+	out[1] = Json::Value(p->sectorY);
+	out[2] = Json::Value(p->sectorZ);
+	out[3] = Json::Value(p->systemIndex);
+	out[4] = Json::Value(p->bodyIndex);
+}
+
+static bool _systempath_from_json(const Json::Value &obj)
+{
+	if (!obj.isArray()) return false;
+	if (obj.size() < 3 || obj.size() > 5) return false;
+	for (Json::ArrayIndex i = 0; i < obj.size(); ++i) { if (!obj[i].isIntegral()) { return false; } }
+
+	SystemPath p;
+	p.sectorX = obj[0].asInt();
+	p.sectorY = obj[1].asInt();
+	p.sectorZ = obj[2].asInt();
+	if (obj.size() >= 4) { p.systemIndex = obj[3].asUInt(); }
+	if (obj.size() >= 5) { p.bodyIndex = obj[4].asUInt(); }
+
+	LuaObject<SystemPath>::PushToLua(p);
+	return true;
+}
+
 template <> const char *LuaObject<SystemPath>::s_type = "SystemPath";
 
 template <> void LuaObject<SystemPath>::RegisterClass()
@@ -655,5 +684,6 @@ template <> void LuaObject<SystemPath>::RegisterClass()
 	};
 
 	LuaObjectBase::CreateClass(s_type, 0, l_methods, l_attrs, l_meta);
-	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_systempath_serializer, _systempath_deserializer));
+	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(
+		_systempath_serializer, _systempath_deserializer, _systempath_to_json, _systempath_from_json));
 }

--- a/src/scenegraph/LuaModelSkin.cpp
+++ b/src/scenegraph/LuaModelSkin.cpp
@@ -128,6 +128,20 @@ static bool _modelskin_deserializer(const char *pos, const char **next)
 	return true;
 }
 
+static void _modelskin_to_json(Json::Value &out, LuaWrappable *o)
+{
+	SceneGraph::ModelSkin *skin = static_cast<SceneGraph::ModelSkin*>(o);
+	skin->SaveToJson(out);
+}
+
+static bool _modelskin_from_json(const Json::Value &obj)
+{
+	SceneGraph::ModelSkin skin;
+	skin.LoadFromJson(obj);
+	LuaObject<SceneGraph::ModelSkin>::PushToLua(skin);
+	return true;
+}
+
 using namespace SceneGraph;
 
 template <> const char *LuaObject<SceneGraph::ModelSkin>::s_type = "SceneGraph.ModelSkin";
@@ -146,6 +160,7 @@ template <> void LuaObject<SceneGraph::ModelSkin>::RegisterClass()
 	};
 
 	LuaObjectBase::CreateClass(s_type, 0, l_methods, 0, 0);
-	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_modelskin_serializer, _modelskin_deserializer));
+	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(
+		_modelskin_serializer, _modelskin_deserializer, _modelskin_to_json, _modelskin_from_json));
 }
 


### PR DESCRIPTION
*Updated 2018-09-02*

I've only done very superficial tests.

This replaces some of the custom bytestream serialization of Lua objects to generate JSON values instead. Long term I don't like this because it's likely to be very slow (both on save and on load), but short term it means that much more of the save file can be examined and interpreted by a person with a text editor (after decompressing the save), which is potentially valuable for debugging save problems.

When saving it just outputs the JSON version. When loading it will prefer to load the JSON version if available, but can load bytestream serialised data (ie, existing saves from before this PR) otherwise.

Lua->JSON structure:

- nil -> null
- bool -> bool
- integer -> integer
- string -> string (will definitely break for strings containing nul characters)
- userdata (LuaObject) -> `{ "userdata": { "cpp_class": "<...>", "inner": <...> } }`
- number (float) -> `{ "number": <... uses DoubleToStr ...> }`
- plain table -> `{ "ref": <unique ID number for the object>, "table": [ <table slots in array form; an array because JSON doesn't allow non-string keys for objects> ] }`
- Lua "class" (table with a metatable & Lua serialiser functions) -> `{ "ref": <unique ID>, "table": [ <table data> ], "lua_class": "<...>" }`
- Lua back-reference (reference to table that has been serialised previously; required to support circular references in tables) -> `{ "ref": <unique ID> }`

LuaRef structure: `{ "lua_ref_json": <... Lua value structured as above ...> }`

LuaObject structure: Depends on the type of object (but see "userdata" above).

----

**Previously:**

Current problems/remaining todo:
- Doesn't bump save version but won't be able to load files generated from previous versions. This could be fixed pretty easily by branching to the old or new unpickle code based based on what JSON value type is being unpickled. Or just bump save version and break all old saves again for simplicity.
- LuaObject values (e.g., various C++ objects that are exposed to Lua) are still pickled to a mostly-opaque bytestream. The reverse (LuaRef objects, which are Lua objects that are exposed to C++) are pickled to JSON.

Would work best combined with #4205 so that a custom extraction program isn't required to decompress the save files.