### PR TITLE
Avoid misaligned read when loading SGM files

### DIFF
--- a/src/scenegraph/Serializer.h
+++ b/src/scenegraph/Serializer.h
@@ -9,6 +9,7 @@
 #include "Color.h"
 #include "Quaternion.h"
 #include "vector3.h"
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
@@ -119,12 +120,15 @@ namespace Serializer {
 	public:
 		Reader() :
 			m_at(nullptr),
-			m_streamVersion(-1) {}
+			m_streamVersion(-1)
+		{
+		}
 
 		explicit Reader(const ByteRange &data) :
 			m_data(data),
 			m_at(data.begin)
-		{}
+		{
+		}
 
 		bool AtEnd() { return m_at != m_data.end; }
 

--- a/src/scenegraph/Serializer.h
+++ b/src/scenegraph/Serializer.h
@@ -149,7 +149,7 @@ namespace Serializer {
 				throw std::out_of_range("Serializer::Reader encountered truncated stream.");
 #endif
 
-			out = *reinterpret_cast<const T *>(m_at);
+			std::memcpy(&out, m_at, sizeof(T)); // use memcpy to handle unaligned reads
 			m_at += sizeof(T);
 		}
 


### PR DESCRIPTION
Amend the Scenegraph serialization interface to more correctly handle the unaligned reads required by the SGM data structure layout. While the unaligned reads are in practice not an issue, this provides some future proofing against future compiler "improvements" (read: backwards compatibility breakages) and means the code is more portable to architectures like ARM64 which have a hardware requirement of aligned reads.

Closes #5687.