### PR TITLE
Fix equipment market widget not updating stock properly

### DIFF
--- a/data/pigui/libs/equipment-market.lua
+++ b/data/pigui/libs/equipment-market.lua
@@ -104,11 +104,8 @@ local defaultFuncs = {
     end,
 
     -- do something when we buy this commodity
-    bought = function (self, e)
-		local count = -1
-		if self.tradeAmount ~= nil then
-			count = self.tradeAmount
-		end
+    bought = function (self, e, tradeamount)
+		local count = tradeamount or 1  -- default to 1 for e.g. equipment market
         Game.player:GetDockedWith():AddEquipmentStock(e, -count)
     end,
 
@@ -139,11 +136,8 @@ local defaultFuncs = {
     end,
 
     -- do something when we sell this items
-    sold = function (self, e)
-		local count = -1
-		if self.tradeAmount ~= nil then
-			count = self.tradeAmount
-		end
+    sold = function (self, e, tradeamount)
+		local count = tradeamount or 1  -- default to 1 for e.g. equipment market
         Game.player:GetDockedWith():AddEquipmentStock(e, count)
     end,
 


### PR DESCRIPTION
1. The third argument to bought/sold wasn't passed, instead the member variable was used directly in the body, also shortened the code a bit.

2. When selling/buying from ship equipment market, it defaulted to -1 units, should be 1.

I've tested ship equipment market and commodity market (both buying/selling 1, 10, units and also negatively priced commodities), and goodstrader on the BBS.

Closes #5071
