### PR TITLE
Progressive trading

### DIFF
--- a/data/economy/commodities/agricultural.json
+++ b/data/economy/commodities/agricultural.json
@@ -5,37 +5,37 @@
 			"inputs": [ "farm_machinery", "fertilizer" ],
 			"consumable": true,
 			"producer": "agricultural",
-			"price": 105
+			"price": 675
 		},
 		"animal_meat": {
 			"l10n_key": "ANIMAL_MEAT",
 			"inputs": [ "farm_machinery", "fertilizer" ],
 			"producer": "agricultural",
-			"price": 125
+			"price": 847
 		},
 		"live_animals": {
 			"l10n_key": "LIVE_ANIMALS",
 			"inputs": [ "farm_machinery", "fertilizer" ],
 			"producer": "agricultural",
-			"price": 932
+			"price": 2111
 		},
 		"liquor": {
 			"l10n_key": "LIQUOR",
 			"inputs": [ "farm_machinery", "fertilizer" ],
 			"producer": "agricultural",
-			"price": 422
+			"price": 1337
 		},
 		"grain": {
 			"l10n_key": "GRAIN",
 			"inputs": [ "farm_machinery", "fertilizer" ],
 			"producer": "agricultural",
-			"price": 41
+			"price": 381
 		},
 		"slaves": {
 			"l10n_key": "SLAVES",
 			"inputs": [ ],
 			"producer": "agricultural",
-			"price": 1011,
+			"price": 2111,
 			"default_legality": [ 1, 16 ]
 		}
 	}

--- a/data/economy/commodities/high_tech.json
+++ b/data/economy/commodities/high_tech.json
@@ -5,44 +5,44 @@
 			"l10n_key": "MEDICINES",
 			"inputs": [ "computers", "carbon_ore" ],
 			"producer": "industrial",
-			"price": 563
+			"price": 1680
 		},
 		"computers": {
 			"l10n_key": "COMPUTERS",
 			"inputs": [ "precious_metals", "industrial_machinery" ],
 			"producer": "industrial",
-			"price": 461
+			"price": 1499
 		},
 		"robots": {
 			"l10n_key": "ROBOTS",
 			"inputs": [ "plastics", "computers" ],
 			"producer": "industrial",
-			"price": 829
+			"price": 1883
 		},
 		"industrial_machinery": {
 			"l10n_key": "INDUSTRIAL_MACHINERY",
 			"inputs": [ "metal_alloys", "robots" ],
 			"producer": "industrial",
-			"price": 124
+			"price": 756
 		},
 		"air_processors": {
 			"l10n_key": "AIR_PROCESSORS",
 			"inputs": [ "plastics", "industrial_machinery" ],
 			"producer": "industrial",
-			"price": 204
+			"price": 950
 		},
 		"battle_weapons": {
 			"l10n_key": "BATTLE_WEAPONS",
 			"inputs": [ "metal_alloys", "industrial_machinery" ],
 			"producer": "industrial",
-			"price": 607,
+			"price": 1680,
 			"default_legality": [ 1, 3 ]
 		},
 		"nerve_gas": {
 			"l10n_key": "NERVE_GAS",
 			"inputs": [ ],
 			"producer": "industrial",
-			"price": 813,
+			"price": 1883,
 			"default_legality": [ 1, 10 ]
 		}
 	}

--- a/data/economy/commodities/industrial.json
+++ b/data/economy/commodities/industrial.json
@@ -4,56 +4,57 @@
 			"l10n_key": "METAL_ALLOYS",
 			"inputs": [ "metal_ore", "industrial_machinery" ],
 			"producer": "industrial",
-			"price": 43
+			"price": 427
 		},
 		"plastics": {
 			"l10n_key": "PLASTICS",
 			"inputs": [ "carbon_ore", "industrial_machinery" ],
 			"producer": "industrial",
-			"price": 36
+			"price": 340
 		},
 		"textiles": {
 			"l10n_key": "TEXTILES",
 			"inputs": [ "plastics" ],
 			"producer": "industrial",
-			"price": 65
+			"price": 537
 		},
 		"fertilizer": {
 			"l10n_key": "FERTILIZER",
 			"inputs": [ "carbon_ore" ],
 			"producer": "industrial",
-			"price": 15
+			"price": 304
 		},
 		"consumer_goods": {
 			"l10n_key": "CONSUMER_GOODS",
 			"inputs": [ "plastics", "textiles" ],
 			"producer": "industrial",
-			"price": 246
+			"price": 1065
 		},
 		"farm_machinery": {
 			"l10n_key": "FARM_MACHINERY",
 			"inputs": [ "metal_alloys", "robots" ],
 			"producer": "industrial",
-			"price": 80
+			"price": 602
 		},
 		"mining_machinery": {
 			"l10n_key": "MINING_MACHINERY",
 			"inputs": [ "metal_alloys", "robots" ],
 			"producer": "industrial",
-			"price": 312
+			"price": 1193
+
 		},
 		"hand_weapons": {
 			"l10n_key": "HAND_WEAPONS",
 			"inputs": [ "metal_alloys", "computers" ],
 			"producer": "industrial",
-			"price": 251,
+			"price": 1065,
 			"default_legality": [ 1, 2 ]
 		},
 		"narcotics": {
 			"l10n_key": "NARCOTICS",
 			"inputs": [ ],
 			"producer": "industrial",
-			"price": 632,
+			"price": 1499,
 			"default_legality": [ 1, 2 ]
 		},
 		"military_fuel": {

--- a/data/economy/commodities/mining.json
+++ b/data/economy/commodities/mining.json
@@ -10,7 +10,7 @@
 			"l10n_key": "LIQUID_OXYGEN",
 			"inputs": [ "water", "industrial_machinery" ],
 			"producer": "mining",
-			"price": 9.8
+			"price": 271
 		},
 		"water": {
 			"l10n_key": "WATER",
@@ -22,19 +22,19 @@
 			"l10n_key": "CARBON_ORE",
 			"inputs": [ "mining_machinery" ],
 			"producer": "mining",
-			"price": 7
+			"price": 242
 		},
 		"metal_ore": {
 			"l10n_key": "METAL_ORE",
 			"inputs": [ "mining_machinery" ],
 			"producer": "mining",
-			"price": 43
+			"price": 479
 		},
 		"precious_metals": {
 			"l10n_key": "PRECIOUS_METALS",
 			"inputs": [ "mining_machinery" ],
 			"producer": "mining",
-			"price": 2180
+			"price": 2366
 		}
 	}
 }

--- a/data/libs/Calibration.lua
+++ b/data/libs/Calibration.lua
@@ -1,0 +1,118 @@
+-- Copyright © 2008-2021 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+--Profit as ratio of investment from Major export to minor import (estimated from the current economy)
+local p = 0.25
+
+--Average as ratio of nominal stock from Major export to minor import. See updateEquipmentStock function in SpaceStation.lua
+local v = 1.30
+
+--Maximum shift of stock from Major export to minor import. See updateEquipmentStock function in SpaceStation.lua
+local v2 = 1.80
+
+-- Definition of exponential
+-- of current 48th line of SpaceStation.lua by the free cargo of 2 ships and the willing ratio of their profits.
+-- Minimum free cargo for amphiesma is 12t. We have 16 ships and prefer them to increase their free cargo by constant ratio.
+-- Our largest ship is dsminer with 3021t free cargo. The ratio RVab of free cargo volumes of ship 'a' and his next ship 'b' should be such that RVab^16=3021/12
+local Nships = 16 --Number of ships we want to callibrate
+local Vmax = 3021 -- maximum free available cargo of largest ship
+local Vmin = 12 -- maximum free available cargo of smallest ship
+local RVab = (Vmax / Vmin)^(1/Nships)
+
+-- Ratio Rab of profits of 'a' and 'b' ships should be eye detectible by player. So, we want it above 1.20.
+-- As i wanted between 1.20 and 1.25, i chosed, in a try not to get too away from current price of precious metals, to define it as 1.225
+local Rab = 1.225
+
+-- The exponential of former line 48 of SpaceStation.lua calculated by two ratios of volume and profit
+local Exponential = function (RVolume, Rprofit)
+	return math.log(RVolume)/(math.log(RVolume)-math.log(Rprofit))
+end
+
+local minMissiles = 2 --number of missiles that corresponds to minmum trading profit. In other words number of missiles smalest ship can acquire.
+local maxMissiles = 24 --maximum number of missiles any ship can acquire. It should be get average reward about equal to the profit of the second in hierarchy trading ship.
+
+local Calibration
+Calibration = {
+	--StockPriceOne can variate to fine tune stock and prices. I prefer it constant so as to define prices from stock. See function updateEquipmentStock in SpaceStation.lua.
+	--On low prices rn are large integers that can not exceed much the 2*10^9 anyway.
+	StockPriceOne = 10^9,
+	PriceExponential = Exponential(RVab, Rab),
+	avgStock = v
+}
+
+-- THE MOST IMPORTANT FUNCTION OF CALIBRATION. Average maximum profit of a ship that can trade cargo tones of his specialization commoditiy.
+-- Once the initial and permanent settings for StockPriceOne and PriceExponential is taken, all future ships' profits and prices are defined according to them.
+Calibration.profit = function (cargo)
+	local a = Calibration.PriceExponential
+	local constant = Calibration.StockPriceOne
+	local coeff = (v2 * constant / cargo)^((1-a) / a)
+	local profitTo = p * v * coeff * constant
+	local profitFrom = p * v2 * coeff * constant / 2
+	return (profitTo + profitFrom) / 2
+end
+
+--Define the ratio of fighting rewards to minimum trading profit in linear way. Used in Assassination and Combat modules.
+Calibration.Fighting = function (missiles)
+	local ratio = Rab^(Nships - 1)
+	return math.max(1, (ratio - 1) / (maxMissiles - minMissiles) * missiles + 1 - 2 * (ratio - 1) / (maxMissiles - minMissiles))
+end
+
+-- The maximum profit of the base (smallest) ship.
+Calibration.minProfit = Calibration.profit(Vmin)
+
+--Nominal cash needed to trade all stock of a commodity depended on its nominal price.
+Calibration.InvestmentOfPrice = function (price)
+	return Calibration.StockPriceOne / price^(Calibration.PriceExponential - 1)
+end
+
+-- Adding prerequisite feature to ships in order to exclude them from function addRandomShipAdvert of SpaceStation.lua, if player is not their prequisite.
+-- Prerequisite is table for example prerequisites["Sinonatrix"] = {"Amphiesma", "Lunar Shuttle"}
+
+Calibration.prerequisite = function (pship,xship)
+	local prerequisites ={}
+	prerequisites["Lunar Shuttle"] = {"Amphiesma"}
+	prerequisites["Sinonatrix"] = {"Lunar Shuttle"}
+	prerequisites["Mola Mola"] = {"Sinonatrix"}
+	prerequisites["Natrix"] = {"Mola Mola"}
+	prerequisites["Skipjack"] = {"Natrix"}
+	prerequisites["Deneb"] = {"Skipjack"}
+	prerequisites["Bluenose"] = {"Deneb"}
+	prerequisites["AC-33 Dropstar"] = {"Bluenose"}
+	prerequisites["Mola Ramsayi"] = {"AC-33 Dropstar"}
+	prerequisites["Venturestar"] = {"Mola Ramsayi"}
+	prerequisites["Storeria"] = {"Venturestar"}
+	prerequisites["Malabar"] = {"Storeria"}
+	prerequisites["Nerodia"] = {"Malabar"}
+	prerequisites["Vatakara"] = {"Nerodia"}
+	prerequisites["Lodos"] = {"Vatakara"}
+
+	if not prerequisites[xship] then
+		return true
+	else
+		for i, p in pairs(prerequisites[xship]) do
+		if p == pship then
+				return true
+			end
+		end
+		return false
+	end
+end
+
+--------------------- Not used. Just helpfull -------------------------
+
+--Nominal cash needed to trade all stock of a commodity depended on its nominal stock.
+Calibration.InvestmentOfStock = function (stock)
+	return (Calibration.StockPriceOne / stock)^(1 / Calibration.PriceExponential) * stock
+end
+
+--Nominal price of best commodity for a ship with cargo tones free cargo to trade
+Calibration.BestCommodityPrice = function (cargo)
+	return (v2 * Calibration.StockPriceOne / cargo)^(1 / Calibration.PriceExponential)
+end
+
+--Price of 'next' ship depended on current ship's free cargo and value along with 'turns' (or standard units or station visits) needed to acquire it.
+Calibration.ShipPrice = function(currentShipPrice, currentCargo, turns)
+	return Calibration.profit(currentCargo) * turns + currentShipPrice / 2
+end
+
+return Calibration

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -291,8 +291,10 @@ end
 
 -- add num random ships for sale to station ShipMarket
 local function addRandomShipAdvert(station, num)
+	local playersShip = Game.player:GetShipType()
 	for i=1,num do
-		local avail = station.type == "STARPORT_SURFACE" and groundShips or spaceShips
+		local avail_0 = station.type == "STARPORT_SURFACE" and groundShips or spaceShips
+		local avail = utils.build_array(utils.filter(function (k,def) return (playersShip == def.name or Calibration.prerequisite(playersShip,def.name)) end, pairs(avail_0)))
 		local def = avail[Engine.rand:Integer(1,#avail)]
 		local model = Engine.GetModel(def.modelName)
 		local pattern = model.numPatterns ~= 0 and Engine.rand:Integer(1,model.numPatterns) or nil

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -16,8 +16,12 @@ local ModelSkin = require 'SceneGraph.ModelSkin'
 local Serializer = require 'Serializer'
 local Equipment = require 'Equipment'
 local Faction = require 'Faction'
+local Calibration = require 'Calibration'
 local Lang = require 'Lang'
 local l = Lang.GetResource("ui-core")
+
+local StockOne = Calibration.StockPriceOne
+local PriceExp = Calibration.PriceExponential
 
 --
 -- Class: SpaceStation
@@ -45,7 +49,7 @@ local function updateEquipmentStock (station)
 	local hydrogen = Equipment.cargo.hydrogen
 	for key, e in pairs(Equipment.cargo) do
 		if e.purchasable then
-			local rn = 100000 / math.abs(e.price) --have about 100,000 worth of stock, per commodity
+			local rn = math.min(StockOne / (math.abs(e.price))^PriceExp, 10^6)	--have less than 1,000,000 stock per commodity.
 			if e == hydrogen then
 				equipmentStock[station][e] = math.floor(rn/2 + Engine.rand:Integer(0,rn)) --always stock hydrogen
 			else

--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -17,6 +17,7 @@ local Equipment = require 'Equipment'
 local ShipDef = require 'ShipDef'
 local Ship = require 'Ship'
 local utils = require 'utils'
+local Calibration = require 'Calibration'
 
 local lc = Lang.GetResource 'core'
 local l = Lang.GetResource("module-assassination")
@@ -170,7 +171,16 @@ local makeAdvert = function (station)
 	local time = Engine.rand:Number(1, 4)
 	local due = Game.time + dist / max_ass_dist * time * 22*60*60*24 + Engine.rand:Number(7*60*60*24, 31*60*60*24)
 	local danger = Engine.rand:Integer(1,4)
-	local reward = Engine.rand:Number(2100, 7000) * danger
+
+	local tradeCargo = Game.player.totalCargo*0.81 --the rest 0.19 is used for fuel.
+	local rewardRatio = 3/4-- For getting that ratio of average effective trading profit
+
+	--- Fighters should have independed from cargo reward. For that we increase minimum reward depending on number of missiles that player can acquire.
+	local missiles = Game.player:GetEquipSlotCapacity("missile")
+	local minimumRewardRatio = math.max(rewardRatio, Calibration.Fighting(missiles))
+
+	local profit = math.max(Calibration.profit(tradeCargo) * rewardRatio, Calibration.minProfit * minimumRewardRatio)  
+	local reward = Engine.rand:Number(2100/8259 * profit, 7000/8259 * profit) * danger --8259 is the current estimated profit from assassination module.
 	reward = utils.round(reward, 500)
 
 	-- XXX hull mass is a bad way to determine suitability for role

--- a/data/modules/Combat/Combat.lua
+++ b/data/modules/Combat/Combat.lua
@@ -17,6 +17,7 @@ local Equipment = require 'Equipment'
 local ShipDef = require 'ShipDef'
 local Ship = require 'Ship'
 local utils = require 'utils'
+local Calibration = require 'Calibration'
 
 local l = Lang.GetResource("module-combat")
 local lc = Lang.GetResource 'core'
@@ -216,7 +217,17 @@ local makeAdvert = function (station)
 
 	location = flavour.planets[Engine.rand:Integer(1, #flavour.planets)]
 	dist = location:DistanceTo(Game.system)
+
+	local tradeCargo = Game.player.totalCargo*0.81 --the rest 0.19 is used for fuel.
+	local rewardRatio = 3/4-- For getting that ratio of average effective trading profit
+
+	--- Fighters should have increased reward. For that we increase minimum reward depending on number of missiles that player can acquire.
+	local missiles = Game.player:GetEquipSlotCapacity("missile")
+	local minimumRewardRatio = math.max(rewardRatio, Calibration.Fighting(missiles))
+
+	local profit = math.max(Calibration.profit(tradeCargo) * rewardRatio, Calibration.minProfit * minimumRewardRatio)
 	reward = math.ceil(dist * typical_reward * (1 + dedication)^2 * (1 + risk) * (1 + urgency) * Engine.rand:Number(0.8, 1.2))
+	reward = reward / 2300 * profit -- 2300 is the roughly estimated curent reward per standard unit
 	reward = utils.round(reward, 100)
 	due = Game.time + typical_travel_time * Engine.rand:Number(0.9, 1.1) + dist * typical_hyperspace_time * (1.5 - urgency) * Engine.rand:Number(0.9, 1.1)
 

--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -367,10 +367,10 @@ local onShipDocked = function (ship, station)
 
 			local newPrice, newStockChange
 			if n.demand > 0 then
-				newPrice = n.demand * price -- increase price
+				newPrice = (1.20 + 0.28 * n.demand) * price -- increase price :jimishol up to triple the price
 				newStockChange = -1 * stock -- remove all stock
 			elseif n.demand < 0 then
-				newPrice = math.ceil(price / (1 + math.abs(n.demand)))  -- dump price
+				newPrice = math.ceil(price / (1 + 0.20 * math.abs(n.demand)))  -- dump price :jimishol down to third of price
 				newStockChange = math.ceil(math.abs(n.demand * stock))  -- spam stock
 			else
 				error("demand should probably not be 0.")

--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -15,6 +15,7 @@ local ShipDef = require 'ShipDef'
 local Ship = require 'Ship'
 local eq = require 'Equipment'
 local utils = require 'utils'
+local Calibration = require 'Calibration'
 
 -- Get the language resource
 local l = Lang.GetResource("module-taxi")
@@ -254,7 +255,12 @@ local makeAdvert = function (station)
 	if #nearbysystems == 0 then return end
 	location = nearbysystems[Engine.rand:Integer(1,#nearbysystems)]
 	local dist = location:DistanceTo(Game.system)
-	reward = ((dist / max_taxi_dist) * typical_reward * (group / 2) * (1+risk) * (1+3*urgency) * Engine.rand:Number(0.8,1.2))
+
+        local cargo = Game.player.totalCargo * 0.81 --the rest 0.19 is used for fuel.
+	local rewardRatio = 2/3 -- For getting that ratio of current average trading profit
+        local profit = math.max(Calibration.profit(cargo) * rewardRatio, Calibration.minProfit * rewardRatio)
+
+	reward = ((dist / max_taxi_dist) * typical_reward * (group / 2) * (1+risk) * (1+3*urgency) * Engine.rand:Number(0.8,1.2)) * profit/5666 --5666 is the current estimated profit from taxi module.
 	reward = utils.round(reward, 50)
 	due = Game.time + ((dist / max_taxi_dist) * typical_travel_time * (1.5-urgency) * Engine.rand:Number(0.9,1.1))
 

--- a/data/ships/ac33.json
+++ b/data/ships/ac33.json
@@ -6,17 +6,17 @@
 	"ship_class": "medium_freighter",
 	"min_crew": 3,
 	"max_crew": 5,
-	"price": 1015644,
+	"price": 420475,
 	"hull_mass": 780,
 	"atmospheric_pressure_limit": 7.9,
-	"capacity": 920,
+	"capacity": 609,
 	"slots": {
 		"engine": 1,
 		"cabin": 50,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 26,
-		"cargo": 480
+		"cargo": 169
 	},
 	"roles": ["mercenary", "merchant", "pirate"],
 	

--- a/data/ships/amphiesma.json
+++ b/data/ships/amphiesma.json
@@ -6,7 +6,7 @@
 	"ship_class": "light_passenger_shuttle",
 	"min_crew": 1,
 	"max_crew": 2,
-	"price": 38470,
+	"price": 35002,
 	"hull_mass": 18,
 	"atmospheric_pressure_limit": 3.1,
 	"capacity": 38,

--- a/data/ships/bluenose.json
+++ b/data/ships/bluenose.json
@@ -6,17 +6,17 @@
 	"ship_class": "medium_freighter",
 	"min_crew": 2,
 	"max_crew": 3,
-	"price": 518244,
+	"price": 515460,
 	"hull_mass": 210,
 	"atmospheric_pressure_limit": 4.2,
-	"capacity": 600,
+	"capacity": 256,
 	"slots": {
 		"engine": 1,
 		"cabin": 20,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 2,
-		"cargo": 550
+		"cargo": 206
 	},
 	"roles": ["merchant", "pirate"],
 	

--- a/data/ships/deneb.json
+++ b/data/ships/deneb.json
@@ -6,17 +6,17 @@
 	"ship_class": "medium_freighter",
 	"min_crew": 2,
 	"max_crew": 3,
-	"price": 424104,
+	"price": 342628,
 	"hull_mass": 175,
 	"atmospheric_pressure_limit": 5.7,
-	"capacity": 430,
+	"capacity": 181,
 	"slots": {
 		"engine": 1,
 		"cabin": 50,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 2,
-		"cargo": 360
+		"cargo": 111
 	},
 	"roles": ["mercenary", "merchant", "pirate"],
 

--- a/data/ships/dsminer.json
+++ b/data/ships/dsminer.json
@@ -6,7 +6,7 @@
 	"ship_class": "heavy_freighter",
 	"min_crew": 5,
 	"max_crew": 12,
-	"price": 2676331,
+	"price": 4162951,
 	"hull_mass": 1380,
 	"atmospheric_pressure_limit": 2,
 	"capacity": 3900,

--- a/data/ships/lodos.json
+++ b/data/ships/lodos.json
@@ -6,17 +6,17 @@
 	"ship_class": "heavy_freighter",
 	"min_crew": 2,
 	"max_crew": 5,
-	"price": 2541351,
+	"price": 2134845,
 	"hull_mass": 850,
 	"atmospheric_pressure_limit": 3.2,
-	"capacity": 3100,
+	"capacity": 2583,
 	"slots": {
 		"engine": 1,
 		"cabin": 50,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 2,
-		"cargo": 2800
+		"cargo": 2283
 	},
 	"roles": ["merchant"],
 	

--- a/data/ships/lunarshuttle.json
+++ b/data/ships/lunarshuttle.json
@@ -6,16 +6,16 @@
 	"ship_class": "medium_passenger_shuttle",
 	"min_crew": 1,
 	"max_crew": 4,
-	"price": 35002,
+	"price": 91234,
 	"hull_mass": 30,
 	"atmospheric_pressure_limit": 3.5,
-	"capacity": 30,
+	"capacity": 25,
 	"slots": {
 		"engine": 1,
 		"cabin": 20,
 		"laser_front": 1,
 		"missile": 1,
-		"cargo": 30
+		"cargo": 25
 	},
 	"roles": ["mercenary", "merchant", "pirate", "courier"],
 		

--- a/data/ships/malabar.json
+++ b/data/ships/malabar.json
@@ -6,17 +6,17 @@
 	"ship_class": "heavy_passenger_transport",
 	"min_crew": 1,
 	"max_crew": 8,
-	"price": 2219852,
+	"price": 1161321,
 	"hull_mass": 940,
 	"atmospheric_pressure_limit": 4.7,
-	"capacity": 2600,
+	"capacity": 1837,
 	"slots": {
 		"engine": 1,
 		"cabin": 80,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 6,
-		"cargo": 1600
+		"cargo": 837
 	},
 	"roles": ["merchant"],
 	

--- a/data/ships/molamola.json
+++ b/data/ships/molamola.json
@@ -6,16 +6,16 @@
 	"ship_class": "light_freighter",
 	"min_crew": 1,
 	"max_crew": 3,
-	"price": 81062,
+	"price": 178616,
 	"hull_mass": 27,
 	"atmospheric_pressure_limit": 5.1,
-	"capacity": 84,
+	"capacity": 49,
 	"slots": {
 		"engine": 1,
 		"cabin": 8,
 		"laser_front": 1,
 		"missile": 2,
-		"cargo": 80
+		"cargo": 45
 	},
 	"roles": ["mercenary", "merchant", "pirate", "courier"],
 	

--- a/data/ships/molaramsayi.json
+++ b/data/ships/molaramsayi.json
@@ -6,17 +6,17 @@
 	"ship_class": "medium_freighter",
 	"min_crew": 1,
 	"max_crew": 5,
-	"price": 814200,
+	"price": 773838,
 	"hull_mass": 380,
 	"atmospheric_pressure_limit": 3.8,
-	"capacity": 950,
+	"capacity": 525,
 	"slots": {
 		"engine": 1,
 		"cabin": 60,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 3,
-		"cargo": 900
+		"cargo": 475
 	},
 	"roles": ["merchant"],
 

--- a/data/ships/natrix.json
+++ b/data/ships/natrix.json
@@ -6,17 +6,17 @@
 	"ship_class": "medium_freighter",
 	"min_crew": 1,
 	"max_crew": 3,
-	"price": 96181,
+	"price": 224849,
 	"hull_mass": 50,
 	"atmospheric_pressure_limit": 3.3,
-	"capacity": 84,
+	"capacity": 64,
 	"slots": {
 		"engine": 1,
 		"cabin": 25,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 2,
-		"cargo": 80
+		"cargo": 60
 	},
 	"roles": ["mercenary", "merchant", "pirate", "courier"],
 

--- a/data/ships/nerodia.json
+++ b/data/ships/nerodia.json
@@ -6,10 +6,10 @@
 	"ship_class": "medium_freighter",
 	"min_crew": 1,
 	"max_crew": 6,
-	"price": 2059371,
+	"price": 1422630,
 	"hull_mass": 450,
 	"atmospheric_pressure_limit": 3.7,
-	"capacity": 2700,
+	"capacity": 1716,
 	"slots": {
 		"engine": 1,
 		"cabin": 35,
@@ -17,7 +17,7 @@
 		"laser_rear": 1,
 		"missile": 2,
 		"atmo_shield": 0,
-		"cargo": 2500
+		"cargo": 1516
 	},
 	"roles": ["merchant"],
 	

--- a/data/ships/sinonatrix.json
+++ b/data/ships/sinonatrix.json
@@ -6,16 +6,16 @@
 	"ship_class": "light_courier",
 	"min_crew": 1,
 	"max_crew": 2,
-	"price": 62707,
+	"price": 135940,
 	"hull_mass": 28,
 	"atmospheric_pressure_limit": 3.2,
-	"capacity": 35,
+	"capacity": 39,
 	"slots": {
 		"engine": 1,
 		"cabin": 3,
 		"laser_front": 1,
 		"missile": 4,
-		"cargo": 30
+		"cargo": 34
 	},
 	"roles": ["mercenary", "merchant", "pirate", "courier"],
 

--- a/data/ships/skipjack.json
+++ b/data/ships/skipjack.json
@@ -6,10 +6,10 @@
 	"ship_class": "medium_courier",
 	"min_crew": 2,
 	"max_crew": 3,
-	"price": 204837,
+	"price": 278463,
 	"hull_mass": 80,
 	"atmospheric_pressure_limit": 4,
-	"capacity": 192,
+	"capacity": 136,
 	"slots": {
 		"engine": 1,
 		"cabin": 5,
@@ -17,7 +17,7 @@
 		"laser_front": 1,
 		"missile": 8,
 		"sensor": 1,
-		"cargo": 140
+		"cargo": 84
 	},
 	"roles": ["mercenary", "merchant", "pirate", "courier"],
 	

--- a/data/ships/storeria.json
+++ b/data/ships/storeria.json
@@ -6,17 +6,17 @@
 	"ship_class": "medium_freighter",
 	"min_crew": 1,
 	"max_crew": 5,
-	"price": 1219170,
+	"price": 947998,
 	"hull_mass": 500,
 	"atmospheric_pressure_limit": 3.2,
-	"capacity": 1650,
+	"capacity": 985,
 	"slots": {
 		"engine": 1,
 		"cabin": 30,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 1,
-		"cargo": 1500
+		"cargo": 835
 	},
 	"roles": ["merchant"],	
 	

--- a/data/ships/vatakara.json
+++ b/data/ships/vatakara.json
@@ -6,17 +6,17 @@
 	"ship_class": "heavy_freighter",
 	"min_crew": 1,
 	"max_crew": 8,
-	"price": 2655296,
+	"price": 1742728,
 	"hull_mass": 890,
 	"atmospheric_pressure_limit": 4.9,
-	"capacity": 3200,
+	"capacity": 2330,
 	"slots": {
 		"engine": 1,
 		"cabin": 10,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 6,
-		"cargo": 2900
+		"cargo": 2030
 	},
 	"roles": ["merchant"],
 	

--- a/data/ships/venturestar.json
+++ b/data/ships/venturestar.json
@@ -6,17 +6,17 @@
 	"ship_class": "medium_freighter",
 	"min_crew": 2,
 	"max_crew": 5,
-	"price": 1127263,
+	"price": 631627,
 	"hull_mass": 460,
 	"atmospheric_pressure_limit": 7.2,
-	"capacity": 1160,
+	"capacity": 584,
 	"slots": {
 		"engine": 1,
 		"cabin": 35,
 		"laser_front": 1,
 		"laser_rear": 1,
 		"missile": 6,
-		"cargo": 880
+		"cargo": 304
 	},
 	"roles": ["merchant"],	
 	


### PR DESCRIPTION
**Progressive trading. The power of denominator's power.**

**Introduction**
By adding an exponential in ‘rn’ of updateEquipmentStock function in SpaceStation.lua function, ships’ average maximum profit is defined. In order, that ship, to be able to earn that profit from trading a particular commodity, it must find it in stock that his maximum equals to ship’s free available cargo.  From that, the added exponential, defines the price of that particular commodity. In that manner, that exponential, as the ultimate constant of the economy of the pioneer game, potentially quantifies every aspect that is related to economy.

_Current state’s trading system is flat_ because of player’s dominating best strategy.
He finds a system that major exports the most expensive commodity and trade around it. He never has to alter commodity. He never has to alter system. He never has to alter his ship by a larger one, if his current ship is able to  trade about 144000 credits of that commodity. The only reason to do any of the above is because he is boring to repeat the same routes with the same ship and trade the same commodity. In the same time, he likes the screen images of game flights, wanting to continue playing it. However, the boring element should not be involved at all as an element of player’s strategy. _I cry this out from personal experience because I am a pure player that just try to improve his playing experience._

There is no reason for developers to spent their time and efforts to alter commodity prices (including that of precious metals), to alter ship or equipment prices, to seek for the best prices for them, to copy commodity prices from other games, to compare prices with other games, to try to lure players by undetectable by players raise of stock or prices by 1%, 2%, 5% or whatever. Nor to blame for their failures the large variation of stocks or the absence of export on some commodities, trying to decrease it. 
_The above dominating player’s strategy will be unbeatable in all cases._
Neither seems right to alter missions’ rewards to compensate the boring trading. Missions will either dominate or equalize trading profit, so missions, as less boring, will be preferred from trading  and that will erase effectively the trading activity from the game, or missions will be auxiliary to trading and will not help against the boring best strategy.
I analyzed many of that reasons in my pdf article at https://github.com/jimishol/Pioneerspacesim_trading_economy. Anyone wants to read it must keep focus on article’s main declaration, that **_the current code is enough to reveal the present, but hidden, relations between commodity prices and stock, ship profits and their prices._**
By the realization of the effects of adding the exponential, along with the relationships it reveals, the way is open for developers to fine adjust these relationships at will. There is no point to copy prices from other games. Neither other games will accomplish anything copying prices from pioneer. The source of success is not in prices. It is in the existence of the exponential and the relationships it reveals.

**All that the present PR aims to, is to add an exponential, different from 1, on the denominator of ‘rn’ at updateEquipmentStock function in SpaceStation.lua file.** 

In current state, where exponential equals to 1, the ‘rn’ definition line defines that the cash investment for trade is constant. Soon enough, ships have enough space to trade according to that constant and profit from all ships, farther up, is more or less constant. Those ships can not be distinguished from each other by the profit they can earn. That fact leads to the boring, dominating, best player’s strategy and ruined every try of developers for a better trading system.

_The addition of exponential, indirectly, defines the cash investment for trade either as a function of commodity stock or as a function of commodity price._ That fact leads to the determination of ships profit as a function of their cargo and, consequently, distinguishes ships from each other by the profit they can earn.
The addition of the exponential at ‘rn’ definition adds no code and programming logic, so it does not prevent at all the dreams of developers for a game model that simulates economy. Any developer can trivially, for his abilities, build some economy model, as a game into galaxy simulation game, by simple logic. Let have that production, that will need that, define that demand and then even let NPCs build ships or even define some metric to calculate the work needed to do any of the above. The hard part is to be proven that that model can work in pioneer. I never managed to think about a metric that measures the work that would be needed by an NPC to build a ship and consequently define its price. My fundamental  difficulty was that _player uses his real time_, by activating time acceleration, while _NPCs will use game time_ without acceleration. Without common time there is no way to define work, let alone measure it. 
Anyway, till that time of developing an economy simulation game in the game of pioneer, I think, there is no reason to keep the economy flat and the trading boring.

My initial hopes that by adding the exponential alone would be enough, soon proved false. By that addition alone, the economy worked indeed as expected but most ships, but three, was proven too expensive and was false strategy to buy them. Consequently all commodities, but three, proved to be decorative bets and did not participate in the player's selections. No one was interested in my arguments, so I was forced, since I like the game, to learn basics of lua, neglect C that was and remains completely incomprehensible to me, and implement the DYI strategy. I've always thought of programming as a means, not an end in itself, so, since it was never my job to develop code, I will forget lua in the very first few months, as I did with other languages in the past.

Because the addition of the exponential alone made little difference, I calculated new prices of commodities and ships by using it. In fact, I did not used the equilibrium equations, that I mention in my article, at all. Instead of defining the exponential, I calculated it and its simple calculation is clear in **Calibration.lua file** I created. I took care to keep base commodity and ship, same as in current state but, because of calibration, prices of next **commodities and ships** should be altered, as ships’ cargos too. I left out fuel commodities, so as not to affect the usual game play. For the above, the **corresponding json files was altered**.

Equilibrium equations from my article, pointed that ship prices should be evolved over time. That would be unheard for the developers. So, the idea of prerequisite ships came up. Imagine you have chains of ships. A chain of ‘lodos’, a chain of ‘deneb, of ‘bluenose’ and so on. Player will chose a chain for his avatar and from there, he will have be available to buy the flag ship, as his ultimate target, the base of all other chains, every ship that does not have a prerequisite, his ship and ships of his chain that have his current ship as a prerequisite. He has his chain as avatar, is forced to upgrade his ships at a predefined order and, if he wants to change his avatar with another chain, he has to start all over again from the new chain’s base, without considerable cash at his disposal. To ask from developers to build a chain of ships for each type of ships would be also unheard. So, I used the existent ships as one chain and altered more or less their cargo, so as to correspond to the needs of my calibration. So, **the prerequisite function in Calibration.lua** came up. _His right place was as a tag in ships’ json files_, but, as I said, I am unable to read, how much to touch, C code. 
The present calibration can be played without the prerequisite feature. In that case some ships will be just decor. I prefer to play with that feature active.

By playing I noticed, as player, that although i managed to escape from staying around a system in the whole game, still, in every upgrade of my ship, I looked for a new system and tended to stick around it as soon I found one. The idea of recent systems came up. Systems, in order to gain player as customer, offer increased stock when player first visit them. After 6 months, they drop their stock by a visible to player ratio. As soon as I detected that drop, I tended to seek for other new systems. The game no longer leaves me to rest. Even then, I started to miss my home, the Sol system. I found it unfair to know that the Sol system will keep to drop their offer to me because I once was its customer. So, after 5 years of absence, systems want to lure player again. **The recent system function created** and completed. 

**Trading seemed complete and calibrated.**
Missions although, as profit by trading increased, loosed even the auxiliary role they had at the start of game. One of the advantages that the exponential has to offer is that it allows the quantification of each ship’s profit. Since I had simulated and measured the average reward of missions, when I wrote my article, it was not hard to dynamically change their rewards in a such way that they keep steady ratio to player’s profit. Thus **a little alteration of mission rewards** came up. Now I enjoy to see mission rewards to increase, as I move up to better ships.

Because of commodity price alteration, a NEWS event came up giving me 1000000 credits, potentially allowed me to buy the flag ship and finish the trading game at once. I consider it unacceptable. The average profit is 27.5% of player’s investment. 10ple price means 900% profit and that was about 33 times more than that I could earn normally. Because of the way the calibration was defined, as 17 turns per ship upgrade, I knew that this was equal to jump two scales in my chain. I altered NEWS event so as to give most the triple or 1/3 of commodities price, as enough reward. Thus the **alteration of NEWS module** came up.

SoldOut module missions need 2 round to complete. Because of price alteration lograndom function most of the time had too little  in stock. I modified it to ask ¼ of their initial demand. It was too little again and, before I start this PR, I altered it to ask as much as major export produce. I calculated that half of the times will be beneficial to player, half the times will not.  Thus the **SoldOut.lua modification** came up.
Potentially, in very low priced commodities, SoldOut would ask even millions of tones and it would not be closed till it gets them. I altered that behavior so as not to ask over the double of players total cargo.

**Fighters** have small available cargo, so if player chooses them, because rewards change dynamically corresponding on current player’s free cargo, missions would offer small rewards all the time. I **normalized the missions rewards to increase them depending on missiles**, only if they are greater than those due to current ship’s free cargo. I do not  play fighters and I have no psychological respond to their missions. In adverts of missions, I see rewards for them high enough. I did not faced, if it is good or bad, the fact that ac33 will have the maximum of game’s profit, if it choose fighting missions, due to its maximum number of missiles it can have.
Because fighters gain profit due to their equipment (missiles) and not by their ability to trade, time came to answer the question ‘_what would be the right price for equipment?_’. For example how much should cost atmospheric shields or radar? Non of that increase profit, so their right value should be zero. And not only that. They take away some tones from player’s cargo, tones that could be used for gaining more profit by trading. The obvious answer to previous question comes naturally. _Developers should pay the players in order to use their creations._ To create some function that raises rewards when some equipment is used, should be trivial for developers. My problem is how player could distinguish that raise, from the overall reward he sees, so as his strategy to include it. That is, how player will detect that the possession of the equipment is that, that makes rewards to raise.
 
By previous minimum alterations, **the game has transformed to an addictive challenged trading game**. Even the large price and stock variations add challenge and do not seem to be disadvantage at all. Player has strong feeling of progress and there is no period in game where he can find rest, around a system, for long.
I played the PR’s game for hours, before the PR’s creation. It is so much transformed, in a better direction, that I can hardly believe that I will start new game in master branch any more. 

_The game’s economy is no longer arbitrary depended on individual developers’ minds_ but turn around one real value number. The ‘rn’s denominator's power. Because of time acceleration, I strongly believe that the economy in pioneer game can not be develop-centric, but can only be a math-centric one. The exponential can lead to mathematically controled economy. So, for those that insist that the game is still, I can not but repeat the very popular “**_E pur si muove_**”.

