### PR TITLE
Add GitHub Action for building VS 2019 Solution

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -25,6 +25,27 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  build-vs-solution:
+    runs-on: windows-2019
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: pioneer
+
+      - name: Checkout pioneer-thirdparty
+        uses: actions/checkout@v2
+        with:
+          repository: pioneerspacesim/pioneer-thirdparty
+          path: pioneer-thirdparty
+
+      - name: Build VS Solution
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cd pioneer
+          msbuild win32\vs2019\pioneer.sln /property:Configuration=Release
+
   build-msvc:
     runs-on: windows-2019
 


### PR DESCRIPTION
This should attempt building the VS Solution anytime the cmake builds are triggered. This is solely intended to help us find when the solution breaks before it gets into master.

*Note*: as of right now, the solution *is* broken in master, so this check will fail regardless (I've fixed it in the Radar PiGUI PR along with those changes).

edit: do not merge yet, I have renamed Pi.cpp -> Pi_.cpp to test the builds, I will force push to remove that later.