### PR TITLE
Add ship jump status to translation strings

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -335,6 +335,10 @@
     "description": "",
     "message": "Dock at current target"
   },
+  "DRIVE_ACTIVE": {
+    "description": "Ship jump status",
+    "message": "Drive active"
+  },
   "DUE": {
     "description": "mission deadline date",
     "message": "Due"
@@ -963,6 +967,14 @@
     "description": "For player reputation",
     "message": "Inexperienced"
   },
+  "INITIATED": {
+    "description": "Ship jump status",
+    "message": "Initiated"
+  },
+  "INSUFFICIENT_FUEL": {
+    "description": "Ship jump status",
+    "message": "Insufficient fuel"
+  },
   "INSUFFICIENT_FUNDS": {
     "description": "",
     "message": "Insufficient funds."
@@ -1279,6 +1291,10 @@
     "description": "",
     "message": "{equipment} is not supported on this ship model"
   },
+  "NO_DRIVE": {
+    "description": "Ship jump status",
+    "message": "No drive"
+  },
   "NO_FILTER_MATCHES": {
     "description": "No matches to this filter.",
     "message": "Nothing matches that filter"
@@ -1330,6 +1346,10 @@
   "ORBITAL_ANALYSIS_NOTES": {
     "description": "",
     "message": "Circular orbit speed is given for a tangential velocity. The ship should be moving in a direction at 90° to the ship/{name} axis.\n\nDescent speed is an absolute minimum, and is also tangential. A slower speed or a lower angle will result in a course which intersects with the surface of {name}.\n\nEscape speed will in theory work in any direction, as long as the ship does not collide with {name} on the way.\n\t\t"
+  },
+  "OUT_OF_RANGE": {
+    "description": "Ship jump status",
+    "message": "Out of range"
   },
   "OUTER_ARM": {
     "description": "Arm of the Milky Way galaxy",
@@ -1518,6 +1538,10 @@
   "ROUTE_JUMPS": {
     "description": "For hyperjump planner",
     "message": "Route Jumps"
+  },
+  "SAFETY_LOCKOUT": {
+    "description": "Ship jump status",
+    "message": "Safety lockout"
   },
   "SAGITTARIUS_ARM": {
     "description": "Arm of the Milky Way galaxy",

--- a/data/pigui/modules/map-sector-view.lua
+++ b/data/pigui/modules/map-sector-view.lua
@@ -151,7 +151,7 @@ local function showSearch()
 									 for _,item in pairs(data) do
 										 local system = item.path:GetStarSystem()
 										 local label = system.name
-										 label = label .. '  ' .. item.jumpStatus .. ", " .. string.format("%.2f", item.distance) .. lc.UNIT_LY .. ", " .. item.fuelRequired .. lc.UNIT_TONNES .. ", " .. ui.Format.Duration(item.duration, 2)
+										 label = label .. '  (' .. lui[item.jumpStatus] .. "), " .. string.format("%.2f", item.distance) .. lc.UNIT_LY .. ", " .. item.fuelRequired .. lc.UNIT_TONNES .. ", " .. ui.Format.Duration(item.duration, 2)
 
 										 if ui.selectable(label, false, {}) then
 											 Engine.SetSectorMapSelected(item.path)


### PR DESCRIPTION
This is shown in sector view, and was previously just returning the all caps
English constants.

![2020-02-25-203335_1600x900_scrot](https://user-images.githubusercontent.com/619390/75280860-81483180-580e-11ea-8e3e-970ef660a5a5.png)

