### PR TITLE
Add "Borderless Window" configuration option

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -67,6 +67,10 @@
     "description": "",
     "message": "Backward acceleration"
   },
+  "BORDERLESS": {
+    "description": "Option to enable a borderless window",
+    "message": "Borderless Window"
+  },
   "BULLETIN_BOARD": {
     "description": "",
     "message": "Bulletin Board"

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -196,6 +196,7 @@ local function showVideoOptions()
 	local selectedDetail = keyOf(detailLabels,keyOf(detailLevels, Engine.GetPlanetDetailLevel()))-1
 
 	local fullscreen = Engine.GetFullscreen()
+	local borderless = Engine.GetBorderless()
 	local vsync = Engine.GetVSyncEnabled()
 	local anisoFilter = Engine.GetAnisoFiltering()
 
@@ -210,6 +211,12 @@ local function showVideoOptions()
 	local enableCockpit = Engine.GetCockpitEnabled()
 	local enableAutoSave = Engine.GetAutosaveEnabled()
 	local starDensity = Engine.GetAmountStars() * 100
+
+	local selectedFullscreenWindow
+
+	if Engine.GetFullscreen() then selectedFullscreenWindow = 0
+	elseif Engine.GetBorderless() then selectedFullscreenWindow = 2
+	else selectedFullscreenWindow = 1 end
 
 	local c
 	ui.text(lui.VIDEO_CONFIGURATION_RESTART_GAME_TO_APPLY)
@@ -226,12 +233,21 @@ local function showVideoOptions()
 		Engine.SetMultisampling(aa)
 	end
 
-	ui.columns(2,"video_checkboxes",false)
-	c,fullscreen = checkbox(lui.FULL_SCREEN, fullscreen)
+	c,selectedFullscreenWindow = combo("FULLSCREEN_MODE", selectedFullscreenWindow, {"Fullscreen", "Window", "Fullscreen Window"})
 	if c then
-		Engine.SetFullscreen(fullscreen)
+		if selectedFullscreenWindow == 0 then
+			Engine.SetFullscreen(true)
+			Engine.SetBorderless(false)
+		elseif selectedFullscreenWindow == 1 then
+			Engine.SetFullscreen(false)
+			Engine.SetBorderless(false)
+		elseif selectedFullscreenWindow == 2 then
+			Engine.SetFullscreen(false)
+			Engine.SetBorderless(true)
+		end
 	end
-	ui.nextColumn()
+
+	ui.columns(2,"video_checkboxes",false)
 	c,vsync = checkbox(lui.VSYNC, vsync, lui.VSYNC_DESC)
 	if c then
 		Engine.SetVSyncEnabled(vsync)

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -12,6 +12,7 @@ GameConfig::GameConfig(const map_string &override_)
 	map["AMD_MESA_HACKS"] = "0";
 	map["DisableSound"] = "0";
 	map["StartFullscreen"] = "0";
+	map["BorderlessWindow"] = "0";
 	map["ScrWidth"] = "1280";
 	map["ScrHeight"] = "720";
 	map["UIScaleFactor"] = "1";

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -173,6 +173,7 @@ Graphics::Renderer *GuiApplication::StartupRenderer(IniConfig *config, bool hidd
 	videoSettings.width = config->Int("ScrWidth");
 	videoSettings.height = config->Int("ScrHeight");
 	videoSettings.fullscreen = (config->Int("StartFullscreen") != 0);
+	videoSettings.borderless = (config->Int("BorderlessWindow") != 0);
 	videoSettings.hidden = hidden;
 	videoSettings.requestedSamples = config->Int("AntiAliasingMode");
 	videoSettings.vsync = (config->Int("VSync") != 0);

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -26,6 +26,7 @@ namespace Graphics {
 	struct Settings {
 		RendererType rendererType;
 		bool fullscreen;
+		bool borderless;
 		bool hidden;
 		bool useTextureCompression;
 		bool useAnisotropicFiltering;

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -283,6 +283,23 @@ static int l_engine_set_video_resolution(lua_State *l)
 	return 0;
 }
 
+static int l_engine_get_borderless(lua_State *l)
+{
+	lua_pushboolean(l, Pi::config->Int("BorderlessWindow") != 0);
+	return 1;
+}
+
+static int l_engine_set_borderless(lua_State *l)
+{
+	if (lua_isnone(l, 1))
+		return luaL_error(l, "SetBorderless takes one boolean argument");
+	const bool borderless = lua_toboolean(l, 1);
+	Pi::config->SetInt("BorderlessWindow", (borderless ? 1 : 0));
+	Pi::config->Save();
+
+	return 0;
+}
+
 /*
  * Method: GetFullscreen
  *
@@ -902,6 +919,8 @@ void LuaEngine::Register()
 		{ "SetVideoResolution", l_engine_set_video_resolution },
 		{ "GetFullscreen", l_engine_get_fullscreen },
 		{ "SetFullscreen", l_engine_set_fullscreen },
+		{ "GetBorderless", l_engine_get_borderless },
+		{ "SetBorderless", l_engine_set_borderless },
 		{ "GetDisableScreenshotInfo", l_engine_get_disable_screenshot_info },
 		{ "SetDisableScreenshotInfo", l_engine_set_disable_screenshot_info },
 		{ "GetVSyncEnabled", l_engine_get_vsync_enabled },


### PR DESCRIPTION
Add an option for running Pioneer in 'borderless window' mode. This will be the same as windowed mode except without window decorations or a border.

This is desirable on multi-monitor systems or when alt-tabbing. I didn't add a 'fullscreen windowed' because that's just this and setting the resolution to the same as the monitor.

Disabled:
![image](https://user-images.githubusercontent.com/7342077/100003953-cc3ea780-2d94-11eb-8303-06f885be8e2c.png)

Enabled:
![image](https://user-images.githubusercontent.com/7342077/100003879-b7faaa80-2d94-11eb-8c74-4748e5c0f694.png)

And a new option on the options screen:
![image](https://user-images.githubusercontent.com/7342077/100004039-eaa4a300-2d94-11eb-885e-c0f4c35cf69a.png)

