### PR TITLE
Fix small errors, adjust orbitscanner balance

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -211,7 +211,7 @@ misc.orbitscanner_good = BodyScannerType.New({
 	capabilities={mass=7,sensor=1}, purchasable=true, tech_level=8,
 	max_range=100000000, target_altitude=0, state="HALTED", progress=0,
 	bodyscanner_stats={scan_speed=3, scan_tolerance=0.05},
-	stats={ aperture = 2.2, minAltitude = 1750000, resolution = 11375, orbital = true },
+	stats={ aperture = 2.8, minAltitude = 1750000, resolution = 12375, orbital = true },
 	icon_name="equip_orbit_scanner"
 })
 

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -885,10 +885,13 @@ local onGameStart = function ()
 	if loaded_data then
 		CrewRoster = loaded_data
 		Event.Queue('crewAvailable') -- Signal any scripts that depend on initialised crew
-	else
-		CrewRoster = {}
 	end
+
 	loaded_data = nil
+end
+
+local onGameEnd = function()
+	CrewRoster = {}
 end
 
 local serialize = function ()
@@ -940,6 +943,7 @@ end
 Event.Register("onEnterSystem", onEnterSystem)
 Event.Register("onShipDestroyed", onShipDestroyed)
 Event.Register("onGameStart", onGameStart)
+Event.Register("onGameEnd", onGameEnd)
 Event.Register("onShipTypeChanged", onShipTypeChanged)
 Serializer:Register("ShipClass", serialize, unserialize)
 

--- a/data/pigui/modules/info-view/02-personal-info.lua
+++ b/data/pigui/modules/info-view/02-personal-info.lua
@@ -15,7 +15,7 @@ local orbiteer = ui.fonts.orbiteer
 local colors = ui.theme.colors
 local icons = ui.theme.icons
 
-local textTable = require 'pigui/libs/text-table'
+local textTable = require 'pigui.libs.text-table'
 
 local l = Lang.GetResource("ui-core")
 

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -67,7 +67,8 @@ end
 local function cargolist ()
 	local count = cachedCargoList or rebuildCargoList()
 
-	ui.beginTable("cargoTable", 3, { "SizingFixedFit" })
+	if not ui.beginTable("cargoTable", 3, { "SizingFixedFit" }) then return end
+
 	ui.tableSetupColumn("Amount")
 	ui.tableSetupColumn("Name", { "WidthStretch" })
 	ui.tableSetupColumn("Jettison")

--- a/data/pigui/modules/sidebar/cargo.lua
+++ b/data/pigui/modules/sidebar/cargo.lua
@@ -252,17 +252,18 @@ function module:drawBody()
 
 	if cargoMgr:GetUsedSpace() > 0 then
 
-		ui.beginTable("cargo", 4)
-		ui.tableSetupColumn("Cargo")
-		ui.tableSetupColumn("Amount")
-		ui.tableSetupColumn("Gauge", { "WidthStretch" })
-		ui.tableSetupColumn("Buttons")
+		if ui.beginTable("cargo", 4) then
+			ui.tableSetupColumn("Cargo")
+			ui.tableSetupColumn("Amount")
+			ui.tableSetupColumn("Gauge", { "WidthStretch" })
+			ui.tableSetupColumn("Buttons")
 
-		for _, v in ipairs(sortTable) do
-			self:drawCargoRow(v, maxWidth, totalSpace)
+			for _, v in ipairs(sortTable) do
+				self:drawCargoRow(v, maxWidth, totalSpace)
+			end
+
+			ui.endTable()
 		end
-
-		ui.endTable()
 
 	else
 		ui.alignTextToButtonPadding()

--- a/data/pigui/modules/station-view/02-bulletinBoard.lua
+++ b/data/pigui/modules/station-view/02-bulletinBoard.lua
@@ -150,6 +150,14 @@ bulletinBoard = Table.New("BulletinBoardTable", false, {
 		local ref = item.__ref
 		local ad = SpaceStation.adverts[station][ref]
 
+		-- TODO: if the player is watching the BBS while an ad expires, the ad
+		-- will be grayed-out but not removed until the player clicks on
+		-- something.
+		if not ad then
+			refresh()
+			return
+		end
+
 		if Game.paused then
 			return
 		end

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -269,7 +269,8 @@ local tradeMenu = function()
 				ui.child("ShipSpecs", Vector2(0, 0), function()
 					ui.withStyleVars({ CellPadding = Vector2(8, 4) }, function()
 
-						ui.beginTable("specs", 4)
+						if not ui.beginTable("specs", 4) then return end
+
 						ui.tableSetupColumn("name1")
 						ui.tableSetupColumn("body1")
 						ui.tableSetupColumn("name2")

--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -323,7 +323,8 @@ function SystemEconView:drawPriceList(key, prices)
 	local iconSize = Vector2(ui.getTextLineHeight() + 4)
 	local out = nil
 
-	ui.beginTable("prices", 3)
+	if not ui.beginTable("prices", 3) then return end
+
 	ui.tableSetupColumn("Name", { "WidthStretch" })
 	ui.tableSetupColumn("Indicators")
 	ui.tableSetupColumn("Amount")

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -10,8 +10,9 @@ local Equipment = require 'Equipment'
 local Format = require 'Format'
 local MusicPlayer = require 'modules.MusicPlayer'
 local Lang = require 'Lang'
-local FlightLog = require ("FlightLog")
-local Commodities = require("Commodities")
+local FlightLog = require 'FlightLog'
+local Commodities = require 'Commodities'
+local Character = require 'Character'
 local Vector2 = _G.Vector2
 
 local lc = Lang.GetResource("core")
@@ -184,6 +185,14 @@ local function startAtLocation(location)
 	Game.player:SetLabel(Ship.MakeRandomLabel())
 
 	Game.player:SetMoney(location.money)
+
+	local ship = Game.player
+	-- Generate crew for the starting ship
+	for i = 2, ShipDef[ship.shipId].minCrew do
+		local newCrew = Character.New()
+		newCrew:RollNew(true)
+		ship:Enroll(newCrew)
+	end
 
 	if location.hyperdrive then
 		Game.player:AddEquip(hyperspace['hyperdrive_'..ShipDef[Game.player.shipId].hyperdriveClass])

--- a/data/ships/skipjack.json
+++ b/data/ships/skipjack.json
@@ -16,11 +16,11 @@
 		"scoop": 2,
 		"laser_front": 1,
 		"missile": 8,
-		"sensor": 1,
+		"sensor": 3,
 		"cargo": 140
 	},
 	"roles": ["mercenary", "merchant", "pirate", "courier"],
-	
+
 	"effective_exhaust_velocity": 18900000,
 	"thruster_fuel_use": -1.0,
 	"fuel_tank_mass": 135,

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -392,7 +392,7 @@ static int l_body_get_altitude_rel_to(lua_State *l)
 	if (other && other->IsType(ObjectType::TERRAINBODY)) {
 		const TerrainBody *terrain = static_cast<const TerrainBody *>(other);
 		vector3d surface_pos = pos.Normalized();
-		double radius = 0.0;
+		double radius = terrain->GetSystemBody()->GetRadius();
 		if (center_dist <= 3.0 * terrain->GetMaxFeatureRadius()) {
 			radius = terrain->GetTerrainHeight(surface_pos);
 		}

--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -610,7 +610,7 @@ static int l_get_gps(lua_State *l)
 			if (!playerFrame->IsRotFrame())
 				playerFrame = Frame::GetFrame(playerFrame->GetRotFrame());
 			vector3d surface_pos = pos.Normalized();
-			double radius = 0.0;
+			double radius = terrain->GetSystemBody()->GetRadius();
 			if (center_dist <= 3.0 * terrain->GetMaxFeatureRadius()) {
 				radius = terrain->GetTerrainHeight(surface_pos);
 			}

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -145,7 +145,7 @@ REGISTER_INPUT_BINDING(PlayerShipController)
 	auto flightGroup = controlsPage->GetBindingGroup("ShipOrient");
 	input->AddAxisBinding("BindAxisPitch", flightGroup, Axis({}, { SDLK_k }, { SDLK_i }));
 	input->AddAxisBinding("BindAxisYaw", flightGroup, Axis({}, { SDLK_j }, { SDLK_l }));
-	input->AddAxisBinding("BindAxisRoll", flightGroup, Axis({}, { SDLK_u }, { SDLK_o }));
+	input->AddAxisBinding("BindAxisRoll", flightGroup, Axis({}, { SDLK_q }, { SDLK_e }));
 	input->AddActionBinding("BindKillRot", flightGroup, Action({ SDLK_p }, { SDLK_x }));
 	input->AddActionBinding("BindToggleRotationDamping", flightGroup, Action({ SDLK_v }));
 


### PR DESCRIPTION
Fixes #5512, by refreshing the BBS if the player tries to click on a negative-time ad. A more in-depth fix will need to be deferred to the next patch.
Fixes #5511, prevents an erroneous overwrite of the CrewRoster table on game start. Also generates enough crew to take off with the starting ship, in case we or others setup a start with a ship requiring multiple crew members.
Fixes #5508, displays orbital distance relative to sea-level-radius of the body rather than body's surface. Provides a true "distance to surface" display.
Fixes #5521, increase Skipjack sensor slots to 3 to make it an "exploration" themed medium courier.

This PR also adjusts the parameters of the expensive orbital scanner to provide a generally faster scan rate than a cheap scanner, and make it a little bit more useful when scanning small-to-medium moons.