### PR TITLE
Fix the hyperjump edges being solid by providing an alpha value

### DIFF
--- a/src/Color.h
+++ b/src/Color.h
@@ -91,6 +91,11 @@ struct Color4ub {
 		g((rgba >> 16) & 0xff),
 		b((rgba >> 8) & 0xff),
 		a(rgba & 0xff) {}
+	constexpr Color4ub(const Color4ub &c, const Uint8 a) :
+		r(c.r),
+		g(c.g),
+		b(c.b),
+		a(a) {}
 
 	operator unsigned char *() { return &r; }
 	operator const unsigned char *() const { return &r; }

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -195,11 +195,13 @@ void HyperspaceCloud::InitGraphics(Graphics::Renderer *renderer)
 
 	Graphics::VertexArray vertices(ATTRIB_POSITION | ATTRIB_DIFFUSE);
 
-	make_circle_thing(vertices, 1000.f, Color::WHITE, Color::BLUE);
+	const Color edgeArrivingColour(Color::BLUE, 0); // alpha needs to be zero'd
+	make_circle_thing(vertices, 1000.f, Color::WHITE, edgeArrivingColour);
 	s_cloudMeshArriving.reset(renderer->CreateMeshObjectFromArray(&vertices));
 
 	vertices.Clear();
 
-	make_circle_thing(vertices, 1000.f, Color::WHITE, Color::RED);
+	const Color edgeLeavingColour(Color::RED, 0); // alpha needs to be zero'd
+	make_circle_thing(vertices, 1000.f, Color::WHITE, edgeLeavingColour);
 	s_cloudMeshLeaving.reset(renderer->CreateMeshObjectFromArray(&vertices));
 }


### PR DESCRIPTION
Fix the hyperjump edges being solid by providing an alpha value.

I added a new c'tor for Color4ub to take a Color4ub and override the alpha value

Fixes #5261