### PR TITLE
Add alternative naming schemes

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,7 @@
 January 2021
    * New Features
      * New scoop mission (#4860)
+	 * Add alternative naming schemes (#4933)
 
    * Internal Changes
      * Happy new year (#5105)

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -57,7 +57,17 @@ namespace HybridNames {
 		"orn", "il", "iel", "im",
 		"uk", "ium", "ia", "eon",
 		"ob", "ak", "arg", "ber",
-		"ane", "esh", "ad", "un"
+		"ane", "esh", "ad", "un",
+
+		//WKFO
+		"ank", "bur", "ist", "iz",
+		"erz", "tra", "shir", "gu",
+		"ant", "kon", "ya", "us",
+		"esk", "ig", "kah", "zon",
+		"tay", "ash", "mar", "van",
+		"sus", "tar", "run", "isk",
+		"hir", "gaz", "sun", "gat",
+		"pi", "cis", "ele", "ova"
 	};
 	static const unsigned int SYS_NAME_FRAGS = ((unsigned int)(sizeof(sys_names) / sizeof(char *)));
 

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -28,7 +28,7 @@ namespace FrontierNames {
 
 	void GetName(std::string &name, Random &rng)
 	{
-		/* well done. you get a real name  */
+		// add fragments to build a name
 		int len = rng.Int32(2, 3);
 		for (int i = 0; i < len; i++) {
 			name += sys_names[rng.Int32(0, SYS_NAME_FRAGS - 1)];
@@ -63,7 +63,7 @@ namespace HybridNames {
 
 	void GetName(std::string &name, Random &rng)
 	{
-		/* well done. you get a real name  */
+		// add fragments to build a name
 		int len = rng.Int32(2, 3);
 		for (int i = 0; i < len; i++) {
 			name += sys_names[rng.Int32(0, SYS_NAME_FRAGS - 1)];
@@ -134,8 +134,8 @@ namespace Katakana {
 
 	void GetName(std::string &name, Random &rng)
 	{
-		/* well done. you get a real name  */
-		int len = rng.Int32(2, 3);
+		// add fragments to build a name
+		int len = rng.Int32(2, 4);
 		for (int i = 0; i < len; i++) {
 			name += KatakanaFragments[rng.Int32(0, KATAKANA_FRAGS - 1)];
 		}
@@ -235,6 +235,7 @@ const std::string SectorRandomSystemsGenerator::GenName(RefCountedPtr<Galaxy> ga
 
 	Uint32 weight = rng.Int32(chance);
 	if (weight < 500 || galaxy->GetFactions()->IsHomeSystem(SystemPath(sx, sy, sz, si))) {
+		// well done. you get a "real" name
 		int nameGen = rng.Int32(0, 3);
 		switch (nameGen) {
 		case 0: FrontierNames::GetName(name, rng); break;

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -13,10 +13,136 @@
 
 #define Square(x) ((x) * (x))
 
-static const unsigned int SYS_NAME_FRAGS = 32;
-static const char *sys_names[SYS_NAME_FRAGS] = { "en", "la", "can", "be", "and", "phi", "eth", "ol", "ve", "ho", "a",
-	"lia", "an", "ar", "ur", "mi", "in", "ti", "qu", "so", "ed", "ess",
-	"ex", "io", "ce", "ze", "fa", "ay", "wa", "da", "ack", "gre" };
+namespace FrontierNames {
+	static const char *sys_names[] = {
+		"en", "la", "can", "be",
+		"and", "phi", "eth", "ol",
+		"ve", "ho", "a", "lia",
+		"an", "ar", "ur", "mi",
+		"in", "ti", "qu", "so",
+		"ed", "ess", "ex", "io",
+		"ce", "ze", "fa", "ay",
+		"wa", "da", "ack", "gre"
+	};
+	static const unsigned int SYS_NAME_FRAGS = ((unsigned int)(sizeof(sys_names) / sizeof(char *)));
+
+	void GetName(std::string &name, Random &rng)
+	{
+		/* well done. you get a real name  */
+		int len = rng.Int32(2, 3);
+		for (int i = 0; i < len; i++) {
+			name += sys_names[rng.Int32(0, SYS_NAME_FRAGS - 1)];
+		}
+
+		name[0] = toupper(name[0]);
+	}
+} // namespace FrontierNames
+
+namespace HybridNames {
+	static const char *sys_names[] = {
+		"en", "la", "can", "be",
+		"and", "phi", "eth", "ol",
+		"ve", "ho", "a", "lia",
+		"an", "ar", "ur", "mi",
+		"in", "ti", "qu", "so",
+		"ed", "ess", "ex", "io",
+		"ce", "ze", "fa", "ay",
+		"wa", "da", "ack", "gre",
+
+		//Doomdark-esque additions
+		"img", "or", "ir", "dol",
+		"orth", "angr", "igr", "ash",
+		"el", "mor", "ul", "atr",
+		"orm", "udr", "is", "ildr",
+		"orn", "il", "iel", "im",
+		"uk", "ium", "ia", "eon",
+		"ob", "ak", "arg", "ber",
+		"ane", "esh", "ad", "un"
+	};
+	static const unsigned int SYS_NAME_FRAGS = ((unsigned int)(sizeof(sys_names) / sizeof(char *)));
+
+	void GetName(std::string &name, Random &rng)
+	{
+		/* well done. you get a real name  */
+		int len = rng.Int32(2, 3);
+		for (int i = 0; i < len; i++) {
+			name += sys_names[rng.Int32(0, SYS_NAME_FRAGS - 1)];
+		}
+
+		name[0] = toupper(name[0]);
+	}
+} // namespace HybridNames
+
+namespace Doomdark {
+	static const char *Prefixes[] = {
+		"img", "dol", "lor", "ush", "mor", "tal", "car", "ulf", "as", "tor", "ob", "f", "gl",
+		"s", "th", "gan", "mal", "im", "var", "hag", "zar", "anv", "ber", "kah", "ash"
+	};
+	static const unsigned int PREFIX_FRAGS = ((unsigned int)(sizeof(Prefixes) / sizeof(char *)));
+
+	static const char *Midwords[] = {
+		"ar", "or", "ir", "en", "orth", "angr", "igr", "ash", "el", "in", "ul", "atr", "orm", "udr", "is", "ildr"
+	};
+	static const unsigned int MIDWORD_FRAGS = ((unsigned int)(sizeof(Midwords) / sizeof(char *)));
+
+	static const char *Suffixes[] = {
+		"orn", "il", "iel", "im", "uk", "ium", "ia", "eon", "ay", "ak", "arg", "and", "ane", "esh", "ad", "un"
+	};
+	static const unsigned int SUFFIX_FRAGS = ((unsigned int)(sizeof(Suffixes) / sizeof(char *)));
+
+	void GetName(std::string &name, Random &rng)
+	{
+		// Doodarken a name
+		name += Prefixes[rng.Int32(0, PREFIX_FRAGS - 1)];
+		name += Midwords[rng.Int32(0, MIDWORD_FRAGS - 1)];
+		name += Suffixes[rng.Int32(0, SUFFIX_FRAGS - 1)];
+
+		name[0] = toupper(name[0]);
+	}
+} // namespace Doomdark
+
+namespace Katakana {
+	static const char *KatakanaFragments[] = {
+		"a", "i", "u", "e", "o",
+		"ka", "ki", "ku", "ke", "ko",
+		"ga", "gi", "gu", "ge", "go",
+		"sa", "shi", "su", "se", "so",
+		"za", "ji", "zu", "ze", "zo",
+		"ta", "chi", "tsu", "te", "to",
+		"da", "ji", "zu", "de", "do",
+		"na", "ni", "nu", "ne", "no",
+		"ha", "hi", "fu", "he", "ho",
+		"ba", "bi", "bu", "be", "bo",
+		"pa", "pi", "pu", "pe", "po",
+		"ma", "mi", "mu", "me", "mo",
+		"ya", "yu", "yo",
+		"ra", "ri", "ru", "re", "ro",
+		"wa", "wo",
+		"kya", "kyu", "kyo",
+		"gya", "gyu", "gyo",
+		"sha", "shu", "sho",
+		"ja", "ju", "jo",
+		"cha", "chu", "cho",
+		"nya", "nyu", "nyo",
+		"hya", "hyu", "hyo",
+		"bya", "byu", "byo",
+		"pya", "pyu", "pyo",
+		"mya", "myu", "myo",
+		"rya", "ryu", "ryo"
+	};
+	static const unsigned int KATAKANA_FRAGS = ((unsigned int)(sizeof(KatakanaFragments) / sizeof(char *)));
+
+	void GetName(std::string &name, Random &rng)
+	{
+		/* well done. you get a real name  */
+		int len = rng.Int32(2, 3);
+		for (int i = 0; i < len; i++) {
+			name += KatakanaFragments[rng.Int32(0, KATAKANA_FRAGS - 1)];
+		}
+
+		name[0] = toupper(name[0]);
+	}
+} // namespace Katakana
 
 bool SectorCustomSystemsGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<Sector> sector, GalaxyGenerator::SectorConfig *config)
 {
@@ -109,12 +235,16 @@ const std::string SectorRandomSystemsGenerator::GenName(RefCountedPtr<Galaxy> ga
 
 	Uint32 weight = rng.Int32(chance);
 	if (weight < 500 || galaxy->GetFactions()->IsHomeSystem(SystemPath(sx, sy, sz, si))) {
-		/* well done. you get a real name  */
-		int len = rng.Int32(2, 3);
-		for (int i = 0; i < len; i++) {
-			name += sys_names[rng.Int32(0, SYS_NAME_FRAGS - 1)];
+		int nameGen = rng.Int32(0, 3);
+		switch (nameGen) {
+		case 0: FrontierNames::GetName(name, rng); break;
+		case 1: HybridNames::GetName(name, rng); break;
+		case 2: Doomdark::GetName(name, rng); break;
+		case 3: Katakana::GetName(name, rng); break;
+		default:
+			FrontierNames::GetName(name, rng); 
+			break;
 		}
-		name[0] = toupper(name[0]);
 		return name;
 	} else if (weight < 800) {
 		char buf[128];
@@ -240,7 +370,7 @@ bool SectorRandomSystemsGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> gala
 				s.m_starType[0] = SystemBody::TYPE_STAR_M_GIANT;
 			} else if (weight < 800) {
 				s.m_starType[0] = SystemBody::TYPE_STAR_O; // should be 1 but that is boring
-			} else if (weight < 2000) { // weight < 1300 / 20500
+			} else if (weight < 2000) {					   // weight < 1300 / 20500
 				s.m_starType[0] = SystemBody::TYPE_STAR_B;
 			} else if (weight < 8000) { // weight < 7300
 				s.m_starType[0] = SystemBody::TYPE_STAR_A;

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -22,7 +22,7 @@ namespace FrontierNames {
 		"in", "ti", "qu", "so",
 		"ed", "ess", "ex", "io",
 		"ce", "ze", "fa", "ay",
-		"wa", "da", "ack", "gre"
+		"wa", "de", "ack", "gre"
 	};
 	static const unsigned int SYS_NAME_FRAGS = ((unsigned int)(sizeof(sys_names) / sizeof(char *)));
 
@@ -47,7 +47,7 @@ namespace HybridNames {
 		"in", "ti", "qu", "so",
 		"ed", "ess", "ex", "io",
 		"ce", "ze", "fa", "ay",
-		"wa", "da", "ack", "gre",
+		"wa", "de", "ack", "gre",
 
 		//Doomdark-esque additions
 		"img", "or", "ir", "dol",

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -112,7 +112,8 @@ namespace Doomdark {
 } // namespace Doomdark
 
 namespace Katakana {
-	static const char* StartFragments[] = {
+	// clang-format off
+	static const char *StartFragments[] = {
 		"kyo","gyo","shu","sho","chu","cho","hyu","myo",
 		"ryu","chi","tsu","shi","ka","ki","ku","ke",
 		"ko","ga","gi","gu","ge","go","sa","su",
@@ -123,7 +124,7 @@ namespace Katakana {
 		"ru","wa","jo","a","i","u","e","o",
 		
 	};
-	static const char* MiddleFragments[] = {
+	static const char *MiddleFragments[] = {
 		"sshi","ppo","tto","mbo","kka","kyu","sho","chu",
 		"chi","tsu","shi","ka","ki","ku","ke","ko",
 		"ga","gi","gu","ge","go","sa","su","se",
@@ -134,7 +135,7 @@ namespace Katakana {
 		"ra","ri","ru","re","ro","wa","ju","jo",
 		"a","i","u","e","o","n",
 	};
-	static const char* EndFragments[] = {
+	static const char *EndFragments[] = {
 		"ttsu","ppu","ssa","tto","tte","noh","mba","kko",
 		"kyo","shu","chu","nyu","nyo","ryu","chi","tsu",
 		"shi","ka","ki","ku","ke","ko","ga","gi",
@@ -146,10 +147,11 @@ namespace Katakana {
 		"ru","re","ro","wa","ja","jo","i","e",
 		"o","n",
 	};
+	// clang-format on
 
-	static const unsigned int NUM_START_FRAGS = ((unsigned int)(sizeof(StartFragments) / sizeof(char*)));
-	static const unsigned int NUM_MIDDLE_FRAGS = ((unsigned int)(sizeof(MiddleFragments) / sizeof(char*)));
-	static const unsigned int NUM_END_FRAGS = ((unsigned int)(sizeof(EndFragments) / sizeof(char*))); 
+	static const unsigned int NUM_START_FRAGS = COUNTOF(StartFragments);
+	static const unsigned int NUM_MIDDLE_FRAGS = COUNTOF(MiddleFragments);
+	static const unsigned int NUM_END_FRAGS = COUNTOF(EndFragments);
 
 	void GetName(std::string &name, Random &rng)
 	{
@@ -158,8 +160,7 @@ namespace Katakana {
 
 		// middle
 		size_t count = rng.Int32(0, 2);
-		for (size_t i = 0; i < count; i++)
-		{
+		for (size_t i = 0; i < count; i++) {
 			name += MiddleFragments[rng.Int32(0, NUM_MIDDLE_FRAGS - 1)];
 		}
 
@@ -270,7 +271,7 @@ const std::string SectorRandomSystemsGenerator::GenName(RefCountedPtr<Galaxy> ga
 		case 2: Doomdark::GetName(name, rng); break;
 		case 3: Katakana::GetName(name, rng); break;
 		default:
-			FrontierNames::GetName(name, rng); 
+			FrontierNames::GetName(name, rng);
 			break;
 		}
 		return name;

--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -112,44 +112,61 @@ namespace Doomdark {
 } // namespace Doomdark
 
 namespace Katakana {
-	static const char *KatakanaFragments[] = {
-		"a", "i", "u", "e", "o",
-		"ka", "ki", "ku", "ke", "ko",
-		"ga", "gi", "gu", "ge", "go",
-		"sa", "shi", "su", "se", "so",
-		"za", "ji", "zu", "ze", "zo",
-		"ta", "chi", "tsu", "te", "to",
-		"da", "ji", "zu", "de", "do",
-		"na", "ni", "nu", "ne", "no",
-		"ha", "hi", "fu", "he", "ho",
-		"ba", "bi", "bu", "be", "bo",
-		"pa", "pi", "pu", "pe", "po",
-		"ma", "mi", "mu", "me", "mo",
-		"ya", "yu", "yo",
-		"ra", "ri", "ru", "re", "ro",
-		"wa", "wo",
-		"kya", "kyu", "kyo",
-		"gya", "gyu", "gyo",
-		"sha", "shu", "sho",
-		"ja", "ju", "jo",
-		"cha", "chu", "cho",
-		"nya", "nyu", "nyo",
-		"hya", "hyu", "hyo",
-		"bya", "byu", "byo",
-		"pya", "pyu", "pyo",
-		"mya", "myu", "myo",
-		"rya", "ryu", "ryo"
+	static const char* StartFragments[] = {
+		"kyo","gyo","shu","sho","chu","cho","hyu","myo",
+		"ryu","chi","tsu","shi","ka","ki","ku","ke",
+		"ko","ga","gi","gu","ge","go","sa","su",
+		"se","so","za","zu","ze","ta","te","to",
+		"da","na","ni","nu","ne","no","ha","hi",
+		"fu","he","ho","ba","bi","bu","be","ma",
+		"mi","mu","me","mo","ya","yu","yo","ri",
+		"ru","wa","jo","a","i","u","e","o",
+		
 	};
-	static const unsigned int KATAKANA_FRAGS = ((unsigned int)(sizeof(KatakanaFragments) / sizeof(char *)));
+	static const char* MiddleFragments[] = {
+		"sshi","ppo","tto","mbo","kka","kyu","sho","chu",
+		"chi","tsu","shi","ka","ki","ku","ke","ko",
+		"ga","gi","gu","ge","go","sa","su","se",
+		"so","za","ji","zu","ze","ta","te","to",
+		"da","de","do","na","ni","nu","ne","no",
+		"ha","hi","fu","ho","ba","bi","bu","be",
+		"bo","ma","mi","mu","me","mo","ya","yo",
+		"ra","ri","ru","re","ro","wa","ju","jo",
+		"a","i","u","e","o","n",
+	};
+	static const char* EndFragments[] = {
+		"ttsu","ppu","ssa","tto","tte","noh","mba","kko",
+		"kyo","shu","chu","nyu","nyo","ryu","chi","tsu",
+		"shi","ka","ki","ku","ke","ko","ga","gi",
+		"gu","go","sa","su","se","so","za","ji",
+		"zu","ze","zo","ta","te","to","da","de",
+		"do","na","ni","ne","no","ha","hi","fu",
+		"he","ho","ba","bi","bu","be","bo","ma",
+		"mi","mu","me","mo","ya","yo","ra","ri",
+		"ru","re","ro","wa","ja","jo","i","e",
+		"o","n",
+	};
+
+	static const unsigned int NUM_START_FRAGS = ((unsigned int)(sizeof(StartFragments) / sizeof(char*)));
+	static const unsigned int NUM_MIDDLE_FRAGS = ((unsigned int)(sizeof(MiddleFragments) / sizeof(char*)));
+	static const unsigned int NUM_END_FRAGS = ((unsigned int)(sizeof(EndFragments) / sizeof(char*))); 
 
 	void GetName(std::string &name, Random &rng)
 	{
-		// add fragments to build a name
-		int len = rng.Int32(2, 4);
-		for (int i = 0; i < len; i++) {
-			name += KatakanaFragments[rng.Int32(0, KATAKANA_FRAGS - 1)];
+		// beginning
+		name += StartFragments[rng.Int32(0, NUM_START_FRAGS - 1)];
+
+		// middle
+		size_t count = rng.Int32(0, 2);
+		for (size_t i = 0; i < count; i++)
+		{
+			name += MiddleFragments[rng.Int32(0, NUM_MIDDLE_FRAGS - 1)];
 		}
 
+		// end
+		name += EndFragments[rng.Int32(0, NUM_END_FRAGS - 1)];
+
+		// Capitalisation
 		name[0] = toupper(name[0]);
 	}
 } // namespace Katakana


### PR DESCRIPTION
Duplicate and extend the Frontier naming to create a hybrid, semi-replicate Doomdarks naming system, add naming fragements based on Japanese Katakana.

Then pick between all four possibilities when naming a star system.

Fixes #4866

Things to consider:
- swearwords http://www.youswear.com/?language=Japanese
- ~~lack of randomness sometimes "anda"~~
