### PR TITLE
Fix broken Lua->C seed transfers in Face & CustomSystem

### DIFF
--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -160,7 +160,7 @@ static int l_csb_radius_km(lua_State *L)
 static int l_csb_seed(lua_State *L)
 {
 	CustomSystemBody *csb = l_csb_check(L, 1);
-	csb->seed = luaL_checkinteger(L, 2);
+	csb->seed = luaL_checkunsigned(L, 2);
 	csb->want_rand_seed = false;
 	lua_settop(L, 1);
 	return 1;
@@ -378,7 +378,7 @@ static int l_csys_new(lua_State *L)
 static int l_csys_seed(lua_State *L)
 {
 	CustomSystem *cs = l_csys_check(L, 1);
-	cs->seed = luaL_checkinteger(L, 2);
+	cs->seed = luaL_checkunsigned(L, 2);
 	lua_settop(L, 1);
 	return 1;
 }

--- a/src/gameui/LuaFace.cpp
+++ b/src/gameui/LuaFace.cpp
@@ -38,7 +38,7 @@ public:
 		Uint32 seed = 0;
 
 		if (lua_gettop(l) > 2 && !lua_isnil(l, 3))
-			seed = luaL_checkinteger(l, 3);
+			seed = luaL_checkunsigned(l, 3);
 
 		LuaObject<Face>::PushToLua(new Face(c, flags, seed));
 		return 1;


### PR DESCRIPTION
Some RNG seed values are being transferred using checkinteger from Lua to C. This gives different results on x86 vs x64 (because lua_Integer is a different type), and potentially maps half the uint32 seed range to the same value. Face and CustomSystem are the only examples I found but there may be others.

Achernar uses custom system seeds > INT_MAX, so that was already different on x86 vs x64. According to #4295, the face generator was generating the same face half the time since the Lua-side seeds were expanded to 32-bit in a previous patch.
