### PR TITLE
Handle JSON errors in Ship Type, Station Type definitions

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -827,7 +827,10 @@ Game *Game::LoadGame(const std::string &filename)
 		const char *pdata = plain_data.data();
 		Json::Reader jsonReader;
 		Json::Value rootNode;
-		jsonReader.parse(pdata, pdata + plain_data.size(), rootNode); 
+		if (!jsonReader.parse(pdata, pdata + plain_data.size(), rootNode)) {
+			Output("Game load failed: %s\n", jsonReader.getFormattedErrorMessages().c_str());
+			throw SavedGameCorruptException();
+		}
 		if (!rootNode.isObject()) throw SavedGameCorruptException();
 		return new Game(rootNode);
 	} catch (gzip::DecompressionFailedException) {


### PR DESCRIPTION
For #4226. Makes the game abort on startup when it tries to load a ship-def or station-def that fails parsing. There should be a not-totally-useless error message written to stdout, or (on Windows) to output.txt.

Code structure is pretty bad (sorry).