### PR TITLE
Switch to Libera.Chat in Readme.md

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -35,7 +35,7 @@ builds and is otherwise not actively maintained. Read the section below for
 details on using it for your platform.
 
 If you're having trouble compiling, please ask in #pioneer on
-irc.freenode.net. Most users are available to answer during CET daytime, but
+irc.libera.chat. Most users are available to answer during CET daytime, but
 questions are welcome anytime.
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build](https://github.com/pioneerspacesim/pioneer/workflows/Build%20Pioneer/badge.svg)](https://github.com/pioneerspacesim/pioneer/actions)
 [![Build status](https://ci.appveyor.com/api/projects/status/b2n2fe1vv3wr6n56/branch/master?svg=true)](https://ci.appveyor.com/project/pioneerspacesim/pioneer/branch/master)
 [![License GPLv3](https://img.shields.io/badge/license-GPL_v3-green.svg)](http://www.gnu.org/licenses/gpl-3.0.html)
-[![#pioneer on Freenode](https://img.shields.io/badge/Freenode-%23pioneer-brightgreen.svg)](https://kiwiirc.com/client/irc.freenode.net/pioneer)
+[![#pioneer on Libera.Chat](https://img.shields.io/badge/LiberaChat-%23pioneer-brightgreen.svg)](https://kiwiirc.com/client/irc.libera.chat/pioneer)
 
 # Pioneer Space Simulator
 
@@ -22,8 +22,8 @@ For more information, see:
 
 ## Community
 
-Come by #pioneer at irc.freenode.net and say hi to the team:
-  http://pioneerspacesim.net/irc
+Come by #pioneer at irc.libera.chat and say hi to the team:
+  https://kiwiirc.com/client/irc.libera.chat/pioneer
 
 Bugs? Please log an issue:
   http://pioneerspacesim.net/issues


### PR DESCRIPTION
With the sale and subsequent takeover of freenode, the development team no longer uses that IRC network for collaboration. Update links to point to libera.chat instead.

As an additional note, http://pioneerspacesim.net/irc needs to be updated to redirect to a KiwiIRC join link for the new irc channel instead of pointing to freenode's webchat app.
