### PR TITLE
Police Coronatrix texture fix

### DIFF
--- a/data/ships/coronatrix_police.json
+++ b/data/ships/coronatrix_police.json
@@ -1,6 +1,6 @@
 {
-	"model": "coronatrix",
-	"name": "Coronatrix Police",
+	"model": "coronatrix_police",
+	"name": "Coronatrix (Police)",
 	"cockpit": "coronatrix_cockpit",
 	"manufacturer": "opli",
 	"ship_class": "light_courier",


### PR DESCRIPTION
Now it picks the correct model, with the police texture. I've also added parentheses around the Police in the name to get it consistent with the other police ships (although they should never pop up on the market)
