### PR TITLE
Define ui.oneOverSqrtTwo (fixes 4965)

### DIFF
--- a/data/pigui/baseui.lua
+++ b/data/pigui/baseui.lua
@@ -13,6 +13,8 @@ local two_pi = pi * 2
 local standard_gravity = 9.80665
 local one_over_sqrt_two = 1 / math.sqrt(2)
 
+ui.oneOverSqrtTwo = one_over_sqrt_two
+ui.standardGravity = standard_gravity
 ui.theme = defaultTheme
 ui.twoPi = two_pi
 ui.pi_2 = pi_2

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -50,7 +50,6 @@ ui.getTextLineHeight = pigui.GetTextLineHeight
 ui.getTextLineHeightWithSpacing = pigui.GetTextLineHeightWithSpacing
 ui.lowThrustButton = pigui.LowThrustButton
 ui.thrustIndicator = pigui.ThrustIndicator
-ui.oneOverSqrtTwo = one_over_sqrt_two
 ui.isMouseClicked = pigui.IsMouseClicked
 ui.isMouseDown = pigui.IsMouseDown
 ui.getMousePos = pigui.GetMousePos


### PR DESCRIPTION
Looks like I missed a variable being defined when I split the PiGui Lua modules apart, breaking 2D radar. 

`ui.oneOverSqrtTwo` and `ui.standardGravity` are now defined again in pigui/baseui.lua.

Fixes #4965
