### PR TITLE
Fix uninitialized variables, memory leaks

### DIFF
--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -168,6 +168,7 @@ namespace FileSystem {
 		}
 		StringRange AsStringRange() const { return StringRange(m_data, m_size); }
 		ByteRange AsByteRange() const { return ByteRange(m_data, m_size); }
+		std::string_view AsStringView() const { return std::string_view(m_data, m_size); }
 
 	protected:
 		FileData(const FileInfo &info, size_t size, char *data) :

--- a/src/GasGiantJobs.h
+++ b/src/GasGiantJobs.h
@@ -168,7 +168,7 @@ namespace GasGiantJobs {
 
 		inline Sint32 UVDims() const { return uvDIMs; }
 		Graphics::Texture *Texture() const { return m_texture.Get(); }
-		GenFaceQuad *Quad() const { return pQuad; }
+		GenFaceQuad *Quad() const { return pQuad.get(); }
 		const SystemPath &SysPath() const { return sysPath; }
 		void SetupMaterialParams(const int face);
 
@@ -186,7 +186,7 @@ namespace GasGiantJobs {
 		Terrain *pTerrain;
 		const float planetRadius;
 		const float hueAdjust;
-		GenFaceQuad *pQuad;
+		std::unique_ptr<GenFaceQuad> pQuad;
 	};
 
 	// ********************************************************************************

--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -212,7 +212,9 @@ GeomTree::GeomTree(Serializer::Reader &rd)
 	for (int i = 0; i < m_numEdges; i++) {
 		edgeIdxs[i] = i;
 	}
+
 	m_edgeTree.reset(new BVHTree(m_numEdges, edgeIdxs, &m_aabbs[0]));
+	delete[] edgeIdxs;
 }
 
 static bool SlabsRayAabbTest(const BVHNode *n, const vector3f &start, const vector3f &invDir, isect_t *isect)

--- a/src/lua/LuaRef.cpp
+++ b/src/lua/LuaRef.cpp
@@ -21,14 +21,12 @@ const LuaRef &LuaRef::operator=(const LuaRef &ref)
 {
 	if (&ref == this)
 		return ref;
-	if (m_id != LUA_NOREF && m_lua) {
-		--(*m_copycount);
-	}
-	CheckCopyCount();
+	Unref();
+
 	m_lua = ref.m_lua;
 	m_id = ref.m_id;
 	m_copycount = ref.m_copycount;
-	if (m_lua && m_id)
+	if (m_lua && m_id != LUA_NOREF)
 		++(*m_copycount);
 	return *this;
 }
@@ -75,14 +73,9 @@ void LuaRef::CheckCopyCount()
 
 LuaRef::LuaRef(lua_State *l, int index) :
 	m_lua(l),
-	m_id(0)
+	m_id(LUA_NOREF)
 {
 	assert(m_lua && index);
-	if (index == LUA_NOREF) {
-		m_copycount = new int(0);
-		return;
-	}
-
 	index = lua_absindex(m_lua, index);
 
 	PushGlobalToStack();

--- a/src/lua/LuaRef.h
+++ b/src/lua/LuaRef.h
@@ -14,7 +14,7 @@ public:
 	LuaRef() :
 		m_lua(0),
 		m_id(LUA_NOREF),
-		m_copycount(new int(0)) {}
+		m_copycount(nullptr) {}
 	LuaRef(lua_State *l, int index);
 	LuaRef(const LuaRef &ref);
 	~LuaRef();

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -39,6 +39,7 @@ namespace SceneGraph {
 		m_boundingRadius(10.f),
 		m_renderer(r),
 		m_name(name),
+		m_activeAnimations(0),
 		m_curPatternIndex(0),
 		m_curPattern(0),
 		m_debugFlags(0)
@@ -56,6 +57,7 @@ namespace SceneGraph {
 		m_collMesh(model.m_collMesh), //might have to make this per-instance at some point
 		m_renderer(model.m_renderer),
 		m_name(model.m_name),
+		m_activeAnimations(0),
 		m_curPatternIndex(model.m_curPatternIndex),
 		m_curPattern(model.m_curPattern),
 		m_debugFlags(0)

--- a/src/ship/ShipViewController.cpp
+++ b/src/ship/ShipViewController.cpp
@@ -68,6 +68,7 @@ ShipViewController::ShipViewController(WorldView *v) :
 	ViewController(v),
 	m_camType(CAM_INTERNAL),
 	headtracker_input_priority(false),
+	m_mouseActive(false),
 	InputBindings(Pi::input)
 {
 	InputBindings.RegisterBindings();

--- a/src/text/DistanceFieldFont.cpp
+++ b/src/text/DistanceFieldFont.cpp
@@ -3,7 +3,6 @@
 
 #include "DistanceFieldFont.h"
 #include "FileSystem.h"
-#include "StringRange.h"
 #include "graphics/Texture.h"
 #include "graphics/VertexArray.h"
 #include "utils.h"
@@ -19,22 +18,23 @@ namespace Text {
 	{
 		//parse definition
 		RefCountedPtr<FileSystem::FileData> fontdef = FileSystem::gameDataFiles.ReadFile(definition);
-		StringRange data = fontdef->AsStringRange();
+
+		std::string_view data = fontdef->AsStringView();
 
 		bool doingCharacters = false;
 
-		while (!data.Empty()) {
-			const StringRange line = data.ReadLine();
-			if (line.Empty()) continue;
+		while (!data.empty()) {
+			const std::string_view line = read_line(data);
+			if (line.empty()) continue;
 
 			if (doingCharacters) {
 				ParseChar(line);
 			} else {
-				if (starts_with(line.begin, "info")) //contains font size
+				if (starts_with(line, "info")) //contains font size
 					ParseInfo(line);
-				else if (starts_with(line.begin, "common ")) //contains UV sheet w/h
+				else if (starts_with(line, "common ")) //contains UV sheet w/h
 					ParseCommon(line);
-				else if (starts_with(line.begin, "chars ")) //after this, file should be all characters
+				else if (starts_with(line, "chars ")) //after this, file should be all characters
 					doingCharacters = true;
 			}
 		}
@@ -126,9 +126,9 @@ namespace Text {
 	}
 
 	//get font definitions from a line of xml, insert glyph information into the map
-	void DistanceFieldFont::ParseChar(const StringRange &r)
+	void DistanceFieldFont::ParseChar(std::string_view r)
 	{
-		std::stringstream ss(r.ToString());
+		std::stringstream ss(std::string { r });
 		std::string token;
 
 		Uint32 id = 0;
@@ -173,9 +173,9 @@ namespace Text {
 		m_glyphs[id] = g;
 	}
 
-	void DistanceFieldFont::ParseCommon(const StringRange &line)
+	void DistanceFieldFont::ParseCommon(std::string_view line)
 	{
-		std::stringstream ss(line.ToString());
+		std::stringstream ss(std::string { line });
 		std::string token;
 
 		while (ss >> token) {
@@ -190,9 +190,9 @@ namespace Text {
 		}
 	}
 
-	void DistanceFieldFont::ParseInfo(const StringRange &line)
+	void DistanceFieldFont::ParseInfo(std::string_view line)
 	{
-		std::stringstream ss(line.ToString());
+		std::stringstream ss(std::string { line });
 		std::string token;
 
 		while (ss >> token) {

--- a/src/text/DistanceFieldFont.h
+++ b/src/text/DistanceFieldFont.h
@@ -22,8 +22,12 @@
  * char id=32 x=253.875 y=0 width=2 height=2.125 xoffset=-1 yoffset=30.875 xadvance=16 page=0 chnl=15
  * (etc)
  */
-#include "StringRange.h"
-#include "libs.h"
+
+#include "RefCounted.h"
+#include "vector2.h"
+
+#include <string>
+#include <map>
 
 namespace Graphics {
 	class Texture;
@@ -54,9 +58,9 @@ namespace Text {
 		float m_fontSize; //32 etc. Glyph size/advance will be scaled to 1/fontSize.
 
 		void AddGlyph(Graphics::VertexArray &va, const vector2f &pos, const Glyph &, vector2f &bounds);
-		void ParseChar(const StringRange &line);
-		void ParseCommon(const StringRange &line);
-		void ParseInfo(const StringRange &line);
+		void ParseChar(std::string_view line);
+		void ParseCommon(std::string_view line);
+		void ParseInfo(std::string_view line);
 	};
 
 } // namespace Text

--- a/src/utils.h
+++ b/src/utils.h
@@ -145,6 +145,45 @@ inline bool compare_ci(const std::string_view s, const std::string_view t)
 	return true;
 }
 
+inline std::string_view read_line(std::string_view &s)
+{
+	if (s.empty())
+		return {};
+
+	std::string_view out = s;
+
+	size_t end = s.find_first_of("\r\n");
+	if (end == std::string_view::npos) {
+		s = {};
+		return out;
+	}
+
+	out = { s.data(), end };
+
+	size_t start = s.find_first_not_of("\r\n", end);
+	if (start == std::string_view::npos) {
+		s = {};
+		return out;
+	}
+
+	s.remove_prefix(start);
+	return out;
+}
+
+inline std::string_view strip_spaces(std::string_view &s)
+{
+	if (s.empty())
+		return s;
+
+	size_t start = s.find_first_not_of(" \t\r\n\v");
+	if (start == std::string::npos)
+		return {};
+
+	size_t end = s.find_last_not_of(" \t\r\n\v");
+
+	return s.substr(start, end);
+}
+
 static inline size_t SplitSpec(const std::string &spec, std::vector<int> &output)
 {
 	static const std::string delim(",");


### PR DESCRIPTION
I've run AddressSanitizer, LeakSanitizer, and ThreadSanitizer on the code (as well as a brief pass with Valgrind) to clean up any possible issues or errors that might have been introduced without notice.

This PR fixes, in total:
- 1 read-past-end bug (in DistanceFieldFont.cpp)
- 2 uninitialized variable accesses (in scenegraph/Model.cpp and ship/ShipViewController.cpp)
- 3 memory leaks, of varying severity between a few hundred bytes and 600kb