### PR TITLE
CMake profiler build option: support older versions of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ endif (USE_SYSTEM_LIBLUA)
 
 option(PROFILER_ENABLED "Build pioneer with profiling support built-in." OFF)
 if (PROFILER_ENABLED)
-	add_compile_definitions(PIONEER_PROFILER=1)
+	add_definitions(-DPIONEER_PROFILER=1)
 endif(PROFILER_ENABLED)
 
 if (MSVC)


### PR DESCRIPTION
Let's you build pioneer with profiler also under cmake versions less than 3.12.

Thanks to @laarmen for pointing out that the command used so far,

`add_compile_definitions(PIONEER_PROFILER=1)`

actually is a cmake macro, 

> but only available in 3.12 and later, which was released in July 2018.

As it happens, I am still running Debian stretch (old stable), which has cmake 3.7.2. The new stable Debian "buster", released July 2019, has cmake 3.13.4.