### PR TITLE
Refactor Lua Serialization

### DIFF
--- a/src/Color.h
+++ b/src/Color.h
@@ -124,17 +124,27 @@ struct Color4ub {
 	static Color4ub FromLuaTable(lua_State *l, int idx);
 
 	Uint8 GetLuminance() const;
-	void Shade(float factor)
+	Color4ub Shade(float factor)
 	{
-		r = static_cast<Uint8>(r * (1.0f - factor));
-		g = static_cast<Uint8>(g * (1.0f - factor));
-		b = static_cast<Uint8>(b * (1.0f - factor));
+		Color4ub out = *this;
+		out.r = static_cast<Uint8>(r * (1.0f - factor));
+		out.g = static_cast<Uint8>(g * (1.0f - factor));
+		out.b = static_cast<Uint8>(b * (1.0f - factor));
+		return out;
 	}
-	void Tint(float factor)
+	Color4ub Tint(float factor)
 	{
-		r = static_cast<Uint8>(r + (255.0f - r) * factor);
-		g = static_cast<Uint8>(g + (255.0f - g) * factor);
-		b = static_cast<Uint8>(b + (255.0f - b) * factor);
+		Color4ub out = *this;
+		out.r = static_cast<Uint8>(r + (255.0f - r) * factor);
+		out.g = static_cast<Uint8>(g + (255.0f - g) * factor);
+		out.b = static_cast<Uint8>(b + (255.0f - b) * factor);
+		return out;
+	}
+	Color4ub Opacity(float factor)
+	{
+		Color4ub out = *this;
+		out.a = static_cast<Uint8>(factor <= 1.0 ? factor * 255 : uint8_t(factor));
+		return out;
 	}
 
 	static const Color4ub BLACK;

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -649,7 +649,7 @@ void CustomSystemsDatabase::Load()
 
 	// provide shortcut vector constructor: v = vector.new
 	lua_getglobal(L, LuaVector::LibName);
-	lua_getfield(L, -1, "new");
+	lua_getfield(L, -1, "New");
 	assert(lua_iscfunction(L, -1));
 	lua_setglobal(L, "v");
 	lua_pop(L, 1); // pop the vector table

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -699,39 +699,6 @@ static bool push_body_to_lua(Body *body)
 	return true;
 }
 
-/*
-static std::string _body_serializer(LuaWrappable *o)
-{
-	static char buf[256];
-	Body *b = static_cast<Body *>(o);
-	snprintf(buf, sizeof(buf), "%u\n", Pi::game->GetSpace()->GetIndexForBody(b));
-	return std::string(buf);
-}
-
-static bool _body_deserializer(const char *pos, const char **next)
-{
-	Uint32 n = strtoul(pos, const_cast<char **>(next), 0);
-	if (pos == *next) return false;
-	(*next)++; // skip newline
-
-	Body *body = Pi::game->GetSpace()->GetBodyByIndex(n);
-	return push_body_to_lua(body);
-}
-
-static void _body_to_json(Json &out, LuaWrappable *o)
-{
-	Body *b = static_cast<Body *>(o);
-	out = Json(Pi::game->GetSpace()->GetIndexForBody(b));
-}
-
-static bool _body_from_json(const Json &obj)
-{
-	if (!obj.is_number_integer()) return false;
-	Body *body = Pi::game->GetSpace()->GetBodyByIndex(obj);
-	return push_body_to_lua(body);
-}
-*/
-
 static bool pi_lua_body_serializer(lua_State *l, Json &out)
 {
 	Body *body = LuaObject<Body>::GetFromLua(-1);

--- a/src/lua/LuaCall.h
+++ b/src/lua/LuaCall.h
@@ -12,90 +12,175 @@
 #include "Lua.h"
 #include "LuaPushPull.h"
 
+// Backend to bind call a C++ free function with arguments from Lua.
+// Parameter `index` points to the first argument
+
+template <typename Ret>
+Ret pi_lua_multiple_call(lua_State *l, int index, Ret (*fn)())
+{
+	return fn();
+}
+
+template <typename Ret, typename Arg1>
+Ret pi_lua_multiple_call(lua_State *l, int index, Ret (*fn)(Arg1))
+{
+	auto arg1 = LuaPull<Arg1>(l, index);
+	return fn(arg1);
+}
+
+template <typename Ret, typename Arg1, typename Arg2>
+Ret pi_lua_multiple_call(lua_State *l, int index, Ret (*fn)(Arg1, Arg2))
+{
+	auto arg1 = LuaPull<Arg1>(l, index);
+	auto arg2 = LuaPull<Arg2>(l, index + 1);
+	return fn(arg1, arg2);
+}
+
+template <typename Ret, typename Arg1, typename Arg2, typename Arg3>
+Ret pi_lua_multiple_call(lua_State *l, int index, Ret (*fn)(Arg1, Arg2, Arg3))
+{
+	auto arg1 = LuaPull<Arg1>(l, index);
+	auto arg2 = LuaPull<Arg2>(l, index + 1);
+	auto arg3 = LuaPull<Arg3>(l, index + 2);
+	return fn(arg1, arg2, arg3);
+}
+
+template <typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4>
+Ret pi_lua_multiple_call(lua_State *l, int index, Ret (*fn)(Arg1, Arg2, Arg3, Arg4))
+{
+	auto arg1 = LuaPull<Arg1>(l, index);
+	auto arg2 = LuaPull<Arg2>(l, index + 1);
+	auto arg3 = LuaPull<Arg3>(l, index + 2);
+	auto arg4 = LuaPull<Arg4>(l, index + 3);
+	return fn(arg1, arg2, arg3, arg4);
+}
+
+template <typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5>
+Ret pi_lua_multiple_call(lua_State *l, int index, Ret (*fn)(Arg1, Arg2, Arg3, Arg4, Arg5))
+{
+	auto arg1 = LuaPull<Arg1>(l, index);
+	auto arg2 = LuaPull<Arg2>(l, index + 1);
+	auto arg3 = LuaPull<Arg3>(l, index + 2);
+	auto arg4 = LuaPull<Arg4>(l, index + 3);
+	auto arg5 = LuaPull<Arg5>(l, index + 4);
+	return fn(arg1, arg2, arg3, arg4, arg5);
+}
+
+template <typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6>
+Ret pi_lua_multiple_call(lua_State *l, int index, Ret (*fn)(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6))
+{
+	auto arg1 = LuaPull<Arg1>(l, index);
+	auto arg2 = LuaPull<Arg2>(l, index + 1);
+	auto arg3 = LuaPull<Arg3>(l, index + 2);
+	auto arg4 = LuaPull<Arg4>(l, index + 3);
+	auto arg5 = LuaPull<Arg5>(l, index + 4);
+	auto arg6 = LuaPull<Arg6>(l, index + 5);
+	return fn(arg1, arg2, arg3, arg4, arg5, arg6);
+}
+
+template <typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7>
+Ret pi_lua_multiple_call(lua_State *l, int index, Ret (*fn)(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7))
+{
+	auto arg1 = LuaPull<Arg1>(l, index);
+	auto arg2 = LuaPull<Arg2>(l, index + 1);
+	auto arg3 = LuaPull<Arg3>(l, index + 2);
+	auto arg4 = LuaPull<Arg4>(l, index + 3);
+	auto arg5 = LuaPull<Arg5>(l, index + 4);
+	auto arg6 = LuaPull<Arg6>(l, index + 5);
+	auto arg7 = LuaPull<Arg7>(l, index + 6);
+	return fn(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+}
+
 // Backend to bind call a C++ member function with arguments from Lua.
 // Parameter `index` points one-behind the first argument, where the object
 // pointer should traditionally be
 
-template<class T, typename Ret>
+template <class T, typename Ret>
 Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)())
 {
 	return (ptr->*fn)();
 }
 
-template<class T, typename Ret, typename Arg1>
+template <class T, typename Ret, typename Arg1>
 Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1))
 {
-	auto arg1 = LuaPull<Arg1>(l, index+1);
+	auto arg1 = LuaPull<Arg1>(l, index + 1);
 	return (ptr->*fn)(arg1);
 }
 
-template<class T, typename Ret, typename Arg1, typename Arg2>
+template <class T, typename Ret, typename Arg1, typename Arg2>
 Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2))
 {
-	auto arg1 = LuaPull<Arg1>(l, index+1);
-	auto arg2 = LuaPull<Arg2>(l, index+2);
+	auto arg1 = LuaPull<Arg1>(l, index + 1);
+	auto arg2 = LuaPull<Arg2>(l, index + 2);
 	return (ptr->*fn)(arg1, arg2);
 }
 
-template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3>
+template <class T, typename Ret, typename Arg1, typename Arg2, typename Arg3>
 Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3))
 {
-	auto arg1 = LuaPull<Arg1>(l, index+1);
-	auto arg2 = LuaPull<Arg2>(l, index+2);
-	auto arg3 = LuaPull<Arg3>(l, index+3);
+	auto arg1 = LuaPull<Arg1>(l, index + 1);
+	auto arg2 = LuaPull<Arg2>(l, index + 2);
+	auto arg3 = LuaPull<Arg3>(l, index + 3);
 	return (ptr->*fn)(arg1, arg2, arg3);
 }
 
-template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4>
+template <class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4>
 Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3, Arg4))
 {
-	auto arg1 = LuaPull<Arg1>(l, index+1);
-	auto arg2 = LuaPull<Arg2>(l, index+2);
-	auto arg3 = LuaPull<Arg3>(l, index+3);
-	auto arg4 = LuaPull<Arg4>(l, index+4);
+	auto arg1 = LuaPull<Arg1>(l, index + 1);
+	auto arg2 = LuaPull<Arg2>(l, index + 2);
+	auto arg3 = LuaPull<Arg3>(l, index + 3);
+	auto arg4 = LuaPull<Arg4>(l, index + 4);
 	return (ptr->*fn)(arg1, arg2, arg3, arg4);
 }
 
-template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5>
+template <class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5>
 Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3, Arg4, Arg5))
 {
-	auto arg1 = LuaPull<Arg1>(l, index+1);
-	auto arg2 = LuaPull<Arg2>(l, index+2);
-	auto arg3 = LuaPull<Arg3>(l, index+3);
-	auto arg4 = LuaPull<Arg4>(l, index+4);
-	auto arg5 = LuaPull<Arg5>(l, index+5);
+	auto arg1 = LuaPull<Arg1>(l, index + 1);
+	auto arg2 = LuaPull<Arg2>(l, index + 2);
+	auto arg3 = LuaPull<Arg3>(l, index + 3);
+	auto arg4 = LuaPull<Arg4>(l, index + 4);
+	auto arg5 = LuaPull<Arg5>(l, index + 5);
 	return (ptr->*fn)(arg1, arg2, arg3, arg4, arg5);
 }
 
-template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6>
+template <class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6>
 Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6))
 {
-	auto arg1 = LuaPull<Arg1>(l, index+1);
-	auto arg2 = LuaPull<Arg2>(l, index+2);
-	auto arg3 = LuaPull<Arg3>(l, index+3);
-	auto arg4 = LuaPull<Arg4>(l, index+4);
-	auto arg5 = LuaPull<Arg5>(l, index+5);
-	auto arg6 = LuaPull<Arg6>(l, index+6);
+	auto arg1 = LuaPull<Arg1>(l, index + 1);
+	auto arg2 = LuaPull<Arg2>(l, index + 2);
+	auto arg3 = LuaPull<Arg3>(l, index + 3);
+	auto arg4 = LuaPull<Arg4>(l, index + 4);
+	auto arg5 = LuaPull<Arg5>(l, index + 5);
+	auto arg6 = LuaPull<Arg6>(l, index + 6);
 	return (ptr->*fn)(arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
-template<class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7>
+template <class T, typename Ret, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5, typename Arg6, typename Arg7>
 Ret pi_lua_multiple_call(lua_State *l, int index, T *ptr, Ret (T::*fn)(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7))
 {
-	auto arg1 = LuaPull<Arg1>(l, index+1);
-	auto arg2 = LuaPull<Arg2>(l, index+2);
-	auto arg3 = LuaPull<Arg3>(l, index+3);
-	auto arg4 = LuaPull<Arg4>(l, index+4);
-	auto arg5 = LuaPull<Arg5>(l, index+5);
-	auto arg6 = LuaPull<Arg6>(l, index+6);
-	auto arg7 = LuaPull<Arg7>(l, index+7);
+	auto arg1 = LuaPull<Arg1>(l, index + 1);
+	auto arg2 = LuaPull<Arg2>(l, index + 2);
+	auto arg3 = LuaPull<Arg3>(l, index + 3);
+	auto arg4 = LuaPull<Arg4>(l, index + 4);
+	auto arg5 = LuaPull<Arg5>(l, index + 5);
+	auto arg6 = LuaPull<Arg6>(l, index + 6);
+	auto arg7 = LuaPull<Arg7>(l, index + 7);
 	return (ptr->*fn)(arg1, arg2, arg3, arg4, arg5, arg6, arg7);
 }
 
 // Pull an object and arguments for the passed function from Lua.
 // Intended to ease the amount of boilerplate code needed to bind a method to Lua.
 
-template<class T, typename Ret, typename ...Args>
+template <typename Ret, typename... Args>
+Ret pi_lua_generic_call(lua_State *l, int index, Ret (*fn)(Args...))
+{
+	return pi_lua_multiple_call<Ret, Args...>(l, index, fn);
+}
+
+template <class T, typename Ret, typename... Args>
 Ret pi_lua_generic_call(lua_State *l, int index, Ret (T::*fn)(Args...))
 {
 	T *ptr = LuaPull<T>(l, index);

--- a/src/lua/LuaMetaType.cpp
+++ b/src/lua/LuaMetaType.cpp
@@ -409,6 +409,30 @@ void LuaMetaTypeBase::GetMetatable() const
 	LUA_DEBUG_END(m_lua, 1);
 }
 
+void *LuaMetaTypeBase::TestUserdata(lua_State *l, int index, const char *type)
+{
+	void *p = lua_touserdata(l, index);
+	if (p != nullptr && lua_getmetatable(l, index)) {
+		if (GetMetatableFromName(l, type) && lua_rawequal(l, -1, -2)) {
+			lua_pop(l, 2);
+			return p;
+		}
+		lua_pop(l, 1);
+	}
+	return nullptr;
+}
+
+void *LuaMetaTypeBase::CheckUserdata(lua_State *l, int index, const char *type)
+{
+	void *p = TestUserdata(l, index, type);
+	if (!p) {
+		const char *msg = lua_pushfstring(l, "%s expected, got %s", type, luaL_typename(l, index));
+		luaL_argerror(l, index, msg);
+	}
+
+	return p;
+}
+
 void LuaMetaTypeBase::CreateMetaType(lua_State *l)
 {
 	luaL_getsubtable(l, LUA_REGISTRYINDEX, "LuaMetaTypes");

--- a/src/lua/LuaMetaType.cpp
+++ b/src/lua/LuaMetaType.cpp
@@ -450,6 +450,9 @@ void LuaMetaTypeBase::CreateMetaType(lua_State *l)
 
 	// create the methods table
 	lua_newtable(l);
+	// create the methods metatable
+	lua_newtable(l);
+	lua_setmetatable(l, -2);
 	lua_setfield(l, -2, "methods");
 
 	lua_pushcclosure(l, &l_index, 0);

--- a/src/lua/LuaMetaType.h
+++ b/src/lua/LuaMetaType.h
@@ -91,6 +91,12 @@ public:
 	// Get the lua-side metatable from a type name instead of a LuaRef.
 	static bool GetMetatableFromName(lua_State *l, const char *name);
 
+	// A replacement for luaL_testudata that is metatype-aware
+	static void *TestUserdata(lua_State *l, int index, const char *name);
+
+	// A replacement for luaL_checkudata that is metatype-aware
+	static void *CheckUserdata(lua_State *l, int index, const char *name);
+
 protected:
 	//=========================================================================
 	// LuaMetaTypeGeneric support:

--- a/src/lua/LuaObject.cpp
+++ b/src/lua/LuaObject.cpp
@@ -400,6 +400,7 @@ void LuaObjectBase::CreateClass(LuaMetaTypeBase *metaType)
 	// Get the method table from the metatype
 	metaType->GetMetatable();
 	lua_getfield(l, -1, "methods");
+
 	lua_remove(l, -2); // "global" table, type name, methods table
 
 	// add the exists method

--- a/src/lua/LuaObject.cpp
+++ b/src/lua/LuaObject.cpp
@@ -91,7 +91,6 @@
  */
 
 static std::map<std::string, std::map<std::string, PromotionTest>> promotions;
-static std::map<std::string, SerializerPair> serializers;
 
 class LuaObjectHelpers {
 public:
@@ -688,81 +687,6 @@ void LuaObjectBase::RegisterSerializer(const char *type, SerializerPair pair)
 	lua_pop(l, 1);
 	LUA_DEBUG_END(l, 0);
 }
-
-/*
-void LuaObjectBase::RegisterSerializer(const char *type, SerializerPair pair)
-{
-	serializers[type] = pair;
-}
-
-std::string LuaObjectBase::Serialize()
-{
-	static char buf[256];
-
-	lua_State *l = Lua::manager->GetLuaState();
-
-	auto i = serializers.find(m_type);
-	if (i == serializers.end()) {
-		luaL_error(l, "No registered serializer for type %s\n", m_type);
-		abort();
-	}
-
-	snprintf(buf, sizeof(buf), "%s\n", m_type);
-
-	return std::string(buf) + (*i).second.serialize(GetObject());
-}
-
-bool LuaObjectBase::Deserialize(const char *stream, const char **next)
-{
-	static char buf[256];
-
-	const char *end = strchr(stream, '\n');
-	int len = end - stream;
-	end++; // skip newline
-
-	snprintf(buf, sizeof(buf), "%.*s", len, stream);
-
-	lua_State *l = Lua::manager->GetLuaState();
-
-	auto i = serializers.find(buf);
-	if (i == serializers.end()) {
-		luaL_error(l, "No registered deserializer for type %s\n", buf);
-		abort();
-	}
-
-	return (*i).second.deserialize(end, next);
-}
-
-void LuaObjectBase::ToJson(Json &out)
-{
-	lua_State *l = Lua::manager->GetLuaState();
-
-	const auto it = serializers.find(m_type);
-	if (it == serializers.end()) {
-		luaL_error(l, "No registered serializer for type %s\n", m_type);
-		abort();
-	}
-
-	out["cpp_class"] = Json(m_type);
-	Json inner = Json::object();
-	it->second.to_json(inner, GetObject());
-	out["inner"] = inner;
-}
-
-bool LuaObjectBase::FromJson(const Json &obj)
-{
-	if (obj["cpp_class"].is_null() || obj["inner"].is_null()) return false;
-	const std::string type = obj["cpp_class"];
-	auto it = serializers.find(type);
-	if (it == serializers.end()) {
-		lua_State *l = Lua::manager->GetLuaState();
-		luaL_error(l, "No registered deserializer for type %s\n", type.c_str());
-		abort();
-	}
-
-	return it->second.from_json(obj["inner"]);
-}
-*/
 
 // Takes a lua userdata object at the top of the stack and serializes it to json
 bool LuaObjectBase::SerializeToJson(lua_State *l, Json &out)

--- a/src/lua/LuaObject.h
+++ b/src/lua/LuaObject.h
@@ -501,4 +501,30 @@ void pi_lua_generic_push(lua_State *l, T *value)
 		lua_pushnil(l);
 }
 
+// LuaPushPull stuff.
+template <class T>
+void pi_lua_generic_pull(lua_State *l, int index, RefCountedPtr<T> &out)
+{
+	assert(l == Lua::manager->GetLuaState());
+	out = LuaObject<typename std::remove_cv<T>::type>::CheckFromLua(index);
+}
+
+template <class T>
+bool pi_lua_strict_pull(lua_State *l, int index, RefCountedPtr<T> &out)
+{
+	assert(l == Lua::manager->GetLuaState());
+	out = LuaObject<typename std::remove_cv<T>::type>::GetFromLua(index);
+	return out != 0;
+}
+
+template <class T>
+void pi_lua_generic_push(lua_State *l, RefCountedPtr<T> value)
+{
+	assert(l == Lua::manager->GetLuaState());
+	if (value)
+		LuaObject<typename std::remove_cv<T>::type>::PushToLua(value.Get());
+	else
+		lua_pushnil(l);
+}
+
 #endif

--- a/src/lua/LuaObject.h
+++ b/src/lua/LuaObject.h
@@ -121,6 +121,9 @@ public:
 	// its PropertyMap. Returns nullptr on failure.
 	static PropertyMap *GetPropertiesFromObject(lua_State *l, int object);
 
+	// register a serializer pair for a given type
+	static void RegisterSerializer(const char *type, SerializerPair pair);
+
 protected:
 	// base class constructor, called by the wrapper Push* methods
 	LuaObjectBase(const char *type) :
@@ -166,20 +169,11 @@ protected:
 	// object will be of target_type
 	static void RegisterPromotion(const char *base_type, const char *target_type, PromotionTest test_fn);
 
-	// register a serializer pair for a given type
-	static void RegisterSerializer(const char *type, SerializerPair pair);
-
-	// [[deprecated]] std::string Serialize();
-	// [[deprecated]] static bool Deserialize(const char *stream, const char **next);
-
 	// Take a lua object at the top of the stack and serialize it to Json
 	static bool SerializeToJson(lua_State *l, Json &out);
 
 	// Take a json object and deserialize it to a lua object
 	static bool DeserializeFromJson(lua_State *l, const Json &obj);
-
-	// [[deprecated]] void ToJson(Json &out);
-	// [[deprecated]] static bool FromJson(const Json &obj);
 
 	// allocate n bytes from Lua memory and leave it an associated userdata on
 	// the stack. this is a wrapper around lua_newuserdata

--- a/src/lua/LuaPushPull.h
+++ b/src/lua/LuaPushPull.h
@@ -5,8 +5,9 @@
 #define _LUAPUSHPULL_H
 
 #include <lua.hpp>
-
 #include "Lua.h"
+
+#include <cstddef>
 #include <string>
 #include <tuple>
 
@@ -19,6 +20,7 @@ inline void pi_lua_generic_push(lua_State *l, const std::string &value)
 {
 	lua_pushlstring(l, value.c_str(), value.size());
 }
+inline void pi_lua_generic_push(lua_State *l, const std::nullptr_t &value) { lua_pushnil(l); }
 
 inline void pi_lua_generic_pull(lua_State *l, int index, bool &out) { out = lua_toboolean(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, int &out) { out = luaL_checkinteger(l, index); }

--- a/src/lua/LuaRef.cpp
+++ b/src/lua/LuaRef.cpp
@@ -145,8 +145,10 @@ void LuaRef::LoadFromJson(const Json &jsonObj)
 	if (jsonObj.count("lua_ref_json")) {
 		LuaSerializer::unpickle_json(m_lua, jsonObj["lua_ref_json"]);
 	} else if (jsonObj.count("lua_ref")) {
-		std::string pickled = jsonObj["lua_ref"];
+		/*std::string pickled = jsonObj["lua_ref"];
 		LuaSerializer::unpickle(m_lua, pickled.c_str());
+		*/
+		throw SavedGameCorruptException();
 	} else {
 		throw SavedGameCorruptException();
 	}

--- a/src/lua/LuaRef.cpp
+++ b/src/lua/LuaRef.cpp
@@ -145,9 +145,7 @@ void LuaRef::LoadFromJson(const Json &jsonObj)
 	if (jsonObj.count("lua_ref_json")) {
 		LuaSerializer::unpickle_json(m_lua, jsonObj["lua_ref_json"]);
 	} else if (jsonObj.count("lua_ref")) {
-		/*std::string pickled = jsonObj["lua_ref"];
-		LuaSerializer::unpickle(m_lua, pickled.c_str());
-		*/
+		// old text-based serialization
 		throw SavedGameCorruptException();
 	} else {
 		throw SavedGameCorruptException();

--- a/src/lua/LuaSerializer.cpp
+++ b/src/lua/LuaSerializer.cpp
@@ -20,28 +20,27 @@
 // function for each module with its table
 //
 // we keep a copy of this table around. next time we save we overwrite the
-// each individual module's data. that way if a player loads a game with dat
+// each individual module's data. that way if a player loads a game with data
 // for a module that is not currently loaded, we don't lose its data in the
 // next save
 
 // pickler can handle simple types (boolean, number, string) and will drill
 // down into tables. it can do userdata assuming the appropriate Lua wrapper
-// class has registered a serializer and deseriaizer
+// class has registered a serializer and deserializer
 //
-// pickle format is newline-seperated. each line begins with a type value,
-// followed by data for that type as follows
-//   fNNN.nnn - number (float)
-//   bN       - boolean. N is 0 or 1 for true/false
-//   sNNN     - string. number is length, followed by newline, then string of bytes
-//   t        - table. followed by a float (fNNN.nnn) uniquely identifying the
-//            - table, then more pickled stuff (ie recursive)
-//   n        - end of table
-//   r        - reference to previously-seen table. followed by the table id
-//   uXXXX    - userdata. XXXX is type, followed by newline, followed by data
-//                everything after u is passed down to LuaObject::Serialize to
-//                generate using per-class serializers
-//   oXXXX    - object. XXX is type, followed by newline, followed by one
-//              pickled item (typically t[able])
+// Data is picked into JSON format, with a few specifics about file structure.
+// Tables are pickled into a JSON Array with key,value pairs occupying
+// consecutive entries in the array. Thus, one key-value pair takes 2 array
+// slots.
+// A top-level JSON object can represent several different types of lua objects
+// using a scheme as follows:
+//   "lua_table": {"table": []} - defines a new lua table with values pickled
+//                                in the 'table' array
+//   "ref": 10491324            - references a previously-defined lua table
+//   "lua_class": "ClassName"   - indicates this Lua table is an object of a
+//                                specific class object registered by Lua
+//   "cpp_class": "ClassName"   - this object is a C++ userdata of a specific
+//                                class registered by C++ of the same name
 
 // on serialize, if an item has a metatable with a "class" attribute, the
 // "Serialize" function under that namespace will be called with the type. the
@@ -50,285 +49,6 @@
 // on deserialize, the data after an "object" item will be passed to the
 // "Deserialize" function under that namespace. that data returned will be
 // given back to the module
-
-/*
-void LuaSerializer::pickle(lua_State *l, int to_serialize, std::string &out, std::string key)
-{
-	PROFILE_SCOPED()
-	static char buf[256];
-
-	LUA_DEBUG_START(l);
-
-	// tables are pickled recursively, so we can run out of Lua stack space if we're not careful
-	// start by ensuring we have enough (this grows the stack if necessary)
-	// (20 is somewhat arbitrary)
-	if (!lua_checkstack(l, 20))
-		luaL_error(l, "The Lua stack couldn't be extended (out of memory?)");
-
-	to_serialize = lua_absindex(l, to_serialize);
-	int idx = to_serialize;
-
-	if (lua_getmetatable(l, idx)) {
-		lua_getfield(l, -1, "class");
-		if (lua_isnil(l, -1))
-			lua_pop(l, 2);
-
-		else {
-			const char *cl = lua_tostring(l, -1);
-			snprintf(buf, sizeof(buf), "o%s\n", cl);
-
-			lua_getfield(l, LUA_REGISTRYINDEX, "PiSerializerClasses");
-
-			lua_getfield(l, -1, cl);
-			if (lua_isnil(l, -1))
-				luaL_error(l, "No Serialize method found for class '%s'\n", cl);
-
-			lua_getfield(l, -1, "Serialize");
-			if (lua_isnil(l, -1))
-				luaL_error(l, "No Serialize method found for class '%s'\n", cl);
-
-			lua_pushvalue(l, idx);
-			pi_lua_protected_call(l, 1, 1);
-
-			idx = lua_gettop(l);
-
-			if (lua_isnil(l, idx)) {
-				lua_pop(l, 5);
-				LUA_DEBUG_END(l, 0);
-				return;
-			}
-
-			out += buf;
-		}
-	}
-
-	switch (lua_type(l, idx)) {
-	case LUA_TNIL:
-		break;
-
-	case LUA_TNUMBER: {
-		snprintf(buf, sizeof(buf), "f%g\n", lua_tonumber(l, idx));
-		out += buf;
-		break;
-	}
-
-	case LUA_TBOOLEAN: {
-		snprintf(buf, sizeof(buf), "b%d", lua_toboolean(l, idx) ? 1 : 0);
-		out += buf;
-		break;
-	}
-
-	case LUA_TSTRING: {
-		size_t len;
-		const char *str = lua_tolstring(l, idx, &len);
-		snprintf(buf, sizeof(buf), "s" SIZET_FMT "\n", len);
-		out += buf;
-		out.append(str, len);
-		break;
-	}
-
-	case LUA_TTABLE: {
-		lua_pushinteger(l, lua_Integer(lua_topointer(l, to_serialize))); // ptr
-
-		lua_getfield(l, LUA_REGISTRYINDEX, "PiSerializerTableRefs"); // ptr reftable
-		lua_pushvalue(l, -2); // ptr reftable ptr
-		lua_rawget(l, -2); // ptr reftable ???
-
-		if (!lua_isnil(l, -1)) {
-			out += "r";
-			pickle(l, -3, out, key);
-			lua_pop(l, 3); // [empty]
-		}
-
-		else {
-			out += "t";
-
-			lua_pushvalue(l, -3); // ptr reftable nil ptr
-			lua_pushvalue(l, to_serialize); // ptr reftable nil ptr table
-			lua_rawset(l, -4); // ptr reftable nil
-			pickle(l, -3, out, key);
-			lua_pop(l, 3); // [empty]
-
-			lua_pushvalue(l, idx);
-			lua_pushnil(l);
-			while (lua_next(l, -2)) {
-
-				lua_pushvalue(l, -2);
-				const char *k = lua_tostring(l, -1);
-				std::string new_key = key + "." + (k ? std::string(k) : "<" + std::string(lua_typename(l, lua_type(l, -1))) + ">");
-				lua_pop(l, 1);
-
-				// Copy the values to pickle, as they might be mutated by the pickling process.
-				pickle(l, -2, out, new_key);
-				pickle(l, -1, out, new_key);
-				lua_pop(l, 1);
-			}
-			lua_pop(l, 1);
-			out += "n";
-		}
-
-		break;
-	}
-
-	case LUA_TUSERDATA: {
-		out += "u";
-
-		LuaObjectBase *lo = static_cast<LuaObjectBase *>(lua_touserdata(l, idx));
-		void *o = lo->GetObject();
-		if (!o)
-			Error("Lua serializer '%s' tried to serialize an invalid '%s' object", key.c_str(), lo->GetType());
-
-		out += lo->Serialize();
-		break;
-	}
-
-	default:
-		Error("Lua serializer '%s' tried to serialize %s value", key.c_str(), lua_typename(l, lua_type(l, idx)));
-		break;
-	}
-
-	if (idx != lua_absindex(l, to_serialize)) // It means we called a transformation function on the data, so we clean it up.
-		lua_pop(l, 5);
-
-	LUA_DEBUG_END(l, 0);
-}
-*/
-
-/*
-const char *LuaSerializer::unpickle(lua_State *l, const char *pos)
-{
-	PROFILE_SCOPED()
-	LUA_DEBUG_START(l);
-
-	// tables are also unpickled recursively, so we can run out of Lua stack space if we're not careful
-	// start by ensuring we have enough (this grows the stack if necessary)
-	// (20 is somewhat arbitrary)
-	if (!lua_checkstack(l, 20))
-		luaL_error(l, "The Lua stack couldn't be extended (not enough memory?)");
-
-	char type = *pos++;
-
-	switch (type) {
-
-	case 'f': {
-		char *end;
-		double f = strtod(pos, &end);
-		if (pos == end) throw SavedGameCorruptException();
-		lua_pushnumber(l, f);
-		pos = end + 1; // skip newline
-		break;
-	}
-
-	case 'b': {
-		if (*pos != '0' && *pos != '1') throw SavedGameCorruptException();
-		lua_pushboolean(l, *pos == '1');
-		pos++;
-		break;
-	}
-
-	case 's': {
-		char *end;
-		int len = strtol(pos, const_cast<char **>(&end), 0);
-		if (pos == end) throw SavedGameCorruptException();
-		end++; // skip newline
-		lua_pushlstring(l, end, len);
-		pos = end + len;
-		break;
-	}
-
-	case 't': {
-		lua_newtable(l);
-
-		lua_getfield(l, LUA_REGISTRYINDEX, "PiSerializerTableRefs");
-		pos = unpickle(l, pos);
-		lua_pushvalue(l, -3);
-		lua_rawset(l, -3);
-		lua_pop(l, 1);
-
-		while (*pos != 'n') {
-			pos = unpickle(l, pos);
-			pos = unpickle(l, pos);
-			lua_rawset(l, -3);
-		}
-		pos++;
-
-		break;
-	}
-
-	case 'r': {
-		pos = unpickle(l, pos);
-
-		lua_getfield(l, LUA_REGISTRYINDEX, "PiSerializerTableRefs");
-		lua_pushvalue(l, -2);
-		lua_rawget(l, -2);
-
-		if (lua_isnil(l, -1))
-			throw SavedGameCorruptException();
-
-		lua_insert(l, -3);
-		lua_pop(l, 2);
-
-		break;
-	}
-
-	case 'u': {
-		const char *end;
-		if (!LuaObjectBase::Deserialize(pos, &end))
-			throw SavedGameCorruptException();
-		pos = end;
-		break;
-	}
-
-	case 'o': {
-		const char *end = strchr(pos, '\n');
-		if (!end) throw SavedGameCorruptException();
-		int len = end - pos;
-		end++; // skip newline
-
-		const char *cl = pos;
-
-		// unpickle the object, and insert it beneath the method table value
-		pos = unpickle(l, end);
-
-		// If it is a reference, don't run the unserializer. It has either
-		// already been run, or the data is still building (cyclic
-		// references will do that to you.)
-		if (*end != 'r') {
-			// get PiSerializerClasses[typename]
-			lua_getfield(l, LUA_REGISTRYINDEX, "PiSerializerClasses");
-			lua_pushlstring(l, cl, len);
-			lua_gettable(l, -2);
-			lua_remove(l, -2);
-
-			if (lua_isnil(l, -1)) {
-				lua_pop(l, 2);
-				break;
-			}
-
-			lua_getfield(l, -1, "Unserialize");
-			if (lua_isnil(l, -1)) {
-				lua_pushlstring(l, cl, len);
-				luaL_error(l, "No Unserialize method found for class '%s'\n", lua_tostring(l, -1));
-			}
-
-			lua_insert(l, -3);
-			lua_pop(l, 1);
-
-			pi_lua_protected_call(l, 1, 1);
-		}
-
-		break;
-	}
-
-	default:
-		throw SavedGameCorruptException();
-	}
-
-	LUA_DEBUG_END(l, 1);
-
-	return pos;
-}
-*/
 
 void LuaSerializer::pickle_json(lua_State *l, int to_serialize, Json &out, const std::string &key)
 {
@@ -679,12 +399,7 @@ void LuaSerializer::FromJson(const Json &jsonObj)
 		}
 		unpickle_json(l, value);
 	} else if (jsonObj.count("lua_modules")) {
-		/*
-		std::string pickled = JsonToBinStr(jsonObj["lua_modules"]);
-		const char *start = pickled.c_str();
-		const char *end = unpickle(l, start);
-		if (size_t(end - start) != pickled.length()) throw SavedGameCorruptException();
-		*/
+		// old text-based serialization
 		throw SavedGameCorruptException();
 	} else {
 		throw SavedGameCorruptException();

--- a/src/lua/LuaSerializer.h
+++ b/src/lua/LuaSerializer.h
@@ -25,9 +25,6 @@ private:
 	static int l_register(lua_State *l);
 	static int l_register_class(lua_State *l);
 
-	static void pickle(lua_State *l, int idx, std::string &out, std::string key = "");
-	static const char *unpickle(lua_State *l, const char *pos);
-
 	static void pickle_json(lua_State *l, int idx, Json &out, const std::string &key = "");
 	static void unpickle_json(lua_State *l, const Json &value);
 };

--- a/src/lua/LuaSystemPath.cpp
+++ b/src/lua/LuaSystemPath.cpp
@@ -577,6 +577,7 @@ static int l_sbodypath_meta_tostring(lua_State *l)
 	return 1;
 }
 
+/*
 static std::string _systempath_serializer(LuaWrappable *o)
 {
 	static char buf[256];
@@ -619,19 +620,23 @@ static bool _systempath_deserializer(const char *pos, const char **next)
 
 	return true;
 }
+*/
 
-static void _systempath_to_json(Json &out, LuaWrappable *o)
+static bool _systempath_to_json(lua_State *l, Json &out)
 {
-	SystemPath *p = static_cast<SystemPath *>(o);
+	auto *p = LuaObject<SystemPath>::GetFromLua(-1);
+	if (!p) return false;
+
 	out = Json::array();
 	out[0] = Json(p->sectorX);
 	out[1] = Json(p->sectorY);
 	out[2] = Json(p->sectorZ);
 	out[3] = Json(p->systemIndex);
 	out[4] = Json(p->bodyIndex);
+	return true;
 }
 
-static bool _systempath_from_json(const Json &obj)
+static bool _systempath_from_json(lua_State *l, const Json &obj)
 {
 	if (!obj.is_array()) return false;
 	if (obj.size() < 3 || obj.size() > 5) return false;
@@ -697,5 +702,5 @@ void LuaObject<SystemPath>::RegisterClass()
 	};
 
 	LuaObjectBase::CreateClass(s_type, 0, l_methods, l_attrs, l_meta);
-	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_systempath_serializer, _systempath_deserializer, _systempath_to_json, _systempath_from_json));
+	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_systempath_to_json, _systempath_from_json));
 }

--- a/src/lua/LuaSystemPath.cpp
+++ b/src/lua/LuaSystemPath.cpp
@@ -577,51 +577,6 @@ static int l_sbodypath_meta_tostring(lua_State *l)
 	return 1;
 }
 
-/*
-static std::string _systempath_serializer(LuaWrappable *o)
-{
-	static char buf[256];
-
-	SystemPath *sbp = static_cast<SystemPath *>(o);
-	snprintf(buf, sizeof(buf), "%d\n%d\n%d\n%u\n%u\n",
-		sbp->sectorX, sbp->sectorY, sbp->sectorZ, sbp->systemIndex, sbp->bodyIndex);
-
-	return std::string(buf);
-}
-
-static bool _systempath_deserializer(const char *pos, const char **next)
-{
-	const char *end;
-
-	Sint32 sectorX = strtol(pos, const_cast<char **>(&end), 0);
-	if (pos == end) return false;
-	pos = end + 1; // skip newline
-
-	Sint32 sectorY = strtol(pos, const_cast<char **>(&end), 0);
-	if (pos == end) return false;
-	pos = end + 1; // skip newline
-
-	Sint32 sectorZ = strtol(pos, const_cast<char **>(&end), 0);
-	if (pos == end) return false;
-	pos = end + 1; // skip newline
-
-	Uint32 systemNum = strtoul(pos, const_cast<char **>(&end), 0);
-	if (pos == end) return false;
-	pos = end + 1; // skip newline
-
-	Uint32 sbodyId = strtoul(pos, const_cast<char **>(&end), 0);
-	if (pos == end) return false;
-	pos = end + 1; // skip newline
-
-	const SystemPath sbp(sectorX, sectorY, sectorZ, systemNum, sbodyId);
-	LuaObject<SystemPath>::PushToLua(sbp);
-
-	*next = pos;
-
-	return true;
-}
-*/
-
 static bool _systempath_to_json(lua_State *l, Json &out)
 {
 	auto *p = LuaObject<SystemPath>::GetFromLua(-1);

--- a/src/scenegraph/LuaModelSkin.cpp
+++ b/src/scenegraph/LuaModelSkin.cpp
@@ -92,6 +92,7 @@ namespace SceneGraph {
 
 } // namespace SceneGraph
 
+/*
 static std::string _modelskin_serializer(LuaWrappable *o)
 {
 	static char buf[256];
@@ -126,14 +127,18 @@ static bool _modelskin_deserializer(const char *pos, const char **next)
 
 	return true;
 }
+*/
 
-static void _modelskin_to_json(Json &out, LuaWrappable *o)
+static bool _modelskin_to_json(lua_State *l, Json &out)
 {
-	SceneGraph::ModelSkin *skin = static_cast<SceneGraph::ModelSkin *>(o);
+	auto *skin = LuaObject<SceneGraph::ModelSkin>::GetFromLua(-1);
+	if (!skin) return false;
+
 	skin->SaveToJson(out);
+	return true;
 }
 
-static bool _modelskin_from_json(const Json &obj)
+static bool _modelskin_from_json(lua_State *l, const Json &obj)
 {
 	SceneGraph::ModelSkin skin;
 	skin.LoadFromJson(obj);
@@ -161,5 +166,5 @@ void LuaObject<SceneGraph::ModelSkin>::RegisterClass()
 	};
 
 	LuaObjectBase::CreateClass(s_type, 0, l_methods, 0, 0);
-	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_modelskin_serializer, _modelskin_deserializer, _modelskin_to_json, _modelskin_from_json));
+	LuaObjectBase::RegisterSerializer(s_type, SerializerPair(_modelskin_to_json, _modelskin_from_json));
 }

--- a/src/scenegraph/LuaModelSkin.cpp
+++ b/src/scenegraph/LuaModelSkin.cpp
@@ -92,43 +92,6 @@ namespace SceneGraph {
 
 } // namespace SceneGraph
 
-/*
-static std::string _modelskin_serializer(LuaWrappable *o)
-{
-	static char buf[256];
-
-	SceneGraph::ModelSkin *skin = static_cast<SceneGraph::ModelSkin *>(o);
-
-	Serializer::Writer wr;
-	skin->Save(wr);
-	const std::string &ser = wr.GetData();
-	snprintf(buf, sizeof(buf), SIZET_FMT "\n", ser.size());
-
-	return std::string(buf) + ser;
-}
-
-static bool _modelskin_deserializer(const char *pos, const char **next)
-{
-	const char *end;
-
-	Uint32 serlen = strtoul(pos, const_cast<char **>(&end), 0);
-	if (pos == end) return false;
-	pos = end + 1; // skip newline
-
-	std::string buf(pos, serlen);
-	const char *bufp = buf.c_str();
-	Serializer::Reader rd(ByteRange(bufp, bufp + buf.size()));
-	SceneGraph::ModelSkin skin;
-	skin.Load(rd);
-
-	LuaObject<SceneGraph::ModelSkin>::PushToLua(skin);
-
-	*next = pos + serlen;
-
-	return true;
-}
-*/
-
 static bool _modelskin_to_json(lua_State *l, Json &out)
 {
 	auto *skin = LuaObject<SceneGraph::ModelSkin>::GetFromLua(-1);


### PR DESCRIPTION
This PR removes the old text-based Lua pickling and serialization entirely, and fixes a long-running bug where an attempt to serialize out a non-LuaWrappable userdata object was impossible and would cause a segfault. Now, object serialization operates in a type-erased fashion, allowing userdata objects of all sorts to be serialized to Json from a Lua context with only a single function call to register the serialization hooks.

This PR also includes several major improvements to the LuaMetaType framework for efficient Lua binding of C++ objects - now it supports binding generic C++ functions (like ImGui methods), as well as directly registering meta-methods in several different ways and first-class support for registering constructors. The internals of the binding framework have been slightly refactored as well to make them more readable and better communicate the use of the different wrapper function templates.

Additionally, LuaVector, LuaVector2, and LuaColor have been ported to the LuaMetaType binding system and serialization support has been added to each class.