### PR TITLE
UnexploredGray

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -1211,6 +1211,13 @@ void SectorView::BuildFarSector(RefCountedPtr<Sector> sec, const vector3f &origi
 		// skip the system if it doesn't fall within the sphere we're viewing.
 		if ((m_pos*Sector::SIZE - (*i).GetFullPosition()).Length() > (m_zoomClamped/FAR_THRESHOLD )*OUTER_RADIUS) continue;
 
+		if (!i->IsExplored())
+		{
+			points.push_back((*i).GetFullPosition() - origin);
+			colors.push_back({ 100,100,100,155 });					// flat gray for unexplored systems
+			continue;
+		}
+
 		// if the system belongs to a faction we've chosen to hide also skip it, if it's not selectd in some way
 		m_visibleFactions.insert(i->GetFaction());
 		if (m_hiddenFactions.find(i->GetFaction()) != m_hiddenFactions.end()


### PR DESCRIPTION
zoomed out sectorview shows unexplored stars as gray instead of independent yellow.

![screenshot-20171227-225112](https://user-images.githubusercontent.com/14345157/34447115-40396604-ece1-11e7-813c-2a15414d5178.png)


