### PR TITLE
Fuel scooping rework

### DIFF
--- a/data/modules/FuelScoop.lua
+++ b/data/modules/FuelScoop.lua
@@ -12,11 +12,11 @@ local lc = Lang.GetResource("core")
 -- These callbacks are triggered from C++ or Lua and are responsible for
 -- providing UI feedback about the scooping process.
 
-Event.Register("onShipScoopFuel", function(ship, body)
+Event.Register("onShipScoopFuel", function(ship, body, amount)
 	---@type CargoManager
 	local cargoMgr = ship:GetComponent('CargoManager')
 
-	cargoMgr:AddCommodity(Commodities.hydrogen, 1)
+	cargoMgr:AddCommodity(Commodities.hydrogen, amount)
 
 	if ship == Game.player then
 		Game.AddCommsLogLine(lc.FUEL_SCOOP_ACTIVE_N_TONNES_H_COLLECTED:gsub('%%quantity',

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1258,8 +1258,11 @@ void Ship::StaticUpdate(const float timeStep)
 				const double dot = vdir.Dot(pdir);
 				if ((m_stats.free_capacity) && (dot > 0.90) && (speed > 100.0) && (density > 0.3)) {
 					const double rate = speed * density * 0.00000333 * double(m_stats.fuel_scoop_cap);
-					if (Pi::rng.Double() < rate) {
-						LuaEvent::Queue("onShipScoopFuel", this, p);
+					m_hydrogenScoopedAccumulator += rate * Pi::game->GetTimeAccelRate();
+					if (m_hydrogenScoopedAccumulator > 1) {
+						const double scoopedTons = floor(m_hydrogenScoopedAccumulator);
+						LuaEvent::Queue("onShipScoopFuel", this, p, scoopedTons);
+						m_hydrogenScoopedAccumulator -= scoopedTons;
 					}
 				}
 			}

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1265,10 +1265,10 @@ void Ship::StaticUpdate(const float timeStep)
 				 *
 				 * fuel_scoop_cap = area, m^2. rate = kg^2/(m*s^3) = (Pa*kg)/s^2
 				 */
-				const double hydrogen_density = 0.00000333;
+				const double hydrogen_density = 0.0002;
 				if ((m_stats.free_capacity) && (dot > 0.90) && speed_times_density > (100.0 * 0.3)) {
 					const double rate = speed_times_density * hydrogen_density * double(m_stats.fuel_scoop_cap);
-					m_hydrogenScoopedAccumulator += rate * Pi::game->GetTimeAccelRate();
+					m_hydrogenScoopedAccumulator += rate * timeStep;
 					if (m_hydrogenScoopedAccumulator > 1) {
 						const double scoopedTons = floor(m_hydrogenScoopedAccumulator);
 						LuaEvent::Queue("onShipScoopFuel", this, p, scoopedTons);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1257,9 +1257,17 @@ void Ship::StaticUpdate(const float timeStep)
 				const vector3d pdir = -GetOrient().VectorZ();
 				const double dot = vdir.Dot(pdir);
 				const double speed_times_density = speed * density;
-				// reference: speed > 100.0, density > 0.3
+				/*
+				 * speed = m/s, density = g/cm^3 -> T/m^3, pressure = Pa -> N/m^2 -> kg/(m*s^2)
+				 * m    T      kg         m*kg^2           kg^2
+				 * - * --- * ----- = 1000 ------- = 1000 -------
+				 * s   m^3   m*s^2        m^4*s^3        m^3*s^3
+				 *
+				 * fuel_scoop_cap = area, m^2. rate = kg^2/(m*s^3) = (Pa*kg)/s^2
+				 */
+				const double hydrogen_density = 0.00000333;
 				if ((m_stats.free_capacity) && (dot > 0.90) && speed_times_density > (100.0 * 0.3)) {
-					const double rate = speed_times_density * 0.00000333 * double(m_stats.fuel_scoop_cap);
+					const double rate = speed_times_density * hydrogen_density * double(m_stats.fuel_scoop_cap);
 					m_hydrogenScoopedAccumulator += rate * Pi::game->GetTimeAccelRate();
 					if (m_hydrogenScoopedAccumulator > 1) {
 						const double scoopedTons = floor(m_hydrogenScoopedAccumulator);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1256,8 +1256,10 @@ void Ship::StaticUpdate(const float timeStep)
 				const vector3d vdir = GetVelocity().Normalized();
 				const vector3d pdir = -GetOrient().VectorZ();
 				const double dot = vdir.Dot(pdir);
-				if ((m_stats.free_capacity) && (dot > 0.90) && (speed > 100.0) && (density > 0.3)) {
-					const double rate = speed * density * 0.00000333 * double(m_stats.fuel_scoop_cap);
+				const double speed_times_density = speed * density;
+				// reference: speed > 100.0, density > 0.3
+				if ((m_stats.free_capacity) && (dot > 0.90) && speed_times_density > (100.0 * 0.3)) {
+					const double rate = speed_times_density * 0.00000333 * double(m_stats.fuel_scoop_cap);
 					m_hydrogenScoopedAccumulator += rate * Pi::game->GetTimeAccelRate();
 					if (m_hydrogenScoopedAccumulator > 1) {
 						const double scoopedTons = floor(m_hydrogenScoopedAccumulator);

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -330,6 +330,8 @@ private:
 
 	std::string m_shipName;
 
+	double m_hydrogenScoopedAccumulator = 0;
+
 public:
 	// FIXME: these methods are deprecated; all calls should use the propulsion object directly.
 	void ClearAngThrusterState() { m_propulsion->ClearAngThrusterState(); }


### PR DESCRIPTION
Fuel scooping was:

1) based on random numbers
2) not aware of time acceleration
3) inefficient if rate was too high (which is still unlikely to happen without time acceleration)
4) not working properly (see https://github.com/pioneerspacesim/pioneer/issues/5237)

Instead of this, I suggest:
1) accumulate hydrogen at rate based on speed and pressure
2) replace strict speed/pressure requirement (I think it's likely being able to scoop even at sparse atmospheres even when flying fast enough)