### PR TITLE
Change lua_pushinteger for lua_pushnumber to preserve value of seed

### DIFF
--- a/src/LuaBody.cpp
+++ b/src/LuaBody.cpp
@@ -71,7 +71,7 @@ static int l_body_attr_seed(lua_State *l)
 	const SystemBody *sbody = b->GetSystemBody();
 	assert(sbody);
 
-	lua_pushinteger(l, sbody->GetSeed());
+	lua_pushnumber(l, sbody->GetSeed());
 	return 1;
 }
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Fix #4249 by changing lua_pushinteger for lua_pushnumber to preserve value of seed
<!-- Please make sure you've read documentation on contributing -->

