### PR TITLE
AlertState cache cleared on load

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -124,6 +124,11 @@ void Ship::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	m_launchLockTimeout = StrToFloat(shipObj["launch_lock_timeout"].asString());
 	m_testLanded = shipObj["test_landed"].asBool();
 	m_flightState = static_cast<FlightState>(shipObj["flight_state"].asInt());
+	
+	m_lastAlertUpdate = 0.0;	// alertstate check cache timer
+	m_shipNear = false;			// alertstate check cache value
+	m_shipFiring = false;		// alertstate check cache value
+
 	m_alertState = static_cast<AlertState>(shipObj["alert_state"].asInt());
 	Properties().Set("flightState", EnumStrings::GetString("ShipFlightState", m_flightState));
 	Properties().Set("alertStatus", EnumStrings::GetString("ShipAlertStatus", m_alertState));
@@ -213,6 +218,8 @@ void Ship::InitMaterials()
 
 void Ship::Init()
 {
+	Output("Running Ship::Init()\n");
+
 	m_invulnerable = false;
 
 	m_sensors.reset(new Sensors(this));
@@ -266,10 +273,13 @@ void Ship::PostLoadFixup(Space *space)
 
 Ship::Ship(const ShipType::Id &shipId): DynamicBody(),
 	m_controller(0),
-  m_flightState(FLYING),
-  m_alertState(ALERT_NONE),
+    m_flightState(FLYING),
+    m_alertState(ALERT_NONE),
 	m_landingGearAnimation(nullptr)
 {
+	/*
+		THIS CODE DOES NOT RUN WHEN LOADING SAVEGAMES!!
+	*/
 	AddFeature( Feature::PROPULSION ); // add component propulsion
 	AddFeature( Feature::FIXED_GUNS ); // add component fixed guns
 	Properties().Set("flightState", EnumStrings::GetString("ShipFlightState", m_flightState));
@@ -944,6 +954,16 @@ void Ship::UpdateAlertState()
 	}
 
 	bool ship_is_near = false, ship_is_firing = false;
+
+	// sanity check: m_lastAlertUpdate should not be in the future.
+	// reset and re-check if it is.
+	if (m_lastAlertUpdate > Pi::game->GetTime() + 2)
+	{
+		m_lastAlertUpdate = 0;
+		m_shipNear = false;
+		m_shipFiring = false;
+	}
+
 	if (m_lastAlertUpdate + 1.0 <= Pi::game->GetTime())
 	{
 		// time to update the list again, once per second should suffice

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -218,8 +218,6 @@ void Ship::InitMaterials()
 
 void Ship::Init()
 {
-	Output("Running Ship::Init()\n");
-
 	m_invulnerable = false;
 
 	m_sensors.reset(new Sensors(this));
@@ -957,7 +955,7 @@ void Ship::UpdateAlertState()
 
 	// sanity check: m_lastAlertUpdate should not be in the future.
 	// reset and re-check if it is.
-	if (m_lastAlertUpdate > Pi::game->GetTime() + 2)
+	if (m_lastAlertUpdate > Pi::game->GetTime())
 	{
 		m_lastAlertUpdate = 0;
 		m_shipNear = false;


### PR DESCRIPTION
Loading a savegame would leave alertstate cache values undefined possibly triggering an alert or postponing further checks hundreds of years into the future.

This fixes it, clearing the cache on load and adding a sanity check in UpdateAlertState()
