### PR TITLE
Consider InputBindings::Axis active only if it's value is non-zero

### DIFF
--- a/src/InputBindings.h
+++ b/src/InputBindings.h
@@ -189,7 +189,7 @@ namespace InputBindings {
 		// NOTE: sigc::signals cannot be copied, this function is for convenience to copy bindings only
 		Axis &operator=(const Axis &rhs);
 
-		bool IsActive() { return m_value != 0.0 || positive.IsActive() || negative.IsActive(); }
+		bool IsActive() { return m_value != 0.0; }
 		float GetValue() { return m_value; }
 		// if we want to set the value of the axis, for example from the UI slider
 		// must be remembered separately, because m_value is overwritten by data from the joystick


### PR DESCRIPTION
`StaticUpdate` is now called between `PollEvents` and `DispatchEvents`. In this interval in the first frame, the axis bindings are already "active", but the value has not yet been calculated.

Remove the direct dependence of axis "activeness" on bindings so that `IsActive` is always consistent with `GetValue`.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

