### PR TITLE
Add BodyComponent system

### DIFF
--- a/data/modules/Debug/TestComponent.lua
+++ b/data/modules/Debug/TestComponent.lua
@@ -1,0 +1,40 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file tests adding and retrieving Lua BodyComponents to the player,
+-- and is used to test serialization of body components.
+
+local Event = require 'Event'
+local Game = require 'Game'
+local Serializer = require 'Serializer'
+local utils = require 'utils'
+
+local TestComponent = utils.inherits(nil, 'TestComponent')
+
+function TestComponent.New()
+	local self = setmetatable({}, TestComponent.meta)
+
+	self.testStr = "I am a test string"
+	self.testNumber = 1234
+
+	return self
+end
+
+--[[
+Serializer:RegisterClass('TestComponent', TestComponent)
+
+Event.Register('onGameStart', function()
+	print('TestComponent #onGameStart')
+	local comp = Game.player:GetComponent('TestComponent')
+
+	if comp then
+		print("Loaded from save file, test component:")
+		utils.print_r(comp)
+	else
+		print("Setting player component")
+		comp = TestComponent.New()
+		Game.player:SetComponent('TestComponent', comp)
+		utils.print_r(Game.player:GetComponent('TestComponent'))
+	end
+end)
+--]]

--- a/data/modules/Debug/TestSerialization.lua
+++ b/data/modules/Debug/TestSerialization.lua
@@ -1,0 +1,46 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Serializer = require 'Serializer'
+local utils = require 'utils'
+
+-- This file ensures unserializers that return different values are respected
+-- by the lua serialization system - references to the original table should
+-- be unpickled into the modified table returned by the original serializer.
+
+-- Note: nested references to a table being deserialized will not be
+-- automatically converted to references to the "replacement" table.
+
+-- Disable this test until needed.
+--[[
+
+local testClass = utils.inherits(nil, 'TestClass')
+
+local testInstance = testClass.New()
+
+function testClass:Unserialize(data)
+	return testInstance
+end
+
+local function serialize()
+	return {
+		a = testInstance,
+		b = testInstance,
+		c = testInstance
+	}
+end
+
+local function unserialize(data)
+	utils.print_r(data.a)
+	utils.print_r(data.b)
+	utils.print_r(data.c)
+
+	print(data.a == data.b, data.a == data.c, data.b == data.c)
+
+	print(testInstance)
+	print(data.a == testInstance, data.b == testInstance, data.c == testInstance)
+end
+
+Serializer:RegisterClass('TestClass', testClass)
+Serializer:Register('TestSerialization', serialize, unserialize)
+--]]

--- a/licenses/zlib.txt
+++ b/licenses/zlib.txt
@@ -1,0 +1,17 @@
+Copyright (c) <year> <copyright holders>
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -18,12 +18,6 @@
 #include "Star.h"
 #include "lua/LuaEvent.h"
 
-size_t BodyComponentDB::m_componentIdx = 0;
-std::map<size_t, std::unique_ptr<BodyComponentDB::PoolBase>> BodyComponentDB::m_componentPools;
-std::map<std::string, std::unique_ptr<BodyComponentDB::SerializerBase>> BodyComponentDB::m_componentSerializers;
-std::map<std::string, BodyComponentDB::PoolBase *> BodyComponentDB::m_componentNames;
-std::vector<BodyComponentDB::PoolBase *> BodyComponentDB::m_componentTypes;
-
 Body::Body() :
 	PropertiedObject(),
 	m_interpPos(0.0),
@@ -109,7 +103,7 @@ void Body::SaveToJson(Json &jsonObj, Space *space)
 			Json serializedComponent = Json::object();
 			serializer->toJson(this, serializedComponent, space);
 
-			componentsObj[serializer->typeName] = serializedComponent;
+			componentsObj[type->typeName] = serializedComponent;
 		}
 	}
 

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -21,6 +21,7 @@
 size_t BodyComponentDB::m_componentIdx = 0;
 std::map<size_t, std::unique_ptr<BodyComponentDB::PoolBase>> BodyComponentDB::m_componentPools;
 std::map<std::string, std::unique_ptr<BodyComponentDB::SerializerBase>> BodyComponentDB::m_componentSerializers;
+std::map<std::string, BodyComponentDB::PoolBase *> BodyComponentDB::m_componentNames;
 std::vector<BodyComponentDB::PoolBase *> BodyComponentDB::m_componentTypes;
 
 Body::Body() :

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -21,7 +21,7 @@
 size_t BodyComponentDB::m_componentIdx = 0;
 std::map<size_t, std::unique_ptr<BodyComponentDB::PoolBase>> BodyComponentDB::m_componentPools;
 std::map<std::string, std::unique_ptr<BodyComponentDB::SerializerBase>> BodyComponentDB::m_componentSerializers;
-std::vector<size_t> BodyComponentDB::m_componentTypes;
+std::vector<BodyComponentDB::PoolBase *> BodyComponentDB::m_componentTypes;
 
 Body::Body() :
 	PropertiedObject(),

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -113,6 +113,14 @@ void Body::SaveToJson(Json &jsonObj, Space *space)
 	}
 
 	jsonObj["components"] = componentsObj;
+
+	// Serialize lua components
+	Json luaComponentsObj = Json::object();
+	if (LuaObjectBase::SerializeComponents(this, luaComponentsObj)) {
+		if (!luaComponentsObj.empty()) {
+			jsonObj["lua_components"] = luaComponentsObj;
+		}
+	}
 }
 
 void Body::ToJson(Json &jsonObj, Space *space)
@@ -197,6 +205,19 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 			}
 
 			serializer->fromJson(body, pair.value(), space);
+		}
+	}
+
+	// Deserialize lua components
+	if (jsonObj.count("lua_components") != 0) {
+		const Json &luaComponents = jsonObj["lua_components"];
+		if (luaComponents.is_object() && !luaComponents.empty()) {
+			// Ensure we've registered the body object in Lua
+			// TODO: this is a bit messy, should be handled inside a lua-related function somewhere
+			LuaObject<Body>::PushToLua(body);
+			lua_pop(Lua::manager->GetLuaState(), 1);
+
+			LuaObjectBase::DeserializeComponents(body, luaComponents);
 		}
 	}
 

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -108,14 +108,6 @@ void Body::SaveToJson(Json &jsonObj, Space *space)
 	}
 
 	jsonObj["components"] = componentsObj;
-
-	// Serialize lua components
-	Json luaComponentsObj = Json::object();
-	if (LuaObjectBase::SerializeComponents(this, luaComponentsObj)) {
-		if (!luaComponentsObj.empty()) {
-			jsonObj["lua_components"] = luaComponentsObj;
-		}
-	}
 }
 
 void Body::ToJson(Json &jsonObj, Space *space)
@@ -200,19 +192,6 @@ Body *Body::FromJson(const Json &jsonObj, Space *space)
 			}
 
 			serializer->fromJson(body, pair.value(), space);
-		}
-	}
-
-	// Deserialize lua components
-	if (jsonObj.count("lua_components") != 0) {
-		const Json &luaComponents = jsonObj["lua_components"];
-		if (luaComponents.is_object() && !luaComponents.empty()) {
-			// Ensure we've registered the body object in Lua
-			// TODO: this is a bit messy, should be handled inside a lua-related function somewhere
-			LuaObject<Body>::PushToLua(body);
-			lua_pop(Lua::manager->GetLuaState(), 1);
-
-			LuaObjectBase::DeserializeComponents(body, luaComponents);
 		}
 	}
 

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -56,8 +56,6 @@ Body::Body(const Json &jsonObj, Space *space) :
 		m_orient = bodyObj["orient"];
 		m_physRadius = bodyObj["phys_radius"];
 		m_clipRadius = bodyObj["clip_radius"];
-
-		Json components = jsonObj["components"];
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
@@ -80,6 +78,8 @@ Body::~Body()
 
 void Body::SaveToJson(Json &jsonObj, Space *space)
 {
+	PROFILE_SCOPED()
+
 	Json bodyObj = Json::object(); // Create JSON object to contain body data.
 
 	Properties().SaveToJson(bodyObj["properties"]);
@@ -93,6 +93,26 @@ void Body::SaveToJson(Json &jsonObj, Space *space)
 	bodyObj["clip_radius"] = m_clipRadius;
 
 	jsonObj["body"] = bodyObj; // Add body object to supplied object.
+
+	Json componentsObj = Json::object();
+
+	// Iterate components and serialize
+	size_t components = GetComponentList();
+	for (uint32_t index = 0; components && index < 64; (components >>= 1, index++)) {
+		if ((components & 1UL) == 0)
+			continue;
+
+		auto type = BodyComponentDB::GetComponentType(index);
+		BodyComponentDB::SerializerBase *serializer = type->serializer;
+		if (serializer) {
+			Json serializedComponent = Json::object();
+			serializer->toJson(this, serializedComponent, space);
+
+			componentsObj[serializer->typeName] = serializedComponent;
+		}
+	}
+
+	jsonObj["components"] = componentsObj;
 }
 
 void Body::ToJson(Json &jsonObj, Space *space)
@@ -118,42 +138,69 @@ void Body::ToJson(Json &jsonObj, Space *space)
 
 Body *Body::FromJson(const Json &jsonObj, Space *space)
 {
+	PROFILE_SCOPED()
+
 	if (!jsonObj["body_type"].is_number_integer())
 		throw SavedGameCorruptException();
+
+	Body *body = nullptr;
 
 	ObjectType type = ObjectType(jsonObj["body_type"]);
 	switch (type) {
 	case ObjectType::STAR:
-		return new Star(jsonObj, space);
+		body = new Star(jsonObj, space);
+		break;
 	case ObjectType::PLANET:
-		return new Planet(jsonObj, space);
+		body = new Planet(jsonObj, space);
+		break;
 	case ObjectType::SPACESTATION:
-		return new SpaceStation(jsonObj, space);
+		body = new SpaceStation(jsonObj, space);
+		break;
 	case ObjectType::SHIP: {
 		Ship *s = new Ship(jsonObj, space);
 		// Here because of comments in Ship.cpp on following function
 		s->UpdateLuaStats();
-		return static_cast<Body *>(s);
+		body = static_cast<Body *>(s);
+		break;
 	}
 	case ObjectType::PLAYER: {
 		Player *p = new Player(jsonObj, space);
 		// Read comments in Ship.cpp on following function
 		p->UpdateLuaStats();
-		return static_cast<Body *>(p);
+		body = static_cast<Body *>(p);
+		break;
 	}
 	case ObjectType::MISSILE:
-		return new Missile(jsonObj, space);
+		body = new Missile(jsonObj, space);
+		break;
 	case ObjectType::PROJECTILE:
-		return new Projectile(jsonObj, space);
+		body = new Projectile(jsonObj, space);
+		break;
 	case ObjectType::CARGOBODY:
-		return new CargoBody(jsonObj, space);
+		body = new CargoBody(jsonObj, space);
+		break;
 	case ObjectType::HYPERSPACECLOUD:
-		return new HyperspaceCloud(jsonObj, space);
+		body = new HyperspaceCloud(jsonObj, space);
+		break;
 	default:
 		assert(0);
 	}
 
-	return nullptr;
+	// Iterate component records and deserialize
+	const Json &components = jsonObj["components"];
+	if (components.is_object()) {
+		for (auto pair : components.items()) {
+			BodyComponentDB::SerializerBase *serializer = BodyComponentDB::GetSerializer(pair.key());
+			if (!serializer) {
+				Log::Warning("Cannot deserialize body component '{}'.\n", pair.key());
+				continue;
+			}
+
+			serializer->fromJson(body, pair.value(), space);
+		}
+	}
+
+	return body;
 }
 
 vector3d Body::GetPositionRelTo(FrameId relToId) const

--- a/src/BodyComponent.cpp
+++ b/src/BodyComponent.cpp
@@ -1,0 +1,43 @@
+
+#include "BodyComponent.h"
+
+size_t BodyComponentDB::m_componentIdx = 0;
+std::map<size_t, std::unique_ptr<BodyComponentDB::PoolBase>> BodyComponentDB::m_componentPools;
+std::map<std::string, std::unique_ptr<BodyComponentDB::SerializerBase>> BodyComponentDB::m_componentSerializers;
+std::map<std::string, BodyComponentDB::PoolBase *> BodyComponentDB::m_componentNames;
+std::vector<BodyComponentDB::PoolBase *> BodyComponentDB::m_componentTypes;
+
+std::vector<void (*)()> &GetBodyComponentRegistrars()
+{
+	static std::vector<void (*)()> m_registrars = {};
+	return m_registrars;
+}
+
+void BodyComponentDB::Init()
+{
+	for (auto &registrar : GetBodyComponentRegistrars()) {
+		registrar();
+	}
+}
+
+void BodyComponentDB::Uninit()
+{
+	// Reset all static variables and free all allocated memory
+	m_componentTypes.clear();
+	m_componentNames.clear();
+	m_componentSerializers.clear();
+	m_componentPools.clear();
+	m_componentIdx = 0;
+}
+
+bool BodyComponentDB::AddComponentRegistrar(void (*registrar)())
+{
+	GetBodyComponentRegistrars().push_back(registrar);
+	return true;
+}
+
+BodyComponentDB::PoolBase::~PoolBase()
+{
+	if (luaInterface)
+		delete luaInterface;
+}

--- a/src/BodyComponent.h
+++ b/src/BodyComponent.h
@@ -41,9 +41,11 @@ public:
 
 	// Polymorphic interface to support generic deletion operations
 	struct PoolBase {
-		PoolBase(size_t i) :
-			componentIndex(i) {}
+		PoolBase(size_t index, size_t type) :
+			componentIndex(index),
+			componentType(type) {}
 		size_t componentIndex = 0;
+		size_t componentType = 0;
 		SerializerBase *serializer = nullptr;
 
 		virtual void deleteComponent(Body *body) = 0;

--- a/src/BodyComponent.h
+++ b/src/BodyComponent.h
@@ -33,7 +33,7 @@ public:
 
 		std::string typeName;
 		virtual void toJson(const Body *body, Json &obj, Space *space) = 0;
-		virtual BodyComponent *fromJson(Body *body, const Json &obj, Space *space) = 0;
+		virtual void fromJson(Body *body, const Json &obj, Space *space) = 0;
 	};
 
 	// Polymorphic interface to support generic deletion operations
@@ -76,6 +76,10 @@ public:
 
 	// Type-specific serialization implementation. Delegates to the type's
 	// internal serialization methods and provides the needed glue code.
+	//
+	// The Component::LoadFromJson method will be called after the component
+	// is constructed and added to the body, and may potentially have defaults
+	// set by the owning Body before it is deserialized.
 	template <typename T>
 	struct Serializer final : public SerializerBase {
 		Serializer(std::string name, Pool<T> *pool) :
@@ -89,12 +93,10 @@ public:
 			pool->get(body)->SaveToJson(obj, space);
 		}
 
-		virtual BodyComponent *fromJson(Body *body, const Json &obj, Space *space) override
+		virtual void fromJson(Body *body, const Json &obj, Space *space) override
 		{
-			pool->deleteComponent(body);
 			auto *component = pool->newComponent(body);
 			component->LoadFromJson(obj, space);
-			return component;
 		}
 	};
 

--- a/src/BodyComponent.h
+++ b/src/BodyComponent.h
@@ -1,0 +1,142 @@
+// Copyright © 2008-2020 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "JsonFwd.h"
+#include "core/TypeId.h"
+
+#include <cassert>
+#include <cstddef>
+#include <map>
+#include <vector>
+
+class Body;
+class Space;
+class BodyComponent {};
+
+/*
+	BodyComponentDB provides a simple interface to support dynamic composition
+	of game objects.
+
+	It is intended for use as a transitional interface to facilitate the
+	migration of Pioneer's inheritance-hierarchy based object model to an ECS-
+	style system, and thus is not and never will be a permanent solution.
+
+	Please direct all concerns about speed and efficiency to /dev/null
+	Improvements to compile times are welcomed wherever possible.
+*/
+class BodyComponentDB {
+public:
+	// Polymorphic interface to support generic serialization operations
+	// This functionality is separated to facilitate components that do not wish
+	// to be serialized.
+	struct SerializerBase {
+		SerializerBase(std::string name) :
+			typeName(name) {}
+		std::string typeName;
+		virtual void toJson(const Body *body, Json &obj, Space *space) = 0;
+		virtual BodyComponent *fromJson(Body *body, const Json &obj, Space *space) = 0;
+	};
+
+	// Polymorphic interface to support generic deletion operations
+	struct PoolBase {
+		PoolBase(size_t i) :
+			componentIndex(i) {}
+		size_t componentIndex = 0;
+		SerializerBase *serializer = nullptr;
+
+		virtual void deleteComponent(Body *body) = 0;
+	};
+
+	template <typename T>
+	struct Serializer;
+
+	// Type-specific component pool; uses std::map as a backing store.
+	// This is not meant to be particularly performant, merely to transition API usage.
+	template <typename T>
+	struct Pool final : public PoolBase {
+		using PoolBase::PoolBase;
+
+		virtual void deleteComponent(Body *body) override { m_components.erase(body); }
+		// Create a new component, or return the existing one.
+		T *newComponent(const Body *body) { return &m_components[body]; }
+		// Assert that a component exists for this body and return it
+		T *get(const Body *body) { return &m_components.at(body); }
+
+	private:
+		template <typename U>
+		friend struct BodyComponentDB::Serializer;
+		std::map<const Body *, T> m_components;
+	};
+
+	// Type-specific serialization implementation. Delegates to the type's
+	// internal serialization methods and provides the needed glue code.
+	template <typename T>
+	struct Serializer final : public SerializerBase {
+		Serializer(std::string name, Pool<T> *pool) :
+			SerializerBase(name),
+			pool(pool)
+		{}
+		Pool<T> *pool;
+
+		virtual void toJson(const Body *body, Json &obj, Space *space) override
+		{
+			pool->get(body)->SaveToJson(obj, space);
+		}
+
+		virtual BodyComponent *fromJson(Body *body, const Json &obj, Space *space) override
+		{
+			pool->deleteComponent(body);
+			auto *component = pool->newComponent(body);
+			component->LoadFromJson(obj, space);
+			return component;
+		}
+	};
+
+	// Returns (and creates) a type-specific pool.
+	template <typename T>
+	static Pool<T> *GetComponentType()
+	{
+		auto iter = m_componentPools.find(TypeId<T>::Get());
+		if (iter == m_componentPools.end()) {
+			iter = m_componentPools.emplace(TypeId<T>::Get(), new Pool<T>(m_componentIdx++, TypeId<T>::Get())).first;
+			m_componentTypes.push_back(TypeId<T>::Get());
+		}
+
+		return static_cast<Pool<T> *>(iter->second.get());
+	}
+
+	// Returns (if present) the polymorphic interface to component associated with the given index
+	// This differs from the type-ID and is volatile between program restarts
+	static PoolBase *GetComponentType(size_t componentIndex) { return m_componentPools.at(m_componentTypes[componentIndex]).get(); }
+
+	// Register a serializer for the given type.
+	template <typename T>
+	static bool RegisterSerializer(std::string typeName)
+	{
+		assert(!m_componentSerializers.count(typeName));
+		SerializerBase *serial = new Serializer<T>(typeName, GetComponentType<T>());
+		m_componentSerializers.emplace(typeName, serial);
+		GetComponentType<T>()->serializer = serial;
+		return true;
+	}
+
+	// Returns a pointer to the registered Serializer instance for a type identified by the given name, or nullptr.
+	// To retrieve the serializer instance for a given type index, use GetComponentType(idx)->serializer
+	// or GetComponentType<T>()->serializer.
+	static SerializerBase *GetSerializer(const std::string &typeName)
+	{
+		auto iter = m_componentSerializers.find(typeName);
+		if (iter != m_componentSerializers.end())
+			return iter->second.get();
+
+		return nullptr;
+	}
+
+private:
+	static std::map<size_t, std::unique_ptr<PoolBase>> m_componentPools;
+	static std::map<std::string, std::unique_ptr<SerializerBase>> m_componentSerializers;
+	static std::vector<size_t> m_componentTypes;
+	static size_t m_componentIdx;
+};

--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -16,9 +16,7 @@ static const float KINETIC_ENERGY_MULT = 0.00001f;
 const double DynamicBody::DEFAULT_DRAG_COEFF = 0.1; // 'smooth sphere'
 
 DynamicBody::DynamicBody() :
-	ModelBody(),
-	m_propulsion(nullptr),
-	m_fixedGuns(nullptr)
+	ModelBody()
 {
 	m_dragCoeff = DEFAULT_DRAG_COEFF;
 	m_flags = Body::FLAG_CAN_MOVE_FRAME;
@@ -39,8 +37,6 @@ DynamicBody::DynamicBody() :
 	m_lastTorque = vector3d(0.0);
 	m_aiMessage = AIError::AIERROR_NONE;
 	m_decelerating = false;
-	for (int i = 0; i < Feature::MAX_FEATURE; i++)
-		m_features[i] = false;
 }
 
 DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
@@ -50,9 +46,7 @@ DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
 	m_atmosForce(vector3d(0.0)),
 	m_gravityForce(vector3d(0.0)),
 	m_lastForce(vector3d(0.0)),
-	m_lastTorque(vector3d(0.0)),
-	m_propulsion(nullptr),
-	m_fixedGuns(nullptr)
+	m_lastTorque(vector3d(0.0))
 {
 	m_flags = Body::FLAG_CAN_MOVE_FRAME;
 	m_oldPos = GetPosition();
@@ -75,8 +69,6 @@ DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
 
 	m_aiMessage = AIError::AIERROR_NONE;
 	m_decelerating = false;
-	for (int i = 0; i < Feature::MAX_FEATURE; i++)
-		m_features[i] = false;
 }
 
 void DynamicBody::SaveToJson(Json &jsonObj, Space *space)
@@ -118,18 +110,6 @@ void DynamicBody::PostLoadFixup(Space *space)
 
 DynamicBody::~DynamicBody()
 {
-	m_propulsion.Reset();
-	m_fixedGuns.Reset();
-}
-
-void DynamicBody::AddFeature(Feature f)
-{
-	m_features[f] = true;
-	if (f == Feature::PROPULSION && m_propulsion == nullptr) {
-		m_propulsion.Reset(new Propulsion());
-	} else if (f == Feature::FIXED_GUNS && m_fixedGuns == nullptr) {
-		m_fixedGuns.Reset(new FixedGuns());
-	}
 }
 
 void DynamicBody::SetForce(const vector3d &f)
@@ -155,30 +135,6 @@ void DynamicBody::AddRelForce(const vector3d &f)
 void DynamicBody::AddRelTorque(const vector3d &t)
 {
 	m_torque += GetOrient() * t;
-}
-
-const Propulsion *DynamicBody::GetPropulsion() const
-{
-	assert(m_propulsion != nullptr);
-	return m_propulsion.Get();
-}
-
-Propulsion *DynamicBody::GetPropulsion()
-{
-	assert(m_propulsion != nullptr);
-	return m_propulsion.Get();
-}
-
-const FixedGuns *DynamicBody::GetFixedGuns() const
-{
-	assert(m_fixedGuns != nullptr);
-	return m_fixedGuns.Get();
-}
-
-FixedGuns *DynamicBody::GetFixedGuns()
-{
-	assert(m_fixedGuns != nullptr);
-	return m_fixedGuns.Get();
 }
 
 void DynamicBody::SetTorque(const vector3d &t)

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -77,19 +77,7 @@ public:
 		return tmp;
 	}
 
-	enum Feature {
-		PROPULSION = 0,
-		FIXED_GUNS = 1,
-		MAX_FEATURE = 2,
-	};
-
-	bool Have(Feature f) const { return m_features[f]; };
 	void SetDecelerating(bool decel) { m_decelerating = decel; }
-	const Propulsion *GetPropulsion() const;
-	Propulsion *GetPropulsion();
-	const FixedGuns *GetFixedGuns() const;
-	FixedGuns *GetFixedGuns();
-	void AddFeature(Feature f);
 
 protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
@@ -124,11 +112,6 @@ private:
 	// for time accel reduction fudge
 	vector3d m_lastForce;
 	vector3d m_lastTorque;
-
-	bool m_features[MAX_FEATURE];
-
-	RefCountedPtr<Propulsion> m_propulsion;
-	RefCountedPtr<FixedGuns> m_fixedGuns;
 };
 
 #endif /* _DYNAMICBODY_H */

--- a/src/FixedGuns.cpp
+++ b/src/FixedGuns.cpp
@@ -12,6 +12,10 @@
 #include "scenegraph/MatrixTransform.h"
 #include "vector3.h"
 
+REGISTER_COMPONENT_TYPE(FixedGuns) {
+	BodyComponentDB::RegisterComponent<FixedGuns>("FixedGuns");
+}
+
 FixedGuns::FixedGuns()
 {
 }

--- a/src/FixedGuns.cpp
+++ b/src/FixedGuns.cpp
@@ -58,7 +58,6 @@ void FixedGuns::Init(DynamicBody *b)
 		m_recharge_stat[i] = 0.0;
 		m_temperature_stat[i] = 0.0;
 	}
-	b->AddFeature(DynamicBody::FIXED_GUNS);
 }
 
 void FixedGuns::SaveToJson(Json &jsonObj, Space *space)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -172,6 +172,10 @@ Game::Game(const Json &jsonObj) :
 	// views
 	LoadViewsFromJson(jsonObj);
 
+	// lua components
+	// the contents of m_space->m_bodies must not change until after this call
+	Pi::luaSerializer->LoadComponents(jsonObj, m_space.get());
+
 	// lua
 	Pi::luaSerializer->FromJson(jsonObj);
 
@@ -225,6 +229,10 @@ void Game::ToJson(Json &jsonObj)
 	// views. must be saved in init order
 	m_gameViews->m_sectorView->SaveToJson(jsonObj);
 	m_gameViews->m_worldView->SaveToJson(jsonObj);
+
+	// lua components
+	// the contents of m_space->m_bodies must not change until after this call
+	Pi::luaSerializer->SaveComponents(jsonObj, m_space.get());
 
 	// lua
 	Pi::luaSerializer->ToJson(jsonObj);

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -40,6 +40,7 @@ private:
 	Body *m_owner;
 	bool m_armed;
 	const ShipType *m_type;
+	Propulsion *m_propulsion;
 
 	int m_ownerIndex; // deserialisation
 };

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1,12 +1,15 @@
 // Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-#include "Input.h"
 #include "buildopts.h"
 
 #include "Pi.h"
 
+#include "Body.h"
+#include "BodyComponent.h"
+
 #include "BaseSphere.h"
+#include "Beam.h"
 #include "CityOnPlanet.h"
 #include "DeathView.h"
 #include "EnumStrings.h"
@@ -17,29 +20,13 @@
 #include "GameConfig.h"
 #include "GameLog.h"
 #include "GameSaveError.h"
+#include "Input.h"
 #include "Intro.h"
 #include "Lang.h"
 #include "Missile.h"
 #include "ModManager.h"
 #include "ModelCache.h"
 #include "NavLights.h"
-#include "core/GuiApplication.h"
-#include "core/Log.h"
-#include "core/OS.h"
-#include "graphics/Material.h"
-#include "graphics/RenderState.h"
-#include "graphics/opengl/RendererGL.h"
-#include "imgui/imgui.h"
-#include "lua/Lua.h"
-#include "lua/LuaConsole.h"
-#include "lua/LuaEvent.h"
-#include "lua/LuaTimer.h"
-#include "profiler/Profiler.h"
-#include "sound/AmbientSounds.h"
-#if WITH_OBJECTVIEWER
-#include "ObjectViewerView.h"
-#endif
-#include "Beam.h"
 #include "Player.h"
 #include "PngWriter.h"
 #include "Projectile.h"
@@ -54,26 +41,38 @@
 #include "Tombstone.h"
 #include "TransferPlanner.h"
 #include "WorldView.h"
+
+#if WITH_OBJECTVIEWER
+#include "ObjectViewerView.h"
+#endif
+
 #include "galaxy/GalaxyGenerator.h"
-#include "libs.h"
+
+#include "graphics/Renderer.h"
+#include "graphics/Material.h"
+#include "graphics/RenderState.h"
+#include "graphics/opengl/RendererGL.h"
+
+#include "core/GuiApplication.h"
+#include "core/Log.h"
+#include "core/OS.h"
+
+#include "lua/Lua.h"
+#include "lua/LuaConsole.h"
+#include "lua/LuaEvent.h"
+#include "lua/LuaTimer.h"
+
 #include "pigui/LuaPiGui.h"
 #include "pigui/PerfInfo.h"
 #include "pigui/PiGui.h"
-#include "ship/PlayerShipController.h"
-#include "ship/ShipViewController.h"
+
+#include "sound/AmbientSounds.h"
 #include "sound/Sound.h"
 #include "sound/SoundMusic.h"
 
-#include "graphics/Renderer.h"
-
-#if WITH_DEVKEYS
-#include "graphics/Graphics.h"
-#include "graphics/Light.h"
-#include "graphics/Stats.h"
-#endif // WITH_DEVKEYS
-
-#include "scenegraph/Lua.h"
+#include "libs.h"
 #include "versioningInfo.h"
+#include "profiler/Profiler.h"
 
 #ifdef PROFILE_LUA_TIME
 #include <time.h>
@@ -377,6 +376,8 @@ void Pi::App::Startup()
 	// Can be initialized directly after FileSystem::Init, but put it here for convenience
 	GalacticEconomy::Init();
 
+	BodyComponentDB::Init();
+
 	Profiler::Clock threadTimer;
 	threadTimer.Start();
 
@@ -443,6 +444,8 @@ void Pi::App::Shutdown()
 	delete Pi::modelCache;
 
 	GalaxyGenerator::Uninit();
+
+	BodyComponentDB::Uninit();
 
 	ShutdownRenderer();
 	Pi::renderer = nullptr;

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -53,7 +53,7 @@ Player::Player(const ShipType::Id &shipId) :
 {
 	SetController(new PlayerShipController());
 	InitCockpit();
-	GetFixedGuns()->SetShouldUseLeadCalc(true);
+	m_fixedGuns->SetShouldUseLeadCalc(true);
 	registerEquipChangeListener(this);
 	m_accel = vector3d(0.0f, 0.0f, 0.0f);
 }
@@ -62,7 +62,7 @@ Player::Player(const Json &jsonObj, Space *space) :
 	Ship(jsonObj, space)
 {
 	InitCockpit();
-	GetFixedGuns()->SetShouldUseLeadCalc(true);
+	m_fixedGuns->SetShouldUseLeadCalc(true);
 	registerEquipChangeListener(this);
 }
 
@@ -307,8 +307,8 @@ void Player::StaticUpdate(const float timeStep)
 	Ship::StaticUpdate(timeStep);
 
 	for (size_t i = 0; i < GUNMOUNT_MAX; i++)
-		if (GetFixedGuns()->IsGunMounted(i))
-			GetFixedGuns()->UpdateLead(timeStep, i, this, GetCombatTarget());
+		if (m_fixedGuns->IsGunMounted(i))
+			m_fixedGuns->UpdateLead(timeStep, i, this, GetCombatTarget());
 
 	// store last 20 jerk (derivative of acceleration wrt. time) values
 	// first, move the earlier values back by one

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -102,7 +102,6 @@ public:
 	void Explode();
 	virtual bool DoDamage(float kgDamage); // can be overloaded in Player to add audio
 	void SetGunState(int idx, int state);
-	float GetGunTemperature(int idx) const { return GetFixedGuns()->GetGunTemperature(idx); }
 	void UpdateMass();
 	virtual bool SetWheelState(bool down); // returns success of state change, NOT state itself
 	void Blastoff();
@@ -240,6 +239,8 @@ public:
 
 	double GetLandingPosOffset() const { return m_landingMinOffset; }
 
+	Propulsion *GetPropulsion() { return m_propulsion; }
+
 protected:
 	vector3d CalcAtmosphericForce() const override;
 
@@ -270,6 +271,9 @@ protected:
 	} m_hyperspace;
 
 	LuaRef m_equipSet;
+
+	Propulsion *m_propulsion;
+	FixedGuns *m_fixedGuns;
 
 private:
 	float GetECMRechargeTime();
@@ -326,19 +330,20 @@ private:
 	std::string m_shipName;
 
 public:
-	void ClearAngThrusterState() { GetPropulsion()->ClearAngThrusterState(); }
-	void ClearLinThrusterState() { GetPropulsion()->ClearLinThrusterState(); }
-	double GetAccelFwd() { return GetPropulsion()->GetAccelFwd(); }
-	void SetAngThrusterState(const vector3d &levels) { GetPropulsion()->SetAngThrusterState(levels); }
-	double GetFuel() const { return GetPropulsion()->GetFuel(); }
-	double GetAccel(Thruster thruster) const { return GetPropulsion()->GetAccel(thruster); }
-	void SetFuel(const double f) { GetPropulsion()->SetFuel(f); }
-	void SetFuelReserve(const double f) { GetPropulsion()->SetFuelReserve(f); }
+	// FIXME: these methods are deprecated; all calls should use the propulsion object directly.
+	void ClearAngThrusterState() { m_propulsion->ClearAngThrusterState(); }
+	void ClearLinThrusterState() { m_propulsion->ClearLinThrusterState(); }
+	double GetAccelFwd() { return m_propulsion->GetAccelFwd(); }
+	void SetAngThrusterState(const vector3d &levels) { m_propulsion->SetAngThrusterState(levels); }
+	double GetFuel() const { return m_propulsion->GetFuel(); }
+	double GetAccel(Thruster thruster) const { return m_propulsion->GetAccel(thruster); }
+	void SetFuel(const double f) { m_propulsion->SetFuel(f); }
+	void SetFuelReserve(const double f) { m_propulsion->SetFuelReserve(f); }
 
-	bool AIMatchVel(const vector3d &vel, const vector3d &powerLimit = vector3d(1.0)) { return GetPropulsion()->AIMatchVel(vel, powerLimit); }
-	double AIFaceDirection(const vector3d &dir, double av = 0) { return GetPropulsion()->AIFaceDirection(dir, av); }
-	void SetThrusterState(int axis, double level) { return GetPropulsion()->SetLinThrusterState(axis, level); }
-	void AIMatchAngVelObjSpace(const vector3d &desiredAngVel, const vector3d &powerLimit = vector3d(1.0)) { return GetPropulsion()->AIMatchAngVelObjSpace(desiredAngVel, powerLimit); }
+	bool AIMatchVel(const vector3d &vel, const vector3d &powerLimit = vector3d(1.0)) { return m_propulsion->AIMatchVel(vel, powerLimit); }
+	double AIFaceDirection(const vector3d &dir, double av = 0) { return m_propulsion->AIFaceDirection(dir, av); }
+	void SetThrusterState(int axis, double level) { return m_propulsion->SetLinThrusterState(axis, level); }
+	void AIMatchAngVelObjSpace(const vector3d &desiredAngVel, const vector3d &powerLimit = vector3d(1.0)) { return m_propulsion->AIMatchAngVelObjSpace(desiredAngVel, powerLimit); }
 };
 
 #endif /* _SHIP_H */

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -11,6 +11,7 @@
 #include "Space.h"
 #include "SpaceStation.h"
 #include "perlin.h"
+#include "ship/Propulsion.h"
 
 static const double VICINITY_MIN = 15000.0;
 static const double VICINITY_MUL = 4.0;
@@ -232,7 +233,7 @@ AICmdKamikaze::AICmdKamikaze(DynamicBody *dBody, Body *target) :
 	AICommand(dBody, CMD_KAMIKAZE)
 {
 	m_target = target;
-	m_prop.Reset(m_dBody->GetPropulsion());
+	m_prop = m_dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -257,7 +258,7 @@ void AICmdKamikaze::PostLoadFixup(Space *space)
 	AICommand::PostLoadFixup(space);
 	m_target = space->GetBodyByIndex(m_targetIndex);
 	// Ensure needed sub-system:
-	m_prop.Reset(m_dBody->GetPropulsion());
+	m_prop = m_dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -324,8 +325,8 @@ AICmdKill::AICmdKill(DynamicBody *dBody, Ship *target) :
 	m_target = target;
 	m_leadTime = m_evadeTime = m_closeTime = 0.0;
 	m_lastVel = m_target->GetVelocity();
-	m_prop.Reset(m_dBody->GetPropulsion());
-	m_fguns.Reset(m_dBody->GetFixedGuns());
+	m_prop = m_dBody->GetComponent<Propulsion>();
+	m_fguns = m_dBody->GetComponent<FixedGuns>();
 	assert(m_prop != nullptr);
 	assert(m_fguns != nullptr);
 }
@@ -357,8 +358,8 @@ void AICmdKill::PostLoadFixup(Space *space)
 	m_leadTime = m_evadeTime = m_closeTime = 0.0;
 	m_lastVel = m_target->GetVelocity();
 	// Ensure needed sub-system:
-	m_prop.Reset(m_dBody->GetPropulsion());
-	m_fguns.Reset(m_dBody->GetFixedGuns());
+	m_prop = m_dBody->GetComponent<Propulsion>();
+	m_fguns = m_dBody->GetComponent<FixedGuns>();
 	assert(m_prop != nullptr);
 	assert(m_fguns != nullptr);
 }
@@ -722,8 +723,8 @@ static vector3d GenerateTangent(DynamicBody *dBody, FrameId targframeId, const v
 //4 - probable path intercept
 int CheckCollision(DynamicBody *dBody, const vector3d &pathdir, double pathdist, const vector3d &tpos, double endvel, double r)
 {
-	if (!dBody->Have(DynamicBody::PROPULSION)) return 0;
-	Propulsion *prop = dBody->GetPropulsion();
+	if (!dBody->HasComponent<Propulsion>()) return 0;
+	Propulsion *prop = dBody->GetComponent<Propulsion>();
 	assert(prop != nullptr);
 	// ship is in obstructor's frame anyway, so is tpos
 	if (pathdist < 100.0) return 0;
@@ -805,7 +806,7 @@ static bool ParentSafetyAdjust(DynamicBody *dBody, FrameId targframeId, vector3d
 
 	// aim for zero velocity at surface of that body
 	// still along path to target
-	Propulsion *prop = dBody->GetPropulsion();
+	Propulsion *prop = dBody->GetComponent<Propulsion>();
 	if (prop == nullptr) return false;
 	vector3d targpos2 = targpos - dBody->GetPosition();
 	double targdist = targpos2.Length();
@@ -821,8 +822,8 @@ static bool ParentSafetyAdjust(DynamicBody *dBody, FrameId targframeId, vector3d
 static bool CheckSuicide(DynamicBody *dBody, const vector3d &tandir)
 {
 	Body *body = Frame::GetFrame(dBody->GetFrame())->GetBody();
-	if (dBody->Have(DynamicBody::PROPULSION)) return false;
-	Propulsion *prop = dBody->GetPropulsion();
+	if (!dBody->HasComponent<Propulsion>()) return false;
+	Propulsion *prop = dBody->GetComponent<Propulsion>();
 	assert(prop != nullptr);
 	if (!body || !body->IsType(ObjectType::TERRAINBODY)) return false;
 
@@ -860,7 +861,7 @@ void AICmdFlyTo::PostLoadFixup(Space *space)
 	m_lockhead = true;
 	m_frameId = m_target ? m_target->GetFrame() : FrameId();
 	// Ensure needed sub-system:
-	m_prop.Reset(m_dBody->GetPropulsion());
+	m_prop = m_dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -868,7 +869,7 @@ void AICmdFlyTo::PostLoadFixup(Space *space)
 AICmdFlyTo::AICmdFlyTo(DynamicBody *dBody, Body *target) :
 	AICommand(dBody, CMD_FLYTO)
 {
-	m_prop.Reset(dBody->GetPropulsion());
+	m_prop = dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 	m_frameId = FrameId::Invalid;
 	m_state = -6;
@@ -879,7 +880,7 @@ AICmdFlyTo::AICmdFlyTo(DynamicBody *dBody, Body *target) :
 	if (!target->IsType(ObjectType::TERRAINBODY))
 		m_dist = VICINITY_MIN;
 	else
-		m_dist = VICINITY_MUL * MaxEffectRad(target, m_prop.Get());
+		m_dist = VICINITY_MUL * MaxEffectRad(target, m_prop);
 
 	if (target->IsType(ObjectType::SPACESTATION) && static_cast<SpaceStation *>(target)->IsGroundStation()) {
 		m_posoff = target->GetPosition() + VICINITY_MIN * target->GetOrient().VectorY();
@@ -906,7 +907,7 @@ AICmdFlyTo::AICmdFlyTo(DynamicBody *dBody, FrameId targframe, const vector3d &po
 	m_lockhead(true),
 	m_frameId(FrameId::Invalid)
 {
-	m_prop.Reset(dBody->GetPropulsion());
+	m_prop = dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -1003,7 +1004,7 @@ bool AICmdFlyTo::TimeStepUpdate()
 	// TODO: collision needs to be processed according to vdiff, not reldir?
 
 	Body *body = Frame::GetFrame(m_frameId)->GetBody();
-	double erad = MaxEffectRad(body, m_prop.Get());
+	double erad = MaxEffectRad(body, m_prop);
 	Frame *targframe = Frame::GetFrame(targframeId);
 	if ((m_target && body != m_target) || (targframe && (!m_tangent || body != targframe->GetBody()))) {
 		int coll = CheckCollision(m_dBody, reldir, targdist, targpos, m_endvel, erad);
@@ -1156,7 +1157,7 @@ void AICmdDock::PostLoadFixup(Space *space)
 	AICommand::PostLoadFixup(space);
 	m_target = static_cast<SpaceStation *>(space->GetBodyByIndex(m_targetIndex));
 	// Ensure needed sub-system:
-	m_prop.Reset(m_dBody->GetPropulsion());
+	m_prop = m_dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -1170,7 +1171,7 @@ AICmdDock::AICmdDock(DynamicBody *dBody, SpaceStation *target) :
 	ship = static_cast<Ship *>(dBody);
 	assert(ship != nullptr);
 
-	m_prop.Reset(ship->GetPropulsion());
+	m_prop = ship->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 
 	if (target->IsGroundStation()) {
@@ -1356,7 +1357,7 @@ bool AICmdDock::TimeStepUpdate()
 AICmdHoldPosition::AICmdHoldPosition(DynamicBody *dBody) :
 	AICommand(dBody, CMD_HOLDPOSITION)
 {
-	m_prop.Reset(m_dBody->GetPropulsion());
+	m_prop = m_dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -1364,7 +1365,7 @@ AICmdHoldPosition::AICmdHoldPosition(const Json &jsonObj) :
 	AICommand(jsonObj, CMD_HOLDPOSITION)
 {
 	// Ensure needed sub-system:
-	m_prop.Reset(m_dBody->GetPropulsion());
+	m_prop = m_dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -1389,7 +1390,7 @@ void AICmdFlyAround::PostLoadFixup(Space *space)
 	AICommand::PostLoadFixup(space);
 	m_obstructor = space->GetBodyByIndex(m_obstructorIndex);
 	// Ensure needed sub-system:
-	m_prop.Reset(m_dBody->GetPropulsion());
+	m_prop = m_dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -1403,7 +1404,7 @@ void AICmdFlyAround::Setup(Body *obstructor, double alt, double vel, int mode)
 	m_targmode = mode;
 
 	// push out of effect radius (gravity safety & station parking zones)
-	alt = std::max(alt, MaxEffectRad(obstructor, m_prop.Get()));
+	alt = std::max(alt, MaxEffectRad(obstructor, m_prop));
 
 	// drag within frame because orbits are impossible otherwise
 	// timestep code also doesn't work correctly for ex-frame cases, should probably be fixed
@@ -1420,7 +1421,7 @@ void AICmdFlyAround::Setup(Body *obstructor, double alt, double vel, int mode)
 AICmdFlyAround::AICmdFlyAround(DynamicBody *dBody, Body *obstructor, double relalt, int mode) :
 	AICommand(dBody, CMD_FLYAROUND)
 {
-	m_prop.Reset(dBody->GetPropulsion());
+	m_prop = dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 
 	assert(!std::isnan(relalt));
@@ -1432,7 +1433,7 @@ AICmdFlyAround::AICmdFlyAround(DynamicBody *dBody, Body *obstructor, double rela
 AICmdFlyAround::AICmdFlyAround(DynamicBody *dBody, Body *obstructor, double alt, double vel, int mode) :
 	AICommand(dBody, CMD_FLYAROUND)
 {
-	m_prop.Reset(dBody->GetPropulsion());
+	m_prop = dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 
 	assert(!std::isnan(alt));
@@ -1468,7 +1469,7 @@ void AICmdFlyAround::SaveToJson(Json &jsonObj)
 
 double AICmdFlyAround::MaxVel(double targdist, double targalt)
 {
-	Propulsion *prop = m_dBody->GetPropulsion();
+	Propulsion *prop = m_dBody->GetComponent<Propulsion>();
 	assert(prop != 0);
 
 	if (targalt > m_alt) return m_vel;
@@ -1590,7 +1591,7 @@ AICmdFormation::AICmdFormation(DynamicBody *dBody, DynamicBody *target, const ve
 	m_target(target),
 	m_posoff(posoff)
 {
-	m_prop.Reset(dBody->GetPropulsion());
+	m_prop = dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 
@@ -1622,7 +1623,7 @@ void AICmdFormation::PostLoadFixup(Space *space)
 	AICommand::PostLoadFixup(space);
 	m_target = static_cast<Ship *>(space->GetBodyByIndex(m_targetIndex));
 	// Ensure needed sub-system:
-	m_prop.Reset(m_dBody->GetPropulsion());
+	m_prop = m_dBody->GetComponent<Propulsion>();
 	assert(m_prop != nullptr);
 }
 

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -723,9 +723,10 @@ static vector3d GenerateTangent(DynamicBody *dBody, FrameId targframeId, const v
 //4 - probable path intercept
 int CheckCollision(DynamicBody *dBody, const vector3d &pathdir, double pathdist, const vector3d &tpos, double endvel, double r)
 {
-	if (!dBody->HasComponent<Propulsion>()) return 0;
 	Propulsion *prop = dBody->GetComponent<Propulsion>();
-	assert(prop != nullptr);
+	if (!prop) // This body doesn't have any propulsion to avoid collision
+		return 0;
+
 	// ship is in obstructor's frame anyway, so is tpos
 	if (pathdist < 100.0) return 0;
 	Body *body = Frame::GetFrame(dBody->GetFrame())->GetBody();

--- a/src/ShipAICmd.h
+++ b/src/ShipAICmd.h
@@ -8,8 +8,8 @@
 #include "JsonFwd.h"
 
 #include "DynamicBody.h"
-#include "FrameId.h"
 #include "FixedGuns.h"
+#include "FrameId.h"
 #include "ship/Propulsion.h"
 
 class Ship;
@@ -64,8 +64,8 @@ public:
 
 protected:
 	DynamicBody *m_dBody;
-	RefCountedPtr<Propulsion> m_prop;
-	RefCountedPtr<FixedGuns> m_fguns;
+	Propulsion *m_prop;
+	FixedGuns *m_fguns;
 
 	std::unique_ptr<AICommand> m_child;
 	bool m_is_flyto = false;
@@ -89,9 +89,9 @@ public:
 private:
 	enum EDockingStates {
 		eDockGetDataStart = 0, // 0: get data for docking start pos
-		eDockFlyToStart = 1, // 1: Fly to docking start pos
-		eDockGetDataEnd = 2, // 2: get data for docking end pos
-		eDockFlyToEnd = 3, // 3: Fly to docking end pos
+		eDockFlyToStart = 1,   // 1: Fly to docking start pos
+		eDockGetDataEnd = 2,   // 2: get data for docking end pos
+		eDockFlyToEnd = 3,	   // 3: Fly to docking end pos
 		eDockingComplete = 4,
 		eInvalidDockingStage = 5
 	};
@@ -101,7 +101,7 @@ private:
 	vector3d m_dockdir;
 	vector3d m_dockupdir;
 	EDockingStates m_state; // see TimeStepUpdate()
-	int m_targetIndex; // used during deserialisation
+	int m_targetIndex;		// used during deserialisation
 
 	void IncrementState()
 	{
@@ -130,12 +130,12 @@ public:
 	virtual void OnDeleted(const Body *body);
 
 private:
-	Body *m_target; // target for vicinity. Either this or targframe is 0
-	double m_dist; // vicinity distance
+	Body *m_target;		   // target for vicinity. Either this or targframe is 0
+	double m_dist;		   // vicinity distance
 	FrameId m_targframeId; // target frame for waypoint
-	vector3d m_posoff; // offset in target frame
-	double m_endvel; // target speed in direction of motion at end of path, positive only
-	bool m_tangent; // true if path is to a tangent of the target frame's body
+	vector3d m_posoff;	   // offset in target frame
+	double m_endvel;	   // target speed in direction of motion at end of path, positive only
+	bool m_tangent;		   // true if path is to a tangent of the target frame's body
 	int m_state;
 
 	bool m_lockhead;
@@ -170,10 +170,10 @@ protected:
 	double MaxVel(double targdist, double targalt);
 
 private:
-	Body *m_obstructor; // body to fly around
+	Body *m_obstructor;	   // body to fly around
 	int m_obstructorIndex; // deserialisation
 	double m_alt, m_vel;
-	int m_targmode; // 0 targpos termination, 1 infinite, 2+ orbital termination
+	int m_targmode;		// 0 targpos termination, 1 infinite, 2+ orbital termination
 	vector3d m_targpos; // target position in ship space
 };
 
@@ -235,7 +235,7 @@ public:
 
 private:
 	DynamicBody *m_target; // target frame for waypoint
-	vector3d m_posoff; // offset in target frame
+	vector3d m_posoff;	   // offset in target frame
 
 	int m_targetIndex; // used during deserialisation
 };

--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -182,8 +182,9 @@ void ShipCockpit::Update(const Player *player, float timeStep)
 
 	// setup thruster levels
 	if (GetModel()) {
-		vector3f linthrust{ player->GetPropulsion()->GetLinThrusterState() };
-		vector3f angthrust{ player->GetPropulsion()->GetAngThrusterState() };
+		Propulsion *prop = player->GetComponent<Propulsion>();
+		vector3f linthrust{ prop->GetLinThrusterState() };
+		vector3f angthrust{ prop->GetAngThrusterState() };
 		GetModel()->SetThrust(linthrust, -angthrust);
 	}
 }

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -336,8 +336,9 @@ void WorldView::UpdateProjectedObjects()
 			}
 		}
 
-		if (laser >= 0 && Pi::player->GetFixedGuns()->IsGunMounted(laser)) {
-			UpdateIndicator(m_targetLeadIndicator, cam_rot * Pi::player->GetFixedGuns()->GetTargetLeadPos());
+		FixedGuns *gunManager = Pi::player->GetComponent<FixedGuns>();
+		if (laser >= 0 && gunManager->IsGunMounted(laser)) {
+			UpdateIndicator(m_targetLeadIndicator, cam_rot * gunManager->GetTargetLeadPos());
 			if ((m_targetLeadIndicator.side != INDICATOR_ONSCREEN) || (m_combatTargetIndicator.side != INDICATOR_ONSCREEN))
 				HideIndicator(m_targetLeadIndicator);
 		} else {

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -143,7 +143,7 @@ static int l_body_get_component(lua_State *l)
 
 static int l_body_set_component(lua_State *l)
 {
-	Body *b = LuaObject<Body>::CheckFromLua(1);
+	LuaObject<Body>::CheckFromLua(1);
 	std::string componentName = luaL_checkstring(l, 2);
 
 	BodyComponentDB::PoolBase *pool = BodyComponentDB::GetComponentType(componentName);
@@ -152,7 +152,7 @@ static int l_body_set_component(lua_State *l)
 	}
 
 	if (componentName == "__properties") {
-		return luaL_error(l, "'__properties' is a reserved name for body components.");
+		return luaL_error(l, "'__properties' is a reserved name and cannot be used as a component.");
 	}
 
 	int type = lua_type(l, 3);

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -121,9 +121,13 @@ static int l_body_attr_path(lua_State *l)
 static int l_body_get_component(lua_State *l)
 {
 	Body *b = LuaObject<Body>::CheckFromLua(1);
-	std::string_view componentName = luaL_checkstring(l, 2);
+	std::string componentName = luaL_checkstring(l, 2);
 
-	// TODO: lookup C++ components
+	BodyComponentDB::PoolBase *pool = BodyComponentDB::GetComponentType(componentName);
+	if (pool && pool->luaInterface) {
+		pool->luaInterface->PushToLua(b);
+		return 1;
+	}
 
 	if (componentName == "__properties") {
 		lua_pushnil(l);
@@ -140,12 +144,15 @@ static int l_body_get_component(lua_State *l)
 static int l_body_set_component(lua_State *l)
 {
 	Body *b = LuaObject<Body>::CheckFromLua(1);
-	std::string_view componentName = luaL_checkstring(l, 2);
+	std::string componentName = luaL_checkstring(l, 2);
 
-	// TODO: lookup C++ components
+	BodyComponentDB::PoolBase *pool = BodyComponentDB::GetComponentType(componentName);
+	if (pool) {
+		return luaL_error(l, "Cannot set C++ body component '%s' to a lua value.");
+	}
 
 	if (componentName == "__properties") {
-		return luaL_error(l, "Error: '__properties' is a reserved name for body components.");
+		return luaL_error(l, "'__properties' is a reserved name for body components.");
 	}
 
 	int type = lua_type(l, 3);

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -118,6 +118,48 @@ static int l_body_attr_path(lua_State *l)
 	return 1;
 }
 
+static int l_body_get_component(lua_State *l)
+{
+	Body *b = LuaObject<Body>::CheckFromLua(1);
+	std::string_view componentName = luaL_checkstring(l, 2);
+
+	// TODO: lookup C++ components
+
+	if (componentName == "__properties") {
+		lua_pushnil(l);
+		return 1;
+	}
+
+	lua_getuservalue(l, 1);
+	lua_pushvalue(l, 2);
+	lua_rawget(l, -2);
+
+	return 1;
+}
+
+static int l_body_set_component(lua_State *l)
+{
+	Body *b = LuaObject<Body>::CheckFromLua(1);
+	std::string_view componentName = luaL_checkstring(l, 2);
+
+	// TODO: lookup C++ components
+
+	if (componentName == "__properties") {
+		return luaL_error(l, "Error: '__properties' is a reserved name for body components.");
+	}
+
+	int type = lua_type(l, 3);
+	if (type != LUA_TNIL && type != LUA_TTABLE) {
+		return luaL_error(l, "Cannot set body component '%s' to non-table value.", componentName.data());
+	}
+
+	lua_getuservalue(l, 1);
+	lua_replace(l, 1);
+	lua_rawset(l, -3);
+
+	return 0;
+}
+
 /*
  * Method: GetVelocityRelTo
  *
@@ -745,6 +787,8 @@ void LuaObject<Body>::RegisterClass()
 	const char *l_parent = "PropertiedObject";
 
 	static luaL_Reg l_methods[] = {
+		{ "GetComponent", l_body_get_component },
+		{ "SetComponent", l_body_set_component },
 		{ "IsDynamic", l_body_is_dynamic },
 		{ "DistanceTo", l_body_distance_to },
 		{ "GetGroundPosition", l_body_get_ground_position },

--- a/src/lua/LuaBodyComponent.h
+++ b/src/lua/LuaBodyComponent.h
@@ -1,0 +1,35 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "BodyComponent.h"
+#include "LuaObject.h"
+
+// Type-specific Lua management implementation for body components.
+//
+// BodyComponents are not automatically compatible with LuaPush / LuaPull,
+// and must either be managed with PushComponentToLua() or retrieved with
+// GetComponent(typeName) from the Lua side.
+//
+// Note: there is currently no Lua event handling for when a C++ component is
+// deleted - the LuaObject handle is just silently orphaned.
+template <typename T>
+struct BodyComponentDB::LuaInterface final : LuaInterfaceBase {
+	static_assert(std::is_base_of_v<LuaWrappable, T>, "BodyComponents must inherit from LuaWrappable to be pushed to Lua!");
+
+	LuaInterface(Pool<T> *pool) :
+		pool(pool)
+	{}
+	Pool<T> *pool;
+
+	virtual void PushToLua(const Body *body) override
+	{
+		LuaObject<T>::PushComponentToLua(pool->get(body));
+	}
+
+	virtual void DeregisterComponent(const Body *body) override
+	{
+		LuaObjectBase::DeregisterObject(pool->get(body));
+	}
+};

--- a/src/lua/LuaObject.cpp
+++ b/src/lua/LuaObject.cpp
@@ -210,8 +210,6 @@ int LuaObjectHelpers::l_gc(lua_State *l)
 	luaL_checktype(l, 1, LUA_TUSERDATA);
 	LuaObjectBase *lo = static_cast<LuaObjectBase *>(lua_touserdata(l, 1));
 
-	LuaObjectBase::Deregister(lo);
-
 	lo->~LuaObjectBase();
 
 	return 0;

--- a/src/lua/LuaObject.h
+++ b/src/lua/LuaObject.h
@@ -124,6 +124,16 @@ public:
 	// register a serializer pair for a given type
 	static void RegisterSerializer(const char *type, SerializerPair pair);
 
+	// Serialize all lua components registered for the given object.
+	// Requires the LuaWrappable object to have been pushed to Lua at least once and still exist.
+	// LuaComponents are only valid for LuaCoreObjects (in practice, only Body descendants)
+	static bool SerializeComponents(LuaWrappable *object, Json &out);
+
+	// Deserialize all lua components saved for the given object
+	// Requires the LuaWrappable object to have been pushed to Lua at least once and still exist
+	// LuaComponents are only valid for LuaCoreObjects (in practice, only Body descendants)
+	static bool DeserializeComponents(LuaWrappable *object, const Json &obj);
+
 protected:
 	// base class constructor, called by the wrapper Push* methods
 	LuaObjectBase(const char *type) :

--- a/src/lua/LuaSerializer.h
+++ b/src/lua/LuaSerializer.h
@@ -9,6 +9,8 @@
 #include "LuaObject.h"
 #include "LuaRef.h"
 
+class Space;
+
 class LuaSerializer : public DeleteEmitter {
 	friend class LuaObjectBase;
 	friend class LuaObject<LuaSerializer>;
@@ -18,6 +20,9 @@ class LuaSerializer : public DeleteEmitter {
 public:
 	void ToJson(Json &jsonObj);
 	void FromJson(const Json &jsonObj);
+
+	void SaveComponents(Json &jsonObj, Space *space);
+	void LoadComponents(const Json &jsonObj, Space *space);
 
 	void InitTableRefs();
 	void UninitTableRefs();

--- a/src/lua/LuaSerializer.h
+++ b/src/lua/LuaSerializer.h
@@ -10,6 +10,7 @@
 #include "LuaRef.h"
 
 class LuaSerializer : public DeleteEmitter {
+	friend class LuaObjectBase;
 	friend class LuaObject<LuaSerializer>;
 	friend void LuaRef::SaveToJson(Json &jsonObj);
 	friend void LuaRef::LoadFromJson(const Json &jsonObj);

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -1146,7 +1146,7 @@ static int l_ship_get_gun_temperature(lua_State *l)
 {
 	Ship *s = LuaObject<Ship>::CheckFromLua(1);
 	int gun = luaL_checkinteger(l, 2);
-	LuaPush(l, s->GetGunTemperature(gun));
+	LuaPush(l, s->GetComponent<FixedGuns>()->GetGunTemperature(gun));
 	return 1;
 }
 
@@ -1282,7 +1282,7 @@ static int l_ship_is_hyperspace_active(lua_State *l)
 static int l_ship_get_thruster_state(lua_State *l)
 {
 	Ship *s = LuaObject<Ship>::CheckFromLua(1);
-	vector3d v = s->GetPropulsion()->GetLinThrusterState();
+	vector3d v = s->GetComponent<Propulsion>()->GetLinThrusterState();
 	LuaPush<vector3d>(l, v);
 	return 1;
 }

--- a/src/ship/Propulsion.cpp
+++ b/src/ship/Propulsion.cpp
@@ -9,6 +9,16 @@
 #include "Player.h"
 #include "PlayerShipController.h"
 
+// #include "lua/LuaBodyComponent.h"
+
+REGISTER_COMPONENT_TYPE(Propulsion) {
+	BodyComponentDB::RegisterComponent<Propulsion>("Propulsion");
+	// Commented out as serialization is still handled in Ship
+	// BodyComponentDB::RegisterSerializer<Propulsion>();
+	// Commented out as Propulsion has no lua interface at current
+	// BodyComponentDB::RegisterLuaInterface<Propulsion>();
+}
+
 void Propulsion::SaveToJson(Json &jsonObj, Space *space)
 {
 	//Json PropulsionObj(Json::objectValue); // Create JSON object to contain propulsion data.


### PR DESCRIPTION
Fixes #5385.

This PR introduces something I've had sitting in a work branch for several months now: a move towards a composition-based object model rather than a strict inheritance model.

I've added fully-serialized C++ components that can be queried and composed at runtime; other than a need to register a serializer in some sort of centralized fashion the composition functionality is usable at any time by any piece of code without needing to know the concrete type of the body object it is operating on. The ship FixedGuns and Propulsion variables have been migrated to use this new system, although some further work is required to handle querying these components from Lua in a sane manner.

I've also added the ability for Lua to associate arbitrary tables with Body objects as components - also fully serialized - and query them at runtime. This allows for more fully-featured data ownership compared to using a PropertyMap or maintaining a separate lookup table keyed by the object. I intend to migrate the EquipSet functionality to use this LuaComponent feature at some point, though that will likely involve a refactor or rewrite of the equipment handling at the same time.

There is not currently any event handling for LuaComponents when the owning Body object is deleted, though that's something that can be implemented fairly easily if needed. Persisting LuaComponents across body destruction (e.g. when leaving and re-entering a system) is something that will still need to be done manually at a higher level of abstraction.

I know this PR is heavy on implementation and light on use-cases, but it makes moving code to a modular, composition-based approach much easier moving forwards and is already used internally by several of my work branches.

The API related to these two features is quite simple; for C++ objects you need to register a component type, optionally register its serializer, and then just add a new component to the body:

```c++
struct MyComponent {
    MyComponent();
    void SaveToJson(Json &out, Space *space);
    void LoadFromJson(const Json &obj, Space *space);
};

void SomeRegisterFunc() {
    BodyComponentDB::RegisterComponent<MyComponent>("MyComponent");
    BodyComponentDB::RegisterSerializer<MyComponent>();
}

void InitSomeBody(Body *body) {
    // Serialization and creation of the component when loading a save is automatic
    MyComponent *comp = body->AddComponent<MyComponent>();
}
```

Lua components are similar; simply make a new table and call SetComponent on a body with the value.
```lua
local TestComponent = utils.inherits(nil, "TestComponent")

Serializer:RegisterClass("TestComponent", TestComponent)

function someTestFunc(body)
    body:SetComponent("TestComponent", TestComponent.New())

    -- This value will be serialized with the body and loaded via TestComponent.Unserialize
    body:GetComponent("TestComponent").someField = "test"
end
```