### PR TITLE
Autodetect availability of FPE ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,14 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
+include(CheckSymbolExists)
+check_symbol_exists(feclearexcept "fenv.h" HAS_FECLEAREXCEPT)
+check_symbol_exists(feenableexcept "fenv.h" HAS_FEENABLEEXCEPT)
+check_symbol_exists(fedisableexcept "fenv.h" HAS_FEDISABLEEXCEPT)
+if (HAS_FECLEAREXCEPT AND HAS_FEENABLEEXCEPT AND HAS_FEDISABLEEXCEPT)
+	set(HAS_FPE_OPS ON)
+endif()
+
 if (NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
 		"Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel."

--- a/buildopts.h.cmakein
+++ b/buildopts.h.cmakein
@@ -7,5 +7,6 @@
 
 #cmakedefine01 WITH_OBJECTVIEWER
 #cmakedefine01 WITH_DEVKEYS
+#cmakedefine01 HAS_FPE_OPS
 
 #endif /* BUILDOPTS_H */

--- a/src/posix/OSPosix.cpp
+++ b/src/posix/OSPosix.cpp
@@ -3,6 +3,7 @@
 
 #include "FileSystem.h"
 #include "OS.h"
+#include "buildopts.h"
 #include <SDL.h>
 #include <fenv.h>
 #include <sys/time.h>
@@ -48,7 +49,7 @@ namespace OS {
 
 	void EnableFPE()
 	{
-#if defined(_GNU_SOURCE) && !defined(__APPLE__)
+#if HAS_FPE_OPS
 		// clear any outstanding exceptions before enabling, otherwise they'll
 		// trip immediately
 		feclearexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
@@ -58,7 +59,7 @@ namespace OS {
 
 	void DisableFPE()
 	{
-#if defined(_GNU_SOURCE) && !defined(__APPLE__)
+#if HAS_FPE_OPS
 		fedisableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
 #endif
 	}


### PR DESCRIPTION
Use CMake to detect the availability of feclearexcept, feenableexcept,
fedisableexcept.

Fixes #4645.