### PR TITLE
Load mods from directories as well as zip files

### DIFF
--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -155,7 +155,7 @@ void CityOnPlanet::LoadBuildingType(std::string_view key, const Json &buildingDe
 
 void CityOnPlanet::LoadCityFlavour(const FileSystem::FileInfo &file)
 {
-	Json fileData = JsonUtils::LoadJson(file.Read());
+	Json fileData = JsonUtils::LoadJsonDataFile(file.GetPath(), true);
 	if (!fileData.is_object()) {
 		Log::Info("CityOnPlanet: Could not load city definition file '{}' as a valid JSON file.", file.GetPath());
 		return;

--- a/src/ModManager.cpp
+++ b/src/ModManager.cpp
@@ -10,12 +10,15 @@ void ModManager::Init()
 {
 	FileSystem::userFiles.MakeDirectory("mods");
 
-	for (FileSystem::FileEnumerator files(FileSystem::userFiles, "mods", 0); !files.Finished(); files.Next()) {
+	for (FileSystem::FileEnumerator files(FileSystem::userFiles, "mods", FileSystem::FileEnumerator::IncludeDirs); !files.Finished(); files.Next()) {
 		const FileSystem::FileInfo &info = files.Current();
 		const std::string &zipPath = info.GetPath();
 		if (ends_with_ci(zipPath, ".zip")) {
 			Output("adding mod: %s\n", zipPath.c_str());
 			FileSystem::gameDataFiles.PrependSource(new FileSystem::FileSourceZip(FileSystem::userFiles, zipPath));
+		} else if (info.IsDir()) {
+			Output("adding mod: %s\n", zipPath.c_str());
+			FileSystem::gameDataFiles.PrependSource(new FileSystem::FileSourceFS(FileSystem::JoinPath(FileSystem::userFiles.GetRoot(), zipPath)));
 		}
 	}
 }


### PR DESCRIPTION
This PR simply improves the mod development workflow slightly, by enabling the game to load mods from filesystem directories in the mods folder as well as zip files. It also fixes an overlooked bug in the city rework that prevented the city definition JSON files from being modded via the .json.patch method.