### PR TITLE
Fix missing gas giant atmospheres

### DIFF
--- a/data/libs/Equipment.lua
+++ b/data/libs/Equipment.lua
@@ -65,13 +65,13 @@ misc.missile_naval = EquipType.New({
 })
 misc.atmospheric_shielding = EquipType.New({
 	l10n_key="ATMOSPHERIC_SHIELDING", slots="atmo_shield", price=200,
-	capabilities={mass=1, atmo_shield=9},
+	capabilities={mass=1, atmo_shield=4},
 	purchasable=true, tech_level=3,
 	icon_name="equip_atmo_shield_generator"
 })
 misc.heavy_atmospheric_shielding = EquipType.New({
 	l10n_key="ATMOSPHERIC_SHIELDING_HEAVY", slots="atmo_shield", price=900,
-	capabilities={mass=2, atmo_shield=19},
+	capabilities={mass=2, atmo_shield=9},
 	purchasable=true, tech_level=5,
 	icon_name="equip_atmo_shield_generator"
 })

--- a/data/meta/SystemBody.lua
+++ b/data/meta/SystemBody.lua
@@ -42,12 +42,15 @@
 --- The measure of metallicity of the body's crust:
 --- 0.0 = light (Al, SiO2, etc), 1.0 = heavy (Fe, heavy metals)
 ---@field metallicity number
---- The measure of volatile gas present in the atmosphere of the body:
---- 0.0 = no atmosphere, 1.0 = earth atmosphere density, 4.0+ ~= venus
----@field volatileGas number
+--- The atmospheric density at "surface level" of the body:
+--- 0.0 = no atmosphere, 1.225 = earth atmosphere density, 64 ~= venus
+---@field atmosDensity number
 --- The compositional value of any atmospheric gasses in the bodys atmosphere (if any):
 --- 0.0 = reducing (H2, NH3, etc), 1.0 = oxidising (CO2, O2, etc)
 ---@field atmosOxidizing number
+--- The pressure of the atmosphere at the body's mean "surface level":
+--- 1.0atm = earth
+---@field surfacePressure number
 --- The measure of volatile liquids present on the body:
 --- 0.0 = none, 1.0 = waterworld (earth = 70%)
 ---@field volatileLiquid number

--- a/data/modules/Scout/Scout.lua
+++ b/data/modules/Scout/Scout.lua
@@ -330,7 +330,7 @@ local function calcSurfaceScanMission(sBody, difficulty, reward)
 
 	-- Calculate parameters which make approaching the body to scan it more difficult
 	local bodyDifficulty = (1 + sBody.gravity / EARTH_G)
-		* (1 + math.max(math.log(sBody.volatileGas), 0.0) * 0.5)
+		* (1 + math.max(math.log(sBody.atmosDensity), 0.0) * 0.5)
 		* (1 + sBody.eccentricity * 0.5)
 
 	local bodyReward = 1

--- a/data/systems/custom/00_sol.json
+++ b/data/systems/custom/00_sol.json
@@ -1106,8 +1106,8 @@
 				255,
 				3
 			],
-			"atmosDensity": "f1/4281008650",
-			"atmosOxidizing": "f0/3435973836",
+			"atmosDensity": "f1/1305670057",
+			"atmosOxidizing": "f0/780903168",
 			"averageTemp": 165,
 			"axialTilt": "f0/234629479",
 			"children": [
@@ -1863,8 +1863,8 @@
 				255,
 				3
 			],
-			"atmosDensity": "f0/0",
-			"atmosOxidizing": "f0/0",
+			"atmosDensity": "f1/2319282339",
+			"atmosOxidizing": "f0/317241888",
 			"averageTemp": 134,
 			"axialTilt": "f0/2003720761",
 			"children": [
@@ -2244,8 +2244,8 @@
 				255,
 				3
 			],
-			"atmosDensity": "f0/0",
-			"atmosOxidizing": "f0/0",
+			"atmosDensity": "f3/1803886264",
+			"atmosOxidizing": "f0/170822560",
 			"averageTemp": 76,
 			"axialTilt": "f1/3034018070",
 			"children": [
@@ -2438,8 +2438,8 @@
 				255,
 				3
 			],
-			"atmosDensity": "f0/0",
-			"atmosOxidizing": "f0/0",
+			"atmosDensity": "f3/2873333121",
+			"atmosOxidizing": "f0/73209672",
 			"averageTemp": 72,
 			"axialTilt": "f0/2122909538",
 			"children": [
@@ -2745,9 +2745,9 @@
 	"longDesc": "Sol is a fine joint",
 	"name": "Sol",
 	"pos": [
-		0.00800000037997961,
-		0.00800000037997961,
-		0.00800000037997961
+		0.0,
+		0.0,
+		0.0
 	],
 	"sector": [
 		0,

--- a/src/editor/system/GalaxyEditAPI.cpp
+++ b/src/editor/system/GalaxyEditAPI.cpp
@@ -518,9 +518,12 @@ void SystemBody::EditorAPI::EditOrbitalParameters(SystemBody *body, UndoSystem *
 				body->GetParent()->GetMass(),
 				-orbit_time_at_start).Length() / 1000.0;
 
-			ImGui::InputDouble("Orbital Velocity (AP)", &orbit_vel_ap, 0.0, 0.0, "%.2f km/s");
-			ImGui::InputDouble("Orbital Velocity (PE)", &orbit_vel_pe, 0.0, 0.0, "%.2f km/s");
+			ImGui::InputDouble("Orbital Vel. (AP)", &orbit_vel_ap, 0.0, 0.0, "%.2f km/s");
+			ImGui::InputDouble("Orbital Vel. (PE)", &orbit_vel_pe, 0.0, 0.0, "%.2f km/s");
 		}
+
+		double escape_velocity = body->CalcEscapeVelocity();
+		ImGui::InputDouble("Escape Velocity", &escape_velocity, 0.0, 0.0, "%0.2f km/s");
 
 		ImGui::EndDisabled();
 	}
@@ -720,7 +723,7 @@ void SystemBody::EditorAPI::EditProperties(SystemBody *body, Random &rng, UndoSy
 	bool gasGiant = body->GetSuperType() == SystemBody::SUPERTYPE_GAS_GIANT;
 
 	bodyChanged |= Draw::InputFixedSlider("Atm. Density", &body->m_volatileGas,
-		0.0, gasGiant ? 50.0 : 1.225, "%.3f kg/m³", 0);
+		0.0, gasGiant ? 2.0 : 1.225, "%.3f kg/m³", 0);
 	if (Draw::UndoHelper("Edit Atmosphere Density", undo))
 		AddUndoSingleValueClosure(undo, &body->m_volatileGas, updateBodyDerived);
 

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -709,6 +709,12 @@ void StarSystemRandomGenerator::PickPlanetType(SystemBody *sbody, Random &rand)
 		sbody->m_radius = fixed(rand.Int32(starTypeInfo[sbody->GetType()].radius[0], starTypeInfo[sbody->GetType()].radius[1]), 100);
 	} else if (sbody->GetMassAsFixed() > 6) {
 		sbody->m_type = SystemBody::TYPE_PLANET_GAS_GIANT;
+		// Generate a random "surface" density for gas giants roughly fitted to real-life estimation of Jupiter at "cloud deck" level
+		// The bounds are derived from real-world density-at-1-bar data for the outer gas giants with an
+		// approximation factor for density at cloud deck level of `3e * density @ 1 bar`
+		sbody->m_volatileGas = rand.NormFixed(fixed(1050, 1000), fixed(8000, 1000)).Abs();
+		// Most gas giant atmospheres contain an incredibly small or negligible proportion of oxidizing elements / water ice
+		sbody->m_atmosOxidizing = rand.NormFixed(fixed(0, 1), fixed(300, 1000)).Abs();
 	} else if (sbody->GetMassAsFixed() > fixed(1, 12000)) {
 		sbody->m_type = SystemBody::TYPE_PLANET_TERRESTRIAL;
 
@@ -822,6 +828,8 @@ void StarSystemRandomGenerator::PickPlanetType(SystemBody *sbody, Random &rand)
 		sbody->m_rotationPeriod = (1 - lambda) * sbody->GetRotationPeriodAsFixed() + lambda * sbody->GetOrbit().Period() / 3600 / 24;
 		sbody->m_axialTilt = (1 - lambda) * sbody->GetAxialTiltAsFixed() + lambda * sbody->GetInclinationAsFixed();
 	} // else .. nothing happens to the satellite
+
+	sbody->SetAtmFromParameters();
 
 	PickAtmosphere(sbody);
 	PickRings(sbody);

--- a/src/lua/LuaSystemBody.cpp
+++ b/src/lua/LuaSystemBody.cpp
@@ -483,10 +483,10 @@ static int l_sbody_attr_metallicity(lua_State *l)
 }
 
 /*
- * Attribute: volatileGas
+ * Attribute: atmosDensity
  *
- * Returns the measure of volatile gas present in the atmosphere of the body
- * 0.0 = no atmosphere, 1.0 = earth atmosphere density, 4.0+ ~= venus
+ * Returns the atmospheric density at "surface level" of the body
+ * 0.0 = no atmosphere, 1.225 = earth atmosphere density, 64+ ~= venus
  *
  * Availability:
  *
@@ -496,10 +496,10 @@ static int l_sbody_attr_metallicity(lua_State *l)
  *
  *   experimental
  */
-static int l_sbody_attr_volatileGas(lua_State *l)
+static int l_sbody_attr_atmosDensity(lua_State *l)
 {
 	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
-	lua_pushnumber(l, sbody->GetVolatileGas());
+	lua_pushnumber(l, sbody->GetAtmSurfaceDensity());
 	return 1;
 }
 
@@ -521,6 +521,26 @@ static int l_sbody_attr_atmosOxidizing(lua_State *l)
 {
 	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
 	lua_pushnumber(l, sbody->GetAtmosOxidizing());
+	return 1;
+}
+
+/*
+ * Attribute: surfacePressure
+ *
+ * The pressure of the atmosphere at the surface of the body (atm).
+ *
+ * Availability:
+ *
+ *   2024
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_sbody_attr_surfacePressure(lua_State *l)
+{
+	SystemBody *sbody = LuaObject<SystemBody>::CheckFromLua(1);
+	lua_pushnumber(l, sbody->GetAtmSurfacePressure());
 	return 1;
 }
 
@@ -810,8 +830,9 @@ void LuaObject<SystemBody>::RegisterClass()
 		{ "axialTilt", l_sbody_attr_axial_tilt },
 		{ "averageTemp", l_sbody_attr_average_temp },
 		{ "metallicity", l_sbody_attr_metallicity },
-		{ "volatileGas", l_sbody_attr_volatileGas },
+		{ "atmosDensity", l_sbody_attr_atmosDensity },
 		{ "atmosOxidizing", l_sbody_attr_atmosOxidizing },
+		{ "surfacePressure", l_sbody_attr_surfacePressure },
 		{ "volatileLiquid", l_sbody_attr_volatileLiquid },
 		{ "volatileIces", l_sbody_attr_volatileIces },
 		{ "volcanicity", l_sbody_attr_volcanicity },


### PR DESCRIPTION
This PR resolves an oversight/issue introduced with the System Editor series of PRs which resulted in randomly-generated gas giants not correctly computing an atmospheric density and the Sol system gas giants not having explicitly-set atmospheric densities.

This additionally fixes #5677 and partially addresses #4222 by defining the surface level for gas giants (which corresponds to the physical collision sphere below which a ship cannot pass) as being the "upper cloud deck" level. The density at cloud deck level is estimated using the expression `2𝑒 * density at 1 bar`, based on real-world data published by NASA regarding the solar system gas giants. I've correspondingly introduced a new generation expression for gas giant surface density using bounds fitted to real-world gas giant density, rather than the previous fixed 14kg/m³.

This definition for the surface density and height is necessary due to a) the lack of scientific data establishing cloud deck pressure or density, and b) the inability of ships in Pioneer to pass below the "surface" of a gas giant at this time without significant changes to the physics engine and autopilot code.

This PR additionally renames the Lua attribute `SystemBody.volatileGas` to `SystemBody.atmosDensity` (matching the name presented to the user in the SystemEditor) and adds a `SystemBody.surfacePressure` attribute which can be used to compute the mean atmospheric pressure at the defined surface of the body.