### PR TITLE
Fix 'nil' in hyperdrive Maintenance BBS advert

### DIFF
--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -114,6 +114,7 @@ local onChat = function (form, ref, option)
 	local pricesuggestion = string.interp(ad.price, {
 		drive = hyperdrive and hyperdrive:GetName() or lui.NONE,
 		price = Format.Money(price),
+		lasttime = lastServiceMessage(hyperdrive),
 	})
 
 	if not hyperdrive then
@@ -134,9 +135,7 @@ local onChat = function (form, ref, option)
 		form:SetFace(ad.mechanic)
 		-- Replace token with details of last service (which might have
 		-- been seconds ago)
-		form:SetMessage(string.interp(message, {
-			lasttime = lastServiceMessage(hyperdrive),
-		}))
+		form:SetMessage(message)
 		if not hyperdrive then
 			-- er, do nothing, I suppose.
 		elseif Game.player:GetMoney() < price then


### PR DESCRIPTION
Supposed to print time since last maintenance of engines.

Fixes #5752

I'm not sure why the code was structured the way it was, but it was written like that for NewUI (did it not refresh as imgui does?)

Tested it's correct for ship with and without engines to service, as well as when you service, and click advert again. 


