### PR TITLE
Some map fixes

### DIFF
--- a/data/pigui/libs/chat-form.lua
+++ b/data/pigui/libs/chat-form.lua
@@ -171,7 +171,8 @@ function ChatForm:AddNavButton (target)
 					ui.playSfx("OK")
 				end
 			elseif not Game.InHyperspace() then
-				Game.sectorView:SwitchToPath(target:GetStarSystem().path)
+				-- if a specific systembody is given, set the sector map to the correct star (if the system is multiple)
+				Game.sectorView:SwitchToPath(target:IsBodyPath() and target:GetSystemBody().nearestJumpable.path or target:GetStarSystem().path)
 				ui.playBoinkNoise()
 			end
 		end

--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -32,7 +32,8 @@ local function setLocationAsTarget(location)
 			ui.playSfx("OK")
 		end
 	elseif not Game.InHyperspace() then
-		Game.sectorView:SwitchToPath(location:GetStarSystem().path)
+		-- if a specific systembody is given, set the sector map to the correct star (if the system is multiple)
+		Game.sectorView:SwitchToPath(location:IsBodyPath() and location:GetSystemBody().nearestJumpable.path or location:GetStarSystem().path)
 		ui.playBoinkNoise()
 	end
 end

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -333,7 +333,10 @@ local leftBarMode = "SEARCH"
 function Windows.searchBar:Show()
 	if mainMenuButton(icons.search_lens, lc.SEARCH) then leftBarMode = "SEARCH" end
 	ui.sameLine()
-	if mainMenuButton(icons.money, lui.ECONOMY_TRADE) then leftBarMode = "ECONOMY" end
+	if mainMenuButton(icons.money, lui.ECONOMY_TRADE) then
+		leftBarMode = "ECONOMY"
+		self.size.y = self.fullHeight
+	end
 
 	ui.spacing()
 
@@ -353,9 +356,12 @@ function Windows.searchBar:Show()
 
 		if not systemPaths or #systemPaths == 0 then
 			ui.text(lc.NOT_FOUND)
+			self.size.y = self.collapsedHeight
 		else
 			drawSearchResults(systemPaths)
+			self.size.y = self.fullHeight
 		end
+
 	elseif leftBarMode == "ECONOMY" then
 		local selectedPath = sectorView:GetSelectedSystemPath()
 		local currentPath = sectorView:GetCurrentSystemPath()
@@ -392,8 +398,11 @@ function Windows.searchBar:Show()
 end
 
 function Windows.searchBar.Dummy()
+	mainMenuButton(icons.search_lens, lc.SEARCH)
+	ui.spacing()
 	ui.text("***************")
 	ui.inputText("", "", {})
+	ui.spacing()
 	ui.text("***************")
 end
 
@@ -459,7 +468,9 @@ local function displaySectorViewWindow()
 				Windows.systemInfo.pos = Windows.hjPlanner.pos - Vector2(0, Windows.systemInfo.size.y)
 				Windows.systemInfo.size.x = Windows.hjPlanner.size.x
 				Windows.searchBar.pos = Windows.current.pos + Windows.current.size
+				Windows.searchBar.collapsedHeight = Windows.searchBar.size.y
 				Windows.searchBar.size.y = ui.screenHeight - Windows.searchBar.pos.y - edgePadding.y - ui.timeWindowSize.y
+				Windows.searchBar.fullHeight = Windows.searchBar.size.y
 				Windows.edgeButtons.pos = Vector2(ui.screenWidth - Windows.edgeButtons.size.x, ui.screenHeight / 2 - Windows.edgeButtons.size.y / 2) -- center-right
 				Windows.factions.pos = Vector2(Windows.systemInfo.pos.x, Windows.current.pos.y)
 				Windows.factions.size = Vector2(ui.screenWidth - Windows.factions.pos.x - edgePadding.x, 0.0)

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -1125,9 +1125,19 @@ void SectorView::Update()
 	const float moveSpeed = Pi::GetMoveSpeedShiftModifier();
 	float move = moveSpeed * frameTime * m_zoomClamped;
 	vector3f shift(0.0f);
-	if (InputBindings.mapViewMoveLeft->IsActive()) shift.x -= move * InputBindings.mapViewMoveLeft->GetValue();
-	if (InputBindings.mapViewMoveForward->IsActive()) shift.y += move * InputBindings.mapViewMoveForward->GetValue();
-	if (InputBindings.mapViewMoveUp->IsActive()) shift.z += move * InputBindings.mapViewMoveUp->GetValue();
+	bool manual_move = false; // used so that when you click on a system and move there, passing systems are not selected
+	if (InputBindings.mapViewMoveLeft->IsActive()) {
+		shift.x -= move * InputBindings.mapViewMoveLeft->GetValue();
+		manual_move = true;
+	}
+	if (InputBindings.mapViewMoveForward->IsActive()) {
+		shift.y += move * InputBindings.mapViewMoveForward->GetValue();
+		manual_move = true;
+	}
+	if (InputBindings.mapViewMoveUp->IsActive()) {
+		shift.z += move * InputBindings.mapViewMoveUp->GetValue();
+		manual_move = true;
+	}
 	m_posMovingTo += shift * shiftRot;
 
 	if (InputBindings.mapViewZoom->IsActive()) m_zoomMovingTo -= move * InputBindings.mapViewZoom->GetValue();
@@ -1187,7 +1197,7 @@ void SectorView::Update()
 		m_zoomClamped = Clamp(m_zoom, 1.f, FAR_LIMIT);
 	}
 
-	if (m_automaticSystemSelection) {
+	if (m_automaticSystemSelection && manual_move) {
 		SystemPath new_selected = SystemPath(int(floor(m_pos.x)), int(floor(m_pos.y)), int(floor(m_pos.z)), 0);
 
 		RefCountedPtr<Sector> ps = GetCached(new_selected);

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -130,7 +130,6 @@ public:
 	void AccelerateTime(float step);
 	void SetRealTime();
 	std::vector<Projectable> GetProjected() const { return m_projected; }
-	void BodyInaccessible(Body *b);
 	void SetVisibility(std::string param);
 	void SetZoomMode(bool enable);
 	void SetRotateMode(bool enable);

--- a/src/galaxy/SystemBody.h
+++ b/src/galaxy/SystemBody.h
@@ -86,6 +86,9 @@ public:
 	// We allow hyperjump to any star of the system
 	bool IsJumpable() const { return GetSuperType() == SUPERTYPE_STAR; }
 
+	// Climb the hierarchy until we find a jumpable. Guaranteed that every systembody has a jumpable parent.
+	SystemBody *GetNearestJumpable() { return IsJumpable() ? this : GetParent()->GetNearestJumpable(); }
+
 	bool HasChildren() const { return !m_children.empty(); }
 	Uint32 GetNumChildren() const { return static_cast<Uint32>(m_children.size()); }
 	IterationProxy<std::vector<SystemBody *>> GetChildren() { return MakeIterationProxy(m_children); }

--- a/src/lua/LuaSystemBody.cpp
+++ b/src/lua/LuaSystemBody.cpp
@@ -656,6 +656,12 @@ static int l_sbody_attr_children(lua_State *l)
 	return 1;
 }
 
+static int l_sbody_attr_nearest_jumpable(lua_State *l)
+{
+	LuaObject<SystemBody>::PushToLua(LuaObject<SystemBody>::CheckFromLua(1)->GetNearestJumpable());
+	return 1;
+}
+
 static int l_sbody_attr_is_moon(lua_State *l)
 {
 	LuaPush<bool>(l, LuaObject<SystemBody>::CheckFromLua(1)->IsMoon());
@@ -716,6 +722,7 @@ void LuaObject<SystemBody>::RegisterClass()
 		{ "path", l_sbody_attr_path },
 		{ "body", l_sbody_attr_body },
 		{ "children", l_sbody_attr_children },
+		{ "nearestJumpable", l_sbody_attr_nearest_jumpable },
 		{ "isMoon", l_sbody_attr_is_moon },
 		{ "physicsBody", l_sbody_attr_physics_body },
 		{ 0, 0 }


### PR DESCRIPTION
- fix segfault in the system map if a centered ship is removed
![sysmap2](https://user-images.githubusercontent.com/18342621/101087767-c41c0e80-35c3-11eb-8b07-f652936aecaf.gif)

- reset the system map view if the centered ship is hidden
![sysmap1](https://user-images.githubusercontent.com/18342621/101087783-cd0ce000-35c3-11eb-8609-70687ad09f17.gif)

- if the mission target is a specific systembody, when you press the "set as nav target" button, the sector map is set to the correct star of the multiple system
- shrink the searchbar window in the sector map when nothing is shown on it
![secmap](https://user-images.githubusercontent.com/18342621/101087792-d433ee00-35c3-11eb-840a-08eac46750b1.gif)

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

