### PR TITLE
Merge 36 Ophiuchi & Gliese 664 into a single star system

### DIFF
--- a/data/systems/02_local_stars.lua
+++ b/data/systems/02_local_stars.lua
@@ -259,7 +259,7 @@ CustomSystem:new('Gliese 706',{'STAR_K'}):add_to_sector(-4,-1,2,v(0.460,0.851,0.
 CustomSystem:new('Gliese 707',{'STAR_K'}):add_to_sector(-4,-1,-4,v(0.170,0.793,0.368))
 CustomSystem:new('Gliese 701',{'STAR_M'}):add_to_sector(-4,-1,-1,v(0.827,0.929,0.832))
 CustomSystem:new('Gliese 661',{'STAR_K','STAR_M'}):add_to_sector(-2,0,1,v(0.238,0.374,0.844))
-CustomSystem:new('Gliese 664',{'STAR_K'}):add_to_sector(-3,0,-2,v(0.863,0.413,0.913))
+--CustomSystem:new('Gliese 664',{'STAR_K'}):add_to_sector(-3,0,-2,v(0.863,0.413,0.913)) Duplicate of 36 Ophiuchi system
 CustomSystem:new('Gliese 667',{'STAR_K','STAR_K','STAR_M'}):add_to_sector(-3,0,-2,v(0.709,0.415,0.370))
 CustomSystem:new('Gliese 666',{'STAR_M','STAR_M'}):add_to_sector(-3,0,-3,v(0.579,0.437,0.396))
 CustomSystem:new('Kruger 60',{'STAR_M','STAR_M'}):add_to_sector(-1,-1,1,v(0.659,0.195,0.381))

--- a/data/systems/02_local_stars.lua
+++ b/data/systems/02_local_stars.lua
@@ -259,7 +259,7 @@ CustomSystem:new('Gliese 706',{'STAR_K'}):add_to_sector(-4,-1,2,v(0.460,0.851,0.
 CustomSystem:new('Gliese 707',{'STAR_K'}):add_to_sector(-4,-1,-4,v(0.170,0.793,0.368))
 CustomSystem:new('Gliese 701',{'STAR_M'}):add_to_sector(-4,-1,-1,v(0.827,0.929,0.832))
 CustomSystem:new('Gliese 661',{'STAR_K','STAR_M'}):add_to_sector(-2,0,1,v(0.238,0.374,0.844))
---CustomSystem:new('Gliese 664',{'STAR_K'}):add_to_sector(-3,0,-2,v(0.863,0.413,0.913)) Duplicate of 36 Ophiuchi system
+--CustomSystem:new('Gliese 664',{'STAR_K'}):add_to_sector(-3,0,-2,v(0.863,0.413,0.913)) Part of 36 Ophiuchi system
 CustomSystem:new('Gliese 667',{'STAR_K','STAR_K','STAR_M'}):add_to_sector(-3,0,-2,v(0.709,0.415,0.370))
 CustomSystem:new('Gliese 666',{'STAR_M','STAR_M'}):add_to_sector(-3,0,-3,v(0.579,0.437,0.396))
 CustomSystem:new('Kruger 60',{'STAR_M','STAR_M'}):add_to_sector(-1,-1,1,v(0.659,0.195,0.381))
@@ -412,7 +412,7 @@ CustomSystem:new('NN 3518',{'STAR_M'}):add_to_sector(3,3,-3,v(0.279,0.149,0.988)
 CustomSystem:new('GJ 1156',{'STAR_M'}):add_to_sector(-1,2,0,v(0.782,0.607,0.514))
 CustomSystem:new('Gliese 293',{'WHITE_DWARF'}):add_to_sector(0,0,-3,v(0.939,0.505,0.392))
 CustomSystem:new('GJ 1093',{'STAR_M'}):add_to_sector(2,0,1,v(0.884,0.765,0.049))
-CustomSystem:new('36 Ophiuchi',{'STAR_K'}):add_to_sector(-3,0,-2,v(0.859,0.422,0.907))
+CustomSystem:new('36 Ophiuchi',{'STAR_K', 'STAR_K', 'STAR_K'}):other_names({"Gliese 663", "Gliese 664"}):add_to_sector(-3,0,-2,v(0.859,0.422,0.907))
 CustomSystem:new('Gliese 570',{'STAR_K'}):add_to_sector(-2,2,-2,v(0.014,0.031,0.886))
 CustomSystem:new('Gliese 572',{'STAR_M'}):add_to_sector(-3,2,3,v(0.623,0.357,0.398))
 CustomSystem:new('Wolf 424',{'STAR_M','STAR_M'}):add_to_sector(-1,1,0,v(0.748,0.716,0.275))


### PR DESCRIPTION
Gliese 664 is 36 Ophiuchi C.
https://en.wikipedia.org/wiki/36_Ophiuchi (see "other designations")

Yet they were treated as separate star systems (because I think GJ catalogue treats them as such) and were sitting on top of each other in the sector map.

36 Ophiuchi B was nonexistent altogether. It has been added too.