### PR TITLE
Fixes #5360 - lead calculation changes

### DIFF
--- a/src/FixedGuns.h
+++ b/src/FixedGuns.h
@@ -49,6 +49,7 @@ public:
 	inline float GetProjSpeed(int idx) const { return m_gun[idx].projData.speed; };
 	inline const vector3d &GetTargetLeadPos() const { return m_targetLeadPos; }
 	inline const vector3d &GetCurrentLeadDir() const { return m_currentLeadDir; }
+	inline bool IsFiringSolutionOk() const { return m_firingSolutionOk; }
 	inline void SetCoolingBoost(float cooler) { m_cooler_boost = cooler; };
 
 private:
@@ -75,6 +76,7 @@ private:
 	bool m_shouldUseLeadCalc = false;
 	vector3d m_targetLeadPos;
 	vector3d m_currentLeadDir;
+	bool m_firingSolutionOk = false;
 };
 
 #endif // FIXEDGUNS_H

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -333,7 +333,7 @@ void WorldView::UpdateProjectedObjects()
 		}
 
 		FixedGuns *gunManager = Pi::player->GetComponent<FixedGuns>();
-		if (laser >= 0 && gunManager->IsGunMounted(laser)) {
+		if (laser >= 0 && gunManager->IsGunMounted(laser) && gunManager->IsFiringSolutionOk()) {
 			UpdateIndicator(m_targetLeadIndicator, cam_rot * gunManager->GetTargetLeadPos());
 			if ((m_targetLeadIndicator.side != INDICATOR_ONSCREEN) || (m_combatTargetIndicator.side != INDICATOR_ONSCREEN))
 				HideIndicator(m_targetLeadIndicator);


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
1. Removal of lead calculation for beam weapons. They become deadly!
2. I tried to improve the lead calculation a bit. I have a save file where I have 0 speed relative to a trader ship that is 2.3 km away and unable to hit it because the target is accelerating. Adjustment for target acceleration helps with this.
3. There was this FIXME for doubled lead angle. The problem was that the Fire function was rotating shooting direction that was already rotated giving twice the needed angle..I think. Anyway the additional transformation in the Fire function was unnecessary.

<!-- Please make sure you've read documentation on contributing -->

