### PR TITLE
Donate to crank improvements

### DIFF
--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -47,6 +47,10 @@
     "description": "",
     "message": "SUPPORT FREEDOM! Stop the great injustice of proprietary software controlling your ship."
   },
+  "SALES_PITCH": {
+    "description": "",
+    "message": "Your reputation would benefit by donating {cash} to our cause, but any donation would help."
+  },
   "THANK_YOU_ALL_DONATIONS_ARE_WELCOME": {
     "description": "",
     "message": "Thank you. All donations are welcome."

--- a/data/modules/DonateToCranks/DonateToCranks.lua
+++ b/data/modules/DonateToCranks/DonateToCranks.lua
@@ -4,7 +4,6 @@
 local Engine = require 'Engine'
 local Lang = require 'Lang'
 local Game = require 'Game'
-local Comms = require 'Comms'
 local Character = require 'Character'
 local Event = require 'Event'
 local Serializer = require 'Serializer'
@@ -39,39 +38,34 @@ end
 
 local onChat = function (form, ref, option)
 	local ad = ads[ref]
+	form:Clear()
 
-	if option == 0 then
-		form:Clear()
-
-		form:SetTitle(ad.title)
-		form:SetFace(ad.charcter)
-		form:SetMessage(ad.message)
-
-		form:AddOption(Format.Money(1,false), 1)
-		form:AddOption(Format.Money(10,false), 10)
-		form:AddOption(Format.Money(100,false), 100)
-		form:AddOption(Format.Money(1000,false), 1000)
-		form:AddOption(Format.Money(10000,false), 10000)
-		form:AddOption(Format.Money(100000,false), 100000)
-
-		return
-	end
+	form:SetTitle(ad.title)
+	form:SetFace(ad.charcter)
 
 	if option == -1 then
 		form:Close()
 		return
 	end
 
-	if Game.player:GetMoney() < option then
-		Comms.Message(l.YOU_DO_NOT_HAVE_ENOUGH_MONEY)
+	if option == 0 then
+		form:SetMessage(ad.message)
+	elseif Game.player:GetMoney() < option then
+		form:SetMessage(l.YOU_DO_NOT_HAVE_ENOUGH_MONEY)
 	else
 		if option >= 10000 then
-			Comms.Message(l.WOW_THAT_WAS_VERY_GENEROUS)
+			form:SetMessage(l.WOW_THAT_WAS_VERY_GENEROUS)
 		else
-			Comms.Message(l.THANK_YOU_ALL_DONATIONS_ARE_WELCOME)
+			form:SetMessage(l.THANK_YOU_ALL_DONATIONS_ARE_WELCOME)
 		end
 		Game.player:AddMoney(-option)
 		addReputation(option * ad.modifier)
+	end
+
+	-- Draw buttons donation button options
+	for i=0,5,1 do
+		donate = math.floor(10^i)
+		form:AddOption(Format.Money(donate, false), donate)
 	end
 end
 

--- a/data/modules/DonateToCranks/DonateToCranks.lua
+++ b/data/modules/DonateToCranks/DonateToCranks.lua
@@ -44,7 +44,7 @@ local onChat = function (form, ref, option)
 		form:Clear()
 
 		form:SetTitle(ad.title)
-		form:SetFace({ seed = ad.faceseed })
+		form:SetFace(ad.charcter)
 		form:SetMessage(ad.message)
 
 		form:AddOption(Format.Money(1,false), 1)
@@ -87,7 +87,7 @@ local onCreateBB = function (station)
 		title    = flavours[n].title,
 		message  = flavours[n].message,
 		station  = station,
-		faceseed = Engine.rand:Integer()
+		charcter = Character.New({armour=false}),
 	}
 
 	local ref = station:AddAdvert({


### PR DESCRIPTION
# Fix: face seed

New pigui chat-form did not support explicitly setting seed, giving new face every time the advert is clicked. Fixed it by having the same charracter for each instance of a BBS. (These adverts are not fix to station over time).

# Fix: crank talking back

The comms that was used before, is rendered to world view, so messages (e.g. "note enough money", or "thanks") sent there are not seen. Update message in chat box instead, making it more of a dialogue. Also, now the advert closes itself when the player has donated.

![untitled](https://user-images.githubusercontent.com/619390/101992386-0d9ae680-3cb3-11eb-8ffb-aa9442a3c01f.gif)


# New: Indicate to user what amount to donate

There is currently no way the player to know:

1. How close they are to next jump in reputation status, nor,

2. Difference between different donation organizations (some are more cranks than others)

With this, each donation indicates how much money is needed to gain next level of reputation. Thus, it still obscures directly knowing reputation points and the "force multiplier" factor for the particular donation cause on reputation.

Here is how much is needed to go from current reputation level ("nobody") to next ("inexperienced"):

![2020-12-12-200038_1600x900_scrot](https://user-images.githubusercontent.com/619390/101992597-d88f9380-3cb4-11eb-8f30-f566069613b5.png)
