### PR TITLE
More crash fixes!

### DIFF
--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -46,9 +46,17 @@ local function getSaveTooltip(name)
 		return stats
 	end
 	ret = lui.GAME_TIME..":    " .. Format.Date(stats.time)
-	if stats.system then    ret = ret .. "\n"..lc.SYSTEM..": " .. stats.system end
-	if stats.credits then   ret = ret .. "\n"..lui.CREDITS..": " .. Format.Money(stats.credits) end
-	if stats.ship   then    ret = ret .. "\n"..lc.SHIP..": " .. ShipDef[stats.ship].name end
+	local ship = stats.ship and ShipDef[stats.ship]
+
+	if stats.system then ret = ret .. "\n"..lc.SYSTEM..": " .. stats.system end
+	if stats.credits then ret = ret .. "\n"..lui.CREDITS..": " .. Format.Money(stats.credits) end
+
+	if ship then
+		ret = ret .. "\n"..lc.SHIP..": " .. ship.name
+	else
+		ret = ret .. "\n" .. lc.SHIP .. ": " .. lc.UNKNOWN
+	end
+
 	if stats.flight_state then
 		ret = ret .. "\n"..lui.FLIGHT_STATE..": "
 		if stats.flight_state == "docked" then ret = ret .. lc.DOCKED

--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -202,7 +202,11 @@ namespace FileSystem {
 		m_dirLen(0),
 		m_type(type)
 	{
-		assert((m_path.size() <= 1) || (m_path[m_path.size() - 1] != '/'));
+		if (!m_path.empty() && m_path[m_path.size() - 1] == '/') {
+			// remove trailing slash
+			m_path.pop_back();
+		}
+
 		std::size_t slashpos = m_path.rfind('/');
 		if (slashpos != std::string::npos) {
 			m_dirLen = slashpos + 1;

--- a/src/Input.h
+++ b/src/Input.h
@@ -195,9 +195,9 @@ public:
 	void SetMouseYInvert(bool state);
 
 	bool IsMouseButtonPressed(int button) { return mouseButton[button] == 1; }
-	bool IsMouseButtonReleased(int button) { return mouseButton[button] == 3; }
+	bool IsMouseButtonReleased(int button) { return mouseButton[button] == 4; }
 
-	int MouseButtonState(int button) { return mouseButton[button] & 3; }
+	bool MouseButtonState(int button) { return mouseButton[button] & 3; }
 	void SetMouseButtonState(int button, bool state) { mouseButton[button] = state; }
 
 	void GetMousePosition(int position[2]);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -111,7 +111,6 @@ std::unique_ptr<LuaConsole> Pi::luaConsole;
 Game *Pi::game;
 Random Pi::rng;
 float Pi::frameTime;
-bool Pi::doingMouseGrab;
 bool Pi::showDebugInfo = false;
 int Pi::statSceneTris = 0;
 int Pi::statNumPatches = 0;
@@ -1102,8 +1101,6 @@ void GameLoop::End()
 	// Clean up any left-over mouse state
 	Pi::input->SetCapturingMouse(false);
 
-	Pi::SetMouseGrab(false);
-
 #ifdef REMOTE_LUA_REPL
 	Pi::luaConsole->CloseTCPDebugConnection();
 #endif
@@ -1230,17 +1227,6 @@ float Pi::GetMoveSpeedShiftModifier()
 	if (Pi::input->KeyState(SDLK_LSHIFT)) return 100.f;
 	if (Pi::input->KeyState(SDLK_RSHIFT)) return 10.f;
 	return 1;
-}
-
-void Pi::SetMouseGrab(bool on)
-{
-	if (!doingMouseGrab && on) {
-		Pi::input->SetCapturingMouse(true);
-		doingMouseGrab = true;
-	} else if (doingMouseGrab && !on) {
-		Pi::input->SetCapturingMouse(false);
-		doingMouseGrab = false;
-	}
 }
 
 // This absolutely ought not to be part of the Pi class

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -151,9 +151,6 @@ public:
 	static bool AreHudTrailsDisplayed() { return hudTrailsDisplayed; }
 	static void SetHudTrailsDisplayed(bool state) { hudTrailsDisplayed = state; }
 
-	static void SetMouseGrab(bool on);
-	static bool DoingMouseGrab() { return doingMouseGrab; }
-
 	// Get the default speed modifier to apply to movement (scrolling, zooming...), depending on the "shift" keys.
 	// This is a default value only, centralized here to promote uniform user expericience.
 	static float GetMoveSpeedShiftModifier();

--- a/src/lua/LuaDev.cpp
+++ b/src/lua/LuaDev.cpp
@@ -138,7 +138,7 @@ static int l_dev_galaxy_stats(lua_State *l)
 		void ProcessSystem(const Sector::System &system) override
 		{
 			RefCountedPtr<StarSystem> starsystem = galaxy->GetStarSystem(system.GetPath());
-			for (const auto b : starsystem->GetBodies()) {
+			for (const auto &b : starsystem->GetBodies()) {
 				auto children = b->GetChildren();
 				if (std::find_if(children.cbegin(), children.cend(), [](const SystemBody *kid) {
 						return kid->GetType() == SystemBody::TYPE_STARPORT_SURFACE;

--- a/src/lua/LuaTimer.cpp
+++ b/src/lua/LuaTimer.cpp
@@ -94,6 +94,7 @@ void LuaTimer::Tick()
 
 	// Clear the scratch buffer
 	m_called.clear();
+	lua_pop(l, 1);
 
 	LUA_DEBUG_END(l, 0);
 }


### PR DESCRIPTION
- Fix an issue where hovering over a save with a ship not present in the game files (new, deleted, or modded) would cause a lua error in the menu.
- Fix the "mouse capture bug" in all of the map screens (caused by incorrect return type of `input->GetMouseButtonState`).
- Fix an assert that was triggering in debug builds for some time, replaced with a conditional branch to handle the assert case.
- Fix a stack overflow inadvertently introduced when I reworked LuaTimer. Fixes #5473.