### PR TITLE
Fixes #5403 kill rotation killing HUD and bringing back possibility to turn rotation damping off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ endif(APPLE)
 option(USE_LLD_LINKER "Use the LLVM lld linker instead of gcc's linker" OFF)
 if (CMAKE_COMPILER_IS_GNUCXX)
 	add_compile_options(
-		-fdiagnostics-color
+		-fdiagnostics-color=auto
 		-Wall
 		-Wextra
 		-Wno-unused-parameter

--- a/data/pigui/modules/flight-ui/reticule.lua
+++ b/data/pigui/modules/flight-ui/reticule.lua
@@ -478,7 +478,8 @@ local flightstate_info = {
 	["CONTROL_FIXHEADING_ANTINORMAL"] = { icon = icons.antinormal_thin, tooltip = lui.HUD_BUTTON_FIX_ANTINORMAL },
 	["CONTROL_FIXHEADING_RADIALLY_INWARD"] = { icon = icons.radial_in_thin, tooltip = lui.HUD_BUTTON_FIX_RADIAL_IN },
 	["CONTROL_FIXHEADING_RADIALLY_OUTWARD"] = { icon = icons.radial_out_thin, tooltip = lui.HUD_BUTTON_FIX_RADIAL_OUT },
-	["CONTROL_FIXHEADING_KILLROT"] = { icon = icons.rotation_damping_on_thin , tooltip = lui.HUD_BUTTON_KILL_ROTATION }
+	-- "CONTROL_FIXHEADING_KILLROT" uses the same icon as rotation damping on
+	["CONTROL_FIXHEADING_KILLROT"] = { icon = icons.rotation_damping_on , tooltip = lui.HUD_BUTTON_KILL_ROTATION }
 }
 
 local radial_menu_actions_orbital = {

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -343,7 +343,10 @@ public:
 	bool AIMatchVel(const vector3d &vel, const vector3d &powerLimit = vector3d(1.0)) { return m_propulsion->AIMatchVel(vel, powerLimit); }
 	double AIFaceDirection(const vector3d &dir, double av = 0) { return m_propulsion->AIFaceDirection(dir, av); }
 	void SetThrusterState(int axis, double level) { return m_propulsion->SetLinThrusterState(axis, level); }
-	void AIMatchAngVelObjSpace(const vector3d &desiredAngVel, const vector3d &powerLimit = vector3d(1.0)) { return m_propulsion->AIMatchAngVelObjSpace(desiredAngVel, powerLimit); }
+	void AIMatchAngVelObjSpace(const vector3d &desiredAngVel, const vector3d &powerLimit = vector3d(1.0), bool ignoreZeroValues = false)
+	{
+		m_propulsion->AIMatchAngVelObjSpace(desiredAngVel, powerLimit, ignoreZeroValues);
+	}
 };
 
 #endif /* _SHIP_H */

--- a/src/ship/PlayerShipController.h
+++ b/src/ship/PlayerShipController.h
@@ -107,7 +107,7 @@ private:
 	struct Util;
 
 	// Poll controls, set gun states
-	void PollControls(float timeStep, const bool force_rotation_damping, int *mouseMotion, TotalDesiredAction &outParams);
+	void PollControls(float timeStep, int *mouseMotion, TotalDesiredAction &outParams);
 	// desired speed of linear and rotary movement, calculated by flight control assistance
 	void FlightAssist(const float timeStep, TotalDesiredAction &outParams);
 	// send a control request to propulsion

--- a/src/ship/Propulsion.cpp
+++ b/src/ship/Propulsion.cpp
@@ -363,16 +363,24 @@ vector3d Propulsion::AIChangeVelDir(const vector3d &reqdiffvel)
 }
 
 // Input in object space
-void Propulsion::AIMatchAngVelObjSpace(const vector3d &angvel, const vector3d &powerLimit)
+void Propulsion::AIMatchAngVelObjSpace(const vector3d &angvel, const vector3d &powerLimit, bool ignoreZeroValues)
 {
 	double maxAccel = m_angThrust / m_dBody->GetAngularInertia();
 	double invFrameAccel = 1.0 / maxAccel / Pi::game->GetTimeStep();
 
-	vector3d diff = angvel - m_dBody->GetAngVelocity() * m_dBody->GetOrient(); // find diff between current & desired angvel
-	diff = diff * invFrameAccel;
-	diff.x = Clamp(diff.x, -powerLimit.x, powerLimit.x);
-	diff.y = Clamp(diff.y, -powerLimit.y, powerLimit.y);
-	diff.z = Clamp(diff.z, -powerLimit.z, powerLimit.z);
+	vector3d currAngVel = m_dBody->GetAngVelocity() * m_dBody->GetOrient();
+	vector3d diff;
+
+	for (int axis = 0; axis < 3; axis++) {
+
+		if (!ignoreZeroValues || abs(angvel[axis]) > 0.001) {
+			diff[axis] = (angvel[axis] - currAngVel[axis]);
+			diff[axis] = diff[axis] * invFrameAccel;
+			diff[axis] = Clamp(diff[axis], -powerLimit[axis], powerLimit[axis]);
+		} else
+			diff[axis] = 0.0;
+	}
+
 	SetAngThrusterState(diff);
 }
 

--- a/src/ship/Propulsion.h
+++ b/src/ship/Propulsion.h
@@ -116,7 +116,7 @@ public:
 	bool AIMatchVel(const vector3d &vel, const vector3d &powerLimit = vector3d(1.0));
 	bool AIChangeVelBy(const vector3d &diffvel, const vector3d &powerLimit = vector3d(1.0)); // acts in object space
 	vector3d AIChangeVelDir(const vector3d &diffvel);										 // object space, maintain direction
-	void AIMatchAngVelObjSpace(const vector3d &angvel, const vector3d &powerLimit = vector3d(1.0));
+	void AIMatchAngVelObjSpace(const vector3d &angvel, const vector3d &powerLimit = vector3d(1.0), bool ignoreZeroValues = false);
 	double AIFaceUpdir(const vector3d &updir, double av = 0);
 	double AIFaceDirection(const vector3d &dir, double av = 0);
 	vector3d AIGetLeadDir(const Body *target, const vector3d &targaccel, double projspeed);


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
First issue was undefined icon for kill rotation in lua code for the HUD reticule. The result was assertion and killing the HUD permanently.
The second thing was that handling of rotation damping on/off was completely removed with some recent refactoring. I brought it back using logic from 20220203.
<!-- Please make sure you've read documentation on contributing -->

