### PR TITLE
module-combat (en.json): correct spelling

### DIFF
--- a/data/lang/module-combat/en.json
+++ b/data/lang/module-combat/en.json
@@ -305,7 +305,7 @@
   },
   "RISK_4": {
     "description": "",
-    "message": "The enemy is very well equiped and has access to the latest technology. Be careful!"
+    "message": "The enemy is very well equipped and has access to the latest technology. Be careful!"
   },
   "SET_AS_TARGET": {
     "description": "",


### PR DESCRIPTION
I picked this up from one of WKFO's combat videos on [YouTube](https://youtu.be/i__2Q-pQRGY?t=11): just a simple spelling correction for the English version (equiped -> equipped).

I went through the rest of the file and could not find any more corrections.