### PR TITLE
Include ad title in bulletin board search

### DIFF
--- a/data/pigui/modules/station-view/02-bulletinBoard.lua
+++ b/data/pigui/modules/station-view/02-bulletinBoard.lua
@@ -55,12 +55,12 @@ local function refresh()
 	bulletinBoard.items = {}
 
 	for ref,ad in pairs(ads or {}) do
-		if searchText == ""
-			or searchText ~= "" and string.find(
+		if not searchText or searchText == ""
+			or string.find(
 				string.lower(ad.title),
 				string.lower(searchText),
 				1, true)
-			or searchText ~= "" and string.find(
+			or string.find(
 				string.lower(ad.description),
 				string.lower(searchText),
 				1, true)

--- a/data/pigui/modules/station-view/02-bulletinBoard.lua
+++ b/data/pigui/modules/station-view/02-bulletinBoard.lua
@@ -57,6 +57,10 @@ local function refresh()
 	for ref,ad in pairs(ads or {}) do
 		if searchText == ""
 			or searchText ~= "" and string.find(
+				string.lower(ad.title),
+				string.lower(searchText),
+				1, true)
+			or searchText ~= "" and string.find(
 				string.lower(ad.description),
 				string.lower(searchText),
 				1, true)


### PR DESCRIPTION
Include ad title in search on the bulletin board.

Motivation: I just found it more practical/correct after interpreting an earlier search result as a wee bit odd.
