### PR TITLE
Remove price reduction when selling commodities

### DIFF
--- a/data/pigui/libs/equipment-market.lua
+++ b/data/pigui/libs/equipment-market.lua
@@ -32,7 +32,11 @@ local defaultFuncs = {
     getSellPrice = function (self, e)
         local basePrice = Game.player:GetDockedWith():GetEquipmentPrice(e)
         if basePrice > 0 then
-            return sellPriceReduction * basePrice
+			if e:IsValidSlot("cargo") then
+				return basePrice
+			else
+				return sellPriceReduction * basePrice
+			end
         else
             return 1.0/sellPriceReduction * basePrice
         end


### PR DESCRIPTION
Sorry for rapid and major changes to the PR.
We now get full money back when selling a commodity, as opposed to equipment.

fixes #4858