### PR TITLE
Add a 'FindMostRecentSaveGame' function in Game and use it in MainMenu

### DIFF
--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -36,6 +36,8 @@ local showQuitConfirm = false
 local quitConfirmMsg
 local max_flavours = 22
 
+local canContinue = false
+
 local startLocations = {
 	{['name']=lui.START_AT_MARS,
 	 ['desc']=lui.START_AT_MARS_DESC,
@@ -134,7 +136,7 @@ local function quitGame()
 end
 
 local function continueGame()
-	Game.LoadGame("_exit")
+	Game.LoadGame(canContinue)
 end
 
 local function startAtLocation(location)
@@ -157,7 +159,7 @@ local function callModules(mode)
 end
 
 local function showMainMenu()
-	local canContinue = Game.CanLoadGame('_exit')
+	canContinue = Game.FindMostRecentSaveGame()
 	local buttons = 4
 
 	local winPos = Vector2(ui.screenWidth - mainButtonSize.x - 100, ui.screenHeight/2 - (buttons * mainButtonSize.y)/2 - (2*mainButtonSize.y)/2 - 8)

--- a/src/Game.h
+++ b/src/Game.h
@@ -43,6 +43,7 @@ public:
 	// LoadGame and SaveGame throw exceptions on failure
 	static Game *LoadGame(const std::string &filename);
 	static bool CanLoadGame(const std::string &filename);
+	static std::string FindMostRecentSaveGame();
 	// XXX game arg should be const, and this should probably be a member function
 	// (or LoadGame/SaveGame should be somewhere else entirely)
 	static void SaveGame(const std::string &filename, Game *game);

--- a/src/LuaGame.cpp
+++ b/src/LuaGame.cpp
@@ -218,6 +218,40 @@ static int l_game_can_load_game(lua_State *l)
 }
 
 /*
+ * Function: GetMostRecentSaveGame
+ *
+ * Get the name of the most recent savegame or a boolean false if
+ * any save game is present in save dir
+ *
+ * > Game.GetMostRecentSaveGame()
+ *
+ * Parameters:
+ *
+ *   -
+ *
+ * Return:
+ *
+ *   string representing a filename or false
+ *
+ * Availability:
+ *
+ *   Dec 2019
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_game_most_recent_file_name(lua_State *l)
+{
+	const std::string filename = Game::FindMostRecentSaveGame();
+
+	if (filename.empty()) lua_pushboolean(l, false);
+	else lua_pushlstring(l, filename.c_str(), filename.size());
+
+	return 1;
+}
+
+/*
  * Function: SaveGame
  *
  * Save the current game.
@@ -641,6 +675,7 @@ void LuaGame::Register()
 		{ "StartGame", l_game_start_game },
 		{ "LoadGame", l_game_load_game },
 		{ "CanLoadGame", l_game_can_load_game },
+		{ "FindMostRecentSaveGame", l_game_most_recent_file_name },
 		{ "SaveGame", l_game_save_game },
 		{ "EndGame", l_game_end_game },
 		{ "InHyperspace", l_game_in_hyperspace },


### PR DESCRIPTION
iIn order to generalize the "Continue" button functionality
in `MainMenu`, pick the name of the most recent filename
and return that name to Lua. If it's not possible, return
a boolean `false` to disable that button.

Tested:
1) saving with Ctrl-F9 and reloading > it works
2) renaming save folder > it works (button disabled)

@cwyss , don't get me wrong: I hope you agree this way
is better. And if so, this will supersedes #4758

Oh, I forget it: merry Christmas  to everyone!
