### PR TITLE
Minor optimisations around avoiding isqrt

### DIFF
--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -9,6 +9,8 @@
 #include "Factions.h"
 #include "GameSaveError.h"
 
+#define Square(x) ((x)*(x))
+
 static const unsigned int SYS_NAME_FRAGS = 32;
 static const char *sys_names[SYS_NAME_FRAGS] =
 { "en", "la", "can", "be", "and", "phi", "eth", "ol", "ve", "ho", "a",
@@ -17,11 +19,10 @@ static const char *sys_names[SYS_NAME_FRAGS] =
 
 bool SectorCustomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<Sector> sector, GalaxyGenerator::SectorConfig* config)
 {
-	PROFILE_SCOPED()
-
 	const int sx = sector->sx;
 	const int sy = sector->sy;
 	const int sz = sector->sz;
+	const Sint64 dist = (1 + sx*sx + sy*sy + sz*sz);
 
 	if ((sx >= -m_customOnlyRadius) && (sx <= m_customOnlyRadius-1) &&
 		(sy >= -m_customOnlyRadius) && (sy <= m_customOnlyRadius-1) &&
@@ -49,8 +50,7 @@ bool SectorCustomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 			 * ~500ly - ~700ly (65-90 sectors): gradual
 			 * ~700ly+: unexplored
 			 */
-			int dist = isqrt(1 + sx*sx + sy*sy + sz*sz);
-			if (((dist <= 90) && ( dist <= 65 || rng.Int32(dist) <= 40)) || galaxy->GetFactions()->IsHomeSystem(SystemPath(sx, sy, sz, sysIdx)))
+			if (((dist <= Square(90)) && ( dist <= Square(65) || rng.Int32(dist) <= Square(40))) || galaxy->GetFactions()->IsHomeSystem(SystemPath(sx, sy, sz, sysIdx)))
 				s.m_explored = StarSystem::eEXPLORED_AT_START;
 			else
 				s.m_explored = StarSystem::eUNEXPLORED;
@@ -67,7 +67,6 @@ bool SectorCustomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 
 const std::string SectorRandomSystemsGenerator::GenName(RefCountedPtr<Galaxy> galaxy, const Sector& sec, Sector::System &sys, int si, Random &rng)
 {
-	PROFILE_SCOPED()
 	std::string name;
 	const int sx = sec.sx;
 	const int sy = sec.sy;
@@ -140,8 +139,8 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 	const int sy = sector->sy;
 	const int sz = sector->sz;
 	const int customCount = static_cast<Uint32>(sector->m_systems.size());
-	const int dist = isqrt(1 + sx*sx + sy*sy + sz*sz);
-	const int freqSqrt = isqrt(1 + sx * sx + sy * sy);
+	const Sint64 dist = (1 + sx*sx + sy*sy + sz*sz);
+	const Sint64 freq = (1 + sx * sx + sy * sy);
 
 	const int numSystems = (rng.Int32(4,20) * galaxy->GetSectorDensity(sx, sy, sz)) >> 8;
 	sector->m_systems.reserve(numSystems);
@@ -175,7 +174,7 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 			s.m_explored = StarSystem::eUNEXPLORED;
 
 		// Frequencies are low enough that we probably don't need this anymore.
-		if (freqSqrt > 10)
+		if (freq > Square(10))
 		{
 			const Uint32 weight = rng.Int32(1000000);
 			if (weight < 1) {
@@ -283,7 +282,7 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 
 		if ((s.m_starType[0] <= SystemBody::TYPE_STAR_A) && (rng.Int32(10)==0)) {
 			// make primary a giant. never more than one giant in a system
-			if (freqSqrt > 10)
+			if (freq > Square(10))
 			{
 				const Uint32 weight = rng.Int32(1000);
 				if (weight >= 999) {
@@ -311,7 +310,7 @@ bool SectorRandomSystemsGenerator::Apply(Random& rng, RefCountedPtr<Galaxy> gala
 				} else {
 					s.m_starType[0] = SystemBody::TYPE_STAR_M_GIANT;
 				}
-			} else if (freqSqrt > 5) s.m_starType[0] = SystemBody::TYPE_STAR_M_GIANT;
+			} else if (freq > Square(5)) s.m_starType[0] = SystemBody::TYPE_STAR_M_GIANT;
 			else s.m_starType[0] = SystemBody::TYPE_STAR_M;
 
 			//Output("%d: %d%\n", sx, sy);

--- a/src/utils.h
+++ b/src/utils.h
@@ -70,6 +70,8 @@ std::string format_duration(double seconds);
 
 static inline Sint64 isqrt(Sint64 a)
 {
+	// replace with cast from sqrt below which is between x7.3 (win32, Debug) & x15 (x64, Release) times faster
+#if 0
 	Sint64 ret=0;
 	Sint64 s;
 	Sint64 ret_sq=-a-1;
@@ -83,7 +85,10 @@ static inline Sint64 isqrt(Sint64 a)
 		}
 	}
 	return ret;
-}
+#else
+	return static_cast<int64_t>(sqrt(static_cast<double>(a)));
+#endif
+}  
 
 namespace Graphics {
     struct ScreendumpState;

--- a/src/utils.h
+++ b/src/utils.h
@@ -71,10 +71,14 @@ std::string format_duration(double seconds);
 static inline Sint64 isqrt(Sint64 a)
 {
 	// replace with cast from sqrt below which is between x7.3 (win32, Debug) & x15 (x64, Release) times faster
-#if 0
+	return static_cast<int64_t>(sqrt(static_cast<double>(a)));
+}
+
+static inline Sint64 isqrt(fixed v)
+{
 	Sint64 ret=0;
 	Sint64 s;
-	Sint64 ret_sq=-a-1;
+	Sint64 ret_sq = -v.v - 1;
 	for(s=62; s>=0; s-=2){
 		Sint64 b;
 		ret+= ret;
@@ -85,9 +89,6 @@ static inline Sint64 isqrt(Sint64 a)
 		}
 	}
 	return ret;
-#else
-	return static_cast<int64_t>(sqrt(static_cast<double>(a)));
-#endif
 }  
 
 namespace Graphics {


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Two sets of really low level optimisations:
- Avoid using isqrt at all wherever possible by using the square of the comparison value instead.
- Replace soft isqrt with cast from sqrt which is 7.3 to x15 times faster.

Suggested in a post-commit [comment](https://github.com/pioneerspacesim/pioneer/commit/208065b95a187c8da10f6bb47cfd7eb21f2bd3e8#commitcomment-27075091) by @joonicks 👍 
<!-- Please make sure you've read documentation on contributing -->

