### PR TITLE
Some improvements and fixes in data management

### DIFF
--- a/data/modules/TradeShips/Events.lua
+++ b/data/modules/TradeShips/Events.lua
@@ -322,5 +322,6 @@ local onGameEnd = function ()
 	-- drop the references for our data so Lua can free them
 	-- and so we can start fresh if the player starts another game
 	Core.ships, Core.params = nil, nil
+	Core.log:clear()
 end
 Event.Register("onGameEnd", onGameEnd)

--- a/src/ConnectionTicket.h
+++ b/src/ConnectionTicket.h
@@ -1,0 +1,23 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "sigc++/connection.h"
+
+// Lifetime management utility for sigc::connection
+// Use this instead of sigs::connection if you don't want to manually
+// disconnect in the destructor
+
+struct ConnectionTicket {
+
+	~ConnectionTicket() {
+		m_connection.disconnect();
+	}
+
+	void operator=(sigc::connection &&c) {
+		m_connection = c;
+	}
+
+	sigc::connection m_connection;
+};

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -35,6 +35,8 @@
 #include <sstream>
 #include <unordered_set>
 
+SectorView::~SectorView() {}
+
 using namespace Graphics;
 
 static const int DRAW_RAD = 5;
@@ -621,15 +623,6 @@ void SectorView::InitObject()
 	m_lineMat.Reset(m_renderer->CreateMaterial("vtxColor", lineDesc, rsd));
 
 	m_drawList.reset(new ImDrawList(ImGui::GetDrawListSharedData()));
-}
-
-SectorView::~SectorView()
-{
-	m_onMouseWheelCon.disconnect();
-	m_onToggleSelectionFollowView.disconnect();
-	m_onWarpToCurrent.disconnect();
-	m_onWarpToSelected.disconnect();
-	m_onViewReset.disconnect();
 }
 
 void SectorView::SaveToJson(Json &jsonObj)

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -4,6 +4,7 @@
 #ifndef _SECTORVIEW_H
 #define _SECTORVIEW_H
 
+#include "ConnectionTicket.h"
 #include "DeleteEmitter.h"
 #include "Input.h"
 #include "galaxy/Sector.h"
@@ -162,11 +163,11 @@ private:
 
 	Uint8 m_detailBoxVisible;
 
-	sigc::connection m_onMouseWheelCon;
-	sigc::connection m_onToggleSelectionFollowView;
-	sigc::connection m_onWarpToCurrent;
-	sigc::connection m_onWarpToSelected;
-	sigc::connection m_onViewReset;
+	ConnectionTicket m_onMouseWheelCon;
+	ConnectionTicket m_onToggleSelectionFollowView;
+	ConnectionTicket m_onWarpToCurrent;
+	ConnectionTicket m_onWarpToSelected;
+	ConnectionTicket m_onViewReset;
 
 	RefCountedPtr<SectorCache::Slave> m_sectorCache;
 	std::string m_previousSearch;

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -105,7 +105,6 @@ SystemView::SystemView(Game *game) :
 SystemView::~SystemView()
 {
 	m_contacts.clear();
-	m_onMouseWheelCon.disconnect();
 }
 
 void SystemView::AccelerateTime(float step)

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -14,6 +14,7 @@
 #include "matrix4x4.h"
 #include "pigui/PiGuiView.h"
 #include "vector3.h"
+#include "ConnectionTicket.h"
 
 class StarSystem;
 class SystemBody;
@@ -219,7 +220,7 @@ private:
 	bool m_realtime;
 	double m_timeStep;
 
-	sigc::connection m_onMouseWheelCon;
+	ConnectionTicket m_onMouseWheelCon;
 
 	std::unique_ptr<Graphics::Drawables::Disk> m_bodyIcon;
 	std::unique_ptr<Graphics::Material> m_bodyMat;

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -27,6 +27,8 @@
 #include "ship/ShipViewController.h"
 #include "sound/Sound.h"
 
+WorldView::~WorldView() {}
+
 namespace {
 	static const float HUD_CROSSHAIR_SIZE = 8.0f;
 	static const Color green(0, 255, 0, 204);
@@ -121,12 +123,6 @@ void WorldView::InitObject()
 	m_onDecTimeAccelCon = InputBindings.decreaseTimeAcceleration->onPressed.connect(sigc::mem_fun(this, &WorldView::OnRequestTimeAccelDec));
 }
 
-WorldView::~WorldView()
-{
-	m_onToggleHudModeCon.disconnect();
-	m_onIncTimeAccelCon.disconnect();
-	m_onDecTimeAccelCon.disconnect();
-}
 
 void WorldView::SaveToJson(Json &jsonObj)
 {

--- a/src/WorldView.h
+++ b/src/WorldView.h
@@ -4,6 +4,7 @@
 #ifndef _WORLDVIEW_H
 #define _WORLDVIEW_H
 
+#include "ConnectionTicket.h"
 #include "graphics/Drawables.h"
 #include "pigui/PiGuiView.h"
 #include "ship/ShipViewController.h"
@@ -32,7 +33,7 @@ public:
 	friend class NavTunnelWidget;
 	WorldView(Game *game);
 	WorldView(const Json &jsonObj, Game *game);
-	virtual ~WorldView();
+	~WorldView() override;
 
 	void Update() override;
 	void Draw3D() override;
@@ -110,9 +111,9 @@ private:
 
 	bool m_labelsOn;
 
-	sigc::connection m_onToggleHudModeCon;
-	sigc::connection m_onIncTimeAccelCon;
-	sigc::connection m_onDecTimeAccelCon;
+	ConnectionTicket m_onToggleHudModeCon;
+	ConnectionTicket m_onIncTimeAccelCon;
+	ConnectionTicket m_onDecTimeAccelCon;
 
 	RefCountedPtr<CameraContext> m_cameraContext;
 	std::unique_ptr<Camera> m_camera;

--- a/src/lua/LuaConsole.cpp
+++ b/src/lua/LuaConsole.cpp
@@ -60,11 +60,6 @@ LuaConsole::LuaConsole() :
 	std::fill_n(m_editBuffer.get(), EDIT_BUFFER_LENGTH, '\0');
 }
 
-LuaConsole::~LuaConsole()
-{
-	m_logCallbackConn.disconnect();
-}
-
 REGISTER_INPUT_BINDING(LuaConsole)
 {
 	auto *group = Pi::input->GetBindingPage("General")->GetBindingGroup("Miscellaneous");

--- a/src/lua/LuaConsole.h
+++ b/src/lua/LuaConsole.h
@@ -7,7 +7,7 @@
 #include "Input.h"
 #include "LuaManager.h"
 #include "RefCounted.h"
-#include "sigc++/connection.h"
+#include "ConnectionTicket.h"
 #include <deque>
 
 struct ImGuiInputTextCallbackData;
@@ -15,7 +15,6 @@ struct ImGuiInputTextCallbackData;
 class LuaConsole {
 public:
 	LuaConsole();
-	~LuaConsole();
 
 	void SetupBindings();
 	void Toggle();
@@ -51,7 +50,7 @@ private:
 	bool m_active;
 	Input::InputFrame m_inputFrame;
 	InputBindings::Action *toggleLuaConsole;
-	sigc::connection m_logCallbackConn;
+	ConnectionTicket m_logCallbackConn;
 
 	// Output log
 	std::vector<std::string> m_outputLines;

--- a/src/lua/LuaRef.cpp
+++ b/src/lua/LuaRef.cpp
@@ -42,7 +42,6 @@ void LuaRef::Unref()
 {
 	if (m_id != LUA_NOREF && m_lua) {
 		--(*m_copycount);
-		m_id = LUA_NOREF;
 		CheckCopyCount();
 	}
 }
@@ -70,6 +69,7 @@ void LuaRef::CheckCopyCount()
 		PushGlobalToStack();
 		luaL_unref(m_lua, -1, m_id);
 		lua_pop(m_lua, 1);
+		m_id = LUA_NOREF;
 	}
 }
 

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -225,14 +225,7 @@ void PlayerShipController::InputBinding::RegisterBindings()
 
 PlayerShipController::~PlayerShipController()
 {
-	m_toggleSpeedLimiter.disconnect();
-	m_toggleCruise.disconnect();
-	m_fireMissileKey.disconnect();
-	m_connRotationDampingToggleKey.disconnect();
-
 	Pi::input->RemoveInputFrame(&InputBindings);
-	m_connRotationDampingToggleKey.disconnect();
-	m_fireMissileKey.disconnect();
 }
 
 void PlayerShipController::SaveToJson(Json &jsonObj, Space *space)

--- a/src/ship/PlayerShipController.h
+++ b/src/ship/PlayerShipController.h
@@ -5,6 +5,7 @@
 
 #include "Input.h"
 #include "ShipController.h"
+#include "ConnectionTicket.h"
 
 // autopilot AI + input
 class PlayerShipController : public ShipController {
@@ -146,8 +147,8 @@ private:
 	FollowMode m_followMode = FOLLOW_POS;
 	CruiseDirection m_cruiseDirection = CRUISE_FWD;
 
-	sigc::connection m_connRotationDampingToggleKey;
-	sigc::connection m_fireMissileKey;
-	sigc::connection m_toggleCruise;
-	sigc::connection m_toggleSpeedLimiter;
+	ConnectionTicket m_connRotationDampingToggleKey;
+	ConnectionTicket m_fireMissileKey;
+	ConnectionTicket m_toggleCruise;
+	ConnectionTicket m_toggleSpeedLimiter;
 };


### PR DESCRIPTION
- create a wrapper for `sigc::signal`, automatically disconnected in the destructor
- fix bug in `LuaRef::Unref` causing leaks
- clear the log of tradeships after the end of the game, so that links to ships do not hang in it

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

