### PR TITLE
Fix crash when opening main menu in hyperspace (#4302)

### DIFF
--- a/data/pigui/modules/hyperjump-planner.lua
+++ b/data/pigui/modules/hyperjump-planner.lua
@@ -226,14 +226,12 @@ end -- showHyperJumpPlannerWindow
 
 local function displayHyperJumpPlanner()
     player = Game.player
-    current_system = Game.system
-    current_path = current_system.path
-
-    current_fuel = player:CountEquip(Equipment.cargo.hydrogen,"cargo")
-
     local current_view = Game.CurrentView()
 
-    if current_view == "sector" then
+    if current_view == "sector" and not Game.InHyperspace() then
+		current_system = Game.system
+		current_path = current_system.path
+		current_fuel = player:CountEquip(Equipment.cargo.hydrogen,"cargo")
         map_selected_path = Engine.GetSectorMapSelectedSystemPath()
         hyperjump_route = Engine.SectorMapGetRoute()
         route_jumps = Engine.SectorMapGetRouteSize()


### PR DESCRIPTION
Fixes #4302

Only initialize the hyperjump planner variables if
  the player is not currently in hyperspace.

