### PR TITLE
Refactor and rework random system generator

### DIFF
--- a/src/galaxy/SectorGenerator.cpp
+++ b/src/galaxy/SectorGenerator.cpp
@@ -274,12 +274,8 @@ bool SectorRandomSystemsGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> gala
 		}
 		//Output("%d: %d%\n", sx, sy);
 
-		if (s.m_numStars > 1) {
-			s.m_starType[1] = SystemBody::BodyType(rng.Int32(SystemBody::TYPE_STAR_MIN, s.m_starType[0]));
-			if (s.m_numStars > 2) {
-				s.m_starType[2] = SystemBody::BodyType(rng.Int32(SystemBody::TYPE_STAR_MIN, s.m_starType[0]));
-				s.m_starType[3] = SystemBody::BodyType(rng.Int32(SystemBody::TYPE_STAR_MIN, s.m_starType[2]));
-			}
+		for (int i = 1; i < s.m_numStars; i++) {
+			s.m_starType[i] = SystemBody::BodyType(rng.Int32(SystemBody::TYPE_STAR_MIN, s.m_starType[i - 1]));
 		}
 
 		if ((s.m_starType[0] <= SystemBody::TYPE_STAR_A) && (rng.Int32(10) == 0)) {

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1285,12 +1285,13 @@ bool StarSystemRandomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 
 	SystemBody *star[4];
 	SystemBody *centGrav1(0), *centGrav2(0);
+	const std::string systemName = sec->m_systems[system->GetPath().systemIndex].GetName();
 
 	const int numStars = secSys.GetNumStars();
 	assert((numStars >= 1) && (numStars <= 4));
 	if (numStars == 1) {
 		SystemBody::BodyType type = sec->m_systems[system->GetPath().systemIndex].GetStarType(0);
-		star[0] = MakeSystemBody(system, 0, sec->m_systems[system->GetPath().systemIndex].GetName(), nullptr);
+		star[0] = MakeSystemBody(system, 0, systemName, nullptr);
 		star[0]->m_orbMin = fixed();
 		star[0]->m_orbMax = fixed();
 
@@ -1298,15 +1299,15 @@ bool StarSystemRandomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 		system->SetRootBody(star[0]);
 		system->SetNumStars(1);
 	} else {
-		centGrav1 = MakeSystemBody(system, 0, sec->m_systems[system->GetPath().systemIndex].GetName(), "A,B");
+		centGrav1 = MakeSystemBody(system, 0, systemName, "A,B");
 		centGrav1->m_type = SystemBody::TYPE_GRAVPOINT;
 		system->SetRootBody(centGrav1);
 
 		SystemBody::BodyType type = sec->m_systems[system->GetPath().systemIndex].GetStarType(0);
-		star[0] = MakeSystemBody(system, centGrav1, sec->m_systems[system->GetPath().systemIndex].GetName(), "A");
+		star[0] = MakeSystemBody(system, centGrav1, systemName, "A");
 		MakeStarOfType(star[0], type, rng);
 
-		star[1] = MakeSystemBody(system, centGrav1, sec->m_systems[system->GetPath().systemIndex].GetName(), "B");
+		star[1] = MakeSystemBody(system, centGrav1, systemName, "B");
 		MakeStarOfTypeLighterThan(star[1], sec->m_systems[system->GetPath().systemIndex].GetStarType(1), star[0]->GetMassAsFixed(), rng);
 
 		centGrav1->m_mass = star[0]->GetMassAsFixed() + star[1]->GetMassAsFixed();
@@ -1326,21 +1327,21 @@ bool StarSystemRandomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 			}
 			// 3rd and maybe 4th star
 			if (numStars == 3) {
-				star[2] = MakeSystemBody(system, 0, sec->m_systems[system->GetPath().systemIndex].GetName(), "C");
+				star[2] = MakeSystemBody(system, 0, systemName, "C");
 				star[2]->m_orbMin = 0;
 				star[2]->m_orbMax = 0;
 				MakeStarOfTypeLighterThan(star[2], sec->m_systems[system->GetPath().systemIndex].GetStarType(2), star[0]->GetMassAsFixed(), rng);
 				centGrav2 = star[2];
 				system->SetNumStars(3);
 			} else {
-				centGrav2 = MakeSystemBody(system, 0, sec->m_systems[system->GetPath().systemIndex].GetName(), "C,D");
+				centGrav2 = MakeSystemBody(system, 0, systemName, "C,D");
 				centGrav2->m_type = SystemBody::TYPE_GRAVPOINT;
 				centGrav2->m_orbMax = 0;
 
-				star[2] = MakeSystemBody(system, centGrav2, sec->m_systems[system->GetPath().systemIndex].GetName(), "C");
+				star[2] = MakeSystemBody(system, centGrav2, systemName, "C");
 				MakeStarOfTypeLighterThan(star[2], sec->m_systems[system->GetPath().systemIndex].GetStarType(2), star[0]->GetMassAsFixed(), rng);
 
-				star[3] = MakeSystemBody(system, centGrav2, sec->m_systems[system->GetPath().systemIndex].GetName(), "D");
+				star[3] = MakeSystemBody(system, centGrav2, systemName, "D");
 				MakeStarOfTypeLighterThan(star[3], sec->m_systems[system->GetPath().systemIndex].GetStarType(3), star[2]->GetMassAsFixed(), rng);
 
 				// Separate stars by 0.2 radii for each, so that their planets don't bump into the other star
@@ -1351,7 +1352,7 @@ bool StarSystemRandomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 				centGrav2->m_children.push_back(star[3]);
 				system->SetNumStars(4);
 			}
-			SystemBody *superCentGrav = MakeSystemBody(system, 0, sec->m_systems[system->GetPath().systemIndex].GetName(), nullptr);
+			SystemBody *superCentGrav = MakeSystemBody(system, 0, systemName, nullptr);
 			superCentGrav->m_type = SystemBody::TYPE_GRAVPOINT;
 			centGrav1->m_parent = superCentGrav;
 			centGrav2->m_parent = superCentGrav;

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1292,13 +1292,9 @@ SystemBody* StarSystemRandomGenerator::MakeGravPointForBodies(RefCountedPtr<Star
 	return grav;
 }
 
-std::string StarSystemRandomGenerator::GetStarNameFromId(const int id)
+char StarSystemRandomGenerator::GetStarSuffixFromOffset(const int offsetId) const
 {
-	// UGLY HACK
-	assert((id >= 0) && (id < 26));
-	char buf[16];
-	snprintf(buf, sizeof(buf), "%c", 'A' + id);
-	return buf;
+	return 'A' + Clamp(offsetId, 0, 26);
 }
 
 SystemBody* StarSystemRandomGenerator::PlaceStars(Random &rng, RefCountedPtr<StarSystem::GeneratorAPI> system, const Sector::System &secSys, const int offset, const int numStars, const fixed maxMass = fixed())
@@ -1310,7 +1306,8 @@ SystemBody* StarSystemRandomGenerator::PlaceStars(Random &rng, RefCountedPtr<Sta
 		// We have only one star in the system, make it root
 
 		SystemBody::BodyType type = secSys.GetStarType(0);
-		body = MakeSystemBody(system, systemName, GetStarNameFromId(offset));
+		const std::string suffix(1, GetStarSuffixFromOffset(offset));
+		body = MakeSystemBody(system, systemName, suffix);
 
 		if (maxMass != 0) {
 			MakeStarOfTypeLighterThan(body, type, maxMass, rng);
@@ -1325,7 +1322,8 @@ SystemBody* StarSystemRandomGenerator::PlaceStars(Random &rng, RefCountedPtr<Sta
 
 		for (int i = 0; i < 2; i++) {
 			SystemBody::BodyType type = secSys.GetStarType(i);
-			bodies[i] = MakeSystemBody(system, systemName, GetStarNameFromId(offset + i));
+			const std::string suffix(1, GetStarSuffixFromOffset(offset + i));
+			bodies[i] = MakeSystemBody(system, systemName, suffix);
 			if (i == 0) {
 				if (maxMass != 0) {
 					MakeStarOfTypeLighterThan(bodies[i], secSys.GetStarType(i), maxMass, rng);

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1294,7 +1294,8 @@ SystemBody* StarSystemRandomGenerator::MakeGravPointForBodies(RefCountedPtr<Star
 
 char StarSystemRandomGenerator::GetStarSuffixFromOffset(const int offsetId) const
 {
-	return 'A' + Clamp(offsetId, 0, 26);
+	assert((offsetId >= 0) && (offsetId <= 25));
+	return 'A' + Clamp(offsetId, 0, 25);
 }
 
 SystemBody* StarSystemRandomGenerator::PlaceStars(Random &rng, RefCountedPtr<StarSystem::GeneratorAPI> system, const Sector::System &secSys, const int offset, const int numStars, const fixed maxMass = fixed())

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1273,7 +1273,7 @@ SystemBody* StarSystemRandomGenerator::MakeSystemBody(RefCountedPtr<StarSystem::
 	return newBody;
 }
 
-SystemBody* StarSystemRandomGenerator::MakeGravFor(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, SystemBody * body1, SystemBody * body2)
+SystemBody* StarSystemRandomGenerator::MakeGravPointForBodies(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, SystemBody * body1, SystemBody * body2)
 {
 	const std::string suffix1 = body1->m_name.substr(systemName.size() + 1);
 	const std::string suffix2 = body2->m_name.substr(systemName.size() + 1);
@@ -1339,7 +1339,7 @@ SystemBody* StarSystemRandomGenerator::PlaceStars(Random &rng, RefCountedPtr<Sta
 			system->AddStar(bodies[i]);
 		}
 
-		body = MakeGravFor(system, systemName, bodies[0], bodies[1]);
+		body = MakeGravPointForBodies(system, systemName, bodies[0], bodies[1]);
 
 		// Separate stars by 0.2 radii for each, so that their planets don't bump into the other star
 		const fixed minDist = fixed(12, 10) * (bodies[0]->GetRadiusAsFixed() + bodies[1]->GetRadiusAsFixed()) * AU_SOL_RADIUS;
@@ -1354,7 +1354,7 @@ SystemBody* StarSystemRandomGenerator::PlaceStars(Random &rng, RefCountedPtr<Sta
 		bodies[0] = PlaceStars(rng, system, secSys, offset,           chooseL, 0);
 		bodies[1] = PlaceStars(rng, system, secSys, offset + chooseL, chooseR, bodies[0]->GetMassAsFixed());
 
-		body = MakeGravFor(system, systemName, bodies[0], bodies[1]);
+		body = MakeGravPointForBodies(system, systemName, bodies[0], bodies[1]);
 
 		const fixed minDist = bodies[0]->m_orbMax + bodies[1]->m_orbMax;
 		MakeBinaryPair(bodies[0], bodies[1], 4 * minDist, rng);

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1220,25 +1220,31 @@ void StarSystemRandomGenerator::MakeBinaryPair(SystemBody *a, SystemBody *b, fix
 	fixed m = a->GetMassAsFixed() + b->GetMassAsFixed();
 	fixed a0 = b->GetMassAsFixed() / m;
 	fixed a1 = a->GetMassAsFixed() / m;
-	a->m_eccentricity = rand.NFixed(3);
+	fixed ecc = rand.NFixed(3);
+	fixed axis = fixed(0);
 	int mul = 1;
 
 	do {
 		switch (rand.Int32(3)) {
-		case 2: a->m_semiMajorAxis = fixed(rand.Int32(100, 10000), 100); break;
-		case 1: a->m_semiMajorAxis = fixed(rand.Int32(10, 1000), 100); break;
+		case 2: axis = fixed(rand.Int32(100, 10000), 100); break;
+		case 1: axis = fixed(rand.Int32(10, 1000), 100); break;
 		default:
-		case 0: a->m_semiMajorAxis = fixed(rand.Int32(1, 100), 100); break;
+		case 0: axis = fixed(rand.Int32(1, 100), 100); break;
 		}
-		a->m_semiMajorAxis *= mul;
+		axis *= mul;
 		mul *= 2;
-	} while (a->m_semiMajorAxis - a->m_eccentricity * a->m_semiMajorAxis < minDist);
+	} while (axis - ecc * axis < minDist);
+
+	a->m_semiMajorAxis = axis * a0;
+	b->m_semiMajorAxis = axis * a1;
+	a->m_eccentricity = ecc;
+	b->m_eccentricity = ecc;
 
 	const double total_mass = a->GetMass() + b->GetMass();
-	const double e = a->m_eccentricity.ToDouble();
+	const double e = ecc.ToDouble();
 
-	a->m_orbit.SetShapeAroundBarycentre(AU * (a->m_semiMajorAxis * a0).ToDouble(), total_mass, a->GetMass(), e);
-	b->m_orbit.SetShapeAroundBarycentre(AU * (a->m_semiMajorAxis * a1).ToDouble(), total_mass, b->GetMass(), e);
+	a->m_orbit.SetShapeAroundBarycentre(AU * a->m_semiMajorAxis.ToDouble(), total_mass, a->GetMass(), e);
+	b->m_orbit.SetShapeAroundBarycentre(AU * b->m_semiMajorAxis.ToDouble(), total_mass, b->GetMass(), e);
 
 	const float rotX = -0.5f * float(M_PI); //(float)(rand.Double()*M_PI/2.0);
 	const float rotY = static_cast<float>(rand.Double(M_PI));
@@ -1253,8 +1259,9 @@ void StarSystemRandomGenerator::MakeBinaryPair(SystemBody *a, SystemBody *b, fix
 	b->m_orbitalOffset = fixed(int(round(rotY * 10000)), 10000);
 	a->m_orbitalOffset = fixed(int(round(rotY * 10000)), 10000);
 
-	fixed orbMin = a->m_semiMajorAxis - a->m_eccentricity * a->m_semiMajorAxis;
-	fixed orbMax = 2 * a->m_semiMajorAxis - orbMin;
+	fixed orbMin = axis - ecc * axis;
+	fixed orbMax = 2 * axis - orbMin;
+
 	a->m_orbMin = orbMin;
 	b->m_orbMin = orbMin;
 	a->m_orbMax = orbMax;

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1345,6 +1345,7 @@ SystemBody* StarSystemRandomGenerator::PlaceStars(Random &rng, RefCountedPtr<Sta
 		const fixed minDist = fixed(12, 10) * (bodies[0]->GetRadiusAsFixed() + bodies[1]->GetRadiusAsFixed()) * AU_SOL_RADIUS;
 
 		MakeBinaryPair(bodies[0], bodies[1], minDist, rng);
+		body->m_orbMax = bodies[0]->m_orbMax + bodies[1]->m_orbMax;
 	} else {
 		SystemBody *bodies[2];
 
@@ -1358,6 +1359,7 @@ SystemBody* StarSystemRandomGenerator::PlaceStars(Random &rng, RefCountedPtr<Sta
 
 		const fixed minDist = bodies[0]->m_orbMax + bodies[1]->m_orbMax;
 		MakeBinaryPair(bodies[0], bodies[1], 4 * minDist, rng);
+		body->m_orbMax = minDist;
 	}
 
 	return body;

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1285,12 +1285,12 @@ bool StarSystemRandomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 
 	SystemBody *star[4];
 	SystemBody *centGrav1(0), *centGrav2(0);
-	const std::string systemName = sec->m_systems[system->GetPath().systemIndex].GetName();
+	const std::string systemName = secSys.GetName();
 
 	const int numStars = secSys.GetNumStars();
 	assert((numStars >= 1) && (numStars <= 4));
 	if (numStars == 1) {
-		SystemBody::BodyType type = sec->m_systems[system->GetPath().systemIndex].GetStarType(0);
+		SystemBody::BodyType type = secSys.GetStarType(0);
 		star[0] = MakeSystemBody(system, 0, systemName, nullptr);
 		star[0]->m_orbMin = fixed();
 		star[0]->m_orbMax = fixed();
@@ -1303,12 +1303,12 @@ bool StarSystemRandomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 		centGrav1->m_type = SystemBody::TYPE_GRAVPOINT;
 		system->SetRootBody(centGrav1);
 
-		SystemBody::BodyType type = sec->m_systems[system->GetPath().systemIndex].GetStarType(0);
+		SystemBody::BodyType type = secSys.GetStarType(0);
 		star[0] = MakeSystemBody(system, centGrav1, systemName, "A");
 		MakeStarOfType(star[0], type, rng);
 
 		star[1] = MakeSystemBody(system, centGrav1, systemName, "B");
-		MakeStarOfTypeLighterThan(star[1], sec->m_systems[system->GetPath().systemIndex].GetStarType(1), star[0]->GetMassAsFixed(), rng);
+		MakeStarOfTypeLighterThan(star[1], secSys.GetStarType(1), star[0]->GetMassAsFixed(), rng);
 
 		centGrav1->m_mass = star[0]->GetMassAsFixed() + star[1]->GetMassAsFixed();
 		centGrav1->m_children.push_back(star[0]);
@@ -1330,7 +1330,7 @@ bool StarSystemRandomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 				star[2] = MakeSystemBody(system, 0, systemName, "C");
 				star[2]->m_orbMin = 0;
 				star[2]->m_orbMax = 0;
-				MakeStarOfTypeLighterThan(star[2], sec->m_systems[system->GetPath().systemIndex].GetStarType(2), star[0]->GetMassAsFixed(), rng);
+				MakeStarOfTypeLighterThan(star[2], secSys.GetStarType(2), star[0]->GetMassAsFixed(), rng);
 				centGrav2 = star[2];
 				system->SetNumStars(3);
 			} else {
@@ -1339,10 +1339,10 @@ bool StarSystemRandomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 				centGrav2->m_orbMax = 0;
 
 				star[2] = MakeSystemBody(system, centGrav2, systemName, "C");
-				MakeStarOfTypeLighterThan(star[2], sec->m_systems[system->GetPath().systemIndex].GetStarType(2), star[0]->GetMassAsFixed(), rng);
+				MakeStarOfTypeLighterThan(star[2], secSys.GetStarType(2), star[0]->GetMassAsFixed(), rng);
 
 				star[3] = MakeSystemBody(system, centGrav2, systemName, "D");
-				MakeStarOfTypeLighterThan(star[3], sec->m_systems[system->GetPath().systemIndex].GetStarType(3), star[2]->GetMassAsFixed(), rng);
+				MakeStarOfTypeLighterThan(star[3], secSys.GetStarType(3), star[2]->GetMassAsFixed(), rng);
 
 				// Separate stars by 0.2 radii for each, so that their planets don't bump into the other star
 				const fixed minDist2 = (fixed(12, 10) * star[2]->GetRadiusAsFixed() + fixed(12, 10) * star[3]->GetRadiusAsFixed()) * AU_SOL_RADIUS;

--- a/src/galaxy/StarSystemGenerator.h
+++ b/src/galaxy/StarSystemGenerator.h
@@ -45,7 +45,7 @@ public:
 	static constexpr uint32_t BODY_SATELLITE_SALT = 0xf5123a90;
 
 	SystemBody *MakeSystemBody(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, const std::string &bodySuffix);
-	SystemBody *MakeGravFor(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, SystemBody *body1, SystemBody *body2);
+	SystemBody *MakeGravPointForBodies(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, SystemBody *body1, SystemBody *body2);
 	std::string GetStarNameFromId(const int id);
 	SystemBody *PlaceStars(Random &rng, RefCountedPtr<StarSystem::GeneratorAPI> system, const Sector::System &secSys, const int offset, const int numStars, const fixed maxMass);
 

--- a/src/galaxy/StarSystemGenerator.h
+++ b/src/galaxy/StarSystemGenerator.h
@@ -46,7 +46,7 @@ public:
 
 	SystemBody *MakeSystemBody(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, const std::string &bodySuffix);
 	SystemBody *MakeGravPointForBodies(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, SystemBody *body1, SystemBody *body2);
-	std::string GetStarNameFromId(const int id);
+	char GetStarSuffixFromOffset(const int offsetId) const;
 	SystemBody *PlaceStars(Random &rng, RefCountedPtr<StarSystem::GeneratorAPI> system, const Sector::System &secSys, const int offset, const int numStars, const fixed maxMass);
 
 	virtual bool Apply(Random &rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<StarSystem::GeneratorAPI> system, GalaxyGenerator::StarSystemConfig *config);

--- a/src/galaxy/StarSystemGenerator.h
+++ b/src/galaxy/StarSystemGenerator.h
@@ -45,6 +45,7 @@ public:
 	static constexpr uint32_t BODY_SATELLITE_SALT = 0xf5123a90;
 
 	SystemBody *MakeSystemBody(RefCountedPtr<StarSystem::GeneratorAPI> system, SystemBody *parent, const std::string &systemName, const char *bodySuffix);
+	SystemBody *MakeGravFor(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, SystemBody *body1, SystemBody *body2);
 
 	virtual bool Apply(Random &rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<StarSystem::GeneratorAPI> system, GalaxyGenerator::StarSystemConfig *config);
 

--- a/src/galaxy/StarSystemGenerator.h
+++ b/src/galaxy/StarSystemGenerator.h
@@ -44,7 +44,7 @@ class StarSystemRandomGenerator : public StarSystemLegacyGeneratorBase {
 public:
 	static constexpr uint32_t BODY_SATELLITE_SALT = 0xf5123a90;
 
-	SystemBody *MakeSystemBody(RefCountedPtr<StarSystem::GeneratorAPI> system, SystemBody *parent, const std::string &systemName, const char *bodySuffix);
+	SystemBody *MakeSystemBody(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, const char *bodySuffix);
 	SystemBody *MakeGravFor(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, SystemBody *body1, SystemBody *body2);
 
 	virtual bool Apply(Random &rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<StarSystem::GeneratorAPI> system, GalaxyGenerator::StarSystemConfig *config);

--- a/src/galaxy/StarSystemGenerator.h
+++ b/src/galaxy/StarSystemGenerator.h
@@ -44,8 +44,10 @@ class StarSystemRandomGenerator : public StarSystemLegacyGeneratorBase {
 public:
 	static constexpr uint32_t BODY_SATELLITE_SALT = 0xf5123a90;
 
-	SystemBody *MakeSystemBody(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, const char *bodySuffix);
+	SystemBody *MakeSystemBody(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, const std::string &bodySuffix);
 	SystemBody *MakeGravFor(RefCountedPtr<StarSystem::GeneratorAPI> system, const std::string &systemName, SystemBody *body1, SystemBody *body2);
+	std::string GetStarNameFromId(const int id);
+	SystemBody *PlaceStars(Random &rng, RefCountedPtr<StarSystem::GeneratorAPI> system, const Sector::System &secSys, const int offset, const int numStars, const fixed maxMass);
 
 	virtual bool Apply(Random &rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<StarSystem::GeneratorAPI> system, GalaxyGenerator::StarSystemConfig *config);
 
@@ -57,6 +59,7 @@ public:
 
 private:
 	void MakePlanetsAround(RefCountedPtr<StarSystem::GeneratorAPI> system, SystemBody *primary, Random &rand);
+	void MakePlanetsAroundChildrenGravs(RefCountedPtr<StarSystem::GeneratorAPI> system, SystemBody *primary, Random &rand);
 	void MakeRandomStar(SystemBody *sbody, Random &rand);
 	void MakeStarOfType(SystemBody *sbody, SystemBody::BodyType type, Random &rand);
 	void MakeStarOfTypeLighterThan(SystemBody *sbody, SystemBody::BodyType type, fixed maxMass, Random &rand);

--- a/src/galaxy/StarSystemGenerator.h
+++ b/src/galaxy/StarSystemGenerator.h
@@ -44,6 +44,8 @@ class StarSystemRandomGenerator : public StarSystemLegacyGeneratorBase {
 public:
 	static constexpr uint32_t BODY_SATELLITE_SALT = 0xf5123a90;
 
+	SystemBody *MakeSystemBody(RefCountedPtr<StarSystem::GeneratorAPI> system, SystemBody *parent, const std::string &systemName, const char *bodySuffix);
+
 	virtual bool Apply(Random &rng, RefCountedPtr<Galaxy> galaxy, RefCountedPtr<StarSystem::GeneratorAPI> system, GalaxyGenerator::StarSystemConfig *config);
 
 	// Calculate the min, max distances from the primary where satellites should be generated


### PR DESCRIPTION
Current implementation allows up to *four* stars in the system with only layout of "two binary systems orbiting each other"

- [x] Clean up the code
- [x] Work out on star layouts
- [x] Remove upper limit of stars being generated (separate PR)