### PR TITLE
BBS advert for soldout commodity

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -111,6 +111,11 @@ file_filter = data/lang/module-secondhand/<lang>.json
 source_file = data/lang/module-secondhand/en.json
 source_lang = en
 
+[pioneer.module-soldout]
+file_filter = data/lang/module-soldout/<lang>.json
+source_file = data/lang/module-soldout/en.json
+source_lang = en
+
 [pioneer.module-stationrefuelling]
 file_filter = data/lang/module-stationrefuelling/<lang>.json
 source_file = data/lang/module-stationrefuelling/en.json

--- a/data/lang/module-soldout/en.json
+++ b/data/lang/module-soldout/en.json
@@ -1,0 +1,30 @@
+{
+  "AMOUNT": {
+    "description": "The amount (for now in tonne) of goods person wants to buy",
+    "message": "I'll buy anything you have, up to the full {amount}t that I need."
+  },
+  "MESSAGE": {
+    "description": "",
+    "message": "I'm {name}. I need {commodity} urgently, and I'll pay twice the market price ({price})."
+  },
+  "NOT_IN_STOCK": {
+    "description": "Regarding selling more than the player has",
+    "message": "Not enough {commodity} in stock."
+  },
+  "SELL_1": {
+    "description": "Sell one single unit (probably tonne)",
+    "message": "Sell 1"
+  },
+  "SELL_N": {
+    "description": "Sell several units (probably in tonne), i.e. N > 1",
+    "message": "Sell {N}"
+  },
+  "SELL_ALL": {
+    "description": "Sell everything player has of the good/commodity",
+    "message": "Sell all"
+  },
+  "TITLE": {
+    "description": "",
+    "message": "WANTED: {commodity}. Will pay {price} per tonne"
+  }
+}

--- a/data/modules/SoldOut/SoldOut.lua
+++ b/data/modules/SoldOut/SoldOut.lua
@@ -1,0 +1,157 @@
+-- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Engine = require 'Engine'
+local Lang = require 'Lang'
+local Game = require 'Game'
+local Event = require 'Event'
+local Serializer = require 'Serializer'
+local Character = require 'Character'
+local Format = require 'Format'
+local Equipment = require 'Equipment'
+
+local l = Lang.GetResource("module-soldout")
+
+local ads = {}
+
+local onChat = function (form, ref, option)
+	local ad = ads[ref]
+	-- Maximum amount the player can sell:
+	local max = Game.player:CountEquip(ad.commodity, "cargo")
+	max = ad.amount < max and ad.amount or max
+
+	form:Clear()
+	form:SetTitle(ad.title)
+	form:SetFace(ad.client)
+
+	if option == 0 then
+		form:SetMessage(ad.message .. "\n\n" .. string.interp(l.AMOUNT, {amount = ad.amount}))
+	elseif option == -1 then
+		form:Close()
+		return
+	elseif option == "max" then
+		if max < 1 then
+			form:SetMessage(string.interp(l.NOT_IN_STOCK, {commodity = ad.commodity:GetName()}))
+		else
+			Game.player:RemoveEquip(ad.commodity, max)
+			Game.player:AddMoney(ad.price * max)
+			ad.amount = ad.amount - max
+			form:SetMessage(ad.message .. "\n\n" .. string.interp(l.AMOUNT, {amount = ad.amount}))
+		end
+	elseif option > 0 then
+		if max < option then
+			form:SetMessage(string.interp(l.NOT_IN_STOCK, {commodity = ad.commodity:GetName()}))
+		else
+			Game.player:RemoveEquip(ad.commodity, option)
+			Game.player:AddMoney(ad.price * option)
+			ad.amount = ad.amount - option
+			form:SetMessage(ad.message .. "\n\n" .. string.interp(l.AMOUNT, {amount = ad.amount}))
+		end
+	end
+
+	-- Buttons asking how much quantity to sell, store value as an int
+	-- wrapped in a table:
+	form:AddOption(l.SELL_1, 1)
+	for i, val in pairs{10, 100, 1000} do
+		form:AddOption(string.interp(l.SELL_N, {N=val}), val)
+	end
+	form:AddOption(l.SELL_ALL, "max")
+
+	-- Buyer has bought all they want?
+	if ad.amount == 0 then
+		form:RemoveAdvertOnClose()
+	end
+
+	return
+end
+
+-- Numbers that span orders of magnitude are best modelled by
+-- random sampling from uniformly distributed density in log-space:
+local lograndom = function(min, max)
+	assert(min > 0)
+	return math.exp(Engine.rand:Number(math.log(min), math.log(max)))
+end
+
+local makeAdvert = function(station, commodity)
+	-- Select commodity to run low on
+	local ad = {
+		station   = station,
+		client    = Character.New(),
+		price     = 2 * station:GetEquipmentPrice(commodity),
+		commodity = commodity,
+	}
+
+	-- Amount that the desperado wants to buy is determined by the
+	-- wallet, i.e. fewer units if expensive commodity.
+	-- Money is uniformly distirubted in log space
+	local money_to_spend = lograndom(1e2, 1e5)
+	ad.amount = math.ceil(money_to_spend / math.abs(ad.price))
+
+	ad.title = string.interp(l.TITLE,
+		{commodity = ad.commodity:GetName(), price = Format.Money(ad.price)})
+
+	ad.message = string.interp(l.MESSAGE,
+		{name = ad.client.name, commodity = commodity:GetName(), price = Format.Money(ad.price)})
+
+	local ref = station:AddAdvert({
+		description = ad.title,
+		icon        = "donate_to_cranks",
+		onChat      = onChat,
+		onDelete    = onDelete})
+	ads[ref] = ad
+end
+
+local onDelete = function (ref)
+	ads[ref] = nil
+end
+
+local onCreateBB = function (station)
+	-- Only relevant to create an advert for goods that are have zero stock
+	-- (probability for that is set in SpaceStation.lua)
+	local sold_out = {}
+	for i, c in pairs(Equipment.cargo) do
+		local stock = station:GetEquipmentStock(c)
+		if stock == 0 then
+			table.insert(sold_out, c)
+		end
+	end
+
+	-- low random chance of spawning
+	for i, c in pairs(sold_out) do
+		if Engine.rand:Number(0, 1) > 0.5 then
+			makeAdvert(station, c)
+		end
+	end
+end
+
+local loaded_data
+
+local onGameStart = function ()
+	ads = {}
+
+	if not loaded_data or not loaded_data.ads then return end
+
+	for k,ad in pairs(loaded_data.ads) do
+		local ref = ad.station:AddAdvert({
+			description = l.TITLE,
+			icon        = "donate_to_cranks",
+			onChat      = onChat,
+			onDelete    = onDelete})
+		ads[ref] = ad
+	end
+
+	loaded_data = nil
+end
+
+local serialize = function ()
+	return { ads = ads }
+end
+
+local unserialize = function (data)
+	loaded_data = data
+end
+
+Event.Register("onCreateBB", onCreateBB)
+Event.Register("onGameStart", onGameStart)
+
+Serializer:Register("SoldOut", serialize, unserialize)


### PR DESCRIPTION
## Intro
In frontier one would often have the habit to check the BBS for special "WANTED" adverts before selling the commodity on the market exchange. Especially if the station had 0t in stock.
![2020-12-06-164844_1600x900_scrot](https://user-images.githubusercontent.com/619390/101291815-d5575c00-380b-11eb-8d53-dd2ba29dc281.png)
![2020-12-06-164855_1600x900_scrot](https://user-images.githubusercontent.com/619390/101291816-d8524c80-380b-11eb-92f7-36f0ec3ba70c.png)

## About this Pioneer BBS advert
This module selects a major import and with a fairly low probability (for now 10% adds one advert, and zeros out the stock of that commodity in the commodity market).

There's only one flavor because this advert will be rare, so slight rewording of it will not make a difference.

This is in some way similar to #2753, but that one announces where the market is sold out globally, to all neighboring systems, (and offers a larger multiple than x2), where as this advert is as brief as can be.

Advert uses "$" icon for now (could alternatively use the shopping cart icon)
![2020-12-06-213818_1600x900_scrot](https://user-images.githubusercontent.com/619390/101291850-13ed1680-380c-11eb-930d-0fbfed7b6eea.png)
![2020-12-06-213831_1600x900_scrot](https://user-images.githubusercontent.com/619390/101291854-164f7080-380c-11eb-9ef0-e7fbcc763910.png)

## To-Do
Please don't look at the code, it's messy

  - [x] Don't allow selling more than I have
  - [x] Is it normal for other commodities to also be zeroed out? Looks like a bug, zeroing out stock of other major import commodities.
  - [x] Sanitize code & commits.
  - [x] Put strings into language module
  - [ ] Remove debug stuff (e.g. constant spawn)