### PR TITLE
Add a recovery reader for the v90 flight log

### DIFF
--- a/data/modules/FlightLog/FlightLog.lua
+++ b/data/modules/FlightLog/FlightLog.lua
@@ -381,36 +381,7 @@ local loaded_data
 
 local onGameStart = function ()
 
-	if loaded_data and loaded_data.Version == 1 then
-
-		for _, v in pairs( loaded_data.System ) do
-
-			local data = { systemp = v[1], arrtime = v[2], deptime = nil, entry = v[4] }
-			if ( data.arrtime ~= nil ) then
-				-- entry
-				table.insert(FlightLogData, FlightLogEntry.System.Unserialize( data ))
-			end
-			data.arrtime = nil
-			data.deptime = v[3]
-			if (data.deptime ~= nil) then
-				-- exit
-				table.insert(FlightLogData, FlightLogEntry.System.Unserialize( data ))
-			end
-		end
-
-		for _, v in pairs( loaded_data.Station ) do
-			local data = { systemp = v[1], deptime = v[2], money = v[3], entry = v[4] }
-			table.insert(FlightLogData, FlightLogEntry.Station.Unserialize(data))
-		end
-
-		for _, v in pairs( loaded_data.Custom ) do
-			local data = { systemp = v[1], time = v[2], money = v[3], location = v[4], entry = v[5] }
-			table.insert(FlightLogData, FlightLogEntry.Custom.Unserialize(data))
-		end
-
-		FlightLog.OrganizeEntries()
-
-	elseif loaded_data and loaded_data.Version > 1 then
+	if loaded_data then
 		FlightLogData = loaded_data.Data
 	end
 
@@ -432,7 +403,6 @@ end
 local serialize = function ()
 	return {
 		Data = FlightLogData,
-		Version = 2 -- version for backwards compatibility
 	}
 end
 

--- a/data/modules/FlightLog/FlightLog.lua
+++ b/data/modules/FlightLog/FlightLog.lua
@@ -226,12 +226,12 @@ end
 --   time - Game date
 --   money - Financial balance at time of record creation
 --   location - Array, with two strings: flight state, and relevant additional string
---   text - Free text string
+--   entry - Free text string
 --
 ---@param entry table
 function FlightLog.InsertCustomEntry(entry)
-	if entry.path and entry.time and entry.money and entry.location and entry.text then
-		FlightLog.AddEntry( FlightLogEntry.Custom.New( entry.path, entry.time, entry.money, entry.location, entry.text ) )
+	if entry.path and entry.time and entry.money and entry.location and entry.entry then
+		FlightLog.AddEntry( FlightLogEntry.Custom.New( entry.path, entry.time, entry.money, entry.location, entry.entry ) )
 		return true
 	else
 		return false
@@ -254,12 +254,12 @@ end
 --   path - System path, pointing to player's current system
 --   arrtime - Game date, arrival
 --   deptime - Game date, departure (optional)
---   text - Free text string (optional)
+--   entry - Free text string (optional)
 --
 ---@param entry table
 function FlightLog.InsertSystemEntry(entry)
 	if entry.path and (entry.arrtime or entry.deptime) then
-		FlightLog.AddEntry( FlightLogEntry.System.New( entry.path, entry.arrtime, entry.deptime, entry.text or "" ) )
+		FlightLog.AddEntry( FlightLogEntry.System.New( entry.path, entry.arrtime, entry.deptime, entry.entry or "" ) )
 		return true
 	else
 		return false
@@ -280,14 +280,14 @@ end
 -- Entry:
 --
 --   path - System path
---   arrtime - Game date, arrival
+--   deptime - Game date, _arrival_
 --   money - Financial balance at time of record creation
---   text - Free text string (optional)
+--   entry - Free text string (optional)
 --
 ---@param entry table
 function FlightLog.InsertStationEntry(entry)
-	if entry.path and entry.time and entry.money then
-		FlightLog.AddEntry( FlightLogEntry.Station.New( entry.path, entry.time, entry.money, entry.text or "" ) )
+	if entry.path and entry.deptime and entry.money then
+		FlightLog.AddEntry( FlightLogEntry.Station.New( entry.path, entry.deptime, entry.money, entry.entry or "" ) )
 		return true
 	else
 		return false

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -173,10 +173,10 @@ local function startGame(gameParams)
 	for _, entry in ipairs(gameParams.flightlog.Custom) do
 		if FlightLog.InsertCustomEntry(entry) then
 			-- ok then
-		elseif entry.text then
+		elseif entry.entry then
 			-- allow a custom log entry containing only text
 			-- because when starting a new game we only have text
-			FlightLog.MakeCustomEntry(entry.text)
+			FlightLog.MakeCustomEntry(entry.entry)
 		else
 			logWarning("Wrong entry for the custom flight log")
 		end

--- a/data/pigui/modules/new-game-window/flight-log.lua
+++ b/data/pigui/modules/new-game-window/flight-log.lua
@@ -233,6 +233,44 @@ FlightLog.reader = Helpers.versioned {{
 
 		return value
 	end
+
+}, {
+
+	version = 90,
+	fnc = function(saveGame)
+
+		local function entryWithSafeSystemPath(entry)
+			local parsed = {}
+			for k,v in pairs(entry) do
+				if k == 'systemp' then
+					parsed.path = systemPathFromTable(entry.systemp.inner)
+				else
+					parsed[k] = v
+				end
+			end
+			return parsed
+		end
+
+		local value = { Custom = {}, System = {}, Station = {} }
+
+		local logData, errorString = Helpers.getByPath(saveGame, "lua_modules_json/FlightLog/Data")
+		if errorString then return nil, errorString end
+
+		for _, entry in ipairs(logData) do
+			local entryType = Helpers.getLuaClass(entry)
+
+			if entryType == 'FlightLogEntry.Custom' then
+				table.insert(value.Custom, entryWithSafeSystemPath(entry))
+			elseif entryType == 'FlightLogEntry.System' then
+				table.insert(value.System, entryWithSafeSystemPath(entry))
+			elseif entryType == 'FlightLogEntry.Station' then
+				table.insert(value.Station, entryWithSafeSystemPath(entry))
+			else
+				return nil, lui.UNKNOWN_STATION_LOG_ENTRY_FORMAT
+			end
+		end
+		return value
+	end
 }}
 
 FlightLog.updateLayout = false

--- a/data/pigui/modules/new-game-window/flight-log.lua
+++ b/data/pigui/modules/new-game-window/flight-log.lua
@@ -26,7 +26,7 @@ function FlightLog:fromStartVariant(variant)
 	self.value.System = {}
 	self.value.Station = {}
 	self.value.Custom = {
-		variant.logmsg and { text = variant.logmsg }
+		variant.logmsg and { entry = variant.logmsg }
 	}
 end
 
@@ -86,22 +86,22 @@ local entryTemplates = {
 		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
 		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
 		{ id = "money",    label = lui.CASH,           render = Format.Money },
-		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+		{ id = "entry",    label = lui.ENTRY,          render = tostring, wrap = true },
 	},
 	System = {
 		{ id = "arrtime",  label = lui.ARRIVAL_DATE,   render = Format.Date },
 		{ id = "deptime",  label = lui.DEPARTURE_DATE, render = Format.Date },
 		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
 		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
-		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+		{ id = "entry",    label = lui.ENTRY,          render = tostring, wrap = true },
 	},
 	Station = {
-		{ id = "time",     label = lui.DATE,           render = Format.Date },
+		{ id = "deptime",  label = lui.DATE,           render = Format.Date },
 		{ id = "path",     label = lui.STATION,        render = asStation },
 		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
 		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
 		{ id = "money",    label = lui.CASH,           render = Format.Money },
-		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+		{ id = "entry",    label = lui.ENTRY,          render = tostring, wrap = true },
 	},
 }
 
@@ -187,9 +187,9 @@ FlightLog.reader = Helpers.versioned {{
 				parsed.location = loc and { loc[1], loc[2], loc[3] }
 				parsed.path = systemPathFromTable(entry[1].inner)
 				parsed.money = entry[3]
-				parsed.text = entry[5]
+				parsed.entry = entry[5]
 			end
-			if not entry or not parsed.time or not parsed.location or not parsed.path or not parsed.money or not parsed.text then
+			if not entry or not parsed.time or not parsed.location or not parsed.path or not parsed.money or not parsed.entry then
 				return nil, lui.UNKNOWN_CUSTOM_LOG_ENTRY_FORMAT
 			end
 			table.insert(value.Custom, parsed)
@@ -205,7 +205,7 @@ FlightLog.reader = Helpers.versioned {{
 				parsed.arrtime = entry[2]
 				parsed.deptime = entry[3]
 				parsed.path = systemPathFromTable(entry[1].inner)
-				parsed.text = entry[4]
+				parsed.entry = entry[4]
 			end
 			if not entry or not parsed.path then
 				return nil, lui.UNKNOWN_SYSTEM_LOG_ENTRY_FORMAT
@@ -220,12 +220,12 @@ FlightLog.reader = Helpers.versioned {{
 		for _, entry in ipairs(station) do
 			local parsed = {}
 			if entry then
-				parsed.time = entry[2]
+				parsed.deptime = entry[2]
 				parsed.path = systemPathFromTable(entry[1].inner)
 				parsed.money = entry[3]
-				parsed.text = entry[4]
+				parsed.entry = entry[4]
 			end
-			if not entry or not parsed.time or not parsed.path or not parsed.money then
+			if not entry or not parsed.deptime or not parsed.path or not parsed.money then
 				return nil, lui.UNKNOWN_STATION_LOG_ENTRY_FORMAT
 			end
 			table.insert(value.Station, parsed)

--- a/data/pigui/modules/new-game-window/helpers.lua
+++ b/data/pigui/modules/new-game-window/helpers.lua
@@ -191,4 +191,29 @@ function Helpers.getPlayerShipParameter(saveGame, paramPath)
 	return param
 end
 
+--
+-- Function: Helpers.getLuaClass
+--
+-- Retrieves the value of the 'class' field from the metatable. It should have
+-- been there when the save was unpickled.
+--
+-- Example:
+--
+-- > local entryType = Helpers.getLuaClass(entry)
+--
+-- Parameters:
+--
+--   tbl - table
+--
+-- Returns:
+--
+--   typename - string?
+--
+---@param tbl table
+---@return string? typename
+function Helpers.getLuaClass(tbl)
+	local typeTable = getmetatable(tbl)
+	if typeTable then return typeTable.class end
+end
+
 return Helpers

--- a/data/pigui/modules/new-game-window/recovery.lua
+++ b/data/pigui/modules/new-game-window/recovery.lua
@@ -30,6 +30,8 @@ local fixupDoc = Helpers.versioned {{
 
 		local refs = {}
 
+		local typeTables = {}
+
 		local function unpickle(tbl)
 			local result = {}
 			tbl = tbl.table
@@ -59,6 +61,14 @@ local fixupDoc = Helpers.versioned {{
 
 			local result = {}
 			if tbl.ref then
+				if tbl.lua_class then
+					local typeTable = typeTables[tbl.lua_class]
+					if not typeTable then
+						typeTable = { class = tbl.lua_class }
+						typeTables[tbl.lua_class] = typeTable
+					end
+					setmetatable(result, typeTable)
+				end
 				cache[tbl.ref] = result
 				tbl = refs[tbl.ref]
 			else


### PR DESCRIPTION
Although the flight log is now a single list, it still has the same three types of entries. Therefore it can still be shown without changing the GUI in the start menu, where 3 sections (entry types) are shown separately, depending on the combobox.

It is now possible to determine the log entry type only by the object type, which becomes available after full deserialization. But I would not want to do this, including reusing the actual code from the game, since it may change over time. Information about the object type is contained in the `lua_class` field, which is lost when the save tree is unpickled. In order to save this information, and at the same time not change anything radically in the unpickled tree, it was decided to put all type names into one separate subtable in the save tree, `type_names`, the keys in which will be the tables corresponding to the unpickled objects.