### PR TITLE
Quick fix for 4418, disallow zero length buffers

### DIFF
--- a/src/ui/TextLayout.cpp
+++ b/src/ui/TextLayout.cpp
@@ -128,7 +128,7 @@ void TextLayout::Draw(const Point &layoutSize, const Point &drawPos, const Point
 		if (!m_vbuffer.Valid() || (m_vbuffer->GetCapacity() < va.GetNumVerts())) {
 			m_vbuffer.Reset(m_font->CreateVertexBuffer(va, true));
 		}
-		else {
+		else if(!va.IsEmpty()) {
 			m_vbuffer->Populate(va);
 		}
 	}


### PR DESCRIPTION
Fixes #4418

Somehow a sentence with 4 words was being turned into a zero length vertex array buffer.
This just prevents this from being passed on.
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

