### PR TITLE
Add ItemCard UI Helper

### DIFF
--- a/data/libs/autoload.lua
+++ b/data/libs/autoload.lua
@@ -22,6 +22,16 @@ math.clamp = function(v, min, max)
 	return math.min(max, math.max(v,min))
 end
 
+-- linearly interpolate between min and max according to V
+math.lerp = function(min, max, v)
+	return min + (max - min) * v
+end
+
+-- calculate the interpolation factor of the given number v relative to min and max
+math.invlerp = function(min, max, v)
+	return (v - min) / (max - min)
+end
+
 debug.deprecated = function(name)
 	local deprecated_function = debug.getinfo(2)
 	local caller = debug.getinfo(3)

--- a/data/libs/autoload.lua
+++ b/data/libs/autoload.lua
@@ -41,5 +41,18 @@ string.interp = function (s, t)
 	return (s:gsub('(%b{})', function(w) return t[w:sub(2,-2)] or w end))
 end
 
+-- make a simple shallow copy of the passed-in table
+-- does not copy metatable nor recurse into the table
+---@generic T
+---@param t T
+---@return T
+table.copy = function(t)
+	local ret = {}
+	for k, v in pairs(t) do
+		ret[k] = v
+	end
+	return ret
+end
+
 -- make import break. you should never import this file
 return nil

--- a/data/libs/autoload.lua
+++ b/data/libs/autoload.lua
@@ -38,8 +38,20 @@ end
 
 -- a nice string interpolator
 string.interp = function (s, t)
-	return (s:gsub('(%b{})', function(w) return t[w:sub(2,-2)] or w end))
+	local i = 0
+	return (s:gsub('(%b{})', function(w)
+		if #w > 2 then
+			return t[w:sub(2, -2)] or w
+		else
+			i = i + 1; return t[i] or w
+		end
+	end))
 end
+
+-- allow using string.interp via "s" % { t }
+---@class string
+---@operator mod(table): string
+getmetatable("").__mod = string.interp
 
 -- make a simple shallow copy of the passed-in table
 -- does not copy metatable nor recurse into the table

--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -115,6 +115,10 @@ end
 -- Example:
 --   > transformed = utils.map_table(t, function(k, v) return k .. "1", v end)
 --
+---@generic K, V, K2, V2
+---@param table table<K, V>
+---@param predicate fun(k: K, v: V): K2, V2
+---@return table<K2, V2>
 function utils.map_table(table, predicate)
 	local t = {}
 	for k, v in pairs(table) do
@@ -134,6 +138,10 @@ end
 -- Example:
 --   > transformed = utils.map_array(t, function(v) return v + 32 end)
 --
+---@generic T, T2
+---@param array T[]
+---@param predicate fun(v: T): T2
+---@return T2[]
 function utils.map_array(array, predicate)
 	local t = {}
 	for i, v in ipairs(array) do
@@ -153,6 +161,9 @@ end
 -- Example:
 --   > filtered = utils.filter_table(t, function (k, v) return true end)
 --
+---@generic K, V
+---@param table table<K, V>
+---@param predicate fun(k: K, v: V): boolean
 function utils.filter_table(table, predicate)
 	local t = {}
 	for k, v in pairs(table) do
@@ -169,6 +180,9 @@ end
 -- Example:
 --   > filtered = utils.filter_array(t, function (i, v) return true end)
 --
+---@generic T
+---@param array T[]
+---@param predicate fun(v: T): boolean
 function utils.filter_array(array, predicate)
 	local t = {}
 	for i, v in ipairs(array) do

--- a/data/meta/Vector.lua
+++ b/data/meta/Vector.lua
@@ -8,6 +8,19 @@
 ---@class Vector2
 ---@field x number
 ---@field y number
+---
+---@operator add: Vector2
+---@operator add(number): Vector2
+---@operator sub: Vector2
+---@operator sub(number): Vector2
+---@operator mul: Vector2
+---@operator mul(number): Vector2
+---@operator div: Vector2
+---@operator div(number): Vector2
+---@operator unm: Vector2
+---@operator call: Vector2
+
+---@class Vector2
 local Vector2 = {}
 
 ---@param x number
@@ -49,6 +62,19 @@ function Vector2:right() end
 ---@field x number
 ---@field y number
 ---@field z number
+---
+---@operator add: Vector3
+---@operator add(number): Vector3
+---@operator sub: Vector3
+---@operator sub(number): Vector3
+---@operator mul: Vector3
+---@operator mul(number): Vector3
+---@operator div: Vector3
+---@operator div(number): Vector3
+---@operator unm: Vector3
+---@operator call: Vector3
+
+---@class Vector3
 local Vector3 = {}
 
 ---@param x number

--- a/data/pigui/libs/buttons.lua
+++ b/data/pigui/libs/buttons.lua
@@ -162,9 +162,9 @@ function ui.iconButton(icon, size, tooltip, variant, fg_color, frame_padding, ic
 	if pigui.IsItemHovered() then
 		local pos = tooltip:find("##") -- get position for id tag start
 		if not pos then
-			pigui.SetTooltip(tooltip)
+			ui.setTooltip(tooltip)
 		elseif pos > 1 then
-			pigui.SetTooltip(string.sub(tooltip, 1, pos - 1))
+			ui.setTooltip(string.sub(tooltip, 1, pos - 1))
 		end
 	end
 

--- a/data/pigui/libs/buttons.lua
+++ b/data/pigui/libs/buttons.lua
@@ -99,8 +99,8 @@ function ui.calcButtonSize(label, font, size)
 	return ui.calcTextSize(label, font, size) + ui.theme.styles.ButtonPadding * 2
 end
 
-function ui.getButtonHeight()
-	return ui.getTextLineHeight() + ui.theme.styles.ButtonPadding.y * 2
+function ui.getButtonHeight(font)
+	return (font and font.size or ui.getTextLineHeight()) + ui.theme.styles.ButtonPadding.y * 2
 end
 
 function ui.getButtonHeightWithSpacing()

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -27,7 +27,7 @@ ui.dummy = pigui.Dummy
 ui.newLine = pigui.NewLine
 ui.spacing = pigui.Spacing
 ui.text = pigui.Text
-ui.combo = pigui.Combo
+ui.combo = pigui.Combo ---@type fun(label: string, selected: integer, items: string[]): changed: boolean, selected: integer
 ui.listBox = pigui.ListBox
 ui.textWrapped = pigui.TextWrapped
 ui.textColored = pigui.TextColored
@@ -60,14 +60,14 @@ ui.thrustIndicator = pigui.ThrustIndicator
 ui.isMouseClicked = pigui.IsMouseClicked
 ui.isMouseDoubleClicked = pigui.IsMouseDoubleClicked
 ui.isMouseDown = pigui.IsMouseDown
-ui.getMousePos = pigui.GetMousePos
+ui.getMousePos = pigui.GetMousePos ---@type fun(): Vector2
 ui.getMouseWheel = pigui.GetMouseWheel
 --ui.setTooltip = maybeSetTooltip
 ui.shouldDrawUI = pigui.ShouldDrawUI
-ui.getWindowPos = pigui.GetWindowPos
-ui.getWindowSize = pigui.GetWindowSize
+ui.getWindowPos = pigui.GetWindowPos ---@type fun(): Vector2
+ui.getWindowSize = pigui.GetWindowSize ---@type fun(): Vector2
 -- available content region
-ui.getContentRegion = pigui.GetContentRegion
+ui.getContentRegion = pigui.GetContentRegion ---@type fun(): Vector2
 
 -- Get the current height of a line of text (font.size)
 ui.getTextLineHeight = pigui.GetTextLineHeight

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -23,6 +23,10 @@ ui.setNextWindowPos = pigui.SetNextWindowPos ---@type fun(pos: Vector2, cond: st
 ui.setNextWindowSize = pigui.SetNextWindowSize ---@type fun(size: Vector2, cond: string)
 ui.setNextWindowSizeConstraints = pigui.SetNextWindowSizeConstraints ---@type fun(min: Vector2, max: Vector2)
 
+-- Forwarded as-is for use in complicated layout primitives without introducing additional scopes
+ui.beginGroup = pigui.BeginGroup
+ui.endGroup = pigui.EndGroup
+
 ui.dummy = pigui.Dummy
 ui.newLine = pigui.NewLine
 ui.spacing = pigui.Spacing
@@ -62,7 +66,6 @@ ui.isMouseDoubleClicked = pigui.IsMouseDoubleClicked
 ui.isMouseDown = pigui.IsMouseDown
 ui.getMousePos = pigui.GetMousePos ---@type fun(): Vector2
 ui.getMouseWheel = pigui.GetMouseWheel
---ui.setTooltip = maybeSetTooltip
 ui.shouldDrawUI = pigui.ShouldDrawUI
 ui.getWindowPos = pigui.GetWindowPos ---@type fun(): Vector2
 ui.getWindowSize = pigui.GetWindowSize ---@type fun(): Vector2

--- a/data/pigui/libs/item-card.lua
+++ b/data/pigui/libs/item-card.lua
@@ -1,0 +1,208 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local PiGui = require 'Engine'.pigui
+local Vector2 = Vector2
+local utils = require 'utils'
+
+local ui = require 'pigui'
+local colors = ui.theme.colors
+local pionillium = ui.fonts.pionillium
+
+--
+-- Class: UI.ItemCard
+--
+-- This class implements an "item card" display with a line of detailed stats
+-- below it.
+--
+
+---@class UI.ItemCard
+local ItemCard = utils.inherits(nil, "UI.ItemCard")
+
+ItemCard.highlightBar = false
+ItemCard.detailFields = 2
+
+ItemCard.iconSize = nil ---@type Vector2?
+ItemCard.lineSpacing  = ui.theme.styles.ItemSpacing
+ItemCard.rounding = 4
+
+ItemCard.backgroundColor = colors.tableBackground
+ItemCard.selectedColor   = colors.tableSelection
+ItemCard.hoveredColor    = colors.tableHighlight
+
+function ItemCard:drawTitle(data, regionWidth, isSelected)
+	-- override to draw your specific item card type!
+end
+
+function ItemCard:drawTooltip(data, isSelected)
+	-- override to draw your specific item card type!
+end
+
+function ItemCard:drawDetailTooltip(detail, tooltip)
+	-- can be overridden to draw extra info!
+
+	ui.withFont(pionillium.body, function()
+		ui.withStyleVars({ WindowPadding = ui.theme.styles.WindowPadding }, function()
+			ui.setTooltip(tooltip)
+		end)
+	end)
+end
+
+function ItemCard:calcHeight()
+	local lineSpacing = self.lineSpacing
+
+	local textHeight = pionillium.body.size + pionillium.details.size + lineSpacing.y
+	local iconHeight = self.iconSize and self.iconSize.y or 0
+	local totalHeight = math.max(iconHeight, textHeight) + lineSpacing.y * 2
+
+	return totalHeight
+end
+
+-- Draw an empty item card background
+function ItemCard:drawBackground(isSelected)
+
+	local lineSpacing = self.lineSpacing
+	local totalHeight = self:calcHeight()
+
+	-- calculate the background area
+	local highlightBegin = ui.getCursorScreenPos()
+	local highlightSize = Vector2(ui.getContentRegion().x, totalHeight)
+	local highlightEnd = highlightBegin + highlightSize
+
+	ui.dummy(highlightSize)
+
+	local isHovered = ui.isMouseHoveringRect(highlightBegin, highlightEnd + Vector2(0, lineSpacing.y)) and ui.isWindowHovered()
+	local bgColor = (isSelected and self.selectedColor) or (isHovered and self.hoveredColor) or self.backgroundColor
+
+	if self.highlightBar then
+		-- if we're hovered, we want to draw a little bar to the left of the background
+		if isHovered or isSelected then
+			ui.addRectFilled(highlightBegin - Vector2(self.rounding, 0), highlightBegin + Vector2(0, totalHeight), colors.equipScreenHighlight, 2, 5)
+		end
+
+		ui.addRectFilled(highlightBegin, highlightEnd, bgColor, self.rounding, (isHovered or isSelected) and 10 or 0) -- 10 == top-right | bottom-right
+	else
+		-- otherwise just draw a normal rounded rectangle
+		ui.addRectFilled(highlightBegin, highlightEnd, bgColor, self.rounding, 0)
+	end
+
+	local isClicked = isHovered and ui.isMouseClicked(0)
+
+	return isClicked, isHovered, highlightSize
+
+end
+
+-- Draw an "item card" visual with a primary icon, customizable title line, and
+-- a row of detailed stats.
+--
+-- draw takes a "data" argument table with a minimum set of required fields:
+--   icon  - icon index to draw on the item
+--   [...] - up to 4 { icon, value, tooltip } data items for the stats line
+function ItemCard:draw(data, isSelected)
+	local lineSpacing = self.lineSpacing
+
+	-- initial sizing setup
+	local textHeight = pionillium.body.size + pionillium.details.size + lineSpacing.y
+
+	local iconSize = self.iconSize or Vector2(textHeight)
+	local iconOffset = (textHeight - iconSize.y) * 0.5
+
+	local textWidth = ui.getContentRegion().x - iconSize.x - lineSpacing.x * 3
+
+	local totalHeight = math.max(iconSize.y, textHeight) + lineSpacing.y * 2
+
+	-- calculate the background area
+	local highlightBegin = ui.getCursorScreenPos()
+	local highlightSize = Vector2(ui.getContentRegion().x, totalHeight)
+	local highlightEnd = highlightBegin + highlightSize
+
+	ui.beginGroup()
+	ui.dummy(highlightSize)
+
+	local isHovered = ui.isItemHovered()
+	local isClicked = ui.isItemClicked(0)
+
+	local bgColor = (isSelected and self.selectedColor) or (isHovered and self.hoveredColor) or self.backgroundColor
+
+	if self.highlightBar then
+		-- if we're hovered, we want to draw a little bar to the left of the background
+		if isHovered or isSelected then
+			ui.addRectFilled(highlightBegin - Vector2(self.rounding, 0), highlightBegin + Vector2(0, totalHeight), colors.equipScreenHighlight, 2, 5)
+		end
+
+		ui.addRectFilled(highlightBegin, highlightEnd, bgColor, self.rounding, (isHovered or isSelected) and 10 or 0) -- 10 == top-right | bottom-right
+	else
+		-- otherwise just draw a normal rounded rectangle
+		ui.addRectFilled(highlightBegin, highlightEnd, bgColor, self.rounding, 0)
+	end
+
+	local detailTooltip = nil
+
+	PiGui.PushClipRect(highlightBegin + lineSpacing, highlightEnd - lineSpacing, true)
+	ui.setCursorScreenPos(highlightBegin)
+
+	ui.withStyleVars({ ItemSpacing = lineSpacing }, function()
+		-- Set up padding for the top and left sides
+		ui.addCursorPos(lineSpacing + Vector2(0, iconOffset))
+
+		-- Draw the main icon and add some spacing next to it
+		ui.icon(data.icon, iconSize, colors.white)
+		-- ui.addCursorPos(Vector2(iconHeight + lineSpacing.x, 0))
+		ui.sameLine()
+		ui.addCursorPos(Vector2(0, -iconOffset))
+
+		-- Draw the title line
+		local pos = ui.getCursorPos()
+		self:drawTitle(data, textWidth, isSelected)
+
+		-- Set up the details line
+		pos = pos + Vector2(0, ui.getTextLineHeightWithSpacing())
+		ui.setCursorPos(pos)
+
+		-- This block draws several small icons with text next to them
+		ui.withFont(pionillium.details, function()
+			-- size of the small details icons
+			local smIconSize = Vector2(ui.getTextLineHeight())
+			local fieldSize = textWidth / self.detailFields
+
+			-- do all of the text first to generate as few draw commands as possible
+			for i, v in ipairs(data) do
+				local offset = fieldSize * (i - 1) + smIconSize.x + 2
+				ui.setCursorPos(pos + Vector2(offset, 1)) -- HACK: force 1-pixel offset here to align baselines
+				ui.text(v[2])
+				if v[3] and ui.isItemHovered() then
+					detailTooltip = v
+				end
+			end
+
+			-- Then draw the icons
+			for i, v in ipairs(data) do
+				local offset = fieldSize * (i - 1)
+				ui.setCursorPos(pos + Vector2(offset, 0))
+				ui.icon(v[1], smIconSize, colors.white)
+			end
+
+			-- ensure we consume the appropriate amount of space if we don't have any details
+			if #data == 0 then
+				ui.newLine()
+			end
+		end)
+
+		-- Add a bit of spacing after the slot
+		ui.spacing()
+
+		if isHovered and not detailTooltip then
+			self:drawTooltip(data, isSelected)
+		elseif detailTooltip then
+			self:drawDetailTooltip(detailTooltip, detailTooltip[3])
+		end
+	end)
+
+	PiGui.PopClipRect()
+
+	ui.endGroup()
+
+	return isClicked, isHovered, highlightSize
+end
+
+return ItemCard

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -208,17 +208,18 @@ ui.Format = {
 		return string.trim(result)
 	end,
 	DistanceUnit = function(distance, fractional)
+		local fmt = fractional and fractional or "%0.2f"
 		local d = math.abs(distance)
 		if d < 1000 then
-			return (fractional and string.format("%0.2f", distance) or math.floor(distance)), lc.UNIT_METERS
+			return (fractional and fmt:format(distance) or math.floor(distance)), lc.UNIT_METERS
 		end
 		if d < 1000*1000 then
-			return string.format("%0.2f", distance / 1000), lc.UNIT_KILOMETERS
+			return fmt:format(distance / 1000), lc.UNIT_KILOMETERS
 		end
 		if d < 1000*1000*1000 then
-			return string.format("%0.2f", distance / 1000 / 1000), lc.UNIT_MILLION_METERS
+			return fmt:format(distance / 1000 / 1000), lc.UNIT_MILLION_METERS
 		end
-		return string.format("%0.2f", distance / 1.4960e11), lc.UNIT_AU
+		return fmt:format(distance / 1.4960e11), lc.UNIT_AU
 	end,
 	Distance = function(distance, fractional)
 		local d, u = ui.Format.DistanceUnit(distance, fractional)

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -399,3 +399,23 @@ ui.addStyledText = function(position, anchor_horizontal, anchor_vertical, text, 
 
 	return size
 end
+
+--
+-- Function: setTooltip
+--
+-- Displays a tooltip in the UI, optionally with the given font.
+-- This function does not display a tooltip if the mouse is currently captured by the game.
+--
+-- Parameters:
+--   tooltip - string, tooltip text to display to the user
+--   font    - optional font table, used to display the given tooltip
+--
+function ui.maybeSetTooltip(tooltip, font)
+	if not Game.player:IsMouseActive() then
+		ui.withFont(font or ui.fonts.pionillium.details, function()
+			pigui.SetTooltip(tooltip)
+		end)
+	end
+end
+
+ui.setTooltip = ui.maybeSetTooltip

--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -711,6 +711,33 @@ function ui.withStyleColorsAndVars(styles, vars, fun)
 end
 
 --
+-- Function: ui.withClipRect
+--
+-- ui.withClipRect(min, max, fun)
+--
+-- Wrap the passed UI code inside a user-defined clipping rectangle
+--
+-- Example:
+--
+-- >
+--
+-- Parameters:
+--   min        - Vector2, minimum screen position of the new clip rect
+--   max        - Vector2, maximum screen position of the new clip rect
+--   fun        - function, a function to call that shows the contents
+--
+-- Returns:
+--
+--   any - the value returned from fun
+--
+function ui.withClipRect(min, max, fun)
+	pigui.PushClipRect(min, max, true)
+	local res = fun()
+	pigui.PopClipRect()
+	return res
+end
+
+--
 -- Function: ui.screenSize
 --
 -- ui.screenSize()

--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -875,11 +875,3 @@ end
 function ui.loadTexture(filename)
 	return pigui:LoadTexture(filename)
 end
-
-function ui.maybeSetTooltip(tooltip)
-	if not Game.player:IsMouseActive() then
-		pigui.SetTooltip(tooltip)
-	end
-end
-
-ui.setTooltip = ui.maybeSetTooltip


### PR DESCRIPTION
Another PR split from the Scout Mission branch. Don't expect a long shelf life before merge.

This PR improves the "equipment item card" UI paradigm used in the ship equipment display widget and breaks it out into its own generic `UI.ItemCard` class for any module to use. It also adds a helper to draw a "blank" item card (e.g. an empty item slot), and improves the ability of surrounding elements to layout correctly relative to the space it takes up.

This PR also includes a slightly opinionated change that unifies all "basic tooltips" set with `ui.setTooltip()` to use a consistent font size regardless of the font size active when the tooltip is set. You can override this by using the custom- tooltip facilities as needed, but this change fixes several very glaring paper-cuts with a tooltip changing font size depending on which part of the element you're hovering over.

This PR also adds a number of basic utilities to the Lua execution environment:

- Provide a shortcut for `string.interp` and add implicit positional argument support.
  ```lua
  "test {} {abc}" % { "123", abc="def" } = "test 123 def"
  ```
- Add `math.lerp` and `math.invlerp` functions for any objects supporting basic math operations (add, sub, mul, div).
- Add a "shallow" `table.copy` helper