### PR TITLE
Ensure autosave before the onGameEnd event fires

### DIFF
--- a/data/modules/AutoSave/AutoSave.lua
+++ b/data/modules/AutoSave/AutoSave.lua
@@ -50,4 +50,5 @@ Event.Register('onShipDocked', f)
 Event.Register('onShipLanded', f)
 Event.Register('onShipUndocked', f)
 Event.Register('onShipTakeOff', f)
-Event.Register('onGameEnd', function() CheckedSave('_exit'); end)
+-- we have to make sure to autosave the game before the end game process starts
+Event.Register('onAutoSaveBeforeGameEnds', function() CheckedSave('_exit'); end)

--- a/data/modules/TradeShips/Core.lua
+++ b/data/modules/TradeShips/Core.lua
@@ -171,10 +171,8 @@ do
 end
 
 local serialize = function()
-	-- all we need to save is trade_ships, the rest can be rebuilt on load
+	-- all we need to save is Core.ships, the rest can be rebuilt on load
 	-- The serializer will crash if we try to serialize dead objects (issue #3123)
-	-- also, trade_ships may be nil, because it is cleared in 'onGameEnd', and this may
-	-- happen before the autosave module creates its '_exit' save
 	if Core.ships ~= nil then
 		local count = 0
 		for k,_ in pairs(Core.ships) do

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1106,6 +1106,10 @@ void GameLoop::End()
 	Pi::luaConsole->CloseTCPDebugConnection();
 #endif
 
+	// we have to make sure to autosave the game before the end game process starts
+	LuaEvent::Queue("onAutoSaveBeforeGameEnds");
+	LuaEvent::Emit();
+
 	// final event
 	LuaEvent::Queue("onGameEnd");
 	LuaEvent::Emit();


### PR DESCRIPTION
Since the autosave at the end of the game was triggered by the `onGameEnd` event, it was randomly queued among other subscribers to this event. This resulted in (at least) an accidental loss of all TradeShips module data during autosave when exiting the game.

Among other options, I chose to create a separate `onAutoSaveBeforeGameEnds` event, as this seems to me the most straightforward and clear.

Fixes #5427

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

