### PR TITLE
New custom system

### DIFF
--- a/data/systems/custom/19_starsend.lua
+++ b/data/systems/custom/19_starsend.lua
@@ -1,0 +1,71 @@
+-- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local s = CustomSystem:new('Star\'s End', { 'STAR_K' })
+	:govtype('CORPORATE')
+	:lawlessness(f(1,100)) -- 1/100th from a peaceful eden
+	:short_desc('Human enclave at the opposite end of the galaxy.')
+	:long_desc([[A special team of ambitious colonists sent out during the fall of Haber Corporation in secrecy has picked this small system as their new home.
+	With intentions to expand the civilization to the remotest reach of Milky Way, they are safekeeping perhaps one of the most detailed records of
+	human history and culture.
+
+	The colonists are currently working on increasing the total population and terraforming the two planets in the system before permanently heading off to colonize
+	neighboring star systems.]])
+
+local starsend = CustomSystemBody:new('Star\'s End', 'STAR_K')
+	:radius(f(7,10))
+	:mass(f(61,110))
+	:temp(4400)
+
+local kobol = CustomSystemBody:new('Kobol', 'PLANET_TERRESTRIAL')
+	:radius(f(92,100))
+	:mass(f(9,10))
+	:temp(260)
+	:semi_major_axis(f(82,100))
+	:eccentricity(f(183,10000))
+	:rotation_period(f(86,100))
+	:axial_tilt(fixed.deg2rad(f(3145,100)))
+	:rotational_phase_at_start(fixed.deg2rad(f(170,1)))
+	:metallicity(f(4,5))
+	:volcanicity(f(3,10))
+	:atmos_density(f(9,10))
+	:atmos_oxidizing(f(72,100))
+	:ocean_cover(f(0,10))
+	:ice_cover(f(1,10))
+	:life(f(2,10))
+	:orbital_phase_at_start(fixed.deg2rad(f(336,1)))
+	:rings(false)
+
+local kobol_starports = {
+	CustomSystemBody:new('Exodus', 'STARPORT_SURFACE')
+		:latitude(math.deg2rad(55))
+		:longitude(math.deg2rad(-37.5)),
+}
+
+local dagobah = CustomSystemBody:new('Dagobah', 'PLANET_TERRESTRIAL')
+	:seed(-1317315059)
+	:radius(f(412,1000))
+	:mass(f(189,1000))
+	:temp(213)
+	:semi_major_axis(f(160,100))
+	:eccentricity(f(1079,10000))
+	:inclination(math.deg2rad(0.92))
+	:rotation_period(f(712,1000))
+	:axial_tilt(fixed.deg2rad(f(1045,100)))
+	:metallicity(f(44,50))
+	:volcanicity(f(8,10))
+	:atmos_density(f(212,1000))
+	:atmos_oxidizing(f(2,100))
+	:ocean_cover(f(0,100))
+	:ice_cover(f(20,1000))
+	:life(f(3,100))
+	:orbital_phase_at_start(fixed.deg2rad(f(12,1)))
+	:rings(false)
+
+s:bodies(starsend, {
+	kobol,
+		kobol_starports,
+	dagobah,
+})
+
+s:add_to_sector(-8615,0,0,v(0.001,0.001,0.001))

--- a/data/systems/custom/19_starsend.lua
+++ b/data/systems/custom/19_starsend.lua
@@ -17,7 +17,7 @@ local starsend = CustomSystemBody:new('Star\'s End', 'STAR_K')
 	:mass(f(61,110))
 	:temp(4400)
 
-local kobol = CustomSystemBody:new('Kobol', 'PLANET_TERRESTRIAL')
+local kobol = CustomSystemBody:new('Cobol', 'PLANET_TERRESTRIAL')
 	:radius(f(92,100))
 	:mass(f(9,10))
 	:temp(260)
@@ -42,7 +42,7 @@ local kobol_starports = {
 		:longitude(math.deg2rad(-37.5)),
 }
 
-local dagobah = CustomSystemBody:new('Dagobah', 'PLANET_TERRESTRIAL')
+local dagobah = CustomSystemBody:new('Yodagobah', 'PLANET_TERRESTRIAL')
 	:seed(-1317315059)
 	:radius(f(412,1000))
 	:mass(f(189,1000))


### PR DESCRIPTION
Adding a custom system, Star's End, to a remote region of Milky Way. (The 'opposite side' of the disk)

- Star's End is a Foundation reference, the vague name for the supposed location of Second Foundation. Since we have Terminus in the middle of the galaxy, I thought the name would be suitable.

- Cobol --> Kobol is the name of the lost, ancient birthplace of mankind in Battlestar Galactica series, which is discovered by the human diaspora some time after the fall. Also, you know, COBOL.

- Yodagobah --> Dagobah is the name of Jedi Master Yoda's remote exile planet in Star Wars universe.

Pioneer-wise lore is:

> A special team of ambitious colonists sent out during the fall of Haber Corporation in secrecy has picked this small system as their new home. With intentions to expand the civilization to the remotest reach of Milky Way, they are safekeeping perhaps one of the most detailed records of human history and culture.
	The colonists are currently working on increasing the total population and terraforming the two planets in the system before permanently heading off to colonize neighboring star systems.

This is the official description. In reality it is just a bunch Haber officers getting everything they can and running from their fate. A bit farther than necessary.

Cobol has a decent atmosphere and barely some plant life (with help of minor terraforming efforts), while Yodagobah mostly owes it's thin atmosphere to it's pretty active volcanism. Also has naturally evolved archaea-ish life near volcanoes.

 ̷I̷ ̷h̷o̷p̷e̷ ̷i̷t̷ ̷i̷s̷n̷'̷t̷ ̷a̷ ̷p̷r̷o̷b̷l̷e̷m̷ ̷t̷o̷ ̷c̷o̷p̷y̷ ̷p̷l̷a̷n̷e̷t̷ ̷n̷a̷m̷e̷s̷,̷ ̷s̷i̷n̷c̷e̷ ̷i̷t̷ ̷i̷s̷ ̷n̷o̷t̷ ̷t̷h̷e̷ ̷f̷i̷r̷s̷t̷ ̷t̷i̷m̷e̷ ̷w̷e̷ ̷a̷r̷e̷ ̷d̷o̷i̷n̷g̷ ̷i̷t̷(̷?̷)̷
sturnclaw and nozmajner suggested non-copy-paste planet names. Thanks!