### PR TITLE
Fix error in SearchRescue.lua in custom systems

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -799,8 +799,11 @@ static FrameId MakeFramesFor(const double at_time, SystemBody *sbody, Body *b, F
 		rotFrame->SetBodies(sbody, b);
 
 		matrix3x3d rotMatrix = matrix3x3d::RotateX(sbody->GetAxialTilt());
-		double angSpeed = 2.0 * M_PI / sbody->GetRotationPeriod();
-		rotFrame->SetAngSpeed(angSpeed);
+
+		if (sbody->GetRotationPeriod() > 0.0) {
+			double angSpeed = 2.0 * M_PI / sbody->GetRotationPeriod();
+			rotFrame->SetAngSpeed(angSpeed);
+		}
 
 		if (sbody->HasRotationPhase())
 			rotMatrix = rotMatrix * matrix3x3d::RotateY(sbody->GetRotationPhaseAtStart());

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -644,8 +644,8 @@ void CustomSystem::LoadFromJson(const Json &systemdef)
 
 	const Json &sector = systemdef["sector"];
 	sectorX = sector[0].get<int32_t>();
-	sectorZ = sector[1].get<int32_t>();
-	sectorY = sector[2].get<int32_t>();
+	sectorY = sector[1].get<int32_t>();
+	sectorZ = sector[2].get<int32_t>();
 
 	const Json &position = systemdef["pos"];
 	pos.x = position[0].get<float>();


### PR DESCRIPTION
If a custom system body had a rotational period of exactly 0 days, when visiting the system it would create a rotational frame for that body with infinite angular velocity. As a result of math operations on Inf / NaN values, the rotation matrix for that frame would contain NaN values which caused the distance between the reference body and that body to compute as NaN. This lead to a nil value being returned from `Space.FindNearestTo()` in `SearchRescue.lua:1063`, which caused the error the user is likely to see.

Fixes #5745.

This PR also contains a fix for an issue where sector indices for JSON custom systems were being loaded from the wrong array locations. The system linked in the issue report above is actually supposed to be in sector `5, 0, 2`, but was loading into sector `5, 2, 0`.