### PR TITLE
Mouseover messages for the ECM and the Advanced ECM systems

### DIFF
--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -151,6 +151,10 @@
     "description": "",
     "message": "An electronic countermeasure missile defence system, capable of destroying some homing missiles."
   },
+  "ECM_HOVER_MESSAGE": {
+    "description": "",
+    "message": "Activate Electronic Countermeasures"
+  },
   "EMPTY_SLOT": {
     "description": "Text indicating an empty equipment slot.",
     "message": "EMPTY"

--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -78,12 +78,14 @@ misc.heavy_atmospheric_shielding = EquipType.New({
 misc.ecm_basic = EquipType.New({
 	l10n_key="ECM_BASIC", slots="ecm", price=6000,
 	capabilities={mass=2, ecm_power=2, ecm_recharge=5},
-	purchasable=true, tech_level=9, ecm_type = 'ecm'
+	purchasable=true, tech_level=9, ecm_type = 'ecm',
+	hover_message="ECM_HOVER_MESSAGE"
 })
 misc.ecm_advanced = EquipType.New({
 	l10n_key="ECM_ADVANCED", slots="ecm", price=15200,
 	capabilities={mass=2, ecm_power=3, ecm_recharge=5},
-	purchasable=true, tech_level="MILITARY", ecm_type = 'ecm_advanced'
+	purchasable=true, tech_level="MILITARY", ecm_type = 'ecm_advanced',
+	hover_message="ECM_HOVER_MESSAGE"
 })
 misc.radar = EquipType.New({
 	l10n_key="RADAR", slots="radar", price=680,

--- a/data/pigui/modules/equipment.lua
+++ b/data/pigui/modules/equipment.lua
@@ -62,7 +62,7 @@ local function displayECM(uiPos)
 	if current_view == "world" then
 		local ecms = player:GetEquip('ecm')
 		for i,ecm in ipairs(ecms) do
-			local size, clicked = iconEqButton(uiPos, icons[ecm.ecm_type], false, mainIconSize, "ECM", not player:IsECMReady(), mainBackgroundColor, mainForegroundColor, mainHoverColor, mainPressedColor, 'ECM')
+			local size, clicked = iconEqButton(uiPos, icons[ecm.ecm_type], false, mainIconSize, "ECM", not player:IsECMReady(), mainBackgroundColor, mainForegroundColor, mainHoverColor, mainPressedColor, lec[ecm.hover_message])
 			uiPos.y = uiPos.y + size.y + 10
 			if clicked then
 				player:UseECM()


### PR DESCRIPTION
Implement hover over messages for the ECM and ECM Advanced.


![ecm3](https://github.com/pioneerspacesim/pioneer/assets/6368949/f4535a25-b6a9-420a-b408-2999e9ffb848)

 * The message is just `Electronic countermeassure` and `Advanced electronic countermeassure`. This harmonizes with the messages for the missiles above which just state the missile types.
 * The hover over message for the missiles capitalize the first letters on all words and this PR doesn't. Which one is preferred?

![ecm1](https://github.com/pioneerspacesim/pioneer/assets/6368949/1a771a13-095a-42db-a127-d4824ae1a812)




Fixes https://github.com/pioneerspacesim/pioneer/issues/5215