### PR TITLE
sectorview zoomout prettier homeworld labels

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -764,29 +764,38 @@ void SectorView::PutFactionLabels(const vector3f &origin)
 
 				Gui::Screen::MeasureString(labelText, labelWidth, labelHeight);
 
+				// draw a big diamond for the location of the star
+				static const float STARSIZE = 5;
+				Graphics::VertexArray outline(Graphics::ATTRIB_POSITION);
+				outline.Add(vector3f(pos.x - STARSIZE - 1.f, pos.y, 1));
+				outline.Add(vector3f(pos.x, pos.y + STARSIZE + 1.f, 1));
+				outline.Add(vector3f(pos.x, pos.y - STARSIZE - 1.f, 1));
+				outline.Add(vector3f(pos.x + STARSIZE + 1.f, pos.y, 1));
+				m_material->diffuse = { 0, 0, 0, 255 };
+				m_renderer->DrawTriangles(&outline, renderState, m_material.Get(), Graphics::TRIANGLE_STRIP);
 
-				{
-					Graphics::VertexArray va(Graphics::ATTRIB_POSITION);
-					va.Add(vector3f(pos.x - 5.f,              pos.y - 5.f,               0));
-					va.Add(vector3f(pos.x - 5.f,              pos.y - 5.f + labelHeight, 0));
-					va.Add(vector3f(pos.x + labelWidth + 5.f, pos.y - 5.f,               0));
-					va.Add(vector3f(pos.x + labelWidth + 5.f, pos.y - 5.f + labelHeight, 0));
-					m_material->diffuse = labelBorder;
-					m_renderer->DrawTriangles(&va, renderState, m_material.Get(), Graphics::TRIANGLE_STRIP);
-				}
+				Graphics::VertexArray marker(Graphics::ATTRIB_POSITION);
+				marker.Add(vector3f(pos.x - STARSIZE, pos.y, 0));
+				marker.Add(vector3f(pos.x, pos.y + STARSIZE, 0));
+				marker.Add(vector3f(pos.x, pos.y - STARSIZE, 0));
+				marker.Add(vector3f(pos.x + STARSIZE, pos.y, 0));
+				m_material->diffuse = labelColor;
+				m_renderer->DrawTriangles(&marker, renderState, m_material.Get(), Graphics::TRIANGLE_STRIP);
 
-				{
-					Graphics::VertexArray va(Graphics::ATTRIB_POSITION);
-					va.Add(vector3f(pos.x - 8.f, pos.y,       0));
-					va.Add(vector3f(pos.x      , pos.y + 8.f, 0));
-					va.Add(vector3f(pos.x,       pos.y - 8.f, 0));
-					va.Add(vector3f(pos.x + 8.f, pos.y,       0));
-					m_material->diffuse = labelColor;
-					m_renderer->DrawTriangles(&va, renderState, m_material.Get(), Graphics::TRIANGLE_STRIP);
-				}
+				// draw a surface for the label to sit on
+				static const float MARGINLEFT = 8;
+				float halfheight = labelHeight / 2.0;
+				Graphics::VertexArray surface(Graphics::ATTRIB_POSITION);
+				surface.Add(vector3f(pos.x + MARGINLEFT - 2.f, pos.y - halfheight, 0));
+				surface.Add(vector3f(pos.x + MARGINLEFT - 2.f, pos.y + halfheight, 0));
+				surface.Add(vector3f(pos.x + MARGINLEFT + labelWidth + 2.f, pos.y - halfheight, 0));
+				surface.Add(vector3f(pos.x + MARGINLEFT + labelWidth + 2.f, pos.y + halfheight, 0));
+				m_material->diffuse = labelBorder;
+				m_renderer->DrawTriangles(&surface, renderState, m_material.Get(), Graphics::TRIANGLE_STRIP);
 
-				if (labelColor.GetLuminance() > 191) labelColor.a = 204;    // luminance is sometimes a bit overly
-				m_clickableLabels->Add(labelText, sigc::bind(sigc::mem_fun(this, &SectorView::OnClickSystem), (*it)->homeworld), pos.x, pos.y, labelColor);
+				if (labelColor.GetLuminance() > 204)
+					labelColor.a = 204;    // luminance is sometimes a bit overly
+				m_clickableLabels->Add(labelText, sigc::bind(sigc::mem_fun(this, &SectorView::OnClickSystem), (*it)->homeworld), pos.x + MARGINLEFT, pos.y - (halfheight / 2.0) - 1.f, labelColor);
 			}
 		}
 	}


### PR DESCRIPTION
no more quick and dirty labels. made the point stand out from the background clutter with contrast background. centered the label and decreased the margins slightly. label no longer overlaps the star.
