### PR TITLE
Trigger Build Pioneer github action on pushes to master

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -4,6 +4,9 @@ name: Build Pioneer
 
 # Controls when the action will run.
 on:
+  push:
+    branches:
+    - master
   pull_request:
     paths:
     - 'src/**.cpp'

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -46,7 +46,7 @@ jobs:
           cd pioneer
           mkdir build
           cd build
-          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX="C:/Program Files/Pioneer" -DPIONEER_DATA_DIR="C:/Program Files/Pioneer/data" -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_MESSAGE=NEVER -DGIT_EXECUTABLE="c:/Program Files/Git/cmd/git.exe"
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX="C:/Program Files/Pioneer" -DPIONEER_DATA_DIR="C:/Program Files/Pioneer/data" -DCMAKE_BUILD_TYPE:STRING=Release -DGIT_EXECUTABLE="c:/Program Files/Git/cmd/git.exe"
           cmake --build .
 
       - name: Build Pioneer Data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,7 @@ install(DIRECTORY data/models/
 if (WIN32)
 	configure_file(pioneer.iss.cmakein pioneer.iss @ONLY)
 	configure_file(CI/appveyor/msvc/publish.cmd.cmakein publish.cmd @ONLY)
-	file(GLOB win_libs ../pioneer-thirdparty/win32/bin/x64/vs2017/*.dll)
+	file(GLOB win_libs ../pioneer-thirdparty/win32/bin/${MSVC_ARCH}/vs2019/*.dll)
 	install(FILES ${win_libs} DESTINATION ${CMAKE_INSTALL_PREFIX})
 	if(NOT ISCC)
 		set(ISCC "C:/Program Files (x86)/Inno Setup 6/ISCC.exe")


### PR DESCRIPTION
This should cause the GitHub actions builds to trigger on all pushes to master, which is how the appveyor and travis builds worked, in addition to any PRs that have cpp/h source changes.

This should get our build badge working again, *and* have the nice side effect of having an unofficial build of master always available: the latest artifacts will be available here -> https://github.com/pioneerspacesim/pioneer/actions?query=workflow%3A%22Build+Pioneer%22+branch%3Amaster

Also, I've turned the 'installing' messages from CMake back on. Since Github actions has separate sections for each step, and creating the installer is one of those steps, the install messages shouldn't be an issue with reviewing the logs. And, it's helpful to see if things are being included/excluded from the installer.

Finally, I also broke the windows installer when I upgraded the windows libraries in pioneer-thirdparty, that is also fixed here.
