### PR TITLE
Add download counter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/b2n2fe1vv3wr6n56/branch/master?svg=true)](https://ci.appveyor.com/project/pioneerspacesim/pioneer/branch/master)
 [![License GPLv3](https://img.shields.io/badge/license-GPL_v3-green.svg)](http://www.gnu.org/licenses/gpl-3.0.html)
 [![#pioneer on Libera.Chat](https://img.shields.io/badge/LiberaChat-%23pioneer-brightgreen.svg)](https://kiwiirc.com/client/irc.libera.chat/pioneer)
+[![Github All Releases](https://img.shields.io/github/downloads/pioneerspacesim/pioneer/latest/total)]()
+
 
 # Pioneer Space Simulator
 


### PR DESCRIPTION
## Screenshot
![2021-07-28-104531_1600x900_scrot](https://user-images.githubusercontent.com/619390/127293125-c7f3f56a-6093-4448-9730-f1bfd53fd875.png)

I also tested a badge for all downloads, it says 27k, not sure if that's all clones, or what? This badge shows linux + windows downloads from latest release.

same as sum of output from: 
```
curl -s https://api.github.com/repos/pioneerspacesim/pioneer/releases | egrep '"name"|"download_count"'
```