### PR TITLE
WIP: Add a data collection mission

### DIFF
--- a/data/lang/module-collectdata/en.json
+++ b/data/lang/module-collectdata/en.json
@@ -26,5 +26,9 @@
   "INDEPENDENT_SCIENTISTS": {
     "description": "",
     "message": "Independent Scientists"
+  },
+  "VERY_GOOD_I_WILL_SEND_THIS_DATA_DIRECTLY_TO_THE": {
+    "description": "",
+    "message": "Very good, I will send this data directly to the "
   }
 }

--- a/data/lang/module-collectdata/en.json
+++ b/data/lang/module-collectdata/en.json
@@ -1,0 +1,14 @@
+{
+  "DATACOLLECTION": {
+    "description": "",
+    "message": "Data collection"
+  },
+  "THANKS_I_CANT_WAIT_FOR_THE_RESULTS": {
+    "description": "",
+    "message": "Thanks, I can't wait for the results!"
+  },
+  "OK_AGREED": {
+    "description": "",
+    "message": "Ok, agreed."
+  }
+}

--- a/data/lang/module-collectdata/en.json
+++ b/data/lang/module-collectdata/en.json
@@ -5,20 +5,26 @@
   },
   "THANKS_I_CANT_WAIT_FOR_THE_RESULTS": {
     "description": "",
-    "message": "Thanks, I can't wait for the results!"
+    "message": "Thanks, we can't wait for the results!"
   },
   "OK_AGREED": {
     "description": "",
     "message": "Ok, agreed."
   },
-  "SCIENCELABS": {
-    "INTERGALACTIC_RESEARCH_FOUNDATION": {
-      "description": "",
-      "message": "Intergalactic Research Foundation"
-    },
-    "EXTRATERESTIAL SCIENCE LABS": {
-      "description": "",
-      "message": "Extraterestial Science Labs"
-    },
+  "INTERGALACTIC_RESEARCH_FOUNDATION": {
+    "description": "",
+    "message": "Intergalactic Research Foundation"
+  },
+  "EXTRATERESTIAL_SCIENCE_LABS": {
+    "description": "",
+    "message": "Extraterestial Science Labs"
+  },
+  "EARTH_FEDERATION_OF_SCIENCE": {
+    "description": "",
+    "message": "Earth Federation of Science"
+  },
+  "INDEPENDENT_SCIENTISTS": {
+    "description": "",
+    "message": "Independent Scientists"
   }
 }

--- a/data/lang/module-collectdata/en.json
+++ b/data/lang/module-collectdata/en.json
@@ -30,5 +30,45 @@
   "VERY_GOOD_I_WILL_SEND_THIS_DATA_DIRECTLY_TO_THE": {
     "description": "",
     "message": "Very good, I will send this data directly to the "
+  },
+  "NOT_LOSE_ENOUGH_TO": {
+    "description": "",
+    "message": "Not close enough to "
+  },
+  "TO_COLLECT_DATA": {
+    "description": "",
+    "message": " to collect data."
+  },
+  "DATA_FROM": {
+    "description": "",
+    "message": "Data from "
+  },
+  "COLLECTED": {
+    "description": "",
+    "message": " collected"
+  },
+  "SET_TO_BE_INSPECTED_PLANET_AS_TARGET": {
+    "description": "",
+    "message": "Set to be inspected planet as target"
+  },
+  "SET_STATION_TO_BRING_THE_DATA_TO_AS_TARGET": {
+    "description": "",
+    "message": "Set station to bring the data to as target"
+  },
+  "THE": {
+    "description": "",
+    "message": "The "
+  },
+  "WANTS_YOU_TO_COLLECT_DATA_FROM": {
+    "description": "",
+    "message": " wants you to collect data from "
+  },
+  "SET_STATION_TO_BRING_THE_DATA_TO_AS_TARGET": {
+    "description": "",
+    "message": "Set station to bring the data to as target"
+  },
+  "AND_BRING_IT_BACK_TO": {
+    "description": "",
+    "message": " and bring it back to "
   }
 }

--- a/data/lang/module-collectdata/en.json
+++ b/data/lang/module-collectdata/en.json
@@ -10,5 +10,15 @@
   "OK_AGREED": {
     "description": "",
     "message": "Ok, agreed."
+  },
+  "SCIENCELABS": {
+    "INTERGALACTIC_RESEARCH_FOUNDATION": {
+      "description": "",
+      "message": "Intergalactic Research Foundation"
+    },
+    "EXTRATERESTIAL SCIENCE LABS": {
+      "description": "",
+      "message": "Extraterestial Science Labs"
+    },
   }
 }

--- a/data/modules/CollectData/CollectData.lua
+++ b/data/modules/CollectData/CollectData.lua
@@ -113,6 +113,12 @@ local onCreateBB = function(station)
   assert(makeAdvert(station))
 end
 
+local onUpdateBB = function(station)
+	if Engine.rand:Integer(12*60*60) < 60*60 then -- roughly once every twelve hours
+		makeAdvert(station)
+	end
+end
+
 local onEnterSystem = function(player)
 end
 
@@ -195,6 +201,7 @@ local onClick = function(mission)
 end
 
 Event.Register("onCreateBB", onCreateBB)
+Event.Register("onUpdateBB", onUpdateBB)
 Event.Register("onEnterSystem", onEnterSystem)
 Event.Register("onShipDocked", onShipDocked)
 Event.Register("onGameStart", onGameStart)

--- a/data/modules/CollectData/CollectData.lua
+++ b/data/modules/CollectData/CollectData.lua
@@ -165,14 +165,17 @@ local onClick = function(mission)
     ui:SmallButton()
   })
   collectDataButton.onClick:Connect(function()
-    local distance = mission.planetToGoTo.body:DistanceTo(Game.player)
-    print(distance)
+    local planetRadius = mission.planetToGoTo.radius
+    local distanceToPlanet = Game.player:DistanceTo(mission.planetToGoTo.body)
+    if distanceToPlanet<planetRadius*2 then
+      
+    end
   end)
   return ui:Grid(2, 1)
     :SetColumn(0, {
       ui:VBox(10):PackEnd({
           ui:MultiLineText(createRequestMessage(mission)),
-          NavButton.New("Set the planet to gather data from as target", mission.planetToGoTo.path),
+          NavButton.New("Set to be inspected planet as target", mission.planetToGoTo.path),
           NavButton.New("Set station to bring the data to as target", mission.location),
           collectDataButton
         })

--- a/data/modules/CollectData/CollectData.lua
+++ b/data/modules/CollectData/CollectData.lua
@@ -64,7 +64,7 @@ local onChat = function(form, ref, option)
       location = ad.location,
       planetToGoTo = ad.planetToGoTo,
       reward = ad.reward,
-      due = ad.due,
+      --due = ad.due,
       scienceLab = ad.scienceLab
     }
     table.insert(missions, Mission.New(mission))
@@ -84,7 +84,7 @@ local makeAdvert = function(station)
   end
   local ad = {
     client = Character.New(),
-    due = Game.time + 1000000,
+    --due = Game.time + 1000000,
     location = station.path,
     planetToGoTo = planetToGoTo,
     reward = 400,
@@ -119,9 +119,14 @@ end
 local onShipDocked = function(player, station)
 	if not player:IsPlayer() then return end
 
-	for _, mission in pairs(missions) do
-    if mission.location == station then
-      print("correct station")
+	for ref, mission in pairs(missions) do
+    if mission.location == station.path then
+      if mission.collectedData then
+        Comms.ImportantMessage(l.VERY_GOOD_I_WILL_SEND_THIS_DATA_DIRECTLY_TO_THE..mission.scienceLab.."!", mission.client.name)
+        player:AddMoney(mission.reward)
+        mission:Remove()
+  			missions[ref] = nil
+      end
     end
 	end
 end
@@ -168,7 +173,10 @@ local onClick = function(mission)
     local planetRadius = mission.planetToGoTo.radius
     local distanceToPlanet = Game.player:DistanceTo(mission.planetToGoTo.body)
     if distanceToPlanet<planetRadius*2 then
-      
+      Comms.Message("Data from "..mission.planetToGoTo.name.." collected")
+      mission.collectedData = true
+    else
+      Comms.Message("Not close enough to "..mission.planetToGoTo.name.." to collect data.")
     end
   end)
   return ui:Grid(2, 1)

--- a/data/modules/CollectData/CollectData.lua
+++ b/data/modules/CollectData/CollectData.lua
@@ -1,0 +1,138 @@
+-- Copyright © 2008-2018 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Engine = import("Engine")
+local Lang = import("Lang")
+local Game = import("Game")
+local Space = import("Space")
+local Comms = import("Comms")
+local Event = import("Event")
+local Mission = import("Mission")
+local Format = import("Format")
+local Serializer = import("Serializer")
+local Character = import("Character")
+local Equipment = import("Equipment")
+local ShipDef = import("ShipDef")
+local Ship = import("Ship")
+local utils = import("utils")
+
+local InfoFace = import("ui/InfoFace")
+local NavButton = import("ui/NavButton")
+
+local l = Lang.GetResource("module-collectdata")
+
+-- Get the UI class
+local ui = Engine.ui
+local missions = {}
+local ads = {}
+
+local onChat = function (form, ref, option)
+  local ad = ads[ref]
+
+  form:Clear()
+
+  if option == -1 then
+    form:Close()
+    return
+  end
+
+  form:SetFace(ad.client)
+
+  if option == 0 then
+    form:SetMessage(ad.text)
+  elseif option == 1 then
+    local mission = {
+      type = "DataCollection"
+    }
+    table.insert(missions, Mission.New(mission))
+    form:SetMessage(l.THANKS_I_CANT_WAIT_FOR_THE_RESULTS)
+  end
+
+  form:AddOption(l.OK_AGREED, 1)
+
+end
+
+function makeAdvert(station)
+  local ad = {
+    text = "Launch it anywhere and we will be happy",
+    guy = "Science Labs & co",
+    client = Character.New()
+  }
+  local ref = station:AddAdvert({
+    description = "Collect data for us!",
+		icon = "delivery",
+		onChat = onChat,
+		onDelete = onDelete,
+		isEnabled = isEnabled
+  })
+  ads[ref] = ad
+  return ad
+end
+
+local isEnabled = function ()
+  return true
+end
+
+local onDelete = function(ref)
+	ads[ref] = nil
+end
+
+local onCreateBB = function(station)
+  assert(makeAdvert(station))
+end
+
+local onEnterSystem = function(player)
+  print("player entered system")
+end
+
+local onShipDocked = function(player, station)
+	if not player:IsPlayer() then return end
+
+	for _, mission in pairs(missions) do
+    if mission.startingStation == station then
+      print("correct station")
+    end
+	end
+end
+
+local loaded_data
+
+local onGameStart = function()
+	missions = {}
+  ads = {}
+
+  if not loaded_data or not loaded_data.ads then return end
+
+  for k,ad in pairs(loaded_data.ads) do
+    local ref = ad.station:AddAdvert({
+      description = ad.desc,
+      icon        = "delivery_urgent",
+      onChat      = onChat,
+      onDelete    = onDelete,
+      isEnabled   = isEnabled })
+    ads[ref] = ad
+  end
+
+  missions = loaded_data.missions
+
+	loaded_data = nil
+end
+
+local serialize = function()
+	return {
+    ads = ads, missions = missions
+  }
+end
+
+local unserialize = function(data)
+	loaded_data = data
+end
+
+Event.Register("onCreateBB", onCreateBB)
+Event.Register("onEnterSystem", onEnterSystem)
+Event.Register("onShipDocked", onShipDocked)
+Event.Register("onGameStart", onGameStart)
+
+Mission.RegisterType('DataCollection',l.DATACOLLECTION,onClick)
+
+Serializer:Register("CollectData", serialize, unserialize)

--- a/data/modules/CollectData/CollectData.lua
+++ b/data/modules/CollectData/CollectData.lua
@@ -35,8 +35,8 @@ local scienceLabs = {
 }
 
 local createRequestMessage = function(ad)
-  return "The "..ad.scienceLab.." wants you to collect data from "..ad.planetToGoTo.name..
-  " and bring it back to "..ad.location:GetSystemBody().name.."."
+  return l.THE..ad.scienceLab..l.WANTS_YOU_TO_COLLECT_DATA_FROM..ad.planetToGoTo.name..
+  l.AND_BRING_IT_BACK_TO..ad.location:GetSystemBody().name.."."
 end
 
 local onChat = function(form, ref, option)
@@ -173,18 +173,18 @@ local onClick = function(mission)
     local planetRadius = mission.planetToGoTo.radius
     local distanceToPlanet = Game.player:DistanceTo(mission.planetToGoTo.body)
     if distanceToPlanet<planetRadius*2 then
-      Comms.Message("Data from "..mission.planetToGoTo.name.." collected")
+      Comms.Message(l.DATA_FROM..mission.planetToGoTo.name..l.COLLECTED)
       mission.collectedData = true
     else
-      Comms.Message("Not close enough to "..mission.planetToGoTo.name.." to collect data.")
+      Comms.Message(l.NOT_LOSE_ENOUGH_TO..mission.planetToGoTo.name..l.TO_COLLECT_DATA)
     end
   end)
   return ui:Grid(2, 1)
     :SetColumn(0, {
       ui:VBox(10):PackEnd({
           ui:MultiLineText(createRequestMessage(mission)),
-          NavButton.New("Set to be inspected planet as target", mission.planetToGoTo.path),
-          NavButton.New("Set station to bring the data to as target", mission.location),
+          NavButton.New(l.SET_TO_BE_INSPECTED_PLANET_AS_TARGET, mission.planetToGoTo.path),
+          NavButton.New(l.SET_STATION_TO_BRING_THE_DATA_TO_AS_TARGET, mission.location),
           collectDataButton
         })
       }


### PR DESCRIPTION
**Warning: This is my first contribution here, so be careful what you merge :D**
I added a data collection mission type, which is quite simple: You have to click collect in the mission info in a low orbit around the wanted planet/moon and then return to the station where the scientist waits.

# Things I think could be improved, but I need feedback on:
* I suggest changing the reward (400) to scale with the distance traveled
* Better "is near planet to inspect" calculations
* More translations
* Add a due system like in every other mission
* Better translation variables (I currently concatenate strings like this: FLY_TO..planet..AND_DO_STUFF)
# Suggestions to extend this:
* Add data collection missions that reach out of the current system
* Add science reputation
* Extend this by adding surface/gas sample missions