### PR TITLE
Acceleration cap

### DIFF
--- a/src/LuaShip.cpp
+++ b/src/LuaShip.cpp
@@ -1189,7 +1189,7 @@ static int l_ship_is_hyperspace_active(lua_State *l)
 static int l_ship_get_thruster_state(lua_State *l)
 {
 	Ship *s = LuaObject<Ship>::CheckFromLua(1);
-	vector3d v = s->GetPropulsion()->GetThrusterState();
+	vector3d v = s->GetPropulsion()->GetLinThrusterState();
 	lua_newtable(l);
 	pi_lua_settable(l, "x", v.x);
 	pi_lua_settable(l, "y", v.y);

--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -125,10 +125,10 @@ void Missile::StaticUpdate(const float timeStep)
 	//Add smoke trails for missiles on thruster state
 	static double s_timeAccum = 0.0;
 	s_timeAccum += timeStep;
-	if (!is_equal_exact(GetPropulsion()->GetThrusterState().LengthSqr(), 0.0) && (s_timeAccum > 4 || 0.1*Pi::rng.Double() < timeStep)) {
+	if (!is_equal_exact(GetPropulsion()->GetLinThrusterState().LengthSqr(), 0.0) && (s_timeAccum > 4 || 0.1*Pi::rng.Double() < timeStep)) {
 		s_timeAccum = 0.0;
 		const vector3d pos = GetOrient() * vector3d(0, 0 , 5);
-		const float speed = std::min(10.0*GetVelocity().Length()*std::max(1.0,fabs(GetPropulsion()->GetThrusterState().z)),100.0);
+		const float speed = std::min(10.0*GetVelocity().Length()*std::max(1.0,fabs(GetPropulsion()->GetLinThrusterState().z)),100.0);
 		SfxManager::AddThrustSmoke(this, speed, pos);
 	}
 }

--- a/src/Propulsion.cpp
+++ b/src/Propulsion.cpp
@@ -202,8 +202,7 @@ vector3d Propulsion::GetThrustMax(const vector3d &dir) const
 float Propulsion::GetFuelUseRate()
 {
 	const float denominator = m_fuelTankMass * m_effectiveExhaustVelocity * 10;
-	return denominator > 0 ? GetThrust(THRUSTER_FORWARD)/denominator : 1e9;
-	//return denominator > 0 ? m_linThrust[THRUSTER_FORWARD]/denominator : 1e9;
+	return denominator > 0 ? m_linThrust[THRUSTER_FORWARD]/denominator : 1e9;
 }
 
 void Propulsion::UpdateFuel(const float timeStep)

--- a/src/Propulsion.cpp
+++ b/src/Propulsion.cpp
@@ -127,12 +127,15 @@ vector3d Propulsion::ClampLinThrusterState(const vector3d &levels) const
 	Thruster thruster;
 
 	thruster = (clamped.x > 0) ? THRUSTER_RIGHT : THRUSTER_LEFT;
+	clamped.x = Clamp(clamped.x, -1.0, 1.0);
 	clamped.x *= GetThrust(thruster) / m_linThrust[thruster];
 
 	thruster = (clamped.y > 0) ? THRUSTER_UP : THRUSTER_DOWN;
+	clamped.y = Clamp(clamped.y, -1.0, 1.0);
 	clamped.y *= GetThrust(thruster) / m_linThrust[thruster];
 
 	thruster = (clamped.z > 0) ? THRUSTER_REVERSE : THRUSTER_FORWARD;
+	clamped.z = Clamp(clamped.z, -1.0, 1.0);
 	clamped.z *= GetThrust(thruster) / m_linThrust[thruster];
 
 	return clamped;
@@ -151,9 +154,6 @@ void Propulsion::SetLinThrusterState(const vector3d &levels)
 		m_linThrusters = vector3d(0.0);
 	} else {
 		m_linThrusters = ClampLinThrusterState(levels);
-		m_linThrusters[0] = ClampLinThrusterState(0, m_linThrusters[0]);
-		m_linThrusters[1] = ClampLinThrusterState(1, m_linThrusters[1]);
-		m_linThrusters[2] = ClampLinThrusterState(2, m_linThrusters[2]);
 	}
 }
 

--- a/src/Propulsion.cpp
+++ b/src/Propulsion.cpp
@@ -12,7 +12,7 @@ void Propulsion::SaveToJson(Json::Value &jsonObj, Space *space)
 {
 	//Json::Value PropulsionObj(Json::objectValue); // Create JSON object to contain propulsion data.
 	VectorToJson(jsonObj, m_angThrusters, "ang_thrusters");
-	VectorToJson(jsonObj, m_thrusters, "thrusters");
+	VectorToJson(jsonObj, m_linThrusters, "thrusters");
 	jsonObj["thruster_fuel"] = DoubleToStr( m_thrusterFuel );
 	jsonObj["reserve_fuel"] = DoubleToStr( m_reserveFuel );
 	// !!! These are commented to avoid savegame bumps:
@@ -32,11 +32,14 @@ void Propulsion::LoadFromJson(const Json::Value &jsonObj, Space *space)
 
 	vector3d temp_vector;
 	JsonToVector(&temp_vector, jsonObj, "ang_thrusters");
-	SetAngThrusterState( temp_vector );
+	SetAngThrusterState(temp_vector);
+
 	JsonToVector(&temp_vector, jsonObj, "thrusters");
-	SetThrusterState( temp_vector );
+	SetLinThrusterState(temp_vector);
+
 	m_thrusterFuel = StrToDouble(jsonObj["thruster_fuel"].asString());
 	m_reserveFuel = StrToDouble(jsonObj["reserve_fuel"].asString());
+
 	// !!! This is commented to avoid savegame bumps:
 	//m_fuelTankMass = jsonObj["tank_mass"].asInt();
 };
@@ -44,26 +47,36 @@ void Propulsion::LoadFromJson(const Json::Value &jsonObj, Space *space)
 Propulsion::Propulsion()
 {
 	m_fuelTankMass = 1;
-	for ( int i=0; i< Thruster::THRUSTER_MAX; i++) m_linThrust[i]=0.0;
+	for (int i=0; i< Thruster::THRUSTER_MAX; i++) m_linThrust[i] = 0.0;
+	for (int i=0; i< Thruster::THRUSTER_MAX; i++) m_linAccelerationCap[i] = INFINITY;
 	m_angThrust = 0.0;
 	m_effectiveExhaustVelocity = 100000.0;
-	m_thrusterFuel= 0.0;	// remaining fuel 0.0-1.0
+	m_thrusterFuel= 0.0; //0.0-1.0, remaining fuel
 	m_reserveFuel= 0.0;
-	m_FuelStateChange = false;
-	m_thrusters = vector3d(0,0,0);
+	m_fuelStateChange = false;
+	m_linThrusters = vector3d(0,0,0);
 	m_angThrusters = vector3d(0,0,0);
 	m_smodel = nullptr;
 	m_dBody = nullptr;
+
 }
 
-void Propulsion::Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass, const double effExVel, const float lin_Thrust[], const float ang_Thrust )
+void Propulsion::Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass, const double effExVel, const float lin_Thrust[], const float ang_Thrust)
 {
-		m_fuelTankMass = tank_mass;
-		m_effectiveExhaustVelocity = effExVel;
-		for (int i=0; i<Thruster::THRUSTER_MAX; i++ ) m_linThrust[i] = lin_Thrust[i];
-		m_angThrust = ang_Thrust;
-		m_smodel = m;
-		m_dBody = b;
+	m_fuelTankMass = tank_mass;
+	m_effectiveExhaustVelocity = effExVel;
+	for (int i=0; i<Thruster::THRUSTER_MAX; i++ ) m_linThrust[i] = lin_Thrust[i];
+	for (int i=0; i<Thruster::THRUSTER_MAX; i++ ) m_linAccelerationCap[i] = INFINITY;
+	m_angThrust = ang_Thrust;
+	m_smodel = m;
+	m_dBody = b;
+
+}
+
+void Propulsion::Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass, const double effExVel, const float lin_Thrust[], const float ang_Thrust, const float lin_AccelerationCap[])
+{
+	Init(b, m, tank_mass, effExVel, lin_Thrust, ang_Thrust);
+	for (int i=0; i<Thruster::THRUSTER_MAX; i++ ) m_linAccelerationCap[i] = lin_AccelerationCap[i];
 }
 
 void Propulsion::SetThrustPowerMult(double p, const float lin_Thrust[], const float ang_Thrust)
@@ -73,6 +86,12 @@ void Propulsion::SetThrustPowerMult(double p, const float lin_Thrust[], const fl
 		m_linThrust[i] = lin_Thrust[i] * p;
 	m_angThrust = ang_Thrust * p;
 
+}
+
+void Propulsion::SetAccelerationCapMult(double p, const float lin_AccelerationCap[])
+{
+	for (int i = 0; i<Thruster::THRUSTER_MAX; i++)
+		m_linAccelerationCap[i] = lin_AccelerationCap[i] * p;
 }
 
 void Propulsion::SetAngThrusterState(const vector3d &levels)
@@ -86,56 +105,125 @@ void Propulsion::SetAngThrusterState(const vector3d &levels)
 	}
 }
 
-void Propulsion::SetThrusterState(const vector3d &levels)
+double Propulsion::ClampLinThrusterState(int axis, double level) const
+{
+	level = Clamp(level, -1.0, 1.0);
+	Thruster thruster;
+
+	if (axis == 0) {
+		thruster = (level > 0) ? THRUSTER_RIGHT : THRUSTER_LEFT;
+	} else if (axis == 1) {
+		thruster = (level > 0) ? THRUSTER_UP : THRUSTER_DOWN;
+	} else {
+		thruster = (level > 0) ? THRUSTER_REVERSE : THRUSTER_FORWARD;
+	}
+
+	return level * GetThrust(thruster) / m_linThrust[thruster];
+}
+
+vector3d Propulsion::ClampLinThrusterState(const vector3d &levels) const
+{
+	vector3d clamped = levels;
+	Thruster thruster;
+
+	thruster = (clamped.x > 0) ? THRUSTER_RIGHT : THRUSTER_LEFT;
+	clamped.x *= GetThrust(thruster) / m_linThrust[thruster];
+
+	thruster = (clamped.y > 0) ? THRUSTER_UP : THRUSTER_DOWN;
+	clamped.y *= GetThrust(thruster) / m_linThrust[thruster];
+
+	thruster = (clamped.z > 0) ? THRUSTER_REVERSE : THRUSTER_FORWARD;
+	clamped.z *= GetThrust(thruster) / m_linThrust[thruster];
+
+	return clamped;
+}
+
+void Propulsion::SetLinThrusterState(int axis, double level)
+{
+	if (m_thrusterFuel <= 0.f) level = 0.0;
+	m_linThrusters[axis] = ClampLinThrusterState(axis, level);
+}
+
+
+void Propulsion::SetLinThrusterState(const vector3d &levels)
 {
 	if (m_thrusterFuel <= 0.f) {
-		m_thrusters = vector3d(0.0);
+		m_linThrusters = vector3d(0.0);
 	} else {
-		m_thrusters.x = Clamp(levels.x, -1.0, 1.0);
-		m_thrusters.y = Clamp(levels.y, -1.0, 1.0);
-		m_thrusters.z = Clamp(levels.z, -1.0, 1.0);
+		m_linThrusters = ClampLinThrusterState(levels);
+		m_linThrusters[0] = ClampLinThrusterState(0, m_linThrusters[0]);
+		m_linThrusters[1] = ClampLinThrusterState(1, m_linThrusters[1]);
+		m_linThrusters[2] = ClampLinThrusterState(2, m_linThrusters[2]);
 	}
 }
 
-vector3d Propulsion::GetThrustMax(const vector3d &dir) const
+double Propulsion::GetThrust(Thruster thruster) const
+{
+	// acceleration = thrust / mass
+	// thrust = acceleration * mass
+	const float mass = static_cast<float>(m_dBody->GetMass());
+	return std::min(
+		m_linThrust[thruster],
+		m_linAccelerationCap[thruster] * mass
+	);
+}
+
+vector3d Propulsion::GetThrust(const vector3d &dir) const
 {
 	vector3d maxThrust;
-	maxThrust.x = ((dir.x > 0) ? m_linThrust[THRUSTER_RIGHT] : -m_linThrust[THRUSTER_LEFT] );
-	maxThrust.y = ((dir.y > 0) ? m_linThrust[THRUSTER_UP] : -m_linThrust[THRUSTER_DOWN] );
-	maxThrust.z = ((dir.z > 0) ? m_linThrust[THRUSTER_REVERSE] : -m_linThrust[THRUSTER_FORWARD] );
+
+	maxThrust.x = (dir.x > 0) ? GetThrust(THRUSTER_RIGHT)   : GetThrust(THRUSTER_LEFT);
+	maxThrust.y = (dir.y > 0) ? GetThrust(THRUSTER_UP)      : GetThrust(THRUSTER_DOWN);
+	maxThrust.z = (dir.z > 0) ? GetThrust(THRUSTER_REVERSE) : GetThrust(THRUSTER_FORWARD);
+
 	return maxThrust;
 }
 
 double Propulsion::GetThrustMin() const
 {
-	double val = m_linThrust[THRUSTER_UP];
+	// These are the weakest thrusters in a ship
+	double val = static_cast<double>(m_linThrust[THRUSTER_UP]);
 	val = std::min(val, static_cast<double>(m_linThrust[THRUSTER_RIGHT]));
-	val = std::min(val, static_cast<double>(-m_linThrust[THRUSTER_LEFT]));
+	val = std::min(val, static_cast<double>(m_linThrust[THRUSTER_LEFT]));
 	return val;
+}
+
+vector3d Propulsion::GetThrustMax(const vector3d &dir) const
+{
+	vector3d maxThrust;
+
+	maxThrust.x = (dir.x > 0) ? m_linThrust[THRUSTER_RIGHT]   : m_linThrust[THRUSTER_LEFT];
+	maxThrust.y = (dir.y > 0) ? m_linThrust[THRUSTER_UP]      : m_linThrust[THRUSTER_DOWN];
+	maxThrust.z = (dir.z > 0) ? m_linThrust[THRUSTER_REVERSE] : m_linThrust[THRUSTER_FORWARD];
+
+	return maxThrust;
 }
 
 float Propulsion::GetFuelUseRate()
 {
 	const float denominator = m_fuelTankMass * m_effectiveExhaustVelocity * 10;
-	return denominator > 0 ? -(m_linThrust[THRUSTER_FORWARD])/denominator : 1e9;
+	return denominator > 0 ? GetThrust(THRUSTER_FORWARD)/denominator : 1e9;
+	//return denominator > 0 ? m_linThrust[THRUSTER_FORWARD]/denominator : 1e9;
 }
 
 void Propulsion::UpdateFuel(const float timeStep)
 {
 	const double fuelUseRate = GetFuelUseRate() * 0.01;
-	double totalThrust = (fabs( m_thrusters.x) + fabs(m_thrusters.y) + fabs(m_thrusters.z));
+	double totalThrust = (fabs(m_linThrusters.x) + fabs(m_linThrusters.y) + fabs(m_linThrusters.z));
 	FuelState lastState = GetFuelState();
 	m_thrusterFuel -= timeStep * (totalThrust * fuelUseRate);
 	FuelState currentState = GetFuelState();
 
-	if (currentState != lastState) m_FuelStateChange = true;
-	else m_FuelStateChange = false;
+	if (currentState != lastState) m_fuelStateChange = true;
+	else m_fuelStateChange = false;
 }
 
 // returns speed that can be reached using fuel minus reserve according to the Tsiolkovsky equation
 double Propulsion::GetSpeedReachedWithFuel() const
 {
 	const double mass = m_dBody->GetMass();
+	// Why is the fuel mass multiplied by 1000 and the fuel use rate divided by 1000?
+	// (see Propulsion::UpdateFuel and Propulsion::GetFuelUseRate)
 	const double fuelmass = 1000 * m_fuelTankMass * ( m_thrusterFuel - m_reserveFuel );
 	if (fuelmass < 0) return 0.0;
 	return m_effectiveExhaustVelocity * log( mass/( mass-fuelmass ));
@@ -148,7 +236,7 @@ void Propulsion::Render(Graphics::Renderer *r, const Camera *camera, const vecto
 	 * thruster and so on)... this code is :-/
 	*/
 	//angthrust negated, for some reason
-	if (m_smodel != nullptr ) m_smodel->SetThrust(vector3f( GetThrusterState() ), -vector3f( GetAngThrusterState() ));
+	if (m_smodel != nullptr ) m_smodel->SetThrust(vector3f( GetLinThrusterState() ), -vector3f( GetAngThrusterState() ));
 }
 
 void Propulsion::AIModelCoordsMatchAngVel(const vector3d &desiredAngVel, double softness)
@@ -179,13 +267,13 @@ void Propulsion::AIModelCoordsMatchSpeedRelTo(const vector3d &v, const DynamicBo
 
 void Propulsion::AIAccelToModelRelativeVelocity(const vector3d &v)
 {
-	vector3d difVel = v - m_dBody->GetVelocity() * m_dBody->GetOrient();	// required change in velocity
-	vector3d maxThrust = GetThrustMax(difVel);
+	vector3d difVel = v - m_dBody->GetVelocity() * m_dBody->GetOrient(); // required change in velocity
+	vector3d maxThrust = GetThrust(difVel);
 	vector3d maxFrameAccel = maxThrust * (Pi::game->GetTimeStep() / m_dBody->GetMass());
 
-	SetThrusterState(0, is_zero_exact(maxFrameAccel.x) ? 0.0 : difVel.x / maxFrameAccel.x);
-	SetThrusterState(1, is_zero_exact(maxFrameAccel.y) ? 0.0 : difVel.y / maxFrameAccel.y);
-	SetThrusterState(2, is_zero_exact(maxFrameAccel.z) ? 0.0 : difVel.z / maxFrameAccel.z);	// use clamping
+	SetLinThrusterState(0, is_zero_exact(maxFrameAccel.x) ? 0.0 : difVel.x / maxFrameAccel.x);
+	SetLinThrusterState(1, is_zero_exact(maxFrameAccel.y) ? 0.0 : difVel.y / maxFrameAccel.y);
+	SetLinThrusterState(2, is_zero_exact(maxFrameAccel.z) ? 0.0 : difVel.z / maxFrameAccel.z); // use clamping
 }
 
 /* NOTE: following code were in Ship-AI.cpp file,
@@ -209,12 +297,12 @@ double calc_ivel(double dist, double vel, double acc)
 {
 	bool inv = false;
 	if (dist < 0) { dist = -dist; vel = -vel; inv = true; }
-	double ivel = 0.9 * sqrt(vel*vel + 2.0 * acc * dist);		// fudge hardly necessary
+	double ivel = 0.9 * sqrt(vel*vel + 2.0 * acc * dist); // fudge hardly necessary
 
 	double endvel = ivel - (acc * Pi::game->GetTimeStep());
-	if (endvel <= 0.0) ivel = dist / Pi::game->GetTimeStep();	// last frame discrete correction
-	else ivel = (ivel + endvel) * 0.5;					// discrete overshoot correction
-//	else ivel = endvel + 0.5*acc/PHYSICS_HZ;			// unknown next timestep discrete overshoot correction
+	if (endvel <= 0.0) ivel = dist / Pi::game->GetTimeStep(); // last frame discrete correction
+	else ivel = (ivel + endvel) * 0.5;                        // discrete overshoot correction
+//	else ivel = endvel + 0.5*acc/PHYSICS_HZ;                  // unknown next timestep discrete overshoot correction
 
 	return (inv) ? -ivel : ivel;
 }
@@ -247,12 +335,12 @@ bool Propulsion::AIChangeVelBy(const vector3d &diffvel)
 	vector3d extf = m_dBody->GetExternalForce() * (Pi::game->GetTimeStep() / m_dBody->GetMass());
 	vector3d diffvel2 = diffvel - extf * m_dBody->GetOrient();
 
-	vector3d maxThrust = GetThrustMax(diffvel2);
+	vector3d maxThrust = GetThrust(diffvel2);
 	vector3d maxFrameAccel = maxThrust * (Pi::game->GetTimeStep() / m_dBody->GetMass());
 	vector3d thrust(diffvel2.x / maxFrameAccel.x,
-					diffvel2.y / maxFrameAccel.y,
-					diffvel2.z / maxFrameAccel.z);
-	SetThrusterState(thrust);			// use clamping
+	                diffvel2.y / maxFrameAccel.y,
+	                diffvel2.z / maxFrameAccel.z);
+	SetLinThrusterState(thrust); // use clamping
 	if (thrust.x*thrust.x > 1.0 || thrust.y*thrust.y > 1.0 || thrust.z*thrust.z > 1.0) return false;
 	return true;
 }
@@ -261,7 +349,7 @@ bool Propulsion::AIChangeVelBy(const vector3d &diffvel)
 vector3d Propulsion::AIChangeVelDir(const vector3d &reqdiffvel)
 {
 	// get max thrust in desired direction after external force compensation
-	vector3d maxthrust = GetThrustMax(reqdiffvel);
+	vector3d maxthrust = GetThrust(reqdiffvel);
 	maxthrust += m_dBody->GetExternalForce() * m_dBody->GetOrient();
 	vector3d maxFA = maxthrust * (Pi::game->GetTimeStep() / m_dBody->GetMass());
 	maxFA.x = fabs(maxFA.x); maxFA.y = fabs(maxFA.y); maxFA.z = fabs(maxFA.z);

--- a/src/Propulsion.cpp
+++ b/src/Propulsion.cpp
@@ -188,7 +188,7 @@ double Propulsion::GetThrustMin() const
 	return val;
 }
 
-vector3d Propulsion::GetThrustMax(const vector3d &dir) const
+vector3d Propulsion::GetThrustUncapped(const vector3d &dir) const
 {
 	vector3d maxThrust;
 

--- a/src/Propulsion.h
+++ b/src/Propulsion.h
@@ -28,38 +28,49 @@ class Propulsion : public RefCounted
 		// Inits:
 		Propulsion();
 		virtual ~Propulsion() {};
-		void Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass, const double effExVel, const float lin_Thrust[], const float ang_Thrust );
+		// Acceleration cap is infinite
+		void Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass, const double effExVel, const float lin_Thrust[], const float ang_Thrust);
+		void Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass, const double effExVel, const float lin_Thrust[], const float ang_Thrust, const float lin_AccelerationCap[]);
+
+		virtual void SaveToJson(Json::Value &jsonObj, Space *space);
+		virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 
 		// Bonus:
 		void SetThrustPowerMult(double p, const float lin_Thrust[], const float ang_Thrust);
+		void SetAccelerationCapMult(double p, const float lin_AccelerationCap[]);
 
-		// Thruster functions
-		inline double GetThrustFwd() const { return -m_linThrust[THRUSTER_FORWARD]; }
-		inline double GetThrustRev() const { return m_linThrust[THRUSTER_REVERSE]; }
-		inline double GetThrustUp() const { return m_linThrust[THRUSTER_UP]; }
+		// Thrust and thruster functions
+		double GetThrust(Thruster thruster) const; // Maximum thrust possible within acceleration cap
+		vector3d GetThrust(const vector3d &dir) const;
+		inline double GetThrustFwd() const { return GetThrust(THRUSTER_FORWARD); }
+		inline double GetThrustRev() const { return GetThrust(THRUSTER_REVERSE); }
+		inline double GetThrustUp() const { return GetThrust(THRUSTER_UP); }
 		double GetThrustMin() const;
 		vector3d GetThrustMax(const vector3d &dir) const;
 
-		inline double GetAccelFwd() const { return GetThrustFwd() / m_dBody->GetMass(); }
-		inline double GetAccelRev() const { return GetThrustRev() / m_dBody->GetMass(); }
-		inline double GetAccelUp() const { return GetThrustUp() / m_dBody->GetMass(); }
-		inline double GetAccelMin() const { return GetThrustMin() / m_dBody->GetMass(); };
-		inline double GetAccel(Thruster thruster) const { return fabs(m_linThrust[thruster] / m_dBody->GetMass()); }
+		inline double GetAccel(Thruster thruster) const { return GetThrust(thruster) / m_dBody->GetMass(); }
+		inline double GetAccelFwd() const { return GetAccel(THRUSTER_FORWARD); } //GetThrustFwd() / m_dBody->GetMass(); }
+		inline double GetAccelRev() const { return GetAccel(THRUSTER_REVERSE); } //GetThrustRev() / m_dBody->GetMass(); }
+		inline double GetAccelUp() const { return GetAccel(THRUSTER_UP); } //GetThrustUp() / m_dBody->GetMass(); }
+		inline double GetAccelMin() const { return GetThrustMin() / m_dBody->GetMass(); }
 
-		inline void SetThrusterState(int axis, double level) {
-			if (m_thrusterFuel <= 0.f) level = 0.0;
-			m_thrusters[axis] = Clamp(level, -1.0, 1.0);
-		}
-		void SetThrusterState(const vector3d &levels);
-		void SetAngThrusterState(const vector3d &levels);
+		double ClampLinThrusterState(int axis, double level) const;
+		vector3d ClampLinThrusterState(const vector3d &levels) const;
+
+		void SetLinThrusterState(int axis, double level);
+		void SetLinThrusterState(const vector3d &levels);
+
 		inline void SetAngThrusterState(int axis, double level) { m_angThrusters[axis] = Clamp(level, -1.0, 1.0); }
-		inline vector3d GetThrusterState() const { return m_thrusters; };
+		void SetAngThrusterState(const vector3d &levels);
+
+		inline vector3d GetLinThrusterState() const { return m_linThrusters; };
 		inline vector3d GetAngThrusterState() const { return m_angThrusters; }
-		inline void ClearLinThrusterState() { m_thrusters = vector3d(0,0,0); }
+
+		inline void ClearLinThrusterState() { m_linThrusters = vector3d(0,0,0); }
 		inline void ClearAngThrusterState() { m_angThrusters = vector3d(0,0,0); }
 
-		inline vector3d GetActualLinThrust() const { return m_thrusters * GetThrustMax( m_thrusters ); }
-		inline vector3d GetActualAngThrust() const { return m_angThrust * m_angThrusters; }
+		inline vector3d GetActualLinThrust() const { return m_linThrusters * GetThrustMax(m_linThrusters); }
+		inline vector3d GetActualAngThrust() const { return m_angThrusters * m_angThrust; }
 
 		// Fuel
 		enum FuelState { // <enum scope='Propulsion' name=PropulsionFuelStatus prefix=FUEL_ public>
@@ -68,12 +79,12 @@ class Propulsion : public RefCounted
 			FUEL_EMPTY,
 		};
 
-		inline FuelState GetFuelState() const { return m_thrusterFuel > 0.05f ? FUEL_OK : m_thrusterFuel > 0.0f ? FUEL_WARNING : FUEL_EMPTY; }
+		inline FuelState GetFuelState() const { return (m_thrusterFuel > 0.05f) ? FUEL_OK : (m_thrusterFuel > 0.0f) ? FUEL_WARNING : FUEL_EMPTY; }
 		// fuel left, 0.0-1.0
-		inline double GetFuel() const { return m_thrusterFuel;	}
-		inline void SetFuel(const double f) { m_thrusterFuel = Clamp( f, 0.0, 1.0 ); }
+		inline double GetFuel() const { return m_thrusterFuel; }
 		inline double GetFuelReserve() const { return m_reserveFuel; }
-		inline void SetFuelReserve(const double f) { m_reserveFuel = Clamp( f, 0.0, 1.0 ); }
+		inline void SetFuel(const double f) { m_thrusterFuel = Clamp(f, 0.0, 1.0 ); }
+		inline void SetFuelReserve(const double f) { m_reserveFuel = Clamp(f, 0.0, 1.0 ); }
 		float GetFuelUseRate();
 		// available delta-V given the ship's current fuel minus reserve according to the Tsiolkovsky equation
 		double GetSpeedReachedWithFuel() const;
@@ -84,7 +95,7 @@ class Propulsion : public RefCounted
 		inline float FuelTankMassLeft() { return m_fuelTankMass * m_thrusterFuel; }
 		inline void SetFuelTankMass( int fTank ) { m_fuelTankMass = fTank; }
 		void UpdateFuel(const float timeStep);
-		inline bool IsFuelStateChanged() { return m_FuelStateChange; }
+		inline bool IsFuelStateChanged() { return m_fuelStateChange; }
 
 		void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
 
@@ -94,29 +105,32 @@ class Propulsion : public RefCounted
 		void AIAccelToModelRelativeVelocity(const vector3d &v);
 
 		bool AIMatchVel(const vector3d &vel);
-		bool AIChangeVelBy(const vector3d &diffvel);		// acts in obj space
-		vector3d AIChangeVelDir(const vector3d &diffvel);	// world space, maintain direction
+		bool AIChangeVelBy(const vector3d &diffvel); // acts in object space
+		vector3d AIChangeVelDir(const vector3d &diffvel); // object space, maintain direction
 		void AIMatchAngVelObjSpace(const vector3d &angvel);
 		double AIFaceUpdir(const vector3d &updir, double av=0);
 		double AIFaceDirection(const vector3d &dir, double av=0);
 		vector3d AIGetLeadDir(const Body *target, const vector3d& targaccel, double projspeed);
 
-  public: // was protected:
-		virtual void SaveToJson(Json::Value &jsonObj, Space *space);
-		virtual void LoadFromJson(const Json::Value &jsonObj, Space *space);
 	private:
-		int m_fuelTankMass;
+		// Thrust and thrusters
 		float m_linThrust[THRUSTER_MAX];
 		float m_angThrust;
+		vector3d m_linThrusters; // 0.0-1.0, thruster levels
+		vector3d m_angThrusters; // 0.0-1.0
+		// Used to calculate max linear thrust by limiting the thruster levels
+		float m_linAccelerationCap[THRUSTER_MAX];
+
+		// Fuel
+		int m_fuelTankMass;
+		double m_thrusterFuel; // 0.0-1.0, remaining fuel
+		double m_reserveFuel;  // 0.0-1.0, fuel not to touch for the current AI program
 		double m_effectiveExhaustVelocity;
-		double m_thrusterFuel;	// remaining fuel 0.0-1.0
-		double m_reserveFuel;	// 0-1, fuel not to touch for the current AI program
-		bool m_FuelStateChange;
-		vector3d m_thrusters;
-		vector3d m_angThrusters;
+		bool m_fuelStateChange;
 
 		const DynamicBody *m_dBody;
 		SceneGraph::Model *m_smodel;
+
 };
 
 #endif // PROPULSION_H

--- a/src/Propulsion.h
+++ b/src/Propulsion.h
@@ -40,13 +40,15 @@ class Propulsion : public RefCounted
 		void SetAccelerationCapMult(double p, const float lin_AccelerationCap[]);
 
 		// Thrust and thruster functions
+		// Everything's capped unless specified otherwise.
 		double GetThrust(Thruster thruster) const; // Maximum thrust possible within acceleration cap
 		vector3d GetThrust(const vector3d &dir) const;
 		inline double GetThrustFwd() const { return GetThrust(THRUSTER_FORWARD); }
 		inline double GetThrustRev() const { return GetThrust(THRUSTER_REVERSE); }
 		inline double GetThrustUp() const { return GetThrust(THRUSTER_UP); }
 		double GetThrustMin() const;
-		vector3d GetThrustMax(const vector3d &dir) const;
+
+		vector3d GetThrustUncapped(const vector3d &dir) const;
 
 		inline double GetAccel(Thruster thruster) const { return GetThrust(thruster) / m_dBody->GetMass(); }
 		inline double GetAccelFwd() const { return GetAccel(THRUSTER_FORWARD); } //GetThrustFwd() / m_dBody->GetMass(); }
@@ -54,9 +56,12 @@ class Propulsion : public RefCounted
 		inline double GetAccelUp() const { return GetAccel(THRUSTER_UP); } //GetThrustUp() / m_dBody->GetMass(); }
 		inline double GetAccelMin() const { return GetThrustMin() / m_dBody->GetMass(); }
 
+		// Clamp thruster levels and scale them down so that a level of 1
+		// corresponds to the thrust from GetThrust().
 		double ClampLinThrusterState(int axis, double level) const;
 		vector3d ClampLinThrusterState(const vector3d &levels) const;
 
+		// A level of 1 corresponds to the thrust from GetThrust().
 		void SetLinThrusterState(int axis, double level);
 		void SetLinThrusterState(const vector3d &levels);
 
@@ -69,7 +74,7 @@ class Propulsion : public RefCounted
 		inline void ClearLinThrusterState() { m_linThrusters = vector3d(0,0,0); }
 		inline void ClearAngThrusterState() { m_angThrusters = vector3d(0,0,0); }
 
-		inline vector3d GetActualLinThrust() const { return m_linThrusters * GetThrustMax(m_linThrusters); }
+		inline vector3d GetActualLinThrust() const { return m_linThrusters * GetThrustUncapped(m_linThrusters); }
 		inline vector3d GetActualAngThrust() const { return m_angThrusters * m_angThrust; }
 
 		// Fuel

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -880,13 +880,13 @@ void Ship::DoThrusterSounds() const
 	float v_env = (Pi::game->GetWorldView()->GetCameraController()->IsExternal() ? 1.0f : 0.5f) * Sound::GetSfxVolume();
 	static Sound::Event sndev;
 	float volBoth = 0.0f;
-	volBoth += 0.5f*fabs(GetPropulsion()->GetThrusterState().y);
-	volBoth += 0.5f*fabs(GetPropulsion()->GetThrusterState().z);
+	volBoth += 0.5f*fabs(GetPropulsion()->GetLinThrusterState().y);
+	volBoth += 0.5f*fabs(GetPropulsion()->GetLinThrusterState().z);
 
 	float targetVol[2] = { volBoth, volBoth };
-	if (GetPropulsion()->GetThrusterState().x > 0.0)
-		targetVol[0] += 0.5f*float(GetPropulsion()->GetThrusterState().x);
-	else targetVol[1] += -0.5f*float(GetPropulsion()->GetThrusterState().x);
+	if (GetPropulsion()->GetLinThrusterState().x > 0.0)
+		targetVol[0] += 0.5f*float(GetPropulsion()->GetLinThrusterState().x);
+	else targetVol[1] += -0.5f*float(GetPropulsion()->GetLinThrusterState().x);
 
 	targetVol[0] = v_env * Clamp(targetVol[0], 0.0f, 1.0f);
 	targetVol[1] = v_env * Clamp(targetVol[1], 0.0f, 1.0f);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -246,7 +246,7 @@ void Ship::Init()
 	p.Set("fuelMassLeft", m_stats.fuel_tank_mass_left);
 
 	// Init of Propulsion:
-	GetPropulsion()->Init( this, GetModel(), m_type->fuelTankMass, m_type->effectiveExhaustVelocity, m_type->linThrust, m_type->angThrust );
+	GetPropulsion()->Init( this, GetModel(), m_type->fuelTankMass, m_type->effectiveExhaustVelocity, m_type->linThrust, m_type->angThrust, m_type->linAccelerationCap );
 
 	p.Set("shipName", m_shipName);
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -321,7 +321,7 @@ public:
 	bool AIMatchVel(const vector3d &vel) { return GetPropulsion()->AIMatchVel(vel); }
 	double AIFaceDirection(const vector3d &dir, double av=0) { return GetPropulsion()->AIFaceDirection(dir, av); }
 	void AIMatchAngVelObjSpace(const vector3d &angvel) { return GetPropulsion()->AIMatchAngVelObjSpace(angvel); }
-	void SetThrusterState(int axis, double level) { return GetPropulsion()->SetThrusterState(axis, level); }
+	void SetThrusterState(int axis, double level) { return GetPropulsion()->SetLinThrusterState(axis, level); }
 	void AIModelCoordsMatchAngVel(const vector3d &desiredAngVel, double softness) { return GetPropulsion()->AIModelCoordsMatchAngVel(desiredAngVel, softness); }
 };
 

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -366,7 +366,7 @@ bool AICmdKill::TimeStepUpdate()
 			// else no evade thrust
 		}
 	}
-	else evadethrust = m_prop->GetThrusterState();
+	else evadethrust = m_prop->GetLinThrusterState();
 
 
 	// todo: some logic behind desired range? pass from higher level
@@ -390,8 +390,8 @@ bool AICmdKill::TimeStepUpdate()
 		else if (vdiff*vdiff < 400.0) evadethrust.z = 0.0;
 		else evadethrust.z = (vdiff > 0.0) ? -1.0 : 1.0;
 	}
-	else evadethrust.z = m_prop->GetThrusterState().z;
-	m_prop->SetThrusterState(evadethrust);
+	else evadethrust.z = m_prop->GetLinThrusterState().z;
+	m_prop->SetLinThrusterState(evadethrust);
 
 	return false;
 }
@@ -795,7 +795,7 @@ bool AICmdFlyTo::TimeStepUpdate()
 #ifdef DEBUG_AUTOPILOT
 if (m_ship->IsType(Object::PLAYER))
 Output("Autopilot dist = %.1f, speed = %.1f, zthrust = %.2f, state = %i\n",
-	targdist, relvel.Length(), m_ship->GetThrusterState().z, m_state);
+	targdist, relvel.Length(), m_ship->GetLinThrusterState().z, m_state);
 #endif
 
 	// frame switch stuff - clear children/collision state
@@ -1067,7 +1067,7 @@ bool AICmdDock::TimeStepUpdate()
 
 #ifdef DEBUG_AUTOPILOT
 Output("AICmdDock dist = %.1f, speed = %.1f, ythrust = %.2f, state = %i\n",
-	targdist, relvel.Length(), m_ship->GetThrusterState().y, m_state);
+	targdist, relvel.Length(), m_ship->GetLinThrusterState().y, m_state);
 #endif
 
 	return false;
@@ -1206,9 +1206,9 @@ bool AICmdFlyAround::TimeStepUpdate()
 //	m_ship->AIFaceDirection(newhead-m_ship->GetPosition());
 
 	// termination condition for orbits
-	vector3d thrust = m_prop->GetThrusterState();
+	vector3d thrust = m_prop->GetLinThrusterState();
 	if (m_targmode >= 2 && thrust.LengthSqr() < 0.01) m_targmode++;
-	if (m_targmode == 4) { m_prop->SetThrusterState(vector3d(0.0)); return true; }
+	if (m_targmode == 4) { m_prop->SetLinThrusterState(vector3d(0.0)); return true; }
 	return false;
 }
 

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -33,7 +33,7 @@ const std::string ShipType::MISSILE_UNGUIDED	= "missile_unguided";
 float ShipType::GetFuelUseRate() const
 {
 	const float denominator = fuelTankMass * effectiveExhaustVelocity * 10;
-	return denominator > 0 ? -linThrust[THRUSTER_FORWARD]/denominator : 1e9;
+	return denominator > 0 ? linThrust[THRUSTER_FORWARD]/denominator : 1e9;
 }
 
 // returns velocity of engine exhausts in m/s
@@ -90,6 +90,13 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 	linThrust[THRUSTER_LEFT] = data.get("left_thrust", 0.0f).asFloat();
 	linThrust[THRUSTER_RIGHT] = data.get("right_thrust", 0.0f).asFloat();
 	angThrust = data.get("angular_thrust", 0.0f).asFloat();
+
+	linAccelerationCap[THRUSTER_REVERSE] = data.get("reverse_acceleration_cap", INFINITY).asFloat();
+	linAccelerationCap[THRUSTER_FORWARD] = data.get("forward_acceleration_cap", INFINITY).asFloat();
+	linAccelerationCap[THRUSTER_UP] = data.get("up_acceleration_cap", INFINITY).asFloat();
+	linAccelerationCap[THRUSTER_DOWN] = data.get("down_acceleration_cap", INFINITY).asFloat();
+	linAccelerationCap[THRUSTER_LEFT] = data.get("left_acceleration_cap", INFINITY).asFloat();
+	linAccelerationCap[THRUSTER_RIGHT] = data.get("right_acceleration_cap", INFINITY).asFloat();
 
 	// Parse global thrusters color
 	bool error = false;
@@ -264,6 +271,13 @@ int _define_ship(lua_State *L, ShipType::Tag tag, std::vector<ShipType::Id> *lis
 	s.linThrust[ShipType::THRUSTER_RIGHT] = t.Get("right_thrust", 0.0f);
 	s.angThrust = t.Get("angular_thrust", 0.0f);
 
+	s.linAccelerationCap[ShipType::THRUSTER_REVERSE] = t.Get("reverse_acceleration_cap", INFINITY);
+	s.linAccelerationCap[ShipType::THRUSTER_FORWARD] = t.Get("forward_acceleration_cap", INFINITY);
+	s.linAccelerationCap[ShipType::THRUSTER_UP] = t.Get("up_acceleration_cap", INFINITY);
+	s.linAccelerationCap[ShipType::THRUSTER_DOWN] = t.Get("down_acceleration_cap", INFINITY);
+	s.linAccelerationCap[ShipType::THRUSTER_LEFT] = t.Get("left_acceleration_cap", INFINITY);
+	s.linAccelerationCap[ShipType::THRUSTER_RIGHT] = t.Get("right_acceleration_cap", INFINITY);
+
 	data["cockpit"] = s.cockpitName;
 	data["reverse_thrust"] = s.linThrust[ShipType::THRUSTER_REVERSE];
 	data["forward_thrust"] = s.linThrust[ShipType::THRUSTER_FORWARD];
@@ -272,6 +286,13 @@ int _define_ship(lua_State *L, ShipType::Tag tag, std::vector<ShipType::Id> *lis
 	data["left_thrust"] = s.linThrust[ShipType::THRUSTER_LEFT];
 	data["right_thrust"] = s.linThrust[ShipType::THRUSTER_RIGHT];
 	data["angular_thrust"] = s.angThrust;
+
+	data["reverse_acceleration_cap"] = s.linAccelerationCap[ShipType::THRUSTER_REVERSE];
+	data["forward_acceleration_cap"] = s.linAccelerationCap[ShipType::THRUSTER_FORWARD];
+	data["up_acceleration_cap"] = s.linAccelerationCap[ShipType::THRUSTER_UP];
+	data["down_acceleration_cap"] = s.linAccelerationCap[ShipType::THRUSTER_DOWN];
+	data["left_acceleration_cap"] = s.linAccelerationCap[ShipType::THRUSTER_LEFT];
+	data["right_acceleration_cap"] = s.linAccelerationCap[ShipType::THRUSTER_RIGHT];
 
 	// angthrust fudge (XXX: why?)
 	s.angThrust = s.angThrust / 2;

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -174,10 +174,6 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 		Output("In file \"%s.json\" directional thrusters custom color must be \"r\",\"g\" and \"b\"\n", modelName.c_str());
 		throw ShipTypeLoadError();
 	}
-	// invert values where necessary
-	linThrust[THRUSTER_FORWARD] *= -1.f;
-	linThrust[THRUSTER_LEFT] *= -1.f;
-	linThrust[THRUSTER_DOWN] *= -1.f;
 	// angthrust fudge (XXX: why?)
 	angThrust = angThrust * 0.5f;
 
@@ -277,10 +273,6 @@ int _define_ship(lua_State *L, ShipType::Tag tag, std::vector<ShipType::Id> *lis
 	data["right_thrust"] = s.linThrust[ShipType::THRUSTER_RIGHT];
 	data["angular_thrust"] = s.angThrust;
 
-	// invert values where necessary
-	s.linThrust[ShipType::THRUSTER_FORWARD] *= -1.f;
-	s.linThrust[ShipType::THRUSTER_LEFT] *= -1.f;
-	s.linThrust[ShipType::THRUSTER_DOWN] *= -1.f;
 	// angthrust fudge (XXX: why?)
 	s.angThrust = s.angThrust / 2;
 

--- a/src/ShipType.h
+++ b/src/ShipType.h
@@ -39,6 +39,7 @@ struct ShipType {
 	std::string cockpitName;
 	float linThrust[THRUSTER_MAX];
 	float angThrust;
+	float linAccelerationCap[THRUSTER_MAX];
 	std::map<std::string, int> slots;
 	std::map<std::string, bool> roles;
 	Color globalThrusterColor; // Override default color for thrusters


### PR DESCRIPTION
Add the option to cap the maximum acceleration for each thruster on a ship.
Can be set via the `<direction>_acceleration_cap` field in the ship.json.
If no such field is set for a thruster, it is not acceleration capped.
