### PR TITLE
Some fixes to the handling of in-space bodies in flight-ui

### DIFF
--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -139,12 +139,12 @@ local function displayOnScreenObjects()
 	local should_show_label = ui.shouldShowLabels()
 	local iconsize = Vector2(18 , 18)
 	local label_offset = 14 -- enough so that the target rectangle fits
-	local collapse = iconsize -- size of clusters to be collapsed into single bodies
-	local click_radius = collapse:length() * 0.5
+	local cluster_size = iconsize.x -- size of clusters to be collapsed into single bodies
+	local click_radius = cluster_size * 0.5
 	-- make click_radius sufficiently smaller than the cluster size
 	-- to prevent overlap of selection regions
 
-	local bodies_grouped = ui.getProjectedBodiesGrouped(collapse, IN_SPACE_INDICATOR_SHIP_MAX_DISTANCE)
+	local bodies_grouped = ui.getProjectedBodiesGrouped(cluster_size, IN_SPACE_INDICATOR_SHIP_MAX_DISTANCE)
 
 	for _,group in ipairs(bodies_grouped) do
 		local mainBody = group.mainBody

--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -170,23 +170,27 @@ local function displayOnScreenObjects()
 		-- mouse release handler
 		if (mp - mainCoords):length() < click_radius then
 			if not ui.isAnyWindowHovered() and ui.isMouseReleased(0) then
-				if group.hasNavTarget then
-					-- if clicked and has nav target, unset nav target
-					player:SetNavTarget(nil)
-					navTarget = nil
-				elseif combatTarget == mainBody then
-					-- if clicked and has combat target, unset nav target
-					player:SetCombatTarget(nil)
-					combatTarget = nil
+				if group.hasNavTarget or combatTarget == mainBody then
+					-- if clicked and is target, unset target
+					if group.hasNavTarget then
+						player:SetNavTarget(nil)
+					else
+						player:SetCombatTarget(nil)
+					end
+					-- if not in setspeed mode or ctrl-click and is setspeed target,
+					-- clear setspeed target
+					if not player:GetSetSpeed() or (ui.ctrlHeld() and group.hasSetSpeedTarget) then
+						player:SetSetSpeedTarget(nil)
+					end
 				elseif not group.multiple then
 					-- clicked on single, just set navtarget/combatTarget
 					setTarget(mainBody)
 					if ui.ctrlHeld() then
-						local target = mainBody
-						if target == player:GetSetSpeedTarget() then
-							target = nil
-						end
-						player:SetSetSpeedTarget(target)
+						-- also set setspeed target on ctrl-click
+						player:SetSetSpeedTarget(mainBody)
+					elseif not player:GetSetSpeed() then
+						-- clear setspeed target if not in setspeed mode
+						player:SetSetSpeedTarget(nil)
 					end
 				else
 					-- clicked on group, show popup
@@ -207,11 +211,11 @@ local function displayOnScreenObjects()
 						player:SetNavTarget(b)
 					end
 					if ui.ctrlHeld() then
-						local target = b
-						if target == player:GetSetSpeedTarget() then
-							target = nil
-						end
-						player:SetSetSpeedTarget(target)
+						-- also set setspeed target on ctrl-click
+						player:SetSetSpeedTarget(b)
+					elseif not player:GetSetSpeed() then
+						-- clear setspeed target if not in setspeed mode
+						player:SetSetSpeedTarget(nil)
 					end
 				end
 			end

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -144,11 +144,7 @@ local function continueGame()
 end
 
 local function canContinue()
-	if Game.CanLoadGame('_exit') or Game.CanLoadGame('_quicksave') then
-		return true
-	else
-		return false
-	end
+	return Game.CanLoadGame('_exit') or Game.CanLoadGame('_quicksave')
 end
 
 local function startAtLocation(location)

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -249,9 +249,9 @@ void Player::SetCombatTarget(Body *const target, bool setSpeedTo)
 	Pi::onPlayerChangeTarget.emit();
 }
 
-void Player::SetNavTarget(Body *const target, bool setSpeedTo)
+void Player::SetNavTarget(Body *const target)
 {
-	static_cast<PlayerShipController *>(m_controller)->SetNavTarget(target, setSpeedTo);
+	static_cast<PlayerShipController *>(m_controller)->SetNavTarget(target);
 	Pi::onPlayerChangeTarget.emit();
 }
 

--- a/src/Player.h
+++ b/src/Player.h
@@ -36,7 +36,7 @@ public:
 	Body *GetNavTarget() const;
 	Body *GetSetSpeedTarget() const;
 	void SetCombatTarget(Body *const target, bool setSpeedTo = false);
-	void SetNavTarget(Body *const target, bool setSpeedTo = false);
+	void SetNavTarget(Body *const target);
 	void SetSetSpeedTarget(Body *const target);
 	void ChangeSetSpeed(double delta);
 

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -412,17 +412,11 @@ void PlayerShipController::SetCombatTarget(Body *const target, bool setSpeedTo)
 {
 	if (setSpeedTo)
 		m_setSpeedTarget = target;
-	else if (m_setSpeedTarget == m_combatTarget)
-		m_setSpeedTarget = 0;
 	m_combatTarget = target;
 }
 
-void PlayerShipController::SetNavTarget(Body *const target, bool setSpeedTo)
+void PlayerShipController::SetNavTarget(Body *const target)
 {
-	if (setSpeedTo)
-		m_setSpeedTarget = target;
-	else if (m_setSpeedTarget == m_navTarget)
-		m_setSpeedTarget = 0;
 	m_navTarget = target;
 }
 

--- a/src/ship/PlayerShipController.h
+++ b/src/ship/PlayerShipController.h
@@ -47,7 +47,7 @@ public:
 	Body *GetNavTarget() const;
 	Body *GetSetSpeedTarget() const override;
 	void SetCombatTarget(Body *const target, bool setSpeedTo = false);
-	void SetNavTarget(Body *const target, bool setSpeedTo = false);
+	void SetNavTarget(Body *const target);
 	void SetSetSpeedTarget(Body *const target);
 
 	sigc::signal<void> onRotationDampingChanged;


### PR DESCRIPTION
I noticed a few issues that remained after #4764:

- In certain (rare) situations it is possible that two clusters of bodies are displayed very close to one another, closer than the cluster size. The problem is not the algorithm which groups the bodies into clusters, but the fact that after creating the clusters, when the bodies of each cluster are sorted according to their importance, the most important body becomes the new main body. That is, the clusters remain unchanged, but the main body which is used to put the body icon on screen might not be the centre of the cluster anymore.

  As an example, in the following savefile Ceres and Jupiter are very close together on screen and cause the described problem: [debug_grouped.gz](https://github.com/pioneerspacesim/pioneer/files/4209073/debug_grouped.gz)

  The fix I implemented is to make sure that already when grouping the bodies into clusters a new body immediately becomes the new main body if it is more important than the old one.

- The old cluster area was rectangular. This makes the clusters depend on the viewing angle: If you roll your ship around a cluster, so that a body's relative position to a cluster changes e.g. from left of the centre to upper-left of the centre, the body may be absorbed into the cluster and then pop out again once it is directly above the centre. 

  I found this behaviour odd, and so I changed the cluster area to a circle.

- When using setspeed mode with a setspeed target different than the frame of reference (i.e. ctrl-selecting that target), the setspeed target is reset to the frame of reference once you select any other target. This is rather unpleasent when you want to use setspeed to accelerate towards some planet, and then want to set a different nav target - temporarily only - to check e.g. your relative speed against it.

  I implemented the following new behaviour:
    - Don't clear the setspeed target when in setspeed mode and a
      different nav target is selected.
    
    - Change or clear the setspeed target in setspeed mode when
      ctrl-selecting a new nav target or ctrl-deselecting the old
      setspeed target, respectively.
    
    - When not in setspeed mode, implicitly clear the setspeed target on
      any target change.

  The last one is to keep you from surprises in case you forget that some setspeed target was ctrl-selected and you are now on some different body and turn on setspeed mode to hover, e.g. Since you probably selected some other target in the meantime, the old setspeed target was implicitly cleared and setspeed is thus again relative to body over which you want to hover.

- The last commit is not really related to in-space bodies but only a small lua code clean-up suggested in https://github.com/pioneerspacesim/pioneer/pull/4758#discussion_r373876072