### PR TITLE
Clarify tooltip to reduce confusion

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1700,8 +1700,8 @@
     "message": "Reward"
   },
   "ROTATE_VIEW": {
-    "description": "",
-    "message": "Rotate view"
+    "description": "Indicates that the button must be kept pressed down, to rotate camera view with mouse",
+    "message": "Hold down to Rotate view"
   },
   "ROUTE_INFO": {
     "description": "For hyperjump planner",


### PR DESCRIPTION
Moving rotation from RMB to MMB throws player off balance at first
exposure. The rotate button has also proven to be un-intuitive, based on
player feedback. Hope this helps, if even a minuscule bit.

Change tooltip in sector view:
"Rotate view" -->  "Hold down to Rotate view"

