### PR TITLE
Add FlatPak recipe

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -8,6 +8,7 @@ Table of Contents
   1.5 OS X - XCode 4
   1.6 OS X - Homebrew
   1.7 Nix - Autotools
+  1.8 Linux - FlatPak
 2 pioneer-thirdparty
   2.1 Linux - Autotools
   2.2 Windows - MSVC
@@ -214,6 +215,29 @@ around where you like (/Applications is a nice place for it).
 Executing ./pioneer requires the development environment to be loaded,
 executing ./src/pioneer does not.
 
+
+1.8 Linux - FlatPak
+-------------------
+
+1. Install flatpak-builder.
+
+    sudo apt install flatpak-builder
+
+2. In the top-level directory, run:
+
+    make -C flatpak
+
+3. After a few minutes the file Pioneer.flatpak should be built inside the
+   flatpak folder.
+
+4. To install the FlatPak package:
+
+    * If it's the first time you're installing a FlatPak package, first
+      follow the setup instructions at https://flatpak.org/setup/
+
+    * Install the flatpak by typing:
+
+      flatpak install flatpak/Pioneer.flatpak
 
 2 pioneer-thirdparty
 ====================

--- a/flatpak/.gitignore
+++ b/flatpak/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+repo
+Pioneer.flatpak

--- a/flatpak/makefile
+++ b/flatpak/makefile
@@ -1,0 +1,25 @@
+#!/usr/bin/make -f
+
+APP := net.pioneerspacesim.Pioneer
+SRC := $(APP).json
+TARGET := Pioneer.flatpak
+
+.PHONY: all clean distclean
+
+all: $(TARGET)
+
+$(TARGET): repo
+	flatpak build-bundle $< $@ $(APP)
+
+repo: build
+	flatpak build-export $@ $<
+	flatpak build-update-repo $@
+
+build: clean
+	flatpak-builder $@ $(SRC)
+
+clean:
+	rm -rf $(TARGET) build repo
+
+distclean: clean
+	rm -rf .flatpak-builder

--- a/flatpak/net.pioneerspacesim.Pioneer.json
+++ b/flatpak/net.pioneerspacesim.Pioneer.json
@@ -1,0 +1,109 @@
+{
+	"app-id": "net.pioneerspacesim.Pioneer",
+	"runtime": "org.freedesktop.Platform",
+	"runtime-version": "1.6",
+	"sdk": "org.freedesktop.Sdk",
+	"command": "pioneer",
+
+	"finish-args": [
+		"--share=ipc",
+		"--socket=x11",
+		"--socket=wayland",
+		"--socket=pulseaudio",
+		"--device=dri",
+		"--persist=.pioneer"
+	],
+
+	"build-options" : {
+		"cflags": "-O3",
+		"cxxflags": "-O3",
+		"strip": true,
+		"env": {
+			"PIONEER_DATA_DIR": "/app/usr/share/pioneer"
+		}
+	},
+
+	"modules": [
+		{
+			"name": "sigcpp",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "http://ftp.acc.umu.se/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.0.tar.xz",
+					"sha256": "f843d6346260bfcb4426259e314512b99e296e8ca241d771d21ac64f28298d81"
+				}
+			]
+		},
+		{
+			"name": "assimp",
+			"buildsystem": "cmake",
+			"config-opts": [
+				"-DASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT:BOOL=NO",
+				"-DASSIMP_BUILD_COLLADA_IMPORTER:BOOL=YES",
+				"-DASSIMP_BUILD_OBJ_IMPORTER:BOOL=YES",
+				"-DASSIMP_BUILD_3MF_IMPORTER:BOOL=YES",
+				"-DASSIMP_BUILD_ASSIMP_TOOLS:BOOL=NO",
+				"-DASSIMP_BUILD_TESTS:BOOL=NO"
+			],
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://github.com/assimp/assimp/archive/v4.1.0.tar.gz",
+					"sha256": "3520b1e9793b93a2ca3b797199e16f40d61762617e072f2d525fad70f9678a71"
+				}
+			]
+		},
+		{
+			"name": "libglu",
+			"buildsystem": "autotools",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "ftp://ftp.freedesktop.org/pub/mesa/glu/glu-9.0.0.tar.bz2",
+					"sha256": "1f7ad0d379a722fcbd303aa5650c6d7d5544fde83196b42a73d1193568a4df12"
+				}
+			]
+		},
+		{
+			"name": "pioneer",
+			"buildsystem": "autotools",
+			"sources": [
+				{
+					"type": "git",
+					"url": "..",
+					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "pioneer-desktop-and-icon",
+			"buildsystem": "simple",
+			"build-commands": [
+				"install -Dm644 pioneer.desktop /app/share/applications/net.pioneerspacesim.Pioneer.desktop",
+				"install -Dm644 pioneer-16x16.png /app/share/icons/hicolor/16x16/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer-22x22.png /app/share/icons/hicolor/22x22/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer-24x24.png /app/share/icons/hicolor/24x24/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer-32x32.png /app/share/icons/hicolor/32x32/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer-40x40.png /app/share/icons/hicolor/40x40/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer-48x48.png /app/share/icons/hicolor/48x48/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer-64x64.png /app/share/icons/hicolor/64x64/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer-128x128.png /app/share/icons/hicolor/128x128/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer-256x256.png /app/share/icons/hicolor/256x256/apps/net.pioneerspacesim.Pioneer.png",
+				"install -Dm644 pioneer.appdata.xml /app/share/appdata/net.pioneerspacesim.Pioneer.appdata.xml"
+			],
+			"sources": [
+				{ "type": "file", "path": "pioneer.desktop" },
+				{ "type": "file", "path": "pioneer.appdata.xml" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-16x16.png" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-22x22.png" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-24x24.png" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-32x32.png" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-40x40.png" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-48x48.png" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-64x64.png" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-128x128.png" },
+				{ "type": "file", "path": "../application-icon/pngs/pioneer-256x256.png" }
+			]
+		}
+	]
+}

--- a/flatpak/pioneer.appdata.xml
+++ b/flatpak/pioneer.appdata.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+	<id>net.pioneerspacesim.Pioneer</id>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>GPL-3.0-only</project_license>
+	<name>Pioneer</name>
+	<summary>A game of lonely space adventure</summary>
+	<url type="homepage">https://pioneerspacesim.net/</url>
+	<url type="faq">https://pioneerwiki.com/wiki/FAQ</url>
+	<launchable type="desktop-id">net.pioneerspacesim.Pioneer</launchable>
+
+	<description>
+		<p>Pioneer is a space adventure game set in our galaxy at the
+			turn of the 31st century.
+		</p>
+		<p>The game is open-ended, and you are free to eke out whatever
+			kind of space-faring existence you can think of. Look
+			for fame or fortune by exploring the millions of star
+			systems. Turn to a life of crime as a pirate, smuggler
+			or bounty hunter. Forge and break alliances with the
+			various factions fighting for power, freedom or
+			self-determination. The universe is whatever you make
+			of it.
+		</p>
+		<p>Pioneer is under constant development and has a friendly
+			community of players, modders and developers around it.
+			We release a new version almost every day. We'd love
+			for you to try it and make part of the galaxy your own!
+		</p>
+	</description>
+
+	<categories>
+		<category>Game</category>
+		<category>AdventureGame</category>
+	</categories>
+
+	<content_rating type="oars-1.1">
+		<content_attribute id="violence-fantasy">moderate</content_attribute>
+		<content_attribute id="violence-slavery">mild</content_attribute>
+		<content_attribute id="drugs-alcohol">mild</content_attribute>
+		<content_attribute id="drugs-narcotics">mild</content_attribute>
+	</content_rating>
+
+	<screenshots>
+		<screenshot type="default">
+			<image type="source">https://pioneerspacesim.net/assets/ss1.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss2.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss3.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss4.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss5.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss6.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss7.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss8.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss9.png</image>
+		</screenshot>
+		<screenshot>
+			<image type="source">https://pioneerspacesim.net/assets/ss10.png</image>
+		</screenshot>
+	</screenshots>
+</component>

--- a/flatpak/pioneer.desktop
+++ b/flatpak/pioneer.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Name=Pioneer
+GenericName=Pioneer Space Simulator
+Comment=A game of lonely space adventure
+Exec=/app/bin/pioneer
+Icon=net.pioneerspacesim.Pioneer
+Terminal=false
+Type=Application
+Categories=Game


### PR DESCRIPTION
This recipe allows to build a self-contained FlatPak image, which can be
used to distribute Pioneer to all Linux users on almost every
distribution.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

