### PR TITLE
Miscellaneous fixes and improvements

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -1,7 +1,9 @@
 -- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+---@class SpaceStation : ModelBody
 local SpaceStation = package.core['SpaceStation']
+
 local Event = require 'Event'
 local Rand = require 'Rand'
 local Space = require 'Space'

--- a/data/meta/CoreObject/Body.meta.lua
+++ b/data/meta/CoreObject/Body.meta.lua
@@ -36,6 +36,25 @@ local Body = {}
 -- Ensure the CoreImport field is visible to static analysis
 package.core["Body"] = Body
 
+-- Check if this body reference is still valid
+---@return boolean
+function Body:exists() end
+
+-- Check if this object is a specific type (e.g. Ship or SpaceStation)
+---@param type string
+---@return boolean
+function Body:isa(type) end
+
+-- Set the given body property to the passed value
+---@param key string
+---@param value any NOTE: functions, tables, and coroutines cannot be set as body properties
+function Body:setprop(key, value) end
+
+-- Check if the given property exists on the body
+---@param key string
+---@return boolean
+function Body:hasprop(key) end
+
 --- Get a C++ or Lua component object from the body if present.
 ---
 --- Note: the caller should check the return value if there is a possibility if

--- a/data/meta/CoreObject/Player.meta.lua
+++ b/data/meta/CoreObject/Player.meta.lua
@@ -16,3 +16,5 @@ local Player = {}
 package.core["Player"] = Player
 
 -- TODO: document methods as required
+
+return Player

--- a/data/meta/Engine.lua
+++ b/data/meta/Engine.lua
@@ -1,0 +1,23 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+-- TODO: this file is partially type-complete, please expand it as more types are added.
+
+---@meta
+
+---@class Engine
+---
+---@field rand Rand
+---@field ticks number Number of milliseconds since Pioneer was started.
+---@field time number Number of real-time seconds since Pioneer was started.
+---@field frameTime number Length of the last frame in seconds.
+---@field pigui unknown This is purposefully left untyped, type information is provided for the ui object
+---@field version string
+
+---@class Engine
+local Engine = {}
+
+-- TODO: add information about Engine methods
+
+return Engine

--- a/data/meta/Rand.lua
+++ b/data/meta/Rand.lua
@@ -1,0 +1,40 @@
+-- Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+---@meta
+
+---@class Rand
+local Rand = {}
+
+---@param seed? number|string
+---@return Rand
+function Rand.New(seed) end
+
+-- Returns a random number in the range [min, max), exclusive.
+---@param min number inclusive minimum value, defaults to 0
+---@param max number exclusive maximum value, defaults to 1
+---@return number
+---@overload fun(): number
+---@overload fun(max: number): number
+function Rand:Number(min, max) end
+
+-- Returns a random integer in the range [min, max), exclusive.
+---@param min integer inclusive minimum value, defaults to 0
+---@param max integer exclusive maximum value, defaults to 1
+---@return integer
+---@overload fun(): integer
+---@overload fun(max: integer): integer
+function Rand:Integer(min, max) end
+
+-- Generates a random integer drawn from a Poisson distribution.
+---@param lambda number the mean of the distribution
+---@return integer
+function Rand:Poisson(lambda) end
+
+-- Generates a random number drawn from a Gaussian distribution
+---@param mean number? the mean (center) of the distribution. If omitted, defaults to 0.
+---@param stddev number? the standard deviation (width) of the distribution. If omitted, defaults to 1.
+---@return number
+function Rand:Normal(mean, stddev) end
+
+return Rand

--- a/data/meta/StarSystem.lua
+++ b/data/meta/StarSystem.lua
@@ -23,6 +23,8 @@
 ---@field explored boolean
 ---
 ---@field numberOfStars integer
+---@field numberOfStations integer
+---@field numberOfBodies integer
 ---@field rootSystemBody SystemBody
 ---
 --- Translated description for the system

--- a/data/meta/SystemPath.lua
+++ b/data/meta/SystemPath.lua
@@ -47,6 +47,7 @@ function SystemPath:SectorOnly() end
 
 --- Calculate the distance between this and another system
 ---@param system SystemPath|StarSystem --not yet implemented
+---@return number
 function SystemPath:DistanceTo(system) end
 
 ---@return StarSystem

--- a/data/modules/Debug/DebugShipSpawn.lua
+++ b/data/modules/Debug/DebugShipSpawn.lua
@@ -192,10 +192,18 @@ ship_spawn_debug_window = function()
       if ui.button("Spawn Docked", Vector2(0, 0)) then
         spawn_ship_docked(ship_name, ai_options[ai_opt_selected], ship_equip)
       end
-      if not Game.player:GetDockedWith() then
-        ui.sameLine()
+    end
+    local SectorView = Game.sectorView
+    if not Game.player:GetDockedWith() then
+      ui.sameLine()
+      if nav_target and nav_target:isa("SpaceStation") then
         if ui.button("Teleport To", Vector2(0, 0)) then
           Game.player:SetDockedWith(nav_target)
+        end
+      end
+      if SectorView:GetSelectedSystemPath() and Game.system and not SectorView:GetSelectedSystemPath():IsSameSystem(Game.system.path) then
+        if ui.button("Hyperjump To", Vector2(0, 0)) then
+          Game.player:InitiateHyperjumpTo(SectorView:GetSelectedSystemPath(), 1.0, 0.0, { })
         end
       end
     end

--- a/data/modules/Debug/DebugShipSpawn.moon
+++ b/data/modules/Debug/DebugShipSpawn.moon
@@ -149,10 +149,16 @@ ship_spawn_debug_window = ->
 			if ui.button "Spawn Docked", Vector2(0, 0)
 				spawn_ship_docked ship_name, ai_options[ai_opt_selected], ship_equip
 
-			if not Game.player\GetDockedWith!
-				ui.sameLine!
+		SectorView = Game.sectorView
+		if not Game.player\GetDockedWith!
+			ui.sameLine!
+			if nav_target and nav_target\isa "SpaceStation"
 				if ui.button "Teleport To", Vector2(0, 0)
 					Game.player\SetDockedWith nav_target
+
+			if SectorView\GetSelectedSystemPath! and Game.system and not SectorView\GetSelectedSystemPath!\IsSameSystem(Game.system.path)
+				if ui.button "Hyperjump To", Vector2(0, 0)
+					Game.player\InitiateHyperjumpTo(SectorView\GetSelectedSystemPath(), 1.0, 0.0, {})
 
 		if Game.player\GetCombatTarget!
 			if ui.button "Spawn##Missile", Vector2(0, 0)

--- a/data/modules/Scoop/Scoop.lua
+++ b/data/modules/Scoop/Scoop.lua
@@ -541,6 +541,8 @@ end
 
 -- 0..25% chance for police to notice you scooping illegal cargo
 local onPlayerCargoChanged = function (comm, amount)
+	if not Game.system then return end
+
 	if Game.system:IsCommodityLegal(comm.name) or Game.player:IsDocked() then return end
 
 	for ref, mission in pairs(missions) do

--- a/src/lua/LuaStarSystem.cpp
+++ b/src/lua/LuaStarSystem.cpp
@@ -581,6 +581,20 @@ static int l_starsystem_attr_number_of_stars(lua_State *l)
 	return 1;
 }
 
+static int l_starsystem_attr_number_of_stations(lua_State *l)
+{
+	StarSystem *s = LuaObject<StarSystem>::CheckFromLua(1);
+	LuaPush(l, s->GetNumSpaceStations());
+	return 1;
+}
+
+static int l_starsystem_attr_number_of_bodies(lua_State *l)
+{
+	StarSystem *s = LuaObject<StarSystem>::CheckFromLua(1);
+	LuaPush(l, s->GetNumBodies());
+	return 1;
+}
+
 static int l_starsystem_attr_root_system_body(lua_State *l)
 {
 	StarSystem *s = LuaObject<StarSystem>::CheckFromLua(1);
@@ -717,6 +731,8 @@ void LuaObject<StarSystem>::RegisterClass()
 		{ "govtype", l_starsystem_attr_govtype },
 		{ "explored", l_starsystem_attr_explored },
 		{ "numberOfStars", l_starsystem_attr_number_of_stars },
+		{ "numberOfStations", l_starsystem_attr_number_of_stations },
+		{ "numberOfBodies", l_starsystem_attr_number_of_bodies },
 		{ "rootSystemBody", l_starsystem_attr_root_system_body },
 		{ "shortDescription", l_starsystem_attr_short_description },
 		{ "govDescription", l_starsystem_attr_gov_description },


### PR DESCRIPTION
Expect a short shelf-life before merge.

This PR adds more type information to Lua autocomplete files, fixes one unreported UI error when pumping fuel in hyperspace, and adds a debug utility to hyperjump to the star selected in the Sector Map. As usual, this debug button is present in the Ship Spawner for lack of a better place to put it right now, and requires the player to be undocked. It ignores maximum range and fuel costs, and can happily hyperjump you directly to Sag A* if you scroll long enough to get there...

This also adds two new attributes to LuaStarSystem to avoid having to generate a potentially expensive Lua table just to query the number of bodies or spacestations in a system.