### PR TITLE
Build fix and comments

### DIFF
--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -323,10 +323,10 @@ void GeoPatch::LODUpdate(const vector3d &campos, const Graphics::Frustum &frustu
 	// always split at first level
 	double centroidDist = DBL_MAX;
 	if (m_parent) {
-		centroidDist = (campos - m_centroid).Length();
-		const bool errorSplit = (centroidDist < m_roughLength);
-		if (!(canSplit && (m_depth < std::min(GEOPATCH_MAX_DEPTH, m_geosphere->GetMaxDepth())) && errorSplit)) {
-			canSplit = false;
+		centroidDist = (campos - m_centroid).Length(); // distance from camera to centre of the patch
+		const bool tooFar = (centroidDist >= m_roughLength); // check if the distance is greater than the rough length, which is how far it should be before it can split
+		if (m_depth >= std::min(GEOPATCH_MAX_DEPTH, m_geosphere->GetMaxDepth()) || tooFar) {
+			canSplit = false; // we're too deep in the quadtree or too far away so cannot split
 		}
 	}
 

--- a/win32/vs2019/pioneer.vcxproj
+++ b/win32/vs2019/pioneer.vcxproj
@@ -460,6 +460,7 @@
     <ClCompile Include="..\..\src\lua\LuaStarSystem.cpp" />
     <ClCompile Include="..\..\src\lua\LuaSystemBody.cpp" />
     <ClCompile Include="..\..\src\lua\LuaSystemPath.cpp" />
+    <ClCompile Include="..\..\src\lua\LuaSystemView.cpp" />
     <ClCompile Include="..\..\src\lua\LuaTimer.cpp" />
     <ClCompile Include="..\..\src\lua\LuaUtils.cpp" />
     <ClCompile Include="..\..\src\lua\LuaVector.cpp" />

--- a/win32/vs2019/pioneer.vcxproj.filters
+++ b/win32/vs2019/pioneer.vcxproj.filters
@@ -564,6 +564,9 @@
     <ClCompile Include="..\..\src\pigui\Widgets.cpp">
       <Filter>src\pigui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\lua\LuaSystemView.cpp">
+      <Filter>src\Lua</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Aabb.h">


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->
Build fix for Visual Studio.

Also reordered the terrain split test, removed the `canSplit` test as it's always true, inverted the logic, and renamed a temporary to make things clearer.
Added some comments.
