### PR TITLE
Rewritten and Improved City Generation for Spaceports

### DIFF
--- a/data/configs/buildings/default.json
+++ b/data/configs/buildings/default.json
@@ -1,0 +1,148 @@
+{
+	"size": [
+		{
+			"population": 6.0,
+			"baseSize": 6000,
+			"atmoSize": 3500,
+			"randomSize": 5000,
+			"density": 0.5
+		},
+		{
+			"population": 2.0,
+			"baseSize": 4000,
+			"atmoSize": 2500,
+			"randomSize": 3000,
+			"density": 0.6
+		},
+		{
+			"population": 0.8,
+			"baseSize": 2500,
+			"atmoSize": 2000,
+			"randomSize": 1500,
+			"density": 0.7
+		},
+		{
+			"population": 0.2,
+			"baseSize": 2000,
+			"atmoSize": 1500,
+			"randomSize": 1000,
+			"density": 0.8
+		},
+		{
+			"population": 0.02,
+			"baseSize": 1000,
+			"atmoSize": 750,
+			"randomSize": 500,
+			"density": 0.9
+		},
+		{
+			"population": 0.001,
+			"baseSize": 500,
+			"atmoSize": 200,
+			"randomSize": 300,
+			"density": 1.0
+		}
+	],
+	"buildings": {
+		"kbuilding01": {
+			"airless-rarity": 0.8,
+			"kind": "industry"
+		},
+		"kbuilding02": {
+			"airless-rarity": 0.3,
+			"atmospheric-rarity": 0.4,
+			"kind": "industry"
+		},
+		"kbuilding03": {
+			"airless-rarity": 0.3,
+			"atmospheric-rarity": 0.5,
+			"kind": "industry"
+		},
+		"Dome1": {
+			"airless-rarity": 0.8,
+			"atmospheric-rarity": 0.5,
+			"kind": "frontier"
+		},
+		"Dome2": {
+			"layout": 1,
+			"airless-rarity": 0.6,
+			"atmospheric-rarity": 0.2,
+			"kind": "frontier"
+		},
+		"Library": {
+			"airless-rarity": 0.3,
+			"atmospheric-rarity": 0.3,
+			"kind": "monument"
+		},
+		"Mall": {
+			"airless-rarity": 0.6,
+			"atmospheric-rarity": 1.0,
+			"kind": "habitat"
+		},
+		"Tower1": {
+			"airless-rarity": 0.7,
+			"atmospheric-rarity": 1.0,
+			"kind": "habitat"
+		},
+		"Tower2": {
+			"airless-rarity": 0.6,
+			"atmospheric-rarity": 0.8,
+			"kind": "monument"
+		},
+		"newbuilding1": {
+			"airless-rarity": 0.9,
+			"atmospheric-rarity": 0.5,
+			"kind": "habitat"
+		},
+		"newbuilding2": {
+			"airless-rarity": 0.9,
+			"atmospheric-rarity": 0.5,
+			"kind": "habitat"
+		},
+		"newbuilding3": {
+			"airless-rarity": 0.9,
+			"atmospheric-rarity": 0.5,
+			"kind": "monument"
+		},
+		"newbuilding4": {
+			"airless-rarity": 0.9,
+			"atmospheric-rarity": 0.5,
+			"kind": "monument"
+		},
+		"newbuilding5": {
+			"airless-rarity": 0.6,
+			"atmospheric-rarity": 0.4,
+			"kind": "habitat"
+		},
+		"newbuilding6": {
+			"airless-rarity": 0.6,
+			"atmospheric-rarity": 0.4,
+			"kind": "habitat"
+		},
+		"newbuilding7": {
+			"airless-rarity": 0.6,
+			"atmospheric-rarity": 0.4,
+			"kind": "industry"
+		},
+		"newbuilding8": {
+			"airless-rarity": 0.5,
+			"atmospheric-rarity": 0.2,
+			"kind": "industry"
+		},
+		"newbuilding9": {
+			"airless-rarity": 0.4,
+			"atmospheric-rarity": 0.3,
+			"kind": "industry"
+		},
+		"newbuilding10": {
+			"airless-rarity": 0.4,
+			"atmospheric-rarity": 0.3,
+			"kind": "storage"
+		},
+		"newbuilding11": {
+			"airless-rarity": 0.3,
+			"atmospheric-rarity": 0.5,
+			"kind": "frontier"
+		}
+	}
+}

--- a/data/modules/Debug/DebugShipSpawn.lua
+++ b/data/modules/Debug/DebugShipSpawn.lua
@@ -192,6 +192,12 @@ ship_spawn_debug_window = function()
       if ui.button("Spawn Docked", Vector2(0, 0)) then
         spawn_ship_docked(ship_name, ai_options[ai_opt_selected], ship_equip)
       end
+      if not Game.player:GetDockedWith() then
+        ui.sameLine()
+        if ui.button("Teleport To", Vector2(0, 0)) then
+          Game.player:SetDockedWith(nav_target)
+        end
+      end
     end
     if Game.player:GetCombatTarget() then
       if ui.button("Spawn##Missile", Vector2(0, 0)) then

--- a/data/modules/Debug/DebugShipSpawn.moon
+++ b/data/modules/Debug/DebugShipSpawn.moon
@@ -7,6 +7,7 @@ Timer = require 'Timer'
 Equipment = require 'Equipment'
 
 import Vector2 from _G
+
 ui = require 'pigui'
 debug_ui = require 'pigui.views.debug'
 
@@ -148,10 +149,15 @@ ship_spawn_debug_window = ->
 			if ui.button "Spawn Docked", Vector2(0, 0)
 				spawn_ship_docked ship_name, ai_options[ai_opt_selected], ship_equip
 
+			if not Game.player\GetDockedWith!
+				ui.sameLine!
+				if ui.button "Teleport To", Vector2(0, 0)
+					Game.player\SetDockedWith nav_target
+
 		if Game.player\GetCombatTarget!
-			ui.sameLine!
-			if ui.button "Spawn Missile", Vector2(0, 0)
+			if ui.button "Spawn##Missile", Vector2(0, 0)
 				do_spawn_missile missile_types[missile_selected + 1]
+			ui.sameLine 0, 2
 
 		ui.nextItemWidth -1.0
 		_, missile_selected = ui.combo "##missile_type", missile_selected, missile_names

--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -135,6 +135,8 @@ void CityOnPlanet::LoadBuildingType(std::string_view key, const Json &buildingDe
 		out.buildingKind = SectorKind::Monument;
 	else if (kind == "habitat")
 		out.buildingKind = SectorKind::Habitat;
+	else if (kind == "frontier")
+		out.buildingKind = SectorKind::Frontier;
 
 	std::string idleName = buildingDef.value("idle", "");
 	if (!idleName.empty()) {
@@ -487,8 +489,8 @@ void CityOnPlanet::Generate(SpaceStation *station)
 					// 1.0 at city center and 0.2 at outskirts
 					rarity *= 1.0 - distribution * 0.8;
 				} else if (buildingType->buildingKind == SectorKind::Frontier) {
-					// extremely rare at city center and 0.8 at outskirts
-					rarity *= (distribution * distribution) * 0.8;
+					// extremely rare at city center and 1.5 at outskirts
+					rarity *= (distribution * distribution) * 1.5;
 				}
 
 				// roll to see if the building spawns here or not

--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -6,38 +6,39 @@
 #include "FileSystem.h"
 #include "Frame.h"
 #include "Game.h"
+#include "JsonUtils.h"
 #include "ModelCache.h"
 #include "Pi.h"
 #include "Planet.h"
 #include "SpaceStation.h"
 #include "collider/Geom.h"
+#include "core/Log.h"
+
 #include "graphics/Frustum.h"
+#include "graphics/Graphics.h"
+#include "graphics/Material.h"
+#include "graphics/RenderState.h"
+#include "graphics/Types.h"
+
 #include "scenegraph/Animation.h"
 #include "scenegraph/ModelSkin.h"
 #include "scenegraph/SceneGraph.h"
 
-static const unsigned int DEFAULT_NUM_BUILDINGS = 1000;
-static const double START_SEG_SIZE = CityOnPlanet::RADIUS;
-static const double START_SEG_SIZE_NO_ATMO = CityOnPlanet::RADIUS / 5.0f;
+#include "utils.h"
 
-using SceneGraph::Model;
-
-CityOnPlanet::citybuildinglist_t CityOnPlanet::s_buildingList = {
-	"city_building",
-	800,
-	2000,
-	0,
-	0,
-};
-
-CityOnPlanet::cityflavourdef_t CityOnPlanet::cityflavour[CITYFLAVOURS];
+std::vector<CityOnPlanet::CityFlavourType> CityOnPlanet::s_cityFlavours;
+std::unique_ptr<Graphics::Material> CityOnPlanet::s_debugMat;
 
 void CityOnPlanet::AddStaticGeomsToCollisionSpace()
 {
+	PROFILE_SCOPED()
+
+	size_t numBuildingTypes = m_cityType->buildingTypes.size();
+
 	// reset data structures
 	m_enabledBuildings.clear();
-	m_buildingCounts.resize(s_buildingList.numBuildings);
-	for (Uint32 i = 0; i < s_buildingList.numBuildings; i++) {
+	m_buildingCounts.resize(numBuildingTypes);
+	for (Uint32 i = 0; i < numBuildingTypes; i++) {
 		m_buildingCounts[i] = 0;
 	}
 
@@ -85,69 +86,177 @@ void CityOnPlanet::RemoveStaticGeomsFromCollisionSpace()
 	}
 }
 
-// Get all model file names under buildings/
-// This is temporary. Buildings should be defined in BuildingSet data files, or something.
-//static
-void CityOnPlanet::EnumerateNewBuildings(std::set<std::string> &filenames)
+void CityOnPlanet::GetModelSize(const Aabb &aabb, uint8_t size[2])
 {
-	const std::string fullpath = FileSystem::JoinPathBelow("models", "buildings");
-	for (FileSystem::FileEnumerator files(FileSystem::gameDataFiles, fullpath, FileSystem::FileEnumerator::Recurse); !files.Finished(); files.Next()) {
-		const std::string &name = files.Current().GetName();
-		if (ends_with_ci(name, ".model")) {
-			filenames.insert(name.substr(0, name.length() - 6));
-		} else if (ends_with_ci(name, ".sgm")) {
-			filenames.insert(name.substr(0, name.length() - 4));
-		}
-	}
+	vector3d aabbSize = aabb.max - aabb.min;
+
+	size[0] = std::ceil(aabbSize.x / double(CELLSIZE));
+	size[1] = std::ceil(aabbSize.z / double(CELLSIZE));
 }
 
-//static
-void CityOnPlanet::LookupBuildingListModels(citybuildinglist_t *list)
+void CityOnPlanet::LoadBuildingType(std::string_view key, const Json &buildingDef, BuildingType &out)
 {
-	std::vector<Model *> models;
+	std::string modelPath = buildingDef.value("model", "");
 
-	//get test newmodels - to be replaced with building set definitions
-	{
-		std::set<std::string> filenames; // set so we get unique names
-		EnumerateNewBuildings(filenames);
-		for (auto it = filenames.begin(), itEnd = filenames.end(); it != itEnd; ++it) {
-			// find/load the model
-			Model *model = Pi::modelCache->FindModel(*it);
+	if (modelPath.empty()) {
+		modelPath = key;
+	}
 
-			// good to use
-			models.push_back(model);
+	out.model = Pi::FindModel(modelPath);
+
+	if (!out.model->GetCollisionMesh().Get()) {
+		out.model->CreateCollisionMesh();
+	}
+
+	GetModelSize(out.model->GetCollisionMesh()->GetAabb(), out.cellSize);
+
+	out.cellSize[0] = buildingDef.value("size-x", out.cellSize[0]);
+	out.cellSize[1] = buildingDef.value("size-y", out.cellSize[1]);
+
+	if (out.cellSize[0] > CELLMAX || out.cellSize[1] > CELLMAX) {
+		Log::Warning("\tCity building {} has {}x{}c footprint (at {} m/c), will be truncated to {}x{}c.",
+			key, out.cellSize[0], out.cellSize[1], CELLSIZE, CELLMAX, CELLMAX);
+
+		out.cellSize[0] = std::min(out.cellSize[0], uint8_t(CELLMAX));
+		out.cellSize[1] = std::min(out.cellSize[1], uint8_t(CELLMAX));
+	}
+
+	out.rarityAirless = buildingDef.value("airless-rarity", 1.0);
+	out.rarityAtmo = buildingDef.value("atmo-rarity", 1.0);
+
+	std::string kind = buildingDef.value("kind", "");
+
+	out.buildingKind = SectorKind::None;
+	if (kind == "storage")
+		out.buildingKind = SectorKind::Storage;
+	else if (kind == "industry")
+		out.buildingKind = SectorKind::Industry;
+	else if (kind == "monument")
+		out.buildingKind = SectorKind::Monument;
+	else if (kind == "habitat")
+		out.buildingKind = SectorKind::Habitat;
+
+	std::string idleName = buildingDef.value("idle", "");
+	if (!idleName.empty()) {
+		out.idleAnimation = out.model->FindAnimation(idleName);
+
+		if (out.idleAnimation == nullptr) {
+			Log::Warning("\tIdle animation {} specified for building {} not found!", idleName, key);
 		}
+	} else {
+		out.idleAnimation = out.model->FindAnimation("idle");
 	}
-	assert(!models.empty());
-	Output("Got %d buildings of tag %s\n", static_cast<int>(models.size()), list->modelTagName);
-	list->buildings = new citybuilding_t[models.size()];
-	list->numBuildings = models.size();
 
-	int i = 0;
-	for (auto m = models.begin(), itEnd = models.end(); m != itEnd; ++m, i++) {
-		list->buildings[i].instIndex = i;
-		list->buildings[i].resolvedModel = *m;
-		list->buildings[i].idle = (*m)->FindAnimation("idle");
-		list->buildings[i].collMesh = (*m)->CreateCollisionMesh();
-		const Aabb &aabb = list->buildings[i].collMesh->GetAabb();
-		const double maxx = std::max(fabs(aabb.max.x), fabs(aabb.min.x));
-		const double maxy = std::max(fabs(aabb.max.z), fabs(aabb.min.z));
-		list->buildings[i].xzradius = sqrt(maxx * maxx + maxy * maxy);
-		Output(" - %s: %f\n", (*m)->GetName().c_str(), list->buildings[i].xzradius);
+	Log::Verbose("\tLoaded city building {} ({}x{}c, atm: {}, arl: {}, kind: {}, idleAnim: {})",
+		key, out.cellSize[0], out.cellSize[1], out.rarityAtmo, out.rarityAirless, out.buildingKind, out.idleAnimation != nullptr);
+}
+
+void CityOnPlanet::LoadCityFlavour(const FileSystem::FileInfo &file)
+{
+	Json fileData = JsonUtils::LoadJson(file.Read());
+	if (!fileData.is_object()) {
+		Log::Info("CityOnPlanet: Could not load city definition file '{}' as a valid JSON file.", file.GetPath());
+		return;
 	}
-	Output("End of buildings.\n");
+
+	Log::Info("Loading city definition file '{}'", file.GetPath());
+
+	const Json &sizeDef = fileData["size"];
+	if (!sizeDef.is_array()) {
+		Log::Warning("\tMissing city size definition array! Should be \"size\": [ ... ]");
+		return;
+	}
+
+	const Json &buildingDefs = fileData["buildings"];
+	if (!buildingDefs.is_object()) {
+		Log::Warning("\tMissing city buildings object! Should be \"buildings\": { ... }");
+		return;
+	}
+
+	CityFlavourType cityType = {};
+
+	uint32_t numSizeDefs = 0;
+	for (const Json &item : sizeDef) {
+		CityRadiusDef radius = {};
+		numSizeDefs++;
+
+		radius.population = item.value("population", 0.0);
+		radius.baseSize = item.value("baseSize", 0.0);
+		radius.atmoSize = item.value("atmoSize", 0.0);
+		radius.randomSize = item.value("randomSize", 0.0);
+		radius.density = item.value("density", 1.0);
+
+		if (!cityType.sizeDefs.empty() && radius.population > cityType.sizeDefs.back().population) {
+			Log::Warning("\tSize definition {} has higher population threshold than previous ({}b vs. {}b); ignoring",
+				numSizeDefs, radius.population, cityType.sizeDefs.back().population);
+			continue;
+		}
+
+		cityType.sizeDefs.emplace_back(std::move(radius));
+	}
+
+	Log::Verbose("\tLoaded {} city size definitions", numSizeDefs);
+
+	uint32_t numBuildingDefs = 0;
+
+	for (const auto &iter : buildingDefs.items()) {
+		BuildingType building = {};
+		numBuildingDefs++;
+
+		try {
+			LoadBuildingType(iter.key(), iter.value(), building);
+		} catch (std::exception &e) {
+			Log::Warning("Couldn't parse building def {}; error: {}", numBuildingDefs, e.what());
+			continue;
+		}
+
+		cityType.buildingTypes.emplace_back(std::move(building));
+	}
+
+	Log::Verbose("\tLoaded {} building definitions", numBuildingDefs);
+
+	s_cityFlavours.emplace_back(std::move(cityType));
+
+	Log::Info("\tCreated city definition flavour #{}", s_cityFlavours.size());
 }
 
 void CityOnPlanet::Init()
 {
 	PROFILE_SCOPED()
-	/* Resolve city model numbers since it is a bit expensive */
-	LookupBuildingListModels(&s_buildingList);
+
+	// Load all city definition configs
+	FileSystem::FileEnumerator iter(FileSystem::gameDataFiles, "configs/buildings/");
+	for (; !iter.Finished(); iter.Next()) {
+		const FileSystem::FileInfo &file = iter.Current();
+		std::string name = file.GetName();
+
+		if (!ends_with_ci(name, ".json")) {
+			continue;
+		}
+
+		try {
+			LoadCityFlavour(file);
+		} catch (std::exception &e) {
+			Log::Warning("CityOnPlanet: failed to parse city definition '{}': {}", name, e.what());
+		}
+	}
+
+	if (s_cityFlavours.empty()) {
+		Log::Error("CityOnPlanet: failed to load any city definitions, no cities will be generated!");
+	}
+
+	Graphics::RenderStateDesc rsd = {};
+	rsd.depthTest = false;
+	rsd.depthWrite = false;
+	rsd.primitiveType = Graphics::LINE_SINGLE;
+
+	s_debugMat.reset(Pi::renderer->CreateMaterial("vtxColor", Graphics::MaterialDescriptor(), rsd));
 }
 
 void CityOnPlanet::Uninit()
 {
-	delete[] s_buildingList.buildings;
+	s_cityFlavours.clear();
+	s_debugMat.reset();
 }
 
 // Need a reliable way to sort the models rather than using their address in memory we use their name which should be unique.
@@ -161,6 +270,9 @@ struct ModelNameComparator {
 	}
 };
 
+// FIXME: this is a horrible idea as it directly mutates models in the ModelCache
+// and forces all instances of a building to have the exact same color.
+// Color data should be supplied via an instance buffer and managed as part of a building instance.
 //static
 void CityOnPlanet::SetCityModelPatterns(const SystemPath &path)
 {
@@ -168,24 +280,20 @@ void CityOnPlanet::SetCityModelPatterns(const SystemPath &path)
 	Uint32 _init[5] = { path.systemIndex, Uint32(path.sectorX), Uint32(path.sectorY), Uint32(path.sectorZ), UNIVERSE_SEED };
 	Random rand(_init, 5);
 
-	typedef std::set<SceneGraph::Model *, ModelNameComparator> ModelSet;
-	typedef ModelSet::iterator TSetIter;
-	ModelSet modelSet;
-	{
-		for (unsigned int j = 0; j < s_buildingList.numBuildings; j++) {
-			SceneGraph::Model *m = s_buildingList.buildings[j].resolvedModel;
-			modelSet.insert(m);
-		}
-	}
-
 	SceneGraph::ModelSkin skin;
-	for (TSetIter it = modelSet.begin(), itEnd = modelSet.end(); it != itEnd; ++it) {
-		SceneGraph::Model *m = (*it);
-		if (!m->SupportsPatterns()) continue;
-		skin.SetRandomColors(rand);
-		skin.Apply(m);
-		if (m->SupportsPatterns())
-			m->SetPattern(rand.Int32(0, m->GetNumPatterns() - 1));
+	for (auto &cityFlavour : s_cityFlavours) {
+		for (auto &buildingType : cityFlavour.buildingTypes) {
+
+			SceneGraph::Model *model = buildingType.model;
+
+			if (!model->SupportsPatterns())
+				continue;
+
+			skin.SetRandomColors(rand);
+			skin.Apply(model);
+
+			model->SetPattern(rand.Int32(model->GetNumPatterns()));
+		}
 	}
 }
 
@@ -202,123 +310,345 @@ CityOnPlanet::~CityOnPlanet()
 CityOnPlanet::CityOnPlanet(Planet *planet, SpaceStation *station, const Uint32 seed)
 {
 	// beware, these are not used in this function, but are used in subroutines!
+	m_body = planet->GetSystemBody();
 	m_planet = planet;
 	m_frame = planet->GetFrame();
 	m_detailLevel = Pi::detail.cities;
 
-	m_buildings.clear();
-	m_buildings.reserve(DEFAULT_NUM_BUILDINGS);
+	m_rand.seed(seed);
 
-	const Aabb &aabb = station->GetAabb();
-	const matrix4x4d &m = station->GetOrient();
-	const vector3d p = station->GetPosition();
-
-	const vector3d mx = m * vector3d(1, 0, 0);
-	const vector3d mz = m * vector3d(0, 0, 1);
-
-	Random rand;
-	rand.seed(seed);
-
-	int population = planet->GetSystemBody()->GetPopulation();
-	int cityradius;
-
-	if (planet->GetSystemBody()->HasAtmosphere()) {
-		population *= 1000;
-		cityradius = (population < 200) ? 200 : ((population > START_SEG_SIZE) ? START_SEG_SIZE : population);
-	} else {
-		population *= 100;
-		cityradius = (population < 250) ? 250 : ((population > START_SEG_SIZE_NO_ATMO) ? START_SEG_SIZE_NO_ATMO : population);
+	if (s_cityFlavours.empty()) {
+		// initialize needed variables to render nothing
+		AddStaticGeomsToCollisionSpace();
+		return; // no buildings available to generate, we already logged an error about this during startup
 	}
 
-	citybuildinglist_t *buildings = &s_buildingList;
-	vector3d cent = p;
-	const int cellsize_i = 80;
-	const double cellsize = double(cellsize_i);						// current widest building = 92
-	const double bodyradius = planet->GetSystemBody()->GetRadius(); // cache for bodyradius value
+	// TODO: allow specifying city flavors based on various parameters (faction, world type, set from custom system def, etc.)
+	m_cityType = &s_cityFlavours[m_rand.Int32(s_cityFlavours.size())];
 
-	static const int gmid = (cityradius / cellsize_i);
-	static const int gsize = gmid * 2;
+	CalcCityRadius(m_body);
 
-	assert((START_SEG_SIZE / cellsize_i) < 100);
-	assert((START_SEG_SIZE_NO_ATMO / cellsize_i) < 100);
-	uint8_t cellgrid[200][200];
-	std::memset(cellgrid, 0, sizeof(cellgrid));
+	// TODO: run in a task thread
+	Generate(station);
 
-	// calculate the size of the station model
-	const int x1 = floor(aabb.min.x / cellsize);
-	const int x2 = ceil(aabb.max.x / cellsize);
-	const int z1 = floor(aabb.min.z / cellsize);
-	const int z2 = ceil(aabb.max.z / cellsize);
+	AddStaticGeomsToCollisionSpace();
+}
 
-	// Clear the cells where the station is
-	for (int x = 0; x <= gsize; x++) {
-		for (int z = 0; z <= gsize; z++) {
-			const int zz = z - gmid;
-			const int xx = x - gmid;
-			if (zz > z1 && zz < z2 && xx > x1 && xx < x2)
-				cellgrid[x][z] = 1;
-		}
+void CityOnPlanet::Generate(SpaceStation *station)
+{
+	PROFILE_SCOPED()
+	Profiler::Clock _genTimer;
+	_genTimer.Start();
+
+	// Create the acceleration grid structure
+	// ==========================================
+
+	// Retrieve the station parameters
+	uint8_t stationSize[2] = {};
+	GetModelSize(station->GetAabb(), stationSize);
+
+	uint32_t stationSizeMax = std::max<uint32_t>(stationSize[0] / 2, stationSize[1] / 2);
+
+	// update the allowed radius to ensure the spaceport isn't larger than the entire city
+	m_cityRadius += stationSizeMax * CELLSIZE;
+
+	// For now, just assume the city is a circle around the spaceport in the center
+	const uint32_t cityExtents = (m_cityRadius / CELLSIZE);
+	m_citySize = cityExtents * 2;
+	m_gridPitch = std::ceil(m_citySize / 8.0);
+
+	Log::Verbose("Generating City for spacestation {}", station->GetSystemBody()->GetName());
+	Log::Verbose("\tpopulation: {0} size {1}x{1}c (radius {2})",
+		m_body->GetPopulation(), m_citySize, m_cityRadius);
+
+
+	// ensure divisible by 8 bytes for fast 64-bit lookup
+	if (m_gridPitch & 7) {
+		m_gridPitch = (m_gridPitch + 7) & ~7;
 	}
+	m_gridLen = m_gridPitch * m_citySize;
+
+	m_gridBitset.reset(new uint8_t[m_gridLen]);
+	std::memset(m_gridBitset.get(), 0, m_gridLen);
+
+	// Setup the station model position relative to the city grid
+	// ==========================================
+
+	// get the increment vectors to multiply X/Z grid coordinates by
+	vector3d incX = station->GetOrient().VectorX() * CELLSIZE;
+	vector3d incZ = station->GetOrient().VectorZ() * CELLSIZE;
+
+	// top-left corner of the grid is -X, -Z relative to station position at center
+	m_gridOrigin = station->GetPosition() - incX * cityExtents - incZ * cityExtents;
+
+	// Setup the station somewhere in the city (defaults to center for now)
+	const uint32_t stationPos[2] = {
+		cityExtents - stationSize[0] / 2,
+		cityExtents - stationSize[1] / 2
+	};
+
+	// Reserve space for the spacestation
+	SetGridOccupancy(stationPos[0], stationPos[1], stationSize, true);
+
+	Log::Verbose("\tCityOnPlanet: Station {} placed at grid {}:{} with extents {}x{}",
+		station->GetModel()->GetName(), stationPos[0], stationPos[1], stationSize[0], stationSize[1]);
+
+
+	// Begin generating buildings for the city
+	// ==========================================
 
 	// precalc orientation transforms (to rotate buildings to face north/south/east/west)
+	const matrix4x4d &m = station->GetOrient();
+
 	matrix4x4d orientcalc[4];
 	orientcalc[0] = m * matrix4x4d::RotateYMatrix(M_PI * 0.5 * 0);
 	orientcalc[1] = m * matrix4x4d::RotateYMatrix(M_PI * 0.5 * 1);
 	orientcalc[2] = m * matrix4x4d::RotateYMatrix(M_PI * 0.5 * 2);
 	orientcalc[3] = m * matrix4x4d::RotateYMatrix(M_PI * 0.5 * 3);
 
-	const double maxdist = pow(gmid + 0.333, 2);
-	for (int x = 0; x <= gsize; x++) {
-		const double distx = pow((x - gmid), 2);
-		for (int z = 0; z <= gsize; z++) {
-			if (cellgrid[x][z] > 0) {
-				// This cell has been allocated for something already
+	// Reserve space for all buildings we expect to generate
+	m_buildings.clear();
+	m_buildings.reserve(cityExtents * cityExtents); // estimate 25% occupancy
+
+	bool hasAtmo = m_body->HasAtmosphere();
+
+	uint32_t discardedCells = 0;
+	uint32_t skippedCells = 0;
+	uint32_t occupiedCells = 0;
+	uint32_t underwaterCells = 0;
+	uint32_t rarityRolls = 0;
+
+	double cityRadiusSqr = m_cityRadius * m_cityRadius;
+
+	for (uint32_t y = 0; y < m_citySize; y++) {
+		for (uint32_t x = 0; x < m_citySize; x++) {
+
+			// Do a basic loop over every cell in the city and determine what could be placed there
+
+			// TODO: future versions of cities should generate a random road network or place individual
+			// important buildings and place additional buildings around said features.
+			// The quality of the result relative to the generation cost would be much improved.
+
+			double radiusSqr = vector2d(
+				(cityExtents - double(x) + 0.5) * CELLSIZE,
+				(cityExtents - double(y) + 0.5) * CELLSIZE
+			).LengthSqr();
+
+			// skip cells outside the city radius
+			if (radiusSqr >= cityRadiusSqr) {
+				skippedCells++;
 				continue;
 			}
-			const double distz = pow((z - gmid), 2);
-			if ((distz + distx) > maxdist)
+
+			// skip already full cells
+			if (TestGridQuick(x, y)) {
+				occupiedCells++;
 				continue;
+			}
 
-			// fewer and fewer buildings the further from center you get
-			if ((distx + distz) * (1.0 / maxdist) > rand.Double())
+			// allow the population of cells to drop off as distance from city center increases
+			// note: this should ideally sample e.g. perlin noise to generate "clusters" of city buildings
+			double radiusNorm = sqrt(radiusSqr) / m_cityRadius;
+			if (radiusNorm > abs(m_rand.Normal()) * m_cityDensity) {
+				discardedCells++;
 				continue;
+			}
 
-			cent = p + mz * ((z - gmid) * cellsize) + mx * ((x - gmid) * cellsize);
-			cent = cent.Normalized();
+			// Attempt to select a building type for this grid cell
+			const BuildingType *buildingType = nullptr;
+			uint32_t typeIndex = 0;
+			for (uint32_t retry = 0; retry < 8; retry++) {
 
-			const double height = planet->GetTerrainHeight(cent);
-			if ((height - bodyradius) < 0) // don't position below sealevel
+				// pick a random building type
+				typeIndex = m_rand.Int32(m_cityType->buildingTypes.size());
+				buildingType = &m_cityType->buildingTypes[typeIndex];
+
+				// skip it if it won't fit here
+				// FIXME: this does not correctly handle the rotation case for non-square buildings.
+				// Need to transpose the cell size and test as well.
+				if (TestGridOccupancy(x, y, buildingType->cellSize)) {
+					buildingType = nullptr;
+					continue;
+				}
+
+				float rarity = hasAtmo ? buildingType->rarityAtmo : buildingType->rarityAirless;
+				float distribution = radiusNorm; // 0.0 .. 1.0 at edge of city
+
+				if (buildingType->buildingKind == SectorKind::Storage) {
+					// rarer in the center and more present at the edges of the city
+					rarity *= 0.5 + distribution * 0.5;
+				} else if (buildingType->buildingKind == SectorKind::Industry) {
+					// rarer in the center and more present at the edges of the city
+					rarity *= 0.3 + distribution * 0.7;
+				} else if (buildingType->buildingKind == SectorKind::Monument) {
+					// prevalent in the city center but extremely rare on the outskirts
+					rarity *= (1.0 - distribution) * 0.5;
+				} else if (buildingType->buildingKind == SectorKind::Habitat) {
+					// 1.0 at city center and 0.2 at outskirts
+					rarity *= 1.0 - distribution * 0.8;
+				} else if (buildingType->buildingKind == SectorKind::Frontier) {
+					// extremely rare at city center and 0.8 at outskirts
+					rarity *= (distribution * distribution) * 0.8;
+				}
+
+				// roll to see if the building spawns here or not
+				if (rarity < 1.0 && m_rand.Double() > rarity) {
+					rarityRolls++;
+					buildingType = nullptr;
+					continue;
+				}
+
+			}
+
+			// if we cannot find a building type, leave the cell empty and move on
+			if (buildingType == nullptr) {
+				discardedCells++;
 				continue;
+			}
 
-			cent = cent * height;
-
-			// quickly get a random building
-			const citybuilding_t &bt = buildings->buildings[rand.Int32(buildings->numBuildings)];
-			const CollMesh *cmesh = bt.collMesh.Get(); // collision mesh
+			SetGridOccupancy(x, y, buildingType->cellSize, true);
 
 			// rotate the building to face a random direction
-			const int32_t orient = rand.Int32(4);
+			const int32_t orient = m_rand.Int32(4);
+
+			// TODO: position model inside cells, add to building list
+			vector2d buildingPos = {
+				double(x) + buildingType->cellSize[0] / 2.0,
+				double(y) + buildingType->cellSize[1] / 2.0,
+			};
+
+			vector3d pos = m_gridOrigin + incX * buildingPos.x + incZ * buildingPos.y;
+			vector3d posNorm = pos.Normalized();
+			double height = m_planet->GetTerrainHeight(posNorm);
+
+			// don't place under planetary sea-level if the body has >10% water
+			// TODO: need a better way to sample both height and biome data to determine if the cell is actually water
+			// This will not properly handle elevated lakes or dry inland depressions below sea-level
+			if (m_body->GetVolatileLiquid() > 0.1 && height < m_body->GetRadius()) {
+				underwaterCells++;
+				continue;
+			}
+
+			// Compute the terrain relative height by scaling the normal of the building's ideal position
+			// This may introduce horizontal inaccuracy errors with sufficiently small planetary radii
+			pos = posNorm * height;
+
+			const CollMesh *cmesh = buildingType->model->GetCollisionMesh().Get();
+
 			// FIXME: geoms need a userdata to tell gameplay code what we actually hit.
 			// We don't want to create a separate Body for each instance of the buildings, so we
 			// scam the code by pretending we're part of the host planet.
-			Geom *geom = new Geom(cmesh->GetGeomTree(), orientcalc[orient], cent, GetPlanet());
+			Geom *geom = new Geom(cmesh->GetGeomTree(), orientcalc[orient], pos, GetPlanet());
 
 			// add it to the list of buildings to render
-			m_buildings.push_back({ bt.instIndex, float(cmesh->GetRadius()), orient, cent, geom });
+			m_buildings.push_back({ typeIndex, float(cmesh->GetRadius()), orient, pos, geom });
+
 		}
 	}
 
-	Aabb buildAABB;
-	for (std::vector<BuildingDef>::const_iterator iter = m_buildings.begin(), itEND = m_buildings.end(); iter != itEND; ++iter) {
-		buildAABB.Update((*iter).pos - p);
+	_genTimer.Stop();
+
+	Log::Verbose("\tCityOnPlanet: generated {} buildings in {}ms ( {} skipped, {} discarded, {} occupied, {} underwater, {} avg rolls / building )",
+		m_buildings.size(), _genTimer.milliseconds(), skippedCells, discardedCells, occupiedCells, underwaterCells, rarityRolls / double(m_buildings.size()));
+
+	_genTimer.SoftReset();
+
+	// Compute the total AABB of this city
+	Aabb totalAABB;
+	const vector3d &stationOrigin = station->GetPosition();
+
+	for (const auto &buildingInst : m_buildings) {
+		totalAABB.Update(buildingInst.pos - stationOrigin);
 	}
-	m_realCentre = buildAABB.min + ((buildAABB.max - buildAABB.min) * 0.5);
-	m_clipRadius = buildAABB.GetRadius();
-	AddStaticGeomsToCollisionSpace();
+
+	m_realCentre = totalAABB.min + ((totalAABB.max - totalAABB.min) * 0.5);
+	m_clipRadius = totalAABB.GetRadius();
+
+	_genTimer.Stop();
+
+	Log::Verbose("\tCityOnPlanet: generated AABB for city in {}ms", _genTimer.milliseconds());
+
+	// Release the memory once we're done generating and reset
+	m_gridBitset.reset();
+	m_gridPitch = 0;
+	m_gridLen = 0;
+}
+
+// Calculate the radius for this city based on the SystemBody's parameters
+void CityOnPlanet::CalcCityRadius(const SystemBody *body)
+{
+	double population = body->GetPopulation();
+	double atmo = body->GetAtmosOxidizing();
+
+	for (const CityRadiusDef &radii : reverse_container(m_cityType->sizeDefs)) {
+		bool isLast = (&radii == &m_cityType->sizeDefs.front());
+
+		if (population > radii.population && !isLast)
+			continue;
+
+		m_cityRadius = radii.baseSize + (atmo * radii.atmoSize) + (m_rand.Double() * radii.randomSize);
+		m_cityDensity = radii.density * 0.8;
+		break;
+	}
+}
+
+#ifdef __BIG_ENDIAN__
+#error "CityOnPlanet does not (yet) support big-endian architectures"
+#endif
+
+// Supports up to 32-cell wide buildings to ensure 8-byte aligned addressing in a single operation
+static inline uint64_t CalcBitmaskForGrid(uint32_t x, uint32_t xsize)
+{
+	uint32_t maskOffset = x & CityOnPlanet::CELLMASK;
+	uint64_t bitmask = uint64_t((1 << xsize) - 1) << maskOffset;
+	// note: need crossplatform bswap_64 here for big-endian compat
+	// we should be able to swap the bitmask rather than the in-memory bytes and have the same effect
+
+	return bitmask;
+}
+
+void CityOnPlanet::SetGridOccupancy(uint32_t x, uint32_t y, const uint8_t size[2], bool occupied)
+{
+	if (x + size[0] > m_citySize || y + size[1] > m_citySize)
+		return; // footprint would be off-grid, prevent writing outside the bitset
+
+	// City grid is stored as lsb-first bitset with one bit per grid cell;
+	// bit 1 of byte 1 is grid 0, while bit 8 of byte 4 is grid 31
+	// Support maximum size of 32 cells for a single building to enable fast 64-bit aligned operations
+
+	uint8_t *dataPtr = m_gridBitset.get() + (x & ~CELLMASK) / 8;
+	uint64_t bitmask = CalcBitmaskForGrid(x, size[0]);
+
+	for (uint32_t idx = y; idx < y + size[1]; idx++) {
+		*reinterpret_cast<uint64_t *>(dataPtr + idx * m_gridPitch) |= bitmask;
+	}
+}
+
+bool CityOnPlanet::TestGridOccupancy(uint32_t x, uint32_t y, const uint8_t size[2])
+{
+	if (x + size[0] > m_citySize || y + size[1] > m_citySize)
+		return true; // always occupied if footprint would be off-grid
+
+
+	// City grid is stored as lsb-first bitset with one bit per grid cell;
+	// bit 1 of byte 1 is grid 0, while bit 8 of byte 4 is grid 31
+	// Support maximum size of 32 cells for a single building to enable fast 64-bit aligned operations
+	uint8_t *dataPtr = m_gridBitset.get() + (x & ~CELLMASK) / 8;
+	uint64_t bitmask = CalcBitmaskForGrid(x, size[0]);
+
+	uint64_t test = 0;
+
+	for (uint32_t idx = y; idx < y + size[1]; idx++) {
+		test |= *reinterpret_cast<uint64_t *>(dataPtr + idx * m_gridPitch) & bitmask;
+	}
+
+	return test != 0;
 }
 
 void CityOnPlanet::Render(Graphics::Renderer *r, const Graphics::Frustum &frustum, const SpaceStation *station, const vector3d &viewCoords, const matrix4x4d &viewTransform)
 {
+	PROFILE_SCOPED()
+
 	// Early frustum test of whole city.
 	const vector3d stationPos = viewTransform * (station->GetPosition() + m_realCentre);
 	//modelview seems to be always identity
@@ -347,25 +677,32 @@ void CityOnPlanet::Render(Graphics::Renderer *r, const Graphics::Frustum &frustu
 	}
 
 	// update any idle animations
-	for (Uint32 i = 0; i < s_buildingList.numBuildings; i++) {
-		SceneGraph::Animation *pAnim = s_buildingList.buildings[i].idle;
-		if (pAnim) {
-			pAnim->SetProgress(fmod(pAnim->GetProgress() + (Pi::game->GetTimeStep() / pAnim->GetDuration()), 1.0));
-			pAnim->Interpolate();
+	// TODO: this is kind of a horrible idea in many ways
+	// animated buildings need per-instance state and need to support instanced drawing with GPU animation transform of some kind
+	// individual cities at the *very* least need to have their own copy of the model used in them so color + animation state
+	// doesn't "leak" into other users of the model
+	for (auto &buildingType : m_cityType->buildingTypes) {
+		SceneGraph::Animation *anim = buildingType.idleAnimation;
+		if (anim) {
+			anim->SetProgress(fmod(anim->GetProgress() + (Pi::game->GetTimeStep() / anim->GetDuration()), 1.0));
+			anim->Interpolate();
 		}
 	}
 
-	Uint32 uCount = 0;
-	std::vector<Uint32> instCount;
+	uint32_t uCount = 0;
+	uint32_t numBuildings = m_cityType->buildingTypes.size();
+
+	std::vector<uint32_t> instCount;
 	std::vector<std::vector<matrix4x4f>> transform;
-	instCount.resize(s_buildingList.numBuildings);
-	transform.resize(s_buildingList.numBuildings);
-	memset(&instCount[0], 0, sizeof(Uint32) * s_buildingList.numBuildings);
-	for (Uint32 i = 0; i < s_buildingList.numBuildings; i++) {
+
+	instCount.resize(numBuildings, 0);
+	transform.resize(numBuildings);
+
+	for (uint32_t i = 0; i < numBuildings; i++) {
 		transform[i].reserve(m_buildingCounts[i]);
 	}
 
-	for (std::vector<BuildingDef>::const_iterator iter = m_enabledBuildings.begin(), itEND = m_enabledBuildings.end(); iter != itEND; ++iter) {
+	for (std::vector<BuildingInstance>::const_iterator iter = m_enabledBuildings.begin(), itEND = m_enabledBuildings.end(); iter != itEND; ++iter) {
 		const vector3d pos = viewTransform * (*iter).pos;
 		const vector3f posf(pos);
 		if (!frustum.TestPoint(pos, (*iter).clipRadius))
@@ -382,10 +719,34 @@ void CityOnPlanet::Render(Graphics::Renderer *r, const Graphics::Frustum &frustu
 	}
 
 	// render the building models using instancing
-	for (Uint32 i = 0; i < s_buildingList.numBuildings; i++) {
+	for (Uint32 i = 0; i < numBuildings; i++) {
 		if (!transform[i].empty())
-			s_buildingList.buildings[i].resolvedModel->Render(transform[i]);
+			m_cityType->buildingTypes[i].model->Render(transform[i]);
 	}
+
+	// Draw debug extents
+	/*
+	r->SetTransform(matrix4x4f(viewTransform));
+	Graphics::VertexArray va(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE);
+
+	vector3f origin = vector3f(m_gridOrigin);
+	vector3f incX = vector3f(station->GetOrient().VectorX() * double(m_citySize * CELLSIZE));
+	vector3f incZ = vector3f(station->GetOrient().VectorZ() * double(m_citySize * CELLSIZE));
+
+	va.Add(origin, Color(255, 0, 0));
+	va.Add(origin + incX, Color(255, 0, 0));
+
+	va.Add(origin + incX, Color(0, 255, 0));
+	va.Add(origin + incX + incZ, Color(0, 255, 0));
+
+	va.Add(origin + incX + incZ, Color(255, 0, 0));
+	va.Add(origin + incZ, Color(255, 0, 0));
+
+	va.Add(origin + incZ, Color(0, 255, 0));
+	va.Add(origin, Color(0, 255, 0));
+
+	r->DrawBuffer(&va, s_debugMat.get());
+	*/
 
 	r->GetStats().AddToStatCount(Graphics::Stats::STAT_BUILDINGS, uCount);
 	r->GetStats().AddToStatCount(Graphics::Stats::STAT_CITIES, 1);

--- a/src/CityOnPlanet.h
+++ b/src/CityOnPlanet.h
@@ -99,7 +99,7 @@ private:
 	void Generate(SpaceStation *station);
 	void CalcCityRadius(const SystemBody *body);
 
-	void SetGridOccupancy(uint32_t x, uint32_t y, const uint8_t size[2], bool occupied);
+	void SetGridOccupancy(uint32_t x, uint32_t y, const uint8_t size[2]);
 	bool TestGridOccupancy(uint32_t x, uint32_t y, const uint8_t size[2]);
 
 	// Quickly check if the given single grid cell is set.

--- a/src/CityOnPlanet.h
+++ b/src/CityOnPlanet.h
@@ -7,6 +7,7 @@
 #include "CollMesh.h"
 #include "FrameId.h"
 #include "Random.h"
+#include "JsonFwd.h"
 
 #include <set>
 
@@ -15,11 +16,18 @@ class Planet;
 class SpaceStation;
 class Frame;
 class SystemPath;
+class SystemBody;
 
 namespace Graphics {
 	class Renderer;
 	class Frustum;
+	class Material;
 } // namespace Graphics
+
+namespace FileSystem {
+	struct FileInfo;
+} // namespace FileSystem
+
 namespace SceneGraph {
 	class Model;
 	class Animation;
@@ -30,20 +38,83 @@ public:
 	CityOnPlanet() = delete;
 	CityOnPlanet(Planet *planet, SpaceStation *station, const Uint32 seed);
 	virtual ~CityOnPlanet();
+
 	void Render(Graphics::Renderer *r, const Graphics::Frustum &camera, const SpaceStation *station, const vector3d &viewCoords, const matrix4x4d &viewTransform);
 	inline Planet *GetPlanet() const { return m_planet; }
+	float GetClipRadius() const { return m_clipRadius; }
 
 	static void Init();
 	static void Uninit();
+
 	static void SetCityModelPatterns(const SystemPath &path);
 
 	static constexpr double RADIUS = 5000.0;
+	// size of a city grid cell
+	static constexpr uint32_t CELLSIZE = 50;
+	// maximum number of cells a single building may take up
+	static constexpr uint32_t CELLMAX = 32;
+	static constexpr uint32_t CELLMASK = CELLMAX - 1;
 
 private:
+
+	// Defines which "city sector" a building should optimally be placed in
+	enum class SectorKind : uint32_t {
+		None,		// no specific sector for a building
+		Storage,	// warehouses and personal storage buildings
+		Industry,	// industrial buildings with high pollution or power draw
+		Monument,	// civic / recreational buildings
+		Habitat,	// living spaces and office buildings
+		Frontier,	// general buildings scattered at the edge of the city
+	};
+
+	// Building type definition
+	struct BuildingType {
+		uint8_t cellSize[2] = {1, 1};
+
+		float rarityAirless = 0;
+		float rarityAtmo = 0;
+
+		SectorKind buildingKind = SectorKind::None;
+
+		SceneGraph::Model *model;
+		SceneGraph::Animation *idleAnimation;
+	};
+
+	struct CityRadiusDef {
+		double population = 0.0;	// billions of people
+		float baseSize = 0.0;		// base size of the city (meters)
+		float atmoSize = 0.0;		// additional size from atmosphere (meters)
+		float randomSize = 0.0;		// random additional size (meters)
+		float density = 0.0;        // density of buildings within the city
+	};
+
+	struct CityFlavourType {
+		std::string flavourName;
+		std::vector<CityRadiusDef> sizeDefs;
+		std::vector<BuildingType> buildingTypes;
+	};
+
+private:
+
+	void Generate(SpaceStation *station);
+	void CalcCityRadius(const SystemBody *body);
+
+	void SetGridOccupancy(uint32_t x, uint32_t y, const uint8_t size[2], bool occupied);
+	bool TestGridOccupancy(uint32_t x, uint32_t y, const uint8_t size[2]);
+
+	// Quickly check if the given single grid cell is set.
+	// It is expected as a precondition that the position is valid and within
+	// the extents of the grid.
+	inline bool TestGridQuick(uint32_t x, uint32_t y) const
+	{
+		// bitset is stored in lsb order with 8 cells per byte
+		return m_gridBitset[y * m_gridPitch + x / 8] & (1 << (x & 7));
+	}
+
 	void AddStaticGeomsToCollisionSpace();
 	void RemoveStaticGeomsFromCollisionSpace();
 
-	struct BuildingDef {
+	struct BuildingInstance {
 		Uint32 instIndex;
 		float clipRadius;
 		int rotation; // 0-3
@@ -51,47 +122,44 @@ private:
 		Geom *geom;
 	};
 
+	const SystemBody *m_body;
 	Planet *m_planet;
+
+	double m_cityRadius;
+	double m_cityDensity;
+	uint32_t m_citySize;
+
 	FrameId m_frame;
-	std::vector<BuildingDef> m_buildings;
-	std::vector<BuildingDef> m_enabledBuildings;
+	Random m_rand;
+
+	std::vector<BuildingInstance> m_buildings;
+	std::vector<BuildingInstance> m_enabledBuildings;
 	std::vector<Uint32> m_buildingCounts;
+
+	// bitmask occupancy grid for quick population of the city
+	std::unique_ptr<uint8_t[]> m_gridBitset;
+	// width of a single grid row in bytes
+	uint32_t m_gridPitch;
+	uint32_t m_gridLen;
+
 	int m_detailLevel;
-	vector3d m_realCentre;
 	float m_clipRadius;
+	vector3d m_realCentre;
+	vector3d m_gridOrigin;
+
+	CityFlavourType *m_cityType;
 
 	// --------------------------------------------------------
 	// statics
-	static const unsigned int CITYFLAVOURS = 5;
+private:
 
-	struct citybuilding_t {
-		const char *modelname;
-		double xzradius;
-		SceneGraph::Model *resolvedModel;
-		SceneGraph::Animation *idle;
-		RefCountedPtr<CollMesh> collMesh;
-		Uint32 instIndex;
-	};
+	static std::vector<CityFlavourType> s_cityFlavours;
 
-	struct citybuildinglist_t {
-		const char *modelTagName;
-		double minRadius, maxRadius;
-		unsigned int numBuildings;
-		citybuilding_t *buildings;
-	};
+	static std::unique_ptr<Graphics::Material> s_debugMat;
 
-	struct cityflavourdef_t {
-		vector3d center;
-		double size;
-	};
-
-	static bool s_cityBuildingsInitted;
-
-	static citybuildinglist_t s_buildingList;
-	static cityflavourdef_t cityflavour[CITYFLAVOURS];
-
-	static void EnumerateNewBuildings(std::set<std::string> &filenames);
-	static void LookupBuildingListModels(citybuildinglist_t *list);
+	static void LoadCityFlavour(const FileSystem::FileInfo &file);
+	static void LoadBuildingType(std::string_view key, const Json &buildingDef, BuildingType &out);
+	static void GetModelSize(const Aabb &aabb, uint8_t size[2]);
 };
 
 #endif /* _CITYONPLANET_H */

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -51,6 +51,9 @@ GameConfig::GameConfig(const map_string &override_)
 	map["EnableGLDebug"] = "0";
 	map["EnableGPUJobs"] = "1";
 	map["GL3ForwardCompatible"] = "1";
+	map["LogVerbose"] = "1";
+	map["ProfileSlowFrames"] = "0";
+	map["ProfilerZoneOutput"] = "0";
 
 	Read(FileSystem::userFiles, "config.ini");
 

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -53,12 +53,12 @@ void GeoSphere::Uninit()
 
 static void print_info(const SystemBody *sbody, const Terrain *terrain)
 {
-	Output(
-		"%s:\n"
-		"    height fractal: %s\n"
-		"    colour fractal: %s\n"
-		"    seed: %u\n",
-		sbody->GetName().c_str(), terrain->GetHeightFractalName(), terrain->GetColorFractalName(), sbody->GetSeed());
+	Log::Verbose(
+		"Geosphere Init for {}:\n" \
+		"\theight fractal: {}\n" \
+		"\tcolour fractal: {}\n" \
+		"\tseed: {}\n",
+		sbody->GetName(), terrain->GetHeightFractalName(), terrain->GetColorFractalName(), sbody->GetSeed());
 }
 
 // static

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -325,6 +325,12 @@ void Pi::App::Startup()
 
 	Log::GetLog()->SetLogFile("output.txt");
 
+	if (config->Int("LogVerbose", 0))
+		Log::GetLog()->SetFileSeverity(Log::Severity::Verbose);
+
+	if (config->Int("LogVerbose", 0) > 1)
+		Log::GetLog()->SetSeverity(Log::Severity::Verbose);
+
 	std::string version(PIONEER_VERSION);
 	if (strlen(PIONEER_EXTRAVERSION)) version += " (" PIONEER_EXTRAVERSION ")";
 	const char *platformName = SDL_GetPlatform();

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -757,7 +757,10 @@ void SpaceStation::Render(Graphics::Renderer *r, const Camera *camera, const vec
 
 		if (!m_adjacentCity) {
 			m_adjacentCity = new CityOnPlanet(static_cast<Planet *>(b), this, m_sbody->GetSeed());
+			// Update clipping radius
+			SetClipRadius(m_adjacentCity->GetClipRadius());
 		}
+
 		m_adjacentCity->Render(r, camera->GetContext()->GetFrustum(), this, viewCoords, viewTransform);
 
 		RenderModel(r, camera, viewCoords, viewTransform, false);

--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -109,9 +109,9 @@ void Log::Logger::WriteLog(Time::DateTime time, Severity sv, std::string_view ms
 
 	if (file && sv <= m_maxFileSeverity) {
 		if (!msg.empty() && msg.back() == '\n')
-			fmt::print(file, "[{0}] {1:<8} {2}", time.ToTimeString(), svName, msg);
+			fmt::print(file, "[{0}] {1:<8}  {2}", time.ToTimeString(), svName, msg);
 		else
-			fmt::print(file, "[{0}] {1:<8} {2}\n", time.ToTimeString(), svName, msg);
+			fmt::print(file, "[{0}] {1:<8}  {2}\n", time.ToTimeString(), svName, msg);
 		// flush log file to ensure we have complete data in case of a crash
 		fflush(file);
 	}

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -17,7 +17,6 @@
 #include "ShipType.h"
 #include "Space.h"
 #include "SpaceStation.h"
-#include "lauxlib.h"
 #include "ship/PlayerShipController.h"
 #include "ship/PrecalcPath.h"
 #include "src/lua.h"


### PR DESCRIPTION
This PR finally finishes implementing the work that joonicks started a very long time ago. It reworks Pioneer's city generation code to be faster, support more natural and intentional building placement, massively improves the code quality and maintainability, allows many parameters to be data-driven, and fixes several major bugs with city generation.

I've included a sample default configuration, with plenty of comments in the code explaining how the algorithm works and what effect the various inputs in the configuration have on the generated result. Feel free to tweak the config further or add entirely new configuration files - when a city is generated it will pick a random configuration from the `data/configs/buildings/` directory.

The default city configuration creates cities anywhere from a few hundred meters wide on sparsely populated planets to ~30km^2 on the most populated worlds (e.g. Earth). This is done at roughly interactive framerates (generating a city causes at most a ~50ms stall), though there's future potential to run the entire generation process asynchronously on a background thread and refrain from rendering the city until it is finished.

There is still plenty of room for optimization in city rendering; that code is mostly unchanged and requires a deeper refactor into the Scenegraph instanced rendering code to achieve a performance gain. The CPU-side cost of rendering 12-20k buildings is very negligible though, coming in at sub-millisecond times on my machine. The existing city detail quality setting can also help with that.

This PR should fix issues where starting a game at New Hope, leaving to the main menu, and then starting one on Mars without closing the game would cause a completely different city layout than if you started directly on Mars.

I've also updated the logging with a new config variable to control printing verbose log messages and added a new debug tool capability to teleport the player's ship to a docked state at the targeted space station. The debug tool is available on the Ship Spawner menu right now, though a refactor of the debug tool UI in general is needed at some point.

Enough from me, have some screenshots!

Itzalean on New Hope:
![image](https://user-images.githubusercontent.com/4218491/204114179-18ff3d4c-cf28-4ac5-9558-dfaf6d4f4b06.png)

Cydonia on Mars:
![image](https://user-images.githubusercontent.com/4218491/204117245-c0e9f93e-e406-488b-9521-26b0325fecf9.png)

London, England, Earth: (ever so slightly in the wrong place)
![image](https://user-images.githubusercontent.com/4218491/204117314-415fa4fc-5ab4-462b-a7c5-7ec4ef84fec9.png)
![image](https://user-images.githubusercontent.com/4218491/204117317-d53f624a-276e-476d-8b38-8318e6023de0.png)

Closes #4913.