### PR TITLE
Move Hyperspace exit locations into the heart of systems

### DIFF
--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -8,6 +8,7 @@
 #include "Game.h"
 #include "GameSaveError.h"
 #include "JsonUtils.h"
+#include "MathUtil.h"
 
 CameraController::CameraController(RefCountedPtr<CameraContext> camera, const Ship *ship) :
 m_camera(camera),
@@ -488,15 +489,6 @@ void FlyByCameraController::Reset()
 	SetPosition(vector3d(0, 0, 0));
 }
 
-static matrix3x3d LookAt(const vector3d eye, const vector3d target, const vector3d up)
-{
-	const vector3d z = (eye - target).NormalizedSafe();
-	const vector3d x = (up.Cross(z)).NormalizedSafe();
-	const vector3d y = (z.Cross(x)).NormalizedSafe();
-
-	return matrix3x3d::FromVectors(x, y, z);
-}
-
 void FlyByCameraController::Update()
 {
 	const Ship *ship = GetShip();
@@ -513,7 +505,7 @@ void FlyByCameraController::Update()
 	m_flybyOrient.Renormalize();
 	camerap = m_old_pos + m_flybyOrient.VectorZ() * m_dist;
 	SetPosition(camerap);
-	camerao = LookAt(camerap, ship_pos, vector3d(0, 1, 0));
+	camerao = MathUtil::LookAt(camerap, ship_pos, vector3d(0, 1, 0));
 	const vector3d rotAxis = camerao.VectorZ();
 	camerao = matrix3x3d::Rotate(m_roll, rotAxis) * camerao;
 	SetOrient(camerao);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -479,9 +479,60 @@ void Game::SwitchToNormalSpace()
 	m_space->AddBody(m_player.get());
 
 	// place it
-	m_player->SetPosition(m_space->GetHyperspaceExitPoint(m_hyperspaceSource, m_hyperspaceDest));
-	m_player->SetVelocity(vector3d(0,0,-100.0));
-	m_player->SetOrient(matrix3x3d::Identity());
+	vector3d position = m_space->GetHyperspaceExitPoint(m_hyperspaceSource, m_hyperspaceDest);
+	m_player->SetPosition(position);
+
+	// calculate orbital velocity
+	vector3d orbVelocity(0, 0, -100.0);
+	matrix3x3d orientation(matrix3x3d::Identity());
+	{
+		auto dest = m_hyperspaceDest;
+
+		Body *primary = nullptr;
+		if (dest.IsBodyPath()) {
+			assert(dest.bodyIndex < m_space->GetStarSystem()->GetNumBodies());
+			primary = m_space->FindBodyForPath(&dest);
+			while (primary && primary->GetSystemBody()->GetSuperType() != SystemBody::SUPERTYPE_STAR) {
+				SystemBody* parent = primary->GetSystemBody()->GetParent();
+				primary = parent ? m_space->FindBodyForPath(&parent->GetPath()) : 0;
+			}
+		}
+		if (!primary) {
+			// find the first non-gravpoint. should be the primary star
+			for (Body* b : m_space->GetBodies())
+				if (b->GetSystemBody()->GetType() != SystemBody::TYPE_GRAVPOINT) {
+					primary = b;
+					break;
+				}
+		}
+		assert(primary);
+
+		// wtf andy?
+		vector3d direction = (primary->GetPosition() - position);
+		double alt = direction.Length();
+
+		// push out of effect radius (gravity safety & station parking zones)
+		alt = std::max(alt, std::max(primary->GetPhysRadius(), sqrt(G * primary->GetMass() / m_player->GetPropulsion()->GetAccelUp())));
+
+		// drag within frame because orbits are impossible otherwise
+		// timestep code also doesn't work correctly for ex-frame cases, should probably be fixed 
+		alt = std::min(alt, 0.95 * primary->GetFrame()->GetNonRotFrame()->GetRadius());
+
+		// generate suitable velocity if none provided
+		double minacc = m_player->GetPropulsion()->GetAccelMin();
+		double mass = primary->IsType(Object::TERRAINBODY) ? primary->GetMass() : 0;
+
+		double vel = sqrt(alt * 0.8 * minacc + mass * G / alt);
+
+		// ...there are so many things wrong with this...
+		vector3d up(direction.z, direction.y, direction.x);
+		vector3d tangent(direction.Cross(up).Normalized());
+		orbVelocity = tangent * vel;
+
+		//orientation = matrix3x3d::FromVectors(tangent, direction);
+	}
+	m_player->SetVelocity(orbVelocity);
+	m_player->SetOrient(orientation);
 
 	// place the exit cloud
 	HyperspaceCloud *cloud = new HyperspaceCloud(0, Pi::game->GetTime(), true);
@@ -502,7 +553,7 @@ void Game::SwitchToNormalSpace()
 			Ship *ship = cloud->EvictShip();
 
 			ship->SetFrame(m_space->GetRootFrame());
-			ship->SetVelocity(vector3d(0,0,-100.0));
+			ship->SetVelocity(orbVelocity*0.9999);
 			ship->SetOrient(matrix3x3d::Identity());
 			ship->SetFlightState(Ship::FLYING);
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -488,6 +488,7 @@ void Game::SwitchToNormalSpace()
 	{
 		auto dest = m_hyperspaceDest;
 
+		// find the primary body in this system
 		Body *primary = nullptr;
 		if (dest.IsBodyPath()) {
 			assert(dest.bodyIndex < m_space->GetStarSystem()->GetNumBodies());
@@ -499,11 +500,12 @@ void Game::SwitchToNormalSpace()
 		}
 		if (!primary) {
 			// find the first non-gravpoint. should be the primary star
-			for (Body* b : m_space->GetBodies())
+			for (Body* b : m_space->GetBodies()) {
 				if (b->GetSystemBody()->GetType() != SystemBody::TYPE_GRAVPOINT) {
 					primary = b;
 					break;
 				}
+			}
 		}
 		assert(primary);
 
@@ -521,7 +523,6 @@ void Game::SwitchToNormalSpace()
 		// generate suitable velocity if none provided
 		double minacc = m_player->GetPropulsion()->GetAccelMin();
 		double mass = primary->IsType(Object::TERRAINBODY) ? primary->GetMass() : 0;
-
 		double vel = sqrt(alt * 0.8 * minacc + mass * G / alt);
 
 		// ...there are so many things wrong with this...
@@ -529,7 +530,8 @@ void Game::SwitchToNormalSpace()
 		vector3d tangent(direction.Cross(up).Normalized());
 		orbVelocity = tangent * vel;
 
-		//orientation = matrix3x3d::FromVectors(tangent, direction);
+		// finally orient the ship in the direction in which we exited from hyperspace
+		orientation = MathUtil::LookAt(position, position + tangent.Normalized(), vector3d(0.0, 1.0, 0.0)); // this probably doesn't always want to be "up"
 	}
 	m_player->SetVelocity(orbVelocity);
 	m_player->SetOrient(orientation);

--- a/src/GasGiantJobs.cpp
+++ b/src/GasGiantJobs.cpp
@@ -207,15 +207,7 @@ namespace GasGiantJobs
 	void SGPUGenResult::OnCancel()	{
 		if( mData.texture ) { mData.texture.Reset(); }
 	}
-
-	//static matrix3x3f LookAt (const vector3f &eye, const vector3f &target, const vector3f &up) {
-	//	const vector3f viewDir  = (target - eye).Normalized();
-	//	const vector3f viewUp   = (up - up.Dot(viewDir) * viewDir).Normalized();
-	//	const vector3f viewSide = viewDir.Cross(viewUp);
-	//
-	//	return matrix3x3f::FromVectors(viewSide, viewUp, -viewDir);
-	//}
-
+	
 	// ********************************************************************************
 	// Overloaded JobGPU class to handle generating the mesh for each patch
 	// ********************************************************************************

--- a/src/MathUtil.h
+++ b/src/MathUtil.h
@@ -39,6 +39,15 @@ namespace MathUtil {
 	float DistanceFromLineSegment(const vector3f& start, const vector3f& end, const vector3f& pos, bool& isWithinLineSegment);
 	float DistanceFromLine(const vector3f& start, const vector3f& end, const vector3f& pos);
 
+	inline static matrix3x3d LookAt(const vector3d eye, const vector3d target, const vector3d up)
+	{
+		const vector3d z = (eye - target).NormalizedSafe();
+		const vector3d x = (up.Cross(z)).NormalizedSafe();
+		const vector3d y = (z.Cross(x)).NormalizedSafe();
+
+		return matrix3x3d::FromVectors(x, y, z);
+	}
+
 //#define TEST_MATHUTIL
 #ifdef TEST_MATHUTIL
 	bool TestDistanceFromLine();

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -371,7 +371,7 @@ vector3d Space::GetHyperspaceExitPoint(const SystemPath &source, const SystemPat
 	// point along the line between source and dest, a reasonable distance
 	// away based on the radius (don't want to end up inside black holes, and
 	// then mix it up so that ships don't end up on top of each other
-	vector3d pos = (sourcePos - destPos).Normalized() * (primary->GetSystemBody()->GetRadius()/AU+1.0)*11.0*AU*Pi::rng.Double(0.95,1.2) + MathUtil::RandomPointOnSphere(5.0,20.0)*1000.0;
+	vector3d pos = (sourcePos - destPos).Normalized() * (primary->GetSystemBody()->GetRadius() * 3.0) + MathUtil::RandomPointOnSphere(5.0, 20.0)*1000.0;
 	assert(pos.Length() > primary->GetSystemBody()->GetRadius());
 	return pos + primary->GetPositionRelTo(GetRootFrame());
 }

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -368,10 +368,12 @@ vector3d Space::GetHyperspaceExitPoint(const SystemPath &source, const SystemPat
 	}
 	assert(primary);
 
+	vector3d dist = (primary->GetSystemBody()->GetRadius() * 3.0) + MathUtil::RandomPointOnSphere(5.0, 20.0)*1000.0;
+
 	// point along the line between source and dest, a reasonable distance
 	// away based on the radius (don't want to end up inside black holes, and
 	// then mix it up so that ships don't end up on top of each other
-	vector3d pos = (sourcePos - destPos).Normalized() * (primary->GetSystemBody()->GetRadius() * 3.0) + MathUtil::RandomPointOnSphere(5.0, 20.0)*1000.0;
+	vector3d pos = (sourcePos - destPos).Normalized() * dist;
 	assert(pos.Length() > primary->GetSystemBody()->GetRadius());
 	return pos + primary->GetPositionRelTo(GetRootFrame());
 }


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Does what it says on the tin and makes the hyperspace exit point be uncomfortably close to the systems hyperspace target star.

- [x] Should add a velocity for safe orbital speed
- [x] Orients the ship in direction of travel

I'm actually going to say that this is ready for testing now. It needs people to go about the galaxy jumping from place to place. Some stars are already pretty close in, others far out.

Ready for testing and feedback.

<!-- Please make sure you've read documentation on contributing -->


