### PR TITLE
Fix out-of-bounds index uncovered by -D_GLIBCXX_ASSERTIONS

### DIFF
--- a/src/core/Property.cpp
+++ b/src/core/Property.cpp
@@ -115,7 +115,7 @@ PropertyMap::iterator PropertyMap::iterator::operator++()
 {
 	size_t sz = map->m_keys.size();
 	if (map && sz > idx)
-		while (!map->m_keys[++idx] && idx < sz) {
+		while (++idx < sz && !map->m_keys[idx]) {
 		}
 	return *this;
 }


### PR DESCRIPTION
Flatpak and Fedora packages are built with this flag, and it was causing a crash on save. Also [encountered by manolollr](https://github.com/pioneerspacesim/pioneer/issues/5387#issuecomment-1172784841) in #5387.

