### PR TITLE
Generate an installer for Windows in the cloud with AppVeyor CI

### DIFF
--- a/CI/appveyor/build.sh
+++ b/CI/appveyor/build.sh
@@ -1,0 +1,26 @@
+#!/c/msys64/usr/bin/bash -l
+
+export PATH=/mingw64/bin:$PATH
+
+# Exit immediately upon error
+set -e
+
+# Echo the commands
+set +v
+
+mkdir -p /c/projects/pioneer/build
+cd /c/projects/pioneer/build
+
+/mingw64/bin/cmake -G 'Unix Makefiles' \
+	-DCMAKE_INSTALL_PREFIX="/c/Program Files/Pioneer" \
+	-DPIONEER_DATA_DIR="/c/Program Files/Pioneer/data" \
+	-DCMAKE_BUILD_TYPE:STRING=Release \
+	-DGIT_EXECUTABLE=/c/Program\\ Files/Git/cmd/git.exe \
+	-DPKG_CONFIG_EXECUTABLE=/mingw64/bin/pkg-config.exe \
+	-DCMAKE_C_COMPILER=/mingw64/bin/x86_64-w64-mingw32-gcc.exe \
+	-DCMAKE_CXX_COMPILER=/mingw64/bin/x86_64-w64-mingw32-g++.exe \
+	-DUSE_SYSTEM_LIBGLEW=ON \
+	-DUSE_SYSTEM_LIBLUA=OFF \
+	/c/projects/pioneer
+
+/mingw64/bin/cmake --build . --target install

--- a/CI/appveyor/prepare.sh
+++ b/CI/appveyor/prepare.sh
@@ -1,0 +1,18 @@
+#!/c/msys64/usr/bin/bash -l
+
+# Exit immediately upon error
+set -e
+
+export PATH=/mingw64/bin:$PATH
+
+# Install dependencies
+/c/msys64/usr/bin/pacman --noconfirm -Sy \
+	mingw-w64-x86_64-cmake \
+	mingw-w64-x86_64-SDL2 \
+	mingw-w64-x86_64-SDL2_image \
+	mingw-w64-x86_64-assimp \
+	mingw-w64-x86_64-freetype \
+	mingw-w64-x86_64-glew \
+	mingw-w64-x86_64-libvorbis \
+	mingw-w64-x86_64-libpng \
+	mingw-w64-x86_64-libsigc++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,13 +224,13 @@ if(USE_PIONEER_THIRDPARTY)
     list(APPEND pioneerLibs Threads::Threads)
 endif()
 
-target_link_libraries(${PROJECT_NAME} LINK_PRIVATE ${pioneerLibs})
-target_link_libraries(modelcompiler LINK_PRIVATE ${pioneerLibs})
-target_link_libraries(savegamedump LINK_PRIVATE ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES})
-
 if (WIN32)
-	target_link_libraries(${PROJECT_NAME} modelcompiler LINK_PRIVATE shlwapi)
+	list(APPEND winLibs shlwapi)
 endif (WIN32)
+
+target_link_libraries(${PROJECT_NAME} LINK_PRIVATE ${pioneerLibs} ${winLibs})
+target_link_libraries(modelcompiler LINK_PRIVATE ${pioneerLibs} ${winLibs})
+target_link_libraries(savegamedump LINK_PRIVATE ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${winLibs})
 
 set_target_properties(${PROJECT_NAME} modelcompiler savegamedump pioneerLib PROPERTIES
 	CXX_STANDARD 11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,8 @@ install(DIRECTORY data/
 )
 
 if (WIN32)
+	configure_file(pioneer.iss.cmakein pioneer.iss @ONLY)
+
 	install(CODE "include(BundleUtilities)
 	fixup_bundle(\"$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/pioneer.exe\" \"\" \"${CMAKE_PROGRAM_PATH}\")"
 	COMPONENT Runtime)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,13 @@ endif (NOT USE_SYSTEM_LIBLUA)
 
 add_library(pioneerLib STATIC ${CXX_FILES})
 
-add_executable(${PROJECT_NAME} WIN32 src/main.cpp)
+if (WIN32)
+	string(TIMESTAMP BUILD_YEAR "%Y")
+	set(RESOURCES ${CMAKE_BINARY_DIR}/pioneer.rc)
+	configure_file(pioneer.rc.cmakein ${RESOURCES} @ONLY)
+endif()
+
+add_executable(${PROJECT_NAME} WIN32 src/main.cpp ${RESOURCES})
 add_executable(modelcompiler WIN32 src/modelcompiler.cpp)
 add_executable(savegamedump WIN32
 	src/savegamedump.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,12 @@ string(TIMESTAMP PROJECT_VERSION "%Y%m%d")
 add_definitions(-DPIONEER_VERSION="${PROJECT_VERSION}")
 
 if (NOT PIONEER_DATA_DIR)
-	file(TO_NATIVE_PATH ${CMAKE_INSTALL_FULL_DATADIR}/pioneer/data PIONEER_DATA_DIR)
-endif(NOT PIONEER_DATA_DIR)
-add_definitions(-DPIONEER_DATA_DIR="${PIONEER_DATA_DIR}")
+	set(PIONEER_DATA_DIR ${CMAKE_INSTALL_FULL_DATADIR}/pioneer/data CACHE PATH
+		"Path where game data will be installed" FORCE)
+endif (NOT PIONEER_DATA_DIR)
+
+file(TO_NATIVE_PATH ${PIONEER_DATA_DIR} _PIONEER_DATA_DIR)
+add_definitions(-DPIONEER_DATA_DIR="${_PIONEER_DATA_DIR}")
 
 if (MINGW)
 	# Enable PRIxYY macros on MinGW
@@ -232,8 +235,8 @@ set_target_properties(${PROJECT_NAME} modelcompiler savegamedump pioneerLib PROP
 install(TARGETS ${PROJECT_NAME} modelcompiler savegamedump
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
-install(DIRECTORY data
-	DESTINATION ${CMAKE_INSTALL_DATADIR}/pioneer
+install(DIRECTORY data/
+	DESTINATION ${PIONEER_DATA_DIR}
 	PATTERN "listdata.*" EXCLUDE
 	PATTERN "Makefile.am" EXCLUDE
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,3 +237,9 @@ install(DIRECTORY data
 	PATTERN "listdata.*" EXCLUDE
 	PATTERN "Makefile.am" EXCLUDE
 )
+
+if (WIN32)
+	install(CODE "include(BundleUtilities)
+	fixup_bundle(\"$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/pioneer.exe\" \"\" \"${CMAKE_PROGRAM_PATH}\")"
+	COMPONENT Runtime)
+endif (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ endif()
 
 include(GNUInstallDirs)
 
+# We don't want a 'bin' folder on Windows
+if (WIN32)
+	set(CMAKE_INSTALL_BINDIR ${CMAKE_INSTALL_PREFIX})
+endif (WIN32)
+
 if (CMAKE_COMPILER_IS_GNUCXX)
     if (NOT IS_TRAVIS)
         add_compile_options(-fdiagnostics-color)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,14 @@ set_target_properties(${PROJECT_NAME} modelcompiler savegamedump pioneerLib PROP
 	CXX_EXTENSIONS ON
 )
 
+# Optimize the models after the modelcompiler is built.
+# This really shouldn't be done inside the source tree...
+add_custom_command(TARGET modelcompiler POST_BUILD
+	COMMAND modelcompiler -b inplace
+	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+	COMMENT "Optimizing models" VERBATIM
+)
+
 install(TARGETS ${PROJECT_NAME} modelcompiler savegamedump
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+clone_depth: 1
+
+install:
+    - cd C:\projects\pioneer
+    - C:\msys64\usr\bin\bash -l /c/projects/pioneer/CI/appveyor/prepare.sh
+
+    #Install Inno Setup
+    - choco install InnoSetup
+    - set PATH=%PATH%;"C:\Program Files (x86)\Inno Setup 5"
+
+build_script:
+    - cd C:\projects\pioneer
+    - C:\msys64\usr\bin\bash -l /c/projects/pioneer/CI/appveyor/build.sh
+
+    #Create the installer and upload artifact
+    - ISCC C:\projects\pioneer\build\pioneer.iss
+    - appveyor PushArtifact C:\projects\pioneer\pioneer-setup.exe

--- a/pioneer.iss.cmakein
+++ b/pioneer.iss.cmakein
@@ -1,0 +1,61 @@
+#define AppExeName "pioneer.exe"
+#define AppName "Pioneer"
+#define AppUrl "https://www.pioneerspacesim.net"
+
+[Setup]
+AppId={{5ba280c9-1d73-4039-b2e1-7fc7800f784c}
+AppName="{#AppName}"
+AppVersion="@PROJECT_VERSION@"
+AppPublisher="{#AppName} Developers"
+AppPublisherURL="{#AppUrl}"
+AppSupportURL="{#AppUrl}"
+AppUpdatesURL="{#AppUrl}"
+AppCopyright="Copyright 2008-@BUILD_YEAR@ {#AppName} developers"
+CreateAppDir=yes
+LicenseFile="C:\projects\pioneer\licenses\GPL-3.txt"
+OutputBaseFilename=pioneer-setup
+OutputDir="C:\projects\pioneer"
+Compression=lzma
+SolidCompression=yes
+ArchitecturesInstallIn64BitMode=x64
+DefaultDirName="@CMAKE_INSTALL_PREFIX@"
+DefaultGroupName=Pioneer
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "brazilianportuguese"; MessagesFile: "compiler:Languages\BrazilianPortuguese.isl"
+Name: "catalan"; MessagesFile: "compiler:Languages\Catalan.isl"
+Name: "corsican"; MessagesFile: "compiler:Languages\Corsican.isl"
+Name: "czech"; MessagesFile: "compiler:Languages\Czech.isl"
+Name: "danish"; MessagesFile: "compiler:Languages\Danish.isl"
+Name: "dutch"; MessagesFile: "compiler:Languages\Dutch.isl"
+Name: "finnish"; MessagesFile: "compiler:Languages\Finnish.isl"
+Name: "french"; MessagesFile: "compiler:Languages\French.isl"
+Name: "german"; MessagesFile: "compiler:Languages\German.isl"
+Name: "greek"; MessagesFile: "compiler:Languages\Greek.isl"
+Name: "hebrew"; MessagesFile: "compiler:Languages\Hebrew.isl"
+Name: "hungarian"; MessagesFile: "compiler:Languages\Hungarian.isl"
+Name: "italian"; MessagesFile: "compiler:Languages\Italian.isl"
+Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
+Name: "norwegian"; MessagesFile: "compiler:Languages\Norwegian.isl"
+Name: "polish"; MessagesFile: "compiler:Languages\Polish.isl"
+Name: "portuguese"; MessagesFile: "compiler:Languages\Portuguese.isl"
+Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
+Name: "scottishgaelic"; MessagesFile: "compiler:Languages\ScottishGaelic.isl"
+Name: "serbiancyrillic"; MessagesFile: "compiler:Languages\SerbianCyrillic.isl"
+Name: "serbianlatin"; MessagesFile: "compiler:Languages\SerbianLatin.isl"
+Name: "slovenian"; MessagesFile: "compiler:Languages\Slovenian.isl"
+Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
+Name: "turkish"; MessagesFile: "compiler:Languages\Turkish.isl"
+Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
+[Files]
+Source: "@CMAKE_INSTALL_PREFIX@\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
+Name: "{commondesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon

--- a/pioneer.rc.cmakein
+++ b/pioneer.rc.cmakein
@@ -1,0 +1,29 @@
+#include <windows.h>
+AppIcon ICON DISCARDABLE "@CMAKE_SOURCE_DIR@/application-icon/pioneer.ico"
+
+LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION @PROJECT_VERSION@
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "FileVersion",        "@PROJECT_VERSION@"
+            VALUE "CompanyName",        "Pioneer developers"
+            VALUE "FileDescription",    "Pioneer Space Simulator"
+            VALUE "InternalName",       "Pioneer"
+            VALUE "LegalCopyright",     "Copyright 2008-@BUILD_YEAR@ Pioneer developers"
+            VALUE "LegalTrademarks",    "https://www.gnu.org/licenses/gpl-3.0.en.html"
+            VALUE "OriginalFilename",   "pioneer.exe"
+            VALUE "ProductName",        "Pioneer"
+            VALUE "ProductVersion",     "@PROJECT_VERSION@"
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1252
+    END
+END


### PR DESCRIPTION
Hi,

This PR adds a few scripts that allows the AppVeyor CI to create Windows builds of Pioneer on each tag, PR or commit. This is really useful to make sure that Windows builds don't get broken in the development process. Besides, creating releases is now very easy, as one can just redistribute the installer generated by AppVeyor that corresponds to the tagged commit.

For now, the generated installer only contains a 64-bit version of the game, but it shouldn't be too hard to alter the script to pack both 32-bit and 64-bit versions in one installer (I don't have time anymore to do it myself) or alter the scripts to do additional things (like pre-compile the models).

To use the AppVeyor CI, visit https://www.appveyor.com/ and sign up with your GitHub account.
In the projects list, click "New project", select "Github" and the Pioneer repository.

No extra configuration should be required, everything is contained within the ```appveyor.yml``` script. The only thing to verify in the project's configuration is that the option "Skip branches without appveyor.yml" is checked.