### PR TITLE
Improve BVH Broadphase Performance

### DIFF
--- a/src/Aabb.h
+++ b/src/Aabb.h
@@ -15,14 +15,16 @@ struct Aabb {
 		min(DBL_MAX, DBL_MAX, DBL_MAX),
 		max(-DBL_MAX, -DBL_MAX, -DBL_MAX),
 		radius(0.1)
-	{}
+	{
+	}
 	// Fast constructor for pre-conditioned values
 	// Should only be used when _min < _max for all {x,y,z}
 	Aabb(const vector3d &_min, const vector3d &_max, float rad) :
 		min(_min),
 		max(_max),
 		radius(rad)
-	{}
+	{
+	}
 	void Update(const Aabb &b)
 	{
 		max.x = std::max(max.x, b.max.x);
@@ -69,7 +71,7 @@ struct Aabb {
 };
 
 // SIMD-capable AABB type without additional overhead
-template<typename Vec3>
+template <typename Vec3>
 struct AABB {
 	using Number = typename Vec3::element_type;
 
@@ -100,8 +102,8 @@ struct AABB {
 
 	auto IntersectsRay(const Vec3 &start, const Vec3 &inv_dir, Number dist) const
 	{
-		using std::min;
 		using std::max;
+		using std::min;
 
 		Vec3 l1 = (this->min - start) * inv_dir;
 		Vec3 l2 = (this->max - start) * inv_dir;

--- a/src/Aabb.h
+++ b/src/Aabb.h
@@ -14,6 +14,24 @@ struct Aabb {
 		max(-DBL_MAX, -DBL_MAX, -DBL_MAX),
 		radius(0.1)
 	{}
+	// Fast constructor for pre-conditioned values
+	// Should only be used when _min < _max for all {x,y,z}
+	Aabb(const vector3d &_min, const vector3d &_max, float rad) :
+		min(_min),
+		max(_max),
+		radius(rad)
+	{}
+	void Update(const Aabb &b)
+	{
+		max.x = std::max(max.x, b.max.x);
+		max.y = std::max(max.y, b.max.y);
+		max.z = std::max(max.z, b.max.z);
+		min.x = std::min(min.x, b.min.x);
+		min.y = std::min(min.y, b.min.y);
+		min.z = std::min(min.z, b.min.z);
+		radius = std::max(radius, b.radius);
+	}
+
 	void Update(const vector3d &p)
 	{
 		if (max.x < p.x) max.x = p.x;
@@ -42,9 +60,7 @@ struct Aabb {
 	}
 	bool Intersects(const Aabb &o) const
 	{
-		return (min.x < o.max.x) && (max.x > o.min.x) &&
-			(min.y < o.max.y) && (max.y > o.min.y) &&
-			(min.z < o.max.z) && (max.z > o.min.z);
+		return min < o.max && max > o.min;
 	}
 	// returns maximum point radius, usually smaller than max radius of bounding box
 	double GetRadius() const { return radius; }

--- a/src/Aabb.h
+++ b/src/Aabb.h
@@ -6,6 +6,8 @@
 
 #include "vector3.h"
 
+#include <algorithm> // for std::min / std::max
+
 struct Aabb {
 	vector3d min, max;
 	double radius;
@@ -65,5 +67,58 @@ struct Aabb {
 	// returns maximum point radius, usually smaller than max radius of bounding box
 	double GetRadius() const { return radius; }
 };
+
+// SIMD-capable AABB type without additional overhead
+template<typename Vec3>
+struct AABB {
+	using Number = typename Vec3::element_type;
+
+	Vec3 min, max;
+
+	static AABB Invalid()
+	{
+		return AABB{ Vec3(DBL_MAX, DBL_MAX, DBL_MAX), Vec3(-DBL_MAX, -DBL_MAX, -DBL_MAX) };
+	}
+
+	void Update(const AABB &rhs)
+	{
+		using std::max;
+		using std::min;
+
+		this->max = max(this->max, rhs.max);
+		this->min = min(this->min, rhs.min);
+	}
+
+	void Update(const Vec3 &point)
+	{
+		using std::max;
+		using std::min;
+
+		this->max = max(this->max, point);
+		this->min = min(this->min, point);
+	}
+
+	auto IntersectsRay(const Vec3 &start, const Vec3 &inv_dir, Number dist) const
+	{
+		using std::min;
+		using std::max;
+
+		Vec3 l1 = (this->min - start) * inv_dir;
+		Vec3 l2 = (this->max - start) * inv_dir;
+
+		Vec3 vmin = min(l1, l2);
+		Vec3 vmax = max(l1, l2);
+
+		double lmin = max(vmin.x, max(vmin.y, vmin.z));
+		double lmax = min(vmax.x, min(vmax.y, vmax.z));
+
+		return ((lmax >= 0.f) & (lmax >= lmin) & (lmin < dist));
+	}
+
+	auto IsIn(Vec3 point) const { return point >= min && point <= max; }
+	auto Intersects(const AABB &rhs) const { return min < rhs.max && max > rhs.min; }
+};
+
+using AABBd = AABB<vector3d>;
 
 #endif /* _AABB_H */

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -172,7 +172,8 @@ private:
 	struct Dummy {
 		Dummy() :
 			madeWithFactory(false)
-		{}
+		{
+		}
 		bool madeWithFactory;
 	};
 

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -155,7 +155,7 @@ private:
 	std::string m_label;
 	double m_radius;
 	int m_flags;
-	int m_collisionSpace;
+	std::unique_ptr<CollisionSpace> m_collisionSpace;
 
 	vector3d m_rootVel; // velocity, position and orient relative to root frame
 	vector3d m_rootPos; // updated by UpdateOrbitRails
@@ -166,7 +166,7 @@ private:
 	int m_astroBodyIndex; // deserialisation
 
 	static std::vector<Frame> s_frames;
-	static std::vector<CollisionSpace> s_collisionSpaces;
+	static std::vector<CollisionSpace *> s_collisionSpaces;
 
 	// A trick in order to avoid a direct call of ctor or dtor: use factory methods instead
 	struct Dummy {

--- a/src/collider/BVHTree.cpp
+++ b/src/collider/BVHTree.cpp
@@ -177,7 +177,7 @@ double BVHTree::CalculateSAH() const
 
 		// surface area = 2 * width * depth * height
 		vector3d size = node->aabb.max - node->aabb.min;
-		double area = 2.f * size.x * size.y * size.z;
+		double area = 2.0 * size.x * size.y * size.z;
 
 		// Cost function according to https://users.aalto.fi/~laines9/publications/aila2013hpg_paper.pdf Eq. 1
 		if (node->IsLeaf())
@@ -187,14 +187,14 @@ double BVHTree::CalculateSAH() const
 	}
 
 	vector3d rootSize = m_root->aabb.max - m_root->aabb.min;
-	float rootArea = 2.f * rootSize.x * rootSize.y * rootSize.z;
+	double rootArea = 2.0 * rootSize.x * rootSize.y * rootSize.z;
 
 	// Perform 1 / Aroot * ( SAH sums )
 	outSAH /= rootArea;
 
 	// Remove the (normalized) SAH cost of the root node from the result
 	// The SAH metric doesn't include the cost of the root node
-	outSAH -= 1.f;
+	outSAH -= 1.0;
 
 	return outSAH;
 }
@@ -391,21 +391,21 @@ double SingleBVHTree::CalculateSAH() const
 
 		// surface area = 2 * width * depth * height
 		vector3d size = node->aabb.max - node->aabb.min;
-		double area = 2.f * size.x * size.y * size.z;
+		double area = 2.0 * size.x * size.y * size.z;
 
 		// Cost function according to https://users.aalto.fi/~laines9/publications/aila2013hpg_paper.pdf Eq. 1
 		outSAH += (node->kids[0] ? 1.2 : 1.0) * area;
 	}
 
 	vector3d rootSize = rootNode->aabb.max - rootNode->aabb.min;
-	float rootArea = 2.f * rootSize.x * rootSize.y * rootSize.z;
+	double rootArea = 2.0 * rootSize.x * rootSize.y * rootSize.z;
 
 	// Perform 1 / Aroot * ( SAH sums )
 	outSAH /= rootArea;
 
 	// Remove the (normalized) SAH cost of the root node from the result
 	// The SAH metric doesn't include the cost of the root node
-	outSAH -= 1.f;
+	outSAH -= 1.0;
 
 	return outSAH;
 }

--- a/src/collider/BVHTree.cpp
+++ b/src/collider/BVHTree.cpp
@@ -6,6 +6,7 @@
 #include "Aabb.h"
 #include "MathUtil.h"
 #include "core/Log.h"
+#include "core/macros.h"
 #include "profiler/Profiler.h"
 
 const int MAX_SPLITPOS_RETRIES = 15;
@@ -326,7 +327,7 @@ void SingleBVHTree::ComputeOverlap(uint32_t nodeId, const AABBd &nodeAabb, std::
 	PROFILE_SCOPED()
 
 	int32_t stackLevel = 0;
-	uint32_t stack[m_treeHeight + 1];
+	uint32_t *stack = stackalloc(uint32_t, m_treeHeight + 1);
 	// Push the root node
 	stack[stackLevel++] = 0;
 
@@ -352,7 +353,7 @@ void SingleBVHTree::TraceRay(const vector3d &start, const vector3d &inv_dir, dou
 	PROFILE_SCOPED()
 
 	int32_t stackLevel = 0;
-	uint32_t stack[m_treeHeight + 1];
+	uint32_t *stack = stackalloc(uint32_t, m_treeHeight + 1);
 	stack[stackLevel++] = 0;
 
 	while (stackLevel > 0) {

--- a/src/collider/BVHTree.cpp
+++ b/src/collider/BVHTree.cpp
@@ -3,6 +3,8 @@
 
 #include "BVHTree.h"
 
+#include "Aabb.h"
+#include "MathUtil.h"
 #include "core/Log.h"
 #include "profiler/Profiler.h"
 
@@ -62,11 +64,6 @@ void BVHTree::BuildNode(BVHNode *node,
 	if (numTris <= 0)
 		Log::Error("BuildNode called with no elements in activeObjIndex.");
 
-	if (numTris == 1) {
-		MakeLeaf(node, objPtrs, activeObjIdx);
-		return;
-	}
-
 	std::vector<int> splitSides(numTris);
 
 	Aabb aabb;
@@ -80,6 +77,11 @@ void BVHTree::BuildNode(BVHNode *node,
 	}
 	node->numTris = numTris;
 	node->aabb = aabb;
+
+	if (numTris == 1) {
+		MakeLeaf(node, objPtrs, activeObjIdx);
+		return;
+	}
 
 	Aabb splitBox = aabb;
 	double splitPos;
@@ -157,4 +159,253 @@ BVHNode *BVHTree::AllocNode()
 	if (m_nodeAllocPos >= m_nodeAllocMax)
 		Log::Error("Out of space in m_bvhNodes.");
 	return &m_bvhNodes[m_nodeAllocPos++];
+}
+
+double BVHTree::CalculateSAH() const
+{
+	double outSAH = 0.0;
+	std::vector<BVHNode *> m_nodeStack = { m_root };
+
+	while (!m_nodeStack.empty()) {
+		BVHNode *node = m_nodeStack.back();
+		m_nodeStack.pop_back();
+
+		if (!node->IsLeaf() && node->kids[0])
+			m_nodeStack.push_back(node->kids[0]);
+		if (!node->IsLeaf() && node->kids[1])
+			m_nodeStack.push_back(node->kids[1]);
+
+		// surface area = 2 * width * depth * height
+		vector3d size = node->aabb.max - node->aabb.min;
+		double area = 2.f * size.x * size.y * size.z;
+
+		// Cost function according to https://users.aalto.fi/~laines9/publications/aila2013hpg_paper.pdf Eq. 1
+		if (node->IsLeaf())
+			outSAH += node->numTris * area;
+		else
+			outSAH += 1.2 * area;
+	}
+
+	vector3d rootSize = m_root->aabb.max - m_root->aabb.min;
+	float rootArea = 2.f * rootSize.x * rootSize.y * rootSize.z;
+
+	// Perform 1 / Aroot * ( SAH sums )
+	outSAH /= rootArea;
+
+	// Remove the (normalized) SAH cost of the root node from the result
+	// The SAH metric doesn't include the cost of the root node
+	outSAH -= 1.f;
+
+	return outSAH;
+}
+
+// ===================================================================
+
+SingleBVHTree::SingleBVHTree() :
+	m_treeHeight(0),
+	m_boundsCenter(0.0, 0.0, 0.0),
+	m_inv_scale_factor(1.0)
+{
+	Clear();
+}
+
+void SingleBVHTree::Clear()
+{
+	m_nodes.clear();
+
+	// Build a default / invalid node for this BVHTree
+	AABBd aabb = AABBd::Invalid();
+	SortKey key = { vector3f(0.f, 0.f, 0.f), 0 };
+	BuildNode(&m_nodes.emplace_back(), &key, 1, &aabb, 0);
+}
+
+void SingleBVHTree::Build(const AABBd &bounds, AABBd *objAabbs, uint32_t numObjs)
+{
+	PROFILE_SCOPED()
+
+	// bound on a fully-populated perfect binary tree: 2 * 2^(log2(n)) - 1
+	// reserve less than that, assuming this won't be a perfect tree
+	// experimental data shows generally 2 nodes per leaf object
+	m_nodes.clear();
+	m_nodes.reserve(2 * numObjs + 1);
+
+	// compute a remapping term to express object positions with highest precision using single floating point
+	// use the average of the bounding volue to remap into [-1 .. 1] space
+	m_boundsCenter = (bounds.max + bounds.min) * 0.5;
+	vector3d inv_scale = 1.0 / (bounds.max - m_boundsCenter);
+	m_inv_scale_factor = (inv_scale.x + inv_scale.y + inv_scale.z) / 3.0;
+
+	// Build a vector of sort keys for individual nodes (position within system)
+	std::vector<SortKey> sortKeys(numObjs);
+	for (size_t idx = 0; idx < numObjs; idx++) {
+		vector3d center = (objAabbs[idx].max + objAabbs[idx].min) * 0.5 - m_boundsCenter;
+		sortKeys[idx].center = vector3f(center * m_inv_scale_factor);
+		sortKeys[idx].index = idx;
+	}
+
+	BuildNode(&m_nodes.emplace_back(), sortKeys.data(), numObjs, objAabbs, 0);
+}
+
+void SingleBVHTree::BuildNode(Node *node, SortKey *keys, uint32_t numKeys, AABBd *objAabbs, uint32_t height)
+{
+	// PROFILE_SCOPED()
+
+	AABBd aabb = AABBd::Invalid();
+	m_treeHeight = std::max(++height, m_treeHeight);
+
+	// Compute the AABB for this node
+	for (size_t idx = 0; idx < numKeys; idx++) {
+		aabb.Update(objAabbs[keys[idx].index]);
+	}
+
+	node->aabb = aabb;
+	node->leafIndex = 0;
+
+	// With only a single item, this is a leaf node. Set both child pointers to 0
+	if (numKeys == 1) {
+		node->kids[0] = node->kids[1] = 0;
+		node->leafIndex = keys[0].index;
+		return;
+	}
+
+	uint32_t startIdx = Partition(keys, numKeys, aabb, objAabbs);
+
+	// If partitioning multiple nodes failed, just split the list down the middle
+	// This should never occur except in extreme degenerate cases
+	if (std::min(startIdx, numKeys - startIdx) == 0)
+		startIdx = numKeys >> 1;
+
+	// Allocate both child nodes together for cache optimization
+	node->kids[0] = m_nodes.size();
+	Node *leftNode = &m_nodes.emplace_back();
+
+	node->kids[1] = m_nodes.size();
+	Node *rightNode = &m_nodes.emplace_back();
+
+	// Descend into left/right node trees
+	// This could potentially be made into a non-recursive stack-based algorithm
+	BuildNode(leftNode, keys, startIdx, objAabbs, height);
+	BuildNode(rightNode, keys + startIdx, numKeys - startIdx, objAabbs, height);
+}
+
+uint32_t SingleBVHTree::Partition(SortKey *keys, uint32_t numKeys, const AABBd &aabb, AABBd *objAabbs)
+{
+	// PROFILE_SCOPED()
+
+	// divide by longest axis
+	uint32_t axis = 2;
+	const vector3d axislen = aabb.max - aabb.min;
+	if ((axislen.x > axislen.y) && (axislen.x > axislen.z))
+		axis = 0;
+	else if (axislen.y > axislen.z)
+		axis = 1;
+
+	const float pivot = (0.5 * (aabb.max[axis] + aabb.min[axis]) - m_boundsCenter[axis]) * m_inv_scale_factor;
+
+	// Simple O(n) sort algorithm to sort all objects according to side of pivot
+	uint32_t startIdx = 0;
+	uint32_t endIdx = numKeys - 1;
+
+	// It is ~10% faster to sort the indices than to sort the whole AABB array
+	// (cache hit rate vs. memory bandwidth)
+	// Sorting in general is extremely fast.
+	while (startIdx <= endIdx && endIdx) {
+		if (keys[startIdx].center[axis] < pivot) {
+			startIdx++;
+		} else {
+			std::swap(keys[startIdx], keys[endIdx]);
+			endIdx--;
+		}
+	}
+
+	return startIdx;
+}
+
+void SingleBVHTree::ComputeOverlap(uint32_t nodeId, const AABBd &nodeAabb, std::vector<std::pair<uint32_t, uint32_t>> &out_isect) const
+{
+	PROFILE_SCOPED()
+
+	int32_t stackLevel = 0;
+	uint32_t stack[m_treeHeight + 1];
+	// Push the root node
+	stack[stackLevel++] = 0;
+
+	while (stackLevel > 0) {
+		const SingleBVHTree::Node *node = &m_nodes[stack[--stackLevel]];
+
+		if (!nodeAabb.Intersects(node->aabb))
+			continue;
+
+		if (node->kids[0] == 0) {
+			out_isect.push_back({ nodeId, node->leafIndex });
+			continue;
+		}
+
+		// Push in reverse order for pre-order traversal
+		stack[stackLevel++] = node->kids[1];
+		stack[stackLevel++] = node->kids[0];
+	}
+}
+
+void SingleBVHTree::TraceRay(const vector3d &start, const vector3d &inv_dir, double len, std::vector<uint32_t> &out_isect) const
+{
+	PROFILE_SCOPED()
+
+	int32_t stackLevel = 0;
+	uint32_t stack[m_treeHeight + 1];
+	stack[stackLevel++] = 0;
+
+	while (stackLevel > 0) {
+		uint32_t nodeIdx = stack[--stackLevel];
+		const SingleBVHTree::Node *node = &m_nodes[nodeIdx];
+
+		// Didn't intersect with the node, ignore it
+		if (!node->aabb.IntersectsRay(start, inv_dir, len))
+			continue;
+
+		// Leaf node - mark intersection and continue
+		if (node->kids[0] == 0) {
+			out_isect.push_back(node->leafIndex);
+			continue;
+		}
+
+		stack[stackLevel++] = node->kids[1];
+		stack[stackLevel++] = node->kids[0];
+	}
+}
+
+double SingleBVHTree::CalculateSAH() const
+{
+	double outSAH = 0.0;
+	auto *rootNode = GetNode(0);
+	std::vector<uint32_t> m_nodeStack = { 0 };
+
+	while (!m_nodeStack.empty()) {
+		auto *node = GetNode(m_nodeStack.back());
+		m_nodeStack.pop_back();
+
+		if (node->kids[0])
+			m_nodeStack.push_back(node->kids[0]);
+		if (node->kids[1])
+			m_nodeStack.push_back(node->kids[1]);
+
+		// surface area = 2 * width * depth * height
+		vector3d size = node->aabb.max - node->aabb.min;
+		double area = 2.f * size.x * size.y * size.z;
+
+		// Cost function according to https://users.aalto.fi/~laines9/publications/aila2013hpg_paper.pdf Eq. 1
+		outSAH += (node->kids[0] ? 1.2 : 1.0) * area;
+	}
+
+	vector3d rootSize = rootNode->aabb.max - rootNode->aabb.min;
+	float rootArea = 2.f * rootSize.x * rootSize.y * rootSize.z;
+
+	// Perform 1 / Aroot * ( SAH sums )
+	outSAH /= rootArea;
+
+	// Remove the (normalized) SAH cost of the root node from the result
+	// The SAH metric doesn't include the cost of the root node
+	outSAH -= 1.f;
+
+	return outSAH;
 }

--- a/src/collider/BVHTree.h
+++ b/src/collider/BVHTree.h
@@ -41,6 +41,8 @@ public:
 		delete[] m_bvhNodes;
 	}
 	BVHNode *GetRoot() { return m_root; }
+	size_t GetNumNodes() const { return m_nodeAllocPos; }
+	double CalculateSAH() const;
 
 private:
 	void BuildNode(BVHNode *node,
@@ -57,6 +59,55 @@ private:
 	BVHNode *m_bvhNodes;
 	size_t m_nodeAllocPos;
 	size_t m_nodeAllocMax;
+};
+
+/*
+ * Single-node binary-tree Bounding Volume Hierarchy tree.
+ *
+ * Uses a top-down construction heuristic to produce a "full" binary tree (i.e.
+ * each node either is a leaf or is guaranteed to have two child nodes.)
+ */
+class SingleBVHTree {
+public:
+	struct Node {
+		AABBd aabb;
+		uint32_t kids[2];
+		uint32_t leafIndex;
+	};
+
+	SingleBVHTree();
+
+	void Clear();
+
+	// Build the BVH structure from the given list of AABBs
+	// Individual nodes will have leaf indices into this array
+	void Build(const AABBd &bounds, AABBd *objAabbs, uint32_t numObjs);
+
+	// Return a pointer to the node at the given index
+	const Node *GetNode(uint32_t index) const { return m_nodes.data() + index; }
+
+	// Compute a list of { objId, leafIndex } intersections and add it to the passed array
+	void ComputeOverlap(uint32_t objId, const AABBd &objAabb, std::vector<std::pair<uint32_t, uint32_t>> &out_isect) const;
+	// Trace a ray through this AABB and add the list of intersected leaves to the passed array
+	void TraceRay(const vector3d &start, const vector3d &inv_dir, double len, std::vector<uint32_t> &out_isect) const;
+
+	size_t GetNumNodes() const { return m_nodes.size(); }
+	uint32_t GetHeight() const { return m_treeHeight; }
+	double CalculateSAH() const;
+
+private:
+	struct SortKey {
+		vector3f center;
+		uint32_t index;
+	};
+
+	void BuildNode(Node *node, SortKey *keys, uint32_t numKeys, AABBd *objAabbs, uint32_t height);
+	uint32_t Partition(SortKey *keys, uint32_t numKeys, const AABBd &aabb, AABBd *objAabbs);
+
+	std::vector<Node> m_nodes;
+	uint32_t m_treeHeight;
+	vector3d m_boundsCenter;
+	double m_inv_scale_factor;
 };
 
 #endif /* _BVHTREE_H */

--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -11,252 +11,21 @@
 
 #include <algorithm>
 
-/* volnode!!!!!!!!!!! */
-struct BvhNode {
-	Aabb aabb;
-
-	/* if geomStart == 0 then not leaf,
-	 * kids[] valid */
-	int numGeoms;
-	Geom **geomStart;
-
-	BvhNode *kids[2];
-
-	BvhNode()
-	{
-		kids[0] = 0;
-		geomStart = 0;
-	}
-
-	bool IsLeaf() const { return geomStart != nullptr; }
-
-	bool CollideRay(const vector3d &start, const vector3d &invDir, isect_t *isect)
-	{
-		PROFILE_SCOPED()
-		double
-			l1 = (aabb.min.x - start.x) * invDir.x,
-			l2 = (aabb.max.x - start.x) * invDir.x,
-			lmin = std::min(l1, l2),
-			lmax = std::max(l1, l2);
-
-		l1 = (aabb.min.y - start.y) * invDir.y;
-		l2 = (aabb.max.y - start.y) * invDir.y;
-		lmin = std::max(std::min(l1, l2), lmin);
-		lmax = std::min(std::max(l1, l2), lmax);
-
-		l1 = (aabb.min.z - start.z) * invDir.z;
-		l2 = (aabb.max.z - start.z) * invDir.z;
-		lmin = std::max(std::min(l1, l2), lmin);
-		lmax = std::min(std::max(l1, l2), lmax);
-
-		return ((lmax >= 0.f) & (lmax >= lmin) & (lmin < isect->dist));
-	}
-};
-
-/*
- * Tree of objects in collision space (one tree for static objects, one for
- * dynamic)
- */
-class BvhTree {
-public:
-	Geom **m_geoms;
-	BvhNode *m_root;
-	BvhNode *m_nodesAlloc;
-	int m_nodesAllocPos;
-	int m_nodesAllocMax;
-	// tree height at best log2(n), at worst n (n is the number of objects in the tree)
-	// it seems that the height of that tree never exceeds 20
-	// also TREE HEIGHT - THREE EIGHT, neat
-	static constexpr int MAX_TREE_HEIGHT = 38;
-
-	BvhNode *AllocNode()
-	{
-		assert(m_nodesAllocPos < m_nodesAllocMax);
-		return &m_nodesAlloc[m_nodesAllocPos++];
-	}
-
-	// Avoid re-allocation of memory when m_geoms are less than before,
-	void Refresh(const std::list<Geom *> &m_geoms);
-
-	BvhTree(const std::list<Geom *> &geoms);
-	~BvhTree()
-	{
-		FreeAll();
-	}
-	void CollideGeom(Geom *, const Aabb &, int minMailboxValue, void (*callback)(CollisionContact *));
-
-private:
-	void BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &outGeomPos, int maxHeight);
-
-	void FreeAll()
-	{
-		if (m_geoms) delete[] m_geoms;
-		m_geoms = nullptr;
-		if (m_nodesAlloc) delete[] m_nodesAlloc;
-		m_nodesAlloc = nullptr;
-	}
-};
-
-BvhTree::BvhTree(const std::list<Geom *> &geoms)
-{
-	PROFILE_SCOPED()
-	m_geoms = nullptr;
-	m_nodesAlloc = nullptr;
-	int numGeoms = geoms.size();
-	if (numGeoms == 0) {
-		m_root = nullptr;
-		return;
-	}
-	m_geoms = new Geom *[numGeoms];
-	int geomPos = 0;
-	m_nodesAllocPos = 0;
-	m_nodesAllocMax = numGeoms * 2;
-	m_nodesAlloc = new BvhNode[m_nodesAllocMax];
-	m_root = AllocNode();
-	BuildNode(m_root, geoms, geomPos, MAX_TREE_HEIGHT);
-	assert(geomPos == numGeoms);
-}
-
-void BvhTree::Refresh(const std::list<Geom *> &geoms)
-{
-	PROFILE_SCOPED()
-	int numGeoms = geoms.size();
-	if (numGeoms == 0) {
-		m_root = nullptr;
-		FreeAll();
-		return;
-	}
-	int geomPos = 0;
-	m_nodesAllocPos = 0;
-	m_root = AllocNode();
-	BuildNode(m_root, geoms, geomPos, MAX_TREE_HEIGHT);
-	assert(geomPos == numGeoms);
-}
-
-void BvhTree::CollideGeom(Geom *g, const Aabb &geomAabb, int minMailboxValue, void (*callback)(CollisionContact *))
-{
-	PROFILE_SCOPED()
-	if (!m_root) return;
-
-	// our big aabb
-	vector3d pos = g->GetPosition();
-	double radius = g->GetGeomTree()->GetRadius();
-
-	int stackPos = -1;
-	BvhNode *stack[MAX_TREE_HEIGHT];
-	BvhNode *node = m_root;
-
-	for (;;) {
-		if (geomAabb.Intersects(node->aabb)) {
-			if (node->geomStart) {
-				for (int i = 0; i < node->numGeoms; i++) {
-					Geom *g2 = node->geomStart[i];
-					if (!g2->IsEnabled()) continue;
-					if (g2->GetMailboxIndex() < minMailboxValue) continue;
-					if (g2 == g) continue;
-					if (g->GetGroup() && g2->GetGroup() == g->GetGroup()) continue;
-					double radius2 = g2->GetGeomTree()->GetRadius();
-					vector3d pos2 = g2->GetPosition();
-					if ((pos - pos2).Length() <= (radius + radius2)) {
-						g->Collide(g2, callback);
-					}
-				}
-			} else if (node->kids[0]) {
-				stack[++stackPos] = node->kids[0];
-				node = node->kids[1];
-				continue;
-			}
-		}
-
-		if (stackPos < 0) break;
-		node = stack[stackPos--];
-	}
-}
-
-void BvhTree::BuildNode(BvhNode *node, const std::list<Geom *> &a_geoms, int &outGeomPos, int maxHeight)
-{
-	// PROFILE_SCOPED()
-	const int numGeoms = a_geoms.size();
-	// make aabb from spheres
-	// XXX suboptimal for static objects, as they have fixed rotation so
-	// we can use a precise rotated aabb rather than worst case XXX
-	Aabb aabb;
-	aabb.min = vector3d(FLT_MAX, FLT_MAX, FLT_MAX);
-	aabb.max = vector3d(-FLT_MAX, -FLT_MAX, -FLT_MAX);
-
-	for (std::list<Geom *>::const_iterator i = a_geoms.begin();
-		 i != a_geoms.end(); ++i) {
-		vector3d p = (*i)->GetPosition();
-		double rad = (*i)->GetGeomTree()->GetRadius();
-		aabb.Update(p + vector3d(rad, rad, rad));
-		aabb.Update(p - vector3d(rad, rad, rad));
-	}
-
-	// divide by longest axis
-	int axis;
-	const vector3d axislen = aabb.max - aabb.min;
-	if ((axislen.x > axislen.y) && (axislen.x > axislen.z))
-		axis = 0;
-	else if (axislen.y > axislen.z)
-		axis = 1;
-	else
-		axis = 2;
-	const double pivot = 0.5 * (aabb.max[axis] + aabb.min[axis]);
-
-	std::list<Geom *> side[2];
-
-	for (std::list<Geom *>::const_iterator i = a_geoms.begin();
-		 i != a_geoms.end(); ++i) {
-		if ((*i)->GetPosition()[axis] < pivot) {
-			side[0].push_back(*i);
-		} else {
-			side[1].push_back(*i);
-		}
-	}
-
-	node->numGeoms = numGeoms;
-	node->aabb = aabb;
-
-	// one side has all nodes, or we have reached the maximum tree height - just make a fucking child
-	if (side[0].size() == 0 || side[1].size() == 0 || maxHeight == 0) {
-		node->geomStart = &m_geoms[outGeomPos];
-
-		// copy geoms to the stinking flat array
-		for (std::list<Geom *>::const_iterator i = a_geoms.begin();
-			 i != a_geoms.end(); ++i) {
-			m_geoms[outGeomPos++] = *i;
-		}
-	} else {
-		// recurse!
-		node->geomStart = 0;
-		node->kids[0] = AllocNode();
-		node->kids[1] = AllocNode();
-
-		BuildNode(node->kids[0], side[0], outGeomPos, maxHeight - 1);
-		BuildNode(node->kids[1], side[1], outGeomPos, maxHeight - 1);
-	}
-}
-
-///////////////////////////////////////////////////////////////////////
-
 int CollisionSpace::s_nextHandle = 1;
 
 CollisionSpace::CollisionSpace() :
-	m_staticObjectTree(nullptr),
-	m_dynamicObjectTree(nullptr),
+	m_staticObjectTree(new SingleBVHTree()),
+	m_dynamicObjectTree(new SingleBVHTree()),
+	m_enabledStaticGeoms(0),
+	m_enabledDynGeoms(0),
+	m_needStaticGeomRebuild(true),
 	m_duringCollision(false)
 {
-	PROFILE_SCOPED()
 	sphere.radius = 0;
-	m_needStaticGeomRebuild = true;
-	m_oldGeomsNumber = 0;
 }
 
 CollisionSpace::~CollisionSpace()
 {
-	PROFILE_SCOPED()
-	if (m_staticObjectTree) delete m_staticObjectTree;
-	if (m_dynamicObjectTree) delete m_dynamicObjectTree;
 }
 
 void CollisionSpace::AddGeom(Geom *geom)
@@ -265,22 +34,20 @@ void CollisionSpace::AddGeom(Geom *geom)
 	assert(!m_duringCollision);
 
 	m_geoms.push_back(geom);
-	m_geomVec.push_back(geom);
 }
 
 void CollisionSpace::RemoveGeom(Geom *geom)
 {
 	PROFILE_SCOPED()
 	assert(!m_duringCollision);
-	m_geoms.remove(geom);
 
-	auto iter = std::find(m_geomVec.begin(), m_geomVec.end(), geom);
-	if (iter == m_geomVec.end())
+	auto iter = std::find(m_geoms.begin(), m_geoms.end(), geom);
+	if (iter == m_geoms.end())
 		return;
 
-	if (m_geomVec.size() > 1)
-		std::swap(*iter, m_geomVec.back());
-	m_geomVec.pop_back();
+	if (m_geoms.size() > 1)
+		std::swap(*iter, m_geoms.back());
+	m_geoms.pop_back();
 }
 
 void CollisionSpace::AddStaticGeom(Geom *geom)
@@ -289,7 +56,6 @@ void CollisionSpace::AddStaticGeom(Geom *geom)
 	assert(!m_duringCollision);
 
 	m_staticGeoms.push_back(geom);
-	m_staticGeomVec.push_back(geom);
 	m_needStaticGeomRebuild = true;
 }
 
@@ -298,16 +64,15 @@ void CollisionSpace::RemoveStaticGeom(Geom *geom)
 	PROFILE_SCOPED()
 	assert(!m_duringCollision);
 
-	m_staticGeoms.remove(geom);
 	m_needStaticGeomRebuild = true;
 
-	auto iter = std::find(m_staticGeomVec.begin(), m_staticGeomVec.end(), geom);
-	if (iter == m_staticGeomVec.end())
+	auto iter = std::find(m_staticGeoms.begin(), m_staticGeoms.end(), geom);
+	if (iter == m_staticGeoms.end())
 		return;
 
-	if (m_staticGeomVec.size() > 1)
-		std::swap(*iter, m_staticGeomVec.back());
-	m_staticGeomVec.pop_back();
+	if (m_staticGeoms.size() > 1)
+		std::swap(*iter, m_staticGeoms.back());
+	m_staticGeoms.pop_back();
 }
 
 void CollisionSpace::CollideRaySphere(const vector3d &start, const vector3d &dir, isect_t *isect)
@@ -347,89 +112,31 @@ void CollisionSpace::TraceRay(const vector3d &start, const vector3d &dir, double
 	vector3d invDir(1.0 / dir.x, 1.0 / dir.y, 1.0 / dir.z);
 	c->distance = len;
 
-	BvhNode *vn_stack[BvhTree::MAX_TREE_HEIGHT];
-	BvhNode *node = m_staticObjectTree->m_root;
-	int stackPos = -1;
+	std::vector<uint32_t> isect_result;
+	isect_result.reserve(8);
 
-	for (; node;) {
-		// do we hit it?
-		{
-			isect_t isect;
-			isect.dist = float(c->distance);
-			isect.triIdx = -1;
-			if (!node->CollideRay(start, invDir, &isect)) goto pop_jizz;
+	if (m_enabledStaticGeoms > 0) {
+		m_staticObjectTree->TraceRay(start, dir, len, isect_result);
+
+		for (uint32_t &idx : isect_result) {
+			Geom *g = m_staticGeoms[idx];
+			TraceRayGeom(g, start, dir, len, c);
 		}
 
-		if (node->geomStart) {
-			// it is a leaf node
-			// collide with all geoms
-			for (int i = 0; i < node->numGeoms; i++) {
-				Geom *g = node->geomStart[i];
-
-				const matrix4x4d &invTrans = g->GetInvTransform();
-				vector3d ms = invTrans * start;
-				vector3d md = invTrans.ApplyRotationOnly(dir);
-				vector3f modelStart = vector3f(ms.x, ms.y, ms.z);
-				vector3f modelDir = vector3f(md.x, md.y, md.z);
-
-				isect_t isect;
-				isect.dist = float(c->distance);
-				isect.triIdx = -1;
-				g->GetGeomTree()->TraceRay(modelStart, modelDir, &isect);
-				if (isect.triIdx != -1) {
-					c->pos = start + dir * double(isect.dist);
-
-					vector3f n = g->GetGeomTree()->GetTriNormal(isect.triIdx);
-					c->normal = vector3d(n.x, n.y, n.z);
-					c->normal = g->GetTransform().ApplyRotationOnly(c->normal);
-
-					c->depth = len - isect.dist;
-					c->triIdx = isect.triIdx;
-					c->userData1 = g->GetUserData();
-					c->userData2 = 0;
-					c->geomFlag = g->GetGeomTree()->GetTriFlag(isect.triIdx);
-					c->distance = isect.dist;
-				}
-			}
-		} else if (node->kids[0]) {
-			vn_stack[++stackPos] = node->kids[0];
-			node = node->kids[1];
-			continue;
-		}
-	pop_jizz:
-		if (stackPos < 0) break;
-		node = vn_stack[stackPos--];
+		isect_result.clear();
 	}
 
-	for (std::list<Geom *>::iterator i = m_geoms.begin(); i != m_geoms.end(); ++i) {
-		if ((*i) == ignore) continue;
-		if ((*i)->IsEnabled()) {
-			const matrix4x4d &invTrans = (*i)->GetInvTransform();
-			vector3d ms = invTrans * start;
-			vector3d md = invTrans.ApplyRotationOnly(dir);
-			vector3f modelStart = vector3f(ms.x, ms.y, ms.z);
-			vector3f modelDir = vector3f(md.x, md.y, md.z);
+	if (m_enabledDynGeoms > 0) {
+		m_dynamicObjectTree->TraceRay(start, dir, len, isect_result);
 
-			isect_t isect;
-			isect.dist = float(c->distance);
-			isect.triIdx = -1;
-			(*i)->GetGeomTree()->TraceRay(modelStart, modelDir, &isect);
-			if (isect.triIdx != -1) {
-				c->pos = start + dir * double(isect.dist);
+		for (uint32_t &idx : isect_result) {
+			Geom *g = m_geoms[idx];
 
-				vector3f n = (*i)->GetGeomTree()->GetTriNormal(isect.triIdx);
-				c->normal = vector3d(n.x, n.y, n.z);
-				c->normal = (*i)->GetTransform().ApplyRotationOnly(c->normal);
-
-				c->depth = len - isect.dist;
-				c->triIdx = isect.triIdx;
-				c->userData1 = (*i)->GetUserData();
-				c->userData2 = 0;
-				c->geomFlag = (*i)->GetGeomTree()->GetTriFlag(isect.triIdx);
-				c->distance = isect.dist;
-			}
+			if (g != ignore)
+				TraceRayGeom(g, start, dir, len, c);
 		}
 	}
+
 	{
 		isect_t isect;
 		isect.dist = float(c->distance);
@@ -448,26 +155,33 @@ void CollisionSpace::TraceRay(const vector3d &start, const vector3d &dir, double
 	}
 }
 
-/*
- * Do not collide objects with mailbox value < minMailboxValue
- */
-void CollisionSpace::CollideGeoms(Geom *a, int minMailboxValue, void (*callback)(CollisionContact *))
+void CollisionSpace::TraceRayGeom(Geom *g, const vector3d &start, const vector3d &dir, double len, CollisionContact *c)
 {
 	PROFILE_SCOPED()
-	if (!a->IsEnabled()) return;
-	// our big aabb
-	vector3d pos = a->GetPosition();
-	double radius = a->GetGeomTree()->GetRadius();
-	Aabb ourAabb;
-	ourAabb.min = pos - vector3d(radius, radius, radius);
-	ourAabb.max = pos + vector3d(radius, radius, radius);
 
-	if (m_staticObjectTree) m_staticObjectTree->CollideGeom(a, ourAabb, 0, callback);
-	if (m_dynamicObjectTree) m_dynamicObjectTree->CollideGeom(a, ourAabb, minMailboxValue, callback);
+	const matrix4x4d &invTrans = g->GetInvTransform();
+	vector3d ms = invTrans * start;
+	vector3d md = invTrans.ApplyRotationOnly(dir);
+	vector3f modelStart = vector3f(ms);
+	vector3f modelDir = vector3f(md);
 
-	/* test the fucker against the planet sphere thing */
-	if (sphere.radius > 0.0) {
-		a->CollideSphere(sphere, callback);
+	isect_t isect;
+	isect.dist = float(c->distance);
+	isect.triIdx = -1;
+	g->GetGeomTree()->TraceRay(modelStart, modelDir, &isect);
+	if (isect.triIdx != -1) {
+		c->pos = start + dir * double(isect.dist);
+
+		vector3f n = g->GetGeomTree()->GetTriNormal(isect.triIdx);
+		c->normal = vector3d(n.x, n.y, n.z);
+		c->normal = g->GetTransform().ApplyRotationOnly(c->normal);
+
+		c->depth = len - isect.dist;
+		c->triIdx = isect.triIdx;
+		c->userData1 = g->GetUserData();
+		c->userData2 = 0;
+		c->geomFlag = g->GetGeomTree()->GetTriFlag(isect.triIdx);
+		c->distance = isect.dist;
 	}
 }
 
@@ -491,103 +205,25 @@ void CollisionSpace::CollideGeom(Geom *a, Geom *b, void (*callback)(CollisionCon
 	}
 }
 
-double CollisionSpace::CalcSAH(BvhTree *tree) const
-{
-	if (!tree || !tree->m_root)
-		return 0.0;
-
-	double outSAH = 0.0;
-	auto *rootNode = tree->m_root;
-	std::vector<BvhNode *> m_nodeStack = { rootNode };
-
-	while (!m_nodeStack.empty()) {
-		auto *node = m_nodeStack.back();
-		m_nodeStack.pop_back();
-
-		if (!node->IsLeaf() && node->kids[0])
-			m_nodeStack.push_back(node->kids[0]);
-		if (!node->IsLeaf() && node->kids[1])
-			m_nodeStack.push_back(node->kids[1]);
-
-		// surface area = 2 * width * depth * height
-		vector3d size = node->aabb.max - node->aabb.min;
-		double area = 2.f * size.x * size.y * size.z;
-
-		// Cost function according to https://users.aalto.fi/~laines9/publications/aila2013hpg_paper.pdf Eq. 1
-		if (node->IsLeaf())
-			outSAH += node->numGeoms * area;
-		else
-			outSAH += 1.2 * area;
-	}
-
-	vector3d rootSize = rootNode->aabb.max - rootNode->aabb.min;
-	float rootArea = 2.f * rootSize.x * rootSize.y * rootSize.z;
-
-	// Perform 1 / Aroot * ( SAH sums )
-	outSAH /= rootArea;
-
-	// Remove the (normalized) SAH cost of the root node from the result
-	// The SAH metric doesn't include the cost of the root node
-	outSAH -= 1.f;
-
-	return outSAH;
-}
-
-double CollisionSpace::CalcSAH(SingleBVHTree *tree) const
-{
-	return tree ? tree->CalculateSAH() : 0.0;
-}
-
 // ===================================================================
 
 void CollisionSpace::RebuildObjectTrees()
 {
 	PROFILE_SCOPED()
 
-	{
-		PROFILE_SCOPED_DESC("Rebuild Old Trees")
+	if (m_needStaticGeomRebuild) {
+		std::vector<AABBd> staticAabbs;
 
-		if (m_needStaticGeomRebuild) {
-			if (m_staticObjectTree) delete m_staticObjectTree;
-			m_staticObjectTree = new BvhTree(m_staticGeoms);
-		}
-		if (m_oldGeomsNumber < m_geoms.size()) {
-			// Have more geoms: rebuild completely (ask more memory)
-			if (m_dynamicObjectTree) delete m_dynamicObjectTree;
-			m_dynamicObjectTree = new BvhTree(m_geoms);
-		} else {
-			// Same number or less (no needs for more memory)
-			if (m_dynamicObjectTree)
-				m_dynamicObjectTree->Refresh(m_geoms);
-			else
-				m_dynamicObjectTree = new BvhTree(m_geoms);
-		}
-
-		m_oldGeomsNumber = m_geoms.size();
-	}
-	{
-		PROFILE_SCOPED_DESC("Rebuild New Trees")
-
-		if (!m_staticObjectTree2) {
-			m_staticObjectTree2.reset(new SingleBVHTree());
-		}
-
-		if (!m_dynamicObjectTree2) {
-			m_dynamicObjectTree2.reset(new SingleBVHTree());
-		}
-
-		if (m_needStaticGeomRebuild) {
-			std::vector<AABBd> staticAabbs;
-			m_enabledStaticGeoms = SortEnabledGeoms(m_staticGeomVec);
-
-			RebuildBVHTree(m_staticObjectTree2.get(), m_enabledStaticGeoms, m_staticGeomVec, staticAabbs);
-		}
-
-		m_enabledDynGeoms = SortEnabledGeoms(m_geomVec);
-		RebuildBVHTree(m_dynamicObjectTree2.get(), m_enabledDynGeoms, m_geomVec, m_geomAabbs);
+		m_enabledStaticGeoms = SortEnabledGeoms(m_staticGeoms);
+		RebuildBVHTree(m_staticObjectTree.get(), m_enabledStaticGeoms, m_staticGeoms, staticAabbs);
+		m_needStaticGeomRebuild = false;
 	}
 
-	m_needStaticGeomRebuild = false;
+	// NOTE: we store AABBs in m_geomAabbs for fast O(1) lookup during Collide()
+	// This doubles the memory cost but allows SingleBVHTree to store leaf nodes
+	// in a cache-friendly order.
+	m_enabledDynGeoms = SortEnabledGeoms(m_geoms);
+	RebuildBVHTree(m_dynamicObjectTree.get(), m_enabledDynGeoms, m_geoms, m_geomAabbs);
 }
 
 uint32_t CollisionSpace::SortEnabledGeoms(std::vector<Geom *> &geoms)
@@ -619,8 +255,10 @@ void CollisionSpace::RebuildBVHTree(SingleBVHTree *tree, uint32_t numGeoms, cons
 	PROFILE_SCOPED()
 	assert(numGeoms < INT32_MAX);
 
-	if (numGeoms == 0)
+	if (numGeoms == 0) {
+		tree->Clear();
 		return;
+	}
 
 	aabbs.resize(0);
 	aabbs.reserve(numGeoms);
@@ -650,59 +288,42 @@ void CollisionSpace::Collide(void (*callback)(CollisionContact *))
 
 	RebuildObjectTrees();
 
-	{
-		PROFILE_SCOPED_DESC("Mailbox Collision")
+	std::vector<Intersection> static_isect;
+	std::vector<Intersection> dyn_isect;
 
-		int mailboxMin = 0;
-		for (std::list<Geom *>::iterator i = m_geoms.begin(); i != m_geoms.end(); ++i) {
-			(*i)->SetMailboxIndex(mailboxMin++);
-		}
+	static_isect.reserve(32);
+	dyn_isect.reserve(32);
 
-		/* This mailbox nonsense is so: after collision(a,b), we will not
-		* attempt collision(b,a) */
-		mailboxMin = 1;
-		for (std::list<Geom *>::iterator i = m_geoms.begin(); i != m_geoms.end(); ++i, mailboxMin++) {
-			CollideGeoms(*i, mailboxMin, callback);
-		}
+	// Testing against an empty tree (one "invalid" node) is still slower than
+	// a static branch (remains uniformly predictable across the entire loop)
+	bool hasStatic = m_enabledStaticGeoms > 0;
+
+	for (uint32_t idx = 0; idx < m_enabledDynGeoms; idx++) {
+		Geom *g = m_geoms[idx];
+		if (!g->IsEnabled())
+			continue;
+
+		const AABBd &aabb = m_geomAabbs[idx];
+
+		if (hasStatic)
+			m_staticObjectTree->ComputeOverlap(idx, aabb, static_isect);
+		m_dynamicObjectTree->ComputeOverlap(idx, aabb, dyn_isect);
 	}
 
-	{
-		PROFILE_SCOPED_DESC("BVHTree2 Collision")
-		std::vector<Intersection> static_isect;
-		std::vector<Intersection> dyn_isect;
-
-		static_isect.reserve(32);
-		dyn_isect.reserve(32);
-
-		bool hasStatic = m_enabledStaticGeoms > 0;
-
-		for (uint32_t idx = 0; idx < m_enabledDynGeoms; idx++) {
-			Geom *g = m_geomVec[idx];
-			if (!g->IsEnabled())
-				continue;
-
-			const AABBd &aabb = m_geomAabbs[idx];
-
-			if (hasStatic)
-				m_staticObjectTree2->ComputeOverlap(idx, aabb, static_isect);
-			m_dynamicObjectTree2->ComputeOverlap(idx, aabb, dyn_isect);
-		}
-
-		// No mailbox test needed for colliding a dynamic geom against static geoms
-		for (const Intersection &isect : static_isect) {
-			CollideGeom(m_geomVec[isect.first], m_staticGeomVec[isect.second], callback);
-		}
-
-		// Simple mailbox test to ensure every valid collision is only processed once
-		for (const Intersection &isect : dyn_isect) {
-			if (isect.first >= isect.second)
-				continue;
-
-			CollideGeom(m_geomVec[isect.first], m_geomVec[isect.second], callback);
-		}
-
-		CollidePlanet(callback);
+	// No mailbox test needed for colliding a dynamic geom against static geoms
+	for (const Intersection &isect : static_isect) {
+		CollideGeom(m_geoms[isect.first], m_staticGeoms[isect.second], callback);
 	}
+
+	// Simple mailbox test to ensure every valid collision is only processed once
+	for (const Intersection &isect : dyn_isect) {
+		if (isect.first >= isect.second)
+			continue;
+
+		CollideGeom(m_geoms[isect.first], m_geoms[isect.second], callback);
+	}
+
+	CollidePlanet(callback);
 
 	m_duringCollision = false;
 }
@@ -714,8 +335,8 @@ void CollisionSpace::CollidePlanet(void (*callback)(CollisionContact *))
 	// If this collision space exists for a planet, collide all dynamic geoms
 	// against the planet
 	if (sphere.radius > 0.0) {
-		for (uint32_t idx = 0; idx < m_geomVec.size(); idx++) {
-			Geom *g = m_geomVec[idx];
+		for (uint32_t idx = 0; idx < m_geoms.size(); idx++) {
+			Geom *g = m_geoms[idx];
 			if (!g->IsEnabled())
 				continue;
 

--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -272,7 +272,7 @@ void CollisionSpace::RebuildBVHTree(SingleBVHTree *tree, uint32_t numGeoms, cons
 		vector3d pos = geom->GetPosition();
 		double radius = geom->GetGeomTree()->GetRadius();
 
-		AABBd aabb { {pos - radius }, { pos + radius } };
+		AABBd aabb{ { pos - radius }, { pos + radius } };
 
 		aabbs.push_back(aabb);
 		bounds.Update(aabb);

--- a/src/collider/CollisionSpace.h
+++ b/src/collider/CollisionSpace.h
@@ -4,11 +4,11 @@
 #ifndef _COLLISION_SPACE
 #define _COLLISION_SPACE
 
-#include "../vector3.h"
 #include "../Aabb.h"
+#include "../vector3.h"
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 class Geom;
 class SingleBVHTree;

--- a/src/collider/CollisionSpace.h
+++ b/src/collider/CollisionSpace.h
@@ -5,7 +5,11 @@
 #define _COLLISION_SPACE
 
 #include "../vector3.h"
+#include "../Aabb.h"
+
 #include <list>
+#include <vector>
+#include <memory>
 
 class Geom;
 struct isect_t;
@@ -18,6 +22,7 @@ struct Sphere {
 };
 
 class BvhTree;
+class SingleBVHTree;
 
 /*
  * Collision spaces have a bunch of geoms and at most one sphere (for a planet).
@@ -53,7 +58,15 @@ public:
 		return s_nextHandle++;
 	}
 
+	double GetDynamicTreeSAH() const { return CalcSAH(m_dynamicObjectTree); }
+	double GetDynamicTree2SAH() const  { return CalcSAH(m_dynamicObjectTree2.get()); }
+
+	double GetStaticTreeSAH() const  { return CalcSAH(m_staticObjectTree); }
+	double GetStaticTree2SAH() const  { return CalcSAH(m_staticObjectTree2.get()); }
+
 private:
+	using Intersection = std::pair<uint32_t, uint32_t>;
+
 	void CollideGeoms(Geom *a, int minMailboxValue, void (*callback)(CollisionContact *));
 	void CollideRaySphere(const vector3d &start, const vector3d &dir, isect_t *isect);
 	std::list<Geom *> m_geoms;
@@ -63,7 +76,28 @@ private:
 	BvhTree *m_dynamicObjectTree;
 	Sphere sphere;
 
+	double CalcSAH(BvhTree *tree) const;
+	double CalcSAH(SingleBVHTree *tree) const;
+
+	uint32_t SortEnabledGeoms(std::vector<Geom *> &geoms);
+	void RebuildBVHTree(SingleBVHTree *tree, uint32_t numEnabled, const std::vector<Geom *> &geoms, std::vector<AABBd> &aabbs);
+
+	void CollideGeom(Geom *a, Geom *b, void (*callback)(CollisionContact *));
+	void CollidePlanet(void (*callback)(CollisionContact *));
+
+	std::unique_ptr<SingleBVHTree> m_staticObjectTree2;
+	std::unique_ptr<SingleBVHTree> m_dynamicObjectTree2;
+
+	uint32_t m_enabledStaticGeoms;
+	uint32_t m_enabledDynGeoms;
+	std::vector<Geom *> m_staticGeomVec;
+	std::vector<Geom *> m_geomVec;
+
+	std::vector<AABBd> m_geomAabbs;
+	std::vector<AABBd> m_staticGeomAabbs;
+
 	uint32_t m_oldGeomsNumber;
+	bool m_duringCollision;
 
 	static int s_nextHandle;
 };

--- a/src/collider/Geom.cpp
+++ b/src/collider/Geom.cpp
@@ -13,9 +13,9 @@
 static const unsigned int MAX_CONTACTS = 8;
 
 Geom::Geom(const GeomTree *geomtree, const matrix4x4d &m, const vector3d &pos, void *data) :
-	m_orient(m),
 	m_pos(pos),
 	m_geomtree(geomtree),
+	m_orient(m),
 	m_data(data),
 	m_group(0),
 	m_mailboxIndex(0),

--- a/src/collider/Geom.h
+++ b/src/collider/Geom.h
@@ -43,6 +43,7 @@ private:
 	vector3d m_pos;
 	const GeomTree *m_geomtree;
 	matrix4x4d m_orient, m_invOrient;
+
 public:
 	matrix4x4d m_animTransform;
 

--- a/src/collider/Geom.h
+++ b/src/collider/Geom.h
@@ -34,17 +34,19 @@ public:
 	inline void SetGroup(int g) { m_group = g; }
 	inline int GetGroup() const { return m_group; }
 
-	matrix4x4d m_animTransform;
-
 private:
 	void CollideEdgesWithTrisOf(int &maxContacts, const Geom *b, const matrix4x4d &transTo, void (*callback)(CollisionContact *)) const;
 	void CollideEdgesTris(int &maxContacts, const BVHNode *edgeNode, const matrix4x4d &transToB,
 		const Geom *b, const BVHNode *btriNode, void (*callback)(CollisionContact *)) const;
 
 	// double-buffer position so we can keep previous position
-	matrix4x4d m_orient, m_invOrient;
 	vector3d m_pos;
 	const GeomTree *m_geomtree;
+	matrix4x4d m_orient, m_invOrient;
+public:
+	matrix4x4d m_animTransform;
+
+private:
 	void *m_data;
 	int m_group;
 	int m_mailboxIndex; // used to avoid duplicate collisions

--- a/src/core/macros.h
+++ b/src/core/macros.h
@@ -37,3 +37,14 @@
 template <typename T, size_t N>
 char (&COUNTOF_Helper(T (&array)[N]))[N];
 #define COUNTOF(array) (sizeof(COUNTOF_Helper(array)))
+
+// Helper to implement stack-based variable-length arrays in a crossplatform way
+// Avoids a heap allocation for std::vector in "hot" code
+
+#ifdef _MSC_VER
+#include <malloc.h>
+#define stackalloc(T, n) reinterpret_cast<T *>(_alloca(sizeof(T) * n))
+#else
+#include <alloca.h>
+#define stackalloc(T, n) reinterpret_cast<T *>(alloca(sizeof(T) * n))
+#endif

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -3,6 +3,7 @@
 
 #include "Drawables.h"
 
+#include "Aabb.h"
 #include "MathUtil.h"
 #include "Texture.h"
 #include "TextureBuilder.h"
@@ -994,6 +995,39 @@ namespace Graphics {
 				s_axes = new Axes3D(r);
 			}
 			return s_axes;
+		}
+
+		void AABB::DrawVertices(Graphics::VertexArray &va, const matrix4x4f &transform, const Aabb &aabb, Color color)
+		{
+			const vector3f verts[16] = {
+				transform * vector3f(aabb.min.x, aabb.min.y, aabb.min.z),
+				transform * vector3f(aabb.max.x, aabb.min.y, aabb.min.z),
+				transform * vector3f(aabb.max.x, aabb.max.y, aabb.min.z),
+				transform * vector3f(aabb.min.x, aabb.max.y, aabb.min.z),
+				transform * vector3f(aabb.min.x, aabb.min.y, aabb.min.z),
+				transform * vector3f(aabb.min.x, aabb.min.y, aabb.max.z),
+				transform * vector3f(aabb.max.x, aabb.min.y, aabb.max.z),
+				transform * vector3f(aabb.max.x, aabb.min.y, aabb.min.z),
+
+				transform * vector3f(aabb.max.x, aabb.max.y, aabb.max.z),
+				transform * vector3f(aabb.min.x, aabb.max.y, aabb.max.z),
+				transform * vector3f(aabb.min.x, aabb.min.y, aabb.max.z),
+				transform * vector3f(aabb.max.x, aabb.min.y, aabb.max.z),
+				transform * vector3f(aabb.max.x, aabb.max.y, aabb.max.z),
+				transform * vector3f(aabb.max.x, aabb.max.y, aabb.min.z),
+				transform * vector3f(aabb.min.x, aabb.max.y, aabb.min.z),
+				transform * vector3f(aabb.min.x, aabb.max.y, aabb.max.z),
+			};
+
+			for (unsigned int i = 0; i < 7; i++) {
+				va.Add(verts[i], color);
+				va.Add(verts[i + 1], color);
+			}
+
+			for (unsigned int i = 8; i < 15; i++) {
+				va.Add(verts[i], color);
+				va.Add(verts[i + 1], color);
+			}
 		}
 
 	} // namespace Drawables

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -876,12 +876,12 @@ namespace Graphics {
 			Graphics::VertexArray va = Graphics::VertexArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
 
 			// Generate two triangles for the grid plane
-			va.Add(vector3f( grid_size.x, 0, -grid_size.y), vector2f( grid_size.x, -grid_size.y));
-			va.Add(vector3f(-grid_size.x, 0,  grid_size.y), vector2f(-grid_size.x,  grid_size.y));
+			va.Add(vector3f(grid_size.x, 0, -grid_size.y), vector2f(grid_size.x, -grid_size.y));
+			va.Add(vector3f(-grid_size.x, 0, grid_size.y), vector2f(-grid_size.x, grid_size.y));
 			va.Add(vector3f(-grid_size.x, 0, -grid_size.y), vector2f(-grid_size.x, -grid_size.y));
-			va.Add(vector3f( grid_size.x, 0, -grid_size.y), vector2f( grid_size.x, -grid_size.y));
-			va.Add(vector3f( grid_size.x, 0,  grid_size.y), vector2f( grid_size.x,  grid_size.y));
-			va.Add(vector3f(-grid_size.x, 0,  grid_size.y), vector2f(-grid_size.x,  grid_size.y));
+			va.Add(vector3f(grid_size.x, 0, -grid_size.y), vector2f(grid_size.x, -grid_size.y));
+			va.Add(vector3f(grid_size.x, 0, grid_size.y), vector2f(grid_size.x, grid_size.y));
+			va.Add(vector3f(-grid_size.x, 0, grid_size.y), vector2f(-grid_size.x, grid_size.y));
 
 			GridData data = {};
 			data.thin_color = m_minorColor.ToColor4f();

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -10,6 +10,8 @@
 
 #include <memory>
 
+struct Aabb;
+
 namespace Graphics {
 	class Renderer;
 
@@ -281,6 +283,15 @@ namespace Graphics {
 		};
 
 		Axes3D *GetAxes3DDrawable(Graphics::Renderer *r);
+
+		//------------------------------------------------------------
+
+		// axis-aligned bounding box visualizer
+
+		class AABB {
+		public:
+			static void DrawVertices(Graphics::VertexArray &va, const matrix4x4f &transform, const Aabb &aabb, Color color);
+		};
 
 	} // namespace Drawables
 

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -577,35 +577,7 @@ namespace SceneGraph {
 	{
 		PROFILE_SCOPED()
 
-		const vector3f verts[16] = {
-			transform * vector3f(aabb.min.x, aabb.min.y, aabb.min.z),
-			transform * vector3f(aabb.max.x, aabb.min.y, aabb.min.z),
-			transform * vector3f(aabb.max.x, aabb.max.y, aabb.min.z),
-			transform * vector3f(aabb.min.x, aabb.max.y, aabb.min.z),
-			transform * vector3f(aabb.min.x, aabb.min.y, aabb.min.z),
-			transform * vector3f(aabb.min.x, aabb.min.y, aabb.max.z),
-			transform * vector3f(aabb.max.x, aabb.min.y, aabb.max.z),
-			transform * vector3f(aabb.max.x, aabb.min.y, aabb.min.z),
-
-			transform * vector3f(aabb.max.x, aabb.max.y, aabb.max.z),
-			transform * vector3f(aabb.min.x, aabb.max.y, aabb.max.z),
-			transform * vector3f(aabb.min.x, aabb.min.y, aabb.max.z),
-			transform * vector3f(aabb.max.x, aabb.min.y, aabb.max.z),
-			transform * vector3f(aabb.max.x, aabb.max.y, aabb.max.z),
-			transform * vector3f(aabb.max.x, aabb.max.y, aabb.min.z),
-			transform * vector3f(aabb.min.x, aabb.max.y, aabb.min.z),
-			transform * vector3f(aabb.min.x, aabb.max.y, aabb.max.z),
-		};
-
-		for (unsigned int i = 0; i < 7; i++) {
-			lines.Add(verts[i], color);
-			lines.Add(verts[i + 1], color);
-		}
-
-		for (unsigned int i = 8; i < 15; i++) {
-			lines.Add(verts[i], color);
-			lines.Add(verts[i + 1], color);
-		}
+		Graphics::Drawables::AABB::DrawVertices(lines, transform, aabb, color);
 	}
 
 	static void AddClipSphereVisualizer(float radius, Color color, Graphics::VertexArray &lines)

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -20,9 +20,9 @@
 #include "scenegraph/Animation.h"
 #include "scenegraph/Label3D.h"
 #include "scenegraph/MatrixTransform.h"
-#include "scenegraph/Tag.h"
 #include "scenegraph/NodeVisitor.h"
 #include "scenegraph/StaticGeometry.h"
+#include "scenegraph/Tag.h"
 #include "utils.h"
 
 namespace SceneGraph {

--- a/src/vector3.h
+++ b/src/vector3.h
@@ -15,6 +15,8 @@
 template <typename T>
 class alignas(sizeof(T)) vector3 {
 public:
+	using element_type = T;
+
 	T x, y, z;
 
 	// Constructor definitions are outside class declaration to enforce that
@@ -113,6 +115,15 @@ public:
 	{
 		return vector3(scalar / a.x, scalar / a.y, scalar / a.z);
 	}
+
+	// component-wise ALL-less-than
+	auto operator<(const vector3 &b) const { return x < b.x && y < b.y && z < b.z; }
+	// component-wise ALL-less-equal
+	auto operator<=(const vector3 &b) const { return x <= b.x && y <= b.y && z <= b.z; }
+	// component-wise ALL-greater-than
+	auto operator>(const vector3 &b) const { return x > b.x && y > b.y && z > b.z; }
+	// component-wise ALL-greater-equal
+	auto operator>=(const vector3 &b) const { return x >= b.x && y >= b.y && z >= b.z; }
 
 	vector3 Cross(const vector3 &b) const { return vector3(y * b.z - z * b.y, z * b.x - x * b.z, x * b.y - y * b.x); }
 	T Dot(const vector3 &b) const { return x * b.x + y * b.y + z * b.z; }
@@ -283,6 +294,22 @@ inline vector3<double>::vector3(const double vals[3]) :
 	y(vals[1]),
 	z(vals[2])
 {}
+
+// max() overload for use with C++ ADL
+template<typename T>
+vector3<T> max(const vector3<T> &lhs, const vector3<T> &rhs)
+{
+	using std::max; // support max(T) overloads
+	return vector3<T>(max(lhs.x, rhs.x), max(lhs.y, rhs.y), max(lhs.z, rhs.z));
+}
+
+// min() overload for use with C++ ADL
+template<typename T>
+vector3<T> min(const vector3<T> &lhs, const vector3<T> &rhs)
+{
+	using std::min; // support min(T) overloads
+	return vector3<T>(min(lhs.x, rhs.x), min(lhs.y, rhs.y), min(lhs.z, rhs.z));
+}
 
 #pragma pack()
 

--- a/src/vector3.h
+++ b/src/vector3.h
@@ -227,76 +227,88 @@ inline vector3<float>::vector3(const vector2f &v, float t) :
 	x(v.x),
 	y(v.y),
 	z(t)
-{}
+{
+}
 template <>
 inline vector3<float>::vector3(const vector3<double> &v) :
 	x(float(v.x)),
 	y(float(v.y)),
 	z(float(v.z))
-{}
+{
+}
 template <>
 inline vector3<double>::vector3(const vector3<float> &v) :
 	x(v.x),
 	y(v.y),
 	z(v.z)
-{}
+{
+}
 template <>
 inline vector3<double>::vector3(const vector2f &v, double t) :
 	x(v.x),
 	y(v.y),
 	z(t)
-{}
+{
+}
 template <>
 inline vector3<float>::vector3(float val) :
 	x(val),
 	y(val),
 	z(val)
-{}
+{
+}
 template <>
 inline vector3<double>::vector3(double val) :
 	x(val),
 	y(val),
 	z(val)
-{}
+{
+}
 template <>
 inline vector3<float>::vector3(float _x, float _y, float _z) :
 	x(_x),
 	y(_y),
 	z(_z)
-{}
+{
+}
 template <>
 inline vector3<double>::vector3(double _x, double _y, double _z) :
 	x(_x),
 	y(_y),
 	z(_z)
-{}
+{
+}
 template <>
 inline vector3<float>::vector3(const float vals[3]) :
 	x(vals[0]),
 	y(vals[1]),
 	z(vals[2])
-{}
+{
+}
 template <>
 inline vector3<float>::vector3(const double vals[3]) :
 	x(float(vals[0])),
 	y(float(vals[1])),
 	z(float(vals[2]))
-{}
+{
+}
 template <>
 inline vector3<double>::vector3(const float vals[3]) :
 	x(vals[0]),
 	y(vals[1]),
 	z(vals[2])
-{}
+{
+}
 template <>
 inline vector3<double>::vector3(const double vals[3]) :
 	x(vals[0]),
 	y(vals[1]),
 	z(vals[2])
-{}
+{
+}
 
 // max() overload for use with C++ ADL
-template<typename T>
+template <typename T>
 vector3<T> max(const vector3<T> &lhs, const vector3<T> &rhs)
 {
 	using std::max; // support max(T) overloads
@@ -304,7 +316,7 @@ vector3<T> max(const vector3<T> &lhs, const vector3<T> &rhs)
 }
 
 // min() overload for use with C++ ADL
-template<typename T>
+template <typename T>
 vector3<T> min(const vector3<T> &lhs, const vector3<T> &rhs)
 {
 	using std::min; // support min(T) overloads


### PR DESCRIPTION
This PR refactors our CollisionSpace broadphase collision acceleration structure to be significantly more efficient. With no intersections (the usual case for the root frame of a system), the broadphase queries run approximately 3.5x to 4x faster.

I no longer have the performance numbers for this branch due to how many intervening PRs I've needed to merge, but the broadphase cost wasn't a significant performance sink to start with (on the order of 0.3-0.5ms / frame in the Sol system) so don't expect a huge FPS boost - this is mostly attacking low-hanging fruit which would have been a greater problem further down the line.

I've not yet tried to apply this optimization to our narrow-phase BVHTree implementation - I have a different idea which involves using single-precision floats and splitting large Geoms as part of the import step to fit within the precision limits of a regular `float`-based AABB.

The performance gain from this PR is mostly due to completely removing the need for a `std::list<Geom *>` during iteration, reducing the amount of allocations needed per-frame (can re-use the array memory if not significantly increasing the number of geoms or altering the topology), and cramming everything needed for a node into a single cache line.

The (rather abysmal) prior cache inefficiency was the largest factor responsible for the time cost involved in rebuilding and traversing the broadphase BVH, though once bodies start overlapping the narrow-phase collision tri-edge-edge-tri test still significantly dominates the runtime cost.

CC @JonBooth78 to have a gander at the physics code and hopefully improve your familiarity with that area of the codebase. :smile: