### PR TITLE
Fix low-hanging bugs in prep for mid-year release

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,13 @@
+July 2021
+   * Internal Changes
+     * Add error display to tab views that have crashed (#5224)
+
+   * Fixes
+     * Fix FlightLog buttons being offscreen (#5224)
+     * Fix invalid MSAA settings causing openGL errors (#5224)
+     * Fix ESC key not closing the settings window (#5224)
+     * Fix crash in ModelViewer when switching to FPS navigation (#5224)
+
 June 2021
    * New Features
      * Improve startup times with threading (#4951)
@@ -13,6 +23,8 @@ June 2021
      * Fix build with USE_SYSTEM_LIBLUA=ON (#5206)
      * Fixing the covering of data by icons in reticule in low res (#5211)
      * Fix missing translation strings in comms log (#5212)
+     * Fix corrupt savefiles being generated with GCC11 (#5218)
+     * Fix undefined behavior when caching ship equipment (#5217)
 
 May 2021
    * New Features

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1581,7 +1581,7 @@
   },
   "PLEASE_REPORT_THIS_ERROR": {
 	"description": "Informational text mentioning the error and asking the player to report it.",
-	"message": "Oops, something went wrong here! Please report this error, the output log, and your current save file to the Pioneer issue tracker on Github."
+	"message": "Oops, something went wrong here! Please report the steps to reproduce this error, the output log, and your save file to the Pioneer issue tracker on Github.\nYou can find your output log at: {path}/output.txt"
   },
   "POLICE": {
     "description": "",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1579,6 +1579,10 @@
     "description": "",
     "message": "Planet textures"
   },
+  "PLEASE_REPORT_THIS_ERROR": {
+	"description": "Informational text mentioning the error and asking the player to report it.",
+	"message": "Oops, something went wrong here! Please report this error, the output log, and your current save file to the Pioneer issue tracker on Github."
+  },
   "POLICE": {
     "description": "",
     "message": "Police"

--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -401,8 +401,7 @@ end
 --   a random element of the array, with the probability specified in the weight key
 --
 utils.chooseNormalized = function(array)
-	local choice = Engine.rand:Number(1.0)
-	sum = 0
+	local choice, sum = Engine.rand:Number(1.0), 0.0
 	for _, option in ipairs(array) do
 		sum = sum + option.weight
 		if choice <= sum then return option end

--- a/data/modules/DonateToCranks/DonateToCranks.lua
+++ b/data/modules/DonateToCranks/DonateToCranks.lua
@@ -23,7 +23,6 @@ local ads = {}
 
 
 local addReputation = function (money, character)
-	local test = istest or false
 	local char = character or Character.persistent.player
 	local curRep = char.reputation
 	local newRep
@@ -89,7 +88,7 @@ local onChat = function (form, ref, option)
 
 	-- Draw buttons donation button options
 	for i=0,5,1 do
-		donate = math.floor(10^i)
+		local donate = math.floor(10^i)
 		form:AddOption(Format.Money(donate, false), donate)
 	end
 end

--- a/data/modules/TradeShips/Debug.lua
+++ b/data/modules/TradeShips/Debug.lua
@@ -8,7 +8,7 @@ local e = require 'Equipment'
 local Game = require 'Game'
 local ui = require 'pigui.baseui'
 local utils = require 'utils'
-local Vector2 = _G.Vector2
+local Vector2 = Vector2
 local Space = require 'Space'
 
 local Core = require 'modules.TradeShips.Core'
@@ -261,7 +261,7 @@ debugView.registerTab('debug-trade-ships', function()
 			},{
 				callbacks = {
 					onClick = function(row)
-						status = Core.ships[row.ship] and Core.ships[row.ship].status
+						local status = Core.ships[row.ship] and Core.ships[row.ship].status
 						if status and status ~= "hyperspace" and status ~= "hyperspace_out" then
 							Game.systemView:SetSelectedObject(Engine.GetEnumValue("ProjectableTypes", "OBJECT"),
 								Engine.GetEnumValue("ProjectableBases", "SHIP"), row.ship)

--- a/data/modules/TradeShips/Trader.lua
+++ b/data/modules/TradeShips/Trader.lua
@@ -287,7 +287,7 @@ trader_task.doUndock = function(ship)
 end
 
 trader_task.doRedock = function(ship)
-	trader = Core.ships[ship]
+	local trader = Core.ships[ship]
 	if trader then
 		if ship:exists() and ship.flightState ~= 'HYPERSPACE' then
 			trader['starport'] = Trader.getNearestStarport(ship, trader.starport)
@@ -320,7 +320,7 @@ end
 Trader.spawnInCloud = function(ship_name, cloud, route, dest_time)
 	-- choose random local route for choosen ship,
 	-- the hyperjump target depends on this (for multiple system)
-	ship = Space.SpawnShip(ship_name, 0, 0, {cloud.from, route.from:GetSystemBody().path, dest_time})
+	local ship = Space.SpawnShip(ship_name, 0, 0, {cloud.from, route.from:GetSystemBody().path, dest_time})
 	ship:SetLabel(Ship.MakeRandomLabel())
 	Trader.addEquip(ship)
 	Trader.addFuel(ship)

--- a/data/pigui/libs/array-table.lua
+++ b/data/pigui/libs/array-table.lua
@@ -60,8 +60,8 @@ array_table.draw = function(id, tbl, iter, columns, extra)
 	local function less   (a, b) return a and ( not b or a < b ) end
 	local function greater(a, b) return a and ( not b or b < a ) end
 	local sort_symbol = {
-		[less]    = { sym = "▼ ", nxt = greater },
-		[greater] = { sym = "▲ ", nxt = less    }
+		[less]    = { sym = "▲ ", nxt = greater },
+		[greater] = { sym = "▼ ", nxt = less    }
 	}
 	if not sort_param[id] then sort_param[id] = {} end
 

--- a/data/pigui/libs/array-table.lua
+++ b/data/pigui/libs/array-table.lua
@@ -1,9 +1,10 @@
 local ui = require 'pigui.baseui'
-array_table = {}
 
 --
 -- Table: array_table
 --
+
+local array_table = {}
 
 --
 -- Function: array_table.draw

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -116,6 +116,7 @@ ui.HoveredFlags = pigui.HoveredFlags
 ui.button = pigui.Button
 
 ui.dataDirPath = pigui.DataDirPath
+ui.userDirPath = pigui.UserDirPath
 ui.addImage = pigui.AddImage
 ui.image = pigui.Image
 

--- a/data/pigui/modules/fx-window.lua
+++ b/data/pigui/modules/fx-window.lua
@@ -91,7 +91,7 @@ end
 
 local function button_info(current_view)
 	ui.sameLine()
-	active = current_view == "info"
+	local active = current_view == "info"
 	if mainMenuButton(icons.personal_info, active, lui.HUD_BUTTON_SHOW_PERSONAL_INFO) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f3)) then
 		if not active then
 			Game.SetView("info")
@@ -102,7 +102,7 @@ end
 local function button_comms(current_view)
 	if player:IsDocked() then
 		ui.sameLine()
-		active = current_view == "space_station"
+		local active = current_view == "space_station"
 		if mainMenuButton(icons.comms, active, lui.HUD_BUTTON_SHOW_COMMS) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f4)) then
 			if not active then
 				Game.SetView("space_station")

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -8,7 +8,7 @@ local Lang = require 'Lang'
 local ShipDef = require 'ShipDef'
 local ModelSpinner = require 'PiGui.Modules.ModelSpinner'
 local InfoView = require 'pigui.views.info-view'
-local Vector2 = _G.Vector2
+local Vector2 = Vector2
 
 local ui = require 'pigui'
 local l = Lang.GetResource("ui-core")

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -30,6 +30,7 @@ local function resetModelSpinner()
 end
 
 local function shipSpinner()
+	if not modelSpinner then resetModelSpinner() end
 	local spinnerWidth = ui.getColumnWidth()
 	modelSpinner:setSize(Vector2(spinnerWidth, spinnerWidth / 1.5))
 
@@ -38,6 +39,7 @@ local function shipSpinner()
 	ui.group(function ()
 		local font = ui.fonts.orbiteer.large
 		ui.withFont(font.name, font.size, function()
+			ui.alignTextToFramePadding()
 			ui.text(shipDef.name)
 			ui.sameLine()
 			ui.pushItemWidth(-1.0)
@@ -184,6 +186,7 @@ InfoView:registerView({
 		end)
 	end,
 	refresh = function() end,
+	debugReload = function() package.reimport() end
 })
 
 Event.Register("onGameStart", resetModelSpinner)

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -22,7 +22,7 @@ end
 -- convert an axis binding style ID to a translation resource identifier
 local function localize_binding_id(str)
 	local jsonIndex = str:gsub("([^A-Z0-9_])([A-Z0-9])", "%1_%2"):upper()
-	return rawget(linput, jsonIndex) or '[NO_JSON] '..jsonIndex
+	return rawget(linput, jsonIndex) or ('[NO_JSON] '..jsonIndex)
 end
 
 local function get_binding_desc(bind)
@@ -79,7 +79,7 @@ local keyCaptureNum
 
 local function combo(label, selected, items, tooltip)
 	local color = colors.buttonBlue
-	local changed, ret = 0
+	local changed, ret = 0, nil
 	ui.withStyleColors({["Button"]=color,["ButtonHovered"]=color:tint(0.1),["ButtonActive"]=color:tint(0.2)},function()
 		changed, ret = ui.combo(label, selected, items)
 	end)

--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -52,7 +52,7 @@ local minor_import = 4
 local major_import = 10
 
 local function getExportInfo(price)
-	local icon, color, tooltip = nil
+	local icon, color, tooltip
 
 	if not price then
 		icon = icons.alert_generic
@@ -75,7 +75,7 @@ local function getExportInfo(price)
 end
 
 local function getProfitabilityInfo(priceA, priceB)
-	local icon, color, tooltip = nil
+	local icon, color, tooltip
 	local priceDiff = (priceA and priceB) and priceB - priceA
 
 	if priceDiff and math.abs(priceDiff) > major_import then

--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -244,7 +244,7 @@ ui.registerHandler('game', function(delta_t)
 			end)
 		end)
 
-		if currentView == "world" and ui.escapeKeyReleased() then
+		if currentView == "world" and ui.escapeKeyReleased(true) then
 			if not ui.optionsWindow.isOpen then
 				Game.SetTimeAcceleration("paused")
 				ui.optionsWindow:open()

--- a/data/pigui/views/tab-view.lua
+++ b/data/pigui/views/tab-view.lua
@@ -110,7 +110,7 @@ function PiGuiTabView.renderTabView(self)
 			ui.setNextWindowSize(self.viewWindowSize, "Always")
 			ui.window("StationView", {"NoResize", "NoTitleBar"}, function()
 				tab.showView, tab.err = ui.pcall(tab.draw, tab)
-				if not tab.showView then logWarning(err) end
+				if not tab.showView then logWarning(tab.err) end
 			end)
 		end)
     end
@@ -123,7 +123,7 @@ function PiGuiTabView.renderTabView(self)
 				ui.withFont(ui.fonts.orbiteer.medlarge, function() ui.text(lui.AN_ERROR_HAS_OCCURRED) end)
 				ui.withFont(ui.fonts.pionillium.medium, function()
 					ui.spacing()
-					ui.textWrapped(lui.PLEASE_REPORT_THIS_ERROR)
+					ui.textWrapped(lui.PLEASE_REPORT_THIS_ERROR:interp {path = ui.userDirPath()})
 					ui.spacing()
 					ui.child("#TabErrorMsg", function()
 						local err = tab.err

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -171,7 +171,8 @@ std::map<SDL_JoystickID, JoystickInfo> &Input::GetJoysticks()
 
 */
 
-Manager::Manager(IniConfig *config) :
+Manager::Manager(IniConfig *config, SDL_Window *window) :
+	m_window(window),
 	m_config(config),
 	keyModState(0),
 	mouseButton(),
@@ -719,7 +720,7 @@ void Manager::SetCapturingMouse(bool grabbed)
 	if (grabbed == m_capturingMouse)
 		return;
 
-	SDL_SetWindowGrab(Pi::renderer->GetSDLWindow(), SDL_bool(grabbed));
+	SDL_SetWindowGrab(m_window, SDL_bool(grabbed));
 	SDL_SetRelativeMouseMode(SDL_bool(grabbed));
 	m_capturingMouse = grabbed;
 }

--- a/src/Input.h
+++ b/src/Input.h
@@ -117,7 +117,7 @@ namespace Input {
 
 class Input::Manager {
 public:
-	Manager(IniConfig *config);
+	Manager(IniConfig *config, SDL_Window *window);
 	void InitGame();
 
 	// Call this at the start of a frame, before passing SDL events in
@@ -222,6 +222,7 @@ private:
 	bool GetBindingState(InputBindings::KeyBinding &key);
 	float GetAxisState(InputBindings::JoyAxis &axis);
 
+	SDL_Window *m_window;
 	IniConfig *m_config;
 	bool m_enableConfigSaving;
 

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -97,7 +97,6 @@ void ModelViewerApp::Startup()
 	Graphics::RendererOGL::RegisterRenderer();
 
 	auto *renderer = StartupRenderer(config.get());
-
 	StartupInput(config.get());
 	StartupPiGui();
 
@@ -210,6 +209,7 @@ void ModelViewer::ToggleGuns()
 	m_options.attachGuns = !m_options.attachGuns;
 	SceneGraph::Model::TVecMT tags;
 	m_model->FindTagsByStartOfName("tag_gun_", tags);
+	m_model->FindTagsByStartOfName("tag_gunmount_", tags);
 	if (tags.empty()) {
 		AddLog("Missing tags \"tag_gun_XXX\" in model");
 		return;
@@ -343,6 +343,7 @@ void ModelViewer::ClearModel()
 	m_gunModel.reset();
 	m_scaleModel.reset();
 
+	m_options.attachGuns = false;
 	m_options.mouselookEnabled = false;
 	m_input->SetCapturingMouse(false);
 	m_viewPos = vector3f(0.0f, 0.0f, 10.0f);
@@ -981,6 +982,7 @@ void ModelViewer::DrawModelOptions()
 	if (ImGui::Button("Reload Model"))
 		ReloadModel();
 
+	ImGui::Checkbox("Show Scale Model", &m_options.showLandingPad);
 	ImGui::Checkbox("Show Collision Mesh", &m_options.showCollMesh);
 	m_options.showAabb = m_options.showCollMesh;
 	ImGui::Checkbox("Show Tags", &m_options.showTags);

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -208,7 +208,7 @@ void GuiApplication::ShutdownRenderer()
 Input::Manager *GuiApplication::StartupInput(IniConfig *config)
 {
 	PROFILE_SCOPED()
-	m_input.reset(new Input::Manager(config));
+	m_input.reset(new Input::Manager(config, m_renderer->GetSDLWindow()));
 
 	return m_input.get();
 }

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -102,7 +102,7 @@ int PiGui::pushOnScreenPositionDirection(lua_State *l, vector3d position)
 	PROFILE_SCOPED()
 	const int width = Graphics::GetScreenWidth();
 	const int height = Graphics::GetScreenHeight();
-	vector3d direction = (position - vector3d(width / 2, height / 2, 0)).Normalized();
+	vector3d direction = (position - vector3d(width / 2.0, height / 2.0, 0)).Normalized();
 	if (vector3d(0, 0, 0) == position || position.x < 0 || position.y < 0 || position.x > width || position.y > height || position.z > 0) {
 		LuaPush<bool>(l, false);
 		LuaPush<vector2d>(l, vector2d(position.x, position.y));
@@ -1724,7 +1724,7 @@ PiGui::TScreenSpace lua_world_space_to_screen_space(const Body *body)
 	const vector3d p = Pi::game->GetWorldView()->WorldSpaceToScreenSpace(body);
 	const int width = Graphics::GetScreenWidth();
 	const int height = Graphics::GetScreenHeight();
-	const vector3d direction = (p - vector3d(width / 2, height / 2, 0)).Normalized();
+	const vector3d direction = (p - vector3d(width / 2.0, height / 2.0, 0)).Normalized();
 	if (vector3d(0, 0, 0) == p || p.x < 0 || p.y < 0 || p.x > width || p.y > height || p.z > 0) {
 		return PiGui::TScreenSpace(false, vector2d(0, 0), direction * (p.z > 0 ? -1 : 1));
 	} else {

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -2231,6 +2231,13 @@ static int l_pigui_data_dir_path(lua_State *l)
 	return 1;
 }
 
+static int l_pigui_user_dir_path(lua_State *l)
+{
+	PROFILE_SCOPED()
+	LuaPush(l, FileSystem::GetUserDir());
+	return 1;
+}
+
 static int l_pigui_is_window_hovered(lua_State *l)
 {
 	int flags = LuaPull<ImGuiHoveredFlags_>(l, 1, ImGuiHoveredFlags_None);
@@ -2908,6 +2915,7 @@ void LuaObject<PiGui::Instance>::RegisterClass()
 		{ "ProgressBar", l_pigui_progress_bar },
 		{ "LoadTextureFromSVG", l_pigui_load_texture_from_svg },
 		{ "DataDirPath", l_pigui_data_dir_path },
+		{ "UserDirPath", l_pigui_user_dir_path },
 		{ "ShouldDrawUI", l_pigui_should_draw_ui },
 		{ "GetTargetsNearby", l_pigui_get_targets_nearby },
 		{ "GetProjectedBodies", l_pigui_get_projected_bodies },

--- a/src/lua/LuaVector2.cpp
+++ b/src/lua/LuaVector2.cpp
@@ -105,7 +105,9 @@ static int l_vector_mul(lua_State *L)
 		const double s = lua_tonumber(L, 2);
 		LuaVector2::PushToLua(L, *v * s);
 	} else {
-		return luaL_error(L, "general vector product doesn't exist; please use dot() or cross()");
+		const vector2d *v1 = LuaVector2::CheckFromLua(L, 1);
+		const vector2d *v2 = LuaVector2::CheckFromLua(L, 2);
+		LuaVector2::PushToLua(L, (*v1) * (*v2));
 	}
 	return 1;
 }

--- a/src/lua/core/Sandbox.cpp
+++ b/src/lua/core/Sandbox.cpp
@@ -34,8 +34,10 @@ static int l_d_mode_enabled(lua_State *L)
 
 static int l_log_warning(lua_State *L)
 {
-	std::string str = lua_tostring(L, 1);
-	Log::GetLog()->LogLevel(Log::Severity::Warning, str);
+	const char *str = lua_tostring(L, 1);
+	if (lua_gettop(L) > 0 && str)
+		Log::GetLog()->LogLevel(Log::Severity::Warning, str);
+
 	return 0;
 }
 


### PR DESCRIPTION
This is a maintenance PR to clean up a few outstanding bugs and prep a release before we merge the renderer rewrite and other PRs that make major changes and take the master branch unstable.

- Partially resolves (but doesn't close) #5158 by ensuring the edit button stays on screen.
- Fixes #5162 with better error tracking that catches when MSAA is unavailable for whatever reason.
- Fixes (partially) #5149, adds an error dialog that displays an error has occurred and prompts the player to report the issue.
- Fixes #5179.
- Fixes #5104. There are further issues with first-person navigation, but now it doesn't crash.

![image](https://user-images.githubusercontent.com/4218491/124525212-65727980-ddcc-11eb-9bf7-4c4f896f7d67.png)
