### PR TITLE
Fix bugs in fixed division

### DIFF
--- a/src/test/TestFixed.cpp
+++ b/src/test/TestFixed.cpp
@@ -1,0 +1,33 @@
+#include <limits>
+#include "doctest.h"
+#include "fixed.h"
+
+TEST_CASE("Fixed")
+{
+	SUBCASE("operator ==")
+	{
+		// 42.0 == 42.0
+		CHECK(fixed(42, 1) == fixed(42, 1));
+		// 123.0 != 321.0
+		CHECK(fixed(123, 1) != fixed(321, 1));
+		// 7.0 == 7.0
+		CHECK(fixed(0x7'00000000) == fixed(7, 1));
+	}
+
+	SUBCASE("operator /")
+	{
+		// 3.0 / 3.0 == 1.0
+		CHECK(fixed(3, 1) / fixed(3, 1) == fixed(1, 1));
+		// -3.0 / 3.0 == -1.0
+		// There used to be a bug causing this to produce an incorrect result
+		CHECK(fixed(-3'00000000) / fixed(3, 1) == fixed(-1'00000000));
+		// 0x40000000.00000000 / 0x40000000.00000001 == 0x00000000.ffffffff (because we round down)
+		// There used to be a bug causing this to produce an incorrect result
+		CHECK(fixed(0x40000000'00000000) / fixed(0x40000000'00000001) == fixed(0x00000000'ffffffff));
+		// fixed(INT_MIN) / fixed(INT_MIN) used to trigger a signed int overflow
+		Sint64 min = std::numeric_limits<Sint64>::min();
+		CHECK(fixed(min) / fixed(min) == fixed(1, 1));
+		// fixed(INT_MIN) / -1.0 used to trigger a signed int overflow
+		CHECK(fixed(min) / fixed(-1'00000000) == fixed(min) / fixed(-1'00000000));
+	}
+}


### PR DESCRIPTION
Fixes #5697

Note: the return statement at the end does convert Uint64 to Sint64, which is *implementation-defined* in C++17 if the value is > INT64_MAX. Here is why I think this is probably OK:

1. My biggest argument why I think this is OK is that C++20 guarantees wraparound modulo 2^64 in this case.
2. [gcc guarantees the right result](https://gcc.gnu.org/onlinedocs/gcc/Integers-implementation.html)
3. [Microsoft C++ guarantees the right result](https://learn.microsoft.com/en-us/cpp/cpp/type-conversions-and-type-safety-modern-cpp?view=msvc-170#signed---unsigned-conversions)
4. [clang unfortunately does not document its implementation-defined behaviour](https://github.com/llvm/llvm-project/issues/11644)