### PR TITLE
ASAN/valgrind fixes

### DIFF
--- a/src/LZ4Format.cpp
+++ b/src/LZ4Format.cpp
@@ -62,14 +62,14 @@ std::string lz4::DecompressLZ4(const char *data, size_t length)
 	return out;
 }
 
-std::unique_ptr<char> lz4::CompressLZ4(const std::string &data, const int lz4_preset, std::size_t &outSize)
+std::unique_ptr<char[]> lz4::CompressLZ4(const std::string &data, const int lz4_preset, std::size_t &outSize)
 {
 	PROFILE_SCOPED()
 	LZ4F_preferences_t pref = LZ4F_INIT_PREFERENCES;
 	pref.compressionLevel = lz4_preset;
 
 	std::size_t compressBound = LZ4F_compressFrameBound(data.size(), &pref);
-	std::unique_ptr<char> out(new char[compressBound]);
+	std::unique_ptr<char[]> out(new char[compressBound]);
 
 	std::size_t _size = LZ4F_compressFrame(out.get(), compressBound, data.data(), data.size(), &pref);
 	checkError<lz4::CompressionFailedException>(_size);

--- a/src/LZ4Format.h
+++ b/src/LZ4Format.h
@@ -26,5 +26,5 @@ namespace lz4 {
 	// Compresses a block of data according to the lz4 framing format.
 	// If compression fails it throws an exception.
 	// lz4_speed is the compression preset; 0 = default compression, 3-12 = HC compression
-	std::unique_ptr<char> CompressLZ4(const std::string &data, const int lz4_preset, std::size_t &outSize);
+	std::unique_ptr<char[]> CompressLZ4(const std::string &data, const int lz4_preset, std::size_t &outSize);
 } // namespace lz4

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -71,8 +71,6 @@ Ship::Ship(const ShipType::Id &shipId) :
 	ClearAngThrusterState();
 	ClearLinThrusterState();
 
-	InitEquipSet();
-
 	m_hyperspace.countdown = 0;
 	m_hyperspace.now = false;
 	GetFixedGuns()->Init(this);
@@ -81,6 +79,8 @@ Ship::Ship(const ShipType::Id &shipId) :
 	m_curAICmd = 0;
 	m_aiMessage = AIERROR_NONE;
 	m_decelerating = false;
+
+	InitEquipSet();
 
 	SetModel(m_type->modelName.c_str());
 	// Setting thrusters colors

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -80,7 +80,7 @@ namespace Graphics {
 				INSTOFFS_MAT2 = 8,
 				INSTOFFS_MAT3 = 9
 			};
-			std::unique_ptr<matrix4x4f> m_data;
+			std::unique_ptr<matrix4x4f[]> m_data;
 		};
 
 	} // namespace OGL

--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -149,7 +149,7 @@ void BinaryConverter::Save(const std::string &filename, const std::string &savep
 	size_t outSize = 0;
 	const std::string &data = wr.GetData();
 	try {
-		std::unique_ptr<char> compressedData = lz4::CompressLZ4(data, 6, outSize);
+		std::unique_ptr<char[]> compressedData = lz4::CompressLZ4(data, 6, outSize);
 		Output("Compressed model (%s): %.2f KB -> %.2f KB\n", filename.c_str(), data.size() / 1024.f, outSize / 1024.f);
 		fwrite(compressedData.get(), outSize, 1, f);
 		fclose(f);


### PR DESCRIPTION
Fix a few `new[]`/`delete` mismatches and places where we read from memory that hasn't been initialized. Mostly found by valgrind. I tried to get an ASAN build working too but it was a pain(*).

There are probably a lot more - running under valgrind is too slow to interact with the game really so this is just stuff that showed up when running modelcompiler and right at the start of a new game. I didn't, e.g., click around all the different views.

(*) E.g., sigc++ 2 is not ASAN-clean. https://github.com/libsigcplusplus/libsigcplusplus/issues/10