### PR TITLE
Generate atmospheres for gas giants in legacy custom systems

### DIFF
--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -1018,7 +1018,9 @@ void CustomSystemsDatabase::RunLuaSystemSanityChecks(CustomSystem *csys)
 
 		bool wantRings = body->ringStatus == CustomSystemBody::WANT_RANDOM_RINGS || body->ringStatus == CustomSystemBody::WANT_RINGS;
 
-		if (!(body->want_rand_offset || body->want_rand_phase || body->want_rand_arg_periapsis || wantRings))
+		bool wantAtm = body->bodyData.m_type == SystemBodyType::TYPE_PLANET_GAS_GIANT && body->bodyData.m_volatileGas == fixed(0);
+
+		if (!(body->want_rand_offset || body->want_rand_phase || body->want_rand_arg_periapsis || wantRings || wantAtm))
 			continue;
 
 		// Generate body orbit parameters from its seed
@@ -1045,6 +1047,12 @@ void CustomSystemsDatabase::RunLuaSystemSanityChecks(CustomSystem *csys)
 				break;
 			default: break;
 			}
+		}
+
+		if (wantAtm) {
+			// Taken from StarSystemRandomGenerator::PickPlanetType
+			body->bodyData.m_volatileGas = rand.NormFixed(fixed(1050, 1000), fixed(8000, 1000)).Abs();
+			body->bodyData.m_atmosOxidizing = rand.NormFixed(fixed(0, 1), fixed(300, 1000)).Abs();
 		}
 
 	}


### PR DESCRIPTION
Prior to the merge of the System Editor and associated system generation refactor, all gas giants had a fixed 14.0 kg/m3 atmospheric surface density value which overrode the value of `m_volatileGas` and thus many Lua custom systems never set the atmospheric density parameter, which resulted gas giants in custom systems (e.g. Sol, Noril, etc.) missing scoopable atmospheres.

Sol was resolved by manually editing the gas giants to set density to real-world values; this PR follows up and adds an additional "fixup" step when loading legacy Lua custom systems that generates "missing" atmospheric density values for gas giants.

**Testing Steps:**
Visit Noril C and attempt to scoop it for fuel. It should have an atmospheric density > 0 before you crash :wink:
