### PR TITLE
Restore feature: maximum display distance for ship indicators

### DIFF
--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -138,7 +138,7 @@ local function displayOnScreenObjects()
 	local iconsize = Vector2(18 , 18)
 	local label_offset = 14 -- enough so that the target rectangle fits
 	local collapse = iconsize
-	local bodies_grouped = ui.getProjectedBodiesGrouped(collapse)
+	local bodies_grouped = ui.getProjectedBodiesGrouped(collapse, IN_SPACE_INDICATOR_SHIP_MAX_DISTANCE)
 
 	for _,group in ipairs(bodies_grouped) do
 		local mainBody = group[2].body

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -1467,6 +1467,7 @@ static int l_pigui_get_projected_bodies_grouped(lua_State *l)
 {
 	PROFILE_SCOPED()
 	const vector2d gap = LuaPull<vector2d>(l, 1);
+	const double ship_max_distance = LuaPull<double>(l, 2);
 
 	TSS_vector filtered;
 	filtered.reserve(Pi::game->GetSpace()->GetNumBodies());
@@ -1474,6 +1475,8 @@ static int l_pigui_get_projected_bodies_grouped(lua_State *l)
 	for (Body *body : Pi::game->GetSpace()->GetBodies()) {
 		if (body == Pi::game->GetPlayer()) continue;
 		if (body->GetType() == Object::PROJECTILE) continue;
+		if (body->GetType() == Object::SHIP &&
+			body->GetPositionRelTo(Pi::player).Length() > ship_max_distance) continue;
 		const TScreenSpace res = lua_world_space_to_screen_space(body); // defined in LuaPiGui.cpp
 		if (!res._onScreen) continue;
 		filtered.emplace_back(res);


### PR DESCRIPTION
Make ship indicators be displayed in game UI _only_ if closer than a certain distance, currently 1000 km.

This feature seems to have been gone since d90e14ec1 (5 May 2019, #4548). I went through the comments, but couldn't find a hint that it was dropped on purpose. Moreover, in `data/pigui/views/game.lua` the constant `IN_SPACE_INDICATOR_SHIP_MAX_DISTANCE` from the old code is still present, but not used anymore.
Hence my conclusion that the feature was lost by accident.

In my restore, I don't use a hard coded value for the maximum distance on the c++ side, but instead pass the value of `IN_SPACE_INDICATOR_SHIP_MAX_DISTANCE` (which is 1000km) in `game.lua` to `getProjectedBodiesGrouped()` as an additional parameter. Code-wise, this is similar to the current radar size being passed to `getTargetsNearby()` in `radar.lua`.

I hope that I did not undo something that was deliberately deleted :-)
Any comments or suggestions welcome!