### PR TITLE
Search and Rescue: fix refueling mission

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1425,7 +1425,7 @@ local missionStatus = function (mission)
 		end
 	end
 	for commodity,_ in pairs(mission.deliver_comm_check) do
-		if mission.deliver_comm_check[commodity] == "PARTIAL" or mission.pickup_comm_check[commodity] == "ABORT" then
+		if mission.deliver_comm_check[commodity] == "PARTIAL" or mission.deliver_comm_check[commodity] == "ABORT" then
 			status = "PARTIAL"
 		end
 	end
@@ -1443,7 +1443,7 @@ local missionStatusReset = function (mission)
 		if mission.pickup_comm_check[commodity] == "PARTIAL" then mission.pickup_comm_check[commodity] = "NOT" end
 	end
 	for commodity,_ in pairs(mission.deliver_comm_check) do
-		if mission.deliver_comm_check[commodity] == "PARTIAL" then mission.pickup_comm_check[commodity] = "NOT" end
+		if mission.deliver_comm_check[commodity] == "PARTIAL" then mission.deliver_comm_check[commodity] = "NOT" end
 	end
 end
 
@@ -1738,11 +1738,6 @@ local deliverCommodity = function (mission, commodity)
 	else
 		removeCargo(Game.player, commodity)
 		addCargo(mission.target, commodity)
-		if mission.cargo_comm[commodity] == nil then
-			mission.cargo_comm[commodity] = 1
-		else
-			mission.cargo_comm[commodity] = mission.cargo_comm[commodity] + 1
-		end
 
 		-- show result message if done delivering this commodity
 		mission.deliver_comm[commodity] = mission.deliver_comm[commodity] - 1


### PR DESCRIPTION
Small changes to the search and rescue mission code which fixes two bugs in the refueling mission.

### Description

If the mission requires the player to deliver more hydrogen to the stranded ship than the player has in his cargo hold (e.g. if the players cargo hold is too small to load all needed hydrogen), the player is now able to deliver the hydrogen in multiple passes, i.e., deliver hydrogen, fly back to a space port to get more hydrogen, deliver the additional hydrogen, get more hydrogen if needed, and so on, until finished. 

Before the fix, the stranded ship would only accept 1t of additional hydrogen in the second and every subsequent pass, even though more hydrogen was available. Now all hydrogen in the cargo space is used in every pass.

This fixes #5238.

The second bug was that, if the player had hydrogen left in his cargo hold after completing the refueling, this unused hydrogen would be deleted upon returning to the star port. This is now also fixed, unused hydrogen is not touched.


### Remarks

- Both bugs are simple copy-and-paste errors that seem to have been present ever since the search-and-rescue mission was added to pioneer.
- Tested with own saved game and with the savefile from #5238.

- It seems that in the search and rescue code it was also intended that the player could deliver replacement crew to a stranded ship in multiple passes. However, this is not possible in the current pioneer version, since when accepting the rescue mission it is checked that the player has at least as many (free) passenger cabins as there are replacement crew members. If the player would be able to accept the mission with fewer cabins (one free cabin minimum), then in principle a multi pass crew transfer would be possible. But I have not checked that this actually works.