### PR TITLE
Donate to Cranks - incorporate info from factions

### DIFF
--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -71,6 +71,54 @@
     "description": "",
     "message": "Liberate your ship! Please choose amount to donate. Happy hacking."
   },
+  "FLAVOUR_6_ADTITLE": {
+    "description": "",
+    "message": "VETERAN DAY!"
+  },
+  "FLAVOUR_6_DESC": {
+    "description": "",
+    "message": "Support the veterans of the {MILITARY}."
+  },
+  "FLAVOUR_6_MESSAGE": {
+    "description": "",
+    "message": "The {MILITARY}. You can always count on them.\nCan they count on you?"
+  },
+  "FLAVOUR_7_ADTITLE": {
+    "description": "",
+    "message": "DO THEY HAVE YOUR SUPPORT?"
+  },
+  "FLAVOUR_7_DESC": {
+    "description": "",
+    "message": "Support the veterans of the {POLICE}."
+  },
+  "FLAVOUR_7_MESSAGE": {
+    "description": "",
+    "message": "The brave men and women of the {POLICE} who is working day and night to keep us safe!"
+  },
+  "FLAVOUR_8_ADTITLE": {
+    "description": "",
+    "message": "SUPPORT OUR VETERANS!"
+  },
+  "FLAVOUR_8_DESC": {
+    "description": "",
+    "message": "Support the veterans of our armed forces."
+  },
+  "FLAVOUR_8_MESSAGE": {
+    "description": "",
+    "message": "The brave soldiers of the {MILITARY} places themselves in harm's way for you!"
+  },
+  "FLAVOUR_9_ADTITLE": {
+    "description": "",
+    "message": "END POWERTY!"
+  },
+  "FLAVOUR_9_DESC": {
+    "description": "",
+    "message": "Support the fight against powerty in the {FACTION}."
+  },
+  "FLAVOUR_9_MESSAGE": {
+    "description": "",
+    "message": "We empower families in the {FACTION} to create a better future for all."
+  },
   "SALES_PITCH": {
     "description": "",
     "message": "Your reputation would benefit by donating {cash} to our cause, but any donation would help."

--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -109,7 +109,7 @@
   },
   "FLAVOUR_9_ADTITLE": {
     "description": "",
-    "message": "END POWERTY!"
+    "message": "END POVERTY!"
   },
   "FLAVOUR_9_DESC": {
     "description": "",

--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -73,7 +73,7 @@
   },
   "FLAVOUR_6_ADTITLE": {
     "description": "",
-    "message": "VETERAN DAY!"
+    "message": "VETERANS DAY!"
   },
   "FLAVOUR_6_DESC": {
     "description": "",

--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -113,7 +113,7 @@
   },
   "FLAVOUR_9_DESC": {
     "description": "",
-    "message": "Support the fight against powerty in the {FACTION}."
+    "message": "Support the fight against poverty in the {FACTION}."
   },
   "FLAVOUR_9_MESSAGE": {
     "description": "",

--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -105,7 +105,7 @@
   },
   "FLAVOUR_8_MESSAGE": {
     "description": "",
-    "message": "The brave soldiers of the {MILITARY} places themselves in harm's way for you!"
+    "message": "The brave soldiers of the {MILITARY} place themselves in harm's way for you!"
   },
   "FLAVOUR_9_ADTITLE": {
     "description": "",

--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -93,7 +93,7 @@
   },
   "FLAVOUR_7_MESSAGE": {
     "description": "",
-    "message": "The brave men and women of the {POLICE} who is working day and night to keep us safe!"
+    "message": "Those brave men and women of the {POLICE} who has dedicated their lives to keeping {SYSTEM} safe!"
   },
   "FLAVOUR_8_ADTITLE": {
     "description": "",

--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -93,7 +93,7 @@
   },
   "FLAVOUR_7_MESSAGE": {
     "description": "",
-    "message": "Those brave men and women of the {POLICE} who has dedicated their lives to keeping {SYSTEM} safe!"
+    "message": "Those brave men and women of the {POLICE} who have dedicated their lives to keeping {SYSTEM} safe!"
   },
   "FLAVOUR_8_ADTITLE": {
     "description": "",

--- a/data/lang/module-donatetocranks/en.json
+++ b/data/lang/module-donatetocranks/en.json
@@ -93,7 +93,7 @@
   },
   "FLAVOUR_7_MESSAGE": {
     "description": "",
-    "message": "Those brave men and women of the {POLICE} who have dedicated their lives to keeping {SYSTEM} safe!"
+    "message": "Those brave men and women of the {POLICE} who have dedicated their lives to keeping {SYSTEM} safe need your support!"
   },
   "FLAVOUR_8_ADTITLE": {
     "description": "",

--- a/data/modules/DonateToCranks/DonateToCranks.lua
+++ b/data/modules/DonateToCranks/DonateToCranks.lua
@@ -63,7 +63,7 @@ local onChat = function (form, ref, option)
 	local ad = ads[ref]
 	form:Clear()
 
-	form:SetTitle(string.interp(ad.desc, ad.stringVariables))
+	form:SetTitle(string.interp(flavours[ad.n].desc, ad.stringVariables))
 	form:SetFace(ad.character)
 
 	if option == -1 then
@@ -72,7 +72,7 @@ local onChat = function (form, ref, option)
 	end
 
 	if option == 0 then
-		form:SetMessage(string.interp(ad.message, ad.stringVariables) .. "\n\n" .. string.interp(
+		form:SetMessage(string.interp(flavours[ad.n].message, ad.stringVariables) .. "\n\n" .. string.interp(
 			l.SALES_PITCH, {cash = Format.Money(computeReputation(ad), false)}))
 
 	elseif Game.player:GetMoney() < option then
@@ -113,9 +113,6 @@ local onCreateBB = function (station)
 	local stringVariables = {SYSTEM = system, FACTION = faction, MILITARY = military, POLICE = police}
 	local ad = {
 		modifier = n == 6 and 1.5 or 1.0, -- donating to FOSS is twice as good
-		title    = flavours[n].title,
-		desc     = flavours[n].desc,
-		message  = flavours[n].message,
 		stringVariables = stringVariables,
 		station  = station,
 		character = Character.New({armour=false}),
@@ -123,13 +120,14 @@ local onCreateBB = function (station)
 	}
 
 	local ref = station:AddAdvert({
-		title       = string.interp(ad.title, ad.stringVariables),
-		description = string.interp(ad.desc, ad.stringVariables),
+		title       = string.interp(flavours[n].title, stringVariables),
+		description = string.interp(flavours[n].desc, stringVariables),
 		icon        = "donate_to_cranks",
 		onChat      = onChat,
 		onDelete    = onDelete})
 	ads[ref] = ad
 end
+
 
 local loaded_data
 

--- a/data/modules/DonateToCranks/DonateToCranks.lua
+++ b/data/modules/DonateToCranks/DonateToCranks.lua
@@ -12,7 +12,7 @@ local Format = require 'Format'
 local l = Lang.GetResource("module-donatetocranks")
 
 local flavours = {}
-for i = 0,5 do
+for i = 0,9 do
 	table.insert(flavours, {
 		title     = l["FLAVOUR_" .. i .. "_ADTITLE"],
 		desc      = l["FLAVOUR_" .. i .. "_DESC"],
@@ -63,7 +63,7 @@ local onChat = function (form, ref, option)
 	local ad = ads[ref]
 	form:Clear()
 
-	form:SetTitle(ad.title)
+	form:SetTitle(ad.desc)
 	form:SetFace(ad.character)
 
 	if option == -1 then
@@ -106,18 +106,23 @@ local onCreateBB = function (station)
 		return
 	end
 
+	local faction = Game.system.faction.name
+	local military = Game.system.faction.militaryName
+	local police = Game.system.faction.policeName
+	local stringVariables = {FACTION = faction, MILITARY = military, POLICE = police}
 	local ad = {
 		modifier = n == 6 and 1.5 or 1.0, -- donating to FOSS is twice as good
-		title    = flavours[n].desc,
-		message  = flavours[n].message,
+		title    = string.upper(string.interp(flavours[n].title, stringVariables)),
+		desc     = string.interp(flavours[n].desc, stringVariables),
+		message  = string.interp(flavours[n].message, stringVariables),
 		station  = station,
 		character = Character.New({armour=false}),
 		n        = n
 	}
 
 	local ref = station:AddAdvert({
-		title       = flavours[n].title,
-		description = flavours[n].desc,
+		title       = ad.title,
+		description = ad.desc,
 		icon        = "donate_to_cranks",
 		onChat      = onChat,
 		onDelete    = onDelete})
@@ -131,10 +136,15 @@ local onGameStart = function ()
 
 	if not loaded_data or not loaded_data.ads then return end
 
+	local faction = Game.system.faction.name
+	local military = Game.system.faction.militaryName
+	local police = Game.system.faction.policeName
+	local stringVariables = {FACTION = faction, MILITARY = military, POLICE = police}
+
 	for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({
-			title       = flavours[ad.n].title,
-			description = flavours[ad.n].desc,
+			title       = string.upper(string.interp(flavours[ad.n].title), stringVariables),
+			description = string.interp(flavours[ad.n].desc, stringVariables),
 			icon        = "donate_to_cranks",
 			onChat      = onChat,
 			onDelete    = onDelete})

--- a/data/modules/DonateToCranks/DonateToCranks.lua
+++ b/data/modules/DonateToCranks/DonateToCranks.lua
@@ -63,7 +63,7 @@ local onChat = function (form, ref, option)
 	local ad = ads[ref]
 	form:Clear()
 
-	form:SetTitle(ad.desc)
+	form:SetTitle(string.interp(ad.desc, ad.stringVariables))
 	form:SetFace(ad.character)
 
 	if option == -1 then
@@ -72,7 +72,7 @@ local onChat = function (form, ref, option)
 	end
 
 	if option == 0 then
-		form:SetMessage(ad.message .. "\n\n" .. string.interp(
+		form:SetMessage(string.interp(ad.message, ad.stringVariables) .. "\n\n" .. string.interp(
 			l.SALES_PITCH, {cash = Format.Money(computeReputation(ad), false)}))
 
 	elseif Game.player:GetMoney() < option then
@@ -109,20 +109,22 @@ local onCreateBB = function (station)
 	local faction = Game.system.faction.name
 	local military = Game.system.faction.militaryName
 	local police = Game.system.faction.policeName
-	local stringVariables = {FACTION = faction, MILITARY = military, POLICE = police}
+	local system = Game.system.name
+	local stringVariables = {SYSTEM = system, FACTION = faction, MILITARY = military, POLICE = police}
 	local ad = {
 		modifier = n == 6 and 1.5 or 1.0, -- donating to FOSS is twice as good
 		title    = string.upper(string.interp(flavours[n].title, stringVariables)),
 		desc     = string.interp(flavours[n].desc, stringVariables),
 		message  = string.interp(flavours[n].message, stringVariables),
+		stringVariables = stringVariables,
 		station  = station,
 		character = Character.New({armour=false}),
 		n        = n
 	}
 
 	local ref = station:AddAdvert({
-		title       = ad.title,
-		description = ad.desc,
+		title       = string.interp(ad.title, ad.stringVariables),
+		description = string.interp(ad.desc, ad.stringVariables),
 		icon        = "donate_to_cranks",
 		onChat      = onChat,
 		onDelete    = onDelete})
@@ -136,15 +138,10 @@ local onGameStart = function ()
 
 	if not loaded_data or not loaded_data.ads then return end
 
-	local faction = Game.system.faction.name
-	local military = Game.system.faction.militaryName
-	local police = Game.system.faction.policeName
-	local stringVariables = {FACTION = faction, MILITARY = military, POLICE = police}
-
 	for k,ad in pairs(loaded_data.ads) do
 		local ref = ad.station:AddAdvert({
-			title       = string.upper(string.interp(flavours[ad.n].title), stringVariables),
-			description = string.interp(flavours[ad.n].desc, stringVariables),
+			title       = string.interp(flavours[ad.n].title, ad.stringVariables),
+			description = string.interp(flavours[ad.n].desc, ad.stringVariables),
 			icon        = "donate_to_cranks",
 			onChat      = onChat,
 			onDelete    = onDelete})

--- a/data/modules/DonateToCranks/DonateToCranks.lua
+++ b/data/modules/DonateToCranks/DonateToCranks.lua
@@ -113,9 +113,9 @@ local onCreateBB = function (station)
 	local stringVariables = {SYSTEM = system, FACTION = faction, MILITARY = military, POLICE = police}
 	local ad = {
 		modifier = n == 6 and 1.5 or 1.0, -- donating to FOSS is twice as good
-		title    = string.upper(string.interp(flavours[n].title, stringVariables)),
-		desc     = string.interp(flavours[n].desc, stringVariables),
-		message  = string.interp(flavours[n].message, stringVariables),
+		title    = flavours[n].title,
+		desc     = flavours[n].desc,
+		message  = flavours[n].message,
 		stringVariables = stringVariables,
 		station  = station,
 		character = Character.New({armour=false}),


### PR DESCRIPTION
Improving immersion in 'Donate to Cranks' by adding some faction info as string variables (faction name and the names of the police and military forces) and some new flavours to make use of them.
I tried to make the string interpolation in just one place but failed at that so it's now done in onCreateBB and onGameStart separately.

![crank1](https://user-images.githubusercontent.com/6368949/208310044-2eccc15b-8f81-4f2f-abf9-591b5bac900e.png)