### PR TITLE
CMake: only install precompiled models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,8 +252,13 @@ install(TARGETS ${PROJECT_NAME} modelcompiler savegamedump
 )
 install(DIRECTORY data/
 	DESTINATION ${PIONEER_DATA_DIR}
+	REGEX "/models" EXCLUDE
 	PATTERN "listdata.*" EXCLUDE
 	PATTERN "Makefile.am" EXCLUDE
+)
+install(DIRECTORY data/models/
+	DESTINATION ${PIONEER_DATA_DIR}/models
+	FILES_MATCHING PATTERN "*.sgm"
 )
 
 if (WIN32)


### PR DESCRIPTION
Install only the *.sgm precompiled models, as when they are present, the other model files aren't needed.