### PR TITLE
Localize header strings on ship information screen

### DIFF
--- a/data/pigui/libs/text-table.lua
+++ b/data/pigui/libs/text-table.lua
@@ -18,7 +18,7 @@ function textTable.draw(t)
 			local width, textWidth = ui.getColumnWidth(), ui.calcTextSize(entry[2]).x + 1
 			-- FIXME: add support for ui.getStyleVar("ItemSpacing"). Hardcoding to 8 for now
 			ui.sameLine(math.max(width - textWidth, width / 2 + 8), 0)
-			ui.text(entry[2])
+			ui.textWrapped(entry[2])
 		elseif type(entry) == "string" then
 			ui.spacing()
 			ui.text(entry)

--- a/data/pigui/libs/text-table.lua
+++ b/data/pigui/libs/text-table.lua
@@ -18,7 +18,7 @@ function textTable.draw(t)
 			local width, textWidth = ui.getColumnWidth(), ui.calcTextSize(entry[2]).x + 1
 			-- FIXME: add support for ui.getStyleVar("ItemSpacing"). Hardcoding to 8 for now
 			ui.sameLine(math.max(width - textWidth, width / 2 + 8), 0)
-			ui.textWrapped(entry[2])
+			ui.text(entry[2])
 		elseif type(entry) == "string" then
 			ui.spacing()
 			ui.text(entry)

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -55,7 +55,7 @@ local collapsingHeaderFlags = ui.TreeNodeFlags { "DefaultOpen" }
 
 local function shipStats()
 	local closed = ui.withFont(fonts.pionillium.medlarge, function()
-		return not ui.collapsingHeader("Ship Information", collapsingHeaderFlags)
+		return not ui.collapsingHeader(l.SHIP_INFORMATION, collapsingHeaderFlags)
 	end)
 
 	-- TODO: draw info ontop of the header
@@ -127,7 +127,7 @@ end
 
 local function equipmentList()
 	local closed = ui.withFont(fonts.pionillium.medlarge, function()
-		return not ui.collapsingHeader("Equipment", collapsingHeaderFlags)
+		return not ui.collapsingHeader(l.EQUIPMENT, collapsingHeaderFlags)
 	end)
 
 	if closed then return end


### PR DESCRIPTION
- Localize table headers
- Fix ragged layout by using text instead of textWrapped. The textWrapped function really needs a width parameter, but we have sufficient space on this screen at 800x600 resolution and I didn't want to dig this deep into it.

Tested with Scottish Gaelic and Hungarian - in my experience, if it fits these 2 languages, it fits.

Before:
![pioneer-ship-information-alignment](https://user-images.githubusercontent.com/4095570/101594056-f628d880-39e8-11eb-9cd8-bfd20cde6552.png)

After:
![pioneer-ship-information-alignment-after](https://user-images.githubusercontent.com/4095570/101594059-f75a0580-39e8-11eb-9c20-67a7c3db17d7.png)
