### PR TITLE
Query the maximum (MS)AA samples

### DIFF
--- a/data/ui/Settings.lua
+++ b/data/ui/Settings.lua
@@ -69,9 +69,19 @@ ui.templates.Settings = function (args)
 		end
 		local modeDropDown = optionDropDown(GetVideoMode, SetVideoMode, l.VIDEO_RESOLUTION, videoModeLabels, videoModeLabels)
 
-		local aaLabels = { l.OFF, "x2", "x4", "x8", "x16" }
-		local aaModes = { 0, 2, 4, 8, 16 }
-		local aaDropDown = optionDropDown(Engine.GetMultisampling, Engine.SetMultisampling, l.MULTISAMPLING, aaLabels, aaModes)
+		local maxSamples = Engine.GetMaximumAASamples()
+		local aaLabels = { l.OFF, "x2", "x4", "x8", "x16", "x32", "x64" }
+		local aaModes = { 0, 2, 4, 8, 16, 32, 64 } -- I honestly had no idea you could get these values before today!
+		local aaTempLabels = {}
+		local aaTempModes = {}
+		-- many thanks/blame to impaktor for the following loop code
+		for i,value in ipairs(aaModes) do
+			if value < maxSamples then
+				table.insert(aaTempModes, value)
+				table.insert(aaTempLabels, aaLabels[i])
+			end
+		end
+		local aaDropDown = optionDropDown(Engine.GetMultisampling, Engine.SetMultisampling, l.MULTISAMPLING, aaTempLabels, aaTempModes)
 
 		local detailLevels = { 'VERY_LOW', 'LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH' }
 		local detailLabels = { l.VERY_LOW, l.LOW, l.MEDIUM, l.HIGH, l.VERY_HIGH }

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -195,6 +195,39 @@ static int l_engine_get_video_mode_list(lua_State *l)
 }
 
 /*
+* Method: GetMaximumAASamples
+*
+* Get the maximum number of samples the current OpenGL context supports
+*
+* > Engine.GetMaximumAASamples()
+*
+* Availability:
+*
+*   2017-12
+*
+* Status:
+*
+*   stable
+*/
+
+static int l_engine_get_maximum_aa_samples(lua_State *l)
+{
+	LUA_DEBUG_START(l);
+
+	if(Pi::renderer != nullptr) {
+		int maxSamples = Pi::renderer->GetMaximumNumberAASamples();
+		lua_pushinteger(l, maxSamples);
+	} else {
+		lua_pushinteger(l, 0);
+	}
+
+	LUA_DEBUG_END(l, 1);
+	return 1;
+}
+
+
+
+/*
  * Method: GetVideoResolution
  *
  * Get the current video resolution width and height
@@ -1029,6 +1062,7 @@ void LuaEngine::Register()
 		{ "Quit", l_engine_quit },
 
 		{ "GetVideoModeList", l_engine_get_video_mode_list },
+		{ "GetMaximumAASamples", l_engine_get_maximum_aa_samples },
 		{ "GetVideoResolution", l_engine_get_video_resolution },
 		{ "SetVideoResolution", l_engine_set_video_resolution },
 		{ "GetFullscreen", l_engine_get_fullscreen },

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -60,6 +60,7 @@ public:
 	float GetDisplayAspect() const { return static_cast<float>(m_width) / static_cast<float>(m_height); }
 	int GetWindowWidth() const { return m_width; }
 	int GetWindowHeight() const { return m_height; }
+	virtual int GetMaximumNumberAASamples() const = 0;
 
 	//get supported minimum for z near and maximum for z far values
 	virtual bool GetNearFarRange(float &near_, float &far_) const = 0;

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -27,6 +27,7 @@ public:
 	virtual const char *GetName() const override final { return "Dummy"; }
 	virtual RendererType GetRendererType() const  override final { return RENDERER_DUMMY; }
 	virtual bool SupportsInstancing() override final { return false; }
+	virtual int GetMaximumNumberAASamples() const override final { return 0; }
 	virtual bool GetNearFarRange(float &near_, float &far_) const override final { return true; }
 
 	virtual bool BeginFrame() override final { return true; }

--- a/src/graphics/gl2/GL2Renderer.cpp
+++ b/src/graphics/gl2/GL2Renderer.cpp
@@ -391,6 +391,18 @@ void RendererGL2::WriteRendererInfo(std::ostream &out) const
 	dump_and_clear_opengl_errors(out);
 }
 
+int RendererGL2::GetMaximumNumberAASamples() const
+{
+	GLint value = 0;
+	glGetIntegerv(GL_MAX_SAMPLES, &value);
+	// do this as there's a good chance that GL_MAX_SAMPLES won't exist for a pre-GL 3.0 context
+	GLenum err = glGetError();
+	if( err ) {
+		return 0;
+	}
+	return value;
+}
+
 bool RendererGL2::GetNearFarRange(float &near_, float &far_) const
 {
 	near_ = m_minZNear;

--- a/src/graphics/gl2/GL2Renderer.h
+++ b/src/graphics/gl2/GL2Renderer.h
@@ -54,6 +54,7 @@ public:
 
 	virtual bool SupportsInstancing() override final { return false; }
 
+	virtual int GetMaximumNumberAASamples() const override final;
 	virtual bool GetNearFarRange(float &near, float &far) const override final;
 
 	virtual bool BeginFrame() override final;

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -392,6 +392,13 @@ void RendererOGL::WriteRendererInfo(std::ostream &out) const
 	dump_and_clear_opengl_errors(out);
 }
 
+int RendererOGL::GetMaximumNumberAASamples() const
+{
+	GLint value = 0;
+	glGetIntegerv(GL_MAX_SAMPLES, &value);
+	return value;
+}
+
 bool RendererOGL::GetNearFarRange(float &near_, float &far_) const
 {
 	near_ = m_minZNear;

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -60,6 +60,7 @@ public:
 
 	virtual bool SupportsInstancing() override final { return true; }
 
+	virtual int GetMaximumNumberAASamples() const override final;
 	virtual bool GetNearFarRange(float &near_, float &far_) const override final;
 
 	virtual bool BeginFrame() override final;


### PR DESCRIPTION
Add the ability to query the maximum number of (MS)AA samples the GPU can support.

fixes #4192

@impaktor thanks!

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

