### PR TITLE
Fix for -10% and +10% buttons in station's lobby

### DIFF
--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -128,7 +128,8 @@ local refuelInternalTank = function (delta)
 	end
 
 	Game.player:AddMoney(-total)
-	station:AddCommodityStock(Commodities.hydrogen, -math.ceil(mass))
+	local commodityChangeAmount = mass < 0 and math.floor(mass) or math.ceil(mass)
+	station:AddCommodityStock(Commodities.hydrogen, commodityChangeAmount)
 	Game.player:SetFuelPercent(fuel)
 end
 


### PR DESCRIPTION
Fixes #5585

The problem was with this line in `refuelInternalTank` in `data/pigui/modules/station-view/01-lobby.lua`:

`station:AddCommodityStock(Commodities.hydrogen, -math.ceil(mass))`

`math.ceil` is rounding number up, so if this number is negative(ex. -2.3) it will be rounded to -2 because it is nearest value that greater or equal to -2.3. So the solution is to change above mentioned line to:

`local commodityChangeAmount = mass < 0 and math.floor(mass) or math.ceil(mass)
station:AddCommodityStock(Commodities.hydrogen, commodityChangeAmount)`

[Accepted answer by Guffa(albeit it's for javascript, but works the same way)](https://stackoverflow.com/questions/26335076/math-ceil-not-working-with-negative-floats)