### PR TITLE
Fix startup crash, m_prop was null

### DIFF
--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -45,9 +45,9 @@ DynamicBody::DynamicBody()
 void DynamicBody::AddFeature( Feature f ) {
 	m_features[f] = true;
 	if(f == Feature::PROPULSION && m_propulsion == nullptr) {
-		m_propulsion = new Propulsion();
+		m_propulsion.Reset(new Propulsion());
 	} else if(f == Feature::FIXED_GUNS && m_fixedGuns == nullptr) {
-		m_fixedGuns = new FixedGuns();
+		m_fixedGuns.Reset(new FixedGuns());
 	}
 }
 
@@ -133,22 +133,22 @@ void DynamicBody::PostLoadFixup(Space *space)
 
 const Propulsion *DynamicBody::GetPropulsion() const {
 	assert(m_propulsion != nullptr);
-	return m_propulsion;
+	return m_propulsion.Get();
 }
 
 Propulsion *DynamicBody::GetPropulsion() {
 	assert(m_propulsion != nullptr);
-	return m_propulsion;
+	return m_propulsion.Get();
 }
 
 const FixedGuns *DynamicBody::GetFixedGuns() const {
 	assert(m_fixedGuns != nullptr);
-	return m_fixedGuns;
+	return m_fixedGuns.Get();
 }
 
 FixedGuns *DynamicBody::GetFixedGuns() {
 	assert(m_fixedGuns != nullptr);
-	return m_fixedGuns;
+	return m_fixedGuns.Get();
 }
 
 void DynamicBody::SetTorque(const vector3d &t)
@@ -290,10 +290,8 @@ vector3d DynamicBody::GetAngularMomentum() const
 
 DynamicBody::~DynamicBody()
 {
-	if(m_propulsion != nullptr)
-		delete m_propulsion;
-	if(m_fixedGuns != nullptr)
-		delete m_fixedGuns;
+	m_propulsion.Reset();
+	m_fixedGuns.Reset();
 }
 
 vector3d DynamicBody::GetVelocity() const

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -113,8 +113,8 @@ private:
 
 	bool m_features[MAX_FEATURE];
 
-	Propulsion *m_propulsion;
-	FixedGuns *m_fixedGuns;
+	RefCountedPtr<Propulsion> m_propulsion;
+	RefCountedPtr<FixedGuns> m_fixedGuns;
 };
 
 #endif /* _DYNAMICBODY_H */

--- a/src/FixedGuns.h
+++ b/src/FixedGuns.h
@@ -19,7 +19,7 @@ enum Guns {
 	GUNMOUNT_MAX = 2
 };
 
-class FixedGuns
+class FixedGuns : public RefCounted
 {
 	public:
 		FixedGuns();

--- a/src/Propulsion.h
+++ b/src/Propulsion.h
@@ -22,7 +22,7 @@ enum Thruster { // <enum scope='Thruster' name=ShipTypeThruster prefix=THRUSTER_
 	THRUSTER_MAX // <enum skip>
 };
 
-class Propulsion
+class Propulsion : public RefCounted
 {
 	public:
 		// Inits:

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -723,11 +723,11 @@ extern double calc_ivel(double dist, double vel, double acc);
 // Fly to vicinity of body
 AICmdFlyTo::AICmdFlyTo(DynamicBody *dBody, Body *target) : AICommand(dBody, CMD_FLYTO)
 {
-	m_prop = dBody->GetPropulsion();
+	m_prop.Reset(dBody->GetPropulsion());
 	assert(m_prop!=nullptr);
 	m_frame = 0; m_state = -6; m_lockhead = true; m_endvel = 0; m_tangent = false;
 	if (!target->IsType(Object::TERRAINBODY)) m_dist = VICINITY_MIN;
-	else m_dist = VICINITY_MUL*MaxEffectRad(target, m_prop);
+	else m_dist = VICINITY_MUL*MaxEffectRad(target, m_prop.Get());
 
 	if (target->IsType(Object::SPACESTATION) && static_cast<SpaceStation*>(target)->IsGroundStation()) {
 		m_posoff = target->GetPosition() + 15000.0 * target->GetOrient().VectorY();
@@ -751,7 +751,7 @@ AICmdFlyTo::AICmdFlyTo(DynamicBody *dBody, Frame *targframe, const vector3d &pos
 	m_lockhead(true),
 	m_frame(nullptr)
 {
-	m_prop = dBody->GetPropulsion();
+	m_prop.Reset(dBody->GetPropulsion());
 	assert(m_prop!=nullptr);
 }
 
@@ -809,7 +809,7 @@ Output("Autopilot dist = %.1f, speed = %.1f, zthrust = %.2f, state = %i\n",
 // TODO: collision needs to be processed according to vdiff, not reldir?
 
 	Body *body = m_frame->GetBody();
-	double erad = MaxEffectRad(body, m_prop);
+	double erad = MaxEffectRad(body, m_prop.Get());
 	if ((m_target && body != m_target)
 		|| (m_targframe && (!m_tangent || body != m_targframe->GetBody())))
 	{
@@ -930,7 +930,7 @@ AICmdDock::AICmdDock(DynamicBody *dBody, SpaceStation *target) : AICommand(dBody
 	ship = static_cast<Ship*>(dBody);
 	assert(ship!=nullptr);
 
-	m_prop = ship->GetPropulsion(); // dBody->GetPropulsion();
+	m_prop.Reset(ship->GetPropulsion());
 	assert(m_prop!=nullptr);
 
 	double grav = GetGravityAtPos(m_target->GetFrame(), m_target->GetPosition());
@@ -1087,7 +1087,7 @@ void AICmdFlyAround::Setup(Body *obstructor, double alt, double vel, int mode)
 	m_obstructor = obstructor; m_alt = alt; m_vel = vel; m_targmode = mode;
 
 	// push out of effect radius (gravity safety & station parking zones)
-	alt = std::max(alt, MaxEffectRad(obstructor, m_prop));
+	alt = std::max(alt, MaxEffectRad(obstructor, m_prop.Get()));
 
 	// drag within frame because orbits are impossible otherwise
 	// timestep code also doesn't work correctly for ex-frame cases, should probably be fixed 
@@ -1102,7 +1102,7 @@ void AICmdFlyAround::Setup(Body *obstructor, double alt, double vel, int mode)
 AICmdFlyAround::AICmdFlyAround(DynamicBody *dBody, Body *obstructor, double relalt, int mode)
 	: AICommand (dBody, CMD_FLYAROUND)
 {
-	m_prop = dBody->GetPropulsion();
+	m_prop.Reset(dBody->GetPropulsion());
 	assert(m_prop!=nullptr);
 
 	assert(!std::isnan(relalt));
@@ -1114,7 +1114,7 @@ AICmdFlyAround::AICmdFlyAround(DynamicBody *dBody, Body *obstructor, double rela
 AICmdFlyAround::AICmdFlyAround(DynamicBody *dBody, Body *obstructor, double alt, double vel, int mode)
 	: AICommand (dBody, CMD_FLYAROUND)
 {
-	m_prop = dBody->GetPropulsion();
+	m_prop.Reset(dBody->GetPropulsion());
 	assert(m_prop!=nullptr);
 
 	assert(!std::isnan(alt));
@@ -1217,7 +1217,7 @@ AICmdFormation::AICmdFormation(DynamicBody *dBody, DynamicBody *target, const ve
 	m_target(target),
 	m_posoff(posoff)
 {
-	m_prop = dBody->GetPropulsion();
+	m_prop.Reset(dBody->GetPropulsion());
 	assert(m_prop!=nullptr);
 }
 

--- a/src/ShipAICmd.h
+++ b/src/ShipAICmd.h
@@ -29,8 +29,6 @@ public:
 	AICommand(DynamicBody *dBody, CmdName name):
 		m_dBody(dBody), m_cmdName(name) {
 		m_dBody->AIMessage(DynamicBody::AIERROR_NONE);
-		m_prop = nullptr;
-		m_fguns = nullptr;
 	}
 	virtual ~AICommand() {}
 
@@ -53,8 +51,8 @@ public:
 	CmdName GetType() const { return m_cmdName; }
 protected:
 	DynamicBody *m_dBody;
-	Propulsion *m_prop;
-	FixedGuns *m_fguns;
+	RefCountedPtr<Propulsion> m_prop;
+	RefCountedPtr<FixedGuns> m_fguns;
 
 	std::unique_ptr<AICommand> m_child;
 	CmdName m_cmdName;
@@ -98,7 +96,7 @@ public:
 		AICommand::PostLoadFixup(space);
 		m_target = static_cast<SpaceStation *>(space->GetBodyByIndex(m_targetIndex));
 		// Ensure needed sub-system:
-		m_prop = m_dBody->GetPropulsion();
+		m_prop.Reset(m_dBody->GetPropulsion());
 		assert(m_prop!=nullptr);
 	}
 	virtual void OnDeleted(const Body *body) {
@@ -182,7 +180,7 @@ public:
 		m_targframe = space->GetFrameByIndex(m_targframeIndex);
 		m_lockhead = true;
 		// Ensure needed sub-system:
-		m_prop = m_dBody->GetPropulsion();
+		m_prop.Reset(m_dBody->GetPropulsion());
 		assert(m_prop!=nullptr);
 	}
 	virtual void OnDeleted(const Body *body) {
@@ -240,7 +238,7 @@ public:
 		AICommand::PostLoadFixup(space);
 		m_obstructor = space->GetBodyByIndex(m_obstructorIndex);
 		// Ensure needed sub-system:
-		m_prop = m_dBody->GetPropulsion();
+		m_prop.Reset(m_dBody->GetPropulsion());
 		assert(m_prop!=nullptr);
 	}
 	virtual void OnDeleted(const Body *body) {
@@ -268,8 +266,8 @@ public:
 		m_target = target;
 		m_leadTime = m_evadeTime = m_closeTime = 0.0;
 		m_lastVel = m_target->GetVelocity();
-		m_prop = m_dBody->GetPropulsion();
-		m_fguns = m_dBody->GetFixedGuns();
+		m_prop.Reset(m_dBody->GetPropulsion());
+		m_fguns.Reset(m_dBody->GetFixedGuns());
 		assert(m_prop!=nullptr);
 		assert(m_fguns!=nullptr);
 	}
@@ -297,8 +295,8 @@ public:
 		m_leadTime = m_evadeTime = m_closeTime = 0.0;
 		m_lastVel = m_target->GetVelocity();
 		// Ensure needed sub-system:
-		m_prop = m_dBody->GetPropulsion();
-		m_fguns = m_dBody->GetFixedGuns();
+		m_prop.Reset(m_dBody->GetPropulsion());
+		m_fguns.Reset(m_dBody->GetFixedGuns());
 		assert(m_prop!=nullptr);
 		assert(m_fguns!=nullptr);
 	}
@@ -320,7 +318,7 @@ public:
 	virtual bool TimeStepUpdate();
 	AICmdKamikaze(DynamicBody *dBody, Body *target) : AICommand(dBody, CMD_KAMIKAZE) {
 		m_target = target;
-		m_prop = m_dBody->GetPropulsion();
+		m_prop.Reset(m_dBody->GetPropulsion());
 		assert(m_prop!=nullptr);
 	}
 
@@ -339,7 +337,7 @@ public:
 		AICommand::PostLoadFixup(space);
 		m_target = space->GetBodyByIndex(m_targetIndex);
 		// Ensure needed sub-system:
-		m_prop = m_dBody->GetPropulsion();
+		m_prop.Reset(m_dBody->GetPropulsion());
 		assert(m_prop!=nullptr);
 	}
 
@@ -357,12 +355,12 @@ class AICmdHoldPosition : public AICommand {
 public:
 	virtual bool TimeStepUpdate();
 	AICmdHoldPosition(DynamicBody *dBody) : AICommand(dBody, CMD_HOLDPOSITION) {
-		m_prop = m_dBody->GetPropulsion();
+		m_prop.Reset(m_dBody->GetPropulsion());
 		assert(m_prop!=nullptr);
 	}
 	AICmdHoldPosition(const Json::Value &jsonObj) : AICommand(jsonObj, CMD_HOLDPOSITION) {
 		// Ensure needed sub-system:
-		m_prop = m_dBody->GetPropulsion();
+		m_prop.Reset(m_dBody->GetPropulsion());
 		assert(m_prop!=nullptr);
 	}
 };
@@ -395,7 +393,7 @@ public:
 		AICommand::PostLoadFixup(space);
 		m_target = static_cast<Ship*>(space->GetBodyByIndex(m_targetIndex));
 		// Ensure needed sub-system:
-		m_prop = m_dBody->GetPropulsion();
+		m_prop.Reset(m_dBody->GetPropulsion());
 		assert(m_prop!=nullptr);
 	}
 	virtual void OnDeleted(const Body *body) {

--- a/src/ShipAICmd.h
+++ b/src/ShipAICmd.h
@@ -357,8 +357,8 @@ class AICmdHoldPosition : public AICommand {
 public:
 	virtual bool TimeStepUpdate();
 	AICmdHoldPosition(DynamicBody *dBody) : AICommand(dBody, CMD_HOLDPOSITION) {
-		Propulsion *prop = m_dBody->GetPropulsion();
-		assert(prop!=0);
+		m_prop = m_dBody->GetPropulsion();
+		assert(m_prop!=nullptr);
 	}
 	AICmdHoldPosition(const Json::Value &jsonObj) : AICommand(jsonObj, CMD_HOLDPOSITION) {
 		// Ensure needed sub-system:


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
I noticed this crash as I started looking into another bug, simply selecting the New Hope start location crashed the game immediately.

It turns out that it was attempting to use a `nullptr` as the value hadn't been set, instead it was being assigned too a locally created variable.

Simple mistake, simple fix.

Since the objects lifetimes are also managed by a `DynamicBody` but pointers to them are held within Ai Commands I've also made them `RefCounted` objects.
<!-- Please make sure you've read documentation on contributing -->

