### PR TITLE
Close default ctors and use a Ctor for load

### DIFF
--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -141,8 +141,6 @@ Beam::Beam(const Json &jsonObj, Space *space) :
 	if (!s_sideMat) BuildModel();
 	m_flags |= FLAG_DRAW_LAST;
 
-	Body::LoadFromJson(jsonObj, space);
-
 	try {
 		Json projectileObj = jsonObj["projectile"];
 

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Beam.h"
+
 #include "CargoBody.h"
 #include "Frame.h"
 #include "Game.h"
@@ -110,18 +111,51 @@ void Beam::FreeModel()
 	s_glowVerts.reset();
 }
 
-Beam::Beam() :
-	Body()
+Beam::Beam(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dir) :
+	Body(),
+	m_age(0),
+	m_active(true)
 {
 	if (!s_sideMat) BuildModel();
-	SetOrient(matrix3x3d::Identity());
-	m_baseDam = 0;
-	m_length = 0;
-	m_mining = false;
-	m_parent = 0;
 	m_flags |= FLAG_DRAW_LAST;
-	m_age = 0;
-	m_active = true;
+
+	m_parent = parent;
+	m_dir = dir;
+	m_baseDam = prData.damage;
+	m_length = prData.length;
+	m_mining = prData.mining;
+	m_color = prData.color;
+	SetFrame(parent->GetFrame());
+
+	SetOrient(parent->GetOrient());
+	SetPosition(pos);
+	m_baseVel = baseVel;
+	SetClipRadius(GetRadius());
+	SetPhysRadius(GetRadius());
+}
+
+Beam::Beam(const Json &jsonObj, Space *space) :
+	Body(jsonObj, space),
+	m_active(true)
+{
+	if (!s_sideMat) BuildModel();
+	m_flags |= FLAG_DRAW_LAST;
+
+	Body::LoadFromJson(jsonObj, space);
+
+	try {
+		Json projectileObj = jsonObj["projectile"];
+
+		JsonToVector(&m_dir, projectileObj["dir"]);
+		m_baseDam = projectileObj["base_dam"];
+		m_length = projectileObj["length"];
+		m_mining = projectileObj["mining"];
+		m_age = projectileObj["age"];
+		JsonToColor(&m_color, projectileObj["color"]);
+		m_parentIndex = projectileObj["index_for_body"];
+	} catch (Json::type_error &) {
+		throw SavedGameCorruptException();
+	}
 }
 
 Beam::~Beam()
@@ -139,27 +173,10 @@ void Beam::SaveToJson(Json &jsonObj, Space *space)
 	projectileObj["length"] = m_length;
 	projectileObj["mining"] = m_mining;
 	projectileObj["color"] = m_color;
+	projectileObj["age"] = m_age;
 	projectileObj["index_for_body"] = space->GetIndexForBody(m_parent);
 
 	jsonObj["projectile"] = projectileObj; // Add projectile object to supplied object.
-}
-
-void Beam::LoadFromJson(const Json &jsonObj, Space *space)
-{
-	Body::LoadFromJson(jsonObj, space);
-
-	try {
-		Json projectileObj = jsonObj["projectile"];
-
-		JsonToVector(&m_dir, projectileObj["dir"]);
-		m_baseDam = projectileObj["base_dam"];
-		m_length = projectileObj["length"];
-		m_mining = projectileObj["mining"];
-		JsonToColor(&m_color, projectileObj["color"]);
-		m_parentIndex = projectileObj["index_for_body"];
-	} catch (Json::type_error &) {
-		throw SavedGameCorruptException();
-	}
 }
 
 void Beam::PostLoadFixup(Space *space)
@@ -344,19 +361,6 @@ void Beam::Render(Graphics::Renderer *renderer, const Camera *camera, const vect
 // static
 void Beam::Add(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dir)
 {
-	Beam *p = new Beam();
-	p->m_parent = parent;
-	p->m_dir = dir;
-	p->m_baseDam = prData.damage;
-	p->m_length = prData.length;
-	p->m_mining = prData.mining;
-	p->m_color = prData.color;
-	p->SetFrame(parent->GetFrame());
-
-	p->SetOrient(parent->GetOrient());
-	p->SetPosition(pos);
-	p->m_baseVel = baseVel;
-	p->SetClipRadius(p->GetRadius());
-	p->SetPhysRadius(p->GetRadius());
+	Beam *p = new Beam(parent, prData, pos, baseVel, dir);
 	Pi::game->GetSpace()->AddBody(p);
 }

--- a/src/Beam.h
+++ b/src/Beam.h
@@ -10,11 +10,13 @@
 #include "graphics/Material.h"
 
 class Frame;
+
 namespace Graphics {
 	class Renderer;
 	class VertexArray;
 	class RenderState;
 } // namespace Graphics
+
 struct ProjectileData;
 
 class Beam : public Body {
@@ -23,7 +25,9 @@ public:
 
 	static void Add(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dir);
 
-	Beam();
+	Beam() = delete;
+	Beam(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dir);
+	Beam(const Json &jsonObj, Space *space);
 	virtual ~Beam();
 	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override final;
 	void TimeStepUpdate(const float timeStep) override final;
@@ -36,7 +40,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override final;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override final;
 
 private:
 	float GetDamage() const;

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -118,14 +118,14 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 		Ship *s = new Ship(jsonObj, space);
 		// Here because of comments in Ship.cpp on following function
 		s->UpdateLuaStats();
-		return static_cast<Body*>(s);
-		}
+		return static_cast<Body *>(s);
+	}
 	case Object::PLAYER: {
 		Player *p = new Player(jsonObj, space);
 		// Read comments in Ship.cpp on following function
 		p->UpdateLuaStats();
-		return static_cast<Body*>(p);
-		}
+		return static_cast<Body *>(p);
+	}
 	case Object::MISSILE:
 		return new Missile(jsonObj, space);
 	case Object::PROJECTILE:

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -117,8 +117,7 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 		b = new Player();
 		break;
 	case Object::MISSILE:
-		b = new Missile();
-		break;
+		return new Missile(jsonObj, space);
 	case Object::PROJECTILE:
 		return new Projectile(jsonObj, space);
 	case Object::CARGOBODY:

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -34,6 +34,31 @@ Body::Body() :
 	Properties().Set("label", m_label);
 }
 
+Body::Body(const Json &jsonObj, Space *space) :
+	PropertiedObject(Lua::manager),
+	m_flags(0),
+	m_interpPos(0.0),
+	m_interpOrient(matrix3x3d::Identity()),
+	m_frame(nullptr)
+{
+	try {
+		Json bodyObj = jsonObj["body"];
+
+		Properties().LoadFromJson(bodyObj);
+		m_frame = space->GetFrameByIndex(bodyObj["index_for_frame"]);
+		m_label = bodyObj["label"];
+		Properties().Set("label", m_label);
+		m_dead = bodyObj["dead"];
+
+		m_pos = bodyObj["pos"];
+		m_orient = bodyObj["orient"];
+		m_physRadius = bodyObj["phys_radius"];
+		m_clipRadius = bodyObj["clip_radius"];
+	} catch (Json::type_error &) {
+		throw SavedGameCorruptException();
+	}
+}
+
 Body::~Body()
 {
 }
@@ -53,26 +78,6 @@ void Body::SaveToJson(Json &jsonObj, Space *space)
 	bodyObj["clip_radius"] = m_clipRadius;
 
 	jsonObj["body"] = bodyObj; // Add body object to supplied object.
-}
-
-void Body::LoadFromJson(const Json &jsonObj, Space *space)
-{
-	try {
-		Json bodyObj = jsonObj["body"];
-
-		Properties().LoadFromJson(bodyObj);
-		m_frame = space->GetFrameByIndex(bodyObj["index_for_frame"]);
-		m_label = bodyObj["label"];
-		Properties().Set("label", m_label);
-		m_dead = bodyObj["dead"];
-
-		m_pos = bodyObj["pos"];
-		m_orient = bodyObj["orient"];
-		m_physRadius = bodyObj["phys_radius"];
-		m_clipRadius = bodyObj["clip_radius"];
-	} catch (Json::type_error &) {
-		throw SavedGameCorruptException();
-	}
 }
 
 void Body::ToJson(Json &jsonObj, Space *space)

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -104,11 +104,9 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 	Object::Type type = Object::Type(jsonObj["body_type"]);
 	switch (type) {
 	case Object::STAR:
-		b = new Star();
-		break;
+		return new Star(jsonObj, space);
 	case Object::PLANET:
-		b = new Planet();
-		break;
+		return new Planet(jsonObj, space);
 	case Object::SPACESTATION:
 		b = new SpaceStation();
 		break;

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -124,8 +124,7 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 	case Object::CARGOBODY:
 		return new CargoBody(jsonObj, space);
 	case Object::HYPERSPACECLOUD:
-		b = new HyperspaceCloud();
-		break;
+		return new HyperspaceCloud(jsonObj, space);
 	default:
 		assert(0);
 	}

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -101,7 +101,6 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 	if (!jsonObj["body_type"].is_number_integer())
 		throw SavedGameCorruptException();
 
-	Body *b = 0;
 	Object::Type type = Object::Type(jsonObj["body_type"]);
 	switch (type) {
 	case Object::STAR:
@@ -110,12 +109,18 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 		return new Planet(jsonObj, space);
 	case Object::SPACESTATION:
 		return new SpaceStation(jsonObj, space);
-	case Object::SHIP:
-		b = new Ship();
-		break;
-	case Object::PLAYER:
-		b = new Player();
-		break;
+	case Object::SHIP: {
+		Ship *s = new Ship(jsonObj, space);
+		// Here because of comments in Ship.cpp on following function
+		s->UpdateLuaStats();
+		return static_cast<Body*>(s);
+		}
+	case Object::PLAYER: {
+		Player *p = new Player(jsonObj, space);
+		// Read comments in Ship.cpp on following function
+		p->UpdateLuaStats();
+		return static_cast<Body*>(p);
+		}
 	case Object::MISSILE:
 		return new Missile(jsonObj, space);
 	case Object::PROJECTILE:
@@ -127,8 +132,8 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 	default:
 		assert(0);
 	}
-	b->LoadFromJson(jsonObj, space);
-	return b;
+
+	return nullptr;
 }
 
 vector3d Body::GetPositionRelTo(const Frame *relTo) const

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -108,8 +108,7 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 	case Object::PLANET:
 		return new Planet(jsonObj, space);
 	case Object::SPACESTATION:
-		b = new SpaceStation();
-		break;
+		return new SpaceStation(jsonObj, space);
 	case Object::SHIP:
 		b = new Ship();
 		break;
@@ -120,8 +119,7 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 		b = new Missile();
 		break;
 	case Object::PROJECTILE:
-		b = new Projectile();
-		break;
+		return new Projectile(jsonObj, space);
 	case Object::CARGOBODY:
 		b = new CargoBody();
 		break;

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Body.h"
+
 #include "CargoBody.h"
 #include "Frame.h"
 #include "GameSaveError.h"
@@ -121,8 +122,7 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 	case Object::PROJECTILE:
 		return new Projectile(jsonObj, space);
 	case Object::CARGOBODY:
-		b = new CargoBody();
-		break;
+		return new CargoBody(jsonObj, space);
 	case Object::HYPERSPACECLOUD:
 		b = new HyperspaceCloud();
 		break;

--- a/src/Body.h
+++ b/src/Body.h
@@ -24,6 +24,7 @@ class Body : public Object, public PropertiedObject {
 public:
 	OBJDEF(Body, Object, BODY);
 	Body();
+	Body(const Json &jsonObj, Space *space);
 	virtual ~Body();
 	void ToJson(Json &jsonObj, Space *space);
 	static Body *FromJson(const Json &jsonObj, Space *space);
@@ -110,7 +111,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space);
-	virtual void LoadFromJson(const Json &jsonObj, Space *space);
 	unsigned int m_flags;
 
 	// Interpolated draw orientation-position

--- a/src/CargoBody.cpp
+++ b/src/CargoBody.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "CargoBody.h"
+
 #include "Game.h"
 #include "GameSaveError.h"
 #include "Pi.h"
@@ -23,7 +24,7 @@ void CargoBody::SaveToJson(Json &jsonObj, Space *space)
 	jsonObj["cargo_body"] = cargoBodyObj; // Add cargo body object to supplied object.
 }
 
-void CargoBody::LoadFromJson(const Json &jsonObj, Space *space)
+CargoBody::CargoBody(const Json &jsonObj, Space *space)
 {
 	DynamicBody::LoadFromJson(jsonObj, space);
 	GetModel()->SetLabel(GetLabel());

--- a/src/CargoBody.cpp
+++ b/src/CargoBody.cpp
@@ -24,9 +24,9 @@ void CargoBody::SaveToJson(Json &jsonObj, Space *space)
 	jsonObj["cargo_body"] = cargoBodyObj; // Add cargo body object to supplied object.
 }
 
-CargoBody::CargoBody(const Json &jsonObj, Space *space)
+CargoBody::CargoBody(const Json &jsonObj, Space *space) :
+	DynamicBody(jsonObj, space)
 {
-	DynamicBody::LoadFromJson(jsonObj, space);
 	GetModel()->SetLabel(GetLabel());
 
 	try {

--- a/src/CargoBody.cpp
+++ b/src/CargoBody.cpp
@@ -10,18 +10,16 @@
 #include "Ship.h"
 #include "Space.h"
 
-void CargoBody::SaveToJson(Json &jsonObj, Space *space)
+CargoBody::CargoBody(const LuaRef &cargo, float selfdestructTimer) :
+	m_cargo(cargo)
 {
-	DynamicBody::SaveToJson(jsonObj, space);
+	SetModel("cargo");
+	Init();
+	SetMass(1.0);
+	m_selfdestructTimer = selfdestructTimer; // number of seconds to live
 
-	Json cargoBodyObj = Json::object(); // Create JSON object to contain cargo body data.
-
-	m_cargo.SaveToJson(cargoBodyObj);
-	cargoBodyObj["hit_points"] = m_hitpoints;
-	cargoBodyObj["self_destruct_timer"] = m_selfdestructTimer;
-	cargoBodyObj["has_self_destruct"] = m_hasSelfdestruct;
-
-	jsonObj["cargo_body"] = cargoBodyObj; // Add cargo body object to supplied object.
+	if (is_zero_exact(selfdestructTimer)) // turn off self destruct
+		m_hasSelfdestruct = false;
 }
 
 CargoBody::CargoBody(const Json &jsonObj, Space *space) :
@@ -40,6 +38,20 @@ CargoBody::CargoBody(const Json &jsonObj, Space *space) :
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
+}
+
+void CargoBody::SaveToJson(Json &jsonObj, Space *space)
+{
+	DynamicBody::SaveToJson(jsonObj, space);
+
+	Json cargoBodyObj = Json::object(); // Create JSON object to contain cargo body data.
+
+	m_cargo.SaveToJson(cargoBodyObj);
+	cargoBodyObj["hit_points"] = m_hitpoints;
+	cargoBodyObj["self_destruct_timer"] = m_selfdestructTimer;
+	cargoBodyObj["has_self_destruct"] = m_hasSelfdestruct;
+
+	jsonObj["cargo_body"] = cargoBodyObj; // Add cargo body object to supplied object.
 }
 
 void CargoBody::Init()
@@ -63,18 +75,6 @@ void CargoBody::Init()
 	GetModel()->SetColors(colors);
 
 	Properties().Set("type", cargoname);
-}
-
-CargoBody::CargoBody(const LuaRef &cargo, float selfdestructTimer) :
-	m_cargo(cargo)
-{
-	SetModel("cargo");
-	Init();
-	SetMass(1.0);
-	m_selfdestructTimer = selfdestructTimer; // number of seconds to live
-
-	if (is_zero_exact(selfdestructTimer)) // turn off self destruct
-		m_hasSelfdestruct = false;
 }
 
 void CargoBody::TimeStepUpdate(const float timeStep)

--- a/src/CargoBody.h
+++ b/src/CargoBody.h
@@ -15,8 +15,9 @@ namespace Graphics {
 class CargoBody : public DynamicBody {
 public:
 	OBJDEF(CargoBody, DynamicBody, CARGOBODY);
+	CargoBody() = delete;
 	CargoBody(const LuaRef &cargo, float selfdestructTimer = 86400.0f); // default to 24 h lifetime
-	CargoBody() {}
+	CargoBody(const Json &jsonObj, Space *space);
 	LuaRef GetCargoType() const { return m_cargo; }
 	virtual void SetLabel(const std::string &label) override;
 	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
@@ -26,7 +27,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 private:
 	void Init();

--- a/src/CargoBody.h
+++ b/src/CargoBody.h
@@ -25,7 +25,8 @@ public:
 	virtual bool OnCollision(Object *o, Uint32 flags, double relVel) override;
 	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact &contactData) override;
 
-	~CargoBody() {};
+	~CargoBody(){};
+
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
 

--- a/src/CargoBody.h
+++ b/src/CargoBody.h
@@ -25,6 +25,7 @@ public:
 	virtual bool OnCollision(Object *o, Uint32 flags, double relVel) override;
 	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact &contactData) override;
 
+	~CargoBody() {};
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
 

--- a/src/CityOnPlanet.h
+++ b/src/CityOnPlanet.h
@@ -30,6 +30,7 @@ namespace SceneGraph {
 class CityOnPlanet : public Object {
 public:
 	OBJDEF(CityOnPlanet, Object, CITYONPLANET);
+	CityOnPlanet() = delete;
 	CityOnPlanet(Planet *planet, SpaceStation *station, const Uint32 seed);
 	virtual ~CityOnPlanet();
 	void Render(Graphics::Renderer *r, const Graphics::Frustum &camera, const SpaceStation *station, const vector3d &viewCoords, const matrix4x4d &viewTransform);

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -81,6 +81,37 @@ DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
 
 }
 
+void DynamicBody::SaveToJson(Json &jsonObj, Space *space)
+{
+	ModelBody::SaveToJson(jsonObj, space);
+
+	Json dynamicBodyObj = Json::object(); // Create JSON object to contain dynamic body data.
+
+	dynamicBodyObj["force"] = m_force;
+	dynamicBodyObj["torque"] = m_torque;
+	dynamicBodyObj["vel"] = m_vel;
+	dynamicBodyObj["ang_vel"] = m_angVel;
+	dynamicBodyObj["mass"] = m_mass;
+	dynamicBodyObj["mass_radius"] = m_massRadius;
+	dynamicBodyObj["ang_inertia"] = m_angInertia;
+	dynamicBodyObj["is_moving"] = m_isMoving;
+
+	jsonObj["dynamic_body"] = dynamicBodyObj; // Add dynamic body object to supplied object.
+}
+
+void DynamicBody::PostLoadFixup(Space *space)
+{
+	Body::PostLoadFixup(space);
+	m_oldPos = GetPosition();
+	//	CalcExternalForce();		// too dangerous
+}
+
+DynamicBody::~DynamicBody()
+{
+	m_propulsion.Reset();
+	m_fixedGuns.Reset();
+}
+
 void DynamicBody::AddFeature(Feature f)
 {
 	m_features[f] = true;
@@ -114,31 +145,6 @@ void DynamicBody::AddRelForce(const vector3d &f)
 void DynamicBody::AddRelTorque(const vector3d &t)
 {
 	m_torque += GetOrient() * t;
-}
-
-void DynamicBody::SaveToJson(Json &jsonObj, Space *space)
-{
-	ModelBody::SaveToJson(jsonObj, space);
-
-	Json dynamicBodyObj = Json::object(); // Create JSON object to contain dynamic body data.
-
-	dynamicBodyObj["force"] = m_force;
-	dynamicBodyObj["torque"] = m_torque;
-	dynamicBodyObj["vel"] = m_vel;
-	dynamicBodyObj["ang_vel"] = m_angVel;
-	dynamicBodyObj["mass"] = m_mass;
-	dynamicBodyObj["mass_radius"] = m_massRadius;
-	dynamicBodyObj["ang_inertia"] = m_angInertia;
-	dynamicBodyObj["is_moving"] = m_isMoving;
-
-	jsonObj["dynamic_body"] = dynamicBodyObj; // Add dynamic body object to supplied object.
-}
-
-void DynamicBody::PostLoadFixup(Space *space)
-{
-	Body::PostLoadFixup(space);
-	m_oldPos = GetPosition();
-	//	CalcExternalForce();		// too dangerous
 }
 
 const Propulsion *DynamicBody::GetPropulsion() const
@@ -301,12 +307,6 @@ void DynamicBody::SetMassDistributionFromModel()
 vector3d DynamicBody::GetAngularMomentum() const
 {
 	return m_angInertia * m_angVel;
-}
-
-DynamicBody::~DynamicBody()
-{
-	m_propulsion.Reset();
-	m_fixedGuns.Reset();
 }
 
 vector3d DynamicBody::GetVelocity() const

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -76,7 +76,6 @@ DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
 	m_decelerating = false;
 	for (int i = 0; i < Feature::MAX_FEATURE; i++)
 		m_features[i] = false;
-
 }
 
 void DynamicBody::SaveToJson(Json &jsonObj, Space *space)

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -43,7 +43,7 @@ DynamicBody::DynamicBody() :
 }
 
 DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
-	ModelBody(),
+	ModelBody(jsonObj, space),
 	m_propulsion(nullptr),
 	m_fixedGuns(nullptr),
 	m_dragCoeff(DEFAULT_DRAG_COEFF),
@@ -53,8 +53,6 @@ DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
 	m_lastForce(vector3d(0.0)),
 	m_lastTorque(vector3d(0.0))
 {
-	ModelBody::LoadFromJson(jsonObj, space);
-
 	m_flags = Body::FLAG_CAN_MOVE_FRAME;
 	m_oldPos = GetPosition();
 	m_oldAngDisplacement = vector3d(0.0);

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -21,7 +21,9 @@ private:
 public:
 	OBJDEF(DynamicBody, ModelBody, DYNAMICBODY);
 	DynamicBody();
+	DynamicBody(const Json &jsonObj, Space *space);
 	virtual ~DynamicBody();
+
 	virtual vector3d GetVelocity() const override;
 	virtual void SetVelocity(const vector3d &v) override;
 	virtual void SetFrame(Frame *f) override;
@@ -91,7 +93,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 	static const double DEFAULT_DRAG_COEFF;
 	double m_dragCoeff;

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -33,10 +33,9 @@ HyperspaceCloud::HyperspaceCloud(Ship *s, double dueDate, bool isArrival) :
 }
 
 HyperspaceCloud::HyperspaceCloud(const Json &jsonObj, Space *space) :
+	Body(jsonObj, space),
 	m_isBeingKilled(false)
 {
-	Body::LoadFromJson(jsonObj, space);
-
 	try {
 		Json hyperspaceCloudObj = jsonObj["hyperspace_cloud"];
 

--- a/src/HyperspaceCloud.h
+++ b/src/HyperspaceCloud.h
@@ -8,6 +8,7 @@
 
 class Frame;
 class Ship;
+
 namespace Graphics {
 	class Material;
 	class Renderer;
@@ -18,8 +19,9 @@ namespace Graphics {
 class HyperspaceCloud : public Body {
 public:
 	OBJDEF(HyperspaceCloud, Body, HYPERSPACECLOUD);
+	HyperspaceCloud() = delete;
 	HyperspaceCloud(Ship *, double dateDue, bool isArrival);
-	HyperspaceCloud();
+	HyperspaceCloud(const Json &jsonObj, Space *space);
 	virtual ~HyperspaceCloud();
 	virtual void SetVelocity(const vector3d &v) override { m_vel = v; }
 	virtual vector3d GetVelocity() const override { return m_vel; }
@@ -35,7 +37,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 private:
 	void InitGraphics();

--- a/src/LuaBody.cpp
+++ b/src/LuaBody.cpp
@@ -11,6 +11,7 @@
 #include "LuaUtils.h"
 #include "Pi.h"
 #include "TerrainBody.h"
+#include "WorldView.h"
 #include "galaxy/StarSystem.h"
 
 #include "CargoBody.h"

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "LuaEngine.h"
+
 #include "EnumStrings.h"
 #include "FileSystem.h"
 #include "FloatComparison.h"
@@ -21,6 +22,7 @@
 #include "SectorView.h"
 #include "Sound.h"
 #include "SoundMusic.h"
+#include "WorldView.h"
 #include "buildopts.h"
 #include "graphics/Graphics.h"
 #include "scenegraph/Model.h"

--- a/src/LuaPlayer.cpp
+++ b/src/LuaPlayer.cpp
@@ -12,6 +12,7 @@
 #include "Player.h"
 #include "SectorView.h"
 #include "TerrainBody.h"
+#include "WorldView.h"
 #include "galaxy/Galaxy.h"
 
 /*

--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -44,9 +44,9 @@ Missile::Missile(const ShipType::Id &shipId, Body *owner, int power)
 	GetPropulsion()->Init(this, GetModel(), m_type->fuelTankMass, m_type->effectiveExhaustVelocity, m_type->linThrust, m_type->angThrust);
 }
 
-Missile::Missile(const Json &jsonObj, Space *space)
+Missile::Missile(const Json &jsonObj, Space *space) :
+	DynamicBody(jsonObj, space)
 {
-	DynamicBody::LoadFromJson(jsonObj, space);
 	AddFeature(Feature::PROPULSION);
 	GetPropulsion()->LoadFromJson(jsonObj, space);
 	Json missileObj = jsonObj["missile"];

--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -69,19 +69,6 @@ Missile::Missile(const Json &jsonObj, Space *space) :
 	GetPropulsion()->Init(this, GetModel(), m_type->fuelTankMass, m_type->effectiveExhaustVelocity, m_type->linThrust, m_type->angThrust);
 }
 
-Missile::~Missile()
-{
-	if (m_curAICmd) delete m_curAICmd;
-}
-
-void Missile::ECMAttack(int power_val)
-{
-	if (power_val > m_power) {
-		CollisionContact dummy;
-		OnDamage(0, 1.0f, dummy);
-	}
-}
-
 void Missile::SaveToJson(Json &jsonObj, Space *space)
 {
 	DynamicBody::SaveToJson(jsonObj, space);
@@ -104,6 +91,19 @@ void Missile::PostLoadFixup(Space *space)
 	DynamicBody::PostLoadFixup(space);
 	m_owner = space->GetBodyByIndex(m_ownerIndex);
 	if (m_curAICmd) m_curAICmd->PostLoadFixup(space);
+}
+
+Missile::~Missile()
+{
+	if (m_curAICmd) delete m_curAICmd;
+}
+
+void Missile::ECMAttack(int power_val)
+{
+	if (power_val > m_power) {
+		CollisionContact dummy;
+		OnDamage(0, 1.0f, dummy);
+	}
 }
 
 void Missile::StaticUpdate(const float timeStep)

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -12,8 +12,9 @@
 class Missile : public DynamicBody {
 public:
 	OBJDEF(Missile, DynamicBody, MISSILE);
+	Missile() = delete;
 	Missile(const ShipType::Id &type, Body *owner, int power = -1);
-	Missile() {}
+	Missile(const Json &jsonObj, Space *space);
 	virtual ~Missile();
 	void StaticUpdate(const float timeStep) override;
 	void TimeStepUpdate(const float timeStep) override;
@@ -31,7 +32,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 private:
 	void Explode();

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -59,12 +59,14 @@ public:
 ModelBody::ModelBody() :
 	m_isStatic(false),
 	m_colliding(true),
-	m_geom(0),
-	m_model(0)
+	m_geom(nullptr),
+	m_model(nullptr)
 {
 }
 
-void ModelBody::LoadFromJson(const Json &jsonObj, Space *space)
+ModelBody::ModelBody(const Json &jsonObj, Space *space) :
+	m_geom(nullptr),
+	m_model(nullptr)
 {
 	Body::LoadFromJson(jsonObj, space);
 	Json modelBodyObj = jsonObj["model_body"];

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -64,6 +64,23 @@ ModelBody::ModelBody() :
 {
 }
 
+void ModelBody::LoadFromJson(const Json &jsonObj, Space *space)
+{
+	Body::LoadFromJson(jsonObj, space);
+	Json modelBodyObj = jsonObj["model_body"];
+
+	try {
+		m_isStatic = modelBodyObj["is_static"];
+		m_colliding = modelBodyObj["is_colliding"];
+		SetModel(modelBodyObj["model_name"].get<std::string>().c_str());
+	} catch (Json::type_error &) {
+		throw SavedGameCorruptException();
+	}
+
+	m_model->LoadFromJson(modelBodyObj);
+	m_shields->LoadFromJson(modelBodyObj);
+}
+
 ModelBody::~ModelBody()
 {
 	SetFrame(0); // Will remove geom from frame if necessary.
@@ -86,23 +103,6 @@ void ModelBody::SaveToJson(Json &jsonObj, Space *space)
 	m_shields->SaveToJson(modelBodyObj);
 
 	jsonObj["model_body"] = modelBodyObj; // Add model body object to supplied object.
-}
-
-void ModelBody::LoadFromJson(const Json &jsonObj, Space *space)
-{
-	Body::LoadFromJson(jsonObj, space);
-	Json modelBodyObj = jsonObj["model_body"];
-
-	try {
-		m_isStatic = modelBodyObj["is_static"];
-		m_colliding = modelBodyObj["is_colliding"];
-		SetModel(modelBodyObj["model_name"].get<std::string>().c_str());
-	} catch (Json::type_error &) {
-		throw SavedGameCorruptException();
-	}
-
-	m_model->LoadFromJson(modelBodyObj);
-	m_shields->LoadFromJson(modelBodyObj);
 }
 
 void ModelBody::SetStatic(bool isStatic)

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -65,10 +65,10 @@ ModelBody::ModelBody() :
 }
 
 ModelBody::ModelBody(const Json &jsonObj, Space *space) :
+	Body(jsonObj, space),
 	m_geom(nullptr),
 	m_model(nullptr)
 {
-	Body::LoadFromJson(jsonObj, space);
 	Json modelBodyObj = jsonObj["model_body"];
 
 	try {

--- a/src/ModelBody.h
+++ b/src/ModelBody.h
@@ -25,6 +25,7 @@ class ModelBody : public Body {
 public:
 	OBJDEF(ModelBody, Body, MODELBODY);
 	ModelBody();
+	ModelBody(const Json &jsonObj, Space *space);
 	virtual ~ModelBody();
 	void SetPosition(const vector3d &p) override;
 	void SetOrient(const matrix3x3d &r) override;
@@ -48,7 +49,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 	void SetLighting(Graphics::Renderer *r, const Camera *camera, std::vector<Graphics::Light> &oldLights, Color &oldAmbient);
 	void ResetLighting(Graphics::Renderer *r, const std::vector<Graphics::Light> &oldLights, const Color &oldAmbient);

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -19,13 +19,6 @@ using namespace Graphics;
 
 static const Graphics::AttributeSet RING_VERTEX_ATTRIBS = Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0;
 
-Planet::Planet() :
-	TerrainBody(),
-	m_ringVertices(RING_VERTEX_ATTRIBS),
-	m_ringState(nullptr)
-{
-}
-
 Planet::Planet(SystemBody *sbody) :
 	TerrainBody(sbody),
 	m_ringVertices(RING_VERTEX_ATTRIBS),
@@ -34,7 +27,10 @@ Planet::Planet(SystemBody *sbody) :
 	InitParams(sbody);
 }
 
-void Planet::LoadFromJson(const Json &jsonObj, Space *space)
+Planet::Planet(const Json &jsonObj, Space *space) :
+	TerrainBody(),
+	m_ringVertices(RING_VERTEX_ATTRIBS),
+	m_ringState(nullptr)
 {
 	TerrainBody::LoadFromJson(jsonObj, space);
 

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -28,12 +28,10 @@ Planet::Planet(SystemBody *sbody) :
 }
 
 Planet::Planet(const Json &jsonObj, Space *space) :
-	TerrainBody(),
+	TerrainBody(jsonObj, space),
 	m_ringVertices(RING_VERTEX_ATTRIBS),
 	m_ringState(nullptr)
 {
-	TerrainBody::LoadFromJson(jsonObj, space);
-
 	const SystemBody *sbody = GetSystemBody();
 	assert(sbody);
 	InitParams(sbody);

--- a/src/Planet.h
+++ b/src/Planet.h
@@ -30,7 +30,6 @@ public:
 	friend class ObjectViewerView;
 
 protected:
-
 private:
 	void InitParams(const SystemBody *);
 	void GenerateRings(Graphics::Renderer *renderer);

--- a/src/Planet.h
+++ b/src/Planet.h
@@ -18,8 +18,9 @@ namespace Graphics {
 class Planet : public TerrainBody {
 public:
 	OBJDEF(Planet, TerrainBody, PLANET);
+	Planet() = delete;
 	Planet(SystemBody *);
-	Planet();
+	Planet(const Json &jsonObj, Space *space);
 
 	virtual void SubRender(Graphics::Renderer *r, const matrix4x4d &viewTran, const vector3d &camPos) override;
 
@@ -29,7 +30,6 @@ public:
 	friend class ObjectViewerView;
 
 protected:
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 private:
 	void InitParams(const SystemBody *);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Player.h"
+
 #include "Frame.h"
 #include "Game.h"
 #include "GameConfig.h"
@@ -51,6 +52,13 @@ Player::Player(const ShipType::Id &shipId) :
 	registerEquipChangeListener(this);
 }
 
+Player::Player(const Json &jsonObj, Space *space) :
+	Ship(jsonObj, space)
+{
+	InitCockpit();
+	registerEquipChangeListener(this);
+}
+
 void Player::SetShipType(const ShipType::Id &shipId)
 {
 	Ship::SetShipType(shipId);
@@ -61,14 +69,6 @@ void Player::SetShipType(const ShipType::Id &shipId)
 void Player::SaveToJson(Json &jsonObj, Space *space)
 {
 	Ship::SaveToJson(jsonObj, space);
-}
-
-void Player::LoadFromJson(const Json &jsonObj, Space *space)
-{
-	Pi::player = this;
-	Ship::LoadFromJson(jsonObj, space);
-	InitCockpit();
-	registerEquipChangeListener(this);
 }
 
 void Player::InitCockpit()

--- a/src/Player.h
+++ b/src/Player.h
@@ -19,8 +19,10 @@ namespace Graphics {
 class Player : public Ship {
 public:
 	OBJDEF(Player, Ship, PLAYER);
+	Player() = delete;
+	Player(const Json &jsonObj, Space *space);
 	Player(const ShipType::Id &shipId);
-	Player(){}; //default constructor used before Load
+
 	virtual void SetDockedWith(SpaceStation *, int port) override;
 	virtual bool DoCrushDamage(float kgDamage) override final; // overloaded to add "crush" audio
 	virtual bool OnDamage(Object *attacker, float kgDamage, const CollisionContact &contactData) override;
@@ -56,7 +58,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 	virtual void OnEnterSystem() override;
 	virtual void OnEnterHyperspace() override;

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -108,7 +108,8 @@ void Projectile::FreeModel()
 	s_glowVerts.reset();
 }
 
-Projectile::Projectile(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel) : Body()
+Projectile::Projectile(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel) :
+	Body()
 {
 	if (!s_sideMat) BuildModel();
 	m_flags |= FLAG_DRAW_LAST;
@@ -356,7 +357,8 @@ void Projectile::Render(Graphics::Renderer *renderer, const Camera *camera, cons
 	}
 }
 
-void Projectile::Add(Body *parent, float lifespan, float dam, float length, float width, bool mining, const Color &color, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel) {
+void Projectile::Add(Body *parent, float lifespan, float dam, float length, float width, bool mining, const Color &color, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel)
+{
 	ProjectileData prData;
 	prData.lifespan = lifespan;
 	prData.damage = dam;

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -132,10 +132,10 @@ Projectile::Projectile(Body *parent, const ProjectileData &prData, const vector3
 	SetPhysRadius(GetRadius());
 }
 
-Projectile::Projectile(const Json &jsonObj, Space *space)
+Projectile::Projectile(const Json &jsonObj, Space *space) :
+	Body(jsonObj, space)
 {
 	if (!s_sideMat) BuildModel();
-	Body::LoadFromJson(jsonObj, space);
 
 	try {
 		Json projectileObj = jsonObj["projectile"];

--- a/src/Projectile.h
+++ b/src/Projectile.h
@@ -40,12 +40,11 @@ public:
 	OBJDEF(Projectile, Body, PROJECTILE);
 
 	static void Add(Body *parent, float lifespan, float dam, float length, float width, bool mining, const Color &color, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel);
-	static void Add(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel)
-	{
-		Add(parent, prData.lifespan, prData.damage, prData.length, prData.width, prData.mining, prData.color, pos, baseVel, dirVel);
-	}
+	static void Add(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel);
 
-	Projectile();
+	Projectile() = delete;
+	Projectile(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel);
+	Projectile(const Json &jsonObj, Space *space);
 	virtual ~Projectile();
 	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override final;
 	void TimeStepUpdate(const float timeStep) override final;
@@ -58,7 +57,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override final;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override final;
 
 private:
 	float GetDamage() const;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Ship.h"
+
 #include "CargoBody.h"
 #include "CityOnPlanet.h"
 #include "EnumStrings.h"
@@ -18,6 +19,7 @@
 #include "Shields.h"
 #include "ShipController.h"
 #include "StringF.h"
+#include "WorldView.h"
 #include "graphics/TextureBuilder.h"
 
 static const float TONS_HULL_PER_SHIELD = 10.f;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -568,7 +568,7 @@ void Ship::UpdateLuaStats()
 	int hyperclass = 0;
 	p.Get<int>("hyperclass_cap", hyperclass);
 	if (hyperclass) {
-		std::tie(m_stats.hyperspace_range_max, m_stats.hyperspace_range) = \
+		std::tie(m_stats.hyperspace_range_max, m_stats.hyperspace_range) =
 			LuaObject<Ship>::CallMethod<double, double>(this, "GetHyperspaceRange");
 	}
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -72,11 +72,9 @@ void Ship::SaveToJson(Json &jsonObj, Space *space)
 	jsonObj["ship"] = shipObj; // Add ship object to supplied object.
 }
 
-Ship::Ship(const Json &jsonObj, Space *space)
+Ship::Ship(const Json &jsonObj, Space *space) :
+	DynamicBody(jsonObj, space)
 {
-	AddFeature(Feature::PROPULSION); // add component propulsion
-
-	DynamicBody::LoadFromJson(jsonObj, space);
 	AddFeature(Feature::PROPULSION); // add component propulsion
 	AddFeature(Feature::FIXED_GUNS); // add component fixed guns
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -64,8 +64,9 @@ class Ship : public DynamicBody {
 
 public:
 	OBJDEF(Ship, DynamicBody, SHIP);
+	Ship() = delete;
+	Ship(const Json &jsonObj, Space *space);
 	Ship(const ShipType::Id &shipId);
-	Ship() {} //default constructor used before Load
 	virtual ~Ship();
 
 	virtual void SetFrame(Frame *f) override;
@@ -235,7 +236,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 	bool AITimeStep(float timeStep); // Called by controller. Returns true if complete
 

--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "ShipCockpit.h"
+
 #include "CameraController.h"
 #include "Easing.h"
 #include "Game.h"

--- a/src/ShipCockpit.h
+++ b/src/ShipCockpit.h
@@ -4,10 +4,7 @@
 #ifndef _SHIP_COCKPIT_H_
 #define _SHIP_COCKPIT_H_
 
-#include "CameraController.h"
 #include "ModelBody.h"
-#include "WorldView.h"
-#include "libs.h"
 #include "scenegraph/Model.h"
 
 static const float COCKPIT_LAG_MAX_ANGLE = 7.5f;
@@ -17,9 +14,12 @@ static const float COCKPIT_MAX_GFORCE = 10000.0f;
 static const float COCKPIT_ACCEL_OFFSET = 0.075f;
 
 class Player;
+class Camera;
+class InternalCameraController;
 
 class ShipCockpit : public ModelBody {
 public:
+
 	explicit ShipCockpit(const std::string &modelName);
 	virtual ~ShipCockpit();
 

--- a/src/ShipCockpit.h
+++ b/src/ShipCockpit.h
@@ -19,7 +19,6 @@ class InternalCameraController;
 
 class ShipCockpit : public ModelBody {
 public:
-
 	explicit ShipCockpit(const std::string &modelName);
 	virtual ~ShipCockpit();
 

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -34,9 +34,9 @@ SpaceStation::SpaceStation(const SystemBody *sbody) :
 }
 
 SpaceStation::SpaceStation(const Json &jsonObj, Space *space) :
+	ModelBody(jsonObj, space),
 	m_type(nullptr)
 {
-	ModelBody::LoadFromJson(jsonObj, space);
 	GetModel()->SetLabel(GetLabel());
 
 	try {

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -20,55 +20,21 @@
 #include "graphics/Graphics.h"
 #include "scenegraph/ModelSkin.h"
 
-void SpaceStation::Init()
+SpaceStation::SpaceStation(const SystemBody *sbody) :
+	ModelBody(),
+	m_type(nullptr)
 {
-	SpaceStationType::Init();
+	m_sbody = sbody;
+
+	m_oldAngDisplacement = 0.0;
+
+	m_doorAnimationStep = m_doorAnimationState = 0.0;
+
+	InitStation();
 }
 
-void SpaceStation::SaveToJson(Json &jsonObj, Space *space)
-{
-	ModelBody::SaveToJson(jsonObj, space);
-
-	Json spaceStationObj({}); // Create JSON object to contain space station data.
-
-	Json shipDockingArray = Json::array(); // Create JSON array to contain ship docking data.
-	for (Uint32 i = 0; i < m_shipDocking.size(); i++) {
-		Json shipDockingArrayEl({}); // Create JSON object to contain ship docking.
-		Uint32 bodyIndex = space->GetIndexForBody(m_shipDocking[i].ship);
-		if (bodyIndex != 0) {
-			shipDockingArrayEl["index_for_body"] = bodyIndex;
-			shipDockingArrayEl["stage"] = m_shipDocking[i].stage;
-			shipDockingArrayEl["stage_pos"] = m_shipDocking[i].stagePos; // stagePos is a double but was saved as a float in pre-JSON system for some reason (saved as double here).
-			shipDockingArrayEl["from_pos"] = m_shipDocking[i].fromPos;
-			shipDockingArrayEl["from_rot"] = m_shipDocking[i].fromRot;
-		}
-		shipDockingArray.push_back(shipDockingArrayEl); // Append ship docking object to array.
-	}
-	spaceStationObj["ship_docking"] = shipDockingArray; // Add ship docking array to space station object.
-
-	// store each of the port details and bay IDs
-	Json portArray = Json::array(); // Create JSON array to contain port data.
-	for (Uint32 i = 0; i < m_ports.size(); i++) {
-		Json portArrayEl({}); // Create JSON object to contain port.
-
-		if (m_ports[i].inUse)
-			portArrayEl["in_use"] = m_ports[i].inUse;
-
-		portArray.push_back(portArrayEl); // Append port object to array.
-	}
-	spaceStationObj["ports"] = portArray; // Add port array to space station object.
-
-	spaceStationObj["index_for_system_body"] = space->GetIndexForSystemBody(m_sbody);
-
-	spaceStationObj["door_animation_step"] = m_doorAnimationStep;
-	spaceStationObj["door_animation_state"] = m_doorAnimationState;
-
-	m_navLights->SaveToJson(spaceStationObj);
-
-	jsonObj["space_station"] = spaceStationObj; // Add space station object to supplied object.
-}
-
-void SpaceStation::LoadFromJson(const Json &jsonObj, Space *space)
+SpaceStation::SpaceStation(const Json &jsonObj, Space *space) :
+	m_type(nullptr)
 {
 	ModelBody::LoadFromJson(jsonObj, space);
 	GetModel()->SetLabel(GetLabel());
@@ -122,25 +88,60 @@ void SpaceStation::LoadFromJson(const Json &jsonObj, Space *space)
 	}
 }
 
+void SpaceStation::Init()
+{
+	SpaceStationType::Init();
+}
+
+void SpaceStation::SaveToJson(Json &jsonObj, Space *space)
+{
+	ModelBody::SaveToJson(jsonObj, space);
+
+	Json spaceStationObj({}); // Create JSON object to contain space station data.
+
+	Json shipDockingArray = Json::array(); // Create JSON array to contain ship docking data.
+	for (Uint32 i = 0; i < m_shipDocking.size(); i++) {
+		Json shipDockingArrayEl({}); // Create JSON object to contain ship docking.
+		Uint32 bodyIndex = space->GetIndexForBody(m_shipDocking[i].ship);
+		if (bodyIndex != 0) {
+			shipDockingArrayEl["index_for_body"] = bodyIndex;
+			shipDockingArrayEl["stage"] = m_shipDocking[i].stage;
+			shipDockingArrayEl["stage_pos"] = m_shipDocking[i].stagePos; // stagePos is a double but was saved as a float in pre-JSON system for some reason (saved as double here).
+			shipDockingArrayEl["from_pos"] = m_shipDocking[i].fromPos;
+			shipDockingArrayEl["from_rot"] = m_shipDocking[i].fromRot;
+		}
+		shipDockingArray.push_back(shipDockingArrayEl); // Append ship docking object to array.
+	}
+	spaceStationObj["ship_docking"] = shipDockingArray; // Add ship docking array to space station object.
+
+	// store each of the port details and bay IDs
+	Json portArray = Json::array(); // Create JSON array to contain port data.
+	for (Uint32 i = 0; i < m_ports.size(); i++) {
+		Json portArrayEl({}); // Create JSON object to contain port.
+
+		if (m_ports[i].inUse)
+			portArrayEl["in_use"] = m_ports[i].inUse;
+
+		portArray.push_back(portArrayEl); // Append port object to array.
+	}
+	spaceStationObj["ports"] = portArray; // Add port array to space station object.
+
+	spaceStationObj["index_for_system_body"] = space->GetIndexForSystemBody(m_sbody);
+
+	spaceStationObj["door_animation_step"] = m_doorAnimationStep;
+	spaceStationObj["door_animation_state"] = m_doorAnimationState;
+
+	m_navLights->SaveToJson(spaceStationObj);
+
+	jsonObj["space_station"] = spaceStationObj; // Add space station object to supplied object.
+}
+
 void SpaceStation::PostLoadFixup(Space *space)
 {
 	ModelBody::PostLoadFixup(space);
 	for (Uint32 i = 0; i < m_shipDocking.size(); i++) {
 		m_shipDocking[i].ship = static_cast<Ship *>(space->GetBodyByIndex(m_shipDocking[i].shipIndex));
 	}
-}
-
-SpaceStation::SpaceStation(const SystemBody *sbody) :
-	ModelBody(),
-	m_type(nullptr)
-{
-	m_sbody = sbody;
-
-	m_oldAngDisplacement = 0.0;
-
-	m_doorAnimationStep = m_doorAnimationState = 0.0;
-
-	InitStation();
 }
 
 void SpaceStation::InitStation()

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -30,10 +30,11 @@ public:
 	OBJDEF(SpaceStation, ModelBody, SPACESTATION);
 	static void Init();
 
+	SpaceStation() = delete;
 	// Should point to SystemBody in Pi::currentSystem
 	SpaceStation(const SystemBody *);
-	SpaceStation() :
-		m_type(nullptr) {}
+	SpaceStation(const Json &jsonObj, Space *space);
+
 	virtual ~SpaceStation();
 	virtual vector3d GetAngVelocity() const { return vector3d(0, m_type->AngVel(), 0); }
 	virtual bool OnCollision(Object *b, Uint32 flags, double relVel) override;
@@ -73,7 +74,6 @@ public:
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 private:
 	void DockingUpdate(const double timeStep);

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -11,18 +11,13 @@
 
 using namespace Graphics;
 
-Star::Star() :
-	TerrainBody()
-{
-}
-
 Star::Star(SystemBody *sbody) :
 	TerrainBody(sbody)
 {
 	InitStar();
 }
 
-void Star::LoadFromJson(const Json &jsonObj, Space *space)
+Star::Star(const Json &jsonObj, Space *space)
 {
 	TerrainBody::LoadFromJson(jsonObj, space); // to get sbody
 	InitStar();

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -2,12 +2,11 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Star.h"
+
 #include "Pi.h"
 #include "graphics/Graphics.h"
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
-#include "gui/Gui.h"
-#include <SDL_stdinc.h>
 
 using namespace Graphics;
 
@@ -17,9 +16,9 @@ Star::Star(SystemBody *sbody) :
 	InitStar();
 }
 
-Star::Star(const Json &jsonObj, Space *space)
+Star::Star(const Json &jsonObj, Space *space) :
+	TerrainBody(jsonObj, space)
 {
-	TerrainBody::LoadFromJson(jsonObj, space); // to get sbody
 	InitStar();
 }
 

--- a/src/Star.h
+++ b/src/Star.h
@@ -14,15 +14,15 @@ namespace Graphics {
 class Star : public TerrainBody {
 public:
 	OBJDEF(Star, TerrainBody, STAR);
+	Star() = delete;
 	Star(SystemBody *sbody);
-	Star();
+	Star(const Json &jsonObj, Space *space);
 	virtual ~Star(){};
 
 	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 
 protected:
 	void InitStar();
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 	Graphics::RenderState *m_haloState;
 };

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -7,7 +7,6 @@
 #include "GameSaveError.h"
 #include "GasGiant.h"
 #include "GeoSphere.h"
-#include "Pi.h"
 #include "Space.h"
 #include "WorldView.h"
 #include "graphics/Graphics.h"
@@ -19,13 +18,6 @@ TerrainBody::TerrainBody(SystemBody *sbody) :
 	m_mass(0)
 {
 	InitTerrainBody();
-}
-
-TerrainBody::TerrainBody() :
-	Body(),
-	m_sbody(0),
-	m_mass(0)
-{
 }
 
 TerrainBody::~TerrainBody()
@@ -58,9 +50,9 @@ void TerrainBody::SaveToJson(Json &jsonObj, Space *space)
 	jsonObj["terrain_body"] = terrainBodyObj; // Add terrain body object to supplied object.
 }
 
-void TerrainBody::LoadFromJson(const Json &jsonObj, Space *space)
+TerrainBody::TerrainBody(const Json &jsonObj, Space *space) :
+	Body(jsonObj, space)
 {
-	Body::LoadFromJson(jsonObj, space);
 
 	try {
 		Json terrainBodyObj = jsonObj["terrain_body"];

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -34,14 +34,14 @@ public:
 	static void OnChangeDetailLevel();
 
 protected:
+	TerrainBody() = delete;
 	TerrainBody(SystemBody *);
-	TerrainBody();
+	TerrainBody(const Json &jsonObj, Space *space);
 	virtual ~TerrainBody();
 
 	void InitTerrainBody();
 
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
-	virtual void LoadFromJson(const Json &jsonObj, Space *space) override;
 
 private:
 	const SystemBody *m_sbody;


### PR DESCRIPTION
Most controversial point could be removing "UpdateLuaStats" from Ship loading function
to Body::FromJson, but Body is used as a factory so is (IMO) a minor design issue.

Minor changes:
* Projectile and Beam did not use "age" when load
* there where too many includes in ShipCockpit

I left default ctor in Body (and so ModelBody and DynamicBody)

