### PR TITLE
Fix the accumulation of zombie traders and some other unnecessary things

### DIFF
--- a/data/modules/LifeSupport.lua
+++ b/data/modules/LifeSupport.lua
@@ -10,10 +10,10 @@ local Timer       = require 'Timer'
 local lc = require 'Lang'.GetResource("core")
 
 local function LifeSupportCallback(self)
-	if not self:exists() then return false end
+	if not self:exists() then return true end
 
 	if self:GetDockedWith() then
-		return true
+		return false
 	end
 
 	---@type CargoManager
@@ -32,7 +32,7 @@ local function LifeSupportCallback(self)
 	-- 	Engine.RequestProfileFrame()
 	-- end
 
-	return true
+	return false
 end
 
 -- TODO: this can be massively improved as far as performance goes; it should
@@ -48,6 +48,6 @@ Event.Register('onShipCreated', function (ship)
 	-- so distribute timer callback load over the full 5s to avoid massive
 	-- single-frame spikes where every ship is processed at once
 	Timer:CallAt(Game.time + 5.0 * Engine.rand:Number(), function()
-		Timer:CallEvery(5.0, function() LifeSupportCallback(ship) end)
+		Timer:CallEvery(5.0, function() return LifeSupportCallback(ship) end)
 	end)
 end)

--- a/data/modules/System/OutOfFuel.lua
+++ b/data/modules/System/OutOfFuel.lua
@@ -13,10 +13,12 @@ local onShipFuelChanged = function (ship, state)
 			Comms.ImportantMessage(l.YOUR_FUEL_TANK_IS_ALMOST_EMPTY)
 		elseif state == "EMPTY" then
 			Comms.ImportantMessage(l.YOUR_FUEL_TANK_IS_EMPTY)
+			Event.Queue('onShipOutOfFuel', ship)
 		end
 	else
 		if state == "EMPTY" then
 			print(('{label} ({id}) out of fuel'):interp({label=ship.label,id=ship.shipId}))
+			Event.Queue('onShipOutOfFuel', ship)
 		end
 	end
 end

--- a/data/modules/TradeShips/Events.lua
+++ b/data/modules/TradeShips/Events.lua
@@ -305,6 +305,13 @@ local onShipDestroyed = function (ship, attacker)
 end
 Event.Register("onShipDestroyed", onShipDestroyed)
 
+local onShipOutOfFuel = function (ship)
+	if not Core.ships[ship] then return end
+	-- we don't want to bother yet
+	Core.ships[ship] = nil
+	ship:Explode()
+end
+Event.Register("onShipOutOfFuel", onShipOutOfFuel)
 
 local onGameEnd = function ()
 	-- drop the references for our data so Lua can free them

--- a/data/modules/TradeShips/Flow.lua
+++ b/data/modules/TradeShips/Flow.lua
@@ -485,9 +485,10 @@ Flow.spawnInitialShips = function()
 			local ship = Space.SpawnShipDocked(params.id, params.port)
 			-- if can't spawn - just skip
 			if ship then
-				Core.ships[ship] = { ts_error = "OK", status = 'docked', starport	= params.port, ship_name = params.id }
+				Core.ships[ship] = { ts_error = "OK", status = 'docked', starport = params.port, ship_name = params.id }
 				ship:SetLabel(Ship.MakeRandomLabel())
 				Trader.addEquip(ship)
+				Trader.assignTask(ship, Game.time + utils.deviation(Core.params.port_params[params.port].time * 3600, 0.8), 'doUndock')
 			end
 		end
 	end

--- a/data/modules/TradeShips/Trader.lua
+++ b/data/modules/TradeShips/Trader.lua
@@ -212,9 +212,14 @@ local function canAtmo(ship)
 	return ship:CountEquip(e.misc.atmospheric_shielding) ~= 0
 end
 
+local THRUSTER_UP = Engine.GetEnumValue('ShipTypeThruster', 'UP')
+
 Trader.isStarportAcceptableForShip = function(starport, ship)
-	return canAtmo(ship) or not isAtmo(starport)
-	-- TODO add a check to see if the ship has enough engine power to handle gravity
+	if not isAtmo(starport) then return true end
+	if not canAtmo(ship) then return false end
+	local bellyThrust = ship:GetThrusterAcceleration(THRUSTER_UP)
+	local portGravity = starport.path:GetSystemBody().parent.gravity
+	return bellyThrust > portGravity
 end
 
 Trader.getNearestStarport = function(ship, current)

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -1325,6 +1325,28 @@ static int l_ship_get_thruster_state(lua_State *l)
 	return 1;
 }
 
+/* Method: GetThrusterAcceleration
+ *
+ * Returns maximum acceleration in one of 6 directions
+ *
+ * Parameters:
+ *
+ *   direction - number, the <ShipTypeThruster> enum value
+ *
+ * Returns:
+ *
+ *   acceleration - number, m/s/s
+ *
+ */
+static int l_ship_get_thruster_acceleration(lua_State *l)
+{
+	Ship *s = LuaObject<Ship>::CheckFromLua(1);
+	auto direction = Thruster(LuaPull<int>(l, 2));
+	double acc = s->GetComponent<Propulsion>()->GetAccel(direction);
+	LuaPush(l, acc);
+	return 1;
+}
+
 /*
  * Group: AI methods
  *
@@ -1706,6 +1728,7 @@ void LuaObject<Ship>::RegisterClass()
 		{ "GetVelocity", l_ship_get_velocity },
 		{ "GetPosition", l_ship_get_position },
 		{ "GetThrusterState", l_ship_get_thruster_state },
+		{ "GetThrusterAcceleration", l_ship_get_thruster_acceleration },
 
 		{ "IsDocked", l_ship_is_docked },
 		{ "IsLanded", l_ship_is_landed },

--- a/src/lua/LuaTimer.cpp
+++ b/src/lua/LuaTimer.cpp
@@ -82,7 +82,10 @@ void LuaTimer::Tick()
 		}
 
 		lua_getfield(l, -1, "every");
-		double next = call.at + lua_tonumber(l, -1);
+		double every = lua_tonumber(l, -1);
+		// will take into account that we could skip the appointed time,
+		// but will maintain the original "alignment"
+		double next = now + every - fmod(now - call.at, every);
 		lua_pop(l, 1);
 
 		lua_pushnumber(l, next); // [ cb, next ]


### PR DESCRIPTION
Collected the simplest, but quite effective fixes so that when you stay in one system for a long time, there is no noticeable drop in performance.

Fixes #5735
(taking into account that #5127 and #5785 are merged)

~~Although at least there remains the problem that occasionally the tradeship runs out of fuel; repairing it probably requires serious intervention in the autopilot, or the creation of evacuation ships, for example.~~ **just explode them**