### PR TITLE
Add Sponsor button to github

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://pioneerspacesim.net/page/donate/"]


### PR DESCRIPTION
Add Sponsor button to github, which redirects to
https://pioneerspacesim.net/page/donate/.