### PR TITLE
Fix that sometimes ships get stuck the moment they start to dock

### DIFF
--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -1389,6 +1389,10 @@ bool AICmdDock::TimeStepUpdate()
 		if (m_state != eDockGetDataEnd) {
 			m_dockpos = dockpos.pos;
 		}
+		// we are already near the station, what could go wrong?
+		// set the fuel reserve to 0, since the fuel could become lower than the
+		// current reserve during the flight, and the ship will not fly anywhere
+		m_prop->SetFuelReserve(0.0);
 
 		m_dockdir = dockpos.zaxis.Normalized();
 		m_dockupdir = dockpos.yaxis.Normalized(); // don't trust these enough


### PR DESCRIPTION
- Fix that sometimes ships get stuck the moment they start to dock.
- ~~Fix that during a long free flight the autopilot constantly corrects the course towards the target and this leads to unnecessary fuel consumption.~~ **Сan't reproduce**
- ~~Add a simple queue for docking with the station in order to somewhat reduce the probability of a collision of ships~~ **It didn't work out that easy, let's postpone**

~~Also in order to find out which ships are in a given frame, I implemented the `Frame::GetBodiesInside` function, and for its work - the `CollisionSpace::GetGeoms` function.~~


