### PR TITLE
Fix ModelNameComparator illegal const conversion

### DIFF
--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -151,7 +151,7 @@ bool setcomp(SceneGraph::Model *mlhs, SceneGraph::Model *mrhs) { return mlhs->Ge
 bool (*fn_pt)(SceneGraph::Model *mlhs, SceneGraph::Model *mrhs) = setcomp;
 
 struct ModelNameComparator {
-	bool operator()(SceneGraph::Model *lhs, SceneGraph::Model *rhs)
+	bool operator()(const SceneGraph::Model *lhs, const SceneGraph::Model *rhs) const
 	{
 		return lhs->GetName() < rhs->GetName();
 	}


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Make the ModelNameComparator const so avoid illegal const conversion