### PR TITLE
Improve label rendering, fix crash when changing model flags

### DIFF
--- a/data/shaders/opengl/label.frag
+++ b/data/shaders/opengl/label.frag
@@ -1,0 +1,92 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+// #extension GL_ARB_gpu_shader5 : enable
+
+// Partially copied from multi.frag, should probably have some sort of
+// generic framework for surface shaders
+
+#include "attributes.glsl"
+#include "lib.glsl"
+
+#ifdef TEXTURE0
+in vec2 texCoord0;
+#endif
+
+#if NUM_LIGHTS > 0
+in vec3 eyePos;
+in vec3 normal;
+#endif
+
+#ifdef TEXTURE0
+uniform sampler2D texture0; //diffuse
+#endif
+
+uniform vec4 lightIntensity;
+
+out vec4 frag_color;
+
+Surface initSurface()
+{
+	Surface surf;
+	surf.color = material.diffuse;
+	surf.specular = material.specular.xyz;
+	surf.shininess = material.shininess;
+	surf.emissive = material.emission.xyz;
+	surf.normal = vec3(0, 0, 1);
+	surf.ambientOcclusion = 1.0;
+	return surf;
+}
+
+void getSurface(inout Surface surf)
+{
+#ifdef TEXTURE0
+	surf.color *= texture(texture0, texCoord0);
+#endif
+
+	// signed distance to the 'edge' of the font - negative is outside the edge, positive is inside the edge
+	float dist = surf.color.a - 0.5;
+	// calculate the derivative of distance around 0 to create smooth antialiasing
+	float deltaDist = fwidth(dist);
+	surf.color.a = smoothstep(-deltaDist, deltaDist, dist);
+
+#if (NUM_LIGHTS > 0)
+//directional lighting
+	surf.normal = normalize(normal);
+#endif
+}
+
+void main(void)
+{
+	// initialize here to prevent warnings about possibly-unused variables
+	Surface surface = initSurface();
+
+	getSurface(surface);
+
+#ifdef ALPHA_TEST
+	if (surface.color.a == 0.0)
+		discard;
+#endif
+
+	//directional lighting
+#if (NUM_LIGHTS > 0)
+	//ambient only make sense with lighting
+	vec3 diffuse = scene.ambient.xyz * surface.color.xyz;
+	vec3 specular = vec3(0.0);
+	float intensity[4] = float[](
+		lightIntensity.x,
+		lightIntensity.y,
+		lightIntensity.z,
+		lightIntensity.w
+	);
+
+	for (int i=0; i<NUM_LIGHTS; ++i) {
+		BlinnPhongDirectionalLight(uLight[i], intensity[i], surface, eyePos, diffuse, specular);
+	}
+
+	vec3 final_color = diffuse * surface.ambientOcclusion + surface.emissive + specular;
+	frag_color = vec4(final_color, surface.color.w);
+#else
+	frag_color = surface.color;
+#endif
+}

--- a/data/shaders/opengl/label.shaderdef
+++ b/data/shaders/opengl/label.shaderdef
@@ -1,0 +1,16 @@
+## Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+## Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+# Draws alpha-blended SDF text
+
+Shader label
+
+Texture sampler2D texture0 name=diffuse
+
+PushConstant vec4 lightIntensity binding=1
+
+Buffer LightData binding=0
+Buffer DrawData binding=1
+
+Vertex "multi.vert"
+Fragment "label.frag"

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -12,6 +12,8 @@
 #include "Space.h"
 #include "StringF.h"
 
+#include "core/TaskGraph.h"
+
 #include "galaxy/StarSystem.h"
 #include "galaxy/GalaxyGenerator.h"
 

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -9,6 +9,7 @@
 #include "SDL.h"
 #include "SDL_events.h"
 #include "SDL_joystick.h"
+#include "SDL_mouse.h"
 
 #include <array>
 #include <regex>
@@ -476,6 +477,11 @@ void Manager::SetMouseYInvert(bool state)
 		m_config->SetInt("InvertMouseY", mouseYInvert);
 		m_config->Save();
 	}
+}
+
+void Manager::GetMousePosition(int position[2])
+{
+	SDL_GetMouseState(&position[0], &position[1]);
 }
 
 /*

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -494,6 +494,14 @@ void Manager::NewFrame()
 {
 	mouseMotion.fill(0);
 	mouseWheel = 0;
+
+	for (char &m : mouseButton) {
+		if (m == 1) // if we were just pressed last frame, migrate to held state
+			m = 2;
+		if (m == 4) // if we were just released last frame, migrate to empty state
+			m = 0;
+	}
+
 	for (auto &k : keyState) {
 		auto &val = keyState[k.first];
 		switch (k.second) {
@@ -620,7 +628,7 @@ void Manager::HandleSDLEvent(SDL_Event &event)
 		break;
 	case SDL_MOUSEBUTTONUP:
 		if (event.button.button < mouseButton.size()) {
-			mouseButton[event.button.button] = 0;
+			mouseButton[event.button.button] = 4;
 			onMouseButtonUp.emit(event.button.button,
 				event.button.x, event.button.y);
 		}

--- a/src/Input.h
+++ b/src/Input.h
@@ -192,7 +192,10 @@ public:
 	bool IsMouseYInvert() { return mouseYInvert; }
 	void SetMouseYInvert(bool state);
 
-	int MouseButtonState(int button) { return mouseButton[button]; }
+	bool IsMouseButtonPressed(int button) { return mouseButton[button] == 1; }
+	bool IsMouseButtonReleased(int button) { return mouseButton[button] == 3; }
+
+	int MouseButtonState(int button) { return mouseButton[button] & 3; }
 	void SetMouseButtonState(int button, bool state) { mouseButton[button] = state; }
 
 	void GetMousePosition(int position[2]);

--- a/src/Input.h
+++ b/src/Input.h
@@ -195,6 +195,8 @@ public:
 	int MouseButtonState(int button) { return mouseButton[button]; }
 	void SetMouseButtonState(int button, bool state) { mouseButton[button] = state; }
 
+	void GetMousePosition(int position[2]);
+
 	void GetMouseMotion(int motion[2])
 	{
 		std::copy_n(mouseMotion.data(), mouseMotion.size(), motion);

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -113,7 +113,7 @@ void ModelViewerApp::Startup()
 	Shields::Init(renderer);
 
 	//run main loop until quit
-	m_modelViewer = std::make_shared<ModelViewer>(this, Lua::manager);
+	m_modelViewer.Reset(new ModelViewer(this, Lua::manager));
 	if (!m_modelName.empty())
 		m_modelViewer->SetModel(m_modelName);
 
@@ -125,7 +125,7 @@ void ModelViewerApp::Startup()
 void ModelViewerApp::Shutdown()
 {
 	//uninit components
-	m_modelViewer.reset();
+	m_modelViewer.Reset();
 	Lua::Uninit();
 	Shields::Uninit();
 	NavLights::Uninit();

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -827,6 +827,7 @@ void ModelViewer::SetModel(const std::string &filename)
 
 void ModelViewer::OnModelChanged()
 {
+	ResetCamera();
 	ResetThrusters();
 	m_model->SetColors(m_colors);
 

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -101,6 +101,7 @@ private:
 	void DrawModelOptions();
 	void DrawModelTags();
 	void DrawTagNames();
+	void DrawModelHierarchy();
 	void DrawShipControls();
 	void DrawLog();
 	void DrawPiGui();

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -40,7 +40,7 @@ protected:
 
 private:
 	std::string m_modelName;
-	std::shared_ptr<ModelViewer> m_modelViewer;
+	RefCountedPtr<ModelViewer> m_modelViewer;
 };
 
 class ModelViewer : public Application::Lifecycle {

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -742,9 +742,6 @@ void Pi::HandleKeyDown(SDL_Keysym *key)
 
 	// special keys: CTRL+[KEY].
 	switch (key->sym) {
-	case SDLK_q: // Quit
-		Pi::RequestQuit();
-		break;
 	case SDLK_PRINTSCREEN: // print
 	case SDLK_KP_MULTIPLY: // screen
 	{
@@ -998,6 +995,11 @@ void GameLoop::Update(float deltaTime)
 
 	Pi::GetView()->Update();
 	Pi::GetView()->Draw3D();
+
+	// Kick rendering in the background to avoid write->delete->read issues with UI command processing
+	// This may cause future issues if graphic resources are deleted while in-flight, but OpenGL is
+	// capable of handling that eventuality and it prevents application-scope crashes
+	Pi::renderer->FlushCommandBuffers();
 
 	// FIXME: Handling events at the moment must be after view->Draw3D and before
 	// Gui::Draw so that labels drawn to screen can have mouse events correctly

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -256,16 +256,16 @@ void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
 	Pi::config = new GameConfig(options);
 	m_instance = new Pi::App();
 
-	GetApp()->m_loader = std::make_shared<StartupScreen>();
-	GetApp()->m_mainMenu = std::make_shared<MainMenu>();
-	GetApp()->m_gameLoop = std::make_shared<GameLoop>();
+	GetApp()->m_loader.Reset(new StartupScreen());
+	GetApp()->m_mainMenu.Reset(new MainMenu());
+	GetApp()->m_gameLoop.Reset(new GameLoop());
 
 	m_instance->m_noGui = no_gui;
 }
 
 void Pi::App::SetStartPath(const SystemPath &startPath)
 {
-	static_cast<MainMenu *>(m_mainMenu.get())->SetStartPath(startPath);
+	static_cast<MainMenu *>(m_mainMenu.Get())->SetStartPath(startPath);
 }
 
 void TestGPUJobsSupport()
@@ -477,12 +477,12 @@ void Pi::App::Shutdown()
 
 JobSet *Pi::App::GetAsyncStartupQueue() const
 {
-	return static_cast<StartupScreen *>(m_loader.get())->asyncStartupQueue.get();
+	return static_cast<StartupScreen *>(m_loader.Get())->asyncStartupQueue.get();
 }
 
 JobSet *Pi::App::GetCurrentLoadStepQueue() const
 {
-	return static_cast<StartupScreen *>(m_loader.get())->currentStepQueue.get();
+	return static_cast<StartupScreen *>(m_loader.Get())->currentStepQueue.get();
 }
 
 // TODO: investigate constructing a DAG out of Init functions and dependencies
@@ -979,7 +979,7 @@ void GameLoop::Update(float deltaTime)
 		} else if (Pi::game->GetTime() - time_player_died > 8.0) {
 			// This also shouldn't go here, though we should evaluate to what degree
 			// Pi.cpp is involved in queuing the tombstone loop.
-			SetNextLifecycle(std::make_shared<TombstoneLoop>());
+			SetNextLifecycle(RefCountedPtr<TombstoneLoop>(new TombstoneLoop()));
 			RequestEndLifecycle();
 		}
 	}

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -4,7 +4,6 @@
 #ifndef _PI_H
 #define _PI_H
 
-#include "JobQueue.h"
 #include "Random.h"
 #include "core/GuiApplication.h"
 #include "gameconsts.h"
@@ -25,9 +24,9 @@ namespace PiGui {
 } //namespace PiGui
 
 class Game;
-
 class GameConfig;
 class Intro;
+class JobSet;
 class LuaConsole;
 class LuaNameGen;
 class LuaTimer;

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -120,9 +120,9 @@ public:
 
 		bool m_noGui;
 
-		std::shared_ptr<Lifecycle> m_loader;
-		std::shared_ptr<Lifecycle> m_mainMenu;
-		std::shared_ptr<Lifecycle> m_gameLoop;
+		RefCountedPtr<Lifecycle> m_loader;
+		RefCountedPtr<Lifecycle> m_mainMenu;
+		RefCountedPtr<Lifecycle> m_gameLoop;
 	};
 
 public:

--- a/src/Quaternion.h
+++ b/src/Quaternion.h
@@ -99,6 +99,13 @@ public:
 		r.z = a.z * s;
 		return r;
 	}
+	// vector transform with quaternion
+	// (see https://community.khronos.org/t/quaternion-functions-for-glsl/50140/3)
+	friend vector3<T> operator*(const Quaternion &a, const vector3<T> &vec)
+	{
+		vector3<T> xyz = vector3<T>(a.x, a.y, a.z);
+		return vec + 2.0 * (vec.Cross(xyz) + a.w * vec).Cross(xyz);
+	}
 	friend Quaternion operator+(const Quaternion &a, const Quaternion &b)
 	{
 		Quaternion r;

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -7,6 +7,7 @@
 #include "OS.h"
 #include "SDL.h"
 #include "StringName.h"
+#include "TaskGraph.h"
 #include "profiler/Profiler.h"
 #include "utils.h"
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -19,7 +19,7 @@ static constexpr Uint32 SYNC_JOBS_PER_LOOP = 1;
 Application::Application() {}
 Application::~Application() {}
 
-void Application::QueueLifecycle(std::shared_ptr<Lifecycle> cycle)
+void Application::QueueLifecycle(RefCountedPtr<Lifecycle> cycle)
 {
 	if (!cycle)
 		throw std::runtime_error("Invalid Lifecycle object pushed to Application queue!");
@@ -104,7 +104,7 @@ bool Application::StartLifecycle()
 	// Lifecycle objects returned from Lifecycle::End() take priority over queued objects
 	if (m_priorityLifecycle) {
 		m_activeLifecycle = m_priorityLifecycle;
-		m_priorityLifecycle = nullptr;
+		m_priorityLifecycle.Reset();
 	} else {
 		m_activeLifecycle = std::move(m_queuedLifecycles.front());
 		m_queuedLifecycles.pop();
@@ -134,7 +134,7 @@ void Application::EndLifecycle()
 	// wait until we've finished the control flow for the lifecycle;
 	// the lifecycle may decide to set the next lifecycle in End()
 	m_priorityLifecycle = m_activeLifecycle->m_nextLifecycle;
-	m_activeLifecycle = nullptr;
+	m_activeLifecycle.Reset();
 }
 
 void Application::ClearQueuedLifecycles()

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "core/TaskGraph.h"
 #include "RefCounted.h"
 
 #include <memory>
@@ -12,6 +11,7 @@
 
 class JobQueue;
 class SyncJobQueue;
+class TaskGraph;
 
 class Application {
 public:

--- a/src/core/TaskGraph.h
+++ b/src/core/TaskGraph.h
@@ -99,6 +99,8 @@ public:
 	struct Handle {
 		Handle(const Handle &) = delete;
 		Handle &operator=(const Handle &) = delete;
+		Handle(Handle &&) = default;
+		Handle &operator=(Handle &&) = default;
 		bool IsComplete() { return !m_set || m_set->IsComplete(); }
 
 	private:

--- a/src/matrix3x3.h
+++ b/src/matrix3x3.h
@@ -220,11 +220,15 @@ public:
 		minv[idx2d(2, 2)] = (cell2d(0, 0) * cell2d(1, 1) - cell2d(1, 0) * cell2d(0, 1)) * invdet;
 		return minv;
 	}
-	void Renormalize()
+	matrix3x3 Normalized() const
 	{
 		vector3<T> x = VectorX().Normalized();
 		vector3<T> y = VectorZ().Cross(x).Normalized();
-		*this = FromVectors(x, y);
+		return FromVectors(x, y);
+	}
+	void Renormalize()
+	{
+		*this = Normalized();
 	}
 	void Print() const
 	{

--- a/src/scenegraph/Label3D.cpp
+++ b/src/scenegraph/Label3D.cpp
@@ -5,6 +5,7 @@
 #include "NodeVisitor.h"
 #include "graphics/RenderState.h"
 #include "graphics/Renderer.h"
+#include "graphics/Types.h"
 #include "graphics/VertexArray.h"
 #include "graphics/VertexBuffer.h"
 
@@ -21,9 +22,10 @@ namespace SceneGraph {
 
 		Graphics::RenderStateDesc rsd;
 		rsd.depthWrite = false;
+		rsd.blendMode = Graphics::BLEND_ALPHA;
 
 		m_geometry.reset(font->CreateVertexArray());
-		m_material.Reset(r->CreateMaterial("multi", matdesc, rsd));
+		m_material.Reset(r->CreateMaterial("label", matdesc, rsd));
 		m_material->SetTexture("texture0"_hash, font->GetTexture());
 		m_material->diffuse = Color::WHITE;
 		m_material->emissive = Color(38, 38, 38);

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -757,12 +757,15 @@ namespace SceneGraph {
 		return m;
 	}
 
-	void Loader::CreateLabel(Group *parent, const matrix4x4f &m)
+	void Loader::CreateLabel(const std::string &name, Group *parent, const matrix4x4f &m)
 	{
 		PROFILE_SCOPED()
 		MatrixTransform *trans = new MatrixTransform(m_renderer, m);
+
 		Label3D *label = new Label3D(m_renderer, m_labelFont);
 		label->SetText("Bananas");
+		label->SetName(name);
+
 		trans->AddChild(label);
 		parent->AddChild(trans);
 	}
@@ -858,7 +861,7 @@ namespace SceneGraph {
 			} else if (starts_with(nodename, "thruster_")) {
 				CreateThruster(nodename, accum * m);
 			} else if (starts_with(nodename, "label_")) {
-				CreateLabel(parent, m);
+				CreateLabel(nodename, parent, m);
 			} else if (starts_with(nodename, "tag_")) {
 				m_model->AddTag(nodename, new MatrixTransform(m_renderer, accum * m));
 			} else if (starts_with(nodename, "entrance_")) {

--- a/src/scenegraph/Loader.h
+++ b/src/scenegraph/Loader.h
@@ -68,7 +68,7 @@ namespace SceneGraph {
 		void ConvertAiMeshes(std::vector<RefCountedPtr<StaticGeometry>> &, const aiScene *); //model is only for material lookup
 		void ConvertAnimations(const aiScene *, const std::vector<AnimDefinition> &, Node *meshRoot);
 		void ConvertNodes(aiNode *node, Group *parent, std::vector<RefCountedPtr<StaticGeometry>> &meshes, const matrix4x4f &);
-		void CreateLabel(Group *parent, const matrix4x4f &);
+		void CreateLabel(const std::string &name, Group *parent, const matrix4x4f &);
 		void CreateThruster(const std::string &name, const matrix4x4f &nodeTrans);
 		void CreateNavlight(const std::string &name, const matrix4x4f &nodeTrans);
 		RefCountedPtr<CollisionGeometry> CreateCollisionGeometry(RefCountedPtr<StaticGeometry>, unsigned int collFlag);

--- a/src/scenegraph/Parser.cpp
+++ b/src/scenegraph/Parser.cpp
@@ -83,7 +83,7 @@ namespace SceneGraph {
 	{
 		checkString(ss, out, "file name");
 		//add newmodels/some_model/ to path
-		out = FileSystem::JoinPathBelow(m_path, out);
+		out = FileSystem::NormalisePath(FileSystem::JoinPath(m_path, out));
 		return true;
 	}
 

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -8,12 +8,15 @@
 #include "Sound.h"
 #include "Body.h"
 #include "FileSystem.h"
+#include "JobQueue.h"
 #include "Pi.h"
 #include "Player.h"
+
 #include "SDL_audio.h"
 #include "SDL_events.h"
 #include <SDL.h>
 #include <vorbis/vorbisfile.h>
+
 #include <cassert>
 #include <cerrno>
 #include <cstdio>

--- a/src/vector3.h
+++ b/src/vector3.h
@@ -109,6 +109,10 @@ public:
 		const T inv = 1.0 / scalar;
 		return vector3(a.x * inv, a.y * inv, a.z * inv);
 	}
+	friend vector3 operator/(const T scalar, const vector3 &a)
+	{
+		return vector3(scalar / a.x, scalar / a.y, scalar / a.z);
+	}
 
 	vector3 Cross(const vector3 &b) const { return vector3(y * b.z - z * b.y, z * b.x - x * b.z, x * b.y - y * b.x); }
 	T Dot(const vector3 &b) const { return x * b.x + y * b.y + z * b.z; }


### PR DESCRIPTION
This PR is a general catch-all of various "engine" changes I've made over the last 5 months or so.

The headlining feature is an improved shader for the Label3D model node. I've added anti-aliasing to the SDF font rendering to avoid the persistent jagged edges that showed up even with MSAA enabled. This is most visible on ships as their ID number.

I've also made a change to flush the renderer's command buffer "early" before the UI is drawn, to avoid crashes caused by a resource in the command buffer being deleted by model code. This isn't a perfect solution, but it gets the crashes out of the way for now without costing much (if any) performance.

This PR also includes a new "hierarchy" tab for the ModelViewer, which shows the computed node structure of the loaded model. It's not 100% complete, but already quite useful when developing the clickable cockpit branch.

Finally, I've included a few general engine-related cleanup and internal-feature commits that I've managed to pull out of the cockpit/MFD branch; these simply improve code quality and provide more utility to future developers.