### PR TITLE
Significantly Slash Savefile Sizes

### DIFF
--- a/src/posix/FileSystemPosix.cpp
+++ b/src/posix/FileSystemPosix.cpp
@@ -82,8 +82,6 @@ namespace FileSystem {
 		CFRelease(resourcesURL);
 		return path;
 #else
-		printf("Init!\n");
-
 		if (!getenv("PIONEER_LOCAL_DATA_ONLY")) {
 			/* PIONEER_DATA_DIR should point to ${prefix}/share/pioneer/data.
 			 * If this directory does not exist, try to use the "data" folder

--- a/src/scenegraph/MatrixTransform.h
+++ b/src/scenegraph/MatrixTransform.h
@@ -3,16 +3,24 @@
 
 #ifndef _MATRIXTRANSFORM_H
 #define _MATRIXTRANSFORM_H
-/*
- * Applies a matrix transform to child nodes
- */
+
 #include "Group.h"
 #include "matrix4x4.h"
+
 namespace Graphics {
 	class Renderer;
 }
 
 namespace SceneGraph {
+
+	/*
+	* Applies a matrix transform to child nodes
+	*
+	* Note: transforms are not automatically serialized when saving to disk;
+	* they are derived from the original model and animations.
+	* If you have programmatically positioned a MatrixTransform, it is your
+	* responsibility to ensure the new position is properly serialized.
+	*/
 	class MatrixTransform : public Group {
 	public:
 		MatrixTransform(Graphics::Renderer *r, const matrix4x4f &m);

--- a/src/scenegraph/ModelSkin.cpp
+++ b/src/scenegraph/ModelSkin.cpp
@@ -103,15 +103,14 @@ namespace SceneGraph {
 			Json colorsArray = modelSkinObj["colors"].get<Json::array_t>();
 			if (colorsArray.size() != 3) throw SavedGameCorruptException();
 			for (unsigned int i = 0; i < 3; i++) {
-				Json arrayElem = colorsArray[i];
-				m_colors[i] = arrayElem["color"];
+				if (colorsArray[i].is_array())
+					m_colors[i] = colorsArray[i];
 			}
 
 			Json decalsArray = modelSkinObj["decals"].get<Json::array_t>();
-			if (decalsArray.size() != MAX_DECAL_MATERIALS) throw SavedGameCorruptException();
 			for (unsigned int i = 0; i < MAX_DECAL_MATERIALS; i++) {
-				Json arrayElem = decalsArray[i];
-				m_decals[i] = arrayElem["decal"].get<std::string>();
+				if (decalsArray.size() > i && decalsArray[i].is_string())
+					m_decals[i] = decalsArray[i].get<std::string>();
 			}
 
 			m_label = modelSkinObj["label"].get<std::string>();
@@ -138,18 +137,14 @@ namespace SceneGraph {
 
 		Json colorsArray = Json::array(); // Create JSON array to contain colors data.
 		for (unsigned int i = 0; i < 3; i++) {
-			Json arrayElem({});
-			arrayElem["color"] = m_colors[i];
-			colorsArray.push_back(arrayElem);
+			colorsArray.push_back(m_colors[i]);
 		}
 
 		modelSkinObj["colors"] = colorsArray; // Add colors array to model skin object.
 
 		Json decalsArray = Json::array(); // Create JSON array to contain decals data.
 		for (unsigned int i = 0; i < MAX_DECAL_MATERIALS; i++) {
-			Json arrayElem({});
-			arrayElem["decal"] = m_decals[i];
-			decalsArray.push_back(arrayElem);
+			decalsArray.push_back(m_decals[i]);
 		}
 
 		modelSkinObj["decals"] = decalsArray; // Add decals array to model skin object.


### PR DESCRIPTION
Our savefiles are truly too large. Not only are we storing completely redundant data about MatrixTransform nodes that will immediately be overwritten by the animation system, but we're also storing every last detail about every market in the system regardless of whether we've been there or not.

On top of removing redundant save data from the C++ side, we now only create a station's market when we actually land there, which removes one of the biggest hogs of save data. How big, you ask? Uncompressed, our savefiles dropped from 2MB to ~500KB, and compressed they dropped from 350KB to 75KB. I've tested on a Mars start after taking off and landing at Mars High to generate a representative sample of the average in-system activity a player might have.

This has a nice side effect of making autosaves almost entirely imperceptible to gameplay; it's not quite as smooth as an asynchronous save might be, but we practically *fly* through the save process now.

@impaktor for your reference, this is following on to your(?) comment in the code about only creating adverts when docked... I just extended that to the entire station market instead of just the BBS.

I'd appreciate some thorough testing - I've put it through a minimal test case, but I'd appreciate it if this could be tested against someone's in-progress campaign just to be sure there aren't any edge cases or catastrophic oversights I've missed!

EDIT: I know I said we'd be freezing for an RC build soon, but while we're bumping the save version I wanted to fix as many "bugs" as possible. :stuck_out_tongue: 