### PR TITLE
Reinstate searching by Sector coordinates

### DIFF
--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -1220,6 +1220,14 @@ static int l_engine_set_sector_map_selected(lua_State *l)
 		return 0;
 }
 
+static int l_engine_sector_map_goto_sector_path(lua_State *l)
+{
+	SectorView *sv = Pi::game->GetSectorView();
+	SystemPath *path = LuaObject<SystemPath>::CheckFromLua(1);
+	sv->GotoSector(*path);
+	return 0;
+}
+
 static int l_engine_sector_map_goto_system_path(lua_State *l)
 {
 		SectorView *sv = Pi::game->GetSectorView();
@@ -1393,6 +1401,7 @@ void LuaEngine::Register()
 		{ "SetSectorMapAutomaticSystemSelection",   l_engine_set_sector_map_automatic_system_selection },
 		{ "SetSectorMapLockHyperspaceTarget",       l_engine_set_sector_map_lock_hyperspace_target },
 		{ "SetSectorMapSelected",                   l_engine_set_sector_map_selected },
+		{ "SectorMapGotoSectorPath",                l_engine_sector_map_goto_sector_path },
 		{ "SectorMapGotoSystemPath",                l_engine_sector_map_goto_system_path },
 		{ "GetSectorMapFactions",                   l_engine_get_sector_map_factions },
 		{ "SetSectorMapFactionVisible",             l_engine_set_sector_map_faction_visible },

--- a/src/LuaGame.cpp
+++ b/src/LuaGame.cpp
@@ -72,6 +72,27 @@ static int l_game_start_game(lua_State *l)
 	return 0;
 }
 
+
+/*
+* Function: SaveGameStats
+*
+* Start a new game.
+*
+* > Game.SaveGameStats(filename)
+*
+* Parameters:
+*
+*   filename - The filename of the save game to retrieve stats for.
+*              Stats will be loaded from the 'savefiles' directory in the user's game directory.
+*
+* Availability:
+*
+*   2018-02-10
+*
+* Status:
+*
+*   experimental
+*/
 static int l_game_savegame_stats(lua_State *l)
 {
 	std::string filename = LuaPull<std::string>(l, 1);

--- a/src/LuaSystemPath.cpp
+++ b/src/LuaSystemPath.cpp
@@ -409,6 +409,42 @@ static int l_sbodypath_is_system_path(lua_State *l)
 	LuaPush(l, path->IsSystemPath());
 	return 1;
 }
+
+/*
+* Method: ParseString
+*
+* Parse a string and try to make a SystemPath from it
+*
+* > sector_path = SystemPath.Parse()
+*
+* Return:
+*
+*   sector_path - the SystemPath that represents just the sector
+*
+* Availability:
+*
+*   2018-06-16
+*
+* Status:
+*
+*   experimental
+*/
+static int l_sbodypath_parse_string(lua_State *l)
+{
+	std::string path = LuaPull<std::string>(l, 1);
+	try
+	{
+		SystemPath syspath = SystemPath::Parse(path.c_str());
+		LuaObject<SystemPath>::PushToLua(syspath.SectorOnly());
+		return 1;
+	}
+	catch (SystemPath::ParseFailure pf)
+	{
+		return 0;
+	}
+	return 0;
+}
+
 /*
  * Attribute: sectorX
  *
@@ -600,6 +636,7 @@ template <> void LuaObject<SystemPath>::RegisterClass()
 		{ "IsSystemPath",  l_sbodypath_is_system_path },
 		{ "IsSectorPath",  l_sbodypath_is_sector_path },
 		{ "IsBodyPath",    l_sbodypath_is_body_path },
+		{ "ParseString",   l_sbodypath_parse_string},
 		{ 0, 0 }
 	};
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -229,7 +229,7 @@ void write_screenshot(const Graphics::ScreendumpState &sd, const char* destFile)
 // strcasestr() adapted from gnulib
 // (c) 2005 FSF. GPL2+
 
-#define TOLOWER(c) (isupper(c) ? tolower(c) : (c))
+#define TOLOWER(c) (isupper((unsigned char)c) ? tolower((unsigned char)c) : ((unsigned char)c))
 
 const char *pi_strcasestr (const char *haystack, const char *needle)
 {


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
SectorView lost the ability to search by coordinates in the conversion to Pi-IMGUI, this simply restores that functionality.

It works by attempting to parse a string into a SystemPath, if that fails then it falls through to the existing search functionality. However if it succeeds then it moves the Sector screens viewing location to those coordinates.

This is intended to fix #4340
<!-- Please make sure you've read documentation on contributing -->

