### PR TITLE
Add OSX to travis test matrix, upgrade Linux tests to 16.04 Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,59 @@
-dist: trusty
+dist: xenial
 language: minimal
+compiler: gcc
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-    packages: &packages
-      - gcc-4.9
-      - g++-4.9
+    packages:
       - mesa-common-dev
       - libfreetype6-dev
       - libfreeimage-dev
       - libglew-dev
       - libsigc++-2.0-dev
       - libvorbis-dev
-      - libpng-dev
+      - libpng16-dev
+      - libassimp-dev
+      - libsdl2-dev
+      - libsdl2-image-dev
+  homebrew:
+    packages:
+      - gcc
+      - freetype
+      - freeimage
+      - glew
+      - libsigc++
+      - libvorbis
+      - libpng
+      - assimp
+      - sdl2
+      - sdl2_image
+      - libogg
 matrix:
   include:
     - name: Static Checks
+      os: osx # OSX is twice as fast to complete the checks
       env: STATIC_CHECKS=yes
       deploy: false
       before_install: skip
       addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+        homebrew:
           packages:
-            - clang-format-6.0
-            - libstdc++6 # >= 4.9 needed for clang-format-6.0
+            clang-format
       script: sh ./scripts/clang-format.sh
 
     - name: Build GCC
-      # >= 4.9 needed for C++11 support
-      compiler: gcc
-      env: CC=gcc-4.9 CXX=g++-4.9
-      before_install:
-        - git clone --depth 1 git://github.com/pioneerspacesim/pioneer-thirdparty.git pioneer-thirdparty
-        - cd pioneer-thirdparty/ && autoconf && ./configure "$CONFIGURE_OPTS" && make assimp && make sdl2 && make sdl2_image && cd ../
-      script:
-        - ./bootstrap cmake -DUSE_PIONEER_THIRDPARTY=1 && make -C build
+      os: linux
+
+    - name: Build Clang
+      os: linux
+      env: CC=clang CXX=clang++
+
+    - name: Build OSX
+      os: osx
+
+script:
+  - ./bootstrap cmake && make -C build
 
 before_deploy:
   - env SDL_VIDEODRIVER=dummy ./build/modelcompiler -b inplace

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - mesa-common-dev
-      - libfreetype6-dev
       - libfreeimage-dev
       - libglew-dev
       - libsigc++-2.0-dev
       - libvorbis-dev
-      - libpng16-dev
       - libassimp-dev
       - libsdl2-dev
       - libsdl2-image-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ if (WIN32)
 	set(CMAKE_INSTALL_BINDIR ${CMAKE_INSTALL_PREFIX})
 endif (WIN32)
 
+if (APPLE)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu")
+endif(APPLE)
+
 if (CMAKE_COMPILER_IS_GNUCXX)
     if (NOT IS_TRAVIS)
         add_compile_options(-fdiagnostics-color)

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -38,9 +38,12 @@ else
 fi
 
 for file in $FILES; do
-    "$CLANG_FORMAT" -style=file "$file" | \
-    diff $DIFF_COLOR -u "$file" - | \
-    sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+    CLANG_MESSAGE=`"$CLANG_FORMAT" -style=file "$file"`
+
+    if [ "$?" = "0" ]; then
+        diff $DIFF_COLOR -u "$file" - <<< $CLANG_MESSAGE | \
+        sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+    fi
 done
 
 # if no patch has been generated all is ok, clean up the file stub and exit


### PR DESCRIPTION
I've updated our travis testing environment to test against Mac OSX 10.13 High Sierra and upgraded the linux test environment to Xenial 16.04. This has the fortunate side-effect of getting rid of the `pioneer-thirdparty` dependency, as well as reducing compile times and simplifying our travis setup. 

This should have no effect on Appveyor builds, and is ready for merge immediately.