### PR TITLE
Update for pause menu

### DIFF
--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -270,7 +270,6 @@ end)
 Event.Register("onPauseMenuOpen", function()
 	lastTimeAcceleration = Game.GetTimeAcceleration() ~= Game.GetRequestedTimeAcceleration() and Game.GetRequestedTimeAcceleration() or Game.GetTimeAcceleration()
 	Game.SetTimeAcceleration("paused")
-	Input.EnableBindings(false)
 end)
 
 Event.Register("onPauseMenuClosed", function()
@@ -297,14 +296,7 @@ ui.registerHandler('game', function(delta_t)
 
 		-- TODO: dispatch escape key to views and let them handle it
 		if currentView == "world" and ui.escapeKeyReleased(true) then
-			if not ui.optionsWindow.isOpen then
-				ui.optionsWindow:open()
-				Event.Queue("onPauseMenuOpen")
-			else
-				ui.optionsWindow:close()
-				Game.SetTimeAcceleration("1x")
-				Event.Queue("onPauseMenuClosed")
-			end
+			ui.optionsWindow:changeState()
 		end
 
 		callModules('modal')


### PR DESCRIPTION
**Changes**:

1. Queuing of events `onPauseMenuOpen`/`onPauseMenuClosed` is moved to `ui.optionsWindow:open()` and `ui.optionsWindow:close()` respectively. This was made to ensure queuing of this events no matter where this window was opened or closed;

2. Added `ui.optionsWindow:changeState()` method to group `ui.optionsWindow:open()` and `ui.optionsWindow:close()` into one;

3. Temporarily moved `Input.EnableBindings(false)` from `onPauseMenuOpen`, because when the game is paused, lua events are not processed. Because of this, game will still read input bindings if pause menu was opened, while time acceleration was `paused`. This fixes it.

**Bonus**:
Save button will be blocked if player is hyperspacing.

**Update**: formatting correction, removed two tabs on an empty line in `settings-window.lua`