### PR TITLE
Docking with orbital in manual mode

### DIFF
--- a/data/meta/Constants.lua
+++ b/data/meta/Constants.lua
@@ -30,6 +30,14 @@ Constants.PhysicsObjectType = {
 	[9] = "MISSILE",
 }
 
+-- A <Constants.AltitudeType> string
+---@enum AltitudeType
+Constants.AltitudeType = {
+	[1] = "DEFAULT",
+	[2] = "SEA_LEVEL",
+	[3] = "ABOVE_TERRAIN",
+}
+
 -- A <Constants.ShipAIError> string
 ---@enum ShipAIError
 Constants.ShipAIError = {
@@ -109,6 +117,38 @@ Constants.DockingRefusedReason = {
 	[1] = "ClearanceAlreadyGranted",
 	[2] = "TooFarFromStation",
 	[3] = "NoBaysAvailable",
+}
+
+-- A <Constants.DockStage> string
+---@enum DockStage
+Constants.DockStage = {
+	[1] = "NONE",
+	[2] = "MANUAL",
+	[3] = "DOCK_STAGES_BEGIN",
+	[4] = "CLEARANCE_GRANTED",
+	[5] = "DOCK_ANIMATION_NONE",
+	[6] = "DOCK_ANIMATION_1",
+	[7] = "DOCK_ANIMATION_2",
+	[8] = "DOCK_ANIMATION_3",
+	[9] = "DOCK_ANIMATION_MAX",
+	[10] = "TOUCHDOWN",
+	[11] = "LEVELING",
+	[12] = "REPOSITION",
+	[13] = "JUST_DOCK",
+	[14] = "DOCK_STAGES_END",
+	[15] = "DOCKED",
+	[16] = "UNDOCK_STAGES_BEGIN",
+	[17] = "UNDOCK_BEGIN",
+	[18] = "UNDOCK_ANIMATION_NONE",
+	[19] = "UNDOCK_ANIMATION_1",
+	[20] = "UNDOCK_ANIMATION_2",
+	[21] = "UNDOCK_ANIMATION_3",
+	[22] = "UNDOCK_ANIMATION_MAX",
+	[23] = "UNDOCK_END",
+	[24] = "LEAVE",
+	[25] = "UNDOCK_STAGES_END",
+	[26] = "APPROACH1",
+	[27] = "APPROACH2",
 }
 
 -- A <Constants.ProjectableTypes> string

--- a/data/models/stations/orbital_station/station_docking_A.dae
+++ b/data/models/stations/orbital_station/station_docking_A.dae
@@ -3,31 +3,14 @@
   <asset>
     <contributor>
       <author>Blender User</author>
-      <authoring_tool>Blender 3.0.0 Beta commit date:2021-10-27, commit time:22:07, hash:b838eaf2b960</authoring_tool>
+      <authoring_tool>Blender 3.3.6 commit date:2023-04-17, commit time:14:03, hash:948f8298b982</authoring_tool>
     </contributor>
-    <created>2021-10-31T12:56:40</created>
-    <modified>2021-10-31T12:56:40</modified>
+    <created>2024-01-07T22:31:08</created>
+    <modified>2024-01-07T22:31:08</modified>
     <unit name="meter" meter="1"/>
     <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
-    <effect id="JoinedMaterial__2-effect">
-      <profile_COMMON>
-        <technique sid="common">
-          <lambert>
-            <emission>
-              <color sid="emission">0 0 0 1</color>
-            </emission>
-            <diffuse>
-              <color sid="diffuse">0.4096 0.4096 0.4096 1</color>
-            </diffuse>
-            <index_of_refraction>
-              <float sid="ior">1</float>
-            </index_of_refraction>
-          </lambert>
-        </technique>
-      </profile_COMMON>
-    </effect>
     <effect id="facade_001-effect">
       <profile_COMMON>
         <technique sid="common">
@@ -37,6 +20,23 @@
             </emission>
             <diffuse>
               <color sid="diffuse">0.64 0.01314007 0.002662271 1</color>
+            </diffuse>
+            <index_of_refraction>
+              <float sid="ior">1</float>
+            </index_of_refraction>
+          </lambert>
+        </technique>
+      </profile_COMMON>
+    </effect>
+    <effect id="JoinedMaterial__2-effect">
+      <profile_COMMON>
+        <technique sid="common">
+          <lambert>
+            <emission>
+              <color sid="emission">0 0 0 1</color>
+            </emission>
+            <diffuse>
+              <color sid="diffuse">0.4096 0.4096 0.4096 1</color>
             </diffuse>
             <index_of_refraction>
               <float sid="ior">1</float>
@@ -65,59 +65,17 @@
   </library_effects>
   <library_images/>
   <library_materials>
-    <material id="JoinedMaterial__2-material" name="JoinedMaterial__2">
-      <instance_effect url="#JoinedMaterial__2-effect"/>
-    </material>
     <material id="facade_001-material" name="facade.001">
       <instance_effect url="#facade_001-effect"/>
+    </material>
+    <material id="JoinedMaterial__2-material" name="JoinedMaterial__2">
+      <instance_effect url="#JoinedMaterial__2-effect"/>
     </material>
     <material id="floor_001-material" name="floor.001">
       <instance_effect url="#floor_001-effect"/>
     </material>
   </library_materials>
   <library_geometries>
-    <geometry id="collision_pad1Mesh_008-mesh" name="collision_pad1Mesh.008">
-      <mesh>
-        <source id="collision_pad1Mesh_008-mesh-positions">
-          <float_array id="collision_pad1Mesh_008-mesh-positions-array" count="111">0 109.9739 428.3379 0 -3.80603e-6 428.3379 -109.9739 109.9739 428.3379 0 -109.9739 428.3379 109.9739 -109.9739 428.3379 109.9739 -3.80603e-6 428.3379 109.9739 109.9739 428.3379 -109.9739 -3.80603e-6 428.3379 -109.9739 -109.9739 428.3379 0 -109.9739 525.5236 -109.9739 -109.9739 525.5236 0 109.9739 525.5236 109.9739 109.9739 525.5236 -109.9739 -3.80603e-6 525.5236 0 -3.80603e-6 525.5236 109.9739 -3.80603e-6 525.5236 109.9739 -109.9739 525.5236 109.9739 -3.80603e-6 525.5236 0 -3.80603e-6 525.5236 -109.9739 -3.80603e-6 525.5236 0 109.9739 525.5236 -109.9739 109.9739 525.5236 0 -109.9739 525.5236 -109.9739 109.9739 472.5839 -109.9739 -3.80603e-6 472.5839 0 -3.80603e-6 472.5839 0 109.9739 472.5839 109.9739 -109.9739 472.5839 109.9739 -3.80603e-6 472.5839 109.9739 109.9739 472.5839 -109.9739 -109.9739 472.5839 0 -109.9739 472.5839 0 109.9739 428.3379 -109.9739 2.81605e-5 428.3379 0 2.81605e-5 428.3379 0 -109.9739 428.3379 109.9739 2.81605e-5 428.3379</float_array>
-          <technique_common>
-            <accessor source="#collision_pad1Mesh_008-mesh-positions-array" count="37" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="collision_pad1Mesh_008-mesh-normals">
-          <float_array id="collision_pad1Mesh_008-mesh-normals-array" count="15">0 0 1 1 0 0 0 1 3.28922e-7 0 1 3.28922e-7 -1 0 0</float_array>
-          <technique_common>
-            <accessor source="#collision_pad1Mesh_008-mesh-normals-array" count="5" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="collision_pad1Mesh_008-mesh-map-0">
-          <float_array id="collision_pad1Mesh_008-mesh-map-0-array" count="192">0.5 0.9999 0.5 0.5 0.9999 0.5 10e-5 0.9999 10e-5 0.5 0.5 0.5 0.5 0.5 0.5 0.9999 10e-5 0.9999 0.5 10e-5 0.5 0.5 10e-5 0.5 0.5 0.5 0.5 10e-5 0.9999 10e-5 0.9999 10e-5 0.9999 0.5 0.5 0.5 0.9999 0.5 0.9999 0.9999 0.5 0.9999 10e-5 0.5 10e-5 10e-5 0.5 10e-5 0.5 0.9999 0.5 0.5 0.9999 0.5 10e-5 0.9999 10e-5 0.5 0.5 0.5 0.5 0.5 0.5 0.9999 10e-5 0.9999 0.5 10e-5 0.5 0.5 10e-5 0.5 0.5 0.5 0.5 10e-5 0.9999 10e-5 0.9999 10e-5 0.9999 0.5 0.5 0.5 0.9999 0.5 0.9999 0.9999 0.5 0.9999 10e-5 0.5 10e-5 10e-5 0.5 10e-5 0.5 0.5 0.5 0.9999 0.5 0.9999 0.5 0.9999 0.5 0.5 0.5 0.5 0.5 0.5 10e-5 0.5 10e-5 0.5 10e-5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 10e-5 0.5 10e-5 0.5 10e-5 0.5 0.5 0.5 0.5 0.9999 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.9999 0.5 0.9999 0.5 0.5 0.9999 0.5 0.5 0.9999 0.5 10e-5 0.9999 10e-5 0.5 0.5 0.5 0.5 0.5 0.5 0.9999 10e-5 0.9999 0.5 10e-5 0.5 0.5 10e-5 0.5 0.5 0.5 0.5 10e-5 0.9999 10e-5 0.9999 10e-5 0.9999 0.5 0.5 0.5 0.9999 0.5 0.9999 0.9999 0.5 0.9999 10e-5 0.5 10e-5 10e-5 0.5 10e-5</float_array>
-          <technique_common>
-            <accessor source="#collision_pad1Mesh_008-mesh-map-0-array" count="96" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="collision_pad1Mesh_008-mesh-vertices">
-          <input semantic="POSITION" source="#collision_pad1Mesh_008-mesh-positions"/>
-        </vertices>
-        <triangles material="JoinedMaterial__2-material" count="32">
-          <input semantic="VERTEX" source="#collision_pad1Mesh_008-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#collision_pad1Mesh_008-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#collision_pad1Mesh_008-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 1 0 1 5 0 2 2 0 3 7 0 4 1 0 5 1 0 6 0 0 7 2 0 8 3 0 9 1 0 10 7 0 11 1 0 12 3 0 13 4 0 14 4 0 15 5 0 16 1 0 17 5 0 18 6 0 19 0 0 20 7 0 21 8 0 22 3 0 23 26 0 24 25 0 25 28 0 26 23 0 27 24 0 28 25 0 29 25 0 30 26 0 31 23 0 32 31 0 33 25 0 34 24 0 35 25 0 36 31 0 37 27 0 38 27 0 39 28 0 40 25 0 41 28 0 42 29 0 43 26 0 44 24 0 45 30 0 46 31 0 47 34 1 48 32 1 49 20 1 50 20 1 51 18 1 52 34 1 53 34 2 54 33 2 55 13 2 56 13 3 57 18 3 58 34 3 59 34 4 60 35 4 61 22 4 62 22 4 63 18 4 64 34 4 65 36 2 66 34 2 67 18 2 68 18 3 69 17 3 70 36 3 71 11 0 72 14 0 73 15 0 74 21 0 75 19 0 76 14 0 77 14 0 78 11 0 79 21 0 80 9 0 81 14 0 82 19 0 83 14 0 84 9 0 85 16 0 86 16 0 87 15 0 88 14 0 89 15 0 90 12 0 91 11 0 92 19 0 93 10 0 94 9 0 95</p>
-        </triangles>
-      </mesh>
-    </geometry>
     <geometry id="Cube_014-mesh" name="Cube.014">
       <mesh>
         <source id="Cube_014-mesh-positions">
@@ -160,6 +118,48 @@
         </triangles>
       </mesh>
     </geometry>
+    <geometry id="collision_pad1Mesh_007-mesh" name="collision_pad1Mesh.007">
+      <mesh>
+        <source id="collision_pad1Mesh_007-mesh-positions">
+          <float_array id="collision_pad1Mesh_007-mesh-positions-array" count="111">0 89.27861 498.5058 0 0 498.5058 -63.8065 63.8065 498.5058 0 -89.2786 498.5058 63.8065 -63.80649 498.5058 89.2786 0 498.5058 63.8065 63.8065 498.5058 -89.2786 0 498.5058 -63.8065 -63.80649 498.5058 0 -89.2786 562.0177 -63.8065 -63.80649 562.0177 0 89.27861 562.0177 63.8065 63.8065 562.0177 -89.2786 0 562.0177 0 0 562.0177 89.2786 0 562.0177 63.8065 -63.80649 562.0177 89.2786 0 562.0177 0 0 562.0177 -89.2786 0 562.0177 0 89.27861 562.0177 -63.8065 63.8065 562.0177 0 -89.2786 562.0177 -63.8065 63.8065 527.421 -89.2786 0 527.421 0 0 527.421 0 89.27861 527.421 63.8065 -63.80649 527.421 89.2786 0 527.421 63.8065 63.8065 527.421 -63.8065 -63.80649 527.421 0 -89.2786 527.421 0 89.27863 498.5058 -89.2786 2.60664e-5 498.5058 0 2.60664e-5 498.5058 0 -89.27857 498.5058 89.2786 2.60664e-5 498.5058</float_array>
+          <technique_common>
+            <accessor source="#collision_pad1Mesh_007-mesh-positions-array" count="37" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="collision_pad1Mesh_007-mesh-normals">
+          <float_array id="collision_pad1Mesh_007-mesh-normals-array" count="33">0 0 1 1.02858e-6 0 1 -3.42861e-7 0 1 -1.71205e-6 0 1 5.70682e-7 0 1 1 0 0 0 1 4.086e-7 0 1 4.086e-7 -1 0 0 6.85721e-7 0 1 -1.14136e-6 0 1</float_array>
+          <technique_common>
+            <accessor source="#collision_pad1Mesh_007-mesh-normals-array" count="11" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="collision_pad1Mesh_007-mesh-map-0">
+          <float_array id="collision_pad1Mesh_007-mesh-map-0-array" count="192">0.5 0.9999 0.5 0.5 0.9999 0.5 10e-5 0.9999 10e-5 0.5 0.5 0.5 0.5 0.5 0.5 0.9999 10e-5 0.9999 0.5 10e-5 0.5 0.5 10e-5 0.5 0.5 0.5 0.5 10e-5 0.9999 10e-5 0.9999 10e-5 0.9999 0.5 0.5 0.5 0.9999 0.5 0.9999 0.9999 0.5 0.9999 10e-5 0.5 10e-5 10e-5 0.5 10e-5 0.5 0.9999 0.5 0.5 0.9999 0.5 10e-5 0.9999 10e-5 0.5 0.5 0.5 0.5 0.5 0.5 0.9999 10e-5 0.9999 0.5 10e-5 0.5 0.5 10e-5 0.5 0.5 0.5 0.5 10e-5 0.9999 10e-5 0.9999 10e-5 0.9999 0.5 0.5 0.5 0.9999 0.5 0.9999 0.9999 0.5 0.9999 10e-5 0.5 10e-5 10e-5 0.5 10e-5 0.5 0.5 0.5 0.9999 0.5 0.9999 0.5 0.9999 0.5 0.5 0.5 0.5 0.5 0.5 10e-5 0.5 10e-5 0.5 10e-5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 10e-5 0.5 10e-5 0.5 10e-5 0.5 0.5 0.5 0.5 0.9999 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.9999 0.5 0.9999 0.5 0.5 0.9999 0.5 0.5 0.9999 0.5 10e-5 0.9999 10e-5 0.5 0.5 0.5 0.5 0.5 0.5 0.9999 10e-5 0.9999 0.5 10e-5 0.5 0.5 10e-5 0.5 0.5 0.5 0.5 10e-5 0.9999 10e-5 0.9999 10e-5 0.9999 0.5 0.5 0.5 0.9999 0.5 0.9999 0.9999 0.5 0.9999 10e-5 0.5 10e-5 10e-5 0.5 10e-5</float_array>
+          <technique_common>
+            <accessor source="#collision_pad1Mesh_007-mesh-map-0-array" count="96" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="collision_pad1Mesh_007-mesh-vertices">
+          <input semantic="POSITION" source="#collision_pad1Mesh_007-mesh-positions"/>
+        </vertices>
+        <triangles material="JoinedMaterial__2-material" count="32">
+          <input semantic="VERTEX" source="#collision_pad1Mesh_007-mesh-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#collision_pad1Mesh_007-mesh-normals" offset="1"/>
+          <input semantic="TEXCOORD" source="#collision_pad1Mesh_007-mesh-map-0" offset="2" set="0"/>
+          <p>0 0 0 1 0 1 5 0 2 2 0 3 7 0 4 1 0 5 1 0 6 0 0 7 2 0 8 3 0 9 1 0 10 7 0 11 1 0 12 3 0 13 4 0 14 4 0 15 5 0 16 1 0 17 5 0 18 6 0 19 0 0 20 7 0 21 8 0 22 3 0 23 26 0 24 25 0 25 28 0 26 23 0 27 24 0 28 25 0 29 25 1 30 26 1 31 23 1 32 31 0 33 25 0 34 24 0 35 25 2 36 31 2 37 27 2 38 27 0 39 28 0 40 25 0 41 28 3 42 29 3 43 26 3 44 24 4 45 30 4 46 31 4 47 34 5 48 32 5 49 20 5 50 20 5 51 18 5 52 34 5 53 34 6 54 33 6 55 13 6 56 13 7 57 18 7 58 34 7 59 34 8 60 35 8 61 22 8 62 22 8 63 18 8 64 34 8 65 36 6 66 34 6 67 18 6 68 18 7 69 17 7 70 36 7 71 11 0 72 14 0 73 15 0 74 21 0 75 19 0 76 14 0 77 14 9 78 11 9 79 21 9 80 9 0 81 14 0 82 19 0 83 14 0 84 9 0 85 16 0 86 16 0 87 15 0 88 14 0 89 15 10 90 12 10 91 11 10 92 19 0 93 10 0 94 9 0 95</p>
+        </triangles>
+      </mesh>
+    </geometry>
     <geometry id="Plane_006-mesh" name="Plane.006">
       <mesh>
         <source id="Plane_006-mesh-positions">
@@ -173,9 +173,9 @@
           </technique_common>
         </source>
         <source id="Plane_006-mesh-normals">
-          <float_array id="Plane_006-mesh-normals-array" count="15">-1 0 0 0 -1.80709e-7 1 -0.005188226 0.9999865 0 -1 0 0 0 -2.71064e-7 1</float_array>
+          <float_array id="Plane_006-mesh-normals-array" count="12">-1 0 0 0 -2.25886e-7 1 -0.005214691 0.9999864 0 -0.005214691 0.9999865 0</float_array>
           <technique_common>
-            <accessor source="#Plane_006-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_006-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -183,36 +183,36 @@
           </technique_common>
         </source>
         <source id="Plane_006-mesh-map-0">
-          <float_array id="Plane_006-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_006-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_006-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_006-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_006-mesh-map-1">
-          <float_array id="Plane_006-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3918218 0.6963986 0.4903964 0.5552033 0.3917729 0.555238 0 0 0 0 0 0 0 0 0 0 0 0 0.3918218 0.6963986 0.4904453 0.6963641 0.4903964 0.5552033</float_array>
+          <float_array id="Plane_006-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3917729 0.555238 0.3918218 0.6963986 0.4904453 0.6963641 0.4903964 0.5552033</float_array>
           <technique_common>
-            <accessor source="#Plane_006-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_006-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_006-mesh-map-2">
-          <float_array id="Plane_006-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3914743 0.6961722 0.4903317 0.5546731 0.3914726 0.5546743 0 0 0 0 0 0 0 0 0 0 0 0 0.3914743 0.6961722 0.4903334 0.6961711 0.4903317 0.5546731</float_array>
+          <float_array id="Plane_006-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3914726 0.5546743 0.3914743 0.6961722 0.4903334 0.6961711 0.4903317 0.5546731</float_array>
           <technique_common>
-            <accessor source="#Plane_006-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_006-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_006-mesh-colors-Col" name="Col">
-          <float_array id="Plane_006-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_006-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_006-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_006-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -223,15 +223,16 @@
         <vertices id="Plane_006-mesh-vertices">
           <input semantic="POSITION" source="#Plane_006-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_006-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_006-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_006-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_006-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_006-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_006-mesh-colors-Col" offset="3" set="0"/>
-          <p>1 0 0 0 2 0 1 1 3 0 2 2 4 1 3 3 7 1 4 4 5 1 5 5 10 2 6 6 9 2 7 7 8 2 8 8 1 3 9 9 0 3 10 10 2 3 11 11 4 4 12 12 6 4 13 13 7 4 14 14 10 2 15 15 11 2 16 16 9 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 8 2 8 8 10 3 9 9 11 2 10 10 9 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_004-mesh" name="Plane.004">
@@ -247,9 +248,9 @@
           </technique_common>
         </source>
         <source id="Plane_004-mesh-normals">
-          <float_array id="Plane_004-mesh-normals-array" count="15">-1 0 0 0 -1.80709e-7 1 0.009430348 0.9999555 0 -1 0 0 0 -2.71064e-7 1</float_array>
+          <float_array id="Plane_004-mesh-normals-array" count="12">-1 0 0 0 -2.25886e-7 1 0.009447216 0.9999554 0 0.009447216 0.9999555 0</float_array>
           <technique_common>
-            <accessor source="#Plane_004-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_004-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -257,36 +258,36 @@
           </technique_common>
         </source>
         <source id="Plane_004-mesh-map-0">
-          <float_array id="Plane_004-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_004-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_004-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_004-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_004-mesh-map-1">
-          <float_array id="Plane_004-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3920181 0.6962958 0.4906905 0.5551689 0.4906418 0.6963298 0 0 0 0 0 0 0 0 0 0 0 0 0.3920181 0.6962958 0.3920668 0.5551349 0.4906905 0.5551689</float_array>
+          <float_array id="Plane_004-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4906418 0.6963298 0.3920181 0.6962958 0.3920668 0.5551349 0.4906905 0.5551689</float_array>
           <technique_common>
-            <accessor source="#Plane_004-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_004-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_004-mesh-map-2">
-          <float_array id="Plane_004-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3914743 0.6961722 0.4903317 0.5546731 0.4903334 0.6961711 0 0 0 0 0 0 0 0 0 0 0 0 0.3914743 0.6961722 0.3914726 0.5546743 0.4903317 0.5546731</float_array>
+          <float_array id="Plane_004-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4903334 0.6961711 0.3914743 0.6961722 0.3914726 0.5546743 0.4903317 0.5546731</float_array>
           <technique_common>
-            <accessor source="#Plane_004-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_004-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_004-mesh-colors-Col" name="Col">
-          <float_array id="Plane_004-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_004-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_004-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_004-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -297,15 +298,16 @@
         <vertices id="Plane_004-mesh-vertices">
           <input semantic="POSITION" source="#Plane_004-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_004-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_004-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_004-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_004-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_004-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_004-mesh-colors-Col" offset="3" set="0"/>
-          <p>1 0 0 0 2 0 1 1 3 0 2 2 5 1 3 3 6 1 4 4 7 1 5 5 10 2 6 6 9 2 7 7 11 2 8 8 1 3 9 9 0 3 10 10 2 3 11 11 5 4 12 12 4 4 13 13 6 4 14 14 10 2 15 15 8 2 16 16 9 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 11 2 8 8 10 3 9 9 8 2 10 10 9 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_005-mesh" name="Plane.005">
@@ -321,9 +323,9 @@
           </technique_common>
         </source>
         <source id="Plane_005-mesh-normals">
-          <float_array id="Plane_005-mesh-normals-array" count="15">-1 0 0 0 -1.80709e-7 1 0.003204524 0.9999949 0 -1 0 0 0 -2.71064e-7 1</float_array>
+          <float_array id="Plane_005-mesh-normals-array" count="12">-1 0 0 0 -2.25886e-7 1 0.003211975 0.9999949 0 0.003211975 0.9999949 0</float_array>
           <technique_common>
-            <accessor source="#Plane_005-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_005-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -331,36 +333,36 @@
           </technique_common>
         </source>
         <source id="Plane_005-mesh-map-0">
-          <float_array id="Plane_005-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_005-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_005-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_005-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_005-mesh-map-1">
-          <float_array id="Plane_005-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.4903964 0.5552033 0.4906418 0.6963298 0.4906905 0.5551689 0 0 0 0 0 0 0 0 0 0 0 0 0.4903964 0.5552033 0.4904453 0.6963641 0.4906418 0.6963298</float_array>
+          <float_array id="Plane_005-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4903964 0.5552033 0.4904453 0.6963641 0.4906418 0.6963298 0.4906905 0.5551689</float_array>
           <technique_common>
-            <accessor source="#Plane_005-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_005-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_005-mesh-map-2">
-          <float_array id="Plane_005-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.4903317 0.5546731 0.4903334 0.6961711 0.4903317 0.5546731 0 0 0 0 0 0 0 0 0 0 0 0 0.4903317 0.5546731 0.4903334 0.6961711 0.4903334 0.6961711</float_array>
+          <float_array id="Plane_005-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4903317 0.5546731 0.4903334 0.6961711 0.4903334 0.6961711 0.4903317 0.5546731</float_array>
           <technique_common>
-            <accessor source="#Plane_005-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_005-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_005-mesh-colors-Col" name="Col">
-          <float_array id="Plane_005-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_005-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_005-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_005-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -371,15 +373,16 @@
         <vertices id="Plane_005-mesh-vertices">
           <input semantic="POSITION" source="#Plane_005-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_005-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_005-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_005-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_005-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_005-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_005-mesh-colors-Col" offset="3" set="0"/>
-          <p>1 0 0 0 2 0 1 1 3 0 2 2 4 1 3 3 7 1 4 4 5 1 5 5 8 2 6 6 11 2 7 7 10 2 8 8 1 3 9 9 0 3 10 10 2 3 11 11 4 4 12 12 6 4 13 13 7 4 14 14 8 2 15 15 9 2 16 16 11 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 8 2 8 8 9 3 9 9 11 2 10 10 10 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_007-mesh" name="Plane.007">
@@ -395,9 +398,9 @@
           </technique_common>
         </source>
         <source id="Plane_007-mesh-normals">
-          <float_array id="Plane_007-mesh-normals-array" count="15">-1 0 0 0 -1.80709e-7 1 -0.005188226 0.9999865 0 -1 0 0 0 -2.71064e-7 1</float_array>
+          <float_array id="Plane_007-mesh-normals-array" count="12">-1 0 0 0 -2.25886e-7 1 -0.005214691 0.9999864 1.36726e-7 -0.005214691 0.9999864 1.36726e-7</float_array>
           <technique_common>
-            <accessor source="#Plane_007-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_007-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -405,36 +408,36 @@
           </technique_common>
         </source>
         <source id="Plane_007-mesh-map-0">
-          <float_array id="Plane_007-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_007-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_007-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_007-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_007-mesh-map-1">
-          <float_array id="Plane_007-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3918707 0.8375591 0.4904453 0.6963641 0.3918218 0.6963986 0 0 0 0 0 0 0 0 0 0 0 0 0.3918707 0.8375591 0.4904941 0.8375248 0.4904453 0.6963641</float_array>
+          <float_array id="Plane_007-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3918218 0.6963986 0.3918707 0.8375591 0.4904941 0.8375248 0.4904453 0.6963641</float_array>
           <technique_common>
-            <accessor source="#Plane_007-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_007-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_007-mesh-map-2">
-          <float_array id="Plane_007-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3914759 0.83767 0.4903334 0.6961711 0.3914743 0.6961722 0 0 0 0 0 0 0 0 0 0 0 0 0.3914759 0.83767 0.4903351 0.8376689 0.4903334 0.6961711</float_array>
+          <float_array id="Plane_007-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3914743 0.6961722 0.3914759 0.83767 0.4903351 0.8376689 0.4903334 0.6961711</float_array>
           <technique_common>
-            <accessor source="#Plane_007-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_007-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_007-mesh-colors-Col" name="Col">
-          <float_array id="Plane_007-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_007-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_007-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_007-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -445,15 +448,16 @@
         <vertices id="Plane_007-mesh-vertices">
           <input semantic="POSITION" source="#Plane_007-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_007-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_007-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_007-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_007-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_007-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_007-mesh-colors-Col" offset="3" set="0"/>
-          <p>1 0 0 0 2 0 1 1 3 0 2 2 4 1 3 3 7 1 4 4 5 1 5 5 10 2 6 6 9 2 7 7 8 2 8 8 1 3 9 9 0 3 10 10 2 3 11 11 4 4 12 12 6 4 13 13 7 4 14 14 10 2 15 15 11 2 16 16 9 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 8 2 8 8 10 3 9 9 11 2 10 10 9 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_009-mesh" name="Plane.009">
@@ -469,9 +473,9 @@
           </technique_common>
         </source>
         <source id="Plane_009-mesh-normals">
-          <float_array id="Plane_009-mesh-normals-array" count="15">-1 0 0 0 -1.80709e-7 1 0.009430348 0.9999555 0 -1 0 0 0 -2.71064e-7 1</float_array>
+          <float_array id="Plane_009-mesh-normals-array" count="12">-1 0 0 0 -2.25886e-7 1 0.009447216 0.9999554 0 0.009447216 0.9999555 0</float_array>
           <technique_common>
-            <accessor source="#Plane_009-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_009-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -479,36 +483,36 @@
           </technique_common>
         </source>
         <source id="Plane_009-mesh-map-0">
-          <float_array id="Plane_009-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_009-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_009-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_009-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_009-mesh-map-1">
-          <float_array id="Plane_009-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3919694 0.8374567 0.4906418 0.6963298 0.4905931 0.8374907 0 0 0 0 0 0 0 0 0 0 0 0 0.3919694 0.8374567 0.3920181 0.6962958 0.4906418 0.6963298</float_array>
+          <float_array id="Plane_009-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4905931 0.8374907 0.3919694 0.8374567 0.3920181 0.6962958 0.4906418 0.6963298</float_array>
           <technique_common>
-            <accessor source="#Plane_009-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_009-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_009-mesh-map-2">
-          <float_array id="Plane_009-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3914759 0.83767 0.4903334 0.6961711 0.4903351 0.8376689 0 0 0 0 0 0 0 0 0 0 0 0 0.3914759 0.83767 0.3914743 0.6961722 0.4903334 0.6961711</float_array>
+          <float_array id="Plane_009-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4903351 0.8376689 0.3914759 0.83767 0.3914743 0.6961722 0.4903334 0.6961711</float_array>
           <technique_common>
-            <accessor source="#Plane_009-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_009-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_009-mesh-colors-Col" name="Col">
-          <float_array id="Plane_009-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_009-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_009-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_009-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -519,15 +523,16 @@
         <vertices id="Plane_009-mesh-vertices">
           <input semantic="POSITION" source="#Plane_009-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_009-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_009-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_009-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_009-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_009-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_009-mesh-colors-Col" offset="3" set="0"/>
-          <p>1 0 0 0 2 0 1 1 3 0 2 2 5 1 3 3 6 1 4 4 7 1 5 5 10 2 6 6 9 2 7 7 8 2 8 8 1 3 9 9 0 3 10 10 2 3 11 11 5 4 12 12 4 4 13 13 6 4 14 14 10 2 15 15 11 2 16 16 9 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 8 2 8 8 10 3 9 9 11 2 10 10 9 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_008-mesh" name="Plane.008">
@@ -543,9 +548,9 @@
           </technique_common>
         </source>
         <source id="Plane_008-mesh-normals">
-          <float_array id="Plane_008-mesh-normals-array" count="15">-1 0 0 0 -1.80709e-7 1 0.003204524 0.9999949 0 -1 0 0 0 -2.71064e-7 1</float_array>
+          <float_array id="Plane_008-mesh-normals-array" count="12">-1 0 0 0 -2.25886e-7 1 0.003211975 0.9999949 0 0.003211975 0.9999949 0</float_array>
           <technique_common>
-            <accessor source="#Plane_008-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_008-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -553,36 +558,36 @@
           </technique_common>
         </source>
         <source id="Plane_008-mesh-map-0">
-          <float_array id="Plane_008-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_008-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_008-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_008-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_008-mesh-map-1">
-          <float_array id="Plane_008-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.4904453 0.6963641 0.4905931 0.8374907 0.4906418 0.6963298 0 0 0 0 0 0 0 0 0 0 0 0 0.4904453 0.6963641 0.4904941 0.8375248 0.4905931 0.8374907</float_array>
+          <float_array id="Plane_008-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4904453 0.6963641 0.4904941 0.8375248 0.4905931 0.8374907 0.4906418 0.6963298</float_array>
           <technique_common>
-            <accessor source="#Plane_008-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_008-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_008-mesh-map-2">
-          <float_array id="Plane_008-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.4903334 0.6961711 0.4903351 0.8376689 0.4903334 0.6961711 0 0 0 0 0 0 0 0 0 0 0 0 0.4903334 0.6961711 0.4903351 0.8376689 0.4903351 0.8376689</float_array>
+          <float_array id="Plane_008-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4903334 0.6961711 0.4903351 0.8376689 0.4903351 0.8376689 0.4903334 0.6961711</float_array>
           <technique_common>
-            <accessor source="#Plane_008-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_008-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_008-mesh-colors-Col" name="Col">
-          <float_array id="Plane_008-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_008-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_008-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_008-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -593,15 +598,16 @@
         <vertices id="Plane_008-mesh-vertices">
           <input semantic="POSITION" source="#Plane_008-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_008-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_008-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_008-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_008-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_008-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_008-mesh-colors-Col" offset="3" set="0"/>
-          <p>1 0 0 0 2 0 1 1 3 0 2 2 5 1 3 3 6 1 4 4 7 1 5 5 11 2 6 6 8 2 7 7 9 2 8 8 1 3 9 9 0 3 10 10 2 3 11 11 5 4 12 12 4 4 13 13 6 4 14 14 11 2 15 15 10 2 16 16 8 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 11 2 8 8 10 3 9 9 8 2 10 10 9 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_003-mesh" name="Plane.003">
@@ -617,9 +623,9 @@
           </technique_common>
         </source>
         <source id="Plane_003-mesh-normals">
-          <float_array id="Plane_003-mesh-normals-array" count="15">-1 0 0 -0.008250415 -1.80587e-7 0.999966 -0.005188226 0.9999865 0 -1 0 0 -0.008250415 -2.70766e-7 0.999966</float_array>
+          <float_array id="Plane_003-mesh-normals-array" count="12">-1 0 0 -0.008250415 -2.25729e-7 0.999966 -0.005214691 0.9999864 1.36726e-7 -0.005214691 0.9999865 1.36726e-7</float_array>
           <technique_common>
-            <accessor source="#Plane_003-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_003-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -627,36 +633,36 @@
           </technique_common>
         </source>
         <source id="Plane_003-mesh-map-0">
-          <float_array id="Plane_003-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_003-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_003-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_003-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_003-mesh-map-1">
-          <float_array id="Plane_003-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3919197 0.9787197 0.4904941 0.8375248 0.3918707 0.8375591 0 0 0 0 0 0 0 0 0 0 0 0 0.3919197 0.9787197 0.490543 0.9786855 0.4904941 0.8375248</float_array>
+          <float_array id="Plane_003-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3918707 0.8375591 0.3919197 0.9787197 0.490543 0.9786855 0.4904941 0.8375248</float_array>
           <technique_common>
-            <accessor source="#Plane_003-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_003-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_003-mesh-map-2">
-          <float_array id="Plane_003-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3914775 0.9791679 0.4903351 0.8376689 0.3914759 0.83767 0 0 0 0 0 0 0 0 0 0 0 0 0.3914775 0.9791679 0.4903367 0.9791668 0.4903351 0.8376689</float_array>
+          <float_array id="Plane_003-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3914759 0.83767 0.3914775 0.9791679 0.4903367 0.9791668 0.4903351 0.8376689</float_array>
           <technique_common>
-            <accessor source="#Plane_003-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_003-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_003-mesh-colors-Col" name="Col">
-          <float_array id="Plane_003-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_003-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_003-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_003-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -667,15 +673,16 @@
         <vertices id="Plane_003-mesh-vertices">
           <input semantic="POSITION" source="#Plane_003-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_003-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_003-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_003-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_003-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_003-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_003-mesh-colors-Col" offset="3" set="0"/>
-          <p>1 0 0 0 2 0 1 1 3 0 2 2 4 1 3 3 7 1 4 4 5 1 5 5 8 2 6 6 11 2 7 7 10 2 8 8 1 3 9 9 0 3 10 10 2 3 11 11 4 4 12 12 6 4 13 13 7 4 14 14 8 2 15 15 9 2 16 16 11 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 10 2 8 8 8 2 9 9 9 3 10 10 11 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_010-mesh" name="Plane.010">
@@ -691,9 +698,9 @@
           </technique_common>
         </source>
         <source id="Plane_010-mesh-normals">
-          <float_array id="Plane_010-mesh-normals-array" count="15">-1 0 0 0 -1.80709e-7 1 0.009430348 0.9999555 0 -1 0 0 0 -2.71064e-7 1</float_array>
+          <float_array id="Plane_010-mesh-normals-array" count="12">-1 0 0 0 -2.25886e-7 1 0.009447216 0.9999555 0 0.009447216 0.9999554 0</float_array>
           <technique_common>
-            <accessor source="#Plane_010-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_010-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -701,36 +708,36 @@
           </technique_common>
         </source>
         <source id="Plane_010-mesh-map-0">
-          <float_array id="Plane_010-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_010-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_010-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_010-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_010-mesh-map-1">
-          <float_array id="Plane_010-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3919207 0.9786177 0.4905931 0.8374907 0.4905444 0.9786517 0 0 0 0 0 0 0 0 0 0 0 0 0.3919207 0.9786177 0.3919694 0.8374567 0.4905931 0.8374907</float_array>
+          <float_array id="Plane_010-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4905444 0.9786517 0.3919207 0.9786177 0.3919694 0.8374567 0.4905931 0.8374907</float_array>
           <technique_common>
-            <accessor source="#Plane_010-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_010-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_010-mesh-map-2">
-          <float_array id="Plane_010-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.3914775 0.9791679 0.4903351 0.8376689 0.4903367 0.9791668 0 0 0 0 0 0 0 0 0 0 0 0 0.3914775 0.9791679 0.3914759 0.83767 0.4903351 0.8376689</float_array>
+          <float_array id="Plane_010-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4903367 0.9791668 0.3914775 0.9791679 0.3914759 0.83767 0.4903351 0.8376689</float_array>
           <technique_common>
-            <accessor source="#Plane_010-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_010-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_010-mesh-colors-Col" name="Col">
-          <float_array id="Plane_010-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_010-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_010-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_010-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -741,15 +748,16 @@
         <vertices id="Plane_010-mesh-vertices">
           <input semantic="POSITION" source="#Plane_010-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_010-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_010-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_010-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_010-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_010-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_010-mesh-colors-Col" offset="3" set="0"/>
-          <p>0 0 0 0 3 0 1 1 1 0 2 2 5 1 3 3 6 1 4 4 7 1 5 5 10 2 6 6 9 2 7 7 11 2 8 8 0 3 9 9 2 3 10 10 3 3 11 11 5 4 12 12 4 4 13 13 6 4 14 14 10 2 15 15 8 2 16 16 9 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 11 2 8 8 10 3 9 9 8 2 10 10 9 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_011-mesh" name="Plane.011">
@@ -765,9 +773,9 @@
           </technique_common>
         </source>
         <source id="Plane_011-mesh-normals">
-          <float_array id="Plane_011-mesh-normals-array" count="15">-1 0 0 0 -1.80709e-7 1 0.003204524 0.9999949 0 -1 0 0 0 -2.71064e-7 1</float_array>
+          <float_array id="Plane_011-mesh-normals-array" count="12">-1 0 0 0 -2.25886e-7 1 0.003211975 0.9999949 0 0.003211975 0.9999949 0</float_array>
           <technique_common>
-            <accessor source="#Plane_011-mesh-normals-array" count="5" stride="3">
+            <accessor source="#Plane_011-mesh-normals-array" count="4" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -775,36 +783,36 @@
           </technique_common>
         </source>
         <source id="Plane_011-mesh-map-0">
-          <float_array id="Plane_011-mesh-map-0-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_011-mesh-map-0-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_011-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_011-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_011-mesh-map-1">
-          <float_array id="Plane_011-mesh-map-1-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.4904941 0.8375248 0.4905444 0.9786517 0.4905931 0.8374907 0 0 0 0 0 0 0 0 0 0 0 0 0.4904941 0.8375248 0.490543 0.9786855 0.4905444 0.9786517</float_array>
+          <float_array id="Plane_011-mesh-map-1-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4904941 0.8375248 0.490543 0.9786855 0.4905444 0.9786517 0.4905931 0.8374907</float_array>
           <technique_common>
-            <accessor source="#Plane_011-mesh-map-1-array" count="18" stride="2">
+            <accessor source="#Plane_011-mesh-map-1-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_011-mesh-map-2">
-          <float_array id="Plane_011-mesh-map-2-array" count="36">0 0 0 0 0 0 0 0 0 0 0 0 0.4903351 0.8376689 0.4903367 0.9791668 0.4903351 0.8376689 0 0 0 0 0 0 0 0 0 0 0 0 0.4903351 0.8376689 0.4903367 0.9791668 0.4903367 0.9791668</float_array>
+          <float_array id="Plane_011-mesh-map-2-array" count="24">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4903351 0.8376689 0.4903367 0.9791668 0.4903367 0.9791668 0.4903351 0.8376689</float_array>
           <technique_common>
-            <accessor source="#Plane_011-mesh-map-2-array" count="18" stride="2">
+            <accessor source="#Plane_011-mesh-map-2-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
           </technique_common>
         </source>
         <source id="Plane_011-mesh-colors-Col" name="Col">
-          <float_array id="Plane_011-mesh-colors-Col-array" count="72">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
+          <float_array id="Plane_011-mesh-colors-Col-array" count="48">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
-            <accessor source="#Plane_011-mesh-colors-Col-array" count="18" stride="4">
+            <accessor source="#Plane_011-mesh-colors-Col-array" count="12" stride="4">
               <param name="R" type="float"/>
               <param name="G" type="float"/>
               <param name="B" type="float"/>
@@ -815,21 +823,22 @@
         <vertices id="Plane_011-mesh-vertices">
           <input semantic="POSITION" source="#Plane_011-mesh-positions"/>
         </vertices>
-        <triangles material="floor_001-material" count="6">
+        <polylist material="floor_001-material" count="3">
           <input semantic="VERTEX" source="#Plane_011-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_011-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_011-mesh-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#Plane_011-mesh-map-1" offset="2" set="1"/>
           <input semantic="TEXCOORD" source="#Plane_011-mesh-map-2" offset="2" set="2"/>
           <input semantic="COLOR" source="#Plane_011-mesh-colors-Col" offset="3" set="0"/>
-          <p>0 0 0 0 3 0 1 1 1 0 2 2 5 1 3 3 6 1 4 4 7 1 5 5 11 2 6 6 8 2 7 7 10 2 8 8 0 3 9 9 2 3 10 10 3 3 11 11 5 4 12 12 4 4 13 13 6 4 14 14 11 2 15 15 9 2 16 16 8 2 17 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>1 0 0 0 0 0 1 1 2 0 2 2 3 0 3 3 5 1 4 4 4 1 5 5 6 1 6 6 7 1 7 7 11 2 8 8 9 3 9 9 8 2 10 10 10 3 11 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_001-mesh" name="Plane.001">
       <mesh>
         <source id="Plane_001-mesh-positions">
-          <float_array id="Plane_001-mesh-positions-array" count="36">-36.79067 0.002928256 -46.91596 37.50193 0.0340771 -46.91602 -36.79071 0.002798557 42.56732 37.50189 0.033957 42.56732 2.7848e-6 0.1326723 -46.80677 -3.32969e-6 0.1326361 42.56732 2.7845e-6 -2.50603 -46.80677 -3.33e-6 -2.506064 42.56732 -36.7908 0.1227688 -1.373835 37.50181 0.1431856 -1.373831 -36.7908 -2.515932 -1.373836 37.50181 -2.495515 -1.373832</float_array>
+          <float_array id="Plane_001-mesh-positions-array" count="36">-36.79067 0.002928256 -46.91596 37.50193 0.0340771 -46.91602 -36.79071 0.002798557 42.56732 37.50189 0.033957 42.56732 2.78482e-6 -0.006156623 -46.80677 -3.32967e-6 -0.006192743 42.56732 2.7845e-6 -2.50603 -46.80677 -3.33e-6 -2.506064 42.56732 -36.7908 -0.01606011 -1.373835 37.50181 0.004356682 -1.373831 -36.7908 -2.515932 -1.373836 37.50181 -2.495515 -1.373832</float_array>
           <technique_common>
             <accessor source="#Plane_001-mesh-positions-array" count="12" stride="3">
               <param name="X" type="float"/>
@@ -839,9 +848,9 @@
           </technique_common>
         </source>
         <source id="Plane_001-mesh-normals">
-          <float_array id="Plane_001-mesh-normals-array" count="18">-4.19273e-4 1 1.3422e-6 1 0 0 0 2.71064e-7 -1 -4.19401e-4 1 1.44878e-6 1 0 0 0 3.16241e-7 -1</float_array>
+          <float_array id="Plane_001-mesh-normals-array" count="9">-4.19337e-4 1 1.39549e-6 1 0 0 0 3.0996e-7 -1</float_array>
           <technique_common>
-            <accessor source="#Plane_001-mesh-normals-array" count="6" stride="3">
+            <accessor source="#Plane_001-mesh-normals-array" count="3" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -849,9 +858,9 @@
           </technique_common>
         </source>
         <source id="Plane_001-mesh-map-0">
-          <float_array id="Plane_001-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_001-mesh-map-0-array" count="24">0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_001-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_001-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
@@ -860,18 +869,19 @@
         <vertices id="Plane_001-mesh-vertices">
           <input semantic="POSITION" source="#Plane_001-mesh-positions"/>
         </vertices>
-        <triangles count="6">
+        <polylist count="3">
           <input semantic="VERTEX" source="#Plane_001-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_001-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_001-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 5 1 3 6 1 4 4 1 5 11 2 6 8 2 7 9 2 8 0 3 9 2 3 10 3 3 11 5 4 12 7 4 13 6 4 14 11 5 15 10 5 16 8 5 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>0 0 0 2 0 1 3 0 2 1 0 3 5 1 4 7 1 5 6 1 6 4 1 7 9 2 8 11 2 9 10 2 10 8 2 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_002-mesh" name="Plane.002">
       <mesh>
         <source id="Plane_002-mesh-positions">
-          <float_array id="Plane_002-mesh-positions-array" count="36">-72.78211 -0.06702548 -91.35774 73.58309 0.1391649 -91.3577 -72.87258 0.005350768 87.43787 73.58303 0.1389174 87.43791 3.98343e-4 0.1326792 -91.35774 3.88683e-4 0.1326282 87.43788 3.98343e-4 -2.506023 -91.35771 3.88682e-4 -2.506072 87.43791 -72.78231 0.113318 -3.568856 73.58306 0.1527228 -3.568849 -72.78231 -2.525383 -3.568827 73.58306 -2.485977 -3.56882</float_array>
+          <float_array id="Plane_002-mesh-positions-array" count="36">-72.78211 -0.06702548 -91.35774 73.58309 0.1391649 -91.3577 -72.87258 0.005350768 87.43787 73.58303 0.1389174 87.43791 3.98343e-4 0.02926808 -91.35774 3.88683e-4 0.02921706 87.43788 3.98343e-4 -2.506023 -91.35771 3.88682e-4 -2.506072 87.43791 -72.78231 0.009906947 -3.568856 73.58306 0.04931169 -3.568849 -72.78231 -2.525383 -3.568827 73.58306 -2.485977 -3.56882</float_array>
           <technique_common>
             <accessor source="#Plane_002-mesh-positions-array" count="12" stride="3">
               <param name="X" type="float"/>
@@ -881,9 +891,9 @@
           </technique_common>
         </source>
         <source id="Plane_002-mesh-normals">
-          <float_array id="Plane_002-mesh-normals-array" count="18">-0.001408696 0.9999991 1.38383e-6 1 0 0 0 -1.11136e-5 -1 -9.11993e-4 0.9999995 -4.0526e-4 1 0 0 0 -1.09329e-5 -1</float_array>
+          <float_array id="Plane_002-mesh-normals-array" count="9">-0.001160264 0.9999994 -2.02001e-4 1 0 0 0 -1.14729e-5 -1</float_array>
           <technique_common>
-            <accessor source="#Plane_002-mesh-normals-array" count="6" stride="3">
+            <accessor source="#Plane_002-mesh-normals-array" count="3" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -891,9 +901,9 @@
           </technique_common>
         </source>
         <source id="Plane_002-mesh-map-0">
-          <float_array id="Plane_002-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_002-mesh-map-0-array" count="24">0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_002-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_002-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
@@ -902,20 +912,33 @@
         <vertices id="Plane_002-mesh-vertices">
           <input semantic="POSITION" source="#Plane_002-mesh-positions"/>
         </vertices>
-        <triangles count="6">
+        <polylist count="3">
           <input semantic="VERTEX" source="#Plane_002-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_002-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_002-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 5 1 3 6 1 4 4 1 5 11 2 6 8 2 7 9 2 8 0 3 9 2 3 10 3 3 11 5 4 12 7 4 13 6 4 14 11 5 15 10 5 16 8 5 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>0 0 0 2 0 1 3 0 2 1 0 3 5 1 4 7 1 5 6 1 6 4 1 7 9 2 8 11 2 9 10 2 10 8 2 11</p>
+        </polylist>
       </mesh>
     </geometry>
   </library_geometries>
   <library_visual_scenes>
     <visual_scene id="Scene" name="Scene">
-      <node id="collision_port" name="collision_port" type="NODE">
+      <node id="dummy" name="dummy" type="NODE">
+        <matrix sid="transform">1 0 0 -5.22162e-6 0 1 0 118.4497 0 0 1 41.70764 0 0 0 1</matrix>
+        <instance_geometry url="#Cube_014-mesh" name="dummy">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="facade_001-material" target="#facade_001-material">
+                <bind_vertex_input semantic="Cube_014-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_port07" name="collision_port07" type="NODE">
         <matrix sid="transform">1 0 0 0 0 1 -4.37115e-8 0 0 4.37115e-8 1 0 0 0 0 1</matrix>
-        <instance_geometry url="#collision_pad1Mesh_008-mesh" name="collision_port">
+        <instance_geometry url="#collision_pad1Mesh_007-mesh" name="collision_port07">
           <bind_material>
             <technique_common>
               <instance_material symbol="JoinedMaterial__2-material" target="#JoinedMaterial__2-material">
@@ -925,13 +948,85 @@
           </bind_material>
         </instance_geometry>
       </node>
-      <node id="dummy" name="dummy" type="NODE">
-        <matrix sid="transform">1 0 0 -5.22162e-6 0 1 0 118.4497 0 0 1 41.70764 0 0 0 1</matrix>
-        <instance_geometry url="#Cube_014-mesh" name="dummy">
+      <node id="collision_port06" name="collision_port06" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 -4.37115e-8 0 0 4.37115e-8 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#collision_pad1Mesh_007-mesh" name="collision_port06">
           <bind_material>
             <technique_common>
-              <instance_material symbol="facade_001-material" target="#facade_001-material">
-                <bind_vertex_input semantic="Cube_014-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
+              <instance_material symbol="JoinedMaterial__2-material" target="#JoinedMaterial__2-material">
+                <bind_vertex_input semantic="collision_pad1Mesh-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_port05" name="collision_port05" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 -4.37115e-8 0 0 4.37115e-8 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#collision_pad1Mesh_007-mesh" name="collision_port05">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="JoinedMaterial__2-material" target="#JoinedMaterial__2-material">
+                <bind_vertex_input semantic="collision_pad1Mesh-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_port04" name="collision_port04" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 -4.37115e-8 0 0 4.37115e-8 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#collision_pad1Mesh_007-mesh" name="collision_port04">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="JoinedMaterial__2-material" target="#JoinedMaterial__2-material">
+                <bind_vertex_input semantic="collision_pad1Mesh-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_port03" name="collision_port03" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 -4.37115e-8 0 0 4.37115e-8 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#collision_pad1Mesh_007-mesh" name="collision_port03">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="JoinedMaterial__2-material" target="#JoinedMaterial__2-material">
+                <bind_vertex_input semantic="collision_pad1Mesh-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_port02" name="collision_port02" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 -4.37115e-8 0 0 4.37115e-8 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#collision_pad1Mesh_007-mesh" name="collision_port02">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="JoinedMaterial__2-material" target="#JoinedMaterial__2-material">
+                <bind_vertex_input semantic="collision_pad1Mesh-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_port01" name="collision_port01" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 -4.37115e-8 0 0 4.37115e-8 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#collision_pad1Mesh_007-mesh" name="collision_port01">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="JoinedMaterial__2-material" target="#JoinedMaterial__2-material">
+                <bind_vertex_input semantic="collision_pad1Mesh-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+      <node id="collision_port" name="collision_port" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 -4.37115e-8 0 0 4.37115e-8 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#collision_pad1Mesh_007-mesh" name="collision_port">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="JoinedMaterial__2-material" target="#JoinedMaterial__2-material">
+                <bind_vertex_input semantic="collision_pad1Mesh-mesh-map-0" input_semantic="TEXCOORD" input_set="0"/>
               </instance_material>
             </technique_common>
           </bind_material>
@@ -1554,238 +1649,238 @@
         <instance_geometry url="#Plane_001-mesh" name="collision_pad01"/>
       </node>
       <node id="entrance_port07" name="entrance_port07" type="NODE">
-        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86442e-5 -1.50996e-7 1 3.25841e-7 1.63845e-6 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86421e-5 -1.50996e-7 1 3.25841e-7 -0.001437783 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
       </node>
       <node id="entrance_port06" name="entrance_port06" type="NODE">
-        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86442e-5 -1.50996e-7 1 3.25841e-7 1.63845e-6 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86421e-5 -1.50996e-7 1 3.25841e-7 -0.001437783 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
       </node>
       <node id="exit_port06" name="exit_port06" type="NODE">
-        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 2.28882e-5 1.34359e-7 1 -3.01992e-7 -6.10352e-5 3.01992e-7 3.01992e-7 1 -219.3727 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 2.29132e-5 1.34359e-7 1 -3.01992e-7 -0.00150036 3.01992e-7 3.01992e-7 1 -219.3727 0 0 0 1</matrix>
       </node>
       <node id="exit_port05" name="exit_port05" type="NODE">
-        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 -3.55549e-14 1.34359e-7 1 -3.01992e-7 -8.01086e-5 3.01992e-7 3.01992e-7 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 2.66585e-8 1.34359e-7 1 -3.01992e-7 -0.001519433 3.01992e-7 3.01992e-7 1 -160.1249 0 0 0 1</matrix>
       </node>
       <node id="entrance_port01" name="entrance_port01" type="NODE">
-        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86442e-5 -1.50996e-7 1 3.25841e-7 1.63845e-6 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86421e-5 -1.50996e-7 1 3.25841e-7 -0.001437783 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b01" name="loc_A001_p01_s0_50_b01" type="NODE">
-        <matrix sid="transform">9.12384e-4 -0.9999996 -1.97205e-4 111.4373 0.9999996 9.12384e-4 2.2092e-7 -0.3554066 -4.09933e-8 -1.97205e-4 1 450.2831 0 0 0 1</matrix>
+        <matrix sid="transform">9.12384e-4 -0.9999996 -1.97205e-4 111.4192 0.9999996 9.12384e-4 2.2092e-7 2.17438e-4 -4.09933e-8 -1.97205e-4 1 450.3273 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b02" name="loc_A001_p01_s0_50_b02" type="NODE">
-        <matrix sid="transform">-0.7064613 -0.7077516 -1.51848e-6 79.04932 0.7077516 -0.7064613 -1.30236e-6 78.54671 -1.50996e-7 -1.99477e-6 1 450.2831 0 0 0 1</matrix>
+        <matrix sid="transform">-0.7064613 -0.7077516 -1.51848e-6 78.78504 0.7077516 -0.7064613 -1.30236e-6 78.78537 -1.50996e-7 -1.99477e-6 1 450.3273 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b03" name="loc_A001_p01_s0_50_b03" type="NODE">
-        <matrix sid="transform">-0.9999996 -9.1234e-4 -3.91017e-7 0.3553619 9.1234e-4 -0.9999996 -1.756e-6 111.4372 -3.89414e-7 -1.75635e-6 1 450.2831 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9999996 -9.1234e-4 -3.91017e-7 -2.65121e-4 9.1234e-4 -0.9999996 -1.756e-6 111.4191 -3.89414e-7 -1.75635e-6 1 450.3273 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b04" name="loc_A001_p01_s0_50_b04" type="NODE">
-        <matrix sid="transform">-0.7077515 0.7064615 5.04573e-7 -78.54676 -0.7064615 -0.7077515 -1.30421e-6 79.04929 -5.6426e-7 -1.27952e-6 1 450.2831 0 0 0 1</matrix>
+        <matrix sid="transform">-0.7077515 0.7064615 5.04573e-7 -78.78542 -0.7064615 -0.7077515 -1.30421e-6 78.78502 -5.6426e-7 -1.27952e-6 1 450.3273 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b05" name="loc_A001_p01_s0_50_b05" type="NODE">
-        <matrix sid="transform">-9.12384e-4 0.9999996 -6.42859e-5 -111.4373 -0.9999996 -9.12384e-4 -2.67188e-7 0.3553216 -3.25841e-7 6.42856e-5 1 450.2831 0 0 0 1</matrix>
+        <matrix sid="transform">-9.12384e-4 0.9999996 -6.42859e-5 -111.4192 -0.9999996 -9.12384e-4 -2.67188e-7 -3.01361e-4 -3.25841e-7 6.42856e-5 1 450.3273 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b06" name="loc_A001_p01_s0_50_b06" type="NODE">
-        <matrix sid="transform">0.7064616 0.7077514 1.17151e-6 -79.04931 -0.7077514 0.7064616 8.84973e-7 -78.54679 -2.01285e-7 -1.45434e-6 1 450.2831 0 0 0 1</matrix>
+        <matrix sid="transform">0.7064616 0.7077514 1.17151e-6 -78.78503 -0.7077514 0.7064616 8.84973e-7 -78.78545 -2.01285e-7 -1.45434e-6 1 450.3273 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b07" name="loc_A001_p01_s0_50_b07" type="NODE">
-        <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 -0.3553391 -9.12038e-4 0.9999996 1.36694e-6 -111.4373 -3.25927e-7 -1.36724e-6 1 450.2831 0 0 0 1</matrix>
+        <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 2.8801e-4 -9.12038e-4 0.9999996 1.36694e-6 -111.4192 -3.25927e-7 -1.36724e-6 1 450.3273 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b08" name="loc_A001_p01_s0_50_b08" type="NODE">
-        <matrix sid="transform">0.7077509 -0.7064619 -9.63872e-7 78.54678 0.7064619 0.7077509 1.05531e-6 -79.04932 -6.33536e-8 -1.42783e-6 1 450.2831 0 0 0 1</matrix>
+        <matrix sid="transform">0.7077509 -0.7064619 -9.63872e-7 78.78544 0.7064619 0.7077509 1.05531e-6 -78.78505 -6.33536e-8 -1.42783e-6 1 450.3273 0 0 0 1</matrix>
       </node>
       <node id="exit_port01" name="exit_port01" type="NODE">
-        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 -6.04311e-5 1.34359e-7 1 -3.01992e-7 5.51776e-7 3.01992e-7 3.01992e-7 1 449.7744 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 -6.04454e-5 1.34359e-7 1 -3.01992e-7 -0.00143886 3.01992e-7 3.01992e-7 1 449.7744 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b16" name="loc_B001_p02_s0_50_b16" type="NODE">
-        <matrix sid="transform">0.7077509 -0.706462 -9.73372e-7 78.5468 0.706462 0.7077509 1.05531e-6 -79.04933 -5.663e-8 -1.43454e-6 1 361.0183 0 0 0 1</matrix>
+        <matrix sid="transform">0.7077509 -0.706462 -9.73372e-7 78.78552 0.706462 0.7077509 1.05531e-6 -78.78514 -5.663e-8 -1.43454e-6 1 360.844 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b15" name="loc_B001_p02_s0_50_b15" type="NODE">
-        <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 -0.3553271 -9.12038e-4 0.9999996 1.36694e-6 -111.4373 -3.25927e-7 -1.36724e-6 1 361.0183 0 0 0 1</matrix>
+        <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 2.57492e-4 -9.12038e-4 0.9999996 1.36694e-6 -111.4193 -3.25927e-7 -1.36724e-6 1 360.8441 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b14" name="loc_B001_p02_s0_50_b14" type="NODE">
-        <matrix sid="transform">0.7064616 0.7077514 1.17151e-6 -79.04929 -0.7077514 0.7064616 8.84973e-7 -78.5468 -2.01285e-7 -1.45434e-6 1 361.0183 0 0 0 1</matrix>
+        <matrix sid="transform">0.7064616 0.7077514 1.17151e-6 -78.78514 -0.7077514 0.7064616 8.84973e-7 -78.78552 -2.01285e-7 -1.45434e-6 1 360.8443 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b13" name="loc_B001_p02_s0_50_b13" type="NODE">
-        <matrix sid="transform">-9.12384e-4 0.9999996 -6.42859e-5 -111.4372 -0.9999996 -9.12384e-4 -2.67188e-7 0.3553166 -3.25841e-7 6.42856e-5 1 361.0183 0 0 0 1</matrix>
+        <matrix sid="transform">-9.12384e-4 0.9999996 -6.42859e-5 -111.4018 -0.9999996 -9.12384e-4 -2.67188e-7 0.3552004 -3.25841e-7 6.42856e-5 1 361.0183 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b12" name="loc_B001_p02_s0_50_b12" type="NODE">
-        <matrix sid="transform">-0.7077515 0.7064615 5.04573e-7 -78.54675 -0.7064615 -0.7077515 -1.30421e-6 79.04929 -5.6426e-7 -1.27952e-6 1 361.0183 0 0 0 1</matrix>
+        <matrix sid="transform">-0.7077515 0.7064615 5.04573e-7 -78.78546 -0.7064615 -0.7077515 -1.30421e-6 78.78511 -5.6426e-7 -1.27952e-6 1 360.8441 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b11" name="loc_B001_p02_s0_50_b11" type="NODE">
-        <matrix sid="transform">-0.9999996 -9.1234e-4 -3.91017e-7 0.3553739 9.1234e-4 -0.9999996 -1.756e-6 111.4372 -3.89414e-7 -1.75635e-6 1 361.0183 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9999996 -9.1234e-4 -3.91017e-7 -2.34604e-4 9.1234e-4 -0.9999996 -1.756e-6 111.4192 -3.89414e-7 -1.75635e-6 1 360.8441 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b10" name="loc_B001_p02_s0_50_b10" type="NODE">
-        <matrix sid="transform">-0.7064613 -0.7077516 -1.51848e-6 79.04934 0.7077516 -0.7064613 -1.30236e-6 78.54671 -1.50996e-7 -1.99477e-6 1 361.0183 0 0 0 1</matrix>
+        <matrix sid="transform">-0.7064613 -0.7077516 -1.51848e-6 78.78519 0.7077516 -0.7064613 -1.30236e-6 78.78548 -1.50996e-7 -1.99477e-6 1 360.844 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b09" name="loc_B001_p02_s0_50_b09" type="NODE">
-        <matrix sid="transform">9.12384e-4 -0.9999996 -1.97205e-4 111.4373 0.9999996 9.12384e-4 2.2092e-7 -0.3554115 -4.09933e-8 -1.97205e-4 1 361.0183 0 0 0 1</matrix>
+        <matrix sid="transform">9.12384e-4 -0.9999996 -1.97205e-4 111.4368 0.9999996 9.12384e-4 2.2092e-7 1.98364e-4 -4.09933e-8 -1.97205e-4 1 360.8439 0 0 0 1</matrix>
       </node>
       <node id="entrance_port02" name="entrance_port02" type="NODE">
-        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86442e-5 -1.50996e-7 1 3.25841e-7 1.63845e-6 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86421e-5 -1.50996e-7 1 3.25841e-7 -0.001437783 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
       </node>
       <node id="exit_port02" name="exit_port02" type="NODE">
-        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 -4.84894e-5 1.34359e-7 1 -3.01992e-7 -4.39313e-6 3.01992e-7 3.01992e-7 1 360.8954 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 -4.84987e-5 1.34359e-7 1 -3.01992e-7 -0.001443795 3.01992e-7 3.01992e-7 1 360.8954 0 0 0 1</matrix>
       </node>
       <node id="exit_port03" name="exit_port03" type="NODE">
-        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 1.15856e-5 1.34359e-7 1 -3.01992e-7 -2.92694e-5 3.01992e-7 3.01992e-7 1 -86.2278 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 1.1601e-5 1.34359e-7 1 -3.01992e-7 -0.001468618 3.01992e-7 3.01992e-7 1 -86.2278 0 0 0 1</matrix>
       </node>
       <node id="loc_D001_p03_s0_50_b21" name="loc_D001_p03_s0_50_b21" type="NODE">
-        <matrix sid="transform">9.12384e-4 -0.9999996 -1.97205e-4 111.4373 0.9999996 9.12384e-4 2.2092e-7 -0.3554363 -4.09933e-8 -1.97205e-4 1 -86.10487 0 0 0 1</matrix>
+        <matrix sid="transform">9.12384e-4 -0.9999996 -1.97205e-4 111.525 0.9999996 9.12384e-4 2.2092e-7 9.53674e-5 -4.09933e-8 -1.97205e-4 1 -86.14433 0 0 0 1</matrix>
       </node>
       <node id="loc_D001_p03_s0_50_b22" name="loc_D001_p03_s0_50_b22" type="NODE">
-        <matrix sid="transform">-0.7064613 -0.7077516 -1.51848e-6 79.0494 0.7077516 -0.7064613 -1.30236e-6 78.54668 -1.50996e-7 -1.99477e-6 1 -86.10487 0 0 0 1</matrix>
+        <matrix sid="transform">-0.7064613 -0.7077516 -1.51848e-6 78.78584 0.7077516 -0.7064613 -1.30236e-6 78.78598 -1.50996e-7 -1.99477e-6 1 -86.15062 0 0 0 1</matrix>
       </node>
       <node id="loc_D001_p03_s0_50_b23" name="loc_D001_p03_s0_50_b23" type="NODE">
-        <matrix sid="transform">-0.9999996 -9.1234e-4 -3.91017e-7 0.355434 9.1234e-4 -0.9999996 -1.756e-6 111.4372 -3.89414e-7 -1.75635e-6 1 -86.10487 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9999996 -9.1234e-4 -3.91017e-7 -8.96454e-5 9.1234e-4 -0.9999996 -1.756e-6 111.4199 -3.89414e-7 -1.75635e-6 1 -86.15055 0 0 0 1</matrix>
       </node>
       <node id="loc_D001_p03_s0_50_b24" name="loc_D001_p03_s0_50_b24" type="NODE">
-        <matrix sid="transform">-0.7077515 0.7064615 5.04573e-7 -78.54668 -0.7064615 -0.7077515 -1.30421e-6 79.04926 -5.6426e-7 -1.27952e-6 1 -86.10487 0 0 0 1</matrix>
+        <matrix sid="transform">-0.7077515 0.7064615 5.04573e-7 -78.78573 -0.7064615 -0.7077515 -1.30421e-6 78.78556 -5.6426e-7 -1.27952e-6 1 -86.15055 0 0 0 1</matrix>
       </node>
       <node id="loc_D001_p03_s0_50_b25" name="loc_D001_p03_s0_50_b25" type="NODE">
-        <matrix sid="transform">-9.12384e-4 0.9999996 -6.42859e-5 -111.4372 -0.9999996 -9.12384e-4 -2.67188e-7 0.3552917 -3.25841e-7 6.42856e-5 1 -86.10487 0 0 0 1</matrix>
+        <matrix sid="transform">-9.12384e-4 0.9999996 -6.42859e-5 -111.3847 -0.9999996 -9.12384e-4 -2.67188e-7 -2.32697e-4 -3.25841e-7 6.42856e-5 1 -86.16301 0 0 0 1</matrix>
       </node>
       <node id="loc_D001_p03_s0_50_b26" name="loc_D001_p03_s0_50_b26" type="NODE">
-        <matrix sid="transform">0.7064616 0.7077514 1.17151e-6 -79.04922 -0.7077514 0.7064616 8.84973e-7 -78.54683 -2.01285e-7 -1.45434e-6 1 -86.10487 0 0 0 1</matrix>
+        <matrix sid="transform">0.7064616 0.7077514 1.17151e-6 -78.78565 -0.7077514 0.7064616 8.84973e-7 -78.78592 -2.01285e-7 -1.45434e-6 1 -86.15062 0 0 0 1</matrix>
       </node>
       <node id="loc_D001_p03_s0_50_b27" name="loc_D001_p03_s0_50_b27" type="NODE">
-        <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 -0.355267 -9.12038e-4 0.9999996 1.36694e-6 -111.4373 -3.25927e-7 -1.36724e-6 1 -86.10487 0 0 0 1</matrix>
+        <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 1.12534e-4 -9.12038e-4 0.9999996 1.36694e-6 -111.4199 -3.25927e-7 -1.36724e-6 1 -86.15073 0 0 0 1</matrix>
       </node>
       <node id="loc_D001_p03_s0_50_b28" name="loc_D001_p03_s0_50_b28" type="NODE">
-        <matrix sid="transform">0.7077505 -0.7064625 -9.47533e-7 78.54686 0.7064625 0.7077505 1.13968e-6 -79.04935 -1.34522e-7 -1.476e-6 1 -86.10487 0 0 0 1</matrix>
+        <matrix sid="transform">0.7077505 -0.7064625 -9.47533e-7 78.78596 0.7064625 0.7077505 1.13968e-6 -78.78561 -1.34522e-7 -1.476e-6 1 -86.1508 0 0 0 1</matrix>
       </node>
       <node id="entrance_port03" name="entrance_port03" type="NODE">
-        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86442e-5 -1.50996e-7 1 3.25841e-7 1.63845e-6 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86421e-5 -1.50996e-7 1 3.25841e-7 -0.001437783 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
       </node>
       <node id="exit_port04" name="exit_port04" type="NODE">
-        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 -3.04377e-5 1.34359e-7 1 -3.01992e-7 -1.18681e-5 3.01992e-7 3.01992e-7 1 226.5409 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 -3.04396e-5 1.34359e-7 1 -3.01992e-7 -0.001451254 3.01992e-7 3.01992e-7 1 226.5409 0 0 0 1</matrix>
       </node>
       <node id="loc_C001_p04_s0_100_b20" name="loc_C001_p04_s0_100_b20" type="NODE">
-        <matrix sid="transform">9.12384e-4 -0.9999996 -1.97205e-4 111.4373 0.9999996 9.12384e-4 2.2092e-7 -0.355419 -4.09933e-8 -1.97205e-4 1 226.6638 0 0 0 1</matrix>
+        <matrix sid="transform">9.12384e-4 -0.9999996 -1.97205e-4 111.3835 0.9999996 9.12384e-4 2.2092e-7 0.02249336 -4.09933e-8 -1.97205e-4 1 226.7039 0 0 0 1</matrix>
       </node>
       <node id="loc_C001_p04_s0_100_b19" name="loc_C001_p04_s0_100_b19" type="NODE">
-        <matrix sid="transform">-0.9999996 -9.1234e-4 -3.91017e-7 0.355392 9.1234e-4 -0.9999996 -1.756e-6 111.4372 -3.89414e-7 -1.75635e-6 1 226.6638 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9999996 -9.1234e-4 -3.91017e-7 -0.02211189 9.1234e-4 -0.9999996 -1.756e-6 111.3838 -3.89414e-7 -1.75635e-6 1 226.7037 0 0 0 1</matrix>
       </node>
       <node id="loc_C001_p04_s0_100_b18" name="loc_C001_p04_s0_100_b18" type="NODE">
-        <matrix sid="transform">-9.12384e-4 0.9999996 -6.42859e-5 -111.4372 -0.9999996 -9.12384e-4 -2.67188e-7 0.3553091 -3.25841e-7 6.42856e-5 1 226.6638 0 0 0 1</matrix>
+        <matrix sid="transform">-9.12384e-4 0.9999996 -6.42859e-5 -111.3834 -0.9999996 -9.12384e-4 -2.67188e-7 -0.02188301 -3.25841e-7 6.42856e-5 1 226.7039 0 0 0 1</matrix>
       </node>
       <node id="loc_C001_p04_s0_100_b17" name="loc_C001_p04_s0_100_b17" type="NODE">
-        <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 -0.355309 -9.12038e-4 0.9999996 1.36694e-6 -111.4373 -3.25927e-7 -1.36724e-6 1 226.6638 0 0 0 1</matrix>
+        <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 0.02260017 -9.12038e-4 0.9999996 1.36694e-6 -111.3835 -3.25927e-7 -1.36724e-6 1 226.7039 0 0 0 1</matrix>
       </node>
       <node id="entrance_port04" name="entrance_port04" type="NODE">
-        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86442e-5 -1.50996e-7 1 3.25841e-7 1.63845e-6 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86421e-5 -1.50996e-7 1 3.25841e-7 -0.001437783 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
       </node>
       <node id="entrance_port05" name="entrance_port05" type="NODE">
-        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86442e-5 -1.50996e-7 1 3.25841e-7 1.63845e-6 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -1.50996e-7 1.50996e-7 -6.86421e-5 -1.50996e-7 1 3.25841e-7 -0.001437783 -1.50996e-7 3.25841e-7 -1 510.8989 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b64" name="loc_E001_p07_s0_33_b64" type="NODE">
-        <matrix sid="transform">-0.921849 -0.3875492 -1.13205e-6 40.77646 0.3875492 -0.921849 -1.68796e-6 96.33852 -3.89414e-7 -1.99477e-6 1 -280.2508 0 0 0 1</matrix>
+        <matrix sid="transform">-0.921849 -0.3875492 -1.13205e-6 40.03863 0.3875492 -0.921849 -1.68796e-6 96.64384 -3.89414e-7 -1.99477e-6 1 -279.8525 0 0 0 1</matrix>
       </node>
       <node id="exit_port07" name="exit_port07" type="NODE">
-        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 3.76708e-5 1.34359e-7 1 -3.01992e-7 -4.00709e-5 3.01992e-7 3.01992e-7 1 -280.3737 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.34359e-7 -3.01992e-7 3.7697e-5 1.34359e-7 1 -3.01992e-7 -0.001479397 3.01992e-7 3.01992e-7 1 -280.3737 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b63" name="loc_E001_p07_s0_33_b63" type="NODE">
-        <matrix sid="transform">-0.9999947 0.003212358 -5.57849e-7 -0.08221817 -0.003212358 -0.9999947 -1.99657e-6 104.6127 -5.6426e-7 -1.99477e-6 1 -280.2508 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9999947 0.003212358 -5.57849e-7 0.02693748 -0.003212358 -0.9999947 -1.99657e-6 104.6105 -5.6426e-7 -1.99477e-6 1 -279.8525 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b62" name="loc_E001_p07_s0_33_b62" type="NODE">
-        <matrix sid="transform">-0.9202005 0.3914473 1.68287e-7 -40.71669 -0.3914473 -0.9202005 -1.83707e-6 96.36375 -5.6426e-7 -1.75635e-6 1 -280.2508 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9202005 0.3914473 1.68287e-7 -40.03683 -0.3914473 -0.9202005 -1.83707e-6 96.64457 -5.6426e-7 -1.75635e-6 1 -279.8525 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b50" name="loc_E001_p06_s0_33_b50" type="NODE">
-        <matrix sid="transform">-0.9202005 0.3914473 1.68287e-7 -40.7167 -0.3914473 -0.9202005 -1.83707e-6 96.36375 -5.6426e-7 -1.75635e-6 1 -219.3728 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9202005 0.3914473 1.68287e-7 -40.03706 -0.3914473 -0.9202005 -1.83707e-6 96.64449 -5.6426e-7 -1.75635e-6 1 -220.2697 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b51" name="loc_E001_p06_s0_33_b51" type="NODE">
-        <matrix sid="transform">-0.9999947 0.003212358 -5.57849e-7 -0.08222635 -0.003212358 -0.9999947 -1.99657e-6 104.6127 -5.6426e-7 -1.99477e-6 1 -219.3728 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9999947 0.003212358 -5.57849e-7 0.02118874 -0.003212358 -0.9999947 -1.99657e-6 104.6105 -5.6426e-7 -1.99477e-6 1 -220.2697 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b52" name="loc_E001_p06_s0_33_b52" type="NODE">
-        <matrix sid="transform">-0.921849 -0.3875492 -1.13205e-6 40.77645 0.3875492 -0.921849 -1.68796e-6 96.33852 -3.89414e-7 -1.99477e-6 1 -219.3728 0 0 0 1</matrix>
+        <matrix sid="transform">-0.921849 -0.3875492 -1.13205e-6 40.03844 0.3875492 -0.921849 -1.68796e-6 96.64394 -3.89414e-7 -1.99477e-6 1 -220.2697 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b40" name="loc_E001_p05_s0_33_b40" type="NODE">
-        <matrix sid="transform">-0.921849 -0.3875492 -1.13205e-6 40.77645 0.3875492 -0.921849 -1.68796e-6 96.33852 -3.89414e-7 -1.99477e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">-0.921849 -0.3875492 -1.13205e-6 40.03827 0.3875492 -0.921849 -1.68796e-6 96.64401 -3.89414e-7 -1.99477e-6 1 -160.6869 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b39" name="loc_E001_p05_s0_33_b39" type="NODE">
-        <matrix sid="transform">-0.9999947 0.003212358 -5.57849e-7 -0.08223431 -0.003212358 -0.9999947 -1.99657e-6 104.6127 -5.6426e-7 -1.99477e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9999947 0.003212358 -5.57849e-7 0.01544476 -0.003212358 -0.9999947 -1.99657e-6 104.6105 -5.6426e-7 -1.99477e-6 1 -160.6869 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b38" name="loc_E001_p05_s0_33_b38" type="NODE">
-        <matrix sid="transform">-0.9202005 0.3914473 1.68287e-7 -40.71671 -0.3914473 -0.9202005 -1.83707e-6 96.36375 -5.6426e-7 -1.75635e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9202005 0.3914473 1.68287e-7 -40.03728 -0.3914473 -0.9202005 -1.83707e-6 96.64442 -5.6426e-7 -1.75635e-6 1 -160.687 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b35" name="loc_E001_p05_s0_33_b35" type="NODE">
-        <matrix sid="transform">0.3914472 0.9202006 1.48122e-6 -96.36375 -0.9202006 0.3914472 9.15655e-7 -40.71671 2.62767e-7 -1.72145e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">0.3914472 0.9202006 1.48122e-6 -96.644 -0.9202006 0.3914472 9.15655e-7 -40.03748 2.62767e-7 -1.72145e-6 1 -160.6871 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b36" name="loc_E001_p05_s0_33_b36" type="NODE">
-        <matrix sid="transform">0.003211687 0.9999947 2.00192e-5 -104.6127 -0.9999947 0.003211687 1.7134e-7 -0.0822773 1.07044e-7 -2.00197e-5 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">0.003211687 0.9999947 2.00192e-5 -104.6028 -0.9999947 0.003211687 1.7134e-7 0.007684708 1.07044e-7 -2.00197e-5 1 -160.6919 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b37" name="loc_E001_p05_s0_33_b37" type="NODE">
-        <matrix sid="transform">-0.3875493 0.921849 1.05324e-6 -96.3385 -0.921849 -0.3875493 -7.96252e-7 40.77642 -3.25841e-7 -1.27952e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3875493 0.921849 1.05324e-6 -96.64389 -0.921849 -0.3875493 -7.96252e-7 40.0379 -3.25841e-7 -1.27952e-6 1 -160.6871 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b49" name="loc_E001_p06_s0_33_b49" type="NODE">
-        <matrix sid="transform">-0.3875493 0.921849 1.05324e-6 -96.33849 -0.921849 -0.3875493 -7.96252e-7 40.77642 -3.25841e-7 -1.27952e-6 1 -219.3728 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3875493 0.921849 1.05324e-6 -96.64376 -0.921849 -0.3875493 -7.96252e-7 40.03795 -3.25841e-7 -1.27952e-6 1 -220.2698 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b48" name="loc_E001_p06_s0_33_b48" type="NODE">
-        <matrix sid="transform">0.003211687 0.9999947 2.00192e-5 -104.6127 -0.9999947 0.003211687 1.7134e-7 -0.08227801 1.07044e-7 -2.00197e-5 1 -219.3728 0 0 0 1</matrix>
+        <matrix sid="transform">0.003211687 0.9999947 2.00192e-5 -104.5999 -0.9999947 0.003211687 1.7134e-7 0.01055574 1.07044e-7 -2.00197e-5 1 -220.2747 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b47" name="loc_E001_p06_s0_33_b47" type="NODE">
-        <matrix sid="transform">0.3914472 0.9202006 1.48122e-6 -96.36374 -0.9202006 0.3914472 9.15655e-7 -40.71671 2.62767e-7 -1.72145e-6 1 -219.3728 0 0 0 1</matrix>
+        <matrix sid="transform">0.3914472 0.9202006 1.48122e-6 -96.64392 -0.9202006 0.3914472 9.15655e-7 -40.03733 2.62767e-7 -1.72145e-6 1 -220.2699 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b59" name="loc_E001_p07_s0_33_b59" type="NODE">
-        <matrix sid="transform">0.3914472 0.9202006 1.48122e-6 -96.36372 -0.9202006 0.3914472 9.15655e-7 -40.71671 2.62767e-7 -1.72145e-6 1 -280.2508 0 0 0 1</matrix>
+        <matrix sid="transform">0.3914472 0.9202006 1.48122e-6 -96.64385 -0.9202006 0.3914472 9.15655e-7 -40.03719 2.62767e-7 -1.72145e-6 1 -279.8527 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b60" name="loc_E001_p07_s0_33_b60" type="NODE">
-        <matrix sid="transform">0.003211687 0.9999947 2.00192e-5 -104.6127 -0.9999947 0.003211687 1.7134e-7 -0.08228637 1.07044e-7 -2.00197e-5 1 -280.2508 0 0 0 1</matrix>
+        <matrix sid="transform">0.003211687 0.9999947 2.00192e-5 -104.597 -0.9999947 0.003211687 1.7134e-7 0.01343107 1.07044e-7 -2.00197e-5 1 -279.8575 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b61" name="loc_E001_p07_s0_33_b61" type="NODE">
-        <matrix sid="transform">-0.3875493 0.921849 1.05324e-6 -96.33849 -0.921849 -0.3875493 -7.96252e-7 40.77642 -3.25841e-7 -1.27952e-6 1 -280.2508 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3875493 0.921849 1.05324e-6 -96.64362 -0.921849 -0.3875493 -7.96252e-7 40.038 -3.25841e-7 -1.27952e-6 1 -279.8526 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b58" name="loc_E001_p07_s0_33_b58" type="NODE">
-        <matrix sid="transform">0.921849 0.3875494 5.27696e-7 -40.7764 -0.3875494 0.921849 1.70061e-6 -96.33852 1.72616e-7 -1.77222e-6 1 -280.2508 0 0 0 1</matrix>
+        <matrix sid="transform">0.921849 0.3875494 5.27696e-7 -40.76347 -0.3875494 0.921849 1.70061e-6 -96.30799 1.72616e-7 -1.77222e-6 1 -280.2508 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b57" name="loc_E001_p07_s0_33_b57" type="NODE">
-        <matrix sid="transform">0.9999947 -0.003212535 -1.56729e-7 0.08232117 0.003212535 0.9999947 1.72456e-6 -104.6128 1.51188e-7 -1.72505e-6 1 -280.2507 0 0 0 1</matrix>
+        <matrix sid="transform">0.9999947 -0.003212535 -1.56729e-7 7.62939e-5 0.003212535 0.9999947 1.72456e-6 -104.6105 1.51188e-7 -1.72505e-6 1 -279.8524 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b56" name="loc_E001_p07_s0_33_b56" type="NODE">
-        <matrix sid="transform">0.9202003 -0.3914476 -9.50538e-7 40.71671 0.3914476 0.9202003 1.91699e-6 -96.36378 1.24285e-7 -2.1361e-6 1 -280.2507 0 0 0 1</matrix>
+        <matrix sid="transform">0.9202003 -0.3914476 -9.50538e-7 40.0379 0.3914476 0.9202003 1.91699e-6 -96.64421 1.24285e-7 -2.1361e-6 1 -279.8524 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b44" name="loc_E001_p06_s0_33_b44" type="NODE">
-        <matrix sid="transform">0.9202003 -0.3914476 -9.50538e-7 40.71671 0.3914476 0.9202003 1.91699e-6 -96.36378 1.24285e-7 -2.1361e-6 1 -219.3727 0 0 0 1</matrix>
+        <matrix sid="transform">0.9202003 -0.3914476 -9.50538e-7 40.03791 0.3914476 0.9202003 1.91699e-6 -96.6442 1.24285e-7 -2.1361e-6 1 -220.2697 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b45" name="loc_E001_p06_s0_33_b45" type="NODE">
-        <matrix sid="transform">0.9999947 -0.003212535 -1.56729e-7 0.08230591 0.003212535 0.9999947 1.72456e-6 -104.6128 1.51188e-7 -1.72505e-6 1 -219.3728 0 0 0 1</matrix>
+        <matrix sid="transform">0.9999947 -0.003212535 -1.56729e-7 7.62939e-5 0.003212535 0.9999947 1.72456e-6 -104.6105 1.51188e-7 -1.72505e-6 1 -220.2697 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b46" name="loc_E001_p06_s0_33_b46" type="NODE">
-        <matrix sid="transform">0.921849 0.3875494 5.27696e-7 -40.77641 -0.3875494 0.921849 1.70061e-6 -96.33852 1.72616e-7 -1.77222e-6 1 -219.3728 0 0 0 1</matrix>
+        <matrix sid="transform">0.921849 0.3875494 5.27696e-7 -40.03777 -0.3875494 0.921849 1.70061e-6 -96.64426 1.72616e-7 -1.77222e-6 1 -220.2696 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b34" name="loc_E001_p05_s0_33_b34" type="NODE">
-        <matrix sid="transform">0.921849 0.3875494 5.27696e-7 -40.77642 -0.3875494 0.921849 1.70061e-6 -96.33852 1.72616e-7 -1.77222e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">0.921849 0.3875494 5.27696e-7 -40.03777 -0.3875494 0.921849 1.70061e-6 -96.64426 1.72616e-7 -1.77222e-6 1 -160.6869 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b33" name="loc_E001_p05_s0_33_b33" type="NODE">
-        <matrix sid="transform">0.9999947 -0.003212535 -1.56729e-7 0.08229828 0.003212535 0.9999947 1.72456e-6 -104.6128 1.51188e-7 -1.72505e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">0.9999947 -0.003212535 -1.56729e-7 7.53403e-5 0.003212535 0.9999947 1.72456e-6 -104.6105 1.51188e-7 -1.72505e-6 1 -160.6869 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b32" name="loc_E001_p05_s0_33_b32" type="NODE">
-        <matrix sid="transform">0.9202003 -0.3914476 -9.50538e-7 40.7167 0.3914476 0.9202003 1.91699e-6 -96.36378 1.24285e-7 -2.1361e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">0.9202003 -0.3914476 -9.50538e-7 40.03791 0.3914476 0.9202003 1.91699e-6 -96.6442 1.24285e-7 -2.1361e-6 1 -160.6869 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b29" name="loc_E001_p05_s0_33_b29" type="NODE">
-        <matrix sid="transform">-0.3914477 -0.9202005 -2.11409e-6 96.3638 0.9202005 -0.3914477 -7.35231e-7 40.71664 -1.50996e-7 -2.23319e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3914477 -0.9202005 -2.11409e-6 96.64462 0.9202005 -0.3914477 -7.35231e-7 40.0377 -1.50996e-7 -2.23319e-6 1 -160.6868 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b30" name="loc_E001_p05_s0_33_b30" type="NODE">
-        <matrix sid="transform">-0.003211926 -0.9999947 -4.84866e-5 104.6128 0.9999947 -0.003211926 -4.73968e-9 0.08227348 -1.50996e-7 -4.84864e-5 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">-0.003211926 -0.9999947 -4.84866e-5 104.6183 0.9999947 -0.003211926 -4.73968e-9 -0.007694244 -1.50996e-7 -4.84864e-5 1 -160.6819 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p05_s0_33_b31" name="loc_E001_p05_s0_33_b31" type="NODE">
-        <matrix sid="transform">0.3875487 -0.9218493 -1.51376e-6 96.33852 0.9218493 0.3875487 7.21856e-7 -40.77645 -7.87875e-8 -1.67521e-6 1 -160.1249 0 0 0 1</matrix>
+        <matrix sid="transform">0.3875487 -0.9218493 -1.51376e-6 96.64438 0.9218493 0.3875487 7.21856e-7 -40.03814 -7.87875e-8 -1.67521e-6 1 -160.6867 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b43" name="loc_E001_p06_s0_33_b43" type="NODE">
-        <matrix sid="transform">0.3875487 -0.9218493 -1.51376e-6 96.33852 0.9218493 0.3875487 7.21856e-7 -40.77645 -7.87875e-8 -1.67521e-6 1 -219.3727 0 0 0 1</matrix>
+        <matrix sid="transform">0.3875487 -0.9218493 -1.51376e-6 96.64443 0.9218493 0.3875487 7.21856e-7 -40.03827 -7.87875e-8 -1.67521e-6 1 -220.2695 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b42" name="loc_E001_p06_s0_33_b42" type="NODE">
-        <matrix sid="transform">-0.003211926 -0.9999947 -4.84866e-5 104.6128 0.9999947 -0.003211926 -4.73968e-9 0.08227278 -1.50996e-7 -4.84864e-5 1 -219.3727 0 0 0 1</matrix>
+        <matrix sid="transform">-0.003211926 -0.9999947 -4.84866e-5 104.6212 0.9999947 -0.003211926 -4.73968e-9 -0.01056623 -1.50996e-7 -4.84864e-5 1 -220.2646 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p06_s0_33_b41" name="loc_E001_p06_s0_33_b41" type="NODE">
-        <matrix sid="transform">-0.3914477 -0.9202005 -2.11409e-6 96.3638 0.9202005 -0.3914477 -7.35231e-7 40.71664 -1.50996e-7 -2.23319e-6 1 -219.3727 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3914477 -0.9202005 -2.11409e-6 96.64477 0.9202005 -0.3914477 -7.35231e-7 40.03762 -1.50996e-7 -2.23319e-6 1 -220.2695 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b53" name="loc_E001_p07_s0_33_b53" type="NODE">
-        <matrix sid="transform">-0.3914477 -0.9202005 -2.11409e-6 96.36382 0.9202005 -0.3914477 -7.35231e-7 40.71664 -1.50996e-7 -2.23319e-6 1 -280.2507 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3914477 -0.9202005 -2.11409e-6 96.64493 0.9202005 -0.3914477 -7.35231e-7 40.03755 -1.50996e-7 -2.23319e-6 1 -279.8524 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b54" name="loc_E001_p07_s0_33_b54" type="NODE">
-        <matrix sid="transform">-0.003211926 -0.9999947 -4.84866e-5 104.6128 0.9999947 -0.003211926 -4.73968e-9 0.08227205 -1.50996e-7 -4.84864e-5 1 -280.2507 0 0 0 1</matrix>
+        <matrix sid="transform">-0.003211926 -0.9999947 -4.84866e-5 104.624 0.9999947 -0.003211926 -4.73968e-9 -0.01343966 -1.50996e-7 -4.84864e-5 1 -279.8475 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p07_s0_33_b55" name="loc_E001_p07_s0_33_b55" type="NODE">
-        <matrix sid="transform">0.3875487 -0.9218493 -1.51376e-6 96.33855 0.9218493 0.3875487 7.21856e-7 -40.77645 -7.87875e-8 -1.67521e-6 1 -280.2508 0 0 0 1</matrix>
+        <matrix sid="transform">0.3875487 -0.9218493 -1.51376e-6 96.64447 0.9218493 0.3875487 7.21856e-7 -40.03841 -7.87875e-8 -1.67521e-6 1 -279.8524 0 0 0 1</matrix>
       </node>
     </visual_scene>
   </library_visual_scenes>

--- a/data/models/stations/orbital_station/station_docking_B.dae
+++ b/data/models/stations/orbital_station/station_docking_B.dae
@@ -3,10 +3,10 @@
   <asset>
     <contributor>
       <author>Blender User</author>
-      <authoring_tool>Blender 3.0.0 Beta commit date:2021-10-27, commit time:22:07, hash:b838eaf2b960</authoring_tool>
+      <authoring_tool>Blender 3.3.6 commit date:2023-04-17, commit time:14:03, hash:948f8298b982</authoring_tool>
     </contributor>
-    <created>2021-10-31T12:56:20</created>
-    <modified>2021-10-31T12:56:20</modified>
+    <created>2024-01-07T20:49:35</created>
+    <modified>2024-01-07T20:49:35</modified>
     <unit name="meter" meter="1"/>
     <up_axis>Z_UP</up_axis>
   </asset>
@@ -98,304 +98,10 @@
         </triangles>
       </mesh>
     </geometry>
-    <geometry id="Plane_008-mesh" name="Plane.008">
-      <mesh>
-        <source id="Plane_008-mesh-positions">
-          <float_array id="Plane_008-mesh-positions-array" count="36">-20.0785 -0.1890732 -30.42757 21.54779 0.204251 -30.42757 -20.07851 -0.1889467 29.15516 21.54778 0.2043701 29.15517 -3.49964e-6 0.2042532 -30.42757 -3.43652e-6 0.2043727 29.15516 -3.49986e-6 -2.434449 -30.42757 -3.43675e-6 -2.434328 29.15516 -20.0785 -0.189076 0.5922599 21.54779 0.2042533 0.5922575 -20.0785 -2.827777 0.5922592 21.54779 -2.434447 0.592257</float_array>
-          <technique_common>
-            <accessor source="#Plane_008-mesh-positions-array" count="12" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_008-mesh-normals">
-          <float_array id="Plane_008-mesh-normals-array" count="18">-0.009448468 0.9999554 -2.12249e-6 -1 0 0 0 -1.80709e-7 1 -0.009448289 0.9999554 -1.99924e-6 -1 0 0 0 -2.71064e-7 1</float_array>
-          <technique_common>
-            <accessor source="#Plane_008-mesh-normals-array" count="6" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_008-mesh-map-0">
-          <float_array id="Plane_008-mesh-map-0-array" count="36">0 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
-          <technique_common>
-            <accessor source="#Plane_008-mesh-map-0-array" count="18" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="Plane_008-mesh-vertices">
-          <input semantic="POSITION" source="#Plane_008-mesh-positions"/>
-        </vertices>
-        <triangles count="6">
-          <input semantic="VERTEX" source="#Plane_008-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#Plane_008-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#Plane_008-mesh-map-0" offset="2" set="0"/>
-          <p>2 0 0 1 0 1 0 0 2 4 1 3 7 1 4 5 1 5 8 2 6 11 2 7 9 2 8 2 3 9 3 3 10 1 3 11 4 4 12 6 4 13 7 4 14 8 5 15 10 5 16 11 5 17</p>
-        </triangles>
-      </mesh>
-    </geometry>
-    <geometry id="Plane_006-mesh" name="Plane.006">
-      <mesh>
-        <source id="Plane_006-mesh-positions">
-          <float_array id="Plane_006-mesh-positions-array" count="36">-20.7261 -0.06482702 -30.42756 20.8909 0.06888341 -30.42758 -20.72607 -0.06407654 29.15517 20.89092 0.06963574 29.15515 -3.52055e-6 -0.06482344 -30.42756 -3.52051e-6 -0.06408059 29.15517 -3.52077e-6 -2.703526 -30.42756 -3.52073e-6 -2.702781 29.15517 -20.72607 -0.06407749 0.5922599 20.89092 0.06963342 0.5922575 -20.72607 -2.702778 0.5922592 20.89092 -2.569067 0.592257</float_array>
-          <technique_common>
-            <accessor source="#Plane_006-mesh-positions-array" count="12" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_006-mesh-normals">
-          <float_array id="Plane_006-mesh-normals-array" count="18">-0.003212809 0.9999949 -1.2626e-5 -1 0 0 0 -1.80709e-7 1 -0.003212869 0.9999949 -1.25944e-5 -1 0 0 0 -2.71064e-7 1</float_array>
-          <technique_common>
-            <accessor source="#Plane_006-mesh-normals-array" count="6" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_006-mesh-map-0">
-          <float_array id="Plane_006-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
-          <technique_common>
-            <accessor source="#Plane_006-mesh-map-0-array" count="18" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="Plane_006-mesh-vertices">
-          <input semantic="POSITION" source="#Plane_006-mesh-positions"/>
-        </vertices>
-        <triangles count="6">
-          <input semantic="VERTEX" source="#Plane_006-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#Plane_006-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#Plane_006-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 4 1 3 7 1 4 5 1 5 8 2 6 11 2 7 9 2 8 0 3 9 2 3 10 3 3 11 4 4 12 6 4 13 7 4 14 8 5 15 10 5 16 11 5 17</p>
-        </triangles>
-      </mesh>
-    </geometry>
-    <geometry id="Plane_007-mesh" name="Plane.007">
-      <mesh>
-        <source id="Plane_007-mesh-positions">
-          <float_array id="Plane_007-mesh-positions-array" count="36">-21.613 0.1128774 -30.42756 20.0146 -0.1041762 -30.42758 -21.61298 0.1129507 29.15517 20.01461 -0.1041082 29.15515 -3.81081e-6 0.1128787 -30.42756 -3.77913e-6 0.1129504 29.15517 -3.81103e-6 -2.525824 -30.42756 -3.77935e-6 -2.52575 29.15517 -21.61299 0.1129137 0.5922626 20.01461 -0.1041425 0.5922557 -21.61299 -2.525787 0.5922619 20.01461 -2.742843 0.5922552</float_array>
-          <technique_common>
-            <accessor source="#Plane_007-mesh-positions-array" count="12" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_007-mesh-normals">
-          <float_array id="Plane_007-mesh-normals-array" count="18">0.005214095 0.9999864 -1.14399e-6 1 0 0 1.58178e-7 -1.80709e-7 1 0.005214214 0.9999864 -1.23052e-6 1 0 0 1.67132e-7 -2.71064e-7 1</float_array>
-          <technique_common>
-            <accessor source="#Plane_007-mesh-normals-array" count="6" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_007-mesh-map-0">
-          <float_array id="Plane_007-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
-          <technique_common>
-            <accessor source="#Plane_007-mesh-map-0-array" count="18" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="Plane_007-mesh-vertices">
-          <input semantic="POSITION" source="#Plane_007-mesh-positions"/>
-        </vertices>
-        <triangles count="6">
-          <input semantic="VERTEX" source="#Plane_007-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#Plane_007-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#Plane_007-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 7 1 3 4 1 4 5 1 5 9 2 6 10 2 7 11 2 8 0 3 9 2 3 10 3 3 11 7 4 12 6 4 13 4 4 14 9 5 15 8 5 16 10 5 17</p>
-        </triangles>
-      </mesh>
-    </geometry>
-    <geometry id="Plane_009-mesh" name="Plane.009">
-      <mesh>
-        <source id="Plane_009-mesh-positions">
-          <float_array id="Plane_009-mesh-positions-array" count="36">-20.0785 -0.1890739 -30.79135 21.54779 0.2042503 -30.79134 -20.07851 -0.1889474 28.79139 21.54778 0.2043694 28.79139 -3.14747e-6 0.2042443 -30.79134 -3.43825e-6 0.2043719 28.79139 -3.14769e-6 -2.434458 -30.79134 -3.43847e-6 -2.434329 28.79139 -20.07851 -0.1889528 0.5922599 21.54778 0.2043675 0.5922575 -20.07851 -2.827654 0.5922592 21.54778 -2.434333 0.592257</float_array>
-          <technique_common>
-            <accessor source="#Plane_009-mesh-positions-array" count="12" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_009-mesh-normals">
-          <float_array id="Plane_009-mesh-normals-array" count="18">-0.009448468 0.9999554 -2.12247e-6 -1 0 0 0 -1.80709e-7 1 -0.009448289 0.9999554 -1.99924e-6 -1 0 0 0 -2.71064e-7 1</float_array>
-          <technique_common>
-            <accessor source="#Plane_009-mesh-normals-array" count="6" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_009-mesh-map-0">
-          <float_array id="Plane_009-mesh-map-0-array" count="36">0 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
-          <technique_common>
-            <accessor source="#Plane_009-mesh-map-0-array" count="18" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="Plane_009-mesh-vertices">
-          <input semantic="POSITION" source="#Plane_009-mesh-positions"/>
-        </vertices>
-        <triangles count="6">
-          <input semantic="VERTEX" source="#Plane_009-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#Plane_009-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#Plane_009-mesh-map-0" offset="2" set="0"/>
-          <p>2 0 0 1 0 1 0 0 2 4 1 3 7 1 4 5 1 5 8 2 6 11 2 7 9 2 8 2 3 9 3 3 10 1 3 11 4 4 12 6 4 13 7 4 14 8 5 15 10 5 16 11 5 17</p>
-        </triangles>
-      </mesh>
-    </geometry>
-    <geometry id="Plane_005-mesh" name="Plane.005">
-      <mesh>
-        <source id="Plane_005-mesh-positions">
-          <float_array id="Plane_005-mesh-positions-array" count="36">-20.7261 -0.06483155 -30.79133 20.8909 0.06887882 -30.79135 -20.72607 -0.06408107 28.7914 20.89092 0.06963121 28.79138 -3.52053e-6 -0.06482803 -30.79134 -3.52049e-6 -0.06408518 28.7914 -3.52075e-6 -2.70353 -30.79134 -3.52072e-6 -2.702785 28.7914 -20.72607 -0.06408202 0.5922599 20.89092 0.06962883 0.5922575 -20.72607 -2.702783 0.5922592 20.89092 -2.569072 0.592257</float_array>
-          <technique_common>
-            <accessor source="#Plane_005-mesh-positions-array" count="12" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_005-mesh-normals">
-          <float_array id="Plane_005-mesh-normals-array" count="18">-0.003212809 0.9999949 -1.25943e-5 1 0 0 0 1.80709e-7 -1 -0.003212869 0.9999949 -1.26261e-5 1 0 0 0 2.71064e-7 -1</float_array>
-          <technique_common>
-            <accessor source="#Plane_005-mesh-normals-array" count="6" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_005-mesh-map-0">
-          <float_array id="Plane_005-mesh-map-0-array" count="36">0 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
-          <technique_common>
-            <accessor source="#Plane_005-mesh-map-0-array" count="18" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="Plane_005-mesh-vertices">
-          <input semantic="POSITION" source="#Plane_005-mesh-positions"/>
-        </vertices>
-        <triangles count="6">
-          <input semantic="VERTEX" source="#Plane_005-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#Plane_005-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#Plane_005-mesh-map-0" offset="2" set="0"/>
-          <p>2 0 0 1 0 1 0 0 2 7 1 3 4 1 4 5 1 5 11 2 6 8 2 7 9 2 8 2 3 9 3 3 10 1 3 11 7 4 12 6 4 13 4 4 14 11 5 15 10 5 16 8 5 17</p>
-        </triangles>
-      </mesh>
-    </geometry>
-    <geometry id="Plane_003-mesh" name="Plane.003">
-      <mesh>
-        <source id="Plane_003-mesh-positions">
-          <float_array id="Plane_003-mesh-positions-array" count="36">-21.613 0.112877 -30.79134 20.0146 -0.1041767 -30.79135 -21.61298 0.1129502 28.7914 20.01461 -0.1041086 28.79138 -3.81095e-6 0.1128783 -30.79134 -3.7788e-6 0.11295 28.7914 -3.81117e-6 -2.525824 -30.79134 -3.77902e-6 -2.52575 28.7914 -21.613 0.1128763 0.5922599 20.01459 -0.1041802 0.5922575 -21.613 -2.525825 0.5922592 20.01459 -2.742881 0.592257</float_array>
-          <technique_common>
-            <accessor source="#Plane_003-mesh-positions-array" count="12" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_003-mesh-normals">
-          <float_array id="Plane_003-mesh-normals-array" count="18">0.005214095 0.9999864 -1.14399e-6 1 0 0 0 -1.80709e-7 1 0.005214214 0.9999864 -1.23052e-6 1 0 0 0 -2.71064e-7 1</float_array>
-          <technique_common>
-            <accessor source="#Plane_003-mesh-normals-array" count="6" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_003-mesh-map-0">
-          <float_array id="Plane_003-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
-          <technique_common>
-            <accessor source="#Plane_003-mesh-map-0-array" count="18" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="Plane_003-mesh-vertices">
-          <input semantic="POSITION" source="#Plane_003-mesh-positions"/>
-        </vertices>
-        <triangles count="6">
-          <input semantic="VERTEX" source="#Plane_003-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#Plane_003-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#Plane_003-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 7 1 3 4 1 4 5 1 5 9 2 6 10 2 7 11 2 8 0 3 9 2 3 10 3 3 11 7 4 12 6 4 13 4 4 14 9 5 15 8 5 16 10 5 17</p>
-        </triangles>
-      </mesh>
-    </geometry>
-    <geometry id="Plane_010-mesh" name="Plane.010">
-      <mesh>
-        <source id="Plane_010-mesh-positions">
-          <float_array id="Plane_010-mesh-positions-array" count="36">-20.0785 -0.1890704 -29.08187 21.54779 0.2042538 -29.08187 -20.07851 -0.1889439 30.50087 21.54778 0.2043729 30.50087 -3.3472e-6 0.204255 -29.08186 -3.43682e-6 0.2043754 30.50087 -3.34743e-6 -2.434447 -29.08186 -3.43705e-6 -2.434325 30.50087 -20.0785 -0.1890717 0.5922599 21.54779 0.2042486 0.5922575 -20.0785 -2.827773 0.5922592 21.54779 -2.434452 0.592257</float_array>
-          <technique_common>
-            <accessor source="#Plane_010-mesh-positions-array" count="12" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_010-mesh-normals">
-          <float_array id="Plane_010-mesh-normals-array" count="18">-0.009448468 0.9999554 -1.99922e-6 -1 0 0 0 -1.80709e-7 1 -0.009448289 0.9999554 -2.12249e-6 -1 0 0 0 -2.71064e-7 1</float_array>
-          <technique_common>
-            <accessor source="#Plane_010-mesh-normals-array" count="6" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_010-mesh-map-0">
-          <float_array id="Plane_010-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
-          <technique_common>
-            <accessor source="#Plane_010-mesh-map-0-array" count="18" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="Plane_010-mesh-vertices">
-          <input semantic="POSITION" source="#Plane_010-mesh-positions"/>
-        </vertices>
-        <triangles count="6">
-          <input semantic="VERTEX" source="#Plane_010-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#Plane_010-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#Plane_010-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 4 1 3 7 1 4 5 1 5 8 2 6 11 2 7 9 2 8 0 3 9 2 3 10 3 3 11 4 4 12 6 4 13 7 4 14 8 5 15 10 5 16 11 5 17</p>
-        </triangles>
-      </mesh>
-    </geometry>
     <geometry id="Plane_004-mesh" name="Plane.004">
       <mesh>
         <source id="Plane_004-mesh-positions">
-          <float_array id="Plane_004-mesh-positions-array" count="36">-20.7261 -0.06481009 -29.08187 20.8909 0.06890028 -29.08188 -20.72607 -0.06405961 30.50087 20.89092 0.06965267 30.50086 -5.81097e-6 0.1325879 -29.08187 -1.13878e-6 0.132728 30.50086 -5.81119e-6 -2.506114 -29.08187 -1.13901e-6 -2.505972 30.50086 -20.72665 0.1092845 0.592263 20.89063 0.1565548 0.5922543 -20.72665 -2.529416 0.5922623 20.89063 -2.482146 0.5922538</float_array>
+          <float_array id="Plane_004-mesh-positions-array" count="36">-20.7261 -0.06481009 -29.08187 20.8909 0.06890028 -29.08188 -20.72607 -0.06405961 30.50087 20.89092 0.06965267 30.50086 -5.81097e-6 -0.03773814 -29.08187 -1.13878e-6 -0.03759807 30.50086 -5.81119e-6 -2.506114 -29.08187 -1.13901e-6 -2.505972 30.50086 -20.72665 -0.06104153 0.592263 20.89063 -0.01377123 0.5922543 -20.72665 -2.529416 0.5922623 20.89063 -2.482146 0.5922538</float_array>
           <technique_common>
             <accessor source="#Plane_004-mesh-positions-array" count="12" stride="3">
               <param name="X" type="float"/>
@@ -405,9 +111,9 @@
           </technique_common>
         </source>
         <source id="Plane_004-mesh-normals">
-          <float_array id="Plane_004-mesh-normals-array" count="18">-0.003212809 0.9999949 -1.25943e-5 -1 0 0 2.08424e-7 -1.80709e-7 1 -0.003212869 0.9999949 -1.26261e-5 -1 0 0 2.04896e-7 -2.71064e-7 1</float_array>
+          <float_array id="Plane_004-mesh-normals-array" count="9">-0.003212869 0.9999949 -1.26102e-5 -1 0 0 2.06995e-7 -2.41473e-7 1</float_array>
           <technique_common>
-            <accessor source="#Plane_004-mesh-normals-array" count="6" stride="3">
+            <accessor source="#Plane_004-mesh-normals-array" count="3" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -415,9 +121,9 @@
           </technique_common>
         </source>
         <source id="Plane_004-mesh-map-0">
-          <float_array id="Plane_004-mesh-map-0-array" count="36">0 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_004-mesh-map-0-array" count="24">0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_004-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_004-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
@@ -426,60 +132,19 @@
         <vertices id="Plane_004-mesh-vertices">
           <input semantic="POSITION" source="#Plane_004-mesh-positions"/>
         </vertices>
-        <triangles count="6">
+        <polylist count="3">
           <input semantic="VERTEX" source="#Plane_004-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_004-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_004-mesh-map-0" offset="2" set="0"/>
-          <p>2 0 0 1 0 1 0 0 2 4 1 3 7 1 4 5 1 5 8 2 6 11 2 7 9 2 8 2 3 9 3 3 10 1 3 11 4 4 12 6 4 13 7 4 14 8 5 15 10 5 16 11 5 17</p>
-        </triangles>
-      </mesh>
-    </geometry>
-    <geometry id="Plane_011-mesh" name="Plane.011">
-      <mesh>
-        <source id="Plane_011-mesh-positions">
-          <float_array id="Plane_011-mesh-positions-array" count="36">-21.613 0.112879 -29.08189 20.0146 -0.1041746 -29.0819 -21.61298 0.1129523 30.50085 20.01461 -0.1041066 30.50083 -3.4532e-6 -0.1041772 -29.0819 -3.77914e-6 0.112952 30.50085 -3.45342e-6 -2.74288 -29.0819 -3.77936e-6 -2.525748 30.50085 -21.613 0.1128785 0.5922599 20.0146 -0.104178 0.5922575 -21.613 -2.525822 0.5922592 20.0146 -2.742878 0.592257</float_array>
-          <technique_common>
-            <accessor source="#Plane_011-mesh-positions-array" count="12" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_011-mesh-normals">
-          <float_array id="Plane_011-mesh-normals-array" count="18">0.005214095 0.9999864 -1.14399e-6 1 0 0 0 -1.80709e-7 1 0.005214214 0.9999864 -1.23035e-6 1 0 0 0 -2.71064e-7 1</float_array>
-          <technique_common>
-            <accessor source="#Plane_011-mesh-normals-array" count="6" stride="3">
-              <param name="X" type="float"/>
-              <param name="Y" type="float"/>
-              <param name="Z" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <source id="Plane_011-mesh-map-0">
-          <float_array id="Plane_011-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
-          <technique_common>
-            <accessor source="#Plane_011-mesh-map-0-array" count="18" stride="2">
-              <param name="S" type="float"/>
-              <param name="T" type="float"/>
-            </accessor>
-          </technique_common>
-        </source>
-        <vertices id="Plane_011-mesh-vertices">
-          <input semantic="POSITION" source="#Plane_011-mesh-positions"/>
-        </vertices>
-        <triangles count="6">
-          <input semantic="VERTEX" source="#Plane_011-mesh-vertices" offset="0"/>
-          <input semantic="NORMAL" source="#Plane_011-mesh-normals" offset="1"/>
-          <input semantic="TEXCOORD" source="#Plane_011-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 7 1 3 4 1 4 5 1 5 9 2 6 10 2 7 11 2 8 0 3 9 2 3 10 3 3 11 7 4 12 6 4 13 4 4 14 9 5 15 8 5 16 10 5 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>0 0 0 2 0 1 3 0 2 1 0 3 5 1 4 4 1 5 6 1 6 7 1 7 9 2 8 8 2 9 10 2 10 11 2 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_002-mesh" name="Plane.002">
       <mesh>
         <source id="Plane_002-mesh-positions">
-          <float_array id="Plane_002-mesh-positions-array" count="36">-73.49265 -0.06767559 -89.83592 72.87256 0.1385148 -89.83587 -73.58311 0.00470066 88.9597 72.8725 0.1382673 88.95975 3.97847e-4 0.1326771 -89.83588 3.88187e-4 0.1326261 88.95973 3.97847e-4 -2.506025 -89.83588 3.88186e-4 -2.506074 88.95973 -73.58308 0.004822432 -3.568826 72.87254 0.1383953 -3.568819 -73.58308 -2.633878 -3.568827 72.87254 -2.500305 -3.56882</float_array>
+          <float_array id="Plane_002-mesh-positions-array" count="36">-73.49265 -0.06767559 -89.83592 72.87256 0.1385148 -89.83587 -73.58311 0.00470066 88.9597 72.8725 0.1382673 88.95975 3.97847e-4 0.02072161 -89.83588 3.88187e-4 0.02067059 88.95973 3.97847e-4 -2.506025 -89.83588 3.88186e-4 -2.506074 88.95973 -73.58308 -0.107133 -3.568826 72.87254 0.02643978 -3.568819 -73.58308 -2.633878 -3.568827 72.87254 -2.500305 -3.56882</float_array>
           <technique_common>
             <accessor source="#Plane_002-mesh-positions-array" count="12" stride="3">
               <param name="X" type="float"/>
@@ -489,9 +154,9 @@
           </technique_common>
         </source>
         <source id="Plane_002-mesh-normals">
-          <float_array id="Plane_002-mesh-normals-array" count="18">-0.001408696 0.9999991 1.38383e-6 -1 0 0 0 4.51773e-7 -1 -9.11993e-4 0.9999995 -4.0526e-4 -1 0 0 0 6.32482e-7 -1</float_array>
+          <float_array id="Plane_002-mesh-normals-array" count="9">-0.001160264 0.9999994 -2.02001e-4 -1 0 0 0 5.66148e-7 -1</float_array>
           <technique_common>
-            <accessor source="#Plane_002-mesh-normals-array" count="6" stride="3">
+            <accessor source="#Plane_002-mesh-normals-array" count="3" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -499,9 +164,9 @@
           </technique_common>
         </source>
         <source id="Plane_002-mesh-map-0">
-          <float_array id="Plane_002-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_002-mesh-map-0-array" count="24">0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_002-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_002-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
@@ -510,18 +175,19 @@
         <vertices id="Plane_002-mesh-vertices">
           <input semantic="POSITION" source="#Plane_002-mesh-positions"/>
         </vertices>
-        <triangles count="6">
+        <polylist count="3">
           <input semantic="VERTEX" source="#Plane_002-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_002-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_002-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 4 1 3 7 1 4 5 1 5 11 2 6 8 2 7 9 2 8 0 3 9 2 3 10 3 3 11 4 4 12 6 4 13 7 4 14 11 5 15 10 5 16 8 5 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>0 0 0 2 0 1 3 0 2 1 0 3 5 1 4 4 1 5 6 1 6 7 1 7 9 2 8 11 2 9 10 2 10 8 2 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Plane_001-mesh" name="Plane.001">
       <mesh>
         <source id="Plane_001-mesh-positions">
-          <float_array id="Plane_001-mesh-positions-array" count="36">-37.50128 0.07065105 -45.57873 36.79127 -0.03376418 -45.57868 -37.50133 0.07073253 43.79536 36.79121 -0.03368782 43.79541 5.07091e-6 0.1326507 -45.57871 -6.70745e-6 0.1326565 43.79538 5.07061e-6 -2.506052 -45.57871 -6.70777e-6 -2.506044 43.79538 -37.5013 0.07068967 -1.373839 36.79124 -0.03372907 -1.373828 -37.5013 -2.568011 -1.37384 36.79124 -2.67243 -1.373829</float_array>
+          <float_array id="Plane_001-mesh-positions-array" count="36">-37.50128 0.07065105 -45.57873 36.79127 -0.03376418 -45.57868 -37.50133 0.07073253 43.79536 36.79121 -0.03368782 43.79541 5.07091e-6 0.007062852 -45.57871 -6.70745e-6 0.007068574 43.79538 5.07061e-6 -2.506052 -45.57871 -6.70777e-6 -2.506044 43.79538 -37.5013 0.06136327 -1.373839 36.79124 -0.04305541 -1.373828 -37.5013 -2.568011 -1.37384 36.79124 -2.67243 -1.373829</float_array>
           <technique_common>
             <accessor source="#Plane_001-mesh-positions-array" count="12" stride="3">
               <param name="X" type="float"/>
@@ -531,9 +197,9 @@
           </technique_common>
         </source>
         <source id="Plane_001-mesh-normals">
-          <float_array id="Plane_001-mesh-normals-array" count="18">0.001405417 0.9999991 -8.53004e-7 -1 0 -1.31787e-7 -1.4868e-7 -2.71064e-7 1 0.001405477 0.9999991 -9.10681e-7 -1 0 -1.31787e-7 -1.41079e-7 -3.16241e-7 1</float_array>
+          <float_array id="Plane_001-mesh-normals-array" count="9">0.001405477 0.9999991 -8.81843e-7 -1 0 -1.31787e-7 -1.44173e-7 -2.94694e-7 1</float_array>
           <technique_common>
-            <accessor source="#Plane_001-mesh-normals-array" count="6" stride="3">
+            <accessor source="#Plane_001-mesh-normals-array" count="3" stride="3">
               <param name="X" type="float"/>
               <param name="Y" type="float"/>
               <param name="Z" type="float"/>
@@ -541,9 +207,9 @@
           </technique_common>
         </source>
         <source id="Plane_001-mesh-map-0">
-          <float_array id="Plane_001-mesh-map-0-array" count="36">0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
+          <float_array id="Plane_001-mesh-map-0-array" count="24">0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</float_array>
           <technique_common>
-            <accessor source="#Plane_001-mesh-map-0-array" count="18" stride="2">
+            <accessor source="#Plane_001-mesh-map-0-array" count="12" stride="2">
               <param name="S" type="float"/>
               <param name="T" type="float"/>
             </accessor>
@@ -552,12 +218,13 @@
         <vertices id="Plane_001-mesh-vertices">
           <input semantic="POSITION" source="#Plane_001-mesh-positions"/>
         </vertices>
-        <triangles count="6">
+        <polylist count="3">
           <input semantic="VERTEX" source="#Plane_001-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Plane_001-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#Plane_001-mesh-map-0" offset="2" set="0"/>
-          <p>0 0 0 3 0 1 1 0 2 4 1 3 7 1 4 5 1 5 9 2 6 10 2 7 11 2 8 0 3 9 2 3 10 3 3 11 4 4 12 6 4 13 7 4 14 9 5 15 8 5 16 10 5 17</p>
-        </triangles>
+          <vcount>4 4 4 </vcount>
+          <p>0 0 0 2 0 1 3 0 2 1 0 3 5 1 4 4 1 5 6 1 6 7 1 7 9 2 8 8 2 9 10 2 10 11 2 11</p>
+        </polylist>
       </mesh>
     </geometry>
     <geometry id="Cube_014-mesh" name="Cube.014">
@@ -619,31 +286,31 @@
       </node>
       <node id="collision_pad16" name="collision_pad16" type="NODE">
         <matrix sid="transform">-0.3914475 0.9202005 -1.92831e-6 -96.36374 -0.9202005 -0.3914475 7.25287e-7 40.71675 -8.74228e-8 2.05834e-6 1 55.86814 0 0 0 1</matrix>
-        <instance_geometry url="#Plane_008-mesh" name="collision_pad16"/>
+        <instance_geometry url="#Plane_004-mesh" name="collision_pad16"/>
       </node>
       <node id="collision_pad17" name="collision_pad17" type="NODE">
         <matrix sid="transform">-0.003212371 0.9999948 -1.25474e-5 -104.6127 -0.9999948 -0.003212371 4.29724e-7 0.08230972 3.89414e-7 1.25488e-5 1 55.86814 0 0 0 1</matrix>
-        <instance_geometry url="#Plane_006-mesh" name="collision_pad17"/>
+        <instance_geometry url="#Plane_004-mesh" name="collision_pad17"/>
       </node>
       <node id="collision_pad18" name="collision_pad18" type="NODE">
         <matrix sid="transform">0.3875498 0.9218488 -1.22998e-6 -96.33852 -0.9218488 0.3875498 -1.6537e-7 -40.77638 3.24233e-7 1.19795e-6 1 55.86814 0 0 0 1</matrix>
-        <instance_geometry url="#Plane_007-mesh" name="collision_pad18"/>
+        <instance_geometry url="#Plane_004-mesh" name="collision_pad18"/>
       </node>
       <node id="collision_pad13" name="collision_pad13" type="NODE">
         <matrix sid="transform">-0.3914475 0.9202005 -1.92831e-6 -96.36374 -0.9202005 -0.3914475 7.25287e-7 40.71675 -8.74228e-8 2.05834e-6 1 -3.350822 0 0 0 1</matrix>
-        <instance_geometry url="#Plane_009-mesh" name="collision_pad13"/>
+        <instance_geometry url="#Plane_004-mesh" name="collision_pad13"/>
       </node>
       <node id="collision_pad14" name="collision_pad14" type="NODE">
         <matrix sid="transform">-0.003212371 0.9999948 -1.25474e-5 -104.6127 -0.9999948 -0.003212371 4.29724e-7 0.08230972 3.89414e-7 1.25488e-5 1 -3.350822 0 0 0 1</matrix>
-        <instance_geometry url="#Plane_005-mesh" name="collision_pad14"/>
+        <instance_geometry url="#Plane_004-mesh" name="collision_pad14"/>
       </node>
       <node id="collision_pad15" name="collision_pad15" type="NODE">
         <matrix sid="transform">0.3875498 0.9218488 -1.22998e-6 -96.33852 -0.9218488 0.3875498 -1.6537e-7 -40.77638 3.24233e-7 1.19795e-6 1 -3.350822 0 0 0 1</matrix>
-        <instance_geometry url="#Plane_003-mesh" name="collision_pad15"/>
+        <instance_geometry url="#Plane_004-mesh" name="collision_pad15"/>
       </node>
       <node id="collision_pad10" name="collision_pad10" type="NODE">
         <matrix sid="transform">-0.3914475 0.9202005 -1.92831e-6 -96.36374 -0.9202005 -0.3914475 7.25287e-7 40.71675 -8.74228e-8 2.05834e-6 1 -64.64304 0 0 0 1</matrix>
-        <instance_geometry url="#Plane_010-mesh" name="collision_pad10"/>
+        <instance_geometry url="#Plane_004-mesh" name="collision_pad10"/>
       </node>
       <node id="collision_pad11" name="collision_pad11" type="NODE">
         <matrix sid="transform">-0.003212371 0.9999948 -1.25474e-5 -104.6127 -0.9999948 -0.003212371 4.29724e-7 0.08230972 3.89414e-7 1.25488e-5 1 -64.64303 0 0 0 1</matrix>
@@ -651,7 +318,7 @@
       </node>
       <node id="collision_pad12" name="collision_pad12" type="NODE">
         <matrix sid="transform">0.3875498 0.9218488 -1.22998e-6 -96.33852 -0.9218488 0.3875498 -1.6537e-7 -40.77638 3.24233e-7 1.19795e-6 1 -64.64301 0 0 0 1</matrix>
-        <instance_geometry url="#Plane_011-mesh" name="collision_pad12"/>
+        <instance_geometry url="#Plane_004-mesh" name="collision_pad12"/>
       </node>
       <node id="collision_pad09" name="collision_pad09" type="NODE">
         <matrix sid="transform">0.9999996 9.12038e-4 3.27174e-7 0.3552225 -9.12038e-4 0.9999996 1.36694e-6 -111.4373 -3.25927e-7 -1.36724e-6 1 0.5500488 0 0 0 1</matrix>
@@ -702,94 +369,94 @@
         </instance_geometry>
       </node>
       <node id="entrance_port06" name="entrance_port06" type="NODE">
-        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 3.05176e-5 -8.02679e-7 1 -1.50996e-7 4.36175e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 6.55651e-6 -8.02679e-7 1 -1.50996e-7 -8.7738e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
       </node>
       <node id="entrance_port05" name="entrance_port05" type="NODE">
-        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 3.05176e-5 -8.02679e-7 1 -1.50996e-7 4.36175e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 6.55651e-6 -8.02679e-7 1 -1.50996e-7 -8.7738e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
       </node>
       <node id="exit_port06" name="exit_port06" type="NODE">
-        <matrix sid="transform">1 -1.60536e-6 6.51682e-7 0 1.60536e-6 1 4.76837e-7 6.10352e-5 -6.51683e-7 -4.76836e-7 1 55.86819 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.60536e-6 6.51682e-7 -2.39611e-5 1.60536e-6 1 4.76837e-7 -7.00951e-5 -6.51683e-7 -4.76836e-7 1 55.86819 0 0 0 1</matrix>
       </node>
       <node id="exit_port05" name="exit_port05" type="NODE">
-        <matrix sid="transform">1 -1.60536e-6 6.51682e-7 0 1.60536e-6 1 4.76837e-7 6.11767e-5 -6.51683e-7 -4.76836e-7 1 -3.35083 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.60536e-6 6.51682e-7 -2.39611e-5 1.60536e-6 1 4.76837e-7 -7.00951e-5 -6.51683e-7 -4.76836e-7 1 -3.35083 0 0 0 1</matrix>
       </node>
       <node id="entrance_port01" name="entrance_port01" type="NODE">
-        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 3.05176e-5 -8.02679e-7 1 -1.50996e-7 4.36175e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 6.55651e-6 -8.02679e-7 1 -1.50996e-7 -8.7738e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b02" name="loc_A001_p01_s0_50_b02" type="NODE">
-        <matrix sid="transform">-0.3835266 -0.9235299 5.59219e-7 102.8187 0.9235299 -0.3835266 9.12053e-7 42.9735 -6.27833e-7 8.66252e-7 1 -43.7991 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3835266 -0.9235299 5.59219e-7 102.8155 0.9235299 -0.3835266 9.12053e-7 42.97202 -6.27833e-7 8.66252e-7 1 -43.7991 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b01" name="loc_A001_p01_s0_50_b01" type="NODE">
-        <matrix sid="transform">0.3818406 -0.9242282 1.80073e-6 103.0906 0.9242282 0.3818406 -4.36691e-7 -42.31689 -2.8399e-7 1.83103e-6 1 -43.79908 0 0 0 1</matrix>
+        <matrix sid="transform">0.3818406 -0.9242282 1.80073e-6 103.0873 0.9242282 0.3818406 -4.36691e-7 -42.31569 -2.8399e-7 1.83103e-6 1 -43.79908 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b04" name="loc_A001_p01_s0_50_b04" type="NODE">
-        <matrix sid="transform">-0.9235305 0.383525 -1.78822e-6 -42.97336 -0.383525 -0.9235305 9.69844e-7 102.8186 -1.27952e-6 1.58151e-6 1 -43.79911 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9235305 0.383525 -1.78822e-6 -42.97204 -0.383525 -0.9235305 9.69844e-7 102.8152 -1.27952e-6 1.58151e-6 1 -43.79911 0 0 0 1</matrix>
       </node>
       <node id="loc_A001_p01_s0_50_b03" name="loc_A001_p01_s0_50_b03" type="NODE">
-        <matrix sid="transform">-0.924228 -0.3818412 -2.35006e-7 42.31701 0.3818412 -0.924228 2.32419e-6 103.0906 -1.10467e-6 2.05834e-6 1 -43.79911 0 0 0 1</matrix>
+        <matrix sid="transform">-0.924228 -0.3818412 -2.35006e-7 42.31565 0.3818412 -0.924228 2.32419e-6 103.0872 -1.10467e-6 2.05834e-6 1 -43.79911 0 0 0 1</matrix>
       </node>
       <node id="exit_port01" name="exit_port01" type="NODE">
-        <matrix sid="transform">0.9238799 0.3826826 -3.33435e-7 7.62939e-6 -0.3826826 0.9238799 -1.13462e-7 -5.73712e-6 2.64634e-7 2.32425e-7 1 -43.29041 0 0 0 1</matrix>
+        <matrix sid="transform">0.9238799 0.3826826 -3.33435e-7 -1.62721e-5 -0.3826826 0.9238799 -1.13462e-7 -1.37806e-4 2.64634e-7 2.32425e-7 1 -43.29041 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b07" name="loc_B001_p02_s0_50_b07" type="NODE">
-        <matrix sid="transform">-0.9242279 -0.3818417 -3.26043e-7 42.31699 0.3818417 -0.9242279 2.10383e-6 103.0906 -1.10467e-6 1.81993e-6 1 45.46565 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9242279 -0.3818417 -3.26043e-7 42.31565 0.3818417 -0.9242279 2.10383e-6 103.0873 -1.10467e-6 1.81993e-6 1 45.46565 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b08" name="loc_B001_p02_s0_50_b08" type="NODE">
-        <matrix sid="transform">-0.9235305 0.383525 -1.78822e-6 -42.9734 -0.383525 -0.9235305 9.69844e-7 102.8187 -1.27952e-6 1.58151e-6 1 45.46563 0 0 0 1</matrix>
+        <matrix sid="transform">-0.9235305 0.383525 -1.78822e-6 -42.97208 -0.383525 -0.9235305 9.69844e-7 102.8153 -1.27952e-6 1.58151e-6 1 45.46563 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b05" name="loc_B001_p02_s0_50_b05" type="NODE">
-        <matrix sid="transform">0.3818406 -0.9242282 1.80073e-6 103.0906 0.9242282 0.3818406 -4.36691e-7 -42.31688 -2.8399e-7 1.83103e-6 1 45.46569 0 0 0 1</matrix>
+        <matrix sid="transform">0.3818406 -0.9242282 1.80073e-6 103.0873 0.9242282 0.3818406 -4.36691e-7 -42.31568 -2.8399e-7 1.83103e-6 1 45.46569 0 0 0 1</matrix>
       </node>
       <node id="loc_B001_p02_s0_50_b06" name="loc_B001_p02_s0_50_b06" type="NODE">
-        <matrix sid="transform">-0.3835266 -0.9235299 5.59219e-7 102.8187 0.9235299 -0.3835266 9.12053e-7 42.9735 -6.27833e-7 8.66252e-7 1 45.46568 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3835266 -0.9235299 5.59219e-7 102.8155 0.9235299 -0.3835266 9.12053e-7 42.97202 -6.27833e-7 8.66252e-7 1 45.46568 0 0 0 1</matrix>
       </node>
       <node id="entrance_port02" name="entrance_port02" type="NODE">
-        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 3.05176e-5 -8.02679e-7 1 -1.50996e-7 4.36175e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 6.55651e-6 -8.02679e-7 1 -1.50996e-7 -8.7738e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
       </node>
       <node id="exit_port02" name="exit_port02" type="NODE">
-        <matrix sid="transform">0.9238799 0.3826826 -3.33435e-7 -1.14441e-5 -0.3826826 0.9238799 -1.13462e-7 9.45136e-6 2.64634e-7 2.32425e-7 1 45.58858 0 0 0 1</matrix>
+        <matrix sid="transform">0.9238799 0.3826826 -3.33435e-7 -3.53456e-5 -0.3826826 0.9238799 -1.13462e-7 -1.22547e-4 2.64634e-7 2.32425e-7 1 45.58858 0 0 0 1</matrix>
       </node>
       <node id="entrance_port03" name="entrance_port03" type="NODE">
-        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 3.05176e-5 -8.02679e-7 1 -1.50996e-7 4.36175e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 6.55651e-6 -8.02679e-7 1 -1.50996e-7 -8.7738e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
       </node>
       <node id="exit_port04" name="exit_port04" type="NODE">
-        <matrix sid="transform">1 -1.60536e-6 6.51682e-7 -1.19209e-7 1.60536e-6 1 4.76837e-7 8.97937e-8 -6.51683e-7 -4.76836e-7 1 0.6729431 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.60536e-6 6.51682e-7 -2.40803e-5 1.60536e-6 1 4.76837e-7 -1.3113e-4 -6.51683e-7 -4.76836e-7 1 0.6729431 0 0 0 1</matrix>
       </node>
       <node id="loc_C001_p04_s0_100_b09" name="loc_C001_p04_s0_100_b09" type="NODE">
-        <matrix sid="transform">0.9999996 -9.118e-4 1.75891e-7 0.3552225 9.118e-4 0.9999996 -1.19209e-6 -111.4373 -1.74804e-7 1.19225e-6 1 0.5500516 0 0 0 1</matrix>
+        <matrix sid="transform">0.9999996 -9.118e-4 1.75891e-7 0.3551872 9.118e-4 0.9999996 -1.19209e-6 -111.4339 -1.74804e-7 1.19225e-6 1 0.5500526 0 0 0 1</matrix>
       </node>
       <node id="entrance_port04" name="entrance_port04" type="NODE">
-        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 3.05176e-5 -8.02679e-7 1 -1.50996e-7 4.36175e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
+        <matrix sid="transform">-1 -8.02679e-7 -3.89414e-7 6.55651e-6 -8.02679e-7 1 -1.50996e-7 -8.7738e-5 3.89414e-7 -1.50996e-7 -1 132.823 0 0 0 1</matrix>
       </node>
       <node id="exit_port03" name="exit_port03" type="NODE">
-        <matrix sid="transform">1 -1.60536e-6 6.51682e-7 0 1.60536e-6 1 4.76837e-7 6.11767e-5 -6.51683e-7 -4.76836e-7 1 -64.64302 0 0 0 1</matrix>
+        <matrix sid="transform">1 -1.60536e-6 6.51682e-7 -2.40207e-5 1.60536e-6 1 4.76837e-7 -7.00951e-5 -6.51683e-7 -4.76836e-7 1 -64.64302 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b10" name="loc_E001_p03_s0_33_b10" type="NODE">
-        <matrix sid="transform">-0.3914475 0.9202003 -1.92831e-6 -96.36374 -0.9202003 -0.3914475 7.25287e-7 40.71675 -8.74228e-8 2.05834e-6 1 -64.64304 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3914475 0.9202003 -1.92831e-6 -96.36072 -0.9202003 -0.3914475 7.25287e-7 40.71534 -8.74228e-8 2.05834e-6 1 -64.64304 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b11" name="loc_E001_p03_s0_33_b11" type="NODE">
-        <matrix sid="transform">-0.003212402 0.9999947 -1.25474e-5 -104.6127 -0.9999947 -0.003212402 4.29724e-7 0.08231025 3.89414e-7 1.25488e-5 1 -64.64303 0 0 0 1</matrix>
+        <matrix sid="transform">-0.003212402 0.9999947 -1.25474e-5 -104.6094 -0.9999947 -0.003212402 4.29724e-7 0.08217478 3.89414e-7 1.25488e-5 1 -64.64303 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b12" name="loc_E001_p03_s0_33_b12" type="NODE">
-        <matrix sid="transform">0.3875498 0.9218487 -1.22998e-6 -96.33852 -0.9218487 0.3875498 -1.6537e-7 -40.77639 3.24233e-7 1.19795e-6 1 -64.64301 0 0 0 1</matrix>
+        <matrix sid="transform">0.3875498 0.9218487 -1.22998e-6 -96.33552 -0.9218487 0.3875498 -1.6537e-7 -40.77523 3.24233e-7 1.19795e-6 1 -64.64301 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b15" name="loc_E001_p03_s0_33_b15" type="NODE">
-        <matrix sid="transform">0.3875498 0.9218487 -1.22998e-6 -96.33852 -0.9218487 0.3875498 -1.6537e-7 -40.77636 3.24233e-7 1.19795e-6 1 -3.350817 0 0 0 1</matrix>
+        <matrix sid="transform">0.3875498 0.9218487 -1.22998e-6 -96.33552 -0.9218487 0.3875498 -1.6537e-7 -40.77521 3.24233e-7 1.19795e-6 1 -3.350815 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b14" name="loc_E001_p03_s0_33_b14" type="NODE">
-        <matrix sid="transform">-0.003212402 0.9999947 -1.25474e-5 -104.6127 -0.9999947 -0.003212402 4.29724e-7 0.0823381 3.89414e-7 1.25488e-5 1 -3.350822 0 0 0 1</matrix>
+        <matrix sid="transform">-0.003212402 0.9999947 -1.25474e-5 -104.6094 -0.9999947 -0.003212402 4.29724e-7 0.08220291 3.89414e-7 1.25488e-5 1 -3.350822 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b13" name="loc_E001_p03_s0_33_b13" type="NODE">
-        <matrix sid="transform">-0.3914475 0.9202003 -1.92831e-6 -96.36375 -0.9202003 -0.3914475 7.25287e-7 40.71674 -8.74228e-8 2.05834e-6 1 -3.350843 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3914475 0.9202003 -1.92831e-6 -96.36072 -0.9202003 -0.3914475 7.25287e-7 40.71532 -8.74228e-8 2.05834e-6 1 -3.350845 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b16" name="loc_E001_p03_s0_33_b16" type="NODE">
-        <matrix sid="transform">-0.3914475 0.9202003 -1.92831e-6 -96.36375 -0.9202003 -0.3914475 7.25287e-7 40.71677 -8.74228e-8 2.05834e-6 1 55.86813 0 0 0 1</matrix>
+        <matrix sid="transform">-0.3914475 0.9202003 -1.92831e-6 -96.36072 -0.9202003 -0.3914475 7.25287e-7 40.71535 -8.74228e-8 2.05834e-6 1 55.86813 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b17" name="loc_E001_p03_s0_33_b17" type="NODE">
-        <matrix sid="transform">-0.003212402 0.9999947 -1.25474e-5 -104.6127 -0.9999947 -0.003212402 4.29724e-7 0.08235076 3.89414e-7 1.25488e-5 1 55.86814 0 0 0 1</matrix>
+        <matrix sid="transform">-0.003212402 0.9999947 -1.25474e-5 -104.6094 -0.9999947 -0.003212402 4.29724e-7 0.08221531 3.89414e-7 1.25488e-5 1 55.86814 0 0 0 1</matrix>
       </node>
       <node id="loc_E001_p03_s0_33_b18" name="loc_E001_p03_s0_33_b18" type="NODE">
-        <matrix sid="transform">0.3875498 0.9218487 -1.22998e-6 -96.33855 -0.9218487 0.3875498 -1.6537e-7 -40.77636 3.24233e-7 1.19795e-6 1 55.86819 0 0 0 1</matrix>
+        <matrix sid="transform">0.3875498 0.9218487 -1.22998e-6 -96.33555 -0.9218487 0.3875498 -1.6537e-7 -40.77521 3.24233e-7 1.19795e-6 1 55.86819 0 0 0 1</matrix>
       </node>
     </visual_scene>
   </library_visual_scenes>

--- a/src/AnimationCurves.h
+++ b/src/AnimationCurves.h
@@ -58,6 +58,13 @@ namespace AnimationCurves {
 		return 0.5 * (1.0 - std::cos(p * M_PI));
 	}
 
+	// easing from https://github.com/Michaelangel007/easing#tldr-shut-up-and-show-me-the-code
+	// p should go from 0.0 to 1.0
+	inline float OutSineEasing(float p)
+	{
+		return std::sin(p * M_PI * 0.5);
+	}
+
 	// Based on http://blog.moagrius.com/actionscript/jsas-understanding-easing/
 	// and observations from Godot Engine and Star Citizen
 	// This supports four different easing functions encoded in a single float:

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -133,10 +133,17 @@ void ModelBody::SetStatic(bool isStatic)
 void ModelBody::SetColliding(bool colliding)
 {
 	m_colliding = colliding;
-	if (colliding)
+	if (colliding) {
 		m_geom->Enable();
-	else
+		for(auto &g : m_dynGeoms) {
+			g->Enable();
+		}
+	} else {
 		m_geom->Disable();
+		for(auto &g : m_dynGeoms) {
+			g->Disable();
+		}
+	}
 }
 
 void ModelBody::RebuildCollisionMesh()
@@ -152,6 +159,7 @@ void ModelBody::RebuildCollisionMesh()
 
 	//static geom
 	m_geom = new Geom(m_collMesh->GetGeomTree(), GetOrient(), GetPosition(), this);
+	if(!IsColliding()) m_geom->Disable();
 
 	SetPhysRadius(maxRadius);
 
@@ -166,6 +174,7 @@ void ModelBody::RebuildCollisionMesh()
 		SceneGraph::CollisionGeometry *cg = dgf.GetCgForTree(*it);
 		if (cg)
 			cg->SetGeom(dynG);
+		if(!IsColliding()) dynG->Disable();
 		m_dynGeoms.push_back(dynG);
 	}
 

--- a/src/Player.h
+++ b/src/Player.h
@@ -27,6 +27,7 @@ public:
 	virtual Missile *SpawnMissile(ShipType::Id missile_type, int power = -1) override;
 	virtual void SetAlertState(Ship::AlertState as) override;
 	virtual void NotifyRemoved(const Body *const removedBody) override;
+	virtual bool ManualDocking() const override { return !AIIsActive(); }
 
 	virtual void SetShipType(const ShipType::Id &shipId) override;
 

--- a/src/Player.h
+++ b/src/Player.h
@@ -29,6 +29,8 @@ public:
 	virtual void NotifyRemoved(const Body *const removedBody) override;
 	virtual bool ManualDocking() const override { return !AIIsActive(); }
 
+	void DoFixspeedTakeoff(SpaceStation *from = nullptr);
+
 	virtual void SetShipType(const ShipType::Id &shipId) override;
 
 	PlayerShipController *GetPlayerController() const;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -897,13 +897,22 @@ void Ship::Blastoff()
 
 	assert(f->GetBody()->IsType(ObjectType::PLANET));
 
-	const double planetRadius = 2.0 + static_cast<Planet *>(f->GetBody())->GetTerrainHeight(up);
-	SetVelocity(vector3d(0, 0, 0));
-	SetAngVelocity(vector3d(0, 0, 0));
-	SetFlightState(FLYING);
+	if (ManualDocking()) {
+		if (!IsType(ObjectType::PLAYER)) {
+			Log::Warning("It wasn't the player's ship that tried to take off without an autopilot!");
+			return;
+		}
+		auto p = static_cast<Player*>(this);
+		p->DoFixspeedTakeoff();
+	} else {
+		const double planetRadius = 2.0 + static_cast<Planet *>(f->GetBody())->GetTerrainHeight(up);
+		SetVelocity(vector3d(0, 0, 0));
+		SetAngVelocity(vector3d(0, 0, 0));
+		SetFlightState(FLYING);
 
-	SetPosition(up * planetRadius - GetAabb().min.y * up);
-	SetThrusterState(1, 1.0); // thrust upwards
+		SetPosition(up * planetRadius - GetAabb().min.y * up);
+		SetThrusterState(1, 1.0); // thrust upwards
+	}
 
 	LuaEvent::Queue("onShipTakeOff", this, f->GetBody());
 }

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -34,6 +34,7 @@
 #include "lua/LuaUtils.h"
 #include "scenegraph/Animation.h"
 #include "scenegraph/Tag.h"
+#include "scenegraph/CollisionGeometry.h"
 #include "ship/PlayerShipController.h"
 
 static const float TONS_HULL_PER_SHIELD = 10.f;
@@ -522,12 +523,11 @@ bool Ship::OnDamage(Body *attacker, float kgDamage, const CollisionContact &cont
 
 bool Ship::OnCollision(Body *b, Uint32 flags, double relVel)
 {
-	// Collision with SpaceStation docking surface is
+	// Collision with SpaceStation docking or entrance surface is
 	// completely handled by SpaceStations, you only
 	// need to return a "true" value in order to trigger
 	// a bounce in Space::OnCollision
-	// NOTE: 0x10 is a special flag set on docking surfaces
-	if (b->IsType(ObjectType::SPACESTATION) && (flags & 0x10)) {
+	if (b->IsType(ObjectType::SPACESTATION) && (flags & (SceneGraph::CollisionGeometry::DOCKING | SceneGraph::CollisionGeometry::ENTRANCE))) {
 		return true;
 	}
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -104,6 +104,7 @@ public:
 	void SetGunState(int idx, int state);
 	void UpdateMass();
 	virtual bool SetWheelState(bool down); // returns success of state change, NOT state itself
+	virtual bool ManualDocking() const { return false; }
 	void Blastoff();
 	bool Undock();
 	virtual void TimeStepUpdate(const float timeStep) override;
@@ -184,7 +185,7 @@ public:
 	AlertState GetAlertState() { return m_alertState; }
 
 	void AIClearInstructions(); // Note: defined in Ship-AI.cpp
-	bool AIIsActive() { return m_curAICmd ? true : false; }
+	bool AIIsActive() const { return m_curAICmd ? true : false; }
 	void AIGetStatusText(char *str); // Note: defined in Ship-AI.cpp
 
 	void AIKamikaze(Body *target); // Note: defined in Ship-AI.cpp

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -1350,7 +1350,8 @@ bool AICmdDock::TimeStepUpdate()
 	}
 
 	switch (ship->GetFlightState()) {
-	case Ship::UNDOCKING: return false; // allow undock animation to proceed
+	case Ship::DOCKING:
+	case Ship::UNDOCKING: return false; // allow dock / undock animation to proceed
 	case Ship::DOCKED:
 	case Ship::LANDED:
 		LaunchShip(ship);
@@ -1359,7 +1360,6 @@ bool AICmdDock::TimeStepUpdate()
 	case Ship::HYPERSPACE:
 		return false;
 	case Ship::FLYING:
-	case Ship::DOCKING:
 		break;
 	}
 
@@ -1385,7 +1385,7 @@ bool AICmdDock::TimeStepUpdate()
 	if (m_state == eDockGetDataStart || m_state == eDockGetDataEnd || m_state == eDockingComplete) {
 		const SpaceStationType *type = m_target->GetStationType();
 		SpaceStationType::positionOrient_t dockpos;
-		type->GetShipApproachWaypoints(port, (m_state == 0) ? 1 : 2, dockpos);
+		type->GetShipApproachWaypoints(port, (m_state == 0) ? DockStage::APPROACH1 : DockStage::APPROACH2, dockpos);
 		if (m_state != eDockGetDataEnd) {
 			m_dockpos = dockpos.pos;
 		}

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -572,7 +572,13 @@ void SpaceStation::DockingUpdate(const double timeStep)
 			dt.ship->SetFlightState(Ship::FLYING);
 			dt.ship->SetAngVelocity(GetAngVelocity());
 			if (m_type->IsSurfaceStation()) {
-				dt.ship->SetThrusterState(1, 1.0); // up
+				if(!dt.ship->ManualDocking()) {
+					dt.ship->SetThrusterState(1, 1.0); // up
+				} else {
+					// only the player can launch without autopilot
+					auto player = static_cast<Player*>(dt.ship);
+					player->DoFixspeedTakeoff();
+				}
 			} else {
 				dt.ship->SetThrusterState(2, -1.0); // forward
 			}

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -22,6 +22,7 @@
 #include "graphics/Renderer.h"
 #include "lua/LuaEvent.h"
 #include "scenegraph/Animation.h"
+#include "scenegraph/CollisionGeometry.h"
 #include "scenegraph/MatrixTransform.h"
 #include "scenegraph/ModelSkin.h"
 #include "utils.h"
@@ -383,8 +384,9 @@ bool SpaceStation::GetDockingClearance(Ship *s)
 
 bool SpaceStation::OnCollision(Body *b, Uint32 flags, double relVel)
 {
-	if ((flags >= 0x10) && (b->IsType(ObjectType::SHIP))) {
+	if ((flags & (SceneGraph::CollisionGeometry::DOCKING | SceneGraph::CollisionGeometry::ENTRANCE)) && (b->IsType(ObjectType::SHIP))) {
 		Ship *s = static_cast<Ship *>(b);
+		if(s->ManualDocking() && (flags & SceneGraph::CollisionGeometry::ENTRANCE)) return false;
 
 		int port = -1;
 		for (Uint32 i = 0; i < m_shipDocking.size(); i++) {

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -89,25 +89,18 @@ private:
 	void DockingUpdate(const double timeStep);
 	void PositionDockingShip(Ship *ship, int port) const;
 	void PositionDockedShip(Ship *ship, int port) const;
-	bool LevelShip(Ship *ship, int port, const float timeStep) const;
+	bool LevelShip(Ship *ship, int port, const float timeStep);
 	void DoLawAndOrder(const double timeStep);
 	bool IsPortLocked(const int bay) const;
 	void LockPort(const int bay, const bool lockIt);
+	double GetDockAnimStageDuration(const int bay, const DockStage stage) const;
+	double GetUndockAnimStageDuration(const int bay, const DockStage stage) const;
 
-	/* Stage 0 means docking port empty
-	 * Stage 1 means docking clearance granted to ->ship
-	 * Stage 2 to m_type->numDockingStages is docking animation
-	 * Stage m_type->numDockingStages+1 means evaluating repos
-	 * Stage m_type->numDockingStages+2 means ship is repositioning
-	 * Stage m_type->numDockingStages+3 means ship is just docked
-	 * Stage m_type->numDockingStages+4 means ship is docked
-	 * Stage -1 to -m_type->numUndockStages is undocking animation
-	 */
 	struct shipDocking_t {
 		shipDocking_t() :
 			ship(0),
 			shipIndex(0),
-			stage(0),
+			stage(DockStage::NONE),
 			stagePos(0),
 			fromPos(0.0),
 			fromRot(1.0, 0.0, 0.0, 0.0),
@@ -116,7 +109,7 @@ private:
 
 		Ship *ship;
 		int shipIndex; // deserialisation
-		int stage;
+		DockStage stage;
 		double stagePos;  // 0 -> 1.0
 		vector3d fromPos; // in station model coords
 		Quaterniond fromRot;
@@ -129,6 +122,9 @@ private:
 	SpaceStationType::TPorts m_ports;
 
 	double m_oldAngDisplacement;
+
+	void SwitchToStage(Uint32 bay, DockStage stage);
+	matrix4x4d GetBayTransform(Uint32 bay) const;
 
 	void InitStation();
 	const SpaceStationType *m_type;

--- a/src/enum_table.cpp
+++ b/src/enum_table.cpp
@@ -11,11 +11,11 @@
 #include "ShipAICmd.h"
 #include "ShipType.h"
 #include "SpaceStation.h"
+#include "SpaceStationType.h"
 #include "SystemView.h"
 #include "galaxy/Polit.h"
 #include "galaxy/SystemBody.h"
 #include "lua/LuaEngine.h"
-#include "lua/LuaFileSystem.h"
 #include "pigui/Face.h"
 #include "scenegraph/Model.h"
 #include "ship/PlayerShipController.h"
@@ -112,6 +112,37 @@ const struct EnumItem ENUM_DockingRefusedReason[] = {
 	{ "ClearanceAlreadyGranted", int(SpaceStation::DockingRefusedReason::ClearanceAlreadyGranted) },
 	{ "TooFarFromStation", int(SpaceStation::DockingRefusedReason::TooFarFromStation) },
 	{ "NoBaysAvailable", int(SpaceStation::DockingRefusedReason::NoBaysAvailable) },
+	{ 0, 0 },
+};
+
+const struct EnumItem ENUM_DockStage[] = {
+	{ "NONE", int(DockStage::NONE) },
+	{ "MANUAL", int(DockStage::MANUAL) },
+	{ "DOCK_STAGES_BEGIN", int(DockStage::DOCK_STAGES_BEGIN) },
+	{ "CLEARANCE_GRANTED", int(DockStage::CLEARANCE_GRANTED) },
+	{ "DOCK_ANIMATION_NONE", int(DockStage::DOCK_ANIMATION_NONE) },
+	{ "DOCK_ANIMATION_1", int(DockStage::DOCK_ANIMATION_1) },
+	{ "DOCK_ANIMATION_2", int(DockStage::DOCK_ANIMATION_2) },
+	{ "DOCK_ANIMATION_3", int(DockStage::DOCK_ANIMATION_3) },
+	{ "DOCK_ANIMATION_MAX", int(DockStage::DOCK_ANIMATION_MAX) },
+	{ "TOUCHDOWN", int(DockStage::TOUCHDOWN) },
+	{ "LEVELING", int(DockStage::LEVELING) },
+	{ "REPOSITION", int(DockStage::REPOSITION) },
+	{ "JUST_DOCK", int(DockStage::JUST_DOCK) },
+	{ "DOCK_STAGES_END", int(DockStage::DOCK_STAGES_END) },
+	{ "DOCKED", int(DockStage::DOCKED) },
+	{ "UNDOCK_STAGES_BEGIN", int(DockStage::UNDOCK_STAGES_BEGIN) },
+	{ "UNDOCK_BEGIN", int(DockStage::UNDOCK_BEGIN) },
+	{ "UNDOCK_ANIMATION_NONE", int(DockStage::UNDOCK_ANIMATION_NONE) },
+	{ "UNDOCK_ANIMATION_1", int(DockStage::UNDOCK_ANIMATION_1) },
+	{ "UNDOCK_ANIMATION_2", int(DockStage::UNDOCK_ANIMATION_2) },
+	{ "UNDOCK_ANIMATION_3", int(DockStage::UNDOCK_ANIMATION_3) },
+	{ "UNDOCK_ANIMATION_MAX", int(DockStage::UNDOCK_ANIMATION_MAX) },
+	{ "UNDOCK_END", int(DockStage::UNDOCK_END) },
+	{ "LEAVE", int(DockStage::LEAVE) },
+	{ "UNDOCK_STAGES_END", int(DockStage::UNDOCK_STAGES_END) },
+	{ "APPROACH1", int(DockStage::APPROACH1) },
+	{ "APPROACH2", int(DockStage::APPROACH2) },
 	{ 0, 0 },
 };
 
@@ -318,6 +349,7 @@ const struct EnumTable ENUM_TABLES[] = {
 	{ "DualLaserOrientation", ENUM_DualLaserOrientation },
 	{ "ShipTypeTag", ENUM_ShipTypeTag },
 	{ "DockingRefusedReason", ENUM_DockingRefusedReason },
+	{ "DockStage", ENUM_DockStage },
 	{ "ProjectableTypes", ENUM_ProjectableTypes },
 	{ "ProjectableBases", ENUM_ProjectableBases },
 	{ "SystemViewMode", ENUM_SystemViewMode },
@@ -348,6 +380,7 @@ const struct EnumTable ENUM_TABLES_PUBLIC[] = {
 	{ "DualLaserOrientation", ENUM_DualLaserOrientation },
 	{ "ShipTypeTag", ENUM_ShipTypeTag },
 	{ "DockingRefusedReason", ENUM_DockingRefusedReason },
+	{ "DockStage", ENUM_DockStage },
 	{ "ProjectableTypes", ENUM_ProjectableTypes },
 	{ "ProjectableBases", ENUM_ProjectableBases },
 	{ "SystemViewMode", ENUM_SystemViewMode },

--- a/src/enum_table.h
+++ b/src/enum_table.h
@@ -26,6 +26,7 @@ extern const struct EnumItem ENUM_ShipAICmdName[];
 extern const struct EnumItem ENUM_DualLaserOrientation[];
 extern const struct EnumItem ENUM_ShipTypeTag[];
 extern const struct EnumItem ENUM_DockingRefusedReason[];
+extern const struct EnumItem ENUM_DockStage[];
 extern const struct EnumItem ENUM_ProjectableTypes[];
 extern const struct EnumItem ENUM_ProjectableBases[];
 extern const struct EnumItem ENUM_SystemViewMode[];

--- a/src/matrix4x4.h
+++ b/src/matrix4x4.h
@@ -680,17 +680,17 @@ public:
 	//from rotation matrices
 	vector3<T> Right() const
 	{
-		return vector3<T>(cell[0], cell[4], cell[8]);
+		return vector3<T>(cell[0], cell[1], cell[2]);
 	}
 
 	vector3<T> Up() const
 	{
-		return vector3<T>(cell[1], cell[5], cell[9]);
+		return vector3<T>(cell[4], cell[5], cell[6]);
 	}
 
 	vector3<T> Back() const
 	{
-		return vector3<T>(cell[2], cell[6], cell[10]);
+		return vector3<T>(cell[8], cell[9], cell[10]);
 	}
 };
 

--- a/src/scenegraph/CollisionGeometry.h
+++ b/src/scenegraph/CollisionGeometry.h
@@ -43,6 +43,11 @@ namespace SceneGraph {
 		Geom *GetGeom() const { return m_geom; }
 		void SetGeom(Geom *g) { m_geom = g; }
 
+		enum Flag : unsigned int {
+			DOCKING  = 0x01,
+			ENTRANCE = 0x02
+		};
+
 	protected:
 		~CollisionGeometry();
 

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -1012,15 +1012,11 @@ namespace SceneGraph {
 		//special names after collision_
 		if (nodename.length() > 10) {
 			//landing pads
-			if (nodename.length() >= 14 && nodename.substr(10, 3) == "pad") {
-				const std::string pad = nodename.substr(13);
-				const int padID = atoi(pad.c_str()) - 1;
-				if (padID < 240) {
-					return 0x10 + padID;
-				}
-			} else if (nodename.length() >= 14 && nodename.substr(10, 4) == "port") {
-				// entrance port
-				return 0x10;
+			if (nodename.length() >= 13 && std::string_view{ nodename }.substr(10, 3) == "pad") {
+				return SceneGraph::CollisionGeometry::DOCKING;
+			//entrance
+			} else if (nodename.length() >= 14 && std::string_view{ nodename }.substr(10, 4) == "port") {
+				return SceneGraph::CollisionGeometry::ENTRANCE;
 			}
 		}
 		//anything else is static collision


### PR DESCRIPTION
If you fly in or launch from the orbital station on autopilot - everything works as before, I just improved these animations a little. But if your autopilot is off, you can fly into the station and land manually.

Since the station is rotating, it is recommended to turn on the "Follow orientation" mode, then the ship will compensate for the rotation of the station. Although, you can land completely manually.

In order not to hit anything, when manually starting from the orbital, the "cruise-up" mode is automatically turned on. It seemed to me that it works well in other places too - when launching from a ground station or from the surface - you are slowly ascending at a speed of 2 m/s.

In fact, this is a quite large refactoring of SpaceStation and SpaceStationType, as a result of which it becomes trivial to implement manual docking.

![pic](https://github.com/pioneerspacesim/pioneer/assets/18342621/4bf5625b-2db0-4d00-be3a-11f57ad081b8)



<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

