### PR TITLE
Fix getting exit parameters from hyperjump

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -494,6 +494,7 @@ void Game::SwitchToNormalSpace()
 	// create a new space for the system
 	m_space.reset(); // HACK: Here because next line will create Frames *before* deleting existing ones
 	m_space.reset(new Space(this, m_galaxy, m_hyperspaceDest, m_space.get()));
+	m_state = State::NORMAL;
 
 	// put the player in it
 	m_player->SetFrame(m_space->GetRootFrame());
@@ -615,8 +616,6 @@ void Game::SwitchToNormalSpace()
 	// HACK: we call RebuildObjectTrees to make the internal state of CollisionSpace valid
 	// This is absolutely not our job and CollisionSpace should be redesigned to fix this.
 	Frame::GetFrame(m_player->GetFrame())->GetCollisionSpace()->RebuildObjectTrees();
-
-	m_state = State::NORMAL;
 }
 
 const float Game::s_timeAccelRates[] = {


### PR DESCRIPTION
The GetBodyForPath function was called (from GetHyperspaceExitParams) before Game::m_state = State::NORMAL was set, so it returned nullptr. Therefore, the first non-gravpoint body was always set as the base body for exit.
(This led to the fact that in the multiple system the star "A" was always chosen, regardless of the player's choice in the sector map.)
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

