### PR TITLE
access all(?) systembody attributes in lua

### DIFF
--- a/src/LuaSystemBody.cpp
+++ b/src/LuaSystemBody.cpp
@@ -399,6 +399,174 @@ static int l_sbody_attr_average_temp(lua_State *l)
 }
 
 /*
+* Attribute: metallicity
+*
+* Returns the measure of metallicity of the body
+* (crust) 0.0 = light (Al, SiO2, etc), 1.0 = heavy (Fe, heavy metals)
+*
+* Availability:
+*
+*   January 2018
+*
+* Status:
+*
+*   experimental
+*/
+static int l_sbody_attr_metallicity(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetMetallicity());
+	return 1;
+}
+
+/*
+* Attribute: volatileGas
+*
+* Returns the measure of volatile gas present in the atmosphere of the body
+* 0.0 = no atmosphere, 1.0 = earth atmosphere density, 4.0+ ~= venus
+*
+* Availability:
+*
+*   January 2018
+*
+* Status:
+*
+*   experimental
+*/
+static int l_sbody_attr_volatileGas(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetVolatileGas());
+	return 1;
+}
+
+/*
+* Attribute: atmosOxidizing
+*
+* Returns the compositional value of any atmospheric gasses in the bodys atmosphere (if any)
+* 0.0 = reducing (H2, NH3, etc), 1.0 = oxidising (CO2, O2, etc)
+*
+* Availability:
+*
+*   January 2018
+*
+* Status:
+*
+*   experimental
+*/
+static int l_sbody_attr_atmosOxidizing(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetAtmosOxidizing());
+	return 1;
+}
+
+/*
+* Attribute: volatileLiquid
+*
+* Returns the measure of volatile liquids present on the body
+* 0.0 = none, 1.0 = waterworld (earth = 70%)
+*
+* Availability:
+*
+*   January 2018
+*
+* Status:
+*
+*   experimental
+*/
+static int l_sbody_attr_volatileLiquid(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetVolatileLiquid());
+	return 1;
+}
+
+/*
+* Attribute: volatileIces
+*
+* Returns the measure of volatile ices present on the body
+* 0.0 = none, 1.0 = total ice cover (earth = 3%)
+*
+* Availability:
+*
+*   January 2018
+*
+* Status:
+*
+*   experimental
+*/
+static int l_sbody_attr_volatileIces(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetVolatileIces());
+	return 1;
+}
+
+/*
+* Attribute: volcanicity
+*
+* Returns the measure of volcanicity of the body
+* 0.0 = none, 1.0 = lava planet
+*
+* Availability:
+*
+*   January 2018
+*
+* Status:
+*
+*   experimental
+*/
+static int l_sbody_attr_volcanicity(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetVolcanicity());
+	return 1;
+}
+
+/*
+* Attribute: life
+*
+* Returns the measure of life present on the body
+* 0.0 = dead, 1.0 = teeming (~= pandora)
+*
+* Availability:
+*
+*   January 2018
+*
+* Status:
+*
+*   experimental
+*/
+static int l_sbody_attr_life(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetLife());
+	return 1;
+}
+
+/*
+* Attribute: hasRings
+*
+* Returns true if the body has a ring or rings of debris or ice in orbit around it
+*
+* Availability:
+*
+*   January 2018
+*
+* Status:
+*
+*  experimental
+*/
+
+static int l_sbody_attr_has_rings(lua_State *l)
+{
+	SystemBody * sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushboolean(l, sbody->HasRings());
+	return 1;
+}
+
+/*
  * Attribute: hasAtmosphere
  *
  * Returns true if an atmosphere is present, false if not
@@ -463,6 +631,14 @@ template <> void LuaObject<SystemBody>::RegisterClass()
 		{ "eccentricity",   l_sbody_attr_eccentricty     },
 		{ "axialTilt",      l_sbody_attr_axial_tilt      },
 		{ "averageTemp",    l_sbody_attr_average_temp    },
+		{ "metallicity",	l_sbody_attr_metallicity	 },
+		{ "volatileGas",	l_sbody_attr_volatileGas	 },
+		{ "atmosOxidizing",	l_sbody_attr_atmosOxidizing  },
+		{ "volatileLiquid",	l_sbody_attr_volatileLiquid  },
+		{ "volatileIces",	l_sbody_attr_volatileIces	 },
+		{ "volcanicity",	l_sbody_attr_volcanicity	 },
+		{ "life",			l_sbody_attr_life			 },
+		{ "hasRings",		l_sbody_attr_has_rings		 },
 		{ "hasAtmosphere",  l_sbody_attr_has_atmosphere  },
 		{ "isScoopable",    l_sbody_attr_is_scoopable    },
 		{ 0, 0 }


### PR DESCRIPTION
to be used when systemview moves to lua, and for my mysterious explorer mod...

new attributes accessible:

metallicity
volatileGas
atmosOxidizing
volatileLiquid
volatileIces
volcanicity
life
hasRings

pretty much all(?) attributes you need to determine visual and textual descriptions of system bodies

