### PR TITLE
Fix game load crash typo

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -61,7 +61,7 @@ WorldView::WorldView(const Json &jsonObj, Game *game) :
 
 	InitObject();
 
-	shipView.LoadFromJson(jsonObj);
+	shipView.LoadFromJson(worldViewObj);
 }
 
 WorldView::InputBinding WorldView::InputBindings;


### PR DESCRIPTION
Fixes #4560.

Looks like a refactoring typo. Crashes on every game load, at least with asserts enabled. Otherwise possibly undefined behaviour.

I haven't tested any other behaviour but this prevents the crash at least, and the rest looks superficially ok.