### PR TITLE
Very WIP: Refactor flight log recover

### DIFF
--- a/data/modules/FlightLog/FlightLog.lua
+++ b/data/modules/FlightLog/FlightLog.lua
@@ -226,12 +226,12 @@ end
 --   time - Game date
 --   money - Financial balance at time of record creation
 --   location - Array, with two strings: flight state, and relevant additional string
---   text - Free text string
+--   entry - Free text string
 --
 ---@param entry table
 function FlightLog.InsertCustomEntry(entry)
-	if entry.path and entry.time and entry.money and entry.location and entry.text then
-		FlightLog.AddEntry( FlightLogEntry.Custom.New( entry.path, entry.time, entry.money, entry.location, entry.text ) )
+	if entry.path and entry.time and entry.money and entry.location and entry.entry then
+		FlightLog.AddEntry( FlightLogEntry.Custom.New( entry.path, entry.time, entry.money, entry.location, entry.entry ) )
 		return true
 	else
 		return false
@@ -254,12 +254,12 @@ end
 --   path - System path, pointing to player's current system
 --   arrtime - Game date, arrival
 --   deptime - Game date, departure (optional)
---   text - Free text string (optional)
+--   entry - Free text string (optional)
 --
 ---@param entry table
 function FlightLog.InsertSystemEntry(entry)
 	if entry.path and (entry.arrtime or entry.deptime) then
-		FlightLog.AddEntry( FlightLogEntry.System.New( entry.path, entry.arrtime, entry.deptime, entry.text or "" ) )
+		FlightLog.AddEntry( FlightLogEntry.System.New( entry.path, entry.arrtime, entry.deptime, entry.entry or "" ) )
 		return true
 	else
 		return false
@@ -280,14 +280,14 @@ end
 -- Entry:
 --
 --   path - System path
---   arrtime - Game date, arrival
+--   deptime - Game date, _arrival_
 --   money - Financial balance at time of record creation
---   text - Free text string (optional)
+--   entry - Free text string (optional)
 --
 ---@param entry table
 function FlightLog.InsertStationEntry(entry)
-	if entry.path and entry.time and entry.money then
-		FlightLog.AddEntry( FlightLogEntry.Station.New( entry.path, entry.time, entry.money, entry.text or "" ) )
+	if entry.path and entry.deptime and entry.money then
+		FlightLog.AddEntry( FlightLogEntry.Station.New( entry.path, entry.deptime, entry.money, entry.entry or "" ) )
 		return true
 	else
 		return false

--- a/data/modules/FlightLog/FlightLogRenderer.lua
+++ b/data/modules/FlightLog/FlightLogRenderer.lua
@@ -1,0 +1,169 @@
+
+local ui = require 'pigui'
+local FlightLog = require 'modules.FlightLog.FlightLog'
+local Vector2 = _G.Vector2
+local Color = _G.Color
+local Lang = require 'Lang'
+local l = Lang.GetResource("ui-core")
+
+local icons = ui.theme.icons
+
+local gray = Color(145, 145, 145)
+
+
+local iconSize = ui.rescaleUI(Vector2(28, 28))
+local buttonSpaceSize = iconSize
+
+local FlightLogRenderer = {}
+
+
+FlightLogRenderer.earliestFirst = true
+FlightLogRenderer.includedSet = { System = true, Custom = true, Station = true }
+
+local function writeLogEntry( entry, formatter, write_header )
+	if write_header then
+		formatter:write( entry:GetLocalizedName() ):newline()
+	end
+
+	for _, pair in ipairs( entry:GetDataPairs( FlightLogRenderer.earliestFirst ) ) do
+		formatter:headerText( pair[1], pair[2] )
+	end
+end
+
+local ui_formatter = {}
+function ui_formatter:headerText(title, text, wrap)
+	-- Title text is gray, followed by the variable text:
+	if not text then return end
+	ui.textColored(gray, string.gsub(title, ":", "") .. ":")
+	ui.sameLine()
+	if wrap then
+		-- TODO: limit width of text box!
+		ui.textWrapped(text)
+	else
+		ui.text(text)
+	end
+end
+
+function ui_formatter:write( string )
+	ui.text( string )
+	ui.sameLine()
+	return self
+end
+
+function ui_formatter:newline()
+	ui.text( "" )
+	return self
+end
+
+	
+local entering_text = false
+
+-- Display Entry text, and Edit button, to update flightlog
+local function inputText(entry, counter, entering_text, str)
+
+	if entering_text == counter then
+		ui.spacing()
+		ui.pushItemWidth(-1.0)
+		local updated_entry, return_pressed = ui.inputText("##" ..str..counter, entry:GetEntry(), {"EnterReturnsTrue"})
+		ui.popItemWidth()
+		if return_pressed then
+			entry:UpdateEntry(updated_entry)
+			entering_text = -1
+		end
+	elseif entry:HasEntry() then
+		ui_formatter:headerText(l.ENTRY, entry:GetEntry(), true)
+	end
+
+	ui.spacing()
+	return entering_text
+end
+
+local function renderLog( formatter, interactive )
+
+	ui.spacing()
+    if interactive then
+        -- input field for custom log:
+        ui_formatter:headerText(l.LOG_NEW, "")
+        ui.sameLine()
+        local text, changed = ui.inputText("##inputfield", "", {"EnterReturnsTrue"})
+        if changed then
+            FlightLog.MakeCustomEntry(text)
+        end
+        ui.separator()
+    end
+
+	local counter = 0
+	for entry in FlightLog:GetLogEntries(FlightLogRenderer.includedSet, nil, FlightLogRenderer.earliestFirst ) do
+	 	counter = counter + 1
+	
+		 writeLogEntry( entry, formatter, true )
+
+         if interactive then
+            if entry:CanHaveEntry() then
+                entering_text = inputText(entry, counter,
+                    entering_text, "custom")
+                ui.nextColumn()
+
+                if ui.iconButton(icons.pencil, buttonSpaceSize, l.EDIT .. "##custom"..counter) then
+                    entering_text = counter
+                end
+            else
+                ui.nextColumn()
+            end
+
+            if entry:SupportsDelete() then
+                if ui.iconButton(icons.trashcan, buttonSpaceSize, l.REMOVE .. "##custom" .. counter) then
+                    entry:Delete()
+                    -- if we were already in edit mode, reset it, or else it carries over to next iteration
+                    entering_text = false
+                end
+            end
+			ui.nextColumn()
+        else
+            if entry:HasEntry() then
+                ui_formatter:headerText(l.ENTRY, entry:GetEntry(), true)
+            end
+        end
+
+		ui.separator()
+		ui.spacing()
+	end
+    if counter == 0 then
+        ui.text(l.NONE)
+    end
+end
+
+function FlightLogRenderer.displayFilterOptions()
+	ui.spacing()
+	local c
+	local flight_log = true;
+
+	c,FlightLogRenderer.includedSet.Custom = ui.checkbox(l.LOG_CUSTOM, FlightLogRenderer.includedSet.Custom)
+	c,FlightLogRenderer.includedSet.Station = ui.checkbox(l.LOG_STATION, FlightLogRenderer.includedSet.Station)
+	c,FlightLogRenderer.includedSet.System = ui.checkbox(l.LOG_SYSTEM, FlightLogRenderer.includedSet.System)
+	ui.separator()
+	c,FlightLogRenderer.earliestFirst = ui.checkbox(l.LOG_EARLIEST_FIRST, FlightLogRenderer.earliestFirst)
+end
+
+
+function FlightLogRenderer.drawFlightHistory( interactive )
+
+	ui.spacing()
+
+    if interactive then
+        -- reserve a narrow right column for edit / remove icon
+        local width = ui.getContentRegion().x
+
+
+        ui.columns(2, "##flightLogColumns", false)
+        ui.setColumnWidth(0, width - (iconSize.x*3)/2)
+        ui.setColumnWidth(1, (iconSize.x*3)/2)
+    end
+
+	renderLog(ui_formatter, interactive)
+end
+
+
+return FlightLogRenderer
+
+

--- a/data/pigui/modules/info-view/06-flightlog.lua
+++ b/data/pigui/modules/info-view/06-flightlog.lua
@@ -7,125 +7,15 @@ local InfoView = require 'pigui.views.info-view'
 local Lang = require 'Lang'
 local FlightLog = require 'modules.FlightLog.FlightLog'
 local FlightLogExporter = require 'modules.FlightLog.FlightLogExporter'
-local Format = require 'Format'
-local Color = _G.Color
-local Vector2 = _G.Vector2
+local FlightLogRenderer = require 'modules.FlightLog.FlightLogRenderer'
 
 local pionillium = ui.fonts.pionillium
 local icons = ui.theme.icons
 
-local gray = Color(145, 145, 145)
-
 local l = Lang.GetResource("ui-core")
 
-local iconSize = ui.rescaleUI(Vector2(28, 28))
-local buttonSpaceSize = iconSize
-
-local earliestFirst = true
 local exportHtml = true
-local includedSet = { System = true, Custom = true, Station = true }
 
-local function writeLogEntry( entry, formatter, write_header )
-	if write_header then
-		formatter:write( entry:GetLocalizedName() ):newline()
-	end
-
-	for _, pair in ipairs( entry:GetDataPairs( earliestFirst ) ) do
-		formatter:headerText( pair[1], pair[2] )
-	end
-end
-
-local ui_formatter = {}
-function ui_formatter:headerText(title, text, wrap)
-	-- Title text is gray, followed by the variable text:
-	if not text then return end
-	ui.textColored(gray, string.gsub(title, ":", "") .. ":")
-	ui.sameLine()
-	if wrap then
-		-- TODO: limit width of text box!
-		ui.textWrapped(text)
-	else
-		ui.text(text)
-	end
-end
-
-function ui_formatter:write( string )
-	ui.text( string )
-	ui.sameLine()
-	return self
-end
-
-function ui_formatter:newline()
-	ui.text( "" )
-	return self
-end
-
-	
-local entering_text = false
-
--- Display Entry text, and Edit button, to update flightlog
-local function inputText(entry, counter, entering_text, str)
-
-	if entering_text == counter then
-		ui.spacing()
-		ui.pushItemWidth(-1.0)
-		local updated_entry, return_pressed = ui.inputText("##" ..str..counter, entry:GetEntry(), {"EnterReturnsTrue"})
-		ui.popItemWidth()
-		if return_pressed then
-			entry:UpdateEntry(updated_entry)
-			entering_text = -1
-		end
-	elseif entry:HasEntry() then
-		ui_formatter:headerText(l.ENTRY, entry:GetEntry(), true)
-	end
-
-	ui.spacing()
-	return entering_text
-end
-
-local function renderLog( formatter )
-
-	ui.spacing()
-	-- input field for custom log:
-	ui_formatter:headerText(l.LOG_NEW, "")
-	ui.sameLine()
-	local text, changed = ui.inputText("##inputfield", "", {"EnterReturnsTrue"})
-	if changed then
-		FlightLog.MakeCustomEntry(text)
-	end
-	ui.separator()
-
-	local counter = 0
-	for entry in FlightLog:GetLogEntries(includedSet, nil, earliestFirst ) do
-	 	counter = counter + 1
-	
-		 writeLogEntry( entry, formatter, true )
-
-		 if entry:CanHaveEntry() then
-			entering_text = inputText(entry, counter,
-				entering_text, "custom")
-			ui.nextColumn()
-
-			if ui.iconButton(icons.pencil, buttonSpaceSize, l.EDIT .. "##custom"..counter) then
-				entering_text = counter
-			end
-		else
-			ui.nextColumn()
-		end
-
-		if entry:SupportsDelete() then
-			if ui.iconButton(icons.trashcan, buttonSpaceSize, l.REMOVE .. "##custom" .. counter) then
-				entry:Delete()
-				-- if we were already in edit mode, reset it, or else it carries over to next iteration
-				entering_text = false
-			end
-		end
-
-		ui.nextColumn()
-		ui.separator()
-		ui.spacing()
-	end
-end
 
 local Windows = {
 	exportButtonWindow = layout.NewWindow(l.LOG_EXPORT, nil, ui.WindowFlags {"AlwaysAutoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"}),
@@ -148,37 +38,10 @@ function Windows.exportButtonWindow.Show()
 	c,exportHtml = ui.checkbox(l.LOG_HTML, exportHtml)
 	ui.sameLine()
 	if ui.button(l.SAVE) then
-		FlightLogExporter.Export( includedSet, earliestFirst, true, exportHtml)
+		FlightLogExporter.Export( FlightLogRenderer.includedSet, FlightLogRenderer.earliestFirst, true, exportHtml)
 	end
 end
 
-
-local function displayFilterOptions()
-	ui.spacing()
-	local c
-	local flight_log = true;
-
-	c,includedSet.Custom = ui.checkbox(l.LOG_CUSTOM, includedSet.Custom)
-	c,includedSet.Station = ui.checkbox(l.LOG_STATION, includedSet.Station)
-	c,includedSet.System = ui.checkbox(l.LOG_SYSTEM, includedSet.System)
-	ui.separator()
-	c,earliestFirst = ui.checkbox(l.LOG_EARLIEST_FIRST, earliestFirst)
-end
-
-
-local function drawFlightHistory()
-
-	ui.spacing()
-	-- reserve a narrow right column for edit / remove icon
-	local width = ui.getContentRegion().x
-
-
-	ui.columns(2, "##flightLogColumns", false)
-	ui.setColumnWidth(0, width - (iconSize.x*3)/2)
-	ui.setColumnWidth(1, (iconSize.x*3)/2)
-
-	renderLog(ui_formatter)
-end
 
 local function drawScreen()
 
@@ -190,13 +53,13 @@ local function drawScreen()
 
 	ui.child( "FlightLogList", function()
 		ui.withFont(pionillium.body, function()
-			drawFlightHistory()
+			FlightLogRenderer.drawFlightHistory( true )
 		end)
 	end)
 	ui.nextColumn()
 	ui.child( "FlightLogConfig", function()
 		ui.withFont(pionillium.body, function()
-			displayFilterOptions()
+			FlightLogRenderer.displayFilterOptions()
 		end) 
 	end)
 

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -21,7 +21,7 @@ local Defs = require 'pigui.modules.new-game-window.defs'
 local Layout = require 'pigui.modules.new-game-window.layout'
 local Recovery = require 'pigui.modules.new-game-window.recovery'
 local StartVariants = require 'pigui.modules.new-game-window.start-variants'
-local FlightLogParam = require 'pigui.modules.new-game-window.flight-log'
+local FlightLogParam = require 'pigui.modules.new-game-window.flight-log-tab'
 local Helpers = require 'pigui.modules.new-game-window.helpers'
 local Game = require 'Game'
 

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -173,10 +173,10 @@ local function startGame(gameParams)
 	for _, entry in ipairs(gameParams.flightlog.Custom) do
 		if FlightLog.InsertCustomEntry(entry) then
 			-- ok then
-		elseif entry.text then
+		elseif entry.entry then
 			-- allow a custom log entry containing only text
 			-- because when starting a new game we only have text
-			FlightLog.MakeCustomEntry(entry.text)
+			FlightLog.MakeCustomEntry(entry.entry)
 		else
 			logWarning("Wrong entry for the custom flight log")
 		end

--- a/data/pigui/modules/new-game-window/flight-log-tab.lua
+++ b/data/pigui/modules/new-game-window/flight-log-tab.lua
@@ -12,17 +12,17 @@ local GameParam = require 'pigui.modules.new-game-window.game-param'
 local Location = require 'pigui.modules.new-game-window.location'
 local Helpers = require 'pigui.modules.new-game-window.helpers'
 
-local FlightLog = GameParam.New(lui.FLIGHT_LOG, "flightlog")
+local FlightLogTab = GameParam.New(lui.FLIGHT_LOG, "flightlog")
 
-FlightLog.value = {
+FlightLogTab.value = {
 	Custom = {},
 	System = {},
 	Station = {}
 }
 
-FlightLog.version = 1
+FlightLogTab.version = 1
 
-function FlightLog:fromStartVariant(variant)
+function FlightLogTab:fromStartVariant(variant)
 	self.value.System = {}
 	self.value.Station = {}
 	self.value.Custom = {
@@ -114,7 +114,7 @@ local function renderEntry(template, entry)
 	end
 end
 
-function FlightLog:draw()
+function FlightLogTab:draw()
 	local h = ui.getCursorPos().y
 	local changed, newValue = ui.combo("##select_log", cbCurrentValue, cbValues)
 	if changed then cbCurrentValue = newValue end
@@ -170,7 +170,7 @@ local function systemPathFromTable(t)
 	return path
 end
 
-FlightLog.reader = Helpers.versioned {{
+FlightLogTab.reader = Helpers.versioned {{
 	version = 89,
 	fnc = function(saveGame)
 
@@ -273,13 +273,13 @@ FlightLog.reader = Helpers.versioned {{
 	end
 }}
 
-FlightLog.updateLayout = false
-FlightLog.updateParams = false
+FlightLogTab.updateLayout = false
+FlightLogTab.updateParams = false
 
-function FlightLog:isValid()
+function FlightLogTab:isValid()
 	return true
 end
 
-FlightLog.TabName = lui.FLIGHT_LOG
+FlightLogTab.TabName = lui.FLIGHT_LOG
 
-return FlightLog
+return FlightLogTab

--- a/data/pigui/modules/new-game-window/flight-log.lua
+++ b/data/pigui/modules/new-game-window/flight-log.lua
@@ -233,6 +233,44 @@ FlightLog.reader = Helpers.versioned {{
 
 		return value
 	end
+
+}, {
+
+	version = 90,
+	fnc = function(saveGame)
+
+		local function entryWithSafeSystemPath(entry)
+			local parsed = {}
+			for k,v in pairs(entry) do
+				if k == 'systemp' then
+					parsed.path = systemPathFromTable(entry.systemp.inner)
+				else
+					parsed[k] = v
+				end
+			end
+			return parsed
+		end
+
+		local value = { Custom = {}, System = {}, Station = {} }
+
+		local logData, errorString = Helpers.getByPath(saveGame, "lua_modules_json/FlightLog/Data")
+		if errorString then return nil, errorString end
+
+		for _, entry in ipairs(logData) do
+			local entryType = saveGame.type_names[entry]
+
+			if entryType == 'FlightLogEntry.Custom' then
+				table.insert(value.Custom, entryWithSafeSystemPath(entry))
+			elseif entryType == 'FlightLogEntry.System' then
+				table.insert(value.System, entryWithSafeSystemPath(entry))
+			elseif entryType == 'FlightLogEntry.Station' then
+				table.insert(value.Station, entryWithSafeSystemPath(entry))
+			else
+				return nil, lui.UNKNOWN_STATION_LOG_ENTRY_FORMAT
+			end
+		end
+		return value
+	end
 }}
 
 FlightLog.updateLayout = false

--- a/data/pigui/modules/new-game-window/flight-log.lua
+++ b/data/pigui/modules/new-game-window/flight-log.lua
@@ -26,7 +26,7 @@ function FlightLog:fromStartVariant(variant)
 	self.value.System = {}
 	self.value.Station = {}
 	self.value.Custom = {
-		variant.logmsg and { text = variant.logmsg }
+		variant.logmsg and { entry = variant.logmsg }
 	}
 end
 
@@ -86,22 +86,22 @@ local entryTemplates = {
 		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
 		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
 		{ id = "money",    label = lui.CASH,           render = Format.Money },
-		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+		{ id = "entry",    label = lui.ENTRY,          render = tostring, wrap = true },
 	},
 	System = {
 		{ id = "arrtime",  label = lui.ARRIVAL_DATE,   render = Format.Date },
 		{ id = "deptime",  label = lui.DEPARTURE_DATE, render = Format.Date },
 		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
 		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
-		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+		{ id = "entry",    label = lui.ENTRY,          render = tostring, wrap = true },
 	},
 	Station = {
-		{ id = "time",     label = lui.DATE,           render = Format.Date },
+		{ id = "deptime",  label = lui.DATE,           render = Format.Date },
 		{ id = "path",     label = lui.STATION,        render = asStation },
 		{ id = "path",     label = lui.IN_SYSTEM,      render = asPath },
 		{ id = "path",     label = lui.ALLEGIANCE,     render = asFaction },
 		{ id = "money",    label = lui.CASH,           render = Format.Money },
-		{ id = "text",     label = lui.ENTRY,          render = tostring, wrap = true },
+		{ id = "entry",    label = lui.ENTRY,          render = tostring, wrap = true },
 	},
 }
 
@@ -187,9 +187,9 @@ FlightLog.reader = Helpers.versioned {{
 				parsed.location = loc and { loc[1], loc[2], loc[3] }
 				parsed.path = systemPathFromTable(entry[1].inner)
 				parsed.money = entry[3]
-				parsed.text = entry[5]
+				parsed.entry = entry[5]
 			end
-			if not entry or not parsed.time or not parsed.location or not parsed.path or not parsed.money or not parsed.text then
+			if not entry or not parsed.time or not parsed.location or not parsed.path or not parsed.money or not parsed.entry then
 				return nil, lui.UNKNOWN_CUSTOM_LOG_ENTRY_FORMAT
 			end
 			table.insert(value.Custom, parsed)
@@ -205,7 +205,7 @@ FlightLog.reader = Helpers.versioned {{
 				parsed.arrtime = entry[2]
 				parsed.deptime = entry[3]
 				parsed.path = systemPathFromTable(entry[1].inner)
-				parsed.text = entry[4]
+				parsed.entry = entry[4]
 			end
 			if not entry or not parsed.path then
 				return nil, lui.UNKNOWN_SYSTEM_LOG_ENTRY_FORMAT
@@ -220,10 +220,10 @@ FlightLog.reader = Helpers.versioned {{
 		for _, entry in ipairs(station) do
 			local parsed = {}
 			if entry then
-				parsed.time = entry[2]
+				parsed.deptime = entry[2]
 				parsed.path = systemPathFromTable(entry[1].inner)
 				parsed.money = entry[3]
-				parsed.text = entry[4]
+				parsed.entry = entry[4]
 			end
 			if not entry or not parsed.time or not parsed.path or not parsed.money then
 				return nil, lui.UNKNOWN_STATION_LOG_ENTRY_FORMAT

--- a/data/pigui/modules/new-game-window/flight-log.lua
+++ b/data/pigui/modules/new-game-window/flight-log.lua
@@ -257,7 +257,7 @@ FlightLog.reader = Helpers.versioned {{
 		if errorString then return nil, errorString end
 
 		for _, entry in ipairs(logData) do
-			local entryType = saveGame.type_names[entry]
+			local entryType = Helpers.getLuaClass(entry)
 
 			if entryType == 'FlightLogEntry.Custom' then
 				table.insert(value.Custom, entryWithSafeSystemPath(entry))

--- a/data/pigui/modules/new-game-window/game-param.lua
+++ b/data/pigui/modules/new-game-window/game-param.lua
@@ -18,6 +18,7 @@ function GameParam:Constructor(name, path)
 	self.value = nil
 	self.hidden = false
 	self.noName = false
+	self.exclude_on_recovery = false
 end
 
 function GameParam:isValid()                 assert(false, tostring(self.name) .. ":isValid() should be overridden.") end

--- a/data/pigui/modules/new-game-window/helpers.lua
+++ b/data/pigui/modules/new-game-window/helpers.lua
@@ -191,4 +191,29 @@ function Helpers.getPlayerShipParameter(saveGame, paramPath)
 	return param
 end
 
+--
+-- Function: Helpers.getLuaClass
+--
+-- Retrieves the value of the 'class' field from the metatable. It should have
+-- been there when the save was unpickled.
+--
+-- Example:
+--
+-- > local entryType = Helpers.getLuaClass(entry)
+--
+-- Parameters:
+--
+--   tbl - table
+--
+-- Returns:
+--
+--   typename - string?
+--
+---@param tbl table
+---@return string? typename
+function Helpers.getLuaClass(tbl)
+	local typeTable = getmetatable(tbl)
+	if typeTable then return typeTable.class end
+end
+
 return Helpers

--- a/data/pigui/modules/new-game-window/layout.lua
+++ b/data/pigui/modules/new-game-window/layout.lua
@@ -6,7 +6,7 @@ local Crew = require 'pigui.modules.new-game-window.crew'
 local Ship = require 'pigui.modules.new-game-window.ship'
 local Location = require 'pigui.modules.new-game-window.location'
 local Summary = require 'pigui.modules.new-game-window.summary'
-local FlightLog = require 'pigui.modules.new-game-window.flight-log'
+local FlightLogTab = require 'pigui.modules.new-game-window.flight-log-tab'
 
 local Layout = {}
 
@@ -26,11 +26,11 @@ Layout.UpdateOrder = {
 	Ship.Fuel,
 	Location,
 	Location.Time,
-	FlightLog,
+	FlightLogTab,
 	Summary.Description
 }
 
-Layout.Tabs = { Summary, Crew, Ship, Location, FlightLog }
+Layout.Tabs = { Summary, Crew, Ship, Location, FlightLogTab }
 
 function Layout.updateLayout(contentRegion)
 

--- a/data/pigui/modules/new-game-window/recovery.lua
+++ b/data/pigui/modules/new-game-window/recovery.lua
@@ -30,6 +30,8 @@ local fixupDoc = Helpers.versioned {{
 
 		local refs = {}
 
+		local typeNames = {}
+
 		local function unpickle(tbl)
 			local result = {}
 			tbl = tbl.table
@@ -60,6 +62,9 @@ local fixupDoc = Helpers.versioned {{
 			local result = {}
 			if tbl.ref then
 				cache[tbl.ref] = result
+				if tbl.lua_class then
+					typeNames[result] = tbl.lua_class
+				end
 				tbl = refs[tbl.ref]
 			else
 				cache[tbl] = result
@@ -95,6 +100,8 @@ local fixupDoc = Helpers.versioned {{
 			print("fixupDoc failed: " .. tostring(countAfter) .. " of " .. tostring(countBefore) .. " refs were not resolved.")
 			return nil
 		end
+
+		gameDoc.type_names = typeNames
 
 		return gameDoc
 	end

--- a/data/pigui/modules/new-game-window/recovery.lua
+++ b/data/pigui/modules/new-game-window/recovery.lua
@@ -30,7 +30,7 @@ local fixupDoc = Helpers.versioned {{
 
 		local refs = {}
 
-		local typeNames = {}
+		local typeTables = {}
 
 		local function unpickle(tbl)
 			local result = {}
@@ -61,10 +61,15 @@ local fixupDoc = Helpers.versioned {{
 
 			local result = {}
 			if tbl.ref then
-				cache[tbl.ref] = result
 				if tbl.lua_class then
-					typeNames[result] = tbl.lua_class
+					local typeTable = typeTables[tbl.lua_class]
+					if not typeTable then
+						typeTable = { class = tbl.lua_class }
+						typeTables[tbl.lua_class] = typeTable
+					end
+					setmetatable(result, typeTable)
 				end
+				cache[tbl.ref] = result
 				tbl = refs[tbl.ref]
 			else
 				cache[tbl] = result
@@ -100,8 +105,6 @@ local fixupDoc = Helpers.versioned {{
 			print("fixupDoc failed: " .. tostring(countAfter) .. " of " .. tostring(countBefore) .. " refs were not resolved.")
 			return nil
 		end
-
-		gameDoc.type_names = typeNames
 
 		return gameDoc
 	end

--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -15,6 +15,11 @@
 #include <fmt/format.h>
 #include <fmt/printf.h>
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 namespace Log {
 	Logger s_defaultLog;
 
@@ -85,6 +90,20 @@ void Log::Logger::LogLevel(Severity sv, std::string_view message)
 void Log::Logger::WriteLog(Time::DateTime time, Severity sv, std::string_view msg)
 {
 	std::string &svName = s_severityNames.at(sv);
+
+#ifdef _MSC_VER
+	// TODO: unicode.., max_severity etc.
+	const static int BUFFER_SIZE = 1024;
+	char buffer[BUFFER_SIZE];
+	const char* m = msg.data();
+	if (!msg.empty() && msg.back() == '\n')
+		snprintf(buffer, BUFFER_SIZE - 1, "%s %.*s", svName.c_str(), msg.size(), msg.data());
+	else
+		snprintf(buffer, BUFFER_SIZE - 1, "%s %.*s\n", svName.c_str(), msg.size(), msg.data());
+
+	OutputDebugStringA(buffer);
+#endif
+
 
 	/* Don't output to the console on Windows
 	   Builds on /subsystem:WINDOWS will not usually have a console


### PR DESCRIPTION
So far this is proof of concept; imagining what it might look like to try and consolidate flight log related code, both serialization (standard case and to recover) but also rendering.

It's very rough and work in progress but I think shows this can be done and is worth exploring.

It's not ready for a detailed review, however, roughly it:

* renames `flight-log.lua` in the new game code to `flight-log-tab.lua`.  I believe it's confusing to have multiple files roughly called flight log.
* passes through the recover code into the flight log deseralization code to unify these; this requires passing some optional helpers
* separates the code to draw flight logs out from the `06-flightlog.lua` code into it's own place.  This should probably sit in the `pygui` tree though rather than the more generic `modules` tree to be honest.
* Uses the above drawing code to draw the flightlog in the new game tab by providing an option to not show all the interactive features, such as editing text or removing custom log entries.  This needs a bit more work, to show the options, but actually seems to work well; also needs testing at different screen resolutions.
** This also currently has issues working out how to format system paths and I think needs tidying up; perhaps by creating these and caching them at the time the flight log entries are created, rather than when they are drawn.  I don't know if this will cause issues if the language is changed or not if we cache strings from the localization system.
*** These issues occur due to difficulty in accessing the Galaxy object.  Is the galaxy invariant within a version of the game, if so, then I wonder why we need an active game to access it?  Perhaps it would be good to allow for multiple galaxies, I'm not sure so this is just idle speculation.



