### PR TITLE
Use an offscreen buffer as the primary render target.

### DIFF
--- a/src/JobQueue.h
+++ b/src/JobQueue.h
@@ -263,6 +263,7 @@ public:
 	virtual void Order(Job *job)
 	{
 		auto x = m_jobs.insert(m_queue->Queue(job, this));
+		(void)x; // suppress unused variable warning
 		assert(x.second);
 	}
 	virtual void RemoveJob(Job::Handle *handle) { m_jobs.erase(*handle); }

--- a/src/graphics/RenderTarget.h
+++ b/src/graphics/RenderTarget.h
@@ -18,12 +18,13 @@ namespace Graphics {
 	// Specifying a depth format with no allowDepthTexture will create a depth buffer
 	// fixed to this rendertarget
 	struct RenderTargetDesc {
-		RenderTargetDesc(Uint16 _width, Uint16 _height, TextureFormat _colorFormat, TextureFormat _depthFormat, bool _allowDepthTexture) :
+		RenderTargetDesc(Uint16 _width, Uint16 _height, TextureFormat _colorFormat, TextureFormat _depthFormat, bool _allowDepthTexture = false, Uint16 _samples = 0) :
 			width(_width),
 			height(_height),
 			colorFormat(_colorFormat),
 			depthFormat(_depthFormat),
-			allowDepthTexture(_allowDepthTexture)
+			allowDepthTexture(_allowDepthTexture),
+			numSamples(_samples)
 		{}
 
 		const Uint16 width;
@@ -31,6 +32,7 @@ namespace Graphics {
 		const TextureFormat colorFormat;
 		const TextureFormat depthFormat;
 		const bool allowDepthTexture;
+		const Uint16 numSamples;
 	};
 
 	class RenderTarget {

--- a/src/graphics/opengl/GLDebug.h
+++ b/src/graphics/opengl/GLDebug.h
@@ -86,6 +86,9 @@ namespace Graphics {
 			GLuint id, GLenum severity, GLsizei length,
 			const GLchar *message, const void *userParam)
 		{
+			// filter out Type=Other informational messages
+			if (type > GL_DEBUG_TYPE_PERFORMANCE)
+				return;
 			Output("Type: %s, Source: %s, ID: %u, Severity: %s, Message: %s\n",
 				type_to_string(type), source_to_string(source), id,
 				severity_to_string(severity), message);

--- a/src/graphics/opengl/RenderTargetGL.h
+++ b/src/graphics/opengl/RenderTargetGL.h
@@ -17,21 +17,6 @@ namespace Graphics {
 
 	namespace OGL {
 
-		class RenderTarget;
-
-		class RenderBuffer : public RefCounted {
-		public:
-			~RenderBuffer();
-			void Bind();
-			void Unbind();
-			void Attach(GLenum attachment);
-
-		protected:
-			friend class RenderTarget;
-			RenderBuffer();
-			GLuint buffer;
-		};
-
 		class RenderTarget : public Graphics::RenderTarget {
 		public:
 			~RenderTarget();
@@ -51,8 +36,8 @@ namespace Graphics {
 
 			bool m_active;
 			GLuint m_fbo;
+			GLuint m_depthRenderbuffer;
 
-			RefCountedPtr<RenderBuffer> m_depthRenderBuffer;
 			RefCountedPtr<Texture> m_colorTexture;
 			RefCountedPtr<Texture> m_depthTexture;
 		};

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -149,6 +149,7 @@ namespace Graphics {
 		std::unordered_map<Uint32, OGL::RenderState *> m_renderStates;
 		float m_invLogZfarPlus1;
 		OGL::RenderTarget *m_activeRenderTarget;
+		OGL::RenderTarget *m_windowRenderTarget;
 		RenderState *m_activeRenderState;
 
 		matrix4x4f m_modelViewMat;

--- a/src/graphics/opengl/TextureGL.h
+++ b/src/graphics/opengl/TextureGL.h
@@ -15,7 +15,7 @@ namespace Graphics {
 			virtual void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final;
 			virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips) override final;
 
-			TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering);
+			TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering, const Uint16 numSamples = 0);
 			virtual ~TextureGL();
 
 			virtual void Bind() override final;


### PR DESCRIPTION
Refactor the renderer to use an offscreen buffer as the primary render target instead of the window surface. Among other benefits, this means that we don't need the windowing system to give us a 24-bit depth MSAA window surface; as long as the GPU is able to render to those textures we'll be fine.

This is required for later postprocessing work; we need to resolve the MSAA before we do image post processing (we'll probably go the tonemap-resolve-inverse-tonemap route as that seems to be pretty standard).

It also lays the groundwork for 32-bit reverse-Z depth buffer (in fact, the clever among you will notice that the renderer is looking for `ARB_clip_control` and creating a `DEPTH_COMPONENT_32F` depth buffer!) This should allow us to drop the logarithmic depth hack, speeding up our shaders somewhat and allowing them to be eligible for the early-Z test again.

Tangentially, this makes resizing windows and changing graphics settings without needing to restart the game much more possible; while changing resolution is going to need more work on the UI layout side of things, changing MSAA is totally technically feasible, just not... implemented, yet.

