### PR TITLE
Handling corrupt and unopenable saved games.

### DIFF
--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -46,8 +46,13 @@ local function getSaveTooltip(name)
 	if saveFileCache[name] then
 		stats = saveFileCache[name]
 	else
-		stats = Game.SaveGameStats(name)
-		saveFileCache[name] = stats
+		local ok
+		ok, stats = pcall(Game.SaveGameStats, name)
+		if ok then
+			saveFileCache[name] = stats
+		else
+			return stats  -- the error
+		end
 	end
 	ret = lui.GAME_TIME..":    " .. Format.Date(stats.time)
 	if stats.system then    ret = ret .. "\n"..lc.SYSTEM..": " .. stats.system end


### PR DESCRIPTION
This solves issue #4415 by changing the displayed tooltip to either `Lang::COULD_NOT_OPEN_FILENAME` or `Lang::GAME_LOAD_CORRUPT`, depending on what issue was observed.
