### PR TITLE
Use system time at start

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -35,10 +35,10 @@
 
 static const int s_saveVersion = 85;
 
-Game::Game(const SystemPath &path, double time) :
+Game::Game(const SystemPath &path, const double startDateTime) :
 	m_galaxy(GalaxyGenerator::Create()),
-	m_time(time),
-	m_state(STATE_NORMAL),
+	m_time(startDateTime),
+	m_state(State::STATE_NORMAL),
 	m_wantHyperspace(false),
 	m_timeAccel(TIMEACCEL_1X),
 	m_requestedTimeAccel(TIMEACCEL_1X),
@@ -273,7 +273,7 @@ void Game::TimeStep(float step)
 {
 	PROFILE_SCOPED()
 	m_time += step; // otherwise planets lag time accel changes by a frame
-	if (m_state == STATE_HYPERSPACE && Pi::game->GetTime() >= m_hyperspaceEndTime)
+	if (m_state == State::STATE_HYPERSPACE && Pi::game->GetTime() >= m_hyperspaceEndTime)
 		m_time = m_hyperspaceEndTime;
 
 	m_space->TimeStep(step);
@@ -282,7 +282,7 @@ void Game::TimeStep(float step)
 	m_gameViews->m_cpan->TimeStepUpdate(step);
 	SfxManager::TimeStepAll(step, m_space->GetRootFrame());
 
-	if (m_state == STATE_HYPERSPACE) {
+	if (m_state == State::STATE_HYPERSPACE) {
 		if (Pi::game->GetTime() >= m_hyperspaceEndTime) {
 			SwitchToNormalSpace();
 			m_player->EnterSystem();
@@ -293,7 +293,7 @@ void Game::TimeStep(float step)
 	}
 
 	if (m_wantHyperspace) {
-		assert(m_state == STATE_NORMAL);
+		assert(m_state == State::STATE_NORMAL);
 		SwitchToHyperspace();
 		return;
 	}
@@ -387,7 +387,7 @@ bool Game::UpdateTimeAccel()
 
 void Game::WantHyperspace()
 {
-	assert(m_state == STATE_NORMAL);
+	assert(m_state == State::STATE_NORMAL);
 	m_wantHyperspace = true;
 }
 
@@ -473,7 +473,7 @@ void Game::SwitchToHyperspace()
 	m_hyperspaceDuration = m_player->GetHyperspaceDuration();
 	m_hyperspaceEndTime = Pi::game->GetTime() + m_hyperspaceDuration;
 
-	m_state = STATE_HYPERSPACE;
+	m_state = State::STATE_HYPERSPACE;
 	m_wantHyperspace = false;
 
 	Output("Started hyperspacing...\n");
@@ -605,7 +605,7 @@ void Game::SwitchToNormalSpace()
 
 	m_space->GetBackground()->SetDrawFlags(Background::Container::DRAW_SKYBOX | Background::Container::DRAW_STARS);
 
-	m_state = STATE_NORMAL;
+	m_state = State::STATE_NORMAL;
 }
 
 const float Game::s_timeAccelRates[] = {

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -38,7 +38,7 @@ static const int s_saveVersion = 85;
 Game::Game(const SystemPath &path, const double startDateTime) :
 	m_galaxy(GalaxyGenerator::Create()),
 	m_time(startDateTime),
-	m_state(State::STATE_NORMAL),
+	m_state(State::NORMAL),
 	m_wantHyperspace(false),
 	m_timeAccel(TIMEACCEL_1X),
 	m_requestedTimeAccel(TIMEACCEL_1X),
@@ -273,7 +273,7 @@ void Game::TimeStep(float step)
 {
 	PROFILE_SCOPED()
 	m_time += step; // otherwise planets lag time accel changes by a frame
-	if (m_state == State::STATE_HYPERSPACE && Pi::game->GetTime() >= m_hyperspaceEndTime)
+	if (m_state == State::HYPERSPACE && Pi::game->GetTime() >= m_hyperspaceEndTime)
 		m_time = m_hyperspaceEndTime;
 
 	m_space->TimeStep(step);
@@ -282,7 +282,7 @@ void Game::TimeStep(float step)
 	m_gameViews->m_cpan->TimeStepUpdate(step);
 	SfxManager::TimeStepAll(step, m_space->GetRootFrame());
 
-	if (m_state == State::STATE_HYPERSPACE) {
+	if (m_state == State::HYPERSPACE) {
 		if (Pi::game->GetTime() >= m_hyperspaceEndTime) {
 			SwitchToNormalSpace();
 			m_player->EnterSystem();
@@ -293,7 +293,7 @@ void Game::TimeStep(float step)
 	}
 
 	if (m_wantHyperspace) {
-		assert(m_state == State::STATE_NORMAL);
+		assert(m_state == State::NORMAL);
 		SwitchToHyperspace();
 		return;
 	}
@@ -387,7 +387,7 @@ bool Game::UpdateTimeAccel()
 
 void Game::WantHyperspace()
 {
-	assert(m_state == State::STATE_NORMAL);
+	assert(m_state == State::NORMAL);
 	m_wantHyperspace = true;
 }
 
@@ -473,7 +473,7 @@ void Game::SwitchToHyperspace()
 	m_hyperspaceDuration = m_player->GetHyperspaceDuration();
 	m_hyperspaceEndTime = Pi::game->GetTime() + m_hyperspaceDuration;
 
-	m_state = State::STATE_HYPERSPACE;
+	m_state = State::HYPERSPACE;
 	m_wantHyperspace = false;
 
 	Output("Started hyperspacing...\n");
@@ -605,7 +605,7 @@ void Game::SwitchToNormalSpace()
 
 	m_space->GetBackground()->SetDrawFlags(Background::Container::DRAW_SKYBOX | Background::Container::DRAW_STARS);
 
-	m_state = State::STATE_NORMAL;
+	m_state = State::NORMAL;
 }
 
 const float Game::s_timeAccelRates[] = {

--- a/src/Game.h
+++ b/src/Game.h
@@ -59,8 +59,8 @@ public:
 	void ToJson(Json &jsonObj);
 
 	// various game states
-	bool IsNormalSpace() const { return m_state == State::STATE_NORMAL; }
-	bool IsHyperspace() const { return m_state == State::STATE_HYPERSPACE; }
+	bool IsNormalSpace() const { return m_state == State::NORMAL; }
+	bool IsHyperspace() const { return m_state == State::HYPERSPACE; }
 
 	RefCountedPtr<Galaxy> GetGalaxy() const { return m_galaxy; }
 	Space *GetSpace() const { return m_space.get(); }
@@ -171,8 +171,8 @@ private:
 	std::unique_ptr<Player> m_player;
 
 	enum class State {
-		STATE_NORMAL,
-		STATE_HYPERSPACE,
+		NORMAL,
+		HYPERSPACE,
 	};
 	State m_state;
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -48,7 +48,7 @@ public:
 	static void SaveGame(const std::string &filename, Game *game);
 
 	// start docked in station referenced by path or nearby to body if it is no station
-	Game(const SystemPath &path, double time = 0.0);
+	Game(const SystemPath &path, const double startDateTime = 0.0);
 
 	// load game
 	Game(const Json &jsonObj);
@@ -59,8 +59,8 @@ public:
 	void ToJson(Json &jsonObj);
 
 	// various game states
-	bool IsNormalSpace() const { return m_state == STATE_NORMAL; }
-	bool IsHyperspace() const { return m_state == STATE_HYPERSPACE; }
+	bool IsNormalSpace() const { return m_state == State::STATE_NORMAL; }
+	bool IsHyperspace() const { return m_state == State::STATE_HYPERSPACE; }
 
 	RefCountedPtr<Galaxy> GetGalaxy() const { return m_galaxy; }
 	Space *GetSpace() const { return m_space.get(); }
@@ -170,7 +170,7 @@ private:
 
 	std::unique_ptr<Player> m_player;
 
-	enum State {
+	enum class State {
 		STATE_NORMAL,
 		STATE_HYPERSPACE,
 	};

--- a/src/LuaGame.cpp
+++ b/src/LuaGame.cpp
@@ -63,8 +63,13 @@ static int l_game_start_game(lua_State *l)
 	}
 
 	SystemPath *path = LuaObject<SystemPath>::CheckFromLua(1);
-	const double start_time = luaL_optnumber(l, 2, 0.0);
+	double start_time = luaL_optnumber(l, 2, 0.0);
 	try {
+		if (start_time == 0.0f) {
+			time_t now;
+			time(&now);
+			start_time = difftime(now, 946684799); // <--- Friday, 31 December 1999 23:59:59 GMT+00:00 as UNIX epoch time in seconds
+		}
 		Pi::game = new Game(*path, start_time);
 	} catch (InvalidGameStartLocation &e) {
 		luaL_error(l, "invalid starting location for game: %s", e.error.c_str());


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
When starting a new Game offset the start time from the year 2000, specifically Friday, 31 December 1999 23:59:59 so that the date and time are exactly 1200 years from whenever they start the game.

This is only done when starting a new game, saved games are not affected.

When testing it today my starting date and time were: 3219, Nov 16, 14:47
<!-- Please make sure you've read documentation on contributing -->

