### PR TITLE
Increase and limit the height of the BvhTree (for collision geoms)

### DIFF
--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -59,6 +59,7 @@ public:
 	BvhNode *m_nodesAlloc;
 	int m_nodesAllocPos;
 	int m_nodesAllocMax;
+	static constexpr int MAX_TREE_HEIGHT = 38;
 
 	BvhNode *AllocNode()
 	{
@@ -77,9 +78,10 @@ public:
 	void CollideGeom(Geom *, const Aabb &, int minMailboxValue, void (*callback)(CollisionContact *));
 
 private:
-	void BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &outGeomPos);
+	void BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &outGeomPos, int maxHeight);
 
-	void FreeAll() {
+	void FreeAll()
+	{
 		if (m_geoms) delete[] m_geoms;
 		m_geoms = nullptr;
 		if (m_nodesAlloc) delete[] m_nodesAlloc;
@@ -103,7 +105,7 @@ BvhTree::BvhTree(const std::list<Geom *> &geoms)
 	m_nodesAllocMax = numGeoms * 2;
 	m_nodesAlloc = new BvhNode[m_nodesAllocMax];
 	m_root = AllocNode();
-	BuildNode(m_root, geoms, geomPos);
+	BuildNode(m_root, geoms, geomPos, MAX_TREE_HEIGHT);
 	assert(geomPos == numGeoms);
 }
 
@@ -119,7 +121,7 @@ void BvhTree::Refresh(const std::list<Geom *> &geoms)
 	int geomPos = 0;
 	m_nodesAllocPos = 0;
 	m_root = AllocNode();
-	BuildNode(m_root, geoms, geomPos);
+	BuildNode(m_root, geoms, geomPos, MAX_TREE_HEIGHT);
 	assert(geomPos == numGeoms);
 }
 
@@ -133,7 +135,7 @@ void BvhTree::CollideGeom(Geom *g, const Aabb &geomAabb, int minMailboxValue, vo
 	double radius = g->GetGeomTree()->GetRadius();
 
 	int stackPos = -1;
-	BvhNode *stack[16];
+	BvhNode *stack[MAX_TREE_HEIGHT];
 	BvhNode *node = m_root;
 
 	for (;;) {
@@ -163,7 +165,7 @@ void BvhTree::CollideGeom(Geom *g, const Aabb &geomAabb, int minMailboxValue, vo
 	}
 }
 
-void BvhTree::BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &outGeomPos)
+void BvhTree::BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &outGeomPos, int maxHeight)
 {
 	PROFILE_SCOPED()
 	const int numGeoms = a_geoms.size();
@@ -207,8 +209,8 @@ void BvhTree::BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &ou
 	node->numGeoms = numGeoms;
 	node->aabb = aabb;
 
-	// side 1 has all nodes. just make a fucking child
-	if ((side[0].size() == 0) || (side[1].size() == 0)) {
+	// one side has all nodes, or we have reached the maximum tree height - just make a fucking child
+	if ((side[0].size() == 0) || (side[1].size() == 0) || maxHeight == 0) {
 		node->geomStart = &m_geoms[outGeomPos];
 
 		// copy geoms to the stinking flat array
@@ -222,8 +224,8 @@ void BvhTree::BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &ou
 		node->kids[0] = AllocNode();
 		node->kids[1] = AllocNode();
 
-		BuildNode(node->kids[0], side[0], outGeomPos);
-		BuildNode(node->kids[1], side[1], outGeomPos);
+		BuildNode(node->kids[0], side[0], outGeomPos, maxHeight - 1);
+		BuildNode(node->kids[1], side[1], outGeomPos, maxHeight - 1);
 	}
 }
 
@@ -311,7 +313,7 @@ void CollisionSpace::TraceRay(const vector3d &start, const vector3d &dir, double
 	vector3d invDir(1.0 / dir.x, 1.0 / dir.y, 1.0 / dir.z);
 	c->distance = len;
 
-	BvhNode *vn_stack[16];
+	BvhNode *vn_stack[BvhTree::MAX_TREE_HEIGHT];
 	BvhNode *node = m_staticObjectTree->m_root;
 	int stackPos = -1;
 
@@ -448,8 +450,10 @@ void CollisionSpace::RebuildObjectTrees()
 		m_dynamicObjectTree = new BvhTree(m_geoms);
 	} else {
 		// Same number or less (no needs for more memory)
-		if (m_dynamicObjectTree) m_dynamicObjectTree->Refresh(m_geoms);
-		else m_dynamicObjectTree = new BvhTree(m_geoms);
+		if (m_dynamicObjectTree)
+			m_dynamicObjectTree->Refresh(m_geoms);
+		else
+			m_dynamicObjectTree = new BvhTree(m_geoms);
 	}
 
 	m_oldGeomsNumber = m_geoms.size();

--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -59,6 +59,9 @@ public:
 	BvhNode *m_nodesAlloc;
 	int m_nodesAllocPos;
 	int m_nodesAllocMax;
+	// tree height at best log2(n), at worst n (n is the number of objects in the tree)
+	// it seems that the height of that tree never exceeds 20
+	// also TREE HEIGHT - THREE EIGHT, neat
 	static constexpr int MAX_TREE_HEIGHT = 38;
 
 	BvhNode *AllocNode()
@@ -210,7 +213,7 @@ void BvhTree::BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &ou
 	node->aabb = aabb;
 
 	// one side has all nodes, or we have reached the maximum tree height - just make a fucking child
-	if ((side[0].size() == 0) || (side[1].size() == 0) || maxHeight == 0) {
+	if (side[0].size() == 0 || side[1].size() == 0 || maxHeight == 0) {
 		node->geomStart = &m_geoms[outGeomPos];
 
 		// copy geoms to the stinking flat array


### PR DESCRIPTION
The height of that tree can fluctuate very much, starting from log2(n) and ending with n (n is the number of objects in space).

When traversing the tree, an array (for the stack) is used, the size of which is fixed, because we do not want dynamic allocations in this case, but must be at least the height of the tree.

We can limit the height of the tree, since a leaf can contain multiple objects.

It seems the height of the tree in the game almost never exceed 20.

So I took the number 38 (with a margin), it seems almost never the height of the tree will be limited, and at the same time we are insured against UB in all cases.

Fixes #5245 

ADD:

I would like to add that I checked the program's work with the height limit of 5, everything seems to work stably, while the tree height (excluding the root) does not exceed 5, and the value of the 'stack' array index does not overflow.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

