### PR TITLE
Avoid passing PIONEER_PROFILER macro on command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ endif (MINGW)
 
 option(WITH_OBJECTVIEWER "Include the object viewer in the build" ON)
 option(WITH_DEVKEYS "Include various extra keybindings for dev functions" ON)
+option(WITH_PROFILER "Build pioneer with profiling support built-in." OFF)
 
 list(APPEND SRC_FOLDERS
 	src/
@@ -152,11 +153,6 @@ if (USE_SYSTEM_LIBLUA)
 		add_definitions(-DLUA_BUILD_AS_DLL)
 	endif (WIN32)
 endif (USE_SYSTEM_LIBLUA)
-
-option(PROFILER_ENABLED "Build pioneer with profiling support built-in." OFF)
-if (PROFILER_ENABLED)
-	add_compile_definitions(PIONEER_PROFILER=1)
-endif(PROFILER_ENABLED)
 
 if (MSVC)
 	include(msvc-defaults.cmake)

--- a/buildopts.h.cmakein
+++ b/buildopts.h.cmakein
@@ -7,5 +7,6 @@
 
 #cmakedefine01 WITH_OBJECTVIEWER
 #cmakedefine01 WITH_DEVKEYS
+#cmakedefine01 WITH_PROFILER
 
 #endif /* BUILDOPTS_H */

--- a/contrib/profiler/CMakeLists.txt
+++ b/contrib/profiler/CMakeLists.txt
@@ -2,6 +2,8 @@ project(profiler LANGUAGES CXX)
 
 set(BUILD_SHARED_LIBS OFF)
 
+include_directories(${CMAKE_BINARY_DIR})
+
 add_library(${PROJECT_NAME} Profiler.cpp)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/contrib/profiler/Profiler.h
+++ b/contrib/profiler/Profiler.h
@@ -1,7 +1,9 @@
 #ifndef __PROFILER_H__
 #define __PROFILER_H__
 
-#ifdef PIONEER_PROFILER
+#include <buildopts.h>
+
+#ifdef WITH_PROFILER
 #define __PROFILER_ENABLED__
 #endif
 

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -16,6 +16,7 @@
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
 #include "perlin.h"
+#include "profiler/Profiler.h"
 
 #include <SDL_stdinc.h>
 #include <iostream>

--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -24,6 +24,7 @@
 #include "graphics/RenderState.h"
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
+#include "profiler/Profiler.h"
 
 namespace {
 	static float lifetime = 0.1f;

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -12,6 +12,7 @@
 #include "Space.h"
 #include "galaxy/StarSystem.h"
 #include "graphics/TextureBuilder.h"
+#include "profiler/Profiler.h"
 
 using namespace Graphics;
 

--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -10,6 +10,7 @@
 #include "Planet.h"
 #include "SpaceStation.h"
 #include "collider/Geom.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/Animation.h"
 #include "scenegraph/ModelSkin.h"
 #include "scenegraph/SceneGraph.h"

--- a/src/CollMesh.cpp
+++ b/src/CollMesh.cpp
@@ -3,6 +3,7 @@
 
 #include "CollMesh.h"
 #include "scenegraph/Serializer.h"
+#include "profiler/Profiler.h"
 
 //This simply stores the collision GeomTrees
 //and AABB.

--- a/src/DeathView.cpp
+++ b/src/DeathView.cpp
@@ -9,6 +9,7 @@
 #include "ShipCpanel.h"
 #include "graphics/Graphics.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 DeathView::DeathView(Game *game) :
 	View(),

--- a/src/FaceParts.cpp
+++ b/src/FaceParts.cpp
@@ -5,6 +5,7 @@
 #include "FileSystem.h"
 #include "SDLWrappers.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 
 namespace {

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -8,6 +8,7 @@
 #include "Sfx.h"
 #include "Space.h"
 #include "collider/collider.h"
+#include "profiler/Profiler.h"
 
 Frame::Frame()
 {

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -31,6 +31,7 @@
 #include "WorldView.h"
 #include "galaxy/GalaxyGenerator.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 #include "ship/PlayerShipController.h"
 
 static const int s_saveVersion = 85;
@@ -44,7 +45,7 @@ Game::Game(const SystemPath &path, double time) :
 	m_requestedTimeAccel(TIMEACCEL_1X),
 	m_forceTimeAccel(false)
 {
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	std::string profilerPath;
 	FileSystem::userFiles.MakeDirectory("profiler");
 	FileSystem::userFiles.MakeDirectory("profiler/NewGame");
@@ -92,7 +93,7 @@ Game::Game(const SystemPath &path, double time) :
 	CreateViews();
 
 	EmitPauseState(IsPaused());
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	Profiler::dumphtml(profilerPath.c_str());
 #endif
 }
@@ -914,7 +915,7 @@ void Game::SaveGame(const std::string &filename, Game *game)
 		throw CouldNotOpenFileException();
 	}
 
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	std::string profilerPath;
 	FileSystem::userFiles.MakeDirectory("profiler");
 	FileSystem::userFiles.MakeDirectory("profiler/saving");
@@ -946,7 +947,7 @@ void Game::SaveGame(const std::string &filename, Game *game)
 		throw CouldNotWriteToFileException();
 	}
 
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	Profiler::dumphtml(profilerPath.c_str());
 #endif
 }

--- a/src/GasGiantJobs.h
+++ b/src/GasGiantJobs.h
@@ -10,6 +10,7 @@
 #include "graphics/Material.h"
 #include "graphics/opengl/GenGasGiantColourMaterial.h"
 #include "graphics/VertexBuffer.h"
+#include "profiler/Profiler.h"
 #include "terrain/Terrain.h"
 #include "vector3.h"
 

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -16,6 +16,7 @@
 #include "graphics/Material.h"
 #include "graphics/Renderer.h"
 #include "perlin.h"
+#include "profiler/Profiler.h"
 #include "vcacheopt/vcacheopt.h"
 #include <algorithm>
 #include <deque>

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -20,6 +20,7 @@
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
 #include "perlin.h"
+#include "profiler/Profiler.h"
 #include "vcacheopt/vcacheopt.h"
 #include <algorithm>
 #include <deque>

--- a/src/HudTrail.cpp
+++ b/src/HudTrail.cpp
@@ -7,6 +7,7 @@
 #include "Pi.h"
 #include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
+#include "profiler/Profiler.h"
 
 const float UPDATE_INTERVAL = 0.1f;
 const Uint16 MAX_POINTS = 100;

--- a/src/JobQueue.cpp
+++ b/src/JobQueue.cpp
@@ -3,6 +3,7 @@
 
 #include "JobQueue.h"
 #include "StringF.h"
+#include "profiler/Profiler.h"
 
 void Job::UnlinkHandle()
 {

--- a/src/JsonUtils.cpp
+++ b/src/JsonUtils.cpp
@@ -10,6 +10,9 @@
 #include "GZipFormat.h"
 #include "base64/base64.hpp"
 #include "utils.h"
+
+#include "profiler/Profiler.h"
+
 #include <cmath>
 
 extern "C" {

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -18,6 +18,7 @@
 #include "WorldView.h"
 #include "graphics/Graphics.h"
 #include "pigui/LuaFlags.h"
+#include "profiler/Profiler.h"
 #include "ship/PlayerShipController.h"
 #include "sound/Sound.h"
 #include "ui/Context.h"

--- a/src/LuaSerializer.cpp
+++ b/src/LuaSerializer.cpp
@@ -5,6 +5,7 @@
 #include "GameSaveError.h"
 #include "JsonUtils.h"
 #include "LuaObject.h"
+#include "profiler/Profiler.h"
 
 // every module can save one object. that will usually be a table.  we call
 // each serializer in turn and capture its return value we build a table like

--- a/src/LuaStarSystem.cpp
+++ b/src/LuaStarSystem.cpp
@@ -20,6 +20,7 @@
 #include "galaxy/GalaxyCache.h"
 #include "galaxy/Sector.h"
 #include "galaxy/StarSystem.h"
+#include "profiler/Profiler.h"
 
 /*
  * Class: StarSystem

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -9,6 +9,7 @@
 #include "Json.h"
 #include "graphics/RenderState.h"
 #include "graphics/TextureBuilder.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/FindNodeVisitor.h"
 #include "scenegraph/SceneGraph.h"
 #include "utils.h"

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -81,6 +81,7 @@
 #include "gameui/Lua.h"
 #include "libs.h"
 #include "pigui/PiGuiLua.h"
+#include "profiler/Profiler.h"
 #include "ship/PlayerShipController.h"
 #include "ship/ShipViewController.h"
 #include "sound/Sound.h"
@@ -136,7 +137,7 @@ bool Pi::doingMouseGrab;
 #if WITH_DEVKEYS
 bool Pi::showDebugInfo = false;
 #endif
-#if PIONEER_PROFILER
+#if WITH_PROFILER
 std::string Pi::profilerPath;
 bool Pi::doProfileSlow = false;
 bool Pi::doProfileOne = false;
@@ -435,7 +436,7 @@ void RegisterInputBindings()
 
 void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
 {
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	Profiler::reset();
 #endif
 
@@ -447,7 +448,7 @@ void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
 
 	FileSystem::Init();
 	FileSystem::userFiles.MakeDirectory(""); // ensure the config directory exists
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	FileSystem::userFiles.MakeDirectory("profiler");
 	profilerPath = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(), "profiler");
 #endif
@@ -773,7 +774,7 @@ void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
 	draw_progress(1.0f);
 
 	timer.Stop();
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	Profiler::dumphtml(profilerPath.c_str());
 #endif
 	Output("\n\nLoading took: %lf milliseconds\n", timer.millicycles());
@@ -899,7 +900,7 @@ void Pi::HandleKeyDown(SDL_Keysym *key)
 			Pi::showDebugInfo = !Pi::showDebugInfo;
 			break;
 
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 		case SDLK_p: // alert it that we want to profile
 			if (input.KeyState(SDLK_LSHIFT) || input.KeyState(SDLK_RSHIFT))
 				Pi::doProfileOne = true;
@@ -1359,7 +1360,7 @@ void Pi::MainLoop()
 	double accumulator = Pi::game->GetTimeStep();
 	Pi::gameTickAlpha = 0;
 
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	Profiler::reset();
 #endif
 
@@ -1564,7 +1565,7 @@ void Pi::MainLoop()
 		Pi::statSceneTris = 0;
 		Pi::statNumPatches = 0;
 
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 		const Uint32 profTicks = SDL_GetTicks();
 		if (Pi::doProfileOne || (Pi::doProfileSlow && (profTicks - newTicks) > 100)) { // slow: < ~10fps
 			Output("dumping profile data\n");
@@ -1589,7 +1590,7 @@ void Pi::MainLoop()
 			fwrite(sd.pixels.get(), sizeof(uint32_t) * Pi::renderer->GetWindowWidth() * Pi::renderer->GetWindowHeight(), 1, Pi::ffmpegFile);
 		}
 
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 		Profiler::reset();
 #endif
 	}

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -150,7 +150,7 @@ public:
 	/* Only use #if WITH_DEVKEYS */
 	static bool showDebugInfo;
 
-#if PIONEER_PROFILER
+#if WITH_PROFILER
 	static std::string profilerPath;
 	static bool doProfileSlow;
 	static bool doProfileOne;

--- a/src/PiGui.cpp
+++ b/src/PiGui.cpp
@@ -4,6 +4,7 @@
 #include "PiGui.h"
 #include "Pi.h"
 #include "graphics/opengl/TextureGL.h" // nasty, usage of GL is implementation specific
+#include "profiler/Profiler.h"
 // Use GLEW instead of GL3W.
 #define IMGUI_IMPL_OPENGL_LOADER_GLEW 1
 #include "imgui/examples/imgui_impl_opengl3.h"

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -12,6 +12,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/Texture.h"
 #include "perlin.h"
+#include "profiler/Profiler.h"
 
 #ifdef _MSC_VER
 #include "win32/WinMath.h"

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -24,6 +24,7 @@
 #include "graphics/RenderState.h"
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
+#include "profiler/Profiler.h"
 
 std::unique_ptr<Graphics::VertexArray> Projectile::s_sideVerts;
 std::unique_ptr<Graphics::VertexArray> Projectile::s_glowVerts;

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -22,6 +22,7 @@
 #include "graphics/Material.h"
 #include "graphics/Renderer.h"
 #include "gui/Gui.h"
+#include "profiler/Profiler.h"
 #include <algorithm>
 #include <sstream>
 #include <unordered_set>

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -9,6 +9,7 @@
 #include "Player.h"
 #include "Ship.h"
 #include "Space.h"
+#include "profiler/Profiler.h"
 
 Sensors::RadarContact::RadarContact() :
 	body(0),

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -19,6 +19,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
 #include "graphics/TextureBuilder.h"
+#include "profiler/Profiler.h"
 
 using namespace Graphics;
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -26,6 +26,7 @@
 #include "StringF.h"
 #include "WorldView.h"
 #include "graphics/TextureBuilder.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/Animation.h"
 #include "scenegraph/MatrixTransform.h"
 #include "ship/PlayerShipController.h"

--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -10,6 +10,7 @@
 #include "Player.h"
 #include "WorldView.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 ShipCockpit::ShipCockpit(const std::string &modelName) :
 	m_shipDir(0.0),

--- a/src/ShipCpanel.cpp
+++ b/src/ShipCpanel.cpp
@@ -15,6 +15,7 @@
 #include "UIView.h"
 #include "WorldView.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 // XXX duplicated in WorldView. should probably be a theme variable
 static const Color s_hudTextColor(0, 255, 0, 204);

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -20,6 +20,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 #include "sound/Sound.h"
 
 using namespace Graphics;

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -13,6 +13,7 @@
 #include "FileSystem.h"
 #include "Json.h"
 #include "Lang.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 #include <algorithm>
 

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -21,6 +21,7 @@
 #include "collider/collider.h"
 #include "galaxy/Galaxy.h"
 #include "graphics/Graphics.h"
+#include "profiler/Profiler.h"
 #include <algorithm>
 #include <functional>
 

--- a/src/SpaceStationType.cpp
+++ b/src/SpaceStationType.cpp
@@ -9,6 +9,7 @@
 #include "Pi.h"
 #include "Ship.h"
 #include "StringF.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/MatrixTransform.h"
 #include "scenegraph/Model.h"
 

--- a/src/SpeedLines.cpp
+++ b/src/SpeedLines.cpp
@@ -10,6 +10,7 @@
 #include "Ship.h"
 #include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
+#include "profiler/Profiler.h"
 
 // default values
 float SpeedLines::BOUNDS = 2000.f;

--- a/src/SystemInfoView.cpp
+++ b/src/SystemInfoView.cpp
@@ -17,6 +17,7 @@
 #include "galaxy/Polit.h"
 #include "graphics/Drawables.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 #include <functional>
 
 SystemInfoView::SystemInfoView(Game *game) :

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -20,6 +20,7 @@
 #include "graphics/Material.h"
 #include "graphics/Renderer.h"
 #include "graphics/TextureBuilder.h"
+#include "profiler/Profiler.h"
 #include <iomanip>
 #include <sstream>
 

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -21,6 +21,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/TextureBuilder.h"
 #include "matrix4x4.h"
+#include "profiler/Profiler.h"
 #include "ship/PlayerShipController.h"
 #include "sound/Sound.h"
 #include "ui/Align.h"

--- a/src/collider/BVHTree.cpp
+++ b/src/collider/BVHTree.cpp
@@ -3,6 +3,7 @@
 
 #include "BVHTree.h"
 #include "buildopts.h"
+#include "profiler/Profiler.h"
 #include <float.h>
 #include <stdio.h>
 

--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -5,6 +5,7 @@
 #include "../libs.h"
 #include "Geom.h"
 #include "GeomTree.h"
+#include "profiler/Profiler.h"
 
 /* volnode!!!!!!!!!!! */
 struct BvhNode {

--- a/src/collider/Geom.cpp
+++ b/src/collider/Geom.cpp
@@ -7,6 +7,7 @@
 #include "GeomTree.h"
 #include "collider.h"
 #include "CollisionContact.h"
+#include "profiler/Profiler.h"
 
 #include <float.h>
 

--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -5,6 +5,7 @@
 #include "../libs.h"
 #include "BVHTree.h"
 #include "Weld.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/Serializer.h"
 
 GeomTree::~GeomTree()

--- a/src/galaxy/Factions.cpp
+++ b/src/galaxy/Factions.cpp
@@ -6,6 +6,7 @@
 #include "galaxy/Galaxy.h"
 #include "galaxy/Sector.h"
 #include "galaxy/SystemPath.h"
+#include "profiler/Profiler.h"
 
 #include "enum_table.h"
 

--- a/src/galaxy/GalaxyCache.cpp
+++ b/src/galaxy/GalaxyCache.cpp
@@ -9,6 +9,7 @@
 #include "galaxy/Sector.h"
 #include "galaxy/StarSystem.h"
 #include "Pi.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 #include <utility>
 

--- a/src/galaxy/Sector.cpp
+++ b/src/galaxy/Sector.cpp
@@ -8,6 +8,7 @@
 
 #include "EnumStrings.h"
 #include "Factions.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 
 const float Sector::SIZE = 8.f;

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -14,6 +14,7 @@
 #include "Orbit.h"
 #include "StringF.h"
 #include "enum_table.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 #include <SDL_stdinc.h>
 #include <algorithm>

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -9,6 +9,7 @@
 #include "Json.h"
 #include "Lang.h"
 #include "LuaNameGen.h"
+#include "profiler/Profiler.h"
 #include "Sector.h"
 #include "utils.h"
 #include "Pi.h"

--- a/src/galaxy/SystemBody.cpp
+++ b/src/galaxy/SystemBody.cpp
@@ -7,6 +7,7 @@
 #include "EnumStrings.h"
 #include "AtmosphereParameters.h"
 #include "enum_table.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 
 SystemBody::SystemBody(const SystemPath &path, StarSystem *system) :

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -4,6 +4,7 @@
 #include "Drawables.h"
 
 #include "graphics/RenderState.h"
+#include "profiler/Profiler.h"
 #include "Texture.h"
 #include "TextureBuilder.h"
 

--- a/src/graphics/Frustum.cpp
+++ b/src/graphics/Frustum.cpp
@@ -3,6 +3,7 @@
 
 #include "Frustum.h"
 #include "Graphics.h"
+#include "profiler/Profiler.h"
 
 namespace Graphics {
 

--- a/src/graphics/VertexArray.cpp
+++ b/src/graphics/VertexArray.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "VertexArray.h"
+#include "profiler/Profiler.h"
 
 namespace Graphics {
 

--- a/src/graphics/opengl/GenGasGiantColourMaterial.cpp
+++ b/src/graphics/opengl/GenGasGiantColourMaterial.cpp
@@ -8,6 +8,7 @@
 #include "TextureGL.h"
 #include "galaxy/StarSystem.h"
 #include "graphics/Graphics.h"
+#include "profiler/Profiler.h"
 #include <sstream>
 
 namespace Graphics {

--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -7,6 +7,7 @@
 #include "StringF.h"
 #include "StringRange.h"
 #include "graphics/Graphics.h"
+#include "profiler/Profiler.h"
 
 #include <set>
 

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -16,6 +16,7 @@
 #include "graphics/Texture.h"
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
+#include "profiler/Profiler.h"
 
 #include "BillboardMaterial.h"
 #include "FresnelColourMaterial.h"
@@ -438,7 +439,8 @@ namespace Graphics {
 	void RendererOGL::CheckErrors(const char *func, const int line)
 	{
 		PROFILE_SCOPED()
-#ifndef PIONEER_PROFILER
+
+#if !WITH_PROFILER
 		GLenum err = glGetError();
 		if (err) {
 			// static-cache current err that sparked this

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -4,6 +4,7 @@
 #include "TextureGL.h"
 #include "RendererGL.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 #include <cassert>
 

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -3,6 +3,7 @@
 
 #include "graphics/opengl/VertexBufferGL.h"
 #include "graphics/VertexArray.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 
 namespace Graphics {

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -6,6 +6,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/gui/GuiButton.cpp
+++ b/src/gui/GuiButton.cpp
@@ -3,6 +3,7 @@
 
 #include "Gui.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 static const float BUTTON_SIZE = 16.f;
 

--- a/src/gui/GuiContainer.cpp
+++ b/src/gui/GuiContainer.cpp
@@ -5,6 +5,7 @@
 
 #include "Gui.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 #include <SDL_stdinc.h>
 

--- a/src/gui/GuiImage.cpp
+++ b/src/gui/GuiImage.cpp
@@ -5,6 +5,7 @@
 #include "GuiScreen.h"
 #include "graphics/TextureBuilder.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/gui/GuiImageButton.cpp
+++ b/src/gui/GuiImageButton.cpp
@@ -4,6 +4,7 @@
 #include "GuiImageButton.h"
 #include "Gui.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/gui/GuiImageRadioButton.cpp
+++ b/src/gui/GuiImageRadioButton.cpp
@@ -4,6 +4,7 @@
 #include "GuiImageRadioButton.h"
 #include "Gui.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/gui/GuiLabel.cpp
+++ b/src/gui/GuiLabel.cpp
@@ -4,6 +4,7 @@
 #include "Gui.h"
 
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/gui/GuiLabelSet.cpp
+++ b/src/gui/GuiLabelSet.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Gui.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/gui/GuiMeterBar.cpp
+++ b/src/gui/GuiMeterBar.cpp
@@ -4,6 +4,7 @@
 #include "Gui.h"
 
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 static const float METERBAR_PADDING = 5.0f;
 static const float METERBAR_BAR_HEIGHT = 8.0f;

--- a/src/gui/GuiMultiStateImageButton.cpp
+++ b/src/gui/GuiMultiStateImageButton.cpp
@@ -3,6 +3,7 @@
 
 #include "Gui.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 	MultiStateImageButton::MultiStateImageButton() :

--- a/src/gui/GuiRadioButton.cpp
+++ b/src/gui/GuiRadioButton.cpp
@@ -3,6 +3,7 @@
 
 #include "Gui.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 static const float BUTTON_SIZE = 16.f;
 

--- a/src/gui/GuiScreen.cpp
+++ b/src/gui/GuiScreen.cpp
@@ -4,6 +4,7 @@
 #include "Gui.h"
 
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 #include "text/TextSupport.h"
 #include "vector3.h" // for projection
 

--- a/src/gui/GuiTabbed.cpp
+++ b/src/gui/GuiTabbed.cpp
@@ -4,6 +4,7 @@
 #include "GuiTabbed.h"
 #include "Gui.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/gui/GuiTextEntry.cpp
+++ b/src/gui/GuiTextEntry.cpp
@@ -3,6 +3,7 @@
 
 #include "Gui.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 #include "text/TextSupport.h"
 #include "text/TextureFont.h"
 

--- a/src/gui/GuiTextLayout.cpp
+++ b/src/gui/GuiTextLayout.cpp
@@ -4,6 +4,7 @@
 #include "Gui.h"
 
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 #include "text/TextSupport.h"
 #include "utils.h"
 

--- a/src/gui/GuiTexturedQuad.cpp
+++ b/src/gui/GuiTexturedQuad.cpp
@@ -6,6 +6,7 @@
 #include "graphics/Material.h"
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"
+#include "profiler/Profiler.h"
 
 using namespace Graphics;
 

--- a/src/gui/GuiToggleButton.cpp
+++ b/src/gui/GuiToggleButton.cpp
@@ -3,6 +3,7 @@
 
 #include "Gui.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 static const float BUTTON_SIZE = 16.f;
 

--- a/src/gui/GuiToolTip.cpp
+++ b/src/gui/GuiToolTip.cpp
@@ -4,6 +4,7 @@
 #include "Gui.h"
 
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/gui/GuiVScrollBar.cpp
+++ b/src/gui/GuiVScrollBar.cpp
@@ -3,6 +3,7 @@
 
 #include "Gui.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 
 static const float SCROLLBAR_SIZE = 12.f;
 static const float BORDER = 2.f;

--- a/src/gui/GuiVScrollPortal.cpp
+++ b/src/gui/GuiVScrollPortal.cpp
@@ -4,6 +4,7 @@
 #include "Gui.h"
 
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 #include "vector2.h"
 
 static const float MINIMUM_HEIGHT = 100.0f;

--- a/src/gui/GuiWidget.cpp
+++ b/src/gui/GuiWidget.cpp
@@ -5,6 +5,7 @@
 
 #include "vector2.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 namespace Gui {
 

--- a/src/libs.h
+++ b/src/libs.h
@@ -61,8 +61,6 @@
 #include "RefCounted.h"
 #include "SmartPtr.h"
 
-#include "profiler/Profiler.h"
-
 #ifdef NDEBUG
 #define PiVerify(x) ((void)(x))
 #else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "galaxy/Galaxy.h"
 #include "galaxy/GalaxyGenerator.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 #include "versioningInfo.h"
 #include <cstdio>
@@ -25,7 +26,7 @@ enum RunMode {
 
 extern "C" int main(int argc, char **argv)
 {
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	Profiler::detect(argc, argv);
 #endif
 

--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -24,6 +24,7 @@
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
 #include "graphics/dummy/RendererDummy.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/BinaryConverter.h"
 #include "scenegraph/DumpVisitor.h"
 #include "scenegraph/FindNodeVisitor.h"
@@ -160,7 +161,7 @@ static FileSystem::FileSourceFS customDataDir(".");
 
 extern "C" int main(int argc, char **argv)
 {
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	Profiler::detect(argc, argv);
 #endif
 
@@ -203,7 +204,7 @@ start:
 	// Init here since we'll need it for both batch and RunCompiler modes.
 	FileSystem::Init();
 	FileSystem::userFiles.MakeDirectory(""); // ensure the config directory exists
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	FileSystem::userFiles.MakeDirectory("profiler");
 	const std::string profilerPath = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(), "profiler");
 #endif
@@ -323,7 +324,7 @@ start:
 		break;
 	}
 
-#ifdef PIONEER_PROFILER
+#if WITH_PROFILER
 	Profiler::dumphtml(profilerPath.c_str());
 #endif
 

--- a/src/pigui/ModelSpinner.cpp
+++ b/src/pigui/ModelSpinner.cpp
@@ -6,6 +6,7 @@
 #include "PiGui.h"
 #include "graphics/RenderTarget.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 
 #include <algorithm>
 

--- a/src/scenegraph/Animation.cpp
+++ b/src/scenegraph/Animation.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Animation.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/Model.h"
 #include <iostream>
 

--- a/src/scenegraph/Billboard.cpp
+++ b/src/scenegraph/Billboard.cpp
@@ -12,6 +12,7 @@
 #include "graphics/Stats.h"
 #include "graphics/VertexArray.h"
 #include "graphics/VertexBuffer.h"
+#include "profiler/Profiler.h"
 
 namespace SceneGraph {
 

--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -7,6 +7,7 @@
 #include "NodeVisitor.h"
 #include "Parser.h"
 #include "StringF.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/Animation.h"
 #include "scenegraph/Label3D.h"
 #include "scenegraph/MatrixTransform.h"

--- a/src/scenegraph/CollisionGeometry.cpp
+++ b/src/scenegraph/CollisionGeometry.cpp
@@ -6,6 +6,7 @@
 #include "NodeCopyCache.h"
 #include "NodeVisitor.h"
 #include "Serializer.h"
+#include "profiler/Profiler.h"
 
 namespace SceneGraph {
 

--- a/src/scenegraph/CollisionVisitor.cpp
+++ b/src/scenegraph/CollisionVisitor.cpp
@@ -7,6 +7,7 @@
 #include "Group.h"
 #include "MatrixTransform.h"
 #include "StaticGeometry.h"
+#include "profiler/Profiler.h"
 
 namespace SceneGraph {
 	CollisionVisitor::CollisionVisitor() :

--- a/src/scenegraph/Group.cpp
+++ b/src/scenegraph/Group.cpp
@@ -5,6 +5,7 @@
 #include "BaseLoader.h"
 #include "NodeCopyCache.h"
 #include "NodeVisitor.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 
 namespace SceneGraph {

--- a/src/scenegraph/LOD.cpp
+++ b/src/scenegraph/LOD.cpp
@@ -9,6 +9,7 @@
 #include "StringF.h"
 #include "graphics/Graphics.h"
 #include "graphics/VertexBuffer.h"
+#include "profiler/Profiler.h"
 
 namespace SceneGraph {
 

--- a/src/scenegraph/Label3D.cpp
+++ b/src/scenegraph/Label3D.cpp
@@ -7,6 +7,7 @@
 #include "graphics/RenderState.h"
 #include "graphics/VertexArray.h"
 #include "graphics/VertexBuffer.h"
+#include "profiler/Profiler.h"
 
 namespace SceneGraph {
 

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -13,6 +13,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
 #include "graphics/TextureBuilder.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 #include <assimp/material.h>
 #include <assimp/postprocess.h>

--- a/src/scenegraph/MatrixTransform.cpp
+++ b/src/scenegraph/MatrixTransform.cpp
@@ -7,6 +7,8 @@
 #include "NodeVisitor.h"
 #include "Serializer.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
+
 namespace SceneGraph {
 
 	MatrixTransform::MatrixTransform(Graphics::Renderer *r, const matrix4x4f &m) :

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -14,6 +14,7 @@
 #include "graphics/RenderState.h"
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
+#include "profiler/Profiler.h"
 #include "scenegraph/Animation.h"
 #include "scenegraph/MatrixTransform.h"
 #include "scenegraph/Label3D.h"

--- a/src/scenegraph/ModelNode.cpp
+++ b/src/scenegraph/ModelNode.cpp
@@ -3,6 +3,7 @@
 
 #include "ModelNode.h"
 #include "Model.h"
+#include "profiler/Profiler.h"
 
 namespace SceneGraph {
 

--- a/src/scenegraph/Parser.cpp
+++ b/src/scenegraph/Parser.cpp
@@ -5,6 +5,7 @@
 #include "FileSystem.h"
 #include "StringF.h"
 #include "StringRange.h"
+#include "profiler/Profiler.h"
 #include <sstream>
 
 namespace SceneGraph {

--- a/src/scenegraph/StaticGeometry.cpp
+++ b/src/scenegraph/StaticGeometry.cpp
@@ -11,6 +11,7 @@
 #include "graphics/Material.h"
 #include "graphics/RenderState.h"
 #include "graphics/Renderer.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 
 namespace SceneGraph {

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -11,6 +11,7 @@
 #include "graphics/Renderer.h"
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
+#include "profiler/Profiler.h"
 
 namespace SceneGraph {
 

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -5,6 +5,7 @@
 #include "LuaEvent.h"
 #include "Pi.h"
 #include "libs.h" //for clamp
+#include "profiler/Profiler.h"
 #include <map>
 
 namespace Sound {

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -9,6 +9,7 @@
 #include "graphics/VertexArray.h"
 #include "graphics/VertexBuffer.h"
 #include "libs.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 
 #ifdef __clang__

--- a/src/ui/Animation.cpp
+++ b/src/ui/Animation.cpp
@@ -2,6 +2,7 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Animation.h"
+#include "profiler/Profiler.h"
 
 namespace UI {
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -11,6 +11,7 @@
 #include "gui/Gui.h"
 #include "libs.h"
 #include "graphics/Graphics.h"
+#include "profiler/Profiler.h"
 #include <cmath>
 #include <cstdio>
 #include <sstream>
@@ -715,4 +716,25 @@ void hexdump(const unsigned char *buf, int len)
 
 		Output("\n");
 	}
+}
+
+MsgTimer::MsgTimer()
+{
+	mTimer = new Profiler::Timer();
+	mTimer->Start();
+}
+
+MsgTimer::~MsgTimer()
+{
+	delete mTimer;
+}
+
+void MsgTimer::Mark(const char *identifier)
+{
+	mTimer->SoftStop();
+
+	const double lastTiming = mTimer->avgms();
+
+	mTimer->SoftReset();
+	Output("(%lf) avgms in %s\n", lastTiming, identifier);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -44,22 +44,20 @@ void IndentedOutput(const char *format, ...) __attribute((format(printf, 1, 2)))
 void IndentIncrease();
 void IndentDecrease();
 
+namespace Profiler {
+	class Timer;
+};
+
 // Helper for timing functions with multiple stages
 // Used on a branch to help time loading.
 struct MsgTimer {
-	MsgTimer() { mTimer.Start(); }
-	~MsgTimer() {}
+	MsgTimer();
+	~MsgTimer();
 
-	void Mark(const char *identifier)
-	{
-		mTimer.SoftStop();
-		const double lastTiming = mTimer.avgms();
-		mTimer.SoftReset();
-		Output("(%lf) avgms in %s\n", lastTiming, identifier);
-	}
+	void Mark(const char *identifier);
 
 protected:
-	Profiler::Timer mTimer;
+	Profiler::Timer *mTimer;
 };
 
 std::string string_join(std::vector<std::string> &v, std::string sep);


### PR DESCRIPTION
Instead of adding -DPIONEER_PROFILER=1 on the command line, we now
define the WITH_PROFILER macro in buildopts.h.

Now, when toggling this option ON/OFF, only the source files using
buildopts.h will be recompiled (~13 files) instead of the whole project
(~390 files).

The option name changed from PROFILER_ENABLED to WITH_PROFILER to
follow the pattern of already existing options.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

