### PR TITLE
Fix that sometimes player ends HJ inside a star

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -342,7 +342,8 @@ void Space::GetHyperspaceExitParams(const SystemPath &source, const SystemPath &
 		(max_orbit_vel * max_orbit_vel);
 
 	// ensure an absolute minimum and an absolute maximum distance
-	dist = Clamp(dist, 0.2 * AU, std::max(primary->GetSystemBody()->GetRadius() * 1.1, 100 * AU));
+	// the minimum distance from the center of the star should not be less than the radius of the star
+	dist = Clamp(dist, primary->GetSystemBody()->GetRadius() * 1.1, std::max(primary->GetSystemBody()->GetRadius() * 1.1, 100 * AU));
 
 	// point velocity vector along the line from source to dest,
 	// make exit position perpendicular to it,


### PR DESCRIPTION
Just rigidly set a lower limit of 1.1 * radius of the star.

Fixes #4869
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

