### PR TITLE
Fix new ImGui volume settings sliders

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1505,7 +1505,7 @@
    },
    "START_AT_BARNARDS_STAR_DESC": {
 	  "description" : "",
-	  "message" : "This is a difficult start from the System Administration Resting prision station."
+	  "message" : "This is a difficult start from the System Administration Resting prison station."
    },
    "START_AT_EARTH" : {
       "description" : "",

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -329,23 +329,23 @@ local function showSoundOptions()
 	local effectsMuted = Engine.GetEffectsMuted()
 	local effectsLevel = Engine.GetEffectsVolume()*100
 
-	c,masterMuted = checkbox(lui.MUTE, masterMuted)
+	c,masterMuted = checkbox(lui.MUTE.."##master", masterMuted)
 	if c then Engine.SetMasterMuted(masterMuted) end
 	ui.sameLine()
 	c,masterLevel = slider(lui.MASTER_VOL, masterLevel, 0, 100)
-	if c then Engine.SetMasterVolume(masterLevel*100) end
+	if c then Engine.SetMasterVolume(masterLevel/100) end
 
-	c,musicMuted = checkbox(lui.MUTE, musicMuted)
-	if c then Engine.SetMasterMuted(musicMuted) end
+	c,musicMuted = checkbox(lui.MUTE.."##music", musicMuted)
+	if c then Engine.SetMusicMuted(musicMuted) end
 	ui.sameLine()
 	c,musicLevel = slider(lui.MUSIC, musicLevel, 0, 100)
-	if c then Engine.SetMasterVolume(musicLevel*100) end
+	if c then Engine.SetMusicVolume(musicLevel/100) end
 
-	c,effectsMuted = checkbox(lui.MUTE, effectsMuted)
-	if c then Engine.SetMasterMuted(effectsMuted) end
+	c,effectsMuted = checkbox(lui.MUTE.."##effects", effectsMuted)
+	if c then Engine.SetEffectsMuted(effectsMuted) end
 	ui.sameLine()
 	c,effectsLevel = slider(lui.EFFECTS, effectsLevel, 0, 100)
-	if c then Engine.SetMasterVolume(effectsLevel*100) end
+	if c then Engine.SetEffectsVolume(effectsLevel/100) end
 end
 
 local function showLanguageOptions()


### PR DESCRIPTION
Volume sliders now actually alter the volumes (and mute buttons also work!).

Also corrected the spelling of 'prison' in the start at Barnard's Star description.


