### PR TITLE
Set hyperdrive last service date to game start date for new games.

### DIFF
--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -225,7 +225,7 @@ local onGameStart = function ()
 
 	if not loaded_data then
 		service_history = {
-			lastdate = 0, -- Default will be overwritten on game start
+			lastdate = Game.time,
 			company = nil, -- Name of company that did the last service
 			service_period = oneyear, -- default
 			jumpcount = 0, -- Number of jumps made after the service_period


### PR DESCRIPTION
This sets the hyperdrive last service date to the game start date for new games. Currently, the hyperdrive service date is still set to Jan 1 3200 for new games:
![image](https://user-images.githubusercontent.com/7342077/87113699-de340980-c23c-11ea-819d-214859dd1006.png)

Currently, that means that new games start with a hyperdrive that is 19 years out of service! 

A new game after this change:
![image](https://user-images.githubusercontent.com/7342077/87113831-294e1c80-c23d-11ea-9cfd-5b2a15006306.png)

Also in regards to the likelihood of the hyperdrive breaking:
Perhaps I'm particularly unlucky, but it would seem that a breakdown becomes fairly likely above 15 jumps after the service period ends. Just doing some quick testing, I got the drive to break 4 times in a row (out of 4 test runs) in the 13-17 jump range. I don't think this is necessarily bad, but it's not anywhere close to the maximum in BreakdownServicing.lua (255), and the likelihood of a random number being less than 0.0588 (~ 15/255) seems like it wouldn't be a given (the test is `Engine.rand:Number() < service_history.jumpcount / max_jumps_unserviced`). 
Actually, if I'm thinking about this correctly, the chance that the drive will break after 15 jumps should be about 5.8% (if random is perfectly random , etc.). Each jump after the service period ends should increase the likelihood of the drive breaking by just under 0.4% each time.

Out of curiosity, I ran 1 million random numbers (`Engine.rand:Number()`) and it's not favoring either end, so perhaps I am just that unlucky?
![image](https://user-images.githubusercontent.com/7342077/87114361-5ea73a00-c23e-11ea-8684-2ec0534b5fcb.png)
