### PR TITLE
Update the clang-format hook, add an auto-apply script. 

### DIFF
--- a/autoformat
+++ b/autoformat
@@ -1,17 +1,17 @@
 #!/bin/sh
 
+./scripts/clang-format.sh
 # Run clang-format, storing the output in MSG
 # Git runs hooks in the base directory, so we don't need to do any fancy dirname stuff.
-MSG="$(./scripts/clang-format.sh)"
 # $? will be non-zero if clang-format detected formatting issues.
 if [ "$?" != 0 ]; then
     # We've had a major malfunction!
-    echo "$MSG"
     read -p "Do you want to automatically apply these changes (y/N)?" apply
-    case "$apply" in
+    case $apply in
         y|Y)
-            # Get the patch info from the message
-            patch="/tmp/$(date +%s).patch"
+			# Get the patch info from the message
+			patch="$(PATCH_MODE=1 ./scripts/clang-format.sh)"
+            MSG="$(cat $patch)"
             echo "$MSG" | git mailinfo --scissors /dev/null "$patch" &>/dev/null
             # And apply it to the staged changes.
             git apply --index "$patch"

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -24,15 +24,22 @@ fi
 if [ -z "$FILES" ]; then
     FILES=$($GIT_DIFF_TOOL --no-commit-id --name-only -r $RANGE | grep -v contrib/ | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc)$")
 fi
-echo -e "Checking files:\n$FILES"
+
+if [ ! $PATCH_MODE ]; then echo -e "Checking files:\n$FILES"; fi
 
 prefix="static-check-clang-format"
 suffix="$(date +%s)"
 patch="/tmp/$prefix-$suffix.patch"
 
+if [ -z "$TRAVIS" ] && [ ! $PATCH_MODE ]; then
+	DIFF_COLOR="--color=always"
+else
+	DIFF_COLOR=""
+fi
+
 for file in $FILES; do
     "$CLANG_FORMAT" -style=file "$file" | \
-    diff -u "$file" - | \
+    diff $DIFF_COLOR -u "$file" - | \
     sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
 done
 
@@ -43,10 +50,16 @@ if [ ! -s "$patch" ] ; then
     exit 0
 fi
 
-# a patch has been created, notify the user and exit
-printf "\n*** The following differences were found between the code to commit "
-printf "and the clang-format rules:\n-----\n"
-cat "$patch"
-rm -f "$patch"
-printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
-exit 1
+if [ $PATCH_MODE ]; then
+	# Print the filename of the generated patch.
+	echo "$patch"
+	exit 1
+else
+	# a patch has been created, notify the user and exit
+	printf "\n*** The following differences were found between the code to commit "
+	printf "and the clang-format rules:\n-----\n"
+	cat "$patch"
+	rm -f "$patch"
+	printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+	exit 1
+fi


### PR DESCRIPTION
Now we copy `scripts/clang-format.sh` to `.git/hooks/pre-commit`. Rewrote the previous hook into a tool for automatically applying the clang-format changes, with color output.

We've got documentation for the hook / code style in [the wiki](https://pioneerwiki.com/wiki/Coding_Conventions), though it will need to be updated for the new way of using the hook files.