### PR TITLE
Fix OSX Travis deployment

### DIFF
--- a/scripts/build-travis.sh
+++ b/scripts/build-travis.sh
@@ -25,15 +25,19 @@ fi
 echo "Copied binaries."
 
 # Copy the text files.
-ls *.txt | grep -v -E '(COMPILING\.txt|SAVEBUMP\.txt|CMakeLists\.txt)' | xargs cp -t $COPY_DIR
+cp AUTHORS.txt $COPY_DIR
+cp Changelog.txt $COPY_DIR
+cp Modelviewer.txt $COPY_DIR
+cp Quickstart.txt $COPY_DIR
 cp README.md $COPY_DIR
+
 # Copy the licenses
-cp -r licenses -t $COPY_DIR
+cp -R licenses $COPY_DIR
 
 echo "Copied text files."
 
 # Copy the text files
-cp -r data -t $COPY_DIR
+cp -R data $COPY_DIR
 
 echo "Copied data files."
 


### PR DESCRIPTION
OSX cp doesn't allow use of -r or -t, -r can be replaced with -R and -t can be avoided

This was causing the OSX Travis build to fail to deploy, or at least failing to copy files
https://travis-ci.org/pioneerspacesim/pioneer/jobs/613081290#L1006
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

