### PR TITLE
Mark Pioneer as DPI-aware on Windows

### DIFF
--- a/src/core/OS.h
+++ b/src/core/OS.h
@@ -33,6 +33,9 @@ namespace OS {
 	// Open the Explorer/Finder/etc
 	bool SupportsFolderBrowser();
 	void OpenUserFolderBrowser();
+
+	// Mark application as DPI-aware
+	void SetDPIAware();
 } // namespace OS
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "ModelViewer.h"
 #include "Pi.h"
 #include "buildopts.h"
+#include "core/OS.h"
 #include "galaxy/Galaxy.h"
 #include "galaxy/GalaxyGenerator.h"
 #include "libs.h"
@@ -28,6 +29,8 @@ extern "C" int main(int argc, char **argv)
 #ifdef PIONEER_PROFILER
 	Profiler::detect(argc, argv);
 #endif
+
+	OS::SetDPIAware();
 
 	RunMode mode = MODE_GAME;
 	std::string modeopt;

--- a/src/posix/OSPosix.cpp
+++ b/src/posix/OSPosix.cpp
@@ -121,4 +121,8 @@ namespace OS {
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Pioneer", FileSystem::userFiles.GetRoot().c_str(), 0);
 	}
 
+	void SetDPIAware()
+	{
+	}
+
 } // namespace OS

--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -291,4 +291,9 @@ namespace OS {
 		ShellExecuteW(NULL, L"open", dumps_path.c_str(), NULL, NULL, SW_SHOWNORMAL);
 	}
 
+	void SetDPIAware()
+	{
+		SetProcessDPIAware();
+	}
+
 } // namespace OS


### PR DESCRIPTION
Without this change, Windows would automatically apply a scaling factor
for Pioneer which prevented the game from using the full resolution.

Mark Pioneer as DPI-aware so that Windows won't mess in our business.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

