### PR TITLE
Move JsonUtils.h/cpp from contrib/json/ to src/

### DIFF
--- a/contrib/json/CMakeLists.txt
+++ b/contrib/json/CMakeLists.txt
@@ -2,7 +2,7 @@ project(json LANGUAGES CXX)
 
 set(BUILD_SHARED_LIBS OFF)
 
-add_library(${PROJECT_NAME} jsoncpp.cpp JsonUtils.cpp)
+add_library(${PROJECT_NAME} jsoncpp.cpp)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
 	CXX_STANDARD 11

--- a/contrib/json/Makefile.am
+++ b/contrib/json/Makefile.am
@@ -4,5 +4,5 @@ include $(top_srcdir)/Makefile.common
 AM_CPPFLAGS += -I @top_srcdir@/contrib -std=c++11
 
 noinst_LIBRARIES = libjson.a
-libjson_a_SOURCES = jsoncpp.cpp JsonUtils.cpp
-noinst_HEADERS = json.h JsonUtils.h
+libjson_a_SOURCES = jsoncpp.cpp
+noinst_HEADERS = json.h

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -23,7 +23,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
 #include "graphics/TextureBuilder.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 
 namespace
 {

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -18,7 +18,7 @@
 #include "Game.h"
 #include "LuaEvent.h"
 #include "GameSaveError.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 
 Body::Body() : PropertiedObject(Lua::manager)
 	, m_flags(0)

--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -7,7 +7,7 @@
 #include "Pi.h"
 #include "Game.h"
 #include "GameSaveError.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 
 CameraController::CameraController(RefCountedPtr<CameraContext> camera, const Ship *ship) :
 m_camera(camera),

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -8,7 +8,7 @@
 #include "Planet.h"
 #include "Pi.h"
 #include "GameSaveError.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "Propulsion.h"
 #include "FixedGuns.h"
 

--- a/src/FixedGuns.h
+++ b/src/FixedGuns.h
@@ -8,7 +8,7 @@
 #include "libs.h"
 #include "Space.h"
 #include "Camera.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "scenegraph/Model.h"
 #include "Projectile.h"
 #include "DynamicBody.h"

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -9,7 +9,7 @@
 #include "galaxy/StarSystem.h"
 #include "Pi.h"
 #include "Game.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "GameSaveError.h"
 #include <algorithm>
 

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -15,7 +15,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
 #include "graphics/RenderState.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "GameSaveError.h"
 
 using namespace Graphics;

--- a/src/JsonUtils.cpp
+++ b/src/JsonUtils.cpp
@@ -4,10 +4,11 @@
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #endif
+
 #include <cmath>
 #include "JsonUtils.h"
-#include "../../src/utils.h"
-#include "../../src/GameSaveError.h" // Need this for the exceptions
+#include "utils.h"
+#include "GameSaveError.h" // Need this for the exceptions
 
 extern "C" {
 #ifdef __GNUC__

--- a/src/JsonUtils.h
+++ b/src/JsonUtils.h
@@ -5,11 +5,11 @@
 #define _JSON_UTILS_H
 
 #include "json/json.h"
-#include "../../src/vector3.h"
-#include "../../src/Quaternion.h"
-#include "../../src/matrix3x3.h"
-#include "../../src/matrix4x4.h"
-#include "../../src/Color.h"
+#include "vector3.h"
+#include "Quaternion.h"
+#include "matrix3x3.h"
+#include "matrix4x4.h"
+#include "Color.h"
 
 // To-JSON functions.
 void VectorToJson(Json::Value &jsonObj, const vector3f &vec, const std::string &name);

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -4,7 +4,7 @@
 #include "LuaSerializer.h"
 #include "LuaObject.h"
 #include "GameSaveError.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 
 // every module can save one object. that will usually be a table.  we call
 // each serializer in turn and capture its return value we build a table like

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,6 +54,7 @@ noinst_HEADERS = \
 	Intro.h \
 	IterationProxy.h \
 	JobQueue.h \
+	JsonUtils.h \
 	GameConfig.h \
 	GameSaveError.h \
 	KeyBindings.h \
@@ -200,6 +201,7 @@ pioneer_SOURCES	= \
 	IniConfig.cpp \
 	Intro.cpp \
 	JobQueue.cpp \
+	JsonUtils.cpp \
 	GameConfig.cpp \
 	KeyBindings.cpp \
 	Lang.cpp \
@@ -459,6 +461,7 @@ modelcompiler_SOURCES = \
 	IniConfig.cpp \
 	GameConfig.cpp \
 	JobQueue.cpp \
+	JsonUtils.cpp \
 	Lang.cpp \
 	ModManager.cpp \
 	NavLights.cpp \

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -22,7 +22,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
 #include "graphics/TextureBuilder.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "GameSaveError.h"
 
 std::unique_ptr<Graphics::VertexArray> Projectile::s_sideVerts;

--- a/src/Propulsion.h
+++ b/src/Propulsion.h
@@ -8,7 +8,7 @@
 #include "libs.h"
 #include "Space.h"
 #include "Camera.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "scenegraph/Model.h"
 #include "DynamicBody.h"
 

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -16,7 +16,7 @@
 #include "graphics/Material.h"
 #include "graphics/Renderer.h"
 #include "graphics/TextureBuilder.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "GameSaveError.h"
 
 using namespace Graphics;

--- a/src/Shields.cpp
+++ b/src/Shields.cpp
@@ -8,7 +8,7 @@
 #include "scenegraph/CollisionGeometry.h"
 #include "Ship.h"
 #include "Pi.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "GameSaveError.h"
 #include <sstream>
 

--- a/src/ShipAICmd.h
+++ b/src/ShipAICmd.h
@@ -8,7 +8,7 @@
 #include "SpaceStation.h"
 #include "Pi.h"
 #include "Game.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "GameSaveError.h"
 #include "libs.h"
 

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -21,7 +21,7 @@
 #include "galaxy/StarSystem.h"
 #include "graphics/Graphics.h"
 #include "scenegraph/ModelSkin.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "GameSaveError.h"
 #include <algorithm>
 

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -8,7 +8,7 @@
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
 #include "StringF.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "FindNodeVisitor.h"
 #include "Thruster.h"
 #include "utils.h"

--- a/src/scenegraph/ModelSkin.cpp
+++ b/src/scenegraph/ModelSkin.cpp
@@ -5,7 +5,7 @@
 #include "Model.h"
 #include "StringF.h"
 #include "graphics/TextureBuilder.h"
-#include "json/JsonUtils.h"
+#include "JsonUtils.h"
 #include "GameSaveError.h"
 
 #include "RandomColor.h"

--- a/win32/vs2015/json/json.vcxproj
+++ b/win32/vs2015/json/json.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -36,11 +36,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\contrib\json\json.h" />
-    <ClInclude Include="..\..\..\contrib\json\JsonUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\contrib\json\jsoncpp.cpp" />
-    <ClCompile Include="..\..\..\contrib\json\JsonUtils.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{026FC030-0192-4582-B1AF-F9AADF4D73AD}</ProjectGuid>

--- a/win32/vs2015/json/json.vcxproj.filters
+++ b/win32/vs2015/json/json.vcxproj.filters
@@ -1,11 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClInclude Include="..\..\..\contrib\json\json.h" />
-    <ClInclude Include="..\..\..\contrib\json\JsonUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\contrib\json\jsoncpp.cpp" />
-    <ClCompile Include="..\..\..\contrib\json\JsonUtils.cpp" />
   </ItemGroup>
 </Project>

--- a/win32/vs2015/pioneer.vcxproj
+++ b/win32/vs2015/pioneer.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -408,6 +408,7 @@
     <ClCompile Include="..\..\src\IniConfig.cpp" />
     <ClCompile Include="..\..\src\Intro.cpp" />
     <ClCompile Include="..\..\src\JobQueue.cpp" />
+    <ClCompile Include="..\..\src\JsonUtils.cpp" />
     <ClCompile Include="..\..\src\KeyBindings.cpp" />
     <ClCompile Include="..\..\src\Lang.cpp" />
     <ClCompile Include="..\..\src\Lua.cpp" />
@@ -586,6 +587,7 @@
     <ClInclude Include="..\..\src\IniConfig.h" />
     <ClInclude Include="..\..\src\Intro.h" />
     <ClInclude Include="..\..\src\JobQueue.h" />
+    <ClInclude Include="..\..\src\JsonUtils.h" />
     <ClInclude Include="..\..\src\KeyBindings.h" />
     <ClInclude Include="..\..\src\libs.h" />
     <ClInclude Include="..\..\src\Lua.h" />

--- a/win32/vs2015/pioneer.vcxproj.filters
+++ b/win32/vs2015/pioneer.vcxproj.filters
@@ -381,6 +381,9 @@
     <ClCompile Include="..\..\src\JobQueue.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\JsonUtils.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\contrib\PicoDDS\PicoDDS.cpp">
       <Filter>src</Filter>
     </ClCompile>
@@ -849,6 +852,9 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\JobQueue.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\JsonUtils.h">
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\contrib\PicoDDS\PicoDDS.h">

--- a/win32/vs2017/json/json.vcxproj
+++ b/win32/vs2017/json/json.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -36,11 +36,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\contrib\json\json.h" />
-    <ClInclude Include="..\..\..\contrib\json\JsonUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\contrib\json\jsoncpp.cpp" />
-    <ClCompile Include="..\..\..\contrib\json\JsonUtils.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{026FC030-0192-4582-B1AF-F9AADF4D73AD}</ProjectGuid>

--- a/win32/vs2017/json/json.vcxproj.filters
+++ b/win32/vs2017/json/json.vcxproj.filters
@@ -1,11 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClInclude Include="..\..\..\contrib\json\json.h" />
-    <ClInclude Include="..\..\..\contrib\json\JsonUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\contrib\json\jsoncpp.cpp" />
-    <ClCompile Include="..\..\..\contrib\json\JsonUtils.cpp" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
These files aren't part of the jsoncpp library and are custom for Pioneer. They also directly include various other Pioneer source files. It's awkward having dependencies flowing in both directions between contrib/ and src/. Unfortunately this isn't the only place we've done it.

I have tried to update the VC++ projects as necessary, but I haven't tested them. I have not updated the XCode project.