### PR TITLE
Compute value of g-force in system editor

### DIFF
--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -807,7 +807,7 @@ function Windows.objectInfo:Show()
 				{ name = lc.RADIUS, icon = icons.body_radius,
 					value = (not starport) and ui.Format.Distance(body.radius) or nil },
 				{ name = lc.SURFACE_GRAVITY, icon = icons.body_radius,
-					value = (not starport) and ui.Format.Speed(body.gravity, true).." ("..ui.Format.Gravity(body.gravity / 9.8066)..")" or nil },
+					value = (not starport) and ui.Format.Speed(body.gravity, true).." ("..ui.Format.Gravity(body.gravity / 9.80665)..")" or nil },
 				{ name = lc.ESCAPE_VELOCITY, icon = icons.body_radius,
 					value = (not starport) and ui.Format.Speed(body.escapeVelocity , true) or nil },
 				{ name = lc.MEAN_DENSITY, icon = icons.body_radius,

--- a/src/editor/system/GalaxyEditAPI.cpp
+++ b/src/editor/system/GalaxyEditAPI.cpp
@@ -652,8 +652,8 @@ void SystemBody::EditorAPI::EditProperties(SystemBody *body, Random &rng, UndoSy
 
 		ImGui::BeginDisabled();
 
-		double surfaceGrav = body->CalcSurfaceGravity();
-		ImGui::InputDouble("Surface Gravity", &surfaceGrav, 0, 0, "%.4fg");
+		double surfaceGrav = body->CalcSurfaceGravity() / 9.8066; // compute g-force
+		ImGui::InputDouble("Surface Gravity", &surfaceGrav, 0, 0, "%.4f g");
 
 		ImGui::EndDisabled();
 

--- a/src/editor/system/GalaxyEditAPI.cpp
+++ b/src/editor/system/GalaxyEditAPI.cpp
@@ -652,7 +652,7 @@ void SystemBody::EditorAPI::EditProperties(SystemBody *body, Random &rng, UndoSy
 
 		ImGui::BeginDisabled();
 
-		double surfaceGrav = body->CalcSurfaceGravity() / 9.8066; // compute g-force
+		double surfaceGrav = body->CalcSurfaceGravity() / 9.80665; // compute g-force
 		ImGui::InputDouble("Surface Gravity", &surfaceGrav, 0, 0, "%.4f g");
 
 		ImGui::EndDisabled();


### PR DESCRIPTION
In the System Editor the surface gravity is presented as acceleration  m/s^2.

* Compute value of 'g' as is done in [system-view-ui.lua](https://github.com/pioneerspacesim/pioneer/blob/23b6700a16a788ced5ae7ea11283489e05cfcd0d/data/pigui/modules/system-view-ui.lua#L810)
* Format change - add space between value and 'g'.
* Add the last decimal of standard gravity to it's full 9.80665.
