### PR TITLE
Fix error setting tooltip in main menu, fix error in hyperspace

### DIFF
--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -2,6 +2,7 @@
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 local Engine = require 'Engine'
 local Format = require 'Format'
+local Input = require 'Input'
 local Lang = require 'Lang'
 local Game = require 'Game'
 local ui = require 'pigui.baseui'
@@ -412,7 +413,7 @@ end
 --   font    - optional font table, used to display the given tooltip
 --
 function ui.maybeSetTooltip(tooltip, font)
-	if not Game.player:IsMouseActive() then
+	if not Input.GetMouseCaptured() then
 		ui.withFont(font or ui.fonts.pionillium.details, function()
 			pigui.SetTooltip(tooltip)
 		end)

--- a/data/pigui/modules/flight-ui/system-overview.lua
+++ b/data/pigui/modules/flight-ui/system-overview.lua
@@ -9,6 +9,7 @@ local Vector2 = _G.Vector2
 local ui = require 'pigui'
 local gameView = require 'pigui.views.game'
 
+local lc = Lang.GetResource("core")
 local lui = Lang.GetResource("ui-core");
 
 local height_fraction = 1.6
@@ -52,17 +53,25 @@ gameView.registerSidebarModule("system-overview", {
 		local pos = ui.getCursorPos() + Vector2(ui.getContentRegion().x - button_width, 0)
 		systemOverview.buttonSize = Vector2(ui.getLineHeight() - style.buttonPadding * 2)
 
-		ui.text(Game.system.name)
+		if Game.system then
+			ui.text(Game.system.name)
 
-		ui.setCursorPos(pos)
-		ui.withStyleVars({ ItemSpacing = spacing }, function()
-			ui.withFont(ui.fonts.pionillium.medium, function()
-				systemOverview:drawControlButtons()
+			ui.setCursorPos(pos)
+			ui.withStyleVars({ ItemSpacing = spacing }, function()
+				ui.withFont(ui.fonts.pionillium.medium, function()
+					systemOverview:drawControlButtons()
+				end)
 			end)
-		end)
+		else
+			ui.text(lc.HYPERSPACE)
+		end
 	end,
 
 	drawBody = function()
+		if not Game.system then
+			return
+		end
+
 		systemOverview:displaySearch()
 
 		systemOverview.size.y = math.max(ui.getContentRegion().y, ui.screenHeight / height_fraction)

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -497,6 +497,12 @@ static int l_input_set_mouse_y_inverted(lua_State *l)
 	return 0;
 }
 
+static int l_input_get_mouse_captured(lua_State *l)
+{
+	LuaPush<bool>(l, Pi::input->IsCapturingMouse());
+	return 1;
+}
+
 static int l_input_get_joystick_enabled(lua_State *l)
 {
 	lua_pushboolean(l, Pi::input->IsJoystickEnabled());
@@ -641,6 +647,9 @@ void LuaInput::Register()
 		{ "SetMouseYInverted", l_input_set_mouse_y_inverted },
 		{ "GetJoystickEnabled", l_input_get_joystick_enabled },
 		{ "SetJoystickEnabled", l_input_set_joystick_enabled },
+
+		{ "GetMouseCaptured", l_input_get_mouse_captured },
+
 		{ NULL, NULL }
 	};
 


### PR DESCRIPTION
Fixes #5457. Fixes #5463.

This PR introduces a new `Input.GetMouseCaptured()` method, which is a more general-purpose accessor than `Player:GetMouseActive()`. This allows it to be used in map screens, etc. which capture the mouse when dragging buttons, as well as when piloting the ship.