### PR TITLE
Illegal commodities nominal price x4

### DIFF
--- a/data/modules/SoldOut/SoldOut.lua
+++ b/data/modules/SoldOut/SoldOut.lua
@@ -83,7 +83,7 @@ local makeAdvert = function(station, commodity)
 	local ad = {
 		station   = station,
 		client    = Character.New(),
-		price     = 2 * station:GetEquipmentPrice(commodity),
+		price     = 2 * station:GetEquipmentPrice(commodity) * ((not Game.system:IsCommodityLegal(commodity:GetName()) and 2) or 1),
 		commodity = commodity,
 	}
 


### PR DESCRIPTION
When illegal commodities get in SoldOut module, double their nominal
price makes no difference as black markets sells already at double
that price.
We double the doubled price when commodity is illegal.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

