### PR TITLE
Resizable Editor Window

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -175,7 +175,8 @@ void Camera::Update()
 		attrs.bodyFlags = b->GetFlags();
 
 		// approximate pixel width (disc diameter) of body on screen
-		const float pixSize = Graphics::GetScreenHeight() * 2.0 * rad / (attrs.camDist * Graphics::GetFovFactor());
+		// FIXME: this should reference a property set on the camera instead of querying the window size
+		const float pixSize = m_renderer->GetWindowHeight() * 2.0 * rad / (attrs.camDist * Graphics::GetFovFactor());
 
 		// terrain objects are visible from distance but might not have any discernable features
 		if (b->IsType(ObjectType::TERRAINBODY)) {

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -154,6 +154,7 @@ void Camera::Update()
 		BodyAttrs attrs;
 		attrs.body = b;
 		attrs.billboard = false; // false by default
+		attrs.calcAtmosphereLighting = false; // false by default
 
 		// If the body wishes to be excluded from the draw, skip it.
 		if (b->GetFlags() & Body::FLAG_DRAW_EXCLUDE)

--- a/src/DeathView.cpp
+++ b/src/DeathView.cpp
@@ -20,7 +20,7 @@ DeathView::DeathView(Game *game) :
 	Pi::renderer->GetNearFarRange(znear, zfar);
 
 	const float fovY = Pi::config->Float("FOVVertical");
-	m_cameraContext.Reset(new CameraContext(Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), fovY, znear, zfar));
+	m_cameraContext.Reset(new CameraContext(Pi::renderer->GetWindowWidth(), Pi::renderer->GetWindowHeight(), fovY, znear, zfar));
 	m_camera.reset(new Camera(m_cameraContext, Pi::renderer));
 }
 

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -251,7 +251,8 @@ Manager::Manager(IniConfig *config, SDL_Window *window) :
 	m_capturingMouse(false),
 	joystickEnabled(true),
 	mouseYInvert(false),
-	m_enableBindings(true)
+	m_enableBindings(true),
+	m_frameListChanged(false)
 {
 	joystickEnabled = (m_config->Int("EnableJoystick")) ? true : false;
 	mouseYInvert = (m_config->Int("InvertMouseY")) ? true : false;

--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -74,8 +74,8 @@ Intro::Intro(Graphics::Renderer *r, int width, int height) :
 
 	m_modelIndex = 0;
 
-	const int w = Graphics::GetScreenWidth();
-	const int h = Graphics::GetScreenHeight();
+	const int w = r->GetWindowWidth();
+	const int h = r->GetWindowHeight();
 
 	// double-width viewport, centred, then offset 1/6th to centre on the left
 	// 2/3rds of the screen, to the left of the menu
@@ -162,7 +162,7 @@ void Intro::Draw(float deltaTime)
 	m_renderer->ClearDepthBuffer();
 	m_background->Draw(brot);
 
-	m_renderer->SetViewport({ m_spinnerLeft, 0, m_spinnerWidth, Graphics::GetScreenHeight() });
+	m_renderer->SetViewport({ m_spinnerLeft, 0, m_spinnerWidth, m_renderer->GetWindowHeight() });
 	m_renderer->SetPerspectiveProjection(75, m_spinnerRatio, 1.f, 10000.f);
 
 	matrix4x4f trans =

--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -40,7 +40,7 @@ ObjectViewerView::ObjectViewerView() :
 	Pi::renderer->GetNearFarRange(znear, zfar);
 
 	const float fovY = Pi::config->Float("FOVVertical");
-	m_cameraContext.Reset(new CameraContext(Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), fovY, znear, zfar));
+	m_cameraContext.Reset(new CameraContext(Pi::renderer->GetWindowWidth(), Pi::renderer->GetWindowHeight(), fovY, znear, zfar));
 	m_camera.reset(new Camera(m_cameraContext, Pi::renderer));
 
 	m_cameraContext->SetCameraFrame(Pi::player->GetFrame());
@@ -148,11 +148,13 @@ void ObjectViewerView::DrawInfoWindow()
 	std::string infoLabel = fmt::format("View dist: {} Object: {}",
 		format_distance(viewingDist), m_targetBody->GetLabel());
 
+	ImVec2 vpSize = ImGui::GetMainViewport()->Size;
+
 	float xpos = ImGui::GetStyle().WindowPadding.x * 2;
-	float ypos = Graphics::GetScreenHeight() - (ImGui::GetTextLineHeightWithSpacing() * 5 + ImGui::GetFrameHeightWithSpacing());
+	float ypos = vpSize.y - (ImGui::GetTextLineHeightWithSpacing() * 5 + ImGui::GetFrameHeightWithSpacing());
 
 	ImGui::SetNextWindowPos({ xpos, ypos });
-	ImGui::SetNextWindowSize({ Graphics::GetScreenWidth() - xpos, Graphics::GetScreenHeight() - ypos });
+	ImGui::SetNextWindowSize({ vpSize.x - xpos, vpSize.y - ypos });
 	ImGui::Begin("ObjectViewerView#Info", nullptr, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration);
 
 	ImGui::TextUnformatted(infoLabel.c_str());
@@ -174,11 +176,13 @@ namespace ImGui {
 
 void ObjectViewerView::DrawControlsWindow()
 {
-	float xpos = Graphics::GetScreenWidth() - Graphics::GetScreenWidth() / 5.0;
+	ImVec2 vpSize = ImGui::GetMainViewport()->Size;
+
+	float xpos = vpSize.x - vpSize.x / 5.0;
 	float ypos = ImGui::GetStyle().WindowPadding.y;
 
 	ImGui::SetNextWindowPos({ xpos, ypos });
-	ImGui::SetNextWindowSize({ Graphics::GetScreenWidth() - xpos, Graphics::GetScreenHeight() - ypos });
+	ImGui::SetNextWindowSize({ vpSize.x - xpos, vpSize.y - ypos });
 	ImGui::Begin("ObjectViewerView#Controls", nullptr, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration);
 
 	if (m_isTerrainBody) {

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -931,6 +931,11 @@ void GameLoop::Update(float deltaTime)
 	frame_time_real = deltaTime * 1e3; // convert to ms
 	frame_stat++;
 
+	// Read events into internal structures and into imgui structures,
+	// dispatch will be performed after the imgui frame, so that imgui can add
+	// something based on clicks on widgets
+	Pi::GetApp()->PollEvents();
+
 #ifdef ENABLE_SERVER_AGENT
 	Pi::serverAgent->ProcessResponses();
 #endif
@@ -1009,15 +1014,6 @@ void GameLoop::Update(float deltaTime)
 	// This may cause future issues if graphic resources are deleted while in-flight, but OpenGL is
 	// capable of handling that eventuality and it prevents application-scope crashes
 	Pi::renderer->FlushCommandBuffers();
-
-	// FIXME: Handling events at the moment must be after view->Draw3D and before
-	// Gui::Draw so that labels drawn to screen can have mouse events correctly
-	// detected. Gui::Draw wipes memory of label positions.
-
-	// Read events into internal structures and into imgui structures,
-	// dispatch will be performed after the imgui frame, so that imgui can add
-	// something based on clicks on widgets
-	Pi::GetApp()->PollEvents();
 
 #ifdef REMOTE_LUA_REPL
 	Pi::luaConsole->HandleTCPDebugConnections();

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -661,7 +661,8 @@ void StartupScreen::End()
 
 void MainMenu::Start()
 {
-	Pi::intro = new Intro(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight());
+	// TODO: just calculate this at draw time inside Intro
+	Pi::intro = new Intro(Pi::renderer, Pi::renderer->GetWindowWidth(), Pi::renderer->GetWindowHeight());
 	if (m_skipMenu) {
 		Output("Loading new game immediately!\n");
 		Pi::StartGame(new Game(m_startPath, 0.0));
@@ -1152,7 +1153,8 @@ void GameLoop::End()
 
 void TombstoneLoop::Start()
 {
-	tombstone.reset(new Tombstone(Pi::renderer, Graphics::GetScreenWidth(), Graphics::GetScreenHeight()));
+	// TODO: just calculate this at draw time inside Tombstone
+	tombstone.reset(new Tombstone(Pi::renderer, Pi::renderer->GetWindowWidth(), Pi::renderer->GetWindowHeight()));
 	startTime = Pi::GetApp()->GetTime();
 }
 

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -350,7 +350,7 @@ void Pi::App::OnStartup()
 	Pi::detail.cities = config->Int("DetailCities");
 
 	Graphics::RendererOGL::RegisterRenderer();
-	Pi::renderer = StartupRenderer(Pi::config);
+	Pi::renderer = StartupRenderer(Pi::config, false, config->Int("DebugWindowResize"));
 
 	Pi::rng.IncRefCount(); // so nothing tries to free it
 	Pi::rng.seed(time(0));

--- a/src/SectorMap.cpp
+++ b/src/SectorMap.cpp
@@ -523,8 +523,8 @@ void SectorMap::InitDefaults()
 
 	m_sectorCache = m_context.galaxy->NewSectorSlaveCache();
 	InputBindings.RegisterBindings();
-	m_size.x = Graphics::GetScreenWidth();
-	m_size.y = Graphics::GetScreenHeight();
+	m_size.x = m_context.renderer->GetWindowWidth();
+	m_size.y = m_context.renderer->GetWindowHeight();
 }
 
 void SectorMap::InitObject()
@@ -1066,7 +1066,9 @@ void SectorMap::DrawFarSectors(const matrix4x4f &modelview)
 
 	// always draw the stars, slightly altering their size for different different resolutions, so they still look okay
 	if (m_farstars.size() > 0) {
-		m_farstarsPoints.SetData(m_context.renderer, m_farstars.size(), &m_farstars[0], &m_farstarsColor[0], modelview, 0.25f * (Graphics::GetScreenHeight() / 720.f));
+		// TODO: this should query screen DPI instead of platform window height
+		float sizeFactor = 0.25f * (m_context.renderer->GetWindowHeight() / 720.f);
+		m_farstarsPoints.SetData(m_context.renderer, m_farstars.size(), &m_farstars[0], &m_farstarsColor[0], modelview, sizeFactor);
 		m_farstarsPoints.Draw(m_context.renderer, m_farStarsMat.Get());
 	}
 

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -26,24 +26,25 @@
 using namespace Graphics;
 
 namespace {
-	float SizeToPixels(const vector3f &trans, const float size)
+	float SizeToPixels(int screenHeight, const vector3f &trans, const float size)
 	{
 		//some hand-tweaked scaling, to make the lights seem larger from distance (final size is in pixels)
 		// gl_PointSize = pixels_per_radian * point_diameter / distance( camera, pointcenter );
-		const float pixrad = Clamp(Graphics::GetScreenHeight() / trans.Length(), 0.1f, 50.0f);
+		// FIXME: this should reference a camera object instead of querying the window height
+		const float pixrad = Clamp(screenHeight / trans.Length(), 0.1f, 50.0f);
 		return (size * Graphics::GetFovFactor()) * pixrad;
 	}
 
-	float GetParticleSpeed(SFX_TYPE t, const vector3f &pos, const Sfx &inst)
+	float GetParticleSpeed(int screenHeight, SFX_TYPE t, const vector3f &pos, const Sfx &inst)
 	{
 		switch (t) {
 		case TYPE_NONE: assert(false);
 		case TYPE_EXPLOSION:
-			return SizeToPixels(pos, inst.m_speed);
+			return SizeToPixels(screenHeight, pos, inst.m_speed);
 		case TYPE_DAMAGE:
-			return SizeToPixels(pos, 20.f);
+			return SizeToPixels(screenHeight, pos, 20.f);
 		case TYPE_SMOKE:
-			return Clamp(SizeToPixels(pos, (inst.m_speed * inst.m_age)), 0.1f, 50.0f);
+			return Clamp(SizeToPixels(screenHeight, pos, (inst.m_speed * inst.m_age)), 0.1f, 50.0f);
 		default:
 			return 0.f;
 		}
@@ -252,6 +253,7 @@ void SfxManager::Cleanup()
 void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 {
 	Frame *f = Frame::GetFrame(fId);
+	int screenHeight = renderer->GetWindowHeight();
 
 	PROFILE_SCOPED()
 	if (f->m_sfx) {
@@ -289,7 +291,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 				const vector3f pos(ftran * inst.m_pos);
 				// pack UV offset and particle size in normal attribute
 				const vector2f offset = CalculateOffset(SFX_TYPE(t), inst);
-				const float speed = GetParticleSpeed(SFX_TYPE(t), pos, inst);
+				const float speed = GetParticleSpeed(screenHeight, SFX_TYPE(t), pos, inst);
 
 				pointArray.Add(pos, vector3f(offset, Clamp(speed, 0.1f, FLT_MAX)));
 			}

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -841,11 +841,11 @@ static bool CheckSuicide(DynamicBody *dBody, const vector3d &obspos, double obsM
 
 	double obsDist = obspos.Length();
 
-	//sanity check 
+	//sanity check
 	if(obsDist > 100 * safeAlt)
 		return false;
 
-	vector3d velDir = dBody->GetVelocity().NormalizedSafe();	
+	vector3d velDir = dBody->GetVelocity().NormalizedSafe();
 	double tangDist = obspos.Dot(velDir);
 
 	//ship passed the planet
@@ -859,7 +859,7 @@ static bool CheckSuicide(DynamicBody *dBody, const vector3d &obspos, double obsM
 	//Ignore speed check -> continue the recovery until speed vector is over horizon
 	if(recovering) return true;
 	//below are more strict speed conditions to enter the recovery
-	
+
 	//for final apreach the targetAlt must be used for safe speed check
 	double zeroSpeedAlt = std::min(safeAlt, targetAlt);
 
@@ -878,7 +878,7 @@ static bool CheckSuicide(DynamicBody *dBody, const vector3d &obspos, double obsM
 
 	//Energy equation with planet gravity taken into account
 	if (breakingDist > 100
-		&& dBody->GetVelocity().LengthSqr() > 2*(prop->GetAccelFwd()*breakingDist - G*obsMass*(obsDist-zeroSpeedAlt)/(obsDist*zeroSpeedAlt))) 
+		&& dBody->GetVelocity().LengthSqr() > 2*(prop->GetAccelFwd()*breakingDist - G*obsMass*(obsDist-zeroSpeedAlt)/(obsDist*zeroSpeedAlt)))
 		return true;
 
 	return false;
@@ -922,6 +922,7 @@ AICmdFlyTo::AICmdFlyTo(DynamicBody *dBody, Body *target) :
 	assert(m_prop != nullptr);
 	m_frameId = FrameId::Invalid;
 	m_state = -6;
+	m_posoff = vector3d(0.0);
 	m_endvel = 0;
 	m_tangent = false;
 	m_is_flyto = true;
@@ -1053,14 +1054,14 @@ bool AICmdFlyTo::TimeStepUpdate()
 			vector3d sidedir = obspos.Cross(m_dBody->GetVelocity()).NormalizedSafe();
 			vector3d updir = sidedir.Cross(m_dBody->GetVelocity()).NormalizedSafe();
 
-			//clamped tangent of Yaw mismatch to target - for driving side trust  
+			//clamped tangent of Yaw mismatch to target - for driving side trust
 			constexpr double cSideDriveRange = 0.02;
 			double targetSideTan = Clamp(targdist > 1 ? relpos.Dot(sidedir)/targdist : 0, -cSideDriveRange, cSideDriveRange);
-			
+
 			//Bellow safe alt (gravity too big for thrusters) breaking will kill the ship eventually
 			//so in this case ship accelerates along speed vector otherwise it is safe to break
 			float sign = G*M/obspos.LengthSqr() > 0.9 * m_prop->GetAccelUp() ? 1.0 : -1.0;
-			
+
 			double ang = m_prop->AIFaceDirection(m_dBody->GetVelocity() * sign);
 			m_prop->AIFaceUpdir(updir);
 #ifdef DEBUG_CHECK_SUICIDE

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -112,7 +112,7 @@ void WorldView::InitObject()
 
 	const float fovY = Pi::config->Float("FOVVertical");
 
-	m_cameraContext.Reset(new CameraContext(Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), fovY, znear, zfar));
+	m_cameraContext.Reset(new CameraContext(Pi::renderer->GetWindowWidth(), Pi::renderer->GetWindowHeight(), fovY, znear, zfar));
 	m_camera.reset(new Camera(m_cameraContext, Pi::renderer));
 
 	InputBindings.RegisterBindings();
@@ -185,7 +185,7 @@ void WorldView::Draw3D()
 
 	// setup orthographic projection the indicator coordinate system expects
 	// (could also draw this using ImGui methods in DrawPiGui, but this is a quick patch for release)
-	m_renderer->SetProjection(matrix4x4f::OrthoFrustum(0, Graphics::GetScreenWidth(), Graphics::GetScreenHeight(), 0, 0, 1));
+	m_renderer->SetProjection(matrix4x4f::OrthoFrustum(0, m_renderer->GetWindowWidth(), m_renderer->GetWindowHeight(), 0, 0, 1));
 	m_renderer->SetTransform(matrix4x4f::Identity());
 
 	// combat target indicator
@@ -356,8 +356,8 @@ void WorldView::UpdateIndicator(Indicator &indicator, const vector3d &cameraSpac
 	const float BORDER_BOTTOM = 90.0;
 	// XXX BORDER_BOTTOM is 10+the control panel height and shouldn't be needed at all
 
-	const float w = Graphics::GetScreenWidth();
-	const float h = Graphics::GetScreenHeight();
+	const float w = m_renderer->GetWindowWidth();
+	const float h = m_renderer->GetWindowHeight();
 
 	if (cameraSpacePos.LengthSqr() < 1e-6) { // length < 1e-3
 		indicator.pos.x = w / 2.0f;
@@ -513,7 +513,7 @@ void WorldView::DrawCombatTargetIndicator(const Indicator &target, const Indicat
 
 void WorldView::DrawEdgeMarker(const Indicator &marker, const Color &c)
 {
-	const vector2f screenCentre(Graphics::GetScreenWidth() / 2.0f, Graphics::GetScreenHeight() / 2.0f);
+	const vector2f screenCentre(m_renderer->GetWindowWidth() / 2.0f, m_renderer->GetWindowHeight() / 2.0f);
 	vector2f dir = screenCentre - marker.pos;
 	float len = dir.Length();
 	dir *= HUD_CROSSHAIR_SIZE / len;
@@ -582,8 +582,8 @@ std::tuple<double, double, double> WorldView::CalculateHeadingPitchRoll(PlaneTyp
 static vector3d projectToScreenSpace(const vector3d &pos, RefCountedPtr<CameraContext> cameraContext, const bool adjustZ = true)
 {
 	const Graphics::Frustum &frustum = cameraContext->GetFrustum();
-	const float h = Graphics::GetScreenHeight();
-	const float w = Graphics::GetScreenWidth();
+	const float h = cameraContext->GetHeight();
+	const float w = cameraContext->GetWidth();
 	vector3d proj;
 	if (!frustum.ProjectPoint(pos, proj)) {
 		return vector3d(w / 2, h / 2, 0);

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -35,6 +35,7 @@ void GuiApplication::BeginFrame()
 	m_renderer->ClearScreen();
 
 	m_renderer->BeginFrame();
+	m_input->NewFrame();
 }
 
 void GuiApplication::EndFrame()
@@ -90,11 +91,6 @@ void GuiApplication::PollEvents()
 {
 	PROFILE_SCOPED()
 	SDL_Event event;
-
-	// FIXME: input state is right before handling updates because
-	// legacy UI code needs to run before input does.
-	// When HandleEvents() is moved to BeginFrame / PreUpdate, this call should go with it
-	m_input->NewFrame();
 
 	while (SDL_PollEvent(&event)) {
 		if (event.type == SDL_QUIT) {

--- a/src/core/GuiApplication.h
+++ b/src/core/GuiApplication.h
@@ -44,7 +44,7 @@ protected:
 
 	// TODO: unify config handling, possibly make the config an Application member
 	// Call this from your OnStartup() method
-	Graphics::Renderer *StartupRenderer(IniConfig *config, bool hidden = false);
+	Graphics::Renderer *StartupRenderer(IniConfig *config, bool hidden = false, bool resizable = false);
 
 	// Call this from your OnStartup() method
 	Input::Manager *StartupInput(IniConfig *config);
@@ -80,6 +80,7 @@ protected:
 
 private:
 	Graphics::RenderTarget *CreateRenderTarget(const Graphics::Settings &settings);
+	void OnWindowResized();
 
 	RefCountedPtr<PiGui::Instance> m_pigui;
 	std::unique_ptr<Input::Manager> m_input;

--- a/src/editor/EditorApp.cpp
+++ b/src/editor/EditorApp.cpp
@@ -123,7 +123,7 @@ void EditorApp::OnStartup()
 
 	Graphics::RendererOGL::RegisterRenderer();
 
-	m_renderer = StartupRenderer(m_editorCfg.get());
+	m_renderer = StartupRenderer(m_editorCfg.get(), false, true);
 	StartupInput(m_editorCfg.get());
 
 	StartupPiGui();
@@ -194,7 +194,7 @@ void LoadingPhase::Update(float dt)
 {
 	constexpr const char *loadingMessage = "Loading...";
 
-	const ImVec2 winSize = { float(Graphics::GetScreenWidth()), float(Graphics::GetScreenHeight()) };
+	const ImVec2 winSize = ImGui::GetMainViewport()->Size;
 	const ImVec2 textSize = ImGui::CalcTextSize(loadingMessage);
 
 	ImGui::SetNextWindowBgAlpha(0.0);

--- a/src/editor/system/SystemEditor.cpp
+++ b/src/editor/system/SystemEditor.cpp
@@ -148,6 +148,8 @@ void SystemEditor::NewSystem(SystemPath path)
 
 	// mark current file as unsaved
 	m_lastSavedUndoStack = size_t(-1);
+
+	m_viewport->SetSystem(m_system);
 }
 
 bool SystemEditor::LoadSystemFromDisk(const std::string &absolutePath)

--- a/src/editor/system/SystemEditor.cpp
+++ b/src/editor/system/SystemEditor.cpp
@@ -227,13 +227,10 @@ bool SystemEditor::LoadSystemFromFile(const FileSystem::FileInfo &file)
 			ok = LoadCustomSystem(csys);
 	}
 
-	if (ok) {
-		std::string windowTitle = fmt::format("System Editor - {}", m_filepath);
-		SDL_SetWindowTitle(m_app->GetRenderer()->GetSDLWindow(), windowTitle.c_str());
-	} else {
+	if (!ok)
 		m_filepath.clear();
-	}
 
+	OnFilepathChanged();
 
 	return ok;
 }
@@ -353,7 +350,7 @@ void SystemEditor::ClearSystem()
 	m_filepath.clear();
 	m_newSystemPath.systemIndex = 0;
 
-	SDL_SetWindowTitle(m_app->GetRenderer()->GetSDLWindow(), "System Editor");
+	OnFilepathChanged();
 }
 
 // Here to avoid needing to drag in the Galaxy header in SystemEditor.h
@@ -483,6 +480,16 @@ void SystemEditor::RegisterMenuActions()
 	m_menuBinder->EndGroup();
 }
 
+void SystemEditor::OnFilepathChanged()
+{
+	if (m_filepath.empty()) {
+		SDL_SetWindowTitle(m_app->GetRenderer()->GetSDLWindow(), "System Editor");
+	} else {
+		std::string windowTitle = fmt::format("System Editor - {}", m_filepath);
+		SDL_SetWindowTitle(m_app->GetRenderer()->GetSDLWindow(), windowTitle.c_str());
+	}
+}
+
 bool SystemEditor::HasUnsavedChanges()
 {
 	return (m_system && GetUndo()->GetStateHash() != m_lastSavedUndoStack);
@@ -584,10 +591,17 @@ void SystemEditor::Update(float deltaTime)
 		if (!filePath.empty()) {
 			Log::Info("SaveFile: {}", filePath);
 
+			// Ensure we're saving JSON files on Windows
+			if (!ends_with_ci(filePath, ".json")) {
+				filePath += ".json";
+			}
+
 			// Update current file path and directory from new "save-as" path
 			if (WriteSystem(filePath)) {
 				m_filepath = filePath;
 				m_filedir = filePath.substr(0, filePath.find_last_of("/\\"));
+
+				OnFilepathChanged();
 			}
 		} else {
 			// Signal cancellation/failure to save

--- a/src/editor/system/SystemEditor.h
+++ b/src/editor/system/SystemEditor.h
@@ -103,8 +103,6 @@ private:
 	void DrawBodyProperties();
 	void DrawSystemProperties();
 
-	void EditName(const char *undo_label, std::string *name);
-
 	void DrawUndoDebug();
 
 	UndoSystem *GetUndo() { return m_undo.get(); }

--- a/src/editor/system/SystemEditor.h
+++ b/src/editor/system/SystemEditor.h
@@ -76,6 +76,8 @@ private:
 	void LoadSystemFromGalaxy(RefCountedPtr<StarSystem> system);
 	void ClearSystem();
 
+	void OnFilepathChanged();
+
 	void RegisterMenuActions();
 
 	bool HasUnsavedChanges();

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -36,19 +36,8 @@ namespace Graphics {
 
 	static bool initted = false;
 	Material *vtxColorMaterial;
-	static int width, height;
 	static float g_fov = 85.f;
 	static float g_fovFactor = 1.f;
-
-	int GetScreenWidth()
-	{
-		return width;
-	}
-
-	int GetScreenHeight()
-	{
-		return height;
-	}
 
 	float GetFov()
 	{
@@ -102,14 +91,6 @@ namespace Graphics {
 		if (renderer == nullptr) {
 			Error("Failed to set video mode: %s", SDL_GetError());
 			return nullptr;
-		}
-
-		if (vs.rendererType == Graphics::RENDERER_DUMMY) {
-			width = vs.width;
-			height = vs.height;
-		} else {
-			width = renderer->GetWindowWidth();
-			height = renderer->GetWindowHeight();
 		}
 
 		Output("Initialized %s\n", renderer->GetName());

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -81,9 +81,6 @@ namespace Graphics {
 	class Material;
 	extern Material *vtxColorMaterial;
 
-	[[deprecated]] int GetScreenWidth();
-	[[deprecated]] int GetScreenHeight();
-
 	float GetFov();
 	void SetFov(float);
 	float GetFovFactor(); //cached 2*tan(fov/2) for LOD

--- a/src/graphics/Graphics.h
+++ b/src/graphics/Graphics.h
@@ -32,6 +32,7 @@ namespace Graphics {
 		bool useAnisotropicFiltering;
 		bool enableDebugMessages;
 		bool gl3ForwardCompatible;
+		bool canBeResized;
 		int vsync;
 		int requestedSamples;
 		int height;
@@ -80,8 +81,8 @@ namespace Graphics {
 	class Material;
 	extern Material *vtxColorMaterial;
 
-	int GetScreenWidth();
-	int GetScreenHeight();
+	[[deprecated]] int GetScreenWidth();
+	[[deprecated]] int GetScreenHeight();
 
 	float GetFov();
 	void SetFov(float);

--- a/src/graphics/RenderTarget.h
+++ b/src/graphics/RenderTarget.h
@@ -27,12 +27,12 @@ namespace Graphics {
 			numSamples(_samples)
 		{}
 
-		const Uint16 width;
-		const Uint16 height;
-		const TextureFormat colorFormat;
-		const TextureFormat depthFormat;
-		const bool allowDepthTexture;
-		const Uint16 numSamples;
+		Uint16 width;
+		Uint16 height;
+		TextureFormat colorFormat;
+		TextureFormat depthFormat;
+		bool allowDepthTexture;
+		Uint16 numSamples;
 	};
 
 	class RenderTarget {

--- a/src/graphics/Renderer.h
+++ b/src/graphics/Renderer.h
@@ -63,6 +63,8 @@ namespace Graphics {
 		virtual bool SupportsInstancing() = 0;
 
 		SDL_Window *GetSDLWindow() const { return m_window; }
+		virtual void OnWindowResized() {};
+
 		float GetDisplayAspect() const { return static_cast<float>(m_width) / static_cast<float>(m_height); }
 		int GetWindowWidth() const { return m_width; }
 		int GetWindowHeight() const { return m_height; }

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -90,6 +90,9 @@ namespace Graphics {
 		if (!vs.hidden && vs.fullscreen) // TODO: support for borderless fullscreen and changing window size
 			winFlags |= SDL_WINDOW_FULLSCREEN;
 
+		if (vs.canBeResized)
+			winFlags |= SDL_WINDOW_RESIZABLE;
+
 		window = SDL_CreateWindow(name, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, vs.width, vs.height, winFlags);
 		if (!window)
 			return false;
@@ -468,6 +471,11 @@ namespace Graphics {
 	void RendererOGL::SetVSyncEnabled(bool enabled)
 	{
 		SDL_GL_SetSwapInterval(enabled ? -1 : 0);
+	}
+
+	void RendererOGL::OnWindowResized()
+	{
+		SDL_GL_GetDrawableSize(m_window, &m_width, &m_height);
 	}
 
 	bool RendererOGL::BeginFrame()

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -58,6 +58,8 @@ namespace Graphics {
 
 		virtual void SetVSyncEnabled(bool) override;
 
+		virtual void OnWindowResized() override;
+
 		virtual bool BeginFrame() override final;
 		virtual bool EndFrame() override final;
 		virtual bool SwapBuffers() override final;

--- a/src/lua/LuaConsole.cpp
+++ b/src/lua/LuaConsole.cpp
@@ -192,7 +192,7 @@ static int callback(ImGuiInputTextCallbackData *data)
 void LuaConsole::Draw()
 {
 	ImGui::SetNextWindowPos({ 0, 0 });
-	ImGui::SetNextWindowSize({ float(Graphics::GetScreenWidth()), float(Graphics::GetScreenHeight()) });
+	ImGui::SetNextWindowSize(ImGui::GetMainViewport()->Size);
 	if (ImGui::Begin("Lua Console", nullptr, ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoSavedSettings)) {
 		if (ImGui::BeginChild("##TextWindow", ImVec2(0.f, -ImGui::GetFrameHeightWithSpacing() - ImGui::GetStyle().ItemSpacing.y))) {
 			for (const auto &str : m_outputLines) {

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -20,6 +20,7 @@
 #include "Space.h"
 #include "WorldView.h"
 #include "graphics/Graphics.h"
+#include "graphics/Renderer.h"
 #include "imgui/backends/imgui_impl_sdl2.h"
 #include "imgui/imgui.h"
 #include "imgui/imgui_internal.h"
@@ -139,8 +140,10 @@ void pi_lua_generic_push(lua_State *l, const ImVec2 &vec)
 int PiGui::pushOnScreenPositionDirection(lua_State *l, vector3d position)
 {
 	PROFILE_SCOPED()
-	const int width = Graphics::GetScreenWidth();
-	const int height = Graphics::GetScreenHeight();
+
+	// TODO: query ImGui viewport or WorldView instead?
+	const int width = Pi::renderer->GetWindowWidth();
+	const int height = Pi::renderer->GetWindowHeight();
 	vector3d direction = (position - vector3d(width / 2.0, height / 2.0, 0)).Normalized();
 	if (vector3d(0, 0, 0) == position || position.x < 0 || position.y < 0 || position.x > width || position.y > height || position.z > 0) {
 		LuaPush<bool>(l, false);
@@ -2045,8 +2048,10 @@ PiGui::TScreenSpace lua_world_space_to_screen_space(const Body *body)
 {
 	PROFILE_SCOPED()
 	const vector3d p = Pi::game->GetWorldView()->WorldSpaceToScreenSpace(body);
-	const int width = Graphics::GetScreenWidth();
-	const int height = Graphics::GetScreenHeight();
+
+	// TODO: query ImGui viewport or WorldView instead?
+	const int width = Pi::renderer->GetWindowWidth();
+	const int height = Pi::renderer->GetWindowHeight();
 	const vector3d direction = (p - vector3d(width / 2.0, height / 2.0, 0)).Normalized();
 	if (vector3d(0, 0, 0) == p || p.x < 0 || p.y < 0 || p.x > width || p.y > height || p.z > 0) {
 		return PiGui::TScreenSpace(false, vector2d(0, 0), direction * (p.z > 0 ? -1 : 1));
@@ -2410,13 +2415,15 @@ static int l_attr_event_queue(lua_State *l)
 
 static int l_attr_screen_height(lua_State *l)
 {
-	LuaPush<int>(l, Graphics::GetScreenHeight());
+	// TODO: query ImGui viewport instead?
+	LuaPush<int>(l, Pi::renderer->GetWindowHeight());
 	return 1;
 }
 
 static int l_attr_screen_width(lua_State *l)
 {
-	LuaPush<int>(l, Graphics::GetScreenWidth());
+	// TODO: query ImGui viewport instead?
+	LuaPush<int>(l, Pi::renderer->GetWindowWidth());
 	return 1;
 }
 

--- a/src/lua/LuaSystemView.cpp
+++ b/src/lua/LuaSystemView.cpp
@@ -48,17 +48,6 @@ static int l_systemview_set_selected_object(lua_State *l)
 	return 0;
 }
 
-bool too_near(const vector3f &a, const vector3f &b, const vector2d &gain)
-{
-	return std::abs(a.x - b.x) < gain.x && std::abs(a.y - b.y) < gain.y
-		// we don’t want to group objects that simply overlap and are located at different distances
-		// therefore, depth is also taken into account, we have z_NDC (normalized device coordinates)
-		// in order to make a strict translation of delta z_NDC into delta "pixels", one also needs to know
-		// the z coordinates in the camera space. I plan to implement this later
-		// at the moment I just picked up a number that works well (6.0)
-		&& std::abs(a.z - b.z) * Graphics::GetScreenWidth() * 6.0 < gain.x;
-}
-
 /*
  * Method: GetProjectedGrouped
  *

--- a/src/scenegraph/Billboard.cpp
+++ b/src/scenegraph/Billboard.cpp
@@ -48,7 +48,8 @@ namespace SceneGraph {
 		PROFILE_SCOPED()
 
 		//some hand-tweaked scaling, to make the lights seem larger from distance (final size is in pixels)
-		const float pixrad = Clamp(Graphics::GetScreenHeight() / trans.GetTranslate().Length(), 1.0f, 15.0f);
+		// FIXME: this should reference a camera object instead of querying the window height
+		const float pixrad = Clamp(m_renderer->GetWindowHeight() / trans.GetTranslate().Length(), 1.0f, 15.0f);
 		const float size = (m_size * Graphics::GetFovFactor()) * pixrad;
 		m_bbVA.Add(trans * vector3f(0.0f), vector3f(m_colorUVoffset, size));
 	}

--- a/src/scenegraph/LOD.cpp
+++ b/src/scenegraph/LOD.cpp
@@ -50,7 +50,8 @@ namespace SceneGraph {
 		//on screen and pick a child to render
 		const vector3f cameraPos(-trans[12], -trans[13], -trans[14]);
 		//fov is vertical, so using screen height
-		const float pixrad = Graphics::GetScreenHeight() * rd->boundingRadius / (cameraPos.Length() * Graphics::GetFovFactor());
+		// FIXME: this should reference a camera object instead of querying the render height
+		const float pixrad = m_renderer->GetWindowHeight() * rd->boundingRadius / (cameraPos.Length() * Graphics::GetFovFactor());
 		if (m_pixelSizes.empty()) return;
 		unsigned int lod = m_children.size() - 1;
 		for (unsigned int i = m_pixelSizes.size(); i > 0; i--) {
@@ -84,7 +85,8 @@ namespace SceneGraph {
 				//on screen and pick a child to render
 				const vector3f cameraPos(-mt[12], -mt[13], -mt[14]);
 				//fov is vertical, so using screen height
-				const float pixrad = Graphics::GetScreenHeight() * rd->boundingRadius / (cameraPos.Length() * Graphics::GetFovFactor());
+				// FIXME: this should reference a camera object instead of querying the window height
+				const float pixrad = m_renderer->GetWindowHeight() * rd->boundingRadius / (cameraPos.Length() * Graphics::GetFovFactor());
 				unsigned int lod = m_children.size() - 1;
 				for (unsigned int i = m_pixelSizes.size(); i > 0; i--) {
 					if (pixrad < m_pixelSizes[i - 1]) {


### PR DESCRIPTION
At long last, we have the technology to resize a window at runtime. ~~It only took three years by my count.~~

This PR provides support for resizing the editor window using the titlebar / window corners (or any other OS-provided method to resize a window). It also fixes some bugs along the way, adds some more FIXME comments (no delve into the dungeon of the code is complete without at least one new FIXME), and sneakily adds an option to resize the main game window as well - though none of the UI currently resizes along with it.

This PR fully deprecates and deletes Graphics::GetScreenHeight/Width, replacing usage with the Renderer::GetWindowHeight/Width methods instead. In a lot of cases, the original use of the function was suboptimal at best, and future work should be done to refactor those algorithms to use a more appropriate source of screen size information. I'll be leaving that for other contributors to hack on at this juncture.

Fixes #5742.

https://github.com/pioneerspacesim/pioneer/assets/4218491/ecf8095a-c9f1-4d04-bb78-9800c21b160f


