### PR TITLE
Reduce probability for imported goods to be sold out

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -50,14 +50,14 @@ local function updateEquipmentStock (station)
 			else
 				local pricemod = Game.system:GetCommodityBasePriceAlterations(key)
 				local stock =  (Engine.rand:Integer(0,rn) + Engine.rand:Integer(0,rn)) / 2 -- normal 0-100% stock
-				if pricemod > 10 then --major import, very low stock
-					stock = stock - (rn*0.6) -- 0-40% stock
+				if pricemod > 10 then --major import, low stock
+					stock = stock - (rn*0.10)     -- shifting .10 = 2% chance of 0 stock
 				elseif pricemod > 2 then --minor import
-					stock = stock - (rn*0.3) -- 0-70% stock
+					stock = stock - (rn*0.07)     -- shifting .07 = 1% chance of 0 stock
 				elseif pricemod < -10 then --major export
-					stock = stock + (rn*0.8) -- 80-180% stock
+					stock = stock + (rn*0.8)
 				elseif pricemod < -2 then --minor export
-					stock = stock + (rn*0.3) -- 30-130% stock
+					stock = stock + (rn*0.3)
 				end
 				equipmentStock[station][e] = math.floor(stock >=0 and stock or 0)
 			end


### PR DESCRIPTION
## Introduction

When doing #5059 (adverts for sold out commodities, where I choose an imported commodity and zero out its stock, and offer twice the price on the BBS), I noticed a lot of the available stock for imported commodities at stations was already at 0t. This jumps out at me. First I assumed it was my code going crazy, such that what is zeroed out on one station, is zeroed out on _all_ stations, but no, this is the actual behaviour on master.

I think seeing 0t of stock of a commodity should be a "wow" moment, triggering the player to check the BBS for adverts for soldout commodities, or to see this "imbalance between supply and demand" when a news event has occurred that alludes to huge event affecting the market in a system.

One should be able to buy also imported goods, even if usually is a bad trade. 

## How it works on master at the moment

For commodities that are neither import/export, there will on average be $50k worth to buy (and theoretically 0 or $100k, but extremely rare).

If the commodity is an import, the distribution is shifted left, (and negative quantities zeroed), such that in practice 32% of (every) major import and 8% of (every) minor imported commodity (on every station) had stock 0t.

Each commodity market has several major and minor imports, so a substantial part of them had zero stock.

The current distribution on for major imports on master (yes, I could calculate it analytically, but numerically required less brain power, the spikes is an artefact of binning, and the price of the commodity, indicated in the title, only scales the x-axis):

![master](https://user-images.githubusercontent.com/619390/102126362-42da3c80-3e4b-11eb-91a8-17c20bacfaf2.png)

For Sol, there are 50 commodities that are sold out on master (at one try):

| Commodity            | station            | import type  |
|----------------------|--------------------|--------------|
| Animal meat          | Bradbury Landing   | minor import |
| Animal meat          | Phobos Base        | minor import |
| Animal meat          | Dante's Base       | minor import |
| Carbon ore           | Jobs Pad           | minor import |
| Carbon ore           | Bradbury Landing   | minor import |
| Carbon ore           | Cydonia            | minor import |
| Carbon ore           | Thebe Gas Refinery | minor import |
| Carbon ore           | Port Makenzie      | minor import |
| Computers            | Shanghai           | minor import |
| Computers            | Los Angeles        | minor import |
| Computers            | Thebe Gas Refinery | minor import |
| Computers            | Enki Catena        | minor import |
| Industrial machinery | Mexico City        | MAJOR import |
| Industrial machinery | Moscow             | MAJOR import |
| Industrial machinery | Mariasuriru        | MAJOR import |
| Industrial machinery | Poseidon Station   | MAJOR import |
| Metal alloys         | Mexico City        | MAJOR import |
| Metal alloys         | London             | MAJOR import |
| Metal alloys         | Moscow             | MAJOR import |
| Metal alloys         | Los Angeles        | MAJOR import |
| Metal alloys         | Jobs Pad           | MAJOR import |
| Metal alloys         | Tranquility Base   | MAJOR import |
| Metal alloys         | Olympus Mons       | MAJOR import |
| Metal alloys         | Mars High          | MAJOR import |
| Metal alloys         | Tomm's Sanctuary   | MAJOR import |
| Metal alloys         | Thebe Gas Refinery | MAJOR import |
| Metal alloys         | Clarke's Station   | MAJOR import |
| Metal alloys         | Enki Catena        | MAJOR import |
| Metal alloys         | Oasis City         | MAJOR import |
| Mining machinery     | Brasilia           | MAJOR import |
| Mining machinery     | Jobs Pad           | MAJOR import |
| Mining machinery     | Torvalds Platform  | MAJOR import |
| Mining machinery     | Tranquility Base   | MAJOR import |
| Mining machinery     | Bradbury Landing   | MAJOR import |
| Mining machinery     | Mars High          | MAJOR import |
| Mining machinery     | Dante's Base       | MAJOR import |
| Mining machinery     | Enki Catena        | MAJOR import |
| Mining machinery     | Poseidon Station   | MAJOR import |
| Plastics             | Shanghai           | MAJOR import |
| Plastics             | London             | MAJOR import |
| Plastics             | Los Angeles        | MAJOR import |
| Plastics             | Gates Spaceport    | MAJOR import |
| Plastics             | Olympus Mons       | MAJOR import |
| Plastics             | Mars High          | MAJOR import |
| Plastics             | Phobos Base        | MAJOR import |
| Plastics             | Dante's Base       | MAJOR import |
| Plastics             | Oasis City         | MAJOR import |
| Robots               | Moscow             | minor import |
| Robots               | Torvalds Platform  | minor import |
| Robots               | Oasis City         | minor import |


## Change introduced in this branch

I've shifted it to have 2% chance (instead of 32%) for (each) major import to have 0t stock, and 1% chance for (each) minor import (instead of 8%).

Here's major imports:

![branch](https://user-images.githubusercontent.com/619390/102126402-508fc200-3e4b-11eb-8875-4cb28ed05b76.png)

For Sol, these are now the commodities that are sold out using this branch:

| Commodity            | Station          | import type  |
|----------------------|------------------|--------------|
| Computers            | Jobs Pad         | minor import |
| Industrial machinery | Clarke's Station | MAJOR import |
| Industrial machinery | Enki Catena      | MAJOR import |
| Metal alloys         | Gates Spaceport  | MAJOR import |
| Mining machinery     | Mars High        | MAJOR import |
