### PR TITLE
Fix missing include

### DIFF
--- a/src/Input.h
+++ b/src/Input.h
@@ -7,7 +7,7 @@
 #include "InputBindings.h"
 
 #include "SDL_joystick.h"
-
+#include <algorithm>
 #include <array>
 #include <vector>
 #include <map>


### PR DESCRIPTION
I've adopted the [pioneer-git](https://aur.archlinux.org/packages/pioneer-git) repo in AUR (Arch Linux User) repository, that tracks our master branch. As such, I note the package is currently not building:
```
[ 15%] Building CXX object CMakeFiles/pioneer-lib.dir/src/HyperspaceCloud.cpp.o
[ 16%] Building CXX object CMakeFiles/pioneer-lib.dir/src/Input.cpp.o
In file included from /tmp/src/pioneer-git/src/Input.cpp:4:
/tmp/src/pioneer-git/src/Input.h: In member function ‘void Input::Manager::GetMouseMotion(int*)’:
/tmp/src/pioneer-git/src/Input.h:206:22: error: ‘copy_n’ is not a member of ‘std’; did you mean ‘copy’?
  206 |                 std::copy_n(mouseMotion.data(), mouseMotion.size(), motion);
      |                      ^~~~~~
      |                      copy
make[2]: *** [CMakeFiles/pioneer-lib.dir/build.make:524: CMakeFiles/pioneer-lib.dir/src/Input.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:316: CMakeFiles/pioneer-lib.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
make: Leaving directory '/tmp/src/pioneer-git/build'
==> ERROR: A failure occurred in build().
    Aborting...
```

I dunno what our policy is on missing includes / implicit includes, but this fixes that. 