### PR TITLE
Add build check for additional build options

### DIFF
--- a/.github/workflows/additional-build-checks.yml
+++ b/.github/workflows/additional-build-checks.yml
@@ -1,0 +1,44 @@
+# Test all pull requests to ensure they build
+
+name: Test Additional Build Options
+
+# Controls when the action will run.
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - 'src/**.cpp'
+    - 'src/**.h'
+
+env:
+  packages: >
+    mesa-common-dev
+    libfreeimage-dev
+    libglew-dev
+    libsigc++-2.0-dev
+    libvorbis-dev
+    libassimp-dev
+    libsdl2-dev
+    libsdl2-image-dev
+    liblua5.1-0-dev
+  extra_opts: >
+    -DWITH_SYSTEM_LIBLUA=ON
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-system-lua:
+    runs-on: ubuntu-20.04
+
+    steps:
+    # Checkout the repository as $GITHUB_WORKSPACE
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-fast update
+        sudo apt-fast install -y ${{ env.packages }}
+
+    - name: Build GCC
+      run: ./bootstrap cmake ${{extra_opts}} && make -C build

--- a/.github/workflows/additional-build-checks.yml
+++ b/.github/workflows/additional-build-checks.yml
@@ -22,7 +22,7 @@ env:
     libassimp-dev
     libsdl2-dev
     libsdl2-image-dev
-    liblua5.1-0-dev
+    liblua5.2-dev
     
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/additional-build-checks.yml
+++ b/.github/workflows/additional-build-checks.yml
@@ -40,4 +40,4 @@ jobs:
         sudo apt-fast install -y ${{ env.packages }}
 
     - name: Build GCC
-      run: ./bootstrap cmake -DWITH_SYSTEM_LIBLUA=ON && make -C build
+      run: ./bootstrap cmake -DUSE_SYSTEM_LIBLUA=ON && make -C build

--- a/.github/workflows/additional-build-checks.yml
+++ b/.github/workflows/additional-build-checks.yml
@@ -23,8 +23,7 @@ env:
     libsdl2-dev
     libsdl2-image-dev
     liblua5.1-0-dev
-  extra_opts: >
-    -DWITH_SYSTEM_LIBLUA=ON
+    
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -41,4 +40,4 @@ jobs:
         sudo apt-fast install -y ${{ env.packages }}
 
     - name: Build GCC
-      run: ./bootstrap cmake ${{extra_opts}} && make -C build
+      run: ./bootstrap cmake -DWITH_SYSTEM_LIBLUA=ON && make -C build

--- a/src/Aabb.h
+++ b/src/Aabb.h
@@ -1,6 +1,7 @@
 // Copyright © 2008-2021 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+
 #ifndef _AABB_H
 #define _AABB_H
 


### PR DESCRIPTION
An extra action to test different build scenarios, such as the one mentioned in #5206 . Some of these are fairly easy to break without realizing it, this will help identify when it happens sooner.

Currently just -DUSE_SYSTEM_LIBLUA=ON, but others can be added in the future


