### PR TITLE
Small fixes for hot reloading modules

### DIFF
--- a/data/pigui/libs/view-util.lua
+++ b/data/pigui/libs/view-util.lua
@@ -4,14 +4,19 @@
 local util = {}
 
 function util.mixin_modules(t)
-    t.modules = {}
-    t.moduleCount = 0
+	t.modules = {}
+	t.moduleCount = 0
 
-    function t.registerModule(name, module)
-        t.modules[name] = module
-        table.insert(t.modules, module)
-        t.moduleCount = t.moduleCount + 1
-    end
+	function t.registerModule(name, module)
+		-- replace if such name already exists
+		if t.modules[name] then
+			t.modules[t.modules[name]] = module
+		else
+			table.insert(t.modules, module)
+			t.moduleCount = t.moduleCount + 1
+			t.modules[name] = t.moduleCount
+		end
+	end
 end
 
 return util

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -888,7 +888,7 @@ void GameLoop::Start()
 #ifndef REMOTE_LUA_REPL_PORT
 #define REMOTE_LUA_REPL_PORT 12345
 #endif
-	luaConsole->OpenTCPDebugConnection(REMOTE_LUA_REPL_PORT);
+	Pi::luaConsole->OpenTCPDebugConnection(REMOTE_LUA_REPL_PORT);
 #endif
 
 	// fire event before the first frame


### PR DESCRIPTION
Fix compilation error occurred when `REMOTE_LUA_REPL=ON`
Fix that `gameView` modules were not replaced on hot-reload, but added more.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

