### PR TITLE
Add Format.DateOnly() to lua side

### DIFF
--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -252,7 +252,7 @@ local createNewsEvent = function (timeInHyper)
 		system = system.name,
 		cargo = Equipment.cargo[cargo]:GetName(),
 		-- Turn string "23:09:27 3 Jan 3200" into "3 Jan 3200:"
-		date  = string.match(Format.Date(date), "%d+ %w+ %d+$")
+		date  = Format.DateOnly(date),
 	})
 	table.insert(news, newsEvent)
 

--- a/src/lua/LuaFormat.cpp
+++ b/src/lua/LuaFormat.cpp
@@ -51,6 +51,32 @@ static int l_format_date(lua_State *l)
 }
 
 /*
+ * Function: DateOnly
+ *
+ * Create a string representation of the given date value, without time.
+ *
+ * > string = Format.DateOnly(date)
+ *
+ * Parameters:
+ *
+ *   date - a date/time value, as seconds since 3200-01-01  00:00:00
+ *
+ * Return:
+ *
+ *   string - the string representation of the date
+ *
+ * Status:
+ *
+ *   stable
+ */
+static int l_format_date_only(lua_State *l)
+{
+	double t = luaL_checknumber(l, 1);
+	lua_pushstring(l, format_date_only(t).c_str());
+	return 1;
+}
+
+/*
  * Function: Distance
  *
  * Create a string representation of the given distance value.
@@ -153,6 +179,7 @@ void LuaFormat::Register()
 
 	static const luaL_Reg l_methods[] = {
 		{ "Date", l_format_date },
+		{ "DateOnly", l_format_date_only },
 		{ "Distance", l_format_distance },
 		{ "Money", l_format_money },
 		{ "AccelG", l_format_accel_g },


### PR DESCRIPTION
This fixes a bug in Greek, where names of the month can't be parsed

After this fix, month is shown, and not `{date}`:

![2021-06-14-174324_1600x900_scrot](https://user-images.githubusercontent.com/619390/121920396-4be39200-cd38-11eb-8f8a-a119523dc195.png)

