### PR TITLE
Fix ships having fuel scoops, hull autorepair etc. without the corresponding equipment installed

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -663,10 +663,15 @@ void Ship::UpdateEquipStats()
 	p.Set("hyperspaceRange", m_stats.hyperspace_range);
 	p.Set("maxHyperspaceRange", m_stats.hyperspace_range_max);
 
+	m_stats.atmo_shield_cap = 0;
 	p.Get<int>("atmo_shield_cap", m_stats.atmo_shield_cap);
+	m_stats.radar_cap = 0;
 	p.Get<int>("radar_cap", m_stats.radar_cap);
+	m_stats.fuel_scoop_cap = 0;
 	p.Get<int>("fuel_scoop_cap", m_stats.fuel_scoop_cap);
+	m_stats.cargo_bay_life_support_cap = 0;
 	p.Get<int>("cargo_life_support_cap", m_stats.cargo_bay_life_support_cap);
+	m_stats.hull_autorepair_cap = 0;
 	p.Get<int>("hull_autorepair_cap", m_stats.hull_autorepair_cap);
 }
 


### PR DESCRIPTION
In `Ship::UpdateEquipStats()` some lua properties are read into variables which could be uninitialized. If a variable is uninitialized, it gets passed to `PropertyMap::Get(k, v)` which passes it to `LuaTable::Get(key, default_value)` as the `default_value` argument. This immediately causes UB by reading uninitialized memory, and in practice causes `v` to retain an unpredictable value when the property does not exist, as the uninitialized value which was copied to `default_value` gets written back to `v` in this case.

The `PropertyMap` API could probably be improved (such as by taking its own `default_value` arg, as is already the case with `LuaTable`) but for now, this PR explicitly initializes the variables in question to 0 before calling `Get()`, as is already the case for some other variables in the same function.

Fixes #5216