### PR TITLE
Fix calculation of latitude and longitude for PlanetaryInfo

### DIFF
--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -231,26 +231,24 @@ end
 
 ui.Format = {
 	Latitude = function(decimal_degrees)
-		local deg = math.floor(decimal_degrees + 0.5)
-		local dec = math.abs(decimal_degrees - deg)
 		local prefix = lc.LATITUDE_NORTH_ABBREV
-		if deg < 0 then
+		if decimal_degrees < 0 then
 			prefix = lc.LATITUDE_SOUTH_ABBREV
-			deg = math.abs(deg)
+			decimal_degrees = math.abs(decimal_degrees)
 		end
-		local min = dec * 60
+		local deg = math.floor(decimal_degrees)
+		local min = (decimal_degrees - deg) * 60
 		local sec = (min - math.floor(min)) * 60
 		return string.format('%s %03i°%02i\'%02i"', prefix, deg, min, sec)
 	end,
 	Longitude = function(decimal_degrees)
-		local deg = math.floor(decimal_degrees + 0.5)
-		local dec = math.abs(decimal_degrees - deg)
 		local prefix = lc.LONGITUDE_EAST_ABBREV
-		if deg < 0 then
+		if decimal_degrees < 0 then
 			prefix = lc.LONGITUDE_WEST_ABBREV
-			deg = math.abs(deg)
+			decimal_degrees = math.abs(decimal_degrees)
 		end
-		local min = dec * 60
+		local deg = math.floor(decimal_degrees)
+		local min = (decimal_degrees - deg) * 60
 		local sec = (min - math.floor(min)) * 60
 		return string.format('%s %03i°%02i\'%02i"', prefix, deg, min, sec)
 	end,


### PR DESCRIPTION
Simple fix to the conversion of lat/lon from floating point values to degree/minutes/seconds format, which is done during output formating for the PlanetaryInfo window (bottom right in flight UI).

The old code only yielded minutes in the range of 0 to 29 where the missing range from 30 to 59 was somehow also mapped to 0 to 29, but "flipped". (Will add some examples)
AFAIK this bug existed already for some time (>=1 year) but was apparently not recognised yet.