### PR TITLE
Don't persist signals past destruction of object they're attached to

### DIFF
--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -105,6 +105,10 @@ void PlayerShipController::InputBinding::RegisterBindings()
 
 PlayerShipController::~PlayerShipController()
 {
+	m_setSpeedMode.disconnect();
+	m_fireMissileKey.disconnect();
+	m_connRotationDampingToggleKey.disconnect();
+
 	Pi::input->RemoveInputFrame(&InputBindings);
 	m_connRotationDampingToggleKey.disconnect();
 	m_fireMissileKey.disconnect();


### PR DESCRIPTION
Fixes #5136, code as suggested by @Web-eWorks 
