### PR TITLE
Fix mission list error when opened during hyperspace

### DIFF
--- a/data/meta/CoreObject/Player.meta.lua
+++ b/data/meta/CoreObject/Player.meta.lua
@@ -17,4 +17,22 @@ package.core["Player"] = Player
 
 -- TODO: document methods as required
 
+---@return Body?
+function Player:GetNavTarget() end
+
+---@param body Body?
+function Player:SetNavTarget(body) end
+
+---@return Body?
+function Player:GetCombatTarget() end
+
+---@param target Body?
+function Player:SetCombatTarget(target) end
+
+---@return SystemPath?
+function Player:GetHyperspaceTarget() end
+
+---@param target SystemPath
+function Player:SetHyperspaceTarget(target) end
+
 return Player

--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -101,7 +101,7 @@ local function makeMissionRows()
 			locationName = mission.location:GetSystemBody().name .. ", " .. locationName
 		end
 
-		local playerSystem = Game.system or Game.player:GetHyperspaceTarget()
+		local playerSystem = Game.system or Game.player:GetHyperspaceTarget():GetStarSystem()
 		local days = math.max(0, (mission.due - Game.time) / (24*60*60))
 
 		-- Use AU for interplanetary, LY for interstellar distances


### PR DESCRIPTION
Existing code was attempting to get the system's path from a SystemPath object instead of a star system directly. Fixed that and provided some additional type information for working with the nav/combat/hyperspace target methods on LuaPlayer.

Fixes #5822.