### PR TITLE
Change CommsWindow opacity, adjust Quit message window

### DIFF
--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -8,6 +8,8 @@ local utils = require 'utils'
 local pigui = Engine.pigui
 local ui = require 'pigui.libs.forwarded'
 
+local defaultBaseResolution = Vector2(1600, 900)
+
 --
 -- Function: ui.rescaleUI
 --
@@ -37,6 +39,10 @@ local ui = require 'pigui.libs.forwarded'
 function ui.rescaleUI(val, baseResolution, rescaleToScreenAspect, targetResolution)
 	if not targetResolution then
 		targetResolution = Vector2(pigui.screen_width, pigui.screen_height)
+	end
+
+	if not baseResolution then
+		baseResolution = defaultBaseResolution
 	end
 
 	local rescaleVector = Vector2(targetResolution.x / baseResolution.x, targetResolution.y / baseResolution.y)

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -102,7 +102,7 @@ theme.colors = {
 	blueFrame				= styleColors.accent_100:shade(0.50),
 	tableHighlight			= styleColors.primary_700,
 	tableSelection			= styleColors.accent_300:shade(0.40),
-	commsWindowBackground	= styleColors.primary_800:opacity(0.75),
+	commsWindowBackground	= styleColors.primary_700:opacity(0.30),
 	buttonBlue				= styleColors.primary_300,
 	buttonInk				= styleColors.white,
 

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -34,6 +34,7 @@ local icons = ui.theme.icons
 local mainButtonSize = Vector2(400,46) * (ui.screenHeight / 1200)
 local dialogButtonSize = Vector2(150,46) * (ui.screenHeight / 1200)
 local mainButtonFontSize = 24 * (ui.screenHeight / 1200)
+local quitPadding = ui.rescaleUI(Vector2(12, 12))
 
 local showQuitConfirm = false
 local quitConfirmMsg
@@ -103,25 +104,29 @@ end --mainTextButton
 local function confirmQuit()
 	ui.setNextWindowPosCenter('Always')
 
-	ui.withStyleColors({["WindowBg"] = colors.commsWindowBackground}, function()
+	ui.withStyleColorsAndVars({WindowBg = colors.blueBackground:opacity(0.70)}, {WindowPadding = quitPadding}, function()
 		-- TODO: this window should be ShowBorders
 		ui.window("MainMenuQuitConfirm", {"NoTitleBar", "NoResize", "AlwaysAutoResize"}, function()
-			ui.withFont(pionillium.large.name, mainButtonFontSize, function()
+			local w = dialogButtonSize.x * 0.6
+			local fullW = w * 3 + dialogButtonSize.x * 2
+
+			ui.withFont(orbiteer.medlarge, function()
 				ui.text(qlc.QUIT)
 			end)
-			ui.withFont(pionillium.large.name, pionillium.large.size, function()
-				ui.pushTextWrapPos(450)
+			ui.withFont(pionillium.medlarge, function()
+				ui.pushTextWrapPos(fullW)
 				ui.textWrapped(quitConfirmMsg)
 				ui.popTextWrapPos()
 			end)
 			ui.dummy(Vector2(5,15)) -- small vertical spacing
-			ui.dummy(Vector2(30, 5))
-			ui.sameLine()
+
+			ui.dummy(Vector2(0, 0))
+			ui.sameLine(0, w)
 			dialogTextButton(qlc.YES, true, Engine.Quit)
-			ui.sameLine()
-			ui.dummy(Vector2(30, 5))
-			ui.sameLine()
+			ui.sameLine(0, w)
 			dialogTextButton(qlc.NO, true, function() showQuitConfirm = false end)
+			ui.sameLine(0, w)
+			ui.dummy(Vector2(0, 0))
 		end)
 	end)
 end


### PR DESCRIPTION
This PR is a minor set of fixes to the comms window background opacity (closes #5286) and quit message popup window. We use more consistent typography in the quit menu, and the buttons are properly centered and positioned now.

![image](https://user-images.githubusercontent.com/4218491/140623891-0fbcefff-523a-4133-b68d-c5447c83c135.png)

![image](https://user-images.githubusercontent.com/4218491/140623904-77f35ebb-9a5e-457e-aa13-bea436a6db07.png)
