### PR TITLE
metadata: Add version number to release in AppData

### DIFF
--- a/metadata/net.pioneerspacesim.Pioneer.appdata.xml
+++ b/metadata/net.pioneerspacesim.Pioneer.appdata.xml
@@ -56,6 +56,6 @@
 	</screenshots>
 
 	<releases>
-		<release date="2018-02-03" />
+		<release version="20180203" date="2018-02-03" />
 	</releases>
 </component>


### PR DESCRIPTION
It will now be the same as the one in https://github.com/flathub/net.pioneerspacesim.Pioneer/.
Then, the one in the flathub repo can be removed.