### PR TITLE
Fix SIGSEGV on switch to system map after HJ

### DIFF
--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -670,3 +670,4 @@ double SystemView::ProjectedSize(double size, vector3d pos)
 
 double SystemView::GetOrbitTime(double t, const SystemBody *b) { return t; }
 double SystemView::GetOrbitTime(double t, const Body *b) { return t - m_game->GetTime(); }
+void SystemView::OnSwitchFrom() { m_projected.clear(); } // because ships from the previous system may remain after last update

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -80,10 +80,10 @@ struct Projectable {
 class SystemView : public PiGuiView, public DeleteEmitter {
 public:
 	SystemView(Game *game);
-	virtual ~SystemView();
-	virtual void Update();
-	virtual void Draw3D();
-	// virtual void OnSwitchTo() { Update(); Draw3D(); }
+	~SystemView() override;
+	void Update() override;
+	void Draw3D() override;
+	void OnSwitchFrom() override;
 
 	Projectable *GetSelectedObject();
 	void SetSelectedObject(Projectable::types type, Projectable::bases base, SystemBody *sb);


### PR DESCRIPTION
If you turn on the ships in the system map, turn off the system map and jump into another system, then pointers to the ships from the previous system remain in `m_projected`, which cause the a segfault. Now clear this when switching from view.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

