### PR TITLE
Remove unused virtualization of Space and 'emplace_back' elements

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -31,7 +31,7 @@ void Space::BodyNearFinder::Prepare()
 	m_bodyDist.clear();
 
 	for (Body *b : m_space->GetBodies())
-		m_bodyDist.push_back(std::move(BodyDist(b, b->GetPositionRelTo(m_space->GetRootFrame()).Length())));
+		m_bodyDist.emplace_back(b, b->GetPositionRelTo(m_space->GetRootFrame()).Length());
 
 	std::sort(m_bodyDist.begin(), m_bodyDist.end());
 }
@@ -798,7 +798,7 @@ void Space::UpdateStarSystemCache(const SystemPath *here)
 
 void Space::GenBody(const double at_time, SystemBody *sbody, Frame *f, std::vector<vector3d> &posAccum)
 {
-	Body *b = 0;
+	Body *b = nullptr;
 
 	if (sbody->GetType() != SystemBody::TYPE_GRAVPOINT) {
 		if (sbody->GetSuperType() == SystemBody::SUPERTYPE_STAR) {

--- a/src/Space.h
+++ b/src/Space.h
@@ -30,7 +30,7 @@ public:
 	// initialise from save file
 	Space(Game *game, RefCountedPtr<Galaxy> galaxy, const Json &jsonObj, double at_time);
 
-	virtual ~Space();
+	~Space();
 
 	void ToJson(Json &jsonObj);
 


### PR DESCRIPTION
As title says, remove `virtual` on Space,
`emplace_back` in Prepare (thus no copy or move are needed),
and use `nullptr` instead of 0

...little by little...