### PR TITLE
Fix midhyperjump game crash

### DIFF
--- a/data/libs/ui/NavButton.lua
+++ b/data/libs/ui/NavButton.lua
@@ -21,11 +21,11 @@ function NavButton.New (text, target)
 		self.widget.onClick:Connect(function ()
 				if self.target:isa("Body") and self.target:IsDynamic() then
 					Game.player:SetNavTarget(self.target)
-				elseif self.target:IsSameSystem(Game.system.path) then
+				elseif Game.system and self.target:IsSameSystem(Game.system.path) then
 					if self.target.bodyIndex then
 						Game.player:SetNavTarget(Space.GetBody(self.target.bodyIndex))
 					end
-				else
+				elseif not Game.InHyperspace() then
 					Game.player:SetHyperspaceTarget(self.target:GetStarSystem().path)
 					-- XXX we should do something useful here
 					-- e.g. switch to the sector map or just beep


### PR DESCRIPTION
Fixes #4703.

The way the NavButton was written, it looks like it was not expected to be pressed in hyperspace. I added some extra checks that fix the issue. I tried to show the option is disabled in the UI as well,but the :Disable method doesn't seem to do anything.

One more thing that came up is a SIGABRT that's thrown when you're not in the main game view as the hyperjump begins (you can switch to a different window when it's in progress). I tried to find the source but it's a pain to debug. I'm pretty sure that's a relatively new issue (wasn't there a PR that let you jump with the sector map open?), but maybe it's something to do with my setup. Can someone test this?

