### PR TITLE
Fix for issue #4411

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -195,16 +195,19 @@ THESE INSTRUCTIONS ARE APPROXIMATE AND ARE UNTESTED; PLEASE SUBMIT CORRECTIONS!
 1.7 Nix - Autotools
 -------------------
 
-1. Install the development environment using the included expressions.
+1. Install nix-shell.
 
-    nix-env -i -f nix/env.nix         # build and install the environment
-    load-env-pioneer                  # load the environment
+2. Install and load the development environment using the included expressions.
 
-2. Run ./bootstrap to generate your 'configure' file
+    nix-shell nix/env.nix             # build, install and load the environment
 
-3. Run ./configure to configure the build.
+3. Run ./bootstrap to generate your 'configure' file.
 
-4. Run make to build everything
+4. Run ./configure to configure the build.
+
+5. Run make to build everything
+
+6. Exit the development environment by exiting the shell.
 
 Executing ./pioneer requires the development environment to be loaded,
 executing ./src/pioneer does not.

--- a/nix/env.nix
+++ b/nix/env.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> { } }:
 let
-  assimp = pkgs.assimp or pkgs.callPackage ./assimp.nix { };
+  assimp = pkgs.assimp or (pkgs.callPackage ./assimp.nix { });
 in
 pkgs.myEnvFun {
   name = "pioneer";


### PR DESCRIPTION
This fixes #4411.

I decided to change the build instructions to mirror what I did (except that I added the `--pure` flag to `nix-shell`, which hides all unspecified software from the spawned shell), because I tested it this way and it worked (`load-env-pioneer` gives me a bunch of errors).

_EDIT by impaktor: fix so it autocloses 4411_