### PR TITLE
Ignore x-axis only mouse wheel events

### DIFF
--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -658,8 +658,10 @@ void Manager::HandleSDLEvent(SDL_Event &event)
 		}
 		break;
 	case SDL_MOUSEWHEEL:
-		mouseWheel = event.wheel.y;
-		onMouseWheel.emit(event.wheel.y > 0); // true = up
+		if (event.wheel.y != 0) {
+			mouseWheel = event.wheel.y;
+			onMouseWheel.emit(event.wheel.y > 0); // true = up
+		}
 		break;
 	case SDL_MOUSEMOTION:
 		mouseMotion[0] += event.motion.xrel;


### PR DESCRIPTION
Some mice (like mine) have an x and y axis on the wheel.

Ignore mouse wheel events that are x-axis only (so therefore have a y-axis value of zero).  The behavior of my (Microsoft) mouse is that pushing left and right on the wheel repeatedly call mouse wheel y events as long as it's held.  We were interpreting these as always being mouse wheel down events, causing my clumsy fingers on the mouse wheel to zoom very quickly out in the third person ship view, sector view and so forth.
