### PR TITLE
Local missions should list distances in AU rather than Ly

### DIFF
--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -102,13 +102,27 @@ local function makeMissionRows()
 		end
 
 		local playerSystem = Game.system or Game.player:GetHyperspaceTarget()
-		local dist = playerSystem:DistanceTo(mission.location)
 		local days = math.max(0, (mission.due - Game.time) / (24*60*60))
+
+		-- Use AU for interplanetary, LY for interstellar distances
+		local dist, dist_display
+		if mission.location:IsSameSystem(playerSystem.path) then
+			if mission.location:IsBodyPath() then
+				local body = mission.location:GetSystemBody().body
+				dist = Game.player:GetPositionRelTo(body):length()
+				dist_display = "\n" .. ui.Format.Distance(dist)
+			else
+				dist_display = "\n-"
+			end
+		else
+			dist = playerSystem:DistanceTo(mission.location)
+			dist_display = string.format("\n%.2f %s", dist, l.LY)
+		end
 
 		local row = {
 			mission:GetTypeDescription(),
 			mission.client.name,
-			locationName .. string.format("\n%.2f %s", dist, l.LY),
+			locationName .. dist_display,
 			ui.Format.Date(mission.due) .."\n".. string.format(l.D_DAYS_LEFT, days),
 			ui.Format.Money(mission.reward),
 		}


### PR DESCRIPTION
When listing table of all player's accepted missions, local deliveries all have distance "0 ly". Switch to AU instead.

Fixes #5755

## Demonstration
![2024-02-10-122202_1266x687_scrot](https://github.com/pioneerspacesim/pioneer/assets/619390/d8f22081-d945-430b-af26-32dfe5d06f57)

## Pondering
- do we have AU units defined elsewhere that I should use, or defining it in the local file is good?
- under which circumstances would `mission.location:GetSystemBody()` return nil, and what should one display in that circumstance?

