### PR TITLE
Miscellaneous fixes (from #4207) 

### DIFF
--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -755,7 +755,7 @@ ui.gauge_height = 25
 ui.gauge_width = 275
 
 ui.gauge = function(position, value, unit, format, minimum, maximum, icon, color, tooltip)
-	local percent = (value - minimum) / (maximum - minimum)
+	local percent = math.clamp((value - minimum) / (maximum - minimum), 0, 1)
 	local offset = 60
 	local uiPos = position
 	ui.withFont(ui.fonts.pionillium.medium.name, ui.fonts.pionillium.medium.size, function()

--- a/src/FixedGuns.h
+++ b/src/FixedGuns.h
@@ -48,6 +48,7 @@ class FixedGuns : public RefCounted
 	private:
 
 		struct GunData {
+			GunData() : pos(0.0f), dir(0.0f), recharge(0.0f), temp_heat_rate(0.0f), temp_cool_rate(0.0f), dual(false) {}
 			vector3f pos;
 			vector3f dir;
 			float recharge;

--- a/src/Projectile.h
+++ b/src/Projectile.h
@@ -10,6 +10,7 @@
 #include "graphics/RenderState.h"
 
 struct ProjectileData {
+	ProjectileData() : lifespan(0.0f), damage(0.0f), length(0.0f), width(0.0f), speed(0.0f), color(Color::WHITE), mining(false), beam(false) {}
 	float lifespan;
 	float damage;
 	float length;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -614,7 +614,6 @@ void Ship::UpdateGunsStats() {
 		Properties().Get(prefix+"damage", damage);
 		if (!damage) {
 			GetFixedGuns()->UnMountGun(num);
-			return;
 		} else {
 			Properties().PushLuaTable();
 			LuaTable prop(Lua::manager->GetLuaState(), -1);


### PR DESCRIPTION
This is just a cherry-pick of @fluffyfreak's fixes that were added to #4207.

Clamp percent value in pigui. Supply default ctors for FixedGuns and ProjectileData. Update all guns in UpdateGunsStats.