### PR TITLE
Better Grid Rendering

### DIFF
--- a/data/shaders/opengl/grid.frag
+++ b/data/shaders/opengl/grid.frag
@@ -1,0 +1,74 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+// Adapted from https://ourmachinery.com/post/borderland-between-rendering-and-editor-part-1/
+// Credit to Tobias Persson for providing an example implementation.
+
+#include "attributes.glsl"
+
+layout(std140) uniform GridData {
+	vec4 color_lod0;
+	vec4 color_lod1;
+	vec4 grid_info;
+	vec2 grid_size;
+	float line_width_px;
+};
+
+in vec3 v_eyepos;
+in vec2 v_uv0;
+
+out vec4 frag_color;
+
+float log10(float v)
+{
+	return log(v) / log(10.0);
+}
+
+// Calculate the combined XY line coverage values for the given pixel with the defined grid setting
+float calc_grid_coverage(vec2 uv, vec2 line_width, float cell_size)
+{
+	vec2 cover = 1 - abs(clamp(mod(uv + line_width * 0.5, cell_size) / line_width, 0, 1) * 2 - 1);
+	return max(cover.x, cover.y);
+}
+
+void main(void)
+{
+	// Calculate the screen-space derivatives of the UV coordinates
+	vec4 derivatives = vec4(dFdx(v_uv0), dFdy(v_uv0));
+	vec2 dudv = vec2(length(derivatives.xz), length(derivatives.yw));
+
+	vec3 grid_dir = grid_info.xyz;
+	float cell_size = grid_info.w;
+
+	float lod_level = max(0, log10(length(dudv) / cell_size) + 1);
+	float lod_transition = fract(lod_level);
+
+	// Calculate the grid cell size at the minimum visible LOD level and the next larger
+	float lod0_cell_size = cell_size * pow(10, floor(lod_level));
+	float lod1_cell_size = lod0_cell_size * 10;
+	float lod2_cell_size = lod1_cell_size * 10;
+
+	// Calculate the XY line coverage values for this pixel
+	vec2 line_width = dudv * line_width_px; // size of a grid line in grid units
+	float lod0_a = calc_grid_coverage(v_uv0, line_width, lod0_cell_size);
+	float lod1_a = calc_grid_coverage(v_uv0, line_width, lod1_cell_size);
+	float lod2_a = calc_grid_coverage(v_uv0, line_width, lod2_cell_size);
+
+	// Generate all three separate color regions: bright, transition, dark
+	vec4 color = lod2_a > 0 ? color_lod1 : lod1_a > 0 ? mix(color_lod1, color_lod0, lod_transition) : color_lod0;
+	color.a *= lod2_a > 0 ? lod2_a : lod1_a > 0 ? lod1_a : lod0_a * (1.0 - lod_transition);
+
+	// Smoothly fade out the very edges of the grid
+	vec2 grid_edge = abs(v_uv0 / grid_size);
+	color.a *= 1.0 - pow(max(grid_edge.x, grid_edge.y), 16);
+
+	// Make the grid transparent at grazing angles
+	vec3 viewdir = normalize(v_eyepos);
+	color.a *= 1.0 - pow(1.0 - abs(dot(viewdir, grid_dir)), 8);
+
+	// Add some subtle depth-fade to further reduce moire effect
+	float viewdist = length(v_eyepos);
+	color.a *= viewdist < 10 ? min(1.0, pow(viewdist, 4)) : min(1.0, max(grid_size.x, grid_size.y) / viewdist);
+
+	frag_color = color;
+}

--- a/data/shaders/opengl/grid.shaderdef
+++ b/data/shaders/opengl/grid.shaderdef
@@ -1,0 +1,10 @@
+## Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+## Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+Shader grid
+
+Buffer DrawData binding=1
+Buffer GridData binding=2
+
+Vertex "grid.vert"
+Fragment "grid.frag"

--- a/data/shaders/opengl/grid.vert
+++ b/data/shaders/opengl/grid.vert
@@ -1,0 +1,14 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "attributes.glsl"
+
+out vec3 v_eyepos;
+out vec2 v_uv0;
+
+void main(void)
+{
+	gl_Position = uViewProjectionMatrix * vec4(a_vertex.xyz, 1.0);
+	v_eyepos = (uViewMatrix * vec4(a_vertex.xyz, 1.0)).xyz;
+	v_uv0 = a_uv0.xy;
+}

--- a/data/shaders/opengl/gridsphere.frag
+++ b/data/shaders/opengl/gridsphere.frag
@@ -1,0 +1,80 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+// Adapted from https://ourmachinery.com/post/borderland-between-rendering-and-editor-part-1/
+// Credit to Tobias Persson for providing an example implementation.
+
+#include "attributes.glsl"
+
+layout(std140) uniform GridData {
+	vec4 color_lod0;
+	vec4 color_lod1;
+	float line_spacing;
+	float line_width_px;
+};
+
+in vec3 v_eyepos;
+in vec3 v_normal;
+
+out vec4 frag_color;
+
+float log10(float v)
+{
+	return log(v) / log(10.0);
+}
+
+float calc_cell_lod(float cell_size, float lod_level)
+{
+	// The top LOD level highlights 90 degree increments, and lower LOD levels highlight 10, 1, 0.1 etc. degree increments
+	return int(lod_level) == 1 ? cell_size * 9 : cell_size * pow(10.0, lod_level);
+}
+
+// Calculate the combined XY line coverage values for the given pixel with the defined grid setting
+float calc_grid_coverage(vec2 uv, vec2 line_width, float cell_size)
+{
+	vec2 cover = 1 - abs(clamp(mod(uv + line_width * 0.5, cell_size) / line_width, 0, 1) * 2 - 1);
+	return max(cover.x, cover.y);
+}
+
+void main(void)
+{
+	vec3 spherical = normalize((uViewMatrixInverse * vec4(v_eyepos, 1.0)).xyz);
+
+	float theta = atan(spherical.z, spherical.x);
+	float phi = acos(spherical.y);
+	vec2 polar_coords = vec2(theta / PI, phi / PI);
+
+	// Calculate the screen-space derivatives of the UV coordinates
+	vec4 derivatives = vec4(dFdx(polar_coords), dFdy(polar_coords));
+	vec2 dudv = vec2(length(derivatives.xz), length(derivatives.yw));
+
+	// Each primary cell covers an area of 10 degrees and subdivides from there
+	float cell_size = 1.0 / 18.0;
+
+	float lod_level = min(1, log10(length(dudv) * line_spacing / cell_size) + 1);
+	float lod_transition = fract(lod_level);
+
+	// Calculate the grid cell size at the minimum visible LOD level and the next larger
+	float lod0_cell_size = calc_cell_lod(cell_size, floor(lod_level));
+	float lod1_cell_size = calc_cell_lod(cell_size, floor(lod_level) + 1);
+	float lod2_cell_size = calc_cell_lod(cell_size, floor(lod_level) + 2);
+
+	// Calculate the XY line coverage values for this pixel
+	vec2 line_width = dudv * line_width_px; // size of a grid line in grid units
+	float lod0_a = calc_grid_coverage(polar_coords, line_width, lod0_cell_size);
+	float lod1_a = calc_grid_coverage(polar_coords, line_width, lod1_cell_size);
+	float lod2_a = calc_grid_coverage(polar_coords, line_width, lod2_cell_size);
+
+	// Generate all three separate color regions: bright, transition, dark
+	vec4 color = lod2_a > 0 ? color_lod1 : lod1_a > 0 ? mix(color_lod1, color_lod0, lod_transition) : color_lod0;
+	color.a *= max(lod2_a, max(lod1_a, lod0_a * (1.0 - lod_transition)));
+
+	// Make the grid transparent at grazing angles
+	vec3 viewdir = normalize(v_eyepos);
+	color.a *= 1.0 - pow(1.0 - abs(dot(viewdir, v_normal)), 8);
+
+	// Make the rear half of the grid sphere less visible
+	color.a *= clamp(dot(viewdir, -v_normal) + 1.0, 0.2, 1.0);
+
+	frag_color = color;
+}

--- a/data/shaders/opengl/gridsphere.shaderdef
+++ b/data/shaders/opengl/gridsphere.shaderdef
@@ -1,0 +1,10 @@
+## Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+## Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+Shader gridsphere
+
+Buffer DrawData binding=1
+Buffer GridData binding=2
+
+Vertex "gridsphere.vert"
+Fragment "gridsphere.frag"

--- a/data/shaders/opengl/gridsphere.vert
+++ b/data/shaders/opengl/gridsphere.vert
@@ -1,0 +1,14 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "attributes.glsl"
+
+out vec3 v_eyepos;
+out vec3 v_normal;
+
+void main(void)
+{
+	gl_Position = uViewProjectionMatrix * vec4(a_vertex.xyz, 1.0);
+	v_eyepos = (uViewMatrix * vec4(a_vertex.xyz, 1.0)).xyz;
+	v_normal = normalize(normalMatrix() * a_vertex.xyz);
+}

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -43,6 +43,7 @@ ModelViewer::Options::Options() :
 	showGeomBBox(false),
 	showShields(false),
 	showGrid(false),
+	showVerticalGrids(false),
 	showLandingPad(false),
 	showUI(true),
 	wireframe(false),
@@ -146,6 +147,11 @@ void ModelViewerApp::PostUpdate()
 {
 	GetRenderer()->ClearDepthBuffer();
 	GetPiGui()->Render();
+
+	if (GetInput()->IsKeyReleased(SDLK_F12)) {
+		GetRenderer()->FlushCommandBuffers();
+		GetRenderer()->ReloadShaders();
+	}
 }
 
 ModelViewer::ModelViewer(ModelViewerApp *app, LuaManager *lm) :
@@ -183,8 +189,7 @@ ModelViewer::ModelViewer(ModelViewerApp *app, LuaManager *lm) :
 	rsd.primitiveType = Graphics::TRIANGLES;
 	m_bgMaterial.reset(m_renderer->CreateMaterial("vtxColor", desc, rsd));
 
-	rsd.primitiveType = Graphics::LINE_SINGLE;
-	m_gridMaterial.reset(m_renderer->CreateMaterial("vtxColor", desc, rsd));
+	m_gridLines.reset(new Graphics::Drawables::GridLines(m_renderer));
 }
 
 void ModelViewer::Start()
@@ -404,33 +409,20 @@ void ModelViewer::DrawGrid(const matrix4x4f &trans, float radius)
 {
 	assert(m_options.showGrid);
 
-	const float dist = zoom_distance(m_baseDistance, m_zoom);
+	// const float dist = zoom_distance(m_baseDistance, m_zoom);
 
-	const float max = std::min(powf(10, ceilf(log10f(dist))), ceilf(radius / m_options.gridInterval) * m_options.gridInterval);
-
-	static std::vector<vector3f> points;
-	points.clear();
-
-	for (float x = -max; x <= max; x += m_options.gridInterval) {
-		points.push_back(vector3f(x, 0, -max));
-		points.push_back(vector3f(x, 0, max));
-		points.push_back(vector3f(0, x, -max));
-		points.push_back(vector3f(0, x, max));
-
-		points.push_back(vector3f(x, -max, 0));
-		points.push_back(vector3f(x, max, 0));
-		points.push_back(vector3f(0, -max, x));
-		points.push_back(vector3f(0, max, x));
-
-		points.push_back(vector3f(-max, x, 0));
-		points.push_back(vector3f(max, x, 0));
-		points.push_back(vector3f(-max, 0, x));
-		points.push_back(vector3f(max, 0, x));
-	}
+	const float max = powf(10, ceilf(log10f(radius * 1.1)));
 
 	m_renderer->SetTransform(trans);
-	m_gridLines.SetData(points.size(), &points[0], Color(128, 128, 128));
-	m_gridLines.Draw(m_renderer, m_gridMaterial.get());
+	m_gridLines->Draw(m_renderer, { max, max }, m_options.gridInterval);
+
+	if (m_options.showVerticalGrids) {
+		m_renderer->SetTransform(trans * matrix4x4f::RotateXMatrix(M_PI * 0.5));
+		m_gridLines->Draw(m_renderer, { max, max }, m_options.gridInterval);
+
+		m_renderer->SetTransform(trans * matrix4x4f::RotateZMatrix(M_PI * 0.5));
+		m_gridLines->Draw(m_renderer, { max, max }, m_options.gridInterval);
+	}
 
 	// industry-standard red/green/blue XYZ axis indiactor
 	m_renderer->SetTransform(trans * matrix4x4f::ScaleMatrix(radius));
@@ -992,25 +984,31 @@ void ModelViewer::DrawModelOptions()
 	ImGui::Checkbox("Show Tags", &m_options.showTags);
 	m_options.showDockingLocators = m_options.showTags;
 
+	ImGui::Spacing();
+
 	ImGui::Checkbox("##ToggleGrid", &m_options.showGrid);
 	ImGui::SameLine(0.0, 4.0f);
 	ImGui::SetNextItemWidth(itmWidth - 4.0f - ImGui::GetFrameHeight());
 
 	std::string currentGridMode = std::to_string(int(m_options.gridInterval)) + "x";
 	if (ImGui::BeginCombo("Grid Mode", currentGridMode.c_str())) {
-		if (ImGui::Selectable("1x"))
+		if (ImGui::Selectable("1m"))
 			m_options.gridInterval = 1.0f;
 
-		if (ImGui::Selectable("10x"))
+		if (ImGui::Selectable("10m"))
 			m_options.gridInterval = 10.0f;
 
-		if (ImGui::Selectable("100x"))
+		if (ImGui::Selectable("100m"))
 			m_options.gridInterval = 100.0f;
 
-		if (ImGui::Selectable("1000x"))
+		if (ImGui::Selectable("1000m"))
 			m_options.gridInterval = 1000.0f;
 
 		ImGui::EndCombo();
+	}
+
+	if (m_options.showGrid) {
+		ImGui::Checkbox("Show Vertical Grids", &m_options.showVerticalGrids);
 	}
 
 	if (m_modelHasShields) {

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -116,6 +116,7 @@ private:
 		bool showGeomBBox;
 		bool showShields;
 		bool showGrid;
+		bool showVerticalGrids;
 		bool showLandingPad;
 		bool showUI;
 		bool wireframe;
@@ -202,12 +203,11 @@ private:
 	float m_landingMinOffset;
 
 	std::unique_ptr<Graphics::Material> m_bgMaterial;
-	std::unique_ptr<Graphics::Material> m_gridMaterial;
 	std::unique_ptr<Graphics::MeshObject> m_bgMesh;
 
 	sigc::signal<void> onModelChanged;
 
-	Graphics::Drawables::Lines m_gridLines;
+	std::unique_ptr<Graphics::Drawables::GridLines> m_gridLines;
 };
 
 #endif

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -478,13 +478,8 @@ namespace Graphics {
 			{ 6, 1, 10 }, { 9, 0, 11 }, { 9, 11, 2 }, { 9, 2, 5 }, { 7, 2, 11 }
 		};
 
-		Sphere3D::Sphere3D(Renderer *renderer, RefCountedPtr<Material> mat, int subdivs, float scale, AttributeSet attribs)
+		Graphics::MeshObject *Icosphere::Generate(Graphics::Renderer *r, int subdivs, float scale, AttributeSet attribs)
 		{
-			PROFILE_SCOPED()
-			assert(attribs.HasAttrib(ATTRIB_POSITION));
-
-			m_material = mat;
-
 			subdivs = Clamp(subdivs, 0, 4);
 			scale = fabs(scale);
 			matrix4x4f trans = matrix4x4f::Identity();
@@ -513,23 +508,18 @@ namespace Graphics {
 			}
 
 			//Create vtx & index buffers and copy data
-			Graphics::IndexBuffer *indexBuffer = renderer->CreateIndexBuffer(indices.size(), BUFFER_USAGE_STATIC);
+			Graphics::IndexBuffer *indexBuffer = r->CreateIndexBuffer(indices.size(), BUFFER_USAGE_STATIC);
 			Uint32 *idxPtr = indexBuffer->Map(Graphics::BUFFER_MAP_WRITE);
 			for (auto it : indices) {
 				*idxPtr = it;
 				idxPtr++;
 			}
 			indexBuffer->Unmap();
-			m_sphereMesh.reset(renderer->CreateMeshObjectFromArray(&vts, indexBuffer));
+
+			return r->CreateMeshObjectFromArray(&vts, indexBuffer);
 		}
 
-		void Sphere3D::Draw(Renderer *r)
-		{
-			PROFILE_SCOPED()
-			r->DrawMesh(m_sphereMesh.get(), m_material.Get());
-		}
-
-		int Sphere3D::AddVertex(VertexArray &vts, const vector3f &v, const vector3f &n)
+		int Icosphere::AddVertex(VertexArray &vts, const vector3f &v, const vector3f &n)
 		{
 			PROFILE_SCOPED()
 			vts.position.push_back(v);
@@ -543,7 +533,7 @@ namespace Graphics {
 			return vts.GetNumVerts() - 1;
 		}
 
-		void Sphere3D::AddTriangle(std::vector<Uint32> &indices, int i1, int i2, int i3)
+		void Icosphere::AddTriangle(std::vector<Uint32> &indices, int i1, int i2, int i3)
 		{
 			PROFILE_SCOPED()
 			indices.push_back(i1);
@@ -551,7 +541,7 @@ namespace Graphics {
 			indices.push_back(i3);
 		}
 
-		void Sphere3D::Subdivide(VertexArray &vts, std::vector<Uint32> &indices,
+		void Icosphere::Subdivide(VertexArray &vts, std::vector<Uint32> &indices,
 			const matrix4x4f &trans, const vector3f &v1, const vector3f &v2, const vector3f &v3,
 			const int i1, const int i2, const int i3, int depth)
 		{
@@ -571,6 +561,23 @@ namespace Graphics {
 			Subdivide(vts, indices, trans, v2, v23, v12, i2, i23, i12, depth - 1);
 			Subdivide(vts, indices, trans, v3, v31, v23, i3, i31, i23, depth - 1);
 			Subdivide(vts, indices, trans, v12, v23, v31, i12, i23, i31, depth - 1);
+		}
+
+		//------------------------------------------------------------
+
+		Sphere3D::Sphere3D(Renderer *renderer, RefCountedPtr<Material> mat, int subdivs, float scale, AttributeSet attribs)
+		{
+			PROFILE_SCOPED()
+			assert(attribs.HasAttrib(ATTRIB_POSITION));
+
+			m_material = mat;
+			m_sphereMesh.reset(Icosphere::Generate(renderer, subdivs, scale, attribs));
+		}
+
+		void Sphere3D::Draw(Renderer *r)
+		{
+			PROFILE_SCOPED()
+			r->DrawMesh(m_sphereMesh.get(), m_material.Get());
 		}
 
 		//------------------------------------------------------------
@@ -883,6 +890,52 @@ namespace Graphics {
 
 			m_gridMat->SetBufferDynamic("GridData"_hash, &data);
 			r->DrawBuffer(&va, m_gridMat.get());
+		}
+
+		//------------------------------------------------------------
+
+		struct GridSphere::GridData {
+			Color4f thin_color;
+			Color4f thick_color;
+			float line_spacing;
+			float line_width;
+		};
+
+		GridSphere::GridSphere(Graphics::Renderer *r, uint32_t num_subdivs) :
+			m_minorColor(Color(160, 160, 160)),
+			m_majorColor(Color(255, 255, 255)),
+			m_lineWidth(2.0f),
+			m_numSubdivs(num_subdivs)
+		{
+			Graphics::RenderStateDesc rsd = {};
+			rsd.blendMode = Graphics::BLEND_ALPHA;
+			rsd.cullMode = Graphics::CULL_NONE;
+			rsd.depthWrite = false;
+
+			m_gridMat.reset(r->CreateMaterial("gridsphere", {}, rsd));
+		}
+
+		void GridSphere::SetLineColors(Color minorLineColor, Color majorLineColor, float lineWidth)
+		{
+			m_minorColor = minorLineColor;
+			m_majorColor = majorLineColor;
+			m_lineWidth = std::min(lineWidth, 1.0f);
+		}
+
+		void GridSphere::Draw(Graphics::Renderer *r, float lineSpacing)
+		{
+			if (!m_sphereMesh) {
+				m_sphereMesh.reset(Icosphere::Generate(r, m_numSubdivs, 1.f, Graphics::ATTRIB_POSITION));
+			}
+
+			GridData data = {};
+			data.thin_color = m_minorColor.ToColor4f();
+			data.thick_color = m_majorColor.ToColor4f();
+			data.line_spacing = lineSpacing;
+			data.line_width = m_lineWidth;
+
+			m_gridMat->SetBufferDynamic("GridData"_hash, &data);
+			r->DrawMesh(m_sphereMesh.get(), m_gridMat.get());
 		}
 
 		//------------------------------------------------------------

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -217,6 +217,26 @@ namespace Graphics {
 
 		//------------------------------------------------------------
 
+		// Shader-based anti-aliased XZ-plane grid rendering.
+		class GridLines {
+		public:
+			GridLines(Graphics::Renderer *r);
+
+			void SetLineColors(Color minorLineColor, Color majorLineColor, float lineWidth = 2.0);
+
+			void Draw(Graphics::Renderer *r, vector2f grid_size, float cell_size);
+
+		private:
+			struct GridData;
+
+			std::unique_ptr<Graphics::Material> m_gridMat;
+			Color m_minorColor;
+			Color m_majorColor;
+			float m_lineWidth;
+		};
+
+		//------------------------------------------------------------
+
 		//industry-standard red/green/blue XYZ axis indicator
 		class Axes3D {
 		public:

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -125,7 +125,23 @@ namespace Graphics {
 			RefCountedPtr<MeshObject> m_pointMesh;
 			std::unique_ptr<VertexArray> m_va;
 		};
+
 		//------------------------------------------------------------
+
+		// Helper class to generate an Icosphere mesh
+		class Icosphere {
+		public:
+			static Graphics::MeshObject *Generate(Graphics::Renderer *r, int subdivisions = 0, float scale = 1.f, AttributeSet attribs = (ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0));
+
+		private:
+			//add a new vertex, return the index
+			static int AddVertex(VertexArray &, const vector3f &v, const vector3f &n);
+			//add three vertex indices to form a triangle
+			static void AddTriangle(std::vector<Uint32> &, int i1, int i2, int i3);
+			static void Subdivide(VertexArray &, std::vector<Uint32> &,
+				const matrix4x4f &trans, const vector3f &v1, const vector3f &v2, const vector3f &v3,
+				int i1, int i2, int i3, int depth);
+		};
 
 		// Three dimensional sphere (subdivided icosahedron) with normals
 		// and spherical texture coordinates.
@@ -140,15 +156,6 @@ namespace Graphics {
 		private:
 			std::unique_ptr<MeshObject> m_sphereMesh;
 			RefCountedPtr<Material> m_material;
-
-			//std::unique_ptr<Surface> m_surface;
-			//add a new vertex, return the index
-			int AddVertex(VertexArray &, const vector3f &v, const vector3f &n);
-			//add three vertex indices to form a triangle
-			void AddTriangle(std::vector<Uint32> &, int i1, int i2, int i3);
-			void Subdivide(VertexArray &, std::vector<Uint32> &,
-				const matrix4x4f &trans, const vector3f &v1, const vector3f &v2, const vector3f &v3,
-				int i1, int i2, int i3, int depth);
 		};
 		//------------------------------------------------------------
 
@@ -233,6 +240,30 @@ namespace Graphics {
 			Color m_minorColor;
 			Color m_majorColor;
 			float m_lineWidth;
+		};
+
+		//------------------------------------------------------------
+
+		// Shader-based anti-aliased UV-sphere grid rendering.
+		// Grid has primary lines at 90 and 10 degree intervals, and subdivides by tenths from there
+		// The visual density of the grid can be controlled by the lineSpacing parameter
+		class GridSphere {
+		public:
+			GridSphere(Graphics::Renderer *r, uint32_t numSubdivs = 12);
+
+			void SetLineColors(Color minorLineColor, Color majorLineColor, float lineWidth = 2.0);
+
+			void Draw(Graphics::Renderer *r, float lineSpacing = 2.0);
+
+		private:
+			struct GridData;
+
+			std::unique_ptr<Graphics::Material> m_gridMat;
+			std::unique_ptr<Graphics::MeshObject> m_sphereMesh;
+			Color m_minorColor;
+			Color m_majorColor;
+			float m_lineWidth;
+			uint32_t m_numSubdivs;
 		};
 
 		//------------------------------------------------------------


### PR DESCRIPTION
They say a picture is worth 1000 words... I've improved the grid rendering in the ModelViewer to support infinite zoom level-of-detail, different grid colors for primary and secondary grid increments, arbitrary line width, and smooth antialiasing. I've also implemented a spherical grid for rendering planetary surface information in the SystemMap.

I'll leave you with these pictures and turn it over to @Gliese852 to use the new grid rendering in the SystemMap:

![](https://i.imgur.com/08v1i16.png)
![](https://i.imgur.com/Wwbbz7U.png)
![](https://i.imgur.com/LV65Tte.png)