### PR TITLE
Significantly update commodity prices!

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -494,12 +494,12 @@ local CARGOLANGRESOURCE = "commodity"
 
 cargo = {
 	hydrogen = EquipType.New({
-		l10n_key = 'HYDROGEN', l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=1,
+		l10n_key = 'HYDROGEN', l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=10,
 		capabilities={mass=1}, economy_type="mining",
 		purchasable=true, icon_name="Hydrogen"
 	}),
 	liquid_oxygen = EquipType.New({
-		l10n_key="LIQUID_OXYGEN", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=1.5,
+		l10n_key="LIQUID_OXYGEN", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=9.8,
 		capabilities={mass=1}, economy_type="mining",
 		purchasable=true, icon_name="Liquid_Oxygen"
 	}),
@@ -509,142 +509,142 @@ cargo = {
 		purchasable=true, icon_name="Water"
 	}),
 	carbon_ore = EquipType.New({
-		l10n_key="CARBON_ORE", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=5,
+		l10n_key="CARBON_ORE", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=7,
 		capabilities={mass=1}, economy_type="mining",
 		purchasable=true, icon_name="Carbon_ore"
 	}),
 	metal_ore = EquipType.New({
-		l10n_key="METAL_ORE", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=3,
+		l10n_key="METAL_ORE", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=43,
 		capabilities={mass=1}, economy_type="mining",
 		purchasable=true, icon_name="Metal_ore"
 	}),
 	metal_alloys = EquipType.New({
-		l10n_key="METAL_ALLOYS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=8,
+		l10n_key="METAL_ALLOYS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=24,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Metal_alloys"
 	}),
 	precious_metals = EquipType.New({
-		l10n_key="PRECIOUS_METALS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=180,
+		l10n_key="PRECIOUS_METALS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=2180,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Precious_metals"
 	}),
 	plastics = EquipType.New({
-		l10n_key="PLASTICS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=12,
+		l10n_key="PLASTICS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=36,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Plastics"
 	}),
 	fruit_and_veg = EquipType.New({
-		l10n_key="FRUIT_AND_VEG", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=12,
+		l10n_key="FRUIT_AND_VEG", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=105,
 		capabilities={mass=1}, economy_type="agriculture",
 		purchasable=true, icon_name="Fruit_and_Veg"
 	}),
 	animal_meat = EquipType.New({
-		l10n_key="ANIMAL_MEAT", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=18,
+		l10n_key="ANIMAL_MEAT", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=125,
 		capabilities={mass=1}, economy_type="agriculture",
 		purchasable=true, icon_name="Animal_Meat"
 	}),
 	live_animals = EquipType.New({
-		l10n_key="LIVE_ANIMALS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=32,
+		l10n_key="LIVE_ANIMALS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=932,
 		capabilities={mass=1}, economy_type="agriculture",
 		purchasable=true, icon_name="Live_Animals"
 	}),
 	liquor = EquipType.New({
-		l10n_key="LIQUOR", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=8,
+		l10n_key="LIQUOR", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=422,
 		capabilities={mass=1}, economy_type="agriculture",
 		purchasable=true, icon_name="Liquor"
 	}),
 	grain = EquipType.New({
-		l10n_key="GRAIN", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=10,
+		l10n_key="GRAIN", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=41,
 		capabilities={mass=1}, economy_type="agriculture",
 		purchasable=true, icon_name="Grain"
 	}),
 	slaves = EquipType.New({
-		l10n_key="SLAVES", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=232,
+		l10n_key="SLAVES", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=1011,
 		capabilities={mass=1}, economy_type="agriculture",
 		purchasable=true, icon_name="Slaves"
 	}),
 	textiles = EquipType.New({
-		l10n_key="TEXTILES", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=8.5,
+		l10n_key="TEXTILES", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=65,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Textiles"
 	}),
 	fertilizer = EquipType.New({
-		l10n_key="FERTILIZER", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=4,
+		l10n_key="FERTILIZER", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=15,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Fertilizer"
 	}),
 	medicines = EquipType.New({
-		l10n_key="MEDICINES", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=22,
+		l10n_key="MEDICINES", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=563,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Medicines"
 	}),
 	consumer_goods = EquipType.New({
-		l10n_key="CONSUMER_GOODS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=140,
+		l10n_key="CONSUMER_GOODS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=246,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Consumer_goods"
 	}),
 	computers = EquipType.New({
-		l10n_key="COMPUTERS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=80,
+		l10n_key="COMPUTERS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=461,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Computers"
 	}),
 	rubbish = EquipType.New({
-		l10n_key="RUBBISH", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=-0.1,
+		l10n_key="RUBBISH", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=-0.7,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Rubbish"
 	}),
 	radioactives = EquipType.New({
-		l10n_key="RADIOACTIVES", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=-3.5,
+		l10n_key="RADIOACTIVES", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=-4.4,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Radioactive_waste"
 	}),
 	narcotics = EquipType.New({
-		l10n_key="NARCOTICS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=157,
+		l10n_key="NARCOTICS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=632,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Narcotics"
 	}),
 	nerve_gas = EquipType.New({
-		l10n_key="NERVE_GAS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=265,
+		l10n_key="NERVE_GAS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=813,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Nerve_Gas"
 	}),
 	military_fuel = EquipType.New({
-		l10n_key="MILITARY_FUEL", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=60,
+		l10n_key="MILITARY_FUEL", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=49,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Military_fuel"
 	}),
 	robots = EquipType.New({
-		l10n_key="ROBOTS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=63,
+		l10n_key="ROBOTS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=829,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Robots"
 	}),
 	hand_weapons = EquipType.New({
-		l10n_key="HAND_WEAPONS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=124,
+		l10n_key="HAND_WEAPONS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=251,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Hand_weapons"
 	}),
 	air_processors = EquipType.New({
-		l10n_key="AIR_PROCESSORS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=20,
+		l10n_key="AIR_PROCESSORS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=204,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Air_processors"
 	}),
 	farm_machinery = EquipType.New({
-		l10n_key="FARM_MACHINERY", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=11,
+		l10n_key="FARM_MACHINERY", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=80,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Farm_machinery"
 	}),
 	mining_machinery = EquipType.New({
-		l10n_key="MINING_MACHINERY", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=12,
+		l10n_key="MINING_MACHINERY", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=312,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Mining_machinery"
 	}),
 	battle_weapons = EquipType.New({
-		l10n_key="BATTLE_WEAPONS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=220,
+		l10n_key="BATTLE_WEAPONS", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=607,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Battle_weapons"
 	}),
 	industrial_machinery = EquipType.New({
-		l10n_key="INDUSTRIAL_MACHINERY", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=13,
+		l10n_key="INDUSTRIAL_MACHINERY", l10n_resource = CARGOLANGRESOURCE, slots="cargo", price=124,
 		capabilities={mass=1}, economy_type="industry",
 		purchasable=true, icon_name="Industrial_machinery"
 	}),


### PR DESCRIPTION
_Recommendation: (Please ignore the tables - they're there for the nerds, and make this PR look intimidating, there be plots for the lazy)_

# Introduction

Trading in pioneer has been, more or less broken from the start. "Broken" in the sense that the profit from commodity trading compared to the work input in relation to mission rewards and expenses (ships, equipment) is much too low.

Pioneer is still basically a Frontier clone (but with ships replaced, and galaxy not 2D flattened). Since trade worked fine in Frontier, relative missions and ship/equipment prices, which I've played a lot, I thought the first (or "zeroth") step to improve Pioneer's trade is to model it on Frontier's, to make it at least as good as their system.


# Diagnosing the problem

To first diagnose the problem in Pioneer, I wrote a little [commodity debug](https://github.com/impaktor/pioneer/tree/debug_commodity_prices) module, as I've show in #4828, which, in the screenshot below shows the heart of the current problem: in a radius of 70 ly, the maximum profit per tonne for 2000 inhabited systems scanned is $73 / t, for Precious metals, with a relative profit of 58%. The starter ships in Pioneer have ~7t available, giving a profit of ~$500 per trade, assuming they fly those 64 ly between the min and max price systems. They could just as well take a package delivery for $600 instead.

![2020-03-08-083815_1600x900_scrot](https://user-images.githubusercontent.com/619390/76158732-4fda3a80-6119-11ea-8e3a-ee964ac31bf8.png)

A more apt comparison is for trade opportunities in a 20 ly radius (encompassing 23 inhabited systems), where we find $44 / t for Consumer goods between _Epsilon Eridani_ and _Kruger 60_ system, just 4.89 ly apart, with a relative profit of 43%, summing up to a total $300 profit per trade, (given starter ship with 7t capacity):

![2020-03-08-083958_1600x900_scrot](https://user-images.githubusercontent.com/619390/76160055-f8db6200-6126-11ea-9ec0-2a8be2a65454.png)


## Trade profit compared to Frontier?

In Frontier, one of the most profitable trade routes is the Sol - Barnard's Star run, hauling robots ($868.8 - $566.9) with $300 profit per tonne, with the starter ship that, like Pioneer, has 7t free space (if selling missiles and pulse laser, which aren't needed in those two safe systems), giving $2100 in pure profit single way. In an evening's casual gameplay I made 5-10 trade runs and went from $100 to $14,000 credits.


### Relative price differences

The relative profit from the Frontier Robot trade is 53%, which looks very comparable to our system in Pioneer (see screenshots above), where _relative_ profit ranges around 40%-70% within 70 ly radius and 30%-55% for 20 ly radius. In fact, I jotted down the prices for 10 markets in Frontier, including these "extreme" profitable outlier systems like Sol-Barnard, and got the following:

_Note the two last columns, showing difference (i.e. "potential profit / tonne" and relative potential profit)_


| COMMODITY        |    MEAN |  MEDIAN |    MIN |    MAX | ABS-DIFF | REL-DIFF |
|------------------|---------|---------|--------|--------|----------|----------|
| Water            |    0.88 |    0.90 |    0.7 |    1.0 |     0.30 |     0.43 |
| Liquid Oxygen    |    9.79 |    9.95 |    8.6 |   11.2 |     2.60 |     0.30 |
| Grain            |   39.54 |   40.95 |   30.3 |   46.9 |    16.60 |     0.55 |
| Fruit and Veg.   |  105.29 |  107.45 |   74.4 |  131.9 |    57.50 |     0.77 |
| Animal Meat      |  129.35 |  131.55 |   94.5 |  173.2 |    78.70 |     0.83 |
| Synthetic Meat   |   19.90 |   20.25 |   16.8 |   22.0 |     5.20 |     0.31 |
| Liquor           |  397.16 |  403.85 |  341.6 |  440.8 |    99.20 |     0.29 |
| Medicines        |  559.16 |  564.65 |  516.5 |  583.4 |    66.90 |     0.13 |
| Fertilizer       |   15.12 |   15.50 |   12.0 |   17.1 |     5.10 |     0.43 |
| Animal Skins     |  758.52 |  783.15 |  606.8 |  834.7 |   227.90 |     0.38 |
| Live Animals     |  940.01 |  935.50 |  858.1 | 1036.3 |   178.20 |     0.21 |
| Luxury Goods     | 1442.74 | 1494.40 | 1207.6 | 1594.0 |   386.40 |     0.32 |
| Heavy Plastics   |   35.38 |   36.50 |   28.9 |   39.6 |    10.70 |     0.37 |
| Metal Alloys     |   24.00 |   25.45 |   19.7 |   27.3 |     7.60 |     0.39 |
| Precious Metals  | 1703.92 | 1712.80 | 1609.2 | 1746.0 |   136.80 |     0.09 |
| Gem Stones       | 3019.84 | 3000.45 | 2968.9 | 3098.7 |   129.80 |     0.04 |
| Minerals         |    6.91 |    7.00 |    6.0 |    7.6 |     1.60 |     0.27 |
| Hydrogen Fuel    |   10.25 |    9.95 |    9.4 |   11.5 |     2.10 |     0.22 |
| Military Fuel    |   50.08 |   50.20 |   49.1 |   50.6 |     1.50 |     0.03 |
| Hand Weapons     |  494.43 |  503.00 |  429.6 |  512.8 |    83.20 |     0.19 |
| Industrial Parts |  119.58 |  125.65 |   93.7 |  133.7 |    40.00 |     0.43 |
| Computers        |  452.15 |  483.35 |  316.5 |  522.3 |   205.80 |     0.65 |
| Air Processors   |  194.48 |  201.75 |  144.7 |  208.6 |    63.90 |     0.44 |
| Farm Machinery   |   77.91 |   83.20 |   57.5 |   87.9 |    30.40 |     0.53 |
| Robots           |  806.35 |  890.65 |  486.4 |  924.1 |   437.70 |     0.90 |
| Radioactives     |   -4.29 |   -4.30 |   -4.4 |   -4.1 |     0.30 |    -0.07 |
| Rubbish          |   -0.69 |   -0.70 |   -0.7 |   -0.6 |     0.10 |    -0.14 |
| Narcotics        |  631.17 |  632.50 |  617.3 |  646.9 |    29.60 |     0.05 |
| Slaves           | 1013.97 | 1006.75 |  990.0 | 1064.4 |    74.40 |     0.08 |
| Battle Weapons   |  609.66 |  609.10 |  594.0 |  623.3 |    29.30 |     0.05 |
| Nerve Gas        |  816.71 |  824.90 |  776.9 |  832.1 |    55.20 |     0.07 |

(The 90% profit for Robots, was due to me sampling two extremes in Frontier, separated by more than +10 hyperjumps, so not a viable trade route in practice)


### Illegal goods - A side note

As seen in the table above, the variance in price for illegal goods in Frontier is minimal, which is logical, since their main function is to buy them legally in one system, and sell them illegally in another, where there is a x2 multiplier on the price, always assuring a nice 100% profit.


### The core of the problem

So if the relative price difference in both games are similar-ish, what's wrong? Assuming you, dear reader, are too lazy to make it through this wall of text, let me show you an image comparing Pioneer's and Frontier's absolute prices:

![pfioneer](https://user-images.githubusercontent.com/619390/76159154-c711cd80-611d-11ea-9731-c21ad47ec5a8.png)

### The core of the problem - ordered!

To really drive home the message here: let's see the same plot again (just because I know how much @laarmen likes plots), but now ordered on price within each game. It's fairly clear that the absolute prices ranges of Pioneer's commodities are much too narrow:

![sorted](https://user-images.githubusercontent.com/619390/76159190-148e3a80-611e-11ea-8f9b-c47191bb473d.png)


# Changes made

From the plot above we see that we have zero commodities in the price range $300-$3000, even though we're almost 1:1 in commodity names with Frontier. However, unfortunately, we don't have two of the three (legal) commodities that Frontier put in the $1000 - $3000 range, namely we lack _Luxury goods_ and _Gems_. Thus I've boosted the price of _Precious metals_ a bit more than Frontier to fill the gap a bit better.

Below you see the price changes I've made, on the same x-axis scale as previous figures:

![NewPioneer](https://user-images.githubusercontent.com/619390/76160909-6939b180-612e-11ea-842b-3a4f5ededeef.png)

Below are the new base prices (right most column), compared to prices in current master, as well as the corresponding commodities in Frontier and their median prices (sample size N=10).

| Median   | Frontier         | Pioneer              | Old/master | New       |
|----------|------------------|----------------------|------------|-----------|
| 153.85   | Air Processors   | Air Processors       | 20         | 153       |
| 125.58   | Animal Meat      | Animal Meat          | 18         | 125       |
| 513.98   | Animal Skins     |                      |            |           |
| 613.6    | Battle Weapons   | Battle Weapons       | 220        | 613       |
| 470.75   | Computers        | Computers            | 80         | 472       |
|          |                  | Consumer goods       | 140        | 146       |
| 80.03    | Farm Machinery   | Farm Machinery       | 11         | 79        |
| 15.28    | Fertilizer       | Fertilizer           | 4          | 14        |
| 105.1    | Fruit and Veg.   | Fruit & vegetables   | 12         | 105       |
| 3052.15  | Gem Stones       |                      |            |           |
| 40.12    | Grain            | Grain                | 10         | 39        |
| 251.95   | Hand Weapons     | *Small arms*         | 124        | 251       |
| 35.4     | Heavy Plastics   | *Plastics*           | 12         | 35        |
| 10.7     | Hydrogen Fuel    | Hydrogen             | 1          | 10        |
| 121.22   | Industrial Parts | Industrial machinery | 13         | 121       |
| 9.7      | Liquid Oxygen    | Liquid Oxygen        | 1.5        | 9.5       |
| 394.27   | Liquor           | Liquor               | 8          | 384       |
| 452.8    | Live Animals     | Live Animals         | 32         | 452       |
| 1443.25  | Luxury Goods     |                      |            |           |
| 563.1    | Medicines        | Medicines            | 22         | 563       |
| 24.82    | Metal Alloys     | Metal Alloys         | 8          | 24.8      |
|          |                  | Metal ore            | 3          | 13        |
| 49.92    | Military Fuel    | Military Fuel        | 60         | 49        |
| 7.1      | Minerals         | *Carbon ore*         | 5          | 7         |
|          |                  | Mining machinery     | 12         | 312       |
| 632.1    | Narcotics        | Narcotics            | 157        | 632       |
| 822.73   | Nerve Gas        | Nerve Gas            | 265        | 822       |
| 1720.67  | Precious Metals  | Precious Metals      | 180        | 2180      |
| -4.3     | Radioactives     | Radioactives         | -3.5       | -4.4      |
| 815.88   | Robots           | Robots               | 63         | 815       |
| -0.7     | Rubbish          | Rubbish              | -0.1       | -0.7      |
| 1014.83  | Slaves           | Slaves               | 232        | 1014      |
|          |                  | Textiles             | 8.5        | 65        |
| 19.55    | Synthetic Meat   |                      |            |           |
| 0.9      | Water            | Water                | 1.2        | 1.2       |



## Result

So how does this impact the money that can be earned on trade route in a smallish ship? Well, within 20 ly radius, Precious metal can be traded at $327 profit per tonne (16%), for those that can afford to fill the cargo hold. This is comparable in profitability to the Sol-Bernard's star route in Frontier. Similarly, at radius 70 ly, where relative profit approaches 50%, the profit for said commodity is close to $900 per tonne, giving $6300 profit for the starter ship, which is nice for a pilot with no reputation to fly missions, and who doesn't have the equipment yet to engage in combat, or ferrying passenger. More important still, now money making will increase exponentially: the more money you have (to afford expensive products, previously not in pioneer), the more money you make, until one buys a new ship, with larger cargo hold.

![2020-03-08-100946_1600x900_scrot](https://user-images.githubusercontent.com/619390/76160971-fbda5080-612e-11ea-86b0-677758858b0b.png)

![2020-03-08-101104_1600x900_scrot](https://user-images.githubusercontent.com/619390/76160974-ff6dd780-612e-11ea-9927-a4535dcaa6cc.png)


## Future changes / additions

- It would be good to get something like _Luxury goods_ into Pioneer. In Frontier, it's produced by the, posh, faction home worlds. I think _Gems_ sounds a bit out of place for a space game, but something equivalent in the ~$3000 (and above) range, like "plasma coils", "gold", "Adamantium", or something similar. If we find a good icon for something, give me a shout!

- Getting a column with average prices into the commodity market (one could just use the `base_price`) would be very helpful for trading decisions, and I don't think that would be too much "hand holding" the player.

- It would be good if commodity descriptions seen in commodity market actually hinted to the underlying economy mechanics. But since we probably want to re-visit how prices fluctuate from base price, this is best done last.


## Feedback

Please share your thoughts. *BIG* caveat: I haven't playtested this, just attacked it with _P-L-O-T-S-!_. I guess upping Hydrogen back to 10 credits is controversial. I remember someone complaining "starting out trading is too difficult in Pioneer" and the price was dropped from $10 to $1 to mitigate it, but that doesn't in any way address the problem, which I believe to be the one outlined herein.


## Epilogue: Other parts of the economy

Next is to balance reward from missions, and ship equipment, and ship prices.

Now, it looks to me like our equipment prices are mostly in the right magnitude but most of our ships are maybe a factor 2-3 too high in price, compared to Frontier, which hearken back to the time when gamers were expected to have a lot more patience than modern generation ("kid's today, bah!"), to slave away in the game to be able to afford that next shiny ship.

I'll attack the package, passenger, and assassin rewards next (coming weeks, I hope).
