### PR TITLE
Properly initialize hyperspace cloud graphics when loading.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,4 +80,6 @@ result
 *.VC.db
 /release
 # Core dumps shouldn't be tracked by git.
-.[09][09]*
+.[0-9][0-9]*
+# Don't track C++ language server cache files.
+.ccls-cache

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -11,9 +11,9 @@
 #include "Player.h"
 #include "Ship.h"
 #include "Space.h"
-#include "perlin.h"
-#include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
+#include "graphics/Renderer.h"
+#include "perlin.h"
 
 using namespace Graphics;
 
@@ -52,6 +52,7 @@ HyperspaceCloud::HyperspaceCloud(const Json &jsonObj, Space *space) :
 			Json shipObj = hyperspaceCloudObj["ship"];
 			m_ship = static_cast<Ship *>(Body::FromJson(shipObj, space));
 		}
+		InitGraphics();
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}


### PR DESCRIPTION
When using the `HyperspaceCloud` JSON constructor, the graphic was not properly initialized, causing a null-pointer dereference and subsequent segfault.

Also updated the `.gitignore` to ignore files from CCLS and properly skip coredumps.
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

