### PR TITLE
Add System Overview Widget to System Map view

### DIFF
--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -181,7 +181,7 @@ utils.inherits = function (baseClass, name)
 
 	-- generic constructor
 	function new_class.New(args)
-		local newinst = baseClass.New(args)
+		local newinst = base_class.New(args)
 		setmetatable( newinst, new_class.meta )
 		return newinst
 	end

--- a/data/pigui/baseui.lua
+++ b/data/pigui/baseui.lua
@@ -6,6 +6,17 @@ local pigui = Engine.pigui
 
 local ui = require 'pigui.libs.forwarded'
 ui.rescaleUI = require 'pigui.libs.rescale-ui'
+
+--
+-- Function: ui.rescaleFraction
+--
+-- Smoothly rescale a UI value without rounding to whole numbers.
+--
+-- ui.rescaleFraction(val, baseResolution, rescaleToScreenAspect, targetResolution)
+ui.rescaleFraction = function (val, baseResolution, rescaleToScreenAspect, targetResolution)
+	return ui.rescaleUI(val, baseResolution, rescaleToScreenAspect, true, targetResolution)
+end
+
 require 'pigui.libs.wrappers'
 
 local defaultTheme = require 'pigui.themes.default'

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -10,7 +10,7 @@ local pigui = Engine.pigui
 local lc = Lang.GetResource("core");
 
 -- get a fractional font factor
-local font_factor = ui.rescaleUI(1, Vector2(1920, 1200), false, true)
+local font_factor = ui.rescaleFraction(1, Vector2(1920, 1200))
 
 local textBackgroundMarginPixels = 2
 

--- a/data/pigui/libs/window-layout.lua
+++ b/data/pigui/libs/window-layout.lua
@@ -1,0 +1,102 @@
+-- Copyright © 2008-2021 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local utils = require "libs.utils"
+local ui = require 'pigui'
+
+-- Layout is a very simple class intended to handle layout and drawing of
+-- multiple auto-sizing windows. Create a layout, create window objects,
+-- and call display() each frame.
+
+local layout = utils.inherits(nil, 'ui.Layout')
+
+local __newLayout = layout.New
+function layout.New(windows)
+	local self = __newLayout()
+	self.__dummyFrames = 3
+
+	self.enabled = true
+	self.mainFont = ui.fonts.pionillium.medium
+	self.windows = windows or {}
+
+	self.onUpdateWindowConstraints = layout.onUpdateWindowConstraints
+	return self
+end
+
+local defaultWindowFlags = ui.WindowFlags {"NoTitleBar", "AlwaysAutoResize", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"}
+function layout.NewWindow(name, bgColor, flags)
+	return {
+		size = Vector2(0.0, 0.0),
+		pos = Vector2(0.0, 0.0),
+		visible = true,
+		name = name,
+		style_colors = {["WindowBg"] = bgColor or ui.theme.colors.lightBlackBackground},
+		params = flags or defaultWindowFlags
+	}
+end
+
+function layout:onUpdateWindowConstraints(windows)
+	-- override me
+end
+
+local function calcWindowPivot(anchorH, anchorV)
+	local pv = Vector2(0, 0)
+	if anchorH == ui.anchor.right then pv.x = 1.0 end
+	if anchorH == ui.anchor.center then pv.x = 0.5 end
+
+	if anchorV == ui.anchor.bottom then pv.y = 1.0 end
+	if anchorV == ui.anchor.center then pv.y = 0.5 end
+
+	return pv
+end
+
+local function showWindow(w)
+	if w.ShouldShow and not w:ShouldShow() then return end
+
+	ui.setNextWindowSize(w.size, "Always")
+	ui.setNextWindowPos(w.pos, "Always", w.pivot)
+	ui.withStyleColors(w.style_colors, function() ui.window(w.name, w.params, function() w:Show() end) end)
+end
+
+function layout:display()
+	if self.__dummyFrames > 0 then -- do it a few frames, because imgui need a few frames to make the correct window size
+
+		-- measuring windows (or dummies)
+		ui.withFont(self.mainFont, function()
+			for _, w in pairs(self.windows) do
+				-- draw window outside the visible viewport
+				ui.setNextWindowPos(Vector2(ui.screenWidth, 0.0), "Always")
+				ui.window(w.name, w.params, function()
+					if w.Dummy then w:Dummy() else w:Show() end
+					w.size = ui.getWindowSize()
+				end)
+			end
+		end)
+
+		-- make final calculations on the last non-working frame
+		if self.__dummyFrames == 1 then
+			for _, w in pairs(self.windows) do
+				local anchorH = w.anchors and w.anchors.h or ui.anchor.left
+				local anchorV = w.anchors and w.anchors.v or ui.anchor.top
+				w.pivot = calcWindowPivot(anchorH, anchorV)
+				w.pos = w.pivot * Vector2(ui.screenWidth, ui.screenHeight)
+			end
+
+			-- callback allows client code to override automatic window calculations
+			self:onUpdateWindowConstraints(self.windows)
+		end
+
+		self.__dummyFrames = self.__dummyFrames - 1
+	else
+		if self.enabled then
+			-- display all windows
+			ui.withFont(self.mainFont, function()
+				for _,w in pairs(self.windows) do
+					if w.visible then showWindow(w) end
+				end
+			end)
+		end
+	end
+end
+
+return layout

--- a/data/pigui/modules/flight-ui/system-overview.lua
+++ b/data/pigui/modules/flight-ui/system-overview.lua
@@ -8,15 +8,19 @@ local Lang = require 'Lang'
 local ui = require 'pigui'
 local lui = Lang.GetResource("ui-core");
 
-local width_fraction = ui.rescaleUI(6, Vector2(1920, 1200))
+local width_fraction = ui.rescaleFraction(5)
 local height_fraction = 2
+
+local style = ui.rescaleUI {
+	screenPadding = 10,
+	buttonSize = Vector2(32, 32),
+}
 
 local systemOverview = require 'pigui.modules.system-overview-window'.New()
 systemOverview.shouldDisplayPlayerDistance = true
 
 local icons = ui.theme.icons
 
-local button_size = Vector2(32,32) * (ui.screenHeight / 1200)
 local frame_padding = 1
 local bg_color = ui.theme.colors.buttonBlue
 local fg_color = ui.theme.colors.white
@@ -31,15 +35,15 @@ function systemOverview:onBodyContextMenu(sbody, body)
 end
 
 function systemOverview:overrideDrawButtons()
-	if ui.coloredSelectedIconButton(icons.distance, button_size, self.shouldSortByPlayerDistance, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SORT_BY_PLAYER_DISTANCE) then
+	if ui.coloredSelectedIconButton(icons.distance, style.buttonSize, self.shouldSortByPlayerDistance, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SORT_BY_PLAYER_DISTANCE) then
 		self.shouldSortByPlayerDistance = not self.shouldSortByPlayerDistance
 	end
 	ui.sameLine()
 
 	self:drawControlButtons()
 
-	ui.sameLine(ui.getWindowSize().x - (button_size.x + 10))
-	if ui.coloredSelectedIconButton(icons.system_overview, button_size, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
+	ui.sameLine(ui.getWindowSize().x - (style.buttonSize.x + style.screenPadding))
+	if ui.coloredSelectedIconButton(icons.system_overview, style.buttonSize, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
 		self.visible = false
 	end
 end
@@ -51,15 +55,15 @@ local function showInfoWindow()
 			systemOverview.visible = false
 		end
 		if not systemOverview.visible then
-			ui.setNextWindowPos(Vector2(ui.screenWidth - button_size.x * 3 - 10 , 10) , "Always")
+			ui.setNextWindowPos(Vector2(ui.screenWidth - style.screenPadding , style.screenPadding), "Always", Vector2(1, 0))
 			ui.window("SystemTargetsSmall", windowFlags, function()
-				if ui.coloredSelectedIconButton(icons.system_overview, button_size, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
+				if ui.coloredSelectedIconButton(icons.system_overview, style.buttonSize, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
 					systemOverview.visible = true
 				end
 			end)
 		else
 			ui.setNextWindowSize(Vector2(ui.screenWidth / width_fraction, ui.screenHeight / height_fraction) , "Always")
-			ui.setNextWindowPos(Vector2(ui.screenWidth - (ui.screenWidth / width_fraction) - 10 , 10) , "Always")
+			ui.setNextWindowPos(Vector2(ui.screenWidth - (ui.screenWidth / width_fraction) - style.screenPadding , style.screenPadding) , "Always")
 			ui.withStyleColorsAndVars({ WindowBg = ui.theme.colors.commsWindowBackground }, { WindowRounding = 0.0 }, function()
 				ui.window("SystemTargets", windowFlags, function()
 					ui.withFont(ui.fonts.pionillium.medium, function()

--- a/data/pigui/modules/flight-ui/system-overview.lua
+++ b/data/pigui/modules/flight-ui/system-overview.lua
@@ -1,0 +1,84 @@
+-- Copyright © 2008-2021 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Game = require 'Game'
+local Space = require 'Space'
+local Lang = require 'Lang'
+
+local ui = require 'pigui'
+local lui = Lang.GetResource("ui-core");
+
+local width_fraction = ui.rescaleUI(6, Vector2(1920, 1200))
+local height_fraction = 2
+
+local systemOverview = require 'pigui.modules.system-overview-window'.New()
+
+local icons = ui.theme.icons
+
+local button_size = Vector2(32,32) * (ui.screenHeight / 1200)
+local frame_padding = 1
+local bg_color = ui.theme.colors.buttonBlue
+local fg_color = ui.theme.colors.white
+
+function systemOverview:onBodySelected(sbody, body)
+	Game.player:SetNavTarget(body)
+	ui.playSfx("OK")
+end
+
+function systemOverview:onBodyContextMenu(sbody, body)
+	ui.openDefaultRadialMenu(body)
+end
+
+function systemOverview:overrideDrawButtons()
+	if ui.coloredSelectedIconButton(icons.distance, button_size, self.shouldSortByPlayerDistance, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SORT_BY_PLAYER_DISTANCE) then
+		self.shouldSortByPlayerDistance = not self.shouldSortByPlayerDistance
+	end
+	ui.sameLine()
+
+	self:drawControlButtons()
+
+	ui.sameLine(ui.getWindowSize().x - (button_size.x + 10))
+	if ui.coloredSelectedIconButton(icons.system_overview, button_size, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
+		self.visible = false
+	end
+end
+
+local windowFlags = ui.WindowFlags {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"}
+local function showInfoWindow()
+	if Game.CurrentView() == "world" then
+		if Game.InHyperspace() or not Game.system.explored then
+			systemOverview.visible = false
+		end
+		if not systemOverview.visible then
+			ui.setNextWindowPos(Vector2(ui.screenWidth - button_size.x * 3 - 10 , 10) , "Always")
+			ui.window("SystemTargetsSmall", windowFlags, function()
+				if ui.coloredSelectedIconButton(icons.system_overview, button_size, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
+					systemOverview.visible = true
+				end
+			end)
+		else
+			ui.setNextWindowSize(Vector2(ui.screenWidth / width_fraction, ui.screenHeight / height_fraction) , "Always")
+			ui.setNextWindowPos(Vector2(ui.screenWidth - (ui.screenWidth / width_fraction) - 10 , 10) , "Always")
+			ui.withStyleColorsAndVars({ WindowBg = ui.theme.colors.commsWindowBackground }, { WindowRounding = 0.0 }, function()
+				ui.window("SystemTargets", windowFlags, function()
+					ui.withFont(ui.fonts.pionillium.medium, function()
+						local root = Space.rootSystemBody
+						local selected = { [Game.player:GetNavTarget() or 0] = true }
+
+						systemOverview:display(Game.system, root, selected)
+					end)
+				end)
+			end)
+
+			if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) then
+				package.reimport 'pigui.modules.system-overview-window'
+				package.reimport()
+			end
+		end
+	end
+end
+
+ui.registerModule("game", {
+	id = "system-overview-window",
+	draw = showInfoWindow
+})

--- a/data/pigui/modules/flight-ui/system-overview.lua
+++ b/data/pigui/modules/flight-ui/system-overview.lua
@@ -12,6 +12,7 @@ local width_fraction = ui.rescaleUI(6, Vector2(1920, 1200))
 local height_fraction = 2
 
 local systemOverview = require 'pigui.modules.system-overview-window'.New()
+systemOverview.shouldDisplayPlayerDistance = true
 
 local icons = ui.theme.icons
 

--- a/data/pigui/modules/system-overview-window.lua
+++ b/data/pigui/modules/system-overview-window.lua
@@ -13,9 +13,12 @@ local getBodyIcon = require 'pigui.modules.flight-ui.body-icons'
 local colors = ui.theme.colors
 local icons = ui.theme.icons
 
-local iconSize = Vector2(24,24)
-local bodyIconSize = Vector2(18,18)
-local button_size = Vector2(32,32) * (ui.screenHeight / 1200)
+local style = ui.rescaleUI {
+	iconSize = Vector2(24,24),
+	bodyIconSize = Vector2(18,18),
+	buttonSize = Vector2(32,32),
+}
+
 local frame_padding = 1
 local bg_color = colors.buttonBlue
 local fg_color = colors.white
@@ -65,7 +68,7 @@ local function make_result(systemBody, label, isSelected)
 end
 
 -- Returns a table of entries.
--- Each entry will have { children_visible = true } if they are a parent of, or a selected object
+-- Each entry will have { children_visible = true } if they are a parent of, or are a selected object
 -- Entries that are excluded by the current filter will have { visible = false }
 ---@return table @ SystemBody entry
 ---@return boolean @ whether this entry is part of the chain of selected objects
@@ -75,6 +78,8 @@ local function calculateEntry(systemBody, parent, selected, filter)
 
 	result = make_result(systemBody, systemBody.name, isSelected)
 	result.visible = isSelected or filter(systemBody)
+
+	-- Set show-flags on the direct parent of this body
 	if systemBody.isSpaceStation then
 		parent.has_space_stations = true
 	elseif systemBody.isGroundStation then
@@ -113,13 +118,13 @@ function SystemOverviewWidget:renderEntry(entry, indent)
 	local sbody = entry.systemBody
 	local label = entry.label or "UNKNOWN"
 
-	ui.dummy(Vector2(iconSize.x * indent / 2.0, iconSize.y))
+	ui.dummy(Vector2(style.iconSize.x * indent / 2.0, style.iconSize.y))
 	ui.sameLine()
-	ui.icon(getBodyIcon(sbody), iconSize, colors.font)
+	ui.icon(getBodyIcon(sbody), style.iconSize, colors.font)
 	ui.sameLine()
 
 	local pos = ui.getCursorPos()
-	if ui.selectable("##" .. label, entry.selected, {"SpanAllColumns"}, Vector2(0, iconSize.y)) then
+	if ui.selectable("##" .. label, entry.selected, {"SpanAllColumns"}, Vector2(0, style.iconSize.y)) then
 		self:onBodySelected(sbody, entry.body)
 	end
 	if ui.isItemHovered() and ui.isMouseDoubleClicked(0) then
@@ -130,27 +135,27 @@ function SystemOverviewWidget:renderEntry(entry, indent)
 	end
 
 	ui.setCursorPos(pos)
-	ui.alignTextToLineHeight(iconSize.y)
+	ui.alignTextToLineHeight(style.iconSize.y)
 	ui.text(label)
 	ui.sameLine()
 
 	if entry.has_moons then
-		ui.icon(icons.moon, bodyIconSize, colors.font)
+		ui.icon(icons.moon, style.bodyIconSize, colors.font)
 		ui.sameLine(0,0.01)
 	end
 	if entry.has_ground_stations then
-		ui.icon(icons.starport, bodyIconSize, colors.font)
+		ui.icon(icons.starport, style.bodyIconSize, colors.font)
 		ui.sameLine(0,0.01)
 	end
 	if entry.has_space_stations then
-		ui.icon(icons.spacestation, bodyIconSize, colors.font)
+		ui.icon(icons.spacestation, style.bodyIconSize, colors.font)
 		ui.sameLine(0,0.01)
 	end
 
 	ui.nextColumn()
-	ui.dummy(Vector2(0, iconSize.y))
+	ui.dummy(Vector2(0, style.iconSize.y))
 	ui.sameLine()
-	ui.alignTextToLineHeight(iconSize.y)
+	ui.alignTextToLineHeight(style.iconSize.y)
 
 	local distance
 	if entry.body and self.shouldDisplayPlayerDistance then
@@ -175,11 +180,11 @@ function SystemOverviewWidget:showEntry(entry, indent, sortFunction)
 end
 
 function SystemOverviewWidget:drawControlButtons()
-	if ui.coloredSelectedIconButton(icons.moon, button_size, self.shouldShowMoons, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_MOONS) then
+	if ui.coloredSelectedIconButton(icons.moon, style.buttonSize, self.shouldShowMoons, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_MOONS) then
 		self.shouldShowMoons = not self.shouldShowMoons
 	end
 	ui.sameLine()
-	if ui.coloredSelectedIconButton(icons.filter_stations, button_size, self.shouldShowStations, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_STATIONS) then
+	if ui.coloredSelectedIconButton(icons.filter_stations, style.buttonSize, self.shouldShowStations, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_STATIONS) then
 		self.shouldShowStations = not self.shouldShowStations
 	end
 end
@@ -198,7 +203,7 @@ function SystemOverviewWidget:display(system, root, selected)
 	self.focusSearchResults = filterText and filterText ~= ""
 
 	ui.sameLine()
-	ui.icon(icons.filter_bodies, button_size, colors.frame, lui.OVERVIEW_NAME_FILTER)
+	ui.icon(icons.filter_bodies, style.buttonSize, colors.frame, lui.OVERVIEW_NAME_FILTER)
 
 	local sortFunction = self.shouldSortByPlayerDistance and sortByPlayerDistance or sortBySystemDistance
 

--- a/data/pigui/modules/system-overview-window.lua
+++ b/data/pigui/modules/system-overview-window.lua
@@ -1,197 +1,207 @@
 -- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local Engine = require 'Engine'
 local Game = require 'Game'
-local Space = require 'Space'
 local Format = require 'Format'
-local utils = require 'utils'
-
 local Lang = require 'Lang'
-local lui = Lang.GetResource("ui-core");
+local utils = require "libs.utils"
 
 local ui = require 'pigui'
+local lui = Lang.GetResource("ui-core");
+local getBodyIcon = require 'pigui.modules.flight-ui.body-icons'
 
 local colors = ui.theme.colors
 local icons = ui.theme.icons
 
-local getBodyIcon = require 'pigui.modules.flight-ui.body-icons'
 local iconSize = Vector2(24,24)
 local bodyIconSize = Vector2(18,18)
-local width_fraction = ui.rescaleUI(6, Vector2(1920, 1200))
-local height_fraction = 2
 local button_size = Vector2(32,32) * (ui.screenHeight / 1200)
 local frame_padding = 1
 local bg_color = colors.buttonBlue
 local fg_color = colors.white
 
+-- Reusable widget to list the static contents of a system.
+-- Intended to be used by flight-ui as a list of nav targets,
+-- and the system info view as a list of bodies in-system
+
+local SystemOverviewWidget = utils.inherits(nil, 'ui.SystemOverviewWidget')
+
+function SystemOverviewWidget.New(args)
+	local self = {}
+	self.shouldSortByPlayerDistance = false
+	self.shouldShowStations = false
+	self.shouldShowMoons = false
+	self.visible = false
+	self.filterText = ""
+
+	return setmetatable(self, SystemOverviewWidget.meta)
+end
+
 local function sortByPlayerDistance(a,b)
-	if a.body == nil then
-		return false;
-	end
-
-	if b.body == nil then
-		return false;
-	end
-
-	return a.body:DistanceTo(Game.player) < b.body:DistanceTo(Game.player)
+	return (a.body and b.body) and a.body:DistanceTo(Game.player) < b.body:DistanceTo(Game.player)
 end
 
 local function sortBySystemDistance(a,b)
 	return (a.systemBody.periapsis + a.systemBody.apoapsis) < (b.systemBody.periapsis + b.systemBody.apoapsis)
 end
-local function calculateEntry(systemBody, parent, navTarget, filterFunction, always_include)
-	local body = systemBody.body
+
+local function make_result(systemBody, label, childrenVisible)
+	return {
+		systemBody = systemBody,
+		body = systemBody.body,
+		label = label,
+		children = {},
+		visible = true,
+		children_visible = childrenVisible,
+		has_space_stations = false,
+		has_ground_stations = false,
+		has_moons = false,
+	}
+end
+
+-- Returns a table of entries.
+-- Each entry will have { children_visible = true } if they are a parent of, or a selected object
+-- Entries that are excluded by the current filter will have { visible = false }
+---@return table @ SystemBody entry
+---@return boolean @ whether this entry is part of the chain of selected objects
+local function calculateEntry(systemBody, parent, selected, filter)
 	local result = nil
-	local should_discard = false
-	local is_target = body == navTarget
-	if body then
-		result = { systemBody = systemBody,
-			body = body,
-			label = body.label,
-			children = {},
-			is_target = is_target,
-			has_space_stations = false,
-			has_ground_stations = false,
-			has_moons = false,
-		}
-		if not filterFunction(body) then
-			should_discard = true
-		end
-		if body:IsSpaceStation() then
-			parent.has_space_stations = true
-		elseif body:IsGroundStation() then
-			parent.has_ground_stations = true
-		elseif body:IsMoon() then
-			parent.has_moons = true
-		end
-	else
-		result = { systemBody = systemBody,
-			body = nil,
-			label = systemBody.name,
-			children = {},
-			is_target = false,
-			has_space_stations = false,
-			has_ground_stations = false,
-			has_moons = false,
-		}
+	local is_target = selected[systemBody] or (systemBody.body and selected[systemBody.body]) or false
+
+	result = make_result(systemBody, systemBody.name, is_target)
+	result.visible = is_target or filter(systemBody)
+	if systemBody.isSpaceStation then
+		parent.has_space_stations = true
+	elseif systemBody.isGroundStation then
+		parent.has_ground_stations = true
+	elseif systemBody.isMoon then
+		parent.has_moons = true
 	end
 
-	local children = systemBody.children or {}
-	for _,v in pairs(children) do
-		local c = calculateEntry(v, result, navTarget, filterFunction, is_target)
-		if c then
-			should_discard = false
-			table.insert(result.children, c)
-		end
+	for _, child in pairs(systemBody.children or {}) do
+		table.insert(result.children, calculateEntry(child, result, selected, filter))
 	end
-	if should_discard and not always_include and not is_target then
-		return nil
-	else
-		return result
+
+	-- propagate children_visible and visible upwards
+	if parent then
+		if result.visible then parent.visible = true end
+		if result.children_visible then parent.children_visible = true end
 	end
+
+	return result
 end
-local function showEntry(entry, indent, sortFunction)
-	local body = entry.body
-	local is_target = entry.is_target
-	local label = entry.label
-	local has_ground_stations = entry.has_ground_stations
-	local has_space_stations = entry.has_space_stations
-	local has_moons = entry.has_moons
-	if body then
-		ui.dummy(Vector2(iconSize.x * indent / 2.0, iconSize.y))
-		ui.sameLine()
-		ui.icon(getBodyIcon(body), iconSize, colors.white)
-		ui.sameLine()
-		local pos = ui.getCursorPos()
-		if ui.selectable("##" .. (label or "UNKNOWN"), is_target, {"SpanAllColumns"}, Vector2(0, iconSize.y)) then
-			Game.player:SetNavTarget(body)
-			ui.playSfx("OK")
-		end
-		if ui.isItemHovered() and ui.isMouseClicked(1) then
-			ui.openDefaultRadialMenu(body)
-		end
-		ui.setCursorPos(pos)
-		ui.alignTextToLineHeight(iconSize.y)
-		ui.text(label or "UNKNOWN")
-		ui.sameLine()
-		if has_moons then
-			ui.icon(icons.moon, bodyIconSize, colors.white)
-			ui.sameLine(0,0.01)
-		end
-		if has_ground_stations then
-			ui.icon(icons.starport, bodyIconSize, colors.white)
-			ui.sameLine(0,0.01)
-		end
-		if has_space_stations then
-			ui.icon(icons.spacestation, bodyIconSize, colors.white)
-			ui.sameLine(0,0.01)
-		end
-		ui.nextColumn()
-		ui.dummy(Vector2(0, iconSize.y))
-		ui.sameLine()
-		ui.alignTextToLineHeight(iconSize.y)
-		ui.text(Format.Distance(body:DistanceTo(Game.player)))
-		ui.nextColumn()
+
+-- Render a row for an entry in the system overview
+function SystemOverviewWidget:renderEntry(entry, indent, selected)
+	local sbody = entry.systemBody
+	local label = entry.label or "UNKNOWN"
+	local isSelected = selected[sbody] or selected[entry.body]
+
+	ui.dummy(Vector2(iconSize.x * indent / 2.0, iconSize.y))
+	ui.sameLine()
+	ui.icon(getBodyIcon(sbody), iconSize, colors.font)
+	ui.sameLine()
+
+	local pos = ui.getCursorPos()
+	if ui.selectable("##" .. label, isSelected, {"SpanAllColumns"}, Vector2(0, iconSize.y)) then
+		self:onBodySelected(sbody, entry.body)
 	end
-	local children = entry.children or {}
-	table.sort(children, sortFunction)
-	for _,v in pairs(children) do
-		showEntry(v, indent + 1, sortFunction)
+	if ui.isItemHovered() and ui.isMouseClicked(1) then
+		self:onBodyContextMenu(sbody, entry.body)
+	end
+
+	ui.setCursorPos(pos)
+	ui.alignTextToLineHeight(iconSize.y)
+	ui.text(label)
+	ui.sameLine()
+
+	if entry.has_moons then
+		ui.icon(icons.moon, bodyIconSize, colors.font)
+		ui.sameLine(0,0.01)
+	end
+	if entry.has_ground_stations then
+		ui.icon(icons.starport, bodyIconSize, colors.font)
+		ui.sameLine(0,0.01)
+	end
+	if entry.has_space_stations then
+		ui.icon(icons.spacestation, bodyIconSize, colors.font)
+		ui.sameLine(0,0.01)
+	end
+
+	ui.nextColumn()
+	ui.dummy(Vector2(0, iconSize.y))
+	ui.sameLine()
+	ui.alignTextToLineHeight(iconSize.y)
+
+	local distance
+	if entry.body and self.showingActiveSystem then
+		distance = entry.body:DistanceTo(Game.player)
+	else
+		distance = (sbody.apoapsis + sbody.periapsis) / 2.0
+	end
+	ui.text(Format.Distance(distance))
+	ui.nextColumn()
+end
+
+function SystemOverviewWidget:showEntry(entry, indent, selected, sortFunction)
+	self:renderEntry(entry, indent, selected)
+
+	table.sort(entry.children, sortFunction)
+	for _, v in pairs(entry.children) do
+		if v.visible or entry.children_visible then
+			self:showEntry(v, indent + 1, selected, sortFunction)
+		end
 	end
 end
 
-
-local shouldSortByPlayerDistance = false
-local shouldShowStations = false
-local shouldShowMoons = false
-local filterText = ""
-local showWindow = false
-
-local function drawBodyList()
-	if ui.coloredSelectedIconButton(icons.distance, button_size, shouldSortByPlayerDistance, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SORT_BY_PLAYER_DISTANCE) then
-		shouldSortByPlayerDistance = not shouldSortByPlayerDistance
+function SystemOverviewWidget:drawControlButtons()
+	if ui.coloredSelectedIconButton(icons.moon, button_size, self.shouldShowMoons, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_MOONS) then
+		self.shouldShowMoons = not self.shouldShowMoons
 	end
 	ui.sameLine()
-	if ui.coloredSelectedIconButton(icons.moon, button_size, shouldShowMoons, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_MOONS) then
-		shouldShowMoons = not shouldShowMoons
+	if ui.coloredSelectedIconButton(icons.filter_stations, button_size, self.shouldShowStations, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_STATIONS) then
+		self.shouldShowStations = not self.shouldShowStations
 	end
-	ui.sameLine()
-	if ui.coloredSelectedIconButton(icons.filter_stations, button_size, shouldShowStations, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_SHOW_STATIONS) then
-		shouldShowStations = not shouldShowStations
-	end
-	ui.sameLine(ui.getWindowSize().x - (button_size.x + 10))
-	if ui.coloredSelectedIconButton(icons.system_overview, button_size, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
-		showWindow = false
-	end
+end
 
-	filterText = ui.inputText("", filterText, {})
+function SystemOverviewWidget:overrideDrawButtons()
+	self:drawControlButtons()
+end
+
+function SystemOverviewWidget:display(system, root, selected)
+	self.showingActiveSystem = Game.system.path:IsSameSystem(system.path)
+	self:overrideDrawButtons()
+
+	root = root or system.rootSystemBody
+
+	local filterText = ui.inputText("", self.filterText, {})
+	self.filterText = filterText
+
 	ui.sameLine()
 	ui.icon(icons.filter_bodies, button_size, colors.frame, lui.OVERVIEW_NAME_FILTER)
 
-	local sortFunction = shouldSortByPlayerDistance and sortByPlayerDistance or sortBySystemDistance
-	local filterFunction = function(body)
-		if body then
-			-- only plain text matches, no regexes
-			if filterText ~= "" and filterText ~= nil and not string.find(body.label:lower(), filterText:lower(), 1, true) then
-				return false
-			end
-			if (not shouldShowMoons) and body:IsMoon() then
-				return false
-			elseif (not shouldShowStations) and body:IsStation() then
-				return false
-			end
+	local sortFunction = self.shouldSortByPlayerDistance and sortByPlayerDistance or sortBySystemDistance
+
+	local filterFunction = function(systemBody)
+		-- only plain text matches, no regexes
+		if filterText ~= "" and filterText ~= nil and not string.find(systemBody.name:lower(), filterText:lower(), 1, true) then
+			return false
+		end
+		if (not self.shouldShowMoons) and systemBody.isMoon then
+			return false
+		elseif (not self.shouldShowStations) and systemBody.isStation then
+			return false
 		end
 		return true
 	end
 
 	ui.child("spaceTargets", function()
-		local root = Space.rootSystemBody
-		local tree = calculateEntry(root, nil, Game.player:GetNavTarget(), filterFunction, false)
+		local tree = calculateEntry(root, nil, selected, filterFunction)
+
 		if tree then
 			ui.columns(2, "spaceTargetColumnsOn", false) -- no border
-			ui.setColumnOffset(1, ui.screenWidth / width_fraction * 0.66)
-			showEntry(tree, 0, sortFunction)
+			ui.setColumnOffset(1, ui.getWindowSize().x * 0.66)
+			self:showEntry(tree, 0, selected, sortFunction)
 			ui.columns(1, "spaceTargetColumnsOff", false) -- no border
 			ui.radialMenu("systemoverviewspacetargets")
 		else
@@ -200,40 +210,4 @@ local function drawBodyList()
 	end)
 end
 
-local function showInfoWindow()
-	if Game.CurrentView() == "world" then
-		if Game.InHyperspace() or not Game.system.explored then
-			showWindow = false
-		end
-		if not showWindow then
-			ui.setNextWindowPos(Vector2(ui.screenWidth - button_size.x * 3 - 10 , 10) , "Always")
-			ui.window("SystemTargetsSmall", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"},
-			function()
-				if ui.coloredSelectedIconButton(icons.system_overview, button_size, false, frame_padding, bg_color, fg_color, lui.TOGGLE_OVERVIEW_WINDOW) then
-					showWindow = true
-				end
-			end)
-		else
-			ui.setNextWindowSize(Vector2(ui.screenWidth / width_fraction, ui.screenHeight / height_fraction) , "Always")
-			ui.setNextWindowPos(Vector2(ui.screenWidth - (ui.screenWidth / width_fraction) - 10 , 10) , "Always")
-			ui.withStyleColorsAndVars({ ["WindowBg"] = colors.commsWindowBackground }, { ["WindowRounding"] = 0.0 }, function()
-				ui.window("SystemTargets", {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus"}, function()
-					ui.withFont(ui.fonts.pionillium.medium, drawBodyList)
-				end)
-			end)
-
-			if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) then
-				package.reimport()
-			end
-		end
-	end
-end
-
-ui.registerModule("game", {
-	id = "system-overview-window",
-	draw = showInfoWindow
-})
-ui.toggleSystemTargets = function()
-	showWindow = not showWindow
-end
-return {}
+return SystemOverviewWidget

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -498,6 +498,7 @@ local function displayOnScreenObjects()
 				if isOrrery and ui.selectable(lc.CENTER, false, {}) then
 					selectedObject = mainObject.ref
 					systemView:SetSelectedObject(mainObject.type, mainObject.base, mainObject.ref)
+					systemView:ViewSelectedObject()
 				end
 				if (isShip or isSystemBody and mainObject.ref.physicsBody) and ui.selectable(lc.SET_AS_TARGET, false, {}) then
 					if isSystemBody then

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -12,6 +12,7 @@ local Constants = _G.Constants
 local Vector2 = _G.Vector2
 local lc = Lang.GetResource("core")
 local luc = Lang.GetResource("ui-core")
+local layout = require 'pigui.libs.window-layout'
 
 local player = nil
 local colors = ui.theme.colors
@@ -79,7 +80,7 @@ local svColor = {
 }
 
 -- button states
-local function loop3items(a, b, c) return { [a] = b, [b] = c, [c] = a } end
+local function loop3items(a, b, c) return a, { [a] = b, [b] = c, [c] = a } end
 
 local buttonState = {
 	SHIPS_OFF     = { icon = icons.ships_no_orbits,    color = svColor.BUTTON_INACTIVE },
@@ -96,12 +97,9 @@ local buttonState = {
 	DISABLED      = {                                  color = svColor.BUTTON_SEMIACTIVE }
 }
 
-local ship_drawing = "SHIPS_OFF"
-local show_lagrange = "LAG_OFF"
-local show_grid = "GRID_OFF"
-local nextShipDrawings = loop3items("SHIPS_OFF", "SHIPS_ON", "SHIPS_ORBITS")
-local nextShowLagrange = loop3items("LAG_OFF", "LAG_ICON", "LAG_ICONTEXT")
-local nextShowGrid = loop3items("GRID_OFF", "GRID_ON", "GRID_AND_LEGS")
+local ship_drawing,  nextShipDrawings = loop3items("SHIPS_OFF", "SHIPS_ON", "SHIPS_ORBITS")
+local show_lagrange, nextShowLagrange = loop3items("LAG_OFF", "LAG_ICON", "LAG_ICONTEXT")
+local show_grid,     nextShowGrid     = loop3items("GRID_OFF", "GRID_ON", "GRID_AND_LEGS")
 
 local onGameStart = function ()
 	--connect to class SystemView
@@ -173,25 +171,18 @@ local function timeButton(icon, tooltip, factor)
 	return active
 end
 
-local function newWindow(name)
-	return {
-		size = Vector2(0.0, 0.0),
-		pos = Vector2(0.0, 0.0),
-		visible = true,
-		name = name,
-		style_colors = {["WindowBg"] = svColor.WINDOW_BG},
-		params = {"NoTitleBar", "AlwaysAutoResize", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"}
-	}
-end
-
 -- all windows in this view
 local Windows = {
-	systemName = newWindow("SystemMapSystemName"),
-	objectInfo = newWindow("SystemMapObjectIngo"),
-	edgeButtons = newWindow("SystemMapEdgeButtons"),
-	orbitPlanner = newWindow("SystemMapOrbitPlanner"),
-	timeButtons = newWindow("SystemMapTimeButtons")
+	systemName = layout.NewWindow("SystemMapSystemName"),
+	objectInfo = layout.NewWindow("SystemMapObjectIngo"),
+	edgeButtons = layout.NewWindow("SystemMapEdgeButtons"),
+	orbitPlanner = layout.NewWindow("SystemMapOrbitPlanner"),
+	timeButtons = layout.NewWindow("SystemMapTimeButtons"),
+	unexplored = layout.NewWindow("SystemMapUnexplored")
 }
+
+local systemViewLayout = layout.New(Windows)
+systemViewLayout.mainFont = winfont
 
 local function edgeButton(icon, tooltip, state)
 	return ui.coloredSelectedIconButton(icon, mainButtonSize, false, mainButtonFramePadding, (state ~= nil and state.color or svColor.BUTTON_ACTIVE), svColor.BUTTON_INK, tooltip)
@@ -250,11 +241,6 @@ function Windows.orbitPlanner.ShouldShow()
 end
 
 function Windows.orbitPlanner.Show()
-	if not Windows.orbitPlanner:ShouldShow() then
-		Windows.orbitPlanner.visible = false
-		return
-	end
-
 	textIcon(icons.semi_major_axis)
 	ui.text(lc.ORBIT_PLANNER)
 	ui.separator()
@@ -412,8 +398,11 @@ local function drawAtlasBodyLabel(label, screenSize, mainCoords, isHovered, isSe
 	ui.addStyledText(labelPos, ui.anchor.left, ui.anchor.baseline, label, fontColor, font)
 end
 
+Windows.unexplored.visible = false
+function Windows.unexplored.Show()
+	ui.text(lc.UNEXPLORED_SYSTEM_NO_SYSTEM_VIEW)
+end
 
-local unexloredWindowFlags = ui.WindowFlags {"NoTitleBar", "AlwaysAutoResize", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings", "NoInputs"}
 -- forked from data/pigui/views/game.lua
 local function displayOnScreenObjects()
 	local isOrrery = systemView:GetDisplayMode() == 'Orrery'
@@ -433,16 +422,10 @@ local function displayOnScreenObjects()
 	-- to prevent overlap of selection regions
 	local objectCounter = 0
 	local objects_grouped = systemView:GetProjectedGrouped(collapse, 1e64)
-	if #objects_grouped == 0 then
-		ui.setNextWindowPos(Vector2(ui.screenWidth, ui.screenHeight) / 2 - ui.calcTextSize(lc.UNEXPLORED_SYSTEM_NO_SYSTEM_VIEW) / 2, "Always")
-		ui.withStyleColors({["WindowBg"] = svColor.WINDOW_BG}, function()
-			ui.window("NoSystemView", unexloredWindowFlags,
-			function()
-				ui.text(lc.UNEXPLORED_SYSTEM_NO_SYSTEM_VIEW);
-			end)
-		end)
-		return
-	end
+
+	-- if there's nothing to display, we're an unexplored system
+	Windows.unexplored.visible = #objects_grouped == 0
+	if Windows.unexplored.visible then return end
 
 	local hoveredObject = nil
 	local atlas_label_objects = {}
@@ -675,66 +658,35 @@ function Windows.objectInfo.Dummy()
 	ui.text("TAB LINE")
 end
 
-local function showWindow(w)
-	if w.ShouldShow and not w:ShouldShow() then return end
-	ui.setNextWindowSize(w.size, "Always")
-	ui.setNextWindowPos(w.pos, "Always")
-	ui.withStyleColors(w.style_colors, function() ui.window(w.name, w.params, w.Show) end)
+function systemViewLayout:onUpdateWindowPivots(w)
+	w.edgeButtons.anchors = { ui.anchor.right, ui.anchor.center }
+	w.timeButtons.anchors = { ui.anchor.right, ui.anchor.bottom }
+	w.orbitPlanner.anchors = { ui.anchor.right, ui.anchor.bottom }
+	w.objectInfo.anchors = { ui.anchor.right, ui.anchor.bottom }
 end
 
-local dummyFrames = 3
+function systemViewLayout:onUpdateWindowConstraints(w)
+	-- resizing, aligning windows - static
+	w.systemName.pos = Vector2(winfont.size)
+	w.systemName.size.x = 0 -- adaptive width
 
-local hideSystemViewWindows = false
+	w.orbitPlanner.pos = w.timeButtons.pos - Vector2(w.edgeButtons.size.x, w.timeButtons.size.y)
+	w.orbitPlanner.size.x = w.timeButtons.size.x - w.edgeButtons.size.x
+	w.objectInfo.pos = w.orbitPlanner.pos - Vector2(0, w.orbitPlanner.size.y)
+	w.objectInfo.size = Vector2(w.orbitPlanner.size.x, 0) -- adaptive height
+end
 
 local function displaySystemViewUI()
 	if not systemView then onGameStart() end
 
 	player = Game.player
-	local current_view = Game.CurrentView()
-	if current_view == "system" then
-		if dummyFrames > 0 then -- do it a few frames, because imgui need a few frames to make the correct window size
-
-			-- first, doing some one-time actions here
-			-- measuring windows (or dummies)
-			ui.withFont(winfont, function()
-				for _,w in pairs(Windows) do
-					ui.setNextWindowPos(Vector2(ui.screenWidth, 0.0), "Always")
-					ui.window(w.name, w.params, function()
-						if w.Dummy then w.Dummy()
-						else w.Show()
-						end
-						w.size = ui.getWindowSize()
-					end)
-				end
-			end)
-
-			-- make final calculations on the last non-working frame
-			if dummyFrames == 1 then
-				-- resizing, aligning windows - static
-				Windows.systemName.pos = Vector2(winfont.size)
-				Windows.systemName.size.x = 0 -- adaptive width
-				Windows.edgeButtons.pos = Vector2(ui.screenWidth - Windows.edgeButtons.size.x, ui.screenHeight / 2 - Windows.edgeButtons.size.y / 2) -- center-right
-				Windows.timeButtons.pos = Vector2(ui.screenWidth, ui.screenHeight) - Windows.timeButtons.size
-				Windows.orbitPlanner.pos = Windows.timeButtons.pos - Vector2(0, Windows.orbitPlanner.size.y)
-				Windows.orbitPlanner.size.x = Windows.edgeButtons.pos.x - Windows.timeButtons.pos.x
-				Windows.objectInfo.pos = Windows.orbitPlanner.pos - Vector2(0, Windows.objectInfo.size.y)
-				Windows.objectInfo.size = Vector2(Windows.orbitPlanner.size.x, 0) -- adaptive height
-			end
-			dummyFrames = dummyFrames - 1
-		else
-			if ui.isKeyReleased(ui.keys.tab) then
-				hideSystemViewWindows = not hideSystemViewWindows;
-			end
-			if not hideSystemViewWindows then
-				-- display all windows
-				ui.withFont(winfont, function()
-					for _,w in pairs(Windows) do
-						if w.visible then showWindow(w) end
-					end
-				end)
-			end
-			displayOnScreenObjects()
+	if Game.CurrentView() == "system" then
+		if ui.isKeyReleased(ui.keys.tab) then
+			systemViewLayout.enabled = not systemViewLayout.enabled
 		end
+
+		systemViewLayout:display()
+		displayOnScreenObjects()
 
 		if ui.escapeKeyReleased() then
 			Game.SetView("sector")

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -459,7 +459,7 @@ ui.registerModule("game", function()
 
 		if ui.isKeyReleased(ui.keys.tab) then
 			sectorViewLayout.enabled = not sectorViewLayout.enabled
-			sectorView:SetLabelsVisibility(hideSectorViewWindows)
+			sectorView:SetLabelsVisibility(not sectorViewLayout.enabled)
 		end
 
 		if ui.escapeKeyReleased() then

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -13,11 +13,11 @@ local lc = Lang.GetResource("core");
 local lui = Lang.GetResource("ui-core");
 
 local ui = require 'pigui'
+local layout = require 'pigui.libs.window-layout'
 
 local player = nil
 local colors = ui.theme.colors
 local icons = ui.theme.icons
-local hideSectorViewWindows = false
 
 local mainButtonSize = ui.rescaleUI(Vector2(32,32), Vector2(1600, 900))
 local mainButtonFramePadding = 3
@@ -91,25 +91,14 @@ local function getHyperspaceDetails(path)
 	return it
 end
 
-local function newWindow(name)
-	return {
-		size = Vector2(0.0, 0.0),
-		pos = Vector2(0.0, 0.0),
-		visible = true,
-		name = name,
-		style_colors = {["WindowBg"] = svColor.WINDOW_BG},
-		params = ui.WindowFlags {"NoTitleBar", "AlwaysAutoResize", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"}
-	}
-end
-
 -- all windows in this view
 local Windows = {
-	current = newWindow("SectorMapCurrentSystem"), -- current system string
-	hjPlanner = newWindow("HyperJumpPlanner"), -- hyper jump planner
-	systemInfo = newWindow("SectorMapSystemInfo"), -- selected system information
-	searchBar = newWindow("SectorMapSearchBar"),
-	edgeButtons = newWindow("SectorMapEdgeButtons"),
-	factions = newWindow("SectorMapFactions")
+	current = layout.NewWindow("SectorMapCurrentSystem"), -- current system string
+	hjPlanner = layout.NewWindow("HyperJumpPlanner"), -- hyper jump planner
+	systemInfo = layout.NewWindow("SectorMapSystemInfo"), -- selected system information
+	searchBar = layout.NewWindow("SectorMapSearchBar"),
+	edgeButtons = layout.NewWindow("SectorMapEdgeButtons"),
+	factions = layout.NewWindow("SectorMapFactions")
 }
 
 local statusIcons = {
@@ -120,6 +109,9 @@ local statusIcons = {
 	OUT_OF_RANGE = { icon = icons.alert_generic },
 	NO_DRIVE = { icon = icons.hyperspace_off }
 }
+
+local sectorViewLayout = layout.New(Windows)
+sectorViewLayout.mainFont = font
 
 local function draw_jump_status(item)
 	textIcon(statusIcons[item.jumpStatus].icon, lui[item.jumpStatus])
@@ -432,72 +424,50 @@ end
 Windows.hjPlanner.Show = hyperJumpPlanner.display
 Windows.hjPlanner.Dummy = hyperJumpPlanner.Dummy
 
-local function showWindow(w)
-	ui.setNextWindowSize(w.size, "Always")
-	ui.setNextWindowPos(w.pos, "Always")
-	ui.withStyleColors(w.style_colors, function() ui.window(w.name, w.params, function() w:Show() end) end)
+function sectorViewLayout:onUpdateWindowPivots(w)
+	w.hjPlanner.anchors = { ui.anchor.right, ui.anchor.bottom }
+	w.systemInfo.anchors = { ui.anchor.right, ui.anchor.bottom }
+	w.edgeButtons.anchors = { ui.anchor.right, ui.anchor.center }
+	w.factions.anchors = { ui.anchor.right, ui.anchor.top }
 end
 
-local dummyFrames = 3
+function sectorViewLayout:onUpdateWindowConstraints(w)
+	-- resizing, aligning windows - static
+	w.current.pos = edgePadding
+	w.current.size.x = 0 -- adaptive width
 
-local function displaySectorViewWindow()
+	w.searchBar.pos = w.current.pos + w.current.size
+	w.searchBar.collapsedHeight = w.searchBar.size.y
+	w.searchBar.fullHeight = ui.screenHeight - w.searchBar.pos.y - edgePadding.y - ui.timeWindowSize.y
+	w.searchBar.size.y = w.searchBar.fullHeight
+
+	local rightColWidth = math.max(w.hjPlanner.size.x, w.systemInfo.size.x)
+	w.hjPlanner.pos = w.hjPlanner.pos - Vector2(w.edgeButtons.size.x, edgePadding.y)
+	w.hjPlanner.size.x = rightColWidth
+
+	w.systemInfo.pos = w.hjPlanner.pos - Vector2(0, w.hjPlanner.size.y)
+	w.systemInfo.size.x = rightColWidth
+
+	w.factions.pos = Vector2(w.hjPlanner.pos.x, edgePadding.y)
+	w.factions.size = Vector2(rightColWidth, 0.0) -- adaptive height
+end
+
+ui.registerModule("game", function()
 	player = Game.player
 	if Game.CurrentView() == "sector" then
-		if dummyFrames > 0 then -- do it a few frames, because imgui need a few frames to make the correct window size
+		sectorViewLayout:display()
 
-			-- measuring windows (or dummies)
-			ui.withFont(font, function()
-				for _,w in pairs(Windows) do
-					ui.setNextWindowPos(Vector2(ui.screenWidth, 0.0), "Always")
-					ui.window(w.name, w.params, function()
-						if w.Dummy then w.Dummy()
-						else w.Show()
-						end
-						w.size = ui.getWindowSize()
-					end)
-				end
-			end)
-
-			-- make final calculations on the last non-working frame
-			if dummyFrames == 1 then
-				-- resizing, aligning windows - static
-				Windows.current.pos = edgePadding
-				Windows.current.size.x = 0 -- adaptive width
-				Windows.hjPlanner.size.x = math.max(Windows.hjPlanner.size.x, Windows.systemInfo.size.x - Windows.edgeButtons.size.x)
-				Windows.hjPlanner.pos = Vector2(ui.screenWidth - Windows.edgeButtons.size.x, ui.screenHeight - edgePadding.y) - Windows.hjPlanner.size
-				Windows.systemInfo.pos = Windows.hjPlanner.pos - Vector2(0, Windows.systemInfo.size.y)
-				Windows.systemInfo.size.x = Windows.hjPlanner.size.x
-				Windows.searchBar.pos = Windows.current.pos + Windows.current.size
-				Windows.searchBar.collapsedHeight = Windows.searchBar.size.y
-				Windows.searchBar.size.y = ui.screenHeight - Windows.searchBar.pos.y - edgePadding.y - ui.timeWindowSize.y
-				Windows.searchBar.fullHeight = Windows.searchBar.size.y
-				Windows.edgeButtons.pos = Vector2(ui.screenWidth - Windows.edgeButtons.size.x, ui.screenHeight / 2 - Windows.edgeButtons.size.y / 2) -- center-right
-				Windows.factions.pos = Vector2(Windows.systemInfo.pos.x, Windows.current.pos.y)
-				Windows.factions.size = Vector2(ui.screenWidth - Windows.factions.pos.x - edgePadding.x, 0.0)
-			end
-			dummyFrames = dummyFrames - 1
-		else
-			if ui.isKeyReleased(ui.keys.tab) then
-				hideSectorViewWindows = not hideSectorViewWindows
-				sectorView:SetLabelsVisibility(hideSectorViewWindows)
-			end
-			if not hideSectorViewWindows then
-				-- display all windows
-				ui.withFont(font, function()
-					for _,w in pairs(Windows) do
-						if w.visible then showWindow(w) end
-					end
-				end)
-			end
+		if ui.isKeyReleased(ui.keys.tab) then
+			sectorViewLayout.enabled = not sectorViewLayout.enabled
+			sectorView:SetLabelsVisibility(hideSectorViewWindows)
 		end
 
 		if ui.escapeKeyReleased() then
 			Game.SetView("world")
 		end
 	end
-end
+end)
 
-ui.registerModule("game", displaySectorViewWindow)
 Event.Register("onGameStart", onGameStart)
 Event.Register("onEnterSystem", function()
 	hyperspaceDetailsCache = {}

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -601,7 +601,7 @@ void SectorView::InitObject()
 
 	m_renderer = Pi::renderer; //XXX pass cleanly to all views constructors!
 
-	Graphics::RenderStateDesc rsd;
+	Graphics::RenderStateDesc rsd {};
 	rsd.blendMode = Graphics::BLEND_ALPHA;
 
 	Graphics::MaterialDescriptor bbMatDesc;

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -541,15 +541,19 @@ Body *Space::FindNearestTo(const Body *b, ObjectType t) const
 
 Body *Space::FindBodyForPath(const SystemPath *path) const
 {
+	if (!path->IsSameSystem(m_starSystem->GetPath()))
+		return nullptr;
+
 	// it is a bit dumb that currentSystem is not part of Space...
 	SystemBody *body = m_starSystem->GetBodyByPath(path);
-
-	if (!body) return 0;
+	if (!body)
+		return nullptr;
 
 	for (Body *b : m_bodies) {
 		if (b->GetSystemBody() == body) return b;
 	}
-	return 0;
+
+	return nullptr;
 }
 
 static FrameId find_frame_with_sbody(FrameId fId, const SystemBody *b)

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -151,6 +151,11 @@ void SystemView::ResetViewpoint()
 	m_atlasZoomTo = m_atlasZoomDefault;
 }
 
+RefCountedPtr<StarSystem> SystemView::GetCurrentSystem()
+{
+	return m_system;
+}
+
 template <typename RefType>
 void SystemView::PutOrbit(Projectable::bases base, RefType *ref, const Orbit *orbit, const vector3d &offset, const Color &color, const double planetRadius, const bool showLagrange)
 {

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -109,6 +109,8 @@ public:
 	void ViewSelectedObject();
 	void ResetViewpoint();
 
+	RefCountedPtr<StarSystem> GetCurrentSystem();
+
 	TransferPlanner *GetTransferPlanner() const { return m_planner; }
 	double GetOrbitPlannerStartTime() const { return m_planner->GetStartTime(); }
 	double GetOrbitPlannerTime() const { return m_time; }

--- a/src/graphics/RenderState.h
+++ b/src/graphics/RenderState.h
@@ -21,7 +21,7 @@ namespace Graphics {
 		bool operator!=(const RenderStateDesc &rhs) const { return !(*this == rhs); }
 		bool operator==(const RenderStateDesc &rhs) const
 		{
-			return blendMode == rhs.blendMode && cullMode == rhs.cullMode && primitiveType == rhs.primitiveType && depthTest == rhs.depthTest && depthWrite == rhs.depthWrite;
+			return blendMode == rhs.blendMode && cullMode == rhs.cullMode && primitiveType == rhs.primitiveType && depthTest == rhs.depthTest && depthWrite == rhs.depthWrite && scissorTest == rhs.scissorTest;
 		}
 
 		BlendMode blendMode;

--- a/src/graphics/opengl/RenderStateCache.cpp
+++ b/src/graphics/opengl/RenderStateCache.cpp
@@ -115,15 +115,16 @@ static size_t HashRenderStateDesc(const RenderStateDesc &desc)
 	// it (most likely) has padding bytes, and those bytes are uninitialized,
 	// thereby arbitrarily affecting the hash output.
 	// (We used to do this and valgrind complained).
-	uint32_t words[5] = {
+	uint32_t words[6] = {
 		desc.blendMode,
 		desc.cullMode,
 		desc.primitiveType,
 		desc.depthTest,
 		desc.depthWrite,
+		desc.scissorTest
 	};
 	uint32_t a = 0, b = 0;
-	lookup3_hashword2(words, 5, &a, &b);
+	lookup3_hashword2(words, 6, &a, &b);
 	return size_t(a) | (size_t(b) << 32);
 }
 

--- a/src/lua/LuaSystemBody.cpp
+++ b/src/lua/LuaSystemBody.cpp
@@ -668,6 +668,26 @@ static int l_sbody_attr_is_moon(lua_State *l)
 	return 1;
 }
 
+static int l_sbody_attr_is_station(lua_State *l)
+{
+	LuaPush<bool>(l, LuaObject<SystemBody>::CheckFromLua(1)->GetSuperType() == SystemBody::SUPERTYPE_STARPORT);
+	return 1;
+}
+
+static int l_sbody_attr_is_ground_station(lua_State *l)
+{
+	SystemBody *sb = LuaObject<SystemBody>::CheckFromLua(1);
+	LuaPush<bool>(l, sb->GetSuperType() == SystemBody::SUPERTYPE_STARPORT && sb->GetType() == SystemBody::TYPE_STARPORT_SURFACE);
+	return 1;
+}
+
+static int l_sbody_attr_is_space_station(lua_State *l)
+{
+	SystemBody *sb = LuaObject<SystemBody>::CheckFromLua(1);
+	LuaPush<bool>(l, sb->GetSuperType() == SystemBody::SUPERTYPE_STARPORT && sb->GetType() == SystemBody::TYPE_STARPORT_ORBITAL);
+	return 1;
+}
+
 static int l_sbody_attr_physics_body(lua_State *l)
 {
 	SystemBody *b = LuaObject<SystemBody>::CheckFromLua(1);
@@ -724,6 +744,9 @@ void LuaObject<SystemBody>::RegisterClass()
 		{ "children", l_sbody_attr_children },
 		{ "nearestJumpable", l_sbody_attr_nearest_jumpable },
 		{ "isMoon", l_sbody_attr_is_moon },
+		{ "isStation", l_sbody_attr_is_station },
+		{ "isGroundStation", l_sbody_attr_is_ground_station },
+		{ "isSpaceStation", l_sbody_attr_is_space_station },
 		{ "physicsBody", l_sbody_attr_physics_body },
 		{ 0, 0 }
 	};

--- a/src/lua/LuaSystemView.cpp
+++ b/src/lua/LuaSystemView.cpp
@@ -272,6 +272,13 @@ static int l_systemview_get_projected_grouped(lua_State *l)
 	return 1;
 }
 
+static int l_systemview_get_system(lua_State *l)
+{
+	SystemView *sv = LuaObject<SystemView>::CheckFromLua(1);
+	LuaPush(l, sv->GetCurrentSystem());
+	return 1;
+}
+
 static int l_systemview_get_selected_object(lua_State *l)
 {
 	SystemView *sv = LuaObject<SystemView>::CheckFromLua(1);
@@ -457,6 +464,7 @@ void LuaObject<SystemView>::RegisterClass()
 {
 	static const luaL_Reg l_methods[] = {
 
+		{ "GetSystem", l_systemview_get_system },
 		{ "ClearSelectedObject", l_systemview_clear_selected_object },
 		{ "GetProjectedGrouped", l_systemview_get_projected_grouped },
 		{ "GetSelectedObject", l_systemview_get_selected_object },


### PR DESCRIPTION
This PR adds the System Overview widget (the body list in the top right of the world view) to both of the System Map view modes. It also refactors out the layout code from both the Sector Map and System Map into a single reusable module for creating full-screen UIs.

It also changes the focus-object interaction in the SystemView to use double-clicks instead of single-clicks; this may be a slightly controversial change, but having selection state decoupled from focus state is fairly useful when interacting with the overview widget.

This is likely the last of the work branches I have outstanding to be merged into the release, nothing else is close enough to done to be a viable candidate.