### PR TITLE
Fix issue on quitting Lua console

### DIFF
--- a/src/lua/LuaConsole.cpp
+++ b/src/lua/LuaConsole.cpp
@@ -69,7 +69,7 @@ REGISTER_INPUT_BINDING(LuaConsole)
 void LuaConsole::SetupBindings()
 {
 	toggleLuaConsole = m_inputFrame.AddAction("BindToggleLuaConsole");
-	toggleLuaConsole->onPressed.connect(sigc::mem_fun(this, &LuaConsole::Toggle));
+	toggleLuaConsole->onReleased.connect(sigc::mem_fun(this, &LuaConsole::Toggle));
 	Pi::input->AddInputFrame(&m_inputFrame);
 }
 

--- a/src/lua/LuaConsole.cpp
+++ b/src/lua/LuaConsole.cpp
@@ -205,7 +205,7 @@ void LuaConsole::Draw()
 		ImGui::EndChild();
 		ImGui::Separator();
 
-		if (ImGui::IsKeyPressed(SDL_GetScancodeFromKey(SDLK_ESCAPE)))
+		if (ImGui::IsKeyReleased(SDL_GetScancodeFromKey(SDLK_ESCAPE)))
 			Toggle();
 
 		ImGui::SetNextItemWidth(ImGui::GetColumnWidth());


### PR DESCRIPTION
Fixes https://github.com/pioneerspacesim/pioneer/issues/5287, fixes #5598.

Escaping out of the Lua console on keypress created issues since the key was then released in another window and escape key release action performed. Fixed by exiting Lua console on escape key release instead of press.