### PR TITLE
Add number of total docking pads at station to lobby

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1651,6 +1651,10 @@
     "description": "",
     "message": "Station manager"
   },
+  "STATION_DOCKS": {
+    "description": "Information shown in the station lobby, for total number of docking pads",
+    "message": "Our total capacity is {total_docking_pads} docking pads."
+  },
   "STATION_ORBIT": {
     "description": "Information shown in the station loby",
     "message": "We are in a {orbit_period} day period orbit around {parent_body}."

--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -231,6 +231,8 @@ local function drawPlayerInfo()
 		tech_certified = string.interp(l.TECH_CERTIFIED, { tech_level = station.techLevel})
 	end
 
+	local station_docks = string.interp(l.STATION_DOCKS, { total_docking_pads = string.format("%d", station.numDocks),})
+
 	local orbit_period = station.path:GetSystemBody().orbitPeriod
 
 	local station_orbit_info = ""
@@ -252,6 +254,7 @@ local function drawPlayerInfo()
 					local curPos = ui.getCursorPos()
 					drawTable.withHeading(station.label, orbiteer.xlarge, {
 						{ tech_certified, "" },
+						{ station_docks, "" },
 						{ station_orbit_info, "" },
 					})
 


### PR DESCRIPTION
I've been playing with the lobby (motivated by comments in other [PR](https://github.com/pioneerspacesim/pioneer/pull/4746#issuecomment-575055727)), trying to see how much of that code I can muster. So in experimenting, I added one more info sentence. 

(I imagine these Lobby-sentences, sort of how the pilot annonuces the weather when you land at a new airport)

I'm doing this as WIP, because maybe wording can be better (suggestions?), or I find other stuff to add to it.

Possibly we'd also like to add information about how many ships are currently
docked, as this only shows the total capacity.

![2020-01-18-102555_1600x900_scrot](https://user-images.githubusercontent.com/619390/72661681-7f07e180-39dd-11ea-8aef-994c531103fc.png)
![2020-01-18-102616_1600x900_scrot](https://user-images.githubusercontent.com/619390/72661684-862eef80-39dd-11ea-8990-99e3d27b2484.png)

