### PR TITLE
Fix Terrain Disappearing

### DIFF
--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -15,6 +15,7 @@ const Color4f Color4f::YELLOW = Color4f(1.0f, 1.0f, 0.0f, 1.0f);
 const Color4f Color4f::GRAY = Color4f(0.5f, 0.5f, 0.5f, 1.f);
 const Color4f Color4f::STEELBLUE = Color4f(0.27f, 0.51f, 0.71f, 1.f);
 const Color4f Color4f::BLANK = Color4f(0.0f, 0.0f, 0.0f, 0.0f);
+const Color4f Color4f::CYAN = Color4f(0.0f, 1.0f, 1.0f, 1.0f);
 
 const Color4ub Color::BLACK = Color(0, 0, 0, 255);
 const Color4ub Color::WHITE = Color(255, 255, 255, 255);
@@ -26,6 +27,7 @@ const Color4ub Color::GRAY = Color(128, 128, 128, 255);
 const Color4ub Color::STEELBLUE = Color(68, 130, 181, 255);
 const Color4ub Color::BLANK = Color(0, 0, 0, 0);
 const Color4ub Color::PINK = Color(252, 15, 192, 255); // debug pink
+const Color4ub Color::CYAN = Color(0, 255, 255, 255);
 
 const Color3ub Color3ub::BLACK = Color3ub(0, 0, 0);
 const Color3ub Color3ub::WHITE = Color3ub(255, 255, 255);
@@ -35,6 +37,8 @@ const Color3ub Color3ub::BLUE = Color3ub(0, 0, 255);
 const Color3ub Color3ub::YELLOW = Color3ub(255, 255, 0);
 const Color3ub Color3ub::STEELBLUE = Color3ub(68, 130, 181);
 const Color3ub Color3ub::BLANK = Color3ub(0, 0, 0);
+const Color3ub Color3ub::PINK = Color3ub(252, 15, 192); // debug pink
+const Color3ub Color3ub::CYAN = Color3ub(0, 255, 255);
 
 float Color4f::GetLuminance() const
 {

--- a/src/Color.h
+++ b/src/Color.h
@@ -56,6 +56,7 @@ struct Color4f {
 	static const Color4f GRAY;
 	static const Color4f STEELBLUE;
 	static const Color4f BLANK;
+	static const Color4f CYAN;
 };
 
 namespace {
@@ -162,6 +163,7 @@ struct Color4ub {
 	static const Color4ub STEELBLUE;
 	static const Color4ub BLANK;
 	static const Color4ub PINK;
+	static const Color4ub CYAN;
 };
 
 struct Color3ub {
@@ -207,6 +209,8 @@ struct Color3ub {
 	static const Color3ub YELLOW;
 	static const Color3ub STEELBLUE;
 	static const Color3ub BLANK;
+	static const Color3ub PINK;
+	static const Color3ub CYAN;
 };
 
 typedef Color4ub Color;

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -94,6 +94,8 @@ public:
 private:
 	static const int NUM_KIDS = 4;
 
+	bool IsOverHorizon(const vector3d &camPos);
+
 	RefCountedPtr<GeoPatchContext> m_ctx;
 	const vector3d m_v0, m_v1, m_v2, m_v3;
 	std::unique_ptr<double[]> m_heights;

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -104,7 +104,8 @@ private:
 	GeoPatch *m_parent;
 	GeoSphere *m_geosphere;
 	double m_roughLength;
-	vector3d m_clipCentroid, m_centroid;
+	vector3d m_clipCentroid; // rendering relative position centroid used for frustum clipping & camera relative rendering calculation
+	vector3d m_centroid; // geometry centroid used for horizon culling, split request, camera distance test
 	double m_clipRadius;
 	Sint32 m_depth;
 	bool m_needUpdateVBOs;
@@ -114,6 +115,7 @@ private:
 	bool m_HasJobRequest;
 #ifdef DEBUG_BOUNDING_SPHERES
 	std::unique_ptr<Graphics::Drawables::Sphere3D> m_boundsphere;
+	RefCountedPtr<Graphics::Material> m_matboundsphere;
 #endif
 };
 

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -426,7 +426,6 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 		emission = StarSystem::starRealColors[GetSystemBody()->GetType()];
 		emission.a = 255;
 	}
-
 	else {
 		// give planet some ambient lighting if the viewer is close to it
 		double camdist = 0.1 / campos.LengthSqr();

--- a/src/Sphere.h
+++ b/src/Sphere.h
@@ -15,6 +15,10 @@ struct SSphere {
 	SSphere(const double rad) :
 		m_centre(vector3d(0.0)),
 		m_radius(rad) {}
+	SSphere(const vector3d &centre, const double rad) :
+		m_centre(centre),
+		m_radius(rad) {}
+
 	vector3d m_centre;
 	double m_radius;
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Fixes #5806 ... if we're lucky

Switched to using the recalculated `m_centroid` instead of `m_clipCentroid` which is surprisingly far below the surface on asteroids. I believe some terrains generate heights which are FAR above expected which buries `m_clipCentroid` much further below the surface than expected.

All of this will need some testing with things to look out for like:
- terrain disappearing
- patches appearing and disappearing as you look around
- terrain not being generated at higher detail

<!-- Please make sure you've read documentation on contributing -->

