### PR TITLE
Gracefully handle destroyed target ships in SAR missions

### DIFF
--- a/data/lang/module-searchrescue/en.json
+++ b/data/lang/module-searchrescue/en.json
@@ -694,5 +694,14 @@
   "WHERE_IS_THE_TARGET": {
     "description": "",
     "message": "Where do I find the target?"
+  },
+  "PLAYER_DESTROYED_TARGET": {
+    "description": "",
+    "message": "We have heard of your deeds, captain! Rest assured that we will report you to the local authorities and get you flagged for completely unacceptable behavior. A criminal lawsuit will follow."
+  },
+  "ACCIDENT_DESTROYED_TARGET": {
+    "description": "",
+    "message": "The sad news has reached us that {shiplabel} has been destroyed. We will pay half of the agreed price for you efforts."
   }
+
 }

--- a/data/lang/module-searchrescue/en.json
+++ b/data/lang/module-searchrescue/en.json
@@ -697,7 +697,7 @@
   },
   "PLAYER_DESTROYED_TARGET": {
     "description": "",
-    "message": "We have heard of your deeds, captain! Rest assured that we will report you to the local authorities and get you flagged for completely unacceptable behavior. A criminal lawsuit will follow."
+    "message": "We have heard of your deeds, captain! Rest assured that we will report you to the local authorities for destroying the very ship you were sent out to help. A criminal lawsuit will follow."
   },
   "ACCIDENT_DESTROYED_TARGET": {
     "description": "",

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -600,7 +600,7 @@ local createTargetShipParameters = function (flavour)
 		end
 	elseif flavour.deliver_crew > 0 then
 		for i,shipdef in pairs(shipdefs) do
-			if shipdef.maxCrew <= flavour.deliver_crew+1 then shipdefs[i] = nil end
+			if shipdef.maxCrew < flavour.deliver_crew+1 then shipdefs[i] = nil end
 		end
 	end
 	----> crew quarters for crew pickup missions
@@ -661,11 +661,13 @@ local createTargetShipParameters = function (flavour)
 		end
 		pickup_crew = flavour.pickup_crew
 		deliver_crew = shipdef.minCrew - crew_num
+	elseif flavour.deliver_crew > 0 then
+		crew_num = rand:Integer(flavour.deliver_crew+1,shipdef.maxCrew)
+		crew_num = crew_num - flavour.deliver_crew
 	elseif flavour.pickup_crew > 0 then
 		crew_num = pickup_crew
 	else
 		crew_num = rand:Integer(shipdef.minCrew,shipdef.maxCrew)
-		crew_num = crew_num - flavour.deliver_crew
 		pickup_crew = flavour.pickup_crew
 		deliver_crew = flavour.deliver_crew
 	end
@@ -1975,16 +1977,16 @@ local onCreateBB = function (station)
 	closestplanets = findClosestPlanets()
 
 	-- force ad creation for debugging
-	-- local num = 3
-	-- for _ = 1,num do
-	-- 	makeAdvert(station, 1, closestplanets)
-	-- 	makeAdvert(station, 2, closestplanets)
-	-- 	makeAdvert(station, 3, closestplanets)
-	-- 	makeAdvert(station, 4, closestplanets)
-	-- 	makeAdvert(station, 5, closestplanets)
-	-- 	makeAdvert(station, 6, closestplanets)
-	-- 	makeAdvert(station, 7, closestplanets)
-	-- end
+	local num = 3
+	for _ = 1,num do
+		-- makeAdvert(station, 1, closestplanets)
+		-- makeAdvert(station, 2, closestplanets)
+		makeAdvert(station, 3, closestplanets)
+		-- makeAdvert(station, 4, closestplanets)
+		-- makeAdvert(station, 5, closestplanets)
+		-- makeAdvert(station, 6, closestplanets)
+		-- makeAdvert(station, 7, closestplanets)
+	end
 
 	if triggerAdCreation() then makeAdvert(station, nil, closestplanets) end
 end
@@ -2018,8 +2020,8 @@ local onUpdateBB = function (station)
 	-- force ad creation for debugging
 	-- local num = 3
 	-- for _ = 1,num do
-	--	makeAdvert(station, 1, closestplanets)
-	--	makeAdvert(station, 2, closestplanets)
+	-- 	makeAdvert(station, 1, closestplanets)
+	-- 	makeAdvert(station, 2, closestplanets)
 	-- 	makeAdvert(station, 3, closestplanets)
 	-- 	makeAdvert(station, 4, closestplanets)
 	-- 	makeAdvert(station, 5, closestplanets)


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This should fix #4547. The SAR missions now handle destroyed target ships without leaving a "zombie" mission in the player's mission roster.

If the target ship is destroyed by accident (i.e. gravity pull, etc), the player is commended for trying to help the target ship and payed 1/2 the agreed upon amount.

If the target ship is destroyed by the player, the mission source is very upset, the player gets punished by removing 2x the reputation he would have otherwise gotten, and, obviously, there is not payout. 

In both cases the mission is closed and removed from the player's mission roster. The player has to return to the mission source for this to take effect.