### PR TITLE
Add Chrome-Tracing output support to profiler

### DIFF
--- a/contrib/profiler/Profiler.h
+++ b/contrib/profiler/Profiler.h
@@ -252,6 +252,7 @@ namespace Profiler {
 	void detect( int argc, char **argv );
 	//void detect( const char *commandLine );
 	void dump(const char *dir = 0);
+	void dumptrace(const char *dir = 0);
 	void dumpzones(const char *dir = 0);
 	void dumphtml(const char *dir = 0);
 	void fastcall enter( const char *name );

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -318,7 +318,11 @@ void Pi::App::Startup()
 
 	SetProfilerPath("profiler/");
 	SetProfileSlowFrames(config->Int("ProfileSlowFrames", 0));
-	SetProfileZones(config->Int("ProfilerZoneOutput", 0));
+	bool profileZones = config->Int("ProfilerZoneOutput", 0);
+	bool profileTraces = config->Int("ProfilerTraceOutput", 0);
+
+	SetProfileZones(profileZones || profileTraces);
+	SetProfileTrace(profileTraces);
 
 	Log::GetLog()->SetLogFile("output.txt");
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -207,16 +207,22 @@ void Application::Run()
 		// TODO: potential pigui frame profile inspector
 		m_runtime.SoftStop();
 		thisTime = m_runtime.seconds();
+
 		// profile frames taking longer than 100ms
-		if (m_doTempProfile || (m_doSlowProfile && thisTime - m_totalTime > 0.100)) {
+		bool isSlowProfile = (m_doSlowProfile && thisTime - m_totalTime > 0.100);
+		if (m_doTempProfile || isSlowProfile) {
 			const std::string path = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(),
 				m_tempProfilePath.empty() ? m_profilerPath : m_tempProfilePath);
 			m_tempProfilePath.clear();
 			m_doTempProfile = false;
 
 			Profiler::dumphtml(path.c_str());
-			if (m_profileZones)
-				Profiler::dumpzones(path.c_str());
+			if (m_profileZones) {
+				if (m_profileTrace)
+					Profiler::dumptrace(path.c_str());
+				else
+					Profiler::dumpzones(path.c_str());
+			}
 		}
 
 		// reset the profiler at the end of the frame

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -115,6 +115,7 @@ protected:
 	void SetProfilerPath(const std::string &);
 	void SetProfileSlowFrames(bool enabled) { m_doSlowProfile = enabled; }
 	void SetProfileZones(bool enabled) { m_profileZones = enabled; }
+	void SetProfileTrace(bool enabled) { m_profileTrace = enabled; }
 
 private:
 	bool StartLifecycle();
@@ -124,6 +125,7 @@ private:
 	bool m_doTempProfile = false;
 	bool m_doSlowProfile = false;
 	bool m_profileZones = false;
+	bool m_profileTrace = false;
 	float m_deltaTime = 0.f;
 	double m_totalTime = 0.f;
 

--- a/src/galaxy/GalaxyGenerator.cpp
+++ b/src/galaxy/GalaxyGenerator.cpp
@@ -170,7 +170,6 @@ GalaxyGenerator *GalaxyGenerator::AddStarSystemStage(StarSystemGeneratorStage *s
 
 RefCountedPtr<Sector> GalaxyGenerator::GenerateSector(RefCountedPtr<Galaxy> galaxy, const SystemPath &path, SectorCache *cache)
 {
-	PROFILE_SCOPED()
 	const Uint32 _init[4] = { Uint32(path.sectorX), Uint32(path.sectorY), Uint32(path.sectorZ), UNIVERSE_SEED };
 	Random rng(_init, 4);
 	SectorConfig config;

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -64,7 +64,6 @@ static Type parse_imgui_flags(lua_State *l, int index, LuaFlags<Type> &lookupTab
 template <typename Type>
 static Type parse_imgui_enum(lua_State *l, int index, LuaFlags<Type> lookupTable)
 {
-	PROFILE_SCOPED()
 	if (lua_isstring(l, index))
 		return lookupTable.LookupEnum(l, index);
 	else if (lua_isnumber(l, index))


### PR DESCRIPTION
In order to support better profiling visualization, I've added support for outputting chrome://tracing format event traces from the profiler - this is a significantly more wasteful format than speedscope for profiling complex applications with many event zones, but it's a format that *many* visualization tools speak or can import to their own format. Chrome-tracing JSON output can be enabled with the `ProfilerTraceOutput=1` option in the config file, and is mutually exclusive with the regular Speedscope JSON output.

I've also removed a few more unnecessary / wasteful profile points which significantly bloat profiling for little gain - the methods they're profiling are very small and optimized, and potentially called hundreds of thousands of times in some traces.