### PR TITLE
Improve LuaTimer performance

### DIFF
--- a/data/meta/CoreObject/Ship.meta.lua
+++ b/data/meta/CoreObject/Ship.meta.lua
@@ -8,6 +8,9 @@
 ---
 ---@class Ship : ModelBody
 ---
+--- Whether the frame this body is in is a rotating frame.
+---@field frameRotating boolean
+---
 ---@field shipId string
 ---@field shipName string
 ---@field equipSet EquipSet

--- a/data/meta/Serializer.lua
+++ b/data/meta/Serializer.lua
@@ -1,0 +1,28 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ modules for Lua static analysis
+
+---@meta
+
+---@class Serializer
+local Serializer = {}
+
+-- Registers a function pair to serialize per-module data across savegames.
+--
+-- The serializer function can only serialize a single table object, but may
+-- store any serializable objects inside that table.
+---@param key string
+---@param serialize fun(): table
+---@param unserialize fun(t: table)
+function Serializer:Register(key, serialize, unserialize) end
+
+-- Registers a class type for serialization across savegames.
+--
+-- Objects of the passed class will be serialized via the Serialize / Unserialize
+-- class methods if referred to by other serialized data.
+---@param key string
+---@param class table
+function Serializer:RegisterClass(key, class) end
+
+return Serializer

--- a/data/meta/Timer.lua
+++ b/data/meta/Timer.lua
@@ -1,0 +1,17 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+---@meta
+
+---@class Timer
+local Timer = {}
+
+---@param interval number
+---@param callback function
+function Timer:CallEvery(interval, callback) end
+
+---@param delay number
+---@param callback function
+function Timer:CallAt(delay, callback) end
+
+return Timer

--- a/src/lua/LuaSerializer.cpp
+++ b/src/lua/LuaSerializer.cpp
@@ -503,6 +503,30 @@ void LuaSerializer::LoadComponents(const Json &jsonObj, Space *space)
 	}
 }
 
+/*
+ * Interface: Serializer
+ */
+
+/*
+ * Function: Register
+ *
+ * Registers a function pair to serialize per-module data across savegames.
+ *
+ * The serializer function can only serialize a single table object, but may
+ * store any serializable objects inside that table.
+ *
+ * Example:
+ *
+ * > Serializer.Register("MyModule", function() return {} end, function(data) ... end)
+ *
+ * Parameters:
+ *
+ *   key          - unique string key of the module serializer to register
+ *   serializer   - function that should return the object to be serialized
+ *   unserializer - function that receives the unserialized object and should
+ *                  restore needed module state
+ *
+ */
 int LuaSerializer::l_register(lua_State *l)
 {
 	LUA_DEBUG_START(l);
@@ -540,6 +564,24 @@ int LuaSerializer::l_register(lua_State *l)
 	return 0;
 }
 
+/*
+ * Function: RegisterClass
+ *
+ * Registers a class object to be serialized across savegames. Objects of the
+ * passed class will be serialized via the Serialize / Unserialize class
+ * methods if referred to by other serialized data.
+ *
+ * Example:
+ *
+ * > Serializer.RegisterClass("MyClass", MyClass)
+ *
+ * Parameters:
+ *
+ *   key   - unique string key of the class to register
+ *   class - a class object containing a Serialize() and Unserialize() method.
+ *           These methods will be called to save / restore state for instances
+ *           of this class.
+ */
 int LuaSerializer::l_register_class(lua_State *l)
 {
 	LUA_DEBUG_START(l);

--- a/src/lua/LuaTimer.cpp
+++ b/src/lua/LuaTimer.cpp
@@ -8,12 +8,37 @@
 #include "LuaUtils.h"
 #include "Pi.h"
 
+#include <algorithm>
+
+LuaTimer::LuaTimer()
+{
+	m_called.reserve(8);
+}
+
+LuaTimer::~LuaTimer()
+{
+}
+
+void LuaTimer::Insert(double at, int callbackId, bool repeats)
+{
+	CallInfo info { at, callbackId, repeats };
+
+	// Keep the queue sorted when inserting new elements.
+	// This is O(log N) + O(N/2) worst-case
+	auto iter = std::lower_bound(m_timeouts.cbegin(), m_timeouts.cend(), info, [](const CallInfo &timeout, const CallInfo &val) {
+		return timeout.at < val.at;
+	});
+
+	m_timeouts.insert(iter, std::move(info));
+}
+
 void LuaTimer::RemoveAll()
 {
 	lua_State *l = Lua::manager->GetLuaState();
 
 	lua_pushnil(l);
 	lua_setfield(l, LUA_REGISTRYINDEX, "PiTimerCallbacks");
+	m_timeouts.clear();
 }
 
 void LuaTimer::Tick()
@@ -23,50 +48,52 @@ void LuaTimer::Tick()
 	assert(Pi::game);
 	lua_State *l = Lua::manager->GetLuaState();
 
-	LUA_DEBUG_START(l);
-
-	lua_getfield(l, LUA_REGISTRYINDEX, "PiTimerCallbacks");
-	if (lua_isnil(l, -1)) {
-		lua_pop(l, 1);
-		LUA_DEBUG_END(l, 0);
-		return;
-	}
-	assert(lua_istable(l, -1));
-
 	double now = Pi::game->GetTime();
 
-	lua_pushnil(l);
-	while (lua_next(l, -2)) {
-		assert(lua_istable(l, -1));
+	// Move called timeouts out of the list into our scratch buffer
+	while (!m_timeouts.empty() && m_timeouts.front().at <= now) {
+		m_called.push_back(m_timeouts.front());
+		m_timeouts.pop_front();
+	}
 
-		lua_getfield(l, -1, "at");
-		double at = lua_tonumber(l, -1);
+	if (m_called.empty())
+		return;
+
+	LUA_DEBUG_START(l);
+
+	luaL_getsubtable(l, LUA_REGISTRYINDEX, "PiTimerCallbacks");
+	int callbackRegistry = lua_gettop(l);
+
+	// Call each callback for the timeout and re-queue if appropriate
+	for (CallInfo &call : m_called) {
+		lua_rawgeti(l, callbackRegistry, call.callbackId);
+		lua_getfield(l, -1, "callback");
+
+		pi_lua_protected_call(l, 0, 1);
+		bool cancel = lua_toboolean(l, -1);
 		lua_pop(l, 1);
 
-		if (at <= now) {
-			lua_getfield(l, -1, "callback");
-			pi_lua_protected_call(l, 0, 1);
-			bool cancel = lua_toboolean(l, -1);
+		if (cancel || !call.repeats) {
+			// Cleanup and remove the callback info
 			lua_pop(l, 1);
-
-			lua_getfield(l, -1, "every");
-			if (lua_isnil(l, -1) || cancel) {
-				lua_pop(l, 1);
-
-				lua_pushvalue(l, -2);
-				lua_pushnil(l);
-				lua_settable(l, -5);
-			} else {
-				double every = lua_tonumber(l, -1);
-				lua_pop(l, 1);
-
-				pi_lua_settable(l, "at", Pi::game->GetTime() + every);
-			}
+			luaL_unref(l, callbackRegistry, call.callbackId);
+			continue;
 		}
 
+		lua_getfield(l, -1, "every");
+		double next = call.at + lua_tonumber(l, -1);
 		lua_pop(l, 1);
+
+		lua_pushnumber(l, next); // [ cb, next ]
+		lua_setfield(l, -2, "at");
+
+		lua_pop(l, 1); // remove callback info from the stack
+
+		Insert(next, call.callbackId, true);
 	}
-	lua_pop(l, 1);
+
+	// Clear the scratch buffer
+	m_called.clear();
 
 	LUA_DEBUG_END(l, 0);
 }
@@ -107,26 +134,19 @@ void LuaTimer::Tick()
  * underlying object exists before trying to use it.
  */
 
-static void _finish_timer_create(lua_State *l)
+static int _finish_timer_create(lua_State *l, int callbackIdx)
 {
+	// Expects the callback data table available at the top of the stack
 	lua_pushstring(l, "callback");
-	lua_pushvalue(l, 3);
+	lua_pushvalue(l, callbackIdx);
 	lua_settable(l, -3);
 
-	lua_getfield(l, LUA_REGISTRYINDEX, "PiTimerCallbacks");
-	if (lua_isnil(l, -1)) {
-		lua_pop(l, 1);
-		lua_newtable(l);
-		lua_pushvalue(l, -1);
-		lua_setfield(l, LUA_REGISTRYINDEX, "PiTimerCallbacks");
-	}
-
-	lua_insert(l, -2);
-	lua_pushinteger(l, lua_rawlen(l, -2) + 1);
-	lua_insert(l, -2);
-	lua_settable(l, -3);
+	luaL_getsubtable(l, LUA_REGISTRYINDEX, "PiTimerCallbacks");
+	lua_insert(l, callbackIdx);
+	int ref = luaL_ref(l, callbackIdx);
 
 	lua_pop(l, 1);
+	return ref;
 }
 
 /*
@@ -178,7 +198,8 @@ static int l_timer_call_at(lua_State *l)
 	lua_newtable(l);
 	pi_lua_settable(l, "at", at);
 
-	_finish_timer_create(l);
+	int ref = _finish_timer_create(l, 3);
+	Pi::luaTimer->Insert(at, ref, false);
 
 	LUA_DEBUG_END(l, 0);
 
@@ -240,11 +261,14 @@ static int l_timer_call_every(lua_State *l)
 
 	LUA_DEBUG_START(l);
 
+	double at = Pi::game->GetTime() + every;
+
 	lua_newtable(l);
 	pi_lua_settable(l, "every", every);
-	pi_lua_settable(l, "at", Pi::game->GetTime() + every);
+	pi_lua_settable(l, "at", at);
 
-	_finish_timer_create(l);
+	int ref = _finish_timer_create(l, 3);
+	Pi::luaTimer->Insert(at, ref, true);
 
 	LUA_DEBUG_END(l, 0);
 

--- a/src/lua/LuaTimer.h
+++ b/src/lua/LuaTimer.h
@@ -6,11 +6,38 @@
 
 #include "DeleteEmitter.h"
 #include "LuaManager.h"
+#include "JsonFwd.h"
+
+#include <deque>
 
 class LuaTimer : public DeleteEmitter {
 public:
+	LuaTimer();
+	~LuaTimer();
+
+	void Init();
+
 	void Tick();
 	void RemoveAll();
+
+	// For internal use only
+	void Insert(double at, int callbackId, bool repeats);
+
+private:
+	/*
+	 * Minimal tracking struct for the next time a callback should be triggered
+	 * Avoids the overhead of constant round-trips into Lua
+	 */
+	struct CallInfo {
+		double at;
+		int callbackId;
+		bool repeats;
+	};
+
+	// Queue of tracked 'timeout' entries
+	std::deque<CallInfo> m_timeouts;
+	// Scratch buffer for timeouts that elapsed this update
+	std::vector<CallInfo> m_called;
 };
 
 #endif


### PR DESCRIPTION
The first of several PRs being split out from the Scout Mission branch. Don't expect a long shelf-life before merge.

This PR refactors the LuaTimer implementation to use a sorted C++ queue to store a list of "timeouts" rather than walking an unordered Lua table to see if a timer is ready to fire yet. This should improve worst-case per-frame performance of the timer implementation, though it does make the worst-case insertion performance of queuing a new timer `O(log N) + O(N/2)` instead of a classic hashtable insert `O(log N)`. ~~If this does prove to be an issue in the future with many 100s of timers being created each second, another approach might be a sorted intrusive-linked-list.~~ EDIT: that's not an option because of the `O(N)` search time to find an insertion point...

LuaTimer has not (yet) shown up as a major performance issue, but this work also lays the groundwork for future improvements like cancelling timers and #5222.