### PR TITLE
fix crash from selling when amount=0

### DIFF
--- a/data/modules/SoldOut/SoldOut.lua
+++ b/data/modules/SoldOut/SoldOut.lua
@@ -61,6 +61,7 @@ local onChat = function (form, ref, option)
 	if ad.amount == 0 then
 		form:RemoveAdvertOnClose()
 		ads[ref] = nil
+		form:Close()
 	end
 
 	return


### PR DESCRIPTION
Fixes #5251 by closing the form, so player can not sell when amount=0.

