### PR TITLE
Add more profiling points

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,14 +53,17 @@ if (CMAKE_COMPILER_IS_GNUCXX)
     if (NOT IS_TRAVIS)
         add_compile_options(
 			-fdiagnostics-color
-			-Wall
-			-Wextra
-			-Wno-unused-parameter
-			-Wno-unused-but-set-parameter
-			-Wno-implicit-fallthrough
 		)
-    endif()
+	endif()
+	add_compile_options(
+		-Wall
+		-Wextra
+		-Wno-unused-parameter
+		-Wno-unused-but-set-parameter
+		-Wno-implicit-fallthrough
+	)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
+	set(CMAKE_CXX_FLAGS_DEBUG "-g -Og")
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 include(CheckSymbolExists)

--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -18,6 +18,7 @@ BaseSphere::~BaseSphere() {}
 //static
 void BaseSphere::Init()
 {
+	PROFILE_SCOPED()
 	GeoSphere::Init();
 	GasGiant::Init();
 }

--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -6,8 +6,8 @@
 #include "GasGiant.h"
 #include "GeoSphere.h"
 
-#include "graphics/Renderer.h"
 #include "graphics/Drawables.h"
+#include "graphics/Renderer.h"
 
 BaseSphere::BaseSphere(const SystemBody *body) :
 	m_sbody(body),

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -48,6 +48,7 @@ NavLights::LightBulb::LightBulb(Uint8 _group, Uint8 _mask, Uint8 _color, SceneGr
 
 void NavLights::Init(Graphics::Renderer *renderer)
 {
+	PROFILE_SCOPED()
 	assert(!g_initted);
 
 	IniConfig cfg;

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -360,6 +360,7 @@ bool SfxManager::SplitMaterialData(const std::string &spec, MaterialData &output
 
 void SfxManager::Init(Graphics::Renderer *r)
 {
+	PROFILE_SCOPED()
 	IniConfig cfg;
 	// set defaults in case they're missing from the file
 	cfg.SetString("damageFile", "textures/smoke.png");

--- a/src/Shields.cpp
+++ b/src/Shields.cpp
@@ -73,6 +73,7 @@ Shields::Hits::Hits(const vector3d &_pos, const Uint32 _start, const Uint32 _end
 
 void Shields::Init(Graphics::Renderer *renderer)
 {
+	PROFILE_SCOPED()
 	assert(!s_initialised);
 
 	// create our global shield material

--- a/src/galaxy/GalaxyGenerator.cpp
+++ b/src/galaxy/GalaxyGenerator.cpp
@@ -19,6 +19,7 @@ RefCountedPtr<Galaxy> GalaxyGenerator::s_galaxy;
 //static
 void GalaxyGenerator::Init(const std::string &name, Version version)
 {
+	PROFILE_SCOPED()
 	s_defaultGenerator = name;
 	s_defaultVersion = (version == LAST_VERSION) ? GetLastVersion(name) : version;
 	GalaxyGenerator::Create(); // This will set s_galaxy

--- a/src/galaxy/GalaxyGenerator.cpp
+++ b/src/galaxy/GalaxyGenerator.cpp
@@ -122,7 +122,7 @@ void GalaxyGenerator::ToJson(Json &jsonObj, RefCountedPtr<Galaxy> galaxy)
 		sysgen->ToJson(starSystemStageArrayEl, galaxy);
 		starSystemStageArray.push_back(starSystemStageArrayEl); // Append system stage object to array.
 	}
-	galaxyGenObj["sector_stage"] = sectorStageArray; // Add sector stage array to galaxy generator object.
+	galaxyGenObj["sector_stage"] = sectorStageArray;		  // Add sector stage array to galaxy generator object.
 	galaxyGenObj["star_system_stage"] = starSystemStageArray; // Add system stage array to galaxy generator object.
 
 	jsonObj["galaxy_generator"] = galaxyGenObj; // Add galaxy generator object to supplied object.

--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -3,6 +3,7 @@
 
 #include "TextureBuilder.h"
 #include "FileSystem.h"
+#include "profiler/Profiler.h"
 #include "utils.h"
 #include <SDL_image.h>
 #include <SDL_rwops.h>
@@ -140,7 +141,9 @@ namespace Graphics {
 		}
 
 		TextureFormat targetTextureFormat;
-		unsigned int virtualWidth, actualWidth, virtualHeight, actualHeight, numberOfMipMaps = 0, numberOfImages = 1;
+		// initialize actualWidth to 1 to avoid divide-by-zero in case we fail to set the values somehow
+		uint32_t virtualWidth = 0, actualWidth = 1, virtualHeight = 0, actualHeight = 1;
+		uint32_t numberOfMipMaps = 0, numberOfImages = 1;
 		if (m_surface) {
 			SDL_PixelFormat *targetPixelFormat;
 			bool needConvert = !GetTargetFormat(m_surface->format, &targetTextureFormat, &targetPixelFormat, m_forceRGBA);
@@ -265,6 +268,7 @@ namespace Graphics {
 
 	void TextureBuilder::LoadSurface()
 	{
+		PROFILE_SCOPED()
 		assert(!m_surface);
 
 		SDLSurfacePtr s;
@@ -286,6 +290,7 @@ namespace Graphics {
 
 	void TextureBuilder::LoadDDS()
 	{
+		PROFILE_SCOPED()
 		assert(!m_surface);
 		assert(!m_dds.headerdone_);
 		if(m_textureType != TEXTURE_2D_ARRAY)

--- a/src/graphics/TextureBuilder.cpp
+++ b/src/graphics/TextureBuilder.cpp
@@ -7,8 +7,8 @@
 #include "utils.h"
 #include <SDL_image.h>
 #include <SDL_rwops.h>
-#include <sstream>
 #include <algorithm>
+#include <sstream>
 
 namespace Graphics {
 
@@ -73,29 +73,29 @@ namespace Graphics {
 #error "SDL surface pixel formats are endian-specific"
 #endif
 	static SDL_PixelFormat pixelFormatRGBA = {
-		0, // format#
-		0, // palette
-		32, // bits per pixel
-		4, // bytes per pixel
-		{ 0, 0 }, // padding
+		0,									// format#
+		0,									// palette
+		32,									// bits per pixel
+		4,									// bytes per pixel
+		{ 0, 0 },							// padding
 		0xff, 0xff00, 0xff0000, 0xff000000, // RGBA mask
-		0, 0, 0, 0, // RGBA loss
-		24, 16, 8, 0, // RGBA shift
-		0, // colour key
-		0 // alpha
+		0, 0, 0, 0,							// RGBA loss
+		24, 16, 8, 0,						// RGBA shift
+		0,									// colour key
+		0									// alpha
 	};
 
 	static SDL_PixelFormat pixelFormatRGB = {
-		0, // format#
-		0, // palette
-		24, // bits per pixel
-		3, // bytes per pixel
-		{ 0, 0 }, // padding
+		0,						   // format#
+		0,						   // palette
+		24,						   // bits per pixel
+		3,						   // bytes per pixel
+		{ 0, 0 },				   // padding
 		0xff, 0xff00, 0xff0000, 0, // RGBA mask
-		0, 0, 0, 0, // RGBA loss
-		16, 8, 0, 0, // RGBA shift
-		0, // colour key
-		0 // alpha
+		0, 0, 0, 0,				   // RGBA loss
+		16, 8, 0, 0,			   // RGBA shift
+		0,						   // colour key
+		0						   // alpha
 	};
 
 	static inline bool GetTargetFormat(const SDL_PixelFormat *sourcePixelFormat, TextureFormat *targetTextureFormat, SDL_PixelFormat **targetPixelFormat, bool forceRGBA)
@@ -201,7 +201,7 @@ namespace Graphics {
 					Output("WARNING: texture '%s' is not power-of-two and may not display correctly\n", m_filenames.front().c_str());
 			}
 		} else {
-			if(m_textureType != TEXTURE_2D_ARRAY) {
+			if (m_textureType != TEXTURE_2D_ARRAY) {
 				switch (m_dds.GetTextureFormat()) {
 				case PicoDDS::FORMAT_DXT1: targetTextureFormat = TEXTURE_DXT1; break;
 				case PicoDDS::FORMAT_DXT5: targetTextureFormat = TEXTURE_DXT5; break;
@@ -219,10 +219,10 @@ namespace Graphics {
 					// Cube map must be fully defined (6 images) to be used correctly
 					assert(numberOfImages == 6);
 				}
-			} else if(m_textureType == TEXTURE_2D_ARRAY) {
+			} else if (m_textureType == TEXTURE_2D_ARRAY) {
 				assert(m_ddsarray.size() == m_layers);
-				assert(m_layers>0);
-				switch(m_ddsarray[0].GetTextureFormat()) {
+				assert(m_layers > 0);
+				switch (m_ddsarray[0].GetTextureFormat()) {
 				case PicoDDS::FORMAT_DXT1: targetTextureFormat = TEXTURE_DXT1; break;
 				case PicoDDS::FORMAT_DXT5: targetTextureFormat = TEXTURE_DXT5; break;
 				default:
@@ -230,14 +230,14 @@ namespace Graphics {
 					assert(false);
 					return;
 				}
-				for(size_t i=0; i<m_layers; i++) {
+				for (size_t i = 0; i < m_layers; i++) {
 					const PicoDDS::DDSImage &dds = m_ddsarray[0];
 					virtualWidth = actualWidth = dds.imgdata_.width;
 					virtualHeight = actualHeight = dds.imgdata_.height;
 					numberOfMipMaps = dds.imgdata_.numMipMaps;
 					numberOfImages += dds.imgdata_.numImages;
 				}
-				assert((numberOfImages-1) == m_layers);
+				assert((numberOfImages - 1) == m_layers);
 			} else {
 				Output("ERROR: unexpected texture type");
 				abort();
@@ -246,7 +246,7 @@ namespace Graphics {
 
 		m_descriptor = TextureDescriptor(
 			targetTextureFormat,
-			vector3f(actualWidth,actualHeight,m_layers),
+			vector3f(actualWidth, actualHeight, m_layers),
 			vector2f(float(virtualWidth) / float(actualWidth), float(virtualHeight) / float(actualHeight)),
 			m_sampleMode, m_generateMipmaps, m_compressTextures, m_anisotropicFiltering, numberOfMipMaps, m_textureType);
 
@@ -279,7 +279,7 @@ namespace Graphics {
 			}
 		} else if (m_textureType == TEXTURE_CUBE_MAP) {
 			Output("LoadSurface: %s: cannot load non-DDS cubemaps\n", m_filenames.front().c_str());
-		} else if(m_textureType == TEXTURE_2D_ARRAY) {
+		} else if (m_textureType == TEXTURE_2D_ARRAY) {
 			Output("LoadSurface: %s: cannot load non-DDS texture array files\n", m_filenames.front().c_str());
 		}
 
@@ -293,21 +293,18 @@ namespace Graphics {
 		PROFILE_SCOPED()
 		assert(!m_surface);
 		assert(!m_dds.headerdone_);
-		if(m_textureType != TEXTURE_2D_ARRAY)
-		{
+		if (m_textureType != TEXTURE_2D_ARRAY) {
 			LoadDDSFromFile(m_filenames.front(), m_dds);
 
 			if (!m_dds.headerdone_) {
 				m_surface = LoadSurfaceFromFile("textures/unknown.png");
 			}
-		} else if(m_textureType == TEXTURE_2D_ARRAY)
-		{
+		} else if (m_textureType == TEXTURE_2D_ARRAY) {
 			m_ddsarray.clear();
 			const size_t layers = m_layers;
 			m_ddsarray.resize(layers);
 
-			for (size_t i = 0; i < layers; i++)
-			{
+			for (size_t i = 0; i < layers; i++) {
 				PiVerify(LoadDDSFromFile(m_filenames[i], m_ddsarray[i]));
 			}
 		}
@@ -318,7 +315,7 @@ namespace Graphics {
 	{
 		if (m_surface) {
 			if (texture->GetDescriptor().type == TEXTURE_2D && m_textureType == TEXTURE_2D) {
-			texture->Update(m_surface->pixels, vector3f(m_surface->w,m_surface->h,0.0f), m_descriptor.format, 0);
+				texture->Update(m_surface->pixels, vector3f(m_surface->w, m_surface->h, 0.0f), m_descriptor.format, 0);
 			} else if (texture->GetDescriptor().type == TEXTURE_CUBE_MAP && m_textureType == TEXTURE_CUBE_MAP) {
 				assert(m_cubemap.size() == 6);
 				TextureCubeData tcd;
@@ -329,16 +326,16 @@ namespace Graphics {
 				tcd.negY = m_cubemap[3]->pixels;
 				tcd.posZ = m_cubemap[4]->pixels;
 				tcd.negZ = m_cubemap[5]->pixels;
-			texture->Update(tcd, vector3f(m_cubemap[0]->w, m_cubemap[0]->h,0.0f), m_descriptor.format, 0);
+				texture->Update(tcd, vector3f(m_cubemap[0]->w, m_cubemap[0]->h, 0.0f), m_descriptor.format, 0);
 			} else {
 				// Given texture and current texture don't have the same type!
 				assert(0);
 			}
-		} else if( m_dds.headerdone_ ) {
+		} else if (m_dds.headerdone_) {
 			assert(m_dds.headerdone_);
 			assert(m_descriptor.format == TEXTURE_DXT1 || m_descriptor.format == TEXTURE_DXT5);
 			if (texture->GetDescriptor().type == TEXTURE_2D && m_textureType == TEXTURE_2D) {
-				texture->Update(m_dds.imgdata_.imgData, vector3f(m_dds.imgdata_.width,m_dds.imgdata_.height,0.0f), m_descriptor.format, m_dds.imgdata_.numMipMaps);
+				texture->Update(m_dds.imgdata_.imgData, vector3f(m_dds.imgdata_.width, m_dds.imgdata_.height, 0.0f), m_descriptor.format, m_dds.imgdata_.numMipMaps);
 			} else if (texture->GetDescriptor().type == TEXTURE_CUBE_MAP && m_textureType == TEXTURE_CUBE_MAP) {
 				TextureCubeData tcd;
 				// Size in bytes of each cube map face
@@ -350,20 +347,20 @@ namespace Graphics {
 				tcd.negY = static_cast<void *>(m_dds.imgdata_.imgData + (3 * face_size));
 				tcd.posZ = static_cast<void *>(m_dds.imgdata_.imgData + (4 * face_size));
 				tcd.negZ = static_cast<void *>(m_dds.imgdata_.imgData + (5 * face_size));
-				texture->Update(tcd, vector3f(m_dds.imgdata_.width, m_dds.imgdata_.height,0.0f), m_descriptor.format, m_dds.imgdata_.numMipMaps);
+				texture->Update(tcd, vector3f(m_dds.imgdata_.width, m_dds.imgdata_.height, 0.0f), m_descriptor.format, m_dds.imgdata_.numMipMaps);
 			} else {
 				// Given texture and current texture don't have the same type!
 				assert(0);
 			}
-		} else if( !m_ddsarray.empty() ) {
+		} else if (!m_ddsarray.empty()) {
 			// texture array
 			assert(m_textureType == TEXTURE_2D_ARRAY);
 			const TextureDescriptor &desc = texture->GetDescriptor();
 			// virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips = 0) = 0;
 			Texture::vecDataPtr dataPtrs;
 			dataPtrs.reserve(m_layers);
-			for(size_t i=0; i<m_layers; i++) {
-				dataPtrs.push_back( m_ddsarray[i].imgdata_.imgData );
+			for (size_t i = 0; i < m_layers; i++) {
+				dataPtrs.push_back(m_ddsarray[i].imgdata_.imgData);
 			}
 			texture->Update(dataPtrs, desc.dataSize, desc.format, desc.numberOfMipMaps);
 		}

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -3,8 +3,8 @@
 
 #include "Gui.h"
 #include "graphics/Graphics.h"
-#include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
+#include "graphics/Renderer.h"
 #include "libs.h"
 
 namespace Gui {

--- a/src/gui/Gui.cpp
+++ b/src/gui/Gui.cpp
@@ -115,6 +115,7 @@ namespace Gui {
 
 	void Init(Graphics::Renderer *renderer, int screen_width, int screen_height, int ui_width, int ui_height)
 	{
+		PROFILE_SCOPED()
 		Screen::Init(renderer, screen_width, screen_height, ui_width, ui_height);
 	}
 

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -470,6 +470,7 @@ namespace Sound {
 
 	static void load_sound(const std::string &basename, const std::string &path, bool is_music)
 	{
+		PROFILE_SCOPED()
 		if (!ends_with_ci(basename, ".ogg")) return;
 
 		Sample sample;
@@ -538,6 +539,7 @@ namespace Sound {
 
 	bool Init(bool automaticallyOpenDevice)
 	{
+		PROFILE_SCOPED()
 		if (m_audioDevice) {
 			DestroyAllEvents();
 			return true;
@@ -633,6 +635,7 @@ namespace Sound {
 
 	void UpdateAudioDevices()
 	{
+		PROFILE_SCOPED()
 		audioDeviceNames.clear();
 		for (int idx = 0; idx < SDL_GetNumAudioDevices(0); idx++) {
 			const char *name = SDL_GetAudioDeviceName(idx, 0);


### PR DESCRIPTION
This adds more profiling calls to better profile the startup phase. Turns out Sound.cpp eats a fair chunk loading all of the sounds in the game up front, something that we might want to run in a background thread at some point... Food for thought!

Also added non-interfering optimizations to the Debug build configuration after reading [this blog](https://mropert.github.io/2019/08/03/fifty_shades_of_debug/). Haven't noticed a *huge* difference, but every little bit counts. Ideally I'd like to ensure we enable inlining explicitly inline-declared functions, but I don't know of a GCC flag for that one.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

