### PR TITLE
Misc cleanup, fixes, and Lua function library improvements

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -1835,6 +1835,10 @@
     "description": "Duration unit: one 7-day week",
     "message": "w"
   },
+  "UNIT_CUBIC_METERS": {
+	"description": "Volume unit: cubic meter",
+	"message": "m³"
+  },
   "UNKNOWN": {
     "description": "",
     "message": "<unknown>"

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -2,6 +2,7 @@
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 ---@class SpaceStation : ModelBody
+---@field techLevel integer
 local SpaceStation = package.core['SpaceStation']
 
 local Economy     = require 'Economy'

--- a/data/libs/autoload.lua
+++ b/data/libs/autoload.lua
@@ -74,5 +74,39 @@ table.copy = function(t)
 	return ret
 end
 
+-- Copy values from table b into a
+--
+-- Does not copy metatable nor recurse into the table.
+-- Pass an optional predicate to transform the keys and values before assignment.
+---@generic K, V
+---@param a table
+---@param b table<K, V>
+---@param predicate nil|fun(k: K, v: V): any, any
+---@return table
+table.merge = function(a, b, predicate)
+	for k, v in pairs(b) do
+		if predicate then k, v = predicate(k, v) end
+		a[k] = v
+	end
+	return a
+end
+
+-- Append array b to array a
+--
+-- Does not copy metatable nor recurse into the table.
+-- Pass an optional predicate to transform the keys and values before assignment.
+---@generic T
+---@param a table
+---@param b T[]
+---@param predicate nil|fun(v: T): any
+---@return table
+table.append = function(a, b, predicate)
+	for _, v in ipairs(b) do
+		if predicate then v = predicate(v) end
+		table.insert(a, v)
+	end
+	return a
+end
+
 -- make import break. you should never import this file
 return nil

--- a/data/libs/autoload.lua
+++ b/data/libs/autoload.lua
@@ -56,9 +56,10 @@ string.interp = function (s, t)
 	end))
 end
 
--- allow using string.interp via "s" % { t }
 ---@class string
 ---@operator mod(table): string
+
+-- allow using string.interp via "s" % { t }
 getmetatable("").__mod = string.interp
 
 -- make a simple shallow copy of the passed-in table

--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -489,17 +489,20 @@ utils.print_r = function(t)
 			if type(t) == "table" then
 				for key, val in pairs(t) do
 					local string_key = tostring(key)
+					local string_val = tostring(val)
 
-					if type(val) == "table" then
-						write(indent, '[%s] => %s {', string_key, tostring(t))
+					if type(val) == "table" and not print_r_cache[string_val] then
+						write(indent, '[%s] => %s {', string_key, string_val)
 
 						sub_print_r(val, indent + string.len(string_key) + 8)
 
 						write(indent + string.len(string_key) + 6, "}")
+					elseif type(val) == "table" then
+						write(indent, "[%s] => *%s", string_key, string_val)
 					elseif (type(val)=="string") then
-						write(indent, "[%s] => '%s'", string_key, val)
+						write(indent, "[%s] => '%s'", string_key, string_val)
 					else
-						write(indent, "[%s] => %s", string_key, tostring(val))
+						write(indent, "[%s] => %s", string_key, string_val)
 					end
 				end
 			else

--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -371,8 +371,8 @@ utils.inherits = function (baseClass, name)
 	new_class.meta = { __index = new_class, class=name }
 
 	-- generic constructor
-	function new_class.New(args)
-		local newinst = base_class.New(args)
+	function new_class.New(...)
+		local newinst = base_class.New(...)
 		setmetatable( newinst, new_class.meta )
 		return newinst
 	end
@@ -404,17 +404,22 @@ end
 -- Wrapper for utils.inherits that manages creating new class instances and
 -- calling the constructor.
 --
-utils.class = function (name, baseClass)
-	local new_class = utils.inherits(baseClass, name)
+utils.class = function (name, base_class)
+	base_class = base_class or object
+	local new_class = utils.inherits(base_class, name)
 
 	new_class.New = function(...)
 		local instance = setmetatable( {}, new_class.meta )
 
-		if new_class.Constructor then
-			new_class.Constructor(instance, ...)
-		end
+		new_class.Constructor(instance, ...)
 
 		return instance
+	end
+
+	new_class.Constructor = function(self, ...)
+		if base_class.Constructor then
+			base_class.Constructor(self, ...)
+		end
 	end
 
 	return new_class

--- a/data/meta/Color.lua
+++ b/data/meta/Color.lua
@@ -1,0 +1,51 @@
+-- Copyright © 2008-2023 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+-- This file implements type information about C++ classes for Lua static analysis
+
+---@meta
+
+---@class Color
+---@field r integer
+---@field g integer
+---@field b integer
+---@field a integer
+---
+---@operator add: Color
+---@operator add(number): Color
+---@operator mul: Color
+---@operator mul(number): Color
+---@operator call: Color
+
+---@class Color
+local Color = {}
+
+---@param r number
+---@param g number
+---@param b number
+---@param a number?
+---@return Color
+---@overload fun(hex: string): Color
+function _G.Color(r, g, b, a) end
+
+-- Return a copy of this color darkened by the given amount (in 0.0..1.0)
+-- Use negative values to lighten.
+--
+-- Rturns a new Color object
+---@param s number
+---@return Color
+function Color:shade(s) end
+
+-- Increase the perceptual saturation of this color by some factor (in 0.0..1.0)
+--
+-- Returns a new Color object
+---@param t number
+---@return Color
+function Color:tint(t) end
+
+-- Set the opacity of this color to the passed value (in 0.0..1.0 or 1..255)
+--
+-- Returns a new Color object
+---@param o number
+---@return Color
+function Color:opacity(o) end

--- a/data/meta/Rand.lua
+++ b/data/meta/Rand.lua
@@ -14,16 +14,16 @@ function Rand.New(seed) end
 ---@param min number inclusive minimum value, defaults to 0
 ---@param max number exclusive maximum value, defaults to 1
 ---@return number
----@overload fun(): number
----@overload fun(max: number): number
+---@overload fun(self: self): number
+---@overload fun(self: self, max: number): number
 function Rand:Number(min, max) end
 
 -- Returns a random integer in the range [min, max), exclusive.
 ---@param min integer inclusive minimum value, defaults to 0
 ---@param max integer exclusive maximum value, defaults to 1
 ---@return integer
----@overload fun(): integer
----@overload fun(max: integer): integer
+---@overload fun(self: self): integer
+---@overload fun(self: self, max: integer): integer
 function Rand:Integer(min, max) end
 
 -- Generates a random integer drawn from a Poisson distribution.

--- a/data/pigui/baseui.lua
+++ b/data/pigui/baseui.lua
@@ -4,7 +4,9 @@
 local Engine = require 'Engine'
 local pigui = Engine.pigui
 
+---@class ui
 local ui = require 'pigui.libs.forwarded'
+
 ui.rescaleUI = require 'pigui.libs.rescale-ui'
 
 ---@type EventQueue

--- a/data/pigui/init.lua
+++ b/data/pigui/init.lua
@@ -6,6 +6,7 @@
 -- aren't available later...
 local Player = require 'Player'
 
+---@class ui
 local ui = require 'pigui.baseui'
 
 require 'pigui.libs.text'

--- a/data/pigui/libs/buttons.lua
+++ b/data/pigui/libs/buttons.lua
@@ -1,9 +1,11 @@
 -- Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 local Engine = require 'Engine'
-local ui = require 'pigui.baseui'
 local pigui = Engine.pigui
 local Vector2 = _G.Vector2
+
+---@class ui
+local ui = require 'pigui.baseui'
 
 --
 -- Function: ui.withButtonColors

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -11,12 +11,13 @@ local ui = require 'pigui'
 local pionillium = ui.fonts.pionillium
 local orbiteer = ui.fonts.orbiteer
 local PiImage = require 'pigui.libs.image'
-local MarketWidget = require 'pigui.libs.equipment-market'
+
+local ModalWindow = require 'pigui.libs.modal-win'
+local TableWidget = require 'pigui.libs.table'
 local EconView = require 'pigui.modules.system-econ-view'
 
 local l = Lang.GetResource("ui-core")
-local colors = ui.theme.colors
-local icons = ui.theme.icons
+
 local Vector2 = _G.Vector2
 local Color = _G.Color
 
@@ -43,8 +44,6 @@ local colorVariant = {
 	[true] = ui.theme.buttonColors.selected,
 	[false] = ui.theme.buttonColors.default
 }
-
-local sellPriceReduction = 0.8
 
 local function get_pricemod(itemType, price)
 	return (price / itemType.price - 1) * 100
@@ -165,7 +164,17 @@ function CommodityMarketWidget.New(id, title, config)
 		return c1:GetName() < c2:GetName()
 	end
 
-	local self = MarketWidget.New(id, title, config)
+	local self = TableWidget.New(id, title, config)
+
+	self.popup = config.popup or ModalWindow.New('popupMsg' .. id, function()
+        ui.text(self.popup.msg)
+        ui.dummy(Vector2((ui.getContentRegion().x - 100) / 2, 0))
+        ui.sameLine()
+        if ui.button("OK", Vector2(100, 0)) then
+            self.popup:close()
+        end
+    end)
+
 	self.icons = {}
 	self.tradeModeBuy = true
 	self.selectedItem = nil
@@ -178,6 +187,13 @@ function CommodityMarketWidget.New(id, title, config)
 
 	self.cargoMgr = nil
 	self.station = nil
+
+	self.funcs.getStock = config.getStock
+	self.funcs.getDemand = config.getDemand
+	self.funcs.getBuyPrice = config.getBuyPrice
+	self.funcs.getSellPrice = config.getSellPrice
+	self.funcs.bought = config.bought
+	self.funcs.sold = config.sold
 
 	self.style.defaults = {
 		itemSpacing = self.itemSpacing
@@ -274,8 +290,6 @@ end
 
 --player clicked confirm purchase button
 function CommodityMarketWidget:DoBuy()
-	if not self.funcs.onClickBuy(self, self.selectedItem) then return end
-
 	local price = self.funcs.getBuyPrice(self, self.selectedItem)
 	local stock = self.funcs.getStock(self, self.selectedItem)
 	local playerfreecargo = self.cargoMgr:GetFreeSpace()
@@ -318,8 +332,6 @@ end
 
 --player clicked the confirm sale button
 function CommodityMarketWidget:DoSell()
-	if not self.funcs.onClickSell(self, self.selectedItem) then return end
-
 	local price = self.funcs.getSellPrice(self, self.selectedItem)
 	--if commodity price is negative (radioactives, garbage), player needs to have enough cash
 	local orderamount = price * self.tradeAmount
@@ -460,7 +472,15 @@ function CommodityMarketWidget:SetSize(size)
 end
 
 function CommodityMarketWidget:Refresh()
-	MarketWidget.refresh(self)
+	self.items = {}
+
+	for k, comm in pairs(Commodities) do
+		if self.funcs.canDisplayItem(self, comm) then
+			table.insert(self.items, comm)
+		end
+	end
+
+	table.sort(self.items, self.funcs.sortingFunction)
 
 	---@type CargoManager
 	self.cargoMgr = Game.player:GetComponent('CargoManager')
@@ -473,7 +493,7 @@ function CommodityMarketWidget:Render(size)
 
 	ui.withStyleVars({ItemSpacing = self.style.itemSpacing}, function()
 		ui.withFont(pionillium.heading, function()
-			MarketWidget.render(self)
+			TableWidget.render(self)
 		end)
 		ui.sameLine(0, self.style.widgetSizes.windowGutter)
 		self:TradeMenu()

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -6,6 +6,7 @@
 local Engine = require 'Engine'
 local pigui = Engine.pigui
 
+---@class ui
 local ui = {}
 
 ui.calcTextAlignment = pigui.CalcTextAlignment
@@ -137,12 +138,12 @@ ui.beginTabItem = pigui.BeginTabItem
 ui.endTabItem = pigui.EndTabItem
 ui.endTabBar = pigui.EndTabBar
 
-ui.beginTable = pigui.BeginTable
+ui.beginTable = pigui.BeginTable ---@type fun(id: string, columns: integer, flags: any)
 ui.endTable = pigui.EndTable
 ui.tableNextRow = pigui.TableNextRow
 ui.tableNextColumn = pigui.TableNextColumn
 ui.tableSetColumnIndex = pigui.TableSetColumnIndex
-ui.tableSetupColumn = pigui.TableSetupColumn
+ui.tableSetupColumn = pigui.TableSetupColumn ---@type fun(id: string, flags: any)
 ui.tableSetupScrollFreeze = pigui.TableSetupScrollFreeze
 ui.tableHeadersRow = pigui.TableHeadersRow
 ui.tableHeader = pigui.TableHeader

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -93,6 +93,7 @@ ui.getWindowPadding = pigui.GetWindowPadding ---@type fun(): Vector2
 -- Add extra window padding after beginning a window.
 -- WARNING: this must only be called at "top-level" window scope (e.g. not in a Group or Columns etc.)
 ui.addWindowPadding = pigui.AddWindowPadding ---@type fun(padding: Vector2)
+ui.getItemRect = pigui.GetItemRect ---@type fun(): Vector2, Vector2 -- return min, max corners of last item bounding box
 
 ui.getTargetsNearby = pigui.GetTargetsNearby
 ui.getProjectedBodies = pigui.GetProjectedBodies

--- a/data/pigui/libs/gauge.lua
+++ b/data/pigui/libs/gauge.lua
@@ -1,6 +1,7 @@
 -- Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+---@class ui
 local ui = require 'pigui.baseui'
 local Vector2 = _G.Vector2
 

--- a/data/pigui/libs/icons.lua
+++ b/data/pigui/libs/icons.lua
@@ -1,8 +1,12 @@
 -- Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 local Engine = require 'Engine'
-local ui = require 'pigui.baseui'
 local pigui = Engine.pigui
+
+---@class ui
+local ui = require 'pigui.baseui'
+
+---@alias ui.Icon integer
 
 local iconsX = 16
 local iconsY = 19

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -5,9 +5,11 @@ local Format = require 'Format'
 local Input = require 'Input'
 local Lang = require 'Lang'
 local Game = require 'Game'
-local ui = require 'pigui.baseui'
 local pigui = Engine.pigui
 local Vector2 = _G.Vector2
+
+---@class ui
+local ui = require 'pigui.baseui'
 
 local lc = Lang.GetResource("core")
 local lui = Lang.GetResource("ui-core")
@@ -102,6 +104,8 @@ end
 --   alignment - number, controls alignment of the text. 0.5 is centered,
 --               1.0 is right aligned.
 --
+---@param text string
+---@param alignment number
 function ui.textAligned(text, alignment)
 	local size = pigui.CalcTextSize(text).x
 	local cw = ui.getContentRegion().x

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -340,6 +340,10 @@ ui.Format = {
 			return string.format("%d%s%s", number, res, deci)
 		end
 	end,
+	-- Format a volume quantity in cubic meters
+	Volume = function(number, places)
+		return ui.Format.Number(number, places or 1) .. lc.UNIT_CUBIC_METERS
+	end,
 	SystemPath = function(path)
 		local sectorString = "("..path.sectorX..", "..path.sectorY..", "..path.sectorZ..")"
 		if path:IsSectorPath() then

--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -6,6 +6,8 @@ local Engine = require 'Engine'
 local Game = require 'Game'
 local utils = require 'utils'
 local pigui = Engine.pigui
+
+---@class ui
 local ui = require 'pigui.libs.forwarded'
 
 --

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -204,16 +204,16 @@ function FormatAndCompareShips:compare_and_draw_column(desc, a, b, fmt_a, fmt_b)
 	if compare < 0 then
 		local old_str = fmt_b and fmt_b( b ) or b
 		ui.withTooltip( l.CURRENT_SHIP .. ": " .. old_str, function ()
-			ui.textAlignedColored(new_str, 1.0, ui.theme.colors.shipmarketCompareWorse)
+			ui.textAlignedColored(new_str, 1.0, ui.theme.colors.compareWorse)
 			ui.tableSetColumnIndex(2 + self.column)
-			ui.icon( ui.theme.icons.shipmarket_compare_worse, Vector2(ui.getTextLineHeight()), ui.theme.colors.shipmarketCompareWorse)
+			ui.icon( ui.theme.icons.shipmarket_compare_worse, Vector2(ui.getTextLineHeight()), ui.theme.colors.compareWorse)
 		end )
 	elseif compare > 0 then
 		local old_str = fmt_b and fmt_b( b ) or b
 		ui.withTooltip( l.CURRENT_SHIP .. ": " .. old_str, function ()
-			ui.textAlignedColored(new_str, 1.0,  ui.theme.colors.shipmarketCompareBetter)
+			ui.textAlignedColored(new_str, 1.0,  ui.theme.colors.compareBetter)
 			ui.tableSetColumnIndex(2 + self.column)
-			ui.icon( ui.theme.icons.shipmarket_compare_better, Vector2(ui.getTextLineHeight()), ui.theme.colors.shipmarketCompareBetter)			
+			ui.icon( ui.theme.icons.shipmarket_compare_better, Vector2(ui.getTextLineHeight()), ui.theme.colors.compareBetter)
 		end )
 	else
 		ui.textAligned(new_str, 1.0)

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -57,7 +57,7 @@ local styleColors = {
 	accent_700		= Color "06318E",
 
 	success_100		= Color "CAF8A8",
-	success_300		= Color "D6A8F8",
+	success_300		= Color "77EE21",
 	success_500		= Color "5ACC0A",
 	success_700		= Color "317005",
 	success_900		= Color "102502",
@@ -73,7 +73,7 @@ local styleColors = {
 	danger_500		= Color "C51010",
 	danger_700		= Color "8C0606",
 	danger_900		= Color "2C0505",
-		
+
 }
 
 theme.styleColors = styleColors
@@ -231,8 +231,8 @@ theme.colors = {
 	equipScreenHighlight    = styleColors.gray_300,
 	equipScreenBgText       = styleColors.gray_400,
 
-	shipmarketCompareBetter = styleColors.accent_300,
-	shipmarketCompareWorse  = styleColors.warning_300,
+	compareBetter = styleColors.accent_300,
+	compareWorse  = styleColors.warning_300,
 }
 
 -- ImGui global theming styles

--- a/data/pigui/views/tab-view.lua
+++ b/data/pigui/views/tab-view.lua
@@ -73,11 +73,23 @@ function PiGuiTabView.registerView(self, view)
 	self:resize()
 end
 
+function PiGuiTabView:refreshTab(i)
+	local tab = self.tabs[i]
+	local ok, err = ui.pcall(tab.refresh, tab)
+
+	if not ok then
+		tab.showView = false
+		tab.err = err
+	end
+end
+
 function PiGuiTabView:SwitchTo(id)
 	for i, v in ipairs(self.tabs) do
 		if v.id == id then
-			if self.currentTab ~= i then self.tabs[i].refresh() end
-			self.currentTab = i
+			if self.currentTab ~= i then
+				self.currentTab = i
+				self:refreshTab(i)
+			end
 			return
 		end
 	end
@@ -93,11 +105,17 @@ function PiGuiTabView.renderTabView(self)
 	self.isActive = Game.CurrentView() == self.name
 	if not self.isActive then return end
 
-	local tab = self.tabs[self.currentTab] or self.tabs[1]
+	if not self.tabs[self.currentTab] then
+		self.currentTab = 1
+	end
+
+	local tab = self.tabs[self.currentTab]
 	if not tab then return end
 
 	-- refresh the tab since we're swapping back to the view
-	if self.isActive and not wasActive then tab.refresh() end
+	if self.isActive and not wasActive then
+		self:refreshTab(self.currentTab)
+	end
 
 	local styleColors = {
 		["WindowBg"] = colors.blueBackground,
@@ -175,7 +193,7 @@ function PiGuiTabView.renderTabView(self)
 	if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) then
 		if tab.debugReload then tab:debugReload() end
 		-- refresh the (possibly) new tab
-		self.tabs[self.currentTab]:refresh()
+		self:refreshTab(self.currentTab)
 	end
 end
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -27,34 +27,12 @@
 static Sound::Event s_soundUndercarriage;
 static Sound::Event s_soundHyperdrive;
 
-static int onEquipChangeListener(lua_State *l)
-{
-	Player *p = LuaObject<Player>::GetFromLua(lua_upvalueindex(1));
-	p->onChangeEquipment.emit();
-	return 0;
-}
-
-static void registerEquipChangeListener(Player *player)
-{
-	lua_State *l = Lua::manager->GetLuaState();
-	LUA_DEBUG_START(l);
-
-	LuaObject<Player>::PushToLua(player);
-	lua_pushcclosure(l, onEquipChangeListener, 1);
-	LuaRef lr(Lua::manager->GetLuaState(), -1);
-	ScopedTable(player->GetEquipSet()).CallMethod("AddListener", lr);
-	lua_pop(l, 1);
-
-	LUA_DEBUG_END(l, 0);
-}
-
 Player::Player(const ShipType::Id &shipId) :
 	Ship(shipId)
 {
 	SetController(new PlayerShipController());
 	InitCockpit();
 	m_fixedGuns->SetShouldUseLeadCalc(true);
-	registerEquipChangeListener(this);
 	m_atmosAccel = vector3d(0.0f, 0.0f, 0.0f);
 }
 
@@ -63,13 +41,11 @@ Player::Player(const Json &jsonObj, Space *space) :
 {
 	InitCockpit();
 	m_fixedGuns->SetShouldUseLeadCalc(true);
-	registerEquipChangeListener(this);
 }
 
 void Player::SetShipType(const ShipType::Id &shipId)
 {
 	Ship::SetShipType(shipId);
-	registerEquipChangeListener(this);
 	InitCockpit();
 }
 
@@ -316,7 +292,7 @@ void Player::StaticUpdate(const float timeStep)
 	bool playCreak = false;
 
 	// play creaking sfx if the acceleration along the Y axis (up/down directions) is higher than 1g
-	// and the rate of change of acceleration is more than 2.5 m s-3 
+	// and the rate of change of acceleration is more than 2.5 m s-3
 	if ((abs(m_atmosAccel.Dot(Player::m_interpOrient.VectorY()))) > 10 && abs(m_atmosJerk.Dot(Player::m_interpOrient.VectorY())) > 2.5) {
 		playCreak = true;
 	}

--- a/src/Player.h
+++ b/src/Player.h
@@ -52,7 +52,6 @@ public:
 	void OnCockpitActivated();
 
 	virtual void StaticUpdate(const float timeStep) override;
-	sigc::signal<void> onChangeEquipment;
 	virtual vector3d GetManeuverVelocity() const;
 	virtual int GetManeuverTime() const;
 

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -1036,6 +1036,13 @@ static int l_pigui_get_window_padding(lua_State *l)
 	return 1;
 }
 
+static int l_pigui_get_item_rect(lua_State *l)
+{
+	LuaPush(l, ImGui::GetItemRectMin());
+	LuaPush(l, ImGui::GetItemRectMax());
+	return 2;
+}
+
 static int l_pigui_add_window_padding(lua_State *l)
 {
 	ImVec2 padding = LuaPull<ImVec2>(l, 1);
@@ -3401,6 +3408,7 @@ void LuaObject<PiGui::Instance>::RegisterClass()
 		{ "GetItemSpacing", l_pigui_get_item_spacing },
 		{ "GetWindowPadding", l_pigui_get_window_padding },
 		{ "AddWindowPadding", l_pigui_add_window_padding },
+		{ "GetItemRect", l_pigui_get_item_rect },
 		{ "InputText", l_pigui_input_text },
 		{ "Combo", l_pigui_combo },
 		{ "ListBox", l_pigui_listbox },


### PR DESCRIPTION
This PR is a bit of a catch-all arising from development of #5734 and contains most of the feature-agnostic commits from that branch.

In no particular order:
- Improved the Lua runtime library with several new utilities for operating on tables
- Added a new `utils.proto` helper function for working with a prototype-based object model
- Fixed an error when attempting to interpolate a non-string object into a string
- Fixed a long-running bug with `utils.print_r` which caused it to print incorrect information about recursive tables (tables that have already been printed)
- Fixed default forwarding constructor for `utils.inherits` - you can now receive arguments from the default `.New()` constructor of a subclass.
- Fixed #5765
- Made most PiGui methods available to Lua autocomplete through the `ui` object. Documenting forwarded methods from C++ is still a WIP and will be improved over time.
- Added two new utility UI functions - ui.getItemRect() and ui.Format.Volume
- Improved the resilience of the tab views against erroring code
- Some misc. preparatory changes for EquipSet v2.