### PR TITLE
Fix buggy saves being created with GCC11

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -40,6 +40,9 @@ Game::Game(const SystemPath &path, const double startDateTime) :
 	m_time(startDateTime),
 	m_state(State::NORMAL),
 	m_wantHyperspace(false),
+	m_hyperspaceProgress(0),
+	m_hyperspaceDuration(0),
+	m_hyperspaceEndTime(0),
 	m_timeAccel(TIMEACCEL_1X),
 	m_requestedTimeAccel(TIMEACCEL_1X),
 	m_forceTimeAccel(false)

--- a/src/ShipAICmd.h
+++ b/src/ShipAICmd.h
@@ -68,7 +68,7 @@ protected:
 	RefCountedPtr<FixedGuns> m_fguns;
 
 	std::unique_ptr<AICommand> m_child;
-	bool m_is_flyto;
+	bool m_is_flyto = false;
 	CmdName m_cmdName;
 
 	int m_dBodyIndex; // deserialisation


### PR DESCRIPTION
GCC11 implements the cbor writer's boolean branch as `add value, 0xF4`.
This breaks horribly when you attempt to write an uninitialized bool value other than 0 or 1.

Also fix an issue with uninitialized floats being written in Game.cpp.

Closes #5205.

