### PR TITLE
Refactor Main Loop Paradigm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,10 @@ if (NOT USE_SYSTEM_LIBLUA)
 	include_directories(contrib/lua)
 endif (NOT USE_SYSTEM_LIBLUA)
 
+add_subdirectory(src/core)
+
 define_pioneer_library(pioneer-lib PIONEER_CXX_FILES PIONEER_HXX_FILES)
+target_link_libraries(pioneer-lib PUBLIC pioneer-core)
 
 add_subdirectory(src/lua)
 

--- a/contrib/profiler/Profiler.h
+++ b/contrib/profiler/Profiler.h
@@ -7,9 +7,6 @@
 
 #define __PROFILER_FULL_TYPE_EXPANSION__
 
-#undef noinline
-#undef fastcall
-
 //#define USE_CHRONO
 #if !defined(USE_CHRONO) && (defined(__arm__) || defined(__aarch64__) || defined(_M_AMD64) || defined(_WIN64) || defined(_M_X64))
 // this isn't optional for __arm__ or x64 builds
@@ -24,12 +21,10 @@
 	#define __PRETTY_FUNCTION__ __FUNCSIG__
 	#define PROFILE_CONCAT( a, b ) a "/" b
 
-	#define noinline __declspec(noinline)
 	#define fastcall __fastcall
 #else
 	#define PROFILE_CONCAT( a, b ) b
 
-	#define noinline __attribute__ ((noinline))
 	#define fastcall
 #endif
 

--- a/contrib/profiler/Profiler.h
+++ b/contrib/profiler/Profiler.h
@@ -221,6 +221,11 @@ namespace Profiler {
 			return dur.count();
 		}
 
+		f64 seconds() {
+			std::chrono::duration<f64> dur = std::chrono::steady_clock::duration(ticks);
+			return dur.count();
+		}
+
 		f64 milliseconds() { return ms(ticks); }
 		f64 currentmilliseconds() { return ms(ticks + (getticks() - started)); }
 		f64 avg() { return average(ticks, calls); }

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -11,12 +11,13 @@
 #include "graphics/Frustum.h"
 #include "graphics/Graphics.h"
 #include "graphics/Material.h"
-#include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
+#include "graphics/Renderer.h"
 #include "graphics/Texture.h"
 #include "graphics/VertexArray.h"
 #include "graphics/opengl/GenGasGiantColourMaterial.h"
 #include "perlin.h"
+#include "utils.h"
 #include "vcacheopt/vcacheopt.h"
 
 RefCountedPtr<GasPatchContext> GasGiant::s_patchContext;
@@ -27,7 +28,7 @@ namespace {
 	static Uint32 s_texture_size_gpu[5];
 	static Uint32 s_noiseOctaves[5];
 	static float s_initialCPUDelayTime = 60.0f; // (perhaps) 60 seconds seems like a reasonable default
-	static float s_initialGPUDelayTime = 5.0f; // (perhaps) 5 seconds seems like a reasonable default
+	static float s_initialGPUDelayTime = 5.0f;	// (perhaps) 5 seconds seems like a reasonable default
 	static std::vector<GasGiant *> s_allGasGiants;
 
 	static const std::string GGJupiter("GGJupiter");

--- a/src/GeoPatchContext.cpp
+++ b/src/GeoPatchContext.cpp
@@ -6,6 +6,7 @@
 #include "Pi.h"
 #include "graphics/Graphics.h"
 #include "graphics/Renderer.h"
+#include "utils.h"
 
 #include "perlin.h"
 #include "vcacheopt/vcacheopt.h"

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -20,6 +20,7 @@
 #include "graphics/TextureBuilder.h"
 #include "graphics/VertexArray.h"
 #include "perlin.h"
+#include "utils.h"
 #include "vcacheopt/vcacheopt.h"
 #include <algorithm>
 #include <deque>

--- a/src/IniConfig.h
+++ b/src/IniConfig.h
@@ -4,7 +4,6 @@
 #ifndef _INICONFIG_H
 #define _INICONFIG_H
 
-#include "libs.h"
 #include <map>
 #include <string>
 

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -4,14 +4,13 @@
 #include "Input.h"
 #include "GameConfig.h"
 #include "Pi.h"
+#include "SDL.h"
 #include "ui/Context.h"
 
 #include <array>
 
-void Input::Init()
+void Input::Init(GameConfig *config)
 {
-	GameConfig *config = Pi::config;
-
 	joystickEnabled = (config->Int("EnableJoystick")) ? true : false;
 	mouseYInvert = (config->Int("InvertMouseY")) ? true : false;
 
@@ -181,6 +180,8 @@ void Input::HandleSDLEvent(SDL_Event &event)
 
 void Input::InitJoysticks()
 {
+	SDL_Init(SDL_INIT_JOYSTICK);
+
 	int joy_count = SDL_NumJoysticks();
 	Output("Initializing joystick subsystem.\n");
 	for (int n = 0; n < joy_count; n++) {

--- a/src/Input.h
+++ b/src/Input.h
@@ -9,14 +9,17 @@
 
 #include <algorithm>
 
+class GameConfig;
+
 class Input {
 	// TODO: better decouple these two classes.
 	friend class Pi;
 
 public:
 	Input(){};
-	void Init();
+	void Init(GameConfig *config);
 	void InitGame();
+	void HandleSDLEvent(SDL_Event &ev);
 
 	// The Page->Group->Binding system serves as a thin veneer for the UI to make
 	// sane reasonings about how to structure the Options dialog.
@@ -149,7 +152,6 @@ public:
 	sigc::signal<void, bool> onMouseWheel;
 
 private:
-	void HandleSDLEvent(SDL_Event &ev);
 	void InitJoysticks();
 
 	std::map<SDL_Keycode, bool> keyState;

--- a/src/Input.h
+++ b/src/Input.h
@@ -16,7 +16,7 @@ class Input {
 	friend class Pi;
 
 public:
-	Input(){};
+	Input() = default;
 	void Init(GameConfig *config);
 	void InitGame();
 	void HandleSDLEvent(SDL_Event &ev);

--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -5,13 +5,13 @@
 #include "Easing.h"
 #include "Lang.h"
 #include "Pi.h"
+#include "galaxy/Galaxy.h"
 #include "graphics/Graphics.h"
 #include "graphics/Renderer.h"
 #include "graphics/TextureBuilder.h"
 #include "scenegraph/ModelSkin.h"
 #include "scenegraph/SceneGraph.h"
 #include <algorithm>
-#include "galaxy/Galaxy.h"
 
 struct PiRngWrapper {
 	unsigned int operator()(unsigned int n)
@@ -84,7 +84,7 @@ Intro::~Intro()
 		delete (*i);
 }
 
-void Intro::Reset(float _time)
+void Intro::Reset()
 {
 	m_model = m_models[m_modelIndex++];
 	if (m_modelIndex == m_models.size()) m_modelIndex = 0;
@@ -95,7 +95,7 @@ void Intro::Reset(float _time)
 	m_zoomBegin = -10000.0f;
 	m_zoomEnd = -m_model->GetDrawClipRadius() * 1.7f;
 	m_dist = m_zoomBegin;
-	m_startTime = _time;
+	m_startTime = Pi::GetApp()->GetTime();
 	m_needReset = false;
 }
 
@@ -104,12 +104,13 @@ static const float ZOOM_IN_END = 2.0f;
 static const float WAIT_END = 12.0f;
 static const float ZOOM_OUT_END = 14.0f;
 
-void Intro::Draw(float _time)
+void Intro::Draw(float deltaTime)
 {
 	if (m_needReset)
-		Reset(_time);
+		Reset();
 
-	float duration = _time - m_startTime;
+	// FIXME: add a better interface for retrieving a global time source
+	float duration = Pi::GetApp()->GetTime() - m_startTime;
 
 	// zoom in
 	if (duration < ZOOM_IN_END)
@@ -138,7 +139,7 @@ void Intro::Draw(float _time)
 
 	// XXX all this stuff will be gone when intro uses a Camera
 	// rotate background by time, and a bit extra Z so it's not so flat
-	matrix4x4d brot = matrix4x4d::RotateXMatrix(-0.25 * _time) * matrix4x4d::RotateZMatrix(0.6);
+	matrix4x4d brot = matrix4x4d::RotateXMatrix(-0.25 * Pi::GetApp()->GetTime()) * matrix4x4d::RotateZMatrix(0.6);
 	m_renderer->ClearDepthBuffer();
 	m_background->Draw(brot);
 
@@ -148,6 +149,6 @@ void Intro::Draw(float _time)
 	matrix4x4f trans =
 		matrix4x4f::Translation(0, 0, m_dist) *
 		matrix4x4f::RotateXMatrix(DEG2RAD(-15.0f)) *
-		matrix4x4f::RotateYMatrix(_time);
+		matrix4x4f::RotateYMatrix(duration);
 	m_model->Render(trans);
 }

--- a/src/Intro.h
+++ b/src/Intro.h
@@ -13,12 +13,12 @@ class Intro : public Cutscene {
 public:
 	Intro(Graphics::Renderer *r, int width, int height);
 	~Intro();
-	virtual void Draw(float time);
+	virtual void Draw(float deltaTime);
 	SceneGraph::Model *getCurrentModel() const { return m_model; }
 	bool isZooming() const { return m_dist == m_zoomEnd; }
 
 private:
-	void Reset(float time);
+	void Reset();
 	bool m_needReset;
 
 	std::vector<SceneGraph::Model *> m_models;

--- a/src/KeyBindings.cpp
+++ b/src/KeyBindings.cpp
@@ -3,6 +3,7 @@
 
 #include "KeyBindings.h"
 #include "GameConfig.h"
+#include "Input.h"
 #include "Lang.h"
 #include "Pi.h"
 #include "StringF.h"
@@ -453,7 +454,7 @@ namespace KeyBindings {
 		ossaxisnum << int(axis);
 
 		return stringf(Lang::JOY_AXIS,
-			formatarg("sign", direction == KeyBindings::NEGATIVE ? "-" : ""), // no + sign if positive
+			formatarg("sign", direction == KeyBindings::NEGATIVE ? "-" : ""),	// no + sign if positive
 			formatarg("signp", direction == KeyBindings::NEGATIVE ? "-" : "+"), // optional with + sign
 			formatarg("joynum", joystick),
 			formatarg("joyname", Pi::input->JoystickName(joystick)),

--- a/src/KeyBindings.cpp
+++ b/src/KeyBindings.cpp
@@ -46,12 +46,12 @@ namespace KeyBindings {
 		if (type == BINDING_DISABLED) {
 			return false;
 		} else if (type == KEYBOARD_KEY) {
-			if (!Pi::input.KeyState(u.keyboard.key))
+			if (!Pi::input->KeyState(u.keyboard.key))
 				return false;
 			if (u.keyboard.mod == KMOD_NONE)
 				return true;
 			else {
-				int mod = Pi::input.KeyModState();
+				int mod = Pi::input->KeyModState();
 				if (mod & KMOD_CTRL) {
 					mod |= KMOD_CTRL;
 				}
@@ -67,10 +67,10 @@ namespace KeyBindings {
 				return ((mod & u.keyboard.mod) == u.keyboard.mod);
 			}
 		} else if (type == JOYSTICK_BUTTON) {
-			return Pi::input.JoystickButtonState(u.joystickButton.joystick, u.joystickButton.button) != 0;
+			return Pi::input->JoystickButtonState(u.joystickButton.joystick, u.joystickButton.button) != 0;
 		} else if (type == JOYSTICK_HAT) {
 			// SDL_HAT generates diagonal directions by ORing two cardinal directions.
-			int hatState = Pi::input.JoystickHatState(u.joystickHat.joystick, u.joystickHat.hat);
+			int hatState = Pi::input->JoystickHatState(u.joystickHat.joystick, u.joystickHat.hat);
 			return (hatState & u.joystickHat.direction) == u.joystickHat.direction;
 		} else
 			abort();
@@ -126,10 +126,10 @@ namespace KeyBindings {
 			if (u.keyboard.mod & KMOD_GUI) oss << Lang::META << " + ";
 			oss << SDL_GetKeyName(u.keyboard.key);
 		} else if (type == JOYSTICK_BUTTON) {
-			oss << Pi::input.JoystickName(u.joystickButton.joystick);
+			oss << Pi::input->JoystickName(u.joystickButton.joystick);
 			oss << Lang::BUTTON << int(u.joystickButton.button);
 		} else if (type == JOYSTICK_HAT) {
-			oss << Pi::input.JoystickName(u.joystickHat.joystick);
+			oss << Pi::input->JoystickName(u.joystickHat.joystick);
 			oss << Lang::HAT << int(u.joystickHat.hat);
 			oss << Lang::DIRECTION << int(u.joystickHat.direction);
 		} else
@@ -209,7 +209,7 @@ namespace KeyBindings {
 			// force terminate
 			joyUUIDBuf[JoyUUIDLength - 1] = '\0';
 			// now, locate the internal ID.
-			int joy = Pi::input.JoystickFromGUIDString(joyUUIDBuf);
+			int joy = Pi::input->JoystickFromGUIDString(joyUUIDBuf);
 			if (joy == -1) {
 				return false;
 			}
@@ -255,10 +255,10 @@ namespace KeyBindings {
 				oss << "Mod" << int(kb.u.keyboard.mod);
 			}
 		} else if (kb.type == JOYSTICK_BUTTON) {
-			oss << "Joy" << Pi::input.JoystickGUIDString(kb.u.joystickButton.joystick);
+			oss << "Joy" << Pi::input->JoystickGUIDString(kb.u.joystickButton.joystick);
 			oss << "/Button" << int(kb.u.joystickButton.button);
 		} else if (kb.type == JOYSTICK_HAT) {
-			oss << "Joy" << Pi::input.JoystickGUIDString(kb.u.joystickButton.joystick);
+			oss << "Joy" << Pi::input->JoystickGUIDString(kb.u.joystickButton.joystick);
 			oss << "/Hat" << int(kb.u.joystickHat.hat);
 			oss << "Dir" << int(kb.u.joystickHat.direction);
 		} else {
@@ -411,14 +411,14 @@ namespace KeyBindings {
 	bool JoyAxisBinding::IsActive() const
 	{
 		// If the stick is within the deadzone, it's not active.
-		return fabs(Pi::input.JoystickAxisState(joystick, axis)) > deadzone;
+		return fabs(Pi::input->JoystickAxisState(joystick, axis)) > deadzone;
 	}
 
 	float JoyAxisBinding::GetValue() const
 	{
 		if (!Enabled()) return 0.0f;
 
-		const float o_val = Pi::input.JoystickAxisState(joystick, axis);
+		const float o_val = Pi::input->JoystickAxisState(joystick, axis);
 
 		// Deadzone with normalisation
 		float value = fabs(o_val);
@@ -456,7 +456,7 @@ namespace KeyBindings {
 			formatarg("sign", direction == KeyBindings::NEGATIVE ? "-" : ""), // no + sign if positive
 			formatarg("signp", direction == KeyBindings::NEGATIVE ? "-" : "+"), // optional with + sign
 			formatarg("joynum", joystick),
-			formatarg("joyname", Pi::input.JoystickName(joystick)),
+			formatarg("joyname", Pi::input->JoystickName(joystick)),
 			formatarg("axis", axis >= 0 && axis < 3 ? axis_names[axis] : ossaxisnum.str()));
 	}
 
@@ -489,7 +489,7 @@ namespace KeyBindings {
 		// force terminate
 		joyUUIDBuf[JoyUUIDLength - 1] = '\0';
 		// now, map the GUID to a joystick number
-		const int joystick = Pi::input.JoystickFromGUIDString(joyUUIDBuf);
+		const int joystick = Pi::input->JoystickFromGUIDString(joyUUIDBuf);
 		if (joystick == -1) {
 			return false;
 		}
@@ -536,7 +536,7 @@ namespace KeyBindings {
 				oss << '-';
 
 			oss << "Joy";
-			oss << Pi::input.JoystickGUIDString(joystick);
+			oss << Pi::input->JoystickGUIDString(joystick);
 			oss << "/Axis";
 			oss << int(axis);
 			oss << "/DZ" << deadzone;

--- a/src/OS.h
+++ b/src/OS.h
@@ -7,8 +7,8 @@
  * Operating system specific functionality, such as
  * raising a message dialog
  */
-#include "libs.h"
-#include "utils.h"
+
+#include <string>
 
 namespace OS {
 
@@ -23,13 +23,8 @@ namespace OS {
 	void EnableFPE();
 	void DisableFPE();
 
-	// High frequency timer. HFTimer() returns count, HFTimerFreq() returns frequency.
-	// should not be considered reliable
-	Uint64 HFTimerFreq();
-	Uint64 HFTimer();
-
 	// http://stackoverflow.com/questions/150355/programmatically-find-the-number-of-cores-on-a-machine
-	int GetNumCores();
+	uint32_t GetNumCores();
 
 	// return a string describing the operating system that the game is running on, useful!
 	const std::string GetOSInfoString();

--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -120,10 +120,10 @@ void ObjectViewerView::Draw3D()
 	Graphics::Light light;
 	light.SetType(Graphics::Light::LIGHT_DIRECTIONAL);
 
-	const int btnState = Pi::input.MouseButtonState(SDL_BUTTON_RIGHT);
+	const int btnState = Pi::input->MouseButtonState(SDL_BUTTON_RIGHT);
 	if (btnState) {
 		int m[2];
-		Pi::input.GetMouseMotion(m);
+		Pi::input->GetMouseMotion(m);
 		m_camRot = matrix4x4d::RotateXMatrix(-0.002 * m[1]) *
 			matrix4x4d::RotateYMatrix(-0.002 * m[0]) * m_camRot;
 		m_cameraContext->SetCameraPosition(Pi::player->GetInterpPosition() + vector3d(0, 0, viewingDist));
@@ -163,8 +163,8 @@ void ObjectViewerView::OnSwitchTo()
 
 void ObjectViewerView::Update()
 {
-	if (Pi::input.KeyState(SDLK_EQUALS)) viewingDist *= 0.99f;
-	if (Pi::input.KeyState(SDLK_MINUS)) viewingDist *= 1.01f;
+	if (Pi::input->KeyState(SDLK_EQUALS)) viewingDist *= 0.99f;
+	if (Pi::input->KeyState(SDLK_MINUS)) viewingDist *= 1.01f;
 	viewingDist = Clamp(viewingDist, 10.0f, 1e12f);
 
 	char buf[128];

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -434,12 +434,11 @@ void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
 
 	// get threads up
 	Uint32 numThreads = config->Int("WorkerThreads");
-	const int numCores = OS::GetNumCores();
-	assert(numCores > 0);
-	if (numThreads == 0) numThreads = std::max(Uint32(numCores) - 1, 1U);
-	asyncJobQueue.reset(new AsyncJobQueue(numThreads));
+	numThreads = numThreads ? numThreads : std::max(OS::GetNumCores() - 1, 1U);
+	Pi::asyncJobQueue.reset(new AsyncJobQueue(numThreads));
+	Pi::syncJobQueue.reset(new SyncJobQueue);
+
 	Output("started %d worker threads\n", numThreads);
-	syncJobQueue.reset(new SyncJobQueue);
 
 	Output("ShipType::Init()\n");
 	// XXX early, Lua init needs it

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -327,8 +327,9 @@ void Pi::App::Startup()
 	startupTimer.Start();
 
 	Application::Startup();
-
+#if PIONEER_PROFILER
 	Pi::profilerPath = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(), "profiler");
+#endif
 
 	if (config->Int("RedirectStdio"))
 		OS::RedirectStdio();

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -24,6 +24,7 @@
 #include "ModelCache.h"
 #include "NavLights.h"
 #include "OS.h"
+#include "core/GuiApplication.h"
 #include "lua/Lua.h"
 #include "lua/LuaConsole.h"
 #include "lua/LuaEvent.h"
@@ -88,6 +89,12 @@
 #define _pclose pclose
 #endif
 
+/*
+===============================================================================
+	DEFINITIONS
+===============================================================================
+*/
+
 float Pi::gameTickAlpha;
 sigc::signal<void> Pi::onPlayerChangeTarget;
 sigc::signal<void> Pi::onPlayerChangeFlightControlState;
@@ -97,7 +104,7 @@ LuaNameGen *Pi::luaNameGen;
 #ifdef ENABLE_SERVER_AGENT
 ServerAgent *Pi::serverAgent;
 #endif
-Input Pi::input;
+Input *Pi::input;
 Player *Pi::player;
 View *Pi::currentView;
 TransferPlanner *Pi::planner;
@@ -134,146 +141,131 @@ Graphics::RenderTarget *Pi::renderTarget;
 RefCountedPtr<Graphics::Texture> Pi::renderTexture;
 std::unique_ptr<Graphics::Drawables::TexturedQuad> Pi::renderQuad;
 Graphics::RenderState *Pi::quadRenderState = nullptr;
-std::vector<Pi::InternalRequests> Pi::internalRequests;
 bool Pi::isRecordingVideo = false;
 FILE *Pi::ffmpegFile = nullptr;
+
+Pi::App *Pi::m_instance = nullptr;
 
 Sound::MusicPlayer Pi::musicPlayer;
 std::unique_ptr<AsyncJobQueue> Pi::asyncJobQueue;
 std::unique_ptr<SyncJobQueue> Pi::syncJobQueue;
 
-// Leaving define in place in case of future rendering problems.
-#define USE_RTT 0
+class LoadStep : public Application::Lifecycle {
+public:
+	LoadStep() :
+		Lifecycle(true)
+	{}
 
-//static
-void Pi::CreateRenderTarget(const Uint16 width, const Uint16 height)
-{
-	/*	@fluffyfreak here's a rendertarget implementation you can use for oculusing and other things. It's pretty simple:
-		 - fill out a RenderTargetDesc struct and call Renderer::CreateRenderTarget
-		 - pass target to Renderer::SetRenderTarget to start rendering to texture
-		 - set up viewport, clear etc, then draw as usual
-		 - SetRenderTarget(0) to resume render to screen
-		 - you can access the attached texture with GetColorTexture to use it with a material
-		You can reuse the same target with multiple textures.
-		In that case, leave the color format to NONE so the initial texture is not created, then use SetColorTexture to attach your own.
-	*/
-#if USE_RTT
-	Graphics::RenderStateDesc rsd;
-	rsd.depthTest = false;
-	rsd.depthWrite = false;
-	rsd.blendMode = Graphics::BLEND_SOLID;
-	quadRenderState = Pi::renderer->CreateRenderState(rsd);
+protected:
+	struct LoaderStep {
+		// TODO: use a lighter-weight wrapper over lambdas instead of std::function
+		std::function<void()> fn;
+		std::string name;
+	};
 
-	Graphics::TextureDescriptor texDesc(
-		Graphics::TEXTURE_RGBA_8888,
-		vector2f(width, height),
-		Graphics::LINEAR_CLAMP, false, false, 0);
-	Pi::renderTexture.Reset(Pi::renderer->CreateTexture(texDesc));
-	Pi::renderQuad.reset(new Graphics::Drawables::TexturedQuad(
-		Pi::renderer, Pi::renderTexture.Get(),
-		vector2f(0.0f, 0.0f), vector2f(float(Graphics::GetScreenWidth()), float(Graphics::GetScreenHeight())),
-		quadRenderState));
+	std::vector<LoaderStep> m_loaders;
+	size_t m_currentLoader = 0;
 
-	// Complete the RT description so we can request a buffer.
-	// NB: we don't want it to create use a texture because we share it with the textured quad created above.
-	Graphics::RenderTargetDesc rtDesc(
-		width,
-		height,
-		Graphics::TEXTURE_NONE, // don't create a texture
-		Graphics::TEXTURE_DEPTH,
-		false);
-	Pi::renderTarget = Pi::renderer->CreateRenderTarget(rtDesc);
-
-	Pi::renderTarget->SetColorTexture(Pi::renderTexture.Get());
-#endif
-}
-
-//static
-void Pi::DrawRenderTarget()
-{
-#if USE_RTT
-	Pi::renderer->BeginFrame();
-	Pi::renderer->SetViewport(0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
-	Pi::renderer->SetTransform(matrix4x4f::Identity());
-
+	template <typename T>
+	void AddStep(std::string name, T fn)
 	{
-		Pi::renderer->SetMatrixMode(Graphics::MatrixMode::PROJECTION);
-		Pi::renderer->PushMatrix();
-		Pi::renderer->SetOrthographicProjection(0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), 0, -1, 1);
-		Pi::renderer->SetMatrixMode(Graphics::MatrixMode::MODELVIEW);
-		Pi::renderer->PushMatrix();
-		Pi::renderer->LoadIdentity();
+		m_loaders.push_back(LoaderStep{ fn, name });
 	}
 
-	Pi::renderQuad->Draw(Pi::renderer);
+	Profiler::Clock m_loadTimer;
 
+	void Start() override;
+	void Update(float) override;
+};
+
+class MainMenu : public Application::Lifecycle {
+public:
+	void SetStartPath(const SystemPath &path)
 	{
-		Pi::renderer->SetMatrixMode(Graphics::MatrixMode::PROJECTION);
-		Pi::renderer->PopMatrix();
-		Pi::renderer->SetMatrixMode(Graphics::MatrixMode::MODELVIEW);
-		Pi::renderer->PopMatrix();
+		m_startPath = path;
+		m_skipMenu = true;
 	}
 
-	Pi::renderer->EndFrame();
+protected:
+	std::unique_ptr<Intro> m_intro;
+
+	void Start() override;
+	void Update(float) override;
+	void End() override;
+
+	bool m_skipMenu;
+	SystemPath m_startPath;
+};
+
+class GameLoop : public Application::Lifecycle {
+protected:
+	void Start() override;
+	void Update(float) override;
+	void End() override;
+
+	void InitGame();
+	void EndGame();
+
+	double time_player_died;
+
+	// Used to measure frame and physics performance timing info
+	// with no portable way to map cycles -> ns, Profiler::Timer is useless for taking measurements
+	// Use Profiler::Clock which is backed by std::chrono::steady_clock (== high_resolution_clock for 99% of uses)
+	Profiler::Clock perfTimer;
+
+	float frame_time_real; // higher resolution than SDL's 1ms, for detailed frame info
+	float phys_time;
+
+	int frame_stat;
+	int phys_stat;
+
+	int MAX_PHYSICS_TICKS;
+	double accumulator;
+
+#if WITH_DEVKEYS
+	Uint32 last_stats = SDL_GetTicks();
+	// FIXME: this is a hack, this class should have its lifecycle managed elsewhere
+	// Ideally an application framework class handles this (as well as the rest of the main loop)
+	// but for now this is the best we have.
+	std::unique_ptr<PiGUI::PerfInfo> perfInfoDisplay;
 #endif
+};
+
+class TombstoneLoop : public Application::Lifecycle {
+protected:
+	void Start() override;
+	void Update(float) override;
+
+	double startTime = 0.0;
+	double accumTime = 0.0;
+	std::unique_ptr<Tombstone> tombstone;
+};
+
+/*
+===============================================================================
+	INITIALIZATION
+===============================================================================
+*/
+
+// TODO: refine this interface
+// We don't use options for anything but the config object,
+// and instead of passing no_gui, we should instead use a different application
+// object devoted to whatever headless work we intend to do
+void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
+{
+	Pi::config = new GameConfig(options);
+	m_instance = new Pi::App();
+
+	GetApp()->m_loader = std::make_shared<LoadStep>();
+	GetApp()->m_mainMenu = std::make_shared<MainMenu>();
+	GetApp()->m_gameLoop = std::make_shared<GameLoop>();
+
+	m_instance->m_noGui = no_gui;
 }
 
-//static
-void Pi::BeginRenderTarget()
+void Pi::App::SetStartPath(const SystemPath &startPath)
 {
-#if USE_RTT
-	Pi::renderer->SetRenderTarget(Pi::renderTarget);
-	Pi::renderer->ClearScreen();
-#endif
-}
-
-//static
-void Pi::EndRenderTarget()
-{
-#if USE_RTT
-	Pi::renderer->SetRenderTarget(nullptr);
-#endif
-}
-
-static void draw_progress(float progress)
-{
-
-	Pi::renderer->ClearScreen();
-	Pi::pigui->NewFrame(Pi::renderer->GetSDLWindow());
-	Pi::DrawPiGui(progress, "INIT");
-	Pi::pigui->Render();
-	Pi::renderer->SwapBuffers();
-}
-
-static void LuaInitGame()
-{
-	LuaEvent::Clear();
-}
-
-SceneGraph::Model *Pi::FindModel(const std::string &name, bool allowPlaceholder)
-{
-	SceneGraph::Model *m = 0;
-	try {
-		m = Pi::modelCache->FindModel(name);
-	} catch (const ModelCache::ModelNotFoundException &) {
-		Output("Could not find model: %s\n", name.c_str());
-		if (allowPlaceholder) {
-			try {
-				m = Pi::modelCache->FindModel("error");
-			} catch (const ModelCache::ModelNotFoundException &) {
-				Error("Could not find placeholder model");
-			}
-		}
-	}
-
-	return m;
-}
-
-const char Pi::SAVE_DIR_NAME[] = "savefiles";
-
-std::string Pi::GetSaveDir()
-{
-	return FileSystem::JoinPath(FileSystem::GetUserDir(), Pi::SAVE_DIR_NAME);
+	static_cast<MainMenu *>(m_mainMenu.get())->SetStartPath(startPath);
 }
 
 void TestGPUJobsSupport()
@@ -328,27 +320,15 @@ void RegisterInputBindings()
 	WorldView::RegisterInputBindings();
 }
 
-void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
+void Pi::App::Startup()
 {
-#ifdef PIONEER_PROFILER
-	Profiler::reset();
-#endif
-
-	Profiler::Timer timer;
-	timer.Start();
-
-	OS::EnableBreakpad();
-	OS::NotifyLoadBegin();
-
-	FileSystem::Init();
-	FileSystem::userFiles.MakeDirectory(""); // ensure the config directory exists
-#ifdef PIONEER_PROFILER
-	FileSystem::userFiles.MakeDirectory("profiler");
-	profilerPath = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(), "profiler");
-#endif
 	PROFILE_SCOPED()
+	Profiler::Clock startupTimer;
+	startupTimer.Start();
 
-	Pi::config = new GameConfig(options);
+	Application::Startup();
+
+	Pi::profilerPath = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(), "profiler");
 
 	if (config->Int("RedirectStdio"))
 		OS::RedirectStdio();
@@ -368,62 +348,29 @@ void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
 	Lang::Resource res(Lang::GetResource("core", config->String("Lang")));
 	Lang::MakeCore(res);
 
+	// FIXME: move these out of the Pi namespace
+	// TODO: add a better configuration interface for this kind of thing
 	Pi::SetAmountBackgroundStars(config->Float("AmountOfBackgroundStars"));
 	Pi::detail.planets = config->Int("DetailPlanets");
 	Pi::detail.cities = config->Int("DetailCities");
 
-	// Initialize SDL
-	Uint32 sdlInitFlags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
-#if defined(DEBUG) || defined(_DEBUG)
-	sdlInitFlags |= SDL_INIT_NOPARACHUTE;
-#endif
-	if (SDL_Init(sdlInitFlags) < 0) {
-		Error("SDL initialization failed: %s\n", SDL_GetError());
-	}
-
-	OutputVersioningInfo();
-
 	Graphics::RendererOGL::RegisterRenderer();
+	Pi::renderer = StartupRenderer(Pi::config);
 
-	// determine what renderer we should use, default to Opengl 3.x
-	const std::string rendererName = config->String("RendererName", Graphics::RendererNameFromType(Graphics::RENDERER_OPENGL_3x));
-	Graphics::RendererType rType = Graphics::RENDERER_OPENGL_3x;
-	//if(rendererName == Graphics::RendererNameFromType(Graphics::RENDERER_OPENGL_3x))
-	//{
-	//	rType = Graphics::RENDERER_OPENGL_3x;
-	//}
-
-	// Do rest of SDL video initialization and create Renderer
-	Graphics::Settings videoSettings = {};
-	videoSettings.rendererType = rType;
-	videoSettings.width = config->Int("ScrWidth");
-	videoSettings.height = config->Int("ScrHeight");
-	videoSettings.fullscreen = (config->Int("StartFullscreen") != 0);
-	videoSettings.hidden = no_gui;
-	videoSettings.requestedSamples = config->Int("AntiAliasingMode");
-	videoSettings.vsync = (config->Int("VSync") != 0);
-	videoSettings.useTextureCompression = (config->Int("UseTextureCompression") != 0);
-	videoSettings.useAnisotropicFiltering = (config->Int("UseAnisotropicFiltering") != 0);
-	videoSettings.enableDebugMessages = (config->Int("EnableGLDebug") != 0);
-	videoSettings.gl3ForwardCompatible = (config->Int("GL3ForwardCompatible") != 0);
-	videoSettings.iconFile = OS::GetIconFilename();
-	videoSettings.title = "Pioneer";
-
-	Pi::renderer = Graphics::Init(videoSettings);
-
-	Pi::CreateRenderTarget(videoSettings.width, videoSettings.height);
 	Pi::rng.IncRefCount(); // so nothing tries to free it
 	Pi::rng.seed(time(0));
 
-	input.Init();
-	input.onKeyPress.connect(sigc::ptr_fun(&Pi::HandleKeyDown));
+	Pi::input = new Input();
+	Pi::input->Init(Pi::config);
+	Pi::input->onKeyPress.connect(sigc::ptr_fun(&Pi::HandleKeyDown));
 
 	// we can only do bindings once joysticks are initialised.
-	if (!no_gui) // This re-saves the config file. With no GUI we want to allow multiple instances in parallel.
+	if (!m_noGui) // This re-saves the config file. With no GUI we want to allow multiple instances in parallel.
 		KeyBindings::InitBindings();
 
 	RegisterInputBindings();
 
+	// FIXME: move these into the appropriate class!
 	navTunnelDisplayed = (config->Int("DisplayNavTunnel")) ? true : false;
 	speedLinesDisplayed = (config->Int("SpeedLines")) ? true : false;
 	hudTrailsDisplayed = (config->Int("HudTrails")) ? true : false;
@@ -432,196 +379,52 @@ void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
 
 	EnumStrings::Init();
 
+	Profiler::Clock threadTimer;
+	threadTimer.Start();
+
 	// get threads up
 	Uint32 numThreads = config->Int("WorkerThreads");
 	numThreads = numThreads ? numThreads : std::max(OS::GetNumCores() - 1, 1U);
 	Pi::asyncJobQueue.reset(new AsyncJobQueue(numThreads));
 	Pi::syncJobQueue.reset(new SyncJobQueue);
 
-	Output("started %d worker threads\n", numThreads);
+	threadTimer.Stop();
+	Output("started %d worker threads in %.2fms\n", numThreads, threadTimer.milliseconds());
 
-	Output("ShipType::Init()\n");
-	// XXX early, Lua init needs it
-	ShipType::Init();
-
-	// XXX UI requires Lua  but Pi::ui must exist before we start loading
-	// templates. so now we have crap everywhere :/
-	Output("Lua::Init()\n");
-	Lua::Init();
-
-	Pi::pigui.Reset(new PiGui);
-	Pi::pigui->Init(Pi::renderer->GetSDLWindow());
-
-	float ui_scale = config->Float("UIScaleFactor", 1.0f);
-	if (Graphics::GetScreenHeight() < 768) {
-		ui_scale = float(Graphics::GetScreenHeight()) / 768.0f;
-	}
-
-	Pi::ui.Reset(new UI::Context(
-		Lua::manager,
-		Pi::renderer,
-		Graphics::GetScreenWidth(),
-		Graphics::GetScreenHeight(),
-		ui_scale));
-
-#ifdef ENABLE_SERVER_AGENT
-	Pi::serverAgent = 0;
-	if (config->Int("EnableServerAgent")) {
-		const std::string endpoint(config->String("ServerEndpoint"));
-		if (endpoint.size() > 0) {
-			Output("Server agent enabled, endpoint: %s\n", endpoint.c_str());
-			Pi::serverAgent = new HTTPServerAgent(endpoint);
-		}
-	}
-	if (!Pi::serverAgent) {
-		Output("Server agent disabled\n");
-		Pi::serverAgent = new NullServerAgent();
-	}
-#endif
-
-	Lua::InitModules();
-
-	Gui::Init(renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), 800, 600);
-
-	// twice, to initialize the font correctly
-	draw_progress(0.01f);
-	draw_progress(0.01f);
-
-	Output("GalaxyGenerator::Init()\n");
-	if (config->HasEntry("GalaxyGenerator"))
-		GalaxyGenerator::Init(config->String("GalaxyGenerator"),
-			config->Int("GalaxyGeneratorVersion", GalaxyGenerator::LAST_VERSION));
-	else
-		GalaxyGenerator::Init();
-
-	draw_progress(0.1f);
-
-	Output("FaceParts::Init()\n");
-	FaceParts::Init();
-	draw_progress(0.2f);
-
-	Output("new ModelCache\n");
-	modelCache = new ModelCache(Pi::renderer);
-	draw_progress(0.3f);
-
-	Output("Shields::Init\n");
-	Shields::Init(Pi::renderer);
-	draw_progress(0.4f);
-
-	//unsigned int control_word;
-	//_clearfp();
-	//_controlfp_s(&control_word, _EM_INEXACT | _EM_UNDERFLOW | _EM_ZERODIVIDE, _MCW_EM);
-	//double fpexcept = Pi::timeAccelRates[1] / Pi::timeAccelRates[0];
-
-	Output("BaseSphere::Init\n");
-	BaseSphere::Init();
-	draw_progress(0.5f);
-
-	Output("CityOnPlanet::Init\n");
-	CityOnPlanet::Init();
-	draw_progress(0.6f);
-
-	Output("SpaceStation::Init\n");
-	SpaceStation::Init();
-	draw_progress(0.7f);
-
-	Output("NavLights::Init\n");
-	NavLights::Init(Pi::renderer);
-	draw_progress(0.75f);
-
-	Output("Sfx::Init\n");
-	SfxManager::Init(Pi::renderer);
-	draw_progress(0.8f);
-
-	if (!no_gui && !config->Int("DisableSound")) {
-		Output("Sound::Init\n");
-		Sound::Init();
-		Sound::SetMasterVolume(config->Float("MasterVolume"));
-		Sound::SetSfxVolume(config->Float("SfxVolume"));
-		GetMusicPlayer().SetVolume(config->Float("MusicVolume"));
-
-		Sound::Pause(0);
-		if (config->Int("MasterMuted")) Sound::Pause(1);
-		if (config->Int("SfxMuted")) Sound::SetSfxVolume(0.f);
-		if (config->Int("MusicMuted")) GetMusicPlayer().SetEnabled(false);
-	}
-	draw_progress(0.9f);
-
-	OS::NotifyLoadEnd();
-	draw_progress(0.95f);
-
-#if 0
-	// test code to produce list of ship stats
-
-	FILE *pStatFile = fopen("shipstat.csv","wt");
-	if (pStatFile)
-	{
-		fprintf(pStatFile, "name,modelname,hullmass,capacity,fakevol,rescale,xsize,ysize,zsize,facc,racc,uacc,sacc,aacc,exvel\n");
-		for (auto iter : ShipType::types)
-		{
-			const ShipType *shipdef = &(iter.second);
-			SceneGraph::Model *model = Pi::FindModel(shipdef->modelName, false);
-
-			double hullmass = shipdef->hullMass;
-			double capacity = shipdef->capacity;
-
-			double xsize = 0.0, ysize = 0.0, zsize = 0.0, fakevol = 0.0, rescale = 0.0, brad = 0.0;
-			if (model) {
-				std::unique_ptr<SceneGraph::Model> inst(model->MakeInstance());
-				model->CreateCollisionMesh();
-				Aabb aabb = model->GetCollisionMesh()->GetAabb();
-				xsize = aabb.max.x-aabb.min.x;
-				ysize = aabb.max.y-aabb.min.y;
-				zsize = aabb.max.z-aabb.min.z;
-				fakevol = xsize*ysize*zsize;
-				brad = aabb.GetRadius();
-				rescale = pow(fakevol/(100 * (hullmass+capacity)), 0.3333333333);
-			}
-
-			double simass = (hullmass + capacity) * 1000.0;
-			double angInertia = (2/5.0)*simass*brad*brad;
-			double acc1 = shipdef->linThrust[Thruster::THRUSTER_FORWARD] / (9.81*simass);
-			double acc2 = shipdef->linThrust[Thruster::THRUSTER_REVERSE] / (9.81*simass);
-			double acc3 = shipdef->linThrust[Thruster::THRUSTER_UP] / (9.81*simass);
-			double acc4 = shipdef->linThrust[Thruster::THRUSTER_RIGHT] / (9.81*simass);
-			double acca = shipdef->angThrust/angInertia;
-			double exvel = shipdef->effectiveExhaustVelocity;
-
-			fprintf(pStatFile, "%s,%s,%.1f,%.1f,%.1f,%.3f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%f,%.1f\n",
-				shipdef->name.c_str(), shipdef->modelName.c_str(), hullmass, capacity,
-				fakevol, rescale, xsize, ysize, zsize, acc1, acc2, acc3, acc4, acca, exvel);
-		}
-		fclose(pStatFile);
-	}
-#endif
-
-	luaConsole = new LuaConsole();
-	KeyBindings::toggleLuaConsole.onPress.connect(sigc::mem_fun(Pi::luaConsole, &LuaConsole::Toggle));
-
-	planner = new TransferPlanner();
-
-	draw_progress(1.0f);
-
-	timer.Stop();
 #ifdef PIONEER_PROFILER
 	Profiler::dumphtml(profilerPath.c_str());
 #endif
-	Output("\n\nLoading took: %lf milliseconds\n", timer.millicycles());
+
+	QueueLifecycle(m_loader);
+
+	// Don't start the main menu if we don't have a GUI
+	if (!m_noGui)
+		QueueLifecycle(m_mainMenu);
+
+	startupTimer.Stop();
+	Output("\n\nEngine startup took %.2fms\n", startupTimer.milliseconds());
 }
 
-bool Pi::IsConsoleActive()
-{
-	return luaConsole && luaConsole->IsActive();
-}
+/*
+===============================================================================
+	DEINITIALIZATION
+===============================================================================
+*/
 
-void Pi::Quit()
+// Immediately destroy everything and end the game.
+void Pi::App::Shutdown()
 {
-	if (Pi::game) { // always end the game if there is one before quitting
-		Pi::EndGame();
-	}
+	Output("Pi shutting down.\n");
+
+	// This function should only be called at the very end of the shutdown procedure.
+	assert(Pi::game == nullptr);
 	if (Pi::ffmpegFile != nullptr) {
 		_pclose(Pi::ffmpegFile);
 	}
+
+	// TODO: connect initializers and deinitializers in a single Module interface
+	// Will need to think about dependency injection for e.g. modules which need a
+	// reference to the renderer
 	Projectile::FreeModel();
 	Beam::FreeModel();
 	delete Pi::intro;
@@ -640,29 +443,282 @@ void Pi::Quit()
 	Lua::UninitModules();
 	Lua::Uninit();
 	Gui::Uninit();
+
 	delete Pi::modelCache;
-	delete Pi::renderer;
-	delete Pi::config;
+
 	GalaxyGenerator::Uninit();
+
+	ShutdownRenderer();
+	Pi::renderer = nullptr;
+
+	delete Pi::config;
 	delete Pi::planner;
-	SDL_Quit();
-	FileSystem::Uninit();
 	asyncJobQueue.reset();
 	syncJobQueue.reset();
+
+	Application::Shutdown();
+
+	SDL_Quit();
+	delete Pi::m_instance;
 	exit(0);
 }
 
-void Pi::SetView(View *v)
+/*
+===============================================================================
+	LOADING
+===============================================================================
+*/
+
+// TODO: investigate constructing a DAG out of Init functions and dependencies
+void LoadStep::Start()
 {
-	if (currentView) currentView->Detach();
-	currentView = v;
-	if (currentView) currentView->Attach();
+	Output("LoadStep::Start()\n");
+	m_loadTimer.Reset();
+	m_loadTimer.Start();
+
+	Output("ShipType::Init()\n");
+	// XXX early, Lua init needs it
+	ShipType::Init();
+
+	// XXX UI requires Lua  but Pi::ui must exist before we start loading
+	// templates. so now we have crap everywhere :/
+	Output("Lua::Init()\n");
+	Lua::Init();
+
+	// TODO: Get the lua state responsible for drawing the init progress up as fast as possible
+	// Investigate using a pigui-only Lua state that we can initialize without depending on
+	// normal init flow, or drawing the init screen in C++ instead?
+	// Ideally we can initialize the ImGui related parts of pigui as soon as the renderer is online,
+	// and then load all the lua-related state once Lua's registered and online...
+	Pi::pigui.Reset(new PiGui);
+	Pi::pigui->Init(Pi::renderer->GetSDLWindow());
+
+	// Don't render the first frame, just make sure all of our fonts are loaded
+	Pi::pigui->NewFrame(Pi::renderer->GetSDLWindow());
+	Pi::pigui->RunHandler(0.01, "INIT");
+	Pi::pigui->EndFrame();
+
+	AddStep("UI::AddContext", []() {
+		float ui_scale = Pi::config->Float("UIScaleFactor", 1.0f);
+		if (Graphics::GetScreenHeight() < 768) {
+			ui_scale = float(Graphics::GetScreenHeight()) / 768.0f;
+		}
+
+		Pi::ui.Reset(new UI::Context(
+			Lua::manager,
+			Pi::renderer,
+			Graphics::GetScreenWidth(),
+			Graphics::GetScreenHeight(),
+			ui_scale));
+	});
+
+#ifdef ENABLE_SERVER_AGENT
+	AddStep("Initialize ServerAgent", []() {
+		Pi::serverAgent = 0;
+		if (Pi::config->Int("EnableServerAgent")) {
+			const std::string endpoint(Pi::config->String("ServerEndpoint"));
+			if (endpoint.size() > 0) {
+				Output("Server agent enabled, endpoint: %s\n", endpoint.c_str());
+				Pi::serverAgent = new HTTPServerAgent(endpoint);
+			}
+		}
+		if (!Pi::serverAgent) {
+			Output("Server agent disabled\n");
+			Pi::serverAgent = new NullServerAgent();
+		}
+	});
+#endif
+
+	// TODO: expose the AddStep interface so Lua::InitModules can granularize its registration
+	AddStep("Lua::InitModules()", &Lua::InitModules);
+
+	AddStep("Gui::Init()", []() {
+		Gui::Init(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), 800, 600);
+	});
+
+	AddStep("GalaxyGenerator::Init()", []() {
+		if (Pi::config->HasEntry("GalaxyGenerator"))
+			GalaxyGenerator::Init(Pi::config->String("GalaxyGenerator"),
+				Pi::config->Int("GalaxyGeneratorVersion", GalaxyGenerator::LAST_VERSION));
+		else
+			GalaxyGenerator::Init();
+	});
+
+	AddStep("FaceParts::Init()", &FaceParts::Init);
+
+	AddStep("new ModelCache", []() {
+		Pi::modelCache = new ModelCache(Pi::renderer);
+	});
+
+	AddStep("Shields::Init", []() {
+		Shields::Init(Pi::renderer);
+	});
+
+	AddStep("BaseSphere::Init", &BaseSphere::Init);
+
+	AddStep("CityOnPlanet::Init", &CityOnPlanet::Init);
+
+	AddStep("SpaceStation::Init", &SpaceStation::Init);
+
+	AddStep("NavLights::Init", []() {
+		NavLights::Init(Pi::renderer);
+	});
+
+	AddStep("Sfx::Init", []() {
+		SfxManager::Init(Pi::renderer);
+	});
+
+	AddStep("Sound::Init", []() {
+		if (Pi::GetApp()->HeadlessMode() || Pi::config->Int("DisableSound"))
+			return;
+
+		Sound::Init();
+		Sound::SetMasterVolume(Pi::config->Float("MasterVolume"));
+		Sound::SetSfxVolume(Pi::config->Float("SfxVolume"));
+		Pi::GetMusicPlayer().SetVolume(Pi::config->Float("MusicVolume"));
+
+		Sound::Pause(0);
+		if (Pi::config->Int("MasterMuted")) Sound::Pause(1);
+		if (Pi::config->Int("SfxMuted")) Sound::SetSfxVolume(0.f);
+		if (Pi::config->Int("MusicMuted")) Pi::GetMusicPlayer().SetEnabled(false);
+	});
+
+	AddStep("PostLoad", []() {
+		Pi::luaConsole = new LuaConsole();
+		KeyBindings::toggleLuaConsole.onPress.connect(sigc::mem_fun(Pi::luaConsole, &LuaConsole::Toggle));
+
+		Pi::planner = new TransferPlanner();
+	});
 }
 
-void Pi::OnChangeDetailLevel()
+void LoadStep::Update(float deltaTime)
 {
-	BaseSphere::OnChangeDetailLevel();
+	if (m_currentLoader < m_loaders.size()) {
+		LoaderStep &loader = m_loaders[m_currentLoader++];
+		float progress = (m_currentLoader) / float(m_loaders.size());
+		Output("Loading [%02.f%%]: %s started\n", progress * 100., loader.name.c_str());
+
+		Profiler::Clock timer;
+		timer.Start();
+
+		loader.fn();
+
+		timer.Stop();
+		Output("Loading [%02.f%%]: %s took %.2fms\n", progress * 100.,
+			loader.name.c_str(), timer.milliseconds());
+
+		Pi::pigui->NewFrame(Pi::renderer->GetSDLWindow());
+		Pi::pigui->RunHandler(progress, "INIT");
+		Pi::pigui->Render();
+
+	} else {
+		OS::NotifyLoadEnd();
+		RequestEndLifecycle();
+
+		m_loadTimer.Stop();
+		Output("\n\nPioneer loading took %.2fms\n", m_loadTimer.milliseconds());
+	}
 }
+
+/*
+===============================================================================
+	MAIN MENU
+===============================================================================
+*/
+
+void MainMenu::Start()
+{
+	Pi::intro = new Intro(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+	if (m_skipMenu) {
+		Output("Loading new game immediately!\n");
+		Pi::StartGame(new Game(m_startPath, 0.0));
+		m_skipMenu = false; // Show the main menu once we're done here.
+	}
+
+	//XXX global ambient colour hack to make explicit the old default ambient colour dependency
+	// for some models
+	Pi::renderer->SetAmbientColor(Color(51, 51, 51, 255));
+}
+
+void MainMenu::Update(float deltaTime)
+{
+	SDL_Event event;
+	while (SDL_PollEvent(&event)) {
+		if (event.type == SDL_QUIT)
+			Pi::RequestQuit();
+		else {
+			Pi::pigui->ProcessEvent(&event);
+
+			if (Pi::pigui->WantCaptureMouse()) {
+				// don't process mouse event any further, imgui already handled it
+				switch (event.type) {
+				case SDL_MOUSEBUTTONDOWN:
+				case SDL_MOUSEBUTTONUP:
+				case SDL_MOUSEWHEEL:
+				case SDL_MOUSEMOTION:
+					continue;
+				default: break;
+				}
+			}
+			if (Pi::pigui->WantCaptureKeyboard()) {
+				// don't process keyboard event any further, imgui already handled it
+				switch (event.type) {
+				case SDL_KEYDOWN:
+				case SDL_KEYUP:
+				case SDL_TEXTINPUT:
+					continue;
+				default: break;
+				}
+			}
+
+			Pi::input->HandleSDLEvent(event);
+		}
+	}
+
+	Pi::intro->Draw(deltaTime);
+
+	Pi::pigui->NewFrame(Pi::renderer->GetSDLWindow());
+	Pi::pigui->RunHandler(deltaTime, "MAINMENU");
+
+	Pi::pigui->Render();
+
+	if (Pi::game) {
+		RequestEndLifecycle();
+	}
+
+#ifdef ENABLE_SERVER_AGENT
+	Pi::serverAgent->ProcessResponses();
+#endif
+}
+
+void MainMenu::End()
+{
+	delete Pi::intro;
+	Pi::intro = nullptr;
+}
+
+// Not much better than setting Pi::game in a Lua function,
+// but it works for now.
+void Pi::StartGame(Game *game)
+{
+	// FIXME: Game.cpp sets Pi::game because some other things depend on that variable
+	// if (Pi::game != nullptr)
+	// 	Error("Attempt to start a new game while one is already running!\n");
+
+	Pi::game = game;
+
+	Pi::GetApp()->GetActiveLifecycle()->RequestEndLifecycle();
+	Pi::GetApp()->QueueLifecycle(Pi::GetApp()->m_gameLoop);
+}
+
+/*
+===============================================================================
+	EVENT HANDLING
+===============================================================================
+*/
+
+// FIXME: move out of Pi.cpp into a proper debug interface!
+static void SpawnTestObjects();
 
 void Pi::HandleKeyDown(SDL_Keysym *key)
 {
@@ -673,195 +729,124 @@ void Pi::HandleKeyDown(SDL_Keysym *key)
 		}
 		return;
 	}
-	const bool CTRL = input.KeyState(SDLK_LCTRL) || input.KeyState(SDLK_RCTRL);
 
-	// special keys.
-	if (CTRL) {
-		switch (key->sym) {
-		case SDLK_q: // Quit
-			Pi::RequestQuit();
-			break;
-		case SDLK_PRINTSCREEN: // print
-		case SDLK_KP_MULTIPLY: // screen
-		{
-			char buf[256];
-			const time_t t = time(0);
-			struct tm *_tm = localtime(&t);
-			strftime(buf, sizeof(buf), "screenshot-%Y%m%d-%H%M%S.png", _tm);
-			Graphics::ScreendumpState sd;
-			Pi::renderer->Screendump(sd);
-			write_screenshot(sd, buf);
-			break;
-		}
+	const bool CTRL = input->KeyState(SDLK_LCTRL) || input->KeyState(SDLK_RCTRL);
+	if (!CTRL) {
+		return;
+	}
 
-		case SDLK_SCROLLLOCK: // toggle video recording
-			Pi::isRecordingVideo = !Pi::isRecordingVideo;
-			if (Pi::isRecordingVideo) {
-				char videoName[256];
-				const time_t t = time(0);
-				struct tm *_tm = localtime(&t);
-				strftime(videoName, sizeof(videoName), "pioneer-%Y%m%d-%H%M%S", _tm);
-				const std::string dir = "videos";
-				FileSystem::userFiles.MakeDirectory(dir);
-				const std::string fname = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot() + "/" + dir, videoName);
-				Output("Video Recording started to %s.\n", fname.c_str());
-				// start ffmpeg telling it to expect raw rgba 720p-60hz frames
-				// -i - tells it to read frames from stdin
-				// if given no frame rate (-r 60), it will just use vfr
-				char cmd[256] = { 0 };
-				snprintf(cmd, sizeof(cmd), "ffmpeg -f rawvideo -pix_fmt rgba -s %dx%d -i - -threads 0 -preset fast -y -pix_fmt yuv420p -crf 21 -vf vflip %s.mp4", config->Int("ScrWidth"), config->Int("ScrHeight"), fname.c_str());
+	// special keys: CTRL+[KEY].
+	switch (key->sym) {
+	case SDLK_q: // Quit
+		Pi::RequestQuit();
+		break;
+	case SDLK_PRINTSCREEN: // print
+	case SDLK_KP_MULTIPLY: // screen
+	{
+		char buf[256];
+		const time_t t = time(0);
+		struct tm *_tm = localtime(&t);
+		strftime(buf, sizeof(buf), "screenshot-%Y%m%d-%H%M%S.png", _tm);
+		Graphics::ScreendumpState sd;
+		Pi::renderer->Screendump(sd);
+		write_screenshot(sd, buf);
+		break;
+	}
 
-				// open pipe to ffmpeg's stdin in binary write mode
-#if defined(_MSC_VER) || defined(__MINGW32__)
-				Pi::ffmpegFile = _popen(cmd, "wb");
-#else
-				Pi::ffmpegFile = _popen(cmd, "w");
+#if 0 // FIXME: find a better home / interface for video recording
+	case SDLK_SCROLLLOCK: // toggle video recording
+		SetVideoRecording(!Pi::isRecordingVideo);
+		break;
 #endif
-			} else {
-				Output("Video Recording ended.\n");
-				if (Pi::ffmpegFile != nullptr) {
-					_pclose(Pi::ffmpegFile);
-					Pi::ffmpegFile = nullptr;
-				}
-			}
-			break;
+
 #if WITH_DEVKEYS
-		case SDLK_i: // Toggle Debug info
-			Pi::showDebugInfo = !Pi::showDebugInfo;
-			break;
+	case SDLK_i: // Toggle Debug info
+		Pi::showDebugInfo = !Pi::showDebugInfo;
+		break;
 
 #ifdef PIONEER_PROFILER
-		case SDLK_p: // alert it that we want to profile
-			if (input.KeyState(SDLK_LSHIFT) || input.KeyState(SDLK_RSHIFT))
-				Pi::doProfileOne = true;
-			else {
-				Pi::doProfileSlow = !Pi::doProfileSlow;
-				Output("slow frame profiling %s\n", Pi::doProfileSlow ? "enabled" : "disabled");
-			}
-			break;
+	case SDLK_p: // alert it that we want to profile
+		if (input->KeyState(SDLK_LSHIFT) || input->KeyState(SDLK_RSHIFT))
+			Pi::doProfileOne = true;
+		else {
+			Pi::doProfileSlow = !Pi::doProfileSlow;
+			Output("slow frame profiling %s\n", Pi::doProfileSlow ? "enabled" : "disabled");
+		}
+		break;
 #endif
 
-		case SDLK_F12: {
-			if (Pi::game) {
-				vector3d dir = -Pi::player->GetOrient().VectorZ();
-				/* add test object */
-				if (input.KeyState(SDLK_RSHIFT)) {
-					Missile *missile =
-						new Missile(ShipType::MISSILE_GUIDED, Pi::player);
-					missile->SetOrient(Pi::player->GetOrient());
-					missile->SetFrame(Pi::player->GetFrame());
-					missile->SetPosition(Pi::player->GetPosition() + 50.0 * dir);
-					missile->SetVelocity(Pi::player->GetVelocity());
-					game->GetSpace()->AddBody(missile);
-					missile->AIKamikaze(Pi::player->GetCombatTarget());
-				} else if (input.KeyState(SDLK_LSHIFT)) {
-					SpaceStation *s = static_cast<SpaceStation *>(Pi::player->GetNavTarget());
-					if (s) {
-						Ship *ship = new Ship(ShipType::POLICE);
-						int port = s->GetFreeDockingPort(ship);
-						if (port != -1) {
-							Output("Putting ship into station\n");
-							// Make police ship intent on killing the player
-							ship->AIKill(Pi::player);
-							ship->SetFrame(Pi::player->GetFrame());
-							ship->SetDockedWith(s, port);
-							game->GetSpace()->AddBody(ship);
-						} else {
-							delete ship;
-							Output("No docking ports free dude\n");
-						}
-					} else {
-						Output("Select a space station...\n");
-					}
-				} else {
-					Ship *ship = new Ship(ShipType::POLICE);
-					if (!input.KeyState(SDLK_LALT)) { //Left ALT = no AI
-						if (!input.KeyState(SDLK_LCTRL))
-							ship->AIFlyTo(Pi::player); // a less lethal option
-						else
-							ship->AIKill(Pi::player); // a really lethal option!
-					}
-					lua_State *l = Lua::manager->GetLuaState();
-					pi_lua_import(l, "Equipment");
-					LuaTable equip(l, -1);
-					LuaObject<Ship>::CallMethod<>(ship, "AddEquip", equip.Sub("laser").Sub("pulsecannon_dual_1mw"));
-					LuaObject<Ship>::CallMethod<>(ship, "AddEquip", equip.Sub("misc").Sub("laser_cooling_booster"));
-					LuaObject<Ship>::CallMethod<>(ship, "AddEquip", equip.Sub("misc").Sub("atmospheric_shielding"));
-					lua_pop(l, 5);
-					ship->SetFrame(Pi::player->GetFrame());
-					ship->SetPosition(Pi::player->GetPosition() + 100.0 * dir);
-					ship->SetVelocity(Pi::player->GetVelocity());
-					ship->UpdateEquipStats();
-					game->GetSpace()->AddBody(ship);
-				}
-			}
-			break;
-		}
+	case SDLK_F11: // Reload shaders
+		renderer->ReloadShaders();
+		break;
+
+	case SDLK_F12: // Spawn
+	{
+		if (Pi::game)
+			SpawnTestObjects();
+
+		break;
+	}
 #endif /* DEVKEYS */
-#if WITH_OBJECTVIEWER
-		case SDLK_F10:
-			Pi::SetView(Pi::game->GetObjectViewerView());
-			break;
-#endif
-		case SDLK_F11:
-			// XXX only works on X11
-			//SDL_WM_ToggleFullScreen(Pi::scrSurface);
-#if WITH_DEVKEYS
-			renderer->ReloadShaders();
-#endif
-			break;
-		case SDLK_F9: // Quicksave
-		{
-			if (Pi::game) {
-				if (Pi::game->IsHyperspace())
-					Pi::game->log->Add(Lang::CANT_SAVE_IN_HYPERSPACE);
 
-				else {
-					const std::string name = "_quicksave";
-					const std::string path = FileSystem::JoinPath(GetSaveDir(), name);
-					try {
-						Game::SaveGame(name, Pi::game);
-						Pi::game->log->Add(Lang::GAME_SAVED_TO + path);
-					} catch (CouldNotOpenFileException) {
-						Pi::game->log->Add(stringf(Lang::COULD_NOT_OPEN_FILENAME, formatarg("path", path)));
-					} catch (CouldNotWriteToFileException) {
-						Pi::game->log->Add(Lang::GAME_SAVE_CANNOT_WRITE);
-					}
-				}
-			}
+#if WITH_OBJECTVIEWER
+	case SDLK_F10:
+		Pi::SetView(Pi::game->GetObjectViewerView());
+		break;
+#endif
+
+	case SDLK_F9: // Quicksave
+	{
+		if (!Pi::game)
 			break;
+
+		if (Pi::game->IsHyperspace())
+			Pi::game->log->Add(Lang::CANT_SAVE_IN_HYPERSPACE);
+
+		else {
+			const std::string name = "_quicksave";
+			const std::string path = FileSystem::JoinPath(GetSaveDir(), name);
+			try {
+				Game::SaveGame(name, Pi::game);
+				Pi::game->log->Add(Lang::GAME_SAVED_TO + path);
+			} catch (CouldNotOpenFileException) {
+				Pi::game->log->Add(stringf(Lang::COULD_NOT_OPEN_FILENAME, formatarg("path", path)));
+			} catch (CouldNotWriteToFileException) {
+				Pi::game->log->Add(Lang::GAME_SAVE_CANNOT_WRITE);
+			}
 		}
-		default:
-			break; // This does nothing but it stops the compiler warnings
-		}
+		break;
+	}
+	default:
+		break; // This does nothing but it stops the compiler warnings
 	}
 }
 
 void Pi::HandleEscKey()
 {
-	if (currentView != 0) {
-		if (currentView == Pi::game->GetSectorView()) {
-			SetView(Pi::game->GetWorldView());
-		} else if ((currentView == Pi::game->GetSystemView()) || (currentView == Pi::game->GetSystemInfoView())) {
-			SetView(Pi::game->GetSectorView());
-		} else {
-			UIView *view = dynamic_cast<UIView *>(currentView);
-			if (view) {
-				// checks the template name
-				const char *tname = view->GetTemplateName();
-				if (tname) {
-					if (!strcmp(tname, "GalacticView")) {
-						SetView(Pi::game->GetSectorView());
-					} else if (!strcmp(tname, "InfoView") || !strcmp(tname, "StationView")) {
-						SetView(Pi::game->GetWorldView());
-					}
+	if (currentView == 0)
+		return;
+
+	if (currentView == Pi::game->GetSectorView()) {
+		SetView(Pi::game->GetWorldView());
+	} else if ((currentView == Pi::game->GetSystemView()) || (currentView == Pi::game->GetSystemInfoView())) {
+		SetView(Pi::game->GetSectorView());
+	} else {
+		UIView *view = dynamic_cast<UIView *>(currentView);
+		if (view) {
+			// checks the template name
+			const char *tname = view->GetTemplateName();
+			if (tname) {
+				if (!strcmp(tname, "GalacticView")) {
+					SetView(Pi::game->GetSectorView());
+				} else if (!strcmp(tname, "InfoView") || !strcmp(tname, "StationView")) {
+					SetView(Pi::game->GetWorldView());
 				}
 			}
 		}
 	}
 }
 
-void Pi::HandleEvents()
+void Pi::App::HandleEvents()
 {
 	PROFILE_SCOPED()
 	SDL_Event event;
@@ -876,7 +861,7 @@ void Pi::HandleEvents()
 	// unified input system
 	bool skipTextInput = false;
 
-	Pi::input.mouseMotion[0] = Pi::input.mouseMotion[1] = 0;
+	Pi::input->mouseMotion[0] = Pi::input->mouseMotion[1] = 0;
 	while (SDL_PollEvent(&event)) {
 		if (event.type == SDL_QUIT) {
 			Pi::RequestQuit();
@@ -885,7 +870,7 @@ void Pi::HandleEvents()
 		Pi::pigui->ProcessEvent(&event);
 
 		// Input system takes priority over mouse events when capturing the mouse
-		if (Pi::pigui->WantCaptureMouse() && !Pi::input.IsCapturingMouse()) {
+		if (Pi::pigui->WantCaptureMouse() && !Pi::input->IsCapturingMouse()) {
 			// don't process mouse event any further, imgui already handled it
 			switch (event.type) {
 			case SDL_MOUSEBUTTONDOWN:
@@ -930,82 +915,78 @@ void Pi::HandleEvents()
 			continue;
 
 		Gui::HandleSDLEvent(&event);
-		input.HandleSDLEvent(event);
+		input->HandleSDLEvent(event);
 	}
 }
 
-void Pi::HandleRequests()
+void Pi::App::HandleRequests()
 {
 	for (auto request : internalRequests) {
 		switch (request) {
-		case END_GAME:
-			EndGame();
-			break;
-		case QUIT_GAME:
-			Quit();
-			break;
+		case InternalRequests::END_GAME: {
+			if (!Pi::game)
+				break;
+
+			m_gameLoop->RequestEndLifecycle();
+		} break;
+		case InternalRequests::QUIT_GAME: {
+			GetActiveLifecycle()->RequestEndLifecycle();
+			RequestQuit();
+		} break;
 		default:
-			Output("Pi::HandleRequests, unhandled request type processed.\n");
+			Output("Pi::HandleRequests, unhandled request type %d processed.\n", int(request));
 			break;
 		}
 	}
 	internalRequests.clear();
 }
 
-void Pi::TombStoneLoop()
+/*
+===============================================================================
+	GAME LOOP
+===============================================================================
+*/
+
+void Pi::App::PreUpdate()
 {
-	std::unique_ptr<Tombstone> tombstone(new Tombstone(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight()));
-	Uint32 last_time = SDL_GetTicks();
-	float _time = 0;
-	do {
-		Pi::HandleEvents();
-		Pi::input.SetCapturingMouse(false);
+	Pi::frameTime = DeltaTime();
 
-		// render the scene
-		Pi::BeginRenderTarget();
-		Pi::renderer->BeginFrame();
-		tombstone->Draw(_time);
-		Pi::renderer->EndFrame();
-		Gui::Draw();
-		Pi::EndRenderTarget();
-
-		Pi::DrawRenderTarget();
-		Pi::renderer->SwapBuffers();
-
-		Pi::HandleRequests();
-
-		Pi::frameTime = 0.001f * (SDL_GetTicks() - last_time);
-		_time += Pi::frameTime;
-		last_time = SDL_GetTicks();
-	} while (!((_time > 2.0) && ((input.MouseButtonState(SDL_BUTTON_LEFT)) || input.KeyState(SDLK_SPACE))));
+	GuiApplication::PreUpdate();
 }
 
-void Pi::InitGame()
+void Pi::App::PostUpdate()
+{
+	GuiApplication::PostUpdate();
+
+	HandleRequests();
+}
+
+void Pi::App::RunJobs()
+{
+	Pi::syncJobQueue->RunJobs(SYNC_JOBS_PER_LOOP);
+	Pi::asyncJobQueue->FinishJobs();
+	Pi::syncJobQueue->FinishJobs();
+}
+
+// FIXME: delete/move this function out of Pi.cpp
+static void OnPlayerDockOrUndock();
+
+void GameLoop::Start()
 {
 	// this is a bit brittle. skank may be forgotten and survive between
 	// games
+	Pi::input->InitGame();
 
-	input.InitGame();
+	if (!Pi::config->Int("DisableSound")) AmbientSounds::Init();
 
-	if (!config->Int("DisableSound")) AmbientSounds::Init();
+	LuaEvent::Clear();
 
-	LuaInitGame();
-}
-
-static void OnPlayerDockOrUndock()
-{
-	Pi::game->RequestTimeAccel(Game::TIMEACCEL_1X);
-	Pi::game->SetTimeAccel(Game::TIMEACCEL_1X);
-}
-
-void Pi::StartGame()
-{
 	Pi::player->onDock.connect(sigc::ptr_fun(&OnPlayerDockOrUndock));
 	Pi::player->onUndock.connect(sigc::ptr_fun(&OnPlayerDockOrUndock));
 	Pi::player->onLanded.connect(sigc::ptr_fun(&OnPlayerDockOrUndock));
 	Pi::game->GetCpan()->ShowAll();
-	DrawGUI = true;
-	SetView(game->GetWorldView());
+	Pi::DrawGUI = true;
+	Pi::SetView(Pi::game->GetWorldView());
 
 #ifdef REMOTE_LUA_REPL
 #ifndef REMOTE_LUA_REPL_PORT
@@ -1017,399 +998,487 @@ void Pi::StartGame()
 	// fire event before the first frame
 	LuaEvent::Queue("onGameStart");
 	LuaEvent::Emit();
+
+	perfInfoDisplay.reset(new PiGUI::PerfInfo());
+
+	frame_stat = 0;
+	phys_stat = 0;
+	accumulator = Pi::game->GetTimeStep();
+	time_player_died = 0.0;
+
+	MAX_PHYSICS_TICKS = Pi::config->Int("MaxPhysicsCyclesPerRender");
+	if (MAX_PHYSICS_TICKS <= 0)
+		MAX_PHYSICS_TICKS = 4;
+
+	Pi::SetGameTickAlpha(0);
+	// If we have a tombstone loop, we will SetNextLifecycle() so it runs before
+	// we jump back to the main menu
+	Pi::GetApp()->QueueLifecycle(Pi::GetApp()->m_mainMenu);
 }
 
-void Pi::Start(const SystemPath &startPath)
+void GameLoop::Update(float deltaTime)
 {
-	Pi::intro = new Intro(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
-	if (startPath != SystemPath(0, 0, 0, 0, 0)) {
-		Pi::game = new Game(startPath, 0.0);
-	}
-	//XXX global ambient colour hack to make explicit the old default ambient colour dependency
-	// for some models
-	Pi::renderer->SetAmbientColor(Color(51, 51, 51, 255));
-
-	Uint32 last_time = SDL_GetTicks();
-	float _time = 0;
-
-	while (!Pi::game) {
-		SDL_Event event;
-		while (SDL_PollEvent(&event)) {
-			if (event.type == SDL_QUIT)
-				Pi::RequestQuit();
-			else {
-				Pi::pigui->ProcessEvent(&event);
-
-				if (Pi::pigui->WantCaptureMouse()) {
-					// don't process mouse event any further, imgui already handled it
-					switch (event.type) {
-					case SDL_MOUSEBUTTONDOWN:
-					case SDL_MOUSEBUTTONUP:
-					case SDL_MOUSEWHEEL:
-					case SDL_MOUSEMOTION:
-						continue;
-					default: break;
-					}
-				}
-				if (Pi::pigui->WantCaptureKeyboard()) {
-					// don't process keyboard event any further, imgui already handled it
-					switch (event.type) {
-					case SDL_KEYDOWN:
-					case SDL_KEYUP:
-					case SDL_TEXTINPUT:
-						continue;
-					default: break;
-					}
-				}
-
-				ui->DispatchSDLEvent(event);
-
-				input.HandleSDLEvent(event);
-			}
-			// XXX hack
-			// if we hit our exit conditions then ignore further queued events
-			// protects against eg double-click during game generation
-			if (Pi::game)
-				while (SDL_PollEvent(&event)) {
-				}
-		}
-
-		Pi::BeginRenderTarget();
-		Pi::renderer->BeginFrame();
-		intro->Draw(_time);
-		Pi::renderer->EndFrame();
-
-		Pi::pigui->NewFrame(Pi::renderer->GetSDLWindow());
-		DrawPiGui(Pi::frameTime, "MAINMENU");
-
-		Pi::pigui->Render();
-		Pi::EndRenderTarget();
-
-		// render the rendertarget texture
-		Pi::DrawRenderTarget();
-		Pi::renderer->SwapBuffers();
-
-		Pi::frameTime = 0.001f * (SDL_GetTicks() - last_time);
-		_time += Pi::frameTime;
-		last_time = SDL_GetTicks();
-
-		Pi::HandleRequests();
+	PROFILE_SCOPED()
+	perfTimer.SoftReset();			   // Reset() + Start()
+	frame_time_real = deltaTime * 1e3; // convert to ms
+	frame_stat++;
 
 #ifdef ENABLE_SERVER_AGENT
-		Pi::serverAgent->ProcessResponses();
+	Pi::serverAgent->ProcessResponses();
 #endif
+
+	// TODO: is it necessary to limit frame delta to 1/4th second?
+	// Presumably if we're rendering < 4 FPS, we don't care about physics error either
+	// if (Pi::frameTime > 0.25) Pi::frameTime = 0.25;
+
+	accumulator += deltaTime * Pi::game->GetTimeAccelRate();
+
+	const float step = Pi::game->GetTimeStep();
+	if (step > 0.0f) {
+		PROFILE_SCOPED_RAW("Physics Update [unpaused]")
+		int phys_ticks = 0;
+		while (accumulator >= step) {
+			if (++phys_ticks >= MAX_PHYSICS_TICKS) {
+				accumulator = 0.0;
+				break;
+			}
+
+			Pi::game->TimeStep(step);
+			BaseSphere::UpdateAllBaseSphereDerivatives();
+
+			accumulator -= step;
+		}
+
+		// rendering interpolation between frames: don't use when docked
+		// FIXME: this is the player's concern, the player should be responsible for calling Pi::SetInterpolation(false) when docked
+		int pstate = Pi::game->GetPlayer()->GetFlightState();
+		if (pstate == Ship::DOCKED || pstate == Ship::DOCKING || pstate == Ship::UNDOCKING)
+			Pi::SetGameTickAlpha(1.0);
+		else
+			Pi::SetGameTickAlpha(accumulator / step);
+
+		phys_stat += phys_ticks;
+	} else {
+		// paused
+		PROFILE_SCOPED_RAW("Physics Update [paused]")
+		BaseSphere::UpdateAllBaseSphereDerivatives();
 	}
 
-	delete Pi::intro;
-	Pi::intro = 0;
+	// Record physics timestep but keep information about current frame timing.
+	perfTimer.SoftStop();
+	// store the physics time until the end of the frame
+	phys_time = perfTimer.milliseconds();
 
-	InitGame();
-	StartGame();
-	MainLoop();
+	// did the player die?
+	if (Pi::game->GetPlayer()->IsDead()) {
+		// FIXME: this is NOT Pi's concern at all! At the very minimum, this should go in Game.cpp
+		if (!(time_player_died > 0.0)) {
+			Pi::game->SetTimeAccel(Game::TIMEACCEL_1X);
+			Pi::game->GetDeathView()->Init();
+			Pi::SetView(Pi::game->GetDeathView());
+			time_player_died = Pi::game->GetTime();
+		} else if (Pi::game->GetTime() - time_player_died > 8.0) {
+			// This also shouldn't go here, though we should evaluate to what degree
+			// Pi.cpp is involved in queuing the tombstone loop.
+			SetNextLifecycle(std::make_shared<TombstoneLoop>());
+			RequestEndLifecycle();
+		}
+	}
+
+	Pi::renderer->SetTransform(matrix4x4f::Identity());
+
+	/* Calculate position for this rendered frame (interpolated between two physics ticks */
+	// XXX should this be here? what is this anyway?
+	for (Body *b : Pi::game->GetSpace()->GetBodies()) {
+		b->UpdateInterpTransform(Pi::GetGameTickAlpha());
+	}
+	Frame::GetFrame(Pi::game->GetSpace()->GetRootFrame())->UpdateInterpTransform(Pi::GetGameTickAlpha());
+
+	Pi::GetView()->Update();
+	Pi::GetView()->Draw3D();
+
+	// FIXME: HandleEvents at the moment must be after view->Draw3D and before
+	// Gui::Draw so that labels drawn to screen can have mouse events correctly
+	// detected. Gui::Draw wipes memory of label positions.
+	Pi::GetApp()->HandleEvents();
+
+#ifdef REMOTE_LUA_REPL
+	Pi::luaConsole->HandleTCPDebugConnections();
+#endif
+
+	// Reset the depth buffer so our UI can get drawn right overtop
+	Pi::renderer->ClearDepthBuffer();
+
+	// FIXME: GUI must die!
+	if (Pi::DrawGUI) {
+		Gui::Draw();
+	}
+
+	// FIXME: newUI must die!
+	// ...also we need better handling of death states
+	// XXX don't draw the UI during death obviously a hack, and still
+	// wrong, because we shouldn't this when the HUD is disabled, but
+	// probably sure draw it if they switch to eg infoview while the HUD is
+	// disabled so we need much smarter control for all this rubbish
+	if ((!Pi::game || Pi::GetView() != Pi::game->GetDeathView()) && Pi::DrawGUI) {
+		Pi::ui->Update();
+		Pi::ui->Draw();
+	}
+
+	// TODO: the escape menu depends on HandleEvents() being called before NewFrame()
+	// Move HandleEvents to either the end of the loop or the very start of the loop
+	// The goal is to be able to call imgui functions for debugging inside C++ code
+	Pi::pigui->NewFrame(Pi::renderer->GetSDLWindow());
+
+	if (Pi::game && !Pi::player->IsDead()) {
+		// FIXME: Always begin a camera frame because WorldSpaceToScreenSpace
+		// requires it and is exposed to pigui.
+		Pi::game->GetWorldView()->BeginCameraFrame();
+		// FIXME: major hack to work around the fact that the console is in newUI and not pigui
+		if (!Pi::IsConsoleActive())
+			Pi::pigui->RunHandler(deltaTime, "GAME");
+		Pi::game->GetWorldView()->EndCameraFrame();
+	}
+
+#if WITH_DEVKEYS
+	// Render this even when we're dead.
+	if (Pi::showDebugInfo) {
+		perfInfoDisplay->Draw();
+	}
+#endif
+
+	Pi::pigui->Render();
+
+	if (Pi::game->UpdateTimeAccel())
+		accumulator = 0; // fix for huge pauses 10000x -> 1x
+
+	if (!Pi::player->IsDead()) {
+		// XXX should this really be limited to while the player is alive?
+		// this is something we need not do every turn...
+		if (!Pi::config->Int("DisableSound")) AmbientSounds::Update();
+	}
+
+	Pi::GetMusicPlayer().Update();
+
+	// FIXME: oldUI must DIEEEEE!
+	Pi::game->GetCpan()->Update();
+
+	Pi::GetApp()->RunJobs();
+
+#if WITH_DEVKEYS
+	perfInfoDisplay->Update(frame_time_real, phys_time);
+	if (Pi::showDebugInfo && SDL_GetTicks() - last_stats >= 1000) {
+		perfInfoDisplay->UpdateFrameInfo(frame_stat, phys_stat);
+		frame_stat = 0;
+		phys_stat = 0;
+		Text::TextureFont::ClearGlyphCount();
+		if (SDL_GetTicks() - last_stats > 1200)
+			last_stats = SDL_GetTicks();
+		else
+			last_stats += 1000;
+	}
+	Pi::statSceneTris = 0;
+	Pi::statNumPatches = 0;
+
+#ifdef PIONEER_PROFILER
+	const Uint32 profTicks = SDL_GetTicks();
+	if (Pi::doProfileOne || (Pi::doProfileSlow && (deltaTime > 0.1))) { // slow: < ~10fps
+		Output("dumping profile data\n");
+		Profiler::dumphtml(Pi::profilerPath.c_str());
+		Pi::doProfileOne = false;
+	}
+#endif
+
+#endif
+
+#if 0 // FIXME: decouple video recording from Pi
+	if (Pi::isRecordingVideo && (Pi::ffmpegFile != nullptr)) {
+		Graphics::ScreendumpState sd;
+		Pi::renderer->FrameGrab(sd);
+		fwrite(sd.pixels.get(), sizeof(uint32_t) * Pi::renderer->GetWindowWidth() * Pi::renderer->GetWindowHeight(), 1, Pi::ffmpegFile);
+	}
+#endif
 }
 
-// request that the game is ended as soon as safely possible
-void Pi::RequestEndGame()
+void GameLoop::End()
 {
-	internalRequests.push_back(END_GAME);
-}
+	// When Pi::game goes, so too goes the death view.
+	Pi::SetView(0);
 
-void Pi::RequestQuit()
-{
-	internalRequests.push_back(QUIT_GAME);
-}
+	// Clean up any left-over mouse state
+	Pi::input->SetCapturingMouse(false);
+	perfInfoDisplay.reset();
 
-void Pi::EndGame()
-{
 	Pi::SetMouseGrab(false);
 
-	Pi::musicPlayer.Stop();
+	Pi::GetMusicPlayer().Stop();
 	Sound::DestroyAllEvents();
 
 	// final event
 	LuaEvent::Queue("onGameEnd");
 	LuaEvent::Emit();
 
-	luaTimer->RemoveAll();
+	Pi::luaTimer->RemoveAll();
 
 	Lua::manager->CollectGarbage();
 
-	if (!config->Int("DisableSound")) AmbientSounds::Uninit();
+	if (!Pi::config->Int("DisableSound")) AmbientSounds::Uninit();
 	Sound::DestroyAllEvents();
 
-	assert(game);
-	delete game;
-	game = 0;
-	player = 0;
+	assert(Pi::game);
+	delete Pi::game;
+	Pi::game = nullptr;
+	Pi::player = nullptr;
 }
 
-void Pi::MainLoop()
+/*
+===============================================================================
+	TOMBSTONE LOOP
+===============================================================================
+*/
+
+void TombstoneLoop::Start()
 {
-	double time_player_died = 0;
-#ifdef MAKING_VIDEO
-	Uint32 last_screendump = SDL_GetTicks();
-	int dumpnum = 0;
-#endif /* MAKING_VIDEO */
+	tombstone.reset(new Tombstone(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight()));
+	startTime = Pi::GetApp()->GetTime();
+}
 
-#if WITH_DEVKEYS
-	Uint32 last_stats = SDL_GetTicks();
-	int frame_stat = 0;
-	int phys_stat = 0;
-	// FIXME: this is a hack, this class should have its lifecycle managed elsewhere
-	// Ideally an application framework class handles this (as well as the rest of the main loop)
-	// but for now this is the best we have.
-	std::unique_ptr<PiGUI::PerfInfo> perfInfoDisplay(new PiGUI::PerfInfo());
-#endif
+void TombstoneLoop::Update(float deltaTime)
+{
+	Pi::GetApp()->HandleEvents();
 
-	int MAX_PHYSICS_TICKS = Pi::config->Int("MaxPhysicsCyclesPerRender");
-	if (MAX_PHYSICS_TICKS <= 0)
-		MAX_PHYSICS_TICKS = 4;
+	// TODO: improve Tombstone, add pigui drawing, etc.
+	tombstone->Draw(accumTime);
+	accumTime += deltaTime;
 
-	// Used to measure frame and physics performance timing info
-	// with no portable way to map cycles -> ns, Profiler::Timer is useless for taking measurements
-	// Use Profiler::Clock which is backed by std::chrono::steady_clock (== high_resolution_clock for 99% of uses)
-	Profiler::Clock perfTimer;
-	float frame_time_real = 0; // higher resolution than SDL's 1ms, for detailed frame info
-	float phys_time = 0;
+	bool hasInput = Pi::input->MouseButtonState(SDL_BUTTON_LEFT) || Pi::input->MouseButtonState(SDL_BUTTON_RIGHT) || Pi::input->KeyState(SDLK_SPACE);
 
-	double currentTime = 0.001 * double(SDL_GetTicks());
-	double accumulator = Pi::game->GetTimeStep();
-	Pi::gameTickAlpha = 0;
+	if ((accumTime > 2.0 && hasInput) || accumTime > 8.0)
+		RequestEndLifecycle();
+}
 
-#ifdef PIONEER_PROFILER
-	Profiler::reset();
-#endif
+/*
+===============================================================================
+	MISCELLANEOUS GARBAGE THAT OUGHT NOT TO BE IN THIS CLASS
+===============================================================================
+*/
 
-	while (Pi::game) {
-		PROFILE_SCOPED()
-		perfTimer.Reset();
-		perfTimer.Start();
-
-#ifdef ENABLE_SERVER_AGENT
-		Pi::serverAgent->ProcessResponses();
-#endif
-
-		const Uint32 newTicks = SDL_GetTicks();
-		double newTime = 0.001 * double(newTicks);
-		Pi::frameTime = newTime - currentTime;
-		if (Pi::frameTime > 0.25) Pi::frameTime = 0.25;
-		currentTime = newTime;
-		accumulator += Pi::frameTime * Pi::game->GetTimeAccelRate();
-
-		const float step = Pi::game->GetTimeStep();
-		if (step > 0.0f) {
-			PROFILE_SCOPED_RAW("unpaused")
-			int phys_ticks = 0;
-			while (accumulator >= step) {
-				if (++phys_ticks >= MAX_PHYSICS_TICKS) {
-					accumulator = 0.0;
-					break;
-				}
-				game->TimeStep(step);
-				BaseSphere::UpdateAllBaseSphereDerivatives();
-
-				accumulator -= step;
-			}
-			// rendering interpolation between frames: don't use when docked
-			int pstate = Pi::game->GetPlayer()->GetFlightState();
-			if (pstate == Ship::DOCKED || pstate == Ship::DOCKING || pstate == Ship::UNDOCKING)
-				Pi::gameTickAlpha = 1.0;
-			else
-				Pi::gameTickAlpha = accumulator / step;
-
-#if WITH_DEVKEYS
-			phys_stat += phys_ticks;
-#endif
-		} else {
-			// paused
-			PROFILE_SCOPED_RAW("paused")
-			BaseSphere::UpdateAllBaseSphereDerivatives();
-		}
-#if WITH_DEVKEYS
-		frame_stat++;
-#endif
-		// Record physics timestep but keep information about current frame timing.
-		perfTimer.SoftStop();
-		phys_time = perfTimer.milliseconds();
-
-		// did the player die?
-		if (Pi::player->IsDead()) {
-			if (time_player_died > 0.0) {
-				if (Pi::game->GetTime() - time_player_died > 8.0) {
-					Pi::SetView(0);
-					Pi::TombStoneLoop();
-					Pi::EndGame();
-					break;
-				}
-			} else {
-				Pi::game->SetTimeAccel(Game::TIMEACCEL_1X);
-				Pi::game->GetDeathView()->Init();
-				Pi::SetView(Pi::game->GetDeathView());
-				time_player_died = Pi::game->GetTime();
+SceneGraph::Model *Pi::FindModel(const std::string &name, bool allowPlaceholder)
+{
+	SceneGraph::Model *m = 0;
+	try {
+		m = Pi::modelCache->FindModel(name);
+	} catch (const ModelCache::ModelNotFoundException &) {
+		Output("Could not find model: %s\n", name.c_str());
+		if (allowPlaceholder) {
+			try {
+				m = Pi::modelCache->FindModel("error");
+			} catch (const ModelCache::ModelNotFoundException &) {
+				Error("Could not find placeholder model");
 			}
 		}
-
-		Pi::BeginRenderTarget();
-		Pi::renderer->SetViewport(0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
-		Pi::renderer->BeginFrame();
-		Pi::renderer->SetTransform(matrix4x4f::Identity());
-
-		/* Calculate position for this rendered frame (interpolated between two physics ticks */
-		// XXX should this be here? what is this anyway?
-		for (Body *b : game->GetSpace()->GetBodies()) {
-			b->UpdateInterpTransform(Pi::GetGameTickAlpha());
-		}
-		Frame::GetFrame(game->GetSpace()->GetRootFrame())->UpdateInterpTransform(Pi::GetGameTickAlpha());
-
-		currentView->Update();
-		currentView->Draw3D();
-
-		// XXX HandleEvents at the moment must be after view->Draw3D and before
-		// Gui::Draw so that labels drawn to screen can have mouse events correctly
-		// detected. Gui::Draw wipes memory of label positions.
-		Pi::HandleEvents();
-
-#ifdef REMOTE_LUA_REPL
-		Pi::luaConsole->HandleTCPDebugConnections();
-#endif
-
-		Pi::renderer->EndFrame();
-
-		Pi::renderer->ClearDepthBuffer();
-		if (DrawGUI) {
-			Gui::Draw();
-		}
-
-		// XXX don't draw the UI during death obviously a hack, and still
-		// wrong, because we shouldn't this when the HUD is disabled, but
-		// probably sure draw it if they switch to eg infoview while the HUD is
-		// disabled so we need much smarter control for all this rubbish
-		if ((!Pi::game || Pi::GetView() != Pi::game->GetDeathView()) && DrawGUI) {
-			Pi::ui->Update();
-			Pi::ui->Draw();
-		}
-
-		Pi::EndRenderTarget();
-		Pi::DrawRenderTarget();
-
-		// TODO: the escape menu depends on HandleEvents() being called before NewFrame()
-		// Move HandleEvents to either the end of the loop or the very start of the loop
-		// The goal is to be able to call imgui functions for debugging inside C++ code
-		Pi::pigui->NewFrame(Pi::renderer->GetSDLWindow());
-
-		if (Pi::game && !Pi::player->IsDead()) {
-			// FIXME: Always begin a camera frame because WorldSpaceToScreenSpace
-			// requires it and is exposed to pigui.
-			Pi::game->GetWorldView()->BeginCameraFrame();
-			DrawPiGui(Pi::frameTime, "GAME");
-			Pi::game->GetWorldView()->EndCameraFrame();
-		}
-
-#if WITH_DEVKEYS
-		// Render this even when we're dead.
-		if (Pi::showDebugInfo) {
-			perfInfoDisplay->Draw();
-		}
-#endif
-
-		Pi::pigui->Render();
-		Pi::renderer->SwapBuffers();
-
-		// game exit will have cleared Pi::game. we can't continue.
-		if (!Pi::game)
-			return;
-
-		if (Pi::game->UpdateTimeAccel())
-			accumulator = 0; // fix for huge pauses 10000x -> 1x
-
-		if (!Pi::player->IsDead()) {
-			// XXX should this really be limited to while the player is alive?
-			// this is something we need not do every turn...
-			if (!config->Int("DisableSound")) AmbientSounds::Update();
-		}
-		Pi::game->GetCpan()->Update();
-		musicPlayer.Update();
-
-		syncJobQueue->RunJobs(SYNC_JOBS_PER_LOOP);
-		asyncJobQueue->FinishJobs();
-		syncJobQueue->FinishJobs();
-
-		HandleRequests();
-
-#if WITH_DEVKEYS
-		perfInfoDisplay->Update(frame_time_real, phys_time);
-		if (Pi::showDebugInfo && SDL_GetTicks() - last_stats >= 1000) {
-			perfInfoDisplay->UpdateFrameInfo(frame_stat, phys_stat);
-			frame_stat = 0;
-			phys_stat = 0;
-			Text::TextureFont::ClearGlyphCount();
-			if (SDL_GetTicks() - last_stats > 1200)
-				last_stats = SDL_GetTicks();
-			else
-				last_stats += 1000;
-		}
-		Pi::statSceneTris = 0;
-		Pi::statNumPatches = 0;
-
-#ifdef PIONEER_PROFILER
-		const Uint32 profTicks = SDL_GetTicks();
-		if (Pi::doProfileOne || (Pi::doProfileSlow && (profTicks - newTicks) > 100)) { // slow: < ~10fps
-			Output("dumping profile data\n");
-			Profiler::dumphtml(profilerPath.c_str());
-			Pi::doProfileOne = false;
-		}
-#endif
-
-#endif
-
-#ifdef MAKING_VIDEO
-		if (SDL_GetTicks() - last_screendump > 50) {
-			last_screendump = SDL_GetTicks();
-			std::string fname = stringf(Lang::SCREENSHOT_FILENAME_TEMPLATE, formatarg("index", dumpnum++));
-			Screendump(fname.c_str(), Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
-		}
-#endif /* MAKING_VIDEO */
-
-		if (isRecordingVideo && (Pi::ffmpegFile != nullptr)) {
-			Graphics::ScreendumpState sd;
-			Pi::renderer->FrameGrab(sd);
-			fwrite(sd.pixels.get(), sizeof(uint32_t) * Pi::renderer->GetWindowWidth() * Pi::renderer->GetWindowHeight(), 1, Pi::ffmpegFile);
-		}
-
-#ifdef PIONEER_PROFILER
-		Profiler::reset();
-#endif
-
-		perfTimer.Stop();
-		frame_time_real = perfTimer.milliseconds();
 	}
+
+	return m;
+}
+
+const char Pi::SAVE_DIR_NAME[] = "savefiles";
+
+std::string Pi::GetSaveDir()
+{
+	return FileSystem::JoinPath(FileSystem::GetUserDir(), Pi::SAVE_DIR_NAME);
+}
+
+// request that the game is ended as soon as safely possible
+void Pi::RequestEndGame()
+{
+	GetApp()->internalRequests.push_back(App::InternalRequests::END_GAME);
+}
+
+void Pi::RequestQuit()
+{
+	GetApp()->internalRequests.push_back(App::InternalRequests::QUIT_GAME);
+}
+
+/*
+	GARBAGE THAT ESPECIALLY SHOULD NOT BE HERE
+*/
+
+bool Pi::IsConsoleActive()
+{
+	return luaConsole && luaConsole->IsActive();
+}
+
+void Pi::SetView(View *v)
+{
+	if (currentView) currentView->Detach();
+	currentView = v;
+	if (currentView) currentView->Attach();
+}
+
+void Pi::OnChangeDetailLevel()
+{
+	BaseSphere::OnChangeDetailLevel();
+}
+
+static void OnPlayerDockOrUndock()
+{
+	Pi::game->RequestTimeAccel(Game::TIMEACCEL_1X);
+	Pi::game->SetTimeAccel(Game::TIMEACCEL_1X);
 }
 
 float Pi::GetMoveSpeedShiftModifier()
 {
 	// Suggestion: make x1000 speed on pressing both keys?
-	if (input.KeyState(SDLK_LSHIFT)) return 100.f;
-	if (input.KeyState(SDLK_RSHIFT)) return 10.f;
+	if (Pi::input->KeyState(SDLK_LSHIFT)) return 100.f;
+	if (Pi::input->KeyState(SDLK_RSHIFT)) return 10.f;
 	return 1;
 }
 
 void Pi::SetMouseGrab(bool on)
 {
 	if (!doingMouseGrab && on) {
-		Pi::input.SetCapturingMouse(true);
+		Pi::input->SetCapturingMouse(true);
 		Pi::ui->SetMousePointerEnabled(false);
 		doingMouseGrab = true;
 	} else if (doingMouseGrab && !on) {
-		Pi::input.SetCapturingMouse(false);
+		Pi::input->SetCapturingMouse(false);
 		Pi::ui->SetMousePointerEnabled(true);
 		doingMouseGrab = false;
 	}
 }
 
-void Pi::DrawPiGui(double delta, std::string handler)
+// This absolutely ought not to be part of the Pi class
+#if 0
+static void SetVideoRecording(bool enabled)
 {
-	PROFILE_SCOPED()
+	Pi::isRecordingVideo = enabled;
+	if (Pi::isRecordingVideo) {
+		char videoName[256];
+		const time_t t = time(0);
+		struct tm *_tm = localtime(&t);
+		strftime(videoName, sizeof(videoName), "pioneer-%Y%m%d-%H%M%S", _tm);
+		const std::string dir = "videos";
+		FileSystem::userFiles.MakeDirectory(dir);
+		const std::string fname = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot() + "/" + dir, videoName);
+		Output("Video Recording started to %s.\n", fname.c_str());
+		// start ffmpeg telling it to expect raw rgba 720p-60hz frames
+		// -i - tells it to read frames from stdin
+		// if given no frame rate (-r 60), it will just use vfr
+		char cmd[256] = { 0 };
+		snprintf(cmd, sizeof(cmd), "ffmpeg -f rawvideo -pix_fmt rgba -s %dx%d -i - -threads 0 -preset fast -y -pix_fmt yuv420p -crf 21 -vf vflip %s.mp4", config->Int("ScrWidth"), config->Int("ScrHeight"), fname.c_str());
 
-	if (!IsConsoleActive())
-		Pi::pigui->RunHandler(delta, handler);
+		// open pipe to ffmpeg's stdin in binary write mode
+#if defined(_MSC_VER) || defined(__MINGW32__)
+		Pi::ffmpegFile = _popen(cmd, "wb");
+#else
+		Pi::ffmpegFile = _popen(cmd, "w");
+#endif
+	} else {
+		Output("Video Recording ended.\n");
+		if (Pi::ffmpegFile != nullptr) {
+			_pclose(Pi::ffmpegFile);
+			Pi::ffmpegFile = nullptr;
+		}
+	}
+}
+#endif
+
+static void SpawnTestObjects()
+{
+	vector3d dir = -Pi::player->GetOrient().VectorZ();
+	/* add test object */
+	if (Pi::input->KeyState(SDLK_RSHIFT)) {
+		Missile *missile =
+			new Missile(ShipType::MISSILE_GUIDED, Pi::player);
+		missile->SetOrient(Pi::player->GetOrient());
+		missile->SetFrame(Pi::player->GetFrame());
+		missile->SetPosition(Pi::player->GetPosition() + 50.0 * dir);
+		missile->SetVelocity(Pi::player->GetVelocity());
+		Pi::game->GetSpace()->AddBody(missile);
+		missile->AIKamikaze(Pi::player->GetCombatTarget());
+	} else if (Pi::input->KeyState(SDLK_LSHIFT)) {
+		SpaceStation *s = static_cast<SpaceStation *>(Pi::player->GetNavTarget());
+		if (s) {
+			Ship *ship = new Ship(ShipType::POLICE);
+			int port = s->GetFreeDockingPort(ship);
+			if (port != -1) {
+				Output("Putting ship into station\n");
+				// Make police ship intent on killing the player
+				ship->AIKill(Pi::player);
+				ship->SetFrame(Pi::player->GetFrame());
+				ship->SetDockedWith(s, port);
+				Pi::game->GetSpace()->AddBody(ship);
+			} else {
+				delete ship;
+				Output("No docking ports free dude\n");
+			}
+		} else {
+			Output("Select a space station...\n");
+		}
+	} else {
+		Ship *ship = new Ship(ShipType::POLICE);
+		if (!Pi::input->KeyState(SDLK_LALT)) { //Left ALT = no AI
+			if (!Pi::input->KeyState(SDLK_LCTRL))
+				ship->AIFlyTo(Pi::player); // a less lethal option
+			else
+				ship->AIKill(Pi::player); // a really lethal option!
+		}
+		lua_State *l = Lua::manager->GetLuaState();
+		pi_lua_import(l, "Equipment");
+		LuaTable equip(l, -1);
+		LuaObject<Ship>::CallMethod<>(ship, "AddEquip", equip.Sub("laser").Sub("pulsecannon_dual_1mw"));
+		LuaObject<Ship>::CallMethod<>(ship, "AddEquip", equip.Sub("misc").Sub("laser_cooling_booster"));
+		LuaObject<Ship>::CallMethod<>(ship, "AddEquip", equip.Sub("misc").Sub("atmospheric_shielding"));
+		lua_pop(l, 5);
+		ship->SetFrame(Pi::player->GetFrame());
+		ship->SetPosition(Pi::player->GetPosition() + 100.0 * dir);
+		ship->SetVelocity(Pi::player->GetVelocity());
+		ship->UpdateEquipStats();
+		Pi::game->GetSpace()->AddBody(ship);
+	}
+}
+
+void printShipStats()
+{
+	// test code to produce list of ship stats
+
+	FILE *pStatFile = fopen("shipstat.csv", "wt");
+	if (pStatFile) {
+		fprintf(pStatFile, "name,modelname,hullmass,capacity,fakevol,rescale,xsize,ysize,zsize,facc,racc,uacc,sacc,aacc,exvel\n");
+		for (auto iter : ShipType::types) {
+			const ShipType *shipdef = &(iter.second);
+			SceneGraph::Model *model = Pi::FindModel(shipdef->modelName, false);
+
+			double hullmass = shipdef->hullMass;
+			double capacity = shipdef->capacity;
+
+			double xsize = 0.0, ysize = 0.0, zsize = 0.0, fakevol = 0.0, rescale = 0.0, brad = 0.0;
+			if (model) {
+				std::unique_ptr<SceneGraph::Model> inst(model->MakeInstance());
+				model->CreateCollisionMesh();
+				Aabb aabb = model->GetCollisionMesh()->GetAabb();
+				xsize = aabb.max.x - aabb.min.x;
+				ysize = aabb.max.y - aabb.min.y;
+				zsize = aabb.max.z - aabb.min.z;
+				fakevol = xsize * ysize * zsize;
+				brad = aabb.GetRadius();
+				rescale = pow(fakevol / (100 * (hullmass + capacity)), 0.3333333333);
+			}
+
+			double simass = (hullmass + capacity) * 1000.0;
+			double angInertia = (2 / 5.0) * simass * brad * brad;
+			double acc1 = shipdef->linThrust[Thruster::THRUSTER_FORWARD] / (9.81 * simass);
+			double acc2 = shipdef->linThrust[Thruster::THRUSTER_REVERSE] / (9.81 * simass);
+			double acc3 = shipdef->linThrust[Thruster::THRUSTER_UP] / (9.81 * simass);
+			double acc4 = shipdef->linThrust[Thruster::THRUSTER_RIGHT] / (9.81 * simass);
+			double acca = shipdef->angThrust / angInertia;
+			double exvel = shipdef->effectiveExhaustVelocity;
+
+			fprintf(pStatFile, "%s,%s,%.1f,%.1f,%.1f,%.3f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%.1f,%f,%.1f\n",
+				shipdef->name.c_str(), shipdef->modelName.c_str(), hullmass, capacity,
+				fakevol, rescale, xsize, ysize, zsize, acc1, acc2, acc3, acc4, acca, exvel);
+		}
+		fclose(pStatFile);
+	}
 }

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -155,11 +155,6 @@ public:
 	static std::string GetSaveDir();
 	static SceneGraph::Model *FindModel(const std::string &, bool allowPlaceholder = true);
 
-	static void CreateRenderTarget(const Uint16 width, const Uint16 height);
-	static void DrawRenderTarget();
-	static void BeginRenderTarget();
-	static void EndRenderTarget();
-
 	static const char SAVE_DIR_NAME[];
 
 	static sigc::signal<void> onPlayerChangeTarget; // navigation or combat
@@ -227,9 +222,7 @@ public:
 	static bool DrawGUI;
 
 private:
-	static void Quit() __attribute((noreturn));
 	static void HandleKeyDown(SDL_Keysym *key);
-	static void HandleEvents();
 	static void HandleEscKey();
 
 	// private members

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -4,7 +4,6 @@
 #ifndef _PI_H
 #define _PI_H
 
-#include "Input.h"
 #include "JobQueue.h"
 #include "Random.h"
 #include "gameconsts.h"
@@ -12,10 +11,12 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <sigc++/sigc++.h>
 
 class Game;
 
 class GameConfig;
+class Input;
 class Intro;
 class LuaConsole;
 class LuaNameGen;
@@ -151,7 +152,7 @@ public:
 	static bool doProfileOne;
 #endif
 
-	static Input input;
+	static Input *input;
 	static Player *player;
 	static TransferPlanner *planner;
 	static LuaConsole *luaConsole;

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -6,7 +6,7 @@
 #include "Game.h"
 #include "GameConfig.h"
 #include "GameSaveError.h"
-#include "KeyBindings.h"
+#include "Input.h"
 #include "MathUtil.h"
 #include "Pi.h"
 #include "Player.h"
@@ -22,6 +22,7 @@
 #include "gui/Gui.h"
 #include "lua/LuaConstants.h"
 #include "lua/LuaObject.h"
+#include "utils.h"
 #include <algorithm>
 #include <sstream>
 #include <unordered_set>
@@ -637,7 +638,7 @@ void SectorView::AutoRoute(const SystemPath &start, const SystemPath &target, st
 	Output("SectorView::AutoRoute, nodes to search = %lu\n", nodes.size());
 
 	// setup inital values and set everything as unvisited
-	std::vector<float> path_dist; // distance from source to node
+	std::vector<float> path_dist;							   // distance from source to node
 	std::vector<std::vector<SystemPath>::size_type> path_prev; // previous node in optimal path
 	std::unordered_set<std::vector<SystemPath>::size_type> unvisited;
 	for (std::vector<SystemPath>::size_type i = 0; i < nodes.size(); i++) {

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -167,7 +167,7 @@ void SectorView::InitObject()
 	m_disk.reset(new Graphics::Drawables::Disk(m_renderer, m_solidState, Color::WHITE, 0.2f));
 
 	m_onMouseWheelCon =
-		Pi::input.onMouseWheel.connect(sigc::mem_fun(this, &SectorView::MouseWheel));
+		Pi::input->onMouseWheel.connect(sigc::mem_fun(this, &SectorView::MouseWheel));
 }
 
 SectorView::~SectorView()
@@ -997,7 +997,7 @@ void SectorView::OnSwitchTo()
 
 	if (!m_onKeyPressConnection.connected())
 		m_onKeyPressConnection =
-			Pi::input.onKeyPress.connect(sigc::mem_fun(this, &SectorView::OnKeyPressed));
+			Pi::input->onKeyPress.connect(sigc::mem_fun(this, &SectorView::OnKeyPressed));
 
 	UIView::OnSwitchTo();
 
@@ -1032,7 +1032,7 @@ void SectorView::OnKeyPressed(SDL_Keysym *keysym)
 	bool reset_view = false;
 
 	// fast move selection to current player system or hyperspace target
-	const bool shifted = (Pi::input.KeyState(SDLK_LSHIFT) || Pi::input.KeyState(SDLK_RSHIFT));
+	const bool shifted = (Pi::input->KeyState(SDLK_LSHIFT) || Pi::input->KeyState(SDLK_RSHIFT));
 	if (KeyBindings::mapWarpToCurrent.Matches(keysym)) {
 		GotoSystem(m_current);
 		reset_view = shifted;
@@ -1101,9 +1101,9 @@ void SectorView::Update()
 		if (KeyBindings::mapViewRotateDown.IsActive()) m_rotXMovingTo += 0.5f * moveSpeed;
 	}
 
-	if (Pi::input.MouseButtonState(SDL_BUTTON_RIGHT)) {
+	if (Pi::input->MouseButtonState(SDL_BUTTON_RIGHT)) {
 		int motion[2];
-		Pi::input.GetMouseMotion(motion);
+		Pi::input->GetMouseMotion(motion);
 
 		m_rotXMovingTo += 0.2f * float(motion[1]);
 		m_rotZMovingTo += 0.2f * float(motion[0]);

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -7,6 +7,7 @@
 #include "Frame.h"
 #include "Game.h"
 #include "GameLog.h"
+#include "Input.h"
 #include "Lang.h"
 #include "Pi.h"
 #include "Player.h"
@@ -679,7 +680,7 @@ void SystemView::OnClickShip(Ship *s)
 		return;
 	}
 	if (Pi::player->GetNavTarget() == s) { //un-select ship if already selected
-		Pi::player->SetNavTarget(0); // remove current
+		Pi::player->SetNavTarget(0);	   // remove current
 		m_game->log->Add(Lang::UNSET_NAVTARGET);
 		m_infoLabel->SetText(""); // remove lingering text
 		m_infoText->SetText("");

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -413,7 +413,7 @@ SystemView::SystemView(Game *game) :
 	Add(b, time_controls_left + 121, time_controls_top);
 
 	m_onMouseWheelCon =
-		Pi::input.onMouseWheel.connect(sigc::mem_fun(this, &SystemView::MouseWheel));
+		Pi::input->onMouseWheel.connect(sigc::mem_fun(this, &SystemView::MouseWheel));
 
 	Graphics::TextureBuilder b1 = Graphics::TextureBuilder::UI("icons/periapsis.png");
 	m_periapsisIcon.reset(new Gui::TexturedQuad(b1.GetOrCreateTexture(Gui::Screen::GetRenderer(), "ui")));
@@ -925,10 +925,10 @@ void SystemView::Update()
 	const float ft = Pi::GetFrameTime();
 	// XXX ugly hack checking for console here
 	if (!Pi::IsConsoleActive()) {
-		if (Pi::input.KeyState(SDLK_EQUALS) ||
+		if (Pi::input->KeyState(SDLK_EQUALS) ||
 			m_zoomInButton->IsPressed())
 			m_zoomTo *= pow(ZOOM_IN_SPEED * Pi::GetMoveSpeedShiftModifier(), ft);
-		if (Pi::input.KeyState(SDLK_MINUS) ||
+		if (Pi::input->KeyState(SDLK_MINUS) ||
 			m_zoomOutButton->IsPressed())
 			m_zoomTo *= pow(ZOOM_OUT_SPEED / Pi::GetMoveSpeedShiftModifier(), ft);
 
@@ -986,9 +986,9 @@ void SystemView::Update()
 	AnimationCurves::Approach(m_rot_x, m_rot_x_to, ft);
 	AnimationCurves::Approach(m_rot_z, m_rot_z_to, ft);
 
-	if (Pi::input.MouseButtonState(SDL_BUTTON_RIGHT)) {
+	if (Pi::input->MouseButtonState(SDL_BUTTON_RIGHT)) {
 		int motion[2];
-		Pi::input.GetMouseMotion(motion);
+		Pi::input->GetMouseMotion(motion);
 		m_rot_x_to += motion[1] * 20 * ft;
 		m_rot_z_to += motion[0] * 20 * ft;
 	}

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -64,13 +64,13 @@ WorldView::InputBinding WorldView::InputBindings;
 void WorldView::RegisterInputBindings()
 {
 	using namespace KeyBindings;
-	Input::BindingPage *page = Pi::input.GetBindingPage("General");
+	Input::BindingPage *page = Pi::input->GetBindingPage("General");
 	Input::BindingGroup *group;
 
 #define BINDING_GROUP(n) group = page->GetBindingGroup(#n);
-#define KEY_BINDING(n, id, k1, k2) InputBindings.n = Pi::input.AddActionBinding(id, group, \
+#define KEY_BINDING(n, id, k1, k2) InputBindings.n = Pi::input->AddActionBinding(id, group, \
 									   ActionBinding(k1, k2));
-#define AXIS_BINDING(n, id, k1, k2) InputBindings.n = Pi::input.AddAxisBinding(id, group, \
+#define AXIS_BINDING(n, id, k1, k2) InputBindings.n = Pi::input->AddAxisBinding(id, group, \
 										AxisBinding(k1, k2));
 
 	BINDING_GROUP(Miscellaneous)

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -88,9 +88,8 @@ void Application::EndLifecycle()
 
 void Application::ClearQueuedLifecycles()
 {
-	// std::queue doesn't provide a clear() method
-	// so simply invoke the destructor by reinitializing the queue
-	m_queuedLifecycles = {};
+	while (m_queuedLifecycles.size())
+		m_queuedLifecycles.pop();
 }
 
 void Application::Run()

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -1,0 +1,160 @@
+// Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "Application.h"
+#include "FileSystem.h"
+#include "OS.h"
+#include "profiler/Profiler.h"
+#include "utils.h"
+
+#include "SDL_timer.h"
+
+#include <stdexcept>
+
+void Application::QueueLifecycle(std::shared_ptr<Lifecycle> cycle)
+{
+	if (!cycle)
+		throw std::runtime_error("Invalid Lifecycle object pushed to Application queue!");
+
+	m_queuedLifecycles.push(cycle);
+}
+
+void Application::Startup()
+{
+	PROFILE_SCOPED()
+
+	OS::EnableBreakpad();
+	OS::NotifyLoadBegin();
+
+	FileSystem::Init();
+	// ensure the config directory exists
+	FileSystem::userFiles.MakeDirectory("");
+
+#ifdef PIONEER_PROFILER
+	FileSystem::userFiles.MakeDirectory("profiler");
+#endif
+}
+
+void Application::Shutdown()
+{
+	FileSystem::Uninit();
+}
+
+bool Application::StartLifecycle()
+{
+	// can't start a lifecycle if there are no more queued.
+	if (!m_priorityLifecycle && !m_queuedLifecycles.size())
+		return false;
+
+	// If we still have an active lifestyle, we don't need to queue any more.
+	if (m_activeLifecycle)
+		throw std::runtime_error("Attempt to start a new lifecycle object while one is still active!");
+
+	// Lifecycle objects returned from Lifecycle::End() take priority over queued objects
+	if (m_priorityLifecycle) {
+		m_activeLifecycle = m_priorityLifecycle;
+		m_priorityLifecycle = nullptr;
+	} else {
+		m_activeLifecycle = std::move(m_queuedLifecycles.front());
+		m_queuedLifecycles.pop();
+	}
+
+	m_activeLifecycle->m_application = this;
+	m_activeLifecycle->Start();
+	return true;
+}
+
+void Application::EndLifecycle()
+{
+	// Can't end a lifecycle if we don't have one active.
+	if (!m_activeLifecycle)
+		return;
+
+	// The only time we should have a prioritized lifecycle is
+	// between EndLifecycle() and the next StartLifecycle().
+	// If it's still set, something has gone wrong.
+	if (m_priorityLifecycle)
+		throw std::runtime_error("Unable to prioritize lifecycle object due to already-prioritized lifecycle. Did you mess up your control flow?");
+
+	m_activeLifecycle->End();
+	m_activeLifecycle->m_application = nullptr;
+	m_activeLifecycle->m_endLifecycle = false;
+
+	// wait until we've finished the control flow for the lifecycle;
+	// the lifecycle may decide to set the next lifecycle in End()
+	m_priorityLifecycle = m_activeLifecycle->m_nextLifecycle;
+	m_activeLifecycle = nullptr;
+}
+
+void Application::ClearQueuedLifecycles()
+{
+	// std::queue doesn't provide a clear() method
+	// so simply invoke the destructor by reinitializing the queue
+	m_queuedLifecycles = {};
+}
+
+void Application::Run()
+{
+	Profiler::Clock m_runtime{};
+	m_runtime.Start();
+
+	Startup();
+
+	if (!m_queuedLifecycles.size())
+		throw std::runtime_error("Application::Run must have a queued lifecycle object (did you forget to queue one?)");
+
+#ifdef PIONEER_PROFILER
+	// For good measure, reset the profiler at the start of the first frame
+	Profiler::reset();
+#endif
+
+	// SoftStop updates the elapsed time measured by the clock, and continues to run the clock.
+	m_runtime.SoftStop();
+	m_totalTime = m_runtime.seconds();
+	while (m_applicationRunning) {
+		m_runtime.SoftStop();
+		double thisTime = m_runtime.seconds();
+		m_deltaTime = thisTime - m_totalTime;
+		m_totalTime = thisTime;
+
+		if (!m_activeLifecycle) {
+			if (!StartLifecycle())
+				break;
+		}
+
+		// If there is no lifecycle object to start, end now.
+		if (!m_activeLifecycle)
+			break;
+
+		BeginFrame();
+
+		// The PreUpdate hook should be used for setting up per-frame state, etc.
+		PreUpdate();
+
+		m_activeLifecycle->Update(m_deltaTime);
+
+		// The PostUpdate hook should be used for finalizing per-frame state, rendering, etc.
+		PostUpdate();
+
+		EndFrame();
+
+		if (m_activeLifecycle->m_endLifecycle) {
+			EndLifecycle();
+		}
+
+		// TODO: design a better profiling interface, cache results of slow frames so they can be inspected
+		// in pigui, etc.
+		// m_runtime.SoftStop();
+		// thisTime = m_runtime.seconds();
+		// if (thisTime - m_totalTime > 0.100) // profile frames taking longer than 100ms
+		// 	Profiler::dumphtml(FileSystem::JoinPathBelow(FileSystem::GetUserDir(), "profiler");
+
+#ifdef PIONEER_PROFILER
+		// reset the profiler at the end of the frame
+		if (!m_activeLifecycle || !m_activeLifecycle->m_profilerAccumulate)
+			Profiler::reset();
+#endif
+	}
+
+	Shutdown();
+}

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -1,0 +1,111 @@
+// Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include <memory>
+#include <queue>
+
+class Application {
+public:
+	Application(){};
+	virtual ~Application(){};
+
+	class Lifecycle {
+	public:
+		Lifecycle(){};
+		Lifecycle(bool profilerAccumulate) :
+			m_profilerAccumulate(profilerAccumulate){};
+		virtual ~Lifecycle(){};
+
+		// Once called, the lifecycle is terminated at the end of the current update.
+		void RequestEndLifecycle() { m_endLifecycle = true; }
+
+	protected:
+		friend class Application;
+
+		// Called when the Lifecycle begins execution
+		virtual void Start(){};
+
+		// Called in a continual loop and passed the time since the last invocation.
+		virtual void Update(float deltaTime) = 0;
+
+		// Called when the lifecycle is leaving execution
+		// If a valid Lifecycle pointer is returned, it is run before any queued lifecycles.
+		virtual void End() {}
+
+		// Set a lifecycle that should begin immediately after this lifecycle has finished execution
+		void SetNextLifecycle(std::shared_ptr<Lifecycle> l)
+		{
+			m_nextLifecycle = l;
+		}
+
+		Application *GetApp();
+
+	private:
+		// set to true when you want to accumulate all updates in a lifecycle into a single profile frame
+		bool m_profilerAccumulate = false;
+		bool m_endLifecycle = false;
+		std::shared_ptr<Lifecycle> m_nextLifecycle;
+		Application *m_application;
+	};
+
+	// Add a lifecycle object to the queue of pending lifecycles
+	// You must add at least one lifecycle before calling Run()
+	void QueueLifecycle(std::shared_ptr<Lifecycle> cycle);
+
+	// Use this function very sparingly (e.g. when the application is shutting down)
+	void ClearQueuedLifecycles();
+
+	// Runs the application as long as there is a valid lifecycle object
+	void Run();
+
+	// Get the time between the start of the last update and the current one
+	float DeltaTime() { return m_deltaTime; }
+
+	double GetTime() { return m_totalTime; }
+
+protected:
+	// Hooks for inheriting classes to add their own behaviors to.
+
+	// Runs before the main loop begins
+	virtual void Startup();
+
+	// Runs after the main loop ends
+	virtual void Shutdown();
+
+	// Runs at the top of each frame.
+	virtual void BeginFrame() {}
+
+	// Runs before each Update() call
+	virtual void PreUpdate() {}
+
+	// Runs after each Update() call
+	virtual void PostUpdate() {}
+
+	// Runs at the bottom of each frame.
+	virtual void EndFrame(){};
+
+	// Request the application quit immediately at the end of the update,
+	// ignoring all queued lifecycles
+	void RequestQuit() { m_applicationRunning = false; }
+
+	Lifecycle *GetActiveLifecycle() { return m_activeLifecycle.get(); }
+
+private:
+	bool StartLifecycle();
+	void EndLifecycle();
+
+	bool m_applicationRunning;
+	float m_deltaTime;
+	double m_totalTime;
+
+	// The lifecycle we're actually running right now
+	std::shared_ptr<Lifecycle> m_activeLifecycle;
+
+	// A lifecycle that should be run next before the rest of the queue.
+	std::shared_ptr<Lifecycle> m_priorityLifecycle;
+
+	// Lifecycles queued by QueueLifecycle()
+	std::queue<std::shared_ptr<Lifecycle>> m_queuedLifecycles;
+};

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+list(APPEND CORE_SRC_FOLDERS
+	${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Creates variables CORE_CXX_FILES and CORE_HXX_FILES
+add_source_folders(CORE CORE_SRC_FOLDERS)
+
+# Creates a library, adds it to the build, and sets C++ target properties on it
+define_pioneer_library(pioneer-core CORE_CXX_FILES CORE_HXX_FILES)
+target_include_directories(pioneer-core PRIVATE ${CMAKE_BINARY_DIR})

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -1,0 +1,147 @@
+// Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "GuiApplication.h"
+#include "GameConfig.h"
+#include "OS.h"
+
+#include "SDL.h"
+#include "graphics/Drawables.h"
+#include "graphics/Graphics.h"
+#include "graphics/RenderState.h"
+#include "graphics/RenderTarget.h"
+#include "graphics/Renderer.h"
+#include "graphics/Texture.h"
+#include "utils.h"
+#include "versioningInfo.h"
+
+// FIXME: add support for offscreen rendertarget drawing and multisample RTs
+#define RTT 0
+
+void GuiApplication::BeginFrame()
+{
+#if RTT
+	m_renderer->SetRenderTarget(m_renderTarget);
+#endif
+	// TODO: render target size
+	m_renderer->SetViewport(0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+	m_renderer->BeginFrame();
+}
+
+void GuiApplication::DrawRenderTarget()
+{
+#if RTT
+	m_renderer->BeginFrame();
+	m_renderer->SetViewport(0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+	m_renderer->SetTransform(matrix4x4f::Identity());
+
+	{
+		m_renderer->SetMatrixMode(Graphics::MatrixMode::PROJECTION);
+		m_renderer->PushMatrix();
+		m_renderer->SetOrthographicProjection(0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), 0, -1, 1);
+		m_renderer->SetMatrixMode(Graphics::MatrixMode::MODELVIEW);
+		m_renderer->PushMatrix();
+		m_renderer->LoadIdentity();
+	}
+
+	m_renderQuad->Draw(m_renderer);
+
+	{
+		m_renderer->SetMatrixMode(Graphics::MatrixMode::PROJECTION);
+		m_renderer->PopMatrix();
+		m_renderer->SetMatrixMode(Graphics::MatrixMode::MODELVIEW);
+		m_renderer->PopMatrix();
+	}
+
+	m_renderer->EndFrame();
+#endif
+}
+
+void GuiApplication::EndFrame()
+{
+#if RTT
+	m_renderer->SetRenderTarget(nullptr);
+	DrawRenderTarget();
+#endif
+	m_renderer->EndFrame();
+	m_renderer->SwapBuffers();
+}
+
+Graphics::RenderTarget *GuiApplication::CreateRenderTarget(const Graphics::Settings &settings)
+{
+	/*	@fluffyfreak here's a rendertarget implementation you can use for oculusing and other things. It's pretty simple:
+		 - fill out a RenderTargetDesc struct and call Renderer::CreateRenderTarget
+		 - pass target to Renderer::SetRenderTarget to start rendering to texture
+		 - set up viewport, clear etc, then draw as usual
+		 - SetRenderTarget(0) to resume render to screen
+		 - you can access the attached texture with GetColorTexture to use it with a material
+		You can reuse the same target with multiple textures.
+		In that case, leave the color format to NONE so the initial texture is not created, then use SetColorTexture to attach your own.
+	*/
+#if RTT
+	Graphics::RenderStateDesc rsd;
+	rsd.depthTest = false;
+	rsd.depthWrite = false;
+	rsd.blendMode = Graphics::BLEND_SOLID;
+	m_renderState.reset(m_renderer->CreateRenderState(rsd));
+
+	// Complete the RT description so we can request a buffer.
+	Graphics::RenderTargetDesc rtDesc(
+		width,
+		height,
+		Graphics::TEXTURE_RGB_888, // don't create a texture
+		Graphics::TEXTURE_DEPTH,
+		false, settings.requestedSamples);
+	m_renderTarget.reset(m_renderer->CreateRenderTarget(rtDesc));
+
+	m_renderTarget->SetColorTexture(*m_renderTexture);
+#endif
+
+	return nullptr;
+}
+
+Graphics::Renderer *GuiApplication::StartupRenderer(const GameConfig *config, bool hidden)
+{
+	PROFILE_SCOPED()
+	// Initialize SDL
+	Uint32 sdlInitFlags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
+	if (SDL_Init(sdlInitFlags) < 0) {
+		Error("SDL initialization failed: %s\n", SDL_GetError());
+	}
+
+	OutputVersioningInfo();
+
+	// determine what renderer we should use, default to Opengl 3.x
+	const std::string rendererName = config->String("RendererName", Graphics::RendererNameFromType(Graphics::RENDERER_OPENGL_3x));
+	// if we add new renderer types, make sure to update this logic
+	Graphics::RendererType rType = Graphics::RENDERER_OPENGL_3x;
+
+	Graphics::Settings videoSettings = {};
+	videoSettings.rendererType = rType;
+	videoSettings.width = config->Int("ScrWidth");
+	videoSettings.height = config->Int("ScrHeight");
+	videoSettings.fullscreen = (config->Int("StartFullscreen") != 0);
+	videoSettings.hidden = hidden;
+	videoSettings.requestedSamples = config->Int("AntiAliasingMode");
+	videoSettings.vsync = (config->Int("VSync") != 0);
+	videoSettings.useTextureCompression = (config->Int("UseTextureCompression") != 0);
+	videoSettings.useAnisotropicFiltering = (config->Int("UseAnisotropicFiltering") != 0);
+	videoSettings.enableDebugMessages = (config->Int("EnableGLDebug") != 0);
+	videoSettings.gl3ForwardCompatible = (config->Int("GL3ForwardCompatible") != 0);
+	videoSettings.iconFile = OS::GetIconFilename();
+	videoSettings.title = m_applicationTitle.c_str();
+
+	m_renderer.reset(Graphics::Init(videoSettings));
+	m_renderTarget.reset(CreateRenderTarget(videoSettings));
+
+	return m_renderer.get();
+}
+
+void GuiApplication::ShutdownRenderer()
+{
+	m_renderTarget.reset();
+	m_renderState.reset();
+	m_renderer.reset();
+
+	SDL_QuitSubSystem(SDL_INIT_VIDEO);
+}

--- a/src/core/GuiApplication.h
+++ b/src/core/GuiApplication.h
@@ -1,0 +1,49 @@
+// Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "Application.h"
+#include "GameConfig.h"
+#include "RefCounted.h"
+
+#include "graphics/RenderState.h"
+#include "graphics/RenderTarget.h"
+#include "graphics/Renderer.h"
+
+class GuiApplication : public Application {
+public:
+	GuiApplication(std::string title) :
+		Application(), m_applicationTitle(title)
+	{}
+
+protected:
+	Graphics::Renderer *GetRenderer() { return m_renderer.get(); }
+
+	// Called at the end of the frame automatically, blits the RT onto the application
+	// framebuffer
+	void DrawRenderTarget();
+
+	// Call this from your Startup() method
+	Graphics::Renderer *StartupRenderer(const GameConfig *config, bool hidden = false);
+
+	// Call this from your Shutdown() method
+	void ShutdownRenderer();
+
+	// Hook to bind the RT and clear the screen.
+	// If you override BeginFrame, make sure you call this.
+	void BeginFrame() override;
+
+	// Hook to end the frame and draw to the application framebuffer.
+	// If you override EndFrame, make sure you call this.
+	void EndFrame() override;
+
+private:
+	Graphics::RenderTarget *CreateRenderTarget(const Graphics::Settings &settings);
+
+	std::string m_applicationTitle;
+
+	std::unique_ptr<Graphics::Renderer> m_renderer;
+	std::unique_ptr<Graphics::RenderTarget> m_renderTarget;
+	std::unique_ptr<Graphics::RenderState> m_renderState;
+};

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -7,6 +7,7 @@
 #include "OS.h"
 #include "Renderer.h"
 #include "StringF.h"
+#include "utils.h"
 #include <iterator>
 #include <sstream>
 

--- a/src/graphics/opengl/Program.cpp
+++ b/src/graphics/opengl/Program.cpp
@@ -7,6 +7,7 @@
 #include "StringF.h"
 #include "StringRange.h"
 #include "graphics/Graphics.h"
+#include "utils.h"
 
 #include <set>
 

--- a/src/lua/LuaGame.cpp
+++ b/src/lua/LuaGame.cpp
@@ -70,7 +70,7 @@ static int l_game_start_game(lua_State *l)
 			time(&now);
 			start_time = difftime(now, 946684799); // <--- Friday, 31 December 1999 23:59:59 GMT+00:00 as UNIX epoch time in seconds
 		}
-		Pi::game = new Game(*path, start_time);
+		Pi::StartGame(new Game(*path, start_time));
 	} catch (InvalidGameStartLocation &e) {
 		luaL_error(l, "invalid starting location for game: %s", e.error.c_str());
 	}
@@ -170,7 +170,7 @@ static int l_game_load_game(lua_State *l)
 	const std::string filename(luaL_checkstring(l, 1));
 
 	try {
-		Pi::game = Game::LoadGame(filename);
+		Pi::StartGame(Game::LoadGame(filename));
 	} catch (SavedGameCorruptException) {
 		luaL_error(l, Lang::GAME_LOAD_CORRUPT);
 	} catch (SavedGameWrongVersionException) {

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -95,7 +95,7 @@ static int l_input_get_bindings(lua_State *l)
 	using namespace KeyBindings;
 
 	int page_idx = 1;
-	for (auto page : Pi::input.GetBindingPages()) {
+	for (auto page : Pi::input->GetBindingPages()) {
 		lua_pushunsigned(l, page_idx++);
 		setup_binding_table(l, page.first.c_str(), "page");
 
@@ -108,14 +108,14 @@ static int l_input_get_bindings(lua_State *l)
 			for (auto type : group.second.bindings) {
 				lua_pushunsigned(l, binding_idx++);
 				if (type.second == Input::BindingGroup::EntryType::ENTRY_ACTION) {
-					ActionBinding *ab = Pi::input.GetActionBinding(type.first);
+					ActionBinding *ab = Pi::input->GetActionBinding(type.first);
 					if (!ab) continue; // Should never happen, but include it here for future proofing.
 					setup_binding_table(l, type.first.c_str(), "action");
 
 					push_key_binding(l, &ab->binding1, "binding1", "bindingDescription1");
 					push_key_binding(l, &ab->binding2, "binding2", "bindingDescription2");
 				} else {
-					AxisBinding *ab = Pi::input.GetAxisBinding(type.first);
+					AxisBinding *ab = Pi::input->GetAxisBinding(type.first);
 					if (!ab) continue; // Should never happen, but include it here for future proofing.
 					setup_binding_table(l, type.first.c_str(), "axis");
 
@@ -163,7 +163,7 @@ static int l_input_set_action_binding(lua_State *l)
 	const char *binding_id = luaL_checkstring(l, 1);
 	const char *binding_config_1 = lua_tostring(l, 2);
 	const char *binding_config_2 = lua_tostring(l, 3);
-	KeyBindings::ActionBinding *action = Pi::input.GetActionBinding(binding_id);
+	KeyBindings::ActionBinding *action = Pi::input->GetActionBinding(binding_id);
 
 	KeyBindings::KeyBinding kb1, kb2;
 	if (binding_config_1) {
@@ -189,7 +189,7 @@ static int l_input_set_axis_binding(lua_State *l)
 	const char *binding_config_axis = lua_tostring(l, 2);
 	const char *binding_config_positive = lua_tostring(l, 3);
 	const char *binding_config_negative = lua_tostring(l, 4);
-	KeyBindings::AxisBinding *binding = Pi::input.GetAxisBinding(binding_id);
+	KeyBindings::AxisBinding *binding = Pi::input->GetAxisBinding(binding_id);
 
 	KeyBindings::JoyAxisBinding ab;
 	if (binding_config_axis) {
@@ -231,7 +231,7 @@ static int l_input_set_mouse_y_inverted(lua_State *l)
 	const bool inverted = lua_toboolean(l, 1);
 	Pi::config->SetInt("InvertMouseY", (inverted ? 1 : 0));
 	Pi::config->Save();
-	Pi::input.SetMouseYInvert(inverted);
+	Pi::input->SetMouseYInvert(inverted);
 	return 0;
 }
 
@@ -248,7 +248,7 @@ static int l_input_set_joystick_enabled(lua_State *l)
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("EnableJoystick", (enabled ? 1 : 0));
 	Pi::config->Save();
-	Pi::input.SetJoystickEnabled(enabled);
+	Pi::input->SetJoystickEnabled(enabled);
 	return 0;
 }
 

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -955,7 +955,7 @@ static int l_pigui_get_axisbinding(lua_State *l)
 {
 	PROFILE_SCOPED()
 	std::string binding = "";
-	if (!Pi::input.IsJoystickEnabled()) {
+	if (!Pi::input->IsJoystickEnabled()) {
 		lua_pushnil(l);
 		return 1;
 	}
@@ -972,13 +972,13 @@ static int l_pigui_get_axisbinding(lua_State *l)
 
 	// otherwise actually check the joystick
 
-	auto joysticks = Pi::input.GetJoysticksState();
+	auto joysticks = Pi::input->GetJoysticksState();
 
 	for (auto js : joysticks) {
 		std::vector<float> axes = js.second.axes;
 		for (size_t a = 0; a < axes.size(); a++) {
 			if (axes[a] > 0.25 || axes[a] < -0.25) {
-				binding = "Joy" + Pi::input.JoystickGUIDString(js.first) + "/Axis" + std::to_string(a);
+				binding = "Joy" + Pi::input->JoystickGUIDString(js.first) + "/Axis" + std::to_string(a);
 				break;
 			}
 		}
@@ -1028,14 +1028,14 @@ static int l_pigui_get_keybinding(lua_State *l)
 	}
 
 	// Check joysticks if no keys are held down
-	if (Pi::input.IsJoystickEnabled() && (key == 0 || (key >= SDLK_LCTRL && key <= SDLK_RGUI))) {
-		auto joysticks = Pi::input.GetJoysticksState();
+	if (Pi::input->IsJoystickEnabled() && (key == 0 || (key >= SDLK_LCTRL && key <= SDLK_RGUI))) {
+		auto joysticks = Pi::input->GetJoysticksState();
 
 		for (auto js : joysticks) {
 			std::vector<bool> buttons = js.second.buttons;
 			for (size_t b = 0; b < buttons.size(); b++) {
 				if (buttons[b]) {
-					binding = "Joy" + Pi::input.JoystickGUIDString(js.first) + "/Button" + std::to_string(b);
+					binding = "Joy" + Pi::input->JoystickGUIDString(js.first) + "/Button" + std::to_string(b);
 					break;
 				}
 			}
@@ -1047,7 +1047,7 @@ static int l_pigui_get_keybinding(lua_State *l)
 					case SDL_HAT_RIGHT:
 					case SDL_HAT_UP:
 					case SDL_HAT_DOWN:
-						binding = "Joy" + Pi::input.JoystickGUIDString(js.first) + "/Hat" + std::to_string(h) + "Dir" + std::to_string(js.second.hats[h]);
+						binding = "Joy" + Pi::input->JoystickGUIDString(js.first) + "/Hat" + std::to_string(h) + "Dir" + std::to_string(js.second.hats[h]);
 						break;
 					default:
 						continue;
@@ -1919,7 +1919,7 @@ static int l_pigui_set_mouse_button_state(lua_State *l)
 	PROFILE_SCOPED()
 	int button = LuaPull<int>(l, 1);
 	bool state = LuaPull<bool>(l, 2);
-	Pi::input.SetMouseButtonState(button, state);
+	Pi::input->SetMouseButtonState(button, state);
 	if (state == false) {
 		// new UI caches which widget should receive the mouse up event
 		// after a mouse down. This function exists exactly because the mouse-up event

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,12 +176,17 @@ start:
 
 		Pi::Init(options, mode == MODE_GALAXYDUMP);
 
-		if (mode == MODE_GAME)
-			for (;;) {
-				Pi::Start(startPath);
-				startPath = SystemPath(0, 0, 0, 0, 0); // Reset the start planet when coming back to the menu
-			}
-		else if (mode == MODE_GALAXYDUMP) {
+		if (mode == MODE_GAME) {
+			if (startPath != SystemPath(0, 0, 0, 0, 0))
+				Pi::GetApp()->SetStartPath(startPath);
+
+			Pi::GetApp()->Run();
+		} else if (mode == MODE_GALAXYDUMP) {
+			// TODO: don't initialize Pi when dumping the galaxy
+			// Galaxy generation is (mostly) self-contained, no need to e.g.
+			// turn on the renderer or load UI for this.
+			Error("GalaxyDump is not currently implemented!");
+
 			FILE *file = filename == "-" ? stdout : fopen(filename.c_str(), "w");
 			if (file == nullptr) {
 				Output("pioneer: could not open \"%s\" for writing: %s\n", filename.c_str(), strerror(errno));

--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -2,9 +2,12 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "PiGui.h"
+#include "Input.h"
 #include "Pi.h"
+
 #include "graphics/opengl/TextureGL.h" // nasty, usage of GL is implementation specific
 #include "imgui/imgui.h"
+
 // Use GLEW instead of GL3W.
 #define IMGUI_IMPL_OPENGL_LOADER_GLEW 1
 #include "imgui/examples/imgui_impl_opengl3.h"

--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -379,7 +379,7 @@ void PiGui::NewFrame(SDL_Window *window)
 
 	// Ask ImGui to hide OS cursor if we're capturing it for input:
 	// it will do this if GetMouseCursor == ImGuiMouseCursor_None.
-	if (Pi::input.IsCapturingMouse()) {
+	if (Pi::input->IsCapturingMouse()) {
 		ImGui::SetMouseCursor(ImGuiMouseCursor_None);
 	}
 

--- a/src/pigui/PiGui.h
+++ b/src/pigui/PiGui.h
@@ -11,9 +11,9 @@
 #include <unordered_set>
 
 class PiFace {
-	friend class PiGui; // need acces to some private data
+	friend class PiGui;	   // need acces to some private data
 	std::string m_ttfname; // only the ttf name, it is automatically sought in data/fonts/
-	float m_sizefactor; // the requested pixelsize is multiplied by this factor
+	float m_sizefactor;	   // the requested pixelsize is multiplied by this factor
 	std::unordered_set<unsigned short> m_invalid_glyphs;
 	mutable std::vector<std::pair<unsigned short, unsigned short>> m_used_ranges;
 	ImVector<ImWchar> m_imgui_ranges;
@@ -87,6 +87,9 @@ public:
 	// Call at the start of every frame. Calls ImGui::NewFrame() internally.
 	void NewFrame(SDL_Window *window);
 
+	// Call at the end of a frame that you're not going to render the results of
+	void EndFrame();
+
 	// Calls ImGui::EndFrame() internally and does book-keeping before rendering.
 	void Render();
 
@@ -131,8 +134,6 @@ public:
 	static void ThrustIndicator(const std::string &id_string, const ImVec2 &size, const ImVec4 &thrust, const ImVec4 &velocity, const ImVec4 &bg_col, int frame_padding, ImColor vel_fg, ImColor vel_bg, ImColor thrust_fg, ImColor thrust_bg);
 
 private:
-	void EndFrame();
-
 	LuaRef m_handlers;
 	LuaRef m_keys;
 	static std::vector<Graphics::Texture *> m_svg_textures;

--- a/src/posix/OSPosix.cpp
+++ b/src/posix/OSPosix.cpp
@@ -4,6 +4,8 @@
 #include "FileSystem.h"
 #include "OS.h"
 #include "buildopts.h"
+#include "utils.h"
+
 #include <SDL.h>
 #include <fenv.h>
 #include <sys/time.h>
@@ -64,19 +66,7 @@ namespace OS {
 #endif
 	}
 
-	Uint64 HFTimerFreq()
-	{
-		return 1000000;
-	}
-
-	Uint64 HFTimer()
-	{
-		timeval t;
-		gettimeofday(&t, 0);
-		return Uint64(t.tv_sec) * 1000000 + Uint64(t.tv_usec);
-	}
-
-	int GetNumCores()
+	uint32_t GetNumCores()
 	{
 #if defined(__APPLE__)
 		int nm[2];
@@ -96,7 +86,11 @@ namespace OS {
 		}
 		return count;
 #else
-		return sysconf(_SC_NPROCESSORS_ONLN);
+		// sysconf can return -1 if _SC_NPROCESSORS_ONLN is not supported
+		int count = sysconf(_SC_NPROCESSORS_ONLN);
+		// There's definitely at least one core.
+		// (What are you running Pioneer on otherwise, a potato battery?)
+		return count > 0 ? uint32_t(count) : 1;
 #endif
 	}
 

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -59,29 +59,29 @@ PlayerShipController::InputBinding PlayerShipController::InputBindings;
 void PlayerShipController::RegisterInputBindings()
 {
 	using namespace KeyBindings;
-	auto controlsPage = Pi::input.GetBindingPage("ShipControls");
+	auto controlsPage = Pi::input->GetBindingPage("ShipControls");
 
 	auto weaponsGroup = controlsPage->GetBindingGroup("Weapons");
-	InputBindings.targetObject = Pi::input.AddActionBinding("BindTargetObject", weaponsGroup, ActionBinding(SDLK_y));
-	InputBindings.primaryFire = Pi::input.AddActionBinding("BindPrimaryFire", weaponsGroup, ActionBinding(SDLK_SPACE));
-	InputBindings.secondaryFire = Pi::input.AddActionBinding("BindSecondaryFire", weaponsGroup, ActionBinding(SDLK_m));
+	InputBindings.targetObject = Pi::input->AddActionBinding("BindTargetObject", weaponsGroup, ActionBinding(SDLK_y));
+	InputBindings.primaryFire = Pi::input->AddActionBinding("BindPrimaryFire", weaponsGroup, ActionBinding(SDLK_SPACE));
+	InputBindings.secondaryFire = Pi::input->AddActionBinding("BindSecondaryFire", weaponsGroup, ActionBinding(SDLK_m));
 
 	auto flightGroup = controlsPage->GetBindingGroup("ShipOrient");
-	InputBindings.pitch = Pi::input.AddAxisBinding("BindAxisPitch", flightGroup, AxisBinding(SDLK_k, SDLK_i));
-	InputBindings.yaw = Pi::input.AddAxisBinding("BindAxisYaw", flightGroup, AxisBinding(SDLK_j, SDLK_l));
-	InputBindings.roll = Pi::input.AddAxisBinding("BindAxisRoll", flightGroup, AxisBinding(SDLK_u, SDLK_o));
-	InputBindings.killRot = Pi::input.AddActionBinding("BindKillRot", flightGroup, ActionBinding(SDLK_p, SDLK_x));
-	InputBindings.toggleRotationDamping = Pi::input.AddActionBinding("BindToggleRotationDamping", flightGroup, ActionBinding(SDLK_v));
+	InputBindings.pitch = Pi::input->AddAxisBinding("BindAxisPitch", flightGroup, AxisBinding(SDLK_k, SDLK_i));
+	InputBindings.yaw = Pi::input->AddAxisBinding("BindAxisYaw", flightGroup, AxisBinding(SDLK_j, SDLK_l));
+	InputBindings.roll = Pi::input->AddAxisBinding("BindAxisRoll", flightGroup, AxisBinding(SDLK_u, SDLK_o));
+	InputBindings.killRot = Pi::input->AddActionBinding("BindKillRot", flightGroup, ActionBinding(SDLK_p, SDLK_x));
+	InputBindings.toggleRotationDamping = Pi::input->AddActionBinding("BindToggleRotationDamping", flightGroup, ActionBinding(SDLK_v));
 
 	auto thrustGroup = controlsPage->GetBindingGroup("ManualControl");
-	InputBindings.thrustForward = Pi::input.AddAxisBinding("BindAxisThrustForward", thrustGroup, AxisBinding(SDLK_w, SDLK_s));
-	InputBindings.thrustUp = Pi::input.AddAxisBinding("BindAxisThrustUp", thrustGroup, AxisBinding(SDLK_r, SDLK_f));
-	InputBindings.thrustLeft = Pi::input.AddAxisBinding("BindAxisThrustLeft", thrustGroup, AxisBinding(SDLK_a, SDLK_d));
-	InputBindings.thrustLowPower = Pi::input.AddActionBinding("BindThrustLowPower", thrustGroup, ActionBinding(SDLK_LSHIFT));
+	InputBindings.thrustForward = Pi::input->AddAxisBinding("BindAxisThrustForward", thrustGroup, AxisBinding(SDLK_w, SDLK_s));
+	InputBindings.thrustUp = Pi::input->AddAxisBinding("BindAxisThrustUp", thrustGroup, AxisBinding(SDLK_r, SDLK_f));
+	InputBindings.thrustLeft = Pi::input->AddAxisBinding("BindAxisThrustLeft", thrustGroup, AxisBinding(SDLK_a, SDLK_d));
+	InputBindings.thrustLowPower = Pi::input->AddActionBinding("BindThrustLowPower", thrustGroup, ActionBinding(SDLK_LSHIFT));
 
 	auto speedGroup = controlsPage->GetBindingGroup("SpeedControl");
-	InputBindings.speedControl = Pi::input.AddAxisBinding("BindSpeedControl", speedGroup, AxisBinding(SDLK_RETURN, SDLK_RSHIFT));
-	InputBindings.toggleSetSpeed = Pi::input.AddActionBinding("BindToggleSetSpeed", speedGroup, ActionBinding(SDLK_v));
+	InputBindings.speedControl = Pi::input->AddAxisBinding("BindSpeedControl", speedGroup, AxisBinding(SDLK_RETURN, SDLK_RSHIFT));
+	InputBindings.toggleSetSpeed = Pi::input->AddActionBinding("BindToggleSetSpeed", speedGroup, ActionBinding(SDLK_v));
 }
 
 PlayerShipController::~PlayerShipController()
@@ -239,14 +239,14 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 
 		const float linearThrustPower = (InputBindings.thrustLowPower->IsActive() ? m_lowThrustPower : 1.0f);
 
-		if (Pi::input.MouseButtonState(SDL_BUTTON_RIGHT)) {
+		if (Pi::input->MouseButtonState(SDL_BUTTON_RIGHT)) {
 			// use ship rotation relative to system, unchanged by frame transitions
 			matrix3x3d rot = m_ship->GetOrientRelTo(Frame::GetFrame(m_ship->GetFrame())->GetNonRotFrame());
 			if (!m_mouseActive && !m_disableMouseFacing) {
 				m_mouseDir = -rot.VectorZ();
 				m_mouseX = m_mouseY = 0;
 				m_mouseActive = true;
-				Pi::input.SetCapturingMouse(true);
+				Pi::input->SetCapturingMouse(true);
 			}
 			vector3d objDir = m_mouseDir * rot;
 
@@ -258,7 +258,7 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 			double modx = clipmouse(objDir.x, m_mouseX);
 			m_mouseX -= modx;
 
-			const bool invertY = (Pi::input.IsMouseYInvert() ? !m_invertMouse : m_invertMouse);
+			const bool invertY = (Pi::input->IsMouseYInvert() ? !m_invertMouse : m_invertMouse);
 
 			m_mouseY += mouseMotion[1] * accel * radiansPerPixel * (invertY ? -1 : 1);
 			double mody = clipmouse(objDir.y, m_mouseY);
@@ -270,7 +270,7 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 			}
 		} else {
 			if (m_mouseActive)
-				Pi::input.SetCapturingMouse(false);
+				Pi::input->SetCapturingMouse(false);
 
 			m_mouseActive = false;
 		}
@@ -302,7 +302,7 @@ void PlayerShipController::PollControls(const float timeStep, const bool force_r
 		if (InputBindings.thrustLeft->IsActive())
 			m_ship->SetThrusterState(0, -linearThrustPower * InputBindings.thrustLeft->GetValue());
 
-		if (InputBindings.primaryFire->IsActive() || (Pi::input.MouseButtonState(SDL_BUTTON_LEFT) && Pi::input.MouseButtonState(SDL_BUTTON_RIGHT))) {
+		if (InputBindings.primaryFire->IsActive() || (Pi::input->MouseButtonState(SDL_BUTTON_LEFT) && Pi::input->MouseButtonState(SDL_BUTTON_RIGHT))) {
 			//XXX worldview? madness, ask from ship instead
 			m_ship->SetGunState(Pi::game->GetWorldView()->GetActiveWeapon(), 1);
 		}

--- a/src/ship/PlayerShipController.h
+++ b/src/ship/PlayerShipController.h
@@ -92,7 +92,7 @@ private:
 	Body *m_navTarget;
 	Body *m_setSpeedTarget;
 	bool m_controlsLocked;
-	bool m_invertMouse; // used for rear view, *not* for invert Y-axis option (which is Pi::input.IsMouseYInvert)
+	bool m_invertMouse; // used for rear view, *not* for invert Y-axis option (which is Pi::input->IsMouseYInvert)
 	bool m_mouseActive;
 	bool m_disableMouseFacing;
 	bool m_rotationDamping;

--- a/src/ship/ShipViewController.cpp
+++ b/src/ship/ShipViewController.cpp
@@ -22,17 +22,17 @@ void ShipViewController::InputBinding::RegisterBindings()
 {
 	using namespace KeyBindings;
 
-	Input::BindingPage *page = Pi::input.GetBindingPage("ShipView");
+	Input::BindingPage *page = Pi::input->GetBindingPage("ShipView");
 	Input::BindingGroup *group;
 
 #define BINDING_GROUP(n) group = page->GetBindingGroup(#n);
 #define KEY_BINDING(n, id, k1, k2)                                    \
 	n =                                                               \
-		Pi::input.AddActionBinding(id, group, ActionBinding(k1, k2)); \
+		Pi::input->AddActionBinding(id, group, ActionBinding(k1, k2)); \
 	actions.push_back(n);
 #define AXIS_BINDING(n, id, k1, k2)                               \
 	n =                                                           \
-		Pi::input.AddAxisBinding(id, group, AxisBinding(k1, k2)); \
+		Pi::input->AddAxisBinding(id, group, AxisBinding(k1, k2)); \
 	axes.push_back(n);
 
 	BINDING_GROUP(GeneralViewControls)
@@ -89,17 +89,17 @@ void ShipViewController::Init()
 
 void ShipViewController::Activated()
 {
-	Pi::input.PushInputFrame(&InputBindings);
+	Pi::input->PushInputFrame(&InputBindings);
 
 	m_onMouseWheelCon =
-		Pi::input.onMouseWheel.connect(sigc::mem_fun(this, &ShipViewController::MouseWheel));
+		Pi::input->onMouseWheel.connect(sigc::mem_fun(this, &ShipViewController::MouseWheel));
 
 	Pi::player->GetPlayerController()->SetMouseForRearView(GetCamType() == CAM_INTERNAL && m_internalCameraController->GetMode() == InternalCameraController::MODE_REAR);
 }
 
 void ShipViewController::Deactivated()
 {
-	Pi::input.RemoveInputFrame(&InputBindings);
+	Pi::input->RemoveInputFrame(&InputBindings);
 
 	m_onMouseWheelCon.disconnect();
 }
@@ -203,14 +203,14 @@ void ShipViewController::Update()
 	}
 
 	int mouseMotion[2];
-	Pi::input.GetMouseMotion(mouseMotion);
+	Pi::input->GetMouseMotion(mouseMotion);
 
 	// external camera mouselook
-	bool mouse_down = Pi::input.MouseButtonState(SDL_BUTTON_MIDDLE);
+	bool mouse_down = Pi::input->MouseButtonState(SDL_BUTTON_MIDDLE);
 	if (mouse_down && !headtracker_input_priority) {
 		if (!m_mouseActive) {
 			m_mouseActive = true;
-			Pi::input.SetCapturingMouse(true);
+			Pi::input->SetCapturingMouse(true);
 		}
 
 		// invert the mouse input to convert between screen coordinates and
@@ -221,7 +221,7 @@ void ShipViewController::Update()
 
 	if (!mouse_down && m_mouseActive) {
 		m_mouseActive = false;
-		Pi::input.SetCapturingMouse(false);
+		Pi::input->SetCapturingMouse(false);
 	}
 
 	m_activeCameraController->Update();

--- a/src/terrain/TerrainDbg.cpp
+++ b/src/terrain/TerrainDbg.cpp
@@ -5,6 +5,7 @@
 
 #include "GameConfig.h"
 #include "Pi.h"
+#include "utils.h"
 
 void Terrain::DebugDump() const
 {

--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -8,6 +8,7 @@
 #include "FileSystem.h"
 #include "OS.h"
 #include "TextUtils.h"
+#include "utils.h"
 #ifdef WITH_BREAKPAD
 #include "breakpad/exception_handler.h"
 #endif

--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -115,21 +115,7 @@ namespace OS {
 #endif
 	}
 
-	Uint64 HFTimerFreq()
-	{
-		LARGE_INTEGER i;
-		QueryPerformanceFrequency(&i);
-		return i.QuadPart;
-	}
-
-	Uint64 HFTimer()
-	{
-		LARGE_INTEGER i;
-		QueryPerformanceCounter(&i);
-		return i.QuadPart;
-	}
-
-	int GetNumCores()
+	uint32_t GetNumCores()
 	{
 		SYSTEM_INFO sysinfo;
 		GetSystemInfo(&sysinfo);

--- a/win32/vs2019/pioneer.vcxproj
+++ b/win32/vs2019/pioneer.vcxproj
@@ -383,6 +383,8 @@
     <ClCompile Include="..\..\src\CityOnPlanet.cpp" />
     <ClCompile Include="..\..\src\CollMesh.cpp" />
     <ClCompile Include="..\..\src\Color.cpp" />
+    <ClCompile Include="..\..\src\core\Application.cpp" />
+    <ClCompile Include="..\..\src\core\GuiApplication.cpp" />
     <ClCompile Include="..\..\src\CRC32.cpp" />
     <ClCompile Include="..\..\src\DateTime.cpp" />
     <ClCompile Include="..\..\src\DeathView.cpp" />
@@ -585,6 +587,8 @@
     <ClInclude Include="..\..\src\CityOnPlanet.h" />
     <ClInclude Include="..\..\src\CollMesh.h" />
     <ClInclude Include="..\..\src\Color.h" />
+    <ClInclude Include="..\..\src\core\Application.h" />
+    <ClInclude Include="..\..\src\core\GuiApplication.h" />
     <ClInclude Include="..\..\src\CRC32.h" />
     <ClInclude Include="..\..\src\DateTime.h" />
     <ClInclude Include="..\..\src\DeathView.h" />

--- a/win32/vs2019/pioneer.vcxproj.filters
+++ b/win32/vs2019/pioneer.vcxproj.filters
@@ -37,6 +37,9 @@
     <Filter Include="src\Lua\Core">
       <UniqueIdentifier>{8b8f8935-2d4d-49c5-8932-3c973b1fc69a}</UniqueIdentifier>
     </Filter>
+    <Filter Include="src\core">
+      <UniqueIdentifier>{077edfac-2118-4205-94da-792445afd8da}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\Body.cpp">
@@ -250,12 +253,6 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\GeoPatchJobs.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\LuaPropertiedObject.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\PropertyMap.cpp">
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\JobQueue.cpp">
@@ -558,6 +555,12 @@
     <ClCompile Include="..\..\src\pigui\PiGuiSandbox.cpp">
       <Filter>src\pigui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\GuiApplication.cpp">
+      <Filter>src\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\Application.cpp">
+      <Filter>src\core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Aabb.h">
@@ -810,12 +813,6 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\GeoPatchJobs.h">
-      <Filter>src</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\PropertiedObject.h">
-      <Filter>src</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\PropertyMap.h">
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\JobQueue.h">
@@ -1102,6 +1099,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\pigui\PiGui.h">
       <Filter>src\pigui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\Application.h">
+      <Filter>src\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\GuiApplication.h">
+      <Filter>src\core</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Ostensibly, I set out to refactor the ModelViewer mode to use ImGui instead of newUI. Then...

![this happened](http://lparchive.org/Dwarf-Fortress-Headshoots/Update%2071/12-feymood.png)

Yeah.

I'll go into more depth about the new main loop in a bit; first I want to talk about the smaller stuff.
- I've made `Pi::input` a pointer to decouple it a little from the main Pi class. Among other reasons, this means I can make the input class live somewhere else and just store a pointer to it in `Pi::input`.
- I've removed two unused methods from the OS namespace and made sure OS::GetNumCores returns at least one core on a POSIX system. (@fluffyfreak you'll need to verify that behavior is ensured on Win32; I'm assuming the Win32 API does in fact return at least one core).
- I've decoupled headers some more; we had a dependency on either `Pi.h` or `OS.h` including `utils.h` in a number of source files that then refused to build when the aforementioned headers were refactored to remove that header.

Now, the elephant in the room. I've noticed as time goes on, that we have a lot of code duplication with our four 'main loops' - Pi::Start, Pi::MainLoop, Pi::Init (though that technically wasn't a loop at all), and the ModelViewer main loop. So, instead of writing yet another main loop, and duplicating yet more pigui handling code, I've been seized by a fey mood for the last few days...

I've implemented an `Application` class that's responsible for initializing the filesystem, running the main loop, tracking update times, and resetting the Profiler each frame. This is all fairly generic stuff that we should be doing no matter what we're running, whether it's the game, the menu, or the ModelViewer.

I've built on the concept with `GuiApplication`, which is responsible for initializing and managing the renderer, handling the 'full-screen' render target (and thus probably window resizing once we have that working), and eventually (I didn't want to bloat the PR any further) initializing and running PiGui.

This is all transparent to the update loop, via the `Lifecycle` concept. A lifecycle is a very simple object - it can run code when it starts executing, when it stops executing, and it's updated every frame. This building block allows us to plug all of our update loops into a single, generic `Application` that doesn't care whether it's running the menu, the Tombstone loop, or the game itself. (Admittedly that's not quite true, but the tangle that is Pi.cpp can't be resolved in one go, as much as I wish otherwise.)

As a result, I've implemented the less-important parts of `Pi::Init()` as it's own Lifecycle - the LoadStep. This lifecycle is responsible for initializing all of our classes like LuaEngine and CityOnPlanet, etc, and it does so by registering 'module initializers' which it then loops through.

This lays the groundwork for asynchronous resource loading - kick the initializer off on another thread, and then just spin until the promise associated with the module becomes valid. Or, for module which don't have dependencies, you can run initializers in parallel. We obviously can't do that right now due to the engine being written for single-threaded code, but the groundwork is there.

To those who wish to review this PR: please don't even bother trying to parse the diff for Pi.cpp. I've re-organized and re-written pretty much the entire file, so it's actually easier to treat it like it's an entirely new file and just read it in its entirety.

I'm 95% confident I've caught all of the bugs arising from this PR; once you get past the churn, all of the important bits are very similar to what we had before. I've done some basic testing to ensure that everything runs and you can take off just fine, but more testing would be appreciated!