### PR TITLE
Fix crash on main menu

### DIFF
--- a/data/pigui/mainmenu.lua
+++ b/data/pigui/mainmenu.lua
@@ -197,7 +197,7 @@ local function showMainMenu()
 	end)
 
 	ui.setNextWindowPos(winPos,'Always')
-	ui.setNextWindowSize(Vector(0,0), 'Always')
+	ui.setNextWindowSize(Vector2(0,0), 'Always')
 	ui.withStyleColors({["WindowBg"] = colors.lightBlackBackground}, function()
 		ui.window("MainMenuButtons", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"}, function()
 			mainTextButton(lui.CONTINUE_GAME, nil, canContinue, continueGame)


### PR DESCRIPTION
The refactoring in #4548 missed one instance of `Vector`; this causes a Lua panic as soon as the main menu is shown.

I hope I'm not racing against someone else's fix; as of this writing, I see no mentions of this in the issues.