### PR TITLE
Editor Binary and Prerequisites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,8 @@ if (WIN32)
 	list(APPEND winLibs shlwapi psapi)
 endif (WIN32)
 
+add_subdirectory(src/editor)
+
 target_link_libraries(${PROJECT_NAME} LINK_PRIVATE ${pioneerLibs} ${winLibs})
 target_link_libraries(unittest LINK_PRIVATE ${pioneerLibs} ${winLibs})
 target_link_libraries(modelcompiler LINK_PRIVATE ${pioneerLibs} ${winLibs})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 project(pioneer LANGUAGES CXX)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_CXX_STANDARD 17)
 
 # If both libGL.so and libOpenGL.so are found, default to the latter
 # (former is a legacy name).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,7 +400,7 @@ else (MODELCOMPILER)
 	message(WARNING "No modelcompiler provided, models won't be optimized!")
 endif(MODELCOMPILER)
 
-install(TARGETS ${PROJECT_NAME} modelcompiler savegamedump
+install(TARGETS ${PROJECT_NAME} editor modelcompiler savegamedump
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(DIRECTORY data/

--- a/Modelviewer.txt
+++ b/Modelviewer.txt
@@ -2,20 +2,20 @@
 		~~~~~~~~~~~~
 
 This is a simple tool to view a game model using the game's rendering engine.
-It's main purpose is to test and debug models, and generally isn't for 
+It's main purpose is to test and debug models, and generally isn't for
 end-user use.
 
 Usage:
 ~~~~~~
-pioneer -mv <model>
+editor -mv <model>
 
 <model>		- name of the model defined in lua
 
 	Example:
-	./pioneer -mv interdictor
+	./editor -mv interdictor
 		- will load the model interdictor
 
-	./pioneer -mv
+	./editor -mv
 		- will launch modelviewer, prompting for a model name.
 
 Keyboard commands:

--- a/scripts/build-travis.sh
+++ b/scripts/build-travis.sh
@@ -2,7 +2,7 @@
 
 # Package a build and prepare it for upload via Travis.
 
-BINARIES=("build/pioneer" "build/modelcompiler" "build/savegamedump")
+BINARIES=("build/pioneer" "build/modelcompiler" "build/savegamedump" "build/editor")
 COPY_DIR=release
 
 # Append .exe to the binaries if we're building for windows.

--- a/src/ModelViewer.cpp
+++ b/src/ModelViewer.cpp
@@ -85,9 +85,8 @@ namespace ImGui {
 	}
 } // namespace ImGui
 
-void ModelViewerApp::Startup()
+void ModelViewerApp::OnStartup()
 {
-	Application::Startup();
 	Log::GetLog()->SetLogFile("output.txt");
 
 	std::unique_ptr<IniConfig> config(new IniConfig);
@@ -123,7 +122,7 @@ void ModelViewerApp::Startup()
 	QueueLifecycle(m_modelViewer);
 }
 
-void ModelViewerApp::Shutdown()
+void ModelViewerApp::OnShutdown()
 {
 	//uninit components
 	m_modelViewer.Reset();
@@ -135,7 +134,6 @@ void ModelViewerApp::Shutdown()
 	ShutdownPiGui();
 	ShutdownRenderer();
 	ShutdownInput();
-	Application::Shutdown();
 }
 
 void ModelViewerApp::PreUpdate()

--- a/src/ModelViewer.h
+++ b/src/ModelViewer.h
@@ -30,8 +30,8 @@ public:
 	std::string &GetModelName() { return m_modelName; }
 
 protected:
-	void Startup() override;
-	void Shutdown() override;
+	void OnStartup() override;
+	void OnShutdown() override;
 
 	void PreUpdate() override;
 	void PostUpdate() override;

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -260,6 +260,8 @@ void Pi::Init(const std::map<std::string, std::string> &options, bool no_gui)
 	GetApp()->m_gameLoop.Reset(new GameLoop());
 
 	m_instance->m_noGui = no_gui;
+
+	m_instance->Startup();
 }
 
 void Pi::App::SetStartPath(const SystemPath &startPath)
@@ -306,21 +308,13 @@ void TestGPUJobsSupport()
 	}
 }
 
-void Pi::App::Startup()
+void Pi::App::OnStartup()
 {
 	PROFILE_SCOPED()
 	Profiler::Clock startupTimer;
 	startupTimer.Start();
 
-	Application::Startup();
-
-	SetProfilerPath("profiler/");
-	SetProfileSlowFrames(config->Int("ProfileSlowFrames", 0));
-	bool profileZones = config->Int("ProfilerZoneOutput", 0);
-	bool profileTraces = config->Int("ProfilerTraceOutput", 0);
-
-	SetProfileZones(profileZones || profileTraces);
-	SetProfileTrace(profileTraces);
+	SetupProfiler(Pi::config);
 
 	Log::GetLog()->SetLogFile("output.txt");
 
@@ -411,7 +405,7 @@ void Pi::App::Startup()
 */
 
 // Immediately destroy everything and end the game.
-void Pi::App::Shutdown()
+void Pi::App::OnShutdown()
 {
 	PROFILE_SCOPED()
 	Output("Pi shutting down.\n");
@@ -460,8 +454,11 @@ void Pi::App::Shutdown()
 
 	delete Pi::config;
 	delete Pi::planner;
+}
 
-	Application::Shutdown();
+void Pi::Uninit()
+{
+	m_instance->Shutdown();
 
 	SDL_Quit();
 	delete Pi::m_instance;

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -97,8 +97,8 @@ public:
 		App() :
 			GuiApplication("Pioneer") {}
 
-		void Startup() override;
-		void Shutdown() override;
+		void OnStartup() override;
+		void OnShutdown() override;
 
 		void PreUpdate() override;
 		void PostUpdate() override;
@@ -126,6 +126,7 @@ public:
 
 public:
 	static void Init(const std::map<std::string, std::string> &options, bool no_gui = false);
+	static void Uninit();
 
 	static void StartGame(Game *game);
 

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -47,10 +47,14 @@ void Application::Startup()
 #endif
 
 	SDL_Init(SDL_INIT_EVENTS);
+
+	OnStartup();
 }
 
 void Application::Shutdown()
 {
+	OnShutdown();
+
 	m_taskGraph.reset();
 	m_syncJobQueue.reset();
 
@@ -157,18 +161,16 @@ void Application::HandleJobs()
 
 void Application::Run()
 {
-	Profiler::Clock m_runtime{};
-	m_runtime.Start();
-	m_applicationRunning = true;
-
-	Startup();
-
 	if (!m_queuedLifecycles.size())
 		throw std::runtime_error("Application::Run must have a queued lifecycle object (did you forget to queue one?)");
 
 	// SoftStop updates the elapsed time measured by the clock, and continues to run the clock.
+	Profiler::Clock m_runtime{};
+	m_runtime.Start();
 	m_runtime.SoftStop();
 	m_totalTime = m_runtime.seconds();
+
+	m_applicationRunning = true;
 	while (m_applicationRunning) {
 		m_runtime.SoftStop();
 		double thisTime = m_runtime.seconds();
@@ -231,6 +233,4 @@ void Application::Run()
 			Profiler::reset();
 #endif
 	}
-
-	Shutdown();
 }

--- a/src/core/Application.h
+++ b/src/core/Application.h
@@ -69,8 +69,14 @@ public:
 	// Use this function very sparingly (e.g. when the application is shutting down)
 	void ClearQueuedLifecycles();
 
+	// Perform initialization tasks at program startup
+	void Startup();
+
 	// Runs the application as long as there is a valid lifecycle object
 	void Run();
+
+	// Perform deinitialization tasks at program termination
+	void Shutdown();
 
 	// Get the time between the start of the last update and the current one
 	float DeltaTime() { return m_deltaTime; }
@@ -88,10 +94,10 @@ protected:
 	// Hooks for inheriting classes to add their own behaviors to.
 
 	// Runs before the main loop begins
-	virtual void Startup();
+	virtual void OnStartup() {}
 
 	// Runs after the main loop ends
-	virtual void Shutdown();
+	virtual void OnShutdown() {}
 
 	// Handle running pinned tasks and processing queued jobs
 	virtual void HandleJobs();

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -169,6 +169,19 @@ void GuiApplication::HandleEvents()
 	DispatchEvents();
 }
 
+void GuiApplication::SetupProfiler(IniConfig *config)
+{
+	// Setup common profiling parameters from the config file
+	bool profileSlow   = config->Int("ProfileSlowFrames", 0);
+	bool profileZones  = config->Int("ProfilerZoneOutput", 0);
+	bool profileTraces = config->Int("ProfilerTraceOutput", 0);
+
+	SetProfilerPath("profiler/");
+	SetProfileSlowFrames(profileSlow);
+	SetProfileZones(profileZones || profileTraces);
+	SetProfileTrace(profileTraces);
+}
+
 Graphics::Renderer *GuiApplication::StartupRenderer(IniConfig *config, bool hidden)
 {
 	PROFILE_SCOPED()

--- a/src/core/GuiApplication.h
+++ b/src/core/GuiApplication.h
@@ -32,23 +32,26 @@ protected:
 	// framebuffer
 	void DrawRenderTarget();
 
+	// Call this from your OnStartup() method
+	void SetupProfiler(IniConfig *config);
+
 	// TODO: unify config handling, possibly make the config an Application member
-	// Call this from your Startup() method
+	// Call this from your OnStartup() method
 	Graphics::Renderer *StartupRenderer(IniConfig *config, bool hidden = false);
 
-	// Call this from your Startup() method
+	// Call this from your OnStartup() method
 	Input::Manager *StartupInput(IniConfig *config);
 
-	// Call this from your Startup() method
+	// Call this from your OnStartup() method
 	PiGui::Instance *StartupPiGui();
 
-	// Call this from your Shutdown() method
+	// Call this from your OnShutdown() method
 	void ShutdownRenderer();
 
-	// Call this from your Shutdown() method
+	// Call this from your OnShutdown() method
 	void ShutdownInput();
 
-	// Call this from your shutdown() method
+	// Call this from your OnShutdown() method
 	void ShutdownPiGui();
 
 	// Hook to bind the RT and clear the screen.

--- a/src/editor/CMakeLists.txt
+++ b/src/editor/CMakeLists.txt
@@ -25,5 +25,6 @@ list(APPEND EDITOR_LIBRARIES
 )
 
 add_executable(editor WIN32 editormain.cpp ${RESOURCES})
+set_cxx_properties(editor)
 target_link_libraries(editor LINK_PRIVATE ${EDITOR_LIBRARIES} ${pioneerLibs} ${winLibs})
 set_target_properties(editor PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/src/editor/CMakeLists.txt
+++ b/src/editor/CMakeLists.txt
@@ -1,0 +1,29 @@
+
+list(APPEND EDITOR_SRC_FOLDERS
+	${CMAKE_CURRENT_SOURCE_DIR}
+	mfd/
+)
+
+# Creates variables EDITOR_CXX_FILES and EDITOR_HXX_FILES
+add_source_folders(EDITOR EDITOR_SRC_FOLDERS)
+
+list(REMOVE_ITEM EDITOR_CXX_FILES
+	editormain.cpp
+)
+
+# Creates a library, adds it to the build, and sets C++ target properties on it
+define_pioneer_library(pioneer-editor EDITOR_CXX_FILES EDITOR_HXX_FILES)
+target_include_directories(pioneer-editor PRIVATE ${CMAKE_BINARY_DIR})
+target_link_libraries(pioneer-editor LINK_PRIVATE
+	pioneer-core
+	pioneer-lib
+)
+
+list(APPEND EDITOR_LIBRARIES
+	pioneer-editor
+	pioneer-core
+)
+
+add_executable(editor WIN32 editormain.cpp ${RESOURCES})
+target_link_libraries(editor LINK_PRIVATE ${EDITOR_LIBRARIES} ${pioneerLibs} ${winLibs})
+set_target_properties(editor PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/src/editor/EditorApp.cpp
+++ b/src/editor/EditorApp.cpp
@@ -11,6 +11,7 @@
 
 #include "argh/argh.h"
 #include "core/IniConfig.h"
+#include "core/OS.h"
 #include "graphics/Graphics.h"
 #include "lua/Lua.h"
 #include "graphics/opengl/RendererGL.h"
@@ -79,6 +80,11 @@ void EditorApp::OnStartup()
 	Lua::Init();
 
 	ModManager::Init();
+
+	// get threads up
+	Uint32 numThreads = cfg.Int("WorkerThreads");
+	numThreads = numThreads ? numThreads : std::max(OS::GetNumCores() - 1, 1U);
+	GetTaskGraph()->SetWorkerThreads(numThreads);
 
 	Graphics::RendererOGL::RegisterRenderer();
 

--- a/src/editor/EditorApp.cpp
+++ b/src/editor/EditorApp.cpp
@@ -1,0 +1,151 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "EditorApp.h"
+
+#include "EditorDraw.h"
+
+#include "FileSystem.h"
+#include "ModManager.h"
+#include "core/IniConfig.h"
+#include "graphics/Graphics.h"
+#include "lua/Lua.h"
+#include "graphics/opengl/RendererGL.h"
+
+using namespace Editor;
+
+EditorApp::EditorApp() :
+	GuiApplication("Pioneer Editor")
+{
+}
+
+EditorApp::~EditorApp()
+{
+}
+
+EditorApp *EditorApp::Get()
+{
+	static EditorApp app = EditorApp();
+	return &app;
+}
+
+void EditorApp::Initialize(argh::parser &cmdline)
+{
+	// Load / register editor modules and frames here
+}
+
+void EditorApp::AddLoadingTask(TaskSet::Handle handle)
+{
+	m_loadingTasks.emplace_back(std::move(handle));
+}
+
+void EditorApp::OnStartup()
+{
+	Log::GetLog()->SetLogFile("editor.txt");
+
+	IniConfig cfg;
+	cfg.SetInt("ScrWidth", 1600);
+	cfg.SetInt("ScrHeight", 900);
+	cfg.SetInt("VSync", 1);
+	cfg.SetInt("AntiAliasingMode", 4);
+
+	cfg.Read(FileSystem::userFiles, "editor.ini");
+	cfg.Save(); // write defaults if the file doesn't exist
+
+	Lua::Init();
+
+	ModManager::Init();
+
+	Graphics::RendererOGL::RegisterRenderer();
+
+	m_renderer = StartupRenderer(&cfg);
+	StartupInput(&cfg);
+
+	StartupPiGui();
+
+	// precache the editor font
+	GetPiGui()->GetFont("pionillium", 13);
+	GetPiGui()->SetDebugStyle();
+
+	RefCountedPtr<LoadingPhase> loader (new LoadingPhase(this));
+	QueueLifecycle(loader);
+}
+
+void EditorApp::OnShutdown()
+{
+	Lua::Uninit();
+	Graphics::Uninit();
+
+	ShutdownPiGui();
+	ShutdownRenderer();
+	ShutdownInput();
+}
+
+void EditorApp::PreUpdate()
+{
+	HandleEvents();
+	GetPiGui()->NewFrame();
+}
+
+void EditorApp::PostUpdate()
+{
+	GetRenderer()->ClearDepthBuffer();
+	GetPiGui()->Render();
+
+	if (GetInput()->IsKeyReleased(SDLK_F11)) {
+		GetRenderer()->FlushCommandBuffers();
+		GetRenderer()->ReloadShaders();
+	}
+}
+
+// ============================================================================
+//  Loading Phase
+// ============================================================================
+
+void LoadingPhase::Update(float dt)
+{
+	constexpr const char *loadingMessage = "Loading...";
+
+	const ImVec2 winSize = { float(Graphics::GetScreenWidth()), float(Graphics::GetScreenHeight()) };
+	const ImVec2 textSize = ImGui::CalcTextSize(loadingMessage);
+
+	ImGui::SetNextWindowBgAlpha(0.0);
+	ImGui::SetNextWindowPos({ 0.f, 0.f }, ImGuiCond_Always);
+	ImGui::SetNextWindowSize(winSize, ImGuiCond_Always);
+
+	ImGui::Begin("##fullscreen", NULL,
+		ImGuiWindowFlags_NoSavedSettings |
+		ImGuiWindowFlags_NoDecoration |
+		ImGuiWindowFlags_NoInputs);
+
+	// Animate the loading screen text while we wait
+	ImColor col(1.f, 1.f, 1.f, cosf(m_app->GetTime() * 4.f));
+	ImGui::PushStyleColor(ImGuiCol_Text, (ImU32) col);
+
+	ImGui::SetCursorScreenPos((winSize - textSize) / 2.0);
+	ImGui::TextUnformatted(loadingMessage);
+
+	ImGui::PopStyleColor(1);
+
+	ImGui::End();
+
+	// ==========================================
+
+	std::vector<TaskSet::Handle> &runningTasks = m_app->GetLoadingTasks();
+
+	// Iterate all currently pending loading tasks and check for completion
+	auto iter = runningTasks.begin();
+	while (iter != runningTasks.end()) {
+		if (iter->IsComplete()) {
+			m_app->GetTaskGraph()->CompleteTaskSet(*iter);
+			iter = runningTasks.erase(iter);
+		} else {
+			++iter;
+		}
+	}
+
+	// Once all tasks are completed, we can end the loading screen
+	if (runningTasks.size() == 0 && m_app->GetTime() >= minRuntime) {
+		RequestEndLifecycle();
+	}
+}

--- a/src/editor/EditorApp.cpp
+++ b/src/editor/EditorApp.cpp
@@ -15,6 +15,8 @@
 #include "lua/Lua.h"
 #include "graphics/opengl/RendererGL.h"
 
+#include "SDL_keycode.h"
+
 using namespace Editor;
 
 EditorApp::EditorApp() :
@@ -46,6 +48,7 @@ void EditorApp::Initialize(argh::parser &cmdline)
 			modelViewer->SetModel(modelName);
 
 		QueueLifecycle(modelViewer);
+		SetAppName("ModelViewer");
 		return;
 	}
 }
@@ -53,6 +56,11 @@ void EditorApp::Initialize(argh::parser &cmdline)
 void EditorApp::AddLoadingTask(TaskSet::Handle handle)
 {
 	m_loadingTasks.emplace_back(std::move(handle));
+}
+
+void EditorApp::SetAppName(std::string_view name)
+{
+	m_appName = name;
 }
 
 void EditorApp::OnStartup()
@@ -111,6 +119,13 @@ void EditorApp::PostUpdate()
 	if (GetInput()->IsKeyReleased(SDLK_F11)) {
 		GetRenderer()->FlushCommandBuffers();
 		GetRenderer()->ReloadShaders();
+	}
+
+	bool ctrl = GetInput()->IsKeyDown(SDLK_LCTRL) || GetInput()->IsKeyDown(SDLK_RCTRL);
+	bool shift = GetInput()->IsKeyDown(SDLK_LSHIFT) || GetInput()->IsKeyDown(SDLK_RSHIFT);
+
+	if (ctrl && shift && GetInput()->IsKeyPressed(SDLK_p)) {
+		RequestProfileFrame(m_appName);
 	}
 }
 

--- a/src/editor/EditorApp.cpp
+++ b/src/editor/EditorApp.cpp
@@ -7,6 +7,9 @@
 
 #include "FileSystem.h"
 #include "ModManager.h"
+#include "ModelViewer.h"
+
+#include "argh/argh.h"
 #include "core/IniConfig.h"
 #include "graphics/Graphics.h"
 #include "lua/Lua.h"
@@ -32,6 +35,19 @@ EditorApp *EditorApp::Get()
 void EditorApp::Initialize(argh::parser &cmdline)
 {
 	// Load / register editor modules and frames here
+
+	if (cmdline[{"-mv", "--modelviewer"}]) {
+		std::string modelName;
+		cmdline({"-mv", "--modelviewer"}, "") >> modelName;
+
+		RefCountedPtr<ModelViewer> modelViewer(new ModelViewer(this, Lua::manager));
+
+		if (!modelName.empty())
+			modelViewer->SetModel(modelName);
+
+		QueueLifecycle(modelViewer);
+		return;
+	}
 }
 
 void EditorApp::AddLoadingTask(TaskSet::Handle handle)

--- a/src/editor/EditorApp.h
+++ b/src/editor/EditorApp.h
@@ -1,0 +1,60 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "core/GuiApplication.h"
+#include "core/TaskGraph.h"
+
+namespace argh {
+	class parser;
+} // namespace argh
+
+namespace Graphics {
+	class Renderer;
+} // namespace Graphics
+
+namespace Editor {
+
+	class EditorApp : public GuiApplication {
+	public:
+		EditorApp();
+		~EditorApp();
+
+		static EditorApp *Get();
+
+		void Initialize(argh::parser &cmdline);
+
+		void AddLoadingTask(TaskSet::Handle handle);
+
+	protected:
+		void OnStartup() override;
+		void OnShutdown() override;
+
+		void PreUpdate() override;
+		void PostUpdate() override;
+
+		friend class LoadingPhase;
+		std::vector<TaskSet::Handle> &GetLoadingTasks() { return m_loadingTasks; }
+
+	private:
+		std::vector<TaskSet::Handle> m_loadingTasks;
+		Graphics::Renderer *m_renderer;
+	};
+
+	class LoadingPhase : public Application::Lifecycle {
+	public:
+		LoadingPhase(EditorApp *app) :
+			Application::Lifecycle(true),
+			m_app(app)
+		{}
+
+	protected:
+		void Update(float dt) override;
+
+	private:
+		EditorApp *m_app;
+		float minRuntime = 2.f;
+	};
+
+} // namespace Editor

--- a/src/editor/EditorApp.h
+++ b/src/editor/EditorApp.h
@@ -27,6 +27,8 @@ namespace Editor {
 
 		void AddLoadingTask(TaskSet::Handle handle);
 
+		void SetAppName(std::string_view name);
+
 	protected:
 		void OnStartup() override;
 		void OnShutdown() override;
@@ -40,6 +42,8 @@ namespace Editor {
 	private:
 		std::vector<TaskSet::Handle> m_loadingTasks;
 		Graphics::Renderer *m_renderer;
+
+		std::string m_appName;
 	};
 
 	class LoadingPhase : public Application::Lifecycle {
@@ -54,7 +58,7 @@ namespace Editor {
 
 	private:
 		EditorApp *m_app;
-		float minRuntime = 2.f;
+		float minRuntime = 1.f;
 	};
 
 } // namespace Editor

--- a/src/editor/EditorDraw.cpp
+++ b/src/editor/EditorDraw.cpp
@@ -1,0 +1,34 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "EditorDraw.h"
+#include "imgui/imgui.h"
+
+using namespace Editor;
+
+ImRect Draw::RectCut(ImRect &orig, float amount, RectSide side)
+{
+	ImRect out = orig;
+
+	if (side == RectSide_Left) {
+		out.Max.x = orig.Min.x = std::min(orig.Min.x + amount, orig.Max.x);
+	} else if (side == RectSide_Top) {
+		out.Max.y = orig.Min.y = std::min(orig.Min.y + amount, orig.Max.y);
+	} else if (side == RectSide_Right) {
+		out.Min.x = orig.Max.x = std::max(orig.Max.x - amount, orig.Min.x);
+	} else if (side == RectSide_Bottom) {
+		out.Min.y = orig.Max.y = std::max(orig.Max.y - amount, orig.Min.y);
+	}
+
+	return out;
+}
+
+bool Draw::BeginWindow(ImRect rect, const char *label, bool *open, ImGuiWindowFlags flags)
+{
+	ImGui::SetNextWindowPos(rect.Min, ImGuiCond_Always);
+	ImGui::SetNextWindowSize(rect.Max - rect.Min, ImGuiCond_Always);
+
+	flags |= ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus;
+
+	return ImGui::Begin(label, open, flags);
+}

--- a/src/editor/EditorDraw.h
+++ b/src/editor/EditorDraw.h
@@ -1,0 +1,8 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "imgui/imgui.h"
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui/imgui_internal.h"

--- a/src/editor/EditorDraw.h
+++ b/src/editor/EditorDraw.h
@@ -6,3 +6,31 @@
 #include "imgui/imgui.h"
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include "imgui/imgui_internal.h"
+
+#include <cstdint>
+
+namespace Editor::Draw {
+	enum RectSide : uint8_t {
+		RectSide_Left = 0,
+		RectSide_Top = 1,
+		RectSide_Right = 2,
+		RectSide_Bottom = 3
+	};
+
+	enum RectAxis : uint8_t {
+		RectAxis_Horizontal = 0,
+		RectAxis_Vertical = 1
+	};
+
+	enum RectAlign : uint8_t {
+		RectAlign_Start = 0,
+		RectAlign_End = 2,
+		RectAlign_Center = 4
+	};
+
+	// Subtract a section from a side of the original rect and return it as a new rect
+	ImRect RectCut(ImRect &orig, float amount, RectSide side);
+
+	bool BeginWindow(ImRect rect, const char *name, bool *p_open = NULL, ImGuiWindowFlags flags = 0);
+
+}

--- a/src/editor/EditorDraw.h
+++ b/src/editor/EditorDraw.h
@@ -7,6 +7,8 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include "imgui/imgui_internal.h"
 
+#include "FloatComparison.h"
+
 #include <cstdint>
 
 namespace Editor::Draw {
@@ -17,20 +19,14 @@ namespace Editor::Draw {
 		RectSide_Bottom = 3
 	};
 
-	enum RectAxis : uint8_t {
-		RectAxis_Horizontal = 0,
-		RectAxis_Vertical = 1
-	};
-
-	enum RectAlign : uint8_t {
-		RectAlign_Start = 0,
-		RectAlign_End = 2,
-		RectAlign_Center = 4
-	};
-
 	// Subtract a section from a side of the original rect and return it as a new rect
 	ImRect RectCut(ImRect &orig, float amount, RectSide side);
 
 	bool BeginWindow(ImRect rect, const char *name, bool *p_open = NULL, ImGuiWindowFlags flags = 0);
 
+}
+
+inline bool operator==(const ImVec2 &a, const ImVec2 &b)
+{
+	return is_equal_general(a.x, b.x) && is_equal_general(a.y, b.y);
 }

--- a/src/editor/EditorDraw.h
+++ b/src/editor/EditorDraw.h
@@ -9,9 +9,14 @@
 
 #include "FloatComparison.h"
 
-#include <cstdint>
+#include <string_view>
+
+namespace Editor {
+	class UndoSystem;
+}
 
 namespace Editor::Draw {
+
 	enum RectSide : uint8_t {
 		RectSide_Left = 0,
 		RectSide_Top = 1,
@@ -22,7 +27,28 @@ namespace Editor::Draw {
 	// Subtract a section from a side of the original rect and return it as a new rect
 	ImRect RectCut(ImRect &orig, float amount, RectSide side);
 
+	// Set the next window size to the given rect and begin it
 	bool BeginWindow(ImRect rect, const char *name, bool *p_open = NULL, ImGuiWindowFlags flags = 0);
+
+	// Draw an edit box for an ImVec2 with the given settings
+	bool EditFloat2(const char *label, ImVec2 *vec, float step = 0.f, float step_fast = 0.f, const char *format = "%.3f");
+
+	// Begin a horizontal layout for N inputs/items, reserving a given amount of size for each one's label
+	bool LayoutHorizontal(const char *label, int nItems, float itemLabelSize);
+
+	// End a horizontal layout block
+	void EndLayout();
+
+	// Manage pushing/popping an UndoEntry after an input widget that provides IsItemActivated() and IsItemDeactivated()
+	// Note: this helper relies on the widget *not* changing the underlying value the frame IsItemActivated() is true
+	bool UndoHelper(std::string_view label, UndoSystem *undo);
+
+	// Open a Combo and manage pushing/popping an UndoEntry. Returns true if the Combo window is open.
+	// Use ImGui::IsWindowAppearing() to determine if you should push an UndoStep.
+	bool ComboUndoHelper(std::string_view entryName, const char *label, const char *preview, UndoSystem *undo);
+
+	// The above, but defaulting the label to the entryName
+	bool ComboUndoHelper(std::string_view label, const char *preview, UndoSystem *undo);
 
 }
 

--- a/src/editor/EditorWindow.cpp
+++ b/src/editor/EditorWindow.cpp
@@ -1,0 +1,44 @@
+// Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "EditorWindow.h"
+
+#include "editor/EditorApp.h"
+
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
+
+using namespace Editor;
+
+EditorWindow::EditorWindow(EditorApp *app) :
+	m_app(app)
+{}
+
+EditorWindow::~EditorWindow()
+{}
+
+void EditorWindow::Update(float deltaTime)
+{
+	ImGuiWindowFlags flags = {};
+
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{ 1.f, 1.f });
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
+
+	bool shouldClose = false;
+	bool open = ImGui::Begin(GetWindowName(), &shouldClose, flags);
+
+	ImGui::PopStyleVar(2);
+
+	if (open) {
+		OnDraw();
+	}
+
+	ImGui::End();
+
+	if (shouldClose && OnCloseRequested()) {
+		OnDisappearing();
+
+		// TODO: close window + inform editor of such
+	}
+}

--- a/src/editor/EditorWindow.h
+++ b/src/editor/EditorWindow.h
@@ -1,0 +1,33 @@
+// Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+namespace Editor
+{
+	class EditorApp;
+
+	class EditorWindow {
+	public:
+		EditorWindow(EditorApp *app);
+		~EditorWindow();
+
+		virtual void OnAppearing() = 0;
+		virtual void OnDisappearing() = 0;
+
+		virtual void Update(float deltaTime);
+
+		virtual const char *GetWindowName() = 0;
+
+	protected:
+
+		virtual void OnDraw() = 0;
+
+		virtual bool OnCloseRequested() = 0;
+
+		EditorApp *GetApp() { return m_app; }
+
+	private:
+		EditorApp *m_app;
+	};
+}

--- a/src/editor/ModelViewer.h
+++ b/src/editor/ModelViewer.h
@@ -1,8 +1,7 @@
 // Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-#ifndef MODELVIEWER_H
-#define MODELVIEWER_H
+#pragma once
 
 #include "Input.h"
 #include "NavLights.h"
@@ -18,30 +17,9 @@
 
 #include <memory>
 
-class ModelViewer;
+namespace Editor {
 
-class ModelViewerApp : public GuiApplication {
-public:
-	ModelViewerApp() :
-		GuiApplication("Model Viewer")
-	{}
-
-	void SetInitialModel(std::string &modelName) { m_modelName = modelName; }
-	std::string &GetModelName() { return m_modelName; }
-
-protected:
-	void OnStartup() override;
-	void OnShutdown() override;
-
-	void PreUpdate() override;
-	void PostUpdate() override;
-
-	friend class ModelViewer;
-
-private:
-	std::string m_modelName;
-	RefCountedPtr<ModelViewer> m_modelViewer;
-};
+class EditorApp;
 
 class ModelViewer : public Application::Lifecycle {
 public:
@@ -54,7 +32,7 @@ public:
 		Bottom
 	};
 
-	ModelViewer(ModelViewerApp *app, LuaManager *l);
+	ModelViewer(EditorApp *app, LuaManager *l);
 	~ModelViewer();
 
 	void SetModel(const std::string &modelName);
@@ -212,4 +190,4 @@ private:
 	std::unique_ptr<Graphics::Drawables::GridLines> m_gridLines;
 };
 
-#endif
+} // namespace Editor

--- a/src/editor/UndoStepType.h
+++ b/src/editor/UndoStepType.h
@@ -1,0 +1,233 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "editor/UndoSystem.h"
+
+namespace Editor {
+
+	// ========================================================================
+	//  UndoSingleValue Helper
+	// ========================================================================
+
+	// UndoSingleValueStep implements an UndoStep that allows tracking mutation
+	// of a single public member variable in any class.
+	//
+	// The only requirements are that the value type be Move-Constructible or
+	// Copy-Constructible, and that the value's memory location will not change
+	// between creation of the UndoStep and when it is undone/redone.
+
+	template<typename ValueType>
+	class UndoSingleValueStep : public UndoStep
+	{
+	public:
+		// Simple copy-state constructor to clone the given value
+		UndoSingleValueStep(ValueType *data) :
+			m_dataRef(data),
+			m_state(*m_dataRef)
+		{
+		}
+
+		// Convenience constructor overload to allow updating a data value in a single call
+		// (allows UndoSingleValueStep to work for move-only values like std::unique_ptr)
+		UndoSingleValueStep(ValueType *data, const ValueType &newValue) :
+			m_dataRef(data),
+			m_state(newValue)
+		{
+			std::swap(m_state, *m_dataRef);
+		}
+
+		void Undo() override { std::swap(*m_dataRef, m_state); }
+		void Redo() override { std::swap(*m_dataRef, m_state); }
+
+		// Implement HasChanged as !(a == b) to reduce the number of operator overloads required
+		bool HasChanged() const override { return !(*m_dataRef == m_state); }
+
+	private:
+		ValueType *m_dataRef;
+		ValueType m_state;
+	};
+
+	template<typename ValueType, typename ClosureType>
+	class UndoSingleValueClosureStep : public UndoStep
+	{
+	public:
+		UndoSingleValueClosureStep(ValueType *type, ClosureType &&updateClosure) :
+			m_dataRef(type),
+			m_state(*m_dataRef),
+			m_onUpdate(std::move(updateClosure))
+		{
+		}
+
+		UndoSingleValueClosureStep(ValueType *type, const ValueType &newValue, ClosureType &&updateClosure) :
+			m_dataRef(type),
+			m_state(newValue),
+			m_onUpdate(std::move(updateClosure))
+		{
+			std::swap(*m_dataRef, m_state);
+			m_onUpdate();
+		}
+
+		void Undo() override
+		{
+			std::swap(*m_dataRef, m_state);
+			m_onUpdate();
+		}
+
+		void Redo() override
+		{
+			std::swap(*m_dataRef, m_state);
+			m_onUpdate();
+		}
+
+		bool HasChanged() const override { return !(*m_dataRef == m_state); }
+
+	private:
+		ValueType *m_dataRef;
+		ValueType m_state;
+
+		ClosureType m_onUpdate;
+	};
+
+	// Helper functions to construct the above UndoStep helpers
+
+	template<typename T>
+	inline void AddUndoSingleValue(UndoSystem *s, T *dataRef)
+	{
+		s->AddUndoStep<UndoSingleValueStep<T>>(dataRef);
+	}
+
+	template<typename T>
+	inline void AddUndoSingleValue(UndoSystem *s, T *dataRef, const T &newValue)
+	{
+		s->AddUndoStep<UndoSingleValueStep<T>>(dataRef, newValue);
+	}
+
+	template<typename T, typename UpdateClosure>
+	inline void AddUndoSingleValueClosure(UndoSystem *s, T *dataRef, UpdateClosure &&closure)
+	{
+		s->AddUndoStep<UndoSingleValueClosureStep<T, UpdateClosure>>(dataRef, std::move(closure));
+	}
+
+	template<typename T, typename UpdateClosure>
+	inline void AddUndoSingleValueClosure(UndoSystem *s, T *dataRef, const T &newValue, UpdateClosure &&closure)
+	{
+		s->AddUndoStep<UndoSingleValueClosureStep<T, UpdateClosure>>(dataRef, newValue, std::move(closure));
+	}
+
+	// ========================================================================
+	//  UndoGetSetValue Helper
+	// ========================================================================
+
+	// UndoGetSetValueStep implements an UndoStep that allows tracking mutation
+	// of a single private member variable exposed by a GetX() / SetX() pair.
+	//
+	// The value type must be Copy-Constructible, and the object containing the
+	// variable must not be reallocated or destroyed during the lifetime of the
+	// UndoStep.
+
+	template<auto GetterFn, auto SetterFn, typename ValueType, typename Obj>
+	class UndoGetSetValueStep : public UndoStep
+	{
+	public:
+		UndoGetSetValueStep(Obj *data) :
+			m_dataRef(data),
+			m_state((m_dataRef->*GetterFn)())
+		{
+		}
+
+		UndoGetSetValueStep(Obj *data, const ValueType &newValue) :
+			m_dataRef(data),
+			m_state(newValue)
+		{
+			swap();
+		}
+
+		void Undo() override { swap(); }
+		void Redo() override { swap(); }
+
+		bool HasChanged() const override { return !((m_dataRef->*GetterFn)() == m_state); }
+
+	private:
+		// two-way swap with opaque setter/getter functions
+		void swap() {
+			ValueType t = (m_dataRef->*GetterFn)();
+			std::swap(t, m_state);
+			(m_dataRef->*SetterFn)(std::move(t));
+		}
+
+		Obj *m_dataRef;
+		ValueType m_state;
+	};
+
+	template<auto GetterFn, auto SetterFn, typename ValueType, typename Obj, typename ClosureType>
+	class UndoGetSetValueClosureStep : public UndoStep
+	{
+	public:
+		UndoGetSetValueClosureStep(Obj *data, ClosureType &&updateClosure) :
+			m_dataRef(data),
+			m_state((m_dataRef->*GetterFn)()),
+			m_update(std::move(updateClosure))
+		{
+		}
+
+		UndoGetSetValueClosureStep(Obj *data, const ValueType &newValue, ClosureType &&updateClosure) :
+			m_dataRef(data),
+			m_state(newValue),
+			m_update(std::move(updateClosure))
+		{
+			swap();
+		}
+
+		void Undo() override { swap(); }
+		void Redo() override { swap(); }
+
+		bool HasChanged() const override { return !((m_dataRef->*GetterFn)() == m_state); }
+
+	private:
+		// two-way swap with opaque setter/getter functions and update closure
+		void swap() {
+			ValueType t = (m_dataRef->*GetterFn)();
+			std::swap(t, m_state);
+			(m_dataRef->*SetterFn)(std::move(t));
+
+			m_update();
+		}
+
+		Obj *m_dataRef;
+		ValueType m_state;
+		ClosureType m_update;
+	};
+
+	// Helper functions to construct the above UndoStep helpers
+
+	template<auto GetterFn, auto SetterFn, typename Obj>
+	inline void AddUndoGetSetValue(UndoSystem *s, Obj *dataRef)
+	{
+		using ValueType = decltype((dataRef->*GetterFn)());
+		s->AddUndoStep<UndoGetSetValueStep<GetterFn, SetterFn, ValueType, Obj>>(dataRef);
+	}
+
+	template<auto GetterFn, auto SetterFn, typename Obj, typename T>
+	inline void AddUndoGetSetValue(UndoSystem *s, Obj *dataRef, const T &newValue)
+	{
+		using ValueType = decltype((dataRef->*GetterFn)());
+		s->AddUndoStep<UndoGetSetValueStep<GetterFn, SetterFn, ValueType, Obj>>(dataRef, newValue);
+	}
+
+	template<auto GetterFn, auto SetterFn, typename Obj, typename UpdateClosure>
+	inline void AddUndoGetSetValueClosure(UndoSystem *s, Obj *dataRef, UpdateClosure &&closure)
+	{
+		using ValueType = decltype((dataRef->*GetterFn)());
+		s->AddUndoStep<UndoGetSetValueClosureStep<GetterFn, SetterFn, ValueType, Obj, UpdateClosure>>(dataRef, std::move(closure));
+	}
+
+	template<auto GetterFn, auto SetterFn, typename Obj, typename T, typename UpdateClosure>
+	inline void AddUndoGetSetValueClosure(UndoSystem *s, Obj *dataRef, const T &newValue, UpdateClosure &&closure)
+	{
+		using ValueType = decltype((dataRef->*GetterFn)());
+		s->AddUndoStep<UndoGetSetValueClosureStep<GetterFn, SetterFn, ValueType, Obj, UpdateClosure>>(dataRef, newValue, std::move(closure));
+	}
+
+} // namespace Editor

--- a/src/editor/UndoSystem.cpp
+++ b/src/editor/UndoSystem.cpp
@@ -1,0 +1,158 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "UndoSystem.h"
+#include "utils.h"
+
+#include <cassert>
+
+using namespace Editor;
+
+void UndoEntry::Undo()
+{
+	for (auto &step : reverse_container(m_steps))
+		step->Undo();
+}
+
+void UndoEntry::Redo()
+{
+	for (auto &step : m_steps)
+		step->Redo();
+}
+
+bool UndoEntry::HasChanged() const
+{
+	for (auto &step : m_steps)
+		if (step->HasChanged())
+			return true;
+
+	return false;
+}
+
+// ============================================================================
+
+UndoSystem::UndoSystem() :
+	m_openUndoDepth(0),
+	m_doing(false)
+{
+}
+
+UndoSystem::~UndoSystem()
+{
+}
+
+size_t UndoSystem::GetNumEntries() const
+{
+	return m_undoStack.size() + m_redoStack.size();
+}
+
+size_t UndoSystem::GetCurrentEntry() const
+{
+	return m_undoStack.size();
+}
+
+const UndoEntry *UndoSystem::GetEntry(size_t stackIdx) const
+{
+	if (stackIdx < m_undoStack.size())
+		return m_undoStack[stackIdx].get();
+
+	stackIdx -= m_undoStack.size();
+
+	if (stackIdx < m_redoStack.size()) // redo is a reverse stack
+		return m_redoStack.rbegin()[stackIdx].get();
+
+	return nullptr;
+}
+
+void UndoSystem::Undo()
+{
+	if (!CanUndo())
+		return;
+
+	UndoEntry *entry = m_undoStack.back().release();
+	m_undoStack.pop_back();
+
+	m_doing = true;
+	entry->Undo();
+	m_doing = false;
+
+	m_redoStack.emplace_back(entry);
+}
+
+void UndoSystem::Redo()
+{
+	if (!CanRedo())
+		return;
+
+	UndoEntry *entry = m_redoStack.back().release();
+	m_redoStack.pop_back();
+
+	m_doing = true;
+	entry->Redo();
+	m_doing = false;
+
+	m_undoStack.emplace_back(entry);
+}
+
+void UndoSystem::Clear()
+{
+	// It's probably a bad idea to call Clear() while redoing an UndoEntry
+	assert(!m_doing && "Cannot clear UndoSystem state while inside an undo step!");
+
+	m_openUndoEntry.reset();
+	m_openUndoDepth = 0;
+
+	m_redoStack.clear();
+	m_undoStack.clear();
+}
+
+void UndoSystem::BeginEntry(std::string_view name)
+{
+	assert(!m_doing && "Cannot begin an entry inside an undo step!");
+
+	// Recursive entries are mostly supported to allow chaining operations that individually would also push undo entries
+	if (m_openUndoDepth++ > 0)
+		return;
+
+	m_openUndoEntry.reset(new UndoEntry());
+	m_openUndoEntry->m_name = name;
+}
+
+void UndoSystem::ResetEntry()
+{
+	assert(!m_doing && "Cannot reset an entry inside an undo step!");
+	assert(m_openUndoDepth > 0 && "Cannot reset an undo entry without having begun one prior");
+
+	m_openUndoEntry->Undo();
+	m_openUndoEntry->m_steps.clear();
+}
+
+void UndoSystem::EndEntry()
+{
+	assert(!m_doing && "Cannot end an entry inside an undo step!");
+
+	// Recursive entries don't need to do any cleanup
+	if (--m_openUndoDepth > 0)
+		return;
+
+	// if the entry represents a change to the application state, commit it to
+	// the undo stack and clear redo state
+	if (m_openUndoEntry->HasChanged()) {
+		UndoEntry *entry = m_openUndoEntry.release();
+		m_undoStack.emplace_back(entry);
+
+		if (!m_redoStack.empty())
+			m_redoStack.clear();
+	} else {
+		// otherwise, just get rid of the entry without touching redo state
+		m_openUndoEntry.reset();
+	}
+}
+
+void UndoSystem::AddUndoStep(UndoStep *undo)
+{
+	assert(!m_doing && "Cannot add an undo step inside an undo step!");
+	assert(m_openUndoEntry && "Cannot add an undo step without a valid open undo entry!");
+
+	m_openUndoEntry->m_steps.emplace_back(undo);
+}

--- a/src/editor/UndoSystem.h
+++ b/src/editor/UndoSystem.h
@@ -1,0 +1,166 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "core/StringName.h"
+
+#include <memory>
+#include <string_view>
+#include <vector>
+
+namespace Editor {
+
+/*
+ * UndoStep represents a single unit of work (a single "change") made as part
+ * of some user action.
+ *
+ * An UndoStep should store only enough state to be able to undo or redo said
+ * change, as the non-transient state of the application is expected to be
+ * exactly the same no matter how many times the user has undone/redone the
+ * step or any other steps around it.
+ *
+ * Changes to transient application data (e.g. caches, derived data, etc)
+ * should be triggered immediately by the UndoStep where possible to maintain
+ * consistency in all areas of the application's data model.
+ *
+ * It is invalid for the Undo() or Redo() methods to directly or indirectly
+ * create a new UndoEntry or UndoStep while being executed, as this will
+ * corrupt the undo manager's state.
+ */
+class UndoStep {
+public:
+	UndoStep() = default;
+	virtual ~UndoStep() = default;
+
+	// Execute an undo step (replace application state with stored state)
+	virtual void Undo() = 0;
+
+	// Execute a redo step (replace stored state with application state)
+	virtual void Redo() = 0;
+
+	// Optimization step: entries for which none of the steps represent a
+	// change in state will not be added to the undo stack
+	virtual bool HasChanged() const { return true; }
+};
+
+/*
+ * An UndoEntry is a mostly implementation-specific detail - it represents a
+ * high-level action by the user (e.g. Transform Object) at the most granular
+ * level of undo. One Ctrl+Z should undo one UndoEntry, and vice versa.
+ *
+ * All managed UndoSteps in an entry are applied in program order to maintain
+ * application state consistency (back-to-front undo, front-to-back redo).
+ */
+class UndoEntry {
+public:
+	std::string_view GetName() const { return m_name.sv(); }
+
+private:
+	friend class UndoSystem;
+	UndoEntry() = default;
+
+	void Undo();
+	void Redo();
+
+	bool HasChanged() const;
+
+	StringName m_name;
+	std::vector<std::unique_ptr<UndoStep>> m_steps;
+};
+
+/*
+ * The UndoSystem provides a central place to manage undo entries for a
+ * specific "undo queue" (e.g. document, window, editor, etc).
+ *
+ * It maintains separate undo/redo stacks under the hood, and allows for
+ * recursion of entries to allow maximum flexibility in calling code.
+ *
+ * Recursive BeginEntry() calls must be matched with EndEntry() calls, and the
+ * name of sub-entries is lost. Undo operates on the granularity of top-level
+ * UndoEntries, so sub-entries only allow composing program operations that
+ * would otherwise require multiple undo interactions for a single user action.
+ *
+ * AddUndoStep() creates a new undo step and adds it to the currently active
+ * UndoEntry. The Redo method of the undo entry is not triggered automatically,
+ * as the semantics of an UndoStep are simpler without the Undo/Do/Redo split.
+ *
+ * Calling BeginEntry() / ResetEntry() / EndEntry() / AddUndoStep() while an
+ * UndoEntry is being undone or redone is a violation of program state and will
+ * cause a crash.
+ *
+ * ============================================================================
+ *
+ * A common pattern is to begin an UndoEntry when the user signals they want
+ * to begin editing (e.g. user clicks on a transform handle) and update that
+ * entry while the user performs some continuous action (such as dragging).
+ *
+ * There are two options to achieve this pattern: if your UndoSteps store only
+ * the "prior state" of the application, you can call BeginEntry() once, submit
+ * one or more UndoSteps, and modify application state as needed over multiple
+ * frames before calling EndEntry().
+ *
+ * Alternatively, if your undo steps must know both the prior and current state
+ * of the application, you can call ResetEntry() each frame to undo and discard
+ * all submitted UndoSteps() in the currently active entry. All submitted steps
+ * will be undone, regardless of BeginEntry() recursion level.
+ */
+class UndoSystem {
+public:
+	UndoSystem();
+	~UndoSystem();
+
+	// Return the total number of undo/redo entries in the stack
+	size_t GetNumEntries() const;
+
+	// Return the index of the "current entry" that describes application state.
+	// This points to the first entry in the redo stack, if any.
+	size_t GetCurrentEntry() const;
+
+	// Return a pointer to the given undo entry if stackIdx < GetNumEntries().
+	const UndoEntry *GetEntry(size_t stackIdx) const;
+
+	bool CanUndo() const { return !m_undoStack.empty(); }
+	bool CanRedo() const { return !m_redoStack.empty(); }
+
+	// Undo the most recent entry in the undo stack (rewind the application state)
+	void Undo();
+
+	// Redo the most recent entry in the redo stack (advance the application state)
+	void Redo();
+
+	// Destroy all undo/redo history (e.g. when closing a file)
+	void Clear();
+
+	// Begin a new undo entry (can be recursive)
+	void BeginEntry(std::string_view name);
+
+	// Return the number of open entries (for debugging purposes)
+	size_t GetEntryDepth() const { return m_openUndoDepth; }
+
+	// Reset the current undo entry to a "clean state"
+	void ResetEntry();
+
+	// Add an undo step to the active undo entry
+	template<typename T, typename ...Args>
+	void AddUndoStep(Args&& ...args)
+	{
+		AddUndoStep(new T(std::forward<Args>(args)...));
+	}
+
+	// End the current undo entry
+	void EndEntry();
+
+private:
+	void AddUndoStep(UndoStep *undo);
+
+	std::vector<std::unique_ptr<UndoEntry>> m_undoStack;
+	std::vector<std::unique_ptr<UndoEntry>> m_redoStack;
+
+	std::unique_ptr<UndoEntry> m_openUndoEntry;
+	size_t m_openUndoDepth;
+
+	bool m_doing;
+};
+
+} // namespace Editor

--- a/src/editor/ViewportWindow.cpp
+++ b/src/editor/ViewportWindow.cpp
@@ -1,0 +1,159 @@
+// Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "ViewportWindow.h"
+
+#include "editor/EditorApp.h"
+#include "graphics/Graphics.h"
+#include "graphics/RenderTarget.h"
+#include "graphics/Texture.h"
+
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui/imgui.h"
+#include "imgui/imgui_internal.h"
+
+using namespace Editor;
+
+ViewportWindow::ViewportWindow(EditorApp *app) :
+	EditorWindow(app),
+	m_viewportExtents(0, 0, 0, 0),
+	m_viewportActive(false),
+	m_viewportHovered(false)
+{}
+
+ViewportWindow::~ViewportWindow()
+{}
+
+void ViewportWindow::OnAppearing()
+{
+
+}
+
+void ViewportWindow::OnDisappearing()
+{
+
+}
+
+void ViewportWindow::Update(float deltaTime)
+{
+	ImGuiWindowFlags flags =
+		ImGuiWindowFlags_NoCollapse |
+        ImGuiWindowFlags_NoScrollbar |
+        ImGuiWindowFlags_NoScrollWithMouse;
+
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{ 1.f, 1.f });
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
+
+	bool shouldClose = false;
+	bool open = ImGui::Begin(GetWindowName(), &shouldClose, flags);
+
+	ImGui::PopStyleVar(2);
+
+	if (open) {
+		ImVec2 size = ImGui::GetContentRegionAvail();
+
+		m_viewportExtents.w = int(size.x);
+		m_viewportExtents.h = int(size.y);
+
+		CreateRenderTarget();
+
+		if (m_renderTarget) {
+			ImVec2 screenPos = ImGui::GetCursorScreenPos();
+
+			// Draw our render target as the window "background"
+			// PiGui rendering happens after the contents of the texture are rendered
+			ImGui::GetWindowDrawList()->AddImageRounded(
+				ImTextureID(m_renderTarget->GetColorTexture()),
+				screenPos, screenPos + size,
+				ImVec2(0, 1), ImVec2(1, 0),
+				IM_COL32_WHITE,
+				ImGui::GetStyle().WindowRounding,
+				ImDrawFlags_RoundCornersBottomRight);
+
+			Graphics::Renderer *r = GetApp()->GetRenderer();
+
+			{
+				Graphics::Renderer::StateTicket st(r);
+
+				r->SetRenderTarget(m_renderTarget.get());
+				r->SetViewport(m_viewportExtents);
+				r->ClearScreen(); // FIXME: add clear-command passing in immediate-state clear color
+
+				OnRender(r);
+
+				r->SetRenderTarget(nullptr);
+			}
+
+			ImGui::BeginChild("##ViewportContainer", ImVec2(0, 0), false,
+				ImGuiWindowFlags_NoBackground |
+				ImGuiWindowFlags_NoScrollbar |
+				ImGuiWindowFlags_NoScrollWithMouse |
+				ImGuiWindowFlags_AlwaysUseWindowPadding);
+
+			// set Horizontal layout type since we're using this window effectively as a toolbar
+			ImGui::GetCurrentWindow()->DC.LayoutType = ImGuiLayoutType_Horizontal;
+
+			// Draw all "viewport overlay" UI here, to properly route inputs
+			OnDraw();
+
+			ImGui::EndChild();
+
+			ImGuiID viewportID = ImGui::GetID("##ViewportOverlay");
+
+			// Update mouse down state, etc; handle active layout area interaction
+
+			ImGuiButtonFlags flags =
+				ImGuiButtonFlags_FlattenChildren |
+				ImGuiButtonFlags_PressedOnClick |
+				ImGuiButtonFlags_MouseButtonMask_;
+
+			ImRect area = { screenPos, screenPos + size };
+
+			bool wasPressed = m_viewportActive;
+			bool clicked = ImGui::ButtonBehavior(area, ImGui::GetID("ViewportContents"),
+				&m_viewportHovered, &m_viewportActive, flags);
+
+			// if the viewport is hovered/active or we just released it,
+			// update mouse interactions with it
+			if (m_viewportHovered || m_viewportActive || wasPressed) {
+				// restrict the mouse pos within the viewport and convert to viewport-relative coords
+				ImVec2 mousePos = ImClamp(ImGui::GetIO().MousePos, area.Min, area.Max) - area.Min;
+
+				// disable mouse/keyboard capture so input subsystem can be used in viewport
+				ImGui::CaptureMouseFromApp(false);
+				ImGui::CaptureKeyboardFromApp(false);
+
+				OnHandleInput(clicked, wasPressed && !m_viewportActive, mousePos);
+			}
+
+		}
+	}
+
+	ImGui::End();
+
+	if (shouldClose && OnCloseRequested()) {
+		OnDisappearing();
+
+		// TODO: close window + inform editor of such
+	}
+}
+
+void ViewportWindow::CreateRenderTarget()
+{
+	bool isValid = m_renderTarget &&
+		m_renderTarget->GetDesc().width == m_viewportExtents.w &&
+		m_renderTarget->GetDesc().height == m_viewportExtents.h;
+
+	if (isValid) {
+		return;
+	}
+
+	Graphics::RenderTargetDesc rtdesc = Graphics::RenderTargetDesc(
+		m_viewportExtents.w, m_viewportExtents.h,
+		Graphics::TextureFormat::TEXTURE_RGB_888,
+		Graphics::TextureFormat::TEXTURE_DEPTH,
+		false, 0 // FIXME: multisample resolve for MSAA!
+	);
+
+	m_renderTarget.reset(GetApp()->GetRenderer()->CreateRenderTarget(rtdesc));
+}

--- a/src/editor/ViewportWindow.h
+++ b/src/editor/ViewportWindow.h
@@ -1,0 +1,53 @@
+// Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#pragma once
+
+#include "editor/EditorWindow.h"
+#include "graphics/Graphics.h"
+#include "imgui/imgui.h"
+
+#include <memory>
+
+namespace Graphics
+{
+	class Renderer;
+	class RenderTarget;
+}
+
+namespace Editor
+{
+
+	class ViewportWindow : public EditorWindow {
+	public:
+		ViewportWindow(EditorApp *app);
+		~ViewportWindow();
+
+		virtual void OnAppearing() override;
+		virtual void OnDisappearing() override;
+
+		virtual void Update(float deltaTime) override;
+
+	protected:
+
+		virtual void OnUpdate(float deltaTime) = 0;
+		virtual void OnRender(Graphics::Renderer *renderer) = 0;
+
+		virtual void OnHandleInput(bool clicked, bool released, ImVec2 mousePos) = 0;
+
+		void CreateRenderTarget();
+
+		Graphics::RenderTarget *GetRenderTarget() { return m_renderTarget.get(); }
+		const Graphics::ViewportExtents &GetViewportExtents() const { return m_viewportExtents; }
+
+
+	private:
+
+		std::unique_ptr<Graphics::RenderTarget> m_renderTarget;
+		Graphics::ViewportExtents m_viewportExtents;
+
+		bool m_viewportActive;
+		bool m_viewportHovered;
+
+	};
+}

--- a/src/editor/editormain.cpp
+++ b/src/editor/editormain.cpp
@@ -1,0 +1,21 @@
+// Copyright © 2008-2022 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "EditorApp.h"
+
+#include "argh/argh.h"
+
+#include <memory>
+
+extern "C" int main(int argc, const char **argv) {
+	argh::parser cmdline(argc, argv);
+
+	Editor::EditorApp *app = Editor::EditorApp::Get(); // instance the editor application
+
+	app->Startup();
+	app->Initialize(cmdline);
+
+	app->Run();
+
+	app->Shutdown();
+}

--- a/src/editor/editormain.cpp
+++ b/src/editor/editormain.cpp
@@ -5,9 +5,10 @@
 
 #include "argh/argh.h"
 
+#include <SDL.h>
 #include <memory>
 
-extern "C" int main(int argc, const char **argv) {
+extern "C" int main(int argc, char **argv) {
 	argh::parser cmdline(argc, argv);
 
 	Editor::EditorApp *app = Editor::EditorApp::Get(); // instance the editor application

--- a/src/lua/LuaUtils.h
+++ b/src/lua/LuaUtils.h
@@ -74,7 +74,7 @@ void pi_lua_import_recursive(lua_State *L, const std::string &importName);
 int pi_lua_panic(lua_State *l) __attribute((noreturn));
 void pi_lua_protected_call(lua_State *state, int nargs, int nresults);
 int pi_lua_loadfile(lua_State *l, const FileSystem::FileData &code);
-void pi_lua_dofile(lua_State *l, const std::string &path);
+void pi_lua_dofile(lua_State *l, const std::string &path, int nret = 0);
 void pi_lua_dofile_recursive(lua_State *l, const std::string &basepath);
 
 void pi_lua_warn(lua_State *l, const char *format, ...) __attribute((format(printf, 2, 3)));

--- a/src/lua/core/Sandbox.cpp
+++ b/src/lua/core/Sandbox.cpp
@@ -323,7 +323,7 @@ void pi_lua_dofile(lua_State *l, const FileSystem::FileData &code, int nret)
 	LUA_DEBUG_END(l, nret);
 }
 
-void pi_lua_dofile(lua_State *l, const std::string &path)
+void pi_lua_dofile(lua_State *l, const std::string &path, int nret)
 {
 	assert(l);
 	LUA_DEBUG_START(l);
@@ -334,7 +334,7 @@ void pi_lua_dofile(lua_State *l, const std::string &path)
 		return;
 	}
 
-	pi_lua_dofile(l, *code);
+	pi_lua_dofile(l, *code, nret);
 
 	LUA_DEBUG_END(l, 0);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "Game.h"
-#include "ModelViewer.h"
 #include "Pi.h"
 #include "buildopts.h"
 #include "core/OS.h"
@@ -16,7 +15,6 @@
 
 enum RunMode {
 	MODE_GAME,
-	MODE_MODELVIEWER,
 	MODE_GALAXYDUMP,
 	MODE_START_AT,
 	MODE_VERSION,
@@ -46,11 +44,6 @@ extern "C" int main(int argc, char **argv)
 
 		if (modeopt == "game" || modeopt == "g") {
 			mode = MODE_GAME;
-			goto start;
-		}
-
-		if (modeopt == "modelviewer" || modeopt == "mv") {
-			mode = MODE_MODELVIEWER;
 			goto start;
 		}
 
@@ -203,18 +196,6 @@ start:
 		}
 
 		Pi::Uninit();
-		break;
-	}
-
-	case MODE_MODELVIEWER: {
-		std::string modelName;
-		if (argc > 2)
-			modelName = argv[2];
-		auto modelViewer = ModelViewerApp();
-		modelViewer.SetInitialModel(modelName);
-		modelViewer.Startup();
-		modelViewer.Run();
-		modelViewer.Shutdown();
 		break;
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,7 +216,6 @@ start:
 			"usage: pioneer [mode] [options...]\n"
 			"available modes:\n"
 			"    -game        [-g]     game (default)\n"
-			"    -modelviewer [-mv]    model viewer\n"
 			"    -galaxydump  [-gd]    galaxy dumper\n"
 			"    -startat     [-sa]    skip main menu and start at Mars\n"
 			"    -startat=sp  [-sa=sp]  skip main menu and start at systempath x,y,z,si,bi\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,6 +201,8 @@ start:
 				Output("pioneer: writing to \"%s\" failed: %s\n", filename.c_str(), strerror(errno));
 			}
 		}
+
+		Pi::Uninit();
 		break;
 	}
 
@@ -210,7 +212,9 @@ start:
 			modelName = argv[2];
 		auto modelViewer = ModelViewerApp();
 		modelViewer.SetInitialModel(modelName);
+		modelViewer.Startup();
 		modelViewer.Run();
+		modelViewer.Shutdown();
 		break;
 	}
 


### PR DESCRIPTION
This pull request adds the basic foundations to support an editor / mod tools pipeline for Pioneer. A new editor binary contains the modelviewer, and provides a framework for common editor paradigms. A fully-functional undo system is provided, as well as various helpers for rendering edit interfaces for various property types.

On its own, this PR does little but change the invocation of the modelviewer from `pioneer -mv` to `editor -mv`, but sets the foundation for several branches that will be landing soon which improve the content creation experience for Pioneer, the most notable of which is the new System Editor tool.

**TODO:**
- [x] Ensure editor binary is installed via CMake / distributed in release builds
- [x] Update in-tree documentation to mention new modelviewer invocation