### PR TITLE
Fix lots of missing ship labels

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -576,11 +576,12 @@ local function addRandomShipAdvert(station, num)
 		local def = avail[Engine.rand:Integer(1,#avail)]
 		local model = Engine.GetModel(def.modelName)
 		local pattern = model.numPatterns ~= 0 and Engine.rand:Integer(1,model.numPatterns) or nil
+		local label = Ship.MakeRandomLabel()
 		addShipOnSale(station, {
 			def     = def,
-			skin    = ModelSkin.New():SetRandomColors(Engine.rand):SetDecal(def.manufacturer),
+			skin    = ModelSkin.New():SetRandomColors(Engine.rand):SetDecal(def.manufacturer):SetLabel(label),
 			pattern = pattern,
-			label   = Ship.MakeRandomLabel(),
+			label   = label,
 		})
 	end
 end

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -711,9 +711,9 @@ local createTargetShip = function (mission)
 	end
 
 	-- set ship looks (label, skin, pattern)
-	ship:SetLabel(mission.shiplabel)
 	local skin = ModelSkin.New():SetRandomColors(rand):SetDecal(shipdef.manufacturer)
 	ship:SetSkin(skin)
+	ship:SetLabel(mission.shiplabel)
 	local model = Engine.GetModel(shipdef.modelName)
 	local pattern
 	if model.numPatterns <= 1 then

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -125,6 +125,7 @@ local function startGame(gameParams)
 	local skin = ModelSkin.New()
 	skin:SetColors({ primary = colors[1], secondary = colors[2], trim = colors[3] })
 	skin:SetDecal(shipDef.manufacturer)
+	skin:SetLabel(gameParams.ship.label)
 	player:SetSkin(skin)
 
 	-- setup player character

--- a/data/pigui/modules/new-game-window/crew.lua
+++ b/data/pigui/modules/new-game-window/crew.lua
@@ -325,7 +325,7 @@ function Crew:drawMember(memberEntry)
 		Widgets.verticalCenter(self.layout, function()
 			Widgets.alignLabel(lui.NAME_PERSON, self.layout, function()
 				local txt, changed = Widgets.inputText(lock, memberEntry:isValid(), "##charname" .. tostring(memberEntry), tostring(memberEntry.value.name), function()
-					memberEntry.value.name = NameGen.FullName(memberEntry.value.female)
+					return NameGen.FullName(memberEntry.value.female)
 				end)
 				if changed then
 					memberEntry.value.name = txt

--- a/data/pigui/modules/new-game-window/ship.lua
+++ b/data/pigui/modules/new-game-window/ship.lua
@@ -99,7 +99,7 @@ ShipName.layout = {}
 function ShipName:draw()
 	Widgets.alignLabel(lui.SHIP_NAME, self.layout, function()
 		local txt, changed = Widgets.inputText(self.lock, self:isValid(), "##shipname", self.value, function()
-			self.value = ShipNames.generateRandom()
+			return ShipNames.generateRandom()
 		end)
 		if changed then self.value = txt end
 	end)
@@ -135,9 +135,12 @@ ShipLabel.value = ""
 function ShipLabel:draw()
 	Widgets.oneLiner(lui.REGISTRATION_NUMBER, self.layout, function()
 		local txt, changed = Widgets.inputText(self.lock, self:isValid(), "##ShipLabel", self.value, function()
-			self.value = ShipObject.MakeRandomLabel()
+			return ShipObject.MakeRandomLabel()
 		end)
-		if changed then self.value = txt end
+		if changed then
+			self.value = txt
+			ShipModel:updateModel()
+		end
 	end)
 end
 
@@ -218,6 +221,7 @@ function ShipModel:updateModel()
 	if not self.skin then return end
 	local c = self.value.colors
 	self.skin:SetColors({ primary = c[1], secondary = c[2], trim = c[3] })
+	self.skin:SetLabel(ShipLabel.value)
 	self.spinner:setModel(modelName, self.skin, self.value.pattern)
 end
 

--- a/data/pigui/modules/new-game-window/widgets.lua
+++ b/data/pigui/modules/new-game-window/widgets.lua
@@ -109,7 +109,10 @@ Widgets.inputText = function(lock, valid, id, text, randomFnc)
 				local txt, changed = ui.inputText(id, text)
 				ui.sameLine()
 				if ui.iconButton(ui.theme.icons.random, Vector2(size, size), tostring(id) .. "_random_button") then
-					randomFnc()
+					local newtxt = randomFnc()
+					if newtxt and newtxt ~= txt then
+						txt, changed = newtxt, true
+					end
 				end
 				return txt, changed
 			else

--- a/data/pigui/modules/station-view/06-shipRepairs.lua
+++ b/data/pigui/modules/station-view/06-shipRepairs.lua
@@ -141,7 +141,7 @@ local function changeColor()
 	local player = Game.player
 	local shipDef = ShipDef[player.shipId]
 	local newColor = reformatColor(previewColors)
-	previewSkin = ModelSkin.New():SetColors(newColor):SetDecal(shipDef.manufacturer)
+	previewSkin = ModelSkin.New():SetColors(newColor):SetDecal(shipDef.manufacturer):SetLabel(player.label)
 	refreshModelSpinner()
 end
 

--- a/src/scenegraph/Label3D.cpp
+++ b/src/scenegraph/Label3D.cpp
@@ -52,6 +52,8 @@ namespace SceneGraph {
 	{
 		//regenerate geometry
 		m_geometry->Clear();
+		m_textMesh.reset();
+
 		if (!text.empty()) {
 			m_font->GetGeometry(*m_geometry, text, vector2f(0.f));
 


### PR DESCRIPTION
This PR fixes #5838, and in the process fixes a number of spots where ship labels either were not appearing or may have been incorrect prior.

- Ship labels now display and update in the new game start window. Modifying the ship label adjusts it on the craft as well, if the craft has a properly-named label node.
- Ships on sale in a space station now display their labels on the craft if the craft model supports labels.
- The paint shop technically appeared correct but would have resulted in the same missing label bug when saving and loading after applying the paint.
- SearchRescue spawned ships will continue to show labels (they technically were painting a label on the ship hull and then attempting-but-failing to clear it).

CC @Gliese852 - I've made minor changes to the new game window widget API and hooked a few things up to get labels to update in sync with the model spinner; just want to double check I haven't inadvertently introduced new bugs :smile:
CC @bszlrd - the Coronatrix at the very least has improperly named label nodes, causing them to be picked up as tags instead. Label nodes need to be named `label_*`; `tag_label_*` results in a tag instead. There is no need to address this immediately, but if you get five minutes it might be worth a quick fix.