### PR TITLE
Restrict entry to Rondel system

### DIFF
--- a/data/lang/module-advice/en.json
+++ b/data/lang/module-advice/en.json
@@ -83,6 +83,14 @@
     "description": "Headline starts with this pre-headline",
     "message": "RUMOUR"
   },
+  "RUMOUR_1_BODYTEXT": {
+    "description": "",
+    "message": "Someone in the Federal Navy told me that one day, one of their corvettes accidentally jumped to a Haber outpost system about 50ly out from Sol, called Rondel; almost causing open conflict. Not many people seem to know about the incident itself outside of the navy, but some say Rondel administration has been more aggressive towards visitors since, and freight pilots started avoiding the system."
+  },
+  "RUMOUR_1_HEADLINE": {
+    "description": "",
+    "message": "The Rondel Incident"
+  },
   "TALE_1_BODYTEXT": {
     "description": "",
     "message": "Don't miss the beautiful eclipse on New Hope as Hades blocks out the light from Epsilon Eridani."

--- a/data/lang/module-rondel/en.json
+++ b/data/lang/module-rondel/en.json
@@ -26,5 +26,41 @@
     "HABER_DEFENSE_CRAFT": {
         "description": "",
         "message": "Haber Defense Craft"
+    },
+    "SOLFED_INTEL": {
+        "description": "",
+        "message": "Solar Federation Intelligence"
+    },
+    "SOLFED_INTEL_INTRO": {
+        "description": "",
+        "message": "Keep your voice down, pilot. I'm an undercover agent working for Solar Federation Intelligence. Your ship's computer memory has some data we are interested in."
+    },
+    "PERFECT": {
+        "description": "",
+        "message": "Perfect. If anyone asks... Surely no one will ask, but if anyone asks, please remember that we were just haggling over a second hand shield generator."
+    },
+    "YOU_SHALL_HAVE_THE_DATA": {
+        "description": "",
+        "message": "You shall have the data."
+    },
+    "WHAT_IS_THIS_ABOUT": {
+        "description": "",
+        "message": "What data? What is this all about?"
+    },
+    "YOU_VISITED_STAR_SYSTEM": {
+        "description": "",
+        "message": "You may or may not have visited some star system we would like to know more about."
+    },
+    "NOT_INTERESTED": {
+        "description": "",
+        "message": "What if I'm not interested?"
+    },
+    "CREDITS_PROMISE": {
+        "description": "",
+        "message": "250,000 in cash. Right now. I would find that interesting."
+    },
+    "HEY_OVER_HERE": {
+        "description": "",
+        "message": "Hey, over here."
     }
 }

--- a/data/lang/module-rondel/en.json
+++ b/data/lang/module-rondel/en.json
@@ -1,0 +1,26 @@
+{
+    "DEFENSE_CRAFT_ELIMINATED": {
+        "description": "",
+        "message": "System defense craft eliminated. Incident has been logged."
+    },
+    "INTERCEPTION_SUCCESSFUL": {
+        "description": "",
+        "message": "Interception successful. Hostile craft destroyed."
+    },
+    "WEAPONS_EVASIVE_ACTION": {
+        "description": "",
+        "message": "Weapons discharge detected. Take evasive action!"
+    },
+    "JETTISON_DEFENSIVE_PRECAUTION": {
+        "description": "",
+        "message": "Jettison detected. Apply defensive precautions!"
+    },
+    "RONDEL_RESTRICTED_ZONE": {
+        "description": "",
+        "message": "{playerShipLabel}, this star system is a restricted zone. You must leave within {seconds} seconds. Should you fail to comply, you will be assumed hostile and defensive precautions will be taken."
+    },
+    "HOSTILE_ACTION_REPORTED": {
+        "description": "",
+        "message": "Hostile action reported. Intercept and destroy!"
+    }
+}

--- a/data/lang/module-rondel/en.json
+++ b/data/lang/module-rondel/en.json
@@ -22,5 +22,9 @@
     "HOSTILE_ACTION_REPORTED": {
         "description": "",
         "message": "Hostile action reported. Intercept and destroy!"
+    },
+    "HABER_DEFENSE_CRAFT": {
+        "description": "",
+        "message": "Haber Defense Craft"
     }
 }

--- a/data/modules/Advice/Advice.lua
+++ b/data/modules/Advice/Advice.lua
@@ -20,7 +20,7 @@ local advice_probability = .2
 -- There are three different versions of flavours "Rumours",
 -- "Traveller's tale", and "Traveller's advice", which have fake /
 -- arbitrary indices, for inflated feeling of rich universe and lore.
-local rumours_num = 0
+local rumours_num = 1
 local travellers_tale_num = 1
 local travellers_advice_indices = {481, -- tame black market
 								   16,  -- road faster taken

--- a/data/modules/PolicePatrol/Rondel.lua
+++ b/data/modules/PolicePatrol/Rondel.lua
@@ -85,7 +85,7 @@ local onEnterSystem = function (player)
 	local shipdef = ShipDef[system.faction.policeShip]
 	for i = 1, 7 do
 		ship = Space.SpawnShipNear(shipdef.id, player, 50, 100)
-		ship:SetLabel(l_ui_core.POLICE)
+		ship:SetLabel(l_rondel.HABER_DEFENSE_CRAFT)
 		ship:AddEquip(Equipment.laser.pulsecannon_2mw)
 		table.insert(patrol, ship)
 	end

--- a/data/modules/PolicePatrol/Rondel.lua
+++ b/data/modules/PolicePatrol/Rondel.lua
@@ -1,4 +1,4 @@
--- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+-- Copyright © 2008-2021 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local Engine = require 'Engine'

--- a/data/modules/PolicePatrol/Rondel.lua
+++ b/data/modules/PolicePatrol/Rondel.lua
@@ -92,10 +92,10 @@ local onEnterSystem = function (player)
 
 	Game.SetTimeAcceleration("1x")
 	Timer:CallAt(Game.time + 2, function ()
-		Comms.ImportantMessage(string.interp(l_rondel.RONDEL_RESTRICTED_ZONE, {seconds = tostring(120*tolerance), playerShipLabel = Game.player:GetLabel()}), ship.label)
+		Comms.ImportantMessage(string.interp(l_rondel.RONDEL_RESTRICTED_ZONE, {seconds = tostring(600*tolerance), playerShipLabel = Game.player:GetLabel()}), ship.label)
 	end)
 
-	Timer:CallAt(Game.time + 120*tolerance, function()
+	Timer:CallAt(Game.time + 600*tolerance, function()
 		attackShip(player)
 		Comms.ImportantMessage(l_rondel.HOSTILE_ACTION_REPORTED, ship.label)
 	end)

--- a/data/modules/PolicePatrol/Rondel.lua
+++ b/data/modules/PolicePatrol/Rondel.lua
@@ -62,7 +62,7 @@ end
 
 local onJettison = function (ship, cargo)
 	if Game.system.name ~= "Rondel" then return end
-	if not jetissionedCargo then
+	if not jetissionedCargo and #patrol > 1 then
 		Comms.ImportantMessage(l_rondel.JETTISON_DEFENSIVE_PRECAUTION, patrol[1].label)
 		jetissionedCargo = true
 	end
@@ -96,8 +96,10 @@ local onEnterSystem = function (player)
 	end)
 
 	Timer:CallAt(Game.time + 600*tolerance, function()
-		attackShip(player)
-		Comms.ImportantMessage(l_rondel.HOSTILE_ACTION_REPORTED, ship.label)
+		if #patrol > 1 then
+			attackShip(player)
+			Comms.ImportantMessage(l_rondel.HOSTILE_ACTION_REPORTED, ship.label)
+		end
 	end)
 end
 

--- a/data/modules/Rondel/Rondel.lua
+++ b/data/modules/Rondel/Rondel.lua
@@ -12,6 +12,7 @@ local Legal = require 'Legal'
 local Serializer = require 'Serializer'
 local Equipment = require 'Equipment'
 local ShipDef = require 'ShipDef'
+local SystemPath = require 'SystemPath'
 local Timer = require 'Timer'
 
 --local Character = require 'Character'
@@ -25,6 +26,8 @@ local jetissionedCargo = false
 
 local rondel_victory = false -- has the player defeated all Rondel guards once in their career?
 local rondel_prize = false -- whether the player has been rewarded or not
+
+local rondel_syspath = SystemPath.New(-1,6,2,0)
 
 local ads = {}
 
@@ -89,7 +92,7 @@ local attackShip = function (ship)
 end
 
 local onShipDestroyed = function (ship, attacker)
-	if ship:IsPlayer() or attacker == nil or Game.system.name ~= "Rondel" then return end
+	if ship:IsPlayer() or attacker == nil or not Game.system.path:IsSameSystem(rondel_syspath) then return end
 
 	for i = 1, #patrol do
 		if patrol[i] == ship then
@@ -108,7 +111,7 @@ local onShipDestroyed = function (ship, attacker)
 end
 
 local onShipFiring = function (ship)
-	if Game.system.name ~= "Rondel" then return end
+	if not Game.system.path:IsSameSystem(rondel_syspath) then return end
 
 	local police = ShipDef[Game.system.faction.policeShip]
 	if ship.shipId ~= police.id then
@@ -124,7 +127,7 @@ local onShipFiring = function (ship)
 end
 
 local onJettison = function (ship, cargo)
-	if Game.system.name ~= "Rondel" then return end
+	if not Game.system.path:IsSameSystem(rondel_syspath) then return end
 	if not jetissionedCargo and #patrol > 1 then
 		Comms.ImportantMessage(l_rondel.JETTISON_DEFENSIVE_PRECAUTION, patrol[1].label)
 		jetissionedCargo = true
@@ -136,7 +139,7 @@ local onEnterSystem = function (player)
 	if not player:IsPlayer() then return end
 
 	local system = Game.system
-	if system.name ~= "Rondel" then return end
+	if not system.path:IsSameSystem(rondel_syspath) then return end
 
 	local tolerance = 1
 	local hyperdrive = Game.player:GetEquip('engine',1)

--- a/data/modules/Rondel/Rondel.lua
+++ b/data/modules/Rondel/Rondel.lua
@@ -1,0 +1,145 @@
+-- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Engine = require 'Engine'
+local Lang = require 'Lang'
+local Game = require 'Game'
+local Space = require 'Space'
+local cargo = require 'Commodities'
+local Comms = require 'Comms'
+local Event = require 'Event'
+local Legal = require 'Legal'
+local Serializer = require 'Serializer'
+local Equipment = require 'Equipment'
+local ShipDef = require 'ShipDef'
+local Timer = require 'Timer'
+
+local l_rondel = Lang.GetResource("module-rondel")
+local l_ui_core = Lang.GetResource("ui-core")
+
+local patrol = {}
+local shipFiring = false
+local jetissionedCargo = false
+
+local attackShip = function (ship)
+	for i = 1, #patrol do
+		patrol[i]:AIKill(ship)
+	end
+end
+
+local onShipDestroyed = function (ship, attacker)
+	if ship:IsPlayer() or attacker == nil or Game.system.name ~= "Rondel" then return end
+
+	for i = 1, #patrol do
+		if patrol[i] == ship then
+			table.remove(patrol, i)
+			if #patrol > 1 then
+				Comms.ImportantMessage(l_rondel.DEFENSE_CRAFT_ELIMINATED, patrol[1].label)
+			end
+			break
+		elseif patrol[i] == attacker then
+			Comms.ImportantMessage(l_rondel.INTERCEPTION_SUCCESSFUL, attacker.label)
+			break
+		end
+	end
+end
+
+local onShipFiring = function (ship)
+	if Game.system.name ~= "Rondel" then return end
+
+	local police = ShipDef[Game.system.faction.policeShip]
+	if ship.shipId ~= police.id then
+		for i = 1, #patrol do
+			if ship:DistanceTo(patrol[i]) <= 4000000 and not shipFiring then
+				shipFiring = true
+				Comms.ImportantMessage(string.interp(l_rondel.WEAPONS_EVASIVE_ACTION, patrol[1].label))
+				attackShip(ship)
+				break
+			end
+		end
+	end
+end
+
+local onJettison = function (ship, cargo)
+	if Game.system.name ~= "Rondel" then return end
+	if not jetissionedCargo then
+		Comms.ImportantMessage(l_rondel.JETTISON_DEFENSIVE_PRECAUTION, patrol[1].label)
+		jetissionedCargo = true
+	end
+	attackShip(ship)
+end
+
+local onEnterSystem = function (player)
+	if not player:IsPlayer() then return end
+
+	local system = Game.system
+	if system.name ~= "Rondel" then return end
+
+	local tolerance = 1
+	local hyperdrive = Game.player:GetEquip('engine',1)
+	if hyperdrive.fuel == cargo.military_fuel then
+		tolerance = 0.5
+	end
+
+	local ship
+	local shipdef = ShipDef[system.faction.policeShip]
+	for i = 1, 7 do
+		ship = Space.SpawnShipNear(shipdef.id, player, 50, 100)
+		ship:SetLabel(l_ui_core.POLICE)
+		ship:AddEquip(Equipment.laser.pulsecannon_2mw)
+		table.insert(patrol, ship)
+	end
+
+	Game.SetTimeAcceleration("1x")
+	Timer:CallAt(Game.time + 2, function ()
+		Comms.ImportantMessage(string.interp(l_rondel.RONDEL_RESTRICTED_ZONE, {seconds = tostring(120*tolerance), playerShipLabel = Game.player:GetLabel()}), ship.label)
+	end)
+
+	Timer:CallAt(Game.time + 120*tolerance, function()
+		attackShip(player)
+		Comms.ImportantMessage(l_rondel.HOSTILE_ACTION_REPORTED, ship.label)
+	end)
+end
+
+local onLeaveSystem = function (ship)
+	if ship:IsPlayer() then
+		shipFiring = false
+		jetissionedCargo = false
+		patrol = {}
+	end
+end
+
+local loaded_data
+
+local onGameStart = function ()
+	shipFiring = false
+	jetissionedCargo = false
+	if loaded_data then
+		patrol = loaded_data.patrol
+		loaded_data = nil
+	end
+end
+
+local onGameEnd = function ()
+	shipFiring = false
+	jetissionedCargo = false
+	patrol = {}
+end
+
+local serialize = function ()
+	return { patrol = patrol }
+end
+
+local unserialize = function (data)
+	loaded_data = data
+end
+
+Event.Register("onEnterSystem", onEnterSystem)
+Event.Register("onLeaveSystem", onLeaveSystem)
+Event.Register("onShipDestroyed", onShipDestroyed)
+Event.Register("onShipFiring", onShipFiring)
+Event.Register("onJettison", onJettison)
+Event.Register("onGameStart", onGameStart)
+Event.Register("onGameEnd", onGameEnd)
+
+Serializer:Register("Rondel", serialize, unserialize)


### PR DESCRIPTION
I know the title makes it sound stupid (why would you stop the players from entering a system?), but hear me out. I noticed a red spot on the sector map and found this Haber system in the middle of SolFed territory.
![rondel1](https://user-images.githubusercontent.com/29180904/103173600-15d75200-486d-11eb-8fa0-57266b4553ed.PNG)


```
-- Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt

-- example of a custom system directly specifying a faction
local s = CustomSystem:new('Rondel',{'STAR_M'})
	:faction('Haber Corporation')
	:short_desc('Military Listening Post')
	:long_desc([[A hidden dagger pointed at the heart of the Federation]])
	:seed(1824351)

s:add_to_sector(-1,6,2,v(0.007,0.260,0.060))
```

It looks like someone made this system just as a custom system example (no starports, no defined planets etc.), but I thought it could use more than just a fancy description... some more excitement. Which brings me to this PR:

Upon entering the system, 7 police vehicles appear near the player and warn them to leave. They are quite paranoid too:

- They allow 2 (EDIT: now 10) minutes to ships with civilian hyperdrives, 1 (EDIT: now 5) minute(s) to those with military hyperdrives. (Because military technology raises more suspicion, and they become less tolerant) If you don't leave, you get attacked.
- Jettisoning anything or firing a weapon triggers hostility, even if you don't hit the police.
- Police in this system use 2MW weapons as opposed to 1MW used by police patrols in other systems.

As for the code, it has been almost entirely copied from the PolicePatrol module, and edited.