### PR TITLE
Fix GasGiant clipping and bright spots on models

### DIFF
--- a/data/shaders/opengl/multi.frag
+++ b/data/shaders/opengl/multi.frag
@@ -88,6 +88,8 @@ void main(void)
 #else
 	vec3 vNormal = normal;
 #endif
+	vNormal = normalize(vNormal);
+
 	//ambient only make sense with lighting
 	vec4 light = scene.ambient;
 	vec4 specular = vec4(0.0);

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -72,7 +72,7 @@ void CameraContext::EndFrame()
 
 void CameraContext::ApplyDrawTransforms(Graphics::Renderer *r)
 {
-	r->SetPerspectiveProjection(m_fovAng, m_width / m_height, m_zNear, m_zFar);
+	r->SetProjection(matrix4x4f::InfinitePerspectiveMatrix(DEG2RAD(m_fovAng), m_width / m_height, m_zNear));
 	r->SetTransform(matrix4x4f::Identity());
 }
 

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -582,7 +582,7 @@ static vector3d projectToScreenSpace(const vector3d &pos, RefCountedPtr<CameraCo
 	float znear;
 	float zfar;
 	Pi::renderer->GetNearFarRange(znear, zfar);
-	proj.z = -((zfar * znear) / (proj.z * (zfar - znear) + znear));
+	proj.z = -znear / proj.z;
 
 	// set z to -1 if in front of camera, 1 else
 	if (adjustZ)

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -82,6 +82,8 @@ namespace Graphics {
 		const vector3d vVP = {
 			vNDC.x * 0.5 + 0.5,
 			vNDC.y * 0.5 + 0.5,
+			// FIXME: this isn't a proper linearization into viewspace (needs -znear / zNDC)
+			// but it accomplishes the goal of positions behind the camera having z > 0.
 			-vNDC.z // undo reverse-Z coordinate flip
 		};
 


### PR DESCRIPTION
As promised, this was pulled out of #5156 to be applied to master. This PR contains a fix for planets and gas giants clipping out of the view, and also a fix for the unreported issue of persistent bright-spot acne on our models, most noticeable on the fuselage of the Pumpkinseed (but prevalent pretty much everywhere).

Closes #5145.

These screenshots are identical loads of the same save (including camera position/zoom), showing the difference with this change applied.

## Before:
![Screenshot from 2021-03-26 22-37-23](https://user-images.githubusercontent.com/4218491/112707853-c3fe9200-8e84-11eb-8430-18d0591c4016.png)
![Screenshot from 2021-03-26 22-40-22](https://user-images.githubusercontent.com/4218491/112707855-c6f98280-8e84-11eb-8b0b-f8378867983f.png)

## After:
![Screenshot from 2021-03-26 22-37-56](https://user-images.githubusercontent.com/4218491/112707857-ca8d0980-8e84-11eb-98cb-c3f202623015.png)
![Screenshot from 2021-03-26 22-41-00](https://user-images.githubusercontent.com/4218491/112707858-cbbe3680-8e84-11eb-9055-430b3cd8967f.png)


