### PR TITLE
Improve Simplex Noise Performance

### DIFF
--- a/src/perlin.cpp
+++ b/src/perlin.cpp
@@ -132,57 +132,18 @@ double noise(const vector3d &p)
 	int i1, j1, k1; // Offsets for second corner of simplex in (i,j,k) coords
 	int i2, j2, k2; // Offsets for third corner of simplex in (i,j,k) coords
 
-	if (x0 >= y0) {
-		if (y0 >= z0) {
-			i1 = 1;
-			j1 = 0;
-			k1 = 0;
-			i2 = 1;
-			j2 = 1;
-			k2 = 0;
-		} // X Y Z order
-		else if (x0 >= z0) {
-			i1 = 1;
-			j1 = 0;
-			k1 = 0;
-			i2 = 1;
-			j2 = 0;
-			k2 = 1;
-		} // X Z Y order
-		else {
-			i1 = 0;
-			j1 = 0;
-			k1 = 1;
-			i2 = 1;
-			j2 = 0;
-			k2 = 1;
-		} // Z X Y order
-	} else { // x0<y0
-		if (y0 < z0) {
-			i1 = 0;
-			j1 = 0;
-			k1 = 1;
-			i2 = 0;
-			j2 = 1;
-			k2 = 1;
-		} // Z Y X order
-		else if (x0 < z0) {
-			i1 = 0;
-			j1 = 1;
-			k1 = 0;
-			i2 = 0;
-			j2 = 1;
-			k2 = 1;
-		} // Y Z X order
-		else {
-			i1 = 0;
-			j1 = 1;
-			k1 = 0;
-			i2 = 1;
-			j2 = 1;
-			k2 = 0;
-		} // Y X Z order
-	}
+	int x_ge_y = x0 >= y0;
+	int y_ge_z = y0 >= z0;
+	int x_ge_z = x0 >= z0;
+
+	// Compute simplex offsets - all values will be 0 or 1
+	i1 = x_ge_y & x_ge_z;
+	j1 = y_ge_z & (!x_ge_y);
+	k1 = (!x_ge_z) & (!y_ge_z);
+
+	i2 = x_ge_y | x_ge_z;
+	j2 = (!x_ge_y) | y_ge_z;
+	k2 = !(x_ge_z & y_ge_z);
 
 	// A step of (1,0,0) in (i,j,k) means a step of (1-c,-c,-c) in (x,y,z),
 	// a step of (0,1,0) in (i,j,k) means a step of (-c,1-c,-c) in (x,y,z), and
@@ -208,37 +169,30 @@ double noise(const vector3d &p)
 	const int gi3 = mod12[perm[ii + 1 + perm[jj + 1 + perm[kk + 1]]]];
 
 	// Noise contributions from the four corners
-	double n0, n1, n2, n3;
+	double n0 = 0.0, n1 = 0.0, n2 = 0.0, n3 = 0.0;
 
 	// Calculate the contribution from the four corners
 	double t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;
-	if (t0 < 0)
-		n0 = 0.0;
-	else {
+	double t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;
+	double t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;
+	double t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;
+
+	if (t0 > 0.0) {
 		t0 *= t0;
 		n0 = t0 * t0 * dot(grad3[gi0], x0, y0, z0);
 	}
 
-	double t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;
-	if (t1 < 0)
-		n1 = 0.0;
-	else {
+	if (t1 > 0.0) {
 		t1 *= t1;
 		n1 = t1 * t1 * dot(grad3[gi1], x1, y1, z1);
 	}
 
-	double t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;
-	if (t2 < 0)
-		n2 = 0.0;
-	else {
+	if (t2 > 0.0) {
 		t2 *= t2;
 		n2 = t2 * t2 * dot(grad3[gi2], x2, y2, z2);
 	}
 
-	double t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;
-	if (t3 < 0)
-		n3 = 0.0;
-	else {
+	if (t3 > 0.0) {
 		t3 *= t3;
 		n3 = t3 * t3 * dot(grad3[gi3], x3, y3, z3);
 	}


### PR DESCRIPTION
For fun yesterday, I ported FastNoise2's Simplex Noise implementation as a competitor to our Simplex `noise()` function taking advantage of SIMD operations. Unfortunately, the overhead required for a SIMD-capable version of the Simplex algorithm almost outweighs the benefit of calculating an additional double-precision noise value per function call.

As part of that work, I found an alternate way to express the truth table in our `noise()` implementation that replaces the complicated if-block with a series of bit operations. This caused our current noise function to be almost as fast as the SIMD version of the algorithm, mostly due to the significantly fewer operations involved in computing the Simplex gradient terms in our existing version.

On my machine, compiling for SSE2, this provides an approximately 20% performance improvement to noise generation functions (33 -> 26 MCycles according to profiling data.) You can see the full table of all the implementations and instruction set levels I tried [here](https://docs.google.com/spreadsheets/d/1_N1cGNaIUIQOQziovTFFBZVs7w87pi9r-gcUFHltCj0/edit?usp=sharing):
- `Noise::Simplex` is a drop-in replacement for `noise()` generating a single value at a time (for apples-to-apples comparison)
- `OctaveNoiseSingle` replaces our `octavenoise()` wrapper with a version that computes multiple octaves in parallel
- The "vectorized" versions are operating in SIMD mode, while scalar versions are using a fallback for platforms without supported vector instructions
- `noise()+` is the code in this PR.