### PR TITLE
Fix for issue #4386

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -75,6 +75,10 @@
     "description": "",
     "message": "Autopilot on"
   },
+  "AUTOPILOT_NOT_INSTALLED": {
+      "description": "",
+      "message": "Autopilot not installed on ship, cannot enable autopilot"
+  },
   "AXIAL_TILT": {
     "description": "",
     "message": "Axial tilt"

--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -75,10 +75,7 @@
     "description": "",
     "message": "Autopilot on"
   },
-  "AUTOPILOT_NOT_INSTALLED": {
-      "description": "",
-      "message": "Autopilot not installed on ship, cannot enable autopilot"
-  },
+  
   "AXIAL_TILT": {
     "description": "",
     "message": "Axial tilt"
@@ -1066,6 +1063,10 @@
   "N_YEARS": {
     "description": "",
     "message": "%years{f.1} years"
+  },
+   "NO_AUTOPILOT_INSTALLED": {
+      "description": "",
+      "message": "Autopilot not installed on ship, cannot enable autopilot"
   },
   "O2_ATMOSPHERE": {
     "description": "",

--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -75,7 +75,6 @@
     "description": "",
     "message": "Autopilot on"
   },
-  
   "AXIAL_TILT": {
     "description": "",
     "message": "Axial tilt"

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -576,45 +576,70 @@ end
 local radial_menu_actions_station = {
 	{icon=ui.theme.icons.comms, tooltip=lc.REQUEST_DOCKING_CLEARANCE,
 	 action=function(target)
-		 local msg = Game.player:RequestDockingClearance(target)
-		 Game.AddCommsLogLine(msg, target.label)
-		 Game.player:SetNavTarget(target)
+			if Game.player:GetEquip('autopilot',0) ~= nil then
+		 		local msg = Game.player:RequestDockingClearance(target)
+		 		Game.AddCommsLogLine(msg, target.label)
+		 		Game.player:SetNavTarget(target)
+		 	else 
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+			end
 	end},
 	{icon=ui.theme.icons.autopilot_dock, tooltip=lc.AUTOPILOT_DOCK_WITH_STATION,
 	 action=function(target)
-		 Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
-		 Game.player:AIDockWith(target)
-		 Game.player:SetNavTarget(target)
+	 		if Game.player:GetEquip('autopilot',0) ~= nil then
+		 		Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
+		 		Game.player:AIDockWith(target)
+		 		Game.player:SetNavTarget(target)
+			else 
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+			end
 	end},
 }
 
 local radial_menu_actions_all_bodies = {
 	{icon=ui.theme.icons.autopilot_fly_to, tooltip=lc.AUTOPILOT_FLY_TO_VICINITY_OF,
 	 action=function(target)
-		 Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
-		 Game.player:AIFlyTo(target)
-		 Game.player:SetNavTarget(target)
+		if Game.player:GetEquip('autopilot',0) ~= nil then
+		 	Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
+		 	Game.player:AIFlyTo(target)
+		 	Game.player:SetNavTarget(target)
+		else 
+			Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+		end
+		
 	end},
 }
 
 local radial_menu_actions_systembody = {
 	{icon=ui.theme.icons.autopilot_low_orbit, tooltip=lc.AUTOPILOT_ENTER_LOW_ORBIT_AROUND,
 	 action=function(target)
-		 Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
-		 Game.player:AIEnterLowOrbit(target)
-		 Game.player:SetNavTarget(target)
+	 		if Game.player:GetEquip('autopilot',0) ~= nil then
+		 		Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
+		 		Game.player:AIEnterLowOrbit(target)
+		 		Game.player:SetNavTarget(target)
+		 	else 
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+			end
 	end},
 	{icon=ui.theme.icons.autopilot_medium_orbit, tooltip=lc.AUTOPILOT_ENTER_MEDIUM_ORBIT_AROUND,
 	 action=function(target)
-		 Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
-		 Game.player:AIEnterMediumOrbit(target)
-		 Game.player:SetNavTarget(target)
+	 		if Game.player:GetEquip('autopilot',0) ~= nil then
+		 		Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
+		 		Game.player:AIEnterMediumOrbit(target)
+		 		Game.player:SetNavTarget(target)
+		 	else 
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+			end
 	end},
 	{icon=ui.theme.icons.autopilot_high_orbit, tooltip=lc.AUTOPILOT_ENTER_HIGH_ORBIT_AROUND,
 	 action=function(target)
-		 Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
-		 Game.player:AIEnterHighOrbit(target)
-		 Game.player:SetNavTarget(target)
+	 		if Game.player:GetEquip('autopilot',0) ~= nil then
+		 		Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
+		 		Game.player:AIEnterHighOrbit(target)
+		 		Game.player:SetNavTarget(target)
+		 	else 
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+			end
 	end},
 }
 

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -581,7 +581,7 @@ local radial_menu_actions_station = {
 		 		Game.AddCommsLogLine(msg, target.label)
 		 		Game.player:SetNavTarget(target)
 		 	else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
+				Game.AddCommsLogLine(lc.NO_AUTOPILOT_INSTALLED)
 			end
 	end},
 	{icon=ui.theme.icons.autopilot_dock, tooltip=lc.AUTOPILOT_DOCK_WITH_STATION,
@@ -591,7 +591,7 @@ local radial_menu_actions_station = {
 		 		Game.player:AIDockWith(target)
 		 		Game.player:SetNavTarget(target)
 			else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
+				Game.AddCommsLogLine(lc.NO_AUTOPILOT_INSTALLED)
 			end
 	end},
 }
@@ -604,7 +604,7 @@ local radial_menu_actions_all_bodies = {
 		 	Game.player:AIFlyTo(target)
 		 	Game.player:SetNavTarget(target)
 		else 
-			Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
+			Game.AddCommsLogLine(lc.NO_AUTOPILOT_INSTALLED)
 		end
 		
 	end},
@@ -618,7 +618,7 @@ local radial_menu_actions_systembody = {
 		 		Game.player:AIEnterLowOrbit(target)
 		 		Game.player:SetNavTarget(target)
 		 	else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
+				Game.AddCommsLogLine(lc.NO_AUTOPILOT_INSTALLED)
 			end
 	end},
 	{icon=ui.theme.icons.autopilot_medium_orbit, tooltip=lc.AUTOPILOT_ENTER_MEDIUM_ORBIT_AROUND,
@@ -628,7 +628,7 @@ local radial_menu_actions_systembody = {
 		 		Game.player:AIEnterMediumOrbit(target)
 		 		Game.player:SetNavTarget(target)
 		 	else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
+				Game.AddCommsLogLine(lc.NO_AUTOPILOT_INSTALLED)
 			end
 	end},
 	{icon=ui.theme.icons.autopilot_high_orbit, tooltip=lc.AUTOPILOT_ENTER_HIGH_ORBIT_AROUND,
@@ -638,7 +638,7 @@ local radial_menu_actions_systembody = {
 		 		Game.player:AIEnterHighOrbit(target)
 		 		Game.player:SetNavTarget(target)
 		 	else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
+				Game.AddCommsLogLine(lc.NO_AUTOPILOT_INSTALLED)
 			end
 	end},
 }

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -576,22 +576,22 @@ end
 local radial_menu_actions_station = {
 	{icon=ui.theme.icons.comms, tooltip=lc.REQUEST_DOCKING_CLEARANCE,
 	 action=function(target)
-			if Game.player:GetEquip('autopilot',0) ~= nil then
+			if next(Game.player:GetEquip('autopilot')) ~= nil then
 		 		local msg = Game.player:RequestDockingClearance(target)
 		 		Game.AddCommsLogLine(msg, target.label)
 		 		Game.player:SetNavTarget(target)
 		 	else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
 			end
 	end},
 	{icon=ui.theme.icons.autopilot_dock, tooltip=lc.AUTOPILOT_DOCK_WITH_STATION,
 	 action=function(target)
-	 		if Game.player:GetEquip('autopilot',0) ~= nil then
+	 		if next(Game.player:GetEquip('autopilot')) ~= nil then
 		 		Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
 		 		Game.player:AIDockWith(target)
 		 		Game.player:SetNavTarget(target)
 			else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
 			end
 	end},
 }
@@ -599,12 +599,12 @@ local radial_menu_actions_station = {
 local radial_menu_actions_all_bodies = {
 	{icon=ui.theme.icons.autopilot_fly_to, tooltip=lc.AUTOPILOT_FLY_TO_VICINITY_OF,
 	 action=function(target)
-		if Game.player:GetEquip('autopilot',0) ~= nil then
+		if next(Game.player:GetEquip('autopilot')) ~= nil then
 		 	Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
 		 	Game.player:AIFlyTo(target)
 		 	Game.player:SetNavTarget(target)
 		else 
-			Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+			Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
 		end
 		
 	end},
@@ -613,32 +613,32 @@ local radial_menu_actions_all_bodies = {
 local radial_menu_actions_systembody = {
 	{icon=ui.theme.icons.autopilot_low_orbit, tooltip=lc.AUTOPILOT_ENTER_LOW_ORBIT_AROUND,
 	 action=function(target)
-	 		if Game.player:GetEquip('autopilot',0) ~= nil then
+	 		if next(Game.player:GetEquip('autopilot')) ~= nil then
 		 		Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
 		 		Game.player:AIEnterLowOrbit(target)
 		 		Game.player:SetNavTarget(target)
 		 	else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
 			end
 	end},
 	{icon=ui.theme.icons.autopilot_medium_orbit, tooltip=lc.AUTOPILOT_ENTER_MEDIUM_ORBIT_AROUND,
 	 action=function(target)
-	 		if Game.player:GetEquip('autopilot',0) ~= nil then
+	 		if next(Game.player:GetEquip('autopilot')) ~= nil then
 		 		Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
 		 		Game.player:AIEnterMediumOrbit(target)
 		 		Game.player:SetNavTarget(target)
 		 	else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
 			end
 	end},
 	{icon=ui.theme.icons.autopilot_high_orbit, tooltip=lc.AUTOPILOT_ENTER_HIGH_ORBIT_AROUND,
 	 action=function(target)
-	 		if Game.player:GetEquip('autopilot',0) ~= nil then
+	 		if next(Game.player:GetEquip('autopilot')) ~= nil then
 		 		Game.player:SetFlightControlState("CONTROL_AUTOPILOT")
 		 		Game.player:AIEnterHighOrbit(target)
 		 		Game.player:SetNavTarget(target)
 		 	else 
-				Game.AddCommsLogLine("Error activating autopilot: No autopilot found")
+				Game.AddCommsLogLine("Error activating autopilot: No autopilot installed")
 			end
 	end},
 }


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
The patch removes the ability to activate the autopilot from the radial menu if the ship does not have an autopilot, it also adds a message stating the error to the player's comms menu, if there is some other place that the message should be I can fix it.
![capture](https://user-images.githubusercontent.com/34953098/44613868-24665800-a7e0-11e8-9643-82ec8330bc76.PNG)

