### PR TITLE
Warn about loading dead bodies, but handle safely.

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -350,6 +350,10 @@ Body *Space::GetBodyByIndex(Uint32 idx) const
 {
 	assert(m_bodyIndexValid);
 	assert(m_bodyIndex.size() > idx);
+	if (idx == SDL_MAX_UINT32 || m_bodyIndex.size() <= idx) {
+		Output("GetBodyByIndex passed bad index %u", idx);
+		return nullptr;
+	}
 	return m_bodyIndex[idx];
 }
 
@@ -365,8 +369,9 @@ Uint32 Space::GetIndexForBody(const Body *body) const
 	assert(m_bodyIndexValid);
 	for (Uint32 i = 0; i < m_bodyIndex.size(); i++)
 		if (m_bodyIndex[i] == body) return i;
-	assert(0);
-	return Uint32(-1);
+	assert(false);
+	Output("GetIndexForBody passed unknown body");
+	return SDL_MAX_UINT32;
 }
 
 Uint32 Space::GetIndexForSystemBody(const SystemBody *sbody) const
@@ -375,7 +380,7 @@ Uint32 Space::GetIndexForSystemBody(const SystemBody *sbody) const
 	for (Uint32 i = 0; i < m_sbodyIndex.size(); i++)
 		if (m_sbodyIndex[i] == sbody) return i;
 	assert(0);
-	return Uint32(-1);
+	return SDL_MAX_UINT32;
 }
 
 void Space::AddSystemBodyToIndex(SystemBody *sbody)


### PR DESCRIPTION
Save games could fail to load due to the body index being written as `(Uint32)-1`.
Handle getting an out-of-range / SDL_MAX_UINT32 value when trying to find a body by returning `nullptr` instead.

This allows savegames to load despite this issue.

The issue itself is caused by the `AICmdFlyAround` having a pointer to a `Body *m_obstructor` that it does not own and is not refcounted. This can be destroyed before/whilst saving, which fails to find the body (_'cos it's gone_), the GetIndexForBody returns `(Uint32)-1`, and upon loading it crashes.

I would like to have fixed the actual cause by this COVID19 vaccination has hit me like a bus and I feel like I've got flu.
So posting this as-is for possible merging, comments, and suggestions. Either other can fix it, or it can wait until my brain works again.