### PR TITLE
Font Consistency and Other Bit-Twiddling

### DIFF
--- a/data/pigui/libs/buttons.lua
+++ b/data/pigui/libs/buttons.lua
@@ -149,13 +149,11 @@ function ui.iconButton(icon, size, tooltip, variant, fg_color, frame_padding, ic
 
 	ui.withID(tooltip, function()
 		ui.withButtonColors(variant, function()
-			pigui.PushID(tooltip)
 			if icon_size then
 				res = pigui.ButtonImageSized(ui.get_icons_texture(size), size, icon_size, uv0, uv1, frame_padding, ui.theme.colors.transparent, fg_color)
 			else
 				res = pigui.ImageButton(ui.get_icons_texture(size), size, uv0, uv1, frame_padding, ui.theme.colors.transparent, fg_color)
 			end
-			pigui.PopID()
 		end)
 	end)
 

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -20,7 +20,7 @@ local Color = _G.Color
 
 local baseWidgetSizes = {
 	rescaleVector = Vector2(1, 1),
-	buySellSize = Vector2(128, 48),
+	buySellSize = Vector2(160, 36),
 	fontSizeLarge = 22.5, -- pionillium.large.size,
 	fontSizeXLarge = 27, -- pionillium.xlarge.size,
 	iconSize = Vector2(0, 22.5 * 1.5),
@@ -314,17 +314,26 @@ end
 function CommodityMarketWidget:TradeMenu()
 	if(self.selectedItem) then
 		ui.child(self.id .. "TradeMenu", vZero, function()
-			if ui.button(l.BUY, self.style.widgetSizes.buySellSize, colorVariant[self.tradeModeBuy]) then
-				self.tradeModeBuy = true
-				self:ChangeTradeAmount(-self.tradeAmount)
-			end
-			ui.sameLine()
-			if ui.button(l.SELL, self.style.widgetSizes.buySellSize, colorVariant[not self.tradeModeBuy]) then
-				self.tradeModeBuy = false
-				self:ChangeTradeAmount(-self.tradeAmount)
-			end
 
-			ui.text('')
+			ui.withFont(pionillium.heading, function()
+				-- center the buy/sell switch buttons
+				ui.addCursorPos(Vector2(ui.getContentRegion().x * 0.5 - self.style.widgetSizes.buySellSize.x - ui.getItemSpacing().x, 0))
+
+				if ui.button(l.BUY, self.style.widgetSizes.buySellSize, colorVariant[self.tradeModeBuy]) then
+					self.tradeModeBuy = true
+					self:ChangeTradeAmount(-self.tradeAmount)
+				end
+
+				ui.sameLine()
+
+				if ui.button(l.SELL, self.style.widgetSizes.buySellSize, colorVariant[not self.tradeModeBuy]) then
+					self.tradeModeBuy = false
+					self:ChangeTradeAmount(-self.tradeAmount)
+				end
+			end)
+
+			ui.newLine()
+
 			local bottomHalf = ui.getCursorPos()
 			bottomHalf.y = bottomHalf.y + ui.getContentRegion().y/1.65
 			if(self.icons[self.selectedItem.icon_name] == nil) then
@@ -336,17 +345,16 @@ function CommodityMarketWidget:TradeMenu()
 			self.icons[self.selectedItem.icon_name]:Draw(commodityIconSize)
 			ui.nextColumn()
 			ui.withStyleVars({ItemSpacing = self.style.itemSpacing/2}, function()
-				ui.withFont(orbiteer.xlarge.name, self.style.widgetSizes.fontSizeLarge, function()
+				ui.withFont(orbiteer.heading, function()
 					-- align the height to the center relative to the icon
-					local fontsize = self.style.widgetSizes.fontSizeLarge
-					ui.addCursorPos(Vector2(0, math.max(0, (commodityIconSize.y - fontsize) / 2)))
+					ui.alignTextToLineHeight(commodityIconSize.y)
 					ui.text(self.selectedItem:GetName())
 				end)
 			end)
 			ui.columns(1, "", false)
 			ui.newLine()
 
-			ui.withFont(pionillium.medlarge, function()
+			ui.withFont(pionillium.heading, function()
 				local pricemod = Game.system:GetCommodityBasePriceAlterations(self.selectedItem.name)
 				-- TODO: unify this with logic in system-econ-view.lua
 				local ptext, picon, pcolor
@@ -366,7 +374,9 @@ function CommodityMarketWidget:TradeMenu()
 					ui.text(ptext)
 					ui.spacing()
 				end
+			end)
 
+			ui.withFont(pionillium.body, function()
 				ui.textWrapped(self.selectedItem:GetDescription())
 			end)
 
@@ -387,13 +397,13 @@ function CommodityMarketWidget:TradeMenu()
 
 			ui.dummy(self.style.itemSpacing/2)
 			ui.withStyleColors({["Text"] = self.tradeTextColor }, function()
-				ui.withFont(pionillium.xlarge.name, self.style.widgetSizes.fontSizeLarge, function()
+				ui.withFont(pionillium.heading, function()
 					ui.text(self.tradeText)
 				end)
 			end)
 
 			ui.addCursorPos(Vector2(0, ui.getContentRegion().y - self.style.widgetSizes.confirmButtonSize.y))
-			ui.withFont(orbiteer.xlarge.name, self.style.widgetSizes.fontSizeXLarge, function()
+			ui.withFont(orbiteer.heading, function()
 				if ui.button(self.tradeModeBuy and l.CONFIRM_PURCHASE or l.CONFIRM_SALE, self.style.widgetSizes.confirmButtonSize) then
 					if self.tradeModeBuy then self:DoBuy()
 					else self:DoSell() end
@@ -438,14 +448,12 @@ end
 function CommodityMarketWidget:Render(size)
 	self:SetSize(size or ui.getContentRegion())
 
-	ui.withFont(pionillium.large, function()
-		ui.withStyleVars({ItemSpacing = self.style.itemSpacing}, function()
-			--ui.child(self.id .. "Container", self.style.widgetSize, containerFlags, function()
+	ui.withStyleVars({ItemSpacing = self.style.itemSpacing}, function()
+		ui.withFont(pionillium.heading, function()
 			MarketWidget.render(self)
-			ui.sameLine(0, self.style.widgetSizes.windowGutter)
-			self:TradeMenu()
-			--end)
 		end)
+		ui.sameLine(0, self.style.widgetSizes.windowGutter)
+		self:TradeMenu()
 	end)
 end
 

--- a/data/pigui/libs/face.lua
+++ b/data/pigui/libs/face.lua
@@ -63,8 +63,8 @@ function PiGuiFace.New (character, style, allowModification)
 			showCharInfo = style.showCharInfo == nil and true or style.showCharInfo,
 			charInfoPadding = style.charInfoPadding or ui.rescaleUI(Vector2(24,24), Vector2(1600, 900)),
 			charInfoBgColor = style.bgColor or Color(0,0,0,160),
-			nameFont = style.nameFont or orbiteer.xlarge,
-			titleFont = style.titleFont or orbiteer.large,
+			nameFont = style.nameFont or orbiteer.heading,
+			titleFont = style.titleFont or orbiteer.body,
 		}
 	}
 
@@ -105,46 +105,58 @@ function PiGuiFace:changeFeature(featureId, amt, callback)
 end
 
 local pigui = Engine.pigui
-local buttonSize = ui.rescaleUI(Vector2(30, 42))
-local iconSize = ui.rescaleUI(Vector2(42, 42))
+local buttonSize = ui.rescaleUI(Vector2(36, 36))
+local iconSize = ui.rescaleUI(Vector2(36, 36))
+
 local function faceGenButton(self, feature)
+
 	if ui.button('<##' .. feature.id, buttonSize) then
 		self:changeFeature(feature.id, -1, feature.callback)
 	end
 	ui.sameLine()
+
 	pigui.PushID(feature.id)
 	ui.icon(feature.icon, iconSize, colors.white)
 	pigui.PopID()
 	if pigui.IsItemHovered() then pigui.SetTooltip(feature.tooltip) end
+
 	ui.sameLine()
 	if ui.button('>##' .. feature.id, buttonSize) then
 		self:changeFeature(feature.id, 1, feature.callback)
 	end
+
 end
 
-local facegenSpacing = ui.rescaleUI(Vector2(24, 6))
+local facegenSpacing = ui.rescaleUI(Vector2(18, 6))
 local facegenSize = Vector2(buttonSize.x * 2 + iconSize.x + facegenSpacing.x * 2, 0)
 local buttonSpaceSize = Vector2(facegenSpacing.x * 2 + buttonSize.x * 2 + iconSize.x, iconSize.y)
-local inputTextPadding = ui.rescaleUI(Vector2(18, 18))
+local inputTextPadding = ui.rescaleUI(Vector2(12, 12))
+
 function PiGuiFace:render()
 	local char = self.character
+
 	if not self.allowModification then
 		self:renderFaceDisplay()
 		return
 	end
+
 	ui.child("CharacterInfoDetails" .. tostring(char), self.style.size or Vector2(0, 0), noSavedSettings, function()
-		ui.withFont(orbiteer.xlarge, function()
+		ui.withFont(self.style.nameFont, function()
 			ui.withStyleVars({FramePadding = inputTextPadding}, function()
+
 				ui.pushItemWidth(ui.getColumnWidth())
 				local text, entered = ui.inputText("", char.name, {})
+
 				if entered then
 					char.name = text
 				end
+
 			end)
 		end)
 
 		local lastPos = ui.getCursorPos()
 		local itemSpacing = self.style.itemSpacing
+
 		ui.child("Face", Vector2(ui.getColumnWidth() - (facegenSize.x + itemSpacing.x), 0), {}, function()
 			self:renderFaceDisplay()
 		end)
@@ -167,26 +179,35 @@ function PiGuiFace:render()
 	end)
 end
 
-function PiGuiFace:renderFaceDisplay ()
+function PiGuiFace:renderFaceDisplay()
+
 	local lastPos = ui.getCursorPos()
 	local region = self.style.size or ui.getContentRegion()
 	local size = math.min(region.x, region.y)
+
 	ui.image(self.faceGen.textureId, Vector2(size), Vector2(0.0, 0.0), self.faceGen.textureSize, colors.white)
 
 	if(self.style.showCharInfo) then
+
 		ui.setCursorPos(lastPos + Vector2(0.0, size - self.style.charInfoHeight))
-		ui.withStyleColorsAndVars({ChildBg = self.style.charInfoBgColor}, {WindowPadding = self.style.charInfoPadding, ItemSpacing = self.style.itemSpacing}, function ()
+		local styles = {WindowPadding = self.style.charInfoPadding, ItemSpacing = self.style.itemSpacing}
+
+		ui.withStyleColorsAndVars({ChildBg = self.style.charInfoBgColor}, styles, function ()
+
 			ui.child("PlayerInfoDetails", Vector2(size, self.style.charInfoHeight), charInfoFlags, function ()
 				ui.withFont(self.style.nameFont.name, self.style.nameFont.size, function()
 					ui.text(self.character.name)
 				end)
+
 				if self.character.title then
 					ui.withFont(self.style.titleFont.name, self.style.titleFont.size, function()
 						ui.text(self.character.title)
 					end)
 				end
 			end)
+
 		end)
+
 	end
 end
 

--- a/data/pigui/libs/ship-equipment.lua
+++ b/data/pigui/libs/ship-equipment.lua
@@ -175,7 +175,7 @@ return EquipMarket.New("EquipmentMarket", l.AVAILABLE_FOR_PURCHASE, {
 	onMouseOverItem = function(s, e)
 		local tooltip = e:GetDescription()
 		if string.len(tooltip) > 0 then
-			ui.withFont(pionillium.medium, function() ui.setTooltip(tooltip) end)
+			ui.withFont(pionillium.body, function() ui.setTooltip(tooltip) end)
 		end
 	end,
 	onClickItem = function(s,e)

--- a/data/pigui/libs/text-table.lua
+++ b/data/pigui/libs/text-table.lua
@@ -14,10 +14,8 @@ function textTable.draw(t)
 	for _, entry in ipairs(t) do
 		if type(entry) == "table" then
 			ui.text(entry[1])
-			-- ui.getColumnWidth() seems to ignore some amount of window padding. More investigation required.
 			local width, textWidth = ui.getContentRegion().x, ui.calcTextSize(entry[2]).x
-			-- FIXME: add support for ui.getStyleVar("ItemSpacing"). Hardcoding to 8 for now
-			ui.sameLine(math.max(width - textWidth, width / 2 + 8), 0)
+			ui.sameLine(math.max(width - textWidth, width / 2 + ui.getItemSpacing().x), 0)
 			ui.textWrapped(entry[2])
 		elseif type(entry) == "string" then
 			ui.spacing()

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -12,13 +12,13 @@ local Vector2 = _G.Vector2
 local lc = Lang.GetResource("core");
 
 -- get a fractional font factor
-local font_factor = ui.rescaleFraction(1, Vector2(1920, 1200))
+local font_factor = ui.rescaleFraction(1, Vector2(1920, 1080))
 
 local textBackgroundMarginPixels = 2
 
 -- apply a subtle bias to prevent fonts from becoming overly tiny at small resolutions
 local function fontScale(size)
-	return math.round(size * (font_factor * 0.8 + 0.2))
+	return math.round(size * (font_factor < 1 and font_factor * 0.8 + 0.2 or font_factor))
 end
 
 ui.fonts = {

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -50,6 +50,12 @@ ui.fonts = {
 		medium	= { name = "orbiteer", size = fontScale(20) },
 		small	= { name = "orbiteer", size = fontScale(14) },
 		tiny	= { name = "orbiteer", size = fontScale(10) },
+
+		-- alternate font breakpoints
+		title   = { name = "orbiteer", size = fontScale(30) },
+		heading = { name = "orbiteer", size = fontScale(24) },
+		body    = { name = "orbiteer", size = fontScale(20) },
+		details = { name = "orbiteer", size = fontScale(16) },
 	},
 }
 

--- a/data/pigui/modules/comms.lua
+++ b/data/pigui/modules/comms.lua
@@ -104,11 +104,13 @@ gameView.registerHudModule("comms", {
 		ui.setNextWindowSize(size, "Always")
 
 		ui.window("ShortCommsLog", windowFlags, function()
-			ui.pushTextWrapPos(0.0)
-			for _, v in iterCommsLog(Game.time - commsLogRetainTime) do
-				showItem(v)
-			end
-			ui.popTextWrapPos()
+			ui.withFont(ui.fonts.pionillium.details, function()
+				ui.pushTextWrapPos(0.0)
+				for _, v in iterCommsLog(Game.time - commsLogRetainTime) do
+					showItem(v)
+				end
+				ui.popTextWrapPos()
+			end)
 		end)
 	end
 })

--- a/data/pigui/modules/info-view/02-personal-info.lua
+++ b/data/pigui/modules/info-view/02-personal-info.lua
@@ -8,7 +8,7 @@ local Engine = require 'Engine'
 local Character = require 'Character'
 local PiGuiFace = require 'pigui.libs.face'
 local Event = require 'Event'
-local pigui = Engine.pigui
+local Game  = require 'Game'
 
 local pionillium = ui.fonts.pionillium
 local orbiteer = ui.fonts.orbiteer
@@ -20,21 +20,27 @@ local textTable = require 'pigui/libs/text-table'
 local l = Lang.GetResource("ui-core")
 
 local itemSpacing = ui.rescaleUI(Vector2(6, 12), Vector2(1920, 1200))
-local faceSize = Vector2(440,424) * (ui.screenWidth / 1200)
 
 local face = nil
 
 local function drawPlayerInfo()
     local player = Character.persistent.player
 
-	textTable.withHeading(l.COMBAT, orbiteer.xlarge, {
+	textTable.withHeading(l.COMBAT, orbiteer.heading, {
 		{ l.RATING, l[player:GetCombatRating()] },
 		{ l.KILLS,  string.format('%d',player.killcount) },
 	})
-	ui.text("")
 
-	textTable.withHeading(l.REPUTATION, orbiteer.xlarge, {
+	ui.newLine()
+
+	textTable.withHeading(l.REPUTATION, orbiteer.heading, {
 		{ l.STATUS..":", l[player:GetReputationRating()] },
+	})
+
+	ui.newLine()
+
+	textTable.withHeading(l.FINANCE, orbiteer.heading, {
+		{ l.CASH .. ":", ui.Format.Money(Game.player:GetMoney()) }
 	})
 end
 
@@ -46,18 +52,27 @@ InfoView:registerView({
 	draw = function()
 		local spacing = InfoView.windowPadding.x * 2.0
         local info_column_width = (ui.getColumnWidth() - spacing) / 2
+
         ui.withStyleVars({ItemSpacing = itemSpacing}, function()
-            ui.withFont(pionillium.large, function()
+            ui.withFont(pionillium.heading, function()
+
                 ui.child("PlayerInfoDetails", Vector2(info_column_width, 0), drawPlayerInfo)
+
                 ui.sameLine(0, spacing)
+
 				ui.child("PlayerView", Vector2(info_column_width, 0), function()
 					face = face or PiGuiFace.New(Character.persistent.player, nil, true)
 					face:render()
 				end)
+
             end)
         end)
     end,
     refresh = function() end,
+	debugReload = function()
+		package.reimport('pigui.libs.face')
+		package.reimport()
+	end
 })
 
 Event.Register("onGameEnd", function ()

--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -43,7 +43,7 @@ local function drawMissionDescription(missionDesc)
 	local contentRegion = ui.getContentRegion()
 	local leftColWidth = contentRegion.x / 1.618 - columnPadding.x / 2
 	ui.child("MissionDetailsColumn", Vector2(leftColWidth, 0), function()
-		ui.withFont(orbiteer.xlarge, function() ui.text(l.MISSION_DETAILS) end)
+		ui.withFont(orbiteer.heading, function() ui.text(l.MISSION_DETAILS) end)
 		ui.newLine()
 
 		if missionDesc.description then
@@ -92,7 +92,7 @@ local rowCache = nil
 local function makeMissionRows()
 	rowCache = {
 		separated = true,
-		{ l.TYPE, l.CLIENT, l.LOCATION, l.DUE, l.REWARD, l.STATUS, font = orbiteer.xlarge }
+		{ l.TYPE, l.CLIENT, l.LOCATION, l.DUE, l.REWARD, l.STATUS, font = orbiteer.heading }
 	}
 
 	for _, mission in pairs(Character.persistent.player.missions) do
@@ -134,7 +134,7 @@ InfoView:registerView({
     icon = ui.theme.icons.star,
     showView = true,
 	draw = function()
-		ui.withFont(pionillium.medlarge, function()
+		ui.withFont(pionillium.body, function()
 			if not rowCache then makeMissionRows() end
 			if activeMission then
 				drawMissionDescription(activeMission)

--- a/data/pigui/modules/info-view/05-crew.lua
+++ b/data/pigui/modules/info-view/05-crew.lua
@@ -145,6 +145,7 @@ local crewTasks = {
 local dismissButton = function(crewMember)
 	if Game.player:Dismiss(crewMember) then
 		crewMember:Save() -- Save to persistent characters list
+
 		if crewMember.contract then
 			if crewMember.contract.outstanding > 0 then
 				Comms.Message(l.IM_TIRED_OF_WORKING_FOR_NOTHING_DONT_YOU_KNOW_WHAT_A_CONTRACT_IS,crewMember.name)
@@ -173,7 +174,7 @@ end
 local function makeCrewList()
 	local t = {
 		separated = true, headerOnly = true,
-		{ l.NAME_PERSON, l.POSITION, l.WAGE, l.OWED, l.NEXT_PAID, "", font = orbiteer.xlarge }
+		{ l.NAME_PERSON, l.POSITION, l.WAGE, l.OWED, l.NEXT_PAID, "", font = orbiteer.heading }
 	}
 
 	local wageTotal = 0
@@ -216,7 +217,7 @@ local function drawCrewList(crewList)
 	textTable.drawTable(6, nil, crewList)
 
 	ui.newLine()
-	ui.withFont(orbiteer.xlarge, function() ui.text(l.GIVE_ORDERS_TO_CREW .. ":") end)
+	ui.withFont(orbiteer.heading, function() ui.text(l.GIVE_ORDERS_TO_CREW .. ":") end)
 	for label, task in pairs(crewTasks) do
 		if ui.button(l[label], Vector2(0, 0)) then lastTaskResult = task() end
 		ui.sameLine()
@@ -234,16 +235,17 @@ local function drawCrewInfo(crew)
 	local spacing = InfoView.windowPadding.x * 2.0
 	local info_column_width = (ui.getColumnWidth() - spacing) / 2
 	ui.child("PlayerInfoDetails", Vector2(info_column_width, 0), function()
-		ui.withFont(orbiteer.xlarge, function() ui.text(crew.name) end)
+		ui.withFont(orbiteer.heading, function() ui.text(crew.name) end)
+		ui.newLine()
 
-		textTable.withHeading(l.QUALIFICATION_SCORES, orbiteer.large, {
+		textTable.withHeading(l.QUALIFICATION_SCORES, orbiteer.body, {
 			{ l.ENGINEERING,	crew.engineering },
 			{ l.PILOTING,		crew.piloting },
 			{ l.NAVIGATION,		crew.navigation },
 			{ l.SENSORS,		crew.sensors },
 		})
 		ui.newLine()
-		textTable.withHeading(l.REPUTATION, orbiteer.large, {
+		textTable.withHeading(l.REPUTATION, orbiteer.body, {
 			{ l.RATING,			l[crew:GetCombatRating()] },
 			{ l.KILLS,			ui.Format.Number(crew.killcount) },
 			{ l.REPUTATION..":",l[crew:GetReputationRating()] },
@@ -251,7 +253,7 @@ local function drawCrewInfo(crew)
 
 		if not crew.player then
 			ui.newLine()
-			ui.withFont(orbiteer.xlarge, function() ui.text(l.EMPLOYMENT) end)
+			ui.withFont(orbiteer.body, function() ui.text(l.EMPLOYMENT) end)
 
 			if Game.player.flightState == 'DOCKED' then
 				if ui.button(l.DISMISS, Vector2(0, 0)) then dismissButton(crew) end
@@ -287,7 +289,7 @@ InfoView:registerView({
     showView = true,
 	draw = function()
 		ui.withStyleVars({ItemSpacing = itemSpacing}, function()
-			ui.withFont(pionillium.medlarge, function()
+			ui.withFont(pionillium.body, function()
 				if inspectingCrewMember then
 					drawCrewInfo(inspectingCrewMember)
 				else

--- a/data/pigui/modules/info-view/06-flightlog.lua
+++ b/data/pigui/modules/info-view/06-flightlog.lua
@@ -2,7 +2,7 @@
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local ui = require 'pigui'
-local InfoView = require 'pigui/views/info-view'
+local InfoView = require 'pigui.views.info-view'
 local Lang = require 'Lang'
 local FlightLog = require 'FlightLog'
 local Format = require 'Format'
@@ -211,7 +211,7 @@ local function drawFlightHistory()
 end
 
 local function drawLog ()
-	ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+	ui.withFont(pionillium.body, function()
 		drawFlightHistory()
 	end)
 end

--- a/data/pigui/modules/sidebar/cargo.lua
+++ b/data/pigui/modules/sidebar/cargo.lua
@@ -273,10 +273,14 @@ function module:drawBody()
 	ui.spacing()
 
 	ui.alignTextToButtonPadding()
-	ui.text(lui.TOTAL .. cargoMgr:GetUsedSpace() .. "t")
-	ui.sameLine()
+	ui.text("{} {}t {} / {}t {}" % {
+		lui.TOTAL,
+		cargoMgr:GetUsedSpace(), lui.USED,
+		cargoMgr:GetFreeSpace(), lui.FREE
+	})
 
 	if self.transferMode then
+		ui.sameLine()
 		local amount = self:countTransfer()
 
 		local buttonText = string.format("%s %st", self.transferMode.label, amount)

--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -180,7 +180,7 @@ local function lobbyMenu()
 	ui.nextColumn()
 
 	-- internal tank refill costs
-	ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+	ui.withFont(pionillium.body, function()
 		ui.text(Format.Money(station:GetCommodityPrice(Commodities.hydrogen)) .. "/t")
 		ui.text(Format.Money(station:GetCommodityPrice(Commodities.hydrogen) * shipDef.fuelTankMass/100 * Game.player.fuel))
 	end)
@@ -196,12 +196,13 @@ local function lobbyMenu()
 
 	-- internal tank fuel gauge
 	local gaugePos = ui.getCursorScreenPos()
+	local gaugeHeight = widgetSizes.buttonSizeBase.y
 	gaugePos.y = gaugePos.y + widgetSizes.buttonSizeBase.y/2
 	local gaugeWidth = ui.getContentRegion().x
 	ui.gauge(gaugePos, Game.player.fuel, '', string.format(l.FUEL .. ": %dt \t" .. l.DELTA_V .. ": %d km/s",
 		shipDef.fuelTankMass/100 * Game.player.fuel, Game.player:GetRemainingDeltaV()/1000),
 		0, 100, icons.fuel,
-		colors.gaugeEquipmentMarket, '', gaugeWidth, widgetSizes.buttonSizeBase.y, ui.fonts.pionillium.medlarge)
+		colors.gaugeEquipmentMarket, '', gaugeWidth, gaugeHeight, pionillium.body)
 
 	-- hyperspace fuel
 	ui.nextColumn()
@@ -214,7 +215,7 @@ local function lobbyMenu()
 	local stored_hyperfuel = cargoMgr:CountCommodity(hyperdrive_fuel)
 
 	-- hyperspace fuel prices
-	ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+	ui.withFont(pionillium.body, function()
 		ui.text(Format.Money(station:GetCommodityPrice(hyperdrive_fuel)) .. "/t")
 		ui.text(Format.Money(station:GetCommodityPrice(hyperdrive_fuel) * stored_hyperfuel))
 	end)
@@ -237,7 +238,7 @@ local function lobbyMenu()
 		stored_hyperfuel, Game.player:GetHyperspaceRange()),
 		0, cargoMgr:GetFreeSpace() + stored_hyperfuel,
 		icons.hyperspace, colors.gaugeEquipmentMarket, '',
-		gaugeWidth, widgetSizes.buttonSizeBase.y, ui.fonts.pionillium.medlarge)
+		gaugeWidth, gaugeHeight, pionillium.body)
 
 	ui.columns(1, '', false)
 end
@@ -277,7 +278,7 @@ local function drawPlayerInfo()
 				parent_body = station.path:GetSystemBody().parent.name})
 	end
 
-	ui.withFont(pionillium.large.name, pionillium.large.size, function()
+	ui.withFont(pionillium.heading, function()
 		ui.withStyleVars({ItemSpacing = widgetSizes.itemSpacing}, function()
 			local buttonSizeSpacing = widgetSizes.buttonLaunchSize.y + widgetSizes.itemSpacing.y
 			local lobbyMenuHeight = widgetSizes.buttonSizeBase.y*2 + widgetSizes.itemSpacing.y*3 -- use an extra itemSpacing to avoid scrollbar
@@ -286,7 +287,7 @@ local function drawPlayerInfo()
 				-- face display has 1:1 aspect ratio, and we need size for a launch button underneath
 				local infoColumnWidth = -math.min(ui.getContentRegion().y - buttonSizeSpacing, widgetSizes.faceSize.x) - widgetSizes.itemSpacing.x
 				ui.child("PlayerShipFuel", Vector2(infoColumnWidth, 0), function()
-					textTable.withHeading(station.label, orbiteer.xlarge, {
+					textTable.withHeading(station.label, orbiteer.title, {
 						{ tech_certified, "" },
 						{ station_docks, "" },
 						{ station_orbit_info, "" },
@@ -299,7 +300,7 @@ local function drawPlayerInfo()
 				ui.group(function()
 					if(face ~= nil) then face:render() end
 
-					ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size, function()
+					ui.withFont(orbiteer.title, function()
 						local size = Vector2(ui.getContentRegion().x, widgetSizes.buttonLaunchSize.y)
 						if ui.button(l.REQUEST_LAUNCH, size) then
 							requestLaunch(station)

--- a/data/pigui/modules/station-view/02-bulletinBoard.lua
+++ b/data/pigui/modules/station-view/02-bulletinBoard.lua
@@ -202,7 +202,7 @@ local function renderBulletinBoard()
 		ui.sameLine()
 
 		ui.child("BulletinBoardSearch", Vector2(0, 0), function()
-			ui.withFont(orbiteer.xlarge, function()
+			ui.withFont(orbiteer.title, function()
 				ui.text(l.SEARCH)
 			end)
 			ui.pushItemWidth(ui.getContentRegion().x)

--- a/data/pigui/modules/station-view/03-commodityMarket.lua
+++ b/data/pigui/modules/station-view/03-commodityMarket.lua
@@ -6,8 +6,6 @@ local StationView = require 'pigui.views.station-view'
 local CommodityWidget = require 'pigui.libs.commodity-market'
 
 local ui = require 'pigui'
-local pionillium = ui.fonts.pionillium
-local orbiteer = ui.fonts.orbiteer
 local l = Lang.GetResource("ui-core")
 
 local commodityMarket = CommodityWidget.New("commodityMarket", false)
@@ -27,4 +25,8 @@ StationView:registerView({
 		commodityMarket.scrollReset = true
 		commodityMarket.selectedItem = nil
 	end,
+	debugReload = function()
+		package.reimport('pigui.libs.commodity-market')
+		package.reimport()
+	end
 })

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -15,6 +15,7 @@ local CommodityType= require 'CommodityType'
 local ui = require 'pigui'
 local pionillium = ui.fonts.pionillium
 local orbiteer = ui.fonts.orbiteer
+local styleColors = ui.theme.styleColors
 local l = Lang.GetResource("ui-core")
 local textTable = require 'pigui.libs.text-table'
 local Vector2 = _G.Vector2
@@ -178,23 +179,25 @@ local tradeMenu = function()
 				ui.columns(2, "shipMarketInfo")
 				ui.setColumnWidth(0, colHeadingWidth)
 
-				ui.withFont(orbiteer.xlarge, function()
+				ui.withFont(orbiteer.title, function()
 					ui.text(selectedItem.def.name)
 				end)
-				ui.withFont(orbiteer.medlarge, function()
+				ui.withFont(orbiteer.body, function()
 					ui.text(shipClassString[selectedItem.def.shipClass])
 				end)
 
-				ui.text(l.PRICE..": "..Format.Money(selectedItem.def.basePrice, false))
-				ui.sameLine()
-				ui.text(l.AFTER_TRADE_IN..": "..Format.Money(selectedItem.def.basePrice - tradeInValue(ShipDef[Game.player.shipId]), false))
+				ui.withFont(pionillium.heading, function()
+					ui.text(l.PRICE..": "..Format.Money(selectedItem.def.basePrice, false))
+					ui.sameLine()
+					ui.text(l.AFTER_TRADE_IN..": "..Format.Money(selectedItem.def.basePrice - tradeInValue(ShipDef[Game.player.shipId]), false))
+				end)
 
 				ui.nextColumn()
 				ui.dummy(widgetSizes.iconSpacer)
 				ui.sameLine()
 				manufacturerIcon(selectedItem.def.manufacturer)
 				local shipBought = false
-				ui.withFont(pionillium.medlarge, function()
+				ui.withFont(pionillium.body, function()
 					shipBought = ui.button(l.BUY_SHIP, widgetSizes.buyButton)
 				end)
 				ui.columns(1, "")
@@ -265,11 +268,35 @@ local tradeMenu = function()
 				}
 
 				ui.child("ShipSpecs", Vector2(0, 0), function()
-					local colSpecNameWidth = ui.getContentRegion().x / 3.6
-					local colSpecValWidth = (ui.getContentRegion().x - colSpecNameWidth*2) / 2
-					local widths = { colSpecNameWidth, colSpecValWidth, colSpecNameWidth, colSpecValWidth }
-					textTable.drawTable(4, widths, shipInfoTable)
+					ui.withStyleVars({ CellPadding = Vector2(8, 4) }, function()
+
+						ui.beginTable("specs", 4)
+						ui.tableSetupColumn("name1")
+						ui.tableSetupColumn("body1")
+						ui.tableSetupColumn("name2")
+						ui.tableSetupColumn("body2")
+
+						for _, item in ipairs(shipInfoTable) do
+							ui.tableNextRow()
+
+							ui.tableSetColumnIndex(0)
+							ui.textColored(styleColors.gray_300, item[1])
+
+							ui.tableSetColumnIndex(1)
+							ui.textAligned(item[2], 1.0)
+
+							ui.tableSetColumnIndex(2)
+							ui.textColored(styleColors.gray_300, item[3])
+
+							ui.tableSetColumnIndex(3)
+							ui.textAligned(item[4], 1.0)
+						end
+
+						ui.endTable()
+
+					end)
 				end)
+
 			end)
 		end)
 	end
@@ -286,7 +313,7 @@ shipMarket = Table.New("shipMarketWidget", false, {
 		ui.setColumnWidth(3, columnWidth)
 	end,
 	renderHeaderRow = function(_)
-		ui.withFont(orbiteer.xlarge, function()
+		ui.withFont(orbiteer.heading, function()
 			ui.text('')
 			ui.nextColumn()
 			ui.text(l.SHIP)
@@ -334,14 +361,18 @@ StationView:registerView({
 	icon = ui.theme.icons.ship,
 	showView = true,
 	draw = function()
-		ui.withFont(pionillium.large, function()
+		ui.withFont(pionillium.heading, function()
 			shipMarket:render()
-			ui.sameLine(0, widgetSizes.itemSpacing.x)
-			tradeMenu()
 		end)
+
+		ui.sameLine(0, widgetSizes.itemSpacing.x)
+		tradeMenu()
 	end,
 	refresh = function()
 		refreshShipMarket()
 		shipMarket.scrollReset = true
 	end,
+	debugReload = function()
+		package.reimport()
+	end
 })

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -17,7 +17,6 @@ local pionillium = ui.fonts.pionillium
 local orbiteer = ui.fonts.orbiteer
 local styleColors = ui.theme.styleColors
 local l = Lang.GetResource("ui-core")
-local textTable = require 'pigui.libs.text-table'
 local Vector2 = _G.Vector2
 
 local vZero = Vector2(0,0)
@@ -34,7 +33,7 @@ local icons = {}
 local manufacturerIcons = {}
 local selectedItem
 
-local shipSellPriceReduction = 0.5
+local shipSellPriceReduction = 0.65
 local equipSellPriceReduction = 0.8
 
 local modelSpinner = ModelSpinner()

--- a/data/pigui/modules/station-view/07-police.lua
+++ b/data/pigui/modules/station-view/07-police.lua
@@ -56,9 +56,10 @@ end
 local function crime_record()
 	local past_crimes, stump = Game.player:GetCrimeRecord()
 	if #utils.build_array(pairs(past_crimes)) > 0 then
-		ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size,
-			function() ui.textColored(gray, l.CRIMINAL_RECORD) end)
-		ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function ()
+		ui.withFont(orbiteer.heading, function()
+			ui.textColored(gray, l.CRIMINAL_RECORD)
+		end)
+		ui.withFont(pionillium.body, function ()
 			for k,v in pairs(past_crimes) do
 				ui.textColored(gray, v.count)
 				-- start second column at this position:
@@ -76,10 +77,12 @@ local function outstanding_fines()
 
 		-- headline
 		ui.dummy(widgetSizes.dummySpaceSmall)
-		ui.withFont(orbiteer.xlarge.name, orbiteer.xlarge.size,
-			function() ui.text(l.OUTSTANDING_FINES) end)
+		ui.withFont(orbiteer.heading, function()
+			ui.text(l.OUTSTANDING_FINES)
+		end)
+
 		-- wrap list in medlarge font
-		ui.withFont(pionillium.medlarge.name, pionillium.medlarge.size, function()
+		ui.withFont(pionillium.body, function()
 			for k,v in pairs(crimes) do
 				ui.text(v.count)
 				-- start second column at this position:
@@ -95,8 +98,9 @@ local function outstanding_fines()
 			end
 		end)
 	else
-		ui.withFont(pionillium.large.name, pionillium.large.size,
-			function() ui.text(l.WE_HAVE_NO_BUSINESS_WITH_YOU) end)
+		ui.withFont(pionillium.body, function()
+			ui.text(l.WE_HAVE_NO_BUSINESS_WITH_YOU)
+		end)
 	end
 end
 
@@ -110,8 +114,11 @@ local function drawPolice()
 			- widgetSizes.faceSize.x - widgetSizes.itemSpacing.x
 
 		ui.child("CrimeStats", Vector2(infoColumnWidth, 0), {}, function()
-			ui.withFont(pionillium.large.name, pionillium.large.size,
-				function () ui.text(intro_txt) end)
+			ui.withFont(pionillium.heading, function ()
+				ui.text(intro_txt)
+			end)
+
+			ui.newLine()
 
 			-- 1. If outstanding fines, show list & offer to pay
 			outstanding_fines()
@@ -145,4 +152,7 @@ StationView:registerView({
 			end
 		end
 	end,
+	debugReload = function()
+		package.reimport()
+	end
 })

--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -277,7 +277,10 @@ ui.registerHandler('game', function(delta_t)
 		-- without triggering the options dialog
 		local currentView = Game.CurrentView()
 
-		ui.withStyleColors({ WindowBg = colors.transparent }, drawHUD)
+		-- Ensure we're wrapping the whole UI in a font that scales with the rest of the game
+		ui.withFont(pionillium.medium, function()
+			ui.withStyleColors({ WindowBg = colors.transparent }, drawHUD)
+		end)
 
 		-- TODO: dispatch escape key to views and let them handle it
 		if currentView == "world" and ui.escapeKeyReleased(true) then

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -323,6 +323,7 @@ static LuaFlags<ImGuiStyleVar_> imguiStyleVarTable = {
 	{ "ItemSpacing", ImGuiStyleVar_ItemSpacing },
 	{ "ItemInnerSpacing", ImGuiStyleVar_ItemInnerSpacing },
 	{ "IndentSpacing", ImGuiStyleVar_IndentSpacing },
+	{ "CellPadding", ImGuiStyleVar_CellPadding },
 	{ "ScrollbarSize", ImGuiStyleVar_ScrollbarSize },
 	{ "ScrollbarRounding", ImGuiStyleVar_ScrollbarRounding },
 	{ "GrabMinSize", ImGuiStyleVar_GrabMinSize },
@@ -3139,6 +3140,7 @@ void PiGui::load_theme_from_table(LuaTable &table, ImGuiStyle &style)
 	SET_STYLE(PopupRounding);
 	SET_STYLE(PopupBorderSize);
 	SET_STYLE(FramePadding);
+	SET_STYLE(CellPadding);
 	SET_STYLE(FrameRounding);
 	SET_STYLE(FrameBorderSize);
 	SET_STYLE(ItemSpacing);


### PR DESCRIPTION
This PR is technically still a bugfix!

This fixes several issues related to font sizing and consistency of font choices in the info and station screens, fixes an overlap between the ScanManager window and the cargo widget, as well as fixing an issue where the comms log did not scale with the rest of the UI, resulting in incredibly tiny comms messages on 4k screens.

I've made a few opinionated changes to UI element layout to fix minor issues and improve readability, like in the Ship Market screen.

I've generally brought the UI elements in line to use the semantic font size breakpoints I've been gradually introducing over the last year - now there are 'details', 'body', 'heading' and 'title' sizes for both Pionillium and Orbiteer, with the various screen code using those breakpoints as appropriate. Some screens use the heading size for content that really should be 'body', simply because the screen is so empty otherwise it looks incredibly out of place. (Those screens would be good candidates for future work or merging into e.g. the Station Lobby tab.)

I'll most likely push one more commit to this branch to adjust the top-level TabView widget and make a few opinionated changes there as well, but this is otherwise complete IMO.

Finally, this PR makes one balance change, which is to increase the trade-in value of ships in good repair to 65% from 50% - this should make our starts (especially the easy one) slightly less difficult to get to the point of upgrading to a better ship.

A picture or two for good measure:

![image](https://user-images.githubusercontent.com/4218491/212822138-69380da5-b757-4a50-8be5-2534e0ff6253.png)
![image](https://user-images.githubusercontent.com/4218491/212822183-74660150-d562-4084-bbd6-816a4178892a.png)
![image](https://user-images.githubusercontent.com/4218491/212822524-45937343-6b51-4e76-abe2-e4d9f4ec7f36.png)
![image](https://user-images.githubusercontent.com/4218491/212822549-b1e2e8b7-5ae0-4f0d-92a6-c1ee9d1c3ad0.png)

And one at 1280x720 showing fonts aren't too small to read :smile:
![image](https://user-images.githubusercontent.com/4218491/212822824-05b4e8d5-67ba-4033-9629-d86db67e1613.png)
