### PR TITLE
Flatten terrain within Cities - WIP

### DIFF
--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -7,8 +7,50 @@
 #include "GeoSphere.h"
 #include "GasGiant.h"
 #include "graphics/Material.h"
+#include "CityOnPlanet.h"
 
-BaseSphere::BaseSphere(const SystemBody *body) : m_sbody(body), m_terrain(Terrain::InstanceTerrain(body)) {}
+BaseSphere::BaseSphere(const SystemBody *body) : m_sbody(body), m_terrain(Terrain::InstanceTerrain(body))
+{
+	std::vector<vector3d> m_positions;
+	std::vector<RegionType> m_regionTypes;
+	const double planetRadius = body->GetRadius();
+	const double invPlanetRadius = 1.0 / planetRadius;
+
+	// step through the planet's sbody's children and set up regions for surface starports
+	for (SystemBody* kid : body->GetChildren()) {
+		if (kid->GetType() == SystemBody::TYPE_STARPORT_SURFACE) {
+			// calculate position of starport
+			const vector3d pos = (kid->GetOrbit().GetPlane() * vector3d(0, 1, 0));
+
+			// set up regions which contain the details for region implementation
+			RegionType rt;
+
+			rt.height = m_terrain->GetHeight(pos); // height in planet radii
+
+			// Calculate average variation of four points about star port
+			// points do not need to be on the planet surface
+			const double delta = (0.75 * CITY_ON_PLANET_RADIUS / planetRadius);
+			double avgVariation = fabs(m_terrain->GetHeight(vector3d(pos.x + delta, pos.y, pos.z)) - rt.height);
+			avgVariation += fabs(m_terrain->GetHeight(vector3d(pos.x - delta, pos.y, pos.z)) - rt.height);
+			avgVariation += fabs(m_terrain->GetHeight(vector3d(pos.x, pos.y, pos.z + delta)) - rt.height);
+			avgVariation += fabs(m_terrain->GetHeight(vector3d(pos.x, pos.y, pos.z - delta)) - rt.height);
+			avgVariation *= 0.25;
+			rt.heightVariation = invPlanetRadius + 0.625 * avgVariation;
+
+			const double citySize_m = CITY_ON_PLANET_RADIUS * 1.1;
+			double size = fabs(cos(std::min(citySize_m, 0.2 * planetRadius) / planetRadius)); // angle between city center/boundary = 2pi*city size/(perimeter great circle = 2pi r)
+			rt.outer = size; // city center pos and current point will be dotted, and compared against size
+			rt.inner = (1.0 - size)*0.5 + size;
+			rt.Type = 1;
+			rt.Valid = true;
+
+			m_positions.push_back(pos);
+			m_regionTypes.push_back(rt);
+		}
+	}
+
+	m_terrain->SetCityRegions(m_positions, m_regionTypes);
+}
 
 BaseSphere::~BaseSphere() {}
 

--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -38,7 +38,7 @@ public:
 	virtual void Update() override;
 	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
 
-	virtual double GetHeight(const vector3d &p) const override { return 0.0; }
+	virtual double GetHeight(const vector3d &p) const override final { return 0.0; }
 
 	// in sbody radii
 	virtual double GetMaxFeatureHeight() const override { return 0.0; }

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -36,7 +36,7 @@ public:
 	virtual void Update() override;
 	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
 
-	virtual double GetHeight(const vector3d &p) const override {
+	virtual double GetHeight(const vector3d &p) const override final {
 		const double h = m_terrain->GetHeight(p);
 #ifdef DEBUG
 		// XXX don't remove this. Fix your fractals instead

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -615,6 +615,59 @@ Terrain::~Terrain()
 {
 }
 
+// Set up region data for each of the system body's child surface starports
+void Terrain::SetCityRegions(const std::vector<vector3d> &positions, const std::vector<RegionType> &regionTypes)
+{
+	m_positions = positions;
+	m_regionTypes = regionTypes;
+}
+
+void Terrain::ApplySimpleHeightRegions(double &h, const vector3d &p) const
+{
+	const double dynamicRangeHeight = 60.0/m_planetRadius; //in radii
+	for (size_t i = 0, iEnd = m_positions.size(); i < iEnd; i++)
+	{
+		if (m_regionTypes[i].Valid)
+		{
+			const vector3d &pos = m_positions[i];
+			const RegionType &rt = m_regionTypes[i];
+			const double th = rt.height; // target height
+			if (pos.Dot(p) > rt.outer)
+			{
+				const double outer = rt.outer;
+				const double inner = rt.inner;
+
+				// maximum variation in height with respect to target height
+				const double delta_h = fabs(h-th);
+				const double neg = (h-th>0.0) ? 1.0 : -1.0;
+
+				// Make up an expression to compress delta_h: 
+				// Compress delta_h between 0 and 1
+				//    1.1 use compression of the form c = (delta_h+a)/(a+(delta_h+a)) (eqn. 1)
+				//    1.2 this gives c in the interval [0.5, 1] for delta_h [0, +inf] with c=0.5 at delta_h=0.
+				//  2.0 Use compressed_h = dynamic range*(sign(h-th)*(c-0.5)) (eqn. 2) to get h between th-0.5*dynamic range, th+0.5*dynamic range
+				
+				// Choosing a value for a
+				//    3.1 c [0.5, 0.8] occurs when delta_h [a to 3a] (3x difference) which is roughly the expressible range (above or below that the function changes slowly)
+				//    3.2 Find an expression for the expected variation and divide by around 3
+				
+				// It may become necessary calculate expected variation based on intermediate quantities generated (e.g. distribution fractals)
+				// or to store a per planet estimation of variation when fracdefs are calculated.
+				const double variationEstimate = rt.heightVariation;
+				const double a = variationEstimate*(1.0/3.0); // point 3.2 
+				
+				const double c = (delta_h+a)/(2.0*a+delta_h); // point 1.1 
+				const double compressed_h = dynamicRangeHeight*(neg*(c-0.5))+th;// point 2.0
+
+				#define blend(a,b,v) a*(1.0-v)+b*v
+				h = blend(h, compressed_h, Clamp((pos.Dot(p)-outer)/(inner-outer), 0.0, 1.0)); // blends from compressed height-terrain height as pos goes inner to outer
+				#undef blend
+				break; 
+			}
+		}
+	}
+}
+
 
 /**
  * Feature width means roughly one perlin noise blob or grain.

--- a/src/terrain/TerrainHeightAsteroid.cpp
+++ b/src/terrain/TerrainHeightAsteroid.cpp
@@ -22,7 +22,7 @@ TerrainHeightFractal<TerrainHeightAsteroid>::TerrainHeightFractal(const SystemBo
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightAsteroid>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightAsteroid>::GetHeightInner(const vector3d &p) const
 {
 	const double n = octavenoise(GetFracDef(0), 0.4, p) * dunes_octavenoise(GetFracDef(1), 0.5, p);
 

--- a/src/terrain/TerrainHeightAsteroid2.cpp
+++ b/src/terrain/TerrainHeightAsteroid2.cpp
@@ -25,7 +25,7 @@ TerrainHeightFractal<TerrainHeightAsteroid2>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightAsteroid2>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightAsteroid2>::GetHeightInner(const vector3d &p) const
 {
 	const double n = voronoiscam_octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 15.0 * octavenoise(GetFracDef(1), 0.5, p), p) *
 		0.75 * ridged_octavenoise(16.0 * octavenoise(GetFracDef(2), 0.275, p), 0.4 * ridged_octavenoise(GetFracDef(3), 0.4, p), 4.0 * octavenoise(GetFracDef(4), 0.35, p), p);

--- a/src/terrain/TerrainHeightAsteroid3.cpp
+++ b/src/terrain/TerrainHeightAsteroid3.cpp
@@ -22,7 +22,7 @@ TerrainHeightFractal<TerrainHeightAsteroid3>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightAsteroid3>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightAsteroid3>::GetHeightInner(const vector3d &p) const
 {
 	const double n = octavenoise(GetFracDef(0), 0.5, p) * ridged_octavenoise(GetFracDef(1), 0.5, p);
 

--- a/src/terrain/TerrainHeightAsteroid4.cpp
+++ b/src/terrain/TerrainHeightAsteroid4.cpp
@@ -25,7 +25,7 @@ TerrainHeightFractal<TerrainHeightAsteroid4>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightAsteroid4>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightAsteroid4>::GetHeightInner(const vector3d &p) const
 {
 	const double n = octavenoise(6, 0.2*octavenoise(GetFracDef(0), 0.3, p), 2.8*ridged_octavenoise(GetFracDef(1), 0.5, p), p) *
 		0.75*ridged_octavenoise(16*octavenoise(GetFracDef(2), 0.275, p), 0.3*octavenoise(GetFracDef(3), 0.4, p), 2.8*ridged_octavenoise(GetFracDef(4), 0.35, p), p);

--- a/src/terrain/TerrainHeightBarrenRock.cpp
+++ b/src/terrain/TerrainHeightBarrenRock.cpp
@@ -22,7 +22,7 @@ TerrainHeightFractal<TerrainHeightBarrenRock>::TerrainHeightFractal(const System
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeightInner(const vector3d &p) const
 {
 	/*return std::max(0.0, m_maxHeight * (octavenoise(GetFracDef(0), 0.5, p) +
 			GetFracDef(1).amplitude * crater_function(GetFracDef(1), p)));*/

--- a/src/terrain/TerrainHeightBarrenRock2.cpp
+++ b/src/terrain/TerrainHeightBarrenRock2.cpp
@@ -20,7 +20,7 @@ TerrainHeightFractal<TerrainHeightBarrenRock2>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightBarrenRock2>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightBarrenRock2>::GetHeightInner(const vector3d &p) const
 {
 
 	double n = billow_octavenoise(16, 0.3*octavenoise(8, 0.4, 2.5, p),Clamp(5.0*ridged_octavenoise(8, 0.377, 4.0, p), 1.0, 5.0), p);

--- a/src/terrain/TerrainHeightBarrenRock3.cpp
+++ b/src/terrain/TerrainHeightBarrenRock3.cpp
@@ -19,7 +19,7 @@ TerrainHeightFractal<TerrainHeightBarrenRock3>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightBarrenRock3>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightBarrenRock3>::GetHeightInner(const vector3d &p) const
 {
 
 	float n = 0.07*voronoiscam_octavenoise(12, Clamp(fabs(0.165 - (0.38*river_octavenoise(12, 0.4, 2.5, p))), 0.15, 0.5),Clamp(8.0*billow_octavenoise(12, 0.37, 4.0, p), 0.5, 9.0), p);

--- a/src/terrain/TerrainHeightEllipsoid.cpp
+++ b/src/terrain/TerrainHeightEllipsoid.cpp
@@ -51,7 +51,7 @@ TerrainHeightFractal<TerrainHeightEllipsoid>::TerrainHeightFractal(const SystemB
 //                                R(t) = ar/sqrt(x_^2+ar^2*y_^2) (eqn. 9) (substituting using eqn. 7 and eqn. 8)
 
 template <>
-double TerrainHeightFractal<TerrainHeightEllipsoid>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightEllipsoid>::GetHeightInner(const vector3d &p) const
 {
 	const double ar = m_minBody.m_aspectRatio;
 	// x_^2 = (p.z^2+p.x^2) (eqn. 5)

--- a/src/terrain/TerrainHeightFlat.cpp
+++ b/src/terrain/TerrainHeightFlat.cpp
@@ -12,7 +12,7 @@ TerrainHeightFractal<TerrainHeightFlat>::TerrainHeightFractal(const SystemBody *
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightFlat>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightFlat>::GetHeightInner(const vector3d &p) const
 {
 	return 0.0;
 }

--- a/src/terrain/TerrainHeightHillsCraters.cpp
+++ b/src/terrain/TerrainHeightHillsCraters.cpp
@@ -23,7 +23,7 @@ TerrainHeightFractal<TerrainHeightHillsCraters>::TerrainHeightFractal(const Syst
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsCraters>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightHillsCraters>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightHillsCraters2.cpp
+++ b/src/terrain/TerrainHeightHillsCraters2.cpp
@@ -27,7 +27,7 @@ TerrainHeightFractal<TerrainHeightHillsCraters2>::TerrainHeightFractal(const Sys
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsCraters2>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightHillsCraters2>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightHillsDunes.cpp
+++ b/src/terrain/TerrainHeightHillsDunes.cpp
@@ -28,7 +28,7 @@ TerrainHeightFractal<TerrainHeightHillsDunes>::TerrainHeightFractal(const System
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsDunes>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightHillsDunes>::GetHeightInner(const vector3d &p) const
 {
 	double continents = ridged_octavenoise(GetFracDef(3), 0.65, p) * (1.0-m_sealevel) - (m_sealevel*0.1);
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightHillsNormal.cpp
+++ b/src/terrain/TerrainHeightHillsNormal.cpp
@@ -29,7 +29,7 @@ TerrainHeightFractal<TerrainHeightHillsNormal>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsNormal>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightHillsNormal>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(3-m_fracnum), 0.65, p) * (1.0-m_sealevel) - (m_sealevel*0.1);
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightHillsRidged.cpp
+++ b/src/terrain/TerrainHeightHillsRidged.cpp
@@ -27,7 +27,7 @@ TerrainHeightFractal<TerrainHeightHillsRidged>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsRidged>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightHillsRidged>::GetHeightInner(const vector3d &p) const
 {
 	double continents = ridged_octavenoise(GetFracDef(3), 0.65, p) * (1.0-m_sealevel) - (m_sealevel*0.1);
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightHillsRivers.cpp
+++ b/src/terrain/TerrainHeightHillsRivers.cpp
@@ -27,7 +27,7 @@ TerrainHeightFractal<TerrainHeightHillsRivers>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsRivers>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightHillsRivers>::GetHeightInner(const vector3d &p) const
 {
 	double continents = river_octavenoise(GetFracDef(3), 0.65, p) * (1.0-m_sealevel) - (m_sealevel*0.1);
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightMapped.cpp
+++ b/src/terrain/TerrainHeightMapped.cpp
@@ -28,7 +28,7 @@ TerrainHeightFractal<TerrainHeightMapped>::TerrainHeightFractal(const SystemBody
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMapped>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMapped>::GetHeightInner(const vector3d &p) const
 {
     // This is all used for Earth and Earth alone
 
@@ -138,6 +138,6 @@ double TerrainHeightFractal<TerrainHeightMapped>::GetHeight(const vector3d &p) c
 			v += h;
 		}
 
-		return v<0 ? 0 : (v/m_planetRadius);
+		return v<0 ? 0 : (v / m_planetRadius);
 	}
 }

--- a/src/terrain/TerrainHeightMapped2.cpp
+++ b/src/terrain/TerrainHeightMapped2.cpp
@@ -14,9 +14,8 @@ TerrainHeightFractal<TerrainHeightMapped2>::TerrainHeightFractal(const SystemBod
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMapped2>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMapped2>::GetHeightInner(const vector3d &p) const
 {
-
 	double latitude = -asin(p.y);
 	if (p.y < -1.0) latitude = -0.5*M_PI;
 	if (p.y > 1.0) latitude = 0.5*M_PI;
@@ -80,8 +79,6 @@ double TerrainHeightFractal<TerrainHeightMapped2>::GetHeight(const vector3d &p) 
 		h -= 0.09;
 
 		return (h > 0.0 ? h : 0.0);
-
 	}
-
 }
 

--- a/src/terrain/TerrainHeightMountainsCraters.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters.cpp
@@ -28,7 +28,7 @@ TerrainHeightFractal<TerrainHeightMountainsCraters>::TerrainHeightFractal(const 
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsCraters>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMountainsCraters>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightMountainsCraters2.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters2.cpp
@@ -30,7 +30,7 @@ TerrainHeightFractal<TerrainHeightMountainsCraters2>::TerrainHeightFractal(const
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsCraters2>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMountainsCraters2>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightMountainsNormal.cpp
+++ b/src/terrain/TerrainHeightMountainsNormal.cpp
@@ -24,7 +24,7 @@ TerrainHeightFractal<TerrainHeightMountainsNormal>::TerrainHeightFractal(const S
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsNormal>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMountainsNormal>::GetHeightInner(const vector3d &p) const
 	//This is among the most complex of terrains, so I'll use this as an example:
 {
 	//We need a continental pattern to place our noise onto, the 0.7*ridged_octavnoise..... is important here

--- a/src/terrain/TerrainHeightMountainsRidged.cpp
+++ b/src/terrain/TerrainHeightMountainsRidged.cpp
@@ -29,7 +29,7 @@ TerrainHeightFractal<TerrainHeightMountainsRidged>::TerrainHeightFractal(const S
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsRidged>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMountainsRidged>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightMountainsRivers.cpp
+++ b/src/terrain/TerrainHeightMountainsRivers.cpp
@@ -27,7 +27,7 @@ TerrainHeightFractal<TerrainHeightMountainsRivers>::TerrainHeightFractal(const S
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsRivers>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMountainsRivers>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.7*
 		ridged_octavenoise(GetFracDef(8), 0.58, p), p) - m_sealevel*0.65;

--- a/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
@@ -34,7 +34,7 @@ TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::TerrainHeightFractal(
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightMountainsVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsVolcano.cpp
@@ -34,7 +34,7 @@ TerrainHeightFractal<TerrainHeightMountainsVolcano>::TerrainHeightFractal(const 
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsVolcano>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightMountainsVolcano>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightRuggedDesert.cpp
+++ b/src/terrain/TerrainHeightRuggedDesert.cpp
@@ -12,7 +12,7 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeightFractalName() const { return "RuggedDesert"; }
 
 template <>
-double TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;// + (cliff_function(GetFracDef(7), p)*0.5);
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightRuggedLava.cpp
+++ b/src/terrain/TerrainHeightRuggedLava.cpp
@@ -35,7 +35,7 @@ TerrainHeightFractal<TerrainHeightRuggedLava>::TerrainHeightFractal(const System
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightRuggedLava>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightRuggedLava>::GetHeightInner(const vector3d &p) const
 {
 	double continents = octavenoise(GetFracDef(0), Clamp(0.725-(m_sealevel/2), 0.1, 0.725), p) - m_sealevel;
 	if (continents < 0) return 0;

--- a/src/terrain/TerrainHeightWaterSolid.cpp
+++ b/src/terrain/TerrainHeightWaterSolid.cpp
@@ -27,7 +27,7 @@ TerrainHeightFractal<TerrainHeightWaterSolid>::TerrainHeightFractal(const System
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightWaterSolid>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightWaterSolid>::GetHeightInner(const vector3d &p) const
 {
 	double continents = 0.7*river_octavenoise(GetFracDef(2), 0.5, p)-m_sealevel;
 	continents = GetFracDef(0).amplitude * ridged_octavenoise(GetFracDef(0),

--- a/src/terrain/TerrainHeightWaterSolidCanyons.cpp
+++ b/src/terrain/TerrainHeightWaterSolidCanyons.cpp
@@ -30,7 +30,7 @@ TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::TerrainHeightFractal(const
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::GetHeight(const vector3d &p) const
+double TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::GetHeightInner(const vector3d &p) const
 {
 	double continents = 0.7*river_octavenoise(GetFracDef(2), 0.5, p)-m_sealevel;
 	continents = GetFracDef(0).amplitude * ridged_octavenoise(GetFracDef(0),


### PR DESCRIPTION
This is an old idea and variation on the initial implementation (#1476) which has long ago fallen out of date.

It's purpose is to flatten the terrain within the radius of a city then falloff/blend into the surrounding terrain and I thought it might be of interest to @joonicks 

This can look ok in some places:
![screenshot-20180109-233047](https://user-images.githubusercontent.com/825083/34748714-c22eb9f4-f595-11e7-965e-f4a9920495ad.png)

and then very much not in others:
![screenshot-20180109-233320](https://user-images.githubusercontent.com/825083/34748717-ca8b9bb2-f595-11e7-9212-4d640554e3c6.png)
![screenshot-20180109-233446](https://user-images.githubusercontent.com/825083/34748721-ccd51d76-f595-11e7-9a58-f787418f947d.png)

-Change GetHeight to GetHeightInner for implementations.
-Add ApplySimpleHeightRegions call it for all uses of GetHeight.
-Initialise cities within ctor of BaseSphere.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

