### PR TITLE
Implementation of target selection.

### DIFF
--- a/data/lang/input-core/en.json
+++ b/data/lang/input-core/en.json
@@ -155,6 +155,10 @@
     "description": "Descriptive name for the TargetObject action.",
     "message": "Target Object"
   },
+  "BIND_CYCLE_HOSTILES": {
+    "description": "Descriptive name for the CycleHostiles action.",
+    "message": "Cycle Hostiles"
+  },
   "BIND_THRUST_LOW_POWER": {
     "description": "Descriptive name for the ThrustLowPower action.",
     "message": "Low Power Thrust Mode (hold)"

--- a/src/Sensors.h
+++ b/src/Sensors.h
@@ -28,7 +28,8 @@ public:
 	};
 
 	enum TargetingCriteria {
-		TARGET_NEAREST_HOSTILE
+		TARGET_NEAREST_HOSTILE,
+		CYCLE_HOSTILE
 	};
 
 	struct RadarContact {

--- a/src/Sensors.h
+++ b/src/Sensors.h
@@ -49,7 +49,7 @@ public:
 	static bool ContactDistanceSort(const RadarContact &a, const RadarContact &b);
 
 	Sensors(Ship *owner);
-	bool ChooseTarget(TargetingCriteria);
+	Body* ChooseTarget(TargetingCriteria, const Body* oldTarget);
 	IFF CheckIFF(Body *other);
 	const ContactList &GetContacts() { return m_radarContacts; }
 	const ContactList &GetStaticContacts() { return m_staticContacts; }

--- a/src/Ship-AI.cpp
+++ b/src/Ship-AI.cpp
@@ -74,6 +74,14 @@ void Ship::AIKill(Ship *target)
 	m_curAICmd = new AICmdKill(this, target);
 }
 
+
+bool Ship::IsAIAttacking(const Ship *target) const
+{
+	return m_curAICmd &&
+		((m_curAICmd->GetType() == AICommand::CMD_KILL && (static_cast<AICmdKill *>(m_curAICmd)->GetTarget() == target)) ||
+			(m_curAICmd->GetType() == AICommand::CMD_KAMIKAZE && (static_cast<AICmdKamikaze *>(m_curAICmd)->GetTarget() == target)));
+}
+
 /*
 void Ship::AIJourney(SystemBodyPath &dest)
 {

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -198,6 +198,7 @@ public:
 	void AIBodyDeleted(const Body *const body){}; // Note: defined in Ship-AI.cpp // todo: signals
 
 	const AICommand *GetAICommand() const { return m_curAICmd; }
+	bool IsAIAttacking(const Ship *target) const;
 
 	virtual void PostLoadFixup(Space *space) override;
 

--- a/src/ShipAICmd.h
+++ b/src/ShipAICmd.h
@@ -65,7 +65,6 @@ public:
 protected:
 	DynamicBody *m_dBody;
 	Propulsion *m_prop;
-	FixedGuns *m_fguns;
 
 	std::unique_ptr<AICommand> m_child;
 	bool m_is_flyto = false;
@@ -191,7 +190,10 @@ public:
 
 	virtual void OnDeleted(const Body *body);
 
+	const Ship* GetTarget() const { return m_target; }
+
 private:
+	FixedGuns *m_fguns;
 	Ship *m_target;
 	double m_leadTime, m_evadeTime, m_closeTime;
 	vector3d m_leadOffset, m_leadDrift, m_lastVel;
@@ -209,6 +211,7 @@ public:
 
 	virtual void OnDeleted(const Body *body);
 
+	const Body* GetTarget() const { return m_target; }
 private:
 	Body *m_target;
 	int m_targetIndex; // used during deserialisation

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -539,6 +539,32 @@ Body *Space::FindNearestTo(const Body *b, ObjectType t) const
 	return nearest;
 }
 
+Body *Space::FindInAngleNearestTo(const Body *b, const vector3d &offset, const vector3d &view_dir, double cosOfMaxAngle) const
+{
+	Body *nearest = 0;
+	double dist = FLT_MAX;
+	for (Body *const body : m_bodies) {
+		if (body == b) continue;
+		if (body->IsDead()) continue;
+
+		//offset from the body center - like for view from ship cocpit
+		vector3d dirBody = body->GetPositionRelTo(b) * b->GetOrient() -  offset;
+		double d = dirBody.Length();
+		//Normalizing but not using Normalized function to avoid calculating Lenght again
+		dirBody = dirBody / d;
+
+		//Bodies outside of the cone disregarded
+		if(dirBody.Dot(view_dir) < cosOfMaxAngle)
+			continue;
+
+		if (d < dist) {
+			dist = d;
+			nearest = body;
+		}
+	}
+	return nearest;
+}
+
 Body *Space::FindBodyForPath(const SystemPath *path) const
 {
 	if (!m_game->IsNormalSpace() || !path->IsSameSystem(m_starSystem->GetPath()))

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -539,10 +539,9 @@ Body *Space::FindNearestTo(const Body *b, ObjectType t) const
 	return nearest;
 }
 
-Body *Space::FindInAngleNearestTo(const Body *b, const vector3d &offset, const vector3d &view_dir, double cosOfMaxAngle) const
+std::vector<Space::BodyDist> Space::BodiesInAngle(const Body *b, const vector3d &offset, const vector3d &view_dir, double cosOfMaxAngle) const
 {
-	Body *nearest = 0;
-	double dist = FLT_MAX;
+	std::vector<BodyDist> ret;
 	for (Body *const body : m_bodies) {
 		if (body == b) continue;
 		if (body->IsDead()) continue;
@@ -550,19 +549,16 @@ Body *Space::FindInAngleNearestTo(const Body *b, const vector3d &offset, const v
 		//offset from the body center - like for view from ship cocpit
 		vector3d dirBody = body->GetPositionRelTo(b) * b->GetOrient() -  offset;
 		double d = dirBody.Length();
-		//Normalizing but not using Normalized function to avoid calculating Lenght again
+		//Normalizing but not using Normalized() function to avoid calculating Lenght again
 		dirBody = dirBody / d;
 
 		//Bodies outside of the cone disregarded
 		if(dirBody.Dot(view_dir) < cosOfMaxAngle)
 			continue;
 
-		if (d < dist) {
-			dist = d;
-			nearest = body;
-		}
+		ret.emplace_back(body, d);
 	}
-	return nearest;
+	return ret;
 }
 
 Body *Space::FindBodyForPath(const SystemPath *path) const

--- a/src/Space.h
+++ b/src/Space.h
@@ -65,6 +65,9 @@ public:
 	Body *FindNearestTo(const Body *b, ObjectType t) const;
 	Body *FindBodyForPath(const SystemPath *path) const;
 
+	//Find bodies within angle to given direction. Dir and offset relative to b like in ship coordinates
+	Body *FindInAngleNearestTo(const Body *b, const vector3d &offset, const vector3d &dir, double cosOfMaxAngle) const;
+
 	Uint32 GetNumBodies() const { return static_cast<Uint32>(m_bodies.size()); }
 	IterationProxy<std::vector<Body *>> GetBodies() { return MakeIterationProxy(m_bodies); }
 	const IterationProxy<const std::vector<Body *>> GetBodies() const { return MakeIterationProxy(m_bodies); }

--- a/src/Space.h
+++ b/src/Space.h
@@ -65,8 +65,6 @@ public:
 	Body *FindNearestTo(const Body *b, ObjectType t) const;
 	Body *FindBodyForPath(const SystemPath *path) const;
 
-	//Find bodies within angle to given direction. Dir and offset relative to b like in ship coordinates
-	Body *FindInAngleNearestTo(const Body *b, const vector3d &offset, const vector3d &dir, double cosOfMaxAngle) const;
 
 	Uint32 GetNumBodies() const { return static_cast<Uint32>(m_bodies.size()); }
 	IterationProxy<std::vector<Body *>> GetBodies() { return MakeIterationProxy(m_bodies); }
@@ -87,6 +85,25 @@ public:
 	}
 
 	void DebugDumpFrames(bool details);
+
+	struct BodyDist {
+		BodyDist(Body *_body, double _dist) :
+			body(_body),
+			dist(_dist) {}
+		Body *body;
+		double dist;
+
+		bool operator<(const BodyDist &a) const { return dist < a.dist; }
+
+		friend bool operator<(const BodyDist &a, double d) { return a.dist < d; }
+		friend bool operator<(double d, const BodyDist &a) { return d < a.dist; }
+	};
+
+	//Find bodies within angle to given direction. dir and offset relative to b like in ship coordinates
+	//returns unsorted vector of bodies with their distance from b+offset
+	//It calculates distance from b for all the bodies so it is quite inefficiet,
+	//it is not designed to be called in each game loop!
+	std::vector<BodyDist> BodiesInAngle(const Body *b, const vector3d &offset, const vector3d &dir, double cosOfMaxAngle) const;
 
 private:
 	void GenSectorCache(RefCountedPtr<Galaxy> galaxy, const SystemPath *here);
@@ -132,6 +149,7 @@ private:
 	//e.g. starfield and milky way)
 	std::unique_ptr<Background::Container> m_background;
 
+
 	class BodyNearFinder {
 	public:
 		BodyNearFinder(const Space *space) :
@@ -142,18 +160,6 @@ private:
 		BodyNearList GetBodiesMaybeNear(const vector3d &pos, double dist);
 
 	private:
-		struct BodyDist {
-			BodyDist(Body *_body, double _dist) :
-				body(_body),
-				dist(_dist) {}
-			Body *body;
-			double dist;
-
-			bool operator<(const BodyDist &a) const { return dist < a.dist; }
-
-			friend bool operator<(const BodyDist &a, double d) { return a.dist < d; }
-			friend bool operator<(double d, const BodyDist &a) { return d < a.dist; }
-		};
 
 		const Space *m_space;
 		std::vector<BodyDist> m_bodyDist;

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -17,6 +17,7 @@
 #include "core/OS.h"
 #include "lua/LuaObject.h"
 #include "ship/ShipController.h"
+#include "Sensors.h"
 
 #include <algorithm>
 
@@ -137,6 +138,7 @@ REGISTER_INPUT_BINDING(PlayerShipController)
 
 	auto weaponsGroup = controlsPage->GetBindingGroup("Weapons");
 	input->AddActionBinding("BindTargetObject", weaponsGroup, Action({ SDLK_y }));
+	input->AddActionBinding("BindCycleHostiles", weaponsGroup, Action({ SDLK_t }));
 	input->AddActionBinding("BindPrimaryFire", weaponsGroup, Action({ SDLK_SPACE }));
 	input->AddActionBinding("BindSecondaryFire", weaponsGroup, Action({ SDLK_m }));
 
@@ -197,11 +199,18 @@ PlayerShipController::PlayerShipController() :
 		[this]() {
 			this->SetSpeedLimiterActive(not this->IsSpeedLimiterActive());
 		});
+
+	m_SelectTarget = InputBindings.targetObject->onPressed.connect (
+		sigc::mem_fun(this, &PlayerShipController::SelectTarget));
+
+	m_CycleHostiles = InputBindings.cycleHostiles->onPressed.connect (
+		sigc::mem_fun(this, &PlayerShipController::CycleHostiles));
 }
 
 void PlayerShipController::InputBinding::RegisterBindings()
 {
 	targetObject = AddAction("BindTargetObject");
+	cycleHostiles = AddAction("BindCycleHostiles");
 	primaryFire = AddAction("BindPrimaryFire");
 	secondaryFire = AddAction("BindSecondaryFire");
 
@@ -755,6 +764,16 @@ void PlayerShipController::FireMissile()
 	if (!Pi::player->GetCombatTarget())
 		return;
 	LuaObject<Ship>::CallMethod(Pi::player, "FireMissileAt", "any", static_cast<Ship *>(Pi::player->GetCombatTarget()));
+}
+
+void PlayerShipController::SelectTarget()
+{
+	std::cout << "Not implemented" << std::endl;
+}
+
+void PlayerShipController::CycleHostiles()
+{
+	Pi::player->GetSensors()->ChooseTarget(Sensors::CYCLE_HOSTILE);
 }
 
 void PlayerShipController::ToggleCruise()

--- a/src/ship/PlayerShipController.h
+++ b/src/ship/PlayerShipController.h
@@ -37,6 +37,10 @@ public:
 	void ToggleRotationDamping();
 	void FireMissile();
 	void ToggleCruise();
+	void SelectTarget();
+	void CycleHostiles();
+
+
 
 	//targeting
 	//XXX AI should utilize one or more of these
@@ -77,6 +81,7 @@ private:
 
 		// Weapons
 		Action *targetObject;
+		Action *cycleHostiles;
 		Action *primaryFire;
 		Action *secondaryFire;
 
@@ -151,4 +156,6 @@ private:
 	ConnectionTicket m_fireMissileKey;
 	ConnectionTicket m_toggleCruise;
 	ConnectionTicket m_toggleSpeedLimiter;
+	ConnectionTicket m_SelectTarget;
+	ConnectionTicket m_CycleHostiles;
 };


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
There is a target selection key defined in the configuration, but it has no binding.
This is a proposal for implementation for it. It uses target list from Sensors.cpp.
The friend or foe identification is supposed to rely on relations which seem not to be implemented at the moment, I decided that checking if the target has active AI command KILL on the player is a good indication of being hostile. This improvement also turns ship speed lines to red for foes.
The selection works by picking nearest hostile if no combat target is selected. Next key press should select next hostile target according to distance. If the furthest hostile is selected next key press will deselect combat target. So it is more like toggling. It works only within distance used in Sensors so 100km.
**EDIT**
The cycling of hostiles has been moved to separate key and implementation of selecting targets near center of the view was added.
<!-- Please make sure you've read documentation on contributing -->

