### PR TITLE
Commsfixes

### DIFF
--- a/data/pigui/modules/comms.lua
+++ b/data/pigui/modules/comms.lua
@@ -53,7 +53,7 @@ local function displayCommsLog()
 										ui.setNextWindowSize(aux , "Always")
 										aux = Vector2(mainButtonSize.x + 2 * mainButtonFramePadding + 15, 10)
 										ui.setNextWindowPos(aux , "Always")
-										ui.window("ShortCommsLog", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"},
+										ui.window("ShortCommsLog", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoScrollbar"},
 															function()
 																local last = nil
 																local rep = 0

--- a/data/pigui/modules/comms.lua
+++ b/data/pigui/modules/comms.lua
@@ -79,7 +79,7 @@ local function displayCommsLog()
 																	table.insert(lines, 1, { sender = last.sender, text = last.text .. ((rep > 1) and (' x ' .. rep) or ''), priority = last.priority })
 																end
 																ui.pushTextWrapPos(ui.screenWidth/4 - 20)
-																for k,v in pairs(utils.reverse(utils.take(lines, commsLinesToShow))) do
+																for k,v in pairs(utils.take(lines, commsLinesToShow)) do
 																	showItem(v)
 																end
 																ui.popTextWrapPos()
@@ -95,7 +95,7 @@ local function displayCommsLog()
 																			function()
 																				local lines = Game.GetCommsLines()
 																				ui.pushTextWrapPos(ui.screenWidth/3 - 20)
-																				for k,v in pairs(lines) do
+																				for k,v in pairs(utils.reverse(lines)) do
 																					showItem(v)
 																				end
 																				ui.popTextWrapPos()

--- a/data/pigui/modules/comms.lua
+++ b/data/pigui/modules/comms.lua
@@ -99,10 +99,6 @@ local function displayCommsLog()
 																					showItem(v)
 																				end
 																				ui.popTextWrapPos()
-																				-- if lastLength ~= #lines then
-																				-- 	ui.setScrollHereY()
-																				-- end
-																				-- lastLength = #lines
 														end)
 												end)
 										end)


### PR DESCRIPTION
Two commits concerning the comms terminal.
 
 * When new messages are pushed to the comms terminal they are eventually presented hidden after the old messages. Solved by showing the new messages on top. Pizzazz!
Fixes https://github.com/pioneerspacesim/pioneer/issues/4688

 * When the small window reaches its five maximum line a scrollbar appears to the right. Scrollbar removed.

Pictures of the comms log messages propagating top to bottom and with scrollbar with five messages.
![test123](https://user-images.githubusercontent.com/6368949/132110808-c117945a-cc82-46a1-b5bd-f0f9a44fe39f.png)
![scrollbar](https://user-images.githubusercontent.com/6368949/132110809-9fec8d5c-374d-411c-aecc-de54b25131f0.png)
