### PR TITLE
StarTypeInfo cleanup

### DIFF
--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -64,218 +64,153 @@ const fixed StarSystemLegacyGeneratorBase::starMetallicities[] = {
 
 const StarSystemLegacyGeneratorBase::StarTypeInfo StarSystemLegacyGeneratorBase::starTypeInfo[] = {
 	{
-		SystemBody::SUPERTYPE_NONE, {}, {},
+		{}, {},
         0, 0
 	}, {
-		SystemBody::SUPERTYPE_STAR, //Brown Dwarf
+		//Brown Dwarf
 		{2,8}, {10,30},
 		1000, 2000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  //white dwarf
+		 //white dwarf
 		{20,100}, {1,2},
 		4000, 40000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //M
+		//M
 		{10,47}, {30,60},
 		2000, 3500
 	}, {
-		SystemBody::SUPERTYPE_STAR, //K
+		//K
 		{50,78}, {60,100},
 		3500, 5000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //G
+		//G
 		{80,110}, {80,120},
 		5000, 6000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //F
+		//F
 		{115,170}, {110,150},
 		6000, 7500
 	}, {
-		SystemBody::SUPERTYPE_STAR, //A
+		//A
 		{180,320}, {120,220},
 		7500, 10000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  //B
+		 //B
 		{200,300}, {120,290},
 		10000, 30000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //O
+		//O
 		{300,400}, {200,310},
 		30000, 60000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //M Giant
+		//M Giant
 		{60,357}, {2000,5000},
 		2500, 3500
 	}, {
-		SystemBody::SUPERTYPE_STAR, //K Giant
+		//K Giant
 		{125,500}, {1500,3000},
 		3500, 5000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //G Giant
+		//G Giant
 		{200,800}, {1000,2000},
 		5000, 6000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //F Giant
+		//F Giant
 		{250,900}, {800,1500},
 		6000, 7500
 	}, {
-		SystemBody::SUPERTYPE_STAR, //A Giant
+		//A Giant
 		{400,1000}, {600,1000},
 		7500, 10000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  //B Giant
+		 //B Giant
 		{500,1000}, {600,1000},
 		10000, 30000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //O Giant
+		//O Giant
 		{600,1200}, {600,1000},
 		30000, 60000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //M Super Giant
+		//M Super Giant
 		{1050,5000}, {7000,15000},
 		2500, 3500
 	}, {
-		SystemBody::SUPERTYPE_STAR, //K Super Giant
+		//K Super Giant
 		{1100,5000}, {5000,9000},
 		3500, 5000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //G Super Giant
+		//G Super Giant
 		{1200,5000}, {4000,8000},
 		5000, 6000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //F Super Giant
+		//F Super Giant
 		{1500,6000}, {3500,7000},
 		6000, 7500
 	}, {
-		SystemBody::SUPERTYPE_STAR, //A Super Giant
+		//A Super Giant
 		{2000,8000}, {3000,6000},
 		7500, 10000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  //B Super Giant
+		 //B Super Giant
 		{3000,9000}, {2500,5000},
 		10000, 30000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //O Super Giant
+		//O Super Giant
 		{5000,10000}, {2000,4000},
 		30000, 60000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //M Hyper Giant
+		//M Hyper Giant
 		{5000,15000}, {20000,40000},
 		2500, 3500
 	}, {
-		SystemBody::SUPERTYPE_STAR, //K Hyper Giant
+		//K Hyper Giant
 		{5000,17000}, {17000,25000},
 		3500, 5000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //G Hyper Giant
+		//G Hyper Giant
 		{5000,18000}, {14000,20000},
 		5000, 6000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //F Hyper Giant
+		//F Hyper Giant
 		{5000,19000}, {12000,17500},
 		6000, 7500
 	}, {
-		SystemBody::SUPERTYPE_STAR, //A Hyper Giant
+		//A Hyper Giant
 		{5000,20000}, {10000,15000},
 		7500, 10000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  //B Hyper Giant
+		 //B Hyper Giant
 		{5000,23000}, {6000,10000},
 		10000, 30000
 	}, {
-		SystemBody::SUPERTYPE_STAR, //O Hyper Giant
+		//O Hyper Giant
 		{10000,30000}, {4000,7000},
 		30000, 60000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  // M WF
+		 // M WF
 		{2000,5000}, {2500,5000},
 		25000, 35000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  // B WF
+		 // B WF
 		{2000,7500}, {2500,5000},
 		35000, 45000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  // O WF
+		 // O WF
 		{2000,10000}, {2500,5000},
 		45000, 60000
 	}, {
-		SystemBody::SUPERTYPE_STAR,  // S BH
+		 // S BH
 		{20,2000}, {0,0},	// XXX black holes are < 1 Sol radii big; this is clamped to a non-zero value later
 		10, 24
 	}, {
-		SystemBody::SUPERTYPE_STAR,  // IM BH
+		 // IM BH
 		{900000,1000000}, {100,500},
 		1, 10
 	}, {
-		SystemBody::SUPERTYPE_STAR,  // SM BH
+		 // SM BH
 		{2000000,5000000}, {10000,20000},
 		10, 24
 	}
-/*	}, {
-		SystemBody::SUPERTYPE_GAS_GIANT,
-		{}, 950, Lang::MEDIUM_GAS_GIANT,
-	}, {
-		SystemBody::SUPERTYPE_GAS_GIANT,
-		{}, 1110, Lang::LARGE_GAS_GIANT,
-	}, {
-		SystemBody::SUPERTYPE_GAS_GIANT,
-		{}, 1500, Lang::VERY_LARGE_GAS_GIANT,
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 1, Lang::ASTEROID,
-		"icons/object_planet_asteroid.png"
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 2, "Large asteroid",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 26, "Small, rocky dwarf planet", // moon radius
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 26, "Small, rocky dwarf planet", // dwarf2 for moon-like colours
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 52, "Small, rocky planet with a thin atmosphere", // mars radius
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "Rocky frozen planet with a thin nitrogen atmosphere", // earth radius
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "Dead world that once housed it's own intricate ecosystem.", // earth radius
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "Rocky planet with a carbon dioxide atmosphere",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "Rocky planet with a methane atmosphere",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "Water world with vast oceans and a thick nitrogen atmosphere",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "Rocky planet with a thick carbon dioxide atmosphere",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "Rocky planet with a thick methane atmosphere",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "Highly volcanic world",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 100, "World with indigenous life and an oxygen atmosphere",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 60, "Marginal terraformed world with minimal plant life",
-	}, {
-		SystemBody::SUPERTYPE_ROCKY_PLANET,
-		{}, 90, "Fully terraformed world with introduced species from numerous successful colonies",
-	}, {
-		SystemBody::SUPERTYPE_STARPORT,
-		{}, 0, Lang::ORBITAL_STARPORT,
-	}, {
-		SystemBody::SUPERTYPE_STARPORT,
-		{}, 0, Lang::STARPORT,
-	}*/
 };
 
 

--- a/src/galaxy/StarSystemGenerator.h
+++ b/src/galaxy/StarSystemGenerator.h
@@ -15,7 +15,6 @@ public:
 class StarSystemLegacyGeneratorBase : public StarSystemGeneratorStage {
 protected:
 	struct StarTypeInfo {
-		SystemBody::BodySuperType supertype;
 		int mass[2]; // min,max % sol for stars, unused for planets
 		int radius[2]; // min,max % sol radii for stars, % earth radii for planets
 		int tempMin, tempMax;


### PR DESCRIPTION
StarTypeInfo does not need or use the additional information that each entry is a star.

Noticed this redundant information a while ago.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

