### PR TITLE
Fix + nerf metal creaking sfx

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -315,8 +315,9 @@ void Player::StaticUpdate(const float timeStep)
 	m_atmosJerk = (current_atmosAccel - m_atmosAccel) * Pi::game->GetInvTimeAccelRate();
 	bool playCreak = false;
 
-	// no metal creaking sfx if accel is lower than 30 m s-2 (around 3g)
-	if (m_atmosAccel.Length() > 30 && m_atmosJerk.Length() > 50) {
+	// play creaking sfx if the acceleration along the Y axis (up/down directions) is higher than 1g
+	// and the rate of change of acceleration is more than 2.5 m s-3 
+	if ((abs(m_atmosAccel.Dot(Player::m_interpOrient.VectorY()))) > 10 && abs(m_atmosJerk.Dot(Player::m_interpOrient.VectorY())) > 2.5) {
 		playCreak = true;
 	}
 
@@ -327,7 +328,7 @@ void Player::StaticUpdate(const float timeStep)
 			m_creakSound.VolumeAnimate(creakVol, creakVol, 0.3f, 0.3f);
 		}
 	} else if (m_creakSound.IsPlaying()) {
-		m_creakSound.VolumeAnimate(0.0f, 0.0f, 0.75f, 0.75f);
+		m_creakSound.VolumeAnimate(0.0f, 0.0f, 1.5f, 1.5f);
 		m_creakSound.SetOp(Sound::OP_STOP_AT_TARGET_VOLUME);
 	}
 	m_atmosAccel = current_atmosAccel;

--- a/src/Player.h
+++ b/src/Player.h
@@ -62,8 +62,8 @@ protected:
 private:
 	std::unique_ptr<ShipCockpit> m_cockpit;
 	Sound::Event m_creakSound;
-	vector3d m_accel;
-	vector3d m_jerk[20] = { vector3d(0.0, 0.0, 0.0) };
+	vector3d m_atmosAccel;
+	vector3d m_atmosJerk;
 };
 
 #endif /* _PLAYER_H */


### PR DESCRIPTION
So the reason this squeaky metal sound has been mistriggering was _probably_ (keyword: probably) that I used GetLastForce() which includes the gravity force, which is a body force and shouldn't be added to the metal strain calculation. Also I got rid of the array of 20 last jerk values because that was a safeguard against single-frame thruster spikes of the autopilot and flight assist. Now that we only use atmospheric acceleration, it should no longer be needed.

In addition, I made the triggering acceleration limits quite higher and the volume lower.

Needs playtesting and a sanity check from someone other than me.