### PR TITLE
Missing Debian/Ubuntu Dependency

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -51,6 +51,7 @@ questions are welcome anytime.
     mesa-common-dev
     libfreeimage-dev
     libglew-dev
+    libfreetype6-dev
     libsigc++-2.0
     libsigc++-2.0-dev
     libvorbis-dev


### PR DESCRIPTION
A build from source is not successful without `libfreetype6-dev`.
This package is available in in the Debian stable repos as well as Ubuntu repos back to 16.04.