### PR TITLE
Make faces in goodstrader persistent

### DIFF
--- a/data/modules/GoodsTrader/GoodsTrader.lua
+++ b/data/modules/GoodsTrader/GoodsTrader.lua
@@ -147,8 +147,7 @@ local onCreateBB = function (station)
 				flavour  = flavour,
 				slogan   = slogan,
 				ispolice = ispolice,
-				faceseed = r:Integer(),
-				trader   = Character.New(),
+				trader   = Character.New({title = flavour, armour=false}, r),
 			}
 
 			ad.stock = {}


### PR DESCRIPTION
I believe when I rebased #4796, after #4775 was merged today, I didn't notice that the `faceseed` wasn't used for the GoodsTrader character.

Closes #4810
