### PR TITLE
Improve surface scan missions on high-pressure worlds

### DIFF
--- a/data/lang/module-scout/en.json
+++ b/data/lang/module-scout/en.json
@@ -442,5 +442,13 @@
   "YOU_WILL_BE_PAID_ON_MY_BEHALF_AT_NEW_DESTINATION": {
     "description": "",
     "message": "You will be paid on my behalf at the NEW DESTINATION"
+  },
+  "SURFACE_SCAN_DETAILS": {
+	  "description": "Additional warning information about a surface scan target",
+	  "message": "The target has a surface pressure of {pressure} with a gravitational force of {gravity} at the surface."
+  },
+  "SURFACE_SCAN_WARNING": {
+	"description": "Warning reminder to player",
+	"message": "Please ensure your ship is capable of operating at the body's surface before accepting the contract."
   }
 }

--- a/data/lang/module-scout/en.json
+++ b/data/lang/module-scout/en.json
@@ -449,6 +449,6 @@
   },
   "SURFACE_SCAN_WARNING": {
 	"description": "Warning reminder to player",
-	"message": "Please ensure your ship is capable of operating at the body's surface before accepting the contract."
+	"message": "Please ensure your ship is capable of operating at the target body's surface before accepting the contract."
   }
 }


### PR DESCRIPTION
It's come to my attention that currently no ships in the game can approach the surface of Venus, yet we generate surface scan missions there anyways. Luckily, that's a quick fix.

I've also thrown in a new section of warning text to surface scan mission ads mentioning the target body's atmospheric pressure and surface gravity when those are potentially a factor limiting the player's ability to carry out the mission.

I've chosen to treat this as an informational notice only rather than preventing the player from accepting the contract to both reduce the amount of code required and also provide maximum flexibility to the player.

This PR can be used with existing saves, though you'll have to re-generate BBS ads by jumping to a different system to clear existing missions to Venus.

![Snapshot_2024-06-17_17-27-02](https://github.com/pioneerspacesim/pioneer/assets/4218491/2259b6a0-8608-4e54-a083-26f8e517cdf0)
