### PR TITLE
Remove transparent backgrounds from screenshots

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -48,9 +48,9 @@
 
 #include "galaxy/GalaxyGenerator.h"
 
-#include "graphics/Renderer.h"
 #include "graphics/Material.h"
 #include "graphics/RenderState.h"
+#include "graphics/Renderer.h"
 #include "graphics/opengl/RendererGL.h"
 
 #include "core/GuiApplication.h"
@@ -70,8 +70,8 @@
 #include "sound/Sound.h"
 #include "sound/SoundMusic.h"
 
-#include "versioningInfo.h"
 #include "profiler/Profiler.h"
+#include "versioningInfo.h"
 
 #include <SDL.h>
 
@@ -140,7 +140,8 @@ class StartupScreen : public Application::Lifecycle {
 public:
 	StartupScreen() :
 		Lifecycle(true)
-	{}
+	{
+	}
 
 	std::unique_ptr<JobSet> asyncStartupQueue;
 	std::unique_ptr<JobSet> currentStepQueue;

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1094,6 +1094,11 @@ void GameLoop::Update(float deltaTime)
 	if (Pi::isRecordingVideo && (Pi::ffmpegFile != nullptr)) {
 		Graphics::ScreendumpState sd;
 		Pi::renderer->FrameGrab(sd);
+		// note: FrameGrab looked slightly buggy and now Screendump will do the same thing but without alpha channel
+		// so it might need some work to ressurect this and add back in the alpha channel.
+		// Also worth noting, this possibly isn't the right way to do things as it can introduce a stall of the GPU/CPU
+		// interaction.  Much better to write/copy using GPU to a chain of offscreen render targets and pull data back from them
+		// meaning what we write to the video may be a frame or two old, but that's acceptable for better performance.
 		fwrite(sd.pixels.get(), sizeof(uint32_t) * Pi::renderer->GetWindowWidth() * Pi::renderer->GetWindowHeight(), 1, Pi::ffmpegFile);
 	}
 #endif

--- a/src/PngWriter.cpp
+++ b/src/PngWriter.cpp
@@ -8,6 +8,7 @@
 
 #include <SDL_image.h>
 
+namespace {
 void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint8 *bytes, int width, int height, int stride, int bytes_per_pixel, bool strip_alpha)
 {
 	// Set up the pixel format color masks for RGB(A) byte arrays.
@@ -39,7 +40,6 @@ void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint
 	}
 
 	// create a surface
-	//SDL_Surface *surface = SDL_CreateRGBSurfaceFrom((void*)bytes, width, height, bytes_per_pixel * 8, width * bytes_per_pixel, rmask, gmask, bmask, amask);
 	SDL_Surface *surface = SDL_CreateRGBSurface(0, width, height, dest_bpp * 8, rmask, gmask, bmask, amask);
 
 	// flip the image vertically and copy to destination surface
@@ -85,6 +85,7 @@ void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint
 	SDL_FreeSurface(surface);
 	surface = nullptr;
 }
+} //namespace
 
 void write_screenshot(const Graphics::ScreendumpState &sd, const char *destFile)
 {

--- a/src/PngWriter.cpp
+++ b/src/PngWriter.cpp
@@ -8,9 +8,15 @@
 
 #include <SDL_image.h>
 
-namespace {
-void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint8 *bytes, int width, int height, int stride, int bytes_per_pixel, bool strip_alpha)
+void write_screenshot(const Graphics::ScreendumpState &sd, const char *destFile)
 {
+	const Uint8 *bytes = sd.pixels.get();
+	const int width = sd.width;
+	const int height = sd.height;
+	const int stride = sd.stride;
+	const int bytes_per_pixel = sd.bpp;
+	bool strip_alpha = true;
+
 	// Set up the pixel format color masks for RGB(A) byte arrays.
 	Uint32 rmask, gmask, bmask, amask;
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
@@ -28,12 +34,9 @@ void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint
 	int dest_bpp = bytes_per_pixel;
 	if (strip_alpha)
 	{
-		if (amask == 0)
-		{
+		if (amask == 0) {
 			strip_alpha = false;
-		}
-		else
-		{
+		} else {
 			amask = 0;
 			dest_bpp--;
 		}
@@ -46,29 +49,20 @@ void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint
 	if (!strip_alpha)
 	{
 		// optimized pass when not stripping alpha.
-		for (int y = 0; y < height; ++y)
-		{
-			Uint8 *dest = static_cast<Uint8*>(surface->pixels) + (height - (y+1)) * surface->pitch;
+		for (int y = 0; y < height; ++y) {
+			Uint8 *dest = static_cast<Uint8 *>(surface->pixels) + (height - (y + 1)) * surface->pitch;
 			const Uint8 *source = bytes + y * stride;
 			memcpy(dest, source, stride);
 		}
 	}
 	else
 	{
-		for (int y = 0; y < height; ++y)
-		{
-			Uint8 *dest = static_cast<Uint8*>(surface->pixels) + (height - (y+1)) * surface->pitch;
-			const Uint8  *source = bytes + y * stride;
-			for (int x = 0; x < width; ++x)
-			{
-				// We could assume bpp is 4/3 here and just do:
-				//*dest = *source++;
-				//*dest = *source++;
-				//*dest = *source++;
-				//++source;
+		for (int y = 0; y < height; ++y) {
+			Uint8 *dest = static_cast<Uint8 *>(surface->pixels) + (height - (y + 1)) * surface->pitch;
+			const Uint8 *source = bytes + y * stride;
+			for (int x = 0; x < width; ++x) {
 
-				for (int channel = 0; channel < dest_bpp; ++channel)
-				{
+				for (int channel = 0; channel < dest_bpp; ++channel) {
 					dest[channel] = source[channel];
 				}
 				source += bytes_per_pixel;
@@ -78,22 +72,17 @@ void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint
 	}
 
 	// do the actual saving
-	const std::string fname = FileSystem::JoinPathBelow(fs.GetRoot(), path);
+	const std::string dir = "screenshots";
+	FileSystem::userFiles.MakeDirectory(dir);
+
+	const std::string relative_path = FileSystem::JoinPathBelow(dir, destFile);
+
+	const std::string fname = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(), relative_path);
 	IMG_SavePNG(surface, fname.c_str());
 
 	//cleanup after ourselves
 	SDL_FreeSurface(surface);
 	surface = nullptr;
-}
-} //namespace
 
-void write_screenshot(const Graphics::ScreendumpState &sd, const char *destFile)
-{
-	const std::string dir = "screenshots";
-	FileSystem::userFiles.MakeDirectory(dir);
-	const std::string fname = FileSystem::JoinPathBelow(dir, destFile);
-
-	write_png(FileSystem::userFiles, fname, sd.pixels.get(), sd.width, sd.height, sd.stride, sd.bpp, true);
-
-	Output("Screenshot %s saved\n", fname.c_str());
+	Output("Screenshot %s saved\n", relative_path.c_str());
 }

--- a/src/PngWriter.h
+++ b/src/PngWriter.h
@@ -16,7 +16,7 @@ namespace Graphics {
 }
 
 // stride is in bytes (bytes per row)
-void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint8 *bytes, int width, int height, int stride, int bytes_per_pixel);
+void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint8 *bytes, int width, int height, int stride, int bytes_per_pixel, bool strip_alpha = false);
 
 void write_screenshot(const Graphics::ScreendumpState &sd, const char *destFile);
 

--- a/src/PngWriter.h
+++ b/src/PngWriter.h
@@ -7,16 +7,9 @@
 #include <SDL_stdinc.h>
 #include <string>
 
-namespace FileSystem {
-	class FileSourceFS;
-}
-
 namespace Graphics {
 	struct ScreendumpState;
 }
-
-// stride is in bytes (bytes per row)
-void write_png(FileSystem::FileSourceFS &fs, const std::string &path, const Uint8 *bytes, int width, int height, int stride, int bytes_per_pixel, bool strip_alpha = false);
 
 void write_screenshot(const Graphics::ScreendumpState &sd, const char *destFile);
 

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -244,7 +244,6 @@ namespace Graphics {
 		};
 
 		virtual bool Screendump(ScreendumpState &sd) { return false; }
-		virtual bool FrameGrab(ScreendumpState &sd) { return false; }
 
 		Stats &GetStats() { return m_stats; }
 

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -19,9 +19,9 @@ struct SDL_Window;
 namespace Graphics {
 
 	/*
-	* Renderer base class. A Renderer draws points, lines, triangles.
-	* It is also used to create render states, materials and vertex/index buffers.
-	*/
+	 * Renderer base class. A Renderer draws points, lines, triangles.
+	 * It is also used to create render states, materials and vertex/index buffers.
+	 */
 
 	class IndexBuffer;
 	class InstanceBuffer;
@@ -221,7 +221,8 @@ namespace Graphics {
 		public:
 			MatrixTicket(Renderer *r) :
 				MatrixTicket(r, r->GetTransform())
-			{}
+			{
+			}
 
 			MatrixTicket(Renderer *r, const matrix4x4f &newMat) :
 				m_renderer(r)

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -1190,30 +1190,4 @@ namespace Graphics {
 		return true;
 	}
 
-	bool RendererOGL::FrameGrab(ScreendumpState &sd)
-	{
-		int w, h;
-		SDL_GetWindowSize(m_window, &w, &h);
-		sd.width = w;
-		sd.height = h;
-		sd.bpp = 4; // XXX get from window
-
-		sd.stride = (4 * sd.width);
-
-		sd.pixels.reset(new Uint8[sd.stride * sd.height]);
-
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-		glPixelStorei(GL_PACK_ALIGNMENT, 4); // never trust defaults
-		glReadBuffer(GL_FRONT);
-		glReadPixels(0, 0, sd.width, sd.height, GL_RGBA, GL_UNSIGNED_BYTE, sd.pixels.get());
-		glFinish();
-
-		// this might harmlessly error if we're in a single buffered mode,
-		// however in double buffered mode it makes the window in window screens
-		// such as ones that show the ship within a menu (F3) work correctly
-		// as GL_BACK is the default.
-		glReadBuffer(GL_BACK);
-		return true;
-	}
-
 } // namespace Graphics

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -2,8 +2,8 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "RendererGL.h"
-#include "RefCounted.h"
 #include "MathUtil.h"
+#include "RefCounted.h"
 #include "SDL_video.h"
 #include "StringF.h"
 
@@ -1089,8 +1089,8 @@ namespace Graphics {
 		if (desc.colorFormat != TEXTURE_NONE && desc.depthFormat != TEXTURE_NONE && !rt->CheckStatus()) {
 			GLuint status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 			Log::Error("Unable to create complete render target. (Error: {})\n"
-				"Does your graphics driver support multisample anti-aliasing?\n"
-				"If this issue persists, try setting AntiAliasingMode=0 in your config file.\n",
+					   "Does your graphics driver support multisample anti-aliasing?\n"
+					   "If this issue persists, try setting AntiAliasingMode=0 in your config file.\n",
 				gl_framebuffer_error_to_string(status));
 		}
 
@@ -1170,19 +1170,23 @@ namespace Graphics {
 		SDL_GetWindowSize(m_window, &w, &h);
 		sd.width = w;
 		sd.height = h;
-		sd.bpp = 4; // XXX get from window
+		sd.bpp = 3;
 
-		// pad rows to 4 bytes, which is the default row alignment for OpenGL
-		sd.stride = ((sd.bpp * sd.width) + 3) & ~3;
+		sd.stride = (sd.bpp * sd.width);
 
 		sd.pixels.reset(new Uint8[sd.stride * sd.height]);
 
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-		glPixelStorei(GL_PACK_ALIGNMENT, 4); // never trust defaults
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+		glPixelStorei(GL_PACK_ALIGNMENT, 1);
 		glReadBuffer(GL_FRONT);
-		glReadPixels(0, 0, sd.width, sd.height, GL_RGBA, GL_UNSIGNED_BYTE, sd.pixels.get());
+		glReadPixels(0, 0, sd.width, sd.height, GL_RGB, GL_UNSIGNED_BYTE, sd.pixels.get());
 		glFinish();
 
+		// this might harmlessly error if we're in a single buffered mode,
+		// however in double buffered mode it makes the window in window screens
+		// such as ones that show the ship within a menu (F3) work correctly
+		// as GL_BACK is the default.
+		glReadBuffer(GL_BACK);
 		return true;
 	}
 
@@ -1204,6 +1208,11 @@ namespace Graphics {
 		glReadPixels(0, 0, sd.width, sd.height, GL_RGBA, GL_UNSIGNED_BYTE, sd.pixels.get());
 		glFinish();
 
+		// this might harmlessly error if we're in a single buffered mode,
+		// however in double buffered mode it makes the window in window screens
+		// such as ones that show the ship within a menu (F3) work correctly
+		// as GL_BACK is the default.
+		glReadBuffer(GL_BACK);
 		return true;
 	}
 

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -117,7 +117,6 @@ namespace Graphics {
 		virtual bool ReloadShaders() override final;
 
 		virtual bool Screendump(ScreendumpState &sd) override final;
-		virtual bool FrameGrab(ScreendumpState &sd) override final;
 
 		bool DrawMeshInternal(OGL::MeshObject *, PrimitiveType type);
 		bool DrawMeshInstancedInternal(OGL::MeshObject *, OGL::InstanceBuffer *, PrimitiveType type);

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -13,7 +13,7 @@
 #include <stack>
 #include <unordered_map>
 
-typedef void* SDL_GLContext;
+typedef void *SDL_GLContext;
 
 namespace Graphics {
 


### PR DESCRIPTION
This fixes #4671

Also, somewhat more optimal and safer, given the old code appears to be copying most bytes 3/4 times and then copying 2/3 bytes off the end of the image, if I read it correctly.

As a side effect screenshot images are a bit smaller now too.

