### PR TITLE
Fix orbital / surface scan missions being unable to be completed

### DIFF
--- a/data/libs/Event.lua
+++ b/data/libs/Event.lua
@@ -50,6 +50,7 @@ function Event:Register(name, module, func)
 	for _, cb in ipairs(self.callbacks[name]) do
 		-- Update registered callback
 		if cb.module == module then
+			logWarning("Module {} overwriting event callback {}" % { module, func })
 			cb.func = func
 			return
 		end

--- a/data/modules/Scout/Scout.lua
+++ b/data/modules/Scout/Scout.lua
@@ -615,12 +615,19 @@ local onScanComplete = function (player, scanId)
 				mission.client.name)
 		end
 	end
+
 	mission.location = newlocation
-	Game.player:SetHyperspaceTarget(mission.location:GetStarSystem().path)
+
+	if Game.system and mission.location:IsSameSystem(Game.system.path) then
+		Game.player:SetNavTarget(mission.location)
+	else
+		Game.player:SetHyperspaceTarget(mission.location:SystemOnly())
+	end
 end
 
 
 ---@param player Player
+---@param station SpaceStation
 local onShipDocked = function (player, station)
 	if not player:IsPlayer() then return end
 	local scanMgr = player:GetComponent("ScanManager")
@@ -670,6 +677,11 @@ end
 local loaded_data
 
 local onGameStart = function ()
+	-- If we loaded a saved game, the player may have a ScanManager component already
+	if not Game.player:GetComponent("ScanManager") then
+		Game.player:SetComponent("ScanManager", ScanManager.New(Game.player))
+	end
+
 	ads = {}
 	missions = {}
 	missionKey = {}
@@ -765,25 +777,17 @@ local onGameEnd = function ()
 	nearbysystems = nil
 end
 
+Event.Register("onGameStart", onGameStart)
 Event.Register("onGameEnd", onGameEnd)
 Event.Register("onCreateBB", onCreateBB)
 Event.Register("onUpdateBB", onUpdateBB)
 Event.Register("onEnterSystem", onEnterSystem)
 Event.Register("onShipDocked", onShipDocked)
-Event.Register("onGameStart", onGameStart)
 
 Event.Register("onScanRangeEnter", onScanRangeEnter)
 Event.Register("onScanRangeExit", onScanRangeExit)
 Event.Register("onScanPaused", onScanPaused)
 Event.Register("onScanComplete", onScanComplete)
-
--- Ensure the player ship has a ScanManager available
-Event.Register('onGameStart', function()
-	-- If we loaded a saved game, the player may have a ScanManager component already
-	if not Game.player:GetComponent("ScanManager") then
-		Game.player:SetComponent("ScanManager", ScanManager.New(Game.player))
-	end
-end)
 
 Mission.RegisterType('Scout', l.MAPPING, buildMissionDescription)
 

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -446,6 +446,7 @@ end})
 
 Event.Register("onGameStart", onGameStart)
 Event.Register("onEnterSystem", function()
+	hyperJumpPlanner.onEnterSystem()
 	hyperspaceDetailsCache = {}
 end)
 
@@ -454,18 +455,17 @@ Event.Register("onGameEnd", function()
 	searchString = ""
 	systemPaths = nil
 	leftBarMode = "SEARCH"
+
+	hyperJumpPlanner.onGameEnd()
 end)
 
--- events moved from hyperJumpPlanner
-Event.Register("onGameEnd", hyperJumpPlanner.onGameEnd)
-Event.Register("onEnterSystem", hyperJumpPlanner.onEnterSystem)
-Event.Register("onShipEquipmentChanged", hyperJumpPlanner.onShipEquipmentChanged)
+Event.Register("onShipEquipmentChanged", function(ship, ...)
+	if ship:IsPlayer() then hyperspaceDetailsCache = {} end
+	hyperJumpPlanner.onShipEquipmentChanged(ship, ...)
+end)
 
-local function clearHyperspaceCache(ship)
-	if ship and ship == player then hyperspaceDetailsCache = {} end
-end
-
-Event.Register("onShipEquipmentChanged", clearHyperspaceCache)
-Event.Register("onShipTypeChanged", clearHyperspaceCache)
+Event.Register("onShipTypeChanged", function(ship, ...)
+	if ship:IsPlayer() then hyperspaceDetailsCache = {} end
+end)
 
 return {}


### PR DESCRIPTION
As an unintended consequence of #5671, two modules were inadvertently overwriting their previously-registered event handlers by dint of not conforming to the existing usage pattern of one handler per event per file. This pattern was made a requirement to support hot-reloading of registered event handlers, but I didn't realize we had some existing code which broke that pattern before I merged the PR.

This PR fixes an issue reported at least once on Discord where scan missions were unable to be completed after loading a saved game with an in-progress scan. I don't believe it's yet been reported over here.