### PR TITLE
Fix for "Assertion failed!" in the "Ship Repairs" window

### DIFF
--- a/data/pigui/modules/station-view/06-shipRepairs.lua
+++ b/data/pigui/modules/station-view/06-shipRepairs.lua
@@ -208,7 +208,7 @@ local function drawShipRepair()
 				else
 					ui.text(getRepairMessage(damageToRepair, repair_cost))
 					ui.pushItemWidth(widgetSizes.gaugeWidth)
-					damageToRepair = ui.sliderInt("", damageToRepair, 1, damage, "%d%%")
+					damageToRepair = ui.sliderInt("##damageToRepair", damageToRepair, 1, damage, "%d%%")
 					repair_cost = getRepairCost(damageToRepair, shipDef)
 
 					if  ui.button(l.PAY, widgetSizes.buttonSize) then


### PR DESCRIPTION

![изображение](https://github.com/pioneerspacesim/pioneer/assets/69468517/7f6ff3ef-f340-45b3-9d09-0dfb9e09bc63)

Fix for `Assertion failed!` error when trying to open repair window, when hull damage is less than 99.9 percent, because `damageToRepair` slider had an empty ID.

