### PR TITLE
Reduce stock to 0 for non-purchaseable items

### DIFF
--- a/data/ui/StationView/EquipmentMarket.lua
+++ b/data/ui/StationView/EquipmentMarket.lua
@@ -33,7 +33,15 @@ local equipmentMarket = function (args)
 		stationColumns = { "name", "buy", "sell", "mass", "stock" },
 		shipColumns = { "name", "amount", "mass", "massTotal" },
 
-		canTrade = function (e) return e.purchasable and hasTech(e) and not e:IsValidSlot("cargo", Game.player) end,
+		canTrade = function (e) return e.purchasable and not e:IsValidSlot("cargo", Game.player) end,
+		-- how much of this item do we have in stock?
+		getStock = function (e)
+			if hasTech(e) then
+				return Game.player:GetDockedWith():GetEquipmentStock(e)
+			else
+				return 0
+			end
+		end,
 	})
 
 	return


### PR DESCRIPTION
This fixes #4276 or at least tries to avoid the main problem. 
It reduces the available stock of parts to zero for stations that don't have a high enough tech level.

This means that ships can still sell their equipment, but there is never any stock available even after a sale.
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

