### PR TITLE
Captains log, star date 2020...

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -35,6 +35,10 @@
     "description": "",
     "message": "An error has occurred"
   },
+  "ARRIVAL_DATE": {
+    "description": "Time of arrival, used in flight log",
+    "message": "Arrival date"
+  },
   "ATMOSPHERIC_SHIELDING": {
     "description": "Used in ShipInfo view, followed by a yes/no depending on if the ship can carry atmospheric shields",
     "message": "Atmospheric shielding"
@@ -259,6 +263,10 @@
     "description": "Player combat rating",
     "message": "Dangerous"
   },
+  "DATE": {
+    "description": "Date of an event, used in flight log",
+    "message": "Date"
+  },
   "DEADLY": {
     "description": "Player combat rating",
     "message": "Deadly"
@@ -282,6 +290,10 @@
   "DELTA_V_MAX": {
     "description": "Delta-v capacity of a ship with cargo bay fully loaded with propellant",
     "message": "Delta-v (max)"
+  },
+  "DEPARTURE_DATE": {
+    "description": "Time of departure, used in flight log",
+    "message": "Departure date"
   },
   "DESCENT_TO_GROUND_SPEED": {
     "description": "",
@@ -359,6 +371,10 @@
     "description": "",
     "message": "Economy & Trade"
   },
+  "EDIT": {
+    "description": "Tooltip, to edit a flight log entry",
+    "message": "Edit"
+  },
   "EFFECTS": {
     "description": "",
     "message": "Effects:"
@@ -402,6 +418,10 @@
   "ENGINEERING": {
     "description": "Engineering skills of crew",
     "message": "Engineering:"
+  },
+  "ENTRY": {
+    "description": "A note/entry/record into the flight log",
+    "message": "Entry"
   },
   "EQUIPMENT": {
     "description": "",
@@ -494,6 +514,42 @@
   "FINAL_TARGET": {
     "description": "Hyperjump planner, referring to star system target",
     "message": "Final Target:"
+  },
+  "FLIGHT_LOG": {
+    "description": "Title for flight log screen, in info view",
+    "message": "Flight Log"
+  },
+  "FLIGHTLOG_STARPORT_ORBITAL": {
+    "description": "Used in Flight Log, to indicate player's position. 'primary_info' is a station name, 'secondary_info' is a space body (planet, moon/satelite, star) name",
+    "message": "Docked at {primary_info}, in orbit around {secondary_info}"
+  },
+  "FLIGHTLOG_STARPORT_SURFACE": {
+    "description": "Used in Flight Log, to indicate player's position. 'primary_info' is a station name, 'secondary_info' is a space body (planet, moon/satelite, star) name",
+    "message": "Docked at {primary_info}, on {secondary_info}"
+  },
+  "FLIGHTLOG_DOCKING": {
+    "description": "Used in Flight Log, to indicate player's position. 'primary_info' is a station name",
+    "message": "Docking at {primary_info}"
+  },
+  "FLIGHTLOG_UNDOCKING": {
+    "description": "Used in Flight Log, to indicate player's position. 'primary_info' is a station name",
+    "message": "Undocking at {primary_info}"
+  },
+  "FLIGHTLOG_FLYING": {
+    "description": "Used in Flight Log, to indicate player's position. 'primary_info' is the name of a space body",
+    "message": "Flying in space, relative {primary_info}"
+  },
+  "FLIGHTLOG_LANDED": {
+    "description": "Used in Flight Log, to indicate player's position, 'primary_info' is the name of a space body, typically a planet, the other two variables are latitude and longitude as floating point number, e.g. 'Landed on Trantor, position (-43.23, 67.89)'",
+    "message": "Landed on {primary_info}, position ({secondary_info}, {tertiary_info})"
+  },
+  "FLIGHTLOG_JUMPING": {
+    "description": "Used in Flight Log, to indicate player's position. 'primary_info' is the star system targeted for hyperspace jump.",
+    "message": "Hyper jumping towards {primary_info}"
+  },
+  "FLIGHTLOG_HYPERSPACE": {
+    "description": "Used in Flight Log, to indicate player's position. 'primary_info' is the star system targeted for hyperspace jump.",
+    "message": "In Hyperspace, enroute to {primary_info}"
   },
   "FLIGHT_STATE": {
     "description": "",
@@ -999,6 +1055,10 @@
     "description": "",
     "message": "In stock"
   },
+  "IN_SYSTEM": {
+    "description": "Used in flight log, show which star system we are/were in",
+    "message": "In system"
+  },
   "ITEM_IS_OUT_OF_STOCK": {
     "description": "",
     "message": "This item is out of stock."
@@ -1090,6 +1150,22 @@
   "LOCATION": {
     "description": "",
     "message": "Location"
+  },
+  "LOG_NEW": {
+    "description": "Indicate to make an entry into flight log system",
+    "message": "New Entry"
+  },
+  "LOG_CUSTOM": {
+    "description": "Label tab for showing custom logged events",
+    "message": "Custom Log"
+  },
+  "LOG_STATION": {
+    "description": "Label tab for showing logged station events",
+    "message": "Station Log"
+  },
+  "LOG_SYSTEM": {
+    "description": "Label tab for showing logged system events",
+    "message": "System Log"
   },
   "LOW": {
     "description": "",
@@ -1495,6 +1571,10 @@
     "description": "For player reputation",
     "message": "Reliable"
   },
+  "REMOVE": {
+    "description": "Remove, e.g. deleting a log entry",
+    "message": "Remove"
+  },
   "REMOVE_JUMP": {
     "description": "UI-button: remove hyper jump from list of planned jumps",
     "message": "Remove Jump"
@@ -1694,6 +1774,10 @@
   "STAR_FIELD_DENSITY": {
     "description": "",
     "message": "Density of Star field"
+  },
+  "STATION": {
+    "description": "Flight log info, will refer to a station by name",
+    "message": "Station"
   },
   "STATION_DOCKS": {
     "description": "Information shown in the station lobby, for total number of docking pads",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1771,6 +1771,18 @@
     "description": "",
     "message": "This is a moderate start from Itzalean on New Hope in the Epsilon Eridani system."
   },
+  "START_LOG_ENTRY_1": {
+    "description": "First custom log message when starting a new game, giving backstory to the character. Importantly we here hint at what actions the player is best to take: buy fuel, get reputation, ask for take off clearance.",
+    "message": "Unfortunately, uncle never showed me how to operate this old barge when he was alive, but I think I'm making an entry in the ship's log now. It's strange, I can still feel him, as if he's in the very walls of this ship. Maybe he can be my co-pilot, and together we will manifest our destiny in the great void. But first, I just need to buy some hydrogen for the jump drive, plot a course to lucrative trading opportunities, and pray to the heavens that traffic control will allow an inexperienced pilot like me to take off, then we'll see what this baby can do. Time to make a reputation for myself!"
+  },
+  "START_LOG_ENTRY_2": {
+    "description": "First custom log message when starting a new game, giving backstory to the character, here going for a Blade Runner feeling",
+    "message": "My boots are still wet from the heavy rainfall last night, back home. The pavement got so wet it - seemingly, in an act of revenge - drenched the night sky with the reflected glow from the neon signs that looked down on the wet street. But I made it, through the rain, to my connecting flight to the starport where my new ship was waiting for me. The starport security officer gave me a funny look when I told him I'm here to pick up a ship. I guess I didn't look like the typical spacer, having sold everything I had to invest in this rusty old bucket, as I was standing in front of him, wet boots and all. But I truly feel, that from now on, my future will be written in the stars. Now, I just need to find the start-key."
+  },
+  "START_LOG_ENTRY_3": {
+    "description": "First custom log message when starting a new game, giving backstory to the character. Here explaining why there's no hyperdrive in the ship, and what to do about it.",
+    "message": "After a long bureaucratic process, I finally got my ship back from the impound, but they had stripped her down to the bare metal, to pay 'the debt' they claimed I had. Not only did they take my favourite coffee brewer, but those bastards also ripped out the hyper drive, so I'm stuck for now in this system, unless I sell whatever is left in the ship, to finance a new drive. But as they say: when life gives you lemons - make lemonade; so even if I'm back at square one, I will think of this as an opportunity instead of as a setback, a second chance. Without coffee. By letting go of what I am, I will become what I might be. The world will turn aside, and let me pass, as it does for those who know where they are going, and I am heading to the stars."
+  },
   "STAR_FIELD_DENSITY": {
     "description": "",
     "message": "Density of Star field"

--- a/data/libs/FlightLog.lua
+++ b/data/libs/FlightLog.lua
@@ -121,11 +121,11 @@ FlightLog = {
 --   iterator - A function which will generate the paths from the log, returning
 --              one each time it is called until it runs out, after which it
 --              returns nil. It also returns, as two additional value, the game
---              time at which the player undocked, and palyer's financial balance.
+--              time at which the player docked, and palyer's financial balance.
 --
 -- Example:
 --
--- Print the names and departure times of the last five stations visited by
+-- Print the names and arrival times of the last five stations visited by
 -- the player
 --
 -- > for systemp, deptime, money, entry in FlightLog.GetStationPaths(5) do
@@ -158,12 +158,12 @@ FlightLog = {
 --
 -- Parameters:
 --
---   index - Index in log, 1 being most recent station undocked from
+--   index - Index in log, 1 being most recent station docked with
 --   entry - New text string to insert instead
 --
 -- Example:
 --
--- Replace note for the second most recent station undocked from
+-- Replace note for the second most recent station docked with
 --
 -- > UpdateStationEntry(2, "This was a smelly station")
 --
@@ -410,7 +410,7 @@ local AddSystemArrivalToLog = function (ship)
 	end
 end
 
--- onShipUndocked
+-- onShipDocked
 local AddStationToLog = function (ship, station)
 	if not ship:IsPlayer() then return end
 	table.insert(FlightLogStation,1,{station.path, Game.time, Game.player:GetMoney(), ""})
@@ -456,7 +456,7 @@ end
 
 Event.Register("onEnterSystem", AddSystemArrivalToLog)
 Event.Register("onLeaveSystem", AddSystemDepartureToLog)
-Event.Register("onShipUndocked", AddStationToLog)
+Event.Register("onShipDocked", AddStationToLog)
 Event.Register("onGameStart", onGameStart)
 Event.Register("onGameEnd", onGameEnd)
 Serializer:Register("FlightLog", serialize, unserialize)

--- a/data/libs/FlightLog.lua
+++ b/data/libs/FlightLog.lua
@@ -90,15 +90,15 @@ FlightLog = {
 --
 --   iterator - A function which will generate the paths from the log, returning
 --              one each time it is called until it runs out, after which it
---              returns nil. It also returns, as a secondary value, the game
---              time at which the player undocked.
+--              returns nil. It also returns, as two additional value, the game
+--              time at which the player undocked, and palyer's financial balance.
 --
 -- Example:
 --
 -- Print the names and departure times of the last five stations visited by
 -- the player
 --
--- > for systemp, deptime in FlightLog.GetStationPaths(5) do
+-- > for systemp, deptime, money in FlightLog.GetStationPaths(5) do
 -- >   print(systemp:GetSystemBody().name, Format.Date(deptime))
 -- > end
 
@@ -110,10 +110,11 @@ FlightLog = {
 				counter = counter + 1
 				if FlightLogStation[counter] then
 					return FlightLogStation[counter][1],
-						   FlightLogStation[counter][2]
+						   FlightLogStation[counter][2],
+						   FlightLogStation[counter][3]
 				end
 			end
-			return nil, nil
+			return nil, nil, nil
 		end
 	end,
 
@@ -200,7 +201,7 @@ end
 -- onShipUndocked
 local AddStationToLog = function (ship, station)
 	if not ship:IsPlayer() then return end
-	table.insert(FlightLogStation,1,{station.path,Game.time})
+	table.insert(FlightLogStation,1,{station.path, Game.time, Game.player:GetMoney()})
 	while #FlightLogStation > FlightLogStationQueueLength do
 		table.remove(FlightLogStation,FlightLogStationQueueLength + 1)
 	end

--- a/data/libs/FlightLog.lua
+++ b/data/libs/FlightLog.lua
@@ -53,7 +53,7 @@ FlightLog = {
 -- Print the names and departure times of the last five systems visited by
 -- the player
 --
--- > for systemp,arrtime,deptime in FlightLog.GetSystemPaths(5) do
+-- > for systemp,arrtime,deptime,entry in FlightLog.GetSystemPaths(5) do
 -- >   print(systemp:GetStarSystem().name, Format.Date(deptime))
 -- > end
 
@@ -66,11 +66,37 @@ FlightLog = {
 				if FlightLogSystem[counter] then
 					return FlightLogSystem[counter][1],
 						   FlightLogSystem[counter][2],
-						   FlightLogSystem[counter][3]
+						   FlightLogSystem[counter][3],
+						   FlightLogSystem[counter][4]
 				end
 			end
-			return nil, nil, nil
+			return nil, nil, nil, nil
 		end
+	end,
+
+
+--
+-- Method: UpdateSystemEntry
+--
+-- Update the free text field in system log.
+--
+-- > UpdateSystemEntry(index, entry)
+--
+-- Parameters:
+--
+--   index - Index in log, 1 being most recent (current) system
+--   entry - New text string to insert instead
+--
+-- Example:
+--
+-- Replace the second most recent system record, i.e. the previously
+-- visited system.
+--
+-- > UpdateSystemEntry(2, "At Orion's shoulder, I see attackships on fire")
+--
+
+	UpdateSystemEntry = function (index, entry)
+		FlightLogSystem[index][4] = entry
 	end,
 
 --
@@ -98,7 +124,7 @@ FlightLog = {
 -- Print the names and departure times of the last five stations visited by
 -- the player
 --
--- > for systemp, deptime, money in FlightLog.GetStationPaths(5) do
+-- > for systemp, deptime, money, entry in FlightLog.GetStationPaths(5) do
 -- >   print(systemp:GetSystemBody().name, Format.Date(deptime))
 -- > end
 
@@ -111,11 +137,35 @@ FlightLog = {
 				if FlightLogStation[counter] then
 					return FlightLogStation[counter][1],
 						   FlightLogStation[counter][2],
-						   FlightLogStation[counter][3]
+						   FlightLogStation[counter][3],
+						   FlightLogStation[counter][4]
 				end
 			end
-			return nil, nil, nil
+			return nil, nil, nil, nil
 		end
+	end,
+
+--
+-- Method: UpdateStationEntry
+--
+-- Update the free text field in station log.
+--
+-- > UpdateStationEntry(index, entry)
+--
+-- Parameters:
+--
+--   index - Index in log, 1 being most recent station undocked from
+--   entry - New text string to insert instead
+--
+-- Example:
+--
+-- Replace note for the second most recent station undocked from
+--
+-- > UpdateStationEntry(2, "This was a smelly station")
+--
+
+	UpdateStationEntry = function (index, entry)
+		FlightLogStation[index][4] = entry
 	end,
 
 --
@@ -192,7 +242,7 @@ end
 -- onEnterSystem
 local AddSystemArrivalToLog = function (ship)
 	if not ship:IsPlayer() then return end
-	table.insert(FlightLogSystem,1,{Game.system.path,Game.time,nil})
+	table.insert(FlightLogSystem,1,{Game.system.path,Game.time,nil,""})
 	while #FlightLogSystem > FlightLogSystemQueueLength do
 		table.remove(FlightLogSystem,FlightLogSystemQueueLength + 1)
 	end
@@ -201,7 +251,7 @@ end
 -- onShipUndocked
 local AddStationToLog = function (ship, station)
 	if not ship:IsPlayer() then return end
-	table.insert(FlightLogStation,1,{station.path, Game.time, Game.player:GetMoney()})
+	table.insert(FlightLogStation,1,{station.path, Game.time, Game.player:GetMoney(), ""})
 	while #FlightLogStation > FlightLogStationQueueLength do
 		table.remove(FlightLogStation,FlightLogStationQueueLength + 1)
 	end
@@ -216,7 +266,7 @@ local onGameStart = function ()
 		FlightLogSystem = loaded_data.System
 		FlightLogStation = loaded_data.Station
 	else
-		table.insert(FlightLogSystem,1,{Game.system.path,nil,nil})
+		table.insert(FlightLogSystem,1,{Game.system.path,nil,nil,""})
 	end
 	loaded_data = nil
 end

--- a/data/libs/FlightLog.lua
+++ b/data/libs/FlightLog.lua
@@ -22,6 +22,9 @@ local FlightLogSystem = {}
 local FlightLogStation = {}
 local FlightLogCustom = {}
 
+-- Version for backwards compability
+local version = 1
+
 local FlightLog
 FlightLog = {
 
@@ -339,7 +342,6 @@ FlightLog = {
 
 	MakeCustomEntry = function (text)
 		text = text or ""
-
 		local location = ""
 		local state = Game.player:GetFlightState()
 
@@ -367,6 +369,25 @@ FlightLog = {
 		table.insert(FlightLogCustom,1,
 			{Game.system.path, Game.time, Game.player:GetMoney(), location, text})
 	end,
+
+--
+-- Group: Attributes
+--
+
+--
+-- Attribute: version
+--
+-- Marks version of flight log, can be used for non-breaking backwards
+-- compatibility, if new features are added to FlightLog
+--
+-- Example:
+--
+-- > if FlightLog.version > 2 then
+-- >     FlightLog.useNewFeature()
+-- > end
+--
+
+	version = version,
 }
 
 -- LOGGING
@@ -403,10 +424,11 @@ end
 local loaded_data
 
 local onGameStart = function ()
-	if loaded_data then
+	if loaded_data and loaded_data.Version then
 		FlightLogSystem = loaded_data.System
 		FlightLogStation = loaded_data.Station
 		FlightLogCustom = loaded_data.Custom
+		version = loaded_data.Version
 	else
 		table.insert(FlightLogSystem,1,{Game.system.path,nil,nil,""})
 	end
@@ -417,10 +439,15 @@ local onGameEnd = function ()
 	FlightLogSystem = {}
 	FlightLogStation = {}
 	FlightLogCustom = {}
+	version = nil
 end
 
 local serialize = function ()
-	return { System = FlightLogSystem, Station = FlightLogStation, Custom = FlightLogCustom }
+	return { System = FlightLogSystem,
+			 Station = FlightLogStation,
+			 Custom = FlightLogCustom,
+			 Version = version
+	}
 end
 
 local unserialize = function (data)

--- a/data/libs/FlightLog.lua
+++ b/data/libs/FlightLog.lua
@@ -220,6 +220,12 @@ local onGameStart = function ()
 	loaded_data = nil
 end
 
+local onGameEnd = function ()
+	FlightLogSystem = {}
+	FlightLogStation = {}
+	FlightLogCustom = {}
+end
+
 local serialize = function ()
 	return { System = FlightLogSystem, Station = FlightLogStation }
 end
@@ -232,6 +238,7 @@ Event.Register("onEnterSystem", AddSystemArrivalToLog)
 Event.Register("onLeaveSystem", AddSystemDepartureToLog)
 Event.Register("onShipUndocked", AddStationToLog)
 Event.Register("onGameStart", onGameStart)
+Event.Register("onGameEnd", onGameEnd)
 Serializer:Register("FlightLog", serialize, unserialize)
 
 return FlightLog

--- a/data/pigui/modules/info-view/06-flightlog.lua
+++ b/data/pigui/modules/info-view/06-flightlog.lua
@@ -1,0 +1,229 @@
+-- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local ui = require 'pigui'
+local InfoView = require 'pigui/views/info-view'
+local Lang = require 'Lang'
+local FlightLog = require 'FlightLog'
+local Format = require 'Format'
+
+local pionillium = ui.fonts.pionillium
+local colors = ui.theme.colors
+local icons = ui.theme.icons
+
+local gray = Color(145, 145, 145)
+
+local l = Lang.GetResource("ui-core")
+
+local iconSize = Vector2(28, 28) * (ui.screenHeight / 1200)
+local buttonSpaceSize = iconSize
+
+-- Sometimes date is empty, e.g. departure date prior to departure
+local function formatDate(date)
+	return date and Format.Date(date) or nil
+end
+
+
+local function formatCoordinates(sysp)
+	return sysp.sectorX ..", "
+		.. sysp.sectorY ..", "
+		.. sysp.sectorZ
+end
+
+-- Format system to be of form: "Sol (0,0,0)"
+local function formatsystem(sysp)
+	return sysp:GetStarSystem().name .. " (" .. formatCoordinates(sysp) .. ")"
+end
+
+-- Title text is gray, followed by the variable text:
+local function headerText(title, text, wrap)
+	if not text then return end
+	ui.textColored(gray, string.gsub(title, ":", "") .. ":")
+	ui.sameLine()
+	if wrap then
+		-- TODO: limit width of text box!
+		ui.textWrapped(text)
+	else
+		ui.text(text)
+	end
+end
+
+
+local entering_text_custom = false
+local entering_text_system = false
+local entering_text_station = false
+
+-- Display Entry text, and Edit button, to update flightlog
+local function inputText(entry, counter, entering_text, log, str, clicked)
+	if #entry > 0 then
+		headerText(l.ENTRY, entry, true)
+	end
+
+	if clicked or entering_text == counter then
+		local updated_entry, return_pressed = ui.inputText("##" ..str..counter, entry, {"EnterReturnsTrue"})
+		entering_text = counter
+		if return_pressed then
+			log(counter, updated_entry)
+			entering_text = -1
+		end
+	end
+	ui.text("")
+	return entering_text
+end
+
+-- Based on flight state, compose a reasonable string for location
+local function composeLocationString(location)
+	return string.interp(l["FLIGHTLOG_"..location[1]],
+		{ primary_info = location[2],
+		  secondary_info = location[3] or "",
+		  tertiary_info = location[4] or "",})
+end
+
+local function renderCustomLog()
+	local counter = 0
+	local was_clicked = false
+	for systemp, time, money, location, entry in FlightLog.GetCustomEntry() do
+		counter = counter + 1
+		-- reserve a narrow right colum for small edit/remove icon,
+		ui.columns(2, "custom" .. counter, false)
+		ui.setColumnWidth(0, ui.getWindowSize().x - 2*iconSize.x)
+
+		headerText(l.DATE, formatDate(time))
+		headerText(l.LOCATION, composeLocationString(location))
+		headerText(l.IN_SYSTEM, formatsystem(systemp))
+		headerText(l.ALLEGIANCE, systemp:GetStarSystem().faction.name)
+		headerText(l.CASH, Format.Money(money))
+
+		::input::
+		entering_text_custom = inputText(entry, counter,
+			entering_text_custom, FlightLog.UpdateCustomEntry, "custom", was_clicked)
+		ui.nextColumn()
+
+		was_clicked = false
+		if ui.coloredSelectedIconButton(icons.pencil, buttonSpaceSize, false,
+			0, colors.buttonBlue, colors.white, l.EDIT .. "##custom"..counter, iconSize) then
+			was_clicked = true
+			-- If edit field was clicked, we want to edit _this_ iteration's field,
+			-- not next record's. Quick, behind you, velociraptor!
+			goto input
+		end
+
+		if ui.coloredSelectedIconButton(icons.trashcan, buttonSpaceSize, false,
+			0, colors.buttonBlue, colors.white, l.REMOVE .. "##custom" .. counter, iconSize) then
+			FlightLog.DeleteCustomEntry(counter)
+			-- if we were already in edit mode, reset it, or else it carries over to next iteration
+			entering_text_custom = false
+		end
+		ui.columns(1)
+		ui.separator()
+	end
+end
+
+-- See comments on previous function
+local function renderStationLog()
+	local counter = 0
+	local was_clicked = false
+	for systemp, deptime, money, entry in FlightLog.GetStationPaths() do
+		counter = counter + 1
+		ui.columns(2, "station" .. counter, false)
+		ui.setColumnWidth(0, ui.getWindowSize().x - 2*iconSize.x)
+
+		local station_type = "FLIGHTLOG_" .. systemp:GetSystemBody().type
+		headerText(l.DATE, formatDate(deptime))
+		headerText(l.STATION, string.interp(l[station_type],
+			{ primary_info = systemp:GetSystemBody().name, secondary_info = systemp:GetSystemBody().parent.name }))
+		-- headerText(l.LOCATION, systemp:GetSystemBody().parent.name)
+		headerText(l.IN_SYSTEM, formatsystem(systemp))
+		headerText(l.ALLEGIANCE, systemp:GetStarSystem().faction.name)
+		headerText(l.CASH, Format.Money(money))
+
+		::input::
+		entering_text_station = inputText(entry, counter,
+			entering_text_station, FlightLog.UpdateStationEntry, "station", was_clicked)
+		ui.nextColumn()
+
+		was_clicked = false
+		if ui.coloredSelectedIconButton(icons.pencil, buttonSpaceSize, false,
+			0, colors.buttonBlue, colors.white, l.EDIT .. "##station"..counter, iconSize) then
+			was_clicked = true
+			goto input
+		end
+		ui.columns(1)
+		ui.separator()
+	end
+end
+
+-- See comments on previous function
+local function renderSystemLog()
+	local counter = 0
+	local was_clicked = false
+	for systemp, arrtime, deptime, entry in FlightLog.GetSystemPaths() do
+		counter = counter + 1
+		ui.columns(2, "system" .. counter, false)
+		ui.setColumnWidth(0, ui.getWindowSize().x - 2*iconSize.x)
+
+		headerText(l.ARRIVAL_DATE, formatDate(arrtime))
+		headerText(l.DEPARTURE_DATE, formatDate(deptime))
+		headerText(l.IN_SYSTEM, formatsystem(systemp))
+		headerText(l.ALLEGIANCE, systemp:GetStarSystem().faction.name)
+
+		::input::
+		entering_text_system = inputText(entry, counter,
+			entering_text_system, FlightLog.UpdateSystemEntry, "sys", was_clicked)
+		ui.nextColumn()
+
+		was_clicked = false
+		if ui.coloredSelectedIconButton(icons.pencil, buttonSpaceSize, false,
+			0, colors.buttonBlue, colors.white, l.EDIT .. "##system"..counter, iconSize) then
+			was_clicked = true
+			goto input
+		end
+		ui.columns(1)
+		ui.separator()
+	end
+end
+
+local function getFlightHistory()
+	if ui.beginTabBar("mytabbar") then
+		if ui.beginTabItem(l.LOG_CUSTOM) then
+			-- input field for custom log:
+			headerText(l.LOG_NEW, "")
+			ui.sameLine()
+			text, changed = ui.inputText("##inputfield", "", {"EnterReturnsTrue"})
+			if changed then
+				FlightLog.MakeCustomEntry(text)
+			end
+			ui.separator()
+
+			renderCustomLog()
+			ui.endTabItem()
+		end
+
+		if ui.beginTabItem(l.LOG_STATION) then
+			renderStationLog()
+			ui.endTabItem()
+		end
+
+		if ui.beginTabItem(l.LOG_SYSTEM) then
+			renderSystemLog()
+			ui.endTabItem()
+		end
+
+		ui.endTabBar()
+	end
+end
+
+local function drawLog ()
+	ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+		getFlightHistory()
+	end)
+end
+
+InfoView:registerView({
+    id = "captainsLog",
+    name = l.FLIGHT_LOG,
+    icon = ui.theme.icons.bookmark,
+    showView = true,
+    draw = drawLog,
+    refresh = function() end,
+})

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -122,18 +122,19 @@ local function showDvLine(leftIcon, resetIcon, rightIcon, key, Formatter, leftTo
 			end
 		end
 	end
-	local press = ui.coloredSelectedIconButton(leftIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_ACTIVE, svColor.BUTTON_INK, leftTooltip, nil, key)
+	local id =  "##" .. key
+	local press = ui.coloredSelectedIconButton(leftIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_ACTIVE, svColor.BUTTON_INK, leftTooltip..id, nil)
 	if press or (key ~= "factor" and ui.isItemActive()) then
 		systemView:TransferPlannerAdd(key, -10)
 	end
 	wheel()
 	ui.sameLine()
-	if ui.coloredSelectedIconButton(resetIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_ACTIVE, svColor.BUTTON_INK, resetTooltip, nil, key) then
+	if ui.coloredSelectedIconButton(resetIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_ACTIVE, svColor.BUTTON_INK, resetTooltip..id, nil) then
 		systemView:TransferPlannerReset(key)
 	end
 	wheel()
 	ui.sameLine()
-	press = ui.coloredSelectedIconButton(rightIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_ACTIVE, svColor.BUTTON_INK, rightTooltip, nil, key)
+	press = ui.coloredSelectedIconButton(rightIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_ACTIVE, svColor.BUTTON_INK, rightTooltip..id, nil)
 	if press or (key ~= "factor" and ui.isItemActive()) then
 		systemView:TransferPlannerAdd(key, 10)
 	end
@@ -433,7 +434,7 @@ local function displayOnScreenObjects()
 				if (isShip or isSystemBody and mainObject.ref.physicsBody) and ui.selectable(lc.SET_AS_TARGET, false, {}) then
 					if isSystemBody then
 						player:SetNavTarget(mainObject.ref.physicsBody)
-					else 
+					else
 						if combatTarget == mainObject.ref then player:SetCombatTarget(nil) end
 						player:SetNavTarget(mainObject.ref)
 					end

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -833,7 +833,35 @@ ui.coloredSelectedButton = function(label, thesize, is_selected, bg_color, toolt
 	end
 	return res
 end
-ui.coloredSelectedIconButton = function(icon, thesize, is_selected, frame_padding, bg_color, fg_color, tooltip, img_size, extraID)
+
+--
+-- Function: ui.coloredSelectedIconButton
+--
+-- > clicked = ui.coloredSelectedIconButton(icon, button_size, is_selected,
+-- >               frame_padding, bg_color, fg_color, tooltip, img_size)
+--
+--
+-- Example:
+--
+-- > clicked = ui.coloredSelectedIconButton(ui.theme.icons.bullseye, Vector2(10,10), false,
+-- >               0, ui.theme.colors.buttonBlue, Color(255,0,0), "Click for action##42", Vector2(8,8))
+--
+-- Parameters:
+--
+--   icon - image to place on button, e.g. from ui.theme.icons
+--   button_size - size of button, Vector2
+--   is_selected - bool
+--   frame_padding - number
+--   bg_color - Color(R,G,B), for background
+--   fg_color - Color(R,G,B), for forground
+--   tooltip - string, mouseover text, will be used as ID, must be unique, append "##uniqueID" if needed
+--   img_size - size of icon on the button, Vector2
+--
+-- Returns:
+--
+--   clicked - true if button was clicked
+--
+ui.coloredSelectedIconButton = function(icon, thesize, is_selected, frame_padding, bg_color, fg_color, tooltipID, img_size)
 	if is_selected then
 		pigui.PushStyleColor("Button", bg_color)
 		pigui.PushStyleColor("ButtonHovered", bg_color:tint(0.1))
@@ -844,10 +872,13 @@ ui.coloredSelectedIconButton = function(icon, thesize, is_selected, frame_paddin
 		pigui.PushStyleColor("ButtonActive", bg_color:shade(0.2))
 	end
 	local uv0,uv1 = get_icon_tex_coords(icon)
-	pigui.PushID(tooltip .. (extraID or ""))
+	pigui.PushID(tooltipID)
 	local res = pigui.ButtonImageSized(ui.icons_texture, thesize, img_size or Vector2(0,0), uv0, uv1, frame_padding, ui.theme.colors.lightBlueBackground, fg_color)
 	pigui.PopID()
 	pigui.PopStyleColor(3)
+	local pos = tooltipID:find("##") -- get position for id tag start
+	local pos = pos and pos - 1      -- if found, move back beyond first "#"
+	local tooltip = pos and string.sub(tooltipID, 1, pos) or tooltipID
 	if pigui.IsItemHovered() then
 		pigui.SetTooltip(tooltip)
 	end

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -10,6 +10,7 @@ local Equipment = require 'Equipment'
 local Format = require 'Format'
 local Event = require 'Event'
 local Lang = require 'Lang'
+local FlightLog = require ("FlightLog")
 
 local lc = Lang.GetResource("core")
 local lui = Lang.GetResource("ui-core")
@@ -42,6 +43,7 @@ local startLocations = {
 	{['name']=lui.START_AT_MARS,
 	 ['desc']=lui.START_AT_MARS_DESC,
 	 ['location']=SystemPath.New(0,0,0,0,18),
+	 ['logmsg']=lui.START_LOG_ENTRY_1,
 	 ['shipType']='sinonatrix',['money']=100,['hyperdrive']=true,
 	 ['equipment']={
 		{laser.pulsecannon_1mw,1},
@@ -52,6 +54,7 @@ local startLocations = {
 	{['name']=lui.START_AT_NEW_HOPE,
 	 ['desc']=lui.START_AT_NEW_HOPE_DESC,
 	 ['location']=SystemPath.New(1,-1,-1,0,4),
+	 ['logmsg']=lui.START_LOG_ENTRY_2,
 	 ['shipType']='pumpkinseed',['money']=100,['hyperdrive']=true,
 	 ['equipment']={
 		{laser.pulsecannon_1mw,1},
@@ -62,6 +65,7 @@ local startLocations = {
 	{['name']=lui.START_AT_BARNARDS_STAR,
 	 ['desc']=lui.START_AT_BARNARDS_STAR_DESC,
 	 ['location']=SystemPath.New(-1,0,0,0,16),
+	 ['logmsg']=lui.START_LOG_ENTRY_3,
 	 ['shipType']='xylophis',['money']=100,['hyperdrive']=false,
 	 ['equipment']={
 		{misc.atmospheric_shielding,1},
@@ -158,6 +162,7 @@ local function startAtLocation(location)
 	for _,equip in pairs(location.equipment) do
 		Game.player:AddEquip(equip[1],equip[2])
 	end
+	FlightLog.MakeCustomEntry(location.logmsg)
 end
 
 local function callModules(mode)

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -469,6 +469,24 @@ static int l_pigui_get_column_width(lua_State *l)
 	return 1;
 }
 
+/*
+ * Function: ui.setColumnWidth
+ *
+ * For not dividing column widths equally
+ *
+ * > ui.setColumnWidth(column_index, width)
+ *
+ * Example:
+ *
+ * > ui.columns(2, "mycolum", true)
+ * > ui.setColumnWidth(0, ui.getWindowSize().x*0.8)
+ *
+ * Parameters:
+ *
+ *   column_index - integer, which column width to set, first being 0
+ *   width - float, width to set
+ *
+ */
 static int l_pigui_set_column_width(lua_State *l)
 {
 	int column_index = LuaPull<int>(l, 1);
@@ -799,6 +817,30 @@ static int l_pigui_path_stroke(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: selectable
+ *
+ * Determine if a text was slected or not
+ *
+ * > clicked = ui.selectable(text, is_selectable, flag)
+ *
+ * Example:
+ *
+ * > if ui.selectable("Fly me to the moon", true) then
+ * >     buyRocketShip()
+ * > end
+ *
+ * Parameters:
+ *
+ *   text - string, text
+ *   is_selectable - boolean, wheater or not a text field is highlighted by mouse over
+ *   flag - optional, selectable flag
+ *
+ * Return:
+ *
+ *   clicked - bool, true if was clicked, else false
+ *
+ */
 static int l_pigui_selectable(lua_State *l)
 {
 	PROFILE_SCOPED()
@@ -918,6 +960,18 @@ static int l_pigui_button_image_sized(lua_State *l)
 	return 1;
 }
 
+/*
+ * Function: textWrapped
+ *
+ * Wrap text, if too long, suitable for English, and similar languages
+ *
+ * > ui.textWrapped(text)
+ *
+ * Parameters:
+ *
+ *   text - string, text string, possibly longer than a single line
+ *
+ */
 static int l_pigui_text_wrapped(lua_State *l)
 {
 	PROFILE_SCOPED()
@@ -2165,6 +2219,29 @@ static int l_pigui_end_tab_item(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: inputText
+ *
+ * A field for text input
+ *
+ * > text_entered, entered = ui.inputText(label, text_displayed, flag)
+ *
+ * Example:
+ *
+ * > text, changed = ui.inputText(label, text, {"EnterReturnsTrue"})
+ *
+ * Parameters:
+ *
+ *   label - A unique string labeling the widget
+ *   text_displayed - Default text in field
+ *   flag - <inputTextFlags>
+ *
+ * Returns:
+ *
+ *   text_entered - text entered
+ *   changed - bool, true if text was entered
+ *
+ */
 static int l_pigui_input_text(lua_State *l)
 {
 	PROFILE_SCOPED()

--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -84,6 +84,20 @@ static int l_set_nav_target(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: SetSetSpeedTarget
+ *
+ * Set the "set speed" of player's ship
+ *
+ * Example:
+ *
+ * > player:SetSetSpeedTarget(body)
+ *
+ * Parameters:
+ *
+ *   body - <Body> relative to witch speed is set relative to
+ *
+ */
 static int l_set_set_speed_target(lua_State *l)
 {
 	Player *p = LuaObject<Player>::CheckFromLua(1);
@@ -92,6 +106,20 @@ static int l_set_set_speed_target(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: ChangeSetSpeed
+ *
+ * Set the "set speed" of player's ship
+ *
+ * Example:
+ *
+ * > player:ChangeSetSpeed(delta)
+ *
+ * Parameters:
+ *
+ *   delta - Float, by how much to change current set speed
+ *
+ */
 static int l_change_set_speed(lua_State *l)
 {
 	Player *p = LuaObject<Player>::CheckFromLua(1);
@@ -488,6 +516,20 @@ static int l_get_heading_pitch_roll(lua_State *l)
 	return 3;
 }
 
+/*
+ * Function: SetRotationDamping
+ *
+ * Set rotation dampening on or off of player's ship
+ *
+ * Example:
+ *
+ * > player:SetRotationDamping(is_on)
+ *
+ * Parameters:
+ *
+ *   is_on - boolean
+ *
+ */
 static int l_set_rotation_damping(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -496,6 +538,20 @@ static int l_set_rotation_damping(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: GetRotationDamping
+ *
+ * Get rotation dampening state of player's ship
+ *
+ * Example:
+ *
+ * > state = player:GetRotationDamping()
+ *
+ * Returns:
+ *
+ *   state - bool
+ *
+ */
 static int l_get_rotation_damping(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -503,6 +559,16 @@ static int l_get_rotation_damping(lua_State *l)
 	return 1;
 }
 
+/*
+ * Function: ToggleRotationDamping
+ *
+ * Toggle rotation dampening on/off
+ *
+ * Example:
+ *
+ * > player:ToggleRotationDamping()
+ *
+ */
 static int l_toggle_rotation_damping(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -510,6 +576,26 @@ static int l_toggle_rotation_damping(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: GetGPS()
+ *
+ * Get altitude, speed, and position of player's ship
+ *
+ * Example:
+ *
+ * > alt, vspd, lat, long = player:GetGPS()
+ *
+ * Returns:
+ *
+ *   alt - altitude
+ *
+ *   vspd - vertical speed
+ *
+ *   latitude - latitude
+ *
+ *   longitude - longitude
+ *
+ */
 static int l_get_gps(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);


### PR DESCRIPTION
## Introduction
Inspired by this [flight log](http://www.planetmic.com/orbit/fdl-file.htm) add-on for original Frontier, I've implemented something similar. This is highly work in progress. I've used the FlightLog that automatically logs departures from _stations_, and arrival/departure times into _systems_. I've also added a _custom_ log, that can be created by writing some fitting string, and pressing enter; and show all three in a Flight Log tab in InfoView.

~~Currently text can only be entered into the _custom_ logs, but I'll extend the other two logs (_system_, and _station_) so one can enter, as @nozmajner suggested: "this was a smelly station".~~

## Potential: Custom entries at start give backstory
I've played around with adding a custom log entry from the mainmenu, when starting a new game, so the first entry could be:

_"Just picked up the ship that uncle Nick left for me to inherrit. This rusty old bucket isn't much, but together we'll write our destiny in the stars, and it's my new home. Can't wait to undock!"_

*"Now I've cleared my debt with Wu, and sold all my belongings, and all I got was this lousy ship. By it's mine, and with it I can escape this god forsaken world and build a brighter future, forever onwards!"*


## Biggest hurdle
- Currently, it's to get the three logs (_system_, _station_, _custom_) to be printed in date-order, instead of printing each one in turn. I think the FlightLog method might have some method that sorts them, or combines them, but they have different table fields, so... need to think. 

- Multiline input. I've experimented with adding multiline text-input field, but the game crashes if I try to use it, so for now, it's just a dead commit.

- Also, this is a savebumping PR, since the updated FlightLog library will be incompatible with the previous, since I'm adding more fields (also log player's money), and a custom log.


## To do
- [x]  0 Allow re-editing old entries in custom logs
- [x]  1 Clear flightlog upon new game (bug of old?)
- [x]  2 Remove (only?) custom entries
-  3 Do we also want to be able to remove SYSTEM and STATION auto-logs as well?
- [x]  4 Add startup custom entry, backstory of how the ship ended up in the player's possession
- [x]  5 Edit/update Entries of SYSTEM and STATION auto-logs as well?
- [x]  6 ~~sort them on dates~~, not printing SYSTEM, STATION & CUSTOM logs separately. EDIT: Solved this by printing each log in a separate tab, thus #4893
- [x]  7 Better "Location" strings for CUSTOM, for if docked, landed, in orbit etc. 
- [x]  8 Document new methods in FlightLog
- [x]  9 Put strings in to translation system
- [x] 10 Use coloured text for some of the log-fields? E.g. Date, or similar?
- [x] 11 Better Log icon for InfoView tab
- [x] 12 Replace "Remove"-button with trashcan?
- [x] 13 Maybe/probably support multiline text box/input.
- [ ]  14 Save versioning of flightlog, to avoid save-bumping.
- ~~15. Make `textWrapped` include the secondary optional argument in LuaPiGui.cpp~~

## For future
These are things that might be intuitive next steps to add, but I don't plan to do them, so up for grabs:
- Export log to text-file?
- Filter logs
- Hyperlink systems/stations to map

## Current state
This is a screenshot of where I'm at. It works pretty well, as is, I think, ~~although only single line text-input, and~~ the tree logs are only date-sorted within each group (First it prints all _custom_ logs, then all _system_ logs, then all _station_ logs).

![2020-02-23-122512_1600x900_scrot](https://user-images.githubusercontent.com/619390/75111286-6b811380-5638-11ea-8068-7b49d6950087.png)

Closes #204