### PR TITLE
CI/appveyor: Don't re-install cmake

### DIFF
--- a/CI/appveyor/build.sh
+++ b/CI/appveyor/build.sh
@@ -11,7 +11,7 @@ set +v
 mkdir -p /c/projects/pioneer/build
 cd /c/projects/pioneer/build
 
-/mingw64/bin/cmake -G 'Unix Makefiles' \
+cmake -G 'Unix Makefiles' \
 	-DCMAKE_INSTALL_PREFIX="/c/Program Files/Pioneer" \
 	-DPIONEER_DATA_DIR="/c/Program Files/Pioneer/data" \
 	-DCMAKE_BUILD_TYPE:STRING=Release \
@@ -23,4 +23,4 @@ cd /c/projects/pioneer/build
 	-DUSE_SYSTEM_LIBLUA=OFF \
 	/c/projects/pioneer
 
-/mingw64/bin/cmake --build . --target install
+cmake --build . --target install

--- a/CI/appveyor/prepare.sh
+++ b/CI/appveyor/prepare.sh
@@ -7,7 +7,6 @@ export PATH=/mingw64/bin:$PATH
 
 # Install dependencies
 /c/msys64/usr/bin/pacman --noconfirm -Sy \
-	mingw-w64-x86_64-cmake \
 	mingw-w64-x86_64-SDL2 \
 	mingw-w64-x86_64-SDL2_image \
 	mingw-w64-x86_64-assimp \


### PR DESCRIPTION
The version that's already installed works fine. The version that is
available in the package manager doesn't, for some reason.

Fixes #4623.