### PR TITLE
Decreasing the max star size to 0.3

### DIFF
--- a/data/configs/Starfield.ini
+++ b/data/configs/Starfield.ini
@@ -17,7 +17,7 @@ medianPosition=0.7
 brightnessPower=3.5
 
 # the bigger this number is the bigger are stars compared to their brightness
-brightnessApparentSizeFactor=0.5
+brightnessApparentSizeFactor=0.3
 
 #the bigger this number is the bigger are stars no matter their brightness
 brightnessApparentSizeOffset=0.1


### PR DESCRIPTION
I think the bigger star size on the starfield is too excessive, it clashes with the HUD, and isn't really feel like they are brighter stars.
So I've decreased the _brightnessApparentSizeFactor_ from 0.5 to 0.3
(Enlarge the screenshots to see the effect properly:
I think they look much better at 03. They are more subtle, but in a nice way:
![0 3](https://user-images.githubusercontent.com/4182678/97781001-b28cb480-1b88-11eb-8fe4-4fc92fa5a707.png)

Original 0.5:
![0 5](https://user-images.githubusercontent.com/4182678/97780998-ab65a680-1b88-11eb-9a62-a8929fdbc4cc.png)

At 0.4 they are still a bit too much in my opinion
![0 4](https://user-images.githubusercontent.com/4182678/97781023-d7812780-1b88-11eb-881a-f11db1da114e.png)

At 0.1, they aren't visible most of the time:
![0 1](https://user-images.githubusercontent.com/4182678/97781050-ff708b00-1b88-11eb-9315-224e4d94ea56.png)

And as a bonus, at 2.0, we turn [Olbers' paradox](https://en.wikipedia.org/wiki/Olbers%27_paradox) on it's head:
![2 0](https://user-images.githubusercontent.com/4182678/97781071-2af37580-1b89-11eb-9302-724a596df4ce.png)
