### PR TITLE
CMake: Fix modelcompiler not compiling anything

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,7 +367,8 @@ if (MODELCOMPILER)
 	# This really shouldn't be done inside the source tree...
 	if (NOT MSVC)
 		add_custom_target(build-models
-			COMMAND ${CMAKE_COMMAND} -E env SDL_VIDEODRIVER=dummy ${MODELCOMPILER} -b inplace
+			COMMAND ${CMAKE_COMMAND} -E env SDL_VIDEODRIVER=dummy PIONEER_LOCAL_DATA_ONLY=1
+			${MODELCOMPILER} -b inplace
 			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 			COMMENT "Optimizing models" VERBATIM
 		)

--- a/src/posix/FileSystemPosix.cpp
+++ b/src/posix/FileSystemPosix.cpp
@@ -82,15 +82,19 @@ namespace FileSystem {
 		CFRelease(resourcesURL);
 		return path;
 #else
-		/* PIONEER_DATA_DIR should point to ${prefix}/share/pioneer/data.
-         * If this directory does not exist, try to use the "data" folder
-         * in the current directory. */
-		Time::DateTime mtime;
-		std::string str = absolute_path(std::string(PIONEER_DATA_DIR));
-		FileInfo::FileType ty = stat_path(str.c_str(), mtime);
+		printf("Init!\n");
 
-		if (ty == FileInfo::FT_DIR)
-			return str;
+		if (!getenv("PIONEER_LOCAL_DATA_ONLY")) {
+			/* PIONEER_DATA_DIR should point to ${prefix}/share/pioneer/data.
+			 * If this directory does not exist, try to use the "data" folder
+			 * in the current directory. */
+			Time::DateTime mtime;
+			std::string str = absolute_path(std::string(PIONEER_DATA_DIR));
+			FileInfo::FileType ty = stat_path(str.c_str(), mtime);
+
+			if (ty == FileInfo::FT_DIR)
+				return str;
+		}
 
 		return absolute_path(std::string("data"));
 #endif


### PR DESCRIPTION
When models are installed on the system, the modelcompiler would use
these instead of the local ones found in the "data" folder. However,
the *.model files are not installed on the system, so the
modelcompiler would end up not compiling anything.

Fix this by returning only the local "data" folder files in
FileSystemPosix.cpp if the PIONEER_LOCAL_DATA_ONLY environment variable
is set, and set this environment variable in CMake when the
modelcompiler is called.