### PR TITLE
Force time acceleration if right mouse button is held down.

### DIFF
--- a/data/pigui/modules/time-window.lua
+++ b/data/pigui/modules/time-window.lua
@@ -42,7 +42,7 @@ local function displayTimeWindow()
 		tooltip = string.interp(lui.HUD_REQUEST_TIME_ACCEL, { time = time })
 		if ui.coloredSelectedIconButton(icons['time_accel_' .. name], button_size, current == name, frame_padding, color, fg_color, tooltip)
 		or (ui.shiftHeld() and ui.isKeyReleased(key)) then
-			Game.SetTimeAcceleration(name, ui.ctrlHeld())
+			Game.SetTimeAcceleration(name, ui.ctrlHeld() or ui.isMouseDown(1))
 		end
 		ui.sameLine()
 	end


### PR DESCRIPTION
As an alternative to holding down the Ctrl key, you can also hold down the right mouse button & click to force time acceleration.

Should fix #4223

@joonicks how does that sound?
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

