### PR TITLE
Include stdlib.h instead of alloca.h for alloca(3) on FreeBSD

### DIFF
--- a/src/core/macros.h
+++ b/src/core/macros.h
@@ -45,6 +45,10 @@ char (&COUNTOF_Helper(T (&array)[N]))[N];
 #include <malloc.h>
 #define stackalloc(T, n) reinterpret_cast<T *>(_alloca(sizeof(T) * n))
 #else
+#ifdef __FreeBSD__
+#include <stdlib.h>
+#else
 #include <alloca.h>
+#endif
 #define stackalloc(T, n) reinterpret_cast<T *>(alloca(sizeof(T) * n))
 #endif


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

