### PR TITLE
Some fixes after sector map refactoring and new start menu added

### DIFF
--- a/data/pigui/modules/new-game-window/widgets.lua
+++ b/data/pigui/modules/new-game-window/widgets.lua
@@ -40,17 +40,14 @@ Widgets.alignLabel = function(label, layout, fnc)
 		-- calculate item's width
 		local before = ui.getCursorPos()
 		fnc()
-		local backup = ui.getCursorPos()
 		ui.sameLine(0)
 		local after = ui.getCursorPos()
 		local width = after.x - before.x
-		layout.itemWidth = layout.itemWidth or width
-		if width < layout.itemWidth then
-			ui.dummy(Vector2(layout.itemWidth - width, 1))
-		else
+
+		if not layout.itemWidth or width > layout.itemWidth then
 			layout.itemWidth = width
-			ui.setCursorPos(backup)
 		end
+		ui.dummy(Vector2(layout.itemWidth - width, 1))
 	end
 end
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -814,15 +814,15 @@ void Game::Views::LoadFromJson(const Json &jsonObj, Game *game)
 Game::Views::~Views()
 {
 #if WITH_OBJECTVIEWER
-	delete m_objectViewerView;
+	if (m_objectViewerView) delete m_objectViewerView;
 #endif
 
-	delete m_deathView;
-	delete m_infoView;
-	delete m_spaceStationView;
-	delete m_systemView;
-	delete m_worldView;
-	delete m_sectorView;
+	if (m_deathView) delete m_deathView;
+	if (m_infoView) delete m_infoView;
+	if (m_spaceStationView) delete m_spaceStationView;
+	if (m_systemView) delete m_systemView;
+	if (m_worldView) delete m_worldView;
+	if (m_sectorView) delete m_sectorView;
 }
 
 // XXX this should be in some kind of central UI management class that

--- a/src/Game.h
+++ b/src/Game.h
@@ -135,15 +135,15 @@ private:
 
 		void SetRenderer(Graphics::Renderer *r);
 
-		SectorView *m_sectorView;
-		SystemView *m_systemView;
-		WorldView *m_worldView;
-		DeathView *m_deathView;
-		View *m_spaceStationView;
-		View *m_infoView;
+		SectorView *m_sectorView = nullptr;
+		SystemView *m_systemView = nullptr;
+		WorldView *m_worldView = nullptr;
+		DeathView *m_deathView = nullptr;
+		View *m_spaceStationView = nullptr;
+		View *m_infoView = nullptr;
 
 		/* Only use #if WITH_OBJECTVIEWER */
-		ObjectViewerView *m_objectViewerView;
+		ObjectViewerView *m_objectViewerView = nullptr;
 	};
 
 	void CreateViews();
@@ -155,12 +155,12 @@ private:
 	void SwitchToHyperspace();
 	void SwitchToNormalSpace();
 
+	std::unique_ptr<Player> m_player;
+
 	RefCountedPtr<Galaxy> m_galaxy;
 	std::unique_ptr<Views> m_gameViews;
 	std::unique_ptr<Space> m_space;
 	double m_time;
-
-	std::unique_ptr<Player> m_player;
 
 	enum class State {
 		NORMAL,

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -209,6 +209,10 @@ void SectorView::SaveToJson(Json &jsonObj)
 	m_current.ToJson(currentSystemObj);
 	sectorViewObj["current"] = currentSystemObj; // Add current system object to sector view object.
 
+	Json selectedSystemObj({}); // Create JSON object to contain selected system data.
+	m_selected.ToJson(selectedSystemObj);
+	sectorViewObj["selected"] = selectedSystemObj; // Add selected system object to sector view object.
+
 	Json hyperspaceSystemObj({}); // Create JSON object to contain hyperspace system data.
 	m_hyperspaceTarget.ToJson(hyperspaceSystemObj);
 	sectorViewObj["hyperspace"] = hyperspaceSystemObj; // Add hyperspace system object to sector view object.

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -314,6 +314,12 @@ Space::~Space()
 	for (Body *body : m_bodies)
 		KillBody(body);
 	UpdateBodies();
+
+	// since the player is owned by the game, we cannot delete it, but it
+	// stores the id of the frame we are going to delete
+	auto player = m_game->GetPlayer();
+	if (player) player->SetFrame(FrameId::Invalid);
+
 	Frame::DeleteFrames();
 }
 


### PR DESCRIPTION
Fixes those problems:

https://github.com/pioneerspacesim/pioneer/pull/5561#issuecomment-1693207911 - segfault on load savegame
https://github.com/pioneerspacesim/pioneer/pull/5561#issuecomment-1693800474 - name and money overlap

There are also explanations in the commit messages.

The first commit is not really needed to fix these problems, but I think it would be better if we see a load error on a failed load rather than a segfault.


<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

