### PR TITLE
Fall back to an empty resource if translation isn't found

### DIFF
--- a/data/pigui/modules/time-window.lua
+++ b/data/pigui/modules/time-window.lua
@@ -48,7 +48,7 @@ local function displayTimeWindow()
 			time = lc.PAUSED
 		end
 		local tooltip = string.interp(lui.HUD_REQUEST_TIME_ACCEL, { time = time })
-		if ui.coloredSelectedIconButton(icons['time_accel_' .. name], button_size, current == name, frame_padding, color, fg_color, tooltip)
+		if ui.coloredSelectedIconButton(icons['time_accel_' .. name], button_size, current == name, frame_padding, color, fg_color, tooltip .. "##time_accel_"..name)
 		or (ui.shiftHeld() and ui.isKeyReleased(key)) then
 			Game.SetTimeAcceleration(name, ui.ctrlHeld() or ui.isMouseDown(1))
 		end

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -232,12 +232,7 @@ local function showMainMenu()
 				desc = desc .. lui.HYPERDRIVE .. ": " .. (loc.hyperdrive and lui.YES or lui.NO) .. "\n"
 				desc = desc .. lui.EQUIPMENT .. ":\n"
 				for _,eq in pairs(loc.equipment) do
-				local equipname
-					if pcall(function() local t = elc[eq[1].l10n_key] end) then
-						equipname = elc[eq[1].l10n_key]
-					elseif pcall(function() local t= clc[eq[1].l10n_key] end) then
-						equipname = clc[eq[1].l10n_key]
-					end
+					local equipname = rawget(elc, eq[1].l10n_key) or rawget(clc, eq[1].l10n_key)
 					desc = desc .. "  - " .. equipname
 					if eq[2] > 1 then
 						desc = desc .. " x" .. eq[2] .. "\n"


### PR DESCRIPTION
This fixes #5007.

- Fix the time accel buttons not working correctly in Polish
- Fix the main menu's weird approach to loading from two lang resources
- Refactor the way we handle missing translations; log a warning and return a placeholder string
