### PR TITLE
Fix assertion failed in Sfx::Sfx(const Json &jsonObj)

### DIFF
--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -70,8 +70,8 @@ Sfx::Sfx(const Json &jsonObj)
 	try {
 		Json sfxObj = jsonObj["sfx"];
 
-		m_pos = jsonObj["pos"];
-		m_vel = jsonObj["vel"];
+		m_pos = sfxObj["pos"];
+		m_vel = sfxObj["vel"];
 		m_age = sfxObj["age"];
 		m_type = sfxObj["type"];
 	} catch (Json::type_error &) {


### PR DESCRIPTION
![AssertionFailed1](https://github.com/pioneerspacesim/pioneer/assets/69468517/b4e1d600-0599-449c-97b5-48405e8b9e8e)

Fix for this error, because `Sfx::Sfx(const Json &jsonObj)` was trying to get `pos` and `vel` keys from passed `jsonObj` itself, when it should get it from `jsonObj[sfx]` object.
This happened randomly when loading the save.