### PR TITLE
Cleanup Modal Window manager registration

### DIFF
--- a/data/pigui/libs/modal-win.lua
+++ b/data/pigui/libs/modal-win.lua
@@ -66,14 +66,6 @@ local function drawModals(idx)
 	end
 end
 
-ui.registerModule('game', function()
-	drawModals(1)
-end)
-
-ui.registerModule('mainMenu', function()
-	drawModals(1)
-end)
-
 ui.registerModule('modal', function()
 	drawModals(1)
 end)


### PR DESCRIPTION
The issue #4832 was actually solved with #4842, but this PR removes unnecessary registration of the Modal Window handler in the game and mainMenu modules, which lead to modal being drawn several times (which doesn't seem to hurt anything, but you never know what it could lead to down the line)



