### PR TITLE
Improve the clang-format hook and autoformat tool.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
           packages:
             - clang-format-6.0
             - libstdc++6 # >= 4.9 needed for clang-format-6.0
-      script: sh ./scripts/clang-format.sh
+      script: bash ./scripts/clang-format.sh
 
     - name: Build GCC
       # >= 4.9 needed for C++11 support

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -41,7 +41,7 @@ for file in $FILES; do
     CLANG_MESSAGE=`"$CLANG_FORMAT" -style=file "$file"`
 
     if [ "$?" = "0" ]; then
-        diff $DIFF_COLOR -u "$file" - <<< $CLANG_MESSAGE | \
+        diff $DIFF_COLOR -u "$file" - <<< "$CLANG_MESSAGE" | \
         sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
     fi
 done


### PR DESCRIPTION
This PR improves the clang-format hook (and the autoformat tool) to only consider staged files and to safely deal with files clang-format throws an error on, including misidentified files and deleted files.