### PR TITLE
Check if loaded_data.ads exist too

### DIFF
--- a/data/modules/Advice/Advice.lua
+++ b/data/modules/Advice/Advice.lua
@@ -110,7 +110,7 @@ local loaded_data
 local onGameStart = function ()
 	ads = {}
 
-	if not loaded_data then return end
+	if not loaded_data or not loaded_data.ads then return end
 
 	for k,ad in pairs(loaded_data.ads or {}) do
 		local ref = ad.station:AddAdvert({

--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -457,7 +457,7 @@ local onGameStart = function ()
 	ads = {}
 	missions = {}
 
-	if not loaded_data then return end
+	if not loaded_data or not loaded_data.ads then return end
 
 	for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({

--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -227,7 +227,7 @@ local onGameStart = function ()
 			service_period = oneyear, -- default
 			jumpcount = 0, -- Number of jumps made after the service_period
 		}
-	else
+	elseif loaded_data.ads then
 		for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({
 			description = ad.title,

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -843,7 +843,7 @@ end
 local loaded_data
 
 local onGameStart = function ()
-	if loaded_data then
+	if loaded_data and loaded_data.ads then
 		ads = {}
 		missions = {}
 		custom_cargo = {}

--- a/data/modules/Combat/Combat.lua
+++ b/data/modules/Combat/Combat.lua
@@ -469,7 +469,7 @@ end
 local loaded_data
 
 local onGameStart = function ()
-	if loaded_data then
+	if loaded_data and loaded_data.ads then
 		ads = {}
 		missions = {}
 

--- a/data/modules/CrewContracts/CrewContracts.lua
+++ b/data/modules/CrewContracts/CrewContracts.lua
@@ -423,7 +423,7 @@ Event.Register("onGameStart", function()
 	-- XXX Need to re-initialise these until Lua is re-initialised with a new game
 	nonPersistentCharactersForCrew = {}
 	stationsWithAdverts = {}
-	if loaded_data then
+	if loaded_data and loaded_data.stationsWithAdverts then
 		nonPersistentCharactersForCrew = loaded_data.nonPersistentCharactersForCrew
 		for k,station in pairs(loaded_data.stationsWithAdverts) do
 		stationsWithAdverts[station:AddAdvert({

--- a/data/modules/DeliverPackage/DeliverPackage.lua
+++ b/data/modules/DeliverPackage/DeliverPackage.lua
@@ -461,7 +461,7 @@ local onGameStart = function ()
 	ads = {}
 	missions = {}
 
-	if not loaded_data then return end
+	if not loaded_data or not loaded_data.ads then return end
 
 	for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({

--- a/data/modules/DonateToCranks/DonateToCranks.lua
+++ b/data/modules/DonateToCranks/DonateToCranks.lua
@@ -103,7 +103,7 @@ local loaded_data
 local onGameStart = function ()
 	ads = {}
 
-	if not loaded_data then return end
+	if not loaded_data or not loaded_data.ads then return end
 
 	for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({

--- a/data/modules/EasterEgg/Message.lua
+++ b/data/modules/EasterEgg/Message.lua
@@ -77,7 +77,7 @@ local loaded_data
 local onGameStart = function ()
 	ads = {}
 
-	if not loaded_data then return end
+	if not loaded_data or not loaded_data.ads then return end
 
 	for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({

--- a/data/modules/FuelClub/FuelClub.lua
+++ b/data/modules/FuelClub/FuelClub.lua
@@ -252,7 +252,7 @@ end
 
 local onGameStart = function ()
 
-	if loaded_data then
+	if loaded_data and loaded_data.ads then
 		-- rebuild saved adverts
 		for k,ad in pairs(loaded_data.ads) do
 			ads[ad.station:AddAdvert({

--- a/data/modules/GoodsTrader/GoodsTrader.lua
+++ b/data/modules/GoodsTrader/GoodsTrader.lua
@@ -152,7 +152,7 @@ local loaded_data
 local onGameStart = function ()
 	ads = {}
 
-	if not loaded_data then return end
+	if not loaded_data or not loaded_data.ads then return end
 
 	for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({

--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -380,7 +380,7 @@ local onGameStart = function ()
 	ads = {}
 	news = {}
 
-	if not loadedData then return end
+	if not loadedData or not loadedData.ads then return end
 
 	for k,ad in pairs(loadedData.ads) do
 		local ref = ad.station:AddAdvert(

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -2089,7 +2089,7 @@ local onGameStart = function ()
 	ads = {}
 	missions = {}
 
-	if not loaded_data then return end
+	if not loaded_data or not loaded_data.ads then return end
 
 	-- fill the global containers with previously saved data if this is a reload
 	for _,ad in pairs(loaded_data.ads) do

--- a/data/modules/SecondHand/SecondHand.lua
+++ b/data/modules/SecondHand/SecondHand.lua
@@ -229,7 +229,7 @@ local loaded_data
 local onGameStart = function ()
     ads = {}
 
-    if not loaded_data then return end
+    if not loaded_data or not loaded_data.ads then return end
 
     for k,ad in pairs(loaded_data.ads) do
         local ref = ad.station:AddAdvert({

--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -448,7 +448,7 @@ local onGameStart = function ()
 	missions = {}
 	passengers = 0
 
-	if not loaded_data then return end
+	if not loaded_data or not loaded_data.ads then return end
 
 	for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({


### PR DESCRIPTION
Fixes crash if one loads game prior to introduction of specific module.

For example, loading old games after introduction of Combat module.
Signed-off-by: Paul B Mahol <onemda@gmail.com>

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

