### PR TITLE
Improve CI Setup and Performance

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -28,6 +28,7 @@ env:
     libassimp-dev
     libsdl2-dev
     libsdl2-image-dev
+    ninja-build
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -100,7 +101,7 @@ jobs:
     - name: Setup CMake
       run: |
         cp scripts/CMakeBuildPresetsCI.json CMakeUserPresets.json
-        cmake --preset linux-x64-release
+        cmake -G Ninja --preset linux-x64-release
 
     - name: Build GCC
       run: cmake --build ./build --target all
@@ -134,7 +135,7 @@ jobs:
     - name: Setup CMake
       run: |
         cp scripts/CMakeBuildPresetsCI.json CMakeUserPresets.json
-        cmake --preset linux-x64-release-avx
+        cmake -G Ninja --preset linux-x64-release-avx
 
     - name: Build GCC
       run: cmake --build ./build --target all
@@ -171,7 +172,7 @@ jobs:
       run: |
         cp scripts/CMakeBuildPresetsCI.json CMakeUserPresets.json
         export CC=clang CXX=clang++
-        cmake --preset linux-x64-release
+        cmake -G Ninja --preset linux-x64-release
 
     - name: Build Clang
       run: cmake --build ./build --target all

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -19,8 +19,7 @@ jobs:
   clang-format-check:
     timeout-minutes: 5
 
-    # Ubuntu 18.04 at the time of writing includes clang-format-9 as default
-    runs-on: [ubuntu-20.04]
+    runs-on: ubuntu-latest
 
     # We want to check all changed files between the pull-request base and the head of the pull request
     env:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-	"version": 2,
+	"version": 3,
 	"configurePresets": [
 		{
 			"name": "x64-Debug",
@@ -73,7 +73,6 @@
 			"displayName": "Linux x64 Debug",
 			"description": "Use system compiler; Profiler=yes",
 			"binaryDir": "${sourceDir}/build/",
-			"generator": "Unix Makefiles",
 			"cacheVariables": {
 				"CMAKE_EXPORT_COMPILE_COMMANDS": true,
 				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
@@ -93,7 +92,6 @@
 			"displayName": "Linux x64 Profiling",
 			"description": "Use system compiler; Profiler=yes",
 			"binaryDir": "${sourceDir}/build/",
-			"generator": "Unix Makefiles",
 			"cacheVariables": {
 				"CMAKE_EXPORT_COMPILE_COMMANDS": true,
 				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
@@ -113,7 +111,6 @@
 			"displayName": "Linux x64 Release",
 			"description": "Use system compiler; Profiler=no",
 			"binaryDir": "${sourceDir}/build/",
-			"generator": "Unix Makefiles",
 			"cacheVariables": {
 				"CMAKE_EXPORT_COMPILE_COMMANDS": true,
 				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
@@ -132,7 +129,6 @@
 			"displayName": "Linux x64 Debug (Clang)",
 			"description": "CC=clang CXX=clang++; Profiler=yes",
 			"binaryDir": "${sourceDir}/build/",
-			"generator": "Unix Makefiles",
 			"cacheVariables": {
 				"CMAKE_EXPORT_COMPILE_COMMANDS": true,
 				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
@@ -154,7 +150,6 @@
 			"displayName": "Linux x64 Profiling (Clang)",
 			"description": "CC=clang CXX=clang++; Profiler=yes",
 			"binaryDir": "${sourceDir}/build/",
-			"generator": "Unix Makefiles",
 			"cacheVariables": {
 				"CMAKE_EXPORT_COMPILE_COMMANDS": true,
 				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
@@ -176,7 +171,6 @@
 			"displayName": "Linux x64 Release (Clang)",
 			"description": "CC=clang CXX=clang++; Profiler=no",
 			"binaryDir": "${sourceDir}/build/",
-			"generator": "Unix Makefiles",
 			"cacheVariables": {
 				"CMAKE_EXPORT_COMPILE_COMMANDS": true,
 				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",

--- a/src/editor/ModelViewerWidget.cpp
+++ b/src/editor/ModelViewerWidget.cpp
@@ -484,7 +484,7 @@ void ModelViewerWidget::OnRender(Graphics::Renderer *r)
 	}
 
 	// Render any extra effects
-	PostRender();
+	m_extPostRender();
 
 	// helper rendering
 	if (m_options.showLandingPad) {

--- a/src/editor/ModelViewerWidget.h
+++ b/src/editor/ModelViewerWidget.h
@@ -89,6 +89,8 @@ namespace Editor
 
 		const matrix4x4f &GetModelViewMat() const { return m_modelViewMat; }
 
+		// Extend to render in-world using Graphics::Renderer
+		UIDelegate &GetUIExtPostRender() { return m_extPostRender; }
 		// Extend to render on top of the viewport surface using ImDrawList
 		UIDelegate &GetUIExtOverlay() { return m_extOverlay; }
 		// Extend to add additional viewport menu buttons
@@ -105,8 +107,7 @@ namespace Editor
 
 		bool OnCloseRequested() override { return true; };
 
-		virtual void PostRender() {};
-
+		UIDelegate m_extPostRender;
 		UIDelegate m_extOverlay;
 		UIDelegate m_extMenus;
 		UIDelegate m_extViewportControls;


### PR DESCRIPTION
This PR refactors some of our CI build scripts and CMake tooling files to support using the `Ninja` generator on Linux instead of Make, which allows us to automatically invoke parallel builds everywhere including our CI runners.

As a result, the CI build should be able to take advantage of all vCores provided to the execution environment, leading to a hopeful build time improvement.

I've also fixed the `clang-format` CI failures by upgrading the runner to a version that provides a newer `clang-format` binary - we were stuck on v11 for CI while developers are on significantly newer versions (my system has v16) and the config files are *not* backwards compatible or well-versioned at all.

For compatibility with VSCode, I've bumped the `CMakePresets.json` version number to v3 - this requires CMake 21 or newer. Older CMake versions will still be able to use the "manual" build workflow on Linux, though CMake is starting to warn about dropping support for the minimum CMake version specified in a lot of our actual `CMakeLists.txt` files so we should re-evaluate those at some point.