### PR TITLE
Remove many warnings

### DIFF
--- a/contrib/json/json.hpp
+++ b/contrib/json/json.hpp
@@ -10172,7 +10172,7 @@ class serializer
             return;
         }
 
-        const bool is_negative = (x <= 0) and (x != 0);  // see issue #755
+        const bool is_negative = !(x>=0);  // see issue #755
         std::size_t i = 0;
 
         while (x != 0)

--- a/contrib/lua/src/luaconf.h
+++ b/contrib/lua/src/luaconf.h
@@ -463,7 +463,7 @@
 @@ LUA_UNSIGNED is the integral type used by lua_pushunsigned/lua_tounsigned.
 ** It must have at least 32 bits.
 */
-#define LUA_UNSIGNED	size_t
+#define LUA_UNSIGNED	unsigned LUA_INT32
 
 
 

--- a/contrib/lua/src/luaconf.h
+++ b/contrib/lua/src/luaconf.h
@@ -463,7 +463,7 @@
 @@ LUA_UNSIGNED is the integral type used by lua_pushunsigned/lua_tounsigned.
 ** It must have at least 32 bits.
 */
-#define LUA_UNSIGNED	unsigned LUA_INT32
+#define LUA_UNSIGNED	size_t
 
 
 

--- a/contrib/nanosvg/nanosvg.h
+++ b/contrib/nanosvg/nanosvg.h
@@ -170,7 +170,7 @@ NSVGimage* nsvgParse(char* input, const char* units, float dpi);
 void nsvgDelete(NSVGimage* image);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif // NANOSVG_H

--- a/contrib/nanosvg/nanosvgrast.h
+++ b/contrib/nanosvg/nanosvgrast.h
@@ -64,7 +64,7 @@ void nsvgDeleteRasterizer(NSVGrasterizer*);
 
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif // NANOSVGRAST_H

--- a/contrib/profiler/Profiler.cpp
+++ b/contrib/profiler/Profiler.cpp
@@ -1235,4 +1235,4 @@ namespace Profiler {
 	void reset() {}
 #endif
 
-}; // namespace Profiler
+} // namespace Profiler

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -323,7 +323,7 @@ namespace Background {
 		}
 		Output("Stars picked from galaxy: %d\n", num);
 		// use a logarithmic scala for brightness since this looks more natural to the human eye
-		for (Uint32 i = 0; i < num; ++i) {
+		for (uint32_t i = 0; i < num; ++i) {
 			brightness[i] = log(brightness[i]);
 		}
 

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -323,13 +323,13 @@ namespace Background {
 		}
 		Output("Stars picked from galaxy: %d\n", num);
 		// use a logarithmic scala for brightness since this looks more natural to the human eye
-		for (int i = 0; i < num; ++i) {
+		for (Uint32 i = 0; i < num; ++i) {
 			brightness[i] = log(brightness[i]);
 		}
 
 		// find the median brightness of all visible stars
 		std::vector<int> sortedBrightnessIndex;
-		for (int i = 0; i < num; ++i) {
+		for (Uint32 i = 0; i < num; ++i) {
 			sortedBrightnessIndex.push_back(i);
 		}
 		std::sort(sortedBrightnessIndex.begin(), sortedBrightnessIndex.end(), [&](const int a, const int b) {

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -111,7 +111,7 @@ public:
 
 	// lights with properties in camera space
 	const std::vector<LightSource> &GetLightSources() const { return m_lightSources; }
-	const int GetNumLightSources() const { return static_cast<Uint32>(m_lightSources.size()); }
+	int GetNumLightSources() const { return static_cast<Uint32>(m_lightSources.size()); }
 
 private:
 	RefCountedPtr<CameraContext> m_context;

--- a/src/Color.h
+++ b/src/Color.h
@@ -81,11 +81,6 @@ struct Color4ub {
 		g(g_),
 		b(b_),
 		a(a_) {}
-	Color4ub(const Color4ub &c) :
-		r(c.r),
-		g(c.g),
-		b(c.b),
-		a(c.a) {}
 	Color4ub(const Color4f &c) :
 		r(Uint8(c.r * 255.f)),
 		g(Uint8(c.g * 255.f)),

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -45,14 +45,14 @@ DynamicBody::DynamicBody() :
 
 DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
 	ModelBody(jsonObj, space),
-	m_propulsion(nullptr),
-	m_fixedGuns(nullptr),
 	m_dragCoeff(DEFAULT_DRAG_COEFF),
+	m_externalForce(vector3d(0.0)),
 	m_atmosForce(vector3d(0.0)),
 	m_gravityForce(vector3d(0.0)),
-	m_externalForce(vector3d(0.0)),
 	m_lastForce(vector3d(0.0)),
-	m_lastTorque(vector3d(0.0))
+	m_lastTorque(vector3d(0.0)),
+	m_propulsion(nullptr),
+	m_fixedGuns(nullptr)
 {
 	m_flags = Body::FLAG_CAN_MOVE_FRAME;
 	m_oldPos = GetPosition();

--- a/src/FixedGuns.cpp
+++ b/src/FixedGuns.cpp
@@ -54,7 +54,7 @@ void FixedGuns::Init(DynamicBody *b)
 		m_gun_present[i] = false;
 		m_recharge_stat[i] = 0.0;
 		m_temperature_stat[i] = 0.0;
-	};
+	}
 	b->AddFeature(DynamicBody::FIXED_GUNS);
 }
 
@@ -71,7 +71,7 @@ void FixedGuns::SaveToJson(Json &jsonObj, Space *space)
 		gunArray.push_back(gunArrayEl); // Append gun object to array.
 	}
 	jsonObj["guns"] = gunArray; // Add gun array to ship object.
-};
+}
 
 void FixedGuns::LoadFromJson(const Json &jsonObj, Space *space)
 {
@@ -89,7 +89,7 @@ void FixedGuns::LoadFromJson(const Json &jsonObj, Space *space)
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
-};
+}
 
 void FixedGuns::InitGuns(SceneGraph::Model *m)
 {
@@ -146,7 +146,7 @@ void FixedGuns::MountGun(const int num, const float recharge, const float lifesp
 	m_gun[num].projData.speed = speed;
 	m_gun[num].projData.beam = beam;
 	m_gun_present[num] = true;
-};
+}
 
 void FixedGuns::UnMountGun(int num)
 {
@@ -197,7 +197,7 @@ bool FixedGuns::Fire(const int num, Body *b)
 	}
 
 	return true;
-};
+}
 
 void FixedGuns::UpdateGuns(float timeStep)
 {

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -157,7 +157,7 @@ void Frame::ToJson(Json &frameObj, FrameId fId, Space *space)
 Frame::~Frame()
 {
 	if (!d.madeWithFactory) {
-		Error("Frame instance deletion outside 'DeleteFrame' [%i]\n", m_thisId.id());
+		Error("Frame instance deletion outside 'DeleteFrame' [%zu]\n", m_thisId.id());
 	}
 }
 
@@ -244,10 +244,10 @@ Frame *Frame::GetFrame(FrameId fId)
 {
 	PROFILE_SCOPED()
 
-	if (fId && fId.id() >= 0 && static_cast<std::size_t>(fId.id()) < s_frames.size())
+	if (fId && fId.id() < s_frames.size())
 		return &s_frames[fId];
 	else if (fId)
-		Error("In '%s': fId is valid but out of range (%i)...\n", __func__, fId.id());
+		Error("In '%s': fId is valid but out of range (%zu)...\n", __func__, fId.id());
 
 	return nullptr;
 }

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -188,7 +188,7 @@ FrameId Frame::FromJson(const Json &frameObj, Space *space, FrameId parent, doub
 		f->m_thisId = frameObj["frameId"];
 
 		// Check if frames order in load and save are the same
-		assert((s_frames.size() - 1) != f->m_thisId.id());
+		assert(s_frames.size() == 0 || (s_frames.size() - 1) != f->m_thisId.id());
 
 		f->m_flags = frameObj["flags"];
 		f->m_radius = frameObj["radius"];
@@ -274,7 +274,7 @@ void Frame::DeleteCameraFrame(FrameId camera)
 
 // Call dtor "popping" element in vector
 #ifndef NDEBUG
-	if (camera.id() < s_frames.size() - 1) {
+	if (s_frames.size() > 0 && camera.id() < s_frames.size() - 1) {
 		Error("DeleteCameraFrame: seems camera frame is not the last frame!\n");
 		abort();
 	};

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -14,16 +14,16 @@ std::vector<Frame> Frame::s_frames;
 std::vector<CollisionSpace> Frame::s_collisionSpaces;
 
 Frame::Frame(const Dummy &d, FrameId parent, const char *label, unsigned int flags, double radius) :
+	m_parent(parent),
 	m_sbody(nullptr),
 	m_astroBody(nullptr),
-	m_parent(parent),
-	m_radius(radius),
-	m_flags(flags),
 	m_pos(vector3d(0.0)),
+	m_initialOrient(matrix3x3d::Identity()),
+	m_orient(matrix3x3d::Identity()),
 	m_vel(vector3d(0.0)),
 	m_angSpeed(0.0),
-	m_orient(matrix3x3d::Identity()),
-	m_initialOrient(matrix3x3d::Identity())
+	m_radius(radius),
+	m_flags(flags)
 {
 	if (!d.madeWithFactory)
 		Error("Frame ctor called directly!\n");
@@ -42,18 +42,18 @@ Frame::Frame(const Dummy &d, FrameId parent, const char *label, unsigned int fla
 }
 
 Frame::Frame(const Dummy &d, FrameId parent) :
+	m_parent(parent),
 	m_sbody(nullptr),
 	m_astroBody(nullptr),
-	m_parent(parent),
+	m_pos(vector3d(0.0)),
+	m_initialOrient(matrix3x3d::Identity()),
+	m_orient(matrix3x3d::Identity()),
+	m_vel(vector3d(0.0)),
+	m_angSpeed(0.0),
 	m_label("camera"),
 	m_radius(0.0),
 	m_flags(FLAG_ROTATING),
-	m_collisionSpace(-1),
-	m_pos(vector3d(0.0)),
-	m_vel(vector3d(0.0)),
-	m_angSpeed(0.0),
-	m_orient(matrix3x3d::Identity()),
-	m_initialOrient(matrix3x3d::Identity())
+	m_collisionSpace(-1)
 {
 	if (!d.madeWithFactory)
 		Error("Frame ctor called directly!\n");
@@ -244,7 +244,7 @@ Frame *Frame::GetFrame(FrameId fId)
 {
 	PROFILE_SCOPED()
 
-	if (fId && fId.id() < s_frames.size())
+	if (fId && fId.id() >= 0 && static_cast<std::size_t>(fId.id()) < s_frames.size())
 		return &s_frames[fId];
 	else if (fId)
 		Error("In '%s': fId is valid but out of range (%i)...\n", __func__, fId.id());

--- a/src/FrameId.h
+++ b/src/FrameId.h
@@ -2,29 +2,36 @@
 #define FRAMEID_H_INCLUDED
 
 #include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <limits>
 
 struct FrameId {
-	static constexpr int Invalid = -1;
+	static constexpr uint32_t Invalid = std::numeric_limits<uint32_t>::max();
 	constexpr FrameId() :
 		m_id(Invalid) {}
-	constexpr FrameId(int new_id) :
+	constexpr FrameId(uint32_t new_id) :
 		m_id(new_id) {}
 
-	constexpr operator bool() const { return m_id > Invalid; }
-	constexpr operator int() const { return m_id; }
+	constexpr operator bool() const { return m_id != Invalid; }
+	constexpr operator uint32_t() const { return m_id; }
 	constexpr operator size_t() const { return m_id; }
 
 	constexpr bool operator==(FrameId rhs) const { return m_id == rhs.m_id; }
 	constexpr bool operator!=(FrameId rhs) const { return m_id != rhs.m_id; }
 
-	constexpr bool valid() const { return m_id > Invalid; }
-	constexpr int id() const { return m_id; }
+	constexpr bool valid() const { return m_id != Invalid; }
+	constexpr size_t id() const {
+		// Cannot use an `if` in constexpr context in C++11, sorry
+		return valid() ? static_cast<size_t>(m_id) : (std::terminate(), 0);
+	}
+	constexpr int unchecked_id() const { return m_id; }
 
 private:
-	int m_id;
+	uint32_t m_id;
 };
 
-static_assert(sizeof(FrameId) == sizeof(int) && alignof(FrameId) == alignof(int),
+static_assert(sizeof(FrameId) == sizeof(uint32_t) && alignof(FrameId) == alignof(uint32_t),
 	"Error: FrameId sized differently than the underlying type on this platform!");
 
 #endif // FRAMEID_H_INCLUDED

--- a/src/FrameId.h
+++ b/src/FrameId.h
@@ -21,11 +21,7 @@ struct FrameId {
 	constexpr bool operator!=(FrameId rhs) const { return m_id != rhs.m_id; }
 
 	constexpr bool valid() const { return m_id != Invalid; }
-	constexpr size_t id() const {
-		// Cannot use an `if` in constexpr context in C++11, sorry
-		return valid() ? static_cast<size_t>(m_id) : (std::terminate(), 0);
-	}
-	constexpr int unchecked_id() const { return m_id; }
+	constexpr size_t id() const { return m_id; }
 
 private:
 	uint32_t m_id;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -888,9 +888,9 @@ Game *Game::LoadGame(const std::string &filename)
 
 	try {
 		return new Game(rootNode);
-	} catch (Json::type_error) {
+	} catch (const Json::type_error&) {
 		throw SavedGameCorruptException();
-	} catch (Json::out_of_range) {
+	} catch (const Json::out_of_range&) {
 		throw SavedGameCorruptException();
 	}
 }

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -80,7 +80,7 @@ namespace {
 
 		return i == 4;
 	}
-}; // namespace
+} // namespace
 
 class GasPatchContext : public RefCounted {
 public:

--- a/src/GasGiantJobs.cpp
+++ b/src/GasGiantJobs.cpp
@@ -295,4 +295,4 @@ namespace GasGiantJobs {
 		GasGiant::OnAddGPUGenResult(mData->SysPath(), mpResults);
 		mpResults = nullptr;
 	}
-}; // namespace GasGiantJobs
+} // namespace GasGiantJobs

--- a/src/GasGiantJobs.h
+++ b/src/GasGiantJobs.h
@@ -77,9 +77,6 @@ namespace GasGiantJobs {
 			STextureFaceData(Color *c_, Sint32 uvDims_) :
 				colors(c_),
 				uvDims(uvDims_) {}
-			STextureFaceData(const STextureFaceData &r) :
-				colors(r.colors),
-				uvDims(r.uvDims) {}
 			Color *colors;
 			Sint32 uvDims;
 		};
@@ -193,9 +190,6 @@ namespace GasGiantJobs {
 			SGPUGenData(Graphics::Texture *t_, Sint32 uvDims_) :
 				texture(t_),
 				uvDims(uvDims_) {}
-			SGPUGenData(const SGPUGenData &r) :
-				texture(r.texture),
-				uvDims(r.uvDims) {}
 			RefCountedPtr<Graphics::Texture> texture;
 			Sint32 uvDims;
 		};
@@ -235,6 +229,6 @@ namespace GasGiantJobs {
 		std::unique_ptr<SGPUGenRequest> mData;
 		SGPUGenResult *mpResults;
 	};
-}; // namespace GasGiantJobs
+} // namespace GasGiantJobs
 
 #endif /* _GASGIANTJOBS_H */

--- a/src/GeoPatchID.h
+++ b/src/GeoPatchID.h
@@ -13,8 +13,6 @@ private:
 public:
 	GeoPatchID(const uint64_t init) :
 		mPatchID(init) {}
-	GeoPatchID(const GeoPatchID &init) :
-		mPatchID(init.mPatchID) {}
 
 	static const uint64_t MAX_SHIFT_DEPTH = 61;
 

--- a/src/GeoPatchJobs.h
+++ b/src/GeoPatchJobs.h
@@ -139,15 +139,6 @@ public:
 			v3(v3_),
 			patchID(patchID_)
 		{}
-		SSplitResultData(const SSplitResultData &r) :
-			normals(r.normals),
-			colors(r.colors),
-			v0(r.v0),
-			v1(r.v1),
-			v2(r.v2),
-			v3(r.v3),
-			patchID(r.patchID)
-		{}
 
 		double *heights;
 		vector3f *normals;

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -11,12 +11,12 @@
 
 Input::Input(IniConfig *config) :
 	m_config(config),
-	m_capturingMouse(false),
-	mouseYInvert(false),
-	joystickEnabled(true),
 	keyModState(0),
 	mouseButton(),
-	mouseMotion()
+	mouseMotion(),
+	m_capturingMouse(false),
+	joystickEnabled(true),
+	mouseYInvert(false)
 {
 	joystickEnabled = (m_config->Int("EnableJoystick")) ? true : false;
 	mouseYInvert = (m_config->Int("InvertMouseY")) ? true : false;

--- a/src/KeyBindings.cpp
+++ b/src/KeyBindings.cpp
@@ -458,7 +458,7 @@ namespace KeyBindings {
 			formatarg("signp", direction == KeyBindings::NEGATIVE ? "-" : "+"), // optional with + sign
 			formatarg("joynum", joystick),
 			formatarg("joyname", Pi::input->JoystickName(joystick)),
-			formatarg("axis", axis >= 0 && axis < 3 ? axis_names[axis] : ossaxisnum.str()));
+			formatarg("axis", axis < 3 ? axis_names[axis] : ossaxisnum.str()));
 	}
 
 	bool JoyAxisBinding::FromString(const char *str, JoyAxisBinding &ab)

--- a/src/LZ4Format.cpp
+++ b/src/LZ4Format.cpp
@@ -75,5 +75,5 @@ std::unique_ptr<char[]> lz4::CompressLZ4(const std::string &data, const int lz4_
 	checkError<lz4::CompressionFailedException>(_size);
 
 	outSize = _size;
-	return std::move(out);
+	return out;
 }

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -167,28 +167,26 @@ void ModelViewerApp::PostUpdate()
 }
 
 ModelViewer::ModelViewer(ModelViewerApp *app, LuaManager *lm) :
-	m_app(app),
 	m_input(app->GetInput()),
 	m_pigui(app->GetPiGui()),
-	m_renderer(app->GetRenderer()),
-	m_screenshotQueued(false),
-	m_shieldIsHit(false),
-	m_settingColourSliders(false),
-	m_shieldHitPan(-1.48f),
-	m_decalTexture(0),
-	m_rotX(0),
-	m_rotY(0),
-	m_zoom(0),
-	m_baseDistance(100.0f),
-	m_rng(time(0)),
-	m_modelIsShip(false),
+	m_logWindowSize(350.0f, 500.0f),
+	m_animWindowSize(0.0f, 150.0f),
 	m_colors({ Color(255, 0, 0),
 		Color(0, 255, 0),
 		Color(0, 0, 255) }),
 	m_modelName(""),
 	m_requestedModelName(),
-	m_logWindowSize(350.0f, 500.0f),
-	m_animWindowSize(0.0f, 150.0f)
+	m_modelIsShip(false),
+	m_screenshotQueued(false),
+	m_shieldIsHit(false),
+	m_shieldHitPan(-1.48f),
+	m_renderer(app->GetRenderer()),
+	m_decalTexture(0),
+	m_rotX(0),
+	m_rotY(0),
+	m_zoom(0),
+	m_baseDistance(100.0f),
+	m_rng(time(0))
 {
 	onModelChanged.connect(sigc::mem_fun(*this, &ModelViewer::OnModelChanged));
 	SetupAxes();

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -132,7 +132,6 @@ private:
 	};
 
 private:
-	ModelViewerApp *m_app;
 	Input *m_input;
 	PiGui::Instance *m_pigui;
 
@@ -186,7 +185,6 @@ private:
 
 	bool m_screenshotQueued;
 	bool m_shieldIsHit;
-	bool m_settingColourSliders;
 	float m_shieldHitPan;
 	Graphics::Renderer *m_renderer;
 	Graphics::Texture *m_decalTexture;

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -222,9 +222,9 @@ void Planet::GenerateRings(Graphics::Renderer *renderer)
 	{
 		Color *row;
 		row = buf.get();
-		memset(row, 0, RING_TEXTURE_WIDTH * 4);
+                std::fill_n(row, RING_TEXTURE_WIDTH, Color::BLACK);
 		row = buf.get() + (RING_TEXTURE_LENGTH - 1) * RING_TEXTURE_WIDTH;
-		memset(row, 0, RING_TEXTURE_WIDTH * 4);
+                std::fill_n(row, RING_TEXTURE_WIDTH, Color::BLACK);
 	}
 
 	const vector3f texSize(RING_TEXTURE_WIDTH, RING_TEXTURE_LENGTH, 0.0f);

--- a/src/Quaternion.h
+++ b/src/Quaternion.h
@@ -7,9 +7,11 @@
 #include "matrix4x4.h"
 #include "vector3.h"
 #include <math.h>
+#include <type_traits>
 
 template <typename T>
 class Quaternion {
+	using other_float_t = typename std::conditional<std::is_same<T, float>::value, double, float>::type;
 public:
 	T w, x, y, z;
 
@@ -19,8 +21,11 @@ public:
 	Quaternion(T w, T x, T y, T z);
 	// from angle and axis
 	Quaternion(T ang, vector3<T> axis);
-	Quaternion(const Quaternion<float> &o);
-	Quaternion(const Quaternion<double> &o);
+	Quaternion(const Quaternion<other_float_t> &o) :
+		w(o.w),
+		x(o.x),
+		y(o.y),
+		z(o.z) {}
 
 	void GetAxisAngle(T &angle, vector3<T> &axis) const
 	{
@@ -247,31 +252,6 @@ inline Quaternion<double>::Quaternion(double ang, vector3<double> axis)
 	y = axis.y * sinHalfAng;
 	z = axis.z * sinHalfAng;
 }
-
-template <>
-inline Quaternion<float>::Quaternion(const Quaternion<float> &o) :
-	w(o.w),
-	x(o.x),
-	y(o.y),
-	z(o.z) {}
-template <>
-inline Quaternion<float>::Quaternion(const Quaternion<double> &o) :
-	w(float(o.w)),
-	x(float(o.x)),
-	y(float(o.y)),
-	z(float(o.z)) {}
-template <>
-inline Quaternion<double>::Quaternion(const Quaternion<float> &o) :
-	w(o.w),
-	x(o.x),
-	y(o.y),
-	z(o.z) {}
-template <>
-inline Quaternion<double>::Quaternion(const Quaternion<double> &o) :
-	w(o.w),
-	x(o.x),
-	y(o.y),
-	z(o.z) {}
 
 typedef Quaternion<float> Quaternionf;
 typedef Quaternion<double> Quaterniond;

--- a/src/Random.h
+++ b/src/Random.h
@@ -52,7 +52,7 @@ public:
 	// seeds.
 	Random(const Uint64 *const seeds, size_t length)
 	{
-		seed(reinterpret_cast<const Uint32 *const>(seeds), length * 2);
+		seed(reinterpret_cast<const Uint32 *>(seeds), length * 2);
 	}
 
 	//
@@ -70,7 +70,7 @@ public:
 	// Seed using an array of 64-bit integers
 	void seed(const Uint64 *const seeds, size_t length)
 	{
-		seed(reinterpret_cast<const Uint32 *const>(seeds), length * 2);
+		seed(reinterpret_cast<const Uint32 *>(seeds), length * 2);
 	}
 
 	// Seed using a single 32-bit integer

--- a/src/RandomColor.cpp
+++ b/src/RandomColor.cpp
@@ -342,4 +342,4 @@ namespace RandomColorGenerator {
 
 		return c;
 	}
-}; // namespace RandomColorGenerator
+} // namespace RandomColorGenerator

--- a/src/RandomColor.h
+++ b/src/RandomColor.h
@@ -144,6 +144,6 @@ namespace RandomColorGenerator {
 		// Converts hue, saturation, and lightness to a color.
 		static Color HsvToColor(int hue, int saturation, double value);
 	};
-}; // namespace RandomColorGenerator
+} // namespace RandomColorGenerator
 
 #endif // _RANDOM_COLOR_H_

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -119,7 +119,9 @@ void SectorView::InitDefaults()
 	m_zoomDefault = Clamp(m_zoomDefault, 0.1f, 5.0f);
 	m_previousSearch = "";
 
-	m_secPosFar = vector3f(INT_MAX, INT_MAX, INT_MAX);
+	// Note: INT_MAX != (int) ((float) INT_MAX)
+	const float farPos = static_cast<float>(INT_MAX);
+	m_secPosFar = vector3f(farPos, farPos, farPos);
 	m_radiusFar = 0;
 	m_cacheXMin = 0;
 	m_cacheXMax = 0;

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -30,7 +30,7 @@ namespace {
 		const float pixrad = Clamp(Graphics::GetScreenHeight() / trans.Length(), 0.1f, 50.0f);
 		return (size * Graphics::GetFovFactor()) * pixrad;
 	}
-}; // namespace
+} // namespace
 
 std::unique_ptr<Graphics::Material> SfxManager::damageParticle;
 std::unique_ptr<Graphics::Material> SfxManager::ecmParticle;
@@ -62,15 +62,6 @@ Sfx::Sfx(const Json &jsonObj)
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
-}
-
-Sfx::Sfx(const Sfx &b) :
-	m_pos(b.m_pos),
-	m_vel(b.m_vel),
-	m_age(b.m_age),
-	m_speed(b.m_speed),
-	m_type(b.m_type)
-{
 }
 
 void Sfx::SaveToJson(Json &jsonObj)

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -31,7 +31,6 @@ public:
 	Sfx() = delete;
 	Sfx(const vector3d &pos, const vector3d &vel, const float speed, const SFX_TYPE type);
 	Sfx(const Json &jsonObj);
-	Sfx(const Sfx &);
 	void SetPosition(const vector3d &p);
 	const vector3d &GetPosition() const { return m_pos; }
 

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -1482,8 +1482,9 @@ bool AICmdFlyAround::TimeStepUpdate()
 			return false;
 		}
 
-	} else
-		; // return false;
+	} else {
+		// return false;
+	}
 
 	double timestep = Pi::game->GetTimeStep();
 	vector3d targpos = (!m_targmode) ? m_targpos :

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -40,7 +40,7 @@ void Space::BodyNearFinder::Prepare()
 
 Space::BodyNearList Space::BodyNearFinder::GetBodiesMaybeNear(const Body *b, double dist)
 {
-	return std::move(GetBodiesMaybeNear(b->GetPositionRelTo(m_space->GetRootFrame()), dist));
+	return GetBodiesMaybeNear(b->GetPositionRelTo(m_space->GetRootFrame()), dist);
 }
 
 Space::BodyNearList Space::BodyNearFinder::GetBodiesMaybeNear(const vector3d &pos, double dist)

--- a/src/Space.h
+++ b/src/Space.h
@@ -77,11 +77,11 @@ public:
 	typedef const std::vector<Body *> BodyNearList;
 	BodyNearList GetBodiesMaybeNear(const Body *b, double dist)
 	{
-		return std::move(m_bodyNearFinder.GetBodiesMaybeNear(b, dist));
+		return m_bodyNearFinder.GetBodiesMaybeNear(b, dist);
 	}
 	BodyNearList GetBodiesMaybeNear(const vector3d &pos, double dist)
 	{
-		return std::move(m_bodyNearFinder.GetBodiesMaybeNear(pos, dist));
+		return m_bodyNearFinder.GetBodiesMaybeNear(pos, dist);
 	}
 
 	void DebugDumpFrames(bool details);

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -184,7 +184,7 @@ void SpaceStation::InitStation()
 		// clear it all to default
 		m_ports = m_type->Ports();
 		// now restore the "inUse" variable only since it's the only bit that might have changed
-		for (int p = 0; p < m_ports.size(); p++) {
+		for (std::size_t p = 0; p < m_ports.size(); p++) {
 			m_ports[p].inUse = backup[p].inUse;
 		}
 	}

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -184,7 +184,7 @@ void SpaceStation::InitStation()
 		// clear it all to default
 		m_ports = m_type->Ports();
 		// now restore the "inUse" variable only since it's the only bit that might have changed
-		for (std::size_t p = 0; p < m_ports.size(); p++) {
+		for (size_t p = 0; p < m_ports.size(); p++) {
 			m_ports[p].inUse = backup[p].inUse;
 		}
 	}

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -227,9 +227,9 @@ void TransferPlanner::SetPosition(const vector3d &position) { m_position = posit
 SystemView::SystemView(Game *game) :
 	UIView(),
 	m_game(game),
-	m_gridDrawing(GridDrawing::OFF),
-	m_shipDrawing(OFF),
 	m_showL4L5(LAG_OFF),
+	m_shipDrawing(OFF),
+	m_gridDrawing(GridDrawing::OFF),
 	m_trans(0.0),
 	m_transTo(0.0)
 {

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -37,16 +37,16 @@ namespace {
 
 WorldView::WorldView(Game *game) :
 	UIView(),
-	m_game(game),
-	shipView(this)
+	shipView(this),
+	m_game(game)
 {
 	InitObject();
 }
 
 WorldView::WorldView(const Json &jsonObj, Game *game) :
 	UIView(),
-	m_game(game),
-	shipView(this)
+	shipView(this),
+	m_game(game)
 {
 	if (!jsonObj["world_view"].is_object()) throw SavedGameCorruptException();
 	Json worldViewObj = jsonObj["world_view"];

--- a/src/collider/CollisionSpace.h
+++ b/src/collider/CollisionSpace.h
@@ -61,7 +61,7 @@ private:
 	BvhTree *m_dynamicObjectTree;
 	Sphere sphere;
 
-	int m_oldGeomsNumber;
+	unsigned m_oldGeomsNumber;
 
 	static int s_nextHandle;
 };

--- a/src/collider/CollisionSpace.h
+++ b/src/collider/CollisionSpace.h
@@ -61,7 +61,7 @@ private:
 	BvhTree *m_dynamicObjectTree;
 	Sphere sphere;
 
-	unsigned m_oldGeomsNumber;
+	uint32_t m_oldGeomsNumber;
 
 	static int s_nextHandle;
 };

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -14,12 +14,8 @@ public:
 	class Lifecycle {
 	public:
 		Lifecycle(){};
-#ifdef PIONEER_PROFILER
 		Lifecycle(bool profilerAccumulate) :
 			m_profilerAccumulate(profilerAccumulate){};
-#else
-		Lifecycle(bool /* profilerAccumulate */){};
-#endif
 		virtual ~Lifecycle(){};
 
 		// Once called, the lifecycle is terminated at the end of the current update.
@@ -45,10 +41,8 @@ public:
 		}
 
 	private:
-#ifdef PIONEER_PROFILER
 		// set to true when you want to accumulate all updates in a lifecycle into a single profile frame
 		bool m_profilerAccumulate = false;
-#endif
 		bool m_endLifecycle = false;
 		std::shared_ptr<Lifecycle> m_nextLifecycle;
 		Application *m_application;

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -14,8 +14,12 @@ public:
 	class Lifecycle {
 	public:
 		Lifecycle(){};
+#ifdef PIONEER_PROFILER
 		Lifecycle(bool profilerAccumulate) :
 			m_profilerAccumulate(profilerAccumulate){};
+#else
+		Lifecycle(bool /* profilerAccumulate */){};
+#endif
 		virtual ~Lifecycle(){};
 
 		// Once called, the lifecycle is terminated at the end of the current update.
@@ -41,8 +45,10 @@ public:
 		}
 
 	private:
+#ifdef PIONEER_PROFILER
 		// set to true when you want to accumulate all updates in a lifecycle into a single profile frame
 		bool m_profilerAccumulate = false;
+#endif
 		bool m_endLifecycle = false;
 		std::shared_ptr<Lifecycle> m_nextLifecycle;
 		Application *m_application;

--- a/src/galaxy/Factions.cpp
+++ b/src/galaxy/Factions.cpp
@@ -547,7 +547,7 @@ const Faction *FactionsDatabase::GetFaction(const std::string &factionName) cons
 	}
 }
 
-const Uint32 FactionsDatabase::GetNumFactions() const
+Uint32 FactionsDatabase::GetNumFactions() const
 {
 	PROFILE_SCOPED()
 	return m_factions.size();
@@ -607,7 +607,7 @@ bool Faction::IsClaimed(SystemPath path) const
 	if it is, then the passed distance will also be updated to be the distance
 	from the factions homeworld to the sysPath.
 */
-const bool Faction::IsCloserAndContains(double &closestFactionDist, const Sector::System *sys) const
+bool Faction::IsCloserAndContains(double &closestFactionDist, const Sector::System *sys) const
 {
 	PROFILE_SCOPED()
 	/*	Treat factions without homeworlds as if they are of effectively infinite radius,
@@ -647,7 +647,7 @@ const bool Faction::IsCloserAndContains(double &closestFactionDist, const Sector
 	}
 }
 
-const Color Faction::AdjustedColour(fixed population, bool inRange) const
+Color Faction::AdjustedColour(fixed population, bool inRange) const
 {
 	PROFILE_SCOPED()
 	Color result;
@@ -658,7 +658,7 @@ const Color Faction::AdjustedColour(fixed population, bool inRange) const
 	return result;
 }
 
-const Polit::GovType Faction::PickGovType(Random &rand) const
+Polit::GovType Faction::PickGovType(Random &rand) const
 {
 	PROFILE_SCOPED()
 	if (!govtype_weights.empty()) {

--- a/src/galaxy/Factions.h
+++ b/src/galaxy/Factions.h
@@ -62,10 +62,10 @@ public:
 
 	Color colour;
 
-	const double Radius() const { return (FACTION_CURRENT_YEAR - foundingDate) * expansionRate; };
-	const bool IsValid() const { return idx != BAD_FACTION_IDX; };
-	const Color AdjustedColour(fixed population, bool inRange) const;
-	const Polit::GovType PickGovType(Random &rand) const;
+	double Radius() const { return (FACTION_CURRENT_YEAR - foundingDate) * expansionRate; };
+	bool IsValid() const { return idx != BAD_FACTION_IDX; };
+	Color AdjustedColour(fixed population, bool inRange) const;
+	Polit::GovType PickGovType(Random &rand) const;
 
 	// set the homeworld to one near the supplied co-ordinates
 	void SetBestFitHomeworld(Sint32 x, Sint32 y, Sint32 z, Sint32 si, Uint32 bi, Sint32 axisChange);
@@ -76,7 +76,7 @@ private:
 
 	Galaxy *const m_galaxy; // galaxy we are part of
 	mutable RefCountedPtr<const Sector> m_homesector; // cache of home sector to use in distance calculations
-	const bool IsCloserAndContains(double &closestFactionDist, const Sector::System *sys) const;
+	bool IsCloserAndContains(double &closestFactionDist, const Sector::System *sys) const;
 };
 
 /* One day it might grow up to become a full tree, on the  other hand it might be
@@ -107,7 +107,7 @@ public:
 	const Faction *GetNearestClaimant(const Sector::System *sys) const;
 	bool IsHomeSystem(const SystemPath &sysPath) const;
 
-	const Uint32 GetNumFactions() const;
+	Uint32 GetNumFactions() const;
 
 	bool MayAssignFactions() const;
 
@@ -119,7 +119,7 @@ private:
 
 	private:
 		std::vector<const Faction *> octbox[2][2][2];
-		static const int BoxIndex(Sint32 sectorIndex) { return sectorIndex < 0 ? 0 : 1; };
+		static int BoxIndex(Sint32 sectorIndex) { return sectorIndex < 0 ? 0 : 1; };
 		void PruneDuplicates(const int bx, const int by, const int bz);
 	};
 

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1611,7 +1611,7 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody *sbody, StarSys
 		sp->m_averageTemp = sbody->GetAverageTemp();
 		sp->m_mass = 0;
 		sp->m_name = gen_unique_station_name(sp, system, namerand);
-		memset(&sp->m_orbit, 0, sizeof(Orbit));
+		sp->m_orbit = Orbit();
 		PositionSettlementOnPlanet(sp, previousOrbits);
 		sbody->m_children.insert(sbody->m_children.begin(), sp);
 		system->AddSpaceStation(sp);
@@ -1626,7 +1626,7 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody *sbody, StarSys
 		sp->m_averageTemp = sbody->m_averageTemp;
 		sp->m_mass = 0;
 		sp->m_name = gen_unique_station_name(sp, system, namerand);
-		memset(&sp->m_orbit, 0, sizeof(Orbit));
+		sp->m_orbit = Orbit();
 		PositionSettlementOnPlanet(sp, previousOrbits);
 		sbody->m_children.insert(sbody->m_children.begin(), sp);
 		system->AddSpaceStation(sp);

--- a/src/galaxy/SystemPath.h
+++ b/src/galaxy/SystemPath.h
@@ -44,12 +44,6 @@ public:
 		systemIndex(si),
 		bodyIndex(bi) {}
 
-	SystemPath(const SystemPath &path) :
-		sectorX(path.sectorX),
-		sectorY(path.sectorY),
-		sectorZ(path.sectorZ),
-		systemIndex(path.systemIndex),
-		bodyIndex(path.bodyIndex) {}
 	SystemPath(const SystemPath *path) :
 		sectorX(path->sectorX),
 		sectorY(path->sectorY),

--- a/src/graphics/Stats.cpp
+++ b/src/graphics/Stats.cpp
@@ -54,7 +54,7 @@ namespace Graphics {
 			frame.m_stats[idx] = statsFrame.at(name);
 		}
 
-		m_currentFrame = ++m_currentFrame % MAX_FRAMES_STORE;
+		m_currentFrame = (m_currentFrame + 1) % MAX_FRAMES_STORE;
 		memset(&m_frameStats[m_currentFrame], 0, sizeof(TFrameData));
 	}
 

--- a/src/graphics/Texture.h
+++ b/src/graphics/Texture.h
@@ -90,29 +90,15 @@ namespace Graphics {
 
 		vector2f GetOriginalSize() const { return vector2f(dataSize.x * texSize.x, dataSize.y * texSize.y); }
 
-		const TextureFormat format;
-		const vector3f dataSize;
-		const vector2f texSize;
-		const TextureSampleMode sampleMode;
-		const bool generateMipmaps;
-		const bool allowCompression;
-		const bool useAnisotropicFiltering;
-		const unsigned int numberOfMipMaps;
-		const TextureType type;
-
-		TextureDescriptor &operator=(const TextureDescriptor &o)
-		{
-			const_cast<TextureFormat &>(format) = o.format;
-			const_cast<vector3f &>(dataSize) = o.dataSize;
-			const_cast<vector2f &>(texSize) = o.texSize;
-			const_cast<TextureSampleMode &>(sampleMode) = o.sampleMode;
-			const_cast<bool &>(generateMipmaps) = o.generateMipmaps;
-			const_cast<bool &>(allowCompression) = o.allowCompression;
-			const_cast<bool &>(useAnisotropicFiltering) = o.useAnisotropicFiltering;
-			const_cast<unsigned int &>(numberOfMipMaps) = o.numberOfMipMaps;
-			const_cast<TextureType &>(type) = o.type;
-			return *this;
-		}
+		TextureFormat format;
+		vector3f dataSize;
+		vector2f texSize;
+		TextureSampleMode sampleMode;
+		bool generateMipmaps;
+		bool allowCompression;
+		bool useAnisotropicFiltering;
+		unsigned int numberOfMipMaps;
+		TextureType type;
 	};
 
 	class Texture : public RefCounted {

--- a/src/graphics/Texture.h
+++ b/src/graphics/Texture.h
@@ -50,6 +50,7 @@ namespace Graphics {
 		void *negZ;
 	};
 
+	// WARNING: internal values shall not be changed
 	class TextureDescriptor {
 	public:
 		TextureDescriptor() :
@@ -90,6 +91,7 @@ namespace Graphics {
 
 		vector2f GetOriginalSize() const { return vector2f(dataSize.x * texSize.x, dataSize.y * texSize.y); }
 
+		// WARNING: these values shall not be changed
 		TextureFormat format;
 		vector3f dataSize;
 		vector2f texSize;

--- a/src/graphics/Texture.h
+++ b/src/graphics/Texture.h
@@ -50,7 +50,7 @@ namespace Graphics {
 		void *negZ;
 	};
 
-	// WARNING: internal values shall not be changed
+	// WARNING: TextureDescriptor is intended to be immutable. Internal values should not be changed!
 	class TextureDescriptor {
 	public:
 		TextureDescriptor() :

--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -23,8 +23,8 @@ namespace Graphics {
 		m_compressTextures(compressTextures),
 		m_anisotropicFiltering(anisoFiltering),
 		m_textureType(TEXTURE_2D),
-		m_prepared(false),
-		m_layers(1)
+		m_layers(1),
+		m_prepared(false)
 	{
 	}
 
@@ -36,8 +36,8 @@ namespace Graphics {
 		m_compressTextures(compressTextures),
 		m_anisotropicFiltering(anisoFiltering),
 		m_textureType(textureType),
-		m_prepared(false),
-		m_layers(layers)
+		m_layers(layers),
+		m_prepared(false)
 	{
 		m_filenames.push_back(filename);
 	}
@@ -51,8 +51,8 @@ namespace Graphics {
 		m_compressTextures(compressTextures),
 		m_anisotropicFiltering(anisoFiltering),
 		m_textureType(textureType),
-		m_prepared(false),
-		m_layers(layers)
+		m_layers(layers),
+		m_prepared(false)
 	{
 		assert(!m_filenames.empty());
 	}
@@ -235,6 +235,9 @@ namespace Graphics {
 					numberOfImages += dds.imgdata_.numImages;
 				}
 				assert((numberOfImages-1) == m_layers);
+			} else {
+				Output("ERROR: unexpected texture type");
+				abort();
 			}
 		}
 
@@ -298,7 +301,7 @@ namespace Graphics {
 			const size_t layers = m_layers;
 			m_ddsarray.resize(layers);
 
-			for (int i = 0; i < layers; i++)
+			for (std::size_t i = 0; i < layers; i++)
 			{
 				PiVerify(LoadDDSFromFile(m_filenames[i], m_ddsarray[i]));
 			}

--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -301,7 +301,7 @@ namespace Graphics {
 			const size_t layers = m_layers;
 			m_ddsarray.resize(layers);
 
-			for (std::size_t i = 0; i < layers; i++)
+			for (size_t i = 0; i < layers; i++)
 			{
 				PiVerify(LoadDDSFromFile(m_filenames[i], m_ddsarray[i]));
 			}

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -42,7 +42,7 @@ namespace Graphics {
 		class BillboardMaterial;
 	} // namespace OGL
 
-	class RendererOGL : public Renderer {
+	class RendererOGL final : public Renderer {
 	public:
 		static void RegisterRenderer();
 

--- a/src/graphics/opengl/TextureGL.cpp
+++ b/src/graphics/opengl/TextureGL.cpp
@@ -84,8 +84,8 @@ namespace Graphics {
 
 		TextureGL::TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering) :
 			Texture(descriptor),
-			m_useAnisoFiltering(useAnisoFiltering && descriptor.useAnisotropicFiltering),
-			m_allocSize(0)
+			m_allocSize(0),
+			m_useAnisoFiltering(useAnisoFiltering && descriptor.useAnisotropicFiltering)
 		{
 			PROFILE_SCOPED()
 			m_target = GLTextureType(descriptor.type);

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -477,7 +477,7 @@ namespace Graphics {
 
 			if (GetUsage() != BUFFER_USAGE_STATIC) {
 				m_data.reset(new matrix4x4f[size]);
-				memset(m_data.get(), 0, sizeof(matrix4x4f) * size);
+				std::fill_n(m_data.get(), size, matrix4x4f(0.f));
 			}
 		}
 

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -63,7 +63,7 @@ namespace Graphics {
 		};
 
 		// Instance buffer
-		class InstanceBuffer : public Graphics::InstanceBuffer, public GLBufferBase {
+		class InstanceBuffer final : public Graphics::InstanceBuffer, public GLBufferBase {
 		public:
 			InstanceBuffer(Uint32 size, BufferUsage);
 			virtual ~InstanceBuffer() override final;

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -939,7 +939,7 @@ static int l_engine_sector_map_get_route(lua_State *l)
 
 	lua_newtable(l);
 	int i = 1;
-	for (const SystemPath j : route) {
+	for (const SystemPath& j : route) {
 		lua_pushnumber(l, i++);
 		LuaObject<SystemPath>::PushToLua(j);
 		lua_settable(l, -3);

--- a/src/lua/LuaGame.cpp
+++ b/src/lua/LuaGame.cpp
@@ -129,10 +129,10 @@ static int l_game_savegame_stats(lua_State *l)
 		const std::string message = stringf(Lang::COULD_NOT_OPEN_FILENAME, formatarg("path", filename));
 		lua_pushlstring(l, message.c_str(), message.size());
 		return lua_error(l);
-	} catch (Json::type_error) {
+	} catch (const Json::type_error&) {
 		luaL_error(l, Lang::GAME_LOAD_CORRUPT);
 		return 0;
-	} catch (Json::out_of_range) {
+	} catch (const Json::out_of_range&) {
 		return luaL_error(l, Lang::GAME_LOAD_CORRUPT);
 	} catch (SavedGameCorruptException) {
 		luaL_error(l, Lang::GAME_LOAD_CORRUPT);

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -527,13 +527,8 @@ static int l_pigui_plot_histogram(lua_State *l)
 	std::unique_ptr<float[]> values(new float[vals.Size()]);
 	float max = FLT_MIN;
 	float min = FLT_MAX;
-	const std::size_t valsSize = vals.Size();
-	if (valsSize >= std::numeric_limits<int>::max()) {
-		Error("vals.Size() >= MAX_INT");
-		abort();
-	}
-	for (int i = 1; i <= static_cast<int>(valsSize); i++) {
-		values[i - 1] = vals.Get<int>(i);
+	for (size_t i = 1; i <= vals.Size(); i++) {
+		values[i - 1] = vals.Get<size_t>(i);
 		if (values[i - 1] > max)
 			max = values[i - 1];
 		if (values[i - 1] < min)

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -527,7 +527,12 @@ static int l_pigui_plot_histogram(lua_State *l)
 	std::unique_ptr<float[]> values(new float[vals.Size()]);
 	float max = FLT_MIN;
 	float min = FLT_MAX;
-	for (int i = 1; i <= vals.Size(); i++) {
+	const std::size_t valsSize = vals.Size();
+	if (valsSize >= std::numeric_limits<int>::max()) {
+		Error("vals.Size() >= MAX_INT");
+		abort();
+	}
+	for (int i = 1; i <= static_cast<int>(valsSize); i++) {
 		values[i - 1] = vals.Get<int>(i);
 		if (values[i - 1] > max)
 			max = values[i - 1];

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -527,8 +527,8 @@ static int l_pigui_plot_histogram(lua_State *l)
 	std::unique_ptr<float[]> values(new float[vals.Size()]);
 	float max = FLT_MIN;
 	float min = FLT_MAX;
-	for (size_t i = 1; i <= vals.Size(); i++) {
-		values[i - 1] = vals.Get<size_t>(i);
+	for (uint32_t i = 1; i <= vals.Size(); i++) {
+		values[i - 1] = vals.Get<uint32_t>(i);
 		if (values[i - 1] > max)
 			max = values[i - 1];
 		if (values[i - 1] < min)

--- a/src/lua/LuaPushPull.h
+++ b/src/lua/LuaPushPull.h
@@ -13,6 +13,7 @@
 inline void pi_lua_generic_push(lua_State *l, bool value) { lua_pushboolean(l, value); }
 inline void pi_lua_generic_push(lua_State *l, int value) { lua_pushinteger(l, value); }
 inline void pi_lua_generic_push(lua_State *l, unsigned int value) { lua_pushinteger(l, value); }
+inline void pi_lua_generic_push(lua_State *l, size_t value) { lua_pushunsigned(l, value); }
 inline void pi_lua_generic_push(lua_State *l, double value) { lua_pushnumber(l, value); }
 inline void pi_lua_generic_push(lua_State *l, const char *value) { lua_pushstring(l, value); }
 inline void pi_lua_generic_push(lua_State *l, const std::string &value)
@@ -23,6 +24,7 @@ inline void pi_lua_generic_push(lua_State *l, const std::string &value)
 inline void pi_lua_generic_pull(lua_State *l, int index, bool &out) { out = lua_toboolean(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, int &out) { out = luaL_checkinteger(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, unsigned int &out) { out = luaL_checkunsigned(l, index); }
+inline void pi_lua_generic_pull(lua_State *l, int index, size_t &out) { out = luaL_checkunsigned(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, float &out) { out = luaL_checknumber(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, double &out) { out = luaL_checknumber(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, const char *&out) { out = luaL_checkstring(l, index); }

--- a/src/lua/LuaPushPull.h
+++ b/src/lua/LuaPushPull.h
@@ -13,7 +13,6 @@
 inline void pi_lua_generic_push(lua_State *l, bool value) { lua_pushboolean(l, value); }
 inline void pi_lua_generic_push(lua_State *l, int value) { lua_pushinteger(l, value); }
 inline void pi_lua_generic_push(lua_State *l, unsigned int value) { lua_pushinteger(l, value); }
-inline void pi_lua_generic_push(lua_State *l, size_t value) { lua_pushunsigned(l, value); }
 inline void pi_lua_generic_push(lua_State *l, double value) { lua_pushnumber(l, value); }
 inline void pi_lua_generic_push(lua_State *l, const char *value) { lua_pushstring(l, value); }
 inline void pi_lua_generic_push(lua_State *l, const std::string &value)
@@ -24,7 +23,6 @@ inline void pi_lua_generic_push(lua_State *l, const std::string &value)
 inline void pi_lua_generic_pull(lua_State *l, int index, bool &out) { out = lua_toboolean(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, int &out) { out = luaL_checkinteger(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, unsigned int &out) { out = luaL_checkunsigned(l, index); }
-inline void pi_lua_generic_pull(lua_State *l, int index, size_t &out) { out = luaL_checkunsigned(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, float &out) { out = luaL_checknumber(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, double &out) { out = luaL_checknumber(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, const char *&out) { out = luaL_checkstring(l, index); }

--- a/src/lua/LuaSystemView.cpp
+++ b/src/lua/LuaSystemView.cpp
@@ -55,7 +55,7 @@ bool too_near(const vector3d &a, const vector3d &b, const vector2d &gain)
 		// the z coordinates in the camera space. I plan to implement this later
 		// at the moment I just picked up a number that works well (6.0)
 		&& std::abs(a.z - b.z) * Graphics::GetScreenWidth() * 6.0 < gain.x;
-};
+}
 
 /*
  * Method: GetProjectedGrouped

--- a/src/pigui/LuaModelSpinner.cpp
+++ b/src/pigui/LuaModelSpinner.cpp
@@ -59,7 +59,7 @@ namespace PiGUI {
 
 			return 0;
 		}
-	}; // namespace LuaPiguiModelSpinner
+	} // namespace LuaPiguiModelSpinner
 } // namespace PiGUI
 
 using namespace PiGUI::LuaPiguiModelSpinner;

--- a/src/pigui/ModelSpinner.cpp
+++ b/src/pigui/ModelSpinner.cpp
@@ -12,8 +12,8 @@
 using namespace PiGUI;
 
 ModelSpinner::ModelSpinner() :
-	m_rot(vector2f(DEG2RAD(-15.0), DEG2RAD(180.0))),
-	m_pauseTime(.0f)
+	m_pauseTime(.0f),
+	m_rot(vector2f(DEG2RAD(-15.0), DEG2RAD(180.0)))
 {
 	Color lc(Color::WHITE);
 	m_light.SetDiffuse(lc);

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -280,7 +280,7 @@ void PerfInfo::DrawTextureCache()
 					const int num_columns = std::max(int(ImGui::GetWindowContentRegionWidth()) / item_width, 1);
 					ImGui::Columns(num_columns);
 					if (num_columns > 1) {
-						for (size_t idx = 0; idx < num_columns; idx++)
+						for (int idx = 0; idx < num_columns; idx++)
 							ImGui::SetColumnWidth(idx, item_width);
 					}
 

--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -144,7 +144,7 @@ Instance::Instance() :
 
 	// ensure the tooltip font exists
 	GetFont("pionillium", 14);
-};
+}
 
 ImFont *Instance::GetFont(const std::string &name, int size)
 {
@@ -436,7 +436,7 @@ void Instance::Uninit()
 // PiGui::PiFace
 //
 
-const bool PiFace::isValidGlyph(unsigned short glyph) const
+bool PiFace::isValidGlyph(unsigned short glyph) const
 {
 	PROFILE_SCOPED()
 	return (m_invalid_glyphs.count(glyph) == 0);

--- a/src/pigui/PiGui.h
+++ b/src/pigui/PiGui.h
@@ -27,12 +27,12 @@ namespace PiGui {
 
 		const std::string &ttfname() const { return m_ttfname; }
 
-		const float sizefactor() const { return m_sizefactor; }
+		float sizefactor() const { return m_sizefactor; }
 
 		//std::unordered_map<unsigned short, unsigned short> &invalid_glyphs() const { return m_invalid_glyphs; }
 		const std::vector<UsedRange> &used_ranges() const { return m_used_ranges; }
 
-		const bool isValidGlyph(unsigned short glyph) const;
+		bool isValidGlyph(unsigned short glyph) const;
 		void addGlyph(unsigned short glyph);
 		void sortUsedRanges() const;
 
@@ -55,9 +55,6 @@ namespace PiGui {
 		PiFont(const std::string &name, const std::vector<PiFace> &faces) :
 			m_name(name),
 			m_faces(faces) {}
-		PiFont(const PiFont &other) :
-			m_name(other.name()),
-			m_faces(other.faces()) {}
 		PiFont() :
 			m_name("unknown") {}
 

--- a/src/pigui/PiGuiSandbox.cpp
+++ b/src/pigui/PiGuiSandbox.cpp
@@ -61,12 +61,12 @@ static int CleanupStyleStack(SavedImguiStackInfo *stackInfo)
 	// to an bigger signed type. In this case, `uint32_t` -> `int64_t`.
 	auto &colorStack = ImGui::GetCurrentContext()->ColorModifiers;
 	int numResetStyles = colorStack.size() - stackInfo->styleColorStack;
-	if (colorStack.size() > (int64_t)stackInfo->styleColorStack)
+	if (colorStack.size() > int64_t(stackInfo->styleColorStack))
 		ImGui::PopStyleColor(colorStack.size() - stackInfo->styleColorStack);
 
 	auto &varStack = ImGui::GetCurrentContext()->StyleModifiers;
 	numResetStyles += varStack.size() - stackInfo->styleVarStack;
-	if (varStack.size() > (int64_t)stackInfo->styleVarStack)
+	if (varStack.size() > int64_t(stackInfo->styleVarStack))
 		ImGui::PopStyleVar(varStack.size() - stackInfo->styleVarStack);
 
 	return numResetStyles;

--- a/src/pigui/PiGuiSandbox.cpp
+++ b/src/pigui/PiGuiSandbox.cpp
@@ -57,12 +57,12 @@ static int CleanupStyleStack(SavedImguiStackInfo *stackInfo)
 {
 	auto &colorStack = ImGui::GetCurrentContext()->ColorModifiers;
 	int numResetStyles = colorStack.size() - stackInfo->styleColorStack;
-	if (colorStack.size() > stackInfo->styleColorStack)
+	if (colorStack.size() > static_cast<int64_t>(stackInfo->styleColorStack))
 		ImGui::PopStyleColor(colorStack.size() - stackInfo->styleColorStack);
 
 	auto &varStack = ImGui::GetCurrentContext()->StyleModifiers;
 	numResetStyles += varStack.size() - stackInfo->styleVarStack;
-	if (varStack.size() > stackInfo->styleVarStack)
+	if (varStack.size() > static_cast<int64_t>(stackInfo->styleVarStack))
 		ImGui::PopStyleVar(varStack.size() - stackInfo->styleVarStack);
 
 	return numResetStyles;

--- a/src/pigui/PiGuiSandbox.cpp
+++ b/src/pigui/PiGuiSandbox.cpp
@@ -55,14 +55,18 @@ static int CleanupWindowStack(SavedImguiStackInfo *stackInfo)
 
 static int CleanupStyleStack(SavedImguiStackInfo *stackInfo)
 {
+	// `ImVector::size()` returns an `int`, and `stackInfo->style*Stack`
+	// properties are `uint32_t`. Therefore, in order to correctly perform
+	// comparison without triggering UB, the unsigned type must be casted
+	// to an bigger signed type. In this case, `uint32_t` -> `int64_t`.
 	auto &colorStack = ImGui::GetCurrentContext()->ColorModifiers;
 	int numResetStyles = colorStack.size() - stackInfo->styleColorStack;
-	if (colorStack.size() > static_cast<int64_t>(stackInfo->styleColorStack))
+	if (colorStack.size() > (int64_t)stackInfo->styleColorStack)
 		ImGui::PopStyleColor(colorStack.size() - stackInfo->styleColorStack);
 
 	auto &varStack = ImGui::GetCurrentContext()->StyleModifiers;
 	numResetStyles += varStack.size() - stackInfo->styleVarStack;
-	if (varStack.size() > static_cast<int64_t>(stackInfo->styleVarStack))
+	if (varStack.size() > (int64_t)stackInfo->styleVarStack)
 		ImGui::PopStyleVar(varStack.size() - stackInfo->styleVarStack);
 
 	return numResetStyles;

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -45,6 +45,7 @@ namespace SceneGraph {
 	}
 
 	Model::Model(const Model &model) :
+		DeleteEmitter(),
 		m_boundingRadius(model.m_boundingRadius),
 		m_materials(model.m_materials),
 		m_patterns(model.m_patterns),
@@ -348,13 +349,13 @@ namespace SceneGraph {
 		return m_materials.at(Clamp(i, 0, int(m_materials.size()) - 1)).second;
 	}
 
-	MatrixTransform *const Model::GetTagByIndex(const unsigned int i) const
+	MatrixTransform *Model::GetTagByIndex(const unsigned int i) const
 	{
 		if (m_tags.empty() || i > m_tags.size() - 1) return 0;
 		return m_tags.at(i);
 	}
 
-	MatrixTransform *const Model::FindTagByName(const std::string &name) const
+	MatrixTransform *Model::FindTagByName(const std::string &name) const
 	{
 		for (TagContainer::const_iterator it = m_tags.begin();
 			 it != m_tags.end();

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -122,8 +122,8 @@ namespace SceneGraph {
 		unsigned int GetNumMaterials() const { return static_cast<Uint32>(m_materials.size()); }
 
 		unsigned int GetNumTags() const { return static_cast<Uint32>(m_tags.size()); }
-		MatrixTransform *const GetTagByIndex(unsigned int index) const;
-		MatrixTransform *const FindTagByName(const std::string &name) const;
+		MatrixTransform *GetTagByIndex(unsigned int index) const;
+		MatrixTransform *FindTagByName(const std::string &name) const;
 		typedef std::vector<MatrixTransform *> TVecMT;
 		void FindTagsByStartOfName(const std::string &name, TVecMT &outNameMTs) const;
 		void AddTag(const std::string &name, MatrixTransform *node);

--- a/src/scenegraph/Serializer.h
+++ b/src/scenegraph/Serializer.h
@@ -151,7 +151,7 @@ namespace Serializer {
 
 			out = *reinterpret_cast<const T *>(m_at);
 			m_at += sizeof(T);
-		};
+		}
 
 		void readObject(std::string &out)
 		{

--- a/src/ship/Propulsion.cpp
+++ b/src/ship/Propulsion.cpp
@@ -19,7 +19,7 @@ void Propulsion::SaveToJson(Json &jsonObj, Space *space)
 	// !!! These are commented to avoid savegame bumps:
 	//jsonObj["tank_mass"] = m_fuelTankMass;
 	//jsonObj["propulsion"] = PropulsionObj;
-};
+}
 
 void Propulsion::LoadFromJson(const Json &jsonObj, Space *space)
 {
@@ -35,7 +35,7 @@ void Propulsion::LoadFromJson(const Json &jsonObj, Space *space)
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
-};
+}
 
 Propulsion::Propulsion()
 {

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -634,7 +634,7 @@ namespace Sound {
 	void UpdateAudioDevices()
 	{
 		audioDeviceNames.clear();
-		for (size_t idx = 0; idx < SDL_GetNumAudioDevices(0); idx++) {
+		for (int idx = 0; idx < SDL_GetNumAudioDevices(0); idx++) {
 			const char *name = SDL_GetAudioDeviceName(idx, 0);
 			audioDeviceNames.emplace_back(name);
 		}

--- a/src/text/FontConfig.h
+++ b/src/text/FontConfig.h
@@ -9,7 +9,7 @@
 
 namespace Text {
 
-	// WARNING: internal values shall not be changed
+	// WARNING: FontConfig is intended to be immutable; internal values shall not be changed
 	class FontConfig {
 	public:
 		// XXX scale is to support to the old UI, and will be removed

--- a/src/text/FontConfig.h
+++ b/src/text/FontConfig.h
@@ -9,6 +9,7 @@
 
 namespace Text {
 
+	// WARNING: internal values shall not be changed
 	class FontConfig {
 	public:
 		// XXX scale is to support to the old UI, and will be removed
@@ -22,6 +23,8 @@ namespace Text {
 				advanceXAdjustment(advanceXAdjustment_),
 				rangeMin(rangeMin_),
 				rangeMax(rangeMax_) {}
+
+			// WARNING: these values shall not be changed
 			std::string fontFile;
 			int pixelWidth;
 			int pixelHeight;

--- a/src/text/FontConfig.h
+++ b/src/text/FontConfig.h
@@ -22,23 +22,12 @@ namespace Text {
 				advanceXAdjustment(advanceXAdjustment_),
 				rangeMin(rangeMin_),
 				rangeMax(rangeMax_) {}
-			const std::string fontFile;
-			const int pixelWidth;
-			const int pixelHeight;
-			const float advanceXAdjustment;
-			const Uint32 rangeMin;
-			const Uint32 rangeMax;
-
-			Face &operator=(const Face &o)
-			{
-				const_cast<std::string &>(fontFile) = o.fontFile;
-				const_cast<int &>(pixelWidth) = o.pixelWidth;
-				const_cast<int &>(pixelHeight) = o.pixelHeight;
-				const_cast<float &>(advanceXAdjustment) = o.advanceXAdjustment;
-				const_cast<Uint32 &>(rangeMin) = o.rangeMin;
-				const_cast<Uint32 &>(rangeMax) = o.rangeMax;
-				return *this;
-			}
+			std::string fontFile;
+			int pixelWidth;
+			int pixelHeight;
+			float advanceXAdjustment;
+			Uint32 rangeMin;
+			Uint32 rangeMax;
 
 			bool operator<(const Face &o) const
 			{

--- a/src/text/TextureFont.cpp
+++ b/src/text/TextureFont.cpp
@@ -30,7 +30,7 @@
 namespace {
 	static const int ATLAS_SIZE = 1024;
 	static double CACHE_EVICTION_TIME = 0.25;
-}; // namespace
+} // namespace
 
 namespace Text {
 

--- a/src/ui/Point.h
+++ b/src/ui/Point.h
@@ -21,9 +21,6 @@ namespace UI {
 		explicit Point(int v) :
 			x(v),
 			y(v) {}
-		Point(const Point &p) :
-			x(p.x),
-			y(p.y) {}
 
 		Point operator+(const Point &v) const { return Point(x + v.x, y + v.y); }
 		Point operator-(const Point &v) const { return Point(x - v.x, y - v.y); }

--- a/src/vector2.h
+++ b/src/vector2.h
@@ -40,9 +40,6 @@ public:
 	explicit vector2(T v) :
 		x(v),
 		y(v) {}
-	vector2(const vector2 &v) :
-		x(v.x),
-		y(v.y) {}
 	explicit vector2(const T v[2]) :
 		x(v[0]),
 		y(v[1]) {}
@@ -117,14 +114,6 @@ template <>
 inline vector2<float>::vector2() {}
 template <>
 inline vector2<double>::vector2() {}
-template <>
-inline vector2<float>::vector2(const vector2<float> &v) :
-	x(v.x),
-	y(v.y) {}
-template <>
-inline vector2<double>::vector2(const vector2<double> &v) :
-	x(v.x),
-	y(v.y) {}
 template <>
 inline vector2<float>::vector2(const vector2<double> &v) :
 	x(float(v.x)),

--- a/src/vector3.h
+++ b/src/vector3.h
@@ -19,8 +19,7 @@ public:
 
 	// Constructor definitions are outside class declaration to enforce that
 	// only float and double versions are possible.
-	vector3();
-	vector3(const vector3<T> &v);
+	vector3() = default;
 	vector3(const vector2f &v, T t);
 	explicit vector3(const T vals[3]);
 	explicit vector3(T val);
@@ -209,18 +208,6 @@ public:
 
 // These are here in this manner to enforce that only float and double versions are possible.
 template <>
-inline vector3<float>::vector3()
-{}
-template <>
-inline vector3<double>::vector3()
-{}
-template <>
-inline vector3<float>::vector3(const vector3<float> &v) :
-	x(v.x),
-	y(v.y),
-	z(v.z)
-{}
-template <>
 inline vector3<float>::vector3(const vector2f &v, float t) :
 	x(v.x),
 	y(v.y),
@@ -234,12 +221,6 @@ inline vector3<float>::vector3(const vector3<double> &v) :
 {}
 template <>
 inline vector3<double>::vector3(const vector3<float> &v) :
-	x(v.x),
-	y(v.y),
-	z(v.z)
-{}
-template <>
-inline vector3<double>::vector3(const vector3<double> &v) :
 	x(v.x),
 	y(v.y),
 	z(v.z)

--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -63,7 +63,7 @@ namespace OS {
 			{ 5, 0, "Windows 2000" },
 			{ 0, 0, nullptr }
 		};
-	}; // namespace
+	} // namespace
 
 	// Notify Windows that the window may become unresponsive
 	void NotifyLoadBegin()


### PR DESCRIPTION
Removing many clang and gcc warnings, trying to catch potential pitfalls.

What have been briefly changed:
* Remove `const`ness from class members. A `const_cast` was used in order to write to `const` members, which is undefined behavior.
* Avoid signed/unsigned comparisons
* Delete many "manual" copy-constructors: these are automatically generated, but at the same time defining them without an explicit copy-assignment is considered a bad practice
* Remove `std::move` from some returns -- it only makes RVO and NRVO impossible
* Avoid `memset` on non-trivial types
* Add `final` specifier to class with `final` destructors
* Remove useless `const` from return types
* Reorder class members initialization
* Superfluous semicolons (boring!)

Just a quick note about the first point: I totally understand that the intent is to have public members that cannot be modified, but at that point the copy-assignment should be deleted (actually, const members make the class unable to `move`, and this is even worse... but it's another issue).
The best thing is to make the members protected (or private) and to create const accessors, and obviously refactor where the class is used. It is boring and boilerplate, but unfortunately there is not a pretty solution for this IMHO.