### PR TITLE
Fixup Travis build script for CMake support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
         - ./bootstrap cmake -DUSE_PIONEER_THIRDPARTY=1 && make -C build
 
 before_deploy:
-  - make sgm
+  - env SDL_VIDEODRIVER=dummy ./build/modelcompiler -b inplace
   - ./scripts/build-travis.sh
 
 deploy:

--- a/scripts/build-travis.sh
+++ b/scripts/build-travis.sh
@@ -2,7 +2,7 @@
 
 # Package a build and prepare it for upload via Travis.
 
-BINARIES=("src/pioneer" "src/modelcompiler")
+BINARIES=("build/pioneer" "build/modelcompiler")
 COPY_DIR=release
 
 # Append .exe to the binaries if we're building for windows.


### PR DESCRIPTION
Pinging @impaktor. This invokes the modelcompiler binary from the Travisfile directly, and updates the build scripts to use the new binary location produced by CMake.