### PR TITLE
Add zone-based profiling support

### DIFF
--- a/contrib/profiler/Profiler.h
+++ b/contrib/profiler/Profiler.h
@@ -252,6 +252,7 @@ namespace Profiler {
 	void detect( int argc, char **argv );
 	//void detect( const char *commandLine );
 	void dump(const char *dir = 0);
+	void dumpzones(const char *dir = 0);
 	void dumphtml(const char *dir = 0);
 	void fastcall enter( const char *name );
 	void fastcall exit();

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -201,6 +201,7 @@ namespace Background {
 
 	void Starfield::Init()
 	{
+		PROFILE_SCOPED()
 		Graphics::MaterialDescriptor desc;
 		desc.effect = Graphics::EFFECT_STARFIELD;
 		desc.textures = 1;
@@ -262,6 +263,7 @@ namespace Background {
 		//fill the array
 		Uint32 num = 0;
 		if (space != nullptr && galaxy.Valid() && space->GetStarSystem() != nullptr) {
+			PROFILE_SCOPED_DESC("Pick Stars from Galaxy")
 			const SystemPath current = space->GetStarSystem()->GetPath();
 
 			const double size = 1.0;
@@ -413,6 +415,7 @@ namespace Background {
 
 	void Starfield::Draw(Graphics::RenderState *rs)
 	{
+		PROFILE_SCOPED()
 		// XXX would be nice to get rid of the Pi:: stuff here
 		if (!Pi::game || Pi::player->GetFlightState() != Ship::HYPERSPACE) {
 			m_pointSprites->Draw(m_renderer, m_renderState);

--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -164,6 +164,7 @@ struct ModelNameComparator {
 //static
 void CityOnPlanet::SetCityModelPatterns(const SystemPath &path)
 {
+	PROFILE_SCOPED()
 	Uint32 _init[5] = { path.systemIndex, Uint32(path.sectorX), Uint32(path.sectorY), Uint32(path.sectorZ), UNIVERSE_SEED };
 	Random rand(_init, 5);
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -85,9 +85,7 @@ Game::Game(const SystemPath &path, const double startDateTime) :
 
 	EmitPauseState(IsPaused());
 
-#ifdef PIONEER_PROFILER
-	Pi::RequestProfileFrame("NewGame");
-#endif
+	Pi::GetApp()->RequestProfileFrame("NewGame");
 }
 
 Game::~Game()
@@ -177,7 +175,7 @@ Game::Game(const Json &jsonObj) :
 
 	EmitPauseState(IsPaused());
 
-	Pi::RequestProfileFrame("LoadGame");
+	Pi::GetApp()->RequestProfileFrame("LoadGame");
 }
 
 void Game::ToJson(Json &jsonObj)
@@ -948,5 +946,5 @@ void Game::SaveGame(const std::string &filename, Game *game)
 		throw CouldNotWriteToFileException();
 	}
 
-	Pi::RequestProfileFrame("SaveGame");
+	Pi::GetApp()->RequestProfileFrame("SaveGame");
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -44,6 +44,7 @@ Game::Game(const SystemPath &path, const double startDateTime) :
 	m_requestedTimeAccel(TIMEACCEL_1X),
 	m_forceTimeAccel(false)
 {
+	PROFILE_SCOPED()
 	// Now that we have a Galaxy, check the starting location
 	if (!path.IsBodyPath())
 		throw InvalidGameStartLocation("SystemPath is not a body path");
@@ -119,6 +120,7 @@ Game::Game(const Json &jsonObj) :
 	m_requestedTimeAccel(TIMEACCEL_PAUSED),
 	m_forceTimeAccel(false)
 {
+	PROFILE_SCOPED()
 	try {
 		int version = jsonObj["version"];
 		Output("savefile version: %d\n", version);
@@ -818,6 +820,7 @@ Game::Views::~Views()
 // manage creation and destruction here to get the timing and order right
 void Game::CreateViews()
 {
+	PROFILE_SCOPED()
 	Pi::SetView(nullptr);
 
 	// XXX views expect Pi::game and Pi::player to exist

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -112,6 +112,7 @@ static void loadAxisConfig(const std::string &str, Input::JoystickInfo::Axis &ou
 
 void Input::InitJoysticks(IniConfig *config)
 {
+	PROFILE_SCOPED()
 	SDL_Init(SDL_INIT_JOYSTICK);
 
 	int joy_count = SDL_NumJoysticks();

--- a/src/JobQueue.cpp
+++ b/src/JobQueue.cpp
@@ -306,7 +306,9 @@ AsyncJobQueue::JobRunner::~JobRunner()
 int AsyncJobQueue::JobRunner::Trampoline(void *data)
 {
 	JobRunner *jr = static_cast<JobRunner *>(data);
+	PROFILE_THREAD_START_DESC(jr->m_threadName.c_str())
 	jr->Main();
+	PROFILE_THREAD_STOP()
 	return 0;
 }
 

--- a/src/JobQueue.cpp
+++ b/src/JobQueue.cpp
@@ -279,7 +279,7 @@ AsyncJobQueue::JobRunner::JobRunner(AsyncJobQueue *jq, const uint8_t idx) :
 	m_threadIdx(idx),
 	m_queueDestroyed(false)
 {
-	m_threadName = stringf("Thread %0{d}", m_threadIdx);
+	m_threadName = stringf("Thread %0", m_threadIdx);
 	m_jobLock = SDL_CreateMutex();
 	m_queueDestroyingLock = SDL_CreateMutex();
 	m_threadId = SDL_CreateThread(&JobRunner::Trampoline, m_threadName.c_str(), this);

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -223,7 +223,6 @@ void NavLights::Render(Graphics::Renderer *renderer)
 
 void NavLights::SetColor(unsigned int group, LightColor c)
 {
-	PROFILE_SCOPED();
 	if (!m_groupLights.count(group)) return;
 	for (LightBulb &light : m_groupLights[group]) {
 		if (light.group != group || light.color == c) continue;
@@ -236,7 +235,6 @@ void NavLights::SetColor(unsigned int group, LightColor c)
 
 void NavLights::SetMask(unsigned int group, uint8_t mask)
 {
-	PROFILE_SCOPED()
 	if (!m_groupLights.count(group)) return;
 	for (LightBulb &light : m_groupLights[group]) {
 		light.mask = mask;

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -194,13 +194,6 @@ public:
 	/* Only use #if WITH_DEVKEYS */
 	static bool showDebugInfo;
 
-#if PIONEER_PROFILER
-	static std::string profilerPath;
-	static std::string profileOnePath;
-	static bool doProfileSlow;
-	static bool doProfileOne;
-#endif
-
 	static void RequestProfileFrame(const std::string &profilePath = "");
 
 	static Input::Manager *input;

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -219,6 +219,7 @@ Space::Space(Game *game, RefCountedPtr<Galaxy> galaxy, const SystemPath &path, S
 	m_processingFinalizationQueue(false)
 #endif
 {
+	PROFILE_SCOPED()
 	Uint32 _init[5] = { path.systemIndex, Uint32(path.sectorX), Uint32(path.sectorY), Uint32(path.sectorZ), UNIVERSE_SEED };
 	Random rand(_init, 5);
 	m_background.reset(new Background::Container(Pi::renderer, rand, this, m_game->GetGalaxy()));
@@ -245,6 +246,7 @@ Space::Space(Game *game, RefCountedPtr<Galaxy> galaxy, const Json &jsonObj, doub
 	m_processingFinalizationQueue(false)
 #endif
 {
+	PROFILE_SCOPED()
 	Json spaceObj = jsonObj["space"];
 
 	m_starSystem = StarSystem::FromJson(galaxy, spaceObj);
@@ -315,6 +317,7 @@ Space::~Space()
 
 void Space::RefreshBackground()
 {
+	PROFILE_SCOPED()
 	const SystemPath &path = m_starSystem->GetPath();
 	Uint32 _init[5] = { path.systemIndex, Uint32(path.sectorX), Uint32(path.sectorY), Uint32(path.sectorZ), UNIVERSE_SEED };
 	Random rand(_init, 5);
@@ -689,6 +692,7 @@ void Space::UpdateStarSystemCache(const SystemPath *here)
 
 static FrameId MakeFramesFor(const double at_time, SystemBody *sbody, Body *b, FrameId fId, std::vector<vector3d> &prevPositions)
 {
+	PROFILE_SCOPED()
 	if (!sbody->GetParent()) {
 		if (b) b->SetFrame(fId);
 		Frame *f = Frame::GetFrame(fId);
@@ -796,6 +800,7 @@ static FrameId MakeFramesFor(const double at_time, SystemBody *sbody, Body *b, F
 
 void Space::GenBody(const double at_time, SystemBody *sbody, FrameId fId, std::vector<vector3d> &posAccum)
 {
+	PROFILE_START()
 	Body *b = nullptr;
 
 	if (sbody->GetType() != SystemBody::TYPE_GRAVPOINT) {
@@ -818,6 +823,7 @@ void Space::GenBody(const double at_time, SystemBody *sbody, FrameId fId, std::v
 	}
 	fId = MakeFramesFor(at_time, sbody, b, fId, posAccum);
 
+	PROFILE_STOP()
 	for (SystemBody *kid : sbody->GetChildren()) {
 		GenBody(at_time, kid, fId, posAccum);
 	}

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -151,6 +151,7 @@ void SpaceStation::PostLoadFixup(Space *space)
 
 void SpaceStation::InitStation()
 {
+	PROFILE_SCOPED()
 	m_adjacentCity = 0;
 	for (int i = 0; i < NUM_STATIC_SLOTS; i++)
 		m_staticSlot[i] = false;
@@ -529,8 +530,8 @@ void SpaceStation::DockingUpdate(const double timeStep)
 		}
 
 		double stageDuration = (dt.stage > 0 ?
-				m_type->GetDockAnimStageDuration(dt.stage - 1) :
-				m_type->GetUndockAnimStageDuration(abs(dt.stage) - 1));
+				  m_type->GetDockAnimStageDuration(dt.stage - 1) :
+				  m_type->GetUndockAnimStageDuration(abs(dt.stage) - 1));
 		dt.stagePos += timeStep / stageDuration;
 
 		if (dt.stage == 1) {

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -27,6 +27,7 @@ TerrainBody::~TerrainBody()
 
 void TerrainBody::InitTerrainBody()
 {
+	PROFILE_SCOPED()
 	assert(m_sbody);
 	m_mass = m_sbody->GetMass();
 	if (!m_baseSphere) {

--- a/src/collider/Geom.cpp
+++ b/src/collider/Geom.cpp
@@ -98,7 +98,6 @@ void Geom::Collide(Geom *b, void (*callback)(CollisionContact *)) const
 
 static bool rotatedAabbIsectsNormalOne(Aabb &a, const matrix4x4d &transA, Aabb &b)
 {
-	PROFILE_SCOPED()
 	Aabb arot;
 	vector3d p[8];
 	p[0] = transA * vector3d(a.min.x, a.min.y, a.min.z);

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -5,11 +5,12 @@
 
 #include <memory>
 #include <queue>
+#include <string>
 
 class Application {
 public:
-	Application(){};
-	virtual ~Application(){};
+	Application() = default;
+	virtual ~Application() = default;
 
 	class Lifecycle {
 	public:
@@ -63,6 +64,8 @@ public:
 
 	double GetTime() { return m_totalTime; }
 
+	void RequestProfileFrame(const std::string &path = "");
+
 protected:
 	// Hooks for inheriting classes to add their own behaviors to.
 
@@ -89,14 +92,23 @@ protected:
 	void RequestQuit() { m_applicationRunning = false; }
 
 	Lifecycle *GetActiveLifecycle() { return m_activeLifecycle.get(); }
+	void SetProfilerPath(const std::string &);
+	void SetProfileSlowFrames(bool enabled) { m_doSlowProfile = enabled; }
+	void SetProfileZones(bool enabled) { m_profileZones = enabled; }
 
 private:
 	bool StartLifecycle();
 	void EndLifecycle();
 
 	bool m_applicationRunning;
+	bool m_doTempProfile;
+	bool m_doSlowProfile;
+	bool m_profileZones;
 	float m_deltaTime;
 	double m_totalTime;
+
+	std::string m_profilerPath;
+	std::string m_tempProfilePath;
 
 	// The lifecycle we're actually running right now
 	std::shared_ptr<Lifecycle> m_activeLifecycle;

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -158,11 +158,14 @@ void GuiApplication::HandleEvents()
 Graphics::Renderer *GuiApplication::StartupRenderer(IniConfig *config, bool hidden)
 {
 	PROFILE_SCOPED()
+
 	// Initialize SDL
+	PROFILE_START_DESC("SDL_Init")
 	Uint32 sdlInitFlags = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
 	if (SDL_Init(sdlInitFlags) < 0) {
 		Error("SDL initialization failed: %s\n", SDL_GetError());
 	}
+	PROFILE_STOP()
 
 	OutputVersioningInfo();
 
@@ -194,6 +197,7 @@ Graphics::Renderer *GuiApplication::StartupRenderer(IniConfig *config, bool hidd
 
 void GuiApplication::ShutdownRenderer()
 {
+	PROFILE_SCOPED()
 	m_renderTarget.reset();
 	m_renderState.reset();
 	m_renderer.reset();
@@ -203,6 +207,7 @@ void GuiApplication::ShutdownRenderer()
 
 Input::Manager *GuiApplication::StartupInput(IniConfig *config)
 {
+	PROFILE_SCOPED()
 	m_input.reset(new Input::Manager(config));
 
 	return m_input.get();
@@ -210,11 +215,13 @@ Input::Manager *GuiApplication::StartupInput(IniConfig *config)
 
 void GuiApplication::ShutdownInput()
 {
+	PROFILE_SCOPED()
 	m_input.reset();
 }
 
 PiGui::Instance *GuiApplication::StartupPiGui()
 {
+	PROFILE_SCOPED()
 	m_pigui.Reset(new PiGui::Instance());
 	m_pigui->Init(GetRenderer());
 	return m_pigui.Get();
@@ -222,6 +229,7 @@ PiGui::Instance *GuiApplication::StartupPiGui()
 
 void GuiApplication::ShutdownPiGui()
 {
+	PROFILE_SCOPED()
 	m_pigui->Uninit();
 	m_pigui.Reset();
 }

--- a/src/galaxy/Factions.cpp
+++ b/src/galaxy/Factions.cpp
@@ -781,7 +781,6 @@ Faction::Faction(Galaxy *galaxy) :
 	m_galaxy(galaxy),
 	m_homesector(0)
 {
-	PROFILE_SCOPED()
 	govtype_weights_total = 0;
 }
 
@@ -866,7 +865,6 @@ void FactionsDatabase::Octsapling::Add(const Faction *faction)
 
 void FactionsDatabase::Octsapling::PruneDuplicates(const int bx, const int by, const int bz)
 {
-	PROFILE_SCOPED()
 	octbox[bx][by][bz].erase(std::unique(octbox[bx][by][bz].begin(), octbox[bx][by][bz].end()), octbox[bx][by][bz].end());
 }
 

--- a/src/galaxy/GalaxyCache.cpp
+++ b/src/galaxy/GalaxyCache.cpp
@@ -4,11 +4,11 @@
 #include "galaxy/GalaxyCache.h"
 
 #include "Game.h"
+#include "Pi.h"
 #include "galaxy/Galaxy.h"
 #include "galaxy/GalaxyGenerator.h"
 #include "galaxy/Sector.h"
 #include "galaxy/StarSystem.h"
-#include "Pi.h"
 #include "utils.h"
 #include <utility>
 
@@ -40,8 +40,6 @@ void GalaxyObjectCache<T, CompareT>::AddToCache(std::vector<RefCountedPtr<T>> &o
 template <typename T, typename CompareT>
 RefCountedPtr<T> GalaxyObjectCache<T, CompareT>::GetIfCached(const SystemPath &path)
 {
-	PROFILE_SCOPED()
-
 	RefCountedPtr<T> s;
 	typename AtticMap::iterator i = m_attic.find(path);
 	if (i != m_attic.end()) {

--- a/src/galaxy/GalaxyCache.cpp
+++ b/src/galaxy/GalaxyCache.cpp
@@ -27,6 +27,7 @@ GalaxyObjectCache<T, CompareT>::~GalaxyObjectCache()
 template <typename T, typename CompareT>
 void GalaxyObjectCache<T, CompareT>::AddToCache(std::vector<RefCountedPtr<T>> &objects)
 {
+	PROFILE_SCOPED()
 	for (auto it = objects.begin(), itEnd = objects.end(); it != itEnd; ++it) {
 		auto inserted = m_attic.insert(std::make_pair(it->Get()->GetPath(), it->Get()));
 		if (!inserted.second) {
@@ -52,8 +53,6 @@ RefCountedPtr<T> GalaxyObjectCache<T, CompareT>::GetIfCached(const SystemPath &p
 template <typename T, typename CompareT>
 RefCountedPtr<T> GalaxyObjectCache<T, CompareT>::GetCached(const SystemPath &path)
 {
-	PROFILE_SCOPED()
-
 	RefCountedPtr<T> s = this->GetIfCached(path);
 	if (!s) {
 		++m_cacheMisses;
@@ -118,8 +117,6 @@ void GalaxyObjectCache<T, CompareT>::Slave::MasterDeleted()
 template <typename T, typename CompareT>
 RefCountedPtr<T> GalaxyObjectCache<T, CompareT>::Slave::GetIfCached(const SystemPath &path)
 {
-	PROFILE_SCOPED()
-
 	typename CacheMap::iterator i = m_cache.find(path);
 	if (i != m_cache.end())
 		return (*i).second;
@@ -255,6 +252,7 @@ GalaxyObjectCache<T, CompareT>::CacheJob::CacheJob(std::unique_ptr<std::vector<S
 template <typename T, typename CompareT>
 void GalaxyObjectCache<T, CompareT>::CacheJob::OnRun() // RUNS IN ANOTHER THREAD!! MUST BE THREAD SAFE!
 {
+	PROFILE_SCOPED()
 	for (auto it = m_paths->begin(), itEnd = m_paths->end(); it != itEnd; ++it)
 		m_objects.push_back(m_galaxyGenerator->Generate<T, GalaxyObjectCache<T, CompareT>>(m_galaxy, *it, nullptr));
 }
@@ -263,6 +261,7 @@ void GalaxyObjectCache<T, CompareT>::CacheJob::OnRun() // RUNS IN ANOTHER THREAD
 template <typename T, typename CompareT>
 void GalaxyObjectCache<T, CompareT>::CacheJob::OnFinish() // runs in primary thread of the context
 {
+	PROFILE_SCOPED()
 	m_slaveCache->AddToCache(m_objects);
 	if (m_slaveCache->m_jobs.IsEmpty() && m_callback)
 		m_callback();

--- a/src/galaxy/GalaxyGenerator.cpp
+++ b/src/galaxy/GalaxyGenerator.cpp
@@ -44,6 +44,7 @@ GalaxyGenerator::Version GalaxyGenerator::GetLastVersion(const std::string &name
 // static
 RefCountedPtr<Galaxy> GalaxyGenerator::Create(const std::string &name, Version version)
 {
+	PROFILE_SCOPED()
 	if (version == LAST_VERSION)
 		version = GetLastVersion(name);
 
@@ -169,6 +170,7 @@ GalaxyGenerator *GalaxyGenerator::AddStarSystemStage(StarSystemGeneratorStage *s
 
 RefCountedPtr<Sector> GalaxyGenerator::GenerateSector(RefCountedPtr<Galaxy> galaxy, const SystemPath &path, SectorCache *cache)
 {
+	PROFILE_SCOPED()
 	const Uint32 _init[4] = { Uint32(path.sectorX), Uint32(path.sectorY), Uint32(path.sectorZ), UNIVERSE_SEED };
 	Random rng(_init, 4);
 	SectorConfig config;
@@ -181,6 +183,7 @@ RefCountedPtr<Sector> GalaxyGenerator::GenerateSector(RefCountedPtr<Galaxy> gala
 
 RefCountedPtr<StarSystem> GalaxyGenerator::GenerateStarSystem(RefCountedPtr<Galaxy> galaxy, const SystemPath &path, StarSystemCache *cache)
 {
+	PROFILE_SCOPED()
 	RefCountedPtr<const Sector> sec = galaxy->GetSector(path);
 	assert(path.systemIndex < sec->m_systems.size());
 	Uint32 seed = sec->m_systems[path.systemIndex].GetSeed();

--- a/src/galaxy/SystemBody.cpp
+++ b/src/galaxy/SystemBody.cpp
@@ -35,14 +35,11 @@ SystemBody::SystemBody(const SystemPath &path, StarSystem *system) :
 
 bool SystemBody::HasAtmosphere() const
 {
-	PROFILE_SCOPED()
 	return (m_volatileGas > fixed(1, 100));
 }
 
 bool SystemBody::IsScoopable() const
 {
-	PROFILE_SCOPED()
-
 	if (GetSuperType() == SUPERTYPE_GAS_GIANT)
 		return true;
 	if ((m_type == TYPE_PLANET_TERRESTRIAL) &&
@@ -116,7 +113,6 @@ AtmosphereParameters SystemBody::CalcAtmosphereParams() const
 
 SystemBody::BodySuperType SystemBody::GetSuperType() const
 {
-	PROFILE_SCOPED()
 	switch (m_type) {
 	case TYPE_BROWN_DWARF:
 	case TYPE_WHITE_DWARF:
@@ -518,7 +514,6 @@ bool SystemBody::IsCoOrbital() const
 
 double SystemBody::CalcSurfaceGravity() const
 {
-	PROFILE_SCOPED()
 	double r = GetRadius();
 	if (r > 0.0) {
 		return G * GetMass() / pow(r, 2);
@@ -580,6 +575,7 @@ void SystemBody::ClearParentAndChildPointers()
 
 SystemBody *SystemBody::GetNearestJumpable()
 {
+	PROFILE_SCOPED()
 	if (IsJumpable()) return this;
 	// trying to find a jumpable parent
 	SystemBody *result = this;

--- a/src/graphics/Frustum.cpp
+++ b/src/graphics/Frustum.cpp
@@ -85,7 +85,6 @@ namespace Graphics {
 
 	bool Frustum::TestPointInfinite(const vector3d &p, double radius) const
 	{
-		PROFILE_SCOPED()
 		// check all planes except far plane
 		for (int i = 0; i < 5; i++)
 			if (m_planes[i].DistanceToPoint(p) + radius < 0)

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -98,6 +98,7 @@ namespace Graphics {
 
 	Renderer *Init(Settings vs)
 	{
+		PROFILE_SCOPED()
 		assert(!initted);
 		if (initted) return 0;
 

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -41,6 +41,7 @@ namespace Graphics {
 
 	static bool CreateWindowAndContext(const char *name, const Graphics::Settings &vs, SDL_Window *&window, SDL_GLContext &context)
 	{
+		PROFILE_SCOPED()
 		Uint32 winFlags = 0;
 
 		winFlags |= SDL_WINDOW_OPENGL;
@@ -95,6 +96,7 @@ namespace Graphics {
 
 	static Renderer *CreateRenderer(const Settings &vs)
 	{
+		PROFILE_SCOPED()
 		assert(vs.rendererType == Graphics::RendererType::RENDERER_OPENGL_3x);
 
 		const std::string name("Pioneer");
@@ -149,6 +151,7 @@ namespace Graphics {
 		m_activeRenderState(nullptr),
 		m_glContext(glContext)
 	{
+		PROFILE_SCOPED()
 		glewExperimental = true;
 		GLenum glew_err;
 		if ((glew_err = glewInit()) != GLEW_OK)
@@ -635,7 +638,6 @@ namespace Graphics {
 
 	bool RendererOGL::SetTransform(const matrix4x4f &m)
 	{
-		PROFILE_SCOPED()
 		m_modelViewMat = m;
 		return true;
 	}
@@ -667,7 +669,6 @@ namespace Graphics {
 
 	bool RendererOGL::SetProjection(const matrix4x4f &m)
 	{
-		PROFILE_SCOPED()
 		m_projectionMat = m;
 		return true;
 	}
@@ -1120,7 +1121,6 @@ namespace Graphics {
 
 	RenderState *RendererOGL::CreateRenderState(const RenderStateDesc &desc)
 	{
-		PROFILE_SCOPED()
 		const uint32_t hash = HashRenderStateDesc(desc);
 		auto it = m_renderStates.find(hash);
 		if (it != m_renderStates.end()) {

--- a/src/pigui/Radar.cpp
+++ b/src/pigui/Radar.cpp
@@ -10,7 +10,6 @@ static constexpr int RADAR_STEPS = 100;
 
 ImVec2 circlePos(float a, ImVec2 center, ImVec2 radius, float scale = 1.0f)
 {
-	PROFILE_SCOPED()
 	return ImVec2(center.x + sin(a) * scale * radius.x, center.y + cos(a) * scale * radius.y);
 }
 

--- a/src/scenegraph/Group.cpp
+++ b/src/scenegraph/Group.cpp
@@ -112,7 +112,6 @@ namespace SceneGraph {
 
 	void Group::Render(const matrix4x4f &trans, const RenderData *rd)
 	{
-		PROFILE_SCOPED()
 		RenderChildren(trans, rd);
 	}
 
@@ -127,7 +126,6 @@ namespace SceneGraph {
 
 	void Group::Render(const std::vector<matrix4x4f> &trans, const RenderData *rd)
 	{
-		PROFILE_SCOPED()
 		RenderChildren(trans, rd);
 	}
 

--- a/src/scenegraph/MatrixTransform.cpp
+++ b/src/scenegraph/MatrixTransform.cpp
@@ -33,7 +33,6 @@ namespace SceneGraph {
 
 	void MatrixTransform::Render(const matrix4x4f &trans, const RenderData *rd)
 	{
-		PROFILE_SCOPED();
 		const matrix4x4f t = trans * m_transform;
 		RenderChildren(t, rd);
 	}
@@ -41,7 +40,6 @@ namespace SceneGraph {
 	static const matrix4x4f s_ident(matrix4x4f::Identity());
 	void MatrixTransform::Render(const std::vector<matrix4x4f> &trans, const RenderData *rd)
 	{
-		PROFILE_SCOPED();
 		if (0 == memcmp(&m_transform, &s_ident, sizeof(matrix4x4f))) {
 			// m_transform is identity so avoid performing all multiplications
 			RenderChildren(trans, rd);


### PR DESCRIPTION
"Congratulations, you're a real profiler now!"

This PR adds support for capturing profile zone start/end events, storing them in a buffer, and writing them to disk in Speedscope Json format for inspection in [Speedscope](https://speedscope.app). This is the "missing link" in our profiling capabilities, the ability to dig into the sequential nature of what's happening in a frame and visually see what functions are taking significant amounts of time.

![Screenshot from 2021-05-02 23-14-46](https://user-images.githubusercontent.com/4218491/116838398-3b1df900-ab9c-11eb-9c3d-9d5b6a433da5.png)

In the process of doing this, I've removed appx. 2000 'unhelpful' profiling calls from the startup phase; these are functions that on average consume <1 microsecond per call and overall have very little contribution to the overall time. I've also dug in a bit and removed 4000+ of these small profiling calls from the average in-game frame capture, which helps to not only reduce overhead (even though the overhead from a profiler enter/exit pair is on the order of 100ns) but also keeps the file size of the resulting profile reports and event data smaller.

Eventually I'd like to run the zone profiler always-on in the background to be able to dynamically inspect data about multiple threads across the last few seconds, but at the moment the worst-case frame (when physics is running) is ~7000 enter-exit pairs per frame. The default thread buffer size of 4MB can only hold 18 frames of history at that size, which is an indication that I'll either need to move the application code causing those events off the main thread into worker threads (divide the storage requirements), improve the size of profiler events, reduce the number of profiler event calls during "normal" conditions (I can easily drop another 4000 semi-useful profiles from the physics system, see the 1000s of tiny profile zones under Geom::Collide), or most likely all three.

~~**Future-compatibility note**: the zone-based profiling uses the "packed pointers" trick made possible by the AMD64 architecture only using 47 of the 64 bits in a pointer; I've added in a (hopefully) complete macro to detect incompatible platforms (basically anything that's not x86 / amd64); if someone actually intends to port Pioneer to an incompatible platform (e.g. PPC64LE) an alternative struct definition for profile event data will need to be added to Profiler.cpp.~~

The above is no longer accurate; this profiler implementation should be fully portable across our prospective platforms!