### PR TITLE
Fix MSVC cmake build (#4658)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ if (WIN32)
 	set(CMAKE_INSTALL_BINDIR ${CMAKE_INSTALL_PREFIX})
 endif (WIN32)
 
+# Put the output into the root dir so it can be run from Visual Studio
+if (MSVC)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif (MSVC)
+
 if (MSVC)
 	# Avoid annoying warnings from Visual Studio
 	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
@@ -335,7 +340,7 @@ set_cxx11_properties(${PROJECT_NAME} modelcompiler savegamedump)
 
 if(MSVC)
 	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND xcopy ..\\pioneer-thirdparty\\win32\\bin\\x64\\vs2017\\*.dll $(TargetDir)*.dll /Y /C
+		COMMAND xcopy ..\\pioneer-thirdparty\\win32\\bin\\x64\\vs2017\\*.dll ${TargetDir}*.dll /Y /C
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		COMMENT "copy the dlls into the directory"
 		VERBATIM

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,34 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": []
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        {
+          "name": "CMAKE_BUILD_TYPE",
+          "value": "RelWithDebInfo",
+          "type": "STRING"
+        }
+      ]
+    }
+  ]
+}

--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -4,8 +4,9 @@ Table of Contents
   1.1 Linux - CMake
   1.2 Windows - MSVC
   1.3 Windows - CMake and MSYS2 (and MinGW-w64)
-  1.4 OS X - Homebrew
-  1.5 OS X - CMake and XCode
+  1.4 Windows - CMake and MSVC
+  1.5 OS X - Homebrew
+  1.6 OS X - CMake and XCode
 2 pioneer-thirdparty
   2.1 Linux - Autotools
   2.2 Windows - MSVC
@@ -108,8 +109,29 @@ questions are welcome anytime.
 7. Now, you can go back to the root directory of Pioneer and do './build/pioneer.exe'
    to play the game.
 
+1.4 Windows - CMake and MSVC
+----------------------------
 
-1.4 OS X - Homebrew
+1. Get both the pioneer and the pioneer-thirdparty repositories and keep them
+   in a directory side by side. Don't rename pioneer-thirdparty because the
+   relative path to it is included in the project files.
+
+2. Open Visual Sudio 2019 and do not open a solution or project ('Continue without code').
+
+3. Go to File->Open->CMake and select pioneer/CMakeLists.txt
+
+4. If a Release build is desired, select 'Manage Configurations' under the build type,
+   which will default to x64-Debug and add x64-Release.
+
+5. Select the appropriate build type.
+
+6. Buid the project (Build->Build All).
+
+7. Pioneer can be run and debugged by selecting 'pioneer.exe' on the 
+   'Select Startup Item' toolbar button, and then clicking run.
+
+
+1.5 OS X - Homebrew
 -------------------
 
 1. Install Homebrew package manager (http://brew.sh/) if you don't have one yet.
@@ -123,7 +145,7 @@ questions are welcome anytime.
      brew install --HEAD pioneer
 
 
-1.5 OS X - CMake and XCode
+1.6 OS X - CMake and XCode
 --------------------------
 
 THESE INSTRUCTIONS ARE APPROXIMATE AND ARE UNTESTED; PLEASE SUBMIT CORRECTIONS!

--- a/msvc-defaults.cmake
+++ b/msvc-defaults.cmake
@@ -14,4 +14,4 @@ set(VORBISFILE_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/incl
 set(VORBISFILE_LIBRARIES ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/libogg_static.lib;${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/libvorbis_static.lib;${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/libvorbisfile_static.lib)
 
 set(SIGCPP_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include/sigc++-2.0)
-set(SIGCPP_LIBRARIES ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/sigc-vc140-2_0.lib)
+set(SIGCPP_LIBRARIES optimized ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/sigc-vc140-2_0.lib debug ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/x64/vs2017/sigc-vc140-d-2_0.lib)


### PR DESCRIPTION
This requires https://github.com/pioneerspacesim/pioneer-thirdparty/pull/29

Update SIGCPP_LIBRARIES to use debug version for debug builds
Fix variable name reference in post_build command
Output executables to the root dir when doing MSVC build

fixes #4658 

With this, the cmake build should work again in MSVC for both Release and Debug.

I added the output dir thing so that you can run debug pioneer from within Visual Studio without having to move files around or attaching it manually. 
I may be using it differently, but when I open the CMakeLists.txt in MSVS (File->Open->Cmake) and build, it outputs everything under out/ without this change.