### PR TITLE
[WIP] Limit ship's jerk by 1g/s

### DIFF
--- a/src/ship/Propulsion.h
+++ b/src/ship/Propulsion.h
@@ -131,6 +131,9 @@ private:
 	// Used to calculate max linear thrust by limiting the thruster levels
 	float m_linAccelerationCap[THRUSTER_MAX];
 
+	vector3d m_linThrustersTarget; // 0.0-1.0, target thruster levels
+	float m_maxJerk;
+
 	// Fuel
 	int m_fuelTankMass;
 	double m_thrusterFuel; // 0.0-1.0, remaining fuel


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This will affect:
- Autopilot
- Manual ship control
- Missiles
- NPC ships (?)

This will disallow accelerating instantly from standing still to full thrust.
Instead, full thrust will be applied after several seconds, increasing or decreasing linearly.

- [ ] Autopilot is broken: ship will never reach its destination, orbiting this point instead.
- [ ] Suggestion from IRC: load jerk limit from ships JSON instead of fixed constant of 9.8 m/s^3