### PR TITLE
Disable the SDL_CaptureMouse path in IMGUI code.

### DIFF
--- a/contrib/imgui/examples/imgui_impl_sdl.cpp
+++ b/contrib/imgui/examples/imgui_impl_sdl.cpp
@@ -271,7 +271,11 @@ static void ImGui_ImplSDL2_UpdateMousePosAndButtons()
     io.MouseDown[2] = g_MousePressed[2] || (mouse_buttons & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0;
     g_MousePressed[0] = g_MousePressed[1] = g_MousePressed[2] = false;
 
-#if SDL_HAS_CAPTURE_MOUSE && !defined(__EMSCRIPTEN__)
+// Using this code-path causes several issues in Pioneer - when capturing the
+// mouse, the mouse snaps back to the center of the window, and there are some
+// issues with the WM's decoration extents being calculated into the window's
+// size on the Cinammon DE.
+#if 0 //SDL_HAS_CAPTURE_MOUSE && !defined(__EMSCRIPTEN__)
     SDL_Window* focused_window = SDL_GetKeyboardFocus();
     if (g_Window == focused_window)
     {


### PR DESCRIPTION
Fixes #4481.

For some reason, the way the IMGUI implementation handles capturing the mouse causes it to snap to the center of the screen whenever we right-click. Additionally, the polling of global coordinates instead of window-local coordinates is causing #4481.

I plan on revisiting this to implement it correctly, but for now this fix should work just fine.

@fluffyfreak has cursorily confirmed that this change is functional on IRC.
@clausimu a sign-off that this PR doesn't cause any undue problems (e.g. when dragging outside of the window, etc.) would be appreciated if you have time.
