### PR TITLE
Move LowThrust Setting to ImGui

### DIFF
--- a/data/pigui/modules/ship-internals-window.lua
+++ b/data/pigui/modules/ship-internals-window.lua
@@ -17,6 +17,8 @@ local mainButtonSize = Vector(32,32) * (ui.screenHeight / 1200)
 local mainButtonFramePadding = 3
 local itemSpacingX = 8 -- imgui default
 
+local show_thrust_slider = false
+
 local function mainMenuButton(icon, selected, tooltip, color)
 	if color == nil then
 		color = colors.white
@@ -32,9 +34,24 @@ local function button_lowThrustPower()
 			["ButtonHovered"] = colors.buttonBlue:shade(0.4),
 			["ButtonActive"] = colors.buttonBlue:shade(0.2)},
 		function ()
-			if ui.lowThrustButton("lowthrust", mainButtonSize, thrust * 100, colors.lightBlueBackground, mainButtonFramePadding, gauge_fg, gauge_bg) then
-				Game:ToggleLowThrustPowerOptions()
+            local winpos = ui.getWindowPos()
+            local pos = ui.getCursorPos()
+			if ui.lowThrustButton("lowthrust", mainButtonSize, thrust * 100, colors.lightBlueBackground, mainButtonFramePadding, gauge_fg, gauge_bg)  then
+                show_thrust_slider = not show_thrust_slider
 			end
+            
+            if show_thrust_slider then
+                local p = winpos + pos - Vector(8,100+9)
+                ui.setNextWindowPos(p,'Always')
+                
+                ui.window("ThrustSliderWindow", {"NoTitleBar", "NoResize"},
+                    function()
+                        ui.withStyleColors({["SliderGrab"] =colors.white, ["SliderGrabActive"]=colors.buttonBlue},function()
+                            new_thrust = ui.vSliderInt('###ThrustLowPowerSlider',Vector(mainButtonSize.x + 1 + 2 * mainButtonFramePadding,100), thrust*100,0,100)
+                            player:SetLowThrustPower(new_thrust/100)
+                        end)
+                end)
+            end
 	end)
 	if ui.isItemHovered() then
 		ui.setTooltip(lc.SELECT_LOW_THRUST_POWER_LEVEL)
@@ -125,7 +142,7 @@ local function displayShipFunctionWindow()
 								button_lowThrustPower()
 								button_thrustIndicator()
 								if ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f8) then
-									Game.ToggleLowThrustPowerOptions()
+                                    show_thrust_slider = not show_thrust_slider
 								end
 							end -- current_view == "world"
 	end)

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -511,6 +511,7 @@ ui.ctrlHeld = function() return pigui.key_ctrl end
 ui.altHeld = function() return pigui.key_alt end
 ui.shiftHeld = function() return pigui.key_shift end
 ui.noModifierHeld = function() return pigui.key_none end
+ui.vSliderInt = pigui.VSliderInt
 ui.coloredSelectedIconButton = function(icon, thesize, is_selected, frame_padding, bg_color, fg_color, tooltip)
 	if is_selected then
 		pigui.PushStyleColor("Button", bg_color)

--- a/src/LuaGame.cpp
+++ b/src/LuaGame.cpp
@@ -539,12 +539,6 @@ static int l_game_toggle_target_actions(lua_State *l)
 	return 0;
 }
 
-static int l_game_toggle_low_thrust_power_options(lua_State *l)
-{
-	Pi::game->GetWorldView()->ToggleLowThrustPowerOptions();
-	return 0;
-}
-
 static int l_game_change_flight_state(lua_State *l)
 {
 	Pi::game->GetWorldView()->ChangeFlightState();
@@ -615,7 +609,6 @@ void LuaGame::Register()
 		{ "SetWorldCamType", l_game_set_world_cam_type },
 		{ "GetWorldCamType", l_game_get_world_cam_type },
 		{ "ToggleTargetActions",         l_game_toggle_target_actions }, // deprecated
-		{ "ToggleLowThrustPowerOptions", l_game_toggle_low_thrust_power_options }, // deprecated
 		{ "ChangeFlightState",           l_game_change_flight_state }, // deprecated
 
 		{ 0, 0 }

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -1161,6 +1161,37 @@ static int l_pigui_circular_slider(lua_State *l) {
 	return 1;
 }
 
+static int l_pigui_vsliderint(lua_State *l) {
+	std::string lbl = LuaPull<std::string>(l, 1);
+	ImVec2 size = LuaPull<ImVec2>(l, 2);
+
+	int value = LuaPull<int>(l, 3);
+	int val_min = LuaPull<int>(l, 4);
+	int val_max = LuaPull<int>(l, 5);
+
+	ImGui::VSliderInt(lbl.c_str(), size, &value, val_min, val_max);
+
+	LuaPush<int>(l, value);
+
+	return 1;
+}
+
+
+static int l_pigui_vsliderfloat(lua_State *l) {
+	std::string lbl = LuaPull<std::string>(l, 1);
+	ImVec2 size = LuaPull<ImVec2>(l, 2);
+
+	float value = LuaPull<float>(l, 3);
+	float val_min = LuaPull<float>(l, 4);
+	float val_max = LuaPull<float>(l, 5);
+
+	ImGui::VSliderFloat(lbl.c_str(), size, &value, val_min, val_max);
+
+	LuaPush<float>(l, value);
+
+	return 1;
+}
+
 static int l_pigui_is_key_released(lua_State *l) {
 	int key = LuaPull<int>(l, 1);
 	LuaPush<bool>(l, ImGui::IsKeyReleased(key));
@@ -1324,6 +1355,8 @@ template <> void LuaObject<PiGui>::RegisterClass()
 		{ "ImageButton",            l_pigui_image_button },
 		{ "RadialMenu",             l_pigui_radial_menu },
 		{ "CircularSlider",         l_pigui_circular_slider },
+		{ "VSliderFloat",           l_pigui_vsliderfloat },
+	    { "VSliderInt",             l_pigui_vsliderint },
 		{ "GetMouseClickedPos",     l_pigui_get_mouse_clicked_pos },
 		{ "AddConvexPolyFilled",    l_pigui_add_convex_poly_filled },
 		{ "IsKeyReleased",          l_pigui_is_key_released },

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -63,7 +63,6 @@ public:
 
 	/* start deprecated */
 	void ToggleTargetActions();
-	void ToggleLowThrustPowerOptions();
 	void ChangeFlightState();
 	/* end deprecated */
 
@@ -133,10 +132,6 @@ private:
 	void OnClickCommsNavOption(Body *target);
 	void BuildCommsNavOptions();
 
-	void HideLowThrustPowerOptions();
-	void ShowLowThrustPowerOptions();
-	void OnSelectLowThrustPower(float power);
-
 	void OnPlayerDockOrUndock();
 	void OnPlayerChangeTarget();
 	void OnPlayerChangeFlightControlState();
@@ -157,12 +152,10 @@ private:
 	Gui::Fixed *m_commsOptions;
 	Gui::VBox *m_commsNavOptions;
 	Gui::HBox *m_commsNavOptionsContainer;
-	Gui::Fixed *m_lowThrustPowerOptions;
 	Gui::Label *m_debugText;
 	bool m_labelsOn;
 	enum CamType m_camType;
 	Uint32 m_showTargetActionsTimeout;
-	Uint32 m_showLowThrustPowerTimeout;
 
 #if WITH_DEVKEYS
 	Gui::Label *m_debugInfo;


### PR DESCRIPTION
Clicking on the low thrust indicator or pressing F8 now shows the slider
above the low thrust indicator. The slider can be used to adjust the
amount of thrust when 'low thrust' is active. Clicking the low thrust
indicator or pressing F8 again hides the slider.

![base profile screenshot 2018 01 07 - 13 34 49 100](https://user-images.githubusercontent.com/7342077/34652675-916b51f2-f3af-11e7-9608-6534c8ea58f4.png)


