### PR TITLE
Cleanup Renderer API to Remove Fixed-Function State

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -543,7 +543,7 @@ namespace Background {
 	void Container::Draw(const matrix4x4d &transform)
 	{
 		PROFILE_SCOPED()
-		m_renderer->SetTransform(transform);
+		m_renderer->SetTransform(matrix4x4f(transform));
 		if (DRAW_SKYBOX & m_drawFlags) {
 			m_universeBox.Draw(m_renderState);
 		}
@@ -551,7 +551,7 @@ namespace Background {
 			m_milkyWay.Draw(m_renderState);
 		}
 		if (DRAW_STARS & m_drawFlags) {
-			m_renderer->SetTransform(transform);
+			m_renderer->SetTransform(matrix4x4f(transform));
 			m_starField.Draw(m_renderState);
 		}
 	}

--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -54,7 +54,7 @@ void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
 	const vector3d xaxis = yaxis.Cross(zaxis);
 	const matrix4x4d invrot = matrix4x4d::MakeRotMatrix(xaxis, yaxis, zaxis).Inverse();
 
-	renderer->SetTransform(modelView * matrix4x4d::ScaleMatrix(rad) * invrot);
+	renderer->SetTransform(matrix4x4f(modelView * matrix4x4d::ScaleMatrix(rad) * invrot));
 
 	if (!m_atmos)
 		m_atmos.reset(new Drawables::Sphere3D(renderer, mat, rs, 4, 1.0f, ATTRIB_POSITION));

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -279,8 +279,7 @@ void Camera::Draw(const Body *excludeBody)
 
 		// draw something!
 		if (attrs->billboard) {
-			Graphics::Renderer::MatrixTicket mt(m_renderer, Graphics::MatrixMode::MODELVIEW);
-			m_renderer->SetTransform(matrix4x4d::Identity());
+			Graphics::Renderer::MatrixTicket mt(m_renderer, matrix4x4f::Identity());
 			m_billboardMaterial->diffuse = attrs->billboardColor;
 			m_renderer->DrawPointSprites(1, &attrs->billboardPos, SfxManager::additiveAlphaState, m_billboardMaterial.get(), attrs->billboardSize);
 		} else

--- a/src/CameraController.cpp
+++ b/src/CameraController.cpp
@@ -69,12 +69,7 @@ static bool FillCameraPosOrient(const SceneGraph::Model *m, const char *tag, vec
 	}
 
 	pos = vector3d(trans.GetTranslate());
-
-	// XXX sigh, this madness has to stop
-	const matrix3x3f tagOrient = trans.GetOrient();
-	matrix3x3d tagOrientd;
-	matrix3x3ftod(tagOrient, tagOrientd);
-	orient = fixOrient * tagOrientd;
+	orient = fixOrient * matrix3x3d(trans.GetOrient());
 
 	return true;
 }

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -669,8 +669,8 @@ void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView,
 	renderer->SetTransform(trans); //need to set this for the following line to work
 	matrix4x4d modv;
 	matrix4x4d proj;
-	matrix4x4ftod(renderer->GetCurrentModelView(), modv);
-	matrix4x4ftod(renderer->GetCurrentProjection(), proj);
+	matrix4x4ftod(renderer->GetTransform(), modv);
+	matrix4x4ftod(renderer->GetProjection(), proj);
 	Graphics::Frustum frustum(modv, proj);
 
 	// no frustum test of entire gasSphere, since Space::Render does this

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -667,10 +667,8 @@ void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView,
 	matrix4x4d trans = modelView;
 	trans.Translate(-campos.x, -campos.y, -campos.z);
 	renderer->SetTransform(trans); //need to set this for the following line to work
-	matrix4x4d modv;
-	matrix4x4d proj;
-	matrix4x4ftod(renderer->GetTransform(), modv);
-	matrix4x4ftod(renderer->GetProjection(), proj);
+	matrix4x4d modv = matrix4x4d(renderer->GetTransform());
+	matrix4x4d proj = matrix4x4d(renderer->GetProjection());
 	Graphics::Frustum frustum(modv, proj);
 
 	// no frustum test of entire gasSphere, since Space::Render does this

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -262,7 +262,7 @@ public:
 		Graphics::RenderState *rs = gasSphere->GetSurfRenderState();
 
 		const vector3d relpos = clipCentroid - campos;
-		renderer->SetTransform(modelView * matrix4x4d::Translation(relpos));
+		renderer->SetTransform(matrix4x4f(modelView * matrix4x4d::Translation(relpos)));
 
 		Pi::statSceneTris += 2 * (ctx->edgeLen - 1) * (ctx->edgeLen - 1);
 		++Pi::statNumPatches;
@@ -666,7 +666,7 @@ void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView,
 
 	matrix4x4d trans = modelView;
 	trans.Translate(-campos.x, -campos.y, -campos.z);
-	renderer->SetTransform(trans); //need to set this for the following line to work
+	renderer->SetTransform(matrix4x4f(trans)); //need to set this for the following line to work
 	matrix4x4d modv = matrix4x4d(renderer->GetTransform());
 	matrix4x4d proj = matrix4x4d(renderer->GetProjection());
 	Graphics::Frustum frustum(modv, proj);
@@ -717,7 +717,7 @@ void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView,
 
 	renderer->SetAmbientColor(ambient);
 
-	renderer->SetTransform(modelView);
+	renderer->SetTransform(matrix4x4f(modelView));
 
 	for (int i = 0; i < NUM_PATCHES; i++) {
 		m_patches[i]->Render(renderer, campos, modelView, frustum);

--- a/src/GasGiantJobs.cpp
+++ b/src/GasGiantJobs.cpp
@@ -242,14 +242,13 @@ namespace GasGiantJobs {
 		Pi::renderer->SetViewport(0, 0, mData->UVDims(), mData->UVDims());
 		Pi::renderer->SetTransform(matrix4x4f::Identity());
 
+		matrix4x4f savedProj = Pi::renderer->GetProjection();
+		matrix4x4f savedMV = Pi::renderer->GetTransform();
+
 		// enter ortho
 		{
-			Pi::renderer->SetMatrixMode(Graphics::MatrixMode::PROJECTION);
-			Pi::renderer->PushMatrix();
 			Pi::renderer->SetOrthographicProjection(0, mData->UVDims(), mData->UVDims(), 0, -1, 1);
-			Pi::renderer->SetMatrixMode(Graphics::MatrixMode::MODELVIEW);
-			Pi::renderer->PushMatrix();
-			Pi::renderer->LoadIdentity();
+			Pi::renderer->SetTransform(matrix4x4f::Identity());
 		}
 
 		GasGiant::BeginRenderTarget();
@@ -269,10 +268,8 @@ namespace GasGiantJobs {
 
 		// leave ortho?
 		{
-			Pi::renderer->SetMatrixMode(Graphics::MatrixMode::PROJECTION);
-			Pi::renderer->PopMatrix();
-			Pi::renderer->SetMatrixMode(Graphics::MatrixMode::MODELVIEW);
-			Pi::renderer->PopMatrix();
+			Pi::renderer->SetProjection(savedProj);
+			Pi::renderer->SetTransform(savedMV);
 		}
 
 		// add this patches data

--- a/src/GasGiantJobs.cpp
+++ b/src/GasGiantJobs.cpp
@@ -239,17 +239,12 @@ namespace GasGiantJobs {
 	{
 		PROFILE_SCOPED()
 
-		Pi::renderer->SetViewport(0, 0, mData->UVDims(), mData->UVDims());
-		Pi::renderer->SetTransform(matrix4x4f::Identity());
-
-		matrix4x4f savedProj = Pi::renderer->GetProjection();
-		matrix4x4f savedMV = Pi::renderer->GetTransform();
+		Graphics::Renderer::StateTicket ticket(Pi::renderer);
 
 		// enter ortho
-		{
-			Pi::renderer->SetOrthographicProjection(0, mData->UVDims(), mData->UVDims(), 0, -1, 1);
-			Pi::renderer->SetTransform(matrix4x4f::Identity());
-		}
+		Pi::renderer->SetViewport({ 0, 0, mData->UVDims(), mData->UVDims() });
+		Pi::renderer->SetOrthographicProjection(0, mData->UVDims(), mData->UVDims(), 0, -1, 1);
+		Pi::renderer->SetTransform(matrix4x4f::Identity());
 
 		GasGiant::BeginRenderTarget();
 		for (Uint32 iFace = 0; iFace < NUM_PATCHES; iFace++) {
@@ -266,18 +261,14 @@ namespace GasGiantJobs {
 		}
 		GasGiant::EndRenderTarget();
 
-		// leave ortho?
-		{
-			Pi::renderer->SetProjection(savedProj);
-			Pi::renderer->SetTransform(savedMV);
-		}
-
 		// add this patches data
 		SGPUGenResult *sr = new SGPUGenResult();
 		sr->addResult(mData->Texture(), mData->UVDims());
 
 		// store the result
 		mpResults = sr;
+
+		// leave ortho when ticket is destroyed
 	}
 
 	void SingleGPUGenJob::OnFinish() // runs in primary thread of the context

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -245,11 +245,11 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 #ifdef DEBUG_BOUNDING_SPHERES
 		RefCountedPtr<Graphics::Material> mat(Pi::renderer->CreateMaterial(Graphics::MaterialDescriptor()));
 		switch (m_depth) {
-			case 0: mat->diffuse = Color::WHITE; break;
-			case 1: mat->diffuse = Color::RED; break;
-			case 2: mat->diffuse = Color::GREEN; break;
-			case 3: mat->diffuse = Color::BLUE; break;
-			default: mat->diffuse = Color::BLACK; break;
+		case 0: mat->diffuse = Color::WHITE; break;
+		case 1: mat->diffuse = Color::RED; break;
+		case 2: mat->diffuse = Color::GREEN; break;
+		case 3: mat->diffuse = Color::BLUE; break;
+		default: mat->diffuse = Color::BLACK; break;
 		}
 		m_boundsphere.reset(new Graphics::Drawables::Sphere3D(Pi::renderer, mat, Pi::renderer->CreateRenderState(Graphics::RenderStateDesc()), 2, m_clipRadius));
 #endif
@@ -323,7 +323,7 @@ void GeoPatch::LODUpdate(const vector3d &campos, const Graphics::Frustum &frustu
 	// always split at first level
 	double centroidDist = DBL_MAX;
 	if (m_parent) {
-		centroidDist = (campos - m_centroid).Length(); // distance from camera to centre of the patch
+		centroidDist = (campos - m_centroid).Length();		 // distance from camera to centre of the patch
 		const bool tooFar = (centroidDist >= m_roughLength); // check if the distance is greater than the rough length, which is how far it should be before it can split
 		if (m_depth >= std::min(GEOPATCH_MAX_DEPTH, m_geosphere->GetMaxDepth()) || tooFar) {
 			canSplit = false; // we're too deep in the quadtree or too far away so cannot split

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -291,7 +291,7 @@ void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, cons
 		Graphics::RenderState *rs = m_geosphere->GetSurfRenderState();
 
 		const vector3d relpos = m_clipCentroid - campos;
-		renderer->SetTransform(modelView * matrix4x4d::Translation(relpos));
+		renderer->SetTransform(matrix4x4f(modelView * matrix4x4d::Translation(relpos)));
 
 		Pi::statSceneTris += (m_ctx->GetNumTris());
 		++Pi::statNumPatches;

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -379,7 +379,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 
 	matrix4x4d trans = modelView;
 	trans.Translate(-campos.x, -campos.y, -campos.z);
-	renderer->SetTransform(trans); //need to set this for the following line to work
+	renderer->SetTransform(matrix4x4f(trans)); //need to set this for the following line to work
 	matrix4x4d modv = matrix4x4d(renderer->GetTransform());
 	matrix4x4d proj = matrix4x4d(renderer->GetProjection());
 	Graphics::Frustum frustum(modv, proj);
@@ -443,7 +443,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 
 	renderer->SetAmbientColor(ambient);
 
-	renderer->SetTransform(modelView);
+	renderer->SetTransform(matrix4x4f(modelView));
 
 	for (int i = 0; i < NUM_PATCHES; i++) {
 		m_patches[i]->Render(renderer, campos, modelView, frustum);

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -380,10 +380,8 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 	matrix4x4d trans = modelView;
 	trans.Translate(-campos.x, -campos.y, -campos.z);
 	renderer->SetTransform(trans); //need to set this for the following line to work
-	matrix4x4d modv;
-	matrix4x4d proj;
-	matrix4x4ftod(renderer->GetTransform(), modv);
-	matrix4x4ftod(renderer->GetProjection(), proj);
+	matrix4x4d modv = matrix4x4d(renderer->GetTransform());
+	matrix4x4d proj = matrix4x4d(renderer->GetProjection());
 	Graphics::Frustum frustum(modv, proj);
 	m_tempFrustum = frustum;
 

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -382,8 +382,8 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 	renderer->SetTransform(trans); //need to set this for the following line to work
 	matrix4x4d modv;
 	matrix4x4d proj;
-	matrix4x4ftod(renderer->GetCurrentModelView(), modv);
-	matrix4x4ftod(renderer->GetCurrentProjection(), proj);
+	matrix4x4ftod(renderer->GetTransform(), modv);
+	matrix4x4ftod(renderer->GetProjection(), proj);
 	Graphics::Frustum frustum(modv, proj);
 	m_tempFrustum = frustum;
 

--- a/src/HudTrail.cpp
+++ b/src/HudTrail.cpp
@@ -77,7 +77,7 @@ void HudTrail::Render(Graphics::Renderer *r)
 			colors.back().a = Uint8(alpha * 255);
 		}
 
-		r->SetTransform(m_transform);
+		r->SetTransform(matrix4x4f(m_transform));
 		m_lines.SetData(tvts.size(), &tvts[0], &colors[0]);
 		m_lines.Draw(r, m_renderState, Graphics::LINE_STRIP);
 	}

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -163,7 +163,7 @@ void HyperspaceCloud::Render(Renderer *renderer, const Camera *camera, const vec
 	vector3d xaxis = vector3d(0, 1, 0).Cross(zaxis).Normalized();
 	vector3d yaxis = zaxis.Cross(xaxis);
 	matrix4x4d rot = matrix4x4d::MakeRotMatrix(xaxis, yaxis, zaxis).Inverse();
-	renderer->SetTransform(trans * rot);
+	renderer->SetTransform(matrix4x4f(trans * rot));
 
 	// precise to the rendered frame (better than PHYSICS_HZ granularity)
 	const double preciseTime = Pi::game->GetTime() + Pi::GetGameTickAlpha() * Pi::game->GetTimeStep();

--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -143,7 +143,7 @@ void Intro::Draw(float deltaTime)
 	m_renderer->ClearDepthBuffer();
 	m_background->Draw(brot);
 
-	m_renderer->SetViewport(m_spinnerLeft, 0, m_spinnerWidth, Graphics::GetScreenHeight());
+	m_renderer->SetViewport({ m_spinnerLeft, 0, m_spinnerWidth, Graphics::GetScreenHeight() });
 	m_renderer->SetPerspectiveProjection(75, m_spinnerRatio, 1.f, 10000.f);
 
 	matrix4x4f trans =

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -59,7 +59,7 @@ public:
 	{
 		if (!cg.GetGeom()) return;
 
-		matrix4x4ftod(m_matrixStack.back(), cg.GetGeom()->m_animTransform);
+		cg.GetGeom()->m_animTransform = matrix4x4d(m_matrixStack.back());
 	}
 };
 

--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -143,7 +143,8 @@ void ObjectViewerView::Draw3D()
 		body->Render(m_renderer, m_camera.get(), vector3d(0, 0, -viewingDist), m_camRot);
 
 		// industry-standard red/green/blue XYZ axis indiactor
-		m_renderer->SetTransform(matrix4x4d::Translation(vector3d(0, 0, -viewingDist)) * m_camRot * matrix4x4d::ScaleMatrix(body->GetClipRadius() * 2.0));
+		matrix4x4d trans = matrix4x4d::Translation(vector3d(0, 0, -viewingDist)) * m_camRot * matrix4x4d::ScaleMatrix(body->GetClipRadius() * 2.0);
+		m_renderer->SetTransform(matrix4x4f(trans));
 		Graphics::Drawables::GetAxes3DDrawable(m_renderer)->Draw(m_renderer);
 	}
 

--- a/src/Planet.cpp
+++ b/src/Planet.cpp
@@ -256,7 +256,7 @@ void Planet::DrawGasGiantRings(Renderer *renderer, const matrix4x4d &modelView)
 	if (!m_ringTexture)
 		GenerateRings(renderer);
 
-	renderer->SetTransform(modelView);
+	renderer->SetTransform(matrix4x4f(modelView));
 	renderer->DrawTriangles(&m_ringVertices, m_ringState, m_ringMaterial.get(), TRIANGLE_STRIP);
 }
 

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -1014,7 +1014,7 @@ void SectorView::BuildFarSector(RefCountedPtr<Sector> sec, const vector3f &origi
 
 void SectorView::OnSwitchTo()
 {
-	m_renderer->SetViewport(0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+	m_renderer->SetViewport({ 0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight() });
 	Pi::input->PushInputFrame(&InputBindings);
 	UIView::OnSwitchTo();
 	Update();

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -254,7 +254,7 @@ void SectorView::Draw3D()
 
 	m_renderer->ClearScreen();
 
-	Graphics::Renderer::MatrixTicket ticket(m_renderer, Graphics::MatrixMode::MODELVIEW);
+	Graphics::Renderer::MatrixTicket ticket(m_renderer);
 
 	// units are lightyears, my friend
 	modelview.Translate(0.f, 0.f, -10.f - 10.f * m_zoom); // not zoomClamped, let us zoom out a bit beyond what we're drawing

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1465,9 +1465,7 @@ void Ship::Render(Graphics::Renderer *renderer, const Camera *camera, const vect
 
 	GetPropulsion()->Render(renderer, camera, viewCoords, viewTransform);
 
-	matrix3x3f mt;
-	matrix3x3dtof(viewTransform.Inverse().GetOrient(), mt);
-	s_heatGradientParams.heatingMatrix = mt;
+	s_heatGradientParams.heatingMatrix = matrix3x3f(viewTransform.Inverse().GetOrient());
 	s_heatGradientParams.heatingNormal = vector3f(GetVelocity().Normalized());
 	s_heatGradientParams.heatingAmount = Clamp(GetHullTemperature(), 0.0, 1.0);
 

--- a/src/ShipCpanelMultiFuncDisplays.cpp
+++ b/src/ShipCpanelMultiFuncDisplays.cpp
@@ -148,9 +148,11 @@ void RadarWidget::Draw()
 
 	// circles and spokes
 	{
-		Graphics::Renderer::MatrixTicket ticket(m_renderer, Graphics::MatrixMode::MODELVIEW);
-		m_renderer->Translate(RADAR_XSHRINK * m_x, m_y, 0);
-		m_renderer->Scale(m_x, m_y, 1.0f);
+		matrix4x4f modelView = m_renderer->GetTransform();
+		modelView.Translate(RADAR_XSHRINK * m_x, m_y, 0);
+		modelView.Scale(m_x, m_y, 1.0f);
+
+		Graphics::Renderer::MatrixTicket ticket(m_renderer, modelView);
 		DrawRingsAndSpokes(false);
 	}
 

--- a/src/SpeedLines.cpp
+++ b/src/SpeedLines.cpp
@@ -130,7 +130,7 @@ void SpeedLines::Render(Graphics::Renderer *r)
 
 	m_vbuffer->Populate(*m_varray);
 
-	r->SetTransform(m_transform);
+	r->SetTransform(matrix4x4f(m_transform));
 	r->DrawBuffer(m_vbuffer.get(), m_renderState, m_material.Get(), Graphics::LINE_SINGLE);
 }
 

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -97,7 +97,7 @@ void Star::Render(Graphics::Renderer *renderer, const Camera *camera, const vect
 		BuildHaloBuffer(renderer, rad);
 	}
 	// scale the halo by the new radius from it's unit size
-	renderer->SetTransform(trans * matrix4x4d::ScaleMatrix(rad) * rot);
+	renderer->SetTransform(matrix4x4f(trans * matrix4x4d::ScaleMatrix(rad) * rot));
 	//render star halo
 	renderer->DrawBuffer(m_haloBuffer.get(), m_haloState, Graphics::vtxColorMaterial, Graphics::TRIANGLE_FAN);
 

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -4,8 +4,8 @@
 #include "Star.h"
 
 #include "Pi.h"
-#include "galaxy/SystemBody.h"
 #include "galaxy/StarSystem.h"
+#include "galaxy/SystemBody.h"
 #include "graphics/RenderState.h"
 #include "graphics/Renderer.h"
 #include "graphics/VertexArray.h"

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -810,8 +810,7 @@ void SystemView::SetSelectedObject(Projectable::types type, Projectable::bases b
 
 double SystemView::ProjectedSize(double size, vector3d pos)
 {
-	matrix4x4d dtrans;
-	matrix4x4ftod(m_cameraSpace, dtrans);
+	matrix4x4d dtrans = matrix4x4d(m_cameraSpace);
 	pos = dtrans * pos; //position in camera space to know distance
 	double result = size / pos.Length() / CAMERA_FOV_RADIANS;
 	return result;

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -25,7 +25,7 @@ void GuiApplication::BeginFrame()
 	m_renderer->SetRenderTarget(m_renderTarget);
 #endif
 	// TODO: render target size
-	m_renderer->SetViewport(0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+	m_renderer->SetViewport({ 0, 0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight() });
 	m_renderer->BeginFrame();
 }
 

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -54,6 +54,23 @@ namespace Graphics {
 		int height;
 	};
 
+	// Lightweight representation of viewport bounds to simplify viewport state management
+	struct Viewport {
+		Viewport() :
+			x(0),
+			y(0),
+			w(0),
+			h(0) {}
+
+		Viewport(int32_t _x, int32_t _y, int32_t _w, int32_t _h) :
+			x(_x),
+			y(_y),
+			w(_w),
+			h(_h) {}
+
+		int32_t x, y, w, h;
+	};
+
 	class Material;
 	extern Material *vtxColorMaterial;
 

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -79,10 +79,10 @@ namespace Graphics {
 		virtual bool ClearDepthBuffer() = 0;
 		virtual bool SetClearColor(const Color &c) = 0;
 
-		virtual bool SetViewport(int x, int y, int width, int height) = 0;
+		virtual bool SetViewport(Viewport vp) = 0;
+		virtual Viewport GetViewport() const = 0;
 
 		//set the model view matrix
-		[[deprecated]] virtual bool SetTransform(const matrix4x4d &m) = 0;
 		virtual bool SetTransform(const matrix4x4f &m) = 0;
 		virtual matrix4x4f GetTransform() const = 0;
 
@@ -144,9 +144,6 @@ namespace Graphics {
 
 		virtual bool ReloadShaders() = 0;
 
-		/// XXX at least use a custom structure you heathens
-		[[deprecated]] virtual void GetCurrentViewport(Sint32 *vp) const = 0;
-
 		// take a ticket representing the current renderer state. when the ticket
 		// is deleted, the renderer state is restored
 		// XXX state must die
@@ -156,6 +153,7 @@ namespace Graphics {
 				m_renderer(r)
 			{
 				m_renderer->PushState();
+				m_storedVP = m_renderer->GetViewport();
 				m_storedProj = m_renderer->GetProjection();
 				m_storedMV = m_renderer->GetTransform();
 			}
@@ -163,6 +161,7 @@ namespace Graphics {
 			virtual ~StateTicket()
 			{
 				m_renderer->PopState();
+				m_renderer->SetViewport(m_storedVP);
 				m_renderer->SetTransform(m_storedMV);
 				m_renderer->SetProjection(m_storedProj);
 			}
@@ -174,6 +173,7 @@ namespace Graphics {
 			Renderer *m_renderer;
 			matrix4x4f m_storedProj;
 			matrix4x4f m_storedMV;
+			Viewport m_storedVP;
 		};
 
 		// Temporarily save the current transform matrix to do non-destructive drawing.

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -9,6 +9,7 @@
 #include "Stats.h"
 #include "Types.h"
 #include "libs.h"
+#include "matrix4x4.h"
 #include <map>
 #include <memory>
 
@@ -32,11 +33,6 @@ namespace Graphics {
 	struct VertexBufferDesc;
 	struct RenderStateDesc;
 	struct RenderTargetDesc;
-
-	enum class MatrixMode {
-		MODELVIEW,
-		PROJECTION
-	};
 
 	// Renderer base, functions return false if
 	// failed/unsupported
@@ -86,12 +82,15 @@ namespace Graphics {
 		virtual bool SetViewport(int x, int y, int width, int height) = 0;
 
 		//set the model view matrix
-		virtual bool SetTransform(const matrix4x4d &m) = 0;
+		[[deprecated]] virtual bool SetTransform(const matrix4x4d &m) = 0;
 		virtual bool SetTransform(const matrix4x4f &m) = 0;
+		virtual matrix4x4f GetTransform() const = 0;
+
 		//set projection matrix
 		virtual bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) = 0;
 		virtual bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) = 0;
 		virtual bool SetProjection(const matrix4x4f &m) = 0;
+		virtual matrix4x4f GetProjection() const = 0;
 
 		virtual bool SetRenderState(RenderState *) = 0;
 
@@ -145,20 +144,8 @@ namespace Graphics {
 
 		virtual bool ReloadShaders() = 0;
 
-		// our own matrix stack
-		// XXX state must die
-		virtual const matrix4x4f &GetCurrentModelView() const = 0;
-		virtual const matrix4x4f &GetCurrentProjection() const = 0;
-		virtual void GetCurrentViewport(Sint32 *vp) const = 0;
-
-		// XXX all quite GL specific. state must die!
-		virtual void SetMatrixMode(MatrixMode mm) = 0;
-		virtual void PushMatrix() = 0;
-		virtual void PopMatrix() = 0;
-		virtual void LoadIdentity() = 0;
-		virtual void LoadMatrix(const matrix4x4f &m) = 0;
-		virtual void Translate(const float x, const float y, const float z) = 0;
-		virtual void Scale(const float x, const float y, const float z) = 0;
+		/// XXX at least use a custom structure you heathens
+		[[deprecated]] virtual void GetCurrentViewport(Sint32 *vp) const = 0;
 
 		// take a ticket representing the current renderer state. when the ticket
 		// is deleted, the renderer state is restored
@@ -166,38 +153,55 @@ namespace Graphics {
 		class StateTicket {
 		public:
 			StateTicket(Renderer *r) :
-				m_renderer(r) { m_renderer->PushState(); }
-			virtual ~StateTicket() { m_renderer->PopState(); }
+				m_renderer(r)
+			{
+				m_renderer->PushState();
+				m_storedProj = m_renderer->GetProjection();
+				m_storedMV = m_renderer->GetTransform();
+			}
+
+			virtual ~StateTicket()
+			{
+				m_renderer->PopState();
+				m_renderer->SetTransform(m_storedMV);
+				m_renderer->SetProjection(m_storedProj);
+			}
+
+			StateTicket(const StateTicket &) = delete;
+			StateTicket &operator=(const StateTicket &) = delete;
 
 		private:
-			StateTicket(const StateTicket &);
-			StateTicket &operator=(const StateTicket &);
 			Renderer *m_renderer;
+			matrix4x4f m_storedProj;
+			matrix4x4f m_storedMV;
 		};
 
-		// take a ticket representing a single state matrix. when the ticket is
-		// deleted, the previous matrix state is restored
-		// XXX state must die
+		// Temporarily save the current transform matrix to do non-destructive drawing.
+		// XXX state has died, does this need to die further?
 		class MatrixTicket {
 		public:
-			MatrixTicket(Renderer *r, MatrixMode m) :
-				m_renderer(r),
-				m_matrixMode(m)
+			MatrixTicket(Renderer *r) :
+				MatrixTicket(r, r->GetTransform())
+			{}
+
+			MatrixTicket(Renderer *r, const matrix4x4f &newMat) :
+				m_renderer(r)
 			{
-				m_renderer->SetMatrixMode(m_matrixMode);
-				m_renderer->PushMatrix();
-			}
-			virtual ~MatrixTicket()
-			{
-				m_renderer->SetMatrixMode(m_matrixMode);
-				m_renderer->PopMatrix();
+				m_storedMat = m_renderer->GetTransform();
+				m_renderer->SetTransform(newMat);
 			}
 
+			virtual ~MatrixTicket()
+			{
+				m_renderer->SetTransform(m_storedMat);
+			}
+
+			MatrixTicket(const MatrixTicket &) = delete;
+			MatrixTicket &operator=(const MatrixTicket &) = delete;
+
 		private:
-			MatrixTicket(const MatrixTicket &);
-			MatrixTicket &operator=(const MatrixTicket &);
 			Renderer *m_renderer;
-			MatrixMode m_matrixMode;
+			matrix4x4f m_storedMat;
 		};
 
 		virtual bool Screendump(ScreendumpState &sd) { return false; }

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -43,9 +43,9 @@ namespace Graphics {
 		virtual bool ClearDepthBuffer() override final { return true; }
 		virtual bool SetClearColor(const Color &c) override final { return true; }
 
-		virtual bool SetViewport(int x, int y, int width, int height) override final { return true; }
+		virtual bool SetViewport(Viewport v) override final { return true; }
+		virtual Viewport GetViewport() const override final { return {}; }
 
-		virtual bool SetTransform(const matrix4x4d &m) override final { return true; }
 		virtual bool SetTransform(const matrix4x4f &m) override final { return true; }
 		virtual matrix4x4f GetTransform() const override final { return matrix4x4f::Identity(); }
 		virtual bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) override final { return true; }
@@ -78,8 +78,6 @@ namespace Graphics {
 		virtual InstanceBuffer *CreateInstanceBuffer(Uint32 size, BufferUsage bu) override final { return new Graphics::Dummy::InstanceBuffer(size, bu); }
 
 		virtual bool ReloadShaders() override final { return true; }
-
-		virtual void GetCurrentViewport(Sint32 *vp) const override final {}
 
 	protected:
 		virtual void PushState() override final {}

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -47,9 +47,11 @@ namespace Graphics {
 
 		virtual bool SetTransform(const matrix4x4d &m) override final { return true; }
 		virtual bool SetTransform(const matrix4x4f &m) override final { return true; }
+		virtual matrix4x4f GetTransform() const override final { return matrix4x4f::Identity(); }
 		virtual bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) override final { return true; }
 		virtual bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) override final { return true; }
 		virtual bool SetProjection(const matrix4x4f &m) override final { return true; }
+		virtual matrix4x4f GetProjection() const override final { return matrix4x4f::Identity(); }
 
 		virtual bool SetWireFrameMode(bool enabled) override final { return true; }
 
@@ -77,17 +79,7 @@ namespace Graphics {
 
 		virtual bool ReloadShaders() override final { return true; }
 
-		virtual const matrix4x4f &GetCurrentModelView() const override final { return m_identity; }
-		virtual const matrix4x4f &GetCurrentProjection() const override final { return m_identity; }
 		virtual void GetCurrentViewport(Sint32 *vp) const override final {}
-
-		virtual void SetMatrixMode(MatrixMode mm) override final {}
-		virtual void PushMatrix() override final {}
-		virtual void PopMatrix() override final {}
-		virtual void LoadIdentity() override final {}
-		virtual void LoadMatrix(const matrix4x4f &m) override final {}
-		virtual void Translate(const float x, const float y, const float z) override final {}
-		virtual void Scale(const float x, const float y, const float z) override final {}
 
 	protected:
 		virtual void PushState() override final {}

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -198,8 +198,6 @@ namespace Graphics {
 
 		TextureBuilder::Init();
 
-		m_viewportStack.push(Viewport());
-
 		const bool useDXTnTextures = vs.useTextureCompression;
 		m_useCompressedTextures = useDXTnTextures;
 
@@ -223,7 +221,7 @@ namespace Graphics {
 		glHint(GL_FRAGMENT_SHADER_DERIVATIVE_HINT, GL_NICEST);
 
 		SetClearColor(Color4f(0.f, 0.f, 0.f, 0.f));
-		SetViewport(0, 0, m_width, m_height);
+		SetViewport(Viewport(0, 0, m_width, m_height));
 
 		if (vs.enableDebugMessages)
 			GLDebug::Enable();
@@ -573,22 +571,16 @@ namespace Graphics {
 		return true;
 	}
 
-	bool RendererOGL::SetViewport(int x, int y, int width, int height)
+	bool RendererOGL::SetViewport(Viewport v)
 	{
-		assert(!m_viewportStack.empty());
-		Viewport &currentViewport = m_viewportStack.top();
-		currentViewport.x = x;
-		currentViewport.y = y;
-		currentViewport.w = width;
-		currentViewport.h = height;
-		glViewport(x, y, width, height);
+		m_viewport = v;
+		glViewport(v.x, v.y, v.w, v.h);
 		return true;
 	}
 
-	bool RendererOGL::SetTransform(const matrix4x4d &m)
+	Viewport RendererOGL::GetViewport() const
 	{
-		PROFILE_SCOPED()
-		return SetTransform(matrix4x4f(m));
+		return m_viewport;
 	}
 
 	bool RendererOGL::SetTransform(const matrix4x4f &m)
@@ -694,7 +686,6 @@ namespace Graphics {
 
 	void RendererOGL::SetMaterialShaderTransforms(Material *m)
 	{
-		//m->SetCommonUniforms(m_modelViewStack.top(), m_projectionStack.top());
 		m->SetCommonUniforms(m_modelViewMat, m_projectionMat);
 		CheckRenderErrors(__FUNCTION__, __LINE__);
 	}
@@ -1165,15 +1156,12 @@ namespace Graphics {
 	// only restoring the things that have changed
 	void RendererOGL::PushState()
 	{
-		m_viewportStack.push(m_viewportStack.top());
+		// empty since viewport handling is now external, evaluate if renderer will need to save any custom state
 	}
 
 	void RendererOGL::PopState()
 	{
-		m_viewportStack.pop();
-		assert(!m_viewportStack.empty());
-		const Viewport &cvp = m_viewportStack.top();
-		SetViewport(cvp.x, cvp.y, cvp.w, cvp.h);
+		// empty since viewport handling is now external, evaluate if renderer will need to save any custom state
 	}
 
 	bool RendererOGL::Screendump(ScreendumpState &sd)

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -588,9 +588,7 @@ namespace Graphics {
 	bool RendererOGL::SetTransform(const matrix4x4d &m)
 	{
 		PROFILE_SCOPED()
-		matrix4x4f mf;
-		matrix4x4dtof(m, mf);
-		return SetTransform(mf);
+		return SetTransform(matrix4x4f(m));
 	}
 
 	bool RendererOGL::SetTransform(const matrix4x4f &m)

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -79,9 +79,12 @@ namespace Graphics {
 
 		virtual bool SetTransform(const matrix4x4d &m) override final;
 		virtual bool SetTransform(const matrix4x4f &m) override final;
+		virtual matrix4x4f GetTransform() const override final;
+
 		virtual bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) override final;
 		virtual bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) override final;
 		virtual bool SetProjection(const matrix4x4f &m) override final;
+		virtual matrix4x4f GetProjection() const override final;
 
 		virtual bool SetWireFrameMode(bool enabled) override final;
 
@@ -109,8 +112,6 @@ namespace Graphics {
 
 		virtual bool ReloadShaders() override final;
 
-		virtual const matrix4x4f &GetCurrentModelView() const override final { return m_modelViewStack.top(); }
-		virtual const matrix4x4f &GetCurrentProjection() const override final { return m_projectionStack.top(); }
 		virtual void GetCurrentViewport(Sint32 *vp) const override final
 		{
 			const Viewport &cur = m_viewportStack.top();
@@ -119,14 +120,6 @@ namespace Graphics {
 			vp[2] = cur.w;
 			vp[3] = cur.h;
 		}
-
-		virtual void SetMatrixMode(MatrixMode mm) override final;
-		virtual void PushMatrix() override final;
-		virtual void PopMatrix() override final;
-		virtual void LoadIdentity() override final;
-		virtual void LoadMatrix(const matrix4x4f &m) override final;
-		virtual void Translate(const float x, const float y, const float z) override final;
-		virtual void Scale(const float x, const float y, const float z) override final;
 
 		virtual bool Screendump(ScreendumpState &sd) override final;
 		virtual bool FrameGrab(ScreendumpState &sd) override final;
@@ -167,9 +160,8 @@ namespace Graphics {
 		OGL::RenderTarget *m_activeRenderTarget;
 		RenderState *m_activeRenderState;
 
-		MatrixMode m_matrixMode;
-		std::stack<matrix4x4f> m_modelViewStack;
-		std::stack<matrix4x4f> m_projectionStack;
+		matrix4x4f m_modelViewMat;
+		matrix4x4f m_projectionMat;
 
 		struct Viewport {
 			Viewport() :

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -75,9 +75,9 @@ namespace Graphics {
 		virtual bool ClearDepthBuffer() override final;
 		virtual bool SetClearColor(const Color &c) override final;
 
-		virtual bool SetViewport(int x, int y, int width, int height) override final;
+		virtual bool SetViewport(Viewport v) override final;
+		virtual Viewport GetViewport() const override final;
 
-		virtual bool SetTransform(const matrix4x4d &m) override final;
 		virtual bool SetTransform(const matrix4x4f &m) override final;
 		virtual matrix4x4f GetTransform() const override final;
 
@@ -111,15 +111,6 @@ namespace Graphics {
 		virtual InstanceBuffer *CreateInstanceBuffer(Uint32 size, BufferUsage) override final;
 
 		virtual bool ReloadShaders() override final;
-
-		virtual void GetCurrentViewport(Sint32 *vp) const override final
-		{
-			const Viewport &cur = m_viewportStack.top();
-			vp[0] = cur.x;
-			vp[1] = cur.y;
-			vp[2] = cur.w;
-			vp[3] = cur.h;
-		}
 
 		virtual bool Screendump(ScreendumpState &sd) override final;
 		virtual bool FrameGrab(ScreendumpState &sd) override final;
@@ -162,16 +153,7 @@ namespace Graphics {
 
 		matrix4x4f m_modelViewMat;
 		matrix4x4f m_projectionMat;
-
-		struct Viewport {
-			Viewport() :
-				x(0),
-				y(0),
-				w(0),
-				h(0) {}
-			Sint32 x, y, w, h;
-		};
-		std::stack<Viewport> m_viewportStack;
+		Viewport m_viewport;
 
 	private:
 		static bool initted;

--- a/src/gui/GuiButton.cpp
+++ b/src/gui/GuiButton.cpp
@@ -128,9 +128,11 @@ namespace Gui {
 		}
 
 		Graphics::Renderer *r = Gui::Screen::GetRenderer();
-		Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
 
-		r->Translate(m_padding, m_padding * 0.5, 0);
+		matrix4x4f modelView = r->GetTransform();
+		modelView.Translate(m_padding, m_padding * 0.5, 0);
+		Graphics::Renderer::MatrixTicket ticket(r, modelView);
+
 		m_label->Draw();
 	}
 

--- a/src/gui/GuiContainer.cpp
+++ b/src/gui/GuiContainer.cpp
@@ -212,8 +212,9 @@ namespace Gui {
 			if (!(*i).w->IsVisible())
 				continue;
 
-			Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
-			r->Translate((*i).pos[0], (*i).pos[1], 0);
+			matrix4x4f modelView = r->GetTransform();
+			modelView.Translate((*i).pos[0], (*i).pos[1], 0);
+			Graphics::Renderer::MatrixTicket ticket(r, modelView);
 			(*i).w->Draw();
 		}
 	}

--- a/src/gui/GuiLabel.cpp
+++ b/src/gui/GuiLabel.cpp
@@ -94,9 +94,11 @@ namespace Gui {
 
 		if (m_shadow) {
 			Graphics::Renderer *r = Gui::Screen::GetRenderer();
-			r->Translate(1, 1, 0);
+			matrix4x4f modelView = r->GetTransform();
+			modelView.Translate(1, 1, 0);
+
+			Graphics::Renderer::MatrixTicket ticket(r, modelView);
 			m_layout->Render(size[0], Color::BLACK);
-			r->Translate(-1, -1, 0);
 		}
 		m_layout->Render(size[0], m_color);
 	}

--- a/src/gui/GuiMeterBar.cpp
+++ b/src/gui/GuiMeterBar.cpp
@@ -39,8 +39,10 @@ namespace Gui {
 
 		// draw inner bar
 		{
-			Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
-			r->Translate(METERBAR_PADDING, METERBAR_PADDING, 0.0f);
+			matrix4x4f modelView = r->GetTransform();
+			modelView.Translate(METERBAR_PADDING, METERBAR_PADDING, 0.0f);
+			Graphics::Renderer::MatrixTicket ticket(r, modelView);
+
 			size.x = m_barValue * (size.x - 2.0f * METERBAR_PADDING);
 			size.y = METERBAR_BAR_HEIGHT;
 			if (!m_inner)

--- a/src/gui/GuiScreen.cpp
+++ b/src/gui/GuiScreen.cpp
@@ -22,7 +22,7 @@ namespace Gui {
 	Gui::Widget *Screen::focusedWidget;
 	matrix4x4f Screen::modelMatrix;
 	matrix4x4f Screen::projMatrix;
-	Sint32 Screen::viewport[4];
+	Graphics::Viewport Screen::viewport;
 
 	FontCache Screen::s_fontCache;
 	std::stack<RefCountedPtr<Text::TextureFont>> Screen::s_fontStack;
@@ -124,8 +124,8 @@ namespace Gui {
 			(vclip[2] / w) * 0.5 + 0.5
 		};
 
-		out.x = v[0] * viewport[2] + viewport[0];
-		out.y = v[1] * viewport[3] + viewport[1];
+		out.x = v[0] * viewport.w + viewport.x;
+		out.y = v[1] * viewport.h + viewport.y;
 		out.z = v[2];
 
 		// map to pixels
@@ -143,7 +143,7 @@ namespace Gui {
 		modelMatrix = r->GetTransform();
 		projMatrix = r->GetProjection();
 
-		r->GetCurrentViewport(&viewport[0]);
+		viewport = r->GetViewport();
 		r->SetOrthographicProjection(0, width, height, 0, -1, 1);
 		r->SetTransform(matrix4x4f::Identity());
 	}

--- a/src/gui/GuiScreen.cpp
+++ b/src/gui/GuiScreen.cpp
@@ -140,8 +140,8 @@ namespace Gui {
 
 		Graphics::Renderer *r = GetRenderer();
 
-		modelMatrix = r->GetCurrentModelView();
-		projMatrix = r->GetCurrentProjection();
+		modelMatrix = r->GetTransform();
+		projMatrix = r->GetProjection();
 
 		r->GetCurrentViewport(&viewport[0]);
 		r->SetOrthographicProjection(0, width, height, 0, -1, 1);
@@ -301,15 +301,16 @@ namespace Gui {
 
 		Graphics::Renderer *r = Gui::Screen::GetRenderer();
 
-		const matrix4x4f &modelMatrix_ = r->GetCurrentModelView();
-		Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
+		const matrix4x4f &modelMatrix_ = r->GetTransform();
+		Graphics::Renderer::MatrixTicket ticket(r);
 
 		const float x = modelMatrix_[12] + xoff;
 		const float y = modelMatrix_[13] + yoff;
 
-		r->LoadIdentity();
-		r->Translate(floor(x / Screen::fontScale[0]) * Screen::fontScale[0], floor(y / Screen::fontScale[1]) * Screen::fontScale[1], 0);
-		r->Scale(Screen::fontScale[0], Screen::fontScale[1], 1);
+		matrix4x4f modelView = matrix4x4f::Identity();
+		modelView.Translate(floor(x / Screen::fontScale[0]) * Screen::fontScale[0], floor(y / Screen::fontScale[1]) * Screen::fontScale[1], 0);
+		modelView.Scale(Screen::fontScale[0], Screen::fontScale[1], 1);
+		r->SetTransform(modelView);
 
 		// temporary, owned by the font
 		Graphics::VertexBuffer *pVB = font->GetCachedVertexBuffer(s);
@@ -339,15 +340,16 @@ namespace Gui {
 
 		Graphics::Renderer *r = Gui::Screen::GetRenderer();
 
-		const matrix4x4f &modelMatrix_ = r->GetCurrentModelView();
-		Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
+		const matrix4x4f &modelMatrix_ = r->GetTransform();
+		Graphics::Renderer::MatrixTicket ticket(r);
 
 		const float x = modelMatrix_[12];
 		const float y = modelMatrix_[13];
 
-		r->LoadIdentity();
-		r->Translate(floor(x / Screen::fontScale[0]) * Screen::fontScale[0], floor(y / Screen::fontScale[1]) * Screen::fontScale[1], 0);
-		r->Scale(Screen::fontScale[0], Screen::fontScale[1], 1);
+		matrix4x4f modelView = matrix4x4f::Identity();
+		modelView.Translate(floor(x / Screen::fontScale[0]) * Screen::fontScale[0], floor(y / Screen::fontScale[1]) * Screen::fontScale[1], 0);
+		modelView.Scale(Screen::fontScale[0], Screen::fontScale[1], 1);
+		r->SetTransform(modelView);
 
 		// temporary, owned by the font
 		Graphics::VertexBuffer *pVB = font->GetCachedVertexBuffer(s);

--- a/src/gui/GuiScreen.h
+++ b/src/gui/GuiScreen.h
@@ -6,6 +6,7 @@
 
 #include "FontCache.h"
 #include "Gui.h"
+#include "graphics/Graphics.h"
 #include "graphics/RenderState.h"
 #include "text/TextureFont.h"
 #include <list>
@@ -87,7 +88,7 @@ namespace Gui {
 		static void OnDeleteFocusedWidget();
 		static matrix4x4f modelMatrix;
 		static matrix4x4f projMatrix;
-		static Sint32 viewport[4];
+		static Graphics::Viewport viewport;
 
 		static FontCache s_fontCache;
 		static std::stack<RefCountedPtr<Text::TextureFont>> s_fontStack;

--- a/src/gui/GuiTextLayout.cpp
+++ b/src/gui/GuiTextLayout.cpp
@@ -92,14 +92,15 @@ namespace Gui {
 
 		Graphics::Renderer *r = Gui::Screen::GetRenderer();
 
-		const matrix4x4f &modelMatrix = r->GetCurrentModelView();
-		Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
+		const matrix4x4f &modelMatrix = r->GetTransform();
+		Graphics::Renderer::MatrixTicket ticket(r);
 		{
 			const float x = modelMatrix[12];
 			const float y = modelMatrix[13];
-			r->LoadIdentity();
-			r->Translate(floor(x / fontScale[0]) * fontScale[0], floor(y / fontScale[1]) * fontScale[1], 0);
-			r->Scale(fontScale[0], fontScale[1], 1);
+			matrix4x4f modelView = matrix4x4f::Identity();
+			modelView.Translate(floor(x / fontScale[0]) * fontScale[0], floor(y / fontScale[1]) * fontScale[1], 0);
+			modelView.Scale(fontScale[0], fontScale[1], 1);
+			r->SetTransform(modelView);
 			m_font->RenderBuffer(m_vbuffer.Get(), color);
 		}
 	}
@@ -124,7 +125,7 @@ namespace Gui {
 		Gui::Screen::GetCoords2Pixels(fontScale);
 
 		Graphics::Renderer *r = Gui::Screen::GetRenderer();
-		Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
+		Graphics::Renderer::MatrixTicket ticket(r);
 
 		Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 

--- a/src/gui/GuiTexturedQuad.cpp
+++ b/src/gui/GuiTexturedQuad.cpp
@@ -50,11 +50,10 @@ namespace Gui {
 
 		{
 			// move and scale the quad on-screen
-			Graphics::Renderer::MatrixTicket mt(renderer, Graphics::MatrixMode::MODELVIEW);
-			const matrix4x4f &mv = renderer->GetCurrentModelView();
+			const matrix4x4f &mv = renderer->GetTransform();
 			matrix4x4f trans(matrix4x4f::Translation(vector3f(pos.x, pos.y, 0.0f)));
 			trans.Scale(size.x, size.y, 0.0f);
-			renderer->SetTransform(mv * trans);
+			Graphics::Renderer::MatrixTicket mt(renderer, mv * trans);
 
 			m_material->diffuse = tint;
 			renderer->DrawBuffer(m_vb.Get(), Gui::Screen::alphaBlendState, m_material.get(), TRIANGLE_STRIP);

--- a/src/gui/GuiToolTip.cpp
+++ b/src/gui/GuiToolTip.cpp
@@ -84,9 +84,10 @@ namespace Gui {
 		m_outlines.SetData(2, &outlineVts[0], outlineColor);
 		m_outlines.Draw(r, Screen::alphaBlendState, Graphics::LINE_LOOP);
 
-		Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
+		matrix4x4f modelView = r->GetTransform();
+		modelView.Translate(TOOLTIP_PADDING, 0, 0);
 
-		r->Translate(TOOLTIP_PADDING, 0, 0);
+		Graphics::Renderer::MatrixTicket ticket(r, modelView);
 		m_layout->Render(size[0] - 2 * TOOLTIP_PADDING);
 	}
 

--- a/src/gui/GuiVScrollPortal.cpp
+++ b/src/gui/GuiVScrollPortal.cpp
@@ -128,10 +128,12 @@ namespace Gui {
 		Screen::GetCoords2Pixels(scale);
 
 		Graphics::Renderer *r = Gui::Screen::GetRenderer();
-		Graphics::Renderer::MatrixTicket ticket(r, Graphics::MatrixMode::MODELVIEW);
 
 		// scroll to whole pixel locations whatever the resolution
-		r->Translate(0, floor((-m_scrollY * toScroll) / scale[1]) * scale[1], 0);
+		matrix4x4f modelView = r->GetTransform();
+		modelView.Translate(0, floor((-m_scrollY * toScroll) / scale[1]) * scale[1], 0);
+
+		Graphics::Renderer::MatrixTicket ticket(r, modelView);
 		Container::Draw();
 
 		SetScissor(false);

--- a/src/matrix3x3.h
+++ b/src/matrix3x3.h
@@ -7,11 +7,13 @@
 #include "vector3.h"
 #include <math.h>
 #include <stdio.h>
+#include <type_traits>
 
 template <typename T>
 class matrix3x3 {
 private:
 	T cell[9];
+	using other_float_t = typename std::conditional<std::is_same<T, float>::value, double, float>::type;
 
 public:
 	matrix3x3() {}
@@ -23,6 +25,11 @@ public:
 	matrix3x3(const T *vals)
 	{
 		memcpy(cell, vals, sizeof(T) * 9);
+	}
+	explicit matrix3x3(const matrix3x3<other_float_t> &m)
+	{
+		for (int i = 0; i < 9; i++)
+			cell[i] = T(m[i]);
 	}
 
 	T &operator[](const size_t i) { return cell[i]; } // used for serializing
@@ -230,17 +237,6 @@ public:
 
 typedef matrix3x3<float> matrix3x3f;
 typedef matrix3x3<double> matrix3x3d;
-
-static inline void matrix3x3ftod(const matrix3x3f &in, matrix3x3d &out)
-{
-	for (int i = 0; i < 9; i++)
-		out[i] = double(in[i]);
-}
-static inline void matrix3x3dtof(const matrix3x3d &in, matrix3x3f &out)
-{
-	for (int i = 0; i < 9; i++)
-		out[i] = float(in[i]);
-}
 
 static const matrix3x3f matrix3x3fIdentity(matrix3x3f::Identity());
 static const matrix3x3d matrix3x3dIdentity(matrix3x3d::Identity());

--- a/src/matrix4x4.h
+++ b/src/matrix4x4.h
@@ -8,11 +8,13 @@
 #include "vector3.h"
 #include <math.h>
 #include <stdio.h>
+#include <type_traits>
 
 template <typename T>
 class matrix4x4 {
 private:
 	T cell[16];
+	using other_float_t = typename std::conditional<std::is_same<T, float>::value, double, float>::type;
 
 public:
 	matrix4x4() {}
@@ -26,11 +28,21 @@ public:
 	{
 		memcpy(cell, vals, sizeof(T) * 16);
 	}
+	matrix4x4(const matrix3x3<T> &m)
+	{
+		LoadFrom3x3Matrix(m.Data());
+	}
 	matrix4x4(const matrix3x3<T> &m, const vector3<T> &v)
 	{
 		LoadFrom3x3Matrix(m.Data());
 		SetTranslate(v);
 	}
+	explicit matrix4x4(const matrix4x4<other_float_t> &m)
+	{
+		for (int i = 0; i < 16; i++)
+			cell[i] = T(m[i]);
+	}
+
 	void SetTranslate(const vector3<T> &v)
 	{
 		cell[12] = v.x;
@@ -42,25 +54,6 @@ public:
 	{
 		for (int i = 0; i < 12; i++)
 			cell[i] = m.cell[i];
-	}
-	matrix4x4(const matrix3x3<T> &m)
-	{
-		cell[0] = m[0];
-		cell[4] = m[1];
-		cell[8] = m[2];
-		cell[12] = 0;
-		cell[1] = m[3];
-		cell[5] = m[4];
-		cell[9] = m[5];
-		cell[13] = 0;
-		cell[2] = m[6];
-		cell[6] = m[7];
-		cell[10] = m[8];
-		cell[14] = 0;
-		cell[3] = 0;
-		cell[7] = 0;
-		cell[11] = 0;
-		cell[15] = 1;
 	}
 	matrix3x3<T> GetOrient() const
 	{
@@ -592,17 +585,6 @@ public:
 
 typedef matrix4x4<float> matrix4x4f;
 typedef matrix4x4<double> matrix4x4d;
-
-static inline void matrix4x4ftod(const matrix4x4f &in, matrix4x4d &out)
-{
-	for (int i = 0; i < 16; i++)
-		out[i] = double(in[i]);
-}
-static inline void matrix4x4dtof(const matrix4x4d &in, matrix4x4f &out)
-{
-	for (int i = 0; i < 16; i++)
-		out[i] = float(in[i]);
-}
 
 static const matrix4x4f matrix4x4fIdentity(matrix4x4f::Identity());
 static const matrix4x4d matrix4x4dIdentity(matrix4x4d::Identity());

--- a/src/pigui/ModelSpinner.cpp
+++ b/src/pigui/ModelSpinner.cpp
@@ -67,7 +67,7 @@ void ModelSpinner::Render()
 	r->SetPerspectiveProjection(fov, m_size.x / m_size.y, 1.f, 10000.f);
 	r->SetTransform(matrix4x4f::Identity());
 	const auto &desc = m_renderTarget.get()->GetDesc();
-	r->SetViewport(0, 0, desc.width, desc.height);
+	r->SetViewport({ 0, 0, desc.width, desc.height });
 
 	r->SetLights(1, &m_light);
 

--- a/src/ui/Context.cpp
+++ b/src/ui/Context.cpp
@@ -14,23 +14,23 @@ namespace UI {
 	static const int SCALE_CUTOFF_HEIGHT = 768;
 
 	static const float FONT_SCALE[] = {
-		0.7f, // XSMALL
+		0.7f,  // XSMALL
 		0.85f, // SMALL
-		1.0f, // NORMAL
-		1.4f, // LARGE
-		1.8f, // XLARGE
+		1.0f,  // NORMAL
+		1.4f,  // LARGE
+		1.8f,  // XLARGE
 
-		0.7f, // HEADING_XSMALL
+		0.7f,  // HEADING_XSMALL
 		0.85f, // HEADING_SMALL
-		1.0f, // HEADING_NORMAL
-		1.4f, // HEADING_LARGE
-		1.8f, // HEADING_XLARGE
+		1.0f,  // HEADING_NORMAL
+		1.4f,  // HEADING_LARGE
+		1.8f,  // HEADING_XLARGE
 
-		0.7f, // MONO_XSMALL
+		0.7f,  // MONO_XSMALL
 		0.85f, // MONO_SMALL
-		1.0f, // MONO_NORMAL
-		1.4f, // MONO_LARGE
-		1.8f // MONO_XLARGE
+		1.0f,  // MONO_NORMAL
+		1.4f,  // MONO_LARGE
+		1.8f   // MONO_XLARGE
 	};
 
 	Context::Context(LuaManager *lua, Graphics::Renderer *renderer, int width, int height) :

--- a/src/ui/Context.cpp
+++ b/src/ui/Context.cpp
@@ -163,7 +163,7 @@ namespace UI {
 
 		// Ticket for the viewport mostly
 		Graphics::Renderer::StateTicket ticket(r);
-		r->SetViewport(0, 0, m_width, m_height);
+		r->SetViewport({ 0, 0, m_width, m_height });
 
 		// reset renderer for each layer
 		for (std::vector<Layer *>::iterator i = m_layers.begin(); i != m_layers.end(); ++i) {


### PR DESCRIPTION
Matrix state ~~must~~ did die!

Remove all OpenGL 2.x like matrix state methods from the renderer API, now the matrix state is the responsibility of the caller via MatrixTicket / StateTicket.

Still TODO is improving the viewport state tracking API, although that should be rather simple to fix via promoting the Viewport struct to the top-level Renderer API.

Needs a little dead-code-elimination because I wrote this between the hours of 3 and 4 AM, but should produce identical results to the previous system.

Ping @fluffyfreak - I recognize that `XXX` comment annotation and this was actually surprisingly simple to do, so there's gotta be a bug in it somewhere, right? *Right?*
