### PR TITLE
Fix game load crash with unattached hyperspace clouds

### DIFF
--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -44,6 +44,7 @@ HyperspaceCloud::HyperspaceCloud(const Json &jsonObj, Space *space) :
 		m_due = hyperspaceCloudObj["due"];
 		m_isArrival = hyperspaceCloudObj["is_arrival"];
 
+		m_ship = 0;
 		if (hyperspaceCloudObj["ship"].is_object()) {
 			Json shipObj = hyperspaceCloudObj["ship"];
 			m_ship = static_cast<Ship *>(Body::FromJson(shipObj, space));

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -44,7 +44,7 @@ HyperspaceCloud::HyperspaceCloud(const Json &jsonObj, Space *space) :
 		m_due = hyperspaceCloudObj["due"];
 		m_isArrival = hyperspaceCloudObj["is_arrival"];
 
-		m_ship = 0;
+		m_ship = nullptr;
 		if (hyperspaceCloudObj["ship"].is_object()) {
 			Json shipObj = hyperspaceCloudObj["ship"];
 			m_ship = static_cast<Ship *>(Body::FromJson(shipObj, space));
@@ -112,7 +112,7 @@ void HyperspaceCloud::TimeStepUpdate(const float timeStep)
 
 		m_ship->EnterSystem();
 
-		m_ship = 0;
+		m_ship = nullptr;
 	}
 
 	// cloud expiration
@@ -126,7 +126,7 @@ void HyperspaceCloud::TimeStepUpdate(const float timeStep)
 Ship *HyperspaceCloud::EvictShip()
 {
 	Ship *s = m_ship;
-	m_ship = 0;
+	m_ship = nullptr;
 	return s;
 }
 


### PR DESCRIPTION
Fixes #4552, maybe.

When loading a saved game with an HS cloud that doesn't have an attached ship, the m_ship pointer is unintialized, causing an immediate crash in MSVC debug and undefined behaviour everywhere else. This patch sets the value of m_ship to 0 in this case.
