### PR TITLE
Save game optimisations

### DIFF
--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -153,7 +153,6 @@ void Beam::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	if (!jsonObj.isMember("projectile")) throw SavedGameCorruptException();
 	Json::Value projectileObj = jsonObj["projectile"];
 
-	if (!projectileObj.isMember("dir")) throw SavedGameCorruptException();
 	if (!projectileObj.isMember("base_dam")) throw SavedGameCorruptException();
 	if (!projectileObj.isMember("length")) throw SavedGameCorruptException();
 	if (!projectileObj.isMember("mining")) throw SavedGameCorruptException();

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -101,10 +101,6 @@ void DynamicBody::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	if (!jsonObj.isMember("dynamic_body")) throw SavedGameCorruptException();
 	Json::Value dynamicBodyObj = jsonObj["dynamic_body"];
 
-	if (!dynamicBodyObj.isMember("force")) throw SavedGameCorruptException();
-	if (!dynamicBodyObj.isMember("torque")) throw SavedGameCorruptException();
-	if (!dynamicBodyObj.isMember("vel")) throw SavedGameCorruptException();
-	if (!dynamicBodyObj.isMember("ang_vel")) throw SavedGameCorruptException();
 	if (!dynamicBodyObj.isMember("mass")) throw SavedGameCorruptException();
 	if (!dynamicBodyObj.isMember("mass_radius")) throw SavedGameCorruptException();
 	if (!dynamicBodyObj.isMember("ang_inertia")) throw SavedGameCorruptException();

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -28,10 +28,8 @@ Frame::Frame(Frame *parent, const char *label, unsigned int flags)
 	Init(parent, label, flags);
 }
 
-void Frame::ToJson(Json::Value &jsonObj, Frame *f, Space *space)
+void Frame::ToJson(Json::Value &frameObj, Frame *f, Space *space)
 {
-	Json::Value frameObj(Json::objectValue); // Create JSON object to contain frame data.
-
 	frameObj["flags"] = f->m_flags;
 	frameObj["radius"] = DoubleToStr(f->m_radius);
 	frameObj["label"] = f->m_label;
@@ -48,27 +46,23 @@ void Frame::ToJson(Json::Value &jsonObj, Frame *f, Space *space)
 		Frame::ToJson(childFrameArrayEl, kid, space);
 		childFrameArray.append(childFrameArrayEl); // Append child frame object to array.
 	}
-	frameObj["child_frames"] = childFrameArray; // Add child frame array to frame object.
+	if (!childFrameArray.empty())
+		frameObj["child_frames"] = childFrameArray; // Add child frame array to frame object.
 
+	// Add sfx array to supplied object.
 	SfxManager::ToJson(frameObj, f);
-
-	jsonObj["frame"] = frameObj; // Add frame object to supplied object.
 }
 
-Frame *Frame::FromJson(const Json::Value &jsonObj, Space *space, Frame *parent, double at_time)
+Frame *Frame::FromJson(const Json::Value &frameObj, Space *space, Frame *parent, double at_time)
 {
 	Frame *f = new Frame();
 	f->m_parent = parent;
-
-	if (!jsonObj.isMember("frame")) throw SavedGameCorruptException();
-	Json::Value frameObj = jsonObj["frame"];
 
 	if (!frameObj.isMember("flags")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("radius")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("label")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("pos")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("ang_speed")) throw SavedGameCorruptException();
-	if (!frameObj.isMember("init_orient")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("index_for_system_body")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("index_for_astro_body")) throw SavedGameCorruptException();
 
@@ -84,12 +78,16 @@ Frame *Frame::FromJson(const Json::Value &jsonObj, Space *space, Frame *parent, 
 	f->m_astroBodyIndex = frameObj["index_for_astro_body"].asUInt();
 	f->m_vel = vector3d(0.0); // m_vel is set to zero.
 
-	if (!frameObj.isMember("child_frames")) throw SavedGameCorruptException();
-	Json::Value childFrameArray = frameObj["child_frames"];
-	if (!childFrameArray.isArray()) throw SavedGameCorruptException();
-	for (unsigned int i = 0; i < childFrameArray.size(); ++i) {
-		f->m_children.push_back(FromJson(childFrameArray[i], space, f, at_time));
+	if (frameObj.isMember("child_frames")) {
+		Json::Value childFrameArray = frameObj["child_frames"];
+		if (!childFrameArray.isArray()) throw SavedGameCorruptException();
+		for (unsigned int i = 0; i < childFrameArray.size(); ++i) {
+			f->m_children.push_back(FromJson(childFrameArray[i], space, f, at_time));
+		}
+	} else {
+		f->m_children.clear();
 	}
+
 	SfxManager::FromJson(frameObj, f);
 
 	f->ClearMovement();

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -61,7 +61,6 @@ Frame *Frame::FromJson(const Json::Value &frameObj, Space *space, Frame *parent,
 	if (!frameObj.isMember("flags")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("radius")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("label")) throw SavedGameCorruptException();
-	if (!frameObj.isMember("pos")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("ang_speed")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("index_for_system_body")) throw SavedGameCorruptException();
 	if (!frameObj.isMember("index_for_astro_body")) throw SavedGameCorruptException();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -28,9 +28,8 @@
 #include "galaxy/GalaxyGenerator.h"
 #include "GameSaveError.h"
 
-static const int  s_saveVersion   = 84;
+static const int  s_saveVersion   = 85;
 static const char s_saveStart[]   = "PIONEER";
-static const char s_saveEnd[]     = "END";
 
 Game::Game(const SystemPath &path, double time) :
 	m_galaxy(GalaxyGenerator::Create()),

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -175,12 +175,6 @@ m_forceTimeAccel(false)
 
 	Pi::luaSerializer->UninitTableRefs();
 
-	// signature check (don't really need this anymore)
-	if (!jsonObj.isMember("trailing_signature")) throw SavedGameCorruptException();
-	Json::Value trailingSignature = jsonObj["trailing_signature"];
-	if (trailingSignature.isString() && trailingSignature.asString().compare(s_saveEnd) == 0) {}
-	else throw SavedGameCorruptException();
-
 	EmitPauseState(IsPaused());
 }
 
@@ -270,9 +264,6 @@ void Game::ToJson(Json::Value &jsonObj)
 	}
 
 	jsonObj["game_info"] = gameInfo;
-
-	// trailing signature
-	jsonObj["trailing_signature"] = s_saveEnd; // Don't really need this anymore.
 
 	Pi::luaSerializer->UninitTableRefs();
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -902,7 +902,11 @@ void Game::SaveGame(const std::string &filename, Game *game)
 	Json::Value rootNode; // Create the root JSON value for receiving the game data.
 	game->ToJson(rootNode); // Encode the game data as JSON and give to the root value.
 	Json::FastWriter jsonWriter; // Create writer for writing the JSON data to string.
-	const std::string jsonDataStr = jsonWriter.write(rootNode); // Write the JSON data.
+	std::string jsonDataStr;
+	{
+		PROFILE_SCOPED_DESC("jsonWriter.write");
+		jsonDataStr = jsonWriter.write(rootNode); // Write the JSON data.
+	}
 
 	FILE *f = FileSystem::userFiles.OpenWriteStream(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename));
 	if (!f) throw CouldNotOpenFileException();

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -97,7 +97,6 @@ void HyperspaceCloud::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	if (!jsonObj.isMember("hyperspace_cloud")) throw SavedGameCorruptException();
 	Json::Value hyperspaceCloudObj = jsonObj["hyperspace_cloud"];
 
-	if (!hyperspaceCloudObj.isMember("vel")) throw SavedGameCorruptException();
 	if (!hyperspaceCloudObj.isMember("birth_date")) throw SavedGameCorruptException();
 	if (!hyperspaceCloudObj.isMember("due")) throw SavedGameCorruptException();
 	if (!hyperspaceCloudObj.isMember("is_arrival")) throw SavedGameCorruptException();

--- a/src/JsonUtils.cpp
+++ b/src/JsonUtils.cpp
@@ -103,9 +103,12 @@ void MatrixToJson(Json::Value &jsonObj, const matrix3x3f &mat, const std::string
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 #ifdef USE_STRING_VERSIONS
-	char str[512];
-	Matrix3x3fToStr(mat, str, 512);
-	jsonObj[name] = str;
+	if (memcmp(&matrix3x3fIdentity, &mat, sizeof(matrix3x3f)) != 0)
+	{
+		char str[512];
+		Matrix3x3fToStr(mat, str, 512);
+		jsonObj[name] = str;
+	}
 #else
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
 	matArray[0] = FloatToStr(mat[0]);
@@ -126,9 +129,12 @@ void MatrixToJson(Json::Value &jsonObj, const matrix3x3d &mat, const std::string
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 #ifdef USE_STRING_VERSIONS
-	char str[512];
-	Matrix3x3dToStr(mat, str, 512);
-	jsonObj[name] = str;
+	if (memcmp(&matrix3x3dIdentity, &mat, sizeof(matrix3x3d)) != 0)
+	{
+		char str[512];
+		Matrix3x3dToStr(mat, str, 512);
+		jsonObj[name] = str;
+	}
 #else
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
 	matArray[0] = DoubleToStr(mat[0]);
@@ -149,9 +155,12 @@ void MatrixToJson(Json::Value &jsonObj, const matrix4x4f &mat, const std::string
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 #ifdef USE_STRING_VERSIONS
-	char str[512];
-	Matrix4x4fToStr(mat, str, 512);
-	jsonObj[name] = str;
+	if (memcmp(&matrix4x4fIdentity, &mat, sizeof(matrix4x4f)) != 0)
+	{
+		char str[512];
+		Matrix4x4fToStr(mat, str, 512);
+		jsonObj[name] = str;
+	}
 #else
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
 	matArray[0] = FloatToStr(mat[0]);
@@ -179,9 +188,12 @@ void MatrixToJson(Json::Value &jsonObj, const matrix4x4d &mat, const std::string
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 #ifdef USE_STRING_VERSIONS
-	char str[512];
-	Matrix4x4dToStr(mat, str, 512);
-	jsonObj[name] = str;
+	if (memcmp(&matrix4x4dIdentity, &mat, sizeof(matrix4x4d)) != 0)
+	{
+		char str[512];
+		Matrix4x4dToStr(mat, str, 512);
+		jsonObj[name] = str;
+	}
 #else
 	Json::Value matArray(Json::arrayValue); // Create JSON array to contain matrix data.
 	matArray[0] = DoubleToStr(mat[0]);
@@ -333,10 +345,16 @@ void JsonToMatrix(matrix3x3f *pMat, const Json::Value &jsonObj, const std::strin
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 #ifdef USE_STRING_VERSIONS
-	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
-	Json::Value matStr = jsonObj[name.c_str()];
-	if (!matStr.isString()) throw SavedGameCorruptException();
-	StrToMatrix3x3f(matStr.asCString(), *pMat);
+	if (!jsonObj.isMember(name))
+	{
+		*pMat = matrix3x3fIdentity;
+	}
+	else
+	{
+		Json::Value matStr = jsonObj[name.c_str()];
+		if (!matStr.isString()) throw SavedGameCorruptException();
+		StrToMatrix3x3f(matStr.asCString(), *pMat);
+	}
 #else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value matArray = jsonObj[name.c_str()];
@@ -354,16 +372,22 @@ void JsonToMatrix(matrix3x3f *pMat, const Json::Value &jsonObj, const std::strin
 	(*pMat)[8] = StrToFloat(matArray[8].asString());
 #endif
 }
-
+#pragma optimize("",off)
 void JsonToMatrix(matrix3x3d *pMat, const Json::Value &jsonObj, const std::string &name)
 {
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 #ifdef USE_STRING_VERSIONS
-	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
-	Json::Value matStr = jsonObj[name.c_str()];
-	if (!matStr.isString()) throw SavedGameCorruptException();
-	StrToMatrix3x3d(matStr.asCString(), *pMat);
+	if (!jsonObj.isMember(name))
+	{
+		*pMat = matrix3x3dIdentity;
+	}
+	else
+	{
+		Json::Value matStr = jsonObj[name.c_str()];
+		if (!matStr.isString()) throw SavedGameCorruptException();
+		StrToMatrix3x3d(matStr.asCString(), *pMat);
+	}
 #else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value matArray = jsonObj[name.c_str()];
@@ -387,10 +411,16 @@ void JsonToMatrix(matrix4x4f *pMat, const Json::Value &jsonObj, const std::strin
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 #ifdef USE_STRING_VERSIONS
-	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
-	Json::Value matStr = jsonObj[name.c_str()];
-	if (!matStr.isString()) throw SavedGameCorruptException();
-	StrToMatrix4x4f(matStr.asCString(), *pMat);
+	if (!jsonObj.isMember(name))
+	{
+		*pMat = matrix4x4fIdentity;
+	}
+	else
+	{
+		Json::Value matStr = jsonObj[name.c_str()];
+		if (!matStr.isString()) throw SavedGameCorruptException();
+		StrToMatrix4x4f(matStr.asCString(), *pMat);
+	}
 #else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value matArray = jsonObj[name.c_str()];
@@ -421,10 +451,16 @@ void JsonToMatrix(matrix4x4d *pMat, const Json::Value &jsonObj, const std::strin
 	PROFILE_SCOPED()
 	assert(!name.empty()); // Can't do anything if no name supplied.
 #ifdef USE_STRING_VERSIONS
-	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
-	Json::Value matStr = jsonObj[name.c_str()];
-	if (!matStr.isString()) throw SavedGameCorruptException();
-	StrToMatrix4x4d(matStr.asCString(), *pMat);
+	if (!jsonObj.isMember(name))
+	{
+		*pMat = matrix4x4dIdentity;
+	}
+	else
+	{
+		Json::Value matStr = jsonObj[name.c_str()];
+		if (!matStr.isString()) throw SavedGameCorruptException();
+		StrToMatrix4x4d(matStr.asCString(), *pMat);
+	}
 #else
 	if (!jsonObj.isMember(name.c_str())) throw SavedGameCorruptException();
 	Json::Value matArray = jsonObj[name.c_str()];

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -55,6 +55,7 @@
 
 void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, std::string key)
 {
+	PROFILE_SCOPED()
 	static char buf[256];
 
 	LUA_DEBUG_START(l);
@@ -195,6 +196,7 @@ void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, std
 
 const char *LuaSerializer::unpickle(lua_State *l, const char *pos)
 {
+	PROFILE_SCOPED()
 	LUA_DEBUG_START(l);
 
 	// tables are also unpickled recursively, so we can run out of Lua stack space if we're not careful
@@ -326,8 +328,9 @@ const char *LuaSerializer::unpickle(lua_State *l, const char *pos)
 	return pos;
 }
 
-void LuaSerializer::pickle_json(lua_State *l, int to_serialize, Json::Value &out, std::string key)
+void LuaSerializer::pickle_json(lua_State *l, int to_serialize, Json::Value &out, const std::string &key)
 {
+	PROFILE_SCOPED()
 	LUA_DEBUG_START(l);
 
 	// tables are pickled recursively, so we can run out of Lua stack space if we're not careful
@@ -475,6 +478,7 @@ void LuaSerializer::pickle_json(lua_State *l, int to_serialize, Json::Value &out
 
 void LuaSerializer::unpickle_json(lua_State *l, const Json::Value &value)
 {
+	PROFILE_SCOPED()
 	LUA_DEBUG_START(l);
 
 	// tables are also unpickled recursively, so we can run out of Lua stack space if we're not careful
@@ -661,6 +665,7 @@ void LuaSerializer::ToJson(Json::Value &jsonObj)
 
 void LuaSerializer::FromJson(const Json::Value &jsonObj)
 {
+	PROFILE_SCOPED()
 	lua_State *l = Lua::manager->GetLuaState();
 
 	LUA_DEBUG_START(l);

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -107,7 +107,7 @@ void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, std
 			break;
 
 		case LUA_TNUMBER: {
-			snprintf(buf, sizeof(buf), "f%f\n", lua_tonumber(l, idx));
+			snprintf(buf, sizeof(buf), "f%g\n", lua_tonumber(l, idx));
 			out += buf;
 			break;
 		}
@@ -119,13 +119,11 @@ void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, std
 		}
 
 		case LUA_TSTRING: {
-			lua_pushvalue(l, idx);
 			size_t len;
-			const char *str = lua_tolstring(l, -1, &len);
+			const char *str = lua_tolstring(l, idx, &len);
 			snprintf(buf, sizeof(buf), "s" SIZET_FMT "\n", len);
 			out += buf;
 			out.append(str, len);
-			lua_pop(l, 1);
 			break;
 		}
 
@@ -220,8 +218,7 @@ const char *LuaSerializer::unpickle(lua_State *l, const char *pos)
 
 		case 'b': {
 			if (*pos != '0' && *pos != '1') throw SavedGameCorruptException();
-			bool b = (*pos == '0') ? false : true;
-			lua_pushboolean(l, b);
+			lua_pushboolean(l, *pos == '1');
 			pos++;
 			break;
 		}

--- a/src/LuaSerializer.h
+++ b/src/LuaSerializer.h
@@ -28,7 +28,7 @@ private:
 	static void pickle(lua_State *l, int idx, std::string &out, std::string key = "");
 	static const char *unpickle(lua_State *l, const char *pos);
 
-	static void pickle_json(lua_State *l, int idx, Json::Value &out, std::string key = "");
+	static void pickle_json(lua_State *l, int idx, Json::Value &out, const std::string &key = "");
 	static void unpickle_json(lua_State *l, const Json::Value &value);
 };
 

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -93,22 +93,6 @@ void ModelBody::SaveToJson(Json::Value &jsonObj, Space *space)
 	jsonObj["model_body"] = modelBodyObj; // Add model body object to supplied object.
 }
 
-void ModelBody::SetStatic(bool isStatic)
-{
-	if (isStatic == m_isStatic) return;
-	m_isStatic = isStatic;
-	if (!m_geom) return;
-
-	if (m_isStatic) {
-		GetFrame()->RemoveGeom(m_geom);
-		GetFrame()->AddStaticGeom(m_geom);
-	}
-	else {
-		GetFrame()->RemoveStaticGeom(m_geom);
-		GetFrame()->AddGeom(m_geom);
-	}
-}
-
 void ModelBody::LoadFromJson(const Json::Value &jsonObj, Space *space)
 {
 	Body::LoadFromJson(jsonObj, space);
@@ -125,6 +109,22 @@ void ModelBody::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	SetModel(modelBodyObj["model_name"].asString().c_str());
 	m_model->LoadFromJson(modelBodyObj);
 	m_shields->LoadFromJson(modelBodyObj);
+}
+
+void ModelBody::SetStatic(bool isStatic)
+{
+	if (isStatic == m_isStatic) return;
+	m_isStatic = isStatic;
+	if (!m_geom) return;
+
+	if (m_isStatic) {
+		GetFrame()->RemoveGeom(m_geom);
+		GetFrame()->AddStaticGeom(m_geom);
+	}
+	else {
+		GetFrame()->RemoveStaticGeom(m_geom);
+		GetFrame()->AddGeom(m_geom);
+	}
 }
 
 void ModelBody::SetColliding(bool colliding)

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -154,8 +154,6 @@ void Projectile::LoadFromJson(const Json::Value &jsonObj, Space *space)
 	if (!jsonObj.isMember("projectile")) throw SavedGameCorruptException();
 	Json::Value projectileObj = jsonObj["projectile"];
 
-	if (!projectileObj.isMember("base_vel")) throw SavedGameCorruptException();
-	if (!projectileObj.isMember("dir_vel")) throw SavedGameCorruptException();
 	if (!projectileObj.isMember("age")) throw SavedGameCorruptException();
 	if (!projectileObj.isMember("life_span")) throw SavedGameCorruptException();
 	if (!projectileObj.isMember("base_dam")) throw SavedGameCorruptException();

--- a/src/Propulsion.cpp
+++ b/src/Propulsion.cpp
@@ -23,8 +23,6 @@ void Propulsion::SaveToJson(Json::Value &jsonObj, Space *space)
 void Propulsion::LoadFromJson(const Json::Value &jsonObj, Space *space)
 {
 
-	if (!jsonObj.isMember("ang_thrusters")) throw SavedGameCorruptException();
-	if (!jsonObj.isMember("thrusters")) throw SavedGameCorruptException();
 	if (!jsonObj.isMember("thruster_fuel")) throw SavedGameCorruptException();
 	if (!jsonObj.isMember("reserve_fuel")) throw SavedGameCorruptException();
 	// !!! This is commented to avoid savegame bumps:

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -70,8 +70,6 @@ void Sfx::LoadFromJson(const Json::Value &jsonObj)
 {
 	if (!jsonObj.isMember("sfx")) throw SavedGameCorruptException();
 	Json::Value sfxObj = jsonObj["sfx"];
-	if (!sfxObj.isMember("pos")) throw SavedGameCorruptException();
-	if (!sfxObj.isMember("vel")) throw SavedGameCorruptException();
 	if (!sfxObj.isMember("age")) throw SavedGameCorruptException();
 	if (!sfxObj.isMember("type")) throw SavedGameCorruptException();
 

--- a/src/ShipAICmd.h
+++ b/src/ShipAICmd.h
@@ -83,9 +83,6 @@ public:
 	}
 	AICmdDock(const Json::Value &jsonObj) : AICommand(jsonObj, CMD_DOCK) {
 		if (!jsonObj.isMember("index_for_target")) throw SavedGameCorruptException();
-		if (!jsonObj.isMember("dock_pos")) throw SavedGameCorruptException();
-		if (!jsonObj.isMember("dock_dir")) throw SavedGameCorruptException();
-		if (!jsonObj.isMember("dock_up_dir")) throw SavedGameCorruptException();
 		if (!jsonObj.isMember("state")) throw SavedGameCorruptException();
 		m_targetIndex = jsonObj["index_for_target"].asInt();
 		JsonToVector(&m_dockpos, jsonObj, "dock_pos");
@@ -163,8 +160,6 @@ public:
 		if (!jsonObj.isMember("index_for_target")) throw SavedGameCorruptException();
 		if (!jsonObj.isMember("dist")) throw SavedGameCorruptException();
 		if (!jsonObj.isMember("index_for_target_frame")) throw SavedGameCorruptException();
-		if (!jsonObj.isMember("pos_off")) throw SavedGameCorruptException();
-		if (!jsonObj.isMember("end_vel")) throw SavedGameCorruptException();
 		if (!jsonObj.isMember("tangent")) throw SavedGameCorruptException();
 		if (!jsonObj.isMember("state")) throw SavedGameCorruptException();
 		m_targetIndex = jsonObj["index_for_target"].asInt();

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -133,7 +133,8 @@ Space::Space(Game *game, RefCountedPtr<Galaxy> galaxy, const Json::Value &jsonOb
 
 	CityOnPlanet::SetCityModelPatterns(m_starSystem->GetPath());
 
-	m_rootFrame.reset(Frame::FromJson(spaceObj, this, 0, at_time));
+	if (!spaceObj.isMember("frame")) throw SavedGameCorruptException();
+	m_rootFrame.reset(Frame::FromJson(spaceObj["frame"], this, 0, at_time));
 	RebuildFrameIndex();
 
 	if (!spaceObj.isMember("bodies")) throw SavedGameCorruptException();
@@ -177,7 +178,9 @@ void Space::ToJson(Json::Value &jsonObj)
 
 	StarSystem::ToJson(spaceObj, m_starSystem.Get());
 
-	Frame::ToJson(spaceObj, m_rootFrame.get(), this);
+	Json::Value frameObj(Json::objectValue);
+	Frame::ToJson(frameObj, m_rootFrame.get(), this);
+	spaceObj["frame"] = frameObj;
 
 	Json::Value bodyArray(Json::arrayValue); // Create JSON array to contain body data.
 	for (Body* b : m_bodies)

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -623,7 +623,6 @@ static void RegisterCustomSystemsAPI(lua_State *L)
 
 void CustomSystemsDatabase::Init()
 {
-	PROFILE_SCOPED()
 	assert(!s_activeCustomSystemsDatabase);
 	s_activeCustomSystemsDatabase = this;
 	lua_State *L = luaL_newstate();
@@ -663,7 +662,6 @@ void CustomSystemsDatabase::Init()
 
 CustomSystemsDatabase::~CustomSystemsDatabase()
 {
-	PROFILE_SCOPED()
 	for (SectorMap::iterator secIt = m_sectorMap.begin(); secIt != m_sectorMap.end(); ++secIt) {
 		for (CustomSystemsDatabase::SystemList::iterator
 				sysIt = secIt->second.begin(); sysIt != secIt->second.end(); ++sysIt) {
@@ -675,7 +673,6 @@ CustomSystemsDatabase::~CustomSystemsDatabase()
 
 const CustomSystemsDatabase::SystemList &CustomSystemsDatabase::GetCustomSystemsForSector(int x, int y, int z) const
 {
-	PROFILE_SCOPED()
 	SystemPath path(x,y,z);
 	SectorMap::const_iterator it = m_sectorMap.find(path);
 	return (it != m_sectorMap.end()) ? it->second : s_emptySystemList;
@@ -696,7 +693,6 @@ CustomSystem::CustomSystem():
 	govType(Polit::GOV_INVALID),
 	want_rand_lawlessness(true)
 {
-	PROFILE_SCOPED()
 	for (int i = 0; i < 4; ++i)
 		primaryType[i] = SystemBody::TYPE_GRAVPOINT;
 }
@@ -717,7 +713,6 @@ CustomSystemBody::CustomSystemBody():
 	seed(0),
 	want_rand_seed(true)
 {
-	PROFILE_SCOPED()
 }
 
 CustomSystemBody::~CustomSystemBody()

--- a/src/matrix3x3.h
+++ b/src/matrix3x3.h
@@ -185,4 +185,7 @@ static inline void matrix3x3dtof(const matrix3x3d &in, matrix3x3f &out)
 		out[i] = float(in[i]);
 }
 
+static const matrix3x3f matrix3x3fIdentity(matrix3x3f::Identity());
+static const matrix3x3d matrix3x3dIdentity(matrix3x3d::Identity());
+
 #endif /* _MATRIX3x3_H */

--- a/src/matrix4x4.h
+++ b/src/matrix4x4.h
@@ -412,4 +412,7 @@ static inline void matrix4x4dtof(const matrix4x4d &in, matrix4x4f &out)
 		out[i] = float(in[i]);
 }
 
+static const matrix4x4f matrix4x4fIdentity(matrix4x4f::Identity());
+static const matrix4x4d matrix4x4dIdentity(matrix4x4d::Identity());
+
 #endif /* _MATRIX4X4_H */

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -532,7 +532,7 @@ public:
 	{
 		const matrix4x4f &m = node.GetTransform();
 		Json::Value matrixTransformObj(Json::objectValue); // Create JSON object to contain matrix transform data.
-		MatrixToJson(matrixTransformObj, m, "matrix_transform");
+		MatrixToJson(matrixTransformObj, m, "m");
 		m_jsonArray.append(matrixTransformObj); // Append matrix transform object to array.
 	}
 
@@ -566,7 +566,11 @@ public:
 	void ApplyMatrixTransform(MatrixTransform &node)
 	{
 		matrix4x4f m;
-		JsonToMatrix(&m, m_jsonArray[m_arrayIndex++], "matrix_transform");
+		if(m_jsonArray[m_arrayIndex].isMember("matrix_transform"))
+			JsonToMatrix(&m, m_jsonArray[m_arrayIndex], "matrix_transform"); // for backwards compatibility
+		else
+			JsonToMatrix(&m, m_jsonArray[m_arrayIndex], "m");
+		++m_arrayIndex;
 		node.SetTransform(m);
 	}
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
With the merging of #4207 saving has gotten a little bit slower. This reminded me of the fact that there's lots of save optimisations we left on-the-table after #3680 and #3684

So here's a couple of little changes that together reduce the size of (_already compressed_) save games by ~26%

~Also this absolutely breaks all existing saves and thus far I'm making no effort to prevent that.~
Contrary to my initial statement this should load most recent save games alright.
<!-- Please make sure you've read documentation on contributing -->

