### PR TITLE
Reduce creaking sound a bit

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -301,29 +301,29 @@ void Player::StaticUpdate(const float timeStep)
 		if (GetFixedGuns()->IsGunMounted(i))
 			GetFixedGuns()->UpdateLead(timeStep, i, this, GetCombatTarget());
 
-	// store last 5 jerk (derivative of acceleration wrt. time) values
+	// store last 20 jerk (derivative of acceleration wrt. time) values
 	// first, move the earlier values back by one
-	for (int i = 0; i < 4; i++) {
+	for (int i = 0; i < 19; i++) {
 		m_jerk[i] = m_jerk[i + 1];
 	}
 	// now insert the latest value
 	vector3d current_accel = GetLastForce() * (1.0 / GetMass());
-	m_jerk[4] = current_accel - m_accel;
+	m_jerk[19] = current_accel - m_accel;
 
 	// now, check whether the jerk values of last 5 frames were higher than
 	// 0.5 m s-3, in which case we will play a creaking metal sfx (player ship is under rapidly changing load)
 	// we do this storing operation so that single-frame jerk spikes when firing thrusters won't trigger
 	// the sound effect
 	bool playCreak = true;
-	for (int i = 1; i < 5; i++) {
-		if ((m_jerk[i] - m_jerk[i - 1]).Length() * Pi::game->GetInvTimeAccelRate() < 0.5f) {
+	for (int i = 1; i < 20; i++) {
+		if ((m_jerk[i] - m_jerk[i - 1]).Length() * Pi::game->GetInvTimeAccelRate() < 0.01f) {
 			playCreak = false;
 		}
 	}
 
 	if (playCreak) {
 		if (!m_creakSound.IsPlaying()) {
-			float creakVol = fmin(float(((m_jerk[4] - m_jerk[3]).Length() * Pi::game->GetInvTimeAccelRate() - 0.45) * 0.3), 1.0f);
+			float creakVol = fmin(float(((m_jerk[19] - m_jerk[18]).Length() * Pi::game->GetInvTimeAccelRate() - 0.45) * 0.3), 1.0f);
 			m_creakSound.Play("metal_creaking", creakVol, creakVol, Sound::OP_REPEAT);
 			m_creakSound.VolumeAnimate(creakVol, creakVol, 1.0f, 1.0f);
 		}

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -310,20 +310,25 @@ void Player::StaticUpdate(const float timeStep)
 	vector3d current_accel = GetLastForce() * (1.0 / GetMass());
 	m_jerk[19] = current_accel - m_accel;
 
-	// now, check whether the jerk values of last 5 frames were higher than
-	// 0.5 m s-3, in which case we will play a creaking metal sfx (player ship is under rapidly changing load)
-	// we do this storing operation so that single-frame jerk spikes when firing thrusters won't trigger
-	// the sound effect
 	bool playCreak = true;
-	for (int i = 1; i < 20; i++) {
-		if ((m_jerk[i] - m_jerk[i - 1]).Length() * Pi::game->GetInvTimeAccelRate() < 0.01f) {
-			playCreak = false;
+
+	if (m_accel.Length() < 5) { // do not play metal creaking sound if accel is lower than 5 m s-2
+		playCreak = false;
+	} else {
+		// check whether the jerk values of last 5 frames were higher than
+		// 0.5 m s-3, in which case we will play a creaking metal sfx (player ship is under rapidly changing load)
+		// we do this storing operation so that single-frame jerk spikes when firing thrusters won't trigger
+		// the sound effect
+		for (int i = 1; i < 20; i++) {
+			if ((m_jerk[i] - m_jerk[i - 1]).Length() * Pi::game->GetInvTimeAccelRate() < 0.01f) {
+				playCreak = false;
+			}
 		}
 	}
 
 	if (playCreak) {
 		if (!m_creakSound.IsPlaying()) {
-			float creakVol = fmin(float(((m_jerk[19] - m_jerk[18]).Length() * Pi::game->GetInvTimeAccelRate() - 0.45) * 0.3), 1.0f);
+			float creakVol = fmin(float(((m_jerk[19] - m_jerk[18]).Length() * Pi::game->GetInvTimeAccelRate() - 0.0095) * 0.3), 1.0f);
 			m_creakSound.Play("metal_creaking", creakVol, creakVol, Sound::OP_REPEAT);
 			m_creakSound.VolumeAnimate(creakVol, creakVol, 1.0f, 1.0f);
 		}

--- a/src/Player.h
+++ b/src/Player.h
@@ -63,7 +63,7 @@ private:
 	std::unique_ptr<ShipCockpit> m_cockpit;
 	Sound::Event m_creakSound;
 	vector3d m_accel;
-	vector3d m_jerk[5] = { vector3d(0.0, 0.0, 0.0) };
+	vector3d m_jerk[20] = { vector3d(0.0, 0.0, 0.0) };
 };
 
 #endif /* _PLAYER_H */


### PR DESCRIPTION
Sorry, turns out the metal creaking sfx was still a bit more trigger-happy than I thought it would be. And I had tested it for quite some time before PRing...

Anyway, I increased the number of frames checked (so consecutive thruster firings in different directions are much less likely to trigger it) and also added a minimum absolute acceleration check of 5 meters per second per second. Seems to work better now.

This is not a draft, but it might be a good idea to give it some time for people to try out. I myself am happy enough with it to open a fixing PR.