### PR TITLE
Fix MusicPlayer crashing when music ends on sector view while in hyperspace

### DIFF
--- a/data/modules/MusicPlayer.lua
+++ b/data/modules/MusicPlayer.lua
@@ -148,7 +148,7 @@ Event.Register("onSongFinished", function ()
 			playAmbient()
 		end
 	elseif Game.CurrentView() == "sector" or Game.CurrentView() == "system_info" or Game.CurrentView() == "system" then
-		if Game.system:DistanceTo(SystemPath.New(0, 0, 0, 0, 0)) < 1000 then -- farther than where ambient music switches
+		if Game.system and Game.system:DistanceTo(SystemPath.New(0, 0, 0, 0, 0)) < 1000 then -- farther than where ambient music switches
 			if music["map-core"] then
 				MusicPlayer.playRandomSongFromCategory("map-core")
 			else -- fall back to ambient if category is empty


### PR DESCRIPTION
Reported on IRC. Just adding one more condition to check on track end.
Please excuse the commit description.