### PR TITLE
Spice up the error message with a dose of retro-sillyness

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -111,7 +111,7 @@ void Error(const char *format, ...)
 	va_end(ap);
 
 	Output("error: %s\n", buf);
-	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Pioneer error", buf, 0);
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Pioneer guru meditation error", buf, 0);
 
 	exit(1);
 }


### PR DESCRIPTION
I can think of no better to review this than @fluffyfreak :grinning: 


![guru3-00c06560](https://user-images.githubusercontent.com/619390/44597668-b8302800-a7d0-11e8-9595-a15feb5f4a09.jpg)
