### PR TITLE
Allow custom factions to make claims

### DIFF
--- a/src/Factions.cpp
+++ b/src/Factions.cpp
@@ -553,7 +553,7 @@ bool FactionsDatabase::MayAssignFactions() const
 	return m_may_assign_factions;
 }
 
-const Faction* FactionsDatabase::GetNearestFaction(const Sector::System* sys) const
+const Faction* FactionsDatabase::GetNearestClaimant(const Sector::System* sys) const
 {
 	PROFILE_SCOPED()
 	// firstly if this a custom StarSystem it may already have a faction assigned

--- a/src/Factions.cpp
+++ b/src/Factions.cpp
@@ -569,7 +569,7 @@ const Faction* FactionsDatabase::GetNearestFaction(const Sector::System* sys) co
 	for (ConstFactionIterator it = candidates.begin(); it != candidates.end(); ++it)
 	{
 		if ((*it)->IsClaimed(sys->GetPath()))
-			result = *it;
+			return *it; // this is a very specific claim, no further checks for distance from another factions homeworld is needed.
 		if ((*it)->IsCloserAndContains(closestFactionDist, sys))
 			result = *it;
 	}

--- a/src/Factions.cpp
+++ b/src/Factions.cpp
@@ -230,6 +230,27 @@ static int l_fac_colour(lua_State *L)
 	return 1;
 }
 
+static int l_fac_claim(lua_State *L)
+{
+	Faction *fac = l_fac_check(L, 1);
+
+	Sint32 sector_x = luaL_checkinteger(L, 2);
+	Sint32 sector_y = luaL_checkinteger(L, 3);
+	Sint32 sector_z = luaL_checkinteger(L, 4);
+
+	SystemPath path(sector_x, sector_y, sector_z);
+
+	path.systemIndex = -99; // magic number, claim whole sector
+
+	if (lua_gettop(L) > 4)
+	{
+		path.systemIndex = luaL_checkinteger(L, 5);
+	}
+	fac->PushClaim(path);
+	lua_settop(L, 1);
+	return 1;
+}
+
 #ifdef DUMP_FACTIONS
 static void ExportFactionToLua(const Faction *fac, const size_t index)
 {
@@ -365,6 +386,7 @@ static luaL_Reg LuaFaction_meta[] = {
 	{ "illegal_goods_probability", &l_fac_illegal_goods_probability },
 	{ "colour",                    &l_fac_colour },
 	{ "add_to_factions",           &l_fac_add_to_factions },
+	{ "claim",					   &l_fac_claim }, // claim possession of a starsystem or sector
 	{ "__gc",                      &l_fac_gc },
 	{ 0, 0 }
 };
@@ -544,8 +566,12 @@ const Faction* FactionsDatabase::GetNearestFaction(const Sector::System* sys) co
 	double closestFactionDist = HUGE_VAL;
 	ConstFactionList& candidates = m_spatial_index.CandidateFactions(sys);
 
-	for (ConstFactionIterator it = candidates.begin(); it != candidates.end(); ++it) {
-		if ((*it)->IsCloserAndContains(closestFactionDist, sys)) result = *it;
+	for (ConstFactionIterator it = candidates.begin(); it != candidates.end(); ++it)
+	{
+		if ((*it)->IsClaimed(sys->GetPath()))
+			result = *it;
+		if ((*it)->IsCloserAndContains(closestFactionDist, sys))
+			result = *it;
 	}
 	return result;
 }
@@ -557,6 +583,20 @@ bool FactionsDatabase::IsHomeSystem(const SystemPath& sysPath) const
 }
 
 // ------- Factions proper --------
+
+bool Faction::IsClaimed(SystemPath path) const
+{
+	// check the factions list of claimed systems/sectors, if there is one
+	SystemPath sector = path;
+	sector.systemIndex = -99;
+
+	for (auto clam = m_ownedsystemlist.begin(); clam != m_ownedsystemlist.end(); clam++)
+	{
+		if (*clam == sector || *clam == path)
+			return true;
+	}
+	return false;
+}
 
 /*	Answer whether the faction both contains the sysPath, and has a homeworld
 	closer than the passed distance.

--- a/src/Factions.h
+++ b/src/Factions.h
@@ -53,7 +53,7 @@ public:
 	typedef std::vector<SystemPath> ClaimList;
 	ClaimList			m_ownedsystemlist;
 	void PushClaim(SystemPath path) { m_ownedsystemlist.push_back(path); }
-	bool Faction::IsClaimed(SystemPath) const;
+	bool IsClaimed(SystemPath) const;
 
 	// commodity legality
 	typedef std::map<GalacticEconomy::Commodity, Uint32> CommodityProbMap;

--- a/src/Factions.h
+++ b/src/Factions.h
@@ -98,7 +98,7 @@ public:
 
 	const Faction *GetFaction(const Uint32 index) const;
 	const Faction *GetFaction(const std::string& factionName) const;
-	const Faction *GetNearestFaction(const Sector::System* sys) const;
+	const Faction *GetNearestClaimant(const Sector::System* sys) const;
 	bool IsHomeSystem(const SystemPath& sysPath) const;
 
 	const Uint32 GetNumFactions() const;

--- a/src/Factions.h
+++ b/src/Factions.h
@@ -50,6 +50,11 @@ public:
 	//police logo
 	//goods/equipment availability (1-per-economy-type: aka agricultural, industrial, tourist, etc)
 
+	typedef std::vector<SystemPath> ClaimList;
+	ClaimList			m_ownedsystemlist;
+	void PushClaim(SystemPath path) { m_ownedsystemlist.push_back(path); }
+	bool Faction::IsClaimed(SystemPath) const;
+
 	// commodity legality
 	typedef std::map<GalacticEconomy::Commodity, Uint32> CommodityProbMap;
 	CommodityProbMap       commodity_legality;

--- a/src/galaxy/Sector.cpp
+++ b/src/galaxy/Sector.cpp
@@ -109,5 +109,5 @@ float Sector::System::DistanceBetween(const System* a, const System* b)
 void Sector::System::AssignFaction() const
 {
 	assert(m_sector->m_galaxy->GetFactions()->MayAssignFactions());
-	m_faction = m_sector->m_galaxy->GetFactions()->GetNearestFaction(this);
+	m_faction = m_sector->m_galaxy->GetFactions()->GetNearestClaimant(this);
 }

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -286,7 +286,7 @@ bool StarSystemFromSectorGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gal
 	assert(system->GetPath().systemIndex >= 0 && system->GetPath().systemIndex < sec->m_systems.size());
 	const Sector::System& secSys = sec->m_systems[system->GetPath().systemIndex];
 
-	system->SetFaction(galaxy->GetFactions()->GetNearestFaction(&secSys));
+	system->SetFaction(galaxy->GetFactions()->GetNearestClaimant(&secSys));
 	system->SetSeed(secSys.GetSeed());
 	system->SetName(secSys.GetName());
 	system->SetExplored(secSys.GetExplored(), secSys.GetExploredTime());


### PR DESCRIPTION
Adds a new command to use when creating custom factions, setting the faction for any individual starsystem or sector.

When creating custom factions, either when doing the Faction.New(), add a :claim(x,y,z,idx) or after the f = Faction.New() add rows of f:claim(x,y,z,idx)

f:claim(x,y,z) for every star in a sector,
f:claim(x,y,z,idx) for an individual starsystem

claims are checked before expansionrate claims
custom systems can not be claimed, only randomly generated ones.

fixes  #4231
