### PR TITLE
Use AudioDevices instead of legacy SDL 1.2 code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ result
 .[0-9][0-9]*
 # Don't track C++ language server cache files.
 .ccls-cache
+.clangd/
+.vscode/

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -7,6 +7,7 @@
 #include <SDL.h>
 #include <map>
 #include <string>
+#include <vector>
 
 class Body;
 
@@ -57,8 +58,11 @@ namespace Sound {
 	};
 	typedef Uint32 eventid;
 
-	bool Init();
+	bool Init(bool automaticallyOpenDevice = true);
+	bool InitDevice(std::string &name);
 	void Uninit();
+	std::vector<std::string> &GetAudioDevices();
+	void UpdateAudioDevices();
 	/**
 	 * Silence all active sound events.
 	 */


### PR DESCRIPTION
Refactored Sound.cpp to use the `SDL_AudioDevice` routines instead of the legacy `SDL_Audio` ones. Additionally, I exposed the list of audio devices and provided a mechanism to allow the application to choose a specific one.

Unfortunately, there's no way to get the name of the audio device once it's been opened, so there's a bit more jumping through hoops before we can implement a UI picker for audio devices.

Also, added VSCode and the ClangD language server to the .gitignore list.