### PR TITLE
Make use of system's alternate names, as original author intended

### DIFF
--- a/data/systems/02_local_stars.lua
+++ b/data/systems/02_local_stars.lua
@@ -239,7 +239,7 @@ CustomSystem:new('Gliese 203',{'STAR_M'}):add_to_sector(3,-1,0,v(0.460,0.514,0.5
 CustomSystem:new('Xi Boötis',{'STAR_G','STAR_K'}):add_to_sector(-2,1,0,v(0.245,0.892,0.894))
 CustomSystem:new('Gliese 205',{'STAR_M'}):add_to_sector(2,-1,-1,v(0.297,0.712,0.851))
 CustomSystem:new('NN 3976',{'STAR_M'}):add_to_sector(-4,1,1,v(0.402,0.118,0.557))
-CustomSystem:new('Toliman',{'STAR_G','STAR_K'}):other_names({"Bungula", "Alpha Centauri", "α Centauri"}):add_to_sector(-1,0,-1,v(0.828,0.204,0.520)) -- "Gliese 559", "FK5 538", "GC 19728", "CCDM J14396-6050",
+CustomSystem:new("Alpha Centauri",{'STAR_G','STAR_K'}):other_names({"Bungula", 'Toliman', "α Centauri"}):add_to_sector(-1,0,-1,v(0.828,0.204,0.520)) -- "Gliese 559", "FK5 538", "GC 19728", "CCDM J14396-6050",
 CustomSystem:new('NN 3801',{'STAR_M'}):add_to_sector(-2,2,2,v(0.656,0.795,0.036))
 CustomSystem:new('NN 3804',{'STAR_M'}):add_to_sector(-2,3,-2,v(0.030,0.957,0.566))
 CustomSystem:new('Gliese 521',{'STAR_M'}):add_to_sector(-2,3,3,v(0.427,0.396,0.900))

--- a/data/systems/custom/08_61cygni.lua
+++ b/data/systems/custom/08_61cygni.lua
@@ -1,7 +1,7 @@
 -- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local s = CustomSystem:new('61 Cygni',{ 'STAR_K' }) --Alt name will be Cennet (Azeri for "paradise")
+local s = CustomSystem:new('Cennet',{ 'STAR_K' }):other_names({"61 Cygni"}) --(Azeri name means "paradise")
 	:faction('Solar Federation')
 	:govtype('EARTHDEMOC')
 	:lawlessness(f(1,100)) -- 1/100th from a peaceful eden
@@ -17,7 +17,8 @@ Nowadays, the system is a hotspot for gene-fashionistas (green skin and horns ar
 --Other starports are named after the vocabulary of genetics : https://www.genome.gov/glossary/ 
  
 
-local cygni = CustomSystemBody:new('61 Cygni', 'STAR_K') --Alt name will be Cennet (Azeri for "paradise")
+
+local cygni = CustomSystemBody:new('Cennet', 'STAR_K')
 	:radius(f(90,100))
 	:mass(f(51,100))
 	:temp(3508)

--- a/data/systems/custom/09_delta_eridani.lua
+++ b/data/systems/custom/09_delta_eridani.lua
@@ -1,7 +1,7 @@
 -- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local s = CustomSystem:new('Delta Eridani',{'STAR_K_GIANT'}) --Alt name will be Svartalfheim
+local s = CustomSystem:new('Delta Eridani',{'STAR_K_GIANT'}):other_names({"Svartalfheim"})
 	:faction('Commonwealth of Independent Worlds')
 	:govtype('CISSOCDEM')
 	:lawlessness(f(15,100)) -- 1/100th from a peaceful eden

--- a/data/systems/custom/10_ayizan_lacaille8760.lua
+++ b/data/systems/custom/10_ayizan_lacaille8760.lua
@@ -1,7 +1,7 @@
 -- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local s = CustomSystem:new('Ayizan',{'STAR_M'}) --Alt name for Lacaille 8760
+local s = CustomSystem:new('Ayizan',{'STAR_M'}):other_names({"Lacaille 8760"})
 	:faction('Solar Federation')
 	:govtype('EARTHCOLONIAL')
 	:lawlessness(f(40,100)) -- More than the usual Earth Colonial system, because fo the guerilla
@@ -16,9 +16,9 @@ While Sol loosened its rule a few decades ago as a side effect of the detente be
 --Names do not infringe any copyright
 --Bodies are named after Haitian Voodoo Loas (spirits)
 --Cities and orbital stations are named after Haitian personalities or locations
- 
 
-local ayizan = CustomSystemBody:new('Ayizan-Lacaille 8760', 'STAR_M') --Remove the "Lacaille 8760" once the alt name feature is built.
+
+local ayizan = CustomSystemBody:new('Ayizan', 'STAR_M')
 	:radius(f(51,100))
 	:mass(f(41,100))
 	:temp(3445)

--- a/data/systems/custom/11_noril_wolf1061.lua
+++ b/data/systems/custom/11_noril_wolf1061.lua
@@ -1,7 +1,7 @@
 -- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local s = CustomSystem:new('Noril',{'STAR_M'}) --Alt name for Wolf 1061
+local s = CustomSystem:new('Noril',{'STAR_M'}):other_names({"Wolf 1061"})
 	:faction('Solar Federation')
 	:govtype('EARTHDEMOC')
 	:lawlessness(f(15,100)) -- 1/100th from a peaceful eden
@@ -17,9 +17,9 @@ Furthermore, several Mill towns have turned into successful cities. Travellers a
 --Bodies' names are inspired by USSR factory-cities : Norilsk, Kisselevsk and Seversk.
 --Uninhabited planets keep their generic names, as the Federal bureaucracy didn't bother to name them
 --Cities are named after fictional companies. Their names are generated with http://www.businessnamegenerators.com/. A quick search lets think there is no actual company  with those names.
- 
 
-local noril = CustomSystemBody:new('Noril-Wolf 1061', 'STAR_M') --Remove the "Wolf 1061" once the alt name feature is built.
+
+local noril = CustomSystemBody:new('Noril', 'STAR_M')
 	:radius(f(48,100))
 	:mass(f(44,100))
 	:temp(2863)


### PR DESCRIPTION
Following in the wake of #5052, I saw that @SpifforOmnivore has left comments in the system definition what the system's names should be once we have alternative naming scheme in place, which we do, since some time ago. This aims to do the wishes of original author. 

@SpifforOmnivore please have a look and see if it's OK with you.

Also, Cennet is turkish? And Azeri is a language? (ping @WKFO)