### PR TITLE
MSVC CMake Updates

### DIFF
--- a/CI/appveyor/msvc/build.cmd
+++ b/CI/appveyor/msvc/build.cmd
@@ -8,6 +8,7 @@ cmake -G Ninja^
  -DCMAKE_INSTALL_PREFIX="C:/Program Files/Pioneer"^
  -DPIONEER_DATA_DIR="C:/Program Files/Pioneer/data"^
  -DCMAKE_BUILD_TYPE:STRING=Release^
+ -DCMAKE_INSTALL_MESSAGE=NEVER^
  -DGIT_EXECUTABLE="c:/Program Files/Git/cmd/git.exe"^
  c:\projects\pioneer || goto error
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,11 @@ if (MSVC)
 	# Use M_PI/M_E macros from math.h
 	add_definitions(-D_USE_MATH_DEFINES -DHAVE_M_PI)
 
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+    # Disable warning C4506 so that src/lua/LuaObject.h: template <> void LuaObject<SystemPath>::PushToLua(const SystemPath &o);
+    # doesn't spew multiple warnings
+
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP /wd4506")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /wd4506")
 endif (MSVC)
 
 if (APPLE)


### PR DESCRIPTION
> [2020-11-15 16:21:31] \<sturnclaw\> The-EG: could I ask you to suppress warning C4506 in MSVC/Windows CMake?
> [2020-11-15 16:21:35] \<sturnclaw\> It's a bit... spammy
> [2020-11-15 16:24:24] \<sturnclaw\> The-EG: also this https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_MESSAGE.html

The C4506 warning is now disabled project wide for the MSVC CMake build, and the appveyor build should no longer have the cmake 'install' messages.