### PR TITLE
Fix catastrofic rotation after undocking from space station.

### DIFF
--- a/src/DynamicBody.cpp
+++ b/src/DynamicBody.cpp
@@ -62,13 +62,25 @@ DynamicBody::DynamicBody(const Json &jsonObj, Space *space) :
 		m_mass = dynamicBodyObj["mass"];
 		m_massRadius = dynamicBodyObj["mass_radius"];
 		m_angInertia = dynamicBodyObj["ang_inertia"];
-		m_isMoving = dynamicBodyObj["is_moving"];
+		SetMoving(dynamicBodyObj["is_moving"]);
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
 
 	m_aiMessage = AIError::AIERROR_NONE;
 	m_decelerating = false;
+}
+
+void DynamicBody::SetMoving(bool isMoving)
+{
+	m_isMoving = isMoving;
+
+	if (!m_isMoving) {
+		m_vel = vector3d(0.0);
+		m_angVel = vector3d(0.0);
+		m_force = vector3d(0.0);
+		m_torque = vector3d(0.0);
+	}
 }
 
 void DynamicBody::SaveToJson(Json &jsonObj, Space *space)

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -32,7 +32,7 @@ public:
 	vector3d GetAngularMomentum() const;
 	double GetAngularInertia() const { return m_angInertia; }
 	void SetMassDistributionFromModel();
-	void SetMoving(bool isMoving) { m_isMoving = isMoving; }
+	void SetMoving(bool isMoving);
 	bool IsMoving() const { return m_isMoving; }
 	virtual double GetMass() const override { return m_mass; } // XXX don't override this
 	virtual void TimeStepUpdate(const float timeStep) override;


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
When ship docks with space station on  autopilot it often generates pairs of big torque and force values that mostly cancel each other in normal flight. Problem starts with docking because when the flight state is changed to DOCKING which translates to m_isMoving==false for DynamicBody then the last unprocessed m_torque and m_force are stored. Those unconsumed torque and force values are later processed after undocking sequence completes and ship switches to FLYING state. This often results in catastrophic rotation + linear movement with ship just throwing forward thruster for few  seconds. In many cases it is fatal. I have attached a savegame - those torque and force values are serialized. It can be used for reproducing the result - just load the save and press F5 to undock. You can also fly around the space station and dock couple of times - maybe with 3rd person view - to see if you can make the game store such values yourself.
So the fix is simple resetting torque, force, velocity and rotation when DynamicBody state is changed to m_isMoving==false.
I could not find a bug report for this thing.

<!-- Please make sure you've read documentation on contributing -->
The save game:
[test.gz](https://github.com/pioneerspacesim/pioneer/files/10047529/test.gz)
