### PR TITLE
Improve Lua documentation, add static type analysis definition files

### DIFF
--- a/data/libs/Game.lua
+++ b/data/libs/Game.lua
@@ -2,7 +2,7 @@ local Game = package.core["Game"]
 local Event = require 'Event'
 
 -- Simple way to track the start date of the game until DateTime objects are exposed to lua
-local gameStartTime = 0
+local gameStartTime = 0.0
 
 Game.comms_log_lines = {}
 Game.AddCommsLogLine = function(text, sender, priority)

--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -1,14 +1,23 @@
 -- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local utils
 local Engine = require 'Engine' -- rand
-utils = {}
 
 --
--- numbered_keys: transform an iterator to one that returns numbered keys
+-- Interface: utils
 --
--- for k,v in numbered_keys(pairs(table)) do ... end
+-- Collection of utility functions to ease working with tables as data
+-- containers or class-like objects.
+--
+local utils = {}
+
+--
+-- Function: numbered_keys
+--
+-- Transform an iterator to one that returns a numeric index instead of keys
+--
+-- Example:
+--   > for i, v in numbered_keys(pairs(table)) do ... end
 --
 function utils.numbered_keys(step, context, position)
   local k = position
@@ -23,10 +32,12 @@ function utils.numbered_keys(step, context, position)
 end
 
 --
--- filter: transform an iterator to one that only returns items that
---         match some predicate
+-- Function: filter
 --
--- for k,v in filter(function (k,v) ... return true end, pairs(table))
+-- Transform an iterator to one that only returns items that match some predicate.
+--
+-- Example:
+--   > for k,v in filter(function (k,v) ... return true end, pairs(table))
 --
 function utils.filter(predicate, step, context, position)
   local f = function (s, k)
@@ -38,9 +49,12 @@ function utils.filter(predicate, step, context, position)
 end
 
 --
--- map: transform an iterator to one that returns modified keys/values
+-- Function: map
 --
--- for k,v in map(function (k,v) ... return newk, newv end, pairs(table))
+-- Transform an iterator to one that returns modified keys/values
+--
+-- Example:
+--   > for k,v in map(function (k,v) ... return newk, newv end, pairs(table))
 --
 function utils.map(transformer, step, context, position)
   local f = function (s, k)
@@ -54,10 +68,12 @@ function utils.map(transformer, step, context, position)
 end
 
 --
--- build_array: return a table containing all values returned by an iterator
---              returned table is built using table.insert (integer keys)
+-- Function: build_array
 --
--- array = build_array(pairs(table))
+-- Return an array table containing the values returned by an iterator.
+--
+-- Example:
+--   > array = build_array(pairs(table))
 --
 function utils.build_array(f, s, k)
   local v
@@ -71,10 +87,12 @@ function utils.build_array(f, s, k)
 end
 
 --
--- build_table: return a table containing all values returned by an iterator
---              returned table is build using t[k] = v
+-- Function: build_table
 --
--- filtered = build_table(filter(function () ... end, pairs(table)))
+-- Return a table containing key-value pairs returned by the provided iterator.
+--
+-- Example:
+--   > filtered = build_table(filter(function () ... end, pairs(table)))
 --
 function utils.build_table(f, s, k)
   local v
@@ -88,14 +106,53 @@ function utils.build_table(f, s, k)
 end
 
 --
--- stable_sort: return a sorted table. Sort isn't fast but stable
--- (default Lua table.sort is fast and unstable).
--- stable_sort uses Merge sort algorithm.
+-- Function: map_table
 --
--- sorted_table = stable_sort(unsorted_table,
---							  function (a,b) return a < b end)
+-- Return a new table created from applying a transformer predicate to the
+-- values of the provided table object. Key iteration order is undefined
+-- (the function will use pairs() internally).
 --
+-- Example:
+--   > transformed = utils.map_table(t, function(k, v) return k .. "1", v end)
+--
+function utils.map_table(table, predicate)
+	local t = {}
+	for k, v in pairs(table) do
+		k, v = predicate(k, v)
+		t[k] = v
+	end
+	return t
+end
 
+--
+-- Function: filter_table
+--
+-- Return a new table created from applying a filter predicate to the values
+-- of the provided table object. Key iteration order is undefined (the function
+-- will use pairs() internally).
+--
+-- Example:
+--   > filtered = utils.filter_table(t, function (k, v) return true end)
+--
+function utils.filter_table(table, predicate)
+	local t = {}
+	for k, v in pairs(table) do
+		if predicate(k, v) then t[k] = v end
+	end
+	return t
+end
+
+--
+-- Function: stable_sort
+--
+-- Sort the given table in-place and return it. Sort isn't fast but will be
+-- stable (default Lua table.sort is fast and unstable).
+--
+-- stable_sort uses a Merge sort algorithm.
+--
+-- Example:
+--   > sorted_table = stable_sort(unsorted_table, function (a,b) return a < b end)
+--
 function utils.stable_sort(values, cmp)
 	if not cmp then
 		cmp = function (a,b) return a <= b end
@@ -149,31 +206,74 @@ function utils.stable_sort(values, cmp)
 end
 
 --
--- inherits(baseClass): returns a new class that implements inheritage from
--- the provided base class.
+-- Class: utils.object
 --
--- To overwrite the constructor (function `New`), don't forget to rename the current
--- one and call it in the new method.
+-- Default base class for lua classes created with <utils.inherits> or
+-- <utils.class>. Implements default serialization and construction methods.
 --
 local object = {}
 
 object.meta = { __index = object, class="object" }
 
+--
+-- Function: New
+--
+-- Creates and returns a new instance of the default object class.
+-- This is overridden in all subclasses.
+--
 function object.New(args)
 	local newinst = {}
 	setmetatable( newinst, object.meta )
 	return newinst
 end
 
+--
+-- Function: Serialize
+--
+-- Method handler called when an instance of this class is about to be
+-- serialized to disk. It should perform any needed data transformation, and
+-- may return an entirely different object if needed.
+--
+-- Returning a different object may have limitations if the instance to be
+-- serialized contains cyclic references to itself.
+--
 function object:Serialize()
 	return self
 end
 
+--
+-- Function: Unserialize
+--
+-- Method handler called when an instance of this class is about to be
+-- deserialized from disk. It should perform any needed data transformation,
+-- set the new instance's metatable, and may return an entirely different
+-- object if needed.
+--
+-- Returning a different object may have limitations if the serialized instance
+-- contains cyclic references to itself.
+--
 function object.Unserialize(data)
 	setmetatable(data, object.meta)
 	return data
 end
 
+--
+-- Interface: utils
+--
+
+--
+-- Function: inherits
+--
+-- Returns a new class that implements optional single-inheritance from the
+-- provided base class.
+--
+-- If no base class is provided, the new class will inherit from <utils.object>
+-- to provide stub implementations for serialization.
+--
+-- The returned class has a default constructor defined as `class.New()`.
+-- To override the constructor, redefine the Class.New() method and save the
+-- `class.New()` method to be called in your custom constructor.
+--
 utils.inherits = function (baseClass, name)
 	local new_class = {}
 	local base_class = baseClass or object
@@ -207,8 +307,12 @@ utils.inherits = function (baseClass, name)
 	return new_class
 end
 
+--
+-- Function: class
+--
 -- Wrapper for utils.inherits that manages creating new class instances and
 -- calling the constructor.
+--
 utils.class = function (name, baseClass)
 	local new_class = utils.inherits(baseClass, name)
 
@@ -225,6 +329,11 @@ utils.class = function (name, baseClass)
 	return new_class
 end
 
+--
+-- Function: print_r
+--
+-- Recursively print the contents of a table to the console.
+--
 utils.print_r = function(t)
 	local print_r_cache={}
 	local function sub_print_r(t,indent,rec_guard)
@@ -260,7 +369,11 @@ utils.print_r = function(t)
 	print()
 end
 
+--
+-- Function: count
+--
 -- Count the number of entries in a table
+--
 utils.count = function(t)
 	local i = 0
 	for _,_ in pairs(t) do
@@ -269,6 +382,11 @@ utils.count = function(t)
 	return i
 end
 
+--
+-- Function: contains
+--
+-- Return true if the function contains the given value under any key.
+--
 utils.contains = function(t, val)
 	for _, v in pairs(t) do
 		if v == val then return true end
@@ -277,33 +395,42 @@ utils.contains = function(t, val)
 	return false
 end
 
+--
+-- Function: take
+--
+-- Return an iterator that iterates through the first N values of the given array table.
+--
 utils.take = function(t, n)
-	local res = {}
-	local i = 0
-	for _,v in pairs(t) do
-		if i == n then
-			return res
-		else
-			table.insert(res, v)
-			i = i + 1
-		end
+	local f = function(s, k)
+		k = k + 1
+		if k > n or s[k] == nil then return nil end
+		return k, s[k]
 	end
-	return res
-end
-
-utils.reverse = function(t)
-	local res = {}
-	for _,v in pairs(t) do
-		table.insert(res, 1, v)
-	end
-	return res
+	return f, t, 0
 end
 
 --
--- round: Round any real number, x, to closest multiple of magnitude |N|,
+-- Function: reverse
+--
+-- Return an iterator that iterates backwards through the given array table.
+--
+utils.reverse = function(t)
+	local f = function(s, k)
+		k = k - 1
+		if k <= 0 then return end
+		return k, s[k]
+	end
+	return f, t, #t + 1
+end
+
+--
+-- Function: round
+--
+-- Round any real number, x, to closest multiple of magnitude |N|,
 -- but never lower. N defaults to 1, if omitted.
 --
--- x_steps_of_N = round(x, N)
+-- Example:
+--   > x_steps_of_N = round(x, N)
 --
 utils.round = function(x, n)
 	local s = math.sign(x)

--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -207,6 +207,24 @@ utils.inherits = function (baseClass, name)
 	return new_class
 end
 
+-- Wrapper for utils.inherits that manages creating new class instances and
+-- calling the constructor.
+utils.class = function (name, baseClass)
+	local new_class = utils.inherits(baseClass, name)
+
+	new_class.New = function(...)
+		local instance = setmetatable( {}, new_class.meta )
+
+		if new_class.Constructor then
+			new_class.Constructor(instance, ...)
+		end
+
+		return instance
+	end
+
+	return new_class
+end
+
 utils.print_r = function(t)
 	local print_r_cache={}
 	local function sub_print_r(t,indent,rec_guard)

--- a/data/meta/Body.lua
+++ b/data/meta/Body.lua
@@ -1,0 +1,144 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+
+---@meta
+
+---
+---@class Body
+---
+---@field label string
+---@field seed integer
+---
+--- The <SystemPath> that points to this body.
+--- Only available for non-dynamic bodies.
+---@field path? SystemPath
+---
+--- The type of the body, as a <Constants.BodyType> constant.
+---@field type? BodyType
+---
+--- The supertype of the body, as a <Constants.BodySuperType> constant
+---@field superType? BodySuperType
+---
+--- The non-dynamic body attached to the frame this dynamic body is in.
+--- Only available for dynamic bodies.
+---@field frameBody? Body
+---
+--- Whether the frame this body is in is a rotating frame.
+--- Only available for dynamic bodies.
+---@field frameRotating? boolean
+---
+
+---@class Body
+local Body = {}
+
+--- Get a C++ or Lua component object from the body if present.
+---
+--- Note: the caller should check the return value if there is a possibility if
+--- the component may not be present on this Body.
+---@generic T
+---@param name `T`
+---@return T
+function Body:GetComponent(name) end
+
+--- Set or clear the given Lua component on the body to the passed object.
+---@generic T
+---@param name `T`
+---@param value T|nil
+function Body:SetComponent(name, value) end
+
+--- Determine if the body is a dynamic body.
+---@return boolean
+function Body:IsDynamic() end
+
+--- Calculate the distance between two bodies
+---@param otherBody Body
+---@return number
+function Body:DistanceTo(otherBody) end
+
+--- Get the body's position relative to its parent frame.
+---
+--- If the parent is a TerrainBody, altitude will be the height above terrain in meters.
+---@return number latitude the latitude of the body in radians
+---@return number longitude the longitude of the body in radians
+---@return number? altitude altitude above the ground in meters
+function Body:GetGroundPosition() end
+
+--- Find the nearest object of a <Constants.PhysicsObjectType> type
+---@param type PhysicsObjectType
+---@return Body nearest
+function Body:FindNearestTo(type) end
+
+--- Get the body's velocity relative to another body as a Vector3
+---@param other Body
+---@return Vector3 velocity
+function Body:GetVelocityRelTo(other) end
+
+--- Get the body's position relative to another body as a Vector3
+---@param other Body
+---@return Vector3 position
+function Body:GetPositionRelTo(other) end
+
+--- Get the body's altitude relative to another body.
+---
+--- Returns height above terrain if the other body is a TerrainBody or
+--- distance between bodies otherwise.
+---@param other Body
+---@return number altitude
+function Body:GetAltitudeRelTo(other) end
+
+---@return number
+function Body:GetPhysicalRadius() end
+
+--- Return the atmospheric state of the given body in this body's atmosphere
+---@param forBody Body
+---@return number? pressure
+---@return number? density
+function Body:GetAtmosphericState(forBody) end
+
+---@return string label
+function Body:GetLabel() end
+
+---@param other Body
+---@return boolean
+function Body:IsMoreImportantThan(other) end
+
+---@return boolean
+function Body:IsMoon() end
+
+---@return boolean
+function Body:IsPlanet() end
+
+---@return boolean
+function Body:IsShip() end
+
+---@return boolean
+function Body:IsHyperspaceCloud() end
+
+---@return boolean
+function Body:IsMissile() end
+
+---@return boolean
+function Body:IsStation() end
+
+---@return boolean
+function Body:IsSpaceStation() end
+
+---@return boolean
+function Body:IsGroundStation() end
+
+---@return boolean
+function Body:IsCargoContainer() end
+
+---@return SystemBody?
+function Body:GetSystemBody() end
+
+---@return Vector3
+function Body:GetVelocity() end
+
+---@param vel Vector3
+function Body:SetVelocity(vel) end
+
+---@param angVel Vector3
+function Body:SetAngVelocity(angVel) end

--- a/data/meta/Game.lua
+++ b/data/meta/Game.lua
@@ -1,0 +1,101 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+-- TODO: this file is partially type-complete, please expand it as more types are added.
+
+---@meta
+
+---@class Game
+---
+---@field player Body #TODO: add Ship / Player to type tree
+---@field system StarSystem? The system the game is currently playing in or nil when in hyperspace.
+---@field systemView unknown #TODO: add type info for SystemView interface
+---@field sectorView unknown #TODO: add type info for SectorView interface
+---@field time number Game time in seconds since Jan. 1 3200
+---@field paused boolean
+
+---@class Game
+local Game = {}
+
+-- Ensure the CoreImport field is visible to static analysis
+package.core["Game"] = Game
+
+--- Start a game at the given location and game world time.
+---
+--- If the given path is a starport, will spawn docked at that starport;
+--- otherwise the player will spawn in orbit around the specified body.
+---@param path SystemPath path to a body to start at
+---@param start_time number optional, default to real time since 31 Dec. 1999
+function Game.StartGame(path, start_time) end
+
+--- Attempts to load and start the specified savefile.
+--- Will throw an error if the game could not be loaded.
+---@param filename string
+function Game.LoadGame(filename) end
+
+--- Try to load the given savefile and determine if it is in a valid format.
+---@param filename string
+---@return boolean
+function Game.CanLoadGame(filename) end
+
+--- Get stats about the specified save game
+---@param filename string
+---@return table stats
+function Game.SaveGameStats(filename) end
+
+--- Save the current game to the given savefile.
+---@param filename string
+function Game.SaveGame(filename) end
+
+--- End the current game and return to the main menu.
+function Game.EndGame() end
+
+--- Switch view back to world view if player is not dead.
+---@deprecated
+function Game.SwitchView() end
+
+---@return string
+function Game.CurrentView() end
+
+---@param view string
+function Game.SetView(view) end
+
+--- Returns the current game time split into y/m/d/h/m/s components
+---@return integer year
+---@return integer month
+---@return integer day
+---@return integer hour
+---@return integer minute
+---@return integer second
+function Game.GetDateTime() end
+
+--- Returns the given time in seconds since 1 Jan. 3200
+-- split into y/m/d/h/m/s components
+---@param time number
+---@return integer year
+---@return integer month
+---@return integer day
+---@return integer hour
+---@return integer minute
+---@return integer second
+function Game.GetPartsFromDateTime(time) end
+
+---@param newAccel string
+function Game.SetTimeAcceleration(newAccel) end
+---@return string
+function Game.GetTimeAcceleration() end
+---@return string
+function Game.GetRequestedTimeAcceleration() end
+
+---@return boolean
+function Game.InHyperspace() end
+---@return number
+function Game.GetHyperspaceTravelledPercentage() end
+
+---@param type string
+function Game.GetWorldCamType(type) end
+---@return string
+function Game.SetWorldCamType() end
+
+return Game

--- a/data/meta/Lang.lua
+++ b/data/meta/Lang.lua
@@ -1,0 +1,24 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+
+---@meta
+
+local Lang = {}
+
+--- Helper typedef to provide completion for the :get() method
+---@type table<string, string>
+local Resource = {}
+
+---@param key string
+---@return string
+function Resource:get(key) end
+
+--- Return a table of strings for the given language resource, optionally
+--- in the specified language.
+---@param name string
+---@param langCode string?
+function Lang.GetResource(name, langCode) return Resource end
+
+return Lang

--- a/data/meta/StarSystem.lua
+++ b/data/meta/StarSystem.lua
@@ -1,0 +1,73 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+
+---@meta
+
+---@class StarSystem
+---
+---@field name string
+---@field other_names string[]
+---@field path SystemPath
+---
+--- The lawlessness value for the system, 0 for peaceful, 1 for raging hordes of pirates
+---@field lawlessness number
+--- The population of this system, in billions of people
+---@field population number
+--- The <Faction> that controls this system
+---@field faction unknown #TODO: add type information for LuaFaction
+--- The government type used in the system
+---@field govtype PolitGovType
+--- Has this system been explored before?
+---@field explored boolean
+---
+---@field numberOfStars integer
+---@field rootSystemBody SystemBody
+---
+--- Translated description for the system
+---@field shortDescription string
+--- Translated description of the system's government type
+---@field govDescription string
+--- Translated description of the system's economic type
+---@field econDescription string
+
+---@class StarSystem
+local StarSystem = {}
+
+---@return SystemPath[]
+function StarSystem:GetStationPaths() end
+
+---@return SystemPath[]
+function StarSystem:GetBodyPaths() end
+
+---@return SystemBody[]
+function StarSystem:GetStars() end
+
+---@return boolean[]
+function StarSystem:GetJumpable() end
+
+---@param name string Commodity identifier
+---@return number
+function StarSystem:GetCommodityBasePriceAlterations(name) end
+
+---@param name string Commodity identifier
+---@return boolean
+function StarSystem:IsCommodityLegal(name) end
+
+---@param range number distance from this system to search, in light years
+---@param filter fun(ss: StarSystem): boolean predicate to filter returned starsystems
+---@return StarSystem[]
+function StarSystem:GetNearbySystems(range, filter) end
+
+--- Calculate the distance between this and another system
+---@param other StarSystem|SystemPath
+---@return number dist distance between the two systems in light years
+function StarSystem:DistanceTo(other) end
+
+-- Export a generated star system to a Lua file for further customization
+function StarSystem:ExportToLua() end
+
+--- Set the star system to be explored by the player
+---@param time number? optional time at which the system was explored
+function StarSystem:Explore(time) end

--- a/data/meta/SystemBody.lua
+++ b/data/meta/SystemBody.lua
@@ -1,0 +1,76 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+
+---@meta
+
+---@class SystemBody
+---
+---@field index integer
+---@field name string
+---@field type BodyType
+---@field superType BodySuperType
+---@field seed integer
+---@field parent SystemBody?
+---
+--- The population of the body, in billions of people.
+---@field population number
+--- The radius of the body, in metres (m).
+---@field radius number
+--- The mass of the body, in kilograms (kg).
+---@field mass number
+--- The gravity on the surface of the body (m/s).
+---@field gravity number
+--- The periapsis of the body's orbit, in metres (m).
+---@field periapsis number
+--- The apoapsis of the body's orbit, in metres (m).
+---@field apoapsis number
+--- The orbit of the body, around its parent, in days
+---@field orbitPeriod number
+--- The rotation period of the body, in days
+---@field rotationPeriod number
+--- The semi-major axis of the orbit, in metres (m).
+---@field semiMajorAxis number
+--- The orbital eccentricity of the body
+---@field eccentricity number
+--- The axial tilt of the body, in radians
+---@field axialTilt number
+--- The average surface temperature of the body, in degrees kelvin
+---@field averageTemp number
+--- The measure of metallicity of the body's crust:
+--- 0.0 = light (Al, SiO2, etc), 1.0 = heavy (Fe, heavy metals)
+---@field metallicity number
+--- The measure of volatile gas present in the atmosphere of the body:
+--- 0.0 = no atmosphere, 1.0 = earth atmosphere density, 4.0+ ~= venus
+---@field volatileGas number
+--- The compositional value of any atmospheric gasses in the bodys atmosphere (if any):
+--- 0.0 = reducing (H2, NH3, etc), 1.0 = oxidising (CO2, O2, etc)
+---@field atmosOxidizing number
+--- The measure of volatile liquids present on the body:
+--- 0.0 = none, 1.0 = waterworld (earth = 70%)
+---@field volatileLiquid number
+--- The measure of volatile ices present on the body:
+--- 0.0 = none, 1.0 = total ice cover (earth = 3%)
+---@field volatileIces number
+--- The measure of volcanicity of the body:
+--- 0.0 = none, 1.0 = lava planet
+---@field volcanicity number
+--- The measure of life present on the body:
+--- 0.0 = dead, 1.0 = teeming (~= pandora)
+---@field life number
+---
+---@field hasRings boolean
+---@field hasAtmosphere boolean
+---@field isScoopable boolean
+---
+---@field astroDescription string
+---@field path SystemPath
+---@field body Body?
+---@field children SystemBody[]
+---@field nearestJumpable SystemBody
+---@field isMoon boolean
+---@field isStation boolean
+---@field isGroundStation boolean
+---@field isSpaceStation boolean
+---@field physicsBody Body?

--- a/data/meta/SystemPath.lua
+++ b/data/meta/SystemPath.lua
@@ -1,0 +1,64 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+
+---@meta
+
+---@class SystemPath
+---
+---@field sectorX integer
+---@field sectorY integer
+---@field sectorZ integer
+---@field systemIndex integer?
+---@field bodyIndex integer?
+
+---@class SystemPath
+local SystemPath = {}
+
+---@param x integer
+---@param y integer
+---@param z integer
+---@return SystemPath
+---@overload fun(x: integer, y: integer, z: integer, si: integer, bi: integer): SystemPath
+function SystemPath.New(x, y, z) end
+
+---@param str string
+---@return SystemPath?
+function SystemPath.ParseString(str) end
+
+--- Determine if two <SystemPath> objects point to objects in the same system.
+---@param other SystemPath
+---@return boolean
+function SystemPath:IsSameSystem(other) end
+
+--- Determine if two <SystemPath> objects point to objects in the same sector.
+---@param other SystemPath
+---@return boolean
+function SystemPath:IsSameSector(other) end
+
+--- Derive a SystemPath that points to the whole system.
+---@return SystemPath
+function SystemPath:SystemOnly() end
+
+--- Derive a SystemPath that points to the whole sector.
+---@return SystemPath
+function SystemPath:SectorOnly() end
+
+--- Calculate the distance between this and another system
+---@param system SystemPath|StarSystem --not yet implemented
+function SystemPath:DistanceTo(system) end
+
+---@return StarSystem
+function SystemPath:GetStarSystem() end
+
+---@return SystemBody
+function SystemPath:GetSystemBody() end
+
+---@return boolean
+function SystemPath:IsSystemPath() end
+
+---@return boolean
+function SystemPath:IsBodyPath() end
+
+return SystemPath

--- a/data/meta/Vector.lua
+++ b/data/meta/Vector.lua
@@ -1,0 +1,75 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+
+---@meta
+
+---@class Vector2
+---@field x number
+---@field y number
+local Vector2 = {}
+
+---@param x number
+---@param y number
+---@return Vector2
+function _G.Vector2(x, y) end
+
+---@return Vector2
+function Vector2:normalized() end
+
+---@return Vector2
+function Vector2:normalised() end
+
+---@return number
+function Vector2:lengthSqr() end
+
+---@return number
+function Vector2:length() end
+
+---@param angle number
+---@return Vector2
+function Vector2:rotate(angle) end
+
+---@return number
+function Vector2:angle() end
+
+--- Rotate the vector by 90 degrees left
+---@return Vector2
+function Vector2:left() end
+
+--- Rotate the vector by 90 degrees right
+---@return Vector2
+function Vector2:right() end
+
+-- ============================================================================
+
+---@class Vector3
+---@field x number
+---@field y number
+---@field z number
+local Vector3 = {}
+
+---@param x number
+---@return Vector3
+---@overload fun(x: number, y: number, z: number): Vector3
+---@overload fun(vec2: Vector2, z: number?): Vector3
+function _G.Vector3(x) end
+
+---@return Vector3
+function Vector3:normalized() end
+
+---@return Vector3
+function Vector3:normalised() end
+
+---@return number
+function Vector3:lengthSqr() end
+
+---@return number
+function Vector3:length() end
+
+---@return Vector3
+function Vector3:cross() end
+
+---@return number
+function Vector3:dot() end

--- a/data/meta/_Core.lua
+++ b/data/meta/_Core.lua
@@ -1,0 +1,65 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about Pioneer's customization of the
+-- Lua global execution environment.
+
+---@meta
+
+--- Convert the angle `a` from degrees to radians
+---@param a number
+---@return number
+math.deg2rad = function(a) end
+
+--- Convert the angle `a` from radians to degrees
+---@param a number
+---@return number
+math.rad2deg = function(a) end
+
+--- CoreImports registry for directly accessing C++ class metatypes without
+--- using the `require()` mechanism (e.g. to allow extending metatypes)
+package.core = {}
+
+--- Trigger a purge and reimport of the specified package.
+--- References to the return value of the old package will not be replaced.
+---@param name string? dot-qualified name of the package to trigger reimport for
+package.reimport = function(name) end
+
+--- Log the specified string at the Warning semantic level
+function logWarning(string) end
+
+-- ============================================================================
+
+-- Document lua Constants as typed subclasses of string for API visibility sake
+
+-- TODO: not all constant types are present here; please update this file as new
+-- constant types are required
+
+-- A <Constants.BodyType> string
+---@class BodyType: string
+
+-- A <Constants.BodySuperType> string
+---@class BodySuperType: string
+
+-- A <Constants.PhysicsObjectType> string
+---@class PhysicsObjectType: string
+
+--- PolitGovType string constant; EARTHCOLONIAL, EARTHDEMOC, EMPIRERULE, etc.
+---@class PolitGovType: string
+
+-- ============================================================================
+
+-- Global Constants namespace
+Constants = {}
+
+---@type BodyType[]
+Constants.BodyType = {}
+
+---@type BodySuperType[]
+Constants.BodySuperType = {}
+
+---@type PhysicsObjectType[]
+Constants.PhysicsObjectType = {}
+
+---@type PolitGovType[]
+Constants.PolitGovType = {}

--- a/data/pigui/libs/rescale-ui.lua
+++ b/data/pigui/libs/rescale-ui.lua
@@ -33,6 +33,9 @@ local defaultBaseResolution = Vector2(1600, 900)
 --
 --   number|Vector2|Table - the scaled value
 --
+---@generic T
+---@param val T
+---@return T
 local function rescaleUI(val, baseResolution, rescaleToScreenAspect, targetResolution, disableCeil)
 	if not targetResolution then
 		targetResolution = Vector2(pigui.screen_width, pigui.screen_height)

--- a/data/pigui/modules/comms.lua
+++ b/data/pigui/modules/comms.lua
@@ -76,7 +76,7 @@ local function displayCommsLog()
 							table.insert(lines, 1, { sender = last.sender, text = last.text .. ((rep > 1) and (' x ' .. rep) or ''), priority = last.priority })
 						end
 						ui.pushTextWrapPos(ui.screenWidth/4 - 20)
-						for _,v in pairs(utils.take(lines, commsLinesToShow)) do
+						for _,v in utils.take(lines, commsLinesToShow) do
 							showItem(v)
 						end
 						ui.popTextWrapPos()
@@ -91,7 +91,7 @@ local function displayCommsLog()
 							function()
 								local lines = Game.GetCommsLines()
 								ui.pushTextWrapPos(ui.screenWidth/3 - 20)
-								for _,v in pairs(utils.reverse(lines)) do
+								for _,v in utils.reverse(lines) do
 									showItem(v)
 								end
 								ui.popTextWrapPos()

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -118,6 +118,21 @@ static int l_body_attr_path(lua_State *l)
 	return 1;
 }
 
+/*
+ * Function: GetComponent
+ *
+ * Returns a handle to the specified LuaComponent or C++ Component attached
+ * to the given body, if present. Will return nil if the specified component
+ * does not exist on this body.
+ *
+ * Availability:
+ *
+ *   June 2022
+ *
+ * Status:
+ *
+ *   stable
+ */
 static int l_body_get_component(lua_State *l)
 {
 	Body *b = LuaObject<Body>::CheckFromLua(1);
@@ -141,6 +156,26 @@ static int l_body_get_component(lua_State *l)
 	return 1;
 }
 
+/*
+ * Function: SetComponent
+ *
+ * Sets the given LuaComponent slot to a specific table value. Will error if
+ * the slot name is reserved by C++ components or if the caller is attempting
+ * to set the `__properties` reserved name.
+ *
+ * Parameters:
+ *
+ *   comp - a table object to be used as the component value or nil to remove
+ *          the component from the Body.
+ *
+ * Availability:
+ *
+ *   June 2022
+ *
+ * Status:
+ *
+ *   stable
+ */
 static int l_body_set_component(lua_State *l)
 {
 	LuaObject<Body>::CheckFromLua(1);


### PR DESCRIPTION
At the great expense of possibly further reducing the lifetime of my keyboard from all of the furious typing, I've added a significant amount of documentation to the `utils` Lua module and added type information "meta files" for several foundational Lua classes defined in C++.

I've also added a helper `utils.class` function which normalizes the LuaObject constructor paradigm with lua-defined classes for less confusion; and refactored the `utils.take` and `utils.reverse` methods to avoid table copies and properly carry out their function.

The new type-information files live in the `data/meta` directory and are simply specially-formatted Lua files containing function and class prototype declarations marked up with EmmyLua syntax that a lua language server can understand. These files are tailored specifically for [sumneko/lua-language-server](https://github.com/sumneko/lua-language-server) as most of our developers use this implementation and it is the most fully-featured language server that is available in multiple IDEs.

Adding new type information is simple; create a new Lua file in the `data/meta` directory and add a `---@meta` comment near the top of the file. Further lua code and documentation will be read by the lua language server and used to populate the type information available during static analysis, but will not be executed by the game at runtime, allowing fields and methods on C++ userdata and other type information that would be invisible to the language server's static analysis to be discovered and used.

I have not documented our entire class hierarchy due to time constraints, as this was originally intended to be a small PR merged separately before the cargo component refactor. I would highly appreciate additional effort from other developers in completing this type documentation - it's quite simple to add this information by simply reading the C++ sources in `src/lua`.

Further documentation efforts would also be appreciated to mark up types in the Lua game files where they're unable to be inferred - e.g. in `onShipXXXX` event handlers, the `ship` parameter of the handler will need to be explicitly declared with `---@param ship Ship`; that is a situation where the type of the parameter is simply unable to be inferred, even though it is strongly known from the C++ side.

To make use of these type information files in VS Code, add an entry to the Lua > Workspace > Library setting (in the UI or in the `settings` object of your workspace file) with the path from the workspace root folder to the `data/meta` folder, like so:
```json
"Lua.workspace.library": [
    "data/meta"
]
```

For developers not using VS Code, consult the documentation for your specific language server adapter plugin to properly set the `workspace.library` configuration value.

**NOTE:** this PR will only remain open for a very short time (less than 24hrs) to gather feedback, as it is a required component to merge the cargo component refactor branch.