### PR TITLE
Pause menu sets last time acceleration after closing

### DIFF
--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -2,6 +2,7 @@
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local Engine = require 'Engine'
+local Event = require 'Event'
 local Input = require 'Input'
 local Game = require 'Game'
 local Lang = require 'Lang'
@@ -680,12 +681,12 @@ ui.optionsWindow = ModalWindow.New("Options", function()
 			Engine.SetStarFieldStarSizeFactor(starFieldStarSizeFactor/100)
 			needBackgroundStarRefresh = false
 		end
-		if Game.player then
-			Game.SetTimeAcceleration("1x")
-			Input.EnableBindings();
-		end
 		if selectedJoystick then
 			Input.SaveJoystickConfig(selectedJoystick)
+		end
+		if Game.player then
+		    Game.SetTimeAcceleration("1x")
+		    Event.Queue("onPauseMenuClosed")
 		end
 	end)
 


### PR DESCRIPTION
The pause menu now sets the last time acceleration that was before it was opened. Its behavior will be the same as when setting up time acceleration without pressing `CTRL`.
Changed behaviour of `Close` button in `settings-window.lua`. Now it will not set time acceleration and not enable input bindings.
**Edit**:

https://github.com/pioneerspacesim/pioneer/assets/69468517/c89d445d-5624-4e12-8cb7-5e4e5421308b

**Update**: deleted bit about forcing time acceleration through `Ctrl+Click` `Close` button.
**Update2**: deleted `settingsMenuWasOpened`. It was not needed.