### PR TITLE
Commodity name clean-up

### DIFF
--- a/data/lang/commodity/en.json
+++ b/data/lang/commodity/en.json
@@ -201,7 +201,7 @@
   },
   "RADIOACTIVES": {
     "description": "",
-    "message": "Radioactives"
+    "message": "Radioactive waste"
   },
   "RADIOACTIVES_DESCRIPTION": {
     "description": "This is an artistic description of the commodity. Translate as you deem appropriate or come up with your own description, long or short, its up to you.",

--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -489,7 +489,7 @@
   },
   "HAND_WEAPONS": {
     "description": "",
-    "message": "Hand weapons"
+    "message": "Small arms"
   },
   "HARD_CAPITALIST": {
     "description": "",


### PR DESCRIPTION
Radioactives are mostly useful and should be paid for.
Radioactive waste mostly isn't and... you get the idea.
(I think it has been that way before, maybe it changed during pigui conversion project, idk)

Commodity "hand weapons" are called "small arms" in market but "hand weapons" in system economy data (and, in turn, trading computer). I changed all into "small arms", as it is in the commodity market.