### PR TITLE
Update buildscripts to use Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-20.04]
 
     steps:
     # Checkout the repository as $GITHUB_WORKSPACE
@@ -125,7 +125,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-20.04]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
 
     # Ubuntu 18.04 at the time of writing includes clang-format-9 as default
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-20.04]
 
     # We want to check all changed files between the pull-request base and the head of the pull request
     env:

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -31,7 +31,7 @@ else
     GIT_DIFF_TOOL="git diff-index --cached"
 fi
 
-# Allow manually specifiying the files.
+# Allow manually specifying the files.
 FILES="$@"
 
 # Otherwise, get a list of all files changed between our RANGE_BASE and the current HEAD
@@ -40,7 +40,7 @@ if [[ -z $FILES ]]; then
 fi
 
 if [[ -z $PATCH_MODE ]]; then
-    echo -e "Checking files:"
+    echo -e "Checking staged files to be committed:"
     for file in $FILES; do
         echo -e "\t$file"
     done

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+clang-format --version
+
 CLANG_FORMAT=$(which clang-format)
 
 # if PATCH_MODE is set to 0, then set it to the empty string so $PATCH_MODE continues to work


### PR DESCRIPTION
This is triggered by #5105, where my local and the remote system clang-format disagrees. Also, when we build linux version, I think we're more likely to be compatible with player's system, using ubuntu 20, rather than 16.