### PR TITLE
Update pioneer wrapper script to use CMake

### DIFF
--- a/pioneer
+++ b/pioneer
@@ -2,12 +2,20 @@
 # Executable wrapper script
 # Ensures the program is up-to-date, then hands over
 
-PROGRAM_NAME=$(basename $0)
+set -e
+cd "$(dirname "$0")"
+PROGRAM_NAME="$(basename "$0")"
 
-EXEC_BIN=src/$PROGRAM_NAME
-START_DIR=$(pwd)
-WORK_DIR=$(dirname $0)
+# Create build directory
+[ -d build ] || make build
+cd build
 
-cd $WORK_DIR
-make && exec $EXEC_BIN $*
-cd $START_DIR
+# Generate build files
+[ -f Makefile ] || cmake ..
+
+# Generate binaries
+make
+
+# Run main binary
+cd ..
+exec build/$PROGRAM_NAME "$@"

--- a/pioneer
+++ b/pioneer
@@ -7,15 +7,15 @@ cd "$(dirname "$0")"
 PROGRAM_NAME="$(basename "$0")"
 
 # Create build directory
-[ -d build ] || make build
-cd build
+[ -d build ] || mkdir build
 
 # Generate build files
-[ -f Makefile ] || cmake ..
+[ -f build/CMakeCache.txt ] || ./boostrap
 
 # Generate binaries
-make
+# Users of GNU Make can enable parallel builds on N cores by setting
+# MAKEFLAGS=-jN when calling this script.
+cmake --build build
 
 # Run main binary
-cd ..
 exec build/$PROGRAM_NAME "$@"


### PR DESCRIPTION
During the Autotools removal in #4511 and #4635, this file was somehow forgotten. Since it is more appealing to use than some opaque `(cd build && make) && build/pioneer`, this PR opts to keep the script and to adapt it to use CMake.

The tangentially related `bootstrap` file is left untouched.