### PR TITLE
Add keybinding "Toggle Lua Console" to settings menu

### DIFF
--- a/data/lang/input-core/en.json
+++ b/data/lang/input-core/en.json
@@ -43,6 +43,10 @@
     "description": "Descriptive name for the CycleCameraMode action.",
     "message": "Cycle Camera Mode"
   },
+  "BIND_DECREASE_SCAN_RANGE": {
+    "description": "Descriptive name for the BindDecreaseScanRange action.",
+    "message": "Decrease Radar Scan Range"
+  },
   "BIND_DECREASE_TIME_ACCELERATION": {
     "description": "Descriptive name for the DecreaseTimeAcceleration action.",
     "message": "Decrease Time Acceleration"
@@ -50,6 +54,10 @@
   "BIND_FRONT_CAMERA": {
     "description": "Descriptive name for the FrontCamera action.",
     "message": "Switch to Front Camera"
+  },
+  "BIND_INCREASE_SCAN_RANGE": {
+    "description": "Descriptive name for the BindIncreaseScanRange action.",
+    "message": "Increase Radar Scan Range"
   },
   "BIND_INCREASE_TIME_ACCELERATION": {
     "description": "Descriptive name for the IncreaseTimeAcceleration action.",
@@ -115,6 +123,10 @@
     "description": "Descriptive name for the ToggleRotationDamping action.",
     "message": "Toggle Rotation Damping"
   },
+  "BIND_TOGGLE_SCAN_MODE": {
+    "description": "Descriptive name for the BindToggleScanMode action.",
+    "message": "Toggle Radar Scan Mode"
+  },
   "BIND_TOGGLE_SET_SPEED": {
     "description": "Descriptive name for the ToggleSetSpeed action.",
     "message": "Toggle Speed Control Mode"
@@ -137,6 +149,10 @@
   },
   "GROUP_MISCELLANEOUS": {
     "message": "Miscellaneous"
+  },
+  "GROUP_RADAR_CONTROL": {
+    "description": "Header for the Radar control input in settings window.",
+    "message": "Radar Control"
   },
   "GROUP_SHIP_ORIENT": {
     "description": "Header for the ShipOrient input group.",

--- a/data/lang/input-core/en.json
+++ b/data/lang/input-core/en.json
@@ -107,6 +107,10 @@
     "description": "Descriptive name for the ToggleHudMode action.",
     "message": "Toggle HUD Mode"
   },
+  "BIND_TOGGLE_LUA_CONSOLE": {
+    "description": "Descriptive name for the ToggleLuaConsole action.",
+    "message": "Toggle Lua Console"
+  },
   "BIND_TOGGLE_ROTATION_DAMPING": {
     "description": "Descriptive name for the ToggleRotationDamping action.",
     "message": "Toggle Rotation Damping"

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -77,6 +77,7 @@ void WorldView::RegisterInputBindings()
 	KEY_BINDING(toggleHudMode, "BindToggleHudMode", SDLK_TAB, 0)
 	KEY_BINDING(increaseTimeAcceleration, "BindIncreaseTimeAcceleration", SDLK_PAGEUP, 0)
 	KEY_BINDING(decreaseTimeAcceleration, "BindDecreaseTimeAcceleration", SDLK_PAGEDOWN, 0)
+	KEY_BINDING(toggleLuaConsole, "BindToggleLuaConsole", SDLK_BACKQUOTE, 0)
 }
 
 void WorldView::InitObject()
@@ -989,4 +990,5 @@ void WorldView::HandleSDLEvent(SDL_Event &event)
 	InputBindings.toggleHudMode->CheckSDLEventAndDispatch(&event);
 	InputBindings.increaseTimeAcceleration->CheckSDLEventAndDispatch(&event);
 	InputBindings.decreaseTimeAcceleration->CheckSDLEventAndDispatch(&event);
+	InputBindings.toggleLuaConsole->CheckSDLEventAndDispatch(&event);
 }

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -166,6 +166,7 @@ private:
 		ActionBinding *toggleHudMode;
 		ActionBinding *increaseTimeAcceleration;
 		ActionBinding *decreaseTimeAcceleration;
+		ActionBinding *toggleLuaConsole;
 	} InputBindings;
 };
 

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -82,6 +82,11 @@ void PlayerShipController::RegisterInputBindings()
 	auto speedGroup = controlsPage->GetBindingGroup("SpeedControl");
 	InputBindings.speedControl = Pi::input.AddAxisBinding("BindSpeedControl", speedGroup, AxisBinding(SDLK_RETURN, SDLK_RSHIFT));
 	InputBindings.toggleSetSpeed = Pi::input.AddActionBinding("BindToggleSetSpeed", speedGroup, ActionBinding(SDLK_v));
+
+	auto radarGroup = controlsPage->GetBindingGroup("RadarControl");
+	InputBindings.toggleScanMode = Pi::input.AddActionBinding("BindToggleScanMode", radarGroup, ActionBinding(SDLK_BACKSLASH));
+	InputBindings.increaseScanRange = Pi::input.AddActionBinding("BindIncreaseScanRange", radarGroup, ActionBinding(SDLK_RIGHTBRACKET));
+	InputBindings.decreaseScanRange = Pi::input.AddActionBinding("BindDecreaseScanRange", radarGroup, ActionBinding(SDLK_LEFTBRACKET));
 }
 
 PlayerShipController::~PlayerShipController()

--- a/src/ship/PlayerShipController.h
+++ b/src/ship/PlayerShipController.h
@@ -79,6 +79,11 @@ private:
 		// Speed Control
 		AxisBinding *speedControl;
 		ActionBinding *toggleSetSpeed;
+
+		// Radar Control
+		ActionBinding *toggleScanMode;
+		ActionBinding *increaseScanRange;
+		ActionBinding *decreaseScanRange;
 	} InputBindings;
 
 	// FIXME: separate the propusion controller from the input system, pass in wanted velocity correction directly.


### PR DESCRIPTION
We need to be able to select this, as default "`" can be located in retarded
position at some keyboard layouts.

I'd like to have a discussion as if there's a reason why a load of key-bindings aren't exposed to lua? Is this on purpose? E.g. `SECTOR_MAP_VIEW`, `EXTERNAL_VIEW`, `RADAR_CONTROL`?

1. do we want them in settings menu?
2. is that to be done for this PR?

__EDIT__ I'd like to have `WITH_DEVKEYS` as well, so players/devs easily can see what keys are available, and I think having dev tools easily accessible encourages dev-ing.