### PR TITLE
travis: Install libsigc++@2 instead of libsigc++.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
       - freetype
       - freeimage
       - glew
-      - libsigc++
+      - libsigc++@2
       - libvorbis
       - libpng
       - assimp


### PR DESCRIPTION
Homebrew provides 3.0.0 for libsigc++ and 2.10.2 for libsigc++@2.

https://formulae.brew.sh/formula/libsigc++
https://formulae.brew.sh/formula/libsigc++@2

This hopefully fixes travis, lets see what CI says.
