### PR TITLE
CMake: Avoid libGLU dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,9 @@ include_directories(
 	${GLEW_INCLUDE_DIRS}
 )
 
+# We don't want/need the GLU dependency
+add_definitions(-DGLEW_NO_GLU)
+
 if (NOT USE_SYSTEM_LIBGLEW)
 	add_subdirectory(contrib/glew)
 	add_library(GLEW::GLEW ALIAS glew)


### PR DESCRIPTION
Set the GLEW_NO_GLU build flag to avoid pulling in <gl/glu.h> when
including <gl/glew.h>, as it otherwise adds a dependency we don't
actually need.