### PR TITLE
LuaMetaType + LuaObject 2.0

### DIFF
--- a/src/lua/Lua.cpp
+++ b/src/lua/Lua.cpp
@@ -57,6 +57,8 @@ namespace Lua {
 	void InitModules()
 	{
 		PROFILE_SCOPED()
+		lua_State *l = Lua::manager->GetLuaState();
+
 		LuaObject<PropertiedObject>::RegisterClass();
 
 		LuaObject<Body>::RegisterClass();
@@ -110,7 +112,6 @@ namespace Lua {
 		SceneGraph::Lua::Init();
 
 		// XXX load everything. for now, just modules
-		lua_State *l = Lua::manager->GetLuaState();
 		pi_lua_dofile(l, "libs/autoload.lua");
 		lua_pop(l, 1);
 

--- a/src/lua/LuaCall.h
+++ b/src/lua/LuaCall.h
@@ -1,0 +1,103 @@
+// Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+/*
+	This file implements a generic method to call a C++ member function with
+	arguments passed in from Lua. It's intended to back a generic method of
+	binding code to Lua with minimal boilerplate needed.
+*/
+
+#include "Lua.h"
+#include "LuaPushPull.h"
+
+// Backend to bind call a C++ member function with arguments from Lua.
+// Parameter `index` points one-behind the first argument, where the object
+// pointer should traditionally be
+
+template<class T, typename Ret>
+Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)())
+{
+	return (ptr->*fn)();
+}
+
+template<class T, typename Ret, typename Arg1>
+Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1))
+{
+	auto arg1 = LuaPull<Arg1>(l, index+1);
+	return (ptr->*fn)(arg1);
+}
+
+template<class T, typename Ret, typename Arg1, typename Arg2>
+Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2))
+{
+	auto arg1 = LuaPull<Arg1>(l, index+1);
+	auto arg2 = LuaPull<Arg2>(l, index+2);
+	return (ptr->*fn)(arg1, arg2);
+}
+
+template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3>
+Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3))
+{
+	auto arg1 = LuaPull<Arg1>(l, index+1);
+	auto arg2 = LuaPull<Arg2>(l, index+2);
+	auto arg3 = LuaPull<Arg3>(l, index+3);
+	return (ptr->*fn)(arg1, arg2, arg3);
+}
+
+template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4>
+Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3, Arg4))
+{
+	auto arg1 = LuaPull<Arg1>(l, index+1);
+	auto arg2 = LuaPull<Arg2>(l, index+2);
+	auto arg3 = LuaPull<Arg3>(l, index+3);
+	auto arg4 = LuaPull<Arg4>(l, index+4);
+	return (ptr->*fn)(arg1, arg2, arg3, arg4);
+}
+
+template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5>
+Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3, Arg4, Arg5))
+{
+	auto arg1 = LuaPull<Arg1>(l, index+1);
+	auto arg2 = LuaPull<Arg2>(l, index+2);
+	auto arg3 = LuaPull<Arg3>(l, index+3);
+	auto arg4 = LuaPull<Arg4>(l, index+4);
+	auto arg5 = LuaPull<Arg5>(l, index+5);
+	return (ptr->*fn)(arg1, arg2, arg3, arg4, arg5);
+}
+
+template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6>
+Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6))
+{
+	auto arg1 = LuaPull<Arg1>(l, index+1);
+	auto arg2 = LuaPull<Arg2>(l, index+2);
+	auto arg3 = LuaPull<Arg3>(l, index+3);
+	auto arg4 = LuaPull<Arg4>(l, index+4);
+	auto arg5 = LuaPull<Arg5>(l, index+5);
+	auto arg6 = LuaPull<Arg6>(l, index+6);
+	return (ptr->*fn)(arg1, arg2, arg3, arg4, arg5, arg6);
+}
+
+template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7>
+Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7))
+{
+	auto arg1 = LuaPull<Arg1>(l, index+1);
+	auto arg2 = LuaPull<Arg2>(l, index+2);
+	auto arg3 = LuaPull<Arg3>(l, index+3);
+	auto arg4 = LuaPull<Arg4>(l, index+4);
+	auto arg5 = LuaPull<Arg5>(l, index+5);
+	auto arg6 = LuaPull<Arg6>(l, index+6);
+	auto arg7 = LuaPull<Arg7>(l, index+7);
+	return (ptr->*fn)(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+}
+
+// Pull an object and arguments for the passed function from Lua.
+// Intended to ease the amount of boilerplate code needed to bind a method to Lua.
+
+template<class T, typename Ret, typename ...Args>
+Ret pi_lua_generic_call(lua_State *l, int index, Ret (T::*fn)(Args...))
+{
+	T *ptr = LuaPull<T>(l, index);
+	return pi_lua_multiple_call<T, Ret, Args...>(l, index, ptr, fn);
+}

--- a/src/lua/LuaConsole.cpp
+++ b/src/lua/LuaConsole.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#include "LuaMetaType.h"
 #include "buildopts.h"
 
 #include "FileSystem.h"
@@ -314,7 +315,8 @@ void LuaConsole::UpdateCompletion(const std::string &statement)
 		lua_gettable(l, -2);
 		chunks.pop();
 	}
-	LuaObjectBase::GetNames(m_completionList, chunks.top(), method);
+	
+	LuaMetaTypeBase::GetNames(m_completionList, chunks.top(), method);
 	if (!m_completionList.empty()) {
 		std::sort(m_completionList.begin(), m_completionList.end());
 		m_completionList.erase(std::unique(m_completionList.begin(), m_completionList.end()), m_completionList.end());

--- a/src/lua/LuaMetaType.cpp
+++ b/src/lua/LuaMetaType.cpp
@@ -1,0 +1,448 @@
+// Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "LuaMetaType.h"
+#include "Lua.h"
+#include "LuaObject.h"
+#include "PropertyMap.h"
+
+// if found, returns true, leaves item to return to lua on top of stack
+// if not found, returns false
+static bool get_method(lua_State *l, int metatable, int name)
+{
+	LUA_DEBUG_START(l);
+
+	name = lua_absindex(l, name);
+
+	// look up the name in the list of methods.
+	lua_getfield(l, metatable, "methods");
+	lua_pushvalue(l, name); // make a copy of the name
+	lua_rawget(l, -2);		// look it up in the methods table
+	lua_remove(l, -2);		// remove the methods table
+
+	// found something, return it
+	if (!lua_isnil(l, -1)) {
+		LUA_DEBUG_END(l, 1);
+		return true;
+	}
+	lua_pop(l, 1);
+
+	// otherwise, just return
+	LUA_DEBUG_END(l, 0);
+	return false;
+}
+
+// if found, returns true, leaves attribute entry on top of stack
+// if not found, returns false
+static bool get_attr_entry(lua_State *l, int metatable, int name)
+{
+	LUA_DEBUG_START(l);
+
+	name = lua_absindex(l, name);
+
+	// lookup the name in the list of attributes
+	lua_getfield(l, metatable, "attrs");
+	lua_pushvalue(l, name); // make a copy of the name
+	lua_rawget(l, -2);		// look it up in the methods table
+	lua_remove(l, -2);		// remove the attributes table
+
+	// found an attribute entry, don't evaluate
+	if (!lua_isnil(l, -1)) {
+		LUA_DEBUG_END(l, 1);
+		return true;
+	}
+	lua_pop(l, 1);
+
+	// not found
+	LUA_DEBUG_END(l, 0);
+	return false;
+}
+
+// takes the metatable, name on top of stack
+// Look up a method or attribute, evaluating the attribute entry as a getter.
+static bool get_method_or_attr(lua_State *l)
+{
+	LUA_DEBUG_START(l);
+
+	// if we have a method, call it
+	if (get_method(l, -2, -1)) {
+		LUA_DEBUG_END(l, 1);
+		return true;
+	} else if (get_attr_entry(l, -2, -1)) {
+		// Someone may have put a non-function value in the attributes
+		// weird, but ok, we can handle it
+		if (lua_isfunction(l, -1)) {
+			lua_pushvalue(l, 1);			// push the self object
+			pi_lua_protected_call(l, 1, 1); // call the attribute entry
+
+			LUA_DEBUG_END(l, 1);
+			return true;
+		}
+
+		LUA_DEBUG_END(l, 1);
+		return true;
+	}
+
+	LUA_DEBUG_END(l, 0);
+	return false;
+}
+
+static int l_index(lua_State *l)
+{
+	// userdata are typed, tables are not
+	bool typeless = lua_istable(l, 1);
+	assert(typeless || lua_isuserdata(l, 1));
+
+	// typeless objects have no parents, and have only one method table, so this is easy
+	if (typeless) {
+		lua_getmetatable(l, 1);
+		lua_pushvalue(l, 2);
+
+		// if we have something in the first metatable, return it
+		if (get_method_or_attr(l))
+			return 1;
+
+		// otherwise, nothing further to look up
+		return 0;
+	}
+
+	// normal userdata object
+	// first check properties. we don't need to drill through lua if the
+	// property is already available
+	lua_getuservalue(l, 1);
+	if (!lua_isnil(l, -1)) {
+		lua_pushvalue(l, 2); // push the key
+		lua_gettable(l, -2); // get the property from the table
+		if (!lua_isnil(l, -1)) {
+			return 1; // return the property if it is set
+		}
+
+		lua_pop(l, 1);
+	}
+	lua_pop(l, 1);
+
+	// push the metatype registry here for later
+	lua_getfield(l, LUA_REGISTRYINDEX, "LuaMetaTypes");
+	int metaTypeRegistry = lua_gettop(l);
+
+	// push metatable, name onto the top of the stack
+	lua_getmetatable(l, 1);
+	lua_pushvalue(l, 2);
+	while (1) {
+		// got a method or an attribute handler from this metatype
+		if (get_method_or_attr(l)) {
+			// clean up the stack
+			lua_insert(l, -3);
+			lua_pop(l, 2);
+			return 1;
+		}
+
+		// if there's no parent metatable, get out
+		lua_getfield(l, -2, "parent");
+		if (lua_isnil(l, -1))
+			break;
+
+		std::string parentName = lua_tostring(l, -1);
+		lua_pop(l, 1); // pop the parent name
+
+		lua_getfield(l, metaTypeRegistry, parentName.c_str());
+		if (lua_isnil(l, -1))
+			return luaL_error(l, "Encountered invalid parent metatype name %s", parentName.c_str());
+
+		lua_replace(l, -3); // replace the metatable with the parent
+	}
+
+	return 0;
+}
+
+static int l_newindex(lua_State *l)
+{
+	// userdata are typed, tables are not
+	bool typeless = lua_istable(l, 1);
+	assert(typeless || lua_isuserdata(l, 1));
+
+	// Attribute setters are not enabled for typeless objects.
+	if (typeless) {
+		lua_rawset(l, 1); // set the value in the table
+		return 0;
+	}
+
+	// Once we've dealt with the chance of a typeless object, the only thing
+	// left is userdata.
+
+	// first check properties. we don't need to drill through the metatype stack
+	// if the property is already available
+	lua_getuservalue(l, 1);
+
+	// Ensure the object already has the property defined
+	// Properties take precedence over attrs only if they've been previously set
+	// (use setprop if you want to be sure you're setting a property)
+	bool hasProperty = false;
+	if (!lua_isnil(l, -1)) {
+		lua_pushvalue(l, 2);
+		lua_gettable(l, -2);
+		hasProperty = !lua_isnil(l, -1);
+		lua_pop(l, 1);
+	}
+
+	// if the object is a valid propertied object, call its setters
+	if (hasProperty) {
+		auto *properties = LuaObjectBase::GetPropertiesFromObject(l, 1);
+
+		std::string name = lua_tostring(l, 2);
+		if (lua_isnumber(l, 3)) {
+			properties->Set(name, lua_tonumber(l, 2));
+		} else if (lua_isstring(l, 3)) {
+			properties->Set(name, lua_tostring(l, 3));
+		}
+
+		return 0;
+	}
+	lua_pop(l, 1);
+
+	// push the metatype registry here for later
+	lua_getfield(l, LUA_REGISTRYINDEX, "LuaMetaTypes");
+	int metaTypeRegistry = lua_gettop(l);
+
+	// Check the metatable for attributes
+	lua_getmetatable(l, 1); // get the metatable
+	while (true) {
+		// if we have an attribute handler, call it
+		// if the attribute entry is a non-function value, it is considered immutable
+		if (get_attr_entry(l, -1, 2)) {
+			if (lua_isfunction(l, -1)) {
+				lua_remove(l, -2);	 // remove the metatable
+				lua_pushvalue(l, 1); // push the self object
+				lua_pushvalue(l, 3); // push the value
+				pi_lua_protected_call(l, 2, 0);
+				return 0;
+			}
+			lua_pop(l, 1);
+		}
+
+		lua_getfield(l, -1, "parent"); // get the parent field from the metatable
+		if (lua_isnil(l, -1))		   // hit the end of the chain, nothing here
+			break;
+
+		std::string parentName = lua_tostring(l, -1);
+		lua_pop(l, 1);
+
+		lua_getfield(l, metaTypeRegistry, parentName.c_str());
+		if (lua_isnil(l, -1))
+			return luaL_error(l, "Encountered invalid parent metatype name %s", parentName.c_str());
+
+		lua_remove(l, -2); // replace the metatable with the parent
+	}
+
+	return luaL_error(l, "Attempt to set undefined property %s on %s", lua_tostring(l, 2), lua_tostring(l, 1));
+}
+
+static void get_names_from_table(lua_State *l, std::vector<std::string> &names, const std::string &prefix, bool methodsOnly)
+{
+	lua_pushnil(l);
+	while (lua_next(l, -2)) {
+
+		// only include string keys. the . syntax doesn't work for anything
+		// else
+		if (lua_type(l, -2) != LUA_TSTRING) {
+			lua_pop(l, 1);
+			continue;
+		}
+
+		// only include callable things if requested
+		if (methodsOnly && lua_type(l, -1) != LUA_TFUNCTION) {
+			lua_pop(l, 1);
+			continue;
+		}
+
+		size_t str_size = 0;
+		const char *name = lua_tolstring(l, -2, &str_size);
+		// anything starting with an underscore is hidden
+		if (name[0] == '_') {
+			lua_pop(l, 1);
+			continue;
+		}
+
+		// check if the name begins with the prefix
+		if (strncmp(name, prefix.c_str(), std::min(str_size, prefix.size())) == 0)
+			// push back the portion of the name not matching the prefix (for completion)
+			names.push_back(std::string(name + prefix.size()));
+
+		lua_pop(l, 1);
+	}
+}
+
+void LuaMetaTypeBase::GetNames(std::vector<std::string> &names, const std::string &prefix, bool methodsOnly)
+{
+	// never show hidden names
+	if (!prefix.empty() && prefix[0] == '_')
+		return;
+
+	lua_State *l = Lua::manager->GetLuaState();
+
+	LUA_DEBUG_START(l);
+
+	// work out if/how we can deal with the value
+	bool typeless;
+	if (lua_istable(l, -1))
+		// we can always look into tables
+		typeless = true;
+
+	else if (lua_isuserdata(l, -1)) {
+		// two known types of userdata
+		// - LuaObject, metatable has a "type" field
+		// - RO table proxy, no type
+		lua_getmetatable(l, -1);
+		lua_getfield(l, -1, "type");
+		typeless = lua_isnil(l, -1);
+		lua_pop(l, 2);
+	}
+
+	else {
+		// it's a non-table object with a metatable
+		// this realistically can only be a string, but let's work with it anyways
+		lua_getmetatable(l, -1);
+		if (lua_isnil(l, -1)) {
+			lua_pop(l, 1);
+			return; // if no metatable, can't do anything
+		}
+
+		lua_getfield(l, -1, "__index");
+		typeless = lua_istable(l, -1);
+		lua_pop(l, 2);
+
+		// if the __index field isn't a table, we can't introspect into it
+		if (!typeless)
+			return;
+	}
+
+	LUA_DEBUG_CHECK(l, 0);
+
+	if (typeless) {
+		// if the object we're getting names from is a table, search it for names
+		if (lua_istable(l, -1))
+			get_names_from_table(l, names, prefix, methodsOnly);
+
+		// Check the metatable indexes
+		// Get the metatable of the object, then check it for an __index field
+		lua_pushvalue(l, -1);
+		while (lua_getmetatable(l, -1)) {
+			lua_getfield(l, -2, "__index");
+
+			// Replace the metatable with the index table to keep a stable stack size.
+			lua_replace(l, -3);
+			lua_pop(l, 1);
+
+			if (lua_istable(l, -1))
+				get_names_from_table(l, names, prefix, methodsOnly);
+			else
+				break;
+		}
+		lua_pop(l, 1);
+
+		return;
+	}
+
+	// properties
+	if (!methodsOnly) {
+		lua_getuservalue(l, -1);
+		if (!lua_isnil(l, -1))
+			get_names_from_table(l, names, prefix, false);
+		lua_pop(l, 1);
+	}
+
+	// check the metatable (and its parents) for methods and attributes
+	lua_getmetatable(l, -1);
+	while (1) {
+		lua_getfield(l, -1, "methods");
+		get_names_from_table(l, names, prefix, methodsOnly);
+		lua_pop(l, 1);
+
+		if (!methodsOnly) {
+			lua_getfield(l, -1, "attrs");
+			get_names_from_table(l, names, prefix, false);
+			lua_pop(l, 1);
+		}
+
+		lua_getfield(l, -1, "parent");
+		std::string parent = lua_tostring(l, -1);
+		if (!lua_isnil(l, -1))
+			parent = lua_tostring(l, -1);
+
+		lua_pop(l, 1); // pop the parent's name
+
+		bool hasParent = !parent.empty() && GetMetatableFromName(l, parent.c_str());
+		if (hasParent)
+			lua_remove(l, -2); // replace the previous metatype with the parent
+		else
+			break; // the old metatype is the only thing on the stack
+	}
+
+	lua_pop(l, 1); // pop the metatable
+
+	LUA_DEBUG_END(l, 0);
+}
+
+bool LuaMetaTypeBase::GetMetatableFromName(lua_State *l, const char *name)
+{
+	luaL_getsubtable(l, LUA_REGISTRYINDEX, "LuaMetaTypes");
+	lua_getfield(l, -1, name);
+	lua_remove(l, -2);
+	if (lua_isnil(l, -1)) {
+		lua_pop(l, 1);
+		return false;
+	}
+
+	return true;
+}
+
+void LuaMetaTypeBase::CreateMetaType(lua_State *l)
+{
+	luaL_getsubtable(l, LUA_REGISTRYINDEX, "LuaMetaTypes");
+
+	// if the type name is empty, we're creating a "throwaway" object with no parent either
+	if (!m_typeName.empty()) {
+		// Warn if we're double-initializing a type name
+		lua_getfield(l, -1, m_typeName.c_str());
+		if (!lua_isnil(l, -1))
+			Output("Double-initialization of lua metatype %s. Do you have a name conflict?\n", m_typeName.c_str());
+		lua_pop(l, 1);
+	}
+
+	lua_newtable(l);
+
+	if (!m_typeName.empty()) {
+		// Set the entry LuaMetaTypes[typename] = metatype
+		lua_pushvalue(l, -1);
+		lua_setfield(l, -3, m_typeName.c_str());
+	}
+
+	// Generate the reference to be stored in the C++ object
+	m_typeTable = LuaRef(l, -1);
+
+	// set the type name on the metatable
+	lua_pushstring(l, m_typeName.c_str());
+	lua_setfield(l, -2, "type");
+
+	if (!m_parent.empty()) {
+		lua_pushstring(l, m_parent.c_str());
+		lua_setfield(l, -2, "parent");
+	}
+
+	// create the attributes table
+	lua_newtable(l);
+	lua_setfield(l, -2, "attrs");
+
+	// create the methods table
+	lua_newtable(l);
+	lua_setfield(l, -2, "methods");
+
+	lua_pushcclosure(l, &l_index, 0);
+	lua_setfield(l, -2, "__index");
+
+	lua_pushcclosure(l, &l_newindex, 0);
+	lua_setfield(l, -2, "__newindex");
+
+	// replace the LuaMetaTypes registry table, leaving the created metatype on the stack
+	lua_replace(l, -2);
+}

--- a/src/lua/LuaMetaType.h
+++ b/src/lua/LuaMetaType.h
@@ -1,0 +1,409 @@
+// Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "Lua.h"
+#include "LuaCall.h"
+#include "LuaManager.h"
+#include "LuaPushPull.h"
+#include "LuaTable.h"
+#include "src/lua.h"
+
+class LuaMetaTypeBase {
+public:
+	LuaMetaTypeBase(const char *name) :
+		m_typeName(name)
+	{}
+
+	// Creates and registers the lua-side object for this type.
+	void CreateMetaType(lua_State *l);
+
+	const char *GetTypeName() const { return m_typeName.c_str(); }
+
+	const char *GetParent() const { return m_parent.c_str(); }
+
+	void SetParent(const char *parent) { m_parent = parent; }
+
+	const LuaRef &GetMetatable() const { return m_typeTable; }
+
+	// Get all valid method/attribute names for the object on the top of the stack.
+	// Mainly intended to be used by the console, though it can also be used for
+	// debug dumping of properties, attributes, and methods
+	static void GetNames(std::vector<std::string> &names, const std::string &prefix = "", bool methodsOnly = false);
+
+	// Get the lua-side metatable from a type name instead of a LuaRef.
+	static bool GetMetatableFromName(lua_State *l, const char *name);
+
+protected:
+	template <typename T, typename Dt>
+	using member_pointer = Dt T::*;
+
+	template <typename T>
+	using free_function = int (*)(lua_State *, T *);
+
+	template <typename T, typename Rt, typename... Args>
+	using member_function = Rt (T::*)(Args...);
+
+	template <typename T, typename Rt, typename... Args>
+	using const_member_function = Rt (T::*)(Args...) const;
+
+	template <typename T, typename Dt>
+	static int member_wrapper_(lua_State *L)
+	{
+		T *ptr = LuaPull<T *>(L, 1);
+		const char *name = lua_tostring(L, lua_upvalueindex(1));
+
+		if (!ptr)
+			return luaL_error(L, "Null or invalid userdata accessed for property %s", name);
+
+		if (lua_gettop(L) > 2)
+			return luaL_error(L, "Invalid number of arguments for property getter/setter %s", name);
+
+		auto &t = PullPointerToMember<member_pointer<T, Dt>>(L, lua_upvalueindex(2));
+		if (lua_gettop(L) == 1) {
+			LuaPush<Dt>(L, ptr->*(t));
+			return 1;
+		} else {
+			(ptr->*(t)) = LuaPull<Dt>(L, 2);
+			return 0;
+		}
+	}
+
+	template <typename T>
+	static int getter_member_wrapper_(lua_State *L)
+	{
+		T *ptr = LuaPull<T *>(L, 1);
+		const char *name = lua_tostring(L, lua_upvalueindex(1));
+		free_function<T> getter = PullFreeFunction<T>(L, lua_upvalueindex(2));
+
+		if (!ptr)
+			return luaL_error(L, "Null or invalid userdata accessed for property %s", name);
+
+		if (lua_gettop(L) > 2)
+			return luaL_error(L, "Invalid number of arguments for property getter/setter %s", name);
+
+		if (lua_gettop(L) > 1) {
+			free_function<T> setter = PullFreeFunction<T>(L, lua_upvalueindex(3));
+			if (setter != nullptr)
+				return setter(L, ptr);
+			else
+				return luaL_error(L, "Attempt to call undefined setter for property %s", name);
+		}
+
+		return getter(L, ptr);
+	}
+
+	template <typename T, typename Dt>
+	static int getter_member_fn_wrapper_(lua_State *L)
+	{
+		T *ptr = LuaPull<T *>(L, 1);
+		const char *name = lua_tostring(L, lua_upvalueindex(1));
+		auto &getter = PullPointerToMember<member_function<T, Dt>>(L, lua_upvalueindex(2));
+
+		if (!ptr)
+			return luaL_error(L, "Null or invalid userdata accessed for property %s", name);
+
+		if (lua_gettop(L) > 2)
+			return luaL_error(L, "Invalid number of arguments for property getter/setter %s", name);
+
+		if (lua_gettop(L) > 1) {
+			auto &setter = PullPointerToMember<member_function<T, void, Dt>>(L, lua_upvalueindex(3));
+			if (setter != nullptr) {
+				pi_lua_multiple_call(L, 1, ptr, setter);
+				return 0;
+			} else
+				return luaL_error(L, "Attempt to call undefined setter for property %s", name);
+		} else {
+			Dt value = pi_lua_multiple_call(L, 1, ptr, getter);
+			LuaPush<Dt>(L, value);
+			return 1;
+		}
+	}
+
+	template <typename T>
+	static int fn_wrapper_(lua_State *L)
+	{
+		T *ptr = LuaPull<T *>(L, 1);
+		const char *name = lua_tostring(L, lua_upvalueindex(1));
+
+		if (!ptr)
+			return luaL_error(L, "Invalid userdata accessed for function %s", name);
+
+		free_function<T> fn = PullFreeFunction<T>(L, lua_upvalueindex(2));
+		return fn(L, ptr);
+	}
+
+	template <typename T, typename Rt, typename... Args>
+	static int member_fn_wrapper_(lua_State *L)
+	{
+		T *ptr = LuaPull<T *>(L, 1);
+		const char *name = lua_tostring(L, lua_upvalueindex(1));
+
+		if (!ptr)
+			return luaL_error(L, "Invalid userdata accessed for function %s", name);
+
+		if (lua_gettop(L) - 1 < sizeof...(Args))
+			return luaL_error(L, "Invalid number of arguments for function %s", name);
+
+		auto &fn = PullPointerToMember<member_function<T, Rt, Args...>>(L, lua_upvalueindex(2));
+		Rt ret = pi_lua_multiple_call(L, 1, ptr, fn);
+		LuaPush<Rt>(L, ret);
+
+		return 1;
+	}
+
+	template <typename T, typename Rt, typename... Args, typename std::enable_if<std::is_same<Rt, void>::value>::type = nullptr>
+	static int member_fn_wrapper_(lua_State *L)
+	{
+		T *ptr = LuaPull<T *>(L, 1);
+		const char *name = lua_tostring(L, lua_upvalueindex(1));
+
+		if (!ptr)
+			return luaL_error(L, "Invalid userdata accessed for function %s", name);
+
+		if (lua_gettop(L) - 1 < sizeof...(Args))
+			return luaL_error(L, "Invalid number of arguments for function %s", name);
+
+		auto &fn = PullPointerToMember<member_function<T, Rt, Args...>>(L, lua_upvalueindex(2));
+		pi_lua_multiple_call(L, 1, ptr, fn);
+
+		return 0;
+	}
+
+	template <typename MemT>
+	static void PushPointerToMember(lua_State *L, MemT obj)
+	{
+		*reinterpret_cast<MemT *>(lua_newuserdata(L, sizeof(MemT))) = obj;
+	}
+
+	template <typename MemT>
+	static MemT &PullPointerToMember(lua_State *L, int idx)
+	{
+		return *reinterpret_cast<MemT *>(lua_touserdata(L, idx));
+	}
+
+	template <typename T>
+	static void PushFreeFunction(lua_State *L, free_function<T> obj)
+	{
+		lua_pushlightuserdata(L, reinterpret_cast<void *>(obj));
+	}
+
+	template <typename T>
+	static free_function<T> &PullFreeFunction(lua_State *L, int index)
+	{
+		return *reinterpret_cast<free_function<T> *>(lua_touserdata(L, index));
+	}
+
+	// Pushes a copy of the metatable's attribute table to the stack
+	void GetAttrTable(lua_State *L, int index)
+	{
+		luaL_getsubtable(L, index, "attrs");
+	}
+
+	// Pushes a copy of the metatable's attribute table to the stack
+	void GetMethodTable(lua_State *L, int index)
+	{
+		luaL_getsubtable(L, index, "methods");
+	}
+
+	std::string m_typeName;
+	std::string m_parent;
+	LuaRef m_typeTable;
+};
+
+template <typename T>
+class LuaMetaType : public LuaMetaTypeBase {
+public:
+	LuaMetaType(const char *name) :
+		LuaMetaTypeBase(name)
+	{}
+
+	// Call this function to set the lua stack up to begin recording members
+	// and methods into the metatype.
+	// It is invalid to call other functions outside a StartRecording / StopRecording pair.
+	LuaMetaType &StartRecording()
+	{
+		assert(m_typeTable.IsValid());
+		assert(m_index == 0);
+		lua_State *L = m_typeTable.GetLua();
+
+		m_typeTable.PushCopyToStack();
+		m_index = lua_gettop(L);
+
+		return *this;
+	}
+
+	// Stop recording and remove the metatype from the stack
+	LuaMetaType &StopRecording()
+	{
+		assert(m_typeTable.IsValid());
+		assert(m_index != 0);
+		lua_State *L = m_typeTable.GetLua();
+
+		lua_remove(L, m_index);
+		m_index = 0;
+
+		return *this;
+	}
+
+	// All functions and members pushed while protection is enabled will error
+	// when accessed by a non-trusted lua script.
+	void SetProtected(bool enabled) { m_protected = enabled; }
+
+	// Set the parent type name of this metatype to the type name provided.
+	// This enables function and member inheritance from parent 'classes'.
+	LuaMetaType &SetParent(const char *parent)
+	{
+		lua_State *L = m_typeTable.GetLua();
+
+		lua_pushstring(L, parent);
+		lua_setfield(L, -2, "parent");
+		m_parent = parent;
+
+		return *this;
+	}
+
+	// Bind a raw C++ data member to Lua.
+	// Obviously, the member in question must be publically accessible, or
+	// LuaMetaTypeBase must be marked as a friend class.
+	template <typename Dt>
+	LuaMetaType &AddMember(const char *name, member_pointer<T, Dt> t)
+	{
+		lua_State *L = m_typeTable.GetLua();
+		GetAttrTable(L, m_index);
+
+		lua_pushstring(L, (m_typeName + "." + name).c_str());
+		PushPointerToMember(L, t);
+		lua_pushcclosure(L, &member_wrapper_<T, Dt>, 2);
+		if (m_protected)
+			lua_pushcclosure(L, &secure_trampoline, 1);
+
+		lua_setfield(L, -2, name);
+		lua_pop(L, 1);
+
+		return *this;
+	}
+
+	// Bind a pseudo-member to Lua via a free-function getter and setter.
+	// The getter and setter are responsible for pulling parameters from Lua.
+	LuaMetaType &AddMember(const char *name, free_function<T> getter, free_function<T> setter = nullptr)
+	{
+		lua_State *L = m_typeTable.GetLua();
+		GetAttrTable(L, m_index);
+
+		lua_pushstring(L, (m_typeName + "." + name).c_str());
+		PushFreeFunction(L, getter);
+		PushFreeFunction(L, setter);
+		lua_pushcclosure(L, &getter_member_wrapper_<T>, 3);
+		if (m_protected)
+			lua_pushcclosure(L, &secure_trampoline, 1);
+
+		lua_setfield(L, -2, name);
+		lua_pop(L, 1);
+
+		return *this;
+	}
+
+	// Magic to allow binding a const function to Lua. Take care to ensure that you do not
+	// push a const object to lua, or this code will become undefined behavior.
+	template <typename Dt>
+	LuaMetaType &AddMember(const char *name, const_member_function<T, Dt> getter, member_function<T, void, Dt> setter = nullptr)
+	{
+		return AddMember(name, const_cast<member_function<T, Dt>>(getter), setter);
+	}
+
+	// Bind a pseudo-member to Lua via a member-function getter and setter.
+	// The parameter will automatically be pulled from Lua and passed to the setter.
+	template <typename Dt>
+	LuaMetaType &AddMember(const char *name, member_function<T, Dt> getter, member_function<T, void, Dt> setter = nullptr)
+	{
+		lua_State *L = m_typeTable.GetLua();
+		GetAttrTable(L, m_index);
+
+		lua_pushstring(L, (m_typeName + "." + name).c_str());
+		PushPointerToMember(L, getter);
+		PushPointerToMember(L, setter);
+		lua_pushcclosure(L, &getter_member_fn_wrapper_<T, Dt>, 3);
+		if (m_protected)
+			lua_pushcclosure(L, &secure_trampoline, 1);
+
+		lua_setfield(L, -2, name);
+		lua_pop(L, 1);
+
+		return *this;
+	}
+
+	// Magic to allow binding a const function to Lua. Take care to ensure that you do not
+	// push a const object to lua, or this code will become undefined behavior.
+	template <typename Rt, typename... Args>
+	LuaMetaType &AddFunction(const char *name, const_member_function<T, Rt, Args...> fn)
+	{
+		return AddFunction(name, const_cast<member_function<T, Rt, Args...>>(fn));
+	}
+
+	// Bind a member function to Lua.
+	// Parameters will automatically be pulled from Lua and be passed to the function.
+	// It is the responsiblity of the programmer to ensure a valid LuaPull implementation
+	// is available for each parameter's time.
+	// If the function has a non-void return type, its return value will automatically be
+	// pushed to Lua.
+	template <typename Rt, typename... Args>
+	LuaMetaType &AddFunction(const char *name, member_function<T, Rt, Args...> fn)
+	{
+		lua_State *L = m_typeTable.GetLua();
+		GetMethodTable(L, m_index);
+
+		lua_pushstring(L, (m_typeName + "." + name).c_str());
+		PushPointerToMember(L, fn);
+		lua_pushcclosure(L, &member_fn_wrapper_<T, Rt, Args...>, 2);
+		if (m_protected)
+			lua_pushcclosure(L, &secure_trampoline, 1);
+
+		lua_setfield(L, -2, name);
+		lua_pop(L, 1);
+
+		return *this;
+	}
+
+	// Bind a free function to Lua.
+	// The self parameter will be automatically provided, but the function
+	// is responsible for pulling the rest of its parameters and pushing the
+	// appropriate number of return values.
+	LuaMetaType &AddFunction(const char *name, free_function<T> fn)
+	{
+		lua_State *L = m_typeTable.GetLua();
+		GetMethodTable(L, m_index);
+
+		lua_pushstring(L, (m_typeName + "." + name).c_str());
+		PushFreeFunction(L, fn);
+		lua_pushcclosure(L, &fn_wrapper_<T>, 2);
+		if (m_protected)
+			lua_pushcclosure(L, &secure_trampoline, 1);
+
+		lua_setfield(L, -2, name);
+		lua_pop(L, 1);
+
+		return *this;
+	}
+
+	LuaMetaType &RegisterFuncs(const luaL_Reg *functions)
+	{
+		lua_State *L = m_typeTable.GetLua();
+		GetMethodTable(L, m_index);
+
+		for (const luaL_Reg *func = functions; func->name; ++func) {
+			lua_pushcfunction(L, func->func);
+			if (m_protected)
+				lua_pushcclosure(L, secure_trampoline, 1);
+
+			lua_setfield(L, -1, func->name);
+		}
+
+		lua_pop(L, 1);
+	}
+
+private:
+	bool m_protected = false;
+	int m_index = 0;
+};

--- a/src/lua/LuaPushPull.h
+++ b/src/lua/LuaPushPull.h
@@ -32,6 +32,7 @@ inline void pi_lua_generic_pull(lua_State *l, int index, std::string &out)
 	const char *buf = luaL_checklstring(l, index, &len);
 	std::string(buf, len).swap(out);
 }
+
 template <typename Type>
 inline void LuaPush(lua_State *l, Type value)
 {


### PR DESCRIPTION
If you've not been following my progress on IRC, let me introduce this PR before I get down to the changes.

For quite some time, I've been stymied in my efforts to make sweeping changes to the structure of the codebase by several factors. The largest of these factors has been (obviously) the code hierarchy and the extreme degree of interconnection between seemingly disparate concerns.

This PR doesn't do anything about that.

This PR is aimed at fixing the *second* largest factor, that being the reams of boilerplate one must write to expose a struct with five public members to Lua. Given a struct like so:
```C++
struct MyAwesomeStruct {
    bool aBooleanValue;
    SomeLessAwesomeStruct sadStruct;
    int anIntegerValue;

    void ThisDoesSomething();
    float AwesomeGetter();
};
```
The code required to bind this structure to Lua is so long I have to put it in a foldout for readability (and I only wrote 15% of the code required in this situation!):

<details>

```C++
// ================================================================

static int l_set_aBooleanValue(lua_State *l)
{
    MyAwesomeStruct &obj = LuaObject<MyAwesomeStruct>::CheckFromLua(l, 1);
    bool value = LuaPull<bool>(l, 2);
    obj.aBooleanValue = value;
    return 0;
}

static int l_get_aBooleanValue(lua_State *l)
{
    MyAwesomeStruct &obj = LuaObject<MyAwesomeStruct>::CheckFromLua(l, 1);
    LuaPush<bool>(l, obj.aBooleanValue);
    return 1;
}

// Rinse and repeat for the rest of the parameters...
// - two methods for each two-way value
// - a larger method for each function call
// Six lines of boilerplate minimum for each method

// ================================================================

template<>
const char *LuaObject<MyAwesomeStruct>::s_type = "MyAwesomeStruct";

template<>
void LuaObject<MyAwesomeStruct>::RegisterClass()
{
    static luaL_Reg l_methods[] = {
        { "SetABooleanValue", l_set_aBooleanValue },
        { "GetABooleanValue", l_get_aBooleanValue },
        // + 2 entries for each value
        // + 1 entry for each function
        { NULL, NULL }
    };

    LuaObjectBase::CreateClass(s_type, l_methods, 0, 0);
}
```
</details>

Suffice to say, a ten-line structure takes about 150 lines of tedious, tiresome boilerplate to bind to Lua. So much for rapid prototyping, eh?

Not all hope is lost though. I've spent the past year thinking, and the past week bashing my head against C++'s templates, and managed to completely invert the paradigm used to create Lua bindings. Behold all twenty lines needed to bind our struct:
```C++
template<>
const char *LuaObject<MyAwesomeStruct>::s_type = "MyAwesomeStruct";

template<>
void LuaObject<MyAwesomeStruct>::RegisterClass()
{
    static LuaMetaType<MyAwesomeStruct> metaType(s_type);

    metaType.StartRecording()
        .AddMember("aBooleanValue", &MyAwesomeStruct::aBooleanValue)
        .AddMember("sadStruct", &MyAwesomeStruct::sadStruct)
        .AddMember("anIntegerValue", &MyAwesomeStruct::anIntegerValue)
        .AddFunction("ThisDoesSomething", &MyAwesomeStruct::ThisDoesSomething)
        .AddMember("awesomeGetter", &MyAwesomeStruct::AwesomeGetter)
        .StopRecording();

    LuaObjectBase::CreateClass(metaType);
}
```

Looks completely different, right? "What's the catch?", I'm sure you're asking...

Other than another 500 lines of templates needed to bind pointer-to-members, the 'catch' is very simple - because this depends *heavily* on the `LuaPush` / `LuaPull` mechanism, you'll have to make sure appropriate overloads of `pi_lua_generic_push` et. al. are available for all of the types (including integral types like `uint8_t`) you're binding to Lua, or you might get reams of template deduction failure errors from the compiler. Compile times for the `Lua*.cpp` files might be slightly increased as well, but I'm more than happy to trade hours of programmer time for less than a minute of compile time.

Runtime performance is (almost) completely unaffected - the `__index` metamethod is *slightly* more complicated in some spots, but now much less complicated in others. There's a `__newindex` metamethod, but it's impact is completely negligible... because we had no mechanism to set attributes before.

Another side benefit is that this simplifies working with PropertyMaps as well - once a property is defined, you can simply call `object.hyperdrive_cap = 4` instead of `object:setprop('hyperdrive_cap', 4)`. Obviously, the old methods are still alive and well. (To avoid confusion, a name not present in the property map will instead run through the attributes first... there's some room for improvement here, like assigning to the property map if no attribute with that name was found.)

#### What if I need custom argument checking?

If you need the flexibility that writing every method manually gave you (for e.g. argument-dependent behavior), fear not - you can do that here too! Lambdas and regular functions are supported in all cases - unlike regular `lua_Cfunction`s, the `self` argument is automatically provided for you to reduce the boilerplate needed.

Support for binding 'regular' functions without a self argument is limited right now, though it's certainly possible through the existing `luaL_Reg` mechanism.

```C++
metaType.AddMember("sadStruct", [](lua_State *l, MyAwesomeStruct *st) -> int {
    if (lua_gettop(l) > 2)
        // setter ...
        auto param = LuaPull<MyParameterType>(l, 2);
    else
        // getter ...
});
```

### Changes:

- Add a new system to bind member functions and data types to Lua without requiring the programmer to spend hours writing boilerplate to pull arguments and data out of Lua.

- Replace our existing `__attribute_x` system for attrs with a separate `attrs` table, (slightly) simplifying lookup. Support attribute setters via a `__newindex` metamethod (attribute handlers will be called with an extra parameter corresponding to the setter).

- Don't lean on `luaL_newmetatable` anymore, explicitly store metatypes in the registry table `LuaMetaTypes` for better namespacing and reliable lookup.

