### PR TITLE
Fix station pads being assigned wrong bay indicies

### DIFF
--- a/src/SpaceStationType.cpp
+++ b/src/SpaceStationType.cpp
@@ -112,17 +112,14 @@ void SpaceStationType::OnSetupComplete()
 		m_ports.push_back(new_port);
 	}
 
-	int bay = 0;
 	for (auto locIter : locator_mts) {
-		int bayStr, portId;
+		int bay, portId;
 		int minSize, maxSize;
 		char padname[8];
 		const matrix4x4f &locTransform = locIter->GetTransform();
 
-		++bay;
-
 		// eg:loc_A001_p01_s0_500_b01
-		PiVerify(5 == sscanf(locIter->GetName().c_str(), "loc_%4s_p%d_s%d_%d_b%d", &padname[0], &portId, &minSize, &maxSize, &bayStr));
+		PiVerify(5 == sscanf(locIter->GetName().c_str(), "loc_%4s_p%d_s%d_%d_b%d", &padname[0], &portId, &minSize, &maxSize, &bay));
 		PiVerify(bay > 0 && portId > 0);
 
 		// find the port and setup the rest of it's information


### PR DESCRIPTION
The bay index assigned to pads was dependent on order of tags in the model file, which can vary depending on the exporter used to generate the model. This caused a mismatch between what was displayed on the UI and which tag was used as the 'landing location'. Instead, the bay index is now determined (correctly) from the `_bNN` portion of the tag name.

Fixes #5408.