### PR TITLE
PiGui profiling changes.

### DIFF
--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -821,11 +821,11 @@ static int l_engine_world_space_to_screen_space(lua_State *l)
 {
 	vector3d pos = LuaPull<vector3d>(l, 1);
 
-	std::tuple<bool, vector3d, vector3d> res = lua_world_space_to_screen_space(pos); // defined in LuaPiGui.cpp
+	TScreenSpace res = lua_world_space_to_screen_space(pos); // defined in LuaPiGui.cpp
 
-	LuaPush<bool>(l, std::get<0>(res));
-	LuaPush<vector3d>(l, std::get<1>(res));
-	LuaPush<vector3d>(l, std::get<2>(res));
+	LuaPush<bool>(l, res._onScreen);
+	LuaPush<vector3d>(l, res._screenPosition);
+	LuaPush<vector3d>(l, res._direction);
 	return 3;
 }
 

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -22,6 +22,7 @@
 template <typename Type>
 static Type parse_imgui_flags(lua_State *l, int index, std::map<std::string, Type> table, std::string name)
 {
+	PROFILE_SCOPED()
 	LuaTable flags(l, index);
 	Type theflags = Type(0);
 	for (LuaTable::VecIter<std::string> iter = flags.Begin<std::string>(); iter != flags.End<std::string>(); ++iter) {
@@ -37,6 +38,7 @@ static Type parse_imgui_flags(lua_State *l, int index, std::map<std::string, Typ
 template <typename Type>
 static Type parse_imgui_enum(lua_State *l, int index, std::map<std::string, Type> table, std::string name)
 {
+	PROFILE_SCOPED()
 	std::string stylestr = LuaPull<std::string>(l, index);
 	if (table.find(stylestr) != table.end())
 		return table.at(stylestr);
@@ -47,6 +49,7 @@ static Type parse_imgui_enum(lua_State *l, int index, std::map<std::string, Type
 
 void *pi_lua_checklightuserdata(lua_State *l, int index)
 {
+	PROFILE_SCOPED()
 	if (lua_islightuserdata(l, index))
 		return lua_touserdata(l, index);
 	else
@@ -56,6 +59,7 @@ void *pi_lua_checklightuserdata(lua_State *l, int index)
 
 void pi_lua_generic_pull(lua_State *l, int index, ImVec2 &vector)
 {
+	PROFILE_SCOPED()
 	LuaTable vec(l, index);
 	vector.x = vec.Get<double>("x");
 	vector.y = vec.Get<double>("y");
@@ -63,6 +67,7 @@ void pi_lua_generic_pull(lua_State *l, int index, ImVec2 &vector)
 
 void pi_lua_generic_pull(lua_State *l, int index, vector3d &vector)
 {
+	PROFILE_SCOPED()
 	LuaTable vec(l, index);
 	vector.x = vec.Get<double>("x");
 	vector.y = vec.Get<double>("y");
@@ -71,6 +76,7 @@ void pi_lua_generic_pull(lua_State *l, int index, vector3d &vector)
 
 void pi_lua_generic_pull(lua_State *l, int index, ImColor &color)
 {
+	PROFILE_SCOPED()
 	LuaTable c(l, index);
 	float sc = 1.0f / 255.0f;
 	color.Value.x = c.Get<int>("r") * sc;
@@ -81,6 +87,7 @@ void pi_lua_generic_pull(lua_State *l, int index, ImColor &color)
 
 int pushOnScreenPositionDirection(lua_State *l, vector3d position)
 {
+	PROFILE_SCOPED()
 	const int width = Graphics::GetScreenWidth();
 	const int height = Graphics::GetScreenHeight();
 	vector3d direction = (position - vector3d(width / 2, height / 2, 0)).Normalized();
@@ -104,6 +111,7 @@ static std::map<std::string, ImGuiSelectableFlags_> imguiSelectableFlagsTable = 
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiSelectableFlags_ &theflags)
 {
+	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiSelectableFlagsTable, "ImGuiSelectableFlags");
 }
 
@@ -123,6 +131,7 @@ static std::map<std::string, ImGuiTreeNodeFlags_> imguiTreeNodeFlagsTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiTreeNodeFlags_ &theflags)
 {
+	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiTreeNodeFlagsTable, "ImGuiTreeNodeFlags");
 }
 
@@ -147,6 +156,7 @@ static std::map<std::string, ImGuiInputTextFlags_> imguiInputTextFlagsTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiInputTextFlags_ &theflags)
 {
+	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiInputTextFlagsTable, "ImGuiInputTextFlagsTable");
 }
 
@@ -159,6 +169,7 @@ static std::map<std::string, ImGuiCond_> imguiSetCondTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiCond_ &value)
 {
+	PROFILE_SCOPED()
 	value = parse_imgui_enum(l, index, imguiSetCondTable, "ImGuiCond");
 }
 
@@ -206,6 +217,7 @@ static std::map<std::string, ImGuiCol_> imguiColTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiCol_ &value)
 {
+	PROFILE_SCOPED()
 	value = parse_imgui_enum(l, index, imguiColTable, "ImGuiCol");
 }
 
@@ -229,6 +241,7 @@ static std::map<std::string, ImGuiStyleVar_> imguiStyleVarTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiStyleVar_ &value)
 {
+	PROFILE_SCOPED()
 	value = parse_imgui_enum(l, index, imguiStyleVarTable, "ImGuiStyleVar");
 }
 
@@ -253,11 +266,13 @@ static std::map<std::string, ImGuiWindowFlags_> imguiWindowFlagsTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiWindowFlags_ &theflags)
 {
+	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiWindowFlagsTable, "ImGuiWindowFlags");
 }
 
 static void pi_lua_pushVector(lua_State *l, double x, double y, double z)
 {
+	PROFILE_SCOPED()
 	const int n = lua_gettop(l);
 	lua_getfield(l, LUA_REGISTRYINDEX, "Imports");
 	lua_getfield(l, -1, "libs/Vector.lua"); // is there a better way to get at the lua Vector than this?
@@ -273,16 +288,19 @@ static void pi_lua_pushVector(lua_State *l, double x, double y, double z)
 
 static void pi_lua_generic_push(lua_State *l, const ImVec2 &v)
 {
+	PROFILE_SCOPED()
 	pi_lua_pushVector(l, v.x, v.y, 0);
 }
 
 void pi_lua_generic_push(lua_State *l, const vector3d &v)
 {
+	PROFILE_SCOPED()
 	pi_lua_pushVector(l, v.x, v.y, v.z);
 }
 
 void pi_lua_generic_push(lua_State *l, const vector3f &v)
 {
+	PROFILE_SCOPED()
 	pi_lua_pushVector(l, v.x, v.y, v.z);
 }
 
@@ -306,6 +324,7 @@ void pi_lua_generic_push(lua_State *l, const vector3f &v)
  */
 static int l_pigui_begin(lua_State *l)
 {
+	PROFILE_SCOPED()
 	const std::string name = LuaPull<std::string>(l, 1);
 	ImGuiWindowFlags theflags = LuaPull<ImGuiWindowFlags_>(l, 2);
 	ImGui::Begin(name.c_str(), nullptr, theflags);
@@ -314,6 +333,7 @@ static int l_pigui_begin(lua_State *l)
 
 static int l_pigui_columns(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int columns = LuaPull<int>(l, 1);
 	std::string id = LuaPull<std::string>(l, 2);
 	bool border = LuaPull<bool>(l, 3);
@@ -323,6 +343,7 @@ static int l_pigui_columns(lua_State *l)
 
 static int l_pigui_set_column_offset(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int column_index = LuaPull<int>(l, 1);
 	double offset_x = LuaPull<double>(l, 2);
 	ImGui::SetColumnOffset(column_index, offset_x);
@@ -331,6 +352,7 @@ static int l_pigui_set_column_offset(lua_State *l)
 
 static int l_pigui_progress_bar(lua_State *l)
 {
+	PROFILE_SCOPED()
 	float fraction = LuaPull<double>(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 	std::string overlay = LuaPull<std::string>(l, 3);
@@ -340,18 +362,21 @@ static int l_pigui_progress_bar(lua_State *l)
 
 static int l_pigui_next_column(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::NextColumn();
 	return 0;
 }
 
 static int l_pigui_end(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::End();
 	return 0;
 }
 
 static int l_pigui_pop_clip_rect(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	draw_list->PopClipRect();
 	return 0;
@@ -359,6 +384,7 @@ static int l_pigui_pop_clip_rect(lua_State *l)
 
 static int l_pigui_push_clip_rect(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 min = LuaPull<ImVec2>(l, 1);
 	ImVec2 max = LuaPull<ImVec2>(l, 2);
@@ -369,6 +395,7 @@ static int l_pigui_push_clip_rect(lua_State *l)
 
 static int l_pigui_push_clip_rect_full_screen(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	draw_list->PushClipRectFullScreen();
 	return 0;
@@ -376,6 +403,7 @@ static int l_pigui_push_clip_rect_full_screen(lua_State *l)
 
 static int l_pigui_set_next_window_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 pos = LuaPull<ImVec2>(l, 1);
 	int cond = LuaPull<ImGuiCond_>(l, 2);
 	ImGui::SetNextWindowPos(pos, cond);
@@ -384,6 +412,7 @@ static int l_pigui_set_next_window_pos(lua_State *l)
 
 static int l_pigui_set_next_window_pos_center(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int cond = LuaPull<ImGuiCond_>(l, 1);
 	ImGui::SetNextWindowPosCenter(cond);
 	return 0;
@@ -391,12 +420,14 @@ static int l_pigui_set_next_window_pos_center(lua_State *l)
 
 static int l_pigui_set_next_window_focus(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::SetNextWindowFocus();
 	return 0;
 }
 
 static int l_pigui_set_window_focus(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string name = LuaPull<std::string>(l, 1);
 	ImGui::SetWindowFocus(name.c_str());
 	return 0;
@@ -404,6 +435,7 @@ static int l_pigui_set_window_focus(lua_State *l)
 
 static int l_pigui_set_next_window_size(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 size = LuaPull<ImVec2>(l, 1);
 	int cond = LuaPull<ImGuiCond_>(l, 2);
 	ImGui::SetNextWindowSize(size, cond);
@@ -412,6 +444,7 @@ static int l_pigui_set_next_window_size(lua_State *l)
 
 static int l_pigui_set_next_window_size_constraints(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 min = LuaPull<ImVec2>(l, 1);
 	ImVec2 max = LuaPull<ImVec2>(l, 2);
 	ImGui::SetNextWindowSizeConstraints(min, max);
@@ -420,6 +453,7 @@ static int l_pigui_set_next_window_size_constraints(lua_State *l)
 
 static int l_pigui_push_style_color(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int style = LuaPull<ImGuiCol_>(l, 1);
 	ImColor color = LuaPull<ImColor>(l, 2);
 	ImGui::PushStyleColor(style, static_cast<ImVec4>(color));
@@ -428,6 +462,7 @@ static int l_pigui_push_style_color(lua_State *l)
 
 static int l_pigui_pop_style_color(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int num = LuaPull<int>(l, 1);
 	ImGui::PopStyleColor(num);
 	return 0;
@@ -435,6 +470,7 @@ static int l_pigui_pop_style_color(lua_State *l)
 
 static int l_pigui_push_style_var(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int style = LuaPull<ImGuiStyleVar_>(l, 1);
 
 	if (lua_isnumber(l, 2)) {
@@ -450,6 +486,7 @@ static int l_pigui_push_style_var(lua_State *l)
 
 static int l_pigui_pop_style_var(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int num = LuaPull<int>(l, 1);
 	ImGui::PopStyleVar(num);
 	return 0;
@@ -457,6 +494,7 @@ static int l_pigui_pop_style_var(lua_State *l)
 
 static int l_pigui_add_line(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 a = LuaPull<ImVec2>(l, 1);
 	ImVec2 b = LuaPull<ImVec2>(l, 2);
@@ -468,6 +506,7 @@ static int l_pigui_add_line(lua_State *l)
 
 static int l_pigui_add_circle(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 center = LuaPull<ImVec2>(l, 1);
 	int radius = LuaPull<int>(l, 2);
@@ -480,6 +519,7 @@ static int l_pigui_add_circle(lua_State *l)
 
 static int l_pigui_add_circle_filled(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 center = LuaPull<ImVec2>(l, 1);
 	int radius = LuaPull<int>(l, 2);
@@ -491,6 +531,7 @@ static int l_pigui_add_circle_filled(lua_State *l)
 
 static int l_pigui_path_arc_to(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 center = LuaPull<ImVec2>(l, 1);
 	double radius = LuaPull<double>(l, 2);
@@ -503,6 +544,7 @@ static int l_pigui_path_arc_to(lua_State *l)
 
 static int l_pigui_path_stroke(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImColor color = LuaPull<ImColor>(l, 1);
 	bool closed = LuaPull<bool>(l, 2);
@@ -513,6 +555,7 @@ static int l_pigui_path_stroke(lua_State *l)
 
 static int l_pigui_selectable(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string label = LuaPull<std::string>(l, 1);
 	bool selected = LuaPull<bool>(l, 2);
 	ImGuiSelectableFlags flags = LuaPull<ImGuiSelectableFlags_>(l, 3);
@@ -524,6 +567,7 @@ static int l_pigui_selectable(lua_State *l)
 
 static int l_pigui_text(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string text = LuaPull<std::string>(l, 1);
 	ImGui::Text("%s", text.c_str());
 	return 0;
@@ -531,6 +575,7 @@ static int l_pigui_text(lua_State *l)
 
 static int l_pigui_button(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string text = LuaPull<std::string>(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 	bool ret = ImGui::Button(text.c_str(), size);
@@ -540,6 +585,7 @@ static int l_pigui_button(lua_State *l)
 
 static int l_pigui_thrust_indicator(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string text = LuaPull<std::string>(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 	vector3d thr = LuaPull<vector3d>(l, 3);
@@ -558,6 +604,7 @@ static int l_pigui_thrust_indicator(lua_State *l)
 
 static int l_pigui_low_thrust_button(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string text = LuaPull<std::string>(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 	float level = LuaPull<int>(l, 3);
@@ -572,6 +619,7 @@ static int l_pigui_low_thrust_button(lua_State *l)
 
 static int l_pigui_text_wrapped(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string text = LuaPull<std::string>(l, 1);
 	ImGui::TextWrapped("%s", text.c_str());
 	return 0;
@@ -579,6 +627,7 @@ static int l_pigui_text_wrapped(lua_State *l)
 
 static int l_pigui_text_colored(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImColor col = LuaPull<ImColor>(l, 1);
 	std::string text = LuaPull<std::string>(l, 2);
 	ImGui::TextColored(col, "%s", text.c_str());
@@ -669,6 +718,7 @@ static int l_pigui_text_colored(lua_State *l)
 
 static int l_pigui_get_axisbinding(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string binding = "";
 	if (!Pi::input.IsJoystickEnabled()) {
 		lua_pushnil(l);
@@ -709,6 +759,7 @@ static int l_pigui_get_axisbinding(lua_State *l)
 
 static int l_pigui_get_keybinding(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGuiIO io = ImGui::GetIO();
 	int key = 0;
 	int mod = 0;
@@ -785,6 +836,7 @@ static int l_pigui_get_keybinding(lua_State *l)
 
 static int l_pigui_add_text(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 center = LuaPull<ImVec2>(l, 1);
 	ImColor color = LuaPull<ImColor>(l, 2);
@@ -795,6 +847,7 @@ static int l_pigui_add_text(lua_State *l)
 
 static int l_pigui_add_triangle(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 a = LuaPull<ImVec2>(l, 1);
 	ImVec2 b = LuaPull<ImVec2>(l, 2);
@@ -807,6 +860,7 @@ static int l_pigui_add_triangle(lua_State *l)
 
 static int l_pigui_add_rect(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 a = LuaPull<ImVec2>(l, 1);
 	ImVec2 b = LuaPull<ImVec2>(l, 2);
@@ -820,6 +874,7 @@ static int l_pigui_add_rect(lua_State *l)
 
 static int l_pigui_add_bezier_curve(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 a = LuaPull<ImVec2>(l, 1);
 	ImVec2 c0 = LuaPull<ImVec2>(l, 2);
@@ -834,6 +889,7 @@ static int l_pigui_add_bezier_curve(lua_State *l)
 
 static int l_pigui_add_image(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImTextureID id = pi_lua_checklightuserdata(l, 1);
 	ImVec2 a = LuaPull<ImVec2>(l, 2);
@@ -847,6 +903,7 @@ static int l_pigui_add_image(lua_State *l)
 
 static int l_pigui_add_image_quad(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImTextureID id = pi_lua_checklightuserdata(l, 1);
 	ImVec2 a = LuaPull<ImVec2>(l, 2);
@@ -864,6 +921,7 @@ static int l_pigui_add_image_quad(lua_State *l)
 
 static int l_pigui_add_rect_filled(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 a = LuaPull<ImVec2>(l, 1);
 	ImVec2 b = LuaPull<ImVec2>(l, 2);
@@ -876,6 +934,7 @@ static int l_pigui_add_rect_filled(lua_State *l)
 
 static int l_pigui_add_quad(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 a = LuaPull<ImVec2>(l, 1);
 	ImVec2 b = LuaPull<ImVec2>(l, 2);
@@ -889,6 +948,7 @@ static int l_pigui_add_quad(lua_State *l)
 
 static int l_pigui_add_triangle_filled(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImVec2 a = LuaPull<ImVec2>(l, 1);
 	ImVec2 b = LuaPull<ImVec2>(l, 2);
@@ -900,6 +960,7 @@ static int l_pigui_add_triangle_filled(lua_State *l)
 
 static int l_pigui_same_line(lua_State *l)
 {
+	PROFILE_SCOPED()
 	double pos_x = LuaPull<double>(l, 1);
 	double spacing_w = LuaPull<double>(l, 2);
 	ImGui::SameLine(pos_x, spacing_w);
@@ -908,30 +969,35 @@ static int l_pigui_same_line(lua_State *l)
 
 static int l_pigui_begin_group(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::BeginGroup();
 	return 0;
 }
 
 static int l_pigui_end_group(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::EndGroup();
 	return 0;
 }
 
 static int l_pigui_separator(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::Separator();
 	return 0;
 }
 
 static int l_pigui_spacing(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::Spacing();
 	return 0;
 }
 
 static int l_pigui_dummy(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 size = LuaPull<ImVec2>(l, 1);
 	ImGui::Dummy(size);
 	return 0;
@@ -939,6 +1005,7 @@ static int l_pigui_dummy(lua_State *l)
 
 static int l_pigui_begin_popup(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string id = LuaPull<std::string>(l, 1);
 	LuaPush<bool>(l, ImGui::BeginPopup(id.c_str()));
 	return 1;
@@ -946,6 +1013,7 @@ static int l_pigui_begin_popup(lua_State *l)
 
 static int l_pigui_open_popup(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string id = LuaPull<std::string>(l, 1);
 	ImGui::OpenPopup(id.c_str());
 	return 0;
@@ -953,12 +1021,14 @@ static int l_pigui_open_popup(lua_State *l)
 
 static int l_pigui_end_popup(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::EndPopup();
 	return 0;
 }
 
 static int l_pigui_begin_child(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string id = LuaPull<std::string>(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 	ImGui::BeginChild(id.c_str(), size);
@@ -967,24 +1037,28 @@ static int l_pigui_begin_child(lua_State *l)
 
 static int l_pigui_end_child(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::EndChild();
 	return 0;
 }
 
 static int l_pigui_is_item_hovered(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush(l, ImGui::IsItemHovered());
 	return 1;
 }
 
 static int l_pigui_is_item_active(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush(l, ImGui::IsItemActive());
 	return 1;
 }
 
 static int l_pigui_is_item_clicked(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int button = LuaPull<int>(l, 1);
 	LuaPush(l, ImGui::IsItemClicked(button));
 	return 1;
@@ -992,6 +1066,7 @@ static int l_pigui_is_item_clicked(lua_State *l)
 
 static int l_pigui_is_mouse_released(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int button = LuaPull<int>(l, 1);
 	LuaPush(l, ImGui::IsMouseReleased(button));
 	return 1;
@@ -999,6 +1074,7 @@ static int l_pigui_is_mouse_released(lua_State *l)
 
 static int l_pigui_is_mouse_down(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int button = LuaPull<int>(l, 1);
 	LuaPush(l, ImGui::IsMouseDown(button));
 	return 1;
@@ -1006,6 +1082,7 @@ static int l_pigui_is_mouse_down(lua_State *l)
 
 static int l_pigui_is_mouse_clicked(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int button = LuaPull<int>(l, 1);
 	LuaPush(l, ImGui::IsMouseClicked(button));
 	return 1;
@@ -1013,6 +1090,7 @@ static int l_pigui_is_mouse_clicked(lua_State *l)
 
 static int l_pigui_push_font(lua_State *l)
 {
+	PROFILE_SCOPED()
 	PiGui *pigui = LuaObject<PiGui>::CheckFromLua(1);
 	std::string fontname = LuaPull<std::string>(l, 2);
 	int size = LuaPull<int>(l, 3);
@@ -1028,12 +1106,14 @@ static int l_pigui_push_font(lua_State *l)
 
 static int l_pigui_pop_font(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::PopFont();
 	return 0;
 }
 
 static int l_pigui_calc_text_size(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string text = LuaPull<std::string>(l, 1);
 	ImVec2 size = ImGui::CalcTextSize(text.c_str());
 	pi_lua_generic_push(l, size);
@@ -1042,6 +1122,7 @@ static int l_pigui_calc_text_size(lua_State *l)
 
 static int l_pigui_get_mouse_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 pos = ImGui::GetMousePos();
 	pi_lua_generic_push(l, pos);
 	return 1;
@@ -1049,6 +1130,7 @@ static int l_pigui_get_mouse_pos(lua_State *l)
 
 static int l_pigui_get_mouse_wheel(lua_State *l)
 {
+	PROFILE_SCOPED()
 	float wheel = ImGui::GetIO().MouseWheel;
 	LuaPush(l, wheel);
 	return 1;
@@ -1056,6 +1138,7 @@ static int l_pigui_get_mouse_wheel(lua_State *l)
 
 static int l_pigui_set_tooltip(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string text = LuaPull<std::string>(l, 1);
 	ImGui::SetTooltip("%s", text.c_str());
 	return 0;
@@ -1063,6 +1146,7 @@ static int l_pigui_set_tooltip(lua_State *l)
 
 static int l_pigui_checkbox(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string label = LuaPull<std::string>(l, 1);
 	bool checked = LuaPull<bool>(l, 2);
 	bool changed = ImGui::Checkbox(label.c_str(), &checked);
@@ -1073,6 +1157,7 @@ static int l_pigui_checkbox(lua_State *l)
 
 static int l_pigui_push_item_width(lua_State *l)
 {
+	PROFILE_SCOPED()
 	double width = LuaPull<double>(l, 1);
 	ImGui::PushItemWidth(width);
 	return 0;
@@ -1080,12 +1165,14 @@ static int l_pigui_push_item_width(lua_State *l)
 
 static int l_pigui_pop_item_width(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::PopItemWidth();
 	return 0;
 }
 
 static int l_pigui_push_id(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string id = LuaPull<std::string>(l, 1);
 	ImGui::PushID(id.c_str());
 	return 0;
@@ -1093,12 +1180,14 @@ static int l_pigui_push_id(lua_State *l)
 
 static int l_pigui_pop_id(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::PopID();
 	return 0;
 }
 
 static int l_pigui_get_window_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 pos = ImGui::GetWindowPos();
 	pi_lua_generic_push(l, pos);
 	return 1;
@@ -1106,18 +1195,21 @@ static int l_pigui_get_window_pos(lua_State *l)
 
 static int l_pigui_get_window_size(lua_State *l)
 {
+	PROFILE_SCOPED()
 	pi_lua_generic_push(l, ImGui::GetWindowSize());
 	return 1;
 }
 
 static int l_pigui_get_content_region(lua_State *l)
 {
+	PROFILE_SCOPED()
 	pi_lua_generic_push(l, ImGui::GetContentRegionAvail());
 	return 1;
 }
 
 static int l_pigui_image(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImTextureID id = pi_lua_checklightuserdata(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 	ImVec2 uv0 = LuaPull<ImVec2>(l, 3);
@@ -1129,6 +1221,7 @@ static int l_pigui_image(lua_State *l)
 
 static int l_pigui_image_button(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImTextureID id = pi_lua_checklightuserdata(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 	ImVec2 uv0 = LuaPull<ImVec2>(l, 3);
@@ -1143,6 +1236,7 @@ static int l_pigui_image_button(lua_State *l)
 
 static int l_pigui_capture_mouse_from_app(lua_State *l)
 {
+	PROFILE_SCOPED()
 	bool b = LuaPull<bool>(l, 1);
 	ImGui::CaptureMouseFromApp(b);
 	return 0;
@@ -1150,6 +1244,7 @@ static int l_pigui_capture_mouse_from_app(lua_State *l)
 
 static int l_pigui_get_mouse_clicked_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int n = LuaPull<int>(l, 1);
 	ImVec2 pos = ImGui::GetIO().MouseClickedPos[n];
 	pi_lua_generic_push(l, pos);
@@ -1158,6 +1253,7 @@ static int l_pigui_get_mouse_clicked_pos(lua_State *l)
 
 std::tuple<bool, vector3d, vector3d> lua_world_space_to_screen_space(vector3d pos)
 {
+	PROFILE_SCOPED()
 	WorldView *wv = Pi::game->GetWorldView();
 	vector3d p = wv->WorldSpaceToScreenSpace(pos);
 	const int width = Graphics::GetScreenWidth();
@@ -1172,6 +1268,7 @@ std::tuple<bool, vector3d, vector3d> lua_world_space_to_screen_space(vector3d po
 
 std::tuple<bool, vector3d, vector3d> lua_world_space_to_screen_space(Body *body)
 {
+	PROFILE_SCOPED()
 	WorldView *wv = Pi::game->GetWorldView();
 	vector3d p = wv->WorldSpaceToScreenSpace(body);
 	const int width = Graphics::GetScreenWidth();
@@ -1186,6 +1283,7 @@ std::tuple<bool, vector3d, vector3d> lua_world_space_to_screen_space(Body *body)
 
 static int l_pigui_get_projected_bodies(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaTable result(l);
 	for (Body *body : Pi::game->GetSpace()->GetBodies()) {
 		if (body == Pi::game->GetPlayer()) continue;
@@ -1210,6 +1308,7 @@ static int l_pigui_get_projected_bodies(lua_State *l)
 
 static int l_pigui_get_targets_nearby(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int range_max = LuaPull<double>(l, 1);
 	LuaTable result(l);
 	Space::BodyNearList nearby;
@@ -1252,6 +1351,7 @@ static int l_pigui_get_targets_nearby(lua_State *l)
 }
 static int l_pigui_disable_mouse_facing(lua_State *l)
 {
+	PROFILE_SCOPED()
 	bool b = LuaPull<bool>(l, 1);
 	auto *p = Pi::player->GetPlayerController();
 	p->SetDisableMouseFacing(b);
@@ -1260,6 +1360,7 @@ static int l_pigui_disable_mouse_facing(lua_State *l)
 
 static int l_pigui_set_mouse_button_state(lua_State *l)
 {
+	PROFILE_SCOPED()
 	int button = LuaPull<int>(l, 1);
 	bool state = LuaPull<bool>(l, 2);
 	Pi::input.SetMouseButtonState(button, state);
@@ -1275,6 +1376,7 @@ static int l_pigui_set_mouse_button_state(lua_State *l)
 
 static int l_pigui_should_show_labels(lua_State *l)
 {
+	PROFILE_SCOPED()
 	bool show_labels = Pi::game->GetWorldView()->ShouldShowLabels();
 	LuaPush(l, show_labels);
 	return 1;
@@ -1282,6 +1384,7 @@ static int l_pigui_should_show_labels(lua_State *l)
 
 static int l_attr_handlers(lua_State *l)
 {
+	PROFILE_SCOPED()
 	PiGui *pigui = LuaObject<PiGui>::CheckFromLua(1);
 	pigui->GetHandlers().PushCopyToStack();
 	return 1;
@@ -1289,6 +1392,7 @@ static int l_attr_handlers(lua_State *l)
 
 static int l_attr_keys(lua_State *l)
 {
+	PROFILE_SCOPED()
 	PiGui *pigui = LuaObject<PiGui>::CheckFromLua(1);
 	pigui->GetKeys().PushCopyToStack();
 	return 1;
@@ -1296,6 +1400,7 @@ static int l_attr_keys(lua_State *l)
 
 static int l_attr_screen_width(lua_State *l)
 {
+	PROFILE_SCOPED()
 	//	PiGui *pigui = LuaObject<PiGui>::CheckFromLua(1);
 	LuaPush<int>(l, Graphics::GetScreenWidth());
 	return 1;
@@ -1303,30 +1408,35 @@ static int l_attr_screen_width(lua_State *l)
 
 static int l_attr_key_ctrl(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush<bool>(l, ImGui::GetIO().KeyCtrl);
 	return 1;
 }
 
 static int l_attr_key_none(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush<bool>(l, !ImGui::GetIO().KeyCtrl & !ImGui::GetIO().KeyShift & !ImGui::GetIO().KeyAlt);
 	return 1;
 }
 
 static int l_attr_key_shift(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush<bool>(l, ImGui::GetIO().KeyShift);
 	return 1;
 }
 
 static int l_attr_key_alt(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush<bool>(l, ImGui::GetIO().KeyAlt);
 	return 1;
 }
 
 static int l_attr_screen_height(lua_State *l)
 {
+	PROFILE_SCOPED()
 	//	PiGui *pigui = LuaObject<PiGui>::CheckFromLua(1);
 	LuaPush<int>(l, Graphics::GetScreenHeight());
 	return 1;
@@ -1336,6 +1446,7 @@ static int l_attr_screen_height(lua_State *l)
 // The Lua API currently uses the old API, and needs to be upgraded.
 static int l_pigui_combo(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string lbl = LuaPull<std::string>(l, 1);
 	int selected = LuaPull<int>(l, 2);
 
@@ -1355,7 +1466,7 @@ static int l_pigui_combo(lua_State *l)
 
 static int l_pigui_listbox(lua_State *l)
 {
-
+	PROFILE_SCOPED()
 	std::string lbl = LuaPull<std::string>(l, 1);
 	int selected = LuaPull<int>(l, 2);
 
@@ -1375,6 +1486,7 @@ static int l_pigui_listbox(lua_State *l)
 
 static int l_pigui_radial_menu(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 center = LuaPull<ImVec2>(l, 1);
 	std::string id = LuaPull<std::string>(l, 2);
 	int mouse_button = LuaPull<int>(l, 3);
@@ -1420,12 +1532,14 @@ static int l_pigui_radial_menu(lua_State *l)
 
 static int l_pigui_should_draw_ui(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush(l, Pi::DrawGUI);
 	return 1;
 }
 
 static int l_pigui_is_mouse_hovering_rect(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 r_min = LuaPull<ImVec2>(l, 1);
 	ImVec2 r_max = LuaPull<ImVec2>(l, 2);
 	bool clip = LuaPull<bool>(l, 3);
@@ -1435,6 +1549,7 @@ static int l_pigui_is_mouse_hovering_rect(lua_State *l)
 
 static int l_pigui_data_dir_path(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string path = FileSystem::GetDataDir();
 	LuaTable pathComponents(l, 1);
 	for (LuaTable::VecIter<std::string> iter = pathComponents.Begin<std::string>(); iter != pathComponents.End<std::string>(); ++iter) {
@@ -1446,24 +1561,28 @@ static int l_pigui_data_dir_path(lua_State *l)
 
 static int l_pigui_is_mouse_hovering_any_window(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush<bool>(l, ImGui::IsMouseHoveringAnyWindow());
 	return 1;
 }
 
 static int l_pigui_is_mouse_hovering_window(lua_State *l)
 {
+	PROFILE_SCOPED()
 	LuaPush<bool>(l, ImGui::IsMouseHoveringWindow());
 	return 1;
 }
 
 static int l_pigui_system_info_view_next_page(lua_State *l)
 {
+	PROFILE_SCOPED()
 	Pi::game->GetSystemInfoView()->NextPage();
 	return 0;
 }
 
 static int l_pigui_input_text(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string label = LuaPull<std::string>(l, 1);
 	std::string text = LuaPull<std::string>(l, 2);
 	int flags = LuaPull<ImGuiInputTextFlags_>(l, 3);
@@ -1480,6 +1599,7 @@ static int l_pigui_input_text(lua_State *l)
 
 static int l_pigui_play_sfx(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string name = LuaPull<std::string>(l, 1);
 	double left = LuaPull<float>(l, 2);
 	double right = LuaPull<float>(l, 3);
@@ -1489,6 +1609,7 @@ static int l_pigui_play_sfx(lua_State *l)
 
 static int l_pigui_circular_slider(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 center = LuaPull<ImVec2>(l, 1);
 	float v = LuaPull<double>(l, 2);
 	float v_min = LuaPull<double>(l, 3);
@@ -1503,6 +1624,7 @@ static int l_pigui_circular_slider(lua_State *l)
 
 static int l_pigui_slider_int(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string lbl = LuaPull<std::string>(l, 1);
 	int value = LuaPull<int>(l, 2);
 	int val_min = LuaPull<int>(l, 3);
@@ -1516,6 +1638,7 @@ static int l_pigui_slider_int(lua_State *l)
 
 static int l_pigui_vsliderint(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string lbl = LuaPull<std::string>(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 
@@ -1532,6 +1655,7 @@ static int l_pigui_vsliderint(lua_State *l)
 
 static int l_pigui_vsliderfloat(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string lbl = LuaPull<std::string>(l, 1);
 	ImVec2 size = LuaPull<ImVec2>(l, 2);
 
@@ -1548,6 +1672,7 @@ static int l_pigui_vsliderfloat(lua_State *l)
 
 static int l_pigui_is_key_released(lua_State *l)
 {
+	PROFILE_SCOPED()
 	SDL_Keycode key = LuaPull<int>(l, 1);
 	LuaPush<bool>(l, ImGui::IsKeyReleased(SDL_GetScancodeFromKey(key)));
 	return 1;
@@ -1555,6 +1680,7 @@ static int l_pigui_is_key_released(lua_State *l)
 
 static int l_pigui_get_cursor_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 v = ImGui::GetCursorPos();
 	LuaPush<ImVec2>(l, v);
 	return 1;
@@ -1562,6 +1688,7 @@ static int l_pigui_get_cursor_pos(lua_State *l)
 
 static int l_pigui_get_cursor_screen_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 v = ImGui::GetCursorScreenPos();
 	LuaPush<ImVec2>(l, v);
 	return 1;
@@ -1569,6 +1696,7 @@ static int l_pigui_get_cursor_screen_pos(lua_State *l)
 
 static int l_pigui_set_cursor_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 v = LuaPull<ImVec2>(l, 1);
 	ImGui::SetCursorPos(v);
 	return 0;
@@ -1576,6 +1704,7 @@ static int l_pigui_set_cursor_pos(lua_State *l)
 
 static int l_pigui_set_cursor_screen_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImVec2 v = LuaPull<ImVec2>(l, 1);
 	ImGui::SetCursorScreenPos(v);
 	return 0;
@@ -1583,6 +1712,7 @@ static int l_pigui_set_cursor_screen_pos(lua_State *l)
 
 static int l_pigui_drag_int_4(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string label = LuaPull<std::string>(l, 1);
 	int v[4];
 	v[0] = LuaPull<int>(l, 2);
@@ -1603,6 +1733,7 @@ static int l_pigui_drag_int_4(lua_State *l)
 
 static int l_pigui_add_convex_poly_filled(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	LuaTable pnts(l, 1);
 	ImColor col = LuaPull<ImColor>(l, 2);
@@ -1626,6 +1757,7 @@ static int l_pigui_add_convex_poly_filled(lua_State *l)
 
 static int l_pigui_load_texture_from_svg(lua_State *l)
 {
+	PROFILE_SCOPED()
 	PiGui *pigui = LuaObject<PiGui>::CheckFromLua(1);
 	std::string svg_filename = LuaPull<std::string>(l, 2);
 	int width = LuaPull<int>(l, 3);
@@ -1638,18 +1770,21 @@ static int l_pigui_load_texture_from_svg(lua_State *l)
 
 static int l_pigui_set_scroll_here(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::SetScrollHere();
 	return 0;
 }
 
 static int l_pigui_pop_text_wrap_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	ImGui::PopTextWrapPos();
 	return 0;
 }
 
 static int l_pigui_collapsing_header(lua_State *l)
 {
+	PROFILE_SCOPED()
 	std::string label = LuaPull<std::string>(l, 1);
 	ImGuiTreeNodeFlags flags = LuaPull<ImGuiTreeNodeFlags_>(l, 2);
 	LuaPush(l, ImGui::CollapsingHeader(label.c_str(), flags));
@@ -1658,6 +1793,7 @@ static int l_pigui_collapsing_header(lua_State *l)
 
 static int l_pigui_push_text_wrap_pos(lua_State *l)
 {
+	PROFILE_SCOPED()
 	float wrap_pos_x = LuaPull<float>(l, 1);
 	ImGui::PushTextWrapPos(wrap_pos_x);
 	return 0;

--- a/src/LuaPiGui.h
+++ b/src/LuaPiGui.h
@@ -7,9 +7,17 @@
 #include "LuaPushPull.h"
 #include <tuple>
 
+struct TScreenSpace
+{
+	TScreenSpace(const bool onScreen, const vector3d &screenPos, const vector3d &direction) : _onScreen(onScreen), _screenPosition(screenPos), _direction(direction) {}
+	bool _onScreen;
+	vector3d _screenPosition;
+	vector3d _direction;
+};
+
 void pi_lua_generic_push(lua_State *l, const vector3d &v);
 void pi_lua_generic_push(lua_State *l, const vector3f &v);
 void pi_lua_generic_pull(lua_State *l, int index, vector3d &vector);
 int pushOnScreenPositionDirection(lua_State *l, vector3d position);
-std::tuple<bool, vector3d, vector3d> lua_world_space_to_screen_space(vector3d pos);
+TScreenSpace lua_world_space_to_screen_space(const vector3d &pos);
 #endif

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1618,6 +1618,7 @@ void Pi::SetMouseGrab(bool on)
 
 void Pi::DrawPiGui(double delta, std::string handler)
 {
+	PROFILE_SCOPED()
 //  #define PROFILE_LUA_TIME 1
 #ifdef PROFILE_LUA_TIME
 	auto before = clock();

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1619,15 +1619,9 @@ void Pi::SetMouseGrab(bool on)
 void Pi::DrawPiGui(double delta, std::string handler)
 {
 	PROFILE_SCOPED()
-//  #define PROFILE_LUA_TIME 1
-#ifdef PROFILE_LUA_TIME
-	auto before = clock();
-#endif
+	
 	if (!IsConsoleActive())
 		Pi::pigui->Render(delta, handler);
-#ifdef PROFILE_LUA_TIME
-	auto after = clock();
-	Output("Lua PiGUI took %f\n", double(after - before) / CLOCKS_PER_SEC);
-#endif
+
 	PiGui::RenderImGui();
 }

--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -53,6 +53,7 @@ static std::vector<std::pair<std::string, int>> keycodes = {
 
 ImTextureID PiGui::RenderSVG(std::string svgFilename, int width, int height)
 {
+	PROFILE_SCOPED()
 	Output("nanosvg: %s %dx%d\n", svgFilename.c_str(), width, height);
 
 	// // re-use existing texture if already loaded
@@ -107,6 +108,7 @@ ImTextureID PiGui::RenderSVG(std::string svgFilename, int width, int height)
 
 ImFont *PiGui::GetFont(const std::string &name, int size)
 {
+	PROFILE_SCOPED()
 	auto iter = m_fonts.find(std::make_pair(name, size));
 	if (iter != m_fonts.end())
 		return iter->second;
@@ -118,6 +120,7 @@ ImFont *PiGui::GetFont(const std::string &name, int size)
 
 void PiGui::AddGlyph(ImFont *font, unsigned short glyph)
 {
+	PROFILE_SCOPED()
 	// range glyph..glyph
 	auto iter = m_im_fonts.find(font);
 	if (iter == m_im_fonts.end()) {
@@ -142,6 +145,7 @@ void PiGui::AddGlyph(ImFont *font, unsigned short glyph)
 
 ImFont *PiGui::AddFont(const std::string &name, int size)
 {
+	PROFILE_SCOPED()
 	auto iter = m_font_definitions.find(name);
 	if (iter == m_font_definitions.end()) {
 		Error("No font definition with name %s\n", name.c_str());
@@ -165,6 +169,7 @@ ImFont *PiGui::AddFont(const std::string &name, int size)
 
 void PiGui::RefreshFontsTexture()
 {
+	PROFILE_SCOPED()
 	// TODO: fix this, do the right thing, don't just re-create *everything* :)
 	ImGui::GetIO().Fonts->Build();
 	ImGui_ImplOpenGL3_CreateDeviceObjects();
@@ -172,11 +177,13 @@ void PiGui::RefreshFontsTexture()
 
 void PiDefaultStyle(ImGuiStyle &style)
 {
+	PROFILE_SCOPED()
 	style.WindowBorderSize = 0.0f; // Thickness of border around windows. Generally set to 0.0f or 1.0f. Other values not well tested.
 }
 
 void PiGui::Init(SDL_Window *window)
 {
+	PROFILE_SCOPED()
 	m_handlers.Unref();
 
 	lua_State *l = Lua::manager->GetLuaState();
@@ -224,6 +231,7 @@ void PiGui::Init(SDL_Window *window)
 
 int PiGui::RadialPopupSelectMenu(const ImVec2 &center, std::string popup_id, int mouse_button, std::vector<ImTextureID> tex_ids, std::vector<std::pair<ImVec2, ImVec2>> uvs, unsigned int size, std::vector<std::string> tooltips)
 {
+	PROFILE_SCOPED()
 	// return:
 	// 0 - n for item selected
 	// -1 for nothing chosen, but menu open
@@ -318,6 +326,7 @@ int PiGui::RadialPopupSelectMenu(const ImVec2 &center, std::string popup_id, int
 
 bool PiGui::CircularSlider(const ImVec2 &center, float *v, float v_min, float v_max)
 {
+	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	ImGuiWindow *window = ImGui::GetCurrentWindow();
 	const ImGuiID id = window->GetID("circularslider");
@@ -331,12 +340,14 @@ bool PiGui::CircularSlider(const ImVec2 &center, float *v, float v_min, float v_
 
 bool PiGui::ProcessEvent(SDL_Event *event)
 {
+	PROFILE_SCOPED()
 	ImGui_ImplSDL2_ProcessEvent(event);
 	return false;
 }
 
 void *PiGui::makeTexture(unsigned char *pixels, int width, int height)
 {
+	PROFILE_SCOPED()
 	// this is not very pretty code and uses the Graphics::TextureGL class directly
 	// Texture descriptor defines the size, type.
 	// Gone for LINEAR_CLAMP here and RGBA like the original code
@@ -359,11 +370,13 @@ void *PiGui::makeTexture(unsigned char *pixels, int width, int height)
 
 void PiGui::EndFrame()
 {
+	PROFILE_SCOPED()
 	ImGui::EndFrame();
 }
 
 void PiGui::NewFrame(SDL_Window *window)
 {
+	PROFILE_SCOPED()
 	// Ask ImGui to hide OS cursor if GUI is not being drawn:
 	// it will do this if MouseDrawCursor is true. After the frame
 	// is created, we set the actual cursor draw state.
@@ -395,6 +408,7 @@ void PiGui::NewFrame(SDL_Window *window)
 }
 void PiGui::Render(double delta, std::string handler)
 {
+	PROFILE_SCOPED()
 	ScopedTable t(m_handlers);
 	if (t.Get<bool>(handler)) {
 		t.Call<bool>(handler, delta);
@@ -425,6 +439,7 @@ void PiGui::Render(double delta, std::string handler)
 
 void PiGui::RenderImGui()
 {
+	PROFILE_SCOPED()
 	ImGui::Render();
 
 	switch (Pi::renderer->GetRendererType()) {
@@ -439,6 +454,7 @@ void PiGui::RenderImGui()
 
 void PiGui::ClearFonts()
 {
+	PROFILE_SCOPED()
 	ImGuiIO &io = ImGui::GetIO();
 	// TODO: should also release all glyph_ranges...
 	m_fonts.clear();
@@ -448,6 +464,7 @@ void PiGui::ClearFonts()
 
 void PiGui::BakeFont(PiFont &font)
 {
+	PROFILE_SCOPED()
 	ImGuiIO &io = ImGui::GetIO();
 	ImFont *imfont = nullptr;
 	for (PiFace &face : font.faces()) {
@@ -488,6 +505,7 @@ void PiGui::BakeFont(PiFont &font)
 
 void PiGui::BakeFonts()
 {
+	PROFILE_SCOPED()
 	//	Output("Baking fonts\n");
 
 	m_should_bake_fonts = false;
@@ -514,6 +532,7 @@ void PiGui::BakeFonts()
 
 static void drawThrust(ImDrawList *draw_list, const ImVec2 &center, const ImVec2 &up, float value, const ImColor &fg, const ImColor &bg)
 {
+	PROFILE_SCOPED()
 	float factor = 0.1; // how much to offset from center
 	const ImVec2 step(up.x * 0.5, up.y * 0.5);
 	const ImVec2 left(-step.y * (1.0 - factor), step.x * (1.0 - factor));
@@ -537,6 +556,7 @@ static void drawThrust(ImDrawList *draw_list, const ImVec2 &center, const ImVec2
 
 void PiGui::ThrustIndicator(const std::string &id_string, const ImVec2 &size_arg, const ImVec4 &thrust, const ImVec4 &velocity, const ImVec4 &bg_col, int frame_padding, ImColor vel_fg, ImColor vel_bg, ImColor thrust_fg, ImColor thrust_bg)
 {
+	PROFILE_SCOPED()
 	ImGuiWindow *window = ImGui::GetCurrentWindow();
 	if (window->SkipItems)
 		return;
@@ -599,6 +619,7 @@ void PiGui::ThrustIndicator(const std::string &id_string, const ImVec2 &size_arg
 
 bool PiGui::LowThrustButton(const char *id_string, const ImVec2 &size_arg, int thrust_level, const ImVec4 &bg_col, int frame_padding, ImColor gauge_fg, ImColor gauge_bg)
 {
+	PROFILE_SCOPED()
 	std::string label = std::to_string(thrust_level);
 	ImGuiWindow *window = ImGui::GetCurrentWindow();
 	if (window->SkipItems)
@@ -652,6 +673,7 @@ bool PiGui::LowThrustButton(const char *id_string, const ImVec2 &size_arg, int t
 
 void PiGui::Cleanup()
 {
+	PROFILE_SCOPED()
 	for (auto tex : m_svg_textures) {
 		delete tex;
 	}
@@ -691,6 +713,7 @@ PiGui::PiGui() :
 
 const bool PiFace::containsGlyph(unsigned short glyph) const
 {
+	PROFILE_SCOPED()
 	for (auto range : m_ranges) {
 		if (range.first <= glyph && glyph <= range.second)
 			return true;
@@ -700,6 +723,7 @@ const bool PiFace::containsGlyph(unsigned short glyph) const
 
 void PiFace::addGlyph(unsigned short glyph)
 {
+	PROFILE_SCOPED()
 	// Output("- PiFace %s adding glyph 0x%x\n", ttfname().c_str(), glyph);
 	for (auto &range : m_used_ranges) {
 		if (range.first <= glyph && glyph <= range.second) {
@@ -713,6 +737,7 @@ void PiFace::addGlyph(unsigned short glyph)
 
 void PiFace::sortUsedRanges() const
 {
+	PROFILE_SCOPED()
 	// sort by ascending lower end of range
 	std::sort(m_used_ranges.begin(), m_used_ranges.end(), [](const std::pair<unsigned short, unsigned short> &a, const std::pair<unsigned short, unsigned short> &b) { return a.first < b.first; });
 	// merge adjacent ranges

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -1071,9 +1071,9 @@ std::tuple<double, double, double> WorldView::CalculateHeadingPitchRoll(PlaneTyp
 		std::isnan(roll) ? 0.0 : roll);
 }
 
-static vector3d projectToScreenSpace(vector3d pos, RefCountedPtr<CameraContext> cameraContext, bool adjustZ = true)
+static vector3d projectToScreenSpace(const vector3d &pos, RefCountedPtr<CameraContext> cameraContext, const bool adjustZ = true)
 {
-	const Graphics::Frustum frustum = cameraContext->GetFrustum();
+	const Graphics::Frustum &frustum = cameraContext->GetFrustum();
 	const float h = Graphics::GetScreenHeight();
 	const float w = Graphics::GetScreenWidth();
 	vector3d proj;
@@ -1089,7 +1089,7 @@ static vector3d projectToScreenSpace(vector3d pos, RefCountedPtr<CameraContext> 
 }
 
 // needs to run inside m_cameraContext->Begin/EndFrame();
-vector3d WorldView::WorldSpaceToScreenSpace(Body *body) const
+vector3d WorldView::WorldSpaceToScreenSpace(const Body *body) const
 {
 	if (body->IsType(Object::PLAYER) && GetCamType() == CAM_INTERNAL)
 		return vector3d(0, 0, 0);
@@ -1099,7 +1099,7 @@ vector3d WorldView::WorldSpaceToScreenSpace(Body *body) const
 }
 
 // needs to run inside m_cameraContext->Begin/EndFrame();
-vector3d WorldView::WorldSpaceToScreenSpace(vector3d position) const
+vector3d WorldView::WorldSpaceToScreenSpace(const vector3d &position) const
 {
 	const Frame *cam_frame = m_cameraContext->GetCamFrame();
 	matrix3x3d cam_rot = cam_frame->GetInterpOrient();
@@ -1108,7 +1108,7 @@ vector3d WorldView::WorldSpaceToScreenSpace(vector3d position) const
 }
 
 // needs to run inside m_cameraContext->Begin/EndFrame();
-vector3d WorldView::ShipSpaceToScreenSpace(vector3d pos) const
+vector3d WorldView::ShipSpaceToScreenSpace(const vector3d &pos) const
 {
 	matrix3x3d orient = Pi::player->GetInterpOrient();
 	const Frame *cam_frame = m_cameraContext->GetCamFrame();
@@ -1118,13 +1118,13 @@ vector3d WorldView::ShipSpaceToScreenSpace(vector3d pos) const
 }
 
 // needs to run inside m_cameraContext->Begin/EndFrame();
-vector3d WorldView::CameraSpaceToScreenSpace(vector3d pos) const
+vector3d WorldView::CameraSpaceToScreenSpace(const vector3d &pos) const
 {
 	return projectToScreenSpace(pos, m_cameraContext);
 }
 
 // needs to run inside m_cameraContext->Begin/EndFrame();
-vector3d WorldView::GetTargetIndicatorScreenPosition(Body *body) const
+vector3d WorldView::GetTargetIndicatorScreenPosition(const Body *body) const
 {
 	if (body->IsType(Object::PLAYER) && GetCamType() == CAM_INTERNAL)
 		return vector3d(0, 0, 0);

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -75,12 +75,12 @@ public:
 
 	std::tuple<double, double, double> CalculateHeadingPitchRoll(enum PlaneType);
 
-	vector3d WorldSpaceToScreenSpace(Body *body) const;
-	vector3d WorldSpaceToScreenSpace(vector3d position) const;
-	vector3d ShipSpaceToScreenSpace(vector3d position) const;
-	vector3d GetTargetIndicatorScreenPosition(Body *body) const;
+	vector3d WorldSpaceToScreenSpace(const Body *body) const;
+	vector3d WorldSpaceToScreenSpace(const vector3d &position) const;
+	vector3d ShipSpaceToScreenSpace(const vector3d &position) const;
+	vector3d GetTargetIndicatorScreenPosition(const Body *body) const;
 	vector3d GetMouseDirection() const;
-	vector3d CameraSpaceToScreenSpace(vector3d pos) const;
+	vector3d CameraSpaceToScreenSpace(const vector3d &pos) const;
 
 	void BeginCameraFrame() { m_cameraContext->BeginFrame(); };
 	void EndCameraFrame() { m_cameraContext->EndFrame(); };
@@ -98,7 +98,6 @@ private:
 	void RefreshButtonStateAndVisibility();
 
 	void ChangeInternalCameraMode(InternalCameraController::Mode m);
-	void UpdateCameraName();
 
 	enum IndicatorSide {
 		INDICATOR_HIDDEN,
@@ -129,17 +128,13 @@ private:
 	void OnToggleLabels();
 
 	void DrawCombatTargetIndicator(const Indicator &target, const Indicator &lead, const Color &c);
-	void DrawImageIndicator(const Indicator &marker, Gui::TexturedQuad *quad, const Color &c);
 	void DrawEdgeMarker(const Indicator &marker, const Color &c);
 
-	void OnPlayerDockOrUndock();
 	void OnPlayerChangeTarget();
-	void OnPlayerChangeFlightControlState();
 	/// Handler for "requestTimeAccelerationInc" event
 	void OnRequestTimeAccelInc();
 	/// Handler for "requestTimeAccelerationDec" event
 	void OnRequestTimeAccelDec();
-	void SelectBody(Body *, bool reselectIsDeselect);
 	void MouseWheel(bool up);
 
 	Game *m_game;


### PR DESCRIPTION
In testing using `PIONEER_PROFILER` defined and our intrusive profiler (_V-sync off, multiple runs, ctrl+shift+p ingame once terrain generated_) this reduces the load of `l_pigui_get_projected_bodies` from ~8% down to ~1% of CPU time.

@ecraven has suggested there are other ways of doing this so this PR might only be useful as reference.
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

