### PR TITLE
Fix mission screen obscuring buttons

### DIFF
--- a/data/pigui/modules/fx-window.lua
+++ b/data/pigui/modules/fx-window.lua
@@ -116,20 +116,16 @@ local function button_info(current_view)
 end
 
 local function button_comms(current_view)
+	if player:IsDocked() then
 	ui.sameLine()
 	if mainMenuButton(icons.comms, current_view == "space_station", lui.HUD_BUTTON_SHOW_COMMS) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f4)) then
-		if player:IsDocked() then
 			if current_view == "space_station" then
 				Game.SetView("world")
 			else
 				Game.SetView("space_station")
 			end
-		else
-			if ui.toggleSystemTargets then
-				ui.toggleSystemTargets()
-			end
-		end
 	end
+end
 end
 
 local function displayFxWindow()

--- a/data/pigui/modules/fx-window.lua
+++ b/data/pigui/modules/fx-window.lua
@@ -117,15 +117,15 @@ end
 
 local function button_comms(current_view)
 	if player:IsDocked() then
-	ui.sameLine()
-	if mainMenuButton(icons.comms, current_view == "space_station", lui.HUD_BUTTON_SHOW_COMMS) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f4)) then
+		ui.sameLine()
+		if mainMenuButton(icons.comms, current_view == "space_station", lui.HUD_BUTTON_SHOW_COMMS) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f4)) then
 			if current_view == "space_station" then
 				Game.SetView("world")
 			else
 				Game.SetView("space_station")
 			end
+		end
 	end
-end
 end
 
 local function displayFxWindow()

--- a/data/pigui/modules/system-overview-window.lua
+++ b/data/pigui/modules/system-overview-window.lua
@@ -174,7 +174,8 @@ local filterText = ""
 local ignore
 local showWindow = false
 local function showInfoWindow()
-	if Game.player:IsDocked() or Game.InHyperspace() or not Game.system.explored then
+	if Game.CurrentView() == "world" and not Game.player:IsDocked() then
+	if Game.InHyperspace() or not Game.system.explored then
 		showWindow = false
 	end
 	local width_fraction = 5
@@ -184,9 +185,7 @@ local function showInfoWindow()
 	local frame_padding = 1
 	local bg_color = colors.buttonBlue
 	local fg_color = colors.white
-	if Game.player:IsDocked() then
-		-- do nothing at all
-	elseif not showWindow then
+	if not showWindow then
 		ui.setNextWindowPos(Vector2(ui.screenWidth - button_size.x * 3 - 10 , 10) , "Always")
 		ui.window("SystemTargetsSmall", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"},
 							function()
@@ -256,6 +255,7 @@ local function showInfoWindow()
 				end)
 		end)
 	end
+end
 end
 ui.registerModule("game", showInfoWindow)
 ui.toggleSystemTargets = function()

--- a/data/pigui/modules/system-overview-window.lua
+++ b/data/pigui/modules/system-overview-window.lua
@@ -175,87 +175,87 @@ local ignore
 local showWindow = false
 local function showInfoWindow()
 	if Game.CurrentView() == "world" and not Game.player:IsDocked() then
-	if Game.InHyperspace() or not Game.system.explored then
-		showWindow = false
-	end
-	local width_fraction = 5
-	local height_fraction = 2
-	local mainButtonSize = Vector2(32,32) * (ui.screenHeight / 1200)
-	local button_size = Vector2(24,24) * (ui.screenHeight / 1200)
-	local frame_padding = 1
-	local bg_color = colors.buttonBlue
-	local fg_color = colors.white
-	if not showWindow then
-		ui.setNextWindowPos(Vector2(ui.screenWidth - button_size.x * 3 - 10 , 10) , "Always")
-		ui.window("SystemTargetsSmall", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"},
-							function()
-								if ui.coloredSelectedIconButton(icons.system_overview, mainButtonSize, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
-									showWindow = true
-								end
-		end)
-	else
-		ui.setNextWindowSize(Vector2(ui.screenWidth / width_fraction, ui.screenHeight / height_fraction) , "Always")
-		ui.setNextWindowPos(Vector2(ui.screenWidth - (ui.screenWidth / width_fraction) - 10 , 10) , "Always")
-		ui.withStyleColors({ ["WindowBg"] = colors.commsWindowBackground }, function()
+		if Game.InHyperspace() or not Game.system.explored then
+			showWindow = false
+		end
+		local width_fraction = 5
+		local height_fraction = 2
+		local mainButtonSize = Vector2(32,32) * (ui.screenHeight / 1200)
+		local button_size = Vector2(24,24) * (ui.screenHeight / 1200)
+		local frame_padding = 1
+		local bg_color = colors.buttonBlue
+		local fg_color = colors.white
+		if not showWindow then
+			ui.setNextWindowPos(Vector2(ui.screenWidth - button_size.x * 3 - 10 , 10) , "Always")
+			ui.window("SystemTargetsSmall", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"},
+			function()
+				if ui.coloredSelectedIconButton(icons.system_overview, mainButtonSize, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
+					showWindow = true
+				end
+			end)
+		else
+			ui.setNextWindowSize(Vector2(ui.screenWidth / width_fraction, ui.screenHeight / height_fraction) , "Always")
+			ui.setNextWindowPos(Vector2(ui.screenWidth - (ui.screenWidth / width_fraction) - 10 , 10) , "Always")
+			ui.withStyleColors({ ["WindowBg"] = colors.commsWindowBackground }, function()
 				ui.withStyleVars({ ["WindowRounding"] = 0.0 }, function()
-						ui.window("SystemTargets", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
-											function()
-												ui.withFont(ui.fonts.pionillium.medium.name, ui.fonts.pionillium.medium.size, function()
-																			--											ignore, shouldSortByPlayerDistance = ui.checkbox("Player Distance", shouldSortByPlayerDistance)
-																			if ui.coloredSelectedIconButton(icons.distance, button_size, shouldSortByPlayerDistance, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SORT_BY_PLAYER_DISTANCE) then
-																				shouldSortByPlayerDistance = not shouldSortByPlayerDistance
-																			end
-																			ui.sameLine()
-																			--											ignore, shouldShowMoons = ui.checkbox("Moons", shouldShowMoons)
-																			if ui.coloredSelectedIconButton(icons.moon, button_size, shouldShowMoons, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_MOONS) then
-																				shouldShowMoons = not shouldShowMoons
-																			end
-																			ui.sameLine()
-																			-- ignore, shouldShowStations = ui.checkbox("Stations", shouldShowStations)
-																			if ui.coloredSelectedIconButton(icons.filter_stations, button_size, shouldShowStations, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_STATIONS) then
-																				shouldShowStations = not shouldShowStations
-																			end
-																			ui.sameLine(ui.getWindowSize().x - button_size.x - 10)
-																			if ui.coloredSelectedIconButton(icons.system_overview, button_size, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
-																				showWindow = false
-																			end
-																			filterText, ignore = ui.inputText("", filterText, {})
-																			ui.sameLine()
-																			ui.icon(icons.filter_bodies, button_size, colors.frame, lui.OVERVIEW_NAME_FILTER)
-																			local sortFunction = shouldSortByPlayerDistance and sortByPlayerDistance or sortBySystemDistance
-																			local filterFunction = function(body)
-																				if body then
-																					-- only plain text matches, no regexes
-																					if filterText ~= "" and filterText ~= nil and not string.find(body.label:lower(), filterText:lower(), 1, true) then
-																						return false
-																					end
-																					if (not shouldShowMoons) and body:IsMoon() then
-																						return false
-																					elseif (not shouldShowStations) and body:IsStation() then
-																						return false
-																					end
-																				end
-																				return true
-																			end
-																			ui.child("spaceTargets", function()
-																								 local root = Space.rootSystemBody
-																								 local tree = calculateEntry(root, nil, Game.player:GetNavTarget(), filterFunction, false)
-																								 if tree then
-																									 ui.columns(2, "spaceTargetColumnsOn", false) -- no border
-																									 ui.setColumnOffset(1, ui.screenWidth / width_fraction * 0.66)
-																									 showEntry(tree, 0, sortFunction)
-																									 ui.columns(1, "spaceTargetColumnsOff", false) -- no border
-																									 ui.radialMenu("systemoverviewspacetargets")
-																								 else
-																									 ui.text(lui.NO_FILTER_MATCHES)
-																								 end
-																			end)
-												end)
+					ui.window("SystemTargets", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
+					function()
+						ui.withFont(ui.fonts.pionillium.medium.name, ui.fonts.pionillium.medium.size, function()
+							--											ignore, shouldSortByPlayerDistance = ui.checkbox("Player Distance", shouldSortByPlayerDistance)
+							if ui.coloredSelectedIconButton(icons.distance, button_size, shouldSortByPlayerDistance, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SORT_BY_PLAYER_DISTANCE) then
+								shouldSortByPlayerDistance = not shouldSortByPlayerDistance
+							end
+							ui.sameLine()
+							--											ignore, shouldShowMoons = ui.checkbox("Moons", shouldShowMoons)
+							if ui.coloredSelectedIconButton(icons.moon, button_size, shouldShowMoons, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_MOONS) then
+								shouldShowMoons = not shouldShowMoons
+							end
+							ui.sameLine()
+							-- ignore, shouldShowStations = ui.checkbox("Stations", shouldShowStations)
+							if ui.coloredSelectedIconButton(icons.filter_stations, button_size, shouldShowStations, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_STATIONS) then
+								shouldShowStations = not shouldShowStations
+							end
+							ui.sameLine(ui.getWindowSize().x - button_size.x - 10)
+							if ui.coloredSelectedIconButton(icons.system_overview, button_size, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
+								showWindow = false
+							end
+							filterText, ignore = ui.inputText("", filterText, {})
+							ui.sameLine()
+							ui.icon(icons.filter_bodies, button_size, colors.frame, lui.OVERVIEW_NAME_FILTER)
+							local sortFunction = shouldSortByPlayerDistance and sortByPlayerDistance or sortBySystemDistance
+							local filterFunction = function(body)
+								if body then
+									-- only plain text matches, no regexes
+									if filterText ~= "" and filterText ~= nil and not string.find(body.label:lower(), filterText:lower(), 1, true) then
+										return false
+									end
+									if (not shouldShowMoons) and body:IsMoon() then
+										return false
+									elseif (not shouldShowStations) and body:IsStation() then
+										return false
+									end
+								end
+								return true
+							end
+							ui.child("spaceTargets", function()
+								local root = Space.rootSystemBody
+								local tree = calculateEntry(root, nil, Game.player:GetNavTarget(), filterFunction, false)
+								if tree then
+									ui.columns(2, "spaceTargetColumnsOn", false) -- no border
+									ui.setColumnOffset(1, ui.screenWidth / width_fraction * 0.66)
+									showEntry(tree, 0, sortFunction)
+									ui.columns(1, "spaceTargetColumnsOff", false) -- no border
+									ui.radialMenu("systemoverviewspacetargets")
+								else
+									ui.text(lui.NO_FILTER_MATCHES)
+								end
+							end)
 						end)
+					end)
 				end)
-		end)
+			end)
+		end
 	end
-end
 end
 ui.registerModule("game", showInfoWindow)
 ui.toggleSystemTargets = function()


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Fixes #4719

Another try, this time commits are fine.
Now if the player is docked or we are not looking into space, the overview window function does nothing at all. In addition, I thought that button "Show Comms" should be removed when it does nothing, that is, when a player is not docked or landed.
