### PR TITLE
Fix undefined behaviour in CommandBufferGL.cpp

### DIFF
--- a/src/graphics/opengl/CommandBufferGL.cpp
+++ b/src/graphics/opengl/CommandBufferGL.cpp
@@ -214,7 +214,9 @@ char *CommandList::SetupMaterialData(OGL::Material *mat)
 	const Shader *s = mat->GetShader();
 
 	char *alloc = AllocDrawData(s);
-	memcpy(alloc, mat->m_pushConstants.get(), s->GetConstantStorageSize());
+	if (mat->m_pushConstants) {
+		memcpy(alloc, mat->m_pushConstants.get(), s->GetConstantStorageSize());
+	}
 
 	BufferBinding<UniformBuffer> *buffers = getBufferBindings(s, alloc);
 	for (size_t index = 0; index < s->GetNumBufferBindings(); index++) {


### PR DESCRIPTION
By compiling with sanitisers enabled I have detected a number of places where we run into undefined behaviour. The patch for the first is in #5692 (thanks to Web-eWorks). This is a patch for the second issue I detected.

1. `mat->m_pushConstants.get()` is sometimes null.
2. I set a breakpoint in a debugger and it turned out that  `s->GetConstantStorageSize() == 0`
3. [The behaviour of memcpy(dst, src, count) is undefined if either of the pointers is null **even if count == zero**](https://en.cppreference.com/w/cpp/string/byte/memcpy)

Fix: add a null check.

Here is how I compile with sanitisers.
1 Make sure `build/` does not exist (because cmake does not update CXXFLAGS for build directories that have already been populated). Alternatively: build in `build-with-sanitizers/`
2. `CXXFLAGS="-fsanitize=address,pointer-compare,pointer-subtract,undefined" LDFLAGS="$CXXFLAGS" cmake -S . -B build/ && make -j2 -C build/`