### PR TITLE
Slight fix/improve atlas-view

### DIFF
--- a/data/pigui/modules/flight-ui/system-overview.lua
+++ b/data/pigui/modules/flight-ui/system-overview.lua
@@ -9,8 +9,8 @@ local ui = require 'pigui'
 local lui = Lang.GetResource("ui-core");
 local Vector2 = _G.Vector2
 
-local width_fraction = ui.rescaleFraction(5)
-local height_fraction = 2
+local width_fraction = 5
+local height_fraction = 1.6
 
 local style = {
 	buttonSize = ui.theme.styles.MainButtonSize,

--- a/data/pigui/modules/fx-window.lua
+++ b/data/pigui/modules/fx-window.lua
@@ -49,9 +49,21 @@ local function buttons_map(current_view)
 	end
 
 	ui.sameLine()
-	active = current_view == "system"
+	local isOrrery = Game.systemView:GetDisplayMode() == "Orrery"
+	active = current_view == "system" and isOrrery
 	if ui.mainMenuButton(icons.system_map, lui.HUD_BUTTON_SWITCH_TO_SYSTEM_MAP, active) or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f6)) then
 		if not active then
+			Game.systemView:SetDisplayMode('Orrery')
+			Game.SetView("system")
+			current_map_view = "system"
+		end
+	end
+
+	ui.sameLine()
+	active = current_view == "system" and not isOrrery
+	if ui.mainMenuButton(icons.system_overview, lui.HUD_BUTTON_SWITCH_TO_SYSTEM_OVERVIEW, active) or (onmap and ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f7)) then
+		if not active then
+			Game.systemView:SetDisplayMode('Atlas')
 			Game.SetView("system")
 			current_map_view = "system"
 		end

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -259,6 +259,7 @@ theme.icons = {
 	direction_frame = 26,
 	direction_frame_hollow = 27,
 	direction_forward = 28,
+	empty = 29,
 	semi_major_axis = 31,
 	-- third row
 	heavy_fighter = 32,

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -121,6 +121,8 @@ public:
 	void SetZoomMode(bool enable);
 	void SetRotateMode(bool enable);
 	double ProjectedSize(double size, vector3d pos);
+	float AtlasViewPlanetGap(float planetRadius) { return std::max(planetRadius * 0.6, 1.33); }
+	float AtlasViewPixelPerUnit();
 
 	float GetZoom() const;
 

--- a/src/lua/LuaSystemView.cpp
+++ b/src/lua/LuaSystemView.cpp
@@ -369,6 +369,21 @@ static int l_systemview_get_zoom(lua_State *l)
 	return 1;
 }
 
+static int l_systemview_atlas_view_planet_gap(lua_State *l)
+{
+	SystemView *sv = LuaObject<SystemView>::CheckFromLua(1);
+	auto radius = LuaPull<float>(l, 2);
+	LuaPush(l, sv->AtlasViewPlanetGap(radius));
+	return 1;
+}
+
+static int l_systemview_atlas_view_pixel_per_unit(lua_State *l)
+{
+	SystemView *sv = LuaObject<SystemView>::CheckFromLua(1);
+	LuaPush(l, sv->AtlasViewPixelPerUnit());
+	return 1;
+}
+
 static int l_systemview_get_display_mode(lua_State *l)
 {
 	SystemView *sv = LuaObject<SystemView>::CheckFromLua(1);
@@ -481,6 +496,8 @@ void LuaObject<SystemView>::RegisterClass()
 		{ "GetDisplayMode", l_systemview_get_display_mode },
 		{ "SetDisplayMode", l_systemview_set_display_mode },
 		{ "GetZoom", l_systemview_get_zoom },
+		{ "AtlasViewPlanetGap", l_systemview_atlas_view_planet_gap },
+		{ "AtlasViewPixelPerUnit", l_systemview_atlas_view_pixel_per_unit },
 
 		{ "TransferPlannerAdd", l_systemview_transfer_planner_add },
 		{ "TransferPlannerGet", l_systemview_transfer_planner_get },


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

https://user-images.githubusercontent.com/18342621/151628791-8cb893e5-f909-4324-91ff-b471011a7ed7.mp4


- show icons for asteroids and orbitals only
- show switch button to atlas-view in top row
- don't show grid, L-points and ships buttons in atlas mode
- fix mouse panning and zooming
- add a button to hide the overview window
- correct overview-window size in worldview
- fix that when you click on the planet if the ship is centered, the view is reset
- show ground stations around the planet when hovering or clicking on it
- generate only one popup (and not for each object)