### PR TITLE
Making ship market comparison colors colorblind friendly

### DIFF
--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -57,7 +57,7 @@ local styleColors = {
 	accent_700		= Color "06318E",
 
 	success_100		= Color "CAF8A8",
-	success_300		= Color "77EE21",
+	success_300		= Color "D6A8F8",
 	success_500		= Color "5ACC0A",
 	success_700		= Color "317005",
 	success_900		= Color "102502",
@@ -73,6 +73,10 @@ local styleColors = {
 	danger_500		= Color "C51010",
 	danger_700		= Color "8C0606",
 	danger_900		= Color "2C0505",
+	
+	compare_worse   = Color "FFA431",
+	compare_better  = Color "33B2E2",
+		
 }
 
 theme.styleColors = styleColors
@@ -230,8 +234,8 @@ theme.colors = {
 	equipScreenHighlight    = styleColors.gray_300,
 	equipScreenBgText       = styleColors.gray_400,
 
-	shipmarketCompareBetter = styleColors.success_300,
-	shipmarketCompareWorse  = styleColors.warning_300,
+	shipmarketCompareBetter = styleColors.compare_better,
+	shipmarketCompareWorse  = styleColors.compare_worse,
 }
 
 -- ImGui global theming styles

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -73,9 +73,6 @@ local styleColors = {
 	danger_500		= Color "C51010",
 	danger_700		= Color "8C0606",
 	danger_900		= Color "2C0505",
-	
-	compare_worse   = Color "FFA431",
-	compare_better  = Color "33B2E2",
 		
 }
 
@@ -234,8 +231,8 @@ theme.colors = {
 	equipScreenHighlight    = styleColors.gray_300,
 	equipScreenBgText       = styleColors.gray_400,
 
-	shipmarketCompareBetter = styleColors.compare_better,
-	shipmarketCompareWorse  = styleColors.compare_worse,
+	shipmarketCompareBetter = styleColors.accent_300,
+	shipmarketCompareWorse  = styleColors.warning_300,
 }
 
 -- ImGui global theming styles


### PR DESCRIPTION
I've changed the coloring of better stats from green to a saturated blue to provide much more contrast for colorblind folks. The red-green pairing can be really hard to distinguish. This pairing should provide better contrast to all four types of color blindness.

I've added two new colors to the theme:
compare_worse - kept the orange-ish red of warning_300
compare_better - added a saturated blue of similar lightness. Could have gone brighter, but then it competed with the white.
And changed the market lines to use these new colors. These could then be used on the eqipment market later too.

(I've also just created an Accessibility tag on github)

Before:
![image](https://github.com/pioneerspacesim/pioneer/assets/249391/5a86f2f9-5ec5-409e-992e-36e043558006)

After:
![image](https://github.com/pioneerspacesim/pioneer/assets/4182678/346e8a33-fe0a-4531-a6b5-549d04124a12)
