### PR TITLE
Gamestart money

### DIFF
--- a/data/ui/MainMenu.lua
+++ b/data/ui/MainMenu.lua
@@ -27,7 +27,7 @@ local setupPlayerSol = function ()
 	Game.player:AddEquip(misc.autopilot)
 	Game.player:AddEquip(misc.radar)
 	Game.player:AddEquip(cargo.hydrogen, 2)
-	Game.player:SetMoney(100)
+	Game.player:SetMoney(1000)
 end
 
 local setupPlayerEridani = function ()
@@ -39,7 +39,7 @@ local setupPlayerEridani = function ()
 	Game.player:AddEquip(misc.autopilot)
 	Game.player:AddEquip(misc.radar)
 	Game.player:AddEquip(cargo.hydrogen, 2)
-	Game.player:SetMoney(100)
+	Game.player:SetMoney(1000)
 end
 
 local setupPlayerBarnard = function ()
@@ -50,7 +50,7 @@ local setupPlayerBarnard = function ()
 	Game.player:AddEquip(misc.autopilot)
 	Game.player:AddEquip(misc.radar)
 	Game.player:AddEquip(cargo.hydrogen, 2)
-	Game.player:SetMoney(100)
+	Game.player:SetMoney(1000)
 end
 
 local loadGame = function (path)


### PR DESCRIPTION
changed the amount of startup cash from 100 to 1000.

why?-----

with only 100 money, the player is FORCED to run missions and the only kind of missions available at the start seems to be deliveries. a player who likes trading can not trade from the start, its impossible.

the impact of this change is very minimal, the player is in theory skipping ahead into the game by 1 or 2 missions.

however, I am also looking at the starter ships. having sinonatrix as a starter ship seems very rich. it costs 219000, maybe thats a mistake, but right now anyways.

I believe a better choice would be a lunar shuttle.
pumpkinseed is also an option (but already used for new hope)
xylophis ~~~ very cheap, if thats good or bad I dont know.
amphiesma is cheaper but compared to sinonatrix its not quite smaller (capacity is higher)

what I do remember from playing frontier/E:D is that you start out with the lowliest of ships, a handful of cash and an open door to the universe. Im not out to copy any game, but I think from a players perspective its a good place to start. its very motivating to have a bigger ship to aim for. currently there arent that many choices.

but. atleast, with 1000 instead of 100. the option of trading to gain cash comes up on the table. even though trading is pretty much a non option right now because of the low commodity prices.
