### PR TITLE
Fix build with USE_SYSTEM_LIBLUA, again

### DIFF
--- a/src/lua/LuaMetaType.h
+++ b/src/lua/LuaMetaType.h
@@ -8,7 +8,8 @@
 #include "LuaManager.h"
 #include "LuaPushPull.h"
 #include "LuaTable.h"
-#include "src/lua.h"
+
+#include <lua.h>
 
 class LuaMetaTypeBase {
 public:

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -16,7 +16,8 @@
 #include "Space.h"
 #include "SpaceStation.h"
 #include "ship/PlayerShipController.h"
-#include "src/lua.h"
+
+#include <lua.h>
 
 /*
  * Class: Ship

--- a/src/lua/LuaStarSystem.cpp
+++ b/src/lua/LuaStarSystem.cpp
@@ -20,7 +20,8 @@
 #include "galaxy/GalaxyCache.h"
 #include "galaxy/Sector.h"
 #include "galaxy/StarSystem.h"
-#include "src/lua.h"
+
+#include <lua.h>
 
 /*
  * Class: StarSystem


### PR DESCRIPTION
Some recent changes did break USE_SYSTEM_LIBLUA, as they included
"src/lua.h" directly instead of <lua.h>.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

