### PR TITLE
Separating shield.models

### DIFF
--- a/data/models/ships/ac33/ac33.model
+++ b/data/models/ships/ac33/ac33.model
@@ -11,7 +11,6 @@ collision ac33_collision.obj
 #LOD
 lod 1000
 mesh ac33.dae
-mesh ac33_shield.dae
 
 lod 350
 mesh ac33_high.dae

--- a/data/models/ships/ac33/ac33_shield.model
+++ b/data/models/ships/ac33/ac33_shield.model
@@ -1,0 +1,1 @@
+mesh ac33_shield.dae

--- a/data/models/ships/bluenose/bluenose.model
+++ b/data/models/ships/bluenose/bluenose.model
@@ -9,7 +9,6 @@ tex_norm bluenose_norm.png
 
 lod 300
 mesh bluenose_hi.dae
-mesh bluenose_shield.dae
 
 lod 100
 mesh bluenose_med.dae

--- a/data/models/ships/bluenose/bluenose_shield.model
+++ b/data/models/ships/bluenose/bluenose_shield.model
@@ -1,0 +1,1 @@
+mesh bluenose_shield.dae

--- a/data/models/ships/bowfin/bowfin.model
+++ b/data/models/ships/bowfin/bowfin.model
@@ -22,7 +22,6 @@ tex_spec bowfin_spec.dds
 
 lod 300
 mesh bowfin_hi.dae
-mesh bowfin_shield.dae
 
 lod 100
 mesh bowfin_med.dae

--- a/data/models/ships/bowfin/bowfin_shield.model
+++ b/data/models/ships/bowfin/bowfin_shield.model
@@ -1,0 +1,1 @@
+mesh bowfin_shield.dae

--- a/data/models/ships/coronatrix/coronatrix_police.model
+++ b/data/models/ships/coronatrix/coronatrix_police.model
@@ -39,4 +39,3 @@ mesh coronatrix_low.dae
 anim gear_down 1 100
 
 collision coronatrix_coll.dae
-mesh coronatrix_shield.dae

--- a/data/models/ships/deneb/deneb.model
+++ b/data/models/ships/deneb/deneb.model
@@ -11,7 +11,6 @@ collision deneb_collision.obj
 # LOD
 lod 1001
 mesh deneb.dae
-mesh deneb_shield.dae
 
 lod 350
 mesh deneb_medhigh.dae

--- a/data/models/ships/deneb/deneb_shield.model
+++ b/data/models/ships/deneb/deneb_shield.model
@@ -1,0 +1,1 @@
+mesh deneb_shield.dae

--- a/data/models/ships/dsminer/dsminer.model
+++ b/data/models/ships/dsminer/dsminer.model
@@ -10,7 +10,6 @@ shininess 80
 
 lod 1000
 mesh dsminer_hi.dae
-mesh dsminer_shield.dae
 
 lod 100
 mesh dsminer_med.dae

--- a/data/models/ships/dsminer/dsminer_shield.model
+++ b/data/models/ships/dsminer/dsminer_shield.model
@@ -1,0 +1,1 @@
+mesh dsminer_shield.dae

--- a/data/models/ships/kanara/kanara.model
+++ b/data/models/ships/kanara/kanara.model
@@ -11,7 +11,6 @@ tex_norm kanara_norm.dds
 
 lod 300
 mesh kanara_hi.dae
-mesh kanara_shield.dae
 
 lod 50
 mesh kanara_med.dae

--- a/data/models/ships/kanara/kanara_civ.model
+++ b/data/models/ships/kanara/kanara_civ.model
@@ -10,7 +10,6 @@ tex_norm kanara_norm.dds
 
 lod 300
 mesh kanara_hi.dae
-mesh kanara_shield.dae
 
 lod 50
 mesh kanara_med.dae

--- a/data/models/ships/kanara/kanara_shield.model
+++ b/data/models/ships/kanara/kanara_shield.model
@@ -1,0 +1,1 @@
+mesh kanara_shield.dae

--- a/data/models/ships/lodos/lodos.model
+++ b/data/models/ships/lodos/lodos.model
@@ -7,7 +7,6 @@ tex_spec lodos-specular.dds
 tex_glow lodos-glow.dds
 
 mesh lodos-hi.dae
-mesh lodos_shield.dae
 
 anim gear_down 1 121
 

--- a/data/models/ships/lodos/lodos_shield.model
+++ b/data/models/ships/lodos/lodos_shield.model
@@ -1,0 +1,1 @@
+mesh lodos_shield.dae

--- a/data/models/ships/lunarshuttle/lunarshuttle.model
+++ b/data/models/ships/lunarshuttle/lunarshuttle.model
@@ -10,7 +10,6 @@ use_patterns
 
 lod 500
 mesh lunar_shuttle_hi.dae
-mesh lunar_shuttle_shield.dae
 
 lod 100 
 mesh lunar_shuttle_lo.dae
@@ -18,7 +17,3 @@ mesh lunar_shuttle_lo.dae
 collision lunar_shuttle_col.dae
 
 anim gear_down 1 100
-
-
-
-

--- a/data/models/ships/lunarshuttle/lunarshuttle_shield.model
+++ b/data/models/ships/lunarshuttle/lunarshuttle_shield.model
@@ -1,0 +1,1 @@
+mesh lunar_shuttle_shield.dae

--- a/data/models/ships/malabar/malabar.model
+++ b/data/models/ships/malabar/malabar.model
@@ -9,7 +9,6 @@ tex_spec malabar_spec.dds
 
 lod 300
 mesh malabar_hi.dae
-mesh malabar_shield.dae
 
 lod 100
 mesh malabar_med.dae

--- a/data/models/ships/malabar/malabar_shield.model
+++ b/data/models/ships/malabar/malabar_shield.model
@@ -1,0 +1,1 @@
+mesh malabar_shield.dae

--- a/data/models/ships/malabar/vatakara.model
+++ b/data/models/ships/malabar/vatakara.model
@@ -9,7 +9,6 @@ tex_spec vatakara_spec.dds
 
 lod 300
 mesh vatakara_hi.dae
-mesh malabar_shield.dae
 
 lod 100
 mesh malabar_med.dae

--- a/data/models/ships/molamola/molamola.model
+++ b/data/models/ships/molamola/molamola.model
@@ -10,7 +10,6 @@ tex_spec molamola_spec.dds
 
 lod 300
 mesh molamola_1hi.dae
-mesh molamola_shield.dae
 
 lod 100
 mesh molamola_2med.dae

--- a/data/models/ships/molamola/molamola_shield.model
+++ b/data/models/ships/molamola/molamola_shield.model
@@ -1,0 +1,1 @@
+mesh molamola_shield.dae

--- a/data/models/ships/molaramsayi/molaramsayi.model
+++ b/data/models/ships/molaramsayi/molaramsayi.model
@@ -11,7 +11,6 @@ tex_norm molaramsayi_norm.dds
 
 lod 300
 mesh molaramsayi_hi.dae
-mesh molaramsayi_shield.dae
 
 lod 50
 mesh molaramsayi_med.dae

--- a/data/models/ships/molaramsayi/molaramsayi_shield.model
+++ b/data/models/ships/molaramsayi/molaramsayi_shield.model
@@ -1,0 +1,1 @@
+mesh molaramsayi_shield.dae

--- a/data/models/ships/natrix/natrix.model
+++ b/data/models/ships/natrix/natrix.model
@@ -14,7 +14,6 @@ specular 1.0 1.0 1.0
 
 lod 100
 mesh natrix.dae
-mesh natrix_shield.dae
 
 lod 10
 mesh natrix_low.dae

--- a/data/models/ships/natrix/natrix_shield.model
+++ b/data/models/ships/natrix/natrix_shield.model
@@ -1,0 +1,1 @@
+mesh natrix_shield.dae

--- a/data/models/ships/nerodia/nerodia.model
+++ b/data/models/ships/nerodia/nerodia.model
@@ -14,4 +14,3 @@ collision nerodia_col.obj
 
 lod 75
 mesh nerodia_LOD.dae
-mesh nerodia_shield.dae

--- a/data/models/ships/nerodia/nerodia_shield.model
+++ b/data/models/ships/nerodia/nerodia_shield.model
@@ -1,0 +1,1 @@
+mesh nerodia_shield.dae

--- a/data/models/ships/pumpkinseed/pumpkinseed.model
+++ b/data/models/ships/pumpkinseed/pumpkinseed.model
@@ -15,7 +15,6 @@ mesh pumpkinseed_2med.dae
 
 lod 300
 mesh pumpkinseed_1hi.dae
-mesh pumpkinseed_shield.dae
 
 collision pumpkinseed_collision.dae
 

--- a/data/models/ships/pumpkinseed/pumpkinseed_police.model
+++ b/data/models/ships/pumpkinseed/pumpkinseed_police.model
@@ -14,7 +14,6 @@ mesh pumpkinseed_2med.dae
 
 lod 300
 mesh pumpkinseed_1hi.dae
-mesh pumpkinseed_shield.dae
 
 collision pumpkinseed_collision.dae
 

--- a/data/models/ships/pumpkinseed/pumpkinseed_shield.model
+++ b/data/models/ships/pumpkinseed/pumpkinseed_shield.model
@@ -1,0 +1,1 @@
+mesh pumpkinseed_shield.dae

--- a/data/models/ships/sinonatrix/sinonatrix.model
+++ b/data/models/ships/sinonatrix/sinonatrix.model
@@ -40,4 +40,3 @@ mesh sinonatrix_low.dae
 anim gear_down 1 100
 
 collision sinonatrix_coll.dae
-mesh sinonatrix_shld.dae

--- a/data/models/ships/sinonatrix/sinonatrix_police.model
+++ b/data/models/ships/sinonatrix/sinonatrix_police.model
@@ -39,4 +39,3 @@ mesh sinonatrix_low.dae
 anim gear_down 1 100
 
 collision sinonatrix_coll.dae
-mesh sinonatrix_shld.dae

--- a/data/models/ships/sinonatrix/sinonatrix_shield.model
+++ b/data/models/ships/sinonatrix/sinonatrix_shield.model
@@ -1,0 +1,1 @@
+mesh sinonatrix_shld.dae

--- a/data/models/ships/skipjack/skipjack.model
+++ b/data/models/ships/skipjack/skipjack.model
@@ -9,7 +9,6 @@ tex_glow skipjack_glow.dds
 
 lod 300
 mesh skipjack_hi.dae
-mesh skipjack_shield.dae
 
 lod 100
 mesh skipjack_med.dae

--- a/data/models/ships/skipjack/skipjack_shield.model
+++ b/data/models/ships/skipjack/skipjack_shield.model
@@ -1,0 +1,1 @@
+mesh skipjack_shield.dae

--- a/data/models/ships/storeria/storeria.model
+++ b/data/models/ships/storeria/storeria.model
@@ -8,7 +8,6 @@ tex_glow storeria_glow.dds
 
 lod 300
 mesh storeria_hi.dae
-mesh storeria_shield.dae
 
 lod 100
 mesh storeria_med.dae

--- a/data/models/ships/storeria/storeria_shield.model
+++ b/data/models/ships/storeria/storeria_shield.model
@@ -1,0 +1,1 @@
+mesh storeria_shield.dae

--- a/data/models/ships/varada/varada.model
+++ b/data/models/ships/varada/varada.model
@@ -10,7 +10,6 @@ tex_spec varada_spec.dds
 
 lod 300
 mesh varada_hi.dae
-mesh varada_shield.dae
 
 lod 50
 mesh varada_med.dae

--- a/data/models/ships/varada/varada_shield.model
+++ b/data/models/ships/varada/varada_shield.model
@@ -1,0 +1,1 @@
+mesh varada_shield.dae

--- a/data/models/ships/venturestar/venturestar.model
+++ b/data/models/ships/venturestar/venturestar.model
@@ -11,7 +11,6 @@ collision venturestar_collision.obj
 #LOD
 lod 1000
 mesh venturestar.dae
-mesh venturestar_shield.dae
 
 lod 350
 mesh venturestar_high.dae

--- a/data/models/ships/venturestar/venturestar_shield.model
+++ b/data/models/ships/venturestar/venturestar_shield.model
@@ -1,0 +1,1 @@
+mesh venturestar_shield.dae

--- a/data/models/ships/wave/wave.model
+++ b/data/models/ships/wave/wave.model
@@ -24,7 +24,6 @@ mesh wave-mq.dae
 
 lod 1000
 mesh wave.dae
-mesh wave_shield.dae
 anim gear_down 0 85
 
 collision wave_coll.dae

--- a/data/models/ships/wave/wave_shield.model
+++ b/data/models/ships/wave/wave_shield.model
@@ -1,0 +1,1 @@
+mesh wave_shield.dae

--- a/data/models/ships/xylophis/xylophis.model
+++ b/data/models/ships/xylophis/xylophis.model
@@ -36,4 +36,3 @@ mesh xylophis_low.dae
 anim gear_down 0 70
 
 collision xylophis_coll.dae
-mesh xylophis_shield.dae

--- a/data/models/ships/xylophis/xylophis_shield.model
+++ b/data/models/ships/xylophis/xylophis_shield.model
@@ -1,0 +1,1 @@
+mesh xylophis_shield.dae

--- a/data/ships/ac33.json
+++ b/data/ships/ac33.json
@@ -2,6 +2,7 @@
 	"model": "ac33",
 	"name": "AC-33 Dropstar",
 	"cockpit": "",
+	"shield_model": "ac33_shield",
 	"manufacturer": "albr",
 	"ship_class": "medium_freighter",
 	"min_crew": 3,

--- a/data/ships/bluenose.json
+++ b/data/ships/bluenose.json
@@ -2,6 +2,7 @@
 	"model": "bluenose",
 	"name": "Bluenose",
 	"cockpit": " ",
+	"shield_model": "bluenose_shield",
 	"manufacturer": "kaluri",
 	"ship_class": "medium_freighter",
 	"min_crew": 2,

--- a/data/ships/bowfin.json
+++ b/data/ships/bowfin.json
@@ -2,6 +2,7 @@
 	"model": "bowfin",
 	"name": "Bowfin",
 	"cockpit": "",
+	"shield_model": "bowfin_shield",
 	"manufacturer": "kaluri",
 	"ship_class": "light_fighter",
 	"min_crew": 1,

--- a/data/ships/coronatrix_police.json
+++ b/data/ships/coronatrix_police.json
@@ -2,6 +2,7 @@
 	"model": "coronatrix_police",
 	"name": "Coronatrix (Police)",
 	"cockpit": "coronatrix_cockpit",
+	"shield_model": "coronatrix_shield",
 	"manufacturer": "opli",
 	"ship_class": "light_courier",
 	"min_crew": 1,

--- a/data/ships/deneb.json
+++ b/data/ships/deneb.json
@@ -2,6 +2,7 @@
 	"model": "deneb",
 	"name": "Deneb",
 	"cockpit": "",
+	"shield_model": "deneb_shield",
 	"manufacturer": "albr",
 	"ship_class": "medium_freighter",
 	"min_crew": 2,

--- a/data/ships/dsminer.json
+++ b/data/ships/dsminer.json
@@ -2,6 +2,7 @@
 	"model": "dsminer",
 	"name": "Deep Space Miner",
 	"cockpit": " ",
+	"shield_model": "dsminer_shield",
 	"manufacturer": "haber",
 	"ship_class": "heavy_freighter",
 	"min_crew": 5,

--- a/data/ships/kanara.json
+++ b/data/ships/kanara.json
@@ -2,6 +2,7 @@
 	"model": "kanara",
 	"name": "Kanara (Police)",
 	"cockpit": "",
+	"shield_model": "kanara_shield",
 	"manufacturer": "mandarava_csepel",
 	"ship_class": "light_fighter",
 	"min_crew": 1,

--- a/data/ships/kanara_civ.json
+++ b/data/ships/kanara_civ.json
@@ -2,6 +2,7 @@
 	"model": "kanara_civ",
 	"name": "Kanara (Civilian)",
 	"cockpit": " ",
+	"shield_model": "kanara_shield",
 	"manufacturer": "mandarava_csepel",
 	"ship_class": "light_fighter",
 	"min_crew": 1,

--- a/data/ships/lodos.json
+++ b/data/ships/lodos.json
@@ -2,6 +2,7 @@
 	"model": "lodos",
 	"name": "Lodos",
 	"cockpit": "",
+	"shield_model": "lodos_shield",
 	"manufacturer": "auronox",
 	"ship_class": "heavy_freighter",
 	"min_crew": 2,

--- a/data/ships/lunarshuttle.json
+++ b/data/ships/lunarshuttle.json
@@ -2,6 +2,7 @@
 	"model": "lunarshuttle",
 	"name": "Lunar Shuttle",
 	"cockpit": "",
+	"shield_model": "lunarshuttle_shield",
 	"manufacturer": "haber",
 	"ship_class": "medium_passenger_shuttle",
 	"min_crew": 1,

--- a/data/ships/malabar.json
+++ b/data/ships/malabar.json
@@ -2,6 +2,7 @@
 	"model": "malabar",
 	"name": "Malabar",
 	"cockpit": "",
+	"shield_model": "malabar_shield",
 	"manufacturer": "mandarava_csepel",
 	"ship_class": "heavy_passenger_transport",
 	"min_crew": 1,

--- a/data/ships/molamola.json
+++ b/data/ships/molamola.json
@@ -2,6 +2,7 @@
 	"model": "molamola",
 	"name": "Mola Mola",
 	"cockpit": "",
+	"shield_model": "molamola_shield",
 	"manufacturer": "kaluri",
 	"ship_class": "light_freighter",
 	"min_crew": 1,

--- a/data/ships/molaramsayi.json
+++ b/data/ships/molaramsayi.json
@@ -2,6 +2,7 @@
 	"model": "molaramsayi",
 	"name": "Mola Ramsayi",
 	"cockpit": " ",
+	"shield_model": "molaramsayi_shield",
 	"manufacturer": "kaluri",
 	"ship_class": "medium_freighter",
 	"min_crew": 1,

--- a/data/ships/natrix.json
+++ b/data/ships/natrix.json
@@ -2,6 +2,7 @@
 	"model": "natrix",
 	"name": "Natrix",
 	"cockpit": "",
+	"shield_model": "natrix_shield",
 	"manufacturer": "opli",
 	"ship_class": "medium_freighter",
 	"min_crew": 1,

--- a/data/ships/nerodia.json
+++ b/data/ships/nerodia.json
@@ -2,6 +2,7 @@
 	"model": "nerodia",
 	"name": "Nerodia",
 	"cockpit": "",
+	"shield_model": "nerodia_shield",
 	"manufacturer": "opli",
 	"ship_class": "medium_freighter",
 	"min_crew": 1,

--- a/data/ships/pumpkinseed.json
+++ b/data/ships/pumpkinseed.json
@@ -2,6 +2,7 @@
 	"model": "pumpkinseed",
 	"name": "Pumpkinseed",
 	"cockpit": " ",
+	"shield_model": "pumpkinseed_shield",
 	"manufacturer": "kaluri",
 	"ship_class": "light_courier",
 	"min_crew": 1,

--- a/data/ships/pumpkinseed_police.json
+++ b/data/ships/pumpkinseed_police.json
@@ -2,6 +2,7 @@
 	"model": "pumpkinseed_police",
 	"name": "Pumpkinseed (Police)",
 	"cockpit": "",
+	"shield_model": "pumpkinseed_shield",
 	"manufacturer": "kaluri",
 	"ship_class": "light_fighter",
 	"min_crew": 1,

--- a/data/ships/sinonatrix.json
+++ b/data/ships/sinonatrix.json
@@ -2,6 +2,7 @@
 	"model": "sinonatrix",
 	"name": "Sinonatrix",
 	"cockpit": "sinonatrix_cockpit",
+	"shield_model": "sinonatrix_shield",
 	"manufacturer": "opli",
 	"ship_class": "light_courier",
 	"min_crew": 1,

--- a/data/ships/sinonatrix_police.json
+++ b/data/ships/sinonatrix_police.json
@@ -2,6 +2,7 @@
 	"model": "sinonatrix_police",
 	"name": "Sinonatrix (Police)",
 	"cockpit": "sinonatrix_cockpit",
+	"shield_model": "sinonatrix_shield",
 	"manufacturer": "opli",
 	"ship_class": "light_fighter",
 	"min_crew": 1,

--- a/data/ships/skipjack.json
+++ b/data/ships/skipjack.json
@@ -2,6 +2,7 @@
 	"model": "skipjack",
 	"name": "Skipjack",
 	"cockpit": " ",
+	"shield_model": "skipjack_shield",
 	"manufacturer": "kaluri",
 	"ship_class": "medium_courier",
 	"min_crew": 2,

--- a/data/ships/storeria.json
+++ b/data/ships/storeria.json
@@ -2,6 +2,7 @@
 	"model": "storeria",
 	"name": "Storeria",
 	"cockpit": "",
+	"shield_model": "storeria_shield",
 	"manufacturer": "opli",
 	"ship_class": "medium_freighter",
 	"min_crew": 1,

--- a/data/ships/varada.json
+++ b/data/ships/varada.json
@@ -2,6 +2,7 @@
 	"model": "varada",
 	"name": "Varada",
 	"cockpit": " ",
+	"shield_model": "varada_shield",
 	"manufacturer": "mandarava_csepel",
 	"ship_class": "light_courier",
 	"min_crew": 1,

--- a/data/ships/vatakara.json
+++ b/data/ships/vatakara.json
@@ -2,6 +2,7 @@
 	"model": "vatakara",
 	"name": "Vatakara",
 	"cockpit": "",
+	"shield_model": "malabar_shield",
 	"manufacturer": "mandarava_csepel",
 	"ship_class": "heavy_freighter",
 	"min_crew": 1,

--- a/data/ships/venturestar.json
+++ b/data/ships/venturestar.json
@@ -1,6 +1,7 @@
 {
 	"model": "venturestar",
 	"name": "Venturestar",
+	"shield_model": "venturestar_shield",
 	"cockpit": "",
 	"manufacturer": "albr",
 	"ship_class": "medium_freighter",

--- a/data/ships/wave.json
+++ b/data/ships/wave.json
@@ -2,6 +2,7 @@
 	"model": "wave",
 	"name": "Wave",
 	"cockpit": "",
+	"shield_model": "wave_shield",
 	"manufacturer": "auronox",
 	"ship_class": "medium_fighter",
 	"min_crew": 1,

--- a/data/ships/xylophis.json
+++ b/data/ships/xylophis.json
@@ -2,6 +2,7 @@
 	"model": "xylophis",
 	"name": "Xylophis",
 	"cockpit": "xylophis_cockpit",
+	"shield_model": "xylophis_shield",
 	"manufacturer": "opli",
 	"ship_class": "light_passenger_shuttle",
 	"min_crew": 1,


### PR DESCRIPTION
For #5840 I'm separating the shields to their own model file. Should be merged after that PR, and the hotfix release. 
This sounds rather ominous: :D
![image](https://github.com/pioneerspacesim/pioneer/assets/4182678/e76a152f-924b-4c99-8592-e9bb7fded75e)

@Web-eWorks All of the ships had separate shield.dae, so there was no need to touch any of the models. The #5840 builds were already expired, so I can't test, but I will do a build and check them later.
**TODO:**
- [x] Update dev docs
- [x] Model files 
- [x] AC33
- [x] Bluenose
- [x] Bowfin
- [x] Coronatrix & police
- [x] Deneb
- [x] DSMiner
- [x] Kanara & police
- [x] Lodos
- [x] Lunar Shuttle
- [x] Malabar @ Vatakara
- [x] Mola Mola
- [x] Mola Ramsayi
- [x] Natrix
- [x] Nerodia
- [x] Pumpkinseed & police
- [x] Sinonatrix & police
- [x] Skipjack
- [x] Storeria
- [x] Varada
- [x] Venturestar
- [x] Wave
- [x] Xylophis