### PR TITLE
Decouple planner buttons

### DIFF
--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -72,18 +72,18 @@ local function showDvLine(leftIcon, resetIcon, rightIcon, key, Formatter, leftTo
 			end
 		end
 	end
-	local press = ui.coloredSelectedIconButton(leftIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_BACK, svColor.BUTTON_INK, leftTooltip)
+	local press = ui.coloredSelectedIconButton(leftIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_BACK, svColor.BUTTON_INK, leftTooltip, nil, key)
 	if press or (key ~= "factor" and ui.isItemActive()) then
 		systemView:TransferPlannerAdd(key, -10)
 	end
 	wheel()
 	ui.sameLine()
-	if ui.coloredSelectedIconButton(resetIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_BACK, svColor.BUTTON_INK, resetTooltip) then
+	if ui.coloredSelectedIconButton(resetIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_BACK, svColor.BUTTON_INK, resetTooltip, nil, key) then
 		systemView:TransferPlannerReset(key)
 	end
 	wheel()
 	ui.sameLine()
-	press = ui.coloredSelectedIconButton(rightIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_BACK, svColor.BUTTON_INK, rightTooltip)
+	press = ui.coloredSelectedIconButton(rightIcon, mainButtonSize, false, mainButtonFramePadding, svColor.BUTTON_BACK, svColor.BUTTON_INK, rightTooltip, nil, key)
 	if press or (key ~= "factor" and ui.isItemActive()) then
 		systemView:TransferPlannerAdd(key, 10)
 	end

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -813,7 +813,7 @@ ui.coloredSelectedButton = function(label, thesize, is_selected, bg_color, toolt
 	end
 	return res
 end
-ui.coloredSelectedIconButton = function(icon, thesize, is_selected, frame_padding, bg_color, fg_color, tooltip, img_size)
+ui.coloredSelectedIconButton = function(icon, thesize, is_selected, frame_padding, bg_color, fg_color, tooltip, img_size, extraID)
 	if is_selected then
 		pigui.PushStyleColor("Button", bg_color)
 		pigui.PushStyleColor("ButtonHovered", bg_color:tint(0.1))
@@ -824,7 +824,7 @@ ui.coloredSelectedIconButton = function(icon, thesize, is_selected, frame_paddin
 		pigui.PushStyleColor("ButtonActive", bg_color:shade(0.2))
 	end
 	local uv0,uv1 = get_icon_tex_coords(icon)
-	pigui.PushID(tooltip)
+	pigui.PushID(tooltip .. (extraID or ""))
 	local res = pigui.ButtonImageSized(ui.icons_texture, thesize, img_size or Vector2(0,0), uv0, uv1, frame_padding, ui.theme.colors.lightBlueBackground, fg_color)
 	pigui.PopID()
 	pigui.PopStyleColor(3)


### PR DESCRIPTION
## Current behavior

Orbit planner buttons changes the value all together when using left and right arrow buttons. This is obviously unintended.

## Desired behavior

* _Thrust_ controls must be independent one each other, and should continuously increase/decrease the value until mouse button is released
* _Time factor_ control must be independent from other controls, but a _step-on-click_ behavior is expected -- i.e. the factor is increased/decreased once per click

## Reason of the issue

~~`PiGui::ButtonImageSized` uses the texture id as the button id. However, left and right arrow buttons share the same texture, leading to this issue. This maybe could be happening with other buttons as well.~~
@Gliese852 clearly showed that the issue was related to the ID of the tooltip, nothing related to `PiGui::ButtonImageSized`.

I am not sure this issue have been already reported, I am not able to find it. If someone can give me some feedback, it can be opened or we can just solve the whole thing in this PR.

~~## Status of the PR~~

~~The think that the best way to handle this situation is have an optional string that can be passed to the function in order to generate a different ID for the ImGui Item. I followed the typical hashing approach to combine hash together in order to _mix_ the texture id with passed string.~~

~~In order to pass an _optional_ string to the function I needed to use an alternative version of `LuaPull`, and instead of doing that just for `const char*`, I decided to implement a _poor man's_ `optional` type and create a generic `LuaPullOpt` function. Side note: I did not create the function for boolean types because, by default, `lua_toboolean` returns `false` in case the value was `nil`. Maybe it should be implemented anyway, in order to distinguish `nil` from `false`, let me know what you think.~~

~~In any case, I am still struggling with the buttons, probably because of my inexperience with `ImGui`. I am not able to _increment/decrement while keeping the mouse pressed_. I changed a bit the return value of `PiGui::ButtonImageSized` in order to return `pressed`, `hovered` and `held` _properties_, but I am still struggling to obtain the desired behavior. Moreover, using only `pressed` value, the factor buttons don't work at all (why???). Maybe it is just something silly that I am missing, so I decided to create this PR in draft mode and, hopefully, get some feedback and help.~~

~~Oh, don't worry: if it is possible to make things work without using `hovered` and `held` properties, I will be very happy to restore the return value of `PiGui::ButtonImageSized` and the related functions -- I was just trying to find something that could work~~ :disappointed:

**EDIT**: the issue is solvable in a much simpler way than I thought, thank you @Gliese852.