### PR TITLE
Add a function to recover from old versions of saves

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -359,6 +359,10 @@
     "description": "Time of departure, used in flight log",
     "message": "Departure date"
   },
+  "DESCRIPTION": {
+    "description": "Start game parameter, e.g. 'This is an easy start from Cydonia'",
+    "message": "Description"
+  },
   "DESTROY_ENEMY_SHIP": {
     "description": "",
     "message": "Destroy enemy ship"

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2307,6 +2307,14 @@
     "description": "",
     "message": "Type"
   },
+  "UNKNOWN_FACTION": {
+    "description": "For entry in the flight log",
+    "message": "Unknown faction"
+  },
+  "UNKNOWN_LOCATION_IN_SECTOR_X": {
+    "description": "For entry in the flight log",
+    "message": "Unknown location in sector {sector}"
+  },
   "UNLAWFUL_WEAPONS_DISCHARGE": {
     "description": "",
     "message": "Unlawful weapons discharge"

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -19,6 +19,10 @@
     "description": "",
     "message": "Allegiance:"
   },
+  "ALL_PARAMETERS_WERE_RECOVERED_SUCCESSFULLY": {
+    "description": "Message when restoring savegame",
+    "message": "All parameters were recovered successfully."
+  },
   "ALL_UP_WEIGHT": {
     "description": "",
     "message": "All-up weight"
@@ -50,6 +54,10 @@
   "ATTEMPT_TO_REPAIR_HULL": {
     "description": "",
     "message": "Attempt to repair hull"
+  },
+  "ATTEMPTING_TO_RECOVER_GAME_PROGRESS_FROM_SAVE_X": {
+    "description": "Message when restoring savegame",
+    "message": "Attempting to recover game progress from save: {save}"
   },
   "AUTO_ROUTE": {
     "description": "Automatically find shortest jump route (measured in time) in star map",
@@ -98,6 +106,14 @@
   "CANNOT_SELL_ITEM": {
     "description": "",
     "message": "This item cannot be sold"
+  },
+  "CANT_FIND_PATH": {
+    "description": "Message when restoring savegame, file path",
+    "message": "Can't find path: %s"
+  },
+  "CANT_FIND_PLAYERS_SHIP_IN_SPACE": {
+    "description": "Message when restoring savegame",
+    "message": "Can't find player's ship in space"
   },
   "CAPACITY": {
     "description": "Capacity of ship to fit more equipment",
@@ -267,9 +283,17 @@
     "description": "",
     "message": "Could not delete save"
   },
+  "COULD_NOT_FIND_SYSTEM_BODY_FOR_FRAME": {
+    "description": "Message when restoring savegame",
+    "message": "Could not find system body for frame"
+  },
   "COULD_NOT_LOAD_GAME": {
     "description": "",
     "message": "Could not load game: "
+  },
+  "COULD_NOT_READ_THE_SAVE_VERSION": {
+    "description": "Message when restoring savegame",
+    "message": "Could not read the save version"
   },
   "CREDIBLE": {
     "description": "For player reputation",
@@ -302,6 +326,10 @@
   "CURRENT_FUEL": {
     "description": "For hyperjump planner",
     "message": "Current Fuel:"
+  },
+  "CURRENT_SAVEGAME_VERSION": {
+    "description": "Message when restoring savegame",
+    "message": "Current savegame version: %s"
   },
   "CURRENT_SHIP": {
     "description": "For tooltip comparing current ship specs to one in the shipyard",
@@ -411,6 +439,10 @@
     "description": "",
     "message": "Docked at"
   },
+  "DOCKED_TO_A_BODY_THAT_IS_NOT_A_STATION": {
+    "description": "Message when restoring savegame",
+    "message": "Docked to a body that is not a station"
+  },
   "DOCK_AT_CURRENT_TARGET": {
     "description": "",
     "message": "Dock at current target"
@@ -503,6 +535,10 @@
     "description": "",
     "message": "Error"
   },
+  "ERROR_APPLYING_PATCH": {
+    "description": "Message when restoring savegame",
+    "message": "Error applying patch"
+  },
   "ERROR_LANDING_GEAR_DOWN": {
     "description": "",
     "message": "Can not initiate hyperjump; landing gear is not retracted!"
@@ -582,6 +618,10 @@
   "FEMALE": {
     "description": "",
     "message": "Female"
+  },
+  "FILE_SAVEGAME_VERSION": {
+    "description": "Message when restoring savegame",
+    "message": "File savegame version: %s"
   },
   "FINAL_TARGET": {
     "description": "Hyperjump planner, referring to star system target",
@@ -1491,6 +1531,10 @@
     "description": "",
     "message": "More info..."
   },
+  "MORE_THAN_ONE_PLAYERS_SHIP_FOUND_IN_SPACE": {
+    "description": "Message when restoring savegame",
+    "message": "More than one player's ship found in space"
+  },
   "MOSTLY_HARMLESS": {
     "description": "",
     "message": "Mostly Harmless"
@@ -1727,6 +1771,10 @@
     "description": "Entry for ship info",
     "message": "Passenger cabin capacity"
   },
+  "PATH_FOUND_BUT_VERIFICATION_FAILED": {
+    "description": "Message when restoring savegame",
+    "message": "Path found but verification failed: %s"
+  },
   "PATTERN": {
     "description": "Ship painting pattern.",
     "message": "Pattern"
@@ -1863,6 +1911,14 @@
     "description": "",
     "message": "Rear weapon"
   },
+  "RECOVER": {
+    "description": "Saveload menu button",
+    "message": "Recover"
+  },
+  "RECOVER_SAVEGAME": {
+    "description": "",
+    "message": "Recover savegame"
+  },
   "REFUEL": {
     "description": "",
     "message": "Refuel"
@@ -1922,6 +1978,10 @@
   "RESET_PREVIEW": {
     "description": "Paintshop button",
     "message": "Reset Preview"
+  },
+  "RECOVERED_BUT_NOT_VALID": {
+    "description": "Message when restoring savegame",
+    "message": "Recovered but not valid"
   },
   "RETURN_TO_GAME": {
     "description": "",
@@ -2195,6 +2255,10 @@
     "description": "Tab item in the start game menu",
     "message": "Summary"
   },
+  "SYSTEM_BODY_INDEX_IS_OUT_OF_RANGE": {
+    "description": "Message when restoring savegame",
+    "message": "System body index is out of range"
+  },
   "TECH_CERTIFIED": {
     "description": "Lobby screen shows the tech level (an integer number) of the station",
     "message": "This station holds a level {tech_level} technology certificate."
@@ -2218,6 +2282,10 @@
   "THERE_IS_NOBODY_ELSE_ON_BOARD_ABLE_TO_FLY_THIS_SHIP": {
     "description": "",
     "message": "There is nobody else on board able to fly this ship."
+  },
+  "THERE_WERE_ERRORS_IN_RECOVERY": {
+    "description": "Message when restoring savegame",
+    "message": "There were errors in recovery:"
   },
   "THE_SHIP_IS_UNDER_STATION_CONTROL_COMMANDER": {
     "description": "",
@@ -2311,6 +2379,10 @@
     "description": "",
     "message": "Type"
   },
+  "UNKNOWN_CUSTOM_LOG_ENTRY_FORMAT": {
+    "description": "Message when restoring savegame",
+    "message": "Unknown custom log entry format"
+  },
   "UNKNOWN_FACTION": {
     "description": "For entry in the flight log",
     "message": "Unknown faction"
@@ -2318,6 +2390,14 @@
   "UNKNOWN_LOCATION_IN_SECTOR_X": {
     "description": "For entry in the flight log",
     "message": "Unknown location in sector {sector}"
+  },
+  "UNKNOWN_STATION_LOG_ENTRY_FORMAT": {
+    "description": "Message when restoring savegame",
+    "message": "Unknown station log entry format"
+  },
+  "UNKNOWN_SYSTEM_LOG_ENTRY_FORMAT": {
+    "description": "Message when restoring savegame",
+    "message": "Unknown system log entry format"
   },
   "UNLAWFUL_WEAPONS_DISCHARGE": {
     "description": "",
@@ -2334,6 +2414,10 @@
   "UNRELIABLE": {
     "description": "",
     "message": "Unreliable"
+  },
+  "UNSUCCESSFULLY_RECOVERED_PARAMETERS_ARE_NOW_UNLOCKED_PLEASE_SET_THEM_MANUALLY": {
+    "description": "Message when restoring savegame",
+    "message": "Unsuccessfully recovered parameters are now unlocked, please set them manually."
   },
   "UP_ACCEL": {
     "description": "",

--- a/data/modules/FlightLog/FlightLog.lua
+++ b/data/modules/FlightLog/FlightLog.lua
@@ -364,6 +364,17 @@ local AddStationToLog = function (ship, station)
 	FlightLog.AddEntry( FlightLogEntry.Station.New( station.path, Game.time, Game.player:GetMoney(), nil ) )
 end
 
+function FlightLog.OrganizeEntries()
+
+	local function sortf( a, b )
+		return a.sort_date > b.sort_date
+	end
+
+	table.sort( FlightLogData, sortf )
+
+	CollapseSystemEvents()
+end
+
 -- LOADING AND SAVING
 
 local loaded_data
@@ -397,13 +408,7 @@ local onGameStart = function ()
 			table.insert(FlightLogData, FlightLogEntry.Custom.Unserialize(data))
 		end
 
-		local function sortf( a, b )
-			return a.sort_date > b.sort_date
-		end
-
-		table.sort( FlightLogData, sortf )
-
-		CollapseSystemEvents()
+		FlightLog.OrganizeEntries()
 
 	elseif loaded_data and loaded_data.Version > 1 then
 		FlightLogData = loaded_data.Data

--- a/data/modules/FlightLog/FlightLog.lua
+++ b/data/modules/FlightLog/FlightLog.lua
@@ -209,7 +209,90 @@ function FlightLog.MakeCustomEntry(text)
 	FlightLog.AddEntry( FlightLogEntry.Custom.New( path, Game.time, Game.player:GetMoney(), location, text ) )
 end
 
+--
+-- Method: InsertCustomEntry
+--
+-- Insert an element into custom flight log with all required fields
+--
+-- > FlightLog.InsertCustomEntry(entry)
+--
+-- Parameters:
+--
+--   entry - table
+--
+-- Entry:
+--
+--   path - System path
+--   time - Game date
+--   money - Financial balance at time of record creation
+--   location - Array, with two strings: flight state, and relevant additional string
+--   text - Free text string
+--
+---@param entry table
+function FlightLog.InsertCustomEntry(entry)
+	if entry.path and entry.time and entry.money and entry.location and entry.text then
+		FlightLog.AddEntry( FlightLogEntry.Custom.New( entry.path, entry.time, entry.money, entry.location, entry.text ) )
+		return true
+	else
+		return false
+	end
+end
 
+--
+-- Method: InsertSystemEntry
+--
+-- Insert an element into system flight log with all required fields
+--
+-- > FlightLog.InsertSystemEntry(entry)
+--
+-- Parameters:
+--
+--   entry - table
+--
+-- Entry:
+--
+--   path - System path, pointing to player's current system
+--   arrtime - Game date, arrival
+--   deptime - Game date, departure (optional)
+--   text - Free text string (optional)
+--
+---@param entry table
+function FlightLog.InsertSystemEntry(entry)
+	if entry.path and (entry.arrtime or entry.deptime) then
+		FlightLog.AddEntry( FlightLogEntry.System.New( entry.path, entry.arrtime, entry.deptime, entry.text or "" ) )
+		return true
+	else
+		return false
+	end
+end
+
+--
+-- Method: InsertStationEntry
+--
+-- Insert an element into station flight log with all required fields
+--
+-- > FlightLog.InsertStationEntry(entry)
+--
+-- Parameters:
+--
+--   entry - table
+--
+-- Entry:
+--
+--   path - System path
+--   arrtime - Game date, arrival
+--   money - Financial balance at time of record creation
+--   text - Free text string (optional)
+--
+---@param entry table
+function FlightLog.InsertStationEntry(entry)
+	if entry.path and entry.time and entry.money then
+		FlightLog.AddEntry( FlightLogEntry.Station.New( entry.path, entry.time, entry.money, entry.text or "" ) )
+		return true
+	else
+		return false
+	end
+end
 
 -- Method: GetLogEntries
 --

--- a/data/modules/StationRefuelling/StationRefuelling.lua
+++ b/data/modules/StationRefuelling/StationRefuelling.lua
@@ -23,12 +23,6 @@ local onShipDocked = function (ship, station)
 		ship:SetFuelPercent() -- refuel NPCs for free.
 		return
 	end
-	-- On spawning, we shouldn't deduct a fee.
-	-- This is a horrible hack but fixing in C++ side would be far more complicated.
-	if ship:hasprop("is_first_spawn") then
-		ship:unsetprop("is_first_spawn")
-		return
-	end
 
 	local fee = calculateFee()
 	if ship:GetMoney() < fee then

--- a/data/pigui/libs/message-box.lua
+++ b/data/pigui/libs/message-box.lua
@@ -5,49 +5,58 @@ local ui = require 'pigui'
 local ModalWindow = require 'pigui.libs.modal-win'
 local Lang = require 'Lang'
 local lui = Lang.GetResource("ui-core")
-
-local OK_BUTTON_WIDTH = 100
+local font = ui.fonts.pionillium.body
+local msgButtonWidth = font.size * 7
 
 local msgbox = {}
 
-msgbox.OK = function(msg)
+local function createBoxModal(msg, footer, footerWidth)
 	ModalWindow.New('PopupMessageBox', function(self)
-		ui.text(msg)
+
+		local textSize = ui.calcTextSize(tostring(msg) .. "\n.")
+		textSize.x = math.min(textSize.x, ui.screenWidth * 0.6)
+		textSize.y = math.min(textSize.y, ui.screenHeight * 0.6)
+		ui.child('PopupMessageBoxText', textSize, { 'HorizontalScrollbar' }, function ()
+			ui.text(msg)
+		end)
+
+		-- centered footer
 		local width = ui.getContentRegion().x
-		if width > OK_BUTTON_WIDTH then
-			ui.dummy(Vector2((width - OK_BUTTON_WIDTH) / 2, 0))
-			ui.sameLine()
+		if width > footerWidth then
+			ui.dummy(Vector2((width - footerWidth) / 2, 0))
+			ui.sameLine(0, 0)
 		end
-		if ui.button(lui.OK, Vector2(OK_BUTTON_WIDTH, 0)) then
-			self:close()
-		end
+		footer(self)
 	end,
 	function (_, drawPopupFn)
 		ui.setNextWindowPosCenter('Always')
-		ui.withStyleColors({ PopupBg = ui.theme.colors.modalBackground }, drawPopupFn)
+		ui.withFont(font, function()
+			ui.withStyleColors({ PopupBg = ui.theme.colors.modalBackground }, drawPopupFn)
+		end)
 	end):open()
 end
 
+msgbox.OK = function(msg)
+	createBoxModal(msg, function(self)
+		if ui.button(lui.OK, Vector2(msgButtonWidth, 0)) then
+			self:close()
+		end
+	end, msgButtonWidth)
+end
+
 msgbox.OK_CANCEL = function(msg, callback)
-	ModalWindow.New('PopupMessageBox', function(self)
-		ui.text(msg)
-		local width = ui.getContentRegion().x
-		local okButton = ui.button(lui.OK, Vector2(OK_BUTTON_WIDTH, 0))
-		if okButton then
+	createBoxModal(msg, function(self)
+		if ui.button(lui.OK, Vector2(msgButtonWidth, 0)) then
 			if callback then
-				callback(okButton)
+				callback()
 			end
 			self:close()
 		end
-		ui.sameLine(width - OK_BUTTON_WIDTH, 0)
-		if ui.button(lui.CANCEL, Vector2(OK_BUTTON_WIDTH, 0)) then
+		ui.sameLine()
+		if ui.button(lui.CANCEL, Vector2(msgButtonWidth, 0)) then
 			self:close()
 		end
-	end,
-	function (_, drawPopupFn)
-		ui.setNextWindowPosCenter('Always')
-		ui.withStyleColors({ PopupBg = ui.theme.colors.modalBackground }, drawPopupFn)
-	end):open()
+	end, msgButtonWidth * 2 + ui.getItemSpacing().x)
 end
 
 return msgbox

--- a/data/pigui/libs/modal-win.lua
+++ b/data/pigui/libs/modal-win.lua
@@ -56,7 +56,10 @@ local function drawModals(idx)
 		win:outerHandler(function ()
 			if ui.beginPopupModal(win.name, win.flags) then
 				win:innerHandler()
-				drawModals(idx+1)
+				-- modal could close in handler
+				if win.isOpen then
+					drawModals(idx+1)
+				end
 				ui.endPopup()
 			end
 		end)

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -9,7 +9,8 @@ local ui = require 'pigui.baseui'
 local pigui = Engine.pigui
 local Vector2 = _G.Vector2
 
-local lc = Lang.GetResource("core");
+local lc = Lang.GetResource("core")
+local lui = Lang.GetResource("ui-core")
 
 -- get a fractional font factor
 local font_factor = ui.rescaleFraction(1, Vector2(1920, 1080))
@@ -336,7 +337,11 @@ ui.Format = {
 		end
 	end,
 	SystemPath = function(path)
-		return path:GetStarSystem().name.." ("..path.sectorX..", "..path.sectorY..", "..path.sectorZ..")"
+		local sectorString = "("..path.sectorX..", "..path.sectorY..", "..path.sectorZ..")"
+		if path:IsSectorPath() then
+			return lui.UNKNOWN_LOCATION_IN_SECTOR_X:interp{ sector = sectorString }
+		end
+		return path:GetStarSystem().name.." "..sectorString
 	end
 }
 

--- a/data/pigui/modules/info-view/06-flightlog.lua
+++ b/data/pigui/modules/info-view/06-flightlog.lua
@@ -30,7 +30,7 @@ local function writeLogEntry( entry, formatter, write_header )
 		formatter:write( entry:GetLocalizedName() ):newline()
 	end
 
-	for _, pair in pairs( entry:GetDataPairs( earliestFirst ) ) do
+	for _, pair in ipairs( entry:GetDataPairs( earliestFirst ) ) do
 		formatter:headerText( pair[1], pair[2] )
 	end
 end

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -196,6 +196,7 @@ local function startGame(gameParams)
 			logWarning("Wrong entry for the station flight log")
 		end
 	end
+	FlightLog.OrganizeEntries()
 
 	if gameParams.autoExec then
 		gameParams.autoExec()

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -124,6 +124,8 @@ local function startGame(gameParams)
 
 	-- setup player character
 	local PlayerCharacter = gameParams.player.char
+	PlayerCharacter.reputation = gameParams.player.reputation
+	PlayerCharacter.killcount = gameParams.player.kills
 	-- Gave the player a missions table (for Misssions.lua)
 	PlayerCharacter.missions = {}
 	-- Insert the player character into the persistent character

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -87,12 +87,10 @@ StartVariants.register({
 	colors     = { Color('E17F00'), Color('FFFFFF'), Color('FF7F00') }
 })
 
--- pass avalable space rect
-local function updateLayout(contentRegion)
-	Layout.updateLayout(contentRegion)
-
+-- synchronize parameter views with updated values
+local function updateParams()
 	for _, tab in ipairs(Layout.Tabs) do
-		tab:updateLayout()
+		if tab.updateParams then tab:updateParams() end
 	end
 end
 
@@ -222,7 +220,7 @@ local function drawBottomButtons()
 end
 
 -- wait a few frames, and then calculate the static layout (updateLayout)
-local initFrames = 3
+local initFrames = 2
 
 NewGameWindow = ModalWindow.New("New Game", function()
 
@@ -240,13 +238,8 @@ NewGameWindow = ModalWindow.New("New Game", function()
 				Crew.Player.Log.value = "Custom start of the game - for the purpose of debugging or cheat."
 			else
 				setStartVariant(StartVariants.item(ret + 1))
+				updateParams()
 			end
-			-- since setStartVariant can be called outside the ImGui frame, we
-			-- can't update the interface inside it. But we do not want to
-			-- check for data changes every frame, so we explicitly call the
-			-- update of the interface, while the amount of free space (content
-			-- region) is already known and does not change
-			updateLayout(Defs.contentRegion)
 		end
 
 		ui.separator()
@@ -257,7 +250,8 @@ NewGameWindow = ModalWindow.New("New Game", function()
 					-- consider the height of bottom buttons
 					drawBottomButtons()
 					-- at this point getContentRegion() exactly returns the size of the available space
-					updateLayout(ui.getContentRegion())
+					Layout.updateLayout(ui.getContentRegion())
+					updateParams()
 				end
 				initFrames = initFrames - 1
 			else

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -19,7 +19,6 @@ local laser = Equipment.laser
 
 local Defs = require 'pigui.modules.new-game-window.defs'
 local Layout = require 'pigui.modules.new-game-window.layout'
-local Crew = require 'pigui.modules.new-game-window.crew'
 local StartVariants = require 'pigui.modules.new-game-window.start-variants'
 local FlightLogParam = require 'pigui.modules.new-game-window.flight-log'
 local Game = require 'Game'
@@ -136,12 +135,9 @@ local function startGame(gameParams)
 
 	-- Generate crew for the starting ship
 	for _, member in ipairs(gameParams.crew) do
-		member.char.contract = {
-			wage = member.wage,
-			payday = gameParams.time + 604800, -- in a week
-			outstanding = 0
-		}
-		player:Enroll(member.char)
+		member.contract.payday = gameParams.time + 604800 -- in a week
+		member.contract.outstanding = 0
+		player:Enroll(member)
 	end
 
 	local eqSections = {

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -98,7 +98,6 @@ local function setStartVariant(variant)
 	for _, param in ipairs(Layout.UpdateOrder) do
 		param:fromStartVariant(variant)
 	end
-	Defs.currentStartVariant = variant
 end
 
 local function startGame(gameParams)

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -263,8 +263,8 @@ NewGameWindow = ModalWindow.New("New Game", function()
 				FlightLogParam.value.Custom = {{ text = "Custom start of the game - for the purpose of debugging or cheat." }}
 			else
 				setStartVariant(StartVariants.item(ret + 1))
-				updateParams()
 			end
+			updateParams()
 		end
 
 		ui.separator()
@@ -317,6 +317,18 @@ end
 
 NewGameWindow:setDebugMode(false)
 
-setStartVariant(StartVariants.item(1))
+local firstOpen = true
+function NewGameWindow:open()
+	if firstOpen or not self.debugMode then
+		firstOpen = false
+		setStartVariant(StartVariants.item(1))
+		profileCombo.selected = 0
+	end
+	if self.debugMode then
+		profileCombo.selected = #profileCombo.items - 1
+		Layout.setLock(false)
+	end
+	ModalWindow.open(self)
+end
 
 return NewGameWindow

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -170,9 +170,6 @@ local function startGame(gameParams)
 		cargoMgr:AddCommodity(Commodities[id], amount)
 	end
 
-	-- XXX horrible hack here to avoid paying a spawn-in docking fee
-	player:setprop("is_first_spawn", true)
-
 	for _, entry in ipairs(gameParams.flightlog.Custom) do
 		if FlightLog.InsertCustomEntry(entry) then
 			-- ok then

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -104,7 +104,11 @@ end
 local function startGame(gameParams)
 
 	-- space, ship in dock / orbit
-	Game.StartGame(gameParams.location.path, gameParams.time, gameParams.ship.type)
+	local startTime = gameParams.time
+	if startTime < 0 then
+		startTime = util.standardGameStartTime()
+	end
+	Game.StartGame(gameParams.location.path, startTime, gameParams.ship.type)
 	local player = Game.player
 
 	player:SetLabel(gameParams.ship.label)
@@ -137,7 +141,7 @@ local function startGame(gameParams)
 
 	-- Generate crew for the starting ship
 	for _, member in ipairs(gameParams.crew) do
-		member.contract.payday = gameParams.time + 604800 -- in a week
+		member.contract.payday = startTime + 604800 -- in a week
 		member.contract.outstanding = 0
 		player:Enroll(member)
 	end

--- a/data/pigui/modules/new-game-window/crew.lua
+++ b/data/pigui/modules/new-game-window/crew.lua
@@ -43,21 +43,6 @@ function PlayerChar:isValid()
 end
 
 --
--- player log
---
--- value: string
---
-local PlayerLog = GameParam.New(lui.LOG_CUSTOM, "player.log")
-
-function PlayerLog:fromStartVariant(variant)
-	self.value = variant.logmsg
-end
-
-function PlayerLog:isValid()
-	return true
-end
-
---
 -- player money
 --
 -- value: number
@@ -426,7 +411,6 @@ Crew.Player = {
 	Money = PlayerMoney,
 	Reputation = PlayerReputation,
 	Rating = PlayerRating,
-	Log = PlayerLog
 }
 
 return Crew

--- a/data/pigui/modules/new-game-window/crew.lua
+++ b/data/pigui/modules/new-game-window/crew.lua
@@ -32,7 +32,7 @@ function PlayerChar:random()
 end
 
 function PlayerChar:fromStartVariant(variant)
-	self:setLock(false)
+	self.lock = true
 end
 
 function PlayerChar:isValid()
@@ -59,7 +59,7 @@ end
 
 function PlayerMoney:fromStartVariant(variant)
 	PlayerMoney.value = variant.money
-	PlayerMoney:setLock(true)
+	PlayerMoney.lock = true
 end
 
 function PlayerMoney:isValid()
@@ -105,7 +105,7 @@ end
 
 function PlayerReputation:fromStartVariant(variant)
 	PlayerReputation.value = 0
-	PlayerReputation:setLock(true)
+	PlayerReputation.lock = true
 end
 
 function PlayerReputation:isValid()
@@ -121,6 +121,10 @@ local PlayerKills = GameParam.New(lui.KILLS, "player.kills")
 
 PlayerKills.value = 0
 
+-- We don’t want to show the kill counter to a new player at all, but if this
+-- is a save recovery, we will show it, but it will be locked
+PlayerKills.showKills = true
+
 -- create an array of levels corresponding to the given name of the interval
 -- the element must be less than its value -> greater than or equal to the previous value
 PlayerKills.values = { Character.combatRatings[2][2] - 5 }
@@ -134,13 +138,15 @@ for _, v in ipairs(Character.combatRatings) do
 end
 
 function PlayerKills:draw()
-	Widgets.alignLabel(lui.KILLS, Crew.layout, function()
-		local value, changed = Widgets.incrementDrag(self.lock, "##playerkills", self.value, 1, 0, 1e15, '%.0f')
-		if changed then
-			self.value = value
-			self.selected = utils.getIndexFromIntervals(Character.combatRatings, self.value)
-		end
-	end)
+	if not self.lock or self.showKills then
+		Widgets.alignLabel(lui.KILLS, Crew.layout, function()
+			local value, changed = Widgets.incrementDrag(self.lock, "##playerkills", self.value, 1, 0, 1e15, '%.0f')
+			if changed then
+				self.value = value
+				self.selected = utils.getIndexFromIntervals(Character.combatRatings, self.value)
+			end
+		end)
+	end
 	Widgets.alignLabel(lui.RATING, Crew.layout, function()
 		local changed, ret = Widgets.combo(self.lock, "##combatrating", self.selected - 1, self.names)
 		if changed then
@@ -155,8 +161,9 @@ function PlayerKills:random()
 end
 
 function PlayerKills:fromStartVariant(variant)
-	PlayerKills.value = 0
-	PlayerKills:setLock(true)
+	self.value = 0
+	self.lock = true
+	self.showKills = false
 end
 
 function PlayerKills:isValid()
@@ -414,7 +421,7 @@ function Crew:fromStartVariant(variant)
 --		createCrewMember()
 	}
 	Crew.currentChar = 1
-	Crew:setLock(true)
+	Crew.lock = true
 end
 
 Crew.TabName = lui.CREW

--- a/data/pigui/modules/new-game-window/crew.lua
+++ b/data/pigui/modules/new-game-window/crew.lua
@@ -89,8 +89,6 @@ for _, v in ipairs(Character.reputations) do
 	table.insert(PlayerReputation.names, lui[v[1]])
 end
 
-PlayerReputation.selected = utils.getIndexFromIntervals(Character.reputations, PlayerReputation.value)
-
 function PlayerReputation:draw()
 	Widgets.alignLabel(lui.REPUTATION, self.layout, function()
 		local changed, ret = Widgets.combo(self.lock, "##reputation", self.selected - 1, self.names)
@@ -115,29 +113,34 @@ function PlayerReputation:isValid()
 end
 
 --
--- player combat rating
+-- player combat killcount
 --
 -- value: number
 --
-local PlayerRating = GameParam.New(lui.RATING, "player.rating")
+local PlayerKills = GameParam.New(lui.KILLS, "player.kills")
 
-PlayerRating.value = 0
+PlayerKills.value = 0
 
 -- create an array of levels corresponding to the given name of the interval
 -- the element must be less than its value -> greater than or equal to the previous value
-PlayerRating.values = { Character.combatRatings[2][2] - 5 }
+PlayerKills.values = { Character.combatRatings[2][2] - 5 }
 for i = 2, #Character.combatRatings do
-	table.insert(PlayerRating.values, Character.combatRatings[i][2])
+	table.insert(PlayerKills.values, Character.combatRatings[i][2])
 end
 
-PlayerRating.names = {}
+PlayerKills.names = {}
 for _, v in ipairs(Character.combatRatings) do
-	table.insert(PlayerRating.names, lui[v[1]])
+	table.insert(PlayerKills.names, lui[v[1]])
 end
 
-PlayerRating.selected = utils.getIndexFromIntervals(Character.combatRatings, PlayerRating.value)
-
-function PlayerRating:draw()
+function PlayerKills:draw()
+	Widgets.alignLabel(lui.KILLS, Crew.layout, function()
+		local value, changed = Widgets.incrementDrag(self.lock, "##playerkills", self.value, 1, 0, 1e15, '%.0f')
+		if changed then
+			self.value = value
+			self.selected = utils.getIndexFromIntervals(Character.combatRatings, self.value)
+		end
+	end)
 	Widgets.alignLabel(lui.RATING, Crew.layout, function()
 		local changed, ret = Widgets.combo(self.lock, "##combatrating", self.selected - 1, self.names)
 		if changed then
@@ -147,16 +150,16 @@ function PlayerRating:draw()
 	end)
 end
 
-function PlayerRating:random()
+function PlayerKills:random()
 	self.value = utils.chooseEqual(self.values)
 end
 
-function PlayerRating:fromStartVariant(variant)
-	PlayerRating.value = 0
-	PlayerRating:setLock(true)
+function PlayerKills:fromStartVariant(variant)
+	PlayerKills.value = 0
+	PlayerKills:setLock(true)
 end
 
-function PlayerRating:isValid()
+function PlayerKills:isValid()
 	return self.value >= 0 and self.value < 10000
 end
 
@@ -277,7 +280,7 @@ function Crew:drawMember(memberEntry)
 			end)
 			if memberEntry.value.player then
 				PlayerMoney:draw()
-				PlayerRating:draw()
+				PlayerKills:draw()
 				PlayerReputation:draw()
 			else
 				local member = memberEntry.value
@@ -393,6 +396,8 @@ end
 
 function Crew:updateParams()
 	self:fillCrewListTable()
+	PlayerReputation.selected = utils.getIndexFromIntervals(Character.reputations, PlayerReputation.value)
+	PlayerKills.selected = utils.getIndexFromIntervals(Character.combatRatings, PlayerKills.value)
 end
 
 function Crew:draw()
@@ -417,7 +422,7 @@ Crew.Player = {
 	Char = PlayerChar,
 	Money = PlayerMoney,
 	Reputation = PlayerReputation,
-	Rating = PlayerRating,
+	Kills = PlayerKills,
 }
 
 return Crew

--- a/data/pigui/modules/new-game-window/crew.lua
+++ b/data/pigui/modules/new-game-window/crew.lua
@@ -396,9 +396,11 @@ function Crew:updateLayout()
 		})
 	end
 
-	self:updateTableItems()
-
 	self.list.style.size = Vector2(namesWidth, Defs.contentRegion.y)
+end
+
+function Crew:updateParams()
+	self:updateTableItems()
 end
 
 function Crew:draw()
@@ -407,11 +409,6 @@ function Crew:draw()
 		ui.sameLine()
 		self:drawMember(self.list.selectedItem)
 	end
-end
-
-function Crew:setLock(lock)
-	GameParam.setLock(self, lock)
-	self:updateTableItems()
 end
 
 function Crew:fromStartVariant(variant)

--- a/data/pigui/modules/new-game-window/defs.lua
+++ b/data/pigui/modules/new-game-window/defs.lua
@@ -8,7 +8,6 @@ Defs.mainFont = ui.fonts.pionillium.medlarge
 Defs.subFont = ui.fonts.pionillium.medium
 Defs.scrollWidth = Defs.mainFont.size
 Defs.winSize = Vector2(Defs.mainFont.size * 60, Defs.mainFont.size * 40)
-Defs.currentStartVariant = {}
 
 Defs.rand = require 'Rand'.New()
 Defs.charParams = { 'luck', 'intelligence', 'charisma', 'notoriety', 'lawfulness', 'engineering', 'piloting', 'navigation', 'sensors' }

--- a/data/pigui/modules/new-game-window/flight-log.lua
+++ b/data/pigui/modules/new-game-window/flight-log.lua
@@ -1,0 +1,152 @@
+-- Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txtl
+
+local ui = require 'pigui'
+local Lang = require 'Lang'
+local lui = Lang.GetResource("ui-core")
+local Format = require 'Format'
+
+local Defs = require 'pigui.modules.new-game-window.defs'
+local GameParam = require 'pigui.modules.new-game-window.game-param'
+local Location = require 'pigui.modules.new-game-window.location'
+
+local FlightLog = GameParam.New(lui.FLIGHT_LOG, "flightlog")
+
+FlightLog.value = {
+	Custom = {},
+	System = {},
+	Station = {}
+}
+
+FlightLog.version = 1
+
+function FlightLog:fromStartVariant(variant)
+	self.value.System = {}
+	self.value.Station = {}
+	self.value.Custom = {
+		{
+			text = variant.logmsg
+		}
+	}
+end
+
+-- Title text is gray, followed by the variable text:
+local function headerText(title, text, wrap)
+	if not text then return end
+	ui.textColored(ui.theme.colors.grey, string.gsub(title, ":", "") .. ":")
+	ui.sameLine()
+	if wrap then
+		ui.textWrapped(text)
+	else
+		ui.text(text)
+	end
+end
+
+local function asFaction(path)
+	if path:IsSectorPath() then return lui.UNKNOWN_FACTION end
+	return Location:getGalaxy():GetStarSystem(path).faction.name
+end
+
+local function asStation(path)
+	if not path:IsBodyPath() then return lui.NO_AVAILABLE_DATA end
+	local system = Location:getGalaxy():GetStarSystem(path)
+	local systembody = system:GetBodyByPath(path)
+	local station_type = "FLIGHTLOG_" .. systembody.type
+	return string.interp(lui[station_type], {
+		primary_info = systembody.name,
+		secondary_info = systembody.parent.name
+	})
+end
+
+local function asPath(path)
+	local sectorString = "(" .. path.sectorX .. ", " .. path.sectorY .. ", " .. path.sectorZ .. ")"
+	if path:IsSectorPath() then
+		return lui.UNKNOWN_LOCATION_IN_SECTOR_X:interp{ sector = sectorString }
+	end
+	local system = Location:getGalaxy():GetStarSystem(path)
+	return system.name .. " " .. sectorString
+end
+
+-- Based on flight state, compose a reasonable string for location
+local function composeLocationString(location)
+	return string.interp(lui["FLIGHTLOG_"..location[1]], {
+		primary_info = location[2],
+		secondary_info = location[3] or "",
+		tertiary_info = location[4] or "",
+	})
+end
+
+local cbCurrentValue = 0
+local cbValues = { lui.LOG_CUSTOM, lui.LOG_SYSTEM, lui.LOG_STATION }
+local sections = { [0] = "Custom", [1] = "System", [2] = "Station" }
+local entryTemplates = {
+	Custom = {
+		{ id = "time",     label = lui.DATE,           render = Format.Date },
+		{ id = "location", label = lui.LOCATION,       render = composeLocationString },
+		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
+		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
+		{ id = "money",    label = lui.CASH,           render = Format.Money },
+		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+	},
+	System = {
+		{ id = "arrtime",  label = lui.ARRIVAL_DATE,   render = Format.Date },
+		{ id = "deptime",  label = lui.DEPARTURE_DATE, render = Format.Date },
+		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
+		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
+		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+	},
+	Station = {
+		{ id = "time",     label = lui.DATE,           render = Format.Date },
+		{ id = "path",     label = lui.STATION,        render = asStation },
+		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
+		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
+		{ id = "money",    label = lui.CASH,           render = Format.Money },
+		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+	},
+}
+
+local function renderEntry(template, entry)
+	for _, param in ipairs(template) do
+		local value = entry[param.id]
+		if value and value ~= "" then -- do not show an empty entry too
+			headerText(param.label, param.render(value), param.wrap)
+		end
+	end
+end
+
+function FlightLog:draw()
+	local h = ui.getCursorPos().y
+	local changed, newValue = ui.combo("##select_log", cbCurrentValue, cbValues)
+	if changed then cbCurrentValue = newValue end
+
+	local section = sections[cbCurrentValue]
+	local entries = self.value[section]
+
+	ui.separator()
+
+	h = ui.getCursorPos().y - h
+	ui.child("flightlog", Vector2(Defs.contentRegion.x, Defs.contentRegion.y - h), function()
+		if #entries == 0 then
+			ui.text(lui.NONE)
+			return
+		end
+		-- draw separators only between elements
+		local sep = function() end
+		for _, entry in ipairs(entries) do
+			sep()
+			renderEntry(entryTemplates[section], entry)
+			sep = ui.separator
+		end
+	end)
+end
+
+FlightLog.updateLayout = false
+FlightLog.updateView = false
+
+function FlightLog:isValid()
+	return true
+end
+
+FlightLog.TabName = lui.FLIGHT_LOG
+
+return FlightLog

--- a/data/pigui/modules/new-game-window/game-param.lua
+++ b/data/pigui/modules/new-game-window/game-param.lua
@@ -25,10 +25,6 @@ function GameParam:fromSaveGame(saveGame)    assert(false, tostring(self.name) .
 function GameParam:fromStartVariant(variant) assert(false, tostring(self.name) .. ":fromStartVariant() Should be overridden.") end
 
 
-function GameParam:setLock(value)
-	self.lock = value
-end
-
 function GameParam:isEmpty()
 	return not self.value
 end

--- a/data/pigui/modules/new-game-window/game-param.lua
+++ b/data/pigui/modules/new-game-window/game-param.lua
@@ -2,6 +2,7 @@
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local utils = require 'utils'
+local Helpers = require 'pigui.modules.new-game-window.helpers'
 
 ---@class NewGameWindow.GameParam
 local GameParam = utils.class("pigui.modules.new-game-window.game-param")
@@ -21,9 +22,35 @@ end
 
 function GameParam:isValid()                 assert(false, tostring(self.name) .. ":isValid() should be overridden.") end
 function GameParam:draw()                    assert(false, tostring(self.name) .. ":draw() Should be overridden.") end
-function GameParam:fromSaveGame(saveGame)    assert(false, tostring(self.name) .. ":fromSave() Should be overridden.") end
 function GameParam:fromStartVariant(variant) assert(false, tostring(self.name) .. ":fromStartVariant() Should be overridden.") end
 
+-- A versioned function that tries to read data from saveGame.
+-- either returns the value of the parameter, or nil and an error string
+--
+-- If in the next version the GameParam.value does not change, but is just
+-- taken from another place(s) in saveFile document, you can simply define a
+-- new reader. For older saves, older readers will be used.
+--
+-- If the meaning and content of the GameParam.value changes, there are 2 ways
+-- - either fix all existing old reader versions so that they generate a value
+-- of a new structure, or create a "patch", a procedure that changes the older
+-- document so that a new reader can read it. In the second case, all old
+-- readers (since they are not compatible in value with the new reader), must
+-- be removed from this array. Old readers can be reused when creating a patch.
+GameParam.reader = Helpers.versioned {{
+	version = 1,
+	fnc = function(_)
+		assert(false, "No saveGame readers")
+	end
+}}
+
+---@param saveGame table
+---@return string? errorString
+function GameParam:fromSaveGame(saveGame)
+	local value, errorString = self.reader(saveGame)
+	if errorString then return errorString end
+	self.value = value
+end
 
 function GameParam:isEmpty()
 	return not self.value

--- a/data/pigui/modules/new-game-window/helpers.lua
+++ b/data/pigui/modules/new-game-window/helpers.lua
@@ -1,0 +1,194 @@
+-- Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txtl
+
+local lui = require 'Lang'.GetResource("ui-core")
+
+local Helpers = {}
+
+-- Given a number (version), select the most suitable function from the array
+-- and run it with the arguments passed. The smallest version is selected, no
+-- less than given. Or the largest if all versions in the array are less than
+-- given. Functions are assumed to be sorted in ascending order of versions
+---@param version number
+---@param fncList table array of tables { version: number, fnc: function }
+---@param ... any
+---@return any ...
+local function runVersioned(version, fncList, ...)
+	local i = #fncList
+	while i > 1 and fncList[i].version > version do
+		i = i - 1
+	end
+	return fncList[i].fnc(...)
+end
+
+
+--
+-- Function: Helpers.versioned
+--
+-- Creates a versioned function. When called, depending on
+-- Helpers.implicitVersion, the appropriate version is launched.
+--
+-- Example:
+--
+-- > Helpers.isPickled = Helpers.versioned {{
+-- > 	version = 89,
+-- > 	fnc = function(tbl)
+-- > 		return tbl and tbl.table
+-- > 	end
+-- > }}
+--
+-- Parameters:
+--
+-- fncList - table, array of tables { version: number, fnc: function }
+--
+-- Returns:
+--
+-- value - function
+--
+---@param fncList table array of tables { version: number, fnc: function }
+---@return function value
+function Helpers.versioned(fncList)
+	return function(...)
+		assert(Helpers.implicitVersion)
+		return runVersioned(Helpers.implicitVersion, fncList, ...)
+	end
+end
+
+
+--
+-- Function: Helpers.getByPath
+--
+-- Looks for an element in the table, sequentially obtaining indices from the
+-- provided string and checking for their presence.
+--
+-- If the key looks like $N, return the N-th value from pairs(table). In fact,
+-- it is used as $1 when there is only one element in the table, but the key
+-- there is a complex table.
+-- If the key starts with #, it is read as a number
+--
+-- Example:
+--
+-- > myTable = { section = { subsection = { key1 = 'value1', key2 = 'value2' }}}
+-- > value, errorString = Helpers.getByPath(myTable, 'section/subsection/key2')
+-- > assert(errorString == nil)
+-- > assert(value == 'value2')
+--
+-- Parameters:
+--
+--   tbl - table
+--   path - string|table, see example
+--   verify - function?
+--
+-- Returns:
+--
+--  value - any?
+--  errorString - string?
+--
+---@param tbl table
+---@param path string|table see example
+---@param verify function?
+---@return any? value
+---@return string? errorString
+function Helpers.getByPath(tbl, path, verify)
+	assert(Helpers.implicitVersion)
+	-- list of paths - return on first successful
+	if type(path) == 'table' then
+		local value
+		local wholeErrorString = ""
+		local sep = ""
+		for _, item in ipairs(path) do
+			local errorString
+			value, errorString = Helpers.getByPath(tbl, item, verify)
+			if value then return value end
+			wholeErrorString = wholeErrorString .. sep .. errorString
+			sep = ",\n    "
+		end
+		return nil, wholeErrorString
+	end
+
+	local currentPath = ""
+	local sep = ""
+	for token in string.gmatch(path, "[^/]+") do
+		currentPath = currentPath .. sep .. token
+		sep = '/'
+		if token:sub(1, 1) == '$' then
+			local i = tonumber(token:sub(2, -1))
+			for _, v in pairs(tbl) do
+				if i == 1 then
+					tbl = v
+					break
+				end
+				i = i - 1
+			end
+			if i ~= 1 then return nil, string.format(lui.CANT_FIND_PATH, currentPath) end
+		elseif token:sub(1, 1) == '#' then
+			tbl = tbl[tonumber(token:sub(2, -1))]
+		else
+			tbl = tbl[token]
+		end
+		if not tbl then return nil, string.format(lui.CANT_FIND_PATH, currentPath) end
+	end
+	if verify and not verify(tbl) then
+		return nil, string.format(lui.PATH_FOUND_BUT_VERIFICATION_FAILED, path)
+	end
+	return tbl
+end
+
+
+---@param saveGame table
+---@return table?
+---@return string? errorString
+local function findPlayerShip(saveGame)
+	local bodies, errorString = Helpers.getByPath(saveGame, "space/bodies")
+	local playerShip
+	local bodyTypePlayer = saveGame.version > 86 and 4 or 5
+	if errorString then return nil, errorString end
+	for _, body in ipairs(bodies) do
+		if body.body_type == bodyTypePlayer then
+			if playerShip then
+				return nil, lui.MORE_THAN_ONE_PLAYERS_SHIP_FOUND_IN_SPACE
+			else
+				playerShip = body
+			end
+		end
+	end
+	if playerShip then return playerShip end
+	return nil, lui.CANT_FIND_PLAYERS_SHIP_IN_SPACE
+end
+
+
+--
+-- Function: Helpers.getPlayerShipParameter
+--
+-- Finds the player's ship in the saved space and pulls out a parameter from it
+-- according to the specified path.
+--
+-- Example:
+--
+-- > local shipID, errorString = Helpers.getPlayerShipParameter(saveGame, "model_body/model_name")
+--
+-- Parameters:
+--
+--   saveGame - table
+--   paramPath - string
+--
+-- Returns:
+--
+--   value - any?
+--   errorString - string?, if it is not nil, an error occurred
+--
+---@param saveGame table
+---@param paramPath string
+---@return any? value
+---@return string? errorString if it is not nil, an error occurred
+function Helpers.getPlayerShipParameter(saveGame, paramPath)
+	local playerShip, errorString = findPlayerShip(saveGame)
+	if errorString then return nil, errorString end
+	assert(playerShip)
+	local param
+	param, errorString = Helpers.getByPath(playerShip, paramPath)
+	if errorString then return nil, errorString end
+	return param
+end
+
+return Helpers

--- a/data/pigui/modules/new-game-window/layout.lua
+++ b/data/pigui/modules/new-game-window/layout.lua
@@ -15,7 +15,7 @@ Layout.UpdateOrder = {
 	Crew.Player.Char,
 	Crew.Player.Money,
 	Crew.Player.Reputation,
-	Crew.Player.Rating,
+	Crew.Player.Kills,
 	Crew,
 	Ship.Type,
 	Ship.Name,

--- a/data/pigui/modules/new-game-window/layout.lua
+++ b/data/pigui/modules/new-game-window/layout.lua
@@ -6,6 +6,7 @@ local Crew = require 'pigui.modules.new-game-window.crew'
 local Ship = require 'pigui.modules.new-game-window.ship'
 local Location = require 'pigui.modules.new-game-window.location'
 local Summary = require 'pigui.modules.new-game-window.summary'
+local FlightLog = require 'pigui.modules.new-game-window.flight-log'
 
 local Layout = {}
 
@@ -15,7 +16,6 @@ Layout.UpdateOrder = {
 	Crew.Player.Money,
 	Crew.Player.Reputation,
 	Crew.Player.Rating,
-	Crew.Player.Log,
 	Crew,
 	Ship.Type,
 	Ship.Name,
@@ -25,10 +25,11 @@ Layout.UpdateOrder = {
 	Ship.Equip,
 	Ship.Fuel,
 	Location,
-	Location.Time
+	Location.Time,
+	FlightLog
 }
 
-Layout.Tabs = { Summary, Crew, Ship, Location }
+Layout.Tabs = { Summary, Crew, Ship, Location, FlightLog }
 
 function Layout.updateLayout(contentRegion)
 

--- a/data/pigui/modules/new-game-window/layout.lua
+++ b/data/pigui/modules/new-game-window/layout.lua
@@ -35,7 +35,7 @@ function Layout.updateLayout(contentRegion)
 	Defs.updateLayoutValues(contentRegion)
 
 	for _, tab in ipairs(Layout.Tabs) do
-		tab:updateLayout()
+		if tab.updateLayout then tab:updateLayout() end
 	end
 end
 

--- a/data/pigui/modules/new-game-window/layout.lua
+++ b/data/pigui/modules/new-game-window/layout.lua
@@ -42,7 +42,7 @@ end
 
 function Layout.setLock(lock)
 	for _, param in ipairs(Layout.UpdateOrder) do
-		param:setLock(lock)
+		param.lock = lock
 	end
 end
 

--- a/data/pigui/modules/new-game-window/layout.lua
+++ b/data/pigui/modules/new-game-window/layout.lua
@@ -26,7 +26,8 @@ Layout.UpdateOrder = {
 	Ship.Fuel,
 	Location,
 	Location.Time,
-	FlightLog
+	FlightLog,
+	Summary.Description
 }
 
 Layout.Tabs = { Summary, Crew, Ship, Location, FlightLog }

--- a/data/pigui/modules/new-game-window/location.lua
+++ b/data/pigui/modules/new-game-window/location.lua
@@ -137,7 +137,7 @@ function Location:setPath(path)
 
 	self.value.path = path
 
-	self.sysCombo = { systems = self.galaxy:GetSector(path.sectorX, path.sectorY, path.sectorZ), labels = {}, selected = 0 }
+	self.sysCombo = { systems = self:getGalaxy():GetSector(path.sectorX, path.sectorY, path.sectorZ), labels = {}, selected = 0 }
 	for _, system in ipairs(self.sysCombo.systems) do
 		table.insert(self.sysCombo.labels, system.name)
 	end

--- a/data/pigui/modules/new-game-window/location.lua
+++ b/data/pigui/modules/new-game-window/location.lua
@@ -8,6 +8,7 @@ local Lang = require 'Lang'
 local lc = Lang.GetResource("core")
 local lui = Lang.GetResource("ui-core")
 
+local Helpers = require 'pigui.modules.new-game-window.helpers'
 local Widgets = require 'pigui.modules.new-game-window.widgets'
 local SectorMap = require 'SectorMap'
 local SystemPath = require 'SystemPath'
@@ -99,6 +100,15 @@ function Time:isValid()
 	-- more negative time is something weird
 	return self.value >= -2
 end
+
+Time.reader = Helpers.versioned {{
+	version = 89,
+	fnc = function(saveGame)
+		local time, errorString = Helpers.getByPath(saveGame, "time")
+		if errorString then return nil, errorString end
+		return time
+	end
+}}
 
 --
 -- location
@@ -199,11 +209,11 @@ function Location:updateLayout()
 		width = Defs.contentRegion.x - mapLayout.width - ui.getItemSpacing().x
 	}
 	if not self.map then self:initMap() end
+	self.map:SetSize(Vector2(mapLayout.width, mapLayout.height))
 end
 
 function Location:initMap()
 	self.map = SectorMap(function (path) self:onClickSystem(path) end)
-	self.map:SetSize(Vector2(mapLayout.width, mapLayout.height))
 	self.galaxy = self.map:GetGalaxy()
 	self.overview = SystemOverviewWidget.New()
 	self.overview.onBodySelected = function(_, sbody, _)
@@ -289,6 +299,79 @@ end
 function Location:updateParams()
 	self:setPath(self.value.path)
 end
+
+---@param id number
+---@param frame table
+---@return number?
+local function getSystemBodyIndexForFrameID(id, frame)
+	if id == frame.frameId then
+		return frame.index_for_system_body
+	end
+	if not frame.child_frames then
+		return nil
+	end
+	for _, childFrame in pairs(frame.child_frames) do
+		local sbi = getSystemBodyIndexForFrameID(id, childFrame)
+		if sbi then return sbi end
+	end
+end
+
+Location.reader = Helpers.versioned {{
+	version = 89,
+	fnc = function(saveGame)
+
+		local system, errorString = Helpers.getByPath(saveGame, "space/star_system")
+		if errorString then return nil, errorString end
+
+		local path = SystemPath.New(system.sector_x, system.sector_y, system.sector_z, system.system_index)
+		local sector = Location:getGalaxy():GetSector(path.sectorX, path.sectorY, path.sectorZ)
+		if path.systemIndex >= #sector then
+			return nil, "Bad system index"
+		end
+
+		-- the indices of the bodies and the corresponding system bodies
+		-- (Space::m_bodyIndex and Space::m_sbodyIndex) turn out to be the same
+		local dockedTo
+		dockedTo, errorString = Helpers.getPlayerShipParameter(saveGame, "ship/index_for_body_docked_with")
+		if errorString then return nil, errorString end
+
+		if dockedTo ~= 0 then
+			-- All we have in the save doc is the index of the physical body
+			-- with which the player was docked when saving. This index is
+			-- created when space is serialized. In order to get a system path
+			-- from this, it would be necessary to initialize the space,
+			-- establishing connections between physical and system bodies.
+			-- Fortunately, in this version, indexing during serialization
+			-- occurs in such a way that physical body index is 1 greater than
+			-- the index of the body in the corresponding system path
+			dockedTo = dockedTo - 1
+			local starSystem = Location:getGalaxy():GetStarSystem(path)
+			if dockedTo >= starSystem.numberOfBodies then
+				return nil, lui.SYSTEM_BODY_INDEX_IS_OUT_OF_RANGE
+			end
+			local bodyPath = SystemPath.New(path.sectorX, path.sectorY, path.sectorZ, path.systemIndex, dockedTo)
+			local systemBody = starSystem:GetBodyByPath(bodyPath)
+			if systemBody.isStation then
+				return { path = bodyPath, state = State.DOCKED }
+			else
+				return nil, lui.DOCKED_TO_A_BODY_THAT_IS_NOT_A_STATION
+			end
+		end
+
+		local frameID, frameTree
+		frameID, errorString = Helpers.getPlayerShipParameter(saveGame, "body/index_for_frame")
+		frameTree, errorString = Helpers.getByPath(saveGame, "space/frame")
+		if errorString then return nil, errorString end
+
+		local systemBodyIndex = getSystemBodyIndexForFrameID(frameID, frameTree)
+		if not systemBodyIndex then
+			return nil, lui.COULD_NOT_FIND_SYSTEM_BODY_FOR_FRAME
+		end
+
+		local bodyPath = SystemPath.New(path.sectorX, path.sectorY, path.sectorZ, path.systemIndex, systemBodyIndex - 1)
+		return { path = bodyPath, state = State.ORBIT }
+	end
+}}
 
 Location.Time = Time
 Location.TabName = lui.LOCATION

--- a/data/pigui/modules/new-game-window/location.lua
+++ b/data/pigui/modules/new-game-window/location.lua
@@ -201,7 +201,6 @@ function Location:updateLayout()
 		width = Defs.contentRegion.x - mapLayout.width - ui.getItemSpacing().x
 	}
 	if not self.map then self:initMap() end
-	self:setPath(self.value.path)
 end
 
 function Location:initMap()
@@ -282,6 +281,10 @@ end
 
 function Location:isValid()
 	return self.bodySelected and true or false
+end
+
+function Location:updateParams()
+	self:setPath(self.value.path)
 end
 
 Location.Time = Time

--- a/data/pigui/modules/new-game-window/location.lua
+++ b/data/pigui/modules/new-game-window/location.lua
@@ -213,6 +213,11 @@ function Location:initMap()
 	end
 end
 
+function Location:getGalaxy()
+	if not self.map then self:initMap() end
+	return self.galaxy
+end
+
 function Location:draw()
 
 	if not self.map then return end

--- a/data/pigui/modules/new-game-window/location.lua
+++ b/data/pigui/modules/new-game-window/location.lua
@@ -92,7 +92,7 @@ end
 function Time:fromStartVariant(variant)
 	self.value = 0
 	self.standard = true
-	self:setLock(true)
+	self.lock = true
 end
 
 function Time:isValid()
@@ -281,7 +281,7 @@ function Location:fromStartVariant(variant)
 		path = variant.location,
 		state = State.UNKNOWN
 	}
-	self:setLock(true)
+	self.lock = true
 end
 
 function Location:isValid()

--- a/data/pigui/modules/new-game-window/recovery.lua
+++ b/data/pigui/modules/new-game-window/recovery.lua
@@ -1,0 +1,130 @@
+-- Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Json = require 'Json'
+local Lang = require 'Lang'
+local lui = Lang.GetResource("ui-core")
+local Helpers = require 'pigui.modules.new-game-window.helpers'
+
+local Recovery = {}
+
+-- patch
+--    from - number (version)
+--    to - number (version)
+--    apply(gameDoc) -> errorString? - function that modifies whole gameDoc
+--
+--    it is assumed that the patches are arranged in the array in ascending
+--    order of versions, and do not intersect
+Recovery.Patches = {}
+
+-- no patches yes
+
+-- Fix up all contained table references
+--
+-- The order and location a table value definition is serialized in is
+-- non-deterministic and any JSON value encoding a reference to a specific
+-- table value may potentially be the one in which that table is serialized to.
+local fixupDoc = Helpers.versioned {{
+	version = 89,
+	fnc = function(gameDoc)
+
+		local refs = {}
+
+		local function unpickle(tbl)
+			local result = {}
+			tbl = tbl.table
+			for i = 1, #tbl, 2 do
+				result[tbl[i]] = tbl[i + 1]
+			end
+			return result
+		end
+
+		-- get refs and unpickle 1 level
+		local function getRefs(tbl)
+			if type(tbl) ~= 'table' then return end
+			if tbl.ref and tbl.table and not refs[tbl.ref] then
+				refs[tbl.ref] = unpickle(tbl)
+			end
+			for k, v in pairs(tbl) do
+				getRefs(k)
+				getRefs(v)
+			end
+		end
+
+		local function putRefs(tbl, cache)
+			if type(tbl) ~= 'table' then return tbl end
+
+			if cache[tbl] then return cache[tbl] end
+			if cache[tbl.ref] then return cache[tbl.ref] end
+
+			local result = {}
+			if tbl.ref then
+				cache[tbl.ref] = result
+				tbl = refs[tbl.ref]
+			else
+				cache[tbl] = result
+			end
+
+			for k, v in pairs(tbl) do
+				result[ putRefs(k, cache) ] = putRefs(v, cache)
+			end
+			return result
+		end
+
+		-- circular references are possible after putRefs
+		local function countRefs(tbl, cache)
+			if type(tbl) ~= 'table' then return 0 end
+			if cache[tbl] then return 0 end
+			cache[tbl] = true
+			local counter = 0
+			if tbl.ref and not tbl.table then
+				counter = counter + 1
+			end
+			for k, v in pairs(tbl) do
+				counter = counter + countRefs(v, cache) + countRefs(k, cache)
+			end
+			return counter
+		end
+
+		getRefs(gameDoc)
+		local countBefore = countRefs(gameDoc, {})
+		gameDoc = putRefs(gameDoc, {})
+		local countAfter = countRefs(gameDoc, {})
+
+		if countAfter ~= 0 then
+			print("fixupDoc failed: " .. tostring(countAfter) .. " of " .. tostring(countBefore) .. " refs were not resolved.")
+			return nil
+		end
+
+		return gameDoc
+	end
+}}
+
+-- the function returns the full game save document patched to the supported
+-- version or a string with an error
+function Recovery.loadDoc(saveName)
+	local gameDoc = Json.LoadSaveFile(saveName)
+	if not gameDoc then
+		return lui.COULD_NOT_LOAD_GAME .. " (" .. tostring(saveName) .. ")"
+	end
+	local version = gameDoc.version
+	if not version then
+		return lui.COULD_NOT_READ_THE_SAVE_VERSION
+	end
+	for _, patch in ipairs(Recovery.Patches) do
+		if patch.from >= version then
+			local errorString = patch.apply(gameDoc)
+			if errorString then
+				return lui.ERROR_APPLYING_PATCH ..  " (" ..  tostring(patch.from) .. " -> " .. tostring(patch.to) .. "): " .. errorString
+			end
+		end
+	end
+	Helpers.implicitVersion = gameDoc.version
+	gameDoc = fixupDoc(gameDoc)
+	if not gameDoc then
+		return lui.COULD_NOT_LOAD_GAME .. " (" .. tostring(saveName) .. ")"
+	end
+	return gameDoc
+end
+
+return Recovery

--- a/data/pigui/modules/new-game-window/ship.lua
+++ b/data/pigui/modules/new-game-window/ship.lua
@@ -72,7 +72,7 @@ end
 
 function ShipType:fromStartVariant(variant)
 	self:setShipID(variant.shipType)
-	self:setLock(true)
+	self.lock = true
 end
 
 function ShipType:isValid()
@@ -99,7 +99,7 @@ end
 
 function ShipName:fromStartVariant(variant)
 	self.value = ShipNames.generateRandom()
-	self:setLock(false)
+	self.lock = false
 end
 
 function ShipName:isValid()
@@ -126,7 +126,7 @@ end
 
 function ShipLabel:fromStartVariant(--[[variant]])
 	self.value = ShipObject.MakeRandomLabel()
-	self:setLock(true)
+	self.lock = false
 end
 
 function ShipLabel:isValid()
@@ -153,7 +153,7 @@ end
 
 function ShipFuel:fromStartVariant(--[[variant]])
 	self.value = 100
-	self:setLock(true)
+	self.lock = true
 end
 
 function ShipFuel:isValid()
@@ -220,7 +220,7 @@ function ShipModel:fromStartVariant(variant)
 	end
 	self.value.pattern = variant.pattern
 	self:updateModel()
-	self:setLock(true)
+	self.lock = true
 end
 
 function ShipModel:isValid()
@@ -321,7 +321,7 @@ function ShipCargo:fromStartVariant(variant)
 		self.value[entry[1].name] = entry[2]
 	end
 	self:updateDrawItems()
-	self:setLock(true)
+	self.lock = true
 end
 --
 -- to_remove: table { x1 = true, ... }
@@ -735,7 +735,7 @@ function ShipEquip:fromStartVariant(variant)
 		end
 	end
 	self:update()
-	self:setLock(true)
+	self.lock = true
 end
 
 function ShipEquip:isValid()

--- a/data/pigui/modules/new-game-window/summary.lua
+++ b/data/pigui/modules/new-game-window/summary.lua
@@ -33,7 +33,7 @@ function Summary:draw()
 	local player = Crew.Player.Char.value
 
 	ui.child("leftside", Vector2(layout.leftWidth, Defs.contentRegion.y), function()
-		local player_member = Crew.Player.Char.crewEntry
+		local player_member = Crew.Player.Char
 		Crew:initMemberFace(player_member)
 		ui.child("face", Vector2(layout.picsize, layout.picsize), function()
 			player_member.face:renderFaceDisplay()

--- a/data/pigui/modules/new-game-window/summary.lua
+++ b/data/pigui/modules/new-game-window/summary.lua
@@ -7,6 +7,7 @@ local Ship = require 'pigui.modules.new-game-window.ship'
 local Defs = require 'pigui.modules.new-game-window.defs'
 local Format = require 'Format'
 local Widgets = require 'pigui.modules.new-game-window.widgets'
+local GameParam = require 'pigui.modules.new-game-window.game-param'
 local ShipDef = require 'ShipDef'
 local Lang = require 'Lang'
 local lui = Lang.GetResource("ui-core")
@@ -15,6 +16,23 @@ local leq = Lang.GetResource("equipment-core")
 local Summary = {}
 
 local layout = {}
+
+local Description = GameParam.New(lui.DESCRIPTION, "description")
+
+function Description:fromStartVariant(variant)
+	self.value = variant.desc
+end
+
+function Description:isValid()
+	return true
+end
+
+function Description:fromSaveGame(saveGame)
+	self.value = lui.RECOVER_SAVEGAME
+end
+
+---@type string
+Description.value = ""
 
 function Summary:updateLayout()
 	layout.picsize = Defs.mainFont.size * 12
@@ -63,9 +81,8 @@ function Summary:draw()
 	ui.child("rightside", Vector2(layout.rightWidth - Defs.scrollWidth, Defs.contentRegion.y), function()
 
 		ui.text("")
-		local startDesc = Defs.currentStartVariant.desc
-		if startDesc and startDesc ~= "" then
-			ui.textWrapped(startDesc)
+		if Description.value and Description.value ~= "" then
+			ui.textWrapped(Description.value)
 			ui.text("")
 		end
 		Widgets.alignLabel(lui.HYPERDRIVE, layout.shipParam, function()
@@ -99,5 +116,6 @@ function Summary:draw()
 end
 
 Summary.TabName = lui.SUMMARY
+Summary.Description = Description
 
 return Summary

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -178,6 +178,7 @@ local function showMainMenu()
 
 			mainTextButton(lui.NEW_GAME, nil, true, function()
 				NewGameWindow:setDebugMode(ui.ctrlHeld())
+				NewGameWindow.mode = 'NEW_GAME'
 				NewGameWindow:open();
 			end)
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -78,15 +78,20 @@ Game::Game(const SystemPath &path, const double startDateTime, const char *shipT
 
 	m_space->AddBody(m_player.get());
 
-	m_player->SetFrame(b->GetFrame());
-
 	if (b->GetType() == ObjectType::SPACESTATION) {
+		m_player->SetFrame(b->GetFrame());
 		m_player->SetDockedWith(static_cast<SpaceStation *>(b), 0);
 	} else {
+		auto f = Frame::GetFrame(b->GetFrame());
+		if (f->IsRotFrame()) {
+			m_player->SetFrame(f->GetParent());
+		} else {
+			m_player->SetFrame(b->GetFrame());
+		}
 		// random orbit
 		// Taken from: LuaSpace.cpp, _orbital_velocity_random_direction()
 		const SystemBody *sbody = b->GetSystemBody();
-		vector3d pos{ MathUtil::RandomPointOnSphere(1.2 * sbody->GetRadius()) };
+		vector3d pos{ MathUtil::RandomPointOnSphere(1.2 * b->GetPhysRadius()) };
 		// calculating basis from radius - vector
 		vector3d k = pos.Normalized();
 		vector3d i;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -995,3 +995,8 @@ void Game::SaveGame(const std::string &filename, Game *game)
 
 	Pi::GetApp()->RequestProfileFrame("SaveGame");
 }
+
+int Game::CurrentSaveVersion()
+{
+	return s_saveVersion;
+}

--- a/src/Game.h
+++ b/src/Game.h
@@ -45,6 +45,7 @@ public:
 	// (or LoadGame/SaveGame should be somewhere else entirely)
 	static void SaveGame(const std::string &filename, Game *game);
 	static bool DeleteSave(const std::string &filename);
+	static int CurrentSaveVersion();
 
 	// start docked in station referenced by path or nearby to body if it is no station
 	Game(const SystemPath &path, const double startDateTime, const char *shipType = "kanara");

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -341,7 +341,7 @@ StarSystem::~StarSystem()
 	PROFILE_SCOPED()
 	// clear parent and children pointers. someone (Lua) might still have a
 	// reference to things that are about to be deleted
-	m_rootBody->ClearParentAndChildPointers();
+	m_rootBody->Orphan();
 	if (m_cache)
 		m_cache->RemoveFromAttic(m_path);
 }

--- a/src/galaxy/SystemBody.cpp
+++ b/src/galaxy/SystemBody.cpp
@@ -927,12 +927,13 @@ void SystemBody::Dump(FILE *file, const char *indent) const
 	fprintf(file, "%s}\n", indent);
 }
 
-void SystemBody::ClearParentAndChildPointers()
+void SystemBody::Orphan()
 {
 	PROFILE_SCOPED()
 	for (std::vector<SystemBody *>::iterator i = m_children.begin(); i != m_children.end(); ++i)
-		(*i)->ClearParentAndChildPointers();
+		(*i)->Orphan();
 	m_parent = 0;
+	m_system = 0;
 	m_children.clear();
 }
 

--- a/src/galaxy/SystemBody.h
+++ b/src/galaxy/SystemBody.h
@@ -325,7 +325,7 @@ private:
 	void SetOrbitFromParameters();
 	void SetAtmFromParameters();
 
-	void ClearParentAndChildPointers();
+	void Orphan();
 
 	SystemBody *m_parent;				  // these are only valid if the StarSystem
 	std::vector<SystemBody *> m_children; // that create them still exists

--- a/src/lua/LuaGalaxy.cpp
+++ b/src/lua/LuaGalaxy.cpp
@@ -27,7 +27,7 @@ const char *LuaObject<Galaxy>::s_type = "Galaxy";
  *
  * Return:
  *
- *   systems - array of objects of type 'System'
+ *   systems - array of objects of type 'StarSystem'
  *
  */
 static int l_galaxy_get_sector(lua_State *l)
@@ -44,11 +44,49 @@ static int l_galaxy_get_sector(lua_State *l)
 	return 1;
 }
 
+/*
+ * Method: GetStarSystem
+ *
+ * Get a star system for the system that path points to, return nil if system
+ * index is out of range for this sector
+ *
+ * > system = galaxy:GetStarSystem(path)
+ *
+ * Parameters:
+ *
+ *   path - the <SystemPath>
+ *
+ * Return:
+ *
+ *   system? - the <StarSystem>
+ *
+ */
+static int l_galaxy_get_star_system(lua_State *l)
+{
+	auto galaxy = LuaObject<Galaxy>::CheckFromLua(1);
+	auto path = LuaObject<SystemPath>::CheckFromLua(2);
+
+	if (path->IsSectorPath()) {
+		return luaL_error(l, "Galaxy:GetStarSystem() path argument does not refer to a system");
+	}
+
+	RefCountedPtr<const Sector> sector = galaxy->GetSector(SystemPath(path->sectorX, path->sectorY, path->sectorZ));
+	if (path->systemIndex >= sector->m_systems.size()) {
+		lua_pushnil(l);
+		return 1;
+	}
+
+	RefCountedPtr<StarSystem> s = galaxy->GetStarSystem(path);
+	LuaObject<StarSystem>::PushToLua(s.Get());
+	return 1;
+}
+
 template <>
 void LuaObject<Galaxy>::RegisterClass()
 {
 	static const luaL_Reg l_methods[] = {
 		{ "GetSector", l_galaxy_get_sector },
+		{ "GetStarSystem", l_galaxy_get_star_system },
 		{ 0, 0 }
 	};
 

--- a/src/lua/LuaGame.cpp
+++ b/src/lua/LuaGame.cpp
@@ -133,6 +133,25 @@ static int l_game_savegame_stats(lua_State *l)
 	}
 }
 
+
+/*
+ * Function: CurrentSaveVersion
+ *
+ * Returns the current version of the game save file format.
+ *
+ * > Game.CurrentSaveVersion()
+ *
+ * Return:
+ *
+ *   number
+ *
+ */
+static int l_game_current_save_version(lua_State *l)
+{
+	LuaPush(l, Game::CurrentSaveVersion());
+	return 1;
+}
+
 /*
  * Function: LoadGame
  *
@@ -684,6 +703,7 @@ void LuaGame::Register()
 		{ "EndGame", l_game_end_game },
 		{ "InHyperspace", l_game_in_hyperspace },
 		{ "SaveGameStats", l_game_savegame_stats },
+		{ "CurrentSaveVersion", l_game_current_save_version },
 
 		{ "SwitchView", l_game_switch_view },
 		{ "CurrentView", l_game_current_view },

--- a/src/lua/LuaJson.cpp
+++ b/src/lua/LuaJson.cpp
@@ -34,10 +34,8 @@ static void _push_json_to_lua(lua_State *l, Json &obj)
 	case Json::value_t::array: {
 		lua_newtable(l);
 		size_t size = obj.size();
-		lua_pushinteger(l, size);
-		lua_setfield(l, -2, "n");
 		for (size_t idx = 0; idx < size; idx++) {
-			lua_pushinteger(l, idx);
+			lua_pushinteger(l, idx + 1);
 			_push_json_to_lua(l, obj[idx]);
 			lua_settable(l, -3);
 		}

--- a/src/lua/LuaSystemBody.cpp
+++ b/src/lua/LuaSystemBody.cpp
@@ -148,15 +148,15 @@ static int l_sbody_attr_parent(lua_State *l)
 {
 	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
 
-	// sbody->parent is 0 as it was cleared by the acquirer. we need to go
-	// back to the starsystem proper to get what we need.
-	RefCountedPtr<StarSystem> s = Pi::game->GetGalaxy()->GetStarSystem(sbody->GetPath());
-	SystemBody *live_sbody = s->GetBodyByPath(sbody->GetPath());
-
-	if (!live_sbody->GetParent())
-		return 0;
-
-	LuaObject<SystemBody>::PushToLua(live_sbody->GetParent());
+	if (!sbody->GetStarSystem()) {
+		// orphan, its system has already been deleted, but SystemPath remains
+		// we'll make a new one just like it
+		RefCountedPtr<StarSystem> s = Pi::game->GetGalaxy()->GetStarSystem(sbody->GetPath());
+		sbody = s->GetBodyByPath(sbody->GetPath());
+		LuaObject<SystemBody>::PushToLua(sbody->GetParent());
+	} else {
+		LuaObject<SystemBody>::PushToLua(sbody->GetParent());
+	}
 	return 1;
 }
 

--- a/src/lua/core/Debug.cpp
+++ b/src/lua/core/Debug.cpp
@@ -184,7 +184,7 @@ std::string _pi_lua_table_tostring(lua_State *l, int idx, int indent, int recurs
 // Return a debug representation of the given lua value
 std::string pi_lua_tostring(lua_State *l, int idx, int indent, int recurseTable)
 {
-	lua_checkstack(l, 1);
+	lua_checkstack(l, 4);
 
 	int type = lua_type(l, idx);
 

--- a/src/savegamedump.cpp
+++ b/src/savegamedump.cpp
@@ -6,17 +6,31 @@
 #include "core/GZipFormat.h"
 #include <SDL.h>
 
+int info()
+{
+	printf(
+		"savegamedump - Dump saved games to JSON for easy inspection.\n"
+		"All paths are relative to the pioneer data folder.\n"
+		"USAGE: savegamedump [--pretty] <input> [output]\n");
+	return 1;
+}
+
 extern "C" int main(int argc, char **argv)
 {
-	if (argc < 2 || argc > 3) {
-		printf(
-			"savegamedump - Dump saved games to JSON for easy inspection.\n"
-			"All paths are relative to the pioneer data folder.\n"
-			"USAGE: savegamedump <input> [output]\n");
-		return 1;
-	}
+	if (argc < 2) return info();
+
+	int indent = -1;
+	int shift = 0;
+
 	std::string filename = argv[1];
-	std::string outname = argc > 2 ? argv[2] : filename + ".json";
+	if (filename == "--pretty") {
+		indent = 2;
+		shift = 1;
+	}
+
+	if (argc < shift+2 || argc > shift+3) return info();
+	filename = argv[shift+1];
+	std::string outname = argc > shift+2 ? argv[shift+2] : filename + ".json";
 
 	auto fileinfo = FileSystem::userFiles.Lookup(filename);
 	if (!fileinfo.Exists()) {
@@ -66,7 +80,7 @@ extern "C" int main(int argc, char **argv)
 		return 1;
 	}
 
-	fputs(rootNode.dump().c_str(), outFile);
+	fputs(rootNode.dump(indent).c_str(), outFile);
 	fclose(outFile);
 
 	return 0;


### PR DESCRIPTION
[recording.webm](https://github.com/pioneerspacesim/pioneer/assets/18342621/f38107d6-35ca-45ab-ad8d-8c5049211509)

If the saveload menu decides that it cannot load a save (most likely due to a version mismatch), the `Load` button will be replaced with `Recover` and you can try to restore the game.

In fact, this is the start of a new game, but we are trying to read the parameters from the save. After a recovery attempt, the same dialog for starting a new game opens, but without selecting a start option.

If an error occurs when reading a parameter from a save, or after restoring the parameter is in an invalid state, it is unlocked so that the player can manually specify it. The exception is the flight log - it is always locked.

Version 89 is currently being successfully restored (2023-02-03). For older versions, it is planned to add "reader" versions in the future. Added the ability to create a "versioned" function; when it is launched, dispatching occurs depending on the specified save version.

Also, now when you launch a new game window in debug mode (with ctrl), it immediately switches to "Custom start". In this case, there are no changes to the parameters after the previous launch of the new game window. That is, if you previously ran a recovery, you can open a new game window in debug mode and there will be the same options, but unlocked.