### PR TITLE
Fix debug commodities tab

### DIFF
--- a/data/modules/Debug/DebugCommodityPrices.lua
+++ b/data/modules/Debug/DebugCommodityPrices.lua
@@ -244,6 +244,7 @@ local function show_system_info(min, sys, str)
 	ui.text("Distance:\t " .. dist .. " ly")
 	ui.text("Faction:\t " .. sys.faction.name)
 	ui.text("Government:\t " .. string.lower(sys.govtype):gsub("^%l", string.upper)) -- PolitGovType
+	ui.spacing()
 
 	-- Add from C++ side, E.g:
 	-- System type: Mining colony
@@ -258,7 +259,7 @@ local function show_details_on_commodity(commodities, selected)
 	ui.text(string.upper(selected))
 	local c = commodities[selected]
 
-	-- If previous click was non-purchasalbe item followed by
+	-- If previous click was non-purchasable item followed by
 	-- filtering them out, 'clicked' value will no longer be in
 	-- 'commodities'
 	if not c then
@@ -276,6 +277,8 @@ local function show_details_on_commodity(commodities, selected)
 	ui.text("Average price:\t" .. Format.Money(c:mean()))
 	ui.text("Standard deviation:\t" .. string.format("%.2f", c:std()))
 
+	ui.spacing()
+
 	if ui.collapsingHeader("Lowest", {"DefaultOpen"}) then
 		show_system_info(c.min, c.minsys, "Lowest")
 	end
@@ -292,12 +295,15 @@ local function show_details_on_commodity(commodities, selected)
 
 		local data = c:get_bins()
 		local y_max = math.max(table.unpack(data))
-		ui.dummy(Vector2(0,50))
+		-- ui.dummy(Vector2(0,50))
 
 		ui.plotHistogram("##price distribution", data, #data, 0, "", 0, y_max, Vector2(400, 100))
 		ui.text("Min: " .. Format.Money(c.min))
 		ui.text("Max: " .. Format.Money(c.max))
+
+		ui.spacing()
 	end
+
 	return purchasable
 end
 
@@ -318,7 +324,7 @@ local function station_economy(commodities, clicked, station)
 	local stock = station:GetCommodityStock(cargo_item)
 	local demand = station:GetCommodityDemand(cargo_item)
 
-	ui.text("\nAt station: " .. station.label)
+	ui.text("At station: " .. station.label)
 	ui.text("Local price " .. price)
 	ui.text("Local stock " .. stock)
 	ui.text("Local demand: " .. demand)
@@ -341,7 +347,7 @@ local function main()
 
 	-- HEADER
 	_, include_illegal = ui.checkbox("Include Illegal goods", include_illegal)
-	_, include_only_purchasable = ui.checkbox("Include only purcasalbe goods", include_only_purchasable)
+	_, include_only_purchasable = ui.checkbox("Include only purchasable goods", include_only_purchasable)
 
 	if ui.button("scan", Vector2(0,0)) then
 		commodities, N = scan_systems(radius)


### PR DESCRIPTION
- Fix standard deviation lacking a `sqrt`
- Add filtering on `purchasable` goods on/off (sadly we can't buy the fuzzy little Quibbles on the commodity market)
- Add some collapsing headers UI stuff when selected a commodity, for bling bling
- Added some info on commodity at current station (if docked). I used this for #5859, and might need it again. It's not über-pretty, but oh, well `¯\_(ツ)_/¯`

## Collapsed
![2024-07-11-163357_1536x960_scrot](https://github.com/pioneerspacesim/pioneer/assets/619390/309fd275-7755-4bf8-b670-5993dcf06739)
## Expanded
![2024-07-11-163416_1536x960_scrot](https://github.com/pioneerspacesim/pioneer/assets/619390/38633d35-1dee-4c84-8084-250e7baf0d0b)
## Include non-purchasable
![2024-07-11-163555_1536x960_scrot](https://github.com/pioneerspacesim/pioneer/assets/619390/3fbf5d60-7762-4fb2-a8c0-30eae0f08db4)
## Some info of station levels
![2024-07-11-163903_1536x960_scrot](https://github.com/pioneerspacesim/pioneer/assets/619390/90047cd3-b269-451f-b6cd-1f63fe5d8540)
 
