### PR TITLE
Make modelcompiler handle custom data dir

### DIFF
--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -17,7 +17,7 @@ fi
 if [ -n "$TRAVIS" ]; then
     GIT_DIFF_TOOL="git diff-tree"
 else
-    GIT_DIFF_TOOL="git diff-index"
+    GIT_DIFF_TOOL="git diff-index --cached"
 fi
 
 # Allow manually specifiying the files.

--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -148,6 +148,8 @@ enum RunMode {
 	MODE_USAGE_ERROR
 };
 
+static FileSystem::FileSourceFS customDataDir(".");
+
 int main(int argc, char **argv)
 {
 #ifdef PIONEER_PROFILER
@@ -241,6 +243,12 @@ start:
 		if (argc > 2) {
 			std::string arg2 = argv[2];
 			isInPlace = (arg2 == "inplace" || arg2 == "true");
+
+			if (!isInPlace && !arg2.empty()) {
+				customDataDir = FileSystem::FileSourceFS(arg2);
+				FileSystem::gameDataFiles.AppendSource(&customDataDir);
+				isInPlace = true;
+			}
 		}
 
 		// find all of the models


### PR DESCRIPTION
This PR adds logic to handle a custom, command-line specified data directory when the modelcompiler is being used as a build tool. The new syntax is `modelcompiler -b /path/to/data`.

CC @orbea 