### PR TITLE
Update all links to the wiki, to point to new (sub)domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,13 +4,13 @@ contact_links:
     url: https://forum.pioneerspacesim.net/
     about: Feature requests and development discussions go on the forum - not on the issue tracker
   - name: "❓ Pioneer FAQ"
-    url: https://pioneerwiki.com/wiki/FAQ
+    url: https://wiki.pioneerspacesim.net/wiki/FAQ
     about: Others might have had the same question before.
   - name: "ℹ️ Pioneer Manual"
-    url: https://pioneerwiki.com/wiki/Manual
+    url: https://wiki.pioneerspacesim.net/wiki/Manual
     about: Manual for the game
   - name: "🚀 Pioneer Flight Manual"
-    url: https://pioneerwiki.com/wiki/Basic_flight
+    url: https://wiki.pioneerspacesim.net/wiki/Basic_flight
     about: Manual for flying
   - name: "🆘 Get in touch with other players"
     url: https://spacesimcentral.com/community/pioneer/

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -3,12 +3,12 @@
 Contributions are welcome!
 
 The following text assumes you're about to submit a new pull request.
-For _how_ to contribute, please see [wiki](http://pioneerwiki.com/wiki/How_you_can_contribute).
+For _how_ to contribute, please see [contributor documentation](https://dev.pioneerspacesim.net/contribute/).
 
 ### Check before submitting
 
-- Have you read [code style](http://pioneerwiki.com/wiki/Code_style) on the wiki?
-- If new to github, make sure you're not opening this pull request from your _master_ branch, but rather a new [separate branch](http://pioneerwiki.com/wiki/Using_git_and_GitHub#Making_a_pull_request)
+- Have you read [code style](https://dev.pioneerspacesim.net/contribute/coding-conventions) in the development documentation?
+- If new to github, make sure you're not opening this pull request from your _master_ branch, but rather a new [separate branch](https://dev.pioneerspacesim.net/contribute/git-and-github#making-a-pull-request)
 - Have you reviewed your code? Don't trust the developers to do it, as they don't have time to read your code.
 - Do you foresee any potential pitfalls or issues? If so please mention them.
 - If a new feature, then please describe it, possibly with screenshot if something graphical.
@@ -25,8 +25,8 @@ For _how_ to contribute, please see [wiki](http://pioneerwiki.com/wiki/How_you_c
 
 
 ### Consider after submitting
-After a pull request has been submitted, it is more common than not, that the branch keeps being modified, as bugs or issues are raised. If the change is to the latest commit on the branch, use `git add`, followed by `git commit --amend`, followed by a forced push, `git push -f`, to keep commit history clean. See [wiki](http://pioneerwiki.com/wiki/Using_git_and_GitHub) for details on editing/fixing commits.
+After a pull request has been submitted, it is more common than not, that the branch keeps being modified, as bugs or issues are raised. If the change is to the latest commit on the branch, use `git add`, followed by `git commit --amend`, followed by a forced push, `git push -f`, to keep commit history clean. See our [documentation](https://dev.pioneerspacesim.net/contribute/git-and-github) for details on editing/fixing commits.
 
-If you're hungry to contribute more, you'll find some pointers on [How you can contribute](http://pioneerwiki.com/wiki/How_you_can_contribute).
+If you're hungry to contribute more, you'll find some pointers on [How you can contribute](https://wiki.pioneerspacesim.net/wiki/How_you_can_contribute).
 
 Thanks for your contribution!

--- a/Quickstart.txt
+++ b/Quickstart.txt
@@ -78,8 +78,8 @@ corner of the flight view. Right click on your destination to see the radial
 menu,  from which you can instruct your autopilot to "fly to vicinity" or "dock 
 with target". 
 
-If you wish to fly manually, you should see the following wiki page: 
-https://pioneerwiki.com/wiki/How_to_fly_without_autopilot
+If you wish to fly manually, you should see the following wiki page:
+https://wiki.pioneerspacesim.net/wiki/How_to_fly_without_autopilot
 
 Press Escape while in-game (not the main menu) to open the settings screen.
 Here you can change screen res/fullscreen mode, language, controls and other

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Follow Pioneer on Twitter:
   https://twitter.com/pioneerspacesim/
 
 Pioneer wiki
-  http://pioneerwiki.com/wiki/Pioneer_Wiki
+  https://wiki.pioneerspacesim.net
 
 Join the player's forum:
   http://spacesimcentral.com/community/pioneer/
@@ -45,35 +45,35 @@ Join the development forum:
 ## Manual
 
 Manual can be found at:
-  http://pioneerwiki.com/wiki/Manual
+  https://wiki.pioneerspacesim.net/wiki/Manual
 
 Basic flight:
-  https://pioneerwiki.com/wiki/Basic_flight
+  https://wiki.pioneerspacesim.net/wiki/Basic_flight
 
 Keyboard and mouse control is found at:
-  http://pioneerwiki.com/wiki/Keyboard_and_mouse_controls
+  https://wiki.pioneerspacesim.net/wiki/Keyboard_and_mouse_controls
 
 
 ## FAQ
 
 For frequently asked questions, please see
-  http://pioneerwiki.com/wiki/FAQ
+  https://wiki.pioneerspacesim.net/wiki/FAQ
 
 
 ## BUG Reporting
 
-Please see the section of the FAQ pertaining to bugs, crashs and reporting other issues: [Bug Reporting FAQs](http://pioneerwiki.com/wiki/FAQ#How.2Fwhere_do_I_report_my_bug.2Fcrash).
+Please see the section of the FAQ pertaining to bugs, crashs and reporting other issues: [Bug Reporting FAQs](https://wiki.pioneerspacesim.net/wiki/FAQ#How.2Fwhere_do_I_report_my_bug.2Fcrash).
 
 Please do your best to fill out the issue template as completely as possible, especially when you're reporting a crash bug or a graphical issue. Having system information including graphics drivers and the method you used to install Pioneer helps immensely to diagnose and fix these kinds of issues.
 
 ## Contributing
 
 If you are hungry to contribute, more information can be found here:
-  http://pioneerwiki.com/wiki/How_you_can_contribute
+  https://wiki.pioneerspacesim.net/wiki/How_you_can_contribute
 
 If you have a contribution you want to share, and want to learn how to make a
 pull request, see:
-  http://pioneerwiki.com/wiki/Using_git_and_GitHub
+  https://dev.pioneerspacesim.net/contribute/git-and-github
 
 Pioneer development documentation
   https://dev.pioneerspacesim.net/

--- a/doxygen/mainpage.dox
+++ b/doxygen/mainpage.dox
@@ -12,7 +12,7 @@ available after a `make codedoc` or from
 [here](http://eatenbyagrue.org/f/pioneer/codedoc/).
 
 There is important documentation on the
-[wiki](http://pioneerwiki.com/wiki/Pioneer_Wiki) on coding conventions, design,
+[wiki](https://wiki.pioneerspacesim.net/wiki/Pioneer_Wiki) on coding conventions, design,
 development model, how to get started with contributing to the project and more.
 
 _Fly safe_

--- a/metadata/net.pioneerspacesim.Pioneer.appdata.xml
+++ b/metadata/net.pioneerspacesim.Pioneer.appdata.xml
@@ -6,8 +6,8 @@
 	<name>Pioneer</name>
 	<summary>A game of lonely space adventure</summary>
 	<url type="homepage">https://pioneerspacesim.net/</url>
-	<url type="faq">https://pioneerwiki.com/wiki/FAQ</url>
 	<launchable type="desktop-id">net.pioneerspacesim.Pioneer.desktop</launchable>
+	<url type="faq">https://wiki.pioneerspacesim.net/wiki/FAQ</url>
 
 	<description>
 		<p>Pioneer is a space adventure game set in our galaxy at the

--- a/src/lua/LuaServerAgent.cpp
+++ b/src/lua/LuaServerAgent.cpp
@@ -18,7 +18,7 @@
  *
  * This page documents the API only. There are other things that need to be
  * done to enable and use this interface. See
- * http://pioneerwiki.com/wiki/ServerAgent for more information.
+ * https://wiki.pioneerspacesim.net/wiki/ServerAgent for more information.
  */
 
 struct CallbackPair {

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -5,7 +5,7 @@
 #define _SCENEGRAPH_MODEL_H
 /*
  * A new model system with a scene graph based approach.
- * Also see: http://pioneerwiki.com/wiki/New_Model_System
+ * Also see: https://wiki.pioneerspacesim.net/wiki/Model_system
  * Open Asset Import Library (assimp) is used as the mesh loader.
  *
  * Similar systems:


### PR DESCRIPTION
Wiki has moved, we're deprecating old URL.

I've changed some of the wiki links to point to the https://dev.pioneerspacesim.net/ dev docs.

The link in src/scenegraph/Model.h points to a removed wiki page (New Model), I've pointed it to [model system](https://wiki.pioneerspacesim.net/wiki/Model_system) instead. (Is that right?)
