### PR TITLE
Don't show military allegiance info for player

### DIFF
--- a/data/ui/InfoView/PersonalInfo.lua
+++ b/data/ui/InfoView/PersonalInfo.lua
@@ -53,12 +53,6 @@ local personalInfo = function ()
 					ui:Label(l.REPUTATION):SetFont("HEADING_LARGE"),
 					ui:Table():SetColumnSpacing(10):AddRows({
 						{ l.STATUS..":", l[player:GetReputationRating()] },
-					}),
-					"",
-					ui:Label(l.MILITARY):SetFont("HEADING_LARGE"),
-					ui:Table():SetColumnSpacing(10):AddRows({
-						{ l.ALLEGIANCE, l.NONE }, -- XXX
-						{ l.RANK,      l.NONE }, -- XXX
 					})
 				})
 			})


### PR DESCRIPTION
It serves literally no purpose right now and might even mislead players into thinking that being a part of a military possible.

I wanted to delete the strings as well but I don't know if they are used somewhere else in the code or if they can be any useful in the future so I left them for now. Can delete them on your wish.

That UI window got a little empty for sure. Maybe we can fill that space with the crime statistics of the player. For example: 

- Wanted in Solar Federation. 5534 Cr fine for unlawful weapons discharge (x3).
4432 Cr fine for illegal hyperspace jump.
6622 Cr fine for black market activities (x2).
- Outlaw in Obsidian Horde.

(I'm not volunteering for now.)