### PR TITLE
Correct message on low cash on landing/docking

### DIFF
--- a/data/lang/module-stationrefuelling/en.json
+++ b/data/lang/module-stationrefuelling/en.json
@@ -1,5 +1,9 @@
 {
-  "THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH": {
+  "THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH_LANDING": {
+    "description": "",
+    "message": "This is {station}. You do not have enough money for your landing fee of {fee}."
+  },
+  "THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH_DOCKING": {
     "description": "",
     "message": "This is {station}. You do not have enough money for your docking fee of {fee}."
   },

--- a/data/modules/StationRefuelling/StationRefuelling.lua
+++ b/data/modules/StationRefuelling/StationRefuelling.lua
@@ -32,7 +32,11 @@ local onShipDocked = function (ship, station)
 
 	local fee = calculateFee()
 	if ship:GetMoney() < fee then
-		Comms.Message(l.THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH:interp({station = station.label,fee = Format.Money(fee)}))
+		if station.isGroundStation == true then
+			Comms.Message(l.THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH_LANDING:interp({station = station.label,fee = Format.Money(fee)}))
+		else
+			Comms.Message(l.THIS_IS_STATION_YOU_DO_NOT_HAVE_ENOUGH_DOCKING:interp({station = station.label,fee = Format.Money(fee)}))
+		end
 		ship:SetMoney(0)
 	else
 		if station.isGroundStation == true then


### PR DESCRIPTION
Fixing a line that I managed to miss from https://github.com/pioneerspacesim/pioneer/pull/4116

Use 'landing fee' for ground stations and not 'docking fee' when low on cash.


![marsdockingfee](https://user-images.githubusercontent.com/6368949/208957798-b1aa3fe5-41d1-4156-825e-736677982775.png)
