### PR TITLE
Add "jettison all" buttons to cargo sidebar menu

### DIFF
--- a/data/pigui/modules/sidebar/cargo.lua
+++ b/data/pigui/modules/sidebar/cargo.lua
@@ -53,6 +53,10 @@ local function transfer_button(icon, tooltip, enabled)
 end
 
 local function transfer_buttons(amount, min, max, tooltip_reduce, tooltip_increase)
+	if transfer_button(icons.time_backward_10x, tooltip_reduce .. "##all", amount > min) then
+		amount = min
+	end
+	ui.sameLine(0, 2)
 	if transfer_button(icons.time_backward_1x, tooltip_reduce, amount > min) then
 		amount = amount - 1
 	end
@@ -60,7 +64,10 @@ local function transfer_buttons(amount, min, max, tooltip_reduce, tooltip_increa
 	if transfer_button(icons.time_forward_1x, tooltip_increase, amount < max) then
 		amount = amount + 1
 	end
-
+	ui.sameLine(0, 2)
+	if transfer_button(icons.time_forward_10x, tooltip_increase .. "##all", amount < max) then
+		amount = max
+	end
 	return amount
 end
 


### PR DESCRIPTION
Closes #5860 feature request by @syonfox (I was going to close it anyway, as we don't do feature requests on the issue tracker, but figured I might as well implement it, low hanging fruit). 

![2024-07-17-165854_1536x960_scrot](https://github.com/user-attachments/assets/89f60b70-cfa5-487d-a307-696697a1d0c5)

Note: just appending "all" to the tooltip hardcoded. Dunno if we keep it, and put it in ui-core, or remove. Not obvious to me why the `tooltips` are passed as arguments to this function?
```lua
transfer_buttons(amount, min, max, tooltip_reduce, tooltip_increase)
```