### PR TITLE
Fixes #5343  Missing info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,13 @@ if (NATURALDOCS)
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
 
+find_program(PYTHON NAMES python)
+if (PYTHON)
+	add_custom_target(enums
+		COMMAND scripts/scan_enums.py -o src/enum_table.cpp --pattern='*.h' -r src
+		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif()
+
 target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt)
 
 list(APPEND pioneerLibs

--- a/data/factions/001_Solar_Federation.lua
+++ b/data/factions/001_Solar_Federation.lua
@@ -4,7 +4,7 @@
 local f = Faction:new('Solar Federation')
 	:description_short('The historical birthplace of humankind')
 	:description('Sol is a fine joint')
-	:homeworld(0,0,0,0,4)
+	:homeworld(0,0,0,0,16) --Mars
 	:foundingDate(3050)
 	:expansionRate(1)
 	:military_name('SolFed Military')

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2099,6 +2099,10 @@
     "description": "Lobby screen shows the tech level of the station",
     "message": "This installation holds a military technology clearance."
   },
+  "TECH_LEVEL": {
+    "description": "System view label for technology level",
+    "message": "Tech level"
+  },
   "TEXTURE_COMPRESSION": {
     "description": "",
     "message": "This frees up more memory for the graphics card, which is likely what you want, at the expense of compressing them during game start."
@@ -2206,6 +2210,10 @@
   "UNOCCUPIED_PASSENGER_CABINS": {
     "description": "",
     "message": "Unoccupied Passenger Cabins"
+  },
+  "PASSENGER_CABIN_CAPACITY": {
+    "description": "Entry for ship info",
+    "message": "Passenger cabin capacity"
   },
   "UNPROFITABLE_TRADE": {
     "description": "Indicates an unprofitable trade route.",

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -24,15 +24,23 @@ local l = Lang.GetResource("ui-core")
 -- Class: SpaceStation
 --
 
-function SpaceStation:Constructor()
-	-- Use a variation of the space station seed itself to ensure consistency
-	local rand = Rand.New(self.seed .. '-techLevel')
+function SpaceStation.GetTechLevel(systemBody)
+
+	local rand = Rand.New(systemBody.seed .. '-techLevel')
 	local techLevel = rand:Integer(1, 6) + rand:Integer(0,6)
-	if Game.system.faction ~= nil and Game.system.faction.hasHomeworld and Game.system.faction.homeworld == self.path:GetSystemBody().parent.path then
+	local system = systemBody.path:GetStarSystem()
+	
+	if system.faction ~= nil and system.faction.hasHomeworld and system.faction.homeworld == systemBody.parent.path then
 		techLevel = math.max(techLevel, 6) -- bump it upto at least 6 if it's a homeworld like Earth
 	end
 	-- cap the techlevel lower end based on the planets population
-	techLevel = math.max(techLevel, math.min(math.floor(self.path:GetSystemBody().parent.population * 0.5), 11))
+	techLevel = math.max(techLevel, math.min(math.floor(systemBody.parent.population * 0.5), 11))
+	return techLevel;
+end
+
+function SpaceStation:Constructor()
+	techLevel = SpaceStation.GetTechLevel(self.path:GetSystemBody())
+
 	self:setprop("techLevel", techLevel)
 end
 

--- a/data/meta/Constants.lua
+++ b/data/meta/Constants.lua
@@ -28,8 +28,8 @@
 -- A <Constants.ShipAICmdName> string
 ---@class ShipAICmdName: string
 
--- A <Constants.HardpointTag> string
----@class HardpointTag: string
+-- A <Constants.DualLaserOrientation> string
+---@class DualLaserOrientation: string
 
 -- A <Constants.ShipTypeTag> string
 ---@class ShipTypeTag: string
@@ -111,8 +111,8 @@ Constants.ShipAlertStatus = {}
 ---@type ShipAICmdName[]
 Constants.ShipAICmdName = {}
 
----@type HardpointTag[]
-Constants.HardpointTag = {}
+---@type DualLaserOrientation[]
+Constants.DualLaserOrientation = {}
 
 ---@type ShipTypeTag[]
 Constants.ShipTypeTag = {}

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -76,6 +76,7 @@ local function shipStats()
 		{ l.CREW_CABINS..":",                 shipDef.maxCrew },
 		{ l.UNOCCUPIED_PASSENGER_CABINS..":", cabinEmpty },
 		{ l.OCCUPIED_PASSENGER_CABINS..":",   cabinOccupied },
+		{ l.PASSENGER_CABIN_CAPACITY..":",    shipDef.equipSlotCapacity.cabin},
 		false,
 		{ l.MISSILE_MOUNTS..":",            shipDef.equipSlotCapacity.missile},
 		{ l.SCOOP_MOUNTS..":",              shipDef.equipSlotCapacity.scoop},

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -259,7 +259,8 @@ local tradeMenu = function()
 						l.ATMOSPHERIC_SHIELDING, yes_no(def.equipSlotCapacity["atmo_shield"]),
 						l.ATMO_PRESS_LIMIT, atmoSlot
 					}, {
-						l.SCOOP_MOUNTS, def.equipSlotCapacity["scoop"]
+						l.SCOOP_MOUNTS, def.equipSlotCapacity["scoop"],
+						l.PASSENGER_CABIN_CAPACITY, def.equipSlotCapacity["cabin"]
 					},
 				}
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Fixes #5343 - missing ship cabin capacity info and space station tech level.

I have only realized that @Web-eWorks is already assigned to this issue when I was about to create the PR, sorry about that..

The change for the ship cabin capacity was quite easy but I need some feedback if it is ok as it is or some rephrasing is needed.

With tech level it was a bit more complicated. Tech level was calculated only when real SpaceStation body was created and is not know in SystemBody objects. SystemBody knows only seed that can be used to calculate the techLevel but it is rather complex operation including RNG.
The lua windows work somewhat surprising to me, their contents are recalculated each time frame. So recalculating tech level of selected body each frame did not seem to be a good idea. So I added a state for the info window with data to display updated only if the selected body changes.

I also added a cmake target for calling scan_enums.py with update in data/meta/Constants.lua after running it.

And one more interesting thing. SolFed homeworld path was pointing to Shanghai instead of Earth. Was it intentional? I hope I do not offend any Chinese people with this correction.

<!-- Please make sure you've read documentation on contributing -->

