### PR TITLE
Fix build with WITH_DEVKEYS=OFF

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1404,7 +1404,9 @@ void Pi::MainLoop()
 			PROFILE_SCOPED_RAW("paused")
 			BaseSphere::UpdateAllBaseSphereDerivatives();
 		}
+#if WITH_DEVKEYS
 		frame_stat++;
+#endif
 
 		// did the player die?
 		if (Pi::player->IsDead()) {


### PR DESCRIPTION
The default is WITH_DEVKEYS=ON so the build error was not detected by
the autobuilders.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>