### PR TITLE
Improve performance with many ships in one system

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -479,6 +479,7 @@ void Frame::ClearMovement()
 
 void Frame::UpdateOrbitRails(double time, double timestep)
 {
+	PROFILE_SCOPED()
 	std::for_each(begin(s_frames), end(s_frames), [&time, &timestep](Frame &frame) {
 		frame.m_oldPos = frame.m_pos;
 		frame.m_oldAngDisplacement = frame.m_angSpeed * timestep;

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -246,7 +246,6 @@ void Frame::DeleteFrames()
 
 Frame *Frame::GetFrame(FrameId fId)
 {
-	PROFILE_SCOPED()
 #ifndef NDEBUG
 	if (fId && fId >= s_frames.size())
 		Error("In '%s': fId is valid but out of range (%zu)...\n", __func__, fId.id());

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -247,13 +247,12 @@ void Frame::DeleteFrames()
 Frame *Frame::GetFrame(FrameId fId)
 {
 	PROFILE_SCOPED()
-
-	if (fId && fId.id() < s_frames.size())
-		return &s_frames[fId];
-	else if (fId)
+#ifndef NDEBUG
+	if (fId && fId >= s_frames.size())
 		Error("In '%s': fId is valid but out of range (%zu)...\n", __func__, fId.id());
+#endif
 
-	return nullptr;
+	return fId.valid() ? &s_frames[fId] : nullptr;
 }
 
 FrameId Frame::CreateCameraFrame(FrameId parent)

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -247,7 +247,7 @@ void Frame::DeleteFrames()
 Frame *Frame::GetFrame(FrameId fId)
 {
 #ifndef NDEBUG
-	if (fId && fId >= s_frames.size())
+	if (fId && fId.id() >= s_frames.size())
 		Error("In '%s': fId is valid but out of range (%zu)...\n", __func__, fId.id());
 #endif
 

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -183,6 +183,10 @@ void ModelBody::SetModel(const char *modelName)
 	//create model instance (some modelbodies, like missiles could avoid this)
 	m_model = Pi::FindModel(m_modelName)->MakeInstance();
 	m_idleAnimation = m_model->FindAnimation("idle");
+	// TODO: this isn't great, as animations will be ticked regardless of whether the modelbody
+	// is next to the player or on the other side of the solar system.
+	if (m_idleAnimation)
+		m_model->SetAnimationActive(m_model->FindAnimationIndex(m_idleAnimation), true);
 
 	SetClipRadius(m_model->GetDrawClipRadius());
 

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -843,6 +843,8 @@ void ModelViewer::OnModelChanged()
 
 	m_animations = m_model->GetAnimations();
 	m_currentAnimation = m_animations.size() ? m_animations.front() : nullptr;
+	if (m_currentAnimation)
+		m_model->SetAnimationActive(0, true);
 
 	m_patterns.clear();
 	m_currentPattern = 0;
@@ -1056,6 +1058,8 @@ void ModelViewer::DrawModelOptions()
 				const bool selected = m_currentAnimation == anim;
 				if (ImGui::Selectable(anim->GetName().c_str(), selected) && !selected) {
 					// selected a new animation entry
+					m_model->SetAnimationActive(m_model->FindAnimationIndex(m_currentAnimation), false);
+					m_model->SetAnimationActive(m_model->FindAnimationIndex(anim), true);
 					m_currentAnimation = anim;
 				}
 			}

--- a/src/Ship-AI.cpp
+++ b/src/Ship-AI.cpp
@@ -19,6 +19,7 @@
 // returns true if command is complete
 bool Ship::AITimeStep(float timeStep)
 {
+	PROFILE_SCOPED()
 	// allow the launch thruster thing to happen
 	if (m_launchLockTimeout > 0.0) return false;
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -229,6 +229,10 @@ void Ship::Init()
 	m_hyperspaceCloud = 0;
 
 	m_landingGearAnimation = GetModel()->FindAnimation("gear_down");
+	// TODO: this causes the landing gear animation to be ticked for all ships regardless of whether it actually needs to be.
+	// Need smarter control regarding landing gear transitions.
+	if (m_landingGearAnimation)
+		GetModel()->SetAnimationActive(GetModel()->FindAnimationIndex(m_landingGearAnimation), true);
 
 	GetFixedGuns()->InitGuns(GetModel());
 
@@ -979,6 +983,7 @@ void Ship::SetFrame(FrameId fId)
 
 void Ship::TimeStepUpdate(const float timeStep)
 {
+	PROFILE_SCOPED()
 	// If docked, station is responsible for updating position/orient of ship
 	// but we call this crap anyway and hope it doesn't do anything bad
 
@@ -1210,6 +1215,7 @@ void Ship::UpdateFuel(const float timeStep)
 
 void Ship::StaticUpdate(const float timeStep)
 {
+	PROFILE_SCOPED()
 	// do player sounds before dead check, so they also turn off
 	if (IsType(ObjectType::PLAYER)) DoThrusterSounds();
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -46,6 +46,13 @@ struct shipstats_t {
 	float shield_mass;
 	float shield_mass_left;
 	float fuel_tank_mass_left;
+
+	// cached equipment information to avoid costly Lua lookups
+	int atmo_shield_cap;
+	int radar_cap;
+	int fuel_scoop_cap;
+	int cargo_bay_life_support_cap;
+	int hull_autorepair_cap;
 };
 
 struct HyperdriveSoundsTable {

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -297,6 +297,7 @@ private:
 
 	FlightState m_flightState;
 	bool m_testLanded;
+	bool m_forceWheelUpdate;
 	float m_launchLockTimeout;
 	float m_wheelState;
 	int m_wheelTransition;

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -953,6 +953,7 @@ static void hitCallback(CollisionContact *c)
 // temporary one-point version
 static void CollideWithTerrain(Body *body, float timeStep)
 {
+	PROFILE_SCOPED()
 	if (!body->IsType(ObjectType::DYNAMICBODY))
 		return;
 	DynamicBody *dynBody = static_cast<DynamicBody *>(body);
@@ -1016,6 +1017,7 @@ void Space::TimeStep(float step)
 
 void Space::UpdateBodies()
 {
+	PROFILE_SCOPED()
 #ifndef NDEBUG
 	m_processingFinalizationQueue = true;
 #endif

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -155,6 +155,7 @@ static void RelocateStarportIfNecessary(SystemBody *sbody, Planet *planet, vecto
 
 void Space::BodyNearFinder::Prepare()
 {
+	PROFILE_SCOPED()
 	m_bodyDist.clear();
 
 	for (Body *b : m_space->GetBodies())

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -79,7 +79,6 @@ static Type parse_imgui_enum(lua_State *l, int index, LuaFlags<Type> lookupTable
 
 void *pi_lua_checklightuserdata(lua_State *l, int index)
 {
-	PROFILE_SCOPED()
 	if (lua_islightuserdata(l, index))
 		return lua_touserdata(l, index);
 	else
@@ -89,14 +88,12 @@ void *pi_lua_checklightuserdata(lua_State *l, int index)
 
 void pi_lua_generic_pull(lua_State *l, int index, ImVec2 &vec)
 {
-	PROFILE_SCOPED()
 	vector2d tr = LuaPull<vector2d>(l, index);
 	vec = ImVec2(tr.x, tr.y);
 }
 
 void pi_lua_generic_push(lua_State *l, const ImVec2 &vec)
 {
-	PROFILE_SCOPED()
 	LuaPush(l, vector2d(vec.x, vec.y));
 }
 
@@ -128,14 +125,12 @@ static LuaFlags<ImGuiSelectableFlags_> imguiSelectableFlagsTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImColor &color)
 {
-	PROFILE_SCOPED()
 	Color tr = LuaPull<Color>(l, index);
 	color = ImColor(tr.r, tr.g, tr.b, tr.a);
 }
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiSelectableFlags_ &theflags)
 {
-	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiSelectableFlagsTable);
 }
 
@@ -163,7 +158,6 @@ static LuaFlags<ImGuiTreeNodeFlags_> imguiTreeNodeFlagsTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiTreeNodeFlags_ &theflags)
 {
-	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiTreeNodeFlagsTable);
 }
 
@@ -196,7 +190,6 @@ static LuaFlags<ImGuiInputTextFlags_> imguiInputTextFlagsTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiInputTextFlags_ &theflags)
 {
-	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiInputTextFlagsTable);
 }
 
@@ -217,7 +210,6 @@ static LuaFlags<ImGuiCond_> imguiSetCondTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiCond_ &value)
 {
-	PROFILE_SCOPED()
 	value = parse_imgui_enum(l, index, imguiSetCondTable);
 }
 
@@ -276,7 +268,6 @@ static LuaFlags<ImGuiCol_> imguiColTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiCol_ &value)
 {
-	PROFILE_SCOPED()
 	value = parse_imgui_enum(l, index, imguiColTable);
 }
 
@@ -305,7 +296,6 @@ static LuaFlags<ImGuiStyleVar_> imguiStyleVarTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiStyleVar_ &value)
 {
-	PROFILE_SCOPED()
 	value = parse_imgui_enum(l, index, imguiStyleVarTable);
 }
 
@@ -330,7 +320,6 @@ static LuaFlags<ImGuiWindowFlags_> imguiWindowFlagsTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiWindowFlags_ &theflags)
 {
-	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiWindowFlagsTable);
 }
 
@@ -356,7 +345,6 @@ static LuaFlags<ImGuiHoveredFlags_> imguiHoveredFlagsTable = {
 
 void pi_lua_generic_pull(lua_State *l, int index, ImGuiHoveredFlags_ &theflags)
 {
-	PROFILE_SCOPED()
 	theflags = parse_imgui_flags(l, index, imguiHoveredFlagsTable);
 }
 
@@ -372,7 +360,6 @@ static vector2d s_center(0., 0.);
 
 static vector2d pointOnClock(const double radius, const double hours)
 {
-	PROFILE_SCOPED()
 	double angle = (hours / 6) * 3.14159;
 	vector2d res = s_center + vector2d(radius * sin(angle), -radius * cos(angle));
 	return res;
@@ -380,7 +367,6 @@ static vector2d pointOnClock(const double radius, const double hours)
 
 static vector2d pointOnClock(const vector2d &center, const double radius, const double hours)
 {
-	PROFILE_SCOPED()
 	// Update center:
 	s_center = center;
 	return pointOnClock(radius, hours);
@@ -388,7 +374,6 @@ static vector2d pointOnClock(const vector2d &center, const double radius, const 
 
 static void lineOnClock(const double hours, const double length, const double radius, const ImColor &color, const double thickness)
 {
-	PROFILE_SCOPED()
 	ImDrawList *draw_list = ImGui::GetWindowDrawList();
 	vector2d p1 = pointOnClock(radius, hours);
 	vector2d p2 = pointOnClock(radius - length, hours);
@@ -398,7 +383,6 @@ static void lineOnClock(const double hours, const double length, const double ra
 
 static void lineOnClock(const vector2d &center, const double hours, const double length, const double radius, const ImColor &color, const double thickness)
 {
-	PROFILE_SCOPED()
 	// Update center:
 	s_center = center;
 	lineOnClock(hours, length, radius, color, thickness);
@@ -563,7 +547,6 @@ static int l_pigui_set_column_width(lua_State *l)
  */
 static int l_pigui_set_column_offset(lua_State *l)
 {
-	PROFILE_SCOPED()
 	int column_index = LuaPull<int>(l, 1);
 	double offset_x = LuaPull<double>(l, 2);
 	ImGui::SetColumnOffset(column_index, offset_x);
@@ -584,7 +567,6 @@ static int l_pigui_set_column_offset(lua_State *l)
  */
 static int l_pigui_get_scroll_y(lua_State *l)
 {
-	PROFILE_SCOPED()
 	LuaPush<double>(l, ImGui::GetScrollY());
 	return 1;
 }
@@ -686,7 +668,6 @@ static int l_pigui_progress_bar(lua_State *l)
  */
 static int l_pigui_next_column(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImGui::NextColumn();
 	return 0;
 }
@@ -1345,7 +1326,6 @@ static int l_pigui_add_triangle_filled(lua_State *l)
  */
 static int l_pigui_same_line(lua_State *l)
 {
-	PROFILE_SCOPED()
 	double pos_x = LuaPull<double>(l, 1);
 	double spacing_w = LuaPull<double>(l, 2);
 	ImGui::SameLine(pos_x, spacing_w);
@@ -1389,14 +1369,12 @@ static int l_pigui_end_group(lua_State *l)
  */
 static int l_pigui_separator(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImGui::Separator();
 	return 0;
 }
 
 static int l_pigui_spacing(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImGui::Spacing();
 	return 0;
 }
@@ -1446,6 +1424,13 @@ static int l_pigui_begin_popup_modal(lua_State *l)
 	return 1;
 }
 
+static int l_pigui_end_popup(lua_State *l)
+{
+	PROFILE_SCOPED()
+	ImGui::EndPopup();
+	return 0;
+}
+
 static int l_pigui_open_popup(lua_State *l)
 {
 	PROFILE_SCOPED()
@@ -1463,16 +1448,8 @@ static int l_pigui_close_current_popup(lua_State *l)
 
 static int l_pigui_is_any_popup_open(lua_State *l)
 {
-	PROFILE_SCOPED()
 	LuaPush<bool>(l, !ImGui::GetCurrentContext()->OpenPopupStack.empty());
 	return 1;
-}
-
-static int l_pigui_end_popup(lua_State *l)
-{
-	PROFILE_SCOPED()
-	ImGui::EndPopup();
-	return 0;
 }
 
 static int l_pigui_begin_child(lua_State *l)
@@ -1591,7 +1568,6 @@ static int l_pigui_calc_text_size(lua_State *l)
 
 static int l_pigui_get_mouse_pos(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImVec2 pos = ImGui::GetMousePos();
 	LuaPush(l, vector2d(pos.x, pos.y));
 	return 1;
@@ -1599,7 +1575,6 @@ static int l_pigui_get_mouse_pos(lua_State *l)
 
 static int l_pigui_get_mouse_wheel(lua_State *l)
 {
-	PROFILE_SCOPED()
 	float wheel = ImGui::GetIO().MouseWheel;
 	LuaPush(l, wheel);
 	return 1;
@@ -1678,7 +1653,6 @@ static int l_pigui_pop_id(lua_State *l)
 
 static int l_pigui_get_window_pos(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImVec2 pos = ImGui::GetWindowPos();
 	LuaPush<vector2d>(l, vector2d(pos.x, pos.y));
 	return 1;
@@ -1686,7 +1660,6 @@ static int l_pigui_get_window_pos(lua_State *l)
 
 static int l_pigui_get_window_size(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImVec2 ws = ImGui::GetWindowSize();
 	LuaPush<vector2d>(l, vector2d(ws.x, ws.y));
 	return 1;
@@ -1694,7 +1667,6 @@ static int l_pigui_get_window_size(lua_State *l)
 
 static int l_pigui_get_content_region(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImVec2 cra = ImGui::GetContentRegionAvail();
 	LuaPush<vector2d>(l, vector2d(cra.x, cra.y));
 	return 1;
@@ -2073,7 +2045,6 @@ static int l_pigui_get_targets_nearby(lua_State *l)
 
 static int l_pigui_disable_mouse_facing(lua_State *l)
 {
-	PROFILE_SCOPED()
 	bool b = LuaPull<bool>(l, 1);
 	auto *p = Pi::player->GetPlayerController();
 	p->SetDisableMouseFacing(b);
@@ -2082,7 +2053,6 @@ static int l_pigui_disable_mouse_facing(lua_State *l)
 
 static int l_pigui_set_mouse_button_state(lua_State *l)
 {
-	PROFILE_SCOPED()
 	int button = LuaPull<int>(l, 1);
 	bool state = LuaPull<bool>(l, 2);
 	Pi::input->SetMouseButtonState(button, state);
@@ -2091,7 +2061,6 @@ static int l_pigui_set_mouse_button_state(lua_State *l)
 
 static int l_pigui_should_show_labels(lua_State *l)
 {
-	PROFILE_SCOPED()
 	bool show_labels = Pi::game->GetWorldView()->ShouldShowLabels();
 	LuaPush(l, show_labels);
 	return 1;
@@ -2099,59 +2068,49 @@ static int l_pigui_should_show_labels(lua_State *l)
 
 static int l_attr_handlers(lua_State *l)
 {
-	PROFILE_SCOPED()
 	PiGui::GetHandlers().PushCopyToStack();
 	return 1;
 }
 
 static int l_attr_keys(lua_State *l)
 {
-	PROFILE_SCOPED()
-	// PiGui::Instance *pigui = LuaObject<PiGui::Instance>::CheckFromLua(1);
 	PiGui::GetKeys().PushCopyToStack();
+	return 1;
+}
+
+static int l_attr_screen_height(lua_State *l)
+{
+	LuaPush<int>(l, Graphics::GetScreenHeight());
 	return 1;
 }
 
 static int l_attr_screen_width(lua_State *l)
 {
-	PROFILE_SCOPED()
 	LuaPush<int>(l, Graphics::GetScreenWidth());
 	return 1;
 }
 
 static int l_attr_key_ctrl(lua_State *l)
 {
-	PROFILE_SCOPED()
 	LuaPush<bool>(l, ImGui::GetIO().KeyCtrl);
 	return 1;
 }
 
 static int l_attr_key_none(lua_State *l)
 {
-	PROFILE_SCOPED()
 	LuaPush<bool>(l, !ImGui::GetIO().KeyCtrl & !ImGui::GetIO().KeyShift & !ImGui::GetIO().KeyAlt);
 	return 1;
 }
 
 static int l_attr_key_shift(lua_State *l)
 {
-	PROFILE_SCOPED()
 	LuaPush<bool>(l, ImGui::GetIO().KeyShift);
 	return 1;
 }
 
 static int l_attr_key_alt(lua_State *l)
 {
-	PROFILE_SCOPED()
 	LuaPush<bool>(l, ImGui::GetIO().KeyAlt);
-	return 1;
-}
-
-static int l_attr_screen_height(lua_State *l)
-{
-	PROFILE_SCOPED()
-	//	PiGui::Instance *pigui = LuaObject<PiGui::Instance>::CheckFromLua(1);
-	LuaPush<int>(l, Graphics::GetScreenHeight());
 	return 1;
 }
 
@@ -2246,14 +2205,12 @@ static int l_pigui_radial_menu(lua_State *l)
 
 static int l_pigui_should_draw_ui(lua_State *l)
 {
-	PROFILE_SCOPED()
 	LuaPush(l, Pi::DrawGUI);
 	return 1;
 }
 
 static int l_pigui_is_mouse_hovering_rect(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImVec2 r_min = LuaPull<ImVec2>(l, 1);
 	ImVec2 r_max = LuaPull<ImVec2>(l, 2);
 	bool clip = LuaPull<bool>(l, 3);
@@ -2275,7 +2232,6 @@ static int l_pigui_data_dir_path(lua_State *l)
 
 static int l_pigui_is_window_hovered(lua_State *l)
 {
-	PROFILE_SCOPED()
 	int flags = LuaPull<ImGuiHoveredFlags_>(l, 1, ImGuiHoveredFlags_None);
 	LuaPush<bool>(l, ImGui::IsWindowHovered(flags));
 	return 1;
@@ -2302,7 +2258,7 @@ static int l_pigui_begin_tab_item(lua_State *l)
 
 static int l_pigui_end_tab_bar(lua_State *l)
 {
-	PROFILE_SCOPED()
+	PROFILE_SCOPED();
 	ImGui::EndTabBar();
 	return 0;
 }
@@ -2510,7 +2466,6 @@ static int l_pigui_color_edit(lua_State *l)
 
 static int l_pigui_is_key_released(lua_State *l)
 {
-	PROFILE_SCOPED()
 	SDL_Keycode key = LuaPull<int>(l, 1);
 	LuaPush<bool>(l, ImGui::IsKeyReleased(SDL_GetScancodeFromKey(key)));
 	return 1;
@@ -2518,7 +2473,6 @@ static int l_pigui_is_key_released(lua_State *l)
 
 static int l_pigui_get_cursor_pos(lua_State *l)
 {
-	PROFILE_SCOPED()
 	vector2d v(ImGui::GetCursorPos().x, ImGui::GetCursorPos().y);
 	LuaPush<vector2d>(l, v);
 	return 1;
@@ -2526,7 +2480,6 @@ static int l_pigui_get_cursor_pos(lua_State *l)
 
 static int l_pigui_get_cursor_screen_pos(lua_State *l)
 {
-	PROFILE_SCOPED()
 	vector2d v(ImGui::GetCursorScreenPos().x, ImGui::GetCursorScreenPos().y);
 	LuaPush<vector2d>(l, v);
 	return 1;
@@ -2534,7 +2487,6 @@ static int l_pigui_get_cursor_screen_pos(lua_State *l)
 
 static int l_pigui_set_cursor_pos(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImVec2 v = LuaPull<ImVec2>(l, 1);
 	ImGui::SetCursorPos(v);
 	return 0;
@@ -2542,7 +2494,6 @@ static int l_pigui_set_cursor_pos(lua_State *l)
 
 static int l_pigui_set_cursor_screen_pos(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImVec2 v = LuaPull<ImVec2>(l, 1);
 	ImGui::SetCursorScreenPos(v);
 	return 0;
@@ -2622,14 +2573,12 @@ static int l_pigui_load_texture_from_svg(lua_State *l)
 
 static int l_pigui_set_scroll_here(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImGui::SetScrollHere();
 	return 0;
 }
 
 static int l_pigui_pop_text_wrap_pos(lua_State *l)
 {
-	PROFILE_SCOPED()
 	ImGui::PopTextWrapPos();
 	return 0;
 }

--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -261,7 +261,7 @@ Model *BinaryConverter::CreateModel(const std::string &filename, Serializer::Rea
 
 	LoadAnimations(rd);
 
-	m_model->UpdateAnimations();
+	m_model->InitAnimations();
 	//m_model->CreateCollisionMesh();
 	if (m_patternsUsed) SetUpPatterns();
 

--- a/src/scenegraph/BinaryConverter.h
+++ b/src/scenegraph/BinaryConverter.h
@@ -51,7 +51,6 @@ namespace SceneGraph {
 		ModelDefinition FindModelDefinition(const std::string &);
 
 		Node *LoadNode(Serializer::Reader &);
-		void LoadChildren(Serializer::Reader &, Group *parent);
 		//this is a very simple loader so it's implemented here
 		static Label3D *LoadLabel3D(NodeDatabase &);
 

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -8,11 +8,11 @@
 #include "LOD.h"
 #include "Parser.h"
 #include "SceneGraph.h"
-#include "scenegraph/Animation.h"
 #include "StringF.h"
-#include "graphics/Renderer.h"
 #include "graphics/RenderState.h"
+#include "graphics/Renderer.h"
 #include "graphics/TextureBuilder.h"
+#include "scenegraph/Animation.h"
 #include "utils.h"
 #include <assimp/material.h>
 #include <assimp/postprocess.h>
@@ -303,7 +303,7 @@ namespace SceneGraph {
 		m_model->CreateCollisionMesh();
 
 		// Do an initial animation update to get all the animation transforms correct
-		m_model->UpdateAnimations();
+		m_model->InitAnimations();
 
 		//find usable pattern textures from the model directory
 		if (patternsUsed)

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -125,9 +125,7 @@ namespace SceneGraph {
 
 	Model *Loader::LoadModel(const std::string &filename)
 	{
-		PROFILE_SCOPED()
-		Model *m = LoadModel(filename, "models");
-		return m;
+		return LoadModel(filename, "models");
 	}
 
 	Model *Loader::LoadModel(const std::string &shortname, const std::string &basepath)

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -568,7 +568,7 @@ namespace SceneGraph {
 			activeArray.push_back(GetAnimationActive(i));
 		}
 		modelObj["animations"] = animationArray; // Add animation array to model object.
-		modelObj["activeAnimations"] = animationArray;
+		modelObj["activeAnimations"] = activeArray;
 
 		modelObj["cur_pattern_index"] = m_curPatternIndex;
 

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -107,7 +107,7 @@ namespace SceneGraph {
 		float GetDrawClipRadius() const { return m_boundingRadius; }
 		void SetDrawClipRadius(float clipRadius) { m_boundingRadius = clipRadius; }
 
-		void Render(const matrix4x4f &trans, const RenderData *rd = 0); //ModelNode can override RD
+		void Render(const matrix4x4f &trans, const RenderData *rd = 0);				 //ModelNode can override RD
 		void Render(const std::vector<matrix4x4f> &trans, const RenderData *rd = 0); //ModelNode can override RD
 
 		RefCountedPtr<CollMesh> CreateCollisionMesh();
@@ -142,8 +142,18 @@ namespace SceneGraph {
 		bool SupportsDecals();
 		bool SupportsPatterns();
 
-		Animation *FindAnimation(const std::string &) const; //0 if not found
+		// update all animations once to ensure all transforms are correctly positioned
+		void InitAnimations();
+		// Get an animation matching the given name or return nullptr.
+		Animation *FindAnimation(const std::string &) const;
+		// Get the index of an animation in this container. If there is no such animation, returns UINT32_MAX.
+		uint32_t FindAnimationIndex(Animation *) const;
+		// Return a reference to all animations defined on this model.
 		const std::vector<Animation *> GetAnimations() const { return m_animations; }
+		// Mark an animation as actively updating. A maximum of 64 active animations are supported.
+		void SetAnimationActive(uint32_t index, bool active);
+		bool GetAnimationActive(uint32_t index) const;
+		// Update all active animations.
 		void UpdateAnimations();
 
 		Graphics::Renderer *GetRenderer() const { return m_renderer; }
@@ -185,7 +195,8 @@ namespace SceneGraph {
 		Graphics::Renderer *m_renderer;
 		std::string m_name;
 		std::vector<Animation *> m_animations;
-		TagContainer m_tags; //named attachment points
+		uint64_t m_activeAnimations; // bitmask of actively ticking animations
+		TagContainer m_tags;		 //named attachment points
 		RenderData m_renderData;
 
 		//per-instance flavour data


### PR DESCRIPTION
This is primarily merging in the work I did to make the tradeships PR (#4984) feasible from a performance perspective. I've added in a few other commits from unmerged branches that made sense and cleaned up the codebase a little bit.

This prevents model animation interpolation from being run when active animations aren't being played, which was the number one performance hog with many ships in a system. It also cleans up a fair amount of C++-to-Lua overhead that was being run every `StaticUpdate` tick.

This PR also removes unneeded code in the TabView and remembers the last tab the user was on in the Comms and Info windows.