### PR TITLE
Route planner optimisations

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -212,7 +212,7 @@ end
 HyperdriveType.GetDuration = function (self, ship, distance, range_max)
 	range_max = range_max or self:GetMaximumRange(ship)
 	local hyperclass = self.capabilities.hyperclass
-	return 0.36*distance^2/(range_max*hyperclass) * (3600*24*math.sqrt(ship.staticMass + ship.fuelMassLeft))
+	return 0.36*distance^2/(range_max*hyperclass) * (86400*math.sqrt(ship.staticMass + ship.fuelMassLeft))
 end
 
 -- range_max is optional, distance defaults to the maximal range.

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -1166,7 +1166,8 @@ static int l_engine_sector_map_auto_route(lua_State *l)
 	SystemPath current_path = sv->GetCurrent();
 	SystemPath target_path = sv->GetSelected();
 
-	std::vector<SystemPath> route = sv->AutoRoute(current_path, target_path);
+	std::vector<SystemPath> route;
+	sv->AutoRoute(route, current_path, target_path);
 	sv->ClearRoute();
 	for (auto it = route.begin(); it != route.end(); it++) {
 		sv->AddToRoute(*it);

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -1167,7 +1167,7 @@ static int l_engine_sector_map_auto_route(lua_State *l)
 	SystemPath target_path = sv->GetSelected();
 
 	std::vector<SystemPath> route;
-	sv->AutoRoute(route, current_path, target_path);
+	sv->AutoRoute(current_path, target_path, route);
 	sv->ClearRoute();
 	for (auto it = route.begin(); it != route.end(); it++) {
 		sv->AddToRoute(*it);

--- a/src/MathUtil.cpp
+++ b/src/MathUtil.cpp
@@ -218,7 +218,7 @@ namespace MathUtil {
 
 	// basic distince from a line segment as described here:
 	// http://paulbourke.net/geometry/pointline/
-	float DistanceFromLine(const vector3f& start, const vector3f& end, const vector3f& pos, bool& isWithinLineSegment)
+	float DistanceFromLineSegment(const vector3f& start, const vector3f& end, const vector3f& pos, bool& isWithinLineSegment)
 	{
 		const float magnitude = (end-start).Length();
 		float t = Dot((pos - start), (end - start)) / (magnitude * magnitude) ;
@@ -230,6 +230,18 @@ namespace MathUtil {
 		} else {
 			isWithinLineSegment = true;
 		}
+		// convert the time t to a vector to use in intersection calculation
+		vector3f tv(t,t,t);
+		vector3f intersect(start + tv * (end - start));
+
+		return (intersect-pos).Length();
+	}
+
+	float DistanceFromLine(const vector3f& start, const vector3f& end, const vector3f& pos)
+	{
+		const float magnitude = (end-start).Length();
+		const float t = Dot((pos - start), (end - start)) / (magnitude * magnitude) ;
+
 		// convert the time t to a vector to use in intersection calculation
 		vector3f tv(t,t,t);
 		vector3f intersect(start + tv * (end - start));
@@ -271,6 +283,12 @@ namespace MathUtil {
 			false,// no
 			false// no
 		};
+		static const bool RESLINE[TotalNum] = {
+			true, // no
+			true,// yes
+			false,// no
+			true// no
+		};
 
 		// Just working with a fixed distance.
 		static const float triggerSoundDistance = 6.0f;
@@ -278,11 +296,19 @@ namespace MathUtil {
 		bool success = true;
 		for( int i=0; i<TotalNum; i++ ) {
 			bool isWithinLineSegment = false;
-			const float dist = DistanceFromLine(E[i], H[i], P[i], isWithinLineSegment);
+			const float dist = DistanceFromLineSegment(E[i], H[i], P[i], isWithinLineSegment);
 
 			// Compare against the expected result and accumulate
 			success &= (RES[i] == (isWithinLineSegment && dist <= triggerSoundDistance));
 		}
+
+		for( int i=0; i<TotalNum; i++ ) {
+			const float dist = DistanceFromLine(E[i], H[i], P[i]);
+
+			// Compare against the expected result and accumulate
+			success &= (RESLINE[i] == (dist <= triggerSoundDistance));
+		}
+		
 		Output("TestDistanceFromLine successful? = %s\n", success ? "yes" : "no");
 		return success;
 	}

--- a/src/MathUtil.h
+++ b/src/MathUtil.h
@@ -36,7 +36,8 @@ namespace MathUtil {
 	matrix3x3f Transpose(const matrix3x3f &);
 
 	// distince from a line segment:
-	float DistanceFromLine(const vector3f& start, const vector3f& end, const vector3f& pos, bool& isWithinLineSegment);
+	float DistanceFromLineSegment(const vector3f& start, const vector3f& end, const vector3f& pos, bool& isWithinLineSegment);
+	float DistanceFromLine(const vector3f& start, const vector3f& end, const vector3f& pos);
 
 //#define TEST_MATHUTIL
 #ifdef TEST_MATHUTIL

--- a/src/MathUtil.h
+++ b/src/MathUtil.h
@@ -34,6 +34,14 @@ namespace MathUtil {
 	// matrix3x3f utility functions
 	matrix3x3f Inverse(const matrix3x3f &);
 	matrix3x3f Transpose(const matrix3x3f &);
+
+	// distince from a line segment:
+	float DistanceFromLine(const vector3f& start, const vector3f& end, const vector3f& pos, bool& isWithinLineSegment);
+
+//#define TEST_MATHUTIL
+#ifdef TEST_MATHUTIL
+	bool TestDistanceFromLine();
+#endif
 }
 
 #endif

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -69,7 +69,7 @@ public:
 	bool RemoveRouteItem(const std::vector<SystemPath>::size_type element);
 	void ClearRoute();
 	std::vector<SystemPath> GetRoute();
-	void AutoRoute(std::vector<SystemPath> &outRoute, const SystemPath &start, const SystemPath &target) const;
+	void AutoRoute(const SystemPath &start, const SystemPath &target, std::vector<SystemPath> &outRoute) const;
 	void SetDrawRouteLines(bool value) { m_drawRouteLines = value; }
 
 

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -69,7 +69,7 @@ public:
 	bool RemoveRouteItem(const std::vector<SystemPath>::size_type element);
 	void ClearRoute();
 	std::vector<SystemPath> GetRoute();
-	std::vector<SystemPath> AutoRoute(const SystemPath &start, const SystemPath &target);
+	void AutoRoute(std::vector<SystemPath> &outRoute, const SystemPath &start, const SystemPath &target) const;
 	void SetDrawRouteLines(bool value) { m_drawRouteLines = value; }
 
 

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -140,6 +140,8 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 	const int sy = sector->sy;
 	const int sz = sector->sz;
 	const int customCount = static_cast<Uint32>(sector->m_systems.size());
+	const int dist = isqrt(1 + sx*sx + sy*sy + sz*sz);
+	const int freqSqrt = isqrt(1 + sx * sx + sy * sy);
 
 	const int numSystems = (rng.Int32(4,20) * galaxy->GetSectorDensity(sx, sy, sz)) >> 8;
 	sector->m_systems.reserve(numSystems);
@@ -167,14 +169,12 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 		 * ~500ly - ~700ly (65-90 sectors): gradual
 		 * ~700ly+: unexplored
 		 */
-		const int dist = isqrt(1 + sx*sx + sy*sy + sz*sz);
 		if (((dist <= 90) && ( dist <= 65 || rng.Int32(dist) <= 40)) || galaxy->GetFactions()->IsHomeSystem(SystemPath(sx, sy, sz, customCount + i)))
 			s.m_explored = StarSystem::eEXPLORED_AT_START;
 		else
 			s.m_explored = StarSystem::eUNEXPLORED;
 
 		// Frequencies are low enough that we probably don't need this anymore.
-		const int freqSqrt = isqrt(1 + sx * sx + sy * sy);
 		if (freqSqrt > 10)
 		{
 			const Uint32 weight = rng.Int32(1000000);

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -141,7 +141,8 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 	const int sz = sector->sz;
 	const int customCount = static_cast<Uint32>(sector->m_systems.size());
 
-	int numSystems = (rng.Int32(4,20) * galaxy->GetSectorDensity(sx, sy, sz)) >> 8;
+	const int numSystems = (rng.Int32(4,20) * galaxy->GetSectorDensity(sx, sy, sz)) >> 8;
+	sector->m_systems.reserve(numSystems);
 
 	for (int i=0; i<numSystems; i++) {
 		Sector::System s(sector.Get(), sx, sy, sz, customCount + i);
@@ -161,25 +162,22 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 		s.m_pos.y = rng.Double(Sector::SIZE);
 		s.m_pos.z = rng.Double(Sector::SIZE);
 
-		s.m_seed = 0;
-		s.m_customSys = 0;
-
 		/*
 		 * 0 - ~500ly from sol: explored
 		 * ~500ly - ~700ly (65-90 sectors): gradual
 		 * ~700ly+: unexplored
 		 */
-		int dist = isqrt(1 + sx*sx + sy*sy + sz*sz);
+		const int dist = isqrt(1 + sx*sx + sy*sy + sz*sz);
 		if (((dist <= 90) && ( dist <= 65 || rng.Int32(dist) <= 40)) || galaxy->GetFactions()->IsHomeSystem(SystemPath(sx, sy, sz, customCount + i)))
 			s.m_explored = StarSystem::eEXPLORED_AT_START;
 		else
 			s.m_explored = StarSystem::eUNEXPLORED;
 
-		Uint32 weight = rng.Int32(1000000);
-
 		// Frequencies are low enough that we probably don't need this anymore.
-		if (isqrt(1+sx*sx+sy*sy) > 10)
+		const int freqSqrt = isqrt(1 + sx * sx + sy * sy);
+		if (freqSqrt > 10)
 		{
+			const Uint32 weight = rng.Int32(1000000);
 			if (weight < 1) {
 				s.m_starType[0] = SystemBody::TYPE_STAR_IM_BH;  // These frequencies are made up
 			} else if (weight < 3) {
@@ -252,6 +250,7 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 				s.m_starType[0] = SystemBody::TYPE_BROWN_DWARF;
 			}
 		} else {
+			const Uint32 weight = rng.Int32(1000000);
 			if (weight < 100) { // should be 1 but that is boring
 				s.m_starType[0] = SystemBody::TYPE_STAR_O;
 			} else if (weight < 1300) {
@@ -284,10 +283,9 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 
 		if ((s.m_starType[0] <= SystemBody::TYPE_STAR_A) && (rng.Int32(10)==0)) {
 			// make primary a giant. never more than one giant in a system
-			// while
-			if (isqrt(1+sx*sx+sy*sy) > 10)
+			if (freqSqrt > 10)
 			{
-				weight = rng.Int32(1000);
+				const Uint32 weight = rng.Int32(1000);
 				if (weight >= 999) {
 					s.m_starType[0] = SystemBody::TYPE_STAR_B_HYPER_GIANT;
 				} else if (weight >= 998) {
@@ -313,7 +311,7 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 				} else {
 					s.m_starType[0] = SystemBody::TYPE_STAR_M_GIANT;
 				}
-			} else if (isqrt(1+sx*sx+sy*sy) > 5) s.m_starType[0] = SystemBody::TYPE_STAR_M_GIANT;
+			} else if (freqSqrt > 5) s.m_starType[0] = SystemBody::TYPE_STAR_M_GIANT;
 			else s.m_starType[0] = SystemBody::TYPE_STAR_M;
 
 			//Output("%d: %d%\n", sx, sy);


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
The route planner (@The-EG) is great but it can be a little bit slow when you're plotting a route over hundreds of light years.

- [x] Avoid calls to GetSector by testing is the sectors in question can be reached by the player
- [x] Limit the total Sectors added as nodes using a tighter bounding volume
- [x] Limit the nodes to within a point-point cylinder/range

There's a few other minor optimisations that snuck in whilst I was doing stuff too.

<!-- Please make sure you've read documentation on contributing -->

