### PR TITLE
fixes #5356 - no shield recharging after selling energy booster

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1313,8 +1313,8 @@ void Ship::StaticUpdate(const float timeStep)
 	if (m_stats.shield_mass_left < m_stats.shield_mass) {
 		// 250 second recharge
 		float recharge_rate = 0.004f;
-		float booster = Properties().Get("shield_energy_booster_cap").get_number(1.0f);
-		recharge_rate *= booster;
+		float booster = Properties().Get("shield_energy_booster_cap");
+		recharge_rate *= booster ? booster : 1.0;
 		m_stats.shield_mass_left = Clamp(m_stats.shield_mass_left + m_stats.shield_mass * recharge_rate * timeStep, 0.0f, m_stats.shield_mass);
 		Properties().Set("shieldMassLeft", m_stats.shield_mass_left);
 	}


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
It is the same issue as with laser cooling booster. When the property was set to 0 after selling the shield energy booster it was not defaulted to 1 as when it was unset in a new ship.
<!-- Please make sure you've read documentation on contributing -->

