### PR TITLE
Improve Startup Times via Threading

### DIFF
--- a/contrib/profiler/Profiler.cpp
+++ b/contrib/profiler/Profiler.cpp
@@ -1034,8 +1034,7 @@ namespace Profiler {
 		};
 
 		void Init(const char *dir) {
-			profileNum = 0;
-
+			firstThreadDump = true;
 			time_t now;
 			time( &now );
 			tm *now_tm = localtime( &now );
@@ -1070,9 +1069,9 @@ namespace Profiler {
 			Buffer<const char *> stack;
 
 			u64 endNs = endTicks * cyclesToTime;
-			fprintf( f, "%c\n{\"type\":\"evented\",\"name\":\"%s (thread %d): %s\",\"unit\":\"nanoseconds\",\"startValue\":0,\"endValue\":%lld,\"events\":[\n",
-				profileNum ? ',' : ' ', programName ? programName : "unnamed", profileNum, timeFormat, endNs );
-			profileNum++;
+			fprintf( f, "%c\n{\"type\":\"evented\",\"name\":\"%s (%s): %s\",\"unit\":\"nanoseconds\",\"startValue\":0,\"endValue\":%lld,\"events\":[\n",
+				firstThreadDump ? ' ' : ',', programName ? programName : "unnamed", zones->Size() ? zones->Data()->str() : "main", timeFormat, endNs );
+			firstThreadDump = false;
 
 			for (u32 i = 0; i < zones->Size(); i++) {
 				const Zone *z = &zones->Data()[i];
@@ -1103,7 +1102,7 @@ namespace Profiler {
 		FILE *f;
 		HashTable<Entry> frameTable;
 		char timeFormat[256], fileFormat[4096];
-		u32 profileNum;
+		bool firstThreadDump;
 	};
 
 	struct PrintfDumper {

--- a/src/JobQueue.cpp
+++ b/src/JobQueue.cpp
@@ -166,7 +166,7 @@ Job::Handle AsyncJobQueue::Queue(Job *job, JobClient *client)
 Job *AsyncJobQueue::GetJob()
 {
 	// profile to find the amount of time we spend waiting for a job
-	PROFILE_SCOPED()
+	PROFILE_SCOPED_DESC("Idle Waiting for Job")
 	SDL_LockMutex(m_queueLock);
 
 	// loop until a new job is available

--- a/src/JobQueue.cpp
+++ b/src/JobQueue.cpp
@@ -309,9 +309,9 @@ AsyncJobQueue::JobRunner::~JobRunner()
 int AsyncJobQueue::JobRunner::Trampoline(void *data)
 {
 	JobRunner *jr = static_cast<JobRunner *>(data);
-	PROFILE_THREAD_START_DESC(jr->m_threadName.c_str())
+
 	jr->Main();
-	PROFILE_THREAD_STOP()
+
 	return 0;
 }
 

--- a/src/JobQueue.h
+++ b/src/JobQueue.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-static const Uint32 MAX_THREADS = 64;
+static const uint32_t MAX_THREADS = 64;
 
 class JobClient;
 class JobQueue;
@@ -61,9 +61,9 @@ public:
 		Handle(Job *job, JobQueue *queue, JobClient *client);
 		void Unlink();
 
-		static unsigned long long s_nextId;
+		static Uint64 s_nextId;
 
-		unsigned long long m_id;
+		Uint64 m_id;
 		Job *m_job;
 		JobQueue *m_queue;
 		JobClient *m_client;
@@ -235,6 +235,7 @@ private:
 	std::deque<Job *> m_finished;
 };
 
+// JobClient is an abstraction to allow transparent management of job handles
 class JobClient {
 public:
 	virtual void Order(Job *job) = 0;
@@ -242,6 +243,8 @@ public:
 	virtual ~JobClient() {}
 };
 
+// JobSet provides an interface for "fire and forget" jobs - call Order with your job,
+// and JobSet will keep the handle alive until the job has finished.
 class JobSet : public JobClient {
 public:
 	JobSet(JobQueue *queue) :

--- a/src/JobQueue.h
+++ b/src/JobQueue.h
@@ -198,6 +198,8 @@ private:
 	SDL_mutex *m_finishedLock[MAX_THREADS];
 
 	std::vector<JobRunner *> m_runners;
+	// scratch space for finishing jobs on main thread
+	std::vector<Job *> m_finishedScratch;
 
 	bool m_shutdown;
 };

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -606,15 +606,9 @@ void StartupScreen::Update(float deltaTime)
 	if (!m_hasQueuedJobs) {
 		if (m_currentLoader < m_loaders.size())
 			RunNewLoader();
-		else {
-			// finish loading once all steps are complete and there's nothing left in the queue.
-			if (asyncStartupQueue->IsEmpty()) {
-				// TODO: this is here because profile dumps are currently run before Lifecycle::End is called
-				// Move profile dumping to Application.cpp to work around this!
-				Pi::RequestProfileFrame();
-				return RequestEndLifecycle();
-			}
-		}
+		// finish loading once all steps are complete and there's nothing left in the queue.
+		else if (asyncStartupQueue->IsEmpty())
+			return RequestEndLifecycle();
 	}
 
 	Pi::pigui->NewFrame();
@@ -649,6 +643,7 @@ void StartupScreen::FinishLoadStep()
 void StartupScreen::End()
 {
 	OS::NotifyLoadEnd();
+	Pi::GetApp()->RequestProfileFrame();
 
 	m_loadTimer.Stop();
 	Output("\n\nPioneer loading took %.2fms\n", m_loadTimer.milliseconds());

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -82,6 +82,16 @@ public:
 
 		void SetStartPath(const SystemPath &startPath);
 
+		// Returns a pointer to the async JobSet for the current startup loading step.
+		// The current load step will not complete until all ordered jobs have finished.
+		// NOTE: this queue runs on a different thread.
+		JobSet *GetCurrentLoadStepQueue() const;
+
+		// Returns a pointer to the async JobSet for the entire startup loading screen.
+		// Loading will not finish until all ordered jobs have finished.
+		// NOTE: this queue runs on a different thread.
+		JobSet *GetAsyncStartupQueue() const;
+
 	protected:
 		// for compatibility, while we're moving Pi's internals into App
 		friend class Pi;

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -204,8 +204,6 @@ public:
 	/* Only use #if WITH_DEVKEYS */
 	static bool showDebugInfo;
 
-	static void RequestProfileFrame(const std::string &profilePath = "");
-
 	static Input::Manager *input;
 	static Player *player;
 	static TransferPlanner *planner;

--- a/src/SDLWrappers.cpp
+++ b/src/SDLWrappers.cpp
@@ -8,6 +8,7 @@
 
 SDLSurfacePtr LoadSurfaceFromFile(const std::string &fname, FileSystem::FileSource &source)
 {
+	PROFILE_SCOPED()
 	RefCountedPtr<FileSystem::FileData> filedata = FileSystem::gameDataFiles.ReadFile(fname);
 	if (!filedata) {
 		Output("LoadSurfaceFromFile: %s: could not read file\n", fname.c_str());

--- a/src/collider/Geom.cpp
+++ b/src/collider/Geom.cpp
@@ -35,7 +35,6 @@ Geom::Geom(const GeomTree *geomtree, const matrix4x4d &m, const vector3d &pos, v
 
 void Geom::MoveTo(const matrix4x4d &m)
 {
-	PROFILE_SCOPED()
 	m_orient = m;
 	m_pos = m_orient.GetTranslate();
 	m_invOrient = m.Inverse();
@@ -43,7 +42,6 @@ void Geom::MoveTo(const matrix4x4d &m)
 
 void Geom::MoveTo(const matrix4x4d &m, const vector3d &pos)
 {
-	PROFILE_SCOPED()
 	m_orient = m;
 	m_pos = pos;
 	m_orient.SetTranslate(pos);

--- a/src/galaxy/Sector.cpp
+++ b/src/galaxy/Sector.cpp
@@ -111,7 +111,6 @@ void Sector::Dump(FILE *file, const char *indent) const
 
 float Sector::System::DistanceBetween(const System *a, const System *b)
 {
-	PROFILE_SCOPED()
 	vector3f dv = a->GetPosition() - b->GetPosition();
 	dv += Sector::SIZE * vector3f(float(a->sx - b->sx), float(a->sy - b->sy), float(a->sz - b->sz));
 	return dv.Length();

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -199,7 +199,6 @@ bool StarSystemFromSectorGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> gal
 
 void StarSystemLegacyGeneratorBase::PickAtmosphere(SystemBody *sbody)
 {
-	PROFILE_SCOPED()
 	/* Alpha value isn't real alpha. in the shader fog depth is determined
 	 * by density*alpha, so that we can have very dense atmospheres
 	 * without having them a big stinking solid color obscuring everything
@@ -293,7 +292,6 @@ static const unsigned char RANDOM_RING_COLORS[][4] = {
 
 void StarSystemLegacyGeneratorBase::PickRings(SystemBody *sbody, bool forceRings)
 {
-	PROFILE_SCOPED()
 	sbody->m_rings.minRadius = fixed();
 	sbody->m_rings.maxRadius = fixed();
 	sbody->m_rings.baseColor = Color(255, 255, 255, 255);
@@ -579,7 +577,6 @@ static double CalcSurfaceTemp(double star_radius, double star_temp, double objec
  */
 static fixed calcEnergyPerUnitAreaAtDist(fixed star_radius, int star_temp, fixed object_dist)
 {
-	PROFILE_SCOPED()
 	fixed temp = star_temp * fixed(1, 5778); //normalize to Sun's temperature
 	const fixed total_solar_emission =
 		temp * temp * temp * temp * star_radius * star_radius;
@@ -659,7 +656,6 @@ int StarSystemRandomGenerator::CalcSurfaceTemp(const SystemBody *primary, fixed 
  */
 const SystemBody *StarSystemRandomGenerator::FindStarAndTrueOrbitalRange(const SystemBody *planet, fixed &orbMin_, fixed &orbMax_) const
 {
-	PROFILE_SCOPED()
 	const SystemBody *star = planet->GetParent();
 
 	assert(star);
@@ -863,7 +859,6 @@ void StarSystemRandomGenerator::PickPlanetType(SystemBody *sbody, Random &rand)
 
 static fixed mass_from_disk_area(fixed a, fixed b, fixed max)
 {
-	PROFILE_SCOPED()
 	// so, density of the disk with distance from star goes like so: 1 - x/discMax
 	//
 	// ---
@@ -889,7 +884,6 @@ static fixed mass_from_disk_area(fixed a, fixed b, fixed max)
 
 static fixed get_disc_density(SystemBody *primary, fixed discMin, fixed discMax, fixed percentOfPrimaryMass)
 {
-	PROFILE_SCOPED()
 	discMax = std::max(discMax, discMin);
 	fixed total = mass_from_disk_area(discMin, discMax, discMax);
 	return primary->GetMassInEarths() * percentOfPrimaryMass / total;

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -579,7 +579,6 @@ namespace Sound {
 	};
 
 	std::vector<std::string> s_audioDeviceNames = {};
-	std::unique_ptr<JobSet> s_audioJobSet;
 
 	bool Init(bool automaticallyOpenDevice)
 	{
@@ -594,13 +593,11 @@ namespace Sound {
 			return false;
 		}
 
-		s_audioJobSet.reset(new JobSet(Pi::GetAsyncJobQueue()));
-
 		// load all the wretched effects
-		s_audioJobSet->Order(new LoadSoundJob("sounds", false));
+		Pi::GetApp()->GetAsyncStartupQueue()->Order(new LoadSoundJob("sounds", false));
 
 		//I'd rather do this in MusicPlayer and store in a different map too, this will do for now
-		s_audioJobSet->Order(new LoadSoundJob("music", true));
+		Pi::GetApp()->GetAsyncStartupQueue()->Order(new LoadSoundJob("music", true));
 
 		UpdateAudioDevices();
 
@@ -660,8 +657,6 @@ namespace Sound {
 
 	void Uninit()
 	{
-		s_audioJobSet.reset();
-
 		if (!m_audioDevice)
 			return;
 


### PR DESCRIPTION
Absolutely not finished, this is a horrendous hack that just so happens to work perfectly on my end.

- I've added profiling to worker threads started by the job system, so now they show up in the profiler output and we can see just how long they stay idle.

- I've also made `Sound::Init()` do it's sound and music loading in a background thread using the Job system, which has a few ramifications: FileSystem will need to be reviewed to ensure it's thread-safe, and if we want to play music at the main menu (or even earlier) then we need some way for the main thread to block until a certain group of jobs are finished (which sounds like a task for JobSet to me!).

At the moment there's absolutely no synchronization here, so if the background thread were to theoretically take an entire minute to finish then the game would start with no or almost no music available to MusicPlayer. Loading the music *should* be thread-safe, but the game would be rather silent until the player started a new game.

I'd love to get @fluffyfreak's feedback on main-thread synchronization in particular - the main thread needs to keep calling `FinishJobs()` due to the way the job system is set up, but ideally there's a way for it to do that but also yield most of it's time if it's still blocked on async jobs.

EDIT: for the interested, this shaves off ~1000mcycles (or around 1/5th) from our warm startup times in a release configuration. I'd prefer to *not* load the entire 160-file music and sound effect library on startup and instead stream in the music as needed, but this is a step in the right direction!