### PR TITLE
Throw lua error when specific Lang is not found.

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -66,7 +66,7 @@ file_filter = data/lang/module-crewcontracts/<lang>.json
 source_file = data/lang/module-crewcontracts/en.json
 source_lang = en
 
-[pioneer.module-easteregg]
+[pioneer.module-easteregg-message]
 file_filter = data/lang/module-easteregg-message/<lang>.json
 source_file = data/lang/module-easteregg-message/en.json
 source_lang = en

--- a/src/LuaLang.cpp
+++ b/src/LuaLang.cpp
@@ -60,8 +60,9 @@ static int l_lang_get_resource(lua_State *l)
 
 	Lang::Resource res(resourceName, langCode);
 	if (!res.Load()) {
-		lua_pushnil(l);
-		return 1;
+		std::string msg = std::string("Translation of '") + resourceName + std::string("' into language '") + langCode + std::string("' not found! This should be in 'data/lang/") + resourceName + std::string("/") + langCode + std::string(".json'.");
+		lua_pushstring(l, msg.c_str());
+		lua_error(l);
 	}
 
 	lua_newtable(l);


### PR DESCRIPTION
When lua Lang.GetResource does not find a resource, it throws a lua error,
mentioning the exact missing file, and does *not* just silently return nil.

Partially fixes #4327.