### PR TITLE
Improve usabiltiy of in-space body indicators

### DIFF
--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -179,6 +179,13 @@ local function displayOnScreenObjects()
 				elseif not group.multiple then
 					-- clicked on single, just set navtarget/combatTarget
 					setTarget(mainBody)
+					if ui.ctrlHeld() then
+						local target = mainBody
+						if target == player:GetSetSpeedTarget() then
+							target = nil
+						end
+						player:SetSetSpeedTarget(target)
+					end
 				else
 					-- clicked on group, show popup
 					ui.openPopup("navtarget" .. mainBody:GetLabel())
@@ -197,13 +204,13 @@ local function displayOnScreenObjects()
 					else
 						player:SetNavTarget(b)
 					end
-				end
-				if ui.ctrlHeld() then
-					local target = b
-					if target == player:GetSetSpeedTarget() then
-						target = nil
+					if ui.ctrlHeld() then
+						local target = b
+						if target == player:GetSetSpeedTarget() then
+							target = nil
+						end
+						player:SetSetSpeedTarget(target)
 					end
-					player:SetSetSpeedTarget(target)
 				end
 			end
 		end)

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -1463,6 +1463,28 @@ bool first_body_is_more_important_than(Body *body, Body *other)
 	return result;
 }
 
+/*
+ * Function: GetProjectedBodiesGrouped
+ *
+ * Returns all bodies visible on screen, grouped into clusters of bodies
+ * that are close together on screen.
+ *
+ * > GetProjectedBodiesGrouped(collapse, ship_max_distance)
+ *
+ * Parameters:
+ *
+ *   collapse - Vector2 defining the screen size of the clusters
+ *
+ *   ship_max_distance - ships farther away than this are not included in the result
+ *
+ * Availability:
+ *
+ *   2019-12
+ *
+ * Status:
+ *
+ *   stable
+ */
 static int l_pigui_get_projected_bodies_grouped(lua_State *l)
 {
 	PROFILE_SCOPED()

--- a/src/LuaPiGui.cpp
+++ b/src/LuaPiGui.cpp
@@ -1467,15 +1467,27 @@ bool first_body_is_more_important_than(Body *body, Body *other)
  * Function: GetProjectedBodiesGrouped
  *
  * Returns all bodies visible on screen, grouped into clusters of bodies
- * that are close together on screen.
+ * which are close together on screen.
  *
- * > GetProjectedBodiesGrouped(collapse, ship_max_distance)
+ * > groups = Engine.pigui.GetProjectedBodiesGrouped(collapse, ship_max_distance)
  *
  * Parameters:
  *
  *   collapse - Vector2 defining the screen size of the clusters
  *
  *   ship_max_distance - ships farther away than this are not included in the result
+ *
+ * Returns:
+ *
+ *   groups - array of info records describing each group
+ *
+ * Fields in info record:
+ *
+ *   screenCoordinates - coordinates of the geometric centre of the group
+ *   mainBody - the main <Body> of the group
+ *   hasNavTarget - true if group contains the player's current navigation target
+ *   multiple - true if group consists of more than one body
+ *   bodies - array of all <Body> objects in the group, sorted by importance
  *
  * Availability:
  *
@@ -1505,78 +1517,79 @@ static int l_pigui_get_projected_bodies_grouped(lua_State *l)
 		filtered.back()._body = body;
 	}
 
-	std::vector<TSS_vector> groups;
-	groups.reserve(filtered.size());
+	struct GroupInfo {
+		Body *m_mainBody;
+		vector2d m_centreCoords; // screen space centre of group
+		vector3d m_worldCoordSum; // coord sum of all bodies in group
+		std::vector<Body *> m_bodies;
+		bool m_hasNavTarget;
 
-	// Perform half-matrix double for
-	for (TSS_vector::iterator it = filtered.begin(); it != filtered.end(); ++it) {
-		TSS_vector group;
-		group.reserve(filtered.end() - it + 1);
-
-		// First element should always be the "media";
-		// so push twice that element:
-		//printf("  Body 1 = %s (%f, %f)\n", (*it)._body->GetLabel().c_str(), (*it)._screenPosition.x, (*it)._screenPosition.y);
-		group.push_back((*it));
-		// Zeroed body so you could distinguish between a "media" element and a "real" element
-		group.back()._body = nullptr;
-		group.push_back((*it));
-
-		// Find near displayed bodies in remaining list of bodies
-		for (TSS_vector::iterator it2 = --filtered.end(); it2 != it;) {
-			//printf("    Body 2 = %s (%f, %f)\n", (*it2)._body->GetLabel().c_str(), (*it2)._screenPosition.x, (*it2)._screenPosition.y);
-			if ((std::abs((*group.begin())._screenPosition.x - (*it2)._screenPosition.x) > gap.x) ||
-				(std::abs((*group.begin())._screenPosition.y - (*it2)._screenPosition.y) > gap.y)) {
-				it2--;
-				continue;
-			}
-			//printf("      %s and %s are near!\n", (*it)._body->GetLabel().c_str(), (*it2)._body->GetLabel().c_str());
-			// There's a "nearest": push it on group, remove from filtered and recalc group center
-			group.push_back(*it2);
-			// nearly-swap&pop: copy last element over *it2 and...
-			(*it2) = filtered.back();
-			// ensure it2 never point past-the-end (thus to rbegin)
-			it2--;
-			// ..."pop"
-			filtered.pop_back();
-			// recalc group (starting with second element because first is the center itself)
-			vector3d media = std::accumulate(group.begin() + 1, group.end(), vector3d(0.0), [](const vector3d &a, const TScreenSpace &ss) {
-				//printf("      Third level with '%s'\n", ss._body->GetLabel().c_str());
-				return a + ss._body->GetPositionRelTo(Pi::player);
-			});
-			media /= double(group.size() - 1);
-			group.front() = lua_world_space_to_screen_space(media);
-			group.front()._body = nullptr; // <- just in case...
+		GroupInfo(Body *b, const vector2d &coords, bool isNavTarget) :
+			m_mainBody(b),
+			m_centreCoords(coords),
+			m_worldCoordSum(b->GetPositionRelTo(Pi::player)),
+			m_hasNavTarget(isNavTarget)
+		{
+			m_bodies.push_back(b);
 		}
-		groups.push_back(std::move(group));
+	};
+	std::vector<GroupInfo> groups;
+	groups.reserve(filtered.size());
+	const Body *nav_target = Pi::game->GetPlayer()->GetNavTarget();
+
+	for (TScreenSpace &obj : filtered) {
+		bool inserted = false;
+		for (GroupInfo &group : groups) {
+			if ((std::abs(group.m_centreCoords.x - obj._screenPosition.x) <= gap.x) &&
+				(std::abs(group.m_centreCoords.y - obj._screenPosition.y) <= gap.y)) {
+				// body inside group boundaries: insert into group
+				group.m_bodies.push_back(obj._body);
+				if (obj._body == nav_target)
+					group.m_hasNavTarget = true;
+
+				// recalc centre
+				group.m_worldCoordSum += obj._body->GetPositionRelTo(Pi::player);
+				vector3d centre = group.m_worldCoordSum / static_cast<double>(group.m_bodies.size());
+				group.m_centreCoords = lua_world_space_to_screen_space(centre)._screenPosition;
+				inserted = true;
+				break;
+			}
+		}
+		if (!inserted) {
+			// create new group
+			GroupInfo newgroup(obj._body, obj._screenPosition,
+				obj._body == nav_target ? true : false);
+			groups.push_back(std::move(newgroup));
+		}
 	}
 
-	// Sort each groups member according to a given function (skipping first element)
-	std::for_each(begin(groups), end(groups), [](TSS_vector &group) {
-		std::sort(begin(group) + 1, end(group), [](TScreenSpace &a, TScreenSpace &b) {
-			return first_body_is_more_important_than(a._body, b._body);
-		});
-	});
+	// Sort each groups member according to a given function
+	for (GroupInfo &group : groups) {
+		std::sort(begin(group.m_bodies), end(group.m_bodies),
+			[](Body *a, Body *b) {
+				return first_body_is_more_important_than(a, b);
+			});
+		// make most important body the main body
+		group.m_mainBody = group.m_bodies.front();
+	}
 
 	LuaTable result(l, groups.size(), 0);
 	int index = 1;
 
-	std::for_each(begin(groups), end(groups), [&l, &result, &index](TSS_vector &group) {
-		int index2 = 1;
-		LuaTable table_group(l, group.size(), 0);
+	for (GroupInfo &group : groups) {
+		LuaTable info_table(l, 0, 5);
+		LuaTable bodies_table(l, group.m_bodies.size(), 0);
 
-		std::for_each(begin(group), end(group), [&l, &table_group, &index2](TScreenSpace &on_screen_object) {
-			LuaTable object(l, 0, 3);
-			object.Set("onscreen", on_screen_object._onScreen);
-			object.Set("screenCoordinates", on_screen_object._screenPosition);
-			if (on_screen_object._body != nullptr)
-				object.Set("body", on_screen_object._body);
-
-			table_group.Set(index2++, object);
-			lua_pop(l, 1);
-		});
-		result.Set(index++, table_group);
+		info_table.Set("screenCoordinates", group.m_centreCoords);
+		info_table.Set("mainBody", group.m_mainBody);
+		bodies_table.LoadVector(group.m_bodies.begin(), group.m_bodies.end());
+		info_table.Set("bodies", bodies_table);
 		lua_pop(l, 1);
-	});
+		info_table.Set("multiple", group.m_bodies.size() > 1 ? true : false);
+		info_table.Set("hasNavTarget", group.m_hasNavTarget);
+		result.Set(index++, info_table);
+		lua_pop(l, 1);
+	}
 	LuaPush(l, result);
 	return 1;
 }


### PR DESCRIPTION
Several fixes to the game UI handling of the in-space body indicators in order to improve their usability:

1. Remove the duplicate entry of the first/main body in the popup for a collapsed group of bodies
2. Adjust location and size of selection area when clicking on a body
3. Clicking on a collapsed navigation target clears the nav target
4. Ctrl-clicking on a body also selects it as the SetSpeedTarget
5. Never collapse the current combat target
6. Use the main body's coordinates to place the indicator of a collapsed group
7. If a collapsed group contains the nav target, this becomes the main body of the group 

These changes fix obvious bugs and also restore old functionality of the game UI as it was pre d90e14e (5 May 2019, #4548). As already mentioned in #4761, I went through the discussion of #4548 but could not find any comments/reasoning for the change of the game UI functionality. For some of the above items however (in particular 6. and 7.), the  new, post d90e14e behaviour might still be the preferred one; this is perhaps subject to debate and/or decision of the maintainers.

The 7 commits of this PR reflect the above items, ordered (roughly) from "obvious bug" to "we might want to keep the new behaviour introduced with d90e14e".

EDIT: Items 1 and 2 squashed into c1c98b7 `Fix in-space body ...`, items 6 and 7 squashed into 322b0c3 `In-space indicator for collapsed ...`

Additional comments to the items:

1. obviously a bug
2. The centre of the selectable area is moved back onto the body. In d90e14e it was shifted to the right of the body onto the label, probably a bug. The size of the area is reduced to that of the nav target box, to prevent overlap of selection areas of nearby bodies. Overlapping areas result in triggering the selection of two bodies while clicking on one body.
3. Since d90e14e it was not possible to deselect a nav target which was part of a collapsed group: clicking on it would only open the group's popup window showing all contained bodies. By contrast, clicking on a nav target that is not part of a group always cleared the nav target.
4. Since d90e14e it was not possible to select a SetSpeedTarget by ctrl-clicking an in-space body (with the notable exception of the main body of a collapsed group.)
5. --
6. d90e14e calculates the geometric centre of each collapsed group, and uses this to place the indicator on screen. This has the effect that when, e.g., approaching the earth-moon system, the indicator representing the collapsed group of earth and moon is placed on the geometric centre, i.e. in the middle between earth and moon. Still the label near the indicator is "Earth (..)", which might wrongly suggest that the indicator represents the position of earth.
7. In d90e14e the "most important" (i.e., the biggest) body of a group is its main body. And the main body's name is displayed next to the onscreen indicator. Hence if the nav target is contained in a group but is not the group's main body, then the indicator of the group is surrounded by the nav target box, but the label displayed next to the indicator / target box is that of the main body, not the nav target. This might be confusing to the user.

@Web-eWorks I also added Lua API documentation for `GetProjectedBodiesGrouped()` :-)

Apologies if this PR is too big, i.e., concerns too many features. But since all of this affects the selection/display of in-space bodies and happens in the same piece of code, I decided to put this in only one PR. Hopefully this also helps when reviewing... :-)