### PR TITLE
Fix projectiles being added a frame behind where they are fired and beam weapons not able to hit

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -69,8 +69,6 @@ Game::Game(const SystemPath &path, const double startDateTime, const char *shipT
 
 	m_space.reset(new Space(this, m_galaxy, path));
 
-	m_space->UpdateBodies();
-
 	Body *b = m_space->FindBodyForPath(&path);
 	assert(b);
 
@@ -533,8 +531,6 @@ void Game::SwitchToNormalSpace()
 	m_player->SetFrame(m_space->GetRootFrame());
 	m_space->AddBody(m_player.get());
 
-	m_space->UpdateBodies();
-
 	// place it
 	vector3d pos, vel;
 	m_space->GetHyperspaceExitParams(m_hyperspaceSource, m_hyperspaceDest, pos, vel);
@@ -975,8 +971,6 @@ void Game::SaveGame(const std::string &filename, Game *game)
 	}
 	if (!f)
 		throw CouldNotOpenFileException();
-
-	game->m_space->UpdateBodies();
 	Json rootNode;
 	game->ToJson(rootNode); // Encode the game data as JSON and give to the root value.
 	std::vector<uint8_t> jsonData;

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -1076,7 +1076,7 @@ void Space::TimeStep(float step)
 	// https://github.com/pioneerspacesim/pioneer/issues/5695
 	//
 	// THIS IS A HACK/WORKAROUND until a more proper solution can be found
-	for (size_t i = 0, e = m_bodies.size(); i != e; ++i) {
+	for (size_t i = 0; i < m_bodies.size(); ++i) {
 		auto b = m_bodies[i];
 		b->StaticUpdate(step);
 	}

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -18,9 +18,9 @@
 #include "SpaceStation.h"
 #include "Star.h"
 #include "SystemView.h"
-#include "core/Log.h"
 #include "collider/CollisionContact.h"
 #include "collider/CollisionSpace.h"
+#include "core/Log.h"
 #include "galaxy/Galaxy.h"
 #include "graphics/Graphics.h"
 #include "lua/LuaEvent.h"
@@ -263,7 +263,7 @@ Space::Space(Game *game, RefCountedPtr<Galaxy> galaxy, const Json &jsonObj, doub
 	try {
 		Json bodyArray = spaceObj["bodies"].get<Json::array_t>();
 		for (Uint32 i = 0; i < bodyArray.size(); i++) {
-			if(bodyArray[i].count("is_not_in_space") > 0)
+			if (bodyArray[i].count("is_not_in_space") > 0)
 				continue;
 			m_bodies.push_back(Body::FromJson(bodyArray[i], this));
 		}
@@ -354,7 +354,7 @@ void Space::ToJson(Json &jsonObj)
 	for (size_t i = 0; i < m_bodyIndex.size() - 1; i++) {
 		// First index of m_bodyIndex is reserved to
 		// nullptr or bad index
-		Body* b = m_bodyIndex[i + 1];
+		Body *b = m_bodyIndex[i + 1];
 		Json bodyArrayEl({}); // Create JSON object to contain body.
 		if (!b->IsInSpace()) {
 			bodyArrayEl["is_not_in_space"] = true;
@@ -456,10 +456,7 @@ void Space::RebuildSystemBodyIndex()
 
 void Space::AddBody(Body *b)
 {
-#ifndef NDEBUG
-	assert(!m_processingFinalizationQueue);
-#endif
-	m_assignedBodies.emplace_back(b, BodyAssignation::CREATE);
+	m_bodies.push_back(b);
 }
 
 void Space::RemoveBody(Body *b)
@@ -1071,9 +1068,18 @@ void Space::TimeStep(float step)
 		b->UpdateFrame();
 
 	// AI acts here, then move all bodies and frames
-	for (Body *b : m_bodies)
+	// NOTE: The AI can add bodies here so we can't use an iterator
+	// this restores the previous version where only the initial list is
+	// updated unless the bodies vector reallocated where anything could
+	// have happened
+	// alternative fixes to delay addition caused
+	// https://github.com/pioneerspacesim/pioneer/issues/5695
+	//
+	// THIS IS A HACK/WORKAROUND until a more proper solution can be found
+	for (size_t i = 0, e = m_bodies.size(); i != e; ++i) {
+		auto b = m_bodies[i];
 		b->StaticUpdate(step);
-
+	}
 	Frame::UpdateOrbitRails(m_game->GetTime(), m_game->GetTimeStep());
 
 	for (Body *b : m_bodies)
@@ -1094,26 +1100,22 @@ void Space::UpdateBodies()
 	m_processingFinalizationQueue = true;
 #endif
 
-	// adding, removing or deleting bodies from space
+	// removing or deleting bodies from space
 	for (const auto &b : m_assignedBodies) {
-		if (b.second == BodyAssignation::CREATE) {
-			m_bodies.push_back(b.first);
-		} else {
-			auto remove_iterator = m_bodies.end();
-			for (auto it = m_bodies.begin(); it != m_bodies.end(); ++it) {
-				if (*it != b.first)
-					(*it)->NotifyRemoved(b.first);
-				else
-					remove_iterator = it;
-			}
-			if (remove_iterator != m_bodies.end()) {
-				*remove_iterator = m_bodies.back();
-				m_bodies.pop_back();
-				if (b.second == BodyAssignation::KILL)
-					delete b.first;
-				else
-					b.first->SetFrame(FrameId::Invalid);
-			}
+		auto remove_iterator = m_bodies.end();
+		for (auto it = m_bodies.begin(); it != m_bodies.end(); ++it) {
+			if (*it != b.first)
+				(*it)->NotifyRemoved(b.first);
+			else
+				remove_iterator = it;
+		}
+		if (remove_iterator != m_bodies.end()) {
+			*remove_iterator = m_bodies.back();
+			m_bodies.pop_back();
+			if (b.second == BodyAssignation::KILL)
+				delete b.first;
+			else
+				b.first->SetFrame(FrameId::Invalid);
 		}
 	}
 

--- a/src/Space.h
+++ b/src/Space.h
@@ -65,7 +65,6 @@ public:
 	Body *FindNearestTo(const Body *b, ObjectType t) const;
 	Body *FindBodyForPath(const SystemPath *path) const;
 
-
 	Uint32 GetNumBodies() const { return static_cast<Uint32>(m_bodies.size()); }
 	IterationProxy<std::vector<Body *>> GetBodies() { return MakeIterationProxy(m_bodies); }
 	const IterationProxy<const std::vector<Body *>> GetBodies() const { return MakeIterationProxy(m_bodies); }
@@ -105,12 +104,6 @@ public:
 	//it is not designed to be called in each game loop!
 	std::vector<BodyDist> BodiesInAngle(const Body *b, const vector3d &offset, const vector3d &dir, double cosOfMaxAngle) const;
 
-	// Don't call this unless you really have to
-	// A bit of a hack but required so we can add a player
-	// into space as we emerge from hyperspace
-	// and then find stuff.
-	void UpdateBodies();
-
 private:
 	void GenSectorCache(RefCountedPtr<Galaxy> galaxy, const SystemPath *here);
 	void UpdateStarSystemCache(const SystemPath *here);
@@ -118,6 +111,7 @@ private:
 	// make sure SystemBody* is in Pi::currentSystem
 	FrameId GetFrameWithSystemBody(const SystemBody *b) const;
 
+	void UpdateBodies();
 
 	void CollideFrame(FrameId fId);
 
@@ -133,11 +127,10 @@ private:
 	// all the bodies we know about
 	std::vector<Body *> m_bodies;
 
-	// bodies that were removed/killed/added this timestep and need pruning/adding at the end
+	// bodies that were removed/killed this timestep and need pruning at the end
 	enum class BodyAssignation {
 		KILL = 0,
-		REMOVE = 1,
-		CREATE = 2
+		REMOVE = 1
 	};
 
 	std::vector<std::pair<Body *, BodyAssignation>> m_assignedBodies;
@@ -155,7 +148,6 @@ private:
 	//e.g. starfield and milky way)
 	std::unique_ptr<Background::Container> m_background;
 
-
 	class BodyNearFinder {
 	public:
 		BodyNearFinder(const Space *space) :
@@ -166,7 +158,6 @@ private:
 		BodyNearList GetBodiesMaybeNear(const vector3d &pos, double dist);
 
 	private:
-
 		const Space *m_space;
 		std::vector<BodyDist> m_bodyDist;
 		std::vector<Body *> m_nearBodies;

--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -116,7 +116,7 @@ void CollisionSpace::TraceRay(const vector3d &start, const vector3d &dir, double
 	isect_result.reserve(8);
 
 	if (m_enabledStaticGeoms > 0) {
-		m_staticObjectTree->TraceRay(start, dir, len, isect_result);
+		m_staticObjectTree->TraceRay(start, invDir, len, isect_result);
 
 		for (uint32_t &idx : isect_result) {
 			Geom *g = m_staticGeoms[idx];
@@ -127,7 +127,7 @@ void CollisionSpace::TraceRay(const vector3d &start, const vector3d &dir, double
 	}
 
 	if (m_enabledDynGeoms > 0) {
-		m_dynamicObjectTree->TraceRay(start, dir, len, isect_result);
+		m_dynamicObjectTree->TraceRay(start, invDir, len, isect_result);
 
 		for (uint32_t &idx : isect_result) {
 			Geom *g = m_geoms[idx];


### PR DESCRIPTION
This makes combat impossible if travelling at speed

Fixes #5695 and Fixes #5741

Revert initial change that fixed adding items to the vector whilst iterating it but introduced the frame lag and instead fix in a simple way.