### PR TITLE
Added a clang-format harness.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,116 @@
+# Commented out parameters are those with the same value as base LLVM style
+# last sync: Clang 6.0.1
+---
+Language:           Cpp
+BasedOnStyle:       LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+#AlignConsecutiveAssignments: false
+#AlignConsecutiveDeclarations: false
+#AlignEscapedNewlines: Right
+AlignOperands:   false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+#AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+#AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+#AllowShortLoopsOnASingleLine: false
+#AlwaysBreakAfterDefinitionReturnType: None
+#AlwaysBreakAfterReturnType: None
+#AlwaysBreakBeforeMultilineStrings: false
+#AlwaysBreakTemplateDeclarations: false
+#BinPackArguments: true
+#BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+#BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+#BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+#BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+#BreakAfterJavaFieldAnnotations: false
+#BreakStringLiterals: true
+ColumnLimit:     0
+#CommentPragmas:  '^ IWYU pragma:'
+#CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+#DerivePointerAlignment: false
+#DisableFormat:   false
+#ExperimentalAutoDetectBinPacking: false
+#FixNamespaceComments: true
+#ForEachMacros:
+#  - foreach
+#  - Q_FOREACH
+#  - BOOST_FOREACH
+#IncludeBlocks:   Preserve
+IncludeCategories:
+ - Regex:           '^".*"'
+   Priority:        1
+ - Regex:           '^<.*\.h>'
+   Priority:        2
+ - Regex:           '^<.*'
+   Priority:        3
+#IncludeIsMainRegex: '(Test)?$'
+#IndentCaseLabels: false
+#IndentPPDirectives: None
+IndentWidth:        4
+#IndentWrappedFunctionNames: false
+#JavaScriptQuotes: Leave
+#JavaScriptWrapImports: true
+#KeepEmptyLinesAtTheStartOfBlocks: true
+#MacroBlockBegin: ''
+#MacroBlockEnd:   ''
+#MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+#ObjCBlockIndentWidth: 2
+#ObjCSpaceAfterProperty: false
+#ObjCSpaceBeforeProtocolList: true
+#PenaltyBreakAssignment: 2
+#PenaltyBreakBeforeFirstCallParameter: 19
+#PenaltyBreakComment: 300
+#PenaltyBreakFirstLessLess: 120
+#PenaltyBreakString: 1000
+#PenaltyExcessCharacter: 1000000
+#PenaltyReturnTypeOnItsOwnLine: 60
+#PointerAlignment: Right
+#RawStringFormats:
+#  - Delimiter:       pb
+#    Language:        TextProto
+#    BasedOnStyle:    google
+#ReflowComments:  true
+#SortIncludes:    true
+#SortUsingDeclarations: true
+#SpaceAfterCStyleCast: false
+#SpaceAfterTemplateKeyword: true
+#SpaceBeforeAssignmentOperators: true
+#SpaceBeforeParens: ControlStatements
+#SpaceInEmptyParentheses: false
+#SpacesBeforeTrailingComments: 1
+#SpacesInAngles:  false
+#SpacesInContainerLiterals: true
+#SpacesInCStyleCastParentheses: false
+#SpacesInParentheses: false
+#SpacesInSquareBrackets: false
+Standard:           Cpp11
+TabWidth:           4
+UseTab:             Always
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,43 @@
+dist: trusty
 language: cpp
 compiler:
   - gcc
-script: ./bootstrap && ./configure --with-thirdparty=$(pwd)/pioneer-thirdparty LIBS="-ldl -lrt -lpthread" && make
+matrix:
+  include:
+    - env: STATIC_CHECKS=yes
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-format-6.0
+            - libstdc++6 # >= 4.9 needed for clang-format-6.0
+
+    - env: STATIC_CHECKS=no
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - mesa-common-dev
+            - libfreetype6-dev
+            - libfreeimage-dev
+            - libglew-dev
+            - libsigc++-2.0-dev
+            - libvorbis-dev
 before_install:
-     - git clone --depth 1 git://github.com/pioneerspacesim/pioneer-thirdparty.git pioneer-thirdparty
-     - cd pioneer-thirdparty/ && autoconf && ./configure && make assimp && make sdl2 && make sdl2_image && cd ../
-     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-     - sudo apt-get update -qq
-     - sudo apt-get install -qq mesa-common-dev libfreetype6-dev libfreeimage-dev libglew-dev libsigc++-2.0-dev libvorbis-dev gcc-4.8 g++-4.8
-     - sudo rm /usr/bin/gcc /usr/bin/g++
-     - sudo ln -s /usr/bin/gcc-4.8 /usr/bin/gcc
-     - sudo ln -s /usr/bin/g++-4.8 /usr/bin/g++
+  - git clone --depth 1 git://github.com/pioneerspacesim/pioneer-thirdparty.git pioneer-thirdparty
+  - cd pioneer-thirdparty/ && autoconf && ./configure && make assimp && make sdl2 && make sdl2_image && cd ../
+  #- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  #- sudo apt-get update -qq
+  #- sudo apt-get install -qq mesa-common-dev libfreetype6-dev libfreeimage-dev libglew-dev libsigc++-2.0-dev libvorbis-dev gcc-4.8 g++-4.8
+  #- sudo rm /usr/bin/gcc /usr/bin/g++ # GCC is v4.8 in trusty instances.
+  #- sudo ln -s /usr/bin/gcc-4.8 /usr/bin/gcc
+  #- sudo ln -s /usr/bin/g++-4.8 /usr/bin/g++
+script:
+  - if [ "$STATIC_CHECKS" = "yes" ]; then
+      sh ./scripts/clang-format.sh
+    else
+      ./bootstrap && ./configure --with-thirdparty=$(pwd)/pioneer-thirdparty LIBS="-ldl -lrt -lpthread" && make
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
           packages:
             - clang-format-6.0
             - libstdc++6 # >= 4.9 needed for clang-format-6.0
+      script: sh ./scripts/clang-format.sh
 
     - env: STATIC_CHECKS=no
       addons:
@@ -26,18 +27,8 @@ matrix:
             - libglew-dev
             - libsigc++-2.0-dev
             - libvorbis-dev
-before_install:
-  - git clone --depth 1 git://github.com/pioneerspacesim/pioneer-thirdparty.git pioneer-thirdparty
-  - cd pioneer-thirdparty/ && autoconf && ./configure && make assimp && make sdl2 && make sdl2_image && cd ../
-  #- sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  #- sudo apt-get update -qq
-  #- sudo apt-get install -qq mesa-common-dev libfreetype6-dev libfreeimage-dev libglew-dev libsigc++-2.0-dev libvorbis-dev gcc-4.8 g++-4.8
-  #- sudo rm /usr/bin/gcc /usr/bin/g++ # GCC is v4.8 in trusty instances.
-  #- sudo ln -s /usr/bin/gcc-4.8 /usr/bin/gcc
-  #- sudo ln -s /usr/bin/g++-4.8 /usr/bin/g++
-script:
-  - if [ "$STATIC_CHECKS" = "yes" ]; then
-      sh ./scripts/clang-format.sh
-    else
-      ./bootstrap && ./configure --with-thirdparty=$(pwd)/pioneer-thirdparty LIBS="-ldl -lrt -lpthread" && make
-    fi
+      before_install:
+        - git clone --depth 1 git://github.com/pioneerspacesim/pioneer-thirdparty.git pioneer-thirdparty
+        - cd pioneer-thirdparty/ && autoconf && ./configure && make assimp && make sdl2 && make sdl2_image && cd ../
+      script:
+        - ./bootstrap && ./configure --with-thirdparty=$(pwd)/pioneer-thirdparty LIBS="-ldl -lrt -lpthread" && make

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 CLANG_FORMAT="clang-format"
+if [ "$TRAVIS" = "true" ]; then
+    CLANG_FORMAT="$CLANG_FORMAT-6.0"
+fi
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     # Check the whole commit range against $TRAVIS_BRANCH, the base merge branch

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+CLANG_FORMAT="clang-format"
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    # Check the whole commit range against $TRAVIS_BRANCH, the base merge branch
+    # We could use $TRAVIS_COMMIT_RANGE but it doesn't play well with force pushes
+    RANGE="$(git rev-parse $TRAVIS_BRANCH) HEAD"
+else
+    # Test only the last commit
+    RANGE=HEAD
+fi
+
+# Allow manually specifiying the files.
+if [ -z "$FILES" ]; then
+    FILES=$(git diff-tree --no-commit-id --name-only -r $RANGE | grep -v contrib/ | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc)$")
+fi
+echo -e "Checking files:\n$FILES"
+
+prefix="static-check-clang-format"
+suffix="$(date +%s)"
+patch="/tmp/$prefix-$suffix.patch"
+
+for file in $FILES; do
+    "$CLANG_FORMAT" -style=file "$file" | \
+    diff -u "$file" - | \
+    sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+done
+
+# if no patch has been generated all is ok, clean up the file stub and exit
+if [ ! -s "$patch" ] ; then
+    printf "Files in this commit comply with the clang-format rules.\n"
+    rm -f "$patch"
+    exit 0
+fi
+
+# a patch has been created, notify the user and exit
+printf "\n*** The following differences were found between the code to commit "
+printf "and the clang-format rules:\n\n"
+cat "$patch"
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+exit 1

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -47,5 +47,6 @@ fi
 printf "\n*** The following differences were found between the code to commit "
 printf "and the clang-format rules:\n-----\n"
 cat "$patch"
+rm -f "$patch"
 printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
 exit 1

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -14,9 +14,15 @@ else
     RANGE=HEAD
 fi
 
+if [ -n "$TRAVIS" ]; then
+    GIT_DIFF_TOOL="git diff-tree"
+else
+    GIT_DIFF_TOOL="git diff-index"
+fi
+
 # Allow manually specifiying the files.
 if [ -z "$FILES" ]; then
-    FILES=$(git diff-tree --no-commit-id --name-only -r $RANGE | grep -v contrib/ | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc)$")
+    FILES=$($GIT_DIFF_TOOL --no-commit-id --name-only -r $RANGE | grep -v contrib/ | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc)$")
 fi
 echo -e "Checking files:\n$FILES"
 
@@ -39,7 +45,7 @@ fi
 
 # a patch has been created, notify the user and exit
 printf "\n*** The following differences were found between the code to commit "
-printf "and the clang-format rules:\n\n"
+printf "and the clang-format rules:\n-----\n"
 cat "$patch"
 printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
 exit 1

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Run clang-format, storing the output in MSG
+# Git runs hooks in the base directory, so we don't need to do any fancy dirname stuff.
+MSG="$(./scripts/clang-format.sh)"
+# $? will be non-zero if clang-format detected formatting issues.
+if [ "$?" != 0 ]; then
+    # We've had a major malfunction!
+    echo "$MSG"
+    read -p "Do you want to automatically apply these changes (y/N)?" apply
+    case "$apply" in
+        y|Y)
+            # Get the patch info from the message
+            patch="/tmp/$(date +%s).patch"
+            echo "$MSG" | git mailinfo --scissors /dev/null "$patch" &>/dev/null
+            # And apply it to the staged changes.
+            git apply --index "$patch"
+            rm "$patch"
+            ;;
+        *) exit 1;;
+    esac
+else
+    # All good, carry on.
+    exit 0
+fi


### PR DESCRIPTION
Per my conversation on IRC, I have implemented a harness for clang-format, mostly adapted from Godot's implementation.

The general gist of it is that, when properly hooked up in `travis.yml`, it will check all changed files in a PR to ensure that they adhere to the code style of the project, generating an error in the CI check if they are wrongly formatted. This will happen alongside the existing code compilation check and an error here will not affect the compilation step.

As the Pioneer code base is wildly inconsistent in and of itself, I have attempted to set sane and compliant defaults for clang-format. However, some limitations of the tool are insurmountable via mere configs - for example, the alignment of pointers and references are both controlled by the same clang-format switch. I would appreciate a review of the clang-format style from the core maintainers.

You can test the current rules by changing a `.h/.cpp` file and running `./scripts/clang-format.sh`. This is designed to run on a *nix / Mac system (e.g. Travis), so it is unfortunately unavailable to run locally on a non Unix-capable Windows development environment.

Running clang-format on the existing codebase is well beyond the scope of this PR, and will need to be carried out by the core team.

TODO:
- Get core maintainers to sign off on the `.clang-format` style.
- [x] Hook up to `travis.yml`.
- [x] Add a pre-commit hook to run clang-format automatically, giving the user an option to automatically apply the generated diffs.

Comments / critiques are welcome and requested.