### PR TITLE
Mostly tech level changes

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1555,6 +1555,14 @@
     "description": "",
     "message": "This is an easy start from London on Earth in the Sol system."
   },
+   "START_AT_MARS" : {
+    "description" : "",
+    "message" : "Start on Mars"
+  },
+  "START_AT_MARS_DESC": {
+    "description" : "",
+    "message" : "This is an easy start from Cydonia on Mars in the Sol system."
+  },
   "START_AT_NEW_HOPE": {
     "description": "New Hope is an in game location",
     "message": "Start at New Hope"

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -27,6 +27,8 @@ function SpaceStation:Constructor()
 	-- Use a variation of the space station seed itself to ensure consistency
 	local rand = Rand.New(self.seed .. '-techLevel')
 	local techLevel = rand:Integer(1, 6) + rand:Integer(0,6)
+	-- cap the techlevel lower end based on the planets population
+	techLevel = math.max(techLevel, math.min(math.floor(self.path:GetSystemBody().parent.population * 0.5), 11))
 	self:setprop("techLevel", techLevel)
 end
 

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -27,6 +27,9 @@ function SpaceStation:Constructor()
 	-- Use a variation of the space station seed itself to ensure consistency
 	local rand = Rand.New(self.seed .. '-techLevel')
 	local techLevel = rand:Integer(1, 6) + rand:Integer(0,6)
+	if Game.system.faction ~= nil and Game.system.faction.hasHomeworld and Game.system.faction.homeworld == self.path:GetSystemBody().parent.path then
+		techLevel = math.max(techLevel, 6) -- bump it upto at least 6 if it's a homeworld like Earth
+	end
 	-- cap the techlevel lower end based on the planets population
 	techLevel = math.max(techLevel, math.min(math.floor(self.path:GetSystemBody().parent.population * 0.5), 11))
 	self:setprop("techLevel", techLevel)

--- a/data/pigui/mainmenu.lua
+++ b/data/pigui/mainmenu.lua
@@ -37,9 +37,9 @@ local quitConfirmMsg
 local max_flavours = 19
 
 local startLocations = {
-	{['name']=lui.START_AT_EARTH,
-	 ['desc']=lui.START_AT_EARTH_DESC,
-	 ['location']=SystemPath.New(0,0,0,0,6,48600),
+	{['name']=lui.START_AT_MARS,
+	 ['desc']=lui.START_AT_MARS_DESC,
+	 ['location']=SystemPath.New(0,0,0,0,18),
 	 ['shipType']='sinonatrix',['money']=100,['hyperdrive']=true,
 	 ['equipment']={
 		{laser.pulsecannon_1mw,1},

--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -86,12 +86,14 @@ void SystemInfoView::OnBodyViewed(SystemBody *b)
 		m_infoBox->PackStart(l);
 	}
 
-	_add_label_and_value(Lang::MASS, stringf(Lang::N_WHATEVER_MASSES, formatarg("mass", b->GetMassAsFixed().ToDouble()),
-		formatarg("units", std::string(b->GetSuperType() == SystemBody::SUPERTYPE_STAR ? Lang::SOLAR : Lang::EARTH))));
+	if (b->GetType() != SystemBody::TYPE_STARPORT_ORBITAL) {
+		_add_label_and_value(Lang::MASS, stringf(Lang::N_WHATEVER_MASSES, formatarg("mass", b->GetMassAsFixed().ToDouble()),
+			formatarg("units", std::string(b->GetSuperType() == SystemBody::SUPERTYPE_STAR ? Lang::SOLAR : Lang::EARTH))));
 
-	_add_label_and_value(Lang::RADIUS, stringf(Lang::N_WHATEVER_RADII, formatarg("radius", b->GetRadiusAsFixed().ToDouble()),
-		formatarg("units", std::string(b->GetSuperType() == SystemBody::SUPERTYPE_STAR ? Lang::SOLAR : Lang::EARTH)),
-		formatarg("radkm", b->GetRadius() / 1000.0)));
+		_add_label_and_value(Lang::RADIUS, stringf(Lang::N_WHATEVER_RADII, formatarg("radius", b->GetRadiusAsFixed().ToDouble()),
+			formatarg("units", std::string(b->GetSuperType() == SystemBody::SUPERTYPE_STAR ? Lang::SOLAR : Lang::EARTH)),
+			formatarg("radkm", b->GetRadius() / 1000.0)));
+	}
 
 	if (b->GetSuperType() == SystemBody::SUPERTYPE_STAR) {
 		_add_label_and_value(Lang::EQUATORIAL_RADIUS_TO_POLAR_RADIUS_RATIO, stringf("%0{f.3}", b->GetAspectRatio()));

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -465,7 +465,7 @@ void StarSystemCustomGenerator::CustomGetKidsOf(RefCountedPtr<StarSystem::Genera
 		kid->m_volcanicity    = csbody->volcanicity;
 		kid->m_atmosOxidizing = csbody->atmosOxidizing;
 		kid->m_life           = csbody->life;
-    kid->m_space_station_type = csbody->spaceStationType;
+		kid->m_space_station_type = csbody->spaceStationType;
 		kid->m_rotationPeriod = csbody->rotationPeriod;
 		kid->m_rotationalPhaseAtStart = csbody->rotationalPhaseAtStart;
 		kid->m_eccentricity = csbody->eccentricity;
@@ -491,24 +491,25 @@ void StarSystemCustomGenerator::CustomGetKidsOf(RefCountedPtr<StarSystem::Genera
 
 		if (kid->GetType() == SystemBody::TYPE_STARPORT_SURFACE) {
 			kid->m_orbit.SetPlane(matrix3x3d::RotateY(csbody->longitude) * matrix3x3d::RotateX(-0.5*M_PI + csbody->latitude));
-		} else {
-                        if (kid->GetSuperType() == SystemBody::SUPERTYPE_STARPORT) {
-                            fixed lowestOrbit = fixed().FromDouble(parent->CalcAtmosphereParams().atmosRadius + 500000.0/EARTH_RADIUS);
-                            if (kid->m_orbit.GetSemiMajorAxis() < lowestOrbit.ToDouble()) {
-                                    Error("%s's orbit is too close to its parent (%.2f/%.2f)", csbody->name.c_str(),kid->m_orbit.GetSemiMajorAxis(),lowestOrbit.ToFloat());
-                            }
-                        }
-                        else {
-                            if (kid->m_orbit.GetSemiMajorAxis() < 1.2 * parent->GetRadius()) {
-                                    Error("%s's orbit is too close to its parent", csbody->name.c_str());
-                            }
-                        }
-			double offset = csbody->want_rand_offset ? rand.Double(2*M_PI) : (csbody->orbitalOffset.ToDouble());
+		}
+		else {
+			if (kid->GetSuperType() == SystemBody::SUPERTYPE_STARPORT) {
+				fixed lowestOrbit = fixed().FromDouble(parent->CalcAtmosphereParams().atmosRadius + 500000.0 / EARTH_RADIUS);
+				if (kid->m_orbit.GetSemiMajorAxis() < lowestOrbit.ToDouble()) {
+					Error("%s's orbit is too close to its parent (%.2f/%.2f)", csbody->name.c_str(), kid->m_orbit.GetSemiMajorAxis(), lowestOrbit.ToFloat());
+				}
+			}
+			else {
+				if (kid->m_orbit.GetSemiMajorAxis() < 1.2 * parent->GetRadius()) {
+					Error("%s's orbit is too close to its parent", csbody->name.c_str());
+				}
+			}
+			double offset = csbody->want_rand_offset ? rand.Double(2 * M_PI) : (csbody->orbitalOffset.ToDouble());
 			kid->m_orbit.SetPlane(matrix3x3d::RotateY(offset) * matrix3x3d::RotateX(-0.5*M_PI + csbody->latitude));
 		}
 		if (kid->GetSuperType() == SystemBody::SUPERTYPE_STARPORT) {
 			(*outHumanInfestedness)++;
-            system->AddSpaceStation(kid);
+			system->AddSpaceStation(kid);
 		}
 		parent->m_children.push_back(kid);
 
@@ -1410,13 +1411,19 @@ void PopulateStarSystemGenerator::PopulateStage1(SystemBody* sbody, StarSystem::
 
 	/* Bad type of planet for settlement */
 	if ((sbody->GetAverageTemp() > CELSIUS+100) || (sbody->GetAverageTemp() < 100) ||
-	    (sbody->GetType() != SystemBody::TYPE_PLANET_TERRESTRIAL && sbody->GetType() != SystemBody::TYPE_PLANET_ASTEROID)) {
+	    (sbody->GetType() != SystemBody::TYPE_PLANET_TERRESTRIAL && sbody->GetType() != SystemBody::TYPE_PLANET_ASTEROID))
+	{
+		Random starportPopRand;
+		starportPopRand.seed(_init, 6);
 
         // orbital starports should carry a small amount of population
         if (sbody->GetType() == SystemBody::TYPE_STARPORT_ORBITAL) {
-			sbody->m_population = fixed(1,100000);
+			sbody->m_population = fixed(1, 100000) + fixed(1, 1000000 + starportPopRand.Int32(-10000,10000));
 			outTotalPop += sbody->m_population;
-        }
+		} else if (sbody->GetType() == SystemBody::TYPE_STARPORT_SURFACE) {
+			sbody->m_population = fixed(1, 10000) + fixed(1, 100000 + starportPopRand.Int32(-100, 100));
+			outTotalPop += sbody->m_population;
+		}
 
 		return;
 	}


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
This PR bumps the tech level for stations based on both population and whether or not it's a homeworld for a faction.

More could be done here, taking into account the distance from the homeworld divided by the radius of the factions bubble for example.

Also found a mistake in the solar federation faction which has had Mars as it's homeworld since it was created! 👍 
<!-- Please make sure you've read documentation on contributing -->

