### PR TITLE
Fudge-fix projectile ray tracing

### DIFF
--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -252,7 +252,8 @@ void Projectile::StaticUpdate(const float timeStep)
 {
 	PROFILE_SCOPED()
 	CollisionContact c;
-	vector3d vel = (m_baseVel+m_dirVel) * timeStep;
+	// Collision spaces don't store velocity, so dirvel-only is still wrong but less awful than dirvel+basevel
+	vector3d vel = m_dirVel * timeStep;
 	GetFrame()->GetCollisionSpace()->TraceRay(GetPosition(), vel.Normalized(), vel.Length(), &c);
 
 	if (c.userData1) {


### PR DESCRIPTION
**Issue**
Projectile collisions against small objects are extremely unreliable when the firer has significant frame-relative velocity. To demonstrate, use the Earth start, thrust outwards for ~500km or so, turn engines off and then spawn a small ship at 100m (eg. `Space.SpawnShipNear("kanara", Game.player, 0.1, 0.1)`). Try shooting it at various ranges. Some will be more reliable than others (17m cycle).

This is caused by CollisionSpace not storing or using the velocity of target objects. Essentially it takes a snapshot of object positions and checks the same ray against each. For correct behaviour, you'd need to test a different ray against each target, because the target-relative velocity of the projectile would vary.

Using TraceRay with basevel+dirvel ray direction is particularly bad: basevel includes the frame-relative velocity of the firing ship, and it's not countered by the velocity of the target ship. Hence the effective ray direction is frequently orthogonal to the apparent direction of travel.

**Fudge**
This switches the projectile code from basevel+dirvel to only using dirvel for the rays. This is not strictly correct (average error ~8m for targets with very high lateral velocity), but it's much less obviously wrong than basevel+dirvel and doesn't require structural changes.

**Side effects**
This should make deep-space combat far more dangerous, or at least more reliably dangerous.
