### PR TITLE
Fix SAR crash where IsPlayer() is falsely called by non-ship body

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1986,7 +1986,7 @@ local onCreateBB = function (station)
 	for _ = 1,num do
 		-- makeAdvert(station, 1, closestplanets)
 		-- makeAdvert(station, 2, closestplanets)
-		-- makeAdvert(station, 3, closestplanets)
+	   -- makeAdvert(station, 3, closestplanets)
 		-- makeAdvert(station, 4, closestplanets)
 		-- makeAdvert(station, 5, closestplanets)
 		-- makeAdvert(station, 6, closestplanets)
@@ -2286,12 +2286,13 @@ end
 local onShipDestroyed = function (ship, attacker)
 	for _,mission in pairs(missions) do
 		if mission.target and ship == mission.target then
-			mission.target = nil
-			if attacker:IsPlayer() then
-				mission.target_destroyed = "BY_PLAYER"
-			else
-				mission.target_destroyed = "BY_ACCIDENT"
-			end
+		   mission.target = nil
+		   mission.target_destroyed = "BY_ACCIDENT"
+		   if attacker:IsDynamic() then
+		      if attacker:IsPlayer() then
+			 mission.target_destroyed = "BY_ACCIDENT"
+		      end
+		   end
 		end
 	end
 

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -2288,7 +2288,7 @@ local onShipDestroyed = function (ship, attacker)
 		if mission.target and ship == mission.target then
 			mission.target = nil
 			mission.target_destroyed = "BY_ACCIDENT"
-			if attacker:IsDynamic() and if attacker:IsPlayer() then
+			if attacker:IsDynamic() and attacker:IsPlayer() then
 				mission.target_destroyed = "BY_PLAYER"
 			end
 		end

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1986,7 +1986,7 @@ local onCreateBB = function (station)
 	for _ = 1,num do
 		-- makeAdvert(station, 1, closestplanets)
 		-- makeAdvert(station, 2, closestplanets)
-	   -- makeAdvert(station, 3, closestplanets)
+		-- makeAdvert(station, 3, closestplanets)
 		-- makeAdvert(station, 4, closestplanets)
 		-- makeAdvert(station, 5, closestplanets)
 		-- makeAdvert(station, 6, closestplanets)
@@ -2286,13 +2286,11 @@ end
 local onShipDestroyed = function (ship, attacker)
 	for _,mission in pairs(missions) do
 		if mission.target and ship == mission.target then
-		   mission.target = nil
-		   mission.target_destroyed = "BY_ACCIDENT"
-		   if attacker:IsDynamic() then
-		      if attacker:IsPlayer() then
-			 mission.target_destroyed = "BY_ACCIDENT"
-		      end
-		   end
+			mission.target = nil
+			mission.target_destroyed = "BY_ACCIDENT"
+			if attacker:IsDynamic() and if attacker:IsPlayer() then
+				mission.target_destroyed = "BY_PLAYER"
+			end
 		end
 	end
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This fixes the last comment of #4551. When a SAR mission ship is destroyed the script tries to establish if it was the player's fault or not. But IsPlayer() is not defined for bodies other than ships. This should fix this issue. The save-file attached to the bug report runs fine now.

I was not able to reproduce the other comments in this bug report (crash after trying to deliver crew). Maybe this got fixed together with #4601? Also, the attached respective save file does not load, which makes it hard to pinpoint if the problem was solved.  