### PR TITLE
Update for "Fix for -10% and +10% buttons in station's lobby" pull request

### DIFF
--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -129,7 +129,7 @@ local refuelInternalTank = function (delta)
 
 	Game.player:AddMoney(-total)
 	local commodityChangeAmount = mass < 0 and math.floor(mass) or math.ceil(mass)
-	station:AddCommodityStock(Commodities.hydrogen, commodityChangeAmount)
+	station:AddCommodityStock(Commodities.hydrogen, -commodityChangeAmount)
 	Game.player:SetFuelPercent(fuel)
 end
 


### PR DESCRIPTION
Fix for [this pull request](https://github.com/pioneerspacesim/pioneer/pull/5628).

Added minus to `commodityChangeAmount` in this line:

`station:AddCommodityStock(Commodities.hydrogen, commodityChangeAmount)`

so demand and in stock decrease is not mixed up for -10% and +10% buttons (-10% decreases in stock and +10% decreases demand).

