### PR TITLE
Add new debug / editor colorscheme

### DIFF
--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -45,7 +45,8 @@ ModelViewer::Options::Options() :
 	mouselookEnabled(false),
 	gridInterval(10.f),
 	lightPreset(0),
-	orthoView(false)
+	orthoView(false),
+	metricsWindow(false)
 {
 }
 
@@ -99,6 +100,10 @@ void ModelViewerApp::Startup()
 
 	StartupInput(config.get());
 	StartupPiGui();
+
+	GetPiGui()->SetDebugStyle();
+	// precache the editor font
+	GetPiGui()->GetFont("pionillium", 13);
 
 	NavLights::Init(renderer);
 	Shields::Init(renderer);
@@ -366,7 +371,7 @@ void ModelViewer::DrawBackground()
 
 	if (!m_bgBuffer.Valid()) {
 		const Color top = Color::BLACK;
-		const Color bottom = Color(77, 77, 77);
+		const Color bottom = Color(28, 31, 36);
 		Graphics::VertexArray bgArr(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE, 6);
 		// triangle 1
 		bgArr.Add(vector3f(0.f, 0.f, 0.f), bottom);
@@ -658,6 +663,10 @@ void ModelViewer::HandleInput()
 	if (m_input->IsKeyPressed(SDLK_p)) {
 		m_options.showLandingPad = !m_options.showLandingPad;
 		AddLog(stringf("Scale/landing pad test %0", m_options.showLandingPad ? "on" : "off"));
+	}
+
+	if (m_input->IsKeyPressed(SDLK_i)) {
+		m_options.metricsWindow = !m_options.metricsWindow;
 	}
 
 	// random colors, eastereggish
@@ -961,7 +970,11 @@ void ModelViewer::DrawModelOptions()
 {
 	float itmWidth = ImGui::CalcItemWidth();
 
+	ImGui::PushFont(m_pigui->GetFont("pionillium", 14));
+	ImGui::AlignTextToFramePadding();
 	ImGui::TextUnformatted(m_modelName.c_str());
+	ImGui::PopFont();
+
 	ImGui::SameLine();
 	if (ImGui::Button("Reload Model"))
 		ReloadModel();
@@ -1099,6 +1112,8 @@ void ModelViewer::DrawPiGui()
 		return;
 	}
 
+	ImGui::PushFont(m_pigui->GetFont("pionillium", 13));
+
 	ImGui::SetNextWindowPos({ 0, 0 });
 	ImGui::SetNextWindowSize({ m_windowSize.x, m_windowSize.y });
 	ImGui::Begin("##background-display", nullptr, fullscreenFlags);
@@ -1134,6 +1149,11 @@ void ModelViewer::DrawPiGui()
 	}
 	ImGui::End();
 	ImGui::PopStyleVar(1);
+
+	if (m_options.metricsWindow)
+		ImGui::ShowDemoWindow();
+
+	ImGui::PopFont();
 }
 
 void ModelViewer::UpdateCamera(float deltaTime)

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -122,6 +122,7 @@ private:
 		float gridInterval;
 		uint32_t lightPreset;
 		bool orthoView;
+		bool metricsWindow;
 
 		Options();
 	};

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -655,7 +655,9 @@ void MainMenu::Update(float deltaTime)
 
 	perfInfoDisplay->Update(deltaTime * 1e3, 0.0);
 	if (Pi::showDebugInfo) {
+		Pi::pigui->SetDebugStyle();
 		perfInfoDisplay->Draw();
+		Pi::pigui->SetNormalStyle();
 	}
 
 	Pi::pigui->Render();
@@ -1038,7 +1040,9 @@ void GameLoop::Update(float deltaTime)
 
 	// Render this even when we're dead.
 	if (Pi::showDebugInfo) {
+		Pi::pigui->SetDebugStyle();
 		perfInfoDisplay->Draw();
+		Pi::pigui->SetNormalStyle();
 	}
 
 	Pi::pigui->Render();

--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -112,12 +112,58 @@ ImTextureID PiGui::RenderSVG(Graphics::Renderer *renderer, std::string svgFilena
 	return makeTexture(renderer, img, W, H);
 }
 
+// Colors taken with love from the Limit Theory editor
+// http://forums.ltheory.com/viewtopic.php?f=30&t=6459
+void StyleColorsDarkPlus(ImGuiStyle &style)
+{
+	style.FramePadding = ImVec2(6, 5);
+
+	style.WindowRounding = 5.0;
+	style.ChildRounding = 2.0;
+	style.FrameRounding = 2.0;
+	style.GrabRounding = 2.0;
+	style.TabRounding = 2.0;
+
+	style.FrameBorderSize = 1.0;
+	style.TabBorderSize = 1.0;
+
+	style.Colors[ImGuiCol_WindowBg] = ImColor(24, 26, 31);
+	style.Colors[ImGuiCol_ChildBg] = ImColor(20, 22, 26);
+	style.Colors[ImGuiCol_PopupBg] = ImColor(20, 22, 26, 240);
+	style.Colors[ImGuiCol_Border] = ImColor(0, 0, 0);
+
+	style.Colors[ImGuiCol_FrameBg] = ImColor(33, 36, 43);
+	style.Colors[ImGuiCol_FrameBgHovered] = ImColor(45, 50, 59);
+	style.Colors[ImGuiCol_FrameBgActive] = ImColor(56, 126, 210);
+
+	style.Colors[ImGuiCol_TitleBg] = ImColor(20, 23, 26);
+	style.Colors[ImGuiCol_TitleBgActive] = ImColor(27, 31, 35);
+	style.Colors[ImGuiCol_TitleBgCollapsed] = ImColor(15, 17, 19);
+	style.Colors[ImGuiCol_MenuBarBg] = ImColor(20, 23, 26);
+
+	style.Colors[ImGuiCol_ScrollbarBg] = ImColor(19, 20, 24);
+	style.Colors[ImGuiCol_ScrollbarGrab] = ImColor(33, 36, 43);
+	style.Colors[ImGuiCol_ScrollbarGrabHovered] = ImColor(81, 88, 105);
+	style.Colors[ImGuiCol_ScrollbarGrabActive] = ImColor(100, 109, 130);
+
+	style.Colors[ImGuiCol_Button] = ImColor(51, 56, 67);
+	style.Colors[ImGuiCol_Header] = ImColor(51, 56, 67);
+	style.Colors[ImGuiCol_HeaderHovered] = ImColor(56, 126, 210);
+	style.Colors[ImGuiCol_HeaderActive] = ImColor(66, 150, 250);
+
+	style.Colors[ImGuiCol_Tab] = ImColor(20, 23, 26);
+	style.Colors[ImGuiCol_TabActive] = ImColor(60, 133, 224);
+	style.Colors[ImGuiCol_TabHovered] = ImColor(66, 150, 250);
+}
+
 //
 //	PiGui::Instance
 //
 
 Instance::Instance() :
-	m_should_bake_fonts(true)
+	m_should_bake_fonts(true),
+	m_debugStyle(),
+	m_debugStyleActive(false)
 {
 	// TODO: clang-format doesn't like list initializers inside function calls
 	// clang-format off
@@ -158,6 +204,24 @@ Instance::Instance() :
 
 	// ensure the tooltip font exists
 	GetFont("pionillium", 14);
+
+	StyleColorsDarkPlus(m_debugStyle);
+}
+
+void Instance::SetDebugStyle()
+{
+	if (!m_debugStyleActive)
+		std::swap(m_debugStyle, ImGui::GetStyle());
+
+	m_debugStyleActive = true;
+}
+
+void Instance::SetNormalStyle()
+{
+	if (m_debugStyleActive)
+		std::swap(m_debugStyle, ImGui::GetStyle());
+
+	m_debugStyleActive = false;
 }
 
 ImFont *Instance::GetFont(const std::string &name, int size)

--- a/src/pigui/PiGui.h
+++ b/src/pigui/PiGui.h
@@ -97,6 +97,12 @@ namespace PiGui {
 		// Calls ImGui::EndFrame() internally and does book-keeping before rendering.
 		void Render();
 
+		// Sets the ImGui Style object to use the predefined development tooling style
+		void SetDebugStyle();
+
+		// Sets the ImGui Style object to use the game UI style object as modified by Lua
+		void SetNormalStyle();
+
 		ImFont *AddFont(const std::string &name, int size);
 		ImFont *GetFont(const std::string &name, int size);
 
@@ -115,6 +121,9 @@ namespace PiGui {
 		bool m_should_bake_fonts;
 
 		std::map<std::string, PiFont> m_font_definitions;
+
+		ImGuiStyle m_debugStyle;
+		bool m_debugStyleActive;
 
 		void BakeFonts();
 		void BakeFont(PiFont &font);


### PR DESCRIPTION
Replace the default (and slightly ugly) ImGui debug colorscheme with a nicer, fancier colorscheme stolen with love from the forever-unreleased Limit Theory editor screenshots.

This was something I whipped up in a few hours to see if I could actually make vanilla ImGui look like a "professional" game engine / editor widget toolkit without touching any of our drawing code. Suffice to say, I'm very happy with the results.

Compare the old version (pardon the layout differences):
![](https://user-images.githubusercontent.com/4218491/76652009-10a65200-653c-11ea-9099-d7a4fbc995e1.png)

To the new version:
![](https://i.imgur.com/Y77n14x.png)
![](https://i.imgur.com/RY8Snvw.png)