### PR TITLE
Fix the build with USE_SYSTEM_LIBLUA.

### DIFF
--- a/src/lua/LuaMetaType.h
+++ b/src/lua/LuaMetaType.h
@@ -8,7 +8,6 @@
 #include "LuaManager.h"
 #include "LuaPushPull.h"
 #include "LuaTable.h"
-#include "src/lua.h"
 
 class LuaMetaTypeBase {
 public:


### PR DESCRIPTION
Fixes https://github.com/pioneerspacesim/pioneer/issues/4939

This header should not be included here and does not seem to be needed. It was probably accidentally included in commit 
https://github.com/pioneerspacesim/pioneer/commit/e80d11ee18165127c8710c3bd17acb168726075a.
