### PR TITLE
[WIP] Compute gravity from each gravity source

### DIFF
--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -233,13 +233,6 @@ void DynamicBody::CalcExternalForce()
 		m_externalForce += m_atmosForce;
 	} else
 		m_atmosForce = vector3d(0.0);
-
-	// centrifugal and coriolis forces for rotating frames
-	if (GetFrame()->IsRotFrame()) {
-		vector3d angRot(0, GetFrame()->GetAngSpeed(), 0);
-		m_externalForce -= m_mass * angRot.Cross(angRot.Cross(GetPosition())); // centrifugal
-		m_externalForce -= 2 * m_mass * angRot.Cross(GetVelocity()); // coriolis
-	}
 }
 
 void DynamicBody::TimeStepUpdate(const float timeStep)

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -213,16 +213,9 @@ void DynamicBody::CalcExternalForce()
 {
 	// gravity
 	if (!GetFrame()) return; // no external force if not in a frame
+	m_externalForce = m_gravityForce;
+
 	Body *body = GetFrame()->GetBody();
-	if (body && !body->IsType(Object::SPACESTATION)) { // they ought to have mass though...
-		vector3d b1b2 = GetPosition();
-		double m1m2 = GetMass() * body->GetMass();
-		double invrsqr = 1.0 / b1b2.LengthSqr();
-		double force = G * m1m2 * invrsqr;
-		m_externalForce = -b1b2 * sqrt(invrsqr) * force;
-	} else
-		m_externalForce = vector3d(0.0);
-	m_gravityForce = m_externalForce;
 
 	// atmospheric drag
 	if (body && GetFrame()->IsRotFrame() && body->IsType(Object::PLANET)) {

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -52,6 +52,8 @@ public:
 	void AddRelTorque(const vector3d &);
 	vector3d GetExternalForce() const { return m_externalForce; }
 	vector3d GetAtmosForce() const { return m_atmosForce; }
+	// This should be called *only* from Space to apply gravity.
+	void SetGravityForce(const vector3d &g) { m_gravityForce = g;}
 	vector3d GetGravityForce() const { return m_gravityForce; }
 	virtual void UpdateInterpTransform(double alpha) override;
 

--- a/src/LuaSpace.cpp
+++ b/src/LuaSpace.cpp
@@ -675,6 +675,17 @@ static int l_space_get_bodies(lua_State *l)
 	return 1;
 }
 
+static int l_space_dump_frames(lua_State *l)
+{
+	Space *space = Pi::game->GetSpace();
+	if (!Pi::game && !space) {
+		luaL_error(l, "Game is not started");
+		return 0;
+	}
+	space->DebugDumpFrames();
+	return 0;
+}
+
 static int l_space_attr_root_system_body(lua_State *l)
 {
 	if (!Pi::game) {
@@ -707,6 +718,7 @@ void LuaSpace::Register()
 
 		{ "GetBody", l_space_get_body },
 		{ "GetBodies", l_space_get_bodies },
+		{ "DbgDumpFrames", l_space_dump_frames },
 		{ 0, 0 }
 	};
 

--- a/src/Space.h
+++ b/src/Space.h
@@ -89,6 +89,7 @@ public:
 		return std::move(m_bodyNearFinder.GetBodiesMaybeNear(pos, dist));
 	}
 
+	void DebugDumpFrames();
 private:
 	void GenSectorCache(RefCountedPtr<Galaxy> galaxy, const SystemPath *here);
 	void UpdateStarSystemCache(const SystemPath *here);
@@ -173,7 +174,6 @@ private:
 	bool m_processingFinalizationQueue;
 #endif
 
-	void DebugDumpFrames();
 };
 
 #endif /* _SPACE_H */

--- a/src/Space.h
+++ b/src/Space.h
@@ -14,6 +14,7 @@
 #include <list>
 
 class Body;
+class DynamicBody;
 class Frame;
 class Ship;
 class HyperspaceCloud;
@@ -95,11 +96,16 @@ private:
 	// make sure SystemBody* is in Pi::currentSystem
 	Frame *GetFrameWithSystemBody(const SystemBody *b) const;
 
+	void CalculateAndSetGravityFor(DynamicBody *b1);
+
 	void UpdateBodies();
 
 	void CollideFrame(Frame *f);
 
 	std::unique_ptr<Frame> m_rootFrame;
+
+	// Bodies with a gravity field
+	std::vector<Body*> m_bodiesWithGravity;
 
 	RefCountedPtr<SectorCache::Slave> m_sectorCache;
 	RefCountedPtr<StarSystemCache::Slave> m_starSystemCache;


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

First commit tries to address what emerge in #4288, basically I did what @jaj22 suggested, and I replaced those `macro` with some more readable and centralized check, which can be extended to be used for more checks in `CustomSystem` and, if useful, also to avoid `GalaxyGenerator` to be completely free to play with numbers (which lead to a lot of strange results).

The second commit is addressing (partially) what emerge in #4164: it add a (more expensive) way to apply gravity forces, leading to a realistic behaviours when DynamicBody(ies) are exposed to more than a single gravitational body.

Given that the second commit doesn't solve #4164, I put some effort trying at least to show what is happening: the third add a grid (and a way to reset orientation) in `SystemView`. It still useful, and can be used to better understand what `GravPoints` meants, giving also a "reason" to keep feedback when in an empty frame. If enough to close the above issue, I let you decide.

Hope @fluffyfreak find some time to check if the graphic code in third commit is ok, and @jaj22 to check if math in second commit is ok (...which is hard to check given that gravity is a relatively weak force).

@nozmajner , feel free to replace the icons I did: they are really a shame :P

TODO:
1) `Orbit` aren't updated, so they can show a "not real orbit": I think is a little flaw, as they still approximate the behaviours.
2) Autopilot (apart from other improvements) should be aware of changes on gravity.

NITPICKS:
1) Optimize the code in Space as actually is not optimized (thoughts it does not show itself in profiler)
2) Add a "sub-grid" around `m_selectedObject`
3) Limit zoom to show only the entire system
4) Draw "legs" for ships (when system is the actual one's and ships are displayed)
