### PR TITLE
Fix joystick axis reporting invalid joystick value when cleared

### DIFF
--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -529,8 +529,12 @@ void pi_lua_generic_push(lua_State *l, InputBindings::JoyAxis axis)
 
 void pi_lua_generic_pull(lua_State *l, int index, InputBindings::JoyAxis &out)
 {
-	if (!lua_istable(l, index))
+	if (!lua_istable(l, index)) {
+		out.joystickId = 0;
+		out.axis = 0;
+		out.direction = 0;
 		return;
+	}
 
 	LuaTable axisTab(l, index);
 	out.joystickId = axisTab.Get<int>("joystick");
@@ -601,7 +605,11 @@ void pi_lua_generic_push(lua_State *l, InputBindings::KeyChord chord)
 
 void pi_lua_generic_pull(lua_State *l, int index, InputBindings::KeyChord &out)
 {
-	if (!lua_istable(l, index)) return;
+	if (!lua_istable(l, index)) {
+		out = {};
+		return;
+	}
+
 	LuaTable chordTab(l, index);
 	if (!chordTab.Get<bool>("enabled"))
 		return;

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -1088,10 +1088,6 @@ static int l_pigui_text_colored(lua_State *l)
 static int l_pigui_get_axisbinding(lua_State *l)
 {
 	PROFILE_SCOPED()
-	if (!Pi::input->IsJoystickEnabled()) {
-		lua_pushnil(l);
-		return 1;
-	}
 
 	// Escape is used to clear an existing binding
 	// io.KeysDown uses scancodes, but we want to use keycodes.
@@ -1099,6 +1095,11 @@ static int l_pigui_get_axisbinding(lua_State *l)
 		LuaPush(l, true);
 		lua_pushnil(l);
 		return 2;
+	}
+
+	if (!Pi::input->IsJoystickEnabled()) {
+		lua_pushnil(l);
+		return 1;
 	}
 
 	// otherwise actually check the joystick


### PR DESCRIPTION
Joystick axis values were left in an uninitialized state if a valid axis table was not present, causing undefined behavior. This broke assigning nil to an axis to clear it.

CC @Gliese852.