### PR TITLE
Fix crash in l_body_get_ground_position if there is no body to get po…

### DIFF
--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -695,6 +695,7 @@ end
 --   experimental
 --
 function Ship:GetGPS()
+   if not self.frameBody then return end
    local lat, lon, altitude = self:GetGroundPosition()
    local vspd = self:GetVelocityRelTo(self.frameBody):dot(self:GetPositionRelTo(self.frameBody):normalized())
    lat = math.rad2deg(lat)

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -261,9 +261,13 @@ vector3d Body::GetVelocityRelTo(const Body *relTo) const
 
 double Body::GetAltitudeRelTo(const Body* relTo, AltitudeType altType)
 {
+	if (!relTo)
+	{
+		return 0.0;
+	}
 	vector3d pos = GetPositionRelTo(relTo);
 	double center_dist = pos.Length();
-	if (relTo && relTo->IsType(ObjectType::TERRAINBODY)) {
+	if (relTo->IsType(ObjectType::TERRAINBODY)) {
 		const TerrainBody* terrain = static_cast<const TerrainBody*>(relTo);
 		vector3d surface_pos = pos.Normalized();
 		double radius;

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -7,8 +7,8 @@
 #include "CargoBody.h"
 #include "Frame.h"
 #include "GameSaveError.h"
-#include "JsonUtils.h"
 #include "HyperspaceCloud.h"
+#include "JsonUtils.h"
 #include "Missile.h"
 #include "Planet.h"
 #include "Player.h"
@@ -259,25 +259,21 @@ vector3d Body::GetVelocityRelTo(const Body *relTo) const
 	return GetVelocityRelTo(relTo->m_frame) - relTo->GetVelocityRelTo(relTo->m_frame);
 }
 
-double Body::GetAltitudeRelTo(const Body* relTo, AltitudeType altType)
+double Body::GetAltitudeRelTo(const Body *relTo, AltitudeType altType)
 {
-	if (!relTo)
-	{
+	if (!relTo) {
 		return 0.0;
 	}
 	vector3d pos = GetPositionRelTo(relTo);
 	double center_dist = pos.Length();
 	if (relTo->IsType(ObjectType::TERRAINBODY)) {
-		const TerrainBody* terrain = static_cast<const TerrainBody*>(relTo);
+		const TerrainBody *terrain = static_cast<const TerrainBody *>(relTo);
 		vector3d surface_pos = pos.Normalized();
 		double radius;
-		if (altType != AltitudeType::DEFAULT)
-		{
+		if (altType != AltitudeType::DEFAULT) {
 			radius = altType == AltitudeType::SEA_LEVEL ? terrain->GetSystemBody()->GetRadius() :
-				terrain->GetTerrainHeight(surface_pos);
-		}
-		else
-		{
+														  terrain->GetTerrainHeight(surface_pos);
+		} else {
 			radius = terrain->GetSystemBody()->GetRadius();
 			if (center_dist <= 3.0 * terrain->GetMaxFeatureRadius()) {
 				radius = terrain->GetTerrainHeight(surface_pos);
@@ -287,8 +283,7 @@ double Body::GetAltitudeRelTo(const Body* relTo, AltitudeType altType)
 		if (altitude < 0)
 			altitude = 0;
 		return altitude;
-	}
-	else {
+	} else {
 		return center_dist;
 	}
 }

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -668,12 +668,18 @@ static int l_body_get_ground_position(lua_State *l)
 		lua_pushnil(l);
 		return 1;
 	}
+	Body* astro = f->GetBody(); // null
+	if (!astro)
+	{
+		lua_pushnil(l);
+		return 1;
+	}
+
 	vector3d pos = b->GetPosition();
 	double latitude = atan2(pos.y, sqrt(pos.x * pos.x + pos.z * pos.z));
 	double longitude = atan2(pos.x, pos.z);
 	lua_pushnumber(l, latitude);
 	lua_pushnumber(l, longitude);
-	Body *astro = f->GetBody();
 	double altitude = b->GetAltitudeRelTo(astro, altType);
 	lua_pushnumber(l, altitude);
 	return 3;

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -395,8 +395,7 @@ static int l_body_get_altitude_rel_to(lua_State *l)
 	Body *b = LuaObject<Body>::CheckFromLua(1);
 	const Body *other = LuaObject<Body>::CheckFromLua(2);
 	AltitudeType altType = AltitudeType::DEFAULT;
-	if (!lua_isnoneornil(l, 3))
-	{
+	if (!lua_isnoneornil(l, 3)) {
 		bool terrainRelative = lua_toboolean(l, 3);
 		altType = terrainRelative ? AltitudeType::ABOVE_TERRAIN : AltitudeType::SEA_LEVEL;
 	}
@@ -491,8 +490,7 @@ static int l_body_attr_frame_body(lua_State *l)
 
 	Frame *f = Frame::GetFrame(b->GetFrame());
 
-	if (!f)
-	{
+	if (!f) {
 		lua_pushnil(l);
 		return 1;
 	}
@@ -526,8 +524,7 @@ static int l_body_attr_frame_rotating(lua_State *l)
 	}
 
 	Frame *f = Frame::GetFrame(b->GetFrame());
-	if (!f)
-	{
+	if (!f) {
 		lua_pushnil(l);
 		return 1;
 	}
@@ -650,8 +647,7 @@ static int l_body_get_ground_position(lua_State *l)
 {
 	Body *b = LuaObject<Body>::CheckFromLua(1);
 	AltitudeType altType = AltitudeType::DEFAULT;
-	if (!lua_isnoneornil(l, 2))
-	{
+	if (!lua_isnoneornil(l, 2)) {
 		bool terrainRelative = lua_toboolean(l, 2);
 		altType = terrainRelative ? AltitudeType::ABOVE_TERRAIN : AltitudeType::SEA_LEVEL;
 	}
@@ -663,14 +659,12 @@ static int l_body_get_ground_position(lua_State *l)
 
 	Frame *f = Frame::GetFrame(b->GetFrame());
 
-	if (!f)
-	{
+	if (!f) {
 		lua_pushnil(l);
 		return 1;
 	}
-	Body* astro = f->GetBody(); // null
-	if (!astro)
-	{
+	Body *astro = f->GetBody();
+	if (!astro) {
 		lua_pushnil(l);
 		return 1;
 	}


### PR DESCRIPTION
…sition relative to

Every time I try to hyperspace I was crashing here (jumping from a space station, if that matters).  Well the crash happened in `GetAltitudeRelTo` which was being passed a `null` body as the first argument.

@Max5377 , I think this relates to your earlier PR.
