### PR TITLE
TradeShips hyperjump code change

### DIFF
--- a/data/modules/TradeShips/Debug.lua
+++ b/data/modules/TradeShips/Debug.lua
@@ -55,7 +55,7 @@ local statuses = {
 }
 
 debugView.registerTab('debug-trade-ships', function()
-	if not Core.ships and not Core.params then return end
+	if not Core.ships and not Core.params or not Game.system then return end
 	if not ui.beginTabItem("Tradeships") then return end
 
 	local function property(key, value)

--- a/data/modules/TradeShips/Events.lua
+++ b/data/modules/TradeShips/Events.lua
@@ -58,7 +58,6 @@ local onEnterSystem = function (ship)
 	elseif Core.ships[ship] ~= nil then
 		local trader = Core.ships[ship]
 		Core.log:add(ship, 'Entered '..Game.system.name..' from '..trader.from_path:GetStarSystem().name)
-
 		if trader.route then
 			ship:AIDockWith(trader.route.to)
 			Core.ships[ship]['starport'] = trader.route.to
@@ -99,23 +98,6 @@ local onLeaveSystem = function (ship)
 	end
 end
 Event.Register("onLeaveSystem", onLeaveSystem)
-
-local onFrameChanged = function (ship)
-	if not ship:isa("Ship") or Core.ships[ship] == nil then return end
-	local trader = Core.ships[ship]
-	Core.log:add(ship, "Entered frame " .. (ship.frameBody and ship.frameBody:GetLabel() or "unknown"))
-
-	if trader.status == 'outbound' then
-		-- the cloud inherits the ship velocity and vector
-		ship:CancelAI()
-		if Trader.getSystemAndJump(ship) ~= 'OK' then
-			ship:AIDockWith(trader.starport)
-			trader['status'] = 'inbound'
-			trader.ts_error = 'cnt_jump_frame'
-		end
-	end
-end
-Event.Register("onFrameChanged", onFrameChanged)
 
 local onShipDocked = function (ship, starport)
 	if Core.ships[ship] == nil then return end
@@ -159,11 +141,10 @@ Event.Register("onShipDocked", onShipDocked)
 
 local onShipUndocked = function (ship, starport)
 	if Core.ships[ship] == nil then return end
-
-	-- fly to the limit of the starport frame
-	ship:AIFlyTo(starport)
-
-	Core.ships[ship]['status'] = 'outbound'
+	local trader = Core.ships[ship]
+	ship:AIEnterLowOrbit(trader.starport:GetSystemBody().system:GetStars()[1].body)
+	Trader.assignTask(ship, Game.time + 10, 'hyperjumpAtDistance')
+	trader['status'] = 'outbound'
 end
 Event.Register("onShipUndocked", onShipUndocked)
 
@@ -171,15 +152,9 @@ local onAICompleted = function (ship, ai_error)
 	if Core.ships[ship] == nil then return end
 	local trader = Core.ships[ship]
 	if ai_error ~= 'NONE' then
-		Core.log:add(ship, 'AICompleted: Error: '..ai_error..' Status: '..trader.status) end
-
-	if trader.status == 'outbound' then
-		if Trader.getSystemAndJump(ship) ~= 'OK' then
-			ship:AIDockWith(trader.starport)
-			trader['status'] = 'inbound'
-			trader.ts_error = 'cnt_jump_aicomp'
-		end
-	elseif trader.status == 'orbit' then
+		Core.log:add(ship, 'AICompleted: Error: '..ai_error..' Status: '..trader.status)
+	end
+	if trader.status == 'orbit' then
 		if ai_error == 'NONE' then
 			trader.ts_error = "wait_6h"
 			Trader.assignTask(ship, Game.time + 21600, 'doRedock')
@@ -258,7 +233,7 @@ local onShipHit = function (ship, attacker)
 		elseif trader.starport and Engine.rand:Number(1) < trader.chance then
 			local distance = ship:DistanceTo(trader.starport)
 			if distance > Core.AU * (2 - trader.chance) then
-				if Trader.getSystemAndJump(ship) then
+				if Trader.getSystemAndJump(ship) == 'OK' then
 					return
 				else
 					trader['no_jump'] = true

--- a/data/modules/TradeShips/Flow.lua
+++ b/data/modules/TradeShips/Flow.lua
@@ -494,6 +494,47 @@ Flow.spawnInitialShips = function()
 	return ships_in_space
 end
 
+Flow.setPlayerAsTraderDocked = function()
+	local ship = Game.player
+	--if player is not a trader
+	if Core.ships[ship] then
+		print("Flow.setPlayerAsTraderDocked: player is already a trader")
+		return
+	end
+	--if player is currently docked
+	if ship.flightState ~= 'DOCKED' then
+		print("Flow.setPlayerAsTraderDocked: can't set player as docked trader when player is not currently docked")
+		return
+	end
+	local dockedStation = ship:GetDockedWith()
+	Core.ships[ship] = { ts_error = "OK", status = 'docked', starport = dockedStation, ship_name = Game.player.shipId }
+	Trader.assignTask(ship, Game.time + utils.deviation(Core.params.port_params[Core.ships[ship].starport].time * 3600, 0.8), 'doUndock')
+end
+
+Flow.setPlayerAsTraderInbound = function()
+	local ship = Game.player
+	--if player is not a trader
+	if Core.ships[ship] then
+		print("Flow.setPlayerAsTraderInbound: player is already a trader")
+		return
+	end
+	-- Space.PutShipOnRoute will teleport player to star's surface when player is docked. We don't want that
+	if ship.flightState ~= 'FLYING' then
+		print("Flow.setPlayerAsTraderInbound: can't set player as inbound trader when player is not currently flying")
+		return
+	end
+	-- if there's any station in the system
+	local nearestStation = ship:FindNearestTo("SPACESTATION")
+	if not nearestStation then
+		print("Flow.setPlayerAsTraderInbound: no nearby station is found to set player as inbound trader")
+		return
+	end
+	Core.ships[ship] = { ts_error = "OK", status = 'inbound', starport = nearestStation, ship_name = Game.player.shipId }
+	Space.PutShipIntoOrbit(ship, Game.system:GetStars()[1].body)
+	Space.PutShipOnRoute(ship, Core.ships[ship].starport, Engine.rand:Number(0.0, 0.999))-- don't generate at the destination
+	ship:AIDockWith(Core.ships[ship].starport)
+end
+
 Flow.run = function()
 	local ship_name = utils.chooseEqual(Core.params.ship_names)
 	local cloud = utils.chooseEqual(Core.params.hyper_routes[ship_name])

--- a/data/modules/TradeShips/Trader.lua
+++ b/data/modules/TradeShips/Trader.lua
@@ -200,10 +200,6 @@ Trader.getSystemAndJump = function (ship)
 	if Core.ships[ship].starport then
 		local body = Space.GetBody(Core.ships[ship].starport.path:GetSystemBody().parent.index)
 		local port = Core.ships[ship].starport
-		-- boost away from the starport before jumping if it is too close
-		if (ship:DistanceTo(port) < 20000) then
-			ship:AIEnterLowOrbit(body)
-		end
 		return jumpToSystem(ship, getSystem(ship))
 	end
 end
@@ -275,6 +271,19 @@ Trader.removeFuel = function (ship, count)
 	return removed
 end
 
+Trader.checkDistBetweenStarport = function (ship)
+	local trader = Core.ships[ship]
+	if not trader then return nil end
+	local distance
+	if trader.starport.type == "STARPORT_ORBITAL" then
+		distance = ship:DistanceTo(trader.starport)
+	else
+		local stationsParent = trader.starport:GetSystemBody().parent.body
+		distance = ship:GetAltitudeRelTo(stationsParent)
+	end
+	return distance >= trader.hyperjumpDist
+end
+
 -- TRADER DEFERRED TASKS
 --
 -- call the passed function in a specified time, checking whether we are still
@@ -292,6 +301,36 @@ local trader_task = {}
 -- made to serialize pending job execution
 -- the task function prototype should be:
 -- function(ship)
+
+trader_task.hyperjumpAtDistance = function(ship)
+	-- the player may have left the system
+	local trader = Core.ships[ship]
+	if not trader then return end
+	if trader.status == "outbound" and trader.ts_error ~= "HIT" then
+		-- if trader is not under attack and started to leave station
+		if trader.starport ~= nil then
+			-- if trader has not started to hyperjump
+			if trader.hyperjumpDist == nil then
+				trader.hyperjumpDist = Engine.rand:Integer(20000, 240000)
+			end
+			if Trader.checkDistBetweenStarport(ship) then
+				-- if distance is large enough attempt to hyperjump
+				local status = Trader.getSystemAndJump(ship)
+				if status ~= 'OK' then
+					ship:CancelAI()
+					ship:AIDockWith(trader.starport)
+					trader['status'] = 'inbound'
+					trader.ts_error = 'cnt_jump_aicomp'
+				end
+				trader.hyperjumpDist = nil
+			else
+				Trader.assignTask(ship, Game.time + 10, 'hyperjumpAtDistance')
+			end
+		end
+	else
+		trader.hyperjumpDist = nil
+	end
+end
 
 trader_task.doUndock = function(ship)
 	-- the player may have left the system or the ship may have already undocked


### PR DESCRIPTION
This PR is an attempt to fix cluttering hyperclouds around stations and rare illegal jumps almost at the planet's surface. Now `TradeShips` behaviour when undocking looks like this.
For orbital stations:
1. Undock;
2. Fly to limits of current orbital station;
3. `OnAICompleted` event fires, tell ship to fly to current system's star;
4. Assign task to check distance between current orbital station and ship, if distance is large enough, make the jump.

For ground stations;
1. Undock;
2. Tell ship to fly to current system's star;
3. Assign task to check altitude between current orbital station's parent and ship, if altitude is high enough, make the jump.

The distance and altitude will be selected from a random interval of 20,000 - 240,000 meters.
Demonstration:
1. Undocking and jumping from Cydonia

https://github.com/pioneerspacesim/pioneer/assets/69468517/bd73a4d7-0f1f-4607-bc64-b5e843707223


2. Undocking and jumping from Gates Starport
   

https://github.com/pioneerspacesim/pioneer/assets/69468517/eabefebd-fcd8-4e99-8a70-1ec8fba50b99

**Update**: rebase.
**Update2**: `addEquip` is removed from `setPlayerAsTraderDocked` and `setPlayerAsTraderInbound`.
Added check if player is currently docked (`setPlayerAsTraderDocked`) or there's nearest station (`setPlayerAsTraderInbound`).
If not, player will not become trader.
**Update3**: rebase.
