### PR TITLE
Small additional improvements to orbit calculation

### DIFF
--- a/src/Orbit.cpp
+++ b/src/Orbit.cpp
@@ -332,7 +332,8 @@ Orbit Orbit::FromBodyState(const vector3d &pos, const vector3d &vel, double cent
 	if (ret.m_eccentricity < 0.0) ret.m_eccentricity = 0.0;
 	ret.m_eccentricity = sqrt(ret.m_eccentricity);
 	//avoid parabola
-	if (ret.m_eccentricity < 1.0001 && ret.m_eccentricity > 0.9999) ret.m_eccentricity = 1.0001;
+	if (ret.m_eccentricity < 1.0001 && ret.m_eccentricity >= 1) ret.m_eccentricity = 1.0001;
+	if (ret.m_eccentricity > 0.9999 && ret.m_eccentricity < 1) ret.m_eccentricity = 0.9999;
 
 	// lines represent these quantities:
 	// 		(e M G)^2
@@ -343,6 +344,11 @@ Orbit Orbit::FromBodyState(const vector3d &pos, const vector3d &vel, double cent
 	if (ret.m_semiMajorAxis < 0) ret.m_semiMajorAxis = 0;
 	ret.m_semiMajorAxis = (sqrt(ret.m_semiMajorAxis) - u) / (2 * EE);
 	ret.m_semiMajorAxis = ret.m_semiMajorAxis / fabs(1.0 - ret.m_eccentricity);
+
+	// clipping of the eccentricity leads to a strong decrease in the semimajor axis.
+	// at low speed, since the ship is almost in the apocenter, semimajor axis should be
+	// almost equal to half distance to the star (no less that's for sure)
+	if (ret.m_eccentricity < 1 && ret.m_semiMajorAxis < r_now / 2) ret.m_semiMajorAxis = r_now / 2;
 
 	// The formulas for rotation matrix were derived based on following assumptions:
 	//	1. Trajectory follows Kepler's law and vector {-r cos(v), -r sin(v), 0}, r(t) and v(t) are parameters.


### PR DESCRIPTION
Sorry for not noticing this right away. When the ship takes off from the planet, the eccentricity of its orbit is for some time in the range 0.9999 .. 1 and turns into a hyperbole 1.0001. The velocity vector is directed from the planet, so a line is drawn that goes from the ship to infinity. It is not right. These changes solve the problem.
Everything seems to be taken into account now. Feel free to kick.

## Changes explained
### Was:
orbit with 0.9999 < e < 1.0001 forced to e = 1.0001 (hyperbola)
### Now:
orbit with 0.9999 < e < 1      forced to e = 0.9999 (ellipse)
orbit with 1   <=   e < 1.0001 forced to e = 1.0001 (hyperbola)

In an elliptical orbit, when the eccentricity is fixed at 0.9999, and
the speed increases, the semi-major axis shrinks and the apocenter moves
toward the star. Therefore, a condition check has been added that prevents
the ship from shifting in this case.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

