### PR TITLE
Disable scrolling for tab-view and character info

### DIFF
--- a/data/pigui/libs/face.lua
+++ b/data/pigui/libs/face.lua
@@ -14,7 +14,7 @@ local colors = ui.theme.colors
 local icons = ui.theme.icons
 local orbiteer = ui.fonts.orbiteer
 local noSavedSettings = ui.WindowFlags {"NoSavedSettings"}
-local charInfoFlags = ui.WindowFlags {"AlwaysUseWindowPadding", "NoScrollbar", "NoSavedSettings"}
+local charInfoFlags = ui.WindowFlags {"AlwaysUseWindowPadding", "NoScrollbar", "NoSavedSettings", "NoScrollWithMouse"}
 
 local ensureCharacter = function (character)
 	if not (character and (type(character)=='table') and getmetatable(character) and (getmetatable(character).class == 'Character'))

--- a/data/pigui/views/tab-view.lua
+++ b/data/pigui/views/tab-view.lua
@@ -84,7 +84,7 @@ function PiGuiTabView:SwitchTo(id)
 	print("View not found:", id)
 end
 
-local staticButtonFlags = ui.WindowFlags {"NoResize", "NoTitleBar", "NoMove", "NoFocusOnAppearing", "NoScrollbar"}
+local staticButtonFlags = ui.WindowFlags {"NoResize", "NoTitleBar", "NoMove", "NoFocusOnAppearing", "NoScrollbar", "NoScrollWithMouse"}
 local vCenter = Vector2(0.5, 0.5)
 local mainWindowFlags = ui.WindowFlags {"NoResize", "NoTitleBar"}
 


### PR DESCRIPTION
Added "NoScrollWithMouse" flag for tab-view (personal info and comms upper left corner buttons) and character info (char name, occupation and char's face) so now they can't be scrolled with mouse.
**Edit**: disables this behaviour:

https://github.com/pioneerspacesim/pioneer/assets/69468517/3a678c0b-cdfc-4055-b348-c890b8a61372

