### PR TITLE
Fix crash when changing distance sort choice

### DIFF
--- a/data/pigui/modules/system-overview-window.lua
+++ b/data/pigui/modules/system-overview-window.lua
@@ -62,6 +62,14 @@ local function getBodyIcon(body)
 end
 
 local function sortByPlayerDistance(a,b)
+	if a.body == nil then
+		return false;
+	end
+	
+	if b.body == nil then
+		return false;
+	end
+	
 	return a.body:DistanceTo(Game.player) < b.body:DistanceTo(Game.player)
 end
 


### PR DESCRIPTION
Guard against the target objects body member being `nil` in some systems.

Fixes #4422 

