### PR TITLE
Fix VS CMake

### DIFF
--- a/CI/appveyor/msvc/prepare.sh
+++ b/CI/appveyor/msvc/prepare.sh
@@ -3,5 +3,6 @@
 # Exit immediately upon error
 set -e
 
-cd /c/projects/pioneer
+cd /c/projects
 git clone --depth 1 git://github.com/pioneerspacesim/pioneer-thirdparty
+cd /c/projects/pioneer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ list(APPEND SRC_FOLDERS
 )
 
 foreach (each IN LISTS SRC_FOLDERS)
+	file(GLOB header_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${each}/*.h)
+	list(APPEND HXX_FILES ${header_files})
 	file(GLOB src_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${each}/*.cpp)
 	list(APPEND CXX_FILES ${src_files})
 endforeach (each IN LISTS SRC_FOLDERS)
@@ -216,7 +218,7 @@ if (NOT USE_SYSTEM_LIBLUA)
 	include_directories(contrib/lua)
 endif (NOT USE_SYSTEM_LIBLUA)
 
-add_library(pioneerLib STATIC ${CXX_FILES})
+add_library(pioneerLib STATIC ${CXX_FILES} ${HXX_FILES})
 
 if (WIN32)
 	string(TIMESTAMP BUILD_YEAR "%Y")
@@ -289,7 +291,14 @@ if(MSVC)
 	target_compile_options(modelcompiler PRIVATE "/MP")
 	target_compile_options(savegamedump PRIVATE "/MP")
 	target_compile_options(pioneerLib PRIVATE "/MP")
-endif()
+
+	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+		COMMAND xcopy ..\\pioneer-thirdparty\\win32\\bin\\x64\\vs2017\\*.dll $(TargetDir)*.dll /Y /C
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		COMMENT "copy the dlls into the directory" 
+		VERBATIM
+	)
+endif(MSVC)
 
 if (CMAKE_CROSSCOMPILING)
 	find_program(MODELCOMPILER modelcompiler DOC "modelcompiler executable for the host")
@@ -306,7 +315,7 @@ if (NOT MSVC)
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		COMMENT "Optimizing models" VERBATIM
 	)
-endif (WIN32)
+endif (NOT MSVC)
 else (MODELCOMPILER)
 	message(WARNING "No modelcompiler provided, models won't be optimized!")
 endif(MODELCOMPILER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,8 +300,7 @@ endif (CMAKE_CROSSCOMPILING)
 if (MODELCOMPILER)
 	# Optimize the models.
 	# This really shouldn't be done inside the source tree...
-if (WIN32)
-else (WIN32)
+if (NOT MSVC)
 	add_custom_command(TARGET modelcompiler POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E env SDL_VIDEODRIVER=dummy ${MODELCOMPILER} -b inplace
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,13 @@ set_target_properties(${PROJECT_NAME} modelcompiler savegamedump pioneerLib PROP
 	CXX_EXTENSIONS ON
 )
 
+if(MSVC)
+	target_compile_options(${PROJECT_NAME} PRIVATE "/MP")
+	target_compile_options(modelcompiler PRIVATE "/MP")
+	target_compile_options(savegamedump PRIVATE "/MP")
+	target_compile_options(pioneerLib PRIVATE "/MP")
+endif()
+
 if (CMAKE_CROSSCOMPILING)
 	find_program(MODELCOMPILER modelcompiler DOC "modelcompiler executable for the host")
 else (CMAKE_CROSSCOMPILING)
@@ -293,11 +300,14 @@ endif (CMAKE_CROSSCOMPILING)
 if (MODELCOMPILER)
 	# Optimize the models.
 	# This really shouldn't be done inside the source tree...
+if (WIN32)
+else (WIN32)
 	add_custom_command(TARGET modelcompiler POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E env SDL_VIDEODRIVER=dummy ${MODELCOMPILER} -b inplace
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		COMMENT "Optimizing models" VERBATIM
 	)
+endif (WIN32)
 else (MODELCOMPILER)
 	message(WARNING "No modelcompiler provided, models won't be optimized!")
 endif(MODELCOMPILER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ if (MSVC)
 
 	# Use M_PI/M_E macros from math.h
 	add_definitions(-D_USE_MATH_DEFINES -DHAVE_M_PI)
+	
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 endif (MSVC)
 
 if (APPLE)
@@ -287,11 +290,6 @@ set_target_properties(${PROJECT_NAME} modelcompiler savegamedump pioneerLib PROP
 )
 
 if(MSVC)
-	target_compile_options(${PROJECT_NAME} PRIVATE "/MP")
-	target_compile_options(modelcompiler PRIVATE "/MP")
-	target_compile_options(savegamedump PRIVATE "/MP")
-	target_compile_options(pioneerLib PRIVATE "/MP")
-
 	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 		COMMAND xcopy ..\\pioneer-thirdparty\\win32\\bin\\x64\\vs2017\\*.dll $(TargetDir)*.dll /Y /C
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/msvc-defaults.cmake
+++ b/msvc-defaults.cmake
@@ -1,17 +1,17 @@
-set(FREETYPE_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/include/freetype)
-set(FREETYPE_LIBRARY ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/freetype271MT.lib)
+set(FREETYPE_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include/freetype)
+set(FREETYPE_LIBRARY ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/freetype271MT.lib)
 
-set(SDL2_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/include)
-set(SDL2_LIBRARIES ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/SDL2.lib;${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/SDL2main.lib)
+set(SDL2_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include)
+set(SDL2_LIBRARIES ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/SDL2.lib;${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/SDL2main.lib)
 
-set(SDL2_IMAGE_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/include)
-set(SDL2_IMAGE_LIBRARIES ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/SDL2_image.lib)
+set(SDL2_IMAGE_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include)
+set(SDL2_IMAGE_LIBRARIES ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/SDL2_image.lib)
 
-set(ASSIMP_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/include)
-set(ASSIMP_LIBRARIES ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/assimp-vc141-mt.lib)
+set(ASSIMP_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include)
+set(ASSIMP_LIBRARIES ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/assimp-vc141-mt.lib)
 
-set(VORBISFILE_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/include)
-set(VORBISFILE_LIBRARIES ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/libogg_static.lib;${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/libvorbis_static.lib;${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/libvorbisfile_static.lib)
+set(VORBISFILE_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include)
+set(VORBISFILE_LIBRARIES ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/libogg_static.lib;${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/libvorbis_static.lib;${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/libvorbisfile_static.lib)
 
-set(SIGCPP_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/include/sigc++-2.0)
-set(SIGCPP_LIBRARIES ${CMAKE_SOURCE_DIR}/pioneer-thirdparty/win32/lib/x64/vs2017/sigc-vc140-2_0.lib)
+set(SIGCPP_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include/sigc++-2.0)
+set(SIGCPP_LIBRARIES ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/sigc-vc140-2_0.lib)


### PR DESCRIPTION
Does a few things to get Visual Studio builds going.
- Enable multithreaded compilation for VS, 
- prevent it Optimizing the models per-build, 
- fix up the pioneer-thirdparty paths

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

