### PR TITLE
Prevent zero length direction vector

### DIFF
--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -1203,7 +1203,11 @@ bool AICmdFlyTo::TimeStepUpdate()
 	// then flip the ship so we can use our main thrusters to decelerate
 	if (m_state && !is_zero_exact(sdiff) && sdiff < maxdecel * timestep * 60) head = -head;
 	if (!m_state && decel) sidefactor = -sidefactor;
-	head = head * maxdecel + perpdir * sidefactor;
+
+	// check that head does not become zero length
+	if (maxdecel > 0.001 || abs(sidefactor) > 0.001) {
+		head = head * maxdecel + perpdir * sidefactor;
+	}
 
 	// face appropriate direction
 	if (m_state >= 3) {


### PR DESCRIPTION
Approximately once every one and a half in-game years (for the Sol system), the following state may occur:

  - some ship is directed towards the planet
  - it has AICmdFlyTo command active
  - its target is on course
  - gravity, respectively, is directed along the the ship, and accelerates it
  - its reverse thrusters are _weaker than gravity_
  - it has zero speed

The combination of these circumstances leads to the fact that both coefficients in the calculation of the head vector are equal to 0. A vector of zero length is passed to Propulsion, where it is normalized and SIGFPE occurs.

Fixes #5516

It would be nice to do a thorough reworking of the autopilot here. For example, to ban ships from flying and stopping with their nose down in gravity, it looks strange. @azieba you worked next to this code not so long ago, I would like to know if you have any plans here?

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

