### PR TITLE
Use an equation in order to calculate HullTemperature

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -702,12 +702,12 @@ misc.missile_naval = EquipType.New({
 })
 misc.atmospheric_shielding = EquipType.New({
 	l10n_key="ATMOSPHERIC_SHIELDING", slots="atmo_shield", price=200,
-	capabilities={mass=1, atmo_shield=1},
+	capabilities={mass=1, atmo_shield=9},
 	purchasable=true, tech_level=3
 })
 misc.heavy_atmospheric_shielding = EquipType.New({
 	l10n_key="ATMOSPHERIC_SHIELDING_HEAVY", slots="atmo_shield", price=900,
-	capabilities={mass=2, atmo_shield=2},
+	capabilities={mass=2, atmo_shield=19},
 	purchasable=true, tech_level=5
 })
 misc.ecm_basic = EquipType.New({

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1039,11 +1039,7 @@ double Ship::GetHullTemperature() const
 	double dragGs = GetAtmosForce().Length() / (GetMass() * 9.81);
 	int atmo_shield_cap = 0;
 	const_cast<Ship *>(this)->Properties().Get(R"(atmo_shield_cap)", atmo_shield_cap);
-	if (atmo_shield_cap && GetWheelState() < 1.0) {
-		return dragGs / (150.0 * atmo_shield_cap);
-	} else {
-		return dragGs / 15.0;
-	}
+	return dragGs / (15.0 * (1.0 + atmo_shield_cap + (2.0 * (1.0 - m_wheelState))));
 }
 
 void Ship::SetAlertState(AlertState as)


### PR DESCRIPTION
It should behave as before, except that with wheels down the temperature is little more (it treble without any shielding).

From now on, an atmospheric shield value of 1 will halve the temperature,
which is quite straightforward.

EDIT: Ops, It seems actually "Atmospheric shields" automatically goes down if wheels are down...
I can do like that but I would ask if it's not too much: if a ship has wheels up and is travelling fast, then hitting the wrong button (landing gear) means that the ship will overheat and probably will explode. Is this right/wished?
