### PR TITLE
Optimise sector view and docked face generation

### DIFF
--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -38,7 +38,8 @@ widgetSizes.buttonFullRefuelSize = Vector2(widgetSizes.buttonSizeBase.x*2 + widg
 widgetSizes.buttonLaunchSize = Vector2(widgetSizes.buttonSizeBase.x*5, widgetSizes.buttonSizeBase.y)
 widgetSizes.iconSize = Vector2(0, widgetSizes.buttonSizeBase.y)
 
-local face;
+local face = nil
+local stationSeed = 0
 local shipDef
 local winPos = Vector2(0,0)
 
@@ -291,9 +292,12 @@ StationView:registerView({
 	refresh = function()
 		local station = Game.player:GetDockedWith()
 		shipDef = ShipDef[Game.player.shipId]
-		if(station) then
-			local rand = Rand.New(station.seed)
-			face = InfoFace.New(Character.New({ title = l.STATION_MANAGER }, rand), {windowPadding = widgetSizes.windowPadding, itemSpacing = widgetSizes.itemSpacing})
+		if (station) then
+			if (stationSeed ~= station.seed) then
+				stationSeed = station.seed
+				local rand = Rand.New(station.seed)
+				face = InfoFace.New(Character.New({ title = l.STATION_MANAGER }, rand), {windowPadding = widgetSizes.windowPadding, itemSpacing = widgetSizes.itemSpacing})
+			end
 			hyperdrive = table.unpack(Game.player:GetEquip("engine")) or nil
 			hyperdrive_fuel = hyperdrive and hyperdrive.fuel or Equipment.cargo.hydrogen
 			hyperdriveIcon = PiImage.New("icons/goods/" .. hyperdrive_fuel.icon_name .. ".png")

--- a/src/FaceParts.cpp
+++ b/src/FaceParts.cpp
@@ -350,6 +350,7 @@ static void _pick(Random &rng, int &inout_value, const int limit)
 
 void FaceParts::PickFaceParts(FaceDescriptor &inout_face, const Uint32 seed)
 {
+	PROFILE_SCOPED()
 	Random rand(seed);
 
 	_pick(rand, inout_face.species, NumSpecies());
@@ -376,6 +377,7 @@ void FaceParts::PickFaceParts(FaceDescriptor &inout_face, const Uint32 seed)
 
 void FaceParts::BuildFaceImage(SDL_Surface *faceIm, const FaceDescriptor &face)
 {
+	PROFILE_SCOPED()
 	const Uint32 selector = _make_selector(face.species, face.race, face.gender);
 
 	_blit_image(faceIm, s_partdb->background_general.Get(), 0, 0);

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -19,6 +19,10 @@ LuaManager::LuaManager() :
 	pi_lua_open_standard_base(m_lua);
 	lua_atpanic(m_lua, pi_lua_panic);
 
+	// this will print nothing currently because there's no stack yet, but it means that the function is included
+	// in the codebase and thus available via the "immediate" window in the MSVC debugger for us in any C++ lua function
+	pi_lua_stacktrace(m_lua);
+
 	instantiated = true;
 }
 

--- a/src/LuaUtils.cpp
+++ b/src/LuaUtils.cpp
@@ -1072,3 +1072,18 @@ int secure_trampoline(lua_State *l)
 	lua_CFunction fn = lua_tocfunction(l, lua_upvalueindex(1));
 	return fn(l);
 }
+
+// https://zeux.io/2010/11/07/lua-callstack-with-c-debugger/
+void pi_lua_stacktrace(lua_State *l)
+{
+	lua_Debug entry;
+	int depth = 0;
+
+	while (lua_getstack(l, depth, &entry)) {
+		int status = lua_getinfo(l, "Sln", &entry);
+		assert(status);
+
+		Output("%s(%d): %s\n", entry.short_src, entry.currentline, entry.name ? entry.name : "?");
+		depth++;
+	}
+}

--- a/src/LuaUtils.h
+++ b/src/LuaUtils.h
@@ -83,6 +83,8 @@ bool pi_lua_split_table_path(lua_State *l, const std::string &path);
 
 int secure_trampoline(lua_State *l);
 
+void pi_lua_stacktrace(lua_State *l);
+
 #ifdef DEBUG
 #define LUA_DEBUG_START(luaptr) const int __luaStartStackDepth = lua_gettop(luaptr)
 #define LUA_DEBUG_END(luaptr, expectedStackDiff)                                                   \

--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -111,6 +111,7 @@ namespace Graphics {
 
 	void TextureBuilder::PrepareSurface()
 	{
+		PROFILE_SCOPED()
 		if (m_prepared) return;
 
 		if (!m_surface && !m_filename.empty()) {

--- a/src/graphics/TextureBuilder.h
+++ b/src/graphics/TextureBuilder.h
@@ -60,6 +60,7 @@ namespace Graphics {
 
 		Texture *GetOrCreateTexture(Renderer *r, const std::string &type)
 		{
+			PROFILE_SCOPED()
 			if (m_filename.empty()) {
 				return CreateTexture(r);
 			}

--- a/src/pigui/Face.cpp
+++ b/src/pigui/Face.cpp
@@ -12,6 +12,7 @@ namespace PiGUI {
 
 	Face::Face(FaceParts::FaceDescriptor& face, Uint32 seed)
 	{
+		PROFILE_SCOPED()
 		if (!seed) seed = time(0);
 
 		m_seed = seed;

--- a/src/pigui/LuaFace.cpp
+++ b/src/pigui/LuaFace.cpp
@@ -14,6 +14,7 @@ namespace PiGUI {
 	public:
 		static inline FaceParts::FaceDescriptor _unpack_face(lua_State *l)
 		{
+			PROFILE_SCOPED()
 			FaceParts::FaceDescriptor face;
 
 			LUA_DEBUG_START(l);
@@ -42,6 +43,7 @@ namespace PiGUI {
 
 		static int l_new(lua_State *l)
 		{
+			PROFILE_SCOPED()
 			FaceParts::FaceDescriptor face = _unpack_face(l);
 
 			Uint32 seed = 0;
@@ -55,6 +57,7 @@ namespace PiGUI {
 
 		static int l_face_attr_texture_id(lua_State *l)
 		{
+			PROFILE_SCOPED()
 			Face *f = LuaObject<PiGUI::Face>::CheckFromLua(1);
 			Uint32 result = f->GetTextureId();
 
@@ -64,6 +67,7 @@ namespace PiGUI {
 
 		static int l_face_attr_texture_size(lua_State *l)
 		{
+			PROFILE_SCOPED()
 			Face *f = LuaObject<PiGUI::Face>::CheckFromLua(1);
 			vector2f result = f->GetTextureSize();
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Profiling some unrelated behaviour showed that we had some expensive behaviour going on.

`SectorView` was doing a lot of work displaying labels even when labels weren't being rendered. When they were being rendered there was still a lot of needless work happening. This mostly just moves around some of the tests and checks so it can early out more often.

Second we were rebuilding the station managers face every single frame!
That was obviously very bad and could account for anywhere from 10% to 25% of a frames CPU time! Not only that but it was thrashing texture generation etc.
This was a little tricky to track down and I had to add some additional profiling code and a Lua utility function called `pi_lua_stacktrace` that let me see how the call came up through the Lua callstack.

I've added a semi-dummy call to `pi_lua_stacktrace` in the LuaManager. That way I can use the "immediate" window in the MSVC debugger to get any Lua callstack that I like whenever I want it. Which is amazing and I wish I'd had this for years! 😁 
<!-- Please make sure you've read documentation on contributing -->

