### PR TITLE
Update SIZET_FMT and catch fmt::system_error exception

### DIFF
--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -84,13 +84,17 @@ void Log::Logger::LogLevel(Severity sv, nonstd::string_view message)
 void Log::Logger::WriteLog(Time::DateTime time, Severity sv, nonstd::string_view msg)
 {
 	std::string &svName = s_severityNames.at(sv);
-
-	if (sv <= Severity::Warning) {
-		fmt::print(stderr, "{}: {}", svName, msg);
-	} else if (sv <= m_maxSeverity) {
-		fmt::print(stdout, "{}", msg);
-		// flush stdout because it might have a different cache size than stderr
-		fflush(stdout);
+	try {
+		if (sv <= Severity::Warning) {
+			fmt::print(stderr, "{}: {}", svName, msg);
+		} else if (sv <= m_maxSeverity) {
+			fmt::print(stdout, "{}", msg);
+			// flush stdout because it might have a different cache size than stderr
+			fflush(stdout);
+		}
+	} catch (fmt::system_error) {
+		// stderr or stdout not valid (ie. no console attached)
+		// silently fail (msg will still be written to file if it's open)
 	}
 
 	if (!printCallback.empty()) {

--- a/src/libs.h
+++ b/src/libs.h
@@ -41,11 +41,7 @@
 #endif
 #endif
 
-#ifdef _WIN32 // MSVC doesn't support the %z specifier, but has its own %I specifier
-#define SIZET_FMT "%Iu"
-#else
 #define SIZET_FMT "%zu"
-#endif
 
 #include "fixed.h"
 #include "matrix3x3.h"


### PR DESCRIPTION
Catch and silently ignore fmt::system_error exception when using fmt::print on stdout and stderr. This will occur if there is no console (ie. for Windows builds).
Set SIZET_FMT to "%zu" on all builds now, fmt does not understand the MSVC "%Iu" format.

This and https://github.com/pioneerspacesim/pioneer/pull/4887 should get Pioneer building and running for x64 again in Visual Studio.

Fixes #4888

