### PR TITLE
.vscode: Add launch settings for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,4 @@ result
 # Don't track C++ language server cache files.
 .ccls-cache
 .clangd/
-.vscode/
 *.code-workspace

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(Windows) Lancher",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/${command:cmake.buildType}/pioneer.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                {"name": "PATH", "value": "${env:PATH};${workspaceFolder}/../pioneer-thirdparty/win32/bin/x86/vs2019"}
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
+}


### PR DESCRIPTION
With this, it is now possible to launch Pioneer directly from VS Code on
Windows by simply pressing F5.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>