### PR TITLE
Fixes and changes for functions in LuaBody/Player/Ship

### DIFF
--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -668,6 +668,40 @@ function Ship:OnScoopCargo(cargoType)
 	return success
 end
 
+
+--
+-- Method: GetGPS
+--
+-- Get altitude, speed, and position of a ship
+--
+-- > alt, vspd, lat, long = ship:GetGPS()
+--
+-- Returns:
+--
+--   alt - altitude
+--
+--   vspd - vertical speed
+--
+--   lat - latitude
+--
+--   lon - longitude
+--
+-- Availability:
+--
+--   November, 2023
+--
+-- Status:
+--
+--   experimental
+--
+function Ship:GetGPS()
+   local lat, lon, altitude = self:GetGroundPosition()
+   local vspd = self:GetVelocityRelTo(self.frameBody):dot(self:GetPositionRelTo(self.frameBody):normalized())
+   lat = math.rad2deg(lat)
+   lon = math.rad2deg(lon)
+   return altitude, vspd, lat, lon
+end
+
 --
 -- Method: Enroll
 --

--- a/data/meta/CoreObject/Body.meta.lua
+++ b/data/meta/CoreObject/Body.meta.lua
@@ -81,11 +81,12 @@ function Body:DistanceTo(otherBody) end
 
 --- Get the body's position relative to its parent frame.
 ---
---- If the parent is a TerrainBody, altitude will be the height above terrain in meters.
+--- If the parent is a TerrainBody, altitude will be the height above terrain or sea level in meters.
+---@param boolean? terrainRelative
 ---@return number latitude the latitude of the body in radians
 ---@return number longitude the longitude of the body in radians
----@return number? altitude altitude above the ground in meters
-function Body:GetGroundPosition() end
+---@return number? altitude altitude above the ground or sea level in meters
+function Body:GetGroundPosition(terrainRelative) end
 
 --- Find the nearest object of a <Constants.PhysicsObjectType> type
 ---@param type PhysicsObjectType
@@ -104,11 +105,12 @@ function Body:GetPositionRelTo(other) end
 
 --- Get the body's altitude relative to another body.
 ---
---- Returns height above terrain if the other body is a TerrainBody or
+--- Returns height above terrain or sea level if the other body is a TerrainBody or
 --- distance between bodies otherwise.
 ---@param other Body
+---@param boolean? terrainRelative
 ---@return number altitude
-function Body:GetAltitudeRelTo(other) end
+function Body:GetAltitudeRelTo(other, terrainRelative) end
 
 ---@return number
 function Body:GetPhysicalRadius() end

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -259,6 +259,36 @@ vector3d Body::GetVelocityRelTo(const Body *relTo) const
 	return GetVelocityRelTo(relTo->m_frame) - relTo->GetVelocityRelTo(relTo->m_frame);
 }
 
+double Body::GetAltitudeRelTo(const Body* relTo, AltitudeType altType)
+{
+	vector3d pos = GetPositionRelTo(relTo);
+	double center_dist = pos.Length();
+	if (relTo && relTo->IsType(ObjectType::TERRAINBODY)) {
+		const TerrainBody* terrain = static_cast<const TerrainBody*>(relTo);
+		vector3d surface_pos = pos.Normalized();
+		double radius;
+		if (altType != AltitudeType::DEFAULT)
+		{
+			radius = altType == AltitudeType::SEA_LEVEL ? terrain->GetSystemBody()->GetRadius() :
+				terrain->GetTerrainHeight(surface_pos);
+		}
+		else
+		{
+			radius = terrain->GetSystemBody()->GetRadius();
+			if (center_dist <= 3.0 * terrain->GetMaxFeatureRadius()) {
+				radius = terrain->GetTerrainHeight(surface_pos);
+			}
+		}
+		double altitude = center_dist - radius;
+		if (altitude < 0)
+			altitude = 0;
+		return altitude;
+	}
+	else {
+		return center_dist;
+	}
+}
+
 void Body::OrientOnSurface(double radius, double latitude, double longitude)
 {
 	vector3d up = vector3d(cos(latitude) * cos(longitude), sin(latitude) * cos(longitude), sin(longitude));

--- a/src/Body.h
+++ b/src/Body.h
@@ -43,6 +43,13 @@ enum class ObjectType { // <enum name=PhysicsObjectType scope='ObjectType' publi
 	HYPERSPACECLOUD // <enum skip>
 };
 
+enum class AltitudeType { // <enum name=AltitudeType scope='AltitudeType' public>
+	//SEA_LEVEL if distant, ABOVE_TERRAIN otherwise
+	DEFAULT,
+	SEA_LEVEL,
+	ABOVE_TERRAIN
+};
+
 #define OBJDEF(__thisClass, __parentClass, __TYPE)                                  \
 	static constexpr ObjectType StaticType() { return ObjectType::__TYPE; }         \
 	static constexpr ObjectType SuperType() { return __parentClass::StaticType(); } \
@@ -175,6 +182,7 @@ public:
 	vector3d GetInterpPositionRelTo(FrameId relToId) const;
 	vector3d GetInterpPositionRelTo(const Body *relTo) const;
 	matrix3x3d GetInterpOrientRelTo(FrameId relToId) const;
+	double GetAltitudeRelTo(const Body* relTo, AltitudeType altType = AltitudeType::DEFAULT);
 
 	// should set m_interpolatedTransform to the smoothly interpolated value
 	// (interpolated by 0 <= alpha <=1) between the previous and current physics tick

--- a/src/enum_table.cpp
+++ b/src/enum_table.cpp
@@ -35,6 +35,13 @@ const struct EnumItem ENUM_PhysicsObjectType[] = {
 	{ 0, 0 },
 };
 
+const struct EnumItem ENUM_AltitudeType[] = {
+	{ "DEFAULT", int(AltitudeType::DEFAULT) },
+	{ "SEA_LEVEL", int(AltitudeType::SEA_LEVEL) },
+	{ "ABOVE_TERRAIN", int(AltitudeType::ABOVE_TERRAIN) },
+	{ 0, 0 },
+};
+
 const struct EnumItem ENUM_ShipAIError[] = {
 	{ "NONE", int(Ship::AIERROR_NONE) },
 	{ "GRAV_TOO_HIGH", int(Ship::AIERROR_GRAV_TOO_HIGH) },
@@ -308,6 +315,7 @@ const struct EnumItem ENUM_ShipControllerFlightControlState[] = {
 
 const struct EnumTable ENUM_TABLES[] = {
 	{ "PhysicsObjectType", ENUM_PhysicsObjectType },
+	{ "AltitudeType", ENUM_AltitudeType },
 	{ "ShipAIError", ENUM_ShipAIError },
 	{ "ShipFlightState", ENUM_ShipFlightState },
 	{ "ShipJumpStatus", ENUM_ShipJumpStatus },
@@ -338,6 +346,7 @@ const struct EnumTable ENUM_TABLES[] = {
 
 const struct EnumTable ENUM_TABLES_PUBLIC[] = {
 	{ "PhysicsObjectType", ENUM_PhysicsObjectType },
+	{ "AltitudeType", ENUM_AltitudeType },
 	{ "ShipAIError", ENUM_ShipAIError },
 	{ "ShipFlightState", ENUM_ShipFlightState },
 	{ "ShipJumpStatus", ENUM_ShipJumpStatus },

--- a/src/enum_table.h
+++ b/src/enum_table.h
@@ -17,6 +17,7 @@ struct EnumTable {
 };
 
 extern const struct EnumItem ENUM_PhysicsObjectType[];
+extern const struct EnumItem ENUM_AltitudeType[];
 extern const struct EnumItem ENUM_ShipAIError[];
 extern const struct EnumItem ENUM_ShipFlightState[];
 extern const struct EnumItem ENUM_ShipJumpStatus[];

--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -47,7 +47,6 @@ static int l_player_is_player(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_nav_target(lua_State *l)
 {
 	Player *p = LuaObject<Player>::CheckFromLua(1);
@@ -74,7 +73,6 @@ static int l_get_nav_target(lua_State *l)
  *
  *   stable
  */
-
 static int l_set_nav_target(lua_State *l)
 {
 	Player *p = LuaObject<Player>::CheckFromLua(1);
@@ -147,7 +145,6 @@ static int l_change_cruise_speed(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_combat_target(lua_State *l)
 {
 	Player *p = LuaObject<Player>::CheckFromLua(1);
@@ -174,7 +171,6 @@ static int l_get_combat_target(lua_State *l)
  *
  *   stable
  */
-
 static int l_set_combat_target(lua_State *l)
 {
 	Player *p = LuaObject<Player>::CheckFromLua(1);
@@ -202,7 +198,6 @@ static int l_set_combat_target(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_hyperspace_target(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -234,7 +229,6 @@ static int l_get_hyperspace_target(lua_State *l)
  *
  *   stable
  */
-
 static int l_set_hyperspace_target(lua_State *l)
 {
 	LuaObject<Player>::CheckFromLua(1);
@@ -280,7 +274,6 @@ static int l_get_mouse_direction(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_is_mouse_active(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -303,7 +296,6 @@ static int l_get_is_mouse_active(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_max_delta_v(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -327,7 +319,6 @@ static int l_get_max_delta_v(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_current_delta_v(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -350,7 +341,6 @@ static int l_get_current_delta_v(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_remaining_delta_v(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -416,7 +406,6 @@ static int l_get_acceleration(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_distance_to_zero_v(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -443,7 +432,6 @@ static int l_get_distance_to_zero_v(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_maneuver_time(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -466,7 +454,6 @@ static int l_get_maneuver_time(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_maneuver_velocity(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -494,7 +481,6 @@ static int l_get_maneuver_velocity(lua_State *l)
  *
  *   stable
  */
-
 static int l_get_heading_pitch_roll(lua_State *l)
 {
 	//  Player *player = LuaObject<Player>::CheckFromLua(1);
@@ -573,65 +559,6 @@ static int l_toggle_rotation_damping(lua_State *l)
 {
 	Player *player = LuaObject<Player>::CheckFromLua(1);
 	player->GetPlayerController()->ToggleRotationDamping();
-	return 0;
-}
-
-/*
- * Function: GetGPS()
- *
- * Get altitude, speed, and position of player's ship
- *
- * Example:
- *
- * > alt, vspd, lat, long = player:GetGPS()
- *
- * Returns:
- *
- *   alt - altitude
- *
- *   vspd - vertical speed
- *
- *   latitude - latitude
- *
- *   longitude - longitude
- *
- */
-static int l_get_gps(lua_State *l)
-{
-	Player *player = LuaObject<Player>::CheckFromLua(1);
-	vector3d pos = Pi::player->GetPosition();
-	double center_dist = pos.Length();
-	FrameId playerFrameId = player->GetFrame();
-	Frame *playerFrame = Frame::GetFrame(playerFrameId);
-	if (playerFrameId.valid()) {
-		Body *astro = Frame::GetFrame(playerFrameId)->GetBody();
-		if (astro && astro->IsType(ObjectType::TERRAINBODY)) {
-			TerrainBody *terrain = static_cast<TerrainBody *>(astro);
-			if (!playerFrame->IsRotFrame())
-				playerFrame = Frame::GetFrame(playerFrame->GetRotFrame());
-			vector3d surface_pos = pos.Normalized();
-			double radius = terrain->GetSystemBody()->GetRadius();
-			if (center_dist <= 3.0 * terrain->GetMaxFeatureRadius()) {
-				radius = terrain->GetTerrainHeight(surface_pos);
-			}
-			double altitude = center_dist - radius;
-			vector3d velocity = player->GetVelocity();
-			double vspeed = velocity.Dot(surface_pos);
-			if (fabs(vspeed) < 0.05) vspeed = 0.0; // Avoid alternating between positive/negative zero
-
-			//			RefreshHeadingPitch();
-
-			if (altitude < 0) altitude = 0;
-			LuaPush(l, altitude);
-			LuaPush(l, vspeed);
-			const float lat = RAD2DEG(asin(surface_pos.y));
-			const float lon = RAD2DEG(atan2(surface_pos.x, surface_pos.z));
-			LuaPush(l, lat);
-			LuaPush(l, lon);
-			return 4;
-			//				}
-		}
-	}
 	return 0;
 }
 
@@ -883,7 +810,6 @@ void LuaObject<Player>::RegisterClass()
 		{ "GetMouseDirection", l_get_mouse_direction },
 		{ "GetRotationDamping", l_get_rotation_damping },
 		{ "SetRotationDamping", l_set_rotation_damping },
-		{ "GetGPS", l_get_gps },
 		{ "ToggleRotationDamping", l_toggle_rotation_damping },
 		{ "GetAlertState", l_get_alert_state },
 		{ "GetLowThrustPower", l_get_low_thrust_power },

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -171,7 +171,6 @@ static int l_ship_get_ship_class(lua_State *l)
  *
  *  experimental
  */
-
 static int l_ship_set_hull_percent(lua_State *l)
 {
 	LUA_DEBUG_START(l);
@@ -262,7 +261,6 @@ static int l_ship_set_fuel_percent(lua_State *l)
  *
  * 	experimental
  */
-
 static int l_ship_explode(lua_State *l)
 {
 	LUA_DEBUG_START(l);


### PR DESCRIPTION
**Update**:
Rewrite of `GetAltitudeRelTo`:
1. This function is moved to body class to support this functionality in C++ code;
2. This function is used in the LUA version of `GetAltitudeRelTo`, `GetGroundPosition` and `GetGPS` for consistency in calculating altitudes;
3. This function supports the choice of which height to calculate (sea-level, above-ground).

Other change:
`GetGPS` is moved to `LuaShip.cpp` to support this function for other ships, not only the player.

Fixes for this issues:

1. `GetAltitudeRelTo` using player pos no matter what first argument is passed;
2. `GetGroundPosition` returns nil when not in the rotating frame of ref;
3. `GetGPS` sometimes return different height than `GetAltitudeRelTo`;
4. Access violation when trying to access `frameBody`, `frameRotation` and call `GetGroundPosition` when body doesn't have frame of ref (ex. when ship is hyperspacing).
**Update2**:
`static bool push_body_to_lua(Body *body)`: 
1. `dynamic_cast` is changed to `static_cast`;
2. case `ModelBody` and `CargoBody` had wrong template type (`Body` and `Star`).
P.S.: Unless, there's some good reason for using templates, it can actually be changed to just `LuaObject<Body>::PushToLua(body)`.
(I checked, haven't seen any oddities).

**Update3**:
Removed space at the start of `l_body_get_altitude_rel_to`. A lot of comments didn't show up for functions, because they had a space between function name. Deleted spaces, so comments will show up when hovering function name.

**Update4**:
1. `GetGPS` is moved to `Ship.lua` to support this function for other ships, not only the player. Implementing this function in C++ is considered unnecessary because of slightly different parameter interface and because of this can be simplified a lot;
2. `GetGroundPosition` also supports the choice of which altitude to calculate (sea level or above terrain).

**Old**:
Fixes for this issues:
1. GetAltitudeRelTo using player pos no matter what first argument is passed;
4. GetGroundPosition returns nil when not in the rotating frame of ref;
5. Access violation for all three functions when body doesn't have frame of ref (ex. when ship is hyperspacing).

Need clarification on this:
1. Is this intentional behavior, that GetAltitudeRelTo and GetGroundPosition returns slightly different values for altitude?
2. Is the second change (deleteing `if (!f->IsRotFrame())`) should be changed back? I deleted that, because with this, when, for example you're on the Moon, altitude will already be `nil` at ~6000m.
**Edit**: to clarify second point, altitude will be different when `IsRotFrame` will be false (basically, when space particles (lines) will start to appear or when not in rotating frame).