### PR TITLE
Restore the "How much mass" question

### DIFF
--- a/data/lang/module-cargorun/en.json
+++ b/data/lang/module-cargorun/en.json
@@ -229,35 +229,35 @@
   },
   "HOWMUCH_1": {
     "description": "regarding mass, always more than 1t",
-    "message": "Yes it is. The total amount is {amount} metric tons."
+    "message": "{amount} metric tons."
   },
   "HOWMUCH_2": {
     "description": "regarding mass, always more than 1t",
-    "message": "Yes, we can split the cargo. I have {amount}t in total."
+    "message": "{amount}t"
   },
   "HOWMUCH_3": {
     "description": "regarding mass, always more than 1t",
-    "message": "Yes. The entire mass is {amount}t."
+    "message": "The mass is {amount}t."
   },
-  "HOWMUCH_NO_1": {
+  "HOWMUCH_4": {
     "description": "regarding mass, always more than 1t",
-    "message": "No, sorry. It is not possible to split the cargo. You have to transport the whole {amount} tons at once."
+    "message": "There are {amount}t."
   },
   "HOWMUCH_SINGULAR_1": {
-    "description": "This string is only used for 1 metric tons (singular)",
-    "message": "No it is not. It's only {amount}t."
+    "description": "This string is only used for 1 metric ton (singular)",
+    "message": "It's only {amount}t."
   },
   "HOWMUCH_WHOLESALER_1": {
     "description": "",
-    "message": "There are {amount}t of {cargoname}. I can offer the following freight runs:"
+    "message": "There are {amount}t of {cargoname}."
   },
   "HOWMUCH_WHOLESALER_2": {
     "description": "",
-    "message": "{amount}t {cargoname} can be divided as follows:"
+    "message": "{amount}t {cargoname}"
   },
   "HOW_MUCH_MASS": {
     "description": "",
-    "message": "Is the amount of cargo negotiable?"
+    "message": "How much mass?"
   },
   "HOW_SOON_MUST_IT_BE_DELIVERED": {
     "description": "",
@@ -331,6 +331,10 @@
     "description": "",
     "message": "Greetings, my name is {name} and I work for Haber Corp. We pay {cash} for the run to {starport} in the {system} ({sectorx}, {sectory}, {sectorz}) system, a distance of {dist} ly."
   },
+  "IS_IT_NEGOTIABLE": {
+    "description": "",
+    "message": "Is the amount of cargo negotiable?"
+  },
   "I_AM_ON_MY_WAY": {
     "description": "",
     "message": "Sensors show that you are taking damage. I'm on my way."
@@ -346,6 +350,26 @@
   "MACHINE_TOOLS": {
     "description": "custom cargo",
     "message": "Machine tools"
+  },
+  "NEGOTIABLE_1": {
+    "description": "regarding mass, always more than 1t",
+    "message": "I can offer the following freight runs:"
+  },
+  "NEGOTIABLE_2": {
+    "description": "regarding mass, always more than 1t",
+    "message": "{amount}t {cargoname} can be divided as follows:"
+  },
+  "NEGOTIABLE_3": {
+    "description": "regarding mass, always more than 1t",
+    "message": "Yes, we can split the cargo."
+  },
+  "NEGOTIABLE_NO_1": {
+    "description": "regarding mass, always more than 1t",
+    "message": "No, sorry. It is not possible to split the cargo. You have to transport the whole {amount} tons at once."
+  },
+  "NEGOTIABLE_SINGULAR_1": {
+    "description": "This string is only used for 1 metric ton (singular)",
+    "message": "No it is not. It's only {amount}t."
   },
   "NEPTUNIUM": {
     "description": "custom cargo",

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -389,40 +389,21 @@ onChat = function (form, ref, option)
 
 	elseif option == 2 then
 		local howmuch
-		if ad.amount == 1 then
-			howmuch = string.interp(l["HOWMUCH_SINGULAR_" .. Engine.rand:Integer(1,getNumberOfFlavours("HOWMUCH_SINGULAR"))],
-				{amount = ad.amount})
-		elseif ad.negotiable then
-			if ad.wholesaler then
-				howmuch = string.interp(l["HOWMUCH_WHOLESALER_" .. Engine.rand:Integer(1, getNumberOfFlavours("HOWMUCH_WHOLESALER"))], {
-					amount    = ad.amount,
-					cargoname = ad.cargotype:GetName()})
-			else
+		if ad.wholesaler then
+			howmuch = string.interp(l["HOWMUCH_WHOLESALER_" .. Engine.rand:Integer(1, getNumberOfFlavours("HOWMUCH_WHOLESALER"))], {
+				amount    = ad.amount,
+				cargoname = ad.cargotype:GetName()})
+		else
+			if ad.amount > 1 then
 				howmuch = string.interp(l["HOWMUCH_" .. Engine.rand:Integer(1,getNumberOfFlavours("HOWMUCH"))],
 					{amount = ad.amount})
+			else
+				howmuch = string.interp(l["HOWMUCH_SINGULAR_" .. Engine.rand:Integer(1,getNumberOfFlavours("HOWMUCH_SINGULAR"))],
+					{amount = ad.amount})
 			end
-
-			local amount = {}
-			local button = 2
-
-			amount[1] = ad.wholesaler and max_cargo or 1
-			for i = 2, 5 do
-				local val = math.ceil(i^2/25 * ad.amount)
-				if val > amount[button-1] then
-					amount[button] = val
-					button = button + 1
-				end
-			end
-			for i, val in pairs(amount) do
-				form:AddOption(string.interp(l.OFFER, { amount = val, reward = Format.Money(math.ceil(ad.reward * val/ad.amount), false) }), 10+val)
-			end
-		else
-			howmuch = string.interp(l["HOWMUCH_NO_" .. Engine.rand:Integer(1,getNumberOfFlavours("HOWMUCH_NO"))],
-				{amount = ad.amount})
 		end
 		form:SetMessage(howmuch)
-		form:RemoveNavButton()
-		form:AddOption(l.GO_BACK, 0)
+		form:AddOption(l.IS_IT_NEGOTIABLE, 6)
 
 	elseif option == 3 then
 		if not ad.pickup and (Game.player.totalCargo - Game.player.usedCargo) < ad.negotiated_amount or
@@ -496,13 +477,46 @@ onChat = function (form, ref, option)
 	elseif option == 5 then
 		form:SetMessage(getRiskMsg(ad))
 
+	elseif option == 6 then
+		local howmuch
+		if ad.amount == 1 then
+			howmuch = string.interp(l["NEGOTIABLE_SINGULAR_" .. Engine.rand:Integer(1,getNumberOfFlavours("NEGOTIABLE_SINGULAR"))],
+				{amount = ad.amount})
+		elseif ad.negotiable then
+			howmuch = string.interp(l["NEGOTIABLE_" .. Engine.rand:Integer(1, getNumberOfFlavours("NEGOTIABLE"))], {
+				amount    = ad.amount,
+				cargoname = ad.cargotype:GetName()})
+
+			local amount = {}
+			local button = 2
+
+			amount[1] = ad.wholesaler and max_cargo or 1
+			for i = 2, 5 do
+				local val = math.ceil(i^2/25 * ad.amount)
+				if val > amount[button-1] then
+					amount[button] = val
+					button = button + 1
+				end
+			end
+			for i, val in pairs(amount) do
+				form:AddOption(string.interp(l.OFFER, { amount = val, reward = Format.Money(math.ceil(ad.reward * val/ad.amount), false) }), 10+val)
+			end
+		else
+			howmuch = string.interp(l["NEGOTIABLE_NO_" .. Engine.rand:Integer(1,getNumberOfFlavours("NEGOTIABLE_NO"))],
+				{amount = ad.amount})
+		end
+		form:SetMessage(howmuch)
+
 	elseif option > 10 then
 		ad.negotiated_amount = option - 10
 		ad.negotiated_reward = math.ceil(ad.reward * ad.negotiated_amount/ad.amount)
 		form:SetMessage(string.interp(l.OK_WE_AGREE, { amount = ad.negotiated_amount, reward = Format.Money(ad.negotiated_reward, false) }))
 	end
 
-	if option ~= 2 then
+	if option == 2 or option == 6 then
+		form:RemoveNavButton()
+		form:AddOption(l.GO_BACK, 0)
+	else
 		form:AddOption(l.WHY_SO_MUCH_MONEY, 1)
 		form:AddOption(l.HOW_MUCH_MASS, 2)
 		form:AddOption(l.HOW_SOON_MUST_IT_BE_DELIVERED, 4)


### PR DESCRIPTION
Improvement of #5164
This restores the "How much mass" question and moves the "Is the amount of cargo negotiable" button below that.

![image](https://user-images.githubusercontent.com/10255455/124658520-244d9880-dea4-11eb-9e4f-eca02b07f68e.png)
