### PR TITLE
fix crash if user disables AntiAliasing

### DIFF
--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -139,7 +139,7 @@ local function showVideoOptions()
 	while curAA < maxAAs do
 		if curAA == 0 then
 			table.insert(aaLabels, lui.OFF)
-			table.insert(aaModes, curAA)
+			aaModes[lui.OFF] = curAA
 			curAA = 2
 		else
 			table.insert(aaLabels, 'x'..curAA)


### PR DESCRIPTION
Happens when you try to disable multisampling in settings screen.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

