### PR TITLE
Fix incorrect position of starports

### DIFF
--- a/src/JsonUtils.cpp
+++ b/src/JsonUtils.cpp
@@ -560,13 +560,13 @@ void from_json(const Json &obj, fixed &f)
 			throw Json::type_error::create(320, "cannot pickle string to fixed point number");
 
 		char *next_str = const_cast<char *>(str.c_str()) + 1;
-		int64_t integer = std::strtol(next_str, &next_str, 10);
+		int64_t integer = std::strtoll(next_str, &next_str, 10);
 
 		// handle cases: f/34, f1356, f14+4
 		if (next_str == nullptr || size_t(next_str - str.c_str()) >= str.size() || *next_str++ != '/')
 			throw Json::type_error::create(320, "cannot pickle string to fixed point number");
 
-		int64_t fractional = std::strtol(next_str, &next_str, 10);
+		int64_t fractional = std::strtoll(next_str, &next_str, 10);
 		// handle cases f1345/7684gfrty; fixed numbers should not have any garbage data involved
 		if (next_str != str.c_str() + str.size())
 			throw Json::type_error::create(320, "cannot pickle string to fixed point number");

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -138,7 +138,6 @@ CSB_FIELD_SETTER_FIXED(mass, bodyData.m_mass)
 CSB_FIELD_SETTER_INT(temp, bodyData.m_averageTemp)
 CSB_FIELD_SETTER_FIXED(semi_major_axis, bodyData.m_semiMajorAxis)
 CSB_FIELD_SETTER_FIXED(eccentricity, bodyData.m_eccentricity)
-CSB_FIELD_SETTER_FIXED(inclination, bodyData.m_inclination)
 CSB_FIELD_SETTER_FIXED(rotation_period, bodyData.m_rotationPeriod)
 CSB_FIELD_SETTER_FIXED(axial_tilt, bodyData.m_axialTilt)
 CSB_FIELD_SETTER_FIXED(metallicity, bodyData.m_metallicity)
@@ -181,6 +180,17 @@ static int l_csb_orbital_offset(lua_State *L)
 		return luaL_error(L, "Bad datatype. Expected fixed or float, got %s", luaL_typename(L, 2));
 	csb->bodyData.m_orbitalOffset = fixed::FromDouble(*value);
 	csb->want_rand_offset = false;
+	lua_settop(L, 1);
+	return 1;
+}
+
+static int l_csb_inclination(lua_State *L)
+{
+	CustomSystemBody *csb = l_csb_check(L, 1);
+	double *value = getDoubleOrFixed(L, 2);
+	if (value == nullptr)
+		return luaL_error(L, "Bad datatype. Expected fixed or float, got %s", luaL_typename(L, 2));
+	csb->bodyData.m_inclination = fixed::FromDouble(*value);
 	lua_settop(L, 1);
 	return 1;
 }


### PR DESCRIPTION
This PR addresses a platform-specific issue where on Windows a fixed-point fractional part greater than 0.5 was being silently truncated when loaded from JSON files. This is most likely the cause for starport positions to be completely incorrect on Windows specifically.

This PR also addresses the log warnings about negative inclination values coming from legacy Lua-based systems until such a time as we convert all such systems to JSON.

Fixes #5792, fixes #5744.