### PR TITLE
Have fancy bug reporting with redirection to wiki/manual/forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,16 @@
+---
+title:
+name: 🪳 Report a bug
+about: Report a defect or unexpected behaviour. Do not use this for feature suggestions.
+note: See FAQ if uncertain: http://pioneerwiki.com/wiki/FAQ#How.2Fwhere_do_I_report_my_bug.2Fcrash
+---
+
 <!-- This is a suggested template for your issue. (remove as you check)     -->
 <!--   * if graphical: also include opengl.txt from pioneer config dir      -->
 <!--     (consult FAQ on wiki for info on how to find opengl.txt).          -->
 <!--   * Please Include version of your last bug-free Pioneer, if possible. -->
 <!--   * Has the issue been reported before? Search the issue tracker.      -->
 <!--   * Perhaps a screenshot illustrates the bug well?                     -->
-<!--   * Feature request? Please consider IRC, player- or dev-forum instead -->
 
 
 ### Observed behaviour

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,23 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "💡 Suggest a feature"
+    url: https://pioneerspacesim.net/forum
+    about: Feature requests and development discussions go on the forum - not on the issue tracker
+  - name: "❓ Pioneer FAQ"
+    url: https://pioneerwiki.com/wiki/FAQ
+    about: Others might have had the same question before.
+  - name: "ℹ️ Pioneer Manual"
+    url: https://pioneerwiki.com/wiki/Manual
+    about: Manual for the game
+  - name: "🚀 Pioneer Flight Manual"
+    url: https://pioneerwiki.com/wiki/Basic_flight
+    about: Manual for flying
+  - name: "🆘 Get in touch with other players"
+    url: https://spacesimcentral.com/community/pioneer/
+    about: Community forum is for players sharing
+  - name: "👨‍💻 Get in touch with developers"
+    url: https://kiwiirc.com/client/irc.libera.chat/pioneer
+    about: Developers coordinate through IRC (mostly inactive during CET night).
+  - name: "🗣️ Contribute language translation"
+    url: https://www.transifex.com/pioneer/pioneer/dashboard/
+    about: All translations and language improvements are entirely community driven


### PR DESCRIPTION
This generates a menu when trying to open a new issue, with re-direct links to FAQ,, manual, dev-forum for feature requests, transifex for lanugage contributions.

~I'll admit~, I have ~not~ read the [documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) for this fully, but rather lazily copy-pasted from another repo:
- Click "new issue" on [this repo](https://github.com/magit/magit/issues), and you see what I'm aiming for