### PR TITLE
Add BUILD_DATE variable for windows builds

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -11,6 +11,7 @@ on:
     paths:
     - 'src/**.cpp'
     - 'src/**.h'
+    - '**/CMakeLists.txt'
   release:
     types: [published]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,7 @@ add_subdirectory(src/lua)
 
 if (WIN32)
 	string(TIMESTAMP BUILD_YEAR "%Y")
+	string(TIMESTAMP BUILD_DATE "%Y%m%d")
 	set(RESOURCES ${CMAKE_BINARY_DIR}/pioneer.rc)
 	configure_file(pioneer.rc.cmakein ${RESOURCES} @ONLY)
 endif()

--- a/pioneer.rc.cmakein
+++ b/pioneer.rc.cmakein
@@ -4,13 +4,13 @@ AppIcon ICON DISCARDABLE "@CMAKE_SOURCE_DIR@/application-icon/pioneer.ico"
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION @PROJECT_VERSION@
+FILEVERSION @BUILD_DATE@
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
         BLOCK "040904E4"
         BEGIN
-            VALUE "FileVersion",        "@PROJECT_VERSION@"
+            VALUE "FileVersion",        "@BUILD_DATE@"
             VALUE "CompanyName",        "Pioneer developers"
             VALUE "FileDescription",    "Pioneer Space Simulator"
             VALUE "InternalName",       "Pioneer"


### PR DESCRIPTION
This is needed for the FILEVERSION constant because it only accepts numeric values, and now our version can be not only numerical.
Please note that I did not change this line:
```
VALUE "ProductVersion",     "@PROJECT_VERSION@"
```
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

