### PR TITLE
Small pre-release QOL fixes

### DIFF
--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -328,7 +328,7 @@ end
 --             false otherwise
 --
 function ui.isAnyWindowHovered()
-	return ui.isWindowHovered({"AnyWindow", "RectOnly"})
+	return ui.isWindowHovered({"AnyWindow", "AllowWhenBlockedByPopup", "AllowWhenBlockedByActiveItem"})
 end
 
 --
@@ -506,9 +506,9 @@ function ui.tabBarFont(id, items, font, ...)
 
 			pigui.EndTabItem()
 		end
-
-		pigui.EndTabItem()
 	end
+
+	pigui.EndTabBar()
 
 	return active_index
 end

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -6,7 +6,6 @@ local Event = require 'Event'
 local Game = require 'Game'
 local Lang = require 'Lang'
 local ShipDef = require 'ShipDef'
-local ModelSpinner = require 'PiGui.Modules.ModelSpinner'
 local InfoView = require 'pigui.views.info-view'
 local Vector2 = Vector2
 
@@ -15,7 +14,6 @@ local l = Lang.GetResource("ui-core")
 
 local fonts = ui.fonts
 local textTable = require 'pigui.libs.text-table'
-
 
 local equipmentWidget = require 'pigui.libs.ship-equipment'.New("ShipInfo")
 
@@ -117,5 +115,8 @@ InfoView:registerView({
 })
 
 Event.Register("onShipTypeChanged", function(ship)
-	if ship == Game.player then equipmentWidget:refresh() end
+	if ship == Game.player then
+		equipmentWidget.ship = Game.player
+		equipmentWidget:refresh()
+	end
 end)

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -3,12 +3,13 @@
 
 #include "GameConfig.h"
 #include "FileSystem.h"
+#include "core/OS.h"
 
 GameConfig::GameConfig(const map_string &override_)
 {
 	// set defaults
 	std::map<std::string, std::string> &map = m_map[""];
-	map["Lang"] = "en";
+	map["Lang"] = OS::GetUserLangCode();
 	map["AMD_MESA_HACKS"] = "0";
 	map["DisableSound"] = "0";
 	map["StartFullscreen"] = "0";

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -130,6 +130,8 @@ void SystemView::ResetViewpoint()
 	m_transTo *= 0.0;
 	m_animateTransition = MAX_TRANSITION_FRAMES;
 
+	if (!m_renderer) return;
+
 	float height = tan(DEG2RAD(CAMERA_FOV)) * 30.0f;
 	m_atlasViewW = height * m_renderer->GetDisplayAspect();
 	m_atlasViewH = height;
@@ -686,6 +688,10 @@ void SystemView::DrawAtlasView()
 	gridTransform.Scale(4.0 / float(AU)); // one grid square = one earth diameter = two units
 	m_renderer->SetTransform(cameraTrans * gridTransform);
 	DrawGrid(64.0);
+
+	// Don't draw bodies in unexplored systems
+	if (m_unexplored)
+		return;
 
 	// Draw the system atlas layout, offsetting the position to ensure it's roughly centered on the grid
 	RenderAtlasBody(m_atlasLayout, vector3f{ -m_atlasPosDefault.x, m_atlasPosDefault.y, 0.0f }, cameraTrans);

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -62,7 +62,7 @@ struct Projectable {
 	} ref;
 	vector3d screenpos; // x,y - screen coordinate, z - in NDC
 	vector3d worldpos;
-	float screensize; // approximate size in screen pixels
+	float screensize = 0.f; // approximate size in screen pixels
 
 	Projectable(const types t, const bases b, const Body *obj) :
 		type(t), base(b)

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -4,7 +4,8 @@
 #include "View.h"
 #include "Pi.h"
 
-View::View()
+View::View() :
+	m_renderer(nullptr)
 {
 }
 

--- a/src/core/OS.h
+++ b/src/core/OS.h
@@ -27,6 +27,10 @@ namespace OS {
 	// return a string describing the operating system that the game is running on, useful!
 	const std::string GetOSInfoString();
 
+	// return a two-character language code detected from the OS environment
+	// If the OS environment language cannot be detected, returns "en"
+	const std::string GetUserLangCode();
+
 	// Enable Google breakpad for crash minidumps
 	void EnableBreakpad();
 

--- a/src/posix/OSPosix.cpp
+++ b/src/posix/OSPosix.cpp
@@ -103,6 +103,13 @@ namespace OS {
 		return std::string(infoString);
 	}
 
+	const std::string GetUserLangCode()
+	{
+		// assume $LANG is in the format en_US.utf8
+		const char *env_lang = getenv("LANG");
+		return std::string(env_lang ? env_lang : "en").substr(0, 2);
+	}
+
 	void EnableBreakpad()
 	{
 		// Support for Mac and Linux should be added

--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -229,6 +229,12 @@ namespace OS {
 		return hwInfo + name;
 	}
 
+	const std::string GetUserLangCode()
+	{
+		// TODO: implement me
+		return "en";
+	}
+
 #ifdef WITH_BREAKPAD
 	/////////////////////////////////////////////////////// Google Breakpad
 	bool FilterCallback(void *context, EXCEPTION_POINTERS *exinfo,


### PR DESCRIPTION
Yet another "microfixes" PR in a long tradition of the same, it does what it says on the tin. Going to leave this open for a little bit to collate small QOL fixes I find.

* Default to the user's environment language code when no config file exists. Fixes #3723.
* Fix lua error when changing ship type. Fixes #5322.
* Fix asserts / issues with ui.isAnyWindowHovered / ui.tabBarFont.
* Fix segfault when accessing invalid renderer ptr. Fixes #5328. Fixes #5329. Probably fixes #5330.
