### PR TITLE
No more crashes when hyperjumping

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -320,7 +320,7 @@ HyperdriveType.HyperjumpTo = function (self, ship, destination)
 	return ship:InitiateHyperjumpTo(destination, warmup_time, duration, sounds), fuel_use, duration
 end
 
-HyperdriveType.OnEnterHyperspace = function (self, ship)
+HyperdriveType.OnLeaveHyperspace = function (self, ship)
 	if ship:hasprop('nextJumpFuelUse') then
 		local amount = ship.nextJumpFuelUse
 		ship:RemoveEquip(self.fuel, amount)

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -1015,12 +1015,9 @@ local onEnterSystem = function (ship)
 			end
 		end
 	end
-end
-
-local onLeaveSystem = function (ship)
 	local engine = ship:GetEquip("engine", 1)
 	if engine then
-		engine:OnEnterHyperspace(ship)
+		engine:OnLeaveHyperspace(ship)
 	end
 end
 
@@ -1036,7 +1033,6 @@ local onShipDestroyed = function (ship, attacker)
 end
 
 Event.Register("onEnterSystem", onEnterSystem)
-Event.Register("onLeaveSystem", onLeaveSystem)
 Event.Register("onShipDestroyed", onShipDestroyed)
 Event.Register("onGameStart", onGameStart)
 Serializer:Register("ShipClass", serialize, unserialize)

--- a/data/pigui/modules/hyperjump-planner.lua
+++ b/data/pigui/modules/hyperjump-planner.lua
@@ -78,21 +78,21 @@ local function showInfo()
 		ui.sameLine()
 		-- we can only have the current path in normal space
 		if current_path then
-		local start = current_path
-		-- Tally up totals for the entire jump plan
-		for _,jump in pairs(hyperjump_route) do
-			local status, distance, fuel, duration = player:GetHyperspaceDetails(start, jump.path)
+			local start = current_path
+			-- Tally up totals for the entire jump plan
+			for _,jump in pairs(hyperjump_route) do
+				local status, distance, fuel, duration = player:GetHyperspaceDetails(start, jump.path)
 
-			total_fuel = total_fuel + fuel
-			total_duration = total_duration + duration
-			total_distance = total_distance + distance
+				total_fuel = total_fuel + fuel
+				total_duration = total_duration + duration
+				total_distance = total_distance + distance
 
-			start = jump.path
-		end
+				start = jump.path
+			end
 
-		if ui.selectable(current_system.name .. " (" .. current_path.sectorX .. ", " .. current_path.sectorY .. ", " .. current_path.sectorZ ..")") then
-			sectorView:SwitchToPath(current_path)
-		end
+			if ui.selectable(current_system.name .. " (" .. current_path.sectorX .. ", " .. current_path.sectorY .. ", " .. current_path.sectorZ ..")") then
+				sectorView:SwitchToPath(current_path)
+			end
 		else -- no current path => we are hyperjumping => no current system
 			ui.text("---")
 		end
@@ -189,84 +189,84 @@ end
 local function showJumpRoute()
 	if ui.collapsingHeader(lui.ROUTE_JUMPS, {"DefaultOpen"}) then
 		mainButton(icons.forward, lui.ADD_JUMP,
-			function()
-				sectorView:AddToRoute(map_selected_path)
-				updateHyperspaceTarget()
-				selected_jump = #hyperjump_route
+		function()
+			sectorView:AddToRoute(map_selected_path)
+			updateHyperspaceTarget()
+			selected_jump = #hyperjump_route
 		end)
 		ui.sameLine()
 
 		mainButton(icons.current_line, lui.REMOVE_JUMP,
-			function()
-				local new_route = {}
-				local new_count = 0
-				if selected_jump then
-					sectorView:RemoveRouteItem(selected_jump)
-				end
-				updateHyperspaceTarget()
+		function()
+			local new_route = {}
+			local new_count = 0
+			if selected_jump then
+				sectorView:RemoveRouteItem(selected_jump)
+			end
+			updateHyperspaceTarget()
 		end)
 		ui.sameLine()
 
 		mainButton(icons.current_periapsis, lui.MOVE_UP,
-			function()
-				if selected_jump then
-					if sectorView:MoveRouteItemUp(selected_jump) then
-						selected_jump = selected_jump - 1
-					end
+		function()
+			if selected_jump then
+				if sectorView:MoveRouteItemUp(selected_jump) then
+					selected_jump = selected_jump - 1
 				end
-				updateHyperspaceTarget()
+			end
+			updateHyperspaceTarget()
 		end)
 		ui.sameLine()
 
 		mainButton(icons.current_apoapsis, lui.MOVE_DOWN,
-			function()
-				if selected_jump then
-					if sectorView:MoveRouteItemDown(selected_jump) then
-						selected_jump = selected_jump + 1
-					end
+		function()
+			if selected_jump then
+				if sectorView:MoveRouteItemDown(selected_jump) then
+					selected_jump = selected_jump + 1
 				end
-				updateHyperspaceTarget()
+			end
+			updateHyperspaceTarget()
 		end)
 		ui.sameLine()
 
 		mainButton(icons.retrograde_thin, lui.CLEAR_ROUTE,
-			function()
-				sectorView:ClearRoute()
-				updateHyperspaceTarget()
+		function()
+			sectorView:ClearRoute()
+			updateHyperspaceTarget()
 		end)
 		ui.sameLine()
 
 		mainButton(icons.hyperspace, lui.AUTO_ROUTE,
-			function()
-				local result = sectorView:AutoRoute()
-				if result == "NO_DRIVE" then
-					mb.OK(lui.NO_DRIVE)
-				elseif result == "NO_VALID_ROUTE" then
-					mb.OK(lui.NO_VALID_ROUTE)
-				end
-				updateHyperspaceTarget()
+		function()
+			local result = sectorView:AutoRoute()
+			if result == "NO_DRIVE" then
+				mb.OK(lui.NO_DRIVE)
+			elseif result == "NO_VALID_ROUTE" then
+				mb.OK(lui.NO_VALID_ROUTE)
+			end
+			updateHyperspaceTarget()
 		end)
 		ui.sameLine()
 
 		mainButton(icons.search_lens, lui.CENTER_ON_SYSTEM,
-			function()
-				if selected_jump then
-					sectorView:GotoSystemPath(hyperjump_route[selected_jump].path)
-				end
+		function()
+			if selected_jump then
+				sectorView:GotoSystemPath(hyperjump_route[selected_jump].path)
+			end
 		end)
 
 		ui.separator()
 
 		local clicked
 		ui.child("routelist", function()
-		for jumpIndex, jump in pairs(hyperjump_route) do
-			ui.withStyleColors({["Text"] = jump.color},
+			for jumpIndex, jump in pairs(hyperjump_route) do
+				ui.withStyleColors({["Text"] = jump.color},
 				function()
 					if ui.selectable(jump.textLine, jumpIndex == selected_jump) then
 						clicked = jumpIndex
 					end
-			end)
-		end -- for
+				end)
+			end -- for
 		end --function
 		)
 
@@ -293,13 +293,13 @@ function hyperJumpPlanner.updateInRoute(path)
 end
 
 local function showHyperJumpPlannerWindow()
-				textIcon(icons.route)
-				ui.sameLine()
-				ui.text(lui.HYPERJUMP_ROUTE)
-				ui.separator()
-				showInfo()
-				ui.separator()
-				showJumpRoute()
+	textIcon(icons.route)
+	ui.sameLine()
+	ui.text(lui.HYPERJUMP_ROUTE)
+	ui.separator()
+	showInfo()
+	ui.separator()
+	showJumpRoute()
 end -- showHyperJumpPlannerWindow
 
 function hyperJumpPlanner.Dummy()
@@ -337,17 +337,17 @@ end
 function hyperJumpPlanner.display()
 	player = Game.player
 	if not textIconSize then
-			textIconSize = ui.calcTextSize("H")
-			textIconSize.x = textIconSize.y -- make square
+		textIconSize = ui.calcTextSize("H")
+		textIconSize.x = textIconSize.y -- make square
 	end
-		local drive = table.unpack(player:GetEquip("engine")) or nil
-		local fuel_type = drive and drive.fuel or Equipment.cargo.hydrogen
-		current_system = Game.system -- will be nil during the hyperjump
-		current_path = Game.system and current_system.path -- will be nil during the hyperjump
-		current_fuel = player:CountEquip(fuel_type,"cargo")
-		map_selected_path = sectorView:GetSelectedSystemPath()
-		route_jumps = sectorView:GetRouteSize()
-		showHyperJumpPlannerWindow()
+	local drive = table.unpack(player:GetEquip("engine")) or nil
+	local fuel_type = drive and drive.fuel or Equipment.cargo.hydrogen
+	current_system = Game.system -- will be nil during the hyperjump
+	current_path = Game.system and current_system.path -- will be nil during the hyperjump
+	current_fuel = player:CountEquip(fuel_type,"cargo")
+	map_selected_path = sectorView:GetSelectedSystemPath()
+	route_jumps = sectorView:GetRouteSize()
+	showHyperJumpPlannerWindow()
 end -- hyperJumpPlanner.display
 
 function hyperJumpPlanner.setSectorView(sv)
@@ -361,14 +361,14 @@ function hyperJumpPlanner.onShipEquipmentChanged(ship, equipment)
 end
 
 function hyperJumpPlanner.onEnterSystem(ship)
-		-- remove the first jump if it's the current system (and enabled to do so)
-		-- this should be the case if you are following a route and want the route to be
-		-- updated as you make multiple jumps
-		if ship:IsPlayer() and remove_first_if_current then
-			if route_jumps > 0 and hyperjump_route[1].path:IsSameSystem(Game.system.path) then
-				sectorView:RemoveRouteItem(1)
-			end
+	-- remove the first jump if it's the current system (and enabled to do so)
+	-- this should be the case if you are following a route and want the route to be
+	-- updated as you make multiple jumps
+	if ship:IsPlayer() and remove_first_if_current then
+		if route_jumps > 0 and hyperjump_route[1].path:IsSameSystem(Game.system.path) then
+			sectorView:RemoveRouteItem(1)
 		end
+	end
 	updateHyperspaceTarget()
 end
 

--- a/data/pigui/modules/hyperjump-planner.lua
+++ b/data/pigui/modules/hyperjump-planner.lua
@@ -74,6 +74,10 @@ local function showInfo()
 		local total_duration = 0
 		local total_distance = 0
 
+		textIcon(icons.display_navtarget, lui.CURRENT_SYSTEM)
+		ui.sameLine()
+		-- we can only have the current path in normal space
+		if current_path then
 		local start = current_path
 		-- Tally up totals for the entire jump plan
 		for _,jump in pairs(hyperjump_route) do
@@ -86,10 +90,11 @@ local function showInfo()
 			start = jump.path
 		end
 
-		textIcon(icons.display_navtarget, lui.CURRENT_SYSTEM)
-		ui.sameLine()
 		if ui.selectable(current_system.name .. " (" .. current_path.sectorX .. ", " .. current_path.sectorY .. ", " .. current_path.sectorZ ..")") then
 			sectorView:SwitchToPath(current_path)
+		end
+		else -- no current path => we are hyperjumping => no current system
+			ui.text("---")
 		end
 
 		textIcon(icons.route_destination, lui.FINAL_TARGET)
@@ -337,8 +342,8 @@ function hyperJumpPlanner.display()
 	end
 		local drive = table.unpack(player:GetEquip("engine")) or nil
 		local fuel_type = drive and drive.fuel or Equipment.cargo.hydrogen
-		current_system = Game.system
-		current_path = current_system.path
+		current_system = Game.system -- will be nil during the hyperjump
+		current_path = Game.system and current_system.path -- will be nil during the hyperjump
 		current_fuel = player:CountEquip(fuel_type,"cargo")
 		map_selected_path = sectorView:GetSelectedSystemPath()
 		route_jumps = sectorView:GetRouteSize()

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -566,7 +566,7 @@ local hideSystemViewWindows = false
 local function displaySystemViewUI()
 	player = Game.player
 	local current_view = Game.CurrentView()
-	if current_view == "system" and not Game.InHyperspace() then
+	if current_view == "system" then
 		if dummyFrames > 0 then -- do it a few frames, because imgui need a few frames to make the correct window size
 
 			-- first, doing some one-time actions here

--- a/src/AnimationCurves.h
+++ b/src/AnimationCurves.h
@@ -5,6 +5,8 @@
 #define ANIMATIONCURVES_H
 
 #include "FloatComparison.h"
+#include "Pi.h"
+#include <cmath>
 
 namespace AnimationCurves {
 
@@ -24,6 +26,37 @@ namespace AnimationCurves {
 		// clamp to target (independent of the direction of motion)
 		const T newDelta(target - cur);
 		if (newDelta * delta < 0) cur = target;
+	}
+
+	// easing from https://github.com/Michaelangel007/easing#tldr-shut-up-and-show-me-the-code
+	// p should go from 0.0 to 1.0
+	inline float InOutQuadraticEasing(float p)
+	{
+		float m = p - 1.0;
+		float t = p * 2.0;
+		if (t < 1)
+			return p * t;
+		else
+			return 1.0 - m * m * 2.0;
+	}
+
+	// easing from https://github.com/Michaelangel007/easing#tldr-shut-up-and-show-me-the-code
+	// p should go from 0.0 to 1.0
+	inline float InOutCubicEasing(float p)
+	{
+		float m = p - 1.0;
+		float t = p * 2.0;
+		if (t < 1)
+			return p * t * t;
+		else
+			return 1.0 + m * m * m * 4.0;
+	}
+
+	// easing from https://github.com/Michaelangel007/easing#tldr-shut-up-and-show-me-the-code
+	// p should go from 0.0 to 1.0
+	inline float InOutSineEasing(float p)
+	{
+		return 0.5 * (1.0 - std::cos(p * M_PI));
 	}
 
 } // namespace AnimationCurves

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -289,6 +289,14 @@ void Game::TimeStep(float step)
 		if (Pi::game->GetTime() >= m_hyperspaceEndTime) {
 			SwitchToNormalSpace();
 			m_player->EnterSystem();
+			// event "onEnterSystem(player)" is in the event queue after p_player->EnterSystem()
+			// in this callback, for example, fuel is reduced
+			// but event handling has already passed, and will only be in the next frame
+			// it turns out that we are already in the system, but the fuel has not yet been reduced
+			// and then the drawing of the views will go, and inconsistencies may occur,
+			// for example, the sphere of the hyperjump range will be too large
+			// so we forcefully call event handling again
+			LuaEvent::Emit();
 			RequestTimeAccel(TIMEACCEL_1X);
 		} else
 			m_hyperspaceProgress += step;

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -3,6 +3,7 @@
 
 #include "SectorView.h"
 
+#include "AnimationCurves.h"
 #include "Game.h"
 #include "GameConfig.h"
 #include "GameSaveError.h"
@@ -305,7 +306,7 @@ void SectorView::Draw3D()
 		const vector3f dstPos = Sector::SIZE * vector3f(float(dstPath.sectorX), float(dstPath.sectorY), float(dstPath.sectorZ)) + dstSystem.GetPosition();
 		// jumpProcess: 0.0f (at source) .. 1.0f (at destination)
 		// smoothing speed at the ends with cubic interpolation
-		const float jumpProcess = InOutCubicEasing(Pi::game->GetHyperspaceProgress() / Pi::game->GetHyperspaceDuration());
+		const float jumpProcess = AnimationCurves::InOutCubicEasing(Pi::game->GetHyperspaceProgress() / Pi::game->GetHyperspaceDuration());
 		// player location indicator's size of the star, on which it is drawn
 		// so we interpolate it too
 		const float dstStarSize = StarSystem::starScale[dstSystem.GetStarType(0)];

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -119,7 +119,7 @@ private:
 	};
 
 	void DrawNearSectors(const matrix4x4f &modelview);
-	void DrawNearSector(const int sx, const int sy, const int sz, const vector3f &playerAbsPos, const matrix4x4f &trans);
+	void DrawNearSector(const int sx, const int sy, const int sz, const matrix4x4f &trans);
 	void PutSystemLabels(RefCountedPtr<Sector> sec, const vector3f &origin, int drawRadius);
 
 	void DrawFarSectors(const matrix4x4f &modelview);

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -547,7 +547,7 @@ void SystemView::Draw3D()
 	}
 	// glLineWidth(1);
 
-	if (m_game->GetSpace()->GetStarSystem()->GetPath().IsSameSystem(m_game->GetSectorView()->GetSelected())) {
+	if (m_game->IsNormalSpace() && m_game->GetSpace()->GetStarSystem()->GetPath().IsSameSystem(m_game->GetSectorView()->GetSelected())) {
 		// draw ships
 		if (m_shipDrawing != OFF) {
 			RefreshShips();

--- a/src/utils.h
+++ b/src/utils.h
@@ -269,6 +269,18 @@ static inline Uint32 ceil_pow2(Uint32 v)
 	return v;
 }
 
+// easing from https://github.com/Michaelangel007/easing#tldr-shut-up-and-show-me-the-code
+// p should go from 0.0 to 1.0
+inline float InOutCubicEasing(float p)
+{
+	float m = p - 1;
+	float t = p * 2;
+	if (t < 1)
+		return p * t * t;
+	else
+		return 1 + m * m * m * 4;
+}
+
 void hexdump(const unsigned char *buf, int bufsz);
 
 #endif /* _UTILS_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -269,18 +269,6 @@ static inline Uint32 ceil_pow2(Uint32 v)
 	return v;
 }
 
-// easing from https://github.com/Michaelangel007/easing#tldr-shut-up-and-show-me-the-code
-// p should go from 0.0 to 1.0
-inline float InOutCubicEasing(float p)
-{
-	float m = p - 1;
-	float t = p * 2;
-	if (t < 1)
-		return p * t * t;
-	else
-		return 1 + m * m * m * 4;
-}
-
 void hexdump(const unsigned char *buf, int bufsz);
 
 #endif /* _UTILS_H */


### PR DESCRIPTION
## Commits

<strike>

### Notify the camera when the ship changes the frame

Since the camera is not tied to the ship, but to the frame of the ship, when the frame changes, the information in the camera becomes irrelevant. If the worldview is active, it is quickly updated, but if the worldview is not active, an accident occurs.
This patch fixes a crash when hyper jumping with an open info screen.

### Rename CameraContext vars to cameraContext (optional)

Many variables of type CameraContext are called camera, and this seems to be confusing because there is also a type Camera, and variables of this type, also called "camera" or something like that.
</strike>

_The problem with info screens was resolved in #4941_
### Fix crashes when hyperjump with a map opened
![ezgif-2-f0135cd12af1](https://user-images.githubusercontent.com/18342621/92323063-44bb8500-f03e-11ea-96d9-ab696148fa9a.gif)
Fixes #4901

**System map:** add a check to see if we are in hyperspace

**Sector map:**
 - move the drawing of the player's indicator from `DrawNearSector` up to `Draw3D`
 - calculate the interpolated position of the player's indicator during a hyperjump
 - don't display current system during hyperjump (lua-side)
 - fix selected system indicator (green circle), it pointed not to the the selected system, but to the current system

**Also:**
 - add easing function into `utils.cpp` to smooth the movement of the player indicator
 - move fuel reduction from the start of the hyperjump to the end
 - force handling of lua events immediately after entering system

### Indent hyperjump-planner.lua

## TODO:
- [x] Fix crash in the system map.
- [x] Fix crash in the sector map.
- [x] Show player movement between systems in the sector map

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

