### PR TITLE
Fix crash in-flight if hj-planner has never opened

### DIFF
--- a/data/pigui/modules/hyperjump-planner.lua
+++ b/data/pigui/modules/hyperjump-planner.lua
@@ -139,7 +139,8 @@ end --mainButton
 
 local function buildJumpRouteList()
 	hyperjump_route = {}
-	local start = current_path
+	local player = Game.player
+	local start = Game.system.path
 	local drive = table.unpack(player:GetEquip("engine")) or nil
 	local fuel_type = drive and drive.fuel or Equipment.cargo.hydrogen
 	local current_fuel = player:CountEquip(fuel_type,"cargo")


### PR DESCRIPTION
When the amount of fuel changes on the ship, the function of rebuilding the route strings is called, because colors can change there. The function uses a pointer to the player, which is calculated when the planner window is displayed. If the window never been shown, a reference to the null pointer occurs and the game crashes.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

