### PR TITLE
Make "Travellers Advice" module work with new revamped BBS

### DIFF
--- a/data/modules/Advice/Advice.lua
+++ b/data/modules/Advice/Advice.lua
@@ -87,7 +87,8 @@ local onCreateBB = function (station)
 
 	local ad = {
 		id = flavours[n].ID,
-		headline = flavours[n].ID .. ": " .. flavours[n].headline,
+		headline = flavours[n].ID,
+		description = flavours[n].headline,
 		bodytext = flavours[n].bodytext,
 		station  = station
 	}
@@ -96,7 +97,8 @@ local onCreateBB = function (station)
 	local ref
 	if rand:Number() < advice_probability then
 		ref = station:AddAdvert({
-			description = ad.headline,
+			title       = ad.headline,
+			description = ad.description,
 			icon        = "advice",
 			onChat      = onChat,
 			onDelete    = onDelete})


### PR DESCRIPTION
## Seems to work 
![2022-01-16-203812_1600x900_scrot](https://user-images.githubusercontent.com/619390/149675270-c0789745-426b-4d26-a41d-9c798f4ae5f0.png)

In screenshot above, I've made a for-loop over all advises, just for demonstration purpose.

## If it doesn't work for testers, well then:
![](https://img.devrant.com/devrant/rant/r_2341310_va2vS.jpg)


 @Web-eWorks was there any other module that I should fix? I see you already fixed the SoldOut module.