### PR TITLE
Optimise route rendering

### DIFF
--- a/src/MathUtil.h
+++ b/src/MathUtil.h
@@ -24,6 +24,11 @@ namespace MathUtil {
 	{
 		return t * v2 + (F(1.0) - t) * v1;
 	}
+	template <class T, class F>
+	inline T Lerp(const T& v1, const T& v2, const F t)
+	{
+		return mix(v1, v2, t);
+	}
 
 	inline float Dot(const vector3f &a, const vector3f &b) { return a.x * b.x + a.y * b.y + a.z * b.z; }
 

--- a/src/MathUtil.h
+++ b/src/MathUtil.h
@@ -25,7 +25,7 @@ namespace MathUtil {
 		return t * v2 + (F(1.0) - t) * v1;
 	}
 	template <class T, class F>
-	inline T Lerp(const T& v1, const T& v2, const F t)
+	inline T Lerp(const T &v1, const T &v2, const F t)
 	{
 		return mix(v1, v2, t);
 	}

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -193,8 +193,12 @@ private:
 
 	// HyperJump Route Planner Stuff
 	std::vector<SystemPath> m_route;
+	Graphics::Drawables::Lines m_routeLines;
 	bool m_drawRouteLines;
-	void DrawRouteLines(const vector3f &playerAbsPos, const matrix4x4f &trans);
+	bool m_setupRouteLines;
+	void DrawRouteLines(const matrix4x4f &trans);
+	void SetupRouteLines(const vector3f &playerAbsPos);
+	void GetPlayerPosAndStarSize(vector3f &playerPosOut, float &currentStarSizeOut);
 
 	Graphics::RenderState *m_solidState;
 	Graphics::RenderState *m_alphaBlendState;

--- a/src/galaxy/Sector.cpp
+++ b/src/galaxy/Sector.cpp
@@ -35,6 +35,14 @@ float Sector::DistanceBetween(RefCountedPtr<const Sector> a, int sysIdxA, RefCou
 	return dv.Length();
 }
 
+float Sector::DistanceBetweenSqr(const RefCountedPtr<const Sector> a, const int sysIdxA, const RefCountedPtr<const Sector> b, const int sysIdxB)
+{
+	PROFILE_SCOPED()
+	vector3f dv = a->m_systems[sysIdxA].GetPosition() - b->m_systems[sysIdxB].GetPosition();
+	dv += Sector::SIZE * vector3f(float(a->sx - b->sx), float(a->sy - b->sy), float(a->sz - b->sz));
+	return dv.LengthSqr();
+}
+
 bool Sector::WithinBox(const int Xmin, const int Xmax, const int Ymin, const int Ymax, const int Zmin, const int Zmax) const
 {
 	PROFILE_SCOPED()

--- a/src/galaxy/Sector.h
+++ b/src/galaxy/Sector.h
@@ -26,6 +26,7 @@ public:
 	~Sector();
 
 	static float DistanceBetween(RefCountedPtr<const Sector> a, int sysIdxA, RefCountedPtr<const Sector> b, int sysIdxB);
+	static float DistanceBetweenSqr(const RefCountedPtr<const Sector> a, const int sysIdxA, const RefCountedPtr<const Sector> b, const int sysIdxB);
 
 	// Sector is within a bounding rectangle - used for SectorView m_sectorCache pruning.
 	bool WithinBox(const int Xmin, const int Xmax, const int Ymin, const int Ymax, const int Zmin, const int Zmax) const;


### PR DESCRIPTION
Build all of the lines into a single buffer once, render as necessary and offset using the transform.

Resolves part of #5030 rendering

- https://github.com/pioneerspacesim/pioneer/blob/b5e21686269c7efcadcc2301169147e6f7ca04e7/src/SectorView.cpp#L751 this needs some kind of spacial bucketting!
- Added a sector selection optimisation to avoid generating sectors we then discard `Info: SectorView::AutoRoute, nodes to search = 5253, earlied out sector distance from line: 109870 times.`
- Avoided a bunch of sqrt operations by using the square distance.
- Tried to reserve some of the vectors and other stl structures.
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

