### PR TITLE
cmake: Don't install .gitignore files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,7 @@ install(TARGETS ${PROJECT_NAME} modelcompiler savegamedump
 install(DIRECTORY data/
 	DESTINATION ${PIONEER_DATA_DIR}
 	REGEX "/models" EXCLUDE
+	PATTERN ".gitignore" EXCLUDE
 	PATTERN "listdata.*" EXCLUDE
 	PATTERN "Makefile.am" EXCLUDE
 )


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This prevents the install process from installing several `.gitignore` files which are obviously not useful to install.

```
$ find package-pioneer/ -iname '*gitignore*'
package-pioneer/usr/share/games/pioneer/music/core/docked/.gitignore
package-pioneer/usr/share/games/pioneer/music/core/near-planet/.gitignore
package-pioneer/usr/share/games/pioneer/music/core/near-spacestation/.gitignore
package-pioneer/usr/share/games/pioneer/music/core/player-destroyed/.gitignore
package-pioneer/usr/share/games/pioneer/music/core/ship-destroyed/.gitignore
package-pioneer/usr/share/games/pioneer/music/core/ship-firing/.gitignore
package-pioneer/usr/share/games/pioneer/music/core/ship-nearby/.gitignore
package-pioneer/usr/share/games/pioneer/music/core/space/.gitignore
package-pioneer/usr/share/games/pioneer/music/core/undocked/.gitignore
```

