### PR TITLE
Fix transparency on menu items

### DIFF
--- a/src/Color.h
+++ b/src/Color.h
@@ -131,15 +131,15 @@ struct Color4ub {
 	Uint8 GetLuminance() const;
 	void Shade(float factor)
 	{
-		r *= static_cast<Uint8>(1.0f - factor);
-		g *= static_cast<Uint8>(1.0f - factor);
-		b *= static_cast<Uint8>(1.0f - factor);
+		r = static_cast<Uint8>(r * (1.0f - factor));
+		g = static_cast<Uint8>(g * (1.0f - factor));
+		b = static_cast<Uint8>(b * (1.0f - factor));
 	}
 	void Tint(float factor)
 	{
-		r += static_cast<Uint8>((255.0f - r) * factor);
-		g += static_cast<Uint8>((255.0f - g) * factor);
-		b += static_cast<Uint8>((255.0f - b) * factor);
+		r = static_cast<Uint8>(r + (255.0f - r) * factor);
+		g = static_cast<Uint8>(g + (255.0f - g) * factor);
+		b = static_cast<Uint8>(b + (255.0f - b) * factor);
 	}
 
 	static const Color4ub BLACK;


### PR DESCRIPTION
Fix a bug introduced in c19aab4e4 ("Color.h: Fix conversion from float
to u8"). The order of operations was wrong.

The resulting behaviour was broken transparency on menu items, and probably other things.