### PR TITLE
Do not toggle bindings when in settings view

### DIFF
--- a/data/pigui/game.lua
+++ b/data/pigui/game.lua
@@ -933,9 +933,11 @@ ui.registerHandler(
 			if not ui.showOptionsWindow then
 				Game.SetTimeAcceleration("paused")
 				ui.showOptionsWindow = true
+				Engine.DisableBindings();
 			else
 				Game.SetTimeAcceleration("1x")
 				ui.showOptionsWindow = false
+				Engine.EnableBindings();
 			end
 		end
 end)

--- a/data/pigui/modules/autopilot-window.lua
+++ b/data/pigui/modules/autopilot-window.lua
@@ -133,6 +133,7 @@ local function button_flight_control()
 end
 
 local function displayAutoPilotWindow()
+	if ui.showOptionsWindow then return end
 	player = Game.player
 	local current_view = Game.CurrentView()
 	ui.setNextWindowSize(Vector(mainButtonSize.x * 6, mainButtonSize.y * 2), "Always")

--- a/data/pigui/modules/equipment.lua
+++ b/data/pigui/modules/equipment.lua
@@ -132,6 +132,7 @@ local function displayMissiles(uiPos)
 end
 
 local function displayEquipment()
+	if ui.showOptionsWindow then return end
 	local uiPos = Vector(15, ui.screenHeight / 3 + 10)
 	uiPos = displayMissiles(uiPos)
 	uiPos = displayECM(uiPos + Vector(0, 10))

--- a/data/pigui/modules/fx-window.lua
+++ b/data/pigui/modules/fx-window.lua
@@ -130,6 +130,7 @@ local function button_comms(current_view)
 end
 
 local function displayFxWindow()
+	if ui.showOptionsWindow then return end
 	player = Game.player
 	local current_view = Game.CurrentView()
 	ui.setNextWindowSize(Vector((mainButtonSize.x + mainButtonFramePadding * 2) * 10, (mainButtonSize.y + mainButtonFramePadding * 2) * 1.5), "Always")

--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -103,6 +103,7 @@ end
 local click_on_radar = false
 -- display either the 3D or the 2D radar, show a popup on right click to select
 local function displayRadar()
+	if ui.showOptionsWindow then return end
 	player = Game.player
 	local radar = player:GetEquip("radar")
 	-- only display if there actually *is* a radar installed

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -481,6 +481,7 @@ local function optionsWindow()
 					ui.showOptionsWindow = false
 					if Game.player then
 						Game.SetTimeAcceleration("1x")
+						Engine.EnableBindings();
 					end
 				end)
 
@@ -491,6 +492,7 @@ local function optionsWindow()
 					ui.sameLine()
 					optionTextButton(lui.END_GAME, nil, true, function()
 						ui.showOptionsWindow = false
+						Engine.EnableBindings();
 						Game.EndGame()
 					end)
 				end

--- a/data/pigui/modules/ship-internals-window.lua
+++ b/data/pigui/modules/ship-internals-window.lua
@@ -130,6 +130,7 @@ local function button_rotation_damping()
 end
 
 local function displayShipFunctionWindow()
+	if ui.showOptionsWindow then return end
 	player = Game.player
 	local current_view = Game.CurrentView()
 	local buttons = 6

--- a/src/KeyBindings.cpp
+++ b/src/KeyBindings.cpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <sstream>
 
+static bool m_disableBindings = 0;
+
 namespace KeyBindings {
 
 #define KEY_BINDING(name,a,b,c,d) KeyAction name;
@@ -329,6 +331,7 @@ bool KeyAction::Matches(const SDL_Keysym *sym) const {
 }
 
 void KeyAction::CheckSDLEventAndDispatch(const SDL_Event *event) {
+	if (m_disableBindings) return;
 	switch (event->type) {
 		case SDL_KEYDOWN:
 		case SDL_KEYUP:
@@ -535,6 +538,16 @@ void InitBindings()
 {
 	UpdateBindings();
 	Pi::config->Save();
+}
+
+void EnableBindings()
+{
+	m_disableBindings = 0;
+}
+
+void DisableBindings()
+{
+	m_disableBindings = 1;
 }
 
 }

--- a/src/KeyBindings.h
+++ b/src/KeyBindings.h
@@ -118,6 +118,8 @@ namespace KeyBindings {
 
 	void InitBindings();
 	void UpdateBindings();
+	void EnableBindings();
+	void DisableBindings();
 
 	void DispatchSDLEvent(const SDL_Event *event);
 

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -837,6 +837,18 @@ static int l_engine_get_key_bindings(lua_State *l)
 	return 1;
 }
 
+static int l_engine_enable_bindings(lua_State *l)
+{
+	KeyBindings::EnableBindings();
+	return 0;
+}
+
+static int l_engine_disable_bindings(lua_State *l)
+{
+	KeyBindings::DisableBindings();
+	return 0;
+}
+
 static int set_key_binding(lua_State *l, const char *config_id, KeyBindings::KeyAction *action) {
 	const char *binding_config_1 = lua_tostring(l, 2);
 	const char *binding_config_2 = lua_tostring(l, 3);
@@ -1375,6 +1387,8 @@ void LuaEngine::Register()
 		{ "GetMusicVolume", l_engine_get_music_volume },
 		{ "SetMusicVolume", l_engine_set_music_volume },
 
+		{ "EnableBindings", l_engine_enable_bindings },
+		{ "DisableBindings", l_engine_disable_bindings },
 		{ "GetKeyBindings", l_engine_get_key_bindings },
 		{ "SetKeyBinding", l_engine_set_key_binding },
 		{ "GetMouseYInverted", l_engine_get_mouse_y_inverted },


### PR DESCRIPTION
Previously keys like missile fire: M would trigger when changing keys. Closes #538.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

