### PR TITLE
Inno Setup script: Remove old Pioneer files before new install

### DIFF
--- a/pioneer.iss.cmakein
+++ b/pioneer.iss.cmakein
@@ -59,3 +59,6 @@ Source: "@CMAKE_INSTALL_PREFIX@\*"; DestDir: "{app}"; Flags: recursesubdirs crea
 Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 Name: "{commondesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+
+[InstallDelete]
+Type: filesandordirs; Name: "{app}"


### PR DESCRIPTION
This makes sure that we don't have leftover files from an old install of
Pioneer inside the new install.

UNTESTED.

Suggested in bug report #4744.