### PR TITLE
Add a maximum distance to the hyperspace exit calculation

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -382,10 +382,9 @@ void Space::GetHyperspaceExitParams(const SystemPath &source, const SystemPath &
 	const double max_orbit_vel = 100e3;
 	double dist = G * primary->GetSystemBody()->GetMass() /
 		(max_orbit_vel * max_orbit_vel);
-	dist = std::max(dist, primary->GetSystemBody()->GetRadius() * 10);
 
-	// ensure an absolut minimum and an absolut maximum distance
-	dist = Clamp(dist, 0.2 * AU, 100 * AU);
+	// ensure an absolute minimum and an absolute maximum distance
+	dist = Clamp(dist, 0.2 * AU, std::max(primary->GetSystemBody()->GetRadius() * 1.1, 100 * AU));
 
 	// point velocity vector along the line from source to dest,
 	// make exit position perpendicular to it,

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -384,8 +384,8 @@ void Space::GetHyperspaceExitParams(const SystemPath &source, const SystemPath &
 		(max_orbit_vel * max_orbit_vel);
 	dist = std::max(dist, primary->GetSystemBody()->GetRadius() * 10);
 
-	// ensure an absolut minimum distance
-	dist = std::max(dist, 0.2 * AU);
+	// ensure an absolut minimum and an absolut maximum distance
+	dist = Clamp(dist, 0.2 * AU, 100 * AU);
 
 	// point velocity vector along the line from source to dest,
 	// make exit position perpendicular to it,


### PR DESCRIPTION
This adds a maximum distance to the hyperspace exit calculation to ensure that the exit point isn't exorbitant far away. Maybe fixes #4479 .

