### PR TITLE
Make (Bulk) Trading Profitable Again + Station Restocking

### DIFF
--- a/data/libs/Game.lua
+++ b/data/libs/Game.lua
@@ -16,7 +16,10 @@ end
 -- Function: GetStartTime()
 --
 -- Returns the zero-offset time in seconds since Jan 1 3200 at which the
--- current game began
+-- current game began.
+--
+-- > local seconds_since_start = Game.time - Game.GetStartTime()
+--
 function Game.GetStartTime()
 	return gameStartTime
 end

--- a/data/libs/Game.lua
+++ b/data/libs/Game.lua
@@ -1,5 +1,9 @@
 local Game = package.core["Game"]
 local Event = require 'Event'
+
+-- Simple way to track the start date of the game until DateTime objects are exposed to lua
+local gameStartTime = 0
+
 Game.comms_log_lines = {}
 Game.AddCommsLogLine = function(text, sender, priority)
 	 table.insert(Game.comms_log_lines, { text=text, time=Game.time, sender=sender, priority = priority or 'normal'})
@@ -9,8 +13,31 @@ Game.GetCommsLines = function()
 	return Game.comms_log_lines
 end
 
+-- Function: GetStartTime()
+--
+-- Returns the zero-offset time in seconds since Jan 1 3200 at which the
+-- current game began
+function Game.GetStartTime()
+	return gameStartTime
+end
+
 Event.Register('onGameStart', function()
 	Game.comms_log_lines = {}
+	gameStartTime = Game.time
 end)
-	
+
+Event.Register('onGameEnd', function()
+	gameStartTime = 0
+end)
+
+local function _serialize()
+	return { startTime = gameStartTime }
+end
+
+local function _deserialize(data)
+	gameStartTime = data.startTime or 0
+end
+
+require 'Serializer':Register('Game', _serialize, _deserialize)
+
 return Game

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -35,41 +35,132 @@ function SpaceStation:Constructor()
 	self:setprop("techLevel", techLevel)
 end
 
+-- visited keeps track of which stations we have docked with and have had
+-- extended info (BBS adverts, ship ads, equipment stock info) generated for
+local visited = {}
 local equipmentStock = {}
 
-local function updateEquipmentStock (station)
-	assert(station and station:exists())
-	if equipmentStock[station] then return end
-	equipmentStock[station] = {}
+-- stationMarket is a persistent table of stock information for every station
+-- the player has visited in their journey
+local stationMarket = {}
 
-	local hydrogen = Equipment.cargo.hydrogen
-	for key, e in pairs(Equipment.cargo) do
+-- return the target stock level for a given commodity based on whether the
+-- commodity is an import/export good at this port (based on pricemod)
+local function applyStockPriceMod(maxStock, stock, pricemod)
+	if pricemod > 10 then --major import, low stock
+		return stock - (maxStock*0.10)     -- shifting .10 = 2% chance of 0 stock
+	elseif pricemod > 4 then --minor import
+		return stock - (maxStock*0.07)     -- shifting .07 = 1% chance of 0 stock
+	elseif pricemod < -10 then --major export
+		return stock + (maxStock*0.8)
+	elseif pricemod < -4 then --minor export
+		return stock + (maxStock*0.3)
+	end
+	return stock
+end
+
+-- set commodity stocking based on price adjusted for some rarity curve by exponent
+-- math.log() flattens the curve at the low end
+local function getMaxStock(price)
+	return 750000 * math.max(0.1, math.log(price, 10)) / price^1.457
+end
+
+-- return the persistent equilibrium stock for a commodity based on a deterministic seed
+local function getStationTargetStock(key, seed)
+	-- use a deterministic random function to determine target stock numbers
+	local rand = Rand.New(seed .. '-stock-' .. key)
+	local e = Equipment.cargo[key]
+	local rn = getMaxStock(math.abs(e.price))
+
+	local pricemod = Game.system:GetCommodityBasePriceAlterations(key)
+	local targetStock = rn * (rand:Number() + rand:Number()) / 2.0 -- normal 0-100% "permanent" stock
+	return rn, math.floor(applyStockPriceMod(rn, targetStock, pricemod))
+end
+
+-- create a persistent entry for the given station's commodity market if it
+-- does not already exist, and populate persistent and transient stock info
+local function createStationMarket(station)
+	assert(station and station:exists())
+	if stationMarket[station.path] then return end
+
+	local storedStation = {
+		commodities = {},
+		lastStockUpdate = Game.time
+	}
+	stationMarket[station.path] = storedStation
+
+	local h2 = Equipment.cargo.hydrogen
+	for key, e in pairs (Equipment.cargo) do
 		if e.purchasable then
-			local rn = 100000 / math.abs(e.price) --have about 100,000 worth of stock, per commodity
-			if e == hydrogen then
-				equipmentStock[station][e] = math.floor(rn/2 + Engine.rand:Integer(0,rn)) --always stock hydrogen
+			local rn, targetStock = getStationTargetStock(key, station.seed)
+			if e == h2 then
+				-- always stock hydrogen, don't store it as a commodity
+				equipmentStock[station][e] = Engine.rand:Integer(rn/4, rn)
 			else
-				local pricemod = Game.system:GetCommodityBasePriceAlterations(key)
-				local stock =  (Engine.rand:Integer(0,rn) + Engine.rand:Integer(0,rn)) / 2 -- normal 0-100% stock
-				if pricemod > 10 then --major import, low stock
-					stock = stock - (rn*0.10)     -- shifting .10 = 2% chance of 0 stock
-				elseif pricemod > 4 then --minor import
-					stock = stock - (rn*0.07)     -- shifting .07 = 1% chance of 0 stock
-				elseif pricemod < -10 then --major export
-					stock = stock + (rn*0.8)
-				elseif pricemod < -4 then --minor export
-					stock = stock + (rn*0.3)
-				end
-				equipmentStock[station][e] = math.floor(stock >=0 and stock or 0)
+				storedStation.commodities[key] = targetStock
+				equipmentStock[station][e] = targetStock
 			end
 		else
 			equipmentStock[station][e] = 0 -- commodity that cant be bought
 		end
 	end
+end
+
+-- handle gradually restocking commodities at a station over time
+-- by default, a station restores to its maximum stock after 12 weeks
+-- this function is safe to call at any time, though it should be rate-limited
+local kTickDuration = 7 * 24 * 60 * 60 -- 1 week
+local kAvgTicksToRestock = 12
+local function updateStationMarket (station)
+	assert(station and station:exists())
+	if not stationMarket[station.path] then return end
+
+	local storedStation = stationMarket[station.path]
+	local lastStockUpdate = storedStation.lastStockUpdate
+	local timeSinceUpdate = Game.time - lastStockUpdate
+	if timeSinceUpdate <= kTickDuration then return end
+
+	-- make sure the next tick happens at the correct time
+	storedStation.lastStockUpdate = lastStockUpdate + math.floor(timeSinceUpdate / kTickDuration) * kTickDuration
+
+	-- use a *different* random function to tally up restocks
+	local randRestock = Rand.New(station.seed .. '-stockMarketUpdate-' .. math.floor(lastStockUpdate))
+
+	for key, stock in pairs (storedStation.commodities) do
+		local rn, targetStock = getStationTargetStock(key, station.seed)
+
+		for i = 1, math.floor(timeSinceUpdate / kTickDuration) do
+			stock = stock + (randRestock:Number() + randRestock:Number()) / kAvgTicksToRestock * targetStock
+		end
+		stock = math.min(targetStock, math.ceil(stock))
+
+		storedStation.commodities[key] = stock
+		if equipmentStock[station] then
+			local e = Equipment.cargo[key]
+			equipmentStock[station][e] = stock
+		end
+	end
+end
+
+-- create a transient entry for this station's equipment stock and seed it with
+-- commodity stock information from persistent data
+local function createEquipmentStock (station)
+	assert(station and station:exists())
+	if equipmentStock[station] then return end
+	equipmentStock[station] = {}
 
 	for _,slot in pairs{"laser", "hyperspace", "misc"} do
 		for key, e in pairs(Equipment[slot]) do
 			equipmentStock[station][e] = Engine.rand:Integer(0,100)
+		end
+	end
+
+	-- stationMarket is persistent across systems but equipmentStock is not,
+	-- so we want to import the data from the station market if it exists
+	if stationMarket[station.path] then
+		for key, stock in pairs(stationMarket[station.path].commodities) do
+			local e = Equipment.cargo[key]
+			equipmentStock[station][e] = stock
 		end
 	end
 end
@@ -141,7 +232,7 @@ end
 --
 function SpaceStation:GetEquipmentStock (e)
 	assert(self:exists())
-	return equipmentStock[self][e] or 0
+	return equipmentStock[self] and equipmentStock[self][e] or 0
 end
 
 --
@@ -168,6 +259,14 @@ end
 function SpaceStation:AddEquipmentStock (e, stock)
 	assert(self:exists())
 	equipmentStock[self][e] = (equipmentStock[self][e] or 0) + stock
+
+	-- update persistent station stock values
+	if e.name and stationMarket[self.path] then
+		local commodities = stationMarket[self.path].commodities
+		if commodities[e.name] then
+			commodities[e.name] = math.max(0, commodities[e.name] + stock)
+		end
+	end
 end
 
 
@@ -655,27 +754,32 @@ end
 local function updateSystem ()
 	local stations = Space.GetBodies(function (b) return b.superType == "STARPORT" end)
 	for i, station in ipairs(stations) do
-		if SpaceStation.adverts[station] then
-			updateEquipmentStock(station)
+		updateStationMarket(station)
+
+		if visited[station] then
 			updateShipsOnSale(station)
 			updateAdverts(station)
 		end
 	end
 end
 
-local function createStationMarket (station)
+local function createStationData (station)
 	SpaceStation.adverts[station] = {}
 	shipsOnSale[station] = {}
+	visited[station] = true
 
-	updateEquipmentStock(station)
+	createEquipmentStock(station)
+	createStationMarket(station)
 	local shipAdsToSpawn = Engine.rand:Poisson(N_equilibrium(station))
 	addRandomShipAdvert(station, shipAdsToSpawn)
+
 	Event.Queue("onCreateBB", station)
 end
 
 local function destroySystem ()
 	equipmentStock = {}
 	equipmentPrice = {}
+	visited = {}
 
 	police = {}
 
@@ -696,6 +800,8 @@ Event.Register("onGameStart", function ()
 	if (loaded_data) then
 		equipmentStock = loaded_data.equipmentStock
 		equipmentPrice = loaded_data.equipmentPrice or {} -- handle missing in old saves
+		stationMarket = loaded_data.stationMarket or {}
+		visited = loaded_data.visited or {}
 		police = loaded_data.police
 		for station,list in pairs(loaded_data.shipsOnSale) do
 			shipsOnSale[station] = {}
@@ -711,6 +817,12 @@ Event.Register("onGameStart", function ()
 				end
 			end
 		end
+
+		-- SAVEBUMP: fixup for save version 87 where player is docked to station without visited data
+		local dockedStation = Game.player:GetDockedWith()
+		if dockedStation and not visited[dockedStation] then
+			createStationData(dockedStation)
+		end
 		loaded_data = nil
 	end
 
@@ -718,8 +830,13 @@ Event.Register("onGameStart", function ()
 end)
 
 Event.Register("onShipDocked", function (ship, station)
-	if ship ~= Game.player or SpaceStation.adverts[station] then return end
-	createStationMarket(station)
+	if ship ~= Game.player then return end
+
+	if not visited[station] then
+		createStationData(station)
+	else
+		updateStationMarket(station)
+	end
 end)
 
 Event.Register("onLeaveSystem", function (ship)
@@ -744,6 +861,8 @@ Event.Register("onGameEnd", function ()
 	nextRef = 0
 	equipmentStock = {}
 	equipmentPrice = {}
+	stationMarket = {}
+	visited = {}
 	police = {}
 	shipsOnSale = {}
 end)
@@ -754,6 +873,8 @@ Serializer:Register("SpaceStation",
 		local data = {
 			equipmentStock = equipmentStock,
 			equipmentPrice = equipmentPrice,
+			stationMarket = stationMarket,
+			visited = visited,
 			police = police,  --todo fails if a police ship is killed
 			shipsOnSale = {},
 		}


### PR DESCRIPTION
## Bulk Trading Changes

This PR addresses a problem very astutely noticed by @jimishol in the economic and trading simulation portion of the game - once the player acquires a ship with ~80t of cargo space, the trading gameplay loop of Pioneer is effectively over. All commodities in the game have the exact same maximum profit for a single trade run, and the only variance is in how much hull space is required to make that exact same amount of money.

This means that once you have found an export/import run for Precious Metals, you have hit the maximum profit ceiling in trading. Sure, you can run a second commodity at the same time in a larger hull, but that costs more fuel, takes more real player time, usually requires a second chain of hyperjumps, and the profit margin is much lower than your primary commodity.

I promised charts, so charts you will have!

![image](https://user-images.githubusercontent.com/4218491/135738221-c1d35b11-0cb2-419d-a0ba-2f1b05871812.png)
(Investment and Profit use left axis, Tonnage uses right axis.)

The current paradigm (which I will call "linear stocking") uses a simple formula to determine the amount of commodities that are present at a station when you enter the system. There is some variance in stock from station to station and from system to system based on the price modification from underlying system economy variables, but that variance has comparatively little effect on the primary viable trade route - buy a commodity at a major export station and sell at a minor import station, yielding approximately 30-35% profit.

With linear stocking, the "midgame" of trading ships (that is, medium haulers) is in fact the endgame of trading in Pioneer; you can spend more money on a larger ship, but you will never make any more money hauling a different cargo in a larger hold than you will hauling Precious Metals in a comparatively small hold.

This problem stems from the fact that the current stocking algorithm only takes into account a single factor - the price of the commodity - to cap the maximum profit that can be made in a single run. It ignores the other implicit factors of cargo space (price to acquire the ship), fuel costs (often 3-10x higher in a large bulk ship), and hyperjump range needed to haul larger cargoes.

This PR addresses that problem by introducing a new station stocking algorithm (which I call "exponential stocking"). It's based on the core of #5272, and uses an exponential term in the function that calculates a station's maximum stock to better model the factors of commodity rarity and time-and-resource cost to the player to haul bulk commodities, resulting in a higher credit-value profit from hauling bulk cargo while leaving the actual profit margin of 30-35% entirely untouched. 

![image](https://user-images.githubusercontent.com/4218491/135738596-9b1c0f3b-5612-4f91-81a9-130fadaff95d.png)
(Investment and Profit use left axis, Tonnage uses right axis.)

This new algorithm provides a better and more balanced economy that gives both large bulk ships and smaller cargo/courier ships like the Amphiesma and the Sinonatrix a role to play in trading and a natural progression through the game. Precious Metals is now a rare, low-volume commodity, being the best good to haul in a small ship but dropping off in absolute profit once the player has worked their way to a Mola Mola or similar entry-level medium hauler. By the time the player has purchased a Skipjack or larger ship, Robots or even Medicines are the better cargo to haul, giving the player an incentive to change it up and not just run the same route between two systems for the rest of the game until they get bored.

![image](https://user-images.githubusercontent.com/4218491/135738772-7f04091a-7c92-49f1-9369-bc4b4af7634f.png)
You can see the source data for all of these charts [here](https://docs.google.com/spreadsheets/d/1wR9-Pof1Tu69GAPbdOjLraKxaP8ZqrQ9PcczVhd8AwE/edit).

## Dynamic Station Restocking

Now, merely that change alone would solve the stated problem by giving bulk haulers a reason to haul textiles in their massive holds instead of being a glorified courier for Precious Metals, but there's something else that can be done to improve the trading gameplay as well, and something that lays the groundwork for a dynamic, simulated economy.

Stations now no longer re-roll their stock values for every commodity each time you re-enter the system, and instead persistently track the player's purchases and re-stock to a deterministic equilibrium over time. This means that when you've bought a station entirely out of one commodity stock, you can't just jump out and jump back in to refresh that station; you'll have to find another station in the system and buy from that station instead.

Stations will over time recover back to their "equilibrium" stock amounts (being a combination of a very lightweight approximation of NPC trade and commodity production happening in the background and the station interface being a front for multiple trading companies with their own exclusivity contracts and stock reserves) as you jump between systems and trade with other stations, eventually becoming a viable part of the player's trade route again.

The constants behind these two algorithms are currently tuned to allow the player to make one "max profit" run from a station before needing to use another station in the same system, with the station restocking after 3-6 such trade runs. This could be further changed after merge in several directions; either to use a lower equilibrium stock and restock much faster (while the player is on the pad, potentially, though I don't think this has much gameplay utility), or to have a higher equilibrium stock and restock much slower, potentially taking a year or more to get back to equilibrium stock after heavy bulk trading.

However, I don't think tuning in either direction is actually the best way to go, as I've neglected to mention how these new features interact with other potential future changes to the economy - one of the biggest is giving each station its own economy type and making export/import price modifications be relative to a specific station or planet rather than system-wide. This would greatly amplify the impact of limited station stocks as instead of N stations in the system to buy that stock from, you could have as little as 1-2 stations that sell the commodity you want at the right price.

Other changes that could impact and provide even more depth would be dynamic commodity prices based on available stock (buy from the highest-stock station and sell to high-demand); or basing station stock on station population and industry/agriculture production of the station and parent bodies during system generation - these values are currently too random and unpredictable to be used directly.

## General Improvements

And of course, I've saved the best for last - I've rewritten the way SpaceStation.lua caches data about visited stations, adding an actual `visited` cache instead of using the advertisement register. This wound up resolving (or at least mitigating the cause) of the `GetEquipmentStock()` bug that's been causing many crashes and issues over the past few months. This supersedes and will close #5284.

I've also added a `Game.GetStartTime()` function for modules (e.g. hyperdrive breakdown) to use to determine when the loaded game was started; unfortunately it's inaccurate for old saves, but going forward that data will be available.

## Testing Notes

I'd appreciate some eyes on this PR with regards to longer-running games; both to confirm the fix for the GetEquipmentStock() bugs and also to test the progression from Amphiesma to Sinonatrix to Mola Mola and then the "midgame". I don't expect to see any bugs shaking out of the woodwork, but I would like feedback about the experience to see if I need to tweak any of the constants further to make the design more apparent.

-------
Fixes #5149, fixes #5233. Closes #5272, closes #5284.