### PR TITLE
Stop planet ambient sound once player gets off the ground

### DIFF
--- a/src/sound/AmbientSounds.cpp
+++ b/src/sound/AmbientSounds.cpp
@@ -148,7 +148,7 @@ void AmbientSounds::Update()
 			}
 		}
 	} else if (s_planetSurfaceNoise.IsPlaying()) {
-		// s_planetSurfaceNoise.IsPlaying() - if we are out of the atmosphere then stop playing
+		// s_planetSurfaceNoise.IsPlaying() - if player is no longer on the ground then stop playing
 		Frame *playerFrame = Frame::GetFrame(Pi::player->GetFrame());
 		if (playerFrame->IsRotFrame()) {
 			const Body *astro = playerFrame->GetBody();
@@ -156,8 +156,8 @@ void AmbientSounds::Update()
 				const double dist = Pi::player->GetPosition().Length();
 				double pressure, density;
 				static_cast<const Planet *>(astro)->GetAtmosphericState(dist, &pressure, &density);
-				if (pressure < 0.001) {
-					// Stop playing surface noise once out of the atmosphere
+				if (Pi::player->GetFlightState() != Ship::LANDED) {
+					// Stop playing surface noise once the ship is off the ground
 					s_planetSurfaceNoise.Stop();
 				}
 			}


### PR DESCRIPTION
There is not much to explain. For example if you rough-land on Earth's surface it plays some water sound, and we want this sound effect to stop once the player is airborne, not when they fly out of the atmosphere.

Partially f i x e s #5113 