### PR TITLE
Fix main menu music not starting to play after exiting back to main menu

### DIFF
--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -128,9 +128,10 @@ local function showMainMenu()
 	if not hasMusicList then
 		hasMusicList = true
 		MusicPlayer.rebuildSongList()
-		MusicPlayer.playRandomSongFromCategory("menu", true)
 	end
-
+	
+	MusicPlayer.playRandomSongFromCategory("menu", true)
+	
 	local showContinue = canContinue()
 	local buttons = 4
 


### PR DESCRIPTION
Fix for when menu music not started to play after exiting back to main menu.

**Update**: moved `MusicPlayer.playRandomSongFromCategory("menu", true)` from `if else` check.