### PR TITLE
Small fixes, medlarge font in shipinfo view

### DIFF
--- a/data/pigui/libs/buttons.lua
+++ b/data/pigui/libs/buttons.lua
@@ -40,25 +40,27 @@ end
 --
 -- Function: ui.coloredSelectedButton
 --
--- ui.coloredSelectedButton(label, thesize, is_selected, bg_color, tooltip, enabled)
+-- > clicked = ui.coloredSelectedIconButton(label, button_size, is_selected,
+-- >               bg_color, tooltip, enabled)
+--
 --
 -- Example:
 --
--- >
+-- > clicked = ui.coloredSelectedButton("Click me", Vector2(100,0), false,
+-- >               ui.theme.colors.buttonBlue, "Does the thing", true)
 --
 -- Parameters:
 --
---   label       - string,
---   thesize     - Vector2,
---   is_selected - boolean,
---   bg_color    - Color, for background
---   fg_color    - Color, for forground
---   tint_color  - Color,
---   tooltip     - string, mouseover text, will be used as ID, must be unique, append "##uniqueID" if needed
+--   label - string, text rendered on the button, must be unique, can append with "##..."
+--   thesize - Vector2 object, giving size of button
+--   is_selected - boolean, if false, uses a darker tint of the button
+--   bg_color - Color(R,G,B), for background
+--   tooltip - string, mouseover text
+--   enabled - enable tootip text and highlight of button when mouse over
 --
 -- Returns:
 --
---   boolean - true if button was clicked
+--   clicked - true if button was clicked, (note: is_selected and enabled does not affect this)
 --
 function ui.coloredSelectedButton(label, thesize, is_selected, bg_color, tooltip, enabled)
 	if is_selected then
@@ -93,7 +95,7 @@ end
 --
 -- Function: ui.coloredSelectedIconButton
 --
--- > clicked = ui.coloredSelectedIconButton(icon, button_size, is_selected,
+-- > clicked = ui.coloredSelectedIconButton(icon, thesize, is_selected,
 -- >               frame_padding, bg_color, fg_color, tooltip, img_size)
 --
 --
@@ -105,7 +107,7 @@ end
 -- Parameters:
 --
 --   icon - image to place on button, e.g. from ui.theme.icons
---   button_size - size of button, Vector2
+--   thesize - size of button, Vector2
 --   is_selected - bool
 --   frame_padding - number
 --   bg_color - Color(R,G,B), for background

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -54,7 +54,7 @@ end
 local collapsingHeaderFlags = ui.TreeNodeFlags { "DefaultOpen" }
 
 local function shipStats()
-	local closed = ui.withFont(fonts.pionillium.medium, function()
+	local closed = ui.withFont(fonts.pionillium.medlarge, function()
 		return not ui.collapsingHeader("Ship Information", collapsingHeaderFlags)
 	end)
 
@@ -126,7 +126,7 @@ local function shipStats()
 end
 
 local function equipmentList()
-	local closed = ui.withFont(fonts.pionillium.medium, function()
+	local closed = ui.withFont(fonts.pionillium.medlarge, function()
 		return not ui.collapsingHeader("Equipment", collapsingHeaderFlags)
 	end)
 
@@ -166,7 +166,7 @@ InfoView:registerView({
 	icon = ui.theme.icons.info,
 	showView = true,
 	draw = function()
-		ui.withFont(fonts.pionillium.medium, function()
+		ui.withFont(fonts.pionillium.medlarge, function()
 			if _OLD_LAYOUT then
 				ui.columns(2, "shipInfo")
 

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -480,6 +480,18 @@ static int l_pigui_columns(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: getColumnWidth
+ *
+ * Return width of column, as float
+ *
+ * > local col_width = ui.getColumnWidth()
+ *
+ * Returns:
+ *
+ *   col_width - float, width of column
+ *
+ */
 static int l_pigui_get_column_width(lua_State *l)
 {
 	int column_index = LuaPull<int>(l, 1, -1);
@@ -515,6 +527,19 @@ static int l_pigui_set_column_width(lua_State *l)
 	return 1;
 }
 
+/*
+ * Function: setColumnOffset
+ *
+ * Set offset of column
+ *
+ * >  ui.setColumnOffset(index, width)
+ *
+ * Parameters:
+ *
+ *   index - int, index of column
+ *   width - float, offset of x coordinate
+ *
+ */
 static int l_pigui_set_column_offset(lua_State *l)
 {
 	PROFILE_SCOPED()
@@ -524,6 +549,18 @@ static int l_pigui_set_column_offset(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: getScrollY
+ *
+ * returns a float
+ *
+ * > local scroll = ui.getScrollY()
+ *
+ * Returns:
+ *
+ *   scroll - float
+ *
+ */
 static int l_pigui_get_scroll_y(lua_State *l)
 {
 	PROFILE_SCOPED()


### PR DESCRIPTION
Change font to medlarge, same as all (most?) other screens in ship info, and add documentation strings. 
(These commits keep getting merge conflicts in #4967, so I'll split them out to their own PR, and update that pr accordingly)

![2020-11-25-213201_1600x900_scrot](https://user-images.githubusercontent.com/619390/100279090-2f336880-2f66-11eb-9f63-dec4a3208296.png)
