### PR TITLE
Add support for IMGUI tabs in pigui

### DIFF
--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -624,6 +624,22 @@ ui.sliderInt = pigui.SliderInt
 ui.pushItemWidth = pigui.PushItemWidth
 ui.popItemWidth = pigui.PopItemWidth
 ui.sliderFloat = pigui.SliderFloat
+
+ui.tabBar = function (id, items)
+	local open = pigui.BeginTabBar(id)
+	if not open then return false end
+
+	for i, v in ipairs(items) do
+		if type(v) == "table" and v[1] and type(v[2]) == "function" then
+			if pigui.BeginTabItem(tostring(v[1]) .. "##" .. tostring(i)) then
+				v[2](v)
+			end
+		end
+	end
+
+	pigui.EndTabBar()
+	return true
+end
 ui.beginTabBar = pigui.BeginTabBar
 ui.beginTabItem = pigui.BeginTabItem
 ui.endTabItem = pigui.EndTabItem

--- a/data/pigui/pigui.lua
+++ b/data/pigui/pigui.lua
@@ -624,6 +624,10 @@ ui.sliderInt = pigui.SliderInt
 ui.pushItemWidth = pigui.PushItemWidth
 ui.popItemWidth = pigui.PopItemWidth
 ui.sliderFloat = pigui.SliderFloat
+ui.beginTabBar = pigui.BeginTabBar
+ui.beginTabItem = pigui.BeginTabItem
+ui.endTabItem = pigui.EndTabItem
+ui.endTabBar = pigui.EndTabBar
 
 -- Flag validation functions. Call with a table of string flags as the only argument.
 ui.SelectableFlags = pigui.SelectableFlags

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -2132,6 +2132,39 @@ static int l_pigui_system_info_view_next_page(lua_State *l)
 	return 0;
 }
 
+static int l_pigui_begin_tab_bar(lua_State *l)
+{
+	PROFILE_SCOPED()
+	std::string str = LuaPull<std::string>(l, 1);
+	ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_None;
+	bool state = ImGui::BeginTabBar(str.c_str(), tab_bar_flags);
+	LuaPush<bool>(l, state);
+	return 1;
+}
+
+static int l_pigui_begin_tab_item(lua_State *l)
+{
+	PROFILE_SCOPED()
+	std::string str = LuaPull<std::string>(l, 1);
+	bool state = ImGui::BeginTabItem(str.c_str());
+	LuaPush<bool>(l, state);
+	return 1;
+}
+
+static int l_pigui_end_tab_bar(lua_State *l)
+{
+	PROFILE_SCOPED()
+	ImGui::EndTabBar();
+	return 0;
+}
+
+static int l_pigui_end_tab_item(lua_State *l)
+{
+	PROFILE_SCOPED()
+	ImGui::EndTabItem();
+	return 0;
+}
+
 static int l_pigui_input_text(lua_State *l)
 {
 	PROFILE_SCOPED()
@@ -2613,6 +2646,10 @@ void LuaObject<PiGui::Instance>::RegisterClass()
 		{ "InputTextFlags", l_pigui_check_input_text_flags },
 		{ "WindowFlags", l_pigui_check_window_flags },
 		{ "HoveredFlags", l_pigui_check_hovered_flags },
+		{ "BeginTabBar", l_pigui_begin_tab_bar },
+		{ "BeginTabItem", l_pigui_begin_tab_item },
+		{ "EndTabBar", l_pigui_end_tab_bar },
+		{ "EndTabItem", l_pigui_end_tab_item },
 		{ 0, 0 }
 	};
 


### PR DESCRIPTION
## Why
I (think I) need this for some experiments I'd like to do on #4795.

## Heads up
I added this code the fastest and easiest way I know, so I'm not betting my life on this code. Especially not:

- where in LuaPigui.cpp it's best to have the functions? Do we even have any convention?

- I hardcoded in the `ImGuiTabBarFlags_None` flag, because 1. I don't know what it does, 2. it wasn't exposed in lua from before and I didn't care to implement exposing a whole tab-flag-thingy, 3. it seems to be what I want for now / I don't know the alternatives

- when we expose the functions in pigui.lua, I do camlecase, with starting letter lowercase.

## Pretty picture
(mouse cursor is removed by screen-shot program, so only tool tip shows)
![2020-06-22-164756_1600x900_scrot](https://user-images.githubusercontent.com/619390/85302614-ae011280-b4a9-11ea-9ca1-1f4183e42f71.png)


