### PR TITLE
Convert integer pi_lua_generic_{push,pull} to fixed width types

### DIFF
--- a/src/lua/LuaPushPull.h
+++ b/src/lua/LuaPushPull.h
@@ -12,10 +12,10 @@
 #include <tuple>
 
 inline void pi_lua_generic_push(lua_State *l, bool value) { lua_pushboolean(l, value); }
-inline void pi_lua_generic_push(lua_State *l, int value) { lua_pushinteger(l, value); }
+inline void pi_lua_generic_push(lua_State *l, int32_t value) { lua_pushinteger(l, value); }
 inline void pi_lua_generic_push(lua_State *l, int64_t value) { lua_pushinteger(l, value); }
-inline void pi_lua_generic_push(lua_State *l, unsigned int value) { lua_pushinteger(l, value); }
-inline void pi_lua_generic_push(lua_State *l, size_t value) { lua_pushinteger(l, value); }
+inline void pi_lua_generic_push(lua_State *l, uint32_t value) { lua_pushinteger(l, value); }
+inline void pi_lua_generic_push(lua_State *l, uint64_t value) { lua_pushinteger(l, value); }
 inline void pi_lua_generic_push(lua_State *l, double value) { lua_pushnumber(l, value); }
 inline void pi_lua_generic_push(lua_State *l, const char *value) { lua_pushstring(l, value); }
 inline void pi_lua_generic_push(lua_State *l, const std::string &value)
@@ -29,10 +29,10 @@ inline void pi_lua_generic_push(lua_State *l, std::string_view &value)
 inline void pi_lua_generic_push(lua_State *l, const std::nullptr_t &value) { lua_pushnil(l); }
 
 inline void pi_lua_generic_pull(lua_State *l, int index, bool &out) { out = lua_toboolean(l, index); }
-inline void pi_lua_generic_pull(lua_State *l, int index, int &out) { out = luaL_checkinteger(l, index); }
+inline void pi_lua_generic_pull(lua_State *l, int index, int32_t &out) { out = luaL_checkinteger(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, int64_t &out) { out = luaL_checkinteger(l, index); }
-inline void pi_lua_generic_pull(lua_State *l, int index, unsigned int &out) { out = luaL_checkunsigned(l, index); }
-inline void pi_lua_generic_pull(lua_State *l, int index, size_t &out) { out = luaL_checkunsigned(l, index); }
+inline void pi_lua_generic_pull(lua_State *l, int index, uint32_t &out) { out = luaL_checkinteger(l, index); }
+inline void pi_lua_generic_pull(lua_State *l, int index, uint64_t &out) { out = luaL_checkinteger(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, float &out) { out = luaL_checknumber(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, double &out) { out = luaL_checknumber(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, const char *&out) { out = luaL_checkstring(l, index); }


### PR DESCRIPTION
- Convert to fixed width types, which work the same way on 32 and 64 bit archs and cover all variable width types such as int and size_t
- Replace deprecated luaL_checkunsigned with luaL_checkinteger

Fixes #5527

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

