### PR TITLE
Move Economy & Trade -view to pigui

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -527,6 +527,10 @@
     "description": "Hyperjump planner, referring to star system target",
     "message": "Final Target:"
   },
+  "FINANCE": {
+    "description": "Financial statement of player, e.g. cash",
+    "message": "Finance"
+  },
   "FLIGHTLOG_DOCKING": {
     "description": "Used in Flight Log, to indicate player's position. 'primary_info' is a station name",
     "message": "Docking at {primary_info}"

--- a/data/libs/EquipSet.lua
+++ b/data/libs/EquipSet.lua
@@ -51,9 +51,9 @@ function EquipSet:AddListener(listener)
 	listeners[self] = listener
 end
 
-function EquipSet:CallListener()
+function EquipSet:CallListener(slot)
 	if listeners[self] then
-		listeners[self]()
+		listeners[self](slot)
 	end
 end
 
@@ -213,7 +213,7 @@ function EquipSet:__TriggerCallbacks(ship, slot)
 	else
 		ship:setprop("totalCargo", math.min(self.slots.cargo.__limit, self.slots.cargo.__occupied+ship.freeCapacity))
 	end
-	self:CallListener()
+	self:CallListener(slot)
 end
 
 -- Method: __Remove_NoCheck (PRIVATE)

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -4,15 +4,245 @@
 local ui = require 'pigui'
 local InfoView = require 'pigui.views.info-view'
 local Lang = require 'Lang'
-
+local Game = require "Game"
+local Equipment = require "Equipment"
+local ShipDef = require "ShipDef"
+local StationView = require 'pigui/views/station-view'
+local Format = require "Format"
 local l = Lang.GetResource("ui-core")
 
+local colors = ui.theme.colors
+local icons = ui.theme.icons
+local pionillium = ui.fonts.pionillium
+local gray = colors.grey
+
+local iconSize = Vector2(28, 28) * (ui.screenHeight / 1200)
+local buttonSpaceSize = iconSize
+
+local shipDef
+local hyperdrive
+local hyperdrive_fuel
+
+local jettison = function (item)
+	local enabled = Game.player.flightState == "FLYING"
+	local bgcolor = enabled and colors.buttonBlue or colors.grey
+	local tooltip = l.JETTISON .. "##".. item:GetName()
+
+	local button = ui.coloredSelectedIconButton(icons.cargo_crate_illegal, buttonSpaceSize, false, 0, colors.buttonBlue, colors.white, tooltip, iconSize)
+
+	if button and enabled then
+		print("Jettison:", item:GetName(), size)
+		Game.player:Jettison(item)
+	end
+
+	return button
+end
+
+local function cargolist ()
+	local count = {}
+	for k, et in pairs(Game.player:GetEquip("cargo")) do
+		if not count[et] then count[et] = 0 end
+		count[et] = count[et]+1
+	end
+
+	local max_width = ui.calcTextSize("12t")
+	ui.columns(3, "cargoTable")
+
+	ui.setColumnWidth(0, max_width.x)
+	for et, nb in pairs(count) do
+		-- count
+		local text = nb .. "t"
+		local width = ui.calcTextSize(text)
+		max_width = max_width.x < width.x and width or max_width
+		ui.text(text)
+		ui.nextColumn()
+
+		-- name
+		ui.text(et:GetName())
+		ui.nextColumn()
+
+		-- jettison button
+		jettison(et)
+		ui.nextColumn()
+	end
+	ui.columns(1, "")
+end
+
+
+local pumpDown = function (fuel)
+	local player = Game.player
+	if player.fuel == 0 or player:GetEquipFree("cargo") == 0 then
+		print("No fuel left to pump!")
+		return
+	end
+
+	-- internal tanks capacity
+ 	local fuelTankMass = ShipDef[player.shipId].fuelTankMass
+
+	-- current fuel in internal tanks, in tonnes
+ 	local availableFuel = math.floor(player.fuel / 100 * fuelTankMass)
+
+	fuel = fuel * -1
+
+	-- Don't go above 100%
+ 	if fuel > availableFuel then fuel = availableFuel end
+
+	-- Military fuel is only used for the hyperdrive
+ 	local drainedFuel = player:AddEquip(Equipment.cargo.hydrogen, fuel)
+
+	-- Set internal thruster fuel tank state
+	-- (player.fuel is percentage, between 0-100)
+ 	player:SetFuelPercent(math.clamp(player.fuel - drainedFuel * 100 / fuelTankMass, 0, 100))
+	print("Game.player.fuel", player.fuel)
+end
+
+-- wrapper around gaugees, for consistent size, and vertical spacing
+local function gauge_bar(x, text, min, max, icon)
+	local height = ui.getTextLineHeight()
+	local gaugePos = ui.getCursorScreenPos()
+	local fudge_factor = 1.0
+	local gaugeWidth = ui.getContentRegion().x * fudge_factor
+	gaugePos.y = gaugePos.y + height
+
+	ui.gauge(gaugePos, x, '', text, min, max, icon,
+			 colors.gaugeEquipmentMarket, '', gaugeWidth, height)
+
+	ui.text("")
+	ui.text("")
+end
+
+-- Gauge bar for internal, interplanetary, fuel tank
+local function gauge_fuel()
+	local player = Game.player
+	local text = string.format(l.FUEL .. ": %dt \t" .. l.DELTA_V .. ": %d km/s",
+		shipDef.fuelTankMass/100 * player.fuel, player:GetRemainingDeltaV()/1000)
+
+	gauge_bar(player.fuel, text, 0, 100, icons.fuel)
+end
+
+-- Gauge bar for hyperdrive fuel / range
+local function gauge_hyperdrive()
+	local player = Game.player
+	local text = string.format(l.FUEL .. ": %dt \t" .. l.HYPERSPACE_RANGE .. ": %d " .. l.LY,
+		player:CountEquip(hyperdrive_fuel), player:GetHyperspaceRange())
+
+	gauge_bar(player:CountEquip(hyperdrive_fuel), text, 0,
+			  player.totalCargo - player.usedCargo + player:CountEquip(hyperdrive_fuel),
+			  icons.hyperspace)
+end
+
+-- Gauge bar for used/free cargo space
+local function gauge_cargo()
+	local player = Game.player
+	gauge_bar(player.usedCapacity, string.format('%%it %s / %it %s', l.USED, player.freeCapacity, l.FREE),
+			  0, player.usedCapacity + player.freeCapacity, icons.market)
+end
+
+-- Gauge bar for used/free cabins
+local function gauge_cabins()
+	local player = Game.player
+	local cabins_total = player:GetEquipCountOccupied("cabin")
+	local cabins_free = player.cabin_cap or 0
+	local cabins_used = cabins_total - cabins_free
+	gauge_bar(cabins_used, string.format('%%i %s / %i %s', l.USED, cabins_free, l.FREE),
+			  0, cabins_total, icons.personal)
+end
+
+local function drawEconTrade()
+	local player = Game.player
+
+	-- Current mass of fuel stored in internal tanks
+	local fuelMassLeft = player.fuelMassLeft
+
+	-- Current fuel in internal tanks, in interval [0,100], as float
+	local currentfuel = player.fuel
+
+	if ui.collapsingHeader(l.FUEL, {"DefaultOpen"}) then
+		gauge_fuel()
+
+		local current_fuel_text = string.format("%.2f%%", currentfuel)
+
+		local width1 = ui.calcTextSize(l.PUMP_DOWN)
+		local width2 = ui.calcTextSize(l.REFUEL)
+		local width = width2.x and width1.x < width2.x or width1.x
+		width = width * 1.2
+
+		-- to-do: maybe show disabled version of button if fuel==100 or hydrogen==0
+		-- (if so, what about military fuel?)
+		-- at the moment: no visual cue for this.
+		ui.text(l.REFUEL)
+		ui.sameLine(width)
+		local options = {1, 10, 100}
+		for _, k in ipairs(options) do
+			if ui.button(tostring(k)  .. "##fuel", Vector2(100, 0)) then
+				-- Refuel k tonnes from cargo hold
+				local successfully_used = Game.player:Refuel(k)
+			end
+			ui.sameLine()
+		end
+		ui.text("")
+
+		-- To-do: Maybe also show disabled version of button if currentfuel == 0 or player:GetEquipFree("cargo") == 0
+		-- at the moment: no visual cue for this.
+		ui.text(l.PUMP_DOWN)
+		ui.sameLine(width)
+		for k, v in ipairs(options) do
+			fuel = -1*v
+			if ui.button(fuel .. "##pump", Vector2(100, 0)) then
+				pumpDown(fuel)
+			end
+			ui.sameLine()
+		end
+		ui.text("")
+	end
+
+	gauge_hyperdrive()
+
+	if ui.collapsingHeader(l.CABINS, {"DefaultOpen"}) then
+		local totalCabins = Game.player:GetEquipCountOccupied("cabin")
+		local usedCabins = totalCabins - (Game.player.cabin_cap or 0)
+
+		gauge_cabins()
+	end
+
+	if ui.collapsingHeader(l.FINANCE, {"DefaultOpen"}) then
+		local cash = player:GetMoney()
+		ui.text(l.CASH)
+		ui.sameLine()
+		ui.text(Format.Money(cash))
+	end
+
+end
 
 InfoView:registerView({
     id = "econTrade",
     name = l.ECONOMY_TRADE,
     icon = ui.theme.icons.cargo_manifest,
-    showView = false,
-    draw = function() end,
-    refresh = function() end,
+    showView = true,
+    draw = function()
+		ui.withStyleVars({ WindowPadding = Vector2(24, 24) }, function()
+			ui.child("", Vector2(0, 0), ui.WindowFlags {"AlwaysUseWindowPadding"}, function()
+            	ui.withFont(pionillium.medlarge, function()
+					local sizex = ui.screenWidth / 2
+					local sizey = ui.getContentRegion().y - StationView.style.height
+					ui.child("leftpanel", Vector2(sizex, sizey), function()
+						drawEconTrade() end)
+
+					ui.sameLine()
+
+					ui.child("rightpanel", Vector2(sizex, sizey), function()
+						if ui.collapsingHeader(l.CARGO, {"DefaultOpen"}) then
+							gauge_cargo()
+							cargolist()
+						end
+					end)
+				end)
+			end)
+		end)
+	end,
+	refresh = function()
+		shipDef = ShipDef[Game.player.shipId]
+		hyperdrive = table.unpack(Game.player:GetEquip("engine")) or nil
+		hyperdrive_fuel = hyperdrive and hyperdrive.fuel or Equipment.cargo.hydrogen
+	end,
 })

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -232,7 +232,7 @@ InfoView:registerView({
 	draw = function()
 		ui.withStyleVars({ItemSpacing = itemSpacing}, function()
 			ui.withFont(pionillium.medlarge, function()
-				local sizex = ui.screenWidth / 2
+				local sizex = (ui.getColumnWidth() - itemSpacing.x) / 2
 				local sizey = ui.getContentRegion().y - StationView.style.height
 				ui.child("leftpanel", Vector2(sizex, sizey), function()
 					drawEconTrade()

--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -127,7 +127,7 @@ local function makeMissionRows()
 	end
 end
 
-InfoView:registerView("missions", {
+InfoView:registerView({
     id = "missions",
     name = l.MISSIONS,
     icon = ui.theme.icons.star,

--- a/data/pigui/modules/info-view/05-crew.lua
+++ b/data/pigui/modules/info-view/05-crew.lua
@@ -275,7 +275,7 @@ require 'Event'.Register('onGameEnd', function()
 	lastTaskResult = ""
 end)
 
-InfoView:registerView("crew", {
+InfoView:registerView({
     id = "crew",
     name = l.CREW_ROSTER,
     icon = ui.theme.icons.roster,

--- a/data/pigui/views/tab-view.lua
+++ b/data/pigui/views/tab-view.lua
@@ -58,20 +58,13 @@ function PiGuiTabView.resize(self)
             self.buttonWindowSize.y + viewWindowPadding.y)
 end
 
-function PiGuiTabView.registerView(self, id, view)
-	if view then
-		local idx = self.tabs[id]
-		if idx then
-			self.tabs[idx] = view; return
-		else
-			self.tabs[id] = #self.tabs + 1
-		end
-	else
-		id, view = view, id
-	end
+function PiGuiTabView.registerView(self, view)
+	local idx = self.tabs[view.id]
+	if idx then self.tabs[idx] = view; return end
 
     table.insert(self.tabs, view)
 	self.viewCount = self.viewCount + 1
+	self.tabs[view.id] = self.viewCount
     self:resize()
 end
 
@@ -155,8 +148,10 @@ function PiGuiTabView.renderTabView(self)
         end)
 	end)
 
-	if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) and tab.debugReload then
-		tab:debugReload()
+	if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) then
+		if tab.debugReload then tab:debugReload() end
+		-- refresh the (possibly) new tab
+		self.tabs[self.currentTab]:refresh()
 	end
 end
 

--- a/src/pigui/PiGuiSandbox.cpp
+++ b/src/pigui/PiGuiSandbox.cpp
@@ -28,7 +28,7 @@ static int CleanupWindowStack(SavedImguiStackInfo *stackInfo)
 
 	// While it shouldn't be possible to get a window stack of less than the last time it was updated,
 	// we want to check for it anyways to avoid causing issues down the line.
-	if (numUnfinishedWindows <= 1 || !stackInfo->windowStackSize)
+	if (numUnfinishedWindows <= 0 || !stackInfo->windowStackSize)
 		return 0;
 
 	for (int n = numUnfinishedWindows; n > 0; n--) {


### PR DESCRIPTION
## Thoughts
Working with this, I think there's a lot of stuff that's overlapping with "ship info". I'd suggest "ship info" only show the static info on that ship's stats, and equipment, and this "economy & trade view" shows all the stuff about cargo, fuel, interna-tank mass, and range. Possibly, this could be outside the scope of this PR.

Also, I had a wrestling match against the colorselectbutton since, in my estimation, it makes no sense, in how it tints the button, but for now, it's some kind of deactivated when landed (one cannot jettison when landed). I got the feeling I was using the wrong function, since it's not doing what I want, which is what the name suggestes it's supposed to do. Theme-issues.

## Bug exposed in master?
I remember playing with this in june/july, and finding some inconsistency  in how we define "cargo space" relative internal fuel mass, but I'm not sure I notice what it was. I.e. (back then) I thought the "Used" cargo space displayed in the cargo gauge bar was wrong.

## What remains
At the moment I'm not quite sure how to do the first two in this list:
- [ ] Move jettison-buttons further right?
- [x] Fix there not being any margin to the left
- [x] Clean up / remove commented out code experiments
- [ ] Tool tip doesn't seem to work?
- [x] Settle on what info should be displayed / how?
  - should progress gauges be shown (at all? / or like now, clustered under "summary")?
  - should we show cash?
- [x] squash some commits
 
![2020-11-10-092015_1600x900_scrot](https://user-images.githubusercontent.com/619390/98650193-d5615a80-2338-11eb-9036-791ffbc122fc.png)

