### PR TITLE
Fix player being unable to collide with Stations if only ship in Frame

### DIFF
--- a/src/collider/BVHTree.cpp
+++ b/src/collider/BVHTree.cpp
@@ -305,17 +305,17 @@ uint32_t SingleBVHTree::Partition(SortKey *keys, uint32_t numKeys, const AABBd &
 
 	// Simple O(n) sort algorithm to sort all objects according to side of pivot
 	uint32_t startIdx = 0;
-	uint32_t endIdx = numKeys - 1;
+	uint32_t endIdx = numKeys;
 
 	// It is ~10% faster to sort the indices than to sort the whole AABB array
 	// (cache hit rate vs. memory bandwidth)
 	// Sorting in general is extremely fast.
-	while (startIdx <= endIdx && endIdx) {
+	while (startIdx < endIdx) {
 		if (keys[startIdx].center[axis] < pivot) {
 			startIdx++;
 		} else {
-			std::swap(keys[startIdx], keys[endIdx]);
 			endIdx--;
+			std::swap(keys[startIdx], keys[endIdx]);
 		}
 	}
 

--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -236,14 +236,14 @@ uint32_t CollisionSpace::SortEnabledGeoms(std::vector<Geom *> &geoms)
 	// Simple O(n) sort algorithm
 	// Sort geoms according to enabled state (group all enabled geoms at start of array)
 	uint32_t startIdx = 0;
-	uint32_t endIdx = geoms.size() - 1;
+	uint32_t endIdx = geoms.size();
 
-	while (startIdx <= endIdx && endIdx) {
+	while (startIdx < endIdx) {
 		if (geoms[startIdx]->IsEnabled()) {
 			startIdx++;
 		} else {
-			std::swap(geoms[startIdx], geoms[endIdx]);
 			endIdx--;
+			std::swap(geoms[startIdx], geoms[endIdx]);
 		}
 	}
 


### PR DESCRIPTION
The CollisionSpace partition sort algorithm had a degenerate case where the contents of a single-element array would always be assigned to the disabled bucket, regardless of if it was enabled or not. This resulted in the player being unable to collide with any static Geom if it was the only active ship in the physics frame.

I've fixed that, and in the process made the sort algorithm a bit simpler.

Fixes #5705. Note that the saves linked in that issue are not compatible with the current master branch.