### PR TITLE
Fixing Skipjack gun tag not having a _0 at the end

### DIFF
--- a/data/models/ships/skipjack/skipjack_hi.dae
+++ b/data/models/ships/skipjack/skipjack_hi.dae
@@ -900,7 +900,7 @@
       <node id="tag_camera_top" name="tag_camera_top" type="NODE">
         <matrix sid="transform">1 0 0 0 0 1 0 6.212425 0 0 1 2.093521 0 0 0 1</matrix>
       </node>
-      <node id="tag_gunmount" name="tag_gunmount" type="NODE">
+      <node id="tag_gunmount_0" name="tag_gunmount_0" type="NODE">
         <matrix sid="transform">1.071138 0 0 0.5465055 0 -4.68209e-8 1.071138 19.98892 0 -1.071138 -4.68209e-8 -0.7930407 0 0 0 1</matrix>
       </node>
       <node id="tag_camera_front" name="tag_camera_front" type="NODE">


### PR DESCRIPTION
Fixes #5177 
The gun tag was just `tag_gunmount` instead of `tag_gunmount_0`
The tag was picked up properly upon buying/switching ship, but would not work after a reload. The weapon sound is audible, but nothing fired. Which might be good to investigate though. This PR fixes the gun not firing after a reload.