### PR TITLE
Improved UI resolution rescaling

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -87,6 +87,10 @@
     "description": "",
     "message": "Cancel"
   },
+  "CANNOT_SELL_ITEM": {
+    "description": "",
+    "message": "This item cannot be sold"
+  },
   "CAPACITY": {
     "description": "Capacity of ship to fit more equipment",
     "message": "Capacity"
@@ -1650,6 +1654,10 @@
   "STATION_ORBIT": {
     "description": "Information shown in the station loby",
     "message": "We are in a {orbit_period} day period orbit around {parent_body}."
+  },
+  "STATION_TECH_TOO_LOW": {
+    "description": "",
+    "message": "Station tech level too low to sell this item"
   },
   "STATUS": {
     "description": "",

--- a/data/libs/ui/PiImage.lua
+++ b/data/libs/ui/PiImage.lua
@@ -1,0 +1,40 @@
+-- Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Image = import 'PiGui.Modules.Image'
+local ui = import 'pigui/pigui.lua'
+local colors = ui.theme.colors
+
+local PiImage = {}
+
+function PiImage.New (filename)
+
+	local piImage = {
+		widget = Image.New(filename)
+	}
+
+	piImage.texture = {
+		id = piImage.widget.id,
+		size = piImage.widget.size,
+		xy = piImage.widget.size.x / piImage.widget.size.y,
+		uv = piImage.widget.uv
+	}
+
+	piImage.Draw = function(self, size)
+		if (size.x == 0 and size.y == 0) then size = self.texture.size
+		elseif (size.y == 0) then size.y = size.x / self.texture.xy
+		elseif (size.x == 0) then size.x = size.y * self.texture.xy
+		end
+
+		ui.image(self.texture.id, size, Vector2(0.0, 0.0), self.texture.uv, colors.white)
+	end
+
+	setmetatable(piImage, {
+		__index = PiImage,
+		class = "UI.PiImage",
+	})
+
+	return piImage
+end
+
+return PiImage

--- a/data/pigui/libs/market.lua
+++ b/data/pigui/libs/market.lua
@@ -175,6 +175,11 @@ local defaultFuncs = {
 local MarketWidget = {}
 
 function MarketWidget.New(id, title, config)
+    local defaultSizes = ui.rescaleUI({
+        windowPadding = Vector2(14, 14),
+        itemSpacing = Vector2(4, 9),
+    }, Vector2(1600, 900))
+
     local self = {
         id = id,
         popupMsgId = 'popupMsg' .. id,
@@ -184,10 +189,11 @@ function MarketWidget.New(id, title, config)
         itemTypes = config.itemTypes or {},
         columnCount = config.columnCount or 0,
         style = {
-            windowPadding = Vector2(math.ceil(18 * (ui.screenHeight / 1200)), math.ceil(18 * (ui.screenHeight / 1200))),
-            itemSpacing = config.itemSpacing or Vector2(math.ceil(6 * (ui.screenHeight / 1200)), math.ceil(12 * (ui.screenHeight / 1200))),
+            windowPadding = config.windowPadding or defaultSizes.windowPadding,
+            itemSpacing = config.itemSpacing or defaultSizes.itemSpacing,
             size = config.size or Vector2(ui.screenWidth / 2,0),
             headingFont = config.headingFont or ui.fonts.orbiteer.xlarge,
+            highlightColor = config.highlightColor or Color(0,63,112),
         },
         funcs = {
             displayItem = config.displayItem or defaultFuncs.displayItem,
@@ -238,7 +244,7 @@ function MarketWidget:render()
                 end)
             end
 
-            if self.selStart then ui.addRectFilled(self.selStart, self.selEnd, Color(0,63,112), 0, 0) end
+            if self.selStart then ui.addRectFilled(self.selStart, self.selEnd, self.style.highlightColor, 0, 0) end
 
             ui.columns(self.columnCount+1, self.id, false)
             self.funcs.initTable(self)

--- a/data/pigui/libs/market.lua
+++ b/data/pigui/libs/market.lua
@@ -1,0 +1,300 @@
+-- Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Game = import 'Game'
+local Lang = import 'Lang'
+
+local ui = import 'pigui/pigui.lua'
+
+local l = Lang.GetResource("ui-core")
+
+local sellPriceReduction = 0.8
+
+local defaultFuncs = {
+    -- can we display this item
+    displayItem = function (self, e)
+        return e.purchasable and e:IsValidSlot("cargo") and Game.system:IsCommodityLegal(e)
+    end,
+
+    -- how much of this item do we have in stock?
+    getStock = function (self, e)
+        return Game.player:GetDockedWith():GetEquipmentStock(e)
+    end,
+
+    -- what do we charge for this item if we are buying
+    getBuyPrice = function (self, e)
+        return Game.player:GetDockedWith():GetEquipmentPrice(e)
+    end,
+
+    -- what do we get for this item if we are selling
+    getSellPrice = function (self, e)
+        local basePrice = Game.player:GetDockedWith():GetEquipmentPrice(e)
+        if basePrice > 0 then
+            return sellPriceReduction * basePrice
+        else
+            return 1.0/sellPriceReduction * basePrice
+        end
+    end,
+
+    -- do something when a "buy" button is clicked
+    -- return true if the buy can proceed
+    onClickBuy = function (self, e)
+        return true -- allow buy
+    end,
+
+    buy = function(self, e)
+        if not self.funcs.onClickBuy(self, e) then return end
+
+        if self.funcs.getStock(self, e) <= 0 then
+            self.popupMsg = l.ITEM_IS_OUT_OF_STOCK
+            ui.openPopup(self.popupMsgId)
+            return
+        end
+
+        local player = Game.player
+
+        -- if this ship model doesn't support fitting of this equip:
+        if player:GetEquipSlotCapacity(e:GetDefaultSlot(player)) < 1 then
+            self.popupMsg = string.interp(l.NOT_SUPPORTED_ON_THIS_SHIP, {equipment = e:GetName(),})
+            ui.openPopup(self.popupMsgId)
+            return
+        end
+
+        -- add to first free slot
+        local slot
+        for i=1,#e.slots do
+            if player:GetEquipFree(e.slots[i]) > 0 then
+                slot = e.slots[i]
+                break
+            end
+        end
+
+        -- if ship maxed out in any valid slot for e
+        if not slot then
+            self.popupMsg = l.SHIP_IS_FULLY_EQUIPPED
+            ui.openPopup(self.popupMsgId)
+            return
+        end
+
+        -- if ship too heavy to support more
+        if player.freeCapacity < e.capabilities.mass then
+            self.popupMsg = l.SHIP_IS_FULLY_LADEN
+            ui.openPopup(self.popupMsgId)
+            return
+        end
+
+
+        local price = self.funcs.getBuyPrice(self, e)
+        if player:GetMoney() < self.funcs.getBuyPrice(self, e) then
+            self.popupMsg = l.YOU_NOT_ENOUGH_MONEY
+            ui.openPopup(self.popupMsgId)
+            return
+        end
+
+        assert(player:AddEquip(e, 1, slot) == 1)
+        player:AddMoney(-price)
+
+        self.funcs.bought(self, e)
+    end,
+
+    -- do something when we buy this commodity
+    bought = function (self, e)
+        Game.player:GetDockedWith():AddEquipmentStock(e, -1)
+    end,
+
+    -- do something when a "sell" button is clicked
+    -- return true if the buy can proceed
+    onClickSell = function (self, e)
+        return true -- allow sell
+    end,
+
+    sell = function(self, e)
+        if not self.funcs.onClickSell(self, e) then return end
+
+        local player = Game.player
+
+        -- remove from last free slot (reverse table)
+        local slot
+        for i=#e.slots,1,-1 do
+            if player:CountEquip(e, e.slots[i]) > 0 then
+                slot = e.slots[i]
+                break
+            end
+        end
+
+        player:RemoveEquip(e, 1, slot)
+        player:AddMoney(self.funcs.getSellPrice(self, e))
+
+        self.funcs.sold(self, e)
+    end,
+
+    -- do something when we sell this items
+    sold = function (self, e)
+        Game.player:GetDockedWith():AddEquipmentStock(e, 1)
+    end,
+
+    initTable = function(self)
+        ui.withFont(self.style.headingFont.name, self.style.headingFont.size, function()
+            ui.text(self.title)
+        end)
+
+        ui.columns(5, self.id, false)
+    end,
+
+    renderRow = function(self, item)
+
+    end,
+
+    onMouseOverItem = function(self, item)
+
+    end,
+
+    -- sort items in the market table
+    sortingFunction = function(e1,e2)
+        if e1:GetDefaultSlot() == e2:GetDefaultSlot() then
+            if e1:GetDefaultSlot() == "cargo" then
+                return e1:GetName() < e2:GetName()        -- cargo sorted on translated name
+            else
+                if e1:GetDefaultSlot():find("laser") then -- can be laser_front or _back
+                    if e1.l10n_key:find("PULSE") and e2.l10n_key:find("PULSE") or
+                            e1.l10n_key:find("PLASMA") and e2.l10n_key:find("PLASMA") then
+                        return e1.price < e2.price
+                    else
+                        return e1.l10n_key < e2.l10n_key
+                    end
+                else
+                    return e1.l10n_key < e2.l10n_key
+                end
+            end
+        else
+            return e1:GetDefaultSlot() < e2:GetDefaultSlot()
+        end
+    end
+}
+
+local MarketWidget = {}
+
+function MarketWidget.New(id, title, config)
+    local self = {
+        id = id,
+        popupMsgId = 'popupMsg' .. id,
+        popupMsg = '',
+        title = title,
+        items = {},
+        itemTypes = config.itemTypes or {},
+        columnCount = config.columnCount or 0,
+        style = {
+            windowPadding = Vector2(math.ceil(18 * (ui.screenHeight / 1200)), math.ceil(18 * (ui.screenHeight / 1200))),
+            itemSpacing = config.itemSpacing or Vector2(math.ceil(6 * (ui.screenHeight / 1200)), math.ceil(12 * (ui.screenHeight / 1200))),
+            size = config.size or Vector2(ui.screenWidth / 2,0),
+            headingFont = config.headingFont or ui.fonts.orbiteer.xlarge,
+        },
+        funcs = {
+            displayItem = config.displayItem or defaultFuncs.displayItem,
+            getStock = config.getStock or defaultFuncs.getStock,
+            getBuyPrice = config.getBuyPrice or defaultFuncs.getBuyPrice,
+            getSellPrice = config.getSellPrice or defaultFuncs.getSellPrice,
+            onClickBuy = config.onClickBuy or defaultFuncs.onClickBuy,
+            onClickSell = config.onClickSell or defaultFuncs.onClickSell,
+            buy = config.buy or defaultFuncs.buy,
+            bought = config.bought or defaultFuncs.bought,
+            sell = config.sell or defaultFuncs.sell,
+            sold = config.sold or defaultFuncs.sold,
+            initTable = config.initTable or defaultFuncs.initTable,
+            renderRow = config.renderRow or defaultFuncs.renderRow,
+            sortingFunction = config.sortingFunction or defaultFuncs.sortingFunction,
+            onMouseOverItem = config.onMouseOverItem or defaultFuncs.onMouseOverItem,
+        },
+    }
+
+    setmetatable(self, {
+        __index = MarketWidget,
+        class = "UI.MarketWidget",
+    })
+
+    return self
+end
+
+function MarketWidget:refresh()
+    self.items = {}
+
+    for i, type in pairs(self.itemTypes) do
+        for j, item in pairs(type) do
+            if self.funcs.displayItem(self, item) then
+                table.insert(self.items, item)
+            end
+        end
+    end
+
+    table.sort(self.items, self.funcs.sortingFunction)
+end
+
+function MarketWidget:render()
+    ui.withStyleVars({WindowPadding = self.style.windowPadding, ItemSpacing = self.style.itemSpacing}, function()
+        ui.child("Market##" .. self.id, self.style.size, {"AlwaysUseWindowPadding"}, function()
+            if(self.title) then
+                ui.withFont(self.style.headingFont.name, self.style.headingFont.size, function()
+                    ui.text(self.title)
+                end)
+            end
+
+            if self.selStart then ui.addRectFilled(self.selStart, self.selEnd, Color(0,63,112), 0, 0) end
+
+            ui.columns(self.columnCount+1, self.id, false)
+            self.funcs.initTable(self)
+
+            ui.text("")
+            ui.nextColumn()
+
+            local startPos
+            local endPos
+            local offset = ui.getWindowPos()
+            local selOffset = self.style.itemSpacing.y / 2
+            local windowSize = ui.getWindowSize() + offset
+            offset.y = offset.y - ui.getScrollY()
+
+            self.selStart = nil
+            self.selEnd = nil
+
+            for _, item in pairs(self.items) do
+                startPos = ui.getCursorPos() + offset
+
+                self.funcs.renderRow(self, item)
+
+                endPos = ui.getCursorPos()
+
+                ui.text("")
+                ui.nextColumn()
+
+                endPos.y = ui.getCursorPos().y
+                endPos = offset + endPos
+
+                if ui.isMouseHoveringRect(startPos, endPos, false) and startPos.y < windowSize.y then
+                    self.funcs.onMouseOverItem(self, item)
+
+                    self.selStart = startPos
+                    self.selEnd = endPos
+
+                    -- center the selection
+                    self.selStart.x = self.selStart.x - 4
+                    self.selStart.y = self.selStart.y - selOffset
+                    self.selEnd.y = self.selEnd.y - selOffset -- selEnd.y points to the beginning of the new row so to center the selection we also move it a bit higher
+                end
+            end
+
+            ui.columns(1, "", false)
+
+            ui.setNextWindowSize(Vector2(0, 0), "Always")
+            ui.popupModal(self.popupMsgId, {"NoTitleBar", "NoResize"}, function ()
+                ui.text(self.popupMsg)
+                ui.dummy(Vector2((ui.getContentRegion().x - 100) / 2, 0))
+                ui.sameLine()
+                if ui.button("OK", Vector2(100, 0)) then
+                    ui.closeCurrentPopup()
+                end
+            end)
+        end)
+    end)
+end
+
+return MarketWidget

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -179,5 +179,6 @@ InfoView:registerView({
 				end)
 			end)
 		end)
-	end
+	end,
+	refresh = function() end,
 })

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -88,7 +88,7 @@ local function shipStats()
 		{
 			l.HYPERSPACE_RANGE..":",
 			string.interp( l.N_LIGHT_YEARS_N_MAX, {
-				range    = string.format("%.1f",player.hyperspaceRange),
+				range    = string.format("%.1f",player:GetHyperspaceRange()),
 				maxRange = string.format("%.1f",player.maxHyperspaceRange)
 			})
 		},

--- a/data/pigui/modules/info-view/02-personal-info.lua
+++ b/data/pigui/modules/info-view/02-personal-info.lua
@@ -173,7 +173,8 @@ InfoView:registerView({
                 ui.child("PlayerView", Vector2(info_column_width - itemSpacing.x, 0), {}, drawPlayerView)
             end)
         end)
-    end
+    end,
+    refresh = function() end,
 })
 
 Event.Register("onGameEnd", function ()

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -13,6 +13,6 @@ InfoView:registerView({
     name = l.ECONOMY_TRADE,
     icon = ui.theme.icons.market,
     showView = false,
-    draw = function()
-    end
+    draw = function() end,
+    refresh = function() end,
 })

--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -13,6 +13,6 @@ InfoView:registerView({
     name = l.MISSIONS,
     icon = ui.theme.icons.star,
     showView = false,
-    draw = function()
-    end
+    draw = function() end,
+    refresh = function() end,
 })

--- a/data/pigui/modules/info-view/05-crew.lua
+++ b/data/pigui/modules/info-view/05-crew.lua
@@ -13,6 +13,6 @@ InfoView:registerView({
     name = l.CREW_ROSTER,
     icon = ui.theme.icons.rooster,
     showView = false,
-    draw = function()
-    end
+    draw = function() end,
+    refresh = function() end,
 })

--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -12,6 +12,6 @@ StationView:registerView({
 	name = l.LOBBY,
 	icon = ui.theme.icons.info,
 	showView = false,
-	draw = function()
-	end
+	draw = function() end,
+	refresh = function() end,
 })

--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -3,15 +3,275 @@
 
 local ui = import 'pigui/pigui.lua'
 local StationView = import 'pigui/views/station-view'
-local Lang = import 'Lang'
 
+local Game = import 'Game'
+local Rand = import 'Rand'
+local Format = import 'Format'
+local Equipment = import 'Equipment'
+local ShipDef = import 'ShipDef'
+local Character = import 'Character'
+local Comms = import 'Comms'
+
+local InfoFace = import 'ui/PiguiFace'
+local PiImage = import 'ui/PiImage'
+local drawTable = import 'pigui/libs/table.lua'
+
+local pionillium = ui.fonts.pionillium
+local orbiteer = ui.fonts.orbiteer
+local colors = ui.theme.colors
+local icons = ui.theme.icons
+
+local Lang = import 'Lang'
 local l = Lang.GetResource("ui-core")
+
+local itemSpacing = Vector2(math.ceil(6 * (ui.screenHeight / 1200)), math.ceil(12 * (ui.screenHeight / 1200)))
+local windowPadding = Vector2(math.ceil(18 * (ui.screenHeight / 1200)), math.ceil(18 * (ui.screenHeight / 1200)))
+local faceSize = Vector2(440,424) * ui.screenWidth / 1200
+local info_column_width = ui.screenWidth - faceSize.x
+local buttonSizeBase = Vector2(math.ceil(85 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
+local buttonFullRefuelSize = Vector2(buttonSizeBase.x*2 + itemSpacing.x, buttonSizeBase.y)
+local buttonLaunchSize = Vector2(buttonSizeBase.x*5, buttonSizeBase.y)
+local iconSize = Vector2(0, buttonSizeBase.y)
+
+local face;
+local shipDef
+local winPos = Vector2(0,0)
+
+local hyperdrive
+local hyperdrive_fuel
+local hydrogenIcon = PiImage.New("icons/goods/Hydrogen.png")
+local hyperdriveIcon = PiImage.New("icons/goods/Hydrogen.png")
+
+local popupMsg = ''
+local popupId = 'lobbyPopup'
+
+local requestLaunch = function ()
+	local crimes, fine = Game.player:GetCrimeOutstanding()
+	local station = Game.player:GetDockedWith()
+
+	if not Game.player:HasCorrectCrew() then
+		Comms.ImportantMessage(l.LAUNCH_PERMISSION_DENIED_CREW, station.label)
+		popupMsg = l.LAUNCH_PERMISSION_DENIED_CREW
+		ui.openPopup(popupId)
+	elseif fine > 0 then
+		Comms.ImportantMessage(l.LAUNCH_PERMISSION_DENIED_FINED, station.label)
+		popupMsg = l.LAUNCH_PERMISSION_DENIED_FINED
+		ui.openPopup(popupId)
+	elseif not Game.player:Undock() then
+		Comms.ImportantMessage(l.LAUNCH_PERMISSION_DENIED_BUSY, station.label)
+		popupMsg = l.LAUNCH_PERMISSION_DENIED_BUSY
+		ui.openPopup(popupId)
+	else
+		Game.SwitchView()
+	end
+end
+
+local refuelInternalTank = function (delta)
+	local station = Game.player:GetDockedWith()
+	local stock = station:GetEquipmentStock(Equipment.cargo.hydrogen)
+	local price = station:GetEquipmentPrice(Equipment.cargo.hydrogen)
+
+	if delta > 0 then
+		if stock == 0 then
+			popupMsg = l.ITEM_IS_OUT_OF_STOCK
+			ui.openPopup(popupId)
+			return
+		end
+
+		delta = math.clamp(delta, 0, 100 - Game.player.fuel)
+	else
+		delta = math.clamp(delta, -Game.player.fuel, 0)
+	end
+
+	local fuel = Game.player.fuel + delta
+	local mass = shipDef.fuelTankMass/100 * delta
+	local total = price * mass
+
+	if total > Game.player:GetMoney() then
+		total = Game.player:GetMoney()
+		mass = total / price
+		fuel = Game.player.fuel + mass * 100 / shipDef.fuelTankMass
+	end
+
+	if stock < mass then
+		mass = stock
+		total = price * mass
+		fuel = Game.player.fuel + mass * 100 / shipDef.fuelTankMass
+	end
+
+	Game.player:AddMoney(-total)
+	station:AddEquipmentStock(Equipment.cargo.hydrogen, -math.ceil(mass))
+	Game.player:SetFuelPercent(fuel)
+end
+
+local refuelHyperdrive = function (mass)
+	local station = Game.player:GetDockedWith()
+	local stock = station:GetEquipmentStock(hyperdrive_fuel)
+	local price = station:GetEquipmentPrice(hyperdrive_fuel)
+
+	if mass > 0 then
+		if stock == 0 then
+			popupMsg = l.ITEM_IS_OUT_OF_STOCK
+			ui.openPopup(popupId)
+			return
+		end
+
+		mass = math.clamp(mass, 0, Game.player.totalCargo - Game.player.usedCargo)
+	else
+		mass = math.clamp(mass, -Game.player:CountEquip(hyperdrive_fuel), 0)
+	end
+
+	local total = price * mass
+	if total > Game.player:GetMoney() then
+		mass = math.floor(Game.player:GetMoney() / price)
+		total = price * mass
+	end
+
+	if stock < mass then
+		mass = stock
+		total = price * mass
+	end
+
+	Game.player:AddMoney(-total)
+	if mass < 0 then
+		Game.player:RemoveEquip(hyperdrive_fuel, math.abs(mass), "cargo")
+	else
+		Game.player:AddEquip(hyperdrive_fuel, mass, "cargo")
+	end
+	station:AddEquipmentStock(hyperdrive_fuel, -mass)
+end
+
+local function drawPlayerInfo()
+	local station = Game.player:GetDockedWith()
+
+	if(not (station and shipDef)) then return end
+
+	local tech_certified
+
+	if station.techLevel == 11 then
+		tech_certified = l.TECH_CERTIFIED_MILITARY
+	else
+		tech_certified = string.interp(l.TECH_CERTIFIED, { tech_level = station.techLevel})
+	end
+
+	local orbit_period = station.path:GetSystemBody().orbitPeriod
+
+	local station_orbit_info = ""
+	if station.type == "STARPORT_ORBITAL" then
+		station_orbit_info =
+		string.interp(l.STATION_ORBIT, { orbit_period = string.format("%.2f", orbit_period),
+										 parent_body = station.path:GetSystemBody().parent.name})
+	end
+
+	ui.withFont(pionillium.medlarge.name, pionillium.large.size, function()
+		ui.withStyleVars({WindowPadding = windowPadding, ItemSpacing = itemSpacing}, function()
+			ui.child("PlayerShipFuel", Vector2(info_column_width, 0), {"AlwaysUseWindowPadding"}, function()
+				local curPos = ui.getCursorPos()
+				drawTable.withHeading(station.label, orbiteer.xlarge, {
+					{ tech_certified, "" },
+					{ station_orbit_info, "" },
+				})
+				ui.setCursorPos(Vector2(curPos.x, curPos.y + faceSize.y - buttonSizeBase.y*3 - itemSpacing.y*2))
+				ui.columns(4, 'thrusterFuel', false)
+				ui.setColumnWidth(0, buttonSizeBase.x + itemSpacing.x)
+				ui.setColumnWidth(1, buttonSizeBase.x + itemSpacing.x)
+				ui.setColumnWidth(2, (buttonSizeBase.x + itemSpacing.x)*4)
+				-- internal tank fuel
+				hydrogenIcon:Draw(iconSize)
+				ui.nextColumn()
+				ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+					ui.text(Format.Money(station:GetEquipmentPrice(Equipment.cargo.hydrogen)) .. "/t")
+					ui.text(Format.Money(station:GetEquipmentPrice(Equipment.cargo.hydrogen) * shipDef.fuelTankMass/100 * Game.player.fuel))
+				end)
+				ui.nextColumn()
+				if ui.coloredSelectedButton(l.REFUEL_FULL, buttonFullRefuelSize, false, colors.buttonBlue, nil, true) then refuelInternalTank(100) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("-10%", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelInternalTank(-10) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("+10%", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelInternalTank(10) end
+				ui.nextColumn()
+				local gaugePos = ui.getWindowPos() + ui.getCursorPos()
+				gaugePos.y = gaugePos.y + windowPadding.y + itemSpacing.y
+				local gaugeWidth = ui.getContentRegion().x
+				ui.gauge(gaugePos, Game.player.fuel, '', string.format(l.FUEL .. ": %dt \t" .. l.DELTA_V .. ": %d km/s",
+						shipDef.fuelTankMass/100 * Game.player.fuel, Game.player:GetRemainingDeltaV()/1000),
+						0, 100, icons.fuel,
+						colors.gaugeEquipmentMarket, '', gaugeWidth, 48, ui.fonts.pionillium.medlarge)
+				-- hyperspace fuel
+				ui.nextColumn()
+				hyperdriveIcon:Draw(iconSize)
+				ui.nextColumn()
+				ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+					ui.text(Format.Money(station:GetEquipmentPrice(hyperdrive_fuel)) .. "/t")
+					ui.text(Format.Money(station:GetEquipmentPrice(hyperdrive_fuel) * Game.player:CountEquip(hyperdrive_fuel)))
+				end)
+				ui.nextColumn()
+				if ui.coloredSelectedButton("-10t", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(-10) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("-1t", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(-1) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("+1t", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(1) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("+10t", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(10) end
+				ui.nextColumn()
+				gaugePos = ui.getWindowPos() + ui.getCursorPos()
+				gaugePos.y = gaugePos.y + windowPadding.y + itemSpacing.y
+				gaugeWidth = ui.getContentRegion().x
+				ui.gauge(gaugePos, Game.player:CountEquip(hyperdrive_fuel), '', string.format(l.FUEL .. ": %dt \t" .. l.HYPERSPACE_RANGE .. ": %d " .. l.LY,
+						Game.player:CountEquip(hyperdrive_fuel), Game.player:GetHyperspaceRange()),
+						0, Game.player.totalCargo - Game.player.usedCargo + Game.player:CountEquip(hyperdrive_fuel),
+						icons.hyperspace, colors.gaugeEquipmentMarket, '',
+						gaugeWidth, 48, ui.fonts.pionillium.medlarge)
+				curPos = ui.getCursorPos()
+				ui.columns(1, '', false)
+				ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size, function()
+					ui.dummy(Vector2(info_column_width - buttonLaunchSize.x - (windowPadding.x + itemSpacing.x)*2, 5))
+					ui.sameLine()
+					if ui.coloredSelectedButton(l.REQUEST_LAUNCH, buttonLaunchSize, false, colors.buttonBlue, nil, true) then requestLaunch() end
+				end)
+
+				ui.setNextWindowSize(Vector2(0, 0), "Always")
+				ui.popupModal(popupId, {"NoTitleBar", "NoResize"}, function ()
+					ui.text(popupMsg)
+					ui.dummy(Vector2((ui.getContentRegion().x - 100) / 2, 0))
+					ui.sameLine()
+					if ui.button("OK", Vector2(100, 0)) then
+						ui.closeCurrentPopup()
+					end
+				end)
+			end)
+
+			ui.sameLine()
+			ui.child("StationManager", Vector2(faceSize.x, 0), {"AlwaysUseWindowPadding"}, function ()
+				if(face ~= nil) then
+					face:Draw(faceSize)
+				end
+			end)
+		end)
+	end)
+end
 
 StationView:registerView({
 	id = "lobby",
 	name = l.LOBBY,
 	icon = ui.theme.icons.info,
-	showView = false,
-	draw = function() end,
-	refresh = function() end,
+	showView = true,
+	draw = function()
+		winPos = ui.getWindowPos();
+		info_column_width = ui.getContentRegion().x - faceSize.x - windowPadding.x
+		ui.child("StationLobby", Vector2(0, ui.getContentRegion().y - 100), {}, drawPlayerInfo)
+
+		StationView:shipSummary()
+	end,
+	refresh = function()
+		local station = Game.player:GetDockedWith()
+		shipDef = ShipDef[Game.player.shipId]
+		if(station) then
+			local rand = Rand.New(station.seed)
+			face = InfoFace.New(Character.New({ title = l.STATION_MANAGER }, rand), {windowPadding = windowPadding, itemSpacing = itemSpacing})
+			hyperdrive = table.unpack(Game.player:GetEquip("engine")) or nil
+			hyperdrive_fuel = hyperdrive and hyperdrive.fuel or Equipment.cargo.hydrogen
+			hyperdriveIcon = PiImage.New("icons/goods/" .. hyperdrive_fuel.icon_name .. ".png")
+		end
+	end,
 })

--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -24,14 +24,19 @@ local icons = ui.theme.icons
 local Lang = import 'Lang'
 local l = Lang.GetResource("ui-core")
 
-local itemSpacing = Vector2(math.ceil(6 * (ui.screenHeight / 1200)), math.ceil(12 * (ui.screenHeight / 1200)))
-local windowPadding = Vector2(math.ceil(18 * (ui.screenHeight / 1200)), math.ceil(18 * (ui.screenHeight / 1200)))
-local faceSize = Vector2(440,424) * ui.screenWidth / 1200
-local info_column_width = ui.screenWidth - faceSize.x
-local buttonSizeBase = Vector2(math.ceil(85 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
-local buttonFullRefuelSize = Vector2(buttonSizeBase.x*2 + itemSpacing.x, buttonSizeBase.y)
-local buttonLaunchSize = Vector2(buttonSizeBase.x*5, buttonSizeBase.y)
-local iconSize = Vector2(0, buttonSizeBase.y)
+local rescaleVector = ui.rescaleUI(Vector2(1, 1), Vector2(1600, 900), true)
+local widgetSizes = ui.rescaleUI({
+	itemSpacing = Vector2(4, 9),
+	windowPadding = Vector2(14, 14),
+	faceSize = Vector2(586,565),
+	buttonSizeBase = Vector2(64, 48),
+}, Vector2(1600, 900))
+
+widgetSizes.itemSpacing = Vector2(math.ceil(widgetSizes.itemSpacing.x), math.ceil(widgetSizes.itemSpacing.y))
+widgetSizes.windowPadding = Vector2(math.ceil(widgetSizes.windowPadding.x), math.ceil(widgetSizes.windowPadding.y))
+widgetSizes.buttonFullRefuelSize = Vector2(widgetSizes.buttonSizeBase.x*2 + widgetSizes.itemSpacing.x, widgetSizes.buttonSizeBase.y)
+widgetSizes.buttonLaunchSize = Vector2(widgetSizes.buttonSizeBase.x*5, widgetSizes.buttonSizeBase.y)
+widgetSizes.iconSize = Vector2(0, widgetSizes.buttonSizeBase.y)
 
 local face;
 local shipDef
@@ -141,6 +146,77 @@ local refuelHyperdrive = function (mass)
 	station:AddEquipmentStock(hyperdrive_fuel, -mass)
 end
 
+local function lobbyMenu(startPos)
+	local station = Game.player:GetDockedWith()
+	ui.setCursorPos(startPos)
+	ui.columns(4, 'thrusterFuel', false)
+	ui.setColumnWidth(0, widgetSizes.buttonSizeBase.x + widgetSizes.itemSpacing.x)
+	ui.setColumnWidth(1, widgetSizes.buttonSizeBase.x + widgetSizes.itemSpacing.x)
+	ui.setColumnWidth(2, (widgetSizes.buttonSizeBase.x + widgetSizes.itemSpacing.x)*4)
+	-- internal tank fuel
+	hydrogenIcon:Draw(widgetSizes.iconSize)
+	ui.nextColumn()
+	ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+		ui.text(Format.Money(station:GetEquipmentPrice(Equipment.cargo.hydrogen)) .. "/t")
+		ui.text(Format.Money(station:GetEquipmentPrice(Equipment.cargo.hydrogen) * shipDef.fuelTankMass/100 * Game.player.fuel))
+	end)
+	ui.nextColumn()
+	if ui.coloredSelectedButton(l.REFUEL_FULL, widgetSizes.buttonFullRefuelSize, false, colors.buttonBlue, nil, true) then refuelInternalTank(100) end
+	ui.sameLine()
+	if ui.coloredSelectedButton("-10%", widgetSizes.buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelInternalTank(-10) end
+	ui.sameLine()
+	if ui.coloredSelectedButton("+10%", widgetSizes.buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelInternalTank(10) end
+	ui.nextColumn()
+	local gaugePos = ui.getCursorScreenPos()
+	gaugePos.y = gaugePos.y + widgetSizes.buttonSizeBase.y/2
+	local gaugeWidth = ui.getContentRegion().x - widgetSizes.itemSpacing.x
+	ui.gauge(gaugePos, Game.player.fuel, '', string.format(l.FUEL .. ": %dt \t" .. l.DELTA_V .. ": %d km/s",
+			shipDef.fuelTankMass/100 * Game.player.fuel, Game.player:GetRemainingDeltaV()/1000),
+			0, 100, icons.fuel,
+			colors.gaugeEquipmentMarket, '', gaugeWidth, widgetSizes.buttonSizeBase.y, ui.fonts.pionillium.medlarge)
+	-- hyperspace fuel
+	ui.nextColumn()
+	hyperdriveIcon:Draw(widgetSizes.iconSize)
+	ui.nextColumn()
+	ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+		ui.text(Format.Money(station:GetEquipmentPrice(hyperdrive_fuel)) .. "/t")
+		ui.text(Format.Money(station:GetEquipmentPrice(hyperdrive_fuel) * Game.player:CountEquip(hyperdrive_fuel)))
+	end)
+	ui.nextColumn()
+	if ui.coloredSelectedButton("-10t", widgetSizes.buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(-10) end
+	ui.sameLine()
+	if ui.coloredSelectedButton("-1t", widgetSizes.buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(-1) end
+	ui.sameLine()
+	if ui.coloredSelectedButton("+1t", widgetSizes.buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(1) end
+	ui.sameLine()
+	if ui.coloredSelectedButton("+10t", widgetSizes.buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(10) end
+	ui.nextColumn()
+	gaugePos = ui.getCursorScreenPos()
+	gaugePos.y = gaugePos.y + widgetSizes.buttonSizeBase.y/2
+	ui.gauge(gaugePos, Game.player:CountEquip(hyperdrive_fuel), '', string.format(l.FUEL .. ": %dt \t" .. l.HYPERSPACE_RANGE .. ": %d " .. l.LY,
+			Game.player:CountEquip(hyperdrive_fuel), Game.player:GetHyperspaceRange()),
+			0, Game.player.totalCargo - Game.player.usedCargo + Game.player:CountEquip(hyperdrive_fuel),
+			icons.hyperspace, colors.gaugeEquipmentMarket, '',
+			gaugeWidth, widgetSizes.buttonSizeBase.y, ui.fonts.pionillium.medlarge)
+
+	ui.columns(1, '', false)
+	ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size, function()
+		ui.dummy(Vector2(ui.getContentRegion().x - widgetSizes.windowPadding.x/2 - widgetSizes.itemSpacing.x*2 - widgetSizes.buttonLaunchSize.x, 0))
+		ui.sameLine()
+		if ui.coloredSelectedButton(l.REQUEST_LAUNCH, widgetSizes.buttonLaunchSize, false, colors.buttonBlue, nil, true) then requestLaunch() end
+	end)
+
+	ui.setNextWindowSize(Vector2(0, 0), "Always")
+	ui.popupModal(popupId, {"NoTitleBar", "NoResize"}, function ()
+		ui.text(popupMsg)
+		ui.dummy(Vector2((ui.getContentRegion().x - 100*rescaleVector.x) / 2, 0))
+		ui.sameLine()
+		if ui.button("OK", Vector2(100*rescaleVector.x, 0)) then
+			ui.closeCurrentPopup()
+		end
+	end)
+end
+
 local function drawPlayerInfo()
 	local station = Game.player:GetDockedWith()
 
@@ -163,90 +239,40 @@ local function drawPlayerInfo()
 										 parent_body = station.path:GetSystemBody().parent.name})
 	end
 
-	ui.withFont(pionillium.medlarge.name, pionillium.large.size, function()
-		ui.withStyleVars({WindowPadding = windowPadding, ItemSpacing = itemSpacing}, function()
-			ui.child("PlayerShipFuel", Vector2(info_column_width, 0), {"AlwaysUseWindowPadding"}, function()
-				local curPos = ui.getCursorPos()
-				drawTable.withHeading(station.label, orbiteer.xlarge, {
-					{ tech_certified, "" },
-					{ station_orbit_info, "" },
-				})
-				ui.setCursorPos(Vector2(curPos.x, curPos.y + faceSize.y - buttonSizeBase.y*3 - itemSpacing.y*2))
-				ui.columns(4, 'thrusterFuel', false)
-				ui.setColumnWidth(0, buttonSizeBase.x + itemSpacing.x)
-				ui.setColumnWidth(1, buttonSizeBase.x + itemSpacing.x)
-				ui.setColumnWidth(2, (buttonSizeBase.x + itemSpacing.x)*4)
-				-- internal tank fuel
-				hydrogenIcon:Draw(iconSize)
-				ui.nextColumn()
-				ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
-					ui.text(Format.Money(station:GetEquipmentPrice(Equipment.cargo.hydrogen)) .. "/t")
-					ui.text(Format.Money(station:GetEquipmentPrice(Equipment.cargo.hydrogen) * shipDef.fuelTankMass/100 * Game.player.fuel))
-				end)
-				ui.nextColumn()
-				if ui.coloredSelectedButton(l.REFUEL_FULL, buttonFullRefuelSize, false, colors.buttonBlue, nil, true) then refuelInternalTank(100) end
-				ui.sameLine()
-				if ui.coloredSelectedButton("-10%", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelInternalTank(-10) end
-				ui.sameLine()
-				if ui.coloredSelectedButton("+10%", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelInternalTank(10) end
-				ui.nextColumn()
-				local gaugePos = ui.getWindowPos() + ui.getCursorPos()
-				gaugePos.y = gaugePos.y + windowPadding.y + itemSpacing.y
-				local gaugeWidth = ui.getContentRegion().x
-				ui.gauge(gaugePos, Game.player.fuel, '', string.format(l.FUEL .. ": %dt \t" .. l.DELTA_V .. ": %d km/s",
-						shipDef.fuelTankMass/100 * Game.player.fuel, Game.player:GetRemainingDeltaV()/1000),
-						0, 100, icons.fuel,
-						colors.gaugeEquipmentMarket, '', gaugeWidth, 48, ui.fonts.pionillium.medlarge)
-				-- hyperspace fuel
-				ui.nextColumn()
-				hyperdriveIcon:Draw(iconSize)
-				ui.nextColumn()
-				ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
-					ui.text(Format.Money(station:GetEquipmentPrice(hyperdrive_fuel)) .. "/t")
-					ui.text(Format.Money(station:GetEquipmentPrice(hyperdrive_fuel) * Game.player:CountEquip(hyperdrive_fuel)))
-				end)
-				ui.nextColumn()
-				if ui.coloredSelectedButton("-10t", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(-10) end
-				ui.sameLine()
-				if ui.coloredSelectedButton("-1t", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(-1) end
-				ui.sameLine()
-				if ui.coloredSelectedButton("+1t", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(1) end
-				ui.sameLine()
-				if ui.coloredSelectedButton("+10t", buttonSizeBase, false, colors.buttonBlue, nil, true) then refuelHyperdrive(10) end
-				ui.nextColumn()
-				gaugePos = ui.getWindowPos() + ui.getCursorPos()
-				gaugePos.y = gaugePos.y + windowPadding.y + itemSpacing.y
-				gaugeWidth = ui.getContentRegion().x
-				ui.gauge(gaugePos, Game.player:CountEquip(hyperdrive_fuel), '', string.format(l.FUEL .. ": %dt \t" .. l.HYPERSPACE_RANGE .. ": %d " .. l.LY,
-						Game.player:CountEquip(hyperdrive_fuel), Game.player:GetHyperspaceRange()),
-						0, Game.player.totalCargo - Game.player.usedCargo + Game.player:CountEquip(hyperdrive_fuel),
-						icons.hyperspace, colors.gaugeEquipmentMarket, '',
-						gaugeWidth, 48, ui.fonts.pionillium.medlarge)
-				curPos = ui.getCursorPos()
-				ui.columns(1, '', false)
-				ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size, function()
-					ui.dummy(Vector2(info_column_width - buttonLaunchSize.x - (windowPadding.x + itemSpacing.x)*2, 5))
-					ui.sameLine()
-					if ui.coloredSelectedButton(l.REQUEST_LAUNCH, buttonLaunchSize, false, colors.buttonBlue, nil, true) then requestLaunch() end
+	ui.withFont(pionillium.large.name, pionillium.large.size, function()
+		ui.withStyleVars({WindowPadding = widgetSizes.windowPadding, ItemSpacing = widgetSizes.itemSpacing}, function()
+			local conReg = ui.getContentRegion()
+			local infoColumnWidth = conReg.x - widgetSizes.faceSize.x - widgetSizes.windowPadding.x*3
+			local lobbyMenuHeight = widgetSizes.buttonSizeBase.y*3 + widgetSizes.itemSpacing.y*2
+			local lobbyMenuAtBottom = (conReg.y - widgetSizes.faceSize.y > lobbyMenuHeight + widgetSizes.windowPadding.x*2)
+
+			ui.child("Wrapper", Vector2(0, widgetSizes.faceSize.y + widgetSizes.windowPadding.y*2 + widgetSizes.itemSpacing.y), {}, function()
+				ui.child("PlayerShipFuel", Vector2(infoColumnWidth, 0), {"AlwaysUseWindowPadding"}, function()
+					local curPos = ui.getCursorPos()
+					drawTable.withHeading(station.label, orbiteer.xlarge, {
+						{ tech_certified, "" },
+						{ station_orbit_info, "" },
+					})
+
+					if not lobbyMenuAtBottom then
+						lobbyMenu(Vector2(curPos.x, curPos.y + widgetSizes.faceSize.y - lobbyMenuHeight))
+					end
 				end)
 
-				ui.setNextWindowSize(Vector2(0, 0), "Always")
-				ui.popupModal(popupId, {"NoTitleBar", "NoResize"}, function ()
-					ui.text(popupMsg)
-					ui.dummy(Vector2((ui.getContentRegion().x - 100) / 2, 0))
-					ui.sameLine()
-					if ui.button("OK", Vector2(100, 0)) then
-						ui.closeCurrentPopup()
+				ui.sameLine()
+				ui.child("StationManager", Vector2(0, 0), {"AlwaysUseWindowPadding", "NoScrollbar"}, function ()
+					if(face ~= nil) then
+						face:Draw(widgetSizes.faceSize)
 					end
 				end)
 			end)
 
-			ui.sameLine()
-			ui.child("StationManager", Vector2(faceSize.x, 0), {"AlwaysUseWindowPadding"}, function ()
-				if(face ~= nil) then
-					face:Draw(faceSize)
-				end
-			end)
+			if lobbyMenuAtBottom then
+				ui.child("LobbyMenuPanel", Vector2(0,0), {"AlwaysUseWindowPadding"}, function()
+					lobbyMenu(Vector2(0,0))
+				end)
+			end
+
 		end)
 	end)
 end
@@ -257,9 +283,8 @@ StationView:registerView({
 	icon = ui.theme.icons.info,
 	showView = true,
 	draw = function()
-		winPos = ui.getWindowPos();
-		info_column_width = ui.getContentRegion().x - faceSize.x - windowPadding.x
-		ui.child("StationLobby", Vector2(0, ui.getContentRegion().y - 100), {}, drawPlayerInfo)
+		widgetSizes.info_column_width = ui.getContentRegion().x - widgetSizes.faceSize.x - widgetSizes.windowPadding.x
+		ui.child("StationLobby", Vector2(0, ui.getContentRegion().y - StationView.style.height), {}, drawPlayerInfo)
 
 		StationView:shipSummary()
 	end,
@@ -268,7 +293,7 @@ StationView:registerView({
 		shipDef = ShipDef[Game.player.shipId]
 		if(station) then
 			local rand = Rand.New(station.seed)
-			face = InfoFace.New(Character.New({ title = l.STATION_MANAGER }, rand), {windowPadding = windowPadding, itemSpacing = itemSpacing})
+			face = InfoFace.New(Character.New({ title = l.STATION_MANAGER }, rand), {windowPadding = widgetSizes.windowPadding, itemSpacing = widgetSizes.itemSpacing})
 			hyperdrive = table.unpack(Game.player:GetEquip("engine")) or nil
 			hyperdrive_fuel = hyperdrive and hyperdrive.fuel or Equipment.cargo.hydrogen
 			hyperdriveIcon = PiImage.New("icons/goods/" .. hyperdrive_fuel.icon_name .. ".png")

--- a/data/pigui/modules/station-view/02-bulletinBoard.lua
+++ b/data/pigui/modules/station-view/02-bulletinBoard.lua
@@ -12,6 +12,6 @@ StationView:registerView({
 	name = l.BULLETIN_BOARD,
 	icon = ui.theme.icons.bbs,
 	showView = false,
-	draw = function()
-	end
+	draw = function() end,
+	refresh = function() end,
 })

--- a/data/pigui/modules/station-view/03-commodityMarket.lua
+++ b/data/pigui/modules/station-view/03-commodityMarket.lua
@@ -1,17 +1,334 @@
 -- Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local ui = import 'pigui/pigui.lua'
-local StationView = import 'pigui/views/station-view'
 local Lang = import 'Lang'
+local Game = import 'Game'
+local Format = import 'Format'
+local Equipment = import 'Equipment'
+local StationView = import 'pigui/views/station-view'
+local Market = import 'pigui/libs/market.lua'
+local PiImage = import 'ui/PiImage'
 
+local ui = import 'pigui/pigui.lua'
+local pionillium = ui.fonts.pionillium
+local orbiteer = ui.fonts.orbiteer
 local l = Lang.GetResource("ui-core")
+local colors = ui.theme.colors
+
+local buySellSize = Vector2(math.ceil(172 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
+local buttonSizeBase = Vector2(math.ceil(85 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
+local marketFont = pionillium.large
+local iconSize = Vector2(0, marketFont.size * 1.5)
+local vZero = Vector2(0,0)
+local smallButton = Vector2(math.ceil(85 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
+local bigButton = Vector2(math.ceil(124 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
+local confirmButtonSize = Vector2(math.ceil(512 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
+
+local commodityMarket
+local icons = {}
+local tradeModeBuy = true;
+local selectedItem
+local tradeAmount = 0
+local tradeText = ''
+local textColorDefault = Color(255, 255, 255)
+local textColorWarning = Color(255, 255, 0)
+local textColorError = Color(255, 0, 0)
+local tradeTextColor = textColorDefault
+
+local popupId = "commodityPopup"
+local popupMsg = "commodityPopup"
+
+-- calls to this function alter traded amount up or down, not absolute values
+local changeTradeAmount = function (delta)
+
+	--get price of commodity after applying local effects of import/export modifiers
+	local price = Game.player:GetDockedWith():GetEquipmentPrice(selectedItem)
+
+	--do you have any money?
+	local playerCash = Game.player:GetMoney()
+
+	--blank value, needs to be initialized or later on lua will complain
+	local stock
+
+	if tradeModeBuy then
+		stock = Game.player:GetDockedWith():GetEquipmentStock(selectedItem)
+		if stock == 0 then
+			tradeText = l.NONE_FOR_SALE_IN_THIS_STATION
+			tradeTextColor = textColorError
+			return
+		end
+		if price > playerCash then
+			tradeText = l.INSUFFICIENT_FUNDS
+			tradeTextColor = textColorWarning
+			return
+		end
+	else
+		stock = Game.player:CountEquip(selectedItem)
+	end
+
+	--dont alter tradeamount before checks have been made
+	local wantamount = tradeAmount + delta
+
+	--how much would the desired amount of merchandise cost?
+	local tradecost = wantamount * price
+
+	--we cant trade more units than we have in stock
+	if delta > 0 and wantamount > stock then --this line is why stock needs to be initialized up there. its possible to get here without stock being set (?)
+		wantamount = stock
+	end
+
+	--we dont trade in negative quantities
+	if wantamount < 0 then
+		wantamount = 0
+	end
+
+	--another empty initialized
+	tradeText = ''
+	if tradeModeBuy then
+		local playerfreecargo = Game.player.totalCargo - Game.player.usedCargo
+		if tradecost > playerCash then
+			wantamount = math.floor(playerCash / price)
+		end
+		local tradecargo = selectedItem.capabilities.mass * wantamount
+		if playerfreecargo < tradecargo then
+			wantamount = math.floor(playerfreecargo / selectedItem.capabilities.mass)
+		end
+		tradeText = l.MARKET_BUYLINE
+	else --mode = sell
+		--if market price is negative make sure player wont go below zero credits after the deal
+		if (playerCash + tradecost) < 0 then
+			wantamount = tradeAmount --kludge, ignore the delta unless player has finances to cover the deal
+			--if player starts at 0 quantity, presses +100 to "sell" radioactives but only has
+			--enough credits to sell 5, this kludge will ignore the +100 completely
+			--todo: change amount to 5 instead
+		end
+		tradeText = l.MARKET_SELLINE
+	end
+	--wantamount is now checked and modified to a safe bounded amount
+	tradeAmount = wantamount
+
+	--current cost of market order if user confirms the deal
+	tradecost = tradeAmount * price
+
+	--its possible to get to this line without tradetext being initialized unless done 30 rows up
+	tradeText = string.interp(tradeText,{ amount = string.format("%d", tradeAmount), price = Format.Money(tradecost)})
+	tradeTextColor = textColorDefault
+end
+
+--player clicked confirm purchase button
+local doBuy = function ()
+	local price = Game.player:GetDockedWith():GetEquipmentPrice(selectedItem)
+	local stock = Game.player:GetDockedWith():GetEquipmentStock(selectedItem)
+	local playerfreecargo = Game.player.totalCargo - Game.player.usedCargo
+	local orderAmount = price * tradeAmount
+
+	--check cash (should never happen since trade amount buttons wont let it happen)
+	if orderAmount > Game.player:GetMoney() then
+		popupMsg = l.YOU_NOT_ENOUGH_MONEY
+		ui.openPopup(popupId)
+		return
+	end
+
+	--check stock
+	if tradeAmount > stock then
+		popupMsg = l.ITEM_IS_OUT_OF_STOCK
+		ui.openPopup(popupId)
+		return
+	end
+
+	--check cargo limit
+	local tradecargo = selectedItem.capabilities.mass * tradeAmount
+	if playerfreecargo < tradecargo then
+		popupMsg = l.SHIP_IS_FULLY_LADEN
+		ui.openPopup(popupId)
+		return
+	end
+
+	--all checks passed
+	assert(Game.player:AddEquip(selectedItem, tradeAmount, "cargo") == tradeAmount)
+	Game.player:AddMoney(-orderAmount) --grab the money
+	Game.player:GetDockedWith():AddEquipmentStock(selectedItem, -tradeAmount)
+	changeTradeAmount(-tradeAmount) --reset the trade amount
+
+	--update market rows
+	tradeAmount = 0;
+	changeTradeAmount(0) --update trade amount text
+	commodityMarket:refresh() --rows needs to be recalculated since now the amounts in stock have changed
+end
+
+--player clicked the confirm sale button
+local doSell = function ()
+	local price = Game.player:GetDockedWith():GetEquipmentPrice(selectedItem)
+	local orderamount = price * tradeAmount
+
+	--if commodity price is negative (radioactives, garbage), player needs to have enough cash
+	Game.player:RemoveEquip(selectedItem, tradeAmount, "cargo")
+	Game.player:AddMoney(orderamount) --grab the money
+	Game.player:GetDockedWith():AddEquipmentStock(selectedItem, tradeAmount)
+	changeTradeAmount(-tradeAmount) --reset the trade amount
+
+	--if player sold all his cargo, switch to buy panel
+	if Game.player:CountEquip(selectedItem) == 0 then tradeModeBuy = true end
+
+	--update market rows
+	tradeAmount = 0;
+	changeTradeAmount(0) --update trade amount text
+	commodityMarket:refresh() --rows needs to be recalculated since now the amounts in stock have changed
+end
+
+
+local tradeMenu = function()
+	if(selectedItem) then
+		ui.withStyleVars({WindowPadding = commodityMarket.style.windowPadding, ItemSpacing = commodityMarket.style.itemSpacing}, function()
+			ui.child("TradeMenu", Vector2(ui.screenWidth / 2,0), {"AlwaysUseWindowPadding"}, function()
+				if(ui.coloredSelectedButton(l.BUY, buySellSize, tradeModeBuy, colors.buttonBlue, nil, true)) then
+					tradeModeBuy = true
+					changeTradeAmount(-tradeAmount)
+				end
+				ui.sameLine()
+				if(ui.coloredSelectedButton(l.SELL, buySellSize, not tradeModeBuy, colors.buttonBlue, nil, true)) then
+					tradeModeBuy = false
+					changeTradeAmount(-tradeAmount)
+				end
+
+				ui.text('')
+				local bottomHalf = ui.getCursorPos()
+				bottomHalf.y = bottomHalf.y + ui.getContentRegion().y/1.65
+				if(icons[selectedItem.icon_name] == nil) then
+					icons[selectedItem.icon_name] = PiImage.New("icons/goods/".. selectedItem.icon_name ..".png")
+				end
+
+				ui.columns(2, "tradeMenuItemTitle", false)
+				ui.setColumnWidth(0, buttonSizeBase.x)
+				icons[selectedItem.icon_name]:Draw(iconSize)
+				ui.nextColumn()
+				ui.withStyleVars({ItemSpacing = commodityMarket.style.itemSpacing/2}, function()
+					ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size, function()
+						ui.dummy(vZero)
+						ui.text(selectedItem:GetName())
+					end)
+				end)
+				ui.columns(1, "", false)
+				ui.text('')
+
+				ui.textWrapped(selectedItem:GetDescription())
+
+				ui.setCursorPos(bottomHalf)
+				if ui.coloredSelectedButton("-100", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-100) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("-10", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-10) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("-1", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-1) end
+				ui.sameLine()
+				if ui.coloredSelectedButton(l.RESET, bigButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-tradeAmount) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("+1", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(1) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("+10", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(10) end
+				ui.sameLine()
+				if ui.coloredSelectedButton("+100", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(100) end
+
+				ui.dummy(commodityMarket.style.itemSpacing/2)
+				ui.withStyleColors({["Text"] = tradeTextColor }, function()
+					ui.withFont(pionillium.xlarge.name, pionillium.xlarge.size, function()
+						ui.text(tradeText)
+					end)
+				end)
+
+				ui.setCursorPos(ui.getCursorPos() - Vector2(0, confirmButtonSize.y - commodityMarket.style.windowPadding.y - ui.getContentRegion().y))
+				ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size, function()
+					if ui.coloredSelectedButton(tradeModeBuy and l.CONFIRM_PURCHASE or l.CONFIRM_SALE, confirmButtonSize, false, colors.buttonBlue, nil, true) then
+						if tradeModeBuy then doBuy()
+						else doSell() end
+					end
+				end)
+
+				ui.setNextWindowSize(Vector2(0, 0), "Always")
+				ui.popupModal(popupId, {"NoTitleBar", "NoResize"}, function ()
+					ui.text(popupMsg)
+					ui.dummy(Vector2((ui.getContentRegion().x - 100) / 2, 0))
+					ui.sameLine()
+					if ui.button("OK", Vector2(100, 0)) then
+						ui.closeCurrentPopup()
+					end
+				end)
+			end)
+		end)
+	end
+end
+
+commodityMarket = Market.New("EquipmentMarket", false, {
+	itemTypes = { Equipment.cargo },
+	columnCount = 5,
+	initTable = function(self)
+		ui.setColumnWidth(0, buttonSizeBase.x)
+		ui.setColumnWidth(1, self.style.size.x / 2 - 50)
+
+		ui.text('')
+		ui.nextColumn()
+		ui.text(l.NAME_OBJECT)
+		ui.nextColumn()
+		ui.text(l.PRICE)
+		ui.nextColumn()
+		ui.text(l.IN_STOCK)
+		ui.nextColumn()
+		ui.text(l.CARGO)
+		ui.nextColumn()
+	end,
+	renderRow = function(self, item)
+		if(icons[item.icon_name] == nil) then
+			icons[item.icon_name] = PiImage.New("icons/goods/".. item.icon_name ..".png")
+		end
+		icons[item.icon_name]:Draw(iconSize)
+		ui.nextColumn()
+		ui.withStyleVars({ItemSpacing = (self.style.itemSpacing / 2)}, function()
+			ui.dummy(vZero)
+			ui.text(item:GetName())
+			ui.nextColumn()
+			ui.dummy(vZero)
+			ui.text(Format.Money(self.funcs.getBuyPrice(self, item)))
+			ui.nextColumn()
+			ui.dummy(vZero)
+			ui.text(self.funcs.getStock(self, item))
+			ui.nextColumn()
+			ui.dummy(vZero)
+			local n = Game.player:CountEquip(item)
+			ui.text(n > 0 and n or '')
+		end)
+		ui.nextColumn()
+	end,
+
+	displayItem = function (s, e) return e.purchasable and e:IsValidSlot("cargo") and Game.system:IsCommodityLegal(e) end,
+	onMouseOverItem = function(s, e)
+		if ui.isMouseClicked(0) and s.funcs.onClickBuy(e) then
+			selectedItem = e
+			tradeModeBuy = true
+			changeTradeAmount(-tradeAmount)
+			s:refresh()
+		end
+	end
+})
+
+local function drawCommoditytView()
+	ui.withFont(marketFont.name, marketFont.size, function()
+
+		ui.child("commodityMarketContainer", Vector2(0, ui.getContentRegion().y - 100), {}, function()
+			commodityMarket:render()
+			ui.sameLine()
+			tradeMenu()
+		end)
+
+		StationView:shipSummary()
+	end)
+end
 
 StationView:registerView({
 	id = "commodityMarket",
 	name = l.COMMODITY_MARKET,
 	icon = ui.theme.icons.market,
-	showView = false,
-	draw = function() end,
-	refresh = function() end,
+	showView = true,
+	draw = drawCommoditytView,
+	refresh = function()
+		commodityMarket:refresh()
+	end,
 })

--- a/data/pigui/modules/station-view/03-commodityMarket.lua
+++ b/data/pigui/modules/station-view/03-commodityMarket.lua
@@ -12,6 +12,6 @@ StationView:registerView({
 	name = l.COMMODITY_MARKET,
 	icon = ui.theme.icons.market,
 	showView = false,
-	draw = function()
-	end
+	draw = function() end,
+	refresh = function() end,
 })

--- a/data/pigui/modules/station-view/03-commodityMarket.lua
+++ b/data/pigui/modules/station-view/03-commodityMarket.lua
@@ -15,14 +15,16 @@ local orbiteer = ui.fonts.orbiteer
 local l = Lang.GetResource("ui-core")
 local colors = ui.theme.colors
 
-local buySellSize = Vector2(math.ceil(172 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
-local buttonSizeBase = Vector2(math.ceil(85 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
-local marketFont = pionillium.large
-local iconSize = Vector2(0, marketFont.size * 1.5)
 local vZero = Vector2(0,0)
-local smallButton = Vector2(math.ceil(85 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
-local bigButton = Vector2(math.ceil(124 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
-local confirmButtonSize = Vector2(math.ceil(512 * (ui.screenHeight / 1200)), math.ceil(64 * (ui.screenHeight / 1200)))
+local rescaleVector = ui.rescaleUI(Vector2(1, 1), Vector2(1600, 900), true)
+local widgetSizes = ui.rescaleUI({
+	buySellSize = Vector2(128, 48),
+	buttonSizeBase = Vector2(64, 48),
+	iconSize = Vector2(0, pionillium.large.size * 1.5),
+	smallButton = Vector2(92, 48),
+	bigButton = Vector2(128, 48),
+	confirmButtonSize = Vector2(384, 48),
+}, Vector2(1600, 900))
 
 local commodityMarket
 local icons = {}
@@ -181,12 +183,12 @@ local tradeMenu = function()
 	if(selectedItem) then
 		ui.withStyleVars({WindowPadding = commodityMarket.style.windowPadding, ItemSpacing = commodityMarket.style.itemSpacing}, function()
 			ui.child("TradeMenu", Vector2(ui.screenWidth / 2,0), {"AlwaysUseWindowPadding"}, function()
-				if(ui.coloredSelectedButton(l.BUY, buySellSize, tradeModeBuy, colors.buttonBlue, nil, true)) then
+				if(ui.coloredSelectedButton(l.BUY, widgetSizes.buySellSize, tradeModeBuy, colors.buttonBlue, nil, true)) then
 					tradeModeBuy = true
 					changeTradeAmount(-tradeAmount)
 				end
 				ui.sameLine()
-				if(ui.coloredSelectedButton(l.SELL, buySellSize, not tradeModeBuy, colors.buttonBlue, nil, true)) then
+				if(ui.coloredSelectedButton(l.SELL, widgetSizes.buySellSize, not tradeModeBuy, colors.buttonBlue, nil, true)) then
 					tradeModeBuy = false
 					changeTradeAmount(-tradeAmount)
 				end
@@ -199,8 +201,8 @@ local tradeMenu = function()
 				end
 
 				ui.columns(2, "tradeMenuItemTitle", false)
-				ui.setColumnWidth(0, buttonSizeBase.x)
-				icons[selectedItem.icon_name]:Draw(iconSize)
+				ui.setColumnWidth(0, widgetSizes.buttonSizeBase.x)
+				icons[selectedItem.icon_name]:Draw(widgetSizes.iconSize)
 				ui.nextColumn()
 				ui.withStyleVars({ItemSpacing = commodityMarket.style.itemSpacing/2}, function()
 					ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size, function()
@@ -214,19 +216,19 @@ local tradeMenu = function()
 				ui.textWrapped(selectedItem:GetDescription())
 
 				ui.setCursorPos(bottomHalf)
-				if ui.coloredSelectedButton("-100", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-100) end
+				if ui.coloredSelectedButton("-100", widgetSizes.smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-100) end
 				ui.sameLine()
-				if ui.coloredSelectedButton("-10", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-10) end
+				if ui.coloredSelectedButton("-10", widgetSizes.smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-10) end
 				ui.sameLine()
-				if ui.coloredSelectedButton("-1", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-1) end
+				if ui.coloredSelectedButton("-1", widgetSizes.smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-1) end
 				ui.sameLine()
-				if ui.coloredSelectedButton(l.RESET, bigButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-tradeAmount) end
+				if ui.coloredSelectedButton(l.RESET, widgetSizes.bigButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(-tradeAmount) end
 				ui.sameLine()
-				if ui.coloredSelectedButton("+1", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(1) end
+				if ui.coloredSelectedButton("+1", widgetSizes.smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(1) end
 				ui.sameLine()
-				if ui.coloredSelectedButton("+10", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(10) end
+				if ui.coloredSelectedButton("+10", widgetSizes.smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(10) end
 				ui.sameLine()
-				if ui.coloredSelectedButton("+100", smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(100) end
+				if ui.coloredSelectedButton("+100", widgetSizes.smallButton, false, colors.buttonBlue, nil, true) then changeTradeAmount(100) end
 
 				ui.dummy(commodityMarket.style.itemSpacing/2)
 				ui.withStyleColors({["Text"] = tradeTextColor }, function()
@@ -235,9 +237,9 @@ local tradeMenu = function()
 					end)
 				end)
 
-				ui.setCursorPos(ui.getCursorPos() - Vector2(0, confirmButtonSize.y - commodityMarket.style.windowPadding.y - ui.getContentRegion().y))
+				ui.setCursorPos(ui.getCursorPos() - Vector2(0, widgetSizes.confirmButtonSize.y - commodityMarket.style.windowPadding.y - ui.getContentRegion().y))
 				ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size, function()
-					if ui.coloredSelectedButton(tradeModeBuy and l.CONFIRM_PURCHASE or l.CONFIRM_SALE, confirmButtonSize, false, colors.buttonBlue, nil, true) then
+					if ui.coloredSelectedButton(tradeModeBuy and l.CONFIRM_PURCHASE or l.CONFIRM_SALE, widgetSizes.confirmButtonSize, false, colors.buttonBlue, nil, true) then
 						if tradeModeBuy then doBuy()
 						else doSell() end
 					end
@@ -246,9 +248,9 @@ local tradeMenu = function()
 				ui.setNextWindowSize(Vector2(0, 0), "Always")
 				ui.popupModal(popupId, {"NoTitleBar", "NoResize"}, function ()
 					ui.text(popupMsg)
-					ui.dummy(Vector2((ui.getContentRegion().x - 100) / 2, 0))
+					ui.dummy(Vector2((ui.getContentRegion().x - 100 * rescaleVector.x) / 2, 0))
 					ui.sameLine()
-					if ui.button("OK", Vector2(100, 0)) then
+					if ui.button("OK", Vector2(100 * widgetSizes.rescaleVector.x, 0)) then
 						ui.closeCurrentPopup()
 					end
 				end)
@@ -261,8 +263,8 @@ commodityMarket = Market.New("EquipmentMarket", false, {
 	itemTypes = { Equipment.cargo },
 	columnCount = 5,
 	initTable = function(self)
-		ui.setColumnWidth(0, buttonSizeBase.x)
-		ui.setColumnWidth(1, self.style.size.x / 2 - 50)
+		ui.setColumnWidth(0, widgetSizes.buttonSizeBase.x)
+		ui.setColumnWidth(1, self.style.size.x / 2 - 50 * rescaleVector.x)
 
 		ui.text('')
 		ui.nextColumn()
@@ -279,7 +281,7 @@ commodityMarket = Market.New("EquipmentMarket", false, {
 		if(icons[item.icon_name] == nil) then
 			icons[item.icon_name] = PiImage.New("icons/goods/".. item.icon_name ..".png")
 		end
-		icons[item.icon_name]:Draw(iconSize)
+		icons[item.icon_name]:Draw(widgetSizes.iconSize)
 		ui.nextColumn()
 		ui.withStyleVars({ItemSpacing = (self.style.itemSpacing / 2)}, function()
 			ui.dummy(vZero)
@@ -310,9 +312,9 @@ commodityMarket = Market.New("EquipmentMarket", false, {
 })
 
 local function drawCommoditytView()
-	ui.withFont(marketFont.name, marketFont.size, function()
 
-		ui.child("commodityMarketContainer", Vector2(0, ui.getContentRegion().y - 100), {}, function()
+	ui.withFont(pionillium.large.name, pionillium.large.size, function()
+		ui.child("commodityMarketContainer", Vector2(0, ui.getContentRegion().y - StationView.style.height), {}, function()
 			commodityMarket:render()
 			ui.sameLine()
 			tradeMenu()

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -12,6 +12,6 @@ StationView:registerView({
 	name = l.SHIP_MARKET,
 	icon = ui.theme.icons.ship,
 	showView = false,
-	draw = function()
-	end
+	draw = function() end,
+	refresh = function() end,
 })

--- a/data/pigui/modules/station-view/05-equipmentMarket.lua
+++ b/data/pigui/modules/station-view/05-equipmentMarket.lua
@@ -1,17 +1,184 @@
 -- Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local ui = import 'pigui/pigui.lua'
-local StationView = import 'pigui/views/station-view'
 local Lang = import 'Lang'
+local Game = import 'Game'
+local Format = import 'Format'
+local Equipment = import 'Equipment'
+local StationView = import 'pigui/views/station-view'
+local Market = import 'pigui/libs/market.lua'
 
+local ui = import 'pigui/pigui.lua'
+local colors = ui.theme.colors
+local icons = ui.theme.icons
+local pionillium = ui.fonts.pionillium
 local l = Lang.GetResource("ui-core")
+
+local hasTech = function (e)
+	local station = Game.player:GetDockedWith()
+	local equip_tech_level = e.tech_level or 1 -- default to 1
+
+	if type(equip_tech_level) == "string" then
+		if equip_tech_level == "MILITARY" then
+			return station.techLevel == 11
+		else
+			error("Unknown tech level:\t"..equip_tech_level)
+		end
+	end
+
+	assert(type(equip_tech_level) == "number")
+	return station.techLevel >= equip_tech_level
+end
+
+local equipmentMarket
+local equipmentMarketPlayer
+
+equipmentMarket = Market.New("EquipmentMarket", l.AVAILABLE_FOR_PURCHASE, {
+	itemTypes = { Equipment.cargo, Equipment.misc, Equipment.laser, Equipment.hyperspace },
+	columnCount = 5,
+	initTable = function(self)
+		ui.setColumnWidth(0, self.style.size.x / 2)
+
+		ui.text(l.NAME_OBJECT)
+		ui.nextColumn()
+		ui.text(l.BUY)
+		ui.nextColumn()
+		ui.text(l.SELL)
+		ui.nextColumn()
+		ui.text(l.MASS)
+		ui.nextColumn()
+		ui.text(l.IN_STOCK)
+		ui.nextColumn()
+	end,
+	renderRow = function(self, item)
+		ui.withTooltip(item:GetDescription(), function()
+			ui.text(item:GetName())
+			ui.nextColumn()
+			ui.text(Format.Money(self.funcs.getBuyPrice(self, item)))
+			ui.nextColumn()
+			ui.text(Format.Money(self.funcs.getSellPrice(self, item)))
+			ui.nextColumn()
+			ui.text(item.capabilities.mass.."t")
+			ui.nextColumn()
+			ui.text(self.funcs.getStock(self, item))
+			ui.nextColumn()
+		end)
+	end,
+
+	displayItem = function (s, e) return e.purchasable and hasTech(e) and not e:IsValidSlot("cargo", Game.player) end,
+	onMouseOverItem = function(s, e)
+		local tooltip = e:GetDescription()
+
+		if string.len(tooltip) > 0 then ui.setTooltip(tooltip) end
+		if ui.isMouseClicked(0) and s.funcs.onClickBuy(e) then
+			s.funcs.buy(s, e)
+			s:refresh()
+			equipmentMarketPlayer:refresh()
+		end
+	end
+})
+
+equipmentMarketPlayer = Market.New("EquipmentMarketPlayer", l.EQUIPPED, {
+	itemTypes = { Equipment.cargo, Equipment.misc, Equipment.laser, Equipment.hyperspace },
+	columnCount = 4,
+	initTable = function(self)
+		ui.setColumnWidth(0, self.style.size.x / 3)
+
+		ui.text(l.NAME_OBJECT)
+		ui.nextColumn()
+		ui.text(l.AMOUNT)
+		ui.nextColumn()
+		ui.text(l.MASS)
+		ui.nextColumn()
+		ui.text(l.TOTAL_MASS)
+		ui.nextColumn()
+	end,
+	renderRow = function(self, item)
+		ui.text(item:GetName())
+		ui.nextColumn()
+		ui.text(self.funcs.getStock(self, item))
+		ui.nextColumn()
+		ui.text(item.capabilities.mass.."t")
+		ui.nextColumn()
+		ui.text(tostring(self.funcs.getStock(self, item) * item.capabilities.mass) .. "t")
+		ui.nextColumn()
+	end,
+
+	onClickSell = function (self, e)
+		if e:IsValidSlot("cargo", Game.player) and not e.purchasable then
+			self.popupMsg = l.CANNOT_SELL_ITEM
+			ui.openPopup(self.popupMsgId)
+			return false
+		end
+
+		if not hasTech(e) then
+			self.popupMsg = l.STATION_TECH_TOO_LOW
+			ui.openPopup(self.popupMsgId)
+			return false
+		end
+
+		return true
+	end,
+	displayItem = function (s, e) return e.purchasable and Game.player:CountEquip(e) > 0 and not e:IsValidSlot("cargo", Game.player) end,
+	getStock = function (s, e) return Game.player:CountEquip(e) end,
+	onMouseOverItem = function(s, e)
+		local tooltip = e:GetDescription()
+
+		if string.len(tooltip) > 0 then ui.setTooltip(tooltip) end
+		if ui.isMouseClicked(0) and s.funcs.onClickSell(s, e) then
+			s.funcs.sell(s, e)
+			equipmentMarket:refresh()
+			equipmentMarketPlayer:refresh()
+		end
+	end
+})
+
+local function drawEquipmentView()
+	local inventoryPadding = Vector2(20, 10)
+	local player = Game.player
+	ui.withFont(pionillium.medlarge.name, pionillium.large.size, function()
+
+		ui.child("equipmentMarketContainer", Vector2(0, ui.getContentRegion().y - 100), {}, function()
+			equipmentMarket:render()
+			ui.sameLine()
+			equipmentMarketPlayer:render()
+		end)
+
+		ui.withStyleVars({WindowPadding = inventoryPadding, ItemSpacing = equipmentMarket.style.itemSpacing}, function()
+			ui.child("shipInventoryContainer", Vector2(0, 0), {"AlwaysUseWindowPadding"}, function()
+				ui.text('')
+				ui.columns(4, 'shipInventory', false)
+				ui.text(l.CASH .. ': ' .. Format.Money(Game.player:GetMoney()))
+				ui.nextColumn()
+				ui.text(l.CAPACITY .. ': ')
+				ui.sameLine()
+				local gaugePos = ui.getWindowPos() + ui.getCursorPos() + inventoryPadding
+				local gaugeWidth = ui.getContentRegion().x - inventoryPadding.x - equipmentMarket.style.itemSpacing.x
+				ui.gauge(gaugePos, player.usedCapacity, '', string.format('%%it %s / %it %s', l.USED, player.freeCapacity, l.FREE), 0, player.usedCapacity + player.freeCapacity, icons.market, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
+				ui.nextColumn()
+				ui.text(l.CABINS .. ': ')
+				ui.sameLine()
+				local cabins_free = player.cabin_cap or 0
+				local cabins = player:GetEquipCountOccupied("cabin")
+				gaugePos = ui.getWindowPos() + ui.getCursorPos() + inventoryPadding
+				gaugeWidth = ui.getContentRegion().x - inventoryPadding.x - equipmentMarket.style.itemSpacing.x
+				ui.gauge(gaugePos, cabins - cabins_free, '', string.format('%%it %s / %it %s', l.USED, cabins, l.FREE), 0, cabins, icons.personal, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
+				ui.nextColumn()
+				ui.text(l.LEGAL_STATUS .. ': ' .. l.CLEAN)
+				ui.columns(1, '', false)
+			end)
+		end)
+	end)
+end
 
 StationView:registerView({
 	id = "equipmentMarket",
 	name = l.EQUIPMENT_MARKET,
 	icon = ui.theme.icons.equipment,
-	showView = false,
-	draw = function()
-	end
+	showView = true,
+	draw = drawEquipmentView,
+	refresh = function()
+		equipmentMarket:refresh()
+		equipmentMarketPlayer:refresh()
+	end,
 })

--- a/data/pigui/modules/station-view/05-equipmentMarket.lua
+++ b/data/pigui/modules/station-view/05-equipmentMarket.lua
@@ -9,8 +9,6 @@ local StationView = import 'pigui/views/station-view'
 local Market = import 'pigui/libs/market.lua'
 
 local ui = import 'pigui/pigui.lua'
-local colors = ui.theme.colors
-local icons = ui.theme.icons
 local pionillium = ui.fonts.pionillium
 local l = Lang.GetResource("ui-core")
 
@@ -134,8 +132,6 @@ equipmentMarketPlayer = Market.New("EquipmentMarketPlayer", l.EQUIPPED, {
 })
 
 local function drawEquipmentView()
-	local inventoryPadding = Vector2(20, 10)
-	local player = Game.player
 	ui.withFont(pionillium.medlarge.name, pionillium.large.size, function()
 
 		ui.child("equipmentMarketContainer", Vector2(0, ui.getContentRegion().y - 100), {}, function()
@@ -144,30 +140,7 @@ local function drawEquipmentView()
 			equipmentMarketPlayer:render()
 		end)
 
-		ui.withStyleVars({WindowPadding = inventoryPadding, ItemSpacing = equipmentMarket.style.itemSpacing}, function()
-			ui.child("shipInventoryContainer", Vector2(0, 0), {"AlwaysUseWindowPadding"}, function()
-				ui.text('')
-				ui.columns(4, 'shipInventory', false)
-				ui.text(l.CASH .. ': ' .. Format.Money(Game.player:GetMoney()))
-				ui.nextColumn()
-				ui.text(l.CAPACITY .. ': ')
-				ui.sameLine()
-				local gaugePos = ui.getWindowPos() + ui.getCursorPos() + inventoryPadding
-				local gaugeWidth = ui.getContentRegion().x - inventoryPadding.x - equipmentMarket.style.itemSpacing.x
-				ui.gauge(gaugePos, player.usedCapacity, '', string.format('%%it %s / %it %s', l.USED, player.freeCapacity, l.FREE), 0, player.usedCapacity + player.freeCapacity, icons.market, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
-				ui.nextColumn()
-				ui.text(l.CABINS .. ': ')
-				ui.sameLine()
-				local cabins_free = player.cabin_cap or 0
-				local cabins = player:GetEquipCountOccupied("cabin")
-				gaugePos = ui.getWindowPos() + ui.getCursorPos() + inventoryPadding
-				gaugeWidth = ui.getContentRegion().x - inventoryPadding.x - equipmentMarket.style.itemSpacing.x
-				ui.gauge(gaugePos, cabins - cabins_free, '', string.format('%%it %s / %it %s', l.USED, cabins, l.FREE), 0, cabins, icons.personal, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
-				ui.nextColumn()
-				ui.text(l.LEGAL_STATUS .. ': ' .. l.CLEAN)
-				ui.columns(1, '', false)
-			end)
-		end)
+		StationView:shipSummary()
 	end)
 end
 

--- a/data/pigui/modules/station-view/05-equipmentMarket.lua
+++ b/data/pigui/modules/station-view/05-equipmentMarket.lua
@@ -35,7 +35,9 @@ equipmentMarket = Market.New("EquipmentMarket", l.AVAILABLE_FOR_PURCHASE, {
 	itemTypes = { Equipment.cargo, Equipment.misc, Equipment.laser, Equipment.hyperspace },
 	columnCount = 5,
 	initTable = function(self)
-		ui.setColumnWidth(0, self.style.size.x / 2)
+		ui.setColumnWidth(0, self.style.size.x / 2.5)
+		ui.setColumnWidth(3, ui.calcTextSize(l.MASS).x + self.style.itemSpacing.x + self.style.windowPadding.x)
+		ui.setColumnWidth(4, ui.calcTextSize(l.IN_STOCK).x + self.style.itemSpacing.x + self.style.windowPadding.x)
 
 		ui.text(l.NAME_OBJECT)
 		ui.nextColumn()
@@ -132,9 +134,9 @@ equipmentMarketPlayer = Market.New("EquipmentMarketPlayer", l.EQUIPPED, {
 })
 
 local function drawEquipmentView()
-	ui.withFont(pionillium.medlarge.name, pionillium.large.size, function()
+	ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
 
-		ui.child("equipmentMarketContainer", Vector2(0, ui.getContentRegion().y - 100), {}, function()
+		ui.child("equipmentMarketContainer", Vector2(0, ui.getContentRegion().y - StationView.style.height), {}, function()
 			equipmentMarket:render()
 			ui.sameLine()
 			equipmentMarketPlayer:render()

--- a/data/pigui/modules/station-view/06-shipRepairs.lua
+++ b/data/pigui/modules/station-view/06-shipRepairs.lua
@@ -12,6 +12,6 @@ StationView:registerView({
 	name = l.SHIP_REPAIRS,
 	icon = ui.theme.icons.repairs,
 	showView = false,
-	draw = function()
-	end
+	draw = function() end,
+	refresh = function() end,
 })

--- a/data/pigui/modules/station-view/07-police.lua
+++ b/data/pigui/modules/station-view/07-police.lua
@@ -12,6 +12,6 @@ StationView:registerView({
 	name = l.POLICE,
 	icon = ui.theme.icons.shield_other,
 	showView = false,
-	draw = function()
-	end
+	draw = function() end,
+	refresh = function() end,
 })

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -87,6 +87,14 @@ function ui.popup(name, fun)
 		pigui.EndPopup()
 	end
 end
+
+function ui.popupModal(name, flags, fun)
+    if pigui.BeginPopupModal(name, flags) then
+        fun()
+        pigui.EndPopup()
+    end
+end
+
 function ui.child(id, size, flags, fun)
 	if flags == nil and fun == nil then -- size is optional
 		fun = size
@@ -530,6 +538,8 @@ ui.setCursorPos = pigui.SetCursorPos
 ui.getCursorPos = pigui.GetCursorPos
 ui.setCursorScreenPos = pigui.SetCursorScreenPos
 ui.getCursorScreenPos = pigui.GetCursorScreenPos
+ui.getTextLineHeight = pigui.GetTextLineHeight
+ui.getTextLineHeightWithSpacing = pigui.GetTextLineHeightWithSpacing
 ui.lowThrustButton = pigui.LowThrustButton
 ui.thrustIndicator = pigui.ThrustIndicator
 ui.oneOverSqrtTwo = one_over_sqrt_two
@@ -561,11 +571,14 @@ ui.isAnyWindowHovered = function()
 end
 ui.collapsingHeader = pigui.CollapsingHeader
 ui.openPopup = pigui.OpenPopup
+ui.closeCurrentPopup = pigui.CloseCurrentPopup
 ui.shouldShowLabels = pigui.ShouldShowLabels
 ui.columns = pigui.Columns
 ui.nextColumn = pigui.NextColumn
 ui.setColumnOffset = pigui.SetColumnOffset
 ui.getColumnWidth = pigui.GetColumnWidth
+ui.setColumnWidth = pigui.SetColumnWidth
+ui.getScrollY = pigui.GetScrollY
 ui.keys = pigui.keys
 ui.systemInfoViewNextPage = pigui.SystemInfoViewNextPage -- deprecated
 ui.isKeyReleased = pigui.IsKeyReleased
@@ -796,29 +809,30 @@ local gauge_show_percent = true
 ui.gauge_height = 25
 ui.gauge_width = 275
 
-ui.gauge = function(position, value, unit, format, minimum, maximum, icon, color, tooltip)
+ui.gauge = function(position, value, unit, format, minimum, maximum, icon, color, tooltip, width, height)
 	local percent = math.clamp((value - minimum) / (maximum - minimum), 0, 1)
 	local offset = 60
 	local uiPos = Vector2(position.x, position.y)
+	local gauge_width = width or ui.gauge_width
+	local gauge_height = height or ui.gauge_height
 	ui.withFont(ui.fonts.pionillium.medium.name, ui.fonts.pionillium.medium.size, function()
-		ui.addLine(uiPos, Vector2(uiPos.x + ui.gauge_width, uiPos.y), ui.theme.colors.gaugeBackground, ui.gauge_height)
+		ui.addLine(uiPos, Vector2(uiPos.x + gauge_width, uiPos.y), ui.theme.colors.gaugeBackground, gauge_height)
 		if gauge_show_percent then
-			local one_hundred = ui.calcTextSize("100")
+			local one_hundred = ui.calcTextSize("100%")
 			uiPos.x = uiPos.x + one_hundred.x * 1.2 -- 1.2 for a bit of slack
-			ui.addStyledText(Vector2(uiPos.x, uiPos.y + ui.gauge_height / 12), ui.anchor.right, ui.anchor.center, string.format("%i", percent * 100), ui.theme.colors.reticuleCircle, ui.fonts.pionillium.medium, tooltip)
+			ui.addStyledText(Vector2(uiPos.x, uiPos.y + gauge_height / 12), ui.anchor.right, ui.anchor.center, string.format("%i%%", percent * 100), ui.theme.colors.reticuleCircle, ui.fonts.pionillium.medium, tooltip)
 		end
-		uiPos.x = uiPos.x + ui.gauge_height * 1.2
-		ui.addIcon(Vector2(uiPos.x - ui.gauge_height / 2, uiPos.y), icon, ui.theme.colors.reticuleCircle, Vector2(ui.gauge_height * 0.9, ui.gauge_height * 0.9), ui.anchor.center, ui.anchor.center, tooltip)
-		local w = (position.x + ui.gauge_width) - uiPos.x
-		ui.addLine(uiPos, Vector2(uiPos.x + w * percent, uiPos.y), color, ui.gauge_height)
+		uiPos.x = uiPos.x + gauge_height * 1.2
+		ui.addIcon(Vector2(uiPos.x - gauge_height / 2, uiPos.y), icon, ui.theme.colors.reticuleCircle, Vector2(gauge_height * 0.9, gauge_height * 0.9), ui.anchor.center, ui.anchor.center, tooltip)
+		local w = (position.x + gauge_width) - uiPos.x
+		ui.addLine(uiPos, Vector2(uiPos.x + w * percent, uiPos.y), color, gauge_height)
 		if value and format then
-			ui.addFancyText(Vector2(uiPos.x + ui.gauge_height/2, uiPos.y + ui.gauge_height/4), ui.anchor.left, ui.anchor.center, {
+			ui.addFancyText(Vector2(uiPos.x + gauge_height/2, uiPos.y + gauge_height/4), ui.anchor.left, ui.anchor.center, {
 				{ text=string.format(format, value), color=ui.theme.colors.reticuleCircle,     font=ui.fonts.pionillium.small, tooltip=tooltip },
 				{ text=unit,                         color=ui.theme.colors.reticuleCircleDark, font=ui.fonts.pionillium.small, tooltip=tooltip }},
-			ui.theme.colors.gaugeBackground)
+					ui.theme.colors.gaugeBackground)
 		end
 	end)
-
 end
 
 ui.loadTextureFromSVG = function(a, b, c)
@@ -839,6 +853,19 @@ end
 
 ui.getModules = function(mode)
 	return modules[mode] or {}
+end
+
+ui.withTooltip = function(tooltip, fun)
+	local startPos = pigui.GetCursorPos()
+	fun()
+	if string.len(tooltip) > 0 then
+		local endPos = pigui.GetCursorPos()
+		local offset = pigui.GetWindowPos()
+		offset.y = offset.y - pigui.GetScrollY()
+		if pigui.IsMouseHoveringRect(offset + startPos, offset + endPos, false) then
+			pigui.SetTooltip(tooltip)
+		end
+	end
 end
 
 return ui

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -54,6 +54,8 @@ ui.fonts = {
 		large = { name = "orbiteer", size = 30 * font_factor, offset = 24 * font_factor },
 		medlarge = { name = "orbiteer", size = 24 * font_factor, offset = 20 * font_factor},
 		medium = { name = "orbiteer", size = 20 * font_factor, offset = 16 * font_factor},
+		small = { name = "orbiteer", size = 14 * font_factor, offset = 11 * font_factor},
+		tiny = { name = "orbiteer", size = 8 * font_factor, offset = 7 * font_factor},
 	},
 }
 
@@ -809,7 +811,7 @@ local gauge_show_percent = true
 ui.gauge_height = 25
 ui.gauge_width = 275
 
-ui.gauge = function(position, value, unit, format, minimum, maximum, icon, color, tooltip, width, height)
+ui.gauge = function(position, value, unit, format, minimum, maximum, icon, color, tooltip, width, height, formatFont, percentFont)
 	local percent = math.clamp((value - minimum) / (maximum - minimum), 0, 1)
 	local offset = 60
 	local uiPos = Vector2(position.x, position.y)
@@ -820,7 +822,7 @@ ui.gauge = function(position, value, unit, format, minimum, maximum, icon, color
 		if gauge_show_percent then
 			local one_hundred = ui.calcTextSize("100%")
 			uiPos.x = uiPos.x + one_hundred.x * 1.2 -- 1.2 for a bit of slack
-			ui.addStyledText(Vector2(uiPos.x, uiPos.y + gauge_height / 12), ui.anchor.right, ui.anchor.center, string.format("%i%%", percent * 100), ui.theme.colors.reticuleCircle, ui.fonts.pionillium.medium, tooltip)
+			ui.addStyledText(Vector2(uiPos.x, uiPos.y + gauge_height / 12), ui.anchor.right, ui.anchor.center, string.format("%i%%", percent * 100), ui.theme.colors.reticuleCircle, percentFont or ui.fonts.pionillium.medium, tooltip)
 		end
 		uiPos.x = uiPos.x + gauge_height * 1.2
 		ui.addIcon(Vector2(uiPos.x - gauge_height / 2, uiPos.y), icon, ui.theme.colors.reticuleCircle, Vector2(gauge_height * 0.9, gauge_height * 0.9), ui.anchor.center, ui.anchor.center, tooltip)
@@ -828,8 +830,8 @@ ui.gauge = function(position, value, unit, format, minimum, maximum, icon, color
 		ui.addLine(uiPos, Vector2(uiPos.x + w * percent, uiPos.y), color, gauge_height)
 		if value and format then
 			ui.addFancyText(Vector2(uiPos.x + gauge_height/2, uiPos.y + gauge_height/4), ui.anchor.left, ui.anchor.center, {
-				{ text=string.format(format, value), color=ui.theme.colors.reticuleCircle,     font=ui.fonts.pionillium.small, tooltip=tooltip },
-				{ text=unit,                         color=ui.theme.colors.reticuleCircleDark, font=ui.fonts.pionillium.small, tooltip=tooltip }},
+				{ text=string.format(format, value), color=ui.theme.colors.reticuleCircle,     font=(formatFont or ui.fonts.pionillium.small), tooltip=tooltip },
+				{ text=unit,                         color=ui.theme.colors.reticuleCircleDark, font=(formatFont or ui.fonts.pionillium.small), tooltip=tooltip }},
 					ui.theme.colors.gaugeBackground)
 		end
 	end)
@@ -838,6 +840,11 @@ end
 ui.loadTextureFromSVG = function(a, b, c)
 	return pigui:LoadTextureFromSVG(a, b, c)
 end
+
+ui.loadTexture = function(filename)
+	return pigui:LoadTexture(filename)
+end
+
 ui.dataDirPath = pigui.DataDirPath
 ui.addImage = pigui.AddImage
 ui.image = pigui.Image

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -42,6 +42,7 @@ ui.fonts = {
 		large = { name = "icons", size = 22 * font_factor, offset = 28 * font_factor}
 	},
 	pionillium = {
+		xlarge = { name = "pionillium", size = 36 * font_factor, offset = 24 * font_factor },
 		large = { name = "pionillium", size = 30 * font_factor, offset = 24 * font_factor},
 		medlarge = { name = "pionillium", size = 24 * font_factor, offset = 18 * font_factor},
 		medium = { name = "pionillium", size = 18 * font_factor, offset = 14 * font_factor},

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -55,7 +55,8 @@ theme.colors = {
 	radarCargo = Color(166, 166, 166),
 	radarNavTarget = Color(0, 255, 0),
 	radarStation = Color(255, 255, 255),
-	radarCloud = Color(128, 128, 255)
+	radarCloud = Color(128, 128, 255),
+    gaugeEquipmentMarket = Color(76,76,158),
 }
 
 theme.icons = {

--- a/data/pigui/views/station-view.lua
+++ b/data/pigui/views/station-view.lua
@@ -1,13 +1,53 @@
 -- Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+local Lang = import 'Lang'
+local Game = import 'Game'
+local Format = import 'Format'
 
+local l = Lang.GetResource("ui-core")
 local ui = import 'pigui/pigui.lua'
+local colors = ui.theme.colors
+local icons = ui.theme.icons
+local pionillium = ui.fonts.pionillium
 local TabView = import 'pigui/views/tab-view.lua'
+
+local itemSpacing = Vector2(math.ceil(6 * (ui.screenHeight / 1200)), math.ceil(12 * (ui.screenHeight / 1200)))
 
 local stationView
 
 if not stationView then
 	stationView = TabView.New("space_station")
+	stationView.shipSummary = function()
+		local inventoryPadding = Vector2(20, 10)
+		local player = Game.player
+
+		ui.withFont(pionillium.medlarge.name, pionillium.large.size, function()
+			ui.withStyleVars({WindowPadding = inventoryPadding, ItemSpacing = itemSpacing}, function()
+				ui.child("shipInventoryContainer", Vector2(0, 0), {"AlwaysUseWindowPadding"}, function()
+					ui.text('')
+					ui.columns(4, 'shipInventory', false)
+					ui.text(l.CASH .. ': ' .. Format.Money(Game.player:GetMoney()))
+					ui.nextColumn()
+					ui.text(l.CAPACITY .. ': ')
+					ui.sameLine()
+					local gaugePos = ui.getWindowPos() + ui.getCursorPos() + inventoryPadding
+					local gaugeWidth = ui.getContentRegion().x - inventoryPadding.x - itemSpacing.x
+					ui.gauge(gaugePos, player.usedCapacity, '', string.format('%%it %s / %it %s', l.USED, player.freeCapacity, l.FREE), 0, player.usedCapacity + player.freeCapacity, icons.market, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
+					ui.nextColumn()
+					ui.text(l.CABINS .. ': ')
+					ui.sameLine()
+					local cabins_free = player.cabin_cap or 0
+					local cabins = player:GetEquipCountOccupied("cabin")
+					gaugePos = ui.getWindowPos() + ui.getCursorPos() + inventoryPadding
+					gaugeWidth = ui.getContentRegion().x - inventoryPadding.x - itemSpacing.x
+					ui.gauge(gaugePos, cabins - cabins_free, '', string.format('%%it %s / %it %s', l.USED, cabins, l.FREE), 0, cabins, icons.personal, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
+					ui.nextColumn()
+					ui.text(l.LEGAL_STATUS .. ': ' .. l.CLEAN)
+					ui.columns(1, '', false)
+				end)
+			end)
+		end)
+	end
 
 	ui.registerModule("game", function() stationView:renderTabView() end)
 end

--- a/data/pigui/views/station-view.lua
+++ b/data/pigui/views/station-view.lua
@@ -11,38 +11,50 @@ local icons = ui.theme.icons
 local pionillium = ui.fonts.pionillium
 local TabView = import 'pigui/views/tab-view.lua'
 
-local itemSpacing = Vector2(math.ceil(6 * (ui.screenHeight / 1200)), math.ceil(12 * (ui.screenHeight / 1200)))
-
 local stationView
 
 if not stationView then
 	stationView = TabView.New("space_station")
-	stationView.shipSummary = function()
-		local inventoryPadding = Vector2(20, 10)
+	stationView.style = ui.rescaleUI({
+		itemSpacing = Vector2(4,9),
+		inventoryPadding = Vector2(20, 10),
+		fontSize = 22,
+		height = 22 + 10 + 10 + 9
+	}, Vector2(1600, 900))
+
+	function stationView:shipSummary()
 		local player = Game.player
 
-		ui.withFont(pionillium.medlarge.name, pionillium.large.size, function()
-			ui.withStyleVars({WindowPadding = inventoryPadding, ItemSpacing = itemSpacing}, function()
+		ui.withFont(pionillium.medlarge.name, self.style.fontSize, function()
+			ui.withStyleVars({WindowPadding = self.style.inventoryPadding, ItemSpacing = self.style.itemSpacing}, function()
 				ui.child("shipInventoryContainer", Vector2(0, 0), {"AlwaysUseWindowPadding"}, function()
-					ui.text('')
+					local moneyText = l.CASH .. ': ' ..  Format.Money(Game.player:GetMoney())
+					local legalText = l.LEGAL_STATUS .. ': ' .. l.CLEAN
+					local moneySize = ui.calcTextSize(moneyText) + self.style.inventoryPadding + self.style.itemSpacing
+					local legalSize = ui.calcTextSize(legalText) + self.style.inventoryPadding + self.style.itemSpacing
+					local gaugeSize = (ui.getContentRegion().x - moneySize.x - legalSize.x) / 2
 					ui.columns(4, 'shipInventory', false)
-					ui.text(l.CASH .. ': ' .. Format.Money(Game.player:GetMoney()))
+					ui.setColumnWidth(0, moneySize.x)
+					ui.setColumnWidth(1, gaugeSize)
+					ui.setColumnWidth(2, gaugeSize)
+					ui.setColumnWidth(3, legalSize.x)
+					ui.text(moneyText)
 					ui.nextColumn()
 					ui.text(l.CAPACITY .. ': ')
 					ui.sameLine()
-					local gaugePos = ui.getWindowPos() + ui.getCursorPos() + inventoryPadding
-					local gaugeWidth = ui.getContentRegion().x - inventoryPadding.x - itemSpacing.x
+					local gaugePos = ui.getWindowPos() + ui.getCursorPos() + self.style.inventoryPadding
+					local gaugeWidth = ui.getContentRegion().x - self.style.inventoryPadding.x - self.style.itemSpacing.x
 					ui.gauge(gaugePos, player.usedCapacity, '', string.format('%%it %s / %it %s', l.USED, player.freeCapacity, l.FREE), 0, player.usedCapacity + player.freeCapacity, icons.market, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
 					ui.nextColumn()
 					ui.text(l.CABINS .. ': ')
 					ui.sameLine()
 					local cabins_free = player.cabin_cap or 0
 					local cabins = player:GetEquipCountOccupied("cabin")
-					gaugePos = ui.getWindowPos() + ui.getCursorPos() + inventoryPadding
-					gaugeWidth = ui.getContentRegion().x - inventoryPadding.x - itemSpacing.x
+					gaugePos = ui.getWindowPos() + ui.getCursorPos() + self.style.inventoryPadding
+					gaugeWidth = ui.getContentRegion().x - self.style.inventoryPadding.x - self.style.itemSpacing.x
 					ui.gauge(gaugePos, cabins - cabins_free, '', string.format('%%it %s / %it %s', l.USED, cabins, l.FREE), 0, cabins, icons.personal, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
 					ui.nextColumn()
-					ui.text(l.LEGAL_STATUS .. ': ' .. l.CLEAN)
+					ui.text(legalText)
 					ui.columns(1, '', false)
 				end)
 			end)

--- a/data/pigui/views/tab-view.lua
+++ b/data/pigui/views/tab-view.lua
@@ -116,6 +116,7 @@ function PiGuiTabView.renderTabView(self)
             for i, v in ipairs(self.tabs) do
                 if infoButton(v.icon, i == self.currentTab, v.name) then
                     self.legacyTabView:SwitchTo(v.id)
+                    self.legacyTabView.outerBody:Hide()
                     if(self.currentTab ~= i) then self.tabs[i].refresh() end
 
                     self.currentTab = i

--- a/data/pigui/views/tab-view.lua
+++ b/data/pigui/views/tab-view.lua
@@ -65,6 +65,7 @@ end
 function PiGuiTabView.renderTabView(self)
     if Game.CurrentView() ~= self.name then
         self.currentTab = 1
+        self.tabs[1].refresh()
         return
     end
 
@@ -115,6 +116,8 @@ function PiGuiTabView.renderTabView(self)
             for i, v in ipairs(self.tabs) do
                 if infoButton(v.icon, i == self.currentTab, v.name) then
                     self.legacyTabView:SwitchTo(v.id)
+                    if(self.currentTab ~= i) then self.tabs[i].refresh() end
+
                     self.currentTab = i
                 end
                 ui.sameLine()

--- a/data/ui/InfoView.lua
+++ b/data/ui/InfoView.lua
@@ -34,6 +34,7 @@ ui.templates.InfoView = function (args)
 	--tabGroup:AddTab({ id = "orbitalAnalysis", title = l.ORBITAL_ANALYSIS,     icon = "Planet",    template = orbitalAnalysis, })
 
 	tabGroup.header:Hide()
+	tabGroup.outerBody:Hide()
 	piInfoView.legacyTabView = tabGroup
 	return tabGroup.widget
 end

--- a/data/ui/StationView.lua
+++ b/data/ui/StationView.lua
@@ -141,6 +141,7 @@ ui.templates.StationView = function (args)
 	tabGroup:SetFooter(footerDefault)
 
 	tabGroup.header:Hide()
+	tabGroup.outerBody:Hide()
 	piStationView.legacyTabView = tabGroup
 	return tabGroup.widget
 end

--- a/data/ui/StationView/Lobby.lua
+++ b/data/ui/StationView/Lobby.lua
@@ -104,7 +104,7 @@ local lobby = function (tab)
 			connections.updateHyperspaceRangeCargo:Disconnect()
 			return
 		end
-		hyperspaceRange:SetText(string.format("%.1f ", Game.player.hyperspaceRange) .. l.LY)
+		hyperspaceRange:SetText(string.format("%.1f ", Game.player:GetHyperspaceRange()) .. l.LY)
 	end
 	updateHyperspaceRange()
 	connections.updateHyperspaceRangeFuel = Game.player:Connect("fuel", updateHyperspaceRange)

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -441,6 +441,15 @@ static int l_pigui_get_column_width(lua_State *l)
 	return 1;
 }
 
+static int l_pigui_set_column_width(lua_State *l)
+{
+	int column_index = LuaPull<int>(l, 1);
+	double width = LuaPull<double>(l, 2);
+	ImGui::SetColumnWidth(column_index, width);
+	LuaPush<double>(l, width);
+	return 1;
+}
+
 static int l_pigui_set_column_offset(lua_State *l)
 {
 	PROFILE_SCOPED()
@@ -448,6 +457,13 @@ static int l_pigui_set_column_offset(lua_State *l)
 	double offset_x = LuaPull<double>(l, 2);
 	ImGui::SetColumnOffset(column_index, offset_x);
 	return 0;
+}
+
+static int l_pigui_get_scroll_y(lua_State *l)
+{
+	PROFILE_SCOPED()
+	LuaPush<double>(l, ImGui::GetScrollY());
+	return 1;
 }
 
 static int l_pigui_progress_bar(lua_State *l)
@@ -1066,11 +1082,28 @@ static int l_pigui_begin_popup(lua_State *l)
 	return 1;
 }
 
+static int l_pigui_begin_popup_modal(lua_State *l)
+{
+	PROFILE_SCOPED()
+	std::string id = LuaPull<std::string>(l, 1);
+	ImGuiWindowFlags flags = LuaPull<ImGuiWindowFlags_>(l, 2, ImGuiWindowFlags_None);
+
+	LuaPush<bool>(l, ImGui::BeginPopupModal(id.c_str(), nullptr, flags));
+	return 1;
+}
+
 static int l_pigui_open_popup(lua_State *l)
 {
 	PROFILE_SCOPED()
 	std::string id = LuaPull<std::string>(l, 1);
 	ImGui::OpenPopup(id.c_str());
+	return 0;
+}
+
+static int l_pigui_close_current_popup(lua_State *l)
+{
+	PROFILE_SCOPED()
+	ImGui::CloseCurrentPopup();
 	return 0;
 }
 
@@ -2142,7 +2175,9 @@ void LuaObject<PiGui>::RegisterClass()
 		{ "Columns", l_pigui_columns },
 		{ "NextColumn", l_pigui_next_column },
 		{ "GetColumnWidth", l_pigui_get_column_width },
+		{ "SetColumnWidth", l_pigui_set_column_width },
 		{ "SetColumnOffset", l_pigui_set_column_offset },
+		{ "GetScrollY", l_pigui_get_scroll_y },
 		{ "Text", l_pigui_text },
 		{ "TextWrapped", l_pigui_text_wrapped },
 		{ "TextColored", l_pigui_text_colored },
@@ -2178,8 +2213,10 @@ void LuaObject<PiGui>::RegisterClass()
 		{ "PushTextWrapPos", l_pigui_push_text_wrap_pos },
 		{ "PopTextWrapPos", l_pigui_pop_text_wrap_pos },
 		{ "BeginPopup", l_pigui_begin_popup },
+		{ "BeginPopupModal", l_pigui_begin_popup_modal },
 		{ "EndPopup", l_pigui_end_popup },
 		{ "OpenPopup", l_pigui_open_popup },
+		{ "CloseCurrentPopup", l_pigui_close_current_popup },
 		{ "PushID", l_pigui_push_id },
 		{ "PopID", l_pigui_pop_id },
 		{ "IsMouseReleased", l_pigui_is_mouse_released },

--- a/src/pigui/Image.cpp
+++ b/src/pigui/Image.cpp
@@ -1,0 +1,30 @@
+// Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "Image.h"
+#include "FileSystem.h"
+#include "graphics/TextureBuilder.h"
+
+namespace PiGUI {
+
+	Image::Image(const std::string &filename)
+	{
+		m_texture.Reset(Graphics::TextureBuilder::Model(filename).GetOrCreateTexture(Pi::renderer, "model"));
+	}
+
+	Uint32 Image::GetId()
+	{
+		return m_texture->GetTextureID();
+	}
+
+	vector2f Image::GetSize()
+	{
+		return m_texture->GetDescriptor().dataSize;
+	}
+
+	vector2f Image::GetUv()
+	{
+		return m_texture->GetDescriptor().texSize;
+	}
+
+} // namespace PiGUI

--- a/src/pigui/Image.h
+++ b/src/pigui/Image.h
@@ -1,0 +1,27 @@
+// Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef PIGUI_IMAGE_H
+#define PIGUI_IMAGE_H
+
+#include "Pi.h"
+#include "SmartPtr.h"
+#include "graphics/TextureBuilder.h"
+
+namespace PiGUI {
+
+	class Image : public RefCounted {
+	public:
+		explicit Image(const std::string &filename);
+
+		Uint32 GetId();
+		vector2f GetSize();
+		vector2f GetUv();
+
+	private:
+		RefCountedPtr<Graphics::Texture> m_texture;
+	};
+
+} // namespace PiGUI
+
+#endif

--- a/src/pigui/LuaImage.cpp
+++ b/src/pigui/LuaImage.cpp
@@ -1,0 +1,69 @@
+// Copyright © 2008-2019 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "Image.h"
+#include "LuaConstants.h"
+#include "LuaObject.h"
+#include "LuaPiGui.h"
+#include "LuaTable.h"
+#include "LuaVector2.h"
+
+namespace PiGUI {
+
+	class LuaPiguiImage {
+	public:
+		static int l_new(lua_State *l)
+		{
+			std::string filename = LuaPull<std::string>(l, 1);
+
+			LuaObject<PiGUI::Image>::PushToLua(new PiGUI::Image(filename));
+			return 1;
+		}
+
+		static int l_image_attr_texture_id(lua_State *l)
+		{
+			Image *i = LuaObject<PiGUI::Image>::CheckFromLua(1);
+			lua_pushlightuserdata(l, reinterpret_cast<void *>(i->GetId()));
+
+			return 1;
+		}
+
+		static int l_image_attr_texture_size(lua_State *l)
+		{
+			Image *i = LuaObject<PiGUI::Image>::CheckFromLua(1);
+			LuaVector2::PushToLuaF(l, i->GetSize());
+
+			return 1;
+		}
+
+		static int l_image_attr_texture_uv(lua_State *l)
+		{
+			Image *i = LuaObject<PiGUI::Image>::CheckFromLua(1);
+			LuaVector2::PushToLuaF(l, i->GetUv());
+
+			return 1;
+		}
+	};
+
+} // namespace PiGUI
+
+template <>
+const char *LuaObject<PiGUI::Image>::s_type = "PiGui.Modules.Image";
+
+template <>
+void LuaObject<PiGUI::Image>::RegisterClass()
+{
+	static const luaL_Reg l_methods[] = {
+		{ "New", PiGUI::LuaPiguiImage::l_new },
+		{ 0, 0 }
+	};
+
+	static const luaL_Reg l_attrs[] = {
+		{ "id", PiGUI::LuaPiguiImage::l_image_attr_texture_id },
+		{ "size", PiGUI::LuaPiguiImage::l_image_attr_texture_size },
+		{ "uv", PiGUI::LuaPiguiImage::l_image_attr_texture_uv },
+		{ 0, 0 }
+	};
+
+	LuaObjectBase::CreateClass(s_type, 0, l_methods, l_attrs, 0);
+}

--- a/src/pigui/PiGuiLua.cpp
+++ b/src/pigui/PiGuiLua.cpp
@@ -3,6 +3,7 @@
 
 #include "PiGuiLua.h"
 #include "Face.h"
+#include "Image.h"
 #include "ModelSpinner.h"
 
 namespace PiGUI {
@@ -10,6 +11,7 @@ namespace PiGUI {
 
 		void Init()
 		{
+			LuaObject<PiGUI::Image>::RegisterClass();
 			LuaObject<PiGUI::Face>::RegisterClass();
 			LuaObject<PiGUI::ModelSpinner>::RegisterClass();
 		}


### PR DESCRIPTION
_EDIT by @impaktor_ [this](https://help.github.com/en/articles/closing-issues-using-keywords#closing-multiple-issues) closes #4624 closes #4651 closes #4654, fixes #4545

Like I mentioned in the previous pull request, I noticed the ui doesn't seem to rescale very well. We typically use code like this to scale to current resolutin:

`local mainButtonSize = Vector2(32,32) * (ui.screenHeight / 1200)`

It usually works well enough. but only within the same aspect ratio. Calculating these sizes has also been annoying, because the formula assumes 1920x1200 as the base resolution, and I usually work on 1600x900. So I wrote the `ui.rescaleUI = function(val, baseResolution, rescaleToScreenAspect)` function, which will automatically rescale any value, or all values in a table, using the relatively smaller dimension (so if the width changed more relative to the base resolution, it will use that). The `rescaleToScreenAspect` parameter works only for vectors, and if it's set it will use both dimensions (so a shape that is a square in 4:3 will become more rectangular in 16:9, and vice versa).

Other than rescaling I added some resolution-dependant rearrangements in the lobby.

So, without further ado, some comparisons:

**Station lobby - 1600x900 (my base resolution):**

![1600x900_lobby](https://user-images.githubusercontent.com/48452426/62818668-90091880-bb4a-11e9-88dc-a7961803f47c.png)

**Station lobby - 1152x864, old rescaling:**

![1152x864_lobby](https://user-images.githubusercontent.com/48452426/62818687-d2caf080-bb4a-11e9-9369-a14728c84f01.png)

**Station lobby - 1280x960, new rescaling**

![1280x960_rescale_lobby](https://user-images.githubusercontent.com/48452426/62818696-e6765700-bb4a-11e9-8935-f262f3b14dea.png)

**Station lobby - 800x600, old rescaling:**

![800x600_lobby](https://user-images.githubusercontent.com/48452426/62818704-0279f880-bb4b-11e9-8165-9b282ab5f49b.png)

**Station lobby - 800x600, new rescaling:**

![800x600_rescale_lobby](https://user-images.githubusercontent.com/48452426/62818707-0d348d80-bb4b-11e9-9569-0689a4811f5f.png)

**EquipmentMarket - 1600x900, old rescaling:**

![1600x900_eq_market](https://user-images.githubusercontent.com/48452426/62818713-25a4a800-bb4b-11e9-9b1e-4885baf28a7c.png)

(note I originally did not notice that with the sizes provided I cut off the "In Stock" column)
**EquipmentMarket - 1600x900, new rescaling:**

![1600x900_rescale_eq_market](https://user-images.githubusercontent.com/48452426/62818737-8f24b680-bb4b-11e9-97ff-c3dc2e787737.png)

**EquipmentMarket - 800x600, old rescaling:**

![800x600_eq_market](https://user-images.githubusercontent.com/48452426/62818738-9d72d280-bb4b-11e9-8a38-a3c657f8dd8e.png)

**EquipmentMarket - 800x600, new rescaling:**

![800x600_rescale_eq_market](https://user-images.githubusercontent.com/48452426/62818742-a8c5fe00-bb4b-11e9-89a9-b3cbbd2475f3.png)
