### PR TITLE
Remove news, once player docks in their system.

### DIFF
--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -378,6 +378,7 @@ local onShipDocked = function (ship, station)
 			-- print("--- NewsEvent: cargo:", cargo_item:GetName(), "price:", newPrice, "stock:", newStockChange)
 			station:SetEquipmentPrice(cargo_item, newPrice)
 			station:AddEquipmentStock(cargo_item, newStockChange)
+			table.remove(news, i)
 		end
 	end
 end


### PR DESCRIPTION
It is a way to prevent player to pick NEWS from a far away system and when
he gets there to start trading back and forth, multiple times, to a near,
few ly away, system exploiting the same news, that remains active because
they was far away when they were picked. A far away news event can last
several, up to 5 game months. An exploit that will eventually be combined
with SoldOut benefits can offer tremendous profit.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

