### PR TITLE
Pigui Model Spinner, move ShipInfo to pigui.

### DIFF
--- a/data/libs/ui/PiguiFace.lua
+++ b/data/libs/ui/PiguiFace.lua
@@ -1,7 +1,7 @@
 -- Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local Face = import 'UI.PiGui.Face'
+local Face = import 'PiGui.Modules.Face'
 local ui = import 'pigui/pigui.lua'
 local colors = ui.theme.colors
 local orbiteer = ui.fonts.orbiteer

--- a/data/pigui/libs/table.lua
+++ b/data/pigui/libs/table.lua
@@ -5,21 +5,20 @@ local ui = import 'pigui/pigui.lua'
 
 local drawTable = {}
 
-function drawTable.draw(n, id, border, t)
-	ui.columns(n, id, border)
-	for _, entry in pairs(t) do
+function drawTable.draw(t)
+	for _, entry in ipairs(t) do
 		if type(entry) == "table" then
-			for i, v in pairs(entry) do
-				if (v) then ui.text(v) end
-				ui.nextColumn()
-			end
+			ui.text(entry[1])
+			ui.sameLine(ui.getContentRegion().x - ui.calcTextSize(entry[2]).x)
+			ui.text(entry[2])
+		elseif type(entry) == "string" then
+			ui.spacing()
+			ui.text(entry)
+			ui.separator()
 		elseif entry == false then
-			ui.dummy({x=5, y=ui.getTextLineHeight()})
-			ui.nextColumn()
-			ui.nextColumn()
+			ui.spacing()
 		end
 	end
-	ui.columns(1, "", false)
 end
 
 function drawTable.withHeading(name, font, t)
@@ -27,7 +26,7 @@ function drawTable.withHeading(name, font, t)
         ui.text(name)
     end)
 
-    drawTable.draw(table.unpack(t))
+    drawTable.draw(t)
 end
 
 return drawTable

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -3,15 +3,186 @@
 
 local ui = import 'pigui/pigui.lua'
 local InfoView = import 'pigui/views/info-view'
+local ModelSpinner = import 'PiGui.Modules.ModelSpinner'
 local Lang = import 'Lang'
+local Game = import 'Game'
+local ShipDef = import 'ShipDef'
+local Equipment = import 'Equipment'
+local Vector2 = _G.Vector2
 
 local l = Lang.GetResource("ui-core")
+
+local fonts = ui.fonts
+
+local drawTable = import 'pigui.libs.table'
+
+-- use the old InfoView style layout instead of the new sidebar layout.
+local _OLD_LAYOUT = true
+
+local modelSpinner = ModelSpinner()
+local cachedShip = nil
+local cachedPattern = nil
+
+local function shipSpinner()
+	local spinnerWidth = _OLD_LAYOUT and ui.getColumnWidth() or ui.getContentRegion().x
+	modelSpinner:setSize(Vector2(spinnerWidth, spinnerWidth / 1.5))
+
+	local player = Game.player
+	local shipDef = ShipDef[player.shipId]
+
+	if shipDef.modelName ~= cachedShip or player.model.pattern ~= cachedPattern then
+		cachedShip = shipDef.modelName
+		cachedPattern = player.model.pattern
+		modelSpinner:setModel(cachedShip, player:GetSkin(), cachedPattern)
+	end
+
+	ui.group(function ()
+		local font = ui.fonts.orbiteer.large
+		ui.withFont(font.name, font.size, function()
+			ui.text(shipDef.name)
+			ui.sameLine()
+			ui.pushItemWidth(-1.0)
+			local entry, apply = ui.inputText("##ShipNameEntry", player.shipName, ui.InputTextFlags {"EnterReturnsTrue"})
+			ui.popItemWidth()
+
+			if (apply) then player:SetShipName(entry) end
+		end)
+
+		modelSpinner:draw()
+	end)
+end
+
+local collapsingHeaderFlags = ui.TreeNodeFlags { "DefaultOpen" }
+
+local function shipStats()
+	local closed = ui.withFont(fonts.pionillium.medium, function()
+		return not ui.collapsingHeader("Ship Information", collapsingHeaderFlags)
+	end)
+
+	-- TODO: draw info ontop of the header
+
+	if closed then return end
+
+	local player = Game.player
+
+	-- Taken directly from ShipInfo.lua.
+	local shipDef     =    ShipDef[player.shipId]
+	local shipLabel   =    player:GetLabel()
+	local hyperdrive  =    table.unpack(player:GetEquip("engine"))
+	local frontWeapon =    table.unpack(player:GetEquip("laser_front"))
+	local rearWeapon  =    table.unpack(player:GetEquip("laser_rear"))
+
+	hyperdrive =  hyperdrive  or nil
+	frontWeapon = frontWeapon or nil
+	rearWeapon =  rearWeapon  or nil
+
+	local mass_with_fuel = player.staticMass + player.fuelMassLeft
+	local mass_with_fuel_kg = 1000 * mass_with_fuel
+
+	-- ship stats mass is in tonnes; scale by 1000 to convert to kg
+	local fwd_acc = -shipDef.linearThrust.FORWARD / mass_with_fuel_kg
+	local bwd_acc = shipDef.linearThrust.REVERSE / mass_with_fuel_kg
+	local up_acc = shipDef.linearThrust.UP / mass_with_fuel_kg
+
+	-- delta-v calculation according to http://en.wikipedia.org/wiki/Tsiolkovsky_rocket_equation
+	local deltav = shipDef.effectiveExhaustVelocity * math.log((player.staticMass + player.fuelMassLeft) / player.staticMass)
+
+	drawTable.draw {
+		{ l.REGISTRATION_NUMBER..":",	shipLabel},
+		{ l.HYPERDRIVE..":",			hyperdrive and hyperdrive:GetName() or l.NONE },
+		{
+			l.HYPERSPACE_RANGE..":",
+			string.interp( l.N_LIGHT_YEARS_N_MAX, {
+				range    = string.format("%.1f",player.hyperspaceRange),
+				maxRange = string.format("%.1f",player.maxHyperspaceRange)
+			})
+		},
+		false,
+		{ l.WEIGHT_EMPTY..":",  string.format("%dt", player.staticMass - player.usedCapacity) },
+		{ l.CAPACITY_USED..":", string.format("%dt (%dt "..l.FREE..")", player.usedCapacity,  player.freeCapacity) },
+		{ l.CARGO_SPACE..":", string.format("%dt (%dt "..l.MAX..")", player.totalCargo, shipDef.equipSlotCapacity.cargo) },
+		{ l.CARGO_SPACE_USED..":", string.format("%dt (%dt "..l.FREE..")", player.usedCargo, player.totalCargo - player.usedCargo) },
+		{ l.FUEL_WEIGHT..":",   string.format("%dt (%dt "..l.MAX..")", player.fuelMassLeft, shipDef.fuelTankMass ) },
+		{ l.ALL_UP_WEIGHT..":", string.format("%dt", mass_with_fuel ) },
+		false,
+		{ l.FRONT_WEAPON..":", frontWeapon and frontWeapon:GetName() or l.NONE },
+		{ l.REAR_WEAPON..":",  rearWeapon and rearWeapon:GetName() or l.NONE },
+		{ l.FUEL..":",         string.format("%d%%", Game.player.fuel)},
+		{ l.DELTA_V..":",      string.format("%d km/s", deltav / 1000)},
+		false,
+		{ l.FORWARD_ACCEL..":",  string.format("%.2f m/s² (%.1f G)", fwd_acc, fwd_acc / 9.81) },
+		{ l.BACKWARD_ACCEL..":", string.format("%.2f m/s² (%.1f G)", bwd_acc, bwd_acc / 9.81) },
+		{ l.UP_ACCEL..":",       string.format("%.2f m/s² (%.1f G)", up_acc, up_acc / 9.81) },
+		false,
+		{ l.MINIMUM_CREW..":", shipDef.minCrew },
+		{ l.CREW_CABINS..":",  shipDef.maxCrew },
+		false,
+		{ l.MISSILE_MOUNTS..":",            shipDef.equipSlotCapacity.missile},
+		{ l.ATMOSPHERIC_SHIELDING..":",     shipDef.equipSlotCapacity.atmo_shield > 1 and l.YES or l.NO },
+		{ l.SCOOP_MOUNTS..":",              shipDef.equipSlotCapacity.scoop},
+	}
+end
+
+local function equipmentList()
+	local closed = ui.withFont(fonts.pionillium.medium, function()
+		return not ui.collapsingHeader("Equipment", collapsingHeaderFlags)
+	end)
+
+	if closed then return end
+
+	-- TODO: there's definitely a better way to do this, but it's copied from ShipInfo.lua for now.
+	local equipItems = {}
+	local equips = {Equipment.cargo, Equipment.misc, Equipment.hyperspace, Equipment.laser}
+	for _,t in pairs(equips) do
+		for k,et in pairs(t) do
+			local slot = et:GetDefaultSlot(Game.player)
+			if (slot ~= "cargo" and slot ~= "missile" and slot ~= "engine" and slot ~= "laser_front" and slot ~= "laser_rear") then
+				local count = Game.player:CountEquip(et)
+				if count > 0 then
+					if count > 1 then
+						if et == Equipment.misc.shield_generator then
+							ui.text(string.interp(l.N_SHIELD_GENERATORS, { quantity = string.format("%d", count) }))
+						elseif et == Equipment.misc.cabin_occupied then
+							ui.text(string.interp(l.N_OCCUPIED_PASSENGER_CABINS, { quantity = string.format("%d", count) }))
+						elseif et == Equipment.misc.cabin then
+							ui.text(string.interp(l.N_UNOCCUPIED_PASSENGER_CABINS, { quantity = string.format("%d", count) }))
+						else
+							ui.text(et:GetName())
+						end
+					else
+						ui.text(et:GetName())
+					end
+				end
+			end
+		end
+	end
+end
 
 InfoView:registerView({
 	id = "shipInfo",
 	name = l.SHIP_INFORMATION,
 	icon = ui.theme.icons.info,
-	showView = false,
+	showView = true,
 	draw = function()
+		ui.withStyleVars({ WindowPadding = Vector2(24, 24) }, function()
+			ui.child("", Vector2(0, 0), ui.WindowFlags {"AlwaysUseWindowPadding"}, function()
+				ui.withFont(fonts.pionillium.medium, function()
+					if _OLD_LAYOUT then
+						ui.columns(2, "shipInfo")
+
+						shipStats()
+						equipmentList()
+						ui.nextColumn()
+
+						shipSpinner()
+						ui.columns(1, "")
+					else
+						shipSpinner()
+						shipStats()
+						equipmentList()
+					end
+				end)
+			end)
+		end)
 	end
 })

--- a/data/pigui/modules/info-view/02-personal-info.lua
+++ b/data/pigui/modules/info-view/02-personal-info.lua
@@ -39,17 +39,13 @@ local function drawPlayerInfo()
     ui.withStyleVars({WindowPadding = windowPadding, ItemSpacing = itemSpacing}, function()
         ui.child("PlayerInfoDetails", Vector2(info_column_width, 0), {"AlwaysUseWindowPadding"}, function()
             drawTable.withHeading(l.COMBAT, orbiteer.xlarge, {
-                2, "playerCombatInfo", false, {
-                    { l.RATING, l[player:GetCombatRating()] },
-                    { l.KILLS,  string.format('%d',player.killcount) },
-                }
+                { l.RATING, l[player:GetCombatRating()] },
+                { l.KILLS,  string.format('%d',player.killcount) },
             })
             ui.text("")
 
             drawTable.withHeading(l.REPUTATION, orbiteer.xlarge, {
-                2, "playerReputationInfo", false, {
-                    { l.STATUS..":", l[player:GetReputationRating()] },
-                }
+                { l.STATUS..":", l[player:GetReputationRating()] },
             })
         end)
     end)

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -102,27 +102,35 @@ function ui.child(id, size, flags, fun)
 	pigui.EndChild()
 end
 function ui.withFont(name, size, fun)
+	-- allow `withFont(fontObj, fun)`
+	if type(name) == "table" and type(size) == "function" then
+		name, size, fun = table.unpack{name.name, name.size, size}
+	end
+
 	local font = pigui:PushFont(name, size)
-	fun()
+	local res = fun()
 	if font then
 		pigui.PopFont()
 	end
+	return res
 end
 
 function ui.withStyleColors(styles, fun)
 	for k,v in pairs(styles) do
 		pigui.PushStyleColor(k, v)
 	end
-	fun()
+	local res = fun()
 	pigui.PopStyleColor(utils.count(styles))
+	return res
 end
 
 function ui.withStyleVars(vars, fun)
 	for k,v in pairs(vars) do
 		pigui.PushStyleVar(k, v)
 	end
-	fun()
+	local res = fun()
 	pigui.PopStyleVar(utils.count(vars))
+	return res
 end
 
 function ui.withStyleColorsAndVars(styles, vars, fun)
@@ -132,9 +140,10 @@ function ui.withStyleColorsAndVars(styles, vars, fun)
 	for k,v in pairs(vars) do
 		pigui.PushStyleVar(k, v)
 	end
-	fun()
+	local res = fun()
 	pigui.PopStyleVar(utils.count(vars))
 	pigui.PopStyleColor(utils.count(styles))
+	return res
 end
 
 pigui.handlers.INIT = function(progress)
@@ -532,6 +541,7 @@ ui.setTooltip = maybeSetTooltip
 ui.shouldDrawUI = pigui.ShouldDrawUI
 ui.getWindowPos = pigui.GetWindowPos
 ui.getWindowSize = pigui.GetWindowSize
+-- available content region
 ui.getContentRegion = pigui.GetContentRegion
 ui.getTextLineHeight = pigui.GetTextLineHeight
 ui.getTextLineHeightWithSpacing = pigui.GetTextLineHeightWithSpacing

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -1836,7 +1836,7 @@ static int l_pigui_input_text(lua_State *l)
 	PROFILE_SCOPED()
 	std::string label = LuaPull<std::string>(l, 1);
 	std::string text = LuaPull<std::string>(l, 2);
-	int flags = LuaPull<ImGuiInputTextFlags_>(l, 3);
+	int flags = LuaPull<ImGuiInputTextFlags_>(l, 3, ImGuiInputTextFlags_None);
 	// callback
 	// user_data
 	char buffer[1024];

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -322,19 +322,16 @@ static void LuaInit()
 	// XXX sigh
 	UI::Lua::Init();
 	GameUI::Lua::Init();
-	PiGUI::Lua::Init();
 	SceneGraph::Lua::Init();
 
 	LuaObject<PiGui>::RegisterClass();
+	PiGUI::Lua::Init();
 
 	// XXX load everything. for now, just modules
 	lua_State *l = Lua::manager->GetLuaState();
 	pi_lua_import(l, "libs/autoload.lua", true);
 	pi_lua_import_recursive(l, "ui");
 	pi_lua_import(l, "pigui/pigui.lua", true);
-	pi_lua_import(l, "pigui/game.lua", true);
-	pi_lua_import(l, "pigui/init.lua", true);
-	pi_lua_import(l, "pigui/mainmenu.lua", true);
 	pi_lua_import_recursive(l, "pigui/modules");
 	pi_lua_import_recursive(l, "pigui/views");
 	pi_lua_import_recursive(l, "modules");

--- a/src/pigui/LuaFace.cpp
+++ b/src/pigui/LuaFace.cpp
@@ -75,7 +75,7 @@ namespace PiGUI {
 } // namespace PiGUI
 
 template <>
-const char *LuaObject<PiGUI::Face>::s_type = "UI.PiGui.Face";
+const char *LuaObject<PiGUI::Face>::s_type = "PiGui.Modules.Face";
 
 template <>
 void LuaObject<PiGUI::Face>::RegisterClass()

--- a/src/pigui/LuaFlags.h
+++ b/src/pigui/LuaFlags.h
@@ -93,8 +93,9 @@ private:
 			lua_pop(l, 2); // clean up the stack!
 			return fl_ret;
 		} else {
-			std::string index_name = lua_tostring(l, -2);
-			lua_pop(l, 3); // clean up the stack!
+			lua_pop(l, 1);
+			std::string index_name = lua_tostring(l, index);
+			lua_pop(l, 2); // clean up the stack!
 			luaL_error(l, "Unknown %s %s", typeName.c_str(), index_name.c_str());
 		}
 		return FlagType(0);

--- a/src/pigui/LuaModelSpinner.cpp
+++ b/src/pigui/LuaModelSpinner.cpp
@@ -1,0 +1,108 @@
+
+#include "LuaObject.h"
+#include "LuaPushPull.h"
+#include "LuaVector.h"
+#include "LuaVector2.h"
+#include "Pi.h"
+#include "pigui/ModelSpinner.h"
+
+namespace PiGUI {
+	namespace LuaPiguiModelSpinner {
+		static int l_model_new(lua_State *l)
+		{
+			LuaObject<ModelSpinner>::PushToLua(new ModelSpinner());
+			return 1;
+		}
+
+		static int l_model_set_model(lua_State *l)
+		{
+			auto *obj = LuaObject<ModelSpinner>::CheckFromLua(1);
+			const std::string name(luaL_checkstring(l, 2));
+			SceneGraph::ModelSkin *skin = LuaObject<SceneGraph::ModelSkin>::CheckFromLua(3);
+			unsigned int pattern = 0;
+			if (lua_gettop(l) > 3 && !lua_isnoneornil(l, 4))
+				pattern = luaL_checkinteger(l, 4) - 1; // Lua counts from 1
+			SceneGraph::Model *model = Pi::FindModel(name);
+			obj->SetModel(model, *skin, pattern);
+
+			return 0;
+		}
+
+		static int l_model_set_size(lua_State *l)
+		{
+			auto *obj = LuaObject<ModelSpinner>::CheckFromLua(1);
+			vector2d &size = *LuaVector2::CheckFromLua(l, 2);
+			obj->SetSize(size);
+			return 0;
+		}
+
+		static int l_model_attr_size(lua_State *l)
+		{
+			auto *obj = LuaObject<ModelSpinner>::CheckFromLua(1);
+			LuaPush<vector2d>(l, obj->GetSize());
+			return 1;
+		}
+
+		static int l_model_space_to_screen_space(lua_State *l)
+		{
+			auto *obj = LuaObject<ModelSpinner>::CheckFromLua(1);
+			vector3d modelSpaceVec = LuaPull<vector3d>(l, 2);
+			LuaPush<vector2d>(l, obj->ModelSpaceToScreenSpace(modelSpaceVec));
+			return 1;
+		}
+
+		static int l_model_draw(lua_State *l)
+		{
+			auto *obj = LuaObject<ModelSpinner>::CheckFromLua(1);
+			obj->Render();
+			obj->DrawPiGui();
+
+			return 0;
+		}
+	}; // namespace LuaPiguiModelSpinner
+} // namespace PiGUI
+
+using namespace PiGUI::LuaPiguiModelSpinner;
+
+template <>
+const char *LuaObject<PiGUI::ModelSpinner>::s_type = "PiGui.Modules.ModelSpinner";
+
+template <>
+void LuaObject<PiGUI::ModelSpinner>::RegisterClass()
+{
+
+	const luaL_Reg l_meta[] = {
+		{ "__call", l_model_new },
+		{ NULL, NULL }
+	};
+
+	const luaL_Reg l_attrs[] = {
+		{ "size", l_model_attr_size },
+		{ NULL, NULL }
+	};
+
+	const luaL_Reg l_methods[] = {
+		{ "new", l_model_new },
+		{ "draw", l_model_draw },
+		{ "setModel", l_model_set_model },
+		{ "setSize", l_model_set_size },
+		{ "modelSpaceToScreenSpace", l_model_space_to_screen_space },
+		{ NULL, NULL }
+	};
+
+	LuaObjectBase::CreateClass(s_type, NULL, l_methods, l_attrs, NULL);
+
+	lua_State *l = Lua::manager->GetLuaState();
+	LUA_DEBUG_START(l);
+
+	// Set the metatable to allow calling ModelSpinner() to create a new instance.
+	pi_lua_split_table_path(l, s_type); // table, name
+	lua_gettable(l, -2);
+
+	lua_newtable(l);
+	luaL_setfuncs(l, l_meta, 0);
+	lua_setmetatable(l, -2);
+	lua_pop(l, 2);
+
+	LUA_DEBUG_END(l, 0);
+}

--- a/src/pigui/ModelSpinner.cpp
+++ b/src/pigui/ModelSpinner.cpp
@@ -1,0 +1,124 @@
+// Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "pigui/ModelSpinner.h"
+#include "Pi.h"
+#include "PiGui.h"
+#include "graphics/RenderTarget.h"
+#include "graphics/Renderer.h"
+
+#include <algorithm>
+
+using namespace PiGUI;
+
+ModelSpinner::ModelSpinner() :
+	m_rot(vector2f(DEG2RAD(-15.0), DEG2RAD(180.0)))
+{
+	Color lc(Color::WHITE);
+	m_light.SetDiffuse(lc);
+	m_light.SetSpecular(lc);
+	m_light.SetPosition(vector3f(0.f, 1.f, 1.f));
+	m_light.SetType(Graphics::Light::LIGHT_DIRECTIONAL);
+}
+
+void ModelSpinner::CreateRenderTarget()
+{
+	if (m_renderTarget)
+		m_renderTarget.reset();
+
+	Graphics::RenderTargetDesc rtDesc{
+		uint16_t(m_size.x), uint16_t(m_size.y),
+		Graphics::TextureFormat::TEXTURE_RGBA_8888,
+		Graphics::TextureFormat::TEXTURE_DEPTH, true
+	};
+
+	m_renderTarget.reset(Pi::renderer->CreateRenderTarget(rtDesc));
+	if (!m_renderTarget) Error("Error creating render target for model viewer.");
+
+	m_needsResize = false;
+}
+
+void ModelSpinner::SetModel(SceneGraph::Model *model, const SceneGraph::ModelSkin &skin, unsigned int pattern)
+{
+	m_model.reset(model->MakeInstance());
+	skin.Apply(m_model.get());
+	m_model->SetPattern(pattern);
+	m_shields.reset(new Shields(model));
+}
+
+void ModelSpinner::Render()
+{
+	PROFILE_SCOPED()
+	// Resizing a render target involves destroying the old one and creating a new one.
+	if (m_needsResize) CreateRenderTarget();
+	if (!m_renderTarget) return;
+
+	Graphics::Renderer *r = Pi::renderer;
+
+	Graphics::Renderer::StateTicket ticket(r);
+
+	r->SetRenderTarget(m_renderTarget.get());
+
+	r->SetClearColor(Color(0, 0, 0, 0));
+	r->ClearScreen();
+
+	const float fov = 45.f;
+	r->SetPerspectiveProjection(fov, m_size.x / m_size.y, 1.f, 10000.f);
+	r->SetTransform(matrix4x4f::Identity());
+	const auto &desc = m_renderTarget.get()->GetDesc();
+	r->SetViewport(0, 0, desc.width, desc.height);
+
+	r->SetLights(1, &m_light);
+
+	matrix4x4f rot = matrix4x4f::RotateXMatrix(m_rot.x);
+	rot.RotateY(m_rot.y);
+	const float dist = m_model->GetDrawClipRadius() / sinf(DEG2RAD(fov * 0.5f));
+	rot[14] = -dist;
+	m_model->Render(rot);
+	r->SetRenderTarget(0);
+}
+
+ImTextureID ModelSpinner::GetTextureID()
+{
+	// Upconvert a GLuint to uint64_t before casting to void *.
+	// This is downconverted to GLuint later by ImGui_ImplOpenGL3.
+	return reinterpret_cast<ImTextureID>(m_renderTarget.get()->GetColorTexture()->GetTextureID() | 0UL);
+}
+
+void ModelSpinner::SetSize(vector2d size)
+{
+	vector2f new_size = static_cast<vector2f>(size);
+	if (new_size == m_size) return;
+
+	m_size = new_size;
+	m_needsResize = true;
+}
+
+void ModelSpinner::DrawPiGui()
+{
+	ImVec2 size(m_size.x, m_size.y);
+
+	if (m_renderTarget) {
+		// Draw the image and stretch it over the available region.
+		// ImGui inverts the vertical axis to get top-left coordinates, so we need to invert our UVs to match.
+		ImGui::Image(GetTextureID(), size, ImVec2(0, 1), ImVec2(1, 0));
+	} else {
+		ImGui::Dummy(size);
+	}
+
+	const ImGuiIO &io = ImGui::GetIO();
+	if (ImGui::IsItemHovered(ImGuiHoveredFlags_None) && ImGui::IsMouseDown(0)) {
+		m_rot.x -= 0.005 * io.MouseDelta.y;
+		m_rot.y -= 0.005 * io.MouseDelta.x;
+		m_pauseTime = 1.0f;
+	} else if (m_pauseTime > 0.0) {
+		m_pauseTime = std::max(0.0f, m_pauseTime - io.DeltaTime);
+	} else {
+		m_rot.y += io.DeltaTime;
+	}
+}
+
+vector2d ModelSpinner::ModelSpaceToScreenSpace(vector3d modelSpaceVec)
+{
+	return { 0.0, 0.0 };
+}

--- a/src/pigui/ModelSpinner.h
+++ b/src/pigui/ModelSpinner.h
@@ -1,0 +1,76 @@
+// Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "RefCounted.h"
+#include "graphics/Light.h"
+
+namespace Graphics {
+	class RenderTarget;
+}
+
+// Forward declare this type from imgui.h
+using ImTextureID = void *;
+
+#include "Shields.h"
+#include "scenegraph/Model.h"
+#include "scenegraph/ModelSkin.h"
+
+// TODO:
+// - make this code reusable across multiple usecases (camera, rear-view mirror, UI preview, etc.)
+// - Render more than a single model, e.g. attachments / equipment / shields (a scene, scenegraph hierarchy, etc.)
+// - Add support for the usual post-processing chain (integrate with regular scene rendering)
+// In essence, we want to make the regular main-scene rendering code modular and able to render
+// arbitrary scenes to RTs that we can use in Pigui et. al.
+// For now we'll do a basic implementation here to move the model spinner functionality to Pigui.
+namespace PiGUI {
+	class ModelSpinner : public RefCounted {
+	public:
+		ModelSpinner();
+
+		// Set the ship we should be looking at.
+		void SetModel(SceneGraph::Model *model, const SceneGraph::ModelSkin &skin, unsigned int pattern);
+
+		// Called to draw the model to the render target.
+		void Render();
+
+		// Draws the model spinner widget and handles user interaction.
+		// Expected to be called during a Begin/End ImGui block.
+		// The modelspinner attempts to take all the available horizontal space
+		// in the window - use ImGui::BeginChild() to constrain the sizing.
+		void DrawPiGui();
+
+		// Set the size of the texture to render.
+		void SetSize(vector2d size);
+
+		// Retrieve the size of the rendered texture.
+		const vector2d GetSize() { return static_cast<vector2d>(m_size); }
+
+		// Transform a model-space location into a screen-space position.
+		vector2d ModelSpaceToScreenSpace(vector3d modelSpaceVec);
+
+	private:
+		std::unique_ptr<Graphics::RenderTarget> m_renderTarget;
+		std::unique_ptr<SceneGraph::Model> m_model;
+		SceneGraph::ModelSkin m_skin;
+		std::unique_ptr<Shields> m_shields;
+		Graphics::Light m_light;
+
+		void CreateRenderTarget();
+		ImTextureID GetTextureID();
+
+		// The size of the render target.
+		vector2f m_size;
+		// Do we need to resize the render target next frame?
+		bool m_needsResize;
+
+		// After the user manually rotates the model, hold that orientation for
+		// a second to let them look at it. Assumes Update() is called every
+		// frame while visible.
+		float m_pauseTime;
+
+		// The rotation of the model.
+		vector2f m_rot;
+	};
+} // namespace PiGUI

--- a/src/pigui/PiGuiLua.cpp
+++ b/src/pigui/PiGuiLua.cpp
@@ -3,6 +3,7 @@
 
 #include "PiGuiLua.h"
 #include "Face.h"
+#include "ModelSpinner.h"
 
 namespace PiGUI {
 	namespace Lua {
@@ -10,7 +11,8 @@ namespace PiGUI {
 		void Init()
 		{
 			LuaObject<PiGUI::Face>::RegisterClass();
+			LuaObject<PiGUI::ModelSpinner>::RegisterClass();
 		}
 
 	} // namespace Lua
-} // namespace GameUI
+} // namespace PiGUI


### PR DESCRIPTION
It's what it says on the tin. @fluffyfreak should probably review the rendering code and make sure I'm not doing something stupid, but otherwise this one's ready to go.

I've done something a little _special_ with the infoview - I've written it so that it's ready to be used in the new sidebar layout I've been hashing out with @nozmajner; all you've gotta do is turn `_OLD_LAYOUT` off and call it from a parent which handles the sizing. I'm going to further extend this with a few custom widgets to achieve the look of the prototypes, but that's for another PR.

@vakhoir on the first window opening, the tab-view wants to show the newUI tab underneath the pigui tab - I'm leaving you to figure out what's going wrong with that code.