### PR TITLE
Move clang-format to Github Actions

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,40 @@
+# Check all pull requests against the clang-format rules.
+
+name: Clang Format
+
+# Controls when the action will run.
+# Run clang-format checks on all pull-requests
+on:
+  pull_request:
+    paths:
+    - 'src/**.cpp'
+    - 'src/**.h'
+
+    paths-ignore:
+    - 'contrib/'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  clang-format-check:
+    timeout-minutes: 5
+
+    # Ubuntu 18.04 at the time of writing includes clang-format-9 as default
+    runs-on: [ubuntu-18.04]
+
+    # We want to check all changed files between the pull-request base and the head of the pull request
+    env:
+      FORMAT_BASE: ${{ github.base_ref }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+    # Checkout the repository as $GITHUB_WORKSPACE
+    - uses: actions/checkout@v2
+
+    # Make sure to include the base we want to merge into
+    - run: |
+      git fetch --no-tags --depth=1 origin ${{ github.base_ref }}
+
+    # Run the clang-format command (in $GITHUB_WORKSPACE, which is where the repo is checked out to)
+    - name: Run clang-format
+      run: ./scripts/clang-format

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,22 +31,6 @@ addons:
 
 matrix:
   include:
-    # OSX is faster to boot and execute the checks, but has more contention for VM instances.
-    # Not waiting fifteen minutes for an instance to come available is faster.
-    - name: Static Checks
-      os: linux
-      env: STATIC_CHECKS=yes
-      deploy:
-        provider: null
-      before_install: skip
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - clang-format
-      script: bash ./scripts/clang-format.sh
-
     - name: Build GCC
       os: linux
 
@@ -74,17 +58,3 @@ deploy:
   on:
     repo: pioneerspacesim/pioneer
     tags: true
-    condition: $STATIC_CHECKS != yes
-
-notifications:
-  irc:
-    channels:
-      - "ircs://chat.freenode.net:6669/#pioneer"
-    on_success: always
-    on_failure: always
-    template:
-      - "%{repository_slug}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
-      - "Change view : %{compare_url}"
-      - "Build details : %{build_url}"
-    nick: travis-jameson
-    password: flyordie

--- a/autoformat
+++ b/autoformat
@@ -1,20 +1,22 @@
-#!/bin/sh
+#!/bin/bash
 
-./scripts/clang-format.sh
+./scripts/clang-format.sh "$@"
+
 # Run clang-format, storing the output in MSG
 # Git runs hooks in the base directory, so we don't need to do any fancy dirname stuff.
 # $? will be non-zero if clang-format detected formatting issues.
-if [ "$?" != 0 ]; then
+format_ok=$?
+if ((format_ok == 1)); then
     # We've had a major malfunction!
     read -p "Do you want to automatically apply these changes (y/N)?" apply
     case $apply in
         y|Y)
 			# Get the patch info from the message and apply it to the staged changes.
-            PATCH_MODE=1 ./scripts/clang-format.sh | git apply --index -
+            PATCH_MODE=1 ./scripts/clang-format.sh "$@" | git apply --index -
             ;;
         *) exit 1;;
     esac
 else
     # All good, carry on.
-    exit 0
+    exit $format_ok
 fi


### PR DESCRIPTION
This change splits our clang-format step out into its own check, makes it a bit easier to run clang-format (for several reasons including that it's included into the default Github Actions image...), and allows us to more clearly see when there's an actual error with the build instead of clang-format complaining that you haven't adhered to the proper syntax.