### PR TITLE
Fix MSVC CI build on non-PR refs

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -56,8 +56,8 @@ jobs:
 
     - name: Build MSVC
       shell: cmd
-      run: |        
-        for /f %%i in ('echo "${{ github.ref }}" ^| awk -F "/" "/pull/ { print \"PR#\"$3 } /heads/ { print $3 }"') do set PROJECT_VERSION_INFO=%%i
+      run: |
+        for /f %%i in ('echo ${{ github.ref }} ^| awk -F "/" "/pull/ { print \"PR#\"$3 } /heads/ { print $3 }"') do set PROJECT_VERSION_INFO=%%i
         echo Project Version: %PROJECT_VERSION_INFO%
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         cd pioneer


### PR DESCRIPTION
#5731 works fine for refspecs in the form `refs/pull/XXXX/merge`, but fails for `refs/heads/<branch>`. I suspect this is because of an erroneous quote character being passed through the `echo` command.