### PR TITLE
Fix build with WITH_SYSTEM_LIBLUA=ON

### DIFF
--- a/contrib/lua/CMakeLists.txt
+++ b/contrib/lua/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT WIN32)
 endif (NOT WIN32)
 
 add_library(${PROJECT_NAME} STATIC ${SRC_FILES})
-target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/src)
 
 # make debug configurations reasonably fast
 if (NOT MSVC)

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -10,4 +10,4 @@ add_source_folders(LUA LUA_SRC_FOLDERS)
 # Creates a library, adds it to the build, and sets C++ target properties on it
 define_pioneer_library(pioneer-lua LUA_CXX_FILES LUA_HXX_FILES)
 target_include_directories(pioneer-lua PRIVATE ${CMAKE_BINARY_DIR})
-target_link_libraries(pioneer-lua pioneer-lib)
+target_link_libraries(pioneer-lua pioneer-lib ${LUA_LIBRARIES})

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -15,9 +15,9 @@
 #include "ShipType.h"
 #include "Space.h"
 #include "SpaceStation.h"
+#include "lua.h"
 #include "ship/PlayerShipController.h"
 #include "ship/PrecalcPath.h"
-#include "src/lua.h"
 
 /*
  * Class: Ship


### PR DESCRIPTION
Don't depend on hardcoded paths to the Lua library in contrib/.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

