### PR TITLE
make jump time depend on equipment

### DIFF
--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -207,7 +207,9 @@ end
 function HyperdriveType:GetDuration(ship, distance, range_max)
 	range_max = range_max or self:GetMaximumRange(ship)
 	local hyperclass = self.capabilities.hyperclass
-	return 0.36*distance^2/(range_max*hyperclass) * (86400*math.sqrt(ship.staticMass + ship.fuelMassLeft))
+	local timefactor = self.capabilities.timefactor
+	-- staticMass + fuelMassLeft == hull + cargo + remaining fuel (ships total mass)
+	return timefactor*distance^2/(range_max*hyperclass) * (86400*math.sqrt(ship.staticMass + ship.fuelMassLeft))
 end
 
 -- range_max is optional, distance defaults to the maximal range.

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -192,78 +192,80 @@ misc.planetscanner = BodyScannerType.New({
 -- timefactor: used in jump duration calculations	- lower is better
 -- 		civilian drives default: 0.36
 --		military drives default: 0.28 (22.2% less jump duration)
+local base_timefactor = 0.36
+local military_timefactor = 0.28
 
 hyperspace.hyperdrive_1 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS1", fuel=cargo.hydrogen, slots="engine",
-	price=700, capabilities={mass=4, hyperclass=1, timefactor=0.36}, purchasable=true, tech_level=3,
+	price=700, capabilities={mass=4, hyperclass=1, timefactor=base_timefactor}, purchasable=true, tech_level=3,
 })
 hyperspace.hyperdrive_2 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS2", fuel=cargo.hydrogen, slots="engine",
-	price=1300, capabilities={mass=10, hyperclass=2, timefactor=0.36}, purchasable=true, tech_level=4,
+	price=1300, capabilities={mass=10, hyperclass=2, timefactor=base_timefactor}, purchasable=true, tech_level=4,
 })
 hyperspace.hyperdrive_3 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS3", fuel=cargo.hydrogen, slots="engine",
-	price=2500, capabilities={mass=20, hyperclass=3, timefactor=0.36}, purchasable=true, tech_level=4,
+	price=2500, capabilities={mass=20, hyperclass=3, timefactor=base_timefactor}, purchasable=true, tech_level=4,
 })
 hyperspace.hyperdrive_4 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS4", fuel=cargo.hydrogen, slots="engine",
-	price=5000, capabilities={mass=40, hyperclass=4, timefactor=0.36}, purchasable=true, tech_level=5,
+	price=5000, capabilities={mass=40, hyperclass=4, timefactor=base_timefactor}, purchasable=true, tech_level=5,
 })
 hyperspace.hyperdrive_5 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS5", fuel=cargo.hydrogen, slots="engine",
-	price=10000, capabilities={mass=120, hyperclass=5, timefactor=0.36}, purchasable=true, tech_level=5,
+	price=10000, capabilities={mass=120, hyperclass=5, timefactor=base_timefactor}, purchasable=true, tech_level=5,
 })
 hyperspace.hyperdrive_6 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS6", fuel=cargo.hydrogen, slots="engine",
-	price=20000, capabilities={mass=225, hyperclass=6, timefactor=0.36}, purchasable=true, tech_level=6,
+	price=20000, capabilities={mass=225, hyperclass=6, timefactor=base_timefactor}, purchasable=true, tech_level=6,
 })
 hyperspace.hyperdrive_7 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS7", fuel=cargo.hydrogen, slots="engine",
-	price=30000, capabilities={mass=400, hyperclass=7, timefactor=0.36}, purchasable=true, tech_level=8,
+	price=30000, capabilities={mass=400, hyperclass=7, timefactor=base_timefactor}, purchasable=true, tech_level=8,
 })
 hyperspace.hyperdrive_8 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS8", fuel=cargo.hydrogen, slots="engine",
-	price=60000, capabilities={mass=580, hyperclass=8, timefactor=0.36}, purchasable=true, tech_level=9,
+	price=60000, capabilities={mass=580, hyperclass=8, timefactor=base_timefactor}, purchasable=true, tech_level=9,
 })
 hyperspace.hyperdrive_9 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS9", fuel=cargo.hydrogen, slots="engine",
-	price=120000, capabilities={mass=740, hyperclass=9, timefactor=0.36}, purchasable=true, tech_level=10,
+	price=120000, capabilities={mass=740, hyperclass=9, timefactor=base_timefactor}, purchasable=true, tech_level=10,
 })
 hyperspace.hyperdrive_mil1 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL1", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=23000, capabilities={mass=3, hyperclass=1, timefactor=0.28}, purchasable=true, tech_level=10,
+	price=23000, capabilities={mass=3, hyperclass=1, timefactor=military_timefactor}, purchasable=true, tech_level=10,
 })
 hyperspace.hyperdrive_mil2 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL2", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=47000, capabilities={mass=8, hyperclass=2, timefactor=0.28}, purchasable=true, tech_level="MILITARY",
+	price=47000, capabilities={mass=8, hyperclass=2, timefactor=military_timefactor}, purchasable=true, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil3 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL3", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=85000, capabilities={mass=16, hyperclass=3, timefactor=0.28}, purchasable=true, tech_level=11,
+	price=85000, capabilities={mass=16, hyperclass=3, timefactor=military_timefactor}, purchasable=true, tech_level=11,
 })
 hyperspace.hyperdrive_mil4 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL4", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=214000, capabilities={mass=30, hyperclass=4, timefactor=0.28}, purchasable=true, tech_level=12,
+	price=214000, capabilities={mass=30, hyperclass=4, timefactor=military_timefactor}, purchasable=true, tech_level=12,
 })
 hyperspace.hyperdrive_mil5 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL5", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=540000, capabilities={mass=53, hyperclass=5, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
+	price=540000, capabilities={mass=53, hyperclass=5, timefactor=military_timefactor}, purchasable=false, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil6 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL6", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=1350000, capabilities={mass=78, hyperclass=6, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
+	price=1350000, capabilities={mass=78, hyperclass=6, timefactor=military_timefactor}, purchasable=false, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil7 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL7", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=3500000, capabilities={mass=128, hyperclass=7, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
+	price=3500000, capabilities={mass=128, hyperclass=7, timefactor=military_timefactor}, purchasable=false, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil8 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL8", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=8500000, capabilities={mass=196, hyperclass=8, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
+	price=8500000, capabilities={mass=196, hyperclass=8, timefactor=military_timefactor}, purchasable=false, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil9 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL9", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=22000000, capabilities={mass=285, hyperclass=9, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
+	price=22000000, capabilities={mass=285, hyperclass=9, timefactor=military_timefactor}, purchasable=false, tech_level="MILITARY",
 })
 
 laser.pulsecannon_1mw = LaserType.New({

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -186,77 +186,84 @@ misc.planetscanner = BodyScannerType.New({
 	bodyscanner_stats={scan_speed=3, scan_tolerance=0.05}
 })
 
+-- hyperdrive capabilities:
+--       mass: weight in tonnes						- lower is better
+-- hyperclass: used in hyperspace jump calculations - higher is better
+-- timefactor: used in jump duration calculations	- lower is better
+-- 		civilian drives default: 0.36
+--		military drives default: 0.28 (22.2% less jump duration)
+
 hyperspace.hyperdrive_1 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS1", fuel=cargo.hydrogen, slots="engine",
-	price=700, capabilities={mass=4, hyperclass=1}, purchasable=true, tech_level=3,
+	price=700, capabilities={mass=4, hyperclass=1, timefactor=0.36}, purchasable=true, tech_level=3,
 })
 hyperspace.hyperdrive_2 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS2", fuel=cargo.hydrogen, slots="engine",
-	price=1300, capabilities={mass=10, hyperclass=2}, purchasable=true, tech_level=4,
+	price=1300, capabilities={mass=10, hyperclass=2, timefactor=0.36}, purchasable=true, tech_level=4,
 })
 hyperspace.hyperdrive_3 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS3", fuel=cargo.hydrogen, slots="engine",
-	price=2500, capabilities={mass=20, hyperclass=3}, purchasable=true, tech_level=4,
+	price=2500, capabilities={mass=20, hyperclass=3, timefactor=0.36}, purchasable=true, tech_level=4,
 })
 hyperspace.hyperdrive_4 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS4", fuel=cargo.hydrogen, slots="engine",
-	price=5000, capabilities={mass=40, hyperclass=4}, purchasable=true, tech_level=5,
+	price=5000, capabilities={mass=40, hyperclass=4, timefactor=0.36}, purchasable=true, tech_level=5,
 })
 hyperspace.hyperdrive_5 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS5", fuel=cargo.hydrogen, slots="engine",
-	price=10000, capabilities={mass=120, hyperclass=5}, purchasable=true, tech_level=5,
+	price=10000, capabilities={mass=120, hyperclass=5, timefactor=0.36}, purchasable=true, tech_level=5,
 })
 hyperspace.hyperdrive_6 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS6", fuel=cargo.hydrogen, slots="engine",
-	price=20000, capabilities={mass=225, hyperclass=6}, purchasable=true, tech_level=6,
+	price=20000, capabilities={mass=225, hyperclass=6, timefactor=0.36}, purchasable=true, tech_level=6,
 })
 hyperspace.hyperdrive_7 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS7", fuel=cargo.hydrogen, slots="engine",
-	price=30000, capabilities={mass=400, hyperclass=7}, purchasable=true, tech_level=8,
+	price=30000, capabilities={mass=400, hyperclass=7, timefactor=0.36}, purchasable=true, tech_level=8,
 })
 hyperspace.hyperdrive_8 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS8", fuel=cargo.hydrogen, slots="engine",
-	price=60000, capabilities={mass=580, hyperclass=8}, purchasable=true, tech_level=9,
+	price=60000, capabilities={mass=580, hyperclass=8, timefactor=0.36}, purchasable=true, tech_level=9,
 })
 hyperspace.hyperdrive_9 = HyperdriveType.New({
 	l10n_key="DRIVE_CLASS9", fuel=cargo.hydrogen, slots="engine",
-	price=120000, capabilities={mass=740, hyperclass=9}, purchasable=true, tech_level=10,
+	price=120000, capabilities={mass=740, hyperclass=9, timefactor=0.36}, purchasable=true, tech_level=10,
 })
 hyperspace.hyperdrive_mil1 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL1", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=23000, capabilities={mass=3, hyperclass=1}, purchasable=true, tech_level=10,
+	price=23000, capabilities={mass=3, hyperclass=1, timefactor=0.28}, purchasable=true, tech_level=10,
 })
 hyperspace.hyperdrive_mil2 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL2", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=47000, capabilities={mass=8, hyperclass=2}, purchasable=true, tech_level="MILITARY",
+	price=47000, capabilities={mass=8, hyperclass=2, timefactor=0.28}, purchasable=true, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil3 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL3", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=85000, capabilities={mass=16, hyperclass=3}, purchasable=true, tech_level=11,
+	price=85000, capabilities={mass=16, hyperclass=3, timefactor=0.28}, purchasable=true, tech_level=11,
 })
 hyperspace.hyperdrive_mil4 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL4", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=214000, capabilities={mass=30, hyperclass=4}, purchasable=true, tech_level=12,
+	price=214000, capabilities={mass=30, hyperclass=4, timefactor=0.28}, purchasable=true, tech_level=12,
 })
 hyperspace.hyperdrive_mil5 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL5", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=540000, capabilities={mass=53, hyperclass=5}, purchasable=false, tech_level="MILITARY",
+	price=540000, capabilities={mass=53, hyperclass=5, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil6 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL6", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=1350000, capabilities={mass=78, hyperclass=6}, purchasable=false, tech_level="MILITARY",
+	price=1350000, capabilities={mass=78, hyperclass=6, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil7 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL7", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=3500000, capabilities={mass=128, hyperclass=7}, purchasable=false, tech_level="MILITARY",
+	price=3500000, capabilities={mass=128, hyperclass=7, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil8 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL8", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=8500000, capabilities={mass=196, hyperclass=8}, purchasable=false, tech_level="MILITARY",
+	price=8500000, capabilities={mass=196, hyperclass=8, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
 })
 hyperspace.hyperdrive_mil9 = HyperdriveType.New({
 	l10n_key="DRIVE_MIL9", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
-	price=22000000, capabilities={mass=285, hyperclass=9}, purchasable=false, tech_level="MILITARY",
+	price=22000000, capabilities={mass=285, hyperclass=9, timefactor=0.28}, purchasable=false, tech_level="MILITARY",
 })
 
 laser.pulsecannon_1mw = LaserType.New({


### PR DESCRIPTION
preserves jump time for all existing civilian drives but reduces jump duration by 22% for military drives

allows for jump times to be tweaked on a per-drive basis

