### PR TITLE
Some hash_random related fixes

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -26,7 +26,7 @@ local l = Lang.GetResource("ui-core")
 
 function SpaceStation:Constructor()
 	-- Use a variation of the space station seed itself to ensure consistency
-	local rand = Rand.New(util.hash_random(self.seed .. '-techLevel', 2^31)-1)
+	local rand = Rand.New(self.seed .. '-techLevel')
 	local techLevel = rand:Integer(1, 6) + rand:Integer(0,6)
 	self:setprop("techLevel", techLevel)
 end

--- a/data/ui/StationView/Police.lua
+++ b/data/ui/StationView/Police.lua
@@ -22,7 +22,7 @@ local police = function (tab)
 
 	local station = Game.player:GetDockedWith()
 
-	local rand = Rand.New(util.hash_random(station.seed .. '-police', 2^31-1) - 1)
+	local rand = Rand.New(station.seed .. '-police')
 	local face = InfoFace.New(Character.New({
 		title  = l.CONSTABLE,
 		armour = true,

--- a/data/ui/StationView/ShipRepairs.lua
+++ b/data/ui/StationView/ShipRepairs.lua
@@ -90,7 +90,7 @@ local shipRepairs = function (args)
 
 	-- XXX need a better way of seeding this
 	local station = Game.player:GetDockedWith()
-	local rand = Rand.New(util.hash_random(station.seed .. '-repair-guy', 2^31-1) - 1)
+	local rand = Rand.New(station.seed .. '-repair-guy')
 	local face = InfoFace.New(Character.New({ title = l.CHIEF_MECHANIC }, rand))
 
 	return

--- a/src/LuaUtils.cpp
+++ b/src/LuaUtils.cpp
@@ -28,8 +28,8 @@ extern "C" {
  *
  *   seed - A string or a number. The output is deterministic based on this value.
  *   m, n - optional. If called as hash_random(seed), the result is in the range 0 <= x < 1.
- *          If called as hash_random(seed, n), the result is an integer in the range 1 <= x <= n.
  *          If called as hash_random(seed, m, n), the result is an integer in the range m <= x <= n.
+ *          m must be less than n. (n - m) must be less than 2^32.
  *
  * Availability:
  *
@@ -50,6 +50,7 @@ static int l_hash_random(lua_State *L)
 	// any platforms Pioneer runs on, but there may be bugs.
 
 	int numargs = lua_gettop(L);
+	// Note according to hashlittle2 comments, hashA is better mixed than hashB.
 	Uint32 hashA = 0, hashB = 0;
 
 	luaL_checkany(L, 1);
@@ -64,47 +65,55 @@ static int l_hash_random(lua_State *L)
 		}
 		case LUA_TNUMBER:
 		{
-			lua_Number n = lua_tonumber(L, 1);
+			double n = lua_tonumber(L, 1);
 			assert(!is_nan(n));
 			// jenkins/lookup3
-			// There are assumptions here that (a) lua_Number is actually
-			// 'double' on platforms we care about and (b) 'double' has the
-			// same in-memory representation on all platforms we care about.
+			// There are assumptions here that 'double' has the same in-memory
+			// representation on all platforms we care about. Also since we're
+			// taking a number as input, the source of that number (Lua code)
+			// needs to compute it in a way that gives the same result on all
+			// platforms, which may be tricky in some cases.
 			lookup3_hashlittle2(&n, sizeof(n), &hashA, &hashB);
 			break;
 		}
 		default: return luaL_error(L, "expected a string or a number for argument 1");
 	}
 
-	// Generate a value in the range 0 <= x < 1.
-	// We have 64 random bits (in hashA and hashB). We take 27 bits from hashA
-	// and 26 bits from hashB to give a 53-bit integer (0 to 2**53-1 inclusive)
-	// (53 bits chosen because IEEE double precision floats can exactly
-	// represent integers up to 53 bits).
-	// 67108864 = 2**26
-	double x = (hashA >> 5) * 67108864.0 + double(hashB >> 6);
-	// 9007199254740992 = 2**53
-	// Divide by 2**53 to get a value from 0 to (less than) 1.
-	x *= 1.0 / 9007199254740992.0;
 	if (numargs == 1) {
+		// Generate a value in the range 0 <= x < 1.
+		// We have 64 random bits (in hashA and hashB). We take 27 bits from
+		// hashA and 26 bits from hashB to give a 53-bit integer
+		// (0 to 2**53-1 inclusive)
+		// (53 bits chosen because IEEE double precision floats can exactly
+		// represent integers up to 2**53).
+		// 67108864 = 2**26
+		double x = (hashA >> 5) * 67108864.0 + double(hashB >> 6);
+		// 9007199254740992 = 2**53
+		// Divide by 2**53 to get a value from 0 to (less than) 1.
+		x *= 1.0 / 9007199254740992.0;
 		// return a value x: 0 <= x < 1
 		lua_pushnumber(L, x);
 		return 1;
-	} else {
-		int m, n;
-		if (numargs == 3) {
-			m = lua_tointeger(L, 2);
-			n = lua_tointeger(L, 3);
-		} else if (numargs == 2) {
-			m = 1;
-			n = lua_tointeger(L, 2);
+	} else if (numargs == 3) {
+		Sint64 m = Sint64(lua_tonumber(L, 2));
+		Sint64 n = Sint64(lua_tonumber(L, 3));
+
+		if (m > n) { return luaL_error(L, "arguments invalid (m > n not allowed)"); }
+
+		// Restrict to 32-bit output. This is a bit weird because we allow both signed and unsigned.
+		if (m < 0) {
+			if (m < INT32_MIN || n > INT32_MAX) { return luaL_error(L, "arguments out of range for signed 32-bit int"); }
 		} else {
-			assert(numargs > 3);
-			return luaL_error(L, "wrong number of arguments");
+			if (n > UINT32_MAX) { return luaL_error(L, "arguments out of range for unsigned 32-bit int"); }
 		}
+
+		Uint64 range = n - m + 1;
+		Uint64 bits = (Uint64(hashB) << 32) | Uint64(hashA);
 		// return a value x: m <= x <= n
-		lua_pushinteger(L, m + int(x * (n - m + 1)));
+		lua_pushnumber(L, double(Sint64(m) + Sint64(bits % range)));
 		return 1;
+	} else {
+		return luaL_error(L, "wrong number of arguments");
 	}
 }
 

--- a/src/LuaUtils.cpp
+++ b/src/LuaUtils.cpp
@@ -54,15 +54,6 @@ static int l_hash_random(lua_State *L)
 
 	luaL_checkany(L, 1);
 	switch (lua_type(L, 1)) {
-		case LUA_TNIL:
-			// There is only one 'nil' value, so we can only produce one output
-			// value. These values were chosen randomly, there are no particular
-			// constraints on what they should be.
-			// With hindsight it may be better to simply return an error if we
-			// get 'nil' as input.
-			hashA = 0xBF42B131u;
-			hashB = 0x2A40F7F2u;
-			break;
 		case LUA_TSTRING:
 		{
 			size_t sz;

--- a/src/Random.h
+++ b/src/Random.h
@@ -238,6 +238,8 @@ public:
 			o *= Fixed();
 		return o;
 	}
+
+	const pcg32 &GetPCG() const { return mPCG; }
 private:
 	Random(const Random&); // copy constructor not defined
 	void operator=(const Random&); // assignment operator not defined


### PR DESCRIPTION
Warning: This will change some procedurally generated stuff due to changing hash_random output and changing Rand seeding.

Tries to make hash_random a little less broken, and stop using it to seed another RNG. Also restricts the output range to 32-bit (signed or unsigned)... though there's a good chance that code is still buggy as I didn't test it thoroughly. Also adds comments explaining the numbers in the hash_random random-double code. Also makes it an error to pass nil as the input to hash_random.

I have not tested the Lua side changes. I have opened up the game and checked that Rand:New('some string') doesn't completely break and that calling util.hash_random rejects some out-of-range values.