### PR TITLE
Improve the atmospheric simulation.

### DIFF
--- a/data/ships/ac33.json
+++ b/data/ships/ac33.json
@@ -32,10 +32,15 @@
    },
    "thruster_fuel_use" : -1.0,
    "up_thrust" : 60000000.0,
+
    "front_cross_section" : 120,
    "side_cross_section" : 280,
    "top_cross_section" : 1190,
-   "lift_coeff" : 1,
+
+   "front_drag_coeff": 0.06,
+   "side_drag_coeff": 0.21,
+   "top_drag_coeff": 0.95,
+
+   "lift_coeff" : 0.76,
    "aero_stability" : 1.8
 }
-

--- a/data/ships/ac33.json
+++ b/data/ships/ac33.json
@@ -31,5 +31,11 @@
       "mercenary" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 60000000.0
+   "up_thrust" : 60000000.0,
+   "front_cross_section" : 120,
+   "side_cross_section" : 280,
+   "top_cross_section" : 1190,
+   "lift_coeff" : 1,
+   "aero_stability" : 1.8
 }
+

--- a/data/ships/amphiesma.json
+++ b/data/ships/amphiesma.json
@@ -30,5 +30,10 @@
       "pirate" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 1000000.0
+   "up_thrust" : 1000000.0,
+   "front_cross_section" : 16.2,
+   "side_cross_section" : 39,
+   "top_cross_section" : 125,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.35
 }

--- a/data/ships/bluenose.json
+++ b/data/ships/bluenose.json
@@ -29,5 +29,10 @@
    },
    "roles" : {
       "merchant" : true
-   }
+   },
+   "front_cross_section" : 80,
+   "side_cross_section" : 337,
+   "top_cross_section" : 580,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.45
 }

--- a/data/ships/bowfin.json
+++ b/data/ships/bowfin.json
@@ -33,5 +33,10 @@
 	"down_thrust" : 1000000,
 	"left_thrust" : 1000000,
 	"right_thrust" : 1000000,
-	"angular_thrust" : 3000000
+	"angular_thrust" : 3000000,
+    "front_cross_section" : 33,
+    "side_cross_section" : 27,
+    "top_cross_section" : 50,
+    "lift_coeff" : 0,
+    "aero_stability" : 0.5
 }

--- a/data/ships/deneb.json
+++ b/data/ships/deneb.json
@@ -31,9 +31,15 @@
    },
    "thruster_fuel_use" : -1.0,
    "up_thrust" : 40000000.0,
+
    "front_cross_section" : 60,
    "side_cross_section" : 225,
    "top_cross_section" : 712,
-   "lift_coeff" : 0.7,
-   "aero_stability" : 1
+
+   "front_drag_coeff": 0.08,
+   "side_drag_coeff": 0.25,
+   "top_drag_coeff": 0.89,
+
+   "lift_coeff" : 0.81,
+   "aero_stability" : 2.1
 }

--- a/data/ships/deneb.json
+++ b/data/ships/deneb.json
@@ -30,5 +30,10 @@
       "mercenary" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 40000000.0
+   "up_thrust" : 40000000.0,
+   "front_cross_section" : 60,
+   "side_cross_section" : 225,
+   "top_cross_section" : 712,
+   "lift_coeff" : 0.7,
+   "aero_stability" : 1
 }

--- a/data/ships/dsminer.json
+++ b/data/ships/dsminer.json
@@ -30,5 +30,10 @@
       "merchant" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 28000000.0
+   "up_thrust" : 28000000.0,
+   "front_cross_section" : 515,
+   "side_cross_section" : 910,
+   "top_cross_section" : 1300,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.15
 }

--- a/data/ships/kanara.json
+++ b/data/ships/kanara.json
@@ -28,5 +28,10 @@
 	"down_thrust" : 220000,
 	"left_thrust" : 220000,
 	"right_thrust" : 220000,
-	"angular_thrust" : 2200000
+	"angular_thrust" : 2200000,
+    "front_cross_section" : 7.5,
+    "side_cross_section" : 38,
+    "top_cross_section" : 16,
+    "lift_coeff" : 0,
+    "aero_stability" : 0.45
 }

--- a/data/ships/kanara_civ.json
+++ b/data/ships/kanara_civ.json
@@ -32,5 +32,10 @@
 	"down_thrust" : 200000,
 	"left_thrust" : 200000,
 	"right_thrust" : 200000,
-	"angular_thrust" : 2000000
+	"angular_thrust" : 2000000,
+    "front_cross_section" : 7.5,
+    "side_cross_section" : 38,
+    "top_cross_section" : 16,
+    "lift_coeff" : 0,
+    "aero_stability" : 0.45
 }

--- a/data/ships/lodos.json
+++ b/data/ships/lodos.json
@@ -29,5 +29,10 @@
    "down_thrust" : 55000000.0,
    "left_thrust" : 30000000.0,
    "right_thrust" : 30000000.0,
-   "angular_thrust" : 225000000.0
+   "angular_thrust" : 225000000.0,
+   "front_cross_section" : 345,
+   "side_cross_section" : 690,
+   "top_cross_section" : 1430,
+   "lift_coeff" : 0.225,
+   "aero_stability" : 11
 }

--- a/data/ships/lunarshuttle.json
+++ b/data/ships/lunarshuttle.json
@@ -30,5 +30,10 @@
       "merchant" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 1100000.0
+   "up_thrust" : 1100000.0,
+   "front_cross_section" : 31,
+   "side_cross_section" : 70,
+   "top_cross_section" : 90,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.4
 }

--- a/data/ships/malabar.json
+++ b/data/ships/malabar.json
@@ -31,5 +31,10 @@
       "merchant" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 70000000.0
+   "up_thrust" : 70000000.0,
+   "front_cross_section" : 635,
+   "side_cross_section" : 1215,
+   "top_cross_section" : 980,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.65
 }

--- a/data/ships/molamola.json
+++ b/data/ships/molamola.json
@@ -30,5 +30,10 @@
       "pirate" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 1900000.0
+   "up_thrust" : 1900000.0,
+   "front_cross_section" : 46,
+   "side_cross_section" : 75,
+   "top_cross_section" : 77,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.225
 }

--- a/data/ships/molaramsayi.json
+++ b/data/ships/molaramsayi.json
@@ -27,5 +27,10 @@
    "down_thrust" : 7000000.0,
    "left_thrust" : 7000000.0,
    "right_thrust" : 7000000.0,
-   "angular_thrust" : 63000000.0
+   "angular_thrust" : 63000000.0,
+   "front_cross_section" : 165,
+   "side_cross_section" : 300,
+   "top_cross_section" : 307,
+   "lift_coeff" : 0,
+   "aero_stability" : 1.1
 }

--- a/data/ships/natrix.json
+++ b/data/ships/natrix.json
@@ -31,5 +31,10 @@
       "pirate" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 3800000.0
+   "up_thrust" : 3800000.0,
+   "front_cross_section" : 37,
+   "side_cross_section" : 95,
+   "top_cross_section" : 290,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.45
 }

--- a/data/ships/nerodia.json
+++ b/data/ships/nerodia.json
@@ -31,5 +31,10 @@
       "mercenary" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 50000000.0
+   "up_thrust" : 50000000.0,
+   "front_cross_section" : 210,
+   "side_cross_section" : 358,
+   "top_cross_section" : 810,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.55
 }

--- a/data/ships/pumpkinseed.json
+++ b/data/ships/pumpkinseed.json
@@ -31,5 +31,10 @@
       "pirate" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 500000.0
+   "up_thrust" : 500000.0,
+   "front_cross_section" : 38,
+   "side_cross_section" : 45,
+   "top_cross_section" : 72,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.35
 }

--- a/data/ships/pumpkinseed_police.json
+++ b/data/ships/pumpkinseed_police.json
@@ -27,5 +27,10 @@
       "sensor"  : 8
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 550000.0
+   "up_thrust" : 550000.0,
+   "front_cross_section" : 38,
+   "side_cross_section" : 45,
+   "top_cross_section" : 72,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.35
 }

--- a/data/ships/sinonatrix.json
+++ b/data/ships/sinonatrix.json
@@ -30,5 +30,10 @@
       "pirate" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 1500000.0
+   "up_thrust" : 1500000.0,
+   "front_cross_section" : 26,
+   "side_cross_section" : 40,
+   "top_cross_section" : 97,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.3
 }

--- a/data/ships/sinonatrix_police.json
+++ b/data/ships/sinonatrix_police.json
@@ -26,5 +26,10 @@
    "down_thrust" : 1200000.0,
    "left_thrust" : 1200000.0,
    "right_thrust" : 1200000.0,
-   "angular_thrust" : 27000000.0
+   "angular_thrust" : 27000000.0,
+   "front_cross_section" : 26,
+   "side_cross_section" : 40,
+   "top_cross_section" : 97,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.3
 }

--- a/data/ships/storeria.json
+++ b/data/ships/storeria.json
@@ -31,5 +31,10 @@
    "down_thrust" : 18000000.0,
    "left_thrust" : 8000000.0,
    "right_thrust" : 8000000.0,
-   "angular_thrust" : 183000000.0
+   "angular_thrust" : 183000000.0,
+   "front_cross_section" : 125,
+   "side_cross_section" : 240,
+   "top_cross_section" : 865,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.7
 }

--- a/data/ships/varada.json
+++ b/data/ships/varada.json
@@ -29,5 +29,10 @@
       "merchant" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 120000.0
+   "up_thrust" : 120000.0,
+   "front_cross_section" : 3.5,
+   "side_cross_section" : 23,
+   "top_cross_section" : 10,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.0125
 }

--- a/data/ships/vatakara.json
+++ b/data/ships/vatakara.json
@@ -31,5 +31,10 @@
       "merchant" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 70000000.0
+   "up_thrust" : 70000000.0,
+   "front_cross_section" : 635,
+   "side_cross_section" : 1215,
+   "top_cross_section" : 980,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.65
 }

--- a/data/ships/venturestar.json
+++ b/data/ships/venturestar.json
@@ -31,9 +31,15 @@
    },
    "thruster_fuel_use" : -1.0,
    "up_thrust" : 50000000.0,
+
    "front_cross_section" : 120,
    "side_cross_section" : 280,
    "top_cross_section" : 1190,
-   "lift_coeff" : 1,
+
+   "front_drag_coeff": 0.06,
+   "side_drag_coeff": 0.21,
+   "top_drag_coeff": 0.95,
+
+   "lift_coeff" : 0.76,
    "aero_stability" : 1.8
 }

--- a/data/ships/venturestar.json
+++ b/data/ships/venturestar.json
@@ -30,5 +30,10 @@
       "merchant" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 50000000.0
+   "up_thrust" : 50000000.0,
+   "front_cross_section" : 120,
+   "side_cross_section" : 280,
+   "top_cross_section" : 1190,
+   "lift_coeff" : 1,
+   "aero_stability" : 1.8
 }

--- a/data/ships/wave.json
+++ b/data/ships/wave.json
@@ -6,7 +6,7 @@
    "effective_exhaust_velocity" : 16900000.0,
    "forward_thrust" : 6800000.0,
    "fuel_tank_mass" : 22,
-   "hull_mass" : 13,
+   "hull_mass" : 47,
    "hyperdrive_class" : 2,
    "left_thrust" : 800000.0,
    "manufacturer" : "auronox",
@@ -37,10 +37,16 @@
       "pirate" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 800000.0,
+   "up_thrust" : 1200000.0,
+
    "front_cross_section" : 35,
    "side_cross_section" : 46,
    "top_cross_section" : 345,
-   "lift_coeff" : 0.275,
-   "aero_stability" : 1.2
+
+   "front_drag_coeff": 0.04,
+   "side_drag_coeff": 0.1,
+   "top_drag_coeff": 0.85,
+
+   "lift_coeff" : 1.0,
+   "aero_stability" : 2.6
 }

--- a/data/ships/wave.json
+++ b/data/ships/wave.json
@@ -37,5 +37,10 @@
       "pirate" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 800000.0
+   "up_thrust" : 800000.0,
+   "front_cross_section" : 35,
+   "side_cross_section" : 46,
+   "top_cross_section" : 345,
+   "lift_coeff" : 0.275,
+   "aero_stability" : 1.2
 }

--- a/data/ships/xylophis.json
+++ b/data/ships/xylophis.json
@@ -29,5 +29,10 @@
       "merchant" : true
    },
    "thruster_fuel_use" : -1.0,
-   "up_thrust" : 245000.0
+   "up_thrust" : 245000.0,
+   "front_cross_section" : 7,
+   "side_cross_section" : 17.5,
+   "top_cross_section" : 32,
+   "lift_coeff" : 0,
+   "aero_stability" : 0.25
 }

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -187,20 +187,24 @@ void DynamicBody::SetFrame(Frame *f)
 	m_externalForce = m_gravityForce = m_atmosForce = vector3d(0.0);
 }
 
-double DynamicBody::CalcAtmosphericForce(double dragCoeff) const
+double DynamicBody::CalcAtmosphericDrag(double velSqr, double area, double coeff) const
 {
 	Body *body = GetFrame()->GetBody();
 	if (!body || !GetFrame()->IsRotFrame() || !body->IsType(Object::PLANET))
 		return 0.0;
 	Planet *planet = static_cast<Planet *>(body);
-	double dist = GetPosition().Length();
-	double speed = m_vel.Length();
 	double pressure, density;
-	planet->GetAtmosphericState(dist, &pressure, &density);
-	const double radius = GetClipRadius(); // bogus, preserving behaviour
-	const double area = radius;
-	// ^^^ yes that is as stupid as it looks
-	return 0.5 * density * speed * speed * area * dragCoeff;
+	planet->GetAtmosphericState(GetPosition().Length(), &pressure, &density);
+
+	// Simplified calculation of atmospheric drag/lift force.
+	return 0.5 * density * velSqr * area * coeff;
+}
+
+vector3d DynamicBody::CalcAtmosphericForce() const
+{
+	vector3d dragDir = -m_vel.NormalizedSafe();
+
+	return CalcAtmosphericDrag(m_vel.LengthSqr(), GetClipRadius(), m_dragCoeff) * dragDir;
 }
 
 void DynamicBody::CalcExternalForce()
@@ -220,16 +224,16 @@ void DynamicBody::CalcExternalForce()
 
 	// atmospheric drag
 	if (body && GetFrame()->IsRotFrame() && body->IsType(Object::PLANET)) {
-		vector3d dragDir = -m_vel.NormalizedSafe();
-		vector3d fDrag = CalcAtmosphericForce(m_dragCoeff) * dragDir;
+		vector3d fAtmoForce = CalcAtmosphericForce();
 
 		// make this a bit less daft at high time accel
 		// only allow atmosForce to increase by .1g per frame
-		vector3d f1g = m_atmosForce + dragDir * GetMass();
-		if (fDrag.LengthSqr() > f1g.LengthSqr())
+		// TODO: clamp fAtmoForce instead.
+		vector3d f1g = m_atmosForce + fAtmoForce.NormalizedSafe() * GetMass();
+		if (fAtmoForce.LengthSqr() > f1g.LengthSqr())
 			m_atmosForce = f1g;
 		else
-			m_atmosForce = fDrag;
+			m_atmosForce = fAtmoForce;
 
 		m_externalForce += m_atmosForce;
 	} else

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -204,7 +204,9 @@ vector3d DynamicBody::CalcAtmosphericForce() const
 {
 	vector3d dragDir = -m_vel.NormalizedSafe();
 
-	return CalcAtmosphericDrag(m_vel.LengthSqr(), GetClipRadius(), m_dragCoeff) * dragDir;
+	// We assume the object is a perfect sphere in the size of the clip radius.
+	// Most things are /not/ using the default DynamicBody code, but this is still better than before.
+	return CalcAtmosphericDrag(m_vel.LengthSqr(), GetClipRadius() * GetClipRadius() * M_PI, m_dragCoeff) * dragDir;
 }
 
 void DynamicBody::CalcExternalForce()

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -36,7 +36,8 @@ public:
 	bool IsMoving() const { return m_isMoving; }
 	virtual double GetMass() const override { return m_mass; } // XXX don't override this
 	virtual void TimeStepUpdate(const float timeStep) override;
-	double CalcAtmosphericForce(double dragCoeff) const;
+	virtual vector3d CalcAtmosphericForce() const;
+	double CalcAtmosphericDrag(double velSqr, double area, double coeff) const;
 	void CalcExternalForce();
 
 	void SetMass(double);
@@ -94,6 +95,7 @@ protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
 
 	static const double DEFAULT_DRAG_COEFF;
+
 	double m_dragCoeff;
 
 	bool m_decelerating;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -389,7 +389,7 @@ vector3d Ship::CalcAtmosphericForce() const
 
 	// The drag forces applied to the craft, in local space.
 	// TODO: verify dimensional accuracy and that we're not generating more drag than physically possible.
-	// TODO: use a different drag constant for each side.
+	// TODO: use a different drag constant for each side (front, back, etc).
 	// This also handles (most of) the lift due to wing deflection.
 	vector3d fAtmosDrag = vector3d(
 		CalcAtmosphericDrag(m_lVSqr, m_sideCrossSec, m_sideDragCoeff),
@@ -408,8 +408,8 @@ vector3d Ship::CalcAtmosphericForce() const
 	if (abs(m_AoAMultiplier) < 0.61) {
 		// Pioneer simulates non-cambered wings, with equal air displacement on either side of AoA.
 
-		// Generated lift peaks at around 0.15 here, and falls off fully at 0.3.
-		// TODO: handle AoA better / more gracefully with an actual curve-based implementation.
+		// Generated lift peaks at around 20 degrees here, and falls off fully at 35-ish.
+		// TODO: handle AoA better / more gracefully with an actual angle- and curve-based implementation.
 		m_AoAMultiplier = cos((abs(m_AoAMultiplier) - 0.31) * 5.0) * sign(m_AoAMultiplier);
 
 		// TODO: verify dimensional accuracy and that we're not generating more lift than physically possible.
@@ -1037,6 +1037,7 @@ double Ship::ExtrapolateHullTemperature() const
 
 double Ship::GetHullTemperature() const
 {
+	// TODO: fix this to properly account for heating due to air friction instead of G-force.
 	return 0.0;
 	double dragGs = GetAtmosForce().Length() / (GetMass() * 9.81);
 	int atmo_shield_cap = 0;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -396,7 +396,10 @@ vector3d Ship::CalcAtmoPassiveControl()
 	
 	double m_drag = CalcAtmosphericForce(DEFAULT_DRAG_COEFF);
 
-	fDragControl = GetOrient().VectorZ().NormalizedSafe() * m_drag * -0.25 * ((m_topCrossSec + m_sideCrossSec) / (m_frontCrossSec * 4)) * m_aeroStabilityMultiplier;
+	fDragControl = GetOrient().VectorZ() * m_drag * -0.25 * ((m_topCrossSec + m_sideCrossSec) / (m_frontCrossSec * 4)) * m_aeroStabilityMultiplier;
+
+	if (fDragControl.Length() > (m_drag * 0.5)) //don't let any ship fly infinitely, just in case a very wrong ship value is inserted
+		fDragControl = GetOrient().VectorZ() * m_drag * -0.5;
 
 	return fDragControl;
 }
@@ -417,7 +420,7 @@ vector3d Ship::CalcAtmoTorque()
 	double m_drag = CalcAtmosphericForce(DEFAULT_DRAG_COEFF);
 
 	if (GetVelocity().Length() > 150) { //don't apply torque at minimal speeds
-		fAtmoTorque = m_drag * m_torqueDir * ((m_topCrossSec + m_sideCrossSec) / (m_frontCrossSec * 4)) * 0.05 * m_aeroStabilityMultiplier;
+		fAtmoTorque = m_drag * m_torqueDir * ((m_topCrossSec + m_sideCrossSec) / (m_frontCrossSec * 4)) * 0.1 * m_aeroStabilityMultiplier;
 	}
 	else {
 		fAtmoTorque = vector3d(0.0);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -401,7 +401,10 @@ vector3d Ship::CalcAtmoPassiveControl()
 	
 	double m_drag = CalcAtmosphericForce(DEFAULT_DRAG_COEFF);
 
-	fDragControl = GetOrient().VectorZ() * m_drag * -0.25 * ((m_topCrossSec + m_sideCrossSec) / (m_frontCrossSec * 4)) * m_aeroStabilityMultiplier;
+	vector3d m_AoAVector = GetOrient().VectorZ() - GetVelocity().NormalizedSafe();
+	double m_AoAMultiplier = m_AoAVector.Length();
+
+	fDragControl = GetOrient().VectorZ() * m_drag * -0.25 * ((m_topCrossSec + m_sideCrossSec) / (m_frontCrossSec * 4)) * m_aeroStabilityMultiplier * (2.1 - m_AoAMultiplier);
 
 	if (fDragControl.Length() > (m_drag * 0.5)) //don't let any ship fly infinitely, just in case a very wrong ship value is inserted
 		fDragControl = GetOrient().VectorZ() * m_drag * -0.5;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -383,6 +383,11 @@ vector3d Ship::CalcAtmoLift()
 	else {
 		fLift = vector3d(0.0); //stall!
 	}
+
+	if (fLift.Length() > m_fDrag * 0.9) { //just a failsafe mechanism
+		fLift = vector3d(0, m_fDrag * 0.9, 0);
+	}
+
 	return fLift;
 }
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -374,7 +374,7 @@ vector3d Ship::CalcAtmoLift()
 
 	double m_fDrag = CalcAtmosphericForce(DEFAULT_DRAG_COEFF); //returns 0 if not in atmosphere, so no need to check
 
-	vector3d m_AoAVector = GetOrient().VectorZ().NormalizedSafe() - GetVelocity().NormalizedSafe();
+	vector3d m_AoAVector = GetOrient().VectorZ() - GetVelocity().NormalizedSafe();
 	double m_AoAMultiplier = m_AoAVector.Length();
 
 	if (m_AoAMultiplier > 1.8) {

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -377,7 +377,7 @@ vector3d Ship::CalcAtmoLift()
 	vector3d m_AoAVector = GetOrient().VectorZ() - GetVelocity().NormalizedSafe();
 	double m_AoAMultiplier = m_AoAVector.Length();
 
-	if (m_AoAMultiplier > 1.8) {
+	if (m_AoAMultiplier > 1.885) {
 		fLift = vector3d(0, m_fDrag * m_AoAMultiplier * m_topCrossSec * m_shipLiftCoeff * DEFAULT_LIFT_TO_DRAG_RATIO, 0);
 	}
 	else {
@@ -404,7 +404,7 @@ vector3d Ship::CalcAtmoPassiveControl()
 	vector3d m_AoAVector = GetOrient().VectorZ() - GetVelocity().NormalizedSafe();
 	double m_AoAMultiplier = m_AoAVector.Length();
 
-	fDragControl = GetOrient().VectorZ() * m_drag * -0.25 * ((m_topCrossSec + m_sideCrossSec) / (m_frontCrossSec * 4)) * m_aeroStabilityMultiplier * (2.1 - m_AoAMultiplier);
+	fDragControl = GetOrient().VectorZ() * m_drag * -0.25 * ((m_topCrossSec + m_sideCrossSec) / (m_frontCrossSec * 4)) * m_aeroStabilityMultiplier * (2 - m_AoAMultiplier);
 
 	if (fDragControl.Length() > (m_drag * 0.5)) //don't let any ship fly infinitely, just in case a very wrong ship value is inserted
 		fDragControl = GetOrient().VectorZ() * m_drag * -0.5;

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -124,14 +124,9 @@ public:
 		HYPERSPACE, // in hyperspace
 	};
 
-	vector3d CalcAtmoLift();
-	vector3d fLift;
-
-	vector3d CalcAtmoPassiveControl();
-	vector3d fDragControl;
-
-	vector3d CalcAtmoTorque();
-	vector3d fAtmoTorque;
+	vector3d CalcAtmosphericForce() const override;
+	// vector3d CalcAtmoPassiveControl() const;
+	vector3d CalcAtmoTorque() const;
 
 	FlightState GetFlightState() const { return m_flightState; }
 	void SetFlightState(FlightState s);

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -124,6 +124,15 @@ public:
 		HYPERSPACE, // in hyperspace
 	};
 
+	vector3d CalcAtmoLift();
+	vector3d fLift;
+
+	vector3d CalcAtmoPassiveControl();
+	vector3d fDragControl;
+
+	vector3d CalcAtmoTorque();
+	vector3d fAtmoTorque;
+
 	FlightState GetFlightState() const { return m_flightState; }
 	void SetFlightState(FlightState s);
 	float GetWheelState() const { return m_wheelState; }
@@ -275,6 +284,8 @@ private:
 	void InitEquipSet();
 
 	bool m_invulnerable;
+
+	static const double DEFAULT_LIFT_TO_DRAG_RATIO;
 
 	static const float DEFAULT_SHIELD_COOLDOWN_TIME;
 	float m_shieldCooldown;

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -91,6 +91,14 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 	linAccelerationCap[THRUSTER_LEFT] = data.value("left_acceleration_cap", INFINITY);
 	linAccelerationCap[THRUSTER_RIGHT] = data.value("right_acceleration_cap", INFINITY);
 
+	//get atmospheric flight values
+	topCrossSection = data.value("top_cross_section", 1.0f);
+	sideCrossSection = data.value("side_cross_section", 1.0f);
+	frontCrossSection = data.value("front_cross_section", 1.0f);
+
+	shipLiftCoefficient = data.value("lift_coeff", 0.0f);
+	atmoStability = data.value("aero_stability", 0.0f);
+
 	// Parse global thrusters color
 	bool error = false;
 	int parse = 0;

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -53,7 +53,7 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 {
 	Json data = JsonUtils::LoadJsonDataFile(path);
 	if (data.is_null()) {
-		Output("couldn't read ship def '%s': %s\n", path.c_str());
+		Output("couldn't read ship def '%s'\n", path.c_str());
 		throw ShipTypeLoadError();
 	}
 
@@ -95,6 +95,10 @@ ShipType::ShipType(const Id &_id, const std::string &path)
 	topCrossSection = data.value("top_cross_section", 1.0f);
 	sideCrossSection = data.value("side_cross_section", 1.0f);
 	frontCrossSection = data.value("front_cross_section", 1.0f);
+
+	topDragCoeff = data.value("top_drag_coeff", 0.1f);
+	sideDragCoeff = data.value("side_drag_coeff", 0.1f);
+	frontDragCoeff = data.value("front_drag_coeff", 0.1f);
 
 	shipLiftCoefficient = data.value("lift_coeff", 0.0f);
 	atmoStability = data.value("aero_stability", 0.0f);

--- a/src/ShipType.h
+++ b/src/ShipType.h
@@ -50,6 +50,14 @@ struct ShipType {
 	float effectiveExhaustVelocity; // velocity at which the propellant escapes the engines
 	int fuelTankMass; //full fuel tank mass, on top of hullMass
 
+	//values for atmospheric flight
+	double topCrossSection;
+	double sideCrossSection;
+	double frontCrossSection;
+
+	double shipLiftCoefficient;
+	double atmoStability;
+
 	// storing money as a double is weird, but the value is a double on the Lua side anyway,
 	// so we don't lose anything by storing it as a double here too
 	double baseprice;

--- a/src/ShipType.h
+++ b/src/ShipType.h
@@ -54,6 +54,9 @@ struct ShipType {
 	double topCrossSection;
 	double sideCrossSection;
 	double frontCrossSection;
+	double topDragCoeff;
+	double sideDragCoeff;
+	double frontDragCoeff;
 
 	double shipLiftCoefficient;
 	double atmoStability;

--- a/src/vector3.h
+++ b/src/vector3.h
@@ -126,6 +126,10 @@ public:
 	T Dot(const vector3 &b) const { return x * b.x + y * b.y + z * b.z; }
 	T Length() const { return sqrt(x * x + y * y + z * z); }
 	T LengthSqr() const { return x * x + y * y + z * z; }
+	vector3 Lerp(const vector3 &b, const double percent) const
+	{
+		return *this + percent * (b - *this);
+	}
 	vector3 Normalized() const
 	{
 		const T l = 1.0f / sqrt(x * x + y * y + z * z);


### PR DESCRIPTION
Building on PR #4556, this PR refactors the various calculations to be more physically accurate with respect to the ship's topology.

Specifically, this PR replaces the previous, *extremely* broken method of calculating atmospheric drag with a new model that takes into account the difference between drag experienced by an object flying nose-first or belly-first. It also changes the equations used to calculate lift, et al to something simpler and more easy to both maintain and verify as physically accurate.

The end result is that you can actually _fly_ on Mars now, though you have to be going pretty fast and have a very aerodynamic ship. I've not tested this on Earth yet, which is why it's still in the Draft stage.

This PR is dependent upon WKFO's PR, and should be merged after his.

Note: I've not updated all of the ships with new values for drag. You'll be wanting to test-fly the Wave, AC33/VentureStar, or Deneb.