### PR TITLE
More transparent comm drop down window.

### DIFF
--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -102,7 +102,7 @@ theme.colors = {
 	blueFrame				= styleColors.accent_100:shade(0.50),
 	tableHighlight			= styleColors.primary_700,
 	tableSelection			= styleColors.accent_300:shade(0.40),
-	commsWindowBackground	= styleColors.primary_800:opacity(0.75),
+	commsWindowBackground	= styleColors.primary_800:opacity(0.10),
 	buttonBlue				= styleColors.primary_300,
 	buttonInk				= styleColors.white,
 


### PR DESCRIPTION
As player, most of the time i have system overview window open.
In current state, even if window is transparent with opacity=0.75,
i have the annoying feeling that something i miss from background.
With opacity=0.10 this feeling is much reduced.
In the rare case that background is so bright that i cannot see window's
informations, a hover of mouse upon it, as it uses other background,
reveals the missing information.

![opacity_10](https://user-images.githubusercontent.com/5658995/135488423-f7d2507d-a7f4-4928-86cd-ce3d238ad788.png)
![opacity_75](https://user-images.githubusercontent.com/5658995/135488447-e49ded94-f577-41d0-8771-e660503261aa.png)


