### PR TITLE
Fix backwards save compatibility with v90 saves

### DIFF
--- a/src/lua/LuaSerializer.cpp
+++ b/src/lua/LuaSerializer.cpp
@@ -413,6 +413,10 @@ void LuaSerializer::LoadPersistent(const Json &json)
 	lua_State *l = Lua::manager->GetLuaState();
 	LUA_DEBUG_START(l);
 
+	// Old savefile with no persistent table.
+	if (!json.count("lua_persistent_json"))
+		return;
+
 	const Json &persist = json["lua_persistent_json"];
 
 	luaL_getsubtable(l, LUA_REGISTRYINDEX, NS_REFTABLE);


### PR DESCRIPTION
Fixes #5797 - the issue was inadvertently caused by the lack of compatibility testing with existing v90 savefiles. The fix is quite simple, and savefiles created in the 20240203 release should be fully loadable with this PR merged.

Testing appreciated, of course.