### PR TITLE
Update MSVC CMake configuration and instructions

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,34 +1,40 @@
-﻿{
-  "configurations": [
-    {
-      "name": "x64-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "buildRoot": "${projectDir}\\out\\build\\${name}",
-      "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "variables": []
-    },
-    {
-      "name": "x64-Release",
-      "generator": "Ninja",
-      "configurationType": "RelWithDebInfo",
-      "buildRoot": "${projectDir}\\out\\build\\${name}",
-      "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": [
+{
+    "configurations": [
         {
-          "name": "CMAKE_BUILD_TYPE",
-          "value": "RelWithDebInfo",
-          "type": "STRING"
+            "name": "x64-Debug",
+            "generator": "Ninja",
+            "configurationType": "Debug",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "variables": []
+        },
+        {
+            "name": "x64-Release",
+            "generator": "Ninja",
+            "configurationType": "Release",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "variables": []
+        },
+        {
+            "name": "x64-Profiling",
+            "generator": "Ninja",
+            "configurationType": "RelWithDebInfo",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
+            "cmakeCommandArgs": "-DPROFILER_ENABLED=1",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "variables": []
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -120,15 +120,14 @@ questions are welcome anytime.
 
 3. Go to File->Open->CMake and select pioneer/CMakeLists.txt
 
-4. If a Release build is desired, select 'Manage Configurations' under the build type,
-   which will default to x64-Debug and add x64-Release.
+4. Select the appropriate build type (x64-Debug or x64-Release) under the configuration
+   drop down on the main toolbar, located next to the run button. 
 
-5. Select the appropriate build type.
+5. Build the project (Build->Build All).
 
-6. Buid the project (Build->Build All).
-
-7. Pioneer can be run and debugged by selecting 'pioneer.exe' on the 
-   'Select Startup Item' toolbar button, and then clicking run.
+6. Pioneer can be run and debugged by selecting 'pioneer.exe' on the 
+   'Select Startup Item' menu (click the small down arrow on the run button), and then clicking run.
+   Be sure to select 'pioneer.exe' and not 'pioneer.exe (install)'.
 
 
 1.5 OS X - Homebrew


### PR DESCRIPTION
- Update COMPILING
  The instructions for using the Visual Studio CMake build should hopefully be a bit more clear now. They now reflect the fact that build configurations are already setup and don't have to be changed (also see next point).
  (@macksting - if you get a chance, I'd love to know if this makes more sense)
- Fix CMakeSettings.json
  A somewhat recent update changed how Visual Studio read this file, and the change was breaking. This should now work properly _and_ I've added a super luxurious newline at the end, too.
- Add x64-Profiling build configuration
  Pre-configured to build with profiling enabled.



