### PR TITLE
Fix / improve orbit calculations.

### DIFF
--- a/src/Orbit.cpp
+++ b/src/Orbit.cpp
@@ -75,11 +75,11 @@ static void calc_position_from_mean_anomaly(const double M, const double e, cons
 		for (iter = 0; iter < 10; iter++) {
 			double dE = (E - e * (sin(E)) - M) / (1.0 - e * cos(E));
 			E = E - dE;
-			if(fabs(dE) < 0.0001) break;
+			if (fabs(dE) < 0.0001) break;
 		}
 		// method above sometimes can't find the solution
 		// especially when e approaches 1
-		if(iter == 10){ // most likely no solution found
+		if (iter == 10) { // most likely no solution found
 			//failsafe to bisection method
 			//max(E - M) == 1, so safe interval is M+-1.1
 			double Emin = M - 1.1;
@@ -87,16 +87,13 @@ static void calc_position_from_mean_anomaly(const double M, const double e, cons
 			double Ymin = Emin - e * sin(Emin) - M;
 			double Ymax = Emax - e * sin(Emax) - M;
 			double Y;
-			for(int i = 0; i < 14; i++){ // 14 iterations for precision 0.00006
+			for (int i = 0; i < 14; i++) { // 14 iterations for precision 0.00006
 				E = (Emin + Emax) / 2;
 				Y = E - e * sin(E) - M;
-				if((Ymin * Y) < 0)
-				{
+				if ((Ymin * Y) < 0) {
 					Ymax = Y;
 					Emax = E;
-				}
-				else
-				{
+				} else {
 					Ymin = Y;
 					Emin = E;
 				}
@@ -120,7 +117,7 @@ static void calc_position_from_mean_anomaly(const double M, const double e, cons
 		for (int iter = 50; iter > 0; --iter) {
 			double d_sh = (M + e * sh - asinh(sh)) / (e - 1 / sqrt(1 + (sh * sh)));
 			sh = sh - d_sh;
-			if(fabs(d_sh) < 0.0001) break;
+			if (fabs(d_sh) < 0.0001) break;
 		}
 
 		double ch = sqrt(1 + sh * sh);
@@ -353,15 +350,15 @@ Orbit Orbit::FromBodyState(const vector3d &pos, const vector3d &vel, double cent
 	//  3. orbitalPhaseAtStart (=offset) is calculated from r = a ((e^2 - 1)/(1 + e cos(v) ))
 	double off = 0;
 
-		if (ret.m_eccentricity < 1) {
-			off = ret.m_semiMajorAxis * (1 - ret.m_eccentricity * ret.m_eccentricity) - r_now;
-		} else {
-			off = ret.m_semiMajorAxis * (-1 + ret.m_eccentricity * ret.m_eccentricity) - r_now;
-		}
+	if (ret.m_eccentricity < 1) {
+		off = ret.m_semiMajorAxis * (1 - ret.m_eccentricity * ret.m_eccentricity) - r_now;
+	} else {
+		off = ret.m_semiMajorAxis * (-1 + ret.m_eccentricity * ret.m_eccentricity) - r_now;
+	}
 
-		// correct sign of offset is given by sign pos.Dot(vel) (heading towards apohelion or perihelion?]
-		off = Clamp(off / (r_now * ret.m_eccentricity), -1.0, 1.0);
-		off = -pos.Dot(vel) / fabs(pos.Dot(vel)) * acos(off);
+	// correct sign of offset is given by sign pos.Dot(vel) (heading towards apohelion or perihelion?]
+	off = Clamp(off / (r_now * ret.m_eccentricity), -1.0, 1.0);
+	off = -pos.Dot(vel) / fabs(pos.Dot(vel)) * acos(off);
 
 	//much simpler and satisfies the specified conditions
 	//and does not have unstable places (almost almost)


### PR DESCRIPTION
# Motivation
If you start a new game, open the system map, and turn on the display of ships, you can see their flickering, which lasts several minutes. Then the situation seems to improve, but still some ships sometimes begin to flicker. Sometimes the ship begins to fly away with acceleration to infinity, sometimes it jerks back and forth. All this ruins the impression of the game, in my opinion.

# Investigation

The problem of the entire instability of the positions of the ships turned out to be that, to display them on the map, first the orbit parameters are calculated by their coordinates, and then their position is calculated again by these parameters. This is necessary in order to rewind time back and forth.
А simple solution for the present time would be to simply store the ship's coordinates inside the orbit at t = 0 and issue them when requested, but this would not solve the problem of coordinate prediction in the future.
so I decided to leave it as it is, just improve the accuracy and stability of the calculations.

# What was done

dc05993

1. it turned out that numerical methods are implemented with a fixed number of iterations (5), and they are not always enough. Moreover, testing showed that in some cases the solution does not converge and even 10,000 iterations are not enough. Therefore, a more slowly converging bisection method was added, in case the main method fails in 10 iterations.
2. When the ship has low speed, its orbit is a very elongated ellipse, and its true anomaly is very very close to pi. Trimming the variable to 1 - 1e-6 before taking the arccos does not allow it to get close to pi enough, so there is a strong shift from the true position. Therefore, it was removed.

633e996 

1. It was found that the orbit orientation matrix is calculated through the Euler angles, which are calculated from the velocity and position vectors, and many divisions are made in which the denominator can unpredictably approach 0. All this was removed since the matrix is easily calculated directly from the vectors.
2. When moving from an elliptical orbit to a hyperbolic one, the eccentricity passes through 1 (parabola), when the average anomaly is zero everywhere, except for infinity. Therefore, the ship at this time is attracted to the point of the pericenter, because there is not enough accuracy to go from the true anomaly to the mean anomaly and back, and stay in the same coordinates. Therefore, I suggest jumping from an ellipse with e = 0.9999 to a hyperbole with e = 1.0001. These orbits are very similar, almost identical. Moreover, ellipses with 0.9999 < e < 1 are also considered as hyperbolas, so that there are no distortions at a low speed of the ship.

# Result

After these changes in the code, the positions of the ships on the system map are stabilized, no problems have been identified.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

