### PR TITLE
Fix clicks falling through buttons in sector map

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -775,7 +775,7 @@ void SectorView::DrawLabels()
 	m_drawList->PushClipRectFullScreen();
 
 	// iterate over the labels starting with the closest one until we find the one over which the cursor is hanging
-	if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) {
+	if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsAnyItemHovered()) {
 		for (int i = m_labels.array.size() - 1; i >= 0; --i) {
 			Label &label = *m_labels.array[i];
 			if (hovered_i == NOT_FOUND && !m_rotateWithMouseButton && label.Hovered(mpos)) {


### PR DESCRIPTION
This is what the problem looked like:

https://user-images.githubusercontent.com/18342621/149637366-41b7c987-573d-4fcc-b5ba-b01c0c6bbb5a.mp4



<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

