### PR TITLE
Fix custom systems with zero stars

### DIFF
--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -41,7 +41,7 @@ local buttonState = {
 	[false]       = ui.theme.buttonColors.transparent
 }
 
-local settings = 
+local settings =
 {
 	draw_vertical_lines=false,
 	draw_out_range_labels=false,
@@ -75,7 +75,7 @@ local onGameStart = function ()
 	hyperspaceDetailsCache = {}
 
 	-- apply any data loaded earlier
-	if loaded_data then	
+	if loaded_data then
 		if loaded_data.jump_targets then
 			local targets = loaded_data.jump_targets
 			for _, target in pairs( loaded_data.jump_targets) do
@@ -172,7 +172,8 @@ function Windows.systemInfo:Show()
 			starsystem.numberOfStars == 1 and starsystem.rootSystemBody.astroDescription or "",
 			lc.BINARY_SYSTEM,
 			lc.TRIPLE_SYSTEM,
-			lc.QUADRUPLE_SYSTEM
+			lc.QUADRUPLE_SYSTEM,
+			[0] = lui.AN_ERROR_HAS_OCCURRED
 		}
 
 		-- description

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -4,6 +4,7 @@
 #include "Background.h"
 
 #include "FileSystem.h"
+#include "FloatComparison.h"
 #include "Game.h"
 #include "GameConfig.h"
 #include "MathUtil.h"
@@ -317,7 +318,9 @@ namespace Background {
 								Color col = StarSystem::starRealColors[ss->GetStarType(i)];
 								colorSystemSum += vector3f(col.r, col.g, col.b) * StarSystem::starLuminosities[ss->GetStarType(i)];
 							}
-							colorSystemSum /= luminositySystemSum;
+
+							if (!is_zero_exact(luminositySystemSum))
+								colorSystemSum /= luminositySystemSum;
 
 							Color col(colorSystemSum.x, colorSystemSum.y, colorSystemSum.z);
 							col.r = Clamp(col.r, info.colorMin.r, info.colorMax.r);
@@ -327,6 +330,9 @@ namespace Background {
 
 							// use a logarithmic scala for brightness since this looks more natural to the human eye
 							float brightness = log(luminositySystemSum / (4 * M_PI * distance.Length() * distance.Length()));
+
+							// handle zero-brightness systems (no stars)
+							brightness = is_zero_exact(luminositySystemSum) ? 0.0 : brightness;
 
 							stars.pos.push_back(distance.Normalized() * 1000.0f);
 							stars.color.push_back(col);

--- a/src/SectorMap.cpp
+++ b/src/SectorMap.cpp
@@ -1024,10 +1024,13 @@ void SectorMap::DrawNearSector(const int sx, const int sy, const int sz, const m
 		// draw star blob itself
 		systrans.Rotate(DEG2RAD(-m_rotZ), 0, 0, 1);
 		systrans.Rotate(DEG2RAD(-m_rotX), 1, 0, 0);
-		systrans.Scale((StarSystem::starScale[(*i).GetStarType(0)]));
+
+		// fallback to M-class star scaling if the system doesn't have any stars (degenerate case)
+		SystemBodyType::BodyType starType = (*i).GetNumStars() > 0 ? (*i).GetStarType(0) : SystemBodyType::TYPE_STAR_M;
+		systrans.Scale((StarSystem::starScale[starType]));
 		m_context.renderer->SetTransform(systrans);
 
-		const Uint8 *col = StarSystem::starColors[(*i).GetStarType(0)];
+		const Uint8 *col = StarSystem::starColors[starType];
 		AddStarBillboard(systrans, vector3f(0.f), Color(col[0], col[1], col[2], 255), 0.5f);
 
 		// add label

--- a/src/editor/system/GalaxyEditAPI.cpp
+++ b/src/editor/system/GalaxyEditAPI.cpp
@@ -218,6 +218,34 @@ void StarSystem::EditorAPI::SortBodyHierarchy(StarSystem *system, UndoSystem *un
 	undo->AddUndoStep<SystemEditorUndo::SortStarSystemBodies>(system, true);
 }
 
+void StarSystem::EditorAPI::GenerateStarList(StarSystem *system)
+{
+	system->m_stars.clear();
+	system->m_numStars = 0;
+	std::vector<std::pair<SystemBody *, size_t>> searchList {
+		{ system->GetRootBody().Get(), 0 }
+	};
+
+	while (!searchList.empty()) {
+		auto &pair = searchList.back();
+		SystemBody *body = pair.first;
+
+		if (pair.second == 0) {
+			if (body->GetSuperType() == SystemBodyType::SUPERTYPE_STAR) {
+				system->m_stars.push_back(body);
+				system->m_numStars++;
+			}
+		}
+
+		if (pair.second < body->GetNumChildren()) {
+			searchList.push_back({ body->GetChildren()[pair.second++], 0 });
+		} else {
+			searchList.pop_back();
+		}
+	}
+
+}
+
 void StarSystem::EditorAPI::EditName(StarSystem *system, Random &rng, UndoSystem *undo)
 {
 	ImGui::BeginGroup();

--- a/src/editor/system/GalaxyEditAPI.h
+++ b/src/editor/system/GalaxyEditAPI.h
@@ -46,6 +46,9 @@ public:
 	// Sort the bodies in the system based on semi-major axis
 	static void SortBodyHierarchy(StarSystem *system, Editor::UndoSystem *undo);
 
+	// Regenerate the system's internal list of stars for export
+	static void GenerateStarList(StarSystem *system);
+
 	static void EditName(StarSystem *system, Random &rng, Editor::UndoSystem *undo);
 	static void EditProperties(StarSystem *system, Editor::CustomSystemInfo &custom, FactionsDatabase *factions, Editor::UndoSystem *undo);
 };

--- a/src/editor/system/SystemEditor.cpp
+++ b/src/editor/system/SystemEditor.cpp
@@ -252,6 +252,9 @@ bool SystemEditor::WriteSystem(const std::string &filepath)
 
 	Json systemdef = Json::object();
 
+	// Generate the list of stars in this system
+	StarSystem::EditorAPI::GenerateStarList(m_system.Get());
+
 	m_system->DumpToJson(systemdef);
 
 	if (m_systemInfo.randomFaction)

--- a/src/galaxy/StarSystem.cpp
+++ b/src/galaxy/StarSystem.cpp
@@ -229,6 +229,7 @@ StarSystem::StarSystem(const SystemPath &path, RefCountedPtr<Galaxy> galaxy, Sta
 	m_exploredTime(0.0),
 	m_econType(GalacticEconomy::InvalidEconomyId),
 	m_seed(0),
+	m_pos(0.0),
 	m_tradeLevel(GalacticEconomy::Commodities().size() + 1, 0),
 	m_commodityLegal(GalacticEconomy::Commodities().size() + 1, true),
 	m_cache(cache)


### PR DESCRIPTION
This PR fixes #5857 - the primary issue was that `StarSystem::m_stars` wasn't being properly populated when creating a new system and adding stars to that system. As a consequence, the game thought there were no stars within the generated system and that exposed a host of bugs related to rendering and processing a system without stars.

I've fixed most of the bugs related to a lack of stars which I found, but didn't perform an exhaustive search to see if there were any I missed in other parts of the game or UI.

I've also fixed a problem which lead to hilariously out-of-range values being set for a system's position within its sector when creating a new system "from scratch". As usual, just another variable which didn't get initialized properly.