### PR TITLE
SystemPath was not fully specified causing a crash

### DIFF
--- a/data/modules/MusicPlayer.lua
+++ b/data/modules/MusicPlayer.lua
@@ -58,7 +58,7 @@ end
 local playAmbient = function ()
 	local category
 
-	local sol = SystemPath.New(0, 0, 0)
+	local sol = SystemPath.New(0, 0, 0, 0, 0)
 	local unexplored_distance = 690
 
 	-- if we're near a planet or spacestation then choose something specific

--- a/src/LuaStarSystem.cpp
+++ b/src/LuaStarSystem.cpp
@@ -359,9 +359,17 @@ static int l_starsystem_distance_to(lua_State *l)
 	RefCountedPtr<const Sector> sec1 = s->m_galaxy->GetSector(*loc1);
 	RefCountedPtr<const Sector> sec2 = s->m_galaxy->GetSector(*loc2);
 
-	double dist = Sector::DistanceBetween(sec1, loc1->systemIndex, sec2, loc2->systemIndex);
-
-	lua_pushnumber(l, dist);
+	// this only works if the SystemPath is valid
+	if (loc1->HasValidSystem() && loc2->HasValidSystem())
+	{
+		double dist = Sector::DistanceBetween(sec1, loc1->systemIndex, sec2, loc2->systemIndex);
+		lua_pushnumber(l, dist);
+	}
+	else
+	{
+		lua_pushnumber(l, FLT_MAX);
+		return luaL_error(l, "Cannot compare non-systemPaths");
+	}
 
 	LUA_DEBUG_END(l, 1);
 	return 1;


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
The systemIndex component was `-1` which was then being used as an index.

I have no idea why only I'm seeing this since it should be crashing everyone's games
<!-- Please make sure you've read documentation on contributing -->

