### PR TITLE
Fix Commodity Market Message Lag

### DIFF
--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -85,10 +85,10 @@ function CommodityMarketWidget.New(id, title, config)
     end
     config.canDisplayItem = config.canDisplayItem or function (s, e) return e.purchasable and e:IsValidSlot("cargo") and Game.system:IsCommodityLegal(e) end
     config.onClickItem = config.onClickItem or function(s,e,k)
+        s.selectedItem = e
         s.tradeModeBuy = true
         s:ChangeTradeAmount(-s.tradeAmount)
         s:Refresh()
-        s.selectedItem = e
     end
 
     self = MarketWidget.New(id, title, config)
@@ -363,7 +363,6 @@ end
 
 function CommodityMarketWidget:Refresh()
     MarketWidget.refresh(self)
-    self.selectedItem = nil
 end
 
 function CommodityMarketWidget:Render(size)

--- a/data/pigui/modules/station-view/03-commodityMarket.lua
+++ b/data/pigui/modules/station-view/03-commodityMarket.lua
@@ -31,5 +31,6 @@ StationView:registerView({
 		resetSize = true
 		commodityMarket:Refresh()
 		commodityMarket.scrollReset = true
+		commodityMarket.selectedItem = nil
 	end,
 })


### PR DESCRIPTION
Fixes #4826

A small issue possibly introduced with the fix to #4797. The method that updates the commodity market message was called before the selected item was set on the object, and so the message was always lagging.

To avoid confusion of what the Refresh method actually does, the selection clearing has to be done explicitly, and has been moved to the appropriate StationView tab.
