### PR TITLE
make fuel scooping less of a suicide

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1283,7 +1283,7 @@ void Ship::StaticUpdate(const float timeStep)
 				const vector3d vdir = GetVelocity().Normalized();
 				const vector3d pdir = -GetOrient().VectorZ();
 				const double dot = vdir.Dot(pdir);
-				if ((m_stats.free_capacity) && (dot > 0.90) && (speed > 1000.0) && (density > 0.5)) {
+				if ((m_stats.free_capacity) && (dot > 0.90) && (speed > 100.0) && (density > 0.3)) {
 					const double rate = speed * density * 0.00000333 * double(m_stats.fuel_scoop_cap);
 					if (Pi::rng.Double() < rate) {
 						lua_State *l = Lua::manager->GetLuaState();


### PR DESCRIPTION
speed and density factored in to how much is scooped hasnt changed, only the threshold where it starts scooping

scooping is still non-trivial

Fixes #5237 
