### PR TITLE
Texture Cache Visualizer and Memory Usage Tracker

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AlignAfterOpenBracket: DontAlign
 #AlignConsecutiveDeclarations: false
 #AlignEscapedNewlines: Right
 AlignOperands:   false
-AlignTrailingComments: false
+AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 #AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: true

--- a/autoformat
+++ b/autoformat
@@ -9,13 +9,8 @@ if [ "$?" != 0 ]; then
     read -p "Do you want to automatically apply these changes (y/N)?" apply
     case $apply in
         y|Y)
-			# Get the patch info from the message
-			patch="$(PATCH_MODE=1 ./scripts/clang-format.sh)"
-            MSG="$(cat $patch)"
-            echo "$MSG" | git mailinfo --scissors /dev/null "$patch" &>/dev/null
-            # And apply it to the staged changes.
-            git apply --index "$patch"
-            rm "$patch"
+			# Get the patch info from the message and apply it to the staged changes.
+            PATCH_MODE=1 ./scripts/clang-format.sh | git apply --index -
             ;;
         *) exit 1;;
     esac

--- a/scripts/build-travis.sh
+++ b/scripts/build-travis.sh
@@ -57,7 +57,7 @@ echo "Bundling output..."
 if [ "$BUILD_TYPE" == "mxe" ]; then
     zip -r "release/zip/pioneer-$TRAVIS_TAG-mxe.zip" release/* -x *release/zip*
 else
-    tar -caf "release/zip/pioneer-$TRAVIS_TAG.tar.gz" --exclude release/zip release/*
+    tar -czf "release/zip/pioneer-$TRAVIS_TAG.tar.gz" --exclude=release/zip release/*
 fi
 
 echo "Release finished successfully!"

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -20,12 +20,18 @@ else
     GIT_DIFF_TOOL="git diff-index --cached"
 fi
 
+FILES="$@"
 # Allow manually specifiying the files.
 if [ -z "$FILES" ]; then
     FILES=$($GIT_DIFF_TOOL --no-commit-id --name-only --diff-filter=d -r $RANGE | grep -v contrib/ | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc)$")
 fi
 
-if [ ! $PATCH_MODE ]; then echo -e "Checking files:\n$FILES"; fi
+if [ ! $PATCH_MODE ]; then
+    echo -e "Checking files:"
+    for file in $FILES; do
+        echo -e "\t$file"
+    done
+fi
 
 prefix="static-check-clang-format"
 suffix="$(date +%s)"
@@ -38,7 +44,7 @@ else
 fi
 
 for file in $FILES; do
-    CLANG_MESSAGE=`"$CLANG_FORMAT" -style=file "$file"`
+    CLANG_MESSAGE=$("$CLANG_FORMAT" -style=file "$file")
 
     if [ "$?" = "0" ]; then
         diff $DIFF_COLOR -u "$file" - <<< "$CLANG_MESSAGE" | \
@@ -55,7 +61,8 @@ fi
 
 if [ $PATCH_MODE ]; then
 	# Print the filename of the generated patch.
-	echo "$patch"
+	cat "$patch"
+    rm -f "$patch"
 	exit 1
 else
 	# a patch has been created, notify the user and exit

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -430,7 +430,7 @@ bool GasGiant::AddTextureFaceResult(GasGiantJobs::STextureFaceResult *res)
 	if (bCreateTexture) {
 		// create texture
 		const vector2f texSize(1.0f, 1.0f);
-		const vector2f dataSize(uvDims, uvDims);
+		const vector3f dataSize(uvDims, uvDims, 0.0f);
 		const Graphics::TextureDescriptor texDesc(
 			Graphics::TEXTURE_RGBA_8888,
 			dataSize, texSize, Graphics::LINEAR_CLAMP,
@@ -533,7 +533,7 @@ void GasGiant::GenerateTexture()
 	// scope the small texture generation
 	{
 		const vector2f texSize(1.0f, 1.0f);
-		const vector2f dataSize(s_texture_size_small, s_texture_size_small);
+		const vector3f dataSize(s_texture_size_small, s_texture_size_small, 0.0f);
 		const Graphics::TextureDescriptor texDesc(
 			Graphics::TEXTURE_RGBA_8888,
 			dataSize, texSize, Graphics::LINEAR_CLAMP,
@@ -592,7 +592,7 @@ void GasGiant::GenerateTexture()
 		// use m_surfaceTexture texture?
 		// create texture
 		const vector2f texSize(1.0f, 1.0f);
-		const vector2f dataSize(s_texture_size_gpu[Pi::detail.planets], s_texture_size_gpu[Pi::detail.planets]);
+		const vector3f dataSize(s_texture_size_gpu[Pi::detail.planets], s_texture_size_gpu[Pi::detail.planets], 0.0f);
 		const Graphics::TextureDescriptor texDesc(
 			Graphics::TEXTURE_RGBA_8888,
 			dataSize, texSize, Graphics::LINEAR_CLAMP,

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -227,7 +227,7 @@ void Planet::GenerateRings(Graphics::Renderer *renderer)
 		memset(row, 0, RING_TEXTURE_WIDTH * 4);
 	}
 
-	const vector2f texSize(RING_TEXTURE_WIDTH, RING_TEXTURE_LENGTH);
+	const vector3f texSize(RING_TEXTURE_WIDTH, RING_TEXTURE_LENGTH, 0.0f);
 	const Graphics::TextureDescriptor texDesc(
 		Graphics::TEXTURE_RGBA_8888, texSize, Graphics::LINEAR_REPEAT, true, true, true, 0, Graphics::TEXTURE_2D);
 

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -22,30 +22,30 @@ namespace Graphics {
 
 	Texture *Renderer::GetCachedTexture(const std::string &type, const std::string &name)
 	{
-		TextureCacheMap::iterator i = m_textures.find(TextureCacheKey(type, name));
-		if (i == m_textures.end()) return 0;
+		TextureCacheMap::iterator i = m_textureCache.find(TextureCacheKey(type, name));
+		if (i == m_textureCache.end()) return 0;
 		return (*i).second->Get();
 	}
 
 	void Renderer::AddCachedTexture(const std::string &type, const std::string &name, Texture *texture)
 	{
 		RemoveCachedTexture(type, name);
-		m_textures.insert(std::make_pair(TextureCacheKey(type, name), new RefCountedPtr<Texture>(texture)));
+		m_textureCache.insert(std::make_pair(TextureCacheKey(type, name), new RefCountedPtr<Texture>(texture)));
 	}
 
 	void Renderer::RemoveCachedTexture(const std::string &type, const std::string &name)
 	{
-		TextureCacheMap::iterator i = m_textures.find(TextureCacheKey(type, name));
-		if (i == m_textures.end()) return;
+		TextureCacheMap::iterator i = m_textureCache.find(TextureCacheKey(type, name));
+		if (i == m_textureCache.end()) return;
 		delete (*i).second;
-		m_textures.erase(i);
+		m_textureCache.erase(i);
 	}
 
 	void Renderer::RemoveAllCachedTextures()
 	{
-		for (TextureCacheMap::iterator i = m_textures.begin(); i != m_textures.end(); ++i)
+		for (TextureCacheMap::iterator i = m_textureCache.begin(); i != m_textureCache.end(); ++i)
 			delete (*i).second;
-		m_textures.clear();
+		m_textureCache.clear();
 	}
 
 	void Renderer::SetGrab(const bool grabbed)

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -41,7 +41,13 @@ namespace Graphics {
 	// Renderer base, functions return false if
 	// failed/unsupported
 	class Renderer {
+	private:
+		typedef std::pair<std::string, std::string> TextureCacheKey;
+		typedef std::map<TextureCacheKey, RefCountedPtr<Texture> *> TextureCacheMap;
+
 	public:
+		using TextureCache = TextureCacheMap;
+
 		Renderer(SDL_Window *win, int width, int height);
 		virtual ~Renderer();
 
@@ -135,6 +141,8 @@ namespace Graphics {
 		void RemoveCachedTexture(const std::string &type, const std::string &name);
 		void RemoveAllCachedTextures();
 
+		const TextureCache &GetTextureCache() { return m_textureCache; }
+
 		virtual bool ReloadShaders() = 0;
 
 		// our own matrix stack
@@ -211,9 +219,7 @@ namespace Graphics {
 		virtual void PopState() = 0;
 
 	private:
-		typedef std::pair<std::string, std::string> TextureCacheKey;
-		typedef std::map<TextureCacheKey, RefCountedPtr<Texture> *> TextureCacheMap;
-		TextureCacheMap m_textures;
+		TextureCacheMap m_textureCache;
 	};
 
 } // namespace Graphics

--- a/src/graphics/Stats.cpp
+++ b/src/graphics/Stats.cpp
@@ -32,7 +32,14 @@ namespace Graphics {
 			GetOrCreateCounter("STAT_STARS"),
 			GetOrCreateCounter("STAT_SHIPS"),
 
-			GetOrCreateCounter("STAT_BILLBOARD")
+			GetOrCreateCounter("STAT_BILLBOARD"),
+
+			GetOrCreateCounter("STAT_NUM_TEXTURE2D", false),
+			GetOrCreateCounter("STAT_MEM_TEXTURE2D", false),
+			GetOrCreateCounter("STAT_NUM_TEXTURECUBE", false),
+			GetOrCreateCounter("STAT_MEM_TEXTURECUBE", false),
+			GetOrCreateCounter("STAT_NUM_TEXTUREARRAY2D", false),
+			GetOrCreateCounter("STAT_MEM_TEXTUREARRAY2D", false)
 		};
 	}
 

--- a/src/graphics/Stats.h
+++ b/src/graphics/Stats.h
@@ -44,6 +44,14 @@ namespace Graphics {
 			// scenegraph entries
 			STAT_BILLBOARD,
 
+			// resource utilization stats
+			STAT_NUM_TEXTURE2D,
+			STAT_MEM_TEXTURE2D,
+			STAT_NUM_TEXTURECUBE,
+			STAT_MEM_TEXTURECUBE,
+			STAT_NUM_TEXTUREARRAY2D,
+			STAT_MEM_TEXTUREARRAY2D,
+
 			MAX_STAT
 		};
 
@@ -54,9 +62,14 @@ namespace Graphics {
 		Stats();
 		~Stats() {}
 
-		void AddToStatCount(const StatType type, const Uint32 count) const
+		void AddToStatCount(const StatType type, const uint32_t count) const
 		{
-			CounterAdd(m_counterRefs[type], count);
+			CounterAdd(m_counterRefs.at(type), count);
+		}
+
+		void SetStatCount(const StatType type, const uint32_t count) const
+		{
+			CounterSet(m_counterRefs.at(type), count);
 		}
 
 		void NextFrame();

--- a/src/graphics/Texture.h
+++ b/src/graphics/Texture.h
@@ -128,7 +128,9 @@ namespace Graphics {
 		typedef std::vector<void *> vecDataPtr;
 		virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips = 0) = 0;
 		virtual void SetSampleMode(TextureSampleMode) = 0;
-		virtual void BuildMipmaps() = 0;
+		// Call this function to update the texture's mipmaps.
+		// validMips is the number of mipmaps which already have valid data uploaded, and is mostly for internal use.
+		virtual void BuildMipmaps(const uint32_t validMips = 1) = 0;
 		virtual uint32_t GetTextureID() const = 0;
 
 		virtual void Bind() = 0;

--- a/src/graphics/Texture.h
+++ b/src/graphics/Texture.h
@@ -5,7 +5,9 @@
 #define _TEXTURE_H
 
 #include "RefCounted.h"
+#include <vector>
 #include "vector2.h"
+#include "vector3.h"
 
 namespace Graphics {
 
@@ -35,7 +37,8 @@ namespace Graphics {
 
 	enum TextureType {
 		TEXTURE_2D,
-		TEXTURE_CUBE_MAP
+		TEXTURE_CUBE_MAP,
+		TEXTURE_2D_ARRAY
 	};
 
 	struct TextureCubeData {
@@ -61,7 +64,7 @@ namespace Graphics {
 			type(TEXTURE_2D)
 		{}
 
-		TextureDescriptor(TextureFormat _format, const vector2f &_dataSize, TextureSampleMode _sampleMode, bool _generateMipmaps, bool _allowCompression, bool _useAnisotropicFiltering, unsigned int _numberOfMipMaps, TextureType _textureType) :
+		TextureDescriptor(TextureFormat _format, const vector3f &_dataSize, TextureSampleMode _sampleMode, bool _generateMipmaps, bool _allowCompression, bool _useAnisotropicFiltering, unsigned int _numberOfMipMaps, TextureType _textureType) :
 			format(_format),
 			dataSize(_dataSize),
 			texSize(1.0f),
@@ -73,7 +76,7 @@ namespace Graphics {
 			type(_textureType)
 		{}
 
-		TextureDescriptor(TextureFormat _format, const vector2f &_dataSize, const vector2f &_texSize, TextureSampleMode _sampleMode, bool _generateMipmaps, bool _allowCompression, bool _useAnisotropicFiltering, unsigned int _numberOfMipMaps, TextureType _textureType) :
+		TextureDescriptor(TextureFormat _format, const vector3f &_dataSize, const vector2f &_texSize, TextureSampleMode _sampleMode, bool _generateMipmaps, bool _allowCompression, bool _useAnisotropicFiltering, unsigned int _numberOfMipMaps, TextureType _textureType) :
 			format(_format),
 			dataSize(_dataSize),
 			texSize(_texSize),
@@ -88,7 +91,7 @@ namespace Graphics {
 		vector2f GetOriginalSize() const { return vector2f(dataSize.x * texSize.x, dataSize.y * texSize.y); }
 
 		const TextureFormat format;
-		const vector2f dataSize;
+		const vector3f dataSize;
 		const vector2f texSize;
 		const TextureSampleMode sampleMode;
 		const bool generateMipmaps;
@@ -100,7 +103,7 @@ namespace Graphics {
 		TextureDescriptor &operator=(const TextureDescriptor &o)
 		{
 			const_cast<TextureFormat &>(format) = o.format;
-			const_cast<vector2f &>(dataSize) = o.dataSize;
+			const_cast<vector3f&>(dataSize) = o.dataSize;
 			const_cast<vector2f &>(texSize) = o.texSize;
 			const_cast<TextureSampleMode &>(sampleMode) = o.sampleMode;
 			const_cast<bool &>(generateMipmaps) = o.generateMipmaps;
@@ -116,12 +119,14 @@ namespace Graphics {
 	public:
 		const TextureDescriptor &GetDescriptor() const { return m_descriptor; }
 
-		virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips = 0) = 0;
-		virtual void Update(const void *data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips = 0)
+		virtual void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips = 0) = 0;
+		virtual void Update(const void *data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips = 0)
 		{
 			Update(data, vector2f(0, 0), dataSize, format, numMips);
 		}
-		virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips = 0) = 0;
+		virtual void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips = 0) = 0;
+		typedef std::vector<void *> vecDataPtr;
+		virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips = 0) = 0;
 		virtual void SetSampleMode(TextureSampleMode) = 0;
 		virtual void BuildMipmaps() = 0;
 		virtual uint32_t GetTextureID() const = 0;

--- a/src/graphics/Texture.h
+++ b/src/graphics/Texture.h
@@ -5,9 +5,9 @@
 #define _TEXTURE_H
 
 #include "RefCounted.h"
-#include <vector>
 #include "vector2.h"
 #include "vector3.h"
+#include <vector>
 
 namespace Graphics {
 
@@ -20,7 +20,7 @@ namespace Graphics {
 		//luminance/intensity formats are deprecated in opengl 3+
 		//so we might remove them someday
 		TEXTURE_LUMINANCE_ALPHA_88, //luminance value put into R,G,B components; separate alpha value
-		TEXTURE_INTENSITY_8, //intensity value put into RGBA components
+		TEXTURE_INTENSITY_8,		//intensity value put into RGBA components
 
 		TEXTURE_DXT1, // data is expected to be pre-compressed
 		TEXTURE_DXT5,
@@ -103,7 +103,7 @@ namespace Graphics {
 		TextureDescriptor &operator=(const TextureDescriptor &o)
 		{
 			const_cast<TextureFormat &>(format) = o.format;
-			const_cast<vector3f&>(dataSize) = o.dataSize;
+			const_cast<vector3f &>(dataSize) = o.dataSize;
 			const_cast<vector2f &>(texSize) = o.texSize;
 			const_cast<TextureSampleMode &>(sampleMode) = o.sampleMode;
 			const_cast<bool &>(generateMipmaps) = o.generateMipmaps;
@@ -132,6 +132,7 @@ namespace Graphics {
 		// validMips is the number of mipmaps which already have valid data uploaded, and is mostly for internal use.
 		virtual void BuildMipmaps(const uint32_t validMips = 1) = 0;
 		virtual uint32_t GetTextureID() const = 0;
+		virtual uint32_t GetTextureMemSize() const = 0;
 
 		virtual void Bind() = 0;
 		virtual void Unbind() = 0;

--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -9,8 +9,6 @@
 #include <sstream>
 #include <algorithm>
 
-// XXX SDL2 can all this be replaced with SDL_GL_BindTexture?
-
 namespace Graphics {
 
 	//static
@@ -56,7 +54,7 @@ namespace Graphics {
 		m_prepared(false),
 		m_layers(layers)
 	{
-		assert(!m_filename.empty());
+		assert(!m_filenames.empty());
 	}
 
 	TextureBuilder::~TextureBuilder()

--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -6,6 +6,7 @@
 #include "utils.h"
 #include <SDL_image.h>
 #include <SDL_rwops.h>
+#include <sstream>
 #include <algorithm>
 
 // XXX SDL2 can all this be replaced with SDL_GL_BindTexture?
@@ -24,12 +25,12 @@ namespace Graphics {
 		m_compressTextures(compressTextures),
 		m_anisotropicFiltering(anisoFiltering),
 		m_textureType(TEXTURE_2D),
-		m_prepared(false)
+		m_prepared(false),
+		m_layers(1)
 	{
 	}
 
-	TextureBuilder::TextureBuilder(const std::string &filename, TextureSampleMode sampleMode, bool generateMipmaps, bool potExtend, bool forceRGBA, bool compressTextures, bool anisoFiltering, TextureType textureType) :
-		m_filename(filename),
+	TextureBuilder::TextureBuilder(const std::string &filename, TextureSampleMode sampleMode, bool generateMipmaps, bool potExtend, bool forceRGBA, bool compressTextures, bool anisoFiltering, TextureType textureType, const size_t layers) :
 		m_sampleMode(sampleMode),
 		m_generateMipmaps(generateMipmaps),
 		m_potExtend(potExtend),
@@ -37,7 +38,23 @@ namespace Graphics {
 		m_compressTextures(compressTextures),
 		m_anisotropicFiltering(anisoFiltering),
 		m_textureType(textureType),
-		m_prepared(false)
+		m_prepared(false),
+		m_layers(layers)
+	{
+		m_filenames.push_back(filename);
+	}
+
+	TextureBuilder::TextureBuilder(const std::vector<std::string> &filenames, TextureSampleMode sampleMode, bool generateMipmaps, bool potExtend, bool forceRGBA, bool compressTextures, bool anisoFiltering, TextureType textureType, const size_t layers) :
+		m_filenames(filenames),
+		m_sampleMode(sampleMode),
+		m_generateMipmaps(generateMipmaps),
+		m_potExtend(potExtend),
+		m_forceRGBA(forceRGBA),
+		m_compressTextures(compressTextures),
+		m_anisotropicFiltering(anisoFiltering),
+		m_textureType(textureType),
+		m_prepared(false),
+		m_layers(layers)
 	{
 		assert(!m_filename.empty());
 	}
@@ -114,8 +131,8 @@ namespace Graphics {
 		PROFILE_SCOPED()
 		if (m_prepared) return;
 
-		if (!m_surface && !m_filename.empty()) {
-			std::string filename = m_filename;
+		if (!m_surface && !m_filenames.empty()) {
+			std::string filename = m_filenames.front();
 			std::transform(filename.begin(), filename.end(), filename.begin(), ::tolower);
 			if (ends_with_ci(filename, ".dds")) {
 				LoadDDS();
@@ -174,37 +191,58 @@ namespace Graphics {
 						assert(0);
 					}
 				}
-			} else if (!m_filename.empty()) {
+			} else if (!m_filenames.front().empty()) {
 				// power-of-two check
 				unsigned long width = ceil_pow2(m_surface->w);
 				unsigned long height = ceil_pow2(m_surface->h);
 
 				if (width != virtualWidth || height != virtualHeight)
-					Output("WARNING: texture '%s' is not power-of-two and may not display correctly\n", m_filename.c_str());
+					Output("WARNING: texture '%s' is not power-of-two and may not display correctly\n", m_filenames.front().c_str());
 			}
 		} else {
-			switch (m_dds.GetTextureFormat()) {
-			case PicoDDS::FORMAT_DXT1: targetTextureFormat = TEXTURE_DXT1; break;
-			case PicoDDS::FORMAT_DXT5: targetTextureFormat = TEXTURE_DXT5; break;
-			default:
-				Output("ERROR: DDS texture with invalid format '%s' (only DXT1 and DXT5 are supported)\n", m_filename.c_str());
-				assert(false);
-				return;
-			}
+			if(m_textureType != TEXTURE_2D_ARRAY) {
+				switch (m_dds.GetTextureFormat()) {
+				case PicoDDS::FORMAT_DXT1: targetTextureFormat = TEXTURE_DXT1; break;
+				case PicoDDS::FORMAT_DXT5: targetTextureFormat = TEXTURE_DXT5; break;
+				default:
+					Output("ERROR: DDS texture with invalid format '%s' (only DXT1 and DXT5 are supported)\n", m_filenames.front().c_str());
+					assert(false);
+					return;
+				}
 
-			virtualWidth = actualWidth = m_dds.imgdata_.width;
-			virtualHeight = actualHeight = m_dds.imgdata_.height;
-			numberOfMipMaps = m_dds.imgdata_.numMipMaps;
-			numberOfImages = m_dds.imgdata_.numImages;
-			if (m_textureType == TEXTURE_CUBE_MAP) {
-				// Cube map must be fully defined (6 images) to be used correctly
-				assert(numberOfImages == 6);
+				virtualWidth = actualWidth = m_dds.imgdata_.width;
+				virtualHeight = actualHeight = m_dds.imgdata_.height;
+				numberOfMipMaps = m_dds.imgdata_.numMipMaps;
+				numberOfImages = m_dds.imgdata_.numImages;
+				if (m_textureType == TEXTURE_CUBE_MAP) {
+					// Cube map must be fully defined (6 images) to be used correctly
+					assert(numberOfImages == 6);
+				}
+			} else if(m_textureType == TEXTURE_2D_ARRAY) {
+				assert(m_ddsarray.size() == m_layers);
+				assert(m_layers>0);
+				switch(m_ddsarray[0].GetTextureFormat()) {
+				case PicoDDS::FORMAT_DXT1: targetTextureFormat = TEXTURE_DXT1; break;
+				case PicoDDS::FORMAT_DXT5: targetTextureFormat = TEXTURE_DXT5; break;
+				default:
+					Output("ERROR: DDS texture with invalid format '%s' (only DXT1 and DXT5 are supported)\n", m_filenames.front().c_str());
+					assert(false);
+					return;
+				}
+				for(size_t i=0; i<m_layers; i++) {
+					const PicoDDS::DDSImage &dds = m_ddsarray[0];
+					virtualWidth = actualWidth = dds.imgdata_.width;
+					virtualHeight = actualHeight = dds.imgdata_.height;
+					numberOfMipMaps = dds.imgdata_.numMipMaps;
+					numberOfImages += dds.imgdata_.numImages;
+				}
+				assert((numberOfImages-1) == m_layers);
 			}
 		}
 
 		m_descriptor = TextureDescriptor(
 			targetTextureFormat,
-			vector2f(actualWidth, actualHeight),
+			vector3f(actualWidth,actualHeight,m_layers),
 			vector2f(float(virtualWidth) / float(actualWidth), float(virtualHeight) / float(actualHeight)),
 			m_sampleMode, m_generateMipmaps, m_compressTextures, m_anisotropicFiltering, numberOfMipMaps, m_textureType);
 
@@ -230,12 +268,14 @@ namespace Graphics {
 
 		SDLSurfacePtr s;
 		if (m_textureType == TEXTURE_2D) {
-			s = LoadSurfaceFromFile(m_filename);
+			s = LoadSurfaceFromFile(m_filenames.front());
 			if (!s) {
 				s = LoadSurfaceFromFile("textures/unknown.png");
 			}
 		} else if (m_textureType == TEXTURE_CUBE_MAP) {
-			Output("LoadSurface: %s: cannot load non-DDS cubemaps\n", m_filename.c_str());
+			Output("LoadSurface: %s: cannot load non-DDS cubemaps\n", m_filenames.front().c_str());
+		} else if(m_textureType == TEXTURE_2D_ARRAY) {
+			Output("LoadSurface: %s: cannot load non-DDS texture array files\n", m_filenames.front().c_str());
 		}
 
 		// XXX if we can't load the fallback texture, then what?
@@ -245,11 +285,25 @@ namespace Graphics {
 
 	void TextureBuilder::LoadDDS()
 	{
+		assert(!m_surface);
 		assert(!m_dds.headerdone_);
-		LoadDDSFromFile(m_filename, m_dds);
+		if(m_textureType != TEXTURE_2D_ARRAY)
+		{
+			LoadDDSFromFile(m_filenames.front(), m_dds);
 
-		if (!m_dds.headerdone_) {
-			m_surface = LoadSurfaceFromFile("textures/unknown.png");
+			if (!m_dds.headerdone_) {
+				m_surface = LoadSurfaceFromFile("textures/unknown.png");
+			}
+		} else if(m_textureType == TEXTURE_2D_ARRAY)
+		{
+			m_ddsarray.clear();
+			const size_t layers = m_layers;
+			m_ddsarray.resize(layers);
+
+			for (int i = 0; i < layers; i++)
+			{
+				PiVerify(LoadDDSFromFile(m_filenames[i], m_ddsarray[i]));
+			}
 		}
 		// XXX if we can't load the fallback texture, then what?
 	}
@@ -258,7 +312,7 @@ namespace Graphics {
 	{
 		if (m_surface) {
 			if (texture->GetDescriptor().type == TEXTURE_2D && m_textureType == TEXTURE_2D) {
-				texture->Update(m_surface->pixels, vector2f(m_surface->w, m_surface->h), m_descriptor.format, 0);
+			texture->Update(m_surface->pixels, vector3f(m_surface->w,m_surface->h,0.0f), m_descriptor.format, 0);
 			} else if (texture->GetDescriptor().type == TEXTURE_CUBE_MAP && m_textureType == TEXTURE_CUBE_MAP) {
 				assert(m_cubemap.size() == 6);
 				TextureCubeData tcd;
@@ -269,16 +323,16 @@ namespace Graphics {
 				tcd.negY = m_cubemap[3]->pixels;
 				tcd.posZ = m_cubemap[4]->pixels;
 				tcd.negZ = m_cubemap[5]->pixels;
-				texture->Update(tcd, vector2f(m_cubemap[0]->w, m_cubemap[0]->h), m_descriptor.format, 0);
+			texture->Update(tcd, vector3f(m_cubemap[0]->w, m_cubemap[0]->h,0.0f), m_descriptor.format, 0);
 			} else {
 				// Given texture and current texture don't have the same type!
 				assert(0);
 			}
-		} else {
+		} else if( m_dds.headerdone_ ) {
 			assert(m_dds.headerdone_);
 			assert(m_descriptor.format == TEXTURE_DXT1 || m_descriptor.format == TEXTURE_DXT5);
 			if (texture->GetDescriptor().type == TEXTURE_2D && m_textureType == TEXTURE_2D) {
-				texture->Update(m_dds.imgdata_.imgData, vector2f(m_dds.imgdata_.width, m_dds.imgdata_.height), m_descriptor.format, m_dds.imgdata_.numMipMaps);
+				texture->Update(m_dds.imgdata_.imgData, vector3f(m_dds.imgdata_.width,m_dds.imgdata_.height,0.0f), m_descriptor.format, m_dds.imgdata_.numMipMaps);
 			} else if (texture->GetDescriptor().type == TEXTURE_CUBE_MAP && m_textureType == TEXTURE_CUBE_MAP) {
 				TextureCubeData tcd;
 				// Size in bytes of each cube map face
@@ -290,11 +344,22 @@ namespace Graphics {
 				tcd.negY = static_cast<void *>(m_dds.imgdata_.imgData + (3 * face_size));
 				tcd.posZ = static_cast<void *>(m_dds.imgdata_.imgData + (4 * face_size));
 				tcd.negZ = static_cast<void *>(m_dds.imgdata_.imgData + (5 * face_size));
-				texture->Update(tcd, vector2f(m_dds.imgdata_.width, m_dds.imgdata_.height), m_descriptor.format, m_dds.imgdata_.numMipMaps);
+				texture->Update(tcd, vector3f(m_dds.imgdata_.width, m_dds.imgdata_.height,0.0f), m_descriptor.format, m_dds.imgdata_.numMipMaps);
 			} else {
 				// Given texture and current texture don't have the same type!
 				assert(0);
 			}
+		} else if( !m_ddsarray.empty() ) {
+			// texture array
+			assert(m_textureType == TEXTURE_2D_ARRAY);
+			const TextureDescriptor &desc = texture->GetDescriptor();
+			// virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips = 0) = 0;
+			Texture::vecDataPtr dataPtrs;
+			dataPtrs.reserve(m_layers);
+			for(size_t i=0; i<m_layers; i++) {
+				dataPtrs.push_back( m_ddsarray[i].imgdata_.imgData );
+			}
+			texture->Update(dataPtrs, desc.dataSize, desc.format, desc.numberOfMipMaps);
 		}
 	}
 

--- a/src/graphics/TextureBuilder.h
+++ b/src/graphics/TextureBuilder.h
@@ -16,8 +16,14 @@ namespace Graphics {
 
 	class TextureBuilder {
 	public:
-		TextureBuilder(const SDLSurfacePtr &surface, TextureSampleMode sampleMode = LINEAR_CLAMP, bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true, bool anisoFiltering = true);
-		TextureBuilder(const std::string &filename, TextureSampleMode sampleMode = LINEAR_CLAMP, bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true, bool anisoFiltering = true, TextureType textureType = TEXTURE_2D);
+		TextureBuilder(const SDLSurfacePtr &surface, TextureSampleMode sampleMode = LINEAR_CLAMP,
+			bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true, bool anisoFiltering = true);
+		TextureBuilder(const std::string &filename, TextureSampleMode sampleMode = LINEAR_CLAMP,
+			bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true, bool anisoFiltering = true,
+			TextureType textureType = TEXTURE_2D, const size_t layers = 1);
+		TextureBuilder(const std::vector<std::string> &filenames, TextureSampleMode sampleMode = LINEAR_CLAMP,
+			bool generateMipmaps = false, bool potExtend = false, bool forceRGBA = true, bool compressTextures = true, bool anisoFiltering = true,
+			TextureType textureType = TEXTURE_2D, const size_t layers = 1);
 		~TextureBuilder();
 
 		static void Init();
@@ -51,6 +57,14 @@ namespace Graphics {
 		{
 			return TextureBuilder(filename, LINEAR_CLAMP, true, true, false, true, false, TEXTURE_CUBE_MAP);
 		}
+		static TextureBuilder LookUpTable(const std::string &filename)
+		{
+			return TextureBuilder(filename, NEAREST_CLAMP, false, true, true, false, false);
+		}
+		static TextureBuilder Array(const std::vector<std::string> &filenames, const size_t layers)
+		{
+			return TextureBuilder(filenames, LINEAR_REPEAT, true, true, false, true, true, TEXTURE_2D_ARRAY, layers);
+		}
 
 		const TextureDescriptor &GetDescriptor()
 		{
@@ -60,18 +74,17 @@ namespace Graphics {
 
 		Texture *GetOrCreateTexture(Renderer *r, const std::string &type)
 		{
-			PROFILE_SCOPED()
-			if (m_filename.empty()) {
+			if (m_filenames.empty()) {
 				return CreateTexture(r);
 			}
 			SDL_LockMutex(m_textureLock);
-			Texture *t = r->GetCachedTexture(type, m_filename);
+			Texture *t = r->GetCachedTexture(type, m_filenames.front());
 			if (t) {
 				SDL_UnlockMutex(m_textureLock);
 				return t;
 			}
 			t = CreateTexture(r);
-			r->AddCachedTexture(type, m_filename, t);
+			r->AddCachedTexture(type, m_filenames.front(), t);
 			SDL_UnlockMutex(m_textureLock);
 			return t;
 		}
@@ -84,7 +97,8 @@ namespace Graphics {
 		SDLSurfacePtr m_surface;
 		std::vector<SDLSurfacePtr> m_cubemap;
 		PicoDDS::DDSImage m_dds;
-		std::string m_filename;
+		std::vector<PicoDDS::DDSImage> m_ddsarray;
+		std::vector<std::string> m_filenames;
 
 		TextureSampleMode m_sampleMode;
 		bool m_generateMipmaps;
@@ -94,6 +108,7 @@ namespace Graphics {
 		bool m_compressTextures;
 		bool m_anisotropicFiltering;
 		TextureType m_textureType;
+		size_t m_layers;
 
 		TextureDescriptor m_descriptor;
 

--- a/src/graphics/dummy/TextureDummy.h
+++ b/src/graphics/dummy/TextureDummy.h
@@ -18,7 +18,7 @@ namespace Graphics {
 		void Unbind() override {}
 
 		virtual void SetSampleMode(TextureSampleMode) override {}
-		virtual void BuildMipmaps() override {}
+		virtual void BuildMipmaps(const uint32_t) override {}
 		virtual uint32_t GetTextureID() const override final { return 0U; }
 
 	private:

--- a/src/graphics/dummy/TextureDummy.h
+++ b/src/graphics/dummy/TextureDummy.h
@@ -10,8 +10,9 @@ namespace Graphics {
 
 	class TextureDummy : public Texture {
 	public:
-		virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override {}
-		virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override {}
+		virtual void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override  final {}
+		virtual void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override  final {}
+		virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips) override final {}
 
 		void Bind() override {}
 		void Unbind() override {}

--- a/src/graphics/dummy/TextureDummy.h
+++ b/src/graphics/dummy/TextureDummy.h
@@ -10,8 +10,8 @@ namespace Graphics {
 
 	class TextureDummy : public Texture {
 	public:
-		virtual void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override  final {}
-		virtual void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override  final {}
+		virtual void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final {}
+		virtual void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final {}
 		virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips) override final {}
 
 		void Bind() override {}
@@ -20,6 +20,7 @@ namespace Graphics {
 		virtual void SetSampleMode(TextureSampleMode) override {}
 		virtual void BuildMipmaps(const uint32_t) override {}
 		virtual uint32_t GetTextureID() const override final { return 0U; }
+		uint32_t GetTextureMemSize() const final { return 0U; }
 
 	private:
 		friend class RendererDummy;

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -1073,7 +1073,7 @@ namespace Graphics {
 		if (desc.colorFormat != TEXTURE_NONE) {
 			Graphics::TextureDescriptor cdesc(
 				desc.colorFormat,
-				vector2f(desc.width, desc.height),
+				vector3f(desc.width, desc.height, 0.0f),
 				vector2f(desc.width, desc.height),
 				LINEAR_CLAMP,
 				false,
@@ -1087,7 +1087,7 @@ namespace Graphics {
 			if (desc.allowDepthTexture) {
 				Graphics::TextureDescriptor ddesc(
 					TEXTURE_DEPTH,
-					vector2f(desc.width, desc.height),
+					vector3f(desc.width, desc.height, 0.0f),
 					vector2f(desc.width, desc.height),
 					LINEAR_CLAMP,
 					false,

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -5,6 +5,7 @@
 #include "GLDebug.h"
 #include "OS.h"
 #include "Program.h"
+#include "RefCounted.h"
 #include "RenderStateGL.h"
 #include "RenderTargetGL.h"
 #include "StringF.h"
@@ -416,6 +417,43 @@ namespace Graphics {
 
 	bool RendererOGL::EndFrame()
 	{
+		uint32_t used_tex2d = 0;
+		uint32_t used_texCube = 0;
+		uint32_t used_texArray2d = 0;
+		uint32_t num_tex2d = 0;
+		uint32_t num_texCube = 0;
+		uint32_t num_texArray2d = 0;
+
+		for (const auto &pair : GetTextureCache()) {
+			auto *texture = pair.second->Get();
+
+			uint32_t size = texture->GetTextureMemSize();
+			switch (texture->GetDescriptor().type) {
+			default:
+				assert(0);
+			case TextureType::TEXTURE_2D:
+				used_tex2d += size;
+				num_tex2d++;
+				break;
+			case TextureType::TEXTURE_CUBE_MAP:
+				used_texCube += size;
+				num_texCube++;
+				break;
+			case TextureType::TEXTURE_2D_ARRAY:
+				used_texArray2d += size;
+				num_texArray2d++;
+				break;
+			}
+		}
+
+		auto &stat = GetStats();
+		stat.SetStatCount(Stats::STAT_NUM_TEXTURE2D, num_tex2d);
+		stat.SetStatCount(Stats::STAT_MEM_TEXTURE2D, used_tex2d);
+		stat.SetStatCount(Stats::STAT_NUM_TEXTUREARRAY2D, num_texArray2d);
+		stat.SetStatCount(Stats::STAT_MEM_TEXTUREARRAY2D, used_texArray2d);
+		stat.SetStatCount(Stats::STAT_NUM_TEXTURECUBE, num_texCube);
+		stat.SetStatCount(Stats::STAT_MEM_TEXTURECUBE, used_texCube);
+
 		return true;
 	}
 

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -193,8 +193,8 @@ namespace Graphics {
 				break;
 
 			case GL_TEXTURE_2D_ARRAY:
-				if(!IsCompressed(descriptor.format)) {
-					if(descriptor.generateMipmaps) {
+				if (!IsCompressed(descriptor.format)) {
+					if (descriptor.generateMipmaps) {
 						glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, 0);
 					}
 					RendererOGL::CheckErrors();
@@ -214,7 +214,7 @@ namespace Graphics {
 					const size_t Layers = descriptor.dataSize.z;
 
 					GLint maxMip = 0;
-					for( unsigned int i=0; i < descriptor.numberOfMipMaps; ++i ) {
+					for (unsigned int i = 0; i < descriptor.numberOfMipMaps; ++i) {
 						maxMip = i;
 						size_t bufSize = ((Width + 3) / 4) * ((Height + 3) / 4) * GetMinSize(descriptor.format);
 						glCompressedTexImage3D(GL_TEXTURE_2D_ARRAY, i, GLInternalFormat(descriptor.format), Width, Height, Layers, 0, bufSize * Layers, nullptr);
@@ -223,7 +223,7 @@ namespace Graphics {
 						Width /= 2;
 						Height /= 2;
 
-						if( !Width || !Height )
+						if (!Width || !Height)
 							break;
 					}
 					glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, maxMip);
@@ -394,48 +394,48 @@ namespace Graphics {
 			assert(Layers == data.size());
 
 			if (!IsCompressed(format)) {
-				for(size_t i = 0; i < Layers; i++) {
+				for (size_t i = 0; i < Layers; i++) {
 					glTexSubImage3D(
-						GL_TEXTURE_2D_ARRAY,		//	GLenum target,
-						0, 							//	GLint level, // mip
-						0, 							//	GLint xoffset,
-						0, 							//	GLint yoffset,
-						i, 							//	GLint zoffset,
-						dataSize.x, 				//	GLsizei width,
-						dataSize.y, 				//	GLsizei height,
-						1,							//	GLsizei depth,
-						GLImageFormat(format), 		//	GLenum format,
-						GLImageType(format), 		//	GLenum type,
-						data[i]);					//	const GLvoid * data);
+						GL_TEXTURE_2D_ARRAY,   //	GLenum target,
+						0,					   //	GLint level, // mip
+						0,					   //	GLint xoffset,
+						0,					   //	GLint yoffset,
+						i,					   //	GLint zoffset,
+						dataSize.x,			   //	GLsizei width,
+						dataSize.y,			   //	GLsizei height,
+						1,					   //	GLsizei depth,
+						GLImageFormat(format), //	GLenum format,
+						GLImageType(format),   //	GLenum type,
+						data[i]);			   //	const GLvoid * data);
 				}
 				RendererOGL::CheckErrors();
 			} else {
 				const GLint oglInternalFormat = GLImageFormat(format);
-				for(size_t ilayer = 0; ilayer < Layers; ilayer++) {
+				for (size_t ilayer = 0; ilayer < Layers; ilayer++) {
 					size_t Offset = 0;
 					size_t Width = dataSize.x;
 					size_t Height = dataSize.y;
 
-					const unsigned char *pData = static_cast<const unsigned char*>(data[ilayer]);
-					for( unsigned int i = 0; i < numMips; ++i ) {
+					const unsigned char *pData = static_cast<const unsigned char *>(data[ilayer]);
+					for (unsigned int i = 0; i < numMips; ++i) {
 						size_t bufSize = ((Width + 3) / 4) * ((Height + 3) / 4) * GetMinSize(format);
 						glCompressedTexSubImage3D(
-							m_target,				//	GLenum  		target,
-							i, 						//	GLint			level,
-							0, 						//	GLint			xoffset,
-							0, 						//	GLint			yoffset,
-							ilayer,					//	GLint			zoffset,
-							Width, 					//	GLsizei  		width,
-							Height, 				//	GLsizei  		height,
-							1,						//	GLsizei  		depth,
-							oglInternalFormat, 		//	GLenum  		format,
-							bufSize, 				//	GLsizei  		imageSize,
-							&pData[Offset]);		//	const GLvoid *  data);
+							m_target,		   //	GLenum  		target,
+							i,				   //	GLint			level,
+							0,				   //	GLint			xoffset,
+							0,				   //	GLint			yoffset,
+							ilayer,			   //	GLint			zoffset,
+							Width,			   //	GLsizei  		width,
+							Height,			   //	GLsizei  		height,
+							1,				   //	GLsizei  		depth,
+							oglInternalFormat, //	GLenum  		format,
+							bufSize,		   //	GLsizei  		imageSize,
+							&pData[Offset]);   //	const GLvoid *  data);
 						Offset += bufSize;
 						Width /= 2;
 						Height /= 2;
 
-						if( !Width || !Height )
+						if (!Width || !Height)
 							break;
 					}
 					RendererOGL::CheckErrors();

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -84,7 +84,8 @@ namespace Graphics {
 
 		TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering) :
 			Texture(descriptor),
-			m_useAnisoFiltering(useAnisoFiltering && descriptor.useAnisotropicFiltering)
+			m_useAnisoFiltering(useAnisoFiltering && descriptor.useAnisotropicFiltering),
+			m_allocSize(0)
 		{
 			PROFILE_SCOPED()
 			m_target = GLTextureType(descriptor.type);
@@ -124,6 +125,7 @@ namespace Graphics {
 
 						Width /= 2;
 						Height /= 2;
+						m_allocSize += bufSize;
 					}
 					glTexParameteri(m_target, GL_TEXTURE_MAX_LEVEL, maxMip);
 					CHECKERRORS();
@@ -183,6 +185,7 @@ namespace Graphics {
 						glCompressedTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, i, GLInternalFormat(descriptor.format), Width, Height, 0, bufSize, 0);
 						Width /= 2;
 						Height /= 2;
+						m_allocSize += bufSize * 6;
 
 						if (!Width || !Height)
 							break;
@@ -222,6 +225,7 @@ namespace Graphics {
 
 						Width /= 2;
 						Height /= 2;
+						m_allocSize += bufSize * Layers;
 
 						if (!Width || !Height)
 							break;

--- a/src/graphics/opengl/TextureGL.h
+++ b/src/graphics/opengl/TextureGL.h
@@ -22,7 +22,7 @@ namespace Graphics {
 			virtual void Unbind() override final;
 
 			virtual void SetSampleMode(TextureSampleMode) override final;
-			virtual void BuildMipmaps() override final;
+			virtual void BuildMipmaps(const uint32_t validMips = 1) override final;
 			virtual uint32_t GetTextureID() const override final
 			{
 				assert(sizeof(uint32_t) == sizeof(GLuint));

--- a/src/graphics/opengl/TextureGL.h
+++ b/src/graphics/opengl/TextureGL.h
@@ -11,8 +11,9 @@ namespace Graphics {
 	namespace OGL {
 		class TextureGL : public Texture {
 		public:
-			virtual void Update(const void *data, const vector2f &pos, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override final;
-			virtual void Update(const TextureCubeData &data, const vector2f &dataSize, TextureFormat format, const unsigned int numMips) override final;
+			virtual void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final;
+			virtual void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final;
+			virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips) override final;
 
 			TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering);
 			virtual ~TextureGL();

--- a/src/graphics/opengl/TextureGL.h
+++ b/src/graphics/opengl/TextureGL.h
@@ -29,9 +29,12 @@ namespace Graphics {
 				return m_texture;
 			}
 
+			uint32_t GetTextureMemSize() const final { return m_allocSize; }
+
 		private:
 			GLenum m_target;
 			GLuint m_texture;
+			uint32_t m_allocSize;
 			const bool m_useAnisoFiltering;
 		};
 	} // namespace OGL

--- a/src/pigui/Image.cpp
+++ b/src/pigui/Image.cpp
@@ -9,7 +9,7 @@ namespace PiGUI {
 
 	Image::Image(const std::string &filename)
 	{
-		m_texture.Reset(Graphics::TextureBuilder::Model(filename).GetOrCreateTexture(Pi::renderer, "model"));
+		m_texture.Reset(Graphics::TextureBuilder::UI(filename).GetOrCreateTexture(Pi::renderer, "ui"));
 	}
 
 	Uint32 Image::GetId()
@@ -20,7 +20,7 @@ namespace PiGUI {
 	vector2f Image::GetSize()
 	{
 		auto size = m_texture->GetDescriptor().dataSize;
-		return vector2f(size.x, size.y);
+		return vector2f(size.x, size.y) * GetUv();
 	}
 
 	vector2f Image::GetUv()

--- a/src/pigui/Image.cpp
+++ b/src/pigui/Image.cpp
@@ -19,7 +19,8 @@ namespace PiGUI {
 
 	vector2f Image::GetSize()
 	{
-		return m_texture->GetDescriptor().dataSize;
+		auto size = m_texture->GetDescriptor().dataSize;
+		return vector2f(size.x, size.y);
 	}
 
 	vector2f Image::GetUv()

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -5,6 +5,7 @@
 #include "Pi.h"
 #include "graphics/Renderer.h"
 #include "graphics/Stats.h"
+#include "graphics/Texture.h"
 #include "lua/Lua.h"
 #include "lua/LuaManager.h"
 #include "text/TextureFont.h"
@@ -21,6 +22,27 @@
 #endif
 
 using namespace PiGUI;
+
+struct PerfInfo::ImGuiState {
+	bool perfWindowOpen = true;
+	bool updatePause;
+
+	bool textureCacheViewerOpen;
+
+	std::map<std::string, std::vector<std::string>> indirectionMap;
+
+	bool hasSelectedTexture = false;
+	std::pair<std::string, std::string> selectedTexture;
+};
+
+PerfInfo::PerfInfo() :
+	m_state(new ImGuiState({}))
+{}
+
+PerfInfo::~PerfInfo()
+{
+	delete m_state;
+}
 
 #define ignoreLine(f) f.ignore(std::numeric_limits<std::streamsize>::max(), '\n')
 static PerfInfo::MemoryInfo GetMemoryInfo()
@@ -66,7 +88,7 @@ static PerfInfo::MemoryInfo GetMemoryInfo()
 void PerfInfo::Update(float deltaTime, float physTime)
 {
 	// Don't accumulate new frames when performance data is paused.
-	if (m_updatePause)
+	if (m_state->updatePause)
 		return;
 
 	// Drop the oldest frame, make room for the new frame.
@@ -106,7 +128,37 @@ void PerfInfo::UpdateFrameInfo(int fS, int pfS)
 	process_mem = GetMemoryInfo();
 }
 
+void PerfInfo::SetUpdatePause(bool pause)
+{
+	m_state->updatePause = pause;
+}
+
+ImTextureID GetImTextureID(const Graphics::Texture *tex)
+{
+	return reinterpret_cast<ImTextureID>(tex->GetTextureID() | 0UL);
+}
+
+namespace ImGui {
+	IMGUI_API void Value(const char *prefix, const std::string &str)
+	{
+		ImGui::TextWrapped("%s: %s", prefix, str.c_str());
+	}
+} // namespace ImGui
+
 void PerfInfo::Draw()
+{
+	if (m_state->perfWindowOpen)
+		DrawPerfWindow();
+
+	if (m_state->textureCacheViewerOpen)
+		DrawTextureCache();
+
+	if (m_state->hasSelectedTexture &&
+		Pi::renderer->GetCachedTexture(m_state->selectedTexture.first, m_state->selectedTexture.second))
+		DrawTextureInspector();
+}
+
+void PerfInfo::DrawPerfWindow()
 {
 	const Graphics::Stats::TFrameData &stats = Pi::renderer->GetStats().FrameStatsPrevious();
 	const Uint32 numDrawCalls = stats.m_stats[Graphics::Stats::STAT_DRAWCALL];
@@ -125,6 +177,17 @@ void PerfInfo::Draw()
 	const Uint32 numDrawShips = stats.m_stats[Graphics::Stats::STAT_SHIPS];
 	const Uint32 numDrawBillBoards = stats.m_stats[Graphics::Stats::STAT_BILLBOARD];
 
+	const Uint32 numTex2ds = stats.m_stats[Graphics::Stats::STAT_NUM_TEXTURE2D];
+	const Uint32 tex2dMemUsage = stats.m_stats[Graphics::Stats::STAT_MEM_TEXTURE2D];
+	const Uint32 numTexCubemaps = stats.m_stats[Graphics::Stats::STAT_NUM_TEXTURECUBE];
+	const Uint32 texCubeMemUsage = stats.m_stats[Graphics::Stats::STAT_MEM_TEXTURECUBE];
+	const Uint32 numTexArray2ds = stats.m_stats[Graphics::Stats::STAT_NUM_TEXTUREARRAY2D];
+	const Uint32 texArray2dMemUsage = stats.m_stats[Graphics::Stats::STAT_MEM_TEXTUREARRAY2D];
+	const Uint32 numCachedTextures = numTex2ds + numTexCubemaps + numTexArray2ds;
+	const Uint32 cachedTextureMemUsage = tex2dMemUsage + texCubeMemUsage + texArray2dMemUsage;
+
+	const double scale_MB = pow(1024, 2.0);
+
 	auto &io = ImGui::GetIO();
 
 	// ImGui::SetNextWindowFocus();
@@ -133,13 +196,13 @@ void PerfInfo::Draw()
 		ImGui::Text("%.1f fps (%.1f ms) %.1f physics ups (%.1f ms/u)", framesThisSecond, frameTimeAverage, physFramesThisSecond, physFrameTimeAverage);
 		ImGui::PlotLines("Frame Time (ms)", m_fpsGraph.data(), m_fpsGraph.size(), 0, nullptr, 0.0, 33.0, { 0, 80 });
 		ImGui::PlotLines("Update Time (ms)", m_physFpsGraph.data(), m_physFpsGraph.size(), 0, nullptr, 0.0, 10.0, { 0, 40 });
-		if (ImGui::Button(m_updatePause ? "Unpause" : "Pause")) {
-			SetUpdatePause(!m_updatePause);
+		if (ImGui::Button(m_state->updatePause ? "Unpause" : "Pause")) {
+			SetUpdatePause(!m_state->updatePause);
 		}
 
 		if (process_mem.currentMemSize)
 			ImGui::Text("%.1f MB process memory usage (%.1f MB peak)", (info.currentMemSize * 1e-3), (info.peakMemSize * 1e-3));
-		ImGui::Text("%.3f MB Lua memory usage", double(lua_mem) / pow(1024.0, 2));
+		ImGui::Text("%.3f MB Lua memory usage", double(lua_mem) / scale_MB);
 		ImGui::Spacing();
 
 		ImGui::Text("Renderer:");
@@ -153,6 +216,13 @@ void PerfInfo::Draw()
 			numDrawAtmospheres, numDrawPlanets, numDrawGasGiants, numDrawStars, numDrawShips);
 		ImGui::Text("%u Buffers Created", numBuffersCreated);
 		ImGui::Spacing();
+		ImGui::Text("%u cached textures, using %.3f MB VRAM", numCachedTextures, double(cachedTextureMemUsage) / scale_MB);
+		if (ImGui::Button("Open Texture Cache Visualizer"))
+			m_state->textureCacheViewerOpen = true;
+		ImGui::Text("%u Texture2D in cache (%.3f MB)", numTex2ds, double(tex2dMemUsage) / scale_MB);
+		ImGui::Text("%u Cubemaps in cache (%.3f MB)", numTexCubemaps, double(texCubeMemUsage) / scale_MB);
+		ImGui::Text("%u TextureArray2D in cache (%.3f MB)", numTexArray2ds, double(texArray2dMemUsage) / scale_MB);
+		ImGui::Spacing();
 
 		ImGui::Text("ImGui stats:");
 		ImGui::Text("%d verts, %d tris", io.MetricsRenderVertices, io.MetricsRenderIndices / 3);
@@ -162,4 +232,97 @@ void PerfInfo::Draw()
 		ImGui::Spacing();
 	}
 	ImGui::End();
+}
+
+bool DrawTexture(PerfInfo::ImGuiState *m_state, const Graphics::Texture *tex)
+{
+	ImGui::BeginGroup();
+	auto pos0 = ImGui::GetCursorPos();
+	ImGui::Image(GetImTextureID(tex), { 128, 128 });
+	auto pos1 = ImGui::GetCursorPos();
+	ImGui::SetCursorPos(pos0);
+
+	auto texSize = tex->GetDescriptor().dataSize;
+	ImGui::Text("%ux%u", uint32_t(texSize.x), uint32_t(texSize.y));
+	ImGui::Text("%.1f KB", double(tex->GetTextureMemSize()) / 1024.0);
+
+	ImGui::SetCursorPos(pos1);
+	ImGui::EndGroup();
+	return ImGui::IsItemClicked();
+}
+
+void PerfInfo::DrawTextureCache()
+{
+	if (ImGui::Begin("Texture Cache Viewer", &m_state->textureCacheViewerOpen, ImGuiWindowFlags_NoNav)) {
+		for (auto &v : m_state->indirectionMap)
+			// purge any textures which may have changed / evicted, but don't resize the vector
+			// in the average case, this will simply re-fill the vector each frame, a fairly trivial operation.
+			v.second.clear();
+
+		for (const auto &t : Pi::renderer->GetTextureCache()) {
+			const auto &key = t.first;
+			if (t.second->Get()->GetDescriptor().type != Graphics::TEXTURE_2D)
+				continue;
+
+			m_state->indirectionMap[key.first].push_back(key.second);
+		}
+
+		if (ImGui::BeginTabBar("Texture List")) {
+			const int item_width = 128 + ImGui::GetStyle().ItemSpacing.x;
+			for (const auto &t : m_state->indirectionMap) {
+				if (!ImGui::BeginTabItem(t.first.c_str()))
+					continue;
+
+				if (ImGui::BeginChild("##Texture List Scroll")) {
+					const int num_columns = std::max(int(ImGui::GetWindowContentRegionWidth()) / item_width, 1);
+					ImGui::Columns(num_columns);
+					if (num_columns > 1) {
+						for (size_t idx = 1; idx < num_columns; idx++)
+							ImGui::SetColumnWidth(idx, item_width);
+					}
+
+					for (const std::string &name : t.second) {
+						const auto *ptr = Pi::renderer->GetCachedTexture(t.first, name);
+						if (DrawTexture(m_state, ptr)) {
+							m_state->selectedTexture = { t.first, name };
+							m_state->hasSelectedTexture = true;
+						}
+
+						if (num_columns > 1)
+							ImGui::NextColumn();
+					}
+				}
+				ImGui::EndChild();
+
+				ImGui::EndTabItem();
+			}
+
+			ImGui::EndTabBar();
+		}
+	}
+	ImGui::End();
+}
+
+void PerfInfo::DrawTextureInspector()
+{
+	const auto &selectedTex = m_state->selectedTexture;
+	const auto *tex = Pi::renderer->GetCachedTexture(selectedTex.first, selectedTex.second);
+	if (tex != nullptr && m_state->hasSelectedTexture) {
+		ImGui::SetNextWindowSize({ 300, 400 }, ImGuiCond_Appearing);
+		std::string window_name = selectedTex.second + "###Texture Inspector";
+		if (ImGui::Begin(window_name.c_str(), &m_state->hasSelectedTexture)) {
+			const Graphics::TextureDescriptor &descriptor = tex->GetDescriptor();
+			ImGui::Image(GetImTextureID(tex), { 256, 256 });
+			ImGui::Text("Dimensions: %ux%u", uint32_t(descriptor.dataSize.x), uint32_t(descriptor.dataSize.y));
+			ImGui::Value("Mipmap Count", tex->GetDescriptor().numberOfMipMaps);
+			ImGui::Value("VRAM Size", tex->GetTextureMemSize());
+
+			ImGui::Spacing();
+			ImGui::Value("Cache Bucket", selectedTex.first);
+			ImGui::Value("Cache ID", selectedTex.second);
+			ImGui::Value("TextureID", tex->GetTextureID());
+			ImGui::Value("RefCount", tex->GetRefCount());
+		}
+		ImGui::End();
+	}
 }

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -291,6 +291,9 @@ void PerfInfo::DrawTextureCache()
 							m_state->hasSelectedTexture = true;
 						}
 
+						if (ImGui::IsItemHovered())
+							ImGui::SetTooltip("%s", name.c_str());
+
 						if (num_columns > 1)
 							ImGui::NextColumn();
 					}

--- a/src/pigui/PerfInfo.h
+++ b/src/pigui/PerfInfo.h
@@ -3,17 +3,23 @@
 
 #pragma once
 
+#include "RefCounted.h"
 #include <array>
+#include <memory>
 
 namespace PiGUI {
 
 	class PerfInfo {
 	public:
+		PerfInfo();
+		~PerfInfo();
+
 		// Information about the current process memory usage in KB.
 		struct MemoryInfo {
 			size_t currentMemSize;
 			size_t peakMemSize;
 		};
+		struct ImGuiState;
 
 		void Draw();
 
@@ -21,9 +27,14 @@ namespace PiGUI {
 		void Update(float frameTime, float physTime);
 		void UpdateFrameInfo(int framesThisSecond, int physFramesThisSecond);
 
-		void SetUpdatePause(bool pause) { m_updatePause = pause; }
+		void SetShowDebugInfo(bool open);
+		void SetUpdatePause(bool pause);
 
 	private:
+		void DrawPerfWindow();
+		void DrawTextureCache();
+		void DrawTextureInspector();
+
 		static const int NUM_FRAMES = 60;
 		std::array<float, NUM_FRAMES> m_fpsGraph;
 		std::array<float, NUM_FRAMES> m_physFpsGraph;
@@ -39,7 +50,7 @@ namespace PiGUI {
 		float framesThisSecond;
 		float physFramesThisSecond;
 
-		bool m_updatePause;
+		ImGuiState *m_state;
 	};
 
 } // namespace PiGUI

--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -356,7 +356,7 @@ void *PiGui::makeTexture(unsigned char *pixels, int width, int height)
 	// Texture descriptor defines the size, type.
 	// Gone for LINEAR_CLAMP here and RGBA like the original code
 	const vector2f texSize(1.0f, 1.0f);
-	const vector2f dataSize(width, height);
+	const vector3f dataSize(width, height, 0.0f);
 	const Graphics::TextureDescriptor texDesc(Graphics::TEXTURE_RGBA_8888,
 		dataSize, texSize, Graphics::LINEAR_CLAMP,
 		false, false, false, 0, Graphics::TEXTURE_2D);

--- a/src/scenegraph/ColorMap.cpp
+++ b/src/scenegraph/ColorMap.cpp
@@ -35,7 +35,7 @@ namespace SceneGraph {
 		AddColor(w, a, colors);
 		AddColor(w, b, colors);
 		AddColor(w, c, colors);
-		vector2f size(colors.size() / 3, 1.f);
+		const vector3f size(colors.size() / 3, 1.f, 0.0f);
 
 		const Graphics::TextureFormat format = Graphics::TEXTURE_RGB_888;
 

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -527,7 +527,7 @@ namespace Text {
 			glyph.texWidth = float(glyph.width) / float(ATLAS_SIZE);
 			glyph.texHeight = float(glyph.height) / float(ATLAS_SIZE);
 
-			m_texture->Update(&m_buf[0], vector2f(m_atlasU, m_atlasV), vector2f(glyph.width, glyph.height), m_texFormat);
+			m_texture->Update(&m_buf[0], vector2f(m_atlasU, m_atlasV), vector3f(glyph.width, glyph.height, 0.0f), m_texFormat);
 
 			m_atlasU += bmStrokeGlyph->bitmap.width;
 
@@ -566,7 +566,7 @@ namespace Text {
 			glyph.texWidth = float(glyph.width) / float(ATLAS_SIZE);
 			glyph.texHeight = float(glyph.height) / float(ATLAS_SIZE);
 
-			m_texture->Update(&m_buf[0], vector2f(m_atlasU, m_atlasV), vector2f(glyph.width, glyph.height), m_texFormat);
+			m_texture->Update(&m_buf[0], vector2f(m_atlasU, m_atlasV), vector3f(glyph.width, glyph.height, 0.0f), m_texFormat);
 
 			m_atlasU += glyph.width;
 		}
@@ -624,13 +624,13 @@ namespace Text {
 		desc.vertexColors = true; //to allow per-character colors
 		desc.textures = 1;
 		m_mat.reset(m_renderer->CreateMaterial(desc));
-		Graphics::TextureDescriptor textureDescriptor(m_texFormat, vector2f(ATLAS_SIZE), Graphics::NEAREST_CLAMP, false, false, false, 0, Graphics::TEXTURE_2D);
+		Graphics::TextureDescriptor textureDescriptor(m_texFormat, vector3f(ATLAS_SIZE, ATLAS_SIZE, 0.0f), Graphics::NEAREST_CLAMP, false, false, false, 0, Graphics::TEXTURE_2D);
 		m_texture.Reset(m_renderer->CreateTexture(textureDescriptor));
 		{
 			const size_t sz = m_bpp * ATLAS_SIZE * ATLAS_SIZE;
 			char *buf = static_cast<char *>(malloc(sz));
 			memset(buf, 0, sz);
-			m_texture->Update(buf, vector2f(0.0f, 0.0f), vector2f(ATLAS_SIZE, ATLAS_SIZE), m_texFormat);
+			m_texture->Update(buf, vector2f(0.0f, 0.0f), vector3f(ATLAS_SIZE, ATLAS_SIZE, 0.0f), m_texFormat);
 			free(buf);
 		}
 		m_mat->texture0 = m_texture.Get();

--- a/src/vector2.h
+++ b/src/vector2.h
@@ -84,6 +84,7 @@ public:
 
 	friend vector2 operator*(const vector2 &v, const T &a) { return vector2(v.x * a, v.y * a); }
 	friend vector2 operator*(const T &a, const vector2 &v) { return v * a; }
+	friend vector2 operator*(const vector2 &va, const vector2 &vb) { return vector2(va.x * vb.x, va.y * vb.y); }
 	friend vector2 operator/(const vector2 &v, const T &a) { return vector2(v.x / a, v.y / a); }
 	friend bool operator<(const vector2 &va, const vector2 &vb) { return va.LengthSqr() < vb.LengthSqr(); }
 
@@ -106,7 +107,7 @@ public:
 	}
 	vector2 Rotate(T alpha) // Rotate around center
 	{
-		return vector2( x * cos(alpha) - y * sin(alpha), y * cos(alpha) + x * sin(alpha));
+		return vector2(x * cos(alpha) - y * sin(alpha), y * cos(alpha) + x * sin(alpha));
 	}
 
 	void Print() const { printf("v(%f,%f)\n", x, y); }


### PR DESCRIPTION
I've implemented a visualizer for our texture caching system that allows inspecting each of the textures stored in the cache (currently only works on Texture2Ds), as well as added performance tracking for memory usage and number of cached textures.

![Screenshot from 2020-03-13 15-02-39](https://user-images.githubusercontent.com/4218491/76652009-10a65200-653c-11ea-9099-d7a4fbc995e1.png)


I eventually want to separate the texture cache into a two-stage indirect cache instead of lumping everything into the same `std::map`; among other reasons, I'd like to remove the static mutex in `TextureBuilder` and instead lock on the specific texture cache bucket we're assigning the texture to.

I've also updated our clang-format script to avoid leaking the generated patch file, and make it easier to manually run the formatter.

Most of this PR has been developed on the terrain-texturing branch, but I've endeavored to cut out everything not relevant to the texture cache changes.