### PR TITLE
Space bodies deferred addition

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -68,6 +68,8 @@ Game::Game(const SystemPath &path, const double startDateTime, const char *shipT
 
 	m_space.reset(new Space(this, m_galaxy, path));
 
+	m_space->UpdateBodies();
+
 	Body *b = m_space->FindBodyForPath(&path);
 	assert(b);
 
@@ -525,6 +527,8 @@ void Game::SwitchToNormalSpace()
 	m_player->SetFrame(m_space->GetRootFrame());
 	m_space->AddBody(m_player.get());
 
+	m_space->UpdateBodies();
+
 	// place it
 	vector3d pos, vel;
 	m_space->GetHyperspaceExitParams(m_hyperspaceSource, m_hyperspaceDest, pos, vel);
@@ -936,6 +940,8 @@ void Game::SaveGame(const std::string &filename, Game *game)
 	if (!FileSystem::userFiles.MakeDirectory(Pi::SAVE_DIR_NAME)) {
 		throw CouldNotOpenFileException();
 	}
+
+	game->m_space->UpdateBodies();
 
 	Json rootNode;
 	game->ToJson(rootNode); // Encode the game data as JSON and give to the root value.

--- a/src/Space.h
+++ b/src/Space.h
@@ -105,6 +105,12 @@ public:
 	//it is not designed to be called in each game loop!
 	std::vector<BodyDist> BodiesInAngle(const Body *b, const vector3d &offset, const vector3d &dir, double cosOfMaxAngle) const;
 
+	// Don't call this unless you really have to
+	// A bit of a hack but required so we can add a player
+	// into space as we emerge from hyperspace
+	// and then find stuff.
+	void UpdateBodies();
+
 private:
 	void GenSectorCache(RefCountedPtr<Galaxy> galaxy, const SystemPath *here);
 	void UpdateStarSystemCache(const SystemPath *here);
@@ -112,7 +118,6 @@ private:
 	// make sure SystemBody* is in Pi::currentSystem
 	FrameId GetFrameWithSystemBody(const SystemBody *b) const;
 
-	void UpdateBodies();
 
 	void CollideFrame(FrameId fId);
 
@@ -128,10 +133,11 @@ private:
 	// all the bodies we know about
 	std::vector<Body *> m_bodies;
 
-	// bodies that were removed/killed this timestep and need pruning at the end
+	// bodies that were removed/killed/added this timestep and need pruning/adding at the end
 	enum class BodyAssignation {
 		KILL = 0,
-		REMOVE = 1
+		REMOVE = 1,
+		CREATE = 2
 	};
 
 	std::vector<std::pair<Body *, BodyAssignation>> m_assignedBodies;


### PR DESCRIPTION
Fix the undefined behaviour when addiing bodies during the update loops that iterate through them

The undefined behaviour comes because when we add an item to the vector, it could have to reallocate to grow the backing storage and therefore the end iterator becomes potentially invalid.

Defer adding bodies until the end of an Space update tick.

A few game related scenarios (emerging from hyperspace, saving a game and loading a game) require this update to be invoked too.

I've been playing with this locally for a while and have yet to find any new issues.
