### PR TITLE
Show import/export in commodity description in commodity market

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -52,11 +52,11 @@ local function updateEquipmentStock (station)
 				local stock =  (Engine.rand:Integer(0,rn) + Engine.rand:Integer(0,rn)) / 2 -- normal 0-100% stock
 				if pricemod > 10 then --major import, low stock
 					stock = stock - (rn*0.10)     -- shifting .10 = 2% chance of 0 stock
-				elseif pricemod > 2 then --minor import
+				elseif pricemod > 4 then --minor import
 					stock = stock - (rn*0.07)     -- shifting .07 = 1% chance of 0 stock
 				elseif pricemod < -10 then --major export
 					stock = stock + (rn*0.8)
-				elseif pricemod < -2 then --minor export
+				elseif pricemod < -4 then --minor export
 					stock = stock + (rn*0.3)
 				end
 				equipmentStock[station][e] = math.floor(stock >=0 and stock or 0)

--- a/data/modules/TradeShips.lua
+++ b/data/modules/TradeShips.lua
@@ -372,12 +372,12 @@ local spawnInitialShips = function (game_start)
 		if key ~= "rubbish" and key ~= "radioactives" and Game.system:IsCommodityLegal(key) then
 			-- values from SystemInfoView::UpdateEconomyTab
 
-			if v > 2 then
+			if v > 4 then
 				import_score = import_score + (v > 10 and 2 or 1) -- lua is crazy
 				table.insert(imports, equip)
 			end
 
-			if v < -2 then
+			if v < -4 then
 				export_score = export_score + (v < -10 and 2 or 1)
 				table.insert(exports, equip)
 			end
@@ -913,9 +913,9 @@ local onGameStart = function ()
 			for key,equip in pairs(e.cargo) do
 				local v = Game.system:GetCommodityBasePriceAlterations(key)
 				if key ~= 'rubbish' and key ~= 'radioactives' and Game.system:IsCommodityLegal(key) then
-					if v > 2 then
+					if v > 4 then
 						table.insert(imports, equip)
-					elseif v < -2 then
+					elseif v < -4 then
 						table.insert(exports, equip)
 					end
 				end

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -295,6 +295,16 @@ function CommodityMarketWidget:TradeMenu()
 				ui.columns(1, "", false)
 				ui.text('')
 
+				local pricemod = Game.system:GetCommodityBasePriceAlterations(self.selectedItem.name)
+				if pricemod > 10 then
+					ui.text(l.MAJOR_IMPORT)
+				elseif pricemod > 4 then
+					ui.text(l.MINOR_IMPORT)
+				elseif pricemod < -10 then
+					ui.text(l.MAJOR_EXPORT)
+				elseif pricemod < -4 then
+					ui.text(l.MINOR_EXPORT)
+				end
 				ui.textWrapped(self.selectedItem:GetDescription())
 
 				ui.setCursorPos(bottomHalf)


### PR DESCRIPTION
This should maybe be shown in a separate column (but green/blue icons would look strange here?), and could be placed better,
but it's a start.

![2020-12-19-103834_1600x900_scrot](https://user-images.githubusercontent.com/619390/102686299-f72ae880-41e6-11eb-9a06-172984e5a213.png)

## Open questions 
It feels like the if-else statement to check if something is import/export keeps popping up everywhere (tradeship, spacestion, here, system econ view). Feels like there should be a method that gets that information for us somewhere? 

At least which numbers for price modification should be the threshold for major/minor export import? 
- system econ view sets 4/10 for minor/major
- Tradeship lua: 2/10 for minor/major 
- Spacestation: 2/10 for minor/major
- commodity market (this PR): 2/10