### PR TITLE
Fix writing into reserved area of background star arrays

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -487,6 +487,10 @@ namespace Background {
 		num = stars.pos.size();
 		Output("Stars picked from galaxy: %d\n", stars.pos.size());
 
+		stars.pos.resize(NUM_BG_STARS);
+		stars.color.resize(NUM_BG_STARS);
+		stars.brightness.resize(NUM_BG_STARS);
+
 		PROFILE_START_DESC("Generate Random Stars")
 		// fill out the remaining target count with generated points and also fill hyperspace stars
 		Output("Generating %d random stars\n", NUM_BG_STARS - num);


### PR DESCRIPTION
The background star arrays used for multithreaded starfield generation allocated enough memory for all stars, but did not have their sizes expanded for randomly-generated star points, resulting in those points not being visible and asserts when writing into the array.

This ~~should fix~~ fixes #5387!