### PR TITLE
Fix dual fire weapon origin problems

### DIFF
--- a/src/FixedGuns.h
+++ b/src/FixedGuns.h
@@ -25,7 +25,7 @@ class FixedGuns : public RefCounted
 		FixedGuns();
 		virtual ~FixedGuns();
 		void Init(DynamicBody *b);
-		void InitGun( SceneGraph::Model *m, const char *tag, int num);
+		void InitGuns( SceneGraph::Model *m);
 		void UpdateGuns( float timeStep );
 		bool Fire( const int num, Body* b );
 		bool IsFiring();
@@ -48,9 +48,11 @@ class FixedGuns : public RefCounted
 	private:
 
 		struct GunData {
-			GunData() : pos(0.0f), dir(0.0f), recharge(0.0f), temp_heat_rate(0.0f), temp_cool_rate(0.0f), dual(false) {}
-			vector3f pos;
-			vector3f dir;
+			struct GunLoc {
+				vector3d pos;
+				vector3d dir;
+			};
+			std::vector<GunLoc> locs;
 			float recharge;
 			float temp_heat_rate;
 			float temp_cool_rate;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -255,8 +255,7 @@ void Ship::Init()
 
 	m_landingGearAnimation = GetModel()->FindAnimation("gear_down");
 
-	GetFixedGuns()->InitGun( GetModel(), "tag_gunmount_0", 0);
-	GetFixedGuns()->InitGun( GetModel(), "tag_gunmount_1", 1);
+	GetFixedGuns()->InitGuns( GetModel());
 
 	// If we've got the tag_landing set then use it for an offset
 	// otherwise use zero so that it will dock but look clearly incorrect


### PR DESCRIPTION
Replace the gunmount system with multiple gun mount locations for front/rear guns.

This could be extended later to allow for multi-barrel ships/systems.

Intended to fix #4397 

Problems:
- legacy ships/mods do not support dual-fire weapons
