### PR TITLE
Separate Cargo from Equipment

### DIFF
--- a/data/libs/CargoManager.lua
+++ b/data/libs/CargoManager.lua
@@ -35,7 +35,7 @@ function CargoManager:Constructor(ship)
 
 	-- Commodity storage is implemented as simple hashtable of name -> { count=n } values
 	-- to ease initial implementation
-	---@type table<string, { count: number }>
+	---@type table<string, { count: number, life_support: number? }>
 	self.commodities = {}
 
 	-- Event listeners for changes to commodities stored in this manager
@@ -113,7 +113,7 @@ function CargoManager:AddCommodity(type, count)
 	local storage = self.commodities[type.name]
 
 	if not storage then
-		storage = { count = 0 }
+		storage = { count = 0, life_support = type.life_support }
 		self.commodities[type.name] = storage
 	end
 
@@ -191,6 +191,23 @@ function CargoManager:CountCommodity(type)
 	end
 
 	return self.commodities[type.name].count
+end
+
+-- Method: DoLifeSupportChecks
+--
+-- Check for commodities on this vessel which would perish under the given
+-- cargo life-support level.
+-- Returns the name of the first commodity found that would perish.
+---@param supportLevel integer
+---@return string?
+function CargoManager:DoLifeSupportChecks(supportLevel)
+	for name, info in pairs(self.commodities) do
+		if info.life_support > supportLevel then
+			return name
+		end
+	end
+
+	return nil
 end
 
 -- Method: AddListener

--- a/data/libs/CargoManager.lua
+++ b/data/libs/CargoManager.lua
@@ -202,7 +202,7 @@ end
 ---@return string?
 function CargoManager:DoLifeSupportChecks(supportLevel)
 	for name, info in pairs(self.commodities) do
-		if info.life_support > supportLevel then
+		if (info.life_support or 0) > supportLevel then
 			return name
 		end
 	end

--- a/data/libs/CargoManager.lua
+++ b/data/libs/CargoManager.lua
@@ -1,0 +1,141 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local ShipDef = require 'ShipDef'
+
+local utils = require 'utils'
+
+--
+-- Class: CargoManager
+--
+-- CargoManager represents and manages all ship-based cargo data storage, in
+-- contrast to EquipSet which manages active ship equipment.
+--
+
+local CargoManager = utils.class('CargoManager')
+
+-- Constructor
+--
+-- Creates and initializes a CargoManager object for the given ship
+function CargoManager:Constructor(ship)
+	self.ship = ship
+
+	-- Cargo space and cargo mass are the same thing right now
+	self.usedCargoSpace = 0
+	self.usedCargoMass = 0
+
+	-- TODO: stored commodities should be represented as array of { name, count, meta } entries
+	-- to allow for e.g. tracking stolen/scooped cargo, or special mission-related cargoes
+
+	-- Commodity storage is implemented as simple hashtable of name -> { count=n } values
+	-- to ease initial implementation
+	self.commodities = {}
+end
+
+-- Method: GetFreeSpace
+--
+-- Returns the available amount of cargo space currently present on the vessel.
+function CargoManager:GetFreeSpace()
+	local ship = self.ship
+
+	local avail_mass = ShipDef[ship.shipId].capacity - ship.mass_cap
+	local cargo_slots = ship.equipSet.slots.cargo
+
+	return math.min(avail_mass, cargo_slots.__limit - self.usedCargoSpace)
+end
+
+-- Method: GetTotalSpace
+--
+-- Returns the theoretical maximum amount of cargo that could be stored on the vessel.
+function CargoManager:GetTotalSpace()
+	local ship = self.ship
+	return math.min(ShipDef[ship.shipId].capacity, ship.equipSet.slots.cargo.__limit)
+end
+
+-- Method: AddCommodity
+--
+-- Add a specific number of the given commodity to this cargo manager.
+-- Will return false if the total number specified cannot be removed from the
+-- cargo manager.
+--
+-- Parameters:
+--   type - CommodityType object of the commodity to add
+--   count - number of commodities
+--
+-- Returns:
+--   success - boolean indicating whether there was enough space on the vessel
+--             to store the commodity
+function CargoManager:AddCommodity(type, count)
+	-- TODO: use a cargo volume metric with variable mass instead of fixed 1m^3 == 1t
+	local required_space = (type.mass or 1) * (count or 1)
+
+	if self:GetFreeSpace() < required_space then
+		return false
+	end
+
+	self.usedCargoSpace = self.usedCargoSpace + required_space
+
+	self.usedCargoMass = self.usedCargoMass + required_space
+	self.ship:setcap("mass_cap", self.ship.mass_cap + required_space)
+
+	local storage = self.commodities[type.name]
+
+	if not storage then
+		storage = { count = 0 }
+		self.commodities[type.name] = storage
+	end
+
+	storage.count = storage.count + count
+
+	return true
+end
+
+-- Method: RemoveCommodity
+--
+-- Remove a specific number of the specified commodity from this cargo manager.
+-- Will return the number of commodities removed, even if that number is less
+-- than initially desired.
+--
+-- Parameters:
+--   type - CommodityType object of the commodity to remove
+--   count - maximum number of commodity items to remove
+--
+-- Returns:
+--   numRemoved - total number of commodity items removed, or 0 if no items
+--                were removed from the cargo
+function CargoManager:RemoveCommodity(type, count)
+	local storage = self.commodities[type.name]
+
+	if not storage or storage.count == 0 then
+		return 0
+	end
+
+	local removed = math.min(storage.count, (count or 1))
+
+	storage.count = storage.count - removed
+
+	-- TODO: use a cargo volume metric with variable mass instead of fixed 1m^3 == 1t
+	local freed_space = (type.mass or 1) * removed
+	self.usedCargoSpace = self.usedCargoSpace - freed_space
+
+	self.usedCargoMass = self.usedCargoMass - freed_space
+	self.ship:setcap("mass_cap", self.ship.mass_cap - freed_space)
+
+	return removed
+end
+
+-- Method: CountCommodity
+--
+-- Returns total amount of a commodity available in this cargo manager.
+--
+-- Parameters:
+--   type - CommodityType object of the commodity to query
+function CargoManager:CountCommodity(type)
+	if not self.commodities[type.name] then
+		return 0
+	end
+
+	return self.commodities[type.name].count
+end
+
+return CargoManager

--- a/data/libs/Commodities.lua
+++ b/data/libs/Commodities.lua
@@ -13,6 +13,8 @@ local cargo = EquipType.cargo
 
 local CARGOLANGRESOURCE = "commodity"
 
+local Commodities = CommodityType.registry
+
 -- TODO: normalize icon name conventions; ideally we don't need this table at all and can simply
 -- use the commodity name for the icon
 local icon_names = {
@@ -71,4 +73,4 @@ for name, commodity in pairs(commodities) do
 	})
 end
 
-return CommodityType.registry
+return Commodities

--- a/data/libs/Commodities.lua
+++ b/data/libs/Commodities.lua
@@ -1,17 +1,18 @@
 -- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local Economy = require 'Economy'
-local EquipType = require 'EquipType'
-
 local CommodityType = require 'CommodityType'
+local Economy       = require 'Economy'
 
-local commodities = Economy.GetCommodities()
-local economies = Economy.GetEconomies()
-
-local cargo = EquipType.cargo
-
-local CARGOLANGRESOURCE = "commodity"
+--
+-- Interface: Commodities
+--
+-- Commodities is a module that wraps the <CommodityType> registry for easy access.
+--
+-- It automatically registers all commodities defined in the economy JSON files,
+-- and any commodity in the game can be retrieved by indexing the table with the
+-- name of the commodity in questino.
+--
 
 local Commodities = CommodityType.registry
 
@@ -51,16 +52,10 @@ local icon_names = {
 	industrial_machinery = "Industrial_machinery"
 }
 
--- TODO: don't create a separate EquipType instance for each commoditity,
--- instead store cargo separately from ship equipment
-for name, commodity in pairs(commodities) do
+local economies = Economy.GetEconomies()
+
+for name, commodity in pairs(Economy.GetCommodities()) do
 	local econ = commodity.producer > 0 and economies[commodity.producer] or {}
-	cargo[commodity.name] = EquipType.EquipType.New({
-		name=commodity.name, slots="cargo",
-		l10n_key=commodity.l10n_key, l10n_resource=CARGOLANGRESOURCE,
-		price=commodity.price, capabilities={mass=1}, economy_type=econ.name,
-		purchasable=true, icon_name=icon_names[commodity.name] or ""
-	})
 
 	local required_life_support_level = nil
 	-- TODO: define this in commodity JSON files rather than explicit callouts

--- a/data/libs/Commodities.lua
+++ b/data/libs/Commodities.lua
@@ -71,4 +71,4 @@ for name, commodity in pairs(commodities) do
 	})
 end
 
-return cargo
+return CommodityType.registry

--- a/data/libs/Commodities.lua
+++ b/data/libs/Commodities.lua
@@ -62,11 +62,18 @@ for name, commodity in pairs(commodities) do
 		purchasable=true, icon_name=icon_names[commodity.name] or ""
 	})
 
+	local required_life_support_level = nil
+	-- TODO: define this in commodity JSON files rather than explicit callouts
+	if name == "live_animals" or name == "slaves" then
+		required_life_support_level = 1
+	end
+
 	CommodityType.RegisterCommodity(name, {
 		l10n_key = commodity.l10n_key,
 		l10n_resource = nil,
 		price = commodity.price,
 		mass = 1,
+		life_support = required_life_support_level,
 		economy_type = econ.name,
 		purchasable = true,
 		icon_name = icon_names[name] or ""

--- a/data/libs/Commodities.lua
+++ b/data/libs/Commodities.lua
@@ -4,6 +4,8 @@
 local Economy = require 'Economy'
 local EquipType = require 'EquipType'
 
+local CommodityType = require 'CommodityType'
+
 local commodities = Economy.GetCommodities()
 local economies = Economy.GetEconomies()
 
@@ -56,6 +58,16 @@ for name, commodity in pairs(commodities) do
 		l10n_key=commodity.l10n_key, l10n_resource=CARGOLANGRESOURCE,
 		price=commodity.price, capabilities={mass=1}, economy_type=econ.name,
 		purchasable=true, icon_name=icon_names[commodity.name] or ""
+	})
+
+	CommodityType.RegisterCommodity(name, {
+		l10n_key = commodity.l10n_key,
+		l10n_resource = nil,
+		price = commodity.price,
+		mass = 1,
+		economy_type = econ.name,
+		purchasable = true,
+		icon_name = icon_names[name] or ""
 	})
 end
 

--- a/data/libs/CommodityType.lua
+++ b/data/libs/CommodityType.lua
@@ -1,6 +1,7 @@
 -- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+local Lang = require 'Lang'
 local utils = require 'utils'
 
 -- Default l10n resource for commodity types
@@ -13,7 +14,10 @@ local CARGOLANGRESOURCE = "commodity"
 -- registered at game startup and serialized by name/ID instead of using table
 -- identities to refer to commodities.
 --
+
+---@class CommodityType
 local CommodityType = utils.class('CommodityType')
+
 
 -- Constructor:
 --
@@ -52,6 +56,26 @@ function CommodityType:Constructor(name, data)
 	self.economy_type  = data.economy_type  or nil
 	self.purchasable   = data.purchasable   or false
 	self.icon_name     = data.icon_name     or ""
+
+	local l = Lang.GetResource(self.l10n_resource)
+	self.lang = {
+		name = l[self.l10n_key],
+		description = l:get(self.l10n_key .. "_DESCRIPTION") or ""
+	}
+end
+
+-- Method: GetName()
+--
+-- Returns the translated name of this commodity
+function CommodityType:GetName()
+	return self.lang.name
+end
+
+-- Method: GetDescription()
+--
+-- Returns the translated description of this commodity
+function CommodityType:GetDescription()
+	return self.lang.description
 end
 
 CommodityType.registry = {}
@@ -73,6 +97,7 @@ end
 -- Return the CommodityType registered for the given name or nil.
 --
 -- Static member function.
+---@return CommodityType
 function CommodityType.GetCommodity(name)
 	return CommodityType.registry[name]
 end

--- a/data/libs/CommodityType.lua
+++ b/data/libs/CommodityType.lua
@@ -110,12 +110,22 @@ function CommodityType.GetCommodity(name)
 	return CommodityType.registry[name]
 end
 
+-- Serialize commodity types by object, but load by name
 function CommodityType:Serialize()
-	return self.name
+	return self
 end
 
+-- Ensure loaded commodity types always point at the 'canonical' instance of the commodity;
+-- commodity types not defined by the current version of the code will be loaded verbatim
 function CommodityType.Unserialize(data)
-	return CommodityType.GetCommodity(data)
+	local ct = CommodityType.GetCommodity(data.name)
+
+	if not ct then
+		logWarning('Commodity type ' .. data.name .. ' could not be found, are you loading an outdated save?')
+		ct = CommodityType.RegisterCommodity(data.name, data)
+	end
+
+	return ct
 end
 
 Serializer:RegisterClass('CommodityType', CommodityType)

--- a/data/libs/CommodityType.lua
+++ b/data/libs/CommodityType.lua
@@ -38,6 +38,9 @@ local CommodityType = utils.class('CommodityType')
 --
 -- mass          - number, mass per 1m^3 ideal volume unit of cargo.
 --
+-- life_support  - optional number, the required life support level of the
+--                 vessel to preserve this commodity
+--
 -- economy_type  - optional string, economy ID of the primary producer of this
 --                 commodity. Defaults to nil.
 --
@@ -55,6 +58,7 @@ function CommodityType:Constructor(name, data)
 	self.l10n_resource = CARGOLANGRESOURCE
 	self.price         = 0
 	self.mass          = 1
+	self.life_support  = 0
 	self.economy_type  = nil
 	self.purchasable   = false
 	self.icon_name     = "Default"

--- a/data/libs/CommodityType.lua
+++ b/data/libs/CommodityType.lua
@@ -78,6 +78,7 @@ function CommodityType:GetDescription()
 	return self.lang.description
 end
 
+---@type { [string]: CommodityType }
 CommodityType.registry = {}
 
 -- Function: RegisterCommodity

--- a/data/libs/CommodityType.lua
+++ b/data/libs/CommodityType.lua
@@ -1,0 +1,80 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local utils = require 'utils'
+
+-- Default l10n resource for commodity types
+local CARGOLANGRESOURCE = "commodity"
+
+--
+-- Class: CommodityType
+--
+-- CommodityType is a backing store for commodity data. Commodities are
+-- registered at game startup and serialized by name/ID instead of using table
+-- identities to refer to commodities.
+--
+local CommodityType = utils.class('CommodityType')
+
+-- Constructor:
+--
+-- Construct a CommodityType from passed commodity data and common defaults.
+-- The following data fields are used if present:
+--
+-- name          - string, unique ID of the commodity
+--
+-- l10n_key      - string, translation key used when displaying this commodity
+--                 to the user (e.g. in ship cargo display)
+--
+-- l10n_resource - string, translation resource to look up the translation key
+--                 in. Defaults to "commodity".
+--
+-- price         - number, average expected purchase price of the commodity
+--                 before any price adjustments due to supply or demand.
+--
+-- mass          - number, mass per 1m^3 ideal volume unit of cargo.
+--
+-- economy_type  - optional string, economy ID of the primary producer of this
+--                 commodity. Defaults to nil.
+--
+-- purchasable   - boolean, controls whether the commodity type will be
+--                 considered for sale or purchase at stations. Mission items
+--                 should usually not be purchasable. Defaults to false.
+--
+-- icon_name     - string, name of the icon file used for this commodity.
+--                 Defaults to "".
+--
+function CommodityType:Constructor(name, data)
+	self.name          = name
+	self.l10n_key      = data.l10n_key      or "UNKNOWN_CARGO"
+	self.l10n_resource = data.l10n_resource or CARGOLANGRESOURCE
+	self.price         = data.price         or 0
+	self.mass          = data.mass          or 1
+	self.economy_type  = data.economy_type  or nil
+	self.purchasable   = data.purchasable   or false
+	self.icon_name     = data.icon_name     or ""
+end
+
+CommodityType.registry = {}
+
+-- Function: RegisterCommodity
+--
+-- Add a CommodityType to the registry under a specific name. Commodity names
+-- should be used to uniquely identify commodities instead of table identities.
+--
+-- Static member function.
+function CommodityType.RegisterCommodity(name, info)
+	assert(not CommodityType.registry[name])
+
+	CommodityType.registry[name] = CommodityType.New(name, info)
+end
+
+-- Function: GetCommodity
+--
+-- Return the CommodityType registered for the given name or nil.
+--
+-- Static member function.
+function CommodityType.GetCommodity(name)
+	return CommodityType.registry[name]
+end
+
+return CommodityType

--- a/data/libs/EquipSet.lua
+++ b/data/libs/EquipSet.lua
@@ -208,11 +208,8 @@ end
 
 function EquipSet:__TriggerCallbacks(ship, slot)
 	ship:UpdateEquipStats()
-	if slot == "cargo" then -- TODO: build a proper property system for the slots
-		ship:setprop("usedCargo", self.slots.cargo.__occupied)
-	else
-		ship:setprop("totalCargo", math.min(self.slots.cargo.__limit, self.slots.cargo.__occupied+ship.freeCapacity))
-	end
+	-- if we reduce the available capacity, we need to update the maximum amount of cargo available
+	ship:setprop("totalCargo", math.min(self.slots.cargo.__limit, ship.usedCargo+ship.freeCapacity))
 	self:CallListener(slot)
 end
 
@@ -307,6 +304,7 @@ function EquipSet:Add(ship, item, num, slot)
 	elseif not item:IsValidSlot(slot, ship) then
 		return -1
 	end
+	assert(slot ~= "cargo", "Cargo slots for equipment are no longer valid")
 
 	local added = self:__Add_NoCheck(item, num, slot)
 	if added == 0 then
@@ -343,6 +341,8 @@ function EquipSet:Remove(ship, item, num, slot)
 	if not slot then
 		slot = item:GetDefaultSlot(ship)
 	end
+	assert(slot ~= "cargo", "Cargo slots for equipment are no longer valid")
+
 	local removed = self:__Remove_NoCheck(item, num, slot)
 	if removed == 0 then
 		return 0

--- a/data/libs/EquipSet.lua
+++ b/data/libs/EquipSet.lua
@@ -57,8 +57,6 @@ function EquipSet:CallListener(slot)
 	end
 end
 
--- XXX(sturnclaw): to fix massive save-file inflation, we manually coalesce cargo items
--- This is suboptimal; cargo should be logically different from ship equipment
 function EquipSet:Serialize()
 	local serialize = {
 		slots = {}
@@ -68,45 +66,10 @@ function EquipSet:Serialize()
 		serialize.slots[k] = v
 	end
 
-	serialize.slots.cargo = {
-		__limit = self.slots.cargo.__limit,
-		__occupied = self.slots.cargo.__occupied,
-		__version = 2
-	}
-
-	-- count the number of cargo items in the bay
-	local occupancy = {}
-	for _, v in pairs(self.slots.cargo) do
-		if type (_) == "number" and type(v) == "table" then
-			occupancy[v] = (occupancy[v] or 0) + 1
-		end
-	end
-
-	-- Collapse instances of the same cargo item into one
-	for k, v in pairs(occupancy) do
-		table.insert(serialize.slots.cargo, { item = k, count = v })
-	end
-
 	return serialize
 end
 
 function EquipSet.Unserialize(data)
-	local cargo = data.slots.cargo
-
-	if (cargo.__version or 0) >= 2 then
-		local newCargo = {
-			__limit = cargo.__limit,
-			__occupied = cargo.__occupied
-		}
-
-		-- unpack collapsed cargo items
-		for _, v in ipairs(cargo) do
-			for i = 1, v.count do table.insert(newCargo, v.item) end
-		end
-
-		data.slots.cargo = newCargo
-	end
-
 	setmetatable(data, EquipSet.meta)
 	return data
 end

--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -305,7 +305,7 @@ function HyperdriveType:HyperjumpTo(ship, destination)
 	local warmup_time = 5 + self.capabilities.hyperclass*1.5
 
 	local sounds
-	if self.fuel == cargo.military_fuel then
+	if self.fuel.name == 'military_fuel' then
 		sounds = HYPERDRIVE_SOUNDS_MILITARY
 	else
 		sounds = HYPERDRIVE_SOUNDS_NORMAL
@@ -316,10 +316,12 @@ end
 
 function HyperdriveType:OnLeaveHyperspace(ship)
 	if ship:hasprop('nextJumpFuelUse') then
+		local cargoMgr = ship:GetComponent('CargoManager')
+
 		local amount = ship.nextJumpFuelUse
-		ship:RemoveEquip(self.fuel, amount)
+		cargoMgr:RemoveCommodity(self.fuel, amount)
 		if self.byproduct then
-			ship:AddEquip(self.byproduct, amount)
+			cargoMgr:AddCommodity(self.byproduct, amount)
 		end
 		ship:unsetprop('nextJumpFuelUse')
 	end

--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -252,7 +252,10 @@ end
 function HyperdriveType:GetRange(ship, remaining_fuel)
 	local range_max = self:GetMaximumRange(ship)
 	local fuel_max = self:GetFuelUse(ship, range_max, range_max)
-	remaining_fuel = remaining_fuel or ship:CountEquip(self.fuel)
+
+	---@type CargoManager
+	local cargoMgr = ship:GetComponent('CargoManager')
+	remaining_fuel = remaining_fuel or cargoMgr:CountCommodity(self.fuel)
 
 	if fuel_max <= remaining_fuel then
 		return range_max, range_max
@@ -316,6 +319,7 @@ end
 
 function HyperdriveType:OnLeaveHyperspace(ship)
 	if ship:hasprop('nextJumpFuelUse') then
+		---@type CargoManager
 		local cargoMgr = ship:GetComponent('CargoManager')
 
 		local amount = ship.nextJumpFuelUse

--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -11,10 +11,6 @@ local Comms = require 'Comms'
 local Game = package.core['Game']
 local Space = package.core['Space']
 
--- XXX this is kind of hacky, but we'll put up with it for now
--- Ideally we should separate out the hyperdrives into their own module
--- that can function independently of the cargo
-local cargo = {}
 local laser = {}
 local hyperspace = {}
 local misc = {}
@@ -472,7 +468,6 @@ Serializer:RegisterClass("SensorType", SensorType)
 Serializer:RegisterClass("BodyScannerType", BodyScannerType)
 
 return {
-	cargo			= cargo,
 	laser			= laser,
 	hyperspace		= hyperspace,
 	misc			= misc,

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -1,37 +1,25 @@
 -- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local utils = require 'utils'
-local Serializer = require 'Serializer'
-local Lang = require 'Lang'
-local ShipDef = require 'ShipDef'
-local Timer = require 'Timer'
-local Comms = require 'Comms'
+local Commodities = require 'Commodities'
+local EquipTypes  = require 'EquipType'
+local Serializer  = require 'Serializer'
 
-local Game = package.core['Game']
-local Space = package.core['Space']
-
-local EquipTypes = require 'EquipType'
-
-local LaserType = EquipTypes.LaserType
-local EquipType = EquipTypes.EquipType
-local HyperdriveType = EquipTypes.HyperdriveType
-local SensorType = EquipTypes.SensorType
+local LaserType       = EquipTypes.LaserType
+local EquipType       = EquipTypes.EquipType
+local HyperdriveType  = EquipTypes.HyperdriveType
+local SensorType      = EquipTypes.SensorType
 local BodyScannerType = EquipTypes.BodyScannerType
 
-local Commodities = require 'Commodities'
-
-local cargo = EquipTypes.cargo
-local laser = EquipTypes.laser
-local hyperspace = EquipTypes.hyperspace
-local misc = EquipTypes.misc
+local laser           = EquipTypes.laser
+local hyperspace      = EquipTypes.hyperspace
+local misc            = EquipTypes.misc
 
 -- Constants: EquipSlot
 --
--- Equipment slots. Every equipment or cargo type has a corresponding
+-- Equipment slots. Every equipment item has a corresponding
 -- "slot" that it fits in to. Each slot has an independent capacity.
 --
--- cargo - any cargo (commodity) item
 -- engine - hyperdrives and military drives
 -- laser_front - front attachment point for lasers and plasma accelerators
 -- laser_rear - rear attachment point for lasers and plasma accelerators

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -11,7 +11,6 @@ local Comms = require 'Comms'
 local Game = package.core['Game']
 local Space = package.core['Space']
 
-
 local EquipTypes = require 'EquipType'
 
 local LaserType = EquipTypes.LaserType
@@ -20,7 +19,9 @@ local HyperdriveType = EquipTypes.HyperdriveType
 local SensorType = EquipTypes.SensorType
 local BodyScannerType = EquipTypes.BodyScannerType
 
-local cargo = require 'Commodities'
+require 'Commodities'
+
+local cargo = EquipTypes.cargo
 local laser = EquipTypes.laser
 local hyperspace = EquipTypes.hyperspace
 local misc = EquipTypes.misc

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -19,7 +19,7 @@ local HyperdriveType = EquipTypes.HyperdriveType
 local SensorType = EquipTypes.SensorType
 local BodyScannerType = EquipTypes.BodyScannerType
 
-require 'Commodities'
+local Commodities = require 'Commodities'
 
 local cargo = EquipTypes.cargo
 local laser = EquipTypes.laser
@@ -204,92 +204,92 @@ misc.planetscanner = BodyScannerType.New({
 })
 
 hyperspace.hyperdrive_1 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS1", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS1", fuel=Commodities.hydrogen, slots="engine",
 	price=700, capabilities={mass=4, hyperclass=1}, purchasable=true, tech_level=3,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_2 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS2", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS2", fuel=Commodities.hydrogen, slots="engine",
 	price=1300, capabilities={mass=10, hyperclass=2}, purchasable=true, tech_level=4,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_3 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS3", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS3", fuel=Commodities.hydrogen, slots="engine",
 	price=2500, capabilities={mass=20, hyperclass=3}, purchasable=true, tech_level=4,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_4 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS4", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS4", fuel=Commodities.hydrogen, slots="engine",
 	price=5000, capabilities={mass=40, hyperclass=4}, purchasable=true, tech_level=5,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_5 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS5", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS5", fuel=Commodities.hydrogen, slots="engine",
 	price=10000, capabilities={mass=120, hyperclass=5}, purchasable=true, tech_level=5,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_6 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS6", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS6", fuel=Commodities.hydrogen, slots="engine",
 	price=20000, capabilities={mass=225, hyperclass=6}, purchasable=true, tech_level=6,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_7 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS7", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS7", fuel=Commodities.hydrogen, slots="engine",
 	price=30000, capabilities={mass=400, hyperclass=7}, purchasable=true, tech_level=8,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_8 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS8", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS8", fuel=Commodities.hydrogen, slots="engine",
 	price=60000, capabilities={mass=580, hyperclass=8}, purchasable=true, tech_level=9,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_9 = HyperdriveType.New({
-	l10n_key="DRIVE_CLASS9", fuel=cargo.hydrogen, slots="engine",
+	l10n_key="DRIVE_CLASS9", fuel=Commodities.hydrogen, slots="engine",
 	price=120000, capabilities={mass=740, hyperclass=9}, purchasable=true, tech_level=10,
 	icon_name="equip_hyperdrive"
 })
 hyperspace.hyperdrive_mil1 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL1", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL1", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=23000, capabilities={mass=3, hyperclass=1}, purchasable=true, tech_level=10,
 	icon_name="equip_hyperdrive_mil"
 })
 hyperspace.hyperdrive_mil2 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL2", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL2", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=47000, capabilities={mass=8, hyperclass=2}, purchasable=true, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
 hyperspace.hyperdrive_mil3 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL3", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL3", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=85000, capabilities={mass=16, hyperclass=3}, purchasable=true, tech_level=11,
 	icon_name="equip_hyperdrive_mil"
 })
 hyperspace.hyperdrive_mil4 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL4", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL4", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=214000, capabilities={mass=30, hyperclass=4}, purchasable=true, tech_level=12,
 	icon_name="equip_hyperdrive_mil"
 })
 hyperspace.hyperdrive_mil5 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL5", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL5", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=540000, capabilities={mass=53, hyperclass=5}, purchasable=false, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
 hyperspace.hyperdrive_mil6 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL6", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL6", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=1350000, capabilities={mass=78, hyperclass=6}, purchasable=false, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
 hyperspace.hyperdrive_mil7 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL7", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL7", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=3500000, capabilities={mass=128, hyperclass=7}, purchasable=false, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
 hyperspace.hyperdrive_mil8 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL8", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL8", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=8500000, capabilities={mass=196, hyperclass=8}, purchasable=false, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
 hyperspace.hyperdrive_mil9 = HyperdriveType.New({
-	l10n_key="DRIVE_MIL9", fuel=cargo.military_fuel, byproduct=cargo.radioactives, slots="engine",
+	l10n_key="DRIVE_MIL9", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives, slots="engine",
 	price=22000000, capabilities={mass=285, hyperclass=9}, purchasable=false, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
@@ -412,7 +412,7 @@ laser.large_plasma_accelerator = LaserType.New({
 
 local serialize = function()
 	local ret = {}
-	for _,k in ipairs{"cargo","laser", "hyperspace", "misc"} do
+	for _,k in ipairs{"laser", "hyperspace", "misc"} do
 		local tmp = {}
 		for kk, vv in pairs(EquipTypes[k]) do
 			tmp[kk] = vv
@@ -423,7 +423,7 @@ local serialize = function()
 end
 
 local unserialize = function (data)
-	for _,k in ipairs{"cargo","laser", "hyperspace", "misc"} do
+	for _,k in ipairs{"laser", "hyperspace", "misc"} do
 		local tmp = EquipTypes[k]
 		for kk, vv in pairs(data[k]) do
 			tmp[kk] = vv

--- a/data/libs/Event.lua
+++ b/data/libs/Event.lua
@@ -332,10 +332,35 @@ Event = {
 --   experimental
 --
 
+
+--
+-- Event: onShipCreated
+--
+-- Triggered when a ship is pushed to Lua and its constructor is called.
+-- This event may be used to start timers related to the ship or add optional
+-- components to the ship object.
+--
+-- > local onShipCreated = function (ship) ... end
+-- > Event.Register("onShipCreated", onShipCreated)
+--
+-- Parameters:
+--
+--   ship - the ship that was created
+--
+-- Availability:
+--
+--   June 2022
+--
+-- Status:
+--
+--   stable
+--
+
 --
 -- Event: onShipDestroyed
 --
--- Triggered when a ship is destroyed.
+-- Triggered when a ship is destroyed by gunfire or collision.
+-- This event will not be triggered when a ship is simply deleted from space.
 --
 -- > local onShipDestroyed = function (ship, attacker) ... end
 -- > Event.Register("onShipDestroyed", onShipDestroyed)
@@ -742,6 +767,52 @@ Event = {
 -- Availability:
 --
 --   alpha 20
+--
+-- Status:
+--
+--   experimental
+--
+
+--
+-- Event: onShipScoopFuel
+--
+-- Triggered when a ship has stayed in the atmosphere of a star or gas giant
+-- and a unit of fuel should be scooped into the players' cargo hold.
+--
+-- > local onShipScoopFuel = function (ship, body) ... end
+-- > Event.Register("onShipScoopFuel", onShipScoopFuel)
+--
+-- Parameters:
+--
+--   ship - the <Ship> which just scooped fuel
+--
+--   body - the <SystemBody> the fuel was scooped from
+--
+-- Availability:
+--
+--   June 2022
+--
+-- Status:
+--
+--   experimental
+--
+
+--
+-- Event: onShipScoopCargo
+--
+-- Triggered when a ship attempts to scoop up a cargo container.
+--
+-- Parameters:
+--
+--   ship - the <Ship> which attempted to scoop a cargo item
+--
+--   success - was the cargo container successfully scooped?
+--
+--   cargoType - the <CommodityType> contained in the cargo item
+--
+-- Availability:
+--
+--   June 2022
 --
 -- Status:
 --

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -119,13 +119,13 @@ end
 --
 -- Method: AddEquip
 --
--- Add an equipment or cargo item to its appropriate equipment slot
+-- Add an equipment item to its appropriate equipment slot
 --
 -- > num_added = ship:AddEquip(item, count, slot)
 --
 -- Parameters:
 --
---   item  - an Equipment type object (e.g., require 'Equipment'.cargo.hydrogen)
+--   item  - an Equipment type object (e.g., require 'Equipment'.misc.radar)
 --
 --   count - optional. The number of this item to add. Defaults to 1.
 --
@@ -138,7 +138,7 @@ end
 --
 -- Example:
 --
--- > ship:AddEquip(Equipment.cargo.animal_meat, 10)
+-- > ship:AddEquip(Equipment.misc.cabin, 10)
 -- > ship:AddEquip(Equipment.laser.pulsecannon_dual_1mw, 1, "laser_rear")
 --
 -- Availability:
@@ -167,7 +167,7 @@ end
 --
 -- Parameters:
 --
---   slot  - a slot name string (e.g., "cargo")
+--   slot  - a slot name string (e.g., "autopilot")
 --
 --   index - optional. The equipment position in the slot to fetch. If
 --           specified the item at that position in the slot will be returned,
@@ -206,7 +206,7 @@ end
 --
 -- Parameters:
 --
---   slot - a slot name (e.g., "cargo")
+--   slot - a slot name (e.g., "autopilot")
 --
 -- Return:
 --
@@ -260,13 +260,13 @@ end
 --
 -- Method: RemoveEquip
 --
--- Remove one or more of a given equipment type from its appropriate cargo slot
+-- Remove one or more of a given equipment type from its appropriate equipment slot
 --
 -- > num_removed = ship:RemoveEquip(item, count, slot)
 --
 -- Parameters:
 --
---   item - an equipment type object (e.g., Equipment.cargo.hydrogen)
+--   item - an equipment type object (e.g., Equipment.misc.autopilot)
 --
 --   count - optional. The number of this item to remove. Defaults to 1.
 --
@@ -952,9 +952,15 @@ local onShipDestroyed = function (ship, attacker)
 	end
 end
 
+-- Reinitialize cargo-related ship properties when changing ship type
+local onShipTypeChanged = function (ship)
+	ship:GetComponent('CargoManager'):OnShipTypeChanged()
+end
+
 Event.Register("onEnterSystem", onEnterSystem)
 Event.Register("onShipDestroyed", onShipDestroyed)
 Event.Register("onGameStart", onGameStart)
+Event.Register("onShipTypeChanged", onShipTypeChanged)
 Serializer:Register("ShipClass", serialize, unserialize)
 
 return Ship

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -10,6 +10,7 @@ local ShipDef = require 'ShipDef'
 local Equipment = require 'Equipment'
 local Timer = require 'Timer'
 local Lang = require 'Lang'
+local CargoManager = require 'CargoManager'
 local Character = require 'Character'
 local Comms = require 'Comms'
 
@@ -20,6 +21,10 @@ local l = Lang.GetResource("ui-core")
 --
 -- Class representing a ship. Inherits from <Body>.
 --
+
+function Ship:Constructor()
+	self:SetComponent('CargoManager', CargoManager.New(self))
+end
 
 -- class method
 function Ship.MakeRandomLabel ()

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -372,7 +372,7 @@ function SpaceStation:GetCommodityPrice(itemType)
 	local price = commodityPrice[self] and commodityPrice[self][itemType.name]
 	if price then return price end
 
-	local mul = ((100 + Game.system:GetCommodityBasePriceAlterations(itemType.name)) / 100)
+	local mul = (100 + Game.system:GetCommodityBasePriceAlterations(itemType.name)) / 100
 	return itemType.price * mul
 end
 
@@ -402,7 +402,10 @@ end
 function SpaceStation:SetCommodityPrice(itemType, price)
 	assert(self:exists())
 
-	if not commodityPrice[self] then commodityPrice[self] = {} end
+	if not commodityPrice[self] then
+		commodityPrice[self] = {}
+	end
+
 	commodityPrice[self][itemType.name] = price
 end
 
@@ -434,7 +437,7 @@ end
 function SpaceStation:GetCommodityStock(itemType)
 	assert(self:exists())
 
-	return (commodityStock[self] and commodityStock[self][itemType.name]) or 0
+	return commodityStock[self] and commodityStock[self][itemType.name] or 0
 end
 
 --

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -50,6 +50,8 @@ local commodityPrice = {}
 -- the player has visited in their journey
 local stationMarket = {}
 
+local ensureStationData
+
 -- Return the target stock level for a given commodity based on whether the
 -- commodity is an import/export good at this port (based on pricemod)
 --
@@ -331,6 +333,7 @@ end
 --
 function SpaceStation:AddEquipmentStock (e, stock)
 	assert(self:exists())
+	ensureStationData(self)
 	assert(equipmentStock[self])
 
 	equipmentStock[self][e] = (equipmentStock[self][e] or 0) + stock
@@ -459,6 +462,7 @@ end
 ---@param amount integer
 function SpaceStation:AddCommodityStock(itemType, amount)
 	assert(self:exists())
+	ensureStationData(self)
 	assert(commodityStock[self])
 
 	-- update transient stocking numbers
@@ -980,6 +984,15 @@ local function createStationData (station)
 	addRandomShipAdvert(station, shipAdsToSpawn)
 
 	Event.Queue("onCreateBB", station)
+end
+
+ensureStationData = function (station)
+	if not visited[station] or not commodityStock[station] or not equipmentStock[station] then
+		logWarning("Creating station data for station " .. station.label .. " before onShipDocked event is processed for that station")
+		logVerbose(debug.dumpstack(2))
+
+		createStationData(station)
+	end
 end
 
 local function destroySystem ()

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -290,7 +290,28 @@ function SpaceStation:AddEquipmentStock (e, stock)
 	end
 end
 
+-- ============================================================================
 
+-- FIXME: redirection functions to ease porting Cargo out of Equipment
+-- These should have proper implementations that track separate commodity stocks
+
+function SpaceStation:GetCommodityPrice(type)
+	return self:GetEquipmentPrice(Equipment.cargo[type.name])
+end
+
+function SpaceStation:SetCommodityPrice(type, price)
+	return self:SetEquipmentPrice(Equipment.cargo[type.name], price)
+end
+
+function SpaceStation:GetCommodityStock(type)
+	return self:GetEquipmentStock(Equipment.cargo[type.name])
+end
+
+function SpaceStation:AddCommodityStock(type, count)
+	return self:AddEquipmentStock(Equipment.cargo[type.name], count)
+end
+
+-- ============================================================================
 
 local shipsOnSale = {}
 
@@ -499,7 +520,6 @@ function SpaceStation:LaunchPolice(targetShip)
 				policeShip:AddEquip(Equipment.laser.pulsecannon_dual_1mw)
 				policeShip:AddEquip(Equipment.misc.atmospheric_shielding)
 				policeShip:AddEquip(Equipment.misc.laser_cooling_booster)
-				policeShip:AddEquip(Equipment.cargo.hydrogen, 1)
 
 				table.insert(police[self], policeShip)
 			end

--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -11,6 +11,7 @@ local Event = require 'Event'
 local Mission = require 'Mission'
 local NameGen = require 'NameGen'
 local Character = require 'Character'
+local Commodities = require 'Commodities'
 local Format = require 'Format'
 local Serializer = require 'Serializer'
 local Equipment = require 'Equipment'
@@ -292,19 +293,25 @@ local onEnterSystem = function (ship)
 						if mission.ship == nil then
 							return -- TODO
 						end
+
 						mission.ship:SetLabel(mission.shipregid)
+
 						mission.ship:AddEquip(Equipment.misc.atmospheric_shielding)
 						local engine = Equipment.hyperspace['hyperdrive_'..tostring(default_drive)]
 						mission.ship:AddEquip(engine)
 						mission.ship:AddEquip(laserdef)
 						mission.ship:AddEquip(Equipment.misc.shield_generator, mission.danger)
-						mission.ship:AddEquip(Equipment.cargo.hydrogen, count)
+
+						mission.ship:GetComponent('CargoManager'):AddCommodity(Commodities.hydrogen, count)
+
 						if mission.danger > 2 then
 							mission.ship:AddEquip(Equipment.misc.shield_energy_booster)
 						end
+
 						if mission.danger > 3 then
 							mission.ship:AddEquip(Equipment.misc.laser_cooling_booster)
 						end
+
 						_setupHooksForMission(mission)
 						mission.shipstate = 'docked'
 					end

--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -7,12 +7,11 @@ local Game = require 'Game'
 local Comms = require 'Comms'
 local Event = require 'Event'
 local Rand = require 'Rand'
-local NameGen = require 'NameGen'
 local Format = require 'Format'
 local Serializer = require 'Serializer'
-local Equipment = require 'Equipment'
 local Character = require 'Character'
 local utils = require 'utils'
+local Commodities = require 'Commodities'
 
 local l = Lang.GetResource("module-breakdownservicing")
 local lui = Lang.GetResource("ui-core")
@@ -287,13 +286,16 @@ local onEnterSystem = function (ship)
 		else
 			-- Destroy the engine
 			local engine = ship:GetEquip('engine',1)
-			if engine.fuel == Equipment.cargo.military_fuel then
+
+			if engine.fuel.name == 'military_fuel' then
 				pigui.playSfx("Hyperdrive_Breakdown_Military", 1.0, 1.0)
 			else
 				pigui.playSfx("Hyperdrive_Breakdown", 1.0, 1.0)
 			end
+
 			ship:RemoveEquip(engine)
-			ship:AddEquip(Equipment.cargo.rubbish, engine.capabilities.mass)
+			ship:GetComponent('CargoManager'):AddCommodity(Commodities.rubbish, engine.capabilities.mass)
+
 			Comms.Message(l.THE_SHIPS_HYPERDRIVE_HAS_BEEN_DESTROYED_BY_A_MALFUNCTION)
 		end
 	end

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -38,241 +38,7 @@ local pickup_factor = 1.75
 -- the maximum price of the custom cargo
 local max_price = 300
 
--- the custom cargo
-local aluminium_tubes = Equipment.EquipType.New({
-	name = "aluminium_tubes",
-	l10n_key = 'ALUMINIUM_TUBES', slots="cargo", price=50,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local art_objects = Equipment.EquipType.New({
-	name = "art_objects",
-	l10n_key = 'ART_OBJECTS', slots="cargo", price=200,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local clus = Equipment.EquipType.New({
-	name = "clus",
-	l10n_key = 'CLUS', slots="cargo", price=20,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local diamonds = Equipment.EquipType.New({
-	name = "diamonds",
-	l10n_key = 'DIAMONDS', slots="cargo", price=300,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local digesters = Equipment.EquipType.New({
-	name = "digesters",
-	l10n_key = 'DIGESTERS', slots="cargo", price=10,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local electrical_appliances = Equipment.EquipType.New({
-	name = "electrical_appliances",
-	l10n_key = 'ELECTRICAL_APPLIANCES', slots="cargo", price=150,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local explosives = Equipment.EquipType.New({
-	name = "explosives",
-	l10n_key = 'EXPLOSIVES', slots="cargo", price=50,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local furniture = Equipment.EquipType.New({
-	name = "furniture",
-	l10n_key = 'FURNITURE', slots="cargo", price=15,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local greenhouses = Equipment.EquipType.New({
-	name = "greenhouses",
-	l10n_key = 'GREENHOUSES', slots="cargo", price=20,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local hazardous_substances = Equipment.EquipType.New({
-	name = "hazardous_substances",
-	l10n_key = 'HAZARDOUS_SUBSTANCES', slots="cargo", price=100,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local machine_tools = Equipment.EquipType.New({
-	name = "machine_tools",
-	l10n_key = 'MACHINE_TOOLS', slots="cargo", price=10,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local neptunium = Equipment.EquipType.New({
-	name = "neptunium",
-	l10n_key = 'NEPTUNIUM', slots="cargo", price=200,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local plutonium = Equipment.EquipType.New({
-	name = "plutonium",
-	l10n_key = 'PLUTONIUM', slots="cargo", price=200,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local semi_finished_products = Equipment.EquipType.New({
-	name = "semi_finished_products",
-	l10n_key = 'SEMI_FINISHED_PRODUCTS', slots="cargo", price=10,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local spaceship_parts = Equipment.EquipType.New({
-	name = "spaceship_parts",
-	l10n_key = 'SPACESHIP_PARTS', slots="cargo", price=250,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local titanium = Equipment.EquipType.New({
-	name = "titanium",
-	l10n_key = 'TITANIUM', slots="cargo", price=150,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local tungsten = Equipment.EquipType.New({
-	name = "tungsten",
-	l10n_key = 'TUNGSTEN', slots="cargo", price=125,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local uranium = Equipment.EquipType.New({
-	name = "uranium",
-	l10n_key = 'URANIUM', slots="cargo", price=175,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local quibbles = Equipment.EquipType.New({
-	name = "quibbles",
-	l10n_key = 'QUIBBLES', slots="cargo", price=1,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local wedding_dresses = Equipment.EquipType.New({
-	name = "wedding_dresses",
-	l10n_key = 'WEDDING_DRESSES', slots="cargo", price=15,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-local stem_bolts = Equipment.EquipType.New({
-	name = "stem_bolts",
-	l10n_key = 'STEM_BOLTS', slots="cargo", price=143,
-	capabilities={mass=1},
-	purchasable=false, icon_name="Default",
-	l10n_resource="module-cargorun"
-})
-
-local chemical = {
-	digesters,
-	hazardous_substances
-}
-
-local mining = {
-	clus,
-	explosives
-}
-
-local hardware = {
-	aluminium_tubes,
-	diamonds,
-	hazardous_substances,
-	machine_tools,
-	neptunium,
-	plutonium,
-	semi_finished_products,
-	spaceship_parts,
-	stem_bolts,
-	titanium,
-	tungsten,
-	uranium
-}
-
-local infrastructure = {
-	clus,
-	explosives,
-	greenhouses
-}
-
-local consumer_goods = {
-	electrical_appliances,
-	furniture,
-	spaceship_parts
-}
-
-local expensive = { -- price >= 175
-	art_objects,
-	diamonds,
-	neptunium,
-	plutonium,
-	spaceship_parts,
-	uranium
-}
-
-local fluffy = {
-	quibbles
-}
-
-local wedding = {
-	wedding_dresses
-}
-
-local art = {
-	art_objects
-}
-
-local gems = {
-	diamonds
-}
-
-local radioactive = {
-	neptunium,
-	plutonium,
-	uranium
-}
-
-local centrifuges = {
-	aluminium_tubes
-}
-
-local custom_cargo = {
-	{ bkey = "CHEMICAL", goods = chemical, weight = 0 },
-	{ bkey = "MINING", goods = mining, weight = 0 },
-	{ bkey = "HARDWARE", goods = hardware, weight = 0 },
-	{ bkey = "INFRASTRUCTURE", goods = infrastructure, weight = 0 },
-	{ bkey = "CONSUMER_GOODS", goods = consumer_goods, weight = 0 },
-	{ bkey = "EXPENSIVE", goods = expensive, weight = 0 },
-	{ bkey = "FLUFFY", goods = fluffy, weight = 0 },
-	{ bkey = "WEDDING" , goods = wedding, weight = 0 },
-	{ bkey = "ART", goods = art, weight = 0 },
-	{ bkey = "GEMS", goods = gems, weight = 0 },
-	{ bkey = "RADIOACTIVE", goods = radioactive, weight = 0 },
-	{ bkey = "CENTRIFUGES", goods = centrifuges, weight = 0 }
-}
+local custom_cargo = require 'modules.CargoRun.CargoTypes'
 
 -- Each branch should have a probability weight proportional to its size
 local custom_cargo_weight_sum = 0
@@ -427,19 +193,29 @@ onChat = function (form, ref, option)
 		form:AddOption(l.IS_IT_NEGOTIABLE, 6)
 
 	elseif option == 3 then
-		if not ad.pickup and (Game.player.totalCargo - Game.player.usedCargo) < ad.negotiated_amount or
-			Game.player.totalCargo < ad.negotiated_amount then
-			form:SetMessage(l.YOU_DO_NOT_HAVE_ENOUGH_CARGO_SPACE_ON_YOUR_SHIP)
-			form:RemoveNavButton()
-			return
+		---@type CargoManager
+		local cargoMgr = Game.player:GetComponent('CargoManager')
+
+		if not ad.pickup then
+			if cargoMgr:GetFreeSpace() < ad.negotiated_amount then
+				form:SetMessage(l.YOU_DO_NOT_HAVE_ENOUGH_EMPTY_CARGO_SPACE)
+				form:RemoveNavButton()
+				return
+			elseif cargoMgr:GetTotalSpace() < ad.negotiated_amount then
+				form:SetMessage(l.YOU_DO_NOT_HAVE_ENOUGH_CARGO_SPACE_ON_YOUR_SHIP)
+				form:RemoveNavButton()
+				return
+			end
 		end
+
 		local cargo_picked_up
 		if not ad.pickup then
-			Game.player:AddEquip(ad.cargotype, ad.negotiated_amount, "cargo")
+			cargoMgr:AddCommodity(ad.cargotype, ad.negotiated_amount)
 			cargo_picked_up = true
 		else
 			cargo_picked_up = false
 		end
+
 		form:RemoveAdvertOnClose()
 		ads[ref] = nil
 		local mission = {
@@ -578,6 +354,7 @@ local makeAdvert = function (station)
 		-- discard stations closer than 1000m and further than 20AU
 		nearbystations = findNearbyStations(station, 1000, 1.4960e11 * 20)
 		if #nearbystations == 0 then return nil end
+
 		amount = Engine.rand:Integer(1, max_cargo)
 		risk = 0 -- no risk for local delivery
 		wholesaler = false -- no local wholesaler delivery
@@ -585,6 +362,7 @@ local makeAdvert = function (station)
 		location, dist = table.unpack(nearbystations[Engine.rand:Integer(1,#nearbystations)])
 		reward = typical_reward_local + math.max(math.sqrt(dist) / 15000, min_local_dist_pay) * (1.5+urgency) * (1+amount/max_cargo)
 		due = (4*24*60*60) + (24*60*60 * (dist / (1.49*10^11))) * (1.5 - urgency)
+
 		if pickup then
 			missiontype = "PICKUP_LOCAL"
 			reward = reward * pickup_factor
@@ -598,11 +376,13 @@ local makeAdvert = function (station)
 			nearbysystems = Game.system:GetNearbySystems(max_delivery_dist, function (s) return #s:GetStationPaths() > 0 end)
 		end
 		if #nearbysystems == 0 then return nil end
+
 		nearbysystem = nearbysystems[Engine.rand:Integer(1,#nearbysystems)]
 		dist = nearbysystem:DistanceTo(Game.system)
 		nearbystations = nearbysystem:GetStationPaths()
 		location = nearbystations[Engine.rand:Integer(1,#nearbystations)]
 		wholesaler = Engine.rand:Number(0, 1) > 0.75 and true or false
+
 		if wholesaler then
 			amount = Engine.rand:Integer(max_cargo, max_cargo_wholesaler)
 			missiontype = "WHOLESALER"
@@ -616,9 +396,11 @@ local makeAdvert = function (station)
 				missiontype = branch
 			end
 		end
+
 		risk = 0.75 * cargotype.price / max_price + Engine.rand:Number(0, 0.25) -- goods with price max_price have a risk of 0.75 to 1
 		reward = (dist / max_delivery_dist) * typical_reward * (1+risk) * (1.5+urgency) * (1+amount/max_cargo_wholesaler) * Engine.rand:Number(0.8,1.2)
 		due = (dist / max_delivery_dist) * typical_travel_time * (1.5 - urgency)
+
 		if pickup then
 			reward = reward * pickup_factor
 			due = due * pickup_factor + Game.time
@@ -630,11 +412,13 @@ local makeAdvert = function (station)
 
 	local n = getNumberOfFlavours("INTROTEXT_" .. missiontype)
 	local introtext
+
 	if n >= 1 then
 		introtext = "INTROTEXT_" .. missiontype .. "_" .. Engine.rand:Integer(1, n)
 	else
 		introtext = "INTROTEXT_" .. Engine.rand:Integer(1, getNumberOfFlavours("INTROTEXT"))
 	end
+
 	local ad = {
 		station       = station,
 		domicile      = station.path,
@@ -691,6 +475,7 @@ local onUpdateBB = function (station)
 			end
 		end
 	end
+
 	if Engine.rand:Integer(12*60*60) < 60*60 then -- roughly once every twelve hours
 		makeAdvert(station)
 	end
@@ -756,6 +541,7 @@ local onEnterSystem = function (player)
 					client = mission.client.name, location = mission.location:GetSystemBody().name,})
 				Comms.ImportantMessage(pirate_greeting, pirate.label)
 				pirate_gripes_time = Game.time
+
 				if mission.wholesaler or Engine.rand:Number(0, 1) >= 0.75 then
 					local shipdef = ShipDef[Game.system.faction.policeShip]
 					local escort = Space.SpawnShipNear(shipdef.id, Game.player, 50, 100)
@@ -764,6 +550,7 @@ local onEnterSystem = function (player)
 					escort:AddEquip(Equipment.misc.shield_generator)
 					escort:AIKill(pirate)
 					table.insert(escort_ships, escort)
+
 					Comms.ImportantMessage(l["ESCORT_CHATTER_" .. Engine.rand:Integer(1, getNumberOfFlavours("ESCORT_CHATTER"))], escort.label)
 					escort_chatter_time = Game.time
 					escort_switch_target = Game.time + Engine.rand:Integer(90, 120)
@@ -888,11 +675,17 @@ local onShipDocked = function (player, station)
 
 	-- First drop off cargo (if any such missions)
 	for ref,mission in pairs(missions) do
-		if (mission.location == station.path and not mission.pickup) or
-			(mission.domicile == station.path and mission.pickup and mission.cargo_picked_up) then
+		local readyToComplete = (mission.location == station.path and not mission.pickup) or
+			(mission.domicile == station.path and mission.pickup and mission.cargo_picked_up)
+
+		if readyToComplete then
+
 			local reputation = mission.localdelivery and 1 or 1.5
 			local oldReputation = Character.persistent.player.reputation
-			local amount = Game.player:RemoveEquip(mission.cargotype, mission.amount, "cargo")
+
+			---@type CargoManager
+			local cargoMgr = Game.player:GetComponent('CargoManager')
+			local amount = cargoMgr:RemoveCommodity(mission.cargotype, mission.amount)
 
 			if Game.time <= mission.due and amount == mission.amount then
 				local n = getNumberOfFlavours("SUCCESSMSG_" .. mission.branch)
@@ -901,6 +694,7 @@ local onShipDocked = function (player, station)
 				else
 					Comms.ImportantMessage(l["SUCCESSMSG_" .. Engine.rand:Integer(1, getNumberOfFlavours("SUCCESSMSG"))], mission.client.name)
 				end
+
 				Character.persistent.player.reputation = Character.persistent.player.reputation + reputation
 				player:AddMoney(mission.reward)
 			else
@@ -916,8 +710,10 @@ local onShipDocked = function (player, station)
 						Comms.ImportantMessage(l["FAILUREMSG_" .. Engine.rand:Integer(1, getNumberOfFlavours("FAILUREMSG"))], mission.client.name)
 					end
 				end
+
 				Character.persistent.player.reputation = Character.persistent.player.reputation - reputation
 			end
+
 			Event.Queue("onReputationChanged", oldReputation, Character.persistent.player.killcount,
 				Character.persistent.player.reputation, Character.persistent.player.killcount)
 
@@ -931,23 +727,34 @@ local onShipDocked = function (player, station)
 
 	-- Now we have space pick up cargo as well
 	for ref,mission in pairs(missions) do
-		if mission.location == station.path and mission.pickup and not mission.cargo_picked_up then
+		local readyToPickup = mission.location == station.path and mission.pickup and not mission.cargo_picked_up
+
+		if readyToPickup then
 			if Game.time < mission.due then
-				if (player.totalCargo - player.usedCargo) < mission.amount then
+
+				---@type CargoManager
+				local cargoMgr = Game.player:GetComponent('CargoManager')
+
+				if cargoMgr:GetFreeSpace() < mission.amount then
 					Comms.ImportantMessage(l.YOU_DO_NOT_HAVE_ENOUGH_EMPTY_CARGO_SPACE, mission.client.name)
 				else
-					Game.player:AddEquip(mission.cargotype, mission.amount, "cargo")
+					cargoMgr:AddCommodity(mission.cargotype, mission.amount);
 					mission.cargo_picked_up = true
 					Comms.ImportantMessage(l.WE_HAVE_LOADED_UP_THE_CARGO_ON_YOUR_SHIP, mission.client.name)
 				end
+
 			else
+
 				local oldReputation = Character.persistent.player.reputation
 				Character.persistent.player.reputation = Character.persistent.player.reputation - (mission.localdelivery and 1 or 1.5)
+
 				Comms.ImportantMessage(l.TOO_LATE_TO_PICK_UP, mission.client.name)
 				Event.Queue("onReputationChanged", oldReputation, Character.persistent.player.killcount,
 					Character.persistent.player.reputation, Character.persistent.player.killcount)
+
 				mission:Remove()
 				missions[ref] = nil
+
 			end
 		end
 	end

--- a/data/modules/CargoRun/CargoTypes.lua
+++ b/data/modules/CargoRun/CargoTypes.lua
@@ -1,0 +1,200 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local CommodityType = require 'CommodityType'
+
+-- the custom cargo
+local aluminium_tubes = CommodityType.RegisterCommodity("aluminium_tubes", {
+	l10n_key = 'ALUMINIUM_TUBES', price=50,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local art_objects = CommodityType.RegisterCommodity("art_objects", {
+	l10n_key = 'ART_OBJECTS', price=200,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local clus = CommodityType.RegisterCommodity("clus", {
+	l10n_key = 'CLUS', price=20,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local diamonds = CommodityType.RegisterCommodity("diamonds", {
+	l10n_key = 'DIAMONDS', price=300,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local digesters = CommodityType.RegisterCommodity("digesters", {
+	l10n_key = 'DIGESTERS', price=10,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local electrical_appliances = CommodityType.RegisterCommodity("electrical_appliances", {
+	l10n_key = 'ELECTRICAL_APPLIANCES', price=150,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local explosives = CommodityType.RegisterCommodity("explosives", {
+	l10n_key = 'EXPLOSIVES', price=50,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local furniture = CommodityType.RegisterCommodity("furniture", {
+	l10n_key = 'FURNITURE', price=15,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local greenhouses = CommodityType.RegisterCommodity("greenhouses", {
+	l10n_key = 'GREENHOUSES', price=20,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local hazardous_substances = CommodityType.RegisterCommodity("hazardous_substances", {
+	l10n_key = 'HAZARDOUS_SUBSTANCES', price=100,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local machine_tools = CommodityType.RegisterCommodity("machine_tools", {
+	l10n_key = 'MACHINE_TOOLS', price=10,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local neptunium = CommodityType.RegisterCommodity("neptunium", {
+	l10n_key = 'NEPTUNIUM', price=200,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local plutonium = CommodityType.RegisterCommodity("plutonium", {
+	l10n_key = 'PLUTONIUM', price=200,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local semi_finished_products = CommodityType.RegisterCommodity("semi_finished_products", {
+	l10n_key = 'SEMI_FINISHED_PRODUCTS', price=10,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local spaceship_parts = CommodityType.RegisterCommodity("spaceship_parts", {
+	l10n_key = 'SPACESHIP_PARTS', price=250,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local titanium = CommodityType.RegisterCommodity("titanium", {
+	l10n_key = 'TITANIUM', price=150,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local tungsten = CommodityType.RegisterCommodity("tungsten", {
+	l10n_key = 'TUNGSTEN', price=125,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local uranium = CommodityType.RegisterCommodity("uranium", {
+	l10n_key = 'URANIUM', price=175,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local quibbles = CommodityType.RegisterCommodity("quibbles", {
+	l10n_key = 'QUIBBLES', price=1,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local wedding_dresses = CommodityType.RegisterCommodity("wedding_dresses", {
+	l10n_key = 'WEDDING_DRESSES', price=15,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+local stem_bolts = CommodityType.RegisterCommodity("stem_bolts", {
+	l10n_key = 'STEM_BOLTS', price=143,
+	mass=1, purchasable=false,
+	l10n_resource="module-cargorun"
+})
+
+local chemical = {
+	digesters,
+	hazardous_substances
+}
+
+local mining = {
+	clus,
+	explosives
+}
+
+local hardware = {
+	aluminium_tubes,
+	diamonds,
+	hazardous_substances,
+	machine_tools,
+	neptunium,
+	plutonium,
+	semi_finished_products,
+	spaceship_parts,
+	stem_bolts,
+	titanium,
+	tungsten,
+	uranium
+}
+
+local infrastructure = {
+	clus,
+	explosives,
+	greenhouses
+}
+
+local consumer_goods = {
+	electrical_appliances,
+	furniture,
+	spaceship_parts
+}
+
+local expensive = { -- price >= 175
+	art_objects,
+	diamonds,
+	neptunium,
+	plutonium,
+	spaceship_parts,
+	uranium
+}
+
+local fluffy = {
+	quibbles
+}
+
+local wedding = {
+	wedding_dresses
+}
+
+local art = {
+	art_objects
+}
+
+local gems = {
+	diamonds
+}
+
+local radioactive = {
+	neptunium,
+	plutonium,
+	uranium
+}
+
+local centrifuges = {
+	aluminium_tubes
+}
+
+local custom_cargo = {
+	{ bkey = "CHEMICAL", goods = chemical, weight = 0 },
+	{ bkey = "MINING", goods = mining, weight = 0 },
+	{ bkey = "HARDWARE", goods = hardware, weight = 0 },
+	{ bkey = "INFRASTRUCTURE", goods = infrastructure, weight = 0 },
+	{ bkey = "CONSUMER_GOODS", goods = consumer_goods, weight = 0 },
+	{ bkey = "EXPENSIVE", goods = expensive, weight = 0 },
+	{ bkey = "FLUFFY", goods = fluffy, weight = 0 },
+	{ bkey = "WEDDING" , goods = wedding, weight = 0 },
+	{ bkey = "ART", goods = art, weight = 0 },
+	{ bkey = "GEMS", goods = gems, weight = 0 },
+	{ bkey = "RADIOACTIVE", goods = radioactive, weight = 0 },
+	{ bkey = "CENTRIFUGES", goods = centrifuges, weight = 0 }
+}
+
+return custom_cargo

--- a/data/modules/Debug/DebugCommodityPrices.lua
+++ b/data/modules/Debug/DebugCommodityPrices.lua
@@ -14,6 +14,7 @@ local Format = require 'Format'
 -- (local) Global options
 local radius = 20
 local N = 0
+local commodities = nil
 local include_illegal, changed = false, false
 
 

--- a/data/modules/Debug/DebugCommodityPrices.lua
+++ b/data/modules/Debug/DebugCommodityPrices.lua
@@ -8,8 +8,8 @@ local Engine = require "Engine"
 local Rand = require "Rand"
 local Format = require "Format"
 local debugView = require 'pigui.views.debug'
-local e = require "Equipment"
 local Format = require 'Format'
+local Commodities = require 'Commodities'
 
 -- (local) Global options
 local radius = 20
@@ -171,21 +171,21 @@ local scan_systems = function(dist)
 	-- for each system
 	for idx, sys in pairs(nearby_systems) do
 		-- for each commodity
-		for key, equip in pairs(e.cargo) do
-			-- table.sort(equip, function (a,b) return a:GetName() > b:GetName() end)
+		for key, comm in pairs(Commodities) do
+			-- table.sort(comm, function (a,b) return a:GetName() > b:GetName() end)
 
 			-- include goods if legal, or if we've chosen to include it
-			local include = include_illegal or sys:IsCommodityLegal(equip.name)
+			local include = include_illegal or sys:IsCommodityLegal(comm.name)
 
 			-- TODO: also include negative products, right?
-			-- if equip.price > 0 then
+			-- if comm.price > 0 then
 
-				local name = equip:GetName()
-				local price = getprice(equip, sys)
+				local name = comm:GetName()
+				local price = getprice(comm, sys)
 
 				if not commodities[name] then
-					commodities[name] = Commodity:new(name, equip.price)
-					print(name, equip.price)
+					commodities[name] = Commodity:new(name, comm.price)
+					print(name, comm.price)
 				end
 
 				-- if interesting, get name, and check price

--- a/data/modules/Debug/DebugRPG.lua
+++ b/data/modules/Debug/DebugRPG.lua
@@ -107,6 +107,7 @@ debugView.registerTab("RPG-debug-view", function()
 		-- Load up on commodities
 		if ui.collapsingHeader("Cargo", {}) then  -- {"OpenOnDoubleClick"}
 
+			---@type CargoManager
 			local cargoMgr = Game.player:GetComponent('CargoManager')
 			local free_space = cargoMgr:GetFreeSpace()
 

--- a/data/modules/Debug/DebugRPG.lua
+++ b/data/modules/Debug/DebugRPG.lua
@@ -5,6 +5,7 @@ local Game = require 'Game'
 local Format = require "Format"
 local ui = require 'pigui'
 local debugView = require 'pigui.views.debug'
+local Commodities = require 'Commodities'
 local amount = 1000
 local selected = 0
 
@@ -21,18 +22,20 @@ end
 
 local Character = require "Character"
 
-local Equipment = require 'Equipment'
-local ci = 0
-
 local commodities = {}
 local commodities_name = {}
 local selected_commodity = 0
 local cargo_amount = 0
-local changed_commodity = false
+
 local get_commodities = function()
-	for key, equip in pairs(Equipment.cargo) do
-		table.insert(commodities, equip)
-		table.insert(commodities_name, equip:GetName())
+	for _, commodity in pairs(Commodities) do
+		table.insert(commodities, commodity)
+	end
+
+	table.sort(commodities, function(a, b) return a:GetName() < b:GetName() end)
+
+	for _, commodity in ipairs(commodities) do
+		table.insert(commodities_name, commodity:GetName())
 	end
 end
 
@@ -69,7 +72,6 @@ debugView.registerTab("RPG-debug-view", function()
 
 		local rows = 10
 		if ui.collapsingHeader("Crime", {}) then
-			local changed, ret = 0
 
 			ui.text("ADD CRIMINAL CHARGES:")
 			local selected_crime = 0
@@ -104,27 +106,26 @@ debugView.registerTab("RPG-debug-view", function()
 
 		-- Load up on commodities
 		if ui.collapsingHeader("Cargo", {}) then  -- {"OpenOnDoubleClick"}
-			-- to do: max cargo space
-			cargo_amount = ui.sliderInt("##CommodityAmount", cargo_amount, 0, 100)
+
+			local cargoMgr = Game.player:GetComponent('CargoManager')
+			local free_space = cargoMgr:GetFreeSpace()
+
+			ui.nextItemWidth(-1.0)
+			cargo_amount = ui.sliderInt("##CommodityAmount", math.min(cargo_amount, free_space), 0, free_space)
 
 			if #commodities == 0 then
 				get_commodities()
 			end
 
-			changed_commodity, commodity_idx = ui.combo("Commodities", selected_commodity, commodities_name)
-
-			if changed_commodity then
-				selected_commodity = commodity_idx
-				ci = selected_commodity + 1
+			if ui.button("Buy commodity") then
+				cargoMgr:AddCommodity(commodities[selected_commodity + 1], cargo_amount)
 			end
-			ui.text("Selected comodity index " ..selected_commodity)
 
-			if ui.button("Buy commodity", Vector2(100, 0)) then
-				print(commodities, ci)            -- when ci=0
-				print(commodities[ci])			  -- and this is nil, next line crashes. If nothing has been selected?
-				print(commodities[ci]:GetName())
-				Game.player:AddEquip(commodities[ci], cargo_amount, "cargo")
-			end
+			ui.sameLine()
+			ui.nextItemWidth(-1.0)
+
+			local _
+			_, selected_commodity = ui.combo("##Commodities", selected_commodity, commodities_name)
 
 		end
 

--- a/data/modules/FuelClub/FuelClub.lua
+++ b/data/modules/FuelClub/FuelClub.lua
@@ -9,9 +9,9 @@ local Event = require 'Event'
 local Character = require 'Character'
 local Format = require 'Format'
 local Serializer = require 'Serializer'
-local Equipment = require 'Equipment'
 local ModalWindow = require 'pigui.libs.modal-win'
 local ui = require 'pigui'
+local Commodities = require 'Commodities'
 
 local rescaleVector = ui.rescaleUI(Vector2(1, 1), Vector2(1600, 900), true)
 local popupSpacer = Vector2(0,0)
@@ -122,49 +122,39 @@ onChat = function (form, ref, option)
 	local membership = memberships[ad.flavour.clubname]
 
 	if option == 0 and membership and (membership.joined + membership.expiry > Game.time) then
+		local saleables = {
+			[Commodities.hydrogen] = 0.5,       -- half price Hydrogen
+			[Commodities.military_fuel] = 0.80, -- 20% off Milfuel
+			[Commodities.radioactives] = 0.0    -- Radioactives go free
+		}
+
 		-- members get the trader interface
-		form:SetMessage(string.interp(ad.flavour.member_intro, {radioactives=Equipment.cargo.radioactives:GetName()}))
+		form:SetMessage(string.interp(ad.flavour.member_intro, {radioactives=Commodities.radioactives:GetName()}))
 		form:AddGoodsTrader({
 			canTrade = function (ref, commodity)
-				return ({
-					[Equipment.cargo.hydrogen] = true,
-					[Equipment.cargo.military_fuel] = true,
-					[Equipment.cargo.radioactives] = true
-				})[commodity]
+				return saleables[commodity] and true or false
 			end,
 			canDisplayItem = function (ref, commodity)
-				return ({
-					[Equipment.cargo.hydrogen] = true,
-					[Equipment.cargo.military_fuel] = true,
-					[Equipment.cargo.radioactives] = true
-				})[commodity]
+				return saleables[commodity] and true or false
 			end,
 			getStock = function (ref, commodity)
-				local prev = ad.stock[commodity]
+				local prev = ad.stock[commodity.name]
 				if prev then
 					return prev
 				end
-				if commodity == Equipment.cargo.radioactives then
-					ad.stock[commodity] = 0
+				if commodity == Commodities.radioactives then
+					ad.stock[commodity.name] = 0
 					return 0
 				end
-				local cur = Engine.rand:Integer(2, (commodity == Equipment.cargo.military_fuel and 25 or 50)) + Engine.rand:Integer(3, 25)
-				ad.stock[commodity] = cur
+				local cur = Engine.rand:Integer(2, (commodity == Commodities.military_fuel and 25 or 50)) + Engine.rand:Integer(3, 25)
+				ad.stock[commodity.name] = cur
 				return cur
 			end,
 			getBuyPrice = function (ref, commodity)
-				return ad.station:GetEquipmentPrice(commodity) * ({
-					[Equipment.cargo.hydrogen] = 0.5, -- half price Hydrogen
-					[Equipment.cargo.military_fuel] = 0.80, -- 20% off Milfuel
-					[Equipment.cargo.radioactives] = 0, -- Radioactives go free
-				})[commodity]
+				return ad.station:GetCommodityPrice(commodity) * saleables[commodity]
 			end,
 			getSellPrice = function (ref, commodity)
-				return ad.station:GetEquipmentPrice(commodity) * ({
-					[Equipment.cargo.hydrogen] = 0.5, -- half price Hydrogen
-					[Equipment.cargo.military_fuel] = 0.80, -- 20% off Milfuel
-					[Equipment.cargo.radioactives] = 0, -- Radioactives go free
-				})[commodity]
+				return ad.station:GetCommodityPrice(commodity) * saleables[commodity]
 			end,
 			-- Next two functions: If your membership is nearly up, you'd better
 			-- trade quickly, because we do check!
@@ -178,10 +168,10 @@ onChat = function (form, ref, option)
 					count = market.tradeAmount
 				end
 
-				if (commodity == Equipment.cargo.radioactives and membership.milrads < count) then
+				if (commodity == Commodities.radioactives and membership.milrads < count) then
 					popupMsg = string.interp(l.YOU_MUST_BUY, {
-						military_fuel = Equipment.cargo.military_fuel:GetName(),
-						radioactives = Equipment.cargo.radioactives:GetName(),
+						military_fuel = Commodities.military_fuel:GetName(),
+						radioactives = Commodities.radioactives:GetName(),
 					})
 					popup:open()
 					return false
@@ -194,8 +184,8 @@ onChat = function (form, ref, option)
 					count = market.tradeAmount
 				end
 
-				ad.stock[commodity] = ad.stock[commodity] - count
-				if commodity == Equipment.cargo.radioactives or commodity == Equipment.cargo.military_fuel then
+				ad.stock[commodity.name] = ad.stock[commodity.name] - count
+				if commodity == Commodities.radioactives or commodity == Commodities.military_fuel then
 					membership.milrads = membership.milrads + count
 				end
 			end,
@@ -205,8 +195,8 @@ onChat = function (form, ref, option)
 					count = market.tradeAmount
 				end
 
-				ad.stock[commodity] = ad.stock[commodity] + count
-				if commodity == Equipment.cargo.radioactives or commodity == Equipment.cargo.military_fuel then
+				ad.stock[commodity.name] = ad.stock[commodity.name] + count
+				if commodity == Commodities.radioactives or commodity == Commodities.military_fuel then
 					membership.milrads = membership.milrads - count
 				end
 			end,
@@ -223,8 +213,8 @@ onChat = function (form, ref, option)
 	elseif option == 1 then
 		-- Player asked the question about radioactives
 		form:SetMessage(string.interp(l.WE_WILL_ONLY_DISPOSE_OF, {
-						military_fuel = Equipment.cargo.military_fuel:GetName(),
-						radioactives = Equipment.cargo.radioactives:GetName()}))
+						military_fuel = Commodities.military_fuel:GetName(),
+						radioactives = Commodities.radioactives:GetName()}))
 		form:AddOption(l.APPLY_FOR_MEMBERSHIP,2)
 		form:AddOption(lc.GO_BACK,0)
 
@@ -268,14 +258,14 @@ onChat = function (form, ref, option)
 		-- non-members get offered membership
 		local message = ad.flavour.nonmember_intro:interp({clubname=ad.flavour.clubname}).."\n"..
 			"\n\t* " ..l.LIST_BENEFITS_FUEL_INTRO..
-			"\n\t* "..string.interp(l.LIST_BENEFITS_FUEL, {fuel=Equipment.cargo.hydrogen:GetName()})..
-			"\n\t* "..string.interp(l.LIST_BENEFITS_FUEL, {fuel=Equipment.cargo.military_fuel:GetName()})..
-			"\n\t* "..string.interp(l.LIST_BENEFITS_DISPOSAL, {radioactives=Equipment.cargo.radioactives:GetName()})..
+			"\n\t* "..string.interp(l.LIST_BENEFITS_FUEL, {fuel=Commodities.hydrogen:GetName()})..
+			"\n\t* "..string.interp(l.LIST_BENEFITS_FUEL, {fuel=Commodities.military_fuel:GetName()})..
+			"\n\t* "..string.interp(l.LIST_BENEFITS_DISPOSAL, {radioactives=Commodities.radioactives:GetName()})..
 			"\n\t* "..l.LIST_BENEFITS_FUEL_TANK..
 			"\n\n"  ..string.interp(l.LIST_BENEFITS_JOIN, {membership_fee=Format.Money(ad.flavour.annual_fee)})
 
 		form:SetMessage(message)
-		form:AddOption(l.WHAT_CONDITIONS_APPLY:interp({radioactives = Equipment.cargo.radioactives:GetName()}),1)
+		form:AddOption(l.WHAT_CONDITIONS_APPLY:interp({radioactives = Commodities.radioactives:GetName()}),1)
 		form:AddOption(l.APPLY_FOR_MEMBERSHIP,2)
 	end
 end
@@ -362,4 +352,3 @@ Event.Register("onShipUndocked", onShipUndocked)
 Event.Register("onGameStart", onGameStart)
 
 Serializer:Register("FuelClub", serialize, unserialize)
-

--- a/data/modules/FuelScoop.lua
+++ b/data/modules/FuelScoop.lua
@@ -1,0 +1,36 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Event       = require 'Event'
+local Commodities = require 'Commodities'
+local Game        = require 'Game'
+local Lang        = require 'Lang'
+
+local lc = Lang.GetResource("core")
+
+-- Utility functions to handle fuel and cargo scooping.
+-- These callbacks are triggered from C++ or Lua and are responsible for
+-- providing UI feedback about the scooping process.
+
+Event.Register("onShipScoopFuel", function(ship, body)
+	---@type CargoManager
+	local cargoMgr = ship:GetComponent('CargoManager')
+
+	cargoMgr:AddCommodity(Commodities.hydrogen, 1)
+
+	if ship == Game.player then
+		Game.AddCommsLogLine(lc.FUEL_SCOOP_ACTIVE_N_TONNES_H_COLLECTED:gsub('%%quantity',
+			cargoMgr:CountCommodity(Commodities.hydrogen)))
+	end
+end)
+
+Event.Register("onShipScoopCargo", function (ship, success, cargoType)
+	if ship ~= Game.player then return end
+
+	if success then
+		Game.AddCommsLogLine(lc.CARGO_SCOOP_ACTIVE_1_TONNE_X_COLLECTED:gsub('%%item',
+			cargoType:GetName()))
+	else
+		Game.AddCommsLogLine(lc.CARGO_SCOOP_ATTEMPTED)
+	end
+end)

--- a/data/modules/GoodsTrader/GoodsTrader.lua
+++ b/data/modules/GoodsTrader/GoodsTrader.lua
@@ -8,8 +8,8 @@ local Event = require 'Event'
 local NameGen = require 'NameGen'
 local Rand = require 'Rand'
 local Serializer = require 'Serializer'
-local Equipment = require 'Equipment'
 local Character = require 'Character'
+local Commodities = require 'Commodities'
 
 local l = Lang.GetResource("module-goodstrader")
 
@@ -111,7 +111,7 @@ end
 
 local onCreateBB = function (station)
 	local has_illegal_goods = false
-	for key in pairs(Equipment.cargo) do
+	for key in pairs(Commodities) do
 		if not Game.system:IsCommodityLegal(key) then
 			has_illegal_goods = true
 		end
@@ -153,11 +153,11 @@ local onCreateBB = function (station)
 
 			ad.stock = {}
 			ad.price = {}
-			for key, e in pairs(Equipment.cargo) do
+			for key, comm in pairs(Commodities) do
 				if not Game.system:IsCommodityLegal(key) then
-					ad.stock[e] = Engine.rand:Integer(1,50)
+					ad.stock[comm] = Engine.rand:Integer(1,50)
 					-- going rate on the black market will be twice normal
-					ad.price[e] = ad.station:GetEquipmentPrice(e) * 2
+					ad.price[comm] = ad.station:GetCommodityPrice(comm) * 2
 				end
 			end
 

--- a/data/modules/LifeSupport.lua
+++ b/data/modules/LifeSupport.lua
@@ -1,0 +1,53 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Commodities = require 'Commodities'
+local Game        = require 'Game'
+local Engine      = require 'Engine'
+local Event       = require 'Event'
+local Timer       = require 'Timer'
+
+local lc = require 'Lang'.GetResource("core")
+
+local function LifeSupportCallback(self)
+	if not self:exists() then return false end
+
+	if self:GetDockedWith() then
+		return true
+	end
+
+	---@type CargoManager
+	local cargoMgr = self:GetComponent('CargoManager')
+
+	local commodityName = cargoMgr:DoLifeSupportChecks(self.cargo_bay_life_support_cap or 0)
+	if commodityName then
+		cargoMgr:RemoveCommodity(Commodities[commodityName], 1)
+
+		if self == Game.player then
+			Game.AddCommsLogLine(lc.CARGO_BAY_LIFE_SUPPORT_LOST)
+		end
+	end
+
+	if self == Game.player then
+		Engine.RequestProfileFrame()
+	end
+
+	return true
+end
+
+-- TODO: this can be massively improved as far as performance goes; it should
+-- only start the timer when a ship is undocked with perishable cargo on board,
+-- and cancel the timer when the ship redocks.
+--
+-- Currently, performance in the average case is quite respectable: a typical
+-- load of ~200us on a decently old machine with 400+ ships.
+-- Updating LuaTimer to have less overhead while checking for time expiration
+-- would also help optimize this.
+Event.Register('onShipCreated', function (ship)
+	-- Many ships can be created during the same frame (by e.g. Tradeships)
+	-- so distribute timer callback load over the full 5s to avoid massive
+	-- single-frame spikes where every ship is processed at once
+	Timer:CallAt(Game.time + 5.0 * Engine.rand:Number(), function()
+		Timer:CallEvery(5.0, function() LifeSupportCallback(ship) end)
+	end)
+end)

--- a/data/modules/Mining.lua
+++ b/data/modules/Mining.lua
@@ -1,23 +1,23 @@
 local Player = package.core["Player"]
 local Engine = require 'Engine'
-local Equipment = require 'Equipment'
+local Commodities = require 'Commodities'
 
 function Player:SpawnMiningContainer(body)
 	-- this function is called from C++ when a mining laser shot hits the surface of an asteroid body and chips off a peice
 	-- body is a valid SystemBody object
-	-- return value needs to be a valid Equipment.cargo.* object
+	-- return value needs to be a valid CommodityType object
 
 	local r = Engine.rand:Number()
 	local m = body.metallicity
 
 	if (r*20 < m) then
-		return Equipment.cargo.precious_metals
+		return Commodities.precious_metals
 	elseif (r*8 < m) then
-		return Equipment.cargo.metal_alloys
+		return Commodities.metal_alloys
 	elseif r < m then
-		return Equipment.cargo.metal_ore
+		return Commodities.metal_ore
 	elseif r < 0.5 then
-		return Equipment.cargo.carbon_ore
+		return Commodities.carbon_ore
 	end
-	return Equipment.cargo.rubbish
+	return Commodities.rubbish
 end

--- a/data/modules/Mining.lua
+++ b/data/modules/Mining.lua
@@ -1,3 +1,6 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
 local Player = package.core["Player"]
 local Engine = require 'Engine'
 local Commodities = require 'Commodities'

--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -121,15 +121,6 @@ for i = 1,#flavours do
 	local f = flavours[i]
 	f.headline = l["FLAVOUR_" .. i-1 .. "_HEADLINE"]
 	f.newsbody = l["FLAVOUR_" .. i-1 .. "_NEWSBODY"]
-
-	-- make sure future changes to Equipment won't break this module:
-	local is_valid = false
-	for key, e in pairs(Equipment.cargo) do
-		if key == f.cargo then
-			is_valid = true
-		end
-	end
-	assert(is_valid)
 end
 
 -- will hold the ads of the current system
@@ -419,17 +410,6 @@ end
 
 local unserialize = function (data)
 	loadedData = data
-
-	-- Saves are backwards compatible with new format, where we save
-	-- cargo string, instead of EquipType object (memory address)
-	-- (remove in a year or so)
-	if data.news then
-		for key, value in pairs(data.news) do
-			if type(value.cargo) == 'table' then
-				value.cargo = value.cargo.name
-			end
-		end
-	end
 end
 
 Event.Register("onCreateBB", onCreateBB)

--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -22,6 +22,7 @@ local Game = require 'Game'
 local Event = require 'Event'
 local Format = require 'Format'
 local Serializer = require 'Serializer'
+local Commodities = require 'Commodities'
 local Equipment = require 'Equipment'
 
 local l = Lang.GetResource("module-newseventcommodity")
@@ -40,76 +41,76 @@ local maxIndexOfGreetings = 5
 
 local flavours = {
 	{                                           -- flavour 0 in en.json
-		cargo = Equipment.cargo.medicines.name, -- which commodity is affected
+		cargo = Commodities.medicines.name, -- which commodity is affected
 		demand = 4,                             -- change in price (and stock)
 	}, {
-		cargo = Equipment.cargo.battle_weapons.name,       --1
+		cargo = Commodities.battle_weapons.name,       --1
 		demand = 4,
 	}, {
-		cargo = Equipment.cargo.grain.name,                --2
+		cargo = Commodities.grain.name,                --2
 		demand = 10,
 	}, {
-		cargo = Equipment.cargo.fruit_and_veg.name,        --3
+		cargo = Commodities.fruit_and_veg.name,        --3
 		demand = 6,
 	}, {
-		cargo = Equipment.cargo.narcotics.name,            --4
+		cargo = Commodities.narcotics.name,            --4
 		demand = -4,
 	}, {
-		cargo = Equipment.cargo.slaves.name,               --5
+		cargo = Commodities.slaves.name,               --5
 		demand = 7,
 	}, {
-		cargo = Equipment.cargo.liquor.name,               --6
+		cargo = Commodities.liquor.name,               --6
 		demand = 3,
 	}, {
-		cargo = Equipment.cargo.industrial_machinery.name, --7
+		cargo = Commodities.industrial_machinery.name, --7
 		demand = 6,
 	}, {
-		cargo = Equipment.cargo.mining_machinery.name,     --8
+		cargo = Commodities.mining_machinery.name,     --8
 		demand = 6,
 	}, {
-		cargo = Equipment.cargo.live_animals.name,         --9
+		cargo = Commodities.live_animals.name,         --9
 		demand = 3,
 	}, {
-		cargo = Equipment.cargo.air_processors.name,       --10
+		cargo = Commodities.air_processors.name,       --10
 		demand = 5,
 	}, {
-		cargo = Equipment.cargo.animal_meat.name,          --11
+		cargo = Commodities.animal_meat.name,          --11
 		demand = 3,
 	}, {
-		cargo = Equipment.cargo.computers.name,            --12
+		cargo = Commodities.computers.name,            --12
 		demand = 3,
 	}, {
-		cargo = Equipment.cargo.robots.name,               --13
+		cargo = Commodities.robots.name,               --13
 		demand = -4,
 	}, {
-		cargo = Equipment.cargo.plastics.name,             --14
+		cargo = Commodities.plastics.name,             --14
 		demand = 3,
 	}, {
-		cargo = Equipment.cargo.narcotics.name,            --15
+		cargo = Commodities.narcotics.name,            --15
 		demand = 4,
 	}, {
-		cargo = Equipment.cargo.farm_machinery.name,       --16
+		cargo = Commodities.farm_machinery.name,       --16
 		demand = 5,
 	}, {
-		cargo = Equipment.cargo.metal_ore.name,            --17
+		cargo = Commodities.metal_ore.name,            --17
 		demand = -10,
 	}, {
-		cargo = Equipment.cargo.consumer_goods.name,       --18
+		cargo = Commodities.consumer_goods.name,       --18
 		demand = 3,
 	}, {
-		cargo = Equipment.cargo.precious_metals.name,      --19
+		cargo = Commodities.precious_metals.name,      --19
 		demand = -3,
 	}, {
-		cargo = Equipment.cargo.fertilizer.name,           --20
+		cargo = Commodities.fertilizer.name,           --20
 		demand = -3,
 	}, {
-		cargo = Equipment.cargo.nerve_gas.name,            --21
+		cargo = Commodities.nerve_gas.name,            --21
 		demand = -4,
 	}, {
-		cargo = Equipment.cargo.hand_weapons.name,         --22
+		cargo = Commodities.hand_weapons.name,         --22
 		demand = 3,
 	}, {
-		cargo = Equipment.cargo.metal_alloys.name,         --23
+		cargo = Commodities.metal_alloys.name,         --23
 		demand = 3,
 	}
 }
@@ -243,7 +244,7 @@ local createNewsEvent = function (timeInHyper)
 	-- add headline from flavour, and more info to be displayed
 	newsEvent.description = string.interp(flavours[flavour].headline, {
 		system = system.name,
-		cargo = Equipment.cargo[cargo]:GetName(),
+		cargo = Commodities[cargo]:GetName(),
 		-- Turn string "23:09:27 3 Jan 3200" into "3 Jan 3200:"
 		date  = Format.DateOnly(date),
 	})
@@ -350,15 +351,16 @@ local onShipDocked = function (ship, station)
 		-- if this is the system of the news
 		if currentSystem:IsSameSystem(n.syspath) then
 			-- send a grateful greeting from the station if the player cargo is right
-			local cargo_item = Equipment.cargo[n.cargo]
-			if ship:CountEquip(cargo_item, "cargo") > 0 and n.demand > 0 then
+			local cargo_item = Commodities[n.cargo]
+
+			if ship:GetComponent('CargoManager'):CountCommodity(cargo_item) > 0 and n.demand > 0 then
 				local greeting = string.interp(l["GRATEFUL_GREETING_"..Engine.rand:Integer(0,maxIndexOfGreetings)],
 					{cargo = cargo_item:GetName()})
 				Comms.Message(greeting)
 			end
 
-			local price = station:GetEquipmentPrice(cargo_item)
-			local stock = station:GetEquipmentStock(cargo_item)
+			local price = station:GetCommodityPrice(cargo_item)
+			local stock = station:GetCommodityStock(cargo_item)
 
 			local newPrice, newStockChange
 			if n.demand > 0 then
@@ -371,8 +373,8 @@ local onShipDocked = function (ship, station)
 				error("demand should probably not be 0.")
 			end
 			-- print("--- NewsEvent: cargo:", cargo_item:GetName(), "price:", newPrice, "stock:", newStockChange)
-			station:SetEquipmentPrice(cargo_item, newPrice)
-			station:AddEquipmentStock(cargo_item, newStockChange)
+			station:SetCommodityPrice(cargo_item, newPrice)
+			station:AddCommodityStock(cargo_item, newStockChange)
 		end
 	end
 end

--- a/data/modules/PolicePatrol/PolicePatrol.lua
+++ b/data/modules/PolicePatrol/PolicePatrol.lua
@@ -12,6 +12,7 @@ local Serializer = require 'Serializer'
 local Equipment = require 'Equipment'
 local ShipDef = require 'ShipDef'
 local Timer = require 'Timer'
+local Commodities = require 'Commodities'
 
 local l = Lang.GetResource("module-policepatrol")
 local l_ui_core = Lang.GetResource("ui-core")
@@ -32,8 +33,8 @@ end
 local hasIllegalGoods = function (cargo)
 	local illegal = false
 
-	for _, e in pairs(cargo) do
-		if not Game.system:IsCommodityLegal(e.name) then
+	for name in pairs(cargo) do
+		if not Game.system:IsCommodityLegal(name) then
 			illegal = true
 			break
 		end
@@ -114,7 +115,7 @@ local onJettison = function (ship, cargo)
 	if not ship:IsPlayer() or Game.system:IsCommodityLegal(cargo.name) then return end
 
 	if #patrol > 0 and showMercy then
-		local manifest = ship:GetEquip("cargo")
+		local manifest = ship:GetComponent('CargoManager').commodities
 		if not hasIllegalGoods(manifest) then
 			Comms.ImportantMessage(l.TAKE_A_HIKE, patrol[1].label)
 			piracy = false
@@ -128,7 +129,7 @@ end
 local onEnterSystem = function (player)
 	if not player:IsPlayer() then return end
 
-	if not hasIllegalGoods(Equipment.cargo) then return end
+	if not hasIllegalGoods(Commodities) then return end
 
 	local system = Game.system
 	if (1 - system.lawlessness) < Engine.rand:Number(4) then return end
@@ -156,7 +157,8 @@ local onEnterSystem = function (player)
 			Comms.ImportantMessage(l["INITIATE_CARGO_SCAN_" .. Engine.rand:Integer(1, getNumberOfFlavours("INITIATE_CARGO_SCAN"))], ship.label)
 			Timer:CallAt(Game.time + Engine.rand:Integer(3, 9), function ()
 				if not Game.system then return end -- Shut up when the player is already in hyperspace
-				local manifest = player:GetEquip("cargo")
+
+				local manifest = player:GetComponent('CargoManager').commodities
 				if hasIllegalGoods(manifest) then
 					Comms.ImportantMessage(l.ILLEGAL_GOODS_DETECTED, ship.label)
 					attackShip(player)

--- a/data/modules/Rondel/Rondel.lua
+++ b/data/modules/Rondel/Rondel.lua
@@ -13,9 +13,9 @@ local Equipment = require 'Equipment'
 local ShipDef = require 'ShipDef'
 local SystemPath = require 'SystemPath'
 local Timer = require 'Timer'
+local Commodities = require 'Commodities'
 
 --local Character = require 'Character'
-local cargo = Equipment.cargo
 
 local l_rondel = Lang.GetResource("module-rondel")
 local l_ui_core = Lang.GetResource("ui-core")
@@ -143,7 +143,7 @@ local onEnterSystem = function (player)
 
 	local tolerance = 1
 	local hyperdrive = Game.player:GetEquip('engine',1)
-	if hyperdrive.fuel == cargo.military_fuel then
+	if hyperdrive.fuel == Commodities.military_fuel then
 		tolerance = 0.5
 	end
 

--- a/data/modules/Rondel/Rondel.lua
+++ b/data/modules/Rondel/Rondel.lua
@@ -5,7 +5,6 @@ local Engine = require 'Engine'
 local Lang = require 'Lang'
 local Game = require 'Game'
 local Space = require 'Space'
-local cargo = require 'Commodities'
 local Comms = require 'Comms'
 local Event = require 'Event'
 local Legal = require 'Legal'
@@ -16,6 +15,7 @@ local SystemPath = require 'SystemPath'
 local Timer = require 'Timer'
 
 --local Character = require 'Character'
+local cargo = Equipment.cargo
 
 local l_rondel = Lang.GetResource("module-rondel")
 local l_ui_core = Lang.GetResource("ui-core")

--- a/data/modules/Scoop/Scoop.lua
+++ b/data/modules/Scoop/Scoop.lua
@@ -16,6 +16,9 @@ local Character = require 'Character'
 local Equipment = require 'Equipment'
 local Serializer = require 'Serializer'
 
+local CommodityType = require 'CommodityType'
+local Commodities   = require 'Commodities'
+
 local utils = require 'utils'
 
 local l = Lang.GetResource("module-scoop")
@@ -32,83 +35,69 @@ local max_dist = 20 * AU
 local ads = {}
 local missions = {}
 
-local rescue_capsule = Equipment.EquipType.New({
-	name = "rescue_capsule",
+local rescue_capsule = CommodityType.RegisterCommodity("rescue_capsule", {
 	l10n_key = "RESCUE_CAPSULE",
 	l10n_resource = "module-scoop",
-	slots = "cargo",
 	price = 500,
 	icon_name = "Default",
 	model_name = "escape_pod",
-	capabilities = { mass = 1, crew = 1 },
+	mass = 1,
 	purchasable = false
 })
 
-local rocket_launchers = Equipment.EquipType.New({
-	name = "rocket_launchers",
+local rocket_launchers = CommodityType.RegisterCommodity("rocket_launchers", {
 	l10n_key = "ROCKET_LAUNCHERS",
 	l10n_resource = "module-scoop",
-	slots = "cargo",
 	price = 500,
 	icon_name = "Default",
-	capabilities = { mass = 1 },
+	mass = 1,
 	purchasable = false
 })
 
-local detonators = Equipment.EquipType.New({
-	name = "detonators",
+local detonators = CommodityType.RegisterCommodity("detonators", {
 	l10n_key = "DETONATORS",
 	l10n_resource = "module-scoop",
-	slots = "cargo",
 	price = 250,
 	icon_name = "Default",
-	capabilities = { mass = 1 },
+	mass = 1,
 	purchasable = false
 })
 
-local nuclear_missile = Equipment.EquipType.New({
-	name = "nuclear_missile",
+local nuclear_missile = CommodityType.RegisterCommodity("nuclear_missile", {
 	l10n_key = "NUCLEAR_MISSILE",
 	l10n_resource = "module-scoop",
-	slots = "cargo",
 	price = 1250,
 	icon_name = "Default",
 	model_name = "missile",
-	capabilities = { mass = 1 },
+	mass = 1,
 	purchasable = false
 })
 
 -- Useless waste that the player has to sort out
-local toxic_waste = Equipment.EquipType.New({
-	name = "toxic_waste",
+local toxic_waste = CommodityType.RegisterCommodity("toxic_waste", {
 	l10n_key = "TOXIC_WASTE",
 	l10n_resource = "module-scoop",
-	slots = "cargo",
 	price = -50,
 	icon_name = "Default",
-	capabilities = { mass = 1 },
+	mass = 1,
 	purchasable = false
 })
 
-local spoiled_food = Equipment.EquipType.New({
-	name = "spoiled_food",
+local spoiled_food = CommodityType.RegisterCommodity("spoiled_food", {
 	l10n_key = "SPOILED_FOOD",
 	l10n_resource = "module-scoop",
-	slots = "cargo",
 	price = -10,
 	icon_name = "Default",
-	capabilities = { mass = 1 },
+	mass = 1,
 	purchasable = false
 })
 
-local unknown = Equipment.EquipType.New({
-	name = "unknown",
+local unknown = CommodityType.RegisterCommodity("unknown", {
 	l10n_key = "UNKNOWN",
 	l10n_resource = "module-scoop",
-	slots = "cargo",
 	price = -5,
 	icon_name = "Default",
-	capabilities = { mass = 1 },
+	mass = 1,
 	purchasable = false
 })
 
@@ -126,8 +115,8 @@ local waste = {
 	toxic_waste,
 	spoiled_food,
 	unknown,
-	Equipment.cargo.radioactives,
-	Equipment.cargo.rubbish
+	Commodities.radioactives,
+	Commodities.rubbish
 }
 
 local flavours = {
@@ -315,11 +304,16 @@ local transferCargo = function (mission, ref)
 
 		if Game.player:DistanceTo(mission.client_ship) <= 100 then
 
+			---@type CargoManager
+			local cargoMgr = Game.player:GetComponent('CargoManager')
+			---@type CargoManager
+			local clientCargo = mission.client_ship:GetComponent('CargoManager')
+
 			-- unload mission cargo
 			for i, e in pairs(mission.debris) do
 				if e.body == nil then
-					if Game.player:RemoveEquip(e.cargo, 1, "cargo") == 1 then
-						mission.client_ship:AddEquip(e.cargo, 1, "cargo")
+					if cargoMgr:RemoveCommodity(e.cargo, 1) == 1 then
+						clientCargo:AddCommodity(e.cargo, 1)
 						mission.debris[i] = nil
 						mission.amount = mission.amount - 1
 					end
@@ -475,7 +469,7 @@ local makeAdvert = function (station)
 	if #planets == 0 then return end
 
 	if flavours[LEGAL].cargo_type == nil then
-		flavours[LEGAL].cargo_type, flavours[ILLEGAL].cargo_type = sortGoods(Equipment.cargo)
+		flavours[LEGAL].cargo_type, flavours[ILLEGAL].cargo_type = sortGoods(Commodities)
 	end
 
 	local stars = Game.system:GetStars()
@@ -543,13 +537,14 @@ local onUpdateBB = function (station)
 	end
 end
 
-local onShipEquipmentChanged = function (ship, equipment)
-	if not ship:IsPlayer() or equipment == nil or equipment:GetDefaultSlot() ~= "cargo" then return end
+-- 0..25% chance for police to notice you scooping illegal cargo
+local onPlayerCargoChanged = function (comm, amount)
+	if Game.system:IsCommodityLegal(comm.name) or Game.player:IsDocked() then return end
 
 	for ref, mission in pairs(missions) do
-		if not mission.police and not Game.system:IsCommodityLegal(equipment.name) and not ship:IsDocked() and mission.location:IsSameSystem(Game.system.path) then
+		if not mission.police and mission.location:IsSameSystem(Game.system.path) then
 			if (1 - Game.system.lawlessness) > Engine.rand:Number(4) then
-				local station = ship:FindNearestTo("SPACESTATION")
+				local station = Game.player:FindNearestTo("SPACESTATION")
 				if station then mission.police = spawnPolice(station) end
 			end
 		end
@@ -658,11 +653,13 @@ local onShipDocked = function (player, station)
 		end
 
 		if mission.return_to_station or mission.deliver_to_ship and not mission.client_ship and mission.station == station.path then
+			---@type CargoManager
+			local cargoMgr = player:GetComponent('CargoManager')
 
 			-- unload mission cargo
 			for i, e in pairs(mission.debris) do
 				if e.body == nil then
-					if player:RemoveEquip(e.cargo, 1, "cargo") == 1 then
+					if cargoMgr:RemoveCommodity(e.cargo, 1) == 1 then
 						mission.debris[i] = nil
 						mission.amount = mission.amount - 1
 					end
@@ -721,7 +718,7 @@ local onEnterSystem = function (ship)
 	local planets = getPopulatedPlanets(Game.system)
 	local num = Engine.rand:Integer(0, math.ceil(Game.system.population * Game.system.lawlessness))
 
-	flavours[LEGAL].cargo_type, flavours[ILLEGAL].cargo_type = sortGoods(Equipment.cargo)
+	flavours[LEGAL].cargo_type, flavours[ILLEGAL].cargo_type = sortGoods(Commodities)
 
 	-- spawn random cargo (legal or illegal goods)
 	for i = 1, num do
@@ -823,6 +820,8 @@ local onGameStart = function ()
 			end
 		end
 	end
+
+	Game.player:GetComponent('CargoManager'):AddListener('scoop-mission', onPlayerCargoChanged)
 end
 
 local onGameEnd = function ()
@@ -841,7 +840,6 @@ end
 
 Event.Register("onCreateBB", onCreateBB)
 Event.Register("onUpdateBB", onUpdateBB)
-Event.Register("onShipEquipmentChanged", onShipEquipmentChanged)
 Event.Register("onShipDocked", onShipDocked)
 Event.Register("onShipUndocked", onShipUndocked)
 Event.Register("onShipHit", onShipHit)

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -37,6 +37,7 @@ local Mission = require 'Mission'
 local Format = require 'Format'
 local Serializer = require 'Serializer'
 local Character = require 'Character'
+local Commodities = require 'Commodities'
 local Equipment = require 'Equipment'
 local ShipDef = require 'ShipDef'
 local Ship = require 'Ship'
@@ -1750,7 +1751,7 @@ local deliverCommodity = function (mission, commodity)
 			-- if commodity was fuel and the mission was local refuel the ship with it
 			if commodity == Equipment.cargo.hydrogen then
 				if mission.flavour.id == 2 or mission.flavour.id == 4 or mission.flavour.id == 5 then
-					mission.target:Refuel(mission.deliver_comm_orig[commodity])
+					mission.target:Refuel(Commodities.hydrogen, mission.deliver_comm_orig[commodity])
 				end
 			end
 		end

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -297,15 +297,6 @@ end
 -- basic mission functions
 -- =======================
 
-local verifyCommodity = function (item)
-	-- Reloads the actual cargo equipment as object. Somehow that can get lost in some
-	-- setups and for some users. All commodities used for any mission flavor have to
-	-- be accounted for here.
-	if item.l10n_key == 'HYDROGEN' then
-		return Equipment.cargo.hydrogen
-	end
-end
-
 local triggerAdCreation = function ()
 	-- Return if ad should be created based on lawlessness and min/max frequency values.
 	-- Ad number per system is based on how many stations a system has so a player will
@@ -434,22 +425,12 @@ end
 
 local cargoPresent = function (ship, item)
 	-- Check if this cargo item is present on the ship.
-	local cargotype = verifyCommodity(item)  -- necessary for some users
-	if ship:CountEquip(cargotype) > 0 then
-		return true
-	else
-		return false
-	end
+	return ship:GetComponent('CargoManager'):CountCommodity(item) > 0
 end
 
 local cargoSpace = function (ship)
 	-- Check if the ship has space for additional cargo.
-	-- TODO: GetEquipFree("cargo") does not seem to work right - issue submitted.
-	if ship:GetEquipFree("cargo") > 0 then
-		return true
-	else
-		return false
-	end
+	return ship:GetComponent('CargoManager'):GetFreeSpace() > 0
 end
 
 local addCrew = function (ship, crew_member)
@@ -489,16 +470,12 @@ end
 
 local addCargo = function (ship, item)
 	-- Add a ton of the supplied cargo item to the ship.
-	if not cargoSpace(ship) then return end
-	local cargotype = verifyCommodity(item)  -- necessary for some users
-	ship:AddEquip(cargotype, 1)
+	ship:GetComponent('CargoManager'):AddCommodity(item, 1)
 end
 
 local removeCargo = function (ship, item)
 	-- Remove a ton of the supplied cargo item from the ship.
-	if not cargoPresent(ship, item) then return end
-	local cargotype = verifyCommodity(item)  -- necessary for some users
-	ship:RemoveEquip(cargotype, 1)
+	ship:GetComponent('CargoManager'):RemoveCommodity(item, 1)
 end
 
 local passEquipmentRequirements = function (requirements)
@@ -767,7 +744,7 @@ local createTargetShip = function (mission)
 	if mission.flavour.id ~= 2 and mission.flavour.id ~= 4 and mission.flavour.id ~= 5 then
 		local drive = ship:GetEquip('engine', 1)
 		local hypfuel = drive.capabilities.hyperclass ^ 2  -- fuel for max range
-		ship:AddEquip(Equipment.cargo.hydrogen, hypfuel)
+		ship:GetComponent('CargoManager'):AddCommodity(drive.fuel or Commodities.hydrogen, hypfuel)
 	end
 
 	-- load a laser
@@ -1299,7 +1276,7 @@ local makeAdvert = function (station, manualFlavour, closestplanets)
 	elseif flavour.id == 4 then
 		needed_fuel = math.max(math.floor(shipdef.fuelTankMass * 0.2), 1)
 	end
-	deliver_comm[Equipment.cargo.hydrogen] = needed_fuel
+	deliver_comm[Commodities.hydrogen] = needed_fuel
 
 	-- terminate ad creation if no suitable target ship could be created
 	if not shipdef then return nil end
@@ -1749,7 +1726,7 @@ local deliverCommodity = function (mission, commodity)
 			mission.deliver_comm_check[commodity] = "COMPLETE"
 
 			-- if commodity was fuel and the mission was local refuel the ship with it
-			if commodity == Equipment.cargo.hydrogen then
+			if commodity == Commodities.hydrogen then
 				if mission.flavour.id == 2 or mission.flavour.id == 4 or mission.flavour.id == 5 then
 					mission.target:Refuel(Commodities.hydrogen, mission.deliver_comm_orig[commodity])
 				end
@@ -2091,9 +2068,11 @@ local onShipDocked = function (ship, station)
 				-- add hydrogen for hyperjumping
 				local drive = ship:GetEquip('engine', 1)
 				if drive then
+					---@type CargoManager
+					local cargoMgr = ship:GetComponent('CargoManager')
 					local hypfuel = drive.capabilities.hyperclass ^ 2  -- fuel for max range
-					hypfuel = hypfuel - ship:CountEquip(Equipment.cargo.hydrogen)
-					ship:AddEquip(Equipment.cargo.hydrogen, hypfuel)
+					hypfuel = hypfuel - cargoMgr:CountCommodity(Commodities.hydrogen)
+					cargoMgr:AddCommodity(Commodities.hydrogen, math.max(hypfuel, 0))
 				end
 			end
 

--- a/data/modules/SoldOut/SoldOut.lua
+++ b/data/modules/SoldOut/SoldOut.lua
@@ -8,7 +8,7 @@ local Event = require 'Event'
 local Serializer = require 'Serializer'
 local Character = require 'Character'
 local Format = require 'Format'
-local Equipment = require 'Equipment'
+local Commodities = require 'Commodities'
 
 local l = Lang.GetResource("module-soldout")
 
@@ -16,8 +16,12 @@ local ads = {}
 
 local onChat = function (form, ref, option)
 	local ad = ads[ref]
+
+	---@type CargoManager
+	local cargoMgr = Game.player:GetComponent('CargoManager')
+
 	-- Maximum amount the player can sell:
-	local max = Game.player:CountEquip(ad.commodity, "cargo")
+	local max = cargoMgr:CountCommodity(ad.commodity)
 	max = ad.amount < max and ad.amount or max
 
 	form:Clear()
@@ -33,7 +37,7 @@ local onChat = function (form, ref, option)
 		if max < 1 then
 			form:SetMessage(string.interp(l.NOT_IN_STOCK, {commodity = ad.commodity:GetName()}))
 		else
-			Game.player:RemoveEquip(ad.commodity, max)
+			cargoMgr:RemoveCommodity(ad.commodity, max)
 			Game.player:AddMoney(ad.price * max)
 			ad.amount = ad.amount - max
 			form:SetMessage(ad.message .. "\n\n" .. string.interp(l.AMOUNT, {amount = ad.amount}))
@@ -42,7 +46,7 @@ local onChat = function (form, ref, option)
 		if max < option then
 			form:SetMessage(string.interp(l.NOT_IN_STOCK, {commodity = ad.commodity:GetName()}))
 		else
-			Game.player:RemoveEquip(ad.commodity, option)
+			cargoMgr:RemoveCommodity(ad.commodity, option)
 			Game.player:AddMoney(ad.price * option)
 			ad.amount = ad.amount - option
 			form:SetMessage(ad.message .. "\n\n" .. string.interp(l.AMOUNT, {amount = ad.amount}))
@@ -83,7 +87,7 @@ local makeAdvert = function(station, commodity)
 	local ad = {
 		station   = station,
 		client    = Character.New(),
-		price     = 2 * station:GetEquipmentPrice(commodity) * ((not Game.system:IsCommodityLegal(commodity:GetName()) and 2) or 1),
+		price     = 2 * station:GetCommodityPrice(commodity) * ((not Game.system:IsCommodityLegal(commodity:GetName()) and 2) or 1),
 		commodity = commodity,
 	}
 
@@ -112,10 +116,12 @@ local onCreateBB = function (station)
 	-- Only relevant to create an advert for goods that are have zero stock
 	-- (probability for that is set in SpaceStation.lua)
 	local sold_out = {}
-	for i, c in pairs(Equipment.cargo) do
-		local stock = station:GetEquipmentStock(c)
-		if stock == 0 then
-			table.insert(sold_out, c)
+	for i, c in pairs(Commodities) do
+		if c.purchasable then
+			local stock = station:GetCommodityStock(c)
+			if stock == 0 then
+				table.insert(sold_out, c)
+			end
 		end
 	end
 

--- a/data/modules/TradeShips/Debug.lua
+++ b/data/modules/TradeShips/Debug.lua
@@ -8,6 +8,7 @@ local e = require 'Equipment'
 local Game = require 'Game'
 local ui = require 'pigui.baseui'
 local utils = require 'utils'
+local CommodityType = require 'CommodityType'
 local Vector2 = Vector2
 local Space = require 'Space'
 
@@ -280,8 +281,10 @@ debugView.registerTab('debug-trade-ships', function()
 	if obj.type ~= Engine.GetEnumValue("ProjectableTypes", "NONE") and Core.ships[obj.ref] then
 		local ship = obj.ref
 		local trader = Core.ships[ship]
+
 		if ui.collapsingHeader("Info:", {"DefaultOpen"}) then
 			property("Trader: ", ship:GetShipType() .. " " .. ship:GetLabel())
+
 			local status = trader.status
 			if status == "docked" then
 				status = status .. " (" .. trader.starport:GetLabel() .. ")"
@@ -290,15 +293,18 @@ debugView.registerTab('debug-trade-ships', function()
 				status = status .. " (" .. trader.starport:GetLabel() .. " - " .. d .. ")"
 			end
 			property("Status: ", status)
+
 			if trader.fnc then
 				property("Task: ", trader.fnc .. " in " .. ui.Format.Duration(trader.delay - Game.time))
 			end
 			property("Fuel: ", string.format("%.4f", ship.fuelMassLeft) .. "/" .. ShipDef[ship.shipId].fuelTankMass .. " t")
 		end
+
 		if ui.collapsingHeader("Internals:", {"DefaultOpen"}) then
 			local equipItems = {}
 			local total_mass = 0
-			local equips = { "cargo", "misc", "hyperspace", "laser" }
+
+			local equips = { "misc", "hyperspace", "laser" }
 			for _,t in ipairs(equips) do
 				for _,et in pairs(e[t]) do
 					local count = ship:CountEquip(et)
@@ -315,7 +321,24 @@ debugView.registerTab('debug-trade-ships', function()
 					end
 				end
 			end
+
+			---@type CargoManager
+			local cargoMgr = ship:GetComponent('CargoManager')
+
+			for name, info in pairs(cargoMgr.commodities) do
+				local ct = CommodityType.GetCommodity(name)
+				total_mass = total_mass + ct.mass * info.count
+				table.insert(equipItems, {
+					name = ct:GetName(),
+					eq_type = "cargo",
+					count = info.count,
+					mass = ct.mass,
+					all_mass = ct.mass * info.count
+				})
+			end
+
 			local capacity = ShipDef[ship.shipId].capacity
+
 			arrayTable.draw("tradeships_traderequipment", equipItems, ipairs, {
 				{ name = "Name",        key = "name",     string = true       },
 				{ name = "Type",        key = "eq_type",  string = true       },

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -119,6 +119,16 @@ function CommodityMarketWidget.New(id, title, config)
         end
     end
 
+	config.bought = function (self, commodity, tradeamount)
+		local count = tradeamount or 1
+        self.station:AddCommodityStock(commodity, -count)
+    end
+
+    config.sold = function (self, commodity, tradeamount)
+		local count = tradeamount or 1
+        Game.player:GetDockedWith():AddCommodityStock(commodity, count)
+    end
+
 	config.onClickItem = config.onClickItem or function(s,e,_)
 		s.selectedItem = e
 		s.tradeModeBuy = true

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -4,7 +4,7 @@
 local Game = require 'Game'
 local Lang = require 'Lang'
 local Format = require 'Format'
-local Equipment = require 'Equipment'
+local Commodities = require 'Commodities'
 
 local ui = require 'pigui'
 local pionillium = ui.fonts.pionillium
@@ -42,18 +42,22 @@ local colorVariant = {
 	[false] = ui.theme.buttonColors.default
 }
 
+local sellPriceReduction = 0.8
+
 local CommodityMarketWidget = {}
 
 function CommodityMarketWidget.New(id, title, config)
 	config = config or {}
 	config.style = config.style or {}
 	config.style.size = config.style.size or Vector2(0,0)
-	config.itemTypes = config.itemTypes or { Equipment.cargo }
+	config.itemTypes = config.itemTypes or { Commodities }
 	config.columnCount = config.columnCount or 5
+
 	config.initTable = config.initTable or function(self)
 		ui.setColumnWidth(0, commodityIconSize.x + ui.getItemSpacing().x)
 		ui.setColumnWidth(1, self.style.size.x / 2 - 50 * self.style.widgetSizes.rescaleVector.x)
 	end
+
 	config.renderHeaderRow = config.renderHeaderRow or function(_)
 		ui.text('')
 		ui.nextColumn()
@@ -66,12 +70,14 @@ function CommodityMarketWidget.New(id, title, config)
 		ui.text(l.CARGO)
 		ui.nextColumn()
 	end
+
 	config.renderItem = config.renderItem or function(self, item)
 		if(self.icons[item.icon_name] == nil) then
 			self.icons[item.icon_name] = PiImage.New("icons/goods/".. item.icon_name ..".png")
 		end
 		self.icons[item.icon_name]:Draw(commodityIconSize)
 		ui.nextColumn()
+
 		ui.withStyleVars({ItemSpacing = (self.style.itemSpacing / 2)}, function()
 			ui.dummy(vZero)
 			ui.text(item:GetName())
@@ -83,17 +89,45 @@ function CommodityMarketWidget.New(id, title, config)
 			ui.text(self.funcs.getStock(self, item))
 			ui.nextColumn()
 			ui.dummy(vZero)
-			local n = Game.player:CountEquip(item)
+			local n = self.cargoMgr:CountCommodity(item)
 			ui.text(n > 0 and n or '')
 		end)
 		ui.nextColumn()
 	end
-	config.canDisplayItem = config.canDisplayItem or function (_, e) return e.purchasable and e:IsValidSlot("cargo") and Game.system:IsCommodityLegal(e.name) end
+
+	config.canDisplayItem = config.canDisplayItem or function (self, commodity)
+		return commodity.purchasable and Game.system:IsCommodityLegal(commodity.name)
+	end
+
+	-- how much of this item do we have in stock?
+    config.getStock = config.getStock or function (self, commodity)
+        return self.station:GetCommodityStock(commodity)
+    end
+
+    -- what do we charge for this item if we are buying
+    config.getBuyPrice = config.getBuyPrice or function (self, commodity)
+        return self.station:GetCommodityPrice(commodity)
+    end
+
+    -- what do we get for this item if we are selling
+    config.getSellPrice = config.getSellPrice or function (self, commodity)
+        local basePrice = self.station:GetCommodityPrice(commodity)
+        if basePrice > 0 then
+			return basePrice
+        else
+            return 1.0/sellPriceReduction * basePrice
+        end
+    end
+
 	config.onClickItem = config.onClickItem or function(s,e,_)
 		s.selectedItem = e
 		s.tradeModeBuy = true
 		s:ChangeTradeAmount(-s.tradeAmount)
 		s:Refresh()
+	end
+
+	config.sortingFunction = config.sortingFunction or function (c1, c2)
+		return c1:GetName() < c2:GetName()
 	end
 
 	local self = MarketWidget.New(id, title, config)
@@ -106,6 +140,10 @@ function CommodityMarketWidget.New(id, title, config)
 	self.textColorWarning = Color(255, 255, 0)
 	self.textColorError = Color(255, 0, 0)
 	self.tradeTextColor = textColorDefault
+
+	self.cargoMgr = nil
+	self.station = nil
+
 	self.style.defaults = {
 		itemSpacing = self.itemSpacing
 	}
@@ -125,7 +163,7 @@ function CommodityMarketWidget:ChangeTradeAmount(delta)
 	end
 
 	--get price of commodity after applying local effects of import/export modifiers
-	local price = Game.player:GetDockedWith():GetEquipmentPrice(self.selectedItem)
+	local price = 0
 
 	--do you have any money?
 	local playerCash = Game.player:GetMoney()
@@ -136,11 +174,13 @@ function CommodityMarketWidget:ChangeTradeAmount(delta)
 	if self.tradeModeBuy then
 		price = self.funcs.getBuyPrice(self, self.selectedItem)
 		stock = self.funcs.getStock(self, self.selectedItem)
+
 		if stock == 0 then
 			self.tradeText = l.NONE_FOR_SALE_IN_THIS_STATION
 			self.tradeTextColor = textColorError
 			return
 		end
+
 		if price > playerCash then
 			self.tradeText = l.INSUFFICIENT_FUNDS
 			self.tradeTextColor = textColorWarning
@@ -148,35 +188,29 @@ function CommodityMarketWidget:ChangeTradeAmount(delta)
 		end
 	else
 		price = self.funcs.getSellPrice(self, self.selectedItem)
-		stock = Game.player:CountEquip(self.selectedItem)
+		stock = self.cargoMgr:CountCommodity(self.selectedItem)
 	end
 
-	--dont alter tradeamount before checks have been made
-	local wantamount = self.tradeAmount + delta
+	--we cant trade more units than we have in stock
+	--we dont trade in negative quantities
+	local wantamount = math.clamp(self.tradeAmount + delta, 0, stock)
 
 	--how much would the desired amount of merchandise cost?
 	local tradecost = wantamount * price
 
-	--we cant trade more units than we have in stock
-	if delta > 0 and wantamount > stock then --this line is why stock needs to be initialized up there. its possible to get here without stock being set (?)
-		wantamount = stock
-	end
-
-	--we dont trade in negative quantities
-	if wantamount < 0 then
-		wantamount = 0
-	end
-
 	--another empty initialized
 	self.tradeText = ''
 	if self.tradeModeBuy then
-		local playerfreecargo = Game.player.totalCargo - Game.player.usedCargo
+		-- TODO: use a volume-based metric rather than a mass-based metric
+		local playerfreecargo = self.cargoMgr:GetFreeSpace()
+
 		if tradecost > playerCash then
 			wantamount = math.floor(playerCash / price)
 		end
-		local tradecargo = self.selectedItem.capabilities.mass * wantamount
+
+		local tradecargo = (self.selectedItem.mass or 1) * wantamount
 		if playerfreecargo < tradecargo then
-			wantamount = math.floor(playerfreecargo / self.selectedItem.capabilities.mass)
+			wantamount = math.floor(playerfreecargo / (self.selectedItem.mass or 1))
 		end
 		self.tradeText = l.MARKET_BUYLINE
 	else --mode = sell
@@ -186,8 +220,8 @@ function CommodityMarketWidget:ChangeTradeAmount(delta)
 			--if player starts at 0 quantity, presses +100 to "sell" radioactives but only has
 			--enough credits to sell 5, this kludge will ignore the +100 completely
 			--todo: change amount to 5 instead
-	end
-	self.tradeText = l.MARKET_SELLINE
+		end
+		self.tradeText = l.MARKET_SELLINE
 	end
 	--wantamount is now checked and modified to a safe bounded amount
 	self.tradeAmount = wantamount
@@ -206,7 +240,7 @@ function CommodityMarketWidget:DoBuy()
 
 	local price = self.funcs.getBuyPrice(self, self.selectedItem)
 	local stock = self.funcs.getStock(self, self.selectedItem)
-	local playerfreecargo = Game.player.totalCargo - Game.player.usedCargo
+	local playerfreecargo = self.cargoMgr:GetFreeSpace()
 	local orderAmount = price * self.tradeAmount
 
 	--check cash (should never happen since trade amount buttons wont let it happen)
@@ -224,7 +258,7 @@ function CommodityMarketWidget:DoBuy()
 	end
 
 	--check cargo limit
-	local tradecargo = self.selectedItem.capabilities.mass * self.tradeAmount
+	local tradecargo = (self.selectedItem.mass or 1) * self.tradeAmount
 	if playerfreecargo < tradecargo then
 		self.popup.msg = l.SHIP_IS_FULLY_LADEN
 		self.popup:open()
@@ -232,8 +266,9 @@ function CommodityMarketWidget:DoBuy()
 	end
 
 	--all checks passed
-	assert(Game.player:AddEquip(self.selectedItem, self.tradeAmount, "cargo") == self.tradeAmount)
+	assert(self.cargoMgr:AddCommodity(self.selectedItem, self.tradeAmount))
 	Game.player:AddMoney(-orderAmount) --grab the money
+
 	self.funcs.bought(self, self.selectedItem, self.tradeAmount)
 	self:ChangeTradeAmount(-self.tradeAmount) --reset the trade amount
 
@@ -248,16 +283,17 @@ function CommodityMarketWidget:DoSell()
 	if not self.funcs.onClickSell(self, self.selectedItem) then return end
 
 	local price = self.funcs.getSellPrice(self, self.selectedItem)
+	--if commodity price is negative (radioactives, garbage), player needs to have enough cash
 	local orderamount = price * self.tradeAmount
 
-	--if commodity price is negative (radioactives, garbage), player needs to have enough cash
-	Game.player:RemoveEquip(self.selectedItem, self.tradeAmount, "cargo")
+	assert(self.cargoMgr:RemoveCommodity(self.selectedItem, self.tradeAmount) == self.tradeAmount)
 	Game.player:AddMoney(orderamount) --grab the money
+
 	self.funcs.sold(self, self.selectedItem, self.tradeAmount)
 	self:ChangeTradeAmount(-self.tradeAmount) --reset the trade amount
 
-	--if player sold all his cargo, switch to buy panel
-	if Game.player:CountEquip(self.selectedItem) == 0 then self.tradeModeBuy = true end
+	--if player sold all of this cargo, switch to buy panel
+	if self.cargoMgr:CountCommodity(self.selectedItem) == 0 then self.tradeModeBuy = true end
 
 	--update market rows
 	self.tradeAmount = 0;
@@ -383,6 +419,9 @@ end
 
 function CommodityMarketWidget:Refresh()
 	MarketWidget.refresh(self)
+
+	self.cargoMgr = Game.player:GetComponent('CargoManager')
+	self.station = Game.player:GetDockedWith()
 end
 
 function CommodityMarketWidget:Render(size)

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -420,6 +420,7 @@ end
 function CommodityMarketWidget:Refresh()
 	MarketWidget.refresh(self)
 
+	---@type CargoManager
 	self.cargoMgr = Game.player:GetComponent('CargoManager')
 	self.station = Game.player:GetDockedWith()
 end

--- a/data/pigui/libs/equipment-market.lua
+++ b/data/pigui/libs/equipment-market.lua
@@ -15,7 +15,7 @@ local sellPriceReduction = 0.8
 local defaultFuncs = {
     -- can we display this item
     canDisplayItem = function (self, e)
-        return e.purchasable and e:IsValidSlot("cargo") and Game.system:IsCommodityLegal(e.name)
+        return e.purchasable
     end,
 
     -- how much of this item do we have in stock?
@@ -180,8 +180,7 @@ local MarketWidget = {
 }
 
 function MarketWidget.New(id, title, config)
-    local self
-    self = TableWidget.New(id, title, config)
+    local self = TableWidget.New(id, title, config)
 
     self.popup = config.popup or ModalWindow.New('popupMsg' .. id, function()
         ui.text(self.popup.msg)
@@ -195,18 +194,19 @@ function MarketWidget.New(id, title, config)
     self.items = {}
     self.itemTypes = config.itemTypes or {}
     self.columnCount = config.columnCount or 0
-    self.funcs.getStock = config.getStock or defaultFuncs.getStock
-    self.funcs.getBuyPrice = config.getBuyPrice or defaultFuncs.getBuyPrice
-    self.funcs.getSellPrice = config.getSellPrice or defaultFuncs.getSellPrice
-    self.funcs.onClickBuy = config.onClickBuy or defaultFuncs.onClickBuy
-    self.funcs.onClickSell = config.onClickSell or defaultFuncs.onClickSell
-    self.funcs.buy = config.buy or defaultFuncs.buy
-    self.funcs.bought = config.bought or defaultFuncs.bought
-    self.funcs.onBuyFailed = config.onBuyFailed or defaultFuncs.onBuyFailed
-    self.funcs.sell = config.sell or defaultFuncs.sell
-    self.funcs.sold = config.sold or defaultFuncs.sold
-    self.funcs.initTable = config.initTable or defaultFuncs.initTable
-    self.funcs.canDisplayItem = config.canDisplayItem or defaultFuncs.canDisplayItem
+
+    self.funcs.getStock        = config.getStock        or defaultFuncs.getStock
+    self.funcs.getBuyPrice     = config.getBuyPrice     or defaultFuncs.getBuyPrice
+    self.funcs.getSellPrice    = config.getSellPrice    or defaultFuncs.getSellPrice
+    self.funcs.onClickBuy      = config.onClickBuy      or defaultFuncs.onClickBuy
+    self.funcs.onClickSell     = config.onClickSell     or defaultFuncs.onClickSell
+    self.funcs.buy             = config.buy             or defaultFuncs.buy
+    self.funcs.bought          = config.bought          or defaultFuncs.bought
+    self.funcs.onBuyFailed     = config.onBuyFailed     or defaultFuncs.onBuyFailed
+    self.funcs.sell            = config.sell            or defaultFuncs.sell
+    self.funcs.sold            = config.sold            or defaultFuncs.sold
+    self.funcs.initTable       = config.initTable       or defaultFuncs.initTable
+    self.funcs.canDisplayItem  = config.canDisplayItem  or defaultFuncs.canDisplayItem
     self.funcs.sortingFunction = config.sortingFunction or defaultFuncs.sortingFunction
     self.funcs.onMouseOverItem = config.onMouseOverItem or defaultFuncs.onMouseOverItem
 

--- a/data/pigui/libs/equipment-market.lua
+++ b/data/pigui/libs/equipment-market.lua
@@ -3,6 +3,7 @@
 
 local Game = require 'Game'
 local Lang = require 'Lang'
+local utils= require 'utils'
 
 local ui = require 'pigui'
 local ModalWindow = require 'pigui.libs.modal-win'
@@ -117,9 +118,9 @@ local defaultFuncs = {
 
         -- remove from last free slot (reverse table)
         local slot
-        for i=#e.slots,1,-1 do
-            if player:CountEquip(e, e.slots[i]) > 0 then
-                slot = e.slots[i]
+        for i, s in utils.reverse(e.slots) do
+            if player:CountEquip(e, s) > 0 then
+                slot = s
                 break
             end
         end

--- a/data/pigui/libs/ship-equipment.lua
+++ b/data/pigui/libs/ship-equipment.lua
@@ -80,7 +80,7 @@ end
 
 local function makeEquipmentMarket()
 return EquipMarket.New("EquipmentMarket", l.AVAILABLE_FOR_PURCHASE, {
-	itemTypes = { Equipment.cargo, Equipment.misc, Equipment.laser, Equipment.hyperspace },
+	itemTypes = { Equipment.misc, Equipment.laser, Equipment.hyperspace },
 	columnCount = 5,
 	initTable = function(self)
 		ui.setColumnWidth(0, self.style.size.x / 2.5)

--- a/data/pigui/libs/ship-equipment.lua
+++ b/data/pigui/libs/ship-equipment.lua
@@ -1,4 +1,4 @@
--- Copyright © 2008-2021 Pioneer Developers. See AUTHORS.txt for details
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local Equipment = require 'Equipment'

--- a/data/pigui/libs/window-layout.lua
+++ b/data/pigui/libs/window-layout.lua
@@ -1,4 +1,4 @@
--- Copyright © 2008-2021 Pioneer Developers. See AUTHORS.txt for details
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local utils = require "libs.utils"

--- a/data/pigui/modules/flight-ui/system-overview.lua
+++ b/data/pigui/modules/flight-ui/system-overview.lua
@@ -1,4 +1,4 @@
--- Copyright © 2008-2021 Pioneer Developers. See AUTHORS.txt for details
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local Game = require 'Game'

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -50,6 +50,7 @@ local function rebuildCargoList()
 	local count = {}
 	local maxCargoCount = 0
 
+	---@type CargoManager
 	local cargoMgr = Game.player:GetComponent('CargoManager')
 	for name, info in pairs(cargoMgr.commodities) do
 		table.insert(count, {

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -155,7 +155,7 @@ local function gauge_hyperdrive()
 
 	local text = string.format(l.FUEL .. ": %%dt \t" .. l.HYPERSPACE_RANGE .. ": %d " .. l.LY, Game.player:GetHyperspaceRange())
 
-	gauge_bar(fuel, text, 0, cargoMgr:GetTotalSpace() - cargoMgr:GetUsedSpace() + fuel, icons.hyperspace)
+	gauge_bar(fuel, text, 0, cargoMgr:GetFreeSpace() + fuel, icons.hyperspace)
 end
 
 -- Gauge bar for used/free cargo space
@@ -164,7 +164,7 @@ local function gauge_cargo()
 	local cargoMgr = Game.player:GetComponent('CargoManager')
 
 	local fmtString = string.format('%%it %s / %it %s', l.USED, cargoMgr:GetFreeSpace(), l.FREE)
-	gauge_bar(cargoMgr:GetUsedSpace(), fmtString, 0, cargoMgr:GetTotalSpace(), icons.market)
+	gauge_bar(cargoMgr:GetUsedSpace(), fmtString, 0, cargoMgr:GetFreeSpace() + cargoMgr:GetUsedSpace(), icons.market)
 end
 
 -- Gauge bar for used/free cabins

--- a/data/pigui/modules/info-view/05-crew.lua
+++ b/data/pigui/modules/info-view/05-crew.lua
@@ -8,6 +8,7 @@ local Lang		= require 'Lang'
 local ShipDef	= require 'ShipDef'
 local InfoView	= require 'pigui.views.info-view'
 local PiGuiFace = require 'pigui.libs.face'
+local Commodities = require 'Commodities'
 
 local ui = require 'pigui'
 local textTable = require 'pigui.libs.text-table'
@@ -60,7 +61,11 @@ local crewTasks = {
 		local hullMassLeft = Game.player.hullMassLeft
 		local hullDamage = hullMass - hullMassLeft
 		if hullDamage > 0 then
-			if Game.player:CountEquip(Equipment.cargo.metal_alloys, "cargo") <= 0 then
+			---@type CargoManager
+			local cargoMgr = Game.player:GetComponent('CargoManager')
+			local num_metal_alloys = cargoMgr:CountCommodity(Commodities.metal_alloys)
+
+			if num_metal_alloys <= 0 then
 				return l.NOT_ENOUGH_ALLOY_TO_ATTEMPT_A_REPAIR:interp({alloy = l.METAL_ALLOYS})
 			end
 
@@ -69,9 +74,9 @@ local crewTasks = {
 				local repair = math.min(
 					-- Need metal alloys for repair. Check amount.
 					math.ceil(hullDamage/(64 - result)), -- 65 > result > 3
-					Game.player:CountEquip(Equipment.cargo.metal_alloys, "cargo")
+					num_metal_alloys
 				)
-				Game.player:RemoveEquip(Equipment.cargo.metal_alloys, repair) -- These will now be part of the hull.
+				cargoMgr:RemoveCommodity(Commodities.metal_alloys, repair) -- These will now be part of the hull.
 				local repairPercent = math.min(math.ceil(100 * (repair + hullMassLeft) / hullMass), 100) -- Get new hull percentage...
 				Game.player:SetHullPercent(repairPercent)   -- ...and set it.
 				return l.HULL_REPAIRED_BY_NAME_NOW_AT_N_PERCENT:interp({name = crewMember.name,repairPercent = repairPercent})

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -10,6 +10,7 @@ local StationView = require 'pigui.views.station-view'
 local Table = require 'pigui.libs.table'
 local PiImage = require 'pigui.libs.image'
 local ModelSpinner = require 'PiGui.Modules.ModelSpinner'
+local CommodityType= require 'CommodityType'
 
 local ui = require 'pigui'
 local pionillium = ui.fonts.pionillium
@@ -133,7 +134,6 @@ local function buyShip (mkt, sos)
 		return
 	end
 
-	local manifest = player:GetEquip("cargo")
 	player:AddMoney(-cost)
 
 	station:ReplaceShipOnSale(sos, {
@@ -147,12 +147,11 @@ local function buyShip (mkt, sos)
 	player:SetSkin(sos.skin)
 	if sos.pattern then player.model:SetPattern(sos.pattern) end
 	player:SetLabel(sos.label)
+
 	if def.hyperdriveClass > 0 then
 		player:AddEquip(Equipment.hyperspace["hyperdrive_" .. def.hyperdriveClass])
 	end
-	for _, e in pairs(manifest) do
-		player:AddEquip(e)
-	end
+
 	player:SetFuelPercent(100)
 	refreshShipMarket();
 

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -11,6 +11,7 @@ local Format = require 'Format'
 local MusicPlayer = require 'modules.MusicPlayer'
 local Lang = require 'Lang'
 local FlightLog = require ("FlightLog")
+local Commodities = require("Commodities")
 local Vector2 = _G.Vector2
 
 local lc = Lang.GetResource("core")
@@ -21,7 +22,6 @@ local clc = Lang.GetResource("commodity")
 
 local ui = require 'pigui'
 
-local cargo = Equipment.cargo
 local misc = Equipment.misc
 local laser = Equipment.laser
 local hyperspace = Equipment.hyperspace
@@ -40,38 +40,58 @@ local quitConfirmMsg
 local max_flavours = 22
 
 local startLocations = {
-	{	['name']=lui.START_AT_MARS,
-		['desc']=lui.START_AT_MARS_DESC,
-		['location']=SystemPath.New(0,0,0,0,18),
-		['logmsg']=lui.START_LOG_ENTRY_1,
-		['shipType']='sinonatrix',['money']=100,['hyperdrive']=true,
-		['equipment']={
-			{laser.pulsecannon_1mw,1},
+	{
+		['name']       = lui.START_AT_MARS,
+		['desc']       = lui.START_AT_MARS_DESC,
+		['location']   = SystemPath.New(0,0,0,0,18),
+		['logmsg']     = lui.START_LOG_ENTRY_1,
+		['shipType']   = 'sinonatrix',
+		['money']      = 100,
+		['hyperdrive'] = true,
+		['equipment']  = {
+			{ laser.pulsecannon_1mw,      1 },
+			{ misc.atmospheric_shielding, 1 },
+			{ misc.autopilot,             1 },
+			{ misc.radar,                 1 }
+		},
+		['cargo']      = {
+			{ Commodities.hydrogen, 2 }
+		}
+	},
+	{
+		['name']       = lui.START_AT_NEW_HOPE,
+		['desc']       = lui.START_AT_NEW_HOPE_DESC,
+		['location']   = SystemPath.New(1,-1,-1,0,4),
+		['logmsg']     = lui.START_LOG_ENTRY_2,
+		['shipType']   = 'pumpkinseed',
+		['money']      = 100,
+		['hyperdrive'] = true,
+		['equipment']  = {
+			{ laser.pulsecannon_1mw,      1 },
+			{ misc.atmospheric_shielding, 1 },
+			{ misc.autopilot,             1 },
+			{ misc.radar,                 1 }
+		},
+		['cargo']      = {
+			{ Commodities.hydrogen, 2 }
+		}
+	},
+	{	['name']        = lui.START_AT_BARNARDS_STAR,
+		['desc']        = lui.START_AT_BARNARDS_STAR_DESC,
+		['location']    = SystemPath.New(-1,0,0,0,16),
+		['logmsg']      = lui.START_LOG_ENTRY_3,
+		['shipType']    = 'xylophis',
+		['money']       = 100,
+		['hyperdrive']  = false,
+		['equipment']   = {
 			{misc.atmospheric_shielding,1},
 			{misc.autopilot,1},
-			{misc.radar,1},
-			{cargo.hydrogen,2}}},
-	{	['name']=lui.START_AT_NEW_HOPE,
-		['desc']=lui.START_AT_NEW_HOPE_DESC,
-		['location']=SystemPath.New(1,-1,-1,0,4),
-		['logmsg']=lui.START_LOG_ENTRY_2,
-		['shipType']='pumpkinseed',['money']=100,['hyperdrive']=true,
-		['equipment']={
-			{laser.pulsecannon_1mw,1},
-			{misc.atmospheric_shielding,1},
-			{misc.autopilot,1},
-			{misc.radar,1},
-			{cargo.hydrogen,2}}},
-	{	['name']=lui.START_AT_BARNARDS_STAR,
-		['desc']=lui.START_AT_BARNARDS_STAR_DESC,
-		['location']=SystemPath.New(-1,0,0,0,16),
-		['logmsg']=lui.START_LOG_ENTRY_3,
-		['shipType']='xylophis',['money']=100,['hyperdrive']=false,
-		['equipment']={
-			{misc.atmospheric_shielding,1},
-			{misc.autopilot,1},
-			{misc.radar,1},
-			{cargo.hydrogen,2}}}
+			{misc.radar,1}
+		},
+		['cargo']       = {
+			{Commodities.hydrogen,2}
+		}
+	}
 }
 
 local function dialogTextButton(label, enabled, callback)
@@ -159,15 +179,25 @@ local hasMusicList = false -- required false at init, see showMainMenu() for usa
 local function startAtLocation(location)
 	hasMusicList = false -- set false so that player restarts music
 	Game.StartGame(location.location)
+
 	Game.player:SetShipType(location.shipType)
 	Game.player:SetLabel(Ship.MakeRandomLabel())
+
+	Game.player:SetMoney(location.money)
+
 	if location.hyperdrive then
 		Game.player:AddEquip(hyperspace['hyperdrive_'..ShipDef[Game.player.shipId].hyperdriveClass])
 	end
-	Game.player:SetMoney(location.money)
+
 	for _,equip in pairs(location.equipment) do
 		Game.player:AddEquip(equip[1],equip[2])
 	end
+
+	local cargoMgr = Game.player:GetComponent('CargoManager')
+	for _,cargo in pairs(location.cargo) do
+		cargoMgr:AddCommodity(cargo[1], cargo[2])
+	end
+
 	-- XXX horrible hack here to avoid paying a spawn-in docking fee
 	Game.player:setprop("is_first_spawn", true)
 	FlightLog.MakeCustomEntry(location.logmsg)

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -193,6 +193,7 @@ local function startAtLocation(location)
 		Game.player:AddEquip(equip[1],equip[2])
 	end
 
+	---@type CargoManager
 	local cargoMgr = Game.player:GetComponent('CargoManager')
 	for _,cargo in pairs(location.cargo) do
 		cargoMgr:AddCommodity(cargo[1], cargo[2])

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -71,6 +71,8 @@ local onGameStart = function ()
 	sectorView:SetDrawUninhabitedLabels(draw_uninhabited_labels)
 	sectorView:SetDrawVerticalLines(draw_vertical_lines)
 	sectorView:SetLabelParams("orbiteer", font.size, 2.0, svColor.LABEL_HIGHLIGHT, svColor.LABEL_SHADE)
+	-- allow hyperjump planner to register its events
+	hyperJumpPlanner.onGameStart()
 end
 
 local function getHyperspaceDetails(path)

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -964,6 +964,17 @@ static int l_engine_get_model(lua_State *l)
 	return 1;
 }
 
+static int l_engine_request_profile_frame(lua_State *l)
+{
+	if (lua_gettop(l) > 0) {
+		Pi::GetApp()->RequestProfileFrame(luaL_checkstring(l, 1));
+	} else {
+		Pi::GetApp()->RequestProfileFrame();
+	}
+
+	return 0;
+}
+
 static int l_get_can_browse_user_folders(lua_State *l)
 {
 	lua_pushboolean(l, OS::SupportsFolderBrowser());
@@ -1065,6 +1076,8 @@ void LuaEngine::Register()
 		{ "GetBodyProjectedScreenPosition", l_engine_get_projected_screen_position },
 		{ "GetTargetIndicatorScreenPosition", l_engine_get_target_indicator_screen_position },
 		{ "GetEnumValue", l_engine_get_enum_value },
+
+		{ "RequestProfileFrame", l_engine_request_profile_frame },
 		{ 0, 0 }
 	};
 

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -447,8 +447,8 @@ static int l_ship_set_ship_name(lua_State *l)
  *
  * Example:
  *
- * > Game.player:SpawnCargo(Equipment.cargo.hydrogen, 0)
- * > Game.player:SpawnCargo(Equipment.cargo.hydrogen)
+ * > Game.player:SpawnCargo(Commodities.hydrogen, 0)
+ * > Game.player:SpawnCargo(Commodities.hydrogen)
  *
  * Availability:
  *

--- a/src/lua/LuaTimer.cpp
+++ b/src/lua/LuaTimer.cpp
@@ -18,6 +18,8 @@ void LuaTimer::RemoveAll()
 
 void LuaTimer::Tick()
 {
+	PROFILE_SCOPED()
+
 	assert(Pi::game);
 	lua_State *l = Lua::manager->GetLuaState();
 


### PR DESCRIPTION
This has been a long time coming as I'm sure @laarmen can attest, but with the advent of the Lua Component feature, I finally have all of the technical pieces in place to do this refactor.

I've added a completely new Lua CargoManager component for ships that is wholly separate from the EquipSet management, and converted all commodities in the game to use the new cargo manager system. Commodity items are now tracked by count and managed by type rather than having hundreds of instances of the same item in an array. This gets rid of a significant amount of overhead when working with commodities, and enforces a clear semantic separation between "items in your cargo hold" and "items mounted to your ship".

As part of this refactor, I've made (and backported) changes to Lua serialization to fix common pain-points when working with commodity types; when loading a saved game, commodity items serialized in the save by lua modules should no longer be duplicated / have a different table instance compared to the ones that were registered as part of normal game startup. I've still made the effort to deal with commodities using string IDs internally to be as robust as possible across serialization, but this change should be useful in the future for other modules as well.

The design of the CargoManager component is intentionally minimal at this time; for this PR I only focused on separating existing commodity-handling functionality out of EquipSet, but the API is designed to allow for future expansions to bring features like:
- Marking certain cargo items as illegally salvaged from a wreck;
- Tracking mission-target cargo items separately from player-purchased commodities;
- Volatile or time-sensitive cargoes which need special handling;
- Storing and transporting equipment items, such as ones removed from the player's ship;
- and potentially even changing ship cargo space to be controlled by adding or removing cargo rack equipment from the ship.

I've moved most C++ handling of fuel scooping and cargo scooping into Lua callbacks that can be further expanded or modded to support custom behaviors, and moved the "cargo life support timer" functionality into a Lua timer callback registered shortly after ship creation. This does add a little bit of overhead due to the unoptimized state of the LuaTimer implementation, but in my testing it averaged around an extra 200us / frame in a Debug build with 400+ ships alive and moving between planets, which is well below noticeable levels.

And lastly (but certainly not leastly) I've ported *all* of the mission modules and UI to use this new API instead of the old `AddEquip/RemoveEquip/GetEquip/CountEquip/GetCargo` methods on Ship. This by far took the longest, as most of our missions have at least something to do with cargo management (even if it is just to add a few tons of hydrogen).

And if it wasn't clear already, this PR *will* break backwards compatibility of game saves. With the sheer size of the PR and changes to major fundamental systems, I have no qualms about savebumping for this release and it's simpler to do it this way and focus on designing the new systems to maintain compatibility going forwards than to try and shoehorn in migration between incompatible systems.

## Testing Notes

Due to the fact that it took me literally all of my free time this week late into the night just to do this refactor and make everything run with the new API, I've not had time to thoroughly test this branch to ensure that the mission modules work correctly and are error free.

As such, I'm going to request that the readers of this PR (yes, you, even if you're not a Pioneer developer) download and test the latest build from this PR and report back when you've tested a mission module below and ensured that it doesn't have any major regressions that would prevent the mission from working properly.

Because of the huge number of changes in this PR, I'd like to have the below checklist completely checked-off before merging this PR, so ***please*** test and report back your findings! It's acceptable to change mission parameters a little to make them spawn on the BBS or trigger rare events more often if needed to actually test the behaviors.

### Tested and Working Modules / Features:
- [x] Assassination (entering system with assassination target should not trigger errors)
- [ ] Breakdown Servicing (trigger a hyperdrive failure)
- [x] Cargo Run Missions:
  - [x Deliver local cargo
  - [x] Deliver interstellar cargo
  - [x] Pickup and return cargo
  - [x] Negotiate smaller delivery amount
- [x] News Event Commodity (extreme demand event, extreme supply event)
- [x] Scoop Missions
- [ ] Search and Rescue Missions:
  - [ ] Pickup/deliver crew (general regression test)
  - [ ] Deliver fuel

Regular game features that should be tested:
- [x] Fuel scooping (from multiple gas giants preferably)
- [x] Cargo scooping (jettisoned cargo)
- [x] Regular cargo trading (ensure station stock depletion works properly across save/reload and when leaving and re-entering a system)