### PR TITLE
Fix invalid binary orbits, hyperjump streaks falling down, negative commodity demand

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -418,9 +418,11 @@ function SpaceStation:AddCommodityStock(itemType, amount)
 	local market = self:GetCommodityMarket(itemType)
 
 	if amount < 0 then
-		market[1] = market[1] + amount
+		-- Buying from market - reduce commodity stock
+		market[1] = math.max(market[1] + amount, 0)
 	else
-		market[2] = market[2] - amount
+		-- Selling to market - reduce commodity demand
+		market[2] = math.max(market[2] - amount, 0)
 	end
 
 	Economy.UpdateCommodityPriceMod(assert(self:GetSystemBody()), itemType.name, market)

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -618,7 +618,9 @@ namespace Background {
 
 			const Sint32 numStars = buffer->GetDesc().numVertices / 2;
 
-			const vector3d pz = Pi::player->GetOrient().VectorZ(); //back vector
+			const vector3d oz = Pi::player->GetOrient().VectorZ(); //back vector in Y-up space
+			const vector3d pz = vector3d(oz.z, oz.x, oz.y); // back vector rotated into Z-up space
+
 			for (int i = 0; i < numStars; i++) {
 				vector3f v = m_hyperVtx[numStars * 2 + i] + vector3f(pz * hyperspaceProgress * mult);
 				const Color &c = m_hyperCol[numStars * 2 + i];


### PR DESCRIPTION
Small collection of bugfixes for the upcoming release.

- Fixes #5764 - I broke this by trying to do the gravpoint mass summation pass piece-wise.
- Fixes #5770 - Since stars are rendered in Z-up space, need to compute the direction of hyperspace star "streaks" in Z-up space as well.
- Fixes #5784 - The commodity market already prevented you from selling more items than there was station demand; added a simple filter to prevent other code from putting a commodity market in an invalid state of negative supply/demand.