### PR TITLE
Add search for the geometrically closest jumpable

### DIFF
--- a/src/galaxy/SystemBody.h
+++ b/src/galaxy/SystemBody.h
@@ -85,9 +85,7 @@ public:
 	bool IsMoon() const { return GetSuperType() == SUPERTYPE_ROCKY_PLANET && !IsPlanet(); }
 	// We allow hyperjump to any star of the system
 	bool IsJumpable() const { return GetSuperType() == SUPERTYPE_STAR; }
-
-	// Climb the hierarchy until we find a jumpable. Guaranteed that every systembody has a jumpable parent.
-	SystemBody *GetNearestJumpable() { return IsJumpable() ? this : GetParent()->GetNearestJumpable(); }
+	SystemBody *GetNearestJumpable();
 
 	bool HasChildren() const { return !m_children.empty(); }
 	Uint32 GetNumChildren() const { return static_cast<Uint32>(m_children.size()); }


### PR DESCRIPTION
In case the systembody does not have a jumpable parent.
This can happen if it revolves around several stars at once.
At the moment this situation leads to a segfault.
Fixes #5112 

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

