### PR TITLE
Update LuaTable for deprecated std::iterator

### DIFF
--- a/src/lua/LuaTable.h
+++ b/src/lua/LuaTable.h
@@ -186,7 +186,15 @@ public:
 	 * not leak anything.
 	 */
 	template <class Value>
-	class VecIter : public std::iterator<std::input_iterator_tag, Value> {
+	class VecIter {
+	public:
+		// iterator category defines
+		using difference_type = std::ptrdiff_t;
+		using value_type = Value;
+		using pointer = Value *;
+		using reference = Value &;
+		using iterator_category = std::input_iterator_tag;
+
 	public:
 		VecIter() :
 			m_table(0),


### PR DESCRIPTION
This PR provides typedefs suitable for `std::iterator_traits` in lieu of using the deprecated `std::iterator` class (which only provided those typedefs anyways).

CC @laarmen.