### PR TITLE
Build with SSE4 / AVX, fix build artifact generation

### DIFF
--- a/.github/actions/upload-linux/action.yml
+++ b/.github/actions/upload-linux/action.yml
@@ -38,6 +38,8 @@ runs:
 
     - name: Build Release
       shell: bash
+      env:
+        BUILD_SLUG: ${{ inputs.build_slug }}
       run: ./scripts/package-release.sh
 
     - name: Upload Release Files

--- a/.github/actions/upload-linux/action.yml
+++ b/.github/actions/upload-linux/action.yml
@@ -1,0 +1,49 @@
+name: "Upload Linux Artifacts"
+description: "Manage generating and uploading release artifacts for linux builds"
+
+inputs:
+  artifact_name:
+    description: "Name of generated artifact"
+    required: true
+  build_slug:
+    description: "platform-arch-build-flags"
+    required: true
+  token:
+    description: "access token for uploading to releases"
+    default: ""
+  upload_release:
+    description: "should the binary be uploaded to a tagged release?"
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install
+      shell: bash
+      run: cmake --build ./build --target install
+
+    - name: Package Artifact
+      shell: bash
+      env:
+        BUILD_SLUG: ${{ inputs.build_slug }}
+      run: |
+        cd out/install/
+        tar -czf "pioneer-$BUILD_SLUG-$(date +%Y%m%d).tar.gz" "pioneer-$BUILD_SLUG"
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ format('out/install/pioneer-{0}-*.tar.gz', inputs.build_slug) }}
+
+    - name: Build Release
+      shell: bash
+      run: ./scripts/package-release.sh
+
+    - name: Upload Release Files
+      uses: softprops/action-gh-release@v1
+      if: ${{ github.event_name == 'release' && inputs.upload_release }}
+      with:
+        files: release/pioneer-linux-x64-*.tar.gz
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -111,24 +111,47 @@ jobs:
     - name: Run Tests
       run: ./build/unittest
 
-    - name: Build Release
+    - name: Generate Artifacts
+      uses: ./.github/actions/upload-linux
+      with:
+        artifact_name: Linux 64-bit
+        build_slug: linux-x64-release
+        token: ${{ secrets.GITHUB_TOKEN }}
+        upload_release: true
+
+  build-gcc-avx:
+    runs-on: ubuntu-20.04
+
+    steps:
+    # Checkout the repository as $GITHUB_WORKSPACE
+    - uses: actions/checkout@v3
+
+    - name: Install Dependencies
       run: |
-        cmake --build ./build --target install
-        ./scripts/package-release.sh
+        sudo apt-fast update
+        sudo apt-fast install -y ${{ env.packages }}
 
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: Linux-Artifacts
-        path: release/pioneer-linux-x64-release-*.tar.gz
+    - name: Setup CMake
+      run: |
+        cp scripts/CMakeBuildPresetsCI.json CMakeUserPresets.json
+        cmake --preset linux-x64-release-avx
 
-    - name: Upload Release Files
-      uses: softprops/action-gh-release@v1
-      if: ${{ github.event_name == 'release' }}
+    - name: Build GCC
+      run: cmake --build ./build --target all
+
+    - name: Build Pioneer Data
+      run: cmake --build ./build --target build-data
+
+    - name: Run Tests
+      run: ./build/unittest
+
+    - name: Generate Artifacts
+      uses: ./.github/actions/upload-linux
       with:
-        files: release/pioneer-linux-x64-release-*.tar.gz
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        artifact_name: Linux 64-bit (AVX2 enabled)
+        build_slug: linux-x64-release-avx
+        token: ${{ secrets.GITHUB_TOKEN }}
+        upload_release: true
 
   build-clang:
     runs-on: ubuntu-20.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,24 @@ if (APPLE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu")
 endif(APPLE)
 
+option(USE_SSE42 "Compile for SSE4.2 compatible microarchitectures (enables optimizations)" ON)
+
+if (USE_SSE42)
+	if (NOT MSVC)
+		add_compile_options("-msse4.2" "-mlzcnt" "-mpopcnt")
+	endif()
+endif (USE_SSE42)
+
+option(USE_AVX2 "Compile for AVX2 compatible microarchitectures (Haswell and newer)" OFF)
+
+if (USE_AVX2)
+	if (MSVC)
+		add_compile_options("/arch:AVX2")
+	else()
+		add_compile_options("-mavx2")
+	endif()
+endif(USE_AVX2)
+
 option(USE_LLD_LINKER "Use the LLVM lld linker instead of gcc's linker" OFF)
 if (CMAKE_COMPILER_IS_GNUCXX)
 	add_compile_options(

--- a/scripts/CMakeBuildPresetsCI.json
+++ b/scripts/CMakeBuildPresetsCI.json
@@ -8,7 +8,7 @@
 			"binaryDir": "${sourceDir}/build/",
 			"generator": "Unix Makefiles",
 			"cacheVariables": {
-				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/pioneer-${presetName}",
 				"PIONEER_INSTALL_INPLACE": "1",
 				"CMAKE_BUILD_TYPE": "RelWithDebInfo"
 			},
@@ -27,8 +27,47 @@
 			"binaryDir": "${sourceDir}/build/",
 			"generator": "Unix Makefiles",
 			"cacheVariables": {
-				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/pioneer-${presetName}",
 				"CMAKE_BUILD_TYPE": "RelWithDebInfo"
+			},
+			"vendor": {
+				"microsoft.com/VisualStudioSettings/CMake/1.0": {
+					"hostOS": [
+						"Linux"
+					]
+				}
+			}
+		},
+		{
+			"name": "linux-x64-release-avx",
+			"displayName": "Linux x64 Release",
+			"description": "in-place installation target; Opt=yes; Profiler=no",
+			"binaryDir": "${sourceDir}/build/",
+			"generator": "Unix Makefiles",
+			"cacheVariables": {
+				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/pioneer-${presetName}",
+				"PIONEER_INSTALL_INPLACE": "1",
+				"CMAKE_BUILD_TYPE": "RelWithDebInfo",
+				"USE_AVX2": true
+			},
+			"vendor": {
+				"microsoft.com/VisualStudioSettings/CMake/1.0": {
+					"hostOS": [
+						"Linux"
+					]
+				}
+			}
+		},
+		{
+			"name": "linux-x64-release-global-avx",
+			"displayName": "Linux x64 Release",
+			"description": "global installation target; Opt=yes; Profiler=no",
+			"binaryDir": "${sourceDir}/build/",
+			"generator": "Unix Makefiles",
+			"cacheVariables": {
+				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/pioneer-${presetName}",
+				"CMAKE_BUILD_TYPE": "RelWithDebInfo",
+				"USE_AVX2": true
 			},
 			"vendor": {
 				"microsoft.com/VisualStudioSettings/CMake/1.0": {

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -54,10 +54,7 @@ mkdir -p release/zip
 
 echo "Bundling output..."
 
-TAG_NAME=$(git describe HEAD)
-if [ -z "$TAG_NAME" ]; then
-	TAG_NAME=$(date +%Y%m%d)
-fi
+TAG_NAME=$(git describe --tags --exact-match HEAD || date +%Y%m%d)
 
 if [ "$BUILD_TYPE" == "mxe" ]; then
     zip -r "release/zip/pioneer-$TAG_NAME-mxe.zip" release/* -x *release/zip*

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -3,14 +3,15 @@ set -e
 
 # Package a build and prepare it for upload to Github.
 
-TAG_NAME=$(git describe HEAD)
-if [ -z "$TAG_NAME" ]; then
-	TAG_NAME=$(date +%Y%m%d)
+TAG_NAME=$(git describe --tags --exact-match HEAD || date +%Y%m%d)
+
+if [ -z "$BUILD_SLUG" ]; then
+	BUILD_SLUG=linux-x64-release
 fi
 
 mkdir release
 
-mv out/install/pioneer-linux-x64-release "release/pioneer-linux-x64-$TAG_NAME"
+mv out/install/pioneer-$BUILD_SLUG "release/pioneer-linux-x64-$TAG_NAME"
 cd release
 
 tar -czf "pioneer-linux-x64-$TAG_NAME.tar.gz" "pioneer-linux-x64-$TAG_NAME"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Package a build and prepare it for upload to Github.
 
@@ -9,7 +10,7 @@ fi
 
 mkdir release
 
-mv out/install/linux-x64-release "release/pioneer-linux-x64-$TAG_NAME"
+mv out/install/pioneer-linux-x64-release "release/pioneer-linux-x64-$TAG_NAME"
 cd release
 
 tar -czf "pioneer-linux-x64-$TAG_NAME.tar.gz" "pioneer-linux-x64-$TAG_NAME"


### PR DESCRIPTION
This PR does a wee refactor of our Linux build scripts to ensure we're correctly generating and uploading release artifacts. It moves the release generation steps into a reusable action file, which is important for the other half of the PR.

This PR enables SSE4.2 support by default for our Linux x64 build type. SSE4.2 has been available and supported in mainstream x86/64 processors for over a decade now, so it makes sense to formally require SSE >= 4.2 for our builds (and allow the compiler to perform automatic optimization and vectorization to take advantage of these instruction sets).

GCC's documentation doesn't specify whether I need to manually add all of the SSE version flags or if `-msse4.2` implies previous SSE versions. If someone is more familiar with the semantics GCC provides I'd appreciate your feedback / review. :smile:

This PR also adds an optional x64 build type with AVX2 enabled. AVX2 has 256-bit-wide SIMD instructions compared to SSE's 128-bit-wide SIMD, and has been supported in most mainstream Intel desktop and laptop CPUs since 2013 (2015 for AMD CPUs). The only reason this hasn't been enabled by default is that there are a number of laptops with Intel Pentium and Celeron "mobile" CPUs which do not provide AVX2 hardware.

Generally, laptops with those "mobile" processors do not have the graphical capability to run Pioneer well, as the integrated GPU is very low-power and they're usually not paired with a discrete GPU of any kind. However, I intend to keep AVX2 an "optional" build type until we've established that it's not affecting our userbase and we can provide a good failure-case UX when a user tries to run Pioneer on a non-AVX2 CPU.