### PR TITLE
Add PrecalcPath files to VS2019

### DIFF
--- a/win32/vs2019/pioneer.vcxproj
+++ b/win32/vs2019/pioneer.vcxproj
@@ -553,6 +553,7 @@
     <ClCompile Include="..\..\src\ShipType.cpp" />
     <ClCompile Include="..\..\src\ship\CameraController.cpp" />
     <ClCompile Include="..\..\src\ship\PlayerShipController.cpp" />
+    <ClCompile Include="..\..\src\ship\PrecalcPath.cpp" />
     <ClCompile Include="..\..\src\ship\Propulsion.cpp" />
     <ClCompile Include="..\..\src\ship\ShipController.cpp" />
     <ClCompile Include="..\..\src\ship\ShipViewController.cpp" />
@@ -735,6 +736,7 @@
     <ClInclude Include="..\..\src\ShipType.h" />
     <ClInclude Include="..\..\src\ship\CameraController.h" />
     <ClInclude Include="..\..\src\ship\PlayerShipController.h" />
+    <ClInclude Include="..\..\src\ship\PrecalcPath.h" />
     <ClInclude Include="..\..\src\ship\Propulsion.h" />
     <ClInclude Include="..\..\src\ship\ShipController.h" />
     <ClInclude Include="..\..\src\ship\ShipViewController.h" />

--- a/win32/vs2019/pioneer.vcxproj.filters
+++ b/win32/vs2019/pioneer.vcxproj.filters
@@ -585,6 +585,9 @@
     <ClCompile Include="..\..\contrib\imgui\imgui_demo.cpp">
       <Filter>src\imgui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ship\PrecalcPath.cpp">
+      <Filter>src\ship</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\Aabb.h">
@@ -1141,6 +1144,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\TransferPlanner.h">
       <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ship\PrecalcPath.h">
+      <Filter>src\ship</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add PrecalcPath files and once again lament the lack of wildcard filesnames in VS

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

