### PR TITLE
Use Equatorial Radius when making the frame for a star

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -851,10 +851,10 @@ static void hitCallback(CollisionContact *c)
 	// collision response
 	assert(po1_isDynBody || po2_isDynBody);
 
-    // Bounce factor
-    const double coeff_rest = 0.35;
-    // Allow stop due to friction
-    const double coeff_slide = 0.700;
+	// Bounce factor
+	const double coeff_rest = 0.35;
+	// Allow stop due to friction
+	const double coeff_slide = 0.700;
 
 	if (po1_isDynBody && po2_isDynBody) {
 		DynamicBody *b1 = static_cast<DynamicBody *>(po1);
@@ -948,7 +948,7 @@ static void hitCallback(CollisionContact *c)
 
 		vector3d correction = std::min(std::max(c->depth - threshold, 0.0) * c->timestep, c->depth + threshold) * c->normal;
 
-		mover->SetPosition(mover->GetPosition() + correction );
+		mover->SetPosition(mover->GetPosition() + correction);
 
 		const float reduction = std::max(1 - coeff_slide * c->timestep, 0.0);
 		vector3d final_vel = linVel1 * (1 - coeff_slide * c->timestep) + force * invMass1;

--- a/src/galaxy/SystemBody.h
+++ b/src/galaxy/SystemBody.h
@@ -5,12 +5,12 @@
 #define SYSTEMBODY_H
 
 #include "Color.h"
-#include "gameconsts.h"
 #include "IterationProxy.h"
-#include "RefCounted.h"
 #include "Orbit.h"
-#include "galaxy/SystemPath.h"
+#include "RefCounted.h"
 #include "galaxy/RingStyle.h"
+#include "galaxy/SystemPath.h"
+#include "gameconsts.h"
 
 class StarSystem;
 
@@ -89,7 +89,7 @@ public:
 	IterationProxy<std::vector<SystemBody *>> GetChildren() { return MakeIterationProxy(m_children); }
 	const IterationProxy<const std::vector<SystemBody *>> GetChildren() const { return MakeIterationProxy(m_children); }
 
-	std::string GetName() const { return m_name; }
+	inline const std::string& GetName() const { return m_name; }
 	std::string GetAstroDescription() const;
 	const char *GetIcon() const;
 	BodyType GetType() const { return m_type; }
@@ -98,13 +98,25 @@ public:
 	bool IsCoOrbitalWith(const SystemBody *other) const; //this and other form a binary pair
 	bool IsCoOrbital() const; //is part of any binary pair
 	fixed GetRadiusAsFixed() const { return m_radius; }
-	double GetRadius() const
-	{ // polar radius
-		if (GetSuperType() <= SUPERTYPE_STAR)
+
+	// the aspect ratio adjustment is converting from equatorial to polar radius to account for ellipsoid bodies, used for calculating terrains etc
+	inline double GetRadius() const
+	{ 
+		if (GetSuperType() <= SUPERTYPE_STAR) // polar radius
 			return (m_radius.ToDouble() / m_aspectRatio.ToDouble()) * SOL_RADIUS;
 		else
 			return m_radius.ToDouble() * EARTH_RADIUS;
 	}
+
+	// the un-adjusted equatorial radius is necessary for calculating the radius of frames, see Space.cpp `MakeFrameFor`
+	inline double GetEquatorialRadius() const
+	{ 
+		if (GetSuperType() <= SUPERTYPE_STAR) // equatorial radius
+			return m_radius.ToDouble() * SOL_RADIUS;
+		else
+			return m_radius.ToDouble() * EARTH_RADIUS;
+	}
+
 	double GetAspectRatio() const { return m_aspectRatio.ToDouble(); }
 	fixed GetMassAsFixed() const { return m_mass; }
 	double GetMass() const
@@ -147,7 +159,7 @@ public:
 	void SetOrbitPlane(const matrix3x3d &orient) { m_orbit.SetPlane(orient); }
 
 	int GetAverageTemp() const { return m_averageTemp; }
-	std::string GetHeightMapFilename() const { return m_heightMapFilename; }
+	inline const std::string& GetHeightMapFilename() const { return m_heightMapFilename; }
 	unsigned int GetHeightMapFractal() const { return m_heightMapFractal; }
 
 	Uint32 GetSeed() const { return m_seed; }

--- a/src/galaxy/SystemBody.h
+++ b/src/galaxy/SystemBody.h
@@ -89,7 +89,7 @@ public:
 	IterationProxy<std::vector<SystemBody *>> GetChildren() { return MakeIterationProxy(m_children); }
 	const IterationProxy<const std::vector<SystemBody *>> GetChildren() const { return MakeIterationProxy(m_children); }
 
-	inline const std::string& GetName() const { return m_name; }
+	inline const std::string &GetName() const { return m_name; }
 	std::string GetAstroDescription() const;
 	const char *GetIcon() const;
 	BodyType GetType() const { return m_type; }
@@ -101,7 +101,7 @@ public:
 
 	// the aspect ratio adjustment is converting from equatorial to polar radius to account for ellipsoid bodies, used for calculating terrains etc
 	inline double GetRadius() const
-	{ 
+	{
 		if (GetSuperType() <= SUPERTYPE_STAR) // polar radius
 			return (m_radius.ToDouble() / m_aspectRatio.ToDouble()) * SOL_RADIUS;
 		else
@@ -110,7 +110,7 @@ public:
 
 	// the un-adjusted equatorial radius is necessary for calculating the radius of frames, see Space.cpp `MakeFrameFor`
 	inline double GetEquatorialRadius() const
-	{ 
+	{
 		if (GetSuperType() <= SUPERTYPE_STAR) // equatorial radius
 			return m_radius.ToDouble() * SOL_RADIUS;
 		else
@@ -159,7 +159,7 @@ public:
 	void SetOrbitPlane(const matrix3x3d &orient) { m_orbit.SetPlane(orient); }
 
 	int GetAverageTemp() const { return m_averageTemp; }
-	inline const std::string& GetHeightMapFilename() const { return m_heightMapFilename; }
+	inline const std::string &GetHeightMapFilename() const { return m_heightMapFilename; }
 	unsigned int GetHeightMapFractal() const { return m_heightMapFractal; }
 
 	Uint32 GetSeed() const { return m_seed; }


### PR DESCRIPTION
Calculate the Equatorial Radius for a body, use it when making the frame for a star.

This fixes #4402

@WKFO when testing this you can use your save game file **_BUT_** you will need to jump out of the system and back in again **because otherwise it just reloads the bad values from the save file**!

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

