### PR TITLE
Fix DLLs not being installed on Windows builds

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -14,6 +14,7 @@ on:
     - '**/CMakeLists.txt'
     - '.github/workflows/build-ci.yml'
     - '.github/actions/*/action.yml'
+    - 'cmake/*.cmake'
   release:
     types: [published]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,6 +434,12 @@ endif(MODELCOMPILER)
 install(TARGETS ${PROJECT_NAME} editor modelcompiler savegamedump
 	RUNTIME DESTINATION ${PIONEER_INSTALL_BINDIR}
 )
+
+if (MSVC)
+	file(GLOB win_libs ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/bin/${MSVC_ARCH}/vs2019/*.dll)
+	install(FILES ${win_libs} DESTINATION ${PIONEER_INSTALL_BINDIR})
+endif (MSVC)
+
 install(DIRECTORY data/
 	DESTINATION ${PIONEER_INSTALL_DATADIR}/data
 	REGEX "/models" EXCLUDE
@@ -441,6 +447,7 @@ install(DIRECTORY data/
 	PATTERN "listdata.*" EXCLUDE
 	PATTERN "Makefile.am" EXCLUDE
 )
+
 install(DIRECTORY data/models/
 	DESTINATION ${PIONEER_INSTALL_DATADIR}/data/models
 	FILES_MATCHING PATTERN "*.sgm" PATTERN "*.dds" PATTERN "*.png"

--- a/cmake/InstallPioneer.cmake
+++ b/cmake/InstallPioneer.cmake
@@ -80,8 +80,6 @@ endif(APPIMAGE_BUILD)
 
 if (WIN32)
 	configure_file(pioneer.iss.cmakein pioneer.iss @ONLY)
-	file(GLOB win_libs ../pioneer-thirdparty/win32/bin/${MSVC_ARCH}/vs2019/*.dll)
-	install(FILES ${win_libs} DESTINATION ${CMAKE_INSTALL_PREFIX})
 	if(NOT ISCC)
 		set(ISCC "C:/Program Files (x86)/Inno Setup 6/ISCC.exe")
 	endif(NOT ISCC)


### PR DESCRIPTION
Potential fix for DLLs not being copied into the release archive for Windows builds. Not sure what broke this, as it was working at least a few months ago if not sooner.