### PR TITLE
Simplified travel times

### DIFF
--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -9,6 +9,7 @@ local Comms = require 'Comms'
 local Timer = require 'Timer'
 local Event = require 'Event'
 local Mission = require 'Mission'
+local MissionUtils = require 'modules.MissionUtils'
 local NameGen = require 'NameGen'
 local Character = require 'Character'
 local Commodities = require 'Commodities'
@@ -188,11 +189,13 @@ local makeAdvert = function (station)
 	local nearbystations = nearbysystem:GetStationPaths()
 	local location = nearbystations[Engine.rand:Integer(1,#nearbystations)]
 	local dist = location:DistanceTo(Game.system)
-	local time = Engine.rand:Number(1, 4)
-	local due = Game.time + dist / max_ass_dist * time * 22*60*60*24 + Engine.rand:Number(7*60*60*24, 31*60*60*24)
+	local time = Engine.rand:Number(7*60*60*24, 35*60*60*24)
+	local due = time + MissionUtils.TravelTime(dist, location) * Engine.rand:Number(0.5, 1.5)
+	local timeout = Game.time + due/2
 	local danger = Engine.rand:Integer(1,4)
 	local reward = Engine.rand:Number(2100, 7000) * danger
 	reward = utils.round(reward, 500)
+	due = utils.round(due + Game.time, 3600)
 
 	-- XXX hull mass is a bad way to determine suitability for role
 	--local shipdefs = utils.build_array(utils.filter(function (k,def) return def.tag == 'SHIP' and def.hullMass >= (danger * 17) and def.equipSlotCapacity.ATMOSHIELD > 0 end, pairs(ShipDef)))
@@ -215,6 +218,7 @@ local makeAdvert = function (station)
 		shipregid = Ship.MakeRandomLabel(),
 		station = station,
 		target = target,
+		timeout = timeout,
 	}
 
 	placeAdvert(station, ad)
@@ -445,7 +449,7 @@ end
 
 local onUpdateBB = function (station)
 	for ref,ad in pairs(ads) do
-		if (ad.due < Game.time + 5*60*60*24) then
+		if ad.timeout < Game.time then
 			ad.station:RemoveAdvert(ref)
 		end
 	end

--- a/data/modules/DeliverPackage/DeliverPackage.lua
+++ b/data/modules/DeliverPackage/DeliverPackage.lua
@@ -8,6 +8,7 @@ local Space = require 'Space'
 local Comms = require 'Comms'
 local Event = require 'Event'
 local Mission = require 'Mission'
+local MissionUtils = require 'modules.MissionUtils'
 local Format = require 'Format'
 local Serializer = require 'Serializer'
 local Character = require 'Character'
@@ -21,9 +22,6 @@ local lc = Lang.GetResource 'core'
 
 -- don't produce missions for further than this many light years away
 local max_delivery_dist = 30
--- typical time for travel to a system max_delivery_dist away
---	Irigi: ~ 4 days for in-system travel, the rest is FTL travel time
-local typical_travel_time = (1.6 * max_delivery_dist + 4) * 24 * 60 * 60
 -- typical reward for delivery to a system max_delivery_dist away
 local typical_reward = 25 * max_delivery_dist
 -- typical reward for delivery to a local port
@@ -254,7 +252,7 @@ end
 -- return statement is nil if no advert was created, else it is bool:
 -- true if a localdelivery, false for non-local
 local makeAdvert = function (station, manualFlavour, nearbystations)
-	local reward, due, location, nearbysystem, dist
+	local reward, due, location, nearbysystem, dist, timeout
 	local client = Character.New()
 
 	-- set flavour manually if a second arg is given
@@ -272,7 +270,7 @@ local makeAdvert = function (station, manualFlavour, nearbystations)
 		if #nearbystations == 0 then return nil end
 		location, dist = table.unpack(nearbystations[Engine.rand:Integer(1,#nearbystations)])
 		reward = typical_reward_local + math.max(math.sqrt(dist) / 15000, min_local_dist_pay) * (1.5+urgency)
-		due = Game.time + ((4*24*60*60) * (Engine.rand:Number(1.5,3.5) - urgency))
+		due =(60*60*18 + MissionUtils.TravelTimeLocal(dist)) * (1.5-urgency) * Engine.rand:Number(0.9,1.1)
 	else
 		if nearbysystems == nil then
 			nearbysystems = Game.system:GetNearbySystems(max_delivery_dist, function (s) return #s:GetStationPaths() > 0 end)
@@ -283,9 +281,11 @@ local makeAdvert = function (station, manualFlavour, nearbystations)
 		local nearbystations = nearbysystem:GetStationPaths()
 		location = nearbystations[Engine.rand:Integer(1,#nearbystations)]
 		reward = ((dist / max_delivery_dist) * typical_reward * (1+risk) * (1.5+urgency) * Engine.rand:Number(0.8,1.2))
-		due = Game.time + ((dist / max_delivery_dist) * typical_travel_time * (1.5-urgency) * Engine.rand:Number(0.9,1.1))
+		due = MissionUtils.TravelTime(dist, location) * (1.5-urgency) * Engine.rand:Number(0.9,1.1)
 	end
 	reward = utils.round(reward, 5)
+	timeout = due/2 + Game.time -- timeout after half of the travel time
+	due = utils.round(due + Game.time, 900)
 
 	local ad = {
 		station		= station,
@@ -295,6 +295,7 @@ local makeAdvert = function (station, manualFlavour, nearbystations)
 		localdelivery = flavours[flavour].localdelivery,
 		dist        = dist,
 		due			= due,
+		timeout     = timeout,
 		risk		= risk,
 		urgency		= urgency,
 		reward		= reward,
@@ -341,14 +342,8 @@ end
 
 local onUpdateBB = function (station)
 	for ref,ad in pairs(ads) do
-		if flavours[ad.flavour].localdelivery then
-			if ad.due < Game.time + 2*60*60*24 then -- two day timeout for locals
-				ad.station:RemoveAdvert(ref)
-			end
-		else
-			if ad.due < Game.time + 5*60*60*24 then -- five day timeout for inter-system
-				ad.station:RemoveAdvert(ref)
-			end
+		if ad.timeout < Game.time then
+			ad.station:RemoveAdvert(ref)
 		end
 	end
 	if Engine.rand:Integer(12*60*60) < 60*60 then -- roughly once every twelve hours

--- a/data/modules/MissionUtils.lua
+++ b/data/modules/MissionUtils.lua
@@ -173,5 +173,59 @@ function MissionUtils.GetNearbyStationPaths(system, range_ly, system_filter, sta
 	return nearby_stations
 end
 
+-- Function: TravelTimeLocal
+--
+-- Returns a standardized travel time to a local target
+--
+-- Example:
+--
+-- > travel_time = MissionUtils.TravelTimeLocal(distance)
+--
+-- Parameters:
+--
+--   distance - the distance to the target in meters
+--
+-- Returns:
+--
+--   the travel time in seconds
+--
+function MissionUtils.TravelTimeLocal(distance)
+	return distance/AU * 2*Days
+end
+
+--
+-- Function: TravelTime
+--
+-- Returns a standardized hyperspace travel time
+--
+-- Example:
+--
+-- > travel_time = MissionUtils.TravelTime(distance, location)
+--
+-- Parameters:
+--
+--   distance - the distance to the target system in light years
+--
+--   location - optional, the location in the target system
+--              must be a station or planet
+--
+-- Returns:
+--
+--   the travel time in seconds
+--
+function MissionUtils.TravelTime(distance, location)
+	local ltt
+
+	if location then
+		local sbody = location:GetSystemBody()
+		-- find the primary planet orbiting the star or gravpoint to calculate the local travel time
+		while sbody.parent and sbody.parent.superType ~= 'STAR' do sbody = sbody.parent end
+		ltt = MissionUtils.TravelTimeLocal((sbody.periapsis+sbody.apoapsis)/2)
+	else
+		ltt = MissionUtils.TravelTimeLocal(AU)
+	end
+
+	return distance * 1.75*Days + ltt
+end
 
 return MissionUtils

--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -8,6 +8,7 @@ local Space = require 'Space'
 local Comms = require 'Comms'
 local Event = require 'Event'
 local Mission = require 'Mission'
+local MissionUtils = require 'modules.MissionUtils'
 local Format = require 'Format'
 local Serializer = require 'Serializer'
 local Character = require 'Character'
@@ -22,9 +23,6 @@ local lc = Lang.GetResource 'core'
 
 -- don't produce missions for further than this many light years away
 local max_taxi_dist = 40
--- typical time for travel to a system max_taxi_dist away
---	Irigi: ~ 4 days for in-system travel, the rest is FTL travel time
-local typical_travel_time = (2.0 * max_taxi_dist + 4) * 24 * 60 * 60
 -- typical reward for taxi service to a system max_taxi_dist away
 local typical_reward = 75 * max_taxi_dist
 -- max number of passengers per trip
@@ -258,7 +256,7 @@ end
 
 local nearbysystems
 local makeAdvert = function (station)
-	local reward, due, location
+	local reward, due, location, timeout
 	local client = Character.New()
 	local flavour = Engine.rand:Integer(1,#flavours)
 	local urgency = flavours[flavour].urgency
@@ -276,7 +274,9 @@ local makeAdvert = function (station)
 	local dist = location:DistanceTo(Game.system)
 	reward = ((dist / max_taxi_dist) * typical_reward * (group / 2) * (1+risk) * (1+3*urgency) * Engine.rand:Number(0.8,1.2))
 	reward = utils.round(reward, 50)
-	due = Game.time + ((dist / max_taxi_dist) * typical_travel_time * (1.5-urgency) * Engine.rand:Number(0.9,1.1))
+	due = MissionUtils.TravelTime(dist) * 1.25 * (1.5-urgency) * Engine.rand:Number(0.9,1.1)
+	timeout = due/2 + Game.time -- timeout after half of the travel time
+	due = utils.round(due + Game.time, 900)
 
 	local ad = {
 		station		= station,
@@ -285,6 +285,7 @@ local makeAdvert = function (station)
 		location	= location.path,
 		dist        = dist,
 		due		    = due,
+		timeout     = timeout,
 		group		= group,
 		risk		= risk,
 		urgency		= urgency,
@@ -304,7 +305,7 @@ end
 
 local onUpdateBB = function (station)
 	for ref,ad in pairs(ads) do
-		if ad.due < Game.time + 5*60*60*24 then
+		if ad.timeout < Game.time then
 			ad.station:RemoveAdvert(ref)
 		end
 	end


### PR DESCRIPTION
This is an attempt to simplify delivery times so that they can be better balanced if necessary.

I have used the DeliverPackage module as a basis and fitted the other with one factor.
![deliverpackage](https://github.com/pioneerspacesim/pioneer/assets/10255455/05470b36-05b1-4e22-84e6-9d19ca4e6f01)
![cargorun](https://github.com/pioneerspacesim/pioneer/assets/10255455/d0562054-41df-4029-9c10-06eafb6ad9c0)
![taxi](https://github.com/pioneerspacesim/pioneer/assets/10255455/ddad5d61-fc98-488e-b297-91b074ccbd7b)
![assassination](https://github.com/pioneerspacesim/pioneer/assets/10255455/b031afcd-178f-4722-9413-dce22c581aeb)

The combat module is now better for ships like the Bowfin.
![combat](https://github.com/pioneerspacesim/pioneer/assets/10255455/304d35ca-1c01-4b0e-9424-4ab2d868c38d)

I have also added a "local part". This should calculate much better delivery times for large systems.
If no location is specified, a distance of 1AU is assumed.

**Now the local deliveries:**

I took the average flight time of a Xylophis from 'System Administration Resting' to 'OPLI Pax' as the basis for the local deliveries. approx. 2 days for 1AU.
![local](https://github.com/pioneerspacesim/pioneer/assets/10255455/63e8f728-a238-4fa8-a637-4be3f35bb38b)
![scoop](https://github.com/pioneerspacesim/pioneer/assets/10255455/5d0e12fa-f879-4aaf-817c-e50bc958b89d)

Finally, the due time is rounded to 1h or 1/4h. In addition, the advert is deleted after half of the calculated travel time. Makes more sense in my opinion.
