### PR TITLE
Prevent change of Pioneer's mouse pointer when hiding HUD

### DIFF
--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -378,9 +378,12 @@ void PiGui::NewFrame(SDL_Window *window)
 	// Ask ImGui to hide OS cursor if GUI is not being drawn:
 	// it will do this if MouseDrawCursor is true. After the frame
 	// is created, we set the actual cursor draw state.
+#if 0 // Mouse cursors are set via the OS facilities.
+	// See also below.
 	if (!Pi::DrawGUI) {
 		ImGui::GetIO().MouseDrawCursor = true;
 	}
+#endif
 	switch (Pi::renderer->GetRendererType()) {
 	default:
 	case Graphics::RENDERER_DUMMY:


### PR DESCRIPTION
### Description

- When hiding the flight-ui with double TAB (i.e. `Pi::DrawGUI==false`), prevent a change of Pioneer's custom mouse pointer back to the system default pointer (fixes #4762)
- This also fixes a bug with Pioneer crashing occasionally after TAB-toggling the flight-ui off/on (fixes #4812)

### Remarks

As mentioned in https://github.com/pioneerspacesim/pioneer/issues/4812#issuecomment-591087280, the fix is to comment out three lines of code which change an imgui mouse setting:
<details>

```
#if 0 // Mouse cursors are set via the OS facilities.
	// See also below.
	if (!Pi::DrawGUI) {
		ImGui::GetIO().MouseDrawCursor = true;
	}
#endif
```
</details>

In fact, a few lines below an analogous change was already made in 5824d0a by @Web-eWorks:
<details>

```
#if 0 // Mouse cursors are set via the OS facilities.
	// We may want to revisit this at a later date.
	if(Pi::DoingMouseGrab() || !Pi::DrawGUI) {
		ImGui::GetIO().MouseDrawCursor = false;
	} else {
		ImGui::GetIO().MouseDrawCursor = true;
	}
#endif
```
</details>

Note that I have no real understanding of the imgui API at all. All I did when trying to find a fix for #4812 was to search for places in the code that are triggered when the HUD is off, i.e. places referencing `Pi::DrawGUI`. So I don't know if this is the proper way to do it. As @Web-eWorks commented in the code, 

> We may want to revisit this at a later date.

So there might be a better way to do it.

Nevertheless, I have checked that both #4762 and #4812 are fixed with this. I also tried to make sure that my uneducated fix does not introduce any new bugs. At least I did not experience any problems while test-playing this.
