### PR TITLE
Dynamic Station Economies

### DIFF
--- a/data/economy/commodities/high_tech.json
+++ b/data/economy/commodities/high_tech.json
@@ -3,13 +3,13 @@
 	"commodities": {
 		"medicines": {
 			"l10n_key": "MEDICINES",
-			"inputs": [ "computers", "carbon_ore" ],
+			"inputs": [ "carbon_ore", [ "computers", 0.4 ] ],
 			"producer": "industrial",
 			"price": 563
 		},
 		"computers": {
 			"l10n_key": "COMPUTERS",
-			"inputs": [ "precious_metals", "industrial_machinery" ],
+			"inputs": [ [ "precious_metals", 0.2 ], "industrial_machinery" ],
 			"producer": "industrial",
 			"price": 461
 		},

--- a/data/economy/commodities/industrial.json
+++ b/data/economy/commodities/industrial.json
@@ -44,7 +44,7 @@
 		},
 		"hand_weapons": {
 			"l10n_key": "HAND_WEAPONS",
-			"inputs": [ "metal_alloys", "computers" ],
+			"inputs": [ "metal_alloys", [ "computers", 0.2 ] ],
 			"producer": "industrial",
 			"price": 251,
 			"default_legality": [ 1, 2 ]

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2346,5 +2346,13 @@
   "ZOOM": {
     "description": "Label for a zoom (magnification) control bar.",
     "message": "Zoom"
+  },
+  "DEMAND": {
+	"description": "Column label for commodity demand at a market.",
+	"message": "Demand"
+  },
+  "INTERSTELLAR_TRADE_AVG": {
+	"description": "Label displaying commodity flow at a per-system level",
+	"message": "Interstellar Trade:"
   }
 }

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2354,5 +2354,9 @@
   "INTERSTELLAR_TRADE_AVG": {
 	"description": "Label displaying commodity flow at a per-system level",
 	"message": "Interstellar Trade:"
+  },
+  "NO_AVAILABLE_DATA": {
+	"description": "Message displaying no stored data available",
+	"message": "No data available"
   }
 }

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2183,6 +2183,10 @@
     "description": "",
     "message": "Total mass"
   },
+  "TRADING_AT": {
+    "description": "Indicates the current system for inspecting commodities.",
+    "message": "At {system}:"
+  },
   "TRADING_FROM": {
     "description": "Indicates the source system of a commodity trade.",
     "message": "From {system}:"

--- a/data/libs/Economy.lua
+++ b/data/libs/Economy.lua
@@ -1,0 +1,359 @@
+-- Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Rand       = require 'Rand'
+local Game       = require 'Game'
+local Serializer = require 'Serializer'
+local utils      = require 'utils'
+
+---@class Economy
+local Economy = package.core['Economy']
+
+---@class Economy.StationMarket
+---@field commodities table<string, table>
+---@field lastStockUpdate number
+
+-- Determines how far a commodity's price can be perturbed from the system-wide
+-- average price at an individual station
+local kMaxCommodityVariance = 12
+
+local Economies = Economy.GetEconomies()
+local Commodities = Economy.GetCommodities()
+
+local stationMarket = {}
+
+local affinityCache = {}
+
+-- Function: GetStationEconomy
+--
+-- This function calculates the economy-type affinities of the given station
+-- based on several body parameters. It's intended as a stub to generate
+-- interesting and sometimes-useful results until a more complete and
+-- parameter-rich implementation can be added to system generation directly.
+--
+-- Status: experimental
+---@param stationBody SystemBody
+---@return table<integer, number> affinity Station's affinity to a specific economic type
+function Economy.GetStationEconomy(stationBody)
+	local sBody = stationBody.parent
+
+	if not sBody then return {} end
+
+	if affinityCache[stationBody.path] then
+		return affinityCache[stationBody.path]
+	end
+
+	logVerbose("Computing station economy type for Station {name}" % stationBody)
+
+	local econAffinity = {}
+	local max = 0.0
+	local sum = 0.0
+
+	-- Two-pass design attempting to maintain a variance between the primary
+	-- producing economy on the station and the secondary economies
+
+	local rand = Rand.New('station-econ-{}' % { stationBody.seed })
+
+	for _, econ in pairs(Economies) do
+		local score = 0.0
+		score = score + econ.generation.agricultural * math.max(sBody.agricultural, sBody.life * 0.75)
+		score = score + econ.generation.metallicity * (sBody.metallicity + sBody.volatileIces) * 0.5
+		score = score + econ.generation.industrial * (sBody.volcanicity * sBody.metallicity + sBody.atmosOxidizing) * 0.5
+
+		econAffinity[econ.id] = score
+		sum = sum + score
+	end
+
+	for _, econ in pairs(Economies) do
+		local score = econAffinity[econ.id]
+		local offset = rand:Number(0, math.min(sum, score))
+
+		score = score + offset
+		sum = sum - offset
+
+		logVerbose("\teconomy {} affinity {}" % { econ.name, score })
+		econAffinity[econ.id] = score
+		max = math.max(max, score)
+	end
+
+	for k, v in pairs(econAffinity) do
+		econAffinity[k] = v / max
+	end
+
+	affinityCache[stationBody.path] = econAffinity
+
+	return econAffinity
+end
+
+-- Modify the given stock or demand level for a commodity based on the
+-- system-wide import/export status of the commodity
+--
+-- Pricemod is technically a percentage modification of the commodity price
+-- but functions more like a factor controlling relative supply and demand of
+-- the commodity - positive values indicate higher demand, while negative
+-- values indicate higher supply
+--
+-- Pricemod is scaled according to a log curve to increase the offset applied
+-- at higher percentages.
+function Economy.ApplyPriceMod(max, val, pricemod)
+	local priceScale = 4.0 - math.clamp(math.log(math.abs(pricemod)), 1, 3)
+	return val - (max * pricemod * 0.01 * priceScale)
+end
+
+-- Function: GetMaxStockForPrice
+--
+-- Returns the maximum commodity stocking at any station based on price
+-- adjusted for some rarity curve by an exponent.
+--
+-- The higher the nominal price of the commodity, the exponentially less
+-- maximum stock this station will have of it - this models commodity rarity
+-- as a function of commodity price.
+function Economy.GetMaxStockForPrice(price)
+	return 290000 / price^1.217
+end
+
+-- weight a scalar in the range -1..1 away from 0 to generate more interesting results
+local function weight_affinity(a)
+	local v = math.abs(a) - 1
+	return math.sign(a) * ( 1 + v * v * v ) -- out cubic easing
+end
+
+-- Function: GetStationTargetStock
+--
+-- Calculate the target stock level for a commodity based on the given station
+-- seed number. This is used to determine the persistent equilibrium stock for
+-- "non-market" commodities at a station. (e.g. rubbish and fuels)
+--
+-- Parameters:
+--   key  - string, name of the commodity
+--   seed - number, the target space station's unique seed value
+--
+-- Returns:
+--  targetStock - the persistent equilibrium stock amount of the commodity for
+--                the given station steed.
+function Economy.GetStationTargetStock(key, seed)
+	-- use a deterministic random function to determine target stock numbers
+	local rand = Rand.New(seed .. '-stock-' .. key)
+	local comm = Commodities[key]
+	local rn = Economy.GetMaxStockForPrice(math.abs(comm.price))
+
+	return rn * (rand:Number() + rand:Number()) * 0.5 -- normal 0-100% "permanent" stock
+end
+
+---@param stationBody SystemBody
+---@param comm table the commodity data involved
+function Economy.GetStationFlowParams(stationBody, comm)
+	local affinities = Economy.GetStationEconomy(stationBody)
+
+	-- use a deterministic random function to determine target stock numbers
+	local rand = Rand.New('station-{}-stock-{}' % { stationBody.seed, comm.name })
+
+	-- Calculate the total flow for a commodity at this station based on a
+	-- normal distribution.
+	-- "Flow" models both supply and demand of a commodity, and is used to
+	-- determine equilibrium state
+	-- NOTE: a better model for calculating commodity flow would be nice -
+	-- this produces varied but irrational results
+	local flow = (rand:Number() + rand:Number()) * 0.5
+
+	-- Calculate this station's proportion of export to import based on its
+	-- affinity to the producing economy.
+	-- A station with high affinity primarily exports the commodity while a
+	-- station with low affinity primarily imports the commodity.
+	local affinity = affinities[comm.producer] or 1
+	affinity = weight_affinity(affinity * 2 - 1)
+	affinity = math.clamp(affinity, -0.99, 0.99)
+
+	-- logVerbose("{}: flow {}, affinity: {}" % { comm.name, flow, affinity })
+
+	return flow, affinity
+end
+
+function Economy.GetCommodityStockFromFlow(comm, flow, affinity)
+	affinity = affinity * 0.5 + 0.5
+
+	local flowQuant = flow * Economy.GetMaxStockForPrice(math.abs(comm.price))
+
+	-- Compute real stock and demand numbers in commodity units
+	local stock = math.ceil(affinity * flowQuant)
+	local demand = math.ceil((1 - affinity) * flowQuant)
+
+	return stock, demand
+end
+
+-- Function: CreateStationCommodityMarket
+--
+-- Calculate the target stock, demand, and nominal pricing for the given
+-- commodity in the 'equilibrium' state at the passed station.
+--
+-- This is the "baseline" amount that the stock level will naturally return to
+-- over time in the absense of any external factors.
+--
+-- Parameters:
+--   stationBody - SystemBody, the target space station body
+--   key         - string, name of the commodity
+--
+-- Returns:
+--  market - table containing information about the equilibrium stock, demand
+--           and price modifier
+---@param stationBody SystemBody
+---@param key string the string name of the commodity
+function Economy.CreateStationCommodityMarket(stationBody, key)
+	local comm = Commodities[key]
+	-- return a new "empty" market table here so it can be modified downstream
+	if not comm then return { 0, 0, 0 } end
+
+	local flow, affinity = Economy.GetStationFlowParams(stationBody, comm)
+
+	-- Calculate the typical amount of stock and demand in commodity units at
+	-- this station to seed the market with, as well as the real price of the
+	-- item at equilibrium
+	local stock, demand = Economy.GetCommodityStockFromFlow(comm, flow, affinity)
+
+	local market = { stock, demand, 0 }
+
+	market[3] = Economy.GetStationCommodityPriceMod(stationBody, key, market)
+
+	return market
+end
+
+-- Function: GetStationCommodityPriceMod
+--
+-- Recompute the price modifier of the given commodity according to the current
+-- market parameters and return the new price modifier
+--
+-- Parameters:
+--   stationBody - SystemBody, the target space station body
+--   key         - string, name of the commodity
+--   commMarket  - table, information about the commodity market
+--
+-- Returns:
+--  pricemod - number, percentage modifier of the commodity price from 'base' value
+---@param sBody SystemBody the station's SystemBody
+---@param key string the string name of the commodity
+---@param commMarket table the current state of the commmodity market
+function Economy.GetStationCommodityPriceMod(sBody, key, commMarket)
+	local comm = Commodities[key]
+	if not comm then return 0 end
+
+	local maxStock = Economy.GetMaxStockForPrice(math.abs(comm.price))
+	local systemMod = sBody.system:GetCommodityBasePriceAlterations(key)
+
+	-- [stock, demand]
+	local stockPrice  = commMarket[1] / maxStock * -kMaxCommodityVariance
+	local demandPrice = commMarket[2] / maxStock *  kMaxCommodityVariance
+
+	return utils.round(stockPrice + demandPrice, 0.01) + systemMod
+end
+
+-- Function: GetStationCommodityPrice
+--
+-- Return a modified price according to the given commodity market conditions
+function Economy.GetMarketPrice(price, pricemod)
+	return price * (1 + pricemod * 0.01)
+end
+
+local kAvgTicksToRestock = 12
+
+---@param sBody SystemBody
+function Economy.UpdateStationCommodityMarket(sBody, rand, market, key, numTicks)
+	local comm = Commodities[key]
+
+	local flow, affinity = Economy.GetStationFlowParams(sBody, comm)
+	local targetStock, targetDemand = Economy.GetCommodityStockFromFlow(comm, flow, affinity)
+
+	local stock, demand, pricemod = market[1], market[2], market[3]
+
+	for i = 1, numTicks do
+		stock = stock + rand:Normal(1, 1) / kAvgTicksToRestock * targetStock
+		demand = demand + rand:Normal(1, 1) / kAvgTicksToRestock * targetDemand
+	end
+
+	stock = math.clamp(math.ceil(stock), 0, targetStock)
+	demand = math.clamp(math.ceil(demand), 0, targetDemand)
+	pricemod = Economy.GetStationCommodityPriceMod(sBody, key, market)
+
+	market[1] = stock
+	market[2] = demand
+	market[3] = pricemod
+end
+
+---@param sBody SystemBody
+---@return Economy.StationMarket
+function Economy.CreateStationMarket(sBody)
+	if stationMarket[sBody.path] then
+		return stationMarket[sBody.path]
+	end
+
+	local storedStation = {
+		commodities = {},
+		lastStockUpdate = Game.time
+	}
+
+	stationMarket[sBody.path] = storedStation
+
+	local h2 = Commodities.hydrogen
+	for key, comm in pairs (Commodities) do
+		-- Don't add entries for "haulaway" commodities or fuel
+		if comm.price > 0.0 and comm ~= h2 then
+			-- Initialize the station's stock levels to the equilibrium
+
+			local cMarket = Economy.CreateStationCommodityMarket(sBody, key)
+			storedStation.commodities[key] = cMarket
+
+			logVerbose("\t{}\n\tstock: {}, demand: {}, priceMod: {}, system priceMod: {}" % {
+				key, cMarket[1], cMarket[2], cMarket[3],
+				sBody.system:GetCommodityBasePriceAlterations(key)
+			})
+		end
+	end
+
+	return storedStation
+end
+
+function Economy.GetStationMarket(path)
+	return stationMarket[path]
+end
+
+local kTickDuration = 7 * 24 * 60 * 60 -- 1 week
+function Economy.UpdateStationMarket(sBody)
+	local market = stationMarket[sBody.path]
+	if not market then return end
+
+	local lastStockUpdate = market.lastStockUpdate
+	local timeSinceUpdate = Game.time - lastStockUpdate
+	if timeSinceUpdate <= kTickDuration then return end
+
+	-- make sure the next tick happens at the correct time
+	local numTicks = math.floor(timeSinceUpdate / kTickDuration)
+	market.lastStockUpdate = lastStockUpdate + numTicks * kTickDuration
+
+	-- use a unique random function to tally up restocks
+	-- this ensures that each restock uses a different random number based on game start time
+	local randRestock = Rand.New(sBody.seed .. '-stockMarketUpdate-' .. math.floor(lastStockUpdate))
+
+	for key, data in pairs (market.commodities) do
+		logVerbose("\tcommodity {} was {}/{} (%{})" % { key, data[1], data[2], data[3] })
+
+		Economy.UpdateStationCommodityMarket(sBody, randRestock, data, key, numTicks)
+
+		logVerbose("\tcommodity {} now {}/{} (%{})" % { key, data[1], data[2], data[3] })
+	end
+end
+
+function Economy.OnGameEnd()
+	stationMarket = {}
+end
+
+Serializer:Register("Economy",
+	function()
+		return {
+			market = stationMarket
+		}
+	end,
+	function(data)
+		stationMarket = data.market
+	end
+)
+
+return Economy

--- a/data/libs/Economy.lua
+++ b/data/libs/Economy.lua
@@ -16,10 +16,16 @@ local Economy = package.core['Economy']
 
 -- Determines how far a commodity's price can be perturbed from the system-wide
 -- average price at an individual station
-local kMaxCommodityVariance = 12
+local kMaxCommodityVariance = 15
 
 local Economies = Economy.GetEconomies()
 local Commodities = Economy.GetCommodities()
+
+
+-- Percentage modifier applied to buying/selling commodities
+-- Prevents buying a commodity at a station and immediately reselling it
+Economy.TradeFeeSplit = 2
+Economy.TotalTradeFees = 2 * Economy.TradeFeeSplit
 
 -- stationMarket is a persistent table of stock information for every station
 -- the player has visited in their journey

--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -254,6 +254,31 @@ function utils.stable_sort(values, cmp)
 	return merge_sort(values)
 end
 
+local __automagic = {
+	__index = function(t, k)
+		local nt = {}
+		t[k] = nt
+		return nt
+	end
+}
+
+--
+-- Function: automagic
+--
+-- Returns an "automagic" table - the table will automatically create a new
+-- subtable if accessed via a key that doesn't yet exist in the table.
+--
+-- Created subtables will be "regular" Lua tables with no automagic capability.
+-- To check if an index exists in the table, `rawget()` must be used.
+--
+-- Example:
+-- > local t = utils.automagic()
+-- > t.someIndexNotPresent.value = "no error will be thrown!"
+--
+function utils.automagic(t)
+	return setmetatable(t or {}, __automagic)
+end
+
 --
 -- Class: utils.object
 --

--- a/data/meta/SystemBody.lua
+++ b/data/meta/SystemBody.lua
@@ -13,6 +13,7 @@
 ---@field superType BodySuperType
 ---@field seed integer
 ---@field parent SystemBody?
+---@field system StarSystem
 ---
 --- The population of the body, in billions of people.
 ---@field population number
@@ -59,6 +60,9 @@
 --- The measure of life present on the body:
 --- 0.0 = dead, 1.0 = teeming (~= pandora)
 ---@field life number
+--- The measure of agricultural activity present on the body:
+--- 0.0 = dead, 1.0 = teeming (~= breadbasket)
+---@field agricultural number
 ---
 ---@field hasRings boolean
 ---@field hasAtmosphere boolean

--- a/data/modules/Debug/DebugCommodityPrices.lua
+++ b/data/modules/Debug/DebugCommodityPrices.lua
@@ -140,7 +140,7 @@ local build_nearby_systems = function (dist, display)
 	local max_dist = dist or 30
 	local display = display or false
 
-	nearbysystems = Game.system:GetNearbySystems(max_dist, function (s) return #s:GetStationPaths() > 0 end)
+	local nearbysystems = Game.system:GetNearbySystems(max_dist, function (s) return #s:GetStationPaths() > 0 end)
 
 	if display then
 		for key, sys in pairs(nearbysystems) do

--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -363,7 +363,7 @@ local onShipDocked = function (ship, station)
 			else
 				error("demand should probably not be 0.")
 			end
-			-- print("--- NewsEvent: cargo:", cargo_item:GetName(), "price:", newPrice, "stock:", newStockChange)
+			-- print("--- NewsEvent: cargo:", cargo_item:GetName(), "price:", newPrice, "stock:", newStock)
 			station:SetCommodityPrice(cargo_item, newPrice)
 			station:SetCommodityStock(cargo_item, newStock)
 		end

--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -353,19 +353,19 @@ local onShipDocked = function (ship, station)
 			local price = station:GetCommodityPrice(cargo_item)
 			local stock = station:GetCommodityStock(cargo_item)
 
-			local newPrice, newStockChange
+			local newPrice, newStock
 			if n.demand > 0 then
 				newPrice = n.demand * price -- increase price
-				newStockChange = -1 * stock -- remove all stock
+				newStock = 0 -- remove all stock
 			elseif n.demand < 0 then
 				newPrice = math.ceil(price / (1 + math.abs(n.demand)))  -- dump price
-				newStockChange = math.ceil(math.abs(n.demand * stock))  -- spam stock
+				newStock = math.ceil(math.abs(n.demand * stock))  -- spam stock
 			else
 				error("demand should probably not be 0.")
 			end
 			-- print("--- NewsEvent: cargo:", cargo_item:GetName(), "price:", newPrice, "stock:", newStockChange)
 			station:SetCommodityPrice(cargo_item, newPrice)
-			station:AddCommodityStock(cargo_item, newStockChange)
+			station:SetCommodityStock(cargo_item, newStock)
 		end
 	end
 end

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -5,6 +5,7 @@ local Game = require 'Game'
 local Lang = require 'Lang'
 local Format = require 'Format'
 local Commodities = require 'Commodities'
+local Economy     = require 'Economy'
 
 local ui = require 'pigui'
 local pionillium = ui.fonts.pionillium
@@ -86,7 +87,7 @@ function CommodityMarketWidget.New(id, title, config)
 		ui.nextColumn()
 
 		ui.withStyleVars({ItemSpacing = (self.style.itemSpacing / 2)}, function()
-			local price = self.funcs.getBuyPrice(self, item)
+			local price = self.station:GetCommodityPrice(item)
 
 			ui.dummy(vZero)
 			ui.text(item:GetName())
@@ -133,17 +134,14 @@ function CommodityMarketWidget.New(id, title, config)
 
     -- what do we charge for this item if we are buying
     config.getBuyPrice = config.getBuyPrice or function (self, commodity)
-        return self.station:GetCommodityPrice(commodity)
+		local price = self.station:GetCommodityPrice(commodity)
+		return price * (1.0 + math.sign(price) * Economy.TradeFeeSplit * 0.01)
     end
 
     -- what do we get for this item if we are selling
     config.getSellPrice = config.getSellPrice or function (self, commodity)
-        local basePrice = self.station:GetCommodityPrice(commodity)
-        if basePrice > 0 then
-			return basePrice
-        else
-            return 1.0/sellPriceReduction * basePrice
-        end
+        local price = self.station:GetCommodityPrice(commodity)
+		return price * (1.0 - math.sign(price) * Economy.TradeFeeSplit * 0.01)
     end
 
 	config.bought = function (self, commodity, tradeamount)

--- a/data/pigui/modules/flight-ui/system-overview.lua
+++ b/data/pigui/modules/flight-ui/system-overview.lua
@@ -47,24 +47,7 @@ gameView.registerSidebarModule("system-overview", {
 	end,
 
 	drawTitle = function()
-		local spacing = style.innerSpacing
-		local button_width = (ui.getLineHeight() + spacing.x) * 3 - spacing.x
-
-		local pos = ui.getCursorPos() + Vector2(ui.getContentRegion().x - button_width, 0)
-		systemOverview.buttonSize = Vector2(ui.getLineHeight() - style.buttonPadding * 2)
-
-		if Game.system then
-			ui.text(Game.system.name)
-
-			ui.setCursorPos(pos)
-			ui.withStyleVars({ ItemSpacing = spacing }, function()
-				ui.withFont(ui.fonts.pionillium.medium, function()
-					systemOverview:drawControlButtons()
-				end)
-			end)
-		else
-			ui.text(lc.HYPERSPACE)
-		end
+		systemOverview:displaySidebarTitle(Game.system)
 	end,
 
 	drawBody = function()

--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -48,6 +48,9 @@ local major_export = -10
 local minor_import = 4
 local major_import = 10
 
+-- price percentage difference necessary to make a trade viable
+local viable_trade = 4 + Economy.TotalTradeFees
+
 function SystemEconView.ClassifyPrice(pricemod)
 	if not pricemod then
 		return priceModTab.illegal
@@ -110,13 +113,13 @@ function SystemEconView.buildStationCommodityList(system, station, otherStation)
 	for name, item in pairs(Commodities) do
 		local legal = system:IsCommodityLegal(name)
 		local systemPrice = system:GetCommodityBasePriceAlterations(name)
-		local price = station:GetCommodityPrice(item) - systemPrice
-		local otherPrice = otherStation and otherStation:GetCommodityPrice(item) - systemPrice
+		local price = station:GetCommodityPrice(item)
+		local otherPrice = otherStation and otherStation:GetCommodityPrice(item)
 
 		local tab = {
 			item.l10n_key,
-			legal and SystemEconView.GetPricemod(item, price),
-			legal and otherPrice and SystemEconView.GetPricemod(item, otherPrice)
+			legal and SystemEconView.GetPricemod(item, price) - systemPrice,
+			legal and otherPrice and SystemEconView.GetPricemod(item, otherPrice) - systemPrice
 		}
 
 		table.insert(legal and commodityList or illegalList, tab)
@@ -130,7 +133,7 @@ end
 local function getProfitabilityInfo(priceA, priceB)
 	local priceDiff = (priceA and priceB) and priceA - priceB
 
-	if priceDiff and math.abs(priceDiff) > major_import then
+	if priceDiff and math.abs(priceDiff) > viable_trade then
 		return priceDiff > 0 and profitTab.profit or profitTab.loss
 	end
 end

--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -305,7 +305,7 @@ function SystemEconView:drawStationComparison(selected, current)
 		if not station or (showComparison and not otherStation) then
 			ui.icon(icons.alert_generic, Vector2(ui.getTextLineHeight()), ui.theme.colors.font)
 			ui.sameLine()
-			ui.text(lc.NO_AVAILABLE_DATA)
+			ui.text(lui.NO_AVAILABLE_DATA)
 		else
 			local commList, illegalList = SystemEconView.buildStationCommodityList(system, station, otherStation)
 			self:drawCommodityList(commList, illegalList, selected, current)
@@ -355,6 +355,7 @@ function SystemEconView:drawSystemFinder()
 	local key = commodityOptions[selectedIndex]
 	local comm = Commodities[key]
 	local commName = lcomm[comm.l10n_key]
+	local station = Game.player:GetDockedWith() ---@type SpaceStation
 
 	ui.withFont(pionillium.body, function()
 
@@ -364,6 +365,14 @@ function SystemEconView:drawSystemFinder()
 			if ui.button("[This System]") then self.compareMode = CompareMode.BySystem end
 		end
 
+		if station then
+			ui.sameLine()
+
+			if ui.button("Load Market Data") then
+				self:loadMarketData(Economy.GetStationMarket(station.path).commodities)
+			end
+		end
+
 		ui.nextItemWidth(-1)
 		local changed, index = ui.combo("##commodityCombo", selectedIndex - 1, commodityOptions)
 		ui.spacing()
@@ -371,11 +380,7 @@ function SystemEconView:drawSystemFinder()
 
 
 		if not self.savedMarket then
-			local station = Game.player:GetDockedWith() ---@type SpaceStation
 
-			if station and ui.button("Load Market Data") then
-				self:loadMarketData(Economy.GetStationMarket(station.path).commodities)
-			end
 		else
 			ui.text(lui.COMMODITY_TRADE_ANALYSIS)
 			ui.spacing()

--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -1,47 +1,44 @@
 -- Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-
-local commodities = require 'Economy'.GetCommodities()
-local ui = require 'pigui'
+local Game    = require 'Game'
+local Economy = require 'Economy'
+local ui      = require 'pigui'
+local utils   = require 'utils'
 
 local lc = require 'Lang'.GetResource('core')
 local lui = require 'Lang'.GetResource('ui-core')
 local lcomm = require 'Lang'.GetResource('commodity')
 
+local Commodities = Economy.GetCommodities()
+
 local icons = ui.theme.icons
 local colors = ui.theme.colors
 local pionillium = ui.fonts.pionillium
 
-local systemEconView = {}
+---@class UI.SystemEconView
+---@field New fun(): self
+local SystemEconView = utils.class('UI.SystemEconView')
 
-function systemEconView.buildCommodityList(sys, otherSys)
-	local commodityList = {}
-	local illegalList = {}
+local CompareMode = {
+	BySystem = 1,
+	ByStation = 2
+}
 
-	for name, info in pairs(commodities) do
-		local legal = sys:IsCommodityLegal(name)
-		local otherLegal = otherSys and otherSys:IsCommodityLegal(name)
+local priceModTab = {
+	major_import = { icons.econ_major_import, colors.econMajorImport, lui.MAJOR_IMPORT },
+	minor_import = { icons.econ_minor_import, colors.econMinorImport, lui.MINOR_IMPORT },
+	major_export = { icons.econ_major_export, colors.econMajorExport, lui.MAJOR_EXPORT },
+	minor_export = { icons.econ_minor_export, colors.econMinorExport, lui.MINOR_EXPORT },
 
-		if legal and (not otherSys or otherLegal) then
-			table.insert(commodityList, {
-				info.l10n_key,
-				legal and sys:GetCommodityBasePriceAlterations(name),
-				otherSys and otherLegal and otherSys:GetCommodityBasePriceAlterations(name)
-			})
-		else
-			table.insert(illegalList, {
-				info.l10n_key,
-				legal and sys:GetCommodityBasePriceAlterations(name),
-				otherSys and otherLegal and otherSys:GetCommodityBasePriceAlterations(name)
-			})
-		end
-	end
+	illegal = { icons.alert_generic, colors.econIllegalCommodity, lui.ILLEGAL_IN_SYSTEM },
+	minimal_trade = { nil, colors.font, lui.MINIMAL_TRADE },
+}
 
-	table.sort(commodityList, function(a, b) return a[1] < b[1] end)
-	table.sort(illegalList, function(a, b) return a[1] < b[1] end)
-	return commodityList, illegalList
-end
+local profitTab = {
+	profit = { icons.econ_profit, colors.econProfit, lui.PROFITABLE_TRADE },
+	loss = { icons.econ_loss, colors.econLoss, lui.UNPROFITABLE_TRADE },
+}
 
 -- break-over price percentage for a commodity to be considered a minor/major export
 local minor_export = -4
@@ -51,99 +48,124 @@ local major_export = -10
 local minor_import = 4
 local major_import = 10
 
-local function getExportInfo(price)
-	local icon, color, tooltip
+function SystemEconView.ClassifyPrice(pricemod)
+	if not pricemod then
+		return priceModTab.illegal
+	elseif pricemod >= major_import then
+		return priceModTab.major_import
+	elseif pricemod >= minor_import then
+		return priceModTab.minor_import
+	elseif pricemod <= major_export then
+		return priceModTab.major_export
+	elseif pricemod <= minor_export then
+		return priceModTab.minor_export
+	end
+end
 
-	if not price then
-		icon = icons.alert_generic
-		color = colors.econIllegalCommodity
-		tooltip = lui.ILLEGAL_IN_SYSTEM
-	elseif price >= minor_import then
-		icon = price > major_import and icons.econ_major_import or icons.econ_minor_import
-		color = price > major_import and colors.econMajorImport or colors.econMinorImport
-		tooltip = price > major_import and lui.MAJOR_IMPORT or lui.MINOR_IMPORT
-	elseif price <= minor_export then
-		icon = price < major_export and icons.econ_major_export or icons.econ_minor_export
-		color = price < major_export and colors.econMajorExport or colors.econMinorExport
-		tooltip = price < major_export and lui.MAJOR_EXPORT or lui.MINOR_EXPORT
-	else
-		color = colors.font
-		tooltip = lui.MINIMAL_TRADE
+function SystemEconView:Constructor()
+	self.compareMode = CompareMode.BySystem
+	self.selectedCommodity = nil
+	self.savedMarket = nil
+end
+
+---@param sys StarSystem
+---@param otherSys StarSystem?
+function SystemEconView.buildCommodityList(sys, otherSys)
+	local commodityList = {}
+	local illegalList = {}
+
+	for name, info in pairs(Commodities) do
+		local legal = sys:IsCommodityLegal(name)
+		local otherLegal = otherSys and otherSys:IsCommodityLegal(name)
+
+		local tab = {
+			info.l10n_key,
+			legal and sys:GetCommodityBasePriceAlterations(name),
+			otherSys and otherLegal and otherSys:GetCommodityBasePriceAlterations(name)
+		}
+
+		if legal and (not otherSys or otherLegal) then
+			table.insert(commodityList, tab)
+		else
+			table.insert(illegalList, tab)
+		end
 	end
 
-	return icon, color, tooltip
+	table.sort(commodityList, function(a, b) return a[1] < b[1] end)
+	table.sort(illegalList, function(a, b) return a[1] < b[1] end)
+	return commodityList, illegalList
 end
 
 local function getProfitabilityInfo(priceA, priceB)
-	local icon, color, tooltip
-	local priceDiff = (priceA and priceB) and priceB - priceA
+	local priceDiff = (priceA and priceB) and priceA - priceB
 
 	if priceDiff and math.abs(priceDiff) > major_import then
-		icon = priceDiff > 0.0 and icons.econ_profit or icons.econ_loss
-		color = priceDiff > 0.0 and colors.econProfit or colors.econLoss
-		tooltip = priceDiff > 0.0 and lui.PROFITABLE_TRADE or lui.UNPROFITABLE_TRADE
+		return priceDiff > 0 and profitTab.profit or profitTab.loss
 	end
-
-	return icon, color, tooltip
 end
 
-local function drawPriceIcon(price, size)
-	local icon, color = getExportInfo(price)
-	if icon then ui.icon(icon, size, color) else ui.dummy(size) end
+local function drawIcon(cls, size)
+	if cls then
+		ui.icon(cls[1], size, cls[2])
+	else
+		ui.dummy(size)
+	end
+end
+
+local function drawExportTooltip(price)
+	local cls = SystemEconView.ClassifyPrice(price) or priceModTab.minimal_trade
+	ui.sameLine()
+	ui.textColored(cls[2], cls[3])
 end
 
 local function drawCommodityTooltip(info, thisSystem, otherSystem)
 	ui.customTooltip(function()
-		ui.withFont(pionillium.medlarge, function() ui.text(lcomm[info[1]]) end)
-		local color, tooltip = select(2, getProfitabilityInfo(info[2], info[3]))
-		if otherSystem and tooltip then
-			ui.textColored(color, tooltip)
+		ui.withFont(pionillium.heading, function() ui.text(lcomm[info[1]]) end)
+
+		local profit = getProfitabilityInfo(info[2], info[3])
+		if otherSystem and profit then
+			ui.textColored(profit[2], profit[3])
 		end
 
 		ui.spacing()
 
-		ui.text(lui.TRADING_FROM:interp({system = thisSystem.name}))
-		color, tooltip = select(2, getExportInfo(info[2]))
-		if tooltip then
-			ui.sameLine()
-			ui.textColored(color, tooltip)
-		end
-
 		if otherSystem then
-			ui.text(lui.TRADING_TO:interp({system = otherSystem.name}))
-			color, tooltip = select(2, getExportInfo(info[3]))
-			if tooltip then
-				ui.sameLine()
-				ui.textColored(color, tooltip)
-			end
+			ui.text(lui.TRADING_FROM:interp({system = otherSystem.name}))
+			drawExportTooltip(info[3])
+
+			ui.text(lui.TRADING_TO:interp({system = thisSystem.name}))
+			drawExportTooltip(info[2])
+		else
+			ui.text(lui.TRADING_AT:interp({system = thisSystem.name}))
+			drawExportTooltip(info[2])
 		end
 	end)
 end
 
-function systemEconView.drawEconList(commList, illegalList, thisSystem, otherSystem)
+---@param thisSystem StarSystem
+---@param otherSystem StarSystem?
+function SystemEconView:drawCommodityList(commList, illegalList, thisSystem, otherSystem)
 	local width = ui.getColumnWidth()
 	local iconWidth = ui.getTextLineHeight() + 4
 	local iconSize = Vector2(iconWidth, iconWidth)
 
-	local currSysPos = width - (otherSystem and iconWidth * 2 or iconWidth)
 	ui.child("CommodityList", Vector2(0, 0), ui.WindowFlags{"NoScrollbar"}, function()
 		for _, info in ipairs(commList) do
 			ui.group(function()
 				ui.text(lcomm[info[1]])
 				ui.sameLine(width - iconWidth * 3)
 
-				local icon, color = getProfitabilityInfo(info[2], info[3])
-				if otherSystem and icon then ui.icon(icon, iconSize, color) else ui.dummy(iconSize) end
+				drawIcon(otherSystem and getProfitabilityInfo(info[2], info[3]), iconSize)
 
 				if otherSystem then
 					ui.sameLine(0, 0)
-					drawPriceIcon(info[2], iconSize)
+					drawIcon(SystemEconView.ClassifyPrice(info[3]), iconSize)
 					ui.sameLine(0, 0)
-					drawPriceIcon(info[3], iconSize)
 				else
 					ui.sameLine(0, iconWidth)
-					drawPriceIcon(info[2], iconSize)
 				end
+
+				drawIcon(SystemEconView.ClassifyPrice(info[2]), iconSize)
 			end)
 
 			if ui.isItemHovered() then
@@ -168,9 +190,9 @@ function systemEconView.drawEconList(commList, illegalList, thisSystem, otherSys
 
 				-- only display illegal icon if the commodity is actually legal in the other system
 				if otherSystem and (info[2] or info[3]) then
-					drawPriceIcon(info[2], iconSize)
+					drawIcon(SystemEconView.ClassifyPrice(info[2]), iconSize)
 					ui.sameLine(0, 0)
-					drawPriceIcon(info[3], iconSize)
+					drawIcon(SystemEconView.ClassifyPrice(info[3]), iconSize)
 				end
 			end)
 
@@ -181,9 +203,167 @@ function systemEconView.drawEconList(commList, illegalList, thisSystem, otherSys
 	end)
 end
 
-function systemEconView.draw(current, other)
-	local commList, illegalList = systemEconView.buildCommodityList(current, other)
-	systemEconView.drawEconList(commList, illegalList, current, other)
+---@param selected StarSystem
+---@param current StarSystem
+function SystemEconView:drawSystemComparison(selected, current)
+	local showComparison = current ~= selected and selected.population > 0
+		and (Game.player["trade_computer_cap"] or 0) > 0
+
+	local otherSys = showComparison and current or nil
+
+	ui.withFont(pionillium.body, function()
+		ui.text(lui.COMMODITY_TRADE_ANALYSIS)
+		ui.spacing()
+
+		ui.withFont(pionillium.heading, function()
+			if showComparison then
+				ui.text(current.name)
+				ui.sameLine(ui.getContentRegion().x - ui.calcTextSize(selected.name).x)
+			end
+
+			ui.text(selected.name)
+		end)
+
+		ui.spacing()
+		ui.separator()
+		ui.spacing()
+
+		if selected.population <= 0 then
+			ui.icon(icons.alert_generic, Vector2(ui.getTextLineHeight()), ui.theme.colors.font)
+			ui.sameLine()
+			ui.text(lc.NO_REGISTERED_INHABITANTS)
+		else
+			local commList, illegalList = SystemEconView.buildCommodityList(selected, otherSys)
+			self:drawCommodityList(commList, illegalList, selected, otherSys)
+		end
+	end)
 end
 
-return systemEconView
+local commodityOptions = {}
+for k, v in pairs(Commodities) do
+	table.insert(commodityOptions, k)
+end
+table.sort(commodityOptions)
+
+function SystemEconView:drawPriceList(key, prices)
+	local iconSize = Vector2(ui.getTextLineHeight() + 4)
+	local out = nil
+
+	ui.beginTable("prices", 3)
+	ui.tableSetupColumn("Name", { "WidthStretch" })
+	ui.tableSetupColumn("Indicators")
+	ui.tableSetupColumn("Amount")
+
+	for i, info in ipairs(prices) do
+		ui.tableNextRow()
+
+		ui.tableSetColumnIndex(0)
+		ui.alignTextToLineHeight(iconSize.y)
+		if ui.selectable(info[1], false, { "SpanAllColumns" }) then out = i end
+
+		ui.tableSetColumnIndex(1)
+
+		local price = ui.Format.Money(info[2])
+		local profit = (info[2] - self.savedMarket[key] > 0) and profitTab.profit or profitTab.loss
+		drawIcon(profit, iconSize)
+
+		ui.tableSetColumnIndex(2)
+		ui.textColored(ui.theme.styleColors.gray_200, price)
+	end
+
+	ui.endTable()
+
+	return out
+end
+
+function SystemEconView:drawSystemFinder()
+	local selectedIndex = self.selectedCommodity or 1
+	local key = commodityOptions[selectedIndex]
+	local comm = Commodities[key]
+	local commName = lcomm[comm.l10n_key]
+
+	ui.withFont(pionillium.body, function()
+
+		if self.compareMode == CompareMode.BySystem then
+			if ui.button("[Nearby Systems]") then self.compareMode = CompareMode.ByStation end
+		elseif self.compareMode == CompareMode.ByStation then
+			if ui.button("[This System]") then self.compareMode = CompareMode.BySystem end
+		end
+
+		ui.nextItemWidth(-1)
+		local changed, index = ui.combo("##commodityCombo", selectedIndex - 1, commodityOptions)
+		ui.spacing()
+		if changed then self.selectedCommodity = index + 1 end
+
+
+		if not self.savedMarket then
+			local station = Game.player:GetDockedWith() ---@type SpaceStation
+
+			if station and ui.button("Load Market Data") then
+				self:loadMarketData(Economy.GetStationMarket(station.path).commodities)
+			end
+		else
+			ui.text(lui.COMMODITY_TRADE_ANALYSIS)
+			ui.spacing()
+
+			ui.withFont(pionillium.heading, function()
+				local price = ui.Format.Money(self.savedMarket[key])
+				ui.textColored(ui.theme.styleColors.gray_200, commName)
+				ui.sameLine(ui.getContentRegion().x - ui.calcTextSize(price).x)
+				ui.text(price)
+			end)
+
+			ui.spacing()
+			ui.separator()
+			ui.spacing()
+
+			if self.compareMode == CompareMode.BySystem then
+
+				local nearbySystems = Game.system:GetNearbySystems(20, function(s) return s.numberOfStations > 0 end)
+
+				local entries = utils.map_array(nearbySystems, function(system)
+					local price = Economy.GetMarketPrice(comm.price, system:GetCommodityBasePriceAlterations(key))
+					return { system.name, price, system.path }
+				end)
+
+				table.sort(entries, function(a, b) return a[2] > b[2] end)
+
+				local idx = self:drawPriceList(key, entries)
+				if idx then
+					Game.sectorView:GotoSystemPath(entries[idx][3])
+				end
+
+			elseif self.compareMode == CompareMode.ByStation then
+
+				local stations = utils.map_array(Game.system:GetStationPaths(), function(path)
+					local sBody = path:GetSystemBody()
+					local station = sBody.physicsBody --[[@as SpaceStation]]
+					local price = station:GetCommodityPrice(Commodities[key])
+
+					return { sBody.name, price, path }
+				end)
+
+				table.sort(stations, function(a, b) return a[2] > b[2] end)
+
+				local idx = self:drawPriceList(key, stations)
+				if idx then
+					Game.player:SetNavTarget(stations[idx][3])
+				end
+
+			end
+
+		end
+
+	end)
+end
+
+function SystemEconView:loadMarketData(market)
+	self.savedMarket = {}
+
+	for key, data in pairs(market) do
+		local comm = Commodities[key]
+		self.savedMarket[key] = Economy.GetMarketPrice(comm.price, data[3])
+	end
+end
+
+return SystemEconView

--- a/data/pigui/modules/system-overview-window.lua
+++ b/data/pigui/modules/system-overview-window.lua
@@ -6,8 +6,11 @@ local Format = require 'Format'
 local Lang = require 'Lang'
 local utils = require "libs.utils"
 
-local ui = require 'pigui'
+local lc = Lang.GetResource("core");
 local lui = Lang.GetResource("ui-core");
+
+local ui = require 'pigui'
+
 local getBodyIcon = require 'pigui.modules.flight-ui.body-icons'
 
 local colors = ui.theme.colors
@@ -235,6 +238,28 @@ function SystemOverviewWidget:display(system, root, selected)
 			ui.text(lui.NO_FILTER_MATCHES)
 		end
 	end)
+end
+
+function SystemOverviewWidget:displaySidebarTitle(system)
+	local spacing = styles.ItemInnerSpacing
+	local numButtons = self.shouldDisplayPlayerDistance and 3 or 2
+	local button_width = (ui.getLineHeight() + spacing.x) * numButtons - spacing.x
+
+	local pos = ui.getCursorPos() + Vector2(ui.getContentRegion().x - button_width, 0)
+	self.buttonSize = Vector2(ui.getLineHeight() - styles.MainButtonPadding * 2)
+
+	if system then
+		ui.text(system.name)
+
+		ui.setCursorPos(pos)
+		ui.withStyleVars({ ItemSpacing = spacing }, function()
+			ui.withFont(ui.fonts.pionillium.medium, function()
+				self:drawControlButtons()
+			end)
+		end)
+	else
+		ui.text(lc.HYPERSPACE)
+	end
 end
 
 return SystemOverviewWidget

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -201,7 +201,7 @@ table.insert(leftSidebar.modules, {
 		if Windows.unexplored.visible then
 			ui.text(luc.UNEXPLORED_SYSTEM_NO_SYSTEM_VIEW)
 		else
-			systemOverviewWidget:displaySidebarTitle(Game.system)
+			systemOverviewWidget:displaySidebarTitle(systemView:GetSystem())
 		end
 	end,
 

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -46,7 +46,7 @@ local startLocations = {
 		['location']   = SystemPath.New(0,0,0,0,18),
 		['logmsg']     = lui.START_LOG_ENTRY_1,
 		['shipType']   = 'coronatrix',
-		['money']      = 100,
+		['money']      = 600,
 		['hyperdrive'] = true,
 		['equipment']  = {
 			{ laser.pulsecannon_1mw,      1 },
@@ -64,7 +64,7 @@ local startLocations = {
 		['location']   = SystemPath.New(1,-1,-1,0,4),
 		['logmsg']     = lui.START_LOG_ENTRY_2,
 		['shipType']   = 'pumpkinseed',
-		['money']      = 100,
+		['money']      = 400,
 		['hyperdrive'] = true,
 		['equipment']  = {
 			{ laser.pulsecannon_1mw,      1 },

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1433,6 +1433,11 @@ void PopulateStarSystemGenerator::PopulateStage1(SystemBody *sbody, StarSystem::
 		// arbitrary percentage price reduction.
 		fixed howmuch = affinity * 256;
 
+		// TODO(sturnclaw): quick and dirty patch to provide a bit more variance in galactic
+		// economy demand. This reduces the 'global' dependence on certain input commodities
+		// and allows a system to conceptually produce more of the commodity than it consumes
+		howmuch = howmuch * rand.Fixed() * 3;
+
 		if (howmuch.ToInt32() == 0)
 			continue;
 

--- a/src/galaxy/SystemBody.h
+++ b/src/galaxy/SystemBody.h
@@ -184,8 +184,9 @@ public:
 	double GetLife() const { return m_life.ToDouble(); }
 
 	fixed GetAgriculturalAsFixed() const { return m_agricultural; }
-	double GetPopulation() const { return m_population.ToDouble(); }
+	double GetAgricultural() const { return m_agricultural.ToDouble(); }
 	fixed GetPopulationAsFixed() const { return m_population; }
+	double GetPopulation() const { return m_population.ToDouble(); }
 
 	double CalcSurfaceGravity() const;
 

--- a/src/lua/LuaEconomy.cpp
+++ b/src/lua/LuaEconomy.cpp
@@ -56,6 +56,20 @@ static void pi_lua_generic_push(lua_State *l, GalacticEconomy::EconomyInfo info)
 	pi_lua_settable(l, "large", info.l10n_key.large);
 	pi_lua_settable(l, "huge", info.l10n_key.huge);
 	lua_setfield(l, -2, "l10n_key");
+
+	lua_newtable(l);
+	pi_lua_settable(l, "agricultural", info.affinity.agricultural.ToDouble());
+	pi_lua_settable(l, "industrial",   info.affinity.industrial.ToDouble());
+	pi_lua_settable(l, "metallicity",  info.affinity.metallicity.ToDouble());
+	lua_setfield(l, -2, "affinity");
+
+	lua_newtable(l);
+	pi_lua_settable(l, "agricultural", info.generation.agricultural.ToDouble());
+	pi_lua_settable(l, "industrial", info.generation.industrial.ToDouble());
+	pi_lua_settable(l, "metallicity", info.generation.metallicity.ToDouble());
+	pi_lua_settable(l, "population", info.generation.population.ToDouble());
+	pi_lua_settable(l, "random", info.generation.random.ToDouble());
+	lua_setfield(l, -2, "generation");
 }
 
 static int l_economy_get_economies(lua_State *l)

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -155,7 +155,8 @@ int PiGui::pushOnScreenPositionDirection(lua_State *l, vector3d position)
 static LuaFlags<ImGuiSelectableFlags_> imguiSelectableFlagsTable = {
 	{ "DontClosePopups", ImGuiSelectableFlags_DontClosePopups },
 	{ "SpanAllColumns", ImGuiSelectableFlags_SpanAllColumns },
-	{ "AllowDoubleClick", ImGuiSelectableFlags_AllowDoubleClick }
+	{ "AllowDoubleClick", ImGuiSelectableFlags_AllowDoubleClick },
+	{ "AllowItemOverlap", ImGuiSelectableFlags_AllowItemOverlap }
 };
 
 void pi_lua_generic_pull(lua_State *l, int index, ImColor &color)

--- a/src/lua/LuaStarSystem.cpp
+++ b/src/lua/LuaStarSystem.cpp
@@ -255,6 +255,7 @@ static int l_starsystem_get_nearby_systems(lua_State *l)
 
 	const int diff_sec = int(ceil(dist_ly / Sector::SIZE));
 
+	uint32_t numSystems = 0;
 	for (int x = here_x - diff_sec; x <= here_x + diff_sec; x++) {
 		for (int y = here_y - diff_sec; y <= here_y + diff_sec; y++) {
 			for (int z = here_z - diff_sec; z <= here_z + diff_sec; z++) {
@@ -279,7 +280,7 @@ static int l_starsystem_get_nearby_systems(lua_State *l)
 						lua_pop(l, 1);
 					}
 
-					lua_pushinteger(l, lua_rawlen(l, -1) + 1);
+					lua_pushinteger(l, ++numSystems);
 					LuaObject<StarSystem>::PushToLua(sys.Get());
 					lua_rawset(l, -3);
 				}

--- a/src/lua/LuaSystemBody.cpp
+++ b/src/lua/LuaSystemBody.cpp
@@ -161,6 +161,26 @@ static int l_sbody_attr_parent(lua_State *l)
 }
 
 /*
+ * Attribute: system
+ *
+ * The StarSystem which contains this SystemBody
+ *
+ * Availability:
+ *
+ *   alpha 16
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_sbody_attr_system(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	LuaPush(l, sbody->GetStarSystem());
+	return 1;
+}
+
+/*
  * Attribute: population
  *
  * The population of the body, in billions of people.
@@ -548,6 +568,27 @@ static int l_sbody_attr_life(lua_State *l)
 }
 
 /*
+ * Attribute: agricultural
+ *
+ * Returns the measure of agricultural activity present on the body
+ * 0.0 = dead, 1.0 = teeming (~= breadbasket)
+ *
+ * Availability:
+ *
+ *   January 2023
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_sbody_attr_agricultural(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetAgriculturalAsFixed().ToDouble());
+	return 1;
+}
+
+/*
  * Attribute: hasRings
  *
  * Returns true if the body has a ring or rings of debris or ice in orbit around it
@@ -711,6 +752,7 @@ void LuaObject<SystemBody>::RegisterClass()
 		{ "superType", l_sbody_attr_super_type },
 		{ "seed", l_sbody_attr_seed },
 		{ "parent", l_sbody_attr_parent },
+		{ "system", l_sbody_attr_system },
 		{ "population", l_sbody_attr_population },
 		{ "radius", l_sbody_attr_radius },
 		{ "mass", l_sbody_attr_mass },
@@ -731,6 +773,7 @@ void LuaObject<SystemBody>::RegisterClass()
 		{ "volcanicity", l_sbody_attr_volcanicity },
 		{ "life", l_sbody_attr_life },
 		{ "hasRings", l_sbody_attr_has_rings },
+		{ "agricultural", l_sbody_attr_agricultural },
 		{ "hasAtmosphere", l_sbody_attr_has_atmosphere },
 		{ "isScoopable", l_sbody_attr_is_scoopable },
 		{ "astroDescription", l_sbody_attr_astro_description },


### PR DESCRIPTION
...Feature freeze can't catch me if I type fast enough!

In all seriousness, this is a down-to-the-wire PR delayed by a round of sickness and a PC rebuild, but one that may prove to be one of the bigger features of the patch. This PR completely rebalances the economic system of Pioneer, providing a (perhaps too generous) 40-50% profit margin for savvy pilots who can sniff out the perfect pair of systems and stations to trade between - but punishes traders who get too complacent with seriously diminishing returns for running the same route too often.

The headlining feature of this PR is of course the "dynamic" economy for stations - we now have a proper supply-and-demand economic system where each station has its own set of commodities produced and consumed (and associated quantities for each), though the system is not quite as well-rounded as I'd like due to the paucity of good input data - I've shoehorned this all in to the existing three major economic archetypes, when I'd really like to split our commodities between 6-8 economic subtypes with more sane production and consumption rates... something for another PR.

Of note: the economic simulation is not "dynamic" in that prices change over time naturally. The existing behavior of station stocking is preserved in that stations will restock / increase demand back to an "equilibrium" value but once reaching that will remain in steady-state until the player takes an action. This is also a subject for another PR.

A secondary feature is an improved trade calculator tool (still WIP as of this writing) that provides extremely "cheaty" information on exactly which system/station has the best trade prices for a commodity (available for developers via alt-click) as well as providing more reasonable information about a station's economic flow for all commodities, similar to the existing system trade tool.

https://user-images.githubusercontent.com/4218491/212623201-1d02e669-af98-48d2-902d-ca1de5aa7eb2.mp4

The commodity market (the video shows an outdated version) now displays the station's local import/export disposition of a commodity, and if the player has a trade computer mounted additionally displays the interstellar import/export nature of a commodity.

I've also included a slightly-opinionated change to increase the easy/medium start's amount of available credits - as in-system missions don't pay much more than fuel cost and immediately running to an interstellar mission to make money isn't the greatest new-player introduction. On a meta level, this also balances removing the Sinonatrix from the easy start with a bit of extra cash instead :smile:

## TESTING REQUIRED

This branch was written hurriedly and not thoroughly tested, so I'd really appreciate everyone reading this PR description downloading a build from the Checks section and testing the economic behavior specifically - you can cheat in money with the Ctrl+I menu (as well as give yourself a better ship for bulk trading) and get setup for trading that way.

I've prepared a short list of scenarios that should be tested (independently) while I'm working on finishing the UI elements:
- In-system trading (in a single system) for at least 2 weeks game-time
- Interstellar trading for at least 24 weeks game-time
- Triggering at least one NewsEventCommodity event
- Triggering at least one SoldOut event