### PR TITLE
Small UX fixes

### DIFF
--- a/data/pigui/libs/chat-form.lua
+++ b/data/pigui/libs/chat-form.lua
@@ -105,7 +105,9 @@ function ChatForm:render ()
 
 		self.navButton()
 
-		if ui.coloredSelectedButton(l.HANG_UP, self.style.buttonSize, false, colors.buttonBlue, nil, true) then self:Close() end
+		if ui.coloredSelectedButton(l.HANG_UP, self.style.buttonSize, false, colors.buttonBlue, nil, true) or ui.escapeKeyReleased(true) then
+			self:Close()
+		end
 	end)
 end
 

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -77,6 +77,7 @@ ui.beginPopupModal = pigui.BeginPopupModal
 ui.endPopup = pigui.EndPopup
 ui.openPopup = pigui.OpenPopup
 ui.closeCurrentPopup = pigui.CloseCurrentPopup
+ui.isAnyPopupOpen = pigui.IsAnyPopupOpen
 ui.shouldShowLabels = pigui.ShouldShowLabels
 ui.columns = pigui.Columns
 ui.nextColumn = pigui.NextColumn

--- a/data/pigui/libs/text-table.lua
+++ b/data/pigui/libs/text-table.lua
@@ -14,8 +14,8 @@ function textTable.draw(t)
 	for _, entry in ipairs(t) do
 		if type(entry) == "table" then
 			ui.text(entry[1])
-			-- add +1 to text width to work around off-by-one issues with textWrapped()
-			local width, textWidth = ui.getColumnWidth(), ui.calcTextSize(entry[2]).x + 1
+			-- ui.getColumnWidth() seems to ignore some amount of window padding. More investigation required.
+			local width, textWidth = ui.getContentRegion().x, ui.calcTextSize(entry[2]).x
 			-- FIXME: add support for ui.getStyleVar("ItemSpacing"). Hardcoding to 8 for now
 			ui.sameLine(math.max(width - textWidth, width / 2 + 8), 0)
 			ui.textWrapped(entry[2])

--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -452,6 +452,25 @@ function ui.shiftHeld() return pigui.key_shift end
 function ui.noModifierHeld() return pigui.key_none end
 
 --
+-- Function: ui.escapeKeyReleased
+--
+-- Performs some sanity checks and returns true if the user has pressed escape
+-- and the escape key is not currently being consumed.
+--
+--
+-- Parameters:
+--
+--   ignorePopup - if true, skip checking for open popups.
+--
+-- Returns:
+--
+--   boolean - true if the escape key is pressed and not being consumed
+--
+function ui.escapeKeyReleased(ignorePopup)
+	return (ignorePopup or not ui.isAnyPopupOpen()) and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.escape)
+end
+
+--
 -- Function: ui.tabBar
 --
 -- ui.tabBar(id, items)

--- a/data/pigui/modules/fx-window.lua
+++ b/data/pigui/modules/fx-window.lua
@@ -56,10 +56,8 @@ local function buttons_map(current_view)
 
 	ui.sameLine()
 	local active = current_view == "sector"
-	if mainMenuButton(icons.sector_map, active, active and lui.HUD_BUTTON_SWITCH_TO_WORLD_VIEW or lui.HUD_BUTTON_SWITCH_TO_SECTOR_MAP) or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f5)) then
-		if active then
-			Game.SetView("world")
-		else
+	if mainMenuButton(icons.sector_map, active, lui.HUD_BUTTON_SWITCH_TO_SECTOR_MAP) or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f5)) then
+		if not active then
 			Game.SetView("sector")
 			current_map_view = "sector"
 		end
@@ -67,10 +65,8 @@ local function buttons_map(current_view)
 
 	ui.sameLine()
 	active = current_view == "system"
-	if mainMenuButton(icons.system_map, active, active and lui.HUD_BUTTON_SWITCH_TO_WORLD_VIEW or lui.HUD_BUTTON_SWITCH_TO_SYSTEM_MAP) or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f6)) then
-		if active then
-			Game.SetView("world")
-		else
+	if mainMenuButton(icons.system_map, active, lui.HUD_BUTTON_SWITCH_TO_SYSTEM_MAP) or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f6)) then
+		if not active then
 			Game.SetView("system")
 			current_map_view = "system"
 		end
@@ -78,7 +74,7 @@ local function buttons_map(current_view)
 
 	ui.sameLine()
 	active = current_view == "system_info"
-	if mainMenuButton(icons.system_overview, active, active and lui.HUD_BUTTON_SWITCH_TO_WORLD_VIEW or lui.HUD_BUTTON_SWITCH_TO_SYSTEM_OVERVIEW) or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f7)) then
+	if mainMenuButton(icons.system_overview, active, lui.HUD_BUTTON_SWITCH_TO_SYSTEM_OVERVIEW) or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f7)) then
 		if not active then
 			Game.SetView("system_info")
 			current_map_view = "system_info"
@@ -95,11 +91,10 @@ end
 
 local function button_info(current_view)
 	ui.sameLine()
-	if (mainMenuButton(icons.personal_info, current_view == "info", lui.HUD_BUTTON_SHOW_PERSONAL_INFO) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f3))) then
-		if current_view ~= "info" then
+	active = current_view == "info"
+	if mainMenuButton(icons.personal_info, active, lui.HUD_BUTTON_SHOW_PERSONAL_INFO) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f3)) then
+		if not active then
 			Game.SetView("info")
-		else
-			Game.SetView("world")
 		end
 	end
 end
@@ -107,10 +102,9 @@ end
 local function button_comms(current_view)
 	if player:IsDocked() then
 		ui.sameLine()
-		if mainMenuButton(icons.comms, current_view == "space_station", lui.HUD_BUTTON_SHOW_COMMS) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f4)) then
-			if current_view == "space_station" then
-				Game.SetView("world")
-			else
+		active = current_view == "space_station"
+		if mainMenuButton(icons.comms, active, lui.HUD_BUTTON_SHOW_COMMS) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f4)) then
+			if not active then
 				Game.SetView("space_station")
 			end
 		end

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -449,7 +449,10 @@ local function axisBinding(info)
 		if axis then
 			local c, inverted = nil, axis.direction < 0
 			c,inverted = ui.checkbox("Inverted##"..info.id, inverted, linput.TEXT_INVERT_AXIS)
-			if c then axis.direction = inverted and -1 or 1; info.axis = axis end
+			if c then
+				axis.direction = inverted and -1 or 1
+				info.axis = axis; Input.SaveBinding(info)
+			end
 		end
 		-- new row
 		ui.nextColumn()

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -619,7 +619,7 @@ local function displaySystemViewUI()
 			displayOnScreenObjects()
 		end
 
-		if ui.noModifierHeld() and ui.isKeyReleased(ui.keys.escape) then
+		if ui.escapeKeyReleased() then
 			Game.SetView("sector")
 		end
 	end

--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -245,7 +245,7 @@ ui.registerHandler('game', function(delta_t)
 			end)
 		end)
 
-		if currentView == "world" and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.escape) then
+		if currentView == "world" and ui.escapeKeyReleased() then
 			if not ui.optionsWindow.isOpen then
 				Game.SetTimeAcceleration("paused")
 				ui.optionsWindow:open()

--- a/data/pigui/views/info-view.lua
+++ b/data/pigui/views/info-view.lua
@@ -10,7 +10,7 @@ infoView.windowPadding = ui.rescaleUI(Vector2(24, 24), Vector2(1920, 1200))
 
 ui.registerModule("game", function()
 	infoView:renderTabView()
-	if infoView.isActive and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.escape) then
+	if infoView.isActive and ui.escapeKeyReleased() then
 		Game.SetView("world")
 	end
 end)

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -490,7 +490,7 @@ local function displaySectorViewWindow()
 			end
 		end
 
-		if ui.noModifierHeld() and ui.isKeyReleased(ui.keys.escape) then
+		if ui.escapeKeyReleased() then
 			Game.SetView("world")
 		end
 	end

--- a/data/pigui/views/station-view.lua
+++ b/data/pigui/views/station-view.lua
@@ -65,7 +65,7 @@ if not stationView then
 
 	ui.registerModule("game", function()
 		stationView:renderTabView()
-		if stationView.isActive and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.escape) then
+		if stationView.isActive and ui.escapeKeyReleased() then
 			Game.SetView("world")
 		end
 	end)

--- a/data/pigui/views/system-info-view.lua
+++ b/data/pigui/views/system-info-view.lua
@@ -8,7 +8,7 @@ local ui = require 'pigui'
 
 ui.registerModule("game", function()
 	if Game.CurrentView() == "system_info" then
-		if ui.noModifierHeld() and ui.isKeyReleased(ui.keys.escape) then
+		if ui.escapeKeyReleased() then
 			Game.SetView("sector")
 		end
 	end

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -1453,6 +1453,13 @@ static int l_pigui_close_current_popup(lua_State *l)
 	return 0;
 }
 
+static int l_pigui_is_any_popup_open(lua_State *l)
+{
+	PROFILE_SCOPED()
+	LuaPush<bool>(l, !ImGui::GetCurrentContext()->OpenPopupStack.empty());
+	return 1;
+}
+
 static int l_pigui_end_popup(lua_State *l)
 {
 	PROFILE_SCOPED()
@@ -2861,6 +2868,7 @@ void LuaObject<PiGui::Instance>::RegisterClass()
 		{ "EndPopup", l_pigui_end_popup },
 		{ "OpenPopup", l_pigui_open_popup },
 		{ "CloseCurrentPopup", l_pigui_close_current_popup },
+		{ "IsAnyPopupOpen", l_pigui_is_any_popup_open },
 		{ "PushID", l_pigui_push_id },
 		{ "PopID", l_pigui_pop_id },
 		{ "IsMouseReleased", l_pigui_is_mouse_released },

--- a/src/ship/ShipViewController.cpp
+++ b/src/ship/ShipViewController.cpp
@@ -178,7 +178,16 @@ void ShipViewController::Update()
 	auto *cam = static_cast<MoveableCameraController *>(m_activeCameraController);
 	auto frameTime = Pi::GetFrameTime();
 
-	if (!InputBindings.active) return;
+	if (!InputBindings.active) {
+		m_activeCameraController->Update();
+
+		if (m_mouseActive) {
+			m_mouseActive = false;
+			Pi::input->SetCapturingMouse(false);
+		}
+
+		return;
+	}
 
 	if (GetCamType() == CAM_INTERNAL) {
 		if (InputBindings.frontCamera->IsActive())


### PR DESCRIPTION
**Fixes #5040:** `ui.getColumnWidth()` appears to be ignoring some window padding, which was causing incorrect behavior. Now we query for `ui.getContentRegion().x` which isn't quite correct either but works without unduly wrapping at all sizes.

**Fixes #4981:** this was a simple matter where we weren't updating the camera's position when the controller didn't have input focus. I also added a bit of code that should help to prevent the cursor from getting stuck in hidden mode.

**Fixes #5065:** dead simple, just needed to tell Pioneer to save the binding when changing the checkbox.

**Fixes #5055:** this was broken for several reasons - the tooltip was being used as the button ID, so clicking on any of the buttons wasn't switching the view correctly. I took the chance to simplify the logic a bit.

**Fixes #5046:** also simple, just needed the escape key to trigger the chat form closing. Implemented a small helper to add a priority system to the escape key so it closes one item at a time and doesn't go from the chat form all the way to the options window in one press.