### PR TITLE
Lua io and FileSystem uri changes

### DIFF
--- a/data/meta/Constants.lua
+++ b/data/meta/Constants.lua
@@ -250,13 +250,6 @@ Constants.DetailLevel = {
 	[5] = "VERY_HIGH",
 }
 
--- A <Constants.FileSystemRoot> string
----@enum FileSystemRoot
-Constants.FileSystemRoot = {
-	[1] = "USER",
-	[2] = "DATA",
-}
-
 -- A <Constants.PiGuiFaceFlags> string
 ---@enum PiGuiFaceFlags
 Constants.PiGuiFaceFlags = {

--- a/data/meta/FileSystem.lua
+++ b/data/meta/FileSystem.lua
@@ -1,0 +1,49 @@
+-- Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+-- This is used in FileSyestem.lua whcih then extends that.
+
+---@meta
+
+---@class FileSystem
+local FileSystem = {}
+
+---@param path string The directory to read the contents of.
+---@return string[] files  A list of files as full paths from the root
+---@return string[] dirs   A list of dirs as full paths from the root
+---
+--- Example:
+---  > local files, dirs = FileSystem.ReadDirectory("user://savefiles")
+function FileSystem.ReadDirectory(path) end
+
+--- Join the passed arguments into a path, correctly handling separators and .
+--- and .. special dirs.
+---
+---@param arg string[]  A list of path elements to be joined
+---@return string       The joined path elements
+function FileSystem.JoinPath( ... ) end
+
+---@param dir_name string The name of the folder to create
+---@return boolean Success
+function FileSystem.MakeDirectory( dir_name ) end
+
+--- Wrapper for our patched io.open that ensures files are opened inside the sandbox.
+--- Prefer using this to io.open
+---
+--- Files in the user folder can be read or written to
+--- Files in the data folder are read only.
+---
+---
+---
+--- Example:
+--- > f = FileSystem.Open( "user://my_file.txt", "w" )
+--- > f:write( "file contents" )
+--- > f:close()
+--- 
+---@param filename string   The name of the file to open, must start either user:// or data://
+---@param mode string|nil   The mode to open the file in, defaults to read only. Only user location files can be written
+---@return file             A lua io file
+function FileSystem.Open( filename ) end
+
+return FileSystem

--- a/data/modules/AutoSave/AutoSave.lua
+++ b/data/modules/AutoSave/AutoSave.lua
@@ -6,7 +6,7 @@ local FileSystem = require 'FileSystem'
 local max_autosaves = 9
 
 local function PickNextAutosave()
-	local ok, files, _ = pcall(FileSystem.ReadDirectory, 'USER', 'savefiles')
+	local ok, files, _ = pcall(FileSystem.ReadDirectory, 'user://savefiles')
 	if not ok then
 		print('Error picking auto-save')
 		return '_autosave1'

--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -130,7 +130,8 @@ local function displaySave(f)
 end
 
 local function showSaveFiles()
-	local ok, files, _ = pcall(FileSystem.ReadDirectory, "USER","savefiles")
+	-- TODO: This is reading the files of disc every frame, think about refactoring to not do this.
+	local ok, files, _ = pcall(FileSystem.ReadDirectory, "user://savefiles")
 	if not ok then
 		print('Error: ' .. files)
 		saveFileCache = {}

--- a/src/enum_table.cpp
+++ b/src/enum_table.cpp
@@ -245,12 +245,6 @@ const struct EnumItem ENUM_DetailLevel[] = {
 	{ 0, 0 },
 };
 
-const struct EnumItem ENUM_FileSystemRoot[] = {
-	{ "USER", int(LuaFileSystem::ROOT_USER) },
-	{ "DATA", int(LuaFileSystem::ROOT_DATA) },
-	{ 0, 0 },
-};
-
 const struct EnumItem ENUM_PiGuiFaceFlags[] = {
 	{ "RAND", int(PiGui::Face::RAND) },
 	{ "MALE", int(PiGui::Face::MALE) },
@@ -333,7 +327,6 @@ const struct EnumTable ENUM_TABLES[] = {
 	{ "BodyType", ENUM_BodyType },
 	{ "BodySuperType", ENUM_BodySuperType },
 	{ "DetailLevel", ENUM_DetailLevel },
-	{ "FileSystemRoot", ENUM_FileSystemRoot },
 	{ "PiGuiFaceFlags", ENUM_PiGuiFaceFlags },
 	{ "ModelDebugFlags", ENUM_ModelDebugFlags },
 	{ "CruiseDirection", ENUM_CruiseDirection },
@@ -364,7 +357,6 @@ const struct EnumTable ENUM_TABLES_PUBLIC[] = {
 	{ "BodyType", ENUM_BodyType },
 	{ "BodySuperType", ENUM_BodySuperType },
 	{ "DetailLevel", ENUM_DetailLevel },
-	{ "FileSystemRoot", ENUM_FileSystemRoot },
 	{ "PiGuiFaceFlags", ENUM_PiGuiFaceFlags },
 	{ "ModelDebugFlags", ENUM_ModelDebugFlags },
 	{ "CruiseDirection", ENUM_CruiseDirection },

--- a/src/enum_table.h
+++ b/src/enum_table.h
@@ -35,7 +35,6 @@ extern const struct EnumItem ENUM_PolitGovType[];
 extern const struct EnumItem ENUM_BodyType[];
 extern const struct EnumItem ENUM_BodySuperType[];
 extern const struct EnumItem ENUM_DetailLevel[];
-extern const struct EnumItem ENUM_FileSystemRoot[];
 extern const struct EnumItem ENUM_PiGuiFaceFlags[];
 extern const struct EnumItem ENUM_ModelDebugFlags[];
 extern const struct EnumItem ENUM_CruiseDirection[];

--- a/src/lua/LuaFileSystem.cpp
+++ b/src/lua/LuaFileSystem.cpp
@@ -7,15 +7,90 @@
 #include "LuaObject.h"
 #include "Pi.h"
 
-/*
- * Interface: FileSystem
- *
- * A global table that provides access to the filesystem.
- *
- * This interface is protected. It can only be used by scripts in Pioneer's
- * data directory. Mods and scripts in the user directory that try to use it
- * will get a Lua error.
- */
+#include "core/StringUtils.h"
+
+struct SplitURI
+{
+	std::string_view full_path;
+	std::string_view scheme;
+	std::string_view rel_path;
+};
+
+SplitURI ParseURIArg(lua_State* l, int numArg)
+{
+	SplitURI res;
+	res.full_path = LuaPull<std::string_view>(l, numArg);
+	size_t sep_pos = res.full_path.find("://");
+	if (sep_pos != std::string_view::npos)
+	{
+		res.scheme = res.full_path.substr(0, sep_pos);
+		sep_pos += 3;
+		res.rel_path = res.full_path.substr(sep_pos);
+	}
+	return res;
+}
+
+struct FileSource
+{
+	FileSystem::FileSource* source;
+	bool					is_read_write;
+};
+
+FileSource DetermineFileSource(std::string_view scheme)
+{
+	FileSource res;
+	if (compare_ci(scheme, "user"))
+	{
+		res.source = &FileSystem::userFiles;
+		res.is_read_write = true;
+	} else if (compare_ci(scheme, "data"))
+	{
+		res.source = &FileSystem::gameDataFiles;
+		res.is_read_write = false;
+	} else
+	{
+		res.source = nullptr;
+		res.is_read_write = false;
+	}
+	return res;
+}
+
+static lua_CFunction l_original_io_open = nullptr;
+
+void LuaFileSystem::register_raw_io_open_function(lua_CFunction open)
+{
+	l_original_io_open = open;
+}
+
+int LuaFileSystem::l_patched_io_open(lua_State* L)
+{
+	SplitURI split_uri = ParseURIArg(L, 1);
+	const FileSource fs = DetermineFileSource(split_uri.scheme);
+	if (!fs.source)
+	{
+		return luaL_error(L, "Path '%s' does not contain a valid scheme, must be user:// or data://", split_uri.full_path.data());
+	}
+
+	std::string_view mode_str = LuaPull<std::string_view>(L, 2, "r");
+	if (mode_str.find_first_of("aw+") != std::string_view::npos && !fs.is_read_write) {
+		return luaL_error(L, "File '%s' is read-only.", split_uri.full_path.data());
+	}
+
+	try
+	{
+		::std::string abs_path = fs.source->Lookup(std::string(split_uri.rel_path)).GetAbsolutePath();
+		LuaPush(L, abs_path);
+		lua_replace(L, 1);
+
+		const int rv = l_original_io_open(L);
+
+		return rv;
+	}
+	catch (const std::invalid_argument&)
+	{
+		return luaL_error(L, "'%s' is not a valid file in its scheme root' - Is the file location within the root?", split_uri.full_path.data());
+	}
+}
 
 static void push_date_time(lua_State *l, const Time::DateTime &dt)
 {
@@ -36,13 +111,12 @@ static void push_date_time(lua_State *l, const Time::DateTime &dt)
 /*
  * Function: ReadDirectory
  *
- * > local files, dirs = FileSystem.ReadDirectory(root, path)
+ * > local files, dirs = FileSystem.ReadDirectory(path)
  *
  * Return a list of files and dirs in the specified directory.
  *
  * Parameters:
  *
- *   root - a <FileSystemRoot> constant for the root of the dir to read from
  *   path - optional. a directory under the root
  *
  * Returns:
@@ -60,61 +134,46 @@ static void push_date_time(lua_State *l, const Time::DateTime &dt)
  */
 static int l_filesystem_read_dir(lua_State *l)
 {
-	LuaFileSystem::Root root = static_cast<LuaFileSystem::Root>(LuaConstants::GetConstantFromArg(l, "FileSystemRoot", 1));
-	std::string path;
-	if (lua_gettop(l) > 1)
-		path = luaL_checkstring(l, 2);
-
-	FileSystem::FileSource *fs = nullptr;
-	switch (root) {
-	case LuaFileSystem::ROOT_USER:
-		fs = &FileSystem::userFiles;
-		break;
-
-	case LuaFileSystem::ROOT_DATA:
-		fs = &FileSystem::gameDataFiles;
-		break;
-
-	default:
-		assert(0); // can't happen
-		return 0;
+	SplitURI split_uri = ParseURIArg(l, 1);
+	const FileSource fs = DetermineFileSource(split_uri.scheme);
+	if (!fs.source)
+	{
+		return luaL_error(l, "Path '%s' does not contain a valid scheme, must be user:// or data://", split_uri.full_path.data());
 	}
 
-	assert(fs);
+	// shame these methods can't take a string_view.
+	std::string rel_path = std::string(split_uri.rel_path);
 
 	{
 		try {
-			const FileSystem::FileInfo &info = fs->Lookup(path);
+			FileSystem::FileInfo info = fs.source->Lookup(rel_path);
 			if (!info.IsDir()) {
-				luaL_error(l, "'%s' is not a directory", path.c_str());
-				return 0;
+				return luaL_error(l, "'%s' is not a directory", split_uri.full_path.data());
 			}
 		} catch (const std::invalid_argument &) {
-			luaL_error(l, "'%s' is not a valid path", path.c_str());
-			return 0;
+			return luaL_error(l, "'%s' is not a valid path", split_uri.full_path.data());
 		}
 	}
-
-	FileSystem::FileEnumerator files(*fs, FileSystem::FileEnumerator::IncludeDirs);
-	files.AddSearchRoot(path);
 
 	lua_newtable(l);
 	int filesTable = lua_gettop(l);
 	lua_newtable(l);
 	int dirsTable = lua_gettop(l);
 
-	for (; !files.Finished(); files.Next()) {
-		const FileSystem::FileInfo &info = files.Current();
+	int dirs_len = 0;
+	int files_len = 0;
 
+	for (const auto &info : fs.source->Enumerate(rel_path, FileSystem::FileEnumerator::IncludeDirs))
+	{
 		lua_newtable(l);
 		pi_lua_settable(l, "name", info.GetName().c_str());
 		push_date_time(l, info.GetModificationTime());
 		lua_setfield(l, -2, "mtime");
 
 		if (info.IsDir())
-			lua_rawseti(l, dirsTable, lua_rawlen(l, dirsTable) + 1);
+			lua_rawseti(l, dirsTable, ++dirs_len);
 		else
-			lua_rawseti(l, filesTable, lua_rawlen(l, filesTable) + 1);
+			lua_rawseti(l, filesTable, ++files_len);
 	}
 
 	return 2;
@@ -146,9 +205,58 @@ static int l_filesystem_join_path(lua_State *l)
 		lua_pushlstring(l, path.c_str(), path.size());
 		return 1;
 	} catch (const std::invalid_argument &) {
-		luaL_error(l, "result is not a valid path");
-		return 0;
+		return luaL_error(l, "result is not a valid path");
 	}
+}
+
+
+/*
+ * Function: MakeDirectory
+ *
+ * > local success = FileSystem.MakeDirectory( dir_name )
+ *
+ * Creating the given directory if it's missing, returning a boolean
+ * indicating success
+ *
+ * Availability:
+ *
+ *   Oct 2023
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_filesystem_make_directory(lua_State *l)
+{
+	SplitURI split_uri = ParseURIArg(l, 1);
+	const FileSource fs = DetermineFileSource(split_uri.scheme);
+	if (!fs.source)
+	{
+		return luaL_error(l, "Path '%s' does not contain a valid scheme, must be user:// or data://", split_uri.full_path.data());
+	}
+
+	if (!fs.is_read_write)
+	{
+		return luaL_error(l, "'%s' does not support file operations that modify it, only things in the user folder do", split_uri.full_path.data());
+	}
+
+	try {
+
+		FileSystem::FileSourceFS& wfs = *static_cast<FileSystem::FileSourceFS*>(fs.source);
+
+		// shame these methods can't take a string_view.
+		std::string rel_path = std::string(split_uri.rel_path);
+		// At the moment, anything with a filesourceFS is also writeable, so the write permission test
+		// above also validates this...
+		wfs.MakeDirectory(rel_path);
+
+		FileSystem::FileInfo f = wfs.Lookup(rel_path);
+
+		lua_pushboolean(l, f.IsDir());
+	} catch (const std::invalid_argument&) {
+		return luaL_error(l, "unable to create directory '%s' the argument is invalid", split_uri.full_path.data());
+	}
+	return 1;
 }
 
 void LuaFileSystem::Register()
@@ -160,6 +268,8 @@ void LuaFileSystem::Register()
 	static const luaL_Reg l_methods[] = {
 		{ "ReadDirectory", l_filesystem_read_dir },
 		{ "JoinPath", l_filesystem_join_path },
+		{ "MakeDirectory", l_filesystem_make_directory },
+		{ "Open", l_patched_io_open },
 		{ 0, 0 }
 	};
 

--- a/src/lua/LuaFileSystem.h
+++ b/src/lua/LuaFileSystem.h
@@ -4,13 +4,13 @@
 #ifndef _LUAFILESYSTEM_H
 #define _LUAFILESYSTEM_H
 
+#include "lua/Lua.h"
+
 namespace LuaFileSystem {
 	void Register();
 
-	enum Root { // <enum scope='LuaFileSystem' name=FileSystemRoot prefix=ROOT_ public>
-		ROOT_USER,
-		ROOT_DATA
-	};
+	void register_raw_io_open_function(lua_CFunction open);
+	int l_patched_io_open(lua_State* L);
 } // namespace LuaFileSystem
 
 #endif


### PR DESCRIPTION
I'd like to be able to use lua standard `io` functionality as it's familiar to people who know lua and also easy to find examples and documentation on - and we don't have to build our own version.

However, this needs to be carefully sandboxed so we don't allow scripts and mods to run wild on a users machine.

So this will look to add the `io` module but redact and modify it as appropriate to keep it safe.

Keeping it safe means only allowing access to the user and data folders and the data folder can only have read only access.

Remaining todo list (at the time of writing):
- Unify and standardize the filenames across the API to accept a uri-style schema so you prefix a path with either `user://` or `data://` to indicate where you want to work.
- Do all FileSystem implementation in C++ rather than the additive shim I got to in lua


