### PR TITLE
Bug fix LuaFlags initialisation problem

### DIFF
--- a/src/pigui/LuaFlags.h
+++ b/src/pigui/LuaFlags.h
@@ -7,10 +7,11 @@
 #include <lua.hpp>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 template <typename FlagType>
 struct LuaFlags {
-	std::initializer_list<std::pair<const char *, FlagType>> LUT;
+	std::vector<std::pair<const char *, FlagType>> LUT;
 	std::string typeName;
 	int lookupTableRef = LUA_NOREF;
 


### PR DESCRIPTION
Only use the std::initializer_list as an initialiser, store values in a vector
fixes #4618 for me on Visual Studio 2019/2017

pinging @Web-eWorks 

