### PR TITLE
Update Github Upload-Artifact action for Windows CI

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -82,10 +82,12 @@ jobs:
         cmake --build . --target win-installer
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Windows-Artifacts
         path: pioneer/pioneer-*-win.exe
+        retention-days: 14
+        compression-level: 0 # contains a pre-compressed self-extracting archive...
 
     - name: Upload Release Files
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This inadvertently got missed during the last set of CI updates - this PR updates the Windows `upload-artifact` Github Action to use version 4 of that action, which is more efficient and provides much faster upload speeds (and also addresses the deprecation notice from using v3).

This also normalizes the Windows artifacts to be retained for 14 days after a build - given that we're generating >1GB of artifacts from each build and there's little need to download a pre-built archive of a past build, it doesn't really make sense to retain builds for the default of 90 days. Binaries uploaded to Github Releases are not affected by this change - they're stored separately and will be retained permanently (for as long as the release exists).