### PR TITLE
Add Easter egg advert, (shown on every 50th station)

### DIFF
--- a/data/lang/module-easteregg-message/en.json
+++ b/data/lang/module-easteregg-message/en.json
@@ -1,0 +1,18 @@
+{
+   "FLAVOUR_0_BODY" : {
+      "description" : "This is a very rare string, that's part of an 'Easter egg'. This specific one is a reference to the song by AC/DC",
+      "message" : "Just ring 36 24 36, I'm always home. I deal in:\n - Concreat shoes,\n - Cyanide,\n - TNT,\n - Neck ties,\n - Contracts,\n - High voltage,\n\n ...or just make a social call."
+   },
+   "FLAVOUR_0_TITLE" : {
+      "description" : "The 'all caps' title should probably not be translated, as it's an AC/DC song title reference. Either way, it's a very rare 'Easter egg'",
+      "message" : "DIRTY DEEDS DONE DIRT CHEAP, if you're having trouble, call me any time"
+   },
+   "FLAVOUR_1_BODY" : {
+      "description" : "This is a very rare string, that's part of an 'Easter egg'. This specific one is a reference to https://en.wikipedia.org/wiki/867-5309/Jenny",
+      "message" : "You don't know me, but call me; 867-5309 / Jenny"
+   },
+   "FLAVOUR_1_TITLE" : {
+      "description" : "A very rare Easter egg, and reference to a line from a famous song.",
+      "message" : "NEED SOMEONE TO TURN TO?"
+   }
+}

--- a/data/modules/EasterEgg/Message.lua
+++ b/data/modules/EasterEgg/Message.lua
@@ -1,0 +1,103 @@
+-- Copyright © 2008-2018 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Engine = import("Engine")
+local Rand = import("Rand")
+local Lang = import("Lang")
+local Game = import("Game")
+local Event = import("Event")
+local Serializer = import("Serializer")
+
+local l = Lang.GetResource("module-easteregg-message")
+local max_flavour_index = 1
+
+local flavours = {}
+for i = 0,max_flavour_index do
+	table.insert(flavours, {
+		title = l["FLAVOUR_" .. i .. "_TITLE"],
+		body  = l["FLAVOUR_" .. i .. "_BODY"],
+	})
+end
+
+local ads = {}
+
+local onChat = function (form, ref, option)
+	local ad = ads[ref]
+
+	form:Clear()
+
+	if option == -1 then
+		form:Close()
+		return
+	end
+
+	form:SetTitle(flavours[ad.flavour].title)
+	form:SetMessage("\n" .. flavours[ad.flavour].body)
+end
+
+
+local makeAdvert = function (station, flavour_index)
+
+	local ad = {
+		flavour = flavour_index,
+		station = station,
+	}
+
+	ad.desc = flavours[ad.flavour].title
+	local ref = station:AddAdvert({
+		description = ad.desc,
+--		icon        = "lightning",
+		onChat      = onChat})
+	ads[ref] = ad
+
+--	print("Hatched egg:\t".. station.label .. flavours[ad.flavour].title)
+
+end
+
+
+local onCreateBB = function (station)
+
+	-- deterministically generate our instance
+	local rand = Rand.New(station.seed + 1)
+
+	-- How many stations for each advert?
+	local one_in_n = 50
+
+	if rand:Number(0, one_in_n) < 1 then
+		makeAdvert(station, rand:Integer(1,#flavours))
+	end
+end
+
+local loaded_data
+
+local onGameStart = function ()
+	ads = {}
+
+	if not loaded_data then return end
+
+	for k,ad in pairs(loaded_data.ads) do
+		local ref = ad.station:AddAdvert({
+			description = ad.desc,
+--			icon        = "lightning",
+			onChat      = onChat,
+		})
+		ads[ref] = ad
+	end
+
+	loaded_data = nil
+end
+
+
+local serialize = function ()
+	return { ads = ads }
+end
+
+
+local unserialize = function (data)
+	loaded_data = data
+end
+
+Event.Register("onCreateBB", onCreateBB)
+Event.Register("onGameStart", onGameStart)
+
+Serializer:Register("Message", serialize, unserialize)


### PR DESCRIPTION
Back in the day, my computer couldn't play Duke Nukem 3D, so I'm making up for it now. As a good nerd, I research all secrets, references and Easter eggs on each level as I play through the game.

On episode 1, level 1, in the bathroom wall, [there's a number](https://en.wikipedia.org/wiki/867-5309/Jenny "Tommy Tutone - 867-5309/Jenny"). Apparently it's "the worlds most famous telephone number" according to Urban dictionary. So why not add it on rare* occasions to pioneer.

But to me, there's [another song](https://en.wikipedia.org/wiki/Dirty_Deeds_Done_Dirt_Cheap_(song) "AC/DC - Dirty deeds done dirt cheap") that mentions a telephone number that fits better in with Pioneer, so I just had to add it, complete with references to the lyrics.

Downside: the player might wrongfully think this is a clue to something in the game, or that they can interact with it some way, but this is just a silly Easter egg.

Anyway, I just thought I'd throw this together and see if it's something we'd like in the game,  this could go the way #4153 did.

_*rare = one station in 50, the advert is "static" to the station, meaning if a station has it it's always the same_

As for BBS icon, I failed to convert the AC/DC lightning bolt to 15x15 pixel image. We can just skip an icon for now.

[youtube: Tommy Tutone- 867-5309 / Jenny](https://www.youtube.com/watch?v=ON56AKnqbog)
[youtube: AC/DC - Dirty Deeds Done Dirt Cheap](https://www.youtube.com/watch?v=26wrvblgGP0)

![screenshot-20180310-195210](https://user-images.githubusercontent.com/619390/37245958-a87e4814-24a0-11e8-935e-1835923aeaae.png)
![screenshot-20180310-195203](https://user-images.githubusercontent.com/619390/37245962-adfd154a-24a0-11e8-949c-4aebe66f0fd7.png)

![](http://www.eeggs.com/images/items/1747.full.jpg)
