### PR TITLE
Add riscv support

### DIFF
--- a/contrib/atomic_queue/defs.h
+++ b/contrib/atomic_queue/defs.h
@@ -47,6 +47,13 @@ namespace atomic_queue {
 constexpr int CACHE_LINE_SIZE = 256; // TODO: Review that this is the correct value.
 static inline void spin_loop_pause() noexcept {} // TODO: Find the right instruction to use here, if any.
 } // namespace atomic_queue
+#elif defined(__riscv)
+namespace atomic_queue {
+constexpr int CACHE_LINE_SIZE = 64;
+static inline void spin_loop_pause() noexcept {
+    asm volatile ("nop");
+}
+} // namespace atomic_queue
 #else
 #warning "Unknown CPU architecture. Using L1 cache line size of 64 bytes and no spinloop pause instruction."
 namespace atomic_queue {

--- a/contrib/profiler/Profiler.h
+++ b/contrib/profiler/Profiler.h
@@ -8,7 +8,7 @@
 #define __PROFILER_FULL_TYPE_EXPANSION__
 
 //#define USE_CHRONO
-#if !defined(USE_CHRONO) && (defined(__arm__) || defined(__aarch64__) || defined(__PPC64__) || defined(_M_AMD64) || defined(_WIN64) || defined(_M_X64))
+#if !defined(USE_CHRONO) && (defined(__arm__) || defined(__aarch64__) || defined(__PPC64__) || defined(_M_AMD64) || defined(_WIN64) || defined(_M_X64) || defined(__riscv))
 // this isn't optional for __arm__ or x64 builds
 #define USE_CHRONO
 #endif


### PR DESCRIPTION
1. Add `__riscv` to `USE_CHRONO` check, like other architectures.
2. Merge https://github.com/max0x7ba/atomic_queue/commit/4e559dabe28e57ee27cb45c8297e1e387beed1d3