### PR TITLE
Minor improvements to System Map

### DIFF
--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -764,23 +764,23 @@ void SystemView::PutBody(const SystemBody *b, const vector3d &offset, const matr
 		if (Pi::player->IsDocked()) {
 			if (m_time == t0) PutSelectionBox(offset + Pi::player->GetPositionRelTo(frame->GetId()) * static_cast<double>(m_zoom), Color::RED);
 		} else {
-		Orbit playerOrbit = Pi::player->ComputeOrbit();
+			Orbit playerOrbit = Pi::player->ComputeOrbit();
 
-		PutOrbit(&playerOrbit, offset, Color::RED, b->GetRadius());
+			PutOrbit(&playerOrbit, offset, Color::RED, b->GetRadius());
 
-		const double plannerStartTime = m_planner->GetStartTime();
-		if (!m_planner->GetPosition().ExactlyEqual(vector3d(0, 0, 0))) {
-			Orbit plannedOrbit = Orbit::FromBodyState(m_planner->GetPosition(),
-				m_planner->GetVel(),
-				frame->GetSystemBody()->GetMass());
-			PutOrbit(&plannedOrbit, offset, Color::STEELBLUE, b->GetRadius());
-			if (std::fabs(m_time - t0) > 1. && (m_time - plannerStartTime) > 0.)
-				PutSelectionBox(offset + plannedOrbit.OrbitalPosAtTime(m_time - plannerStartTime) * static_cast<double>(m_zoom), Color::STEELBLUE);
-			else
-				PutSelectionBox(offset + m_planner->GetPosition() * static_cast<double>(m_zoom), Color::STEELBLUE);
-		}
+			const double plannerStartTime = m_planner->GetStartTime();
+			if (!m_planner->GetPosition().ExactlyEqual(vector3d(0, 0, 0))) {
+				Orbit plannedOrbit = Orbit::FromBodyState(m_planner->GetPosition(),
+					m_planner->GetVel(),
+					frame->GetSystemBody()->GetMass());
+				PutOrbit(&plannedOrbit, offset, Color::STEELBLUE, b->GetRadius());
+				if (std::fabs(m_time - t0) > 1. && (m_time - plannerStartTime) > 0.)
+					PutSelectionBox(offset + plannedOrbit.OrbitalPosAtTime(m_time - plannerStartTime) * static_cast<double>(m_zoom), Color::STEELBLUE);
+				else
+					PutSelectionBox(offset + m_planner->GetPosition() * static_cast<double>(m_zoom), Color::STEELBLUE);
+			}
 
-		PutSelectionBox(offset + playerOrbit.OrbitalPosAtTime(m_time - t0) * double(m_zoom), Color::RED);
+			PutSelectionBox(offset + playerOrbit.OrbitalPosAtTime(m_time - t0) * double(m_zoom), Color::RED);
 		}
 	}
 
@@ -1057,7 +1057,7 @@ void SystemView::PrepareGrid()
 
 	m_displayed_sbody.clear();
 	if (m_gridDrawing == GridDrawing::GRID_AND_LEGS) {
-			m_displayed_sbody = m_system->GetRootBody()->CollectAllChildren();
+		m_displayed_sbody = m_system->GetRootBody()->CollectAllChildren();
 	}
 }
 


### PR DESCRIPTION
### 1. Reject back-projected 2d objects.
Since the function Gui::Screen::Project does not cull points (and most likely should not), this must be done manually, as was done in the SectorView.cpp for labels:
https://github.com/pioneerspacesim/pioneer/blob/105d06e33fcb5b565e3431fc694525e0546a784e/src/SectorView.cpp#L399-L402
Checking z < 1 in the Normalized Device Coordinates discards points that are further than the zfar clipping plane, and beyond the center of the camera. The points between the center of the camera and the znear clipping plane remain. They may be needed.

### 2. Adjust z-far plane for projection to clip space.
With a severe zooming in, the coordinates of objects can become too large and fly out of the z-far plane. Therefore, it was done so that the z-far plane moved away proportionally. But with a severe zooming out, it z-far plane can become smaller than DEFAULT_VIEW_DISTANCE, and this is also taken into account.

### 3. Change the axis of rotation when dragging the mouse horizontally.
Set horizontal rotation around the axis of the ecliptic. It seems to me that it's more convenient to examine the system. For good, it was necessary to rename the variable from **m_rot_z** to **m_rot_y**, but I did not want to recompile everything.

### 4. Do not calculate and draw the player's orbit when it is docked or landed.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

