### PR TITLE
ScanManager improvements and ship properties fixes

### DIFF
--- a/data/libs/CargoManager.lua
+++ b/data/libs/CargoManager.lua
@@ -27,8 +27,14 @@ function CargoManager:Constructor(ship)
 	self.usedCargoMass = 0
 
 	-- Initialize property variables on owning ship for backwards compatibility
-	ship:setprop("totalCargo", self:GetTotalSpace())
-	ship:setprop("usedCargo", 0)
+	-- don't initialize them if they're already created after first save
+	if not self.ship:hasprop("totalCargo") then
+		ship:setprop("totalCargo", self:GetTotalSpace())
+	end
+	
+	if not self.ship:hasprop("usedCargo") then
+		ship:setprop("usedCargo", 0)
+	end
 
 	-- TODO: stored commodities should be represented as array of { name, count, meta } entries
 	-- to allow for e.g. tracking stolen/scooped cargo, or special mission-related cargoes
@@ -99,7 +105,7 @@ end
 function CargoManager:AddCommodity(type, count)
 	-- TODO: use a cargo volume metric with variable mass instead of fixed 1m^3 == 1t
 	local required_space = (type.mass or 1) * (count or 1)
-
+	
 	if self:GetFreeSpace() < required_space then
 		return false
 	end
@@ -245,6 +251,7 @@ end
 function CargoManager:Unserialize()
 	setmetatable(self, CargoManager.meta)
 	self.listeners = {}
+	
 	return self
 end
 

--- a/data/modules/Scout/ScanDisplay.lua
+++ b/data/modules/Scout/ScanDisplay.lua
@@ -94,8 +94,9 @@ function scanDisplay:drawDebug()
 	minRes = ui.dragFloat("MinRes", minRes, 1.0, 0.1, 100, "%f")
 	coverage = ui.dragFloat("Coverage", coverage, 0.5, 0.5, 100, "%fkm^2")
 
-	if scanMgr:GetActiveScan() then
-		local altitude, resolution = scanMgr:GetBodyState(self.ship.frameBody)
+	local activeScan = scanMgr:GetActiveScan()
+	if activeScan then
+		local altitude, resolution = scanMgr:GetBodyState(scanMgr:GetScanBodyByType())
 
 		ui.text("Current Alt: " .. altitude)
 		ui.text("Current Res: " .. resolution)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -375,17 +375,17 @@ bool Game::UpdateTimeAccel()
 
 					vector3d toBody = m_player->GetPosition() - b->GetPositionRelTo(m_player->GetFrame());
 					double dist = toBody.Length();
-					double rad = b->GetPhysRadius();
+					double rad = std::max(b->GetPhysRadius(), 10000.0);
 
 					if (dist < 1000.0) {
 						newTimeAccel = std::min(newTimeAccel, Game::TIMEACCEL_1X);
 					} else if (dist < std::min(rad + 0.0001 * AU, rad * 1.1)) {
 						newTimeAccel = std::min(newTimeAccel, Game::TIMEACCEL_10X);
-					} else if (dist < std::min(rad + 0.001 * AU, rad * 5.0)) {
+					} else if (dist < std::min(rad + 0.001 * AU, rad * 2.5)) {
 						newTimeAccel = std::min(newTimeAccel, Game::TIMEACCEL_100X);
-					} else if (dist < std::min(rad + 0.01 * AU, rad * 10.0)) {
+					} else if (dist < std::min(rad + 0.01 * AU, rad * 5.0)) {
 						newTimeAccel = std::min(newTimeAccel, Game::TIMEACCEL_1000X);
-					} else if (dist < std::min(rad + 0.1 * AU, rad * 1000.0)) {
+					} else if (dist < std::min(rad + 0.1 * AU, rad * 500.0)) {
 						newTimeAccel = std::min(newTimeAccel, Game::TIMEACCEL_10000X);
 					}
 				}

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -677,7 +677,7 @@ void Ship::UpdateLuaStats()
 	m_stats.hyperspace_range = m_stats.hyperspace_range_max = 0;
 	int hyperclass = p.Get("hyperclass_cap");
 	if (hyperclass) {
-		std::tie(m_stats.hyperspace_range_max, m_stats.hyperspace_range) =
+		std::tie(m_stats.hyperspace_range, m_stats.hyperspace_range_max) =
 			LuaObject<Ship>::CallMethod<double, double>(this, "GetHyperspaceRange");
 	}
 

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -756,9 +756,11 @@ static FrameId MakeFramesFor(const double at_time, SystemBody *sbody, Body *b, F
 
 	if ((supertype == SystemBody::SUPERTYPE_GAS_GIANT) ||
 		(supertype == SystemBody::SUPERTYPE_ROCKY_PLANET)) {
-		// for planets we want an non-rotating frame for a few radii
+		// for planets we want an non-rotating frame covering its Hill radius
 		// and a rotating frame with no radius to contain attached objects
-		double frameRadius = std::max(4.0 * sbody->GetRadius(), sbody->GetMaxChildOrbitalDistance() * 1.05);
+		double hillRadius = sbody->GetSemiMajorAxis() * (1.0 - sbody->GetEccentricity()) * pow(sbody->GetMass() / (3.0 * sbody->GetParent()->GetMass()), 1.0 / 3.0);
+		double frameRadius = std::max(hillRadius, sbody->GetMaxChildOrbitalDistance() * 1.05);
+		frameRadius = std::max(sbody->GetRadius() * 4.0, frameRadius);
 		FrameId orbFrameId = Frame::CreateFrame(fId,
 			sbody->GetName().c_str(),
 			Frame::FLAG_HAS_ROT,


### PR DESCRIPTION
**UPDATE**
As suggested by @Web-eWorks, first solution changed to wrap `totalCargo` and `usedCargo` around this check (ex. for `totalCargo`) in `function CargoManager:Constructor(ship)`:
```
if not self.ship:hasprop("totalCargo") then
	ship:setprop("totalCargo", self:GetTotalSpace())
end
```
so this properties will not be reinitialized by `CargoManager`'s constructor, because after saving the game, this properties will be already stored in the ship and will be unserialized during loading the game.
`self.ship:UpdateEquipStats()` was not needed since it's called internally from C++.

While testing more, another bug was found, `maxHyperspaceRange` wasn't properly initialized after loading the game.
This happened, because in this line in `void Ship::UpdateLuaStats()`:

```
	if (hyperclass) {
		std::tie(m_stats.hyperspace_range_max, m_stats.hyperspace_range) =
			LuaObject<Ship>::CallMethod<double, double>(this, "GetHyperspaceRange");
	}
```

`m_stats.hyperspace_range_max`, `m_stats.hyperspace_range` are mixed up since `GetHyperspaceRange` returns `range` and `range_max`, `range` is zero at this time, but will be initialized later. 
Switched them up so `maxHyperspaceRange` will be properly initialized.

### Incorrect display of `cargo space used` after loading the game

Fixes #5557 fixes #5534   
(Maybe more)

The `Ship`'s properties were not assigned new `CargoManager` property values after it was loaded from save.
The most evident case of this is incorrect display of `cargo space used` in `personal info` after loading the save.
This properties is used in a bunch of other places that I listed [here](https://github.com/pioneerspacesim/pioneer/issues/5557#issuecomment-1737314182). 
One of this places is calculating probability of pirates attacking player, so I guess expect more pirate attacks?!
I also want to clarify that this was happening to **every** ship present during save loading.
To fix it, added this lines in `CargoManager:Unserialize`:

```
self.ship:setprop("totalCargo", self:GetTotalSpace())
self.ship:setprop("usedCargo", self.usedCargoSpace)

self.ship:UpdateEquipStats()
```
To assign new values to `Ship`'s properties during `CargoManager` unserialization.

Still don't know if this line is needed:

```
self.ship:UpdateEquipStats()
```
but I leave it for now, just in case, like in `CargoManager:OnShipTypeChanged()`.

### Scanner not starting previous scan after loading the game

Fixes #5577

`ScanManager: StartScanCallback` had no way to determine if the current `ScanManager` was loaded from save when it needed to set up a callback, because field `activeCallback` of `ScanManager` is saved and during unserialization `ScanManager:StartScanCallback` is called which has this check:
```
if updateRate == self.activeCallback then
```
which basically thinks that callback is already setted up for current `ScanManager`, which in reality is not.

Added additional argument to `ScanManager:StartScanCallback` `force` and changed this check to:
```
if updateRate == self.activeCallback and not force then
```
to force through this check if `ScanManager:StartScanCallback` was called from `ScanManager:Unserialize`.

### Orbital scanning stops despite meeting maximum altitude requirements
This was due to an oversight in the `ScanManager`s code, when it did not take into account that player might be too far from the planet, when his frame of reference (`frameBody`) was changing, immediately stopping the scanning process.
Added additional checks when current scan is orbital (ex. immediatly returning from `onFrameChanged` when current scan is orbital) and branching body choice:
```
self.activeScan.orbital and self.activeScan.bodyPath:GetSystemBody().body or self.ship.frameBody
```
**Update**: a small revision of code.
**Update2**: added additional assertions with messages to better describe what happened.