### PR TITLE
Editor Welcome Screen

### DIFF
--- a/src/editor/EditorApp.h
+++ b/src/editor/EditorApp.h
@@ -75,4 +75,18 @@ namespace Editor {
 		float minRuntime = 1.f;
 	};
 
+	class EditorWelcomeScreen : public Application::Lifecycle {
+	public:
+		EditorWelcomeScreen(EditorApp *app) :
+			Application::Lifecycle(),
+			m_app(app)
+		{}
+
+	protected:
+		void Update(float dt) override;
+
+	private:
+		EditorApp *m_app;
+	};
+
 } // namespace Editor

--- a/src/editor/EditorIcons.h
+++ b/src/editor/EditorIcons.h
@@ -12,6 +12,8 @@
 #define EICON_SPACE_STATION u8"\uF063"
 #define EICON_SURFACE_STATION u8"\uF073"
 
+#define EICON_SYSTEM_EDITOR u8"\uF08E"
+
 #define EICON_STOP u8"\uF054"
 #define EICON_PAUSE u8"\uF055"
 #define EICON_PLAY u8"\uF056"

--- a/src/editor/system/SystemEditor.cpp
+++ b/src/editor/system/SystemEditor.cpp
@@ -422,6 +422,8 @@ void SystemEditor::RegisterMenuActions()
 			if (HasUnsavedChanges()) {
 				m_unsavedFileModal = m_app->PushModal<UnsavedFileModal>();
 				m_pendingFileReq = FileRequest_Quit;
+			} else {
+				RequestEndLifecycle();
 			}
 		}
 	});


### PR DESCRIPTION
Per discussion on IRC and various bug reports we've received, this PR implements a "welcome screen" frontend when launching the editor binary without any command line arguments to select the specific editor mode to open.

![Snapshot_2024-02-20_18-54-03](https://github.com/pioneerspacesim/pioneer/assets/4218491/aadd75d1-1037-4779-b022-47bfad104e62)

CC @nozmajner for testing on Windows.