### PR TITLE
Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -31,12 +31,12 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: pioneer
 
     - name: Checkout pioneer-thirdparty
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: pioneerspacesim/pioneer-thirdparty
         path: pioneer-thirdparty
@@ -52,12 +52,12 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: pioneer
 
     - name: Checkout pioneer-thirdparty
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: pioneerspacesim/pioneer-thirdparty
         path: pioneer-thirdparty
@@ -106,7 +106,7 @@ jobs:
 
     steps:
     # Checkout the repository as $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Dependencies
       run: |
@@ -146,7 +146,7 @@ jobs:
     steps:
 
     # Checkout the repository as $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
 
     # Checkout the repository as $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Make sure to include the base we want to merge into
     - run: |


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

Still using v2 of `actions/checkout` will generate some warning like in this run: https://github.com/pioneerspacesim/pioneer/actions/runs/3992876243

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/checkout`, because v3 uses Node.js 16.