### PR TITLE
fix issues #4468 or #4699 - unpleasant scrollbars

### DIFF
--- a/data/pigui/modules/autopilot-window.lua
+++ b/data/pigui/modules/autopilot-window.lua
@@ -152,9 +152,8 @@ local function displayAutoPilotWindow()
 	if ui.showOptionsWindow then return end
 	player = Game.player
 	local current_view = Game.CurrentView()
-	ui.setNextWindowSize(Vector2(mainButtonSize.x * 6, mainButtonSize.y * 2), "Always")
 	ui.setNextWindowPos(Vector2(ui.screenWidth/2 + ui.reticuleCircleRadius / 4 * 3, ui.screenHeight - mainButtonSize.y * 1.5 - 8) , "Always")
-	ui.window("AutoPilot", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
+	ui.window("AutoPilot", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"},
 						function()
 							if current_view == "world" then
 								button_hyperspace()

--- a/data/pigui/modules/comms.lua
+++ b/data/pigui/modules/comms.lua
@@ -35,7 +35,7 @@ local function displayCommsLog()
 	local current_view = Game.CurrentView()
 	if current_view == "world" then
 		ui.setNextWindowPos(Vector2(10, 10) , "Always")
-		ui.window("CommsLogButton", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
+		ui.window("CommsLogButton", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"},
 							function()
 								if ui.coloredSelectedIconButton(icons.comms, mainButtonSize, nil, mainButtonFramePadding, colors.buttonBlue, colors.white, 'Toggle full comms window') then
 									fullComms = not fullComms

--- a/data/pigui/modules/ship-internals-window.lua
+++ b/data/pigui/modules/ship-internals-window.lua
@@ -131,7 +131,7 @@ local function displayShipFunctionWindow()
 	local current_view = Game.CurrentView()
 	local buttons = 6
 	ui.setNextWindowPos(Vector2(ui.screenWidth/2 - ui.reticuleCircleRadius - (mainButtonSize.x + 2 * mainButtonFramePadding) * buttons, ui.screenHeight - mainButtonSize.y * 3 - 8) , "Always")
-	ui.window("ShipFunctions", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
+	ui.window("ShipFunctions", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"},
 						function()
 							if current_view == "world" then
 								local v = ui.getCursorPos()

--- a/data/pigui/modules/system-overview-window.lua
+++ b/data/pigui/modules/system-overview-window.lua
@@ -188,7 +188,7 @@ local function showInfoWindow()
 		-- do nothing at all
 	elseif not showWindow then
 		ui.setNextWindowPos(Vector2(ui.screenWidth - button_size.x * 3 - 10 , 10) , "Always")
-		ui.window("SystemTargetsSmall", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
+		ui.window("SystemTargetsSmall", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"},
 							function()
 								if ui.coloredSelectedIconButton(icons.system_overview, mainButtonSize, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
 									showWindow = true


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->
@Web-eWorks edit: fixes #4468, fixes #4699

Did not dig deep, just solved the problem for 4 areas - CommsLog button, Overview button, Ship internals buttons and autopilot window buttons. Their parameters are not written or read from the file (imgui.ini), so the window is created exactly as needed for the buttons, and scroll bars do not appear.
Honestly, I don't see any reason to save the parameters of any windows to a file, since they are still calculated every time when rendering. Maybe it's better to disable it all.
