### PR TITLE
Fix for commodity market in stock and demand reset

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -1008,6 +1008,10 @@ Event.Register("onGameStart", function ()
 
 		visited = loaded_data.visited or {}
 		police = loaded_data.police
+		
+		for station,_ in pairs(visited) do
+			createCommodityStock(station)
+		end
 
 		for station,list in pairs(loaded_data.shipsOnSale) do
 			shipsOnSale[station] = {}


### PR DESCRIPTION
Fixes #5582 

This happened, because `transientMarket` in `SpaceStation.lua` was never linked to `stationMarket` in `Economy.lua` after loading the save. Adding `createCommodityStock(station)` in loop `for station,list in pairs(loaded_data.shipsOnSale) do` in the `onGameStart` event will make sure to do that for every station player has visited in the system.

**Update**
Changed to a more clean-looking solution.