### PR TITLE
Remove dead links in ui-core

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1263,6 +1263,14 @@
     "description": "",
     "message": "Lobby"
   },
+  "LOCAL_ARM": {
+    "description": "Arm of the Milky Way galaxy",
+    "message": "Local arm"
+  },
+  "LOCATED_N_KM_FROM_THE_CENTRE_OF_NAME": {
+    "description": "",
+    "message": "Located {distance}km from the centre of {name}:"
+  },
   "LOCATION": {
     "description": "",
     "message": "Location"
@@ -1483,6 +1491,10 @@
     "description": "",
     "message": "None for sale in this station."
   },
+  "NORMA_ARM": {
+    "description": "Arm of the Milky Way galaxy",
+    "message": "Norma arm"
+  },
   "NOTES": {
     "description": "",
     "message": "Notes:"
@@ -1567,6 +1579,10 @@
     "description": "Label for the point of an orbit nearest to the orbited body",
     "message": "Periapsis"
   },
+  "OUTER_ARM": {
+    "description": "Arm of the Milky Way galaxy",
+    "message": "Outer arm"
+  },
   "OUTLAW": {
     "description": "Legal status of player",
     "message": "Outlaw"
@@ -1630,6 +1646,10 @@
   "PAY_FINE_OF_N": {
     "description": "",
     "message": "Pay fine of {amount}"
+  },
+  "PERSEUS_ARM": {
+    "description": "Arm of the Milky Way galaxy",
+    "message": "Perseus arm"
   },
   "PERSONAL_INFORMATION": {
     "description": "",
@@ -1831,6 +1851,10 @@
     "description": "Ship jump status",
     "message": "Safety lockout"
   },
+  "SAGITTARIUS_ARM": {
+    "description": "Arm of the Milky Way galaxy",
+    "message": "Sagittarius arm"
+  },
   "SAVE": {
     "description": "",
     "message": "Save"
@@ -1838,6 +1862,10 @@
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"
+  },
+  "SCUTUM_CENTAURUS_ARM": {
+    "description": "Arm of the Milky Way galaxy",
+    "message": "Scutum-Centaurus arm"
   },
   "SELECT": {
     "description": "",
@@ -2046,6 +2074,10 @@
   "THIS_IS_FACTION_POLICE": {
     "description": "Greeting message in police station. 'faction' is one of (English, non-translatable) strings: 'Solar Federation', 'Commonwealth of Independent Worlds', or 'Haber Corporation', and 'faction_police' is one of: 'SolFed Police Force', 'Confederal Police' or, 'Haber Enforcement Division'",
     "message": "This is the {faction_police} of the {faction}"
+  },
+  "THREE_KPC_ARM": {
+    "description": "Arm of the Milky Way galaxy",
+    "message": "3kpc arm"
   },
   "TOGGLE_CARGO_WINDOW": {
     "description": "Label for a button toggling the cargo display window.",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -211,10 +211,6 @@
     "description": "",
     "message": "Commodity trade analysis of:"
   },
-  "COMPACT_RADAR": {
-    "description": "Game settings option",
-    "message": "Compact radar"
-  },
   "COMPETENT": {
     "description": "Combat rating",
     "message": "Competent"
@@ -326,10 +322,6 @@
   "DEPARTURE_DATE": {
     "description": "Time of departure, used in flight log",
     "message": "Departure date"
-  },
-  "DESCENT_TO_GROUND_SPEED": {
-    "description": "",
-    "message": "Descent-to-ground speed:"
   },
   "DESTROY_ENEMY_SHIP": {
     "description": "",
@@ -611,10 +603,6 @@
     "description": "",
     "message": "Forward accel (full)"
   },
-  "FRACTAL_DETAIL": {
-    "description": "",
-    "message": "Fractal detail"
-  },
   "FREE": {
     "description": "Used in Ship Information view as in Capacity: 10t (5t free)",
     "message": "free"
@@ -846,10 +834,6 @@
   "HUD_BUTTON_ROTATION_DAMPING_IS_ON": {
     "description": "Tooltip: Rotation damping is on",
     "message": "Rotation damping is on"
-  },
-  "HUD_BUTTON_SCANNER": {
-    "description": "Tooltip: Scanner",
-    "message": "Scanner"
   },
   "HUD_BUTTON_SET_SPEED": {
     "description": "Tooltip: set speed",
@@ -1279,14 +1263,6 @@
     "description": "",
     "message": "Lobby"
   },
-  "LOCAL_ARM": {
-    "description": "Arm of the Milky Way galaxy",
-    "message": "Local arm"
-  },
-  "LOCATED_N_KM_FROM_THE_CENTRE_OF_NAME": {
-    "description": "",
-    "message": "Located {distance}km from the centre of {name}:"
-  },
   "LOCATION": {
     "description": "",
     "message": "Location"
@@ -1319,17 +1295,9 @@
     "description": "For displaying commodity information",
     "message": "Major Export"
   },
-  "MAJOR_EXPORTS_ITEM": {
-    "description": "",
-    "message": "Major exports"
-  },
   "MAJOR_IMPORT": {
     "description": "For displaying commodity information",
     "message": "Major Import"
-  },
-  "MAJOR_IMPORTS_ITEM": {
-    "description": "",
-    "message": "Major imports"
   },
   "MAKE_NEW_FACE": {
     "description": "",
@@ -1415,17 +1383,9 @@
     "description": "For displaying commodity information",
     "message": "Minor Export"
   },
-  "MINOR_EXPORTS_ITEM": {
-    "description": "",
-    "message": "Minor exports"
-  },
   "MINOR_IMPORT": {
     "description": "For displaying commodity information",
     "message": "Minor Import"
-  },
-  "MINOR_IMPORTS_ITEM": {
-    "description": "",
-    "message": "Minor imports"
   },
   "MISSILE_MOUNTS": {
     "description": "",
@@ -1523,10 +1483,6 @@
     "description": "",
     "message": "None for sale in this station."
   },
-  "NORMA_ARM": {
-    "description": "Arm of the Milky Way galaxy",
-    "message": "Norma arm"
-  },
   "NOTES": {
     "description": "",
     "message": "Notes:"
@@ -1603,14 +1559,6 @@
     "description": "",
     "message": "Orbit"
   },
-  "ORBITAL_ANALYSIS": {
-    "description": "",
-    "message": "Orbital Analysis"
-  },
-  "ORBITAL_ANALYSIS_NOTES": {
-    "description": "",
-    "message": "Circular orbit speed is given for a tangential velocity. The ship should be moving in a direction at 90° to the ship/{name} axis.\n\nDescent speed is an absolute minimum, and is also tangential. A slower speed or a lower angle will result in a course which intersects with the surface of {name}.\n\nEscape speed will in theory work in any direction, as long as the ship does not collide with {name} on the way.\n\t\t"
-  },
   "ORBIT_APOAPSIS": {
     "description": "Label for the point of an orbit furthest from the orbited body",
     "message": "Apoapsis"
@@ -1618,10 +1566,6 @@
   "ORBIT_PERIAPSIS": {
     "description": "Label for the point of an orbit nearest to the orbited body",
     "message": "Periapsis"
-  },
-  "OUTER_ARM": {
-    "description": "Arm of the Milky Way galaxy",
-    "message": "Outer arm"
   },
   "OUTLAW": {
     "description": "Legal status of player",
@@ -1686,10 +1630,6 @@
   "PAY_FINE_OF_N": {
     "description": "",
     "message": "Pay fine of {amount}"
-  },
-  "PERSEUS_ARM": {
-    "description": "Arm of the Milky Way galaxy",
-    "message": "Perseus arm"
   },
   "PERSONAL_INFORMATION": {
     "description": "",
@@ -1891,10 +1831,6 @@
     "description": "Ship jump status",
     "message": "Safety lockout"
   },
-  "SAGITTARIUS_ARM": {
-    "description": "Arm of the Milky Way galaxy",
-    "message": "Sagittarius arm"
-  },
   "SAVE": {
     "description": "",
     "message": "Save"
@@ -1902,10 +1838,6 @@
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"
-  },
-  "SCUTUM_CENTAURUS_ARM": {
-    "description": "Arm of the Milky Way galaxy",
-    "message": "Scutum-Centaurus arm"
   },
   "SELECT": {
     "description": "",
@@ -1999,10 +1931,6 @@
     "description": "",
     "message": "Ship Type"
   },
-  "SHIP_VIEWING_WAS_SOLD": {
-    "description": "",
-    "message": "The ship you were viewing has been sold"
-  },
   "SIMULATING_UNIVERSE_EVOLUTION_N_BYEARS": {
     "description": "",
     "message": "Simulating evolution of the universe: {age} billion years ;-)"
@@ -2018,14 +1946,6 @@
   "START_AT_BARNARDS_STAR_DESC": {
     "description": "",
     "message": "This is a difficult start from the System Administration Resting prison station."
-  },
-  "START_AT_EARTH": {
-    "description": "",
-    "message": "Start at Earth"
-  },
-  "START_AT_EARTH_DESC": {
-    "description": "",
-    "message": "This is an easy start from London on Earth in the Sol system."
   },
   "START_AT_MARS": {
     "description": "",
@@ -2126,10 +2046,6 @@
   "THIS_IS_FACTION_POLICE": {
     "description": "Greeting message in police station. 'faction' is one of (English, non-translatable) strings: 'Solar Federation', 'Commonwealth of Independent Worlds', or 'Haber Corporation', and 'faction_police' is one of: 'SolFed Police Force', 'Confederal Police' or, 'Haber Enforcement Division'",
     "message": "This is the {faction_police} of the {faction}"
-  },
-  "THREE_KPC_ARM": {
-    "description": "Arm of the Milky Way galaxy",
-    "message": "3kpc arm"
   },
   "TOGGLE_CARGO_WINDOW": {
     "description": "Label for a button toggling the cargo display window.",


### PR DESCRIPTION
Removing dead strings in ui-core.

These strings exists only in the lang files and most of them also don't have any reference to them on searching the Pioneer GitHub site. Some exempts below:

Reference to the last action involving the "Arms of the Milky Way " strings: https://github.com/pioneerspacesim/pioneer/issues/3583

`COMPACT_RADAR` removed here: 04195598386c873a9468a668d3fe0a8b44f7d84f