### PR TITLE
Improve/fix system map

### DIFF
--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -371,7 +371,12 @@ bool DynamicBody::OnCollision(Body *o, Uint32 flags, double relVel)
 // return parameters for orbit of any body, gives both elliptic and hyperbolic trajectories
 Orbit DynamicBody::ComputeOrbit() const
 {
-	FrameId nrFrameId = Frame::GetFrame(GetFrame())->GetNonRotFrame();
+	auto f = Frame::GetFrame(GetFrame());
+	// if we are in a rotating frame, then dynamic body currently under the
+	// influence of a rotational frame, therefore getting the orbital parameters
+	// is not appropriate, return the orbit as a fixed point
+	if (f->IsRotFrame()) return Orbit::ForStaticBody(GetPosition());
+	FrameId nrFrameId = f->GetId();
 	const Frame *nrFrame = Frame::GetFrame(nrFrameId);
 	const double mass = nrFrame->GetSystemBody()->GetMass();
 

--- a/src/Orbit.h
+++ b/src/Orbit.h
@@ -16,6 +16,7 @@ public:
 
 	// note: the resulting Orbit is at the given position at t=0
 	static Orbit FromBodyState(const vector3d &position, const vector3d &velocity, double central_mass);
+	static Orbit ForStaticBody(const vector3d &position);
 
 	Orbit() :
 		m_eccentricity(0.0),
@@ -58,6 +59,7 @@ private:
 	double MeanAnomalyFromTrueAnomaly(double trueAnomaly) const;
 	double MeanAnomalyAtTime(double time) const;
 
+	vector3d m_positionForStaticBody;
 	double m_eccentricity;
 	double m_semiMajorAxis;
 	double m_orbitalPhaseAtStart; // 0 to 2 pi radians

--- a/src/lua/LuaSystemView.cpp
+++ b/src/lua/LuaSystemView.cpp
@@ -218,7 +218,7 @@ static int l_systemview_get_projected_grouped(lua_State *l)
 					touchedGroups.push_back(&group);
 			//now select the nearest group (if have)
 			if (touchedGroups.size()) {
-				GroupInfo *nearest;
+				GroupInfo *nearest = nullptr;
 				double min_length = 1e64;
 				for (GroupInfo *&g : touchedGroups) {
 					double this_length = (g->m_mainObject.screenpos - special_object[object_type]->screenpos).Length();


### PR DESCRIPTION
- add a "static" orbit for bodies that are not moving anywhere
- now bodies in a rotating frame, and also in the space port frame have such "static" orbits
- add display of the orbits of objects moving strictly to the star or from the star
- also fix compile warning for possibly uninitiated variable in `LuaSystemView.cpp`
- also fix an issue where smooth animation sometimes have a hard time catching up with a newly selected object:

https://user-images.githubusercontent.com/18342621/105128153-859ace80-5af3-11eb-89b6-72e05428b993.mp4





Fixes #5062

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

