### PR TITLE
WIP Add "sponsor us" button to github account

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://www.paypal.com/donate/?token=T4jFnbKQST8inqHgzVR4hewrB7g9lfemmzP3P79Zd_ec6wL_XXvS0i0CYgBmdvTlBkkGl0&country.x=AU&locale.x=


### PR DESCRIPTION
I discovered github has something called "[sponsor button](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository)", so I thought I open this PR to discuss if/what to put in there. 

Ideally, we would have a better/shorter paypal.me/user link. ping @robn?

For an example, see top middle on this project:
https://github.com/atlas-engineer/next

