### PR TITLE
Modify GetAtmosphericState() to accept any two bodies

### DIFF
--- a/data/pigui/modules/flight-ui/gauges.lua
+++ b/data/pigui/modules/flight-ui/gauges.lua
@@ -81,7 +81,7 @@ gauges.registerGauge(2, {
 	value = function ()
 		local frame = Game.player.frameBody
 		if frame then
-			local pressure, density = frame:GetAtmosphericState()
+			local pressure, density = frame:GetAtmosphericState(Game.player)
 			return pressure
 		else return nil end
 	end,

--- a/data/pigui/modules/master-alarm.lua
+++ b/data/pigui/modules/master-alarm.lua
@@ -46,7 +46,7 @@ local function alarm ()
 	--check atmospheric pressure
 	local frame = Game.player.frameBody
 	if frame then
-		local pressure = frame:GetAtmosphericState()
+		local pressure = frame:GetAtmosphericState(Game.player)
 		if pressure and pressure > 9 and not alreadyAlertedPres then
 			ui.playSfx("alarm_generic1", 1.0, 1.0)
 			alreadyAlertedPres = true

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -635,13 +635,14 @@ static int l_body_get_phys_radius(lua_State *l)
 
 static int l_body_get_atmospheric_state(lua_State *l)
 {
-	Body *b = LuaObject<Body>::CheckFromLua(1);
+	Body *planetBody = LuaObject<Body>::CheckFromLua(1);
+	Body *b = LuaObject<Body>::CheckFromLua(2);
 	//	const SystemBody *sb = b->GetSystemBody();
-	vector3d pos = Pi::player->GetPosition();
+	vector3d pos = b->GetPositionRelTo(planetBody);
 	double center_dist = pos.Length();
-	if (b->IsType(ObjectType::PLANET)) {
+	if (planetBody->IsType(ObjectType::PLANET)) {
 		double pressure, density;
-		static_cast<Planet *>(b)->GetAtmosphericState(center_dist, &pressure, &density);
+		static_cast<Planet *>(planetBody)->GetAtmosphericState(center_dist, &pressure, &density);
 		lua_pushnumber(l, pressure);
 		lua_pushnumber(l, density);
 		return 2;


### PR DESCRIPTION
...instead of just the player. So you can calculate the pressure around any object in atmosphere, not just the player ship.
EDIT: The main motivation for this PR is that it fixes the traffic control giving wrong pressure data.