### PR TITLE
Add additional tooltips to the settings menu

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -279,6 +279,10 @@
     "description": "",
     "message": "Destroy enemy ship"
   },
+  "DETAIL_DESC": {
+    "description": "tooltip description in settings menu",
+    "message": "Lower gives better performance, at cost of visual aesthetics"
+  },
   "DISMISS": {
     "description": "Terminate crew memeber's contract",
     "message": "Dismiss"
@@ -287,13 +291,25 @@
     "description": "",
     "message": "Display HUD trails"
   },
+  "DISPLAY_HUD_TRAILS_DESC": {
+    "description": "tooltip description in settings menu",
+    "message": "Guides the eye by showing the trajectory of ships on the HUD"
+  },
   "DISPLAY_NAV_TUNNELS": {
     "description": "Settings option: hyperspace tunnel effect",
     "message": "Display nav tunnels"
   },
+  "DISPLAY_NAV_TUNNELS_DESC": {
+    "description": "tooltip description in settings menu",
+    "message": "Shows a virtual tunnel to current selected target on the HUD"
+  },
   "DISPLAY_SPEED_LINES": {
     "description": "Settings option: effect when travelling in space",
     "message": "Display speed lines"
+  },
+  "DISPLAY_SPEED_LINES_DESC": {
+    "description": "tooltip description in settings menu",
+    "message": "Assists the sense of direction of movement in space"
   },
   "DOCKED_AT": {
     "description": "",
@@ -339,9 +355,17 @@
     "description": "Allow the game to autosave when docking",
     "message": "Enable Autosave"
   },
+  "ENABLE_AUTOSAVE_DESC": {
+    "description": "tooltip description in settings menu",
+    "message": "save state when docking, might cause some lag depending on disk access time"
+  },
   "ENABLE_COCKPIT": {
     "description": "Game settings option: to use a cockpit 3D model",
     "message": "Enable cockpit (EXPERIMENTAL)"
+  },
+  "ENABLE_COCKPIT_DESC": {
+    "description": "tooltip description in settings menu",
+    "message": "Display a 3D model of the pilot's cockpit. (Currently the dashboard is a placeholder)"
   },
   "ENABLE_JOYSTICK": {
     "description": "",

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -214,50 +214,50 @@ local function showVideoOptions()
 
 
 	ui.separator()
-	c,selectedDetail = combo(lui.PLANET_DETAIL_DISTANCE, selectedDetail, detailLabels)
+	c,selectedDetail = combo(lui.PLANET_DETAIL_DISTANCE, selectedDetail, detailLabels, lui.DETAIL_DESC)
 	if c then
 		local detail = detailLevels[detailLabels[selectedDetail+1]]
 		Engine.SetPlanetDetailLevel(detail)
 	end
 
-	c,planetTextures = checkbox(lui.PLANET_TEXTURES, planetTextures)
+	c,planetTextures = checkbox(lui.PLANET_TEXTURES, planetTextures, lui.TEXTURE_COMPRESSION)
 	if c then
 		Engine.SetPlanetFractalColourEnabled(planetTextures)
 	end
 
-	c,fractalDetail = combo(lui.FRACTAL_DETAIL, fractalDetail, detailLabels)
+	c,fractalDetail = combo(lui.FRACTAL_DETAIL, fractalDetail, detailLabels, lui.DETAIL_DESC)
 	if c then
 		local detail = detailLevels[detailLabels[fractalDetail+1]]
 		Engine.SetFractalDetailLevel(detail)
 	end
 
-	c,cityDetail = combo(lui.CITY_DETAIL_LEVEL, cityDetail, detailLabels)
+	c,cityDetail = combo(lui.CITY_DETAIL_LEVEL, cityDetail, detailLabels, lui.DETAIL_DESC)
 	if c then
 		local detail = detailLevels[detailLabels[cityDetail+1]]
 		Engine.SetCityDetailLevel(detail)
 	end
 
-	c,displayNavTunnels = checkbox(lui.DISPLAY_NAV_TUNNELS, displayNavTunnels)
+	c,displayNavTunnels = checkbox(lui.DISPLAY_NAV_TUNNELS, displayNavTunnels, lui.DISPLAY_NAV_TUNNELS_DESC)
 	if c then
 		Engine.SetDisplayNavTunnels(displayNavTunnels)
 	end
 
-	c,displaySpeedLines = checkbox(lui.DISPLAY_SPEED_LINES, displaySpeedLines)
+	c,displaySpeedLines = checkbox(lui.DISPLAY_SPEED_LINES, displaySpeedLines, lui.DISPLAY_SPEED_LINES_DESC)
 	if c then
 		Engine.SetDisplaySpeedLines(displaySpeedLines)
 	end
 
-	c,displayHudTrails = checkbox(lui.DISPLAY_HUD_TRAILS, displayHudTrails)
+	c,displayHudTrails = checkbox(lui.DISPLAY_HUD_TRAILS, displayHudTrails, lui.DISPLAY_HUD_TRAILS_DESC)
 	if c then
 		Engine.SetDisplayHudTrails(displayHudTrails)
 	end
 
-	c,enableCockpit = checkbox(lui.ENABLE_COCKPIT, enableCockpit)
+	c,enableCockpit = checkbox(lui.ENABLE_COCKPIT, enableCockpit, lui.ENABLE_COCKPIT_DESC)
 	if c then
 		Engine.SetCockpitEnabled(enableCockpit)
 	end
 
-	c,enableAutoSave = checkbox(lui.ENABLE_AUTOSAVE, enableAutoSave)
+	c,enableAutoSave = checkbox(lui.ENABLE_AUTOSAVE, enableAutoSave, lui.ENABLE_AUTOSAVE_DESC)
 	if c then
 		Engine.SetAutosaveEnabled(enableAutoSave)
 	end
@@ -508,4 +508,3 @@ ui.registerModule("game", optionsWindow)
 ui.registerModule("mainMenu", optionsWindow)
 
 return {}
-


### PR DESCRIPTION
# Add additional tooltips to the settings menu
Having mouse over tooltip for only half of the options in settings menu bugged me. Now, I'm just bugged by some of the tooltip starting with capital letter, and some with lowercase. Not sure what is the most sane? 

@fluffyfreak care to skim through the strings I've added and see that stuff does what I say they do?

## Three for one, one for all!
Planet, City and Fractal detail all use the same generic description: 
```json
  "DETAIL_DESC": {
    "description": "tooltip description in settings menu",
    "message": "Lower gives better performance, at cost of visual aesthetics"
  },
```

## Still lacking description
There are still two options lacking description. Not sure what to put here.

- `Fullscreen` - does this have any impa**k**t on performance?
- `Starfield density` - does this have any impakt on performance?