### PR TITLE
Show info when the target area is reached

### DIFF
--- a/data/lang/module-combat/en.json
+++ b/data/lang/module-combat/en.json
@@ -359,6 +359,10 @@
     "description": "",
     "message": "System:"
   },
+  "TARGET_AREA_REACHED": {
+    "description": "",
+    "message": "Target area reached. Start data logging."
+  },
   "TIME_LIMIT": {
     "description": "",
     "message": "Time limit:"

--- a/data/modules/Combat/Combat.lua
+++ b/data/modules/Combat/Combat.lua
@@ -400,6 +400,8 @@ local onFrameChanged = function (player)
 				mission.duration = planet_radius/1000
 				Comms.ImportantMessage(string.interp(l.MISSION_INFO, { duration = Format.Duration(mission.duration) }))
 				missionTimer(mission)
+			else
+				Comms.ImportantMessage(l.TARGET_AREA_REACHED)
 			end
 		end
 		if mission.status == "ACTIVE" and Game.time > mission.due then


### PR DESCRIPTION
Reduce confusion by always indicating that the target area has been reached.
Closes #5499 