### PR TITLE
Fixes, bowfin update, terrain rendering fixes

### DIFF
--- a/data/libs/Economy.lua
+++ b/data/libs/Economy.lua
@@ -421,7 +421,7 @@ Serializer:Register("Economy",
 		}
 	end,
 	function(data)
-		stationMarket = data.market
+		stationMarket = data.market or {}
 	end
 )
 

--- a/data/libs/FlightLog.lua
+++ b/data/libs/FlightLog.lua
@@ -22,9 +22,6 @@ local FlightLogSystem = {}
 local FlightLogStation = {}
 local FlightLogCustom = {}
 
--- Version for backwards compability
-local version = 1
-
 local FlightLog
 FlightLog = {
 
@@ -379,24 +376,6 @@ FlightLog = {
 			{path, Game.time, Game.player:GetMoney(), location, text})
 	end,
 
---
--- Group: Attributes
---
-
---
--- Attribute: version
---
--- Marks version of flight log, can be used for non-breaking backwards
--- compatibility, if new features are added to FlightLog
---
--- Example:
---
--- > if FlightLog.version > 2 then
--- >     FlightLog.useNewFeature()
--- > end
---
-
-	version = version,
 }
 
 -- LOGGING
@@ -433,11 +412,10 @@ end
 local loaded_data
 
 local onGameStart = function ()
-	if loaded_data and loaded_data.Version then
+	if loaded_data and loaded_data.Version >= 1 then
 		FlightLogSystem = loaded_data.System
 		FlightLogStation = loaded_data.Station
 		FlightLogCustom = loaded_data.Custom
-		version = loaded_data.Version
 	else
 		table.insert(FlightLogSystem,1,{Game.system.path,nil,nil,""})
 	end
@@ -448,14 +426,13 @@ local onGameEnd = function ()
 	FlightLogSystem = {}
 	FlightLogStation = {}
 	FlightLogCustom = {}
-	version = nil
 end
 
 local serialize = function ()
 	return { System = FlightLogSystem,
 			 Station = FlightLogStation,
 			 Custom = FlightLogCustom,
-			 Version = version
+			 Version = 1 -- version for backwards compatibility
 	}
 end
 

--- a/data/modules/AutoSave/AutoSave.lua
+++ b/data/modules/AutoSave/AutoSave.lua
@@ -45,10 +45,28 @@ local function CheckedSave(filename)
 	end
 end
 
-local f = function (ship) if ship:IsPlayer() then CheckedSave(PickNextAutosave()); end; end
+local function AutoSave(type)
+	if type == 'exit' then
+		CheckedSave('_exit')
+	else
+		CheckedSave(PickNextAutosave())
+	end
+end
+
+Event.Register('onAutoSave', AutoSave)
+
+local f = function (ship)
+	if ship:IsPlayer() then Event.Queue('onAutoSave') end
+end
+
 Event.Register('onShipDocked', f)
 Event.Register('onShipLanded', f)
-Event.Register('onShipUndocked', f)
-Event.Register('onShipTakeOff', f)
+
 -- we have to make sure to autosave the game before the end game process starts
-Event.Register('onAutoSaveBeforeGameEnds', function() CheckedSave('_exit'); end)
+Event.Register('onAutoSaveBeforeGameEnds', function()
+	CheckedSave('_exit')
+end)
+
+return {
+	Save = AutoSave
+}

--- a/data/pigui/modules/autopilot-window.lua
+++ b/data/pigui/modules/autopilot-window.lua
@@ -4,6 +4,7 @@
 local Game = require 'Game'
 local Event = require 'Event'
 local bindManager = require 'bind-manager'
+local AutoSave    = require 'modules.AutoSave.AutoSave'
 
 local Lang = require 'Lang'
 local lui = Lang.GetResource("ui-core");
@@ -66,12 +67,14 @@ local function button_undock()
 	if player:IsLanded() then
 		if ui.mainMenuButton(icons.autopilot_blastoff, lui.HUD_BUTTON_BLASTOFF) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f5)) then
 			Game.SetTimeAcceleration("1x")
+			AutoSave.Save()
 			player:BlastOff()
 		end
 		return true
 	elseif player:IsDocked() then
 		if ui.mainMenuButton(icons.autopilot_undock, lui.HUD_BUTTON_UNDOCK) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f5)) then
 			Game.SetTimeAcceleration("1x")
+			AutoSave.Save()
 			player:Undock()
 		end
 		return true

--- a/data/pigui/modules/ship-internals-window.lua
+++ b/data/pigui/modules/ship-internals-window.lua
@@ -66,14 +66,17 @@ end
 
 local function button_wheelstate()
 	local wheelstate = player:GetWheelState() -- 0.0 is up, 1.0 is down
-	if wheelstate == 0.0 then -- gear is up
-		if ui.mainMenuButton(icons.landing_gear_down, lui.HUD_BUTTON_LANDING_GEAR_IS_UP) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f6)) then
+	local locked = player:GetFlightControlState() == "CONTROL_AUTOPILOT"
+	if locked and wheelstate == 0.0 then
+		ui.mainMenuButton(icons.landing_gear_down, lc.AUTOPILOT_CONTROL, ui.theme.buttonColors.disabled)
+	elseif wheelstate == 0.0 then -- gear is up
+		if ui.mainMenuButton(icons.landing_gear_down, lui.HUD_BUTTON_LANDING_GEAR_IS_UP) then
 			player:ToggleWheelState()
-	end
+		end
 	elseif wheelstate == 1.0 then -- gear is down
-		if ui.mainMenuButton(icons.landing_gear_up, lui.HUD_BUTTON_LANDING_GEAR_IS_DOWN) or (ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f6)) then
+		if ui.mainMenuButton(icons.landing_gear_up, lui.HUD_BUTTON_LANDING_GEAR_IS_DOWN) then
 			player:ToggleWheelState()
-	end
+		end
 	else
 		ui.mainMenuButton(icons.landing_gear_up, lui.HUD_BUTTON_LANDING_GEAR_IS_MOVING, ui.theme.buttonColors.disabled)
 	end

--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -3,6 +3,7 @@
 
 local ui = require 'pigui'
 local StationView = require 'pigui.views.station-view'
+local AutoSave    = require 'modules.AutoSave.AutoSave'
 
 local Game = require 'Game'
 local Rand = require 'Rand'
@@ -67,11 +68,17 @@ local requestLaunch = function (station)
 		Comms.ImportantMessage(l.LAUNCH_PERMISSION_DENIED_CREW, station.label)
 		popupMsg = l.LAUNCH_PERMISSION_DENIED_CREW
 		popup:open()
+		return
 	elseif fine > 0 then
 		Comms.ImportantMessage(l.LAUNCH_PERMISSION_DENIED_FINED, station.label)
 		popupMsg = l.LAUNCH_PERMISSION_DENIED_FINED
 		popup:open()
-	elseif not Game.player:Undock() then
+		return
+	end
+
+	AutoSave.Save()
+
+	if not Game.player:Undock() then
 		Comms.ImportantMessage(l.LAUNCH_PERMISSION_DENIED_BUSY, station.label)
 		popupMsg = l.LAUNCH_PERMISSION_DENIED_BUSY
 		popup:open()

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -199,7 +199,7 @@ table.insert(leftSidebar.modules, {
 
 	drawTitle = function()
 		if Windows.unexplored.visible then
-			ui.text(luc.UNEXPLORED_SYSTEM_NO_SYSTEM_VIEW)
+			ui.text(lc.UNEXPLORED_SYSTEM_NO_SYSTEM_VIEW)
 		else
 			systemOverviewWidget:displaySidebarTitle(systemView:GetSystem())
 		end

--- a/data/ships/bowfin.json
+++ b/data/ships/bowfin.json
@@ -3,13 +3,13 @@
 	"name": "Bowfin",
 	"cockpit": "",
 	"manufacturer": "kaluri",
-	"ship_class": "medium_fighter",
+	"ship_class": "light_fighter",
 	"min_crew": 1,
 	"max_crew": 1,
-	"price": 32822,
+	"price": 34430,
 	"hull_mass": 25,
 	"atmospheric_pressure_limit": 6.5,
-	"capacity": 12,
+	"capacity": 18,
 	"slots": {
 		"engine": 1,
 		"cabin": 0,
@@ -18,7 +18,7 @@
 		"missile": 24,
 		"cargo": 6
 	},
-	"roles": ["mercenary", "merchant", "pirate", "courier"],
+	"roles": ["mercenary", "pirate", "courier"],
 
 	"effective_exhaust_velocity": 8400000,
 	"thruster_fuel_use": -1.0,

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -35,6 +35,7 @@ class GeoSphere;
 class BasePatchJob;
 class SQuadSplitResult;
 class SSingleSplitResult;
+struct SSplitResultData;
 
 class GeoPatch {
 public:
@@ -85,6 +86,7 @@ public:
 	void RequestSinglePatch();
 	void ReceiveHeightmaps(SQuadSplitResult *psr);
 	void ReceiveHeightmap(const SSingleSplitResult *psr);
+	void ReceiveHeightResult(const SSplitResultData &data);
 	void ReceiveJobHandle(Job::Handle job);
 
 	inline bool HasHeightData() const { return (m_heights.get() != nullptr); }

--- a/src/GeoPatchJobs.h
+++ b/src/GeoPatchJobs.h
@@ -124,29 +124,29 @@ protected:
 	SSingleSplitRequest(const SSingleSplitRequest &r) = delete;
 };
 
+struct SSplitResultData {
+	SSplitResultData() :
+		patchID(0) {}
+	SSplitResultData(double *heights_, vector3f *n_, Color3ub *c_, const vector3d &v0_, const vector3d &v1_, const vector3d &v2_, const vector3d &v3_, const GeoPatchID &patchID_) :
+		heights(heights_),
+		normals(n_),
+		colors(c_),
+		v0(v0_),
+		v1(v1_),
+		v2(v2_),
+		v3(v3_),
+		patchID(patchID_)
+	{}
+
+	double *heights;
+	vector3f *normals;
+	Color3ub *colors;
+	vector3d v0, v1, v2, v3;
+	GeoPatchID patchID;
+};
+
 class SBaseSplitResult {
 public:
-	struct SSplitResultData {
-		SSplitResultData() :
-			patchID(0) {}
-		SSplitResultData(double *heights_, vector3f *n_, Color3ub *c_, const vector3d &v0_, const vector3d &v1_, const vector3d &v2_, const vector3d &v3_, const GeoPatchID &patchID_) :
-			heights(heights_),
-			normals(n_),
-			colors(c_),
-			v0(v0_),
-			v1(v1_),
-			v2(v2_),
-			v3(v3_),
-			patchID(patchID_)
-		{}
-
-		double *heights;
-		vector3f *normals;
-		Color3ub *colors;
-		vector3d v0, v1, v2, v3;
-		GeoPatchID patchID;
-	};
-
 	SBaseSplitResult(const int32_t face_, const int32_t depth_) :
 		mFace(face_),
 		mDepth(depth_) {}


### PR DESCRIPTION
Unsure how much more bugfixing will be finished before Pioneer Day, so have an early batch. I'll try to get to the other reported issues with the Scout Mission etc.

- Fixes #5420: the global version attribute was being reset on game end, causing invalid data to be saved. The entire flight history log was discarded on load.
- Fixes #5458: added a separate button state for "autopilot control". Not using a separate language string due to time reasons.
- Fixes: #5479: this was caused by order of autosave handler relative to other `onShipDocked` handlers. I've deferred autosave by one frame to ensure all handlers run before saving.
- Fixes: #4123: autosave is now made before undocking, rather than after.
- Fixes #5470: this was caused by the autosave running before BBS / markets are generated for the station. Thus, reloading the autosave yields an empty market.
- Fixes: #5493: reloading the game or buying a new ship didn't update the equipment listener used to detect changes to the ship's loadout.

I've updated the Bowfin to have an additional 50% more equipment capacity as an interim measure before moving to volume-based equipment. This allows it to mount missiles in addition to a shield generator... :upside_down_face: The Bowfin's class has been updated to "Light Fighter" from "Medium Fighter" (as it in no way qualifies for a medium ship).

I've also fixed an unreported bug that caused extremely poor quality terrain in elevated areas. The centroid used to calculate LOD distance to a geopatch was remaining at the "sea level" height of the planet, rather than at the average height of the terrain, causing the game to think the camera was much further from the terrain than it actually is. This makes a *huge* difference in visual terrain quality, but leaves the performance cost about the same as before when the player is in low-lying terrain.

Before:
![image](https://user-images.githubusercontent.com/4218491/215306482-5f8ff600-9a70-4d88-b043-27488d3b876c.png)

After:
![image](https://user-images.githubusercontent.com/4218491/215306500-363ce357-288b-4076-b9e6-c7ba67c6b44a.png)
