### PR TITLE
Set the user data for city geom objects.

### DIFF
--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -299,6 +299,7 @@ CityOnPlanet::CityOnPlanet(Planet *planet, SpaceStation *station, const Uint32 s
 			const CollMesh* cmesh = bt.collMesh.Get(); // collision mesh
 			
 			Geom *geom = new Geom(cmesh->GetGeomTree());
+			geom->SetUserData(static_cast<void*>(this));
 
 			// rotate the building to face a random direction
 			int32_t orient = rand.Int32(4);


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Fixes #4274 by setting the user data on city created `Geom` objects.

ping @jaj22 @CampNowhere 

I think that this supercedes #4275 by fixing the root cause rather than treating the problem but it might be worth merging both and adding an error or warning about the cause of #4275 as a message.
<!-- Please make sure you've read documentation on contributing -->

