### PR TITLE
Decouple terrain and related file

### DIFF
--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -5,16 +5,16 @@
 #define _BASESPHERE_H
 
 #include "Camera.h"
+#include "vector3.h"
+#include "galaxy/SystemBody.h"
 #include "graphics/Drawables.h"
 #include "terrain/Terrain.h"
-#include "vector3.h"
 
 namespace Graphics {
 	class Renderer;
 	class RenderState;
 	class Material;
 } // namespace Graphics
-class SystemBody;
 
 class BaseSphere {
 public:

--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -6,7 +6,7 @@
 
 #include "Camera.h"
 #include "vector3.h"
-#include "galaxy/SystemBody.h"
+#include "galaxy/AtmosphereParameters.h"
 #include "graphics/Drawables.h"
 #include "terrain/Terrain.h"
 
@@ -39,7 +39,7 @@ public:
 	virtual double GetMaxFeatureHeight() const = 0;
 
 	struct MaterialParameters {
-		SystemBody::AtmosphereParameters atmosphere;
+		AtmosphereParameters atmosphere;
 		std::vector<Camera::Shadow> shadows;
 		Sint32 patchDepth;
 		Sint32 maxPatchDepth;

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -14,8 +14,6 @@
 #include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
 #include "graphics/Texture.h"
-#include "graphics/TextureBuilder.h"
-#include "graphics/Types.h"
 #include "graphics/VertexArray.h"
 #include "graphics/opengl/GenGasGiantColourMaterial.h"
 #include "libs.h"

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -8,6 +8,7 @@
 #include "GameConfig.h"
 #include "Pi.h"
 #include "RefCounted.h"
+#include "galaxy/AtmosphereParameters.h"
 #include "graphics/Frustum.h"
 #include "graphics/Graphics.h"
 #include "graphics/Material.h"
@@ -752,7 +753,7 @@ void GasGiant::SetUpMaterials()
 	surfDesc.effect = Graphics::EFFECT_GASSPHERE_TERRAIN;
 
 	//planetoid with atmosphere
-	const SystemBody::AtmosphereParameters ap(GetSystemBody()->CalcAtmosphereParams());
+	const AtmosphereParameters ap(GetSystemBody()->CalcAtmosphereParams());
 	surfDesc.lighting = true;
 	assert(ap.atmosDensity > 0.0);
 	{

--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -7,7 +7,6 @@
 #include "BaseSphere.h"
 #include "GasGiantJobs.h"
 #include "JobQueue.h"
-#include "Random.h"
 #include "graphics/Material.h"
 #include "terrain/Terrain.h"
 #include "vector3.h"

--- a/src/GasGiantJobs.h
+++ b/src/GasGiantJobs.h
@@ -7,7 +7,6 @@
 #include <SDL_stdinc.h>
 
 #include "JobQueue.h"
-#include "Random.h"
 #include "graphics/Material.h"
 #include "graphics/opengl/GenGasGiantColourMaterial.h"
 #include "graphics/VertexBuffer.h"

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -14,7 +14,6 @@
 #include "graphics/Graphics.h"
 #include "graphics/Material.h"
 #include "graphics/Renderer.h"
-#include "graphics/VertexArray.h"
 #include "perlin.h"
 #include "vcacheopt/vcacheopt.h"
 #include <algorithm>

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -10,6 +10,7 @@
 #include "Pi.h"
 #include "RefCounted.h"
 #include "Sphere.h"
+#include "galaxy/SystemBody.h"
 #include "graphics/Frustum.h"
 #include "graphics/Graphics.h"
 #include "graphics/Material.h"

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -381,7 +381,7 @@ void GeoPatch::LODUpdate(const vector3d &campos, const Graphics::Frustum &frustu
 void GeoPatch::RequestSinglePatch()
 {
 	if (!m_heights) {
-		assert(!mHasJobRequest);
+		assert(!m_HasJobRequest);
 		m_HasJobRequest = true;
 		SSingleSplitRequest *ssrd = new SSingleSplitRequest(m_v0, m_v1, m_v2, m_v3, m_centroid.Normalized(), m_depth,
 			m_geosphere->GetSystemBody()->GetPath(), m_PatchID, m_ctx->GetEdgeLen() - 2, m_ctx->GetFrac(), m_geosphere->GetTerrain());
@@ -405,10 +405,10 @@ void GeoPatch::ReceiveHeightmaps(SQuadSplitResult *psr)
 		assert(m_HasJobRequest);
 		const int newDepth = m_depth + 1;
 		for (int i = 0; i < NUM_KIDS; i++) {
-			assert(!kids[i]);
+			assert(!m_kids[i]);
 			const SQuadSplitResult::SSplitResultData &data = psr->data(i);
-			assert(i == data.patchID.GetPatchIdx(nD));
-			assert(0 == data.patchID.GetPatchIdx(nD + 1));
+			assert(i == data.patchID.GetPatchIdx(newDepth));
+			assert(0 == data.patchID.GetPatchIdx(newDepth + 1));
 			m_kids[i].reset(new GeoPatch(m_ctx, m_geosphere,
 				data.v0, data.v1, data.v2, data.v3,
 				newDepth, data.patchID));
@@ -431,7 +431,7 @@ void GeoPatch::ReceiveHeightmaps(SQuadSplitResult *psr)
 void GeoPatch::ReceiveHeightmap(const SSingleSplitResult *psr)
 {
 	PROFILE_SCOPED()
-	assert(nullptr == parent);
+	assert(nullptr == m_parent);
 	assert(nullptr != psr);
 	assert(m_HasJobRequest);
 	{

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -25,47 +25,47 @@ static const double GEOPATCH_SUBDIVIDE_AT_CAMDIST = 5.0;
 GeoPatch::GeoPatch(const RefCountedPtr<GeoPatchContext> &ctx_, GeoSphere *gs,
 	const vector3d &v0_, const vector3d &v1_, const vector3d &v2_, const vector3d &v3_,
 	const int depth, const GeoPatchID &ID_) :
-	ctx(ctx_),
-	v0(v0_),
-	v1(v1_),
-	v2(v2_),
-	v3(v3_),
-	heights(nullptr),
-	normals(nullptr),
-	colors(nullptr),
-	parent(nullptr),
-	geosphere(gs),
+	m_ctx(ctx_),
+	m_v0(v0_),
+	m_v1(v1_),
+	m_v2(v2_),
+	m_v3(v3_),
+	m_heights(nullptr),
+	m_normals(nullptr),
+	m_colors(nullptr),
+	m_parent(nullptr),
+	m_geosphere(gs),
 	m_depth(depth),
-	mPatchID(ID_),
-	mHasJobRequest(false)
+	m_PatchID(ID_),
+	m_HasJobRequest(false)
 {
 
-	clipCentroid = (v0 + v1 + v2 + v3) * 0.25;
-	centroid = clipCentroid.Normalized();
-	clipRadius = 0.0;
-	clipRadius = std::max(clipRadius, (v0 - clipCentroid).Length());
-	clipRadius = std::max(clipRadius, (v1 - clipCentroid).Length());
-	clipRadius = std::max(clipRadius, (v2 - clipCentroid).Length());
-	clipRadius = std::max(clipRadius, (v3 - clipCentroid).Length());
+	m_clipCentroid = (m_v0 + m_v1 + m_v2 + m_v3) * 0.25;
+	m_centroid = m_clipCentroid.Normalized();
+	m_clipRadius = 0.0;
+	m_clipRadius = std::max(m_clipRadius, (m_v0 - m_clipCentroid).Length());
+	m_clipRadius = std::max(m_clipRadius, (m_v1 - m_clipCentroid).Length());
+	m_clipRadius = std::max(m_clipRadius, (m_v2 - m_clipCentroid).Length());
+	m_clipRadius = std::max(m_clipRadius, (m_v3 - m_clipCentroid).Length());
 	double distMult;
-	if (geosphere->GetSystemBody()->GetType() < SystemBody::TYPE_PLANET_ASTEROID) {
-		distMult = 10.0 / Clamp(depth, 1, 10);
+	if (m_geosphere->GetSystemBody()->GetType() < SystemBody::TYPE_PLANET_ASTEROID) {
+		distMult = 10.0 / Clamp(m_depth, 1, 10);
 	} else {
-		distMult = 5.0 / Clamp(depth, 1, 5);
+		distMult = 5.0 / Clamp(m_depth, 1, 5);
 	}
-	m_roughLength = GEOPATCH_SUBDIVIDE_AT_CAMDIST / pow(2.0, depth) * distMult;
+	m_roughLength = GEOPATCH_SUBDIVIDE_AT_CAMDIST / pow(2.0, m_depth) * distMult;
 	m_needUpdateVBOs = false;
 }
 
 GeoPatch::~GeoPatch()
 {
-	mHasJobRequest = false;
+	m_HasJobRequest = false;
 	for (int i = 0; i < NUM_KIDS; i++) {
-		kids[i].reset();
+		m_kids[i].reset();
 	}
-	heights.reset();
-	normals.reset();
-	colors.reset();
+	m_heights.reset();
+	m_normals.reset();
+	m_colors.reset();
 }
 
 void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
@@ -85,18 +85,18 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 		vbd.attrib[2].format = Graphics::ATTRIB_FORMAT_UBYTE4;
 		vbd.attrib[3].semantic = Graphics::ATTRIB_UV0;
 		vbd.attrib[3].format = Graphics::ATTRIB_FORMAT_FLOAT2;
-		vbd.numVertices = ctx->NUMVERTICES();
+		vbd.numVertices = m_ctx->NUMVERTICES();
 		vbd.usage = Graphics::BUFFER_USAGE_STATIC;
 		m_vertexBuffer.reset(renderer->CreateVertexBuffer(vbd));
 
 		GeoPatchContext::VBOVertex *VBOVtxPtr = m_vertexBuffer->Map<GeoPatchContext::VBOVertex>(Graphics::BUFFER_MAP_WRITE);
 		assert(m_vertexBuffer->GetDesc().stride == sizeof(GeoPatchContext::VBOVertex));
 
-		const Sint32 edgeLen = ctx->GetEdgeLen();
-		const double frac = ctx->GetFrac();
-		const double *pHts = heights.get();
-		const vector3f *pNorm = normals.get();
-		const Color3ub *pColr = colors.get();
+		const Sint32 edgeLen = m_ctx->GetEdgeLen();
+		const double frac = m_ctx->GetFrac();
+		const double *pHts = m_heights.get();
+		const vector3f *pNorm = m_normals.get();
+		const Color3ub *pColr = m_colors.get();
 
 		double minh = DBL_MAX;
 
@@ -108,8 +108,8 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 				minh = std::min(height, minh);
 				const double xFrac = double(x - 1) * frac;
 				const double yFrac = double(y - 1) * frac;
-				const vector3d p((GetSpherePoint(xFrac, yFrac) * (height + 1.0)) - clipCentroid);
-				clipRadius = std::max(clipRadius, p.Length());
+				const vector3d p((GetSpherePoint(xFrac, yFrac) * (height + 1.0)) - m_clipCentroid);
+				m_clipRadius = std::max(m_clipRadius, p.Length());
 
 				GeoPatchContext::VBOVertex *vtxPtr = &VBOVtxPtr[x + (y * edgeLen)];
 				vtxPtr->pos = vector3f(p);
@@ -144,7 +144,7 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 			const Sint32 x = innerLeft - 1;
 			const double xFrac = double(x - 1) * frac;
 			const double yFrac = double(y - 1) * frac;
-			const vector3d p((GetSpherePoint(xFrac, yFrac) * minhScale) - clipCentroid);
+			const vector3d p((GetSpherePoint(xFrac, yFrac) * minhScale) - m_clipCentroid);
 
 			GeoPatchContext::VBOVertex *vtxPtr = &VBOVtxPtr[outerLeft + (y * edgeLen)];
 			GeoPatchContext::VBOVertex *vtxInr = &VBOVtxPtr[innerLeft + (y * edgeLen)];
@@ -158,7 +158,7 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 			const Sint32 x = innerRight + 1;
 			const double xFrac = double(x - 1) * frac;
 			const double yFrac = double(y - 1) * frac;
-			const vector3d p((GetSpherePoint(xFrac, yFrac) * minhScale) - clipCentroid);
+			const vector3d p((GetSpherePoint(xFrac, yFrac) * minhScale) - m_clipCentroid);
 
 			GeoPatchContext::VBOVertex *vtxPtr = &VBOVtxPtr[outerRight + (y * edgeLen)];
 			GeoPatchContext::VBOVertex *vtxInr = &VBOVtxPtr[innerRight + (y * edgeLen)];
@@ -178,7 +178,7 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 			const Sint32 y = innerTop - 1;
 			const double xFrac = double(x - 1) * frac;
 			const double yFrac = double(y - 1) * frac;
-			const vector3d p((GetSpherePoint(xFrac, yFrac) * minhScale) - clipCentroid);
+			const vector3d p((GetSpherePoint(xFrac, yFrac) * minhScale) - m_clipCentroid);
 
 			GeoPatchContext::VBOVertex *vtxPtr = &VBOVtxPtr[x + (outerTop * edgeLen)];
 			GeoPatchContext::VBOVertex *vtxInr = &VBOVtxPtr[x + (innerTop * edgeLen)];
@@ -192,7 +192,7 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 			const Sint32 y = innerBottom + 1;
 			const double xFrac = double(x - 1) * frac;
 			const double yFrac = double(y - 1) * frac;
-			const vector3d p((GetSpherePoint(xFrac, yFrac) * minhScale) - clipCentroid);
+			const vector3d p((GetSpherePoint(xFrac, yFrac) * minhScale) - m_clipCentroid);
 
 			GeoPatchContext::VBOVertex *vtxPtr = &VBOVtxPtr[x + (outerBottom * edgeLen)];
 			GeoPatchContext::VBOVertex *vtxInr = &VBOVtxPtr[x + (innerBottom * edgeLen)];
@@ -233,8 +233,8 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 		m_vertexBuffer->Unmap();
 
 		// Don't need this anymore so throw it away
-		normals.reset();
-		colors.reset();
+		m_normals.reset();
+		m_colors.reset();
 
 #ifdef DEBUG_BOUNDING_SPHERES
 		RefCountedPtr<Graphics::Material> mat(Pi::renderer->CreateMaterial(Graphics::MaterialDescriptor()));
@@ -251,42 +251,42 @@ void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, cons
 	// must update the VBOs to calculate the clipRadius...
 	UpdateVBOs(renderer);
 	// ...before doing the furstum culling that relies on it.
-	if (!frustum.TestPoint(clipCentroid, clipRadius))
+	if (!frustum.TestPoint(m_clipCentroid, m_clipRadius))
 		return; // nothing below this patch is visible
 
 	// only want to horizon cull patches that can actually be over the horizon!
-	const vector3d camDir(campos - clipCentroid);
+	const vector3d camDir(campos - m_clipCentroid);
 	const vector3d camDirNorm(camDir.Normalized());
-	const vector3d cenDir(clipCentroid.Normalized());
+	const vector3d cenDir(m_clipCentroid.Normalized());
 	const double dotProd = camDirNorm.Dot(cenDir);
 
-	if (dotProd < 0.25 && (camDir.LengthSqr() > (clipRadius * clipRadius))) {
+	if (dotProd < 0.25 && (camDir.LengthSqr() > (m_clipRadius * m_clipRadius))) {
 		SSphere obj;
-		obj.m_centre = clipCentroid;
-		obj.m_radius = clipRadius;
+		obj.m_centre = m_clipCentroid;
+		obj.m_radius = m_clipRadius;
 
 		if (!s_sph.HorizonCulling(campos, obj)) {
 			return; // nothing below this patch is visible
 		}
 	}
 
-	if (kids[0]) {
+	if (m_kids[0]) {
 		for (int i = 0; i < NUM_KIDS; i++)
-			kids[i]->Render(renderer, campos, modelView, frustum);
-	} else if (heights) {
-		RefCountedPtr<Graphics::Material> mat = geosphere->GetSurfaceMaterial();
-		Graphics::RenderState *rs = geosphere->GetSurfRenderState();
+			m_kids[i]->Render(renderer, campos, modelView, frustum);
+	} else if (m_heights) {
+		RefCountedPtr<Graphics::Material> mat = m_geosphere->GetSurfaceMaterial();
+		Graphics::RenderState *rs = m_geosphere->GetSurfRenderState();
 
-		const vector3d relpos = clipCentroid - campos;
+		const vector3d relpos = m_clipCentroid - campos;
 		renderer->SetTransform(modelView * matrix4x4d::Translation(relpos));
 
-		Pi::statSceneTris += (ctx->GetNumTris());
+		Pi::statSceneTris += (m_ctx->GetNumTris());
 		++Pi::statNumPatches;
 
 		// per-patch detail texture scaling value
-		geosphere->GetMaterialParameters().patchDepth = m_depth;
+		m_geosphere->GetMaterialParameters().patchDepth = m_depth;
 
-		renderer->DrawBufferIndexed(m_vertexBuffer.get(), ctx->GetIndexBuffer(), rs, mat.Get());
+		renderer->DrawBufferIndexed(m_vertexBuffer.get(), m_ctx->GetIndexBuffer(), rs, mat.Get());
 #ifdef DEBUG_BOUNDING_SPHERES
 		if (m_boundsphere.get()) {
 			renderer->SetWireFrameMode(true);
@@ -301,38 +301,38 @@ void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, cons
 void GeoPatch::LODUpdate(const vector3d &campos, const Graphics::Frustum &frustum)
 {
 	// there should be no LOD update when we have active split requests
-	if (mHasJobRequest)
+	if (m_HasJobRequest)
 		return;
 
 	bool canSplit = true;
-	bool canMerge = bool(kids[0]);
+	bool canMerge = bool(m_kids[0]);
 
 	// always split at first level
 	double centroidDist = DBL_MAX;
-	if (parent) {
-		centroidDist = (campos - centroid).Length();
+	if (m_parent) {
+		centroidDist = (campos - m_centroid).Length();
 		const bool errorSplit = (centroidDist < m_roughLength);
-		if (!(canSplit && (m_depth < std::min(GEOPATCH_MAX_DEPTH, geosphere->GetMaxDepth())) && errorSplit)) {
+		if (!(canSplit && (m_depth < std::min(GEOPATCH_MAX_DEPTH, m_geosphere->GetMaxDepth())) && errorSplit)) {
 			canSplit = false;
 		}
 	}
 
 	if (canSplit) {
-		if (!kids[0]) {
+		if (!m_kids[0]) {
 			// Test if this patch is visible
-			if (!frustum.TestPoint(clipCentroid, clipRadius))
+			if (!frustum.TestPoint(m_clipCentroid, m_clipRadius))
 				return; // nothing below this patch is visible
 
 			// only want to horizon cull patches that can actually be over the horizon!
-			const vector3d camDir(campos - clipCentroid);
+			const vector3d camDir(campos - m_clipCentroid);
 			const vector3d camDirNorm(camDir.Normalized());
-			const vector3d cenDir(clipCentroid.Normalized());
+			const vector3d cenDir(m_clipCentroid.Normalized());
 			const double dotProd = camDirNorm.Dot(cenDir);
 
-			if (dotProd < 0.25 && (camDir.LengthSqr() > (clipRadius * clipRadius))) {
+			if (dotProd < 0.25 && (camDir.LengthSqr() > (m_clipRadius * m_clipRadius))) {
 				SSphere obj;
-				obj.m_centre = clipCentroid;
-				obj.m_radius = clipRadius;
+				obj.m_centre = m_clipCentroid;
+				obj.m_radius = m_clipRadius;
 
 				if (!s_sph.HorizonCulling(campos, obj)) {
 					return; // nothing below this patch is visible
@@ -340,27 +340,27 @@ void GeoPatch::LODUpdate(const vector3d &campos, const Graphics::Frustum &frustu
 			}
 
 			// we can see this patch so submit the jobs!
-			assert(!mHasJobRequest);
-			mHasJobRequest = true;
+			assert(!m_HasJobRequest);
+			m_HasJobRequest = true;
 
-			SQuadSplitRequest *ssrd = new SQuadSplitRequest(v0, v1, v2, v3, centroid.Normalized(), m_depth,
-				geosphere->GetSystemBody()->GetPath(), mPatchID, ctx->GetEdgeLen() - 2,
-				ctx->GetFrac(), geosphere->GetTerrain());
+			SQuadSplitRequest *ssrd = new SQuadSplitRequest(m_v0, m_v1, m_v2, m_v3, m_centroid.Normalized(), m_depth,
+				m_geosphere->GetSystemBody()->GetPath(), m_PatchID, m_ctx->GetEdgeLen() - 2,
+				m_ctx->GetFrac(), m_geosphere->GetTerrain());
 
 			// add to the GeoSphere to be processed at end of all LODUpdate requests
-			geosphere->AddQuadSplitRequest(centroidDist, ssrd, this);
+			m_geosphere->AddQuadSplitRequest(centroidDist, ssrd, this);
 		} else {
 			for (int i = 0; i < NUM_KIDS; i++) {
-				kids[i]->LODUpdate(campos, frustum);
+				m_kids[i]->LODUpdate(campos, frustum);
 			}
 		}
 	} else if (canMerge) {
 		for (int i = 0; i < NUM_KIDS; i++) {
-			canMerge &= kids[i]->canBeMerged();
+			canMerge &= m_kids[i]->canBeMerged();
 		}
 		if (canMerge) {
 			for (int i = 0; i < NUM_KIDS; i++) {
-				kids[i].reset();
+				m_kids[i].reset();
 			}
 		}
 	}
@@ -368,11 +368,11 @@ void GeoPatch::LODUpdate(const vector3d &campos, const Graphics::Frustum &frustu
 
 void GeoPatch::RequestSinglePatch()
 {
-	if (!heights) {
+	if (!m_heights) {
 		assert(!mHasJobRequest);
-		mHasJobRequest = true;
-		SSingleSplitRequest *ssrd = new SSingleSplitRequest(v0, v1, v2, v3, centroid.Normalized(), m_depth,
-			geosphere->GetSystemBody()->GetPath(), mPatchID, ctx->GetEdgeLen() - 2, ctx->GetFrac(), geosphere->GetTerrain());
+		m_HasJobRequest = true;
+		SSingleSplitRequest *ssrd = new SSingleSplitRequest(m_v0, m_v1, m_v2, m_v3, m_centroid.Normalized(), m_depth,
+			m_geosphere->GetSystemBody()->GetPath(), m_PatchID, m_ctx->GetEdgeLen() - 2, m_ctx->GetFrac(), m_geosphere->GetTerrain());
 		m_job = Pi::GetAsyncJobQueue()->Queue(new SinglePatchJob(ssrd));
 	}
 }
@@ -384,35 +384,35 @@ void GeoPatch::ReceiveHeightmaps(SQuadSplitResult *psr)
 	if (m_depth < psr->depth()) {
 		// this should work because each depth should have a common history
 		const Uint32 kidIdx = psr->data(0).patchID.GetPatchIdx(m_depth + 1);
-		if (kids[kidIdx]) {
-			kids[kidIdx]->ReceiveHeightmaps(psr);
+		if (m_kids[kidIdx]) {
+			m_kids[kidIdx]->ReceiveHeightmaps(psr);
 		} else {
 			psr->OnCancel();
 		}
 	} else {
-		assert(mHasJobRequest);
-		const int nD = m_depth + 1;
+		assert(m_HasJobRequest);
+		const int newDepth = m_depth + 1;
 		for (int i = 0; i < NUM_KIDS; i++) {
 			assert(!kids[i]);
 			const SQuadSplitResult::SSplitResultData &data = psr->data(i);
 			assert(i == data.patchID.GetPatchIdx(nD));
 			assert(0 == data.patchID.GetPatchIdx(nD + 1));
-			kids[i].reset(new GeoPatch(ctx, geosphere,
+			m_kids[i].reset(new GeoPatch(m_ctx, m_geosphere,
 				data.v0, data.v1, data.v2, data.v3,
-				nD, data.patchID));
+				newDepth, data.patchID));
 		}
-		kids[0]->parent = kids[1]->parent = kids[2]->parent = kids[3]->parent = this;
+		m_kids[0]->m_parent = m_kids[1]->m_parent = m_kids[2]->m_parent = m_kids[3]->m_parent = this;
 
 		for (int i = 0; i < NUM_KIDS; i++) {
 			const SQuadSplitResult::SSplitResultData &data = psr->data(i);
-			kids[i]->heights.reset(data.heights);
-			kids[i]->normals.reset(data.normals);
-			kids[i]->colors.reset(data.colors);
+			m_kids[i]->m_heights.reset(data.heights);
+			m_kids[i]->m_normals.reset(data.normals);
+			m_kids[i]->m_colors.reset(data.colors);
 		}
 		for (int i = 0; i < NUM_KIDS; i++) {
-			kids[i]->NeedToUpdateVBOs();
+			m_kids[i]->NeedToUpdateVBOs();
 		}
-		mHasJobRequest = false;
+		m_HasJobRequest = false;
 	}
 }
 
@@ -421,14 +421,14 @@ void GeoPatch::ReceiveHeightmap(const SSingleSplitResult *psr)
 	PROFILE_SCOPED()
 	assert(nullptr == parent);
 	assert(nullptr != psr);
-	assert(mHasJobRequest);
+	assert(m_HasJobRequest);
 	{
 		const SSingleSplitResult::SSplitResultData &data = psr->data();
-		heights.reset(data.heights);
-		normals.reset(data.normals);
-		colors.reset(data.colors);
+		m_heights.reset(data.heights);
+		m_normals.reset(data.normals);
+		m_colors.reset(data.colors);
 	}
-	mHasJobRequest = false;
+	m_HasJobRequest = false;
 }
 
 void GeoPatch::ReceiveJobHandle(Job::Handle job)

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -20,6 +20,10 @@
 #include <algorithm>
 #include <deque>
 
+#ifdef DEBUG_BOUNDING_SPHERES
+#include "graphics/RenderState.h"
+#endif
+
 // tri edge lengths
 static const double GEOPATCH_SUBDIVIDE_AT_CAMDIST = 5.0;
 
@@ -239,7 +243,14 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 
 #ifdef DEBUG_BOUNDING_SPHERES
 		RefCountedPtr<Graphics::Material> mat(Pi::renderer->CreateMaterial(Graphics::MaterialDescriptor()));
-		m_boundsphere.reset(new Graphics::Drawables::Sphere3D(Pi::renderer, mat, Pi::renderer->CreateRenderState(Graphics::RenderStateDesc()), 0, clipRadius));
+		switch (m_depth) {
+			case 0: mat->diffuse = Color::WHITE; break;
+			case 1: mat->diffuse = Color::RED; break;
+			case 2: mat->diffuse = Color::GREEN; break;
+			case 3: mat->diffuse = Color::BLUE; break;
+			default: mat->diffuse = Color::BLACK; break;
+		}
+		m_boundsphere.reset(new Graphics::Drawables::Sphere3D(Pi::renderer, mat, Pi::renderer->CreateRenderState(Graphics::RenderStateDesc()), 2, m_clipRadius));
 #endif
 	}
 }

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -8,9 +8,8 @@
 
 #include "GeoPatchID.h"
 #include "JobQueue.h"
-#include "Random.h"
-#include "graphics/VertexBuffer.h"
 #include "vector3.h"
+#include "graphics/VertexBuffer.h"
 
 #include <deque>
 

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -13,7 +13,14 @@
 
 #include <deque>
 
-// #define DEBUG_BOUNDING_SPHERES
+//#define DEBUG_BOUNDING_SPHERES
+
+#ifdef DEBUG_BOUNDING_SPHERES
+#include "graphics/Drawables.h"
+namespace Graphics {
+	class RenderState;
+}
+#endif
 
 namespace Graphics {
 	class Renderer;

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -19,7 +19,7 @@ namespace Graphics {
 	class Renderer;
 	class Frustum;
 }
-class SystemBody;
+
 class GeoPatchContext;
 class GeoSphere;
 class BasePatchJob;

--- a/src/GeoPatchContext.cpp
+++ b/src/GeoPatchContext.cpp
@@ -28,27 +28,16 @@ void GeoPatchContext::GenerateIndices()
 	std::vector<Uint32> pl_short;
 
 	int tri_count = 0;
-	{
-		// calculate how many tri's there are
-		tri_count = (VBO_COUNT_MID_IDX() / 3);
-		for (int i = 0; i < 4; ++i) {
-			tri_count += (VBO_COUNT_HI_EDGE() / 3);
-		}
-
-		// pre-allocate enough space
-		pl_short.reserve(tri_count);
-
-		// add all of the middle indices
-		for (int i = 0; i < VBO_COUNT_MID_IDX(); ++i) {
-			pl_short.push_back(0);
-		}
-		// add the HI detail indices
-		for (int i = 0; i < 4; i++) {
-			for (int j = 0; j < VBO_COUNT_HI_EDGE(); ++j) {
-				pl_short.push_back(0);
-			}
-		}
+	// calculate how many tri's there are
+	tri_count = (VBO_COUNT_MID_IDX() / 3);
+	for (int i = 0; i < 4; ++i) {
+		tri_count += (VBO_COUNT_HI_EDGE() / 3);
 	}
+
+	// pre-allocate and fill enough space
+	pl_short.assign(tri_count + VBO_COUNT_MID_IDX() + VBO_COUNT_HI_EDGE() * 4, 0);
+
+	Output("GenerateIndices: triangles count = %i, mid indexes = %i, hi edges = %i\n", tri_count, VBO_COUNT_MID_IDX(), VBO_COUNT_HI_EDGE());
 
 	// want vtx indices for tris
 	Uint32 *idx = &pl_short[0];

--- a/src/GeoPatchContext.cpp
+++ b/src/GeoPatchContext.cpp
@@ -13,20 +13,18 @@
 #include <deque>
 
 // static instances
-int GeoPatchContext::edgeLen = 0;
-int GeoPatchContext::numTris = 0;
-double GeoPatchContext::frac = 0.0;
-RefCountedPtr<Graphics::IndexBuffer> GeoPatchContext::indices;
-int GeoPatchContext::prevEdgeLen = 0;
+int GeoPatchContext::m_edgeLen = 0;
+int GeoPatchContext::m_numTris = 0;
+double GeoPatchContext::m_frac = 0.0;
+RefCountedPtr<Graphics::IndexBuffer> GeoPatchContext::m_indices;
+int GeoPatchContext::m_prevEdgeLen = 0;
 
 //static
 void GeoPatchContext::GenerateIndices()
 {
-	if (prevEdgeLen == edgeLen)
+	if (m_prevEdgeLen == m_edgeLen)
 		return;
 
-	//
-	Uint32 *idx;
 	std::vector<Uint32> pl_short;
 
 	int tri_count = 0;
@@ -51,24 +49,24 @@ void GeoPatchContext::GenerateIndices()
 			}
 		}
 	}
+
 	// want vtx indices for tris
-	idx = &pl_short[0];
-	for (int x = 0; x < edgeLen - 1; x++) {
-		for (int y = 0; y < edgeLen - 1; y++) {
+	Uint32 *idx = &pl_short[0];
+	for (int x = 0; x < m_edgeLen - 1; x++) {
+		for (int y = 0; y < m_edgeLen - 1; y++) {
 			// 1st tri
-			idx[0] = x + edgeLen * y;
-			idx[1] = x + 1 + edgeLen * y;
-			idx[2] = x + edgeLen * (y + 1);
+			idx[0] = x + m_edgeLen * y;
+			idx[1] = x + 1 + m_edgeLen * y;
+			idx[2] = x + m_edgeLen * (y + 1);
 			idx += 3;
 
 			// 2nd tri
-			idx[0] = x + 1 + edgeLen * y;
-			idx[1] = x + 1 + edgeLen * (y + 1);
-			idx[2] = x + edgeLen * (y + 1);
+			idx[0] = x + 1 + m_edgeLen * y;
+			idx[1] = x + 1 + m_edgeLen * (y + 1);
+			idx[2] = x + m_edgeLen * (y + 1);
 			idx += 3;
 		}
 	}
-
 	// populate the N indices lists from the arrays built during InitTerrainIndices()
 	// iterate over each index list and optimize it
 	{
@@ -76,21 +74,21 @@ void GeoPatchContext::GenerateIndices()
 		VertexCacheOptimizerUInt::Result res = vco.Optimize(&pl_short[0], tri_count);
 		assert(0 == res);
 		//create buffer & copy
-		indices.Reset(Pi::renderer->CreateIndexBuffer(pl_short.size(), Graphics::BUFFER_USAGE_STATIC));
-		Uint32 *idxPtr = indices->Map(Graphics::BUFFER_MAP_WRITE);
+		m_indices.Reset(Pi::renderer->CreateIndexBuffer(pl_short.size(), Graphics::BUFFER_USAGE_STATIC));
+		Uint32 *idxPtr = m_indices->Map(Graphics::BUFFER_MAP_WRITE);
 		for (Uint32 j = 0; j < pl_short.size(); j++) {
 			idxPtr[j] = pl_short[j];
 		}
-		indices->Unmap();
+		m_indices->Unmap();
 	}
 
-	prevEdgeLen = edgeLen;
+	m_prevEdgeLen = m_edgeLen;
 }
 
 void GeoPatchContext::Init()
 {
-	frac = 1.0 / double(edgeLen - 3);
-	numTris = 2 * (edgeLen - 1) * (edgeLen - 1);
+	m_frac = 1.0 / double(m_edgeLen - 3);
+	m_numTris = 2 * (m_edgeLen - 1) * (m_edgeLen - 1);
 
 	GenerateIndices();
 }

--- a/src/GeoPatchContext.cpp
+++ b/src/GeoPatchContext.cpp
@@ -2,13 +2,10 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "GeoPatchContext.h"
+
 #include "Pi.h"
-#include "RefCounted.h"
-#include "graphics/Frustum.h"
 #include "graphics/Graphics.h"
-#include "graphics/Material.h"
 #include "graphics/Renderer.h"
-#include "graphics/VertexArray.h"
 
 #include "perlin.h"
 #include "vcacheopt/vcacheopt.h"

--- a/src/GeoPatchContext.h
+++ b/src/GeoPatchContext.h
@@ -6,10 +6,8 @@
 
 #include <SDL_stdinc.h>
 
-#include "GeoPatchID.h"
-#include "Random.h"
-#include "graphics/VertexBuffer.h"
 #include "vector3.h"
+#include "graphics/VertexBuffer.h"
 
 #include <deque>
 
@@ -19,6 +17,7 @@
 namespace Graphics {
 	class Renderer;
 }
+
 class SystemBody;
 class GeoPatch;
 class GeoSphere;

--- a/src/GeoPatchContext.h
+++ b/src/GeoPatchContext.h
@@ -14,33 +14,7 @@
 // maximumpatch depth
 #define GEOPATCH_MAX_DEPTH 15
 
-namespace Graphics {
-	class Renderer;
-}
-
-class SystemBody;
-class GeoPatch;
-class GeoSphere;
-
 class GeoPatchContext : public RefCounted {
-private:
-	static int edgeLen;
-	static int numTris;
-
-	static double frac;
-
-	static inline int VBO_COUNT_HI_EDGE() { return 3 * (edgeLen - 1); }
-	static inline int VBO_COUNT_MID_IDX() { return (4 * 3 * (edgeLen - 3)) + 2 * (edgeLen - 3) * (edgeLen - 3) * 3; }
-	//                                            ^^ serrated teeth bit  ^^^ square inner bit
-
-	static inline int IDX_VBO_LO_OFFSET(const int i) { return i * sizeof(Uint32) * 3 * (edgeLen / 2); }
-	static inline int IDX_VBO_HI_OFFSET(const int i) { return (i * sizeof(Uint32) * VBO_COUNT_HI_EDGE()) + IDX_VBO_LO_OFFSET(4); }
-
-	static RefCountedPtr<Graphics::IndexBuffer> indices;
-	static int prevEdgeLen;
-
-	static void GenerateIndices();
-
 public:
 	struct VBOVertex {
 		vector3f pos;
@@ -51,7 +25,7 @@ public:
 
 	GeoPatchContext(const int _edgeLen)
 	{
-		edgeLen = _edgeLen + 2; // +2 for the skirt
+		m_edgeLen = _edgeLen + 2; // +2 for the skirt
 		Init();
 	}
 
@@ -62,13 +36,32 @@ public:
 
 	static void Init();
 
-	static inline Graphics::IndexBuffer *GetIndexBuffer() { return indices.Get(); }
+	static inline Graphics::IndexBuffer *GetIndexBuffer() { return m_indices.Get(); }
 
-	static inline int NUMVERTICES() { return edgeLen * edgeLen; }
+	static inline int NUMVERTICES() { return m_edgeLen * m_edgeLen; }
 
-	static inline int GetEdgeLen() { return edgeLen; }
-	static inline int GetNumTris() { return numTris; }
-	static inline double GetFrac() { return frac; }
+	static inline int GetEdgeLen() { return m_edgeLen; }
+	static inline int GetNumTris() { return m_numTris; }
+	static inline double GetFrac() { return m_frac; }
+
+private:
+	static int m_edgeLen;
+	static int m_numTris;
+
+	static double m_frac;
+
+	static inline int VBO_COUNT_HI_EDGE() { return 3 * (m_edgeLen - 1); }
+	static inline int VBO_COUNT_MID_IDX() { return (4 * 3 * (m_edgeLen - 3)) + 2 * (m_edgeLen - 3) * (m_edgeLen - 3) * 3; }
+	//                                            ^^ serrated teeth bit  ^^^ square inner bit
+
+	static inline int IDX_VBO_LO_OFFSET(const int i) { return i * sizeof(Uint32) * 3 * (m_edgeLen / 2); }
+	static inline int IDX_VBO_HI_OFFSET(const int i) { return (i * sizeof(Uint32) * VBO_COUNT_HI_EDGE()) + IDX_VBO_LO_OFFSET(4); }
+
+	static RefCountedPtr<Graphics::IndexBuffer> m_indices;
+	static int m_prevEdgeLen;
+
+	static void GenerateIndices();
+
 };
 
 #endif /* _GEOPATCHCONTEXT_H */

--- a/src/GeoPatchJobs.cpp
+++ b/src/GeoPatchJobs.cpp
@@ -2,10 +2,8 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "GeoPatchJobs.h"
-#include "GeoPatch.h"
+
 #include "GeoSphere.h"
-#include "Pi.h"
-#include "RefCounted.h"
 #include "libs.h"
 #include "perlin.h"
 

--- a/src/GeoPatchJobs.h
+++ b/src/GeoPatchJobs.h
@@ -6,11 +6,11 @@
 
 #include <SDL_stdinc.h>
 
+#include "Color.h"
 #include "GeoPatchID.h"
 #include "JobQueue.h"
-#include "Random.h"
-#include "terrain/Terrain.h"
 #include "vector3.h"
+#include "terrain/Terrain.h"
 
 class GeoSphere;
 

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -10,6 +10,7 @@
 #include "Pi.h"
 #include "RefCounted.h"
 #include "galaxy/StarSystem.h"
+#include "galaxy/AtmosphereParameters.h"
 #include "graphics/Frustum.h"
 #include "graphics/Graphics.h"
 #include "graphics/Material.h"
@@ -496,7 +497,7 @@ void GeoSphere::SetUpMaterials()
 		surfDesc.effect = Graphics::EFFECT_GEOSPHERE_STAR;
 	} else {
 		//planetoid with or without atmosphere
-		const SystemBody::AtmosphereParameters ap(GetSystemBody()->CalcAtmosphereParams());
+		const AtmosphereParameters ap(GetSystemBody()->CalcAtmosphereParams());
 		surfDesc.lighting = true;
 		if (ap.atmosDensity > 0.0) {
 			surfDesc.quality |= Graphics::HAS_ATMOSPHERE;

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -357,14 +357,7 @@ void GeoSphere::AddQuadSplitRequest(double dist, SQuadSplitRequest *pReq, GeoPat
 
 void GeoSphere::ProcessQuadSplitRequests()
 {
-	class RequestDistanceSort {
-	public:
-		bool operator()(const TDistanceRequest &a, const TDistanceRequest &b)
-		{
-			return a.mDistance < b.mDistance;
-		}
-	};
-	std::sort(mQuadSplitRequests.begin(), mQuadSplitRequests.end(), RequestDistanceSort());
+	std::sort(mQuadSplitRequests.begin(), mQuadSplitRequests.end(), [](TDistanceRequest &a, TDistanceRequest &b) { return a.mDistance < b.mDistance; });
 
 	for (auto iter : mQuadSplitRequests) {
 		SQuadSplitRequest *ssrd = iter.mpRequest;

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -440,8 +440,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 
 	else {
 		// give planet some ambient lighting if the viewer is close to it
-		double camdist = campos.Length();
-		camdist = 0.1 / (camdist * camdist);
+		double camdist = 0.1 / campos.LengthSqr();
 		// why the fuck is this returning 0.1 when we are sat on the planet??
 		// JJ: Because campos is relative to a unit-radius planet - 1.0 at the surface
 		// XXX oh well, it is the value we want anyway...

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -9,6 +9,7 @@
 #include "GeoPatchJobs.h"
 #include "Pi.h"
 #include "RefCounted.h"
+#include "galaxy/StarSystem.h"
 #include "graphics/Frustum.h"
 #include "graphics/Graphics.h"
 #include "graphics/Material.h"

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -8,7 +8,6 @@
 
 #include "BaseSphere.h"
 #include "Camera.h"
-#include "GeoPatchID.h"
 #include "vector3.h"
 
 #include <deque>

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -2,8 +2,10 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Planet.h"
+
 #include "Color.h"
 #include "GeoSphere.h"
+#include "galaxy/SystemBody.h"
 #include "graphics/Graphics.h"
 #include "graphics/Material.h"
 #include "graphics/RenderState.h"

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -4,8 +4,10 @@
 #include "Star.h"
 
 #include "Pi.h"
+#include "galaxy/StarSystem.h"
 #include "graphics/Graphics.h"
 #include "graphics/Renderer.h"
+#include "graphics/RenderState.h"
 #include "graphics/VertexArray.h"
 
 using namespace Graphics;

--- a/src/Star.h
+++ b/src/Star.h
@@ -5,10 +5,10 @@
 #define _STAR_H
 
 #include "TerrainBody.h"
-#include "graphics/RenderState.h"
 
 namespace Graphics {
 	class Renderer;
+	class RenderState;
 }
 
 class Star : public TerrainBody {

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -9,6 +9,7 @@
 #include "GeoSphere.h"
 #include "Json.h"
 #include "Space.h"
+#include "galaxy/SystemBody.h"
 #include "graphics/Graphics.h"
 #include "graphics/Renderer.h"
 

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -99,7 +99,7 @@ void TerrainBody::Render(Graphics::Renderer *renderer, const Camera *camera, con
 
 	vector3d campos = fpos;
 	ftran.ClearToRotOnly();
-	campos = ftran.Inverse() * campos;
+	campos = campos * ftran;
 
 	campos = campos * (1.0 / rad); // position of camera relative to planet "model"
 

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -145,14 +145,6 @@ double TerrainBody::GetTerrainHeight(const vector3d &pos_) const
 	}
 }
 
-bool TerrainBody::IsSuperType(SystemBody::BodySuperType t) const
-{
-	if (!m_sbody)
-		return false;
-	else
-		return m_sbody->GetSuperType() == t;
-}
-
 //static
 void TerrainBody::OnChangeDetailLevel()
 {

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -26,7 +26,6 @@ public:
 	virtual bool OnCollision(Object *b, Uint32 flags, double relVel) override { return true; }
 	virtual double GetMass() const override { return m_mass; }
 	double GetTerrainHeight(const vector3d &pos) const;
-	bool IsSuperType(SystemBody::BodySuperType t) const;
 	virtual const SystemBody *GetSystemBody() const override { return m_sbody; }
 
 	// returns value in metres

--- a/src/galaxy/AtmosphereParameters.h
+++ b/src/galaxy/AtmosphereParameters.h
@@ -1,0 +1,13 @@
+#ifndef ATMOSPHEREPARAMETERS_H_INCLUDED
+#define ATMOSPHEREPARAMETERS_H_INCLUDED
+
+struct AtmosphereParameters {
+	float atmosRadius;
+	float atmosInvScaleHeight;
+	float atmosDensity;
+	float planetRadius;
+	Color atmosCol;
+	vector3d center;
+};
+
+#endif // ATMOSPHEREPARAMETERS_H_INCLUDED

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -3,6 +3,7 @@
 
 #include "StarSystemGenerator.h"
 
+#include "AtmosphereParameters.h"
 #include "Factions.h"
 #include "Galaxy.h"
 #include "Json.h"

--- a/src/galaxy/SystemBody.cpp
+++ b/src/galaxy/SystemBody.cpp
@@ -5,6 +5,7 @@
 
 #include "Lang.h"
 #include "EnumStrings.h"
+#include "AtmosphereParameters.h"
 #include "enum_table.h"
 #include "utils.h"
 
@@ -51,7 +52,7 @@ bool SystemBody::IsScoopable() const
 }
 
 // Calculate parameters used in the atmospheric model for shaders
-SystemBody::AtmosphereParameters SystemBody::CalcAtmosphereParams() const
+AtmosphereParameters SystemBody::CalcAtmosphereParams() const
 {
 	PROFILE_SCOPED()
 	AtmosphereParameters params;

--- a/src/galaxy/SystemBody.h
+++ b/src/galaxy/SystemBody.h
@@ -14,6 +14,8 @@
 
 class StarSystem;
 
+struct AtmosphereParameters;
+
 class SystemBody : public RefCounted {
 public:
 	SystemBody(const SystemPath &path, StarSystem *system);
@@ -191,15 +193,6 @@ public:
 		*outColor = m_atmosColor;
 		*outDensity = m_atmosDensity;
 	}
-
-	struct AtmosphereParameters {
-		float atmosRadius;
-		float atmosInvScaleHeight;
-		float atmosDensity;
-		float planetRadius;
-		Color atmosCol;
-		vector3d center;
-	};
 
 	AtmosphereParameters CalcAtmosphereParams() const;
 

--- a/src/graphics/opengl/GasGiantMaterial.cpp
+++ b/src/graphics/opengl/GasGiantMaterial.cpp
@@ -8,6 +8,7 @@
 #include "StringF.h"
 #include "graphics/Graphics.h"
 #include <sstream>
+#include "galaxy/AtmosphereParameters.h"
 
 namespace Graphics {
 	namespace OGL {
@@ -88,7 +89,7 @@ namespace Graphics {
 
 			GasGiantProgram *p = static_cast<GasGiantProgram *>(m_program);
 			const GeoSphere::MaterialParameters params = *static_cast<GeoSphere::MaterialParameters *>(this->specialParameter0);
-			const SystemBody::AtmosphereParameters ap = params.atmosphere;
+			const AtmosphereParameters ap = params.atmosphere;
 
 			p->emission.Set(this->emissive);
 			p->sceneAmbient.Set(m_renderer->GetAmbientColor());

--- a/src/graphics/opengl/GasGiantMaterial.h
+++ b/src/graphics/opengl/GasGiantMaterial.h
@@ -9,7 +9,6 @@
 #include "MaterialGL.h"
 #include "OpenGLLibs.h"
 #include "Program.h"
-#include "galaxy/StarSystem.h"
 
 namespace Graphics {
 	namespace OGL {

--- a/src/graphics/opengl/GeoSphereMaterial.cpp
+++ b/src/graphics/opengl/GeoSphereMaterial.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "GeoSphereMaterial.h"
+
 #include "Camera.h"
 #include "GeoSphere.h"
 #include "RendererGL.h"
@@ -104,7 +105,7 @@ namespace Graphics {
 
 			GeoSphereProgram *p = static_cast<GeoSphereProgram *>(m_program);
 			const GeoSphere::MaterialParameters params = *static_cast<GeoSphere::MaterialParameters *>(this->specialParameter0);
-			const SystemBody::AtmosphereParameters ap = params.atmosphere;
+			const AtmosphereParameters ap = params.atmosphere;
 
 			p->emission.Set(this->emissive);
 			p->sceneAmbient.Set(m_renderer->GetAmbientColor());

--- a/src/graphics/opengl/GeoSphereMaterial.h
+++ b/src/graphics/opengl/GeoSphereMaterial.h
@@ -9,7 +9,6 @@
 #include "MaterialGL.h"
 #include "OpenGLLibs.h"
 #include "Program.h"
-#include "galaxy/StarSystem.h"
 
 namespace Graphics {
 	namespace OGL {

--- a/src/terrain/FracDef.h
+++ b/src/terrain/FracDef.h
@@ -1,0 +1,16 @@
+#ifndef FRACDEF_H_INCLUDED
+#define FRACDEF_H_INCLUDED
+
+struct fracdef_t {
+	fracdef_t() :
+		amplitude(0.0),
+		frequency(0.0),
+		lacunarity(0.0),
+		octaves(0) {}
+	double amplitude;
+	double frequency;
+	double lacunarity;
+	int octaves;
+};
+
+#endif // FRACDEF_H_INCLUDED

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -6,8 +6,8 @@
 #include "FileSystem.h"
 #include "FloatComparison.h"
 #include "GameConfig.h"
-#include "Pi.h"
 #include "perlin.h"
+#include "../utils.h"
 #include "../galaxy/SystemBody.h"
 
 // static instancer. selects the best height and color classes for the body
@@ -702,19 +702,4 @@ Terrain::MinBodyData::MinBodyData(const SystemBody *body)
 	m_aspectRatio = body->GetAspectRatio();
 	m_path = body->GetPath();
 	m_name = body->GetName();
-}
-
-void Terrain::DebugDump() const
-{
-	Output("Terrain state dump:\n");
-	Output("  Height fractal: %s\n", GetHeightFractalName());
-	Output("  Color fractal: %s\n", GetColorFractalName());
-	Output("  Config: DetailPlanets %d   FractalMultiple %d  Textures  %d\n", Pi::config->Int("DetailPlanets"), Pi::config->Int("FractalMultiple"), Pi::config->Int("Textures"));
-	Output("  Seed: %d\n", m_seed);
-	Output("  Body: %s [%d,%d,%d,%u,%u]\n", m_minBody.m_name.c_str(), m_minBody.m_path.sectorX, m_minBody.m_path.sectorY, m_minBody.m_path.sectorZ, m_minBody.m_path.systemIndex, m_minBody.m_path.bodyIndex);
-	Output("  Aspect Ratio: %g\n", m_minBody.m_aspectRatio);
-	Output("  Fracdefs:\n");
-	for (int i = 0; i < 10; i++) {
-		Output("    %d: amp %f  freq %f  lac %f  oct %d\n", i, m_fracdef[i].amplitude, m_fracdef[i].frequency, m_fracdef[i].lacunarity, m_fracdef[i].octaves);
-	}
 }

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -2,11 +2,13 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Terrain.h"
+
 #include "FileSystem.h"
 #include "FloatComparison.h"
 #include "GameConfig.h"
 #include "Pi.h"
 #include "perlin.h"
+#include "../galaxy/SystemBody.h"
 
 // static instancer. selects the best height and color classes for the body
 Terrain *Terrain::InstanceTerrain(const SystemBody *body)
@@ -692,6 +694,14 @@ double Terrain::BiCubicInterpolation(const vector3d &p) const
 	const double a2 = 0.5 * d0 + 0.5 * d2;
 	const double a3 = -(1 / 6.0) * d0 - 0.5 * d2 + (1 / 6.0) * d3;
 	return (0.1 + a0 + a1 * dy + a2 * dy * dy + a3 * dy * dy * dy);
+}
+
+Terrain::MinBodyData::MinBodyData(const SystemBody *body)
+{
+	m_radius = body->GetRadius();
+	m_aspectRatio = body->GetAspectRatio();
+	m_path = body->GetPath();
+	m_name = body->GetName();
 }
 
 void Terrain::DebugDump() const

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -4,7 +4,11 @@
 #ifndef _TERRAIN_H
 #define _TERRAIN_H
 
-#include "galaxy/StarSystem.h"
+#include "FracDef.h"
+#include "../Random.h"
+#include "../RefCounted.h"
+#include "../vector3.h"
+#include "../galaxy/SystemPath.h"
 
 #include <memory>
 #include <string>
@@ -13,17 +17,7 @@
 #pragma warning(disable : 4250) // workaround for MSVC 2008 multiple inheritance bug
 #endif
 
-struct fracdef_t {
-	fracdef_t() :
-		amplitude(0.0),
-		frequency(0.0),
-		lacunarity(0.0),
-		octaves(0) {}
-	double amplitude;
-	double frequency;
-	double lacunarity;
-	int octaves;
-};
+class SystemBody;
 
 template <typename, typename>
 class TerrainGenerator;
@@ -117,13 +111,7 @@ protected:
 	fracdef_t m_fracdef[MAX_FRACDEFS];
 
 	struct MinBodyData {
-		MinBodyData(const SystemBody *body)
-		{
-			m_radius = body->GetRadius();
-			m_aspectRatio = body->GetAspectRatio();
-			m_path = body->GetPath();
-			m_name = body->GetName();
-		}
+		MinBodyData(const SystemBody *body);
 		double m_radius;
 		double m_aspectRatio;
 		SystemPath m_path;
@@ -135,6 +123,7 @@ protected:
 template <typename HeightFractal>
 class TerrainHeightFractal : virtual public Terrain {
 public:
+	TerrainHeightFractal() = delete;
 	virtual double GetHeight(const vector3d &p) const;
 	virtual const char *GetHeightFractalName() const;
 
@@ -142,12 +131,12 @@ protected:
 	TerrainHeightFractal(const SystemBody *body);
 
 private:
-	TerrainHeightFractal() {}
 };
 
 template <typename ColorFractal>
 class TerrainColorFractal : virtual public Terrain {
 public:
+	TerrainColorFractal() = delete;
 	virtual vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const;
 	virtual const char *GetColorFractalName() const;
 
@@ -155,19 +144,18 @@ protected:
 	TerrainColorFractal(const SystemBody *body);
 
 private:
-	TerrainColorFractal() {}
 };
 
 template <typename HeightFractal, typename ColorFractal>
 class TerrainGenerator : public TerrainHeightFractal<HeightFractal>, public TerrainColorFractal<ColorFractal> {
 public:
+	TerrainGenerator() = delete;
 	TerrainGenerator(const SystemBody *body) :
 		Terrain(body),
 		TerrainHeightFractal<HeightFractal>(body),
 		TerrainColorFractal<ColorFractal>(body) {}
 
 private:
-	TerrainGenerator() {}
 };
 
 //This is the most complex and insanely crazy terrain you will ever see :

--- a/src/terrain/TerrainDbg.cpp
+++ b/src/terrain/TerrainDbg.cpp
@@ -1,0 +1,22 @@
+// Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "Terrain.h"
+
+#include "GameConfig.h"
+#include "Pi.h"
+
+void Terrain::DebugDump() const
+{
+	Output("Terrain state dump:\n");
+	Output("  Height fractal: %s\n", GetHeightFractalName());
+	Output("  Color fractal: %s\n", GetColorFractalName());
+	Output("  Config: DetailPlanets %d   FractalMultiple %d  Textures  %d\n", Pi::config->Int("DetailPlanets"), Pi::config->Int("FractalMultiple"), Pi::config->Int("Textures"));
+	Output("  Seed: %d\n", m_seed);
+	Output("  Body: %s [%d,%d,%d,%u,%u]\n", m_minBody.m_name.c_str(), m_minBody.m_path.sectorX, m_minBody.m_path.sectorY, m_minBody.m_path.sectorZ, m_minBody.m_path.systemIndex, m_minBody.m_path.bodyIndex);
+	Output("  Aspect Ratio: %g\n", m_minBody.m_aspectRatio);
+	Output("  Fracdefs:\n");
+	for (int i = 0; i < 10; i++) {
+		Output("    %d: amp %f  freq %f  lac %f  oct %d\n", i, m_fracdef[i].amplitude, m_fracdef[i].frequency, m_fracdef[i].lacunarity, m_fracdef[i].octaves);
+	}
+}

--- a/src/terrain/TerrainFeature.cpp
+++ b/src/terrain/TerrainFeature.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "FracDef.h"
 #include "TerrainFeature.h"
 #include "TerrainNoise.h"
 

--- a/src/terrain/TerrainFeature.h
+++ b/src/terrain/TerrainFeature.h
@@ -4,7 +4,9 @@
 #ifndef _TERRAINFEATURE_H
 #define _TERRAINFEATURE_H
 
-#include "Terrain.h"
+#include "../vector3.h"
+
+struct fracdef_t;
 
 namespace TerrainFeature {
 

--- a/src/terrain/TerrainHeightEllipsoid.cpp
+++ b/src/terrain/TerrainHeightEllipsoid.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Terrain.h"
+#include <algorithm> // for std::max
 
 template <>
 const char *TerrainHeightFractal<TerrainHeightEllipsoid>::GetHeightFractalName() const { return "Ellipsoid"; }

--- a/src/terrain/TerrainNoise.h
+++ b/src/terrain/TerrainNoise.h
@@ -4,8 +4,8 @@
 #ifndef _TERRAINNOISE_H
 #define _TERRAINNOISE_H
 
-#include "Terrain.h"
 #include "perlin.h"
+#include "../libs.h"
 
 namespace TerrainNoise {
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Moved fractal definition in a separate file, moved ctor of `MinBodyData` in *.cpp,
thus forward declare `SystemBody` and include only `SystemPath`.

`TerrainFeature.h` has no needs to include `Terrain.h` and so `TerrainNoise.h`

...Some other includes I spotted here & there has been decoupled.

**EDIT:** ...added `GeoPatchContext.h|cpp` to the list

**EDIT2:** added some commits to make review easier, to be squashed
