### PR TITLE
Improve error reporting and debug printing utilities

### DIFF
--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -336,37 +336,49 @@ end
 --
 utils.print_r = function(t)
 	local print_r_cache={}
-	local function sub_print_r(t,indent,rec_guard)
+	local print_str_cache = {}
+
+	local write = function(indent, str, ...)
+		table.insert(print_str_cache, string.rep(" ", indent) .. string.format(str, ...))
+	end
+
+	local function sub_print_r(t, indent)
 		if (print_r_cache[tostring(t)]) then
-			print(indent.."*"..tostring(t))
+			write(indent, "*" .. tostring(t))
 		else
-			print_r_cache[tostring(t)]=true
-			if (type(t)=="table") then
-				for pos,val in pairs(t) do
-					local string_pos = tostring(pos)
-					if (type(val)=="table") then
-						print(indent.."["..string_pos.."] => "..tostring(t).." {")
-						sub_print_r(val,indent..string.rep(" ",string.len(string_pos)+8))
-						print(indent..string.rep(" ",string.len(string_pos)+6).."}")
+			print_r_cache[tostring(t)] = true
+
+			if type(t) == "table" then
+				for key, val in pairs(t) do
+					local string_key = tostring(key)
+
+					if type(val) == "table" then
+						write(indent, '[%s] => %s {', string_key, tostring(t))
+
+						sub_print_r(val, indent + string.len(string_key) + 8)
+
+						write(indent + string.len(string_key) + 6, "}")
 					elseif (type(val)=="string") then
-						print(indent.."["..string_pos..'] => "'..val..'"')
+						write(indent, "[%s] => '%s'", string_key, val)
 					else
-						print(indent.."["..string_pos.."] => "..tostring(val))
+						write(indent, "[%s] => %s", string_key, tostring(val))
 					end
 				end
 			else
-				print(indent..tostring(t))
+				write(indent, "%s", tostring(t))
 			end
 		end
 	end
+
 	if (type(t)=="table") then
-		print(tostring(t).." {")
-		sub_print_r(t,"  ")
-		print("}")
+		write(0, "%s {", tostring(t))
+		sub_print_r(t, 2)
+		write(0, "}")
 	else
-		sub_print_r(t,"  ")
+		sub_print_r(t, 2)
 	end
-	print()
+
+	print(table.concat(print_str_cache, "\n"))
 end
 
 --

--- a/data/meta/_Core.lua
+++ b/data/meta/_Core.lua
@@ -6,6 +6,10 @@
 
 ---@meta
 
+--- Dump all relevant variables and parameters for the current lua stack trace.
+---@param level number stack level to start the stack dump at
+debug.dumpstack = function(level) end
+
 --- Convert the angle `a` from degrees to radians
 ---@param a number
 ---@return number

--- a/data/meta/_Core.lua
+++ b/data/meta/_Core.lua
@@ -28,6 +28,9 @@ package.reimport = function(name) end
 --- Log the specified string at the Warning semantic level
 function logWarning(string) end
 
+--- Log the specified string at the Verbose semantic level
+function logVerbose(string) end
+
 -- ============================================================================
 
 -- Document lua Constants as typed subclasses of string for API visibility sake

--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -11,19 +11,21 @@ local ui = require 'pigui.libs.forwarded'
 --
 -- Function: ui.pcall
 --
--- ui.pcall(fun, ...)
+-- Run a function in *protected mode* with the given arguments. Any error
+-- inside the function will be caught and the ImGui stack cleaned up to a safe
+-- state to continue calling UI functions.
 --
--- Clean up the ImGui stack in case of an error
---
+-- A detailed stack dump of the error will be written to the game's output log
+-- and a traceback returned with the error message.
 --
 -- Example:
 --
--- >
+-- > local ok, err = ui.pcall(fun, ...)
 --
 -- Parameters:
 --
---   fun -
---   ... -
+--   fun - function to call in protected mode
+--   ... - any arguments to be passed to the function
 --
 -- Returns:
 --
@@ -33,6 +35,8 @@ function ui.pcall(fun, ...)
 	local stack = pigui.GetImguiStack()
 	return xpcall(fun, function(msg)
 		pigui.CleanupImguiStack(stack)
+		logWarning("Caught error in Lua UI code:\n\t" .. tostring(msg) .. '\n')
+		logVerbose(debug.dumpstack(2))
 		return debug.traceback(msg, 2) .. "\n"
 	end, ...)
 end

--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -168,7 +168,7 @@ local function drawGameModules(delta_t)
 			local ok, err = ui.pcall(module.draw, module, delta_t)
 			if not ok then
 				module.disabled = true
-				logWarning(err)
+				-- TODO: visually notify the user of an error
 			end
 		end
 	end

--- a/data/pigui/views/tab-view.lua
+++ b/data/pigui/views/tab-view.lua
@@ -116,7 +116,6 @@ function PiGuiTabView.renderTabView(self)
 			ui.window("StationView", mainWindowFlags, function()
 				self:renderTab(function()
 					tab.showView, tab.err = ui.pcall(tab.draw, tab)
-					if not tab.showView then logWarning(tab.err) end
 				end)
 			end)
 		end)

--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -104,6 +104,8 @@ void Log::Logger::WriteLog(Time::DateTime time, Severity sv, std::string_view ms
 
 	if (file && sv <= m_maxFileSeverity) {
 		fmt::print(file, "[{0}]{1:>8}: {2}", time.ToTimeString(), svName, msg);
+		// flush log file to ensure we have complete data in case of a crash
+		fflush(file);
 	}
 
 	if (sv <= m_maxMsgSeverity) {

--- a/src/lua/LuaManager.cpp
+++ b/src/lua/LuaManager.cpp
@@ -23,6 +23,11 @@ LuaManager::LuaManager() :
 	// in the codebase and thus available via the "immediate" window in the MSVC debugger for us in any C++ lua function
 	pi_lua_stacktrace(m_lua);
 
+	// this will print the lua version as a string and ensure the function is included for use while debugging.
+	lua_pushstring(m_lua, LUA_VERSION);
+	pi_lua_printvalue(m_lua, -1);
+	lua_pop(m_lua, 1);
+
 	instantiated = true;
 }
 

--- a/src/lua/LuaUtils.h
+++ b/src/lua/LuaUtils.h
@@ -83,6 +83,9 @@ bool pi_lua_split_table_path(lua_State *l, const std::string &path);
 
 int secure_trampoline(lua_State *l);
 
+std::string pi_lua_traceback(lua_State *l, int top);
+std::string pi_lua_dumpstack(lua_State *l, int top);
+void pi_lua_printvalue(lua_State *l, int idx);
 void pi_lua_stacktrace(lua_State *l);
 
 #ifdef DEBUG

--- a/src/lua/core/Debug.cpp
+++ b/src/lua/core/Debug.cpp
@@ -1,0 +1,258 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "CoreFwdDecl.h"
+#include "FileSystem.h"
+#include "core/Log.h"
+#include "libs.h"
+#include "lua.h"
+
+// Forward declarations
+std::string pi_lua_tostring(lua_State *l, int idx, int indent = 0, int recurseTable = -1);
+std::string pi_lua_traceback(lua_State *l, int top);
+
+// ==================================================
+
+static std::string_view _get_funcsource(lua_Debug *entry)
+{
+	std::string_view src = entry->source;
+	if (starts_with(src, "@[T] ")) {
+		return src.substr(5); // strip trusted mark from filename
+	} else if (starts_with(src, "@")) {
+		return src.substr(1); // strip mark from filename
+	} else {
+		return entry->short_src; // let lua figure it out
+	}
+}
+
+static std::string _get_funcname(lua_State *l, lua_Debug *entry)
+{
+	if (entry->namewhat[0] != '\0') {
+		return fmt::format("function {}", entry->name);
+	} else if (entry->what[0] == 'm') {
+		return "main chunk";
+	} else if (entry->what[0] == 'C') {
+		return "?";
+	} else {
+		return fmt::format("function <{}:{}>", _get_funcsource(entry), entry->linedefined);
+	}
+}
+
+static std::string _iterate_locals(lua_State *l, lua_Debug *entry, int recurseTable, int startIdx, int endIdx = 0)
+{
+	// Iterate parameters or locals
+	std::string accum = "";
+	int stackIdx = lua_gettop(l) + 1;
+	const char *paramName = nullptr;
+
+	while ((paramName = lua_getlocal(l, entry, startIdx)) != nullptr) {
+		if (!starts_with(paramName, "(*temp")) // filter out lua temporaries
+			accum += fmt::format("\t\t{} = {}\n", paramName, pi_lua_tostring(l, stackIdx, 2, recurseTable));
+		lua_pop(l, 1);
+
+		startIdx += (startIdx < 0 ? -1 : 1);
+		if (endIdx && startIdx > endIdx)
+			break;
+	}
+
+	return accum;
+}
+
+std::string pi_lua_traceback(lua_State *l, int top)
+{
+	LUA_DEBUG_START(l);
+	std::string accum = "stack traceback:\n";
+
+	lua_Debug entry;
+	int depth = top;
+
+	while (lua_getstack(l, depth, &entry)) {
+		lua_getinfo(l, "Slntu", &entry);
+
+		accum += fmt::format("\t{}:{} in {}\n", _get_funcsource(&entry), entry.currentline, _get_funcname(l, &entry));
+
+		if (entry.istailcall)
+			accum += "\t(...tail calls...)\n";
+
+		depth++;
+	}
+
+	LUA_DEBUG_END(l, 0);
+	return accum;
+}
+
+std::string pi_lua_dumpstack(lua_State *l, int top)
+{
+	LUA_DEBUG_START(l);
+	std::string accum = "stack dump:\n";
+
+	lua_newtable(l);
+	int recurseTable = lua_gettop(l);
+
+	lua_Debug entry;
+	int depth = top;
+
+	while (lua_getstack(l, depth, &entry)) {
+		lua_getinfo(l, "Slntu", &entry);
+
+		accum += fmt::format("\t#{}: {}:{}", depth - top + 1, _get_funcsource(&entry), entry.currentline);
+
+		accum += fmt::format(" in {}:\n", _get_funcname(l, &entry));
+
+		if (entry.what[0] == 'C') {
+			accum += _iterate_locals(l, &entry, recurseTable, -1);
+		} else {
+			if (entry.nparams)
+				accum += _iterate_locals(l, &entry, recurseTable, 1, entry.nparams);
+			if (entry.isvararg)
+				accum += _iterate_locals(l, &entry, recurseTable, -1);
+
+			accum += _iterate_locals(l, &entry, recurseTable, entry.nparams + 1);
+		}
+
+		accum += "\n";
+
+		if (entry.istailcall)
+			accum += "\t(...tail calls...)\n";
+
+		depth++;
+	}
+
+	lua_pop(l, 1);
+
+	LUA_DEBUG_END(l, 0);
+	return accum;
+}
+
+// recurse through a table and print its values
+std::string _pi_lua_table_tostring(lua_State *l, int idx, int indent, int recurseTable)
+{
+	LUA_DEBUG_START(l);
+	lua_checkstack(l, 2);
+
+	if (recurseTable > 0) {
+		lua_pushvalue(l, idx);
+		lua_rawget(l, recurseTable);
+
+		if (!lua_isnil(l, -1)) {
+			lua_pop(l, 1);
+			LUA_DEBUG_END(l, 0);
+			return "[R]";
+		}
+
+		lua_pop(l, 1);
+		lua_pushvalue(l, idx);
+		lua_pushboolean(l, true);
+		lua_rawset(l, recurseTable);
+	}
+
+	std::string accum = "{\n";
+
+	int top = lua_gettop(l);
+
+	// count number of keys in table
+	int iter = 0;
+
+	lua_pushnil(l);
+	while (lua_next(l, idx) != 0) {
+		lua_pop(l, 1);
+		++iter;
+	}
+
+	// Too many keys in this table, don't pollute the log
+	if (iter >= 30) {
+		LUA_DEBUG_END(l, 0);
+		return "{ ... }";
+	}
+
+	lua_pushnil(l);
+	while (lua_next(l, idx) != 0) {
+		accum.append(indent + 1, '\t');
+		accum += fmt::format("{} = {}\n",
+			pi_lua_tostring(l, top + 1, indent + 1, recurseTable),
+			pi_lua_tostring(l, top + 2, indent + 1, recurseTable));
+		lua_pop(l, 1); // pop the value and leave the key on the stack
+	}
+
+	accum.append(indent, '\t');
+	accum += "}";
+
+	LUA_DEBUG_END(l, 0);
+	return accum;
+}
+
+// Return a debug representation of the given lua value
+std::string pi_lua_tostring(lua_State *l, int idx, int indent, int recurseTable)
+{
+	lua_checkstack(l, 1);
+
+	int type = lua_type(l, idx);
+
+	switch (type) {
+		case LUA_TNIL:
+		case LUA_TBOOLEAN:
+		case LUA_TNUMBER:
+		case LUA_TSTRING:
+		case LUA_TUSERDATA: {
+			std::string str = luaL_tolstring(l, idx, NULL);
+			lua_pop(l, 1);
+			return str;
+		}
+
+		case LUA_TLIGHTUSERDATA:
+			return fmt::format("<ptr {}>", lua_touserdata(l, idx));
+
+		case LUA_TTABLE: {
+			if (luaL_getmetafield(l, idx, "class")) {
+				if (lua_isstring(l, -1)) {
+					std::string className = lua_tostring(l, -1);
+					lua_pop(l, 1);
+					return fmt::format("<table {} ({})> {}", className, lua_topointer(l, idx),
+						_pi_lua_table_tostring(l, idx, indent, recurseTable));
+				}
+			}
+
+			return fmt::format("<table ({})> {}", lua_topointer(l, idx),
+				_pi_lua_table_tostring(l, idx, indent, recurseTable));
+		}
+		case LUA_TFUNCTION: {
+			lua_Debug ar;
+			lua_pushvalue(l, idx);
+			lua_getinfo(l, ">S", &ar);
+			if (ar.what[0] == 'C')
+				return fmt::format("<function [C] {}>", lua_topointer(l, idx));
+			else
+				return fmt::format("<function {}:{}>", _get_funcsource(&ar), ar.linedefined);
+		}
+		case LUA_TTHREAD: {
+			lua_State *thread = lua_tothread(l, idx);
+			if (lua_status(thread) == LUA_YIELD)
+				return fmt::format("<yielded thread {}> @ {}", lua_topointer(l, idx), pi_lua_traceback(thread, 0));
+			else
+				return fmt::format("<thread {}>", lua_topointer(l, idx));
+		}
+		default:
+			return "<none>";
+	}
+}
+
+// Pretty-print a lua value to the console for debugging
+void pi_lua_printvalue(lua_State *l, int idx)
+{
+	Log::Info("{}\n", pi_lua_tostring(l, lua_absindex(l, idx)));
+}
+
+// https://zeux.io/2010/11/07/lua-callstack-with-c-debugger/
+void pi_lua_stacktrace(lua_State *l)
+{
+	lua_Debug entry;
+	int depth = 0;
+
+	while (lua_getstack(l, depth, &entry)) {
+		int status = lua_getinfo(l, "Sln", &entry);
+		assert(status);
+
+		Output("%s(%d): %s\n", entry.short_src, entry.currentline, entry.name ? entry.name : "?");
+		depth++;
+	}
+}

--- a/src/lua/core/Import.cpp
+++ b/src/lua/core/Import.cpp
@@ -90,13 +90,13 @@ static std::string get_caller(lua_State *L)
 		int start = 0;
 		int end = strlen(ar.source);
 
-		// strip the trusted annotation if present
-		if ((ar.source[start] != '@') && (end > 5))
-			start = 4;
-
 		// if we have an @, this is a file name. Strip it and return the file name
 		if (ar.source[start] == '@') {
 			start++;
+
+			// strip the trusted annotation ("@[T] ") if present
+			if ((ar.source[start] == '[') && (end > 5))
+				start += 4;
 
 			caller = std::string(&ar.source[start], end - start);
 		}

--- a/src/lua/core/Sandbox.cpp
+++ b/src/lua/core/Sandbox.cpp
@@ -3,6 +3,7 @@
 
 #include "CoreFwdDecl.h"
 #include "FileSystem.h"
+#include "LuaUtils.h"
 #include "core/Log.h"
 #include "libs.h"
 
@@ -32,6 +33,27 @@ static int l_d_mode_enabled(lua_State *L)
 	return 1;
 }
 
+static int l_d_traceback(lua_State *L)
+{
+	const char *str = luaL_optstring(L, 1, "");
+	int level = luaL_optinteger(L, 2, 1);
+
+	if (str[0] != '\0') {
+		lua_pushstring(L, fmt::format("{}\n{}", str, pi_lua_traceback(L, level)).c_str());
+	} else {
+		lua_pushstring(L, pi_lua_traceback(L, level).c_str());
+	}
+
+	return 1;
+}
+
+static int l_d_dumpstack(lua_State *L)
+{
+	int level = luaL_optinteger(L, 1, 1);
+
+	lua_pushstring(L, pi_lua_dumpstack(L, level).c_str());
+	return 1;
+}
 
 // Copy of luaB_print tailored to use Pioneer logging facilities
 static int l_print(lua_State *L)
@@ -59,6 +81,7 @@ static int l_print(lua_State *L)
 		lua_pop(L, 1);  /* pop result */
 	}
 
+	accum.append("\n");
 	Log::GetLog()->LogLevel(Log::Severity::Info, accum);
 	return 0;
 }
@@ -180,12 +203,22 @@ void pi_lua_open_standard_base(lua_State *L)
 	lua_pushcfunction(L, l_d_null_userdata);
 	lua_setfield(L, -2, "makenull");
 
+	lua_pushcfunction(L, l_d_traceback);
+	lua_setfield(L, -2, "traceback");
+
+	lua_pushcfunction(L, l_d_dumpstack);
+	lua_setfield(L, -2, "dumpstack");
+
 	lua_pop(L, 1); // pop the debug table
 }
 
 static int l_handle_error(lua_State *L)
 {
 	const char *msg = lua_tostring(L, 1);
+
+	Log::Debug("{}\n", msg);
+	Log::Debug("{}", pi_lua_dumpstack(L, 1));
+
 	luaL_traceback(L, L, msg, 1);
 	return 1;
 }
@@ -199,12 +232,11 @@ int pi_lua_panic(lua_State *L)
 	errorMsg += lua_tostring(L, -1);
 	lua_pop(L, 1);
 
-	lua_getglobal(L, "debug");
-	lua_getfield(L, -1, "traceback");
-	lua_call(L, 0, 1);
-	errorMsg += "\n";
-	errorMsg += lua_tostring(L, -1);
-	errorMsg += "\n";
+	Log::Debug("{}\n", errorMsg);
+	Log::Debug("{}", pi_lua_dumpstack(L, 0));
+
+	errorMsg += "\n" + pi_lua_traceback(L, 0) + "\n";
+
 	Error("%s", errorMsg.c_str());
 	// Error() is noreturn
 
@@ -223,7 +255,7 @@ void pi_lua_protected_call(lua_State *L, int nargs, int nresults)
 	if (ret) {
 		std::string errorMsg = lua_tostring(L, -1);
 		lua_pop(L, 1);
-		Error("%s", errorMsg.c_str());
+		Error("%s\n", errorMsg.c_str());
 	}
 }
 
@@ -430,19 +462,4 @@ int secure_trampoline(lua_State *l)
 
 	lua_CFunction fn = lua_tocfunction(l, lua_upvalueindex(1));
 	return fn(l);
-}
-
-// https://zeux.io/2010/11/07/lua-callstack-with-c-debugger/
-void pi_lua_stacktrace(lua_State *l)
-{
-	lua_Debug entry;
-	int depth = 0;
-
-	while (lua_getstack(l, depth, &entry)) {
-		int status = lua_getinfo(l, "Sln", &entry);
-		assert(status);
-
-		Output("%s(%d): %s\n", entry.short_src, entry.currentline, entry.name ? entry.name : "?");
-		depth++;
-	}
 }


### PR DESCRIPTION
This PR adds a few utility functions to vastly improve the quality of debugging information we're able to collect in the event of a Lua error or crash.

I've added `debug.dumpstack(level)` which performs a verbose trace through the callstack, recursively dumping the contents of parameters and locals in each stack frame to a string. This allows the state of the program at the point of the error to be inspected to attempt to determine what is responsible for the crash, as well as providing a little more context as to what events lead to the crash in question.

The `ui.pcall` utility has been updated to automatically log a stack dump if an error was triggered. A short callstack will still be displayed in the UI where appropriate, but the full stack dump will be written to `output.txt`.

C++ panic and pcall error handlers also now log stack dumps when encountering a fatal error.

I've changed the 'trusted file' indicator string used when loading Lua chunks to `@[T]` instead of `[T] @`, which matches Lua's assumptions about whether a chunk name is a filepath or a raw string. I've updated `debug.stacktrace()` with a new implementation that respects this change.

I've also made some utility changes to the Lua-scope logging tools:
- Add Lua `logVerbose()` function to complement `logWarning()`.
- Update our `print()` implementation to write to the log as well as the console / stdout.
- Rewrite `utils.print_r()` to print a single string instead of 100s of tiny strings.
- The log functions now flush the log file on write, to prevent log messages from being lost or truncated in event of a crash.
