### PR TITLE
FuelClub: Refuel internal fuel tank only once a day

### DIFF
--- a/data/lang/module-fuelclub/en.json
+++ b/data/lang/module-fuelclub/en.json
@@ -73,7 +73,7 @@
   },
   "LIST_BENEFITS_FUEL_TANK": {
     "description": "",
-    "message": "Fuel tank refilling, where necessary"
+    "message": "Fuel tank refilling, once per day"
   },
   "LIST_BENEFITS_JOIN": {
     "description": "",

--- a/data/lang/module-fuelclub/en.json
+++ b/data/lang/module-fuelclub/en.json
@@ -55,9 +55,9 @@
     "description": "for the Haber faction",
     "message": "Greetings pilot. This is the Haber Propellant and Perishables Division, entrusted with managing the fuel distribution throughout Haber owned space."
   },
-  "GO_BACK": {
+  "FUEL_LEVEL": {
     "description": "",
-    "message": "Go back"
+    "message": "Your current fuel level is {level}%."
   },
   "LIST_BENEFITS_DISPOSAL": {
     "description": "",
@@ -78,6 +78,10 @@
   "LIST_BENEFITS_JOIN": {
     "description": "",
     "message": "Join now! Annual membership costs only {membership_fee}"
+  },
+  "REFUEL_FREE": {
+    "description": "",
+    "message": "Refuel internal fuel tank for free."
   },
   "WE_WILL_ONLY_DISPOSE_OF": {
     "description": "",

--- a/data/pigui/libs/chat-form.lua
+++ b/data/pigui/libs/chat-form.lua
@@ -137,6 +137,7 @@ function ChatForm:Clear ()
 	self.message = nil
 	self.options = nil
 	self.tradeFuncs = nil
+	self.market = nil
 end
 
 local tradeFuncKeys = { "canTrade", "getStock", "getBuyPrice", "getSellPrice", "onClickBuy", "onClickSell", "canDisplayItem", "bought", "sold"}


### PR DESCRIPTION
Members get refueled every time and can sell the internal fuel over and over again.
This PR prevents that and limits the refilling to once a day after takeoff.


