### PR TITLE
Check spaceport being behind a body while drawing nav target indicator

### DIFF
--- a/data/icons/icons.svg
+++ b/data/icons/icons.svg
@@ -1,2009 +1,440 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="3870.3811"
-   height="4596.0371"
-   version="1.1"
-   viewBox="0 0 3628.4701 4308.7699"
-   id="svg7553"
-   sodipodi:docname="icons.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:serif="http://www.serif.com/">
-  <sodipodi:namedview
-     id="namedview7555"
-     pagecolor="#000000"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="false"
-     showgrid="true"
-     inkscape:snap-object-midpoints="false"
-     inkscape:zoom="0.16"
-     inkscape:cx="1425"
-     inkscape:cy="2571.875"
-     inkscape:window-width="2489"
-     inkscape:window-height="1417"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g7551"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:snap-global="true"
-     inkscape:snap-bbox="true"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:snap-nodes="true"
-     inkscape:object-nodes="false"
-     inkscape:bbox-nodes="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid14532"
-       spacingx="226.77016"
-       spacingy="226.77016"
-       originx="-4.4764042e-09"
-       originy="4.2724605e-06" />
-    <sodipodi:guide
-       position="2040.5205,122.26094"
-       orientation="1,0"
-       id="guide16936" />
+<svg width="3870.3811" height="4596.0371" version="1.1" viewBox="0 0 3628.4701 4308.7699" id="svg7553" sodipodi:docname="icons.svg" inkscape:version="1.1.2 (b8e25be833, 2022-02-05)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:serif="http://www.serif.com/">
+  <sodipodi:namedview id="namedview7555" pagecolor="#000000" bordercolor="#666666" borderopacity="1.0" inkscape:pageshadow="2" inkscape:pageopacity="0" inkscape:pagecheckerboard="false" showgrid="true" inkscape:snap-object-midpoints="false" inkscape:zoom="1.28" inkscape:cx="3187.5" inkscape:cy="347.65625" inkscape:window-width="2489" inkscape:window-height="1417" inkscape:window-x="-8" inkscape:window-y="-8" inkscape:window-maximized="1" inkscape:current-layer="g6021-7" fit-margin-top="0" fit-margin-left="0" fit-margin-right="0" fit-margin-bottom="0" inkscape:snap-global="true" inkscape:snap-bbox="true" showguides="true" inkscape:guide-bbox="true" inkscape:snap-nodes="true" inkscape:object-nodes="false" inkscape:bbox-nodes="true" inkscape:lockguides="true" inkscape:snap-grids="false" inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid type="xygrid" id="grid14532" spacingx="226.77016" spacingy="226.77016" originx="-4.4764042e-09" originy="4.2724605e-06"/>
+    <sodipodi:guide position="2040.5205,122.26094" orientation="1,0" id="guide16936" inkscape:locked="true"/>
+    <sodipodi:guide position="2948.0121,3855.2298" orientation="0,-1" id="guide4268" inkscape:locked="true"/>
   </sodipodi:namedview>
-  <defs
-     id="defs4054">
-    <marker
-       id="marker8674"
-       overflow="visible"
-       orient="auto">
-      <path
-         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
-         d="M 8.7186,4.0337 -2.2074,0.016 8.7186,-4.0017 c -1.7455,2.3721 -1.7354,5.6175 0,8.0354 z"
-         fill="#fffffd"
-         fill-rule="evenodd"
-         stroke="#ffffee"
-         stroke-linejoin="round"
-         stroke-width="0.625"
-         id="path3839" />
+  <defs id="defs4054">
+    <marker id="marker8674" overflow="visible" orient="auto">
+      <path transform="matrix(-0.3,0,0,-0.3,0.69,0)" d="M 8.7186,4.0337 -2.2074,0.016 8.7186,-4.0017 c -1.7455,2.3721 -1.7354,5.6175 0,8.0354 z" fill="#fffffd" fill-rule="evenodd" stroke="#ffffee" stroke-linejoin="round" stroke-width="0.625" id="path3839"/>
     </marker>
-    <marker
-       id="marker8458"
-       overflow="visible"
-       orient="auto">
-      <path
-         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
-         d="M 8.7186,4.0337 -2.2074,0.016 8.7186,-4.0017 c -1.7455,2.3721 -1.7354,5.6175 0,8.0354 z"
-         fill="#ffeeff"
-         fill-rule="evenodd"
-         stroke="#ffffee"
-         stroke-linejoin="round"
-         stroke-width="0.625"
-         id="path3842" />
+    <marker id="marker8458" overflow="visible" orient="auto">
+      <path transform="matrix(-0.3,0,0,-0.3,0.69,0)" d="M 8.7186,4.0337 -2.2074,0.016 8.7186,-4.0017 c -1.7455,2.3721 -1.7354,5.6175 0,8.0354 z" fill="#ffeeff" fill-rule="evenodd" stroke="#ffffee" stroke-linejoin="round" stroke-width="0.625" id="path3842"/>
     </marker>
-    <marker
-       id="Arrow2Send"
-       overflow="visible"
-       orient="auto">
-      <path
-         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
-         d="M 8.7186,4.0337 -2.2074,0.016 8.7186,-4.0017 c -1.7455,2.3721 -1.7354,5.6175 0,8.0354 z"
-         fill="#fffff6"
-         fill-rule="evenodd"
-         stroke="#ffffee"
-         stroke-linejoin="round"
-         stroke-width="0.625"
-         id="path3845" />
+    <marker id="Arrow2Send" overflow="visible" orient="auto">
+      <path transform="matrix(-0.3,0,0,-0.3,0.69,0)" d="M 8.7186,4.0337 -2.2074,0.016 8.7186,-4.0017 c -1.7455,2.3721 -1.7354,5.6175 0,8.0354 z" fill="#fffff6" fill-rule="evenodd" stroke="#ffffee" stroke-linejoin="round" stroke-width="0.625" id="path3845"/>
     </marker>
-    <filter
-       id="filter4188"
-       color-interpolation-filters="sRGB"
-       x="0"
-       y="0"
-       width="1"
-       height="1">
-      <feBlend
-         in2="BackgroundImage"
-         mode="screen"
-         id="feBlend3848" />
+    <filter id="filter4188" color-interpolation-filters="sRGB" x="0" y="0" width="1" height="1">
+      <feBlend in2="BackgroundImage" mode="screen" id="feBlend3848"/>
     </filter>
-    <filter
-       id="filter4188-6"
-       color-interpolation-filters="sRGB"
-       x="0"
-       y="0"
-       width="1"
-       height="1">
-      <feBlend
-         in2="BackgroundImage"
-         mode="screen"
-         id="feBlend4012" />
+    <filter id="filter4188-6" color-interpolation-filters="sRGB" x="0" y="0" width="1" height="1">
+      <feBlend in2="BackgroundImage" mode="screen" id="feBlend4012"/>
     </filter>
-    <linearGradient
-       id="linearGradient5431"
-       x1="192.32001"
-       x2="150.00999"
-       y1="1117.4"
-       y2="1116.9"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4860" />
-    <linearGradient
-       id="linearGradient4860">
-      <stop
-         stop-color="#fff"
-         stop-opacity=".32917"
-         offset="0"
-         id="stop4016" />
-      <stop
-         stop-color="#fff"
-         stop-opacity="0"
-         offset="1"
-         id="stop4018" />
+    <linearGradient id="linearGradient5431" x1="192.32001" x2="150.00999" y1="1117.4" y2="1116.9" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4860"/>
+    <linearGradient id="linearGradient4860">
+      <stop stop-color="#fff" stop-opacity=".32917" offset="0" id="stop4016"/>
+      <stop stop-color="#fff" stop-opacity="0" offset="1" id="stop4018"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5433"
-       x1="21.709"
-       x2="19.665001"
-       y1="143.46001"
-       y2="146.67"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4944" />
-    <linearGradient
-       id="linearGradient4944">
-      <stop
-         stop-color="#fff"
-         offset="0"
-         id="stop4022" />
-      <stop
-         stop-color="#929292"
-         stop-opacity="0"
-         offset="1"
-         id="stop4024" />
+    <linearGradient id="linearGradient5433" x1="21.709" x2="19.665001" y1="143.46001" y2="146.67" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4944"/>
+    <linearGradient id="linearGradient4944">
+      <stop stop-color="#fff" offset="0" id="stop4022"/>
+      <stop stop-color="#929292" stop-opacity="0" offset="1" id="stop4024"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5435"
-       x1="164.89999"
-       x2="160.75999"
-       y1="1109.6"
-       y2="1100.2"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4960" />
-    <linearGradient
-       id="linearGradient4960">
-      <stop
-         stop-color="#e3e3e3"
-         offset="0"
-         id="stop4028" />
-      <stop
-         stop-color="#e3e3e3"
-         stop-opacity="0"
-         offset="1"
-         id="stop4030" />
+    <linearGradient id="linearGradient5435" x1="164.89999" x2="160.75999" y1="1109.6" y2="1100.2" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4960"/>
+    <linearGradient id="linearGradient4960">
+      <stop stop-color="#e3e3e3" offset="0" id="stop4028"/>
+      <stop stop-color="#e3e3e3" stop-opacity="0" offset="1" id="stop4030"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5437"
-       x1="20"
-       x2="15.323"
-       y1="140.49001"
-       y2="142.89"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4936" />
-    <linearGradient
-       id="linearGradient4936">
-      <stop
-         stop-color="#c4c4c4"
-         offset="0"
-         id="stop4034" />
-      <stop
-         stop-color="#c4c4c4"
-         stop-opacity="0"
-         offset="1"
-         id="stop4036" />
+    <linearGradient id="linearGradient5437" x1="20" x2="15.323" y1="140.49001" y2="142.89" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4936"/>
+    <linearGradient id="linearGradient4936">
+      <stop stop-color="#c4c4c4" offset="0" id="stop4034"/>
+      <stop stop-color="#c4c4c4" stop-opacity="0" offset="1" id="stop4036"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5439"
-       x1="181.62"
-       x2="167.97"
-       y1="1121.1"
-       y2="1121.4"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4825" />
-    <linearGradient
-       id="linearGradient4825">
-      <stop
-         stop-color="#fff"
-         offset="0"
-         id="stop4040" />
-      <stop
-         stop-color="#d3d3d3"
-         offset="1"
-         id="stop4042" />
+    <linearGradient id="linearGradient5439" x1="181.62" x2="167.97" y1="1121.1" y2="1121.4" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4825"/>
+    <linearGradient id="linearGradient4825">
+      <stop stop-color="#fff" offset="0" id="stop4040"/>
+      <stop stop-color="#d3d3d3" offset="1" id="stop4042"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5441"
-       x1="21.809999"
-       x2="14.605"
-       y1="137.22"
-       y2="134.38"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4952" />
-    <linearGradient
-       id="linearGradient4952">
-      <stop
-         stop-color="#cecece"
-         offset="0"
-         id="stop4046" />
-      <stop
-         stop-color="#cecece"
-         stop-opacity="0"
-         offset="1"
-         id="stop4048" />
+    <linearGradient id="linearGradient5441" x1="21.809999" x2="14.605" y1="137.22" y2="134.38" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4952"/>
+    <linearGradient id="linearGradient4952">
+      <stop stop-color="#cecece" offset="0" id="stop4046"/>
+      <stop stop-color="#cecece" stop-opacity="0" offset="1" id="stop4048"/>
     </linearGradient>
-    <linearGradient
-       id="linearGradient5443"
-       x1="181.21001"
-       x2="167.61"
-       y1="1121.5"
-       y2="1121.2"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4825" />
-    <linearGradient
-       id="linearGradient5445"
-       x1="182.61"
-       x2="168.64"
-       y1="1121.1"
-       y2="1121"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4825" />
-    <linearGradient
-       id="linearGradient5447"
-       x1="181.95"
-       x2="168.75999"
-       y1="1121"
-       y2="1121.2"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4825" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4860"
-       id="linearGradient26937"
-       gradientUnits="userSpaceOnUse"
-       x1="192.32001"
-       y1="1117.4"
-       x2="150.00999"
-       y2="1116.9" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4944"
-       id="linearGradient26939"
-       gradientUnits="userSpaceOnUse"
-       x1="21.709"
-       y1="143.46001"
-       x2="19.665001"
-       y2="146.67" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4960"
-       id="linearGradient26941"
-       gradientUnits="userSpaceOnUse"
-       x1="164.89999"
-       y1="1109.6"
-       x2="160.75999"
-       y2="1100.2" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4936"
-       id="linearGradient26943"
-       gradientUnits="userSpaceOnUse"
-       x1="20"
-       y1="140.49001"
-       x2="15.323"
-       y2="142.89" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4825"
-       id="linearGradient26945"
-       gradientUnits="userSpaceOnUse"
-       x1="181.62"
-       y1="1121.1"
-       x2="167.97"
-       y2="1121.4" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4952"
-       id="linearGradient26947"
-       gradientUnits="userSpaceOnUse"
-       x1="21.809999"
-       y1="137.22"
-       x2="14.605"
-       y2="134.38" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4825"
-       id="linearGradient26949"
-       gradientUnits="userSpaceOnUse"
-       x1="181.21001"
-       y1="1121.5"
-       x2="167.61"
-       y2="1121.2" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4825"
-       id="linearGradient26951"
-       gradientUnits="userSpaceOnUse"
-       x1="182.61"
-       y1="1121.1"
-       x2="168.64"
-       y2="1121" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4825"
-       id="linearGradient26953"
-       gradientUnits="userSpaceOnUse"
-       x1="181.95"
-       y1="1121"
-       x2="168.75999"
-       y2="1121.2" />
-    <linearGradient
-       id="_Linear2"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-32.0767,55.0677,-55.0677,-32.0767,331.057,1041.3)">
-      <stop
-         offset="0"
-         style="stop-color:white;stop-opacity:0.37"
-         id="stop3729" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(179,179,179);stop-opacity:0"
-         id="stop3731" />
+    <linearGradient id="linearGradient5443" x1="181.21001" x2="167.61" y1="1121.5" y2="1121.2" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4825"/>
+    <linearGradient id="linearGradient5445" x1="182.61" x2="168.64" y1="1121.1" y2="1121" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4825"/>
+    <linearGradient id="linearGradient5447" x1="181.95" x2="168.75999" y1="1121" y2="1121.2" gradientUnits="userSpaceOnUse" xlink:href="#linearGradient4825"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4860" id="linearGradient26937" gradientUnits="userSpaceOnUse" x1="192.32001" y1="1117.4" x2="150.00999" y2="1116.9"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4944" id="linearGradient26939" gradientUnits="userSpaceOnUse" x1="21.709" y1="143.46001" x2="19.665001" y2="146.67"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4960" id="linearGradient26941" gradientUnits="userSpaceOnUse" x1="164.89999" y1="1109.6" x2="160.75999" y2="1100.2"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4936" id="linearGradient26943" gradientUnits="userSpaceOnUse" x1="20" y1="140.49001" x2="15.323" y2="142.89"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4825" id="linearGradient26945" gradientUnits="userSpaceOnUse" x1="181.62" y1="1121.1" x2="167.97" y2="1121.4"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4952" id="linearGradient26947" gradientUnits="userSpaceOnUse" x1="21.809999" y1="137.22" x2="14.605" y2="134.38"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4825" id="linearGradient26949" gradientUnits="userSpaceOnUse" x1="181.21001" y1="1121.5" x2="167.61" y2="1121.2"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4825" id="linearGradient26951" gradientUnits="userSpaceOnUse" x1="182.61" y1="1121.1" x2="168.64" y2="1121"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4825" id="linearGradient26953" gradientUnits="userSpaceOnUse" x1="181.95" y1="1121" x2="168.75999" y2="1121.2"/>
+    <linearGradient id="_Linear2" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-32.0767,55.0677,-55.0677,-32.0767,331.057,1041.3)">
+      <stop offset="0" style="stop-color:white;stop-opacity:0.37" id="stop3729"/>
+      <stop offset="1" style="stop-color:rgb(179,179,179);stop-opacity:0" id="stop3731"/>
     </linearGradient>
-    <clipPath
-       id="_clip1">
-      <rect
-         x="0"
-         y="0"
-         width="2902.8"
-         height="2085.3"
-         id="rect2532" />
+    <clipPath id="_clip1">
+      <rect x="0" y="0" width="2902.8" height="2085.3" id="rect2532"/>
     </clipPath>
-    <linearGradient
-       id="_Linear1"
-       x1="0"
-       y1="0"
-       x2="1"
-       y2="0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-32.0767,55.0677,-55.0677,-32.0767,331.057,1041.3)">
-      <stop
-         offset="0"
-         style="stop-color:white;stop-opacity:0.37"
-         id="stop7187" />
-      <stop
-         offset="1"
-         style="stop-color:rgb(179,179,179);stop-opacity:0"
-         id="stop7189" />
+    <linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-32.0767,55.0677,-55.0677,-32.0767,331.057,1041.3)">
+      <stop offset="0" style="stop-color:white;stop-opacity:0.37" id="stop7187"/>
+      <stop offset="1" style="stop-color:rgb(179,179,179);stop-opacity:0" id="stop7189"/>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4860"
-       id="linearGradient24358"
-       gradientUnits="userSpaceOnUse"
-       x1="192.32001"
-       y1="1117.4"
-       x2="150.00999"
-       y2="1116.9" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4944"
-       id="linearGradient24360"
-       gradientUnits="userSpaceOnUse"
-       x1="21.709"
-       y1="143.46001"
-       x2="19.665001"
-       y2="146.67" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4960"
-       id="linearGradient24362"
-       gradientUnits="userSpaceOnUse"
-       x1="164.89999"
-       y1="1109.6"
-       x2="160.75999"
-       y2="1100.2" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4936"
-       id="linearGradient24364"
-       gradientUnits="userSpaceOnUse"
-       x1="20"
-       y1="140.49001"
-       x2="15.323"
-       y2="142.89" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4825"
-       id="linearGradient24366"
-       gradientUnits="userSpaceOnUse"
-       x1="181.62"
-       y1="1121.1"
-       x2="167.97"
-       y2="1121.4" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4952"
-       id="linearGradient24368"
-       gradientUnits="userSpaceOnUse"
-       x1="21.809999"
-       y1="137.22"
-       x2="14.605"
-       y2="134.38" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4825"
-       id="linearGradient24370"
-       gradientUnits="userSpaceOnUse"
-       x1="181.21001"
-       y1="1121.5"
-       x2="167.61"
-       y2="1121.2" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4825"
-       id="linearGradient24372"
-       gradientUnits="userSpaceOnUse"
-       x1="182.61"
-       y1="1121.1"
-       x2="168.64"
-       y2="1121" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4825"
-       id="linearGradient24374"
-       gradientUnits="userSpaceOnUse"
-       x1="181.95"
-       y1="1121"
-       x2="168.75999"
-       y2="1121.2" />
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4860" id="linearGradient24358" gradientUnits="userSpaceOnUse" x1="192.32001" y1="1117.4" x2="150.00999" y2="1116.9"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4944" id="linearGradient24360" gradientUnits="userSpaceOnUse" x1="21.709" y1="143.46001" x2="19.665001" y2="146.67"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4960" id="linearGradient24362" gradientUnits="userSpaceOnUse" x1="164.89999" y1="1109.6" x2="160.75999" y2="1100.2"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4936" id="linearGradient24364" gradientUnits="userSpaceOnUse" x1="20" y1="140.49001" x2="15.323" y2="142.89"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4825" id="linearGradient24366" gradientUnits="userSpaceOnUse" x1="181.62" y1="1121.1" x2="167.97" y2="1121.4"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4952" id="linearGradient24368" gradientUnits="userSpaceOnUse" x1="21.809999" y1="137.22" x2="14.605" y2="134.38"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4825" id="linearGradient24370" gradientUnits="userSpaceOnUse" x1="181.21001" y1="1121.5" x2="167.61" y2="1121.2"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4825" id="linearGradient24372" gradientUnits="userSpaceOnUse" x1="182.61" y1="1121.1" x2="168.64" y2="1121"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4825" id="linearGradient24374" gradientUnits="userSpaceOnUse" x1="181.95" y1="1121" x2="168.75999" y2="1121.2"/>
   </defs>
-  <metadata
-     id="metadata4056">
+  <metadata id="metadata4056">
     <rdf:RDF>
-      <cc:Work
-         rdf:about="">
+      <cc:Work rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     transform="translate(0.06997247,2576.07)"
-     opacity="0.999"
-     id="g7551">
-    <rect
-       x="2494.5"
-       y="-761.81"
-       width="226.77"
-       height="226.77"
-       fill="none"
-       opacity="1"
-       id="rect4058" />
-    <g
-       fill="#ffffff"
-       id="g4066">
-      <path
-         d="m 2690.8,-565.75 c 0,9.1358 -7.6127,16.535 -17.012,16.535 h -131.84 c -9.3991,0 -17.012,-7.3996 -17.012,-16.535 V -706.3 c 0,-9.1358 7.6129,-16.535 17.012,-16.535 h 34.662 c 2.9303,-14.138 15.821,-24.803 31.259,-24.803 15.438,0 28.325,10.665 31.259,24.803 h 34.662 c 9.3991,0 17.012,7.3996 17.012,16.535 z m -30.622,-136.42 h -20.414 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.082 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.414 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.09 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.62 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.09 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.469 c 0,-5.7046 -4.7633,-10.335 -10.632,-10.335 -5.8692,0 -10.632,4.63 -10.632,10.335 0,5.7048 4.7633,10.335 10.632,10.335 5.8691,0 10.632,-4.6299 10.632,-10.335 z"
-         opacity="1"
-         id="path4060" />
-      <path
-         d="m 2592.2,-645.64 c -2.7369,-3.47 -5.1317,-5.1806 -11.07,-5.7647 -1.0753,-0.1954 -1.8572,-1.1241 -1.8572,-2.2237 0,-0.8064 2.6391,-3.2257 2.6122,-3.2502 2.7394,-2.7612 4.2055,-7.233 4.2055,-10.679 0,-5.3492 -4.7382,-9.7746 -10.996,-9.7746 -6.378,0 -10.996,4.4254 -10.996,9.7746 0,3.47 1.4418,7.9663 4.1787,10.73 0,0 2.6391,2.3924 2.6391,3.2013 0,1.1484 -0.8797,2.126 -2.0527,2.2725 -5.8183,0.5865 -8.1643,2.297 -10.874,5.7182 -0.76,1.0019 -1.1973,2.9812 -1.2218,4.0321 v 4.5892 c 0,2.0282 1.6837,3.6654 3.7633,3.6654 h 29.128 c 2.0796,0 3.7632,-1.6372 3.7632,-3.6654 v -4.5941 c -0.024,-1.0534 -0.4423,-3.0302 -1.2218,-4.032 z m 61.262,-26.807 h -44.156 c -3.3722,0 -6.1092,2.737 -6.1092,6.1092 0,3.3723 2.737,6.1092 6.1092,6.1092 h 44.156 c 3.3723,0 6.1091,-2.7369 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1092 -6.1091,-6.1092 z m 0,21.993 h -44.156 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1091 0,3.3724 2.737,6.1092 6.1092,6.1092 h 44.156 c 3.3723,0 6.1091,-2.7368 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1091 -6.1091,-6.1091 z"
-         opacity="1"
-         id="path4062" />
-      <path
-         d="m 2592.2,-598.4 c -2.7369,-3.47 -5.1317,-5.1806 -11.07,-5.7647 -1.0753,-0.1954 -1.8572,-1.1241 -1.8572,-2.2237 0,-0.8064 2.6391,-3.2256 2.6122,-3.2501 2.7394,-2.7613 4.2055,-7.2331 4.2055,-10.679 0,-5.3492 -4.7382,-9.7746 -10.996,-9.7746 -6.378,0 -10.996,4.4254 -10.996,9.7746 0,3.47 1.4418,7.9663 4.1787,10.73 0,0 2.6391,2.3924 2.6391,3.2013 0,1.1485 -0.8797,2.126 -2.0527,2.2725 -5.8183,0.5865 -8.1643,2.297 -10.874,5.7182 -0.76,1.0019 -1.1973,2.9813 -1.2218,4.0321 v 4.5892 c 0,2.0282 1.6837,3.6655 3.7633,3.6655 h 29.128 c 2.0796,0 3.7632,-1.6373 3.7632,-3.6655 v -4.5941 c -0.024,-1.0534 -0.4423,-3.0302 -1.2218,-4.032 z m 61.262,-26.807 h -44.156 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1091 0,3.3723 2.737,6.1092 6.1092,6.1092 h 44.156 c 3.3723,0 6.1091,-2.7369 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1091 -6.1091,-6.1091 z m 0,21.993 h -44.156 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1092 0,3.3723 2.737,6.1091 6.1092,6.1091 h 44.156 c 3.3723,0 6.1091,-2.7368 6.1091,-6.1091 0,-3.3723 -2.7368,-6.1092 -6.1091,-6.1092 z"
-         opacity="1"
-         id="path4064" />
+  <g transform="translate(0.06997247,2576.07)" opacity="0.999" id="g7551">
+    <rect x="2494.5" y="-761.81" width="226.77" height="226.77" fill="none" opacity="1" id="rect4058"/>
+    <g fill="#ffffff" id="g4066">
+      <path d="m 2690.8,-565.75 c 0,9.1358 -7.6127,16.535 -17.012,16.535 h -131.84 c -9.3991,0 -17.012,-7.3996 -17.012,-16.535 V -706.3 c 0,-9.1358 7.6129,-16.535 17.012,-16.535 h 34.662 c 2.9303,-14.138 15.821,-24.803 31.259,-24.803 15.438,0 28.325,10.665 31.259,24.803 h 34.662 c 9.3991,0 17.012,7.3996 17.012,16.535 z m -30.622,-136.42 h -20.414 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.082 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.414 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.09 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.62 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.09 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.469 c 0,-5.7046 -4.7633,-10.335 -10.632,-10.335 -5.8692,0 -10.632,4.63 -10.632,10.335 0,5.7048 4.7633,10.335 10.632,10.335 5.8691,0 10.632,-4.6299 10.632,-10.335 z" opacity="1" id="path4060"/>
+      <path d="m 2592.2,-645.64 c -2.7369,-3.47 -5.1317,-5.1806 -11.07,-5.7647 -1.0753,-0.1954 -1.8572,-1.1241 -1.8572,-2.2237 0,-0.8064 2.6391,-3.2257 2.6122,-3.2502 2.7394,-2.7612 4.2055,-7.233 4.2055,-10.679 0,-5.3492 -4.7382,-9.7746 -10.996,-9.7746 -6.378,0 -10.996,4.4254 -10.996,9.7746 0,3.47 1.4418,7.9663 4.1787,10.73 0,0 2.6391,2.3924 2.6391,3.2013 0,1.1484 -0.8797,2.126 -2.0527,2.2725 -5.8183,0.5865 -8.1643,2.297 -10.874,5.7182 -0.76,1.0019 -1.1973,2.9812 -1.2218,4.0321 v 4.5892 c 0,2.0282 1.6837,3.6654 3.7633,3.6654 h 29.128 c 2.0796,0 3.7632,-1.6372 3.7632,-3.6654 v -4.5941 c -0.024,-1.0534 -0.4423,-3.0302 -1.2218,-4.032 z m 61.262,-26.807 h -44.156 c -3.3722,0 -6.1092,2.737 -6.1092,6.1092 0,3.3723 2.737,6.1092 6.1092,6.1092 h 44.156 c 3.3723,0 6.1091,-2.7369 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1092 -6.1091,-6.1092 z m 0,21.993 h -44.156 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1091 0,3.3724 2.737,6.1092 6.1092,6.1092 h 44.156 c 3.3723,0 6.1091,-2.7368 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1091 -6.1091,-6.1091 z" opacity="1" id="path4062"/>
+      <path d="m 2592.2,-598.4 c -2.7369,-3.47 -5.1317,-5.1806 -11.07,-5.7647 -1.0753,-0.1954 -1.8572,-1.1241 -1.8572,-2.2237 0,-0.8064 2.6391,-3.2256 2.6122,-3.2501 2.7394,-2.7613 4.2055,-7.2331 4.2055,-10.679 0,-5.3492 -4.7382,-9.7746 -10.996,-9.7746 -6.378,0 -10.996,4.4254 -10.996,9.7746 0,3.47 1.4418,7.9663 4.1787,10.73 0,0 2.6391,2.3924 2.6391,3.2013 0,1.1485 -0.8797,2.126 -2.0527,2.2725 -5.8183,0.5865 -8.1643,2.297 -10.874,5.7182 -0.76,1.0019 -1.1973,2.9813 -1.2218,4.0321 v 4.5892 c 0,2.0282 1.6837,3.6655 3.7633,3.6655 h 29.128 c 2.0796,0 3.7632,-1.6373 3.7632,-3.6655 v -4.5941 c -0.024,-1.0534 -0.4423,-3.0302 -1.2218,-4.032 z m 61.262,-26.807 h -44.156 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1091 0,3.3723 2.737,6.1092 6.1092,6.1092 h 44.156 c 3.3723,0 6.1091,-2.7369 6.1091,-6.1092 0,-3.3722 -2.7368,-6.1091 -6.1091,-6.1091 z m 0,21.993 h -44.156 c -3.3722,0 -6.1092,2.7369 -6.1092,6.1092 0,3.3723 2.737,6.1091 6.1092,6.1091 h 44.156 c 3.3723,0 6.1091,-2.7368 6.1091,-6.1091 0,-3.3723 -2.7368,-6.1092 -6.1091,-6.1092 z" opacity="1" id="path4064"/>
     </g>
-    <g
-       transform="translate(681.69,1812.1)"
-       id="g4074">
-      <g
-         transform="matrix(4.1373,0,0,4.1339,-114.76,-1021.3)"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="2"
-         id="g4070">
-        <path
-           d="m 0,-38 c 5.8,0 10.5,4.7 10.5,10.5 0,5.8 -4.7,10.5 -10.5,10.5 -5.8,0 -10.5,-4.7 -10.5,-10.5 0,-5.8 4.7,-10.5 10.5,-10.5 m -15.5,10.22 c 0,10.2 12.03,18.05 13,29.78 V 2.5 C -2.5,3.88 -1.38,5 0,5 1.38,5 2.5,3.88 2.5,2.5 V 2 c 1.03,-11.73 13,-19.58 13,-29.78 C 15.5,-36.19 8.56,-43 0,-43 c -8.56,0 -15.5,6.81 -15.5,15.22 M 0,-34 c -3.59,0 -6.5,2.91 -6.5,6.5 0,3.59 2.91,6.5 6.5,6.5 3.59,0 6.5,-2.91 6.5,-6.5 C 6.5,-31.09 3.59,-34 0,-34 m -2.5,6.5 c 0,-1.38 1.12,-2.5 2.5,-2.5 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5"
-           fill="#ffffff"
-           id="path4068" />
+    <g transform="translate(681.69,1812.1)" id="g4074">
+      <g transform="matrix(4.1373,0,0,4.1339,-114.76,-1021.3)" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" id="g4070">
+        <path d="m 0,-38 c 5.8,0 10.5,4.7 10.5,10.5 0,5.8 -4.7,10.5 -10.5,10.5 -5.8,0 -10.5,-4.7 -10.5,-10.5 0,-5.8 4.7,-10.5 10.5,-10.5 m -15.5,10.22 c 0,10.2 12.03,18.05 13,29.78 V 2.5 C -2.5,3.88 -1.38,5 0,5 1.38,5 2.5,3.88 2.5,2.5 V 2 c 1.03,-11.73 13,-19.58 13,-29.78 C 15.5,-36.19 8.56,-43 0,-43 c -8.56,0 -15.5,6.81 -15.5,15.22 M 0,-34 c -3.59,0 -6.5,2.91 -6.5,6.5 0,3.59 2.91,6.5 6.5,6.5 3.59,0 6.5,-2.91 6.5,-6.5 C 6.5,-31.09 3.59,-34 0,-34 m -2.5,6.5 c 0,-1.38 1.12,-2.5 2.5,-2.5 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5" fill="#ffffff" id="path4068"/>
       </g>
-      <rect
-         x="-228.14"
-         y="-1213.3"
-         width="226.77"
-         height="226.77"
-         ry="10.042"
-         fill="none"
-         id="rect4072"
-         rx="10.042" />
+      <rect x="-228.14" y="-1213.3" width="226.77" height="226.77" ry="10.042" fill="none" id="rect4072" rx="10.042"/>
     </g>
-    <g
-       transform="translate(-1360.6,2040.9)"
-       id="g4080">
-      <rect
-         x="2040.9"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4076" />
-      <path
-         d="m 2137.8,-2522.4 c -11.864,-11.229 -39.52,-15.744 -55.104,0.3997 -15.254,15.744 -27.573,53.707 -27.573,89.511 0,43.197 37.453,49.191 57.874,27.972 11.823,-12.308 12.939,-14.226 20.669,-23.976 h 41.338 c 7.7717,9.7503 8.8463,11.668 20.669,23.976 20.417,21.219 57.874,15.225 57.874,-27.972 0,-35.805 -12.319,-73.767 -27.573,-89.511 -15.585,-16.144 -43.199,-11.628 -55.104,-0.3997 -4.5887,4.3157 -16.535,5.9941 -16.535,5.9941 0,0 -11.947,-1.6784 -16.535,-5.9941 z m -16.535,26.374 v 11.588 h 11.988 c 4.7953,0 8.6812,3.5964 8.6812,7.9921 0,4.3956 -3.8859,7.9921 -8.6812,7.9921 h -11.988 v 11.588 c 0,4.6355 -3.7205,8.3917 -8.2677,8.3917 -4.5473,0 -8.2678,-3.7562 -8.2678,-8.3917 v -11.588 h -11.988 c -4.7953,0 -8.6812,-3.5965 -8.6812,-7.9921 0,-4.3957 3.8859,-7.9921 8.6812,-7.9921 h 11.988 v -11.588 c 0,-4.6354 3.7205,-8.3917 8.2678,-8.3917 4.5472,0 8.2677,3.7563 8.2677,8.3917 z m 74.409,5.5945 c 0,-5.5145 4.6299,-9.9901 10.335,-9.9901 5.7046,0 10.335,4.4756 10.335,9.9901 0,5.5145 -4.63,9.9901 -10.335,9.9901 -5.7048,0 -10.335,-4.4756 -10.335,-9.9901 z m -20.669,23.976 c 0,-5.5146 4.6299,-9.9901 10.335,-9.9901 5.7047,0 10.335,4.4755 10.335,9.9901 0,5.5145 -4.6299,9.9901 -10.335,9.9901 -5.7048,0 -10.335,-4.4756 -10.335,-9.9901 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4078" />
+    <g transform="translate(-1360.6,2040.9)" id="g4080">
+      <rect x="2040.9" y="-2575.8999" width="226.77" height="226.77" fill="none" opacity="1" id="rect4076"/>
+      <path d="m 2137.8,-2522.4 c -11.864,-11.229 -39.52,-15.744 -55.104,0.3997 -15.254,15.744 -27.573,53.707 -27.573,89.511 0,43.197 37.453,49.191 57.874,27.972 11.823,-12.308 12.939,-14.226 20.669,-23.976 h 41.338 c 7.7717,9.7503 8.8463,11.668 20.669,23.976 20.417,21.219 57.874,15.225 57.874,-27.972 0,-35.805 -12.319,-73.767 -27.573,-89.511 -15.585,-16.144 -43.199,-11.628 -55.104,-0.3997 -4.5887,4.3157 -16.535,5.9941 -16.535,5.9941 0,0 -11.947,-1.6784 -16.535,-5.9941 z m -16.535,26.374 v 11.588 h 11.988 c 4.7953,0 8.6812,3.5964 8.6812,7.9921 0,4.3956 -3.8859,7.9921 -8.6812,7.9921 h -11.988 v 11.588 c 0,4.6355 -3.7205,8.3917 -8.2677,8.3917 -4.5473,0 -8.2678,-3.7562 -8.2678,-8.3917 v -11.588 h -11.988 c -4.7953,0 -8.6812,-3.5965 -8.6812,-7.9921 0,-4.3957 3.8859,-7.9921 8.6812,-7.9921 h 11.988 v -11.588 c 0,-4.6354 3.7205,-8.3917 8.2678,-8.3917 4.5472,0 8.2677,3.7563 8.2677,8.3917 z m 74.409,5.5945 c 0,-5.5145 4.6299,-9.9901 10.335,-9.9901 5.7046,0 10.335,4.4756 10.335,9.9901 0,5.5145 -4.63,9.9901 -10.335,9.9901 -5.7048,0 -10.335,-4.4756 -10.335,-9.9901 z m -20.669,23.976 c 0,-5.5146 4.6299,-9.9901 10.335,-9.9901 5.7047,0 10.335,4.4755 10.335,9.9901 0,5.5145 -4.6299,9.9901 -10.335,9.9901 -5.7048,0 -10.335,-4.4756 -10.335,-9.9901 z" fill="#ffffff" opacity="1" id="path4078"/>
     </g>
-    <g
-       transform="translate(0.035449,1814.1)"
-       id="g4086">
-      <rect
-         x="2267.7"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4082" />
-      <path
-         d="m 2303.8,-2418.8 c 12.314,-15.668 28.195,-23.77 55.031,-26.374 4.8407,-0.9467 8.4926,-5.1262 8.4926,-10.087 0,-3.6337 -11.974,-14.51 -11.89,-14.589 -12.357,-12.443 -18.981,-32.658 -18.981,-48.202 0,-24.142 19.958,-43.737 44.586,-43.737 24.628,0 44.586,19.595 44.586,43.737 0,15.626 -6.4543,35.965 -18.938,48.408 0,0 -11.932,10.752 -11.932,14.382 0,5.2543 4.0762,9.6321 9.3417,10.252 26.284,2.6871 41.996,10.748 54.182,26.209 3.5243,4.4647 5.4351,13.435 5.5625,18.231 -0.042,1.2402 0,20.67 0,20.67 0,9.1359 -7.601,16.536 -16.985,16.536 h -131.63 c -9.3842,0 -16.985,-7.3998 -16.985,-16.536 0,0 0.042,-19.43 0,-20.67 0.1274,-4.7954 2.0382,-13.766 5.5626,-18.231 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4084" />
+    <g transform="translate(0.035449,1814.1)" id="g4086">
+      <rect x="2267.7" y="-2575.8999" width="226.77" height="226.77" fill="none" opacity="1" id="rect4082"/>
+      <path d="m 2303.8,-2418.8 c 12.314,-15.668 28.195,-23.77 55.031,-26.374 4.8407,-0.9467 8.4926,-5.1262 8.4926,-10.087 0,-3.6337 -11.974,-14.51 -11.89,-14.589 -12.357,-12.443 -18.981,-32.658 -18.981,-48.202 0,-24.142 19.958,-43.737 44.586,-43.737 24.628,0 44.586,19.595 44.586,43.737 0,15.626 -6.4543,35.965 -18.938,48.408 0,0 -11.932,10.752 -11.932,14.382 0,5.2543 4.0762,9.6321 9.3417,10.252 26.284,2.6871 41.996,10.748 54.182,26.209 3.5243,4.4647 5.4351,13.435 5.5625,18.231 -0.042,1.2402 0,20.67 0,20.67 0,9.1359 -7.601,16.536 -16.985,16.536 h -131.63 c -9.3842,0 -16.985,-7.3998 -16.985,-16.536 0,0 0.042,-19.43 0,-20.67 0.1274,-4.7954 2.0382,-13.766 5.5626,-18.231 z" fill="#ffffff" opacity="1" id="path4084"/>
     </g>
-    <g
-       transform="translate(907.09,680.31)"
-       id="g4092">
-      <rect
-         x="2494.5"
-         y="-2576"
-         width="226.23"
-         height="227.32001"
-         fill="none"
-         opacity="1"
-         id="rect4088" />
-      <path
-         d="m 2640.7,-2383.8 v -90.944 h 6.2006 c 3.431,0 6.2007,2.7697 6.2007,6.2007 v 57.873 c 0,14.84 12.029,26.87 26.869,26.87 14.84,0 26.869,-12.029 26.869,-26.87 v -111.28 c 0,-5.8286 -2.3975,-11.079 -6.2419,-14.84 l -21.913,-21.785 c -3.9643,-3.9727 -10.376,-3.9727 -14.344,0 -3.9684,3.9684 -3.9684,10.376 0,14.34 l 14.22,14.262 -10.5,10.954 c -3.431,3.5137 -3.431,9.1771 0,12.691 1.6907,1.8147 3.9685,2.6828 6.2421,2.6456 l 11.864,-0.042 v 93.056 c 0,3.4311 -2.7696,6.2007 -6.2006,6.2007 -3.431,0 -6.2007,-2.7696 -6.2007,-6.2007 v -57.873 c 0,-14.84 -12.029,-26.87 -26.869,-26.87 h -6.2007 v -49.606 c 0,-9.1357 -7.3993,-16.535 -16.535,-16.535 h -86.809 c -9.1357,0 -16.535,7.3996 -16.535,16.535 v 161.22 h -2.0628 c -5.7045,0 -10.334,4.6299 -10.334,10.335 0,5.7046 4.6299,10.334 10.334,10.334 h 124.01 c 5.7046,0 10.334,-4.6299 10.334,-10.334 0,-5.7047 -4.6299,-10.335 -10.334,-10.335 h -2.0668 z m -90.116,-157.08 h 60.353 c 5.0433,0 9.0943,4.0511 9.0943,9.0944 v 43.818 c 0,5.0433 -4.051,9.0944 -9.0943,9.0944 h -60.353 c -5.0432,0 -9.0943,-4.0511 -9.0943,-9.0944 v -43.818 c 0,-5.0433 4.0511,-9.0944 9.0943,-9.0944 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4090" />
+    <g transform="translate(907.09,680.31)" id="g4092">
+      <rect x="2494.5" y="-2576" width="226.23" height="227.32001" fill="none" opacity="1" id="rect4088"/>
+      <path d="m 2640.7,-2383.8 v -90.944 h 6.2006 c 3.431,0 6.2007,2.7697 6.2007,6.2007 v 57.873 c 0,14.84 12.029,26.87 26.869,26.87 14.84,0 26.869,-12.029 26.869,-26.87 v -111.28 c 0,-5.8286 -2.3975,-11.079 -6.2419,-14.84 l -21.913,-21.785 c -3.9643,-3.9727 -10.376,-3.9727 -14.344,0 -3.9684,3.9684 -3.9684,10.376 0,14.34 l 14.22,14.262 -10.5,10.954 c -3.431,3.5137 -3.431,9.1771 0,12.691 1.6907,1.8147 3.9685,2.6828 6.2421,2.6456 l 11.864,-0.042 v 93.056 c 0,3.4311 -2.7696,6.2007 -6.2006,6.2007 -3.431,0 -6.2007,-2.7696 -6.2007,-6.2007 v -57.873 c 0,-14.84 -12.029,-26.87 -26.869,-26.87 h -6.2007 v -49.606 c 0,-9.1357 -7.3993,-16.535 -16.535,-16.535 h -86.809 c -9.1357,0 -16.535,7.3996 -16.535,16.535 v 161.22 h -2.0628 c -5.7045,0 -10.334,4.6299 -10.334,10.335 0,5.7046 4.6299,10.334 10.334,10.334 h 124.01 c 5.7046,0 10.334,-4.6299 10.334,-10.334 0,-5.7047 -4.6299,-10.335 -10.334,-10.335 h -2.0668 z m -90.116,-157.08 h 60.353 c 5.0433,0 9.0943,4.0511 9.0943,9.0944 v 43.818 c 0,5.0433 -4.051,9.0944 -9.0943,9.0944 h -60.353 c -5.0432,0 -9.0943,-4.0511 -9.0943,-9.0944 v -43.818 c 0,-5.0433 4.0511,-9.0944 9.0943,-9.0944 z" fill="#ffffff" opacity="1" id="path4090"/>
     </g>
-    <g
-       transform="translate(2494.5,1814.2)"
-       id="g4549">
-      <rect
-         x="226.77"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4543" />
-      <path
-         transform="matrix(0.18963,0,0,0.18963,12.013,-2318.9)"
-         d="m 1335.9,-1152.3 c -58.5,58.5 -37.62,182.16 42.12,320.76 -5.041,23.76 -7.56,48.42 -7.56,73.8 0,198.9 161.1,360 360,360 25.38,0 50.022,-2.52 73.8,-7.56 138.6,79.74 262.26,100.62 320.76,42.12 58.5,-58.5 37.62,-182.16 -42.12,-320.76 5.022,-23.76 7.56,-48.42 7.56,-73.8 0,-198.9 -161.1,-360 -360,-360 -25.38,0 -50.04,2.52 -73.8,7.56 -138.6,-79.74 -262.26,-100.62 -320.76,-42.12 z m 717.84,729.18 c -217.62,69.66 -765.38,-553.32 -653.76,-665.1 25.921,-25.74 80.641,-14.58 148.5,19.8 -30.06,17.64 -57.06,39.42 -80.621,64.62 75.96,190.44 320.94,433.62 511.9,505.8 24.66,-23.58 45.918,-50.76 63,-80.64 28.44,61.74 35.64,116.64 10.98,155.52 z"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         filter="url(#filter4188)"
-         id="path4545" />
-      <rect
-         x="226.77"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4547" />
+    <g transform="translate(2494.5,1814.2)" id="g4549">
+      <rect x="226.77" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect4543"/>
+      <path transform="matrix(0.18963,0,0,0.18963,12.013,-2318.9)" d="m 1335.9,-1152.3 c -58.5,58.5 -37.62,182.16 42.12,320.76 -5.041,23.76 -7.56,48.42 -7.56,73.8 0,198.9 161.1,360 360,360 25.38,0 50.022,-2.52 73.8,-7.56 138.6,79.74 262.26,100.62 320.76,42.12 58.5,-58.5 37.62,-182.16 -42.12,-320.76 5.022,-23.76 7.56,-48.42 7.56,-73.8 0,-198.9 -161.1,-360 -360,-360 -25.38,0 -50.04,2.52 -73.8,7.56 -138.6,-79.74 -262.26,-100.62 -320.76,-42.12 z m 717.84,729.18 c -217.62,69.66 -765.38,-553.32 -653.76,-665.1 25.921,-25.74 80.641,-14.58 148.5,19.8 -30.06,17.64 -57.06,39.42 -80.621,64.62 75.96,190.44 320.94,433.62 511.9,505.8 24.66,-23.58 45.918,-50.76 63,-80.64 28.44,61.74 35.64,116.64 10.98,155.52 z" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" filter="url(#filter4188)" id="path4545"/>
+      <rect x="226.77" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect4547"/>
     </g>
-    <g
-       transform="translate(2.6509e-5,1814.2)"
-       id="g4555">
-      <rect
-         x="680.31"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4551" />
-      <path
-         d="m 694.49,-2379.9 c 0,9.1358 7.3996,16.536 16.535,16.536 h 165.35 c 9.1358,0 16.535,-7.3997 16.535,-16.536 v -45.472 c 0,-9.1359 -7.3996,-16.535 -16.535,-16.535 h -49.606 v -43.406 c 0,-5.7048 -4.6299,-10.335 -10.335,-10.335 -5.7051,0 -10.335,4.6299 -10.335,10.335 v 43.406 H 711.02 c -9.1358,0 -16.535,7.3995 -16.535,16.535 z m 20.669,-22.736 c 0,-5.7047 4.6299,-10.335 10.335,-10.335 5.7047,0 10.335,4.6299 10.335,10.335 0,5.7051 -4.6299,10.335 -10.335,10.335 -5.7047,0 -10.335,-4.63 -10.335,-10.335 z m 37.205,0 c 0,-5.7047 4.6299,-10.335 10.335,-10.335 5.7051,0 10.335,4.6299 10.335,10.335 0,5.7051 -4.6299,10.335 -10.335,10.335 -5.7051,0 -10.335,-4.63 -10.335,-10.335 z m 64.075,-126.08 c -23.976,0 -43.406,19.429 -43.406,43.406 0,5.7048 4.6299,10.335 10.335,10.335 5.7051,0 10.335,-4.6299 10.335,-10.335 0,-12.567 10.169,-22.736 22.736,-22.736 12.567,0 22.736,10.169 22.736,22.736 0,5.7048 4.6299,10.335 10.335,10.335 5.7051,0 10.335,-4.6299 10.335,-10.335 0,-23.976 -19.429,-43.406 -43.405,-43.406 z m 0,-33.071 c -42.248,0 -76.476,34.228 -76.476,76.476 0,5.7048 4.6299,10.335 10.335,10.335 5.7051,0 10.335,-4.6299 10.335,-10.335 0,-30.839 24.968,-55.807 55.807,-55.807 30.838,0 55.807,24.968 55.807,55.807 0,5.7048 4.6299,10.335 10.335,10.335 5.7051,0 10.335,-4.6299 10.335,-10.335 0,-42.248 -34.229,-76.476 -76.476,-76.476 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4553" />
+    <g transform="translate(2.6509e-5,1814.2)" id="g4555">
+      <rect x="680.31" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect4551"/>
+      <path d="m 694.49,-2379.9 c 0,9.1358 7.3996,16.536 16.535,16.536 h 165.35 c 9.1358,0 16.535,-7.3997 16.535,-16.536 v -45.472 c 0,-9.1359 -7.3996,-16.535 -16.535,-16.535 h -49.606 v -43.406 c 0,-5.7048 -4.6299,-10.335 -10.335,-10.335 -5.7051,0 -10.335,4.6299 -10.335,10.335 v 43.406 H 711.02 c -9.1358,0 -16.535,7.3995 -16.535,16.535 z m 20.669,-22.736 c 0,-5.7047 4.6299,-10.335 10.335,-10.335 5.7047,0 10.335,4.6299 10.335,10.335 0,5.7051 -4.6299,10.335 -10.335,10.335 -5.7047,0 -10.335,-4.63 -10.335,-10.335 z m 37.205,0 c 0,-5.7047 4.6299,-10.335 10.335,-10.335 5.7051,0 10.335,4.6299 10.335,10.335 0,5.7051 -4.6299,10.335 -10.335,10.335 -5.7051,0 -10.335,-4.63 -10.335,-10.335 z m 64.075,-126.08 c -23.976,0 -43.406,19.429 -43.406,43.406 0,5.7048 4.6299,10.335 10.335,10.335 5.7051,0 10.335,-4.6299 10.335,-10.335 0,-12.567 10.169,-22.736 22.736,-22.736 12.567,0 22.736,10.169 22.736,22.736 0,5.7048 4.6299,10.335 10.335,10.335 5.7051,0 10.335,-4.6299 10.335,-10.335 0,-23.976 -19.429,-43.406 -43.405,-43.406 z m 0,-33.071 c -42.248,0 -76.476,34.228 -76.476,76.476 0,5.7048 4.6299,10.335 10.335,10.335 5.7051,0 10.335,-4.6299 10.335,-10.335 0,-30.839 24.968,-55.807 55.807,-55.807 30.838,0 55.807,24.968 55.807,55.807 0,5.7048 4.6299,10.335 10.335,10.335 5.7051,0 10.335,-4.6299 10.335,-10.335 0,-42.248 -34.229,-76.476 -76.476,-76.476 z" fill="#ffffff" opacity="1" id="path4553"/>
     </g>
-    <g
-       transform="translate(-907.09,2040.9)"
-       id="g4561">
-      <path
-         d="m 1115.1,-2486.1 c -7.6614,-2.8509 -9.6342,6.6906 -11.986,11.642 -3.7889,7.335 -8.9679,14.191 -15.365,19.45 -7.2842,5.8875 -15.535,10.788 -24.746,12.958 23.06,-23.086 26.588,-55.592 14.756,-85.018 -4.3449,-10.797 -11.662,-20.637 -20.405,-28.263 -3.9632,-3.4644 -10.705,-3.8505 -12.298,2.465 -1.218,4.8237 3.8639,8.9832 6.364,12.604 9.4358,14.701 13.103,33.987 8.0124,50.936 -8.2463,-30.73 -33.943,-50.424 -64.688,-55.065 -11.444,-1.4233 -23.492,-1.0283 -34.503,2.7209 -4.6781,1.6042 -10.175,4.8767 -7.0348,10.793 2.7716,5.2143 8.2419,3.0694 12.801,2.6877 18.311,-1.4719 37.902,4.7134 50.694,18.322 -31.522,-8.4404 -61.458,4.7973 -81.007,29.735 -7.187,9.1688 -12.017,20.412 -14.275,31.802 -1.0172,5.157 2.0191,11.194 8.2838,9.4202 4.7863,-1.3549 5.8499,-7.8424 7.7344,-11.815 7.997,-15.497 22.894,-28.351 40.106,-32.407 -23.073,23.068 -26.582,55.606 -14.754,85.023 4.3382,10.786 11.658,20.65 20.407,28.261 3.9608,3.46 10.704,3.8484 12.298,-2.4649 1.2224,-4.8281 -3.8661,-8.9789 -6.3596,-12.609 -9.4335,-14.685 -13.123,-33.996 -8.0168,-50.934 8.2397,30.73 33.945,50.424 64.688,55.067 11.444,1.421 23.492,1.0282 34.501,-2.7231 4.676,-1.5975 10.177,-4.8767 7.0327,-10.791 -2.7672,-5.212 -8.2354,-3.0672 -12.796,-2.6898 -18.326,1.4696 -37.882,-4.7158 -50.694,-18.32 20.067,5.3711 40.777,2.1846 58.234,-8.7561 8.8752,-5.565 16.329,-12.761 22.773,-20.983 4.3427,-5.5365 23.377,-36.161 10.243,-41.048 -3.5482,-1.3174 3.1887,1.185 0,0 z"
-         fill="#ffffff"
-         id="path4557" />
-      <rect
-         x="907.09003"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4559" />
+    <g transform="translate(-907.09,2040.9)" id="g4561">
+      <path d="m 1115.1,-2486.1 c -7.6614,-2.8509 -9.6342,6.6906 -11.986,11.642 -3.7889,7.335 -8.9679,14.191 -15.365,19.45 -7.2842,5.8875 -15.535,10.788 -24.746,12.958 23.06,-23.086 26.588,-55.592 14.756,-85.018 -4.3449,-10.797 -11.662,-20.637 -20.405,-28.263 -3.9632,-3.4644 -10.705,-3.8505 -12.298,2.465 -1.218,4.8237 3.8639,8.9832 6.364,12.604 9.4358,14.701 13.103,33.987 8.0124,50.936 -8.2463,-30.73 -33.943,-50.424 -64.688,-55.065 -11.444,-1.4233 -23.492,-1.0283 -34.503,2.7209 -4.6781,1.6042 -10.175,4.8767 -7.0348,10.793 2.7716,5.2143 8.2419,3.0694 12.801,2.6877 18.311,-1.4719 37.902,4.7134 50.694,18.322 -31.522,-8.4404 -61.458,4.7973 -81.007,29.735 -7.187,9.1688 -12.017,20.412 -14.275,31.802 -1.0172,5.157 2.0191,11.194 8.2838,9.4202 4.7863,-1.3549 5.8499,-7.8424 7.7344,-11.815 7.997,-15.497 22.894,-28.351 40.106,-32.407 -23.073,23.068 -26.582,55.606 -14.754,85.023 4.3382,10.786 11.658,20.65 20.407,28.261 3.9608,3.46 10.704,3.8484 12.298,-2.4649 1.2224,-4.8281 -3.8661,-8.9789 -6.3596,-12.609 -9.4335,-14.685 -13.123,-33.996 -8.0168,-50.934 8.2397,30.73 33.945,50.424 64.688,55.067 11.444,1.421 23.492,1.0282 34.501,-2.7231 4.676,-1.5975 10.177,-4.8767 7.0327,-10.791 -2.7672,-5.212 -8.2354,-3.0672 -12.796,-2.6898 -18.326,1.4696 -37.882,-4.7158 -50.694,-18.32 20.067,5.3711 40.777,2.1846 58.234,-8.7561 8.8752,-5.565 16.329,-12.761 22.773,-20.983 4.3427,-5.5365 23.377,-36.161 10.243,-41.048 -3.5482,-1.3174 3.1887,1.185 0,0 z" fill="#ffffff" id="path4557"/>
+      <rect x="907.09003" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect4559"/>
     </g>
-    <g
-       transform="translate(1814.2,1814.2)"
-       id="g4589">
-      <g
-         fill="none"
-         id="g4579">
-        <rect
-           x="1133.9"
-           y="-2576"
-           width="226.77"
-           height="226.77"
-           opacity="1"
-           id="rect4563" />
-        <g
-           stroke="#ffffff"
-           id="g4577">
-          <rect
-             x="1155.1"
-             y="-2554.7"
-             width="184.25"
-             height="184.25"
-             rx="0.00012162"
-             ry="0.00012162"
-             opacity="1"
-             stroke-linejoin="round"
-             stroke-miterlimit="1.5"
-             stroke-width="14.173"
-             style="paint-order:markers fill stroke"
-             id="rect4565" />
-          <g
-             stroke-width="7.0866"
-             id="g4575">
-            <path
-               d="m 1161.5,-2493.9 h 176.14"
-               id="path4567" />
-            <path
-               d="m 1161.5,-2431.5 h 176.14"
-               id="path4569" />
-            <path
-               d="m 1278.9,-2550.8 v 176.14"
-               id="path4571" />
-            <path
-               d="m 1222.1,-2550.8 v 176.14"
-               id="path4573" />
+    <g transform="translate(1814.2,1814.2)" id="g4589">
+      <g fill="none" id="g4579">
+        <rect x="1133.9" y="-2576" width="226.77" height="226.77" opacity="1" id="rect4563"/>
+        <g stroke="#ffffff" id="g4577">
+          <rect x="1155.1" y="-2554.7" width="184.25" height="184.25" rx="0.00012162" ry="0.00012162" opacity="1" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="14.173" style="paint-order:markers fill stroke" id="rect4565"/>
+          <g stroke-width="7.0866" id="g4575">
+            <path d="m 1161.5,-2493.9 h 176.14" id="path4567"/>
+            <path d="m 1161.5,-2431.5 h 176.14" id="path4569"/>
+            <path d="m 1278.9,-2550.8 v 176.14" id="path4571"/>
+            <path d="m 1222.1,-2550.8 v 176.14" id="path4573"/>
           </g>
         </g>
       </g>
-      <g
-         fill="#ffffff"
-         id="g4587">
-        <circle
-           cx="1205.7"
-           cy="-2495.7"
-           r="28.906"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="circle4581" />
-        <circle
-           cx="1279.2"
-           cy="-2425.7"
-           r="19.844"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="circle4583" />
-        <circle
-           cx="1304.2"
-           cy="-2518.5"
-           r="14.531"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="circle4585" />
+      <g fill="#ffffff" id="g4587">
+        <circle cx="1205.7" cy="-2495.7" r="28.906" opacity="1" style="paint-order:markers fill stroke" id="circle4581"/>
+        <circle cx="1279.2" cy="-2425.7" r="19.844" opacity="1" style="paint-order:markers fill stroke" id="circle4583"/>
+        <circle cx="1304.2" cy="-2518.5" r="14.531" opacity="1" style="paint-order:markers fill stroke" id="circle4585"/>
       </g>
     </g>
-    <g
-       transform="translate(1814.2,1814.2)"
-       opacity="1"
-       id="g4607">
-      <g
-         fill="none"
-         id="g4597">
-        <rect
-           x="1360.6"
-           y="-2576"
-           width="226.77"
-           height="226.77"
-           opacity="1"
-           id="rect4591" />
-        <ellipse
-           transform="matrix(0.94182,-0.33612,0.32627,0.94528,0,0)"
-           cx="2213.3999"
-           cy="-1820.7"
-           rx="71.550003"
-           ry="45.903"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linejoin="round"
-           stroke-width="7.0868"
-           style="paint-order:markers fill stroke"
-           id="ellipse4593" />
-        <path
-           transform="matrix(0.94085,-0.33882,0.32365,0.94618,0,0)"
-           d="m 2111.1,-1893.5 a 136.3,88.063 0 0 1 136.72,16.756 136.3,88.063 0 0 1 42.698,85.571 136.3,88.063 0 0 1 -95.828,65.192"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linejoin="round"
-           stroke-width="7.0871"
-           style="paint-order:markers fill stroke"
-           id="path4595" />
+    <g transform="translate(1814.2,1814.2)" opacity="1" id="g4607">
+      <g fill="none" id="g4597">
+        <rect x="1360.6" y="-2576" width="226.77" height="226.77" opacity="1" id="rect4591"/>
+        <ellipse transform="matrix(0.94182,-0.33612,0.32627,0.94528,0,0)" cx="2213.3999" cy="-1820.7" rx="71.550003" ry="45.903" opacity="1" stroke="#ffffff" stroke-linejoin="round" stroke-width="7.0868" style="paint-order:markers fill stroke" id="ellipse4593"/>
+        <path transform="matrix(0.94085,-0.33882,0.32365,0.94618,0,0)" d="m 2111.1,-1893.5 a 136.3,88.063 0 0 1 136.72,16.756 136.3,88.063 0 0 1 42.698,85.571 136.3,88.063 0 0 1 -95.828,65.192" opacity="1" stroke="#ffffff" stroke-linejoin="round" stroke-width="7.0871" style="paint-order:markers fill stroke" id="path4595"/>
       </g>
-      <g
-         fill="#ffffff"
-         id="g4605">
-        <circle
-           cx="1506"
-           cy="-2537.5"
-           r="15.468"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="circle4599" />
-        <circle
-           cx="1456"
-           cy="-2416.3999"
-           r="15.468"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="circle4601" />
-        <circle
-           cx="1516.1"
-           cy="-2473.8"
-           r="25.191"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="circle4603" />
+      <g fill="#ffffff" id="g4605">
+        <circle cx="1506" cy="-2537.5" r="15.468" opacity="1" style="paint-order:markers fill stroke" id="circle4599"/>
+        <circle cx="1456" cy="-2416.3999" r="15.468" opacity="1" style="paint-order:markers fill stroke" id="circle4601"/>
+        <circle cx="1516.1" cy="-2473.8" r="25.191" opacity="1" style="paint-order:markers fill stroke" id="circle4603"/>
       </g>
     </g>
-    <g
-       transform="translate(1587.4,680.32)"
-       id="g4615">
-      <path
-         d="m 1631.8,-2507.2 c -16.709,0 -30.254,13.545 -30.254,30.254 -10e-5,16.709 13.545,30.254 30.254,30.254 16.709,0 30.254,-13.545 30.254,-30.254 -10e-5,-16.709 -13.545,-30.254 -30.254,-30.254 z m 98.033,0.049 c -2.3328,-0.01 -4.2576,0.6216 -5.5988,1.9629 -3.4339,3.4336 -2.2083,10.692 2.4722,18.827 -0.2958,1.3946 -0.4439,2.8422 -0.4439,4.3318 0,11.675 9.4562,21.131 21.131,21.131 1.4897,0 2.9361,-0.1481 4.3317,-0.4439 8.1353,4.6804 15.394,5.9061 18.827,2.4723 3.4337,-3.4338 2.2083,-10.692 -2.4721,-18.827 0.2947,-1.3947 0.4436,-2.8421 0.4436,-4.3318 0,-11.675 -9.4559,-21.131 -21.131,-21.131 -1.4896,0 -2.9374,0.1479 -4.332,0.4437 -4.9573,-2.8521 -9.5891,-4.4214 -13.228,-4.4351 z m 0.5386,4.8958 c 1.6625,0 3.8507,0.7293 6.34,1.9905 -1.7644,1.0354 -3.3491,2.3139 -4.7321,3.793 4.4586,11.178 18.838,25.452 30.047,29.689 1.4475,-1.384 2.6953,-2.9795 3.698,-4.7333 1.6693,3.6239 2.0918,6.8464 0.6444,9.1284 -12.774,4.0889 -44.925,-32.478 -38.373,-39.039 0.5704,-0.5666 1.3788,-0.8285 2.3763,-0.8283 z m -49.83,9.5151 c -5.9156,1e-4 -10.711,4.7956 -10.711,10.711 10e-5,5.9156 4.7955,10.711 10.711,10.711 5.9155,0 10.711,-4.7955 10.711,-10.711 0,-5.9157 -4.7956,-10.711 -10.711,-10.711 z m 110.86,2.1422 c -4.7325,0 -8.5689,3.8365 -8.5689,8.569 0,4.7325 3.8364,8.5689 8.5689,8.5689 4.7325,1e-4 8.5691,-3.8364 8.5691,-8.5689 0,-4.7326 -3.8365,-8.5691 -8.5691,-8.569 z m -83.547,0.8034 c -4.2889,0 -7.7657,3.4767 -7.7657,7.7656 0,4.2889 3.4768,7.7656 7.7657,7.7656 4.2888,0 7.7656,-3.4768 7.7656,-7.7656 0,-4.2888 -3.4768,-7.7656 -7.7656,-7.7656 z m 0,30.527 c -2.5141,0 -4.5522,2.0381 -4.5522,4.5522 0,2.5141 2.0381,4.5523 4.5522,4.5523 2.5142,0 4.5523,-2.0381 4.5523,-4.5523 0,-2.5141 -2.0382,-4.5522 -4.5523,-4.5522 z m 85.957,0.5355 c -1.7747,0 -3.2133,1.4387 -3.2133,3.2134 0,1.7747 1.4386,3.2134 3.2133,3.2134 1.7747,0 3.2133,-1.4387 3.2133,-3.2134 0,-1.7747 -1.4386,-3.2134 -3.2133,-3.2134 z m -46.419,14.192 c -2.2183,0 -4.0166,1.7983 -4.0167,4.0166 -10e-5,2.2184 1.7983,4.0168 4.0167,4.0168 2.2184,-10e-5 4.0167,-1.7984 4.0166,-4.0168 -10e-5,-2.2183 -1.7983,-4.0165 -4.0166,-4.0166 z m 0,17.406 c -2.5141,0 -4.5523,2.0381 -4.5523,4.5522 0,2.5142 2.0381,4.5523 4.5523,4.5523 2.5141,0 4.5522,-2.0382 4.5522,-4.5523 0,-2.5141 -2.0381,-4.5522 -4.5522,-4.5522 z"
-         fill="#ffffff"
-         id="path4609" />
-      <rect
-         x="1587.4"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4611" />
-      <path
-         d="m 1631.8,-2507.2 c -16.709,0 -30.254,13.545 -30.254,30.254 -10e-5,16.709 13.545,30.254 30.254,30.254 16.709,0 30.254,-13.545 30.254,-30.254 -10e-5,-16.709 -13.545,-30.254 -30.254,-30.254 z m 98.033,0.049 c -2.3328,-0.01 -4.2576,0.6216 -5.5988,1.9629 -3.4339,3.4336 -2.2083,10.692 2.4722,18.827 -0.2958,1.3946 -0.4439,2.8422 -0.4439,4.3318 0,11.675 9.4562,21.131 21.131,21.131 1.4897,0 2.9361,-0.1481 4.3317,-0.4439 8.1353,4.6804 15.394,5.9061 18.827,2.4723 3.4337,-3.4338 2.2083,-10.692 -2.4721,-18.827 0.2947,-1.3947 0.4436,-2.8421 0.4436,-4.3318 0,-11.675 -9.4559,-21.131 -21.131,-21.131 -1.4896,0 -2.9374,0.1479 -4.332,0.4437 -4.9573,-2.8521 -9.5891,-4.4214 -13.228,-4.4351 z m 0.5386,4.8958 c 1.6625,0 3.8507,0.7293 6.34,1.9905 -1.7644,1.0354 -3.3491,2.3139 -4.7321,3.793 4.4586,11.178 18.838,25.452 30.047,29.689 1.4475,-1.384 2.6953,-2.9795 3.698,-4.7333 1.6693,3.6239 2.0918,6.8464 0.6444,9.1284 -12.774,4.0889 -44.925,-32.478 -38.373,-39.039 0.5704,-0.5666 1.3788,-0.8285 2.3763,-0.8283 z m -49.83,9.5151 c -5.9156,1e-4 -10.711,4.7956 -10.711,10.711 10e-5,5.9156 4.7955,10.711 10.711,10.711 5.9155,0 10.711,-4.7955 10.711,-10.711 0,-5.9157 -4.7956,-10.711 -10.711,-10.711 z m 110.86,2.1422 c -4.7325,0 -8.5689,3.8365 -8.5689,8.569 0,4.7325 3.8364,8.5689 8.5689,8.5689 4.7325,1e-4 8.5691,-3.8364 8.5691,-8.5689 0,-4.7326 -3.8365,-8.5691 -8.5691,-8.569 z m -83.547,0.8034 c -4.2889,0 -7.7657,3.4767 -7.7657,7.7656 0,4.2889 3.4768,7.7656 7.7657,7.7656 4.2888,0 7.7656,-3.4768 7.7656,-7.7656 0,-4.2888 -3.4768,-7.7656 -7.7656,-7.7656 z m 0,30.527 c -2.5141,0 -4.5522,2.0381 -4.5522,4.5522 0,2.5141 2.0381,4.5523 4.5522,4.5523 2.5142,0 4.5523,-2.0381 4.5523,-4.5523 0,-2.5141 -2.0382,-4.5522 -4.5523,-4.5522 z m 85.957,0.5355 c -1.7747,0 -3.2133,1.4387 -3.2133,3.2134 0,1.7747 1.4386,3.2134 3.2133,3.2134 1.7747,0 3.2133,-1.4387 3.2133,-3.2134 0,-1.7747 -1.4386,-3.2134 -3.2133,-3.2134 z m -46.419,14.192 c -2.2183,0 -4.0166,1.7983 -4.0167,4.0166 -10e-5,2.2184 1.7983,4.0168 4.0167,4.0168 2.2184,-10e-5 4.0167,-1.7984 4.0166,-4.0168 -10e-5,-2.2183 -1.7983,-4.0165 -4.0166,-4.0166 z m 0,17.406 c -2.5141,0 -4.5523,2.0381 -4.5523,4.5522 0,2.5142 2.0381,4.5523 4.5523,4.5523 2.5141,0 4.5522,-2.0382 4.5522,-4.5523 0,-2.5141 -2.0381,-4.5522 -4.5522,-4.5522 z"
-         fill="#ffffff"
-         id="path4613" />
+    <g transform="translate(1587.4,680.32)" id="g4615">
+      <path d="m 1631.8,-2507.2 c -16.709,0 -30.254,13.545 -30.254,30.254 -10e-5,16.709 13.545,30.254 30.254,30.254 16.709,0 30.254,-13.545 30.254,-30.254 -10e-5,-16.709 -13.545,-30.254 -30.254,-30.254 z m 98.033,0.049 c -2.3328,-0.01 -4.2576,0.6216 -5.5988,1.9629 -3.4339,3.4336 -2.2083,10.692 2.4722,18.827 -0.2958,1.3946 -0.4439,2.8422 -0.4439,4.3318 0,11.675 9.4562,21.131 21.131,21.131 1.4897,0 2.9361,-0.1481 4.3317,-0.4439 8.1353,4.6804 15.394,5.9061 18.827,2.4723 3.4337,-3.4338 2.2083,-10.692 -2.4721,-18.827 0.2947,-1.3947 0.4436,-2.8421 0.4436,-4.3318 0,-11.675 -9.4559,-21.131 -21.131,-21.131 -1.4896,0 -2.9374,0.1479 -4.332,0.4437 -4.9573,-2.8521 -9.5891,-4.4214 -13.228,-4.4351 z m 0.5386,4.8958 c 1.6625,0 3.8507,0.7293 6.34,1.9905 -1.7644,1.0354 -3.3491,2.3139 -4.7321,3.793 4.4586,11.178 18.838,25.452 30.047,29.689 1.4475,-1.384 2.6953,-2.9795 3.698,-4.7333 1.6693,3.6239 2.0918,6.8464 0.6444,9.1284 -12.774,4.0889 -44.925,-32.478 -38.373,-39.039 0.5704,-0.5666 1.3788,-0.8285 2.3763,-0.8283 z m -49.83,9.5151 c -5.9156,1e-4 -10.711,4.7956 -10.711,10.711 10e-5,5.9156 4.7955,10.711 10.711,10.711 5.9155,0 10.711,-4.7955 10.711,-10.711 0,-5.9157 -4.7956,-10.711 -10.711,-10.711 z m 110.86,2.1422 c -4.7325,0 -8.5689,3.8365 -8.5689,8.569 0,4.7325 3.8364,8.5689 8.5689,8.5689 4.7325,1e-4 8.5691,-3.8364 8.5691,-8.5689 0,-4.7326 -3.8365,-8.5691 -8.5691,-8.569 z m -83.547,0.8034 c -4.2889,0 -7.7657,3.4767 -7.7657,7.7656 0,4.2889 3.4768,7.7656 7.7657,7.7656 4.2888,0 7.7656,-3.4768 7.7656,-7.7656 0,-4.2888 -3.4768,-7.7656 -7.7656,-7.7656 z m 0,30.527 c -2.5141,0 -4.5522,2.0381 -4.5522,4.5522 0,2.5141 2.0381,4.5523 4.5522,4.5523 2.5142,0 4.5523,-2.0381 4.5523,-4.5523 0,-2.5141 -2.0382,-4.5522 -4.5523,-4.5522 z m 85.957,0.5355 c -1.7747,0 -3.2133,1.4387 -3.2133,3.2134 0,1.7747 1.4386,3.2134 3.2133,3.2134 1.7747,0 3.2133,-1.4387 3.2133,-3.2134 0,-1.7747 -1.4386,-3.2134 -3.2133,-3.2134 z m -46.419,14.192 c -2.2183,0 -4.0166,1.7983 -4.0167,4.0166 -10e-5,2.2184 1.7983,4.0168 4.0167,4.0168 2.2184,-10e-5 4.0167,-1.7984 4.0166,-4.0168 -10e-5,-2.2183 -1.7983,-4.0165 -4.0166,-4.0166 z m 0,17.406 c -2.5141,0 -4.5523,2.0381 -4.5523,4.5522 0,2.5142 2.0381,4.5523 4.5523,4.5523 2.5141,0 4.5522,-2.0382 4.5522,-4.5523 0,-2.5141 -2.0381,-4.5522 -4.5522,-4.5522 z" fill="#ffffff" id="path4609"/>
+      <rect x="1587.4" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect4611"/>
+      <path d="m 1631.8,-2507.2 c -16.709,0 -30.254,13.545 -30.254,30.254 -10e-5,16.709 13.545,30.254 30.254,30.254 16.709,0 30.254,-13.545 30.254,-30.254 -10e-5,-16.709 -13.545,-30.254 -30.254,-30.254 z m 98.033,0.049 c -2.3328,-0.01 -4.2576,0.6216 -5.5988,1.9629 -3.4339,3.4336 -2.2083,10.692 2.4722,18.827 -0.2958,1.3946 -0.4439,2.8422 -0.4439,4.3318 0,11.675 9.4562,21.131 21.131,21.131 1.4897,0 2.9361,-0.1481 4.3317,-0.4439 8.1353,4.6804 15.394,5.9061 18.827,2.4723 3.4337,-3.4338 2.2083,-10.692 -2.4721,-18.827 0.2947,-1.3947 0.4436,-2.8421 0.4436,-4.3318 0,-11.675 -9.4559,-21.131 -21.131,-21.131 -1.4896,0 -2.9374,0.1479 -4.332,0.4437 -4.9573,-2.8521 -9.5891,-4.4214 -13.228,-4.4351 z m 0.5386,4.8958 c 1.6625,0 3.8507,0.7293 6.34,1.9905 -1.7644,1.0354 -3.3491,2.3139 -4.7321,3.793 4.4586,11.178 18.838,25.452 30.047,29.689 1.4475,-1.384 2.6953,-2.9795 3.698,-4.7333 1.6693,3.6239 2.0918,6.8464 0.6444,9.1284 -12.774,4.0889 -44.925,-32.478 -38.373,-39.039 0.5704,-0.5666 1.3788,-0.8285 2.3763,-0.8283 z m -49.83,9.5151 c -5.9156,1e-4 -10.711,4.7956 -10.711,10.711 10e-5,5.9156 4.7955,10.711 10.711,10.711 5.9155,0 10.711,-4.7955 10.711,-10.711 0,-5.9157 -4.7956,-10.711 -10.711,-10.711 z m 110.86,2.1422 c -4.7325,0 -8.5689,3.8365 -8.5689,8.569 0,4.7325 3.8364,8.5689 8.5689,8.5689 4.7325,1e-4 8.5691,-3.8364 8.5691,-8.5689 0,-4.7326 -3.8365,-8.5691 -8.5691,-8.569 z m -83.547,0.8034 c -4.2889,0 -7.7657,3.4767 -7.7657,7.7656 0,4.2889 3.4768,7.7656 7.7657,7.7656 4.2888,0 7.7656,-3.4768 7.7656,-7.7656 0,-4.2888 -3.4768,-7.7656 -7.7656,-7.7656 z m 0,30.527 c -2.5141,0 -4.5522,2.0381 -4.5522,4.5522 0,2.5141 2.0381,4.5523 4.5522,4.5523 2.5142,0 4.5523,-2.0381 4.5523,-4.5523 0,-2.5141 -2.0382,-4.5522 -4.5523,-4.5522 z m 85.957,0.5355 c -1.7747,0 -3.2133,1.4387 -3.2133,3.2134 0,1.7747 1.4386,3.2134 3.2133,3.2134 1.7747,0 3.2133,-1.4387 3.2133,-3.2134 0,-1.7747 -1.4386,-3.2134 -3.2133,-3.2134 z m -46.419,14.192 c -2.2183,0 -4.0166,1.7983 -4.0167,4.0166 -10e-5,2.2184 1.7983,4.0168 4.0167,4.0168 2.2184,-10e-5 4.0167,-1.7984 4.0166,-4.0168 -10e-5,-2.2183 -1.7983,-4.0165 -4.0166,-4.0166 z m 0,17.406 c -2.5141,0 -4.5523,2.0381 -4.5523,4.5522 0,2.5142 2.0381,4.5523 4.5523,4.5523 2.5141,0 4.5522,-2.0382 4.5522,-4.5523 0,-2.5141 -2.0381,-4.5522 -4.5522,-4.5522 z" fill="#ffffff" id="path4613"/>
     </g>
-    <g
-       transform="translate(1587.4,1814.1)"
-       id="g4621">
-      <rect
-         x="453.54001"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4617" />
-      <path
-         d="m 564.84,-2429.6 c -4.6299,-5.8701 -8.6811,-8.7638 -18.726,-9.7518 -1.8189,-0.3306 -3.1417,-1.9016 -3.1417,-3.7617 0,-1.3642 4.4646,-5.4568 4.4191,-5.4982 4.6341,-4.6712 7.1144,-12.236 7.1144,-18.065 0,-9.0491 -8.0156,-16.535 -18.602,-16.535 -10.789,0 -18.602,7.4863 -18.602,16.535 0,5.8701 2.439,13.476 7.0689,18.152 0,0 4.4646,4.0472 4.4646,5.4155 0,1.9428 -1.4882,3.5965 -3.4724,3.8444 -9.8427,0.9921 -13.811,3.8858 -18.396,9.6732 -1.2856,1.6949 -2.0256,5.0433 -2.0669,6.821 v 7.7634 c 0,3.4311 2.8482,6.2007 6.3662,6.2007 h 49.276 c 3.5179,0 6.3662,-2.7696 6.3662,-6.2007 v -7.7717 c -0.0414,-1.7819 -0.74824,-5.1261 -2.0669,-6.8209 z m 49.606,-45.348 h -20.669 c -5.7047,0 -10.335,4.63 -10.335,10.335 0,5.705 4.6299,10.335 10.335,10.335 h 20.669 c 5.7047,0 10.335,-4.63 10.335,-10.335 0,-5.705 -4.6299,-10.335 -10.335,-10.335 z m 0,37.205 h -20.669 c -5.7047,0 -10.335,4.63 -10.335,10.335 0,5.7048 4.6299,10.335 10.335,10.335 h 20.669 c 5.7047,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.6299,-10.335 -10.335,-10.335 z m -146.75,49.606 c 0,9.1358 7.3996,16.535 16.535,16.535 h 165.35 c 9.1358,0 16.535,-7.3996 16.535,-16.535 v -132.28 c 0,-9.1359 -7.3996,-16.535 -16.535,-16.535 h -49.606 v -7.441 c 0,-5.0432 -4.0512,-9.0944 -9.0945,-9.0944 h -47.953 c -5.0433,0 -9.0945,4.0512 -9.0945,9.0944 v 7.441 h -49.606 c -9.1358,0 -16.535,7.3995 -16.535,16.535 z m 29.764,-128.15 h 36.378 v 7.4411 c 0,5.0432 4.0512,9.0944 9.0945,9.0944 h 47.953 c 5.0433,0 9.0945,-4.0512 9.0945,-9.0944 v -7.4411 h 36.378 c 5.0433,0 9.0945,4.0512 9.0945,9.0946 v 105.83 c 0,5.0432 -4.0512,9.0944 -9.0945,9.0944 h -138.9 c -5.0433,0 -9.0945,-4.0512 -9.0945,-9.0944 v -105.83 c 0,-5.0434 4.0512,-9.0946 9.0945,-9.0946 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4619" />
+    <g transform="translate(1587.4,1814.1)" id="g4621">
+      <rect x="453.54001" y="-2575.8999" width="226.77" height="226.77" fill="none" opacity="1" id="rect4617"/>
+      <path d="m 564.84,-2429.6 c -4.6299,-5.8701 -8.6811,-8.7638 -18.726,-9.7518 -1.8189,-0.3306 -3.1417,-1.9016 -3.1417,-3.7617 0,-1.3642 4.4646,-5.4568 4.4191,-5.4982 4.6341,-4.6712 7.1144,-12.236 7.1144,-18.065 0,-9.0491 -8.0156,-16.535 -18.602,-16.535 -10.789,0 -18.602,7.4863 -18.602,16.535 0,5.8701 2.439,13.476 7.0689,18.152 0,0 4.4646,4.0472 4.4646,5.4155 0,1.9428 -1.4882,3.5965 -3.4724,3.8444 -9.8427,0.9921 -13.811,3.8858 -18.396,9.6732 -1.2856,1.6949 -2.0256,5.0433 -2.0669,6.821 v 7.7634 c 0,3.4311 2.8482,6.2007 6.3662,6.2007 h 49.276 c 3.5179,0 6.3662,-2.7696 6.3662,-6.2007 v -7.7717 c -0.0414,-1.7819 -0.74824,-5.1261 -2.0669,-6.8209 z m 49.606,-45.348 h -20.669 c -5.7047,0 -10.335,4.63 -10.335,10.335 0,5.705 4.6299,10.335 10.335,10.335 h 20.669 c 5.7047,0 10.335,-4.63 10.335,-10.335 0,-5.705 -4.6299,-10.335 -10.335,-10.335 z m 0,37.205 h -20.669 c -5.7047,0 -10.335,4.63 -10.335,10.335 0,5.7048 4.6299,10.335 10.335,10.335 h 20.669 c 5.7047,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.6299,-10.335 -10.335,-10.335 z m -146.75,49.606 c 0,9.1358 7.3996,16.535 16.535,16.535 h 165.35 c 9.1358,0 16.535,-7.3996 16.535,-16.535 v -132.28 c 0,-9.1359 -7.3996,-16.535 -16.535,-16.535 h -49.606 v -7.441 c 0,-5.0432 -4.0512,-9.0944 -9.0945,-9.0944 h -47.953 c -5.0433,0 -9.0945,4.0512 -9.0945,9.0944 v 7.441 h -49.606 c -9.1358,0 -16.535,7.3995 -16.535,16.535 z m 29.764,-128.15 h 36.378 v 7.4411 c 0,5.0432 4.0512,9.0944 9.0945,9.0944 h 47.953 c 5.0433,0 9.0945,-4.0512 9.0945,-9.0944 v -7.4411 h 36.378 c 5.0433,0 9.0945,4.0512 9.0945,9.0946 v 105.83 c 0,5.0432 -4.0512,9.0944 -9.0945,9.0944 h -138.9 c -5.0433,0 -9.0945,-4.0512 -9.0945,-9.0944 v -105.83 c 0,-5.0434 4.0512,-9.0946 9.0945,-9.0946 z" fill="#ffffff" opacity="1" id="path4619"/>
     </g>
-    <g
-       transform="translate(680.31,907.09)"
-       id="g4627">
-      <path
-         d="m 130.22,-2298.7 a 65.091,65.053 15 0 0 -57.469,12.1 c -6.0166,-0.1275 -11.795,0.074 -17.245,0.6273 -10.059,1.0212 -18.642,3.1557 -25.679,6.8217 -7.0366,3.6658 -12.865,9.3332 -14.895,16.908 -2.0296,7.5745 0.18406,15.397 4.445,22.09 4.261,6.6929 10.627,12.834 18.828,18.747 16.402,11.828 39.035,21.764 63.702,28.374 24.667,6.6094 49.236,9.321 69.354,7.2787 10.059,-1.021 18.643,-3.1556 25.679,-6.8216 7.0366,-3.6657 12.865,-9.3331 14.894,-16.908 2.0296,-7.5745 -0.18405,-15.397 -4.445,-22.09 -4.261,-6.6929 -10.627,-12.834 -18.828,-18.748 -4.4419,-3.2031 -9.344,-6.2664 -14.616,-9.1635 a 65.091,65.053 15 0 0 -43.725,-39.216 z m 48.168,63.439 c 6.6602,4.8664 11.262,9.6402 13.682,13.441 2.4742,3.8863 2.6137,6.1781 2.2228,7.6368 -0.39084,1.4586 -1.6576,3.3736 -5.7435,5.5022 -4.0859,2.1286 -10.652,4.0002 -19.123,4.8601 -16.942,1.7198 -39.917,-0.6164 -62.82,-6.7531 -22.903,-6.1367 -43.968,-15.601 -57.78,-25.562 -6.906,-4.9801 -11.657,-9.884 -14.131,-13.77 -2.4742,-3.8863 -2.6137,-6.1781 -2.2228,-7.6367 0.39084,-1.4587 1.6576,-3.3736 5.7435,-5.5022 3.9891,-2.0783 10.348,-3.9088 18.53,-4.7947 a 65.091,65.053 15 0 0 -6.2367,15.13 65.091,65.053 15 0 0 -1.9154,10.702 c 1.5023,1.1903 3.1452,2.4038 4.9313,3.623 13.726,9.3702 34.392,18.33 56.514,24.018 22.122,5.6881 44.111,7.6703 59.733,5.9435 0.93511,-0.1035 1.84,-0.2211 2.7174,-0.3497 a 65.091,65.053 15 0 0 3.7663,-10.243 65.091,65.053 15 0 0 2.1319,-16.245 z m -122.49,29.781 a 65.091,65.053 15 0 0 40.644,32.454 65.091,65.053 15 0 0 51.37,-7.7774 c -14.178,-0.7762 -29.352,-3.2442 -44.66,-7.1805 -17.038,-4.381 -33.237,-10.334 -47.354,-17.496 z"
-         fill="#ffffff"
-         id="path4623" />
-      <rect
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4625"
-         x="0" />
+    <g transform="translate(680.31,907.09)" id="g4627">
+      <path d="m 130.22,-2298.7 a 65.091,65.053 15 0 0 -57.469,12.1 c -6.0166,-0.1275 -11.795,0.074 -17.245,0.6273 -10.059,1.0212 -18.642,3.1557 -25.679,6.8217 -7.0366,3.6658 -12.865,9.3332 -14.895,16.908 -2.0296,7.5745 0.18406,15.397 4.445,22.09 4.261,6.6929 10.627,12.834 18.828,18.747 16.402,11.828 39.035,21.764 63.702,28.374 24.667,6.6094 49.236,9.321 69.354,7.2787 10.059,-1.021 18.643,-3.1556 25.679,-6.8216 7.0366,-3.6657 12.865,-9.3331 14.894,-16.908 2.0296,-7.5745 -0.18405,-15.397 -4.445,-22.09 -4.261,-6.6929 -10.627,-12.834 -18.828,-18.748 -4.4419,-3.2031 -9.344,-6.2664 -14.616,-9.1635 a 65.091,65.053 15 0 0 -43.725,-39.216 z m 48.168,63.439 c 6.6602,4.8664 11.262,9.6402 13.682,13.441 2.4742,3.8863 2.6137,6.1781 2.2228,7.6368 -0.39084,1.4586 -1.6576,3.3736 -5.7435,5.5022 -4.0859,2.1286 -10.652,4.0002 -19.123,4.8601 -16.942,1.7198 -39.917,-0.6164 -62.82,-6.7531 -22.903,-6.1367 -43.968,-15.601 -57.78,-25.562 -6.906,-4.9801 -11.657,-9.884 -14.131,-13.77 -2.4742,-3.8863 -2.6137,-6.1781 -2.2228,-7.6367 0.39084,-1.4587 1.6576,-3.3736 5.7435,-5.5022 3.9891,-2.0783 10.348,-3.9088 18.53,-4.7947 a 65.091,65.053 15 0 0 -6.2367,15.13 65.091,65.053 15 0 0 -1.9154,10.702 c 1.5023,1.1903 3.1452,2.4038 4.9313,3.623 13.726,9.3702 34.392,18.33 56.514,24.018 22.122,5.6881 44.111,7.6703 59.733,5.9435 0.93511,-0.1035 1.84,-0.2211 2.7174,-0.3497 a 65.091,65.053 15 0 0 3.7663,-10.243 65.091,65.053 15 0 0 2.1319,-16.245 z m -122.49,29.781 a 65.091,65.053 15 0 0 40.644,32.454 65.091,65.053 15 0 0 51.37,-7.7774 c -14.178,-0.7762 -29.352,-3.2442 -44.66,-7.1805 -17.038,-4.381 -33.237,-10.334 -47.354,-17.496 z" fill="#ffffff" id="path4623"/>
+      <rect y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect4625" x="0"/>
     </g>
-    <g
-       transform="translate(453.54,453.54)"
-       id="g4633">
-      <path
-         d="m 411.02,-2235.8 a 70.866,70.866 0 0 1 -70.866,70.866 70.866,70.866 0 0 1 -70.866,-70.866 70.866,70.866 0 0 1 70.866,-70.866 70.866,70.866 0 0 1 70.866,70.866 z"
-         fill="#ffffff"
-         id="path4629" />
-      <rect
-         x="226.77"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4631" />
+    <g transform="translate(453.54,453.54)" id="g4633">
+      <path d="m 411.02,-2235.8 a 70.866,70.866 0 0 1 -70.866,70.866 70.866,70.866 0 0 1 -70.866,-70.866 70.866,70.866 0 0 1 70.866,-70.866 70.866,70.866 0 0 1 70.866,70.866 z" fill="#ffffff" id="path4629"/>
+      <rect x="226.77" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect4631"/>
     </g>
-    <g
-       transform="translate(1587.4,3628.3)"
-       id="g4639">
-      <path
-         d="m -720.05,-4772.8 a 85.04,85.04 0 0 0 -116.17,-31.126 85.04,85.04 0 0 0 -31.127,116.17 85.04,85.04 0 0 0 116.17,31.126 85.04,85.04 0 0 0 31.127,-116.17 z m -15.185,8.7669 a 67.506,67.506 0 0 1 -16.737,86.735 l -19.289,-33.41 a 29.809,29.809 0 0 0 3.3799,-34.477 29.809,29.809 0 0 0 -31.551,-14.316 l -19.278,-33.391 a 67.506,67.506 0 0 1 83.475,28.858 z m -100.19,-19.229 19.289,33.409 a 29.809,29.809 0 0 0 -3.3799,34.477 29.809,29.809 0 0 0 31.551,14.316 l 19.279,33.391 a 67.506,67.506 0 0 1 -83.476,-28.859 67.506,67.506 0 0 1 16.738,-86.735 z"
-         fill="#ffffff"
-         id="path4635" />
-      <rect
-         x="-907.09003"
-         y="-4843.7002"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4637" />
+    <g transform="translate(1587.4,3628.3)" id="g4639">
+      <path d="m -720.05,-4772.8 a 85.04,85.04 0 0 0 -116.17,-31.126 85.04,85.04 0 0 0 -31.127,116.17 85.04,85.04 0 0 0 116.17,31.126 85.04,85.04 0 0 0 31.127,-116.17 z m -15.185,8.7669 a 67.506,67.506 0 0 1 -16.737,86.735 l -19.289,-33.41 a 29.809,29.809 0 0 0 3.3799,-34.477 29.809,29.809 0 0 0 -31.551,-14.316 l -19.278,-33.391 a 67.506,67.506 0 0 1 83.475,28.858 z m -100.19,-19.229 19.289,33.409 a 29.809,29.809 0 0 0 -3.3799,34.477 29.809,29.809 0 0 0 31.551,14.316 l 19.279,33.391 a 67.506,67.506 0 0 1 -83.476,-28.859 67.506,67.506 0 0 1 16.738,-86.735 z" fill="#ffffff" id="path4635"/>
+      <rect x="-907.09003" y="-4843.7002" width="226.77" height="226.77" fill="none" opacity="1" id="rect4637"/>
     </g>
-    <g
-       transform="matrix(0.66153,0,0,0.66153,1744.7,2418)"
-       fill="#ffffff"
-       stroke-width="1.5555"
-       id="g4659">
-      <circle
-         cx="1250.9"
-         cy="-2235.8999"
-         r="48.891998"
-         id="circle4641" />
-      <path
-         transform="matrix(0.50694,0,0,0.81777,1045.8,-2785.3)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path4643" />
-      <path
-         transform="matrix(0,-0.50694,0.81777,0,703.96,-2030.8)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path4645" />
-      <path
-         transform="matrix(0,-0.50694,-0.81777,0,1798.5,-2030.8)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path4647" />
-      <path
-         transform="matrix(0.35846,-0.35846,0.57825,0.57825,719.2,-2480)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path4649" />
-      <path
-         transform="matrix(0.35846,0.35846,-0.57825,0.57825,1493.8,-2769.4)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path4651" />
-      <path
-         transform="matrix(-0.35846,0.35846,-0.57825,-0.57825,1783.3,-1995.4)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path4653" />
-      <path
-         transform="matrix(-0.35846,-0.35846,0.57825,-0.57825,1008.7,-1703.6)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path4655" />
-      <path
-         transform="matrix(0.50694,0,0,-0.81777,1045.8,-1690.7)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path4657" />
+    <g transform="matrix(0.66153,0,0,0.66153,1744.7,2418)" fill="#ffffff" stroke-width="1.5555" id="g4659">
+      <circle cx="1250.9" cy="-2235.8999" r="48.891998" id="circle4641"/>
+      <path transform="matrix(0.50694,0,0,0.81777,1045.8,-2785.3)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path4643"/>
+      <path transform="matrix(0,-0.50694,0.81777,0,703.96,-2030.8)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path4645"/>
+      <path transform="matrix(0,-0.50694,-0.81777,0,1798.5,-2030.8)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path4647"/>
+      <path transform="matrix(0.35846,-0.35846,0.57825,0.57825,719.2,-2480)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path4649"/>
+      <path transform="matrix(0.35846,0.35846,-0.57825,0.57825,1493.8,-2769.4)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path4651"/>
+      <path transform="matrix(-0.35846,0.35846,-0.57825,-0.57825,1783.3,-1995.4)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path4653"/>
+      <path transform="matrix(-0.35846,-0.35846,0.57825,-0.57825,1008.7,-1703.6)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path4655"/>
+      <path transform="matrix(0.50694,0,0,-0.81777,1045.8,-1690.7)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path4657"/>
     </g>
-    <rect
-       x="2494.5"
-       y="825.59003"
-       width="226.77"
-       height="226.77"
-       fill="none"
-       id="rect4661" />
-    <path
-       d="m 2643.3,873.73 a 63.779,63.779 0 0 1 63.781,63.778 63.779,63.779 0 0 1 -63.781,63.781 63.779,63.779 0 0 1 -14.065,-1.5711 63.779,63.779 0 0 0 49.718,-62.21 63.779,63.779 0 0 0 -49.713,-62.207 63.779,63.779 0 0 1 14.06,-1.5711 z"
-       fill="#ffffff"
-       stroke-linejoin="round"
-       stroke-miterlimit="1.5"
-       stroke-width="14.173"
-       style="paint-order:markers fill stroke"
-       id="path4663" />
-    <g
-       transform="translate(-1587.4,2040.9)"
-       id="g4669">
-      <path
-         d="m 2772.6,-2561.8 c -9.1356,0 -16.535,7.3995 -16.535,16.535 v 165.35 c 0,9.1356 7.3995,16.535 16.535,16.535 h 124.01 c 9.1357,0 16.535,-7.3995 16.535,-16.535 v -124.34 c 0,-5.5392 -2.1911,-10.458 -5.7046,-14.013 l -37.535,-37.456 c -3.7204,-3.7617 -8.929,-6.0766 -14.634,-6.0766 h -82.675 z m 57.873,28.936 c 0,-4.5471 3.7204,-8.2675 8.2675,-8.2675 4.5472,0 8.2675,3.7204 8.2675,8.2675 v 31.003 c 0,3.431 2.7697,6.2007 6.2007,6.2007 h 31.003 c 4.5472,0 8.2676,3.7204 8.2676,8.2675 0,4.5472 -3.7204,8.2675 -8.2676,8.2675 h -37.204 c -9.1355,0 -16.535,-7.3994 -16.535,-16.535 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4665" />
-      <rect
-         x="2721.3"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4667" />
+    <rect x="2494.5" y="825.59003" width="226.77" height="226.77" fill="none" id="rect4661"/>
+    <path d="m 2643.3,873.73 a 63.779,63.779 0 0 1 63.781,63.778 63.779,63.779 0 0 1 -63.781,63.781 63.779,63.779 0 0 1 -14.065,-1.5711 63.779,63.779 0 0 0 49.718,-62.21 63.779,63.779 0 0 0 -49.713,-62.207 63.779,63.779 0 0 1 14.06,-1.5711 z" fill="#ffffff" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="14.173" style="paint-order:markers fill stroke" id="path4663"/>
+    <g transform="translate(-1587.4,2040.9)" id="g4669">
+      <path d="m 2772.6,-2561.8 c -9.1356,0 -16.535,7.3995 -16.535,16.535 v 165.35 c 0,9.1356 7.3995,16.535 16.535,16.535 h 124.01 c 9.1357,0 16.535,-7.3995 16.535,-16.535 v -124.34 c 0,-5.5392 -2.1911,-10.458 -5.7046,-14.013 l -37.535,-37.456 c -3.7204,-3.7617 -8.929,-6.0766 -14.634,-6.0766 h -82.675 z m 57.873,28.936 c 0,-4.5471 3.7204,-8.2675 8.2675,-8.2675 4.5472,0 8.2675,3.7204 8.2675,8.2675 v 31.003 c 0,3.431 2.7697,6.2007 6.2007,6.2007 h 31.003 c 4.5472,0 8.2676,3.7204 8.2676,8.2675 0,4.5472 -3.7204,8.2675 -8.2676,8.2675 h -37.204 c -9.1355,0 -16.535,-7.3994 -16.535,-16.535 z" fill="#ffffff" opacity="1" id="path4665"/>
+      <rect x="2721.3" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect4667"/>
     </g>
-    <g
-       transform="translate(-2721.3,2040.9)"
-       id="g4675">
-      <rect
-         x="2948"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4671" />
-      <path
-         d="m 3051.2,-2462.6 c 0,-5.6547 4.5893,-10.244 10.244,-10.244 5.6547,0 10.244,4.5893 10.244,10.244 0,5.6547 -4.5893,10.244 -10.244,10.244 -5.6547,0 -10.244,-4.5893 -10.244,-10.244 z m 10.244,-26.634 c -14.71,0 -26.634,11.924 -26.634,26.634 0,14.71 11.924,26.634 26.634,26.634 14.71,0 26.634,-11.924 26.634,-26.634 0,-14.71 -11.924,-26.634 -26.634,-26.634 z m -69.003,46.221 c 1.5571,5.5318 3.7698,10.777 6.5562,15.653 l -12.293,13.44 c -3.5199,3.5239 -3.5199,9.2196 0,12.744 l 13.317,13.317 c 3.5239,3.524 9.2195,3.524 12.744,0 l 13.44,-12.293 c 4.872,2.7864 10.121,4.9991 15.649,6.5562 l 1.1473,18.275 c 0,4.9991 4.0157,9.0147 9.0147,9.0147 h 18.849 c 4.999,0 9.0147,-4.0156 9.0147,-9.0147 l 1.1432,-18.275 c 5.5359,-1.5571 10.781,-3.7698 15.653,-6.5562 l 13.44,12.293 c 3.524,3.524 9.2196,3.524 12.744,0 l 13.317,-13.317 c 3.5199,-3.5239 3.5199,-9.2196 0,-12.744 l -12.293,-13.44 c 2.7863,-4.8762 4.999,-10.121 6.5561,-15.653 l 18.275,-1.1473 c 4.9991,0 9.0147,-4.0156 9.0147,-9.0147 v -18.849 c 0,-4.999 -4.0156,-9.0147 -9.0147,-9.0147 l -18.275,-1.1473 c -1.5571,-5.5318 -3.7698,-10.777 -6.5561,-15.653 l 12.293,-13.44 c 3.5199,-3.5239 3.5199,-9.2196 0,-12.744 l -13.317,-13.317 c -3.524,-3.5239 -9.2196,-3.5239 -12.744,0 l -13.44,12.293 c -4.872,-2.7864 -10.121,-4.9991 -15.653,-6.5562 l -1.1432,-18.275 c 0,-4.999 -4.0157,-9.0147 -9.0147,-9.0147 h -18.849 c -4.999,0 -9.0147,4.0157 -9.0147,9.0147 l -1.1473,18.275 c -5.5318,1.5571 -10.777,3.7698 -15.649,6.5562 l -13.44,-12.293 c -3.524,-3.5239 -9.2196,-3.5239 -12.744,0 l -13.317,13.317 c -3.5199,3.5239 -3.5199,9.2196 0,12.744 l 12.293,13.44 c -2.7864,4.8761 -4.9991,10.121 -6.5562,15.653 l -18.275,1.1473 c -4.9991,0 -9.0147,4.0157 -9.0147,9.0147 v 18.849 c 0,4.9991 4.0156,9.0147 9.0147,9.0147 z m 69.003,-62.611 c 23.766,0 43.025,19.259 43.025,43.025 0,23.766 -19.259,43.025 -43.025,43.025 -23.766,0 -43.025,-19.259 -43.025,-43.025 0,-23.766 19.258,-43.025 43.025,-43.025 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4673" />
+    <g transform="translate(-2721.3,2040.9)" id="g4675">
+      <rect x="2948" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect4671"/>
+      <path d="m 3051.2,-2462.6 c 0,-5.6547 4.5893,-10.244 10.244,-10.244 5.6547,0 10.244,4.5893 10.244,10.244 0,5.6547 -4.5893,10.244 -10.244,10.244 -5.6547,0 -10.244,-4.5893 -10.244,-10.244 z m 10.244,-26.634 c -14.71,0 -26.634,11.924 -26.634,26.634 0,14.71 11.924,26.634 26.634,26.634 14.71,0 26.634,-11.924 26.634,-26.634 0,-14.71 -11.924,-26.634 -26.634,-26.634 z m -69.003,46.221 c 1.5571,5.5318 3.7698,10.777 6.5562,15.653 l -12.293,13.44 c -3.5199,3.5239 -3.5199,9.2196 0,12.744 l 13.317,13.317 c 3.5239,3.524 9.2195,3.524 12.744,0 l 13.44,-12.293 c 4.872,2.7864 10.121,4.9991 15.649,6.5562 l 1.1473,18.275 c 0,4.9991 4.0157,9.0147 9.0147,9.0147 h 18.849 c 4.999,0 9.0147,-4.0156 9.0147,-9.0147 l 1.1432,-18.275 c 5.5359,-1.5571 10.781,-3.7698 15.653,-6.5562 l 13.44,12.293 c 3.524,3.524 9.2196,3.524 12.744,0 l 13.317,-13.317 c 3.5199,-3.5239 3.5199,-9.2196 0,-12.744 l -12.293,-13.44 c 2.7863,-4.8762 4.999,-10.121 6.5561,-15.653 l 18.275,-1.1473 c 4.9991,0 9.0147,-4.0156 9.0147,-9.0147 v -18.849 c 0,-4.999 -4.0156,-9.0147 -9.0147,-9.0147 l -18.275,-1.1473 c -1.5571,-5.5318 -3.7698,-10.777 -6.5561,-15.653 l 12.293,-13.44 c 3.5199,-3.5239 3.5199,-9.2196 0,-12.744 l -13.317,-13.317 c -3.524,-3.5239 -9.2196,-3.5239 -12.744,0 l -13.44,12.293 c -4.872,-2.7864 -10.121,-4.9991 -15.653,-6.5562 l -1.1432,-18.275 c 0,-4.999 -4.0157,-9.0147 -9.0147,-9.0147 h -18.849 c -4.999,0 -9.0147,4.0157 -9.0147,9.0147 l -1.1473,18.275 c -5.5318,1.5571 -10.777,3.7698 -15.649,6.5562 l -13.44,-12.293 c -3.524,-3.5239 -9.2196,-3.5239 -12.744,0 l -13.317,13.317 c -3.5199,3.5239 -3.5199,9.2196 0,12.744 l 12.293,13.44 c -2.7864,4.8761 -4.9991,10.121 -6.5562,15.653 l -18.275,1.1473 c -4.9991,0 -9.0147,4.0157 -9.0147,9.0147 v 18.849 c 0,4.9991 4.0156,9.0147 9.0147,9.0147 z m 69.003,-62.611 c 23.766,0 43.025,19.259 43.025,43.025 0,23.766 -19.259,43.025 -43.025,43.025 -23.766,0 -43.025,-19.259 -43.025,-43.025 0,-23.766 19.258,-43.025 43.025,-43.025 z" fill="#ffffff" opacity="1" id="path4673"/>
     </g>
-    <g
-       transform="translate(-226.77,1814.2)"
-       id="g4681">
-      <path
-         d="m 3189,-2153.1 c 0,9.1359 7.3996,16.536 16.535,16.536 h 165.35 c 9.1358,0 16.535,-7.3996 16.535,-16.536 v -111.61 c 0,-9.1358 -7.3996,-16.536 -16.535,-16.536 h -165.35 c -9.1358,0 -16.535,7.3997 -16.535,16.536 z m 60.85,-55.683 -37.825,-38.073 c -3.1376,-3.1417 -3.1376,-8.2264 0,-11.368 3.1459,-3.1417 8.2305,-3.1417 11.368,0 l 60.358,60.437 c 2.4389,2.3977 6.4529,2.3977 8.8506,0 l 60.433,-60.437 c 3.1418,-3.1417 8.2264,-3.1417 11.368,0 3.1418,3.1417 3.1418,8.2264 0,11.368 l -37.866,38.073 37.866,37.821 c 3.1418,3.1417 3.1418,8.2264 0,11.368 -3.1417,3.1418 -8.2263,3.1418 -11.368,0 l -37.825,-37.784 c 0,0 -11.819,12.03 -13.968,14.179 -3.3525,3.2658 -7.9825,5.2914 -13.022,5.2914 -5.126,0 -9.7559,-2.067 -13.104,-5.4154 -2.1909,-2.1496 -13.931,-14.055 -13.931,-14.055 l -37.788,37.784 c -3.1376,3.1418 -8.2222,3.1418 -11.368,0 -3.1376,-3.1417 -3.1376,-8.2264 0,-11.368 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4677" />
-      <rect
-         x="3174.8"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         rx="1.4398"
-         ry="0.14097001"
-         fill="none"
-         opacity="1"
-         id="rect4679" />
+    <g transform="translate(-226.77,1814.2)" id="g4681">
+      <path d="m 3189,-2153.1 c 0,9.1359 7.3996,16.536 16.535,16.536 h 165.35 c 9.1358,0 16.535,-7.3996 16.535,-16.536 v -111.61 c 0,-9.1358 -7.3996,-16.536 -16.535,-16.536 h -165.35 c -9.1358,0 -16.535,7.3997 -16.535,16.536 z m 60.85,-55.683 -37.825,-38.073 c -3.1376,-3.1417 -3.1376,-8.2264 0,-11.368 3.1459,-3.1417 8.2305,-3.1417 11.368,0 l 60.358,60.437 c 2.4389,2.3977 6.4529,2.3977 8.8506,0 l 60.433,-60.437 c 3.1418,-3.1417 8.2264,-3.1417 11.368,0 3.1418,3.1417 3.1418,8.2264 0,11.368 l -37.866,38.073 37.866,37.821 c 3.1418,3.1417 3.1418,8.2264 0,11.368 -3.1417,3.1418 -8.2263,3.1418 -11.368,0 l -37.825,-37.784 c 0,0 -11.819,12.03 -13.968,14.179 -3.3525,3.2658 -7.9825,5.2914 -13.022,5.2914 -5.126,0 -9.7559,-2.067 -13.104,-5.4154 -2.1909,-2.1496 -13.931,-14.055 -13.931,-14.055 l -37.788,37.784 c -3.1376,3.1418 -8.2222,3.1418 -11.368,0 -3.1376,-3.1417 -3.1376,-8.2264 0,-11.368 z" fill="#ffffff" opacity="1" id="path4677"/>
+      <rect x="3174.8" y="-2349.2" width="226.77" height="226.77" rx="1.4398" ry="0.14097001" fill="none" opacity="1" id="rect4679"/>
     </g>
-    <g
-       transform="translate(-226.77,2040.9)"
-       id="g4687">
-      <path
-         d="m 3614.2,-2475 c 0,-5.7873 -2.3976,-11.037 -6.2421,-14.799 l -78.295,-65.894 c -8.0981,-8.1024 -21.248,-8.1024 -29.35,0 l -78.295,65.894 c -3.8445,3.7619 -6.2421,9.0118 -6.2421,14.799 v 95.12 c 0,9.1358 7.3998,16.535 16.536,16.535 h 165.35 c 9.1358,0 16.535,-7.3996 16.535,-16.535 V -2475 Z m -156.26,-16.494 h 114.09 c 5.0433,0 9.0944,4.0511 9.0944,9.0944 v 15.709 c -0.041,1.9841 -0.8267,3.9271 -2.3562,5.4566 l -25.464,25.671 37.866,37.82 c 3.1417,3.1417 3.1417,8.2264 0,11.368 -3.1419,3.1418 -8.2264,3.1418 -11.368,0 l -38.982,-38.982 h -51.756 l -38.9,38.982 c -3.1416,3.1418 -8.2263,3.1418 -11.368,0 -3.1417,-3.1417 -3.1417,-8.2264 0,-11.368 l 37.825,-37.82 -25.423,-25.671 c -1.6535,-1.6535 -2.4389,-3.8031 -2.3562,-5.9941 v -15.171 c 0,-5.0433 4.0513,-9.0944 9.0945,-9.0944 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4683" />
-      <rect
-         x="3401.6001"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         rx="1.4398"
-         ry="0.14097001"
-         fill="none"
-         opacity="1"
-         id="rect4685" />
+    <g transform="translate(-226.77,2040.9)" id="g4687">
+      <path d="m 3614.2,-2475 c 0,-5.7873 -2.3976,-11.037 -6.2421,-14.799 l -78.295,-65.894 c -8.0981,-8.1024 -21.248,-8.1024 -29.35,0 l -78.295,65.894 c -3.8445,3.7619 -6.2421,9.0118 -6.2421,14.799 v 95.12 c 0,9.1358 7.3998,16.535 16.536,16.535 h 165.35 c 9.1358,0 16.535,-7.3996 16.535,-16.535 V -2475 Z m -156.26,-16.494 h 114.09 c 5.0433,0 9.0944,4.0511 9.0944,9.0944 v 15.709 c -0.041,1.9841 -0.8267,3.9271 -2.3562,5.4566 l -25.464,25.671 37.866,37.82 c 3.1417,3.1417 3.1417,8.2264 0,11.368 -3.1419,3.1418 -8.2264,3.1418 -11.368,0 l -38.982,-38.982 h -51.756 l -38.9,38.982 c -3.1416,3.1418 -8.2263,3.1418 -11.368,0 -3.1417,-3.1417 -3.1417,-8.2264 0,-11.368 l 37.825,-37.82 -25.423,-25.671 c -1.6535,-1.6535 -2.4389,-3.8031 -2.3562,-5.9941 v -15.171 c 0,-5.0433 4.0513,-9.0944 9.0945,-9.0944 z" fill="#ffffff" opacity="1" id="path4683"/>
+      <rect x="3401.6001" y="-2576" width="226.77" height="226.77" rx="1.4398" ry="0.14097001" fill="none" opacity="1" id="rect4685"/>
     </g>
-    <g
-       transform="translate(-2494.5,2040.9)"
-       id="g4693">
-      <rect
-         x="3401.6001"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         rx="1.4398"
-         ry="0.14097001"
-         fill="none"
-         opacity="1"
-         id="rect4689" />
-      <path
-         d="m 3415.7,-2386.1 c 0,5.7047 4.6299,10.335 10.335,10.335 5.002,0 9.177,-3.5551 10.128,-8.2677 h 0.2067 c 0,-4.5473 3.7205,-8.2677 8.2677,-8.2677 4.5473,0 8.2677,3.7204 8.2677,8.2677 v 4.1339 c 0,9.1358 7.3996,16.535 16.536,16.535 h 16.535 c 9.1358,0 16.535,-7.3996 16.535,-16.535 v -62.008 c 0,-9.1359 -7.3996,-16.536 -16.535,-16.536 h -16.535 c -9.1359,0 -16.536,7.3996 -16.536,16.536 v 4.1338 c 0,4.5473 -3.7204,8.2678 -8.2677,8.2678 -4.5472,0 -8.2677,-3.7205 -8.2677,-8.2678 v -24.803 c 0,-43.364 35.179,-78.543 78.543,-78.543 43.364,0 78.543,35.179 78.543,78.543 v 24.803 c 0,4.5473 -3.7205,8.2678 -8.2677,8.2678 -4.5473,0 -8.2677,-3.7205 -8.2677,-8.2678 v -4.1338 c 0,-9.1359 -7.3996,-16.536 -16.536,-16.536 h -16.535 c -9.1358,0 -16.535,7.3996 -16.535,16.536 v 62.008 c 0,9.1358 7.3996,16.535 16.535,16.535 h 16.535 c 9.1359,0 16.536,-7.3996 16.536,-16.535 v -4.1339 c 0,-4.5473 3.7204,-8.2677 8.2677,-8.2677 4.5472,0 8.2677,3.7204 8.2677,8.2677 h 0.2067 c 0.9467,4.7126 5.126,8.2677 10.128,8.2677 5.7047,0 10.335,-4.6299 10.335,-10.335 v -76.476 c 0,-54.815 -44.398,-99.213 -99.213,-99.213 -54.815,0 -99.213,44.398 -99.213,99.213 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4691" />
+    <g transform="translate(-2494.5,2040.9)" id="g4693">
+      <rect x="3401.6001" y="-2576" width="226.77" height="226.77" rx="1.4398" ry="0.14097001" fill="none" opacity="1" id="rect4689"/>
+      <path d="m 3415.7,-2386.1 c 0,5.7047 4.6299,10.335 10.335,10.335 5.002,0 9.177,-3.5551 10.128,-8.2677 h 0.2067 c 0,-4.5473 3.7205,-8.2677 8.2677,-8.2677 4.5473,0 8.2677,3.7204 8.2677,8.2677 v 4.1339 c 0,9.1358 7.3996,16.535 16.536,16.535 h 16.535 c 9.1358,0 16.535,-7.3996 16.535,-16.535 v -62.008 c 0,-9.1359 -7.3996,-16.536 -16.535,-16.536 h -16.535 c -9.1359,0 -16.536,7.3996 -16.536,16.536 v 4.1338 c 0,4.5473 -3.7204,8.2678 -8.2677,8.2678 -4.5472,0 -8.2677,-3.7205 -8.2677,-8.2678 v -24.803 c 0,-43.364 35.179,-78.543 78.543,-78.543 43.364,0 78.543,35.179 78.543,78.543 v 24.803 c 0,4.5473 -3.7205,8.2678 -8.2677,8.2678 -4.5473,0 -8.2677,-3.7205 -8.2677,-8.2678 v -4.1338 c 0,-9.1359 -7.3996,-16.536 -16.536,-16.536 h -16.535 c -9.1358,0 -16.535,7.3996 -16.535,16.536 v 62.008 c 0,9.1358 7.3996,16.535 16.535,16.535 h 16.535 c 9.1359,0 16.536,-7.3996 16.536,-16.535 v -4.1339 c 0,-4.5473 3.7204,-8.2677 8.2677,-8.2677 4.5472,0 8.2677,3.7204 8.2677,8.2677 h 0.2067 c 0.9467,4.7126 5.126,8.2677 10.128,8.2677 5.7047,0 10.335,-4.6299 10.335,-10.335 v -76.476 c 0,-54.815 -44.398,-99.213 -99.213,-99.213 -54.815,0 -99.213,44.398 -99.213,99.213 z" fill="#ffffff" opacity="1" id="path4691"/>
     </g>
-    <g
-       transform="translate(-2267.7,2040.9)"
-       id="g4699">
-      <path
-         d="m 3694.2,-2379.9 c 0,9.1358 7.3996,16.535 16.535,16.535 h 62.008 c 9.1359,0 16.536,-7.3996 16.536,-16.535 v -4.8366 c 0,-3.8858 2.6869,-7.1515 6.3204,-8.0197 19.847,-3.059 35.018,-20.214 35.018,-40.884 0,-9.3012 -3.0591,-17.9 -8.2678,-24.803 v -28.276 c 0,-41.463 -36.088,-75.071 -80.61,-75.071 -44.522,0 -80.61,33.608 -80.61,75.071 v 28.276 c -5.2086,6.9036 -8.2677,15.502 -8.2677,24.803 0,20.67 15.171,37.825 35.014,40.884 3.6378,0.8682 6.3247,4.1339 6.3247,8.0197 z m -8.2676,-82.677 c 0,-11.41 9.2598,-20.669 20.669,-20.669 11.4092,0 20.669,9.2598 20.669,20.669 0,11.409 -9.2599,20.669 -20.669,20.669 -11.4091,0 -20.669,-9.2598 -20.669,-20.669 z m 70.276,0 c 0,-11.41 9.2599,-20.669 20.669,-20.669 11.4091,0 20.669,9.2598 20.669,20.669 0,11.409 -9.2598,20.669 -20.669,20.669 -11.4092,0 -20.669,-9.2598 -20.669,-20.669 z m -34.853,44.15 14.555,-14.551 c 3.2247,-3.2244 8.4333,-3.2244 11.658,0 l 14.551,14.551 c 3.1417,3.1417 3.1417,8.2264 0,11.368 -3.1417,3.1416 -8.2263,3.1417 -11.368,0 l -9.0117,-9.0118 -9.0161,9.0118 c -3.1378,3.1417 -8.2225,3.1417 -11.368,0 -3.1333,-3.1417 -3.1333,-8.2264 0,-11.368 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4695" />
-      <rect
-         x="3628.3"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4697" />
+    <g transform="translate(-2267.7,2040.9)" id="g4699">
+      <path d="m 3694.2,-2379.9 c 0,9.1358 7.3996,16.535 16.535,16.535 h 62.008 c 9.1359,0 16.536,-7.3996 16.536,-16.535 v -4.8366 c 0,-3.8858 2.6869,-7.1515 6.3204,-8.0197 19.847,-3.059 35.018,-20.214 35.018,-40.884 0,-9.3012 -3.0591,-17.9 -8.2678,-24.803 v -28.276 c 0,-41.463 -36.088,-75.071 -80.61,-75.071 -44.522,0 -80.61,33.608 -80.61,75.071 v 28.276 c -5.2086,6.9036 -8.2677,15.502 -8.2677,24.803 0,20.67 15.171,37.825 35.014,40.884 3.6378,0.8682 6.3247,4.1339 6.3247,8.0197 z m -8.2676,-82.677 c 0,-11.41 9.2598,-20.669 20.669,-20.669 11.4092,0 20.669,9.2598 20.669,20.669 0,11.409 -9.2599,20.669 -20.669,20.669 -11.4091,0 -20.669,-9.2598 -20.669,-20.669 z m 70.276,0 c 0,-11.41 9.2599,-20.669 20.669,-20.669 11.4091,0 20.669,9.2598 20.669,20.669 0,11.409 -9.2598,20.669 -20.669,20.669 -11.4092,0 -20.669,-9.2598 -20.669,-20.669 z m -34.853,44.15 14.555,-14.551 c 3.2247,-3.2244 8.4333,-3.2244 11.658,0 l 14.551,14.551 c 3.1417,3.1417 3.1417,8.2264 0,11.368 -3.1417,3.1416 -8.2263,3.1417 -11.368,0 l -9.0117,-9.0118 -9.0161,9.0118 c -3.1378,3.1417 -8.2225,3.1417 -11.368,0 -3.1333,-3.1417 -3.1333,-8.2264 0,-11.368 z" fill="#ffffff" opacity="1" id="path4695"/>
+      <rect x="3628.3" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect4697"/>
     </g>
-    <g
-       transform="translate(-1587.4,1814.2)"
-       id="g4705">
-      <path
-         d="m 3968.5,-2268.9 c -6.0849,0 -11.023,4.9383 -11.023,11.023 0,6.0847 4.9382,11.023 11.023,11.023 h 11.023 v 11.023 c 0,6.0848 4.9383,11.023 11.023,11.023 6.0847,0 11.023,-4.9382 11.023,-11.023 v -11.023 h 11.023 c 6.0846,0 11.023,-4.9384 11.023,-11.023 0,-6.0846 -4.9384,-11.023 -11.023,-11.023 h -11.023 v -11.023 c 0,-6.0847 -4.9382,-11.023 -11.023,-11.023 -6.0848,0 -11.023,4.9384 -11.023,11.023 v 11.023 z m -94.092,102.38 c -6.8385,6.8342 -6.8385,17.945 0,24.78 6.8343,6.8343 17.946,6.8343 24.731,0 l 50.662,-50.618 c 11.817,7.3635 25.75,11.64 40.741,11.64 42.637,0 77.161,-34.524 77.161,-77.161 0,-42.637 -34.524,-77.161 -77.161,-77.161 -42.637,0 -77.161,34.524 -77.161,77.161 0,14.947 4.2771,28.924 11.64,40.741 z m 61.024,-91.359 c 0,-30.424 24.691,-55.115 55.115,-55.115 30.423,0 55.115,24.691 55.115,55.115 0,30.424 -24.692,55.115 -55.115,55.115 -30.424,0 -55.115,-24.692 -55.115,-55.115 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4701" />
-      <rect
-         x="3855.1001"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4703" />
+    <g transform="translate(-1587.4,1814.2)" id="g4705">
+      <path d="m 3968.5,-2268.9 c -6.0849,0 -11.023,4.9383 -11.023,11.023 0,6.0847 4.9382,11.023 11.023,11.023 h 11.023 v 11.023 c 0,6.0848 4.9383,11.023 11.023,11.023 6.0847,0 11.023,-4.9382 11.023,-11.023 v -11.023 h 11.023 c 6.0846,0 11.023,-4.9384 11.023,-11.023 0,-6.0846 -4.9384,-11.023 -11.023,-11.023 h -11.023 v -11.023 c 0,-6.0847 -4.9382,-11.023 -11.023,-11.023 -6.0848,0 -11.023,4.9384 -11.023,11.023 v 11.023 z m -94.092,102.38 c -6.8385,6.8342 -6.8385,17.945 0,24.78 6.8343,6.8343 17.946,6.8343 24.731,0 l 50.662,-50.618 c 11.817,7.3635 25.75,11.64 40.741,11.64 42.637,0 77.161,-34.524 77.161,-77.161 0,-42.637 -34.524,-77.161 -77.161,-77.161 -42.637,0 -77.161,34.524 -77.161,77.161 0,14.947 4.2771,28.924 11.64,40.741 z m 61.024,-91.359 c 0,-30.424 24.691,-55.115 55.115,-55.115 30.423,0 55.115,24.691 55.115,55.115 0,30.424 -24.692,55.115 -55.115,55.115 -30.424,0 -55.115,-24.692 -55.115,-55.115 z" fill="#ffffff" opacity="1" id="path4701"/>
+      <rect x="3855.1001" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect4703"/>
     </g>
-    <g
-       transform="translate(-1360.6,1814.2)"
-       id="g4711">
-      <path
-         d="m 4222.4,-2282.1 c 9.5238,2.2046 17.103,10.318 19.308,19.18 0.754,4.1447 4.3651,7.2752 8.6905,7.2752 4.8501,0 8.8184,-3.9682 8.8184,-8.8184 0,-6.3492 -5.3351,-16.005 -12.61,-23.236 -7.1428,-7.0546 -15.652,-12.037 -22.663,-12.037 -4.8502,0 -8.8184,4.1005 -8.8184,8.9506 0,4.3211 3.1305,7.9365 7.2752,8.6861 z m -121.21,115.61 c -6.8342,6.8342 -6.8342,17.945 0,24.78 6.8342,6.835 17.945,6.8342 24.736,0 l 50.661,-50.617 c 11.817,7.3634 25.75,11.64 40.741,11.64 42.637,0 77.161,-34.524 77.161,-77.161 0,-42.637 -34.524,-77.161 -77.161,-77.161 -42.637,0 -77.161,34.524 -77.161,77.161 0,14.947 4.2767,28.924 11.64,40.741 z m 61.023,-91.358 c 0,-30.423 24.691,-55.115 55.115,-55.115 30.424,0 55.115,24.691 55.115,55.115 0,30.424 -24.691,55.115 -55.115,55.115 -30.424,0 -55.115,-24.691 -55.115,-55.115 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4707" />
-      <rect
-         x="4081.8999"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4709" />
+    <g transform="translate(-1360.6,1814.2)" id="g4711">
+      <path d="m 4222.4,-2282.1 c 9.5238,2.2046 17.103,10.318 19.308,19.18 0.754,4.1447 4.3651,7.2752 8.6905,7.2752 4.8501,0 8.8184,-3.9682 8.8184,-8.8184 0,-6.3492 -5.3351,-16.005 -12.61,-23.236 -7.1428,-7.0546 -15.652,-12.037 -22.663,-12.037 -4.8502,0 -8.8184,4.1005 -8.8184,8.9506 0,4.3211 3.1305,7.9365 7.2752,8.6861 z m -121.21,115.61 c -6.8342,6.8342 -6.8342,17.945 0,24.78 6.8342,6.835 17.945,6.8342 24.736,0 l 50.661,-50.617 c 11.817,7.3634 25.75,11.64 40.741,11.64 42.637,0 77.161,-34.524 77.161,-77.161 0,-42.637 -34.524,-77.161 -77.161,-77.161 -42.637,0 -77.161,34.524 -77.161,77.161 0,14.947 4.2767,28.924 11.64,40.741 z m 61.023,-91.358 c 0,-30.423 24.691,-55.115 55.115,-55.115 30.424,0 55.115,24.691 55.115,55.115 0,30.424 -24.691,55.115 -55.115,55.115 -30.424,0 -55.115,-24.691 -55.115,-55.115 z" fill="#ffffff" opacity="1" id="path4707"/>
+      <rect x="4081.8999" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect4709"/>
     </g>
-    <g
-       transform="translate(-1814.2,1814.2)"
-       id="g4717">
-      <path
-         d="m 4422.1,-2268.9 c -6.0846,0 -11.023,4.9383 -11.023,11.023 0,6.0847 4.9385,11.023 11.023,11.023 h 44.092 c 6.0848,0 11.023,-4.9383 11.023,-11.023 0,-6.0846 -4.9383,-11.023 -11.023,-11.023 z m -94.092,102.38 c -6.8387,6.8342 -6.8387,17.946 0,24.78 6.8344,6.8342 17.946,6.8342 24.731,0 l 50.662,-50.618 c 11.817,7.3635 25.75,11.64 40.741,11.64 42.637,0 77.161,-34.524 77.161,-77.161 0,-42.637 -34.524,-77.161 -77.161,-77.161 -42.637,0 -77.161,34.524 -77.161,77.161 0,14.947 4.2769,28.924 11.64,40.741 z m 61.023,-91.359 c 0,-30.424 24.692,-55.115 55.115,-55.115 30.423,0 55.115,24.692 55.115,55.115 0,30.424 -24.692,55.115 -55.115,55.115 -30.424,0 -55.115,-24.692 -55.115,-55.115 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4713" />
-      <rect
-         x="4308.7002"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4715" />
+    <g transform="translate(-1814.2,1814.2)" id="g4717">
+      <path d="m 4422.1,-2268.9 c -6.0846,0 -11.023,4.9383 -11.023,11.023 0,6.0847 4.9385,11.023 11.023,11.023 h 44.092 c 6.0848,0 11.023,-4.9383 11.023,-11.023 0,-6.0846 -4.9383,-11.023 -11.023,-11.023 z m -94.092,102.38 c -6.8387,6.8342 -6.8387,17.946 0,24.78 6.8344,6.8342 17.946,6.8342 24.731,0 l 50.662,-50.618 c 11.817,7.3635 25.75,11.64 40.741,11.64 42.637,0 77.161,-34.524 77.161,-77.161 0,-42.637 -34.524,-77.161 -77.161,-77.161 -42.637,0 -77.161,34.524 -77.161,77.161 0,14.947 4.2769,28.924 11.64,40.741 z m 61.023,-91.359 c 0,-30.424 24.692,-55.115 55.115,-55.115 30.423,0 55.115,24.692 55.115,55.115 0,30.424 -24.692,55.115 -55.115,55.115 -30.424,0 -55.115,-24.692 -55.115,-55.115 z" fill="#ffffff" opacity="1" id="path4713"/>
+      <rect x="4308.7002" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect4715"/>
     </g>
-    <g
-       transform="translate(-2948,1587.4)"
-       id="g4723">
-      <rect
-         x="4762.2002"
-         y="-2122.3999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4719" />
-      <path
-         d="m 4825.5,-1967.7 52.541,51.342 c 1.4881,1.4883 3.555,2.3977 5.8286,2.3977 4.5472,0 8.2676,-3.6791 8.2676,-8.185 v -173.79 c 0,-4.5058 -3.7204,-8.1849 -8.2676,-8.1849 -2.3191,0 -4.4232,0.9508 -5.9154,2.4802 l -52.417,51.259 h -32.616 c -9.1358,0 -16.535,7.3996 -16.535,16.535 v 49.606 c 0,9.1358 7.3995,16.535 16.535,16.535 z m 113.14,-92.101 c -3.9685,3.9271 -3.9685,10.335 0,14.303 9.8385,9.8797 15.952,23.48 15.952,38.527 0,15.047 -6.1552,28.647 -15.994,38.527 -3.9725,3.9684 -3.9725,10.376 0,14.303 3.923,3.9685 10.335,3.9685 14.303,0 13.518,-13.522 21.909,-32.202 21.909,-52.83 0,-20.586 -8.3089,-39.23 -21.785,-52.747 l -0.083,-0.083 c -3.9643,-3.9684 -10.33,-3.9684 -14.299,0 z m -8.557,82.8 c 7.6475,-7.6889 12.36,-18.272 12.36,-29.97 0,-11.699 -4.7167,-22.281 -12.36,-29.97 -3.9684,-3.9684 -10.376,-3.9684 -14.303,0 -3.9684,3.9271 -3.9684,10.334 0,14.303 3.9685,4.0099 6.4488,9.5492 6.4488,15.667 0,6.1181 -2.4803,11.657 -6.4488,15.667 -3.9684,3.9685 -3.9684,10.334 0,14.303 3.9272,3.9271 10.335,3.9685 14.303,0 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4721" />
+    <g transform="translate(-2948,1587.4)" id="g4723">
+      <rect x="4762.2002" y="-2122.3999" width="226.77" height="226.77" fill="none" opacity="1" id="rect4719"/>
+      <path d="m 4825.5,-1967.7 52.541,51.342 c 1.4881,1.4883 3.555,2.3977 5.8286,2.3977 4.5472,0 8.2676,-3.6791 8.2676,-8.185 v -173.79 c 0,-4.5058 -3.7204,-8.1849 -8.2676,-8.1849 -2.3191,0 -4.4232,0.9508 -5.9154,2.4802 l -52.417,51.259 h -32.616 c -9.1358,0 -16.535,7.3996 -16.535,16.535 v 49.606 c 0,9.1358 7.3995,16.535 16.535,16.535 z m 113.14,-92.101 c -3.9685,3.9271 -3.9685,10.335 0,14.303 9.8385,9.8797 15.952,23.48 15.952,38.527 0,15.047 -6.1552,28.647 -15.994,38.527 -3.9725,3.9684 -3.9725,10.376 0,14.303 3.923,3.9685 10.335,3.9685 14.303,0 13.518,-13.522 21.909,-32.202 21.909,-52.83 0,-20.586 -8.3089,-39.23 -21.785,-52.747 l -0.083,-0.083 c -3.9643,-3.9684 -10.33,-3.9684 -14.299,0 z m -8.557,82.8 c 7.6475,-7.6889 12.36,-18.272 12.36,-29.97 0,-11.699 -4.7167,-22.281 -12.36,-29.97 -3.9684,-3.9684 -10.376,-3.9684 -14.303,0 -3.9684,3.9271 -3.9684,10.334 0,14.303 3.9685,4.0099 6.4488,9.5492 6.4488,15.667 0,6.1181 -2.4803,11.657 -6.4488,15.667 -3.9684,3.9685 -3.9684,10.334 0,14.303 3.9272,3.9271 10.335,3.9685 14.303,0 z" fill="#ffffff" opacity="1" id="path4721"/>
     </g>
-    <g
-       transform="translate(-2948,1587.4)"
-       id="g4729">
-      <rect
-         x="4989"
-         y="-2122.3999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4725" />
-      <path
-         d="m 5062.7,-1985.1 c -5.2916,-2.6015 -11.288,-4.1008 -17.638,-4.1008 -21.915,0 -39.685,17.77 -39.685,39.685 0,21.915 17.77,39.685 39.685,39.685 21.915,0 39.685,-17.77 39.685,-39.685 v -88.189 c 0,-4.8504 3.9686,-8.819 8.819,-8.819 h 74.961 c 4.8504,0 8.8188,3.9686 8.8188,8.819 v 52.605 c -5.2915,-2.6015 -11.288,-4.1008 -17.638,-4.1008 -21.915,0 -39.685,17.77 -39.685,39.685 0,21.915 17.77,39.685 39.685,39.685 21.915,0 39.685,-17.77 39.685,-39.685 v -149.04 c 0,-5.3795 -4.3213,-9.7008 -9.701,-9.7008 h -117.29 c -5.3794,0 -9.7009,4.3213 -9.7009,9.7008 v 113.46 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4727" />
+    <g transform="translate(-2948,1587.4)" id="g4729">
+      <rect x="4989" y="-2122.3999" width="226.77" height="226.77" fill="none" opacity="1" id="rect4725"/>
+      <path d="m 5062.7,-1985.1 c -5.2916,-2.6015 -11.288,-4.1008 -17.638,-4.1008 -21.915,0 -39.685,17.77 -39.685,39.685 0,21.915 17.77,39.685 39.685,39.685 21.915,0 39.685,-17.77 39.685,-39.685 v -88.189 c 0,-4.8504 3.9686,-8.819 8.819,-8.819 h 74.961 c 4.8504,0 8.8188,3.9686 8.8188,8.819 v 52.605 c -5.2915,-2.6015 -11.288,-4.1008 -17.638,-4.1008 -21.915,0 -39.685,17.77 -39.685,39.685 0,21.915 17.77,39.685 39.685,39.685 21.915,0 39.685,-17.77 39.685,-39.685 v -149.04 c 0,-5.3795 -4.3213,-9.7008 -9.701,-9.7008 h -117.29 c -5.3794,0 -9.7009,4.3213 -9.7009,9.7008 v 113.46 z" fill="#ffffff" opacity="1" id="path4727"/>
     </g>
-    <g
-       transform="translate(-2948,1587.4)"
-       id="g4735">
-      <rect
-         x="4535.3999"
-         y="-2122.3999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4731" />
-      <path
-         d="m 4639.7,-1965.9 54.826,53.575 c 1.5528,1.5529 3.7096,2.5019 6.082,2.5019 4.7451,0 8.6272,-3.8392 8.6272,-8.5409 v -181.34 c 0,-4.7018 -3.8821,-8.5408 -8.6272,-8.5408 -2.4199,0 -4.6155,0.992 -6.1726,2.5881 l -54.696,53.489 h -34.034 c -9.533,0 -17.254,7.7213 -17.254,17.254 v 51.763 c 0,9.533 7.7213,17.254 17.254,17.254 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path4733" />
+    <g transform="translate(-2948,1587.4)" id="g4735">
+      <rect x="4535.3999" y="-2122.3999" width="226.77" height="226.77" fill="none" opacity="1" id="rect4731"/>
+      <path d="m 4639.7,-1965.9 54.826,53.575 c 1.5528,1.5529 3.7096,2.5019 6.082,2.5019 4.7451,0 8.6272,-3.8392 8.6272,-8.5409 v -181.34 c 0,-4.7018 -3.8821,-8.5408 -8.6272,-8.5408 -2.4199,0 -4.6155,0.992 -6.1726,2.5881 l -54.696,53.489 h -34.034 c -9.533,0 -17.254,7.7213 -17.254,17.254 v 51.763 c 0,9.533 7.7213,17.254 17.254,17.254 z" fill="#ffffff" opacity="1" id="path4733"/>
     </g>
-    <g
-       transform="translate(2267.7,-453.54)"
-       id="g4747">
-      <g
-         transform="matrix(7.493,0,0,7.493,-721.3,-1504.2)"
-         id="g4743">
-        <circle
-           transform="rotate(-28.358)"
-           cx="251.96001"
-           cy="92.245003"
-           r="6.5830002"
-           fill="#ffffff"
-           opacity="1"
-           id="circle4737" />
-        <ellipse
-           transform="rotate(-28.358)"
-           cx="249.02"
-           cy="92.245003"
-           rx="12.853"
-           ry="9.9139004"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="1.5013"
-           id="ellipse4739" />
-        <circle
-           transform="rotate(-28.358)"
-           cx="236.78"
-           cy="93.389999"
-           r="3.2507"
-           fill="#ffffff"
-           opacity="1"
-           id="circle4741" />
+    <g transform="translate(2267.7,-453.54)" id="g4747">
+      <g transform="matrix(7.493,0,0,7.493,-721.3,-1504.2)" id="g4743">
+        <circle transform="rotate(-28.358)" cx="251.96001" cy="92.245003" r="6.5830002" fill="#ffffff" opacity="1" id="circle4737"/>
+        <ellipse transform="rotate(-28.358)" cx="249.02" cy="92.245003" rx="12.853" ry="9.9139004" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5013" id="ellipse4739"/>
+        <circle transform="rotate(-28.358)" cx="236.78" cy="93.389999" r="3.2507" fill="#ffffff" opacity="1" id="circle4741"/>
       </g>
-      <rect
-         x="1133.9"
-         y="-1895.7"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4745" />
+      <rect x="1133.9" y="-1895.7" width="226.77" height="226.77" fill="none" opacity="1" id="rect4745"/>
     </g>
-    <g
-       transform="translate(3855.1,1.3511e-4)"
-       id="g4767">
-      <g
-         transform="matrix(-3.5486,0.95084,0.95926,3.58,-2012.4,-7183.7)"
-         opacity="1"
-         id="g4763">
-        <g
-           transform="matrix(0.96593,-0.25655,0.26111,0.96593,-364.08,160.63)"
-           fill="#ffffff"
-           id="g4757">
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="9.8042002"
-             rx="4.7266998"
-             ry="3.8506"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4749" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="12.929"
-             rx="4.7266998"
-             ry="3.8506"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4751" />
-          <path
-             d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="5.3843"
-             id="path4753" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="5.6332002"
-             rx="4.7266998"
-             ry="3.8506"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4755" />
+    <g transform="translate(3855.1,1.3511e-4)" id="g4767">
+      <g transform="matrix(-3.5486,0.95084,0.95926,3.58,-2012.4,-7183.7)" opacity="1" id="g4763">
+        <g transform="matrix(0.96593,-0.25655,0.26111,0.96593,-364.08,160.63)" fill="#ffffff" id="g4757">
+          <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="4.7266998" ry="3.8506" fill-opacity="0.32727" opacity="1" id="rect4749"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="4.7266998" ry="3.8506" fill-opacity="0.32727" opacity="1" id="rect4751"/>
+          <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.3843" id="path4753"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="4.7266998" ry="3.8506" fill-opacity="0.32727" opacity="1" id="rect4755"/>
         </g>
-        <g
-           transform="matrix(2.3205,-0.61633,0.62713,2.3199,-1521.6,-1668)"
-           id="g4761">
-          <path
-             transform="scale(-1,1)"
-             d="m -453.33,1467.7 h -3.7462 v -11.878 h 20.988 v 11.878 h -3.7462"
-             fill="none"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="1.4943"
-             id="path4759" />
+        <g transform="matrix(2.3205,-0.61633,0.62713,2.3199,-1521.6,-1668)" id="g4761">
+          <path transform="scale(-1,1)" d="m -453.33,1467.7 h -3.7462 v -11.878 h 20.988 v 11.878 h -3.7462" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.4943" id="path4759"/>
         </g>
       </g>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4765" />
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect4765"/>
     </g>
-    <g
-       transform="translate(3401.6,3.5111e-5)"
-       id="g4787">
-      <g
-         transform="matrix(-5.8137,1.5621,1.5716,5.8815,-1649.3,-10871)"
-         opacity="1"
-         id="g4783">
-        <g
-           transform="matrix(0.96593,-0.25655,0.26111,0.96593,-364.08,160.63)"
-           fill="#ffffff"
-           id="g4777">
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="9.8042002"
-             rx="2.6368999"
-             ry="2.1422"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4769" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="12.929"
-             rx="2.6368999"
-             ry="2.1422"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4771" />
-          <path
-             d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="2.9995"
-             id="path4773" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="5.6332002"
-             rx="2.6368999"
-             ry="2.1422"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4775" />
+    <g transform="translate(3401.6,3.5111e-5)" id="g4787">
+      <g transform="matrix(-5.8137,1.5621,1.5716,5.8815,-1649.3,-10871)" opacity="1" id="g4783">
+        <g transform="matrix(0.96593,-0.25655,0.26111,0.96593,-364.08,160.63)" fill="#ffffff" id="g4777">
+          <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="2.6368999" ry="2.1422" fill-opacity="0.32727" opacity="1" id="rect4769"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="2.6368999" ry="2.1422" fill-opacity="0.32727" opacity="1" id="rect4771"/>
+          <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.9995" id="path4773"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="2.6368999" ry="2.1422" fill-opacity="0.32727" opacity="1" id="rect4775"/>
         </g>
-        <g
-           transform="matrix(0.96593,-0.25655,0.26111,0.96593,-370.54,136.75)"
-           id="g4781">
-          <path
-             d="m 445.05,1486.1 5.0988,-5.0541 5.1785,5.133 m -5.2183,17.489 v -20.569"
-             fill="none"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="1.9997"
-             id="path4779" />
+        <g transform="matrix(0.96593,-0.25655,0.26111,0.96593,-370.54,136.75)" id="g4781">
+          <path d="m 445.05,1486.1 5.0988,-5.0541 5.1785,5.133 m -5.2183,17.489 v -20.569" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.9997" id="path4779"/>
         </g>
       </g>
-      <rect
-         x="-2040.9"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4785" />
+      <rect x="-2040.9" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect4785"/>
     </g>
-    <g
-       transform="translate(3628.3,8.0887e-5)"
-       id="g4811">
-      <g
-         transform="matrix(-5.2023,1.3744,1.4063,5.1749,-1493,-9727)"
-         opacity="1"
-         id="g4807">
-        <g
-           transform="matrix(0.96593,-0.25655,0.26111,0.96593,-364.08,160.63)"
-           fill="#ffffff"
-           id="g4797">
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="9.8042002"
-             rx="3.4237001"
-             ry="2.8287001"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4789" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="12.929"
-             rx="3.4237001"
-             ry="2.8287001"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4791" />
-          <path
-             d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="3.9276"
-             id="path4793" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="5.6332002"
-             rx="3.4237001"
-             ry="2.8287001"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4795" />
+    <g transform="translate(3628.3,8.0887e-5)" id="g4811">
+      <g transform="matrix(-5.2023,1.3744,1.4063,5.1749,-1493,-9727)" opacity="1" id="g4807">
+        <g transform="matrix(0.96593,-0.25655,0.26111,0.96593,-364.08,160.63)" fill="#ffffff" id="g4797">
+          <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="3.4237001" ry="2.8287001" fill-opacity="0.32727" opacity="1" id="rect4789"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="3.4237001" ry="2.8287001" fill-opacity="0.32727" opacity="1" id="rect4791"/>
+          <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.9276" id="path4793"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="3.4237001" ry="2.8287001" fill-opacity="0.32727" opacity="1" id="rect4795"/>
         </g>
-        <g
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           id="g4805">
-          <path
-             transform="matrix(-0.96649,0.2567,0.26096,0.96535,0,0)"
-             d="m -53.619,1517.3 a 17.283,16.701 0 0 1 14.968,-8.3503 17.283,16.701 0 0 1 14.968,8.3503"
-             opacity="1"
-             stroke-width="2.6184"
-             id="path4799" />
-          <path
-             d="m 448.45,1447.4 0.28341,4.5213 -4.9933,0.3579"
-             opacity="1"
-             stroke-width="2.6184"
-             id="path4801" />
-          <path
-             d="m 416.25,1455.9 2.0352,4.0561 4.1892,-2.0132"
-             opacity="1"
-             stroke-width="2.6184"
-             id="path4803" />
+        <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" id="g4805">
+          <path transform="matrix(-0.96649,0.2567,0.26096,0.96535,0,0)" d="m -53.619,1517.3 a 17.283,16.701 0 0 1 14.968,-8.3503 17.283,16.701 0 0 1 14.968,8.3503" opacity="1" stroke-width="2.6184" id="path4799"/>
+          <path d="m 448.45,1447.4 0.28341,4.5213 -4.9933,0.3579" opacity="1" stroke-width="2.6184" id="path4801"/>
+          <path d="m 416.25,1455.9 2.0352,4.0561 4.1892,-2.0132" opacity="1" stroke-width="2.6184" id="path4803"/>
         </g>
       </g>
-      <rect
-         x="-1814.2"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4809" />
+      <rect x="-1814.2" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect4809"/>
     </g>
-    <g
-       transform="translate(907.09,3.5111e-5)"
-       id="g4847">
-      <g
-         transform="matrix(-7.145,0,0,7.1312,3428.5,-12025)"
-         fill="#ffffff"
-         opacity="1"
-         id="g4821">
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="9.8042002"
-           rx="2.5987999"
-           ry="2.1424999"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4813" />
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="12.929"
-           rx="2.5987999"
-           ry="2.1424999"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4815" />
-        <path
-           d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.978"
-           id="path4817" />
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="5.6332002"
-           rx="2.5987999"
-           ry="2.1424999"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4819" />
+    <g transform="translate(907.09,3.5111e-5)" id="g4847">
+      <g transform="matrix(-7.145,0,0,7.1312,3428.5,-12025)" fill="#ffffff" opacity="1" id="g4821">
+        <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="2.5987999" ry="2.1424999" fill-opacity="0.32727" opacity="1" id="rect4813"/>
+        <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="2.5987999" ry="2.1424999" fill-opacity="0.32727" opacity="1" id="rect4815"/>
+        <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.978" id="path4817"/>
+        <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="2.5987999" ry="2.1424999" fill-opacity="0.32727" opacity="1" id="rect4819"/>
       </g>
-      <rect
-         x="226.77"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4823" />
-      <g
-         transform="matrix(7.0861,0,0,7.0861,-3246.4,-11968)"
-         id="g4843">
-        <g
-           transform="matrix(0.52453,0,0,0.52312,247.23,700.97)"
-           fill="#ffffff"
-           opacity="1"
-           id="g4833">
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="9.8042002"
-             rx="2.8375001"
-             ry="2.8375001"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4825" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="12.929"
-             rx="2.8673"
-             ry="2.8673"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4827" />
-          <path
-             d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="5.7271"
-             id="path4829" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="5.6332002"
-             rx="2.8166001"
-             ry="2.8166001"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4831" />
+      <rect x="226.77" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect4823"/>
+      <g transform="matrix(7.0861,0,0,7.0861,-3246.4,-11968)" id="g4843">
+        <g transform="matrix(0.52453,0,0,0.52312,247.23,700.97)" fill="#ffffff" opacity="1" id="g4833">
+          <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="2.8375001" ry="2.8375001" fill-opacity="0.32727" opacity="1" id="rect4825"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="2.8673" ry="2.8673" fill-opacity="0.32727" opacity="1" id="rect4827"/>
+          <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.7271" id="path4829"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="2.8166001" ry="2.8166001" fill-opacity="0.32727" opacity="1" id="rect4831"/>
         </g>
-        <g
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="3"
-           id="g4841">
-          <path
-             d="m 480.39,1480.3 a 12.501,12.501 0 0 1 -15.09,-1.9867 12.501,12.501 0 0 1 -1.9867,-15.09 12.501,12.501 0 0 1 14.062,-5.8247 12.501,12.501 0 0 1 9.2658,12.075"
-             opacity="1"
-             stroke-opacity="0.32549"
-             id="path4835" />
-          <path
-             d="m 463.31,1475.7 a 12.501,12.501 0 0 1 1.2499,-14.286 12.501,12.501 0 0 1 13.852,-3.7117 12.501,12.501 0 0 1 8.2256,11.747"
-             opacity="1"
-             id="path4837" />
-          <path
-             d="m 467.89,1480.3 a 12.501,12.501 0 0 1 -5.4968,-15.102 12.501,12.501 0 0 1 13.918,-8.0357 12.501,12.501 0 0 1 10.331,12.311"
-             opacity="1"
-             stroke-opacity="0.54546"
-             id="path4839" />
+        <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" id="g4841">
+          <path d="m 480.39,1480.3 a 12.501,12.501 0 0 1 -15.09,-1.9867 12.501,12.501 0 0 1 -1.9867,-15.09 12.501,12.501 0 0 1 14.062,-5.8247 12.501,12.501 0 0 1 9.2658,12.075" opacity="1" stroke-opacity="0.32549" id="path4835"/>
+          <path d="m 463.31,1475.7 a 12.501,12.501 0 0 1 1.2499,-14.286 12.501,12.501 0 0 1 13.852,-3.7117 12.501,12.501 0 0 1 8.2256,11.747" opacity="1" id="path4837"/>
+          <path d="m 467.89,1480.3 a 12.501,12.501 0 0 1 -5.4968,-15.102 12.501,12.501 0 0 1 13.918,-8.0357 12.501,12.501 0 0 1 10.331,12.311" opacity="1" stroke-opacity="0.54546" id="path4839"/>
         </g>
       </g>
-      <rect
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4845"
-         x="0" />
+      <rect y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect4845" x="0"/>
     </g>
-    <g
-       transform="translate(4308.7,-226.77)"
-       id="g4859">
-      <g
-         transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)"
-         id="g4855">
-        <circle
-           cx="26.16"
-           cy="1317.3"
-           r="3.7282"
-           fill="#ffffff"
-           opacity="1"
-           id="circle4849" />
-        <circle
-           cx="26.216"
-           cy="1317.3"
-           r="11.232"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.1816"
-           id="circle4851" />
-        <path
-           d="M 19.287,1317.2 H 33.305"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.1816"
-           id="path4853" />
+    <g transform="translate(4308.7,-226.77)" id="g4859">
+      <g transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)" id="g4855">
+        <circle cx="26.16" cy="1317.3" r="3.7282" fill="#ffffff" opacity="1" id="circle4849"/>
+        <circle cx="26.216" cy="1317.3" r="11.232" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1816" id="circle4851"/>
+        <path d="M 19.287,1317.2 H 33.305" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1816" id="path4853"/>
       </g>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4857" />
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect4857"/>
     </g>
-    <g
-       transform="translate(4308.7,-226.77)"
-       id="g4877">
-      <g
-         transform="matrix(8.0515,0,0,8.0515,-2592.2,-12162)"
-         id="g4873">
-        <circle
-           cx="26.216"
-           cy="1317.3"
-           r="11.232"
-           fill="none"
-           opacity="1"
-           stroke="#212121"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-opacity="0.46046"
-           stroke-width="2.1816"
-           id="circle4861" />
-        <circle
-           cx="26.16"
-           cy="1317.3"
-           r="3.7282"
-           fill="#ffffff"
-           opacity="1"
-           id="circle4863" />
-        <g
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.1816"
-           id="g4871">
-          <path
-             d="m 35.943,1311.7 a 11.232,11.232 0 0 1 0,11.232"
-             opacity="1"
-             id="path4865" />
-          <path
-             d="M 19.287,1317.2 H 33.305"
-             opacity="1"
-             id="path4867" />
-          <path
-             d="m 16.489,1322.9 a 11.232,11.232 0 0 1 0,-11.232"
-             opacity="1"
-             id="path4869" />
+    <g transform="translate(4308.7,-226.77)" id="g4877">
+      <g transform="matrix(8.0515,0,0,8.0515,-2592.2,-12162)" id="g4873">
+        <circle cx="26.216" cy="1317.3" r="11.232" fill="none" opacity="1" stroke="#212121" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.46046" stroke-width="2.1816" id="circle4861"/>
+        <circle cx="26.16" cy="1317.3" r="3.7282" fill="#ffffff" opacity="1" id="circle4863"/>
+        <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1816" id="g4871">
+          <path d="m 35.943,1311.7 a 11.232,11.232 0 0 1 0,11.232" opacity="1" id="path4865"/>
+          <path d="M 19.287,1317.2 H 33.305" opacity="1" id="path4867"/>
+          <path d="m 16.489,1322.9 a 11.232,11.232 0 0 1 0,-11.232" opacity="1" id="path4869"/>
         </g>
       </g>
-      <rect
-         x="-2494.5"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4875" />
+      <rect x="-2494.5" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect4875"/>
     </g>
-    <g
-       transform="translate(4308.7,-226.77)"
-       id="g4883">
-      <path
-         d="m -2596,-1580.3 16.619,-63.733 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.947,107.57 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.045 l -16.614,63.733 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.943,-107.57 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         id="path4879" />
-      <rect
-         x="-2721.3"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4881" />
+    <g transform="translate(4308.7,-226.77)" id="g4883">
+      <path d="m -2596,-1580.3 16.619,-63.733 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.947,107.57 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.045 l -16.614,63.733 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.943,-107.57 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" id="path4879"/>
+      <rect x="-2721.3" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect4881"/>
     </g>
-    <g
-       transform="translate(3401.6,-1360.6)"
-       fill="none"
-       id="g4889">
-      <circle
-         cx="-1927.6"
-         cy="-875.20001"
-         r="65.865997"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="circle4885" />
-      <rect
-         x="-2040.9"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect4887" />
+    <g transform="translate(3401.6,-1360.6)" fill="none" id="g4889">
+      <circle cx="-1927.6" cy="-875.20001" r="65.865997" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="circle4885"/>
+      <rect x="-2040.9" y="-988.58002" width="226.77" height="226.77" opacity="1" id="rect4887"/>
     </g>
-    <g
-       transform="translate(3174.8,-1587.4)"
-       id="g4895">
-      <circle
-         cx="-1700.8"
-         cy="-875.20001"
-         r="99.212997"
-         fill="#ffffff"
-         id="circle4891" />
-      <rect
-         x="-1814.2"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4893" />
+    <g transform="translate(3174.8,-1587.4)" id="g4895">
+      <circle cx="-1700.8" cy="-875.20001" r="99.212997" fill="#ffffff" id="circle4891"/>
+      <rect x="-1814.2" y="-988.58002" width="226.77" height="226.77" fill="none" opacity="1" id="rect4893"/>
     </g>
-    <g
-       transform="translate(2267.7,-1587.4)"
-       id="g4909">
-      <g
-         transform="matrix(13.087,0,0,13.237,-12075,-16914)"
-         id="g4905">
-        <g
-           transform="matrix(0,-0.71903,-0.71191,0,1070.3,1892.7)"
-           id="g4899">
-          <path
-             d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375 z"
-             fill="none"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="1.6899"
-             id="path4897" />
+    <g transform="translate(2267.7,-1587.4)" id="g4909">
+      <g transform="matrix(13.087,0,0,13.237,-12075,-16914)" id="g4905">
+        <g transform="matrix(0,-0.71903,-0.71191,0,1070.3,1892.7)" id="g4899">
+          <path d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375 z" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6899" id="path4897"/>
         </g>
-        <g
-           transform="matrix(0,-0.71903,0.71191,0,515.13,1892.7)"
-           id="g4903">
-          <path
-             d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375 z"
-             fill="none"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="1.6899"
-             id="path4901" />
+        <g transform="matrix(0,-0.71903,0.71191,0,515.13,1892.7)" id="g4903">
+          <path d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375 z" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6899" id="path4901"/>
         </g>
       </g>
-      <rect
-         x="-1814.2"
-         y="-761.81"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4907" />
+      <rect x="-1814.2" y="-761.81" width="226.77" height="226.77" fill="none" opacity="1" id="rect4907"/>
     </g>
-    <g
-       transform="translate(2721.3,-1587.4)"
-       id="g4923">
-      <g
-         transform="matrix(13.087,0,0,13.237,-12302,-16677)"
-         id="g4919">
-        <g
-           transform="matrix(0,-0.71903,0.71191,0,523.44,1874.9)"
-           id="g4913">
-          <path
-             d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375 z"
-             fill="none"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="1.6899"
-             id="path4911" />
+    <g transform="translate(2721.3,-1587.4)" id="g4923">
+      <g transform="matrix(13.087,0,0,13.237,-12302,-16677)" id="g4919">
+        <g transform="matrix(0,-0.71903,0.71191,0,523.44,1874.9)" id="g4913">
+          <path d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375 z" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6899" id="path4911"/>
         </g>
-        <g
-           transform="matrix(0,-0.71903,-0.71191,0,1062,1874.9)"
-           id="g4917">
-          <path
-             d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375 z"
-             fill="none"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="1.6899"
-             id="path4915" />
+        <g transform="matrix(0,-0.71903,-0.71191,0,1062,1874.9)" id="g4917">
+          <path d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375 z" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6899" id="path4915"/>
         </g>
       </g>
-      <rect
-         x="-2040.9"
-         y="-761.81"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4921" />
+      <rect x="-2040.9" y="-761.81" width="226.77" height="226.77" fill="none" opacity="1" id="rect4921"/>
     </g>
-    <g
-       transform="translate(2040.9,-1814.2)"
-       fill="none"
-       id="g4929">
-      <rect
-         transform="rotate(45)"
-         x="-1724.8"
-         y="1001.2"
-         width="127.24"
-         height="127.24"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="18.478"
-         id="rect4925" />
-      <rect
-         x="-2040.9"
-         y="-535.03998"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect4927" />
+    <g transform="translate(2040.9,-1814.2)" fill="none" id="g4929">
+      <rect transform="rotate(45)" x="-1724.8" y="1001.2" width="127.24" height="127.24" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="18.478" id="rect4925"/>
+      <rect x="-2040.9" y="-535.03998" width="226.77" height="226.77" opacity="1" id="rect4927"/>
     </g>
-    <g
-       transform="translate(2040.9,-1814.2)"
-       fill="none"
-       id="g4939">
-      <g
-         transform="matrix(11.297,0,0,11.297,-12124,-4799.9)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-width="1.6728"
-         id="g4935">
-        <path
-           d="m 914.75,395.5 15.875,-15.875"
-           id="path4931" />
-        <path
-           d="M 930.62,395.5 914.745,379.625"
-           id="path4933" />
+    <g transform="translate(2040.9,-1814.2)" fill="none" id="g4939">
+      <g transform="matrix(11.297,0,0,11.297,-12124,-4799.9)" stroke="#ffffff" stroke-linecap="round" stroke-width="1.6728" id="g4935">
+        <path d="m 914.75,395.5 15.875,-15.875" id="path4931"/>
+        <path d="M 930.62,395.5 914.745,379.625" id="path4933"/>
       </g>
-      <rect
-         x="-1814.2"
-         y="-535.03998"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect4937" />
+      <rect x="-1814.2" y="-535.03998" width="226.77" height="226.77" opacity="1" id="rect4937"/>
     </g>
-    <g
-       transform="translate(4082,1587.41)"
-       fill="none"
-       id="g4939-6">
-      <g
-         transform="matrix(6.5607541,0,0,6.5604127,-7753.9369,-2964.1764)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-width="2.88048"
-         id="g4935-9"
-         style="stroke-width:3.57246;stroke-miterlimit:4;stroke-dasharray:none">
-        <path
-           d="m 918.04868,392.20016 9.27556,-9.27532"
-           id="path4931-6"
-           style="stroke-width:3.57246;stroke-miterlimit:4;stroke-dasharray:none" />
-        <path
-           d="m 927.32131,392.20016 -9.27555,-9.27532"
-           id="path4933-2"
-           style="stroke-width:3.57246;stroke-miterlimit:4;stroke-dasharray:none" />
+    <g transform="translate(4082,1587.41)" fill="none" id="g4939-6">
+      <g transform="matrix(6.5607541,0,0,6.5604127,-7753.9369,-2964.1764)" stroke="#ffffff" stroke-linecap="round" stroke-width="2.88048" id="g4935-9" style="stroke-width:3.57246;stroke-miterlimit:4;stroke-dasharray:none">
+        <path d="m 918.04868,392.20016 9.27556,-9.27532" id="path4931-6" style="stroke-width:3.57246;stroke-miterlimit:4;stroke-dasharray:none"/>
+        <path d="m 927.32131,392.20016 -9.27555,-9.27532" id="path4933-2" style="stroke-width:3.57246;stroke-miterlimit:4;stroke-dasharray:none"/>
       </g>
-      <rect
-         x="-1814.2"
-         y="-535.03998"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect4937-5" />
-      <circle
-         cx="-1700.4276"
-         cy="-421.60645"
-         r="90.434448"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="17.5652"
-         id="circle38356-9"
-         style="stroke:#ffffff;stroke-opacity:0.286275" />
+      <rect x="-1814.2" y="-535.03998" width="226.77" height="226.77" opacity="1" id="rect4937-5"/>
+      <circle cx="-1700.4276" cy="-421.60645" r="90.434448" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="17.5652" id="circle38356-9" style="stroke:#ffffff;stroke-opacity:0.286275"/>
     </g>
-    <g
-       transform="translate(4308.77,1587.41)"
-       fill="none"
-       id="g4939-6-3">
-      <rect
-         x="-1814.2"
-         y="-535.03998"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect4937-5-1" />
-      <g
-         id="g23250"
-         transform="matrix(0.77082958,0,0,0.77082958,-3382.1314,-1704.2609)">
-        <g
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
-           id="g23217"
-           transform="matrix(10.624864,0,0,10.624864,2053.9151,1534.6333)">
-          <g
-             transform="translate(-1474.97,-881.937)"
-             id="g23179">
-            <g
-               transform="matrix(0.546399,0,0,0.546399,1006.2,131.164)"
-               id="g23177">
-              <g
-                 id="circle1024"
-                 transform="matrix(1.971,0,0,1.971,828.473,-1200.22)" />
-              <g
-                 id="Low-Thrust"
-                 serif:id="Low Thrust"
-                 transform="translate(-625.47,85.1971)">
-                <g
-                   id="g1004" />
-                <g
-                   id="g23167">
-                  <g
-                     transform="translate(546.876,-85.1971)"
-                     id="g23133">
-                    <path
-                       d="m 971.158,1408.78 c 3.303,-3.31 5.159,-7.79 5.159,-12.46 0,-9.72 -7.892,-17.61 -17.613,-17.61 -9.721,0 -17.613,7.89 -17.613,17.61 0,4.67 1.856,9.15 5.159,12.46 -3.303,-3.31 -5.159,-7.79 -5.159,-12.46 0,-9.72 7.892,-17.61 17.613,-17.61 9.721,0 17.613,7.89 17.613,17.61 0,4.67 -1.856,9.15 -5.159,12.46 z"
-                       style="fill:none;stroke:#ffffff;stroke-width:4.56px"
-                       id="path23131" />
+    <g transform="translate(4308.77,1587.41)" fill="none" id="g4939-6-3">
+      <rect x="-1814.2" y="-535.03998" width="226.77" height="226.77" opacity="1" id="rect4937-5-1"/>
+      <g id="g23250" transform="matrix(0.77082958,0,0,0.77082958,-3382.1314,-1704.2609)">
+        <g style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5" id="g23217" transform="matrix(10.624864,0,0,10.624864,2053.9151,1534.6333)">
+          <g transform="translate(-1474.97,-881.937)" id="g23179">
+            <g transform="matrix(0.546399,0,0,0.546399,1006.2,131.164)" id="g23177">
+              <g id="circle1024" transform="matrix(1.971,0,0,1.971,828.473,-1200.22)"/>
+              <g id="Low-Thrust" serif:id="Low Thrust" transform="translate(-625.47,85.1971)">
+                <g id="g1004"/>
+                <g id="g23167">
+                  <g transform="translate(546.876,-85.1971)" id="g23133">
+                    <path d="m 971.158,1408.78 c 3.303,-3.31 5.159,-7.79 5.159,-12.46 0,-9.72 -7.892,-17.61 -17.613,-17.61 -9.721,0 -17.613,7.89 -17.613,17.61 0,4.67 1.856,9.15 5.159,12.46 -3.303,-3.31 -5.159,-7.79 -5.159,-12.46 0,-9.72 7.892,-17.61 17.613,-17.61 9.721,0 17.613,7.89 17.613,17.61 0,4.67 -1.856,9.15 -5.159,12.46 z" style="fill:none;stroke:#ffffff;stroke-width:4.56px" id="path23131"/>
                   </g>
-                  <g
-                     transform="translate(624.486,-85.1971)"
-                     id="g23137">
-                    <path
-                       d="m 881.094,1378.71 v 5.89"
-                       style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1"
-                       id="path23135" />
+                  <g transform="translate(624.486,-85.1971)" id="g23137">
+                    <path d="m 881.094,1378.71 v 5.89" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1" id="path23135"/>
                   </g>
-                  <g
-                     transform="rotate(-22.781946,1010.9941,-201.95054)"
-                     id="g23141">
-                    <path
-                       d="m 881.094,1372.14 v 12.46"
-                       style="fill:none;stroke:#ffffff;stroke-width:3px;stroke-linejoin:miter;stroke-miterlimit:1"
-                       id="path23139" />
+                  <g transform="rotate(-22.781946,1010.9941,-201.95054)" id="g23141">
+                    <path d="m 881.094,1372.14 v 12.46" style="fill:none;stroke:#ffffff;stroke-width:3px;stroke-linejoin:miter;stroke-miterlimit:1" id="path23139"/>
                   </g>
-                  <g
-                     transform="rotate(-45,1090.4944,599.90096)"
-                     id="g23145">
-                    <path
-                       d="m 881.094,1378.71 v 5.89"
-                       style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1"
-                       id="path23143" />
+                  <g transform="rotate(-45,1090.4944,599.90096)" id="g23145">
+                    <path d="m 881.094,1378.71 v 5.89" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1" id="path23143"/>
                   </g>
-                  <g
-                     transform="rotate(-90,1150.7395,1041.4805)"
-                     id="g23149">
-                    <path
-                       d="m 881.094,1378.71 v 5.89"
-                       style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1"
-                       id="path23147" />
+                  <g transform="rotate(-90,1150.7395,1041.4805)" id="g23149">
+                    <path d="m 881.094,1378.71 v 5.89" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1" id="path23147"/>
                   </g>
-                  <g
-                     transform="rotate(-135,1175.6924,1224.3871)"
-                     id="g23153">
-                    <path
-                       d="m 881.094,1378.71 v 5.89"
-                       style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1"
-                       id="path23151" />
+                  <g transform="rotate(-135,1175.6924,1224.3871)" id="g23153">
+                    <path d="m 881.094,1378.71 v 5.89" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1" id="path23151"/>
                   </g>
-                  <g
-                     transform="rotate(45,1296.1781,2107.5431)"
-                     id="g23157">
-                    <path
-                       d="m 881.094,1378.71 v 5.89"
-                       style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1"
-                       id="path23155" />
+                  <g transform="rotate(45,1296.1781,2107.5431)" id="g23157">
+                    <path d="m 881.094,1378.71 v 5.89" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1" id="path23155"/>
                   </g>
-                  <g
-                     transform="rotate(90,1235.935,1665.965)"
-                     id="g23161">
-                    <path
-                       d="m 881.094,1378.71 v 5.89"
-                       style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1"
-                       id="path23159" />
+                  <g transform="rotate(90,1235.935,1665.965)" id="g23161">
+                    <path d="m 881.094,1378.71 v 5.89" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1" id="path23159"/>
                   </g>
-                  <g
-                     transform="rotate(135,1210.9827,1483.0613)"
-                     id="g23165">
-                    <path
-                       d="m 881.094,1378.71 v 5.89"
-                       style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1"
-                       id="path23163" />
+                  <g transform="rotate(135,1210.9827,1483.0613)" id="g23165">
+                    <path d="m 881.094,1378.71 v 5.89" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linejoin:miter;stroke-miterlimit:1" id="path23163"/>
                   </g>
                 </g>
-                <g
-                   id="rect1008"
-                   transform="matrix(0.193975,0,0,0.193975,1483.41,1612.85)">
-                  <rect
-                     x="0"
-                     y="-1668.9"
-                     width="226.77"
-                     height="226.77"
-                     style="fill:none"
-                     id="rect23169" />
+                <g id="rect1008" transform="matrix(0.193975,0,0,0.193975,1483.41,1612.85)">
+                  <rect x="0" y="-1668.9" width="226.77" height="226.77" style="fill:none" id="rect23169"/>
                 </g>
-                <g
-                   transform="matrix(0.193975,0,0,0.193975,-452.072,1744.82)"
-                   id="g23174">
-                  <g
-                     id="g2160">
-                    <rect
-                       id="rect2156"
-                       x="9978"
-                       y="-2349.2"
-                       width="226.77"
-                       height="226.77"
-                       style="fill:none" />
+                <g transform="matrix(0.193975,0,0,0.193975,-452.072,1744.82)" id="g23174">
+                  <g id="g2160">
+                    <rect id="rect2156" x="9978" y="-2349.2" width="226.77" height="226.77" style="fill:none"/>
                   </g>
                 </g>
               </g>
@@ -2012,11520 +443,2945 @@
         </g>
       </g>
     </g>
-    <g
-       transform="translate(2948,-2040.9)"
-       fill="none"
-       id="g4957">
-      <g
-         transform="matrix(11.16,0,0,-11.231,-12232,4148.1)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="1.386"
-         id="g4945">
-        <path
-           d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375"
-           id="path4941" />
-        <path
-           d="m 915.17,393.27 h 16.375"
-           id="path4943" />
+    <g transform="translate(2948,-2040.9)" fill="none" id="g4957">
+      <g transform="matrix(11.16,0,0,-11.231,-12232,4148.1)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.386" id="g4945">
+        <path d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375" id="path4941"/>
+        <path d="m 915.17,393.27 h 16.375" id="path4943"/>
       </g>
-      <rect
-         x="-2040.9"
-         y="-308.26999"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect4947" />
-      <g
-         transform="matrix(11.16,0,0,11.231,-12005,-4537.8)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="1.386"
-         id="g4953">
-        <path
-           d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375"
-           id="path4949" />
-        <path
-           d="m 915.17,393.27 h 16.375"
-           id="path4951" />
+      <rect x="-2040.9" y="-308.26999" width="226.77" height="226.77" opacity="1" id="rect4947"/>
+      <g transform="matrix(11.16,0,0,11.231,-12005,-4537.8)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.386" id="g4953">
+        <path d="m 915.46,388.08 7.9375,-7.9375 7.9375,7.9375" id="path4949"/>
+        <path d="m 915.17,393.27 h 16.375" id="path4951"/>
       </g>
-      <rect
-         x="-1814.2"
-         y="-308.26999"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect4955" />
+      <rect x="-1814.2" y="-308.26999" width="226.77" height="226.77" opacity="1" id="rect4955"/>
     </g>
-    <g
-       transform="translate(4535.1,-453.54)"
-       id="g4967">
-      <g
-         transform="matrix(7.0866,0,0,7.0866,-4655.9,-11090)"
-         id="g4963">
-        <circle
-           cx="513"
-           cy="1409.4"
-           r="0.91904002"
-           fill="#ffffff"
-           opacity="1"
-           id="circle4959" />
-        <circle
-           cx="513"
-           cy="1409.4"
-           r="13.5"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-dasharray="1, 2"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           id="circle4961" />
+    <g transform="translate(4535.1,-453.54)" id="g4967">
+      <g transform="matrix(7.0866,0,0,7.0866,-4655.9,-11090)" id="g4963">
+        <circle cx="513" cy="1409.4" r="0.91904002" fill="#ffffff" opacity="1" id="circle4959"/>
+        <circle cx="513" cy="1409.4" r="13.5" fill="none" opacity="1" stroke="#ffffff" stroke-dasharray="1, 2" stroke-linecap="round" stroke-linejoin="round" id="circle4961"/>
       </g>
-      <rect
-         x="-1133.9"
-         y="-1215.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4965" />
+      <rect x="-1133.9" y="-1215.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect4965"/>
     </g>
-    <g
-       transform="translate(4081.6,-453.54)"
-       id="g4977">
-      <g
-         transform="matrix(7.0866,0,0,7.0866,-4429.1,-11090)"
-         id="g4973">
-        <circle
-           cx="513"
-           cy="1409.4"
-           r="5.1690001"
-           fill="#ffffff"
-           opacity="1"
-           id="circle4969" />
-        <circle
-           cx="513"
-           cy="1409.4"
-           r="13.5"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-dasharray="1, 2"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           id="circle4971" />
+    <g transform="translate(4081.6,-453.54)" id="g4977">
+      <g transform="matrix(7.0866,0,0,7.0866,-4429.1,-11090)" id="g4973">
+        <circle cx="513" cy="1409.4" r="5.1690001" fill="#ffffff" opacity="1" id="circle4969"/>
+        <circle cx="513" cy="1409.4" r="13.5" fill="none" opacity="1" stroke="#ffffff" stroke-dasharray="1, 2" stroke-linecap="round" stroke-linejoin="round" id="circle4971"/>
       </g>
-      <rect
-         x="-907.09003"
-         y="-1215.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4975" />
+      <rect x="-907.09003" y="-1215.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect4975"/>
     </g>
-    <g
-       transform="translate(3628,-453.54)"
-       id="g4985">
-      <circle
-         transform="matrix(7.0866,0,0,7.0866,-4202.4,-11090)"
-         cx="513"
-         cy="1409.4"
-         r="9.5439997"
-         fill="#ffffff"
-         opacity="1"
-         id="circle4979" />
-      <circle
-         transform="matrix(7.0866,0,0,7.0866,-4202.4,-11090)"
-         cx="513"
-         cy="1409.4"
-         r="13.5"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-dasharray="1, 2"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         id="circle4981" />
-      <rect
-         x="-680.31"
-         y="-1215.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect4983" />
+    <g transform="translate(3628,-453.54)" id="g4985">
+      <circle transform="matrix(7.0866,0,0,7.0866,-4202.4,-11090)" cx="513" cy="1409.4" r="9.5439997" fill="#ffffff" opacity="1" id="circle4979"/>
+      <circle transform="matrix(7.0866,0,0,7.0866,-4202.4,-11090)" cx="513" cy="1409.4" r="13.5" fill="none" opacity="1" stroke="#ffffff" stroke-dasharray="1, 2" stroke-linecap="round" stroke-linejoin="round" id="circle4981"/>
+      <rect x="-680.31" y="-1215.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect4983"/>
     </g>
-    <g
-       transform="translate(4989,-226.77)"
-       id="g5005">
-      <g
-         transform="matrix(-3.5486,0.95084,0.95926,3.58,-2692.7,-6956.9)"
-         opacity="1"
-         id="g5001">
-        <g
-           transform="matrix(0.96593,-0.25655,-0.26111,-0.96593,402.29,2995.7)"
-           fill="#ffffff"
-           id="g4995">
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="9.8042002"
-             rx="4.7371001"
-             ry="3.8420999"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4987" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="12.929"
-             rx="4.7371001"
-             ry="3.8420999"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4989" />
-          <path
-             d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="5.3843"
-             id="path4991" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="5.6332002"
-             rx="4.7371001"
-             ry="3.8420999"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4993" />
+    <g transform="translate(4989,-226.77)" id="g5005">
+      <g transform="matrix(-3.5486,0.95084,0.95926,3.58,-2692.7,-6956.9)" opacity="1" id="g5001">
+        <g transform="matrix(0.96593,-0.25655,-0.26111,-0.96593,402.29,2995.7)" fill="#ffffff" id="g4995">
+          <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="4.7371001" ry="3.8420999" fill-opacity="0.32727" opacity="1" id="rect4987"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="4.7371001" ry="3.8420999" fill-opacity="0.32727" opacity="1" id="rect4989"/>
+          <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.3843" id="path4991"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="4.7371001" ry="3.8420999" fill-opacity="0.32727" opacity="1" id="rect4993"/>
         </g>
-        <g
-           transform="matrix(2.3205,-0.61633,0.62713,2.3199,-1521.6,-1668)"
-           id="g4999">
-          <path
-             transform="scale(-1,1)"
-             d="m -453.33,1467.7 h -3.7462 v -11.878 h 20.988 v 11.878 h -3.7462"
-             fill="none"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="1.4943"
-             id="path4997" />
+        <g transform="matrix(2.3205,-0.61633,0.62713,2.3199,-1521.6,-1668)" id="g4999">
+          <path transform="scale(-1,1)" d="m -453.33,1467.7 h -3.7462 v -11.878 h 20.988 v 11.878 h -3.7462" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.4943" id="path4997"/>
         </g>
       </g>
-      <rect
-         x="-2948"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5003" />
+      <rect x="-2948" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect5003"/>
     </g>
-    <g
-       transform="translate(5442.5,-453.54)"
-       id="g5025">
-      <g
-         transform="matrix(6.611,0,0,6.611,-5987.3,-10818)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         id="g5021">
-        <g
-           transform="matrix(0.52453,0,0,0.52312,247.23,700.97)"
-           opacity="1"
-           stroke-width="5.7271"
-           id="g5017">
-          <path
-             d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-             fill="#ffffff"
-             opacity="1"
-             id="path5007" />
-          <g
-             transform="translate(22.488)"
-             id="g5015">
-            <path
-               d="m 404.94,1472.4 h 9.6402 l 4.3812,6.4897 h -18.403 z"
-               fill="#ffffff"
-               opacity="0.417"
-               id="path5009" />
-            <path
-               d="m 406.24,1472.4 h 7.0283 l 3.0753,3.6118 h -13.179 z"
-               fill="#121222"
-               opacity="0.485"
-               id="path5011" />
-            <path
-               d="m 407.48,1472.5 h 4.5501 v 0.076 H 407.48 Z"
-               fill="#121222"
-               opacity="0.495"
-               id="path5013" />
+    <g transform="translate(5442.5,-453.54)" id="g5025">
+      <g transform="matrix(6.611,0,0,6.611,-5987.3,-10818)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" id="g5021">
+        <g transform="matrix(0.52453,0,0,0.52312,247.23,700.97)" opacity="1" stroke-width="5.7271" id="g5017">
+          <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" fill="#ffffff" opacity="1" id="path5007"/>
+          <g transform="translate(22.488)" id="g5015">
+            <path d="m 404.94,1472.4 h 9.6402 l 4.3812,6.4897 h -18.403 z" fill="#ffffff" opacity="0.417" id="path5009"/>
+            <path d="m 406.24,1472.4 h 7.0283 l 3.0753,3.6118 h -13.179 z" fill="#121222" opacity="0.485" id="path5011"/>
+            <path d="m 407.48,1472.5 h 4.5501 v 0.076 H 407.48 Z" fill="#121222" opacity="0.495" id="path5013"/>
           </g>
         </g>
-        <path
-           d="m 491.38,1477.8 h -29"
-           fill="#ffffff"
-           opacity="1"
-           id="path5019" />
+        <path d="m 491.38,1477.8 h -29" fill="#ffffff" opacity="1" id="path5019"/>
       </g>
-      <rect
-         x="-2948"
-         y="-1215.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5023" />
+      <rect x="-2948" y="-1215.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect5023"/>
     </g>
-    <g
-       transform="translate(4081.9,-226.77)"
-       id="g5055">
-      <g
-         transform="matrix(7.3436,0,0,7.5069,-6032.4,-12640)"
-         id="g5049">
-        <g
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           id="g5033">
-          <circle
-             cx="441.23001"
-             cy="1482.3"
-             opacity="1"
-             stroke-width="3.5996"
-             id="ellipse5027"
-             r="5.6567998" />
-          <path
-             d="m 438.95,1472.4 h 4.3599 m -2.18,-0.1766 v -7.0651 m -2.507,0 h 5.0552"
-             opacity="1"
-             stroke-width="3.5996"
-             id="path5029" />
-          <circle
-             cx="441.23001"
-             cy="1482.3"
-             opacity="1"
-             stroke-width="1.1998"
-             id="ellipse5031"
-             r="1.4141999" />
+    <g transform="translate(4081.9,-226.77)" id="g5055">
+      <g transform="matrix(7.3436,0,0,7.5069,-6032.4,-12640)" id="g5049">
+        <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" id="g5033">
+          <circle cx="441.23001" cy="1482.3" opacity="1" stroke-width="3.5996" id="ellipse5027" r="5.6567998"/>
+          <path d="m 438.95,1472.4 h 4.3599 m -2.18,-0.1766 v -7.0651 m -2.507,0 h 5.0552" opacity="1" stroke-width="3.5996" id="path5029"/>
+          <circle cx="441.23001" cy="1482.3" opacity="1" stroke-width="1.1998" id="ellipse5031" r="1.4141999"/>
         </g>
-        <g
-           fill="#ffffff"
-           id="g5047">
-          <circle
-             transform="rotate(15)"
-             cx="809.82001"
-             cy="1314.8"
-             r="0.38156"
-             opacity="1"
-             id="circle5035" />
-          <circle
-             transform="rotate(15)"
-             cx="809.82001"
-             cy="1320.3"
-             r="0.38156"
-             opacity="1"
-             id="circle5037" />
-          <circle
-             transform="rotate(-45)"
-             cx="-736.15997"
-             cy="1357.4"
-             r="0.38156"
-             opacity="1"
-             id="circle5039" />
-          <circle
-             transform="rotate(-45)"
-             cx="-736.15997"
-             cy="1362.9"
-             r="0.38156"
-             opacity="1"
-             id="circle5041" />
-          <circle
-             transform="rotate(-105)"
-             cx="-1546"
-             cy="39.772999"
-             r="0.38156"
-             opacity="1"
-             id="circle5043" />
-          <circle
-             transform="rotate(-105)"
-             cx="-1546"
-             cy="45.272999"
-             r="0.38156"
-             opacity="1"
-             id="circle5045" />
+        <g fill="#ffffff" id="g5047">
+          <circle transform="rotate(15)" cx="809.82001" cy="1314.8" r="0.38156" opacity="1" id="circle5035"/>
+          <circle transform="rotate(15)" cx="809.82001" cy="1320.3" r="0.38156" opacity="1" id="circle5037"/>
+          <circle transform="rotate(-45)" cx="-736.15997" cy="1357.4" r="0.38156" opacity="1" id="circle5039"/>
+          <circle transform="rotate(-45)" cx="-736.15997" cy="1362.9" r="0.38156" opacity="1" id="circle5041"/>
+          <circle transform="rotate(-105)" cx="-1546" cy="39.772999" r="0.38156" opacity="1" id="circle5043"/>
+          <circle transform="rotate(-105)" cx="-1546" cy="45.272999" r="0.38156" opacity="1" id="circle5045"/>
         </g>
       </g>
-      <rect
-         x="-2948"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5051" />
-      <path
-         d="m -2898.8,-1533.7 c -1.7245,0.038 -3.3693,0.7335 -4.5979,1.9442 l -28.399,27.988 c -2.7233,2.6101 -2.7852,6.9434 -0.1374,9.6301 2.6477,2.6866 6.9816,2.688 9.631,0 l 23.652,-23.31 24.06,23.711 c 2.6494,2.685 6.9832,2.6836 9.631,0 2.6478,-2.6866 2.5859,-7.02 -0.1374,-9.63 l -28.807,-28.39 c -1.302,-1.2829 -3.0679,-1.9842 -4.8954,-1.9442 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5053" />
+      <rect x="-2948" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect5051"/>
+      <path d="m -2898.8,-1533.7 c -1.7245,0.038 -3.3693,0.7335 -4.5979,1.9442 l -28.399,27.988 c -2.7233,2.6101 -2.7852,6.9434 -0.1374,9.6301 2.6477,2.6866 6.9816,2.688 9.631,0 l 23.652,-23.31 24.06,23.711 c 2.6494,2.685 6.9832,2.6836 9.631,0 2.6478,-2.6866 2.5859,-7.02 -0.1374,-9.63 l -28.807,-28.39 c -1.302,-1.2829 -3.0679,-1.9842 -4.8954,-1.9442 z" fill="#ffffff" opacity="1" id="path5053"/>
     </g>
-    <g
-       transform="translate(4308.7,-680.31)"
-       id="g5085">
-      <g
-         transform="matrix(0,7.3436,-7.5068,0,8249.7,-4384.7)"
-         id="g5079">
-        <g
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="3.5996"
-           id="g5061">
-          <circle
-             cx="441.23001"
-             cy="1482.3"
-             opacity="1"
-             id="ellipse5057"
-             r="5.6567998" />
-          <path
-             d="m 438.95,1472.4 h 4.3599 m -2.18,-0.1766 v -7.0651 m -2.507,0 h 5.0552"
-             opacity="1"
-             id="path5059" />
+    <g transform="translate(4308.7,-680.31)" id="g5085">
+      <g transform="matrix(0,7.3436,-7.5068,0,8249.7,-4384.7)" id="g5079">
+        <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5996" id="g5061">
+          <circle cx="441.23001" cy="1482.3" opacity="1" id="ellipse5057" r="5.6567998"/>
+          <path d="m 438.95,1472.4 h 4.3599 m -2.18,-0.1766 v -7.0651 m -2.507,0 h 5.0552" opacity="1" id="path5059"/>
         </g>
-        <circle
-           cx="441.23001"
-           cy="1482.3"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="1.1998"
-           id="ellipse5063"
-           r="1.4141999" />
-        <g
-           fill="#ffffff"
-           id="g5077">
-          <circle
-             transform="rotate(15)"
-             cx="809.82001"
-             cy="1314.8"
-             r="0.38156"
-             opacity="1"
-             id="circle5065" />
-          <circle
-             transform="rotate(15)"
-             cx="809.82001"
-             cy="1320.3"
-             r="0.38156"
-             opacity="1"
-             id="circle5067" />
-          <circle
-             transform="rotate(-45)"
-             cx="-736.15997"
-             cy="1357.4"
-             r="0.38156"
-             opacity="1"
-             id="circle5069" />
-          <circle
-             transform="rotate(-45)"
-             cx="-736.15997"
-             cy="1362.9"
-             r="0.38156"
-             opacity="1"
-             id="circle5071" />
-          <circle
-             transform="rotate(-105)"
-             cx="-1546"
-             cy="39.772999"
-             r="0.38156"
-             opacity="1"
-             id="circle5073" />
-          <circle
-             transform="rotate(-105)"
-             cx="-1546"
-             cy="45.272999"
-             r="0.38156"
-             opacity="1"
-             id="circle5075" />
+        <circle cx="441.23001" cy="1482.3" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.1998" id="ellipse5063" r="1.4141999"/>
+        <g fill="#ffffff" id="g5077">
+          <circle transform="rotate(15)" cx="809.82001" cy="1314.8" r="0.38156" opacity="1" id="circle5065"/>
+          <circle transform="rotate(15)" cx="809.82001" cy="1320.3" r="0.38156" opacity="1" id="circle5067"/>
+          <circle transform="rotate(-45)" cx="-736.15997" cy="1357.4" r="0.38156" opacity="1" id="circle5069"/>
+          <circle transform="rotate(-45)" cx="-736.15997" cy="1362.9" r="0.38156" opacity="1" id="circle5071"/>
+          <circle transform="rotate(-105)" cx="-1546" cy="39.772999" r="0.38156" opacity="1" id="circle5073"/>
+          <circle transform="rotate(-105)" cx="-1546" cy="45.272999" r="0.38156" opacity="1" id="circle5075"/>
         </g>
       </g>
-      <rect
-         x="-2948"
-         y="-1215.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5081" />
-      <path
-         d="m -2877.4,-1038.2 c -1.7245,-0.038 -3.3693,-0.7335 -4.5979,-1.9442 l -28.399,-27.988 c -2.7233,-2.6101 -2.7852,-6.9434 -0.1374,-9.6301 2.6477,-2.6866 6.9816,-2.688 9.631,0 l 23.652,23.31 24.06,-23.711 c 2.6494,-2.685 6.9832,-2.6836 9.631,0 2.6478,2.6866 2.5859,7.02 -0.1374,9.63 l -28.807,28.39 c -1.302,1.2829 -3.0679,1.9842 -4.8954,1.9442 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5083" />
+      <rect x="-2948" y="-1215.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect5081"/>
+      <path d="m -2877.4,-1038.2 c -1.7245,-0.038 -3.3693,-0.7335 -4.5979,-1.9442 l -28.399,-27.988 c -2.7233,-2.6101 -2.7852,-6.9434 -0.1374,-9.6301 2.6477,-2.6866 6.9816,-2.688 9.631,0 l 23.652,23.31 24.06,-23.711 c 2.6494,-2.685 6.9832,-2.6836 9.631,0 2.6478,2.6866 2.5859,7.02 -0.1374,9.63 l -28.807,28.39 c -1.302,1.2829 -3.0679,1.9842 -4.8954,1.9442 z" fill="#ffffff" opacity="1" id="path5083"/>
     </g>
-    <g
-       transform="translate(4308.7,-226.77)"
-       id="g5117">
-      <g
-         transform="matrix(8.8645,1.1093,-1.1019,8.8884,-1993.8,-2802.6)"
-         opacity="0.9"
-         id="g5113">
-        <path
-           transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)"
-           d="m 160.65,1099.3 c 4.2945,1.0457 5.4757,6.6628 7.5074,10.43 l 2.5696,1.2209 9.3611,2.2447 12.346,0.9988 -0.0735,6.5172 -11.678,0.5012 -9.1884,2.0696 -4.6629,2.8607 c -1.8324,2.7606 -2.6604,7.4882 -5.3361,7.6186 -4.0489,0.1973 -8.3999,-2.6783 -10.491,-6.1512 -3.227,-5.3605 -3.2119,-12.974 -0.81265,-18.753 1.8108,-4.3614 5.8696,-10.674 10.458,-9.5571 z"
-           fill="url(#linearGradient5431)"
-           opacity="0.99"
-           id="path5087"
-           style="fill:url(#linearGradient26937)" />
-        <g
-           fill="none"
-           id="g5111">
-          <g
-             stroke-linecap="round"
-             id="g5095">
-            <path
-               d="m 19.971,146.4 0.88064,-1.8972 1.365,-1.5001 2.6859,-1.6766 4.5077,-1.0588 5.8562,-0.30888"
-               color="#000000"
-               stroke="url(#linearGradient5433)"
-               stroke-width="0.62942"
-               id="path5089"
-               style="stroke:url(#linearGradient26939)" />
-            <path
-               transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)"
-               d="m 160.6,1099.3 1.591,4.5078 2.74,3.8891 5.6569,3.2704 9.8111,2.3864 11.756,0.884"
-               color="#000000"
-               stroke="url(#linearGradient5435)"
-               stroke-width="1.2622"
-               id="path5091"
-               style="stroke:url(#linearGradient26941)" />
-            <path
-               d="m 14.886,143.31 2.9409,-2.1877 1.8632,-0.94297 3.3473,-0.57174 5.6036,-0.41157 6.728,0.0579"
-               color="#000000"
-               stroke="url(#linearGradient5437)"
-               stroke-width="0.62942"
-               id="path5093"
-               style="stroke:url(#linearGradient26943)" />
+    <g transform="translate(4308.7,-226.77)" id="g5117">
+      <g transform="matrix(8.8645,1.1093,-1.1019,8.8884,-1993.8,-2802.6)" opacity="0.9" id="g5113">
+        <path transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)" d="m 160.65,1099.3 c 4.2945,1.0457 5.4757,6.6628 7.5074,10.43 l 2.5696,1.2209 9.3611,2.2447 12.346,0.9988 -0.0735,6.5172 -11.678,0.5012 -9.1884,2.0696 -4.6629,2.8607 c -1.8324,2.7606 -2.6604,7.4882 -5.3361,7.6186 -4.0489,0.1973 -8.3999,-2.6783 -10.491,-6.1512 -3.227,-5.3605 -3.2119,-12.974 -0.81265,-18.753 1.8108,-4.3614 5.8696,-10.674 10.458,-9.5571 z" fill="url(#linearGradient5431)" opacity="0.99" id="path5087" style="fill:url(#linearGradient26937)"/>
+        <g fill="none" id="g5111">
+          <g stroke-linecap="round" id="g5095">
+            <path d="m 19.971,146.4 0.88064,-1.8972 1.365,-1.5001 2.6859,-1.6766 4.5077,-1.0588 5.8562,-0.30888" color="#000000" stroke="url(#linearGradient5433)" stroke-width="0.62942" id="path5089" style="stroke:url(#linearGradient26939)"/>
+            <path transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)" d="m 160.6,1099.3 1.591,4.5078 2.74,3.8891 5.6569,3.2704 9.8111,2.3864 11.756,0.884" color="#000000" stroke="url(#linearGradient5435)" stroke-width="1.2622" id="path5091" style="stroke:url(#linearGradient26941)"/>
+            <path d="m 14.886,143.31 2.9409,-2.1877 1.8632,-0.94297 3.3473,-0.57174 5.6036,-0.41157 6.728,0.0579" color="#000000" stroke="url(#linearGradient5437)" stroke-width="0.62942" id="path5093" style="stroke:url(#linearGradient26943)"/>
           </g>
-          <ellipse
-             transform="matrix(0.23683,0,0,0.29689,-17.039,-194.54)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5439)"
-             stroke-width="2.3737"
-             id="ellipse5097"
-             style="stroke:url(#linearGradient26945)" />
-          <path
-             d="m 14.512,134.11 2.972,2.0629 2.1122,0.75578 3.3785,0.47815 5.6348,0.006 6.728,-0.0579"
-             color="#000000"
-             stroke="url(#linearGradient5441)"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5099"
-             style="stroke:url(#linearGradient26947)" />
-          <ellipse
-             transform="matrix(0.14004,0,0,0.18447,4.9618,-68.514)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5443)"
-             stroke-width="3.9161"
-             id="ellipse5101"
-             style="stroke:url(#linearGradient26949)" />
-          <ellipse
-             transform="matrix(0.49816,0,0,0.60042,-66.619,-535.12)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5445)"
-             stroke-width="1.1509"
-             id="ellipse5103"
-             style="stroke:url(#linearGradient26951)" />
-          <ellipse
-             transform="matrix(0.36266,0,0,0.44304,-41.697,-358.37)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5447)"
-             stroke-width="1.5703"
-             id="ellipse5105"
-             style="stroke:url(#linearGradient26953)" />
-          <path
-             d="m 21.996,141.63 1.8493,-1.4517 0.17613,-0.11362 1.7833,-0.31128 4.5077,-0.39164 4.9536,-0.11424"
-             color="#000000"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5107" />
-          <path
-             d="m 21.996,134.93 1.8493,1.4517 0.17613,0.11362 1.7833,0.31128 4.5077,0.39164 4.9536,0.11424"
-             color="#000000"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5109" />
+          <ellipse transform="matrix(0.23683,0,0,0.29689,-17.039,-194.54)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5439)" stroke-width="2.3737" id="ellipse5097" style="stroke:url(#linearGradient26945)"/>
+          <path d="m 14.512,134.11 2.972,2.0629 2.1122,0.75578 3.3785,0.47815 5.6348,0.006 6.728,-0.0579" color="#000000" stroke="url(#linearGradient5441)" stroke-linecap="round" stroke-width="0.62942" id="path5099" style="stroke:url(#linearGradient26947)"/>
+          <ellipse transform="matrix(0.14004,0,0,0.18447,4.9618,-68.514)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5443)" stroke-width="3.9161" id="ellipse5101" style="stroke:url(#linearGradient26949)"/>
+          <ellipse transform="matrix(0.49816,0,0,0.60042,-66.619,-535.12)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5445)" stroke-width="1.1509" id="ellipse5103" style="stroke:url(#linearGradient26951)"/>
+          <ellipse transform="matrix(0.36266,0,0,0.44304,-41.697,-358.37)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5447)" stroke-width="1.5703" id="ellipse5105" style="stroke:url(#linearGradient26953)"/>
+          <path d="m 21.996,141.63 1.8493,-1.4517 0.17613,-0.11362 1.7833,-0.31128 4.5077,-0.39164 4.9536,-0.11424" color="#000000" stroke="#ffffff" stroke-linecap="round" stroke-width="0.62942" id="path5107"/>
+          <path d="m 21.996,134.93 1.8493,1.4517 0.17613,0.11362 1.7833,0.31128 4.5077,0.39164 4.9536,0.11424" color="#000000" stroke="#ffffff" stroke-linecap="round" stroke-width="0.62942" id="path5109"/>
         </g>
       </g>
-      <rect
-         x="-2040.9"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5115" />
+      <rect x="-2040.9" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect5115"/>
     </g>
-    <g
-       transform="translate(5442.3826,3174.6931)"
-       id="g5117-8">
-      <g
-         transform="matrix(8.8645,1.1093,-1.1019,8.8884,-1993.8,-2802.6)"
-         opacity="0.9"
-         id="g5113-8">
-        <path
-           transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)"
-           d="m 160.65,1099.3 c 4.2945,1.0457 5.4757,6.6628 7.5074,10.43 l 2.5696,1.2209 9.3611,2.2447 12.346,0.9988 -0.0735,6.5172 -11.678,0.5012 -9.1884,2.0696 -4.6629,2.8607 c -1.8324,2.7606 -2.6604,7.4882 -5.3361,7.6186 -4.0489,0.1973 -8.3999,-2.6783 -10.491,-6.1512 -3.227,-5.3605 -3.2119,-12.974 -0.81265,-18.753 1.8108,-4.3614 5.8696,-10.674 10.458,-9.5571 z"
-           fill="url(#linearGradient5431)"
-           opacity="0.99"
-           id="path5087-6"
-           style="fill:url(#linearGradient24358)" />
-        <g
-           fill="none"
-           id="g5111-4">
-          <g
-             stroke-linecap="round"
-             id="g5095-9">
-            <path
-               d="m 19.971,146.4 0.88064,-1.8972 1.365,-1.5001 2.6859,-1.6766 4.5077,-1.0588 5.8562,-0.30888"
-               color="#000000"
-               stroke="url(#linearGradient5433)"
-               stroke-width="0.62942"
-               id="path5089-3"
-               style="stroke:url(#linearGradient24360)" />
-            <path
-               transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)"
-               d="m 160.6,1099.3 1.591,4.5078 2.74,3.8891 5.6569,3.2704 9.8111,2.3864 11.756,0.884"
-               color="#000000"
-               stroke="url(#linearGradient5435)"
-               stroke-width="1.2622"
-               id="path5091-1"
-               style="stroke:url(#linearGradient24362)" />
-            <path
-               d="m 14.886,143.31 2.9409,-2.1877 1.8632,-0.94297 3.3473,-0.57174 5.6036,-0.41157 6.728,0.0579"
-               color="#000000"
-               stroke="url(#linearGradient5437)"
-               stroke-width="0.62942"
-               id="path5093-7"
-               style="stroke:url(#linearGradient24364)" />
+    <g transform="translate(5442.3826,3174.6931)" id="g5117-8">
+      <g transform="matrix(8.8645,1.1093,-1.1019,8.8884,-1993.8,-2802.6)" opacity="0.9" id="g5113-8">
+        <path transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)" d="m 160.65,1099.3 c 4.2945,1.0457 5.4757,6.6628 7.5074,10.43 l 2.5696,1.2209 9.3611,2.2447 12.346,0.9988 -0.0735,6.5172 -11.678,0.5012 -9.1884,2.0696 -4.6629,2.8607 c -1.8324,2.7606 -2.6604,7.4882 -5.3361,7.6186 -4.0489,0.1973 -8.3999,-2.6783 -10.491,-6.1512 -3.227,-5.3605 -3.2119,-12.974 -0.81265,-18.753 1.8108,-4.3614 5.8696,-10.674 10.458,-9.5571 z" fill="url(#linearGradient5431)" opacity="0.99" id="path5087-6" style="fill:url(#linearGradient24358)"/>
+        <g fill="none" id="g5111-4">
+          <g stroke-linecap="round" id="g5095-9">
+            <path d="m 19.971,146.4 0.88064,-1.8972 1.365,-1.5001 2.6859,-1.6766 4.5077,-1.0588 5.8562,-0.30888" color="#000000" stroke="url(#linearGradient5433)" stroke-width="0.62942" id="path5089-3" style="stroke:url(#linearGradient24360)"/>
+            <path transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)" d="m 160.6,1099.3 1.591,4.5078 2.74,3.8891 5.6569,3.2704 9.8111,2.3864 11.756,0.884" color="#000000" stroke="url(#linearGradient5435)" stroke-width="1.2622" id="path5091-1" style="stroke:url(#linearGradient24362)"/>
+            <path d="m 14.886,143.31 2.9409,-2.1877 1.8632,-0.94297 3.3473,-0.57174 5.6036,-0.41157 6.728,0.0579" color="#000000" stroke="url(#linearGradient5437)" stroke-width="0.62942" id="path5093-7" style="stroke:url(#linearGradient24364)"/>
           </g>
-          <ellipse
-             transform="matrix(0.23683,0,0,0.29689,-17.039,-194.54)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5439)"
-             stroke-width="2.3737"
-             id="ellipse5097-8"
-             style="stroke:url(#linearGradient24366)" />
-          <path
-             d="m 14.512,134.11 2.972,2.0629 2.1122,0.75578 3.3785,0.47815 5.6348,0.006 6.728,-0.0579"
-             color="#000000"
-             stroke="url(#linearGradient5441)"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5099-0"
-             style="stroke:url(#linearGradient24368)" />
-          <ellipse
-             transform="matrix(0.14004,0,0,0.18447,4.9618,-68.514)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5443)"
-             stroke-width="3.9161"
-             id="ellipse5101-6"
-             style="stroke:url(#linearGradient24370)" />
-          <ellipse
-             transform="matrix(0.49816,0,0,0.60042,-66.619,-535.12)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5445)"
-             stroke-width="1.1509"
-             id="ellipse5103-8"
-             style="stroke:url(#linearGradient24372)" />
-          <ellipse
-             transform="matrix(0.36266,0,0,0.44304,-41.697,-358.37)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5447)"
-             stroke-width="1.5703"
-             id="ellipse5105-4"
-             style="stroke:url(#linearGradient24374)" />
-          <path
-             d="m 21.996,141.63 1.8493,-1.4517 0.17613,-0.11362 1.7833,-0.31128 4.5077,-0.39164 4.9536,-0.11424"
-             color="#000000"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5107-4" />
-          <path
-             d="m 21.996,134.93 1.8493,1.4517 0.17613,0.11362 1.7833,0.31128 4.5077,0.39164 4.9536,0.11424"
-             color="#000000"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5109-9" />
+          <ellipse transform="matrix(0.23683,0,0,0.29689,-17.039,-194.54)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5439)" stroke-width="2.3737" id="ellipse5097-8" style="stroke:url(#linearGradient24366)"/>
+          <path d="m 14.512,134.11 2.972,2.0629 2.1122,0.75578 3.3785,0.47815 5.6348,0.006 6.728,-0.0579" color="#000000" stroke="url(#linearGradient5441)" stroke-linecap="round" stroke-width="0.62942" id="path5099-0" style="stroke:url(#linearGradient24368)"/>
+          <ellipse transform="matrix(0.14004,0,0,0.18447,4.9618,-68.514)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5443)" stroke-width="3.9161" id="ellipse5101-6" style="stroke:url(#linearGradient24370)"/>
+          <ellipse transform="matrix(0.49816,0,0,0.60042,-66.619,-535.12)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5445)" stroke-width="1.1509" id="ellipse5103-8" style="stroke:url(#linearGradient24372)"/>
+          <ellipse transform="matrix(0.36266,0,0,0.44304,-41.697,-358.37)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5447)" stroke-width="1.5703" id="ellipse5105-4" style="stroke:url(#linearGradient24374)"/>
+          <path d="m 21.996,141.63 1.8493,-1.4517 0.17613,-0.11362 1.7833,-0.31128 4.5077,-0.39164 4.9536,-0.11424" color="#000000" stroke="#ffffff" stroke-linecap="round" stroke-width="0.62942" id="path5107-4"/>
+          <path d="m 21.996,134.93 1.8493,1.4517 0.17613,0.11362 1.7833,0.31128 4.5077,0.39164 4.9536,0.11424" color="#000000" stroke="#ffffff" stroke-linecap="round" stroke-width="0.62942" id="path5109-9"/>
         </g>
       </g>
-      <rect
-         x="-2040.9"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5115-9" />
+      <rect x="-2040.9" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect5115-9"/>
     </g>
-    <g
-       transform="translate(4535.4,680.31)"
-       id="g5123">
-      <path
-         d="m -4233.8,-1281.9 c 3.1835,8.7221 12.733,13.23 21.374,10.043 l 41.719,-14.346 5.9068,24.681 c 1.2802,5.9576 9.7562,11.369 16,11.369 h 23.772 c 4.5455,0 8.2712,3.7161 8.2712,8.2712 v 2.0684 c 0,5.7012 4.6273,10.336 10.336,10.336 5.702,0 10.336,-4.6265 10.336,-10.336 v -41.343 c 0,-5.702 -4.6273,-10.335 -10.336,-10.335 -5.702,0 -10.336,4.6265 -10.336,10.335 v 2.0676 c 0,4.5456 -3.7153,8.2712 -8.2712,8.2712 h -12.402 c -4.5447,0 -7.1552,-3.8486 -8.2712,-8.2712 l -3.6851,-14.427 42.335,-14.553 c 8.6403,-3.1843 13.106,-12.858 9.961,-21.623 l -31.339,-87.15 c -3.1431,-8.722 -12.692,-13.23 -21.332,-10.044 l -105.38,36.217 c -8.6402,3.1835 -13.106,12.857 -9.961,21.622 l 7.1148,19.804 -15.623,5.7432 -0.7143,-1.9866 c -1.9454,-5.456 -7.9339,-8.2712 -13.312,-6.2854 -5.4265,1.9867 -8.1902,8.0268 -6.2448,13.519 l 18.517,51.473 c 1.9454,5.4972 7.9339,8.3125 13.35,6.3259 5.375,-2.0264 8.1895,-8.0562 6.2037,-13.518 l -1.4843,-3.7273 6.2036,-3.4693 7.6061,-1.9445 9.715,21.209 z m 71.568,-110.88 c 0,-5.7019 4.6273,-10.336 10.336,-10.336 5.702,0 10.336,4.6273 10.336,10.336 0,5.702 -4.6273,10.336 -10.336,10.336 -5.7019,0 -10.336,-4.6273 -10.336,-10.336 z"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         id="path5119" />
-      <rect
-         x="-4308.7002"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5121" />
+    <g transform="translate(4535.4,680.31)" id="g5123">
+      <path d="m -4233.8,-1281.9 c 3.1835,8.7221 12.733,13.23 21.374,10.043 l 41.719,-14.346 5.9068,24.681 c 1.2802,5.9576 9.7562,11.369 16,11.369 h 23.772 c 4.5455,0 8.2712,3.7161 8.2712,8.2712 v 2.0684 c 0,5.7012 4.6273,10.336 10.336,10.336 5.702,0 10.336,-4.6265 10.336,-10.336 v -41.343 c 0,-5.702 -4.6273,-10.335 -10.336,-10.335 -5.702,0 -10.336,4.6265 -10.336,10.335 v 2.0676 c 0,4.5456 -3.7153,8.2712 -8.2712,8.2712 h -12.402 c -4.5447,0 -7.1552,-3.8486 -8.2712,-8.2712 l -3.6851,-14.427 42.335,-14.553 c 8.6403,-3.1843 13.106,-12.858 9.961,-21.623 l -31.339,-87.15 c -3.1431,-8.722 -12.692,-13.23 -21.332,-10.044 l -105.38,36.217 c -8.6402,3.1835 -13.106,12.857 -9.961,21.622 l 7.1148,19.804 -15.623,5.7432 -0.7143,-1.9866 c -1.9454,-5.456 -7.9339,-8.2712 -13.312,-6.2854 -5.4265,1.9867 -8.1902,8.0268 -6.2448,13.519 l 18.517,51.473 c 1.9454,5.4972 7.9339,8.3125 13.35,6.3259 5.375,-2.0264 8.1895,-8.0562 6.2037,-13.518 l -1.4843,-3.7273 6.2036,-3.4693 7.6061,-1.9445 9.715,21.209 z m 71.568,-110.88 c 0,-5.7019 4.6273,-10.336 10.336,-10.336 5.702,0 10.336,4.6273 10.336,10.336 0,5.702 -4.6273,10.336 -10.336,10.336 -5.7019,0 -10.336,-4.6273 -10.336,-10.336 z" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" id="path5119"/>
+      <rect x="-4308.7002" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect5121"/>
     </g>
-    <g
-       transform="translate(4762.2,453.54)"
-       id="g5129">
-      <path
-         d="m -4257.3,-1035.8 c 0,9.1307 7.4005,16.536 16.534,16.536 h 128.14 c 9.1299,0 16.534,-7.3997 16.534,-16.536 v -95.074 c 0,-9.1307 -7.3997,-16.534 -16.534,-16.534 h -49.604 c -4.5447,0 -8.2703,-3.7161 -8.2703,-8.2712 0,-4.5439 3.7161,-8.2695 8.2703,-8.2695 h 55.805 c 5.7011,0 10.333,-4.6265 10.333,-10.334 0,-5.7011 -4.6257,-10.335 -10.333,-10.335 h -68.206 c -7.7275,0 -14.716,5.2503 -16.535,12.402 l -8.2291,24.802 h -16.907 c -5.5376,0 -10.459,2.1906 -14.014,5.7011 l -20.917,21 c -3.7566,3.7153 -6.0797,8.9252 -6.0797,14.633 v 12.402 h -16.536 v -2.0676 c 0,-5.7011 -4.6257,-10.335 -10.333,-10.335 -5.7011,0 -10.335,4.6256 -10.335,10.335 v 53.737 c 0,5.7019 4.6265,10.335 10.335,10.335 5.7011,0 10.333,-4.6273 10.333,-10.335 v -2.0676 h 16.536 v 8.2712 z m 54.564,-45.469 h 76.887 c 5.0456,0 9.0887,4.0526 9.0887,9.0886 v 23.149 c 0,5.0463 -4.0534,9.0886 -9.0887,9.0886 h -76.887 c -5.0455,0 -9.0886,-4.0534 -9.0886,-9.0886 v -23.149 c 0,-5.0463 4.0534,-9.0886 9.0886,-9.0886 z m -9.0886,-35.136 c 0,-5.7019 4.6265,-10.336 10.335,-10.336 5.7012,0 10.334,4.6272 10.334,10.336 0,5.7004 -4.6265,10.333 -10.334,10.333 -5.7011,0 -10.335,-4.6265 -10.335,-10.333 z"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         id="path5125" />
-      <rect
-         x="-4308.7002"
-         y="-1215.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5127" />
+    <g transform="translate(4762.2,453.54)" id="g5129">
+      <path d="m -4257.3,-1035.8 c 0,9.1307 7.4005,16.536 16.534,16.536 h 128.14 c 9.1299,0 16.534,-7.3997 16.534,-16.536 v -95.074 c 0,-9.1307 -7.3997,-16.534 -16.534,-16.534 h -49.604 c -4.5447,0 -8.2703,-3.7161 -8.2703,-8.2712 0,-4.5439 3.7161,-8.2695 8.2703,-8.2695 h 55.805 c 5.7011,0 10.333,-4.6265 10.333,-10.334 0,-5.7011 -4.6257,-10.335 -10.333,-10.335 h -68.206 c -7.7275,0 -14.716,5.2503 -16.535,12.402 l -8.2291,24.802 h -16.907 c -5.5376,0 -10.459,2.1906 -14.014,5.7011 l -20.917,21 c -3.7566,3.7153 -6.0797,8.9252 -6.0797,14.633 v 12.402 h -16.536 v -2.0676 c 0,-5.7011 -4.6257,-10.335 -10.333,-10.335 -5.7011,0 -10.335,4.6256 -10.335,10.335 v 53.737 c 0,5.7019 4.6265,10.335 10.335,10.335 5.7011,0 10.333,-4.6273 10.333,-10.335 v -2.0676 h 16.536 v 8.2712 z m 54.564,-45.469 h 76.887 c 5.0456,0 9.0887,4.0526 9.0887,9.0886 v 23.149 c 0,5.0463 -4.0534,9.0886 -9.0887,9.0886 h -76.887 c -5.0455,0 -9.0886,-4.0534 -9.0886,-9.0886 v -23.149 c 0,-5.0463 4.0534,-9.0886 9.0886,-9.0886 z m -9.0886,-35.136 c 0,-5.7019 4.6265,-10.336 10.335,-10.336 5.7012,0 10.334,4.6272 10.334,10.336 0,5.7004 -4.6265,10.333 -10.334,10.333 -5.7011,0 -10.335,-4.6265 -10.335,-10.333 z" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" id="path5125"/>
+      <rect x="-4308.7002" y="-1215.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect5127"/>
     </g>
-    <g
-       transform="translate(-4535.4,-453.54)"
-       id="g5135">
-      <path
-         d="m 6462.8,-1881.5 c -3.084,0.095 -5.7683,2.1352 -6.6842,5.0816 l -57.125,183.96 c -1.4444,4.6536 2.0332,9.375 6.9058,9.3757 h 114.25 c 4.8727,-7e-4 8.3503,-4.722 6.9059,-9.3757 l -57.125,-183.96 c -0.9646,-3.1026 -3.8799,-5.1811 -7.1274,-5.0816 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5131" />
-      <rect
-         x="6349.6001"
-         y="-1895.7"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5133" />
+    <g transform="translate(-4535.4,-453.54)" id="g5135">
+      <path d="m 6462.8,-1881.5 c -3.084,0.095 -5.7683,2.1352 -6.6842,5.0816 l -57.125,183.96 c -1.4444,4.6536 2.0332,9.375 6.9058,9.3757 h 114.25 c 4.8727,-7e-4 8.3503,-4.722 6.9059,-9.3757 l -57.125,-183.96 c -0.9646,-3.1026 -3.8799,-5.1811 -7.1274,-5.0816 z" fill="#ffffff" opacity="1" id="path5131"/>
+      <rect x="6349.6001" y="-1895.7" width="226.77" height="226.77" fill="none" opacity="1" id="rect5133"/>
     </g>
-    <g
-       transform="translate(-4535.4,-453.54)"
-       id="g5141">
-      <path
-         d="m 6916.3,-1881.5 c -2.5152,-0.037 -4.8684,1.2384 -6.209,3.3671 l -58.642,93.148 c -0.727,1.1544 -1.1111,2.4912 -1.1086,3.8554 l 0.1786,90.859 c 0.012,3.976 3.2333,7.195 7.2092,7.1953 h 116.93 c 3.953,0 7.1686,-3.1842 7.2087,-7.1373 l 0.8819,-88.433 c 0.014,-1.3683 -0.3622,-2.7123 -1.084,-3.875 l -59.346,-95.574 c -1.2954,-2.085 -3.5623,-3.3679 -6.0167,-3.4048 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5137" />
-      <rect
-         x="6803.1001"
-         y="-1895.7"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5139" />
+    <g transform="translate(-4535.4,-453.54)" id="g5141">
+      <path d="m 6916.3,-1881.5 c -2.5152,-0.037 -4.8684,1.2384 -6.209,3.3671 l -58.642,93.148 c -0.727,1.1544 -1.1111,2.4912 -1.1086,3.8554 l 0.1786,90.859 c 0.012,3.976 3.2333,7.195 7.2092,7.1953 h 116.93 c 3.953,0 7.1686,-3.1842 7.2087,-7.1373 l 0.8819,-88.433 c 0.014,-1.3683 -0.3622,-2.7123 -1.084,-3.875 l -59.346,-95.574 c -1.2954,-2.085 -3.5623,-3.3679 -6.0167,-3.4048 z" fill="#ffffff" opacity="1" id="path5137"/>
+      <rect x="6803.1001" y="-1895.7" width="226.77" height="226.77" fill="none" opacity="1" id="rect5139"/>
     </g>
-    <g
-       transform="translate(-4762.2,-453.54)"
-       id="g5147">
-      <path
-         d="m 7369.8,-1881.5 c -2.5153,-0.037 -4.8684,1.2382 -6.209,3.3669 l -58.642,93.148 c -0.7267,1.1544 -1.1111,2.4913 -1.1084,3.8554 l 0.1788,90.859 c 0.012,3.9759 3.2333,7.1949 7.2093,7.1953 h 116.93 c 3.9533,-5e-4 7.1689,-3.1842 7.2089,-7.1372 l 0.8821,-88.433 c 0.013,-1.3683 -0.3625,-2.7124 -1.0843,-3.875 l -59.346,-95.574 c -1.2951,-2.085 -3.562,-3.3679 -6.0163,-3.4047 z m -0.1506,20.806 52.158,83.998 -0.7898,79.2 h -102.59 l -0.1607,-81.575 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5143" />
-      <rect
-         x="7256.7002"
-         y="-1895.7"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5145" />
+    <g transform="translate(-4762.2,-453.54)" id="g5147">
+      <path d="m 7369.8,-1881.5 c -2.5153,-0.037 -4.8684,1.2382 -6.209,3.3669 l -58.642,93.148 c -0.7267,1.1544 -1.1111,2.4913 -1.1084,3.8554 l 0.1788,90.859 c 0.012,3.9759 3.2333,7.1949 7.2093,7.1953 h 116.93 c 3.9533,-5e-4 7.1689,-3.1842 7.2089,-7.1372 l 0.8821,-88.433 c 0.013,-1.3683 -0.3625,-2.7124 -1.0843,-3.875 l -59.346,-95.574 c -1.2951,-2.085 -3.562,-3.3679 -6.0163,-3.4047 z m -0.1506,20.806 52.158,83.998 -0.7898,79.2 h -102.59 l -0.1607,-81.575 z" fill="#ffffff" opacity="1" id="path5143"/>
+      <rect x="7256.7002" y="-1895.7" width="226.77" height="226.77" fill="none" opacity="1" id="rect5145"/>
     </g>
-    <g
-       transform="translate(-1587.4,-453.54)"
-       id="g5155">
-      <path
-         d="m 4445.4,-1808.1 -23.136,-19.493 -23.523,19.742"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="path5149" />
-      <path
-         d="m 4422,-1795.3 c 7.5844,0 13.578,5.9934 13.578,13.578 0,7.5846 -5.9934,13.578 -13.578,13.578 -7.5842,0 -13.578,-5.9935 -13.578,-13.578 0,-7.5845 5.9937,-13.578 13.578,-13.578 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5151" />
-      <rect
-         x="4308.7002"
-         y="-1895.7"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5153" />
+    <g transform="translate(-1587.4,-453.54)" id="g5155">
+      <path d="m 4445.4,-1808.1 -23.136,-19.493 -23.523,19.742" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="path5149"/>
+      <path d="m 4422,-1795.3 c 7.5844,0 13.578,5.9934 13.578,13.578 0,7.5846 -5.9934,13.578 -13.578,13.578 -7.5842,0 -13.578,-5.9935 -13.578,-13.578 0,-7.5845 5.9937,-13.578 13.578,-13.578 z" fill="#ffffff" opacity="1" id="path5151"/>
+      <rect x="4308.7002" y="-1895.7" width="226.77" height="226.77" fill="none" opacity="1" id="rect5153"/>
     </g>
-    <g
-       transform="translate(-9751.2,-226.77)"
-       id="g5161">
-      <path
-         d="m 11452,-2261.3 c -14.191,0 -25.772,11.582 -25.772,25.772 0,14.191 11.581,25.772 25.772,25.772 14.19,0 25.773,-11.582 25.773,-25.772 0,-14.191 -11.583,-25.772 -25.773,-25.772 z m 0,63.584 c -79.895,31.597 -39.948,15.799 0,0 z m 0,-137.31 c -54.629,0 -99.214,44.584 -99.214,99.213 0,54.629 44.585,99.213 99.214,99.213 54.628,0 99.213,-44.584 99.213,-99.213 0,-54.629 -44.585,-99.213 -99.213,-99.213 z m 0,27.908 c 39.545,0 71.304,31.759 71.304,71.305 0,39.546 -31.759,71.305 -71.304,71.305 -39.546,0 -71.305,-31.759 -71.305,-71.305 0,-39.546 31.759,-71.305 71.305,-71.305 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5157" />
-      <rect
-         x="11339"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5159" />
+    <g transform="translate(-9751.2,-226.77)" id="g5161">
+      <path d="m 11452,-2261.3 c -14.191,0 -25.772,11.582 -25.772,25.772 0,14.191 11.581,25.772 25.772,25.772 14.19,0 25.773,-11.582 25.773,-25.772 0,-14.191 -11.583,-25.772 -25.773,-25.772 z m 0,63.584 c -79.895,31.597 -39.948,15.799 0,0 z m 0,-137.31 c -54.629,0 -99.214,44.584 -99.214,99.213 0,54.629 44.585,99.213 99.214,99.213 54.628,0 99.213,-44.584 99.213,-99.213 0,-54.629 -44.585,-99.213 -99.213,-99.213 z m 0,27.908 c 39.545,0 71.304,31.759 71.304,71.305 0,39.546 -31.759,71.305 -71.304,71.305 -39.546,0 -71.305,-31.759 -71.305,-71.305 0,-39.546 31.759,-71.305 71.305,-71.305 z" fill="#ffffff" opacity="1" id="path5157"/>
+      <rect x="11339" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5159"/>
     </g>
-    <g
-       transform="translate(-7710.2,-226.77)"
-       id="g5171">
-      <rect
-         x="8617.2998"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5163" />
-      <g
-         transform="rotate(-90,8701.7,-2264.8)"
-         fill="#ffffff"
-         id="g5169">
-        <path
-           d="m 8730.1,-2324.7 a 14.175,14.175 0 0 0 -13.898,14.434 l 0.6387,148.9 a 14.175,14.175 0 1 0 28.346,-0.121 l -0.6367,-148.9 a 14.175,14.175 0 0 0 -14.449,-14.312 z"
-           color="#000000"
-           color-rendering="auto"
-           image-rendering="auto"
-           opacity="1"
-           shape-rendering="auto"
-           solid-color="#000000"
-           style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal"
-           id="path5165" />
-        <path
-           d="m 8600.2,-2236.7 c 0.095,-4.2767 1.8191,-8.3558 4.8216,-11.403 l 69.409,-70.429 c 6.4729,-6.7538 17.22,-6.9072 23.882,-0.3407 6.6627,6.5663 6.6662,17.314 0.011,23.885 l -57.807,58.657 58.804,59.668 c 6.6587,6.5705 6.6551,17.318 -0.011,23.885 -6.6627,6.5663 -17.409,6.4129 -23.882,-0.3409 l -70.405,-71.44 c -3.1817,-3.229 -4.9209,-7.6084 -4.8216,-12.14 z"
-           opacity="1"
-           id="path5167" />
+    <g transform="translate(-7710.2,-226.77)" id="g5171">
+      <rect x="8617.2998" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5163"/>
+      <g transform="rotate(-90,8701.7,-2264.8)" fill="#ffffff" id="g5169">
+        <path d="m 8730.1,-2324.7 a 14.175,14.175 0 0 0 -13.898,14.434 l 0.6387,148.9 a 14.175,14.175 0 1 0 28.346,-0.121 l -0.6367,-148.9 a 14.175,14.175 0 0 0 -14.449,-14.312 z" color="#000000" color-rendering="auto" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal" id="path5165"/>
+        <path d="m 8600.2,-2236.7 c 0.095,-4.2767 1.8191,-8.3558 4.8216,-11.403 l 69.409,-70.429 c 6.4729,-6.7538 17.22,-6.9072 23.882,-0.3407 6.6627,6.5663 6.6662,17.314 0.011,23.885 l -57.807,58.657 58.804,59.668 c 6.6587,6.5705 6.6551,17.318 -0.011,23.885 -6.6627,6.5663 -17.409,6.4129 -23.882,-0.3409 l -70.405,-71.44 c -3.1817,-3.229 -4.9209,-7.6084 -4.8216,-12.14 z" opacity="1" id="path5167"/>
       </g>
     </g>
-    <g
-       transform="matrix(1,0,0,-1,-7483.5,-4698.4)"
-       id="g5181">
-      <rect
-         x="8617.2998"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5173" />
-      <g
-         transform="rotate(-90,8701.7,-2264.8)"
-         fill="#ffffff"
-         id="g5179">
-        <path
-           d="m 8730.1,-2324.7 a 14.175,14.175 0 0 0 -13.898,14.434 l 0.6387,148.9 a 14.175,14.175 0 1 0 28.346,-0.121 l -0.6367,-148.9 a 14.175,14.175 0 0 0 -14.449,-14.312 z"
-           color="#000000"
-           color-rendering="auto"
-           image-rendering="auto"
-           opacity="1"
-           shape-rendering="auto"
-           solid-color="#000000"
-           style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal"
-           id="path5175" />
-        <path
-           d="m 8600.2,-2236.7 c 0.095,-4.2767 1.8191,-8.3558 4.8216,-11.403 l 69.409,-70.429 c 6.4729,-6.7538 17.22,-6.9072 23.882,-0.3407 6.6627,6.5663 6.6662,17.314 0.011,23.885 l -57.807,58.657 58.804,59.668 c 6.6587,6.5705 6.6551,17.318 -0.011,23.885 -6.6627,6.5663 -17.409,6.4129 -23.882,-0.3409 l -70.405,-71.44 c -3.1817,-3.229 -4.9209,-7.6084 -4.8216,-12.14 z"
-           opacity="1"
-           id="path5177" />
+    <g transform="matrix(1,0,0,-1,-7483.5,-4698.4)" id="g5181">
+      <rect x="8617.2998" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5173"/>
+      <g transform="rotate(-90,8701.7,-2264.8)" fill="#ffffff" id="g5179">
+        <path d="m 8730.1,-2324.7 a 14.175,14.175 0 0 0 -13.898,14.434 l 0.6387,148.9 a 14.175,14.175 0 1 0 28.346,-0.121 l -0.6367,-148.9 a 14.175,14.175 0 0 0 -14.449,-14.312 z" color="#000000" color-rendering="auto" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal" id="path5175"/>
+        <path d="m 8600.2,-2236.7 c 0.095,-4.2767 1.8191,-8.3558 4.8216,-11.403 l 69.409,-70.429 c 6.4729,-6.7538 17.22,-6.9072 23.882,-0.3407 6.6627,6.5663 6.6662,17.314 0.011,23.885 l -57.807,58.657 58.804,59.668 c 6.6587,6.5705 6.6551,17.318 -0.011,23.885 -6.6627,6.5663 -17.409,6.4129 -23.882,-0.3409 l -70.405,-71.44 c -3.1817,-3.229 -4.9209,-7.6084 -4.8216,-12.14 z" opacity="1" id="path5177"/>
       </g>
     </g>
-    <g
-       transform="translate(907.09,-1360.6)"
-       id="g5191">
-      <rect
-         x="1814.2"
-         y="-761.81"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5183" />
-      <circle
-         cx="1970.1"
-         cy="-648.42999"
-         r="35.432999"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="circle5185" />
-      <ellipse
-         cx="1927.6"
-         cy="-648.42999"
-         rx="77.953003"
-         ry="49.605999"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="ellipse5187" />
-      <circle
-         cx="1970.1"
-         cy="-648.42999"
-         r="14.173"
-         fill="#ffffff"
-         opacity="1"
-         id="circle5189" />
+    <g transform="translate(907.09,-1360.6)" id="g5191">
+      <rect x="1814.2" y="-761.81" width="226.77" height="226.77" fill="none" opacity="1" id="rect5183"/>
+      <circle cx="1970.1" cy="-648.42999" r="35.432999" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="circle5185"/>
+      <ellipse cx="1927.6" cy="-648.42999" rx="77.953003" ry="49.605999" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="ellipse5187"/>
+      <circle cx="1970.1" cy="-648.42999" r="14.173" fill="#ffffff" opacity="1" id="circle5189"/>
     </g>
-    <g
-       transform="translate(2721.3,-1587.4)"
-       id="g5205">
-      <rect
-         x="226.77"
-         y="-535.03998"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5193" />
-      <g
-         transform="translate(-1629.9,226.77)"
-         id="g5199">
-        <circle
-           cx="1970.1"
-           cy="-648.42999"
-           r="92.125999"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="circle5195" />
-        <circle
-           cx="1970.1"
-           cy="-648.42999"
-           r="28.346001"
-           fill="#ffffff"
-           opacity="1"
-           id="circle5197" />
+    <g transform="translate(2721.3,-1587.4)" id="g5205">
+      <rect x="226.77" y="-535.03998" width="226.77" height="226.77" fill="none" opacity="1" id="rect5193"/>
+      <g transform="translate(-1629.9,226.77)" id="g5199">
+        <circle cx="1970.1" cy="-648.42999" r="92.125999" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="circle5195"/>
+        <circle cx="1970.1" cy="-648.42999" r="28.346001" fill="#ffffff" opacity="1" id="circle5197"/>
       </g>
-      <path
-         d="m 340.16,-421.65 63.708,-63.708"
-         fill="#ffffff"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path5201" />
-      <path
-         d="M 252.08,-421.74 H 431.63"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-opacity="0.51515"
-         stroke-width="14.173"
-         id="path5203" />
+      <path d="m 340.16,-421.65 63.708,-63.708" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path5201"/>
+      <path d="M 252.08,-421.74 H 431.63" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.51515" stroke-width="14.173" id="path5203"/>
     </g>
-    <g
-       transform="rotate(90,5215.7,-5977.6)"
-       id="g5211">
-      <path
-         d="m 9125.5,-2236.8 c 0.1068,-4.8286 2.0538,-9.434 5.4438,-12.874 l 78.365,-79.517 c 7.3082,-7.6253 19.441,-7.7985 26.964,-0.3847 7.5224,7.4136 7.5264,19.548 0.012,26.967 l -65.267,66.226 66.392,67.367 c 7.518,7.4184 7.5139,19.553 -0.012,26.967 -7.5225,7.4136 -19.656,7.2404 -26.964,-0.3849 l -79.49,-80.659 c -3.5923,-3.6456 -5.5559,-8.5902 -5.4438,-13.707 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5207" />
-      <rect
-         x="9070.9004"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5209" />
+    <g transform="rotate(90,5215.7,-5977.6)" id="g5211">
+      <path d="m 9125.5,-2236.8 c 0.1068,-4.8286 2.0538,-9.434 5.4438,-12.874 l 78.365,-79.517 c 7.3082,-7.6253 19.441,-7.7985 26.964,-0.3847 7.5224,7.4136 7.5264,19.548 0.012,26.967 l -65.267,66.226 66.392,67.367 c 7.518,7.4184 7.5139,19.553 -0.012,26.967 -7.5225,7.4136 -19.656,7.2404 -26.964,-0.3849 l -79.49,-80.659 c -3.5923,-3.6456 -5.5559,-8.5902 -5.4438,-13.707 z" fill="#ffffff" opacity="1" id="path5207"/>
+      <rect x="9070.9004" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5209"/>
     </g>
-    <g
-       transform="rotate(-90,5669.3,1505.9)"
-       id="g5217">
-      <path
-         d="m 9125.5,-2236.8 c 0.1068,-4.8286 2.0538,-9.434 5.4438,-12.874 l 78.365,-79.517 c 7.3082,-7.6253 19.441,-7.7985 26.964,-0.3847 7.5224,7.4136 7.5264,19.548 0.012,26.967 l -65.267,66.226 66.392,67.367 c 7.518,7.4184 7.5139,19.553 -0.012,26.967 -7.5225,7.4136 -19.656,7.2404 -26.964,-0.3849 l -79.49,-80.659 c -3.5923,-3.6456 -5.5559,-8.5902 -5.4438,-13.707 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5213" />
-      <rect
-         x="9070.9004"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5215" />
+    <g transform="rotate(-90,5669.3,1505.9)" id="g5217">
+      <path d="m 9125.5,-2236.8 c 0.1068,-4.8286 2.0538,-9.434 5.4438,-12.874 l 78.365,-79.517 c 7.3082,-7.6253 19.441,-7.7985 26.964,-0.3847 7.5224,7.4136 7.5264,19.548 0.012,26.967 l -65.267,66.226 66.392,67.367 c 7.518,7.4184 7.5139,19.553 -0.012,26.967 -7.5225,7.4136 -19.656,7.2404 -26.964,-0.3849 l -79.49,-80.659 c -3.5923,-3.6456 -5.5559,-8.5902 -5.4438,-13.707 z" fill="#ffffff" opacity="1" id="path5213"/>
+      <rect x="9070.9004" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5215"/>
     </g>
-    <g
-       transform="matrix(-1,0,0,1,12699,226.77)"
-       id="g5223">
-      <path
-         d="m 11452,-2335 c -54.629,0 -99.214,44.584 -99.214,99.213 0,54.629 44.585,99.213 99.214,99.213 54.628,0 99.213,-44.584 99.213,-99.213 0,-54.629 -44.585,-99.213 -99.213,-99.213 z m 0,27.908 c 39.545,0 71.304,31.759 71.304,71.305 0,39.546 -31.759,71.305 -71.304,71.305 -39.546,0 -71.305,-31.759 -71.305,-71.305 0,-39.546 31.759,-71.305 71.305,-71.305 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5219" />
-      <rect
-         x="11339"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5221" />
+    <g transform="matrix(-1,0,0,1,12699,226.77)" id="g5223">
+      <path d="m 11452,-2335 c -54.629,0 -99.214,44.584 -99.214,99.213 0,54.629 44.585,99.213 99.214,99.213 54.628,0 99.213,-44.584 99.213,-99.213 0,-54.629 -44.585,-99.213 -99.213,-99.213 z m 0,27.908 c 39.545,0 71.304,31.759 71.304,71.305 0,39.546 -31.759,71.305 -71.304,71.305 -39.546,0 -71.305,-31.759 -71.305,-71.305 0,-39.546 31.759,-71.305 71.305,-71.305 z" fill="#ffffff" opacity="1" id="path5219"/>
+      <rect x="11339" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5221"/>
     </g>
-    <g
-       transform="rotate(-90,6009.4,1165.7)"
-       id="g5235">
-      <rect
-         x="9070.9004"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5225" />
-      <g
-         transform="translate(-30.429,1.7114e-5)"
-         fill="#ffffff"
-         id="g5233">
-        <path
-           d="m 9115.5,-2236.6 c 0.082,-3.6953 1.5717,-7.2197 4.1661,-9.8525 l 59.972,-60.854 c 5.5929,-5.8356 14.878,-5.9681 20.635,-0.2945 5.7568,5.6736 5.7599,14.96 0.01,20.637 l -49.948,50.682 50.809,51.555 c 5.7534,5.6772 5.7503,14.964 -0.01,20.637 -5.7569,5.6735 -15.042,5.541 -20.635,-0.2945 l -60.833,-61.727 c -2.7492,-2.7899 -4.2519,-6.5739 -4.1661,-10.49 z"
-           opacity="1"
-           id="path5227" />
-        <path
-           d="m 9169.7,-2236.6 c 0.082,-3.6953 1.5718,-7.2197 4.1661,-9.8525 l 59.972,-60.854 c 5.5929,-5.8356 14.878,-5.9681 20.635,-0.2945 5.7567,5.6736 5.7598,14.96 0.01,20.637 l -49.948,50.682 50.809,51.555 c 5.7534,5.6772 5.7503,14.964 -0.01,20.637 -5.7568,5.6735 -15.042,5.541 -20.635,-0.2945 l -60.833,-61.727 c -2.7491,-2.7899 -4.2519,-6.5739 -4.1661,-10.49 z"
-           opacity="1"
-           id="path5229" />
-        <path
-           d="m 9223.9,-2236.6 c 0.082,-3.6953 1.5717,-7.2197 4.166,-9.8525 l 59.972,-60.854 c 5.5928,-5.8356 14.878,-5.9681 20.635,-0.2945 5.7568,5.6736 5.7599,14.96 0.01,20.637 l -49.948,50.682 50.809,51.555 c 5.7534,5.6772 5.7503,14.964 -0.01,20.637 -5.7569,5.6735 -15.042,5.541 -20.635,-0.2945 l -60.833,-61.727 c -2.7491,-2.7899 -4.2518,-6.5739 -4.166,-10.49 z"
-           opacity="1"
-           id="path5231" />
+    <g transform="rotate(-90,6009.4,1165.7)" id="g5235">
+      <rect x="9070.9004" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5225"/>
+      <g transform="translate(-30.429,1.7114e-5)" fill="#ffffff" id="g5233">
+        <path d="m 9115.5,-2236.6 c 0.082,-3.6953 1.5717,-7.2197 4.1661,-9.8525 l 59.972,-60.854 c 5.5929,-5.8356 14.878,-5.9681 20.635,-0.2945 5.7568,5.6736 5.7599,14.96 0.01,20.637 l -49.948,50.682 50.809,51.555 c 5.7534,5.6772 5.7503,14.964 -0.01,20.637 -5.7569,5.6735 -15.042,5.541 -20.635,-0.2945 l -60.833,-61.727 c -2.7492,-2.7899 -4.2519,-6.5739 -4.1661,-10.49 z" opacity="1" id="path5227"/>
+        <path d="m 9169.7,-2236.6 c 0.082,-3.6953 1.5718,-7.2197 4.1661,-9.8525 l 59.972,-60.854 c 5.5929,-5.8356 14.878,-5.9681 20.635,-0.2945 5.7567,5.6736 5.7598,14.96 0.01,20.637 l -49.948,50.682 50.809,51.555 c 5.7534,5.6772 5.7503,14.964 -0.01,20.637 -5.7568,5.6735 -15.042,5.541 -20.635,-0.2945 l -60.833,-61.727 c -2.7491,-2.7899 -4.2519,-6.5739 -4.1661,-10.49 z" opacity="1" id="path5229"/>
+        <path d="m 9223.9,-2236.6 c 0.082,-3.6953 1.5717,-7.2197 4.166,-9.8525 l 59.972,-60.854 c 5.5928,-5.8356 14.878,-5.9681 20.635,-0.2945 5.7568,5.6736 5.7599,14.96 0.01,20.637 l -49.948,50.682 50.809,51.555 c 5.7534,5.6772 5.7503,14.964 -0.01,20.637 -5.7569,5.6735 -15.042,5.541 -20.635,-0.2945 l -60.833,-61.727 c -2.7491,-2.7899 -4.2518,-6.5739 -4.166,-10.49 z" opacity="1" id="path5231"/>
       </g>
     </g>
-    <g
-       transform="translate(1814.2,-1587.4)"
-       id="g5243">
-      <g
-         transform="translate(-1629.9,226.77)"
-         fill="#ffffff"
-         id="g5239">
-        <path
-           transform="translate(496.06,-2802.8)"
-           d="m 1474,2055.1 c -54.71,-10e-5 -99.211,44.503 -99.211,99.213 0,54.71 44.501,99.213 99.211,99.213 54.71,0 99.213,-44.503 99.213,-99.213 0,-54.71 -44.503,-99.213 -99.213,-99.213 z m 25.695,32.449 a 10.631,10.631 0 0 1 1.0606,0.043 10.631,10.631 0 0 1 1.0527,0.1465 10.631,10.631 0 0 1 1.0313,0.2539 10.631,10.631 0 0 1 1.0019,0.3535 10.631,10.631 0 0 1 1.875,0.998 10.631,10.631 0 0 1 1.6367,1.3516 10.631,10.631 0 0 1 1.336,1.6484 10.631,10.631 0 0 1 0.539,0.916 10.631,10.631 0 0 1 0.4434,0.9649 10.631,10.631 0 0 1 0.3457,1.0058 10.631,10.631 0 0 1 0.2441,1.0332 10.631,10.631 0 0 1 0.1387,1.0547 10.631,10.631 0 0 1 0.033,1.0625 10.631,10.631 0 0 1 -0.074,1.0586 10.631,10.631 0 0 1 -0.1777,1.0489 10.631,10.631 0 0 1 -0.2832,1.0234 10.631,10.631 0 0 1 -0.3829,0.9922 l -21.947,47.476 27.385,13.367 a 10.631,10.631 0 0 1 0.1269,0.064 10.631,10.631 0 0 1 0.916,0.5391 10.631,10.631 0 0 1 3.9961,4.8496 10.631,10.631 0 0 1 0.7305,5.2089 10.631,10.631 0 0 1 -0.1719,1.0489 10.631,10.631 0 0 1 -5.6738,7.3008 10.631,10.631 0 0 1 -1.9883,0.748 10.631,10.631 0 0 1 -1.0391,0.2227 10.631,10.631 0 0 1 -2.1191,0.1269 10.631,10.631 0 0 1 -3.1191,-0.5996 10.631,10.631 0 0 1 -0.9825,-0.4043 l -36.773,-17.949 a 10.631,10.631 0 0 1 -0.127,-0.064 10.631,10.631 0 0 1 -1.7734,-1.166 10.631,10.631 0 0 1 -0.791,-0.7109 10.631,10.631 0 0 1 -1.3496,-1.6367 10.631,10.631 0 0 1 -0.5449,-0.9122 10.631,10.631 0 0 1 -0.4532,-0.9628 10.631,10.631 0 0 1 -0.3535,-1.002 10.631,10.631 0 0 1 -0.3984,-2.084 10.631,10.631 0 0 1 0.022,-2.123 10.631,10.631 0 0 1 0.4453,-2.0742 10.631,10.631 0 0 1 0.3047,-0.8106 10.631,10.631 0 0 1 0.4804,-1.3437 l 25.902,-56.031 a 10.631,10.631 0 0 1 0.062,-0.1269 10.631,10.631 0 0 1 1.8203,-2.6036 10.631,10.631 0 0 1 2.5098,-1.9492 10.631,10.631 0 0 1 2.9726,-1.1191 10.631,10.631 0 0 1 1.0488,-0.1699 10.631,10.631 0 0 1 1.0625,-0.064 z"
-           color="#000000"
-           color-rendering="auto"
-           fill="#ffffff"
-           image-rendering="auto"
-           opacity="1"
-           shape-rendering="auto"
-           solid-color="#000000"
-           style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal"
-           id="path5237" />
+    <g transform="translate(1814.2,-1587.4)" id="g5243">
+      <g transform="translate(-1629.9,226.77)" fill="#ffffff" id="g5239">
+        <path transform="translate(496.06,-2802.8)" d="m 1474,2055.1 c -54.71,-10e-5 -99.211,44.503 -99.211,99.213 0,54.71 44.501,99.213 99.211,99.213 54.71,0 99.213,-44.503 99.213,-99.213 0,-54.71 -44.503,-99.213 -99.213,-99.213 z m 25.695,32.449 a 10.631,10.631 0 0 1 1.0606,0.043 10.631,10.631 0 0 1 1.0527,0.1465 10.631,10.631 0 0 1 1.0313,0.2539 10.631,10.631 0 0 1 1.0019,0.3535 10.631,10.631 0 0 1 1.875,0.998 10.631,10.631 0 0 1 1.6367,1.3516 10.631,10.631 0 0 1 1.336,1.6484 10.631,10.631 0 0 1 0.539,0.916 10.631,10.631 0 0 1 0.4434,0.9649 10.631,10.631 0 0 1 0.3457,1.0058 10.631,10.631 0 0 1 0.2441,1.0332 10.631,10.631 0 0 1 0.1387,1.0547 10.631,10.631 0 0 1 0.033,1.0625 10.631,10.631 0 0 1 -0.074,1.0586 10.631,10.631 0 0 1 -0.1777,1.0489 10.631,10.631 0 0 1 -0.2832,1.0234 10.631,10.631 0 0 1 -0.3829,0.9922 l -21.947,47.476 27.385,13.367 a 10.631,10.631 0 0 1 0.1269,0.064 10.631,10.631 0 0 1 0.916,0.5391 10.631,10.631 0 0 1 3.9961,4.8496 10.631,10.631 0 0 1 0.7305,5.2089 10.631,10.631 0 0 1 -0.1719,1.0489 10.631,10.631 0 0 1 -5.6738,7.3008 10.631,10.631 0 0 1 -1.9883,0.748 10.631,10.631 0 0 1 -1.0391,0.2227 10.631,10.631 0 0 1 -2.1191,0.1269 10.631,10.631 0 0 1 -3.1191,-0.5996 10.631,10.631 0 0 1 -0.9825,-0.4043 l -36.773,-17.949 a 10.631,10.631 0 0 1 -0.127,-0.064 10.631,10.631 0 0 1 -1.7734,-1.166 10.631,10.631 0 0 1 -0.791,-0.7109 10.631,10.631 0 0 1 -1.3496,-1.6367 10.631,10.631 0 0 1 -0.5449,-0.9122 10.631,10.631 0 0 1 -0.4532,-0.9628 10.631,10.631 0 0 1 -0.3535,-1.002 10.631,10.631 0 0 1 -0.3984,-2.084 10.631,10.631 0 0 1 0.022,-2.123 10.631,10.631 0 0 1 0.4453,-2.0742 10.631,10.631 0 0 1 0.3047,-0.8106 10.631,10.631 0 0 1 0.4804,-1.3437 l 25.902,-56.031 a 10.631,10.631 0 0 1 0.062,-0.1269 10.631,10.631 0 0 1 1.8203,-2.6036 10.631,10.631 0 0 1 2.5098,-1.9492 10.631,10.631 0 0 1 2.9726,-1.1191 10.631,10.631 0 0 1 1.0488,-0.1699 10.631,10.631 0 0 1 1.0625,-0.064 z" color="#000000" color-rendering="auto" fill="#ffffff" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal" id="path5237"/>
       </g>
-      <rect
-         x="226.77"
-         y="-535.03998"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5241" />
+      <rect x="226.77" y="-535.03998" width="226.77" height="226.77" fill="none" opacity="1" id="rect5241"/>
     </g>
-    <g
-       transform="translate(-8163.8,226.77)"
-       id="g5251">
-      <path
-         d="m 11452,-2335 c -54.629,0 -99.214,44.584 -99.214,99.213 0,54.629 44.585,99.213 99.214,99.213 54.628,0 99.213,-44.584 99.213,-99.213 0,-54.629 -44.585,-99.213 -99.213,-99.213 z m 0,27.908 c 39.545,0 71.304,31.759 71.304,71.305 0,39.546 -31.759,71.305 -71.304,71.305 -39.546,0 -71.305,-31.759 -71.305,-71.305 0,-39.546 31.759,-71.305 71.305,-71.305 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5245" />
-      <rect
-         x="11339"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5247" />
-      <path
-         d="m 11452,-2335 c 54.629,0 99.214,44.584 99.214,99.213 0,54.629 -44.585,99.213 -99.214,99.213 -54.628,0 -99.213,-44.584 -99.213,-99.213 0,-54.629 44.585,-99.213 99.213,-99.213 z m 0,27.908 c -39.545,0 -71.304,31.759 -71.304,71.305 0,39.546 31.759,71.305 71.304,71.305 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5249" />
+    <g transform="translate(-8163.8,226.77)" id="g5251">
+      <path d="m 11452,-2335 c -54.629,0 -99.214,44.584 -99.214,99.213 0,54.629 44.585,99.213 99.214,99.213 54.628,0 99.213,-44.584 99.213,-99.213 0,-54.629 -44.585,-99.213 -99.213,-99.213 z m 0,27.908 c 39.545,0 71.304,31.759 71.304,71.305 0,39.546 -31.759,71.305 -71.304,71.305 -39.546,0 -71.305,-31.759 -71.305,-71.305 0,-39.546 31.759,-71.305 71.305,-71.305 z" fill="#ffffff" opacity="1" id="path5245"/>
+      <rect x="11339" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5247"/>
+      <path d="m 11452,-2335 c 54.629,0 99.214,44.584 99.214,99.213 0,54.629 -44.585,99.213 -99.214,99.213 -54.628,0 -99.213,-44.584 -99.213,-99.213 0,-54.629 44.585,-99.213 99.213,-99.213 z m 0,27.908 c -39.545,0 -71.304,31.759 -71.304,71.305 0,39.546 31.759,71.305 71.304,71.305 z" fill="#ffffff" opacity="1" id="path5249"/>
     </g>
-    <g
-       transform="rotate(-90,7596.9,1846.1)"
-       id="g5259">
-      <path
-         d="m 11452,-2335 c -54.629,0 -99.214,44.584 -99.214,99.213 0,54.629 44.585,99.213 99.214,99.213 54.628,0 99.213,-44.584 99.213,-99.213 0,-54.629 -44.585,-99.213 -99.213,-99.213 z m 0,27.908 c 39.545,0 71.304,31.759 71.304,71.305 0,39.546 -31.759,71.305 -71.304,71.305 -39.546,0 -71.305,-31.759 -71.305,-71.305 0,-39.546 31.759,-71.305 71.305,-71.305 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5253" />
-      <rect
-         x="11339"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5255" />
-      <path
-         d="m 11452,-2335 c 54.629,0 99.214,44.584 99.214,99.213 0,54.629 -44.585,99.213 -99.214,99.213 -54.628,0 -99.213,-44.584 -99.213,-99.213 0,-54.629 44.585,-99.213 99.213,-99.213 z m 0,27.908 c -39.545,0 -71.304,31.759 -71.304,71.305 0,39.546 31.759,71.305 71.304,71.305 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5257" />
+    <g transform="rotate(-90,7596.9,1846.1)" id="g5259">
+      <path d="m 11452,-2335 c -54.629,0 -99.214,44.584 -99.214,99.213 0,54.629 44.585,99.213 99.214,99.213 54.628,0 99.213,-44.584 99.213,-99.213 0,-54.629 -44.585,-99.213 -99.213,-99.213 z m 0,27.908 c 39.545,0 71.304,31.759 71.304,71.305 0,39.546 -31.759,71.305 -71.304,71.305 -39.546,0 -71.305,-31.759 -71.305,-71.305 0,-39.546 31.759,-71.305 71.305,-71.305 z" fill="#ffffff" opacity="1" id="path5253"/>
+      <rect x="11339" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5255"/>
+      <path d="m 11452,-2335 c 54.629,0 99.214,44.584 99.214,99.213 0,54.629 -44.585,99.213 -99.214,99.213 -54.628,0 -99.213,-44.584 -99.213,-99.213 0,-54.629 44.585,-99.213 99.213,-99.213 z m 0,27.908 c -39.545,0 -71.304,31.759 -71.304,71.305 0,39.546 31.759,71.305 71.304,71.305 z" fill="#ffffff" opacity="1" id="path5257"/>
     </g>
-    <g
-       transform="translate(-3855.1,3174.8)"
-       id="g5265">
-      <path
-         d="m 4322.8,-3596.5 c 0,54.815 44.398,99.213 99.213,99.213 54.815,0 99.213,-44.398 99.213,-99.213 0,-54.815 -44.398,-99.213 -99.213,-99.213 -54.815,0 -99.213,44.398 -99.213,99.213 z m 20.669,0 c 0,-6.3662 0.7441,-12.567 2.1909,-18.478 l 18.478,18.478 -4.1339,24.803 16.536,16.536 v 22.695 c -20.008,-14.22 -33.071,-37.618 -33.071,-64.033 z m 60.478,-76.435 c 5.7872,-1.4055 11.823,-2.1082 18.065,-2.1082 6.9035,0 13.6,0.9094 19.966,2.563 l -3.4311,5.7047 4.1339,4.1339 h 12.402 l 3.4311,-3.4312 c 2.8937,1.5296 5.622,3.1831 8.2677,5.0434 l -7.565,2.5216 -8.2677,8.2677 8.2677,4.1339 v 4.1338 h -8.2677 v 8.2678 c 0,0 5.7047,4.1338 12.402,4.1338 6.5728,0 3.6378,-9.0531 8.2677,-12.402 4.6713,-3.3484 10.335,-2.6043 10.335,-2.6043 l 2.6871,0.7028 c 5.0433,6.6555 9.0531,14.096 11.781,22.157 v 0.4134 c 0,0 -5.8287,-4.1338 -16.535,-4.1338 -10.7063,0 -20.669,4.1338 -20.669,4.1338 0,0 -11.658,3.3898 -12.402,12.402 -1.2814,15.502 4.1339,20.669 4.1339,20.669 l 20.669,12.402 v 40.222 c -13.518,11.037 -30.798,17.652 -49.606,17.652 -8.8878,0 -17.404,-1.4469 -25.382,-4.1752 l 21.248,-49.565 -4.1338,-20.669 c 0,0 -16.411,-20.669 -24.803,-20.669 -8.3919,0 -12.402,12.402 -12.402,12.402 l -8.2678,-16.535 24.803,-16.535 12.402,-33.071 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5261" />
-      <rect
-         x="4308.7002"
-         y="-3709.8"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5263" />
+    <g transform="translate(-3855.1,3174.8)" id="g5265">
+      <path d="m 4322.8,-3596.5 c 0,54.815 44.398,99.213 99.213,99.213 54.815,0 99.213,-44.398 99.213,-99.213 0,-54.815 -44.398,-99.213 -99.213,-99.213 -54.815,0 -99.213,44.398 -99.213,99.213 z m 20.669,0 c 0,-6.3662 0.7441,-12.567 2.1909,-18.478 l 18.478,18.478 -4.1339,24.803 16.536,16.536 v 22.695 c -20.008,-14.22 -33.071,-37.618 -33.071,-64.033 z m 60.478,-76.435 c 5.7872,-1.4055 11.823,-2.1082 18.065,-2.1082 6.9035,0 13.6,0.9094 19.966,2.563 l -3.4311,5.7047 4.1339,4.1339 h 12.402 l 3.4311,-3.4312 c 2.8937,1.5296 5.622,3.1831 8.2677,5.0434 l -7.565,2.5216 -8.2677,8.2677 8.2677,4.1339 v 4.1338 h -8.2677 v 8.2678 c 0,0 5.7047,4.1338 12.402,4.1338 6.5728,0 3.6378,-9.0531 8.2677,-12.402 4.6713,-3.3484 10.335,-2.6043 10.335,-2.6043 l 2.6871,0.7028 c 5.0433,6.6555 9.0531,14.096 11.781,22.157 v 0.4134 c 0,0 -5.8287,-4.1338 -16.535,-4.1338 -10.7063,0 -20.669,4.1338 -20.669,4.1338 0,0 -11.658,3.3898 -12.402,12.402 -1.2814,15.502 4.1339,20.669 4.1339,20.669 l 20.669,12.402 v 40.222 c -13.518,11.037 -30.798,17.652 -49.606,17.652 -8.8878,0 -17.404,-1.4469 -25.382,-4.1752 l 21.248,-49.565 -4.1338,-20.669 c 0,0 -16.411,-20.669 -24.803,-20.669 -8.3919,0 -12.402,12.402 -12.402,12.402 l -8.2678,-16.535 24.803,-16.535 12.402,-33.071 z" fill="#ffffff" opacity="1" id="path5261"/>
+      <rect x="4308.7002" y="-3709.8" width="226.77" height="226.77" fill="none" opacity="1" id="rect5263"/>
     </g>
-    <g
-       transform="translate(-5442.5,3401.6)"
-       id="g5271">
-      <path
-         d="m 5743.4,-3695.7 c -9.1358,0 -16.535,7.3996 -16.535,16.536 v 173.62 c 0,4.5473 3.7205,8.2677 8.2677,8.2677 2.2736,0 4.3406,-0.9094 5.8288,-2.3976 l 21.413,-21.289 c 3.2244,-3.2657 8.4744,-3.2657 11.699,0 l 21.372,21.289 c 1.4882,1.4882 3.5551,2.3976 5.8288,2.3976 4.5472,0 8.2677,-3.7204 8.2677,-8.2677 v -161.22 c 0,-4.7952 3.7205,-8.2677 8.2677,-8.2677 h 10.335 c 5.7048,0 10.335,-4.6299 10.335,-10.335 0,-5.7051 -4.6299,-10.335 -10.335,-10.335 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5267" />
-      <rect
-         x="5669.2998"
-         y="-3709.8"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5269" />
+    <g transform="translate(-5442.5,3401.6)" id="g5271">
+      <path d="m 5743.4,-3695.7 c -9.1358,0 -16.535,7.3996 -16.535,16.536 v 173.62 c 0,4.5473 3.7205,8.2677 8.2677,8.2677 2.2736,0 4.3406,-0.9094 5.8288,-2.3976 l 21.413,-21.289 c 3.2244,-3.2657 8.4744,-3.2657 11.699,0 l 21.372,21.289 c 1.4882,1.4882 3.5551,2.3976 5.8288,2.3976 4.5472,0 8.2677,-3.7204 8.2677,-8.2677 v -161.22 c 0,-4.7952 3.7205,-8.2677 8.2677,-8.2677 h 10.335 c 5.7048,0 10.335,-4.6299 10.335,-10.335 0,-5.7051 -4.6299,-10.335 -10.335,-10.335 z" fill="#ffffff" opacity="1" id="path5267"/>
+      <rect x="5669.2998" y="-3709.8" width="226.77" height="226.77" fill="none" opacity="1" id="rect5269"/>
     </g>
-    <g
-       transform="translate(-4308.7,2948)"
-       id="g5277">
-      <path
-         d="m 5910.2,-3526.2 c 0,15.997 12.938,28.935 28.935,28.935 7.9777,0 15.418,-3.0175 20.668,-8.267 l 52.744,-52.785 14.137,14.137 c -1.9014,6.9443 -0.083,14.715 5.4191,20.25 l 20.502,20.502 c 8.1802,8.1472 21.283,8.2257 29.348,0.1654 8.0645,-8.0604 7.9818,-21.16 -0.1653,-29.348 l -20.502,-20.502 c -5.5389,-5.4976 -13.31,-7.3163 -20.25,-5.4149 l -14.137,-14.099 9.0896,-9.0896 c 19.345,4.8775 40.674,-0.2108 55.761,-14.963 10.375,-10.168 16.084,-23.065 16.865,-36.416 v -0.7027 c 0,-4.5097 -3.7202,-8.1472 -8.3084,-8.1472 -2.2775,0 -4.3443,0.9135 -5.8737,2.3561 l -2.4346,2.3975 -8.3539,8.1802 c -5.2537,5.1256 -12.731,8.143 -20.792,8.143 -8.0149,0 -15.087,-3.5135 -20.337,-8.6804 -5.1669,-5.2495 -8.7176,-12.359 -8.7176,-20.378 0,-8.0603 3.0133,-15.542 8.143,-20.792 l 8.1802,-8.3538 2.3975,-2.4346 c 1.4467,-1.5294 2.3561,-3.5962 2.3561,-5.8738 0,-4.584 -3.6375,-8.3083 -8.1472,-8.3083 h -0.7027 c -13.347,0.7812 -26.248,6.4896 -36.416,16.865 -14.752,15.087 -19.8,36.42 -14.922,55.72 l -9.1309,9.1309 -38.152,-38.19 v -10.458 l -24.801,-12.4 -12.4,12.4 12.4,24.801 h 10.416 l 38.194,38.152 -52.744,52.802 c -5.2495,5.2496 -8.267,12.69 -8.267,20.668 z m 20.668,-2.0668 c 0,-5.7042 4.6295,-10.334 10.334,-10.334 5.7042,0 10.334,4.6296 10.334,10.334 0,5.7043 -4.6295,10.334 -10.334,10.334 -5.7043,0 -10.334,-4.6295 -10.334,-10.334 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5273" />
-      <rect
-         x="5896.1001"
-         y="-3709.8"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5275" />
+    <g transform="translate(-4308.7,2948)" id="g5277">
+      <path d="m 5910.2,-3526.2 c 0,15.997 12.938,28.935 28.935,28.935 7.9777,0 15.418,-3.0175 20.668,-8.267 l 52.744,-52.785 14.137,14.137 c -1.9014,6.9443 -0.083,14.715 5.4191,20.25 l 20.502,20.502 c 8.1802,8.1472 21.283,8.2257 29.348,0.1654 8.0645,-8.0604 7.9818,-21.16 -0.1653,-29.348 l -20.502,-20.502 c -5.5389,-5.4976 -13.31,-7.3163 -20.25,-5.4149 l -14.137,-14.099 9.0896,-9.0896 c 19.345,4.8775 40.674,-0.2108 55.761,-14.963 10.375,-10.168 16.084,-23.065 16.865,-36.416 v -0.7027 c 0,-4.5097 -3.7202,-8.1472 -8.3084,-8.1472 -2.2775,0 -4.3443,0.9135 -5.8737,2.3561 l -2.4346,2.3975 -8.3539,8.1802 c -5.2537,5.1256 -12.731,8.143 -20.792,8.143 -8.0149,0 -15.087,-3.5135 -20.337,-8.6804 -5.1669,-5.2495 -8.7176,-12.359 -8.7176,-20.378 0,-8.0603 3.0133,-15.542 8.143,-20.792 l 8.1802,-8.3538 2.3975,-2.4346 c 1.4467,-1.5294 2.3561,-3.5962 2.3561,-5.8738 0,-4.584 -3.6375,-8.3083 -8.1472,-8.3083 h -0.7027 c -13.347,0.7812 -26.248,6.4896 -36.416,16.865 -14.752,15.087 -19.8,36.42 -14.922,55.72 l -9.1309,9.1309 -38.152,-38.19 v -10.458 l -24.801,-12.4 -12.4,12.4 12.4,24.801 h 10.416 l 38.194,38.152 -52.744,52.802 c -5.2495,5.2496 -8.267,12.69 -8.267,20.668 z m 20.668,-2.0668 c 0,-5.7042 4.6295,-10.334 10.334,-10.334 5.7042,0 10.334,4.6296 10.334,10.334 0,5.7043 -4.6295,10.334 -10.334,10.334 -5.7043,0 -10.334,-4.6295 -10.334,-10.334 z" fill="#ffffff" opacity="1" id="path5273"/>
+      <rect x="5896.1001" y="-3709.8" width="226.77" height="226.77" fill="none" opacity="1" id="rect5275"/>
     </g>
-    <g
-       transform="translate(-6349.6,3401.6)"
-       id="g5283">
-      <path
-         d="m 6363.5,-3598.5 c 0,54.799 44.414,99.213 99.213,99.213 54.799,0 99.213,-44.414 99.213,-99.213 0,-54.799 -44.414,-99.213 -99.213,-99.213 -54.799,0 -99.213,44.414 -99.213,99.213 z m 21.109,0 c 0,-5.0662 0.4644,-10.006 1.3932,-14.776 h 20.265 c -0.38,4.1796 -0.5489,8.4014 -0.5489,12.666 0,4.264 0.1689,8.4858 0.5489,12.665 h -20.982 c -0.4647,-3.4619 -0.6755,-6.966 -0.6755,-10.554 z m 8.7391,-35.885 c 6.1636,-11.948 15.325,-22.08 26.513,-29.426 -4.4329,9.3302 -7.8948,19.167 -10.301,29.426 z m 58.177,-41.416 0.6333,-0.084 v 41.5 h -20.771 c 4.1796,-15.114 11.061,-29.13 20.138,-41.416 z m 21.742,-0.084 0.5909,0.084 c 9.0771,12.286 16.001,26.302 20.18,41.416 h -20.771 z m 32.254,12.074 c 11.188,7.346 20.391,17.478 26.556,29.426 h -16.254 c -2.3642,-10.259 -5.8725,-20.096 -10.302,-29.426 z m 33.901,50.535 c 0.9286,4.7707 1.3932,9.7102 1.3932,14.776 0,3.5885 -0.2533,7.0926 -0.7177,10.554 h -20.898 c 0.3377,-4.1796 0.5066,-8.4014 0.5066,-12.665 0,-4.2641 -0.1689,-8.4859 -0.5066,-12.666 z m -5.2772,46.44 c -6.6283,14.903 -17.774,27.357 -31.706,35.59 5.9105,-11.103 10.428,-23.051 13.383,-35.59 z m -111.16,35.59 c -13.932,-8.2326 -25.078,-20.687 -31.706,-35.59 h 18.323 c 2.9553,12.539 7.4726,24.529 13.383,35.59 z m 4.4752,-82.03 h 24.698 v 25.331 h -24.698 c -0.4225,-4.1796 -0.6333,-8.4014 -0.6333,-12.665 0,-4.2641 0.2108,-8.4859 0.6333,-12.666 z m 45.807,0 h 24.698 c 0.4264,4.1796 0.6333,8.4014 0.6333,12.666 0,4.264 -0.2111,8.4858 -0.6333,12.665 h -24.698 z m -41.88,46.44 h 20.771 v 42.218 c -9.3725,-12.497 -16.507,-26.766 -20.771,-42.218 z m 41.88,0 h 20.771 c -4.2641,15.452 -11.399,29.722 -20.771,42.218 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5279" />
-      <rect
-         x="6349.6001"
-         y="-3709.8"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5281" />
+    <g transform="translate(-6349.6,3401.6)" id="g5283">
+      <path d="m 6363.5,-3598.5 c 0,54.799 44.414,99.213 99.213,99.213 54.799,0 99.213,-44.414 99.213,-99.213 0,-54.799 -44.414,-99.213 -99.213,-99.213 -54.799,0 -99.213,44.414 -99.213,99.213 z m 21.109,0 c 0,-5.0662 0.4644,-10.006 1.3932,-14.776 h 20.265 c -0.38,4.1796 -0.5489,8.4014 -0.5489,12.666 0,4.264 0.1689,8.4858 0.5489,12.665 h -20.982 c -0.4647,-3.4619 -0.6755,-6.966 -0.6755,-10.554 z m 8.7391,-35.885 c 6.1636,-11.948 15.325,-22.08 26.513,-29.426 -4.4329,9.3302 -7.8948,19.167 -10.301,29.426 z m 58.177,-41.416 0.6333,-0.084 v 41.5 h -20.771 c 4.1796,-15.114 11.061,-29.13 20.138,-41.416 z m 21.742,-0.084 0.5909,0.084 c 9.0771,12.286 16.001,26.302 20.18,41.416 h -20.771 z m 32.254,12.074 c 11.188,7.346 20.391,17.478 26.556,29.426 h -16.254 c -2.3642,-10.259 -5.8725,-20.096 -10.302,-29.426 z m 33.901,50.535 c 0.9286,4.7707 1.3932,9.7102 1.3932,14.776 0,3.5885 -0.2533,7.0926 -0.7177,10.554 h -20.898 c 0.3377,-4.1796 0.5066,-8.4014 0.5066,-12.665 0,-4.2641 -0.1689,-8.4859 -0.5066,-12.666 z m -5.2772,46.44 c -6.6283,14.903 -17.774,27.357 -31.706,35.59 5.9105,-11.103 10.428,-23.051 13.383,-35.59 z m -111.16,35.59 c -13.932,-8.2326 -25.078,-20.687 -31.706,-35.59 h 18.323 c 2.9553,12.539 7.4726,24.529 13.383,35.59 z m 4.4752,-82.03 h 24.698 v 25.331 h -24.698 c -0.4225,-4.1796 -0.6333,-8.4014 -0.6333,-12.665 0,-4.2641 0.2108,-8.4859 0.6333,-12.666 z m 45.807,0 h 24.698 c 0.4264,4.1796 0.6333,8.4014 0.6333,12.666 0,4.264 -0.2111,8.4858 -0.6333,12.665 h -24.698 z m -41.88,46.44 h 20.771 v 42.218 c -9.3725,-12.497 -16.507,-26.766 -20.771,-42.218 z m 41.88,0 h 20.771 c -4.2641,15.452 -11.399,29.722 -20.771,42.218 z" fill="#ffffff" opacity="1" id="path5279"/>
+      <rect x="6349.6001" y="-3709.8" width="226.77" height="226.77" fill="none" opacity="1" id="rect5281"/>
     </g>
-    <g
-       transform="translate(-4308.7,2267.7)"
-       id="g5289">
-      <path
-         d="m 6203.1,-2982.3 c 0,18.272 14.799,33.071 33.071,33.071 18.272,0 33.071,-14.799 33.071,-33.071 0,-18.272 -14.799,-33.071 -33.071,-33.071 -18.272,0 -33.071,14.799 -33.071,33.071 z m 0,70.276 v 74.41 h -10.335 c -5.704,0 -10.334,4.6299 -10.334,10.335 0,5.7048 4.63,10.335 10.334,10.335 h 86.812 c 5.704,0 10.334,-4.6299 10.334,-10.335 0,-5.7047 -4.63,-10.335 -10.334,-10.335 h -10.335 v -85.984 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -67.382 c -5.704,0 -10.334,4.63 -10.334,10.335 0,5.705 4.63,10.335 10.334,10.335 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5285" />
-      <rect
-         x="6122.7998"
-         y="-3029.5"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5287" />
+    <g transform="translate(-4308.7,2267.7)" id="g5289">
+      <path d="m 6203.1,-2982.3 c 0,18.272 14.799,33.071 33.071,33.071 18.272,0 33.071,-14.799 33.071,-33.071 0,-18.272 -14.799,-33.071 -33.071,-33.071 -18.272,0 -33.071,14.799 -33.071,33.071 z m 0,70.276 v 74.41 h -10.335 c -5.704,0 -10.334,4.6299 -10.334,10.335 0,5.7048 4.63,10.335 10.334,10.335 h 86.812 c 5.704,0 10.334,-4.6299 10.334,-10.335 0,-5.7047 -4.63,-10.335 -10.334,-10.335 h -10.335 v -85.984 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -67.382 c -5.704,0 -10.334,4.63 -10.334,10.335 0,5.705 4.63,10.335 10.334,10.335 z" fill="#ffffff" opacity="1" id="path5285"/>
+      <rect x="6122.7998" y="-3029.5" width="226.77" height="226.77" fill="none" opacity="1" id="rect5287"/>
     </g>
-    <g
-       transform="translate(-3628.3,1133.9)"
-       id="g5295">
-      <path
-         d="m 6472.5,-2946.2 -12.608,12.526 -50.516,-50.516 c -1.488,-1.4882 -3.514,-2.3976 -5.787,-2.3976 -3.679,0 -6.821,2.439 -7.855,5.7461 l -0.454,1.4882 c -3.018,9.5078 -4.672,19.636 -4.672,30.177 0,24.596 8.93,47.085 23.729,64.406 l -1.571,2.067 c -7.276,7.2342 -11.451,16.411 -12.484,25.878 -13.931,3.6378 -25.01,13.972 -29.392,27.284 0,0 -0.951,2.5216 -0.951,4.3819 0,4.5472 3.803,8.2677 8.475,8.2677 h 65.728 c 4.671,0 8.474,-3.7205 8.474,-8.2677 0,-2.6044 -1.157,-4.9607 -1.157,-4.9607 -4.63,-13.348 -15.998,-23.604 -30.177,-26.953 0.909,-4.0512 2.935,-7.8957 6.076,-11.037 l 1.902,-2.4803 c 16.742,12.939 37.742,20.628 60.561,20.628 10.376,0 20.38,-1.5709 29.764,-4.5472 0.455,-0.124 2.108,-0.8268 2.108,-0.8268 3.142,-1.1575 5.415,-4.1752 5.415,-7.7303 0,-2.315 -0.95,-4.4232 -2.521,-5.9114 l -1.282,-1.2402 -49.027,-49.069 12.566,-12.567 c 3.969,-3.9685 3.969,-10.376 0,-14.344 -3.968,-3.9685 -10.376,-3.9685 -14.344,0 z m 29.723,7.3583 c 0,5.7047 4.63,10.335 10.334,10.335 5.705,0 10.335,-4.6299 10.335,-10.335 l -0.04,-2.067 c -0.496,-10.417 -4.713,-20.669 -12.691,-28.606 -7.937,-7.9783 -18.189,-12.195 -28.607,-12.691 l -2.067,-0.041 c -5.704,0 -10.334,4.6299 -10.334,10.335 0,5.7051 4.63,10.335 10.334,10.335 0.703,0 2.067,0.083 2.067,0.083 5.126,0.4961 10.087,2.6457 14.014,6.5729 3.927,3.9271 6.077,8.8877 6.531,14.014 0,0 0.125,1.3642 0.125,2.067 z m 33.071,0 c 0,5.7047 4.629,10.335 10.334,10.335 5.705,0 10.335,-4.6299 10.335,-10.335 l -0.04,-2.067 c -0.496,-18.892 -7.937,-37.618 -22.364,-52.004 -14.386,-14.427 -33.112,-21.868 -52.004,-22.364 l -2.067,-0.041 c -5.704,0 -10.334,4.6299 -10.334,10.335 0,5.7048 4.63,10.335 10.334,10.335 l 2.067,0.041 c 13.601,0.4961 27.036,5.9528 37.412,16.287 10.334,10.376 15.791,23.811 16.287,37.411 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5291" />
-      <rect
-         x="6349.6001"
-         y="-3029.5"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5293" />
+    <g transform="translate(-3628.3,1133.9)" id="g5295">
+      <path d="m 6472.5,-2946.2 -12.608,12.526 -50.516,-50.516 c -1.488,-1.4882 -3.514,-2.3976 -5.787,-2.3976 -3.679,0 -6.821,2.439 -7.855,5.7461 l -0.454,1.4882 c -3.018,9.5078 -4.672,19.636 -4.672,30.177 0,24.596 8.93,47.085 23.729,64.406 l -1.571,2.067 c -7.276,7.2342 -11.451,16.411 -12.484,25.878 -13.931,3.6378 -25.01,13.972 -29.392,27.284 0,0 -0.951,2.5216 -0.951,4.3819 0,4.5472 3.803,8.2677 8.475,8.2677 h 65.728 c 4.671,0 8.474,-3.7205 8.474,-8.2677 0,-2.6044 -1.157,-4.9607 -1.157,-4.9607 -4.63,-13.348 -15.998,-23.604 -30.177,-26.953 0.909,-4.0512 2.935,-7.8957 6.076,-11.037 l 1.902,-2.4803 c 16.742,12.939 37.742,20.628 60.561,20.628 10.376,0 20.38,-1.5709 29.764,-4.5472 0.455,-0.124 2.108,-0.8268 2.108,-0.8268 3.142,-1.1575 5.415,-4.1752 5.415,-7.7303 0,-2.315 -0.95,-4.4232 -2.521,-5.9114 l -1.282,-1.2402 -49.027,-49.069 12.566,-12.567 c 3.969,-3.9685 3.969,-10.376 0,-14.344 -3.968,-3.9685 -10.376,-3.9685 -14.344,0 z m 29.723,7.3583 c 0,5.7047 4.63,10.335 10.334,10.335 5.705,0 10.335,-4.6299 10.335,-10.335 l -0.04,-2.067 c -0.496,-10.417 -4.713,-20.669 -12.691,-28.606 -7.937,-7.9783 -18.189,-12.195 -28.607,-12.691 l -2.067,-0.041 c -5.704,0 -10.334,4.6299 -10.334,10.335 0,5.7051 4.63,10.335 10.334,10.335 0.703,0 2.067,0.083 2.067,0.083 5.126,0.4961 10.087,2.6457 14.014,6.5729 3.927,3.9271 6.077,8.8877 6.531,14.014 0,0 0.125,1.3642 0.125,2.067 z m 33.071,0 c 0,5.7047 4.629,10.335 10.334,10.335 5.705,0 10.335,-4.6299 10.335,-10.335 l -0.04,-2.067 c -0.496,-18.892 -7.937,-37.618 -22.364,-52.004 -14.386,-14.427 -33.112,-21.868 -52.004,-22.364 l -2.067,-0.041 c -5.704,0 -10.334,4.6299 -10.334,10.335 0,5.7048 4.63,10.335 10.334,10.335 l 2.067,0.041 c 13.601,0.4961 27.036,5.9528 37.412,16.287 10.334,10.376 15.791,23.811 16.287,37.411 z" fill="#ffffff" opacity="1" id="path5291"/>
+      <rect x="6349.6001" y="-3029.5" width="226.77" height="226.77" fill="none" opacity="1" id="rect5293"/>
     </g>
-    <g
-       transform="translate(-6349.6,2721.3)"
-       id="g5301">
-      <path
-         d="m 6833.9,-2833.5 c 0,9.1358 7.4,16.535 16.536,16.535 h 132.28 c 9.1358,0 16.536,-7.3996 16.536,-16.535 v -82.677 c 0,-9.1358 -7.4,-16.535 -16.536,-16.535 h -99.213 v -28.937 c 0,-18.272 14.799,-33.071 33.071,-33.071 18.272,0 33.071,14.799 33.071,33.071 v 2.0669 c 0,5.7047 4.63,10.335 10.335,10.335 5.705,0 10.335,-4.6299 10.335,-10.335 v -2.0669 c 0,-29.681 -24.059,-53.74 -53.741,-53.74 -29.685,0 -53.74,24.059 -53.74,53.74 v 28.937 h -12.401 c -9.1358,0 -16.536,7.3996 -16.536,16.535 z m 66.142,-53.74 c 0,-9.1358 7.3991,-16.535 16.535,-16.535 9.1358,0 16.536,7.3996 16.536,16.535 0,5.8288 -3.0175,10.955 -7.565,13.89 0,0 1.6167,9.7559 3.4309,21.248 0,3.4311 -2.7692,6.2008 -6.2009,6.2008 h -12.402 c -3.4308,0 -6.2008,-2.7697 -6.2008,-6.2008 l 3.4317,-21.248 c -4.5475,-2.935 -7.565,-8.061 -7.565,-13.89 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5297" />
-      <rect
-         x="6803.1001"
-         y="-3029.5"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5299" />
+    <g transform="translate(-6349.6,2721.3)" id="g5301">
+      <path d="m 6833.9,-2833.5 c 0,9.1358 7.4,16.535 16.536,16.535 h 132.28 c 9.1358,0 16.536,-7.3996 16.536,-16.535 v -82.677 c 0,-9.1358 -7.4,-16.535 -16.536,-16.535 h -99.213 v -28.937 c 0,-18.272 14.799,-33.071 33.071,-33.071 18.272,0 33.071,14.799 33.071,33.071 v 2.0669 c 0,5.7047 4.63,10.335 10.335,10.335 5.705,0 10.335,-4.6299 10.335,-10.335 v -2.0669 c 0,-29.681 -24.059,-53.74 -53.741,-53.74 -29.685,0 -53.74,24.059 -53.74,53.74 v 28.937 h -12.401 c -9.1358,0 -16.536,7.3996 -16.536,16.535 z m 66.142,-53.74 c 0,-9.1358 7.3991,-16.535 16.535,-16.535 9.1358,0 16.536,7.3996 16.536,16.535 0,5.8288 -3.0175,10.955 -7.565,13.89 0,0 1.6167,9.7559 3.4309,21.248 0,3.4311 -2.7692,6.2008 -6.2009,6.2008 h -12.402 c -3.4308,0 -6.2008,-2.7697 -6.2008,-6.2008 l 3.4317,-21.248 c -4.5475,-2.935 -7.565,-8.061 -7.565,-13.89 z" fill="#ffffff" opacity="1" id="path5297"/>
+      <rect x="6803.1001" y="-3029.5" width="226.77" height="226.77" fill="none" opacity="1" id="rect5299"/>
     </g>
-    <g
-       transform="translate(-7483.5,-226.77)"
-       id="g5307">
-      <path
-         d="m 8193.3,-2323.9 c -8.4142,-0.2484 -15.371,6.5038 -15.373,14.922 v 146.22 c 0,6.2561 3.9031,11.848 9.774,14.009 5.8713,2.161 12.467,0.433 16.524,-4.3291 l 62.26,-73.111 c 4.7506,-5.5793 4.7506,-13.781 0,-19.361 l -62.26,-73.111 c -2.7373,-3.2129 -6.7064,-5.1173 -10.925,-5.2419 z m 167.68,0 c -4.2191,0.1246 -8.1885,2.029 -10.926,5.2419 l -62.26,73.111 c -4.7506,5.5793 -4.7506,13.781 0,19.361 l 62.26,73.111 c 4.0571,4.7621 10.653,6.4901 16.524,4.3291 5.8709,-2.1609 9.7722,-7.7527 9.7741,-14.009 v -146.22 c 0,-8.4178 -6.9585,-15.17 -15.372,-14.922 z m -153.19,55.483 27.72,32.551 -27.72,32.551 z m 138.7,0 v 65.101 l -27.72,-32.551 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5303" />
-      <rect
-         x="8163.7998"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5305" />
+    <g transform="translate(-7483.5,-226.77)" id="g5307">
+      <path d="m 8193.3,-2323.9 c -8.4142,-0.2484 -15.371,6.5038 -15.373,14.922 v 146.22 c 0,6.2561 3.9031,11.848 9.774,14.009 5.8713,2.161 12.467,0.433 16.524,-4.3291 l 62.26,-73.111 c 4.7506,-5.5793 4.7506,-13.781 0,-19.361 l -62.26,-73.111 c -2.7373,-3.2129 -6.7064,-5.1173 -10.925,-5.2419 z m 167.68,0 c -4.2191,0.1246 -8.1885,2.029 -10.926,5.2419 l -62.26,73.111 c -4.7506,5.5793 -4.7506,13.781 0,19.361 l 62.26,73.111 c 4.0571,4.7621 10.653,6.4901 16.524,4.3291 5.8709,-2.1609 9.7722,-7.7527 9.7741,-14.009 v -146.22 c 0,-8.4178 -6.9585,-15.17 -15.372,-14.922 z m -153.19,55.483 27.72,32.551 -27.72,32.551 z m 138.7,0 v 65.101 l -27.72,-32.551 z" fill="#ffffff" opacity="1" id="path5303"/>
+      <rect x="8163.7998" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5305"/>
     </g>
-    <g
-       transform="translate(-4762.2,2040.9)"
-       id="g5313">
-      <path
-         d="m 6213.5,-2246.2 c 0,8.8465 5.043,16.494 12.401,20.256 v 60.354 c 0,4.5472 -3.72,8.2677 -8.267,8.2677 h -22.737 c -5.704,0 -10.334,4.6299 -10.334,10.335 0,5.7048 4.63,10.335 10.334,10.335 h 82.677 c 5.705,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.63,-10.335 -10.335,-10.335 h -22.736 c -4.547,0 -8.267,-3.7205 -8.267,-8.2677 v -60.354 c 7.354,-3.7618 12.401,-11.409 12.401,-20.256 0,-12.567 -10.169,-22.736 -22.736,-22.736 -12.567,0 -22.736,10.169 -22.736,22.736 z m -33.071,0.8268 c 0,10.335 2.769,20.008 7.565,28.358 l 0.62,0.9508 c 1.691,3.3897 5.167,5.7047 9.177,5.7047 5.705,0 10.335,-4.6713 10.335,-10.459 0,-1.9842 -0.542,-3.8445 -1.489,-5.4153 l -1.12,-1.9016 c -2.811,-5.126 -4.419,-10.996 -4.419,-17.238 0,-19.594 15.754,-35.965 35.138,-35.965 19.384,0 35.138,16.37 35.138,35.965 0,6.2421 -1.617,12.112 -4.424,17.238 l -1.116,1.9016 c -0.95,1.5708 -1.488,3.4311 -1.488,5.4153 0,5.7874 4.63,10.459 10.335,10.459 4.01,0 7.482,-2.315 9.177,-5.7047 l 0.62,-0.9508 c 4.795,-8.3504 7.565,-18.024 7.565,-28.358 0,-31.128 -24.969,-56.634 -55.807,-56.634 -30.839,0 -55.807,25.506 -55.807,56.634 z m -33.071,0 c 0,20.215 6.614,38.858 17.821,53.864 l 0.744,1.0334 c 1.856,2.563 4.915,4.2166 8.309,4.2166 5.705,0 10.335,-4.6713 10.335,-10.417 0,-2.3977 -0.782,-4.63 -2.15,-6.4075 l -0.785,-1.0748 c -8.557,-11.492 -13.601,-25.754 -13.601,-41.215 0,-38.032 30.55,-69.035 68.209,-69.035 37.655,0 68.209,31.004 68.209,69.035 0,15.461 -5.048,29.722 -13.601,41.215 l -0.785,1.0748 c -1.364,1.7775 -2.15,4.0098 -2.15,6.4075 0,5.746 4.63,10.417 10.335,10.417 3.386,0 6.453,-1.6536 8.309,-4.2166 l 0.744,-1.0334 c 11.207,-15.006 17.821,-33.65 17.821,-53.864 0,-49.565 -39.809,-89.705 -88.878,-89.705 -49.069,0 -88.886,40.14 -88.886,89.705 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5309" />
-      <rect
-         x="6122.7998"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5311" />
+    <g transform="translate(-4762.2,2040.9)" id="g5313">
+      <path d="m 6213.5,-2246.2 c 0,8.8465 5.043,16.494 12.401,20.256 v 60.354 c 0,4.5472 -3.72,8.2677 -8.267,8.2677 h -22.737 c -5.704,0 -10.334,4.6299 -10.334,10.335 0,5.7048 4.63,10.335 10.334,10.335 h 82.677 c 5.705,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.63,-10.335 -10.335,-10.335 h -22.736 c -4.547,0 -8.267,-3.7205 -8.267,-8.2677 v -60.354 c 7.354,-3.7618 12.401,-11.409 12.401,-20.256 0,-12.567 -10.169,-22.736 -22.736,-22.736 -12.567,0 -22.736,10.169 -22.736,22.736 z m -33.071,0.8268 c 0,10.335 2.769,20.008 7.565,28.358 l 0.62,0.9508 c 1.691,3.3897 5.167,5.7047 9.177,5.7047 5.705,0 10.335,-4.6713 10.335,-10.459 0,-1.9842 -0.542,-3.8445 -1.489,-5.4153 l -1.12,-1.9016 c -2.811,-5.126 -4.419,-10.996 -4.419,-17.238 0,-19.594 15.754,-35.965 35.138,-35.965 19.384,0 35.138,16.37 35.138,35.965 0,6.2421 -1.617,12.112 -4.424,17.238 l -1.116,1.9016 c -0.95,1.5708 -1.488,3.4311 -1.488,5.4153 0,5.7874 4.63,10.459 10.335,10.459 4.01,0 7.482,-2.315 9.177,-5.7047 l 0.62,-0.9508 c 4.795,-8.3504 7.565,-18.024 7.565,-28.358 0,-31.128 -24.969,-56.634 -55.807,-56.634 -30.839,0 -55.807,25.506 -55.807,56.634 z m -33.071,0 c 0,20.215 6.614,38.858 17.821,53.864 l 0.744,1.0334 c 1.856,2.563 4.915,4.2166 8.309,4.2166 5.705,0 10.335,-4.6713 10.335,-10.417 0,-2.3977 -0.782,-4.63 -2.15,-6.4075 l -0.785,-1.0748 c -8.557,-11.492 -13.601,-25.754 -13.601,-41.215 0,-38.032 30.55,-69.035 68.209,-69.035 37.655,0 68.209,31.004 68.209,69.035 0,15.461 -5.048,29.722 -13.601,41.215 l -0.785,1.0748 c -1.364,1.7775 -2.15,4.0098 -2.15,6.4075 0,5.746 4.63,10.417 10.335,10.417 3.386,0 6.453,-1.6536 8.309,-4.2166 l 0.744,-1.0334 c 11.207,-15.006 17.821,-33.65 17.821,-53.864 0,-49.565 -39.809,-89.705 -88.878,-89.705 -49.069,0 -88.886,40.14 -88.886,89.705 z" fill="#ffffff" opacity="1" id="path5309"/>
+      <rect x="6122.7998" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5311"/>
     </g>
-    <g
-       transform="translate(-5215.7,2040.9)"
-       id="g5319">
-      <path
-         d="m 6854.6,-2286 v 0.5787 c 1.323,36.378 8.103,68.912 11.203,72.095 7.193,9.5906 29.475,25.382 42.042,33.319 3.1,1.9842 5.746,2.3563 8.722,2.4389 2.976,-0.083 5.618,-0.5787 8.718,-2.4389 12.819,-7.565 35.39,-23.728 42.542,-33.319 3.142,-3.183 9.421,-35.717 10.748,-72.095 l 0.04,-0.5787 c 0,-3.3485 -2.149,-6.2422 -5.126,-7.317 -15.584,-5.4154 -38.399,-6.8622 -56.882,-6.8622 -18.519,0 -41.338,1.4468 -56.882,6.8622 -2.98,1.0748 -5.126,3.9685 -5.126,7.317 z m -37.246,-23.852 0.04,0.9095 c 2.109,58.205 11.451,109.38 16.495,114.47 11.574,15.378 48.573,39.272 68.58,52.335 4.754,3.1004 9.302,5.4154 14.097,5.5394 4.795,-0.124 9.343,-2.439 14.097,-5.5394 20.007,-13.063 57.006,-36.957 68.58,-52.335 5.044,-5.0847 14.386,-56.262 16.495,-114.47 l 0.04,-0.9095 c 0,-5.374 -3.473,-10.045 -8.268,-11.74 -25.092,-8.6811 -61.098,-13.435 -90.945,-13.435 -29.851,0 -65.857,4.754 -90.945,13.435 -4.795,1.6949 -8.268,6.3662 -8.268,11.74 z m 20.049,13.518 c 0,-4.2992 2.77,-7.9784 6.573,-9.3426 19.847,-6.8622 48.991,-8.6811 72.595,-8.6811 23.605,0 52.748,1.8189 72.595,8.6811 3.803,1.3642 6.573,5.0434 6.573,9.3426 l -0.04,0.7027 c -1.691,46.093 -9.674,87.928 -13.684,91.979 -9.181,12.154 -38.449,31.666 -54.277,42 -3.762,2.4389 -7.359,4.2992 -11.162,4.3819 -3.803,-0.083 -7.399,-1.943 -11.161,-4.3819 -15.833,-10.335 -45.101,-29.847 -54.278,-42 -4.01,-4.0512 -11.988,-45.886 -13.687,-91.979 l -0.04,-0.7027 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5315" />
-      <rect
-         x="6803.1001"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5317" />
+    <g transform="translate(-5215.7,2040.9)" id="g5319">
+      <path d="m 6854.6,-2286 v 0.5787 c 1.323,36.378 8.103,68.912 11.203,72.095 7.193,9.5906 29.475,25.382 42.042,33.319 3.1,1.9842 5.746,2.3563 8.722,2.4389 2.976,-0.083 5.618,-0.5787 8.718,-2.4389 12.819,-7.565 35.39,-23.728 42.542,-33.319 3.142,-3.183 9.421,-35.717 10.748,-72.095 l 0.04,-0.5787 c 0,-3.3485 -2.149,-6.2422 -5.126,-7.317 -15.584,-5.4154 -38.399,-6.8622 -56.882,-6.8622 -18.519,0 -41.338,1.4468 -56.882,6.8622 -2.98,1.0748 -5.126,3.9685 -5.126,7.317 z m -37.246,-23.852 0.04,0.9095 c 2.109,58.205 11.451,109.38 16.495,114.47 11.574,15.378 48.573,39.272 68.58,52.335 4.754,3.1004 9.302,5.4154 14.097,5.5394 4.795,-0.124 9.343,-2.439 14.097,-5.5394 20.007,-13.063 57.006,-36.957 68.58,-52.335 5.044,-5.0847 14.386,-56.262 16.495,-114.47 l 0.04,-0.9095 c 0,-5.374 -3.473,-10.045 -8.268,-11.74 -25.092,-8.6811 -61.098,-13.435 -90.945,-13.435 -29.851,0 -65.857,4.754 -90.945,13.435 -4.795,1.6949 -8.268,6.3662 -8.268,11.74 z m 20.049,13.518 c 0,-4.2992 2.77,-7.9784 6.573,-9.3426 19.847,-6.8622 48.991,-8.6811 72.595,-8.6811 23.605,0 52.748,1.8189 72.595,8.6811 3.803,1.3642 6.573,5.0434 6.573,9.3426 l -0.04,0.7027 c -1.691,46.093 -9.674,87.928 -13.684,91.979 -9.181,12.154 -38.449,31.666 -54.277,42 -3.762,2.4389 -7.359,4.2992 -11.162,4.3819 -3.803,-0.083 -7.399,-1.943 -11.161,-4.3819 -15.833,-10.335 -45.101,-29.847 -54.278,-42 -4.01,-4.0512 -11.988,-45.886 -13.687,-91.979 l -0.04,-0.7027 z" fill="#ffffff" opacity="1" id="path5315"/>
+      <rect x="6803.1001" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5317"/>
     </g>
-    <g
-       transform="translate(-6576.4,1587.4)"
-       id="g5325">
-      <path
-         d="m 7601,-2180 c 0,-3.6378 -0.62,-7.1103 -1.782,-10.335 h 24.187 c -1.116,3.2244 -1.736,6.6969 -1.736,10.335 0,17.118 13.886,31.004 31.004,31.004 17.115,0 31.004,-13.886 31.004,-31.004 0,-17.114 -13.889,-31.004 -31.004,-31.004 h -68.209 c -4.547,0 -8.267,-3.7205 -8.267,-8.2677 0,-4.5473 3.72,-8.2678 8.267,-8.2678 h 71.103 c 7.482,0 13.927,-4.386 16.862,-10.748 1.12,-2.3977 22.534,-51.223 22.534,-51.223 0.579,-1.3228 1.116,-2.6456 1.116,-4.1752 0,-4.5472 -3.721,-8.2677 -8.268,-8.2677 h -129.06 l -3.473,-10.707 c -1.612,-5.7503 -6.114,-9.9627 -12.149,-9.9627 h -35.138 c -5.705,0 -10.335,4.63 -10.335,10.335 0,5.7048 4.63,10.335 10.335,10.335 h 21.703 c 3.679,0 6.779,2.3976 7.854,5.6634 l 17.445,89.164 c -9.549,5.2541 -15.998,15.461 -15.998,27.122 0,17.118 13.885,31.004 31.004,31.004 17.114,0 31.004,-13.882 31.004,-31 z m -20.669,0 c 0,5.7047 -4.63,10.335 -10.335,10.335 -5.705,0 -10.335,-4.6299 -10.335,-10.335 0,-5.7048 4.63,-10.335 10.335,-10.335 5.705,0 10.335,4.6299 10.335,10.335 z m 82.677,0 c 0,5.7047 -4.63,10.335 -10.335,10.335 -5.704,0 -10.334,-4.6299 -10.334,-10.335 0,-5.7048 4.63,-10.335 10.334,-10.335 5.705,0 10.335,4.6299 10.335,10.335 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5321" />
-      <rect
-         x="7483.5"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5323" />
+    <g transform="translate(-6576.4,1587.4)" id="g5325">
+      <path d="m 7601,-2180 c 0,-3.6378 -0.62,-7.1103 -1.782,-10.335 h 24.187 c -1.116,3.2244 -1.736,6.6969 -1.736,10.335 0,17.118 13.886,31.004 31.004,31.004 17.115,0 31.004,-13.886 31.004,-31.004 0,-17.114 -13.889,-31.004 -31.004,-31.004 h -68.209 c -4.547,0 -8.267,-3.7205 -8.267,-8.2677 0,-4.5473 3.72,-8.2678 8.267,-8.2678 h 71.103 c 7.482,0 13.927,-4.386 16.862,-10.748 1.12,-2.3977 22.534,-51.223 22.534,-51.223 0.579,-1.3228 1.116,-2.6456 1.116,-4.1752 0,-4.5472 -3.721,-8.2677 -8.268,-8.2677 h -129.06 l -3.473,-10.707 c -1.612,-5.7503 -6.114,-9.9627 -12.149,-9.9627 h -35.138 c -5.705,0 -10.335,4.63 -10.335,10.335 0,5.7048 4.63,10.335 10.335,10.335 h 21.703 c 3.679,0 6.779,2.3976 7.854,5.6634 l 17.445,89.164 c -9.549,5.2541 -15.998,15.461 -15.998,27.122 0,17.118 13.885,31.004 31.004,31.004 17.114,0 31.004,-13.882 31.004,-31 z m -20.669,0 c 0,5.7047 -4.63,10.335 -10.335,10.335 -5.705,0 -10.335,-4.6299 -10.335,-10.335 0,-5.7048 4.63,-10.335 10.335,-10.335 5.705,0 10.335,4.6299 10.335,10.335 z m 82.677,0 c 0,5.7047 -4.63,10.335 -10.335,10.335 -5.704,0 -10.334,-4.6299 -10.334,-10.335 0,-5.7048 4.63,-10.335 10.334,-10.335 5.705,0 10.335,4.6299 10.335,10.335 z" fill="#ffffff" opacity="1" id="path5321"/>
+      <rect x="7483.5" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5323"/>
     </g>
-    <g
-       transform="translate(-6349.6,2267.7)"
-       id="g5331">
-      <path
-         d="m 7638.2,-2514.3 c 0,5.7044 4.629,10.334 10.334,10.334 5.704,0 10.334,-4.6297 10.334,-10.334 0,-5.7043 -4.63,-10.334 -10.334,-10.334 -5.705,0 -10.334,4.6297 -10.334,10.334 z m -72.256,146.08 c 6.366,6.4071 16.7,6.4071 23.107,0 l 101.03,-100.36 c 4.046,-4.0509 6.076,-9.3832 5.993,-14.716 v -58.036 c 0,-11.326 -9.18,-20.503 -20.502,-20.503 h -58.036 c -5.333,-0.083 -10.665,1.9428 -14.72,5.9937 l -100.36,101.03 c -6.407,6.4071 -6.407,16.741 0,23.107 z m 55.721,-146.08 c 0,-14.84 12.029,-26.868 26.869,-26.868 14.839,0 26.868,12.029 26.868,26.868 0,14.84 -12.029,26.868 -26.868,26.868 -14.84,0 -26.869,-12.029 -26.869,-26.868 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5327" />
-      <rect
-         x="7483.5"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5329" />
+    <g transform="translate(-6349.6,2267.7)" id="g5331">
+      <path d="m 7638.2,-2514.3 c 0,5.7044 4.629,10.334 10.334,10.334 5.704,0 10.334,-4.6297 10.334,-10.334 0,-5.7043 -4.63,-10.334 -10.334,-10.334 -5.705,0 -10.334,4.6297 -10.334,10.334 z m -72.256,146.08 c 6.366,6.4071 16.7,6.4071 23.107,0 l 101.03,-100.36 c 4.046,-4.0509 6.076,-9.3832 5.993,-14.716 v -58.036 c 0,-11.326 -9.18,-20.503 -20.502,-20.503 h -58.036 c -5.333,-0.083 -10.665,1.9428 -14.72,5.9937 l -100.36,101.03 c -6.407,6.4071 -6.407,16.741 0,23.107 z m 55.721,-146.08 c 0,-14.84 12.029,-26.868 26.869,-26.868 14.839,0 26.868,12.029 26.868,26.868 0,14.84 -12.029,26.868 -26.868,26.868 -14.84,0 -26.869,-12.029 -26.869,-26.868 z" fill="#ffffff" opacity="1" id="path5327"/>
+      <rect x="7483.5" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect5329"/>
     </g>
-    <g
-       transform="rotate(90,4081.9,-5297.2)"
-       id="g5337">
-      <path
-         d="m 7345.7,-3015.4 h 48.686 c 0.189,0 0.341,0.015 0.341,0.033 v 198.36 c 0,0.019 -0.152,0.034 -0.341,0.034 H 7345.7 c -0.189,0 -0.341,-0.015 -0.341,-0.034 v -198.36 c 0,-0.019 0.152,-0.033 0.341,-0.033 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5333" />
-      <rect
-         x="7256.7002"
-         y="-3029.5"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5335" />
+    <g transform="rotate(90,4081.9,-5297.2)" id="g5337">
+      <path d="m 7345.7,-3015.4 h 48.686 c 0.189,0 0.341,0.015 0.341,0.033 v 198.36 c 0,0.019 -0.152,0.034 -0.341,0.034 H 7345.7 c -0.189,0 -0.341,-0.015 -0.341,-0.034 v -198.36 c 0,-0.019 0.152,-0.033 0.341,-0.033 z" fill="#ffffff" opacity="1" id="path5333"/>
+      <rect x="7256.7002" y="-3029.5" width="226.77" height="226.77" fill="none" opacity="1" id="rect5335"/>
     </g>
-    <g
-       transform="translate(-4762.2,907.09)"
-       id="g5343">
-      <path
-         d="m 7724.4,-2653.8 c 0,9.3302 7.557,16.887 16.887,16.887 h 25.331 v 26.049 c 0,4.6863 3.8,8.4437 8.444,8.4437 2.368,0 4.513,-0.971 6.037,-2.5331 l 31.959,-31.959 h 92.881 c 9.33,0 16.887,-7.5571 16.887,-16.887 v -105.55 c 0,-9.3303 -7.557,-16.887 -16.887,-16.887 h -164.65 c -9.33,0 -16.887,7.557 -16.887,16.887 z m 50.662,-48.551 c 0,-5.8261 4.728,-10.554 10.555,-10.554 5.826,0 10.554,4.7284 10.554,10.554 0,5.8262 -4.728,10.555 -10.554,10.555 -5.827,0 -10.555,-4.7284 -10.555,-10.555 z m 37.996,0 c 0,-5.8261 4.729,-10.554 10.555,-10.554 5.826,0 10.555,4.7284 10.555,10.554 0,5.8262 -4.729,10.555 -10.555,10.555 -5.826,0 -10.555,-4.7284 -10.555,-10.555 z m 37.997,0 c 0,-5.8261 4.728,-10.554 10.554,-10.554 5.827,0 10.555,4.7284 10.555,10.554 0,5.8262 -4.728,10.555 -10.555,10.555 -5.826,0 -10.554,-4.7284 -10.554,-10.555 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5339" />
-      <rect
-         x="7710.2002"
-         y="-2802.8"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5341" />
+    <g transform="translate(-4762.2,907.09)" id="g5343">
+      <path d="m 7724.4,-2653.8 c 0,9.3302 7.557,16.887 16.887,16.887 h 25.331 v 26.049 c 0,4.6863 3.8,8.4437 8.444,8.4437 2.368,0 4.513,-0.971 6.037,-2.5331 l 31.959,-31.959 h 92.881 c 9.33,0 16.887,-7.5571 16.887,-16.887 v -105.55 c 0,-9.3303 -7.557,-16.887 -16.887,-16.887 h -164.65 c -9.33,0 -16.887,7.557 -16.887,16.887 z m 50.662,-48.551 c 0,-5.8261 4.728,-10.554 10.555,-10.554 5.826,0 10.554,4.7284 10.554,10.554 0,5.8262 -4.728,10.555 -10.554,10.555 -5.827,0 -10.555,-4.7284 -10.555,-10.555 z m 37.996,0 c 0,-5.8261 4.729,-10.554 10.555,-10.554 5.826,0 10.555,4.7284 10.555,10.554 0,5.8262 -4.729,10.555 -10.555,10.555 -5.826,0 -10.555,-4.7284 -10.555,-10.555 z m 37.997,0 c 0,-5.8261 4.728,-10.554 10.554,-10.554 5.827,0 10.555,4.7284 10.555,10.554 0,5.8262 -4.728,10.555 -10.555,10.555 -5.826,0 -10.554,-4.7284 -10.554,-10.555 z" fill="#ffffff" opacity="1" id="path5339"/>
+      <rect x="7710.2002" y="-2802.8" width="226.77" height="226.77" fill="none" opacity="1" id="rect5341"/>
     </g>
-    <g
-       transform="translate(-5896.1,2267.7)"
-       id="g5349">
-      <path
-         d="m 8277.2,-2557.7 c -3.683,0 -6.738,2.4804 -7.689,5.8701 l -19.512,60.272 h -64.075 c -4.423,0 -7.937,3.8486 -7.937,8.3091 0,2.7283 1.364,5.1673 3.431,6.6183 1.282,0.8681 51.756,37.742 51.756,37.742 0,0 -19.383,59.528 -19.76,60.478 -0.289,0.8681 -0.492,1.8189 -0.492,2.8111 0,4.4645 3.593,8.061 8.016,8.061 1.695,0 3.266,-0.5374 4.589,-1.4468 l 51.673,-37.622 c 0,0 50.516,36.792 51.673,37.622 1.319,0.9094 2.894,1.4468 4.585,1.4468 4.423,0 8.02,-3.6378 8.02,-8.061 0,-0.988 -0.207,-1.943 -0.496,-2.8111 -0.373,-0.9466 -19.756,-60.478 -19.756,-60.478 0,0 50.47,-36.874 51.756,-37.742 2.067,-1.451 3.431,-3.8858 3.431,-6.6555 0,-4.4191 -3.431,-8.2678 -7.854,-8.2678 h -64.075 l -19.595,-60.272 c -0.951,-3.3939 -4.01,-5.8743 -7.689,-5.8743 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5345" />
-      <rect
-         x="8163.7998"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5347" />
+    <g transform="translate(-5896.1,2267.7)" id="g5349">
+      <path d="m 8277.2,-2557.7 c -3.683,0 -6.738,2.4804 -7.689,5.8701 l -19.512,60.272 h -64.075 c -4.423,0 -7.937,3.8486 -7.937,8.3091 0,2.7283 1.364,5.1673 3.431,6.6183 1.282,0.8681 51.756,37.742 51.756,37.742 0,0 -19.383,59.528 -19.76,60.478 -0.289,0.8681 -0.492,1.8189 -0.492,2.8111 0,4.4645 3.593,8.061 8.016,8.061 1.695,0 3.266,-0.5374 4.589,-1.4468 l 51.673,-37.622 c 0,0 50.516,36.792 51.673,37.622 1.319,0.9094 2.894,1.4468 4.585,1.4468 4.423,0 8.02,-3.6378 8.02,-8.061 0,-0.988 -0.207,-1.943 -0.496,-2.8111 -0.373,-0.9466 -19.756,-60.478 -19.756,-60.478 0,0 50.47,-36.874 51.756,-37.742 2.067,-1.451 3.431,-3.8858 3.431,-6.6555 0,-4.4191 -3.431,-8.2678 -7.854,-8.2678 h -64.075 l -19.595,-60.272 c -0.951,-3.3939 -4.01,-5.8743 -7.689,-5.8743 z" fill="#ffffff" opacity="1" id="path5345"/>
+      <rect x="8163.7998" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect5347"/>
     </g>
-    <g
-       transform="translate(-8163.8,3401.6)"
-       id="g5355">
-      <path
-         d="m 8570.1,-2590.2 c 9.136,0 16.535,-7.3996 16.535,-16.536 v -20.669 h 7.441 c 5.044,0 9.095,-4.0512 9.095,-9.0946 v -43.819 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -7.441 v -16.536 h 7.441 c 5.044,0 9.095,-4.0512 9.095,-9.0945 v -43.819 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -7.441 v -4.1339 c 0,-9.1358 -7.399,-16.536 -16.535,-16.536 h -128.15 c -9.136,0 -16.536,7.3997 -16.536,16.536 v 16.536 h -10.334 c -5.705,0 -10.335,4.6299 -10.335,10.335 0,5.7047 4.63,10.335 10.335,10.335 h 10.334 v 16.536 h -10.334 c -5.705,0 -10.335,4.6299 -10.335,10.335 0,5.7048 4.63,10.335 10.335,10.335 h 10.334 v 16.536 h -10.334 c -5.705,0 -10.335,4.63 -10.335,10.335 0,5.705 4.63,10.335 10.335,10.335 h 10.334 v 16.536 h -10.334 c -5.705,0 -10.335,4.6299 -10.335,10.335 0,5.7048 4.63,10.335 10.335,10.335 h 10.334 v 16.536 c 0,9.1359 7.4,16.536 16.536,16.536 z m -124.02,-29.764 v -3.3071 h 14.468 c 5.705,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.63,-10.335 -10.335,-10.335 h -14.468 v -16.536 h 14.468 c 5.705,0 10.335,-4.63 10.335,-10.335 0,-5.705 -4.63,-10.335 -10.335,-10.335 h -14.468 v -16.536 h 14.468 c 5.705,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.63,-10.335 -10.335,-10.335 h -14.468 v -16.536 h 14.468 c 5.705,0 10.335,-4.63 10.335,-10.335 0,-5.7048 -4.63,-10.335 -10.335,-10.335 h -14.468 v -3.3071 c 0,-5.0433 4.051,-9.0945 9.094,-9.0945 h 27.284 c 5.043,0 9.094,4.0512 9.094,9.0945 v 138.9 c 0,5.0434 -4.051,9.0945 -9.094,9.0945 h -27.284 c -5.043,0 -9.094,-4.0511 -9.094,-9.0945 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5351" />
-      <rect
-         x="8390.5996"
-         y="-2802.8"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5353" />
+    <g transform="translate(-8163.8,3401.6)" id="g5355">
+      <path d="m 8570.1,-2590.2 c 9.136,0 16.535,-7.3996 16.535,-16.536 v -20.669 h 7.441 c 5.044,0 9.095,-4.0512 9.095,-9.0946 v -43.819 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -7.441 v -16.536 h 7.441 c 5.044,0 9.095,-4.0512 9.095,-9.0945 v -43.819 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -7.441 v -4.1339 c 0,-9.1358 -7.399,-16.536 -16.535,-16.536 h -128.15 c -9.136,0 -16.536,7.3997 -16.536,16.536 v 16.536 h -10.334 c -5.705,0 -10.335,4.6299 -10.335,10.335 0,5.7047 4.63,10.335 10.335,10.335 h 10.334 v 16.536 h -10.334 c -5.705,0 -10.335,4.6299 -10.335,10.335 0,5.7048 4.63,10.335 10.335,10.335 h 10.334 v 16.536 h -10.334 c -5.705,0 -10.335,4.63 -10.335,10.335 0,5.705 4.63,10.335 10.335,10.335 h 10.334 v 16.536 h -10.334 c -5.705,0 -10.335,4.6299 -10.335,10.335 0,5.7048 4.63,10.335 10.335,10.335 h 10.334 v 16.536 c 0,9.1359 7.4,16.536 16.536,16.536 z m -124.02,-29.764 v -3.3071 h 14.468 c 5.705,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.63,-10.335 -10.335,-10.335 h -14.468 v -16.536 h 14.468 c 5.705,0 10.335,-4.63 10.335,-10.335 0,-5.705 -4.63,-10.335 -10.335,-10.335 h -14.468 v -16.536 h 14.468 c 5.705,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.63,-10.335 -10.335,-10.335 h -14.468 v -16.536 h 14.468 c 5.705,0 10.335,-4.63 10.335,-10.335 0,-5.7048 -4.63,-10.335 -10.335,-10.335 h -14.468 v -3.3071 c 0,-5.0433 4.051,-9.0945 9.094,-9.0945 h 27.284 c 5.043,0 9.094,4.0512 9.094,9.0945 v 138.9 c 0,5.0434 -4.051,9.0945 -9.094,9.0945 h -27.284 c -5.043,0 -9.094,-4.0511 -9.094,-9.0945 z" fill="#ffffff" opacity="1" id="path5351"/>
+      <rect x="8390.5996" y="-2802.8" width="226.77" height="226.77" fill="none" opacity="1" id="rect5353"/>
     </g>
-    <g
-       transform="translate(-7029.9,2494.5)"
-       id="g5361">
-      <path
-         d="m 8441.9,-3095.4 c 0,5.7047 4.63,10.335 10.335,10.335 5.704,0 10.334,-4.63 10.334,-10.335 0,-5.7048 -4.63,-10.335 -10.334,-10.335 -5.705,0 -10.335,4.6299 -10.335,10.335 z m 101.61,-97.146 -102.31,-44.894 c -4.589,-1.7362 -9.632,0.5374 -11.203,5.0847 -1.612,4.5473 0.827,9.6733 5.416,11.41 l 64.736,28.4 h -78.915 c -9.136,0 -16.536,7.3996 -16.536,16.536 v 111.61 c 0,9.1359 7.4,16.536 16.536,16.536 h 148.82 c 9.136,0 16.535,-7.3996 16.535,-16.536 v -57.874 h 7.441 c 5.044,0 9.095,-4.0512 9.095,-9.0945 v -23.15 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -7.441 v -12.402 c 0,-9.1359 -7.399,-16.536 -16.535,-16.536 z m -109.05,20.669 h 122.36 c 5.043,0 9.094,4.0512 9.094,9.0946 v 14.882 c 0,5.0433 -4.051,9.0945 -9.094,9.0945 h -81.851 l -12.402,-12.402 -12.401,12.402 h -15.709 c -5.043,0 -9.095,-4.0512 -9.095,-9.0945 v -14.882 c 0,-5.0434 4.052,-9.0946 9.095,-9.0946 z m 110.79,59.941 c 0,-5.7047 4.63,-10.335 10.334,-10.335 5.705,0 10.335,4.63 10.335,10.335 0,5.705 -4.63,10.335 -10.335,10.335 -5.704,0 -10.334,-4.63 -10.334,-10.335 z m -119.88,16.536 c 0,-14.841 12.03,-26.87 26.871,-26.87 14.84,0 26.87,12.03 26.87,26.87 0,14.84 -12.03,26.87 -26.87,26.87 -14.841,0 -26.871,-12.03 -26.871,-26.87 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5357" />
-      <rect
-         x="8390.5996"
-         y="-3256.3"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5359" />
+    <g transform="translate(-7029.9,2494.5)" id="g5361">
+      <path d="m 8441.9,-3095.4 c 0,5.7047 4.63,10.335 10.335,10.335 5.704,0 10.334,-4.63 10.334,-10.335 0,-5.7048 -4.63,-10.335 -10.334,-10.335 -5.705,0 -10.335,4.6299 -10.335,10.335 z m 101.61,-97.146 -102.31,-44.894 c -4.589,-1.7362 -9.632,0.5374 -11.203,5.0847 -1.612,4.5473 0.827,9.6733 5.416,11.41 l 64.736,28.4 h -78.915 c -9.136,0 -16.536,7.3996 -16.536,16.536 v 111.61 c 0,9.1359 7.4,16.536 16.536,16.536 h 148.82 c 9.136,0 16.535,-7.3996 16.535,-16.536 v -57.874 h 7.441 c 5.044,0 9.095,-4.0512 9.095,-9.0945 v -23.15 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -7.441 v -12.402 c 0,-9.1359 -7.399,-16.536 -16.535,-16.536 z m -109.05,20.669 h 122.36 c 5.043,0 9.094,4.0512 9.094,9.0946 v 14.882 c 0,5.0433 -4.051,9.0945 -9.094,9.0945 h -81.851 l -12.402,-12.402 -12.401,12.402 h -15.709 c -5.043,0 -9.095,-4.0512 -9.095,-9.0945 v -14.882 c 0,-5.0434 4.052,-9.0946 9.095,-9.0946 z m 110.79,59.941 c 0,-5.7047 4.63,-10.335 10.334,-10.335 5.705,0 10.335,4.63 10.335,10.335 0,5.705 -4.63,10.335 -10.335,10.335 -5.704,0 -10.334,-4.63 -10.334,-10.335 z m -119.88,16.536 c 0,-14.841 12.03,-26.87 26.871,-26.87 14.84,0 26.87,12.03 26.87,26.87 0,14.84 -12.03,26.87 -26.87,26.87 -14.841,0 -26.871,-12.03 -26.871,-26.87 z" fill="#ffffff" opacity="1" id="path5357"/>
+      <rect x="8390.5996" y="-3256.3" width="226.77" height="226.77" fill="none" opacity="1" id="rect5359"/>
     </g>
-    <g
-       transform="translate(-7029.9,2948)"
-       id="g5369">
-      <path
-         d="m 7769.9,-3188.4 v 28.938 h -12.402 c -9.1351,0 -16.535,7.3997 -16.535,16.536 v 82.679 c 0,9.1359 7.4002,16.536 16.535,16.536 h 132.29 c 9.1361,0 16.535,-7.3998 16.535,-16.536 v -82.679 c 0,-9.136 -7.3992,-16.536 -16.535,-16.536 h -12.402 v -28.938 c 0,-29.682 -24.06,-53.741 -53.741,-53.741 -29.681,0 -53.741,24.06 -53.741,53.741 z m 20.669,28.938 v -28.938 c 0,-18.272 14.8,-33.071 33.072,-33.071 18.272,0 33.072,14.8 33.072,33.071 v 28.938 z m 16.536,45.473 c 0,-9.1359 7.3991,-16.536 16.535,-16.536 9.1359,0 16.536,7.3998 16.536,16.536 0,5.8288 -3.0181,10.955 -7.5651,13.89 0,0 1.616,9.756 3.431,21.248 0,3.4312 -2.77,6.201 -6.2011,6.201 h -12.402 c -3.4311,0 -6.2001,-2.7698 -6.2001,-6.201 l 3.431,-21.248 c -4.548,-2.9352 -7.5651,-8.0613 -7.5651,-13.89 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5363" />
-      <rect
-         x="7710.2002"
-         y="-3256.3"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5365" />
-      <rect
-         x="7710.2002"
-         y="-3256.3"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5367" />
+    <g transform="translate(-7029.9,2948)" id="g5369">
+      <path d="m 7769.9,-3188.4 v 28.938 h -12.402 c -9.1351,0 -16.535,7.3997 -16.535,16.536 v 82.679 c 0,9.1359 7.4002,16.536 16.535,16.536 h 132.29 c 9.1361,0 16.535,-7.3998 16.535,-16.536 v -82.679 c 0,-9.136 -7.3992,-16.536 -16.535,-16.536 h -12.402 v -28.938 c 0,-29.682 -24.06,-53.741 -53.741,-53.741 -29.681,0 -53.741,24.06 -53.741,53.741 z m 20.669,28.938 v -28.938 c 0,-18.272 14.8,-33.071 33.072,-33.071 18.272,0 33.072,14.8 33.072,33.071 v 28.938 z m 16.536,45.473 c 0,-9.1359 7.3991,-16.536 16.535,-16.536 9.1359,0 16.536,7.3998 16.536,16.536 0,5.8288 -3.0181,10.955 -7.5651,13.89 0,0 1.616,9.756 3.431,21.248 0,3.4312 -2.77,6.201 -6.2011,6.201 h -12.402 c -3.4311,0 -6.2001,-2.7698 -6.2001,-6.201 l 3.431,-21.248 c -4.548,-2.9352 -7.5651,-8.0613 -7.5651,-13.89 z" fill="#ffffff" opacity="1" id="path5363"/>
+      <rect x="7710.2002" y="-3256.3" width="226.77" height="226.77" fill="none" opacity="1" id="rect5365"/>
+      <rect x="7710.2002" y="-3256.3" width="226.77" height="226.77" fill="none" opacity="1" id="rect5367"/>
     </g>
-    <g
-       transform="translate(-5442.5,1814.2)"
-       id="g5375">
-      <path
-         d="m 7382.1,-1972.4 12.03,12.03 c 3.964,3.9685 10.372,3.9685 14.34,0 3.973,-3.9685 3.973,-10.376 0,-14.344 l -11.984,-12.03 11.984,-11.988 c 0,0 -45.386,-19.388 -47.246,-20.091 -0.992,-0.372 -2.026,-0.5787 -3.1,-0.5787 -4.796,0 -8.682,3.8445 -8.682,8.5985 0,1.1161 0.207,2.1496 0.579,3.1004 0.703,1.7775 20.091,47.333 20.091,47.333 z m -111.2,39.809 c 0,9.1359 7.4,16.536 16.536,16.536 h 165.35 c 9.136,0 16.536,-7.3996 16.536,-16.536 v -152.95 c 0,-9.1358 -7.4,-16.535 -16.536,-16.535 h -165.35 c -9.136,0 -16.536,7.3996 -16.536,16.535 z m 29.764,-111.61 h 138.9 c 5.043,0 9.095,4.0512 9.095,9.0945 v 89.292 c 0,5.0434 -4.052,9.0946 -9.095,9.0946 h -138.9 c -5.043,0 -9.095,-4.0512 -9.095,-9.0946 v -89.292 c 0,-5.0433 4.052,-9.0945 9.095,-9.0945 z m -9.095,-26.87 c 0,-5.7047 4.63,-10.335 10.335,-10.335 5.705,0 10.335,4.63 10.335,10.335 0,5.705 -4.63,10.335 -10.335,10.335 -5.705,0 -10.335,-4.63 -10.335,-10.335 z m 37.205,0 c 0,-5.7047 4.63,-10.335 10.335,-10.335 5.705,0 10.335,4.63 10.335,10.335 0,5.705 -4.63,10.335 -10.335,10.335 -5.705,0 -10.335,-4.63 -10.335,-10.335 z m 37.205,0 c 0,-5.7047 4.63,-10.335 10.335,-10.335 5.705,0 10.334,4.63 10.334,10.335 0,5.705 -4.629,10.335 -10.334,10.335 -5.705,0 -10.335,-4.63 -10.335,-10.335 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5371" />
-      <rect
-         x="7256.7002"
-         y="-2122.3999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5373" />
+    <g transform="translate(-5442.5,1814.2)" id="g5375">
+      <path d="m 7382.1,-1972.4 12.03,12.03 c 3.964,3.9685 10.372,3.9685 14.34,0 3.973,-3.9685 3.973,-10.376 0,-14.344 l -11.984,-12.03 11.984,-11.988 c 0,0 -45.386,-19.388 -47.246,-20.091 -0.992,-0.372 -2.026,-0.5787 -3.1,-0.5787 -4.796,0 -8.682,3.8445 -8.682,8.5985 0,1.1161 0.207,2.1496 0.579,3.1004 0.703,1.7775 20.091,47.333 20.091,47.333 z m -111.2,39.809 c 0,9.1359 7.4,16.536 16.536,16.536 h 165.35 c 9.136,0 16.536,-7.3996 16.536,-16.536 v -152.95 c 0,-9.1358 -7.4,-16.535 -16.536,-16.535 h -165.35 c -9.136,0 -16.536,7.3996 -16.536,16.535 z m 29.764,-111.61 h 138.9 c 5.043,0 9.095,4.0512 9.095,9.0945 v 89.292 c 0,5.0434 -4.052,9.0946 -9.095,9.0946 h -138.9 c -5.043,0 -9.095,-4.0512 -9.095,-9.0946 v -89.292 c 0,-5.0433 4.052,-9.0945 9.095,-9.0945 z m -9.095,-26.87 c 0,-5.7047 4.63,-10.335 10.335,-10.335 5.705,0 10.335,4.63 10.335,10.335 0,5.705 -4.63,10.335 -10.335,10.335 -5.705,0 -10.335,-4.63 -10.335,-10.335 z m 37.205,0 c 0,-5.7047 4.63,-10.335 10.335,-10.335 5.705,0 10.335,4.63 10.335,10.335 0,5.705 -4.63,10.335 -10.335,10.335 -5.705,0 -10.335,-4.63 -10.335,-10.335 z m 37.205,0 c 0,-5.7047 4.63,-10.335 10.335,-10.335 5.705,0 10.334,4.63 10.334,10.335 0,5.705 -4.629,10.335 -10.334,10.335 -5.705,0 -10.335,-4.63 -10.335,-10.335 z" fill="#ffffff" opacity="1" id="path5371"/>
+      <rect x="7256.7002" y="-2122.3999" width="226.77" height="226.77" fill="none" opacity="1" id="rect5373"/>
     </g>
-    <g
-       transform="translate(-5896.1,1587.4)"
-       id="g5381">
-      <path
-         d="m 8149.6,-1807.2 c 0,-4.5101 -3.721,-8.1851 -8.268,-8.1851 -2.273,0 -4.34,0.9136 -5.829,2.3976 l -35.51,30.554 v -24.762 c 0,-4.5101 -3.72,-8.1851 -8.267,-8.1851 -2.274,0 -4.341,0.9136 -5.829,2.3977 l -35.51,30.553 v -24.762 c 0,-4.51 -3.72,-8.185 -8.268,-8.185 -2.273,0 -4.34,0.9135 -5.829,2.3976 l -35.882,30.839 -7.895,-90.284 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -14.882 c -5.043,0 -9.094,4.0512 -9.094,9.0945 l -8.268,172.8 c 0,9.1358 7.4,16.536 16.536,16.536 h 165.35 c 9.136,0 16.536,-7.3997 16.536,-16.536 z m -119.88,53.286 v 9.3425 c 0,4.2579 -3.473,7.7304 -7.731,7.7304 h -9.342 c -4.258,0 -7.731,-3.4725 -7.731,-7.7304 v -9.3425 c 0,-4.2579 3.473,-7.7304 7.731,-7.7304 h 9.342 c 4.258,0 7.731,3.4725 7.731,7.7304 z m 49.606,0 v 9.3425 c 0,4.2579 -3.472,7.7304 -7.73,7.7304 h -9.343 c -4.258,0 -7.73,-3.4725 -7.73,-7.7304 v -9.3425 c 0,-4.2579 3.472,-7.7304 7.73,-7.7304 h 9.343 c 4.258,0 7.73,3.4725 7.73,7.7304 z m 49.607,0 v 9.3425 c 0,4.2579 -3.473,7.7304 -7.731,7.7304 h -9.342 c -4.258,0 -7.731,-3.4725 -7.731,-7.7304 v -9.3425 c 0,-4.2579 3.473,-7.7304 7.731,-7.7304 h 9.342 c 4.258,0 7.731,3.4725 7.731,7.7304 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5377" />
-      <rect
-         x="7937"
-         y="-1895.7"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5379" />
+    <g transform="translate(-5896.1,1587.4)" id="g5381">
+      <path d="m 8149.6,-1807.2 c 0,-4.5101 -3.721,-8.1851 -8.268,-8.1851 -2.273,0 -4.34,0.9136 -5.829,2.3976 l -35.51,30.554 v -24.762 c 0,-4.5101 -3.72,-8.1851 -8.267,-8.1851 -2.274,0 -4.341,0.9136 -5.829,2.3977 l -35.51,30.553 v -24.762 c 0,-4.51 -3.72,-8.185 -8.268,-8.185 -2.273,0 -4.34,0.9135 -5.829,2.3976 l -35.882,30.839 -7.895,-90.284 c 0,-5.0433 -4.051,-9.0945 -9.095,-9.0945 h -14.882 c -5.043,0 -9.094,4.0512 -9.094,9.0945 l -8.268,172.8 c 0,9.1358 7.4,16.536 16.536,16.536 h 165.35 c 9.136,0 16.536,-7.3997 16.536,-16.536 z m -119.88,53.286 v 9.3425 c 0,4.2579 -3.473,7.7304 -7.731,7.7304 h -9.342 c -4.258,0 -7.731,-3.4725 -7.731,-7.7304 v -9.3425 c 0,-4.2579 3.473,-7.7304 7.731,-7.7304 h 9.342 c 4.258,0 7.731,3.4725 7.731,7.7304 z m 49.606,0 v 9.3425 c 0,4.2579 -3.472,7.7304 -7.73,7.7304 h -9.343 c -4.258,0 -7.73,-3.4725 -7.73,-7.7304 v -9.3425 c 0,-4.2579 3.472,-7.7304 7.73,-7.7304 h 9.343 c 4.258,0 7.73,3.4725 7.73,7.7304 z m 49.607,0 v 9.3425 c 0,4.2579 -3.473,7.7304 -7.731,7.7304 h -9.342 c -4.258,0 -7.731,-3.4725 -7.731,-7.7304 v -9.3425 c 0,-4.2579 3.473,-7.7304 7.731,-7.7304 h 9.342 c 4.258,0 7.731,3.4725 7.731,7.7304 z" fill="#ffffff" opacity="1" id="path5377"/>
+      <rect x="7937" y="-1895.7" width="226.77" height="226.77" fill="none" opacity="1" id="rect5379"/>
     </g>
-    <g
-       transform="translate(-1.1509e-5,1814.2)"
-       id="g5387">
-      <path
-         d="m 88.557,-2462.6 c 0,13.686 11.118,24.808 24.808,24.808 13.691,0 24.809,-11.122 24.809,-24.808 v -0.207 c -2.651,2.687 -6.285,4.341 -10.337,4.341 -7.984,0 -14.472,-6.492 -14.472,-14.471 0,-5.748 3.386,-10.75 8.228,-13.066 -2.563,-0.91 -5.333,-1.405 -8.228,-1.405 -13.69,0 -24.808,11.122 -24.808,24.808 z m 118.5,-14.1 c -15.385,-19.557 -52.841,-52.056 -93.651,-52.056 -40.851,0 -78.349,32.499 -93.735,52.056 -3.473,4.465 -5.375,9.303 -5.499,14.1 0.124,4.795 2.026,9.633 5.499,14.098 15.386,19.558 52.842,52.057 93.693,52.057 40.852,0 78.308,-32.499 93.693,-52.057 3.514,-4.465 5.416,-9.303 5.54,-14.098 -0.124,-4.797 -2.026,-9.635 -5.54,-14.1 z m -93.693,55.447 c -22.823,0 -41.347,-18.524 -41.347,-41.347 0,-22.825 18.524,-41.347 41.347,-41.347 22.824,0 41.347,18.522 41.347,41.347 0,22.823 -18.523,41.347 -41.347,41.347 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5383" />
-      <rect
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5385"
-         x="0" />
+    <g transform="translate(-1.1509e-5,1814.2)" id="g5387">
+      <path d="m 88.557,-2462.6 c 0,13.686 11.118,24.808 24.808,24.808 13.691,0 24.809,-11.122 24.809,-24.808 v -0.207 c -2.651,2.687 -6.285,4.341 -10.337,4.341 -7.984,0 -14.472,-6.492 -14.472,-14.471 0,-5.748 3.386,-10.75 8.228,-13.066 -2.563,-0.91 -5.333,-1.405 -8.228,-1.405 -13.69,0 -24.808,11.122 -24.808,24.808 z m 118.5,-14.1 c -15.385,-19.557 -52.841,-52.056 -93.651,-52.056 -40.851,0 -78.349,32.499 -93.735,52.056 -3.473,4.465 -5.375,9.303 -5.499,14.1 0.124,4.795 2.026,9.633 5.499,14.098 15.386,19.558 52.842,52.057 93.693,52.057 40.852,0 78.308,-32.499 93.693,-52.057 3.514,-4.465 5.416,-9.303 5.54,-14.098 -0.124,-4.797 -2.026,-9.635 -5.54,-14.1 z m -93.693,55.447 c -22.823,0 -41.347,-18.524 -41.347,-41.347 0,-22.825 18.524,-41.347 41.347,-41.347 22.824,0 41.347,18.522 41.347,41.347 0,22.823 -18.523,41.347 -41.347,41.347 z" fill="#ffffff" opacity="1" id="path5383"/>
+      <rect y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect5385" x="0"/>
     </g>
-    <g
-       fill="none"
-       id="g5403">
-      <rect
-         x="2267.7"
-         y="-2122.3999"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect5389" />
-      <g
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="g5401">
-        <path
-           d="m 2306.3,-2099.7 h 149.66"
-           opacity="1"
-           id="path5391" />
-        <path
-           d="m 2343.7,-2054.7 h 74.757"
-           opacity="1"
-           id="path5393" />
-        <path
-           d="m 2306.3,-2007.3 h 149.66"
-           opacity="1"
-           id="path5395" />
-        <path
-           d="m 2343.7,-1962.3 h 74.757"
-           opacity="1"
-           id="path5397" />
-        <path
-           d="m 2306.3,-1917.3 h 149.66"
-           opacity="1"
-           id="path5399" />
+    <g fill="none" id="g5403">
+      <rect x="2267.7" y="-2122.3999" width="226.77" height="226.77" opacity="1" id="rect5389"/>
+      <g stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="g5401">
+        <path d="m 2306.3,-2099.7 h 149.66" opacity="1" id="path5391"/>
+        <path d="m 2343.7,-2054.7 h 74.757" opacity="1" id="path5393"/>
+        <path d="m 2306.3,-2007.3 h 149.66" opacity="1" id="path5395"/>
+        <path d="m 2343.7,-1962.3 h 74.757" opacity="1" id="path5397"/>
+        <path d="m 2306.3,-1917.3 h 149.66" opacity="1" id="path5399"/>
       </g>
     </g>
-    <g
-       transform="translate(-4308.7,-453.54)"
-       id="g5409">
-      <path
-         d="m 6462.8,-1881.5 c -3.084,0.095 -5.7683,2.1352 -6.6842,5.0816 l -57.125,183.96 c -1.4444,4.6536 2.0332,9.375 6.9058,9.3757 h 114.25 c 4.8727,-7e-4 8.3503,-4.722 6.9059,-9.3757 l -57.125,-183.96 c -0.9646,-3.1026 -3.8799,-5.1811 -7.1274,-5.0816 z m 0.2215,31.61 47.307,152.35 h -94.615 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5405" />
-      <rect
-         x="6349.6001"
-         y="-1895.7"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5407" />
+    <g transform="translate(-4308.7,-453.54)" id="g5409">
+      <path d="m 6462.8,-1881.5 c -3.084,0.095 -5.7683,2.1352 -6.6842,5.0816 l -57.125,183.96 c -1.4444,4.6536 2.0332,9.375 6.9058,9.3757 h 114.25 c 4.8727,-7e-4 8.3503,-4.722 6.9059,-9.3757 l -57.125,-183.96 c -0.9646,-3.1026 -3.8799,-5.1811 -7.1274,-5.0816 z m 0.2215,31.61 47.307,152.35 h -94.615 z" fill="#ffffff" opacity="1" id="path5405"/>
+      <rect x="6349.6001" y="-1895.7" width="226.77" height="226.77" fill="none" opacity="1" id="rect5407"/>
     </g>
-    <g
-       transform="translate(5215.7,-226.77)"
-       id="g5429">
-      <g
-         transform="matrix(-3.5486,0.95084,0.95926,3.58,-2692.7,-6956.9)"
-         opacity="1"
-         id="g5425">
-        <g
-           transform="matrix(0.96593,-0.25655,-0.26111,-0.96593,402.29,2995.7)"
-           id="g5413">
-          <path
-             d="m 424.87,1491.6 7.3779,-8.8015 7.3779,8.8015 z"
-             fill="#ffffff"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="5.3843"
-             id="path5411" />
+    <g transform="translate(5215.7,-226.77)" id="g5429">
+      <g transform="matrix(-3.5486,0.95084,0.95926,3.58,-2692.7,-6956.9)" opacity="1" id="g5425">
+        <g transform="matrix(0.96593,-0.25655,-0.26111,-0.96593,402.29,2995.7)" id="g5413">
+          <path d="m 424.87,1491.6 7.3779,-8.8015 7.3779,8.8015 z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.3843" id="path5411"/>
         </g>
-        <g
-           transform="matrix(2.3205,-0.61633,0.62713,2.3199,-1521.6,-1668)"
-           id="g5417">
-          <path
-             transform="scale(-1,1)"
-             d="m -453.33,1467.7 h -3.7462 v -11.878 h 20.988 v 11.878 h -3.7462"
-             fill="none"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="1.4943"
-             id="path5415" />
+        <g transform="matrix(2.3205,-0.61633,0.62713,2.3199,-1521.6,-1668)" id="g5417">
+          <path transform="scale(-1,1)" d="m -453.33,1467.7 h -3.7462 v -11.878 h 20.988 v 11.878 h -3.7462" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.4943" id="path5415"/>
         </g>
-        <g
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="3.841"
-           id="g5423">
-          <path
-             d="m 441.34,1457.2 -10.153,17.431"
-             opacity="1"
-             id="path5419" />
-          <path
-             d="m 427.47,1460.9 17.586,10.064"
-             opacity="1"
-             id="path5421" />
+        <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.841" id="g5423">
+          <path d="m 441.34,1457.2 -10.153,17.431" opacity="1" id="path5419"/>
+          <path d="m 427.47,1460.9 17.586,10.064" opacity="1" id="path5421"/>
         </g>
       </g>
-      <rect
-         x="-2948"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5427" />
+      <rect x="-2948" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect5427"/>
     </g>
-    <g
-       transform="translate(5669.3,-453.54)"
-       id="g5447">
-      <g
-         transform="matrix(6.611,0,0,6.611,-5987.3,-10818)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         id="g5443">
-        <g
-           transform="matrix(0.52453,0,0,0.52312,247.23,700.97)"
-           opacity="1"
-           id="g5439">
-          <path
-             d="m 424.87,1477.5 7.3779,-8.8015 7.3779,8.8015 z"
-             fill="#ffffff"
-             opacity="1"
-             stroke-width="5.7271"
-             id="path5431" />
-          <g
-             transform="matrix(-1.0233,0.27494,0.27663,1.0352,473.38,-182.31)"
-             fill="none"
-             opacity="1"
-             stroke-width="3.841"
-             id="g5437">
-            <path
-               d="m 441.34,1457.2 -10.153,17.431"
-               opacity="1"
-               id="path5433" />
-            <path
-               d="m 427.47,1460.9 17.586,10.064"
-               opacity="1"
-               id="path5435" />
+    <g transform="translate(5669.3,-453.54)" id="g5447">
+      <g transform="matrix(6.611,0,0,6.611,-5987.3,-10818)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" id="g5443">
+        <g transform="matrix(0.52453,0,0,0.52312,247.23,700.97)" opacity="1" id="g5439">
+          <path d="m 424.87,1477.5 7.3779,-8.8015 7.3779,8.8015 z" fill="#ffffff" opacity="1" stroke-width="5.7271" id="path5431"/>
+          <g transform="matrix(-1.0233,0.27494,0.27663,1.0352,473.38,-182.31)" fill="none" opacity="1" stroke-width="3.841" id="g5437">
+            <path d="m 441.34,1457.2 -10.153,17.431" opacity="1" id="path5433"/>
+            <path d="m 427.47,1460.9 17.586,10.064" opacity="1" id="path5435"/>
           </g>
         </g>
-        <path
-           d="m 491.38,1477.8 h -29"
-           fill="#ffffff"
-           opacity="1"
-           id="path5441" />
+        <path d="m 491.38,1477.8 h -29" fill="#ffffff" opacity="1" id="path5441"/>
       </g>
-      <rect
-         x="-2948"
-         y="-1215.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5445" />
+      <rect x="-2948" y="-1215.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect5445"/>
     </g>
-    <g
-       transform="translate(4536.7,-226.77)"
-       id="g5479">
-      <g
-         transform="matrix(8.8645,1.1093,-1.1019,8.8884,-1993.8,-2802.6)"
-         opacity="0.9"
-         id="g5475">
-        <path
-           transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)"
-           d="m 160.65,1099.3 c 4.2945,1.0457 5.4757,6.6628 7.5074,10.43 l 2.5696,1.2209 9.3611,2.2447 12.346,0.9988 -0.0735,6.5172 -11.678,0.5012 -9.1884,2.0696 -4.6629,2.8607 c -1.8324,2.7606 -2.6604,7.4882 -5.3361,7.6186 -4.0489,0.1973 -8.3999,-2.6783 -10.491,-6.1512 -3.227,-5.3605 -3.2119,-12.974 -0.81265,-18.753 1.8108,-4.3614 5.8696,-10.674 10.458,-9.5571 z"
-           fill="url(#linearGradient5431)"
-           opacity="0.99"
-           id="path5449"
-           style="fill:url(#linearGradient5431)" />
-        <g
-           fill="none"
-           id="g5473">
-          <g
-             stroke-linecap="round"
-             id="g5457">
-            <path
-               d="m 19.971,146.4 0.88064,-1.8972 1.365,-1.5001 2.6859,-1.6766 4.5077,-1.0588 5.8562,-0.30888"
-               color="#000000"
-               stroke="url(#linearGradient5433)"
-               stroke-width="0.62942"
-               id="path5451"
-               style="stroke:url(#linearGradient5433)" />
-            <path
-               transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)"
-               d="m 160.6,1099.3 1.591,4.5078 2.74,3.8891 5.6569,3.2704 9.8111,2.3864 11.756,0.884"
-               color="#000000"
-               stroke="url(#linearGradient5435)"
-               stroke-width="1.2622"
-               id="path5453"
-               style="stroke:url(#linearGradient5435)" />
-            <path
-               d="m 14.886,143.31 2.9409,-2.1877 1.8632,-0.94297 3.3473,-0.57174 5.6036,-0.41157 6.728,0.0579"
-               color="#000000"
-               stroke="url(#linearGradient5437)"
-               stroke-width="0.62942"
-               id="path5455"
-               style="stroke:url(#linearGradient5437)" />
+    <g transform="translate(4536.7,-226.77)" id="g5479">
+      <g transform="matrix(8.8645,1.1093,-1.1019,8.8884,-1993.8,-2802.6)" opacity="0.9" id="g5475">
+        <path transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)" d="m 160.65,1099.3 c 4.2945,1.0457 5.4757,6.6628 7.5074,10.43 l 2.5696,1.2209 9.3611,2.2447 12.346,0.9988 -0.0735,6.5172 -11.678,0.5012 -9.1884,2.0696 -4.6629,2.8607 c -1.8324,2.7606 -2.6604,7.4882 -5.3361,7.6186 -4.0489,0.1973 -8.3999,-2.6783 -10.491,-6.1512 -3.227,-5.3605 -3.2119,-12.974 -0.81265,-18.753 1.8108,-4.3614 5.8696,-10.674 10.458,-9.5571 z" fill="url(#linearGradient5431)" opacity="0.99" id="path5449" style="fill:url(#linearGradient5431)"/>
+        <g fill="none" id="g5473">
+          <g stroke-linecap="round" id="g5457">
+            <path d="m 19.971,146.4 0.88064,-1.8972 1.365,-1.5001 2.6859,-1.6766 4.5077,-1.0588 5.8562,-0.30888" color="#000000" stroke="url(#linearGradient5433)" stroke-width="0.62942" id="path5451" style="stroke:url(#linearGradient5433)"/>
+            <path transform="matrix(0.49816,0,0,0.49916,-60.387,-419.45)" d="m 160.6,1099.3 1.591,4.5078 2.74,3.8891 5.6569,3.2704 9.8111,2.3864 11.756,0.884" color="#000000" stroke="url(#linearGradient5435)" stroke-width="1.2622" id="path5453" style="stroke:url(#linearGradient5435)"/>
+            <path d="m 14.886,143.31 2.9409,-2.1877 1.8632,-0.94297 3.3473,-0.57174 5.6036,-0.41157 6.728,0.0579" color="#000000" stroke="url(#linearGradient5437)" stroke-width="0.62942" id="path5455" style="stroke:url(#linearGradient5437)"/>
           </g>
-          <ellipse
-             transform="matrix(0.23683,0,0,0.29689,-17.039,-194.54)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5439)"
-             stroke-width="2.3737"
-             id="ellipse5459"
-             style="stroke:url(#linearGradient5439)" />
-          <path
-             d="m 14.512,134.11 2.972,2.0629 2.1122,0.75578 3.3785,0.47815 5.6348,0.006 6.728,-0.0579"
-             color="#000000"
-             stroke="url(#linearGradient5441)"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5461"
-             style="stroke:url(#linearGradient5441)" />
-          <ellipse
-             transform="matrix(0.14004,0,0,0.18447,4.9618,-68.514)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5443)"
-             stroke-width="3.9161"
-             id="ellipse5463"
-             style="stroke:url(#linearGradient5443)" />
-          <ellipse
-             transform="matrix(0.49816,0,0,0.60042,-66.619,-535.12)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5445)"
-             stroke-width="1.1509"
-             id="ellipse5465"
-             style="stroke:url(#linearGradient5445)" />
-          <ellipse
-             transform="matrix(0.36266,0,0,0.44304,-41.697,-358.37)"
-             cx="175.19"
-             cy="1121"
-             rx="6.4334998"
-             ry="10.783"
-             stroke="url(#linearGradient5447)"
-             stroke-width="1.5703"
-             id="ellipse5467"
-             style="stroke:url(#linearGradient5447)" />
-          <path
-             d="m 21.996,141.63 1.8493,-1.4517 0.17613,-0.11362 1.7833,-0.31128 4.5077,-0.39164 4.9536,-0.11424"
-             color="#000000"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5469" />
-          <path
-             d="m 21.996,134.93 1.8493,1.4517 0.17613,0.11362 1.7833,0.31128 4.5077,0.39164 4.9536,0.11424"
-             color="#000000"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-width="0.62942"
-             id="path5471" />
+          <ellipse transform="matrix(0.23683,0,0,0.29689,-17.039,-194.54)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5439)" stroke-width="2.3737" id="ellipse5459" style="stroke:url(#linearGradient5439)"/>
+          <path d="m 14.512,134.11 2.972,2.0629 2.1122,0.75578 3.3785,0.47815 5.6348,0.006 6.728,-0.0579" color="#000000" stroke="url(#linearGradient5441)" stroke-linecap="round" stroke-width="0.62942" id="path5461" style="stroke:url(#linearGradient5441)"/>
+          <ellipse transform="matrix(0.14004,0,0,0.18447,4.9618,-68.514)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5443)" stroke-width="3.9161" id="ellipse5463" style="stroke:url(#linearGradient5443)"/>
+          <ellipse transform="matrix(0.49816,0,0,0.60042,-66.619,-535.12)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5445)" stroke-width="1.1509" id="ellipse5465" style="stroke:url(#linearGradient5445)"/>
+          <ellipse transform="matrix(0.36266,0,0,0.44304,-41.697,-358.37)" cx="175.19" cy="1121" rx="6.4334998" ry="10.783" stroke="url(#linearGradient5447)" stroke-width="1.5703" id="ellipse5467" style="stroke:url(#linearGradient5447)"/>
+          <path d="m 21.996,141.63 1.8493,-1.4517 0.17613,-0.11362 1.7833,-0.31128 4.5077,-0.39164 4.9536,-0.11424" color="#000000" stroke="#ffffff" stroke-linecap="round" stroke-width="0.62942" id="path5469"/>
+          <path d="m 21.996,134.93 1.8493,1.4517 0.17613,0.11362 1.7833,0.31128 4.5077,0.39164 4.9536,0.11424" color="#000000" stroke="#ffffff" stroke-linecap="round" stroke-width="0.62942" id="path5471"/>
         </g>
       </g>
-      <rect
-         x="-2040.9"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5477" />
+      <rect x="-2040.9" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect5477"/>
     </g>
-    <g
-       transform="matrix(-9.8328,2.634,2.658,9.9172,3010.9,-17460)"
-       opacity="1"
-       id="g5483">
-      <path
-         transform="matrix(-0.094888,0.025202,0.025432,0.09408,664.24,1324.4)"
-         d="m 2544.7,722.5 a 7.1178,7.057 74.556 0 0 -2.0938,0.25977 7.1178,7.057 74.556 0 0 -2.9687,11.965 l 68.025,68 -68.041,68.025 a 7.1185,7.0576 74.556 1 0 9.9766,10.115 l 68.107,-68.1 68.109,68.086 a 7.1179,7.0571 74.556 1 0 9.9141,-10.088 l -68.02,-68 68.035,-68.025 a 7.1178,7.057 74.556 0 0 -6.9844,-11.934 v -0.004 a 7.1178,7.057 74.556 0 0 -2.9707,1.8164 l -68.121,68.105 -68.092,-68.07 a 7.1178,7.057 74.556 0 0 -4.875,-2.1524 z"
-         color="#000000"
-         color-rendering="auto"
-         fill="#ffffff"
-         image-rendering="auto"
-         opacity="1"
-         shape-rendering="auto"
-         solid-color="#000000"
-         stroke="#000000"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="7.0866"
-         style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal"
-         id="path5481" />
+    <g transform="matrix(-9.8328,2.634,2.658,9.9172,3010.9,-17460)" opacity="1" id="g5483">
+      <path transform="matrix(-0.094888,0.025202,0.025432,0.09408,664.24,1324.4)" d="m 2544.7,722.5 a 7.1178,7.057 74.556 0 0 -2.0938,0.25977 7.1178,7.057 74.556 0 0 -2.9687,11.965 l 68.025,68 -68.041,68.025 a 7.1185,7.0576 74.556 1 0 9.9766,10.115 l 68.107,-68.1 68.109,68.086 a 7.1179,7.0571 74.556 1 0 9.9141,-10.088 l -68.02,-68 68.035,-68.025 a 7.1178,7.057 74.556 0 0 -6.9844,-11.934 v -0.004 a 7.1178,7.057 74.556 0 0 -2.9707,1.8164 l -68.121,68.105 -68.092,-68.07 a 7.1178,7.057 74.556 0 0 -4.875,-2.1524 z" color="#000000" color-rendering="auto" fill="#ffffff" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.0866" style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal" id="path5481"/>
     </g>
-    <path
-       d="m 3415.7,-338.98 c 0,9.1358 7.3996,16.535 16.535,16.535 h 53.74 c 9.1358,0 16.535,-7.3996 16.535,-16.535 v -66.142 h 24.803 v 66.142 c 0,9.1358 7.3996,16.535 16.536,16.535 h 53.74 c 9.1359,0 16.536,-7.3996 16.536,-16.535 v -107.48 c 0,-9.1358 -7.3996,-16.535 -16.536,-16.535 h -8.2677 V -500.2 h 2.0669 c 5.7048,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.6299,-10.335 -10.335,-10.335 h -53.74 c -5.7047,0 -10.335,4.6299 -10.335,10.335 0,5.7048 4.63,10.335 10.335,10.335 h 2.0669 v 37.205 h -49.606 V -500.2 h 2.0669 c 5.7047,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.6299,-10.335 -10.335,-10.335 h -53.74 c -5.7048,0 -10.335,4.6299 -10.335,10.335 0,5.7048 4.6299,10.335 10.335,10.335 h 2.0668 v 37.205 h -8.2677 c -9.1358,0 -16.535,7.3996 -16.535,16.535 z m 107.48,-86.811 h -16.536 c -4.5472,0 -8.2677,-3.7205 -8.2677,-8.2678 0,-4.5472 3.7205,-8.2677 8.2677,-8.2677 h 16.536 c 4.5471,0 8.2676,3.7205 8.2676,8.2677 0,4.5473 -3.7205,8.2678 -8.2676,8.2678 z"
-       fill="#ffffff"
-       opacity="1"
-       id="path5485" />
-    <rect
-       x="3401.6001"
-       y="-535.03998"
-       width="226.77"
-       height="226.77"
-       rx="4.7371001"
-       ry="3.8420999"
-       fill="none"
-       opacity="1"
-       id="rect5487" />
-    <g
-       transform="matrix(0,1,1,0,3709.8,-4390.2)"
-       id="g5495">
-      <desc
-         id="desc5489">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5491" />
-      <path
-         transform="matrix(0.20646,0,0,0.20231,2406,-1772)"
-         d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z"
-         fill="#ffffff"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="69.35"
-         id="path5493" />
+    <path d="m 3415.7,-338.98 c 0,9.1358 7.3996,16.535 16.535,16.535 h 53.74 c 9.1358,0 16.535,-7.3996 16.535,-16.535 v -66.142 h 24.803 v 66.142 c 0,9.1358 7.3996,16.535 16.536,16.535 h 53.74 c 9.1359,0 16.536,-7.3996 16.536,-16.535 v -107.48 c 0,-9.1358 -7.3996,-16.535 -16.536,-16.535 h -8.2677 V -500.2 h 2.0669 c 5.7048,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.6299,-10.335 -10.335,-10.335 h -53.74 c -5.7047,0 -10.335,4.6299 -10.335,10.335 0,5.7048 4.63,10.335 10.335,10.335 h 2.0669 v 37.205 h -49.606 V -500.2 h 2.0669 c 5.7047,0 10.335,-4.6299 10.335,-10.335 0,-5.7047 -4.6299,-10.335 -10.335,-10.335 h -53.74 c -5.7048,0 -10.335,4.6299 -10.335,10.335 0,5.7048 4.6299,10.335 10.335,10.335 h 2.0668 v 37.205 h -8.2677 c -9.1358,0 -16.535,7.3996 -16.535,16.535 z m 107.48,-86.811 h -16.536 c -4.5472,0 -8.2677,-3.7205 -8.2677,-8.2678 0,-4.5472 3.7205,-8.2677 8.2677,-8.2677 h 16.536 c 4.5471,0 8.2676,3.7205 8.2676,8.2677 0,4.5473 -3.7205,8.2678 -8.2676,8.2678 z" fill="#ffffff" opacity="1" id="path5485"/>
+    <rect x="3401.6001" y="-535.03998" width="226.77" height="226.77" rx="4.7371001" ry="3.8420999" fill="none" opacity="1" id="rect5487"/>
+    <g transform="matrix(0,1,1,0,3709.8,-4390.2)" id="g5495">
+      <desc id="desc5489">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5491"/>
+      <path transform="matrix(0.20646,0,0,0.20231,2406,-1772)" d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="69.35" id="path5493"/>
     </g>
-    <rect
-       x="972.82001"
-       y="-1376.4"
-       width="95.307999"
-       height="95.307999"
-       rx="3.3255"
-       ry="2.6422"
-       fill="#ffffff"
-       opacity="1"
-       id="rect5497" />
-    <rect
-       x="907.09003"
-       y="-1442.1"
-       width="226.77"
-       height="226.77"
-       rx="6.9233999"
-       ry="5.5008001"
-       fill="none"
-       opacity="1"
-       id="rect5499" />
-    <g
-       transform="matrix(0,1,1,0,3936.6,-4390.2)"
-       id="g5513">
-      <desc
-         id="desc5501">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5503" />
-      <g
-         transform="translate(0,0.78473)"
-         id="g5511">
-        <g
-           transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="19.189"
-           id="g5509">
-          <path
-             d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z"
-             fill="#ffffff"
-             opacity="1"
-             id="path5505" />
-          <path
-             d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298"
-             fill="none"
-             opacity="1"
-             id="path5507" />
+    <rect x="972.82001" y="-1376.4" width="95.307999" height="95.307999" rx="3.3255" ry="2.6422" fill="#ffffff" opacity="1" id="rect5497"/>
+    <rect x="907.09003" y="-1442.1" width="226.77" height="226.77" rx="6.9233999" ry="5.5008001" fill="none" opacity="1" id="rect5499"/>
+    <g transform="matrix(0,1,1,0,3936.6,-4390.2)" id="g5513">
+      <desc id="desc5501">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5503"/>
+      <g transform="translate(0,0.78473)" id="g5511">
+        <g transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="19.189" id="g5509">
+          <path d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z" fill="#ffffff" opacity="1" id="path5505"/>
+          <path d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298" fill="none" opacity="1" id="path5507"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0,1,1,0,3936.6,-4390.2)"
-       id="g5519">
-      <desc
-         id="desc5515">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5517" />
+    <g transform="matrix(0,1,1,0,3936.6,-4390.2)" id="g5519">
+      <desc id="desc5515">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5517"/>
     </g>
-    <g
-       transform="matrix(0,1,1,0,4163.4,-4390.2)"
-       id="g5535">
-      <desc
-         id="desc5521">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5523" />
-      <g
-         transform="translate(0,-14.158)"
-         id="g5533">
-        <g
-           transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="19.189"
-           id="g5531">
-          <path
-             d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z"
-             fill="#ffffff"
-             opacity="1"
-             id="path5525" />
-          <path
-             d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298"
-             fill="none"
-             opacity="1"
-             id="path5527" />
-          <path
-             d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298"
-             fill="none"
-             opacity="1"
-             id="path5529" />
+    <g transform="matrix(0,1,1,0,4163.4,-4390.2)" id="g5535">
+      <desc id="desc5521">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5523"/>
+      <g transform="translate(0,-14.158)" id="g5533">
+        <g transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="19.189" id="g5531">
+          <path d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z" fill="#ffffff" opacity="1" id="path5525"/>
+          <path d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298" fill="none" opacity="1" id="path5527"/>
+          <path d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298" fill="none" opacity="1" id="path5529"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0,1,1,0,4390.2,-4390.2)"
-       id="g5555">
-      <desc
-         id="desc5537">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5539" />
-      <g
-         transform="translate(0,-29.101)"
-         id="g5553">
-        <g
-           transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="19.189"
-           id="g5551">
-          <path
-             d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z"
-             fill="#ffffff"
-             opacity="1"
-             id="path5541" />
-          <g
-             fill="none"
-             id="g5549">
-            <path
-               d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298"
-               opacity="1"
-               id="path5543" />
-            <path
-               d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298"
-               opacity="1"
-               id="path5545" />
-            <path
-               d="m 3117.1,-2190.8 -55.365,82.298 -55.97,-82.298"
-               opacity="1"
-               id="path5547" />
+    <g transform="matrix(0,1,1,0,4390.2,-4390.2)" id="g5555">
+      <desc id="desc5537">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5539"/>
+      <g transform="translate(0,-29.101)" id="g5553">
+        <g transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="19.189" id="g5551">
+          <path d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z" fill="#ffffff" opacity="1" id="path5541"/>
+          <g fill="none" id="g5549">
+            <path d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5543"/>
+            <path d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5545"/>
+            <path d="m 3117.1,-2190.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5547"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0,1,1,0,4616.9,-4390.2)"
-       id="g5577">
-      <desc
-         id="desc5557">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5559" />
-      <g
-         transform="translate(0,-43.487)"
-         id="g5575">
-        <g
-           transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="19.189"
-           id="g5573">
-          <path
-             d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z"
-             fill="#ffffff"
-             opacity="1"
-             id="path5561" />
-          <g
-             fill="none"
-             id="g5571">
-            <path
-               d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298"
-               opacity="1"
-               id="path5563" />
-            <path
-               d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298"
-               opacity="1"
-               id="path5565" />
-            <path
-               d="m 3117.1,-2190.8 -55.365,82.298 -55.97,-82.298"
-               opacity="1"
-               id="path5567" />
-            <path
-               d="m 3117.1,-2150.8 -55.365,82.298 -55.97,-82.298"
-               opacity="1"
-               id="path5569" />
+    <g transform="matrix(0,1,1,0,4616.9,-4390.2)" id="g5577">
+      <desc id="desc5557">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5559"/>
+      <g transform="translate(0,-43.487)" id="g5575">
+        <g transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="19.189" id="g5573">
+          <path d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z" fill="#ffffff" opacity="1" id="path5561"/>
+          <g fill="none" id="g5571">
+            <path d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5563"/>
+            <path d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5565"/>
+            <path d="m 3117.1,-2190.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5567"/>
+            <path d="m 3117.1,-2150.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5569"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(226.98)"
-       id="g5585">
-      <rect
-         x="972.82001"
-         y="-1376.4"
-         width="33.271"
-         height="95.307999"
-         rx="1.1609"
-         ry="2.6422"
-         fill="#ffffff"
-         opacity="1"
-         id="rect5579" />
-      <rect
-         x="907.09003"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         rx="6.9233999"
-         ry="5.5008001"
-         fill="none"
-         opacity="1"
-         id="rect5581" />
-      <rect
-         x="1034.4"
-         y="-1376.4"
-         width="33.689999"
-         height="95.307999"
-         rx="1.1755"
-         ry="2.6422"
-         fill="#ffffff"
-         opacity="1"
-         id="rect5583" />
+    <g transform="translate(226.98)" id="g5585">
+      <rect x="972.82001" y="-1376.4" width="33.271" height="95.307999" rx="1.1609" ry="2.6422" fill="#ffffff" opacity="1" id="rect5579"/>
+      <rect x="907.09003" y="-1442.1" width="226.77" height="226.77" rx="6.9233999" ry="5.5008001" fill="none" opacity="1" id="rect5581"/>
+      <rect x="1034.4" y="-1376.4" width="33.689999" height="95.307999" rx="1.1755" ry="2.6422" fill="#ffffff" opacity="1" id="rect5583"/>
     </g>
-    <g
-       transform="matrix(0,1,1,0,4390.2,-4163.4)"
-       id="g5591">
-      <desc
-         id="desc5587">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5589" />
+    <g transform="matrix(0,1,1,0,4390.2,-4163.4)" id="g5591">
+      <desc id="desc5587">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5589"/>
     </g>
-    <g
-       transform="matrix(0,1,1,0,4616.9,-4163.4)"
-       id="g5607">
-      <desc
-         id="desc5593">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5595" />
-      <g
-         transform="translate(0,-14.158)"
-         id="g5605">
-        <g
-           transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)"
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="19.189"
-           id="g5603">
-          <path
-             d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z"
-             opacity="1"
-             id="path5597" />
-          <path
-             d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298"
-             opacity="1"
-             id="path5599" />
-          <path
-             d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298"
-             opacity="1"
-             id="path5601" />
+    <g transform="matrix(0,1,1,0,4616.9,-4163.4)" id="g5607">
+      <desc id="desc5593">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5595"/>
+      <g transform="translate(0,-14.158)" id="g5605">
+        <g transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="19.189" id="g5603">
+          <path d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z" opacity="1" id="path5597"/>
+          <path d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5599"/>
+          <path d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5601"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0,1,1,0,4390.2,-4163.4)"
-       id="g5621">
-      <desc
-         id="desc5609">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5611" />
-      <g
-         transform="translate(0,0.78473)"
-         id="g5619">
-        <g
-           transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)"
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="19.189"
-           id="g5617">
-          <path
-             d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z"
-             opacity="1"
-             id="path5613" />
-          <path
-             d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298"
-             opacity="1"
-             id="path5615" />
+    <g transform="matrix(0,1,1,0,4390.2,-4163.4)" id="g5621">
+      <desc id="desc5609">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5611"/>
+      <g transform="translate(0,0.78473)" id="g5619">
+        <g transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="19.189" id="g5617">
+          <path d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z" opacity="1" id="path5613"/>
+          <path d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5615"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0,1,1,0,4163.4,-4163.4)"
-       id="g5629">
-      <desc
-         id="desc5623">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5625" />
-      <path
-         transform="matrix(0.20646,0,0,0.20231,2406,-1772)"
-         d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="69.35"
-         id="path5627" />
+    <g transform="matrix(0,1,1,0,4163.4,-4163.4)" id="g5629">
+      <desc id="desc5623">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5625"/>
+      <path transform="matrix(0.20646,0,0,0.20231,2406,-1772)" d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="69.35" id="path5627"/>
     </g>
-    <g
-       transform="translate(680.31,226.77)"
-       fill="none"
-       id="g5635">
-      <rect
-         x="979.90997"
-         y="-1369.3"
-         width="81.135002"
-         height="81.135002"
-         rx="2.8309"
-         ry="2.2492001"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="rect5631" />
-      <rect
-         x="907.09003"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         rx="6.9233999"
-         ry="5.5008001"
-         opacity="1"
-         id="rect5633" />
+    <g transform="translate(680.31,226.77)" fill="none" id="g5635">
+      <rect x="979.90997" y="-1369.3" width="81.135002" height="81.135002" rx="2.8309" ry="2.2492001" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="rect5631"/>
+      <rect x="907.09003" y="-1442.1" width="226.77" height="226.77" rx="6.9233999" ry="5.5008001" opacity="1" id="rect5633"/>
     </g>
-    <g
-       transform="rotate(90,1700.8,-2462.6)"
-       id="g5643">
-      <desc
-         id="desc5637">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5639" />
-      <path
-         transform="matrix(0.20646,0,0,0.20231,2406,-1772)"
-         d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="69.35"
-         id="path5641" />
+    <g transform="rotate(90,1700.8,-2462.6)" id="g5643">
+      <desc id="desc5637">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5639"/>
+      <path transform="matrix(0.20646,0,0,0.20231,2406,-1772)" d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="69.35" id="path5641"/>
     </g>
-    <g
-       transform="rotate(90,1587.4,-2576)"
-       id="g5657">
-      <desc
-         id="desc5645">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5647" />
-      <g
-         transform="translate(0,0.78473)"
-         id="g5655">
-        <g
-           transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)"
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="19.189"
-           id="g5653">
-          <path
-             d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z"
-             opacity="1"
-             id="path5649" />
-          <path
-             d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298"
-             opacity="1"
-             id="path5651" />
+    <g transform="rotate(90,1587.4,-2576)" id="g5657">
+      <desc id="desc5645">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5647"/>
+      <g transform="translate(0,0.78473)" id="g5655">
+        <g transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="19.189" id="g5653">
+          <path d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z" opacity="1" id="path5649"/>
+          <path d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5651"/>
         </g>
       </g>
     </g>
-    <g
-       transform="rotate(90,1474,-2689.4)"
-       id="g5673">
-      <desc
-         id="desc5659">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5661" />
-      <g
-         transform="translate(0,-14.158)"
-         id="g5671">
-        <g
-           transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)"
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="19.189"
-           id="g5669">
-          <path
-             d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z"
-             opacity="1"
-             id="path5663" />
-          <path
-             d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298"
-             opacity="1"
-             id="path5665" />
-          <path
-             d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298"
-             opacity="1"
-             id="path5667" />
+    <g transform="rotate(90,1474,-2689.4)" id="g5673">
+      <desc id="desc5659">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5661"/>
+      <g transform="translate(0,-14.158)" id="g5671">
+        <g transform="matrix(0.73021,0,0,0.74715,825.95,-554.2)" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="19.189" id="g5669">
+          <path d="m 3061.7,-2233.5 -55.97,-81.624 h 111.33 z" opacity="1" id="path5663"/>
+          <path d="m 3117.1,-2270.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5665"/>
+          <path d="m 3117.1,-2230.8 -55.365,82.298 -55.97,-82.298" opacity="1" id="path5667"/>
         </g>
       </g>
     </g>
-    <text
-       x="943.65356"
-       y="-775.98425"
-       fill="#ffffff"
-       font-family="TitilliumText25L"
-       font-weight="600"
-       opacity="1"
-       stroke-linecap="round"
-       stroke-linejoin="round"
-       stroke-width="14.173"
-       style="line-height:0%"
-       xml:space="preserve"
-       id="text5677"><tspan
-         x="943.65356"
-         y="-775.98425"
-         font-size="283.46px"
-         style="line-height:1.25"
-         id="tspan5675">!</tspan></text>
-    <rect
-       x="907.09003"
-       y="-988.58002"
-       width="226.77"
-       height="226.77"
-       rx="2.8309"
-       ry="2.2492001"
-       fill="none"
-       opacity="1"
-       id="rect5679" />
-    <g
-       transform="translate(226.77)"
-       id="g5693">
-      <rect
-         x="907.09003"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         rx="2.8309"
-         ry="2.2492001"
-         fill="none"
-         opacity="1"
-         id="rect5681" />
-      <g
-         transform="translate(-31.25)"
-         fill="#ffffff"
-         font-family="TitilliumText25L"
-         font-weight="600"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="g5691">
-        <text
-           x="943.65356"
-           y="-775.98425"
-           opacity="1"
-           style="line-height:0%"
-           xml:space="preserve"
-           id="text5685"><tspan
-             x="943.65356"
-             y="-775.98425"
-             font-size="283.46px"
-             style="line-height:1.25"
-             id="tspan5683">!</tspan></text>
-        <text
-           x="1006.1536"
-           y="-775.98425"
-           opacity="1"
-           style="line-height:0%"
-           xml:space="preserve"
-           id="text5689"><tspan
-             x="1006.1536"
-             y="-775.98425"
-             font-size="283.46px"
-             style="line-height:1.25"
-             id="tspan5687">!</tspan></text>
+    <text x="943.65356" y="-775.98425" fill="#ffffff" font-family="TitilliumText25L" font-weight="600" opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" style="line-height:0%" xml:space="preserve" id="text5677"><tspan x="943.65356" y="-775.98425" font-size="283.46px" style="line-height:1.25" id="tspan5675">!</tspan></text>
+    <rect x="907.09003" y="-988.58002" width="226.77" height="226.77" rx="2.8309" ry="2.2492001" fill="none" opacity="1" id="rect5679"/>
+    <g transform="translate(226.77)" id="g5693">
+      <rect x="907.09003" y="-988.58002" width="226.77" height="226.77" rx="2.8309" ry="2.2492001" fill="none" opacity="1" id="rect5681"/>
+      <g transform="translate(-31.25)" fill="#ffffff" font-family="TitilliumText25L" font-weight="600" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="g5691">
+        <text x="943.65356" y="-775.98425" opacity="1" style="line-height:0%" xml:space="preserve" id="text5685"><tspan x="943.65356" y="-775.98425" font-size="283.46px" style="line-height:1.25" id="tspan5683">!</tspan></text>
+        <text x="1006.1536" y="-775.98425" opacity="1" style="line-height:0%" xml:space="preserve" id="text5689"><tspan x="1006.1536" y="-775.98425" font-size="283.46px" style="line-height:1.25" id="tspan5687">!</tspan></text>
       </g>
     </g>
-    <g
-       transform="translate(453.54,-1.0665e-5)"
-       id="g5709">
-      <text
-         x="943.65356"
-         y="-775.98425"
-         fill="#ffffff"
-         font-family="TitilliumText25L"
-         font-weight="600"
-         opacity="1"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         style="line-height:0%"
-         xml:space="preserve"
-         id="text5697"><tspan
-           x="943.65356"
-           y="-775.98425"
-           font-size="283.46px"
-           style="line-height:1.25"
-           id="tspan5695">!</tspan></text>
-      <rect
-         x="907.09003"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         rx="2.8309"
-         ry="2.2492001"
-         fill="none"
-         opacity="1"
-         id="rect5699" />
-      <text
-         x="881.65356"
-         y="-775.98425"
-         fill="#ffffff"
-         font-family="TitilliumText25L"
-         font-weight="600"
-         opacity="1"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         style="line-height:0%"
-         xml:space="preserve"
-         id="text5703"><tspan
-           x="881.65356"
-           y="-775.98425"
-           font-size="283.46px"
-           style="line-height:1.25"
-           id="tspan5701">!</tspan></text>
-      <text
-         x="1006.1536"
-         y="-775.98425"
-         fill="#ffffff"
-         font-family="TitilliumText25L"
-         font-weight="600"
-         opacity="1"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         style="line-height:0%"
-         xml:space="preserve"
-         id="text5707"><tspan
-           x="1006.1536"
-           y="-775.98425"
-           font-size="283.46px"
-           style="line-height:1.25"
-           id="tspan5705">!</tspan></text>
+    <g transform="translate(453.54,-1.0665e-5)" id="g5709">
+      <text x="943.65356" y="-775.98425" fill="#ffffff" font-family="TitilliumText25L" font-weight="600" opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" style="line-height:0%" xml:space="preserve" id="text5697"><tspan x="943.65356" y="-775.98425" font-size="283.46px" style="line-height:1.25" id="tspan5695">!</tspan></text>
+      <rect x="907.09003" y="-988.58002" width="226.77" height="226.77" rx="2.8309" ry="2.2492001" fill="none" opacity="1" id="rect5699"/>
+      <text x="881.65356" y="-775.98425" fill="#ffffff" font-family="TitilliumText25L" font-weight="600" opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" style="line-height:0%" xml:space="preserve" id="text5703"><tspan x="881.65356" y="-775.98425" font-size="283.46px" style="line-height:1.25" id="tspan5701">!</tspan></text>
+      <text x="1006.1536" y="-775.98425" fill="#ffffff" font-family="TitilliumText25L" font-weight="600" opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" style="line-height:0%" xml:space="preserve" id="text5707"><tspan x="1006.1536" y="-775.98425" font-size="283.46px" style="line-height:1.25" id="tspan5705">!</tspan></text>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,680.31,-81.496)"
-       id="g5719">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5711"
-         x="0"
-         y="0" />
-      <g
-         transform="matrix(2.447,0,0,2.447,-1442.3,-43.019)"
-         id="g5717">
-        <g
-           transform="translate(-275.59,-149.52)"
-           id="g5715">
-          <path
-             d="m 868.12,168.03 c -0.99736,0 -1.8108,0.81339 -1.8108,1.8108 v 4.8647 c 0,0.99736 0.81339,1.8108 1.8108,1.8108 h 0.16216 v 0.94591 c 0,0.79722 0.52526,1.4689 1.2432,1.7026 v -1.4594 c 0,-0.24457 0.18785,-0.43242 0.43242,-0.43242 0.24456,0 0.43241,0.18785 0.43241,0.43242 v 1.5405 h 0.70268 v -1.5405 c 0,-0.24457 0.18785,-0.43242 0.43242,-0.43242 0.24457,0 0.45945,0.18785 0.45945,0.43242 v 1.5405 h 0.6216 v -1.5405 c 0,-0.24457 0.18784,-0.43242 0.43242,-0.43242 0.24456,0 0.45944,0.18785 0.45944,0.43242 v 1.4594 c 0.74246,-0.21949 1.2972,-0.88791 1.2972,-1.7026 v -0.94591 h 0.16216 c 0.99737,0 1.8108,-0.81339 1.8108,-1.8108 v -4.8647 c 0,-0.99736 -0.81338,-1.8108 -1.8108,-1.8108 z m 1.081,3.054 h 0.72971 c 0.54617,0 0.97294,0.45378 0.97294,0.99996 v 0.67566 c 0,0.54617 -0.42677,0.99996 -0.97294,0.99996 H 869.201 c -0.54617,0 -0.97294,-0.45379 -0.97294,-0.99996 v -0.67566 c 0,-0.54618 0.42677,-0.99996 0.97294,-0.99996 z m 3.9458,0 h 0.72971 c 0.54617,0 0.97294,0.45378 0.97294,0.99996 v 0.67566 c 0,0.54617 -0.42677,0.99996 -0.97294,0.99996 h -0.72971 c -0.54618,0 -0.97294,-0.45379 -0.97294,-0.99996 v -0.67566 c 0,-0.54618 0.42676,-0.99996 0.97294,-0.99996 z m -1.9999,3.3242 c 0.16584,0 0.29728,0.15847 0.29728,0.32431 v 1.1892 c 0,0.16584 -0.13144,0.29729 -0.29728,0.29729 -0.16584,0 -0.29729,-0.13145 -0.29729,-0.29729 v -1.1892 c 0,-0.16584 0.13145,-0.32431 0.29729,-0.32431 z m 0.67565,0 c 0.16585,0 0.29729,0.15847 0.29729,0.32431 v 1.1892 c 0,0.16584 -0.13144,0.29729 -0.29729,0.29729 -0.16584,0 -0.29729,-0.13145 -0.29729,-0.29729 v -1.1892 c 0,-0.16584 0.13145,-0.32431 0.29729,-0.32431 z"
-             fill="#ffffff"
-             id="path5713" />
+    <g transform="matrix(7.0866,0,0,7.0866,680.31,-81.496)" id="g5719">
+      <rect width="32" height="32" fill="none" id="rect5711" x="0" y="0"/>
+      <g transform="matrix(2.447,0,0,2.447,-1442.3,-43.019)" id="g5717">
+        <g transform="translate(-275.59,-149.52)" id="g5715">
+          <path d="m 868.12,168.03 c -0.99736,0 -1.8108,0.81339 -1.8108,1.8108 v 4.8647 c 0,0.99736 0.81339,1.8108 1.8108,1.8108 h 0.16216 v 0.94591 c 0,0.79722 0.52526,1.4689 1.2432,1.7026 v -1.4594 c 0,-0.24457 0.18785,-0.43242 0.43242,-0.43242 0.24456,0 0.43241,0.18785 0.43241,0.43242 v 1.5405 h 0.70268 v -1.5405 c 0,-0.24457 0.18785,-0.43242 0.43242,-0.43242 0.24457,0 0.45945,0.18785 0.45945,0.43242 v 1.5405 h 0.6216 v -1.5405 c 0,-0.24457 0.18784,-0.43242 0.43242,-0.43242 0.24456,0 0.45944,0.18785 0.45944,0.43242 v 1.4594 c 0.74246,-0.21949 1.2972,-0.88791 1.2972,-1.7026 v -0.94591 h 0.16216 c 0.99737,0 1.8108,-0.81339 1.8108,-1.8108 v -4.8647 c 0,-0.99736 -0.81338,-1.8108 -1.8108,-1.8108 z m 1.081,3.054 h 0.72971 c 0.54617,0 0.97294,0.45378 0.97294,0.99996 v 0.67566 c 0,0.54617 -0.42677,0.99996 -0.97294,0.99996 H 869.201 c -0.54617,0 -0.97294,-0.45379 -0.97294,-0.99996 v -0.67566 c 0,-0.54618 0.42677,-0.99996 0.97294,-0.99996 z m 3.9458,0 h 0.72971 c 0.54617,0 0.97294,0.45378 0.97294,0.99996 v 0.67566 c 0,0.54617 -0.42677,0.99996 -0.97294,0.99996 h -0.72971 c -0.54618,0 -0.97294,-0.45379 -0.97294,-0.99996 v -0.67566 c 0,-0.54618 0.42676,-0.99996 0.97294,-0.99996 z m -1.9999,3.3242 c 0.16584,0 0.29728,0.15847 0.29728,0.32431 v 1.1892 c 0,0.16584 -0.13144,0.29729 -0.29728,0.29729 -0.16584,0 -0.29729,-0.13145 -0.29729,-0.29729 v -1.1892 c 0,-0.16584 0.13145,-0.32431 0.29729,-0.32431 z m 0.67565,0 c 0.16585,0 0.29729,0.15847 0.29729,0.32431 v 1.1892 c 0,0.16584 -0.13144,0.29729 -0.29729,0.29729 -0.16584,0 -0.29729,-0.13145 -0.29729,-0.29729 v -1.1892 c 0,-0.16584 0.13145,-0.32431 0.29729,-0.32431 z" fill="#ffffff" id="path5713"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,907.09,-81.496)"
-       id="g5727">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5721"
-         x="0"
-         y="0" />
-      <g
-         fill="#ffffff"
-         aria-label="$"
-         id="g5725">
-        <path
-           d="m 26,9.934 v 1.5818 H 22.1626 V 9.934 q 0,-0.20505 -0.20505,-0.20505 h -4.4819 v 4.7748 h 4.4819 q 1.6697,0 2.8415,1.201 1.201,1.1717 1.201,2.8415 v 4.394 q 0,1.6697 -1.201,2.8708 -1.1717,1.1717 -2.8415,1.1717 h -4.4819 v 3.0172 h -3.8374 v -3.0172 h -4.4819 q -1.6697,0 -2.8708,-1.1717 -1.1717,-1.201 -1.1717,-2.8708 v -1.5818 h 3.8374 v 1.5818 q 0,0.20505 0.20505,0.20505 h 4.4819 V 18.3412 H 9.1563 q -1.6697,0 -2.8708,-1.1717 -1.1717,-1.201 -1.1717,-2.8708 V 9.934 q 0,-1.6697 1.1717,-2.8415 1.201,-1.201 2.8708,-1.201 h 4.4819 V 2.8743 h 3.8374 v 3.0172 h 4.4819 q 1.6697,0 2.8415,1.201 Q 26,8.2642 26,9.934 Z m -4.0425,8.4072 h -4.4819 v 4.8041 h 4.4819 q 0.20505,0 0.20505,-0.20505 v -4.394 q 0,-0.20505 -0.20505,-0.20505 z M 13.6382,14.5038 V 9.729 H 9.1563 q -0.20505,0 -0.20505,0.20505 v 4.3647 q 0,0.20505 0.20505,0.20505 z"
-           fill="#ffffff"
-           id="path5723" />
+    <g transform="matrix(7.0866,0,0,7.0866,907.09,-81.496)" id="g5727">
+      <rect width="32" height="32" fill="none" id="rect5721" x="0" y="0"/>
+      <g fill="#ffffff" aria-label="$" id="g5725">
+        <path d="m 26,9.934 v 1.5818 H 22.1626 V 9.934 q 0,-0.20505 -0.20505,-0.20505 h -4.4819 v 4.7748 h 4.4819 q 1.6697,0 2.8415,1.201 1.201,1.1717 1.201,2.8415 v 4.394 q 0,1.6697 -1.201,2.8708 -1.1717,1.1717 -2.8415,1.1717 h -4.4819 v 3.0172 h -3.8374 v -3.0172 h -4.4819 q -1.6697,0 -2.8708,-1.1717 -1.1717,-1.201 -1.1717,-2.8708 v -1.5818 h 3.8374 v 1.5818 q 0,0.20505 0.20505,0.20505 h 4.4819 V 18.3412 H 9.1563 q -1.6697,0 -2.8708,-1.1717 -1.1717,-1.201 -1.1717,-2.8708 V 9.934 q 0,-1.6697 1.1717,-2.8415 1.201,-1.201 2.8708,-1.201 h 4.4819 V 2.8743 h 3.8374 v 3.0172 h 4.4819 q 1.6697,0 2.8415,1.201 Q 26,8.2642 26,9.934 Z m -4.0425,8.4072 h -4.4819 v 4.8041 h 4.4819 q 0.20505,0 0.20505,-0.20505 v -4.394 q 0,-0.20505 -0.20505,-0.20505 z M 13.6382,14.5038 V 9.729 H 9.1563 q -0.20505,0 -0.20505,0.20505 v 4.3647 q 0,0.20505 0.20505,0.20505 z" fill="#ffffff" id="path5723"/>
       </g>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,2494.5,-81.496)"
-       id="g5737">
-      <g
-         transform="matrix(1.7796,0,0,1.7796,-1530.1,-399.47)"
-         id="g5733">
-        <rect
-           x="860.78003"
-           y="228.25999"
-           width="16.034"
-           height="10.409"
-           fill="#ffffff"
-           id="rect5729" />
-        <path
-           d="m 875.26,228.87 -6.4375,4.4062 -6.5312,-4.3438 -0.5625,0.84375 6.8125,4.5 0.28125,0.1875 0.28125,-0.1875 6.7188,-4.5938 z"
-           color="#000000"
-           fill="#0c1d34"
-           style="text-indent:0;text-decoration-line:none;text-transform:none"
-           id="path5731" />
+    <g transform="matrix(7.0866,0,0,7.0866,2494.5,-81.496)" id="g5737">
+      <g transform="matrix(1.7796,0,0,1.7796,-1530.1,-399.47)" id="g5733">
+        <rect x="860.78003" y="228.25999" width="16.034" height="10.409" fill="#ffffff" id="rect5729"/>
+        <path d="m 875.26,228.87 -6.4375,4.4062 -6.5312,-4.3438 -0.5625,0.84375 6.8125,4.5 0.28125,0.1875 0.28125,-0.1875 6.7188,-4.5938 z" color="#000000" fill="#0c1d34" style="text-indent:0;text-decoration-line:none;text-transform:none" id="path5731"/>
       </g>
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5735"
-         x="0"
-         y="0" />
+      <rect width="32" height="32" fill="none" id="rect5735" x="0" y="0"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,2721.3,-81.496)"
-       id="g5757">
-      <g
-         transform="matrix(1.2835,0,-0.60466,1.1622,-955.36,-255.34)"
-         id="g5753">
-        <g
-           transform="matrix(0.90362,0,0,1,84.503,0)"
-           id="g5743">
-          <rect
-             x="860.78003"
-             y="228.25999"
-             width="16.034"
-             height="10.409"
-             fill="#ffffff"
-             id="rect5739" />
-          <path
-             d="m 875.26,228.87 -6.4375,4.4062 -6.5312,-4.3438 -0.5625,0.84375 6.8125,4.5 0.28125,0.1875 0.28125,-0.1875 6.7188,-4.5938 z"
-             color="#000000"
-             fill="#0c1d34"
-             style="text-indent:0;text-decoration-line:none;text-transform:none"
-             id="path5741" />
+    <g transform="matrix(7.0866,0,0,7.0866,2721.3,-81.496)" id="g5757">
+      <g transform="matrix(1.2835,0,-0.60466,1.1622,-955.36,-255.34)" id="g5753">
+        <g transform="matrix(0.90362,0,0,1,84.503,0)" id="g5743">
+          <rect x="860.78003" y="228.25999" width="16.034" height="10.409" fill="#ffffff" id="rect5739"/>
+          <path d="m 875.26,228.87 -6.4375,4.4062 -6.5312,-4.3438 -0.5625,0.84375 6.8125,4.5 0.28125,0.1875 0.28125,-0.1875 6.7188,-4.5938 z" color="#000000" fill="#0c1d34" style="text-indent:0;text-decoration-line:none;text-transform:none" id="path5741"/>
         </g>
-        <g
-           transform="matrix(-0.14775,0,0,1,988.38,0)"
-           id="g5747">
-          <rect
-             x="859.31"
-             y="228.25999"
-             width="16.034"
-             height="10.409"
-             fill="#ffffff"
-             id="rect5745" />
+        <g transform="matrix(-0.14775,0,0,1,988.38,0)" id="g5747">
+          <rect x="859.31" y="228.25999" width="16.034" height="10.409" fill="#ffffff" id="rect5745"/>
         </g>
-        <g
-           transform="matrix(-0.060135,0,0,1,909.66,0)"
-           id="g5751">
-          <rect
-             x="860.78003"
-             y="228.25999"
-             width="16.034"
-             height="10.409"
-             fill="#ffffff"
-             id="rect5749" />
+        <g transform="matrix(-0.060135,0,0,1,909.66,0)" id="g5751">
+          <rect x="860.78003" y="228.25999" width="16.034" height="10.409" fill="#ffffff" id="rect5749"/>
         </g>
       </g>
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5755"
-         x="0"
-         y="0" />
+      <rect width="32" height="32" fill="none" id="rect5755" x="0" y="0"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,453.54,-81.496)"
-       id="g5765">
-      <path
-         d="m 21.098,6.3066 c -0.24548,5.2869 2.4454,9.7825 4.3145,13.031 0.93452,1.6244 1.6484,3.0011 1.7832,3.6641 0.06739,0.3315 0.01952,0.38019 0.02148,0.37695 0.002,-0.0032 -0.05909,0.1145 -0.52344,0.25195 -0.75492,0.22347 -1.1276,0.11622 -1.6094,-0.18359 -0.48182,-0.29982 -1.0131,-0.89475 -1.5254,-1.6211 -0.5123,-0.72635 -0.99808,-1.5571 -1.5859,-2.3008 -0.58782,-0.7437 -1.4006,-1.5859 -2.666,-1.5859 a 1.3784,1.3784 0 0 0 -0.07617,0.002 l -0.83789,0.04687 0.15234,2.752 0.76367,-0.04297 c -0.09763,1.84e-4 0.09661,0.02429 0.50195,0.53711 0.40687,0.51474 0.90092,1.3358 1.4961,2.1797 0.59518,0.84393 1.2988,1.7374 2.3203,2.373 1.0215,0.63563 2.4202,0.90888 3.8477,0.48633 0.86537,-0.25617 1.6451,-0.71488 2.0996,-1.4648 0.4545,-0.74996 0.47241,-1.6169 0.32226,-2.3555 -0.3003,-1.4772 -1.1554,-2.8592 -2.0938,-4.4902 -1.8767,-3.2622 -4.1508,-7.269 -3.9531,-11.527 z"
-         color="#000000"
-         color-rendering="auto"
-         fill="#ffffff"
-         image-rendering="auto"
-         opacity="1"
-         shape-rendering="auto"
-         solid-color="#000000"
-         style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal"
-         id="path5759" />
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5761"
-         x="0"
-         y="0" />
-      <path
-         transform="translate(2274,-1626.3)"
-         d="m -2267.7,1628.3 c -1.0946,0 -1.957,0.8604 -1.957,1.955 v 24.031 c 0,1.0946 0.8624,1.9551 1.957,1.9551 h 12.201 c 1.0946,0 1.955,-0.8605 1.955,-1.9551 v -24.031 c 0,-1.0946 -0.8604,-1.955 -1.955,-1.955 z m 3.166,2.9453 h 5.8672 c 1.0946,0 2.0039,0.9073 2.0039,2.0019 v 3.8203 c 0,1.0946 -0.9093,2.002 -2.0039,2.002 h -5.8672 c -1.0946,0 -2.0019,-0.9074 -2.0019,-2.002 v -3.8203 c 0,-1.0946 0.9073,-2.0019 2.0019,-2.0019 z m 0.9121,11.768 0.9414,1.6094 0.1446,0.2539 0.1933,0.3535 c -0.4438,0.2564 -0.7461,0.7241 -0.7461,1.2735 v 0.016 l -0.3886,-0.014 h -2.1524 c 0.1415,-1.4144 0.636,-2.6595 2.0078,-3.4922 z m 4.0156,0 c 1.0323,0.7523 1.9933,1.5929 2.0079,3.4922 h -2.1524 l -0.3711,0.014 c 1e-4,-0.01 0,-0.01 0,-0.016 0,-0.557 -0.3057,-1.0355 -0.7597,-1.2891 l 0.1914,-0.3379 0.1445,-0.2539 0.9394,-1.6094 z m -1.998,2.6504 c 0.4546,0 0.8223,0.3677 0.8223,0.8223 0,0.4546 -0.3677,0.8242 -0.8223,0.8242 -0.4546,0 -0.8242,-0.3696 -0.8242,-0.8242 0,-0.4546 0.3696,-0.8223 0.8242,-0.8223 z m -0.7383,2.1133 c 0.218,0.1259 0.4763,0.2168 0.7461,0.2168 0.2699,0 0.5125,-0.091 0.7305,-0.2168 l 0.1933,0.3203 0.1446,0.252 0.9414,1.6113 c -1.3807,0.7743 -2.7226,0.6915 -4.0352,0 l 0.9219,-1.6113 0.1641,-0.252 z"
-         fill="#ffffff"
-         id="path5763" />
+    <g transform="matrix(7.0866,0,0,7.0866,453.54,-81.496)" id="g5765">
+      <path d="m 21.098,6.3066 c -0.24548,5.2869 2.4454,9.7825 4.3145,13.031 0.93452,1.6244 1.6484,3.0011 1.7832,3.6641 0.06739,0.3315 0.01952,0.38019 0.02148,0.37695 0.002,-0.0032 -0.05909,0.1145 -0.52344,0.25195 -0.75492,0.22347 -1.1276,0.11622 -1.6094,-0.18359 -0.48182,-0.29982 -1.0131,-0.89475 -1.5254,-1.6211 -0.5123,-0.72635 -0.99808,-1.5571 -1.5859,-2.3008 -0.58782,-0.7437 -1.4006,-1.5859 -2.666,-1.5859 a 1.3784,1.3784 0 0 0 -0.07617,0.002 l -0.83789,0.04687 0.15234,2.752 0.76367,-0.04297 c -0.09763,1.84e-4 0.09661,0.02429 0.50195,0.53711 0.40687,0.51474 0.90092,1.3358 1.4961,2.1797 0.59518,0.84393 1.2988,1.7374 2.3203,2.373 1.0215,0.63563 2.4202,0.90888 3.8477,0.48633 0.86537,-0.25617 1.6451,-0.71488 2.0996,-1.4648 0.4545,-0.74996 0.47241,-1.6169 0.32226,-2.3555 -0.3003,-1.4772 -1.1554,-2.8592 -2.0938,-4.4902 -1.8767,-3.2622 -4.1508,-7.269 -3.9531,-11.527 z" color="#000000" color-rendering="auto" fill="#ffffff" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal" id="path5759"/>
+      <rect width="32" height="32" fill="none" id="rect5761" x="0" y="0"/>
+      <path transform="translate(2274,-1626.3)" d="m -2267.7,1628.3 c -1.0946,0 -1.957,0.8604 -1.957,1.955 v 24.031 c 0,1.0946 0.8624,1.9551 1.957,1.9551 h 12.201 c 1.0946,0 1.955,-0.8605 1.955,-1.9551 v -24.031 c 0,-1.0946 -0.8604,-1.955 -1.955,-1.955 z m 3.166,2.9453 h 5.8672 c 1.0946,0 2.0039,0.9073 2.0039,2.0019 v 3.8203 c 0,1.0946 -0.9093,2.002 -2.0039,2.002 h -5.8672 c -1.0946,0 -2.0019,-0.9074 -2.0019,-2.002 v -3.8203 c 0,-1.0946 0.9073,-2.0019 2.0019,-2.0019 z m 0.9121,11.768 0.9414,1.6094 0.1446,0.2539 0.1933,0.3535 c -0.4438,0.2564 -0.7461,0.7241 -0.7461,1.2735 v 0.016 l -0.3886,-0.014 h -2.1524 c 0.1415,-1.4144 0.636,-2.6595 2.0078,-3.4922 z m 4.0156,0 c 1.0323,0.7523 1.9933,1.5929 2.0079,3.4922 h -2.1524 l -0.3711,0.014 c 1e-4,-0.01 0,-0.01 0,-0.016 0,-0.557 -0.3057,-1.0355 -0.7597,-1.2891 l 0.1914,-0.3379 0.1445,-0.2539 0.9394,-1.6094 z m -1.998,2.6504 c 0.4546,0 0.8223,0.3677 0.8223,0.8223 0,0.4546 -0.3677,0.8242 -0.8223,0.8242 -0.4546,0 -0.8242,-0.3696 -0.8242,-0.8242 0,-0.4546 0.3696,-0.8223 0.8242,-0.8223 z m -0.7383,2.1133 c 0.218,0.1259 0.4763,0.2168 0.7461,0.2168 0.2699,0 0.5125,-0.091 0.7305,-0.2168 l 0.1933,0.3203 0.1446,0.252 0.9414,1.6113 c -1.3807,0.7743 -2.7226,0.6915 -4.0352,0 l 0.9219,-1.6113 0.1641,-0.252 z" fill="#ffffff" id="path5763"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,2948,-81.496)"
-       id="g5781">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5767"
-         x="0"
-         y="0" />
-      <g
-         transform="matrix(0.63903,0,0,0.63903,-259.59,51.976)"
-         fill="#ffffff"
-         id="g5779">
-        <path
-           d="m 419.84,-70.354 h 33.941 l -7.4246,15.203 h -23.865 z"
-           id="path5769" />
-        <g
-           id="g5777">
-          <path
-             d="m 410.62,-75.531 a 2.003,2.003 0 1 0 0.21875,4 h 7.6875 c 0.24895,1.3028 1.0024,5.1606 2.0312,10.406 0.59472,3.0322 1.2023,6.0891 1.6875,8.4375 0.24258,1.1742 0.45757,2.165 0.625,2.9062 0.0837,0.37061 0.15431,0.68871 0.21875,0.9375 0.0322,0.1244 0.0583,0.22913 0.0937,0.34375 0.0355,0.11462 -0.005,0.14411 0.21875,0.53125 0.44882,0.7774 0.86575,0.84644 1.0938,0.9375 0.228,0.09106 0.3822,0.09443 0.53125,0.125 0.2981,0.06115 0.5578,0.09801 0.875,0.125 0.6344,0.05398 1.4162,0.07732 2.3438,0.09375 1.8551,0.03286 4.251,0.01168 6.625,-0.03125 4.748,-0.08587 9.4375,-0.25 9.4375,-0.25 a 2.0015253,2.0015253 0 1 0 -0.15625,-4 c 0,0 -4.6444,0.16501 -9.3438,0.25 -2.3496,0.04249 -4.7071,0.06246 -6.4688,0.03125 -0.67066,-0.01188 -1.1469,-0.03607 -1.5938,-0.0625 -0.15525,-0.69105 -0.3619,-1.6277 -0.59375,-2.75 -0.4799,-2.3229 -1.0629,-5.3809 -1.6562,-8.4062 -1.1868,-6.0508 -2.3438,-12 -2.3438,-12 a 2.0002,2.0002 0 0 0 -1.9688,-1.625 h -9.3438 a 2.0002,2.0002 0 0 0 -0.21875,0 z"
-             color="#000000"
-             style="text-indent:0;text-decoration-line:none;text-transform:none"
-             id="path5771" />
-          <path
-             d="m 425.32,-50.972 c -3.8146,0 -6.9453,3.149 -6.9453,6.9635 0,3.8145 3.1308,6.9453 6.9453,6.9453 3.8146,0 6.9636,-3.1308 6.9636,-6.9453 0,-3.8145 -3.149,-6.9635 -6.9636,-6.9635 z m 0,4.0104 c 1.6528,0 2.9531,1.3003 2.9531,2.9531 0,1.6528 -1.3003,2.9349 -2.9531,2.9349 -1.6528,0 -2.9531,-1.2821 -2.9531,-2.9349 0,-1.6528 1.3003,-2.9531 2.9531,-2.9531 z"
-             color="#000000"
-             style="text-indent:0;text-decoration-line:none;text-transform:none"
-             id="path5773" />
-          <path
-             d="m 443.82,-50.972 c -3.8146,0 -6.9453,3.149 -6.9453,6.9635 0,3.8145 3.1308,6.9453 6.9453,6.9453 3.8146,0 6.9636,-3.1308 6.9636,-6.9453 0,-3.8145 -3.149,-6.9635 -6.9636,-6.9635 z m 0,4.0104 c 1.6528,0 2.9531,1.3003 2.9531,2.9531 0,1.6528 -1.3003,2.9349 -2.9531,2.9349 -1.6528,0 -2.9531,-1.2821 -2.9531,-2.9349 0,-1.6528 1.3003,-2.9531 2.9531,-2.9531 z"
-             color="#000000"
-             style="text-indent:0;text-decoration-line:none;text-transform:none"
-             id="path5775" />
+    <g transform="matrix(7.0866,0,0,7.0866,2948,-81.496)" id="g5781">
+      <rect width="32" height="32" fill="none" id="rect5767" x="0" y="0"/>
+      <g transform="matrix(0.63903,0,0,0.63903,-259.59,51.976)" fill="#ffffff" id="g5779">
+        <path d="m 419.84,-70.354 h 33.941 l -7.4246,15.203 h -23.865 z" id="path5769"/>
+        <g id="g5777">
+          <path d="m 410.62,-75.531 a 2.003,2.003 0 1 0 0.21875,4 h 7.6875 c 0.24895,1.3028 1.0024,5.1606 2.0312,10.406 0.59472,3.0322 1.2023,6.0891 1.6875,8.4375 0.24258,1.1742 0.45757,2.165 0.625,2.9062 0.0837,0.37061 0.15431,0.68871 0.21875,0.9375 0.0322,0.1244 0.0583,0.22913 0.0937,0.34375 0.0355,0.11462 -0.005,0.14411 0.21875,0.53125 0.44882,0.7774 0.86575,0.84644 1.0938,0.9375 0.228,0.09106 0.3822,0.09443 0.53125,0.125 0.2981,0.06115 0.5578,0.09801 0.875,0.125 0.6344,0.05398 1.4162,0.07732 2.3438,0.09375 1.8551,0.03286 4.251,0.01168 6.625,-0.03125 4.748,-0.08587 9.4375,-0.25 9.4375,-0.25 a 2.0015253,2.0015253 0 1 0 -0.15625,-4 c 0,0 -4.6444,0.16501 -9.3438,0.25 -2.3496,0.04249 -4.7071,0.06246 -6.4688,0.03125 -0.67066,-0.01188 -1.1469,-0.03607 -1.5938,-0.0625 -0.15525,-0.69105 -0.3619,-1.6277 -0.59375,-2.75 -0.4799,-2.3229 -1.0629,-5.3809 -1.6562,-8.4062 -1.1868,-6.0508 -2.3438,-12 -2.3438,-12 a 2.0002,2.0002 0 0 0 -1.9688,-1.625 h -9.3438 a 2.0002,2.0002 0 0 0 -0.21875,0 z" color="#000000" style="text-indent:0;text-decoration-line:none;text-transform:none" id="path5771"/>
+          <path d="m 425.32,-50.972 c -3.8146,0 -6.9453,3.149 -6.9453,6.9635 0,3.8145 3.1308,6.9453 6.9453,6.9453 3.8146,0 6.9636,-3.1308 6.9636,-6.9453 0,-3.8145 -3.149,-6.9635 -6.9636,-6.9635 z m 0,4.0104 c 1.6528,0 2.9531,1.3003 2.9531,2.9531 0,1.6528 -1.3003,2.9349 -2.9531,2.9349 -1.6528,0 -2.9531,-1.2821 -2.9531,-2.9349 0,-1.6528 1.3003,-2.9531 2.9531,-2.9531 z" color="#000000" style="text-indent:0;text-decoration-line:none;text-transform:none" id="path5773"/>
+          <path d="m 443.82,-50.972 c -3.8146,0 -6.9453,3.149 -6.9453,6.9635 0,3.8145 3.1308,6.9453 6.9453,6.9453 3.8146,0 6.9636,-3.1308 6.9636,-6.9453 0,-3.8145 -3.149,-6.9635 -6.9636,-6.9635 z m 0,4.0104 c 1.6528,0 2.9531,1.3003 2.9531,2.9531 0,1.6528 -1.3003,2.9349 -2.9531,2.9349 -1.6528,0 -2.9531,-1.2821 -2.9531,-2.9349 0,-1.6528 1.3003,-2.9531 2.9531,-2.9531 z" color="#000000" style="text-indent:0;text-decoration-line:none;text-transform:none" id="path5775"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,1814.2,-81.496)"
-       id="g5787">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5783"
-         x="0"
-         y="0" />
-      <path
-         d="m 18.221,5.0689 c -2.2298,0 -4.5629,1.7019 -5.4723,3.87 h -1.2761 l -5.5551,17.992 h 14.53 l 5.5551,-17.992 h -1.1457 c 0.42944,-2.1681 -0.85267,-3.87 -3.0825,-3.87 z m -0.67081,2.1726 h 3.553 c 1.0609,0 1.6751,0.71177 1.5807,1.6974 h -7.7625 c 0.51421,-0.98561 1.568,-1.6974 2.6288,-1.6974 z m -9.0649,1.6974 c -1.5046,0 -3.0898,1.2112 -3.5543,2.7158 l -3.8781,12.561 c -0.46453,1.5046 0.37274,2.7158 1.8773,2.7158 h 0.95053 l 5.5551,-17.992 z m 19.554,0 -5.5551,17.992 h 1.0863 c 1.5046,0 3.0898,-1.2112 3.5543,-2.7158 l 3.8781,-12.561 c 0.46453,-1.5046 -0.37274,-2.7158 -1.8773,-2.7158 z"
-         fill="#ffffff"
-         id="path5785" />
+    <g transform="matrix(7.0866,0,0,7.0866,1814.2,-81.496)" id="g5787">
+      <rect width="32" height="32" fill="none" id="rect5783" x="0" y="0"/>
+      <path d="m 18.221,5.0689 c -2.2298,0 -4.5629,1.7019 -5.4723,3.87 h -1.2761 l -5.5551,17.992 h 14.53 l 5.5551,-17.992 h -1.1457 c 0.42944,-2.1681 -0.85267,-3.87 -3.0825,-3.87 z m -0.67081,2.1726 h 3.553 c 1.0609,0 1.6751,0.71177 1.5807,1.6974 h -7.7625 c 0.51421,-0.98561 1.568,-1.6974 2.6288,-1.6974 z m -9.0649,1.6974 c -1.5046,0 -3.0898,1.2112 -3.5543,2.7158 l -3.8781,12.561 c -0.46453,1.5046 0.37274,2.7158 1.8773,2.7158 h 0.95053 l 5.5551,-17.992 z m 19.554,0 -5.5551,17.992 h 1.0863 c 1.5046,0 3.0898,-1.2112 3.5543,-2.7158 l 3.8781,-12.561 c 0.46453,-1.5046 -0.37274,-2.7158 -1.8773,-2.7158 z" fill="#ffffff" id="path5785"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,3174.8,-81.496)"
-       id="g5793">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5789"
-         x="0"
-         y="0" />
-      <path
-         d="m 22.955,4.5026 c -2.42,-0.77941 -5.1719,-0.21984 -7.0932,1.7015 -2.1283,2.1283 -2.5999,5.2823 -1.4142,7.8666 l -10.253,10.253 3.5134,3.5134 10.297,-10.297 c 2.5649,1.1271 5.6557,0.66402 7.7561,-1.4363 1.8865,-1.8865 2.4629,-4.5727 1.7457,-6.9606 l -4.331,4.331 -4.2647,-0.33146 -0.33146,-4.2647 z"
-         fill="#ffffff"
-         id="path5791" />
+    <g transform="matrix(7.0866,0,0,7.0866,3174.8,-81.496)" id="g5793">
+      <rect width="32" height="32" fill="none" id="rect5789" x="0" y="0"/>
+      <path d="m 22.955,4.5026 c -2.42,-0.77941 -5.1719,-0.21984 -7.0932,1.7015 -2.1283,2.1283 -2.5999,5.2823 -1.4142,7.8666 l -10.253,10.253 3.5134,3.5134 10.297,-10.297 c 2.5649,1.1271 5.6557,0.66402 7.7561,-1.4363 1.8865,-1.8865 2.4629,-4.5727 1.7457,-6.9606 l -4.331,4.331 -4.2647,-0.33146 -0.33146,-4.2647 z" fill="#ffffff" id="path5791"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,1133.9,-81.496)"
-       id="g5799">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5795"
-         x="0"
-         y="0" />
-      <path
-         d="M 5,3 V 28 H 26.031 V 3 Z m 3.0312,2 h 2 v 2 h -2 z M 11,5 h 3 v 2 h -3 z m 4.0312,0 H 21 V 7 H 15.0312 Z M 22,5 h 2.0312 V 7 H 22 Z M 7,8 h 6.0625 v 2 H 7 Z m 7,0 h 2.0312 v 2 H 14 Z m 4,0 h 5.9688 V 18.062 H 18 Z M 7.031,11 h 2 v 2 h -2 z m 3.5312,0 h 6.4062 v 2 h -6.4062 z m -3.5625,5 h 3 v 2 h -3 z m 4,0 h 3 v 2 h -3 z m 4,0 h 2 v 2 h -2 z m -7.9688,3 h 5.9688 v 2 H 7.0309 Z m 7.7188,0 h 3.75 v 2 h -3.75 z m 5.2188,0 h 4.0312 v 2 h -4.0312 z m -11.969,3 h 7.0312 v 2 H 7.9995 Z m 9,0 h 4 v 2 h -4 z m 5.0312,0 h 1.9688 v 2 h -1.9688 z"
-         fill="#ffffff"
-         id="path5797" />
+    <g transform="matrix(7.0866,0,0,7.0866,1133.9,-81.496)" id="g5799">
+      <rect width="32" height="32" fill="none" id="rect5795" x="0" y="0"/>
+      <path d="M 5,3 V 28 H 26.031 V 3 Z m 3.0312,2 h 2 v 2 h -2 z M 11,5 h 3 v 2 h -3 z m 4.0312,0 H 21 V 7 H 15.0312 Z M 22,5 h 2.0312 V 7 H 22 Z M 7,8 h 6.0625 v 2 H 7 Z m 7,0 h 2.0312 v 2 H 14 Z m 4,0 h 5.9688 V 18.062 H 18 Z M 7.031,11 h 2 v 2 h -2 z m 3.5312,0 h 6.4062 v 2 h -6.4062 z m -3.5625,5 h 3 v 2 h -3 z m 4,0 h 3 v 2 h -3 z m 4,0 h 2 v 2 h -2 z m -7.9688,3 h 5.9688 v 2 H 7.0309 Z m 7.7188,0 h 3.75 v 2 h -3.75 z m 5.2188,0 h 4.0312 v 2 h -4.0312 z m -11.969,3 h 7.0312 v 2 H 7.9995 Z m 9,0 h 4 v 2 h -4 z m 5.0312,0 h 1.9688 v 2 h -1.9688 z" fill="#ffffff" id="path5797"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,9.8584e-6,-81.496)"
-       id="g5805">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5801"
-         x="0"
-         y="0" />
-      <circle
-         transform="matrix(0.70084,0,0,0.70084,3.6108,5.9623)"
-         cx="17.677999"
-         cy="14.322"
-         r="9.1924"
-         fill="#ffffff"
-         stroke="#ffffff"
-         stroke-width="0.20135"
-         id="circle5803" />
+    <g transform="matrix(7.0866,0,0,7.0866,9.8584e-6,-81.496)" id="g5805">
+      <rect width="32" height="32" fill="none" id="rect5801" x="0" y="0"/>
+      <circle transform="matrix(0.70084,0,0,0.70084,3.6108,5.9623)" cx="17.677999" cy="14.322" r="9.1924" fill="#ffffff" stroke="#ffffff" stroke-width="0.20135" id="circle5803"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,0,145.28)"
-       id="g5811">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5807"
-         x="0"
-         y="0" />
-      <path
-         d="M 14.281,5.6562 V 9.0937 C 13.5871,9.26551 12.9404,9.54766 12.3435,9.9062 L 9.906,7.4687 7.4685,9.9062 9.906,12.3437 C 9.54746,12.9406 9.26531,13.5873 9.0935,14.2812 H 5.656 v 3.4375 h 3.4375 c 0.17181,0.6939 0.45396,1.3406 0.8125,1.9375 l -2.4375,2.4375 2.4375,2.4375 2.4375,-2.4375 c 0.5969,0.35854 1.2436,0.64069 1.9375,0.8125 v 3.4375 h 3.4375 v -3.4375 c 0.6939,-0.17181 1.3406,-0.45396 1.9375,-0.8125 l 2.4375,2.4375 2.4375,-2.4375 -2.4375,-2.4375 c 0.35854,-0.5969 0.64069,-1.2436 0.8125,-1.9375 h 3.4375 V 14.2812 H 22.906 C 22.73419,13.5873 22.45204,12.9406 22.0935,12.3437 L 24.531,9.9062 22.0935,7.4687 19.656,9.9062 C 19.0591,9.54766 18.4124,9.26551 17.7185,9.0937 V 5.6562 Z"
-         fill="#ffffff"
-         id="path5809" />
+    <g transform="matrix(7.0866,0,0,7.0866,0,145.28)" id="g5811">
+      <rect width="32" height="32" fill="none" id="rect5807" x="0" y="0"/>
+      <path d="M 14.281,5.6562 V 9.0937 C 13.5871,9.26551 12.9404,9.54766 12.3435,9.9062 L 9.906,7.4687 7.4685,9.9062 9.906,12.3437 C 9.54746,12.9406 9.26531,13.5873 9.0935,14.2812 H 5.656 v 3.4375 h 3.4375 c 0.17181,0.6939 0.45396,1.3406 0.8125,1.9375 l -2.4375,2.4375 2.4375,2.4375 2.4375,-2.4375 c 0.5969,0.35854 1.2436,0.64069 1.9375,0.8125 v 3.4375 h 3.4375 v -3.4375 c 0.6939,-0.17181 1.3406,-0.45396 1.9375,-0.8125 l 2.4375,2.4375 2.4375,-2.4375 -2.4375,-2.4375 c 0.35854,-0.5969 0.64069,-1.2436 0.8125,-1.9375 h 3.4375 V 14.2812 H 22.906 C 22.73419,13.5873 22.45204,12.9406 22.0935,12.3437 L 24.531,9.9062 22.0935,7.4687 19.656,9.9062 C 19.0591,9.54766 18.4124,9.26551 17.7185,9.0937 V 5.6562 Z" fill="#ffffff" id="path5809"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,3401.6,-81.496)"
-       id="g5831">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect5813"
-         x="0"
-         y="0" />
-      <g
-         transform="matrix(1.2404,-0.45116,0.45116,1.2404,-11.743,4.7856)"
-         fill="#ffffff"
-         id="g5821">
-        <path
-           d="m 14.125,10 h 9.0625 v 6.875 H 14.125 Z"
-           opacity="1"
-           id="path5815" />
-        <path
-           d="m 24,9 h 3.875 v 8.875 H 24 Z"
-           opacity="1"
-           id="path5817" />
-        <path
-           d="m 6.8772,11.326 h 6.4108 v 4.2233 H 6.8772 Z"
-           opacity="1"
-           id="path5819" />
+    <g transform="matrix(7.0866,0,0,7.0866,3401.6,-81.496)" id="g5831">
+      <rect width="32" height="32" fill="none" id="rect5813" x="0" y="0"/>
+      <g transform="matrix(1.2404,-0.45116,0.45116,1.2404,-11.743,4.7856)" fill="#ffffff" id="g5821">
+        <path d="m 14.125,10 h 9.0625 v 6.875 H 14.125 Z" opacity="1" id="path5815"/>
+        <path d="m 24,9 h 3.875 v 8.875 H 24 Z" opacity="1" id="path5817"/>
+        <path d="m 6.8772,11.326 h 6.4108 v 4.2233 H 6.8772 Z" opacity="1" id="path5819"/>
       </g>
-      <g
-         fill="#ffffff"
-         id="g5829">
-        <rect
-           transform="rotate(-22.03)"
-           x="10.984"
-           y="25.677"
-           width="1.6794"
-           height="12.58"
-           rx="0.83969003"
-           ry="0.83969003"
-           opacity="1"
-           id="rect5823" />
-        <rect
-           transform="matrix(-0.92699,-0.37509,-0.37509,0.92699,0,0)"
-           x="-24.559999"
-           y="11.294"
-           width="1.6794"
-           height="12.58"
-           rx="0.83969003"
-           ry="0.83969003"
-           opacity="1"
-           id="rect5825" />
-        <path
-           d="m 16.219,19.219 5.875,-2.1562 v 3.8438 h -5.875 z"
-           opacity="1"
-           id="path5827" />
+      <g fill="#ffffff" id="g5829">
+        <rect transform="rotate(-22.03)" x="10.984" y="25.677" width="1.6794" height="12.58" rx="0.83969003" ry="0.83969003" opacity="1" id="rect5823"/>
+        <rect transform="matrix(-0.92699,-0.37509,-0.37509,0.92699,0,0)" x="-24.559999" y="11.294" width="1.6794" height="12.58" rx="0.83969003" ry="0.83969003" opacity="1" id="rect5825"/>
+        <path d="m 16.219,19.219 5.875,-2.1562 v 3.8438 h -5.875 z" opacity="1" id="path5827"/>
       </g>
     </g>
-    <g
-       transform="matrix(5.3442,0,0,5.3442,126.45,-139.92)"
-       fill="#ffffff"
-       id="g5837">
-      <path
-         d="m 40.116,16.002 c -1.5644,-0.04871 -3.0335,0.75011 -3.842,2.0905 l -14.226,23.649 c -1.7289,2.8837 0.34308,6.5513 3.7053,6.5569 h 28.469 c 3.3623,0 5.4368,-3.6732 3.7078,-6.5569 L 43.7011,18.0925 C 42.94,16.8307 41.5883,16.044 40.1153,16.002 Z m -2.2417,7.8351 h 4.2298 l -0.14388,12.575 h -3.9444 z m 0.0562,15.26 h 4.1151 v 4.7446 h -4.1151 z"
-         color="#000000"
-         color-rendering="auto"
-         fill="#ffffff"
-         image-rendering="auto"
-         opacity="1"
-         shape-rendering="auto"
-         solid-color="#000000"
-         style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal"
-         id="path5833" />
-      <rect
-         x="18.771999"
-         y="10.933"
-         width="42.432999"
-         height="42.432999"
-         rx="0.57275999"
-         ry="0.19397999"
-         fill="none"
-         opacity="1"
-         id="rect5835" />
+    <g transform="matrix(5.3442,0,0,5.3442,126.45,-139.92)" fill="#ffffff" id="g5837">
+      <path d="m 40.116,16.002 c -1.5644,-0.04871 -3.0335,0.75011 -3.842,2.0905 l -14.226,23.649 c -1.7289,2.8837 0.34308,6.5513 3.7053,6.5569 h 28.469 c 3.3623,0 5.4368,-3.6732 3.7078,-6.5569 L 43.7011,18.0925 C 42.94,16.8307 41.5883,16.044 40.1153,16.002 Z m -2.2417,7.8351 h 4.2298 l -0.14388,12.575 h -3.9444 z m 0.0562,15.26 h 4.1151 v 4.7446 h -4.1151 z" color="#000000" color-rendering="auto" fill="#ffffff" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal" id="path5833"/>
+      <rect x="18.771999" y="10.933" width="42.432999" height="42.432999" rx="0.57275999" ry="0.19397999" fill="none" opacity="1" id="rect5835"/>
     </g>
-    <g
-       transform="translate(-907.05,2494.4)"
-       id="g5843">
-      <rect
-         x="2267.7"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5839" />
-      <path
-         d="m 2303.8,-2418.8 c 12.314,-15.668 28.195,-23.77 55.031,-26.374 4.8407,-0.9467 8.4926,-5.1262 8.4926,-10.087 0,-3.6337 -11.974,-14.51 -11.89,-14.589 -12.357,-12.443 -18.981,-32.658 -18.981,-48.202 0,-24.142 19.958,-43.737 44.586,-43.737 24.628,0 44.586,19.595 44.586,43.737 0,15.626 -6.4543,35.965 -18.938,48.408 0,0 -11.932,10.752 -11.932,14.382 0,5.2543 4.0762,9.6321 9.3417,10.252 26.284,2.6871 41.996,10.748 54.182,26.209 3.5243,4.4647 5.4351,13.435 5.5625,18.231 -0.042,1.2402 0,20.67 0,20.67 0,9.1359 -7.601,16.536 -16.985,16.536 h -131.63 c -9.3842,0 -16.985,-7.3998 -16.985,-16.536 0,0 0.042,-19.43 0,-20.67 0.1274,-4.7954 2.0382,-13.766 5.5626,-18.231 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5841" />
+    <g transform="translate(-907.05,2494.4)" id="g5843">
+      <rect x="2267.7" y="-2575.8999" width="226.77" height="226.77" fill="none" opacity="1" id="rect5839"/>
+      <path d="m 2303.8,-2418.8 c 12.314,-15.668 28.195,-23.77 55.031,-26.374 4.8407,-0.9467 8.4926,-5.1262 8.4926,-10.087 0,-3.6337 -11.974,-14.51 -11.89,-14.589 -12.357,-12.443 -18.981,-32.658 -18.981,-48.202 0,-24.142 19.958,-43.737 44.586,-43.737 24.628,0 44.586,19.595 44.586,43.737 0,15.626 -6.4543,35.965 -18.938,48.408 0,0 -11.932,10.752 -11.932,14.382 0,5.2543 4.0762,9.6321 9.3417,10.252 26.284,2.6871 41.996,10.748 54.182,26.209 3.5243,4.4647 5.4351,13.435 5.5625,18.231 -0.042,1.2402 0,20.67 0,20.67 0,9.1359 -7.601,16.536 -16.985,16.536 h -131.63 c -9.3842,0 -16.985,-7.3998 -16.985,-16.536 0,0 0.042,-19.43 0,-20.67 0.1274,-4.7954 2.0382,-13.766 5.5626,-18.231 z" fill="#ffffff" opacity="1" id="path5841"/>
     </g>
-    <g
-       transform="translate(3401.3,-226.77)"
-       id="g5881">
-      <g
-         transform="matrix(1.2947,0,0,1.2947,233.89,324.73)"
-         id="g5879">
-        <g
-           transform="translate(-175.16)"
-           id="g5877">
-          <rect
-             x="-705.88"
-             y="-1189.5"
-             width="175.16"
-             height="175.16"
-             fill="none"
-             opacity="1"
-             id="rect5845" />
-          <g
-             transform="translate(27.371,0.039699)"
-             id="g5875">
-            <g
-               transform="matrix(0.28572,0,0,1,-452.59,0)"
-               fill="#ffffff"
-               id="g5859">
-              <g
-                 fill-opacity="0.19697"
-                 id="g5855">
-                <rect
-                   x="-694.92999"
-                   y="-1178.6"
-                   width="153.25999"
-                   height="153.25999"
-                   opacity="1"
-                   id="rect5847" />
-                <rect
-                   x="-694.92999"
-                   y="-1167.7"
-                   width="153.25999"
-                   height="142.31"
-                   opacity="1"
-                   id="rect5849" />
-                <rect
-                   x="-694.92999"
-                   y="-1145.8"
-                   width="153.25999"
-                   height="120.42"
-                   opacity="1"
-                   id="rect5851" />
-                <rect
-                   x="-694.92999"
-                   y="-1112.9"
-                   width="153.25999"
-                   height="87.578003"
-                   opacity="1"
-                   id="rect5853" />
+    <g transform="translate(3401.3,-226.77)" id="g5881">
+      <g transform="matrix(1.2947,0,0,1.2947,233.89,324.73)" id="g5879">
+        <g transform="translate(-175.16)" id="g5877">
+          <rect x="-705.88" y="-1189.5" width="175.16" height="175.16" fill="none" opacity="1" id="rect5845"/>
+          <g transform="translate(27.371,0.039699)" id="g5875">
+            <g transform="matrix(0.28572,0,0,1,-452.59,0)" fill="#ffffff" id="g5859">
+              <g fill-opacity="0.19697" id="g5855">
+                <rect x="-694.92999" y="-1178.6" width="153.25999" height="153.25999" opacity="1" id="rect5847"/>
+                <rect x="-694.92999" y="-1167.7" width="153.25999" height="142.31" opacity="1" id="rect5849"/>
+                <rect x="-694.92999" y="-1145.8" width="153.25999" height="120.42" opacity="1" id="rect5851"/>
+                <rect x="-694.92999" y="-1112.9" width="153.25999" height="87.578003" opacity="1" id="rect5853"/>
               </g>
-              <rect
-                 x="-694.92999"
-                 y="-1069.1"
-                 width="153.25999"
-                 height="43.789001"
-                 opacity="1"
-                 id="rect5857" />
+              <rect x="-694.92999" y="-1069.1" width="153.25999" height="43.789001" opacity="1" id="rect5857"/>
             </g>
-            <g
-               fill="none"
-               stroke="#ffffff"
-               stroke-linecap="round"
-               stroke-linejoin="round"
-               stroke-width="5.4736"
-               id="g5873">
-              <path
-                 d="m -664.86,-1028.1 h -16.353"
-                 opacity="1"
-                 id="path5861" />
-              <path
-                 d="m -664.86,-1175.9 h -16.353"
-                 opacity="1"
-                 id="path5863" />
-              <path
-                 d="m -681.19,-1028.4 v -147.51"
-                 opacity="1"
-                 id="path5865" />
-              <path
-                 d="m -664.86,-1102 h -16.353"
-                 opacity="1"
-                 id="path5867" />
-              <path
-                 d="m -672.79,-1137.5 h -8.1764"
-                 opacity="1"
-                 id="path5869" />
-              <path
-                 d="m -672.79,-1065.6 h -8.1764"
-                 opacity="1"
-                 id="path5871" />
+            <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.4736" id="g5873">
+              <path d="m -664.86,-1028.1 h -16.353" opacity="1" id="path5861"/>
+              <path d="m -664.86,-1175.9 h -16.353" opacity="1" id="path5863"/>
+              <path d="m -681.19,-1028.4 v -147.51" opacity="1" id="path5865"/>
+              <path d="m -664.86,-1102 h -16.353" opacity="1" id="path5867"/>
+              <path d="m -672.79,-1137.5 h -8.1764" opacity="1" id="path5869"/>
+              <path d="m -672.79,-1065.6 h -8.1764" opacity="1" id="path5871"/>
             </g>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(3401.6,3628.3)"
-       id="g5891">
-      <rect
-         transform="translate(-3628.3,-3628.3)"
-         x="2948"
-         y="-1215.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5883" />
-      <g
-         transform="translate(-5.4726,-56.693)"
-         fill="#ffffff"
-         id="g5889">
-        <path
-           d="m -473.41,-4694.9 a 42.52,42.52 0 0 0 -58.083,-15.563 42.52,42.52 0 0 0 -15.563,58.083 42.52,42.52 0 0 0 58.083,15.563 42.52,42.52 0 0 0 15.563,-58.083 z m -7.5922,4.3834 a 33.753,33.753 0 0 1 -8.3686,43.368 l -9.6445,-16.705 a 14.905,14.905 0 0 0 1.69,-17.238 14.905,14.905 0 0 0 -15.775,-7.158 l -9.6391,-16.695 a 33.753,33.753 0 0 1 41.738,14.429 z m -50.093,-9.6144 9.6444,16.704 a 14.905,14.905 0 0 0 -1.6899,17.239 14.905,14.905 0 0 0 15.775,7.158 l 9.6392,16.696 a 33.753,33.753 0 0 1 -41.738,-14.429 33.753,33.753 0 0 1 8.3688,-43.367 z"
-           id="path5885" />
-        <path
-           d="m -609.1,-4716.1 v 51.598 l -13.261,5.656 v -35.49 l -32.837,-12.503 v 75.778 h 74.094 v -85.039 z"
-           id="path5887" />
+    <g transform="translate(3401.6,3628.3)" id="g5891">
+      <rect transform="translate(-3628.3,-3628.3)" x="2948" y="-1215.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect5883"/>
+      <g transform="translate(-5.4726,-56.693)" fill="#ffffff" id="g5889">
+        <path d="m -473.41,-4694.9 a 42.52,42.52 0 0 0 -58.083,-15.563 42.52,42.52 0 0 0 -15.563,58.083 42.52,42.52 0 0 0 58.083,15.563 42.52,42.52 0 0 0 15.563,-58.083 z m -7.5922,4.3834 a 33.753,33.753 0 0 1 -8.3686,43.368 l -9.6445,-16.705 a 14.905,14.905 0 0 0 1.69,-17.238 14.905,14.905 0 0 0 -15.775,-7.158 l -9.6391,-16.695 a 33.753,33.753 0 0 1 41.738,14.429 z m -50.093,-9.6144 9.6444,16.704 a 14.905,14.905 0 0 0 -1.6899,17.239 14.905,14.905 0 0 0 15.775,7.158 l 9.6392,16.696 a 33.753,33.753 0 0 1 -41.738,-14.429 33.753,33.753 0 0 1 8.3688,-43.367 z" id="path5885"/>
+        <path d="m -609.1,-4716.1 v 51.598 l -13.261,5.656 v -35.49 l -32.837,-12.503 v 75.778 h 74.094 v -85.039 z" id="path5887"/>
       </g>
     </g>
-    <g
-       transform="translate(-460.63,233.86)"
-       id="g5903">
-      <g
-         transform="matrix(1.1667,0,0,1.1667,-532.69,146.91)"
-         id="g5901">
-        <g
-           transform="translate(-194.38,-194.38)"
-           id="g5899">
-          <rect
-             transform="matrix(0.85714,0,0,0.85714,456.59,-125.92)"
-             x="3181.8999"
-             y="-1222.4"
-             width="226.77"
-             height="226.77"
-             fill="none"
-             opacity="1"
-             id="rect5893" />
-          <path
-             d="m 3254.1,-1108 a 32.545,32.527 15 0 0 -28.735,6.0499 c -3.0083,-0.064 -5.8976,0.037 -8.6225,0.3137 -5.0295,0.5106 -9.3213,1.5778 -12.84,3.4108 -3.5184,1.8329 -6.4325,4.6666 -7.4473,8.454 -1.0148,3.7872 0.092,7.6984 2.2225,11.045 2.1305,3.3464 5.3136,6.4167 9.414,9.3736 8.2008,5.9139 19.517,10.882 31.851,14.187 12.334,3.3047 24.618,4.6605 34.677,3.6394 5.0295,-0.5105 9.3214,-1.5778 12.84,-3.4108 3.5183,-1.8329 6.4324,-4.6666 7.4472,-8.454 1.0148,-3.7872 -0.092,-7.6984 -2.2225,-11.045 -2.1305,-3.3465 -5.3137,-6.4169 -9.4141,-9.3738 -2.2209,-1.6015 -4.6719,-3.1332 -7.3082,-4.5817 a 32.545,32.527 15 0 0 -21.862,-19.608 z m 24.084,31.719 c 3.3301,2.4332 5.6312,4.8201 6.8409,6.7204 1.2371,1.9431 1.3069,3.089 1.1114,3.8184 -0.1954,0.7293 -0.8287,1.6868 -2.8716,2.7511 -2.043,1.0643 -5.326,2.0001 -9.5614,2.43 -8.4709,0.8599 -19.959,-0.3082 -31.41,-3.3765 -11.451,-3.0684 -21.984,-7.8007 -28.89,-12.781 -3.453,-2.49 -5.8283,-4.942 -7.0654,-6.8852 -1.2371,-1.9431 -1.3068,-3.089 -1.1114,-3.8183 0.1954,-0.7294 0.8288,-1.6868 2.8717,-2.7511 1.9946,-1.0392 5.1739,-1.9544 9.265,-2.3974 a 32.545,32.527 15 0 0 -3.1184,7.5649 32.545,32.527 15 0 0 -0.9577,5.351 c 0.7512,0.5951 1.5726,1.2019 2.4657,1.8115 6.8628,4.6851 17.196,9.1651 28.257,12.009 11.061,2.844 22.055,3.8351 29.866,2.9717 0.4676,-0.052 0.92,-0.1105 1.3587,-0.1748 a 32.545,32.527 15 0 0 1.8832,-5.1217 32.545,32.527 15 0 0 1.0659,-8.1224 z m -61.243,14.89 a 32.545,32.527 15 0 0 20.322,16.227 32.545,32.527 15 0 0 25.685,-3.8887 c -7.0891,-0.3881 -14.676,-1.6221 -22.33,-3.5902 -8.5189,-2.1905 -16.618,-5.1669 -23.677,-8.7478 z"
-             fill="#ffffff"
-             id="path5895" />
-          <path
-             d="m 3336.3,-1107.6 a 29.865,29.865 0 0 0 -29.865,29.865 29.865,29.865 0 0 0 29.865,29.865 29.865,29.865 0 0 0 9.8068,-1.6926 15.728,15.728 0 0 1 -14.999,-15.692 15.728,15.728 0 0 1 15.728,-15.728 15.728,15.728 0 0 1 15.728,15.728 15.728,15.728 0 0 1 -0.1399,1.976 29.865,29.865 0 0 0 3.7411,-14.457 29.865,29.865 0 0 0 -29.865,-29.865 z"
-             fill="#ffffff"
-             id="path5897" />
+    <g transform="translate(-460.63,233.86)" id="g5903">
+      <g transform="matrix(1.1667,0,0,1.1667,-532.69,146.91)" id="g5901">
+        <g transform="translate(-194.38,-194.38)" id="g5899">
+          <rect transform="matrix(0.85714,0,0,0.85714,456.59,-125.92)" x="3181.8999" y="-1222.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect5893"/>
+          <path d="m 3254.1,-1108 a 32.545,32.527 15 0 0 -28.735,6.0499 c -3.0083,-0.064 -5.8976,0.037 -8.6225,0.3137 -5.0295,0.5106 -9.3213,1.5778 -12.84,3.4108 -3.5184,1.8329 -6.4325,4.6666 -7.4473,8.454 -1.0148,3.7872 0.092,7.6984 2.2225,11.045 2.1305,3.3464 5.3136,6.4167 9.414,9.3736 8.2008,5.9139 19.517,10.882 31.851,14.187 12.334,3.3047 24.618,4.6605 34.677,3.6394 5.0295,-0.5105 9.3214,-1.5778 12.84,-3.4108 3.5183,-1.8329 6.4324,-4.6666 7.4472,-8.454 1.0148,-3.7872 -0.092,-7.6984 -2.2225,-11.045 -2.1305,-3.3465 -5.3137,-6.4169 -9.4141,-9.3738 -2.2209,-1.6015 -4.6719,-3.1332 -7.3082,-4.5817 a 32.545,32.527 15 0 0 -21.862,-19.608 z m 24.084,31.719 c 3.3301,2.4332 5.6312,4.8201 6.8409,6.7204 1.2371,1.9431 1.3069,3.089 1.1114,3.8184 -0.1954,0.7293 -0.8287,1.6868 -2.8716,2.7511 -2.043,1.0643 -5.326,2.0001 -9.5614,2.43 -8.4709,0.8599 -19.959,-0.3082 -31.41,-3.3765 -11.451,-3.0684 -21.984,-7.8007 -28.89,-12.781 -3.453,-2.49 -5.8283,-4.942 -7.0654,-6.8852 -1.2371,-1.9431 -1.3068,-3.089 -1.1114,-3.8183 0.1954,-0.7294 0.8288,-1.6868 2.8717,-2.7511 1.9946,-1.0392 5.1739,-1.9544 9.265,-2.3974 a 32.545,32.527 15 0 0 -3.1184,7.5649 32.545,32.527 15 0 0 -0.9577,5.351 c 0.7512,0.5951 1.5726,1.2019 2.4657,1.8115 6.8628,4.6851 17.196,9.1651 28.257,12.009 11.061,2.844 22.055,3.8351 29.866,2.9717 0.4676,-0.052 0.92,-0.1105 1.3587,-0.1748 a 32.545,32.527 15 0 0 1.8832,-5.1217 32.545,32.527 15 0 0 1.0659,-8.1224 z m -61.243,14.89 a 32.545,32.527 15 0 0 20.322,16.227 32.545,32.527 15 0 0 25.685,-3.8887 c -7.0891,-0.3881 -14.676,-1.6221 -22.33,-3.5902 -8.5189,-2.1905 -16.618,-5.1669 -23.677,-8.7478 z" fill="#ffffff" id="path5895"/>
+          <path d="m 3336.3,-1107.6 a 29.865,29.865 0 0 0 -29.865,29.865 29.865,29.865 0 0 0 29.865,29.865 29.865,29.865 0 0 0 9.8068,-1.6926 15.728,15.728 0 0 1 -14.999,-15.692 15.728,15.728 0 0 1 15.728,-15.728 15.728,15.728 0 0 1 15.728,15.728 15.728,15.728 0 0 1 -0.1399,1.976 29.865,29.865 0 0 0 3.7411,-14.457 29.865,29.865 0 0 0 -29.865,-29.865 z" fill="#ffffff" id="path5897"/>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(-3855.1,907.09)"
-       id="g5909">
-      <path
-         d="m 6916.6,-2155.6 c -25.146,0 -56.13,-1.9661 -77.237,-9.3195 -4.0465,-1.4594 -6.9617,-5.3879 -6.9617,-9.9347 v -0.785 c 1.7964,-49.397 11,-93.575 15.21,-97.897 9.7671,-13.023 40.024,-34.464 57.089,-45.242 4.2094,-2.6943 7.8031,-3.2002 11.844,-3.3124 4.041,0.1127 7.6269,0.7865 11.836,3.3124 17.406,10.272 48.056,32.219 57.768,45.242 4.2665,4.3221 12.793,48.5 14.594,97.897 l 0.053,0.785 c 0,4.5468 -2.9167,8.4753 -6.9591,9.9347 -21.161,7.3534 -52.142,9.3195 -77.239,9.3195 z m -14.219,-107.93 h 28.346 v -28.946 h -28.346 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5905" />
-      <rect
-         x="6803.1001"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5907" />
+    <g transform="translate(-3855.1,907.09)" id="g5909">
+      <path d="m 6916.6,-2155.6 c -25.146,0 -56.13,-1.9661 -77.237,-9.3195 -4.0465,-1.4594 -6.9617,-5.3879 -6.9617,-9.9347 v -0.785 c 1.7964,-49.397 11,-93.575 15.21,-97.897 9.7671,-13.023 40.024,-34.464 57.089,-45.242 4.2094,-2.6943 7.8031,-3.2002 11.844,-3.3124 4.041,0.1127 7.6269,0.7865 11.836,3.3124 17.406,10.272 48.056,32.219 57.768,45.242 4.2665,4.3221 12.793,48.5 14.594,97.897 l 0.053,0.785 c 0,4.5468 -2.9167,8.4753 -6.9591,9.9347 -21.161,7.3534 -52.142,9.3195 -77.239,9.3195 z m -14.219,-107.93 h 28.346 v -28.946 h -28.346 z" fill="#ffffff" opacity="1" id="path5905"/>
+      <rect x="6803.1001" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5907"/>
     </g>
-    <g
-       transform="translate(1587.4,1133.9)"
-       id="g5921">
-      <g
-         transform="matrix(0.33519,0,0,0.33519,1556.5,-2113.3)"
-         fill="#ffffff"
-         id="g5917">
-        <path
-           transform="matrix(0.4848,0,0,0.26808,-175.08,-176.53)"
-           d="m 464.37,-705.5 -804.2,464.31 v -464.31 -464.31 l 402.1,232.15 z"
-           id="path5911" />
-        <path
-           transform="matrix(1.7959,0,0,0.77621,459.75,-82.478)"
-           d="m -557.77,-435.32 102.11,-58.95 -10e-6,58.95 v 58.95 l -51.053,-29.475 z"
-           id="path5913" />
-        <path
-           transform="matrix(1.7959,0,0,0.77621,459.75,26.951)"
-           d="m -557.77,-435.32 102.11,-58.95 -10e-6,58.95 v 58.95 l -51.053,-29.475 z"
-           id="path5915" />
+    <g transform="translate(1587.4,1133.9)" id="g5921">
+      <g transform="matrix(0.33519,0,0,0.33519,1556.5,-2113.3)" fill="#ffffff" id="g5917">
+        <path transform="matrix(0.4848,0,0,0.26808,-175.08,-176.53)" d="m 464.37,-705.5 -804.2,464.31 v -464.31 -464.31 l 402.1,232.15 z" id="path5911"/>
+        <path transform="matrix(1.7959,0,0,0.77621,459.75,-82.478)" d="m -557.77,-435.32 102.11,-58.95 -10e-6,58.95 v 58.95 l -51.053,-29.475 z" id="path5913"/>
+        <path transform="matrix(1.7959,0,0,0.77621,459.75,26.951)" d="m -557.77,-435.32 102.11,-58.95 -10e-6,58.95 v 58.95 l -51.053,-29.475 z" id="path5915"/>
       </g>
-      <rect
-         x="1360.6"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5919" />
+      <rect x="1360.6" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5919"/>
     </g>
-    <g
-       transform="translate(5.2702,-5.2001)"
-       id="g5933">
-      <g
-         transform="translate(-4081.9,907.09)"
-         id="g5927">
-        <path
-           transform="translate(4081.9,-3483.1)"
-           d="m 2834.6,1148 c -29.851,0 -65.857,4.7545 -90.945,13.436 -4.795,1.6949 -8.2676,6.3662 -8.2676,11.74 l 0.039,0.9082 c 2.109,58.205 11.45,109.38 16.494,114.47 11.574,15.378 48.573,39.273 68.58,52.336 4.754,3.1004 9.3027,5.415 14.098,5.539 4.795,-0.124 9.3436,-2.4386 14.098,-5.539 20.007,-13.063 57.006,-36.958 68.58,-52.336 5.044,-5.0847 14.385,-56.262 16.494,-114.47 l 0.041,-0.9082 c 0,-5.374 -3.4746,-10.045 -8.2696,-11.74 -25.092,-8.6811 -61.096,-13.436 -90.943,-13.436 z m 0.01,20.67 c 23.605,0 52.747,1.8175 72.594,8.6797 3.803,1.3642 6.5742,5.0445 6.5742,9.3437 l -0.041,0.7031 c -1.691,46.093 -9.6736,87.927 -13.684,91.978 -9.181,12.154 -38.449,31.665 -54.277,42 -3.762,2.439 -7.3592,4.2982 -11.162,4.3809 -3.8029,-0.083 -7.3981,-1.942 -11.16,-4.3809 -15.833,-10.335 -45.102,-29.846 -54.279,-42 -4.01,-4.0511 -11.986,-45.886 -13.686,-91.978 l -0.041,-0.7031 h -0.01 c 0,-4.2992 2.7692,-7.9795 6.5722,-9.3437 19.847,-6.8622 48.992,-8.6797 72.596,-8.6797 z"
-           fill="#ffffff"
-           opacity="1"
-           id="path5923" />
-        <rect
-           x="6803.1001"
-           y="-2349.2"
-           width="226.77"
-           height="226.77"
-           fill="none"
-           opacity="1"
-           id="rect5925" />
+    <g transform="translate(5.2702,-5.2001)" id="g5933">
+      <g transform="translate(-4081.9,907.09)" id="g5927">
+        <path transform="translate(4081.9,-3483.1)" d="m 2834.6,1148 c -29.851,0 -65.857,4.7545 -90.945,13.436 -4.795,1.6949 -8.2676,6.3662 -8.2676,11.74 l 0.039,0.9082 c 2.109,58.205 11.45,109.38 16.494,114.47 11.574,15.378 48.573,39.273 68.58,52.336 4.754,3.1004 9.3027,5.415 14.098,5.539 4.795,-0.124 9.3436,-2.4386 14.098,-5.539 20.007,-13.063 57.006,-36.958 68.58,-52.336 5.044,-5.0847 14.385,-56.262 16.494,-114.47 l 0.041,-0.9082 c 0,-5.374 -3.4746,-10.045 -8.2696,-11.74 -25.092,-8.6811 -61.096,-13.436 -90.943,-13.436 z m 0.01,20.67 c 23.605,0 52.747,1.8175 72.594,8.6797 3.803,1.3642 6.5742,5.0445 6.5742,9.3437 l -0.041,0.7031 c -1.691,46.093 -9.6736,87.927 -13.684,91.978 -9.181,12.154 -38.449,31.665 -54.277,42 -3.762,2.439 -7.3592,4.2982 -11.162,4.3809 -3.8029,-0.083 -7.3981,-1.942 -11.16,-4.3809 -15.833,-10.335 -45.102,-29.846 -54.279,-42 -4.01,-4.0511 -11.986,-45.886 -13.686,-91.978 l -0.041,-0.7031 h -0.01 c 0,-4.2992 2.7692,-7.9795 6.5722,-9.3437 19.847,-6.8622 48.992,-8.6797 72.596,-8.6797 z" fill="#ffffff" opacity="1" id="path5923"/>
+        <rect x="6803.1001" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5925"/>
       </g>
-      <path
-         d="m 2834.7,-1394.4 c -18.519,0 -41.337,1.4479 -56.881,6.8633 -2.98,1.0748 -5.1269,3.9679 -5.1269,7.3164 v 0.5781 c 1.323,36.378 8.1012,68.913 11.201,72.096 7.193,9.5906 29.476,25.381 42.043,33.318 3.1,1.9842 5.7466,2.3568 8.7226,2.4394 2.976,-0.083 5.6168,-0.5792 8.7168,-2.4394 12.819,-7.565 35.391,-23.728 42.543,-33.318 3.142,-3.183 9.4211,-35.718 10.748,-72.096 l 0.039,-0.5781 c 0,-3.3485 -2.148,-6.2416 -5.125,-7.3164 -15.584,-5.4154 -38.4,-6.8633 -56.883,-6.8633 z m -14.188,63.467 h 30 v 28.5 h -30 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5929" />
-      <rect
-         x="2721.3"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5931" />
+      <path d="m 2834.7,-1394.4 c -18.519,0 -41.337,1.4479 -56.881,6.8633 -2.98,1.0748 -5.1269,3.9679 -5.1269,7.3164 v 0.5781 c 1.323,36.378 8.1012,68.913 11.201,72.096 7.193,9.5906 29.476,25.381 42.043,33.318 3.1,1.9842 5.7466,2.3568 8.7226,2.4394 2.976,-0.083 5.6168,-0.5792 8.7168,-2.4394 12.819,-7.565 35.391,-23.728 42.543,-33.318 3.142,-3.183 9.4211,-35.718 10.748,-72.096 l 0.039,-0.5781 c 0,-3.3485 -2.148,-6.2416 -5.125,-7.3164 -15.584,-5.4154 -38.4,-6.8633 -56.883,-6.8633 z m -14.188,63.467 h 30 v 28.5 h -30 z" fill="#ffffff" opacity="1" id="path5929"/>
+      <rect x="2721.3" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect5931"/>
     </g>
-    <g
-       transform="matrix(1.2195,0,0,1.2052,-726.63,244.1)"
-       id="g5943">
-      <path
-         d="m 3316.3,-1305.1 a 42,42 0 0 1 16.027,47.038 42,42 0 0 1 -40.062,29.402 42,42 0 0 1 -40.068,-29.394 42,42 0 0 1 16.018,-47.041"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="11.691"
-         id="path5935" />
-      <path
-         d="m 3268.2,-1305.8 v -51.696 c 0,-13.319 10.722,-24.042 24.042,-24.042 13.32,0 24.042,10.723 24.042,24.042 v 51.696"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="11.691"
-         id="path5937" />
-      <ellipse
-         cx="3292.3"
-         cy="-1270.6"
-         rx="23.245001"
-         ry="23.197001"
-         fill="#ffffff"
-         opacity="1"
-         id="ellipse5939" />
-      <rect
-         x="3285.3"
-         y="-1328.6"
-         width="13.947"
-         height="47.041"
-         ry="7.0560999"
-         fill="#ffffff"
-         opacity="1"
-         id="rect5941"
-         rx="7.0560999" />
+    <g transform="matrix(1.2195,0,0,1.2052,-726.63,244.1)" id="g5943">
+      <path d="m 3316.3,-1305.1 a 42,42 0 0 1 16.027,47.038 42,42 0 0 1 -40.062,29.402 42,42 0 0 1 -40.068,-29.394 42,42 0 0 1 16.018,-47.041" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="11.691" id="path5935"/>
+      <path d="m 3268.2,-1305.8 v -51.696 c 0,-13.319 10.722,-24.042 24.042,-24.042 13.32,0 24.042,10.723 24.042,24.042 v 51.696" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="11.691" id="path5937"/>
+      <ellipse cx="3292.3" cy="-1270.6" rx="23.245001" ry="23.197001" fill="#ffffff" opacity="1" id="ellipse5939"/>
+      <rect x="3285.3" y="-1328.6" width="13.947" height="47.041" ry="7.0560999" fill="#ffffff" opacity="1" id="rect5941" rx="7.0560999"/>
     </g>
-    <rect
-       x="3174.8"
-       y="-1442.1"
-       width="226.77"
-       height="226.77"
-       ry="0"
-       fill="none"
-       opacity="1"
-       id="rect5945" />
-    <g
-       transform="matrix(0.60711,0,0,0.60711,2261.3,-1047.7)"
-       id="g5957">
-      <text
-         x="943.65356"
-         y="-775.98425"
-         fill="#ffffff"
-         font-family="TitilliumText25L"
-         font-weight="600"
-         opacity="1"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         style="line-height:0%"
-         xml:space="preserve"
-         id="text5949"><tspan
-           x="943.65356"
-           y="-775.98425"
-           font-family="TitilliumText25L"
-           font-size="283.46px"
-           font-weight="900"
-           style="line-height:1.25"
-           id="tspan5947">!</tspan></text>
-      <rect
-         x="907.09003"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         rx="2.8309"
-         ry="2.2492001"
-         fill="none"
-         opacity="1"
-         id="rect5951" />
-      <text
-         x="943.65356"
-         y="-775.98425"
-         fill="#ffffff"
-         font-family="TitilliumText25L"
-         font-weight="600"
-         opacity="1"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         style="line-height:0%"
-         xml:space="preserve"
-         id="text5955"><tspan
-           x="943.65356"
-           y="-775.98425"
-           font-family="TitilliumText25L"
-           font-size="283.46px"
-           font-weight="900"
-           style="line-height:1.25"
-           id="tspan5953">!</tspan></text>
+    <rect x="3174.8" y="-1442.1" width="226.77" height="226.77" ry="0" fill="none" opacity="1" id="rect5945"/>
+    <g transform="matrix(0.60711,0,0,0.60711,2261.3,-1047.7)" id="g5957">
+      <text x="943.65356" y="-775.98425" fill="#ffffff" font-family="TitilliumText25L" font-weight="600" opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" style="line-height:0%" xml:space="preserve" id="text5949"><tspan x="943.65356" y="-775.98425" font-family="TitilliumText25L" font-size="283.46px" font-weight="900" style="line-height:1.25" id="tspan5947">!</tspan></text>
+      <rect x="907.09003" y="-988.58002" width="226.77" height="226.77" rx="2.8309" ry="2.2492001" fill="none" opacity="1" id="rect5951"/>
+      <text x="943.65356" y="-775.98425" fill="#ffffff" font-family="TitilliumText25L" font-weight="600" opacity="1" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" style="line-height:0%" xml:space="preserve" id="text5955"><tspan x="943.65356" y="-775.98425" font-family="TitilliumText25L" font-size="283.46px" font-weight="900" style="line-height:1.25" id="tspan5953">!</tspan></text>
     </g>
-    <g
-       transform="translate(-8163.8,-226.77)"
-       id="g5963">
-      <path
-         d="m 11452,-2292.5 c -31.217,0 -56.694,25.477 -56.694,56.693 0,31.216 25.477,56.692 56.694,56.692 31.216,0 56.693,-25.476 56.693,-56.692 0,-31.216 -25.477,-56.693 -56.693,-56.693 z m 0,9.0785 c 26.406,0 47.614,21.207 47.614,47.614 0,26.407 -21.208,47.614 -47.614,47.614 -26.407,0 -47.615,-21.207 -47.615,-47.614 0,-26.407 21.208,-47.614 47.615,-47.614 z m 0,21.735 c -14.339,0 -26.04,11.702 -26.04,26.04 0,14.338 11.701,26.041 26.04,26.041 14.338,0 26.041,-11.703 26.041,-26.041 0,-14.338 -11.703,-26.04 -26.041,-26.04 z m 0,10.304 c 8.664,0 15.738,7.0715 15.738,15.737 0,8.6652 -7.074,15.738 -15.738,15.738 -8.665,0 -15.738,-7.0725 -15.738,-15.738 0,-8.6651 7.073,-15.737 15.738,-15.737 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path5959" />
-      <rect
-         x="11339"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5961" />
+    <g transform="translate(-8163.8,-226.77)" id="g5963">
+      <path d="m 11452,-2292.5 c -31.217,0 -56.694,25.477 -56.694,56.693 0,31.216 25.477,56.692 56.694,56.692 31.216,0 56.693,-25.476 56.693,-56.692 0,-31.216 -25.477,-56.693 -56.693,-56.693 z m 0,9.0785 c 26.406,0 47.614,21.207 47.614,47.614 0,26.407 -21.208,47.614 -47.614,47.614 -26.407,0 -47.615,-21.207 -47.615,-47.614 0,-26.407 21.208,-47.614 47.615,-47.614 z m 0,21.735 c -14.339,0 -26.04,11.702 -26.04,26.04 0,14.338 11.701,26.041 26.04,26.041 14.338,0 26.041,-11.703 26.041,-26.041 0,-14.338 -11.703,-26.04 -26.041,-26.04 z m 0,10.304 c 8.664,0 15.738,7.0715 15.738,15.737 0,8.6652 -7.074,15.738 -15.738,15.738 -8.665,0 -15.738,-7.0725 -15.738,-15.738 0,-8.6651 7.073,-15.737 15.738,-15.737 z" fill="#ffffff" opacity="1" id="path5959"/>
+      <rect x="11339" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5961"/>
     </g>
-    <g
-       transform="translate(-8163.8,-226.77)"
-       id="g5977">
-      <rect
-         x="9978"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5965" />
-      <g
-         fill="#535b4f"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="g5975">
-        <path
-           d="m 10091,-2255.1 v -70.866"
-           opacity="1"
-           id="path5967" />
-        <path
-           d="m 10091,-2145.7 v -70.866"
-           opacity="1"
-           id="path5969" />
-        <path
-           d="m 10072,-2235.8 h -70.867"
-           opacity="1"
-           id="path5971" />
-        <path
-           d="m 10181,-2235.8 h -70.866"
-           opacity="1"
-           id="path5973" />
+    <g transform="translate(-8163.8,-226.77)" id="g5977">
+      <rect x="9978" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5965"/>
+      <g fill="#535b4f" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="g5975">
+        <path d="m 10091,-2255.1 v -70.866" opacity="1" id="path5967"/>
+        <path d="m 10091,-2145.7 v -70.866" opacity="1" id="path5969"/>
+        <path d="m 10072,-2235.8 h -70.867" opacity="1" id="path5971"/>
+        <path d="m 10181,-2235.8 h -70.866" opacity="1" id="path5973"/>
       </g>
     </g>
-    <g
-       transform="translate(-7937,-226.77)"
-       id="g5991">
-      <rect
-         x="9978"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect5979" />
-      <g
-         fill="#535b4f"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="g5989">
-        <path
-           d="m 10078,-2249.4 -50.11,-50.11"
-           opacity="1"
-           id="path5981" />
-        <path
-           d="m 10155,-2172.1 -50.11,-50.11"
-           opacity="1"
-           id="path5983" />
-        <path
-           d="m 10078,-2222.2 -50.11,50.11"
-           opacity="1"
-           id="path5985" />
-        <path
-           d="m 10155,-2299.5 -50.11,50.11"
-           opacity="1"
-           id="path5987" />
+    <g transform="translate(-7937,-226.77)" id="g5991">
+      <rect x="9978" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect5979"/>
+      <g fill="#535b4f" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="g5989">
+        <path d="m 10078,-2249.4 -50.11,-50.11" opacity="1" id="path5981"/>
+        <path d="m 10155,-2172.1 -50.11,-50.11" opacity="1" id="path5983"/>
+        <path d="m 10078,-2222.2 -50.11,50.11" opacity="1" id="path5985"/>
+        <path d="m 10155,-2299.5 -50.11,50.11" opacity="1" id="path5987"/>
       </g>
     </g>
-    <g
-       transform="translate(-7710.2,-226.77)"
-       fill="none"
-       id="g5997">
-      <rect
-         x="9978"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect5993" />
-      <path
-         d="m 10155,-2172.1 -63.719,-63.718 -63.717,63.718"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="path5995" />
+    <g transform="translate(-7710.2,-226.77)" fill="none" id="g5997">
+      <rect x="9978" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect5993"/>
+      <path d="m 10155,-2172.1 -63.719,-63.718 -63.717,63.718" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="path5995"/>
     </g>
-    <g
-       transform="rotate(-90,6236.2,1392.5)"
-       fill="none"
-       id="g6003">
-      <rect
-         x="9978"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect5999" />
-      <path
-         d="m 10155,-2172.1 -63.719,-63.718 -63.717,63.718"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="path6001" />
+    <g transform="rotate(-90,6236.2,1392.5)" fill="none" id="g6003">
+      <rect x="9978" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect5999"/>
+      <path d="m 10155,-2172.1 -63.719,-63.718 -63.717,63.718" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="path6001"/>
     </g>
-    <g
-       transform="rotate(180,6463,-2349.2)"
-       fill="none"
-       id="g6009">
-      <rect
-         x="9978"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect6005" />
-      <path
-         d="m 10155,-2172.1 -63.719,-63.718 -63.717,63.718"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="path6007" />
+    <g transform="rotate(180,6463,-2349.2)" fill="none" id="g6009">
+      <rect x="9978" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect6005"/>
+      <path d="m 10155,-2172.1 -63.719,-63.718 -63.717,63.718" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="path6007"/>
     </g>
-    <g
-       transform="rotate(90,6689.8,-5864.2)"
-       fill="none"
-       id="g6015">
-      <rect
-         x="9978"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect6011" />
-      <path
-         d="m 10155,-2172.1 -63.719,-63.718 -63.717,63.718"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="path6013" />
+    <g transform="rotate(90,6689.8,-5864.2)" fill="none" id="g6015">
+      <rect x="9978" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect6011"/>
+      <path d="m 10155,-2172.1 -63.719,-63.718 -63.717,63.718" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="path6013"/>
     </g>
-    <g
-       transform="translate(-7483.5,-226.77)"
-       fill="none"
-       id="g6021">
-      <path
-         d="m 11075,-2197.5 v 38.283 l -38.282,-10e-5 m -76.565,-3e-4 -38.283,-1e-4 v -38.283 m 0,-76.566 v -38.283 l 38.283,2e-4 m 76.565,3e-4 38.282,1e-4 v 38.283"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="16.948"
-         id="path6017" />
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect6019" />
+    <g transform="translate(-7483.5176,-226.77)" fill="none" id="g6021">
+      <path d="m 11075,-2197.5 v 38.283 l -38.282,-10e-5 m -76.565,-3e-4 -38.283,-1e-4 v -38.283 m 0,-76.566 v -38.283 l 38.283,2e-4 m 76.565,3e-4 38.282,1e-4 v 38.283" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="16.948" id="path6017"/>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect6019"/>
     </g>
-    <g
-       transform="translate(1133.9,1360.6)"
-       id="g6027">
-      <path
-         d="m 566.93,-2285.4 a 49.606,49.606 0 0 0 -49.606,49.606 49.606,49.606 0 0 0 49.606,49.606 49.606,49.606 0 0 0 16.289,-2.8113 26.125,26.125 0 0 1 -24.914,-26.064 26.125,26.125 0 0 1 26.125,-26.124 26.125,26.125 0 0 1 26.125,26.124 26.125,26.125 0 0 1 -0.23236,3.2822 49.606,49.606 0 0 0 6.214,-24.013 49.606,49.606 0 0 0 -49.606,-49.606 z"
-         fill="#ffffff"
-         id="path6023" />
-      <rect
-         x="453.54001"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6025" />
+    <g transform="translate(1133.9,1360.6)" id="g6027">
+      <path d="m 566.93,-2285.4 a 49.606,49.606 0 0 0 -49.606,49.606 49.606,49.606 0 0 0 49.606,49.606 49.606,49.606 0 0 0 16.289,-2.8113 26.125,26.125 0 0 1 -24.914,-26.064 26.125,26.125 0 0 1 26.125,-26.124 26.125,26.125 0 0 1 26.125,26.124 26.125,26.125 0 0 1 -0.23236,3.2822 49.606,49.606 0 0 0 6.214,-24.013 49.606,49.606 0 0 0 -49.606,-49.606 z" fill="#ffffff" id="path6023"/>
+      <rect x="453.54001" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6025"/>
     </g>
-    <g
-       transform="translate(453.54,1360.6)"
-       id="g6039">
-      <g
-         transform="matrix(0.33519,0,0,0.33519,1556.5,-2113.3)"
-         fill="#ffffff"
-         id="g6035">
-        <path
-           transform="matrix(0.4848,0,0,0.26808,-175.08,-176.53)"
-           d="m 464.37,-705.5 -804.2,464.31 v -464.31 -464.31 l 402.1,232.15 z"
-           id="path6029" />
-        <path
-           transform="matrix(1.7959,0,0,0.77621,459.75,-82.478)"
-           d="m -557.77,-435.32 102.11,-58.95 -10e-6,58.95 v 58.95 l -51.053,-29.475 z"
-           id="path6031" />
-        <path
-           transform="matrix(1.7959,0,0,0.77621,459.75,26.951)"
-           d="m -557.77,-435.32 102.11,-58.95 -10e-6,58.95 v 58.95 l -51.053,-29.475 z"
-           id="path6033" />
+    <g transform="translate(453.54,1360.6)" id="g6039">
+      <g transform="matrix(0.33519,0,0,0.33519,1556.5,-2113.3)" fill="#ffffff" id="g6035">
+        <path transform="matrix(0.4848,0,0,0.26808,-175.08,-176.53)" d="m 464.37,-705.5 -804.2,464.31 v -464.31 -464.31 l 402.1,232.15 z" id="path6029"/>
+        <path transform="matrix(1.7959,0,0,0.77621,459.75,-82.478)" d="m -557.77,-435.32 102.11,-58.95 -10e-6,58.95 v 58.95 l -51.053,-29.475 z" id="path6031"/>
+        <path transform="matrix(1.7959,0,0,0.77621,459.75,26.951)" d="m -557.77,-435.32 102.11,-58.95 -10e-6,58.95 v 58.95 l -51.053,-29.475 z" id="path6033"/>
       </g>
-      <rect
-         x="1360.6"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6037" />
+      <rect x="1360.6" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6037"/>
     </g>
-    <g
-       transform="translate(-10658,226.77)"
-       fill="none"
-       id="g6045">
-      <path
-         d="m 10998,-2285.4 49.607,77.982 -49.606,21.231 -49.607,-21.232 z"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6041" />
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect6043" />
+    <g transform="translate(-10658,226.77)" fill="none" id="g6045">
+      <path d="m 10998,-2285.4 49.607,77.982 -49.606,21.231 -49.607,-21.232 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6041"/>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect6043"/>
     </g>
-    <g
-       transform="translate(-10431,226.77)"
-       fill="none"
-       id="g6051">
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect6047" />
-      <path
-         d="m 10998,-2271.3 35.434,55.702 -35.433,15.165 -35.435,-15.166 z"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6049" />
+    <g transform="translate(-10431,226.77)" fill="none" id="g6051">
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect6047"/>
+      <path d="m 10998,-2271.3 35.434,55.702 -35.433,15.165 -35.435,-15.166 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6049"/>
     </g>
-    <g
-       transform="translate(-10658,453.54)"
-       id="g6065">
-      <title
-         id="title6053">Icon Medium Courier</title>
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6055" />
-      <g
-         transform="translate(0,12.04)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="g6063">
-        <path
-           d="m 10998,-2311.6 21.261,70.867 -42.522,-2e-4 z"
-           fill="none"
-           opacity="1"
-           id="path6057" />
-        <path
-           d="m 10977,-2211.5 h 43.47"
-           fill="#ffffff"
-           opacity="1"
-           id="path6059" />
-        <path
-           d="m 10990,-2183.8 h 16.45"
-           fill="#ffffff"
-           opacity="1"
-           id="path6061" />
+    <g transform="translate(-10658,453.54)" id="g6065">
+      <title id="title6053">Icon Medium Courier</title>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6055"/>
+      <g transform="translate(0,12.04)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="g6063">
+        <path d="m 10998,-2311.6 21.261,70.867 -42.522,-2e-4 z" fill="none" opacity="1" id="path6057"/>
+        <path d="m 10977,-2211.5 h 43.47" fill="#ffffff" opacity="1" id="path6059"/>
+        <path d="m 10990,-2183.8 h 16.45" fill="#ffffff" opacity="1" id="path6061"/>
       </g>
     </g>
-    <g
-       transform="translate(-10423,474.26)"
-       id="g6077">
-      <title
-         id="title6067">Icon Light courier</title>
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6069" />
-      <g
-         transform="translate(0,12.04)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="g6075">
-        <path
-           d="m 10998,-2297.5 21.261,56.695 -42.522,-1e-4 z"
-           fill="none"
-           opacity="1"
-           id="path6071" />
-        <path
-           d="m 10990,-2211.9 h 16.45"
-           fill="#ffffff"
-           opacity="1"
-           id="path6073" />
+    <g transform="translate(-10423,474.26)" id="g6077">
+      <title id="title6067">Icon Light courier</title>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6069"/>
+      <g transform="translate(0,12.04)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="g6075">
+        <path d="m 10998,-2297.5 21.261,56.695 -42.522,-1e-4 z" fill="none" opacity="1" id="path6071"/>
+        <path d="m 10990,-2211.9 h 16.45" fill="#ffffff" opacity="1" id="path6073"/>
       </g>
     </g>
-    <g
-       transform="matrix(1,0,0,-1,-10658,-3791.3)"
-       id="g6085">
-      <title
-         id="title6079">Icon Medium Passegner Shuttle</title>
-      <path
-         d="m 10998,-2285.4 49.607,77.982 c -35.433,28.318 -63.78,28.318 -99.213,-2e-4 z"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6081" />
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6083" />
+    <g transform="matrix(1,0,0,-1,-10658,-3791.3)" id="g6085">
+      <title id="title6079">Icon Medium Passegner Shuttle</title>
+      <path d="m 10998,-2285.4 49.607,77.982 c -35.433,28.318 -63.78,28.318 -99.213,-2e-4 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6081"/>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6083"/>
     </g>
-    <g
-       transform="matrix(1,0,0,-1,-10431,-3791.3)"
-       id="g6093">
-      <title
-         id="title6087">Icon Light Passegner Shuttle</title>
-      <path
-         d="m 10998,-2271.3 35.435,55.703 c -25.31,20.228 -45.559,20.228 -70.869,-10e-5 z"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6089" />
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6091" />
+    <g transform="matrix(1,0,0,-1,-10431,-3791.3)" id="g6093">
+      <title id="title6087">Icon Light Passegner Shuttle</title>
+      <path d="m 10998,-2271.3 35.435,55.703 c -25.31,20.228 -45.559,20.228 -70.869,-10e-5 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6089"/>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6091"/>
     </g>
-    <g
-       transform="translate(-10885,226.77)"
-       id="g6099">
-      <path
-         d="m 10998,-2285.4 49.607,77.982 -49.606,21.231 -49.607,-21.232 z"
-         fill="#ffffff"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6095" />
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6097" />
+    <g transform="translate(-10885,226.77)" id="g6099">
+      <path d="m 10998,-2285.4 49.607,77.982 -49.606,21.231 -49.607,-21.232 z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6095"/>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6097"/>
     </g>
-    <g
-       transform="translate(-10885,453.54)"
-       id="g6113">
-      <title
-         id="title6101">Icon Heavy Courier</title>
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6103" />
-      <g
-         transform="translate(0,12.04)"
-         fill="#ffffff"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="g6111">
-        <path
-           d="m 10998,-2311.6 21.261,70.867 -42.522,-2e-4 z"
-           opacity="1"
-           id="path6105" />
-        <path
-           d="m 10977,-2211.5 h 43.47"
-           opacity="1"
-           id="path6107" />
-        <path
-           d="m 10990,-2183.8 h 16.45"
-           opacity="1"
-           id="path6109" />
+    <g transform="translate(-10885,453.54)" id="g6113">
+      <title id="title6101">Icon Heavy Courier</title>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6103"/>
+      <g transform="translate(0,12.04)" fill="#ffffff" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="g6111">
+        <path d="m 10998,-2311.6 21.261,70.867 -42.522,-2e-4 z" opacity="1" id="path6105"/>
+        <path d="m 10977,-2211.5 h 43.47" opacity="1" id="path6107"/>
+        <path d="m 10990,-2183.8 h 16.45" opacity="1" id="path6109"/>
       </g>
     </g>
-    <g
-       transform="matrix(1,0,0,-1,-10885,-3791.3)"
-       id="g6121">
-      <title
-         id="title6115">Icon Heavy Passegner Shuttle</title>
-      <path
-         d="m 10998,-2285.4 49.607,77.982 c -35.433,28.318 -63.78,28.318 -99.213,-2e-4 z"
-         fill="#ffffff"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6117" />
-      <rect
-         x="10885"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6119" />
+    <g transform="matrix(1,0,0,-1,-10885,-3791.3)" id="g6121">
+      <title id="title6115">Icon Heavy Passegner Shuttle</title>
+      <path d="m 10998,-2285.4 49.607,77.982 c -35.433,28.318 -63.78,28.318 -99.213,-2e-4 z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6117"/>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6119"/>
     </g>
-    <g
-       fill="none"
-       id="g6129">
-      <title
-         id="title6123">Icon Medium Passegner Transport</title>
-      <path
-         transform="rotate(90)"
-         d="m -1377.5,-375.59 h 126.73 v 70.866 h -126.73 l -28.125,-35.433 z"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6125" />
-      <rect
-         x="226.77"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6127" />
+    <g fill="none" id="g6129">
+      <title id="title6123">Icon Medium Passegner Transport</title>
+      <path transform="rotate(90)" d="m -1377.5,-375.59 h 126.73 v 70.866 h -126.73 l -28.125,-35.433 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6125"/>
+      <rect x="226.77" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect6127"/>
     </g>
-    <g
-       transform="translate(-226.77)"
-       id="g6137">
-      <title
-         id="title6131">Icon Heavy Passegner Transport</title>
-      <path
-         transform="rotate(90)"
-         d="m -1377.5,-375.59 h 126.73 v 70.866 h -126.73 l -28.125,-35.433 z"
-         fill="#ffffff"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6133" />
-      <rect
-         x="226.77"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6135" />
+    <g transform="translate(-226.77)" id="g6137">
+      <title id="title6131">Icon Heavy Passegner Transport</title>
+      <path transform="rotate(90)" d="m -1377.5,-375.59 h 126.73 v 70.866 h -126.73 l -28.125,-35.433 z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6133"/>
+      <rect x="226.77" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect6135"/>
     </g>
-    <g
-       transform="translate(226.77)"
-       id="g6145">
-      <title
-         id="title6139">Icon Light Passegner Transport</title>
-      <path
-         d="m 361.42,-1360.1 v 82.052 H 318.9 v -82.052 l 21.26,-18.209 z"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6141" />
-      <rect
-         x="226.77"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6143" />
+    <g transform="translate(226.77)" id="g6145">
+      <title id="title6139">Icon Light Passegner Transport</title>
+      <path d="m 361.42,-1360.1 v 82.052 H 318.9 v -82.052 l 21.26,-18.209 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6141"/>
+      <rect x="226.77" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect6143"/>
     </g>
-    <g
-       transform="matrix(1,0,0,-1,0,-2430.7)"
-       fill="none"
-       id="g6157">
-      <title
-         id="title6147">Icon Medium Cargo Shuttle</title>
-      <g
-         fill="none"
-         id="g6155">
-        <path
-           d="m 375.59,-1350 v 99.213 H 304.724 V -1350 Z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6149" />
-        <rect
-           x="226.77"
-           y="-1442.1"
-           width="226.77"
-           height="226.77"
-           opacity="1"
-           id="rect6151" />
-        <path
-           transform="rotate(90)"
-           d="m -1377.5,-304.72 -28.125,-35.433 28.125,-35.433"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6153" />
+    <g transform="matrix(1,0,0,-1,0,-2430.7)" fill="none" id="g6157">
+      <title id="title6147">Icon Medium Cargo Shuttle</title>
+      <g fill="none" id="g6155">
+        <path d="m 375.59,-1350 v 99.213 H 304.724 V -1350 Z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6149"/>
+        <rect x="226.77" y="-1442.1" width="226.77" height="226.77" opacity="1" id="rect6151"/>
+        <path transform="rotate(90)" d="m -1377.5,-304.72 -28.125,-35.433 28.125,-35.433" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6153"/>
       </g>
     </g>
-    <g
-       transform="matrix(1,0,0,-1,226.77,-2430.7)"
-       id="g6169">
-      <title
-         id="title6159">Icon Light Cargo Shuttle</title>
-      <g
-         fill="none"
-         id="g6167">
-        <path
-           d="m 361.42,-1335.8 v 56.693 H 318.9 v -56.693 z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6161" />
-        <rect
-           x="226.77"
-           y="-1442.1"
-           width="226.77"
-           height="226.77"
-           opacity="1"
-           id="rect6163" />
-        <path
-           d="m 318.9,-1360.1 21.26,-18.209 21.26,18.209"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6165" />
+    <g transform="matrix(1,0,0,-1,226.77,-2430.7)" id="g6169">
+      <title id="title6159">Icon Light Cargo Shuttle</title>
+      <g fill="none" id="g6167">
+        <path d="m 361.42,-1335.8 v 56.693 H 318.9 v -56.693 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6161"/>
+        <rect x="226.77" y="-1442.1" width="226.77" height="226.77" opacity="1" id="rect6163"/>
+        <path d="m 318.9,-1360.1 21.26,-18.209 21.26,18.209" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6165"/>
       </g>
     </g>
-    <g
-       transform="matrix(1,0,0,-1,-226.77,-2430.7)"
-       fill="none"
-       id="g6179">
-      <title
-         id="title6171">Icon Heavy Cargo Shuttle</title>
-      <path
-         d="m 375.59,-1350 v 99.213 H 304.724 V -1350 Z"
-         fill="#ffffff"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6173" />
-      <rect
-         x="226.77"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6175" />
-      <path
-         transform="rotate(90)"
-         d="m -1377.5,-304.72 -28.125,-35.433 28.125,-35.433"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6177" />
+    <g transform="matrix(1,0,0,-1,-226.77,-2430.7)" fill="none" id="g6179">
+      <title id="title6171">Icon Heavy Cargo Shuttle</title>
+      <path d="m 375.59,-1350 v 99.213 H 304.724 V -1350 Z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6173"/>
+      <rect x="226.77" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect6175"/>
+      <path transform="rotate(90)" d="m -1377.5,-304.72 -28.125,-35.433 28.125,-35.433" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6177"/>
     </g>
-    <g
-       transform="rotate(90,113.39,-1102)"
-       fill="none"
-       id="g6191">
-      <title
-         id="title6181">Icon Medium Cargo Transport</title>
-      <g
-         fill="none"
-         id="g6189">
-        <path
-           d="m 375.59,-1350 v 99.213 H 304.724 V -1350 Z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6183" />
-        <rect
-           x="226.77"
-           y="-1442.1"
-           width="226.77"
-           height="226.77"
-           opacity="1"
-           id="rect6185" />
-        <path
-           transform="rotate(90)"
-           d="m -1377.5,-304.72 -28.125,-35.433 28.125,-35.433"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6187" />
+    <g transform="rotate(90,113.39,-1102)" fill="none" id="g6191">
+      <title id="title6181">Icon Medium Cargo Transport</title>
+      <g fill="none" id="g6189">
+        <path d="m 375.59,-1350 v 99.213 H 304.724 V -1350 Z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6183"/>
+        <rect x="226.77" y="-1442.1" width="226.77" height="226.77" opacity="1" id="rect6185"/>
+        <path transform="rotate(90)" d="m -1377.5,-304.72 -28.125,-35.433 28.125,-35.433" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6187"/>
       </g>
     </g>
-    <g
-       transform="rotate(90,226.77,-988.58)"
-       id="g6203">
-      <title
-         id="title6193">Icon Light Cargo Transport</title>
-      <g
-         fill="none"
-         id="g6201">
-        <path
-           d="m 361.42,-1335.8 v 56.693 H 318.9 v -56.693 z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6195" />
-        <rect
-           x="226.77"
-           y="-1442.1"
-           width="226.77"
-           height="226.77"
-           opacity="1"
-           id="rect6197" />
-        <path
-           d="m 318.9,-1360.1 21.26,-18.209 21.26,18.209"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6199" />
+    <g transform="rotate(90,226.77,-988.58)" id="g6203">
+      <title id="title6193">Icon Light Cargo Transport</title>
+      <g fill="none" id="g6201">
+        <path d="m 361.42,-1335.8 v 56.693 H 318.9 v -56.693 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6195"/>
+        <rect x="226.77" y="-1442.1" width="226.77" height="226.77" opacity="1" id="rect6197"/>
+        <path d="m 318.9,-1360.1 21.26,-18.209 21.26,18.209" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6199"/>
       </g>
     </g>
-    <g
-       transform="rotate(90,5.6221e-5,-1215.4)"
-       fill="none"
-       id="g6213">
-      <title
-         id="title6205">Icon Heavy Cargo Transport</title>
-      <path
-         d="m 375.59,-1350 v 99.213 H 304.724 V -1350 Z"
-         fill="#ffffff"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6207" />
-      <rect
-         x="226.77"
-         y="-1442.1"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6209" />
-      <path
-         transform="rotate(90)"
-         d="m -1377.5,-304.72 -28.125,-35.433 28.125,-35.433"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6211" />
+    <g transform="rotate(90,5.6221e-5,-1215.4)" fill="none" id="g6213">
+      <title id="title6205">Icon Heavy Cargo Transport</title>
+      <path d="m 375.59,-1350 v 99.213 H 304.724 V -1350 Z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6207"/>
+      <rect x="226.77" y="-1442.1" width="226.77" height="226.77" fill="none" opacity="1" id="rect6209"/>
+      <path transform="rotate(90)" d="m -1377.5,-304.72 -28.125,-35.433 28.125,-35.433" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6211"/>
     </g>
-    <g
-       clip-rule="evenodd"
-       fill-rule="evenodd"
-       stroke-linejoin="round"
-       stroke-miterlimit="1.4142"
-       id="g6311">
-      <g
-         id="Guided"
-         transform="matrix(6.3481,0,0,6.3481,-128.29,-2822.3)">
-        <g
-           transform="matrix(0,0.40132,-0.65416,0,429.09,464.22)"
-           id="g6217">
-          <rect
-             x="102.18"
-             y="412.70001"
-             width="79.737"
-             height="97.834999"
-             fill-opacity="0"
-             id="rect6215" />
+    <g clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.4142" id="g6311">
+      <g id="Guided" transform="matrix(6.3481,0,0,6.3481,-128.29,-2822.3)">
+        <g transform="matrix(0,0.40132,-0.65416,0,429.09,464.22)" id="g6217">
+          <rect x="102.18" y="412.70001" width="79.737" height="97.834999" fill-opacity="0" id="rect6215"/>
         </g>
-        <g
-           transform="matrix(0,1.2845,-1.2845,0,719.29,466.75)"
-           id="g6239">
-          <g
-             transform="matrix(0.10033,0,0,0.39432,28.159,279.9)"
-             id="g6221">
-            <path
-               d="m 181.92,422.24 c 0,-12.06 -26.579,-13.06 -39.868,-13.06 -13.29,0 -39.869,1 -39.869,13.06 v 84.255 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z"
-               fill="#ffffff"
-               id="path6219" />
+        <g transform="matrix(0,1.2845,-1.2845,0,719.29,466.75)" id="g6239">
+          <g transform="matrix(0.10033,0,0,0.39432,28.159,279.9)" id="g6221">
+            <path d="m 181.92,422.24 c 0,-12.06 -26.579,-13.06 -39.868,-13.06 -13.29,0 -39.869,1 -39.869,13.06 v 84.255 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z" fill="#ffffff" id="path6219"/>
           </g>
-          <g
-             transform="matrix(1,0,0,1.3667,0,-179.55)"
-             id="g6225">
-            <path
-               d="m 41.471,483.32 c 0.144,-0.289 0.52,-0.481 0.94,-0.481 0.421,0 0.797,0.192 0.941,0.481 0.54,1.086 1.113,2.235 1.113,2.235 h -4.107 c 0,0 0.572,-1.149 1.113,-2.235 z"
-               fill="#ffffff"
-               id="path6223" />
+          <g transform="matrix(1,0,0,1.3667,0,-179.55)" id="g6225">
+            <path d="m 41.471,483.32 c 0.144,-0.289 0.52,-0.481 0.94,-0.481 0.421,0 0.797,0.192 0.941,0.481 0.54,1.086 1.113,2.235 1.113,2.235 h -4.107 c 0,0 0.572,-1.149 1.113,-2.235 z" fill="#ffffff" id="path6223"/>
           </g>
-          <g
-             transform="matrix(0.69214,0,0,2.4253,13.057,-675.11)"
-             id="g6229">
-            <rect
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999"
-               id="rect6227" />
+          <g transform="matrix(0.69214,0,0,2.4253,13.057,-675.11)" id="g6229">
+            <rect x="38.410999" y="463.29999" width="8" height="0.82499999" id="rect6227"/>
           </g>
-          <g
-             transform="matrix(0.69214,0,0,2.4253,13.057,-671.18)"
-             id="g6233">
-            <rect
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999"
-               id="rect6231" />
+          <g transform="matrix(0.69214,0,0,2.4253,13.057,-671.18)" id="g6233">
+            <rect x="38.410999" y="463.29999" width="8" height="0.82499999" id="rect6231"/>
           </g>
-          <g
-             transform="matrix(1.2389,0,0,0.56491,-10.132,141.73)"
-             id="g6237">
-            <path
-               d="m 42.411,583.12 7.134,14.268 H 35.278 Z"
-               fill="#ffffff"
-               id="path6235" />
+          <g transform="matrix(1.2389,0,0,0.56491,-10.132,141.73)" id="g6237">
+            <path d="m 42.411,583.12 7.134,14.268 H 35.278 Z" fill="#ffffff" id="path6235"/>
           </g>
         </g>
       </g>
-      <g
-         id="Naval"
-         transform="matrix(6.3481,0,0,6.3481,762.4,-3630.7)">
-        <g
-           transform="matrix(0,0.40132,-0.65416,0,431.3,591.57)"
-           id="g6244">
-          <rect
-             x="102.18"
-             y="412.70001"
-             width="79.737"
-             height="97.834999"
-             fill-opacity="0"
-             id="rect6242" />
+      <g id="Naval" transform="matrix(6.3481,0,0,6.3481,762.4,-3630.7)">
+        <g transform="matrix(0,0.40132,-0.65416,0,431.3,591.57)" id="g6244">
+          <rect x="102.18" y="412.70001" width="79.737" height="97.834999" fill-opacity="0" id="rect6242"/>
         </g>
-        <g
-           transform="matrix(0,1.279,-1.279,0,718.84,594.33)"
-           id="g6262">
-          <g
-             transform="matrix(0.10033,0,0,0.39432,28.159,279.9)"
-             id="g6248">
-            <path
-               d="m 181.92,430.27 c 0,-12.059 -39.868,-21.179 -39.868,-21.179 0,0 -39.869,9.12 -39.869,21.179 v 76.225 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z"
-               fill="#ffffff"
-               id="path6246" />
+        <g transform="matrix(0,1.279,-1.279,0,718.84,594.33)" id="g6262">
+          <g transform="matrix(0.10033,0,0,0.39432,28.159,279.9)" id="g6248">
+            <path d="m 181.92,430.27 c 0,-12.059 -39.868,-21.179 -39.868,-21.179 0,0 -39.869,9.12 -39.869,21.179 v 76.225 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z" fill="#ffffff" id="path6246"/>
           </g>
-          <g
-             transform="matrix(1,0,0,1.3667,0,-179.55)"
-             id="g6252">
-            <path
-               d="m 41.467,483.33 c 0.145,-0.29 0.522,-0.483 0.944,-0.483 0.423,0 0.8,0.193 0.945,0.483 0.539,1.083 1.109,2.227 1.109,2.227 h -4.107 c 0,0 0.57,-1.144 1.109,-2.227 z"
-               fill="#ffffff"
-               id="path6250" />
+          <g transform="matrix(1,0,0,1.3667,0,-179.55)" id="g6252">
+            <path d="m 41.467,483.33 c 0.145,-0.29 0.522,-0.483 0.944,-0.483 0.423,0 0.8,0.193 0.945,0.483 0.539,1.083 1.109,2.227 1.109,2.227 h -4.107 c 0,0 0.57,-1.144 1.109,-2.227 z" fill="#ffffff" id="path6250"/>
           </g>
-          <g
-             transform="matrix(0.85577,0,0,0.66028,7.3915,44.788)"
-             id="g6256">
-            <rect
-               x="30.594"
-               y="648.10999"
-               width="20.655001"
-               height="9.3050003"
-               fill="#ffffff"
-               id="rect6254" />
+          <g transform="matrix(0.85577,0,0,0.66028,7.3915,44.788)" id="g6256">
+            <rect x="30.594" y="648.10999" width="20.655001" height="9.3050003" fill="#ffffff" id="rect6254"/>
           </g>
-          <g
-             transform="matrix(0.85577,0,0,0.40641,7.3915,190.32)"
-             id="g6260">
-            <rect
-               x="30.594"
-               y="648.10999"
-               width="20.655001"
-               height="9.3050003"
-               fill="#ffffff"
-               id="rect6258" />
+          <g transform="matrix(0.85577,0,0,0.40641,7.3915,190.32)" id="g6260">
+            <rect x="30.594" y="648.10999" width="20.655001" height="9.3050003" fill="#ffffff" id="rect6258"/>
           </g>
         </g>
       </g>
-      <g
-         id="Dumb"
-         transform="matrix(6.3481,0,0,6.3481,-580.61,-2504.4)">
-        <g
-           transform="matrix(0,0.40132,-0.65416,0,429.41,414.15)"
-           id="g6267">
-          <rect
-             x="102.18"
-             y="412.70001"
-             width="79.737"
-             height="97.834999"
-             fill-opacity="0"
-             id="rect6265" />
+      <g id="Dumb" transform="matrix(6.3481,0,0,6.3481,-580.61,-2504.4)">
+        <g transform="matrix(0,0.40132,-0.65416,0,429.41,414.15)" id="g6267">
+          <rect x="102.18" y="412.70001" width="79.737" height="97.834999" fill-opacity="0" id="rect6265"/>
         </g>
-        <g
-           transform="matrix(0,1.2834,-1.2834,0,719.11,416.72)"
-           id="g6277">
-          <g
-             transform="matrix(0.10033,0,0,0.40885,28.159,272.49)"
-             id="g6271">
-            <path
-               d="m 181.92,415.24 c 0,-1.404 -4.645,-2.544 -10.366,-2.544 h -59.005 c -5.721,0 -10.366,1.14 -10.366,2.544 v 92.747 c 0,1.404 4.645,2.544 10.366,2.544 h 59.005 c 5.721,0 10.366,-1.14 10.366,-2.544 z"
-               fill="#ffffff"
-               id="path6269" />
+        <g transform="matrix(0,1.2834,-1.2834,0,719.11,416.72)" id="g6277">
+          <g transform="matrix(0.10033,0,0,0.40885,28.159,272.49)" id="g6271">
+            <path d="m 181.92,415.24 c 0,-1.404 -4.645,-2.544 -10.366,-2.544 h -59.005 c -5.721,0 -10.366,1.14 -10.366,2.544 v 92.747 c 0,1.404 4.645,2.544 10.366,2.544 h 59.005 c 5.721,0 10.366,-1.14 10.366,-2.544 z" fill="#ffffff" id="path6269"/>
           </g>
-          <g
-             transform="matrix(1,0,0,1.3667,0,-179.55)"
-             id="g6275">
-            <path
-               d="m 42.411,481.43 2.054,4.123 h -4.107 z"
-               fill="#ffffff"
-               id="path6273" />
+          <g transform="matrix(1,0,0,1.3667,0,-179.55)" id="g6275">
+            <path d="m 42.411,481.43 2.054,4.123 h -4.107 z" fill="#ffffff" id="path6273"/>
           </g>
         </g>
       </g>
-      <g
-         id="Smart"
-         transform="matrix(6.3481,0,0,6.3481,312.2,-3249.6)">
-        <g
-           transform="matrix(0,0.40132,-0.65416,0,431.3,531.54)"
-           id="g6282">
-          <rect
-             x="102.18"
-             y="412.70001"
-             width="79.737"
-             height="97.834999"
-             fill-opacity="0"
-             id="rect6280" />
+      <g id="Smart" transform="matrix(6.3481,0,0,6.3481,312.2,-3249.6)">
+        <g transform="matrix(0,0.40132,-0.65416,0,431.3,531.54)" id="g6282">
+          <rect x="102.18" y="412.70001" width="79.737" height="97.834999" fill-opacity="0" id="rect6280"/>
         </g>
-        <g
-           transform="matrix(0,1.279,-1.279,0,718.84,534.26)"
-           id="g6308">
-          <g
-             transform="matrix(0.10033,0,0,0.39432,28.159,279.9)"
-             id="g6286">
-            <path
-               d="m 181.92,430.27 c 0,-12.059 -26.579,-21.179 -39.868,-21.179 -13.29,0 -39.869,9.12 -39.869,21.179 v 76.225 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z"
-               fill="#ffffff"
-               id="path6284" />
+        <g transform="matrix(0,1.279,-1.279,0,718.84,534.26)" id="g6308">
+          <g transform="matrix(0.10033,0,0,0.39432,28.159,279.9)" id="g6286">
+            <path d="m 181.92,430.27 c 0,-12.059 -26.579,-21.179 -39.868,-21.179 -13.29,0 -39.869,9.12 -39.869,21.179 v 76.225 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z" fill="#ffffff" id="path6284"/>
           </g>
-          <g
-             transform="matrix(1,0,0,1.3667,0,-179.55)"
-             id="g6290">
-            <path
-               d="m 41.467,483.33 c 0.145,-0.29 0.522,-0.483 0.944,-0.483 0.423,0 0.8,0.193 0.945,0.483 0.539,1.083 1.109,2.227 1.109,2.227 h -4.107 c 0,0 0.57,-1.144 1.109,-2.227 z"
-               fill="#ffffff"
-               id="path6288" />
+          <g transform="matrix(1,0,0,1.3667,0,-179.55)" id="g6290">
+            <path d="m 41.467,483.33 c 0.145,-0.29 0.522,-0.483 0.944,-0.483 0.423,0 0.8,0.193 0.945,0.483 0.539,1.083 1.109,2.227 1.109,2.227 h -4.107 c 0,0 0.57,-1.144 1.109,-2.227 z" fill="#ffffff" id="path6288"/>
           </g>
-          <g
-             transform="matrix(0.69214,0,0,2.4253,13.057,-675.11)"
-             id="g6294">
-            <rect
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999"
-               id="rect6292" />
+          <g transform="matrix(0.69214,0,0,2.4253,13.057,-675.11)" id="g6294">
+            <rect x="38.410999" y="463.29999" width="8" height="0.82499999" id="rect6292"/>
           </g>
-          <g
-             transform="matrix(0.69214,0,0,2.4253,13.057,-671.18)"
-             id="g6298">
-            <rect
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999"
-               id="rect6296" />
+          <g transform="matrix(0.69214,0,0,2.4253,13.057,-671.18)" id="g6298">
+            <rect x="38.410999" y="463.29999" width="8" height="0.82499999" id="rect6296"/>
           </g>
-          <g
-             transform="matrix(0.69214,0,0,2.4253,13.057,-667.01)"
-             id="g6302">
-            <rect
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999"
-               id="rect6300" />
+          <g transform="matrix(0.69214,0,0,2.4253,13.057,-667.01)" id="g6302">
+            <rect x="38.410999" y="463.29999" width="8" height="0.82499999" id="rect6300"/>
           </g>
-          <g
-             transform="matrix(1.2389,0,0,1,-10.132,-118.52)"
-             id="g6306">
-            <path
-               d="m 42.411,583.12 7.134,14.268 H 35.278 Z"
-               fill="#ffffff"
-               id="path6304" />
+          <g transform="matrix(1.2389,0,0,1,-10.132,-118.52)" id="g6306">
+            <path d="m 42.411,583.12 7.134,14.268 H 35.278 Z" fill="#ffffff" id="path6304"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0,1,1,0,5977.6,-2802.8)"
-       id="g6317">
-      <path
-         d="m 1626.7,-2507.2 a 25.171,25.171 0 0 0 -25.171,25.171 25.171,25.171 0 0 0 25.171,25.171 25.171,25.171 0 0 0 25.171,-25.171 25.171,25.171 0 0 0 -25.171,-25.171 z m 103.12,0.049 c -2.3328,-0.01 -4.2576,0.6216 -5.5988,1.9629 -3.4339,3.4336 -2.2083,10.692 2.4722,18.827 -0.2958,1.3946 -0.4439,2.8422 -0.4439,4.3318 0,11.675 9.4562,21.131 21.131,21.131 1.4897,0 2.9361,-0.1481 4.3317,-0.4439 8.1353,4.6804 15.394,5.9061 18.827,2.4723 3.4337,-3.4338 2.2083,-10.692 -2.4721,-18.827 0.2947,-1.3947 0.4436,-2.8421 0.4436,-4.3318 0,-11.675 -9.4559,-21.131 -21.131,-21.131 -1.4896,0 -2.9374,0.1479 -4.332,0.4437 -4.9573,-2.8521 -9.5891,-4.4214 -13.228,-4.4351 z m 0.5386,4.8958 c 1.6625,0 3.8507,0.7293 6.34,1.9905 -1.7644,1.0354 -3.3491,2.3139 -4.7321,3.793 4.4586,11.178 18.838,25.452 30.047,29.689 1.4475,-1.384 2.6953,-2.9795 3.698,-4.7333 1.6693,3.6239 2.0918,6.8464 0.6444,9.1284 -12.774,4.0889 -44.925,-32.478 -38.373,-39.039 0.5704,-0.5666 1.3788,-0.8285 2.3763,-0.8283 z m -49.83,9.5151 a 10.711,10.711 0 0 0 -10.711,10.711 10.711,10.711 0 0 0 10.711,10.711 10.711,10.711 0 0 0 10.711,-10.711 10.711,10.711 0 0 0 -10.711,-10.711 z m 110.86,2.1422 a 8.569,8.569 0 0 0 -8.5689,8.569 8.569,8.569 0 0 0 8.5689,8.5689 8.569,8.569 0 0 0 8.5691,-8.5689 8.569,8.569 0 0 0 -8.5691,-8.569 z m -83.547,0.8034 a 7.7656,7.7656 0 0 0 -7.7657,7.7656 7.7656,7.7656 0 0 0 7.7657,7.7656 7.7656,7.7656 0 0 0 7.7656,-7.7656 7.7656,7.7656 0 0 0 -7.7656,-7.7656 z m 0,30.527 a 4.5523,4.5523 0 0 0 -4.5522,4.5522 4.5523,4.5523 0 0 0 4.5522,4.5523 4.5523,4.5523 0 0 0 4.5523,-4.5523 4.5523,4.5523 0 0 0 -4.5523,-4.5522 z m 85.957,0.5355 a 3.2134,3.2134 0 0 0 -3.2133,3.2134 3.2134,3.2134 0 0 0 3.2133,3.2134 3.2134,3.2134 0 0 0 3.2133,-3.2134 3.2134,3.2134 0 0 0 -3.2133,-3.2134 z m -46.419,14.192 a 4.0167,4.0167 0 0 0 -4.0167,4.0166 4.0167,4.0167 0 0 0 4.0167,4.0168 4.0167,4.0167 0 0 0 4.0166,-4.0168 4.0167,4.0167 0 0 0 -4.0166,-4.0166 z m 0,17.406 a 4.5523,4.5523 0 0 0 -4.5523,4.5522 4.5523,4.5523 0 0 0 4.5523,4.5523 4.5523,4.5523 0 0 0 4.5522,-4.5523 4.5523,4.5523 0 0 0 -4.5522,-4.5522 z"
-         fill="#ffffff"
-         id="path6313" />
-      <rect
-         x="1587.4"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6315" />
+    <g transform="matrix(0,1,1,0,5977.6,-2802.8)" id="g6317">
+      <path d="m 1626.7,-2507.2 a 25.171,25.171 0 0 0 -25.171,25.171 25.171,25.171 0 0 0 25.171,25.171 25.171,25.171 0 0 0 25.171,-25.171 25.171,25.171 0 0 0 -25.171,-25.171 z m 103.12,0.049 c -2.3328,-0.01 -4.2576,0.6216 -5.5988,1.9629 -3.4339,3.4336 -2.2083,10.692 2.4722,18.827 -0.2958,1.3946 -0.4439,2.8422 -0.4439,4.3318 0,11.675 9.4562,21.131 21.131,21.131 1.4897,0 2.9361,-0.1481 4.3317,-0.4439 8.1353,4.6804 15.394,5.9061 18.827,2.4723 3.4337,-3.4338 2.2083,-10.692 -2.4721,-18.827 0.2947,-1.3947 0.4436,-2.8421 0.4436,-4.3318 0,-11.675 -9.4559,-21.131 -21.131,-21.131 -1.4896,0 -2.9374,0.1479 -4.332,0.4437 -4.9573,-2.8521 -9.5891,-4.4214 -13.228,-4.4351 z m 0.5386,4.8958 c 1.6625,0 3.8507,0.7293 6.34,1.9905 -1.7644,1.0354 -3.3491,2.3139 -4.7321,3.793 4.4586,11.178 18.838,25.452 30.047,29.689 1.4475,-1.384 2.6953,-2.9795 3.698,-4.7333 1.6693,3.6239 2.0918,6.8464 0.6444,9.1284 -12.774,4.0889 -44.925,-32.478 -38.373,-39.039 0.5704,-0.5666 1.3788,-0.8285 2.3763,-0.8283 z m -49.83,9.5151 a 10.711,10.711 0 0 0 -10.711,10.711 10.711,10.711 0 0 0 10.711,10.711 10.711,10.711 0 0 0 10.711,-10.711 10.711,10.711 0 0 0 -10.711,-10.711 z m 110.86,2.1422 a 8.569,8.569 0 0 0 -8.5689,8.569 8.569,8.569 0 0 0 8.5689,8.5689 8.569,8.569 0 0 0 8.5691,-8.5689 8.569,8.569 0 0 0 -8.5691,-8.569 z m -83.547,0.8034 a 7.7656,7.7656 0 0 0 -7.7657,7.7656 7.7656,7.7656 0 0 0 7.7657,7.7656 7.7656,7.7656 0 0 0 7.7656,-7.7656 7.7656,7.7656 0 0 0 -7.7656,-7.7656 z m 0,30.527 a 4.5523,4.5523 0 0 0 -4.5522,4.5522 4.5523,4.5523 0 0 0 4.5522,4.5523 4.5523,4.5523 0 0 0 4.5523,-4.5523 4.5523,4.5523 0 0 0 -4.5523,-4.5522 z m 85.957,0.5355 a 3.2134,3.2134 0 0 0 -3.2133,3.2134 3.2134,3.2134 0 0 0 3.2133,3.2134 3.2134,3.2134 0 0 0 3.2133,-3.2134 3.2134,3.2134 0 0 0 -3.2133,-3.2134 z m -46.419,14.192 a 4.0167,4.0167 0 0 0 -4.0167,4.0166 4.0167,4.0167 0 0 0 4.0167,4.0168 4.0167,4.0167 0 0 0 4.0166,-4.0168 4.0167,4.0167 0 0 0 -4.0166,-4.0166 z m 0,17.406 a 4.5523,4.5523 0 0 0 -4.5523,4.5522 4.5523,4.5523 0 0 0 4.5523,4.5523 4.5523,4.5523 0 0 0 4.5522,-4.5523 4.5523,4.5523 0 0 0 -4.5522,-4.5522 z" fill="#ffffff" id="path6313"/>
+      <rect x="1587.4" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect6315"/>
     </g>
-    <g
-       transform="matrix(-1,0,0,1,6576.4,1360.6)"
-       id="g6327">
-      <desc
-         id="desc6319">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6321" />
-      <path
-         transform="matrix(0.469,0,0,0.46614,1572.4,-1167.2)"
-         d="m 3174.8,-2278.7 -143.78,-181.25 h 287.56 z"
-         fill="#ffffff"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="30.313"
-         id="path6323" />
-      <rect
-         transform="scale(-1,1)"
-         x="-3075.7"
-         y="-2249.8999"
-         width="28.431"
-         height="99.138"
-         rx="14.031"
-         ry="14.031"
-         fill="#ffffff"
-         stroke-width="0.96536"
-         id="rect6325" />
+    <g transform="matrix(-1,0,0,1,6576.4,1360.6)" id="g6327">
+      <desc id="desc6319">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6321"/>
+      <path transform="matrix(0.469,0,0,0.46614,1572.4,-1167.2)" d="m 3174.8,-2278.7 -143.78,-181.25 h 287.56 z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="30.313" id="path6323"/>
+      <rect transform="scale(-1,1)" x="-3075.7" y="-2249.8999" width="28.431" height="99.138" rx="14.031" ry="14.031" fill="#ffffff" stroke-width="0.96536" id="rect6325"/>
     </g>
-    <g
-       transform="translate(5215.7,680.31)"
-       id="g6343">
-      <g
-         transform="matrix(-5.8137,1.5621,1.5716,5.8815,-1649.3,-10871)"
-         opacity="1"
-         id="g6339">
-        <g
-           transform="translate(1.8438,0.47874)"
-           stroke-width="5.1621"
-           id="g6337">
-          <g
-             transform="matrix(-0.2581,-0.95479,0.97719,-0.25954,-899.89,2282.6)"
-             id="g6331">
-            <path
-               d="m 445.05,1486.1 5.0988,-5.0541 5.1785,5.133 m -5.2183,17.489 v -20.569"
-               fill="none"
-               opacity="1"
-               stroke="#ffffff"
-               stroke-linecap="round"
-               stroke-linejoin="round"
-               stroke-width="5.1621"
-               id="path6329" />
+    <g transform="translate(5215.7,680.31)" id="g6343">
+      <g transform="matrix(-5.8137,1.5621,1.5716,5.8815,-1649.3,-10871)" opacity="1" id="g6339">
+        <g transform="translate(1.8438,0.47874)" stroke-width="5.1621" id="g6337">
+          <g transform="matrix(-0.2581,-0.95479,0.97719,-0.25954,-899.89,2282.6)" id="g6331">
+            <path d="m 445.05,1486.1 5.0988,-5.0541 5.1785,5.133 m -5.2183,17.489 v -20.569" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.1621" id="path6329"/>
           </g>
-          <g
-             transform="matrix(-0.2581,-0.95479,-0.97719,0.25954,2016.8,1507.9)"
-             id="g6335">
-            <path
-               d="m 445.05,1486.1 5.0988,-5.0541 5.1785,5.133 m -5.2183,17.489 v -20.569"
-               fill="none"
-               opacity="1"
-               stroke="#ffffff"
-               stroke-linecap="round"
-               stroke-linejoin="round"
-               stroke-width="5.1621"
-               id="path6333" />
+          <g transform="matrix(-0.2581,-0.95479,-0.97719,0.25954,2016.8,1507.9)" id="g6335">
+            <path d="m 445.05,1486.1 5.0988,-5.0541 5.1785,5.133 m -5.2183,17.489 v -20.569" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.1621" id="path6333"/>
           </g>
         </g>
       </g>
-      <rect
-         x="-2040.9"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6341" />
+      <rect x="-2040.9" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect6341"/>
     </g>
-    <path
-       d="m 1079.9,237.86 c -5.9897,-14.96 4.6104,-34.431 -5.2806,-50.601 -13.044,-21.304 -68.212,-42.901 -104.03,-5.7201 -16.59,17.197 -5.5169,34.394 -7.9207,49.061 -2.8718,21.656 -25.299,21.002 -25.299,36.668 42.756,11.294 32.629,-7.9936 93.472,-7.8102 27.9,0.10854 17.221,11.44 72.035,11.477 -6.5415,-18.151 -16.826,-17.747 -22.974,-33.074 z"
-       fill="#ffffff"
-       stroke="#ffffff"
-       stroke-width="3.8012"
-       id="path6345" />
-    <rect
-       x="907.09003"
-       y="145.28"
-       width="226.77"
-       height="226.77"
-       fill="none"
-       opacity="1"
-       id="rect6347" />
-    <path
-       d="m 954.37,306.4 c 10.539,-14.549 24.131,-22.072 47.099,-24.491 4.1429,-0.8791 7.2684,-4.76 7.2684,-9.3664 0,-3.3741 -10.248,-13.474 -10.176,-13.546 -10.575,-11.554 -16.245,-30.326 -16.245,-44.759 0,-22.418 17.081,-40.613 38.159,-40.613 21.078,0 38.159,18.195 38.159,40.613 0,14.51 -5.5239,33.396 -16.208,44.951 0,0 -10.212,9.9843 -10.212,13.355 0,4.879 3.4887,8.9441 7.9951,9.5199 22.496,2.4952 35.942,9.9805 46.372,24.337 3.0163,4.1458 4.6516,12.476 4.7607,16.928 -0.036,1.1516 0,19.193 0,19.193 0,8.4833 -6.5054,15.355 -14.537,15.355 h -112.66 c -8.0315,0 -14.537,-6.8713 -14.537,-15.355 0,0 0.036,-18.042 0,-19.193 0.109,-4.4528 1.7444,-12.783 4.7608,-16.928 z"
-       fill="#a4a4a4"
-       opacity="1"
-       id="path6349" />
-    <g
-       transform="translate(-5896.1,2721.3)"
-       id="g6361">
-      <rect
-         x="8163.7998"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6351" />
-      <g
-         stroke="#ffffee"
-         stroke-linecap="round"
-         stroke-miterlimit="0"
-         stroke-width="14.173"
-         id="g6359">
-        <path
-           d="m 8277.2,-2462.6 87.927,65.98"
-           fill="#fffff6"
-           marker-end="url(#Arrow2Send)"
-           id="path6353" />
-        <path
-           d="m 8277.2,-2462.6 v -70.866"
-           fill="#ffeeff"
-           marker-end="url(#marker8458)"
-           id="path6355" />
-        <path
-           d="m 8277.2,-2462.6 -78.766,42.227"
-           fill="#fffffd"
-           marker-end="url(#marker8674)"
-           id="path6357" />
+    <path d="m 1079.9,237.86 c -5.9897,-14.96 4.6104,-34.431 -5.2806,-50.601 -13.044,-21.304 -68.212,-42.901 -104.03,-5.7201 -16.59,17.197 -5.5169,34.394 -7.9207,49.061 -2.8718,21.656 -25.299,21.002 -25.299,36.668 42.756,11.294 32.629,-7.9936 93.472,-7.8102 27.9,0.10854 17.221,11.44 72.035,11.477 -6.5415,-18.151 -16.826,-17.747 -22.974,-33.074 z" fill="#ffffff" stroke="#ffffff" stroke-width="3.8012" id="path6345"/>
+    <rect x="907.09003" y="145.28" width="226.77" height="226.77" fill="none" opacity="1" id="rect6347"/>
+    <path d="m 954.37,306.4 c 10.539,-14.549 24.131,-22.072 47.099,-24.491 4.1429,-0.8791 7.2684,-4.76 7.2684,-9.3664 0,-3.3741 -10.248,-13.474 -10.176,-13.546 -10.575,-11.554 -16.245,-30.326 -16.245,-44.759 0,-22.418 17.081,-40.613 38.159,-40.613 21.078,0 38.159,18.195 38.159,40.613 0,14.51 -5.5239,33.396 -16.208,44.951 0,0 -10.212,9.9843 -10.212,13.355 0,4.879 3.4887,8.9441 7.9951,9.5199 22.496,2.4952 35.942,9.9805 46.372,24.337 3.0163,4.1458 4.6516,12.476 4.7607,16.928 -0.036,1.1516 0,19.193 0,19.193 0,8.4833 -6.5054,15.355 -14.537,15.355 h -112.66 c -8.0315,0 -14.537,-6.8713 -14.537,-15.355 0,0 0.036,-18.042 0,-19.193 0.109,-4.4528 1.7444,-12.783 4.7608,-16.928 z" fill="#a4a4a4" opacity="1" id="path6349"/>
+    <g transform="translate(-5896.1,2721.3)" id="g6361">
+      <rect x="8163.7998" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect6351"/>
+      <g stroke="#ffffee" stroke-linecap="round" stroke-miterlimit="0" stroke-width="14.173" id="g6359">
+        <path d="m 8277.2,-2462.6 87.927,65.98" fill="#fffff6" marker-end="url(#Arrow2Send)" id="path6353"/>
+        <path d="m 8277.2,-2462.6 v -70.866" fill="#ffeeff" marker-end="url(#marker8458)" id="path6355"/>
+        <path d="m 8277.2,-2462.6 -78.766,42.227" fill="#fffffd" marker-end="url(#marker8674)" id="path6357"/>
       </g>
     </g>
-    <g
-       transform="translate(-5669.3,2721.3)"
-       fill="none"
-       id="g6375">
-      <rect
-         x="8163.7998"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect6363" />
-      <g
-         stroke="#ffffee"
-         stroke-width="8.8583"
-         id="g6373">
-        <rect
-           x="8204.5996"
-           y="-2462.6001"
-           width="72.536003"
-           height="72.536003"
-           ry="0"
-           id="rect6365" />
-        <rect
-           x="8204.5996"
-           y="-2535.1001"
-           width="72.536003"
-           height="72.536003"
-           ry="0"
-           id="rect6367" />
-        <rect
-           x="8277.2002"
-           y="-2535.1001"
-           width="72.536003"
-           height="72.536003"
-           ry="0"
-           id="rect6369" />
-        <rect
-           x="8277.2002"
-           y="-2462.6001"
-           width="72.535004"
-           height="72.536003"
-           ry="0"
-           id="rect6371" />
+    <g transform="translate(-5669.3,2721.3)" fill="none" id="g6375">
+      <rect x="8163.7998" y="-2576" width="226.77" height="226.77" opacity="1" id="rect6363"/>
+      <g stroke="#ffffee" stroke-width="8.8583" id="g6373">
+        <rect x="8204.5996" y="-2462.6001" width="72.536003" height="72.536003" ry="0" id="rect6365"/>
+        <rect x="8204.5996" y="-2535.1001" width="72.536003" height="72.536003" ry="0" id="rect6367"/>
+        <rect x="8277.2002" y="-2535.1001" width="72.536003" height="72.536003" ry="0" id="rect6369"/>
+        <rect x="8277.2002" y="-2462.6001" width="72.535004" height="72.536003" ry="0" id="rect6371"/>
       </g>
     </g>
-    <g
-       transform="translate(-5215.7,2267.7)"
-       fill="none"
-       id="g6391">
-      <rect
-         x="8163.7998"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect6377" />
-      <g
-         stroke="#fffff4"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         id="g6389">
-        <path
-           d="m 8278.8,-2541.2 78.607,78.607 -78.607,78.607 -78.607,-78.607 78.607,-78.607"
-           stroke-width="10.63"
-           id="path6379" />
-        <g
-           stroke-width="8.8583"
-           id="g6387">
-          <path
-             d="m 8222.1,-2519.3 113.39,113.39"
-             id="path6381" />
-          <path
-             d="m 8335.5,-2519.3 -113.39,113.39"
-             id="path6383" />
-          <path
-             d="m 8278.8,-2495.5 32.978,32.978 -32.978,32.978 -32.978,-32.978 32.978,-32.978"
-             id="path6385" />
+    <g transform="translate(-5215.7,2267.7)" fill="none" id="g6391">
+      <rect x="8163.7998" y="-2576" width="226.77" height="226.77" opacity="1" id="rect6377"/>
+      <g stroke="#fffff4" stroke-linecap="round" stroke-linejoin="round" id="g6389">
+        <path d="m 8278.8,-2541.2 78.607,78.607 -78.607,78.607 -78.607,-78.607 78.607,-78.607" stroke-width="10.63" id="path6379"/>
+        <g stroke-width="8.8583" id="g6387">
+          <path d="m 8222.1,-2519.3 113.39,113.39" id="path6381"/>
+          <path d="m 8335.5,-2519.3 -113.39,113.39" id="path6383"/>
+          <path d="m 8278.8,-2495.5 32.978,32.978 -32.978,32.978 -32.978,-32.978 32.978,-32.978" id="path6385"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,2494.5,-308.27)"
-       id="g6397">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect6393"
-         x="0"
-         y="0" />
-      <path
-         d="m 21.868,7.4708 q -1.5875,-1.0895 -5.3074,-1.0895 -3.9377,0 -3.9377,1.821 0,1.4319 4.1089,2.179 3.2374,0.57588 5.0584,2.3191 2.2101,2.1012 2.2101,6.4125 0,4.1245 -2.1323,6.5525 -2.1323,2.4436 -5.8677,2.4436 -3.7198,0 -5.8677,-2.4436 -2.1323,-2.428 -2.1323,-6.7082 0,-3.1751 2.1323,-5.7432 0.8249,-0.99611 1.9922,-1.5564 Q 9.6968,10.428 9.6968,8.2335 9.6968,4 16.5606,4 20.0003,4 21.868,5.0895 Z m -7.5953,4.965 q -1.0584,0.45136 -1.9144,1.5875 -1.3385,1.7588 -1.3385,4.9339 0,3.1595 1.323,4.9339 1.3385,1.7899 3.6576,1.7899 2.2879,0 3.6265,-1.8054 1.3385,-1.8054 1.3385,-4.7626 0,-3.0973 -1.4163,-4.5914 -1.5097,-1.6031 -3.4708,-1.7743 -0.99611,-0.09338 -1.8054,-0.31128 z"
-         fill="#ffffff"
-         id="path6395" />
+    <g transform="matrix(7.0866,0,0,7.0866,2494.5,-308.27)" id="g6397">
+      <rect width="32" height="32" fill="none" id="rect6393" x="0" y="0"/>
+      <path d="m 21.868,7.4708 q -1.5875,-1.0895 -5.3074,-1.0895 -3.9377,0 -3.9377,1.821 0,1.4319 4.1089,2.179 3.2374,0.57588 5.0584,2.3191 2.2101,2.1012 2.2101,6.4125 0,4.1245 -2.1323,6.5525 -2.1323,2.4436 -5.8677,2.4436 -3.7198,0 -5.8677,-2.4436 -2.1323,-2.428 -2.1323,-6.7082 0,-3.1751 2.1323,-5.7432 0.8249,-0.99611 1.9922,-1.5564 Q 9.6968,10.428 9.6968,8.2335 9.6968,4 16.5606,4 20.0003,4 21.868,5.0895 Z m -7.5953,4.965 q -1.0584,0.45136 -1.9144,1.5875 -1.3385,1.7588 -1.3385,4.9339 0,3.1595 1.323,4.9339 1.3385,1.7899 3.6576,1.7899 2.2879,0 3.6265,-1.8054 1.3385,-1.8054 1.3385,-4.7626 0,-3.0973 -1.4163,-4.5914 -1.5097,-1.6031 -3.4708,-1.7743 -0.99611,-0.09338 -1.8054,-0.31128 z" fill="#ffffff" id="path6395"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,2721.3,-308.27)"
-       fill="none"
-       id="g6405">
-      <rect
-         width="32"
-         height="32"
-         id="rect6399"
-         x="0"
-         y="0" />
-      <circle
-         cx="16"
-         cy="16"
-         r="10"
-         stroke="#fffff4"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="2"
-         id="circle6401" />
-      <path
-         d="m 12,16 h 4 l 3.0463,-5.9278"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="2"
-         id="path6403" />
+    <g transform="matrix(7.0866,0,0,7.0866,2721.3,-308.27)" fill="none" id="g6405">
+      <rect width="32" height="32" id="rect6399" x="0" y="0"/>
+      <circle cx="16" cy="16" r="10" stroke="#fffff4" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" id="circle6401"/>
+      <path d="m 12,16 h 4 l 3.0463,-5.9278" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" id="path6403"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,3401.6,-308.27)"
-       id="g6421">
-      <g
-         fill="none"
-         id="g6417">
-        <rect
-           width="32"
-           height="32"
-           id="rect6407"
-           x="0"
-           y="0" />
-        <g
-           stroke-linecap="round"
-           id="g6415">
-          <circle
-             cx="16"
-             cy="16"
-             r="11.315"
-             stroke="#fffff4"
-             stroke-linejoin="round"
-             stroke-width="1.0983"
-             id="circle6409" />
-          <circle
-             cx="16"
-             cy="16"
-             r="6.4327002"
-             stroke="#fffff4"
-             stroke-linejoin="round"
-             stroke-width="2"
-             id="circle6411" />
-          <path
-             d="m 16,3.6342 v 24.731"
-             stroke="#ffffeb"
-             stroke-width="2"
-             id="path6413" />
+    <g transform="matrix(7.0866,0,0,7.0866,3401.6,-308.27)" id="g6421">
+      <g fill="none" id="g6417">
+        <rect width="32" height="32" id="rect6407" x="0" y="0"/>
+        <g stroke-linecap="round" id="g6415">
+          <circle cx="16" cy="16" r="11.315" stroke="#fffff4" stroke-linejoin="round" stroke-width="1.0983" id="circle6409"/>
+          <circle cx="16" cy="16" r="6.4327002" stroke="#fffff4" stroke-linejoin="round" stroke-width="2" id="circle6411"/>
+          <path d="m 16,3.6342 v 24.731" stroke="#ffffeb" stroke-width="2" id="path6413"/>
         </g>
       </g>
-      <circle
-         cx="16"
-         cy="16"
-         r="2.2734001"
-         fill="#ffffff"
-         stroke="#fffff4"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="0.45468"
-         id="circle6419" />
+      <circle cx="16" cy="16" r="2.2734001" fill="#ffffff" stroke="#fffff4" stroke-linecap="round" stroke-linejoin="round" stroke-width="0.45468" id="circle6419"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,3174.8,-308.27)"
-       id="g6441">
-      <g
-         fill="none"
-         id="g6435">
-        <rect
-           width="32"
-           height="32"
-           id="rect6423"
-           x="0"
-           y="0" />
-        <g
-           stroke="#fffff4"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           id="g6431">
-          <path
-             d="M 6.6372,8.1852 C 8.9543,5.4091 12.384,3.8043 16,3.8043"
-             id="path6425" />
-          <path
-             d="m 25.363,23.815 c -2.3171,2.7761 -5.7468,4.3809 -9.3628,4.3809"
-             id="path6427" />
-          <circle
-             cx="16"
-             cy="16"
-             r="6.4327002"
-             stroke-width="2"
-             id="circle6429" />
+    <g transform="matrix(7.0866,0,0,7.0866,3174.8,-308.27)" id="g6441">
+      <g fill="none" id="g6435">
+        <rect width="32" height="32" id="rect6423" x="0" y="0"/>
+        <g stroke="#fffff4" stroke-linecap="round" stroke-linejoin="round" id="g6431">
+          <path d="M 6.6372,8.1852 C 8.9543,5.4091 12.384,3.8043 16,3.8043" id="path6425"/>
+          <path d="m 25.363,23.815 c -2.3171,2.7761 -5.7468,4.3809 -9.3628,4.3809" id="path6427"/>
+          <circle cx="16" cy="16" r="6.4327002" stroke-width="2" id="circle6429"/>
         </g>
-        <path
-           d="m 16,4.1797 v 23.641"
-           stroke="#ffffeb"
-           stroke-linecap="round"
-           stroke-width="1.9554"
-           id="path6433" />
+        <path d="m 16,4.1797 v 23.641" stroke="#ffffeb" stroke-linecap="round" stroke-width="1.9554" id="path6433"/>
       </g>
-      <circle
-         cx="16"
-         cy="16"
-         r="2.2734001"
-         fill="#ffffff"
-         stroke="#fffff4"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="0.45468"
-         id="circle6437" />
-      <path
-         d="m 6.5067,8.0761 18.987,15.848"
-         fill="none"
-         stroke="#ffffeb"
-         stroke-linecap="round"
-         id="path6439" />
+      <circle cx="16" cy="16" r="2.2734001" fill="#ffffff" stroke="#fffff4" stroke-linecap="round" stroke-linejoin="round" stroke-width="0.45468" id="circle6437"/>
+      <path d="m 6.5067,8.0761 18.987,15.848" fill="none" stroke="#ffffeb" stroke-linecap="round" id="path6439"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,3401.6,145.28)"
-       fill="none"
-       id="g6453">
-      <rect
-         width="32"
-         height="32"
-         id="rect6443"
-         x="0"
-         y="0" />
-      <g
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="2.5"
-         id="g6451">
-        <path
-           d="m 20,4 6,12 -6,12"
-           id="path6445" />
-        <path
-           d="M 16,16 H 4"
-           id="path6447" />
-        <path
-           d="M 10,10 V 22"
-           id="path6449" />
+    <g transform="matrix(7.0866,0,0,7.0866,3401.6,145.28)" fill="none" id="g6453">
+      <rect width="32" height="32" id="rect6443" x="0" y="0"/>
+      <g stroke="#ffffff" stroke-linejoin="round" stroke-width="2.5" id="g6451">
+        <path d="m 20,4 6,12 -6,12" id="path6445"/>
+        <path d="M 16,16 H 4" id="path6447"/>
+        <path d="M 10,10 V 22" id="path6449"/>
       </g>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,3174.8,145.28)"
-       id="g6465">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect6455"
-         x="0"
-         y="0" />
-      <path
-         d="M 12,28 6,16 12,4"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="2.5"
-         id="path6457" />
-      <path
-         d="m 14,16 h 8"
-         fill="#ffffff"
-         id="path6459" />
-      <path
-         d="m 14,16 h 8"
-         fill="#ffffff"
-         id="path6461" />
-      <path
-         d="M 16,16 H 28"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="2.5"
-         id="path6463" />
+    <g transform="matrix(7.0866,0,0,7.0866,3174.8,145.28)" id="g6465">
+      <rect width="32" height="32" fill="none" id="rect6455" x="0" y="0"/>
+      <path d="M 12,28 6,16 12,4" fill="none" stroke="#ffffff" stroke-linejoin="round" stroke-width="2.5" id="path6457"/>
+      <path d="m 14,16 h 8" fill="#ffffff" id="path6459"/>
+      <path d="m 14,16 h 8" fill="#ffffff" id="path6461"/>
+      <path d="M 16,16 H 28" fill="none" stroke="#ffffff" stroke-linejoin="round" stroke-width="2.5" id="path6463"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,3174.8,-1215.4)"
-       id="g6471">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect6467"
-         x="0"
-         y="0" />
-      <circle
-         transform="matrix(0.70084,0,0,0.70084,3.6108,5.9623)"
-         cx="17.677999"
-         cy="14.322"
-         r="9.1924"
-         fill="#ffffff"
-         stroke="#ffffff"
-         stroke-width="0.20135"
-         id="circle6469" />
+    <g transform="matrix(7.0866,0,0,7.0866,3174.8,-1215.4)" id="g6471">
+      <rect width="32" height="32" fill="none" id="rect6467" x="0" y="0"/>
+      <circle transform="matrix(0.70084,0,0,0.70084,3.6108,5.9623)" cx="17.677999" cy="14.322" r="9.1924" fill="#ffffff" stroke="#ffffff" stroke-width="0.20135" id="circle6469"/>
     </g>
-    <g
-       transform="matrix(-1,0,0,1,4989,2494.5)"
-       id="g6479">
-      <desc
-         id="desc6473">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6475" />
-      <path
-         transform="matrix(0.20646,0,0,0.20231,2406,-1764.5)"
-         d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="69.35"
-         id="path6477" />
+    <g transform="matrix(-1,0,0,1,4989,2494.5)" id="g6479">
+      <desc id="desc6473">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6475"/>
+      <path transform="matrix(0.20646,0,0,0.20231,2406,-1764.5)" d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="69.35" id="path6477"/>
     </g>
-    <g
-       transform="matrix(1,0,0,-1,-907.09,-1977.2)"
-       id="g6487">
-      <desc
-         id="desc6481">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6483" />
-      <path
-         transform="matrix(0.20646,0,0,0.20231,2406,-1764.5)"
-         d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="69.35"
-         id="path6485" />
+    <g transform="matrix(1,0,0,-1,-907.09,-1977.2)" id="g6487">
+      <desc id="desc6481">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6483"/>
+      <path transform="matrix(0.20646,0,0,0.20231,2406,-1764.5)" d="m 3174.8,-2122.4 -196.39,-340.16 h 392.78 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="69.35" id="path6485"/>
     </g>
-    <g
-       transform="translate(-908.25,680.32)"
-       id="g6495">
-      <rect
-         x="2721.3"
-         y="-308.26999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6489" />
-      <path
-         transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-         d="m 3046.3,2464.7 c -20.235,0 -36.633,16.101 -36.633,35.938 0,12.771 5.443,29.38 15.596,39.604 -0.07,0.065 9.7695,9.0007 9.7695,11.986 0,2.9468 -1.5732,5.5534 -3.9453,7.0683 5.0512,1.6795 10.448,2.6016 16.06,2.6016 5.2035,0 10.224,-0.7861 14.953,-2.2383 -2.7005,-1.4485 -4.5313,-4.2416 -4.5313,-7.4316 0,-2.9822 9.8047,-11.816 9.8047,-11.816 5.8801,-5.861 10.122,-13.854 12.68,-22.027 -0.4241,-0.1104 -0.8356,-0.2517 -1.2344,-0.4179 l -0.09,-0.039 c -0.3954,-0.1696 -0.779,-0.3618 -1.1446,-0.582 -0.3653,-0.2201 -0.7119,-0.4661 -1.0429,-0.7324 -0.02,-0.016 -0.042,-0.03 -0.062,-0.047 -0.3145,-0.2573 -0.6097,-0.5367 -0.8887,-0.8321 -0.041,-0.043 -0.079,-0.087 -0.1191,-0.1308 -0.2756,-0.3029 -0.5365,-0.618 -0.7715,-0.9551 0,0 0,-0.01 -0.01,-0.014 -0.2225,-0.3202 -0.4211,-0.6583 -0.6036,-1.0058 -0.037,-0.07 -0.076,-0.138 -0.1113,-0.209 -0.1684,-0.3412 -0.3142,-0.6936 -0.4414,-1.0566 -0.057,-0.1629 -0.1117,-0.3254 -0.1602,-0.4922 -0.017,-0.057 -0.035,-0.114 -0.051,-0.1719 -0.068,-0.252 -0.1285,-0.5076 -0.1758,-0.7676 -0.294,-1.1816 -0.6767,-2.3502 -1.1426,-3.4961 -0.9319,-2.2918 -2.1943,-4.4918 -3.7285,-6.5117 -0.767,-1.01 -1.6019,-1.975 -2.4981,-2.8848 -0.4481,-0.4548 -0.9109,-0.8964 -1.3886,-1.3222 -0.9555,-0.8516 -1.9681,-1.6422 -3.0313,-2.3614 -1.0631,-0.7191 -2.1774,-1.3664 -3.334,-1.9316 -1.1565,-0.5652 -2.3561,-1.0478 -3.5918,-1.4375 -0.6178,-0.1949 -1.2439,-0.3667 -1.8789,-0.5137 -0.2763,-0.05 -0.5491,-0.1122 -0.8164,-0.1855 -0.8019,-0.2199 -1.5606,-0.5417 -2.2617,-0.9512 -0.7011,-0.4095 -1.3436,-0.9059 -1.9141,-1.4746 -0.3802,-0.3792 -0.7278,-0.7898 -1.039,-1.2285 -0.1556,-0.2194 -0.3028,-0.4452 -0.4395,-0.6778 -0.2733,-0.465 -0.5081,-0.9557 -0.6992,-1.4667 -0.3821,-1.0222 -0.5898,-2.1271 -0.5898,-3.2793 0,-0.3227 0.017,-0.6434 0.049,-0.959 1e-4,-7e-4 -10e-5,0 0,0 0.097,-0.948 0.3355,-1.8602 0.6934,-2.7129 2e-4,-5e-4 -3e-4,0 0,0 0.3582,-0.8532 0.8358,-1.6469 1.4121,-2.3575 0.1924,-0.2372 0.3959,-0.4638 0.6093,-0.6816 0.2128,-0.2171 0.4359,-0.425 0.668,-0.6211 0.9301,-0.7859 2.0093,-1.3966 3.1856,-1.7754 0.5881,-0.1894 1.1997,-0.3201 1.83,-0.3867 0.3152,-0.033 0.6357,-0.051 0.959,-0.051 1.4016,0 2.8598,0.1881 4.3535,0.541 7e-4,2e-4 0,-1e-4 0,0 0.9963,0.2355 2.0069,0.5446 3.0293,0.9219 0.5112,0.1887 1.0255,0.3934 1.541,0.6153 1.0309,0.4436 2.0683,0.9521 3.1074,1.5195 1.5586,0.851 3.1207,1.8346 4.6641,2.9297 1.0289,0.73 2.0494,1.5106 3.0566,2.334 1.5109,1.235 2.9914,2.5675 4.4199,3.9785 0.444,0.4412 0.8789,0.8926 1.3086,1.3496 -5.7485,-12.464 -18.528,-21.148 -33.385,-21.148 z m 61.533,123.17 c -15.627,14.267 -36.426,22.967 -59.27,22.967 -17.081,0 -32.956,-4.8738 -46.42,-13.264 l -23.867,23.848 c 0,10.91 -0.01,15.135 -0.01,15.135 0,7.5064 6.2446,13.586 13.955,13.586 h 108.16 c 7.7103,0 13.955,-6.0795 13.955,-13.586 0,0 -0.034,-30.374 0,-31.393 -0.1048,-3.9401 -1.6747,-11.31 -4.5703,-14.978 -0.6295,-0.7986 -1.2756,-1.5644 -1.9297,-2.3145 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path6491" />
-      <path
-         transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-         d="m 3047.1,2434 c -45.479,0 -82.305,36.826 -82.305,82.305 0,15.944 4.5618,30.853 12.416,43.457 l -53.992,53.992 c -7.2898,7.2898 -7.2898,19.142 0,26.432 7.2898,7.29 19.142,7.2898 26.385,0 l 54.039,-53.992 c 12.604,7.8543 27.466,12.416 43.457,12.416 45.479,0 82.305,-36.826 82.305,-82.305 0,-45.479 -36.826,-82.305 -82.305,-82.305 z m 0,23.516 c 32.452,0 58.789,26.338 58.789,58.789 0,32.451 -26.338,58.789 -58.789,58.789 -32.452,0 -58.789,-26.338 -58.789,-58.789 0,-32.451 26.338,-58.789 58.789,-58.789 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path6493" />
+    <g transform="translate(-908.25,680.32)" id="g6495">
+      <rect x="2721.3" y="-308.26999" width="226.77" height="226.77" fill="none" opacity="1" id="rect6489"/>
+      <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 3046.3,2464.7 c -20.235,0 -36.633,16.101 -36.633,35.938 0,12.771 5.443,29.38 15.596,39.604 -0.07,0.065 9.7695,9.0007 9.7695,11.986 0,2.9468 -1.5732,5.5534 -3.9453,7.0683 5.0512,1.6795 10.448,2.6016 16.06,2.6016 5.2035,0 10.224,-0.7861 14.953,-2.2383 -2.7005,-1.4485 -4.5313,-4.2416 -4.5313,-7.4316 0,-2.9822 9.8047,-11.816 9.8047,-11.816 5.8801,-5.861 10.122,-13.854 12.68,-22.027 -0.4241,-0.1104 -0.8356,-0.2517 -1.2344,-0.4179 l -0.09,-0.039 c -0.3954,-0.1696 -0.779,-0.3618 -1.1446,-0.582 -0.3653,-0.2201 -0.7119,-0.4661 -1.0429,-0.7324 -0.02,-0.016 -0.042,-0.03 -0.062,-0.047 -0.3145,-0.2573 -0.6097,-0.5367 -0.8887,-0.8321 -0.041,-0.043 -0.079,-0.087 -0.1191,-0.1308 -0.2756,-0.3029 -0.5365,-0.618 -0.7715,-0.9551 0,0 0,-0.01 -0.01,-0.014 -0.2225,-0.3202 -0.4211,-0.6583 -0.6036,-1.0058 -0.037,-0.07 -0.076,-0.138 -0.1113,-0.209 -0.1684,-0.3412 -0.3142,-0.6936 -0.4414,-1.0566 -0.057,-0.1629 -0.1117,-0.3254 -0.1602,-0.4922 -0.017,-0.057 -0.035,-0.114 -0.051,-0.1719 -0.068,-0.252 -0.1285,-0.5076 -0.1758,-0.7676 -0.294,-1.1816 -0.6767,-2.3502 -1.1426,-3.4961 -0.9319,-2.2918 -2.1943,-4.4918 -3.7285,-6.5117 -0.767,-1.01 -1.6019,-1.975 -2.4981,-2.8848 -0.4481,-0.4548 -0.9109,-0.8964 -1.3886,-1.3222 -0.9555,-0.8516 -1.9681,-1.6422 -3.0313,-2.3614 -1.0631,-0.7191 -2.1774,-1.3664 -3.334,-1.9316 -1.1565,-0.5652 -2.3561,-1.0478 -3.5918,-1.4375 -0.6178,-0.1949 -1.2439,-0.3667 -1.8789,-0.5137 -0.2763,-0.05 -0.5491,-0.1122 -0.8164,-0.1855 -0.8019,-0.2199 -1.5606,-0.5417 -2.2617,-0.9512 -0.7011,-0.4095 -1.3436,-0.9059 -1.9141,-1.4746 -0.3802,-0.3792 -0.7278,-0.7898 -1.039,-1.2285 -0.1556,-0.2194 -0.3028,-0.4452 -0.4395,-0.6778 -0.2733,-0.465 -0.5081,-0.9557 -0.6992,-1.4667 -0.3821,-1.0222 -0.5898,-2.1271 -0.5898,-3.2793 0,-0.3227 0.017,-0.6434 0.049,-0.959 1e-4,-7e-4 -10e-5,0 0,0 0.097,-0.948 0.3355,-1.8602 0.6934,-2.7129 2e-4,-5e-4 -3e-4,0 0,0 0.3582,-0.8532 0.8358,-1.6469 1.4121,-2.3575 0.1924,-0.2372 0.3959,-0.4638 0.6093,-0.6816 0.2128,-0.2171 0.4359,-0.425 0.668,-0.6211 0.9301,-0.7859 2.0093,-1.3966 3.1856,-1.7754 0.5881,-0.1894 1.1997,-0.3201 1.83,-0.3867 0.3152,-0.033 0.6357,-0.051 0.959,-0.051 1.4016,0 2.8598,0.1881 4.3535,0.541 7e-4,2e-4 0,-1e-4 0,0 0.9963,0.2355 2.0069,0.5446 3.0293,0.9219 0.5112,0.1887 1.0255,0.3934 1.541,0.6153 1.0309,0.4436 2.0683,0.9521 3.1074,1.5195 1.5586,0.851 3.1207,1.8346 4.6641,2.9297 1.0289,0.73 2.0494,1.5106 3.0566,2.334 1.5109,1.235 2.9914,2.5675 4.4199,3.9785 0.444,0.4412 0.8789,0.8926 1.3086,1.3496 -5.7485,-12.464 -18.528,-21.148 -33.385,-21.148 z m 61.533,123.17 c -15.627,14.267 -36.426,22.967 -59.27,22.967 -17.081,0 -32.956,-4.8738 -46.42,-13.264 l -23.867,23.848 c 0,10.91 -0.01,15.135 -0.01,15.135 0,7.5064 6.2446,13.586 13.955,13.586 h 108.16 c 7.7103,0 13.955,-6.0795 13.955,-13.586 0,0 -0.034,-30.374 0,-31.393 -0.1048,-3.9401 -1.6747,-11.31 -4.5703,-14.978 -0.6295,-0.7986 -1.2756,-1.5644 -1.9297,-2.3145 z" fill="#ffffff" opacity="1" id="path6491"/>
+      <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 3047.1,2434 c -45.479,0 -82.305,36.826 -82.305,82.305 0,15.944 4.5618,30.853 12.416,43.457 l -53.992,53.992 c -7.2898,7.2898 -7.2898,19.142 0,26.432 7.2898,7.29 19.142,7.2898 26.385,0 l 54.039,-53.992 c 12.604,7.8543 27.466,12.416 43.457,12.416 45.479,0 82.305,-36.826 82.305,-82.305 0,-45.479 -36.826,-82.305 -82.305,-82.305 z m 0,23.516 c 32.452,0 58.789,26.338 58.789,58.789 0,32.451 -26.338,58.789 -58.789,58.789 -32.452,0 -58.789,-26.338 -58.789,-58.789 0,-32.451 26.338,-58.789 58.789,-58.789 z" fill="#ffffff" opacity="1" id="path6493"/>
     </g>
-    <g
-       transform="translate(455.39,226.77)"
-       id="g6503">
-      <g
-         transform="matrix(3.4622,0,0,3.4593,1949.6,299.07)"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="2"
-         id="g6499">
-        <path
-           d="m 6.2396,-20.045 v 28.68 c 0,1.3145 -1.0755,2.39 -2.39,2.39 -1.3145,0 -2.39,-1.0755 -2.39,-2.39 v -28.68 c 0,-1.3145 1.0755,-2.39 2.39,-2.39 1.3145,0 2.39,1.0755 2.39,2.39 m -10.755,0 v 28.68 c 0,1.3145 -1.0755,2.39 -2.39,2.39 -1.3145,0 -2.39,-1.0755 -2.39,-2.39 v -28.68 c 0,-1.3145 1.0755,-2.39 2.39,-2.39 1.3145,0 2.39,1.0755 2.39,2.39 m -10.755,0 v 28.68 c 0,1.3145 -1.0755,2.39 -2.39,2.39 -1.3145,0 -2.39,-1.0755 -2.39,-2.39 v -28.68 c 0,-1.3145 1.0755,-2.39 2.39,-2.39 1.3145,0 2.39,1.0755 2.39,2.39 m 16.73,-8.3649 h -16.73 v -3.346 c 0,-1.4579 1.1711,-2.629 2.629,-2.629 h 11.472 c 1.4579,0 2.629,1.1711 2.629,2.629 z m 13.742,0 H 7.4342 v -7.1699 c 0,-2.6409 -2.139,-4.7799 -4.7799,-4.7799 h -19.12 c -2.6409,0 -4.7799,2.139 -4.7799,4.7799 v 7.1699 h -7.7674 c -1.6491,0 -2.9875,1.3384 -2.9875,2.9875 0,1.6491 1.3384,2.9875 2.9875,2.9875 h 1.7925 v 34.655 c 0,2.6409 2.139,4.7799 4.7799,4.7799 h 31.07 c 2.6409,0 4.7799,-2.139 4.7799,-4.7799 v -34.655 h 1.7925 c 1.6491,0 2.9875,-1.3384 2.9875,-2.9875 0,-1.6491 -1.3384,-2.9875 -2.9875,-2.9875"
-           fill="#ffffff"
-           stroke-width="1.195"
-           id="path6497" />
+    <g transform="translate(455.39,226.77)" id="g6503">
+      <g transform="matrix(3.4622,0,0,3.4593,1949.6,299.07)" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" id="g6499">
+        <path d="m 6.2396,-20.045 v 28.68 c 0,1.3145 -1.0755,2.39 -2.39,2.39 -1.3145,0 -2.39,-1.0755 -2.39,-2.39 v -28.68 c 0,-1.3145 1.0755,-2.39 2.39,-2.39 1.3145,0 2.39,1.0755 2.39,2.39 m -10.755,0 v 28.68 c 0,1.3145 -1.0755,2.39 -2.39,2.39 -1.3145,0 -2.39,-1.0755 -2.39,-2.39 v -28.68 c 0,-1.3145 1.0755,-2.39 2.39,-2.39 1.3145,0 2.39,1.0755 2.39,2.39 m -10.755,0 v 28.68 c 0,1.3145 -1.0755,2.39 -2.39,2.39 -1.3145,0 -2.39,-1.0755 -2.39,-2.39 v -28.68 c 0,-1.3145 1.0755,-2.39 2.39,-2.39 1.3145,0 2.39,1.0755 2.39,2.39 m 16.73,-8.3649 h -16.73 v -3.346 c 0,-1.4579 1.1711,-2.629 2.629,-2.629 h 11.472 c 1.4579,0 2.629,1.1711 2.629,2.629 z m 13.742,0 H 7.4342 v -7.1699 c 0,-2.6409 -2.139,-4.7799 -4.7799,-4.7799 h -19.12 c -2.6409,0 -4.7799,2.139 -4.7799,4.7799 v 7.1699 h -7.7674 c -1.6491,0 -2.9875,1.3384 -2.9875,2.9875 0,1.6491 1.3384,2.9875 2.9875,2.9875 h 1.7925 v 34.655 c 0,2.6409 2.139,4.7799 4.7799,4.7799 h 31.07 c 2.6409,0 4.7799,-2.139 4.7799,-4.7799 v -34.655 h 1.7925 c 1.6491,0 2.9875,-1.3384 2.9875,-2.9875 0,-1.6491 -1.3384,-2.9875 -2.9875,-2.9875" fill="#ffffff" stroke-width="1.195" id="path6497"/>
       </g>
-      <rect
-         x="1812.3"
-         y="145.28"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         stroke-width="0.95094"
-         id="rect6501" />
+      <rect x="1812.3" y="145.28" width="226.77" height="226.77" fill="none" stroke-width="0.95094" id="rect6501"/>
     </g>
-    <g
-       transform="translate(680.35,2948)"
-       id="g6535">
-      <g
-         transform="matrix(4.1369,0,0,4.1335,2153.9,-2526.1)"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="2"
-         id="g6507">
-        <path
-           d="M 0,30.81 -9.34,32.6 -17.08,24.85 -15.3,15.5 -1.39,1.57 c 0.77,-0.77 2.01,-0.77 2.78,0 0.77,0.77 0.77,2.02 0,2.79 l -12.86,12.88 c -0.96,0.96 -0.96,2.52 0,3.48 0.96,0.96 2.51,0.96 3.47,0 L 4.87,7.84 c 0.77,-0.77 2.01,-0.77 2.78,0 0.77,0.77 0.77,2.01 0,2.78 L -5.21,23.5 c -0.96,0.96 -0.96,2.52 0,3.48 0.96,0.96 2.51,0.96 3.47,0 L 11.13,14.1 c 0.76,-0.76 2.01,-0.76 2.78,0 0.77,0.77 0.77,2.02 0,2.79 z M -18.34,11.58 c -0.98,0.98 -1.45,2.38 -1.69,3.8 l -3.81,18.02 c -0.54,3.2 2.67,6.42 5.91,5.92 L 0.11,35.56 C 1.43,35.32 2.86,34.91 3.84,33.93 L 22.95,14.8 c 1.53,-1.54 1.53,-4.03 0,-5.57 L 6.26,-7.48 c -1.54,-1.53 -4.03,-1.53 -5.56,0 z"
-           fill="#ffffff"
-           id="path6505" />
+    <g transform="translate(680.35,2948)" id="g6535">
+      <g transform="matrix(4.1369,0,0,4.1335,2153.9,-2526.1)" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" id="g6507">
+        <path d="M 0,30.81 -9.34,32.6 -17.08,24.85 -15.3,15.5 -1.39,1.57 c 0.77,-0.77 2.01,-0.77 2.78,0 0.77,0.77 0.77,2.02 0,2.79 l -12.86,12.88 c -0.96,0.96 -0.96,2.52 0,3.48 0.96,0.96 2.51,0.96 3.47,0 L 4.87,7.84 c 0.77,-0.77 2.01,-0.77 2.78,0 0.77,0.77 0.77,2.01 0,2.78 L -5.21,23.5 c -0.96,0.96 -0.96,2.52 0,3.48 0.96,0.96 2.51,0.96 3.47,0 L 11.13,14.1 c 0.76,-0.76 2.01,-0.76 2.78,0 0.77,0.77 0.77,2.02 0,2.79 z M -18.34,11.58 c -0.98,0.98 -1.45,2.38 -1.69,3.8 l -3.81,18.02 c -0.54,3.2 2.67,6.42 5.91,5.92 L 0.11,35.56 C 1.43,35.32 2.86,34.91 3.84,33.93 L 22.95,14.8 c 1.53,-1.54 1.53,-4.03 0,-5.57 L 6.26,-7.48 c -1.54,-1.53 -4.03,-1.53 -5.56,0 z" fill="#ffffff" id="path6505"/>
       </g>
-      <rect
-         x="2040.9"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         stroke-width="0.94316"
-         id="rect6509" />
-      <g
-         transform="matrix(4.1369,0,0,4.1335,2377.4,-2478.6)"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="2"
-         id="g6513">
-        <path
-           d="m 0,7.52 -16.95,16.95 c -0.36,0.36 -0.58,0.86 -0.58,1.41 0,1.1 0.89,2 2,2 0.29,0 0.56,-0.06 0.81,-0.17 0,0 28.24,-12.24 28.56,-12.39 0.66,-0.3 1.17,-0.88 1.37,-1.6 l 4.57,-16.47 0.92,0.91 c 0.96,0.96 2.51,0.96 3.47,0 0.96,-0.96 0.96,-2.51 0,-3.47 L 10.08,-19.4 c -0.96,-0.96 -2.51,-0.96 -3.47,0 -0.96,0.96 -0.96,2.51 0,3.47 l 0.91,0.91 -16.5,4.59 c -0.72,0.21 -1.3,0.73 -1.6,1.41 l -12.37,28.54 c -0.1,0.24 -0.16,0.5 -0.16,0.78 0,1.11 0.9,2 2,2 0.57,0 1.08,-0.23 1.44,-0.61 L -2.75,4.77 C -2.98,4.18 -3.11,3.55 -3.11,2.88 c 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 0,2.76 -2.24,5 -5,5 C 1.22,7.88 0.59,7.75 0,7.52"
-           fill="#ffffff"
-           id="path6511" />
+      <rect x="2040.9" y="-2575.8999" width="226.77" height="226.77" fill="none" stroke-width="0.94316" id="rect6509"/>
+      <g transform="matrix(4.1369,0,0,4.1335,2377.4,-2478.6)" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" id="g6513">
+        <path d="m 0,7.52 -16.95,16.95 c -0.36,0.36 -0.58,0.86 -0.58,1.41 0,1.1 0.89,2 2,2 0.29,0 0.56,-0.06 0.81,-0.17 0,0 28.24,-12.24 28.56,-12.39 0.66,-0.3 1.17,-0.88 1.37,-1.6 l 4.57,-16.47 0.92,0.91 c 0.96,0.96 2.51,0.96 3.47,0 0.96,-0.96 0.96,-2.51 0,-3.47 L 10.08,-19.4 c -0.96,-0.96 -2.51,-0.96 -3.47,0 -0.96,0.96 -0.96,2.51 0,3.47 l 0.91,0.91 -16.5,4.59 c -0.72,0.21 -1.3,0.73 -1.6,1.41 l -12.37,28.54 c -0.1,0.24 -0.16,0.5 -0.16,0.78 0,1.11 0.9,2 2,2 0.57,0 1.08,-0.23 1.44,-0.61 L -2.75,4.77 C -2.98,4.18 -3.11,3.55 -3.11,2.88 c 0,-2.76 2.24,-5 5,-5 2.76,0 5,2.24 5,5 0,2.76 -2.24,5 -5,5 C 1.22,7.88 0.59,7.75 0,7.52" fill="#ffffff" id="path6511"/>
       </g>
-      <rect
-         x="2267.7"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         stroke-width="0.94316"
-         id="rect6515" />
-      <g
-         transform="matrix(4.1373,0,0,4.1339,2643.8,-2438.5)"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="2"
-         id="g6519">
-        <path
-           d="m 0,-11.64 3.72,-3.77 c 0.36,-0.36 0.58,-0.86 0.58,-1.41 0,-1.1 -0.89,-2 -1.98,-2 h -5.95 c 0.49,-3.39 3.399,-6 6.93,-6 3.87,0 7,3.13 7,7 0,3.87 -3.13,7 -7,7 -1.19,0 -2.32,-0.3 -3.3,-0.82 M -16.7,0.18 v 11 c 0,1.1 -0.9,2 -2,2 h -5.5 c -1.38,0 -2.5,1.12 -2.5,2.5 0,1.38 1.12,2.5 2.5,2.5 h 20 c 1.38,0 2.5,-1.12 2.5,-2.5 0,-1.38 -1.12,-2.5 -2.5,-2.5 h -5.5 c -1.1,0 -2,-0.9 -2,-2 v -11 l 8.09,-8.19 c 1.96,1.38 4.34,2.19 6.91,2.19 6.63,0 12,-5.37 12,-12 0,-6.63 -5.37,-12 -12,-12 -6.29,0 -11.45,4.84 -11.96,11 h -22.06 c -1.09,0 -1.98,0.9 -1.98,2 0,0.56 0.23,1.07 0.6,1.43 z"
-           fill="#ffffff"
-           id="path6517" />
+      <rect x="2267.7" y="-2575.8999" width="226.77" height="226.77" fill="none" stroke-width="0.94316" id="rect6515"/>
+      <g transform="matrix(4.1373,0,0,4.1339,2643.8,-2438.5)" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" id="g6519">
+        <path d="m 0,-11.64 3.72,-3.77 c 0.36,-0.36 0.58,-0.86 0.58,-1.41 0,-1.1 -0.89,-2 -1.98,-2 h -5.95 c 0.49,-3.39 3.399,-6 6.93,-6 3.87,0 7,3.13 7,7 0,3.87 -3.13,7 -7,7 -1.19,0 -2.32,-0.3 -3.3,-0.82 M -16.7,0.18 v 11 c 0,1.1 -0.9,2 -2,2 h -5.5 c -1.38,0 -2.5,1.12 -2.5,2.5 0,1.38 1.12,2.5 2.5,2.5 h 20 c 1.38,0 2.5,-1.12 2.5,-2.5 0,-1.38 -1.12,-2.5 -2.5,-2.5 h -5.5 c -1.1,0 -2,-0.9 -2,-2 v -11 l 8.09,-8.19 c 1.96,1.38 4.34,2.19 6.91,2.19 6.63,0 12,-5.37 12,-12 0,-6.63 -5.37,-12 -12,-12 -6.29,0 -11.45,4.84 -11.96,11 h -22.06 c -1.09,0 -1.98,0.9 -1.98,2 0,0.56 0.23,1.07 0.6,1.43 z" fill="#ffffff" id="path6517"/>
       </g>
-      <rect
-         x="2494.5"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         stroke-width="0.93775"
-         id="rect6521" />
-      <g
-         transform="matrix(4.1373,0,0,4.1339,2913.7,-2480.6)"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="2"
-         id="g6525">
-        <path
-           d="m 0,10 c 0,1.66 -1.34,3 -3,3 -1.66,0 -3,-1.34 -3,-3 V -5 c 0,-1.66 1.34,-3 3,-3 1.66,0 3,1.34 3,3 z m -34,-22 v 29 c 0,1.1 -0.9,2 -2,2 -1.1,0 -2,-0.9 -2,-2 v -29 c 0,-1.1 0.9,-2 2,-2 1.1,0 2,0.9 2,2 m 28,29.42 c 0.93,0.37 1.94,0.58 3,0.58 4.42,0 8,-3.58 8,-8 V -5 c 0,-4.42 -3.58,-8 -8,-8 -1.06,0 -2.07,0.21 -3,0.58 V -15 c 0,-2.21 -1.79,-4 -4,-4 h -29 c -2.21,0 -4,1.79 -4,4 v 33.85 c 0,5.61 4.54,10.15 10.15,10.15 h 16.7 C -10.54,29 -6,24.46 -6,18.85 Z"
-           fill="#ffffff"
-           id="path6523" />
+      <rect x="2494.5" y="-2575.8999" width="226.77" height="226.77" fill="none" stroke-width="0.93775" id="rect6521"/>
+      <g transform="matrix(4.1373,0,0,4.1339,2913.7,-2480.6)" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" id="g6525">
+        <path d="m 0,10 c 0,1.66 -1.34,3 -3,3 -1.66,0 -3,-1.34 -3,-3 V -5 c 0,-1.66 1.34,-3 3,-3 1.66,0 3,1.34 3,3 z m -34,-22 v 29 c 0,1.1 -0.9,2 -2,2 -1.1,0 -2,-0.9 -2,-2 v -29 c 0,-1.1 0.9,-2 2,-2 1.1,0 2,0.9 2,2 m 28,29.42 c 0.93,0.37 1.94,0.58 3,0.58 4.42,0 8,-3.58 8,-8 V -5 c 0,-4.42 -3.58,-8 -8,-8 -1.06,0 -2.07,0.21 -3,0.58 V -15 c 0,-2.21 -1.79,-4 -4,-4 h -29 c -2.21,0 -4,1.79 -4,4 v 33.85 c 0,5.61 4.54,10.15 10.15,10.15 h 16.7 C -10.54,29 -6,24.46 -6,18.85 Z" fill="#ffffff" id="path6523"/>
       </g>
-      <rect
-         x="2722.6001"
-         y="-2570.7"
-         width="225"
-         height="221.56"
-         fill="none"
-         stroke-width="0.93421"
-         id="rect6527" />
-      <rect
-         x="1814.1"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6529" />
-      <g
-         transform="matrix(4.1373,0,0,4.1339,1844.8,-2379.9)"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="2"
-         id="g6533">
-        <path
-           d="M 0,-40 V 0 C 0,2.21 1.79,4 4,4 H 37.5 C 38.88,4 40,2.88 40,1.5 40,0.12 38.88,-1 37.5,-1 H 7 C 5.9,-1 5,-1.9 5,-3 5,-4.1 5.9,-5 7,-5 h 29 c 2.21,0 4,-1.79 4,-4 v -31 c 0,-2.21 -1.79,-4 -4,-4 H 22 v 17.99 c 0,0.26 -0.1,0.52 -0.29,0.72 -0.39,0.39 -1.03,0.39 -1.42,0 -0.26,-0.27 -4.29,-3.62 -4.29,-3.62 0,0 -4.03,3.35 -4.29,3.62 -0.39,0.39 -1.03,0.39 -1.42,0 C 10.1,-25.49 10,-25.75 10,-26.01 V -44 H 4 c -2.21,0 -4,1.79 -4,4"
-           fill="#ffffff"
-           id="path6531" />
+      <rect x="2722.6001" y="-2570.7" width="225" height="221.56" fill="none" stroke-width="0.93421" id="rect6527"/>
+      <rect x="1814.1" y="-2575.8999" width="226.77" height="226.77" fill="none" opacity="1" id="rect6529"/>
+      <g transform="matrix(4.1373,0,0,4.1339,1844.8,-2379.9)" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" id="g6533">
+        <path d="M 0,-40 V 0 C 0,2.21 1.79,4 4,4 H 37.5 C 38.88,4 40,2.88 40,1.5 40,0.12 38.88,-1 37.5,-1 H 7 C 5.9,-1 5,-1.9 5,-3 5,-4.1 5.9,-5 7,-5 h 29 c 2.21,0 4,-1.79 4,-4 v -31 c 0,-2.21 -1.79,-4 -4,-4 H 22 v 17.99 c 0,0.26 -0.1,0.52 -0.29,0.72 -0.39,0.39 -1.03,0.39 -1.42,0 -0.26,-0.27 -4.29,-3.62 -4.29,-3.62 0,0 -4.03,3.35 -4.29,3.62 -0.39,0.39 -1.03,0.39 -1.42,0 C 10.1,-25.49 10,-25.75 10,-26.01 V -44 H 4 c -2.21,0 -4,1.79 -4,4" fill="#ffffff" id="path6531"/>
       </g>
     </g>
-    <g
-       transform="translate(-1814.1,3174.7)"
-       id="g6545">
-      <rect
-         x="1814.1"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6537" />
-      <path
-         d="m 2010.5,-2379.9 c 0,9.1358 -7.6127,16.535 -17.012,16.535 h -131.84 c -9.3991,0 -17.012,-7.3996 -17.012,-16.535 v -140.55 c 0,-9.1358 7.6129,-16.535 17.012,-16.535 h 34.662 c 2.9303,-14.138 15.821,-24.803 31.259,-24.803 15.438,0 28.325,10.665 31.259,24.803 h 34.662 c 9.3991,0 17.012,7.3996 17.012,16.535 z m -30.622,-136.42 h -20.414 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.082 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.414 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.09 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.62 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.09 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.469 c 0,-5.7046 -4.7633,-10.335 -10.632,-10.335 -5.8692,0 -10.632,4.63 -10.632,10.335 0,5.7048 4.7633,10.335 10.632,10.335 5.8691,0 10.632,-4.6299 10.632,-10.335 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path6539" />
-      <path
-         d="m 1878.5,-2446.5 27.184,-17.147 37.639,20.492 32.202,-51.858"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10.63"
-         id="path6541" />
-      <path
-         d="m 1878.5,-2414.5 27.184,-17.147 37.639,7.9461 32.202,19.656"
-         fill="none"
-         stroke="#ffffff"
-         stroke-dasharray="10.6299, 21.2598"
-         stroke-linecap="square"
-         stroke-linejoin="round"
-         stroke-width="10.63"
-         id="path6543" />
+    <g transform="translate(-1814.1,3174.7)" id="g6545">
+      <rect x="1814.1" y="-2575.8999" width="226.77" height="226.77" fill="none" opacity="1" id="rect6537"/>
+      <path d="m 2010.5,-2379.9 c 0,9.1358 -7.6127,16.535 -17.012,16.535 h -131.84 c -9.3991,0 -17.012,-7.3996 -17.012,-16.535 v -140.55 c 0,-9.1358 7.6129,-16.535 17.012,-16.535 h 34.662 c 2.9303,-14.138 15.821,-24.803 31.259,-24.803 15.438,0 28.325,10.665 31.259,24.803 h 34.662 c 9.3991,0 17.012,7.3996 17.012,16.535 z m -30.622,-136.42 h -20.414 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.082 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.414 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.09 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.62 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.09 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.469 c 0,-5.7046 -4.7633,-10.335 -10.632,-10.335 -5.8692,0 -10.632,4.63 -10.632,10.335 0,5.7048 4.7633,10.335 10.632,10.335 5.8691,0 10.632,-4.6299 10.632,-10.335 z" fill="#ffffff" opacity="1" id="path6539"/>
+      <path d="m 1878.5,-2446.5 27.184,-17.147 37.639,20.492 32.202,-51.858" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10.63" id="path6541"/>
+      <path d="m 1878.5,-2414.5 27.184,-17.147 37.639,7.9461 32.202,19.656" fill="none" stroke="#ffffff" stroke-dasharray="10.6299, 21.2598" stroke-linecap="square" stroke-linejoin="round" stroke-width="10.63" id="path6543"/>
     </g>
-    <g
-       transform="translate(-8163.8,-226.77)"
-       id="g6551">
-      <path
-         d="m 8705.6,-2320.8 c 8.1225,-0.2397 14.838,6.2783 14.84,14.404 v 141.15 c 0,6.0392 -3.7678,11.437 -9.4352,13.523 -5.6676,2.0861 -12.035,0.4179 -15.951,-4.1791 l -60.102,-70.576 c -4.5859,-5.3859 -4.5859,-13.304 0,-18.689 l 60.102,-70.577 c 2.6425,-3.1015 6.4741,-4.9399 10.547,-5.0602 z m 50.25,0 c 4.0727,0.1203 7.9046,1.9587 10.547,5.0602 l 60.102,70.577 c 4.5859,5.3859 4.5859,13.304 0,18.689 l -60.102,70.576 c -3.9165,4.597 -10.284,6.2652 -15.951,4.1791 -5.6674,-2.086 -9.4335,-7.484 -9.4352,-13.523 v -141.15 c 0,-8.126 6.7172,-14.644 14.839,-14.404 z m -64.236,53.559 -26.759,31.422 26.759,31.422 z m 78.222,0 v 62.844 l 26.759,-31.422 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path6547" />
-      <rect
-         x="8617.2998"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6549" />
+    <g transform="translate(-8163.8,-226.77)" id="g6551">
+      <path d="m 8705.6,-2320.8 c 8.1225,-0.2397 14.838,6.2783 14.84,14.404 v 141.15 c 0,6.0392 -3.7678,11.437 -9.4352,13.523 -5.6676,2.0861 -12.035,0.4179 -15.951,-4.1791 l -60.102,-70.576 c -4.5859,-5.3859 -4.5859,-13.304 0,-18.689 l 60.102,-70.577 c 2.6425,-3.1015 6.4741,-4.9399 10.547,-5.0602 z m 50.25,0 c 4.0727,0.1203 7.9046,1.9587 10.547,5.0602 l 60.102,70.577 c 4.5859,5.3859 4.5859,13.304 0,18.689 l -60.102,70.576 c -3.9165,4.597 -10.284,6.2652 -15.951,4.1791 -5.6674,-2.086 -9.4335,-7.484 -9.4352,-13.523 v -141.15 c 0,-8.126 6.7172,-14.644 14.839,-14.404 z m -64.236,53.559 -26.759,31.422 26.759,31.422 z m 78.222,0 v 62.844 l 26.759,-31.422 z" fill="#ffffff" opacity="1" id="path6547"/>
+      <rect x="8617.2998" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6549"/>
     </g>
-    <g
-       transform="translate(-9751.2,-226.77)"
-       id="g6557">
-      <rect
-         x="9978"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6553" />
-      <path
-         d="m 10155,-2299.5 -127.44,127.44 m 127.44,-3e-4 -127.44,-127.44"
-         fill="#535b4f"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="path6555" />
+    <g transform="translate(-9751.2,-226.77)" id="g6557">
+      <rect x="9978" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6553"/>
+      <path d="m 10155,-2299.5 -127.44,127.44 m 127.44,-3e-4 -127.44,-127.44" fill="#535b4f" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="path6555"/>
     </g>
-    <g
-       fill="none"
-       id="g6563">
-      <path
-         d="m 113.38,-2528.2 65.56,65.559 -65.559,65.559 -65.56,-65.559 z"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="10"
-         id="path6559" />
-      <rect
-         x="6.2500003e-05"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         opacity="1"
-         id="rect6561" />
+    <g fill="none" id="g6563">
+      <path d="m 113.38,-2528.2 65.56,65.559 -65.559,65.559 -65.56,-65.559 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10" id="path6559"/>
+      <rect x="6.2500003e-05" y="-2576" width="226.77" height="226.77" opacity="1" id="rect6561"/>
     </g>
-    <g
-       transform="translate(1587.4,-1587.4)"
-       id="g6573">
-      <g
-         transform="translate(681.69,1812.1)"
-         id="g6571">
-        <g
-           transform="matrix(4.1373,0,0,4.1339,-114.76,-1021.3)"
-           clip-rule="evenodd"
-           fill="#ffffff"
-           fill-rule="evenodd"
-           stroke-linejoin="round"
-           stroke-miterlimit="2"
-           id="g6567">
-          <path
-             d="m 0,-38 c 5.8,0 10.5,4.7 10.5,10.5 0,5.8 -4.7,10.5 -10.5,10.5 -5.8,0 -10.5,-4.7 -10.5,-10.5 0,-5.8 4.7,-10.5 10.5,-10.5 m -15.5,10.22 c 0,10.2 12.03,18.05 13,29.78 V 2.5 C -2.5,3.88 -1.38,5 0,5 1.38,5 2.5,3.88 2.5,2.5 V 2 c 1.03,-11.73 13,-19.58 13,-29.78 C 15.5,-36.19 8.56,-43 0,-43 c -8.56,0 -15.5,6.81 -15.5,15.22 M 0,-34 c -3.59,0 -6.5,2.91 -6.5,6.5 0,3.59 2.91,6.5 6.5,6.5 3.59,0 6.5,-2.91 6.5,-6.5 C 6.5,-31.09 3.59,-34 0,-34 m -2.5,6.5 c 0,-1.38 1.12,-2.5 2.5,-2.5 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5"
-             fill="#ffffff"
-             id="path6565" />
+    <g transform="translate(1587.4,-1587.4)" id="g6573">
+      <g transform="translate(681.69,1812.1)" id="g6571">
+        <g transform="matrix(4.1373,0,0,4.1339,-114.76,-1021.3)" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" id="g6567">
+          <path d="m 0,-38 c 5.8,0 10.5,4.7 10.5,10.5 0,5.8 -4.7,10.5 -10.5,10.5 -5.8,0 -10.5,-4.7 -10.5,-10.5 0,-5.8 4.7,-10.5 10.5,-10.5 m -15.5,10.22 c 0,10.2 12.03,18.05 13,29.78 V 2.5 C -2.5,3.88 -1.38,5 0,5 1.38,5 2.5,3.88 2.5,2.5 V 2 c 1.03,-11.73 13,-19.58 13,-29.78 C 15.5,-36.19 8.56,-43 0,-43 c -8.56,0 -15.5,6.81 -15.5,15.22 M 0,-34 c -3.59,0 -6.5,2.91 -6.5,6.5 0,3.59 2.91,6.5 6.5,6.5 3.59,0 6.5,-2.91 6.5,-6.5 C 6.5,-31.09 3.59,-34 0,-34 m -2.5,6.5 c 0,-1.38 1.12,-2.5 2.5,-2.5 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5" fill="#ffffff" id="path6565"/>
         </g>
-        <rect
-           x="-228.14"
-           y="-1213.3"
-           width="226.77"
-           height="226.77"
-           ry="10.042"
-           fill="none"
-           id="rect6569"
-           rx="10.042" />
+        <rect x="-228.14" y="-1213.3" width="226.77" height="226.77" ry="10.042" fill="none" id="rect6569" rx="10.042"/>
       </g>
     </g>
-    <path
-       d="m 2304.9,-957.99 c -12.822,0 -20.835,13.884 -14.425,24.989 l 77.414,134.09 c 6.4122,11.104 22.441,11.104 28.854,0 l 77.414,-134.09 c 6.4103,-11.105 -1.6034,-24.986 -14.425,-24.989 z m 67.92,25.078 h 19.187 l -0.6472,57.044 h -17.892 z m 0.2582,69.231 h 18.67 v 21.521 h -18.67 z"
-       color="#000000"
-       color-rendering="auto"
-       dominant-baseline="auto"
-       fill="#ffffff"
-       fill-opacity="0.78431"
-       image-rendering="auto"
-       opacity="1"
-       shape-rendering="auto"
-       solid-color="#000000"
-       style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;isolation:auto;mix-blend-mode:normal"
-       id="path6575" />
-    <g
-       transform="translate(1.1829,-5.323)"
-       color="#000000"
-       color-rendering="auto"
-       fill="#000100"
-       image-rendering="auto"
-       opacity="1"
-       shape-rendering="auto"
-       solid-color="#000000"
-       stroke-linejoin="round"
-       style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal"
-       aria-label="!"
-       id="g6579">
-      <path
-         transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-         d="m 2476.4,1747.6 c -10.506,0 -17.07,11.374 -11.818,20.473 l 63.43,109.86 c 5.2534,9.0976 18.383,9.0976 23.637,0 l 63.43,-109.86 c 5.2512,-9.0984 -1.3147,-20.471 -11.82,-20.473 z m 52.656,10.746 h 21.768 l -0.7343,64.717 h -20.299 z m 0.2929,78.543 h 21.182 v 24.416 h -21.182 z"
-         fill="#ffffff"
-         stroke-width="50.429"
-         id="path6577" />
+    <path d="m 2304.9,-957.99 c -12.822,0 -20.835,13.884 -14.425,24.989 l 77.414,134.09 c 6.4122,11.104 22.441,11.104 28.854,0 l 77.414,-134.09 c 6.4103,-11.105 -1.6034,-24.986 -14.425,-24.989 z m 67.92,25.078 h 19.187 l -0.6472,57.044 h -17.892 z m 0.2582,69.231 h 18.67 v 21.521 h -18.67 z" color="#000000" color-rendering="auto" dominant-baseline="auto" fill="#ffffff" fill-opacity="0.78431" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;isolation:auto;mix-blend-mode:normal" id="path6575"/>
+    <g transform="translate(1.1829,-5.323)" color="#000000" color-rendering="auto" fill="#000100" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" stroke-linejoin="round" style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal" aria-label="!" id="g6579">
+      <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 2476.4,1747.6 c -10.506,0 -17.07,11.374 -11.818,20.473 l 63.43,109.86 c 5.2534,9.0976 18.383,9.0976 23.637,0 l 63.43,-109.86 c 5.2512,-9.0984 -1.3147,-20.471 -11.82,-20.473 z m 52.656,10.746 h 21.768 l -0.7343,64.717 h -20.299 z m 0.2929,78.543 h 21.182 v 24.416 h -21.182 z" fill="#ffffff" stroke-width="50.429" id="path6577"/>
     </g>
-    <rect
-       x="2270.1001"
-       y="-986.84998"
-       width="229.17999"
-       height="224.16"
-       ry="10.005"
-       fill="none"
-       id="rect6581"
-       rx="10.005" />
-    <path
-       transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-       d="m 2781,1723.4 a 90.416,90.416 0 0 0 -90.416,90.416 90.416,90.416 0 0 0 90.416,90.416 90.416,90.416 0 0 0 90.416,-90.416 A 90.416,90.416 0 0 0 2781,1723.4 Z m -32.055,37.434 h 21.77 l -0.7364,64.717 h -20.297 z m 44.352,0 h 21.768 l -0.7344,64.717 h -20.297 z m -44.057,78.543 h 21.18 v 24.416 h -21.18 z m 44.352,0 h 21.18 v 24.416 h -21.18 z"
-       fill="#ffffff"
-       fill-opacity="0.84706"
-       opacity="1"
-       id="path6583" />
-    <path
-       transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-       d="m 2781,1738.2 a 75.591,75.591 0 0 0 -75.59,75.59 75.591,75.591 0 0 0 75.59,75.592 75.591,75.591 0 0 0 75.59,-75.592 75.591,75.591 0 0 0 -75.59,-75.59 z m -32.055,22.608 h 21.77 l -0.7364,64.717 h -20.297 z m 44.352,0 h 21.768 l -0.7344,64.717 h -20.297 z m -44.057,78.543 h 21.18 v 24.416 h -21.18 z m 44.352,0 h 21.18 v 24.416 h -21.18 z"
-       fill="#ffffff"
-       opacity="1"
-       id="path6585" />
-    <rect
-       x="2495.8999"
-       y="-986.84998"
-       width="227.50999"
-       height="225.84"
-       ry="10.005"
-       fill="none"
-       id="rect6587"
-       rx="10.005" />
-    <g
-       transform="matrix(0.69224,0,0,0.69224,4606.2,161.75)"
-       id="g6593">
-      <path
-         d="m -2596,-1580.3 16.619,-63.733 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.947,107.57 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.045 l -16.614,63.733 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.943,-107.57 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         id="path6589" />
-      <rect
-         x="-2721.3"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6591" />
+    <rect x="2270.1001" y="-986.84998" width="229.17999" height="224.16" ry="10.005" fill="none" id="rect6581" rx="10.005"/>
+    <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 2781,1723.4 a 90.416,90.416 0 0 0 -90.416,90.416 90.416,90.416 0 0 0 90.416,90.416 90.416,90.416 0 0 0 90.416,-90.416 A 90.416,90.416 0 0 0 2781,1723.4 Z m -32.055,37.434 h 21.77 l -0.7364,64.717 h -20.297 z m 44.352,0 h 21.768 l -0.7344,64.717 h -20.297 z m -44.057,78.543 h 21.18 v 24.416 h -21.18 z m 44.352,0 h 21.18 v 24.416 h -21.18 z" fill="#ffffff" fill-opacity="0.84706" opacity="1" id="path6583"/>
+    <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 2781,1738.2 a 75.591,75.591 0 0 0 -75.59,75.59 75.591,75.591 0 0 0 75.59,75.592 75.591,75.591 0 0 0 75.59,-75.592 75.591,75.591 0 0 0 -75.59,-75.59 z m -32.055,22.608 h 21.77 l -0.7364,64.717 h -20.297 z m 44.352,0 h 21.768 l -0.7344,64.717 h -20.297 z m -44.057,78.543 h 21.18 v 24.416 h -21.18 z m 44.352,0 h 21.18 v 24.416 h -21.18 z" fill="#ffffff" opacity="1" id="path6585"/>
+    <rect x="2495.8999" y="-986.84998" width="227.50999" height="225.84" ry="10.005" fill="none" id="rect6587" rx="10.005"/>
+    <g transform="matrix(0.69224,0,0,0.69224,4606.2,161.75)" id="g6593">
+      <path d="m -2596,-1580.3 16.619,-63.733 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.947,107.57 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.045 l -16.614,63.733 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.943,-107.57 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" id="path6589"/>
+      <rect x="-2721.3" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect6591"/>
     </g>
-    <g
-       transform="matrix(0.69224,0,0,0.69224,4662.3,226.81)"
-       id="g6599">
-      <path
-         d="m -2596,-1580.3 16.619,-63.733 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.947,107.57 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.045 l -16.614,63.733 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.943,-107.57 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z"
-         clip-rule="evenodd"
-         fill="#ffffff"
-         fill-rule="evenodd"
-         id="path6595" />
-      <rect
-         x="-2721.3"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6597" />
+    <g transform="matrix(0.69224,0,0,0.69224,4662.3,226.81)" id="g6599">
+      <path d="m -2596,-1580.3 16.619,-63.733 c 0.2037,-1.0229 0.4074,-1.6369 0.4074,-2.4561 0,-4.5026 -3.6325,-8.1867 -8.1452,-8.1867 -2.5587,0 -4.8307,1.1255 -6.3141,3.0701 l -82.947,107.57 c -1.1153,1.4331 -1.7802,3.1719 -1.7802,5.1165 0,4.5033 3.7248,8.2893 8.2681,8.2893 h 50.045 l -16.614,63.733 c -0.2037,1.0236 -0.4074,1.6376 -0.4074,2.4553 0,4.5033 3.6324,8.1874 8.1452,8.1874 2.5586,0 4.8306,-1.1254 6.3242,-2.9675 l 82.943,-107.57 c 1.1153,-1.4332 1.7809,-3.1727 1.7809,-5.1166 0,-4.5033 -3.7255,-8.2892 -8.2688,-8.2892 h -50.049 z" clip-rule="evenodd" fill="#ffffff" fill-rule="evenodd" id="path6595"/>
+      <rect x="-2721.3" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect6597"/>
     </g>
-    <rect
-       x="2723.3999"
-       y="-988.52002"
-       width="224.16"
-       height="230.85001"
-       ry="0"
-       fill="none"
-       id="rect6601" />
-    <path
-       d="m 2990.3,-953.61 c -9.815,0 -17.716,7.9024 -17.716,17.717 v 120.71 c 0,9.815 7.9005,17.717 17.716,17.717 h 142 c 9.815,0 17.717,-7.9023 17.717,-17.717 v -120.71 c 0,-9.815 -7.9023,-17.717 -17.717,-17.717 z m 7.7893,17.955 h 1.0712 c 3.9259,0 7.0862,3.1602 7.0862,7.0862 v 106.06 c 0,3.926 -3.1603,7.0862 -7.0862,7.0862 h -1.0712 c -3.926,0 -7.0862,-3.1602 -7.0862,-7.0862 v -106.06 c 0,-3.926 3.1602,-7.0862 7.0862,-7.0862 z m 25.734,0 h 1.0712 c 3.9261,0 7.0881,3.1602 7.0881,7.0862 v 106.06 c 0,3.926 -3.162,7.0862 -7.0881,7.0862 h -1.0712 c -3.9259,0 -7.0862,-3.1602 -7.0862,-7.0862 v -106.06 c 0,-3.926 3.1603,-7.0862 7.0862,-7.0862 z m 24.899,0 h 1.0712 c 3.9259,0 7.0862,3.1602 7.0862,7.0862 v 106.06 c 0,3.926 -3.1603,7.0862 -7.0862,7.0862 h -1.0712 c -3.926,0 -7.088,-3.1602 -7.088,-7.0862 v -106.06 c 0,-3.926 3.162,-7.0862 7.088,-7.0862 z m 36.502,13.718 a 10.941,10.941 0 0 1 10.94,10.941 10.941,10.941 0 0 1 -10.94,10.941 10.941,10.941 0 0 1 -10.942,-10.941 10.941,10.941 0 0 1 10.942,-10.941 z m 28.894,0 a 10.941,10.941 0 0 1 10.941,10.941 10.941,10.941 0 0 1 -10.941,10.941 10.941,10.941 0 0 1 -10.94,-10.941 10.941,10.941 0 0 1 10.94,-10.941 z m -28.894,35.457 a 10.941,10.941 0 0 1 10.94,10.941 10.941,10.941 0 0 1 -10.94,10.941 10.941,10.941 0 0 1 -10.942,-10.941 10.941,10.941 0 0 1 10.942,-10.941 z m 28.894,0 a 10.941,10.941 0 0 1 10.941,10.941 10.941,10.941 0 0 1 -10.941,10.941 10.941,10.941 0 0 1 -10.94,-10.941 10.941,10.941 0 0 1 10.94,-10.941 z m -28.894,35.457 a 10.941,10.941 0 0 1 10.94,10.941 10.941,10.941 0 0 1 -10.94,10.941 10.941,10.941 0 0 1 -10.942,-10.941 10.941,10.941 0 0 1 10.942,-10.941 z m 28.894,0 a 10.941,10.941 0 0 1 10.941,10.941 10.941,10.941 0 0 1 -10.941,10.941 10.941,10.941 0 0 1 -10.94,-10.941 10.941,10.941 0 0 1 10.94,-10.941 z"
-       fill="#ffffff"
-       opacity="1"
-       id="path6603" />
-    <rect
-       x="2948.8999"
-       y="-986.92999"
-       width="228.3"
-       height="225.92999"
-       fill="none"
-       id="rect6605" />
-    <g
-       transform="translate(-680.29,1814.1)"
-       id="g6611">
-      <rect
-         x="1814.1"
-         y="-2575.8999"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6607" />
-      <path
-         d="m 1897.8,-2462.5 h 59.542 c 5.8691,0 10.632,4.6298 10.632,10.335 0,5.7047 -4.7632,10.335 -10.632,10.335 H 1897.8 c -5.8691,0 -10.632,-4.6299 -10.632,-10.335 0,-5.7048 4.7634,-10.335 10.632,-10.335 z m 0,37.205 h 59.542 c 5.8691,0 10.632,4.63 10.632,10.335 0,5.705 -4.7632,10.335 -10.632,10.335 H 1897.8 c -5.8691,0 -10.632,-4.6299 -10.632,-10.335 0,-5.7051 4.7634,-10.335 10.632,-10.335 z m 112.7,45.472 c 0,9.1358 -7.6127,16.535 -17.012,16.535 h -131.84 c -9.3991,0 -17.012,-7.3996 -17.012,-16.535 v -140.55 c 0,-9.1358 7.6129,-16.535 17.012,-16.535 h 34.662 c 2.9303,-14.138 15.821,-24.803 31.259,-24.803 15.438,0 28.325,10.665 31.259,24.803 h 34.662 c 9.3991,0 17.012,7.3996 17.012,16.535 z m -30.622,-136.42 h -20.414 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.082 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.414 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.09 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.62 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.09 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.469 c 0,-5.7046 -4.7633,-10.335 -10.632,-10.335 -5.8692,0 -10.632,4.63 -10.632,10.335 0,5.7048 4.7633,10.335 10.632,10.335 5.8691,0 10.632,-4.6299 10.632,-10.335 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path6609" />
+    <rect x="2723.3999" y="-988.52002" width="224.16" height="230.85001" ry="0" fill="none" id="rect6601"/>
+    <path d="m 2990.3,-953.61 c -9.815,0 -17.716,7.9024 -17.716,17.717 v 120.71 c 0,9.815 7.9005,17.717 17.716,17.717 h 142 c 9.815,0 17.717,-7.9023 17.717,-17.717 v -120.71 c 0,-9.815 -7.9023,-17.717 -17.717,-17.717 z m 7.7893,17.955 h 1.0712 c 3.9259,0 7.0862,3.1602 7.0862,7.0862 v 106.06 c 0,3.926 -3.1603,7.0862 -7.0862,7.0862 h -1.0712 c -3.926,0 -7.0862,-3.1602 -7.0862,-7.0862 v -106.06 c 0,-3.926 3.1602,-7.0862 7.0862,-7.0862 z m 25.734,0 h 1.0712 c 3.9261,0 7.0881,3.1602 7.0881,7.0862 v 106.06 c 0,3.926 -3.162,7.0862 -7.0881,7.0862 h -1.0712 c -3.9259,0 -7.0862,-3.1602 -7.0862,-7.0862 v -106.06 c 0,-3.926 3.1603,-7.0862 7.0862,-7.0862 z m 24.899,0 h 1.0712 c 3.9259,0 7.0862,3.1602 7.0862,7.0862 v 106.06 c 0,3.926 -3.1603,7.0862 -7.0862,7.0862 h -1.0712 c -3.926,0 -7.088,-3.1602 -7.088,-7.0862 v -106.06 c 0,-3.926 3.162,-7.0862 7.088,-7.0862 z m 36.502,13.718 a 10.941,10.941 0 0 1 10.94,10.941 10.941,10.941 0 0 1 -10.94,10.941 10.941,10.941 0 0 1 -10.942,-10.941 10.941,10.941 0 0 1 10.942,-10.941 z m 28.894,0 a 10.941,10.941 0 0 1 10.941,10.941 10.941,10.941 0 0 1 -10.941,10.941 10.941,10.941 0 0 1 -10.94,-10.941 10.941,10.941 0 0 1 10.94,-10.941 z m -28.894,35.457 a 10.941,10.941 0 0 1 10.94,10.941 10.941,10.941 0 0 1 -10.94,10.941 10.941,10.941 0 0 1 -10.942,-10.941 10.941,10.941 0 0 1 10.942,-10.941 z m 28.894,0 a 10.941,10.941 0 0 1 10.941,10.941 10.941,10.941 0 0 1 -10.941,10.941 10.941,10.941 0 0 1 -10.94,-10.941 10.941,10.941 0 0 1 10.94,-10.941 z m -28.894,35.457 a 10.941,10.941 0 0 1 10.94,10.941 10.941,10.941 0 0 1 -10.94,10.941 10.941,10.941 0 0 1 -10.942,-10.941 10.941,10.941 0 0 1 10.942,-10.941 z m 28.894,0 a 10.941,10.941 0 0 1 10.941,10.941 10.941,10.941 0 0 1 -10.941,10.941 10.941,10.941 0 0 1 -10.94,-10.941 10.941,10.941 0 0 1 10.94,-10.941 z" fill="#ffffff" opacity="1" id="path6603"/>
+    <rect x="2948.8999" y="-986.92999" width="228.3" height="225.92999" fill="none" id="rect6605"/>
+    <g transform="translate(-680.29,1814.1)" id="g6611">
+      <rect x="1814.1" y="-2575.8999" width="226.77" height="226.77" fill="none" opacity="1" id="rect6607"/>
+      <path d="m 1897.8,-2462.5 h 59.542 c 5.8691,0 10.632,4.6298 10.632,10.335 0,5.7047 -4.7632,10.335 -10.632,10.335 H 1897.8 c -5.8691,0 -10.632,-4.6299 -10.632,-10.335 0,-5.7048 4.7634,-10.335 10.632,-10.335 z m 0,37.205 h 59.542 c 5.8691,0 10.632,4.63 10.632,10.335 0,5.705 -4.7632,10.335 -10.632,10.335 H 1897.8 c -5.8691,0 -10.632,-4.6299 -10.632,-10.335 0,-5.7051 4.7634,-10.335 10.632,-10.335 z m 112.7,45.472 c 0,9.1358 -7.6127,16.535 -17.012,16.535 h -131.84 c -9.3991,0 -17.012,-7.3996 -17.012,-16.535 v -140.55 c 0,-9.1358 7.6129,-16.535 17.012,-16.535 h 34.662 c 2.9303,-14.138 15.821,-24.803 31.259,-24.803 15.438,0 28.325,10.665 31.259,24.803 h 34.662 c 9.3991,0 17.012,7.3996 17.012,16.535 z m -30.622,-136.42 h -20.414 v 7.4409 c 0,5.0433 -4.1679,9.0945 -9.3566,9.0945 h -45.082 c -5.1885,0 -9.3565,-4.0512 -9.3565,-9.0945 v -7.4409 h -20.414 c -5.1887,0 -9.3566,4.0512 -9.3566,9.0944 v 114.09 c 0,5.0432 4.1679,9.0944 9.3566,9.0944 h 104.62 c 5.1887,0 9.3566,-4.0512 9.3566,-9.0944 v -114.09 c 0,-5.0432 -4.1679,-9.0944 -9.3566,-9.0944 z m -41.679,-14.469 c 0,-5.7046 -4.7633,-10.335 -10.632,-10.335 -5.8692,0 -10.632,4.63 -10.632,10.335 0,5.7048 4.7633,10.335 10.632,10.335 5.8691,0 10.632,-4.6299 10.632,-10.335 z" fill="#ffffff" opacity="1" id="path6609"/>
     </g>
-    <g
-       fill="#ffffff"
-       id="g6619">
-      <path
-         d="m 396.85,159.45 c -3.5441,0 -3.5441,14.173 0,14.174 h 15.535 l -19.079,17.716 v 10.629 h 10.629 l 21.261,-19.606 v 19.607 c -0.001,3.5423 14.172,3.5423 14.172,0 v -42.521 h -10.629 z"
-         id="path6613" />
-      <path
-         d="m 302.19,300.98 -0.15976,26.16 h -13.376 c -6.6878,1e-4 -6.6878,13.112 0,13.112 h 13.376 v 13.112 c -3e-5,6.5562 13.376,6.5562 13.376,-10e-6 v -13.112 h 13.376 c 6.6877,9e-5 6.6877,-13.112 -0.079,-13.213 l -13.297,0.10076 -0.16905,-26.228 z m 6.0798,-123.01 a 66.885,64.704 0 0 0 -66.885,64.703 66.885,64.704 0 0 0 66.885,64.705 66.885,64.704 0 0 0 66.885,-64.705 66.885,64.704 0 0 0 -66.885,-64.703 z m 0,13.37 a 53.065,51.334 0 0 1 53.064,51.333 53.065,51.334 0 0 1 -53.064,51.335 53.065,51.334 0 0 1 -53.066,-51.335 53.065,51.334 0 0 1 53.066,-51.333 z"
-         stroke="#ffffff"
-         stroke-width="0.87598px"
-         id="path6615" />
-      <path
-         d="m 358.31,175.62 c -36.938,3.4e-4 -66.882,29.248 -66.883,65.328 -6.8e-4,36.08 29.944,65.329 66.883,65.329 36.939,-3.4e-4 66.883,-29.249 66.883,-65.329 -3.3e-4,-36.079 -29.945,-65.327 -66.883,-65.328 z m 0,13.499 c 29.306,5e-4 53.062,23.205 53.063,51.829 4.6e-4,28.625 -23.757,51.83 -53.063,51.831 -29.307,4.4e-4 -53.065,-23.205 -53.064,-51.831 5e-4,-28.625 23.758,-51.829 53.064,-51.829 z"
-         id="path6617" />
+    <g fill="#ffffff" id="g6619">
+      <path d="m 396.85,159.45 c -3.5441,0 -3.5441,14.173 0,14.174 h 15.535 l -19.079,17.716 v 10.629 h 10.629 l 21.261,-19.606 v 19.607 c -0.001,3.5423 14.172,3.5423 14.172,0 v -42.521 h -10.629 z" id="path6613"/>
+      <path d="m 302.19,300.98 -0.15976,26.16 h -13.376 c -6.6878,1e-4 -6.6878,13.112 0,13.112 h 13.376 v 13.112 c -3e-5,6.5562 13.376,6.5562 13.376,-10e-6 v -13.112 h 13.376 c 6.6877,9e-5 6.6877,-13.112 -0.079,-13.213 l -13.297,0.10076 -0.16905,-26.228 z m 6.0798,-123.01 a 66.885,64.704 0 0 0 -66.885,64.703 66.885,64.704 0 0 0 66.885,64.705 66.885,64.704 0 0 0 66.885,-64.705 66.885,64.704 0 0 0 -66.885,-64.703 z m 0,13.37 a 53.065,51.334 0 0 1 53.064,51.333 53.065,51.334 0 0 1 -53.064,51.335 53.065,51.334 0 0 1 -53.066,-51.335 53.065,51.334 0 0 1 53.066,-51.333 z" stroke="#ffffff" stroke-width="0.87598px" id="path6615"/>
+      <path d="m 358.31,175.62 c -36.938,3.4e-4 -66.882,29.248 -66.883,65.328 -6.8e-4,36.08 29.944,65.329 66.883,65.329 36.939,-3.4e-4 66.883,-29.249 66.883,-65.329 -3.3e-4,-36.079 -29.945,-65.327 -66.883,-65.328 z m 0,13.499 c 29.306,5e-4 53.062,23.205 53.063,51.829 4.6e-4,28.625 -23.757,51.83 -53.063,51.831 -29.307,4.4e-4 -53.065,-23.205 -53.064,-51.831 5e-4,-28.625 23.758,-51.829 53.064,-51.829 z" id="path6617"/>
     </g>
-    <rect
-       x="226.77"
-       y="144.94"
-       width="228.24001"
-       height="228.24001"
-       fill="none"
-       id="rect6621" />
-    <path
-       d="m 1190.6,230.31 v 127.56 h 113.39 V 230.31 l 21.26,10.63 21.26,-53.15 -56.693,-28.346 h -14.173 l -28.346,28.346 -28.346,-28.346 h -14.173 l -56.693,28.346 21.26,53.15 21.26,-10.63"
-       fill="#ffffff"
-       stroke="#c2c2c2"
-       stroke-width="0.9375px"
-       id="path6623" />
-    <rect
-       x="1133.9"
-       y="145.34"
-       width="227.84"
-       height="227.84"
-       fill="none"
-       id="rect6625" />
-    <path
-       d="m 1569.7,242.72 -26.126,37.555 a 27.885,27.885 0 0 0 -27.023,-21.149 27.885,27.885 0 0 0 -27.825,26.115 h -44.863 a 27.885,27.885 0 0 0 -27.753,-25.267 27.885,27.885 0 0 0 -6.1982,0.72506 l 7.4249,-10.891 c 3.5434,3.5433 5.3146,7.0862 7.0862,7.0862 1.7718,0 3.5437,-1.7717 -7.0862,-12.402 l -12.411,17.84 a 27.885,27.885 0 0 0 -16.703,25.527 27.885,27.885 0 0 0 27.887,27.887 27.885,27.885 0 0 0 27.852,-26.962 h 44.789 a 27.885,27.885 0 0 0 27.799,26.115 27.885,27.885 0 0 0 27.885,-27.887 27.885,27.885 0 0 0 -0.09,-1.7907 l 25.353,-37.185 c 3.5433,3.5433 5.3164,7.0862 7.088,7.0862 1.7717,0 3.5419,-1.7718 -7.088,-12.402 z m -53.148,19.933 a 24.358,24.358 0 0 1 24.358,24.358 24.358,24.358 0 0 1 -24.358,24.358 24.358,24.358 0 0 1 -24.359,-24.358 24.358,24.358 0 0 1 24.359,-24.358 z m -100.44,0.84778 a 24.358,24.358 0 0 1 24.358,24.358 24.358,24.358 0 0 1 -24.358,24.358 24.358,24.358 0 0 1 -24.359,-24.358 24.358,24.358 0 0 1 0.029,-0.56765 l 14.91,-21.87 a 24.358,24.358 0 0 1 9.419,-1.9208 z m -16.496,6.4691 -6.0425,8.6847 a 24.358,24.358 0 0 1 6.0425,-8.6847 z"
-       fill="#ffffff"
-       stroke="#c2c2c2"
-       stroke-width="0.92225"
-       id="path6627" />
-    <rect
-       x="1360.6"
-       y="145.28"
-       width="226.91"
-       height="226.77"
-       fill="none"
-       id="rect6629" />
-    <path
-       d="m 1675.3,215.13 c -4.4289,7.5649 -9.5225,18.85 -15.17,33.858 -1.6609,-3.7225 -2.9904,-6.6982 -4.0976,-8.9294 -1.1071,-2.358 -2.6568,-4.9603 -4.5399,-7.9383 -1.8812,-2.9757 -3.7642,-5.3314 -5.6473,-6.9448 -3.6529,-3.4713 -9.4112,-6.2005 -15.943,-6.2005 h -24.803 c -2.1054,0 -3.5439,-1.6111 -3.5439,-3.9691 v -23.81 c 0,-2.3556 1.4385,-3.9691 3.5439,-3.9691 h 24.803 c 18.491,0 33.55,9.3028 45.398,27.904 z m 123.68,101.94 -35.433,39.684 c -0.6648,0.7446 -1.5517,1.1158 -2.5478,1.1158 -1.8831,0 -3.5437,-1.8602 -3.5437,-3.9692 v -23.81 c -2.3238,0 -5.5361,0 -9.4113,0.1246 -3.8755,0 -6.8659,0 -8.9691,0.1246 -2.1032,0 -4.7622,0 -8.0838,-0.1246 -3.3216,-0.1246 -5.9784,-0.371 -7.8615,-0.6199 -1.881,-0.3712 -4.3177,-0.7446 -7.086,-1.3646 -5.6469,-1.1158 -8.5261,-2.976 -13.398,-5.8292 -6.9767,-4.2158 -12.402,-10.541 -18.825,-20.215 4.3178,-7.6871 9.4113,-18.974 15.058,-33.855 l 4.0976,9.0539 c 1.1072,2.2312 2.5478,4.8359 4.4288,7.8113 1.8831,2.9781 3.7661,5.3337 5.6474,7.0696 3.875,3.3491 9.5221,6.0758 16.057,6.0758 h 28.345 v -23.81 c 0,-2.3559 1.4406,-3.9691 3.5437,-3.9691 0.8871,0 1.7719,0.3734 2.6571,1.24 l 35.324,39.562 c 1.3274,1.4866 1.3274,4.2158 0,5.7048 z m 0,-111.12 -35.433,39.685 c -0.6648,0.7445 -1.5517,1.1156 -2.5478,1.1156 -1.8831,0 -3.5437,-1.8601 -3.5437,-3.9691 v -23.81 h -28.345 c -7.088,0 -12.844,2.4803 -17.275,7.4405 -4.4289,4.9603 -7.086,9.674 -10.63,17.239 -2.3258,5.0846 -5.2047,12.154 -8.6355,21.206 -2.1053,5.4581 -3.9863,10.047 -5.538,13.768 -1.4386,3.7202 -3.4328,8.0605 -5.9786,13.021 -2.4367,4.9602 -4.7622,9.0538 -7.0859,12.401 -4.4307,6.5737 -11.185,14.51 -18.16,18.852 -6.7544,4.0914 -15.834,7.1915 -25.91,7.1915 h -24.803 c -2.1054,0 -3.5439,-1.6112 -3.5439,-3.9691 v -23.81 c 0,-2.3559 1.4385,-3.969 3.5439,-3.969 h 24.803 c 7.0857,0 12.844,-2.4802 17.273,-7.4402 4.4287,-4.9604 7.0877,-9.6719 10.63,-17.237 2.3256,-5.0848 5.2047,-12.154 8.6374,-21.208 l 5.425,-13.765 c 1.5517,-3.7202 3.5439,-8.0605 5.9806,-13.021 2.5457,-4.9625 4.8714,-9.0539 7.0857,-12.403 4.54,-6.5714 11.406,-14.634 18.16,-18.726 6.9766,-4.3403 15.945,-7.3182 26.022,-7.3182 h 28.345 v -23.81 c 0,-2.3557 1.4406,-3.9691 3.5437,-3.9691 0.8872,0 1.772,0.3734 2.6571,1.24 l 35.324,39.562 c 1.3272,1.4868 1.3272,4.2161 -2e-4,5.7048 z"
-       fill="#ffffff"
-       id="path6631" />
-    <rect
-       x="1589.2"
-       y="145.67999"
-       width="224.96001"
-       height="224.16"
-       fill="none"
-       id="rect6633" />
-    <path
-       d="m 759.95,221.12 c 10.265,2.9451 24.39,14.149 34.291,14.027 10.848,-0.1506 23.88,-11.841 34.874,-14.756 21.659,-5.7081 42.008,15.606 47.323,30.666 l -47.323,-2.6415 c 0,0 -36.402,5.4955 -36.402,5.4955 l -36.402,-5.5562 -43.683,2.7022 c 5.424,-15.394 25.373,-36.252 47.323,-29.937 z m 3.6402,41.414 c 0,0 36.402,5.4652 36.402,5.4652 l 29.122,-5.4652 h 40.043 c -21.623,49.278 -128.43,49.278 -149.25,0 z"
-       fill="#ffffff"
-       stroke="#d2d2d2"
-       stroke-width="3.3245"
-       id="path6635" />
-    <rect
-       x="680.40997"
-       y="145.58"
-       width="227.67999"
-       height="226.47"
-       fill="none"
-       id="rect6637" />
-    <path
-       d="m 591.61,251.77 c -4.0734,-14.631 -9.5308,-57.793 -8.3444,-72.852 0.514,-6.6502 3.6382,-23.254 13.446,-16.518 7.4744,5.1057 9.9659,55.733 12.734,67.918 6.8414,30.033 46.863,57.321 19.813,87.569 l -22.502,19.693 c -9.689,8.3664 -15.028,13.73 -27.683,16.175 -20.405,2.3572 -32.982,-5.0198 -52.083,-21.409 -7.3556,-6.3499 -18.31,-12.528 -22.937,-21.409 -12.853,-24.542 17.659,-61.544 27.564,-46.294 7.6528,13.732 -10.561,27.199 -7.9094,38.614 17.242,14.773 30.649,22.01 39.547,25.099 13.842,4.8053 44.887,-17.639 55.366,-29.39 -1.6993,-14.405 -21.751,-28.489 -27.01,-47.195 z"
-       fill="#ffffff"
-       stroke="#ffffff"
-       stroke-width="4.1192"
-       id="path6639" />
-    <rect
-       x="453.54001"
-       y="145.28"
-       width="226.77"
-       height="226.77"
-       fill="none"
-       id="rect6641" />
-    <g
-       transform="translate(-4762.2,1133.9)"
-       id="g6649">
-      <rect
-         x="8163.7998"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6643" />
-      <path
-         d="m 8203.7,-2506 -28.438,-0.4182 49.767,65.241 56.877,-63.568 -35.966,-0.8364 c 0,0 8.0177,-38.362 43.342,-41.995 28.439,4.1822 18.554,47.431 18.554,47.431 0,0 7.1096,-5.4369 17.983,-5.0187 10.874,0.4183 15.892,11.919 15.892,11.919 0,0 4.182,-23.211 -4.1822,-37.848 -8.3642,-14.637 -28.438,-31.784 -53.531,-30.53 -25.093,1.2547 -44.331,4.1821 -62.314,23.838 -14.638,18.82 -17.983,31.784 -17.983,31.784 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path6645" />
-      <path
-         d="m 8234.9,-2421.4 50.239,63.682 0.3823,-35.772 c 40.233,6.163 71.287,1.8276 85.669,-13.457 14.382,-15.285 15.012,-40.82 5.6423,-57.639 -9.3693,-16.819 -32.095,-21.798 -32.095,-21.798 0,0 6.1707,10.971 6.3568,20.872 0.1827,9.7237 -10.243,16.349 -10.243,16.349 0,0 17.512,1.9115 20.836,3.4682 3.324,1.5567 5.762,1.9039 -0.5228,7.4519 -6.2848,5.548 -41.233,12.442 -74.941,2.6361 l 0.8277,-38.78 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path6647" />
+    <rect x="226.77" y="144.94" width="228.24001" height="228.24001" fill="none" id="rect6621"/>
+    <path d="m 1190.6,230.31 v 127.56 h 113.39 V 230.31 l 21.26,10.63 21.26,-53.15 -56.693,-28.346 h -14.173 l -28.346,28.346 -28.346,-28.346 h -14.173 l -56.693,28.346 21.26,53.15 21.26,-10.63" fill="#ffffff" stroke="#c2c2c2" stroke-width="0.9375px" id="path6623"/>
+    <rect x="1133.9" y="145.34" width="227.84" height="227.84" fill="none" id="rect6625"/>
+    <path d="m 1569.7,242.72 -26.126,37.555 a 27.885,27.885 0 0 0 -27.023,-21.149 27.885,27.885 0 0 0 -27.825,26.115 h -44.863 a 27.885,27.885 0 0 0 -27.753,-25.267 27.885,27.885 0 0 0 -6.1982,0.72506 l 7.4249,-10.891 c 3.5434,3.5433 5.3146,7.0862 7.0862,7.0862 1.7718,0 3.5437,-1.7717 -7.0862,-12.402 l -12.411,17.84 a 27.885,27.885 0 0 0 -16.703,25.527 27.885,27.885 0 0 0 27.887,27.887 27.885,27.885 0 0 0 27.852,-26.962 h 44.789 a 27.885,27.885 0 0 0 27.799,26.115 27.885,27.885 0 0 0 27.885,-27.887 27.885,27.885 0 0 0 -0.09,-1.7907 l 25.353,-37.185 c 3.5433,3.5433 5.3164,7.0862 7.088,7.0862 1.7717,0 3.5419,-1.7718 -7.088,-12.402 z m -53.148,19.933 a 24.358,24.358 0 0 1 24.358,24.358 24.358,24.358 0 0 1 -24.358,24.358 24.358,24.358 0 0 1 -24.359,-24.358 24.358,24.358 0 0 1 24.359,-24.358 z m -100.44,0.84778 a 24.358,24.358 0 0 1 24.358,24.358 24.358,24.358 0 0 1 -24.358,24.358 24.358,24.358 0 0 1 -24.359,-24.358 24.358,24.358 0 0 1 0.029,-0.56765 l 14.91,-21.87 a 24.358,24.358 0 0 1 9.419,-1.9208 z m -16.496,6.4691 -6.0425,8.6847 a 24.358,24.358 0 0 1 6.0425,-8.6847 z" fill="#ffffff" stroke="#c2c2c2" stroke-width="0.92225" id="path6627"/>
+    <rect x="1360.6" y="145.28" width="226.91" height="226.77" fill="none" id="rect6629"/>
+    <path d="m 1675.3,215.13 c -4.4289,7.5649 -9.5225,18.85 -15.17,33.858 -1.6609,-3.7225 -2.9904,-6.6982 -4.0976,-8.9294 -1.1071,-2.358 -2.6568,-4.9603 -4.5399,-7.9383 -1.8812,-2.9757 -3.7642,-5.3314 -5.6473,-6.9448 -3.6529,-3.4713 -9.4112,-6.2005 -15.943,-6.2005 h -24.803 c -2.1054,0 -3.5439,-1.6111 -3.5439,-3.9691 v -23.81 c 0,-2.3556 1.4385,-3.9691 3.5439,-3.9691 h 24.803 c 18.491,0 33.55,9.3028 45.398,27.904 z m 123.68,101.94 -35.433,39.684 c -0.6648,0.7446 -1.5517,1.1158 -2.5478,1.1158 -1.8831,0 -3.5437,-1.8602 -3.5437,-3.9692 v -23.81 c -2.3238,0 -5.5361,0 -9.4113,0.1246 -3.8755,0 -6.8659,0 -8.9691,0.1246 -2.1032,0 -4.7622,0 -8.0838,-0.1246 -3.3216,-0.1246 -5.9784,-0.371 -7.8615,-0.6199 -1.881,-0.3712 -4.3177,-0.7446 -7.086,-1.3646 -5.6469,-1.1158 -8.5261,-2.976 -13.398,-5.8292 -6.9767,-4.2158 -12.402,-10.541 -18.825,-20.215 4.3178,-7.6871 9.4113,-18.974 15.058,-33.855 l 4.0976,9.0539 c 1.1072,2.2312 2.5478,4.8359 4.4288,7.8113 1.8831,2.9781 3.7661,5.3337 5.6474,7.0696 3.875,3.3491 9.5221,6.0758 16.057,6.0758 h 28.345 v -23.81 c 0,-2.3559 1.4406,-3.9691 3.5437,-3.9691 0.8871,0 1.7719,0.3734 2.6571,1.24 l 35.324,39.562 c 1.3274,1.4866 1.3274,4.2158 0,5.7048 z m 0,-111.12 -35.433,39.685 c -0.6648,0.7445 -1.5517,1.1156 -2.5478,1.1156 -1.8831,0 -3.5437,-1.8601 -3.5437,-3.9691 v -23.81 h -28.345 c -7.088,0 -12.844,2.4803 -17.275,7.4405 -4.4289,4.9603 -7.086,9.674 -10.63,17.239 -2.3258,5.0846 -5.2047,12.154 -8.6355,21.206 -2.1053,5.4581 -3.9863,10.047 -5.538,13.768 -1.4386,3.7202 -3.4328,8.0605 -5.9786,13.021 -2.4367,4.9602 -4.7622,9.0538 -7.0859,12.401 -4.4307,6.5737 -11.185,14.51 -18.16,18.852 -6.7544,4.0914 -15.834,7.1915 -25.91,7.1915 h -24.803 c -2.1054,0 -3.5439,-1.6112 -3.5439,-3.9691 v -23.81 c 0,-2.3559 1.4385,-3.969 3.5439,-3.969 h 24.803 c 7.0857,0 12.844,-2.4802 17.273,-7.4402 4.4287,-4.9604 7.0877,-9.6719 10.63,-17.237 2.3256,-5.0848 5.2047,-12.154 8.6374,-21.208 l 5.425,-13.765 c 1.5517,-3.7202 3.5439,-8.0605 5.9806,-13.021 2.5457,-4.9625 4.8714,-9.0539 7.0857,-12.403 4.54,-6.5714 11.406,-14.634 18.16,-18.726 6.9766,-4.3403 15.945,-7.3182 26.022,-7.3182 h 28.345 v -23.81 c 0,-2.3557 1.4406,-3.9691 3.5437,-3.9691 0.8872,0 1.772,0.3734 2.6571,1.24 l 35.324,39.562 c 1.3272,1.4868 1.3272,4.2161 -2e-4,5.7048 z" fill="#ffffff" id="path6631"/>
+    <rect x="1589.2" y="145.67999" width="224.96001" height="224.16" fill="none" id="rect6633"/>
+    <path d="m 759.95,221.12 c 10.265,2.9451 24.39,14.149 34.291,14.027 10.848,-0.1506 23.88,-11.841 34.874,-14.756 21.659,-5.7081 42.008,15.606 47.323,30.666 l -47.323,-2.6415 c 0,0 -36.402,5.4955 -36.402,5.4955 l -36.402,-5.5562 -43.683,2.7022 c 5.424,-15.394 25.373,-36.252 47.323,-29.937 z m 3.6402,41.414 c 0,0 36.402,5.4652 36.402,5.4652 l 29.122,-5.4652 h 40.043 c -21.623,49.278 -128.43,49.278 -149.25,0 z" fill="#ffffff" stroke="#d2d2d2" stroke-width="3.3245" id="path6635"/>
+    <rect x="680.40997" y="145.58" width="227.67999" height="226.47" fill="none" id="rect6637"/>
+    <path d="m 591.61,251.77 c -4.0734,-14.631 -9.5308,-57.793 -8.3444,-72.852 0.514,-6.6502 3.6382,-23.254 13.446,-16.518 7.4744,5.1057 9.9659,55.733 12.734,67.918 6.8414,30.033 46.863,57.321 19.813,87.569 l -22.502,19.693 c -9.689,8.3664 -15.028,13.73 -27.683,16.175 -20.405,2.3572 -32.982,-5.0198 -52.083,-21.409 -7.3556,-6.3499 -18.31,-12.528 -22.937,-21.409 -12.853,-24.542 17.659,-61.544 27.564,-46.294 7.6528,13.732 -10.561,27.199 -7.9094,38.614 17.242,14.773 30.649,22.01 39.547,25.099 13.842,4.8053 44.887,-17.639 55.366,-29.39 -1.6993,-14.405 -21.751,-28.489 -27.01,-47.195 z" fill="#ffffff" stroke="#ffffff" stroke-width="4.1192" id="path6639"/>
+    <rect x="453.54001" y="145.28" width="226.77" height="226.77" fill="none" id="rect6641"/>
+    <g transform="translate(-4762.2,1133.9)" id="g6649">
+      <rect x="8163.7998" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect6643"/>
+      <path d="m 8203.7,-2506 -28.438,-0.4182 49.767,65.241 56.877,-63.568 -35.966,-0.8364 c 0,0 8.0177,-38.362 43.342,-41.995 28.439,4.1822 18.554,47.431 18.554,47.431 0,0 7.1096,-5.4369 17.983,-5.0187 10.874,0.4183 15.892,11.919 15.892,11.919 0,0 4.182,-23.211 -4.1822,-37.848 -8.3642,-14.637 -28.438,-31.784 -53.531,-30.53 -25.093,1.2547 -44.331,4.1821 -62.314,23.838 -14.638,18.82 -17.983,31.784 -17.983,31.784 z" fill="#ffffff" opacity="1" id="path6645"/>
+      <path d="m 8234.9,-2421.4 50.239,63.682 0.3823,-35.772 c 40.233,6.163 71.287,1.8276 85.669,-13.457 14.382,-15.285 15.012,-40.82 5.6423,-57.639 -9.3693,-16.819 -32.095,-21.798 -32.095,-21.798 0,0 6.1707,10.971 6.3568,20.872 0.1827,9.7237 -10.243,16.349 -10.243,16.349 0,0 17.512,1.9115 20.836,3.4682 3.324,1.5567 5.762,1.9039 -0.5228,7.4519 -6.2848,5.548 -41.233,12.442 -74.941,2.6361 l 0.8277,-38.78 z" fill="#ffffff" opacity="1" id="path6647"/>
     </g>
-    <g
-       transform="translate(-6803.1,3174.8)"
-       id="g6683">
-      <g
-         fill="none"
-         id="g6669">
-        <rect
-           x="8163.7998"
-           y="-2576"
-           width="226.77"
-           height="226.77"
-           opacity="1"
-           id="rect6651" />
-        <circle
-           cx="8324.9004"
-           cy="-2518.6001"
-           r="21.26"
-           stroke="#ffffee"
-           stroke-width="8.8583"
-           id="circle6653" />
-        <g
-           stroke="#ffffff"
-           stroke-width="7.0866"
-           id="g6667">
-          <g
-             stroke-dasharray="7.08661, 7.08661"
-             id="g6661">
-            <path
-               d="m 8307.4,-2507.8 -103.21,60.623"
-               id="path6655" />
-            <path
-               d="m 8304.4,-2520 -78.532,-5.4549"
-               id="path6657" />
-            <path
-               d="m 8331.2,-2497.4 19.748,68.569"
-               id="path6659" />
+    <g transform="translate(-6803.1,3174.8)" id="g6683">
+      <g fill="none" id="g6669">
+        <rect x="8163.7998" y="-2576" width="226.77" height="226.77" opacity="1" id="rect6651"/>
+        <circle cx="8324.9004" cy="-2518.6001" r="21.26" stroke="#ffffee" stroke-width="8.8583" id="circle6653"/>
+        <g stroke="#ffffff" stroke-width="7.0866" id="g6667">
+          <g stroke-dasharray="7.08661, 7.08661" id="g6661">
+            <path d="m 8307.4,-2507.8 -103.21,60.623" id="path6655"/>
+            <path d="m 8304.4,-2520 -78.532,-5.4549" id="path6657"/>
+            <path d="m 8331.2,-2497.4 19.748,68.569" id="path6659"/>
           </g>
-          <path
-             d="m 8343.4,-2504.4 c 25.929,32.621 23.808,70.911 -8.8419,109"
-             id="path6663" />
-          <path
-             d="m 8189.3,-2511.5 c 43.284,-24.375 69.948,-32.19 116.97,-20.235"
-             id="path6665" />
+          <path d="m 8343.4,-2504.4 c 25.929,32.621 23.808,70.911 -8.8419,109" id="path6663"/>
+          <path d="m 8189.3,-2511.5 c 43.284,-24.375 69.948,-32.19 116.97,-20.235" id="path6665"/>
         </g>
       </g>
-      <g
-         fill="#ffffff"
-         id="g6681">
-        <ellipse
-           cx="8219.2998"
-           cy="-2528.8"
-           rx="8.5103998"
-           ry="8.2357998"
-           stroke="#ffffff"
-           stroke-width="9.3037"
-           id="ellipse6671" />
-        <ellipse
-           cx="8354"
-           cy="-2425.8999"
-           rx="8.5103998"
-           ry="8.2357998"
-           stroke="#ffffff"
-           stroke-width="9.3037"
-           id="ellipse6673" />
-        <path
-           d="m 8219.5,-2382 q -9.2338,0 -9.2338,-5.8874 v -38.634 h 8.615 v 36.788 q 0,1.3935 0.2857,1.7418 0.5711,0.5574 2.3322,0.5574 h 16.183 v 5.4346 z"
-           id="path6675" />
-        <path
-           d="m 8266.9,-2407.9 q 0,-2.9263 -3.8554,-2.9263 h -8.6626 q -1.4279,0 -2.2372,0.6619 -0.7615,0.627 -0.8091,1.6373 h -8.1867 q 0.096,-3.1701 2.7131,-5.2952 2.7605,-2.2644 6.9967,-2.2644 h 12.708 q 4.0934,0 6.7588,2.2296 2.5703,2.1251 2.5703,5.1907 v 26.615 h -7.9488 v -1.3586 q -2.5702,1.4631 -5.0452,1.4631 h -7.8059 q -4.3314,0 -7.7108,-1.9509 -3.665,-2.125 -3.665,-5.1558 v -6.619 q 0,-3.0657 3.665,-5.1907 3.427,-1.9858 7.7108,-1.9858 h 9.2338 q 1.9039,0 3.5698,0.7665 z m -0.1429,17.697 v -4.3198 q 0,-1.3237 -1.0471,-2.2295 -0.9995,-0.9406 -2.951,-0.9406 h -8.0915 q -1.999,0 -2.9034,0.9406 -0.9043,0.9058 -0.9043,2.2295 v 4.3198 q 0,1.3238 0.9043,2.2645 0.9044,0.9057 2.9034,0.9057 h 8.0915 q 1.9515,0 2.951,-0.9057 1.0471,-0.9407 1.0471,-2.2645 z"
-           id="path6677" />
-        <path
-           d="m 8296.2,-2415.9 q 3.8077,0 6.9015,1.6373 v -1.6373 h 7.4728 l 0.048,40.341 q 0,3.2747 -2.0942,5.8178 -2.4275,2.8566 -6.7589,2.8566 h -10.471 q -3.3794,0 -5.9973,-1.5329 -2.7605,-1.6721 -2.7605,-4.0758 v -2.2296 h 7.2347 q -0.048,1.1148 0.9519,1.8464 1.0472,0.7315 2.5703,0.7315 h 4.2361 q 3.0938,0 4.4265,-1.498 0.4284,-0.4877 0.4284,-1.1844 v -8.9531 q -3.189,1.707 -5.2356,1.707 h -5.2358 q -6.2351,0 -9.4718,-2.9263 -2.8558,-2.6476 -2.8558,-7.3855 v -13.935 q 0,-4.4592 3.5698,-7.0023 3.6174,-2.5779 9.7098,-2.5779 z m 6.1876,25.222 v -17.523 q 0,-1.6026 -3.3794,-2.369 -0.8092,-0.209 -1.4756,-0.209 h -4.0933 q -4.9025,0 -5.5213,3.1353 -0.1903,0.9755 -0.1903,2.16 v 12.646 q 0,2.6128 0.8091,3.6579 1.5232,1.9508 4.9025,1.9508 h 4.0933 q 1.3804,0 2.6179,-0.836 2.2371,-1.5677 2.2371,-2.6128 z"
-           id="path6679" />
+      <g fill="#ffffff" id="g6681">
+        <ellipse cx="8219.2998" cy="-2528.8" rx="8.5103998" ry="8.2357998" stroke="#ffffff" stroke-width="9.3037" id="ellipse6671"/>
+        <ellipse cx="8354" cy="-2425.8999" rx="8.5103998" ry="8.2357998" stroke="#ffffff" stroke-width="9.3037" id="ellipse6673"/>
+        <path d="m 8219.5,-2382 q -9.2338,0 -9.2338,-5.8874 v -38.634 h 8.615 v 36.788 q 0,1.3935 0.2857,1.7418 0.5711,0.5574 2.3322,0.5574 h 16.183 v 5.4346 z" id="path6675"/>
+        <path d="m 8266.9,-2407.9 q 0,-2.9263 -3.8554,-2.9263 h -8.6626 q -1.4279,0 -2.2372,0.6619 -0.7615,0.627 -0.8091,1.6373 h -8.1867 q 0.096,-3.1701 2.7131,-5.2952 2.7605,-2.2644 6.9967,-2.2644 h 12.708 q 4.0934,0 6.7588,2.2296 2.5703,2.1251 2.5703,5.1907 v 26.615 h -7.9488 v -1.3586 q -2.5702,1.4631 -5.0452,1.4631 h -7.8059 q -4.3314,0 -7.7108,-1.9509 -3.665,-2.125 -3.665,-5.1558 v -6.619 q 0,-3.0657 3.665,-5.1907 3.427,-1.9858 7.7108,-1.9858 h 9.2338 q 1.9039,0 3.5698,0.7665 z m -0.1429,17.697 v -4.3198 q 0,-1.3237 -1.0471,-2.2295 -0.9995,-0.9406 -2.951,-0.9406 h -8.0915 q -1.999,0 -2.9034,0.9406 -0.9043,0.9058 -0.9043,2.2295 v 4.3198 q 0,1.3238 0.9043,2.2645 0.9044,0.9057 2.9034,0.9057 h 8.0915 q 1.9515,0 2.951,-0.9057 1.0471,-0.9407 1.0471,-2.2645 z" id="path6677"/>
+        <path d="m 8296.2,-2415.9 q 3.8077,0 6.9015,1.6373 v -1.6373 h 7.4728 l 0.048,40.341 q 0,3.2747 -2.0942,5.8178 -2.4275,2.8566 -6.7589,2.8566 h -10.471 q -3.3794,0 -5.9973,-1.5329 -2.7605,-1.6721 -2.7605,-4.0758 v -2.2296 h 7.2347 q -0.048,1.1148 0.9519,1.8464 1.0472,0.7315 2.5703,0.7315 h 4.2361 q 3.0938,0 4.4265,-1.498 0.4284,-0.4877 0.4284,-1.1844 v -8.9531 q -3.189,1.707 -5.2356,1.707 h -5.2358 q -6.2351,0 -9.4718,-2.9263 -2.8558,-2.6476 -2.8558,-7.3855 v -13.935 q 0,-4.4592 3.5698,-7.0023 3.6174,-2.5779 9.7098,-2.5779 z m 6.1876,25.222 v -17.523 q 0,-1.6026 -3.3794,-2.369 -0.8092,-0.209 -1.4756,-0.209 h -4.0933 q -4.9025,0 -5.5213,3.1353 -0.1903,0.9755 -0.1903,2.16 v 12.646 q 0,2.6128 0.8091,3.6579 1.5232,1.9508 4.9025,1.9508 h 4.0933 q 1.3804,0 2.6179,-0.836 2.2371,-1.5677 2.2371,-2.6128 z" id="path6679"/>
       </g>
     </g>
-    <g
-       transform="translate(-7483.5,3174.8)"
-       id="g6689">
-      <rect
-         x="8163.7998"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6685" />
-      <path
-         d="m 8227.4,-2553.9 -22.329,16.617 c 0,0 21.32,22.801 25.456,59.108 h -15.574 v 31.151 h 15.574 c -4.1361,36.307 -25.456,59.106 -25.456,59.106 l 22.329,16.619 c 0,0 40.508,-45.917 106.85,-79.355 l 13.806,-11.946 -13.806,-11.944 c -66.344,-33.438 -106.85,-79.355 -106.85,-79.355 z m 19.47,62.028 h 9.0105 c 2.1271,0 3.8393,1.7122 3.8393,3.8392 0,2.127 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7123 -3.8394,-3.8393 0,-2.127 1.7123,-3.8392 3.8394,-3.8392 z m 25.43,0 h 9.0086 c 2.1271,0 3.8394,1.7122 3.8394,3.8392 0,2.127 -1.7123,3.8393 -3.8394,3.8393 H 8272.3 c -2.127,0 -3.8393,-1.7123 -3.8393,-3.8393 0,-2.127 1.7123,-3.8392 3.8393,-3.8392 z m 27.463,15.55 8.0427,0.3441 c 2.6845,4.1003 5.7744,6.3606 11.176,8.56 4.3952,1.7896 4.9984,4.8172 4.9984,4.8172 0,0 -0.6032,3.0297 -4.9984,4.8192 -5.4014,2.1995 -8.4913,4.4598 -11.176,8.5599 l -8.0427,0.3442 c 0,0 -4.9148,-8.3087 -5.9723,-13.723 -0.021,0.1074 -0.05,0.221 -0.068,0.326 v -0.65 c 0.018,0.1046 0.048,0.2172 0.068,0.324 1.058,-5.4146 5.9723,-13.721 5.9723,-13.721 z m -52.893,35.316 h 9.0105 c 2.1271,0 3.8393,1.7123 3.8393,3.8393 0,2.1271 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7122 -3.8394,-3.8393 0,-2.127 1.7123,-3.8393 3.8394,-3.8393 z m 25.43,0 h 9.0086 c 2.1271,0 3.8394,1.7123 3.8394,3.8393 0,2.1271 -1.7123,3.8393 -3.8394,3.8393 H 8272.3 c -2.127,0 -3.8393,-1.7122 -3.8393,-3.8393 0,-2.127 1.7123,-3.8393 3.8393,-3.8393 z"
-         fill="#ffffff"
-         id="path6687" />
+    <g transform="translate(-7483.5,3174.8)" id="g6689">
+      <rect x="8163.7998" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect6685"/>
+      <path d="m 8227.4,-2553.9 -22.329,16.617 c 0,0 21.32,22.801 25.456,59.108 h -15.574 v 31.151 h 15.574 c -4.1361,36.307 -25.456,59.106 -25.456,59.106 l 22.329,16.619 c 0,0 40.508,-45.917 106.85,-79.355 l 13.806,-11.946 -13.806,-11.944 c -66.344,-33.438 -106.85,-79.355 -106.85,-79.355 z m 19.47,62.028 h 9.0105 c 2.1271,0 3.8393,1.7122 3.8393,3.8392 0,2.127 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7123 -3.8394,-3.8393 0,-2.127 1.7123,-3.8392 3.8394,-3.8392 z m 25.43,0 h 9.0086 c 2.1271,0 3.8394,1.7122 3.8394,3.8392 0,2.127 -1.7123,3.8393 -3.8394,3.8393 H 8272.3 c -2.127,0 -3.8393,-1.7123 -3.8393,-3.8393 0,-2.127 1.7123,-3.8392 3.8393,-3.8392 z m 27.463,15.55 8.0427,0.3441 c 2.6845,4.1003 5.7744,6.3606 11.176,8.56 4.3952,1.7896 4.9984,4.8172 4.9984,4.8172 0,0 -0.6032,3.0297 -4.9984,4.8192 -5.4014,2.1995 -8.4913,4.4598 -11.176,8.5599 l -8.0427,0.3442 c 0,0 -4.9148,-8.3087 -5.9723,-13.723 -0.021,0.1074 -0.05,0.221 -0.068,0.326 v -0.65 c 0.018,0.1046 0.048,0.2172 0.068,0.324 1.058,-5.4146 5.9723,-13.721 5.9723,-13.721 z m -52.893,35.316 h 9.0105 c 2.1271,0 3.8393,1.7123 3.8393,3.8393 0,2.1271 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7122 -3.8394,-3.8393 0,-2.127 1.7123,-3.8393 3.8394,-3.8393 z m 25.43,0 h 9.0086 c 2.1271,0 3.8394,1.7123 3.8394,3.8393 0,2.1271 -1.7123,3.8393 -3.8394,3.8393 H 8272.3 c -2.127,0 -3.8393,-1.7122 -3.8393,-3.8393 0,-2.127 1.7123,-3.8393 3.8393,-3.8393 z" fill="#ffffff" id="path6687"/>
     </g>
-    <g
-       transform="translate(-7029.9,3174.8)"
-       id="g6725">
-      <g
-         fill="none"
-         id="g6709">
-        <rect
-           x="8163.7998"
-           y="-2576"
-           width="226.77"
-           height="226.77"
-           opacity="1"
-           id="rect6691" />
-        <circle
-           cx="8324.9004"
-           cy="-2518.6001"
-           r="21.26"
-           stroke="#ffffee"
-           stroke-width="8.8583"
-           id="circle6693" />
-        <g
-           stroke="#ffffff"
-           stroke-width="7.0866"
-           id="g6707">
-          <g
-             stroke-dasharray="7.08661, 7.08661"
-             id="g6701">
-            <path
-               d="m 8307.4,-2507.8 -103.21,60.623"
-               id="path6695" />
-            <path
-               d="m 8304.4,-2520 -78.532,-5.4549"
-               id="path6697" />
-            <path
-               d="m 8331.2,-2497.4 19.748,68.569"
-               id="path6699" />
+    <g transform="translate(-7029.9,3174.8)" id="g6725">
+      <g fill="none" id="g6709">
+        <rect x="8163.7998" y="-2576" width="226.77" height="226.77" opacity="1" id="rect6691"/>
+        <circle cx="8324.9004" cy="-2518.6001" r="21.26" stroke="#ffffee" stroke-width="8.8583" id="circle6693"/>
+        <g stroke="#ffffff" stroke-width="7.0866" id="g6707">
+          <g stroke-dasharray="7.08661, 7.08661" id="g6701">
+            <path d="m 8307.4,-2507.8 -103.21,60.623" id="path6695"/>
+            <path d="m 8304.4,-2520 -78.532,-5.4549" id="path6697"/>
+            <path d="m 8331.2,-2497.4 19.748,68.569" id="path6699"/>
           </g>
-          <path
-             d="m 8343.4,-2504.4 c 25.929,32.621 23.808,70.911 -8.8419,109"
-             id="path6703" />
-          <path
-             d="m 8189.3,-2511.5 c 43.284,-24.375 69.948,-32.19 116.97,-20.235"
-             id="path6705" />
+          <path d="m 8343.4,-2504.4 c 25.929,32.621 23.808,70.911 -8.8419,109" id="path6703"/>
+          <path d="m 8189.3,-2511.5 c 43.284,-24.375 69.948,-32.19 116.97,-20.235" id="path6705"/>
         </g>
       </g>
-      <g
-         fill="#ffffff"
-         id="g6723">
-        <ellipse
-           cx="8219.2998"
-           cy="-2528.8"
-           rx="8.5103998"
-           ry="8.2357998"
-           stroke="#ffffff"
-           stroke-width="9.3037"
-           id="ellipse6711" />
-        <ellipse
-           cx="8354"
-           cy="-2425.8999"
-           rx="8.5103998"
-           ry="8.2357998"
-           stroke="#ffffff"
-           stroke-width="9.3037"
-           id="ellipse6713" />
-        <g
-           fill-opacity="0.28788"
-           id="g6721">
-          <path
-             d="m 8219.5,-2382 q -9.2338,0 -9.2338,-5.8874 v -38.634 h 8.615 v 36.788 q 0,1.3935 0.2857,1.7418 0.5711,0.5574 2.3322,0.5574 h 16.183 v 5.4346 z"
-             id="path6715" />
-          <path
-             d="m 8266.9,-2407.9 q 0,-2.9263 -3.8554,-2.9263 h -8.6626 q -1.4279,0 -2.2372,0.6619 -0.7615,0.627 -0.8091,1.6373 h -8.1867 q 0.096,-3.1701 2.7131,-5.2952 2.7605,-2.2644 6.9967,-2.2644 h 12.708 q 4.0934,0 6.7588,2.2296 2.5703,2.1251 2.5703,5.1907 v 26.615 h -7.9488 v -1.3586 q -2.5702,1.4631 -5.0452,1.4631 h -7.8059 q -4.3314,0 -7.7108,-1.9509 -3.665,-2.125 -3.665,-5.1558 v -6.619 q 0,-3.0657 3.665,-5.1907 3.427,-1.9858 7.7108,-1.9858 h 9.2338 q 1.9039,0 3.5698,0.7665 z m -0.1429,17.697 v -4.3198 q 0,-1.3237 -1.0471,-2.2295 -0.9995,-0.9406 -2.951,-0.9406 h -8.0915 q -1.999,0 -2.9034,0.9406 -0.9043,0.9058 -0.9043,2.2295 v 4.3198 q 0,1.3238 0.9043,2.2645 0.9044,0.9057 2.9034,0.9057 h 8.0915 q 1.9515,0 2.951,-0.9057 1.0471,-0.9407 1.0471,-2.2645 z"
-             id="path6717" />
-          <path
-             d="m 8296.2,-2415.9 q 3.8077,0 6.9015,1.6373 v -1.6373 h 7.4728 l 0.048,40.341 q 0,3.2747 -2.0942,5.8178 -2.4275,2.8566 -6.7589,2.8566 h -10.471 q -3.3794,0 -5.9973,-1.5329 -2.7605,-1.6721 -2.7605,-4.0758 v -2.2296 h 7.2347 q -0.048,1.1148 0.9519,1.8464 1.0472,0.7315 2.5703,0.7315 h 4.2361 q 3.0938,0 4.4265,-1.498 0.4284,-0.4877 0.4284,-1.1844 v -8.9531 q -3.189,1.707 -5.2356,1.707 h -5.2358 q -6.2351,0 -9.4718,-2.9263 -2.8558,-2.6476 -2.8558,-7.3855 v -13.935 q 0,-4.4592 3.5698,-7.0023 3.6174,-2.5779 9.7098,-2.5779 z m 6.1876,25.222 v -17.523 q 0,-1.6026 -3.3794,-2.369 -0.8092,-0.209 -1.4756,-0.209 h -4.0933 q -4.9025,0 -5.5213,3.1353 -0.1903,0.9755 -0.1903,2.16 v 12.646 q 0,2.6128 0.8091,3.6579 1.5232,1.9508 4.9025,1.9508 h 4.0933 q 1.3804,0 2.6179,-0.836 2.2371,-1.5677 2.2371,-2.6128 z"
-             id="path6719" />
+      <g fill="#ffffff" id="g6723">
+        <ellipse cx="8219.2998" cy="-2528.8" rx="8.5103998" ry="8.2357998" stroke="#ffffff" stroke-width="9.3037" id="ellipse6711"/>
+        <ellipse cx="8354" cy="-2425.8999" rx="8.5103998" ry="8.2357998" stroke="#ffffff" stroke-width="9.3037" id="ellipse6713"/>
+        <g fill-opacity="0.28788" id="g6721">
+          <path d="m 8219.5,-2382 q -9.2338,0 -9.2338,-5.8874 v -38.634 h 8.615 v 36.788 q 0,1.3935 0.2857,1.7418 0.5711,0.5574 2.3322,0.5574 h 16.183 v 5.4346 z" id="path6715"/>
+          <path d="m 8266.9,-2407.9 q 0,-2.9263 -3.8554,-2.9263 h -8.6626 q -1.4279,0 -2.2372,0.6619 -0.7615,0.627 -0.8091,1.6373 h -8.1867 q 0.096,-3.1701 2.7131,-5.2952 2.7605,-2.2644 6.9967,-2.2644 h 12.708 q 4.0934,0 6.7588,2.2296 2.5703,2.1251 2.5703,5.1907 v 26.615 h -7.9488 v -1.3586 q -2.5702,1.4631 -5.0452,1.4631 h -7.8059 q -4.3314,0 -7.7108,-1.9509 -3.665,-2.125 -3.665,-5.1558 v -6.619 q 0,-3.0657 3.665,-5.1907 3.427,-1.9858 7.7108,-1.9858 h 9.2338 q 1.9039,0 3.5698,0.7665 z m -0.1429,17.697 v -4.3198 q 0,-1.3237 -1.0471,-2.2295 -0.9995,-0.9406 -2.951,-0.9406 h -8.0915 q -1.999,0 -2.9034,0.9406 -0.9043,0.9058 -0.9043,2.2295 v 4.3198 q 0,1.3238 0.9043,2.2645 0.9044,0.9057 2.9034,0.9057 h 8.0915 q 1.9515,0 2.951,-0.9057 1.0471,-0.9407 1.0471,-2.2645 z" id="path6717"/>
+          <path d="m 8296.2,-2415.9 q 3.8077,0 6.9015,1.6373 v -1.6373 h 7.4728 l 0.048,40.341 q 0,3.2747 -2.0942,5.8178 -2.4275,2.8566 -6.7589,2.8566 h -10.471 q -3.3794,0 -5.9973,-1.5329 -2.7605,-1.6721 -2.7605,-4.0758 v -2.2296 h 7.2347 q -0.048,1.1148 0.9519,1.8464 1.0472,0.7315 2.5703,0.7315 h 4.2361 q 3.0938,0 4.4265,-1.498 0.4284,-0.4877 0.4284,-1.1844 v -8.9531 q -3.189,1.707 -5.2356,1.707 h -5.2358 q -6.2351,0 -9.4718,-2.9263 -2.8558,-2.6476 -2.8558,-7.3855 v -13.935 q 0,-4.4592 3.5698,-7.0023 3.6174,-2.5779 9.7098,-2.5779 z m 6.1876,25.222 v -17.523 q 0,-1.6026 -3.3794,-2.369 -0.8092,-0.209 -1.4756,-0.209 h -4.0933 q -4.9025,0 -5.5213,3.1353 -0.1903,0.9755 -0.1903,2.16 v 12.646 q 0,2.6128 0.8091,3.6579 1.5232,1.9508 4.9025,1.9508 h 4.0933 q 1.3804,0 2.6179,-0.836 2.2371,-1.5677 2.2371,-2.6128 z" id="path6719"/>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(7.4844e-5,-5.3628e-5)"
-       id="g6735">
-      <rect
-         x="907.09003"
-         y="598.82001"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6727" />
-      <path
-         d="m 986.09,687.4 -1.9544,13.324 c 0,0 15.095,0.50662 28.932,11.513 l -5.3285,5.3283 10.658,10.658 5.3284,-5.3284 c 11.006,13.837 11.512,28.931 11.512,28.931 l 13.325,-1.9537 c 0,0 -1.8503,-29.568 9.4074,-63.706 l 0.636,-8.8105 -8.8097,0.63683 c -34.138,11.258 -63.706,9.4072 -63.706,9.4072 z m 27.882,14.56 3.0827,-3.0826 c 0.7277,-0.72773 1.8993,-0.72773 2.627,-8e-5 0.7276,0.72773 0.7277,1.8994 -10e-5,2.6271 l -3.0826,3.0826 c -0.7278,0.7278 -1.8994,0.72773 -2.6271,8e-5 -0.7276,-0.72773 -0.7276,-1.8993 10e-5,-2.627 z m 8.7002,-8.7002 3.0821,-3.082 c 0.7277,-0.72765 1.8993,-0.72773 2.627,0 0.7277,0.72765 0.7276,1.8993 -10e-5,2.627 l -3.082,3.082 c -0.7277,0.72772 -1.8994,0.72772 -2.6271,0 -0.7277,-0.72773 -0.7277,-1.8993 10e-5,-2.627 z m 14.716,-4.0754 2.8694,-2.6339 c 2.3212,0.48442 4.1516,0.20055 6.7519,-0.8949 2.116,-0.89145 3.3582,-0.0622 3.3582,-0.0622 0,0 0.8302,1.2429 -0.062,3.3589 -1.0954,2.6005 -1.3792,4.4308 -0.8949,6.752 l -2.6338,2.8693 c 0,0 -4.5241,-1.1611 -6.7383,-2.6518 0.03,0.0442 0.059,0.0928 0.088,0.13485 l -0.2224,-0.22237 c 0.042,0.03 0.091,0.0578 0.1341,0.0876 -1.4904,-2.2144 -2.6511,-6.7376 -2.6511,-6.7376 z m -6.0133,30.178 3.0828,-3.0826 c 0.7276,-0.7278 1.8992,-0.72773 2.6269,0 0.7278,0.72772 0.7278,1.8993 0,2.627 l -3.0827,3.0828 c -0.7277,0.72765 -1.8993,0.72773 -2.627,0 -0.7277,-0.72772 -0.7277,-1.8993 0,-2.6271 z m 8.7002,-8.7002 3.0821,-3.082 c 0.7278,-0.72773 1.8993,-0.72773 2.6271,-8e-5 0.7277,0.7278 0.7276,1.8994 -10e-5,2.6271 l -3.0821,3.082 c -0.7276,0.72772 -1.8992,0.72772 -2.6269,0 -0.7277,-0.72773 -0.7277,-1.8993 -10e-5,-2.627 z"
-         fill="#ffffff"
-         id="path6729" />
-      <path
-         transform="rotate(37.948)"
-         d="m 1243.5,-192.94 a 271.08,271.08 0 0 1 11.05,63.913"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="square"
-         stroke-linejoin="round"
-         stroke-width="10.63"
-         id="path6731" />
-      <path
-         transform="rotate(37.948)"
-         d="m 1243.2,-36.439 a 271.08,271.08 0 0 1 -39.58,79.931"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linecap="square"
-         stroke-linejoin="round"
-         stroke-width="10.63"
-         id="path6733" />
+    <g transform="translate(7.4844e-5,-5.3628e-5)" id="g6735">
+      <rect x="907.09003" y="598.82001" width="226.77" height="226.77" fill="none" opacity="1" id="rect6727"/>
+      <path d="m 986.09,687.4 -1.9544,13.324 c 0,0 15.095,0.50662 28.932,11.513 l -5.3285,5.3283 10.658,10.658 5.3284,-5.3284 c 11.006,13.837 11.512,28.931 11.512,28.931 l 13.325,-1.9537 c 0,0 -1.8503,-29.568 9.4074,-63.706 l 0.636,-8.8105 -8.8097,0.63683 c -34.138,11.258 -63.706,9.4072 -63.706,9.4072 z m 27.882,14.56 3.0827,-3.0826 c 0.7277,-0.72773 1.8993,-0.72773 2.627,-8e-5 0.7276,0.72773 0.7277,1.8994 -10e-5,2.6271 l -3.0826,3.0826 c -0.7278,0.7278 -1.8994,0.72773 -2.6271,8e-5 -0.7276,-0.72773 -0.7276,-1.8993 10e-5,-2.627 z m 8.7002,-8.7002 3.0821,-3.082 c 0.7277,-0.72765 1.8993,-0.72773 2.627,0 0.7277,0.72765 0.7276,1.8993 -10e-5,2.627 l -3.082,3.082 c -0.7277,0.72772 -1.8994,0.72772 -2.6271,0 -0.7277,-0.72773 -0.7277,-1.8993 10e-5,-2.627 z m 14.716,-4.0754 2.8694,-2.6339 c 2.3212,0.48442 4.1516,0.20055 6.7519,-0.8949 2.116,-0.89145 3.3582,-0.0622 3.3582,-0.0622 0,0 0.8302,1.2429 -0.062,3.3589 -1.0954,2.6005 -1.3792,4.4308 -0.8949,6.752 l -2.6338,2.8693 c 0,0 -4.5241,-1.1611 -6.7383,-2.6518 0.03,0.0442 0.059,0.0928 0.088,0.13485 l -0.2224,-0.22237 c 0.042,0.03 0.091,0.0578 0.1341,0.0876 -1.4904,-2.2144 -2.6511,-6.7376 -2.6511,-6.7376 z m -6.0133,30.178 3.0828,-3.0826 c 0.7276,-0.7278 1.8992,-0.72773 2.6269,0 0.7278,0.72772 0.7278,1.8993 0,2.627 l -3.0827,3.0828 c -0.7277,0.72765 -1.8993,0.72773 -2.627,0 -0.7277,-0.72772 -0.7277,-1.8993 0,-2.6271 z m 8.7002,-8.7002 3.0821,-3.082 c 0.7278,-0.72773 1.8993,-0.72773 2.6271,-8e-5 0.7277,0.7278 0.7276,1.8994 -10e-5,2.6271 l -3.0821,3.082 c -0.7276,0.72772 -1.8992,0.72772 -2.6269,0 -0.7277,-0.72773 -0.7277,-1.8993 -10e-5,-2.627 z" fill="#ffffff" id="path6729"/>
+      <path transform="rotate(37.948)" d="m 1243.5,-192.94 a 271.08,271.08 0 0 1 11.05,63.913" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="square" stroke-linejoin="round" stroke-width="10.63" id="path6731"/>
+      <path transform="rotate(37.948)" d="m 1243.2,-36.439 a 271.08,271.08 0 0 1 -39.58,79.931" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="square" stroke-linejoin="round" stroke-width="10.63" id="path6733"/>
     </g>
-    <g
-       transform="translate(453.54,-4.6924e-5)"
-       clip-rule="evenodd"
-       fill-rule="evenodd"
-       stroke-linejoin="round"
-       id="g6773">
-      <g
-         stroke-miterlimit="1.5"
-         id="g6755">
-        <g
-           transform="matrix(6.8719,0,0,6.4792,-6294.6,598.82)"
-           fill="none"
-           id="g6741">
-          <rect
-             x="1081"
-             width="33"
-             height="35"
-             id="rect6737"
-             y="0" />
-          <path
-             d="m 1114,0 h -33 v 35 h 33 z m -29.39,3.824 v 27.352 h 25.78 V 3.824 Z"
-             id="path6739" />
+    <g transform="translate(453.54,-4.6924e-5)" clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" id="g6773">
+      <g stroke-miterlimit="1.5" id="g6755">
+        <g transform="matrix(6.8719,0,0,6.4792,-6294.6,598.82)" fill="none" id="g6741">
+          <rect x="1081" width="33" height="35" id="rect6737" y="0"/>
+          <path d="m 1114,0 h -33 v 35 h 33 z m -29.39,3.824 v 27.352 h 25.78 V 3.824 Z" id="path6739"/>
         </g>
-        <g
-           transform="matrix(12.512,0,0,12.512,-22575,-6002.3)"
-           stroke-width="0.66007"
-           id="g6747">
-          <circle
-             cx="1900.3"
-             cy="540.5"
-             r="2.5"
-             fill="#ffffff"
-             id="circle6743" />
-          <path
-             d="m 1900.3,538 c 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5 0,-1.38 1.12,-2.5 2.5,-2.5 z m 0,3 c -0.27,0 -0.5,-0.224 -0.5,-0.5 0,-0.276 0.23,-0.5 0.5,-0.5 0.28,0 0.5,0.224 0.5,0.5 0,0.276 -0.22,0.5 -0.5,0.5 z"
-             fill-opacity="0"
-             id="path6745" />
+        <g transform="matrix(12.512,0,0,12.512,-22575,-6002.3)" stroke-width="0.66007" id="g6747">
+          <circle cx="1900.3" cy="540.5" r="2.5" fill="#ffffff" id="circle6743"/>
+          <path d="m 1900.3,538 c 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5 0,-1.38 1.12,-2.5 2.5,-2.5 z m 0,3 c -0.27,0 -0.5,-0.224 -0.5,-0.5 0,-0.276 0.23,-0.5 0.5,-0.5 0.28,0 0.5,0.224 0.5,0.5 0,0.276 -0.22,0.5 -0.5,0.5 z" fill-opacity="0" id="path6745"/>
         </g>
-        <g
-           transform="matrix(8.259,0,0,8.259,-14393,-3810.8)"
-           id="g6753">
-          <circle
-             cx="1900.3"
-             cy="540.5"
-             r="2.5"
-             fill="#ffffff"
-             id="circle6749" />
-          <path
-             d="m 1900.3,538 c 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5 0,-1.38 1.12,-2.5 2.5,-2.5 z m 0,3 c -0.27,0 -0.5,-0.224 -0.5,-0.5 0,-0.276 0.23,-0.5 0.5,-0.5 0.28,0 0.5,0.224 0.5,0.5 0,0.276 -0.22,0.5 -0.5,0.5 z"
-             fill-opacity="0"
-             id="path6751" />
+        <g transform="matrix(8.259,0,0,8.259,-14393,-3810.8)" id="g6753">
+          <circle cx="1900.3" cy="540.5" r="2.5" fill="#ffffff" id="circle6749"/>
+          <path d="m 1900.3,538 c 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5 0,-1.38 1.12,-2.5 2.5,-2.5 z m 0,3 c -0.27,0 -0.5,-0.224 -0.5,-0.5 0,-0.276 0.23,-0.5 0.5,-0.5 0.28,0 0.5,0.224 0.5,0.5 0,0.276 -0.22,0.5 -0.5,0.5 z" fill-opacity="0" id="path6751"/>
         </g>
       </g>
-      <g
-         transform="matrix(8.259,0,0,8.259,-14414,-3715.8)"
-         stroke-width="1.7161"
-         id="g6759">
-        <path
-           d="m 1900.3,537.05 c 1.9037,0 3.4488,1.545 3.4488,3.4488 0,1.9037 -1.5451,3.4488 -3.4488,3.4488 -1.9037,0 -3.4488,-1.545 -3.4488,-3.4488 0,-1.9037 1.5451,-3.4488 3.4488,-3.4488 z m 0,1.3795 c 1.145,0 2.0693,0.92703 2.0693,2.0693 0,1.14227 -0.9243,2.0693 -2.0693,2.0693 -1.145,0 -2.0692,-0.92703 -2.0692,-2.0693 0,-1.14227 0.9242,-2.0693 2.0692,-2.0693 z"
-           fill="#ffffff"
-           stroke-width="1.7161"
-           id="path6757" />
+      <g transform="matrix(8.259,0,0,8.259,-14414,-3715.8)" stroke-width="1.7161" id="g6759">
+        <path d="m 1900.3,537.05 c 1.9037,0 3.4488,1.545 3.4488,3.4488 0,1.9037 -1.5451,3.4488 -3.4488,3.4488 -1.9037,0 -3.4488,-1.545 -3.4488,-3.4488 0,-1.9037 1.5451,-3.4488 3.4488,-3.4488 z m 0,1.3795 c 1.145,0 2.0693,0.92703 2.0693,2.0693 0,1.14227 -0.9243,2.0693 -2.0693,2.0693 -1.145,0 -2.0692,-0.92703 -2.0692,-2.0693 0,-1.14227 0.9242,-2.0693 2.0692,-2.0693 z" fill="#ffffff" stroke-width="1.7161" id="path6757"/>
       </g>
-      <g
-         transform="matrix(8.259,0,0,8.259,-14468,-3790.1)"
-         stroke-width="1.7161"
-         id="g6763">
-        <path
-           d="m 1900.3,537.2 c 1.821,0 3.2989,1.4779 3.2989,3.299 0,1.821 -1.4779,3.299 -3.2989,3.299 -1.821,0 -3.299,-1.4779 -3.299,-3.299 0,-1.821 1.478,-3.299 3.299,-3.299 z m 0,1.3196 c 1.0952,0 1.9794,0.88676 1.9794,1.9794 0,1.0926 -0.8842,1.9794 -1.9794,1.9794 -1.0953,0 -1.9794,-0.88676 -1.9794,-1.9794 0,-1.0926 0.8841,-1.9794 1.9794,-1.9794 z"
-           fill="#ffffff"
-           stroke-width="1.7161"
-           id="path6761" />
+      <g transform="matrix(8.259,0,0,8.259,-14468,-3790.1)" stroke-width="1.7161" id="g6763">
+        <path d="m 1900.3,537.2 c 1.821,0 3.2989,1.4779 3.2989,3.299 0,1.821 -1.4779,3.299 -3.2989,3.299 -1.821,0 -3.299,-1.4779 -3.299,-3.299 0,-1.821 1.478,-3.299 3.299,-3.299 z m 0,1.3196 c 1.0952,0 1.9794,0.88676 1.9794,1.9794 0,1.0926 -0.8842,1.9794 -1.9794,1.9794 -1.0953,0 -1.9794,-0.88676 -1.9794,-1.9794 0,-1.0926 0.8841,-1.9794 1.9794,-1.9794 z" fill="#ffffff" stroke-width="1.7161" id="path6761"/>
       </g>
-      <g
-         transform="matrix(8.259,0,0,8.259,-14492,-3703.4)"
-         fill="none"
-         stroke="#ffffff"
-         stroke-miterlimit="1.5"
-         stroke-width="1.7161"
-         id="g6771">
-        <path
-           d="m 1900.3,540.5 7.52,-1.049"
-           id="path6765" />
-        <path
-           d="m 1908.4,536.93 -4.1005,-5.0926"
-           id="path6767" />
-        <path
-           d="m 1905.3,529.47 6.99,-1.967"
-           id="path6769" />
+      <g transform="matrix(8.259,0,0,8.259,-14492,-3703.4)" fill="none" stroke="#ffffff" stroke-miterlimit="1.5" stroke-width="1.7161" id="g6771">
+        <path d="m 1900.3,540.5 7.52,-1.049" id="path6765"/>
+        <path d="m 1908.4,536.93 -4.1005,-5.0926" id="path6767"/>
+        <path d="m 1905.3,529.47 6.99,-1.967" id="path6769"/>
       </g>
     </g>
-    <g
-       transform="translate(2494.5,-453.54)"
-       id="g6795">
-      <g
-         transform="matrix(9.6531,0,0,9.6531,-870.97,852.02)"
-         clip-rule="evenodd"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="1.5"
-         id="g6791">
-        <g
-           transform="matrix(0.86486,0,0,0.86486,-1273.6,-580.25)"
-           id="g6789">
-          <g
-             transform="matrix(2.3875,0,0,2.3875,-3024.4,-585.55)"
-             id="g6779">
-            <circle
-               cx="1900.3"
-               cy="540.5"
-               r="2.5"
-               fill="#ffffff"
-               id="circle6775" />
-            <path
-               d="m 1900.3,538 c 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5 0,-1.38 1.12,-2.5 2.5,-2.5 z m 0,1.453 c 0.58,0 1.05,0.469 1.05,1.047 0,0.578 -0.47,1.047 -1.05,1.047 -0.58,0 -1.05,-0.469 -1.05,-1.047 0,-0.578 0.47,-1.047 1.05,-1.047 z"
-               fill-opacity="0"
-               id="path6777" />
+    <g transform="translate(2494.5,-453.54)" id="g6795">
+      <g transform="matrix(9.6531,0,0,9.6531,-870.97,852.02)" clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.5" id="g6791">
+        <g transform="matrix(0.86486,0,0,0.86486,-1273.6,-580.25)" id="g6789">
+          <g transform="matrix(2.3875,0,0,2.3875,-3024.4,-585.55)" id="g6779">
+            <circle cx="1900.3" cy="540.5" r="2.5" fill="#ffffff" id="circle6775"/>
+            <path d="m 1900.3,538 c 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5 0,-1.38 1.12,-2.5 2.5,-2.5 z m 0,1.453 c 0.58,0 1.05,0.469 1.05,1.047 0,0.578 -0.47,1.047 -1.05,1.047 -0.58,0 -1.05,-0.469 -1.05,-1.047 0,-0.578 0.47,-1.047 1.05,-1.047 z" fill-opacity="0" id="path6777"/>
           </g>
-          <g
-             transform="translate(-398.03,175.07)"
-             id="g6783">
-            <path
-               d="m 1900.3,537.39 c 1.7192,0 3.1146,1.3953 3.1146,3.1145 0,1.7192 -1.3954,3.1145 -3.1146,3.1145 -1.7192,0 -3.1145,-1.3953 -3.1145,-3.1145 0,-1.7192 1.3953,-3.1145 3.1145,-3.1145 z m 0,1.4402 c 0.9219,0 1.6818,0.74998 1.6818,1.6744 0,0.92439 -0.7599,1.6744 -1.6818,1.6744 -0.9219,0 -1.6694,-0.74998 -1.6694,-1.6744 0,-0.9244 0.7475,-1.6744 1.6694,-1.6744 z"
-               fill="#ffffff"
-               id="path6781" />
+          <g transform="translate(-398.03,175.07)" id="g6783">
+            <path d="m 1900.3,537.39 c 1.7192,0 3.1146,1.3953 3.1146,3.1145 0,1.7192 -1.3954,3.1145 -3.1146,3.1145 -1.7192,0 -3.1145,-1.3953 -3.1145,-3.1145 0,-1.7192 1.3953,-3.1145 3.1145,-3.1145 z m 0,1.4402 c 0.9219,0 1.6818,0.74998 1.6818,1.6744 0,0.92439 -0.7599,1.6744 -1.6818,1.6744 -0.9219,0 -1.6694,-0.74998 -1.6694,-1.6744 0,-0.9244 0.7475,-1.6744 1.6694,-1.6744 z" fill="#ffffff" id="path6781"/>
           </g>
-          <g
-             transform="translate(-399,176.04)"
-             id="g6787">
-            <path
-               d="m 1902.9,537.87 6.0383,-6.5123"
-               fill="none"
-               stroke="#ffffff"
-               stroke-miterlimit="1.5"
-               stroke-width="1.6977"
-               id="path6785" />
+          <g transform="translate(-399,176.04)" id="g6787">
+            <path d="m 1902.9,537.87 6.0383,-6.5123" fill="none" stroke="#ffffff" stroke-miterlimit="1.5" stroke-width="1.6977" id="path6785"/>
           </g>
         </g>
       </g>
-      <rect
-         x="-680.32001"
-         y="1052.4"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6793" />
+      <rect x="-680.32001" y="1052.4" width="226.77" height="226.77" fill="none" opacity="1" id="rect6793"/>
     </g>
-    <g
-       transform="translate(453.54,-4.6924e-5)"
-       id="g6817">
-      <g
-         transform="matrix(12.546,0,0,12.546,1305.6,304.44)"
-         clip-rule="evenodd"
-         fill-rule="evenodd"
-         stroke-linejoin="round"
-         stroke-miterlimit="1.5"
-         id="g6813">
-        <g
-           transform="matrix(0.72072,0,0,0.72072,-1054.9,-479.38)"
-           id="g6811">
-          <g
-             transform="translate(-387.83,164.39)"
-             id="g6801">
-            <circle
-               cx="1900.3"
-               cy="540.5"
-               r="3.7695999"
-               fill="#ffffff"
-               id="circle6797" />
-            <path
-               d="m 1900.3,538 c 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5 0,-1.38 1.12,-2.5 2.5,-2.5 z m 0,3.469 c -0.53,0 -0.97,-0.434 -0.97,-0.969 0,-0.535 0.44,-0.969 0.97,-0.969 0.54,0 0.97,0.434 0.97,0.969 0,0.535 -0.43,0.969 -0.97,0.969 z"
-               fill-opacity="0"
-               id="path6799" />
+    <g transform="translate(453.54,-4.6924e-5)" id="g6817">
+      <g transform="matrix(12.546,0,0,12.546,1305.6,304.44)" clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.5" id="g6813">
+        <g transform="matrix(0.72072,0,0,0.72072,-1054.9,-479.38)" id="g6811">
+          <g transform="translate(-387.83,164.39)" id="g6801">
+            <circle cx="1900.3" cy="540.5" r="3.7695999" fill="#ffffff" id="circle6797"/>
+            <path d="m 1900.3,538 c 1.38,0 2.5,1.12 2.5,2.5 0,1.38 -1.12,2.5 -2.5,2.5 -1.38,0 -2.5,-1.12 -2.5,-2.5 0,-1.38 1.12,-2.5 2.5,-2.5 z m 0,3.469 c -0.53,0 -0.97,-0.434 -0.97,-0.969 0,-0.535 0.44,-0.969 0.97,-0.969 0.54,0 0.97,0.434 0.97,0.969 0,0.535 -0.43,0.969 -0.97,0.969 z" fill-opacity="0" id="path6799"/>
           </g>
-          <g
-             transform="translate(-398.03,175.07)"
-             id="g6805">
-            <path
-               d="m 1900.3,536.97 c 1.9497,0 3.532,1.5823 3.532,3.532 0,1.9496 -1.5823,3.532 -3.532,3.532 -1.9496,0 -3.532,-1.5823 -3.532,-3.532 0,-1.9497 1.5824,-3.532 3.532,-3.532 z m 0,1.6332 c 1.0455,0 1.9073,0.8505 1.9073,1.8988 0,1.0483 -0.8618,1.8988 -1.9073,1.8988 -1.0454,0 -1.8931,-0.8505 -1.8931,-1.8988 0,-1.0483 0.8477,-1.8988 1.8931,-1.8988 z"
-               fill="#ffffff"
-               id="path6803" />
+          <g transform="translate(-398.03,175.07)" id="g6805">
+            <path d="m 1900.3,536.97 c 1.9497,0 3.532,1.5823 3.532,3.532 0,1.9496 -1.5823,3.532 -3.532,3.532 -1.9496,0 -3.532,-1.5823 -3.532,-3.532 0,-1.9497 1.5824,-3.532 3.532,-3.532 z m 0,1.6332 c 1.0455,0 1.9073,0.8505 1.9073,1.8988 0,1.0483 -0.8618,1.8988 -1.9073,1.8988 -1.0454,0 -1.8931,-0.8505 -1.8931,-1.8988 0,-1.0483 0.8477,-1.8988 1.8931,-1.8988 z" fill="#ffffff" id="path6803"/>
           </g>
-          <g
-             transform="translate(-399,176.04)"
-             id="g6809">
-            <path
-               d="m 1903.4,537.55 6.103,-6.753"
-               fill="none"
-               stroke="#ffffff"
-               stroke-miterlimit="1.5"
-               stroke-width="1.5674"
-               id="path6807" />
+          <g transform="translate(-399,176.04)" id="g6809">
+            <path d="m 1903.4,537.55 6.103,-6.753" fill="none" stroke="#ffffff" stroke-miterlimit="1.5" stroke-width="1.5674" id="path6807"/>
           </g>
         </g>
       </g>
-      <rect
-         x="1587.4"
-         y="598.82001"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6815" />
+      <rect x="1587.4" y="598.82001" width="226.77" height="226.77" fill="none" opacity="1" id="rect6815"/>
     </g>
-    <g
-       transform="translate(-4.7544,1588.3)"
-       id="g6827">
-      <path
-         d="m 2366.9,-950.45 c 6.4108,-11.104 22.441,-11.102 28.853,0.002 l 77.417,134.09 c 6.41,11.105 -1.6045,24.987 -14.427,24.988 l -154.83,-0.002 c -12.822,-9.1e-4 -20.837,-13.882 -14.428,-24.987 z m -51.595,120.14 15.551,24.444 31.677,0.0231 -30.766,-53.288 z m 59.6,-29.628 -13.735,-23.79 -14.503,50.772 51.722,13.694 -13.589,-23.536 35.488,-20.489 -9.8957,-17.14 z"
-         color="#000000"
-         color-rendering="auto"
-         dominant-baseline="auto"
-         fill="#ffffff"
-         fill-opacity="0.78431"
-         image-rendering="auto"
-         opacity="1"
-         shape-rendering="auto"
-         solid-color="#000000"
-         style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;isolation:auto;mix-blend-mode:normal"
-         id="path6819" />
-      <g
-         transform="matrix(-0.5,0.86603,0.86603,0.5,4343.8,-2469.2)"
-         color="#000000"
-         color-rendering="auto"
-         fill="#000100"
-         image-rendering="auto"
-         opacity="1"
-         shape-rendering="auto"
-         solid-color="#000000"
-         stroke-linejoin="round"
-         style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal"
-         aria-label="!"
-         id="g6823">
-        <path
-           transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-           d="m 2476.4,1747.6 c -10.506,0 -17.07,11.374 -11.818,20.473 l 63.43,109.86 c 5.2534,9.0976 18.383,9.0976 23.637,0 l 63.43,-109.86 c 5.2512,-9.0984 -1.3147,-20.471 -11.82,-20.473 z m 119.32,0.3569 14.327,27.472 -16.863,29.294 -32.878,-56.946 z m -59.129,39.284 -14.651,-25.376 54.403,13.895 -14.702,54.868 -14.494,-25.105 -37.854,21.855 -10.555,-18.282 z"
-           fill="#ffffff"
-           stroke-width="50.429"
-           id="path6821" />
+    <g transform="translate(-4.7544,1588.3)" id="g6827">
+      <path d="m 2366.9,-950.45 c 6.4108,-11.104 22.441,-11.102 28.853,0.002 l 77.417,134.09 c 6.41,11.105 -1.6045,24.987 -14.427,24.988 l -154.83,-0.002 c -12.822,-9.1e-4 -20.837,-13.882 -14.428,-24.987 z m -51.595,120.14 15.551,24.444 31.677,0.0231 -30.766,-53.288 z m 59.6,-29.628 -13.735,-23.79 -14.503,50.772 51.722,13.694 -13.589,-23.536 35.488,-20.489 -9.8957,-17.14 z" color="#000000" color-rendering="auto" dominant-baseline="auto" fill="#ffffff" fill-opacity="0.78431" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;isolation:auto;mix-blend-mode:normal" id="path6819"/>
+      <g transform="matrix(-0.5,0.86603,0.86603,0.5,4343.8,-2469.2)" color="#000000" color-rendering="auto" fill="#000100" image-rendering="auto" opacity="1" shape-rendering="auto" solid-color="#000000" stroke-linejoin="round" style="text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal" aria-label="!" id="g6823">
+        <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 2476.4,1747.6 c -10.506,0 -17.07,11.374 -11.818,20.473 l 63.43,109.86 c 5.2534,9.0976 18.383,9.0976 23.637,0 l 63.43,-109.86 c 5.2512,-9.0984 -1.3147,-20.471 -11.82,-20.473 z m 119.32,0.3569 14.327,27.472 -16.863,29.294 -32.878,-56.946 z m -59.129,39.284 -14.651,-25.376 54.403,13.895 -14.702,54.868 -14.494,-25.105 -37.854,21.855 -10.555,-18.282 z" fill="#ffffff" stroke-width="50.429" id="path6821"/>
       </g>
-      <rect
-         x="2270.1001"
-         y="-986.84998"
-         width="229.17999"
-         height="224.16"
-         ry="10.005"
-         fill="none"
-         id="rect6825"
-         rx="10.005" />
+      <rect x="2270.1001" y="-986.84998" width="229.17999" height="224.16" ry="10.005" fill="none" id="rect6825" rx="10.005"/>
     </g>
-    <g
-       transform="matrix(-1,0,0,1,5215.7,1.1675e-5)"
-       id="g6843">
-      <path
-         d="m 2682.1,712.49 a 74.136,74.134 0 0 1 -45.766,68.491 74.136,74.134 0 0 1 -80.793,-16.07 74.136,74.134 0 0 1 -16.071,-80.79 74.136,74.134 0 0 1 68.493,-45.764"
-         fill="none"
-         opacity="0.997"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="21.26"
-         style="paint-order:normal"
-         id="path6829" />
-      <g
-         opacity="1"
-         id="g6839">
-        <path
-           d="m 2691.9,614.2 a 14.173,14.173 0 0 0 -10.072,4.1523 l -75.111,75.105 a 14.173,14.173 0 0 0 0,20.045 14.173,14.173 0 0 0 20.045,0 l 75.109,-75.107 a 14.173,14.173 0 0 0 0,-20.043 14.173,14.173 0 0 0 -9.9707,-4.1523 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           fill="#ffffff"
-           image-rendering="auto"
-           shape-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-           id="path6831" />
-        <g
-           fill="#ffffff"
-           fill-rule="evenodd"
-           opacity="1"
-           shape-rendering="auto"
-           id="g6837">
-          <path
-             d="m 2593.6,726.61 14.633,-54.72 40.087,40.089 z"
-             color="#000000"
-             color-rendering="auto"
-             dominant-baseline="auto"
-             image-rendering="auto"
-             solid-color="#000000"
-             stop-color="#000000"
-             style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-             id="path6833" />
-          <path
-             d="m 2606.3,664.59 -18.016,67.365 6.3164,-1.6894 61.049,-16.322 z m 3.918,14.609 30.822,30.824 -42.074,11.25 z"
-             color="#000000"
-             color-rendering="auto"
-             dominant-baseline="auto"
-             image-rendering="auto"
-             solid-color="#000000"
-             stop-color="#000000"
-             style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-             id="path6835" />
+    <g transform="matrix(-1,0,0,1,5215.7,1.1675e-5)" id="g6843">
+      <path d="m 2682.1,712.49 a 74.136,74.134 0 0 1 -45.766,68.491 74.136,74.134 0 0 1 -80.793,-16.07 74.136,74.134 0 0 1 -16.071,-80.79 74.136,74.134 0 0 1 68.493,-45.764" fill="none" opacity="0.997" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="21.26" style="paint-order:normal" id="path6829"/>
+      <g opacity="1" id="g6839">
+        <path d="m 2691.9,614.2 a 14.173,14.173 0 0 0 -10.072,4.1523 l -75.111,75.105 a 14.173,14.173 0 0 0 0,20.045 14.173,14.173 0 0 0 20.045,0 l 75.109,-75.107 a 14.173,14.173 0 0 0 0,-20.043 14.173,14.173 0 0 0 -9.9707,-4.1523 z" color="#000000" color-rendering="auto" dominant-baseline="auto" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6831"/>
+        <g fill="#ffffff" fill-rule="evenodd" opacity="1" shape-rendering="auto" id="g6837">
+          <path d="m 2593.6,726.61 14.633,-54.72 40.087,40.089 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6833"/>
+          <path d="m 2606.3,664.59 -18.016,67.365 6.3164,-1.6894 61.049,-16.322 z m 3.918,14.609 30.822,30.824 -42.074,11.25 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6835"/>
         </g>
       </g>
-      <rect
-         x="2494.5"
-         y="598.82001"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         style="paint-order:normal"
-         id="rect6841" />
+      <rect x="2494.5" y="598.82001" width="226.77" height="226.77" fill="none" style="paint-order:normal" id="rect6841"/>
     </g>
-    <g
-       transform="matrix(-1,0,0,1,5669.3,0)"
-       id="g6859">
-      <path
-         d="m 2887.9,712.39 a 53.172,53.173 0 0 1 -32.824,49.125 53.172,53.173 0 0 1 -57.946,-11.526 53.172,53.173 0 0 1 -11.526,-57.947 53.172,53.173 0 0 1 49.124,-32.825"
-         fill="none"
-         opacity="0.997"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="21.26"
-         style="paint-order:normal"
-         id="path6845" />
-      <g
-         opacity="1"
-         id="g6855">
-        <path
-           d="m 2894.7,641.42 a 10.63,10.63 0 0 0 -7.3653,3.1113 l -53.871,53.871 a 10.63,10.63 0 0 0 0,15.033 10.63,10.63 0 0 0 15.033,0 l 53.871,-53.871 a 10.63,10.63 0 0 0 0,-15.033 10.63,10.63 0 0 0 -7.666,-3.1113 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           fill="#ffffff"
-           image-rendering="auto"
-           shape-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-           id="path6847" />
-        <g
-           fill="#ffffff"
-           fill-rule="evenodd"
-           opacity="1"
-           shape-rendering="auto"
-           id="g6853">
-          <path
-             d="m 2823.7,723.27 10.974,-41.04 30.066,30.065 z"
-             color="#000000"
-             color-rendering="auto"
-             dominant-baseline="auto"
-             image-rendering="auto"
-             solid-color="#000000"
-             stop-color="#000000"
-             style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-             id="path6849" />
-          <path
-             d="m 2833.2,676.75 -13.51,50.523 4.7383,-1.2676 45.785,-12.244 z m 2.9375,10.955 23.121,23.119 -31.557,8.4375 z"
-             color="#000000"
-             color-rendering="auto"
-             dominant-baseline="auto"
-             image-rendering="auto"
-             solid-color="#000000"
-             stop-color="#000000"
-             style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-             id="path6851" />
+    <g transform="matrix(-1,0,0,1,5669.3,0)" id="g6859">
+      <path d="m 2887.9,712.39 a 53.172,53.173 0 0 1 -32.824,49.125 53.172,53.173 0 0 1 -57.946,-11.526 53.172,53.173 0 0 1 -11.526,-57.947 53.172,53.173 0 0 1 49.124,-32.825" fill="none" opacity="0.997" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="21.26" style="paint-order:normal" id="path6845"/>
+      <g opacity="1" id="g6855">
+        <path d="m 2894.7,641.42 a 10.63,10.63 0 0 0 -7.3653,3.1113 l -53.871,53.871 a 10.63,10.63 0 0 0 0,15.033 10.63,10.63 0 0 0 15.033,0 l 53.871,-53.871 a 10.63,10.63 0 0 0 0,-15.033 10.63,10.63 0 0 0 -7.666,-3.1113 z" color="#000000" color-rendering="auto" dominant-baseline="auto" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6847"/>
+        <g fill="#ffffff" fill-rule="evenodd" opacity="1" shape-rendering="auto" id="g6853">
+          <path d="m 2823.7,723.27 10.974,-41.04 30.066,30.065 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6849"/>
+          <path d="m 2833.2,676.75 -13.51,50.523 4.7383,-1.2676 45.785,-12.244 z m 2.9375,10.955 23.121,23.119 -31.557,8.4375 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6851"/>
         </g>
       </g>
-      <rect
-         x="2721.3"
-         y="598.82001"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="0.999"
-         style="paint-order:normal"
-         id="rect6857" />
+      <rect x="2721.3" y="598.82001" width="226.77" height="226.77" fill="none" opacity="0.999" style="paint-order:normal" id="rect6857"/>
     </g>
-    <path
-       d="m 3135.8,712.49 a 74.136,74.134 0 0 1 -45.766,68.491 74.136,74.134 0 0 1 -80.793,-16.07 74.136,74.134 0 0 1 -16.071,-80.79 74.136,74.134 0 0 1 68.493,-45.764"
-       fill="none"
-       opacity="0.997"
-       stroke="#ffffff"
-       stroke-linecap="round"
-       stroke-linejoin="round"
-       stroke-width="21.26"
-       style="paint-order:normal"
-       id="path6861" />
-    <g
-       opacity="1"
-       id="g6871">
-      <path
-         d="m 3134.9,624.92 a 14.173,14.173 0 0 0 -10.074,4.1523 l -75.109,75.107 a 14.173,14.173 0 0 0 0,20.043 14.173,14.173 0 0 0 20.043,0 l 75.111,-75.107 a 14.173,14.173 0 0 0 0,-20.043 14.173,14.173 0 0 0 -9.9707,-4.1523 z"
-         color="#000000"
-         color-rendering="auto"
-         dominant-baseline="auto"
-         fill="#ffffff"
-         image-rendering="auto"
-         shape-rendering="auto"
-         solid-color="#000000"
-         stop-color="#000000"
-         style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-         id="path6863" />
-      <g
-         fill="#ffffff"
-         fill-rule="evenodd"
-         opacity="1"
-         shape-rendering="auto"
-         id="g6869">
-        <path
-           d="m 3158,615.97 -14.633,54.72 -40.087,-40.089 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           image-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-           id="path6865" />
-        <path
-           d="m 3163.3,610.62 -6.3164,1.6894 -61.049,16.322 49.35,49.354 z m -10.682,10.682 -11.252,42.074 -30.822,-30.824 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           image-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-           id="path6867" />
+    <path d="m 3135.8,712.49 a 74.136,74.134 0 0 1 -45.766,68.491 74.136,74.134 0 0 1 -80.793,-16.07 74.136,74.134 0 0 1 -16.071,-80.79 74.136,74.134 0 0 1 68.493,-45.764" fill="none" opacity="0.997" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="21.26" style="paint-order:normal" id="path6861"/>
+    <g opacity="1" id="g6871">
+      <path d="m 3134.9,624.92 a 14.173,14.173 0 0 0 -10.074,4.1523 l -75.109,75.107 a 14.173,14.173 0 0 0 0,20.043 14.173,14.173 0 0 0 20.043,0 l 75.111,-75.107 a 14.173,14.173 0 0 0 0,-20.043 14.173,14.173 0 0 0 -9.9707,-4.1523 z" color="#000000" color-rendering="auto" dominant-baseline="auto" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6863"/>
+      <g fill="#ffffff" fill-rule="evenodd" opacity="1" shape-rendering="auto" id="g6869">
+        <path d="m 3158,615.97 -14.633,54.72 -40.087,-40.089 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6865"/>
+        <path d="m 3163.3,610.62 -6.3164,1.6894 -61.049,16.322 49.35,49.354 z m -10.682,10.682 -11.252,42.074 -30.822,-30.824 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6867"/>
       </g>
     </g>
-    <rect
-       x="2948"
-       y="598.82001"
-       width="226.77"
-       height="226.77"
-       fill="none"
-       opacity="0.999"
-       style="paint-order:normal"
-       id="rect6873" />
-    <g
-       transform="translate(0,-1.7017e-5)"
-       id="g6889">
-      <path
-         d="m 3341.6,712.39 a 53.172,53.173 0 0 1 -32.824,49.125 53.172,53.173 0 0 1 -57.946,-11.526 53.172,53.173 0 0 1 -11.526,-57.947 53.172,53.173 0 0 1 49.124,-32.825"
-         fill="none"
-         opacity="0.997"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="21.26"
-         style="paint-order:normal"
-         id="path6875" />
-      <g
-         opacity="1"
-         id="g6885">
-        <path
-           d="m 3337.8,652.15 a 10.63,10.63 0 0 0 -7.3672,3.1133 l -53.869,53.871 a 10.63,10.63 0 0 0 0,15.033 10.63,10.63 0 0 0 15.033,0 l 53.869,-53.871 a 10.63,10.63 0 0 0 0,-15.033 10.63,10.63 0 0 0 -7.666,-3.1133 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           fill="#ffffff"
-           image-rendering="auto"
-           shape-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-           id="path6877" />
-        <g
-           fill="#ffffff"
-           fill-rule="evenodd"
-           opacity="1"
-           shape-rendering="auto"
-           id="g6883">
-          <path
-             d="m 3355.3,645.43 -10.974,41.04 -30.066,-30.065 z"
-             color="#000000"
-             color-rendering="auto"
-             dominant-baseline="auto"
-             image-rendering="auto"
-             solid-color="#000000"
-             stop-color="#000000"
-             style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-             id="path6879" />
-          <path
-             d="m 3359.3,641.42 -4.7383,1.2676 -45.785,12.244 37.014,37.012 z m -8.0117,8.0117 -8.4375,31.555 -23.119,-23.117 z"
-             color="#000000"
-             color-rendering="auto"
-             dominant-baseline="auto"
-             image-rendering="auto"
-             solid-color="#000000"
-             stop-color="#000000"
-             style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-             id="path6881" />
+    <rect x="2948" y="598.82001" width="226.77" height="226.77" fill="none" opacity="0.999" style="paint-order:normal" id="rect6873"/>
+    <g transform="translate(0,-1.7017e-5)" id="g6889">
+      <path d="m 3341.6,712.39 a 53.172,53.173 0 0 1 -32.824,49.125 53.172,53.173 0 0 1 -57.946,-11.526 53.172,53.173 0 0 1 -11.526,-57.947 53.172,53.173 0 0 1 49.124,-32.825" fill="none" opacity="0.997" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="21.26" style="paint-order:normal" id="path6875"/>
+      <g opacity="1" id="g6885">
+        <path d="m 3337.8,652.15 a 10.63,10.63 0 0 0 -7.3672,3.1133 l -53.869,53.871 a 10.63,10.63 0 0 0 0,15.033 10.63,10.63 0 0 0 15.033,0 l 53.869,-53.871 a 10.63,10.63 0 0 0 0,-15.033 10.63,10.63 0 0 0 -7.666,-3.1133 z" color="#000000" color-rendering="auto" dominant-baseline="auto" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6877"/>
+        <g fill="#ffffff" fill-rule="evenodd" opacity="1" shape-rendering="auto" id="g6883">
+          <path d="m 3355.3,645.43 -10.974,41.04 -30.066,-30.065 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6879"/>
+          <path d="m 3359.3,641.42 -4.7383,1.2676 -45.785,12.244 37.014,37.012 z m -8.0117,8.0117 -8.4375,31.555 -23.119,-23.117 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path6881"/>
         </g>
       </g>
-      <rect
-         x="3174.8"
-         y="598.82001"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="0.999"
-         style="paint-order:normal"
-         id="rect6887" />
+      <rect x="3174.8" y="598.82001" width="226.77" height="226.77" fill="none" opacity="0.999" style="paint-order:normal" id="rect6887"/>
     </g>
-    <rect
-       x="-2.5391e-06"
-       y="825.59003"
-       width="226.77"
-       height="226.77"
-       fill="none"
-       opacity="0.999"
-       id="rect6891" />
-    <g
-       transform="translate(-1814.8,3403)"
-       opacity="0.999"
-       stroke-width="22.968"
-       id="g6895">
-      <path
-         d="m 1864.3,-2441.2 50.386,23.291 40.291,-52.428 51.095,-69.094"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path6893" />
+    <rect x="-2.5391e-06" y="825.59003" width="226.77" height="226.77" fill="none" opacity="0.999" id="rect6891"/>
+    <g transform="translate(-1814.8,3403)" opacity="0.999" stroke-width="22.968" id="g6895">
+      <path d="m 1864.3,-2441.2 50.386,23.291 40.291,-52.428 51.095,-69.094" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6893"/>
     </g>
-    <rect
-       x="-2.5391e-06"
-       y="825.27002"
-       width="226.77"
-       height="227.10001"
-       fill="none"
-       opacity="0.999"
-       id="rect6897" />
-    <g
-       fill="#ffffff"
-       id="g6907">
-      <path
-         d="m 42.52,975.94 28.346,13.59 v 34.485 H 42.52 Z"
-         id="path6899" />
-      <path
-         d="m 127.56,976.76 28.346,-37.786 v 85.039 H 127.56 Z"
-         id="path6901" />
-      <path
-         d="m 85.039,995.67 c 7.292,2.8174 11.854,6.2467 17.215,5.8005 5.7551,-0.479 6.3254,-3.4803 11.132,-8.7836 v 31.33 H 85.04 Z"
-         opacity="0.999"
-         id="path6903" />
-      <path
-         d="m 170.08,925.04 28.346,-42.758 v 141.73 H 170.08 Z"
-         opacity="0.999"
-         id="path6905" />
+    <rect x="-2.5391e-06" y="825.27002" width="226.77" height="227.10001" fill="none" opacity="0.999" id="rect6897"/>
+    <g fill="#ffffff" id="g6907">
+      <path d="m 42.52,975.94 28.346,13.59 v 34.485 H 42.52 Z" id="path6899"/>
+      <path d="m 127.56,976.76 28.346,-37.786 v 85.039 H 127.56 Z" id="path6901"/>
+      <path d="m 85.039,995.67 c 7.292,2.8174 11.854,6.2467 17.215,5.8005 5.7551,-0.479 6.3254,-3.4803 11.132,-8.7836 v 31.33 H 85.04 Z" opacity="0.999" id="path6903"/>
+      <path d="m 170.08,925.04 28.346,-42.758 v 141.73 H 170.08 Z" opacity="0.999" id="path6905"/>
     </g>
-    <g
-       transform="translate(226.77)"
-       id="g6927">
-      <rect
-         x="-2.5391e-06"
-         y="825.59003"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="0.999"
-         id="rect6909" />
-      <g
-         transform="translate(-1814.8,3403)"
-         opacity="0.999"
-         stroke-width="22.968"
-         id="g6913">
-        <path
-           d="m 1864.3,-2538.7 50.386,42.516 40.291,-0.058 51.095,73.432"
-           fill="none"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           id="path6911" />
+    <g transform="translate(226.77)" id="g6927">
+      <rect x="-2.5391e-06" y="825.59003" width="226.77" height="226.77" fill="none" opacity="0.999" id="rect6909"/>
+      <g transform="translate(-1814.8,3403)" opacity="0.999" stroke-width="22.968" id="g6913">
+        <path d="m 1864.3,-2538.7 50.386,42.516 40.291,-0.058 51.095,73.432" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.173" id="path6911"/>
       </g>
-      <rect
-         x="-2.5391e-06"
-         y="825.27002"
-         width="226.77"
-         height="227.10001"
-         fill="none"
-         opacity="0.999"
-         id="rect6915" />
-      <g
-         fill="#ffffff"
-         id="g6925">
-        <path
-           d="m 42.52,881.25 28.346,24.371 v 118.39 H 42.52 Z"
-           id="path6917" />
-        <path
-           d="m 127.56,925.72 28.346,37.123 v 61.174 H 127.56 Z"
-           id="path6919" />
-        <path
-           d="m 85.371,914.96 c 4.6404,5.1376 5.8615,6.0993 8.7628,8.2864 2.9424,2.2181 10.634,1.6573 19.252,1.4916 v 99.278 h -28.346 z"
-           opacity="0.999"
-           id="path6921" />
-        <path
-           d="m 170.08,978.74 28.346,38.117 v 7.1611 H 170.08 Z"
-           opacity="0.999"
-           id="path6923" />
+      <rect x="-2.5391e-06" y="825.27002" width="226.77" height="227.10001" fill="none" opacity="0.999" id="rect6915"/>
+      <g fill="#ffffff" id="g6925">
+        <path d="m 42.52,881.25 28.346,24.371 v 118.39 H 42.52 Z" id="path6917"/>
+        <path d="m 127.56,925.72 28.346,37.123 v 61.174 H 127.56 Z" id="path6919"/>
+        <path d="m 85.371,914.96 c 4.6404,5.1376 5.8615,6.0993 8.7628,8.2864 2.9424,2.2181 10.634,1.6573 19.252,1.4916 v 99.278 h -28.346 z" opacity="0.999" id="path6921"/>
+        <path d="m 170.08,978.74 28.346,38.117 v 7.1611 H 170.08 Z" opacity="0.999" id="path6923"/>
       </g>
     </g>
-    <g
-       transform="translate(-226.77,2.6416e-5)"
-       id="g6948">
-      <rect
-         x="3628.3"
-         y="598.82001"
-         width="226.77"
-         height="226.77"
-         rx="0.00012162"
-         ry="0.00012162"
-         fill="none"
-         style="paint-order:markers fill stroke"
-         id="rect6929" />
-      <g
-         id="g2866"
-         transform="matrix(1,0,0,1.0526,0,-37.484)"
-         stroke-width="0.97468">
-        <rect
-           x="3656.7"
-           y="644.88"
-           width="28.346001"
-           height="134.64999"
-           rx="0"
-           ry="0"
-           fill="#ffffff"
-           style="paint-order:markers fill stroke"
-           id="rect6931" />
-        <rect
-           x="3798.3999"
-           y="644.88"
-           width="28.346001"
-           height="134.64999"
-           rx="0"
-           ry="0"
-           fill="#ffffff"
-           style="paint-order:markers fill stroke"
-           id="rect6933" />
-        <rect
-           transform="rotate(90)"
-           x="644.88"
-           y="-3791.1001"
-           width="24.802999"
-           height="98.799004"
-           rx="0"
-           ry="0"
-           fill="#ffffff"
-           style="paint-order:markers fill stroke"
-           id="rect6935" />
-        <rect
-           transform="rotate(90)"
-           x="754.71997"
-           y="-3791.1001"
-           width="24.802999"
-           height="98.800003"
-           rx="0"
-           ry="0"
-           fill="#ffffff"
-           style="paint-order:markers fill stroke"
-           id="rect6937" />
-        <path
-           transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-           d="m 3952.3,3471.8 33.865,18.568 h 57.63 V 3471.8 Z"
-           fill="#ffffff"
-           style="paint-order:markers fill stroke"
-           id="path6939" />
-        <path
-           transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-           d="m 3939.2,3495.8 v 23.275 h 43.787 l -40.588,-23.275 z m 55.066,0 40.588,23.275 h 8.7582 V 3495.8 Z"
-           fill="#ffffff"
-           style="paint-order:markers fill stroke"
-           id="path6941" />
-        <path
-           transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-           d="m 3938.8,3524.4 v 19.805 h 89.616 l -36.023,-19.805 z"
-           fill="#ffffff"
-           style="paint-order:markers fill stroke"
-           id="path6943" />
-        <rect
-           transform="matrix(0,1,-0.86748,-0.49747,0,0)"
-           x="-1439.2"
-           y="-4371.2002"
-           width="13.228"
-           height="115.61"
-           rx="0"
-           ry="0"
-           fill="#ffffff"
-           style="paint-order:markers fill stroke"
-           id="rect6945" />
+    <g transform="translate(-226.77,2.6416e-5)" id="g6948">
+      <rect x="3628.3" y="598.82001" width="226.77" height="226.77" rx="0.00012162" ry="0.00012162" fill="none" style="paint-order:markers fill stroke" id="rect6929"/>
+      <g id="g2866" transform="matrix(1,0,0,1.0526,0,-37.484)" stroke-width="0.97468">
+        <rect x="3656.7" y="644.88" width="28.346001" height="134.64999" rx="0" ry="0" fill="#ffffff" style="paint-order:markers fill stroke" id="rect6931"/>
+        <rect x="3798.3999" y="644.88" width="28.346001" height="134.64999" rx="0" ry="0" fill="#ffffff" style="paint-order:markers fill stroke" id="rect6933"/>
+        <rect transform="rotate(90)" x="644.88" y="-3791.1001" width="24.802999" height="98.799004" rx="0" ry="0" fill="#ffffff" style="paint-order:markers fill stroke" id="rect6935"/>
+        <rect transform="rotate(90)" x="754.71997" y="-3791.1001" width="24.802999" height="98.800003" rx="0" ry="0" fill="#ffffff" style="paint-order:markers fill stroke" id="rect6937"/>
+        <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 3952.3,3471.8 33.865,18.568 h 57.63 V 3471.8 Z" fill="#ffffff" style="paint-order:markers fill stroke" id="path6939"/>
+        <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 3939.2,3495.8 v 23.275 h 43.787 l -40.588,-23.275 z m 55.066,0 40.588,23.275 h 8.7582 V 3495.8 Z" fill="#ffffff" style="paint-order:markers fill stroke" id="path6941"/>
+        <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 3938.8,3524.4 v 19.805 h 89.616 l -36.023,-19.805 z" fill="#ffffff" style="paint-order:markers fill stroke" id="path6943"/>
+        <rect transform="matrix(0,1,-0.86748,-0.49747,0,0)" x="-1439.2" y="-4371.2002" width="13.228" height="115.61" rx="0" ry="0" fill="#ffffff" style="paint-order:markers fill stroke" id="rect6945"/>
       </g>
     </g>
-    <g
-       transform="translate(-1587.4,-680.31)"
-       id="g6970">
-      <rect
-         x="3656.7"
-         y="644.88"
-         width="28.346001"
-         height="134.64999"
-         rx="6.0236001"
-         ry="6.0236001"
-         fill="#ffffff"
-         style="paint-order:markers fill stroke"
-         id="rect6950" />
-      <rect
-         x="3798.3999"
-         y="644.88"
-         width="28.346001"
-         height="134.64999"
-         rx="6.0236001"
-         ry="6.0236001"
-         fill="#ffffff"
-         style="paint-order:markers fill stroke"
-         id="rect6952" />
-      <rect
-         x="3628.3"
-         y="598.82001"
-         width="226.77"
-         height="226.77"
-         rx="0.00012162"
-         ry="0.00012162"
-         fill="none"
-         style="paint-order:markers fill stroke"
-         id="rect6954" />
-      <g
-         fill="#ffffff"
-         id="g6968">
-        <rect
-           transform="rotate(90)"
-           x="644.88"
-           y="-3794.8999"
-           width="28.118"
-           height="106.3"
-           rx="6.0236001"
-           ry="6.0236001"
-           style="paint-order:markers fill stroke"
-           id="rect6956" />
-        <rect
-           transform="rotate(90)"
-           x="754.46002"
-           y="-3794.8999"
-           width="25.072001"
-           height="106.3"
-           rx="6.0236001"
-           ry="6.0236001"
-           style="paint-order:markers fill stroke"
-           id="rect6958" />
-        <path
-           transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-           d="m 3941,3469.8 35.865,20.568 h 64.551 c 3.5595,0 6.4258,-2.8662 6.4258,-6.4257 v -7.7188 c 0,-3.5596 -2.8663,-6.4238 -6.4258,-6.4238 z m -6.5449,10.391 v 3.752 c 0,3.5595 2.8662,6.4257 6.4258,6.4257 l 6.6598,0.3536 -9.407,-5.2647 c -1.3878,-0.7766 -3.6786,-1.707 -3.6786,-5.2666 z"
-           style="paint-order:markers fill stroke"
-           id="path6960" />
-        <path
-           transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-           d="m 3940.9,3495.8 c -3.5596,0 -6.4258,2.8662 -6.4258,6.4258 v 10.424 c 0,3.5595 2.8662,6.4258 6.4258,6.4258 h 50.068 l -40.588,-23.275 z m 45.348,0 40.588,23.275 h 14.6 c 3.5595,0 6.4258,-2.8663 6.4258,-6.4258 v -10.424 c 0,-3.5596 -2.8663,-6.4258 -6.4258,-6.4258 z"
-           style="paint-order:markers fill stroke"
-           id="path6962" />
-        <path
-           transform="matrix(0.9375,0,0,0.9375,0,-2576)"
-           d="m 3940.9,3524.4 c -3.5596,0 -6.4258,2.8642 -6.4258,6.4238 v 8.9551 c 0,3.5595 2.8662,6.4257 6.4258,6.4257 h 97.457 l -38.023,-21.805 z m 95.301,0 6.7442,3.8671 c 2.7234,1.5618 4.916,2.7678 4.916,6.3274 v -3.7707 c 0,-3.5596 -2.8663,-6.4238 -6.4258,-6.4238 z"
-           style="paint-order:markers fill stroke"
-           id="path6964" />
-        <rect
-           transform="matrix(0,1,-0.86748,-0.49747,0,0)"
-           x="-1437.6"
-           y="-4375.5"
-           width="10.029"
-           height="124.26"
-           rx="4.9790001"
-           ry="5.3126001"
-           style="paint-order:markers fill stroke"
-           id="rect6966" />
+    <g transform="translate(-1587.4,-680.31)" id="g6970">
+      <rect x="3656.7" y="644.88" width="28.346001" height="134.64999" rx="6.0236001" ry="6.0236001" fill="#ffffff" style="paint-order:markers fill stroke" id="rect6950"/>
+      <rect x="3798.3999" y="644.88" width="28.346001" height="134.64999" rx="6.0236001" ry="6.0236001" fill="#ffffff" style="paint-order:markers fill stroke" id="rect6952"/>
+      <rect x="3628.3" y="598.82001" width="226.77" height="226.77" rx="0.00012162" ry="0.00012162" fill="none" style="paint-order:markers fill stroke" id="rect6954"/>
+      <g fill="#ffffff" id="g6968">
+        <rect transform="rotate(90)" x="644.88" y="-3794.8999" width="28.118" height="106.3" rx="6.0236001" ry="6.0236001" style="paint-order:markers fill stroke" id="rect6956"/>
+        <rect transform="rotate(90)" x="754.46002" y="-3794.8999" width="25.072001" height="106.3" rx="6.0236001" ry="6.0236001" style="paint-order:markers fill stroke" id="rect6958"/>
+        <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 3941,3469.8 35.865,20.568 h 64.551 c 3.5595,0 6.4258,-2.8662 6.4258,-6.4257 v -7.7188 c 0,-3.5596 -2.8663,-6.4238 -6.4258,-6.4238 z m -6.5449,10.391 v 3.752 c 0,3.5595 2.8662,6.4257 6.4258,6.4257 l 6.6598,0.3536 -9.407,-5.2647 c -1.3878,-0.7766 -3.6786,-1.707 -3.6786,-5.2666 z" style="paint-order:markers fill stroke" id="path6960"/>
+        <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 3940.9,3495.8 c -3.5596,0 -6.4258,2.8662 -6.4258,6.4258 v 10.424 c 0,3.5595 2.8662,6.4258 6.4258,6.4258 h 50.068 l -40.588,-23.275 z m 45.348,0 40.588,23.275 h 14.6 c 3.5595,0 6.4258,-2.8663 6.4258,-6.4258 v -10.424 c 0,-3.5596 -2.8663,-6.4258 -6.4258,-6.4258 z" style="paint-order:markers fill stroke" id="path6962"/>
+        <path transform="matrix(0.9375,0,0,0.9375,0,-2576)" d="m 3940.9,3524.4 c -3.5596,0 -6.4258,2.8642 -6.4258,6.4238 v 8.9551 c 0,3.5595 2.8662,6.4257 6.4258,6.4257 h 97.457 l -38.023,-21.805 z m 95.301,0 6.7442,3.8671 c 2.7234,1.5618 4.916,2.7678 4.916,6.3274 v -3.7707 c 0,-3.5596 -2.8663,-6.4238 -6.4258,-6.4238 z" style="paint-order:markers fill stroke" id="path6964"/>
+        <rect transform="matrix(0,1,-0.86748,-0.49747,0,0)" x="-1437.6" y="-4375.5" width="10.029" height="124.26" rx="4.9790001" ry="5.3126001" style="paint-order:markers fill stroke" id="rect6966"/>
       </g>
     </g>
-    <g
-       transform="translate(-1360.6,-680.31)"
-       id="g6996">
-      <rect
-         x="3628.3"
-         y="598.82001"
-         width="226.77"
-         height="226.77"
-         rx="0.00012162"
-         ry="0.00012162"
-         fill="none"
-         style="paint-order:markers fill stroke"
-         id="rect6972" />
-      <g
-         transform="matrix(0.63158,0,-0.24617,0.63158,1584.6,262.39)"
-         fill="#ffffff"
-         stroke-width="1.5833"
-         id="g6994">
-        <rect
-           x="3656.7"
-           y="644.88"
-           width="28.346001"
-           height="134.64999"
-           rx="9.5374002"
-           ry="8.8863001"
-           style="paint-order:markers fill stroke"
-           id="rect6974" />
-        <rect
-           x="3798.3999"
-           y="644.88"
-           width="28.346001"
-           height="134.64999"
-           rx="9.5374002"
-           ry="8.8863001"
-           style="paint-order:markers fill stroke"
-           id="rect6976" />
-        <rect
-           transform="rotate(90)"
-           x="644.88"
-           y="-3794.8999"
-           width="28.118"
-           height="106.3"
-           rx="8.8863001"
-           ry="9.5374002"
-           style="paint-order:markers fill stroke"
-           id="rect6978" />
-        <rect
-           transform="rotate(90)"
-           x="754.46002"
-           y="-3794.8999"
-           width="25.072001"
-           height="106.3"
-           rx="8.8863001"
-           ry="9.5374002"
-           style="paint-order:markers fill stroke"
-           id="rect6980" />
-        <path
-           d="m 3694.7,676.98 33.624,19.283 h 60.516 c 3.337,0 6.0242,-2.6871 6.0242,-6.0241 v -7.2364 c 0,-3.3371 -2.6872,-6.0223 -6.0242,-6.0223 z m -6.1358,9.7412 v 3.5175 c 0,3.337 2.687,6.0241 6.0242,6.0241 l 6.2435,0.3315 -8.819,-4.9357 c -1.3011,-0.72806 -3.4487,-1.6003 -3.4487,-4.9374 z"
-           style="paint-order:markers fill stroke"
-           id="path6982" />
-        <path
-           d="m 3694.6,701.29 c -3.3372,0 -6.0242,2.6871 -6.0242,6.0242 v 9.7723 c 0,3.337 2.687,6.0242 6.0242,6.0242 h 46.939 l -38.051,-21.821 z m 42.513,0 38.051,21.821 h 13.687 c 3.337,0 6.0242,-2.6872 6.0242,-6.0242 v -9.7723 c 0,-3.3371 -2.6872,-6.0242 -6.0242,-6.0242 z"
-           style="paint-order:markers fill stroke"
-           id="path6984" />
-        <path
-           d="m 3694.6,728.15 c -3.3372,0 -6.0242,2.6852 -6.0242,6.0223 v 8.3954 c 0,3.337 2.687,6.0241 6.0242,6.0241 h 91.366 l -35.647,-20.442 z m 89.344,0 6.3226,3.6254 c 2.5532,1.4642 4.6088,2.5948 4.6088,5.9319 v -3.535 c 0,-3.3371 -2.6872,-6.0223 -6.0242,-6.0223 z"
-           style="paint-order:markers fill stroke"
-           id="path6986" />
-        <rect
-           transform="matrix(0,1,-0.86748,-0.49747,0,0)"
-           x="-1437.6"
-           y="-4375.5"
-           width="10.029"
-           height="124.26"
-           rx="7.3453002"
-           ry="10.045"
-           style="paint-order:markers fill stroke"
-           id="rect6988" />
-        <rect
-           x="3596.8999"
-           y="644.88"
-           width="48.289001"
-           height="134.64999"
-           rx="0"
-           ry="0"
-           style="paint-order:markers fill stroke"
-           id="rect6990" />
-        <rect
-           x="3564.2"
-           y="644.88"
-           width="18.601999"
-           height="134.64999"
-           rx="0"
-           ry="0"
-           style="paint-order:markers fill stroke"
-           id="rect6992" />
+    <g transform="translate(-1360.6,-680.31)" id="g6996">
+      <rect x="3628.3" y="598.82001" width="226.77" height="226.77" rx="0.00012162" ry="0.00012162" fill="none" style="paint-order:markers fill stroke" id="rect6972"/>
+      <g transform="matrix(0.63158,0,-0.24617,0.63158,1584.6,262.39)" fill="#ffffff" stroke-width="1.5833" id="g6994">
+        <rect x="3656.7" y="644.88" width="28.346001" height="134.64999" rx="9.5374002" ry="8.8863001" style="paint-order:markers fill stroke" id="rect6974"/>
+        <rect x="3798.3999" y="644.88" width="28.346001" height="134.64999" rx="9.5374002" ry="8.8863001" style="paint-order:markers fill stroke" id="rect6976"/>
+        <rect transform="rotate(90)" x="644.88" y="-3794.8999" width="28.118" height="106.3" rx="8.8863001" ry="9.5374002" style="paint-order:markers fill stroke" id="rect6978"/>
+        <rect transform="rotate(90)" x="754.46002" y="-3794.8999" width="25.072001" height="106.3" rx="8.8863001" ry="9.5374002" style="paint-order:markers fill stroke" id="rect6980"/>
+        <path d="m 3694.7,676.98 33.624,19.283 h 60.516 c 3.337,0 6.0242,-2.6871 6.0242,-6.0241 v -7.2364 c 0,-3.3371 -2.6872,-6.0223 -6.0242,-6.0223 z m -6.1358,9.7412 v 3.5175 c 0,3.337 2.687,6.0241 6.0242,6.0241 l 6.2435,0.3315 -8.819,-4.9357 c -1.3011,-0.72806 -3.4487,-1.6003 -3.4487,-4.9374 z" style="paint-order:markers fill stroke" id="path6982"/>
+        <path d="m 3694.6,701.29 c -3.3372,0 -6.0242,2.6871 -6.0242,6.0242 v 9.7723 c 0,3.337 2.687,6.0242 6.0242,6.0242 h 46.939 l -38.051,-21.821 z m 42.513,0 38.051,21.821 h 13.687 c 3.337,0 6.0242,-2.6872 6.0242,-6.0242 v -9.7723 c 0,-3.3371 -2.6872,-6.0242 -6.0242,-6.0242 z" style="paint-order:markers fill stroke" id="path6984"/>
+        <path d="m 3694.6,728.15 c -3.3372,0 -6.0242,2.6852 -6.0242,6.0223 v 8.3954 c 0,3.337 2.687,6.0241 6.0242,6.0241 h 91.366 l -35.647,-20.442 z m 89.344,0 6.3226,3.6254 c 2.5532,1.4642 4.6088,2.5948 4.6088,5.9319 v -3.535 c 0,-3.3371 -2.6872,-6.0223 -6.0242,-6.0223 z" style="paint-order:markers fill stroke" id="path6986"/>
+        <rect transform="matrix(0,1,-0.86748,-0.49747,0,0)" x="-1437.6" y="-4375.5" width="10.029" height="124.26" rx="7.3453002" ry="10.045" style="paint-order:markers fill stroke" id="rect6988"/>
+        <rect x="3596.8999" y="644.88" width="48.289001" height="134.64999" rx="0" ry="0" style="paint-order:markers fill stroke" id="rect6990"/>
+        <rect x="3564.2" y="644.88" width="18.601999" height="134.64999" rx="0" ry="0" style="paint-order:markers fill stroke" id="rect6992"/>
       </g>
     </g>
-    <g
-       transform="translate(-7256.7,680.32)"
-       id="g7002">
-      <rect
-         x="8163.7998"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6998" />
-      <path
-         d="m 8227.4,-2553.9 -22.329,16.617 c 0,0 21.32,22.801 25.456,59.108 h -15.574 v 31.151 h 15.574 c -4.1361,36.307 -25.456,59.106 -25.456,59.106 l 22.329,16.619 c 0,0 40.508,-45.917 106.85,-79.355 l 13.806,-11.946 -13.806,-11.944 c -66.344,-33.438 -106.85,-79.355 -106.85,-79.355 z m 19.47,62.028 h 9.0105 c 2.1271,0 3.8393,1.7122 3.8393,3.8392 0,2.127 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7123 -3.8394,-3.8393 0,-2.127 1.7123,-3.8392 3.8394,-3.8392 z m 25.43,0 h 9.0086 c 2.1271,0 3.8394,1.7122 3.8394,3.8392 0,2.127 -1.7123,3.8393 -3.8394,3.8393 H 8272.3 c -2.127,0 -3.8393,-1.7123 -3.8393,-3.8393 0,-2.127 1.7123,-3.8392 3.8393,-3.8392 z m 27.463,15.55 8.0427,0.3441 c 2.6845,4.1003 5.7744,6.3606 11.176,8.56 4.3952,1.7896 4.9984,4.8172 4.9984,4.8172 0,0 -0.6032,3.0297 -4.9984,4.8192 -5.4014,2.1995 -8.4913,4.4598 -11.176,8.5599 l -8.0427,0.3442 c 0,0 -4.9148,-8.3087 -5.9723,-13.723 -0.021,0.1074 -0.05,0.221 -0.068,0.326 v -0.65 c 0.018,0.1046 0.048,0.2172 0.068,0.324 1.058,-5.4146 5.9723,-13.721 5.9723,-13.721 z m -52.893,35.316 h 9.0105 c 2.1271,0 3.8393,1.7123 3.8393,3.8393 0,2.1271 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7122 -3.8394,-3.8393 0,-2.127 1.7123,-3.8393 3.8394,-3.8393 z m 25.43,0 h 9.0086 c 2.1271,0 3.8394,1.7123 3.8394,3.8393 0,2.1271 -1.7123,3.8393 -3.8394,3.8393 H 8272.3 c -2.127,0 -3.8393,-1.7122 -3.8393,-3.8393 0,-2.127 1.7123,-3.8393 3.8393,-3.8393 z"
-         fill="#ffffff"
-         id="path7000" />
+    <g transform="translate(-7256.7,680.32)" id="g7002">
+      <rect x="8163.7998" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect6998"/>
+      <path d="m 8227.4,-2553.9 -22.329,16.617 c 0,0 21.32,22.801 25.456,59.108 h -15.574 v 31.151 h 15.574 c -4.1361,36.307 -25.456,59.106 -25.456,59.106 l 22.329,16.619 c 0,0 40.508,-45.917 106.85,-79.355 l 13.806,-11.946 -13.806,-11.944 c -66.344,-33.438 -106.85,-79.355 -106.85,-79.355 z m 19.47,62.028 h 9.0105 c 2.1271,0 3.8393,1.7122 3.8393,3.8392 0,2.127 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7123 -3.8394,-3.8393 0,-2.127 1.7123,-3.8392 3.8394,-3.8392 z m 25.43,0 h 9.0086 c 2.1271,0 3.8394,1.7122 3.8394,3.8392 0,2.127 -1.7123,3.8393 -3.8394,3.8393 H 8272.3 c -2.127,0 -3.8393,-1.7123 -3.8393,-3.8393 0,-2.127 1.7123,-3.8392 3.8393,-3.8392 z m 27.463,15.55 8.0427,0.3441 c 2.6845,4.1003 5.7744,6.3606 11.176,8.56 4.3952,1.7896 4.9984,4.8172 4.9984,4.8172 0,0 -0.6032,3.0297 -4.9984,4.8192 -5.4014,2.1995 -8.4913,4.4598 -11.176,8.5599 l -8.0427,0.3442 c 0,0 -4.9148,-8.3087 -5.9723,-13.723 -0.021,0.1074 -0.05,0.221 -0.068,0.326 v -0.65 c 0.018,0.1046 0.048,0.2172 0.068,0.324 1.058,-5.4146 5.9723,-13.721 5.9723,-13.721 z m -52.893,35.316 h 9.0105 c 2.1271,0 3.8393,1.7123 3.8393,3.8393 0,2.1271 -1.7122,3.8393 -3.8393,3.8393 h -9.0105 c -2.1271,0 -3.8394,-1.7122 -3.8394,-3.8393 0,-2.127 1.7123,-3.8393 3.8394,-3.8393 z m 25.43,0 h 9.0086 c 2.1271,0 3.8394,1.7123 3.8394,3.8393 0,2.1271 -1.7123,3.8393 -3.8394,3.8393 H 8272.3 c -2.127,0 -3.8393,-1.7122 -3.8393,-3.8393 0,-2.127 1.7123,-3.8393 3.8393,-3.8393 z" fill="#ffffff" id="path7000"/>
     </g>
-    <g
-       id="starport"
-       transform="translate(1133.9,1814.2)"
-       opacity="0.999">
-      <g
-         transform="matrix(6.611,0,0,6.611,-3719.6,-10591)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         id="g7010">
-        <path
-           d="m 491.38,1481.7 h -29"
-           fill="#ffffff"
-           opacity="1"
-           stroke-width="1.0719"
-           id="path7004" />
-        <path
-           d="m 467.13,1481.3 0.0531,-2.5684 2.6156,2.9593 1.7633,-2.9593 2.1142,2.9593 3.0668,-2.9593 2.9665,2.9593 2.2145,-2.9593 1.663,2.9593 2.7159,-2.9593 v 2.7689"
-           fill="none"
-           opacity="1"
-           id="path7006" />
-        <rect
-           x="466.42999"
-           y="1476.6"
-           width="20.707001"
-           height="1.9439"
-           rx="0.75313997"
-           ry="0.80359"
-           fill="#ffffff"
-           stroke-width="1.0719"
-           style="paint-order:markers fill stroke"
-           id="rect7008" />
+    <g id="starport" transform="translate(1133.9,1814.2)" opacity="0.999">
+      <g transform="matrix(6.611,0,0,6.611,-3719.6,-10591)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" id="g7010">
+        <path d="m 491.38,1481.7 h -29" fill="#ffffff" opacity="1" stroke-width="1.0719" id="path7004"/>
+        <path d="m 467.13,1481.3 0.0531,-2.5684 2.6156,2.9593 1.7633,-2.9593 2.1142,2.9593 3.0668,-2.9593 2.9665,2.9593 2.2145,-2.9593 1.663,2.9593 2.7159,-2.9593 v 2.7689" fill="none" opacity="1" id="path7006"/>
+        <rect x="466.42999" y="1476.6" width="20.707001" height="1.9439" rx="0.75313997" ry="0.80359" fill="#ffffff" stroke-width="1.0719" style="paint-order:markers fill stroke" id="rect7008"/>
       </g>
-      <g
-         fill="none"
-         id="g7034">
-        <rect
-           x="-680.32001"
-           y="-988.58002"
-           width="226.77"
-           height="226.77"
-           id="rect7012" />
-        <g
-           stroke="#ffffff"
-           stroke-linejoin="round"
-           id="g7032">
-          <path
-             d="m -485.91,-889.86 v 89.475 m -36.46,-41.25 v -48.225"
-             stroke-linecap="round"
-             stroke-width="7.0866"
-             style="paint-order:markers fill stroke"
-             id="path7014" />
-          <path
-             d="m -529.66,-935.59 h 51.03 c 2.7584,0 4.979,2.3694 4.979,5.3126 v 26.746 c 0,2.9432 -9.7523,12.344 -11.776,12.344 h -37.436 c -2.0236,0 -11.776,-9.4006 -11.776,-12.344 v -26.746 c 0,-2.9432 2.2207,-5.3126 4.979,-5.3126 z"
-             stroke-linecap="round"
-             stroke-width="7.0866"
-             style="paint-order:markers fill stroke"
-             id="path7016" />
-          <g
-             id="g7030">
-            <g
-               stroke-width="7.0866"
-               id="g7026">
-              <path
-                 d="m -527.17,-917.7 h 12.757"
-                 style="paint-order:markers fill stroke"
-                 id="path7018" />
-              <path
-                 d="m -510.44,-917.7 h 12.757"
-                 style="paint-order:markers fill stroke"
-                 id="path7020" />
-              <path
-                 d="m -494.03,-917.7 h 12.757"
-                 style="paint-order:markers fill stroke"
-                 id="path7022" />
-              <path
-                 d="m -491.96,-975.45 v 36.622"
-                 style="paint-order:markers fill stroke"
-                 id="path7024" />
+      <g fill="none" id="g7034">
+        <rect x="-680.32001" y="-988.58002" width="226.77" height="226.77" id="rect7012"/>
+        <g stroke="#ffffff" stroke-linejoin="round" id="g7032">
+          <path d="m -485.91,-889.86 v 89.475 m -36.46,-41.25 v -48.225" stroke-linecap="round" stroke-width="7.0866" style="paint-order:markers fill stroke" id="path7014"/>
+          <path d="m -529.66,-935.59 h 51.03 c 2.7584,0 4.979,2.3694 4.979,5.3126 v 26.746 c 0,2.9432 -9.7523,12.344 -11.776,12.344 h -37.436 c -2.0236,0 -11.776,-9.4006 -11.776,-12.344 v -26.746 c 0,-2.9432 2.2207,-5.3126 4.979,-5.3126 z" stroke-linecap="round" stroke-width="7.0866" style="paint-order:markers fill stroke" id="path7016"/>
+          <g id="g7030">
+            <g stroke-width="7.0866" id="g7026">
+              <path d="m -527.17,-917.7 h 12.757" style="paint-order:markers fill stroke" id="path7018"/>
+              <path d="m -510.44,-917.7 h 12.757" style="paint-order:markers fill stroke" id="path7020"/>
+              <path d="m -494.03,-917.7 h 12.757" style="paint-order:markers fill stroke" id="path7022"/>
+              <path d="m -491.96,-975.45 v 36.622" style="paint-order:markers fill stroke" id="path7024"/>
             </g>
-            <path
-               d="m -502.57,-958.71 v 19.884"
-               stroke-width="3.5433"
-               style="paint-order:markers fill stroke"
-               id="path7028" />
+            <path d="m -502.57,-958.71 v 19.884" stroke-width="3.5433" style="paint-order:markers fill stroke" id="path7028"/>
           </g>
         </g>
       </g>
-      <g
-         fill="none"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         id="g7052">
-        <path
-           d="m -567.59,-840.76 h -72.112 l 0.01,-11.651 16.29,0.16668 0.24448,-12.52 30.724,-0.46875 c 17.489,-0.22081 33.395,0.38153 45.397,15.869 -6.7215,8.8738 -11.055,8.6899 -20.553,8.6036 z"
-           opacity="0.999"
-           stroke-linecap="round"
-           stroke-width="7.0866"
-           id="path7036" />
-        <g
-           id="g7050">
-          <path
-             d="m -623.8,-852.25 h 16.904 l 10.607,10.607"
-             stroke-width="7.0866"
-             id="path7038" />
-          <path
-             d="m -623.21,-861.38 0.23565,-14.833 h 17.083 l 10.607,10.607"
-             stroke-width="7.0866"
-             id="path7040" />
-          <g
-             stroke-width="3.5433"
-             id="g7048">
-            <path
-               d="m -569.27,-855.65 h 12.757"
-               style="paint-order:markers fill stroke"
-               id="path7042" />
-            <path
-               d="m -577.12,-855.65 h 3.8512"
-               style="paint-order:markers fill stroke"
-               id="path7044" />
-            <path
-               d="m -584.74,-855.65 h 3.8512"
-               style="paint-order:markers fill stroke"
-               id="path7046" />
+      <g fill="none" stroke="#ffffff" stroke-linejoin="round" id="g7052">
+        <path d="m -567.59,-840.76 h -72.112 l 0.01,-11.651 16.29,0.16668 0.24448,-12.52 30.724,-0.46875 c 17.489,-0.22081 33.395,0.38153 45.397,15.869 -6.7215,8.8738 -11.055,8.6899 -20.553,8.6036 z" opacity="0.999" stroke-linecap="round" stroke-width="7.0866" id="path7036"/>
+        <g id="g7050">
+          <path d="m -623.8,-852.25 h 16.904 l 10.607,10.607" stroke-width="7.0866" id="path7038"/>
+          <path d="m -623.21,-861.38 0.23565,-14.833 h 17.083 l 10.607,10.607" stroke-width="7.0866" id="path7040"/>
+          <g stroke-width="3.5433" id="g7048">
+            <path d="m -569.27,-855.65 h 12.757" style="paint-order:markers fill stroke" id="path7042"/>
+            <path d="m -577.12,-855.65 h 3.8512" style="paint-order:markers fill stroke" id="path7044"/>
+            <path d="m -584.74,-855.65 h 3.8512" style="paint-order:markers fill stroke" id="path7046"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(1360.6,1814.2)"
-       opacity="0.999"
-       id="g7077">
-      <path
-         d="M -471.07,-795.17 H -662.79"
-         fill="#ffffff"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="7.0866"
-         id="path7055" />
-      <g
-         fill="none"
-         id="g7063">
-        <rect
-           x="-680.32001"
-           y="-988.58002"
-           width="226.77"
-           height="226.77"
-           id="rect7057" />
-        <path
-           d="m -599.78,-900.01 34.408,102.13"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="7.0866"
-           style="paint-order:markers fill stroke"
-           id="path7059" />
-        <path
-           d="m -584.04,-900.01 -34.408,102.13"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="7.0866"
-           style="paint-order:markers fill stroke"
-           id="path7061" />
+    <g transform="translate(1360.6,1814.2)" opacity="0.999" id="g7077">
+      <path d="M -471.07,-795.17 H -662.79" fill="#ffffff" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.0866" id="path7055"/>
+      <g fill="none" id="g7063">
+        <rect x="-680.32001" y="-988.58002" width="226.77" height="226.77" id="rect7057"/>
+        <path d="m -599.78,-900.01 34.408,102.13" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.0866" style="paint-order:markers fill stroke" id="path7059"/>
+        <path d="m -584.04,-900.01 -34.408,102.13" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.0866" style="paint-order:markers fill stroke" id="path7061"/>
       </g>
-      <path
-         d="m -566.93,-797.82 -24.88,-79.123 -26.637,79.064 12.879,0.0146 12.879,-39.595 12.879,39.624 z"
-         fill="#ffffff"
-         style="paint-order:markers fill stroke"
-         id="path7065" />
-      <g
-         transform="matrix(1.2275,0,0,1.2275,105.36,181.79)"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         id="g7075">
-        <path
-           d="m -522.99,-814.96 h 12.757"
-           stroke-width="5.773"
-           style="paint-order:markers fill stroke"
-           id="path7067" />
-        <path
-           d="m -507.63,-861.68 v 36.622"
-           stroke-width="5.773"
-           style="paint-order:markers fill stroke"
-           id="path7069" />
-        <path
-           d="m -516.6,-848.81 v 19.884"
-           stroke-width="2.8865"
-           style="paint-order:markers fill stroke"
-           id="path7071" />
-        <path
-           d="m -554.71,-794.41 a 30.234,30.234 0 0 1 12.735,-28.789 30.234,30.234 0 0 1 31.425,-1.8629 30.234,30.234 0 0 1 16.047,27.082"
-           opacity="0.999"
-           stroke-width="5.773"
-           style="paint-order:markers fill stroke"
-           id="path7073" />
+      <path d="m -566.93,-797.82 -24.88,-79.123 -26.637,79.064 12.879,0.0146 12.879,-39.595 12.879,39.624 z" fill="#ffffff" style="paint-order:markers fill stroke" id="path7065"/>
+      <g transform="matrix(1.2275,0,0,1.2275,105.36,181.79)" fill="none" stroke="#ffffff" stroke-linejoin="round" id="g7075">
+        <path d="m -522.99,-814.96 h 12.757" stroke-width="5.773" style="paint-order:markers fill stroke" id="path7067"/>
+        <path d="m -507.63,-861.68 v 36.622" stroke-width="5.773" style="paint-order:markers fill stroke" id="path7069"/>
+        <path d="m -516.6,-848.81 v 19.884" stroke-width="2.8865" style="paint-order:markers fill stroke" id="path7071"/>
+        <path d="m -554.71,-794.41 a 30.234,30.234 0 0 1 12.735,-28.789 30.234,30.234 0 0 1 31.425,-1.8629 30.234,30.234 0 0 1 16.047,27.082" opacity="0.999" stroke-width="5.773" style="paint-order:markers fill stroke" id="path7073"/>
       </g>
     </g>
-    <g
-       transform="translate(1587.4,1814.2)"
-       opacity="0.999"
-       id="g7107">
-      <path
-         d="M -471.07,-795.17 H -662.79"
-         fill="#ffffff"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="7.0866"
-         id="path7079" />
-      <rect
-         x="-680.32001"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         id="rect7081" />
-      <g
-         transform="matrix(1.4722,0,0,1.472,225.8,376.12)"
-         stroke-width="0.6793"
-         id="g7105">
-        <g
-           fill="none"
-           stroke="#ffffff"
-           stroke-linejoin="round"
-           id="g7099">
-          <path
-             d="m -557.05,-814.96 h 5.3816"
-             stroke-width="4.8139"
-             style="paint-order:markers fill stroke"
-             id="path7083" />
-          <path
-             d="m -507.63,-861.68 v 36.622"
-             stroke-width="4.8139"
-             style="paint-order:markers fill stroke"
-             id="path7085" />
-          <path
-             d="m -516.6,-848.81 v 19.884"
-             stroke-width="2.407"
-             style="paint-order:markers fill stroke"
-             id="path7087" />
-          <g
-             stroke-width="4.8139"
-             id="g7095">
-            <path
-               d="m -546.55,-794.23 a 27.339,30.234 0 0 1 11.516,-28.789 27.339,30.234 0 0 1 28.415,-1.8629 27.339,30.234 0 0 1 14.511,27.082"
-               opacity="0.999"
-               style="paint-order:markers fill stroke"
-               id="path7089" />
-            <path
-               d="m -584.03,-794.41 a 27.339,30.234 0 0 1 6.5485,-23.884 27.339,30.234 0 0 1 20.556,-10.301"
-               opacity="0.999"
-               style="paint-order:markers fill stroke"
-               id="path7091" />
-            <path
-               d="m -519.15,-828.54 -38.11,-0.0562"
-               opacity="0.999"
-               style="paint-order:markers fill stroke"
-               id="path7093" />
+    <g transform="translate(1587.4,1814.2)" opacity="0.999" id="g7107">
+      <path d="M -471.07,-795.17 H -662.79" fill="#ffffff" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.0866" id="path7079"/>
+      <rect x="-680.32001" y="-988.58002" width="226.77" height="226.77" fill="none" id="rect7081"/>
+      <g transform="matrix(1.4722,0,0,1.472,225.8,376.12)" stroke-width="0.6793" id="g7105">
+        <g fill="none" stroke="#ffffff" stroke-linejoin="round" id="g7099">
+          <path d="m -557.05,-814.96 h 5.3816" stroke-width="4.8139" style="paint-order:markers fill stroke" id="path7083"/>
+          <path d="m -507.63,-861.68 v 36.622" stroke-width="4.8139" style="paint-order:markers fill stroke" id="path7085"/>
+          <path d="m -516.6,-848.81 v 19.884" stroke-width="2.407" style="paint-order:markers fill stroke" id="path7087"/>
+          <g stroke-width="4.8139" id="g7095">
+            <path d="m -546.55,-794.23 a 27.339,30.234 0 0 1 11.516,-28.789 27.339,30.234 0 0 1 28.415,-1.8629 27.339,30.234 0 0 1 14.511,27.082" opacity="0.999" style="paint-order:markers fill stroke" id="path7089"/>
+            <path d="m -584.03,-794.41 a 27.339,30.234 0 0 1 6.5485,-23.884 27.339,30.234 0 0 1 20.556,-10.301" opacity="0.999" style="paint-order:markers fill stroke" id="path7091"/>
+            <path d="m -519.15,-828.54 -38.11,-0.0562" opacity="0.999" style="paint-order:markers fill stroke" id="path7093"/>
           </g>
-          <path
-             d="m -567.75,-814.96 h 5.3816"
-             stroke-width="4.8139"
-             style="paint-order:markers fill stroke"
-             id="path7097" />
+          <path d="m -567.75,-814.96 h 5.3816" stroke-width="4.8139" style="paint-order:markers fill stroke" id="path7097"/>
         </g>
-        <rect
-           x="-516.02002"
-           y="-817.20001"
-           width="9.5685997"
-           height="21.278"
-           rx="2.9333999"
-           ry="2.9333999"
-           fill="#ffffff"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7101" />
-        <path
-           d="m -528.46,-814.96 h 5.3816"
-           fill="none"
-           stroke="#ffffff"
-           stroke-linejoin="round"
-           stroke-width="4.8139"
-           style="paint-order:markers fill stroke"
-           id="path7103" />
+        <rect x="-516.02002" y="-817.20001" width="9.5685997" height="21.278" rx="2.9333999" ry="2.9333999" fill="#ffffff" opacity="0.999" style="paint-order:markers fill stroke" id="rect7101"/>
+        <path d="m -528.46,-814.96 h 5.3816" fill="none" stroke="#ffffff" stroke-linejoin="round" stroke-width="4.8139" style="paint-order:markers fill stroke" id="path7103"/>
       </g>
     </g>
-    <g
-       transform="translate(1814.2,1814.2)"
-       opacity="0.999"
-       id="g7131">
-      <path
-         d="M -471.07,-795.17 H -662.79"
-         fill="#ffffff"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="7.0866"
-         id="path7109" />
-      <rect
-         x="-680.32001"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         id="rect7111" />
-      <g
-         opacity="0.999"
-         id="g7115">
-        <path
-           transform="matrix(0.9375,0,0,0.9375,-1814.2,-4390.2)"
-           d="m 1308.5,3737.3 c -4.5803,0 -8.3848,3.8044 -8.3848,8.3848 v 6.7344 h 10.512 c 2.552,0 4.6055,2.0537 4.6055,4.6054 v 5.9063 c 0,2.5517 -2.0985,5.0824 -4.6055,4.6054 h -10.512 l -0.1777,18.146 70.486,-0.041 10.022,49.316 41.166,-0.3984 v -13.76 h -26.445 c -2.552,0 -4.6074,-2.0537 -4.6074,-4.6055 v -5.9062 c 0,-2.5517 2.0554,-4.6055 4.6074,-4.6055 h 26.445 v -10.383 h -10.945 c -2.552,0 -4.6074,-2.0537 -4.6074,-4.6055 v -5.9062 c 0,-2.5517 2.0554,-4.6055 4.6074,-4.6055 h 10.945 v -12.646 h -11.064 c -2.5519,0 -4.6054,-2.0537 -4.6054,-4.6054 v -5.9063 c 0,-2.5517 2.0535,-4.6054 4.6054,-4.6054 h 11.064 v -6.7344 c 0,-4.5804 -3.8065,-8.3848 -8.3867,-8.3848 z m 26.457,15.119 h 6.1738 c 2.552,0 4.6075,2.0537 4.6074,4.6054 v 5.9063 c 0,2.5517 -2.0554,4.6054 -4.6074,4.6054 h -6.1738 c -2.552,0 -4.6055,-2.0537 -4.6055,-4.6054 v -5.9063 c 0,-2.5517 2.0535,-4.6054 4.6055,-4.6054 z m 30.768,0 h 20.492 c 2.5519,0 4.6074,2.0537 4.6074,4.6054 v 5.9063 c 0,2.5517 -2.0555,4.6054 -4.6074,4.6054 h -20.492 c -2.552,0 -4.6074,-2.0537 -4.6074,-4.6054 v -5.9063 c 0,-2.5517 2.0554,-4.6054 4.6074,-4.6054 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           fill="#ffffff"
-           image-rendering="auto"
-           shape-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal;paint-order:markers fill stroke"
-           id="path7113" />
+    <g transform="translate(1814.2,1814.2)" opacity="0.999" id="g7131">
+      <path d="M -471.07,-795.17 H -662.79" fill="#ffffff" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.0866" id="path7109"/>
+      <rect x="-680.32001" y="-988.58002" width="226.77" height="226.77" fill="none" id="rect7111"/>
+      <g opacity="0.999" id="g7115">
+        <path transform="matrix(0.9375,0,0,0.9375,-1814.2,-4390.2)" d="m 1308.5,3737.3 c -4.5803,0 -8.3848,3.8044 -8.3848,8.3848 v 6.7344 h 10.512 c 2.552,0 4.6055,2.0537 4.6055,4.6054 v 5.9063 c 0,2.5517 -2.0985,5.0824 -4.6055,4.6054 h -10.512 l -0.1777,18.146 70.486,-0.041 10.022,49.316 41.166,-0.3984 v -13.76 h -26.445 c -2.552,0 -4.6074,-2.0537 -4.6074,-4.6055 v -5.9062 c 0,-2.5517 2.0554,-4.6055 4.6074,-4.6055 h 26.445 v -10.383 h -10.945 c -2.552,0 -4.6074,-2.0537 -4.6074,-4.6055 v -5.9062 c 0,-2.5517 2.0554,-4.6055 4.6074,-4.6055 h 10.945 v -12.646 h -11.064 c -2.5519,0 -4.6054,-2.0537 -4.6054,-4.6054 v -5.9063 c 0,-2.5517 2.0535,-4.6054 4.6054,-4.6054 h 11.064 v -6.7344 c 0,-4.5804 -3.8065,-8.3848 -8.3867,-8.3848 z m 26.457,15.119 h 6.1738 c 2.552,0 4.6075,2.0537 4.6074,4.6054 v 5.9063 c 0,2.5517 -2.0554,4.6054 -4.6074,4.6054 h -6.1738 c -2.552,0 -4.6055,-2.0537 -4.6055,-4.6054 v -5.9063 c 0,-2.5517 2.0535,-4.6054 4.6055,-4.6054 z m 30.768,0 h 20.492 c 2.5519,0 4.6074,2.0537 4.6074,4.6054 v 5.9063 c 0,2.5517 -2.0555,4.6054 -4.6074,4.6054 h -20.492 c -2.552,0 -4.6074,-2.0537 -4.6074,-4.6054 v -5.9063 c 0,-2.5517 2.0554,-4.6054 4.6074,-4.6054 z" color="#000000" color-rendering="auto" dominant-baseline="auto" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal;paint-order:markers fill stroke" id="path7113"/>
       </g>
-      <path
-         d="m -644.86,-796.83 10.607,-38.182 c 0.58131,-2.0926 1.9261,-3.894 4.3185,-3.894 h 97.662 c 2.3925,0 3.7372,1.8014 4.3185,3.894 l 10.607,38.182"
-         fill="none"
-         opacity="0.999"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="7.0866"
-         style="paint-order:markers fill stroke"
-         id="path7117" />
-      <g
-         fill="#ffffff"
-         id="g7129">
-        <rect
-           x="-640.40997"
-           y="-822.64001"
-           width="19.625"
-           height="11.059"
-           rx="4.3185"
-           ry="4.3181"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7119" />
-        <rect
-           x="-615.09003"
-           y="-822.64001"
-           width="37.672001"
-           height="11.059"
-           rx="4.3185"
-           ry="4.3181"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7121" />
-        <rect
-           transform="rotate(-90)"
-           x="884.29999"
-           y="-581.10999"
-           width="61.206001"
-           height="7.5430999"
-           rx="0"
-           ry="0"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7123" />
-        <rect
-           transform="rotate(-90)"
-           x="884.14001"
-           y="-566.85999"
-           width="30.712"
-           height="4.2284999"
-           rx="0"
-           ry="0"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7125" />
-        <rect
-           transform="rotate(-90)"
-           x="840.71997"
-           y="-629"
-           width="50.102001"
-           height="4.2284999"
-           rx="0"
-           ry="0"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7127" />
+      <path d="m -644.86,-796.83 10.607,-38.182 c 0.58131,-2.0926 1.9261,-3.894 4.3185,-3.894 h 97.662 c 2.3925,0 3.7372,1.8014 4.3185,3.894 l 10.607,38.182" fill="none" opacity="0.999" stroke="#ffffff" stroke-linejoin="round" stroke-width="7.0866" style="paint-order:markers fill stroke" id="path7117"/>
+      <g fill="#ffffff" id="g7129">
+        <rect x="-640.40997" y="-822.64001" width="19.625" height="11.059" rx="4.3185" ry="4.3181" opacity="0.999" style="paint-order:markers fill stroke" id="rect7119"/>
+        <rect x="-615.09003" y="-822.64001" width="37.672001" height="11.059" rx="4.3185" ry="4.3181" opacity="0.999" style="paint-order:markers fill stroke" id="rect7121"/>
+        <rect transform="rotate(-90)" x="884.29999" y="-581.10999" width="61.206001" height="7.5430999" rx="0" ry="0" opacity="0.999" style="paint-order:markers fill stroke" id="rect7123"/>
+        <rect transform="rotate(-90)" x="884.14001" y="-566.85999" width="30.712" height="4.2284999" rx="0" ry="0" opacity="0.999" style="paint-order:markers fill stroke" id="rect7125"/>
+        <rect transform="rotate(-90)" x="840.71997" y="-629" width="50.102001" height="4.2284999" rx="0" ry="0" opacity="0.999" style="paint-order:markers fill stroke" id="rect7127"/>
       </g>
     </g>
-    <g
-       transform="translate(2040.9,1814.2)"
-       opacity="0.999"
-       id="g7179">
-      <path
-         d="M -471.07,-795.17 H -662.79"
-         fill="#ffffff"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="7.0866"
-         id="path7133" />
-      <rect
-         x="-680.32001"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         id="rect7135" />
-      <path
-         d="m -518.58,-856.11 v -93.532 c 0,-2.3922 -2.035,-3.6044 -4.3185,-4.3181 l -55.142,-17.236 c -2.2835,-0.71375 -4.3185,1.9259 -4.3185,4.3181 v 68.62"
-         fill="none"
-         opacity="0.999"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="7.0866"
-         style="paint-order:markers fill stroke"
-         id="path7137" />
-      <g
-         fill="#ffffff"
-         id="g7147">
-        <rect
-           transform="rotate(-90)"
-           x="903.53998"
-           y="-623.62"
-           width="28.346001"
-           height="7.5430999"
-           rx="0"
-           ry="0"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7139" />
-        <rect
-           transform="rotate(-90)"
-           x="954.92999"
-           y="-530.63"
-           width="19.476999"
-           height="4.2284999"
-           rx="0"
-           ry="0"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7141" />
-        <rect
-           transform="rotate(-90)"
-           x="934.62"
-           y="-521.09003"
-           width="50.102001"
-           height="4.2284999"
-           rx="0"
-           ry="0"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7143" />
-        <path
-           transform="matrix(0.9375,0,0,0.9375,-2040.9,-4390.2)"
-           d="m 1518.9,3707.7 c -15.43,0 -28.067,11.512 -29.842,26.449 h 8.1601 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -8.3808 v 8.375 h 19.131 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -19.131 v 6.125 h 8.3808 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -8.3808 v 6.75 h 19.131 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -19.131 v 17.02 l 39.018,-0.8574 0.8893,-60.215 70.028,-3.9824 v -30.102 c 0,-16.654 -13.408,-30.062 -30.062,-30.062 z m 43.076,26.199 h 27.367 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -27.367 c -2.493,0 -4.5,-2.007 -4.5,-4.5 v -6.125 c 0,-2.493 2.007,-4.5 4.5,-4.5 z m -45.375,0.375 h 27.367 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -27.367 c -2.493,0 -4.5,-2.007 -4.5,-4.5 v -6.125 c 0,-2.493 2.007,-4.5 4.5,-4.5 z"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="path7145" />
+    <g transform="translate(2040.9,1814.2)" opacity="0.999" id="g7179">
+      <path d="M -471.07,-795.17 H -662.79" fill="#ffffff" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.0866" id="path7133"/>
+      <rect x="-680.32001" y="-988.58002" width="226.77" height="226.77" fill="none" id="rect7135"/>
+      <path d="m -518.58,-856.11 v -93.532 c 0,-2.3922 -2.035,-3.6044 -4.3185,-4.3181 l -55.142,-17.236 c -2.2835,-0.71375 -4.3185,1.9259 -4.3185,4.3181 v 68.62" fill="none" opacity="0.999" stroke="#ffffff" stroke-linejoin="round" stroke-width="7.0866" style="paint-order:markers fill stroke" id="path7137"/>
+      <g fill="#ffffff" id="g7147">
+        <rect transform="rotate(-90)" x="903.53998" y="-623.62" width="28.346001" height="7.5430999" rx="0" ry="0" opacity="0.999" style="paint-order:markers fill stroke" id="rect7139"/>
+        <rect transform="rotate(-90)" x="954.92999" y="-530.63" width="19.476999" height="4.2284999" rx="0" ry="0" opacity="0.999" style="paint-order:markers fill stroke" id="rect7141"/>
+        <rect transform="rotate(-90)" x="934.62" y="-521.09003" width="50.102001" height="4.2284999" rx="0" ry="0" opacity="0.999" style="paint-order:markers fill stroke" id="rect7143"/>
+        <path transform="matrix(0.9375,0,0,0.9375,-2040.9,-4390.2)" d="m 1518.9,3707.7 c -15.43,0 -28.067,11.512 -29.842,26.449 h 8.1601 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -8.3808 v 8.375 h 19.131 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -19.131 v 6.125 h 8.3808 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -8.3808 v 6.75 h 19.131 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -19.131 v 17.02 l 39.018,-0.8574 0.8893,-60.215 70.028,-3.9824 v -30.102 c 0,-16.654 -13.408,-30.062 -30.062,-30.062 z m 43.076,26.199 h 27.367 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -27.367 c -2.493,0 -4.5,-2.007 -4.5,-4.5 v -6.125 c 0,-2.493 2.007,-4.5 4.5,-4.5 z m -45.375,0.375 h 27.367 c 2.493,0 4.5,2.007 4.5,4.5 v 6.125 c 0,2.493 -2.007,4.5 -4.5,4.5 h -27.367 c -2.493,0 -4.5,-2.007 -4.5,-4.5 v -6.125 c 0,-2.493 2.007,-4.5 4.5,-4.5 z" opacity="0.999" style="paint-order:markers fill stroke" id="path7145"/>
       </g>
-      <path
-         d="m -608.48,-795.12 v -50.093 c 0,-8.8152 5.0463,-12.263 11.759,-12.263 h 105.23 c 3.3984,0 6.1342,2.9607 6.1342,6.6383 v 55.718"
-         fill="none"
-         opacity="0.999"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="7.0866"
-         style="paint-order:markers fill stroke"
-         id="path7149" />
-      <g
-         fill="#ffffff"
-         id="g7177">
-        <rect
-           x="-555.59998"
-           y="-940.96002"
-           width="37.352001"
-           height="8.5448999"
-           rx="4.2186999"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7151" />
-        <rect
-           x="-543.75"
-           y="-918.96997"
-           width="25.502001"
-           height="8.5448999"
-           rx="4.2188001"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7153" />
-        <rect
-           x="-531.84998"
-           y="-879.46997"
-           width="12.893"
-           height="8.5448999"
-           rx="4.2188001"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7155" />
-        <rect
-           x="-532.08002"
-           y="-898.69"
-           width="13.596"
-           height="8.5448999"
-           rx="4.2188001"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7157" />
-        <rect
-           x="-573.65002"
-           y="-940.96002"
-           width="11.571"
-           height="8.5448999"
-           rx="4.2186999"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7159" />
-        <rect
-           x="-573.65002"
-           y="-927.84003"
-           width="11.571"
-           height="8.5448999"
-           rx="4.2186999"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7161" />
-        <rect
-           x="-573.65002"
-           y="-954.54999"
-           width="11.571"
-           height="8.5448999"
-           rx="4.2186999"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7163" />
-        <rect
-           x="-536.15002"
-           y="-846.03998"
-           width="38.290001"
-           height="11.357"
-           rx="4.2186999"
-           ry="4.2186999"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7165" />
-        <rect
-           x="-582.78998"
-           y="-846.03998"
-           width="38.290001"
-           height="11.357"
-           rx="4.2186999"
-           ry="4.2186999"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7167" />
-        <rect
-           x="-561.70001"
-           y="-821.19"
-           width="38.290001"
-           height="11.123"
-           rx="4.2186999"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7169" />
-        <rect
-           x="-596.73999"
-           y="-821.19"
-           width="26.688999"
-           height="11.123"
-           rx="4.2186999"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7171" />
-        <rect
-           x="-517.40002"
-           y="-821.19"
-           width="21.649"
-           height="27.295"
-           rx="4.2186999"
-           ry="4.2188001"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7173" />
-        <rect
-           transform="rotate(-90)"
-           x="858.78003"
-           y="-499.64001"
-           width="49.909"
-           height="7.5430999"
-           rx="0"
-           ry="0"
-           opacity="0.999"
-           style="paint-order:markers fill stroke"
-           id="rect7175" />
+      <path d="m -608.48,-795.12 v -50.093 c 0,-8.8152 5.0463,-12.263 11.759,-12.263 h 105.23 c 3.3984,0 6.1342,2.9607 6.1342,6.6383 v 55.718" fill="none" opacity="0.999" stroke="#ffffff" stroke-linejoin="round" stroke-width="7.0866" style="paint-order:markers fill stroke" id="path7149"/>
+      <g fill="#ffffff" id="g7177">
+        <rect x="-555.59998" y="-940.96002" width="37.352001" height="8.5448999" rx="4.2186999" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7151"/>
+        <rect x="-543.75" y="-918.96997" width="25.502001" height="8.5448999" rx="4.2188001" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7153"/>
+        <rect x="-531.84998" y="-879.46997" width="12.893" height="8.5448999" rx="4.2188001" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7155"/>
+        <rect x="-532.08002" y="-898.69" width="13.596" height="8.5448999" rx="4.2188001" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7157"/>
+        <rect x="-573.65002" y="-940.96002" width="11.571" height="8.5448999" rx="4.2186999" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7159"/>
+        <rect x="-573.65002" y="-927.84003" width="11.571" height="8.5448999" rx="4.2186999" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7161"/>
+        <rect x="-573.65002" y="-954.54999" width="11.571" height="8.5448999" rx="4.2186999" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7163"/>
+        <rect x="-536.15002" y="-846.03998" width="38.290001" height="11.357" rx="4.2186999" ry="4.2186999" opacity="0.999" style="paint-order:markers fill stroke" id="rect7165"/>
+        <rect x="-582.78998" y="-846.03998" width="38.290001" height="11.357" rx="4.2186999" ry="4.2186999" opacity="0.999" style="paint-order:markers fill stroke" id="rect7167"/>
+        <rect x="-561.70001" y="-821.19" width="38.290001" height="11.123" rx="4.2186999" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7169"/>
+        <rect x="-596.73999" y="-821.19" width="26.688999" height="11.123" rx="4.2186999" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7171"/>
+        <rect x="-517.40002" y="-821.19" width="21.649" height="27.295" rx="4.2186999" ry="4.2188001" opacity="0.999" style="paint-order:markers fill stroke" id="rect7173"/>
+        <rect transform="rotate(-90)" x="858.78003" y="-499.64001" width="49.909" height="7.5430999" rx="0" ry="0" opacity="0.999" style="paint-order:markers fill stroke" id="rect7175"/>
       </g>
     </g>
-    <g
-       fill="none"
-       id="g7209">
-      <circle
-         cx="1701.5"
-         cy="939.75"
-         r="91.393997"
-         opacity="0.999"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         style="paint-order:markers fill stroke"
-         id="circle7181" />
-      <rect
-         x="1587.4"
-         y="825.59003"
-         width="226.77"
-         height="226.77"
-         opacity="0.999"
-         style="paint-order:markers fill stroke"
-         id="rect7183" />
-      <g
-         stroke="#ffffff"
-         id="g7207">
-        <circle
-           cx="1701.5"
-           cy="939.41998"
-           r="21.35"
-           opacity="0.999"
-           stroke-linejoin="round"
-           stroke-width="14.173"
-           style="paint-order:markers fill stroke"
-           id="circle7185" />
-        <path
-           d="m 1626.2,983.14 54.504,-31.468 m 42.361,-24.457 54.504,-31.468"
-           stroke-width="14.173"
-           id="path7187" />
-        <circle
-           cx="1701.5"
-           cy="939.75"
-           r="73.963997"
-           opacity="0.999"
-           stroke-linejoin="round"
-           stroke-width="3.5433"
-           style="paint-order:markers fill stroke"
-           id="circle7189" />
-        <g
-           id="g7205">
-          <g
-             stroke-width="7.0866"
-             id="g7201">
-            <path
-               d="m 1658.1,1015.1 7.3695,-12.764 m 72.654,-125.84 7.3695,-12.764"
-               id="path7191" />
-            <path
-               d="m 1701.8,1026.8 v -14.739 m 0,-145.31 v -14.739"
-               id="path7193" />
-            <path
-               d="m 1745.5,1015.1 -7.3695,-12.764 m -72.654,-125.84 -7.3695,-12.764"
-               id="path7195" />
-            <path
-               d="m 1777.5,983.14 -12.764,-7.3694 m -125.84,-72.654 -12.764,-7.3694"
-               id="path7197" />
-            <path
-               d="m 1789.2,939.45 -14.739,6e-5 m -145.31,-2e-5 -14.739,6e-5"
-               id="path7199" />
+    <g fill="none" id="g7209">
+      <circle cx="1701.5" cy="939.75" r="91.393997" opacity="0.999" stroke="#ffffff" stroke-linejoin="round" stroke-width="14.173" style="paint-order:markers fill stroke" id="circle7181"/>
+      <rect x="1587.4" y="825.59003" width="226.77" height="226.77" opacity="0.999" style="paint-order:markers fill stroke" id="rect7183"/>
+      <g stroke="#ffffff" id="g7207">
+        <circle cx="1701.5" cy="939.41998" r="21.35" opacity="0.999" stroke-linejoin="round" stroke-width="14.173" style="paint-order:markers fill stroke" id="circle7185"/>
+        <path d="m 1626.2,983.14 54.504,-31.468 m 42.361,-24.457 54.504,-31.468" stroke-width="14.173" id="path7187"/>
+        <circle cx="1701.5" cy="939.75" r="73.963997" opacity="0.999" stroke-linejoin="round" stroke-width="3.5433" style="paint-order:markers fill stroke" id="circle7189"/>
+        <g id="g7205">
+          <g stroke-width="7.0866" id="g7201">
+            <path d="m 1658.1,1015.1 7.3695,-12.764 m 72.654,-125.84 7.3695,-12.764" id="path7191"/>
+            <path d="m 1701.8,1026.8 v -14.739 m 0,-145.31 v -14.739" id="path7193"/>
+            <path d="m 1745.5,1015.1 -7.3695,-12.764 m -72.654,-125.84 -7.3695,-12.764" id="path7195"/>
+            <path d="m 1777.5,983.14 -12.764,-7.3694 m -125.84,-72.654 -12.764,-7.3694" id="path7197"/>
+            <path d="m 1789.2,939.45 -14.739,6e-5 m -145.31,-2e-5 -14.739,6e-5" id="path7199"/>
           </g>
-          <path
-             d="m 1777.5,895.75 -12.764,7.3695 m -125.84,72.654 -12.764,7.3695"
-             stroke-width="35.433"
-             id="path7203" />
+          <path d="m 1777.5,895.75 -12.764,7.3695 m -125.84,72.654 -12.764,7.3695" stroke-width="35.433" id="path7203"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(-1,0,0,1,3628.3,0)"
-       fill="none"
-       id="g7235">
-      <circle
-         cx="1701.1"
-         cy="939.28003"
-         r="64.791"
-         opacity="0.999"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="12.756"
-         style="paint-order:markers fill stroke"
-         id="circle7211" />
-      <rect
-         x="1587.4"
-         y="825.59003"
-         width="226.77"
-         height="226.77"
-         opacity="0.999"
-         style="paint-order:markers fill stroke"
-         id="rect7213" />
-      <g
-         stroke="#ffffff"
-         id="g7233">
-        <circle
-           cx="1701.1"
-           cy="938.95001"
-           r="17.275999"
-           opacity="0.999"
-           stroke-linejoin="round"
-           stroke-width="21.26"
-           style="paint-order:markers fill stroke"
-           id="circle7215" />
-        <g
-           id="g7229">
-          <path
-             d="m 1652.2,967.45 27.796,-16.048 m 43.057,-24.859 27.796,-16.048"
-             stroke-width="14.173"
-             id="path7217" />
-          <g
-             stroke-width="7.0866"
-             id="g7225">
-            <path
-               d="m 1701.4,997.93 v -9.9251 m 0,-97.85 v -9.9251"
-               id="path7219" />
-            <path
-               d="m 1730.8,990.04 -4.9625,-8.5954 m -48.925,-84.74 -4.9626,-8.5954"
-               id="path7221" />
-            <path
-               d="m 1752.3,968.5 -8.5955,-4.9625 m -84.74,-48.925 -8.5955,-4.9625"
-               id="path7223" />
+    <g transform="matrix(-1,0,0,1,3628.3,0)" fill="none" id="g7235">
+      <circle cx="1701.1" cy="939.28003" r="64.791" opacity="0.999" stroke="#ffffff" stroke-linejoin="round" stroke-width="12.756" style="paint-order:markers fill stroke" id="circle7211"/>
+      <rect x="1587.4" y="825.59003" width="226.77" height="226.77" opacity="0.999" style="paint-order:markers fill stroke" id="rect7213"/>
+      <g stroke="#ffffff" id="g7233">
+        <circle cx="1701.1" cy="938.95001" r="17.275999" opacity="0.999" stroke-linejoin="round" stroke-width="21.26" style="paint-order:markers fill stroke" id="circle7215"/>
+        <g id="g7229">
+          <path d="m 1652.2,967.45 27.796,-16.048 m 43.057,-24.859 27.796,-16.048" stroke-width="14.173" id="path7217"/>
+          <g stroke-width="7.0866" id="g7225">
+            <path d="m 1701.4,997.93 v -9.9251 m 0,-97.85 v -9.9251" id="path7219"/>
+            <path d="m 1730.8,990.04 -4.9625,-8.5954 m -48.925,-84.74 -4.9626,-8.5954" id="path7221"/>
+            <path d="m 1752.3,968.5 -8.5955,-4.9625 m -84.74,-48.925 -8.5955,-4.9625" id="path7223"/>
           </g>
-          <path
-             d="m 1752.3,909.65 -13.467,7.7751 m -74.998,43.3 -13.467,7.7751"
-             stroke-width="54.213"
-             id="path7227" />
+          <path d="m 1752.3,909.65 -13.467,7.7751 m -74.998,43.3 -13.467,7.7751" stroke-width="54.213" id="path7227"/>
         </g>
-        <circle
-           cx="1701.1"
-           cy="939.28003"
-           r="47.382"
-           opacity="0.999"
-           stroke-linejoin="round"
-           stroke-width="7.0866"
-           style="paint-order:markers fill stroke"
-           id="circle7231" />
+        <circle cx="1701.1" cy="939.28003" r="47.382" opacity="0.999" stroke-linejoin="round" stroke-width="7.0866" style="paint-order:markers fill stroke" id="circle7231"/>
       </g>
     </g>
-    <g
-       transform="matrix(-1,0,0,1,3855.1,3.9453e-5)"
-       id="g7299">
-      <rect
-         x="1587.4"
-         y="825.59003"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="0.999"
-         style="paint-order:markers fill stroke"
-         id="rect7237" />
-      <g
-         transform="matrix(0.43634,0.43634,-0.43634,0.43634,1359.1,-204.07)"
-         stroke="#ffffff"
-         stroke-width="1.6205"
-         id="g7277">
-        <g
-           stroke-linejoin="round"
-           stroke-width="11.484"
-           id="g7243">
-          <path
-             transform="scale(-1,1)"
-             d="m -1686.4,936.33 a 30.005,17.198 0 0 1 13.944,19.615 30.005,17.198 0 0 1 -29.84,12.494 30.005,17.198 0 0 1 -28.361,-13.579 30.005,17.198 0 0 1 16.138,-19.054"
-             fill="none"
-             opacity="0.999"
-             style="paint-order:markers fill stroke"
-             id="path7239" />
-          <path
-             d="m 1731.4,950.83 -0.054,66.617 c -0.01,9.498 -13.434,17.198 -30.004,17.198 -16.571,0 -30.005,-7.6997 -30.005,-17.198 v -67.166 c 0,0 -1.2278,22.179 29.146,21.578 32.677,-0.64664 31.058,-20.948 30.918,-21.03 z"
-             fill="#ffffff"
-             opacity="0.999"
-             style="paint-order:markers fill stroke"
-             id="path7241" />
+    <g transform="matrix(-1,0,0,1,3855.1,3.9453e-5)" id="g7299">
+      <rect x="1587.4" y="825.59003" width="226.77" height="226.77" fill="none" opacity="0.999" style="paint-order:markers fill stroke" id="rect7237"/>
+      <g transform="matrix(0.43634,0.43634,-0.43634,0.43634,1359.1,-204.07)" stroke="#ffffff" stroke-width="1.6205" id="g7277">
+        <g stroke-linejoin="round" stroke-width="11.484" id="g7243">
+          <path transform="scale(-1,1)" d="m -1686.4,936.33 a 30.005,17.198 0 0 1 13.944,19.615 30.005,17.198 0 0 1 -29.84,12.494 30.005,17.198 0 0 1 -28.361,-13.579 30.005,17.198 0 0 1 16.138,-19.054" fill="none" opacity="0.999" style="paint-order:markers fill stroke" id="path7239"/>
+          <path d="m 1731.4,950.83 -0.054,66.617 c -0.01,9.498 -13.434,17.198 -30.004,17.198 -16.571,0 -30.005,-7.6997 -30.005,-17.198 v -67.166 c 0,0 -1.2278,22.179 29.146,21.578 32.677,-0.64664 31.058,-20.948 30.918,-21.03 z" fill="#ffffff" opacity="0.999" style="paint-order:markers fill stroke" id="path7241"/>
         </g>
-        <g
-           transform="rotate(-45,1633,891.7)"
-           fill="none"
-           id="g7259">
-          <path
-             d="m 1647.2,955.26 -22.251,-22.251"
-             stroke-width="17.226"
-             id="path7245" />
-          <rect
-             transform="matrix(-0.70711,0.70711,0.70711,0.70711,0,0)"
-             x="-509.60001"
-             y="1750.3"
-             width="40.880001"
-             height="61.578999"
-             opacity="0.999"
-             stroke-linejoin="round"
-             stroke-width="11.484"
-             style="paint-order:markers fill stroke"
-             id="rect7247" />
-          <g
-             stroke-width="5.7421"
-             id="g7257">
-            <path
-               d="m 1617.4,897.94 -27.56,27.56"
-               id="path7249" />
-            <path
-               d="m 1627.4,907.96 -27.56,27.56"
-               id="path7251" />
-            <path
-               d="m 1607.4,887.91 -27.56,27.56"
-               id="path7253" />
-            <path
-               d="m 1584.9,893.04 40.916,40.916"
-               id="path7255" />
+        <g transform="rotate(-45,1633,891.7)" fill="none" id="g7259">
+          <path d="m 1647.2,955.26 -22.251,-22.251" stroke-width="17.226" id="path7245"/>
+          <rect transform="matrix(-0.70711,0.70711,0.70711,0.70711,0,0)" x="-509.60001" y="1750.3" width="40.880001" height="61.578999" opacity="0.999" stroke-linejoin="round" stroke-width="11.484" style="paint-order:markers fill stroke" id="rect7247"/>
+          <g stroke-width="5.7421" id="g7257">
+            <path d="m 1617.4,897.94 -27.56,27.56" id="path7249"/>
+            <path d="m 1627.4,907.96 -27.56,27.56" id="path7251"/>
+            <path d="m 1607.4,887.91 -27.56,27.56" id="path7253"/>
+            <path d="m 1584.9,893.04 40.916,40.916" id="path7255"/>
           </g>
         </g>
-        <g
-           transform="rotate(135,1687.3,954.27)"
-           fill="none"
-           id="g7275">
-          <path
-             d="m 1647.2,955.26 -22.251,-22.251"
-             stroke-width="17.226"
-             id="path7261" />
-          <rect
-             transform="matrix(-0.70711,0.70711,0.70711,0.70711,0,0)"
-             x="-509.60001"
-             y="1750.3"
-             width="40.880001"
-             height="61.578999"
-             opacity="0.999"
-             stroke-linejoin="round"
-             stroke-width="11.484"
-             style="paint-order:markers fill stroke"
-             id="rect7263" />
-          <g
-             stroke-width="5.7421"
-             id="g7273">
-            <path
-               d="m 1617.4,897.94 -27.56,27.56"
-               id="path7265" />
-            <path
-               d="m 1627.4,907.96 -27.56,27.56"
-               id="path7267" />
-            <path
-               d="m 1607.4,887.91 -27.56,27.56"
-               id="path7269" />
-            <path
-               d="m 1584.9,893.04 40.916,40.916"
-               id="path7271" />
+        <g transform="rotate(135,1687.3,954.27)" fill="none" id="g7275">
+          <path d="m 1647.2,955.26 -22.251,-22.251" stroke-width="17.226" id="path7261"/>
+          <rect transform="matrix(-0.70711,0.70711,0.70711,0.70711,0,0)" x="-509.60001" y="1750.3" width="40.880001" height="61.578999" opacity="0.999" stroke-linejoin="round" stroke-width="11.484" style="paint-order:markers fill stroke" id="rect7263"/>
+          <g stroke-width="5.7421" id="g7273">
+            <path d="m 1617.4,897.94 -27.56,27.56" id="path7265"/>
+            <path d="m 1627.4,907.96 -27.56,27.56" id="path7267"/>
+            <path d="m 1607.4,887.91 -27.56,27.56" id="path7269"/>
+            <path d="m 1584.9,893.04 40.916,40.916" id="path7271"/>
           </g>
         </g>
       </g>
-      <g
-         transform="matrix(0.43634,0.43634,-0.43634,0.43634,1420.3,-265.29)"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         id="g7285">
-        <ellipse
-           transform="scale(-1,1)"
-           cx="-1701.3"
-           cy="951.25"
-           rx="30.004999"
-           ry="17.198"
-           fill="none"
-           opacity="0.999"
-           stroke-width="11.484"
-           style="paint-order:markers fill stroke"
-           id="ellipse7279" />
-        <path
-           d="m 1731.4,950.83 -0.054,93.134 c -0.01,9.498 -13.434,17.198 -30.004,17.198 -16.571,0 -30.005,-7.6997 -30.005,-17.198 v -93.683 c 0,0 -1.2278,22.179 29.146,21.578 32.677,-0.64664 31.058,-20.948 30.918,-21.03 z"
-           fill="#ffffff"
-           opacity="0.999"
-           stroke-width="11.484"
-           style="paint-order:markers fill stroke"
-           id="path7281" />
-        <path
-           d="m 1714.8,1045.1 -0.019,41.806 c 0,4.2634 -6.0289,7.7188 -13.467,7.7179 -7.4384,0 -13.469,-3.458 -13.469,-7.7214 l -0.01,-42.052 c 0,0 -0.5498,9.9557 13.084,9.6877 14.668,-0.2883 13.94,-9.4011 13.877,-9.4378 z"
-           fill="none"
-           opacity="0.999"
-           stroke-width="11.484"
-           style="paint-order:markers fill stroke"
-           id="path7283" />
+      <g transform="matrix(0.43634,0.43634,-0.43634,0.43634,1420.3,-265.29)" stroke="#ffffff" stroke-linejoin="round" id="g7285">
+        <ellipse transform="scale(-1,1)" cx="-1701.3" cy="951.25" rx="30.004999" ry="17.198" fill="none" opacity="0.999" stroke-width="11.484" style="paint-order:markers fill stroke" id="ellipse7279"/>
+        <path d="m 1731.4,950.83 -0.054,93.134 c -0.01,9.498 -13.434,17.198 -30.004,17.198 -16.571,0 -30.005,-7.6997 -30.005,-17.198 v -93.683 c 0,0 -1.2278,22.179 29.146,21.578 32.677,-0.64664 31.058,-20.948 30.918,-21.03 z" fill="#ffffff" opacity="0.999" stroke-width="11.484" style="paint-order:markers fill stroke" id="path7281"/>
+        <path d="m 1714.8,1045.1 -0.019,41.806 c 0,4.2634 -6.0289,7.7188 -13.467,7.7179 -7.4384,0 -13.469,-3.458 -13.469,-7.7214 l -0.01,-42.052 c 0,0 -0.5498,9.9557 13.084,9.6877 14.668,-0.2883 13.94,-9.4011 13.877,-9.4378 z" fill="none" opacity="0.999" stroke-width="11.484" style="paint-order:markers fill stroke" id="path7283"/>
       </g>
-      <g
-         fill="none"
-         stroke="#000000"
-         stroke-width="14.173"
-         id="g7297">
-        <path
-           d="m 1737.1,913 4.4704,4.4705"
-           opacity="0.999"
-           id="path7287" />
-        <path
-           d="m 1727.8,921.94 4.4705,4.4705"
-           opacity="0.999"
-           id="path7289" />
-        <path
-           d="m 1719.2,930.72 4.4704,4.4705"
-           opacity="0.999"
-           id="path7291" />
-        <path
-           d="m 1664.4,954.99 4.4705,4.4705"
-           opacity="0.999"
-           id="path7293" />
-        <path
-           d="m 1655.5,963.61 4.4705,4.4705"
-           opacity="0.999"
-           id="path7295" />
+      <g fill="none" stroke="#000000" stroke-width="14.173" id="g7297">
+        <path d="m 1737.1,913 4.4704,4.4705" opacity="0.999" id="path7287"/>
+        <path d="m 1727.8,921.94 4.4705,4.4705" opacity="0.999" id="path7289"/>
+        <path d="m 1719.2,930.72 4.4704,4.4705" opacity="0.999" id="path7291"/>
+        <path d="m 1664.4,954.99 4.4705,4.4705" opacity="0.999" id="path7293"/>
+        <path d="m 1655.5,963.61 4.4705,4.4705" opacity="0.999" id="path7295"/>
       </g>
     </g>
-    <g
-       transform="translate(-4989,-226.77)"
-       id="g7317">
-      <path
-         d="m 5973.6,-1769.5 c 6.2404,-5.4624 10.436,-7.2286 16.1,-6.2205 5.2755,0.939 8.0453,4.0439 12.075,10.611 -6.2158,-4.2268 -6.5211,-5.2183 -12.807,-6.9523 -3.5992,-0.9928 -8.2528,0.8886 -15.368,2.5614 z"
-         fill="#ffffff"
-         opacity="1"
-         style="paint-order:markers fill stroke"
-         id="path7301" />
-      <rect
-         x="5896.1001"
-         y="-1895.7"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect7303" />
-      <path
-         d="m 6009.2,-1802 9.5733,-29.496 33.377,-6.7272 16.3,11.902 c 0,0 12.161,33.895 5.4335,47.866 -9.3478,19.415 -43.305,7.0544 -40.97,21.055 2.3781,14.259 -4.8925,25.998 -10.514,31.723 -7.5278,7.6663 -15.699,8.1835 -22.515,6.473 0,0 -11.285,-7.9029 -17.774,-9.8377 -6.5144,-1.9422 -14.166,1.3422 -20.338,-1.5075 -4.3105,-1.9905 -10.013,-10.13 -10.013,-10.13 -10.948,-8.7108 0.3511,-23.974 3.6223,-32.86 3.9474,-10.723 17.154,-28.098 25.098,-27.167 z"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-width="14.173"
-         id="path7305" />
-      <g
-         fill="#ffffff"
-         id="g7315">
-        <path
-           d="m 6045.1,-1788.3 c 0.297,-3.9413 3.5941,-5.0086 5.5449,-4.3101 1.817,0.6506 0.67,2.3363 0.1338,5.8889 -0.6526,4.323 -0.4893,4.4398 -2.6542,3.2383 -1.2395,-0.6879 -3.2173,-2.2594 -3.0245,-4.8171 z"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="path7307" />
-        <path
-           d="m 6040.7,-1811 c -6.888,-1.3442 -8.7574,-0.1454 -7.0836,-3.2641 1.559,-2.9047 7.7676,-7.0506 13.916,-5.3892 7.481,2.0218 4.2309,8.203 1.6209,11.572 -1.4942,1.9291 -3.983,-2.0467 -8.4528,-2.919 z"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="path7309" />
-        <path
-           d="m 6012.7,-1747.5 c -1.3191,4.2396 -2.7285,6.2165 -5.5612,7.3309 -2.6384,1.0379 -4.7396,0.386 -8.3586,-1.5019 3.9641,0.207 4.3736,0.5763 7.6859,-0.3784 1.8965,-0.5467 3.4812,-2.7039 6.2339,-5.4506 z"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="path7311" />
-        <path
-           d="m 5985.9,-1745.2 c -4.3225,1.015 -6.7412,0.8039 -9.139,-1.0713 -2.2334,-1.7467 -2.738,-3.888 -2.948,-7.9644 2.3824,-2.8827 7.0288,-1.7935 9.5324,0.576 1.4336,1.3566 2.8158,3.8227 2.5546,8.4597 z"
-           opacity="1"
-           style="paint-order:markers fill stroke"
-           id="path7313" />
+    <g transform="translate(-4989,-226.77)" id="g7317">
+      <path d="m 5973.6,-1769.5 c 6.2404,-5.4624 10.436,-7.2286 16.1,-6.2205 5.2755,0.939 8.0453,4.0439 12.075,10.611 -6.2158,-4.2268 -6.5211,-5.2183 -12.807,-6.9523 -3.5992,-0.9928 -8.2528,0.8886 -15.368,2.5614 z" fill="#ffffff" opacity="1" style="paint-order:markers fill stroke" id="path7301"/>
+      <rect x="5896.1001" y="-1895.7" width="226.77" height="226.77" fill="none" opacity="1" id="rect7303"/>
+      <path d="m 6009.2,-1802 9.5733,-29.496 33.377,-6.7272 16.3,11.902 c 0,0 12.161,33.895 5.4335,47.866 -9.3478,19.415 -43.305,7.0544 -40.97,21.055 2.3781,14.259 -4.8925,25.998 -10.514,31.723 -7.5278,7.6663 -15.699,8.1835 -22.515,6.473 0,0 -11.285,-7.9029 -17.774,-9.8377 -6.5144,-1.9422 -14.166,1.3422 -20.338,-1.5075 -4.3105,-1.9905 -10.013,-10.13 -10.013,-10.13 -10.948,-8.7108 0.3511,-23.974 3.6223,-32.86 3.9474,-10.723 17.154,-28.098 25.098,-27.167 z" fill="none" stroke="#ffffff" stroke-linejoin="round" stroke-width="14.173" id="path7305"/>
+      <g fill="#ffffff" id="g7315">
+        <path d="m 6045.1,-1788.3 c 0.297,-3.9413 3.5941,-5.0086 5.5449,-4.3101 1.817,0.6506 0.67,2.3363 0.1338,5.8889 -0.6526,4.323 -0.4893,4.4398 -2.6542,3.2383 -1.2395,-0.6879 -3.2173,-2.2594 -3.0245,-4.8171 z" opacity="1" style="paint-order:markers fill stroke" id="path7307"/>
+        <path d="m 6040.7,-1811 c -6.888,-1.3442 -8.7574,-0.1454 -7.0836,-3.2641 1.559,-2.9047 7.7676,-7.0506 13.916,-5.3892 7.481,2.0218 4.2309,8.203 1.6209,11.572 -1.4942,1.9291 -3.983,-2.0467 -8.4528,-2.919 z" opacity="1" style="paint-order:markers fill stroke" id="path7309"/>
+        <path d="m 6012.7,-1747.5 c -1.3191,4.2396 -2.7285,6.2165 -5.5612,7.3309 -2.6384,1.0379 -4.7396,0.386 -8.3586,-1.5019 3.9641,0.207 4.3736,0.5763 7.6859,-0.3784 1.8965,-0.5467 3.4812,-2.7039 6.2339,-5.4506 z" opacity="1" style="paint-order:markers fill stroke" id="path7311"/>
+        <path d="m 5985.9,-1745.2 c -4.3225,1.015 -6.7412,0.8039 -9.139,-1.0713 -2.2334,-1.7467 -2.738,-3.888 -2.948,-7.9644 2.3824,-2.8827 7.0288,-1.7935 9.5324,0.576 1.4336,1.3566 2.8158,3.8227 2.5546,8.4597 z" opacity="1" style="paint-order:markers fill stroke" id="path7313"/>
       </g>
     </g>
-    <g
-       transform="translate(-1587.4,-249.29)"
-       id="g7345">
-      <rect
-         x="3628.3"
-         y="621.33002"
-         width="226.77"
-         height="226.77"
-         rx="0.00012162"
-         ry="0.00012162"
-         fill="none"
-         style="paint-order:markers fill stroke"
-         id="rect7319" />
-      <g
-         transform="translate(0,50.64)"
-         fill="#ffffff"
-         id="g7343">
-        <rect
-           x="3705.8999"
-           y="683.85999"
-           width="20.141001"
-           height="95.668999"
-           rx="6.0236001"
-           ry="6.0236001"
-           style="paint-order:markers fill stroke"
-           id="rect7321" />
-        <rect
-           x="3806.6001"
-           y="683.85999"
-           width="20.141001"
-           height="95.668999"
-           rx="6.0236001"
-           ry="6.0236001"
-           style="paint-order:markers fill stroke"
-           id="rect7323" />
-        <rect
-           transform="rotate(90)"
-           x="683.85999"
-           y="-3804.1001"
-           width="19.978001"
-           height="75.528"
-           rx="6.0236001"
-           ry="6.0236001"
-           style="paint-order:markers fill stroke"
-           id="rect7325" />
-        <rect
-           transform="rotate(90)"
-           x="761.71002"
-           y="-3804.1001"
-           width="17.813999"
-           height="75.528999"
-           rx="6.0236001"
-           ry="6.0236001"
-           style="paint-order:markers fill stroke"
-           id="rect7327" />
-        <path
-           d="m 3732.9,706.66 23.89,13.701 h 42.998 c 2.3711,0 4.2804,-1.9092 4.2804,-4.2803 v -5.1416 c 0,-2.3711 -1.9093,-4.279 -4.2804,-4.279 z m -4.3596,6.9214 v 2.4993 c 0,2.371 1.9092,4.2803 4.2803,4.2803 l 4.4362,0.23554 -6.2661,-3.5069 c -0.9245,-0.51731 -2.4504,-1.1371 -2.4504,-3.5082 z"
-           style="paint-order:markers fill stroke"
-           id="path7329" />
-        <path
-           d="m 3732.9,723.94 c -2.3711,0 -4.2803,1.9092 -4.2803,4.2804 v 6.9435 c 0,2.371 1.9092,4.2803 4.2803,4.2803 h 33.351 l -27.036,-15.504 z m 30.207,0 27.036,15.504 h 9.725 c 2.3711,0 4.2804,-1.9093 4.2804,-4.2803 v -6.9435 c 0,-2.3711 -1.9093,-4.2804 -4.2804,-4.2804 z"
-           style="paint-order:markers fill stroke"
-           id="path7331" />
-        <path
-           d="m 3732.9,743.02 c -2.3711,0 -4.2803,1.9079 -4.2803,4.279 v 5.9652 c 0,2.371 1.9092,4.2803 4.2803,4.2803 h 64.918 l -25.328,-14.524 z m 63.482,0 4.4924,2.576 c 1.8141,1.0403 3.2747,1.8437 3.2747,4.2148 v -2.5117 c 0,-2.3711 -1.9093,-4.279 -4.2804,-4.279 z"
-           style="paint-order:markers fill stroke"
-           id="path7333" />
-        <g
-           id="g7341">
-          <rect
-             transform="matrix(0,1,-0.86748,-0.49747,0,0)"
-             x="-1431.1"
-             y="-4385.8999"
-             width="7.1257"
-             height="88.288002"
-             rx="4.9790001"
-             ry="5.3126001"
-             style="paint-order:markers fill stroke"
-             id="rect7335" />
-          <path
-             d="m 3737.3,606.32 c -8.7955,0 -15.923,6.9987 -15.923,15.621 0,5.5511 2.3656,12.77 6.7786,17.214 -0.03,0.028 4.2462,3.9135 4.2462,5.2112 0,1.7716 -1.3035,3.2635 -3.0322,3.6017 -9.5842,0.9301 -15.255,3.8235 -19.653,9.4189 -1.2587,1.5945 -1.9411,4.7986 -1.9867,6.5113 0.015,0.4428 0,7.3809 0,7.3809 0,3.2628 2.7131,5.8877 6.0644,5.907 l 44.933,0.25874 c 0,0 2.039,0.50811 5.8228,-3.7388 2.8361,-3.1832 1.5766,-10.997 1.1631,-14.11 -0.7349,-5.5325 -13.196,-10.306 -13.196,-10.306 -2.7329,-0.67932 -4.3789,-0.9973 -6.9818,-1.2633 -1.8805,-0.2215 -3.3362,-1.7838 -3.3362,-3.6603 0,-1.2963 4.2609,-5.1361 4.2609,-5.1361 4.4584,-4.444 6.7638,-11.708 6.7638,-17.289 0,-8.622 -7.1291,-15.621 -15.925,-15.621 z"
-             opacity="1"
-             id="path7337" />
-          <path
-             d="m 3696.4,590.84 c -8.7954,0 -15.923,6.9988 -15.923,15.621 0,5.5512 2.3657,12.77 6.7786,17.214 -0.03,0.028 4.2462,3.9135 4.2462,5.2112 0,1.7717 -1.3035,3.2637 -3.0322,3.6017 -9.5842,0.9301 -15.257,3.8234 -19.654,9.4189 -1.2587,1.5945 -1.9443,4.7987 -1.9868,6.5113 0.01,0.2036 8e-4,19.427 1e-4,39.537 -0.1044,1.6835 0.8429,3.1205 2.1254,3.1154 1.9295,-0.01 4.4525,-0.039 5.7825,0.015 1.0995,0.045 1.6447,0.7682 1.6447,2.1453 v 35.8 c 0,1.48 0.1664,3.0293 -1.8931,3.3155 -0.2033,0.028 -5.1808,0.1273 -5.6305,0.134 -1.1858,0.018 -2.0097,0.4847 -2.0291,2.0176 v 4.8509 c 0,1.6468 1.3704,2.9816 3.0621,2.9816 h 26.37 c -0.076,-6.727 0.089,-30.046 0.161,-53.524 0.01,-2.6483 2.6871,-6.5926 6.7383,-7.1265 0.04,-12.102 0.084,-21.218 0.1283,-21.368 3.0591,-10.53 13.907,-14.297 19.777,-14.934 0.8076,-0.1578 1.535,-0.5262 2.1277,-1.04 -0.3126,-0.9329 -0.7152,-1.8067 -1.2086,-2.4317 -4.3523,-5.5216 -9.9634,-8.4007 -19.35,-9.3603 -1.8805,-0.2214 -3.3362,-1.7837 -3.3362,-3.6603 -1e-4,-1.2961 4.2627,-5.1361 4.2627,-5.1361 4.4585,-4.4438 6.7621,-11.708 6.7621,-17.289 0,-8.6219 -7.1273,-15.621 -15.923,-15.621 z"
-             opacity="1"
-             id="path7339" />
+    <g transform="translate(-1587.4,-249.29)" id="g7345">
+      <rect x="3628.3" y="621.33002" width="226.77" height="226.77" rx="0.00012162" ry="0.00012162" fill="none" style="paint-order:markers fill stroke" id="rect7319"/>
+      <g transform="translate(0,50.64)" fill="#ffffff" id="g7343">
+        <rect x="3705.8999" y="683.85999" width="20.141001" height="95.668999" rx="6.0236001" ry="6.0236001" style="paint-order:markers fill stroke" id="rect7321"/>
+        <rect x="3806.6001" y="683.85999" width="20.141001" height="95.668999" rx="6.0236001" ry="6.0236001" style="paint-order:markers fill stroke" id="rect7323"/>
+        <rect transform="rotate(90)" x="683.85999" y="-3804.1001" width="19.978001" height="75.528" rx="6.0236001" ry="6.0236001" style="paint-order:markers fill stroke" id="rect7325"/>
+        <rect transform="rotate(90)" x="761.71002" y="-3804.1001" width="17.813999" height="75.528999" rx="6.0236001" ry="6.0236001" style="paint-order:markers fill stroke" id="rect7327"/>
+        <path d="m 3732.9,706.66 23.89,13.701 h 42.998 c 2.3711,0 4.2804,-1.9092 4.2804,-4.2803 v -5.1416 c 0,-2.3711 -1.9093,-4.279 -4.2804,-4.279 z m -4.3596,6.9214 v 2.4993 c 0,2.371 1.9092,4.2803 4.2803,4.2803 l 4.4362,0.23554 -6.2661,-3.5069 c -0.9245,-0.51731 -2.4504,-1.1371 -2.4504,-3.5082 z" style="paint-order:markers fill stroke" id="path7329"/>
+        <path d="m 3732.9,723.94 c -2.3711,0 -4.2803,1.9092 -4.2803,4.2804 v 6.9435 c 0,2.371 1.9092,4.2803 4.2803,4.2803 h 33.351 l -27.036,-15.504 z m 30.207,0 27.036,15.504 h 9.725 c 2.3711,0 4.2804,-1.9093 4.2804,-4.2803 v -6.9435 c 0,-2.3711 -1.9093,-4.2804 -4.2804,-4.2804 z" style="paint-order:markers fill stroke" id="path7331"/>
+        <path d="m 3732.9,743.02 c -2.3711,0 -4.2803,1.9079 -4.2803,4.279 v 5.9652 c 0,2.371 1.9092,4.2803 4.2803,4.2803 h 64.918 l -25.328,-14.524 z m 63.482,0 4.4924,2.576 c 1.8141,1.0403 3.2747,1.8437 3.2747,4.2148 v -2.5117 c 0,-2.3711 -1.9093,-4.279 -4.2804,-4.279 z" style="paint-order:markers fill stroke" id="path7333"/>
+        <g id="g7341">
+          <rect transform="matrix(0,1,-0.86748,-0.49747,0,0)" x="-1431.1" y="-4385.8999" width="7.1257" height="88.288002" rx="4.9790001" ry="5.3126001" style="paint-order:markers fill stroke" id="rect7335"/>
+          <path d="m 3737.3,606.32 c -8.7955,0 -15.923,6.9987 -15.923,15.621 0,5.5511 2.3656,12.77 6.7786,17.214 -0.03,0.028 4.2462,3.9135 4.2462,5.2112 0,1.7716 -1.3035,3.2635 -3.0322,3.6017 -9.5842,0.9301 -15.255,3.8235 -19.653,9.4189 -1.2587,1.5945 -1.9411,4.7986 -1.9867,6.5113 0.015,0.4428 0,7.3809 0,7.3809 0,3.2628 2.7131,5.8877 6.0644,5.907 l 44.933,0.25874 c 0,0 2.039,0.50811 5.8228,-3.7388 2.8361,-3.1832 1.5766,-10.997 1.1631,-14.11 -0.7349,-5.5325 -13.196,-10.306 -13.196,-10.306 -2.7329,-0.67932 -4.3789,-0.9973 -6.9818,-1.2633 -1.8805,-0.2215 -3.3362,-1.7838 -3.3362,-3.6603 0,-1.2963 4.2609,-5.1361 4.2609,-5.1361 4.4584,-4.444 6.7638,-11.708 6.7638,-17.289 0,-8.622 -7.1291,-15.621 -15.925,-15.621 z" opacity="1" id="path7337"/>
+          <path d="m 3696.4,590.84 c -8.7954,0 -15.923,6.9988 -15.923,15.621 0,5.5512 2.3657,12.77 6.7786,17.214 -0.03,0.028 4.2462,3.9135 4.2462,5.2112 0,1.7717 -1.3035,3.2637 -3.0322,3.6017 -9.5842,0.9301 -15.257,3.8234 -19.654,9.4189 -1.2587,1.5945 -1.9443,4.7987 -1.9868,6.5113 0.01,0.2036 8e-4,19.427 1e-4,39.537 -0.1044,1.6835 0.8429,3.1205 2.1254,3.1154 1.9295,-0.01 4.4525,-0.039 5.7825,0.015 1.0995,0.045 1.6447,0.7682 1.6447,2.1453 v 35.8 c 0,1.48 0.1664,3.0293 -1.8931,3.3155 -0.2033,0.028 -5.1808,0.1273 -5.6305,0.134 -1.1858,0.018 -2.0097,0.4847 -2.0291,2.0176 v 4.8509 c 0,1.6468 1.3704,2.9816 3.0621,2.9816 h 26.37 c -0.076,-6.727 0.089,-30.046 0.161,-53.524 0.01,-2.6483 2.6871,-6.5926 6.7383,-7.1265 0.04,-12.102 0.084,-21.218 0.1283,-21.368 3.0591,-10.53 13.907,-14.297 19.777,-14.934 0.8076,-0.1578 1.535,-0.5262 2.1277,-1.04 -0.3126,-0.9329 -0.7152,-1.8067 -1.2086,-2.4317 -4.3523,-5.5216 -9.9634,-8.4007 -19.35,-9.3603 -1.8805,-0.2214 -3.3362,-1.7837 -3.3362,-3.6603 -1e-4,-1.2961 4.2627,-5.1361 4.2627,-5.1361 4.4585,-4.4438 6.7621,-11.708 6.7621,-17.289 0,-8.6219 -7.1273,-15.621 -15.923,-15.621 z" opacity="1" id="path7339"/>
         </g>
       </g>
     </g>
-    <g
-       transform="rotate(90,3515,-3596.5)"
-       id="g7353">
-      <path
-         d="m 7345.7,-3015.4 h 48.686 c 0.189,0 0.341,0.015 0.341,0.033 v 198.36 c 0,0.019 -0.152,0.034 -0.341,0.034 H 7345.7 c -0.189,0 -0.341,-0.015 -0.341,-0.034 v -198.36 c 0,-0.019 0.152,-0.033 0.341,-0.033 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path7347" />
-      <rect
-         x="7256.7002"
-         y="-3029.5"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect7349" />
-      <path
-         d="m 7270.9,-2891.8 v -48.686 c 0,-0.189 0.015,-0.341 0.033,-0.341 h 198.36 c 0.019,0 0.034,0.152 0.034,0.341 v 48.686 c 0,0.189 -0.015,0.341 -0.034,0.341 h -198.36 c -0.019,0 -0.033,-0.152 -0.033,-0.341 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path7351" />
+    <g transform="rotate(90,3515,-3596.5)" id="g7353">
+      <path d="m 7345.7,-3015.4 h 48.686 c 0.189,0 0.341,0.015 0.341,0.033 v 198.36 c 0,0.019 -0.152,0.034 -0.341,0.034 H 7345.7 c -0.189,0 -0.341,-0.015 -0.341,-0.034 v -198.36 c 0,-0.019 0.152,-0.033 0.341,-0.033 z" fill="#ffffff" opacity="1" id="path7347"/>
+      <rect x="7256.7002" y="-3029.5" width="226.77" height="226.77" fill="none" opacity="1" id="rect7349"/>
+      <path d="m 7270.9,-2891.8 v -48.686 c 0,-0.189 0.015,-0.341 0.033,-0.341 h 198.36 c 0.019,0 0.034,0.152 0.034,0.341 v 48.686 c 0,0.189 -0.015,0.341 -0.034,0.341 h -198.36 c -0.019,0 -0.033,-0.152 -0.033,-0.341 z" fill="#ffffff" opacity="1" id="path7351"/>
     </g>
-    <rect
-       x="3401.6001"
-       y="825.69"
-       width="226.77"
-       height="226.77"
-       rx="0.00012162"
-       ry="0.00012162"
-       fill="none"
-       style="paint-order:markers fill stroke"
-       id="rect7355" />
-    <g
-       transform="matrix(0.85806,0,0,0.85806,304.96,329.06)"
-       stroke="#ffffff"
-       stroke-width="24.777"
-       id="g7361">
-      <circle
-         cx="3741"
-         cy="710.81"
-         r="86.719002"
-         fill-opacity="0"
-         opacity="0.999"
-         stroke-linejoin="round"
-         style="paint-order:markers fill stroke"
-         id="circle7357" />
-      <path
-         d="M 3688.2,765.58 3797.58,656.2"
-         fill="none"
-         id="path7359" />
+    <rect x="3401.6001" y="825.69" width="226.77" height="226.77" rx="0.00012162" ry="0.00012162" fill="none" style="paint-order:markers fill stroke" id="rect7355"/>
+    <g transform="matrix(0.85806,0,0,0.85806,304.96,329.06)" stroke="#ffffff" stroke-width="24.777" id="g7361">
+      <circle cx="3741" cy="710.81" r="86.719002" fill-opacity="0" opacity="0.999" stroke-linejoin="round" style="paint-order:markers fill stroke" id="circle7357"/>
+      <path d="M 3688.2,765.58 3797.58,656.2" fill="none" id="path7359"/>
     </g>
-    <use
-       transform="matrix(1,0,0,1.0526,-226.77,189.29)"
-       width="100%"
-       height="100%"
-       opacity="0.3"
-       stroke-width="0.97468"
-       xlink:href="#g2866"
-       id="use7363"
-       x="0"
-       y="0" />
-    <g
-       transform="translate(-5215.7,3401.6)"
-       opacity="0.999"
-       id="g7369">
-      <path
-         d="m 7626.4,-2499.5 c 0,4.0746 3.3064,7.3815 7.3814,7.3815 4.0743,0 7.3814,-3.3069 7.3814,-7.3815 0,-4.0745 -3.3071,-7.3814 -7.3814,-7.3814 -4.075,0 -7.3814,3.3069 -7.3814,7.3814 z m -51.611,104.34 c 4.5472,4.5765 11.929,4.5765 16.505,0 l 72.161,-71.688 c 2.89,-2.8935 4.34,-6.7022 4.2807,-10.511 v -41.454 c 0,-8.0901 -6.5571,-14.645 -14.644,-14.645 h -41.454 c -3.8093,-0.059 -7.6178,1.3878 -10.514,4.2812 l -71.686,72.161 c -4.5764,4.5765 -4.5764,11.958 0,16.505 z m 39.801,-104.34 c 0,-10.6 8.5922,-19.192 19.192,-19.192 10.599,0 19.191,8.5919 19.191,19.192 0,10.6 -8.5921,19.192 -19.191,19.192 -10.6,0 -19.192,-8.592 -19.192,-19.192 z"
-         fill="#ffffff"
-         opacity="1"
-         id="path7365" />
-      <rect
-         x="7483.5"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect7367" />
+    <use transform="matrix(1,0,0,1.0526,-226.77,189.29)" width="100%" height="100%" opacity="0.3" stroke-width="0.97468" xlink:href="#g2866" id="use7363" x="0" y="0"/>
+    <g transform="translate(-5215.7,3401.6)" opacity="0.999" id="g7369">
+      <path d="m 7626.4,-2499.5 c 0,4.0746 3.3064,7.3815 7.3814,7.3815 4.0743,0 7.3814,-3.3069 7.3814,-7.3815 0,-4.0745 -3.3071,-7.3814 -7.3814,-7.3814 -4.075,0 -7.3814,3.3069 -7.3814,7.3814 z m -51.611,104.34 c 4.5472,4.5765 11.929,4.5765 16.505,0 l 72.161,-71.688 c 2.89,-2.8935 4.34,-6.7022 4.2807,-10.511 v -41.454 c 0,-8.0901 -6.5571,-14.645 -14.644,-14.645 h -41.454 c -3.8093,-0.059 -7.6178,1.3878 -10.514,4.2812 l -71.686,72.161 c -4.5764,4.5765 -4.5764,11.958 0,16.505 z m 39.801,-104.34 c 0,-10.6 8.5922,-19.192 19.192,-19.192 10.599,0 19.191,8.5919 19.191,19.192 0,10.6 -8.5921,19.192 -19.191,19.192 -10.6,0 -19.192,-8.592 -19.192,-19.192 z" fill="#ffffff" opacity="1" id="path7365"/>
+      <rect x="7483.5" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect7367"/>
     </g>
-    <g
-       fill="none"
-       id="g7375">
-      <rect
-         x="2721.3"
-         y="825.59003"
-         width="226.77"
-         height="226.77"
-         id="rect7371" />
-      <path
-         d="m 2898.4,938.98 a 63.78,63.78 0 0 1 -63.701,63.78 63.78,63.78 0 0 1 -63.858,-63.622 63.78,63.78 0 0 1 63.543,-63.937 63.78,63.78 0 0 1 64.015,63.464 l -63.779,0.31523 z"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-miterlimit="1.5"
-         stroke-width="14.173"
-         style="paint-order:markers fill stroke"
-         id="path7373" />
+    <g fill="none" id="g7375">
+      <rect x="2721.3" y="825.59003" width="226.77" height="226.77" id="rect7371"/>
+      <path d="m 2898.4,938.98 a 63.78,63.78 0 0 1 -63.701,63.78 63.78,63.78 0 0 1 -63.858,-63.622 63.78,63.78 0 0 1 63.543,-63.937 63.78,63.78 0 0 1 64.015,63.464 l -63.779,0.31523 z" opacity="1" stroke="#ffffff" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="14.173" style="paint-order:markers fill stroke" id="path7373"/>
     </g>
-    <g
-       transform="translate(226.77)"
-       id="g7387">
-      <rect
-         x="2721.3"
-         y="825.59003"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         id="rect7377" />
-      <ellipse
-         cx="2834.6001"
-         cy="938.97998"
-         rx="81.496002"
-         ry="50.166"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-miterlimit="1.5"
-         stroke-width="10.63"
-         style="paint-order:markers fill stroke"
-         id="ellipse7379" />
-      <ellipse
-         cx="2806.3"
-         cy="938.78998"
-         rx="23.504999"
-         ry="23.813999"
-         fill="#ffffff"
-         opacity="1"
-         style="paint-order:markers fill stroke"
-         id="ellipse7381" />
-      <ellipse
-         cx="2905.5"
-         cy="914.19"
-         rx="14.173"
-         ry="14.36"
-         fill="#ffffff"
-         opacity="1"
-         style="paint-order:markers fill stroke"
-         id="ellipse7383" />
-      <path
-         d="m 2806.6,938 99.15,-23.329"
-         fill="none"
-         stroke="#ffffff"
-         stroke-width="7.0866"
-         id="path7385" />
+    <g transform="translate(226.77)" id="g7387">
+      <rect x="2721.3" y="825.59003" width="226.77" height="226.77" fill="none" id="rect7377"/>
+      <ellipse cx="2834.6001" cy="938.97998" rx="81.496002" ry="50.166" fill="none" opacity="1" stroke="#ffffff" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="10.63" style="paint-order:markers fill stroke" id="ellipse7379"/>
+      <ellipse cx="2806.3" cy="938.78998" rx="23.504999" ry="23.813999" fill="#ffffff" opacity="1" style="paint-order:markers fill stroke" id="ellipse7381"/>
+      <ellipse cx="2905.5" cy="914.19" rx="14.173" ry="14.36" fill="#ffffff" opacity="1" style="paint-order:markers fill stroke" id="ellipse7383"/>
+      <path d="m 2806.6,938 99.15,-23.329" fill="none" stroke="#ffffff" stroke-width="7.0866" id="path7385"/>
     </g>
-    <g
-       transform="translate(453.54,-3.8323e-5)"
-       id="g7395">
-      <rect
-         x="2721.3"
-         y="825.59003"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         id="rect7389" />
-      <path
-         d="m 2902.7,938.95 a 68.134,68.177 0 0 1 -54.842,66.867 68.134,68.177 0 0 1 -76.24,-40.777 68.134,68.177 0 0 1 25.094,-82.778 68.134,68.177 0 0 1 86.032,8.4787"
-         fill="none"
-         opacity="1"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         stroke-miterlimit="1.5"
-         stroke-width="14.173"
-         style="paint-order:markers fill stroke"
-         id="path7391" />
-      <ellipse
-         cx="2834.6001"
-         cy="939.19"
-         rx="26.867001"
-         ry="26.886999"
-         fill="#ffffff"
-         opacity="1"
-         style="paint-order:markers fill stroke"
-         id="ellipse7393" />
+    <g transform="translate(453.54,-3.8323e-5)" id="g7395">
+      <rect x="2721.3" y="825.59003" width="226.77" height="226.77" fill="none" id="rect7389"/>
+      <path d="m 2902.7,938.95 a 68.134,68.177 0 0 1 -54.842,66.867 68.134,68.177 0 0 1 -76.24,-40.777 68.134,68.177 0 0 1 25.094,-82.778 68.134,68.177 0 0 1 86.032,8.4787" fill="none" opacity="1" stroke="#ffffff" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="14.173" style="paint-order:markers fill stroke" id="path7391"/>
+      <ellipse cx="2834.6001" cy="939.19" rx="26.867001" ry="26.886999" fill="#ffffff" opacity="1" style="paint-order:markers fill stroke" id="ellipse7393"/>
     </g>
-    <path
-       transform="matrix(1.0435,0.22884,-0.22898,1.0441,74.117,-798.27)"
-       d="m 3368.6,947.83 h -36.37 l 18.185,-31.498 z"
-       fill="#ffffff"
-       opacity="1"
-       stroke="#ffffff"
-       stroke-linejoin="round"
-       stroke-miterlimit="1.5"
-       stroke-width="9.9474"
-       style="paint-order:markers fill stroke"
-       id="path7397" />
-    <g
-       transform="translate(1814.2,1814.2)"
-       opacity="1"
-       id="g7417">
-      <rect
-         x="1587.4"
-         y="-2576"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect7399" />
-      <g
-         fill="#ffffff"
-         id="g7415">
-        <path
-           d="m 1764.3,-2409.5 c -5.6556,0 -10.241,4.5848 -10.241,10.24 0,5.656 4.5849,10.241 10.241,10.241 5.6557,0 10.24,-4.5849 10.24,-10.241 0,-5.6555 -4.5848,-10.24 -10.24,-10.24 z"
-           id="path7401" />
-        <g
-           id="g7411">
-          <path
-             d="m 1764.3,-2432.9 c -2.9443,0 -5.3311,2.3868 -5.3313,5.3312 -10e-5,2.9444 2.3869,5.3314 5.3313,5.3314 2.9445,-1e-4 5.3313,-2.387 5.3312,-5.3314 -10e-5,-2.9444 -2.3868,-5.3311 -5.3312,-5.3312 z"
-             id="path7403" />
-          <path
-             d="m 1711.9,-2435.7 c -4.3224,0 -7.8264,3.504 -7.8264,7.8264 0,4.3224 3.504,7.8266 7.8264,7.8266 4.3225,0 7.8266,-3.504 7.8266,-7.8266 0,-4.3224 -3.5042,-7.8264 -7.8266,-7.8264 z"
-             id="path7405" />
-          <path
-             d="m 1711.5,-2490.2 c -7.3738,0 -13.351,5.9774 -13.351,13.351 0,7.3738 5.9775,13.351 13.351,13.351 7.3735,0 13.351,-5.9775 13.351,-13.351 0,-7.3735 -5.9776,-13.351 -13.351,-13.351 z"
-             id="path7407" />
-          <path
-             d="m 1741.6,-2509.6 c -3.0963,-0.013 -5.651,0.8251 -7.4312,2.6054 -4.5578,4.5573 -2.931,14.191 3.2813,24.989 -0.3926,1.851 -0.5892,3.7724 -0.5892,5.7495 0,15.496 12.551,28.047 28.047,28.047 1.9773,0 3.8971,-0.1966 5.7494,-0.5892 10.798,6.2122 20.432,7.8391 24.989,3.2815 4.5575,-4.5577 2.931,-14.192 -3.2812,-24.989 0.3911,-1.8511 0.5888,-3.7722 0.5888,-5.7495 0,-15.496 -12.551,-28.046 -28.046,-28.046 -1.9771,0 -3.8987,0.1963 -5.7498,0.5889 -6.5797,-3.7856 -12.727,-5.8685 -17.558,-5.8867 z m 0.7149,6.4981 c 2.2066,0 5.111,0.968 8.415,2.642 -2.3419,1.3743 -4.4452,3.0712 -6.2809,5.0344 5.9179,14.837 25.003,33.782 39.881,39.405 1.9212,-1.8369 3.5774,-3.9546 4.9083,-6.2824 2.2156,4.8099 2.7764,9.0871 0.8553,12.116 -16.954,5.4271 -59.628,-43.107 -50.932,-51.816 0.757,-0.752 1.83,-1.0996 3.154,-1.0994 z"
-             id="path7409" />
+    <path transform="matrix(1.0435,0.22884,-0.22898,1.0441,74.117,-798.27)" d="m 3368.6,947.83 h -36.37 l 18.185,-31.498 z" fill="#ffffff" opacity="1" stroke="#ffffff" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="9.9474" style="paint-order:markers fill stroke" id="path7397"/>
+    <g transform="translate(1814.2,1814.2)" opacity="1" id="g7417">
+      <rect x="1587.4" y="-2576" width="226.77" height="226.77" fill="none" opacity="1" id="rect7399"/>
+      <g fill="#ffffff" id="g7415">
+        <path d="m 1764.3,-2409.5 c -5.6556,0 -10.241,4.5848 -10.241,10.24 0,5.656 4.5849,10.241 10.241,10.241 5.6557,0 10.24,-4.5849 10.24,-10.241 0,-5.6555 -4.5848,-10.24 -10.24,-10.24 z" id="path7401"/>
+        <g id="g7411">
+          <path d="m 1764.3,-2432.9 c -2.9443,0 -5.3311,2.3868 -5.3313,5.3312 -10e-5,2.9444 2.3869,5.3314 5.3313,5.3314 2.9445,-1e-4 5.3313,-2.387 5.3312,-5.3314 -10e-5,-2.9444 -2.3868,-5.3311 -5.3312,-5.3312 z" id="path7403"/>
+          <path d="m 1711.9,-2435.7 c -4.3224,0 -7.8264,3.504 -7.8264,7.8264 0,4.3224 3.504,7.8266 7.8264,7.8266 4.3225,0 7.8266,-3.504 7.8266,-7.8266 0,-4.3224 -3.5042,-7.8264 -7.8266,-7.8264 z" id="path7405"/>
+          <path d="m 1711.5,-2490.2 c -7.3738,0 -13.351,5.9774 -13.351,13.351 0,7.3738 5.9775,13.351 13.351,13.351 7.3735,0 13.351,-5.9775 13.351,-13.351 0,-7.3735 -5.9776,-13.351 -13.351,-13.351 z" id="path7407"/>
+          <path d="m 1741.6,-2509.6 c -3.0963,-0.013 -5.651,0.8251 -7.4312,2.6054 -4.5578,4.5573 -2.931,14.191 3.2813,24.989 -0.3926,1.851 -0.5892,3.7724 -0.5892,5.7495 0,15.496 12.551,28.047 28.047,28.047 1.9773,0 3.8971,-0.1966 5.7494,-0.5892 10.798,6.2122 20.432,7.8391 24.989,3.2815 4.5575,-4.5577 2.931,-14.192 -3.2812,-24.989 0.3911,-1.8511 0.5888,-3.7722 0.5888,-5.7495 0,-15.496 -12.551,-28.046 -28.046,-28.046 -1.9771,0 -3.8987,0.1963 -5.7498,0.5889 -6.5797,-3.7856 -12.727,-5.8685 -17.558,-5.8867 z m 0.7149,6.4981 c 2.2066,0 5.111,0.968 8.415,2.642 -2.3419,1.3743 -4.4452,3.0712 -6.2809,5.0344 5.9179,14.837 25.003,33.782 39.881,39.405 1.9212,-1.8369 3.5774,-3.9546 4.9083,-6.2824 2.2156,4.8099 2.7764,9.0871 0.8553,12.116 -16.954,5.4271 -59.628,-43.107 -50.932,-51.816 0.757,-0.752 1.83,-1.0996 3.154,-1.0994 z" id="path7409"/>
         </g>
-        <path
-           d="m 1644.4,-2518 c -22.933,0 -41.523,18.59 -41.523,41.523 -10e-5,22.933 18.591,41.523 41.523,41.524 22.933,0 41.523,-18.591 41.523,-41.524 -10e-5,-22.932 -18.591,-41.523 -41.523,-41.523 z"
-           id="path7413" />
+        <path d="m 1644.4,-2518 c -22.933,0 -41.523,18.59 -41.523,41.523 -10e-5,22.933 18.591,41.523 41.523,41.524 22.933,0 41.523,-18.591 41.523,-41.524 -10e-5,-22.932 -18.591,-41.523 -41.523,-41.523 z" id="path7413"/>
       </g>
     </g>
-    <g
-       transform="matrix(0.66153,0,0,0.66153,1744.7,2418)"
-       fill="#ffffff"
-       stroke-width="1.5555"
-       id="g7437">
-      <circle
-         cx="1250.9"
-         cy="-2235.8999"
-         r="48.891998"
-         id="circle7419" />
-      <path
-         transform="matrix(0.50694,0,0,0.81777,1045.8,-2785.3)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path7421" />
-      <path
-         transform="matrix(0,-0.50694,0.81777,0,703.96,-2030.8)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path7423" />
-      <path
-         transform="matrix(0,-0.50694,-0.81777,0,1798.5,-2030.8)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path7425" />
-      <path
-         transform="matrix(0.35846,-0.35846,0.57825,0.57825,719.2,-2480)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path7427" />
-      <path
-         transform="matrix(0.35846,0.35846,-0.57825,0.57825,1493.8,-2769.4)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path7429" />
-      <path
-         transform="matrix(-0.35846,0.35846,-0.57825,-0.57825,1783.3,-1995.4)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path7431" />
-      <path
-         transform="matrix(-0.35846,-0.35846,0.57825,-0.57825,1008.7,-1703.6)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path7433" />
-      <path
-         transform="matrix(0.50694,0,0,-0.81777,1045.8,-1690.7)"
-         d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-         id="path7435" />
+    <g transform="matrix(0.66153,0,0,0.66153,1744.7,2418)" fill="#ffffff" stroke-width="1.5555" id="g7437">
+      <circle cx="1250.9" cy="-2235.8999" r="48.891998" id="circle7419"/>
+      <path transform="matrix(0.50694,0,0,0.81777,1045.8,-2785.3)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7421"/>
+      <path transform="matrix(0,-0.50694,0.81777,0,703.96,-2030.8)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7423"/>
+      <path transform="matrix(0,-0.50694,-0.81777,0,1798.5,-2030.8)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7425"/>
+      <path transform="matrix(0.35846,-0.35846,0.57825,0.57825,719.2,-2480)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7427"/>
+      <path transform="matrix(0.35846,0.35846,-0.57825,0.57825,1493.8,-2769.4)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7429"/>
+      <path transform="matrix(-0.35846,0.35846,-0.57825,-0.57825,1783.3,-1995.4)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7431"/>
+      <path transform="matrix(-0.35846,-0.35846,0.57825,-0.57825,1008.7,-1703.6)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7433"/>
+      <path transform="matrix(0.50694,0,0,-0.81777,1045.8,-1690.7)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7435"/>
     </g>
-    <rect
-       x="2494.5"
-       y="825.59003"
-       width="226.77"
-       height="226.77"
-       fill="none"
-       id="rect7439" />
-    <path
-       d="m 2643.3,873.73 a 63.779,63.779 0 0 1 63.781,63.778 63.779,63.779 0 0 1 -63.781,63.781 63.779,63.779 0 0 1 -14.065,-1.5711 63.779,63.779 0 0 0 49.718,-62.21 63.779,63.779 0 0 0 -49.713,-62.207 63.779,63.779 0 0 1 14.06,-1.5711 z"
-       fill="#ffffff"
-       stroke-linejoin="round"
-       stroke-miterlimit="1.5"
-       stroke-width="14.173"
-       style="paint-order:markers fill stroke"
-       id="path7441" />
-    <g
-       transform="translate(-453.54,226.77)"
-       id="g7465">
-      <g
-         transform="matrix(1.029,0,0,1.029,-40.273,67.063)"
-         fill="#ffffff"
-         id="g7461">
-        <circle
-           cx="1250.9"
-           cy="-2235.8999"
-           r="48.891998"
-           id="circle7443" />
-        <path
-           transform="matrix(0.50694,0,0,0.81777,1045.8,-2785.3)"
-           d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-           id="path7445" />
-        <path
-           transform="matrix(0,-0.50694,0.81777,0,703.96,-2030.8)"
-           d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-           id="path7447" />
-        <path
-           transform="matrix(0,-0.50694,-0.81777,0,1798.5,-2030.8)"
-           d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-           id="path7449" />
-        <path
-           transform="matrix(0.35846,-0.35846,0.57825,0.57825,719.2,-2480)"
-           d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-           id="path7451" />
-        <path
-           transform="matrix(0.35846,0.35846,-0.57825,0.57825,1493.8,-2769.4)"
-           d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-           id="path7453" />
-        <path
-           transform="matrix(-0.35846,0.35846,-0.57825,-0.57825,1783.3,-1995.4)"
-           d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-           id="path7455" />
-        <path
-           transform="matrix(-0.35846,-0.35846,0.57825,-0.57825,1008.7,-1703.6)"
-           d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-           id="path7457" />
-        <path
-           transform="matrix(0.50694,0,0,-0.81777,1045.8,-1690.7)"
-           d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z"
-           id="path7459" />
+    <rect x="2494.5" y="825.59003" width="226.77" height="226.77" fill="none" id="rect7439"/>
+    <path d="m 2643.3,873.73 a 63.779,63.779 0 0 1 63.781,63.778 63.779,63.779 0 0 1 -63.781,63.781 63.779,63.779 0 0 1 -14.065,-1.5711 63.779,63.779 0 0 0 49.718,-62.21 63.779,63.779 0 0 0 -49.713,-62.207 63.779,63.779 0 0 1 14.06,-1.5711 z" fill="#ffffff" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="14.173" style="paint-order:markers fill stroke" id="path7441"/>
+    <g transform="translate(-453.54,226.77)" id="g7465">
+      <g transform="matrix(1.029,0,0,1.029,-40.273,67.063)" fill="#ffffff" id="g7461">
+        <circle cx="1250.9" cy="-2235.8999" r="48.891998" id="circle7443"/>
+        <path transform="matrix(0.50694,0,0,0.81777,1045.8,-2785.3)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7445"/>
+        <path transform="matrix(0,-0.50694,0.81777,0,703.96,-2030.8)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7447"/>
+        <path transform="matrix(0,-0.50694,-0.81777,0,1798.5,-2030.8)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7449"/>
+        <path transform="matrix(0.35846,-0.35846,0.57825,0.57825,719.2,-2480)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7451"/>
+        <path transform="matrix(0.35846,0.35846,-0.57825,0.57825,1493.8,-2769.4)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7453"/>
+        <path transform="matrix(-0.35846,0.35846,-0.57825,-0.57825,1783.3,-1995.4)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7455"/>
+        <path transform="matrix(-0.35846,-0.35846,0.57825,-0.57825,1008.7,-1703.6)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7457"/>
+        <path transform="matrix(0.50694,0,0,-0.81777,1045.8,-1690.7)" d="m 404.57,551.32 23.192,40.17 H 404.57 381.378 l 11.596,-20.085 z" id="path7459"/>
       </g>
-      <rect
-         x="1133.9"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect7463" />
+      <rect x="1133.9" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect7463"/>
     </g>
-    <g
-       transform="translate(226.77,680.31)"
-       id="g7471">
-      <path
-         d="m 566.93,-2292.5 a 56.693,56.693 0 0 0 -56.693,56.693 56.693,56.693 0 0 0 56.693,56.693 56.693,56.693 0 0 0 18.616,-3.2129 29.857,29.857 0 0 1 -28.474,-29.787 29.857,29.857 0 0 1 29.857,-29.857 29.857,29.857 0 0 1 29.857,29.857 29.857,29.857 0 0 1 -0.26555,3.7511 56.693,56.693 0 0 0 7.1017,-27.444 56.693,56.693 0 0 0 -56.693,-56.693 z"
-         fill="#ffffff"
-         id="path7467" />
-      <rect
-         x="453.54001"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect7469" />
+    <g transform="translate(226.77,680.31)" id="g7471">
+      <path d="m 566.93,-2292.5 a 56.693,56.693 0 0 0 -56.693,56.693 56.693,56.693 0 0 0 56.693,56.693 56.693,56.693 0 0 0 18.616,-3.2129 29.857,29.857 0 0 1 -28.474,-29.787 29.857,29.857 0 0 1 29.857,-29.857 29.857,29.857 0 0 1 29.857,29.857 29.857,29.857 0 0 1 -0.26555,3.7511 56.693,56.693 0 0 0 7.1017,-27.444 56.693,56.693 0 0 0 -56.693,-56.693 z" fill="#ffffff" id="path7467"/>
+      <rect x="453.54001" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect7469"/>
     </g>
-    <g
-       transform="translate(-680.31,-226.77)"
-       id="g7489">
-      <rect
-         x="1587.4"
-         y="-81.492996"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="0.999"
-         id="rect7473" />
-      <path
-         id="path2880"
-         d="m 1614.2,41.64 15.262,-34.702 7.6312,-17.351 15.262,34.702 7.6312,17.351"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="9.609" />
-      <path
-         id="path2835"
-         d="m 1667.6,58.991 c -20.35,8.8228 -40.7,10.983 -61.05,0"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="14.062" />
-      <g
-         fill="#ffffff"
-         opacity="0.999"
-         shape-rendering="auto"
-         id="g7481">
-        <path
-           d="m 1696.9,-47.414 h 7.7214 l 5.625,146.53 h -18.971 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           image-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-           id="path7477" />
-        <path
-           transform="matrix(0.9375,0,0,0.9375,680.31,-2349.2)"
-           d="m 1084.4,2450.3 c -2.6873,-6e-4 -4.8948,2.1232 -4.998,4.8085 l -5.6289,146.63 h -0.018 c 0,4.8503 -3.9682,8.8183 -8.8184,8.8183 h -20.672 c -6.0843,0 -11.022,4.9384 -11.022,11.023 0,6.0852 4.9372,11.024 11.022,11.024 h 88.189 c 6.0853,0 11.023,-4.9383 11.023,-11.024 0,-6.085 -4.9381,-11.023 -11.023,-11.023 h -20.356 c -4.8501,0 -8.8183,-5.968 -8.8281,-8.3932 l -5.6387,-147.05 c -0.1034,-2.6845 -2.3095,-4.808 -4.9961,-4.8085 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           image-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal"
-           id="path7479" />
+    <g transform="translate(-680.31,-226.77)" id="g7489">
+      <rect x="1587.4" y="-81.492996" width="226.77" height="226.77" fill="none" opacity="0.999" id="rect7473"/>
+      <path id="path2880" d="m 1614.2,41.64 15.262,-34.702 7.6312,-17.351 15.262,34.702 7.6312,17.351" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="9.609"/>
+      <path id="path2835" d="m 1667.6,58.991 c -20.35,8.8228 -40.7,10.983 -61.05,0" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="14.062"/>
+      <g fill="#ffffff" opacity="0.999" shape-rendering="auto" id="g7481">
+        <path d="m 1696.9,-47.414 h 7.7214 l 5.625,146.53 h -18.971 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path7477"/>
+        <path transform="matrix(0.9375,0,0,0.9375,680.31,-2349.2)" d="m 1084.4,2450.3 c -2.6873,-6e-4 -4.8948,2.1232 -4.998,4.8085 l -5.6289,146.63 h -0.018 c 0,4.8503 -3.9682,8.8183 -8.8184,8.8183 h -20.672 c -6.0843,0 -11.022,4.9384 -11.022,11.023 0,6.0852 4.9372,11.024 11.022,11.024 h 88.189 c 6.0853,0 11.023,-4.9383 11.023,-11.024 0,-6.085 -4.9381,-11.023 -11.023,-11.023 h -20.356 c -4.8501,0 -8.8183,-5.968 -8.8281,-8.3932 l -5.6387,-147.05 c -0.1034,-2.6845 -2.3095,-4.808 -4.9961,-4.8085 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal" id="path7479"/>
       </g>
-      <path
-         d="m 1634.7,-24.08 17.457,-3.425 48.834,14.695 48.614,-14.695 17.236,3.425"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="9.375"
-         id="path7483" />
-      <use
-         transform="translate(128.16)"
-         width="100%"
-         height="100%"
-         xlink:href="#path2880"
-         id="use7485"
-         x="0"
-         y="0" />
-      <use
-         transform="translate(128.16)"
-         width="100%"
-         height="100%"
-         xlink:href="#path2835"
-         id="use7487"
-         x="0"
-         y="0" />
+      <path d="m 1634.7,-24.08 17.457,-3.425 48.834,14.695 48.614,-14.695 17.236,3.425" fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="9.375" id="path7483"/>
+      <use transform="translate(128.16)" width="100%" height="100%" xlink:href="#path2880" id="use7485" x="0" y="0"/>
+      <use transform="translate(128.16)" width="100%" height="100%" xlink:href="#path2835" id="use7487" x="0" y="0"/>
     </g>
-    <g
-       transform="matrix(7.0866,0,0,7.0866,1587.4,-81.496)"
-       id="g7495">
-      <rect
-         width="32"
-         height="32"
-         fill="none"
-         id="rect7491"
-         x="0"
-         y="0" />
-      <path
-         d="m 14.221,5.0689 c -2.2298,0 -4.0374,1.7019 -4.2774,3.87 H 8.6675 v 17.992 h 14.53 V 8.9389 h -1.1457 c -0.23997,-2.1681 -2.0475,-3.87 -4.2774,-3.87 z m 0,2.1726 h 3.553 c 1.0609,0 1.8948,0.71177 2.1047,1.6974 H 12.1162 C 12.3261,7.95329 13.1601,7.2415 14.2209,7.2415 Z M 5.6802,8.9389 c -1.5046,0 -2.7158,1.2112 -2.7158,2.7158 v 12.561 c 0,1.5046 1.2112,2.7158 2.7158,2.7158 H 6.63073 V 8.9395 Z m 19.554,0 v 17.992 h 1.0863 c 1.5046,0 2.7158,-1.2112 2.7158,-2.7158 v -12.561 c 0,-1.5046 -1.2112,-2.7158 -2.7158,-2.7158 z"
-         fill="#ffffff"
-         id="path7493" />
+    <g transform="matrix(7.0866,0,0,7.0866,1587.4,-81.496)" id="g7495">
+      <rect width="32" height="32" fill="none" id="rect7491" x="0" y="0"/>
+      <path d="m 14.221,5.0689 c -2.2298,0 -4.0374,1.7019 -4.2774,3.87 H 8.6675 v 17.992 h 14.53 V 8.9389 h -1.1457 c -0.23997,-2.1681 -2.0475,-3.87 -4.2774,-3.87 z m 0,2.1726 h 3.553 c 1.0609,0 1.8948,0.71177 2.1047,1.6974 H 12.1162 C 12.3261,7.95329 13.1601,7.2415 14.2209,7.2415 Z M 5.6802,8.9389 c -1.5046,0 -2.7158,1.2112 -2.7158,2.7158 v 12.561 c 0,1.5046 1.2112,2.7158 2.7158,2.7158 H 6.63073 V 8.9395 Z m 19.554,0 v 17.992 h 1.0863 c 1.5046,0 2.7158,-1.2112 2.7158,-2.7158 v -12.561 c 0,-1.5046 -1.2112,-2.7158 -2.7158,-2.7158 z" fill="#ffffff" id="path7493"/>
     </g>
-    <g
-       transform="translate(1360.6)"
-       opacity="0.999"
-       id="g7549">
-      <g
-         transform="matrix(6.611,0,0,6.611,-3719.6,-10591)"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         id="g7503">
-        <path
-           d="M 490.82,1483.5 H 462.994"
-           fill="#ffffff"
-           opacity="1"
-           stroke-width="2.1439"
-           id="path7497" />
-        <path
-           d="m 465.1,1482.4 0.0531,-4.5538 2.6156,4.9447 1.7633,-4.9447 2.1142,4.9447 3.0668,-4.9447 2.9665,4.9447 2.2145,-4.9447 1.663,4.9447 2.7159,-4.9447 v 4.7543"
-           fill="none"
-           opacity="1"
-           id="path7499" />
-        <rect
-           x="464.79001"
-           y="1476.7"
-           width="20.129999"
-           height="2.9793"
-           rx="0.63085002"
-           ry="0.64311999"
-           fill="#ffffff"
-           stroke-width="1.3085"
-           style="paint-order:markers fill stroke"
-           id="rect7501" />
+    <g transform="translate(1360.6)" opacity="0.999" id="g7549">
+      <g transform="matrix(6.611,0,0,6.611,-3719.6,-10591)" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" id="g7503">
+        <path d="M 490.82,1483.5 H 462.994" fill="#ffffff" opacity="1" stroke-width="2.1439" id="path7497"/>
+        <path d="m 465.1,1482.4 0.0531,-4.5538 2.6156,4.9447 1.7633,-4.9447 2.1142,4.9447 3.0668,-4.9447 2.9665,4.9447 2.2145,-4.9447 1.663,4.9447 2.7159,-4.9447 v 4.7543" fill="none" opacity="1" id="path7499"/>
+        <rect x="464.79001" y="1476.7" width="20.129999" height="2.9793" rx="0.63085002" ry="0.64311999" fill="#ffffff" stroke-width="1.3085" style="paint-order:markers fill stroke" id="rect7501"/>
       </g>
-      <rect
-         x="-680.32001"
-         y="-988.58002"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         id="rect7505" />
-      <path
-         d="m -485.61,-889.88 0.0755,39.503 -35.342,0.0145 v -39.517"
-         fill="#ffffff"
-         stroke="#ffffff"
-         stroke-linecap="round"
-         stroke-linejoin="round"
-         stroke-width="7.0325"
-         style="paint-order:markers fill stroke"
-         id="path7507" />
-      <g
-         fill="none"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         id="g7523">
-        <path
-           d="m -527.39,-939.6 h 48.487 c 2.6209,0 4.7309,2.2449 4.7309,5.0334 v 27.047 c 0,2.7885 -9.2663,11.695 -11.189,11.695 h -35.57 c -1.9227,0 -11.189,-8.9066 -11.189,-11.695 v -27.047 c 0,-2.7885 2.11,-5.0334 4.7309,-5.0334 z"
-           stroke-width="12.918"
-           style="paint-order:markers fill stroke"
-           id="path7509" />
-        <g
-           stroke-width="7.0866"
-           id="g7519">
-          <path
-             d="m -527.17,-917.7 h 12.757"
-             style="paint-order:markers fill stroke"
-             id="path7511" />
-          <path
-             d="m -510.44,-917.7 h 12.757"
-             style="paint-order:markers fill stroke"
-             id="path7513" />
-          <path
-             d="m -494.03,-917.7 h 12.757"
-             style="paint-order:markers fill stroke"
-             id="path7515" />
-          <path
-             d="m -491.96,-975.45 v 36.622"
-             style="paint-order:markers fill stroke"
-             id="path7517" />
+      <rect x="-680.32001" y="-988.58002" width="226.77" height="226.77" fill="none" id="rect7505"/>
+      <path d="m -485.61,-889.88 0.0755,39.503 -35.342,0.0145 v -39.517" fill="#ffffff" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="7.0325" style="paint-order:markers fill stroke" id="path7507"/>
+      <g fill="none" stroke="#ffffff" stroke-linejoin="round" id="g7523">
+        <path d="m -527.39,-939.6 h 48.487 c 2.6209,0 4.7309,2.2449 4.7309,5.0334 v 27.047 c 0,2.7885 -9.2663,11.695 -11.189,11.695 h -35.57 c -1.9227,0 -11.189,-8.9066 -11.189,-11.695 v -27.047 c 0,-2.7885 2.11,-5.0334 4.7309,-5.0334 z" stroke-width="12.918" style="paint-order:markers fill stroke" id="path7509"/>
+        <g stroke-width="7.0866" id="g7519">
+          <path d="m -527.17,-917.7 h 12.757" style="paint-order:markers fill stroke" id="path7511"/>
+          <path d="m -510.44,-917.7 h 12.757" style="paint-order:markers fill stroke" id="path7513"/>
+          <path d="m -494.03,-917.7 h 12.757" style="paint-order:markers fill stroke" id="path7515"/>
+          <path d="m -491.96,-975.45 v 36.622" style="paint-order:markers fill stroke" id="path7517"/>
         </g>
-        <path
-           d="m -502.57,-958.71 v 19.884"
-           stroke-width="3.5433"
-           style="paint-order:markers fill stroke"
-           id="path7521" />
+        <path d="m -502.57,-958.71 v 19.884" stroke-width="3.5433" style="paint-order:markers fill stroke" id="path7521"/>
       </g>
-      <g
-         transform="matrix(1.1291,0,0,1.3524,60.147,286.2)"
-         fill="none"
-         stroke="#ffffff"
-         stroke-linejoin="round"
-         id="g7541">
-        <path
-           d="m -567.59,-840.76 h -72.112 l 0.01,-11.651 16.29,0.16668 0.24448,-12.52 30.724,-0.46875 c 17.489,-0.22081 33.395,0.38153 45.397,15.869 -6.7215,8.8738 -11.055,8.6899 -20.553,8.6036 z"
-           opacity="0.999"
-           stroke-linecap="round"
-           stroke-width="7.0866"
-           id="path7525" />
-        <g
-           id="g7539">
-          <path
-             d="m -623.8,-852.25 h 16.904 l 10.607,10.607"
-             stroke-width="7.0866"
-             id="path7527" />
-          <path
-             d="m -623.21,-861.38 0.23565,-14.833 h 17.083 l 10.607,10.607"
-             stroke-width="7.0866"
-             id="path7529" />
-          <g
-             stroke-width="3.5433"
-             id="g7537">
-            <path
-               d="m -569.27,-855.65 h 12.757"
-               style="paint-order:markers fill stroke"
-               id="path7531" />
-            <path
-               d="m -577.12,-855.65 h 3.8512"
-               style="paint-order:markers fill stroke"
-               id="path7533" />
-            <path
-               d="m -584.74,-855.65 h 3.8512"
-               style="paint-order:markers fill stroke"
-               id="path7535" />
+      <g transform="matrix(1.1291,0,0,1.3524,60.147,286.2)" fill="none" stroke="#ffffff" stroke-linejoin="round" id="g7541">
+        <path d="m -567.59,-840.76 h -72.112 l 0.01,-11.651 16.29,0.16668 0.24448,-12.52 30.724,-0.46875 c 17.489,-0.22081 33.395,0.38153 45.397,15.869 -6.7215,8.8738 -11.055,8.6899 -20.553,8.6036 z" opacity="0.999" stroke-linecap="round" stroke-width="7.0866" id="path7525"/>
+        <g id="g7539">
+          <path d="m -623.8,-852.25 h 16.904 l 10.607,10.607" stroke-width="7.0866" id="path7527"/>
+          <path d="m -623.21,-861.38 0.23565,-14.833 h 17.083 l 10.607,10.607" stroke-width="7.0866" id="path7529"/>
+          <g stroke-width="3.5433" id="g7537">
+            <path d="m -569.27,-855.65 h 12.757" style="paint-order:markers fill stroke" id="path7531"/>
+            <path d="m -577.12,-855.65 h 3.8512" style="paint-order:markers fill stroke" id="path7533"/>
+            <path d="m -584.74,-855.65 h 3.8512" style="paint-order:markers fill stroke" id="path7535"/>
           </g>
         </g>
       </g>
-      <g
-         fill="#ffffff"
-         opacity="0.999"
-         shape-rendering="auto"
-         id="g7547">
-        <path
-           d="m -484.51,-858.55 0.0193,76.14 -9.0915,0.029 v -76.168 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           image-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal;paint-order:markers fill stroke"
-           id="path7543" />
-        <path
-           d="m -501.09,-861.02 c -1.3671,8.9e-4 -2.4748,1.1095 -2.4746,2.4766 l 0.098,11.718 c 4.4086,0.098 7.402,4.2263 7.402,7.3613 v 42.113 c 0,5.9769 -3.2862,7.1517 -7.5,7.1517 v 7.8237 c -2e-4,1.3701 1.1123,2.48 2.4824,2.4766 l 16.592,-0.0293 c 1.3648,-0.004 2.4689,-1.1118 2.4688,-2.4766 l -0.0195,-76.141 c -8.9e-4,-1.3671 -1.1095,-2.4748 -2.4766,-2.4746 z"
-           color="#000000"
-           color-rendering="auto"
-           dominant-baseline="auto"
-           image-rendering="auto"
-           solid-color="#000000"
-           stop-color="#000000"
-           style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal;paint-order:markers fill stroke"
-           id="path7545" />
+      <g fill="#ffffff" opacity="0.999" shape-rendering="auto" id="g7547">
+        <path d="m -484.51,-858.55 0.0193,76.14 -9.0915,0.029 v -76.168 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal;paint-order:markers fill stroke" id="path7543"/>
+        <path d="m -501.09,-861.02 c -1.3671,8.9e-4 -2.4748,1.1095 -2.4746,2.4766 l 0.098,11.718 c 4.4086,0.098 7.402,4.2263 7.402,7.3613 v 42.113 c 0,5.9769 -3.2862,7.1517 -7.5,7.1517 v 7.8237 c -2e-4,1.3701 1.1123,2.48 2.4824,2.4766 l 16.592,-0.0293 c 1.3648,-0.004 2.4689,-1.1118 2.4688,-2.4766 l -0.0195,-76.141 c -8.9e-4,-1.3671 -1.1095,-2.4748 -2.4766,-2.4746 z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" solid-color="#000000" stop-color="#000000" style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal;paint-order:markers fill stroke" id="path7545"/>
       </g>
     </g>
-    <g
-       transform="translate(2267.6999,2721.27)"
-       id="g7739">
-      <title
-         id="title25121">follow-ori</title>
-      <g
-         transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)"
-         id="g7735">
-        <path
-           id="circle7731"
-           style="opacity:1;fill:none;stroke:#ffffff;stroke-width:18.7362;stroke-linecap:round;stroke-linejoin:round"
-           d="m 120.51172,3894.5098 c -53.104043,0.2344 -96.031576,43.3453 -96.039064,96.4492 m 0,0 c 0.007,0.2351 0.01477,0.4701 0.02344,0.7051 m 0,0 v 0 m 96.033204,95.7441 v 0 m 0,0 c 0.13606,0 0.27212,0.01 0.4082,0.014 m 0,0 c 52.99853,-0.011 96.06218,-42.777 96.44141,-95.7735 m 0,0 v 0 m 0,0 c 0.009,-0.2298 0.0164,-0.4596 0.0234,-0.6894 m -96.46484,-96.4649 c -0.14194,0 -0.28387,0.01 -0.42578,0.016"
-           transform="matrix(0.11643753,0,0,0.11643753,12.134393,852.60262)"
-           sodipodi:nodetypes="cccccccccccccccccc" />
+    <g transform="translate(2267.6999,2721.27)" id="g7739">
+      <title id="title25121">follow-ori</title>
+      <g transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)" id="g7735">
+        <path id="circle7731" style="opacity:1;fill:none;stroke:#ffffff;stroke-width:18.7362;stroke-linecap:round;stroke-linejoin:round" d="m 120.51172,3894.5098 c -53.104043,0.2344 -96.031576,43.3453 -96.039064,96.4492 m 0,0 c 0.007,0.2351 0.01477,0.4701 0.02344,0.7051 m 0,0 v 0 m 96.033204,95.7441 v 0 m 0,0 c 0.13606,0 0.27212,0.01 0.4082,0.014 m 0,0 c 52.99853,-0.011 96.06218,-42.777 96.44141,-95.7735 m 0,0 v 0 m 0,0 c 0.009,-0.2298 0.0164,-0.4596 0.0234,-0.6894 m -96.46484,-96.4649 c -0.14194,0 -0.28387,0.01 -0.42578,0.016" transform="matrix(0.11643753,0,0,0.11643753,12.134393,852.60262)" sodipodi:nodetypes="cccccccccccccccccc"/>
       </g>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect7737" />
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect7737"/>
     </g>
-    <g
-       transform="translate(2494.5099,2721.2903)"
-       id="g17236">
-      <title
-         id="title25123">follow-pos</title>
-      <g
-         transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)"
-         id="g17232">
-        <path
-           id="ellipse17212"
-           style="opacity:1;fill:none;stroke:#ffffff;stroke-width:2.18157;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill"
-           d="m 21.83343,1306.9618 v 0 m 0,0 c -2.713007,1.1491 -4.865843,3.3183 -5.994476,6.0399 m 0,0 c -0.0099,0.025 -0.01977,0.051 -0.02952,0.077 m 0,0 v 0 m 0.04223,8.5411 v 0 m 0,0 c 1.135631,2.7263 3.299342,4.8956 6.022684,6.0383 m 0,0 v 0 m 0,0 c 0.01464,0.01 0.02883,0.013 0.04347,0.019 m 8.511257,0.032 v 0 m 0,0 c 2.764149,-1.1186 4.97005,-3.2904 6.13153,-6.0367 m 0,0 v 0 m 0,0 c 0.01099,-0.024 0.02182,-0.049 0.03261,-0.073 m 0.0083,-8.5763 v 0 m 0,0 c -1.137523,-2.7614 -3.327957,-4.9561 -6.087153,-6.099"
-           sodipodi:nodetypes="cccccccccccccccccccccccccccc" />
+    <g transform="translate(2494.5099,2721.2903)" id="g17236">
+      <title id="title25123">follow-pos</title>
+      <g transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)" id="g17232">
+        <path id="ellipse17212" style="opacity:1;fill:none;stroke:#ffffff;stroke-width:2.18157;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill" d="m 21.83343,1306.9618 v 0 m 0,0 c -2.713007,1.1491 -4.865843,3.3183 -5.994476,6.0399 m 0,0 c -0.0099,0.025 -0.01977,0.051 -0.02952,0.077 m 0,0 v 0 m 0.04223,8.5411 v 0 m 0,0 c 1.135631,2.7263 3.299342,4.8956 6.022684,6.0383 m 0,0 v 0 m 0,0 c 0.01464,0.01 0.02883,0.013 0.04347,0.019 m 8.511257,0.032 v 0 m 0,0 c 2.764149,-1.1186 4.97005,-3.2904 6.13153,-6.0367 m 0,0 v 0 m 0,0 c 0.01099,-0.024 0.02182,-0.049 0.03261,-0.073 m 0.0083,-8.5763 v 0 m 0,0 c -1.137523,-2.7614 -3.327957,-4.9561 -6.087153,-6.099" sodipodi:nodetypes="cccccccccccccccccccccccccccc"/>
       </g>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect17234" />
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect17234"/>
     </g>
-    <g
-       transform="translate(2721.2799,2721.2903)"
-       id="g20700">
-      <title
-         id="title25125">follow-icon-circle</title>
-      <g
-         transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)"
-         id="g20696">
-        <circle
-           cx="26.216"
-           cy="1317.3"
-           r="11.232"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.1816"
-           id="circle20692" />
+    <g transform="translate(2721.2799,2721.2903)" id="g20700">
+      <title id="title25125">follow-icon-circle</title>
+      <g transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)" id="g20696">
+        <circle cx="26.216" cy="1317.3" r="11.232" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1816" id="circle20692"/>
       </g>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect20698" />
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect20698"/>
     </g>
-    <g
-       transform="translate(2721.2399,2948.06)"
-       id="g20700-1">
-      <title
-         id="title25125-6">follow-icon-circle</title>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect20698-4" />
-      <g
-         id="g11718"
-         transform="matrix(0.92974295,0,0,0.92974295,-21.728981,-3173.2583)">
-        <g
-           transform="translate(-6037.4904,3531.3619)"
-           id="g7107-9"
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-          <g
-             id="rect4088-6"
-             transform="matrix(0.642897,0,0,0.642897,2109.27,-177.09)">
-            <rect
-               x="2494.5"
-               y="-2576"
-               width="226.23"
-               height="227.32001"
-               style="fill:none"
-               id="rect7104" />
+    <g transform="translate(2721.2399,2948.06)" id="g20700-1">
+      <title id="title25125-6">follow-icon-circle</title>
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect20698-4"/>
+      <g id="g11718" transform="matrix(0.92974295,0,0,0.92974295,-21.728981,-3173.2583)">
+        <g transform="translate(-6037.4904,3531.3619)" id="g7107-9" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+          <g id="rect4088-6" transform="matrix(0.642897,0,0,0.642897,2109.27,-177.09)">
+            <rect x="2494.5" y="-2576" width="226.23" height="227.32001" style="fill:none" id="rect7104"/>
           </g>
         </g>
-        <g
-           transform="translate(-6037.4904,3531.3619)"
-           id="g7117"
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-          <g
-             id="rect69291"
-             serif:id="rect6929"
-             transform="matrix(0.740007,0,0,0.740007,944.105,-2339.35)">
-            <path
-               d="m 3855.07,598.82 c 0,0 0,0 0,0 H 3628.3 c 0,0 0,0 0,0 v 226.77 c 0,0 0,0 0,0 h 226.77 c 0,0 0,0 0,0 z"
-               style="fill:none"
-               id="path7114" />
+        <g transform="translate(-6037.4904,3531.3619)" id="g7117" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+          <g id="rect69291" serif:id="rect6929" transform="matrix(0.740007,0,0,0.740007,944.105,-2339.35)">
+            <path d="m 3855.07,598.82 c 0,0 0,0 0,0 H 3628.3 c 0,0 0,0 0,0 v 226.77 c 0,0 0,0 0,0 h 226.77 c 0,0 0,0 0,0 z" style="fill:none" id="path7114"/>
           </g>
         </g>
-        <g
-           transform="translate(-6037.4904,3531.3619)"
-           id="g7140"
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-          <g
-             id="g28661"
-             serif:id="g2866"
-             transform="matrix(0.470409,0,0,0.495153,1953.09,-2130.81)">
-            <rect
-               id="rect69311"
-               serif:id="rect6931"
-               x="3656.7"
-               y="644.88"
-               width="28.346001"
-               height="134.64999"
-               style="fill:#ffffff" />
-            <rect
-               id="rect69331"
-               serif:id="rect6933"
-               x="3798.3999"
-               y="644.88"
-               width="28.346001"
-               height="134.64999"
-               style="fill:#ffffff" />
-            <g
-               id="rect69351"
-               serif:id="rect6935"
-               transform="rotate(90)">
-              <rect
-                 x="644.88"
-                 y="-3791.1001"
-                 width="24.802999"
-                 height="98.799004"
-                 style="fill:#ffffff"
-                 id="rect7121-5" />
+        <g transform="translate(-6037.4904,3531.3619)" id="g7140" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+          <g id="g28661" serif:id="g2866" transform="matrix(0.470409,0,0,0.495153,1953.09,-2130.81)">
+            <rect id="rect69311" serif:id="rect6931" x="3656.7" y="644.88" width="28.346001" height="134.64999" style="fill:#ffffff"/>
+            <rect id="rect69331" serif:id="rect6933" x="3798.3999" y="644.88" width="28.346001" height="134.64999" style="fill:#ffffff"/>
+            <g id="rect69351" serif:id="rect6935" transform="rotate(90)">
+              <rect x="644.88" y="-3791.1001" width="24.802999" height="98.799004" style="fill:#ffffff" id="rect7121-5"/>
             </g>
-            <g
-               id="rect69371"
-               serif:id="rect6937"
-               transform="rotate(90)">
-              <rect
-                 x="754.71997"
-                 y="-3791.1001"
-                 width="24.802999"
-                 height="98.800003"
-                 style="fill:#ffffff"
-                 id="rect7124" />
+            <g id="rect69371" serif:id="rect6937" transform="rotate(90)">
+              <rect x="754.71997" y="-3791.1001" width="24.802999" height="98.800003" style="fill:#ffffff" id="rect7124"/>
             </g>
-            <g
-               id="path69391"
-               serif:id="path6939"
-               transform="matrix(0.9375,0,0,0.9375,0,-2576)">
-              <path
-                 d="m 3952.3,3471.8 33.86,18.57 h 57.64 v -18.57 z"
-                 style="fill:#ffffff;fill-rule:nonzero"
-                 id="path7127" />
+            <g id="path69391" serif:id="path6939" transform="matrix(0.9375,0,0,0.9375,0,-2576)">
+              <path d="m 3952.3,3471.8 33.86,18.57 h 57.64 v -18.57 z" style="fill:#ffffff;fill-rule:nonzero" id="path7127"/>
             </g>
-            <g
-               id="path69411"
-               serif:id="path6941"
-               transform="matrix(0.9375,0,0,0.9375,0,-2576)">
-              <path
-                 d="m 3939.2,3495.8 v 23.28 h 43.79 l -40.59,-23.28 z m 55.07,0 40.58,23.28 h 8.76 v -23.28 z"
-                 style="fill:#ffffff;fill-rule:nonzero"
-                 id="path7130" />
+            <g id="path69411" serif:id="path6941" transform="matrix(0.9375,0,0,0.9375,0,-2576)">
+              <path d="m 3939.2,3495.8 v 23.28 h 43.79 l -40.59,-23.28 z m 55.07,0 40.58,23.28 h 8.76 v -23.28 z" style="fill:#ffffff;fill-rule:nonzero" id="path7130"/>
             </g>
-            <g
-               id="path69431"
-               serif:id="path6943"
-               transform="matrix(0.9375,0,0,0.9375,0,-2576)">
-              <path
-                 d="m 3938.8,3524.4 v 19.8 h 89.62 l -36.03,-19.8 z"
-                 style="fill:#ffffff;fill-rule:nonzero"
-                 id="path7133-6" />
+            <g id="path69431" serif:id="path6943" transform="matrix(0.9375,0,0,0.9375,0,-2576)">
+              <path d="m 3938.8,3524.4 v 19.8 h 89.62 l -36.03,-19.8 z" style="fill:#ffffff;fill-rule:nonzero" id="path7133-6"/>
             </g>
-            <g
-               id="rect69451"
-               serif:id="rect6945"
-               transform="matrix(0,1,-0.86748,-0.49747,0,0)">
-              <rect
-                 x="-1439.2"
-                 y="-4371.2002"
-                 width="13.228"
-                 height="115.61"
-                 style="fill:#ffffff"
-                 id="rect7136" />
+            <g id="rect69451" serif:id="rect6945" transform="matrix(0,1,-0.86748,-0.49747,0,0)">
+              <rect x="-1439.2" y="-4371.2002" width="13.228" height="115.61" style="fill:#ffffff" id="rect7136"/>
             </g>
           </g>
         </g>
-        <g
-           transform="translate(-6037.4904,3531.3619)"
-           id="g7146"
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-          <g
-             transform="matrix(0.693754,0,0,0.693754,3629.07,-1875.41)"
-             id="g7144">
-            <path
-               d="m 48.826,130.202 -20.547,-9.246 13,-79.623 h 56.378"
-               style="fill:none;stroke:#ffffff;stroke-width:21.62px"
-               id="path7142" />
+        <g transform="translate(-6037.4904,3531.3619)" id="g7146" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+          <g transform="matrix(0.693754,0,0,0.693754,3629.07,-1875.41)" id="g7144">
+            <path d="m 48.826,130.202 -20.547,-9.246 13,-79.623 h 56.378" style="fill:none;stroke:#ffffff;stroke-width:21.62px" id="path7142"/>
           </g>
         </g>
-        <g
-           transform="translate(-6037.4904,3531.3619)"
-           id="g7152"
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-          <g
-             transform="matrix(0.693754,0,0,0.693754,3629.07,-1875.41)"
-             id="g7150">
-            <path
-               d="m 144.313,52.144 h 47.108 c 0,0 10.182,62.345 10.182,62.345 0,0 -12.986,5.858 -12.986,5.858 -5.439,2.454 -7.862,8.862 -5.409,14.3 2.454,5.439 8.862,7.863 14.3,5.409 l 20.547,-9.27 c 4.46,-2.012 7.012,-6.768 6.224,-11.596 l -13,-79.599 c -0.854,-5.229 -5.371,-9.068 -10.669,-9.068 h -56.297 c -5.966,0 -10.811,4.844 -10.811,10.81 0,5.967 4.845,10.811 10.811,10.811 z"
-               style="fill:#ffffff"
-               id="path7148" />
+        <g transform="translate(-6037.4904,3531.3619)" id="g7152" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+          <g transform="matrix(0.693754,0,0,0.693754,3629.07,-1875.41)" id="g7150">
+            <path d="m 144.313,52.144 h 47.108 c 0,0 10.182,62.345 10.182,62.345 0,0 -12.986,5.858 -12.986,5.858 -5.439,2.454 -7.862,8.862 -5.409,14.3 2.454,5.439 8.862,7.863 14.3,5.409 l 20.547,-9.27 c 4.46,-2.012 7.012,-6.768 6.224,-11.596 l -13,-79.599 c -0.854,-5.229 -5.371,-9.068 -10.669,-9.068 h -56.297 c -5.966,0 -10.811,4.844 -10.811,10.81 0,5.967 4.845,10.811 10.811,10.811 z" style="fill:#ffffff" id="path7148"/>
           </g>
         </g>
-        <g
-           transform="translate(-6037.4904,3531.3619)"
-           id="g7157"
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-          <g
-             id="path40901"
-             serif:id="path4090"
-             transform="matrix(0.937497,0,0,0.937497,3174.89,-1895.69)">
-            <path
-               d="m 647.886,76.57 h 14.998 c 6.265,0 11.339,5.074 11.339,11.339 v 34.018 h 4.252 c 10.177,0 18.426,8.249 18.426,18.426 v 39.687 c 0,2.353 1.899,4.252 4.252,4.252 2.353,0 4.252,-1.899 4.252,-4.252 v -63.814 l -8.136,0.029 c -1.559,0.025 -3.121,-0.57 -4.28,-1.814 -2.353,-2.41 -2.353,-6.294 0,-8.703 l 7.2,-7.512 -9.752,-9.781 c -2.721,-2.718 -2.721,-7.112 0,-9.833 2.722,-2.725 7.118,-2.725 9.837,0 l 15.027,14.939 c 2.636,2.579 4.281,6.18 4.281,10.177 v 76.311 c 0,10.177 -8.249,18.426 -18.426,18.426 -10.177,0 -18.426,-8.249 -18.426,-18.426 v -39.687 c 0,-2.353 -1.899,-4.252 -4.252,-4.252 h -4.252 v 62.366 l -0.002,0.001 h 1.417 c 3.912,0 7.087,3.175 7.087,7.087 0,3.912 -3.175,7.087 -7.087,7.087 H 590.6 c -3.912,0 -7.087,-3.175 -7.087,-7.087 0,-3.912 3.175,-7.087 7.087,-7.087 h 1.415 v -32.118 h 30.223 v -33.081 h 31.578 c 3.458,0 6.236,-2.778 6.236,-6.236 V 96.983 c 0,-3.459 -2.778,-6.237 -6.236,-6.237 h -3.589 z m -20.664,14.176 h -4.984 v -5.65 h -29.872 c 1.25,-4.903 5.694,-8.526 10.988,-8.526 h 21.527 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path7154" />
+        <g transform="translate(-6037.4904,3531.3619)" id="g7157" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+          <g id="path40901" serif:id="path4090" transform="matrix(0.937497,0,0,0.937497,3174.89,-1895.69)">
+            <path d="m 647.886,76.57 h 14.998 c 6.265,0 11.339,5.074 11.339,11.339 v 34.018 h 4.252 c 10.177,0 18.426,8.249 18.426,18.426 v 39.687 c 0,2.353 1.899,4.252 4.252,4.252 2.353,0 4.252,-1.899 4.252,-4.252 v -63.814 l -8.136,0.029 c -1.559,0.025 -3.121,-0.57 -4.28,-1.814 -2.353,-2.41 -2.353,-6.294 0,-8.703 l 7.2,-7.512 -9.752,-9.781 c -2.721,-2.718 -2.721,-7.112 0,-9.833 2.722,-2.725 7.118,-2.725 9.837,0 l 15.027,14.939 c 2.636,2.579 4.281,6.18 4.281,10.177 v 76.311 c 0,10.177 -8.249,18.426 -18.426,18.426 -10.177,0 -18.426,-8.249 -18.426,-18.426 v -39.687 c 0,-2.353 -1.899,-4.252 -4.252,-4.252 h -4.252 v 62.366 l -0.002,0.001 h 1.417 c 3.912,0 7.087,3.175 7.087,7.087 0,3.912 -3.175,7.087 -7.087,7.087 H 590.6 c -3.912,0 -7.087,-3.175 -7.087,-7.087 0,-3.912 3.175,-7.087 7.087,-7.087 h 1.415 v -32.118 h 30.223 v -33.081 h 31.578 c 3.458,0 6.236,-2.778 6.236,-6.236 V 96.983 c 0,-3.459 -2.778,-6.237 -6.236,-6.237 h -3.589 z m -20.664,14.176 h -4.984 v -5.65 h -29.872 c 1.25,-4.903 5.694,-8.526 10.988,-8.526 h 21.527 z" style="fill:#ffffff;fill-rule:nonzero" id="path7154"/>
           </g>
         </g>
-        <g
-           transform="translate(-6037.4904,3531.3619)"
-           id="g7163"
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-          <g
-             transform="matrix(0.693754,0,0,0.693754,3629.07,-1881.12)"
-             id="g7161">
-            <circle
-               cx="120.985"
-               cy="49.551998"
-               r="23.327999"
-               style="fill:none;stroke:#ffffff;stroke-width:21.62px"
-               id="circle7159" />
+        <g transform="translate(-6037.4904,3531.3619)" id="g7163" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+          <g transform="matrix(0.693754,0,0,0.693754,3629.07,-1881.12)" id="g7161">
+            <circle cx="120.985" cy="49.551998" r="23.327999" style="fill:none;stroke:#ffffff;stroke-width:21.62px" id="circle7159"/>
           </g>
         </g>
-        <g
-           transform="translate(-6037.4904,3531.3619)"
-           id="g7169"
-           style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-          <g
-             transform="matrix(0.693754,0,0,0.693754,3629.07,-1896.23)"
-             id="g7167">
-            <path
-               d="M 120.985,48.005 V 13.595"
-               style="fill:none;stroke:#ffffff;stroke-width:21.62px"
-               id="path7165" />
+        <g transform="translate(-6037.4904,3531.3619)" id="g7169" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+          <g transform="matrix(0.693754,0,0,0.693754,3629.07,-1896.23)" id="g7167">
+            <path d="M 120.985,48.005 V 13.595" style="fill:none;stroke:#ffffff;stroke-width:21.62px" id="path7165"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(3174.813,2721.0467)"
-       id="g21006"
-       style="stroke:#ffffff">
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect21004"
-         style="stroke:none" />
+    <g transform="translate(3174.813,2721.0467)" id="g21006" style="stroke:#ffffff">
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect21004" style="stroke:none"/>
     </g>
-    <g
-       transform="translate(2948.0099,2721.29)"
-       id="g30325">
-      <title
-         id="title30317">follow-icon-filled-circle</title>
-      <g
-         transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)"
-         id="g30321">
-        <path
-           style="color:#000000;fill:#ffffff;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
-           d="m 26.216797,1304.9766 c -6.792768,0 -12.324219,5.5314 -12.324219,12.3242 0,6.7927 5.531451,12.3222 12.324219,12.3222 6.792768,0 12.322265,-5.5295 12.322265,-12.3222 0,-6.7928 -5.529497,-12.3242 -12.322265,-12.3242 z"
-           id="circle30319"
-           sodipodi:nodetypes="sssss" />
+    <g transform="translate(2948.0099,2721.29)" id="g30325">
+      <title id="title30317">follow-icon-filled-circle</title>
+      <g transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)" id="g30321">
+        <path style="color:#000000;fill:#ffffff;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none" d="m 26.216797,1304.9766 c -6.792768,0 -12.324219,5.5314 -12.324219,12.3242 0,6.7927 5.531451,12.3222 12.324219,12.3222 6.792768,0 12.322265,-5.5295 12.322265,-12.3222 0,-6.7928 -5.529497,-12.3242 -12.322265,-12.3242 z" id="circle30319" sodipodi:nodetypes="sssss"/>
       </g>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect30323" />
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect30323"/>
     </g>
-    <g
-       transform="translate(3401.613,2721.0467)"
-       id="g32197">
-      <title
-         id="title32439">manual-flight</title>
-      <rect
-         x="-2494.5"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect32195"
-         style="stroke:none" />
-      <g
-         transform="matrix(5.5783973,0,0,5.5634019,-4792.3655,-9719.4292)"
-         fill="#ffffff"
-         opacity="1"
-         id="g4833-1-4-38">
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="9.8042002"
-           rx="1.8906192"
-           ry="1.8906192"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4825-5-8-1" />
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="12.929"
-           rx="1.9104748"
-           ry="1.9104748"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4827-5-3-9" />
-        <path
-           d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="5.7271"
-           id="path4829-6-3-4"
-           sodipodi:nodetypes="ccc"
-           style="fill:none" />
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="5.6332002"
-           rx="1.8766935"
-           ry="1.8766935"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4831-2-9-1" />
+    <g transform="translate(3401.613,2721.0467)" id="g32197">
+      <title id="title32439">manual-flight</title>
+      <rect x="-2494.5" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect32195" style="stroke:none"/>
+      <g transform="matrix(5.5783973,0,0,5.5634019,-4792.3655,-9719.4292)" fill="#ffffff" opacity="1" id="g4833-1-4-38">
+        <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="1.8906192" ry="1.8906192" fill-opacity="0.32727" opacity="1" id="rect4825-5-8-1"/>
+        <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="1.9104748" ry="1.9104748" fill-opacity="0.32727" opacity="1" id="rect4827-5-3-9"/>
+        <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.7271" id="path4829-6-3-4" sodipodi:nodetypes="ccc" style="fill:none"/>
+        <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="1.8766935" ry="1.8766935" fill-opacity="0.32727" opacity="1" id="rect4831-2-9-1"/>
       </g>
     </g>
-    <g
-       transform="translate(3628.35,2721.29)"
-       id="g32197-8">
-      <title
-         id="title32439-0">manual-flight</title>
-      <rect
-         x="-2494.5"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect32195-6"
-         style="stroke:none" />
-      <g
-         transform="matrix(5.5783973,0,0,5.5634019,-4792.3655,-9719.4292)"
-         fill="#ffffff"
-         opacity="1"
-         id="g4833-1-4-38-1">
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="9.8042002"
-           rx="1.8906192"
-           ry="1.8906192"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4825-5-8-1-5" />
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="12.929"
-           rx="1.9104748"
-           ry="1.9104748"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4827-5-3-9-4" />
-        <path
-           d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="5.7271"
-           id="path4829-6-3-4-2"
-           sodipodi:nodetypes="cccc"
-           style="fill:#ffffff" />
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="5.6332002"
-           rx="1.8766935"
-           ry="1.8766935"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4831-2-9-1-2" />
+    <g transform="translate(3628.35,2721.29)" id="g32197-8">
+      <title id="title32439-0">manual-flight</title>
+      <rect x="-2494.5" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect32195-6" style="stroke:none"/>
+      <g transform="matrix(5.5783973,0,0,5.5634019,-4792.3655,-9719.4292)" fill="#ffffff" opacity="1" id="g4833-1-4-38-1">
+        <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="1.8906192" ry="1.8906192" fill-opacity="0.32727" opacity="1" id="rect4825-5-8-1-5"/>
+        <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="1.9104748" ry="1.9104748" fill-opacity="0.32727" opacity="1" id="rect4827-5-3-9-4"/>
+        <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.7271" id="path4829-6-3-4-2" sodipodi:nodetypes="cccc" style="fill:#ffffff"/>
+        <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="1.8766935" ry="1.8766935" fill-opacity="0.32727" opacity="1" id="rect4831-2-9-1-2"/>
       </g>
     </g>
-    <g
-       transform="translate(3855.0599,2721.26)"
-       id="g34055">
-      <title
-         id="title34047">follow-icon-circle</title>
-      <g
-         transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)"
-         id="g34051">
-        <circle
-           cx="26.216"
-           cy="1317.3"
-           r="11.232"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.1816"
-           id="circle34049"
-           style="stroke:#ffffff;stroke-opacity:0.286275" />
+    <g transform="translate(3855.0599,2721.26)" id="g34055">
+      <title id="title34047">follow-icon-circle</title>
+      <g transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)" id="g34051">
+        <circle cx="26.216" cy="1317.3" r="11.232" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1816" id="circle34049" style="stroke:#ffffff;stroke-opacity:0.286275"/>
       </g>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect34053" />
-      <g
-         transform="matrix(3.716872,0,0,3.7068806,-3760.932,-6995.354)"
-         fill="#ffffff"
-         opacity="1"
-         id="g4833-1-4-3">
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="9.8042002"
-           rx="2.8375001"
-           ry="2.8375001"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4825-5-8-3" />
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="12.929"
-           rx="2.8673"
-           ry="2.8673"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4827-5-3-2" />
-        <path
-           d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="5.7271"
-           id="path4829-6-3-3"
-           sodipodi:nodetypes="ccc"
-           style="fill:none" />
-        <rect
-           x="423.39999"
-           y="1469.1"
-           width="17.68"
-           height="5.6332002"
-           rx="2.8166001"
-           ry="2.8166001"
-           fill-opacity="0.32727"
-           opacity="1"
-           id="rect4831-2-9-6" />
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect34053"/>
+      <g transform="matrix(3.716872,0,0,3.7068806,-3760.932,-6995.354)" fill="#ffffff" opacity="1" id="g4833-1-4-3">
+        <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="2.8375001" ry="2.8375001" fill-opacity="0.32727" opacity="1" id="rect4825-5-8-3"/>
+        <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="2.8673" ry="2.8673" fill-opacity="0.32727" opacity="1" id="rect4827-5-3-2"/>
+        <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.7271" id="path4829-6-3-3" sodipodi:nodetypes="ccc" style="fill:none"/>
+        <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="2.8166001" ry="2.8166001" fill-opacity="0.32727" opacity="1" id="rect4831-2-9-6"/>
       </g>
     </g>
-    <g
-       transform="translate(4081.8369,2721.5037)"
-       id="g38362">
-      <title
-         id="title38354">follow-icon-circle</title>
-      <g
-         transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)"
-         id="g38358">
-        <circle
-           cx="26.216"
-           cy="1317.3"
-           r="11.232"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.1816"
-           id="circle38356"
-           style="stroke:#ffffff;stroke-opacity:0.286275" />
-        <g
-           transform="matrix(0.46163721,0,0,0.46039628,-173.32571,641.6998)"
-           fill="#ffffff"
-           opacity="1"
-           id="g4833-1">
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="9.8042002"
-             rx="2.8375001"
-             ry="2.8375001"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4825-5" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="12.929"
-             rx="2.8673"
-             ry="2.8673"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4827-5" />
-          <path
-             d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z"
-             opacity="1"
-             stroke="#ffffff"
-             stroke-linecap="round"
-             stroke-linejoin="round"
-             stroke-width="5.7271"
-             id="path4829-6" />
-          <rect
-             x="423.39999"
-             y="1469.1"
-             width="17.68"
-             height="5.6332002"
-             rx="2.8166001"
-             ry="2.8166001"
-             fill-opacity="0.32727"
-             opacity="1"
-             id="rect4831-2" />
+    <g transform="translate(4081.8369,2721.5037)" id="g38362">
+      <title id="title38354">follow-icon-circle</title>
+      <g transform="matrix(8.0515,0,0,8.0515,-2365.4,-12162)" id="g38358">
+        <circle cx="26.216" cy="1317.3" r="11.232" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1816" id="circle38356" style="stroke:#ffffff;stroke-opacity:0.286275"/>
+        <g transform="matrix(0.46163721,0,0,0.46039628,-173.32571,641.6998)" fill="#ffffff" opacity="1" id="g4833-1">
+          <rect x="423.39999" y="1469.1" width="17.68" height="9.8042002" rx="2.8375001" ry="2.8375001" fill-opacity="0.32727" opacity="1" id="rect4825-5"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="12.929" rx="2.8673" ry="2.8673" fill-opacity="0.32727" opacity="1" id="rect4827-5"/>
+          <path d="m 424.87,1464.5 7.3779,-8.8015 7.3779,8.8015 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5.7271" id="path4829-6"/>
+          <rect x="423.39999" y="1469.1" width="17.68" height="5.6332002" rx="2.8166001" ry="2.8166001" fill-opacity="0.32727" opacity="1" id="rect4831-2"/>
         </g>
       </g>
-      <rect
-         x="-2267.7"
-         y="-1668.9"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect38360" />
+      <rect x="-2267.7" y="-1668.9" width="226.77" height="226.77" fill="none" opacity="1" id="rect38360"/>
     </g>
-    <g
-       id="g17133"
-       transform="translate(453.56997,-8.2617312e-5)">
-      <g
-         transform="matrix(8.0515,0,0,8.0515,1489.6599,-9440.7399)"
-         id="g39307">
-        <circle
-           cx="26.216"
-           cy="1317.3"
-           r="11.232"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.1816"
-           id="circle39303"
-           style="stroke:#ffffff;stroke-opacity:0.286275" />
-        <path
-           d="m 23.132874,1314.5184 -0.05083,-4.0522 6.862653,4.0522 z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.64029"
-           id="path4829-6-1"
-           sodipodi:nodetypes="cccc"
-           style="fill:#ffffff" />
-        <path
-           d="m 21.46796,1324.1169 h 9.769901 z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="2.14552"
-           id="path4829-6-1-5"
-           sodipodi:nodetypes="ccc"
-           style="fill:#ffffff" />
-        <g
-           id="rect4827-5-5-6-7"
-           transform="matrix(1.0106168,0,0,1.0106168,-3.6578507,-15.926999)">
-          <path
-             style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-linejoin:round;-inkscape-stroke:none"
-             d="m 26.663883,1318.5508 c -0.496167,0 -0.788341,0.5575 -0.507813,0.9668 l 3.208984,4.6836 c 0.245264,0.3586 0.774268,0.3586 1.019532,0 l 3.210937,-4.6836 c 0.281027,-0.41 -0.01271,-0.9671 -0.509765,-0.9668 z"
-             id="path29481-0"
-             sodipodi:nodetypes="ccccccc" />
-          <path
-             style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-width:0.710355;stroke-linejoin:round;-inkscape-stroke:none"
-             d="m 27.594199,1318.5508 c -0.352455,0 -0.560002,0.396 -0.360728,0.6868 l 2.279518,3.327 c 0.174225,0.2547 0.550006,0.2547 0.72423,0 l 2.280905,-3.327 c 0.199629,-0.2913 -0.009,-0.687 -0.362114,-0.6868 z"
-             id="path30053-8"
-             sodipodi:nodetypes="ccccccc" />
-          <path
-             style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-width:0.43197;stroke-linejoin:round;-inkscape-stroke:none"
-             d="m 28.48835,1318.5508 c -0.214329,0 -0.34054,0.2408 -0.21936,0.4176 l 1.386184,2.0232 c 0.105947,0.1549 0.334461,0.1549 0.440408,0 l 1.387028,-2.0232 c 0.121395,-0.1771 -0.0055,-0.4177 -0.220203,-0.4176 z"
-             id="path30157-8"
-             sodipodi:nodetypes="ccccccc" />
+    <g id="g17133" transform="translate(453.56997,-8.2617312e-5)">
+      <g transform="matrix(8.0515,0,0,8.0515,1489.6599,-9440.7399)" id="g39307">
+        <circle cx="26.216" cy="1317.3" r="11.232" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.1816" id="circle39303" style="stroke:#ffffff;stroke-opacity:0.286275"/>
+        <path d="m 23.132874,1314.5184 -0.05083,-4.0522 6.862653,4.0522 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.64029" id="path4829-6-1" sodipodi:nodetypes="cccc" style="fill:#ffffff"/>
+        <path d="m 21.46796,1324.1169 h 9.769901 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.14552" id="path4829-6-1-5" sodipodi:nodetypes="ccc" style="fill:#ffffff"/>
+        <g id="rect4827-5-5-6-7" transform="matrix(1.0106168,0,0,1.0106168,-3.6578507,-15.926999)">
+          <path style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-linejoin:round;-inkscape-stroke:none" d="m 26.663883,1318.5508 c -0.496167,0 -0.788341,0.5575 -0.507813,0.9668 l 3.208984,4.6836 c 0.245264,0.3586 0.774268,0.3586 1.019532,0 l 3.210937,-4.6836 c 0.281027,-0.41 -0.01271,-0.9671 -0.509765,-0.9668 z" id="path29481-0" sodipodi:nodetypes="ccccccc"/>
+          <path style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-width:0.710355;stroke-linejoin:round;-inkscape-stroke:none" d="m 27.594199,1318.5508 c -0.352455,0 -0.560002,0.396 -0.360728,0.6868 l 2.279518,3.327 c 0.174225,0.2547 0.550006,0.2547 0.72423,0 l 2.280905,-3.327 c 0.199629,-0.2913 -0.009,-0.687 -0.362114,-0.6868 z" id="path30053-8" sodipodi:nodetypes="ccccccc"/>
+          <path style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-width:0.43197;stroke-linejoin:round;-inkscape-stroke:none" d="m 28.48835,1318.5508 c -0.214329,0 -0.34054,0.2408 -0.21936,0.4176 l 1.386184,2.0232 c 0.105947,0.1549 0.334461,0.1549 0.440408,0 l 1.387028,-2.0232 c 0.121395,-0.1771 -0.0055,-0.4177 -0.220203,-0.4176 z" id="path30157-8" sodipodi:nodetypes="ccccccc"/>
         </g>
       </g>
-      <rect
-         x="1587.36"
-         y="1052.3601"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect39309" />
+      <rect x="1587.36" y="1052.3601" width="226.77" height="226.77" fill="none" opacity="1" id="rect39309"/>
     </g>
-    <rect
-       x="1814.13"
-       y="1052.36"
-       width="226.77"
-       height="226.77"
-       fill="none"
-       opacity="1"
-       id="rect39309-4"
-       style="fill:none;stroke:none" />
-    <g
-       id="g13740"
-       transform="translate(-680.45004,0.02000732)">
-      <rect
-         x="2041.0302"
-         y="1052.37"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect39309-4-7"
-         style="fill:none;stroke:none" />
-      <g
-         id="g13694"
-         transform="matrix(1.4833142,0,0,1.4833142,-1076.3987,-545.74737)">
-        <path
-           d="m 2152.1787,1132.5042 -0.4092,-32.6263 55.2546,32.6263 z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="21.2583"
-           id="path4829-6-1-0"
-           sodipodi:nodetypes="cccc"
-           style="fill:#ffffff" />
-        <path
-           d="m 2138.7737,1209.7865 h 78.6623 z"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="17.2747"
-           id="path4829-6-1-5-1"
-           sodipodi:nodetypes="ccc"
-           style="fill:#ffffff" />
-        <g
-           id="g11371-4"
-           transform="matrix(8.0515,0,0,8.0515,1966.4423,-9466.6189)">
-          <g
-             id="rect4827-5-5-6"
-             transform="translate(-3.4269286)">
-            <path
-               style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-linejoin:round;-inkscape-stroke:none"
-               d="m 26.663883,1318.5508 c -0.496167,0 -0.788341,0.5575 -0.507813,0.9668 l 3.208984,4.6836 c 0.245264,0.3586 0.774268,0.3586 1.019532,0 l 3.210937,-4.6836 c 0.281027,-0.41 -0.01271,-0.9671 -0.509765,-0.9668 z"
-               id="path29481"
-               sodipodi:nodetypes="ccccccc" />
-            <path
-               style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-width:0.710355;stroke-linejoin:round;-inkscape-stroke:none"
-               d="m 27.594199,1318.5508 c -0.352455,0 -0.560002,0.396 -0.360728,0.6868 l 2.279518,3.327 c 0.174225,0.2547 0.550006,0.2547 0.72423,0 l 2.280905,-3.327 c 0.199629,-0.2913 -0.009,-0.687 -0.362114,-0.6868 z"
-               id="path30053"
-               sodipodi:nodetypes="ccccccc" />
-            <path
-               style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-width:0.43197;stroke-linejoin:round;-inkscape-stroke:none"
-               d="m 28.48835,1318.5508 c -0.214329,0 -0.34054,0.2408 -0.21936,0.4176 l 1.386184,2.0232 c 0.105947,0.1549 0.334461,0.1549 0.440408,0 l 1.387028,-2.0232 c 0.121395,-0.1771 -0.0055,-0.4177 -0.220203,-0.4176 z"
-               id="path30157"
-               sodipodi:nodetypes="ccccccc" />
+    <rect x="1814.13" y="1052.36" width="226.77" height="226.77" fill="none" opacity="1" id="rect39309-4" style="fill:none;stroke:none"/>
+    <g id="g13740" transform="translate(-680.45004,0.02000732)">
+      <rect x="2041.0302" y="1052.37" width="226.77" height="226.77" fill="none" opacity="1" id="rect39309-4-7" style="fill:none;stroke:none"/>
+      <g id="g13694" transform="matrix(1.4833142,0,0,1.4833142,-1076.3987,-545.74737)">
+        <path d="m 2152.1787,1132.5042 -0.4092,-32.6263 55.2546,32.6263 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="21.2583" id="path4829-6-1-0" sodipodi:nodetypes="cccc" style="fill:#ffffff"/>
+        <path d="m 2138.7737,1209.7865 h 78.6623 z" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="17.2747" id="path4829-6-1-5-1" sodipodi:nodetypes="ccc" style="fill:#ffffff"/>
+        <g id="g11371-4" transform="matrix(8.0515,0,0,8.0515,1966.4423,-9466.6189)">
+          <g id="rect4827-5-5-6" transform="translate(-3.4269286)">
+            <path style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-linejoin:round;-inkscape-stroke:none" d="m 26.663883,1318.5508 c -0.496167,0 -0.788341,0.5575 -0.507813,0.9668 l 3.208984,4.6836 c 0.245264,0.3586 0.774268,0.3586 1.019532,0 l 3.210937,-4.6836 c 0.281027,-0.41 -0.01271,-0.9671 -0.509765,-0.9668 z" id="path29481" sodipodi:nodetypes="ccccccc"/>
+            <path style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-width:0.710355;stroke-linejoin:round;-inkscape-stroke:none" d="m 27.594199,1318.5508 c -0.352455,0 -0.560002,0.396 -0.360728,0.6868 l 2.279518,3.327 c 0.174225,0.2547 0.550006,0.2547 0.72423,0 l 2.280905,-3.327 c 0.199629,-0.2913 -0.009,-0.687 -0.362114,-0.6868 z" id="path30053" sodipodi:nodetypes="ccccccc"/>
+            <path style="color:#000000;fill:#ffffff;fill-opacity:0.32549;stroke:none;stroke-width:0.43197;stroke-linejoin:round;-inkscape-stroke:none" d="m 28.48835,1318.5508 c -0.214329,0 -0.34054,0.2408 -0.21936,0.4176 l 1.386184,2.0232 c 0.105947,0.1549 0.334461,0.1549 0.440408,0 l 1.387028,-2.0232 c 0.121395,-0.1771 -0.0055,-0.4177 -0.220203,-0.4176 z" id="path30157" sodipodi:nodetypes="ccccccc"/>
           </g>
         </g>
       </g>
     </g>
-    <rect
-       x="-2645.1416"
-       y="1975.8395"
-       width="2721.3657"
-       height="4079.8105"
-       style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke-width:1.35432;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
-       id="rect2530" />
-    <g
-       transform="translate(-3401.4901,680.34027)"
-       id="g5983"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="g6948-3"
-         transform="translate(-226.77,2.6416e-5)">
-        <path
-           id="rect6929-7"
-           d="m 3855.07,598.82 c 0,0 0,0 0,0 H 3628.3 c 0,0 0,0 0,0 v 226.77 c 0,0 0,0 0,0 h 226.77 c 0,0 0,0 0,0 z"
-           style="fill:none" />
-        <g
-           id="g2866-4"
-           transform="matrix(0.635682,0,0,0.669119,1363.18,273.133)">
-          <rect
-             id="rect6931-8"
-             x="3656.7"
-             y="644.88"
-             width="28.346001"
-             height="134.64999"
-             style="fill:#ffffff" />
-          <rect
-             id="rect6933-9"
-             x="3798.3999"
-             y="644.88"
-             width="28.346001"
-             height="134.64999"
-             style="fill:#ffffff" />
-          <g
-             id="rect6935-2"
-             transform="rotate(90)">
-            <rect
-               x="644.88"
-               y="-3791.1001"
-               width="24.802999"
-               height="98.799004"
-               style="fill:#ffffff"
-               id="rect5947" />
+    <rect x="-2645.1416" y="1975.8395" width="2721.3657" height="4079.8105" style="clip-rule:evenodd;fill:none;fill-rule:evenodd;stroke-width:1.35432;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5" id="rect2530"/>
+    <g transform="translate(-3401.4901,680.34027)" id="g5983" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="g6948-3" transform="translate(-226.77,2.6416e-5)">
+        <path id="rect6929-7" d="m 3855.07,598.82 c 0,0 0,0 0,0 H 3628.3 c 0,0 0,0 0,0 v 226.77 c 0,0 0,0 0,0 h 226.77 c 0,0 0,0 0,0 z" style="fill:none"/>
+        <g id="g2866-4" transform="matrix(0.635682,0,0,0.669119,1363.18,273.133)">
+          <rect id="rect6931-8" x="3656.7" y="644.88" width="28.346001" height="134.64999" style="fill:#ffffff"/>
+          <rect id="rect6933-9" x="3798.3999" y="644.88" width="28.346001" height="134.64999" style="fill:#ffffff"/>
+          <g id="rect6935-2" transform="rotate(90)">
+            <rect x="644.88" y="-3791.1001" width="24.802999" height="98.799004" style="fill:#ffffff" id="rect5947"/>
           </g>
-          <g
-             id="rect6937-2"
-             transform="rotate(90)">
-            <rect
-               x="754.71997"
-               y="-3791.1001"
-               width="24.802999"
-               height="98.800003"
-               style="fill:#ffffff"
-               id="rect5950" />
+          <g id="rect6937-2" transform="rotate(90)">
+            <rect x="754.71997" y="-3791.1001" width="24.802999" height="98.800003" style="fill:#ffffff" id="rect5950"/>
           </g>
-          <g
-             id="path6939-7"
-             transform="matrix(0.9375,0,0,0.9375,0,-2576)">
-            <path
-               d="m 3952.3,3471.8 33.86,18.57 h 57.64 v -18.57 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path5953" />
+          <g id="path6939-7" transform="matrix(0.9375,0,0,0.9375,0,-2576)">
+            <path d="m 3952.3,3471.8 33.86,18.57 h 57.64 v -18.57 z" style="fill:#ffffff;fill-rule:nonzero" id="path5953"/>
           </g>
-          <g
-             id="path6941-5"
-             transform="matrix(0.9375,0,0,0.9375,0,-2576)">
-            <path
-               d="m 3939.2,3495.8 v 23.28 h 43.79 l -40.59,-23.28 z m 55.07,0 40.58,23.28 h 8.76 v -23.28 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path5956" />
+          <g id="path6941-5" transform="matrix(0.9375,0,0,0.9375,0,-2576)">
+            <path d="m 3939.2,3495.8 v 23.28 h 43.79 l -40.59,-23.28 z m 55.07,0 40.58,23.28 h 8.76 v -23.28 z" style="fill:#ffffff;fill-rule:nonzero" id="path5956"/>
           </g>
-          <g
-             id="path6943-0"
-             transform="matrix(0.9375,0,0,0.9375,0,-2576)">
-            <path
-               d="m 3938.8,3524.4 v 19.8 h 89.62 l -36.03,-19.8 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path5959-8" />
+          <g id="path6943-0" transform="matrix(0.9375,0,0,0.9375,0,-2576)">
+            <path d="m 3938.8,3524.4 v 19.8 h 89.62 l -36.03,-19.8 z" style="fill:#ffffff;fill-rule:nonzero" id="path5959-8"/>
           </g>
-          <g
-             id="rect6945-2"
-             transform="matrix(0,1,-0.86748,-0.49747,0,0)">
-            <rect
-               x="-1439.2"
-               y="-4371.2002"
-               width="13.228"
-               height="115.61"
-               style="fill:#ffffff"
-               id="rect5962" />
+          <g id="rect6945-2" transform="matrix(0,1,-0.86748,-0.49747,0,0)">
+            <rect x="-1439.2" y="-4371.2002" width="13.228" height="115.61" style="fill:#ffffff" id="rect5962"/>
           </g>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,3628.3,626.934)"
-           id="g5968">
-          <path
-             d="m 48.826,130.202 -20.547,-9.246 13,-79.623 h 56.378"
-             style="fill:none;stroke:#ffffff;stroke-width:16px"
-             id="path5966" />
+        <g transform="matrix(0.937497,0,0,0.937497,3628.3,626.934)" id="g5968">
+          <path d="m 48.826,130.202 -20.547,-9.246 13,-79.623 h 56.378" style="fill:none;stroke:#ffffff;stroke-width:16px" id="path5966"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,3628.3,626.934)"
-           id="g5972">
-          <path
-             d="m 144.313,41.333 h 56.297 l 13,79.599 -20.547,9.27"
-             style="fill:none;stroke:#ffffff;stroke-width:16px"
-             id="path5970" />
+        <g transform="matrix(0.937497,0,0,0.937497,3628.3,626.934)" id="g5972">
+          <path d="m 144.313,41.333 h 56.297 l 13,79.599 -20.547,9.27" style="fill:none;stroke:#ffffff;stroke-width:16px" id="path5970"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,3628.3,619.229)"
-           id="g5976">
-          <circle
-             cx="120.985"
-             cy="49.551998"
-             r="23.327999"
-             style="fill:none;stroke:#ffffff;stroke-width:16px"
-             id="circle5974" />
+        <g transform="matrix(0.937497,0,0,0.937497,3628.3,619.229)" id="g5976">
+          <circle cx="120.985" cy="49.551998" r="23.327999" style="fill:none;stroke:#ffffff;stroke-width:16px" id="circle5974"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,3628.3,598.81)"
-           id="g5980">
-          <path
-             d="M 120.985,48.005 V 13.595"
-             style="fill:none;stroke:#ffffff;stroke-width:16px"
-             id="path5978" />
+        <g transform="matrix(0.937497,0,0,0.937497,3628.3,598.81)" id="g5980">
+          <path d="M 120.985,48.005 V 13.595" style="fill:none;stroke:#ffffff;stroke-width:16px" id="path5978"/>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(881.9067,1347.7184)"
-       id="g6003-3"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Guided-4"
-         transform="matrix(7.08499,0,0,7.08499,-1328.89,-3421.38)">
-        <g
-           id="g6217-6"
-           transform="matrix(0,0.40132,-0.326991,0,262.059,464.22)">
-          <rect
-             id="rect6215-7"
-             x="102.18"
-             y="412.70001"
-             width="79.737"
-             height="97.834999"
-             style="fill-opacity:0" />
+    <g transform="translate(881.9067,1347.7184)" id="g6003-3" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Guided-4" transform="matrix(7.08499,0,0,7.08499,-1328.89,-3421.38)">
+        <g id="g6217-6" transform="matrix(0,0.40132,-0.326991,0,262.059,464.22)">
+          <rect id="rect6215-7" x="102.18" y="412.70001" width="79.737" height="97.834999" style="fill-opacity:0"/>
         </g>
-        <g
-           id="g6239-4"
-           transform="matrix(0,1.2845,-1.2845,0,719.29,466.75)">
-          <g
-             id="g6221-9"
-             transform="matrix(0.0698245,0,0,0.39432,32.4925,279.9)">
-            <path
-               id="path6219-9"
-               d="m 181.92,479.714 c 0,-12.06 -26.579,-13.06 -39.868,-13.06 -13.29,0 -39.869,1 -39.869,13.06 v 26.781 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z"
-               style="fill:#ffffff" />
+        <g id="g6239-4" transform="matrix(0,1.2845,-1.2845,0,719.29,466.75)">
+          <g id="g6221-9" transform="matrix(0.0698245,0,0,0.39432,32.4925,279.9)">
+            <path id="path6219-9" d="m 181.92,479.714 c 0,-12.06 -26.579,-13.06 -39.868,-13.06 -13.29,0 -39.869,1 -39.869,13.06 v 26.781 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z" style="fill:#ffffff"/>
           </g>
-          <g
-             id="g6225-5"
-             transform="matrix(1,0,0,1.3667,0,-179.55)">
-            <path
-               id="path6223-2"
-               d="m 41.471,483.32 c 0.144,-0.289 0.52,-0.481 0.94,-0.481 0.421,0 0.797,0.192 0.941,0.481 0.54,1.086 1.113,2.235 1.113,2.235 h -4.107 c 0,0 0.572,-1.149 1.113,-2.235 z"
-               style="fill:#ffffff" />
+          <g id="g6225-5" transform="matrix(1,0,0,1.3667,0,-179.55)">
+            <path id="path6223-2" d="m 41.471,483.32 c 0.144,-0.289 0.52,-0.481 0.94,-0.481 0.421,0 0.797,0.192 0.941,0.481 0.54,1.086 1.113,2.235 1.113,2.235 h -4.107 c 0,0 0.572,-1.149 1.113,-2.235 z" style="fill:#ffffff"/>
           </g>
-          <g
-             transform="matrix(0.630569,0,0,0.56491,15.6682,141.73)"
-             id="g5993">
-            <g
-               id="g6237-7">
-              <path
-                 id="path6235-5"
-                 d="m 42.411,583.12 7.134,14.268 H 35.278 Z"
-                 style="fill:#ffffff" />
+          <g transform="matrix(0.630569,0,0,0.56491,15.6682,141.73)" id="g5993">
+            <g id="g6237-7">
+              <path id="path6235-5" d="m 42.411,583.12 7.134,14.268 H 35.278 Z" style="fill:#ffffff"/>
             </g>
           </g>
-          <g
-             transform="matrix(0.459602,0,0,1.45156,22.9192,-204.613)"
-             id="g5997-9">
-            <g
-               id="g6229-8">
-              <rect
-                 id="rect6227-3"
-                 x="38.410999"
-                 y="463.29999"
-                 width="8"
-                 height="0.82499999" />
+          <g transform="matrix(0.459602,0,0,1.45156,22.9192,-204.613)" id="g5997-9">
+            <g id="g6229-8">
+              <rect id="rect6227-3" x="38.410999" y="463.29999" width="8" height="0.82499999"/>
             </g>
           </g>
-          <g
-             id="g6233-4"
-             transform="matrix(0.459602,0,0,1.45156,22.9192,-202.261)">
-            <rect
-               id="rect6231-1"
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999" />
+          <g id="g6233-4" transform="matrix(0.459602,0,0,1.45156,22.9192,-202.261)">
+            <rect id="rect6231-1" x="38.410999" y="463.29999" width="8" height="0.82499999"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(881.9067,1347.7184)"
-       id="g6023"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Naval-9"
-         transform="matrix(7.08499,0,0,7.08499,-891.109,-4323.9)">
-        <g
-           id="g6244-1"
-           transform="matrix(0,0.40132,-0.327169,0,264.36,591.57)">
-          <rect
-             id="rect6242-6"
-             x="102.18"
-             y="412.70001"
-             width="79.737"
-             height="97.834999"
-             style="fill-opacity:0" />
+    <g transform="translate(881.9067,1347.7184)" id="g6023" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Naval-9" transform="matrix(7.08499,0,0,7.08499,-891.109,-4323.9)">
+        <g id="g6244-1" transform="matrix(0,0.40132,-0.327169,0,264.36,591.57)">
+          <rect id="rect6242-6" x="102.18" y="412.70001" width="79.737" height="97.834999" style="fill-opacity:0"/>
         </g>
-        <g
-           id="g6262-2"
-           transform="matrix(0,1.279,-1.279,0,718.84,594.33)">
-          <g
-             transform="matrix(0.0689626,0,0,0.172811,32.6148,392.987)"
-             id="g6009-2">
-            <g
-               id="g6248-1">
-              <path
-                 id="path6246-0"
-                 d="m 181.92,448.23 c 0,-12.059 -39.868,-39.139 -39.868,-39.139 0,0 -39.869,27.08 -39.869,39.139 v 58.265 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z"
-                 style="fill:#ffffff" />
+        <g id="g6262-2" transform="matrix(0,1.279,-1.279,0,718.84,594.33)">
+          <g transform="matrix(0.0689626,0,0,0.172811,32.6148,392.987)" id="g6009-2">
+            <g id="g6248-1">
+              <path id="path6246-0" d="m 181.92,448.23 c 0,-12.059 -39.868,-39.139 -39.868,-39.139 0,0 -39.869,27.08 -39.869,39.139 v 58.265 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z" style="fill:#ffffff"/>
             </g>
           </g>
-          <g
-             id="g6252-2"
-             transform="matrix(1,0,0,1.3667,0,-179.55)">
-            <path
-               id="path6250-8"
-               d="m 41.467,483.33 c 0.145,-0.29 0.522,-0.483 0.944,-0.483 0.423,0 0.8,0.193 0.945,0.483 0.539,1.083 1.109,2.227 1.109,2.227 h -4.107 c 0,0 0.57,-1.144 1.109,-2.227 z"
-               style="fill:#ffffff" />
+          <g id="g6252-2" transform="matrix(1,0,0,1.3667,0,-179.55)">
+            <path id="path6250-8" d="m 41.467,483.33 c 0.145,-0.29 0.522,-0.483 0.944,-0.483 0.423,0 0.8,0.193 0.945,0.483 0.539,1.083 1.109,2.227 1.109,2.227 h -4.107 c 0,0 0.57,-1.144 1.109,-2.227 z" style="fill:#ffffff"/>
           </g>
-          <g
-             transform="matrix(0.389646,0,0,0.398655,26.466,216.784)"
-             id="g6015-5">
-            <g
-               id="g6256-2">
-              <rect
-                 id="rect6254-9"
-                 x="30.594"
-                 y="648.10999"
-                 width="20.655001"
-                 height="9.3050003"
-                 style="fill:#ffffff" />
+          <g transform="matrix(0.389646,0,0,0.398655,26.466,216.784)" id="g6015-5">
+            <g id="g6256-2">
+              <rect id="rect6254-9" x="30.594" y="648.10999" width="20.655001" height="9.3050003" style="fill:#ffffff"/>
             </g>
           </g>
-          <g
-             transform="matrix(0.389646,0,0,0.245377,26.466,310.859)"
-             id="g6019">
-            <g
-               id="g6260-7">
-              <rect
-                 id="rect6258-5"
-                 x="30.594"
-                 y="648.10999"
-                 width="20.655001"
-                 height="9.3050003"
-                 style="fill:#ffffff" />
+          <g transform="matrix(0.389646,0,0,0.245377,26.466,310.859)" id="g6019">
+            <g id="g6260-7">
+              <rect id="rect6258-5" x="30.594" y="648.10999" width="20.655001" height="9.3050003" style="fill:#ffffff"/>
             </g>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(881.9067,1347.7184)"
-       id="g6035-5"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Dumb-0"
-         transform="matrix(7.08499,0,0,7.08499,-1558.06,-3066.57)">
-        <g
-           id="g6267-5"
-           transform="matrix(0,0.40132,-0.327169,0,262.47,414.15)">
-          <rect
-             id="rect6265-5"
-             x="102.18"
-             y="412.70001"
-             width="79.737"
-             height="97.834999"
-             style="fill-opacity:0" />
+    <g transform="translate(881.9067,1347.7184)" id="g6035-5" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Dumb-0" transform="matrix(7.08499,0,0,7.08499,-1558.06,-3066.57)">
+        <g id="g6267-5" transform="matrix(0,0.40132,-0.327169,0,262.47,414.15)">
+          <rect id="rect6265-5" x="102.18" y="412.70001" width="79.737" height="97.834999" style="fill-opacity:0"/>
         </g>
-        <g
-           id="g6277-9"
-           transform="matrix(0,1.2834,-1.2834,0,719.11,416.72)">
-          <g
-             transform="matrix(0.0694734,0,0,0.167658,32.5422,395.626)"
-             id="g6029">
-            <g
-               id="g6271-4">
-              <path
-                 id="path6269-5"
-                 d="m 181.92,419.545 c 0,-1.404 -4.645,-6.849 -10.366,-6.849 h -59.005 c -5.721,0 -10.366,5.445 -10.366,6.849 v 85.982 c 0,1.404 4.645,5.004 10.366,5.004 h 59.005 c 5.721,0 10.366,-3.6 10.366,-5.004 z"
-                 style="fill:#ffffff" />
+        <g id="g6277-9" transform="matrix(0,1.2834,-1.2834,0,719.11,416.72)">
+          <g transform="matrix(0.0694734,0,0,0.167658,32.5422,395.626)" id="g6029">
+            <g id="g6271-4">
+              <path id="path6269-5" d="m 181.92,419.545 c 0,-1.404 -4.645,-6.849 -10.366,-6.849 h -59.005 c -5.721,0 -10.366,5.445 -10.366,6.849 v 85.982 c 0,1.404 4.645,5.004 10.366,5.004 h 59.005 c 5.721,0 10.366,-3.6 10.366,-5.004 z" style="fill:#ffffff"/>
             </g>
           </g>
-          <g
-             id="g6275-0"
-             transform="matrix(1,0,0,1.3667,0,-179.55)">
-            <path
-               id="path6273-5"
-               d="m 42.411,481.43 2.054,4.123 h -4.107 z"
-               style="fill:#ffffff" />
+          <g id="g6275-0" transform="matrix(1,0,0,1.3667,0,-179.55)">
+            <path id="path6273-5" d="m 42.411,481.43 2.054,4.123 h -4.107 z" style="fill:#ffffff"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(881.9067,1347.7184)"
-       id="g6057"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Smart-0"
-         transform="matrix(7.08499,0,0,7.08499,-1117.89,-3898.28)">
-        <g
-           id="g6282-4"
-           transform="matrix(0,0.40132,-0.327169,0,264.36,531.54)">
-          <rect
-             id="rect6280-5"
-             x="102.18"
-             y="412.70001"
-             width="79.737"
-             height="97.834999"
-             style="fill-opacity:0" />
+    <g transform="translate(881.9067,1347.7184)" id="g6057" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Smart-0" transform="matrix(7.08499,0,0,7.08499,-1117.89,-3898.28)">
+        <g id="g6282-4" transform="matrix(0,0.40132,-0.327169,0,264.36,531.54)">
+          <rect id="rect6280-5" x="102.18" y="412.70001" width="79.737" height="97.834999" style="fill-opacity:0"/>
         </g>
-        <g
-           id="g6308-2"
-           transform="matrix(0,1.279,-1.279,0,718.84,534.26)">
-          <g
-             transform="matrix(0.0729099,0,0,0.163768,32.0541,397.604)"
-             id="g6041">
-            <g
-               id="g6286-8">
-              <path
-                 id="path6284-2"
-                 d="m 181.92,436.587 c 0,-12.059 -26.579,-27.496 -39.868,-27.496 -13.29,0 -39.869,15.437 -39.869,27.496 v 69.908 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z"
-                 style="fill:#ffffff" />
+        <g id="g6308-2" transform="matrix(0,1.279,-1.279,0,718.84,534.26)">
+          <g transform="matrix(0.0729099,0,0,0.163768,32.0541,397.604)" id="g6041">
+            <g id="g6286-8">
+              <path id="path6284-2" d="m 181.92,436.587 c 0,-12.059 -26.579,-27.496 -39.868,-27.496 -13.29,0 -39.869,15.437 -39.869,27.496 v 69.908 c 0,2.227 4.645,4.036 10.366,4.036 h 59.005 c 5.721,0 10.366,-1.809 10.366,-4.036 z" style="fill:#ffffff"/>
             </g>
           </g>
-          <g
-             id="g6290-6"
-             transform="matrix(1,0,0,1.3667,0,-179.55)">
-            <path
-               id="path6288-1"
-               d="m 41.467,483.33 c 0.145,-0.29 0.522,-0.483 0.944,-0.483 0.423,0 0.8,0.193 0.945,0.483 0.539,1.083 1.109,2.227 1.109,2.227 h -4.107 c 0,0 0.57,-1.144 1.109,-2.227 z"
-               style="fill:#ffffff" />
+          <g id="g6290-6" transform="matrix(1,0,0,1.3667,0,-179.55)">
+            <path id="path6288-1" d="m 41.467,483.33 c 0.145,-0.29 0.522,-0.483 0.944,-0.483 0.423,0 0.8,0.193 0.945,0.483 0.539,1.083 1.109,2.227 1.109,2.227 h -4.107 c 0,0 0.57,-1.144 1.109,-2.227 z" style="fill:#ffffff"/>
           </g>
-          <g
-             transform="matrix(0.637089,0,0,0.417838,15.3917,229.257)"
-             id="g6047">
-            <g
-               id="g6306-1">
-              <path
-                 id="path6304-6"
-                 d="m 42.411,583.12 c 2.378,4.756 4.756,9.512 7.134,14.268 H 35.278 Z"
-                 style="fill:#ffffff" />
+          <g transform="matrix(0.637089,0,0,0.417838,15.3917,229.257)" id="g6047">
+            <g id="g6306-1">
+              <path id="path6304-6" d="m 42.411,583.12 c 2.378,4.756 4.756,9.512 7.134,14.268 H 35.278 Z" style="fill:#ffffff"/>
             </g>
           </g>
-          <g
-             id="g6294-7"
-             transform="matrix(0.476247,0,0,1.21265,22.2132,-93.9649)">
-            <rect
-               id="rect6292-7"
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999" />
+          <g id="g6294-7" transform="matrix(0.476247,0,0,1.21265,22.2132,-93.9649)">
+            <rect id="rect6292-7" x="38.410999" y="463.29999" width="8" height="0.82499999"/>
           </g>
-          <g
-             id="g6298-6"
-             transform="matrix(0.476247,0,0,1.21265,22.2132,-91.9999)">
-            <rect
-               id="rect6296-3"
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999" />
+          <g id="g6298-6" transform="matrix(0.476247,0,0,1.21265,22.2132,-91.9999)">
+            <rect id="rect6296-3" x="38.410999" y="463.29999" width="8" height="0.82499999"/>
           </g>
-          <g
-             id="g6302-6"
-             transform="matrix(0.476247,0,0,1.21265,22.2132,-89.9149)">
-            <rect
-               id="rect6300-7"
-               x="38.410999"
-               y="463.29999"
-               width="8"
-               height="0.82499999" />
+          <g id="g6302-6" transform="matrix(0.476247,0,0,1.21265,22.2132,-89.9149)">
+            <rect id="rect6300-7" x="38.410999" y="463.29999" width="8" height="0.82499999"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6124"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Laser">
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6061">
-          <path
-             d="M 18.766,362.85 H 131.935"
-             style="fill:none;stroke:#ffffff;stroke-width:15.01px"
-             id="path6059-4" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6124" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Laser">
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6061">
+          <path d="M 18.766,362.85 H 131.935" style="fill:none;stroke:#ffffff;stroke-width:15.01px" id="path6059-4"/>
         </g>
-        <g
-           transform="matrix(1.13883,-9.08907e-4,0,0.545706,-154.099,-41.7945)"
-           id="g6065-6">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6063" />
+        <g transform="matrix(1.13883,-9.08907e-4,0,0.545706,-154.099,-41.7945)" id="g6065-6">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6063"/>
         </g>
-        <g
-           transform="matrix(0.488631,0,0,0.234142,101.85,88.9121)"
-           id="g6069">
-          <path
-             d="m 171.45,362.85 h 94.82"
-             style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-             id="path6067" />
+        <g transform="matrix(0.488631,0,0,0.234142,101.85,88.9121)" id="g6069">
+          <path d="m 171.45,362.85 h 94.82" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6067"/>
         </g>
-        <g
-           transform="matrix(0.423167,-0.117071,0.244315,0.202773,21.1182,114.454)"
-           id="g6073">
-          <path
-             d="m 171.45,362.85 h 53.108"
-             style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-             id="path6071-4" />
+        <g transform="matrix(0.423167,-0.117071,0.244315,0.202773,21.1182,114.454)" id="g6073">
+          <path d="m 171.45,362.85 h 53.108" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6071-4"/>
         </g>
-        <g
-           transform="matrix(0.423167,-0.117071,0.244315,0.202773,21.1182,114.454)"
-           id="g6077-7">
-          <path
-             d="m 262.725,362.85 h 26.026"
-             style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-             id="path6075" />
+        <g transform="matrix(0.423167,-0.117071,0.244315,0.202773,21.1182,114.454)" id="g6077-7">
+          <path d="m 262.725,362.85 h 26.026" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6075"/>
         </g>
-        <g
-           transform="matrix(0.244315,-0.202968,0.423167,0.116733,-22.146,155.949)"
-           id="g6081">
-          <path
-             d="m 171.45,362.85 h 43.106"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6079" />
+        <g transform="matrix(0.244315,-0.202968,0.423167,0.116733,-22.146,155.949)" id="g6081">
+          <path d="m 171.45,362.85 h 43.106" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6079"/>
         </g>
-        <g
-           transform="matrix(0.244315,-0.202968,0.423167,0.116733,-22.146,155.949)"
-           id="g6085-2">
-          <path
-             d="M 248.273,362.85 H 361.09"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6083" />
+        <g transform="matrix(0.244315,-0.202968,0.423167,0.116733,-22.146,155.949)" id="g6085-2">
+          <path d="M 248.273,362.85 H 361.09" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6083"/>
         </g>
-        <g
-           transform="matrix(0,-0.234142,0.488631,-3.89978e-4,-16.3497,202.218)"
-           id="g6089">
-          <path
-             d="m 171.45,362.85 h 61.808"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6087" />
+        <g transform="matrix(0,-0.234142,0.488631,-3.89978e-4,-16.3497,202.218)" id="g6089">
+          <path d="m 171.45,362.85 h 61.808" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6087"/>
         </g>
-        <g
-           transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,240.861)"
-           id="g6093-0">
-          <path
-             d="M 171.45,362.85 H 290.292"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6091" />
+        <g transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,240.861)" id="g6093-0">
+          <path d="M 171.45,362.85 H 290.292" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6091"/>
         </g>
-        <g
-           transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,240.861)"
-           id="g6097">
-          <path
-             d="M 336.424,362.85 H 361.09"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6095-0" />
+        <g transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,240.861)" id="g6097">
+          <path d="M 336.424,362.85 H 361.09" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6095-0"/>
         </g>
-        <g
-           transform="matrix(-0.244315,0.202773,-0.423167,-0.117071,344.046,191.824)"
-           id="g6101">
-          <path
-             d="m 171.45,362.85 h 68.26"
-             style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-             id="path6099" />
+        <g transform="matrix(-0.244315,0.202773,-0.423167,-0.117071,344.046,191.824)" id="g6101">
+          <path d="m 171.45,362.85 h 68.26" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6099"/>
         </g>
-        <g
-           transform="matrix(0,0.234142,-0.488631,0,338.25,145.551)"
-           id="g6105">
-          <path
-             d="M 171.45,362.85 H 276.149"
-             style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-             id="path6103" />
+        <g transform="matrix(0,0.234142,-0.488631,0,338.25,145.551)" id="g6105">
+          <path d="M 171.45,362.85 H 276.149" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6103"/>
         </g>
-        <g
-           transform="matrix(0.244315,0.202773,-0.423167,0.117071,284.946,106.866)"
-           id="g6109">
-          <path
-             d="M 171.45,362.85 H 300.404"
-             style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-             id="path6107-8" />
+        <g transform="matrix(0.244315,0.202773,-0.423167,0.117071,284.946,106.866)" id="g6109">
+          <path d="M 171.45,362.85 H 300.404" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6107-8"/>
         </g>
-        <g
-           transform="matrix(0.244315,0.202773,-0.423167,0.117071,284.946,106.866)"
-           id="g6113-9">
-          <path
-             d="m 336.13,362.85 h 24.96"
-             style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-             id="path6111" />
+        <g transform="matrix(0.244315,0.202773,-0.423167,0.117071,284.946,106.866)" id="g6113-9">
+          <path d="m 336.13,362.85 h 24.96" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6111"/>
         </g>
-        <g
-           transform="matrix(0.423167,0.117071,-0.244315,0.202773,198.418,86.1346)"
-           id="g6117">
-          <path
-             d="m 171.45,362.85 h 50.499"
-             style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-             id="path6115" />
+        <g transform="matrix(0.423167,0.117071,-0.244315,0.202773,198.418,86.1346)" id="g6117">
+          <path d="m 171.45,362.85 h 50.499" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6115"/>
         </g>
-        <g
-           transform="scale(1,0.47918)"
-           id="g6121-6">
-          <rect
-             x="0"
-             y="241.89999"
-             width="241.911"
-             height="241.89999"
-             style="fill:none"
-             id="rect6119-9" />
+        <g transform="scale(1,0.47918)" id="g6121-6">
+          <rect x="0" y="241.89999" width="241.911" height="241.89999" style="fill:none" id="rect6119-9"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6199"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Plasma"
-         transform="translate(241.9)">
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6128">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35"
-             id="path6126" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6199" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Plasma" transform="translate(241.9)">
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6128">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35" id="path6126"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6132">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:30.02px;stroke-opacity:0.35"
-             id="path6130" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6132">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:30.02px;stroke-opacity:0.35" id="path6130"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6136">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:10.01px;stroke-linecap:butt;stroke-dasharray:50.04, 20.02, 0, 0"
-             id="path6134" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6136">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:10.01px;stroke-linecap:butt;stroke-dasharray:50.04, 20.02, 0, 0" id="path6134"/>
         </g>
-        <g
-           transform="matrix(1.56752,-0.00125105,0,0.751127,-272.694,-122.935)"
-           id="g6140">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6138" />
+        <g transform="matrix(1.56752,-0.00125105,0,0.751127,-272.694,-122.935)" id="g6140">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6138"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6144">
-          <path
-             d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259"
-             style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8"
-             id="path6142" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6144">
+          <path d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259" style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8" id="path6142"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6148">
-          <path
-             d="m 283.614,386.786 c 2.534,2.04 4.156,5.167 4.156,8.67 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8"
-             id="path6146" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6148">
+          <path d="m 283.614,386.786 c 2.534,2.04 4.156,5.167 4.156,8.67 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8" id="path6146"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6152">
-          <path
-             d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -2.951,0 -5.781,-1.172 -7.868,-3.259"
-             style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8"
-             id="path6150" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6152">
+          <path d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -2.951,0 -5.781,-1.172 -7.868,-3.259" style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8" id="path6150"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6156">
-          <path
-             d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 2.56,0 4.919,0.866 6.8,2.321"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6154" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6156">
+          <path d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 2.56,0 4.919,0.866 6.8,2.321" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6154"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6160">
-          <path
-             d="m 286.036,389.492 c 1.098,1.724 1.734,3.771 1.734,5.964 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6158" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6160">
+          <path d="m 286.036,389.492 c 1.098,1.724 1.734,3.771 1.734,5.964 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6158"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6164">
-          <path
-             d="m 285.066,402.725 c -1.672,1.935 -3.999,3.289 -6.635,3.716"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6162" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6164">
+          <path d="m 285.066,402.725 c -1.672,1.935 -3.999,3.289 -6.635,3.716" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6162"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6168">
-          <path
-             d="m 274.825,406.435 c -2.277,-0.377 -4.397,-1.457 -6.051,-3.11"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6166" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6168">
+          <path d="m 274.825,406.435 c -2.277,-0.377 -4.397,-1.457 -6.051,-3.11" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6166"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6172">
-          <path
-             d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6170" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6172">
+          <path d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6170"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6176">
-          <path
-             d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6174" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6176">
+          <path d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6174"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6180">
-          <path
-             d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461 0.424,0.773 0.76,1.602 0.992,2.473"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6178" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6180">
+          <path d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461 0.424,0.773 0.76,1.602 0.992,2.473" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6178"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6184">
-          <path
-             d="m 287.77,395.456 c 0,2.271 -0.682,4.383 -1.851,6.145"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6182" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6184">
+          <path d="m 287.77,395.456 c 0,2.271 -0.682,4.383 -1.851,6.145" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6182"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6188">
-          <path
-             d="m 284.694,403.134 c -1.229,1.288 -2.762,2.282 -4.485,2.865 -1.119,0.379 -2.319,0.585 -3.567,0.585"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6186" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6188">
+          <path d="m 284.694,403.134 c -1.229,1.288 -2.762,2.282 -4.485,2.865 -1.119,0.379 -2.319,0.585 -3.567,0.585" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6186"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6192">
-          <path
-             d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6190" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6192">
+          <path d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6190"/>
         </g>
-        <g
-           transform="scale(1,0.47918)"
-           id="g6196">
-          <rect
-             x="0"
-             y="241.89999"
-             width="241.911"
-             height="241.89999"
-             style="fill:none"
-             id="rect6194" />
+        <g transform="scale(1,0.47918)" id="g6196">
+          <rect x="0" y="241.89999" width="241.911" height="241.89999" style="fill:none" id="rect6194"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6276"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Cannon"
-         transform="translate(483.8)">
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6203-3">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:15.01px;stroke-opacity:0.35"
-             id="path6201" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6276" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Cannon" transform="translate(483.8)">
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6203-3">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:15.01px;stroke-opacity:0.35" id="path6201"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6207">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35"
-             id="path6205" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6207">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35" id="path6205"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6211">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:24.02, 16.01, 0, 0"
-             id="path6209" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6211">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:24.02, 16.01, 0, 0" id="path6209"/>
         </g>
-        <g
-           transform="matrix(1.17867,-9.40703e-4,0,0.564797,-165.121,-49.3352)"
-           id="g6215">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6213" />
+        <g transform="matrix(1.17867,-9.40703e-4,0,0.564797,-165.121,-49.3352)" id="g6215">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6213"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6219">
-          <path
-             d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6217" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6219">
+          <path d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6217"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6223">
-          <path
-             d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6221" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6223">
+          <path d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6221"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6227">
-          <path
-             d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -1.959,0 -3.864,-0.517 -5.535,-1.474"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6225" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6227">
+          <path d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -1.959,0 -3.864,-0.517 -5.535,-1.474" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6225"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6231">
-          <path
-             d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 1.374,0 2.69,0.249 3.906,0.706"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6229" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6231">
+          <path d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 1.374,0 2.69,0.249 3.906,0.706" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6229"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6235">
-          <path
-             d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6233" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6235">
+          <path d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6233"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6240">
-          <path
-             d="m 285.066,402.725 c -1.208,1.398 -2.757,2.492 -4.518,3.153"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6237" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6240">
+          <path d="m 285.066,402.725 c -1.208,1.398 -2.757,2.492 -4.518,3.153" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6237"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6245">
-          <path
-             d="m 273.822,406.221 c -0.676,-0.178 -1.334,-0.418 -1.964,-0.718 -0.782,-0.372 -1.521,-0.836 -2.202,-1.385"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6242" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6245">
+          <path d="m 273.822,406.221 c -0.676,-0.178 -1.334,-0.418 -1.964,-0.718 -0.782,-0.372 -1.521,-0.836 -2.202,-1.385" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6242"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6249">
-          <path
-             d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6247" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6249">
+          <path d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6247"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6253">
-          <path
-             d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6251" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6253">
+          <path d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6251"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6257">
-          <path
-             d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6255" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6257">
+          <path d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6255"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6261">
-          <path
-             d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6259" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6261">
+          <path d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6259"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6265">
-          <path
-             d="m 282.566,404.876 c -0.732,0.462 -1.522,0.84 -2.357,1.123 -1.119,0.379 -2.319,0.585 -3.567,0.585"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6263" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6265">
+          <path d="m 282.566,404.876 c -0.732,0.462 -1.522,0.84 -2.357,1.123 -1.119,0.379 -2.319,0.585 -3.567,0.585" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6263"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6269">
-          <path
-             d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6267" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6269">
+          <path d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6267"/>
         </g>
-        <g
-           transform="scale(1,0.47918)"
-           id="g6273">
-          <rect
-             x="0"
-             y="241.89999"
-             width="241.911"
-             height="241.89999"
-             style="fill:none"
-             id="rect6271" />
+        <g transform="scale(1,0.47918)" id="g6273">
+          <rect x="0" y="241.89999" width="241.911" height="241.89999" style="fill:none" id="rect6271"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6348"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Cannon-rapid"
-         serif:id="Cannon rapid"
-         transform="translate(725.7)">
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6280">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35"
-             id="path6278" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6348" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Cannon-rapid" serif:id="Cannon rapid" transform="translate(725.7)">
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6280">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35" id="path6278"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6284">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:8.01, 8.01"
-             id="path6282" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6284">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:8.01, 8.01" id="path6282"/>
         </g>
-        <g
-           transform="matrix(1.17867,-9.40703e-4,0,0.564797,-165.121,-49.3352)"
-           id="g6288">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6286" />
+        <g transform="matrix(1.17867,-9.40703e-4,0,0.564797,-165.121,-49.3352)" id="g6288">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6286"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6292">
-          <path
-             d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6290" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6292">
+          <path d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6290"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6296">
-          <path
-             d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6294" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6296">
+          <path d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6294"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)"
-           id="g6300">
-          <path
-             d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -1.959,0 -3.864,-0.517 -5.535,-1.474"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6298" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-385.8)" id="g6300">
+          <path d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -1.959,0 -3.864,-0.517 -5.535,-1.474" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6298"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6304">
-          <path
-             d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 1.374,0 2.69,0.249 3.906,0.706"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6302" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6304">
+          <path d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 1.374,0 2.69,0.249 3.906,0.706" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6302"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6309">
-          <path
-             d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6306" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6309">
+          <path d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6306"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6313">
-          <path
-             d="m 285.066,402.725 c -1.208,1.398 -2.757,2.492 -4.518,3.153"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6311" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6313">
+          <path d="m 285.066,402.725 c -1.208,1.398 -2.757,2.492 -4.518,3.153" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6311"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)"
-           id="g6317-4">
-          <path
-             d="m 273.822,406.221 c -0.676,-0.178 -1.334,-0.418 -1.964,-0.718 -0.782,-0.372 -1.521,-0.836 -2.202,-1.385"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6315" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-707.448)" id="g6317-4">
+          <path d="m 273.822,406.221 c -0.676,-0.178 -1.334,-0.418 -1.964,-0.718 -0.782,-0.372 -1.521,-0.836 -2.202,-1.385" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6315"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6321">
-          <path
-             d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6319" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6321">
+          <path d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6319"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6325">
-          <path
-             d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6323-8" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6325">
+          <path d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6323-8"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6329">
-          <path
-             d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6327" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6329">
+          <path d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6327"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6333">
-          <path
-             d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6331" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6333">
+          <path d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6331"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6337-3">
-          <path
-             d="m 282.566,404.876 c -0.732,0.462 -1.522,0.84 -2.357,1.123 -1.119,0.379 -2.319,0.585 -3.567,0.585"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6335" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6337-3">
+          <path d="m 282.566,404.876 c -0.732,0.462 -1.522,0.84 -2.357,1.123 -1.119,0.379 -2.319,0.585 -3.567,0.585" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6335"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)"
-           id="g6341">
-          <path
-             d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6339" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-988.135)" id="g6341">
+          <path d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6339"/>
         </g>
-        <g
-           transform="scale(1,0.47918)"
-           id="g6345">
-          <rect
-             x="0"
-             y="241.89999"
-             width="241.911"
-             height="241.89999"
-             style="fill:none"
-             id="rect6343" />
+        <g transform="scale(1,0.47918)" id="g6345">
+          <rect x="0" y="241.89999" width="241.911" height="241.89999" style="fill:none" id="rect6343"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6443"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Cannon-rapud-dual"
-         serif:id="Cannon rapud dual"
-         transform="translate(1935.19)">
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)"
-           id="g6352">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:12.01px;stroke-opacity:0.35"
-             id="path6350" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6443" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Cannon-rapud-dual" serif:id="Cannon rapud dual" transform="translate(1935.19)">
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)" id="g6352">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:12.01px;stroke-opacity:0.35" id="path6350"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)"
-           id="g6356">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:5px;stroke-linecap:butt;stroke-dasharray:5, 5"
-             id="path6354" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)" id="g6356">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:5px;stroke-linecap:butt;stroke-dasharray:5, 5" id="path6354"/>
         </g>
-        <g
-           transform="matrix(1.17867,-9.40703e-4,0,0.564797,-165.121,-68.5024)"
-           id="g6360">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6358" />
+        <g transform="matrix(1.17867,-9.40703e-4,0,0.564797,-165.121,-68.5024)" id="g6360">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6358"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)"
-           id="g6364">
-          <path
-             d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6362" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)" id="g6364">
+          <path d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6362"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)"
-           id="g6368">
-          <path
-             d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6366" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)" id="g6368">
+          <path d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6366"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)"
-           id="g6372">
-          <path
-             d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 1.374,0 2.69,0.249 3.906,0.706"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6370" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)" id="g6372">
+          <path d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 1.374,0 2.69,0.249 3.906,0.706" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6370"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)"
-           id="g6376">
-          <path
-             d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6374" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)" id="g6376">
+          <path d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6374"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6380">
-          <path
-             d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6378" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6380">
+          <path d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6378"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6384">
-          <path
-             d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6382" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6384">
+          <path d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6382"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6388">
-          <path
-             d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6386" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6388">
+          <path d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6386"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6392">
-          <path
-             d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6390" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6392">
+          <path d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6390"/>
         </g>
-        <g
-           transform="matrix(0.723175,-5.77169e-4,0,0.346531,4.41413,62.518)"
-           id="g6396">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:27.68px;stroke-opacity:0.35"
-             id="path6394" />
+        <g transform="matrix(0.723175,-5.77169e-4,0,0.346531,4.41413,62.518)" id="g6396">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:27.68px;stroke-opacity:0.35" id="path6394"/>
         </g>
-        <g
-           transform="matrix(0.723175,-5.77169e-4,0,0.346531,4.41413,62.518)"
-           id="g6400">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:11.07px;stroke-linecap:butt;stroke-dasharray:11.07, 11.07"
-             id="path6398" />
+        <g transform="matrix(0.723175,-5.77169e-4,0,0.346531,4.41413,62.518)" id="g6400">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:11.07px;stroke-linecap:butt;stroke-dasharray:11.07, 11.07" id="path6398"/>
         </g>
-        <g
-           transform="matrix(1.17867,-9.40703e-4,0,0.564797,-195.121,-34.9598)"
-           id="g6404">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6402" />
+        <g transform="matrix(1.17867,-9.40703e-4,0,0.564797,-195.121,-34.9598)" id="g6404">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6402"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-686.897,-371.425)"
-           id="g6408">
-          <path
-             d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6406" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-686.897,-371.425)" id="g6408">
+          <path d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6406"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-686.897,-371.425)"
-           id="g6412">
-          <path
-             d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -1.959,0 -3.864,-0.517 -5.535,-1.474"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6410" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-686.897,-371.425)" id="g6412">
+          <path d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -1.959,0 -3.864,-0.517 -5.535,-1.474" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6410"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1157.02,-693.073)"
-           id="g6416">
-          <path
-             d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6414" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1157.02,-693.073)" id="g6416">
+          <path d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6414"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1157.02,-693.073)"
-           id="g6420">
-          <path
-             d="m 285.066,402.725 c -1.208,1.398 -2.757,2.492 -4.518,3.153"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6418" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1157.02,-693.073)" id="g6420">
+          <path d="m 285.066,402.725 c -1.208,1.398 -2.757,2.492 -4.518,3.153" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6418"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1157.02,-693.073)"
-           id="g6424">
-          <path
-             d="m 273.822,406.221 c -0.676,-0.178 -1.334,-0.418 -1.964,-0.718 -0.782,-0.372 -1.521,-0.836 -2.202,-1.385"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6422" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1157.02,-693.073)" id="g6424">
+          <path d="m 273.822,406.221 c -0.676,-0.178 -1.334,-0.418 -1.964,-0.718 -0.782,-0.372 -1.521,-0.836 -2.202,-1.385" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6422"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1567.27,-973.76)"
-           id="g6428">
-          <path
-             d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6426" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1567.27,-973.76)" id="g6428">
+          <path d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6426"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1567.27,-973.76)"
-           id="g6432">
-          <path
-             d="m 282.566,404.876 c -0.732,0.462 -1.522,0.84 -2.357,1.123 -1.119,0.379 -2.319,0.585 -3.567,0.585"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6430" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1567.27,-973.76)" id="g6432">
+          <path d="m 282.566,404.876 c -0.732,0.462 -1.522,0.84 -2.357,1.123 -1.119,0.379 -2.319,0.585 -3.567,0.585" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6430"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1567.27,-973.76)"
-           id="g6436">
-          <path
-             d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6434" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1567.27,-973.76)" id="g6436">
+          <path d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6434"/>
         </g>
-        <g
-           transform="scale(1,0.47918)"
-           id="g6440">
-          <rect
-             x="0"
-             y="241.89999"
-             width="241.911"
-             height="241.89999"
-             style="fill:none"
-             id="rect6438" />
+        <g transform="scale(1,0.47918)" id="g6440">
+          <rect x="0" y="241.89999" width="241.911" height="241.89999" style="fill:none" id="rect6438"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6519-1"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Mining-Cannon"
-         serif:id="Mining Cannon"
-         transform="translate(967.589,-1.05647)">
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6447">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:15.01px;stroke-opacity:0.35"
-             id="path6445-6" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6519-1" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Mining-Cannon" serif:id="Mining Cannon" transform="translate(967.589,-1.05647)">
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6447">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:15.01px;stroke-opacity:0.35" id="path6445-6"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6451-2">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35"
-             id="path6449-7" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6451-2">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35" id="path6449-7"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)"
-           id="g6455">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:24.02, 16.01, 0, 0"
-             id="path6453" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,0.0149776)" id="g6455">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:24.02, 16.01, 0, 0" id="path6453"/>
         </g>
-        <g
-           transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,16.3858,241.917)"
-           id="g6459">
-          <path
-             d="M 171.45,362.85 H 374.781"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6457-6" />
+        <g transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,16.3858,241.917)" id="g6459">
+          <path d="M 171.45,362.85 H 374.781" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6457-6"/>
         </g>
-        <g
-           transform="matrix(-0.396911,-0.136274,0.28447,-0.19058,85.1685,260.448)"
-           id="g6463">
-          <path
-             d="m 196.02,362.85 h 39.624"
-             style="fill:none;stroke:#ffffff;stroke-width:18.41px"
-             id="path6461-7" />
+        <g transform="matrix(-0.396911,-0.136274,0.28447,-0.19058,85.1685,260.448)" id="g6463">
+          <path d="m 196.02,362.85 h 39.624" style="fill:none;stroke:#ffffff;stroke-width:18.41px" id="path6461-7"/>
         </g>
-        <g
-           transform="matrix(-0.396911,-0.136274,0.28447,-0.19058,85.1685,260.448)"
-           id="g6467">
-          <path
-             d="m 264.931,362.85 h 25.361"
-             style="fill:none;stroke:#ffffff;stroke-width:10.23px"
-             id="path6465" />
+        <g transform="matrix(-0.396911,-0.136274,0.28447,-0.19058,85.1685,260.448)" id="g6467">
+          <path d="m 264.931,362.85 h 25.361" style="fill:none;stroke:#ffffff;stroke-width:10.23px" id="path6465"/>
         </g>
-        <g
-           transform="matrix(-0.471641,0.0605568,-0.126951,-0.226277,243.491,249.594)"
-           id="g6471-4">
-          <path
-             d="m 264.931,362.85 h 25.361"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6469" />
+        <g transform="matrix(-0.471641,0.0605568,-0.126951,-0.226277,243.491,249.594)" id="g6471-4">
+          <path d="m 264.931,362.85 h 25.361" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6469"/>
         </g>
-        <g
-           transform="matrix(-0.126376,0.226001,-0.472427,-0.060456,327.087,169.415)"
-           id="g6475">
-          <path
-             d="m 264.931,362.85 h 25.361"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6473" />
+        <g transform="matrix(-0.126376,0.226001,-0.472427,-0.060456,327.087,169.415)" id="g6475">
+          <path d="m 264.931,362.85 h 25.361" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6473"/>
         </g>
-        <g
-           transform="matrix(-0.345265,0.165444,-0.346051,-0.165545,307.706,214.871)"
-           id="g6479-6">
-          <path
-             d="m 230.962,362.85 h 21.839"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6477-1" />
+        <g transform="matrix(-0.345265,0.165444,-0.346051,-0.165545,307.706,214.871)" id="g6479-6">
+          <path d="m 230.962,362.85 h 21.839" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6477-1"/>
         </g>
-        <g
-           transform="matrix(-0.4047,0.130908,-0.273924,-0.194095,288.724,229.408)"
-           id="g6483">
-          <path
-             d="m 171.45,362.85 h 35.656"
-             style="fill:none;stroke:#ffffff;stroke-width:20.46px"
-             id="path6481" />
+        <g transform="matrix(-0.4047,0.130908,-0.273924,-0.194095,288.724,229.408)" id="g6483">
+          <path d="m 171.45,362.85 h 35.656" style="fill:none;stroke:#ffffff;stroke-width:20.46px" id="path6481"/>
         </g>
-        <g
-           transform="matrix(-0.4047,0.130908,-0.273924,-0.194095,288.724,229.408)"
-           id="g6487-6">
-          <path
-             d="m 234.028,362.85 h 56.264"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6485-2" />
+        <g transform="matrix(-0.4047,0.130908,-0.273924,-0.194095,288.724,229.408)" id="g6487-6">
+          <path d="m 234.028,362.85 h 56.264" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6485-2"/>
         </g>
-        <g
-           transform="matrix(-0.196576,0.214175,-0.447769,-0.0941532,326.631,183.073)"
-           id="g6491">
-          <path
-             d="M 171.45,362.85 H 290.292"
-             style="fill:none;stroke:#ffffff;stroke-width:18.41px"
-             id="path6489" />
+        <g transform="matrix(-0.196576,0.214175,-0.447769,-0.0941532,326.631,183.073)" id="g6491">
+          <path d="M 171.45,362.85 H 290.292" style="fill:none;stroke:#ffffff;stroke-width:18.41px" id="path6489"/>
         </g>
-        <g
-           transform="matrix(-0.0828541,-0.23058,0.481823,-0.0399514,-24.4264,217.199)"
-           id="g6495-6">
-          <path
-             d="M 189.044,362.85 H 290.292"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6493-9" />
+        <g transform="matrix(-0.0828541,-0.23058,0.481823,-0.0399514,-24.4264,217.199)" id="g6495-6">
+          <path d="M 189.044,362.85 H 290.292" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6493-9"/>
         </g>
-        <g
-           transform="matrix(-0.0209107,0.233759,-0.488552,-0.00983979,320.182,150.111)"
-           id="g6499-3">
-          <path
-             d="M 212.921,362.85 H 352.388"
-             style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-             id="path6497-5" />
+        <g transform="matrix(-0.0209107,0.233759,-0.488552,-0.00983979,320.182,150.111)" id="g6499-3">
+          <path d="M 212.921,362.85 H 352.388" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6497-5"/>
         </g>
-        <g
-           id="rect7303-6"
-           transform="matrix(1.06667,0,0,0.511127,-6289.17,1085.92)">
-          <rect
-             x="5896.1001"
-             y="-1895.7"
-             width="226.77"
-             height="226.77"
-             style="fill:none"
-             id="rect6501-5" />
+        <g id="rect7303-6" transform="matrix(1.06667,0,0,0.511127,-6289.17,1085.92)">
+          <rect x="5896.1001" y="-1895.7" width="226.77" height="226.77" style="fill:none" id="rect6501-5"/>
         </g>
-        <g
-           transform="matrix(0.74995,-0.266075,0.555272,0.359361,527.236,1156.25)"
-           id="g6516">
-          <g
-             id="path7301-9"
-             transform="translate(-4989,-226.77)">
-            <path
-               d="m 5973.6,-1769.5 c 6.24,-5.46 10.44,-7.23 16.1,-6.22 5.28,0.94 8.04,4.04 12.08,10.61 -6.22,-4.23 -6.53,-5.22 -12.81,-6.95 -3.6,-1 -8.25,0.89 -15.37,2.56 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path6504" />
+        <g transform="matrix(0.74995,-0.266075,0.555272,0.359361,527.236,1156.25)" id="g6516">
+          <g id="path7301-9" transform="translate(-4989,-226.77)">
+            <path d="m 5973.6,-1769.5 c 6.24,-5.46 10.44,-7.23 16.1,-6.22 5.28,0.94 8.04,4.04 12.08,10.61 -6.22,-4.23 -6.53,-5.22 -12.81,-6.95 -3.6,-1 -8.25,0.89 -15.37,2.56 z" style="fill:#ffffff;fill-rule:nonzero" id="path6504"/>
           </g>
-          <g
-             id="path7305-3"
-             transform="translate(-4989,-226.77)">
-            <path
-               d="m 6009.2,-1802 c 0,0 21.38,30.6 23.71,44.6 2.38,14.26 -4.89,26 -10.51,31.72 -7.53,7.67 -15.7,8.19 -22.51,6.48 0,0 -11.29,-7.91 -17.78,-9.84 -6.51,-1.94 -14.17,1.34 -20.34,-1.51 -4.31,-1.99 -10.01,-10.13 -10.01,-10.13 -10.95,-8.71 0.35,-23.97 3.62,-32.86 3.95,-10.72 17.16,-28.1 25.1,-27.17 z"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:14.17px;stroke-linecap:butt;stroke-miterlimit:4"
-               id="path6507" />
+          <g id="path7305-3" transform="translate(-4989,-226.77)">
+            <path d="m 6009.2,-1802 c 0,0 21.38,30.6 23.71,44.6 2.38,14.26 -4.89,26 -10.51,31.72 -7.53,7.67 -15.7,8.19 -22.51,6.48 0,0 -11.29,-7.91 -17.78,-9.84 -6.51,-1.94 -14.17,1.34 -20.34,-1.51 -4.31,-1.99 -10.01,-10.13 -10.01,-10.13 -10.95,-8.71 0.35,-23.97 3.62,-32.86 3.95,-10.72 17.16,-28.1 25.1,-27.17 z" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:14.17px;stroke-linecap:butt;stroke-miterlimit:4" id="path6507"/>
           </g>
-          <g
-             id="path7311-6"
-             transform="translate(-4989,-226.77)">
-            <path
-               d="m 6012.7,-1747.5 c -1.32,4.24 -2.73,6.22 -5.56,7.33 -2.64,1.04 -4.74,0.39 -8.36,-1.5 3.96,0.21 4.37,0.57 7.69,-0.38 1.89,-0.55 3.48,-2.7 6.23,-5.45 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path6510" />
+          <g id="path7311-6" transform="translate(-4989,-226.77)">
+            <path d="m 6012.7,-1747.5 c -1.32,4.24 -2.73,6.22 -5.56,7.33 -2.64,1.04 -4.74,0.39 -8.36,-1.5 3.96,0.21 4.37,0.57 7.69,-0.38 1.89,-0.55 3.48,-2.7 6.23,-5.45 z" style="fill:#ffffff;fill-rule:nonzero" id="path6510"/>
           </g>
-          <g
-             id="path7313-4"
-             transform="translate(-4989,-226.77)">
-            <path
-               d="m 5985.9,-1745.2 c -4.32,1.02 -6.74,0.8 -9.14,-1.07 -2.23,-1.75 -2.74,-3.89 -2.95,-7.97 2.38,-2.88 7.03,-1.79 9.54,0.58 1.43,1.36 2.81,3.82 2.55,8.46 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path6513" />
+          <g id="path7313-4" transform="translate(-4989,-226.77)">
+            <path d="m 5985.9,-1745.2 c -4.32,1.02 -6.74,0.8 -9.14,-1.07 -2.23,-1.75 -2.74,-3.89 -2.95,-7.97 2.38,-2.88 7.03,-1.79 9.54,0.58 1.43,1.36 2.81,3.82 2.55,8.46 z" style="fill:#ffffff;fill-rule:nonzero" id="path6513"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6602"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Laser-dual"
-         serif:id="Laser dual"
-         transform="translate(1209.5)">
-        <g
-           id="g6565">
-          <g
-             transform="matrix(1,-7.98104e-4,0,0.47918,0,-12.4437)"
-             id="g6523">
-            <path
-               d="M 18.766,362.85 H 131.935"
-               style="fill:none;stroke:#ffffff;stroke-width:10.01px"
-               id="path6521" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6602" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Laser-dual" serif:id="Laser dual" transform="translate(1209.5)">
+        <g id="g6565">
+          <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-12.4437)" id="g6523">
+            <path d="M 18.766,362.85 H 131.935" style="fill:none;stroke:#ffffff;stroke-width:10.01px" id="path6521"/>
           </g>
-          <g
-             transform="matrix(1.11041,-8.86226e-4,0,0.532089,-146.238,-48.8743)"
-             id="g6527">
-            <circle
-               cx="276.642"
-               cy="395.45599"
-               r="11.128"
-               style="fill:#ffffff"
-               id="circle6525" />
+          <g transform="matrix(1.11041,-8.86226e-4,0,0.532089,-146.238,-48.8743)" id="g6527">
+            <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6525"/>
           </g>
-          <g
-             transform="matrix(0.488631,0,0,0.234142,101.85,76.4534)"
-             id="g6531">
-            <path
-               d="m 171.45,362.85 h 94.82"
-               style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-               id="path6529" />
+          <g transform="matrix(0.488631,0,0,0.234142,101.85,76.4534)" id="g6531">
+            <path d="m 171.45,362.85 h 94.82" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6529"/>
           </g>
-          <g
-             transform="matrix(0.423167,-0.117071,0.244315,0.202773,21.1182,101.995)"
-             id="g6535-4">
-            <path
-               d="m 171.45,362.85 h 53.108"
-               style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-               id="path6533" />
+          <g transform="matrix(0.423167,-0.117071,0.244315,0.202773,21.1182,101.995)" id="g6535-4">
+            <path d="m 171.45,362.85 h 53.108" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6533"/>
           </g>
-          <g
-             transform="matrix(0.423167,-0.117071,0.244315,0.202773,21.1182,101.995)"
-             id="g6539">
-            <path
-               d="m 262.725,362.85 h 26.026"
-               style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-               id="path6537" />
+          <g transform="matrix(0.423167,-0.117071,0.244315,0.202773,21.1182,101.995)" id="g6539">
+            <path d="m 262.725,362.85 h 26.026" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6537"/>
           </g>
-          <g
-             transform="matrix(0.244315,-0.202968,0.423167,0.116733,-22.146,143.491)"
-             id="g6543">
-            <path
-               d="m 171.45,362.85 h 43.106"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6541-1" />
+          <g transform="matrix(0.244315,-0.202968,0.423167,0.116733,-22.146,143.491)" id="g6543">
+            <path d="m 171.45,362.85 h 43.106" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6541-1"/>
           </g>
-          <g
-             transform="matrix(0.244315,-0.202968,0.423167,0.116733,-22.146,143.491)"
-             id="g6547">
-            <path
-               d="m 248.273,362.85 h 67.089"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6545" />
+          <g transform="matrix(0.244315,-0.202968,0.423167,0.116733,-22.146,143.491)" id="g6547">
+            <path d="m 248.273,362.85 h 67.089" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6545"/>
           </g>
-          <g
-             transform="matrix(0,-0.234142,0.488631,-3.89978e-4,-16.3497,189.759)"
-             id="g6551-6">
-            <path
-               d="m 171.45,362.85 h 61.808"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6549" />
+          <g transform="matrix(0,-0.234142,0.488631,-3.89978e-4,-16.3497,189.759)" id="g6551-6">
+            <path d="m 171.45,362.85 h 61.808" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6549"/>
           </g>
-          <g
-             transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,228.402)"
-             id="g6555">
-            <path
-               d="m 171.45,362.85 h 87.019"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6553" />
+          <g transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,228.402)" id="g6555">
+            <path d="m 171.45,362.85 h 87.019" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6553"/>
           </g>
-          <g
-             transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,228.402)"
-             id="g6559">
-            <path
-               d="M -20.034,362.85 H 70.375"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6557" />
+          <g transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,228.402)" id="g6559">
+            <path d="M -20.034,362.85 H 70.375" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6557"/>
           </g>
-          <g
-             transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,228.402)"
-             id="g6563-4">
-            <path
-               d="m 288.736,362.85 h 33.245"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6561" />
+          <g transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,36.9539,228.402)" id="g6563-4">
+            <path d="m 288.736,362.85 h 33.245" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6561"/>
           </g>
         </g>
-        <g
-           id="g6595">
-          <g
-             transform="matrix(1,-7.98104e-4,0,0.47918,-30,12.4737)"
-             id="g6569">
-            <path
-               d="m 48.766,362.9 83.169,-0.05"
-               style="fill:none;stroke:#ffffff;stroke-width:15.01px"
-               id="path6567" />
+        <g id="g6595">
+          <g transform="matrix(1,-7.98104e-4,0,0.47918,-30,12.4737)" id="g6569">
+            <path d="m 48.766,362.9 83.169,-0.05" style="fill:none;stroke:#ffffff;stroke-width:15.01px" id="path6567"/>
           </g>
-          <g
-             transform="matrix(1.13883,-9.08907e-4,0,0.545706,-184.099,-29.3358)"
-             id="g6573-4">
-            <circle
-               cx="276.642"
-               cy="395.45599"
-               r="11.128"
-               style="fill:#ffffff"
-               id="circle6571" />
+          <g transform="matrix(1.13883,-9.08907e-4,0,0.545706,-184.099,-29.3358)" id="g6573-4">
+            <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6571"/>
           </g>
-          <g
-             transform="matrix(-0.244315,0.202773,-0.423167,-0.117071,314.046,204.283)"
-             id="g6577">
-            <path
-               d="m 171.45,362.85 h 68.26"
-               style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-               id="path6575-3" />
+          <g transform="matrix(-0.244315,0.202773,-0.423167,-0.117071,314.046,204.283)" id="g6577">
+            <path d="m 171.45,362.85 h 68.26" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6575-3"/>
           </g>
-          <g
-             transform="matrix(0,0.234142,-0.488631,0,308.25,158.01)"
-             id="g6581">
-            <path
-               d="M 171.45,362.85 H 276.149"
-               style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-               id="path6579" />
+          <g transform="matrix(0,0.234142,-0.488631,0,308.25,158.01)" id="g6581">
+            <path d="M 171.45,362.85 H 276.149" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6579"/>
           </g>
-          <g
-             transform="matrix(0.244315,0.202773,-0.423167,0.117071,254.946,119.325)"
-             id="g6585">
-            <path
-               d="m 171.45,362.85 h 51.74"
-               style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-               id="path6583-1" />
+          <g transform="matrix(0.244315,0.202773,-0.423167,0.117071,254.946,119.325)" id="g6585">
+            <path d="m 171.45,362.85 h 51.74" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6583-1"/>
           </g>
-          <g
-             transform="matrix(0.244315,0.202773,-0.423167,0.117071,254.946,119.325)"
-             id="g6589">
-            <path
-               d="m 251.888,362.85 h 65.333"
-               style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-               id="path6587" />
+          <g transform="matrix(0.244315,0.202773,-0.423167,0.117071,254.946,119.325)" id="g6589">
+            <path d="m 251.888,362.85 h 65.333" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6587"/>
           </g>
-          <g
-             transform="matrix(0.423167,0.117071,-0.244315,0.202773,168.418,98.5933)"
-             id="g6593-8">
-            <path
-               d="m 171.45,362.85 h 50.499"
-               style="fill:none;stroke:#ffffff;stroke-width:12.28px"
-               id="path6591" />
+          <g transform="matrix(0.423167,0.117071,-0.244315,0.202773,168.418,98.5933)" id="g6593-8">
+            <path d="m 171.45,362.85 h 50.499" style="fill:none;stroke:#ffffff;stroke-width:12.28px" id="path6591"/>
           </g>
         </g>
-        <g
-           transform="scale(1,0.47918)"
-           id="g6599-5">
-          <rect
-             x="0"
-             y="241.89999"
-             width="241.911"
-             height="241.89999"
-             style="fill:none"
-             id="rect6597-5" />
+        <g transform="scale(1,0.47918)" id="g6599-5">
+          <rect x="0" y="241.89999" width="241.911" height="241.89999" style="fill:none" id="rect6597-5"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6705"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Plasma-dual"
-         serif:id="Plasma dual"
-         transform="translate(1451.41)">
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)"
-           id="g6606">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:27.02px;stroke-opacity:0.35"
-             id="path6604" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6705" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Plasma-dual" serif:id="Plasma dual" transform="translate(1451.41)">
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)" id="g6606">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:27.02px;stroke-opacity:0.35" id="path6604"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)"
-           id="g6610">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:17.01px;stroke-opacity:0.35"
-             id="path6608" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)" id="g6610">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:17.01px;stroke-opacity:0.35" id="path6608"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)"
-           id="g6614">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:40.03, 16.01, 0, 0"
-             id="path6612" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)" id="g6614">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:40.03, 16.01, 0, 0" id="path6612"/>
         </g>
-        <g
-           transform="matrix(1.36209,-0.00108709,0,0.652685,-215.861,-103.218)"
-           id="g6618">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6616" />
+        <g transform="matrix(1.36209,-0.00108709,0,0.652685,-215.861,-103.218)" id="g6618">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6616"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)"
-           id="g6622">
-          <path
-             d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259"
-             style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8"
-             id="path6620" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)" id="g6622">
+          <path d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259" style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8" id="path6620"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)"
-           id="g6626">
-          <path
-             d="m 283.614,386.786 c 2.534,2.04 4.156,5.167 4.156,8.67 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8"
-             id="path6624" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)" id="g6626">
+          <path d="m 283.614,386.786 c 2.534,2.04 4.156,5.167 4.156,8.67 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8" id="path6624"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)"
-           id="g6630">
-          <path
-             d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 2.56,0 4.919,0.866 6.8,2.321"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6628" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)" id="g6630">
+          <path d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 2.56,0 4.919,0.866 6.8,2.321" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6628"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)"
-           id="g6634">
-          <path
-             d="m 286.036,389.492 c 1.098,1.724 1.734,3.771 1.734,5.964 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6632" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)" id="g6634">
+          <path d="m 286.036,389.492 c 1.098,1.724 1.734,3.771 1.734,5.964 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6632"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6638">
-          <path
-             d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6636" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6638">
+          <path d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6636"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6642">
-          <path
-             d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6640" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6642">
+          <path d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6640"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6646">
-          <path
-             d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461 0.424,0.773 0.76,1.602 0.992,2.473"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6644" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6646">
+          <path d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461 0.424,0.773 0.76,1.602 0.992,2.473" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6644"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6650">
-          <path
-             d="m 287.77,395.456 c 0,2.271 -0.682,4.383 -1.851,6.145"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6648" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6650">
+          <path d="m 287.77,395.456 c 0,2.271 -0.682,4.383 -1.851,6.145" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6648"/>
         </g>
-        <g
-           transform="matrix(0.694357,7.9349e-4,0,-0.47641,5.73583,359.97)"
-           id="g6654">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:35.02px;stroke-opacity:0.35"
-             id="path6652" />
+        <g transform="matrix(0.694357,7.9349e-4,0,-0.47641,5.73583,359.97)" id="g6654">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:35.02px;stroke-opacity:0.35" id="path6652"/>
         </g>
-        <g
-           transform="matrix(0.694357,7.9349e-4,0,-0.47641,5.73583,359.97)"
-           id="g6658">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:23.35px;stroke-opacity:0.35"
-             id="path6656" />
+        <g transform="matrix(0.694357,7.9349e-4,0,-0.47641,5.73583,359.97)" id="g6658">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:23.35px;stroke-opacity:0.35" id="path6656"/>
         </g>
-        <g
-           transform="matrix(0.694357,7.9349e-4,0,-0.47641,5.73583,359.97)"
-           id="g6662">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:11.67px;stroke-linecap:butt;stroke-dasharray:58.37, 23.35, 0, 0;stroke-dashoffset:35.02"
-             id="path6660" />
+        <g transform="matrix(0.694357,7.9349e-4,0,-0.47641,5.73583,359.97)" id="g6662">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:11.67px;stroke-linecap:butt;stroke-dasharray:58.37, 23.35, 0, 0;stroke-dashoffset:35.02" id="path6660"/>
         </g>
-        <g
-           transform="matrix(1.56752,-0.00125105,0,0.751127,-295.694,-109.518)"
-           id="g6666">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6664" />
+        <g transform="matrix(1.56752,-0.00125105,0,0.751127,-295.694,-109.518)" id="g6666">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6664"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-679.897,-372.383)"
-           id="g6670">
-          <path
-             d="m 283.614,386.786 c 2.534,2.04 4.156,5.167 4.156,8.67 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8"
-             id="path6668" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-679.897,-372.383)" id="g6670">
+          <path d="m 283.614,386.786 c 2.534,2.04 4.156,5.167 4.156,8.67 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8" id="path6668"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-679.897,-372.383)"
-           id="g6674">
-          <path
-             d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -2.951,0 -5.781,-1.172 -7.868,-3.259"
-             style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8"
-             id="path6672" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-679.897,-372.383)" id="g6674">
+          <path d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -2.951,0 -5.781,-1.172 -7.868,-3.259" style="fill:none;stroke:#ffffff;stroke-width:5.08px;stroke-opacity:0.8" id="path6672"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1150.02,-694.031)"
-           id="g6678">
-          <path
-             d="m 286.036,389.492 c 1.098,1.724 1.734,3.771 1.734,5.964 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6676" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1150.02,-694.031)" id="g6678">
+          <path d="m 286.036,389.492 c 1.098,1.724 1.734,3.771 1.734,5.964 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6676"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1150.02,-694.031)"
-           id="g6682">
-          <path
-             d="m 285.066,402.725 c -1.672,1.935 -3.999,3.289 -6.635,3.716"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6680" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1150.02,-694.031)" id="g6682">
+          <path d="m 285.066,402.725 c -1.672,1.935 -3.999,3.289 -6.635,3.716" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6680"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1150.02,-694.031)"
-           id="g6686">
-          <path
-             d="m 274.825,406.435 c -2.277,-0.377 -4.397,-1.457 -6.051,-3.11"
-             style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46"
-             id="path6684" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1150.02,-694.031)" id="g6686">
+          <path d="m 274.825,406.435 c -2.277,-0.377 -4.397,-1.457 -6.051,-3.11" style="fill:none;stroke:#ffffff;stroke-width:2.15px;stroke-opacity:0.46" id="path6684"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1560.27,-974.718)"
-           id="g6690">
-          <path
-             d="m 287.77,395.456 c 0,2.271 -0.682,4.383 -1.851,6.145"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6688" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1560.27,-974.718)" id="g6690">
+          <path d="m 287.77,395.456 c 0,2.271 -0.682,4.383 -1.851,6.145" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6688"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1560.27,-974.718)"
-           id="g6694">
-          <path
-             d="m 284.694,403.134 c -1.229,1.288 -2.762,2.282 -4.485,2.865 -1.119,0.379 -2.319,0.585 -3.567,0.585"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6692" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1560.27,-974.718)" id="g6694">
+          <path d="m 284.694,403.134 c -1.229,1.288 -2.762,2.282 -4.485,2.865 -1.119,0.379 -2.319,0.585 -3.567,0.585" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6692"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1560.27,-974.718)"
-           id="g6698">
-          <path
-             d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6696" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1560.27,-974.718)" id="g6698">
+          <path d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6696"/>
         </g>
-        <g
-           transform="scale(1,0.47918)"
-           id="g6702">
-          <rect
-             x="0"
-             y="241.89999"
-             width="241.911"
-             height="241.89999"
-             style="fill:none"
-             id="rect6700" />
+        <g transform="scale(1,0.47918)" id="g6702">
+          <rect x="0" y="241.89999" width="241.911" height="241.89999" style="fill:none" id="rect6700"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6808"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Cannon-dual"
-         serif:id="Cannon dual"
-         transform="translate(1693.31)">
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)"
-           id="g6709-5">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:11.01px;stroke-opacity:0.35"
-             id="path6707" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6808" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Cannon-dual" serif:id="Cannon dual" transform="translate(1693.31)">
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)" id="g6709-5">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:11.01px;stroke-opacity:0.35" id="path6707"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)"
-           id="g6713">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:16.01px;stroke-opacity:0.35"
-             id="path6711" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)" id="g6713">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:16.01px;stroke-opacity:0.35" id="path6711"/>
         </g>
-        <g
-           transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)"
-           id="g6717">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:5px;stroke-linecap:butt;stroke-dasharray:20.02, 10.01, 0, 0"
-             id="path6715-8" />
+        <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-19.1522)" id="g6717">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:5px;stroke-linecap:butt;stroke-dasharray:20.02, 10.01, 0, 0" id="path6715-8"/>
         </g>
-        <g
-           transform="matrix(1.17867,-9.40703e-4,0,0.564797,-165.121,-68.5024)"
-           id="g6721-4">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6719" />
+        <g transform="matrix(1.17867,-9.40703e-4,0,0.564797,-165.121,-68.5024)" id="g6721-4">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6719"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)"
-           id="g6725-1">
-          <path
-             d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6723" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)" id="g6725-1">
+          <path d="m 268.774,387.588 c 2.087,-2.087 4.917,-3.259 7.868,-3.259" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6723"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)"
-           id="g6729">
-          <path
-             d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6727" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-656.897,-404.967)" id="g6729">
+          <path d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6727"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)"
-           id="g6733">
-          <path
-             d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 1.374,0 2.69,0.249 3.906,0.706"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6731-0" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)" id="g6733">
+          <path d="m 271.113,385.8 c 1.669,-0.956 3.573,-1.471 5.529,-1.471 1.374,0 2.69,0.249 3.906,0.706" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6731-0"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)"
-           id="g6737">
-          <path
-             d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6735" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1127.02,-726.615)" id="g6737">
+          <path d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6735"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6741-4">
-          <path
-             d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6739-7" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6741-4">
+          <path d="m 268.774,387.588 c 0.352,-0.352 0.725,-0.677 1.116,-0.976" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6739-7"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6745">
-          <path
-             d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6743" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6745">
+          <path d="m 274.608,384.516 c 0.666,-0.123 1.347,-0.187 2.034,-0.187 1.206,0 2.366,0.192 3.454,0.547 0.516,0.169 1.016,0.374 1.497,0.614" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6743"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6749">
-          <path
-             d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6747" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6749">
+          <path d="m 284.572,387.653 c 0.718,0.729 1.336,1.557 1.832,2.461" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6747"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)"
-           id="g6753-4">
-          <path
-             d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6751-9" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1537.27,-1007.3)" id="g6753-4">
+          <path d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6751-9"/>
         </g>
-        <g
-           transform="matrix(0.826971,-6.60009e-4,0,0.396268,1.51052,44.4725)"
-           id="g6757">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:18.15px;stroke-opacity:0.35"
-             id="path6755" />
+        <g transform="matrix(0.826971,-6.60009e-4,0,0.396268,1.51052,44.4725)" id="g6757">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:18.15px;stroke-opacity:0.35" id="path6755"/>
         </g>
-        <g
-           transform="matrix(0.826971,-6.60009e-4,0,0.396268,1.51052,44.4725)"
-           id="g6761">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:24.2px;stroke-opacity:0.35"
-             id="path6759" />
+        <g transform="matrix(0.826971,-6.60009e-4,0,0.396268,1.51052,44.4725)" id="g6761">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:24.2px;stroke-opacity:0.35" id="path6759"/>
         </g>
-        <g
-           transform="matrix(0.826971,-6.60009e-4,0,0.396268,1.51052,44.4725)"
-           id="g6765">
-          <path
-             d="M 18.766,362.85 H 124.317"
-             style="fill:none;stroke:#ffffff;stroke-width:9.68px;stroke-linecap:butt;stroke-dasharray:29.05, 19.36, 0, 0;stroke-dashoffset:9.68"
-             id="path6763" />
+        <g transform="matrix(0.826971,-6.60009e-4,0,0.396268,1.51052,44.4725)" id="g6765">
+          <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:9.68px;stroke-linecap:butt;stroke-dasharray:29.05, 19.36, 0, 0;stroke-dashoffset:9.68" id="path6763"/>
         </g>
-        <g
-           transform="matrix(1.17867,-9.40703e-4,0,0.564797,-185.121,-34.9598)"
-           id="g6769">
-          <circle
-             cx="276.642"
-             cy="395.45599"
-             r="11.128"
-             style="fill:#ffffff"
-             id="circle6767" />
+        <g transform="matrix(1.17867,-9.40703e-4,0,0.564797,-185.121,-34.9598)" id="g6769">
+          <circle cx="276.642" cy="395.45599" r="11.128" style="fill:#ffffff" id="circle6767"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-676.897,-371.425)"
-           id="g6773-6">
-          <path
-             d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6771" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-676.897,-371.425)" id="g6773-6">
+          <path d="m 285.569,388.815 c 1.382,1.855 2.201,4.153 2.201,6.641 0,2.013 -0.536,3.902 -1.472,5.532" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6771"/>
         </g>
-        <g
-           transform="matrix(2.95633,-0.00235946,0,1.41662,-676.897,-371.425)"
-           id="g6777">
-          <path
-             d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -1.959,0 -3.864,-0.517 -5.535,-1.474"
-             style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8"
-             id="path6775" />
+        <g transform="matrix(2.95633,-0.00235946,0,1.41662,-676.897,-371.425)" id="g6777">
+          <path d="m 281.326,405.552 c -1.424,0.662 -3.011,1.032 -4.684,1.032 -1.959,0 -3.864,-0.517 -5.535,-1.474" style="fill:none;stroke:#ffffff;stroke-width:4.06px;stroke-opacity:0.8" id="path6775"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1147.02,-693.073)"
-           id="g6781">
-          <path
-             d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6779" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1147.02,-693.073)" id="g6781">
+          <path d="m 287.098,391.642 c 0.435,1.19 0.672,2.475 0.672,3.814 0,1.759 -0.409,3.422 -1.136,4.901" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6779"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1147.02,-693.073)"
-           id="g6785">
-          <path
-             d="m 285.066,402.725 c -1.208,1.398 -2.757,2.492 -4.518,3.153"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6783" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1147.02,-693.073)" id="g6785">
+          <path d="m 285.066,402.725 c -1.208,1.398 -2.757,2.492 -4.518,3.153" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6783"/>
         </g>
-        <g
-           transform="matrix(4.65571,-0.00371574,0,2.23092,-1147.02,-693.073)"
-           id="g6789-8">
-          <path
-             d="m 273.822,406.221 c -0.676,-0.178 -1.334,-0.418 -1.964,-0.718 -0.782,-0.372 -1.521,-0.836 -2.202,-1.385"
-             style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46"
-             id="path6787" />
+        <g transform="matrix(4.65571,-0.00371574,0,2.23092,-1147.02,-693.073)" id="g6789-8">
+          <path d="m 273.822,406.221 c -0.676,-0.178 -1.334,-0.418 -1.964,-0.718 -0.782,-0.372 -1.521,-0.836 -2.202,-1.385" style="fill:none;stroke:#ffffff;stroke-width:1.07px;stroke-opacity:0.46" id="path6787"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1557.27,-973.76)"
-           id="g6793">
-          <path
-             d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6791" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1557.27,-973.76)" id="g6793">
+          <path d="m 287.77,395.456 c 0,0.901 -0.107,1.776 -0.309,2.615" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6791"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1557.27,-973.76)"
-           id="g6797">
-          <path
-             d="m 282.566,404.876 c -0.732,0.462 -1.522,0.84 -2.357,1.123 -1.119,0.379 -2.319,0.585 -3.567,0.585"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6795" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1557.27,-973.76)" id="g6797">
+          <path d="m 282.566,404.876 c -0.732,0.462 -1.522,0.84 -2.357,1.123 -1.119,0.379 -2.319,0.585 -3.567,0.585" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6795"/>
         </g>
-        <g
-           transform="matrix(6.13867,-0.0048993,0,2.94153,-1557.27,-973.76)"
-           id="g6801-6">
-          <path
-             d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524"
-             style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33"
-             id="path6799-1" />
+        <g transform="matrix(6.13867,-0.0048993,0,2.94153,-1557.27,-973.76)" id="g6801-6">
+          <path d="m 270.675,404.849 c -0.682,-0.434 -1.32,-0.944 -1.901,-1.524" style="fill:none;stroke:#ffffff;stroke-width:0.82px;stroke-opacity:0.33" id="path6799-1"/>
         </g>
-        <g
-           transform="scale(1,0.47918)"
-           id="g6805-7">
-          <rect
-             x="0"
-             y="241.89999"
-             width="241.911"
-             height="241.89999"
-             style="fill:none"
-             id="rect6803" />
+        <g transform="scale(1,0.47918)" id="g6805-7">
+          <rect x="0" y="241.89999" width="241.911" height="241.89999" style="fill:none" id="rect6803"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)"
-       id="g6900"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Mining-Cannon-Dual"
-         serif:id="Mining Cannon Dual"
-         transform="translate(2177.1,-1.05647)">
-        <g
-           transform="matrix(0.983144,0.0876107,-0.381557,0.983144,52.5202,0.330463)"
-           id="g6838">
-          <g
-             transform="matrix(1,-7.98104e-4,0,0.47918,0,-14.3604)"
-             id="g6812">
-            <path
-               d="M 18.766,362.85 H 124.317"
-               style="fill:none;stroke:#ffffff;stroke-width:15.01px;stroke-opacity:0.35"
-               id="path6810" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,680.30997,1052.3687)" id="g6900" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Mining-Cannon-Dual" serif:id="Mining Cannon Dual" transform="translate(2177.1,-1.05647)">
+        <g transform="matrix(0.983144,0.0876107,-0.381557,0.983144,52.5202,0.330463)" id="g6838">
+          <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-14.3604)" id="g6812">
+            <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:15.01px;stroke-opacity:0.35" id="path6810"/>
           </g>
-          <g
-             transform="matrix(1,-7.98104e-4,0,0.47918,0,-14.3604)"
-             id="g6816">
-            <path
-               d="M 18.766,362.85 H 124.317"
-               style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35"
-               id="path6814" />
+          <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-14.3604)" id="g6816">
+            <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:20.02px;stroke-opacity:0.35" id="path6814"/>
           </g>
-          <g
-             transform="matrix(1,-7.98104e-4,0,0.47918,0,-14.3604)"
-             id="g6820">
-            <path
-               d="M 18.766,362.85 H 124.317"
-               style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:24.02, 16.01, 0, 0"
-               id="path6818" />
+          <g transform="matrix(1,-7.98104e-4,0,0.47918,0,-14.3604)" id="g6820">
+            <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:8.01px;stroke-linecap:butt;stroke-dasharray:24.02, 16.01, 0, 0" id="path6818"/>
           </g>
-          <g
-             transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,16.3858,227.542)"
-             id="g6824">
-            <path
-               d="M 171.45,362.85 H 374.781"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6822" />
+          <g transform="matrix(-0.244315,-0.202578,0.423167,-0.117409,16.3858,227.542)" id="g6824">
+            <path d="M 171.45,362.85 H 374.781" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6822"/>
           </g>
-          <g
-             transform="matrix(-0.396911,-0.136274,0.28447,-0.19058,85.1685,246.072)"
-             id="g6828">
-            <path
-               d="m 196.02,362.85 h 39.624"
-               style="fill:none;stroke:#ffffff;stroke-width:18.41px"
-               id="path6826" />
+          <g transform="matrix(-0.396911,-0.136274,0.28447,-0.19058,85.1685,246.072)" id="g6828">
+            <path d="m 196.02,362.85 h 39.624" style="fill:none;stroke:#ffffff;stroke-width:18.41px" id="path6826"/>
           </g>
-          <g
-             transform="matrix(-0.396911,-0.136274,0.28447,-0.19058,85.1685,246.072)"
-             id="g6832">
-            <path
-               d="m 264.931,362.85 h 25.361"
-               style="fill:none;stroke:#ffffff;stroke-width:10.23px"
-               id="path6830" />
+          <g transform="matrix(-0.396911,-0.136274,0.28447,-0.19058,85.1685,246.072)" id="g6832">
+            <path d="m 264.931,362.85 h 25.361" style="fill:none;stroke:#ffffff;stroke-width:10.23px" id="path6830"/>
           </g>
-          <g
-             transform="matrix(-0.0828541,-0.23058,0.481823,-0.0399514,-24.4264,202.823)"
-             id="g6836">
-            <path
-               d="M 189.044,362.85 H 290.292"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6834" />
+          <g transform="matrix(-0.0828541,-0.23058,0.481823,-0.0399514,-24.4264,202.823)" id="g6836">
+            <path d="M 189.044,362.85 H 290.292" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6834"/>
           </g>
         </g>
-        <g
-           transform="matrix(0.988675,-0.0719131,0.313192,0.988675,-57.5956,1.37789)"
-           id="g6880">
-          <g
-             transform="matrix(0.897302,-7.1614e-4,0,0.429969,2.76717,32.2451)"
-             id="g6842">
-            <path
-               d="M 18.766,362.85 H 124.317"
-               style="fill:none;stroke:#ffffff;stroke-width:16.73px;stroke-opacity:0.35"
-               id="path6840" />
+        <g transform="matrix(0.988675,-0.0719131,0.313192,0.988675,-57.5956,1.37789)" id="g6880">
+          <g transform="matrix(0.897302,-7.1614e-4,0,0.429969,2.76717,32.2451)" id="g6842">
+            <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:16.73px;stroke-opacity:0.35" id="path6840"/>
           </g>
-          <g
-             transform="matrix(0.897302,-7.1614e-4,0,0.429969,2.76717,32.2451)"
-             id="g6846">
-            <path
-               d="M 18.766,362.85 H 124.317"
-               style="fill:none;stroke:#ffffff;stroke-width:22.31px;stroke-opacity:0.35"
-               id="path6844" />
+          <g transform="matrix(0.897302,-7.1614e-4,0,0.429969,2.76717,32.2451)" id="g6846">
+            <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:22.31px;stroke-opacity:0.35" id="path6844"/>
           </g>
-          <g
-             transform="matrix(0.897302,-7.1614e-4,0,0.429969,2.76717,32.2451)"
-             id="g6850">
-            <path
-               d="M 18.766,362.85 H 124.317"
-               style="fill:none;stroke:#ffffff;stroke-width:8.92px;stroke-linecap:butt;stroke-dasharray:26.77, 17.85, 0, 0"
-               id="path6848" />
+          <g transform="matrix(0.897302,-7.1614e-4,0,0.429969,2.76717,32.2451)" id="g6850">
+            <path d="M 18.766,362.85 H 124.317" style="fill:none;stroke:#ffffff;stroke-width:8.92px;stroke-linecap:butt;stroke-dasharray:26.77, 17.85, 0, 0" id="path6848"/>
           </g>
-          <g
-             transform="matrix(-0.471641,0.0605568,-0.126951,-0.226277,233.491,263.969)"
-             id="g6854">
-            <path
-               d="m 264.931,362.85 h 25.361"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6852" />
+          <g transform="matrix(-0.471641,0.0605568,-0.126951,-0.226277,233.491,263.969)" id="g6854">
+            <path d="m 264.931,362.85 h 25.361" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6852"/>
           </g>
-          <g
-             transform="matrix(-0.126376,0.226001,-0.472427,-0.060456,317.087,183.791)"
-             id="g6858">
-            <path
-               d="m 264.931,362.85 h 25.361"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6856" />
+          <g transform="matrix(-0.126376,0.226001,-0.472427,-0.060456,317.087,183.791)" id="g6858">
+            <path d="m 264.931,362.85 h 25.361" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6856"/>
           </g>
-          <g
-             transform="matrix(-0.345265,0.165444,-0.346051,-0.165545,297.706,229.247)"
-             id="g6862">
-            <path
-               d="m 230.962,362.85 h 21.839"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6860" />
+          <g transform="matrix(-0.345265,0.165444,-0.346051,-0.165545,297.706,229.247)" id="g6862">
+            <path d="m 230.962,362.85 h 21.839" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6860"/>
           </g>
-          <g
-             transform="matrix(-0.4047,0.130908,-0.273924,-0.194095,278.724,243.783)"
-             id="g6866">
-            <path
-               d="m 171.45,362.85 h 35.656"
-               style="fill:none;stroke:#ffffff;stroke-width:20.46px"
-               id="path6864" />
+          <g transform="matrix(-0.4047,0.130908,-0.273924,-0.194095,278.724,243.783)" id="g6866">
+            <path d="m 171.45,362.85 h 35.656" style="fill:none;stroke:#ffffff;stroke-width:20.46px" id="path6864"/>
           </g>
-          <g
-             transform="matrix(-0.4047,0.130908,-0.273924,-0.194095,278.724,243.783)"
-             id="g6870">
-            <path
-               d="m 234.028,362.85 h 56.264"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6868" />
+          <g transform="matrix(-0.4047,0.130908,-0.273924,-0.194095,278.724,243.783)" id="g6870">
+            <path d="m 234.028,362.85 h 56.264" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6868"/>
           </g>
-          <g
-             transform="matrix(-0.196576,0.214175,-0.447769,-0.0941532,316.631,197.448)"
-             id="g6874">
-            <path
-               d="M 171.45,362.85 H 290.292"
-               style="fill:none;stroke:#ffffff;stroke-width:18.41px"
-               id="path6872" />
+          <g transform="matrix(-0.196576,0.214175,-0.447769,-0.0941532,316.631,197.448)" id="g6874">
+            <path d="M 171.45,362.85 H 290.292" style="fill:none;stroke:#ffffff;stroke-width:18.41px" id="path6872"/>
           </g>
-          <g
-             transform="matrix(-0.0209107,0.233759,-0.488552,-0.00983979,310.182,164.486)"
-             id="g6878">
-            <path
-               d="M 212.921,362.85 H 352.388"
-               style="fill:none;stroke:#ffffff;stroke-width:12.27px"
-               id="path6876" />
+          <g transform="matrix(-0.0209107,0.233759,-0.488552,-0.00983979,310.182,164.486)" id="g6878">
+            <path d="M 212.921,362.85 H 352.388" style="fill:none;stroke:#ffffff;stroke-width:12.27px" id="path6876"/>
           </g>
         </g>
-        <g
-           id="rect73031"
-           serif:id="rect7303"
-           transform="matrix(1.06667,0,0,0.511127,-6289.17,1085.92)">
-          <rect
-             x="5896.1001"
-             y="-1895.7"
-             width="226.77"
-             height="226.77"
-             style="fill:none"
-             id="rect6882" />
+        <g id="rect73031" serif:id="rect7303" transform="matrix(1.06667,0,0,0.511127,-6289.17,1085.92)">
+          <rect x="5896.1001" y="-1895.7" width="226.77" height="226.77" style="fill:none" id="rect6882"/>
         </g>
-        <g
-           transform="matrix(0.74995,-0.266075,0.555272,0.359361,527.236,1156.25)"
-           id="g6897">
-          <g
-             id="path73011"
-             serif:id="path7301"
-             transform="translate(-4989,-226.77)">
-            <path
-               d="m 5973.6,-1769.5 c 6.24,-5.46 10.44,-7.23 16.1,-6.22 5.28,0.94 8.04,4.04 12.08,10.61 -6.22,-4.23 -6.53,-5.22 -12.81,-6.95 -3.6,-1 -8.25,0.89 -15.37,2.56 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path6885" />
+        <g transform="matrix(0.74995,-0.266075,0.555272,0.359361,527.236,1156.25)" id="g6897">
+          <g id="path73011" serif:id="path7301" transform="translate(-4989,-226.77)">
+            <path d="m 5973.6,-1769.5 c 6.24,-5.46 10.44,-7.23 16.1,-6.22 5.28,0.94 8.04,4.04 12.08,10.61 -6.22,-4.23 -6.53,-5.22 -12.81,-6.95 -3.6,-1 -8.25,0.89 -15.37,2.56 z" style="fill:#ffffff;fill-rule:nonzero" id="path6885"/>
           </g>
-          <g
-             id="path73051"
-             serif:id="path7305"
-             transform="translate(-4989,-226.77)">
-            <path
-               d="m 6009.2,-1802 c 0,0 21.38,30.6 23.71,44.6 2.38,14.26 -4.89,26 -10.51,31.72 -7.53,7.67 -15.7,8.19 -22.51,6.48 0,0 -11.29,-7.91 -17.78,-9.84 -6.51,-1.94 -14.17,1.34 -20.34,-1.51 -4.31,-1.99 -10.01,-10.13 -10.01,-10.13 -10.95,-8.71 0.35,-23.97 3.62,-32.86 3.95,-10.72 17.16,-28.1 25.1,-27.17 z"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:14.17px;stroke-linecap:butt;stroke-miterlimit:4"
-               id="path6888" />
+          <g id="path73051" serif:id="path7305" transform="translate(-4989,-226.77)">
+            <path d="m 6009.2,-1802 c 0,0 21.38,30.6 23.71,44.6 2.38,14.26 -4.89,26 -10.51,31.72 -7.53,7.67 -15.7,8.19 -22.51,6.48 0,0 -11.29,-7.91 -17.78,-9.84 -6.51,-1.94 -14.17,1.34 -20.34,-1.51 -4.31,-1.99 -10.01,-10.13 -10.01,-10.13 -10.95,-8.71 0.35,-23.97 3.62,-32.86 3.95,-10.72 17.16,-28.1 25.1,-27.17 z" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:14.17px;stroke-linecap:butt;stroke-miterlimit:4" id="path6888"/>
           </g>
-          <g
-             id="path73111"
-             serif:id="path7311"
-             transform="translate(-4989,-226.77)">
-            <path
-               d="m 6012.7,-1747.5 c -1.32,4.24 -2.73,6.22 -5.56,7.33 -2.64,1.04 -4.74,0.39 -8.36,-1.5 3.96,0.21 4.37,0.57 7.69,-0.38 1.89,-0.55 3.48,-2.7 6.23,-5.45 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path6891" />
+          <g id="path73111" serif:id="path7311" transform="translate(-4989,-226.77)">
+            <path d="m 6012.7,-1747.5 c -1.32,4.24 -2.73,6.22 -5.56,7.33 -2.64,1.04 -4.74,0.39 -8.36,-1.5 3.96,0.21 4.37,0.57 7.69,-0.38 1.89,-0.55 3.48,-2.7 6.23,-5.45 z" style="fill:#ffffff;fill-rule:nonzero" id="path6891"/>
           </g>
-          <g
-             id="path73131"
-             serif:id="path7313"
-             transform="translate(-4989,-226.77)">
-            <path
-               d="m 5985.9,-1745.2 c -4.32,1.02 -6.74,0.8 -9.14,-1.07 -2.23,-1.75 -2.74,-3.89 -2.95,-7.97 2.38,-2.88 7.03,-1.79 9.54,0.58 1.43,1.36 2.81,3.82 2.55,8.46 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path6894" />
+          <g id="path73131" serif:id="path7313" transform="translate(-4989,-226.77)">
+            <path d="m 5985.9,-1745.2 c -4.32,1.02 -6.74,0.8 -9.14,-1.07 -2.23,-1.75 -2.74,-3.89 -2.95,-7.97 2.38,-2.88 7.03,-1.79 9.54,0.58 1.43,1.36 2.81,3.82 2.55,8.46 z" style="fill:#ffffff;fill-rule:nonzero" id="path6894"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,906.92261,825.44492)"
-       id="g6917"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Shield"
-         transform="matrix(1.06667,0,0,0.511127,-2902.62,1084.84)">
-        <g
-           id="g5927-0"
-           transform="matrix(0.75529,0,0,0.75529,-2389.37,359.964)">
-          <g
-             id="path5923-8"
-             transform="translate(4081.9,-3483.1)">
-            <path
-               d="m 2834.61,1168.67 c 23.61,0 52.75,1.82 72.59,8.68 3.81,1.36 6.58,5.04 6.58,9.34 l -0.04,0.71 c -1.69,46.09 -9.68,87.92 -13.69,91.97 -9.18,12.16 -38.45,31.67 -54.27,42 -3.77,2.44 -7.36,4.3 -11.17,4.39 -3.8,-0.09 -7.39,-1.95 -11.16,-4.39 -15.83,-10.33 -45.1,-29.84 -54.27,-42 -4.02,-4.05 -11.99,-45.88 -13.69,-91.97 l -0.04,-0.71 h -0.01 c 0,-4.3 2.77,-7.98 6.57,-9.34 19.85,-6.86 48.99,-8.68 72.6,-8.68 z"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:8.69px;stroke-linecap:butt;stroke-miterlimit:2;stroke-dasharray:26.07, 8.69, 0, 0;stroke-opacity:0.62"
-               id="path6902" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,906.92261,825.44492)" id="g6917" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Shield" transform="matrix(1.06667,0,0,0.511127,-2902.62,1084.84)">
+        <g id="g5927-0" transform="matrix(0.75529,0,0,0.75529,-2389.37,359.964)">
+          <g id="path5923-8" transform="translate(4081.9,-3483.1)">
+            <path d="m 2834.61,1168.67 c 23.61,0 52.75,1.82 72.59,8.68 3.81,1.36 6.58,5.04 6.58,9.34 l -0.04,0.71 c -1.69,46.09 -9.68,87.92 -13.69,91.97 -9.18,12.16 -38.45,31.67 -54.27,42 -3.77,2.44 -7.36,4.3 -11.17,4.39 -3.8,-0.09 -7.39,-1.95 -11.16,-4.39 -15.83,-10.33 -45.1,-29.84 -54.27,-42 -4.02,-4.05 -11.99,-45.88 -13.69,-91.97 l -0.04,-0.71 h -0.01 c 0,-4.3 2.77,-7.98 6.57,-9.34 19.85,-6.86 48.99,-8.68 72.6,-8.68 z" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:8.69px;stroke-linecap:butt;stroke-miterlimit:2;stroke-dasharray:26.07, 8.69, 0, 0;stroke-opacity:0.62" id="path6902"/>
           </g>
-          <g
-             id="path59231"
-             serif:id="path5923"
-             transform="matrix(1.26407,0,0,1.26407,3333.37,-3812.45)">
-            <path
-               d="m 2834.61,1168.67 c 23.61,0 52.75,1.82 72.59,8.68 3.81,1.36 6.58,5.04 6.58,9.34 l -0.04,0.71 c -1.69,46.09 -9.68,87.92 -13.69,91.97 -9.18,12.16 -38.45,31.67 -54.27,42 -3.77,2.44 -7.36,4.3 -11.17,4.39 -3.8,-0.09 -7.39,-1.95 -11.16,-4.39 -15.83,-10.33 -45.1,-29.84 -54.27,-42 -4.02,-4.05 -11.99,-45.88 -13.69,-91.97 l -0.04,-0.71 h -0.01 c 0,-4.3 2.77,-7.98 6.57,-9.34 19.85,-6.86 48.99,-8.68 72.6,-8.68 z"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:6.87px;stroke-linecap:butt;stroke-miterlimit:2;stroke-dasharray:6.87, 6.87;stroke-opacity:0.27"
-               id="path6905-6" />
+          <g id="path59231" serif:id="path5923" transform="matrix(1.26407,0,0,1.26407,3333.37,-3812.45)">
+            <path d="m 2834.61,1168.67 c 23.61,0 52.75,1.82 72.59,8.68 3.81,1.36 6.58,5.04 6.58,9.34 l -0.04,0.71 c -1.69,46.09 -9.68,87.92 -13.69,91.97 -9.18,12.16 -38.45,31.67 -54.27,42 -3.77,2.44 -7.36,4.3 -11.17,4.39 -3.8,-0.09 -7.39,-1.95 -11.16,-4.39 -15.83,-10.33 -45.1,-29.84 -54.27,-42 -4.02,-4.05 -11.99,-45.88 -13.69,-91.97 l -0.04,-0.71 h -0.01 c 0,-4.3 2.77,-7.98 6.57,-9.34 19.85,-6.86 48.99,-8.68 72.6,-8.68 z" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:6.87px;stroke-linecap:butt;stroke-miterlimit:2;stroke-dasharray:6.87, 6.87;stroke-opacity:0.27" id="path6905-6"/>
           </g>
-          <rect
-             id="rect5925-4"
-             x="6803.1001"
-             y="-2349.2"
-             width="226.77"
-             height="226.77"
-             style="fill:none" />
+          <rect id="rect5925-4" x="6803.1001" y="-2349.2" width="226.77" height="226.77" style="fill:none"/>
         </g>
-        <g
-           id="path5929-0"
-           transform="matrix(0.75529,0,0,0.75529,693.651,-325.152)">
-          <path
-             d="m 2834.7,-1394.4 c -18.52,0 -41.34,1.45 -56.88,6.86 -2.98,1.08 -5.13,3.97 -5.13,7.32 v 0.58 c 1.32,36.38 8.1,68.91 11.2,72.09 7.2,9.59 29.48,25.39 42.05,33.32 3.1,1.99 5.74,2.36 8.72,2.44 2.98,-0.08 5.62,-0.58 8.72,-2.44 12.82,-7.56 35.39,-23.73 42.54,-33.32 3.14,-3.18 9.42,-35.71 10.75,-72.09 l 0.04,-0.58 c 0,-3.35 -2.15,-6.24 -5.13,-7.32 -15.58,-5.41 -38.4,-6.86 -56.88,-6.86 z m -14.19,63.47 h 30 v 28.5 h -30 z"
-             style="fill:#ffffff;fill-rule:nonzero"
-             id="path6910" />
+        <g id="path5929-0" transform="matrix(0.75529,0,0,0.75529,693.651,-325.152)">
+          <path d="m 2834.7,-1394.4 c -18.52,0 -41.34,1.45 -56.88,6.86 -2.98,1.08 -5.13,3.97 -5.13,7.32 v 0.58 c 1.32,36.38 8.1,68.91 11.2,72.09 7.2,9.59 29.48,25.39 42.05,33.32 3.1,1.99 5.74,2.36 8.72,2.44 2.98,-0.08 5.62,-0.58 8.72,-2.44 12.82,-7.56 35.39,-23.73 42.54,-33.32 3.14,-3.18 9.42,-35.71 10.75,-72.09 l 0.04,-0.58 c 0,-3.35 -2.15,-6.24 -5.13,-7.32 -15.58,-5.41 -38.4,-6.86 -56.88,-6.86 z m -14.19,63.47 h 30 v 28.5 h -30 z" style="fill:#ffffff;fill-rule:nonzero" id="path6910"/>
         </g>
-        <g
-           id="rect5931-1"
-           transform="translate(-0.0140235,4.77529e-4)">
-          <rect
-             x="2721.3"
-             y="-1442.1"
-             width="226.77"
-             height="226.77"
-             style="fill:none"
-             id="rect6913" />
+        <g id="rect5931-1" transform="translate(-0.0140235,4.77529e-4)">
+          <rect x="2721.3" y="-1442.1" width="226.77" height="226.77" style="fill:none" id="rect6913"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,906.98277,825.64899)"
-       id="g6936"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Atmo-Shield"
-         serif:id="Atmo Shield"
-         transform="matrix(-1.06667,0,0,-0.511127,3386.64,-273.478)">
-        <g
-           id="g59271"
-           serif:id="g5927"
-           transform="matrix(0.534071,-0.534071,0.534071,0.534071,333.351,3561.45)">
-          <g
-             id="path59232"
-             serif:id="path5923"
-             transform="translate(4081.9,-3483.1)">
-            <path
-               d="m 2834.86,1380.56 c -22.98,-7.65 -58.79,-59.29 -69.74,-105.08 -7.93,-33.14 -8.92,-68.73 -9.63,-88.08 l -0.04,-0.71 h -0.01 c 0,-4.3 2.77,-7.98 6.57,-9.34 19.85,-6.86 48.99,-8.68 72.6,-8.68 v 0 c 23.61,0 52.75,1.82 72.59,8.68 3.81,1.36 6.58,5.04 6.58,9.34 l -0.04,0.71 c 11.1,57.8 -33,172.8 -78.88,193.16 z"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:8.69px;stroke-linecap:butt;stroke-miterlimit:2;stroke-dasharray:26.07, 8.69, 0, 0;stroke-opacity:0.57"
-               id="path6919-5" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,906.98277,825.64899)" id="g6936" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Atmo-Shield" serif:id="Atmo Shield" transform="matrix(-1.06667,0,0,-0.511127,3386.64,-273.478)">
+        <g id="g59271" serif:id="g5927" transform="matrix(0.534071,-0.534071,0.534071,0.534071,333.351,3561.45)">
+          <g id="path59232" serif:id="path5923" transform="translate(4081.9,-3483.1)">
+            <path d="m 2834.86,1380.56 c -22.98,-7.65 -58.79,-59.29 -69.74,-105.08 -7.93,-33.14 -8.92,-68.73 -9.63,-88.08 l -0.04,-0.71 h -0.01 c 0,-4.3 2.77,-7.98 6.57,-9.34 19.85,-6.86 48.99,-8.68 72.6,-8.68 v 0 c 23.61,0 52.75,1.82 72.59,8.68 3.81,1.36 6.58,5.04 6.58,9.34 l -0.04,0.71 c 11.1,57.8 -33,172.8 -78.88,193.16 z" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:8.69px;stroke-linecap:butt;stroke-miterlimit:2;stroke-dasharray:26.07, 8.69, 0, 0;stroke-opacity:0.57" id="path6919-5"/>
           </g>
-          <g
-             id="path59233"
-             serif:id="path5923"
-             transform="matrix(1.26407,0,0,1.26407,3333.37,-3812.45)">
-            <path
-               d="m 2742.06,1275.24 c 2.62,-46.65 23.65,-93.31 27.07,-94.54 19.85,-6.86 41.87,-12.03 65.48,-12.03 v 0 c 23.61,0 45.63,4.75 65.47,11.61 3.81,1.37 24.38,56.13 24.21,105.8"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:10.8px;stroke-linecap:butt;stroke-miterlimit:2;stroke-opacity:0.84"
-               id="path6922" />
+          <g id="path59233" serif:id="path5923" transform="matrix(1.26407,0,0,1.26407,3333.37,-3812.45)">
+            <path d="m 2742.06,1275.24 c 2.62,-46.65 23.65,-93.31 27.07,-94.54 19.85,-6.86 41.87,-12.03 65.48,-12.03 v 0 c 23.61,0 45.63,4.75 65.47,11.61 3.81,1.37 24.38,56.13 24.21,105.8" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:10.8px;stroke-linecap:butt;stroke-miterlimit:2;stroke-opacity:0.84" id="path6922"/>
           </g>
-          <g
-             id="path59234"
-             serif:id="path5923"
-             transform="matrix(1.53896,0,0,1.53896,2554.56,-4149.84)">
-            <path
-               d="m 2742.06,1275.24 c 2.62,-46.65 23.65,-93.31 27.07,-94.54 19.85,-6.86 41.87,-12.03 65.48,-12.03 v 0 c 23.61,0 45.63,4.75 65.47,11.61 3.81,1.37 24.38,56.13 24.21,105.8"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:4.03px;stroke-linecap:butt;stroke-miterlimit:2;stroke-opacity:0.66"
-               id="path6925" />
+          <g id="path59234" serif:id="path5923" transform="matrix(1.53896,0,0,1.53896,2554.56,-4149.84)">
+            <path d="m 2742.06,1275.24 c 2.62,-46.65 23.65,-93.31 27.07,-94.54 19.85,-6.86 41.87,-12.03 65.48,-12.03 v 0 c 23.61,0 45.63,4.75 65.47,11.61 3.81,1.37 24.38,56.13 24.21,105.8" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:4.03px;stroke-linecap:butt;stroke-miterlimit:2;stroke-opacity:0.66" id="path6925"/>
           </g>
         </g>
-        <g
-           id="path59291"
-           serif:id="path5929"
-           transform="matrix(0.534071,-0.534071,0.534071,0.534071,2028.92,896.98)">
-          <path
-             d="m 2834.7,-1394.4 c -18.52,0 -41.34,1.45 -56.88,6.86 -2.98,1.08 -5.13,3.97 -5.13,7.32 v 0.58 c 1.32,36.38 8.1,68.91 11.2,72.09 7.2,9.59 29.48,25.39 42.05,33.32 3.1,1.99 5.74,2.36 8.72,2.44 2.98,-0.08 5.62,-0.58 8.72,-2.44 12.82,-7.56 35.39,-23.73 42.54,-33.32 3.14,-3.18 9.42,-35.71 10.75,-72.09 l 0.04,-0.58 c 0,-3.35 -2.15,-6.24 -5.13,-7.32 -15.58,-5.41 -38.4,-6.86 -56.88,-6.86 z m -14.19,63.47 h 30 v 28.5 h -30 z"
-             style="fill:#ffffff;fill-rule:nonzero"
-             id="path6929" />
+        <g id="path59291" serif:id="path5929" transform="matrix(0.534071,-0.534071,0.534071,0.534071,2028.92,896.98)">
+          <path d="m 2834.7,-1394.4 c -18.52,0 -41.34,1.45 -56.88,6.86 -2.98,1.08 -5.13,3.97 -5.13,7.32 v 0.58 c 1.32,36.38 8.1,68.91 11.2,72.09 7.2,9.59 29.48,25.39 42.05,33.32 3.1,1.99 5.74,2.36 8.72,2.44 2.98,-0.08 5.62,-0.58 8.72,-2.44 12.82,-7.56 35.39,-23.73 42.54,-33.32 3.14,-3.18 9.42,-35.71 10.75,-72.09 l 0.04,-0.58 c 0,-3.35 -2.15,-6.24 -5.13,-7.32 -15.58,-5.41 -38.4,-6.86 -56.88,-6.86 z m -14.19,63.47 h 30 v 28.5 h -30 z" style="fill:#ffffff;fill-rule:nonzero" id="path6929"/>
         </g>
-        <g
-           id="rect59311"
-           serif:id="rect5931"
-           transform="translate(-0.0140235,4.77529e-4)">
-          <rect
-             x="2721.3"
-             y="-1442.1"
-             width="226.77"
-             height="226.77"
-             style="fill:none"
-             id="rect6932" />
+        <g id="rect59311" serif:id="rect5931" transform="translate(-0.0140235,4.77529e-4)">
+          <rect x="2721.3" y="-1442.1" width="226.77" height="226.77" style="fill:none" id="rect6932"/>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(-1343.0584,3401.53)"
-       id="g6941"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="g5295-2"
-         transform="translate(-3645.88,1133.9)">
-        <path
-           id="path5291-8"
-           d="m 6472.5,-2946.2 -12.61,12.53 -50.51,-50.52 c -1.49,-1.49 -3.52,-2.4 -5.79,-2.4 -3.68,0 -6.82,2.44 -7.86,5.75 l -0.45,1.49 c -3.02,9.5 -4.67,19.63 -4.67,30.17 0,24.6 8.93,47.09 23.73,64.41 l -1.57,2.07 c -7.28,7.23 -11.45,16.41 -12.49,25.87 -13.93,3.64 -25.01,13.98 -29.39,27.29 0,0 -0.95,2.52 -0.95,4.38 0,4.55 3.8,8.27 8.47,8.27 h 65.73 c 4.67,0 8.48,-3.72 8.48,-8.27 0,-2.6 -1.16,-4.96 -1.16,-4.96 -4.63,-13.35 -16,-23.6 -30.18,-26.95 0.91,-4.05 2.94,-7.9 6.08,-11.04 l 1.9,-2.48 c 16.74,12.94 37.74,20.63 60.56,20.63 10.38,0 20.38,-1.57 29.77,-4.55 0.45,-0.12 2.1,-0.83 2.1,-0.83 3.15,-1.15 5.42,-4.17 5.42,-7.73 0,-2.31 -0.95,-4.42 -2.52,-5.91 l -1.28,-1.24 -49.03,-49.07 12.56,-12.56 c 3.97,-3.97 3.97,-10.38 0,-14.35 -3.96,-3.97 -10.37,-3.97 -14.34,0 z m 29.72,7.36 c 0,5.7 4.63,10.33 10.34,10.33 5.7,0 10.33,-4.63 10.33,-10.33 l -0.04,-2.07 c -0.49,-10.42 -4.71,-20.67 -12.69,-28.6 -7.94,-7.98 -18.19,-12.2 -28.61,-12.7 l -2.06,-0.04 c -5.71,0 -10.34,4.63 -10.34,10.34 0,5.7 4.63,10.33 10.34,10.33 0.7,0 2.06,0.09 2.06,0.09 5.13,0.49 10.09,2.64 14.02,6.57 3.92,3.93 6.08,8.89 6.53,14.01 0,0 0.12,1.37 0.12,2.07 z m 33.07,0 c 0,5.7 4.63,10.33 10.34,10.33 5.7,0 10.33,-4.63 10.33,-10.33 l -0.04,-2.07 c -0.49,-18.89 -7.93,-37.62 -22.36,-52 -14.39,-14.43 -33.11,-21.87 -52,-22.37 l -2.07,-0.04 c -5.71,0 -10.34,4.63 -10.34,10.34 0,5.7 4.63,10.33 10.34,10.33 l 2.07,0.04 c 13.6,0.5 27.03,5.96 37.41,16.29 10.33,10.38 15.79,23.81 16.28,37.41 z"
-           style="fill:#ffffff;fill-rule:nonzero" />
-        <rect
-           id="rect5293-7"
-           x="6349.6001"
-           y="-3029.5"
-           width="226.77"
-           height="226.77"
-           style="fill:none" />
+    <g transform="translate(-1343.0584,3401.53)" id="g6941" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="g5295-2" transform="translate(-3645.88,1133.9)">
+        <path id="path5291-8" d="m 6472.5,-2946.2 -12.61,12.53 -50.51,-50.52 c -1.49,-1.49 -3.52,-2.4 -5.79,-2.4 -3.68,0 -6.82,2.44 -7.86,5.75 l -0.45,1.49 c -3.02,9.5 -4.67,19.63 -4.67,30.17 0,24.6 8.93,47.09 23.73,64.41 l -1.57,2.07 c -7.28,7.23 -11.45,16.41 -12.49,25.87 -13.93,3.64 -25.01,13.98 -29.39,27.29 0,0 -0.95,2.52 -0.95,4.38 0,4.55 3.8,8.27 8.47,8.27 h 65.73 c 4.67,0 8.48,-3.72 8.48,-8.27 0,-2.6 -1.16,-4.96 -1.16,-4.96 -4.63,-13.35 -16,-23.6 -30.18,-26.95 0.91,-4.05 2.94,-7.9 6.08,-11.04 l 1.9,-2.48 c 16.74,12.94 37.74,20.63 60.56,20.63 10.38,0 20.38,-1.57 29.77,-4.55 0.45,-0.12 2.1,-0.83 2.1,-0.83 3.15,-1.15 5.42,-4.17 5.42,-7.73 0,-2.31 -0.95,-4.42 -2.52,-5.91 l -1.28,-1.24 -49.03,-49.07 12.56,-12.56 c 3.97,-3.97 3.97,-10.38 0,-14.35 -3.96,-3.97 -10.37,-3.97 -14.34,0 z m 29.72,7.36 c 0,5.7 4.63,10.33 10.34,10.33 5.7,0 10.33,-4.63 10.33,-10.33 l -0.04,-2.07 c -0.49,-10.42 -4.71,-20.67 -12.69,-28.6 -7.94,-7.98 -18.19,-12.2 -28.61,-12.7 l -2.06,-0.04 c -5.71,0 -10.34,4.63 -10.34,10.34 0,5.7 4.63,10.33 10.34,10.33 0.7,0 2.06,0.09 2.06,0.09 5.13,0.49 10.09,2.64 14.02,6.57 3.92,3.93 6.08,8.89 6.53,14.01 0,0 0.12,1.37 0.12,2.07 z m 33.07,0 c 0,5.7 4.63,10.33 10.34,10.33 5.7,0 10.33,-4.63 10.33,-10.33 l -0.04,-2.07 c -0.49,-18.89 -7.93,-37.62 -22.36,-52 -14.39,-14.43 -33.11,-21.87 -52,-22.37 l -2.07,-0.04 c -5.71,0 -10.34,4.63 -10.34,10.34 0,5.7 4.63,10.33 10.34,10.33 l 2.07,0.04 c 13.6,0.5 27.03,5.96 37.41,16.29 10.33,10.38 15.79,23.81 16.28,37.41 z" style="fill:#ffffff;fill-rule:nonzero"/>
+        <rect id="rect5293-7" x="6349.6001" y="-3029.5" width="226.77" height="226.77" style="fill:none"/>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,2267.6154,371.87006)"
-       id="g6977"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Cabin---empty"
-         serif:id="Cabin - empty"
-         transform="matrix(1.06667,0,0,0.511127,-2883.96,1432.55)">
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)"
-           id="g6946">
-          <path
-             d="M 25.496,1330.45 H 216.378"
-             style="fill:none;stroke:#ffffff;stroke-width:15px;stroke-linecap:butt"
-             id="path6944" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,2267.6154,371.87006)" id="g6977" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Cabin---empty" serif:id="Cabin - empty" transform="matrix(1.06667,0,0,0.511127,-2883.96,1432.55)">
+        <g transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)" id="g6946">
+          <path d="M 25.496,1330.45 H 216.378" style="fill:none;stroke:#ffffff;stroke-width:15px;stroke-linecap:butt" id="path6944"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)"
-           id="g6950">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:10px;stroke-linecap:butt"
-             id="path6948" />
+        <g transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)" id="g6950">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:10px;stroke-linecap:butt" id="path6948"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937507,2747.3,-2802.74)"
-           id="g6954">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:10px;stroke-linecap:butt"
-             id="path6952" />
+        <g transform="matrix(0.937497,0,0,0.937507,2747.3,-2802.74)" id="g6954">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:10px;stroke-linecap:butt" id="path6952"/>
         </g>
-        <g
-           transform="matrix(0,-0.937497,0.409432,0,2276.87,-1420.23)"
-           id="g6958">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt"
-             id="path6956" />
+        <g transform="matrix(0,-0.937497,0.409432,0,2276.87,-1420.23)" id="g6958">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt" id="path6956"/>
         </g>
-        <g
-           transform="matrix(0,-0.937497,0.409432,0,2276.87,-1397.31)"
-           id="g6962">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt"
-             id="path6960-1" />
+        <g transform="matrix(0,-0.937497,0.409432,0,2276.87,-1397.31)" id="g6962">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt" id="path6960-1"/>
         </g>
-        <g
-           transform="matrix(0,-0.937497,0.409432,0,2276.87,-1374.41)"
-           id="g6966">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt"
-             id="path6964-4" />
+        <g transform="matrix(0,-0.937497,0.409432,0,2276.87,-1374.41)" id="g6966">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt" id="path6964-4"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2703.71,-2813.9)"
-           id="g6970-9">
-          <path
-             d="m 216.378,1294.66 c 0,-26.33 -21.383,-47.72 -47.72,-47.72 H 73.217 c -26.338,0 -47.721,21.39 -47.721,47.72 v 95.45 c 0,26.33 21.383,47.72 47.721,47.72 h 95.441 c 26.337,0 47.72,-21.39 47.72,-47.72 z"
-             style="fill:none;stroke:#ffffff;stroke-width:15px;stroke-linecap:butt"
-             id="path6968" />
+        <g transform="matrix(0.937497,0,0,0.937497,2703.71,-2813.9)" id="g6970-9">
+          <path d="m 216.378,1294.66 c 0,-26.33 -21.383,-47.72 -47.72,-47.72 H 73.217 c -26.338,0 -47.721,21.39 -47.721,47.72 v 95.45 c 0,26.33 21.383,47.72 47.721,47.72 h 95.441 c 26.337,0 47.72,-21.39 47.72,-47.72 z" style="fill:none;stroke:#ffffff;stroke-width:15px;stroke-linecap:butt" id="path6968"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)"
-           id="g6974">
-          <rect
-             x="0.011"
-             y="1209.49"
-             width="241.88901"
-             height="241.911"
-             style="fill:none"
-             id="rect6972-1" />
+        <g transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)" id="g6974">
+          <rect x="0.011" y="1209.49" width="241.88901" height="241.911" style="fill:none" id="rect6972-1"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,2267.6154,371.87006)"
-       id="g7032-3"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Cabin---occupied"
-         serif:id="Cabin - occupied"
-         transform="matrix(1.06667,0,0,0.511127,-2642.07,1432.55)">
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)"
-           id="g6981">
-          <path
-             d="M 25.496,1330.45 H 216.378"
-             style="fill:none;stroke:#ffffff;stroke-width:15px;stroke-linecap:butt"
-             id="path6979" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,2267.6154,371.87006)" id="g7032-3" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Cabin---occupied" serif:id="Cabin - occupied" transform="matrix(1.06667,0,0,0.511127,-2642.07,1432.55)">
+        <g transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)" id="g6981">
+          <path d="M 25.496,1330.45 H 216.378" style="fill:none;stroke:#ffffff;stroke-width:15px;stroke-linecap:butt" id="path6979"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)"
-           id="g6985">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:10px;stroke-linecap:butt"
-             id="path6983" />
+        <g transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)" id="g6985">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:10px;stroke-linecap:butt" id="path6983"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937507,2747.3,-2802.74)"
-           id="g6989">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:10px;stroke-linecap:butt"
-             id="path6987" />
+        <g transform="matrix(0.937497,0,0,0.937507,2747.3,-2802.74)" id="g6989">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:10px;stroke-linecap:butt" id="path6987"/>
         </g>
-        <g
-           transform="matrix(0,-0.937497,0.409432,0,2276.87,-1420.23)"
-           id="g6993">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt"
-             id="path6991" />
+        <g transform="matrix(0,-0.937497,0.409432,0,2276.87,-1420.23)" id="g6993">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt" id="path6991"/>
         </g>
-        <g
-           transform="matrix(0,-0.937497,0.409432,0,2276.87,-1397.31)"
-           id="g6997">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt"
-             id="path6995" />
+        <g transform="matrix(0,-0.937497,0.409432,0,2276.87,-1397.31)" id="g6997">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt" id="path6995"/>
         </g>
-        <g
-           transform="matrix(0,-0.937497,0.409432,0,2276.87,-1374.41)"
-           id="g7001">
-          <path
-             d="m 120.937,1330.45 v 95.45"
-             style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt"
-             id="path6999" />
+        <g transform="matrix(0,-0.937497,0.409432,0,2276.87,-1374.41)" id="g7001">
+          <path d="m 120.937,1330.45 v 95.45" style="fill:none;stroke:#ffffff;stroke-width:12.96px;stroke-linecap:butt" id="path6999"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2703.71,-2813.9)"
-           id="g7005">
-          <path
-             d="m 216.378,1294.66 c 0,-26.33 -21.383,-47.72 -47.72,-47.72 H 73.217 c -26.338,0 -47.721,21.39 -47.721,47.72 v 95.45 c 0,26.33 21.383,47.72 47.721,47.72 h 95.441 c 26.337,0 47.72,-21.39 47.72,-47.72 z"
-             style="fill:none;stroke:#ffffff;stroke-width:15px;stroke-linecap:butt"
-             id="path7003" />
+        <g transform="matrix(0.937497,0,0,0.937497,2703.71,-2813.9)" id="g7005">
+          <path d="m 216.378,1294.66 c 0,-26.33 -21.383,-47.72 -47.72,-47.72 H 73.217 c -26.338,0 -47.721,21.39 -47.721,47.72 v 95.45 c 0,26.33 21.383,47.72 47.721,47.72 h 95.441 c 26.337,0 47.72,-21.39 47.72,-47.72 z" style="fill:none;stroke:#ffffff;stroke-width:15px;stroke-linecap:butt" id="path7003"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)"
-           id="g7009">
-          <rect
-             x="0.011"
-             y="1209.49"
-             width="241.88901"
-             height="241.911"
-             style="fill:none"
-             id="rect7007" />
+        <g transform="matrix(0.937497,0,0,0.937497,2703.71,-2802.72)" id="g7009">
+          <rect x="0.011" y="1209.49" width="241.88901" height="241.911" style="fill:none" id="rect7007"/>
         </g>
-        <g
-           transform="matrix(0.91168,0,0,0.610494,2493.54,-2367.67)"
-           id="g7013">
-          <path
-             d="m 453.033,1296.11 c 0,-6.32 -3.434,-11.45 -7.664,-11.45 H 343.75 c -4.231,0 -7.665,5.13 -7.665,11.45 V 1319 c 0,6.32 3.434,11.44 7.665,11.44 h 101.619 c 4.23,0 7.664,-5.12 7.664,-11.44 z"
-             style="fill:#ffffff"
-             id="path7011" />
+        <g transform="matrix(0.91168,0,0,0.610494,2493.54,-2367.67)" id="g7013">
+          <path d="m 453.033,1296.11 c 0,-6.32 -3.434,-11.45 -7.664,-11.45 H 343.75 c -4.231,0 -7.665,5.13 -7.665,11.45 V 1319 c 0,6.32 3.434,11.44 7.665,11.44 h 101.619 c 4.23,0 7.664,-5.12 7.664,-11.44 z" style="fill:#ffffff" id="path7011"/>
         </g>
-        <g
-           transform="matrix(0.160814,0,0,0.286088,2715.41,-1881.77)"
-           id="g7017">
-          <path
-             d="m 453.033,1290.16 c 0,-3.04 -4.379,-5.5 -9.773,-5.5 h -97.401 c -5.394,0 -9.774,2.46 -9.774,5.5 v 34.79 c 0,3.03 4.38,5.49 9.774,5.49 h 97.401 c 5.394,0 9.773,-2.46 9.773,-5.49 z"
-             style="fill:none;stroke:#ffffff;stroke-width:20.2px;stroke-linecap:butt"
-             id="path7015" />
+        <g transform="matrix(0.160814,0,0,0.286088,2715.41,-1881.77)" id="g7017">
+          <path d="m 453.033,1290.16 c 0,-3.04 -4.379,-5.5 -9.773,-5.5 h -97.401 c -5.394,0 -9.774,2.46 -9.774,5.5 v 34.79 c 0,3.03 4.38,5.49 9.774,5.49 h 97.401 c 5.394,0 9.773,-2.46 9.773,-5.49 z" style="fill:none;stroke:#ffffff;stroke-width:20.2px;stroke-linecap:butt" id="path7015"/>
         </g>
-        <g
-           transform="matrix(0.937497,0,0,0.937497,2476.94,-2802.73)"
-           id="g7021">
-          <path
-             d="m 351.886,1386.19 c 0,-2.75 -2.234,-4.98 -4.986,-4.98 h -49.7 c -2.753,0 -4.987,2.23 -4.987,4.98 v 31.59 c 0,2.75 2.234,4.98 4.987,4.98 h 49.7 c 2.752,0 4.986,-2.23 4.986,-4.98 z m -43.048,-0.17 h -2.77 v 32.45 h 2.77 z m 30.474,0 h -2.77 v 32.45 h 2.77 z"
-             style="fill:#ffffff"
-             id="path7019" />
+        <g transform="matrix(0.937497,0,0,0.937497,2476.94,-2802.73)" id="g7021">
+          <path d="m 351.886,1386.19 c 0,-2.75 -2.234,-4.98 -4.986,-4.98 h -49.7 c -2.753,0 -4.987,2.23 -4.987,4.98 v 31.59 c 0,2.75 2.234,4.98 4.987,4.98 h 49.7 c 2.752,0 4.986,-2.23 4.986,-4.98 z m -43.048,-0.17 h -2.77 v 32.45 h 2.77 z m 30.474,0 h -2.77 v 32.45 h 2.77 z" style="fill:#ffffff" id="path7019"/>
         </g>
-        <g
-           transform="matrix(0.91168,0,0,-0.407417,2493.54,-1065.19)"
-           id="g7025">
-          <path
-             d="m 453.033,1296.11 c 0,-6.32 -2.291,-11.45 -5.114,-11.45 H 341.2 c -2.823,0 -5.115,5.13 -5.115,11.45 V 1319 c 0,6.32 2.292,11.44 5.115,11.44 h 106.719 c 2.823,0 5.114,-5.12 5.114,-11.44 z"
-             style="fill:#ffffff"
-             id="path7023" />
+        <g transform="matrix(0.91168,0,0,-0.407417,2493.54,-1065.19)" id="g7025">
+          <path d="m 453.033,1296.11 c 0,-6.32 -2.291,-11.45 -5.114,-11.45 H 341.2 c -2.823,0 -5.115,5.13 -5.115,11.45 V 1319 c 0,6.32 2.292,11.44 5.115,11.44 h 106.719 c 2.823,0 5.114,-5.12 5.114,-11.44 z" style="fill:#ffffff" id="path7023"/>
         </g>
-        <g
-           transform="matrix(-0.505544,0,0,0.610494,2956.64,-2367.67)"
-           id="g7029">
-          <path
-             d="m 453.033,1296.11 c 0,-6.32 -6.193,-11.45 -13.821,-11.45 h -89.305 c -7.629,0 -13.822,5.13 -13.822,11.45 V 1319 c 0,6.32 6.193,11.44 13.822,11.44 h 89.305 c 7.628,0 13.821,-5.12 13.821,-11.44 z"
-             style="fill:#ffffff"
-             id="path7027" />
+        <g transform="matrix(-0.505544,0,0,0.610494,2956.64,-2367.67)" id="g7029">
+          <path d="m 453.033,1296.11 c 0,-6.32 -6.193,-11.45 -13.821,-11.45 h -89.305 c -7.629,0 -13.822,5.13 -13.822,11.45 V 1319 c 0,6.32 6.193,11.44 13.822,11.44 h 89.305 c 7.628,0 13.821,-5.12 13.821,-11.44 z" style="fill:#ffffff" id="path7027"/>
         </g>
       </g>
     </g>
-    <g
-       transform="matrix(0.93749681,0,0,1.9564621,1358.6973,600.58409)"
-       id="g7061"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="Radar2">
-        <g
-           transform="matrix(0.899003,0,0,0.430785,36.6467,49.17)"
-           id="g7036">
-          <circle
-             cx="362.85001"
-             cy="1096.6899"
-             r="112.795"
-             style="fill:none;stroke:#ffffff;stroke-width:16.69px;stroke-linecap:butt"
-             id="circle7034" />
+    <g transform="matrix(0.93749681,0,0,1.9564621,1358.6973,600.58409)" id="g7061" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="Radar2">
+        <g transform="matrix(0.899003,0,0,0.430785,36.6467,49.17)" id="g7036">
+          <circle cx="362.85001" cy="1096.6899" r="112.795" style="fill:none;stroke:#ffffff;stroke-width:16.69px;stroke-linecap:butt" id="circle7034"/>
         </g>
-        <g
-           transform="matrix(0.801224,0,0,0.383931,72.126,100.555)"
-           id="g7040">
-          <path
-             d="m 306.842,998.788 c -35.118,20.092 -56.787,57.452 -56.787,97.902 H 362.85 Z"
-             style="fill:url(#_Linear1)"
-             id="path7038-7" />
+        <g transform="matrix(0.801224,0,0,0.383931,72.126,100.555)" id="g7040">
+          <path d="m 306.842,998.788 c -35.118,20.092 -56.787,57.452 -56.787,97.902 H 362.85 Z" style="fill:url(#_Linear1)" id="path7038-7"/>
         </g>
-        <g
-           opacity="0.41"
-           id="g7054">
-          <g
-             transform="matrix(0.4537,0,0,0.217404,198.225,283.183)"
-             id="g7044">
-            <circle
-               cx="362.85001"
-               cy="1096.6899"
-               r="112.795"
-               style="fill:none;stroke:#ffffff;stroke-width:4.41px;stroke-linecap:butt"
-               id="circle7042" />
+        <g opacity="0.41" id="g7054">
+          <g transform="matrix(0.4537,0,0,0.217404,198.225,283.183)" id="g7044">
+            <circle cx="362.85001" cy="1096.6899" r="112.795" style="fill:none;stroke:#ffffff;stroke-width:4.41px;stroke-linecap:butt" id="circle7042"/>
           </g>
-          <g
-             transform="scale(1,0.47918)"
-             id="g7048-9">
-            <path
-               d="M 362.85,987.142 V 1189.42"
-               style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linecap:butt"
-               id="path7046-0" />
+          <g transform="scale(1,0.47918)" id="g7048-9">
+            <path d="M 362.85,987.142 V 1189.42" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linecap:butt" id="path7046-0"/>
           </g>
-          <g
-             transform="matrix(0,0.47918,-1,0,1451.13,347.612)"
-             id="g7052-4">
-            <path
-               d="M 362.85,987.142 V 1189.42"
-               style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linecap:butt"
-               id="path7050" />
+          <g transform="matrix(0,0.47918,-1,0,1451.13,347.612)" id="g7052-4">
+            <path d="M 362.85,987.142 V 1189.42" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linecap:butt" id="path7050"/>
           </g>
         </g>
-        <g
-           transform="matrix(-0.866025,0.23959,-0.5,-0.414982,1221.23,886.165)"
-           id="g7058">
-          <path
-             d="m 362.85,1088.28 v 90.94"
-             style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linecap:butt"
-             id="path7056" />
+        <g transform="matrix(-0.866025,0.23959,-0.5,-0.414982,1221.23,886.165)" id="g7058">
+          <path d="m 362.85,1088.28 v 90.94" style="fill:none;stroke:#ffffff;stroke-width:2px;stroke-linecap:butt" id="path7056"/>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(1360.632,2040.93)"
-       id="g7071"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="g5265-4"
-         transform="translate(-3855.1,3174.8)">
-        <g
-           id="path5261-6"
-           transform="matrix(0.716449,0,0,0.716449,1282,-991.66)">
-          <path
-             d="m 4322.8,-3596.5 c 0,54.82 44.4,99.21 99.21,99.21 54.82,0 99.22,-44.39 99.22,-99.21 0,-54.82 -44.4,-99.21 -99.22,-99.21 -54.81,0 -99.21,44.39 -99.21,99.21 z m 20.67,0 c 0,-6.37 0.74,-12.57 2.19,-18.48 l 18.48,18.48 -4.14,24.8 16.54,16.54 v 22.69 c -20.01,-14.22 -33.07,-37.61 -33.07,-64.03 z m 60.48,-76.43 c 5.78,-1.41 11.82,-2.11 18.06,-2.11 6.91,0 13.6,0.91 19.97,2.56 l -3.43,5.7 4.13,4.14 h 12.4 l 3.43,-3.43 c 2.9,1.53 5.63,3.18 8.27,5.04 l -7.56,2.52 -8.27,8.27 8.27,4.13 v 4.14 h -8.27 v 8.27 c 0,0 5.7,4.13 12.4,4.13 6.57,0 3.64,-9.05 8.27,-12.4 4.67,-3.35 10.33,-2.61 10.33,-2.61 l 2.69,0.71 c 5.04,6.65 9.05,14.09 11.78,22.15 v 0.42 c 0,0 -5.83,-4.14 -16.53,-4.14 -10.71,0 -20.67,4.14 -20.67,4.14 0,0 -11.66,3.39 -12.4,12.4 -1.29,15.5 4.13,20.67 4.13,20.67 l 20.67,12.4 v 40.22 c -13.52,11.04 -30.8,17.65 -49.61,17.65 -8.89,0 -17.4,-1.44 -25.38,-4.17 l 21.25,-49.57 -4.14,-20.67 c 0,0 -16.41,-20.66 -24.8,-20.66 -8.39,0 -12.4,12.4 -12.4,12.4 l -8.27,-16.54 24.8,-16.53 12.41,-33.07 z"
-             style="fill:#ffffff;fill-rule:nonzero"
-             id="path7063" />
+    <g transform="translate(1360.632,2040.93)" id="g7071" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="g5265-4" transform="translate(-3855.1,3174.8)">
+        <g id="path5261-6" transform="matrix(0.716449,0,0,0.716449,1282,-991.66)">
+          <path d="m 4322.8,-3596.5 c 0,54.82 44.4,99.21 99.21,99.21 54.82,0 99.22,-44.39 99.22,-99.21 0,-54.82 -44.4,-99.21 -99.22,-99.21 -54.81,0 -99.21,44.39 -99.21,99.21 z m 20.67,0 c 0,-6.37 0.74,-12.57 2.19,-18.48 l 18.48,18.48 -4.14,24.8 16.54,16.54 v 22.69 c -20.01,-14.22 -33.07,-37.61 -33.07,-64.03 z m 60.48,-76.43 c 5.78,-1.41 11.82,-2.11 18.06,-2.11 6.91,0 13.6,0.91 19.97,2.56 l -3.43,5.7 4.13,4.14 h 12.4 l 3.43,-3.43 c 2.9,1.53 5.63,3.18 8.27,5.04 l -7.56,2.52 -8.27,8.27 8.27,4.13 v 4.14 h -8.27 v 8.27 c 0,0 5.7,4.13 12.4,4.13 6.57,0 3.64,-9.05 8.27,-12.4 4.67,-3.35 10.33,-2.61 10.33,-2.61 l 2.69,0.71 c 5.04,6.65 9.05,14.09 11.78,22.15 v 0.42 c 0,0 -5.83,-4.14 -16.53,-4.14 -10.71,0 -20.67,4.14 -20.67,4.14 0,0 -11.66,3.39 -12.4,12.4 -1.29,15.5 4.13,20.67 4.13,20.67 l 20.67,12.4 v 40.22 c -13.52,11.04 -30.8,17.65 -49.61,17.65 -8.89,0 -17.4,-1.44 -25.38,-4.17 l 21.25,-49.57 -4.14,-20.67 c 0,0 -16.41,-20.66 -24.8,-20.66 -8.39,0 -12.4,12.4 -12.4,12.4 l -8.27,-16.54 24.8,-16.53 12.41,-33.07 z" style="fill:#ffffff;fill-rule:nonzero" id="path7063"/>
         </g>
-        <g
-           id="path52911"
-           serif:id="path5291"
-           transform="matrix(0,0.438011,-0.438011,0,3084.45,-6494.11)">
-          <path
-             d="m 6472.5,-2946.2 -12.61,12.53 -50.51,-50.52 c -1.49,-1.49 -3.52,-2.4 -5.79,-2.4 -3.68,0 -6.82,2.44 -7.86,5.75 l -0.45,1.49 c -3.02,9.5 -4.67,19.63 -4.67,30.17 0,24.6 8.93,47.09 23.73,64.41 l 14.92,14.18 c 16.74,12.94 37.74,20.63 60.56,20.63 10.38,0 20.38,-1.57 29.77,-4.55 0.45,-0.12 2.1,-0.83 2.1,-0.83 3.15,-1.15 5.42,-4.17 5.42,-7.73 0,-2.31 -0.95,-4.42 -2.52,-5.91 l -1.28,-1.24 -49.03,-49.07 12.56,-12.56 c 3.97,-3.97 3.97,-10.38 0,-14.35 -3.96,-3.97 -10.37,-3.97 -14.34,0 z m 29.72,7.36 c 0,5.7 4.63,10.33 10.34,10.33 5.7,0 10.33,-4.63 10.33,-10.33 l -0.04,-2.07 c -0.49,-10.42 -4.71,-20.67 -12.69,-28.6 -7.94,-7.98 -18.19,-12.2 -28.61,-12.7 l -2.06,-0.04 c -5.71,0 -10.34,4.63 -10.34,10.34 0,5.7 4.63,10.33 10.34,10.33 0.7,0 2.06,0.09 2.06,0.09 5.13,0.49 10.09,2.64 14.02,6.57 3.92,3.93 6.08,8.89 6.53,14.01 0,0 0.12,1.37 0.12,2.07 z m 33.07,0 c 0,5.7 4.63,10.33 10.34,10.33 5.7,0 10.33,-4.63 10.33,-10.33 l -0.04,-2.07 c -0.49,-18.89 -7.93,-37.62 -22.36,-52 -14.39,-14.43 -33.11,-21.87 -52,-22.37 l -2.07,-0.04 c -5.71,0 -10.34,4.63 -10.34,10.34 0,5.7 4.63,10.33 10.34,10.33 l 2.07,0.04 c 13.6,0.5 27.03,5.96 37.41,16.29 10.33,10.38 15.79,23.81 16.28,37.41 z"
-             style="fill:#ffffff;fill-rule:nonzero"
-             id="path7066" />
+        <g id="path52911" serif:id="path5291" transform="matrix(0,0.438011,-0.438011,0,3084.45,-6494.11)">
+          <path d="m 6472.5,-2946.2 -12.61,12.53 -50.51,-50.52 c -1.49,-1.49 -3.52,-2.4 -5.79,-2.4 -3.68,0 -6.82,2.44 -7.86,5.75 l -0.45,1.49 c -3.02,9.5 -4.67,19.63 -4.67,30.17 0,24.6 8.93,47.09 23.73,64.41 l 14.92,14.18 c 16.74,12.94 37.74,20.63 60.56,20.63 10.38,0 20.38,-1.57 29.77,-4.55 0.45,-0.12 2.1,-0.83 2.1,-0.83 3.15,-1.15 5.42,-4.17 5.42,-7.73 0,-2.31 -0.95,-4.42 -2.52,-5.91 l -1.28,-1.24 -49.03,-49.07 12.56,-12.56 c 3.97,-3.97 3.97,-10.38 0,-14.35 -3.96,-3.97 -10.37,-3.97 -14.34,0 z m 29.72,7.36 c 0,5.7 4.63,10.33 10.34,10.33 5.7,0 10.33,-4.63 10.33,-10.33 l -0.04,-2.07 c -0.49,-10.42 -4.71,-20.67 -12.69,-28.6 -7.94,-7.98 -18.19,-12.2 -28.61,-12.7 l -2.06,-0.04 c -5.71,0 -10.34,4.63 -10.34,10.34 0,5.7 4.63,10.33 10.34,10.33 0.7,0 2.06,0.09 2.06,0.09 5.13,0.49 10.09,2.64 14.02,6.57 3.92,3.93 6.08,8.89 6.53,14.01 0,0 0.12,1.37 0.12,2.07 z m 33.07,0 c 0,5.7 4.63,10.33 10.34,10.33 5.7,0 10.33,-4.63 10.33,-10.33 l -0.04,-2.07 c -0.49,-18.89 -7.93,-37.62 -22.36,-52 -14.39,-14.43 -33.11,-21.87 -52,-22.37 l -2.07,-0.04 c -5.71,0 -10.34,4.63 -10.34,10.34 0,5.7 4.63,10.33 10.34,10.33 l 2.07,0.04 c 13.6,0.5 27.03,5.96 37.41,16.29 10.33,10.38 15.79,23.81 16.28,37.41 z" style="fill:#ffffff;fill-rule:nonzero" id="path7066"/>
         </g>
-        <rect
-           id="rect5263-1"
-           x="4308.7002"
-           y="-3709.8"
-           width="226.77"
-           height="226.77"
-           style="fill:none" />
+        <rect id="rect5263-1" x="4308.7002" y="-3709.8" width="226.77" height="226.77" style="fill:none"/>
       </g>
     </g>
-    <g
-       transform="translate(1818.6616,2040.8929)"
-       id="g7076"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="g4675-0"
-         transform="translate(-2725.8,2040.9)">
-        <rect
-           id="rect4671-0"
-           x="2948"
-           y="-2576"
-           width="226.77"
-           height="226.77"
-           style="fill:none" />
-        <path
-           id="path4673-9"
-           d="m 3051.2,-2462.6 c 0,-5.66 4.59,-10.24 10.24,-10.24 5.66,0 10.25,4.58 10.25,10.24 0,5.65 -4.59,10.24 -10.25,10.24 -5.65,0 -10.24,-4.59 -10.24,-10.24 z m 10.24,-26.63 c -14.71,0 -26.63,11.92 -26.63,26.63 0,14.71 11.92,26.63 26.63,26.63 14.71,0 26.64,-11.92 26.64,-26.63 0,-14.71 -11.93,-26.63 -26.64,-26.63 z m -69,46.22 c 1.56,5.53 3.77,10.77 6.56,15.65 l -12.3,13.44 c -3.52,3.52 -3.52,9.22 0,12.74 l 13.32,13.32 c 3.53,3.52 9.22,3.52 12.74,0 l 13.44,-12.29 c 4.88,2.78 10.13,5 15.65,6.55 l 1.15,18.28 c 0,5 4.02,9.01 9.02,9.01 h 18.85 c 4.99,0 9.01,-4.01 9.01,-9.01 l 1.14,-18.28 c 5.54,-1.55 10.78,-3.77 15.66,-6.55 l 13.44,12.29 c 3.52,3.52 9.22,3.52 12.74,0 l 13.32,-13.32 c 3.52,-3.52 3.52,-9.22 0,-12.74 l -12.3,-13.44 c 2.79,-4.88 5,-10.12 6.56,-15.65 l 18.28,-1.15 c 4.99,0 9.01,-4.02 9.01,-9.02 v -18.84 c 0,-5 -4.02,-9.02 -9.01,-9.02 l -18.28,-1.15 c -1.56,-5.53 -3.77,-10.77 -6.56,-15.65 l 12.3,-13.44 c 3.52,-3.52 3.52,-9.22 0,-12.74 l -13.32,-13.32 c -3.52,-3.52 -9.22,-3.52 -12.74,0 l -13.44,12.29 c -4.88,-2.78 -10.12,-5 -15.66,-6.55 l -1.14,-18.28 c 0,-5 -4.02,-9.01 -9.01,-9.01 h -18.85 c -5,0 -9.02,4.01 -9.02,9.01 l -1.15,18.28 c -5.53,1.55 -10.77,3.77 -15.65,6.55 l -13.44,-12.29 c -3.52,-3.52 -9.21,-3.52 -12.74,0 l -13.32,13.32 c -3.52,3.52 -3.52,9.22 0,12.74 l 12.3,13.44 c -2.79,4.88 -5,10.12 -6.56,15.65 l -18.27,1.15 c -5,0 -9.02,4.02 -9.02,9.02 v 18.84 c 0,5 4.02,9.02 9.02,9.02 z m 69,-62.61 c 23.77,0 43.03,19.25 43.03,43.02 0,23.77 -19.26,43.03 -43.03,43.03 -23.76,0 -43.02,-19.26 -43.02,-43.03 0,-23.77 19.26,-43.02 43.02,-43.02 z"
-           style="fill:#ffffff;fill-rule:nonzero" />
+    <g transform="translate(1818.6616,2040.8929)" id="g7076" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="g4675-0" transform="translate(-2725.8,2040.9)">
+        <rect id="rect4671-0" x="2948" y="-2576" width="226.77" height="226.77" style="fill:none"/>
+        <path id="path4673-9" d="m 3051.2,-2462.6 c 0,-5.66 4.59,-10.24 10.24,-10.24 5.66,0 10.25,4.58 10.25,10.24 0,5.65 -4.59,10.24 -10.25,10.24 -5.65,0 -10.24,-4.59 -10.24,-10.24 z m 10.24,-26.63 c -14.71,0 -26.63,11.92 -26.63,26.63 0,14.71 11.92,26.63 26.63,26.63 14.71,0 26.64,-11.92 26.64,-26.63 0,-14.71 -11.93,-26.63 -26.64,-26.63 z m -69,46.22 c 1.56,5.53 3.77,10.77 6.56,15.65 l -12.3,13.44 c -3.52,3.52 -3.52,9.22 0,12.74 l 13.32,13.32 c 3.53,3.52 9.22,3.52 12.74,0 l 13.44,-12.29 c 4.88,2.78 10.13,5 15.65,6.55 l 1.15,18.28 c 0,5 4.02,9.01 9.02,9.01 h 18.85 c 4.99,0 9.01,-4.01 9.01,-9.01 l 1.14,-18.28 c 5.54,-1.55 10.78,-3.77 15.66,-6.55 l 13.44,12.29 c 3.52,3.52 9.22,3.52 12.74,0 l 13.32,-13.32 c 3.52,-3.52 3.52,-9.22 0,-12.74 l -12.3,-13.44 c 2.79,-4.88 5,-10.12 6.56,-15.65 l 18.28,-1.15 c 4.99,0 9.01,-4.02 9.01,-9.02 v -18.84 c 0,-5 -4.02,-9.02 -9.01,-9.02 l -18.28,-1.15 c -1.56,-5.53 -3.77,-10.77 -6.56,-15.65 l 12.3,-13.44 c 3.52,-3.52 3.52,-9.22 0,-12.74 l -13.32,-13.32 c -3.52,-3.52 -9.22,-3.52 -12.74,0 l -13.44,12.29 c -4.88,-2.78 -10.12,-5 -15.66,-6.55 l -1.14,-18.28 c 0,-5 -4.02,-9.01 -9.01,-9.01 h -18.85 c -5,0 -9.02,4.01 -9.02,9.01 l -1.15,18.28 c -5.53,1.55 -10.77,3.77 -15.65,6.55 l -13.44,-12.29 c -3.52,-3.52 -9.21,-3.52 -12.74,0 l -13.32,13.32 c -3.52,3.52 -3.52,9.22 0,12.74 l 12.3,13.44 c -2.79,4.88 -5,10.12 -6.56,15.65 l -18.27,1.15 c -5,0 -9.02,4.02 -9.02,9.02 v 18.84 c 0,5 4.02,9.02 9.02,9.02 z m 69,-62.61 c 23.77,0 43.03,19.25 43.03,43.02 0,23.77 -19.26,43.03 -43.03,43.03 -23.76,0 -43.02,-19.26 -43.02,-43.03 0,-23.77 19.26,-43.02 43.02,-43.02 z" style="fill:#ffffff;fill-rule:nonzero"/>
       </g>
     </g>
-    <g
-       transform="translate(2267.6641,3189.3797)"
-       id="g7089"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="g4847-4"
-         transform="translate(226.738,-14.6866)">
-        <g
-           id="g4821-2"
-           transform="matrix(-7.145,0,0,7.1312,3428.5,-12025)">
-          <path
-             id="rect4815-0"
-             d="m 441.08,1471.86 c 0,-1.52 -1.235,-2.76 -2.755,-2.76 h -12.17 c -1.52,0 -2.755,1.24 -2.755,2.76 v 7.41 c 0,1.52 1.235,2.76 2.755,2.76 h 12.17 c 1.52,0 2.755,-1.24 2.755,-2.76 z"
-             style="fill:#ffffff;fill-opacity:0.33" />
-          <path
-             id="rect4813-0"
-             d="m 441.08,1471.86 c 0,-1.52 -1.235,-2.76 -2.755,-2.76 h -12.17 c -1.52,0 -2.755,1.24 -2.755,2.76 v 4.28 c 0,1.53 1.235,2.76 2.755,2.76 h 12.17 c 1.52,0 2.755,-1.23 2.755,-2.76 z"
-             style="fill:#ffffff;fill-opacity:0.33" />
-          <path
-             id="rect48151"
-             serif:id="rect4815"
-             d="m 441.08,1471.86 c 0,-1.52 -1.235,-2.76 -2.755,-2.76 h -12.17 c -1.52,0 -2.755,1.24 -2.755,2.76 v 7.41 c 0,1.52 1.235,2.76 2.755,2.76 h 12.17 c 1.52,0 2.755,-1.24 2.755,-2.76 z"
-             style="fill:#ffffff;fill-opacity:0.33" />
-          <g
-             transform="matrix(-0.13121,0,0,0.131464,448.108,1229.61)"
-             id="g7083">
-            <path
-               d="m 105.786,1716.27 h 2.59 l -4,8 h -9.043 c -3.906,3.25 -7.948,6.93 -11.902,10.95 h 17.945 l -3,8 H 76.094 c -3.023,3.55 -5.9,7.29 -8.511,11.17 h 28.793 l -1,8 H 62.721 c -2.249,4.15 -4.14,8.41 -5.551,12.75 h 37.206 l -0.722,8 h -38.5 c -0.489,2.76 -0.761,5.55 -0.786,8.34 -0.039,4.41 5.869,6.55 10.276,6.55 h 112.459 c 4.407,0 10.406,-2.15 10.277,-6.55 -0.083,-2.79 -0.416,-5.57 -0.968,-8.34 H 99.295 l 0.722,-8 h 84.209 c -1.492,-4.32 -3.453,-8.59 -5.759,-12.75 h -77.45 l 1,-8 h 71.519 c -2.624,-3.87 -5.497,-7.61 -8.508,-11.17 h -61.011 l 3,-8 h 50.756 c -3.887,-4.01 -7.849,-7.69 -11.679,-10.95 h -36.077 l 4,-8 h 21.86 c -7.012,-4.99 -12.626,-7.87 -15.003,-7.87 -2.195,0 -7.895,2.86 -15.088,7.87 z"
-               style="fill:#ffffff"
-               id="path7081" />
+    <g transform="translate(2267.6641,3189.3797)" id="g7089" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="g4847-4" transform="translate(226.738,-14.6866)">
+        <g id="g4821-2" transform="matrix(-7.145,0,0,7.1312,3428.5,-12025)">
+          <path id="rect4815-0" d="m 441.08,1471.86 c 0,-1.52 -1.235,-2.76 -2.755,-2.76 h -12.17 c -1.52,0 -2.755,1.24 -2.755,2.76 v 7.41 c 0,1.52 1.235,2.76 2.755,2.76 h 12.17 c 1.52,0 2.755,-1.24 2.755,-2.76 z" style="fill:#ffffff;fill-opacity:0.33"/>
+          <path id="rect4813-0" d="m 441.08,1471.86 c 0,-1.52 -1.235,-2.76 -2.755,-2.76 h -12.17 c -1.52,0 -2.755,1.24 -2.755,2.76 v 4.28 c 0,1.53 1.235,2.76 2.755,2.76 h 12.17 c 1.52,0 2.755,-1.23 2.755,-2.76 z" style="fill:#ffffff;fill-opacity:0.33"/>
+          <path id="rect48151" serif:id="rect4815" d="m 441.08,1471.86 c 0,-1.52 -1.235,-2.76 -2.755,-2.76 h -12.17 c -1.52,0 -2.755,1.24 -2.755,2.76 v 7.41 c 0,1.52 1.235,2.76 2.755,2.76 h 12.17 c 1.52,0 2.755,-1.24 2.755,-2.76 z" style="fill:#ffffff;fill-opacity:0.33"/>
+          <g transform="matrix(-0.13121,0,0,0.131464,448.108,1229.61)" id="g7083">
+            <path d="m 105.786,1716.27 h 2.59 l -4,8 h -9.043 c -3.906,3.25 -7.948,6.93 -11.902,10.95 h 17.945 l -3,8 H 76.094 c -3.023,3.55 -5.9,7.29 -8.511,11.17 h 28.793 l -1,8 H 62.721 c -2.249,4.15 -4.14,8.41 -5.551,12.75 h 37.206 l -0.722,8 h -38.5 c -0.489,2.76 -0.761,5.55 -0.786,8.34 -0.039,4.41 5.869,6.55 10.276,6.55 h 112.459 c 4.407,0 10.406,-2.15 10.277,-6.55 -0.083,-2.79 -0.416,-5.57 -0.968,-8.34 H 99.295 l 0.722,-8 h 84.209 c -1.492,-4.32 -3.453,-8.59 -5.759,-12.75 h -77.45 l 1,-8 h 71.519 c -2.624,-3.87 -5.497,-7.61 -8.508,-11.17 h -61.011 l 3,-8 h 50.756 c -3.887,-4.01 -7.849,-7.69 -11.679,-10.95 h -36.077 l 4,-8 h 21.86 c -7.012,-4.99 -12.626,-7.87 -15.003,-7.87 -2.195,0 -7.895,2.86 -15.088,7.87 z" style="fill:#ffffff" id="path7081"/>
           </g>
-          <path
-             id="rect4819-5"
-             d="m 441.08,1471.86 c 0,-1.52 -1.235,-2.76 -2.755,-2.76 h -12.17 c -1.52,0 -2.755,1.24 -2.755,2.76 v 0.11 c 0,1.53 1.235,2.76 2.755,2.76 h 12.17 c 1.52,0 2.755,-1.23 2.755,-2.76 z"
-             style="fill:#ffffff;fill-opacity:0.33" />
+          <path id="rect4819-5" d="m 441.08,1471.86 c 0,-1.52 -1.235,-2.76 -2.755,-2.76 h -12.17 c -1.52,0 -2.755,1.24 -2.755,2.76 v 0.11 c 0,1.53 1.235,2.76 2.755,2.76 h 12.17 c 1.52,0 2.755,-1.23 2.755,-2.76 z" style="fill:#ffffff;fill-opacity:0.33"/>
         </g>
-        <rect
-           id="rect4823-0"
-           x="226.77"
-           y="-1668.9"
-           width="226.77"
-           height="226.77"
-           style="fill:none" />
+        <rect id="rect4823-0" x="226.77" y="-1668.9" width="226.77" height="226.77" style="fill:none"/>
       </g>
     </g>
-    <g
-       id="g21754"
-       transform="translate(3056.709,-1961.709)">
-      <g
-         transform="translate(-1922.9669,3775.7018)"
-         id="g7096"
-         style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-        <g
-           id="g5375-3"
-           transform="translate(-5442.5,1814.2)">
-          <g
-             id="path5371-5"
-             transform="rotate(180,7370.1,-2009.065)">
-            <path
-               d="m 7270.9,-1932.59 c 0,9.14 7.4,16.53 16.54,16.53 h 165.35 c 9.13,0 16.53,-7.39 16.53,-16.53 v -152.95 c 0,-9.14 -7.4,-16.54 -16.53,-16.54 h -165.35 c -9.14,0 -16.54,7.4 -16.54,16.54 z m 29.76,-111.61 h 138.9 c 5.05,0 9.1,4.05 9.1,9.09 v 89.29 c 0,5.05 -4.05,9.1 -9.1,9.1 h -138.9 c -5.04,0 -9.09,-4.05 -9.09,-9.1 v -89.29 c 0,-5.04 4.05,-9.09 9.09,-9.09 z m -9.09,-26.87 c 0,-5.71 4.63,-10.34 10.33,-10.34 5.71,0 10.34,4.63 10.34,10.34 0,5.7 -4.63,10.33 -10.34,10.33 -5.7,0 -10.33,-4.63 -10.33,-10.33 z m 37.2,0 c 0,-5.71 4.63,-10.34 10.34,-10.34 5.7,0 10.33,4.63 10.33,10.34 0,5.7 -4.63,10.33 -10.33,10.33 -5.71,0 -10.34,-4.63 -10.34,-10.33 z m 37.21,0 c 0,-5.71 4.63,-10.34 10.33,-10.34 5.71,0 10.34,4.63 10.34,10.34 0,5.7 -4.63,10.33 -10.34,10.33 -5.7,0 -10.33,-4.63 -10.33,-10.33 z"
-               style="fill:#ffffff;fill-rule:nonzero"
-               id="path7091-7" />
+    <g id="g21754" transform="translate(3056.709,-1961.709)">
+      <g transform="translate(-1922.9669,3775.7018)" id="g7096" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+        <g id="g5375-3" transform="translate(-5442.5,1814.2)">
+          <g id="path5371-5" transform="rotate(180,7370.1,-2009.065)">
+            <path d="m 7270.9,-1932.59 c 0,9.14 7.4,16.53 16.54,16.53 h 165.35 c 9.13,0 16.53,-7.39 16.53,-16.53 v -152.95 c 0,-9.14 -7.4,-16.54 -16.53,-16.54 h -165.35 c -9.14,0 -16.54,7.4 -16.54,16.54 z m 29.76,-111.61 h 138.9 c 5.05,0 9.1,4.05 9.1,9.09 v 89.29 c 0,5.05 -4.05,9.1 -9.1,9.1 h -138.9 c -5.04,0 -9.09,-4.05 -9.09,-9.1 v -89.29 c 0,-5.04 4.05,-9.09 9.09,-9.09 z m -9.09,-26.87 c 0,-5.71 4.63,-10.34 10.33,-10.34 5.71,0 10.34,4.63 10.34,10.34 0,5.7 -4.63,10.33 -10.34,10.33 -5.7,0 -10.33,-4.63 -10.33,-10.33 z m 37.2,0 c 0,-5.71 4.63,-10.34 10.34,-10.34 5.7,0 10.33,4.63 10.33,10.34 0,5.7 -4.63,10.33 -10.33,10.33 -5.71,0 -10.34,-4.63 -10.34,-10.33 z m 37.21,0 c 0,-5.71 4.63,-10.34 10.33,-10.34 5.71,0 10.34,4.63 10.34,10.34 0,5.7 -4.63,10.33 -10.34,10.33 -5.7,0 -10.33,-4.63 -10.33,-10.33 z" style="fill:#ffffff;fill-rule:nonzero" id="path7091-7"/>
           </g>
-          <rect
-             id="rect5373-3"
-             x="7256.7002"
-             y="-2122.3999"
-             width="226.77"
-             height="226.77"
-             style="fill:none" />
+          <rect id="rect5373-3" x="7256.7002" y="-2122.3999" width="226.77" height="226.77" style="fill:none"/>
         </g>
       </g>
-      <g
-         transform="matrix(0.39926395,0,0,0.39926395,-371.16034,3584.7618)"
-         id="g7102"
-         style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-        <g
-           id="g5727-2"
-           transform="matrix(7.0866,0,0,7.0866,901.856,-180.947)">
-          <rect
-             id="rect5721-8"
-             x="0"
-             y="0"
-             width="32"
-             height="32"
-             style="fill:none" />
-          <g
-             id="g5725-0">
-            <path
-               id="path5723-4"
-               d="m 26,9.934 v 1.582 H 22.163 V 9.934 c 0,-0.137 -0.069,-0.205 -0.205,-0.205 h -4.482 v 4.775 h 4.482 c 1.113,0 2.06,0.4 2.841,1.201 C 25.6,16.486 26,17.433 26,18.546 v 4.394 c 0,1.113 -0.4,2.07 -1.201,2.871 -0.781,0.781 -1.728,1.172 -2.841,1.172 H 17.476 V 30 H 13.638 V 26.983 H 9.156 c -1.113,0 -2.07,-0.391 -2.87,-1.172 C 5.504,25.01 5.114,24.053 5.114,22.94 v -1.582 h 3.837 v 1.582 c 0,0.137 0.069,0.205 0.205,0.205 h 4.482 V 18.341 H 9.156 c -1.113,0 -2.07,-0.39 -2.87,-1.171 C 5.504,16.369 5.114,15.412 5.114,14.299 V 9.934 c 0,-1.113 0.39,-2.06 1.171,-2.842 0.801,-0.8 1.758,-1.201 2.871,-1.201 h 4.482 V 2.874 h 3.838 v 3.018 h 4.481 c 1.114,0 2.061,0.4 2.842,1.2 C 25.6,7.874 26,8.821 26,9.934 Z m -4.042,8.407 h -4.482 v 4.804 h 4.482 c 0.136,0 0.205,-0.068 0.205,-0.205 v -4.394 c 0,-0.136 -0.069,-0.205 -0.205,-0.205 z m -8.32,-3.837 V 9.729 H 9.156 c -0.136,0 -0.205,0.068 -0.205,0.205 v 4.365 c 0,0.136 0.069,0.205 0.205,0.205 z"
-               style="fill:#ffffff;fill-rule:nonzero" />
+      <g transform="matrix(0.39926395,0,0,0.39926395,-371.16034,3584.7618)" id="g7102" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+        <g id="g5727-2" transform="matrix(7.0866,0,0,7.0866,901.856,-180.947)">
+          <rect id="rect5721-8" x="0" y="0" width="32" height="32" style="fill:none"/>
+          <g id="g5725-0">
+            <path id="path5723-4" d="m 26,9.934 v 1.582 H 22.163 V 9.934 c 0,-0.137 -0.069,-0.205 -0.205,-0.205 h -4.482 v 4.775 h 4.482 c 1.113,0 2.06,0.4 2.841,1.201 C 25.6,16.486 26,17.433 26,18.546 v 4.394 c 0,1.113 -0.4,2.07 -1.201,2.871 -0.781,0.781 -1.728,1.172 -2.841,1.172 H 17.476 V 30 H 13.638 V 26.983 H 9.156 c -1.113,0 -2.07,-0.391 -2.87,-1.172 C 5.504,25.01 5.114,24.053 5.114,22.94 v -1.582 h 3.837 v 1.582 c 0,0.137 0.069,0.205 0.205,0.205 h 4.482 V 18.341 H 9.156 c -1.113,0 -2.07,-0.39 -2.87,-1.171 C 5.504,16.369 5.114,15.412 5.114,14.299 V 9.934 c 0,-1.113 0.39,-2.06 1.171,-2.842 0.801,-0.8 1.758,-1.201 2.871,-1.201 h 4.482 V 2.874 h 3.838 v 3.018 h 4.481 c 1.114,0 2.061,0.4 2.842,1.2 C 25.6,7.874 26,8.821 26,9.934 Z m -4.042,8.407 h -4.482 v 4.804 h 4.482 c 0.136,0 0.205,-0.068 0.205,-0.205 v -4.394 c 0,-0.136 -0.069,-0.205 -0.205,-0.205 z m -8.32,-3.837 V 9.729 H 9.156 c -0.136,0 -0.205,0.068 -0.205,0.205 v 4.365 c 0,0.136 0.069,0.205 0.205,0.205 z" style="fill:#ffffff;fill-rule:nonzero"/>
           </g>
         </g>
       </g>
     </g>
-    <g
-       transform="translate(-3174.7801,3174.3002)"
-       id="g7112"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="g4092-0"
-         transform="translate(907.09,680.31)">
-        <rect
-           id="rect40881"
-           serif:id="rect4088"
-           x="2494.5"
-           y="-2576"
-           width="226.23"
-           height="227.32001"
-           style="fill:none" />
-        <path
-           id="path4090-8"
-           d="m 2640.7,-2383.8 v -90.94 h 6.2 c 3.43,0 6.2,2.77 6.2,6.2 v 57.87 c 0,14.84 12.03,26.87 26.87,26.87 14.84,0 26.87,-12.03 26.87,-26.87 v -111.28 c 0,-5.83 -2.4,-11.08 -6.24,-14.84 l -21.92,-21.79 c -3.96,-3.97 -10.37,-3.97 -14.34,0 -3.97,3.97 -3.97,10.38 0,14.34 l 14.22,14.27 -10.5,10.95 c -3.43,3.51 -3.43,9.18 0,12.69 1.69,1.82 3.97,2.68 6.24,2.65 l 11.87,-0.04 v 93.05 c 0,3.43 -2.77,6.2 -6.2,6.2 -3.44,0 -6.21,-2.77 -6.21,-6.2 v -57.87 c 0,-14.84 -12.02,-26.87 -26.86,-26.87 h -6.2 v -49.61 c 0,-9.13 -7.4,-16.53 -16.54,-16.53 h -86.81 c -9.13,0 -16.53,7.4 -16.53,16.53 v 161.22 h -2.07 c -5.7,0 -10.33,4.63 -10.33,10.34 0,5.7 4.63,10.33 10.33,10.33 h 124.01 c 5.71,0 10.34,-4.63 10.34,-10.33 0,-5.71 -4.63,-10.34 -10.34,-10.34 z m -90.12,-157.08 h 60.36 c 5.04,0 9.09,4.05 9.09,9.09 v 43.82 c 0,5.05 -4.05,9.1 -9.09,9.1 h -60.36 c -5.04,0 -9.09,-4.05 -9.09,-9.1 v -43.82 c 0,-5.04 4.05,-9.09 9.09,-9.09 z"
-           style="fill:#ffffff;fill-rule:nonzero" />
+    <g transform="translate(-3174.7801,3174.3002)" id="g7112" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="g4092-0" transform="translate(907.09,680.31)">
+        <rect id="rect40881" serif:id="rect4088" x="2494.5" y="-2576" width="226.23" height="227.32001" style="fill:none"/>
+        <path id="path4090-8" d="m 2640.7,-2383.8 v -90.94 h 6.2 c 3.43,0 6.2,2.77 6.2,6.2 v 57.87 c 0,14.84 12.03,26.87 26.87,26.87 14.84,0 26.87,-12.03 26.87,-26.87 v -111.28 c 0,-5.83 -2.4,-11.08 -6.24,-14.84 l -21.92,-21.79 c -3.96,-3.97 -10.37,-3.97 -14.34,0 -3.97,3.97 -3.97,10.38 0,14.34 l 14.22,14.27 -10.5,10.95 c -3.43,3.51 -3.43,9.18 0,12.69 1.69,1.82 3.97,2.68 6.24,2.65 l 11.87,-0.04 v 93.05 c 0,3.43 -2.77,6.2 -6.2,6.2 -3.44,0 -6.21,-2.77 -6.21,-6.2 v -57.87 c 0,-14.84 -12.02,-26.87 -26.86,-26.87 h -6.2 v -49.61 c 0,-9.13 -7.4,-16.53 -16.54,-16.53 h -86.81 c -9.13,0 -16.53,7.4 -16.53,16.53 v 161.22 h -2.07 c -5.7,0 -10.33,4.63 -10.33,10.34 0,5.7 4.63,10.33 10.33,10.33 h 124.01 c 5.71,0 10.34,-4.63 10.34,-10.33 0,-5.71 -4.63,-10.34 -10.34,-10.34 z m -90.12,-157.08 h 60.36 c 5.04,0 9.09,4.05 9.09,9.09 v 43.82 c 0,5.05 -4.05,9.1 -9.09,9.1 h -60.36 c -5.04,0 -9.09,-4.05 -9.09,-9.1 v -43.82 c 0,-5.04 4.05,-9.09 9.09,-9.09 z" style="fill:#ffffff;fill-rule:nonzero"/>
       </g>
     </g>
-    <g
-       transform="translate(2365.2454,3304.5269)"
-       id="g7183"
-       style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
-      <g
-         id="g48471"
-         serif:id="g4847"
-         transform="translate(809.467,-129.834)">
-        <g
-           id="g4843-4"
-           transform="matrix(7.0861,0,0,7.0861,-3246.4,-11968)">
-          <g
-             id="g4833-0"
-             transform="matrix(0.52453,0,0,0.52312,247.23,700.97)">
-            <path
-               id="rect4825-8"
-               d="m 441.08,1469.82 c 0,-0.4 -0.321,-0.72 -0.716,-0.72 h -16.248 c -0.395,0 -0.716,0.32 -0.716,0.72 v 8.37 c 0,0.39 0.321,0.71 0.716,0.71 h 16.248 c 0.395,0 0.716,-0.32 0.716,-0.71 z"
-               style="fill:#ffffff;fill-opacity:0.33" />
-            <path
-               id="rect4827-0"
-               d="m 441.08,1469.83 c 0,-0.41 -0.324,-0.73 -0.723,-0.73 h -16.234 c -0.399,0 -0.723,0.32 -0.723,0.73 v 11.47 c 0,0.4 0.324,0.73 0.723,0.73 h 16.234 c 0.399,0 0.723,-0.33 0.723,-0.73 z"
-               style="fill:#ffffff;fill-opacity:0.33" />
-            <path
-               id="path4829-1"
-               d="m 424.87,1464.5 7.378,-8.8 7.378,8.8 z"
-               style="fill:#ffffff;fill-rule:nonzero;stroke:#ffffff;stroke-width:5.73px;stroke-miterlimit:4" />
-            <path
-               id="rect4831-27"
-               d="m 441.08,1469.81 c 0,-0.39 -0.318,-0.71 -0.71,-0.71 h -16.26 c -0.392,0 -0.71,0.32 -0.71,0.71 v 4.21 c 0,0.39 0.318,0.71 0.71,0.71 h 16.26 c 0.392,0 0.71,-0.32 0.71,-0.71 z"
-               style="fill:#ffffff;fill-opacity:0.33" />
+    <g transform="translate(2365.2454,3304.5269)" id="g7183" style="clip-rule:evenodd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5">
+      <g id="g48471" serif:id="g4847" transform="translate(809.467,-129.834)">
+        <g id="g4843-4" transform="matrix(7.0861,0,0,7.0861,-3246.4,-11968)">
+          <g id="g4833-0" transform="matrix(0.52453,0,0,0.52312,247.23,700.97)">
+            <path id="rect4825-8" d="m 441.08,1469.82 c 0,-0.4 -0.321,-0.72 -0.716,-0.72 h -16.248 c -0.395,0 -0.716,0.32 -0.716,0.72 v 8.37 c 0,0.39 0.321,0.71 0.716,0.71 h 16.248 c 0.395,0 0.716,-0.32 0.716,-0.71 z" style="fill:#ffffff;fill-opacity:0.33"/>
+            <path id="rect4827-0" d="m 441.08,1469.83 c 0,-0.41 -0.324,-0.73 -0.723,-0.73 h -16.234 c -0.399,0 -0.723,0.32 -0.723,0.73 v 11.47 c 0,0.4 0.324,0.73 0.723,0.73 h 16.234 c 0.399,0 0.723,-0.33 0.723,-0.73 z" style="fill:#ffffff;fill-opacity:0.33"/>
+            <path id="path4829-1" d="m 424.87,1464.5 7.378,-8.8 7.378,8.8 z" style="fill:#ffffff;fill-rule:nonzero;stroke:#ffffff;stroke-width:5.73px;stroke-miterlimit:4"/>
+            <path id="rect4831-27" d="m 441.08,1469.81 c 0,-0.39 -0.318,-0.71 -0.71,-0.71 h -16.26 c -0.392,0 -0.71,0.32 -0.71,0.71 v 4.21 c 0,0.39 0.318,0.71 0.71,0.71 h 16.26 c 0.392,0 0.71,-0.32 0.71,-0.71 z" style="fill:#ffffff;fill-opacity:0.33"/>
           </g>
-          <g
-             id="g4841-8">
-            <path
-               id="path4835-4"
-               d="m 480.39,1480.3 c -4.885,2.82 -11.102,2 -15.09,-1.99 -3.988,-3.98 -4.807,-10.2 -1.987,-15.09 2.82,-4.88 8.614,-7.28 14.062,-5.82 5.449,1.46 9.266,6.43 9.266,12.07"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:3px;stroke-miterlimit:4;stroke-opacity:0.32" />
-            <path
-               id="path4837-0"
-               d="m 463.31,1475.7 c -2.622,-4.54 -2.12,-10.27 1.25,-14.29 3.37,-4.01 8.925,-5.5 13.852,-3.71 4.927,1.8 8.225,6.51 8.226,11.75"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:3px;stroke-miterlimit:4" />
-            <path
-               id="path4839-2"
-               d="m 467.89,1480.3 c -5.233,-3.02 -7.563,-9.42 -5.497,-15.1 2.067,-5.68 7.968,-9.09 13.918,-8.04 5.951,1.05 10.331,6.27 10.331,12.31"
-               style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:3px;stroke-miterlimit:4;stroke-opacity:0.55" />
+          <g id="g4841-8">
+            <path id="path4835-4" d="m 480.39,1480.3 c -4.885,2.82 -11.102,2 -15.09,-1.99 -3.988,-3.98 -4.807,-10.2 -1.987,-15.09 2.82,-4.88 8.614,-7.28 14.062,-5.82 5.449,1.46 9.266,6.43 9.266,12.07" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:3px;stroke-miterlimit:4;stroke-opacity:0.32"/>
+            <path id="path4837-0" d="m 463.31,1475.7 c -2.622,-4.54 -2.12,-10.27 1.25,-14.29 3.37,-4.01 8.925,-5.5 13.852,-3.71 4.927,1.8 8.225,6.51 8.226,11.75" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:3px;stroke-miterlimit:4"/>
+            <path id="path4839-2" d="m 467.89,1480.3 c -5.233,-3.02 -7.563,-9.42 -5.497,-15.1 2.067,-5.68 7.968,-9.09 13.918,-8.04 5.951,1.05 10.331,6.27 10.331,12.31" style="fill:none;fill-rule:nonzero;stroke:#ffffff;stroke-width:3px;stroke-miterlimit:4;stroke-opacity:0.55"/>
           </g>
         </g>
-        <rect
-           id="rect4845-7"
-           x="0"
-           y="-1668.9"
-           width="226.77"
-           height="226.77"
-           style="fill:none" />
+        <rect id="rect4845-7" x="0" y="-1668.9" width="226.77" height="226.77" style="fill:none"/>
       </g>
     </g>
-    <g
-       transform="matrix(1.0000007,0,0,-1.0000007,-226.83012,-1070.1789)"
-       id="g6487-2">
-      <desc
-         id="desc6481-8">Icon</desc>
-      <rect
-         x="2948"
-         y="-2349.2"
-         width="226.77"
-         height="226.77"
-         fill="none"
-         opacity="1"
-         id="rect6483-2" />
-      <g
-         id="g4308"
-         transform="matrix(0.87875123,0,0,0.87875123,369.59784,-277.12016)">
-        <path
-           d="m 3015.0257,-2182.1532 -52.6513,-89.0855 h 105.3026 z"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="18.3762"
-           id="path6485-6" />
-        <path
-           d="m 3162.7392,-2186.6664 -52.6513,-89.0855 -52.6513,89.0855"
-           fill="none"
-           opacity="1"
-           stroke="#ffffff"
-           stroke-linecap="round"
-           stroke-linejoin="round"
-           stroke-width="18.3762"
-           id="path6485-6-4"
-           sodipodi:nodetypes="ccc" />
+    <g transform="matrix(1.0000007,0,0,-1.0000007,-226.83012,-1070.1789)" id="g6487-2">
+      <desc id="desc6481-8">Icon</desc>
+      <rect x="2948" y="-2349.2" width="226.77" height="226.77" fill="none" opacity="1" id="rect6483-2"/>
+      <g id="g4308" transform="matrix(0.87875123,0,0,0.87875123,369.59784,-277.12016)">
+        <path d="m 3015.0257,-2182.1532 -52.6513,-89.0855 h 105.3026 z" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="18.3762" id="path6485-6"/>
+        <path d="m 3162.7392,-2186.6664 -52.6513,-89.0855 -52.6513,89.0855" fill="none" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="18.3762" id="path6485-6-4" sodipodi:nodetypes="ccc"/>
       </g>
+    </g>
+    <g transform="translate(-7937.0577,-0.09972888)" fill="none" id="g5434" style="opacity:0.215054" inkscape:label="trgt-horizon">
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect5432"/>
+    </g>
+    <g transform="translate(-7937.0577,-0.09972888)" fill="none" id="g6021-7" inkscape:label="trgt-horizon-2">
+      <path d="m 11075,-2197.5 v 38.283 l -38.282,-10e-5 m -76.565,-3e-4 -38.283,-1e-4 v -38.283 m 0,-76.566 v -38.283 l 38.283,2e-4 m 76.565,3e-4 38.282,1e-4 v 38.283" opacity="0.123967" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="16.948" id="path5430"/>
+      <path d="m 11029.218,-2312.349 15.391,1e-4 m 30.391,30.3915 v 15.3914" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="16.948" id="path6017-6" sodipodi:nodetypes="cccc" inkscape:label="path6017-6"/>
+      <rect x="10885" y="-2349.2" width="226.77" height="226.77" opacity="1" id="rect6019-9"/>
+      <path d="m 10967.421,-2312.349 -15.391,1e-4 m -30.391,30.3915 v 15.3914" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="16.948" id="use4730" sodipodi:nodetypes="cccc" inkscape:label="path6017-6"/>
+      <use x="0" y="0" xlink:href="#path6017-6" id="use4732" width="100%" height="100%" transform="rotate(180,10998.319,-2235.6315)" inkscape:label="A"/>
+      <path d="m 10967.42,-2158.914 -15.391,-10e-5 m -30.391,-30.3915 v -15.3914" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="16.948" id="use4734" sodipodi:nodetypes="cccc" inkscape:label="path6017-6"/>
+      <path d="m 11029.29,-2158.914 15.391,-10e-5 m 30.391,-30.3915 v -15.3914" opacity="1" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="16.948" id="use4736" sodipodi:nodetypes="cccc" inkscape:label="path6017-6"/>
     </g>
   </g>
 </svg>

--- a/data/pigui/modules/flight-ui/indicators.lua
+++ b/data/pigui/modules/flight-ui/indicators.lua
@@ -4,7 +4,6 @@
 local ui = require 'pigui'
 local Engine = require 'Engine'
 local Game = require 'Game'
-local Space = require 'Space'
 local Vector2 = _G.Vector2
 local Vector3 = _G.Vector3
 
@@ -118,9 +117,8 @@ local function displayNavTargetIndicator(navTarget)
 	-- checks if the nav target is a ground starport below the horizon of the player's frame
 	local isaGroundPortBehindPlanet = false
 	if navTarget.type == "STARPORT_SURFACE" then
-		local frame = player.frameBody
-		if Space.GetBody(navTarget.path:GetSystemBody().parent.index) == frame then
-			if navTarget:GetPositionRelTo(frame):dot(player:GetPositionRelTo(navTarget)) < 0 then
+		if navTarget.path:GetSystemBody().parent.path == player.frameBody.path then
+			if navTarget:GetPositionRelTo(player.frameBody):dot(player:GetPositionRelTo(navTarget)) < 0 then
 				isaGroundPortBehindPlanet = true
 			end
 		end

--- a/data/pigui/modules/flight-ui/indicators.lua
+++ b/data/pigui/modules/flight-ui/indicators.lua
@@ -113,19 +113,48 @@ end
 -- display the indicator pointing at the nav target, and pro- and retrograde
 local function displayNavTargetIndicator(navTarget)
 	local onscreen,position,direction = Engine.GetTargetIndicatorScreenPosition(navTarget)
+	local frameBody = player.frameBody
 
-	-- checks if the nav target is a ground starport below the horizon of the player's frame
-	local isaGroundPortBehindPlanet = false
-	if navTarget.type == "STARPORT_SURFACE" then
-		if navTarget.path:GetSystemBody().parent.path == player.frameBody.path then
-			if navTarget:GetPositionRelTo(player.frameBody):dot(player:GetPositionRelTo(navTarget)) < 0 then
-				isaGroundPortBehindPlanet = true
+	-- checks if the nav target is a starport behind (on the other side of) the player's framebody
+	local isaPortBehindPlanet = false
+	
+	if navTarget.path:GetSystemBody().parent.path == frameBody.path and frameBody.path:GetSystemBody().radius > 0 then
+
+		-- ground ports are straightforward - if player is above the zero-horizon from the station's POV, the station is visible
+		if navTarget.type == "STARPORT_SURFACE" then
+			if navTarget:GetPositionRelTo(frameBody):dot(player:GetPositionRelTo(navTarget)) < 0 then
+				isaPortBehindPlanet = true
+			end
+
+		-- orbital ports are a bit trickier
+		elseif navTarget.type == "STARPORT_ORBITAL" then
+			local navWrtPlayer = navTarget:GetPositionRelTo(player)
+			local frameWrtPlayer = frameBody:GetPositionRelTo(player)
+			local navWrtFrame = navTarget:GetPositionRelTo(frameBody)
+			local area = navWrtPlayer:cross(frameWrtPlayer):length()
+
+			-- in the unlikely case that we are absolutely on target, no need to check anything else. also prevents an edge-case zero division.
+			if navWrtPlayer:length() > 0 then
+				-- these will be used to check if the distance between the planet's centre and the line that connects the player and the target
+				-- is larger than the planet's radius
+				local pointLineDist = area / navWrtPlayer:length()
+				local frameRadius = frameBody.path:GetSystemBody().radius
+
+				-- the dot product ensures that the planet and the station are in the same general direction from player's POV
+				-- the length check ensures that the station is actually distant enough to be on the far side.
+				-- without this check, isaPortBehindPlanet also returns true if the station is intersecting the planet's silhouette
+				-- while passing in front of the planet
+				if navWrtPlayer:dot(frameWrtPlayer) > 0 and navWrtPlayer:length() > frameWrtPlayer:length() then
+					if pointLineDist < frameRadius then
+						isaPortBehindPlanet = true
+					end
+				end
 			end
 		end
 	end
 
-	if isaGroundPortBehindPlanet then
-		displayIndicator(onscreen, position, direction, icons.navtarget, colors.navTargetDark, true)
+	if isaPortBehindPlanet then
+		displayIndicator(onscreen, position, direction, icons.square_dashed, colors.navTargetDark, true)
 	else
 		displayIndicator(onscreen, position, direction, icons.square, colors.navTarget, true)
 	end

--- a/data/pigui/modules/flight-ui/indicators.lua
+++ b/data/pigui/modules/flight-ui/indicators.lua
@@ -118,7 +118,7 @@ local function displayNavTargetIndicator(navTarget)
 	-- checks if the nav target is a starport behind (on the other side of) the player's framebody
 	local isaPortBehindPlanet = false
 	
-	if navTarget.path:GetSystemBody().parent.path == frameBody.path and frameBody.path:GetSystemBody().radius > 0 then
+	if frameBody and navTarget.path:GetSystemBody().parent.path == frameBody.path and frameBody.path:GetSystemBody().radius > 0 then
 
 		-- ground ports are straightforward - if player is above the zero-horizon from the station's POV, the station is visible
 		if navTarget.type == "STARPORT_SURFACE" then

--- a/data/pigui/modules/flight-ui/indicators.lua
+++ b/data/pigui/modules/flight-ui/indicators.lua
@@ -4,6 +4,7 @@
 local ui = require 'pigui'
 local Engine = require 'Engine'
 local Game = require 'Game'
+local Space = require 'Space'
 local Vector2 = _G.Vector2
 local Vector3 = _G.Vector3
 
@@ -113,7 +114,24 @@ end
 -- display the indicator pointing at the nav target, and pro- and retrograde
 local function displayNavTargetIndicator(navTarget)
 	local onscreen,position,direction = Engine.GetTargetIndicatorScreenPosition(navTarget)
-	displayIndicator(onscreen, position, direction, icons.square, colors.navTarget, true)
+
+	-- checks if the nav target is a ground starport below the horizon of the player's frame
+	local isaGroundPortBehindPlanet = false
+	if navTarget.type == "STARPORT_SURFACE" then
+		local frame = player.frameBody
+		if Space.GetBody(navTarget.path:GetSystemBody().parent.index) == frame then
+			if navTarget:GetPositionRelTo(frame):dot(player:GetPositionRelTo(navTarget)) < 0 then
+				isaGroundPortBehindPlanet = true
+			end
+		end
+	end
+
+	if isaGroundPortBehindPlanet then
+		displayIndicator(onscreen, position, direction, icons.navtarget, colors.navTargetDark, true)
+	else
+		displayIndicator(onscreen, position, direction, icons.square, colors.navTarget, true)
+	end
+	
 	local navVelocity = -navTarget:GetVelocityRelTo(player)
 	if navVelocity:length() > 1 then
 		onscreen,position,direction = Engine.ProjectRelDirection(navVelocity)

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -267,7 +267,8 @@ theme.icons = {
 	direction_frame = 26,
 	direction_frame_hollow = 27,
 	direction_forward = 28,
-	empty = 29,
+	square_dashed = 29,
+	empty = 30,
 	semi_major_axis = 31,
 	-- third row
 	heavy_fighter = 32,


### PR DESCRIPTION
Draw nav target icon differently for starports that are behind the frame body.
Demo: https://www.youtube.com/watch?v=7KSaPZqU9eA

The math may not hold too well with ground ports on concave-shaped asteroids but it still would be better than not having it at all IMHO.