### PR TITLE
Hyperjump Route Planner

### DIFF
--- a/data/fonts/OverlayFont.json
+++ b/data/fonts/OverlayFont.json
@@ -4,14 +4,14 @@
    "faces" : [
       {
          "fontFile" : "PionilliumText22L-Medium.ttf",
-         "pixelWidth" : 14,
-         "pixelHeight" : 14,
+         "pixelWidth" : 11,
+         "pixelHeight" : 11,
          "advanceXAdjustment" : -1
       },
       {
          "fontFile" : "DejaVuSans.ttf",
-         "pixelWidth" : 14,
-         "pixelHeight" : 14,
+         "pixelWidth" : 11,
+         "pixelHeight" : 11,
          "advanceXAdjustment" : -1,
          "ranges" : [
             [ "0x0400", "0x04FF" ],
@@ -24,8 +24,8 @@
       },
       {
         "fontFile" : "wqy-microhei.ttc",
-        "pixelWidth" : 14,
-        "pixelHeight" : 14,
+        "pixelWidth" : 11,
+        "pixelHeight" : 11,
         "ranges" : [
             [ "0x4E00",  "0x9FFF"  ],
             [ "0x3400",  "0x4DFF"  ],

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -7,6 +7,10 @@
       "description" : "",
       "message" : "Active"
    },
+   "ADD_JUMP" : {
+      "description" : "UI-button: Add hyper jump to list of planned jumps",
+      "message" : "Add Jump"
+   },
    "AFTER_TRADE_IN" : {
       "description" : "",
       "message" : "After trade-in"
@@ -34,6 +38,10 @@
    "ATTEMPT_TO_REPAIR_HULL" : {
       "description" : "",
       "message" : "Attempt to repair hull"
+   },
+   "AUTO_ROUTE" : {
+      "description" : "Automatically find shortest jump route (measured in time) in star map",
+      "message" : "Auto Route"
    },
    "AVAILABLE_FOR_PURCHASE" : {
       "description" : "",
@@ -111,6 +119,10 @@
       "description" : "",
       "message" : "Cash: {money}"
    },
+   "CENTER_ON_SYSTEM" : {
+      "description" : "Center on selected star system",
+      "message" : "Center on System"
+   },
    "CHANGE_BINDING" : {
       "description" : "Key binding option",
       "message" : "Change Binding"
@@ -134,6 +146,10 @@
    "CLEAR" : {
       "description" : "Clear an option in game settings/options menu",
       "message" : "Clear"
+   },
+   "CLEAR_ROUTE" : {
+      "description" : "Clear a planned route of hyperjumps",
+      "message" : "Clear Route"
    },
    "CLIENT" : {
       "description" : "",
@@ -210,6 +226,14 @@
    "CRIMINAL_RECORD" : {
       "description" : "Past crimes / crime history of character",
       "message" : "Criminal record"
+   },
+   "CURRENT_FUEL" : {
+      "description" : "For hyperjump planner",
+      "message" : "Current Fuel:"
+   },
+   "CURRENT_SYSTEM" : {
+      "description" : "For hyperjump planner",
+      "message" : "Current system"
    },
    "DANGEROUS" : {
       "description" : "Player combat rating",
@@ -350,6 +374,10 @@
    "FEMALE" : {
       "description" : "",
       "message" : "Female"
+   },
+   "FINAL_TARGET" : {
+      "description" : "Hyperjump planner, referring to star system target",
+      "message" : "Final Target:"
    },
    "FORWARD_ACCEL" : {
       "description" : "",
@@ -775,6 +803,10 @@
       "description" : "",
       "message" : "Hyperdrive fitted:"
    },
+   "HYPERJUMP_ROUTE" : {
+      "description" : "",
+      "message" : "HyperJump Route"
+   },
    "HYPERSPACE_RANGE" : {
       "description" : "",
       "message" : "Hyperspace range"
@@ -1019,6 +1051,14 @@
       "description" : "",
       "message" : "More info..."
    },
+   "MOVE_DOWN" : {
+      "description" : "move selection down in list",
+      "message" : "Move Down"
+   },
+   "MOVE_UP" : {
+      "description" : "move selection up in list",
+      "message" : "Move Up"
+   },
    "MOSTLY_HARMLESS" : {
       "description" : "",
       "message" : "Mostly Harmless"
@@ -1255,6 +1295,14 @@
       "description" : "For player reputation",
       "message" : "Reliable"
    },
+   "REMOVE_JUMP" : {
+      "description" : "UI-button: remove hyper jump from list of planned jumps",
+      "message" : "Remove Jump"
+   },
+   "REMOVE_WHEN_COMPLETED" : {
+      "description" : "For UI hyperjump planner, referring to jump target system",
+      "message" : "Remove jump when completed"
+   },
    "REPAIR_X_HULL_DAMAGE_FOR_X" : {
       "description" : "",
       "message" : "Repair {damage}% hull damage for {price}"
@@ -1262,6 +1310,10 @@
    "REPUTATION" : {
       "description" : "",
       "message" : "Reputation"
+   },
+   "REQUIRED_FUEL" : {
+      "description" : "Fuel usage for traveling to star system",
+      "message" : "Required Fuel:"
    },
    "REQUEST_LAUNCH" : {
       "description" : "",
@@ -1290,6 +1342,14 @@
    "REWARD" : {
       "description" : "",
       "message" : "Reward"
+   },
+   "ROUTE_INFO" : {
+      "description" : "For hyperjump planner",
+      "message" : "Route Info"
+   },
+   "ROUTE_JUMPS" : {
+      "description" : "For hyperjump planner",
+      "message" : "Route Jumps"
    },
    "SAGITTARIUS_ARM" : {
       "description" : "Arm of the Milky Way galaxy",
@@ -1338,6 +1398,10 @@
    "SET_AS_TARGET" : {
       "description" : "",
       "message" : "Set destination as navigation target."
+   },
+   "SETTINGS" : {
+      "description" : "UI option",
+      "message" : "Settings"
    },
    "SHIP" : {
       "description" : "",
@@ -1450,6 +1514,14 @@
    "TOTAL" : {
       "description" : "",
       "message" : "Total: "
+   },
+   "TOTAL_DISTANCE" : {
+      "description" : "Total distance of a (possibly series) of hyper jump(s)",
+      "message" : "Total Distance:"
+   },
+   "TOTAL_DURATION" : {
+      "description" : "Total duration of a (possibly series) of hyper jump(s)",
+      "message" : "Total Duration:"
    },
    "TOTAL_MASS" : {
       "description" : "",

--- a/data/pigui/modules/hyperjump-planner.lua
+++ b/data/pigui/modules/hyperjump-planner.lua
@@ -5,6 +5,7 @@ local Vector = import('Vector')
 local Event = import('Event')
 local Lang = import("Lang")
 local lc = Lang.GetResource("core")
+local lui = Lang.GetResource("ui-core");
 local Equipment = import("Equipment")
 
 local player = nil
@@ -26,9 +27,9 @@ local current_fuel
 local remove_first_if_current = true
 
 local function showSettings()
-    if ui.collapsingHeader("Settings", {"DefaultOpen"}) then
+    if ui.collapsingHeader(lui.SETTINGS, {"DefaultOpen"}) then
         local changed
-        changed, remove_first_if_current = ui.checkbox("Remove jump when completed", remove_first_if_current)
+        changed, remove_first_if_current = ui.checkbox(lui.REMOVE_WHEN_COMPLETED, remove_first_if_current)
     end
 end -- showSettings
 
@@ -61,8 +62,8 @@ local function showJumpData(start, target, status, distance, fuel, duration, sho
     end
 end -- showJumpData
 
-local function showInfo() 
-    if ui.collapsingHeader("Route Info",{"DefaultOpen"}) then
+local function showInfo()
+    if ui.collapsingHeader(lui.ROUTE_INFO,{"DefaultOpen"}) then
         local total_fuel = 0
         local total_duration = 0
         local total_distance = 0
@@ -78,23 +79,23 @@ local function showInfo()
 
             start = jump
         end
-        
-        ui.text("Current System: " .. current_system.name .. " (" .. current_path.sectorX .. "," .. current_path.sectorY .. "," .. current_path.sectorZ ..")")
-        ui.text("Final Target:")
-        
+
+        ui.text(lui.CURRENT_SYSTEM .. ": " .. current_system.name .. " (" .. current_path.sectorX .. "," .. current_path.sectorY .. "," .. current_path.sectorZ ..")")
+        ui.text(lui.FINAL_TARGET)
+
         if route_jumps > 0 then
             local final_path = hyperjump_route[route_jumps]
             local final_sys = final_path:GetStarSystem()
             ui.sameLine()
             ui.text(final_sys.name .. " (" .. final_path.sectorX .. "," .. final_path.sectorY .. "," .. final_path.sectorZ .. ")")
         end
-        ui.text("Current Fuel: " .. current_fuel .. lc.UNIT_TONNES)
+        ui.text(lui.CURRENT_FUEL .. " " .. current_fuel .. lc.UNIT_TONNES)
         ui.sameLine()
-        ui.text("Required Fuel: " .. total_fuel .. lc.UNIT_TONNES)
-        
-        ui.text("Total Duration: "..ui.Format.Duration(total_duration, 2))
+        ui.text(lui.REQUIRED_FUEL .. " " .. total_fuel .. lc.UNIT_TONNES)
+
+        ui.text(lui.TOTAL_DURATION .. " " ..ui.Format.Duration(total_duration, 2))
         ui.sameLine()
-        ui.text("Total Distance: " ..string.format("%.2f", total_distance) .. lc.UNIT_LY)
+        ui.text(lui.TOTAL_DISTANCE .. " " ..string.format("%.2f", total_distance) .. lc.UNIT_LY)
     end
 end -- showInfo
 
@@ -107,14 +108,14 @@ local function mainButton(icon, tooltip, callback)
 end --mainButton
 
 local function showJumpRoute()
-    if ui.collapsingHeader("Route Jumps", {"DefaultOpen"}) then        
-        mainButton(icons.forward, "Add Jump", 
+    if ui.collapsingHeader(lui.ROUTE_JUMPS, {"DefaultOpen"}) then
+        mainButton(icons.forward, lui.ADD_JUMP,
             function()
                 Engine.SectorMapAddToRoute(map_selected_path)
         end)
         ui.sameLine()
-        
-        mainButton(icons.current_line, "Remove Jump",
+
+        mainButton(icons.current_line, lui.REMOVE_JUMP,
             function()
                 local new_route = {}
                 local new_count = 0
@@ -123,8 +124,8 @@ local function showJumpRoute()
                 end
         end)
         ui.sameLine()
-        
-        mainButton(icons.current_periapsis, "Move Up",
+
+        mainButton(icons.current_periapsis, lui.MOVE_UP,
             function()
                 if selected_jump then
                     if Engine.SectorMapMoveRouteItemUp(selected_jump) then
@@ -133,8 +134,8 @@ local function showJumpRoute()
                 end
         end)
         ui.sameLine()
-        
-        mainButton(icons.current_apoapsis, "Move Down",
+
+        mainButton(icons.current_apoapsis, lui.MOVE_DOWN,
             function()
                 if selected_jump then
                     if Engine.SectorMapMoveRouteItemDown(selected_jump) then
@@ -143,31 +144,31 @@ local function showJumpRoute()
                 end
         end)
         ui.sameLine()
-        
-        mainButton(icons.retrograde_thin, "Clear Route", 
-            function() 
+
+        mainButton(icons.retrograde_thin, lui.CLEAR_ROUTE,
+            function()
                 Engine.SectorMapClearRoute()
                 selected_jump = nil
         end)
         ui.sameLine()
-        
-        mainButton(icons.hyperspace, "Auto Route", 
-            function() 
+
+        mainButton(icons.hyperspace, lui.AUTO_ROUTE,
+            function()
                 Engine.SectorMapAutoRoute()
-                
+
         end)
         ui.sameLine()
-        
-        mainButton(icons.search_lens, "Zoom to System",
+
+        mainButton(icons.search_lens, lui.CENTER_ON_SYSTEM,
             function()
                 if selected_jump then
                     Engine.SectorMapGotoSystemPath(hyperjump_route[selected_jump])
                 end
         end)
-        
-        
+
+
         ui.separator()
-        
+
         local start = current_path
         local clicked
         local running_fuel = 0
@@ -211,7 +212,7 @@ local function showHyperJumpPlannerWindow()
     ui.withStyleColors({["WindowBg"] = colors.lightBlackBackground}, function()
         ui.window("MapSectorViewHyperJumpPlanner", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
             function()
-                ui.text("HyperJump Route")
+                ui.text(lui.HYPERJUMP_ROUTE)
                 ui.separator()
                 showInfo()
                 ui.separator()

--- a/data/pigui/modules/hyperjump-planner.lua
+++ b/data/pigui/modules/hyperjump-planner.lua
@@ -1,0 +1,262 @@
+local Engine = import('Engine')
+local Game = import('Game')
+local ui = import('pigui/pigui.lua')
+local Vector = import('Vector')
+local Event = import('Event')
+local Lang = import("Lang")
+local lc = Lang.GetResource("core")
+local Equipment = import("Equipment")
+
+local player = nil
+local colors = ui.theme.colors
+local icons = ui.theme.icons
+
+local mainButtonSize = Vector(24,24) * (ui.screenHeight / 1200)
+local mainButtonFramePadding = 3
+
+-- hyperjump route stuff
+local hyperjump_route = {}
+local route_jumps = 0
+local auto_route_min_jump = 2 -- minimum jump distance when auto routing
+local current_system
+local current_path
+local map_selected_path
+local selected_jump
+local current_fuel
+local remove_first_if_current = true
+
+local function showSettings()
+    if ui.collapsingHeader("Settings", {"DefaultOpen"}) then
+        local changed
+        changed, remove_first_if_current = ui.checkbox("Remove jump when completed", remove_first_if_current)
+    end
+end -- showSettings
+
+local function showJumpData(start, target, status, distance, fuel, duration, short)
+    --local color = status == "OK" and colors.white or colors.alertRed  -- TODO: dedicated colors?
+    local color = colors.white
+    if short then
+         ui.withStyleColors({["Text"] = color}, function()
+
+            ui.text(target:GetStarSystem().name)
+            ui.sameLine()
+            ui.text("("..fuel .. lc.UNIT_TONNES..")")
+        end)
+    else
+        ui.withStyleColors({["Text"] = color}, function()
+            ui.text(start:GetStarSystem().name)
+            ui.sameLine()
+            ui.text("->")
+            ui.sameLine()
+            ui.text(target:GetStarSystem().name)
+            ui.sameLine()
+            ui.text(":")
+            ui.sameLine()
+            ui.text(string.format("%.2f", distance) .. lc.UNIT_LY)
+            ui.sameLine()
+            ui.text(fuel .. lc.UNIT_TONNES)
+            ui.sameLine()
+            ui.text(ui.Format.Duration(duration, 2))
+        end)
+    end
+end -- showJumpData
+
+local function showInfo() 
+    if ui.collapsingHeader("Route Info",{"DefaultOpen"}) then
+        local total_fuel = 0
+        local total_duration = 0
+        local total_distance = 0
+
+        local start = current_path
+    -- Tally up totals for the entire jump plan
+        for _,jump in pairs(hyperjump_route) do
+            local status, distance, fuel, duration = player:GetHyperspaceDetails(start, jump)
+
+            total_fuel = total_fuel + fuel
+            total_duration = total_duration + duration
+            total_distance = total_distance + distance
+
+            start = jump
+        end
+        
+        ui.text("Current System: " .. current_system.name .. " (" .. current_path.sectorX .. "," .. current_path.sectorY .. "," .. current_path.sectorZ ..")")
+        ui.text("Final Target:")
+        
+        if route_jumps > 0 then
+            local final_path = hyperjump_route[route_jumps]
+            local final_sys = final_path:GetStarSystem()
+            ui.sameLine()
+            ui.text(final_sys.name .. " (" .. final_path.sectorX .. "," .. final_path.sectorY .. "," .. final_path.sectorZ .. ")")
+        end
+        ui.text("Current Fuel: " .. current_fuel .. lc.UNIT_TONNES)
+        ui.sameLine()
+        ui.text("Required Fuel: " .. total_fuel .. lc.UNIT_TONNES)
+        
+        ui.text("Total Duration: "..ui.Format.Duration(total_duration, 2))
+        ui.sameLine()
+        ui.text("Total Distance: " ..string.format("%.2f", total_distance) .. lc.UNIT_LY)
+    end
+end -- showInfo
+
+local function mainButton(icon, tooltip, callback)
+    local button = ui.coloredSelectedIconButton(icon, mainButtonSize, false, mainButtonFramePadding, colors.buttonBlue, colors.white, tooltip)
+    if button then
+        callback()
+    end
+    return button
+end --mainButton
+
+local function showJumpRoute()
+    if ui.collapsingHeader("Route Jumps", {"DefaultOpen"}) then        
+        mainButton(icons.forward, "Add Jump", 
+            function()
+                Engine.SectorMapAddToRoute(map_selected_path)
+        end)
+        ui.sameLine()
+        
+        mainButton(icons.current_line, "Remove Jump",
+            function()
+                local new_route = {}
+                local new_count = 0
+                if selected_jump then
+                    Engine.SectorMapRemoveRouteItem(selected_jump)
+                end
+        end)
+        ui.sameLine()
+        
+        mainButton(icons.current_periapsis, "Move Up",
+            function()
+                if selected_jump then
+                    if Engine.SectorMapMoveRouteItemUp(selected_jump) then
+                        selected_jump = selected_jump - 1
+                    end
+                end
+        end)
+        ui.sameLine()
+        
+        mainButton(icons.current_apoapsis, "Move Down",
+            function()
+                if selected_jump then
+                    if Engine.SectorMapMoveRouteItemDown(selected_jump) then
+                        selected_jump = selected_jump + 1
+                    end
+                end
+        end)
+        ui.sameLine()
+        
+        mainButton(icons.retrograde_thin, "Clear Route", 
+            function() 
+                Engine.SectorMapClearRoute()
+                selected_jump = nil
+        end)
+        ui.sameLine()
+        
+        mainButton(icons.hyperspace, "Auto Route", 
+            function() 
+                Engine.SectorMapAutoRoute()
+                
+        end)
+        ui.sameLine()
+        
+        mainButton(icons.search_lens, "Zoom to System",
+            function()
+                if selected_jump then
+                    Engine.SectorMapGotoSystemPath(hyperjump_route[selected_jump])
+                end
+        end)
+        
+        
+        ui.separator()
+        
+        local start = current_path
+        local clicked
+        local running_fuel = 0
+        for jumpIndex, jump in pairs(hyperjump_route) do
+            local jump_sys = jump:GetStarSystem()
+            local status, distance, fuel, duration = player:GetHyperspaceDetails(start, jump)
+            local color
+            local remaining_fuel = current_fuel - running_fuel - fuel
+
+            if remaining_fuel == 0 then
+                color = colors.alertYellow
+            else
+                if remaining_fuel < 0 then
+                    color = colors.alertRed
+                else
+                    color = colors.white
+                end
+            end
+
+            ui.withStyleColors({["Text"] = color},
+                function()
+                    if ui.selectable(jumpIndex..": ".. jump_sys.name .. " (" .. string.format("%.2f", distance) .. lc.UNIT_LY .. " - " .. fuel .. lc.UNIT_TONNES..")", jumpIndex == selected_jump, {}) then
+                        clicked = jumpIndex
+                    end
+            end)
+            running_fuel = fuel + running_fuel
+            start = jump
+        end
+
+        if clicked then
+            selected_jump = clicked
+        end
+    end
+end -- showJumpPlan
+
+
+
+local function showHyperJumpPlannerWindow()
+    ui.setNextWindowSize(Vector(ui.screenWidth / 5, (ui.screenHeight / 5) * 2), "Always")
+    ui.setNextWindowPos(Vector(ui.screenWidth - ui.screenWidth / 5 - 10, ui.screenHeight - ((ui.screenHeight / 5) * 2) - 10), "Always")
+    ui.withStyleColors({["WindowBg"] = colors.lightBlackBackground}, function()
+        ui.window("MapSectorViewHyperJumpPlanner", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
+            function()
+                ui.text("HyperJump Route")
+                ui.separator()
+                showInfo()
+                ui.separator()
+                showJumpRoute()
+                ui.separator()
+                showSettings()
+        end)
+    end)
+end -- showHyperJumpPlannerWindow
+
+
+local function displayHyperJumpPlanner()
+    player = Game.player
+    current_system = Game.system
+    current_path = current_system.path
+
+    current_fuel = player:CountEquip(Equipment.cargo.hydrogen,"cargo")
+
+    local current_view = Game.CurrentView()
+
+    if current_view == "sector" then
+        map_selected_path = Engine.GetSectorMapSelectedSystemPath()
+        hyperjump_route = Engine.SectorMapGetRoute()
+        route_jumps = Engine.SectorMapGetRouteSize()
+        showHyperJumpPlannerWindow()
+    end
+end -- displayHyperJumpPlanner
+
+ui.registerModule("game", displayHyperJumpPlanner)
+
+Event.Register("onEnterSystem",
+    function(ship)
+        -- remove the first jump if it's the current system (and enabled to do so)
+        -- this should be the case if you are following a route and want the route to be
+        -- updated as you make multiple jumps
+        if ship:IsPlayer() and remove_first_if_current then
+            if route_jumps > 0 and hyperjump_route[1]:IsSameSystem(Game.system.path) then
+                Engine.SectorMapRemoveRouteItem(1)
+            end
+        end
+end)
+
+Event.Register("onGameEnd",
+    function(ship)
+        -- clear the route out so it doesn't show up if the user starts a new game
+        Engine.SectorMapClearRoute()
+end)
+return {}

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -522,6 +522,7 @@ ui.isKeyReleased = pigui.IsKeyReleased
 ui.playSfx = pigui.PlaySfx
 ui.isItemHovered = pigui.IsItemHovered
 ui.isItemActive = pigui.IsItemActive
+ui.isItemClicked = pigui.IsItemClicked
 ui.ctrlHeld = function() return pigui.key_ctrl end
 ui.altHeld = function() return pigui.key_alt end
 ui.shiftHeld = function() return pigui.key_shift end

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -47,7 +47,7 @@ public:
 	virtual void SaveToJson(Json::Value &jsonObj);
 
 	sigc::signal<void> onHyperspaceTargetChanged;
-	
+
 	double GetZoomLevel() const;
 	void ZoomIn();
 	void ZoomOut();
@@ -61,6 +61,18 @@ public:
 	const std::set<const Faction *> &GetVisibleFactions() { return m_visibleFactions; }
 	const std::set<const Faction *> &GetHiddenFactions() { return m_hiddenFactions; }
 	void SetFactionVisible(const Faction *faction, bool visible);
+
+	// HyperJump Route Planner
+	bool MoveRouteItemUp(const std::vector<SystemPath>::size_type element);
+	bool MoveRouteItemDown(const std::vector<SystemPath>::size_type element);
+	void AddToRoute(const SystemPath &path);
+	bool RemoveRouteItem(const std::vector<SystemPath>::size_type element);
+	void ClearRoute();
+	std::vector<SystemPath> GetRoute();
+	std::vector<SystemPath> AutoRoute(const SystemPath &start, const SystemPath &target);
+	void SetDrawRouteLines(bool value) { m_drawRouteLines = value; }
+
+
 protected:
 	virtual void OnSwitchTo();
 
@@ -127,7 +139,7 @@ private:
 	bool m_drawUninhabitedLabels;
 	bool m_drawOutRangeLabels;
 	bool m_drawVerticalLines;
-	
+
 	std::unique_ptr<Graphics::Drawables::Disk> m_disk;
 
 	Gui::LabelSet *m_clickableLabels;
@@ -149,6 +161,11 @@ private:
 	Graphics::Drawables::Line3D m_selectedLine;
 	Graphics::Drawables::Line3D m_secondLine;
 	Graphics::Drawables::Line3D m_jumpLine;
+
+	// HyperJump Route Planner Stuff
+	std::vector<SystemPath> m_route;
+	bool m_drawRouteLines;
+	void DrawRouteLines(const vector3f &playerAbsPos, const matrix4x4f &trans);
 
 	Graphics::RenderState *m_solidState;
 	Graphics::RenderState *m_alphaBlendState;


### PR DESCRIPTION
Work in progress!

This adds a hyperjump route planner to the new sector map in PR #4204. This PR is currently based on that branch and not master (not ready for merge yet!). 

The planner (lower right):
![base profile screenshot 2017 12 29 - 13 03 59 53](https://user-images.githubusercontent.com/7342077/34471076-de0a065e-ef0c-11e7-8ba8-bd7bb9dbf43f.png)

![base profile screenshot 2017 12 29 - 13 41 35 41](https://user-images.githubusercontent.com/7342077/34471146-99bb10ae-ef0e-11e7-9cd5-0d7800d066b2.png)

The planner has functions for adding the currently selected system, removing jumps, reordering and a *very* simple 'auto-route' feature. The option to 'remove jump when completed' will automatically remove the first jump from the list if you hyperjump to that system.

In addition to adding the planner itself:
- Add lines for the current route to the sector map (yellow lines)
- Altered the display of the 'far' (faction colored boxes) view. Smaller boxes and slightly more transparent
- Lowered the font size used on the sector map (and a few other places like the auto pilot screen), which makes the sector map much more readable.

Open issues/todo:
- [ ] Integrate the planner into the main sector map window (left) (tabs?)
- [X] Move the auto-route feature to c++ and use an actual networking algorithm
- [ ] Custom icons
- [ ] Setting button for displaying route lines
- [ ] Favorites/Saving route between game sessions
- [x] Internationalization/Translations (there's some done already for unit names and what-not, but most of the strings are just literals right now).
  