### PR TITLE
SAR fix drive selection

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -721,7 +721,7 @@ local createTargetShip = function (mission)
 				break
 			end
 		end
-		if not drive then
+		if not ship:GetEquip('engine', 1) then
 			ship:AddEquip(Equipment.hyperspace['hyperdrive_1'])
 		end
 	end


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This fixes #4208. Stupid mistake on my part. The fail safe did not engage properly when no drive was added to the mission ship. The provided save game (see #4208) does not crash once this patch is applied. 

