### PR TITLE
Fix death music not playing over tombstone screen

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1089,9 +1089,6 @@ void GameLoop::End()
 
 	Pi::SetMouseGrab(false);
 
-	Pi::GetMusicPlayer().Stop();
-	Sound::DestroyAllEvents();
-
 	// final event
 	LuaEvent::Queue("onGameEnd");
 	LuaEvent::Emit();
@@ -1101,7 +1098,7 @@ void GameLoop::End()
 	Lua::manager->CollectGarbage();
 
 	if (!Pi::config->Int("DisableSound")) AmbientSounds::Uninit();
-	Sound::DestroyAllEvents();
+	Sound::DestroyAllEventsExceptMusic();
 
 	assert(Pi::game);
 	delete Pi::game;
@@ -1131,8 +1128,11 @@ void TombstoneLoop::Update(float deltaTime)
 
 	bool hasInput = Pi::input->MouseButtonState(SDL_BUTTON_LEFT) || Pi::input->MouseButtonState(SDL_BUTTON_RIGHT) || Pi::input->KeyState(SDLK_SPACE);
 
-	if ((accumTime > 2.0 && hasInput) || accumTime > 8.0)
+	if ((accumTime > 2.0 && hasInput) || accumTime > 8.0) {
 		RequestEndLifecycle();
+		Pi::GetMusicPlayer().Stop();
+		Sound::DestroyAllEvents();
+	}
 }
 
 /*

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -468,6 +468,17 @@ namespace Sound {
 		SDL_UnlockAudioDevice(m_audioDevice);
 	}
 
+	void DestroyAllEventsExceptMusic()
+	{
+		/* silence any sound events EXCEPT music
+		   which are on wavstream[0] and [1] */
+		SDL_LockAudioDevice(m_audioDevice);
+		for (unsigned int idx = 2; idx < MAX_WAVSTREAMS; idx++) {
+			DestroyEvent(&wavstream[idx]);
+		}
+		SDL_UnlockAudioDevice(m_audioDevice);
+	}
+
 	static void load_sound(const std::string &basename, const std::string &path, bool is_music)
 	{
 		PROFILE_SCOPED()

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -67,6 +67,7 @@ namespace Sound {
 	 * Silence all active sound events.
 	 */
 	void DestroyAllEvents();
+	void DestroyAllEventsExceptMusic();
 	void Pause(int on);
 	eventid PlaySfx(const char *fx, const float volume_left, const float volume_right, const Op op);
 	eventid PlayMusic(const char *fx, const float volume_left, const float volume_right, const Op op);


### PR DESCRIPTION
While trying to prevent sounds from playing after the game was ended, Pi.cpp accidentally(?) stopped music player from playing as well, which meant no death music would play as the tombstone spinner appeared. Now it works as intended; sound effects stop, but music is not stopped until death view is closed and the program returns to main menu (at which point menu music starts).

I made this a separate PR from #5093 so that only the fix can be merged if one desires.