### PR TITLE
CMake: Make GLEW as external target when using the system one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ endif (WIN32)
 
 option(USE_SYSTEM_LIBGLEW "Use the system's libglew" OFF)
 if (USE_SYSTEM_LIBGLEW)
+	add_library(GLEW::GLEW INTERFACE IMPORTED)
 	find_package(GLEW REQUIRED)
 endif (USE_SYSTEM_LIBGLEW)
 


### PR DESCRIPTION
This avoids an error when USE_SYSTEM_LIBGLEW is OFF then ON from the
GUI of CMake.

Fixes #4409.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>