### PR TITLE
Use extern template for explicit instantiation

### DIFF
--- a/src/galaxy/GalaxyCache.h
+++ b/src/galaxy/GalaxyCache.h
@@ -6,6 +6,7 @@
 
 #include "JobQueue.h"
 #include "RefCounted.h"
+#include "StarSystem.h"
 #include "galaxy/SystemPath.h"
 #include <functional>
 #include <map>
@@ -115,5 +116,7 @@ typedef GalaxyObjectCache<Sector, SystemPath::LessSectorOnly> SectorCache;
 
 class StarSystem;
 typedef GalaxyObjectCache<StarSystem, SystemPath::LessSystemOnly> StarSystemCache;
+
+extern template class GalaxyObjectCache<StarSystem, SystemPath::LessSystemOnly>;
 
 #endif


### PR DESCRIPTION
See https://twitter.com/ollobrains/status/1189430655345496064

When explicitly instantiating a template, the actual
functions will only appear in the translation unit where
it was explicitly instantiated.

However, the vtable and typeinfo will be duplicated
to all TU that includes `GalaxyCache.h`

The `extern class` explicit instatiation declaration
prevents that.

You can verify that by inspecting an object
file from a TU that includes `GalaxyCache.h`
and verifying that `nm -C objfile.o` does not
include `vtable for GalaxyObjectCache<StarSystem...`

See https://isocpp.org/wiki/faq/cpp11-language-templates#extern-templates

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

