### PR TITLE
Fixed broken player's forum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Pioneer wiki
   http://pioneerwiki.com/wiki/Pioneer_Wiki
 
 Join the player's forum:
-  http://spacesimcentral.com/forum/categories/pioneer
+  http://spacesimcentral.com/community/pioneer/
 
 Join the development forum:
   http://pioneerspacesim.net/forum


### PR DESCRIPTION
http://spacesimcentral.com/forum/categories/pioneer is a broken link, I did some searching around the site and the new link to their Pioneer forum is http://spacesimcentral.com/community/pioneer/

