### PR TITLE
cmake: Test for a .git directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 # Get the GIT hash of the latest commit
 include(FindGit OPTIONAL)
-if (GIT_FOUND)
+if (GIT_FOUND AND EXISTS ${PROJECT_SOURCE_DIR}/.git)
 	execute_process(
 		COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
This prevents the following error when git is found and the source directory is not a git repo.
```
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```
