### PR TITLE
Docking fee not applied if fuel tank is at least 99.9 % full

### DIFF
--- a/data/modules/StationRefuelling/StationRefuelling.lua
+++ b/data/modules/StationRefuelling/StationRefuelling.lua
@@ -29,6 +29,9 @@ local onShipDocked = function (ship, station)
 		ship:SetFuelPercent() -- refuel NPCs for free.
 		return
 	end
+	if ship.fuel > 99.9 then -- No docking fee when starting a new game
+		return
+	end
 	local fee = calculateFee()
 	if ship:GetMoney() < fee then
 		Comms.Message(l.THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH:interp({station = station.label,fee = Format.Money(fee)}))


### PR DESCRIPTION
Silly fix proposed to avoid docking fee as onShipDocked is triggered when starting a new game, and possibly other "unfair" fees too (eg. re-docking after accidental launch).

Fixes  #4804

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

