### PR TITLE
Re-add the galaxy dump function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,9 @@
 #include "galaxy/GalaxyGenerator.h"
 #include "utils.h"
 #include "versioningInfo.h"
+#include "lua/Lua.h"
+#include "lua/LuaNameGen.h"
+#include "lua/LuaObject.h"
 
 #include <SDL.h>
 #include <cstdio>
@@ -182,8 +185,10 @@ start:
 			// TODO: don't initialize Pi when dumping the galaxy
 			// Galaxy generation is (mostly) self-contained, no need to e.g.
 			// turn on the renderer or load UI for this.
-			Error("GalaxyDump is not currently implemented!");
 
+			Lua::Init();
+			Pi::luaNameGen = new LuaNameGen(Lua::manager);
+			LuaObject<SystemBody>::RegisterClass();
 			FILE *file = filename == "-" ? stdout : fopen(filename.c_str(), "w");
 			if (file == nullptr) {
 				Output("pioneer: could not open \"%s\" for writing: %s\n", filename.c_str(), strerror(errno));
@@ -194,6 +199,7 @@ start:
 			if (filename != "-" && fclose(file) != 0) {
 				Output("pioneer: writing to \"%s\" failed: %s\n", filename.c_str(), strerror(errno));
 			}
+			// We do not need to delete `Pi::luaNameGen` or call Lua::Uninit() here because Pi::Uninit() already does that
 		}
 
 		Pi::Uninit();


### PR DESCRIPTION
97828a9ed634b6cb889867e48241df1072e6b810 removed the ability to dump the galaxy data. I needed the data for statistical analysis for balance purposes. Debugging missing global dependencies was quite frustrating, but now we can dump galaxies again.

Note: dumping the galaxy opens and closes a gui window. I am not sure why this happens, but any galaxy dump is better than no galaxy dump.