### PR TITLE
Fix Military Drive 2 not for sale & tweaks

### DIFF
--- a/data/modules/Debug/DebugRPG.lua
+++ b/data/modules/Debug/DebugRPG.lua
@@ -7,7 +7,6 @@ local ui = require 'pigui'
 local debugView = require 'pigui.views.debug'
 local Commodities = require 'Commodities'
 local amount = 1000
-local selected = 0
 
 local Legal = require "Legal"
 local utils = require "utils"
@@ -16,7 +15,7 @@ local l = Lang.GetResource("ui-core")
 
 -- build list of all crime types:
 local crime_types = {}
-for k, v in pairs(Legal.CrimeType) do
+for k, _ in pairs(Legal.CrimeType) do
 	table.insert(crime_types, k)
 end
 
@@ -41,7 +40,7 @@ end
 
 debugView.registerTab("RPG-debug-view", function()
 	if Game.player == nil then return end
-    if not ui.beginTabItem("RPG") then return end
+	if not ui.beginTabItem("RPG") then return end
 		ui.text("State: " .. Game.player:GetFlightState())
 
 		-- Reputation
@@ -70,7 +69,6 @@ debugView.registerTab("RPG-debug-view", function()
 		end
 		ui.separator()
 
-		local rows = 10
 		if ui.collapsingHeader("Crime", {}) then
 
 			ui.text("ADD CRIMINAL CHARGES:")

--- a/data/modules/Scoop/Scoop.lua
+++ b/data/modules/Scoop/Scoop.lua
@@ -93,14 +93,15 @@ local spoiled_food = CommodityType.RegisterCommodity("spoiled_food", {
 	purchasable = false
 })
 
-local unknown = CommodityType.RegisterCommodity("unknown", {
-	l10n_key = "UNKNOWN",
-	l10n_resource = "module-scoop",
-	price = -5,
-	icon_name = "Default",
-	mass = 1,
-	purchasable = false
-})
+-- -- Unclear what player should do with "Unknown" cargo -> disable for now
+-- local unknown = CommodityType.RegisterCommodity("unknown", {
+--	l10n_key = "UNKNOWN",
+--	l10n_resource = "module-scoop",
+--	price = -5,
+--	icon_name = "Default",
+--	mass = 1,
+--	purchasable = false
+-- })
 
 local rescue_capsules = {
 	rescue_capsule
@@ -115,7 +116,7 @@ local weapons = {
 local waste = {
 	toxic_waste,
 	spoiled_food,
-	unknown,
+	-- unknown,
 	Commodities.radioactives,
 	Commodities.rubbish
 }

--- a/data/pigui/libs/ship-equipment.lua
+++ b/data/pigui/libs/ship-equipment.lua
@@ -118,7 +118,7 @@ local hasTech = function (station, e)
 
 	if type(equip_tech_level) == "string" then
 		if equip_tech_level == "MILITARY" then
-			return station.techLevel == 11
+			equip_tech_level = 11
 		else
 			error("Unknown tech level:\t"..equip_tech_level)
 		end


### PR DESCRIPTION
This PR contains multitides:

## 1. Fix a bug
Class 2 military drives require "MILITARY" tech level, which under the hood is interpreted as tech-level 11 (because that's how Frontier implemented it). Higher military drives are available at higher tech levels. Code had a bug where in stations of higher tech level than "MILITARY", you could only buy military drive of class 1, 3, and 4, but not military drive class 2.

I note there's equipment that has "tech level = 11" set, that is technically the same as tech level "Military". Seems to be the way I did it in #3505, so looks intentional, but not sure what the reasoning was.

I saw the bug when watching the "Pioneer - Frequently Failing" play through of the game (last screenshot from Poseidon in orbit around Neptune, level 12 station):
![mpv-shot0001](https://github.com/pioneerspacesim/pioneer/assets/619390/2c8a32e3-5541-4cf2-9913-f3dcce16f581)
![2024-07-05-154225_812x396_scrot](https://github.com/pioneerspacesim/pioneer/assets/619390/5c8ebc5d-0f1d-4465-8143-9a51ef9b66cb)


## 2. Tweak suggestion
Don't generate "Unknown commodity" to scoop - Removing this since player might be tricked to think this has value, being some "discovery" of alien origin, sought after by someone.

