### PR TITLE
Adding icons for future PRs: BBS, systemview, imgui migration, bar

### DIFF
--- a/data/icons/icons.svg
+++ b/data/icons/icons.svg
@@ -2,6 +2,7 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -15,10 +16,186 @@
    viewBox="0 0 3628.3465 3628.3464"
    id="svg4446"
    version="1.1"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
    sodipodi:docname="icons.svg">
   <defs
      id="defs4448">
+    <linearGradient
+       id="linearGradient15655"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#fffff6;stop-opacity:1;"
+         offset="0"
+         id="stop15651" />
+      <stop
+         style="stop-color:#fffff6;stop-opacity:0;"
+         offset="1"
+         id="stop15653" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15609"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#fffff6;stop-opacity:1;"
+         offset="0"
+         id="stop15607" />
+    </linearGradient>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker8674"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path8672"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#ffffee;stroke-opacity:1;fill:#fffffd;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(0.3) rotate(180) translate(-2.3,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker8458"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.3) rotate(180) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#ffffee;stroke-opacity:1;fill:#ffeeff;fill-opacity:1"
+         id="path8456" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Send"
+       style="overflow:visible;"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path6131"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#ffffee;stroke-opacity:1;fill:#fffff6;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(0.3) rotate(180) translate(-2.3,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Send"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Send"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path6113"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffee;stroke-width:1pt;stroke-opacity:1;fill:#e3dbdb;fill-opacity:1"
+         transform="scale(0.2) rotate(180) translate(6,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker7168"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path7166"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffee;stroke-width:1pt;stroke-opacity:1;fill:#e3dbdb;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="DiamondMstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="DiamondMstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6189"
+         d="M 0,-7.0710768 L -7.0710894,0 L 0,7.0710589 L 7.0710462,0 L 0,-7.0710768 z "
+         style="fill-rule:evenodd;stroke:#ffffee;stroke-width:1pt;stroke-opacity:1;fill:#e3dbdb;fill-opacity:1"
+         transform="scale(0.4) translate(6.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Mend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path6125"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#ffffee;stroke-opacity:1;fill:#e3dbdb;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(0.6) rotate(180) translate(0,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Mend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path6107"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffee;stroke-width:1pt;stroke-opacity:1;fill:#e3dbdb;fill-opacity:1"
+         transform="scale(0.4) rotate(180) translate(10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path6101"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffee;stroke-width:1pt;stroke-opacity:1;fill:#e3dbdb;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker6382"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6380"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffee;stroke-width:1pt;stroke-opacity:1;fill:#e3dbdb;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6098"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffee;stroke-width:1pt;stroke-opacity:1;fill:#e3dbdb;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
     <filter
        id="filter4188"
        style="color-interpolation-filters:sRGB"
@@ -704,15 +881,15 @@
      borderopacity="1.0"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.1981383"
-     inkscape:cx="2124.5938"
-     inkscape:cy="1924.2465"
+     inkscape:zoom="0.1767767"
+     inkscape:cx="1429.7092"
+     inkscape:cy="1859.5164"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="1857"
+     inkscape:window-width="1850"
      inkscape:window-height="1057"
-     inkscape:window-x="-8"
+     inkscape:window-x="1912"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      showguides="true"
@@ -726,7 +903,9 @@
      borderlayer="true"
      showborder="true"
      inkscape:snap-nodes="false"
-     inkscape:snap-others="false">
+     inkscape:snap-others="false"
+     inkscape:snap-grids="true"
+     inkscape:snap-intersection-paths="true">
     <inkscape:grid
        type="xygrid"
        id="grid5304"
@@ -764,7 +943,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -773,25 +952,12 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(0,2575.9843)">
-    <path
-       style="opacity:1;fill:#ffffff;fill-opacity:0.84705882;stroke:none;stroke-width:45.20802689;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.84705882"
-       d="m 2780.9531,1723.418 a 90.416108,90.416108 0 0 0 -90.416,90.416 90.416108,90.416108 0 0 0 90.416,90.416 90.416108,90.416108 0 0 0 90.416,-90.416 90.416108,90.416108 0 0 0 -90.416,-90.416 z m -32.0547,37.4336 h 21.7696 l -0.7364,64.7168 h -20.2968 z m 44.3516,0 h 21.7676 l -0.7344,64.7168 h -20.2969 z m -44.0566,78.5429 h 21.1796 v 24.416 h -21.1796 z m 44.3515,0 h 21.1797 v 24.416 h -21.1797 z"
-       transform="matrix(0.93749997,0,0,0.93749997,0,-2575.9843)"
-       id="path5752"
-       inkscape:connector-curvature="0" />
-    <path
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:37.79527664;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.84705882"
-       d="m 2780.9531,1738.2441 a 75.590603,75.590603 0 0 0 -75.5898,75.5899 75.590603,75.590603 0 0 0 75.5898,75.5918 75.590603,75.590603 0 0 0 75.5899,-75.5918 75.590603,75.590603 0 0 0 -75.5899,-75.5899 z m -32.0547,22.6075 h 21.7696 l -0.7364,64.7168 h -20.2968 z m 44.3516,0 h 21.7676 l -0.7344,64.7168 h -20.2969 z m -44.0566,78.5429 h 21.1796 v 24.416 h -21.1796 z m 44.3515,0 h 21.1797 v 24.416 h -21.1797 z"
-       transform="matrix(0.93749997,0,0,0.93749997,0,-2575.9843)"
-       id="circle5891"
-       inkscape:connector-curvature="0" />
     <g
-       id="g5543"
-       transform="translate(-680.28307,1814.12)"
-       inkscape:label="Icon BBS">
+       id="g7713"
+       inkscape:label="rooster">
       <rect
-         y="-2575.9275"
-         x="1814.1449"
+         y="-761.80762"
+         x="2494.4919"
          height="226.76811"
          width="226.76811"
          id="rect4219"
@@ -799,14 +965,52 @@
       <path
          id="rect5585"
          style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 1897.7582,-2462.5433 h 59.5417 c 5.8691,0 10.6323,4.6298 10.6323,10.3346 0,5.7047 -4.7632,10.3346 -10.6323,10.3346 h -59.5417 c -5.8691,0 -10.6325,-4.6299 -10.6325,-10.3346 0,-5.7048 4.7634,-10.3346 10.6325,-10.3346 z m 0,37.2046 h 59.5417 c 5.8691,0 10.6323,4.63 10.6323,10.3347 0,5.7047 -4.7632,10.3346 -10.6323,10.3346 h -59.5417 c -5.8691,0 -10.6325,-4.6299 -10.6325,-10.3346 0,-5.7047 4.7634,-10.3347 10.6325,-10.3347 z m 112.7038,45.4725 c 0,9.1358 -7.6127,16.5354 -17.0118,16.5354 h -131.8423 c -9.3991,0 -17.012,-7.3996 -17.012,-16.5354 v -140.5512 c 0,-9.1358 7.6129,-16.5354 17.012,-16.5354 h 34.6618 c 2.9303,-14.1378 15.8211,-24.8032 31.2594,-24.8032 15.4383,0 28.3248,10.6654 31.2594,24.8032 h 34.6617 c 9.3991,0 17.0118,7.3996 17.0118,16.5354 z m -30.6215,-136.4173 h -20.4141 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.0816 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.4143 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.0946 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.6231 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.0946 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.4686 c 0,-5.7046 -4.7633,-10.3346 -10.6324,-10.3346 -5.8692,0 -10.6325,4.63 -10.6325,10.3346 0,5.7048 4.7633,10.3347 10.6325,10.3347 5.8691,0 10.6324,-4.6299 10.6324,-10.3347 z"
+         d="m 2690.809,-565.7463 c 0,9.1358 -7.6127,16.5354 -17.0118,16.5354 h -131.8423 c -9.3991,0 -17.012,-7.3996 -17.012,-16.5354 v -140.5512 c 0,-9.1358 7.6129,-16.5354 17.012,-16.5354 h 34.6618 c 2.9303,-14.1378 15.8211,-24.8032 31.2594,-24.8032 15.4383,0 28.3248,10.6654 31.2594,24.8032 h 34.6617 c 9.3991,0 17.0118,7.3996 17.0118,16.5354 z m -30.6215,-136.4173 h -20.4141 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.0816 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.4143 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.0946 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.6231 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.0946 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.4686 c 0,-5.7046 -4.7633,-10.3346 -10.6324,-10.3346 -5.8692,0 -10.6325,4.63 -10.6325,10.3346 0,5.7048 4.7633,10.3347 10.6325,10.3347 5.8691,0 10.6324,-4.6299 10.6324,-10.3347 z"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sssssssssssssssssssscscsssscsssscsssssssssssss" />
+         sodipodi:nodetypes="sssssscscsssscsssscsssssssssssss" />
+      <path
+         sodipodi:nodetypes="ccscssscscccssssccssssssssssssss"
+         inkscape:connector-curvature="0"
+         d="m 2592.2394,-645.6431 c -2.7369,-3.47 -5.1317,-5.1806 -11.0697,-5.7647 -1.0753,-0.1954 -1.8572,-1.1241 -1.8572,-2.2237 0,-0.8064 2.6391,-3.2257 2.6122,-3.2502 2.7394,-2.7612 4.2055,-7.233 4.2055,-10.6787 0,-5.3492 -4.7382,-9.7746 -10.9964,-9.7746 -6.378,0 -10.9965,4.4254 -10.9965,9.7746 0,3.47 1.4418,7.9663 4.1787,10.7301 0,0 2.6391,2.3924 2.6391,3.2013 0,1.1484 -0.8797,2.126 -2.0527,2.2725 -5.8183,0.5865 -8.1643,2.297 -10.8743,5.7182 -0.76,1.0019 -1.1973,2.9812 -1.2218,4.0321 v 4.5892 c 0,2.0282 1.6837,3.6654 3.7633,3.6654 h 29.1284 c 2.0796,0 3.7632,-1.6372 3.7632,-3.6654 v -4.5941 c -0.024,-1.0534 -0.4423,-3.0302 -1.2218,-4.032 z m 61.2618,-26.8071 h -44.1562 c -3.3722,0 -6.1092,2.737 -6.1092,6.1092 0,3.3723 2.737,6.1092 6.1092,6.1092 h 44.1562 c 3.3723,0 6.1091,-2.7369 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1092 -6.1091,-6.1092 z m 0,21.993 h -44.1562 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1091 0,3.3724 2.737,6.1092 6.1092,6.1092 h 44.1562 c 3.3723,0 6.1091,-2.7368 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1091 -6.1091,-6.1091 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.59113312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.59113312, 1.18226625;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect5566-2" />
+      <path
+         id="path7675"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.59113312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.59113312, 1.18226625;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 2592.2394,-598.399 c -2.7369,-3.47 -5.1317,-5.1806 -11.0697,-5.7647 -1.0753,-0.1954 -1.8572,-1.1241 -1.8572,-2.2237 0,-0.8064 2.6391,-3.2256 2.6122,-3.2501 2.7394,-2.7613 4.2055,-7.2331 4.2055,-10.6788 0,-5.3492 -4.7382,-9.7746 -10.9964,-9.7746 -6.378,0 -10.9965,4.4254 -10.9965,9.7746 0,3.47 1.4418,7.9663 4.1787,10.7301 0,0 2.6391,2.3924 2.6391,3.2013 0,1.1485 -0.8797,2.126 -2.0527,2.2725 -5.8183,0.5865 -8.1643,2.297 -10.8743,5.7182 -0.76,1.0019 -1.1973,2.9813 -1.2218,4.0321 v 4.5892 c 0,2.0282 1.6837,3.6655 3.7633,3.6655 h 29.1284 c 2.0796,0 3.7632,-1.6373 3.7632,-3.6655 v -4.5941 c -0.024,-1.0534 -0.4423,-3.0302 -1.2218,-4.032 z m 61.2618,-26.807 h -44.1562 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1091 0,3.3723 2.737,6.1092 6.1092,6.1092 h 44.1562 c 3.3723,0 6.1091,-2.7369 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1091 -6.1091,-6.1091 z m 0,21.9929 h -44.1562 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1092 0,3.3723 2.737,6.1091 6.1092,6.1091 h 44.1562 c 3.3723,0 6.1091,-2.7368 6.1091,-6.1091 0,-3.3723 -2.7368,-6.1092 -6.1091,-6.1092 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscssscscccssssccssssssssssssss" />
+    </g>
+    <g
+       id="g7707"
+       inkscape:label="set_navtarget">
+      <g
+         id="g7690"
+         transform="translate(681.68549,1812.0965)">
+        <g
+           id="g336"
+           transform="matrix(4.137302,0,0,4.1338581,-114.75634,-1021.3486)"
+           style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+          <path
+             style="fill:#ffffff"
+             inkscape:connector-curvature="0"
+             id="path334"
+             d="m 0,-38 c 5.8,0 10.5,4.7 10.5,10.5 0,5.8 -4.7,10.5 -10.5,10.5 -5.8,0 -10.5,-4.7 -10.5,-10.5 0,-5.8 4.7,-10.5 10.5,-10.5 m -15.5,10.22 c 0,10.2 12.03,18.05 13,29.78 V 2.5 C -2.5,3.88 -1.38,5 0,5 1.38,5 2.5,3.88 2.5,2.5 V 2 c 1.03,-11.73 13,-19.58 13,-29.78 C 15.5,-36.19 8.56,-43 0,-43 c -8.56,0 -15.5,6.81 -15.5,15.22 M 0,-34 c -3.59,0 -6.5,2.91 -6.5,6.5 0,3.59 2.91,6.5 6.5,6.5 3.59,0 6.5,-2.91 6.5,-6.5 C 6.5,-31.09 3.59,-34 0,-34 m -2.5,6.5 c 0,-1.38 1.12,-2.5 2.5,-2.5 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5" />
+        </g>
+        <rect
+           ry="10.042029"
+           y="-1213.2777"
+           x="-228.14217"
+           height="226.77165"
+           width="226.77165"
+           id="rect7685"
+           style="fill:none;stroke:none;stroke-width:10.72576714;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.72576782, 21.45153565;stroke-dashoffset:0" />
+      </g>
     </g>
     <g
        id="g4233"
        transform="translate(-1360.5945,2040.8916)"
-       inkscape:label="Icon Controls">
+       inkscape:label="controls">
       <rect
          y="-2575.9275"
          x="2040.913"
@@ -824,7 +1028,7 @@
     <g
        id="g4245"
        transform="translate(0.03544938,1814.12)"
-       inkscape:label="Icon Personal">
+       inkscape:label="personal">
       <rect
          y="-2575.9275"
          x="2267.6812"
@@ -843,7 +1047,7 @@
        id="g4257"
        style="stroke:none"
        transform="translate(907.08656,680.31481)"
-       inkscape:label="Icon Fuel %">
+       inkscape:label="fuel">
       <rect
          y="-2575.9841"
          x="2494.4883"
@@ -858,9 +1062,6 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccsssssscccccccccssssscsssscssssssccsssssssss" />
     </g>
-    <g
-       id="layer1-5"
-       transform="translate(11790.693,-20546.119)" />
     <g
        id="layer2"
        inkscape:label="background"
@@ -965,7 +1166,7 @@
            width="100%"
            transform="rotate(-90,406.62956,702.30173)"
            id="use4261-1"
-           inkscape:transform-center-y="-1.5020019e-005"
+           inkscape:transform-center-y="-1.5020019e-05"
            xlink:href="#path4255-1"
            y="0"
            x="0" />
@@ -2089,7 +2290,7 @@
     <g
        id="g5508"
        transform="translate(2494.4847,1814.1733)"
-       inkscape:label="Icon Map">
+       inkscape:label="map">
       <rect
          y="-2575.9844"
          x="226.77165"
@@ -2111,17 +2312,10 @@
          id="rect5492"
          style="opacity:1;fill:none;fill-opacity:0.7020202;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
-    <rect
-       style="opacity:1;fill:none;fill-opacity:0.7020202;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect5500"
-       width="226.76811"
-       height="226.76811"
-       x="-907.0849"
-       y="-5070.4707" />
     <g
        id="g5515"
        transform="translate(2.6508789e-5,1814.1733)"
-       inkscape:label="Icon Comms">
+       inkscape:label="comms">
       <rect
          y="-2575.9844"
          x="680.31494"
@@ -2139,7 +2333,7 @@
     <g
        id="g5521"
        transform="translate(-907.08661,2040.945)"
-       inkscape:label="Icon Galaxy Map">
+       inkscape:label="galaxy_map">
       <path
          inkscape:connector-curvature="0"
          d="m 1115.1339,-2486.1071 c -7.6614,-2.8509 -9.6342,6.6906 -11.9865,11.6423 -3.7889,7.335 -8.9679,14.1911 -15.365,19.4495 -7.2842,5.8875 -15.5349,10.7884 -24.7455,12.9577 23.0596,-23.0862 26.5881,-55.5925 14.7559,-85.0185 -4.3449,-10.797 -11.6621,-20.6366 -20.4049,-28.2629 -3.9632,-3.4644 -10.7046,-3.8505 -12.2978,2.465 -1.218,4.8237 3.8639,8.9832 6.364,12.6044 9.4358,14.7007 13.1032,33.987 8.0124,50.9364 -8.2463,-30.73 -33.9428,-50.4244 -64.6883,-55.0651 -11.44382,-1.4233 -23.49214,-1.0283 -34.50342,2.7209 -4.67809,1.6042 -10.17492,4.8767 -7.03485,10.7928 2.77159,5.2143 8.24191,3.0694 12.80088,2.6877 18.31087,-1.4719 37.90159,4.7134 50.69369,18.3218 -31.52226,-8.4404 -61.45782,4.7973 -81.00663,29.7348 -7.18705,9.1688 -12.01745,20.4117 -14.27492,31.8025 -1.01722,5.157 2.01913,11.1944 8.28381,9.4202 4.78627,-1.3549 5.84993,-7.8424 7.73437,-11.8146 7.99698,-15.4973 22.89412,-28.3511 40.10611,-32.4069 -23.07286,23.0684 -26.58152,55.6056 -14.75372,85.0226 4.33824,10.7862 11.65777,20.6501 20.40722,28.2608 3.96085,3.46 10.70443,3.8484 12.29769,-2.4649 1.22245,-4.8281 -3.86611,-8.9789 -6.3596,-12.6088 -9.4335,-14.6853 -13.12302,-33.9959 -8.01683,-50.9341 8.23968,30.7299 33.9452,50.4243 64.6884,55.0672 11.4437,1.421 23.4921,1.0282 34.5011,-2.7231 4.676,-1.5975 10.1772,-4.8767 7.0327,-10.7906 -2.7672,-5.212 -8.2354,-3.0672 -12.7964,-2.6898 -18.3264,1.4696 -37.8819,-4.7158 -50.6937,-18.3198 20.0674,5.3711 40.7769,2.1846 58.2338,-8.7561 8.8752,-5.565 16.3293,-12.761 22.7727,-20.9831 4.3427,-5.5365 23.3774,-36.1606 10.2433,-41.0483 -3.5482,-1.3174 3.1887,1.185 0,0 z"
@@ -2156,7 +2350,7 @@
     <g
        id="g5527"
        transform="translate(1814.1697,1814.1733)"
-       inkscape:label="Icon SectorMap">
+       inkscape:label="sector_map">
       <path
          inkscape:connector-curvature="0"
          id="rect4693"
@@ -2173,7 +2367,7 @@
     <g
        id="g5533"
        transform="translate(1814.1697,1814.1733)"
-       inkscape:label="Icon OrbitalMap">
+       inkscape:label="system_map">
       <path
          inkscape:connector-curvature="0"
          id="path4734"
@@ -2190,7 +2384,7 @@
     <g
        id="g5539"
        transform="translate(1814.1732,1814.1733)"
-       inkscape:label="Icon SysOverview">
+       inkscape:label="system_overview">
       <path
          inkscape:connector-curvature="0"
          id="path4808"
@@ -2207,7 +2401,7 @@
     <g
        id="g5573"
        transform="translate(1587.4087,1814.12)"
-       inkscape:label="Icon Personal Info">
+       inkscape:label="personal_info">
       <g
          id="g5496">
         <rect
@@ -2228,7 +2422,7 @@
     <g
        id="g5619"
        transform="translate(680.31496,907.08663)"
-       inkscape:label="Icon Gas Giant">
+       inkscape:label="gas_giant">
       <path
          inkscape:connector-curvature="0"
          d="m 130.22265,-2298.6613 a 65.090954,65.053383 15 0 0 -57.469487,12.0998 c -6.016555,-0.1275 -11.795193,0.074 -17.245083,0.6273 -10.058967,1.0212 -18.642432,3.1557 -25.678997,6.8217 -7.036648,3.6658 -12.864946,9.3332 -14.894511,16.9079 -2.029647,7.5745 0.184057,15.3969 4.445032,22.0898 4.260974,6.6929 10.627112,12.8335 18.827888,18.7472 16.401634,11.8278 39.03476,21.7638 63.701728,28.3735 24.66697,6.6094 49.23594,9.321 69.35396,7.2787 10.05905,-1.021 18.64284,-3.1556 25.67941,-6.8216 7.03664,-3.6657 12.86494,-9.3331 14.8945,-16.9079 2.02965,-7.5745 -0.18405,-15.3968 -4.44503,-22.0897 -4.26097,-6.6929 -10.62743,-12.8337 -18.82822,-18.7475 -4.44189,-3.2031 -9.34398,-6.2664 -14.61649,-9.1635 a 65.090954,65.053383 15 0 0 -43.7247,-39.2157 z m 48.16817,63.4387 c 6.66022,4.8664 11.26238,9.6402 13.68188,13.4408 2.47418,3.8863 2.61369,6.1781 2.22284,7.6368 -0.39084,1.4586 -1.65757,3.3736 -5.74347,5.5022 -4.08589,2.1286 -10.6519,4.0002 -19.12279,4.8601 -16.9417,1.7198 -39.91717,-0.6164 -62.81981,-6.7531 -22.902587,-6.1367 -43.967567,-15.6013 -57.779642,-25.5615 -6.906038,-4.9801 -11.656678,-9.884 -14.130861,-13.7704 -2.474183,-3.8863 -2.613687,-6.1781 -2.222844,-7.6367 0.390842,-1.4587 1.65758,-3.3736 5.743474,-5.5022 3.989131,-2.0783 10.347774,-3.9088 18.529856,-4.7947 a 65.090954,65.053383 15 0 0 -6.23668,15.1297 65.090954,65.053383 15 0 0 -1.915425,10.702 c 1.502347,1.1903 3.145187,2.4038 4.931319,3.623 13.725606,9.3702 34.392332,18.3302 56.513963,24.0184 22.12163,5.6881 44.11052,7.6703 59.73261,5.9435 0.93511,-0.1035 1.83999,-0.2211 2.71737,-0.3497 a 65.090954,65.053383 15 0 0 3.76628,-10.2434 65.090954,65.053383 15 0 0 2.13193,-16.2448 z m -122.485804,29.781 a 65.090954,65.053383 15 0 0 40.643589,32.4535 65.090954,65.053383 15 0 0 51.369845,-7.7774 c -14.17813,-0.7762 -29.35173,-3.2442 -44.65965,-7.1805 -17.037876,-4.381 -33.236759,-10.3337 -47.353784,-17.4956 z"
@@ -2246,7 +2440,7 @@
     <g
        id="g5615"
        transform="translate(453.54329,453.54332)"
-       inkscape:label="Icon Planet">
+       inkscape:label="rocky_planet">
       <path
          inkscape:connector-curvature="0"
          id="path4139"
@@ -2263,7 +2457,7 @@
     <g
        id="g5611"
        transform="translate(226.77162,680.31498)"
-       inkscape:label="Icon Moon">
+       inkscape:label="moon">
       <path
          id="path4165"
          d="m 566.92916,-2285.4331 a 49.606473,49.606473 0 0 0 -49.60629,49.6062 49.606473,49.606473 0 0 0 49.60629,49.6064 49.606473,49.606473 0 0 0 16.28936,-2.8113 26.124719,26.124719 0 0 1 -24.91436,-26.064 26.124719,26.124719 0 0 1 26.12513,-26.1245 26.124719,26.124719 0 0 1 26.12456,26.1245 26.124719,26.124719 0 0 1 -0.23236,3.2822 49.606473,49.606473 0 0 0 6.21398,-24.0133 49.606473,49.606473 0 0 0 -49.60631,-49.6062 z"
@@ -2280,7 +2474,7 @@
     <g
        id="g8248"
        transform="translate(1587.4016,3628.3463)"
-       inkscape:label="Icon Orbital Station">
+       inkscape:label="spacestation">
       <path
          inkscape:connector-curvature="0"
          id="path4160"
@@ -2297,7 +2491,7 @@
     <g
        id="g5629"
        transform="translate(-453.54332,226.77173)"
-       inkscape:label="Icon Sun">
+       inkscape:label="sun">
       <g
          transform="matrix(1.0290015,0,0,1.0290015,-40.272562,67.062659)"
          id="g5308">
@@ -2455,7 +2649,7 @@
     <g
        id="g5644"
        transform="translate(-453.54326,453.54326)"
-       inkscape:label="Icon Ship">
+       inkscape:label="ship">
       <g
          id="g4431"
          transform="matrix(0.33518758,0,0,0.33518758,1556.4537,-2113.2601)"
@@ -2523,7 +2717,7 @@
     <g
        id="g5663"
        transform="translate(-1587.4016,2040.945)"
-       inkscape:label="Icon New">
+       inkscape:label="new">
       <path
          sodipodi:nodetypes="cssssssccsccsssssssssss"
          inkscape:connector-curvature="0"
@@ -2541,7 +2735,7 @@
     <g
        id="g5679"
        transform="translate(-2721.2598,2040.945)"
-       inkscape:label="Icon Settings">
+       inkscape:label="settings">
       <rect
          y="-2575.9844"
          x="2948.0315"
@@ -2556,17 +2750,10 @@
          style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
          id="path5675" />
     </g>
-    <rect
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect5685"
-       width="226.77193"
-       height="226.7717"
-       x="1587.4014"
-       y="-5070.4727" />
     <g
        id="g5826"
        transform="translate(-226.77148,1814.1731)"
-       inkscape:label="Icon MSG">
+       inkscape:label="message">
       <path
          sodipodi:nodetypes="ssssssssscccscccscccscccscccccc"
          inkscape:connector-curvature="0"
@@ -2586,7 +2773,7 @@
     <g
        id="g5809"
        transform="translate(-226.77178,2040.9449)"
-       inkscape:label="Icon MSG Opened">
+       inkscape:label="message_open">
       <path
          sodipodi:nodetypes="cccccsssssccsssccccsscccsccccss"
          inkscape:connector-curvature="0"
@@ -2606,7 +2793,7 @@
     <g
        id="g5830"
        transform="translate(-2494.4883,2040.945)"
-       inkscape:label="Icon Icon Sound 1">
+       inkscape:label="sound">
       <rect
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
          id="rect5817"
@@ -2626,7 +2813,7 @@
     <g
        id="g5982"
        transform="translate(-2267.7165,2040.9449)"
-       inkscape:label="Icon Skull">
+       inkscape:label="skull">
       <path
          sodipodi:nodetypes="ssssscscssscscssssssssssssccsssscccc"
          inkscape:connector-curvature="0"
@@ -2644,7 +2831,7 @@
     <g
        id="g6004"
        transform="translate(-1587.4014,1814.1732)"
-       inkscape:label="Icon Zoom In">
+       inkscape:label="zoom_in">
       <path
          sodipodi:nodetypes="ssscssscssscssscsccccssssccsssss"
          inkscape:connector-curvature="0"
@@ -2662,7 +2849,7 @@
     <g
        id="g6008"
        transform="translate(-1360.63,1814.1732)"
-       inkscape:label="Icon Search">
+       inkscape:label="search_lens">
       <path
          sodipodi:nodetypes="ccsscsscssccsssscssssss"
          inkscape:connector-curvature="0"
@@ -2680,7 +2867,7 @@
     <g
        id="g6012"
        transform="translate(-1814.1729,1814.1732)"
-       inkscape:label="Icon Zoom Out">
+       inkscape:label="zoom_out">
       <path
          sodipodi:nodetypes="sssssssccccssssccsssss"
          inkscape:connector-curvature="0"
@@ -2698,7 +2885,7 @@
     <g
        id="g6046"
        transform="translate(-2948.0318,1587.4015)"
-       inkscape:label="Icon UnMute">
+       inkscape:label="unmute">
       <rect
          y="-2122.4409"
          x="4762.2051"
@@ -2716,7 +2903,7 @@
     <g
        id="g6042"
        transform="translate(-2948.0314,1587.4016)"
-       inkscape:label="Icon Music">
+       inkscape:label="music">
       <rect
          y="-2122.4409"
          x="4988.9761"
@@ -2734,7 +2921,7 @@
     <g
        id="g6050"
        transform="translate(-2948.0315,1587.4015)"
-       inkscape:label="Icon Mute">
+       inkscape:label="mute">
       <rect
          y="-2122.4409"
          x="4535.4331"
@@ -2752,7 +2939,7 @@
     <g
        id="g6068"
        transform="translate(2267.7161,-453.54331)"
-       inkscape:label="Icon Semi major Axis">
+       inkscape:label="semi_major_axis">
       <g
          transform="matrix(7.4929899,0,0,7.4929899,-721.29523,-1504.2392)"
          id="g4798"
@@ -2789,16 +2976,9 @@
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
     <g
-       id="g4922"
-       transform="matrix(1.381934,0,0,1.3844996,-2852.0048,-3348.3447)"
-       style="opacity:1" />
-    <g
-       id="g5005"
-       transform="matrix(7.0866142,0,0,7.0866142,-4202.3622,-11089.506)" />
-    <g
        id="g6993"
        transform="translate(3855.1182,1.3511088e-4)"
-       inkscape:label="Autopilot Dock - Land">
+       inkscape:label="autopilot_dock">
       <g
          id="g4795"
          transform="matrix(-3.5485886,0.95084147,0.95926382,3.5800212,-2012.4283,-7183.6806)"
@@ -2866,7 +3046,7 @@
     <g
        id="g7007"
        transform="translate(3401.5748,3.5110882e-5)"
-       inkscape:label="Autopilot GOTO 2">
+       inkscape:label="autopilot_fly_to">
       <g
          id="g4852"
          transform="matrix(-5.8136821,1.5621073,1.5715699,5.8815033,-1649.2994,-10870.805)"
@@ -2930,7 +3110,7 @@
     <g
        id="g7020"
        transform="translate(3628.3465,8.088725e-5)"
-       inkscape:label="Autopilot HOLD">
+       inkscape:label="autopilot_hold">
       <g
          id="g4881"
          transform="matrix(-5.202294,1.3744382,1.4062979,5.1749086,-1493.0306,-9727.0321)"
@@ -3009,7 +3189,7 @@
     <g
        id="g7034"
        transform="translate(907.08663,3.5110882e-5)"
-       inkscape:label="Autopilot Manual Flight">
+       inkscape:label="autopilot_manual">
       <g
          id="g4561"
          transform="matrix(-7.1449865,0,0,7.1311678,3428.5339,-12024.911)"
@@ -3059,7 +3239,7 @@
     <g
        id="g7044"
        transform="translate(907.08663,3.5110882e-5)"
-       inkscape:label="Autopilot Set Speed">
+       inkscape:label="autopőilot_set_speed">
       <g
          id="g4684"
          transform="matrix(7.0860653,0,0,7.0860653,-3246.3761,-11968.083)">
@@ -3152,7 +3332,7 @@
     <g
        id="g7072"
        transform="translate(4308.6615,-226.77161)"
-       inkscape:label="Function Rot Damping OFF">
+       inkscape:label="rotation_damping_off">
       <g
          transform="matrix(8.0514504,0,0,8.0514504,-2365.4077,-12161.709)"
          id="g4158">
@@ -3185,7 +3365,7 @@
     <g
        id="g7104"
        transform="translate(4308.6613,-226.77161)"
-       inkscape:label="Function Rot damping ON">
+       inkscape:label="rotation_damping_on">
       <g
          id="g4163"
          transform="matrix(8.0514504,0,0,8.0514504,-2592.1792,-12161.709)">
@@ -3242,7 +3422,7 @@
     <g
        id="g7115"
        transform="translate(4308.6615,-226.77166)"
-       inkscape:label="Function ECM">
+       inkscape:label="ecm">
       <path
          style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd"
          inkscape:connector-curvature="0"
@@ -3259,7 +3439,7 @@
     <g
        id="g7144"
        transform="translate(3401.5747,-1360.6299)"
-       inkscape:label="Frame of reference opposite">
+       inkscape:label="frame_away">
       <circle
          style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="circle5060"
@@ -3277,7 +3457,7 @@
     <g
        id="g7148"
        transform="translate(3174.8032,-1587.4016)"
-       inkscape:label="Frame of reference">
+       inkscape:label="frame">
       <circle
          r="99.212601"
          cy="-875.1969"
@@ -3295,7 +3475,7 @@
     <g
        id="g7152"
        transform="translate(2267.7165,-1587.4015)"
-       inkscape:label="Autopilot hold Radial out">
+       inkscape:label="radial_out_thin">
       <g
          id="g5330"
          transform="matrix(13.086625,0,0,13.237075,-12075.082,-16913.641)"
@@ -3334,7 +3514,7 @@
     <g
        id="g7160"
        transform="translate(2721.2599,-1587.4015)"
-       inkscape:label="Autopilot hold Radial in">
+       inkscape:label="radial_in_thin">
       <g
          id="g5324"
          transform="matrix(13.086808,0,0,13.237221,-12301.998,-16677.478)"
@@ -3373,7 +3553,7 @@
     <g
        id="g7168"
        transform="translate(2040.9448,-1814.1732)"
-       inkscape:label="Autopilot hold Prograde">
+       inkscape:label="prograde_thin">
       <rect
          transform="rotate(45)"
          y="1001.2147"
@@ -3393,7 +3573,7 @@
     <g
        id="g7172"
        transform="translate(2040.945,-1814.1732)"
-       inkscape:label="Autopilot hold Retrograde">
+       inkscape:label="retrograde_thin">
       <g
          transform="matrix(11.296799,0,0,11.296799,-12124.203,-4799.8693)"
          id="g4982"
@@ -3420,7 +3600,7 @@
     <g
        id="g7184"
        transform="translate(2948.0314,-2040.9449)"
-       inkscape:label="Autopilot hold Antinormal">
+       inkscape:label="antinormal_thin">
       <g
          transform="matrix(11.159539,0,0,-11.230746,-12231.773,4148.0727)"
          id="g5008"
@@ -3448,7 +3628,7 @@
     <g
        id="g7178"
        transform="translate(2948.0314,-2040.9449)"
-       inkscape:label="Autopilot hold Normal">
+       inkscape:label="normal_thin">
       <g
          style="display:inline"
          id="g7122"
@@ -3476,7 +3656,7 @@
     <g
        id="g7228"
        transform="translate(4535.1181,-453.54343)"
-       inkscape:label="Autopilot High Orbit">
+       inkscape:label="autopilot_high_orbit">
       <g
          transform="matrix(7.0866142,0,0,7.0866142,-4655.9055,-11089.506)"
          id="g5039">
@@ -3504,7 +3684,7 @@
     <g
        id="g7234"
        transform="translate(4081.5747,-453.54343)"
-       inkscape:label="Autopilot Med Orbit">
+       inkscape:label="autopilot_medium_orbit">
       <g
          transform="matrix(7.0866142,0,0,7.0866142,-4429.1339,-11089.506)"
          id="g5725">
@@ -3532,7 +3712,7 @@
     <g
        id="g7240"
        transform="translate(3628.0314,-453.54343)"
-       inkscape:label="Autopilot Low Orbit">
+       inkscape:label="autopilot_low_orbit">
       <g
          id="g7223">
         <circle
@@ -3561,7 +3741,7 @@
     <g
        id="g7248"
        transform="translate(4988.9764,-226.77169)"
-       inkscape:label="Autopilot Undock">
+       inkscape:label="autopilot_undock">
       <g
          style="display:inline;opacity:1"
          transform="matrix(-3.5485886,0.95084147,0.95926382,3.5800212,-2692.7433,-6956.9089)"
@@ -3629,7 +3809,7 @@
     <g
        id="g7262"
        transform="translate(5442.5197,-453.5433)"
-       inkscape:label="Autopilot Blastoff">
+       inkscape:label="autopilot_blastoff">
       <g
          transform="matrix(6.6110346,0,0,6.6110346,-5987.3396,-10817.643)"
          id="g5806"
@@ -3684,7 +3864,7 @@
     <g
        id="g7302"
        transform="translate(4081.8898,-226.77161)"
-       inkscape:label="Function Gear up">
+       inkscape:label="landing_gear_up">
       <g
          id="g4184"
          transform="matrix(7.3435927,0,0,7.5068624,-6032.3746,-12639.865)">
@@ -3768,7 +3948,7 @@
     <g
        id="g7317"
        transform="translate(4308.6615,-680.31495)"
-       inkscape:label="Function Gear down">
+       inkscape:label="landing_gear_down">
       <g
          id="g4234"
          transform="matrix(0,7.3435753,-7.5068444,0,8249.6811,-4384.7292)"
@@ -3858,7 +4038,7 @@
     <g
        id="g7369"
        transform="translate(4308.6615,-226.77162)"
-       inkscape:label="Function Hyperspace">
+       inkscape:label="hyperspace">
       <g
          id="g5402"
          transform="matrix(8.8645347,1.109335,-1.1019231,8.8884383,-1993.7774,-2802.6363)"
@@ -3954,7 +4134,7 @@
     <g
        id="g7393"
        transform="translate(4535.4333,680.31492)"
-       inkscape:label="Icon View External">
+       inkscape:label="view_external">
       <path
          style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd"
          inkscape:connector-curvature="0"
@@ -3971,7 +4151,7 @@
     <g
        id="g7389"
        transform="translate(4762.2049,453.54331)"
-       inkscape:label="Icon View Sideral">
+       inkscape:label="view_sideral">
       <path
          style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd"
          inkscape:connector-curvature="0"
@@ -3988,7 +4168,7 @@
     <g
        id="g7427"
        transform="translate(-4535.4332,-453.54332)"
-       inkscape:label="Directional indicator Filled">
+       inkscape:label="direction">
       <path
          sodipodi:nodetypes="cccccccc"
          inkscape:connector-curvature="0"
@@ -4006,7 +4186,7 @@
     <g
        id="g7423"
        transform="translate(-4535.4334,-453.54327)"
-       inkscape:label="Reference Frame direction indicator">
+       inkscape:label="direction_frame">
       <path
          sodipodi:nodetypes="ccccccsccccc"
          inkscape:connector-curvature="0"
@@ -4024,7 +4204,7 @@
     <g
        id="g7419"
        transform="translate(-4762.2047,-453.54332)"
-       inkscape:label="Reference Frame direction indicator Opposite">
+       inkscape:label="direction_frame_hollow">
       <path
          sodipodi:nodetypes="cccccccccccccccccc"
          inkscape:connector-curvature="0"
@@ -4041,7 +4221,8 @@
     </g>
     <g
        id="g7433"
-       transform="translate(-4988.9764,-226.77166)">
+       transform="translate(-4988.9764,-226.77166)"
+       inkscape:label="asteroid_hollow">
       <path
          sodipodi:nodetypes="sccccsccccccccccccsccccccccccc"
          inkscape:connector-curvature="0"
@@ -4059,7 +4240,7 @@
     <g
        id="g7443"
        transform="translate(-1587.4018,-453.54327)"
-       inkscape:label="FWD dir indicator">
+       inkscape:label="direction_forward">
       <path
          style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          d="m 4445.4083,-1808.0559 -23.1357,-19.4926 -23.5234,19.7416"
@@ -4081,66 +4262,9 @@
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
     <g
-       id="g7508"
-       transform="translate(-8163.7799,-226.77163)"
-       inkscape:label="Radial out marker">
-      <path
-         sodipodi:nodetypes="scssccccssccccccsscccccccc"
-         inkscape:connector-curvature="0"
-         d="m 8705.5841,-2320.8084 c 8.1225,-0.2397 14.8377,6.2783 14.8396,14.4043 v 141.1542 c 0,6.0392 -3.7678,11.4372 -9.4352,13.5232 -5.6676,2.0861 -12.0346,0.4179 -15.9512,-4.1791 l -60.1019,-70.5764 c -4.5859,-5.3859 -4.5859,-13.3035 0,-18.6894 l 60.1019,-70.5766 c 2.6425,-3.1015 6.4741,-4.9399 10.5468,-5.0602 z m 50.2499,0 c 4.0727,0.1203 7.9046,1.9587 10.5467,5.0602 l 60.102,70.5766 c 4.5859,5.3859 4.5859,13.3035 0,18.6894 l -60.102,70.5764 c -3.9165,4.597 -10.2835,6.2652 -15.9509,4.1791 -5.6674,-2.086 -9.4335,-7.484 -9.4352,-13.5232 v -141.1542 c 0,-8.126 6.7172,-14.644 14.8394,-14.4043 z m -64.2358,53.5593 -26.7589,31.4222 26.7589,31.4222 z m 78.2219,0 v 62.8444 l 26.7589,-31.4222 z"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect7452" />
-      <rect
-         y="-2349.2126"
-         x="8617.3232"
-         height="226.77165"
-         width="226.77165"
-         id="rect7486"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
-    </g>
-    <g
-       id="g5827">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         d="m 113.385,-2528.1576 65.56,65.559 -65.559,65.5586 -65.56,-65.559 z"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect7460" />
-      <rect
-         y="-2575.9844"
-         x="6.2499996e-005"
-         height="226.77165"
-         width="226.77165"
-         id="rect7496"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
-    </g>
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:0.78431373;fill-rule:nonzero;stroke:none;stroke-width:33.31446075;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="m 2304.8688,-957.99113 c -12.8216,0 -20.8354,13.88381 -14.4251,24.9886 l 77.414,134.08807 c 6.4122,11.10375 22.4413,11.10375 28.8535,0 l 77.414,-134.08807 c 6.4103,-11.10479 -1.6034,-24.98632 -14.4251,-24.9886 z m 67.9195,25.07807 h 19.1868 l -0.6472,57.04431 h -17.8924 z m 0.2582,69.23134 h 18.6704 v 21.52137 h -18.6704 z"
-       id="path5791"
-       inkscape:connector-curvature="0" />
-    <g
-       id="g7504"
-       transform="translate(-7483.4648,-226.77163)"
-       inkscape:label="Radial in marker">
-      <path
-         sodipodi:nodetypes="scssccccssccccccsscccccccc"
-         inkscape:connector-curvature="0"
-         d="m 8193.3253,-2323.8602 c -8.4142,-0.2484 -15.3706,6.5038 -15.3727,14.9216 v 146.2232 c 0,6.2561 3.9031,11.8479 9.774,14.0088 5.8713,2.161 12.467,0.433 16.5241,-4.3291 l 62.2603,-73.1109 c 4.7506,-5.5793 4.7506,-13.7813 0,-19.3606 l -62.2603,-73.1111 c -2.7373,-3.2129 -6.7064,-5.1173 -10.9254,-5.2419 z m 167.6811,0 c -4.2191,0.1246 -8.1885,2.029 -10.9255,5.2419 l -62.2603,73.1111 c -4.7506,5.5793 -4.7506,13.7813 0,19.3606 l 62.2603,73.1109 c 4.0571,4.7621 10.6527,6.4901 16.5237,4.3291 5.8709,-2.1609 9.7722,-7.7527 9.7741,-14.0088 v -146.2232 c 0,-8.4178 -6.9585,-15.17 -15.3723,-14.9216 z m -153.193,55.4826 27.7197,32.5507 -27.7197,32.5506 z m 138.7045,0 v 65.1013 l -27.7198,-32.5506 z"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect7462" />
-      <rect
-         y="-2349.2126"
-         x="8163.7798"
-         height="226.77165"
-         width="226.77165"
-         id="rect7500"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
-    </g>
-    <g
        id="g7537"
        transform="translate(-9751.1814,-226.77163)"
-       inkscape:label="Maneuver node marker">
+       inkscape:label="maneuver">
       <path
          sodipodi:nodetypes="sssssccssssssssss"
          inkscape:connector-curvature="0"
@@ -4158,7 +4282,7 @@
     <g
        transform="translate(-7710.2366,-226.77163)"
        id="g7541"
-       inkscape:label="Antinormal marker">
+       inkscape:label="antinormal">
       <rect
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
          id="rect7545"
@@ -4185,7 +4309,7 @@
     <g
        id="g7585"
        transform="matrix(1,0,0,-1,-7483.465,-4698.4253)"
-       inkscape:label="Normal marker">
+       inkscape:label="normal">
       <rect
          y="-2349.2126"
          x="8617.3232"
@@ -4212,7 +4336,7 @@
     <g
        id="g7670"
        transform="translate(907.0866,-1360.6299)"
-       inkscape:label="Icon eccentricity">
+       inkscape:label="eccentricity">
       <rect
          y="-761.8111"
          x="1814.1732"
@@ -4246,7 +4370,7 @@
     <g
        id="g7751"
        transform="translate(2721.2599,-1587.4016)"
-       inkscape:label="Icon Inclination">
+       inkscape:label="inclination">
       <rect
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:28.34645653;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect7680"
@@ -4285,7 +4409,7 @@
     <g
        id="g7694"
        transform="rotate(90,5215.748,-5977.559)"
-       inkscape:label="Icon arc periapsis">
+       inkscape:label="current_apoapsis">
       <g
          id="g7696">
         <path
@@ -4306,7 +4430,7 @@
     <g
        id="g7702"
        transform="rotate(-90,5669.2911,1505.9054)"
-       inkscape:label="Icon arc Periapsis">
+       inkscape:label="current_periapsis">
       <g
          id="g7704">
         <path
@@ -4327,7 +4451,7 @@
     <g
        transform="matrix(-1,0,0,1,12699.213,226.77146)"
        id="g7712"
-       inkscape:label="Icon arc Current height">
+       inkscape:label="current_height">
       <path
          id="path7714"
          style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
@@ -4345,7 +4469,7 @@
     <g
        transform="rotate(-90,6009.4489,1165.748)"
        id="g7720"
-       inkscape:label="Icon Gravity">
+       inkscape:label="gravity">
       <g
          id="g7722">
         <rect
@@ -4382,7 +4506,7 @@
     <g
        id="g7759"
        transform="translate(1814.1729,-1587.4018)"
-       inkscape:label="Icon ETA">
+       inkscape:label="eta">
       <g
          transform="translate(-1629.9212,226.77167)"
          id="g7763"
@@ -4405,7 +4529,7 @@
     <g
        id="g7790"
        transform="translate(-8163.7808,226.77199)"
-       inkscape:label="Icon Longtitude">
+       inkscape:label="longtitude">
       <path
          sodipodi:nodetypes="ssssssssss"
          inkscape:connector-curvature="0"
@@ -4429,7 +4553,7 @@
     <g
        transform="rotate(-90,7596.8506,1846.0631)"
        id="g7798"
-       inkscape:label="Icon Latitude">
+       inkscape:label="latitude">
       <path
          id="path7800"
          style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
@@ -4453,7 +4577,7 @@
     <g
        id="g8002"
        transform="translate(-3855.1182,3174.8031)"
-       inkscape:label="Icon Language">
+       inkscape:label="language">
       <path
          sodipodi:nodetypes="sssssscccccscsccccccccccccscccccscccccscccsccccc"
          inkscape:connector-curvature="0"
@@ -4471,7 +4595,7 @@
     <g
        id="g7998"
        transform="translate(-5442.5198,3401.5748)"
-       inkscape:label="Icon Bookmark">
+       inkscape:label="bookmarks">
       <path
          sodipodi:nodetypes="ssssccccssssssss"
          inkscape:connector-curvature="0"
@@ -4489,7 +4613,7 @@
     <g
        id="g7994"
        transform="translate(-4308.6614,2948.0315)"
-       inkscape:label="Icon Repairs">
+       inkscape:label="repairs">
       <path
          sodipodi:nodetypes="sscccccscccccccsscccscscccssccccccccccccssssss"
          inkscape:connector-curvature="0"
@@ -4507,7 +4631,7 @@
     <g
        id="g7990"
        transform="translate(-6349.6065,3401.5747)"
-       inkscape:label="Icon Planet grid">
+       inkscape:label="planet_grid">
       <path
          sodipodi:nodetypes="ssssssccsccscccccccccccccccccccsccsccccccccccccccscccsccccccccccc"
          inkscape:connector-curvature="0"
@@ -4525,7 +4649,7 @@
     <g
        id="g7958"
        transform="translate(-4308.6653,2267.7165)"
-       inkscape:label="Icon Information - Lobby">
+       inkscape:label="info">
       <path
          sodipodi:nodetypes="sssssccsssssscsssssc"
          inkscape:connector-curvature="0"
@@ -4543,7 +4667,7 @@
     <g
        id="g7954"
        transform="translate(-3628.3466,1133.8583)"
-       inkscape:label="Function Scanner">
+       inkscape:label="scanner">
       <path
          sodipodi:nodetypes="ccssccsccccssssccccsccscccsccsscccccsscccscscccccsccccc"
          inkscape:connector-curvature="0"
@@ -4561,7 +4685,7 @@
     <g
        id="g7930"
        transform="translate(-6349.6066,2721.2599)"
-       inkscape:label="Icon Unlocked">
+       inkscape:label="unlocked">
       <path
          sodipodi:nodetypes="sssssscssssssssscssssssccssccs"
          inkscape:connector-curvature="0"
@@ -4577,9 +4701,27 @@
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:21.25984192;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5151515" />
     </g>
     <g
+       id="g7504"
+       transform="translate(-7483.4648,-226.77163)"
+       inkscape:label="radial_in">
+      <path
+         sodipodi:nodetypes="scssccccssccccccsscccccccc"
+         inkscape:connector-curvature="0"
+         d="m 8193.3253,-2323.8602 c -8.4142,-0.2484 -15.3706,6.5038 -15.3727,14.9216 v 146.2232 c 0,6.2561 3.9031,11.8479 9.774,14.0088 5.8713,2.161 12.467,0.433 16.5241,-4.3291 l 62.2603,-73.1109 c 4.7506,-5.5793 4.7506,-13.7813 0,-19.3606 l -62.2603,-73.1111 c -2.7373,-3.2129 -6.7064,-5.1173 -10.9254,-5.2419 z m 167.6811,0 c -4.2191,0.1246 -8.1885,2.029 -10.9255,5.2419 l -62.2603,73.1111 c -4.7506,5.5793 -4.7506,13.7813 0,19.3606 l 62.2603,73.1109 c 4.0571,4.7621 10.6527,6.4901 16.5237,4.3291 5.8709,-2.1609 9.7722,-7.7527 9.7741,-14.0088 v -146.2232 c 0,-8.4178 -6.9585,-15.17 -15.3723,-14.9216 z m -153.193,55.4826 27.7197,32.5507 -27.7197,32.5506 z m 138.7045,0 v 65.1013 l -27.7198,-32.5506 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect7462" />
+      <rect
+         y="-2349.2126"
+         x="8163.7798"
+         height="226.77165"
+         width="226.77165"
+         id="rect7500"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
        id="g7962"
        transform="translate(-4762.205,2040.9449)"
-       inkscape:label="Icon Broadcast">
+       inkscape:label="broadcast">
       <path
          sodipodi:nodetypes="scsssssssssscssssccssccsssccssccssssccssccsssccssccsss"
          inkscape:connector-curvature="0"
@@ -4597,7 +4739,7 @@
     <g
        id="g7966"
        transform="translate(-5215.7483,2040.9449)"
-       inkscape:label="Icon Shield">
+       inkscape:label="shield_other">
       <path
          sodipodi:nodetypes="scccccccccscsccccccccccsccccsccccccccccc"
          inkscape:connector-curvature="0"
@@ -4615,7 +4757,7 @@
     <g
        id="g7938"
        transform="translate(-6576.3781,1587.4016)"
-       inkscape:label="Icon Market">
+       inkscape:label="market">
       <path
          sodipodi:nodetypes="sccssssssssccssccsssssccsssssssssssss"
          inkscape:connector-curvature="0"
@@ -4633,7 +4775,7 @@
     <g
        id="g7942"
        transform="translate(-6349.6066,2267.7166)"
-       inkscape:label="Icon Label">
+       inkscape:label="label">
       <path
          sodipodi:nodetypes="sssssccccsscccccsssss"
          inkscape:connector-curvature="0"
@@ -4651,7 +4793,7 @@
     <g
        id="g7950"
        transform="rotate(90,4081.89,-5297.2443)"
-       inkscape:label="Icon Arc Current">
+       inkscape:label="current_line">
       <path
          sodipodi:nodetypes="sssssssss"
          inkscape:connector-curvature="0"
@@ -4669,7 +4811,7 @@
     <g
        id="g7946"
        transform="translate(-4762.2048,907.08651)"
-       inkscape:label="Message bubble">
+       inkscape:label="message_bubble">
       <path
          sodipodi:nodetypes="sscssccssssssssssssssssssssss"
          inkscape:connector-curvature="0"
@@ -4687,7 +4829,7 @@
     <g
        id="g7934"
        transform="translate(-5896.0631,2267.7166)"
-       inkscape:label="Icon Star - Favourite">
+       inkscape:label="star">
       <path
          sodipodi:nodetypes="sccsscccsscccsscccssccs"
          inkscape:connector-curvature="0"
@@ -4704,8 +4846,8 @@
     </g>
     <g
        id="g7982"
-       transform="translate(-5896.0673,2040.9448)"
-       inkscape:label="Icon Rooster">
+       transform="translate(-8163.7802,3401.5746)"
+       inkscape:label="notebook">
       <path
          sodipodi:nodetypes="sscssssccsssscsssscsssccsssccsssccssscsssscsssccsssccsssccssscssssssss"
          inkscape:connector-curvature="0"
@@ -4723,7 +4865,7 @@
     <g
        id="g7986"
        transform="translate(-7029.9218,2494.4883)"
-       inkscape:label="Icon Equipment">
+       inkscape:label="equipment">
       <path
          sodipodi:nodetypes="ssssscccccsssssscsssscsscssssscccssssssssssssss"
          inkscape:connector-curvature="0"
@@ -4741,7 +4883,7 @@
     <g
        id="g7925"
        transform="translate(-7029.9214,2948.0315)"
-       inkscape:label="Icon Locked">
+       inkscape:label="locked">
       <path
          sodipodi:nodetypes="scsssssssscssscsssccsssccssccs"
          inkscape:connector-curvature="0"
@@ -4766,7 +4908,7 @@
     <g
        id="g7972"
        transform="translate(-5442.5201,1814.1731)"
-       inkscape:label="Icon HUD">
+       inkscape:label="hud">
       <path
          sodipodi:nodetypes="cccccccssccccsssssssssssssssssssssssssssssssss"
          inkscape:connector-curvature="0"
@@ -4784,7 +4926,7 @@
     <g
        id="g7978"
        transform="translate(-5896.0634,1587.4016)"
-       inkscape:label="Icon Factory">
+       inkscape:label="factory">
       <path
          sodipodi:nodetypes="ssccssccsscccssccsssssssssssssssssssssssssssssss"
          inkscape:connector-curvature="0"
@@ -4802,7 +4944,7 @@
     <g
        id="g8244"
        transform="translate(-1.1508789e-5,1814.1733)"
-       inkscape:label="Icon View Internal">
+       inkscape:label="view_internal">
       <path
          sodipodi:nodetypes="ssscsscsscscccscccsssss"
          inkscape:connector-curvature="0"
@@ -4819,7 +4961,7 @@
     </g>
     <g
        id="g8275"
-       inkscape:label="Icon Altitude">
+       inkscape:label="altitude">
       <rect
          y="-2122.4409"
          x="2267.7166"
@@ -4859,7 +5001,7 @@
     <g
        transform="translate(-4308.6615,-453.54332)"
        id="g8284"
-       inkscape:label="Directorial indicator Hollow">
+       inkscape:label="direction_hollow">
       <path
          id="path8286"
          style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
@@ -4875,69 +5017,7 @@
          y="-1895.6693" />
     </g>
     <g
-       id="g8294"
-       inkscape:label="Icon Periapsis"
-       transform="matrix(-1,0,0,1,6349.6063,0)">
-      <desc
-         id="desc8306">Icon </desc>
-      <rect
-         y="-2349.2126"
-         x="2948.0315"
-         height="226.77165"
-         width="226.77165"
-         id="rect8290"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         inkscape:transform-center-x="5.6345812e-005"
-         transform="matrix(0.46899886,0,0,0.46614372,1572.4382,-1167.1828)"
-         inkscape:transform-center-y="26.427083"
-         d="m 3174.8032,-2122.441 -196.39,-340.1575 392.78,0 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="2.6179939"
-         sodipodi:arg1="1.5707963"
-         sodipodi:r2="113.38583"
-         sodipodi:r1="226.77165"
-         sodipodi:cy="-2349.2126"
-         sodipodi:cx="3174.8032"
-         sodipodi:sides="3"
-         id="path8292"
-         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:30.31258392;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         sodipodi:type="star" />
-    </g>
-    <g
-       id="g8298"
-       transform="matrix(-1,0,0,1,6122.8346,1.9852093e-5)"
-       inkscape:label="Icon Apoapsis">
-      <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect8300"
-         width="226.77165"
-         height="226.77165"
-         x="2948.0315"
-         y="-2349.2126" />
-      <path
-         sodipodi:type="star"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:30.31258392;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="path8302"
-         sodipodi:sides="3"
-         sodipodi:cx="3174.8032"
-         sodipodi:cy="-2349.2126"
-         sodipodi:r1="226.77165"
-         sodipodi:r2="113.38583"
-         sodipodi:arg1="1.5707963"
-         sodipodi:arg2="2.6179939"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
-         d="m 3174.8032,-2122.441 -196.39,-340.1575 392.78,0 z"
-         inkscape:transform-center-y="-26.427079"
-         transform="matrix(0.46899886,0,0,-0.46614372,1572.4382,-3304.4709)"
-         inkscape:transform-center-x="5.6345812e-005" />
-    </g>
-    <g
-       inkscape:label="Autopilot Undock Illegal"
+       inkscape:label="autopilot_undock_illegal"
        transform="translate(5215.7481,-226.77169)"
        id="g8308">
       <g
@@ -4991,7 +5071,7 @@
          y="-1442.126" />
     </g>
     <g
-       inkscape:label="Autopilot Blastoff Illegal"
+       inkscape:label="autopilot_blastoff_illegal"
        transform="translate(5669.2914,-453.5433)"
        id="g8338">
       <g
@@ -5137,7 +5217,8 @@
     <g
        transform="matrix(-9.8327547,2.6339782,2.6580162,9.9172133,3010.9055,-17460.396)"
        style="display:inline;opacity:1"
-       id="g8334-72">
+       id="g8334-72"
+       inkscape:label="hyperspace_off">
       <path
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:7.08661413;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="m 2544.7227,722.50195 a 7.1178267,7.05695 74.556475 0 0 -2.0938,0.25977 7.1178267,7.05695 74.556475 0 0 -2.9687,11.96484 l 68.0253,68 -68.041,68.02539 a 7.1185227,7.05764 74.556475 1 0 9.9766,10.11524 l 68.1074,-68.09961 68.1094,68.08594 a 7.1179396,7.0570619 74.556475 1 0 9.9141,-10.0879 l -68.0196,-68 68.0352,-68.02539 a 7.1178267,7.05695 74.556475 0 0 -6.9844,-11.93359 v -0.004 a 7.1178267,7.05695 74.556475 0 0 -2.9707,1.81641 l -68.121,68.10547 -68.0918,-68.07031 a 7.1178267,7.05695 74.556475 0 0 -4.875,-2.15235 z"
@@ -5147,7 +5228,7 @@
     </g>
     <g
        id="g8459"
-       inkscape:label="Icon Search 2">
+       inkscape:label="search_binoculars">
       <path
          sodipodi:nodetypes="ssssccssssssccssssssccccssssssccssssssssss"
          inkscape:connector-curvature="0"
@@ -5166,7 +5247,7 @@
     </g>
     <g
        transform="matrix(0,1,1,0,3709.8426,-4390.1576)"
-       inkscape:label="Time Accel 1X"
+       inkscape:label="time_accel_1x"
        id="g8463">
       <desc
          id="desc8465">Icon </desc>
@@ -5194,11 +5275,11 @@
          d="m 3174.8032,-2122.441 -196.39,-340.1575 392.78,0 z"
          inkscape:transform-center-y="11.633394"
          transform="matrix(0.20645741,0,0,0.20230807,2405.9556,-1772.0313)"
-         inkscape:transform-center-x="7.7831932e-005" />
+         inkscape:transform-center-x="7.7831932e-05" />
     </g>
     <g
        id="g8475"
-       inkscape:label="Time Accel Stop">
+       inkscape:label="time_accel_stop">
       <rect
          ry="2.6421504"
          rx="3.3254712"
@@ -5220,7 +5301,7 @@
     </g>
     <g
        id="g8491"
-       inkscape:label="Time Accel 10X"
+       inkscape:label="time_accel_10x"
        transform="matrix(0,1,1,0,3936.6143,-4390.1576)">
       <desc
          id="desc8493">Icon </desc>
@@ -5239,7 +5320,7 @@
            transform="matrix(0.73020592,0,0,0.74714779,825.95222,-554.19703)">
           <path
              style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="4.1615217e-005"
+             inkscape:transform-center-x="4.1615217e-05"
              inkscape:transform-center-y="15.972044"
              d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
              id="path8497"
@@ -5249,7 +5330,7 @@
              id="path8503"
              d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
              inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccc" />
@@ -5272,7 +5353,7 @@
     </g>
     <g
        transform="matrix(0,1,1,0,4163.386,-4390.1576)"
-       inkscape:label="Time Accel 100X"
+       inkscape:label="time_accel_100x"
        id="g8539">
       <desc
          id="desc8541">Icon </desc>
@@ -5295,13 +5376,13 @@
              id="path8549"
              d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
              inkscape:transform-center-y="15.972044"
-             inkscape:transform-center-x="4.1615217e-005"
+             inkscape:transform-center-x="4.1615217e-05"
              style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccc"
              inkscape:connector-curvature="0"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              inkscape:transform-center-y="15.971912"
              d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
              id="path8551" />
@@ -5309,7 +5390,7 @@
              id="path8553"
              d="m 3117.0845,-2230.7747 -55.3652,82.2983 -55.9696,-82.2983"
              inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccc" />
@@ -5318,7 +5399,7 @@
     </g>
     <g
        id="g8559"
-       inkscape:label="Time Accel 1000x"
+       inkscape:label="time_accel_1000x"
        transform="matrix(0,1,1,0,4390.1576,-4390.1576)">
       <desc
          id="desc8561">Icon </desc>
@@ -5337,7 +5418,7 @@
            transform="matrix(0.73020592,0,0,0.74714779,825.95222,-554.19703)">
           <path
              style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="4.1615217e-005"
+             inkscape:transform-center-x="4.1615217e-05"
              inkscape:transform-center-y="15.972044"
              d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
              id="path8569"
@@ -5347,7 +5428,7 @@
              id="path8571"
              d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
              inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccc" />
@@ -5355,7 +5436,7 @@
              sodipodi:nodetypes="ccc"
              inkscape:connector-curvature="0"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              inkscape:transform-center-y="15.971912"
              d="m 3117.0845,-2230.7747 -55.3652,82.2983 -55.9696,-82.2983"
              id="path8573" />
@@ -5363,7 +5444,7 @@
              id="path8575"
              d="m 3117.0845,-2190.7747 -55.3652,82.2983 -55.9696,-82.2983"
              inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccc" />
@@ -5372,7 +5453,7 @@
     </g>
     <g
        transform="matrix(0,1,1,0,4616.9293,-4390.1576)"
-       inkscape:label="Time Accel 10 000x"
+       inkscape:label="time_accel_10000x"
        id="g8579">
       <desc
          id="desc8581">Icon </desc>
@@ -5395,13 +5476,13 @@
              id="path8589"
              d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
              inkscape:transform-center-y="15.972044"
-             inkscape:transform-center-x="4.1615217e-005"
+             inkscape:transform-center-x="4.1615217e-05"
              style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccc"
              inkscape:connector-curvature="0"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              inkscape:transform-center-y="15.971912"
              d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
              id="path8591" />
@@ -5409,7 +5490,7 @@
              id="path8593"
              d="m 3117.0845,-2230.7747 -55.3652,82.2983 -55.9696,-82.2983"
              inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccc" />
@@ -5417,7 +5498,7 @@
              sodipodi:nodetypes="ccc"
              inkscape:connector-curvature="0"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              inkscape:transform-center-y="15.971912"
              d="m 3117.0845,-2190.7747 -55.3652,82.2983 -55.9696,-82.2983"
              id="path8595" />
@@ -5425,7 +5506,7 @@
              id="path8597"
              d="m 3117.0845,-2150.7747 -55.3652,82.2983 -55.9696,-82.2983"
              inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccc" />
@@ -5465,40 +5546,68 @@
          style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.08661413;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
     <g
-       id="g8624"
-       inkscape:label="Orbit Map Time FWD 1x"
-       transform="matrix(0,1,1,0,4163.3859,-4163.3859)">
+       transform="matrix(0,1,1,0,4390.1576,-4163.3859)"
+       inkscape:label="Icon Periapsis"
+       id="g8646">
       <desc
-         id="desc8626">Icon </desc>
+         id="desc8648">Icon </desc>
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect8650"
+         width="226.77165"
+         height="226.77165"
+         x="2948.0315"
+         y="-2349.2126" />
+    </g>
+    <g
+       id="g8652"
+       inkscape:label="time_forward_100x"
+       transform="matrix(0,1,1,0,4616.9293,-4163.3859)">
+      <desc
+         id="desc8654">Icon </desc>
       <rect
          y="-2349.2126"
          x="2948.0315"
          height="226.77165"
          width="226.77165"
-         id="rect8628"
+         id="rect8656"
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         inkscape:transform-center-x="7.7831932e-005"
-         transform="matrix(0.20645741,0,0,0.20230807,2405.9556,-1772.0313)"
-         inkscape:transform-center-y="11.633394"
-         d="m 3174.8032,-2122.441 -196.39,-340.1575 392.78,0 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="2.6179939"
-         sodipodi:arg1="1.5707963"
-         sodipodi:r2="113.38583"
-         sodipodi:r1="226.77165"
-         sodipodi:cy="-2349.2126"
-         sodipodi:cx="3174.8032"
-         sodipodi:sides="3"
-         id="path8630"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:69.35007477;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         sodipodi:type="star" />
+      <g
+         id="g8658"
+         transform="translate(0,-14.158221)">
+        <g
+           id="g8660"
+           transform="matrix(0.73020592,0,0,0.74714779,825.95222,-554.19703)">
+          <path
+             style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:transform-center-x="4.1615217e-05"
+             inkscape:transform-center-y="15.972044"
+             d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
+             id="path8662"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccc" />
+          <path
+             id="path8664"
+             d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
+             inkscape:transform-center-y="15.971912"
+             inkscape:transform-center-x="2.0343216e-05"
+             style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccc" />
+          <path
+             sodipodi:nodetypes="ccc"
+             inkscape:connector-curvature="0"
+             style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             inkscape:transform-center-x="2.0343216e-05"
+             inkscape:transform-center-y="15.971912"
+             d="m 3117.0845,-2230.7747 -55.3652,82.2983 -55.9696,-82.2983"
+             id="path8666" />
+        </g>
+      </g>
     </g>
     <g
        transform="matrix(0,1,1,0,4390.1576,-4163.3859)"
-       inkscape:label="Orbit Map Time FWD 10x"
+       inkscape:label="time_forward_10x"
        id="g8632">
       <desc
          id="desc8634">Icon </desc>
@@ -5521,13 +5630,13 @@
              id="path8642"
              d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
              inkscape:transform-center-y="15.972044"
-             inkscape:transform-center-x="4.1615217e-005"
+             inkscape:transform-center-x="4.1615217e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccc"
              inkscape:connector-curvature="0"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              inkscape:transform-center-y="15.971912"
              d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
              id="path8644" />
@@ -5535,69 +5644,41 @@
       </g>
     </g>
     <g
-       transform="matrix(0,1,1,0,4390.1576,-4163.3859)"
-       inkscape:label="Icon Periapsis"
-       id="g8646">
+       id="g8624"
+       inkscape:label="time_forward_1x"
+       transform="matrix(0,1,1,0,4163.3859,-4163.3859)">
       <desc
-         id="desc8648">Icon </desc>
-      <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect8650"
-         width="226.77165"
-         height="226.77165"
-         x="2948.0315"
-         y="-2349.2126" />
-    </g>
-    <g
-       id="g8652"
-       inkscape:label="Orbit Map Time FWD 100x"
-       transform="matrix(0,1,1,0,4616.9293,-4163.3859)">
-      <desc
-         id="desc8654">Icon </desc>
+         id="desc8626">Icon </desc>
       <rect
          y="-2349.2126"
          x="2948.0315"
          height="226.77165"
          width="226.77165"
-         id="rect8656"
+         id="rect8628"
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <g
-         id="g8658"
-         transform="translate(0,-14.158221)">
-        <g
-           id="g8660"
-           transform="matrix(0.73020592,0,0,0.74714779,825.95222,-554.19703)">
-          <path
-             style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="4.1615217e-005"
-             inkscape:transform-center-y="15.972044"
-             d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
-             id="path8662"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccc" />
-          <path
-             id="path8664"
-             d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
-             inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccc" />
-          <path
-             sodipodi:nodetypes="ccc"
-             inkscape:connector-curvature="0"
-             style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="2.0343216e-005"
-             inkscape:transform-center-y="15.971912"
-             d="m 3117.0845,-2230.7747 -55.3652,82.2983 -55.9696,-82.2983"
-             id="path8666" />
-        </g>
-      </g>
+      <path
+         inkscape:transform-center-x="7.7831932e-05"
+         transform="matrix(0.20645741,0,0,0.20230807,2405.9556,-1772.0313)"
+         inkscape:transform-center-y="11.633394"
+         d="m 3174.8032,-2122.441 -196.39,-340.1575 392.78,0 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0"
+         inkscape:flatsided="true"
+         sodipodi:arg2="2.6179939"
+         sodipodi:arg1="1.5707963"
+         sodipodi:r2="113.38583"
+         sodipodi:r1="226.77165"
+         sodipodi:cy="-2349.2126"
+         sodipodi:cx="3174.8032"
+         sodipodi:sides="3"
+         id="path8630"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:69.35007477;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         sodipodi:type="star" />
     </g>
     <g
        id="g8712"
        transform="translate(680.31496,226.77165)"
-       inkscape:label="Orbit Map Time Center">
+       inkscape:label="time_center">
       <rect
          style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect8714"
@@ -5619,7 +5700,7 @@
     </g>
     <g
        transform="rotate(90,1700.7875,-2462.5984)"
-       inkscape:label="Orbit Map Time BWD 1x"
+       inkscape:label="time_backward_1x"
        id="g8718">
       <desc
          id="desc8720">Icon </desc>
@@ -5647,11 +5728,11 @@
          d="m 3174.8032,-2122.441 -196.39,-340.1575 392.78,0 z"
          inkscape:transform-center-y="11.633394"
          transform="matrix(0.20645741,0,0,0.20230807,2405.9556,-1772.0313)"
-         inkscape:transform-center-x="7.7831932e-005" />
+         inkscape:transform-center-x="7.7831932e-05" />
     </g>
     <g
        id="g8726"
-       inkscape:label="Orbit Map Time BWD 10x"
+       inkscape:label="time_backward_10x"
        transform="rotate(90,1587.4016,-2575.9843)">
       <desc
          id="desc8728">Icon </desc>
@@ -5670,7 +5751,7 @@
            transform="matrix(0.73020592,0,0,0.74714779,825.95222,-554.19703)">
           <path
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="4.1615217e-005"
+             inkscape:transform-center-x="4.1615217e-05"
              inkscape:transform-center-y="15.972044"
              d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
              id="path8736"
@@ -5680,7 +5761,7 @@
              id="path8738"
              d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
              inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccc" />
@@ -5689,7 +5770,7 @@
     </g>
     <g
        transform="rotate(90,1474.0158,-2689.3702)"
-       inkscape:label="Orbit Map Time BWD 100X"
+       inkscape:label="time_backward_100x"
        id="g8740">
       <desc
          id="desc8742">Icon </desc>
@@ -5712,13 +5793,13 @@
              id="path8750"
              d="m 3061.7194,-2233.4641 -55.9695,-81.6243 h 111.3347 z"
              inkscape:transform-center-y="15.972044"
-             inkscape:transform-center-x="4.1615217e-005"
+             inkscape:transform-center-x="4.1615217e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccc"
              inkscape:connector-curvature="0"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              inkscape:transform-center-y="15.971912"
              d="m 3117.0845,-2270.7747 -55.3652,82.2983 -55.9696,-82.2983"
              id="path8752" />
@@ -5726,7 +5807,7 @@
              id="path8754"
              d="m 3117.0845,-2230.7747 -55.3652,82.2983 -55.9696,-82.2983"
              inkscape:transform-center-y="15.971912"
-             inkscape:transform-center-x="2.0343216e-005"
+             inkscape:transform-center-x="2.0343216e-05"
              style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:19.18858147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccc" />
@@ -5735,7 +5816,7 @@
     </g>
     <g
        id="g8762"
-       inkscape:label="Icon Alert !">
+       inkscape:label="warning_1">
       <text
          id="text8756"
          y="-775.98425"
@@ -5762,7 +5843,7 @@
        inkscape:transform-center-x="274"
        inkscape:transform-center-y="5.0000212"
        transform="translate(226.77167,7.3345157e-6)"
-       inkscape:label="Icon Alert !!">
+       inkscape:label="warning_2">
       <rect
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect8773"
@@ -5804,7 +5885,7 @@
        inkscape:transform-center-y="5.0000212"
        inkscape:transform-center-x="274"
        id="g8783"
-       inkscape:label="Icon Alert !!!">
+       inkscape:label="warning_3">
       <text
          id="text8785"
          y="-775.98425"
@@ -5854,7 +5935,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\assassin.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Assasination">
+       inkscape:label="bbs_assassination">
       <rect
          y="0"
          x="0"
@@ -5886,7 +5967,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\donate.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Donate">
+       inkscape:label="bbs_donate">
       <rect
          style="display:inline;fill:none;stroke:none"
          id="rect4259"
@@ -5904,7 +5985,8 @@
            id="tspan3819-2"
            x="5.6586308"
            y="24.975393"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:29.29339409px;line-height:125%;font-family:Orbiteer;-inkscape-font-specification:'Orbiteer Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1">$</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:29.29339409px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+           transform="matrix(0.99887394,0,0,1.0179904,0.00749349,-0.50043764)">$</tspan></text>
     </g>
     <g
        transform="matrix(7.0866142,0,0,7.0866142,2494.4882,-81.496107)"
@@ -5912,7 +5994,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\delivery.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Courier">
+       inkscape:label="bbs_courier">
       <g
          style="display:inline"
          id="g4077-5"
@@ -5947,7 +6029,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\delivery_urgent.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Courier Urgent">
+       inkscape:label="bbs_courier_urgent">
       <g
          transform="matrix(1.28347,0,-0.60466005,1.1622288,-955.35929,-255.33605)"
          id="g4442"
@@ -6008,7 +6090,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\fuel_club.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Fuel club">
+       inkscape:label="bbs_fuel_club">
       <path
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.75653839;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="m 21.097656,6.3066406 c -0.245475,5.2868994 2.445407,9.7824644 4.314453,13.0312504 0.934523,1.624393 1.648425,3.001059 1.783203,3.664062 0.06739,0.331502 0.01952,0.380187 0.02148,0.376953 0.002,-0.0032 -0.05909,0.114498 -0.523438,0.251953 -0.754918,0.223472 -1.127552,0.116222 -1.609375,-0.183593 -0.481822,-0.299815 -1.013138,-0.894752 -1.52539,-1.621094 -0.512252,-0.726342 -0.998083,-1.557069 -1.585938,-2.300781 -0.587855,-0.743712 -1.400599,-1.585938 -2.666015,-1.585938 a 1.378407,1.378407 0 0 0 -0.07617,0.002 l -0.837891,0.04687 0.152344,2.751953 0.763672,-0.04297 c -0.09763,1.84e-4 0.09661,0.02429 0.501953,0.537109 0.40687,0.514743 0.900915,1.33576 1.496094,2.179687 0.595179,0.843928 1.29882,1.737421 2.320312,2.373047 1.021493,0.635627 2.420199,0.908885 3.847656,0.486329 0.865369,-0.256167 1.645106,-0.714885 2.09961,-1.464844 0.454503,-0.749959 0.472414,-1.61686 0.322265,-2.355469 -0.300296,-1.477219 -1.155393,-2.859178 -2.09375,-4.490234 -1.876709,-3.262153 -4.150843,-7.268986 -3.953122,-11.5273841 z"
@@ -6037,7 +6119,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\trader.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Black Market">
+       inkscape:label="bbs_black_market">
       <rect
          y="0"
          x="0"
@@ -6077,7 +6159,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\taxi.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Travel">
+       inkscape:label="bbs_travel">
       <rect
          y="0"
          x="0"
@@ -6098,7 +6180,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\taxi_urgent.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Travel Urgent">
+       inkscape:label="bbs_travel_urgent">
       <rect
          style="display:inline;fill:none;stroke:none"
          id="rect4755"
@@ -6119,7 +6201,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\servicing.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Mechanic">
+       inkscape:label="bbs_mechanic">
       <rect
          style="display:inline;fill:none;stroke:none"
          id="rect3401"
@@ -6139,7 +6221,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\news.png"
        transform="matrix(7.0866142,0,0,7.0866142,1133.8583,-81.496099)"
        id="g3894"
-       inkscape:label="Icon BBS News">
+       inkscape:label="bbs_news">
       <rect
          style="fill:none;stroke:none"
          id="rect3108"
@@ -6160,7 +6242,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\default.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Default">
+       inkscape:label="bbs_default">
       <rect
          style="fill:none;stroke:none"
          id="rect3111"
@@ -6179,7 +6261,7 @@
     <g
        id="g4372"
        transform="matrix(7.0866142,0,0,7.0866142,0,145.27555)"
-       inkscape:label="Icon BBS Used Part">
+       inkscape:label="bbs_used_part">
       <rect
          style="display:inline;fill:none;stroke:none"
          id="rect3116"
@@ -6200,7 +6282,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\secondhand.png"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90"
-       inkscape:label="Icon BBS Survey">
+       inkscape:label="view_flyby">
       <rect
          y="0"
          x="0"
@@ -6265,7 +6347,7 @@
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\small\haul.png"
        id="g4389"
        transform="matrix(7.0866142,0,0,7.0866142,2040.9449,-81.496099)"
-       inkscape:label="Icon BBS Cargo Lift">
+       inkscape:label="bbs_delivery">
       <g
          id="g4391"
          inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\delivery.png"
@@ -6297,7 +6379,7 @@
        id="g4404-4"
        transform="matrix(5.3442386,0,0,5.3442386,126.44744,-139.92244)"
        style="fill:#ffffff"
-       inkscape:label="Icon BBS SAR">
+       inkscape:label="bbs_sar">
       <g
          id="g9311">
         <path
@@ -6317,15 +6399,12 @@
       </g>
     </g>
     <g
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:22.88194466px;line-height:125%;font-family:Orbiteer;-inkscape-font-specification:'Orbiteer, Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;opacity:1;fill:#0c1d34;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6;stroke-opacity:1"
-       id="text4440" />
-    <g
        inkscape:export-ydpi="45"
        inkscape:export-xdpi="45"
        inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\small\haul.png"
        id="g4521"
        transform="matrix(7.0866142,0,0,7.0866142,2267.7166,-81.496094)"
-       inkscape:label="Icon BBS Cargo Lift Urgent">
+       inkscape:label="bbs_deliver_urgent">
       <g
          id="g4523"
          inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\delivery.png"
@@ -6382,7 +6461,7 @@
       </g>
     </g>
     <g
-       inkscape:label="Icon BBS Personal"
+       inkscape:label="bbs_personal"
        transform="translate(-907.05119,2494.4349)"
        id="g9315">
       <rect
@@ -6400,7 +6479,7 @@
          id="path9319" />
     </g>
     <g
-       inkscape:label="Icon Pressure"
+       inkscape:label="pressure"
        transform="translate(3401.2597,-226.77178)"
        id="g9321">
       <g
@@ -6495,7 +6574,7 @@
       </g>
     </g>
     <g
-       inkscape:label="Filter Stations"
+       inkscape:label="filter_stations"
        transform="translate(3401.5748,3628.3463)"
        id="g9487">
       <g
@@ -6528,7 +6607,7 @@
     <g
        id="g9530"
        transform="translate(-460.63,233.85814)"
-       inkscape:label="Filter Bodies">
+       inkscape:label="filter_bodies">
       <g
          id="g9536"
          transform="matrix(1.1666702,0,0,1.1666702,-532.68863,146.91256)">
@@ -6560,7 +6639,7 @@
     <g
        id="g9573"
        transform="translate(-3855.1183,907.08665)"
-       inkscape:label="Icon Ship Hull">
+       inkscape:label="hull">
       <path
          id="path9575"
          d="m 6916.5818,-2155.6412 c -25.1464,0 -56.1301,-1.9661 -77.2368,-9.3195 -4.0465,-1.4594 -6.9617,-5.3879 -6.9617,-9.9347 v 0 -0.785 c 1.7964,-49.3967 11.0004,-93.5746 15.2098,-97.8967 9.7671,-13.0227 40.0245,-34.4645 57.0889,-45.242 4.2094,-2.6943 7.8031,-3.2002 11.8442,-3.3124 4.041,0.1127 7.6269,0.7865 11.8363,3.3124 17.4065,10.2723 48.0563,32.2193 57.7678,45.242 4.2665,4.3221 12.7926,48.5 14.5944,97.8967 l 0.053,0.785 c 0,4.5468 -2.9167,8.4753 -6.9591,9.9347 -21.161,7.3534 -52.1419,9.3195 -77.2394,9.3195 z m -14.2193,-107.933 h 28.3464 v -28.9456 h -28.3464 z"
@@ -6576,7 +6655,7 @@
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:21.25984192;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5151515" />
     </g>
     <g
-       inkscape:label="Filter Ships"
+       inkscape:label="filter_ships"
        transform="translate(1587.4017,1133.8582)"
        id="g9547">
       <g
@@ -6645,7 +6724,8 @@
     </g>
     <g
        id="g6536"
-       transform="translate(5.270184,-5.2000669)">
+       transform="translate(5.270184,-5.2000669)"
+       inkscape:label="shield">
       <g
          id="g9559"
          transform="translate(-4081.89,907.08663)"
@@ -6681,7 +6761,7 @@
     </g>
     <g
        id="g9595"
-       inkscape:label="Icon Temperature">
+       inkscape:label="temperature">
       <g
          id="g9600"
          transform="matrix(1.2194626,0,0,1.2051872,-726.63459,244.0992)">
@@ -6765,7 +6845,7 @@
            sodipodi:role="line">!</tspan></text>
     </g>
     <g
-       inkscape:label="Maneuver node marker"
+       inkscape:label="bullseye"
        transform="translate(-8163.7798,-226.7716)"
        id="g5359">
       <path
@@ -6783,7 +6863,7 @@
          y="-2349.2126" />
     </g>
     <g
-       inkscape:label="Crosshair AFT"
+       inkscape:label="forward"
        transform="translate(-8163.7795,-226.77163)"
        id="g5365">
       <rect
@@ -6817,7 +6897,7 @@
     <g
        id="g5391"
        transform="translate(-7937.0082,-226.77163)"
-       inkscape:label="Crosshair AFT">
+       inkscape:label="backward">
       <rect
          y="-2349.2126"
          x="9977.9531"
@@ -6847,7 +6927,7 @@
          style="opacity:1;fill:#535b4f;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
     <g
-       inkscape:label="Crosshair AFT"
+       inkscape:label="down"
        transform="translate(-7710.2365,-226.77163)"
        id="g5403">
       <rect
@@ -6867,7 +6947,7 @@
     <g
        id="g5420"
        transform="rotate(-90,6236.2207,1392.5198)"
-       inkscape:label="Crosshair AFT">
+       inkscape:label="right">
       <rect
          y="-2349.2126"
          x="9977.9531"
@@ -6883,7 +6963,7 @@
          id="path5424" />
     </g>
     <g
-       inkscape:label="Crosshair AFT"
+       inkscape:label="up"
        transform="rotate(180,6462.9925,-2349.2127)"
        id="g5426">
       <rect
@@ -6903,7 +6983,7 @@
     <g
        id="g5432"
        transform="rotate(90,6689.7641,-5864.1729)"
-       inkscape:label="Crosshair AFT">
+       inkscape:label="left">
       <rect
          y="-2349.2126"
          x="9977.9531"
@@ -6919,31 +6999,13 @@
          id="path5436" />
     </g>
     <g
-       inkscape:label="Crosshair AFT"
-       transform="translate(-9751.1814,-226.77163)"
-       id="g5438">
-      <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect5440"
-         width="226.77165"
-         height="226.77165"
-         x="9977.9531"
-         y="-2349.2126" />
-      <path
-         id="path5448"
-         style="opacity:1;fill:#535b4f;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 10155.056,-2299.5445 -63.718,63.7173 -63.717,63.7181 m 127.436,-3e-4 -63.718,-63.7178 -63.718,-63.7177"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccc" />
-    </g>
-    <g
-       inkscape:label="Prograde marker"
+       inkscape:label="square"
        transform="translate(-7483.4639,-226.77163)"
        id="g5451">
       <path
          id="path5453"
          style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:16.94761276;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 11071.13,-2193.6857 v 38.2828 l -38.282,-10e-5 m -76.565,-3e-4 -38.283,-1e-4 v -38.2829 m 0,-76.5656 v -38.2829 l 38.283,2e-4 m 76.565,3e-4 38.282,10e-5 v 38.2827"
+         d="m 11074.99,-2197.5437 v 38.2828 l -38.282,-10e-5 m -76.565,-3e-4 -38.283,-10e-5 v -38.2829 m 0,-76.5656 v -38.2829 l 38.283,2e-4 m 76.565,3e-4 38.282,1e-4 v 38.2827"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccccccccccc" />
       <rect
@@ -6955,7 +7017,7 @@
          y="-2349.2126" />
     </g>
     <g
-       inkscape:label="Icon Frame"
+       inkscape:label="display_frame"
        transform="translate(1133.8583,1360.6299)"
        id="g5461">
       <path
@@ -6972,7 +7034,7 @@
          y="-2349.2126" />
     </g>
     <g
-       inkscape:label="Icon Shiptarget"
+       inkscape:label="display_combattarget"
        transform="translate(453.5434,1360.6299)"
        id="g5467">
       <g
@@ -7040,41 +7102,9 @@
          y="-2349.2126" />
     </g>
     <g
-       id="g5479"
-       transform="translate(-7937.0082,1360.6299)"
-       inkscape:label="Icon NavTarget">
-      <rect
-         y="-2349.2126"
-         x="9977.9531"
-         height="226.77165"
-         width="226.77165"
-         id="rect5481"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5483"
-         d="m 10091.339,-2255.0712 v -70.8661"
-         style="opacity:1;fill:#535b4f;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         style="opacity:1;fill:#535b4f;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 10091.339,-2145.7163 v -70.8661"
-         id="path5485"
-         inkscape:connector-curvature="0" />
-      <path
-         style="opacity:1;fill:#535b4f;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="m 10072.095,-2235.8268 h -70.867"
-         id="path5487"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path5489"
-         d="m 10181.449,-2235.8268 h -70.866"
-         style="opacity:1;fill:#535b4f;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    </g>
-    <g
        id="g7055"
        transform="translate(-10658.267,226.77167)"
-       inkscape:label="Icon Medium Fighter">
+       inkscape:label="medium_fighter">
       <path
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
@@ -7092,7 +7122,7 @@
     <g
        id="g7071"
        transform="translate(-10431.496,226.77167)"
-       inkscape:label="Icon Light Fighter">
+       inkscape:label="light_fighter">
       <rect
          y="-2349.2126"
          x="10885.039"
@@ -7108,7 +7138,7 @@
          sodipodi:nodetypes="ccccc" />
     </g>
     <g
-       inkscape:label="Prograde marker"
+       inkscape:label="medium_courier"
        transform="translate(-10658.267,453.54332)"
        id="g7077">
       <title
@@ -7145,7 +7175,7 @@
     <g
        id="g7197"
        transform="translate(-10423.135,474.26356)"
-       inkscape:label="Prograde marker">
+       inkscape:label="light_courier">
       <title
          id="title7338">Icon Light courier</title>
       <rect
@@ -7173,7 +7203,7 @@
       </g>
     </g>
     <g
-       inkscape:label="Prograde marker"
+       inkscape:label="medium_passenger_shuttle"
        transform="matrix(1,0,0,-1,-10658.267,-3791.3387)"
        id="g7203">
       <title
@@ -7195,7 +7225,7 @@
     <g
        id="g7209"
        transform="matrix(1,0,0,-1,-10431.495,-3791.3387)"
-       inkscape:label="Prograde marker">
+       inkscape:label="light_passenger_shuttle">
       <title
          id="title7348">Icon Light Passegner Shuttle</title>
       <path
@@ -7213,7 +7243,7 @@
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
     <g
-       inkscape:label="Icon Heavy fighter"
+       inkscape:label="heavy_fighter"
        transform="translate(-10885.039,226.77167)"
        id="g7222">
       <path
@@ -7233,7 +7263,7 @@
     <g
        id="g7235"
        transform="translate(-10885.039,453.54332)"
-       inkscape:label="Prograde marker">
+       inkscape:label="heavy_courier">
       <title
          id="title7342">Icon Heavy Courier</title>
       <rect
@@ -7268,7 +7298,7 @@
     <g
        id="g7241"
        transform="matrix(1,0,0,-1,-10885.039,-3791.3387)"
-       inkscape:label="Prograde marker">
+       inkscape:label="heavy_passenger_shuttle">
       <title
          id="title7344">Icon Heavy Passegner Shuttle</title>
       <path
@@ -7287,7 +7317,8 @@
     </g>
     <g
        id="g7251"
-       style="fill:none">
+       style="fill:none"
+       inkscape:label="medium_passenger_transport">
       <title
          id="title7352">Icon Medium Passegner Transport</title>
       <path
@@ -7307,7 +7338,8 @@
     </g>
     <g
        id="g7257"
-       transform="translate(-226.77166)">
+       transform="translate(-226.77166)"
+       inkscape:label="heavy_passenger_transport">
       <title
          id="title7350">Icon Heavy Passegner Transport</title>
       <path
@@ -7327,7 +7359,8 @@
     </g>
     <g
        id="g7263"
-       transform="translate(226.77166)">
+       transform="translate(226.77166)"
+       inkscape:label="light_passenger_transport">
       <title
          id="title7354">Icon Light Passegner Transport</title>
       <path
@@ -7347,7 +7380,8 @@
     <g
        style="fill:none"
        id="g7287"
-       transform="matrix(1,0,0,-1,0,-2430.7087)">
+       transform="matrix(1,0,0,-1,0,-2430.7087)"
+       inkscape:label="medium_cargo_shuttle">
       <title
          id="title7358">Icon Medium Cargo Shuttle</title>
       <path
@@ -7373,7 +7407,8 @@
     </g>
     <g
        transform="matrix(1,0,0,-1,226.77166,-2430.7087)"
-       id="g7299">
+       id="g7299"
+       inkscape:label="light_cargo_shuttle">
       <title
          id="title7360">Icon Light Cargo Shuttle</title>
       <path
@@ -7399,7 +7434,8 @@
     <g
        transform="matrix(1,0,0,-1,-226.77166,-2430.7087)"
        id="g7309"
-       style="fill:none">
+       style="fill:none"
+       inkscape:label="heavy_cargo_shuttle">
       <title
          id="title7356">Icon Heavy Cargo Shuttle</title>
       <path
@@ -7426,7 +7462,8 @@
     <g
        transform="rotate(90,113.38589,-1101.9686)"
        id="g7320"
-       style="fill:none">
+       style="fill:none"
+       inkscape:label="medium_freighter">
       <title
          id="title7364">Icon Medium Cargo Transport</title>
       <path
@@ -7452,7 +7489,8 @@
     </g>
     <g
        id="g7328"
-       transform="rotate(90,226.77172,-988.58272)">
+       transform="rotate(90,226.77172,-988.58272)"
+       inkscape:label="light_freighter">
       <title
          id="title7366">Icon Light Cargo Transport</title>
       <path
@@ -7478,7 +7516,8 @@
     <g
        style="fill:none"
        id="g7336"
-       transform="rotate(90,5.6220703e-5,-1215.3544)">
+       transform="rotate(90,5.6220703e-5,-1215.3544)"
+       inkscape:label="heavy_freighter">
       <title
          id="title7362">Icon Heavy Cargo Transport</title>
       <path
@@ -7503,30 +7542,10 @@
          transform="rotate(90)" />
     </g>
     <g
-       aria-label="!"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:137.89128113px;line-height:1000%;font-family:TitilliumText25L;-inkscape-font-specification:'TitilliumText25L Heavy';text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:middle;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000100;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:47.27700806;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       id="text5750"
-       transform="translate(1.1828859,-5.3229862)">
-      <path
-         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:TitilliumText25L;-inkscape-font-specification:'TitilliumText25L Heavy';fill:#ffffff;fill-opacity:1;stroke-width:50.42881012"
-         d="m 2476.4121,1747.5645 c -10.5056,0 -17.0696,11.3742 -11.8183,20.4726 l 63.4296,109.8613 c 5.2534,9.0976 18.3834,9.0976 23.6368,0 l 63.4296,-109.8613 c 5.2512,-9.0984 -1.3147,-20.4707 -11.8203,-20.4726 z m 52.6563,10.746 h 21.7675 l -0.7343,64.7168 h -20.2989 z m 0.2929,78.543 h 21.1817 v 24.416 h -21.1817 z"
-         transform="matrix(0.93749997,0,0,0.93749997,0,-2575.9843)"
-         id="path5814"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
-       aria-label="!!"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:137.89128113px;line-height:1000%;font-family:TitilliumText25L;-inkscape-font-specification:'TitilliumText25L Heavy';text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:middle;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000100;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:47.27700806;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       id="text5750-7-0" />
-    <g
-       id="g5899"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:137.89128113px;line-height:1000%;font-family:TitilliumText25L;-inkscape-font-specification:'TitilliumText25L Heavy';text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:middle;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000100;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:47.27700806;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       aria-label="!!"
-       transform="translate(-4.4438728e-6)" />
-    <g
        style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41420996"
        transform="matrix(6.3480639,0,0,6.3480639,-128.29266,-2822.2578)"
-       id="Guided">
+       id="Guided"
+       inkscape:label="missile_guided">
       <g
          id="g4"
          transform="matrix(0,0.40132,-0.654163,0,429.087,464.219)">
@@ -7593,7 +7612,8 @@
     <g
        style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41420996"
        transform="matrix(6.3480639,0,0,6.3480639,762.40151,-3630.6774)"
-       id="Naval">
+       id="Naval"
+       inkscape:label="missile_naval">
       <g
          id="g31"
          transform="matrix(0,0.40132,-0.654163,0,431.302,591.568)">
@@ -7653,7 +7673,8 @@
     <g
        style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41420996"
        transform="matrix(6.3480639,0,0,6.3480639,-580.60668,-2504.4102)"
-       id="Dumb">
+       id="Dumb"
+       inkscape:label="missile_unguided">
       <g
          id="g54"
          transform="matrix(0,0.40132,-0.654163,0,429.412,414.149)">
@@ -7691,7 +7712,8 @@
     <g
        style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41420996"
        transform="matrix(6.3480639,0,0,6.3480639,312.20185,-3249.5967)"
-       id="Smart">
+       id="Smart"
+       inkscape:label="missile_smart">
       <g
          id="g69"
          transform="matrix(0,0.40132,-0.654163,0,431.302,531.537)">
@@ -7766,57 +7788,9 @@
       </g>
     </g>
     <g
-       inkscape:label="Function ECM"
-       transform="matrix(0.69224437,0,0,0.69224437,4606.1575,161.7549)"
-       id="g5786">
-      <path
-         d="m -2595.9564,-1580.3482 16.6193,-63.7334 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.9469,107.5732 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.0446 l -16.6141,63.7334 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.9426,-107.5731 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z"
-         id="path5782"
-         inkscape:connector-curvature="0"
-         style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd" />
-      <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect5784"
-         width="226.77151"
-         height="226.7717"
-         x="-2721.2598"
-         y="-1668.8977" />
-    </g>
-    <g
-       id="g5792"
-       transform="matrix(0.69224437,0,0,0.69224437,4662.3446,226.81362)"
-       inkscape:label="Function ECM">
-      <path
-         style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd"
-         inkscape:connector-curvature="0"
-         id="path5788"
-         d="m -2595.9564,-1580.3482 16.6193,-63.7334 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.9469,107.5732 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.0446 l -16.6141,63.7334 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.9426,-107.5731 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z" />
-      <rect
-         y="-1668.8977"
-         x="-2721.2598"
-         height="226.7717"
-         width="226.77151"
-         id="rect5790"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
-    </g>
-    <path
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.58464569;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 2990.3484,-953.61135 c -9.815,0 -17.7155,7.90237 -17.7155,17.71734 v 120.70678 c 0,9.81497 7.9005,17.71725 17.7155,17.71725 h 142.0001 c 9.815,0 17.7173,-7.90228 17.7173,-17.71725 v -120.70678 c 0,-9.81497 -7.9023,-17.71734 -17.7173,-17.71734 z m 7.7893,17.95537 h 1.0712 c 3.9259,0 7.0862,3.16022 7.0862,7.08619 v 106.05834 c 0,3.92597 -3.1603,7.08619 -7.0862,7.08619 h -1.0712 c -3.926,0 -7.0862,-3.16022 -7.0862,-7.08619 v -106.05834 c 0,-3.92597 3.1602,-7.08619 7.0862,-7.08619 z m 25.7336,0 h 1.0712 c 3.9261,0 7.0881,3.16022 7.0881,7.08619 v 106.05834 c 0,3.92597 -3.162,7.08619 -7.0881,7.08619 h -1.0712 c -3.9259,0 -7.0862,-3.16022 -7.0862,-7.08619 v -106.05834 c 0,-3.92597 3.1603,-7.08619 7.0862,-7.08619 z m 24.8987,0 h 1.0712 c 3.9259,0 7.0862,3.16022 7.0862,7.08619 v 106.05834 c 0,3.92597 -3.1603,7.08619 -7.0862,7.08619 h -1.0712 c -3.926,0 -7.088,-3.16022 -7.088,-7.08619 v -106.05834 c 0,-3.92597 3.162,-7.08619 7.088,-7.08619 z m 36.5021,13.71825 a 10.940943,10.940943 0 0 1 10.9405,10.94053 10.940943,10.940943 0 0 1 -10.9405,10.94053 10.940943,10.940943 0 0 1 -10.9424,-10.94053 10.940943,10.940943 0 0 1 10.9424,-10.94053 z m 28.894,0 a 10.940943,10.940943 0 0 1 10.9406,10.94053 10.940943,10.940943 0 0 1 -10.9406,10.94053 10.940943,10.940943 0 0 1 -10.9405,-10.94053 10.940943,10.940943 0 0 1 10.9405,-10.94053 z m -28.894,35.45653 a 10.940943,10.940943 0 0 1 10.9405,10.94053 10.940943,10.940943 0 0 1 -10.9405,10.94063 10.940943,10.940943 0 0 1 -10.9424,-10.94063 10.940943,10.940943 0 0 1 10.9424,-10.94053 z m 28.894,0 a 10.940943,10.940943 0 0 1 10.9406,10.94053 10.940943,10.940943 0 0 1 -10.9406,10.94063 10.940943,10.940943 0 0 1 -10.9405,-10.94063 10.940943,10.940943 0 0 1 10.9405,-10.94053 z m -28.894,35.45653 a 10.940943,10.940943 0 0 1 10.9405,10.94063 10.940943,10.940943 0 0 1 -10.9405,10.94053 10.940943,10.940943 0 0 1 -10.9424,-10.94053 10.940943,10.940943 0 0 1 10.9424,-10.94063 z m 28.894,0 a 10.940943,10.940943 0 0 1 10.9406,10.94063 10.940943,10.940943 0 0 1 -10.9406,10.94053 10.940943,10.940943 0 0 1 -10.9405,-10.94053 10.940943,10.940943 0 0 1 10.9405,-10.94063 z"
-       id="rect5788"
-       inkscape:connector-curvature="0" />
-    <rect
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.58464569;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect5791"
-       width="7.0973153"
-       height="2.3657718"
-       x="3199.7061"
-       y="-1303.9465"
-       rx="17.716499"
-       ry="2.3657718" />
-    <g
        id="g5539-1"
        transform="matrix(0,1,1,0,5977.5594,-2802.7561)"
-       inkscape:label="Icon SysOverview">
+       inkscape:label="system_overview">
       <path
          inkscape:connector-curvature="0"
          id="path4808-9"
@@ -7832,7 +7806,7 @@
     </g>
     <g
        id="g8294-9"
-       inkscape:label="Icon Periapsis"
+       inkscape:label="filter"
        transform="matrix(-1,0,0,1,6576.3781,1360.6299)">
       <desc
          id="desc8306-8">Icon </desc>
@@ -7846,7 +7820,7 @@
       <path
          transform="matrix(0.46899886,0,0,0.46614372,1572.4382,-1167.1828)"
          style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:30.31258392;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         inkscape:transform-center-x="5.6345812e-005"
+         inkscape:transform-center-x="5.6345812e-05"
          inkscape:transform-center-y="26.427083"
          d="M 3174.8032,-2278.6619 3031.0244,-2459.907 H 3318.582 Z"
          id="path8292-2"
@@ -7866,7 +7840,7 @@
     <g
        id="g7262-3"
        transform="translate(3628.3465,226.77159)"
-       inkscape:label="Autopilot Blastoff">
+       inkscape:label="starport">
       <g
          transform="matrix(6.6110346,0,0,6.6110346,-5987.3396,-10817.643)"
          id="g5806-4"
@@ -7921,7 +7895,7 @@
     <g
        id="g7007-0"
        transform="translate(5215.7481,680.31495)"
-       inkscape:label="Autopilot GOTO 2">
+       inkscape:label="distance">
       <g
          id="g4852-0"
          transform="matrix(-5.8136821,1.5621073,1.5715699,5.8815033,-1649.2994,-10870.805)"
@@ -7962,79 +7936,1083 @@
          id="rect7005-3"
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
-    <path
-       d="m 3044.6817,-406.7666 c -1.2875,-4.2625 -3.0125,-16.8375 -2.6375,-21.225 0.1625,-1.9375 1.15,-6.775 4.25,-4.8125 2.3625,1.4875 3.15,16.2375 4.025,19.7875 2.1625,8.75 14.8125,16.7 6.2625,25.5125 0,0 -7.1125,5.7375 -7.1125,5.7375 -3.0625,2.4375 -4.75,4 -8.75,4.7125 -8.6375,1.55 -10.425,-1.4625 -16.4625,-6.2375 -2.325,-1.85 -5.7875,-3.65 -7.25,-6.2375 -4.0625,-7.15 2.6125,-11.8875 8.7125,-13.4875 1.325,5.9 -0.2125,6.025 -2.5,11.25 7.0125,2.75 9.6875,6.4125 12.5,7.3125 4.375,1.4 12.625,-6.175 17.5,-8.5625 -2.725,-4.8875 -6.875,-8.3 -8.5375,-13.75 z"
-       id="Selection"
-       inkscape:connector-curvature="0"
-       style="fill:none;stroke:#000000;stroke-width:1.25000012" />
-    <path
-       d="m 591.6132,251.76723 c -4.0734,-14.63053 -9.5308,-57.79275 -8.3444,-72.85235 0.514,-6.65024 3.6382,-23.25439 13.4457,-16.51835 7.4744,5.10568 9.9659,55.73333 12.7343,67.9183 6.8414,30.03335 46.8629,57.3208 19.8129,87.56867 l -22.5021,19.69332 c -9.689,8.36641 -15.028,13.72952 -27.6828,16.1751 -20.405,2.35715 -32.9822,-5.01985 -52.0833,-21.40948 -7.3556,-6.34994 -18.3101,-12.52822 -22.937,-21.40949 -12.8527,-24.54154 17.6593,-61.54382 27.5641,-46.29428 7.6528,13.73234 -10.561,27.19879 -7.9094,38.61431 17.2415,14.77254 30.6488,22.01016 39.5467,25.09929 13.8415,4.80534 44.8867,-17.63929 55.3657,-29.38976 -1.6993,-14.40536 -21.7507,-28.4888 -27.0104,-47.19528 z"
-       id="Selection-3"
-       inkscape:connector-curvature="0"
-       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:4.11916065;stroke-opacity:1"
-       sodipodi:nodetypes="cccccccccccccc" />
-    <path
-       id="path2164"
-       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.87598372px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 302.18786,300.98161 -0.15976,26.1597 h -13.37554 c -6.6878,1e-4 -6.6878,13.11229 0,13.1122 h 13.37554 v 13.11221 c -3e-5,6.55618 13.37552,6.55618 13.37556,-1e-5 v -13.1122 h 13.37554 c 6.68774,9e-5 6.68774,-13.1121 -0.079,-13.21296 l -13.29655,0.10076 -0.16905,-26.22791 z m 6.07985,-123.00853 a 66.885475,64.703688 0 0 0 -66.88485,64.70313 66.885475,64.703688 0 0 0 66.88485,64.70475 66.885475,64.703688 0 0 0 66.88485,-64.70475 66.885475,64.703688 0 0 0 -66.88485,-64.70313 z m 0,13.36966 a 53.065353,51.334355 0 0 1 53.06441,51.33347 53.065353,51.334355 0 0 1 -53.06441,51.33518 53.065353,51.334355 0 0 1 -53.06615,-51.33518 53.065353,51.334355 0 0 1 53.06615,-51.33347 z"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 759.9534,221.1225 c 10.26549,2.94511 24.38965,14.14871 34.29111,14.02726 10.84793,-0.1506 23.88001,-11.8412 34.87355,-14.75595 21.65946,-5.70807 42.00843,15.60609 47.32319,30.66566 0,0 -47.32319,-2.6415 -47.32319,-2.6415 0,0 -36.40245,5.49553 -36.40245,5.49553 0,0 -36.40245,-5.55625 -36.40245,-5.55625 0,0 -43.68295,2.70222 -43.68295,2.70222 5.42397,-15.39356 25.37251,-36.25228 47.32319,-29.93697 z m 3.64025,41.41382 c 0,0 36.40245,5.46517 36.40245,5.46517 0,0 29.12196,-5.46517 29.12196,-5.46517 0,0 40.0427,0 40.0427,0 -21.62306,49.2776 -128.42785,49.2776 -149.25006,0 0,0 43.68295,0 43.68295,0 z"
-       id="Selection-36"
-       inkscape:connector-curvature="0"
-       style="fill:#ffffff;stroke:#d2d2d2;stroke-width:3.32453442;stroke-opacity:1;fill-opacity:1" />
-    <path
-       d="m 1079.8665,237.85543 c -5.9897,-14.96047 4.6104,-34.431 -5.2806,-50.60148 -13.0436,-21.30391 -68.2125,-42.90118 -104.03292,-5.72011 -16.59014,17.19712 -5.51692,34.39428 -7.9207,49.06136 -2.87175,21.65648 -25.29905,21.00187 -25.29905,36.66769 42.75611,11.29365 32.62864,-7.99356 93.47227,-7.81021 27.8997,0.10854 17.2206,11.44029 72.0348,11.477 -6.5415,-18.15051 -16.8263,-17.74717 -22.9738,-33.07425 z"
-       id="Selection-7"
-       inkscape:connector-curvature="0"
-       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.80124259;stroke-opacity:1"
-       sodipodi:nodetypes="cccccccc" />
     <g
-       style="display:inline"
-       inkscape:label="Icon BBS Personal"
-       transform="translate(-1360.5928,2721.2065)"
-       id="g9315-6">
+       id="g7810"
+       inkscape:label="hair">
+      <path
+         sodipodi:nodetypes="cccccccc"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.80124259;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         id="Selection-7"
+         d="m 1079.8665,237.85543 c -5.9897,-14.96047 4.6104,-34.431 -5.2806,-50.60148 -13.0436,-21.30391 -68.2125,-42.90118 -104.03292,-5.72011 -16.59014,17.19712 -5.51692,34.39428 -7.9207,49.06136 -2.87175,21.65648 -25.29905,21.00187 -25.29905,36.66769 42.75611,11.29365 32.62864,-7.99356 93.47227,-7.81021 27.8997,0.10854 17.2206,11.44029 72.0348,11.477 -6.5415,-18.15051 -16.8263,-17.74717 -22.9738,-33.07425 z" />
       <rect
          style="opacity:1;fill:none;fill-opacity:0.7020202;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
          id="rect9317-2"
          width="226.76811"
          height="226.76811"
-         x="2267.6812"
-         y="-2575.9275" />
+         x="907.08838"
+         y="145.27901" />
       <path
          sodipodi:nodetypes="ccscssscsccccsscccc"
          inkscape:connector-curvature="0"
-         d="m 2314.9597,-2414.8091 c 10.539,-14.5486 24.1307,-22.0723 47.0986,-24.4906 4.1429,-0.8791 7.2684,-4.76 7.2684,-9.3664 0,-3.3741 -10.2484,-13.4736 -10.1756,-13.5465 -10.5754,-11.5544 -16.2447,-30.3255 -16.2447,-44.7589 0,-22.4177 17.0807,-40.6131 38.1587,-40.6131 21.078,0 38.1586,18.1954 38.1586,40.6131 0,14.5102 -5.5239,33.3964 -16.2083,44.9508 0,0 -10.2119,9.9843 -10.2119,13.3546 0,4.879 3.4887,8.9441 7.9951,9.5199 22.4956,2.4952 35.942,9.9805 46.3721,24.3371 3.0163,4.1458 4.6516,12.4757 4.7607,16.9285 -0.036,1.1516 0,19.1934 0,19.1934 0,8.4833 -6.5054,15.3546 -14.5367,15.3546 h -112.659 c -8.0315,0 -14.5366,-6.8713 -14.5366,-15.3546 0,0 0.036,-18.0418 0,-19.1934 0.109,-4.4528 1.7444,-12.7827 4.7608,-16.9285 z"
+         d="m 954.3669,306.3974 c 10.539,-14.5486 24.1307,-22.0723 47.0986,-24.4906 4.1429,-0.8791 7.2684,-4.76 7.2684,-9.3664 0,-3.3741 -10.2484,-13.4736 -10.1756,-13.5465 -10.5754,-11.5544 -16.2447,-30.3255 -16.2447,-44.7589 0,-22.4177 17.0807,-40.6131 38.1587,-40.6131 21.078,0 38.1586,18.1954 38.1586,40.6131 0,14.5102 -5.5239,33.3964 -16.2083,44.9508 0,0 -10.2119,9.9843 -10.2119,13.3546 0,4.879 3.4887,8.9441 7.9951,9.5199 22.4956,2.4952 35.942,9.9805 46.3721,24.3371 3.0163,4.1458 4.6516,12.4757 4.7607,16.9285 -0.036,1.1516 0,19.1934 0,19.1934 0,8.4833 -6.5054,15.3546 -14.5367,15.3546 h -112.659 c -8.0315,0 -14.5366,-6.8713 -14.5366,-15.3546 0,0 0.036,-18.0418 0,-19.1934 0.109,-4.4528 1.7444,-12.7827 4.7608,-16.9285 z"
          style="opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:none;stroke-width:0.89146978;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.89146977, 1.78293956;stroke-dashoffset:0;stroke-opacity:1"
          id="path9319-9" />
+    </g>
+    <g
+       inkscape:label="systemmap_reset_view"
+       transform="translate(-5896.0633,2721.2598)"
+       id="g1580">
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:21.25984192;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5151515"
+         id="rect1578"
+         width="226.77151"
+         height="226.77162"
+         x="8163.7798"
+         y="-2575.9844" />
       <path
-         style="fill:#ffffff;stroke:#c2c2c2;stroke-width:0.93749994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
-         d="m 2551.144,-2490.8917 v 127.5591 h 113.3857 v -127.5591 l 21.2599,10.6299 21.2599,-53.1496 -56.693,-28.3464 h -14.1732 l -28.3464,28.3464 -28.3465,-28.3464 h -14.1732 l -56.693,28.3464 21.2599,53.1496 21.2599,-10.6299"
-         id="path2236"
+         style="fill:#fffff6;fill-opacity:1;stroke:#ffffee;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Send)"
+         d="m 8277.1656,-2462.5985 87.9272,65.9805"
+         id="path1588"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccc" />
+         sodipodi:nodetypes="cc" />
       <path
-         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#c2c2c2;stroke-width:0.98373342;stroke-opacity:1"
-         d="M 1674.3301 3006.6133 L 1646.4629 3046.6719 A 29.744382 29.74438 0 0 0 1617.6387 3024.1133 A 29.744382 29.74438 0 0 0 1587.959 3051.9688 L 1540.1055 3051.9688 A 29.744382 29.74438 0 0 0 1510.502 3025.0176 A 29.744382 29.74438 0 0 0 1503.8906 3025.791 L 1511.8105 3014.1738 C 1515.5901 3017.9533 1517.4794 3021.7324 1519.3691 3021.7324 C 1521.259 3021.7324 1523.1491 3019.8426 1511.8105 3008.5039 L 1498.5723 3027.5332 A 29.744382 29.74438 0 0 0 1480.7559 3054.7617 A 29.744382 29.74438 0 0 0 1510.502 3084.5078 A 29.744382 29.74438 0 0 0 1540.2109 3055.748 L 1587.9863 3055.748 A 29.744382 29.74438 0 0 0 1617.6387 3083.6035 A 29.744382 29.74438 0 0 0 1647.3828 3053.8574 A 29.744382 29.74438 0 0 0 1647.2871 3051.9473 L 1674.3301 3012.2832 C 1678.1096 3016.0627 1680.0009 3019.8418 1681.8906 3019.8418 C 1683.7804 3019.8418 1685.6686 3017.9519 1674.3301 3006.6133 z M 1617.6387 3027.875 A 25.982358 25.982366 0 0 1 1643.6211 3053.8574 A 25.982358 25.982366 0 0 1 1617.6387 3079.8398 A 25.982358 25.982366 0 0 1 1591.6562 3053.8574 A 25.982358 25.982366 0 0 1 1617.6387 3027.875 z M 1510.502 3028.7793 A 25.982358 25.982366 0 0 1 1536.4844 3054.7617 A 25.982358 25.982366 0 0 1 1510.502 3080.7441 A 25.982358 25.982366 0 0 1 1484.5195 3054.7617 A 25.982358 25.982366 0 0 1 1484.5508 3054.1562 L 1500.4551 3030.8281 A 25.982358 25.982366 0 0 1 1510.502 3028.7793 z M 1492.9062 3035.6797 L 1486.4609 3044.9434 A 25.982358 25.982366 0 0 1 1492.9062 3035.6797 z "
-         transform="matrix(0.93749997,0,0,0.93749997,1360.5928,-5297.1908)"
-         id="path2238-2" />
-      <path
-         id="path2161"
-         d="m 3035.9125,-2506.0745 c -4.4289,7.5649 -9.5225,18.8499 -15.1696,33.8575 -1.6609,-3.7225 -2.9904,-6.6982 -4.0976,-8.9294 -1.1071,-2.358 -2.6568,-4.9603 -4.5399,-7.9383 -1.8812,-2.9757 -3.7642,-5.3314 -5.6473,-6.9448 -3.6529,-3.4713 -9.4112,-6.2005 -15.9434,-6.2005 h -24.8032 c -2.1054,0 -3.5439,-1.6111 -3.5439,-3.9691 v -23.8102 c 0,-2.3556 1.4385,-3.9691 3.5439,-3.9691 h 24.8032 c 18.4913,0 33.5498,9.3028 45.3978,27.9039 z m 123.6847,101.9417 -35.4329,39.6844 c -0.6648,0.7446 -1.5517,1.1158 -2.5478,1.1158 -1.8831,0 -3.5437,-1.8602 -3.5437,-3.9692 v -23.8103 c -2.3238,0 -5.5361,0 -9.4113,0.1246 -3.8755,0 -6.8659,0 -8.9691,0.1246 -2.1032,0 -4.7622,0 -8.0838,-0.1246 -3.3216,-0.1246 -5.9784,-0.371 -7.8615,-0.6199 -1.881,-0.3712 -4.3177,-0.7446 -7.086,-1.3646 -5.6469,-1.1158 -8.5261,-2.976 -13.3976,-5.8292 -6.9767,-4.2158 -12.4016,-10.5406 -18.8247,-20.2146 4.3178,-7.6871 9.4113,-18.9745 15.0583,-33.8553 l 4.0976,9.0539 c 1.1072,2.2312 2.5478,4.8359 4.4288,7.8113 1.8831,2.9781 3.7661,5.3337 5.6474,7.0696 3.875,3.3491 9.5221,6.0758 16.0566,6.0758 h 28.3451 v -23.8102 c 0,-2.3559 1.4406,-3.9691 3.5437,-3.9691 0.8871,0 1.7719,0.3734 2.6571,1.24 l 35.3238,39.5623 c 1.3274,1.4866 1.3274,4.2158 0,5.7048 z m 0,-111.1179 -35.4329,39.6846 c -0.6648,0.7445 -1.5517,1.1156 -2.5478,1.1156 -1.8831,0 -3.5437,-1.8601 -3.5437,-3.9691 v -23.8104 h -28.3451 c -7.088,0 -12.8441,2.4803 -17.2751,7.4405 -4.4289,4.9603 -7.086,9.674 -10.6297,17.2389 -2.3258,5.0846 -5.2047,12.1539 -8.6355,21.2056 -2.1053,5.4581 -3.9863,10.0473 -5.538,13.7675 -1.4386,3.7202 -3.4328,8.0605 -5.9786,13.0208 -2.4367,4.9602 -4.7622,9.0538 -7.0859,12.4007 -4.4307,6.5737 -11.1851,14.5097 -18.1598,18.8522 -6.7544,4.0914 -15.8344,7.1915 -25.9104,7.1915 h -24.8032 c -2.1054,0 -3.5439,-1.6112 -3.5439,-3.9691 v -23.8104 c 0,-2.3559 1.4385,-3.969 3.5439,-3.969 h 24.8032 c 7.0857,0 12.8441,-2.4802 17.273,-7.4402 4.4287,-4.9604 7.0877,-9.6719 10.6296,-17.2368 2.3256,-5.0848 5.2047,-12.1539 8.6374,-21.2079 l 5.425,-13.7653 c 1.5517,-3.7202 3.5439,-8.0605 5.9806,-13.0207 2.5457,-4.9625 4.8714,-9.0539 7.0857,-12.403 4.54,-6.5714 11.4056,-14.6342 18.16,-18.7255 6.9766,-4.3403 15.9452,-7.3182 26.0217,-7.3182 h 28.3451 v -23.8103 c 0,-2.3557 1.4406,-3.9691 3.5437,-3.9691 0.8872,0 1.772,0.3734 2.6571,1.24 l 35.3238,39.5623 c 1.3272,1.4868 1.3272,4.2161 -2e-4,5.7048 z"
+         sodipodi:nodetypes="cc"
          inkscape:connector-curvature="0"
-         style="stroke-width:0.2052106;fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1" />
+         id="path8454"
+         d="m 8277.1656,-2462.5985 v -70.8662"
+         style="fill:#ffeeff;fill-opacity:1;stroke:#ffffee;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker8458)" />
+      <path
+         style="fill:#fffffd;fill-opacity:1;stroke:#ffffee;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker8674)"
+         d="m 8277.1656,-2462.5985 -78.7663,42.2268"
+         id="path8670"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       inkscape:label="systemmap_toggle_grid"
+       transform="translate(-5669.2915,2721.2599)"
+       id="g14131">
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:21.25984192;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5151515"
+         id="rect14129"
+         width="226.77151"
+         height="226.77162"
+         x="8163.7798"
+         y="-2575.9844" />
+      <rect
+         style="fill:none;fill-opacity:1;stroke:#ffffee;stroke-width:8.85826778;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect14133"
+         width="72.535606"
+         height="72.536224"
+         x="8204.6299"
+         y="-2462.5986"
+         ry="0" />
+      <rect
+         ry="0"
+         y="-2535.1345"
+         x="8204.6299"
+         height="72.536034"
+         width="72.535606"
+         id="rect16427"
+         style="fill:none;fill-opacity:1;stroke:#ffffee;stroke-width:8.85826778;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="fill:none;fill-opacity:1;stroke:#ffffee;stroke-width:8.85826778;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect16429"
+         width="72.536285"
+         height="72.536034"
+         x="8277.165"
+         y="-2535.1345"
+         ry="0" />
+      <rect
+         ry="0"
+         y="-2462.5986"
+         x="8277.166"
+         height="72.536224"
+         width="72.535286"
+         id="rect16431"
+         style="fill:none;fill-opacity:1;stroke:#ffffee;stroke-width:8.85826778;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g16445"
+       transform="translate(-5442.5204,2721.2599)"
+       inkscape:label="systemmap_toggle_lagrange_points">
+      <rect
+         y="-2575.9844"
+         x="8163.7798"
+         height="226.77162"
+         width="226.77151"
+         id="rect16435"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:21.25984192;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5151515" />
+      <circle
+         style="fill:none;fill-opacity:1;stroke:#ffffee;stroke-width:8.85826778;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path16851"
+         cx="8324.8525"
+         cy="-2518.6033"
+         r="21.259842" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:7.08661413;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.08661416, 7.08661416;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 8307.3569,-2507.8386 -103.2067,60.6229"
+         id="path16853"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path16867"
+         d="m 8304.4294,-2519.9667 -78.5321,-5.4549"
+         style="fill:none;stroke:#ffffff;stroke-width:7.08661413;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.08661416, 7.08661416;stroke-dashoffset:0;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:7.08661413;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:7.08661416, 7.08661416;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 8331.195,-2497.3832 19.7481,68.5689"
+         id="path16869"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:7.08661413;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 8343.355,-2504.4174 c 25.9292,32.6206 23.8085,70.9107 -8.8419,108.9979"
+         id="path16877"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:7.08661413;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 8189.2948,-2511.4913 c 43.2841,-24.3753 69.9483,-32.1902 116.9737,-20.2352"
+         id="path16875"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <ellipse
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:9.30372238;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path16871"
+         cx="8219.3242"
+         cy="-2528.7891"
+         rx="8.5103521"
+         ry="8.2358246" />
+      <ellipse
+         ry="8.2358246"
+         rx="8.5103521"
+         cy="-2425.9087"
+         cx="8353.9893"
+         id="ellipse16873"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:9.30372238;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path18971"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:1.25;font-family:Uroob;-inkscape-font-specification:'Uroob Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.08487391;stroke-opacity:1"
+         d="m 8219.5061,-2382.017 q -9.2338,0 -9.2338,-5.8874 v -38.6341 h 8.615 v 36.7877 q 0,1.3935 0.2857,1.7418 0.5711,0.5574 2.3322,0.5574 h 16.1829 v 5.4346 z" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path18973"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:1.25;font-family:Uroob;-inkscape-font-specification:'Uroob Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.08487391;stroke-opacity:1"
+         d="m 8266.8652,-2407.866 q 0,-2.9263 -3.8554,-2.9263 h -8.6626 q -1.4279,0 -2.2372,0.6619 -0.7615,0.627 -0.8091,1.6373 h -8.1867 q 0.096,-3.1701 2.7131,-5.2952 2.7605,-2.2644 6.9967,-2.2644 h 12.7084 q 4.0934,0 6.7588,2.2296 2.5703,2.1251 2.5703,5.1907 v 26.6154 h -7.9488 v -1.3586 q -2.5702,1.4631 -5.0452,1.4631 h -7.8059 q -4.3314,0 -7.7108,-1.9509 -3.665,-2.125 -3.665,-5.1558 v -6.619 q 0,-3.0657 3.665,-5.1907 3.427,-1.9858 7.7108,-1.9858 h 9.2338 q 1.9039,0 3.5698,0.7665 z m -0.1429,17.6971 v -4.3198 q 0,-1.3237 -1.0471,-2.2295 -0.9995,-0.9406 -2.951,-0.9406 h -8.0915 q -1.999,0 -2.9034,0.9406 -0.9043,0.9058 -0.9043,2.2295 v 4.3198 q 0,1.3238 0.9043,2.2645 0.9044,0.9057 2.9034,0.9057 h 8.0915 q 1.9515,0 2.951,-0.9057 1.0471,-0.9407 1.0471,-2.2645 z" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path18975"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:1.25;font-family:Uroob;-inkscape-font-specification:'Uroob Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.08487391;stroke-opacity:1"
+         d="m 8296.2326,-2415.9133 q 3.8077,0 6.9015,1.6373 v -1.6373 h 7.4728 l 0.048,40.3411 q 0,3.2747 -2.0942,5.8178 -2.4275,2.8566 -6.7589,2.8566 h -10.4713 q -3.3794,0 -5.9973,-1.5329 -2.7605,-1.6721 -2.7605,-4.0758 v -2.2296 h 7.2347 q -0.048,1.1148 0.9519,1.8464 1.0472,0.7315 2.5703,0.7315 h 4.2361 q 3.0938,0 4.4265,-1.498 0.4284,-0.4877 0.4284,-1.1844 v -8.9531 q -3.189,1.707 -5.2356,1.707 h -5.2358 q -6.2351,0 -9.4718,-2.9263 -2.8558,-2.6476 -2.8558,-7.3855 v -13.9346 q 0,-4.4592 3.5698,-7.0023 3.6174,-2.5779 9.7098,-2.5779 z m 6.1876,25.2219 v -17.5229 q 0,-1.6026 -3.3794,-2.369 -0.8092,-0.209 -1.4756,-0.209 h -4.0933 q -4.9025,0 -5.5213,3.1353 -0.1903,0.9755 -0.1903,2.16 v 12.6457 q 0,2.6128 0.8091,3.6579 1.5232,1.9508 4.9025,1.9508 h 4.0933 q 1.3804,0 2.6179,-0.836 2.2371,-1.5677 2.2371,-2.6128 z" />
+    </g>
+    <g
+       id="g16947"
+       transform="translate(-5215.7487,2721.2599)"
+       inkscape:label="systemmap_toggle_draw_ships">
+      <rect
+         y="-2575.9844"
+         x="8163.7798"
+         height="226.77162"
+         width="226.77151"
+         id="rect16937"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:21.25984192;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5151515" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.03024948px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 8227.3742,-2553.8992 -22.3294,16.6168 c 0,0 21.3203,22.8011 25.4564,59.1085 h -15.5745 v 31.151 h 15.5745 c -4.1361,36.3074 -25.4564,59.1065 -25.4564,59.1065 l 22.3294,16.6189 c 0,0 40.5082,-45.9171 106.8522,-79.3554 l 13.8058,-11.9465 -13.8058,-11.9445 c -66.344,-33.4383 -106.8522,-79.3553 -106.8522,-79.3553 z m 19.4702,62.0283 h 9.0105 c 2.1271,0 3.8393,1.7122 3.8393,3.8392 0,2.127 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7123 -3.8394,-3.8393 0,-2.127 1.7123,-3.8392 3.8394,-3.8392 z m 25.4302,0 h 9.0086 c 2.1271,0 3.8394,1.7122 3.8394,3.8392 0,2.127 -1.7123,3.8393 -3.8394,3.8393 h -9.0086 c -2.127,0 -3.8393,-1.7123 -3.8393,-3.8393 0,-2.127 1.7123,-3.8392 3.8393,-3.8392 z m 27.4626,15.5502 8.0427,0.3441 c 2.6845,4.1003 5.7744,6.3606 11.1758,8.56 4.3952,1.7896 4.9984,4.8172 4.9984,4.8172 0,0 -0.6032,3.0297 -4.9984,4.8192 -5.4014,2.1995 -8.4913,4.4598 -11.1758,8.5599 l -8.0427,0.3442 c 0,0 -4.9148,-8.3087 -5.9723,-13.7233 -0.021,0.1074 -0.05,0.221 -0.068,0.326 v -0.65 c 0.018,0.1046 0.048,0.2172 0.068,0.324 1.058,-5.4146 5.9723,-13.7213 5.9723,-13.7213 z m -52.8928,35.3163 h 9.0105 c 2.1271,0 3.8393,1.7123 3.8393,3.8393 0,2.1271 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7122 -3.8394,-3.8393 0,-2.127 1.7123,-3.8393 3.8394,-3.8393 z m 25.4302,0 h 9.0086 c 2.1271,0 3.8394,1.7123 3.8394,3.8393 0,2.1271 -1.7123,3.8393 -3.8394,3.8393 h -9.0086 c -2.127,0 -3.8393,-1.7122 -3.8393,-3.8393 0,-2.127 1.7123,-3.8393 3.8393,-3.8393 z"
+         id="path17192"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="g18003"
+       transform="translate(-5215.7482,2267.7165)"
+       inkscape:label="orbit_prograde">
+      <rect
+         y="-2575.9844"
+         x="8163.7798"
+         height="226.77162"
+         width="226.77151"
+         id="rect17993"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:21.25984192;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5151515" />
+      <path
+         style="fill:none;stroke:#fffff4;stroke-width:10.62992096;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 8278.835,-2541.1932 78.6072,78.6071 -78.6072,78.6073 -78.6071,-78.6073 78.6071,-78.6071"
+         id="path18005"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#fffff4;stroke-width:8.85826778;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 8222.1421,-2519.2915 113.3858,113.3858"
+         id="path18023"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:#fffff4;stroke-width:8.85826778;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 8335.5279,-2519.2915 -113.3858,113.3858"
+         id="path18025"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path18027"
+         d="m 8278.835,-2495.4753 32.9783,32.9782 -32.9783,32.9782 -32.9782,-32.9782 32.9782,-32.9782"
+         style="fill:none;stroke:#fffff4;stroke-width:8.85826778;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       inkscape:label="orbit_delta"
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\taxi_urgent.png"
+       id="g18965"
+       transform="matrix(7.0866142,0,0,7.0866142,2494.4884,-308.26783)">
+      <rect
+         y="0"
+         x="0"
+         height="32"
+         width="32"
+         id="rect18961"
+         style="display:inline;fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path18978"
+         style="font-style:normal;font-weight:normal;font-size:medium;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.7968871"
+         d="m 21.867707,7.4708154 q -1.587548,-1.0894942 -5.307393,-1.0894942 -3.937743,0 -3.937743,1.8210118 0,1.4319067 4.108949,2.178988 3.237354,0.575876 5.058366,2.319067 2.210117,2.101167 2.210117,6.412451 0,4.124514 -2.132296,6.55253 -2.132296,2.44358 -5.867704,2.44358 -3.719845,0 -5.867705,-2.44358 -2.1322959,-2.428016 -2.1322959,-6.708172 0,-3.175097 2.1322959,-5.743191 0.824903,-0.996109 1.992218,-1.55642 -2.4280157,-1.229572 -2.4280157,-3.4241246 0,-4.2334633 6.8638137,-4.2334633 3.439689,0 5.307393,1.0894942 z m -7.595331,4.9649806 q -1.058366,0.451362 -1.914397,1.587549 -1.338521,1.758755 -1.338521,4.933852 0,3.159534 1.322957,4.933853 1.338521,1.789883 3.657588,1.789883 2.287938,0 3.626459,-1.805447 1.338521,-1.805448 1.338521,-4.762647 0,-3.097276 -1.416342,-4.59144 -1.509728,-1.603112 -3.470817,-1.774319 -0.996109,-0.09338 -1.805448,-0.311284 z" />
+    </g>
+    <g
+       transform="matrix(7.0866142,0,0,7.0866142,2721.26,-308.26785)"
+       id="g19502"
+       inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\taxi_urgent.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"
+       inkscape:label="orbit_start_time">
+      <rect
+         style="display:inline;fill:none;stroke:none"
+         id="rect19498"
+         width="32"
+         height="32"
+         x="0"
+         y="0" />
+      <circle
+         style="fill:none;fill-opacity:1;stroke:#fffff4;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path19506"
+         cx="16.000002"
+         cy="16.000004"
+         r="10" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 12.000007,15.999994 h 3.999997 l 3.046276,-5.927801"
+         id="path19508"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="matrix(7.0866142,0,0,7.0866142,3401.575,-308.26785)"
+       id="g20870"
+       inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\taxi_urgent.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"
+       inkscape:label="orbit_radial">
+      <rect
+         style="display:inline;fill:none;stroke:none"
+         id="rect20864"
+         width="32"
+         height="32"
+         x="0"
+         y="0" />
+      <circle
+         style="fill:none;fill-opacity:1;stroke:#fffff4;stroke-width:1.09833813;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle20866"
+         cx="16.000002"
+         cy="16.000004"
+         r="11.315217" />
+      <circle
+         r="6.4326534"
+         cy="16.000004"
+         cx="16.000002"
+         id="circle20872"
+         style="fill:none;fill-opacity:1;stroke:#fffff4;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#ffffeb;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 15.999997,3.6342418 V 28.365739"
+         id="path20876"
+         inkscape:connector-curvature="0" />
+      <circle
+         style="fill:#ffffff;fill-opacity:1;stroke:#fffff4;stroke-width:0.45468459;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle20878"
+         cx="16.000002"
+         cy="16.000004"
+         r="2.273423" />
+    </g>
+    <g
+       inkscape:label="orbit_normal"
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\taxi_urgent.png"
+       id="g1627"
+       transform="matrix(7.0866142,0,0,7.0866142,3174.8034,-308.26784)">
+      <rect
+         y="0"
+         x="0"
+         height="32"
+         width="32"
+         id="rect1617"
+         style="display:inline;fill:none;stroke:none" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#fffff4;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 6.6371538,8.1852008 C 8.95428,5.4090616 12.383911,3.8043316 16,3.8043316"
+         id="path1644"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#fffff4;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 25.362846,23.81478 C 23.04572,26.590919 19.61609,28.195649 16,28.195649"
+         id="circle1619"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <circle
+         style="fill:none;fill-opacity:1;stroke:#fffff4;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle1621"
+         cx="16.000002"
+         cy="16.000004"
+         r="6.4326534" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1623"
+         d="M 15.999997,4.1796525 V 27.820328"
+         style="fill:none;stroke:#ffffeb;stroke-width:1.95539594;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         r="2.273423"
+         cy="16.000004"
+         cx="16.000002"
+         id="circle1625"
+         style="fill:#ffffff;fill-opacity:1;stroke:#fffff4;stroke-width:0.45468459;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#ffffeb;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.5066591,8.0760852 25.493335,23.923896"
+         id="path1629"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       inkscape:label="orbit_increase"
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\taxi_urgent.png"
+       id="g3219"
+       transform="matrix(7.0866142,0,0,7.0866142,3401.575,145.27545)">
+      <rect
+         y="0"
+         x="0"
+         height="32"
+         width="32"
+         id="rect3213"
+         style="display:inline;fill:none;stroke:none" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 19.999977,3.9999923 25.999986,15.999984 19.999977,27.999988"
+         id="path2316"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 15.999986,16.000001 H 3.9999945"
+         id="path2318"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 9.9999901,10.000005 V 22.000009"
+         id="path2320"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="matrix(7.0866142,0,0,7.0866142,3174.8033,145.27545)"
+       id="g3235"
+       inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\taxi_urgent.png"
+       inkscape:export-xdpi="90"
+       inkscape:export-ydpi="90"
+       inkscape:label="orbit_reduce">
+      <rect
+         style="display:inline;fill:none;stroke:none"
+         id="rect3231"
+         width="32"
+         height="32"
+         x="0"
+         y="0" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 11.999989,27.999988 5.9999937,15.999984 11.999989,3.9999923"
+         id="path1437"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 13.999988,15.999984 h 8.000007"
+         id="path1439"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 13.999988,15.999984 h 8.000007"
+         id="path1441"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.000001,16.000001 h 12"
+         id="path2314"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       inkscape:label="lagrange"
+       inkscape:export-ydpi="90"
+       inkscape:export-xdpi="90"
+       inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\default.png"
+       id="g2317"
+       transform="matrix(7.0866142,0,0,7.0866142,3174.8033,-1215.3545)">
+      <rect
+         y="0"
+         x="0"
+         height="32"
+         width="32"
+         id="rect2313"
+         style="fill:none;stroke:none" />
+      <circle
+         transform="matrix(0.70083945,0,0,0.70083945,3.6107918,5.9623458)"
+         id="circle2315"
+         style="fill:#ffffff;stroke:#ffffff;stroke-width:0.20134585"
+         cx="17.67767"
+         cy="14.32233"
+         r="9.1923885" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,4988.9765,2494.4881)"
+       inkscape:label="apoapsis"
+       id="g4985">
+      <desc
+         id="desc4979">Icon </desc>
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4981"
+         width="226.77165"
+         height="226.77165"
+         x="2948.0315"
+         y="-2349.2126" />
+      <path
+         sodipodi:type="star"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:69.35007477;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path4983"
+         sodipodi:sides="3"
+         sodipodi:cx="3174.8032"
+         sodipodi:cy="-2349.2126"
+         sodipodi:r1="226.77165"
+         sodipodi:r2="113.38583"
+         sodipodi:arg1="1.5707963"
+         sodipodi:arg2="2.6179939"
+         inkscape:flatsided="true"
+         inkscape:rounded="0"
+         inkscape:randomized="0"
+         d="m 3174.8032,-2122.441 -196.39,-340.1575 392.78,0 z"
+         inkscape:transform-center-y="11.633394"
+         transform="matrix(0.20645741,0,0,0.20230807,2405.9556,-1764.5035)"
+         inkscape:transform-center-x="7.7831932e-05" />
+    </g>
+    <g
+       id="g4993"
+       inkscape:label="periapsis"
+       transform="matrix(1,0,0,-1,-907.08654,-1977.1655)">
+      <desc
+         id="desc4987">Icon </desc>
+      <rect
+         y="-2349.2126"
+         x="2948.0315"
+         height="226.77165"
+         width="226.77165"
+         id="rect4989"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:14.17322826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:transform-center-x="7.7831932e-05"
+         transform="matrix(0.20645741,0,0,0.20230807,2405.9556,-1764.5035)"
+         inkscape:transform-center-y="11.633394"
+         d="m 3174.8032,-2122.441 -196.39,-340.1575 392.78,0 z"
+         inkscape:randomized="0"
+         inkscape:rounded="0"
+         inkscape:flatsided="true"
+         sodipodi:arg2="2.6179939"
+         sodipodi:arg1="1.5707963"
+         sodipodi:r2="113.38583"
+         sodipodi:r1="226.77165"
+         sodipodi:cy="-2349.2126"
+         sodipodi:cx="3174.8032"
+         sodipodi:sides="3"
+         id="path4991"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:69.35007477;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         sodipodi:type="star" />
+    </g>
+    <g
+       id="g5252"
+       transform="translate(-908.24767,680.31501)"
+       inkscape:label="search_person">
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect6000-3"
+         width="226.77187"
+         height="226.77171"
+         x="2721.2598"
+         y="-308.26794" />
+      <path
+         sodipodi:nodetypes="sscscscscccccccccccccccccccccccccssccccscccccccccscccccccccscscccsscccc"
+         inkscape:connector-curvature="0"
+         id="path9319-6"
+         transform="matrix(0.93749997,0,0,0.93749997,0,-2575.9843)"
+         d="m 3046.2969,2464.6816 c -20.2353,0 -36.6328,16.1014 -36.6328,35.9375 0,12.7713 5.443,29.3797 15.5957,39.6036 -0.07,0.065 9.7695,9.0007 9.7695,11.9863 0,2.9468 -1.5732,5.5534 -3.9453,7.0683 5.0512,1.6795 10.4476,2.6016 16.0605,2.6016 5.2035,0 10.2237,-0.7861 14.9532,-2.2383 -2.7005,-1.4485 -4.5313,-4.2416 -4.5313,-7.4316 0,-2.9822 9.8047,-11.8164 9.8047,-11.8164 5.8801,-5.861 10.1215,-13.8541 12.6797,-22.0274 -0.4241,-0.1104 -0.8356,-0.2517 -1.2344,-0.4179 -0.03,-0.013 -0.06,-0.026 -0.09,-0.039 -0.3954,-0.1696 -0.779,-0.3618 -1.1446,-0.582 -0.3653,-0.2201 -0.7119,-0.4661 -1.0429,-0.7324 -0.02,-0.016 -0.042,-0.03 -0.062,-0.047 -0.3145,-0.2573 -0.6097,-0.5367 -0.8887,-0.8321 -0.041,-0.043 -0.079,-0.087 -0.1191,-0.1308 -0.2756,-0.3029 -0.5365,-0.618 -0.7715,-0.9551 0,0 0,-0.01 -0.01,-0.014 -0.2225,-0.3202 -0.4211,-0.6583 -0.6036,-1.0058 -0.037,-0.07 -0.076,-0.138 -0.1113,-0.209 -0.1684,-0.3412 -0.3142,-0.6936 -0.4414,-1.0566 -0.057,-0.1629 -0.1117,-0.3254 -0.1602,-0.4922 -0.017,-0.057 -0.035,-0.114 -0.051,-0.1719 -0.068,-0.252 -0.1285,-0.5076 -0.1758,-0.7676 -0.294,-1.1816 -0.6767,-2.3502 -1.1426,-3.4961 -0.9319,-2.2918 -2.1943,-4.4918 -3.7285,-6.5117 -0.767,-1.01 -1.6019,-1.975 -2.4981,-2.8848 -0.4481,-0.4548 -0.9109,-0.8964 -1.3886,-1.3222 -0.9555,-0.8516 -1.9681,-1.6422 -3.0313,-2.3614 -1.0631,-0.7191 -2.1774,-1.3664 -3.334,-1.9316 -1.1565,-0.5652 -2.3561,-1.0478 -3.5918,-1.4375 -0.6178,-0.1949 -1.2439,-0.3667 -1.8789,-0.5137 -0.2763,-0.05 -0.5491,-0.1122 -0.8164,-0.1855 -0.8019,-0.2199 -1.5606,-0.5417 -2.2617,-0.9512 -0.7011,-0.4095 -1.3436,-0.9059 -1.9141,-1.4746 -0.3802,-0.3792 -0.7278,-0.7898 -1.039,-1.2285 -0.1556,-0.2194 -0.3028,-0.4452 -0.4395,-0.6778 -0.2733,-0.465 -0.5081,-0.9557 -0.6992,-1.4667 -0.3821,-1.0222 -0.5898,-2.1271 -0.5898,-3.2793 0,-0.3227 0.017,-0.6434 0.049,-0.959 10e-5,-7e-4 -1e-4,0 0,0 0.097,-0.948 0.3355,-1.8602 0.6934,-2.7129 2e-4,-5e-4 -3e-4,0 0,0 0.3582,-0.8532 0.8358,-1.6469 1.4121,-2.3575 0.1924,-0.2372 0.3959,-0.4638 0.6093,-0.6816 0.2128,-0.2171 0.4359,-0.425 0.668,-0.6211 0.9301,-0.7859 2.0093,-1.3966 3.1856,-1.7754 0.5881,-0.1894 1.1997,-0.3201 1.83,-0.3867 0.3152,-0.033 0.6357,-0.051 0.959,-0.051 1.4016,0 2.8598,0.1881 4.3535,0.541 7e-4,2e-4 0,-10e-5 0,0 0.9963,0.2355 2.0069,0.5446 3.0293,0.9219 0.5112,0.1887 1.0255,0.3934 1.541,0.6153 1.0309,0.4436 2.0683,0.9521 3.1074,1.5195 1.5586,0.851 3.1207,1.8346 4.6641,2.9297 1.0289,0.73 2.0494,1.5106 3.0566,2.334 1.5109,1.235 2.9914,2.5675 4.4199,3.9785 0.444,0.4412 0.8789,0.8926 1.3086,1.3496 -5.7485,-12.4643 -18.5277,-21.1485 -33.3847,-21.1485 z m 61.5332,123.1719 c -15.6271,14.2671 -36.4256,22.9668 -59.2696,22.9668 -17.0807,0 -32.9559,-4.8738 -46.4199,-13.2637 l -23.8672,23.8477 c 0,10.9105 -0.01,15.1348 -0.01,15.1348 0,7.5064 6.2446,13.5859 13.9551,13.5859 h 108.1562 c 7.7103,0 13.9551,-6.0795 13.9551,-13.5859 0,0 -0.034,-30.3736 0,-31.3926 -0.1048,-3.9401 -1.6747,-11.3102 -4.5703,-14.9785 -0.6295,-0.7986 -1.2756,-1.5644 -1.9297,-2.3145 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.82163858;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.82163863, 1.64327724;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sscssccssscsssc"
+         inkscape:connector-curvature="0"
+         id="path5244"
+         transform="matrix(0.93749997,0,0,0.93749997,0,-2575.9843)"
+         d="m 3047.1445,2434.0156 c -45.4791,0 -82.3047,36.8256 -82.3047,82.3047 0,15.9436 4.5618,30.8528 12.4161,43.457 l -53.9922,53.9922 c -7.2898,7.2898 -7.2898,19.1419 0,26.4317 7.2898,7.2898 19.1419,7.2898 26.3847,0 l 54.0391,-53.9922 c 12.6045,7.8543 27.4665,12.416 43.457,12.416 45.4792,0 82.3047,-36.8255 82.3047,-82.3047 0,-45.4791 -36.8255,-82.3047 -82.3047,-82.3047 z m 0,23.5156 c 32.4516,0 58.7891,26.3376 58.7891,58.7891 0,32.4515 -26.3375,58.7891 -58.7891,58.7891 -32.4515,0 -58.789,-26.3376 -58.789,-58.7891 0,-32.4515 26.3375,-58.789 58.789,-58.7891 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.06666672;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1.0666667, 2.1333334;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       inkscape:export-ydpi="45"
+       inkscape:export-xdpi="45"
+       inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\small\haul.png"
+       id="g4389-0"
+       transform="matrix(7.0866142,0,0,7.0866142,2040.9449,372.04711)"
+       inkscape:label="info_hold">
+      <g
+         id="g4391-0"
+         inkscape:export-filename="D:\work\pioneer\graphics_design\icons\bbs_icons\delivery.png"
+         inkscape:export-xdpi="90"
+         inkscape:export-ydpi="90">
+        <g
+           style="display:inline"
+           id="g4393-8"
+           transform="matrix(1.4677533,0,0,1.7795888,-1259.1749,-399.46602)" />
+        <g
+           id="g4395-6">
+          <rect
+             y="0"
+             x="0"
+             height="32"
+             width="32"
+             id="rect4397-8"
+             style="display:inline;fill:none;stroke:none" />
+        </g>
+      </g>
+      <path
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.50003773"
+         d="m 27.294666,18.381248 c 0.848414,0 1.531366,0.683002 1.531366,1.531366 v 6.199667 c 0,0.848414 -0.682952,1.531366 -1.531366,1.531366 H 18.58896 c -0.848414,0 -1.531366,-0.682952 -1.531366,-1.531366 v -6.199667 c 0,-0.848364 0.682952,-1.531366 1.531366,-1.531366 z m -7.721282,1.340951 c -0.300973,-0.005 -0.542491,0.199315 -0.625997,0.442384 -0.08341,0.242668 -0.017,0.550991 0.221666,0.733455 v 0 l 6.768061,5.293349 c 0.155812,0.12206 0.348526,0.167013 0.516639,0.136711 0.168163,-0.0305 0.308223,-0.12456 0.405331,-0.248069 0.09711,-0.123459 0.156111,-0.281571 0.145511,-0.452184 -0.0105,-0.170563 -0.101808,-0.346976 -0.25782,-0.468735 l -6.769061,-5.2934 c -0.115158,-0.09206 -0.257919,-0.143411 -0.40533,-0.144511 z"
+         id="rect4399-6"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.77981281"
+         d="m 2976.4766,2545.418 c -6.4133,0 -11.5762,5.1633 -11.5762,11.5761 v 46.8633 c 0,6.4132 5.1629,11.5762 11.5762,11.5762 h 47.539 v -40.1328 l -37.2773,29.1543 c -1.1778,0.9226 -2.6355,1.2623 -3.9063,1.0332 -1.2711,-0.2306 -2.3304,-0.9414 -3.0644,-1.875 -0.734,-0.9332 -1.1798,-2.1283 -1.0996,-3.418 0.079,-1.2893 0.7698,-2.6226 1.9492,-3.543 l 43.7285,-34.1953 c 1.3436,-6.0756 6.731,-10.5976 13.2227,-10.5976 h 15.0839 c -1.8871,-3.8195 -5.8049,-6.4414 -10.3691,-6.4414 z"
+         transform="matrix(0.13229166,0,0,0.13229166,-384.00002,-319.99999)"
+         id="rect4399-6-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssssccccccccscss" />
+      <path
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.77981281"
+         d="m 3038.541,2481.8066 c -6.4132,0 -11.5762,5.1615 -11.5762,11.5743 v 46.4043 h 14.7247 c -0.6406,-0.8998 -1.0314,-2.0054 -0.9571,-3.2012 0.079,-1.2893 0.7699,-2.6227 1.9492,-3.543 l 51.168,-40.0137 c 0.8705,-0.6961 1.9502,-1.0834 3.0645,-1.0918 l -0.01,0.01 c 2.2751,-0.038 4.1013,1.5083 4.7325,3.3457 0.6304,1.8344 0.1282,4.1638 -1.6758,5.543 l -50.127,39.2051 c 5.7671,1.1069 10.2033,5.8587 10.834,11.7851 h 43.6778 c 6.4132,0 11.5761,-5.161 11.5761,-11.5742 v -46.8652 c 0,-6.4128 -5.1629,-11.5743 -11.5761,-11.5743 z"
+         transform="matrix(0.13229166,0,0,0.13229166,-384.00002,-319.99999)"
+         id="rect4399-6-0"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.38094229;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.38094222, 0.76188452;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 3004.5293,2463.627 c -9.3819,0 -16.9844,7.4653 -16.9844,16.6621 0,5.9212 2.5233,13.6211 7.2305,18.3613 -0.032,0.03 4.5293,4.1744 4.5293,5.5586 0,1.8897 -1.3904,3.4811 -3.2344,3.8418 -10.2231,0.9921 -16.2719,4.0784 -20.9629,10.0469 -1.3426,1.7008 -2.0705,5.1185 -2.1191,6.9453 0.016,0.4724 0,7.873 0,7.873 0,3.4803 2.8939,6.3008 6.4687,6.3008 h 41.3047 v -29.7559 c -2.2143,-0.6151 -4.6708,-1.0638 -7.4472,-1.3476 -2.0059,-0.2362 -3.5586,-1.9027 -3.5586,-3.9043 0,-1.3827 4.5449,-5.4785 4.5449,-5.4785 4.7557,-4.7402 7.2148,-12.4887 7.2148,-18.4414 0,-9.1968 -7.6044,-16.6621 -16.9863,-16.6621 z"
+         transform="matrix(0.13229166,0,0,0.13229166,-384.00002,-319.99999)"
+         id="rect5597-3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.38094229;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:0.38094222, 0.76188452;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 2960.9082,2447.1191 c -9.3818,0 -16.9844,7.4654 -16.9844,16.6621 0,5.9213 2.5234,13.6212 7.2305,18.3614 -0.032,0.03 4.5293,4.1744 4.5293,5.5586 0,1.8898 -1.3904,3.4813 -3.2344,3.8418 -10.2231,0.9921 -16.2739,4.0783 -20.9648,10.0468 -1.3426,1.7008 -2.0739,5.1186 -2.1192,6.9454 0.01,0.2172 8e-4,20.7217 10e-5,42.173 -0.1114,1.7958 0.899,3.3286 2.2671,3.3231 2.0581,-0.01 4.7493,-0.042 6.168,0.016 1.1728,0.048 1.7543,0.8194 1.7543,2.2883 v 38.1868 c 0,1.5787 0.1775,3.2313 -2.0193,3.5365 -0.2169,0.03 -5.5262,0.1358 -6.0059,0.143 -1.2648,0.019 -2.1437,0.517 -2.1643,2.1521 v 5.1743 c 0,1.7566 1.4617,3.1804 3.2662,3.1804 h 28.1284 c -0.081,-7.1755 0.095,-32.0492 0.1718,-57.0918 0.01,-2.8248 2.8662,-7.0321 7.1875,-7.6016 0.043,-12.9088 0.09,-22.6323 0.1368,-22.7929 3.2631,-11.2316 14.834,-15.2504 21.0957,-15.9297 0.8614,-0.1684 1.6373,-0.5613 2.2695,-1.1094 -0.3334,-0.9951 -0.7628,-1.9271 -1.2891,-2.5938 -4.6425,-5.8897 -10.6277,-8.9607 -20.6406,-9.9843 -2.0058,-0.2362 -3.5586,-1.9026 -3.5586,-3.9043 -10e-5,-1.3826 4.5469,-5.4785 4.5469,-5.4785 4.7557,-4.7401 7.2129,-12.4887 7.2129,-18.4415 0,-9.1967 -7.6024,-16.6621 -16.9844,-16.6621 z"
+         transform="matrix(0.13229166,0,0,0.13229166,-384.00002,-319.99999)"
+         id="rect5597-3-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscsccccsssssscssccccccccccssc" />
+    </g>
+    <g
+       id="g5067"
+       transform="translate(455.38715,226.77159)"
+       inkscape:label="trash">
+      <g
+         id="g260"
+         transform="matrix(3.4622141,0,0,3.4593323,1949.6227,299.06523)"
+         style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+        <path
+           style="fill:#ffffff;stroke-width:1.1949873"
+           id="path258"
+           d="M 6.2395934,-20.044606 V 8.6350889 c 0,1.3144861 -1.0754885,2.3899751 -2.3899746,2.3899751 -1.314486,0 -2.3899746,-1.075489 -2.3899746,-2.3899751 V -20.044606 c 0,-1.314486 1.0754886,-2.389975 2.3899746,-2.389975 1.3144861,0 2.3899746,1.075489 2.3899746,2.389975 m -10.7548856,0 V 8.6350889 c 0,1.3144861 -1.0754886,2.3899751 -2.3899746,2.3899751 -1.314486,0 -2.3899746,-1.075489 -2.3899746,-2.3899751 V -20.044606 c 0,-1.314486 1.0754886,-2.389975 2.3899746,-2.389975 1.314486,0 2.3899746,1.075489 2.3899746,2.389975 m -10.7548858,0 V 8.6350889 c 0,1.3144861 -1.075488,2.3899751 -2.389974,2.3899751 -1.314486,0 -2.389975,-1.075489 -2.389975,-2.3899751 V -20.044606 c 0,-1.314486 1.075489,-2.389975 2.389975,-2.389975 1.314486,0 2.389974,1.075489 2.389974,2.389975 M 1.4596442,-28.409517 H -15.270178 v -3.345965 c 0,-1.457884 1.171088,-2.628972 2.628972,-2.628972 h 11.4718782 c 1.45788449,0 2.628972,1.171088 2.628972,2.628972 z m 13.7423538,0 H 7.4345807 v -7.169924 c 0,-2.640922 -2.1390272,-4.779949 -4.7799492,-4.779949 H -16.465165 c -2.640922,0 -4.779949,2.139027 -4.779949,4.779949 v 7.169924 h -7.767418 c -1.649082,0 -2.987468,1.338386 -2.987468,2.987468 0,1.649083 1.338386,2.987468 2.987468,2.987468 h 1.792481 v 34.654632 c 0,2.640922 2.139027,4.779949 4.779949,4.779949 h 31.06967 c 2.640922,0 4.779949,-2.139027 4.779949,-4.779949 v -34.654632 h 1.792481 c 1.649083,0 2.987468,-1.338385 2.987468,-2.987468 0,-1.649082 -1.338385,-2.987468 -2.987468,-2.987468"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         y="145.27545"
+         x="1812.3295"
+         height="226.77165"
+         width="226.77164"
+         id="rect1359"
+         style="fill:none;stroke-width:0.95094484" />
+    </g>
+    <g
+       id="g5124"
+       transform="translate(680.34695,2947.9746)"
+       inkscape:label="pencil">
+      <g
+         style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+         transform="matrix(4.1369002,0,0,4.1334567,2153.8898,-2526.0698)"
+         id="g280">
+        <path
+           inkscape:connector-curvature="0"
+           d="M 0,30.81 -9.34,32.6 -17.08,24.85 -15.3,15.5 -1.39,1.57 c 0.77,-0.77 2.01,-0.77 2.78,0 0.77,0.77 0.77,2.02 0,2.79 l -12.86,12.88 c -0.96,0.96 -0.96,2.52 0,3.48 0.96,0.96 2.51,0.96 3.47,0 L 4.87,7.84 c 0.77,-0.77 2.01,-0.77 2.78,0 0.77,0.77 0.77,2.01 0,2.78 L -5.21,23.5 c -0.96,0.96 -0.96,2.52 0,3.48 0.96,0.96 2.51,0.96 3.47,0 L 11.13,14.1 c 0.76,-0.76 2.01,-0.76 2.78,0 0.77,0.77 0.77,2.02 0,2.79 z M -18.34,11.58 c -0.98,0.98 -1.45,2.38 -1.69,3.8 l -3.81,18.02 c -0.54,3.2 2.67,6.42 5.91,5.92 L 0.11,35.56 C 1.43,35.32 2.86,34.91 3.84,33.93 L 22.95,14.8 c 1.53,-1.54 1.53,-4.03 0,-5.57 L 6.26,-7.48 c -1.54,-1.53 -4.03,-1.53 -5.56,0 z"
+           id="path278"
+           style="fill:#ffffff" />
+      </g>
+      <rect
+         style="fill:none;stroke-width:0.94316423"
+         id="rect5102"
+         width="226.77167"
+         height="226.77168"
+         x="2040.913"
+         y="-2575.9275" />
+    </g>
+    <g
+       id="g5129"
+       transform="translate(680.34695,2947.9746)"
+       inkscape:label="pen">
+      <g
+         style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+         transform="matrix(4.1369002,0,0,4.1334567,2377.3886,-2478.5795)"
+         id="g276">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 0,7.52 -16.95,16.95 c -0.36,0.36 -0.58,0.86 -0.58,1.41 0,1.1 0.89,2 2,2 0.29,0 0.56,-0.06 0.81,-0.17 0,0 28.24,-12.24 28.56,-12.39 0.66,-0.3 1.17,-0.88 1.37,-1.6 l 4.57,-16.47 0.92,0.91 c 0.96,0.96 2.51,0.96 3.47,0 0.96,-0.96 0.96,-2.51 0,-3.47 L 10.08,-19.4 c -0.96,-0.96 -2.51,-0.96 -3.47,0 -0.96,0.96 -0.96,2.51 0,3.47 l 0.91,0.91 -16.5,4.59 c -0.72,0.21 -1.3,0.73 -1.6,1.41 l -12.37,28.54 c -0.1,0.24 -0.16,0.5 -0.16,0.78 0,1.11 0.9,2 2,2 0.57,0 1.08,-0.23 1.44,-0.61 L -2.75,4.77 C -2.98,4.18 -3.11,3.55 -3.11,2.88 c 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 0,2.76 -2.24,5 -5,5 C 1.22,7.88 0.59,7.75 0,7.52"
+           id="path274"
+           style="fill:#ffffff" />
+      </g>
+      <rect
+         y="-2575.9275"
+         x="2267.6846"
+         height="226.77168"
+         width="226.77167"
+         id="rect5119"
+         style="fill:none;stroke-width:0.94316423" />
+    </g>
+    <g
+       id="g5148"
+       transform="translate(680.34695,2947.9746)"
+       inkscape:label="martini_glass">
+      <g
+         style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+         transform="matrix(4.137302,0,0,4.1338581,2643.8366,-2438.4826)"
+         id="g172">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 0,-11.64 3.72,-3.77 c 0.36,-0.36 0.58,-0.86 0.58,-1.41 0,-1.1 -0.89,-2 -1.98,-2 h -5.95 c 0.49,-3.39 3.399,-6 6.93,-6 3.87,0 7,3.13 7,7 0,3.87 -3.13,7 -7,7 -1.19,0 -2.32,-0.3 -3.3,-0.82 M -16.7,0.18 v 11 c 0,1.1 -0.9,2 -2,2 h -5.5 c -1.38,0 -2.5,1.12 -2.5,2.5 0,1.38 1.12,2.5 2.5,2.5 h 20 c 1.38,0 2.5,-1.12 2.5,-2.5 0,-1.38 -1.12,-2.5 -2.5,-2.5 h -5.5 c -1.1,0 -2,-0.9 -2,-2 v -11 l 8.09,-8.19 c 1.96,1.38 4.34,2.19 6.91,2.19 6.63,0 12,-5.37 12,-12 0,-6.63 -5.37,-12 -12,-12 -6.29,0 -11.45,4.84 -11.96,11 h -22.06 c -1.09,0 -1.98,0.9 -1.98,2 0,0.56 0.23,1.07 0.6,1.43 z"
+           id="path170"
+           style="fill:#ffffff" />
+      </g>
+      <rect
+         style="fill:none;stroke-width:0.93774557"
+         id="rect5143"
+         width="226.77161"
+         height="226.77164"
+         x="2494.4563"
+         y="-2575.9275" />
+    </g>
+    <g
+       id="g5163"
+       transform="translate(680.34695,2947.9746)"
+       inkscape:label="beer_mug">
+      <g
+         style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+         transform="matrix(4.137302,0,0,4.1338581,2913.68,-2480.6051)"
+         id="g180">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 0,10 c 0,1.66 -1.34,3 -3,3 -1.66,0 -3,-1.34 -3,-3 V -5 c 0,-1.66 1.34,-3 3,-3 1.66,0 3,1.34 3,3 z m -34,-22 v 29 c 0,1.1 -0.9,2 -2,2 -1.1,0 -2,-0.9 -2,-2 v -29 c 0,-1.1 0.9,-2 2,-2 1.1,0 2,0.9 2,2 m 28,29.42 c 0.93,0.37 1.94,0.58 3,0.58 4.42,0 8,-3.58 8,-8 V -5 c 0,-4.42 -3.58,-8 -8,-8 -1.06,0 -2.07,0.21 -3,0.58 V -15 c 0,-2.21 -1.79,-4 -4,-4 h -29 c -2.21,0 -4,1.79 -4,4 v 33.85 c 0,5.61 4.54,10.15 10.15,10.15 h 16.7 C -10.54,29 -6,24.46 -6,18.85 Z"
+           id="path178"
+           style="fill:#ffffff" />
+      </g>
+      <rect
+         style="fill:none;stroke-width:0.93420637"
+         id="rect5158"
+         width="225"
+         height="221.56001"
+         x="2722.5713"
+         y="-2570.7158" />
+    </g>
+    <g
+       id="g5285"
+       transform="translate(680.34695,2947.9746)"
+       inkscape:label="log">
+      <rect
+         y="-2575.9238"
+         x="1814.1449"
+         height="226.76811"
+         width="226.76811"
+         id="rect4219-3"
+         style="opacity:1;fill:none;fill-opacity:0.7020202;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
+         transform="matrix(4.137302,0,0,4.1338581,1844.7829,-2379.8626)"
+         id="g308">
+        <path
+           inkscape:connector-curvature="0"
+           d="M 0,-40 V 0 C 0,2.21 1.79,4 4,4 H 37.5 C 38.88,4 40,2.88 40,1.5 40,0.12 38.88,-1 37.5,-1 H 7 C 5.9,-1 5,-1.9 5,-3 5,-4.1 5.9,-5 7,-5 h 29 c 2.21,0 4,-1.79 4,-4 v -31 c 0,-2.21 -1.79,-4 -4,-4 H 22 v 17.99 c 0,0.26 -0.1,0.52 -0.29,0.72 -0.39,0.39 -1.03,0.39 -1.42,0 -0.26,-0.27 -4.29,-3.62 -4.29,-3.62 0,0 -4.03,3.35 -4.29,3.62 -0.39,0.39 -1.03,0.39 -1.42,0 C 10.1,-25.49 10,-25.75 10,-26.01 V -44 H 4 c -2.21,0 -4,1.79 -4,4"
+           id="path306"
+           style="fill:#ffffff" />
+      </g>
+    </g>
+    <g
+       id="g5543-8"
+       transform="translate(-1814.1413,3174.7498)"
+       inkscape:label="economy">
+      <rect
+         y="-2575.9275"
+         x="1814.1449"
+         height="226.76811"
+         width="226.76811"
+         id="rect4219-5"
+         style="opacity:1;fill:none;fill-opacity:0.7020202;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         id="rect5585-8"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 2010.462,-2379.8662 c 0,9.1358 -7.6127,16.5354 -17.0118,16.5354 h -131.8423 c -9.3991,0 -17.012,-7.3996 -17.012,-16.5354 v -140.5512 c 0,-9.1358 7.6129,-16.5354 17.012,-16.5354 h 34.6618 c 2.9303,-14.1378 15.8211,-24.8032 31.2594,-24.8032 15.4383,0 28.3248,10.6654 31.2594,24.8032 h 34.6617 c 9.3991,0 17.0118,7.3996 17.0118,16.5354 z m -30.6215,-136.4173 h -20.4141 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.0816 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.4143 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.0946 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.6231 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.0946 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.4686 c 0,-5.7046 -4.7633,-10.3346 -10.6324,-10.3346 -5.8692,0 -10.6325,4.63 -10.6325,10.3346 0,5.7048 4.7633,10.3347 10.6325,10.3347 5.8691,0 10.6324,-4.6299 10.6324,-10.3347 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssscscsssscsssscsssssssssssss" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:10.62992096;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 1878.5461,-2446.5031 27.1839,-17.1467 37.6392,20.4925 32.2024,-51.8585"
+         id="path3028"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7619"
+         d="m 1878.5461,-2414.5129 27.1839,-17.1467 37.6392,7.9461 32.2024,19.656"
+         style="fill:none;stroke:#ffffff;stroke-width:10.62992096;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.62992124, 21.25984249;stroke-dashoffset:0;stroke-opacity:1"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       id="g7508"
+       transform="translate(-8163.7799,-226.77163)"
+       inkscape:label="radial_out">
+      <path
+         sodipodi:nodetypes="scssccccssccccccsscccccccc"
+         inkscape:connector-curvature="0"
+         d="m 8705.5841,-2320.8084 c 8.1225,-0.2397 14.8377,6.2783 14.8396,14.4043 v 141.1542 c 0,6.0392 -3.7678,11.4372 -9.4352,13.5232 -5.6676,2.0861 -12.0346,0.4179 -15.9512,-4.1791 l -60.1019,-70.5764 c -4.5859,-5.3859 -4.5859,-13.3035 0,-18.6894 l 60.1019,-70.5766 c 2.6425,-3.1015 6.4741,-4.9399 10.5468,-5.0602 z m 50.2499,0 c 4.0727,0.1203 7.9046,1.9587 10.5467,5.0602 l 60.102,70.5766 c 4.5859,5.3859 4.5859,13.3035 0,18.6894 l -60.102,70.5764 c -3.9165,4.597 -10.2835,6.2652 -15.9509,4.1791 -5.6674,-2.086 -9.4335,-7.484 -9.4352,-13.5232 v -141.1542 c 0,-8.126 6.7172,-14.644 14.8394,-14.4043 z m -64.2358,53.5593 -26.7589,31.4222 26.7589,31.4222 z m 78.2219,0 v 62.8444 l 26.7589,-31.4222 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect7452" />
+      <rect
+         y="-2349.2126"
+         x="8617.3232"
+         height="226.77165"
+         width="226.77165"
+         id="rect7486"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       inkscape:label="retrograde"
+       transform="translate(-9751.1814,-226.77163)"
+       id="g5438">
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect5440"
+         width="226.77165"
+         height="226.77165"
+         x="9977.9531"
+         y="-2349.2126" />
+      <path
+         id="path5448"
+         style="opacity:1;fill:#535b4f;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 10155.056,-2299.5445 -63.718,63.7173 -63.717,63.7181 m 127.436,-3e-4 -63.718,-63.7178 -63.718,-63.7177"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </g>
+    <g
+       id="g5827"
+       inkscape:label="prograde">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         d="m 113.385,-2528.1576 65.56,65.559 -65.559,65.5586 -65.56,-65.559 z"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect7460" />
+      <rect
+         y="-2575.9844"
+         x="6.2499996e-05"
+         height="226.77165"
+         width="226.77165"
+         id="rect7496"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       id="g7707-9"
+       transform="translate(1587.4017,-1587.4016)"
+       inkscape:label="display_navtarget">
+      <g
+         id="g7690-8"
+         transform="translate(681.68549,1812.0965)">
+        <g
+           id="g336-2"
+           transform="matrix(4.137302,0,0,4.1338581,-114.75634,-1021.3486)"
+           style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2">
+          <path
+             style="fill:#ffffff"
+             inkscape:connector-curvature="0"
+             id="path334-8"
+             d="m 0,-38 c 5.8,0 10.5,4.7 10.5,10.5 0,5.8 -4.7,10.5 -10.5,10.5 -5.8,0 -10.5,-4.7 -10.5,-10.5 0,-5.8 4.7,-10.5 10.5,-10.5 m -15.5,10.22 c 0,10.2 12.03,18.05 13,29.78 V 2.5 C -2.5,3.88 -1.38,5 0,5 1.38,5 2.5,3.88 2.5,2.5 V 2 c 1.03,-11.73 13,-19.58 13,-29.78 C 15.5,-36.19 8.56,-43 0,-43 c -8.56,0 -15.5,6.81 -15.5,15.22 M 0,-34 c -3.59,0 -6.5,2.91 -6.5,6.5 0,3.59 2.91,6.5 6.5,6.5 3.59,0 6.5,-2.91 6.5,-6.5 C 6.5,-31.09 3.59,-34 0,-34 m -2.5,6.5 c 0,-1.38 1.12,-2.5 2.5,-2.5 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5" />
+        </g>
+        <rect
+           ry="10.042029"
+           y="-1213.2777"
+           x="-228.14217"
+           height="226.77165"
+           width="226.77165"
+           id="rect7685-8"
+           style="fill:none;stroke:none;stroke-width:10.72576714;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.72576782, 21.45153565;stroke-dashoffset:0" />
+      </g>
+    </g>
+    <g
+       id="g7756"
+       inkscape:label="alert_1">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5791"
+         d="m 2304.8688,-957.99113 c -12.8216,0 -20.8354,13.88381 -14.4251,24.9886 l 77.414,134.08807 c 6.4122,11.10375 22.4413,11.10375 28.8535,0 l 77.414,-134.08807 c 6.4103,-11.10479 -1.6034,-24.98632 -14.4251,-24.9886 z m 67.9195,25.07807 h 19.1868 l -0.6472,57.04431 h -17.8924 z m 0.2582,69.23134 h 18.6704 v 21.52137 h -18.6704 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:0.78431373;fill-rule:nonzero;stroke:none;stroke-width:33.31446075;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <g
+         transform="translate(1.1828859,-5.3229862)"
+         id="text5750"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:137.89128113px;line-height:1000%;font-family:TitilliumText25L;-inkscape-font-specification:'TitilliumText25L Heavy';text-indent:0;text-align:center;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:middle;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000100;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:47.27700806;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         aria-label="!">
+        <path
+           inkscape:connector-curvature="0"
+           id="path5814"
+           transform="matrix(0.93749997,0,0,0.93749997,0,-2575.9843)"
+           d="m 2476.4121,1747.5645 c -10.5056,0 -17.0696,11.3742 -11.8183,20.4726 l 63.4296,109.8613 c 5.2534,9.0976 18.3834,9.0976 23.6368,0 l 63.4296,-109.8613 c 5.2512,-9.0984 -1.3147,-20.4707 -11.8203,-20.4726 z m 52.6563,10.746 h 21.7675 l -0.7343,64.7168 h -20.2989 z m 0.2929,78.543 h 21.1817 v 24.416 h -21.1817 z"
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:TitilliumText25L;-inkscape-font-specification:'TitilliumText25L Heavy';fill:#ffffff;fill-opacity:1;stroke-width:50.42881012" />
+      </g>
+      <rect
+         ry="10.004812"
+         y="-986.84595"
+         x="2270.0618"
+         height="224.16232"
+         width="229.18089"
+         id="rect7750"
+         style="fill:none;stroke:none;stroke-width:10.62992096;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.62992121, 21.25984244;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="g7764"
+       inkscape:label="alert_2">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5752"
+         transform="matrix(0.93749997,0,0,0.93749997,0,-2575.9843)"
+         d="m 2780.9531,1723.418 a 90.416108,90.416108 0 0 0 -90.416,90.416 90.416108,90.416108 0 0 0 90.416,90.416 90.416108,90.416108 0 0 0 90.416,-90.416 90.416108,90.416108 0 0 0 -90.416,-90.416 z m -32.0547,37.4336 h 21.7696 l -0.7364,64.7168 h -20.2968 z m 44.3516,0 h 21.7676 l -0.7344,64.7168 h -20.2969 z m -44.0566,78.5429 h 21.1796 v 24.416 h -21.1796 z m 44.3515,0 h 21.1797 v 24.416 h -21.1797 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:0.84705882;stroke:none;stroke-width:45.20802689;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.84705882" />
+      <path
+         inkscape:connector-curvature="0"
+         id="circle5891"
+         transform="matrix(0.93749997,0,0,0.93749997,0,-2575.9843)"
+         d="m 2780.9531,1738.2441 a 75.590603,75.590603 0 0 0 -75.5898,75.5899 75.590603,75.590603 0 0 0 75.5898,75.5918 75.590603,75.590603 0 0 0 75.5899,-75.5918 75.590603,75.590603 0 0 0 -75.5899,-75.5899 z m -32.0547,22.6075 h 21.7696 l -0.7364,64.7168 h -20.2968 z m 44.3516,0 h 21.7676 l -0.7344,64.7168 h -20.2969 z m -44.0566,78.5429 h 21.1796 v 24.416 h -21.1796 z m 44.3515,0 h 21.1797 v 24.416 h -21.1797 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:37.79527664;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.84705882" />
+      <rect
+         ry="10.004812"
+         y="-986.84595"
+         x="2495.897"
+         height="225.83519"
+         width="227.50804"
+         id="rect7758"
+         style="fill:none;stroke:none;stroke-width:10.62992096;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.62992121, 21.25984244;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="g7775"
+       inkscape:label="ecm_advanced">
+      <g
+         id="g5786"
+         transform="matrix(0.69224437,0,0,0.69224437,4606.1575,161.7549)"
+         inkscape:label="Function ECM">
+        <path
+           style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd"
+           inkscape:connector-curvature="0"
+           id="path5782"
+           d="m -2595.9564,-1580.3482 16.6193,-63.7334 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.9469,107.5732 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.0446 l -16.6141,63.7334 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.9426,-107.5731 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z" />
+        <rect
+           y="-1668.8977"
+           x="-2721.2598"
+           height="226.7717"
+           width="226.77151"
+           id="rect5784"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         inkscape:label="Function ECM"
+         transform="matrix(0.69224437,0,0,0.69224437,4662.3446,226.81362)"
+         id="g5792">
+        <path
+           d="m -2595.9564,-1580.3482 16.6193,-63.7334 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.9469,107.5732 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.0446 l -16.6141,63.7334 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.9426,-107.5731 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z"
+           id="path5788"
+           inkscape:connector-curvature="0"
+           style="clip-rule:evenodd;display:inline;fill:#ffffff;fill-opacity:1;fill-rule:evenodd" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect5790"
+           width="226.77151"
+           height="226.7717"
+           x="-2721.2598"
+           y="-1668.8977" />
+      </g>
+      <rect
+         ry="0"
+         y="-988.51886"
+         x="2723.405"
+         height="230.85376"
+         width="224.16235"
+         id="rect7766"
+         style="fill:none;stroke:none;stroke-width:10.62992096;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.62992121, 21.25984244;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="g7781"
+       inkscape:label="systems_management">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect5788"
+         d="m 2990.3484,-953.61135 c -9.815,0 -17.7155,7.90237 -17.7155,17.71734 v 120.70678 c 0,9.81497 7.9005,17.71725 17.7155,17.71725 h 142.0001 c 9.815,0 17.7173,-7.90228 17.7173,-17.71725 v -120.70678 c 0,-9.81497 -7.9023,-17.71734 -17.7173,-17.71734 z m 7.7893,17.95537 h 1.0712 c 3.9259,0 7.0862,3.16022 7.0862,7.08619 v 106.05834 c 0,3.92597 -3.1603,7.08619 -7.0862,7.08619 h -1.0712 c -3.926,0 -7.0862,-3.16022 -7.0862,-7.08619 v -106.05834 c 0,-3.92597 3.1602,-7.08619 7.0862,-7.08619 z m 25.7336,0 h 1.0712 c 3.9261,0 7.0881,3.16022 7.0881,7.08619 v 106.05834 c 0,3.92597 -3.162,7.08619 -7.0881,7.08619 h -1.0712 c -3.9259,0 -7.0862,-3.16022 -7.0862,-7.08619 v -106.05834 c 0,-3.92597 3.1603,-7.08619 7.0862,-7.08619 z m 24.8987,0 h 1.0712 c 3.9259,0 7.0862,3.16022 7.0862,7.08619 v 106.05834 c 0,3.92597 -3.1603,7.08619 -7.0862,7.08619 h -1.0712 c -3.926,0 -7.088,-3.16022 -7.088,-7.08619 v -106.05834 c 0,-3.92597 3.162,-7.08619 7.088,-7.08619 z m 36.5021,13.71825 a 10.940943,10.940943 0 0 1 10.9405,10.94053 10.940943,10.940943 0 0 1 -10.9405,10.94053 10.940943,10.940943 0 0 1 -10.9424,-10.94053 10.940943,10.940943 0 0 1 10.9424,-10.94053 z m 28.894,0 a 10.940943,10.940943 0 0 1 10.9406,10.94053 10.940943,10.940943 0 0 1 -10.9406,10.94053 10.940943,10.940943 0 0 1 -10.9405,-10.94053 10.940943,10.940943 0 0 1 10.9405,-10.94053 z m -28.894,35.45653 a 10.940943,10.940943 0 0 1 10.9405,10.94053 10.940943,10.940943 0 0 1 -10.9405,10.94063 10.940943,10.940943 0 0 1 -10.9424,-10.94063 10.940943,10.940943 0 0 1 10.9424,-10.94053 z m 28.894,0 a 10.940943,10.940943 0 0 1 10.9406,10.94053 10.940943,10.940943 0 0 1 -10.9406,10.94063 10.940943,10.940943 0 0 1 -10.9405,-10.94063 10.940943,10.940943 0 0 1 10.9405,-10.94053 z m -28.894,35.45653 a 10.940943,10.940943 0 0 1 10.9405,10.94063 10.940943,10.940943 0 0 1 -10.9405,10.94053 10.940943,10.940943 0 0 1 -10.9424,-10.94053 10.940943,10.940943 0 0 1 10.9424,-10.94063 z m 28.894,0 a 10.940943,10.940943 0 0 1 10.9406,10.94063 10.940943,10.940943 0 0 1 -10.9406,10.94053 10.940943,10.940943 0 0 1 -10.9405,-10.94053 10.940943,10.940943 0 0 1 10.9405,-10.94063 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.58464569;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="-986.93317"
+         x="2948.9343"
+         height="225.9312"
+         width="228.29697"
+         id="rect7777"
+         style="fill:none;stroke:none;stroke-width:10.62992096;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.62992121, 21.25984244;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="g5543"
+       transform="translate(-680.2866,1814.1199)"
+       inkscape:label="bbs">
+      <rect
+         y="-2575.9275"
+         x="1814.1449"
+         height="226.76811"
+         width="226.76811"
+         id="rect4219-0"
+         style="opacity:1;fill:none;fill-opacity:0.7020202;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         id="rect5585-83"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1, 2;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 1897.7582,-2462.5433 h 59.5417 c 5.8691,0 10.6323,4.6298 10.6323,10.3346 0,5.7047 -4.7632,10.3346 -10.6323,10.3346 h -59.5417 c -5.8691,0 -10.6325,-4.6299 -10.6325,-10.3346 0,-5.7048 4.7634,-10.3346 10.6325,-10.3346 z m 0,37.2046 h 59.5417 c 5.8691,0 10.6323,4.63 10.6323,10.3347 0,5.7047 -4.7632,10.3346 -10.6323,10.3346 h -59.5417 c -5.8691,0 -10.6325,-4.6299 -10.6325,-10.3346 0,-5.7047 4.7634,-10.3347 10.6325,-10.3347 z m 112.7038,45.4725 c 0,9.1358 -7.6127,16.5354 -17.0118,16.5354 h -131.8423 c -9.3991,0 -17.012,-7.3996 -17.012,-16.5354 v -140.5512 c 0,-9.1358 7.6129,-16.5354 17.012,-16.5354 h 34.6618 c 2.9303,-14.1378 15.8211,-24.8032 31.2594,-24.8032 15.4383,0 28.3248,10.6654 31.2594,24.8032 h 34.6617 c 9.3991,0 17.0118,7.3996 17.0118,16.5354 z m -30.6215,-136.4173 h -20.4141 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.0816 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.4143 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.0946 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.6231 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.0946 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.4686 c 0,-5.7046 -4.7633,-10.3346 -10.6324,-10.3346 -5.8692,0 -10.6325,4.63 -10.6325,10.3346 0,5.7048 4.7633,10.3347 10.6325,10.3347 5.8691,0 10.6324,-4.6299 10.6324,-10.3347 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssssssssssssssscscsssscsssscsssssssssssss" />
+    </g>
+    <g
+       id="g7838"
+       inkscape:label="gender">
       <path
          style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.93749994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 1757.444,-2561.7578 c -3.5441,0 -3.5441,14.1732 0,14.1741 h 15.5347 l -19.0788,17.7163 v 10.6293 h 10.6293 l 21.2614,-19.6059 v 19.6069 c -10e-4,3.5423 14.1723,3.5423 14.1723,0 v -31.8897 -10.631 h -10.6292 z"
+         d="m 396.8512,159.4487 c -3.5441,0 -3.5441,14.1732 0,14.1741 h 15.5347 l -19.0788,17.7163 v 10.6293 h 10.6293 l 21.2614,-19.6059 v 19.6069 c -10e-4,3.5423 14.1723,3.5423 14.1723,0 v -31.8897 -10.631 h -10.6292 z"
          id="path2162"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 302.18786,300.98161 -0.15976,26.1597 h -13.37554 c -6.6878,1e-4 -6.6878,13.11229 0,13.1122 h 13.37554 v 13.11221 c -3e-5,6.55618 13.37552,6.55618 13.37556,-1e-5 v -13.1122 h 13.37554 c 6.68774,9e-5 6.68774,-13.1121 -0.079,-13.21296 l -13.29655,0.10076 -0.16905,-26.22791 z m 6.07985,-123.00853 a 66.885475,64.703688 0 0 0 -66.88485,64.70313 66.885475,64.703688 0 0 0 66.88485,64.70475 66.885475,64.703688 0 0 0 66.88485,-64.70475 66.885475,64.703688 0 0 0 -66.88485,-64.70313 z m 0,13.36966 a 53.065353,51.334355 0 0 1 53.06441,51.33347 53.065353,51.334355 0 0 1 -53.06441,51.33518 53.065353,51.334355 0 0 1 -53.06615,-51.33518 53.065353,51.334355 0 0 1 53.06615,-51.33347 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.87598372px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path2164" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         d="m 358.31409,175.61707 c -36.9382,3.4e-4 -66.8824,29.24834 -66.88273,65.32768 -6.8e-4,36.08002 29.94384,65.3291 66.88273,65.32944 36.93888,-3.4e-4 66.8834,-29.24942 66.88275,-65.32944 -3.3e-4,-36.07934 -29.94456,-65.32734 -66.88275,-65.32768 z m 0,13.49872 c 29.30556,5e-4 53.06224,23.20482 53.06277,51.82896 4.6e-4,28.62482 -23.75653,51.83022 -53.06277,51.83072 -29.30692,4.4e-4 -53.06497,-23.20522 -53.06448,-51.83072 5e-4,-28.6248 23.75827,-51.82942 53.06448,-51.82896 z"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.88018787px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path2164-3" />
+      <rect
+         y="144.93929"
+         x="226.77167"
+         height="228.24442"
+         width="228.24442"
+         id="rect7793"
+         style="fill:none;stroke:none;stroke-width:10.74332142;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.74332211, 21.48664424;stroke-dashoffset:0" />
     </g>
-    <path
-       id="path2164-3"
-       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.88018787px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 358.31409,175.61707 c -36.9382,3.4e-4 -66.8824,29.24834 -66.88273,65.32768 -6.8e-4,36.08002 29.94384,65.3291 66.88273,65.32944 36.93888,-3.4e-4 66.8834,-29.24942 66.88275,-65.32944 -3.3e-4,-36.07934 -29.94456,-65.32734 -66.88275,-65.32768 z m 0,13.49872 c 29.30556,5e-4 53.06224,23.20482 53.06277,51.82896 4.6e-4,28.62482 -23.75653,51.83022 -53.06277,51.83072 -29.30692,4.4e-4 -53.06497,-23.20522 -53.06448,-51.83072 5e-4,-28.6248 23.75827,-51.82942 53.06448,-51.82896 z"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccc" />
+    <g
+       id="g7817"
+       inkscape:label="clothes">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#c2c2c2;stroke-width:0.93749994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 1190.5512,230.3148 v 127.5591 h 113.3857 V 230.3148 l 21.2599,10.6299 21.2599,-53.1496 -56.693,-28.3464 h -14.1732 l -28.3464,28.3464 -28.3465,-28.3464 h -14.1732 l -56.693,28.3464 21.2599,53.1496 21.2599,-10.6299"
+         id="path2236"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccc" />
+      <rect
+         y="145.33949"
+         x="1133.8583"
+         height="227.84416"
+         width="227.84418"
+         id="rect7813"
+         style="fill:none;stroke:none;stroke-width:11.22329521;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:11.22329573, 22.44659148;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="g7823"
+       inkscape:label="accecories">
+      <path
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#c2c2c2;stroke-width:0.92225003;stroke-opacity:1"
+         d="m 1569.6844,242.71558 -26.1255,37.55493 a 27.885357,27.885355 0 0 0 -27.0227,-21.14868 27.885357,27.885355 0 0 0 -27.8247,26.11453 h -44.8626 a 27.885357,27.885355 0 0 0 -27.7533,-25.26675 27.885357,27.885355 0 0 0 -6.1982,0.72506 l 7.4249,-10.89112 c 3.5434,3.54328 5.3146,7.08618 7.0862,7.08618 1.7718,0 3.5437,-1.77168 -7.0862,-12.40171 l -12.4108,17.83996 a 27.885357,27.885355 0 0 0 -16.7029,25.52672 27.885357,27.885355 0 0 0 27.887,27.88697 27.885357,27.885355 0 0 0 27.8521,-26.96231 h 44.7894 a 27.885357,27.885355 0 0 0 27.7991,26.11453 27.885357,27.885355 0 0 0 27.8851,-27.88697 27.885357,27.885355 0 0 0 -0.09,-1.79072 l 25.3528,-37.18509 c 3.5433,3.54328 5.3164,7.08619 7.088,7.08619 1.7717,0 3.5419,-1.77178 -7.088,-12.40172 z m -53.1482,19.93284 a 24.35846,24.358467 0 0 1 24.3585,24.3585 24.35846,24.358467 0 0 1 -24.3585,24.3585 24.35846,24.358467 0 0 1 -24.3586,-24.3585 24.35846,24.358467 0 0 1 24.3586,-24.3585 z m -100.4406,0.84778 a 24.35846,24.358467 0 0 1 24.3585,24.3585 24.35846,24.358467 0 0 1 -24.3585,24.3585 24.35846,24.358467 0 0 1 -24.3586,-24.3585 24.35846,24.358467 0 0 1 0.029,-0.56765 l 14.9103,-21.8701 a 24.35846,24.358467 0 0 1 9.419,-1.92075 z m -16.4961,6.46913 -6.0425,8.68472 a 24.35846,24.358467 0 0 1 6.0425,-8.68472 z"
+         id="path2238-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="145.27553"
+         x="1360.63"
+         height="226.77158"
+         width="226.90762"
+         id="rect7819"
+         style="fill:none;stroke:none;stroke-width:10.63845062;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.63845103, 21.27690206;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="g7829"
+       inkscape:label="random">
+      <path
+         id="path2161"
+         d="m 1675.3197,215.132 c -4.4289,7.5649 -9.5225,18.8499 -15.1696,33.8575 -1.6609,-3.7225 -2.9904,-6.6982 -4.0976,-8.9294 -1.1071,-2.358 -2.6568,-4.9603 -4.5399,-7.9383 -1.8812,-2.9757 -3.7642,-5.3314 -5.6473,-6.9448 -3.6529,-3.4713 -9.4112,-6.2005 -15.9434,-6.2005 h -24.8032 c -2.1054,0 -3.5439,-1.6111 -3.5439,-3.9691 v -23.8102 c 0,-2.3556 1.4385,-3.9691 3.5439,-3.9691 h 24.8032 c 18.4913,0 33.5498,9.3028 45.3978,27.9039 z m 123.6847,101.9417 -35.4329,39.6844 c -0.6648,0.7446 -1.5517,1.1158 -2.5478,1.1158 -1.8831,0 -3.5437,-1.8602 -3.5437,-3.9692 v -23.8103 c -2.3238,0 -5.5361,0 -9.4113,0.1246 -3.8755,0 -6.8659,0 -8.9691,0.1246 -2.1032,0 -4.7622,0 -8.0838,-0.1246 -3.3216,-0.1246 -5.9784,-0.371 -7.8615,-0.6199 -1.881,-0.3712 -4.3177,-0.7446 -7.086,-1.3646 -5.6469,-1.1158 -8.5261,-2.976 -13.3976,-5.8292 -6.9767,-4.2158 -12.4016,-10.5406 -18.8247,-20.2146 4.3178,-7.6871 9.4113,-18.9745 15.0583,-33.8553 l 4.0976,9.0539 c 1.1072,2.2312 2.5478,4.8359 4.4288,7.8113 1.8831,2.9781 3.7661,5.3337 5.6474,7.0696 3.875,3.3491 9.5221,6.0758 16.0566,6.0758 h 28.3451 v -23.8102 c 0,-2.3559 1.4406,-3.9691 3.5437,-3.9691 0.8871,0 1.7719,0.3734 2.6571,1.24 l 35.3238,39.5623 c 1.3274,1.4866 1.3274,4.2158 0,5.7048 z m 0,-111.1179 -35.4329,39.6846 c -0.6648,0.7445 -1.5517,1.1156 -2.5478,1.1156 -1.8831,0 -3.5437,-1.8601 -3.5437,-3.9691 v -23.8104 h -28.3451 c -7.088,0 -12.8441,2.4803 -17.2751,7.4405 -4.4289,4.9603 -7.086,9.674 -10.6297,17.2389 -2.3258,5.0846 -5.2047,12.1539 -8.6355,21.2056 -2.1053,5.4581 -3.9863,10.0473 -5.538,13.7675 -1.4386,3.7202 -3.4328,8.0605 -5.9786,13.0208 -2.4367,4.9602 -4.7622,9.0538 -7.0859,12.4007 -4.4307,6.5737 -11.1851,14.5097 -18.1598,18.8522 -6.7544,4.0914 -15.8344,7.1915 -25.9104,7.1915 h -24.8032 c -2.1054,0 -3.5439,-1.6112 -3.5439,-3.9691 v -23.8104 c 0,-2.3559 1.4385,-3.969 3.5439,-3.969 h 24.8032 c 7.0857,0 12.8441,-2.4802 17.273,-7.4402 4.4287,-4.9604 7.0877,-9.6719 10.6296,-17.2368 2.3256,-5.0848 5.2047,-12.1539 8.6374,-21.2079 l 5.425,-13.7653 c 1.5517,-3.7202 3.5439,-8.0605 5.9806,-13.0207 2.5457,-4.9625 4.8714,-9.0539 7.0857,-12.403 4.54,-6.5714 11.4056,-14.6342 18.16,-18.7255 6.9766,-4.3403 15.9452,-7.3182 26.0217,-7.3182 h 28.3451 v -23.8103 c 0,-2.3557 1.4406,-3.9691 3.5437,-3.9691 0.8872,0 1.772,0.3734 2.6571,1.24 l 35.3238,39.5623 c 1.3272,1.4868 1.3272,4.2161 -2e-4,5.7048 z"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.2052106;stroke-opacity:1" />
+      <rect
+         y="145.67561"
+         x="1589.2106"
+         height="224.16232"
+         width="224.96271"
+         id="rect7825"
+         style="fill:none;stroke:none;stroke-width:10.49341488;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.49341503, 20.98683008;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="g7845"
+       inkscape:label="mouth">
+      <path
+         inkscape:label="mouth"
+         style="fill:#ffffff;fill-opacity:1;stroke:#d2d2d2;stroke-width:3.32453442;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         id="Selection-36"
+         d="m 759.9534,221.1225 c 10.26549,2.94511 24.38965,14.14871 34.29111,14.02726 10.84793,-0.1506 23.88001,-11.8412 34.87355,-14.75595 21.65946,-5.70807 42.00843,15.60609 47.32319,30.66566 0,0 -47.32319,-2.6415 -47.32319,-2.6415 0,0 -36.40245,5.49553 -36.40245,5.49553 0,0 -36.40245,-5.55625 -36.40245,-5.55625 0,0 -43.68295,2.70222 -43.68295,2.70222 5.42397,-15.39356 25.37251,-36.25228 47.32319,-29.93697 z m 3.64025,41.41382 c 0,0 36.40245,5.46517 36.40245,5.46517 0,0 29.12196,-5.46517 29.12196,-5.46517 0,0 40.0427,0 40.0427,0 -21.62306,49.2776 -128.42785,49.2776 -149.25006,0 0,0 43.68295,0 43.68295,0 z" />
+      <rect
+         y="145.58154"
+         x="680.41241"
+         height="226.46556"
+         width="227.67647"
+         id="rect7841"
+         style="fill:none;stroke:none;stroke-width:10.54120636;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.54120694, 21.0824139;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="g7851"
+       inkscape:label="nose">
+      <path
+         inkscape:label="nose"
+         sodipodi:nodetypes="cccccccccccccc"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:4.11916065;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         id="Selection-3"
+         d="m 591.6132,251.76723 c -4.0734,-14.63053 -9.5308,-57.79275 -8.3444,-72.85235 0.514,-6.65024 3.6382,-23.25439 13.4457,-16.51835 7.4744,5.10568 9.9659,55.73333 12.7343,67.9183 6.8414,30.03335 46.8629,57.3208 19.8129,87.56867 l -22.5021,19.69332 c -9.689,8.36641 -15.028,13.72952 -27.6828,16.1751 -20.405,2.35715 -32.9822,-5.01985 -52.0833,-21.40948 -7.3556,-6.34994 -18.3101,-12.52822 -22.937,-21.40949 -12.8527,-24.54154 17.6593,-61.54382 27.5641,-46.29428 7.6528,13.73234 -10.561,27.19879 -7.9094,38.61431 17.2415,14.77254 30.6488,22.01016 39.5467,25.09929 13.8415,4.80534 44.8867,-17.63929 55.3657,-29.38976 -1.6993,-14.40536 -21.7507,-28.4888 -27.0104,-47.19528 z" />
+      <rect
+         y="145.27545"
+         x="453.54333"
+         height="226.77165"
+         width="226.77167"
+         id="rect7847"
+         style="fill:none;stroke:none;stroke-width:10.69061661;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:10.69061666, 21.38123329;stroke-dashoffset:0" />
+    </g>
   </g>
 </svg>

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -11,7 +11,7 @@ local l = Lang.GetResource("ui-core")
 InfoView:registerView({
     id = "econTrade",
     name = l.ECONOMY_TRADE,
-    icon = ui.theme.icons.market,
+    icon = ui.theme.icons.cargo_manifest,
     showView = false,
     draw = function() end,
     refresh = function() end,

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -93,8 +93,6 @@ theme.icons = {
    direction_frame = 26,
    direction_frame_hollow = 27,
    direction_forward = 28,
-   apoapsis = 29,
-   periapsis = 30,
    semi_major_axis = 31,
    -- third row
    heavy_fighter = 32,
@@ -177,6 +175,7 @@ theme.icons = {
    filter_bodies = 107,
    filter_stations = 108,
    filter_ships = 109,
+   lagrange_marker = 110,
    system_overview = 111,
    -- eighth row
    heavy_freighter = 112,
@@ -191,10 +190,10 @@ theme.icons = {
    display_navtarget = 121,
    alert1 = 122,
    alert2 = 123,
-	 ecm_advanced = 124,
-	 systems_management = 125,
-	 distance = 126,
-	 filter = 127,
+   ecm_advanced = 124,
+   systems_management = 125,
+   distance = 126,
+   filter = 127,
    -- ninth row
    view_internal = 128,
    view_external = 129,
@@ -240,8 +239,15 @@ theme.icons = {
    hud = 168,
    factory = 169,
    star = 170,
+   delta = 171,
+   clock = 172,
+   orbit_prograde = 173,
+   orbit_normal = 174,
+   orbit_radial = 175,
+   -- twelfth row
    view_flyby = 191,
-    -- eleventh row
+   -- thirteenth row
+   cog = 192,
    gender = 193,
    nose = 194,
    mouth = 195,
@@ -249,14 +255,34 @@ theme.icons = {
    clothes = 197,
    accessories = 198,
    random = 199,
+   periapsis = 200,
+   apoapsis = 201,
+   reset_view = 202,
+   toggle_grid = 203,
+   toggle_lagrange = 204,
+   toggle_ships = 205,
+   decrease = 206,
+   increase = 207,
+   -- fourteenth row, wide icons
+   missile_unguided = 208,
+   missile_guided = 210,
+   missile_smart = 212,
+   missile_naval = 214,
+   find_person = 216,
+   cargo_manifest = 217,
+   trashcan = 218,
+   bookmark = 219,
+   pencil = 220,
+   fountain_pen = 221,
+   cocktail_glass = 222,
+   beer_glass = 223,
+   -- fifteenth row
+   chart = 224,
+   binder = 225,
+   navtarget = 226,
    -- TODO: manual / autopilot
-	 -- dummy, until actually defined correctly
-	 mouse_move_direction = 14,
-	 -- fourteenth row, wide icons
-	 missile_unguided = 208,
-	 missile_guided = 210,
-	 missile_smart = 212,
-	 missile_naval = 214,
+   -- dummy, until actually defined correctly
+   mouse_move_direction = 14,
 }
 
 -- TODO: apply these styles at startup.


### PR DESCRIPTION
Updating the icons.svg with a few icons that will be needed for future PRs by @impaktor @Gliese852 @Web-eWorks 
Some of the icons are by Gliese852 (I don't know how I tag as author for the PR)
I've also named all icons in the file with them names from the default.lua for consistency.
I've also changed the display nav target data icon from the reticule from the crosshair to that google-maps like pin. I've added that pin for the BBS set destination as nav target function as well.
I've also removed the old apoapsis and periapsis icons in favor of the new ones. They weren't in use anyway.

![icons](https://user-images.githubusercontent.com/4182678/75589766-f5d3d800-5a7b-11ea-88f9-07ac74ff39ce.png)

