### PR TITLE
Fix animation import issues with assimp >= 5.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ else (MSVC)
 	pkg_check_modules(SDL2 REQUIRED sdl2)
 	pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
 
-	pkg_check_modules(ASSIMP REQUIRED assimp>=5.0.1)
+	pkg_check_modules(ASSIMP REQUIRED assimp>=5.0)
 	pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
 	pkg_check_modules(VORBISFILE REQUIRED vorbisfile)
 endif (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ else (MSVC)
 	pkg_check_modules(SDL2 REQUIRED sdl2)
 	pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
 
-	pkg_check_modules(ASSIMP REQUIRED assimp)
+	pkg_check_modules(ASSIMP REQUIRED assimp>=5.0.1)
 	pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
 	pkg_check_modules(VORBISFILE REQUIRED vorbisfile)
 endif (MSVC)

--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -57,11 +57,11 @@ questions are welcome anytime.
     libsigc++-2.0
     libsigc++-2.0-dev
     libvorbis-dev
-    libassimp-dev >= 3.2
+    libassimp-dev >= 5.0.1
     libsdl2-dev
     libsdl2-image-dev
 
-   If your platform doesn't have assimp 3.2, you'll need to build it from
+   If your platform doesn't have assimp 5, you'll need to build it from
    source. It's available in pioneer-thirdparty, see below.
 
 2. Run './bootstrap' to generate CMake build files in the 'build' folder.
@@ -123,11 +123,11 @@ questions are welcome anytime.
 3. Go to File->Open->CMake and select pioneer/CMakeLists.txt
 
 4. Select the appropriate build type (x64-Debug or x64-Release) under the configuration
-   drop down on the main toolbar, located next to the run button. 
+   drop down on the main toolbar, located next to the run button.
 
 5. Build the project (Build->Build All).
 
-6. Pioneer can be run and debugged by selecting 'pioneer.exe' on the 
+6. Pioneer can be run and debugged by selecting 'pioneer.exe' on the
    'Select Startup Item' menu (click the small down arrow on the run button), and then clicking run.
    Be sure to select 'pioneer.exe' and not 'pioneer.exe (install)'.
 

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -194,9 +194,9 @@ std::string Time::DateTime::ToDateString() const
 std::string Time::DateTime::ToTimeString() const
 {
 	char buf[16];
-	int hour, minute, second;
-	GetTimeParts(&hour, &minute, &second);
-	snprintf(buf, sizeof(buf), "%02d:%02d:%02d", hour, minute, second);
+	int hour, minute, second, microsecond;
+	GetTimeParts(&hour, &minute, &second, &microsecond);
+	snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%06d", hour, minute, second, microsecond);
 	return std::string(buf);
 }
 

--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -19,12 +19,12 @@ namespace Log {
 	Logger s_defaultLog;
 
 	std::map<Severity, std::string> s_severityNames = {
-		{ Severity::Fatal, "Fatal" },
-		{ Severity::Error, "Error" },
-		{ Severity::Warning, "Warning" },
-		{ Severity::Info, "Info" },
-		{ Severity::Debug, "Debug" },
-		{ Severity::Verbose, "Verbose" }
+		{ Severity::Fatal, "Fatal:" },
+		{ Severity::Error, "Error:" },
+		{ Severity::Warning, "Warning:" },
+		{ Severity::Info, "Info:" },
+		{ Severity::Debug, "Debug:" },
+		{ Severity::Verbose, "Verbose:" }
 	};
 
 } // namespace Log
@@ -73,9 +73,10 @@ void Log::Logger::LogLevel(Severity sv, std::string_view message)
 	Time::DateTime epoch(1970, 1, 1);
 	Time::DateTime time = epoch + Time::TimeDelta(t.count(), Time::Microsecond);
 
-	// FIXME: make StringRange derive from string_view so we can use its overloads *and* format it easily
-	while (!message.empty() && is_space(message[0])) {
-		message.remove_prefix(1);
+	// Remove any trailing space suffixes (extra newlines, spaces, etc.)
+	// We'll automatically add a newline to the end of the message when printing it
+	while (!message.empty() && is_space(message.back())) {
+		message.remove_suffix(1);
 	}
 
 	WriteLog(time, sv, message);
@@ -89,12 +90,16 @@ void Log::Logger::WriteLog(Time::DateTime time, Severity sv, std::string_view ms
 	   Builds on /subsystem:WINDOWS will not usually have a console
 	   and fmt::print will throw an exception in this case */
 #ifndef WIN32
-	if (sv <= Severity::Warning) {
-		fmt::print(stderr, "{}: {}", svName, msg);
-	} else if (sv <= m_maxSeverity) {
-		fmt::print(stdout, "{}", msg);
-		// flush stdout because it might have a different cache size than stderr
-		fflush(stdout);
+	auto *outFile = (sv <= Severity::Warning ? stderr : stdout);
+
+	if (sv <= m_maxSeverity) {
+		if (msg.back() == '\n')
+			fmt::print(outFile, "{} {}", svName, msg);
+		else
+			fmt::print(outFile, "{} {}\n", svName, msg);
+
+		// flush log messages to ensure that we retain information in the event of a crash
+		fflush(outFile);
 	}
 #endif
 
@@ -103,7 +108,10 @@ void Log::Logger::WriteLog(Time::DateTime time, Severity sv, std::string_view ms
 	}
 
 	if (file && sv <= m_maxFileSeverity) {
-		fmt::print(file, "[{0}]{1:>8}: {2}", time.ToTimeString(), svName, msg);
+		if (msg.back() == '\n')
+			fmt::print(file, "[{0}] {1:<8} {2}", time.ToTimeString(), svName, msg);
+		else
+			fmt::print(file, "[{0}] {1:<8} {2}\n", time.ToTimeString(), svName, msg);
 		// flush log file to ensure we have complete data in case of a crash
 		fflush(file);
 	}

--- a/src/core/Log.h
+++ b/src/core/Log.h
@@ -52,7 +52,7 @@ namespace Log {
 
 		FILE *file;
 		Severity m_maxSeverity = Severity::Info;
-		Severity m_maxFileSeverity = Severity::Verbose;
+		Severity m_maxFileSeverity = Severity::Debug;
 		Severity m_maxMsgSeverity = Severity::Error;
 		uint8_t current_indent;
 		std::string m_logName;

--- a/src/scenegraph/DumpVisitor.cpp
+++ b/src/scenegraph/DumpVisitor.cpp
@@ -49,7 +49,6 @@ namespace SceneGraph {
 
 	void DumpVisitor::ApplyNode(Node &n)
 	{
-		PutIndent();
 		PutNodeName(n);
 
 		m_stats.nodeCount++;
@@ -57,7 +56,6 @@ namespace SceneGraph {
 
 	void DumpVisitor::ApplyGroup(Group &g)
 	{
-		PutIndent();
 		PutNodeName(g);
 
 		m_level++;
@@ -93,17 +91,11 @@ namespace SceneGraph {
 		ApplyNode(static_cast<Node &>(g));
 	}
 
-	void DumpVisitor::PutIndent() const
-	{
-		for (unsigned int i = 0; i < m_level; i++)
-			Output("  ");
-	}
-
 	void DumpVisitor::PutNodeName(const Node &g) const
 	{
 		if (g.GetName().empty())
-			Output("%s\n", g.GetTypeName());
+			Log::Info("{0:{1}}{2}", " ", m_level * 2, g.GetTypeName());
 		else
-			Output("%s - %s\n", g.GetTypeName(), g.GetName().c_str());
+			Log::Info("{0:{1}}{2} - {3}", " ", m_level * 2, g.GetTypeName(), g.GetName());
 	}
 } // namespace SceneGraph

--- a/src/scenegraph/Loader.h
+++ b/src/scenegraph/Loader.h
@@ -40,9 +40,19 @@ namespace SceneGraph {
 		const std::vector<std::string> &GetLogMessages() const { return m_logMessages; }
 
 	protected:
+		// store the format of the mesh file we're currently importing to
+		// enable importer-specific quirks/workarounds
+		enum class ModelFormat : uint8_t {
+			UNKNOWN = 0,
+			GLTF,
+			COLLADA,
+			WAVEFRONT
+		};
+
 		bool m_doLog;
 		bool m_loadSGMs;
 		bool m_mostDetailedLod;
+		ModelFormat m_modelFormat;
 		std::vector<std::string> m_logMessages;
 		std::string m_curMeshDef; //for logging
 

--- a/src/scenegraph/Loader.h
+++ b/src/scenegraph/Loader.h
@@ -52,11 +52,11 @@ namespace SceneGraph {
 		bool CheckKeysInRange(const aiNodeAnim *, double start, double end);
 		matrix4x4f ConvertMatrix(const aiMatrix4x4 &) const;
 		Model *CreateModel(ModelDefinition &def);
-		RefCountedPtr<Node> LoadMesh(const std::string &filename, const AnimList &animDefs); //load one mesh file so it can be added to the model scenegraph. Materials should be created before this!
+		RefCountedPtr<Node> LoadMesh(const std::string &filename, const std::vector<AnimDefinition> &animDefs); //load one mesh file so it can be added to the model scenegraph. Materials should be created before this!
 		void AddLog(const std::string &);
 		void CheckAnimationConflicts(const Animation *, const std::vector<Animation *> &); //detect animation overlap
 		void ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry>> &, const aiScene *); //model is only for material lookup
-		void ConvertAnimations(const aiScene *, const AnimList &, Node *meshRoot);
+		void ConvertAnimations(const aiScene *, const std::vector<AnimDefinition> &, Node *meshRoot);
 		void ConvertNodes(aiNode *node, Group *parent, std::vector<RefCountedPtr<StaticGeometry>> &meshes, const matrix4x4f &);
 		void CreateLabel(Group *parent, const matrix4x4f &);
 		void CreateThruster(const std::string &name, const matrix4x4f &nodeTrans);

--- a/src/scenegraph/LoaderDefinitions.h
+++ b/src/scenegraph/LoaderDefinitions.h
@@ -64,14 +64,13 @@ namespace SceneGraph {
 		double end;
 		bool loop;
 	};
-	typedef std::vector<AnimDefinition> AnimList;
 
 	struct ModelDefinition {
 		std::string name;
 		std::vector<LodDefinition> lodDefs;
 		std::vector<MaterialDefinition> matDefs;
 		std::vector<std::string> collisionDefs;
-		AnimList animDefs;
+		std::vector<AnimDefinition> animDefs;
 	};
 
 } // namespace SceneGraph

--- a/src/versioningInfo.cpp
+++ b/src/versioningInfo.cpp
@@ -20,7 +20,7 @@ void OutputVersioningInfo()
 {
 	SDL_version ver;
 	SDL_GetVersion(&ver);
-	Output("\n\n--------------------\n");
+	Output("--------------------\n");
 	Output("SDL Version (build) %d.%d.%d\n", SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_PATCHLEVEL);
 	Output("SDL Version (dynamic) %d.%d.%d\n", ver.major, ver.minor, ver.patch);
 	const bool sameSDLVer = (SDL_MAJOR_VERSION == ver.major && SDL_MINOR_VERSION == ver.minor && SDL_PATCHLEVEL == ver.patch);
@@ -38,5 +38,6 @@ void OutputVersioningInfo()
 #endif
 
 	Output("GLEW dynamic version: %s\n", glewGetString(GLEW_VERSION));
-	Output("--------------------\n\n");
+	Output("--------------------\n");
+	Output("\n");
 }


### PR DESCRIPTION
Assimp 5.1.0 changed the `mTicksPerSecond` field for Collada animations from `1.0` to `1000.0`, breaking some assumptions made by the Pioneer model loader.

This PR resolves that, enables support for importing GLTF files with animations, and refactors Pioneer's to-console and to-file logging to provide more information about the source of messages and to correctly handle log messages that do not contain a trailing newline (finally!).

NOTE: to avoid having to add significant amounts of extra code to ensure imports function correctly across three major versions of assimp, we now require assimp v5.0.1 or greater as a compile-time and runtime dependency. This should only be an issue on Ubuntu 18.04 LTS, where you will need to find some way to install libassimp5 as it's not present in the package repositories provided by Canonical.

NOTE: this PR changes the maximum logged level from `Verbose` to `Debug` to avoid completely spamming the log with unneeded information - at the moment, logging `Verbose` messages to file or the console requires a code change. This will be replaced in a separate PR with a command-line argument to specify the wanted log-level provided by the game.