### PR TITLE
Clear autopilot before hyperjumping

### DIFF
--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1502,7 +1502,7 @@ void Ship::EnterHyperspace()
 			SetFlightState(FLYING);
 		return;
 	}
-
+	AIClearInstructions();
 	SetFlightState(Ship::HYPERSPACE);
 
 	// virtual call, do class-specific things


### PR DESCRIPTION
Autopilot objects can store dangling pointers to bodies from the previous system. After arriving to a new system, this may lead to a crash.

Fixes #5242
Fixes #5258
Fixes #5443 
Fixes #5554

4 issues with 1 line! Yay!

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

