### PR TITLE
Fix for glued cockpit

### DIFF
--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -64,13 +64,18 @@ inline void ShipCockpit::resetInternalCameraController()
 
 void ShipCockpit::Update(const Player *player, float timeStep)
 {
-	m_transform = matrix4x4d::Identity();
-
+	//Check if current view is exterior since we don't need to update cockpit
+	//because player can't see it
+	if (Pi::game->GetWorldView()->shipView->IsExteriorView())
+	{
+		return;
+	}
 	if (m_icc == nullptr) {
 		// I don't know where to put this
 		resetInternalCameraController();
 	}
 
+	m_transform = matrix4x4d::Identity();
 	double rotX;
 	double rotY;
 	m_icc->getRots(rotX, rotY);


### PR DESCRIPTION
Fixes #5621

This happened, because there was no check in this statement in `void ShipCockpit::Update(const Player *player, float timeStep)`: 
`if (m_icc == nullptr)`,
if current `CameraController` is really `InternalCameraController`. Because of that, this statement in `inline void ShipCockpit::resetInternalCameraController()`:
`m_icc = static_cast<InternalCameraController *>(Pi::game->GetWorldView()->shipView->GetCameraController());`,
would cast current `CameraController` to invalid type if it was not `InternalCameraController`, which is undefined behaviour.
Added check at the start of `Update` if current view is exterior to ensure that current `CameraController` is really `InternalCameraController`.
