### PR TITLE
Remove option -skipmenu, add option -startat.

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1160,12 +1160,14 @@ void Pi::StartGame()
 	LuaEvent::Emit();
 }
 
-void Pi::Start(const int& startPlanet)
+void Pi::Start(const SystemPath &startPath)
 {
 	Pi::bRequestEndGame = false;
 
 	Pi::intro = new Intro(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
-
+	if(startPath != SystemPath(0,0,0,0,0)) {
+		Pi::game = new Game(startPath, 0.0);
+	}
 	//XXX global ambient colour hack to make explicit the old default ambient colour dependency
 	// for some models
 	Pi::renderer->SetAmbientColor(Color(51, 51, 51, 255));

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -64,7 +64,7 @@ public:
 	static void StartGame();
 	static void RequestEndGame(); // request that the game is ended as soon as safely possible
 	static void EndGame();
-	static void Start(const int& startPlanet);
+	static void Start(const SystemPath &startPath);
 	static void MainLoop();
 	static void TombStoneLoop();
 	static void OnChangeDetailLevel();

--- a/src/galaxy/SystemPath.cpp
+++ b/src/galaxy/SystemPath.cpp
@@ -6,53 +6,60 @@
 #include "Json.h"
 #include <cstdlib>
 
-static int ParseInt(const char *&ss)
+// https://stackoverflow.com/questions/14265581/parse-split-a-string-in-c-using-string-delimiter-standard-c
+static std::vector<std::string> split(const std::string& str, const std::string& delim)
 {
-	assert(ss);
-	char *end = 0;
-	long n = strtol(ss, &end, 10);
-	if (ss == end) {
-		throw SystemPath::ParseFailure();
-	} else {
-		ss = end;
-		return n;
-	}
+	std::vector<std::string> tokens;
+	size_t prev = 0, pos = 0;
+	do
+		{
+			pos = str.find(delim, prev);
+			if (pos == std::string::npos) pos = str.length();
+			std::string token = str.substr(prev, pos-prev);
+			if (!token.empty()) tokens.push_back(token);
+			prev = pos + delim.length();
+		}
+	while (pos < str.length() && prev < str.length());
+	return tokens;
+}
+
+static int ParseInt(const std::string &str)
+{
+	return std::stoi(str);
 }
 
 SystemPath SystemPath::Parse(const char * const str)
 {
+	// Parse a system path, three to five integers separated by commas (,), optionally starting with ( and ending with )
+	// 0,0,0  or  (0, 0, 0)  or  1,3,-3,5  or  (0,0,0,0,18)
 	assert(str);
+	std::string s = str;
 
-	// syspath = '('? [+-]? [0-9]+ [, +-] [0-9]+ [, +-] [0-9]+ ')'?
-	// with whitespace allowed between tokens
+	assert(s.length() > 0);
 
-	const char *s = str;
+	if(s[0] == '(')
+		s = s.substr(1,s.length());
 
-	int x, y, z;
+	if(s[s.length() - 1] == ')')
+		s = s.substr(0,s.length() - 1);
 
-	while (isspace(*s)) { ++s; }
-	if (*s == '(') { ++s; }
-
-	x = ParseInt(s); // note: ParseInt (actually, strtol) skips leading whitespace itself
-
-	while (isspace(*s)) { ++s; }
-	if (*s == ',' || *s == '.') { ++s; }
-
-	y = ParseInt(s);
-
-	while (isspace(*s)) { ++s; }
-	if (*s == ',' || *s == '.') { ++s; }
-
-	z = ParseInt(s);
-
-	while (isspace(*s)) { ++s; }
-	if (*s == ')') { ++s; }
-	while (isspace(*s)) { ++s; }
-
-	if (*s) // extra unexpected text after the system path
+	std::vector<std::string> parts = split(s, ",");
+	int x = 0, y = 0, z = 0, si = 0, bi = 0;
+	if(parts.size() < 3)
 		throw SystemPath::ParseFailure();
-	else
-		return SystemPath(x, y, z);
+	if(parts.size() >= 3) {
+		x = ParseInt(parts[0].c_str());
+		y = ParseInt(parts[1].c_str());
+		z = ParseInt(parts[2].c_str());
+	}
+	if(parts.size() >= 4) {
+		si = ParseInt(parts[3].c_str());
+	}
+	if(parts.size() == 5) {
+		bi = ParseInt(parts[4].c_str());
+	} else
+		throw SystemPath::ParseFailure();
+	return SystemPath(x, y, z, si, bi);
 }
 
 void SystemPath::ToJson(Json &jsonObj) const {


### PR DESCRIPTION
skipmenu was broken, and didn't do anything anyway.

-startat (-sa) allows you to give a SystemPath to start at, skipping the main menu:

./pioneer -startat=(0,0,0,0,18)


