### PR TITLE
System Editor Fixes

### DIFF
--- a/src/editor/system/GalaxyEditAPI.cpp
+++ b/src/editor/system/GalaxyEditAPI.cpp
@@ -548,11 +548,16 @@ void SystemBody::EditorAPI::EditOrbitalParameters(SystemBody *body, UndoSystem *
 
 void SystemBody::EditorAPI::EditEconomicProperties(SystemBody *body, UndoSystem *undo)
 {
+	ImGui::SeparatorText("Economic Parameters");
+
 	// TODO: system generation currently ignores these fields of a system body
 	// and overwrites them with randomly-rolled values.
-	return;
+	ImGui::BeginDisabled();
 
-	ImGui::SeparatorText("Economic Parameters");
+	ImGui::PushTextWrapPos(ImGui::GetContentRegionAvail().x);
+	ImGui::TextColored(ImVec4(0.8, 0.8, 0.8, 1.0), "These fields are currently overwritten when the system is loaded.");
+	ImGui::PopTextWrapPos();
+	ImGui::Spacing();
 
 	ImGui::InputFixed("Population", &body->m_population);
 	if (Draw::UndoHelper("Edit Population", undo))
@@ -561,6 +566,8 @@ void SystemBody::EditorAPI::EditEconomicProperties(SystemBody *body, UndoSystem 
 	ImGui::InputFixed("Agricultural Activity", &body->m_agricultural);
 	if (Draw::UndoHelper("Edit Agricultural Activity", undo))
 		AddUndoSingleValue(undo, &body->m_agricultural);
+
+	ImGui::EndDisabled();
 }
 
 void SystemBody::EditorAPI::EditStarportProperties(SystemBody *body, UndoSystem *undo)

--- a/src/editor/system/SystemEditorHelpers.cpp
+++ b/src/editor/system/SystemEditorHelpers.cpp
@@ -131,7 +131,6 @@ bool Draw::InputFixedDegrees(const char *str, fixed *val, double val_min, double
 	double val_d = RAD2DEG(val->ToDouble());
 
 	bool changed = ImGui::SliderScalar(str, ImGuiDataType_Double, &val_d, &val_min, &val_max, "%.3f°", ImGuiSliderFlags_NoRoundToFormat);
-	// bool changed = ImGui::InputDouble(str, &val_d, 1.0, 10.0, "%.3f°", flags | ImGuiInputTextFlags_EnterReturnsTrue);
 	// delay one frame before writing back the value for the undo system to push a value
 	if (changed && !ImGui::IsItemActivated())
 		*val = fixed::FromDouble(DEG2RAD(val_d));
@@ -170,7 +169,7 @@ bool Draw::InputFixedDistance(const char *str, fixed *val, ImGuiInputTextFlags f
 
 	ImGui::SameLine(0.f, 1.f);
 	Draw::SubtractItemWidth();
-	bool changed = ImGui::InputDouble(str, &val_d, val_step, val_step * 10.0, distance_formats[unit_type], flags | ImGuiInputTextFlags_EnterReturnsTrue);
+	bool changed = ImGui::InputDouble(str, &val_d, val_step, val_step * 10.0, distance_formats[unit_type], flags);
 	if (changed)
 		*val = fixed::FromDouble(val_d / distance_multipliers[unit_type]);
 
@@ -218,7 +217,7 @@ bool Draw::InputFixedMass(const char *str, fixed *val, bool is_solar, ImGuiInput
 
 	ImGui::SameLine(0.f, 1.f);
 	Draw::SubtractItemWidth();
-	bool changed = ImGui::InputDouble(str, &val_d, val_step, val_step * 10.0, mass_formats[unit_type], flags | ImGuiInputTextFlags_EnterReturnsTrue);
+	bool changed = ImGui::InputDouble(str, &val_d, val_step, val_step * 10.0, mass_formats[unit_type], flags);
 
 	if (is_solar && unit_type != MASS_SOLS)
 		val_d /= unit_type == MASS_EARTH ? SOL_TO_EARTH_MASS : SOL_MASS_PT;
@@ -272,7 +271,7 @@ bool Draw::InputFixedRadius(const char *str, fixed *val, bool is_solar, ImGuiInp
 
 	ImGui::SameLine(0.f, 1.f);
 	Draw::SubtractItemWidth();
-	bool changed = ImGui::InputDouble(str, &val_d, val_step, val_step * 10.0, radius_formats[unit_type], flags | ImGuiInputTextFlags_EnterReturnsTrue);
+	bool changed = ImGui::InputDouble(str, &val_d, val_step, val_step * 10.0, radius_formats[unit_type], flags);
 
 	if (is_solar && unit_type != RADIUS_SOLS)
 		val_d /= unit_type == RADIUS_EARTH ? SOL_TO_EARTH_MASS : SOL_RADIUS_KM;


### PR DESCRIPTION
- Fix the tab key not working to confirm certain fields in the system editor (the changed value wasn't being written back to the datastructure unless the enter key was pressed). Fixes #5746.
- The initial state of the system editor didn't display edit fields for a body's population and agricultural index, as they're overwritten by random values when the system is loaded. Those fields are now shown but left disabled with a notice until the fields are honored by the system loading code.