### PR TITLE
Better container for bodies in space

### DIFF
--- a/src/Space.h
+++ b/src/Space.h
@@ -11,7 +11,6 @@
 #include "RefCounted.h"
 #include "galaxy/StarSystem.h"
 #include "vector3.h"
-#include <list>
 
 class Body;
 class Frame;
@@ -67,8 +66,8 @@ public:
 	Body *FindBodyForPath(const SystemPath *path) const;
 
 	Uint32 GetNumBodies() const { return static_cast<Uint32>(m_bodies.size()); }
-	IterationProxy<std::list<Body *>> GetBodies() { return MakeIterationProxy(m_bodies); }
-	const IterationProxy<const std::list<Body *>> GetBodies() const { return MakeIterationProxy(m_bodies); }
+	IterationProxy<std::vector<Body *>> GetBodies() { return MakeIterationProxy(m_bodies); }
+	const IterationProxy<const std::vector<Body *>> GetBodies() const { return MakeIterationProxy(m_bodies); }
 
 	Background::Container *GetBackground() { return m_background.get(); }
 	void RefreshBackground();
@@ -85,6 +84,7 @@ public:
 	}
 
 	void DebugDumpFrames(bool details);
+
 private:
 	void GenSectorCache(RefCountedPtr<Galaxy> galaxy, const SystemPath *here);
 	void UpdateStarSystemCache(const SystemPath *here);
@@ -106,11 +106,15 @@ private:
 	Game *m_game;
 
 	// all the bodies we know about
-	std::list<Body *> m_bodies;
+	std::vector<Body *> m_bodies;
 
 	// bodies that were removed/killed this timestep and need pruning at the end
-	std::list<Body *> m_removeBodies;
-	std::list<Body *> m_killBodies;
+	enum class BodyAssignation {
+		KILL = 0,
+		REMOVE = 1
+	};
+
+	std::vector<std::pair<Body *, BodyAssignation>> m_assignedBodies;
 
 	void RebuildBodyIndex();
 	void RebuildSystemBodyIndex();
@@ -160,7 +164,6 @@ private:
 	//the NotifyRemoved callback (#735)
 	bool m_processingFinalizationQueue;
 #endif
-
 };
 
 #endif /* _SPACE_H */


### PR DESCRIPTION
~~Add a `bunch` class, which is essentially a vector, but removal from the middle occurs in O(1), thanks to the swap-delete idiom. But this changes the order of the elements.~~
Remake the container for bodies in space from `std::list` to `std::vector`, and removing an element from the middle is done by moving the last element to its place.
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

