### PR TITLE
Fix VS2019 Solution

### DIFF
--- a/win32/vs2019/pioneer.vcxproj
+++ b/win32/vs2019/pioneer.vcxproj
@@ -378,7 +378,6 @@
     <ClCompile Include="..\..\src\Beam.cpp" />
     <ClCompile Include="..\..\src\Body.cpp" />
     <ClCompile Include="..\..\src\Camera.cpp" />
-    <ClCompile Include="..\..\src\CameraController.cpp" />
     <ClCompile Include="..\..\src\CargoBody.cpp" />
     <ClCompile Include="..\..\src\CityOnPlanet.cpp" />
     <ClCompile Include="..\..\src\CollMesh.cpp" />
@@ -493,6 +492,10 @@
     <ClCompile Include="..\..\src\pigui\PiGuiLua.cpp" />
     <ClCompile Include="..\..\src\pigui\LuaFace.cpp" />
     <ClCompile Include="..\..\src\pigui\PiGuiSandbox.cpp" />
+    <ClCompile Include="..\..\src\pigui\View.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)pigui\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)pigui\</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\pigui\Widgets.cpp" />
     <ClCompile Include="..\..\src\Plane.cpp" />
     <ClCompile Include="..\..\src\Planet.cpp" />
@@ -533,6 +536,7 @@
     <ClCompile Include="..\..\src\ShipCpanel.cpp" />
     <ClCompile Include="..\..\src\ShipCpanelMultiFuncDisplays.cpp" />
     <ClCompile Include="..\..\src\ShipType.cpp" />
+    <ClCompile Include="..\..\src\ship\CameraController.cpp" />
     <ClCompile Include="..\..\src\ship\PlayerShipController.cpp" />
     <ClCompile Include="..\..\src\ship\Propulsion.cpp" />
     <ClCompile Include="..\..\src\ship\ShipController.cpp" />
@@ -588,7 +592,6 @@
     <ClInclude Include="..\..\src\Body.h" />
     <ClInclude Include="..\..\src\ByteRange.h" />
     <ClInclude Include="..\..\src\Camera.h" />
-    <ClInclude Include="..\..\src\CameraController.h" />
     <ClInclude Include="..\..\src\CargoBody.h" />
     <ClInclude Include="..\..\src\CityOnPlanet.h" />
     <ClInclude Include="..\..\src\CollMesh.h" />
@@ -716,7 +719,7 @@
     <ClInclude Include="..\..\src\ShipCpanel.h" />
     <ClInclude Include="..\..\src\ShipCpanelMultiFuncDisplays.h" />
     <ClInclude Include="..\..\src\ShipType.h" />
-    <ClInclude Include="..\..\src\ship\InteractionController.h" />
+    <ClInclude Include="..\..\src\ship\CameraController.h" />
     <ClInclude Include="..\..\src\ship\PlayerShipController.h" />
     <ClInclude Include="..\..\src\ship\Propulsion.h" />
     <ClInclude Include="..\..\src\ship\ShipController.h" />
@@ -744,6 +747,7 @@
     <ClInclude Include="..\..\src\versioningInfo.h" />
     <ClInclude Include="..\..\src\VideoLink.h" />
     <ClInclude Include="..\..\src\View.h" />
+    <ClInclude Include="..\..\src\ViewController.h" />
     <ClInclude Include="..\..\src\win32\TextUtils.h" />
     <ClInclude Include="..\..\src\win32\WinMath.h" />
     <ClInclude Include="..\..\src\WorldView.h" />

--- a/win32/vs2019/pioneer.vcxproj.filters
+++ b/win32/vs2019/pioneer.vcxproj.filters
@@ -228,9 +228,6 @@
     <ClCompile Include="..\..\src\SpaceStationType.cpp">
       <Filter>src</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\CameraController.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\EnumStrings.cpp">
       <Filter>src</Filter>
     </ClCompile>
@@ -579,6 +576,12 @@
     <ClCompile Include="..\..\src\core\LZ4Format.cpp">
       <Filter>src\core</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ship\CameraController.cpp">
+      <Filter>src\ship</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\pigui\View.cpp">
+      <Filter>src\pigui</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Aabb.h">
@@ -803,9 +806,6 @@
     <ClInclude Include="..\..\src\SpaceStationType.h">
       <Filter>src</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\CameraController.h">
-      <Filter>src</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\EnumStrings.h">
       <Filter>src</Filter>
     </ClInclude>
@@ -952,9 +952,6 @@
     </ClInclude>
     <ClInclude Include="..\..\src\sound\SoundMusic.h">
       <Filter>src\sound</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\ship\InteractionController.h">
-      <Filter>src\ship</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ship\PlayerShipController.h">
       <Filter>src\ship</Filter>
@@ -1138,6 +1135,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\core\LZ4Format.h">
       <Filter>src\core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ship\CameraController.h">
+      <Filter>src\ship</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ViewController.h">
+      <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/7342077/94365529-c764bc80-009f-11eb-8866-3218bbaaa857.png)


Multiple files moved between src/ <-> src/ship/
src/View.cpp and src/pigui/View.cpp were being compiled to view.obj. This caused some weird linking issues: symbols from one would always be missing, but which one depended on what file was compiled last. 
Changed src/pigui/View.cpp to compile to pigui/view.obj


