### PR TITLE
Fixes #5348 - no gun cooling after selling laser cooler

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -687,8 +687,8 @@ void Ship::UpdateLuaStats()
 void Ship::UpdateGunsStats()
 {
 	PropertyMap &prop = Properties();
-	float cooler = prop.Get("laser_cooler_cap").get_integer(1.0f);
-	m_fixedGuns->SetCoolingBoost(cooler);
+	float cooler = prop.Get("laser_cooler_cap");
+	m_fixedGuns->SetCoolingBoost(cooler ? cooler : 1.0f);
 
 	for (int num = 0; num < 2; num++) {
 		std::string prefix(num ? "laser_rear_" : "laser_front_");


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Ship without laser cooler installed ever -> no property laser_cooler_cap ->  Ship::UpdateGunsStats defaults to 1
Buy laser cooler -> lua bumps laser_cooler_cap from non existence to 2
Sell laser cooler -> lua decreases laser_cooler_cap from 2 to 0 -> Ship::UpdateGunsStats sets cooling boost to 0 -> no cooling

I am not sure if what I propose is the proper way to fix it. Maybe all ships should have it's base laser_cooler_cap defined and buying the cooler would bump it up or down from lua. Maybe it should be defaulted in Ship constructor. Maybe it should be defaulted somewhere in lua. What I've done is certainly easiest and I think consistent with original code intent.

<!-- Please make sure you've read documentation on contributing -->

