### PR TITLE
Fix showing Pale-Blue-Dot and other planets again.

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -85,6 +85,7 @@ Camera::Camera(RefCountedPtr<CameraContext> context, Graphics::Renderer *rendere
 	m_renderer(renderer)
 {
 	Graphics::MaterialDescriptor desc;
+	desc.effect = Graphics::EFFECT_BILLBOARD;
 	desc.textures = 1;
 
 	m_billboardMaterial.reset(m_renderer->CreateMaterial(desc));
@@ -148,11 +149,14 @@ void Camera::Update()
 		if (b->IsType(Object::TERRAINBODY)) {
 			if (pixSize < BILLBOARD_PIXEL_THRESHOLD) {
 				attrs.billboard = true;
+
+				// project the position
 				vector3d pos;
-				// limit the minimum billboard size for planets so they're always a little visible
-				const double size = std::max(0.5, rad * 2.0 * m_context->GetFrustum().TranslatePoint(attrs.viewCoords, pos));
+				m_context->GetFrustum().TranslatePoint(attrs.viewCoords, pos);
 				attrs.billboardPos = vector3f(pos);
-				attrs.billboardSize = float(size);
+
+				// limit the minimum billboard size for planets so they're always a little visible
+				attrs.billboardSize = std::max(1.0f, pixSize);
 				if (b->IsType(Object::STAR)) {
 					attrs.billboardColor = StarSystem::starRealColors[b->GetSystemBody()->GetType()];
 				}

--- a/src/graphics/Frustum.cpp
+++ b/src/graphics/Frustum.cpp
@@ -132,15 +132,12 @@ bool Frustum::ProjectPoint(const vector3d &in, vector3d &out) const
 	return true;
 }
 
-double Frustum::TranslatePoint(const vector3d &in, vector3d &out) const
+void Frustum::TranslatePoint(const vector3d &in, vector3d &out) const
 {
 	out = in;
-	double scale = 1.0;
 	while (out.LengthSqr() > m_translateThresholdSqr) {
 		out *= TRANSLATE_STEP;
-		scale *= TRANSLATE_STEP;
 	}
-	return scale;
 }
 
 }

--- a/src/graphics/Frustum.h
+++ b/src/graphics/Frustum.h
@@ -30,7 +30,7 @@ public:
 
 	// translate the given point outside the frustum to a point inside
 	// returns scale factor to make object at that point appear correctly
-	double TranslatePoint(const vector3d &in, vector3d &out) const;
+	void TranslatePoint(const vector3d &in, vector3d &out) const;
 
 private:
 	// create from current gl state


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Fix a bug whereby the billboards were not being drawn for planets once they had gotten far enough away for that to be an option.

We have an onscreen pixel threshold below which we render planets and other objects as billboard.
However I broke that rendering when I rewrote the billboard code back in Apr 3, 2016!

To fix this the commit uses the billboard shader and the onscreen pixel size for a planet.

Fixes #4190
<!-- Please make sure you've read documentation on contributing -->

