### PR TITLE
Disable runtime floating point exceptions

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -870,6 +870,12 @@ static void OnPlayerDockOrUndock();
 void GameLoop::Start()
 {
 	PROFILE_SCOPED()
+
+	// NOTE: this is here because Clang 15+ and GCC 13+ ignore fp-model when
+	// generating vectorized/optimized code and will happily perform exception-
+	// raising operations on the contents of uninitialized or aliased memory
+	OS::DisableFPE();
+
 	// this is a bit brittle. skank may be forgotten and survive between
 	// games
 	Pi::input->InitGame();

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -494,9 +494,7 @@ void PlayerShipController::StaticUpdate(const float timeStep)
 {
 	// call autopilot AI, if active
 	if (m_ship->AIIsActive()) {
-		OS::EnableFPE();
 		m_ship->AITimeStep(timeStep);
-		OS::DisableFPE();
 		// the speed limiter should not work when the autopilot is working
 		if (IsSpeedLimiterActive()) SetSpeedLimiterActive(false);
 		return;

--- a/src/ship/ShipController.cpp
+++ b/src/ship/ShipController.cpp
@@ -7,7 +7,5 @@
 
 void ShipController::StaticUpdate(float timeStep)
 {
-	OS::EnableFPE();
 	m_ship->AITimeStep(timeStep);
-	OS::DisableFPE();
 }


### PR DESCRIPTION
Clang 15+ / GCC 13+ leave us no choice but to disable floating point exceptions. Their auto-vectorization optimizations load invalid values and will cause FPEs even when fp-strict is enabled.

Reference #5601.

@d3rp please confirm this PR fixes the issue on GCC 13.