### PR TITLE
Search bar for save/load window and crashes fix

### DIFF
--- a/data/lang/ui-core/ar.json
+++ b/data/lang/ui-core/ar.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "حفظ"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/bg.json
+++ b/data/lang/ui-core/bg.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Запазване"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Товарни монтировки"

--- a/data/lang/ui-core/ca.json
+++ b/data/lang/ui-core/ca.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Guardar"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/cs.json
+++ b/data/lang/ui-core/cs.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Uložit"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Podvěsy sběračů"

--- a/data/lang/ui-core/da.json
+++ b/data/lang/ui-core/da.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Gem"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/de.json
+++ b/data/lang/ui-core/de.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Speichern"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Schöpferslots"

--- a/data/lang/ui-core/el.json
+++ b/data/lang/ui-core/el.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Αποθήκευση"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Υποδοχείς συλλεκτών"

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Save"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/eo.json
+++ b/data/lang/ui-core/eo.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Save"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/es.json
+++ b/data/lang/ui-core/es.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Guardar"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Monturas de colector"

--- a/data/lang/ui-core/fr.json
+++ b/data/lang/ui-core/fr.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Sauvegarder"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/ga.json
+++ b/data/lang/ui-core/ga.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Sábháil"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Tacaí scúip"

--- a/data/lang/ui-core/gd.json
+++ b/data/lang/ui-core/gd.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Sàbhail"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Tàthaidhean sgioba"

--- a/data/lang/ui-core/hr.json
+++ b/data/lang/ui-core/hr.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Save"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/hu.json
+++ b/data/lang/ui-core/hu.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Ment"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Szívó felfüggesztés"

--- a/data/lang/ui-core/id.json
+++ b/data/lang/ui-core/id.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Save"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/it.json
+++ b/data/lang/ui-core/it.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Salva"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Supporti per raccoglitori"

--- a/data/lang/ui-core/ja-Hira.json
+++ b/data/lang/ui-core/ja-Hira.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Save"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/ja.json
+++ b/data/lang/ui-core/ja.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "セーブ"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "スクープ搭載可能数"

--- a/data/lang/ui-core/ja_JP.json
+++ b/data/lang/ui-core/ja_JP.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Save"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/lt.json
+++ b/data/lang/ui-core/lt.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Įrašyti"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/nb.json
+++ b/data/lang/ui-core/nb.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Lagre"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/nl.json
+++ b/data/lang/ui-core/nl.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Opslaan"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Inlaatbevestigingpunten"

--- a/data/lang/ui-core/pl.json
+++ b/data/lang/ui-core/pl.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Zapisz"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Mocowania czerpaków"

--- a/data/lang/ui-core/pt.json
+++ b/data/lang/ui-core/pt.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Gravar"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Scoop mounts"

--- a/data/lang/ui-core/pt_BR.json
+++ b/data/lang/ui-core/pt_BR.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Salvar"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Slots para coletores"

--- a/data/lang/ui-core/ro.json
+++ b/data/lang/ui-core/ro.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Salvează"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Monturi colectoare"

--- a/data/lang/ui-core/ru.json
+++ b/data/lang/ui-core/ru.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Сохранение"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Чувст. к регистру"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Крепления для заборника"

--- a/data/lang/ui-core/sv.json
+++ b/data/lang/ui-core/sv.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Spara"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Skopfästen"

--- a/data/lang/ui-core/tr.json
+++ b/data/lang/ui-core/tr.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "Kaydet"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "Toplayıcı bağlantıları"

--- a/data/lang/ui-core/zh.json
+++ b/data/lang/ui-core/zh.json
@@ -1911,6 +1911,10 @@
     "description": "",
     "message": "保存"
   },
+  "CASE_SENSITIVE": {
+    "description": "",
+    "message": "Case-sensitive"
+  },
   "SCOOP_MOUNTS": {
     "description": "How many slots or mounts exist on the ship for fitting SCOOPS (e.g. cargo scoop, fuel scoop, multi-scoop) ",
     "message": "收集器挂点"

--- a/data/modules/Debug/DebugCommodityPrices.lua
+++ b/data/modules/Debug/DebugCommodityPrices.lua
@@ -338,6 +338,7 @@ end
 -- end)
 
 debugView.registerTab("Commodity Price", function()
+  if Game.player == nil then return end
   if ui.beginTabItem("Commodity Price") then
     main()
     ui.endTabItem()

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -45,6 +45,7 @@ ui.selectable = pigui.Selectable
 ui.progressBar = pigui.ProgressBar
 ui.plotHistogram = pigui.PlotHistogram
 ui.setTooltip = pigui.SetTooltip
+ui.setItemTooltip = pigui.SetItemTooltip
 ui.addCircle = pigui.AddCircle
 ui.addCircleFilled = pigui.AddCircleFilled
 ui.addRect = pigui.AddRect ---@type fun(a: Vector2, b: Vector2, col: Color, rounding: number, edges: integer, thickness: number)

--- a/data/pigui/modules/new-game-window/ship.lua
+++ b/data/pigui/modules/new-game-window/ship.lua
@@ -427,15 +427,15 @@ local function findEquipmentType(eqTypeID)
 	assert(false, "Wrong Equipment ID: " .. tostring(eqTypeID))
 end
 
-local function findEquipmentPath(eqType)
+local function findEquipmentPath(eqKey)
 	for _, eq_list in pairs({ 'misc', 'laser', 'hyperspace' }) do
 		for id, obj in pairs(Equipment[eq_list]) do
-			if obj == eqType then
+			if obj.l10n_key == eqKey then
 				return eq_list, id
 			end
 		end
 	end
-	assert(false, "Wrong Equipment ID: " .. tostring(eqType))
+	assert(false, "Wrong Equipment ID: " .. tostring(eqKey))
 end
 
 local function hasSlotClass(eqTypeID, slotClass)
@@ -717,7 +717,7 @@ function ShipEquip:fromStartVariant(variant)
 	eq_value.misc = {}
 	for _, entry in pairs(variant.equipment) do
 		local eq, amount = table.unpack(entry)
-		local eq_list, id = findEquipmentPath(eq)
+		local eq_list, id = findEquipmentPath(eq.l10n_key)
 		if eq_list == 'misc' then
 			self:addMiscEntry(id)
 		elseif eq_list == 'laser' then

--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -64,8 +64,8 @@ local function getSaveTooltip(name)
 	else
 		ret = ret .. "\n" .. lc.SHIP .. ": " .. lc.UNKNOWN
 	end
-	
-	
+
+
 	if stats.flight_state then
 		ret = ret .. "\n"..lui.FLIGHT_STATE..": "
 		ret = ret .. (rawget(lc, string.upper(stats.flight_state)) or
@@ -75,7 +75,7 @@ local function getSaveTooltip(name)
 
 	if stats.docked_at then ret = ret .. "\n"..lui.DOCKED_AT..": " .. stats.docked_at end
 	if stats.frame then ret = ret .. "\n"..lui.VICINITY_OF..": " .. stats.frame end
-    
+
 	saveFileCache[name].ret = ret
 	return ret
 end
@@ -84,7 +84,7 @@ local function shouldDisplayThisSave(f)
     if(string.len(searchSave) < minSearchTextLength) then
 	   return true
 	end
-	
+
 	return not caseSensitive and  string.find(string.lower(f.name), string.lower(searchSave), 1, true) ~= nil or
 	string.find(f.name, searchSave, 1, true) ~= nil
 end
@@ -94,9 +94,9 @@ local function displaySave(f)
 	   selectedSave = f.name
 	   saveIsValid = pcall(Game.SaveGameStats, f.name)
 	end
-	if Engine.pigui.IsItemHovered() then
-		local tooltip = getSaveTooltip(f.name)
-		Engine.pigui.SetTooltip(tooltip)
+
+	if ui.isItemHovered("ForTooltip") then
+		ui.setTooltip(getSaveTooltip(f.name))
 	end
 
 	ui.nextColumn()
@@ -170,24 +170,24 @@ end
 ui.saveLoadWindow = ModalWindow.New("LoadGame", function()
 	local saving = ui.saveLoadWindow.mode == "SAVE"
 	local searchTextSize = ui.calcTextSize(searchText, pionillium.medium.name, pionillium.medium.size)
-	
+
 	local txt_width = winSize.x - (ui.getWindowPadding().x + optionButtonSize.x + ui.getItemSpacing().x) * 2
-	
+
 	drawSearchHeader(txt_width)
-	
+
 	ui.separator()
-	
+
 	local saveFilesSearchHeaderHeight = (searchTextSize.y * 2 + ui.getItemSpacing().y * 2 + ui.getWindowPadding().y * 2)
 	local saveFilesChildWindowHeight = (optionButtonSize.y + (saving and searchTextSize.y or 0) + ui.getItemSpacing().y * 2 + ui.getWindowPadding().y * 2)
-	
+
 	local saveFilesChildWindowSize = Vector2(0, (winSize.y - saveFilesChildWindowHeight) - saveFilesSearchHeaderHeight)
-	
+
 	ui.child("savefiles", saveFilesChildWindowSize, function()
 		showSaveFiles()
 	end)
 
 	ui.separator()
-	
+
 	-- a little padding just before the window border, so that the cancel button will not be cut out
 	txt_width = txt_width / 1.03
 	if saving then

--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -20,9 +20,17 @@ local optionButtonSize = ui.rescaleUI(Vector2(100, 32))
 local winSize = Vector2(ui.screenWidth * 0.4, ui.screenHeight * 0.6)
 local pionillium = ui.fonts.pionillium
 
+local searchText = lc.SEARCH .. ':'
+local saveText = lui.SAVE .. ':'
+local caseSensitiveText = lui.CASE_SENSITIVE
+
 local saveFileCache = {}
 local selectedSave
 local saveIsValid = true
+
+local minSearchTextLength = 1
+local searchSave = ""
+local caseSensitive = false
 
 local function optionTextButton(label, enabled, callback)
 	local variant = not enabled and ui.theme.buttonColors.disabled or nil
@@ -56,23 +64,44 @@ local function getSaveTooltip(name)
 	else
 		ret = ret .. "\n" .. lc.SHIP .. ": " .. lc.UNKNOWN
 	end
-
+	
+	
 	if stats.flight_state then
 		ret = ret .. "\n"..lui.FLIGHT_STATE..": "
-		if stats.flight_state == "docked" then ret = ret .. lc.DOCKED
-		elseif stats.flight_state == "docking" then ret = ret .. lc.DOCKING
-		elseif stats.flight_state == "flying" then ret = ret .. lui.FLYING
-		elseif stats.flight_state == "hyperspace" then ret = ret .. lc.HYPERSPACE
-		elseif stats.flight_state == "jumping" then ret = ret .. lui.JUMPING
-		elseif stats.flight_state == "landed" then ret = ret .. lc.LANDED
-		elseif stats.flight_state == "undocking" then ret = ret .. lc.UNDOCKING
-		else ret = ret .. lc.UNKNOWN end
+		ret = ret .. (rawget(lc, string.upper(stats.flight_state)) or
+		rawget(lui, string.upper(stats.flight_state)) or
+		lc.UNKNOWN)
 	end
 
 	if stats.docked_at then ret = ret .. "\n"..lui.DOCKED_AT..": " .. stats.docked_at end
 	if stats.frame then ret = ret .. "\n"..lui.VICINITY_OF..": " .. stats.frame end
-
+    
+	saveFileCache[name].ret = ret
 	return ret
+end
+
+local function shouldDisplayThisSave(f)
+    if(string.len(searchSave) < minSearchTextLength) then
+	   return true
+	end
+	
+	return not caseSensitive and  string.find(string.lower(f.name), string.lower(searchSave), 1, true) ~= nil or
+	string.find(f.name, searchSave, 1, true) ~= nil
+end
+
+local function displaySave(f)
+	if ui.selectable(f.name, f.name == selectedSave, {"SpanAllColumns", "DontClosePopups"}) then
+	   selectedSave = f.name
+	   saveIsValid = pcall(Game.SaveGameStats, f.name)
+	end
+	if Engine.pigui.IsItemHovered() then
+		local tooltip = getSaveTooltip(f.name)
+		Engine.pigui.SetTooltip(tooltip)
+	end
+
+	ui.nextColumn()
+	ui.text(Format.Date(f.mtime.timestamp))
+	ui.nextColumn()
 end
 
 local function showSaveFiles()
@@ -84,18 +113,9 @@ local function showSaveFiles()
 		table.sort(files, function(a,b) return (a.mtime.timestamp > b.mtime.timestamp) end)
 		ui.columns(2,"##saved_games",true)
 		for _,f in pairs(files) do
-			if ui.selectable(f.name, f.name == selectedSave, {"SpanAllColumns", "DontClosePopups"}) then
-				selectedSave = f.name
-				saveIsValid = pcall(Game.SaveGameStats, f.name)
+		    if(shouldDisplayThisSave(f)) then
+				displaySave(f)
 			end
-			if Engine.pigui.IsItemHovered() then
-				local tooltip = getSaveTooltip(f.name)
-				Engine.pigui.SetTooltip(tooltip)
-			end
-
-			ui.nextColumn()
-			ui.text(Format.Date(f.mtime.timestamp))
-			ui.nextColumn()
 		end
 		ui.columns(1,"",false)
 	end
@@ -106,6 +126,7 @@ local function closeAndClearCache()
 	ui.saveLoadWindow.mode = nil
 	saveFileCache = {}
 	popupOpened = false
+	searchSave = ""
 end
 
 local function closeAndLoadOrSave()
@@ -120,32 +141,63 @@ local function closeAndLoadOrSave()
 	end
 end
 
+local function drawSearchHeader(txt_width)
+	ui.withFont(pionillium.medium.name, pionillium.medium.size, function()
+		ui.text(searchText)
+		ui.nextItemWidth(txt_width, 0)
+		searchSave, _ = ui.inputText("##searchSave", searchSave, {})
+		ui.sameLine()
+		local ch, value = ui.checkbox(caseSensitiveText, caseSensitive)
+		if ch then
+			caseSensitive = value
+		end
+	end)
+end
+
+local function drawOptionButtons(txt_width, saving)
+
+	-- for vertical center alignment
+	local txt_hshift = math.max(0, (optionButtonSize.y - ui.getFrameHeight()) / 2)
+	local mode = saving and lui.SAVE or lui.LOAD
+	ui.sameLine(txt_width + ui.getWindowPadding().x + ui.getItemSpacing().x)
+	ui.addCursorPos(Vector2(0, saving and -txt_hshift or txt_hshift))
+	optionTextButton(mode, selectedSave ~= nil and selectedSave ~= '' and saveIsValid, closeAndLoadOrSave)
+	ui.sameLine()
+	ui.addCursorPos(Vector2(0, saving and -txt_hshift or txt_hshift))
+	optionTextButton(lui.CANCEL, true, closeAndClearCache)
+end
+
 ui.saveLoadWindow = ModalWindow.New("LoadGame", function()
 	local saving = ui.saveLoadWindow.mode == "SAVE"
-	local other_height = optionButtonSize.y + ui.getItemSpacing().y * 2 + ui.getWindowPadding().y * 2
-	ui.child("savefiles", Vector2(-1, winSize.y - other_height), function()
+	local searchTextSize = ui.calcTextSize(searchText, pionillium.medium.name, pionillium.medium.size)
+	
+	local txt_width = winSize.x - (ui.getWindowPadding().x + optionButtonSize.x + ui.getItemSpacing().x) * 2
+	
+	drawSearchHeader(txt_width)
+	
+	ui.separator()
+	
+	local saveFilesSearchHeaderHeight = (searchTextSize.y * 2 + ui.getItemSpacing().y * 2 + ui.getWindowPadding().y * 2)
+	local saveFilesChildWindowHeight = (optionButtonSize.y + (saving and searchTextSize.y or 0) + ui.getItemSpacing().y * 2 + ui.getWindowPadding().y * 2)
+	
+	local saveFilesChildWindowSize = Vector2(0, (winSize.y - saveFilesChildWindowHeight) - saveFilesSearchHeaderHeight)
+	
+	ui.child("savefiles", saveFilesChildWindowSize, function()
 		showSaveFiles()
 	end)
 
 	ui.separator()
-
-	local txt_width = winSize.x - (ui.getWindowPadding().x + optionButtonSize.x + ui.getItemSpacing().x) * 2
+	
+	-- a little padding just before the window border, so that the cancel button will not be cut out
+	txt_width = txt_width / 1.03
 	if saving then
-		-- for vertical center alignment
-		local txt_hshift = math.max(0, (optionButtonSize.y - ui.getFrameHeight()) / 2)
-		ui.nextItemWidth(txt_width, 0)
-		ui.addCursorPos(Vector2(0, txt_hshift))
-		selectedSave = ui.inputText("##saveFileName", selectedSave or "", {})
-		ui.sameLine(txt_width + ui.getWindowPadding().x + ui.getItemSpacing().x)
-		ui.addCursorPos(Vector2(0, -txt_hshift))
-	else
-		ui.addCursorPos(Vector2(txt_width + ui.getItemSpacing().x, 0))
+		ui.withFont(pionillium.medium.name, pionillium.medium.size, function()
+			ui.text(saveText)
+			ui.nextItemWidth(txt_width, 0)
+			selectedSave = ui.inputText("##saveFileName", selectedSave or "", {})
+		end)
 	end
-
-	local mode = saving and lui.SAVE or lui.LOAD
-	optionTextButton(mode, selectedSave ~= nil and selectedSave ~= '' and saveIsValid, closeAndLoadOrSave)
-	ui.sameLine()
-	optionTextButton(lui.CANCEL, true, closeAndClearCache)
+	drawOptionButtons(txt_width, saving)
 
 end, function (_, drawPopupFn)
 	ui.setNextWindowSize(winSize, "Always")


### PR DESCRIPTION
### Search bar for save/load window with some rewrite

This PR adds search bar for save/load window to search for specific save by name for quickly choosing it from the list, if player has a lot of saves, for example. Some rewrite to better support resolution scaling and addition of new elements to bottom part.

In action:

https://github.com/pioneerspacesim/pioneer/assets/69468517/3963eda6-feaf-4bab-b949-ddf40576282f

Known issue: although not showed in the video, doesn't support case-insensitive search for non-english characters due to #4110 

And some fixes to two crashes that don't have their own issue.

### Crash 1
![Crash 1 message](https://github.com/pioneerspacesim/pioneer/assets/69468517/f5de8f70-25e4-4895-8768-15bf64d1fea1)



This was happening in main menu with opened tab `Commodity Price` in `Debug Info`, because it lacked check in `registerTab` in `DebugCommodityPrices`:
`if Game.player == nil then return end`

### Crash 2 
![Crash 2 message](https://github.com/pioneerspacesim/pioneer/assets/69468517/3e693abd-4c47-4e2d-8773-83930e45b56e)


This was happening when player tried to choose new game variant in new game window after loading any save and then exiting to main menu.
This was happening, because in `Equipment.lua` tables that define items are reinitialized after loading the save.
This tables is used during registering of start variants in `new-game-window\class.lua` (ex. for `Start At Mars` start):
```
StartVariants.register({
	name       = lui.START_AT_MARS,
	desc       = lui.START_AT_MARS_DESC,
	location   = SystemPath.New(0,0,0,0,18),
	logmsg     = lui.START_LOG_ENTRY_1,
	shipType   = 'coronatrix',
	money      = 600,
	hyperdrive = true,
	equipment  = {
		{ laser.pulsecannon_1mw,      1 },
		{ misc.atmospheric_shielding, 1 },
		{ misc.autopilot,             1 },
		{ misc.radar,                 1 }
	},
	cargo      = {
		{ Commodities.hydrogen, 2 }
	},
	pattern    = 1,
	colors     = { Color('000000'), Color('000000'), Color('000000') }
})
```
and then this tables are compared in this function in `new-game-window\ship.lua`:
```
local function findEquipmentPath(eqType)
	for _, eq_list in pairs({ 'misc', 'laser', 'hyperspace' }) do
		for id, obj in pairs(Equipment[eq_list]) do
			if obj == eqType then
				return eq_list, id
			end
		end
	end
	assert(false, "Wrong Equipment ID: " .. tostring(eqType))
end
```
But since tables in `Equipment.lua` are reinitialized on save load the game will crash with message showed earlier.
So comparison changed to compare against equipment's `l10n_key` since it's unique for every equipment.
