### PR TITLE
Fix Legal footer always being "clean" in station view

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -259,6 +259,10 @@
     "description": "",
     "message": "Crew Roster"
   },
+  "CRIMINAL": {
+    "description": "Legal status of player",
+    "message": "Criminal"
+  },
   "CRIMINAL_RECORD": {
     "description": "Past crimes / crime history of character",
     "message": "Criminal record"
@@ -610,6 +614,10 @@
   "FUEL_WEIGHT": {
     "description": "",
     "message": "Fuel weight"
+  },
+  "FUGITIVE": {
+    "description": "Legal status of player",
+    "message": "Fugitive"
   },
   "FULL_SCREEN": {
     "description": "",
@@ -1479,6 +1487,10 @@
     "description": "",
     "message": "Off"
   },
+  "OFFENDER": {
+    "description": "Legal status of player",
+    "message": "Offender"
+  },
   "OK": {
     "description": "",
     "message": "Ok"
@@ -1506,6 +1518,10 @@
   "OUTER_ARM": {
     "description": "Arm of the Milky Way galaxy",
     "message": "Outer arm"
+  },
+  "OUTLAW": {
+    "description": "Legal status of player",
+    "message": "Outlaw"
   },
   "OUTSTANDING_FINES": {
     "description": "Unpaid fines for crimes committed",

--- a/data/libs/Player.lua
+++ b/data/libs/Player.lua
@@ -282,6 +282,35 @@ function Player:ClearCrimeRecordHistory (faction)
 end
 
 --
+-- Method: GetLegalStatus
+--
+-- > local legal_status = Game.player:GetLegalStatus(faction)
+--
+-- Parameters:
+--
+--   faction - optional argument, defaults to the faction player is in.
+--
+--   legal_status - one of strings "CLEAN", "OFFENDER", "CRIMINAL", "OUTLAW",
+--	                or "FUGITIVE", mapping to translated strings in lang/ui-core
+--
+function Player:GetLegalStatus (faction)
+	local crimes, fine = self:GetCrimeOutstanding()
+	self:setprop("fine", fine)
+
+	if fine < 1 then
+		return('CLEAN')
+	elseif fine < 5500 then
+		return('OFFENDER')
+	elseif fine < 20000 then
+		return('CRIMINAL')
+	elseif fine < 100000 then
+		return('OUTLAW')
+	else
+		return('FUGITIVE')
+	end
+end
+
+--
 -- Method: GetMoney
 --
 -- Get the player's current money

--- a/data/pigui/views/station-view.lua
+++ b/data/pigui/views/station-view.lua
@@ -30,7 +30,7 @@ if not stationView then
 			ui.withStyleVars({WindowPadding = self.style.inventoryPadding, ItemSpacing = self.style.itemSpacing}, function()
 				ui.child("shipInventoryContainer", Vector2(0, 0), {"AlwaysUseWindowPadding"}, function()
 					local moneyText = l.CASH .. ': ' ..  Format.Money(Game.player:GetMoney())
-					local legalText = l.LEGAL_STATUS .. ': ' .. l.CLEAN
+					local legalText = l.LEGAL_STATUS .. ': ' .. l[Game.player:GetLegalStatus()]
 					local moneySize = ui.calcTextSize(moneyText) + self.style.inventoryPadding + self.style.itemSpacing
 					local legalSize = ui.calcTextSize(legalText) + self.style.inventoryPadding + self.style.itemSpacing
 					local gaugeSize = (ui.getContentRegion().x - moneySize.x - legalSize.x) / 2

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -606,7 +606,7 @@ static int l_pigui_get_scroll_y(lua_State *l)
  *
  *   label - string, text on button
  *   data - table of values
- *   display_count - optional, to limit number of pionts to plot
+ *   display_count - optional, to limit number of points to plot
  *   offset - optional x-axis offset, default: 0
  *   overlay_text - optional title string, to put on histogram
  *   y_min - optional float, setting min y-value displayed
@@ -899,7 +899,7 @@ static int l_pigui_path_stroke(lua_State *l)
 /*
  * Function: selectable
  *
- * Determine if a text was slected or not
+ * Determine if a text was selected or not
  *
  * > clicked = ui.selectable(text, is_selectable, flag)
  *
@@ -912,7 +912,7 @@ static int l_pigui_path_stroke(lua_State *l)
  * Parameters:
  *
  *   text - string, text
- *   is_selectable - boolean, wheater or not a text field is highlighted by mouse over
+ *   is_selectable - boolean, whether or not a text field is highlighted by mouse over
  *   flag - optional, selectable flag
  *   size - optional size hint argument
  *
@@ -1847,7 +1847,7 @@ bool PiGui::first_body_is_more_important_than(Body *body, Body *other)
  *
  * Returns all bodies visible on screen, grouped into clusters of bodies
  * which are close together on screen. The current combat target is always
- * kept in its own seperate group.
+ * kept in its own separate group.
  *
  * > groups = Engine.pigui.GetProjectedBodiesGrouped(cluster_size, ship_max_distance)
  *

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -669,7 +669,7 @@ static int l_ship_is_ecm_ready(lua_State *l)
  *   path - a <SystemPath> for the destination system
  *
  *   warmup - the time, in seconds, needed for the engines to warm up.
- *            Minimum time is one second, for saftey reasons.
+ *            Minimum time is one second, for safety reasons.
  *
  *   duration - travel time, in seconds.
  *
@@ -1239,7 +1239,7 @@ static int l_ship_get_thruster_state(lua_State *l)
  *
  * Note the combat AI currently will fly the ship and fire the lasers as
  * necessary, but it will not activate any other equipment (missiles, ECM,
- * etc). It is the responsbility of the script to take those additional
+ * etc). It is the responsibility of the script to take those additional
  * actions if desired.
  *
  * Parameters:


### PR DESCRIPTION
Me, on April 12th, 2014:

> Yes, I've been meaning to look into this just this weekend.

Well, here it is, fixes #2863 (I'm also including a spelling fix commit)

## Demonstrating this fix below:

![2020-12-26-141022_1600x900_scrot](https://user-images.githubusercontent.com/619390/103152218-206aec00-4786-11eb-89b8-26aed69c446c.png)
![2020-12-26-141112_1600x900_scrot](https://user-images.githubusercontent.com/619390/103152221-2365dc80-4786-11eb-876d-451d493f8379.png)

