### PR TITLE
Clarify tooltip, regarding sign of approach to target, closes #4206

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -560,8 +560,8 @@
       "message" : "Distance to the surface of the frame of reference"
    },
    "HUD_SPEED_OF_APPROACH_TO_TARGET" : {
-       "description" : "Tooltip: The speed of approach towards the target.",
-       "message" : "The speed of approach towards the target"
+       "description" : "Tooltip: The speed of approach relative to target.",
+       "message" : "The speed of approach relative to target"
    },
    "HUD_SPEED_OF_APPROACH_TO_FRAME" : {
        "description" : "Tooltip: The speed of approach towards the frame of reference.",


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

People seem to agree that 
1. negative speed relative target is most intuitive
2. but tooltip is counter intuitive