### PR TITLE
Improve Lua type checking for string enums

### DIFF
--- a/data/meta/Constants.lua
+++ b/data/meta/Constants.lua
@@ -17,345 +17,426 @@ Constants = {}
 -- retrieving a value from these tables
 
 -- A <Constants.PhysicsObjectType> string
----@enum PhysicsObjectType
-Constants.PhysicsObjectType = {
-	[1] = "BODY",
-	[2] = "MODELBODY",
-	[3] = "SHIP",
-	[4] = "PLAYER",
-	[5] = "SPACESTATION",
-	[6] = "PLANET",
-	[7] = "STAR",
-	[8] = "CARGOBODY",
-	[9] = "MISSILE",
+---@enum (key) PhysicsObjectType
+local PhysicsObjectType = {
+	BODY = 1,
+	MODELBODY = 2,
+	SHIP = 3,
+	PLAYER = 4,
+	SPACESTATION = 5,
+	PLANET = 6,
+	STAR = 7,
+	CARGOBODY = 8,
+	MISSILE = 9,
 }
+
+---@type PhysicsObjectType[]
+Constants.PhysicsObjectType = {}
 
 -- A <Constants.AltitudeType> string
----@enum AltitudeType
-Constants.AltitudeType = {
-	[1] = "DEFAULT",
-	[2] = "SEA_LEVEL",
-	[3] = "ABOVE_TERRAIN",
+---@enum (key) AltitudeType
+local AltitudeType = {
+	DEFAULT = 1,
+	SEA_LEVEL = 2,
+	ABOVE_TERRAIN = 3,
 }
+
+---@type AltitudeType[]
+Constants.AltitudeType = {}
 
 -- A <Constants.ShipAIError> string
----@enum ShipAIError
-Constants.ShipAIError = {
-	[1] = "NONE",
-	[2] = "GRAV_TOO_HIGH",
-	[3] = "REFUSED_PERM",
-	[4] = "PRESS_TOO_HIGH",
-	[5] = "ORBIT_IMPOSSIBLE",
+---@enum (key) ShipAIError
+local ShipAIError = {
+	NONE = 1,
+	GRAV_TOO_HIGH = 2,
+	REFUSED_PERM = 3,
+	PRESS_TOO_HIGH = 4,
+	ORBIT_IMPOSSIBLE = 5,
 }
+
+---@type ShipAIError[]
+Constants.ShipAIError = {}
 
 -- A <Constants.ShipFlightState> string
----@enum ShipFlightState
-Constants.ShipFlightState = {
-	[1] = "FLYING",
-	[2] = "DOCKING",
-	[3] = "UNDOCKING",
-	[4] = "DOCKED",
-	[5] = "LANDED",
-	[6] = "JUMPING",
-	[7] = "HYPERSPACE",
+---@enum (key) ShipFlightState
+local ShipFlightState = {
+	FLYING = 1,
+	DOCKING = 2,
+	UNDOCKING = 3,
+	DOCKED = 4,
+	LANDED = 5,
+	JUMPING = 6,
+	HYPERSPACE = 7,
 }
+
+---@type ShipFlightState[]
+Constants.ShipFlightState = {}
 
 -- A <Constants.ShipJumpStatus> string
----@enum ShipJumpStatus
-Constants.ShipJumpStatus = {
-	[1] = "OK",
-	[2] = "CURRENT_SYSTEM",
-	[3] = "NO_DRIVE",
-	[4] = "INITIATED",
-	[5] = "DRIVE_ACTIVE",
-	[6] = "OUT_OF_RANGE",
-	[7] = "INSUFFICIENT_FUEL",
-	[8] = "SAFETY_LOCKOUT",
+---@enum (key) ShipJumpStatus
+local ShipJumpStatus = {
+	OK = 1,
+	CURRENT_SYSTEM = 2,
+	NO_DRIVE = 3,
+	INITIATED = 4,
+	DRIVE_ACTIVE = 5,
+	OUT_OF_RANGE = 6,
+	INSUFFICIENT_FUEL = 7,
+	SAFETY_LOCKOUT = 8,
 }
+
+---@type ShipJumpStatus[]
+Constants.ShipJumpStatus = {}
 
 -- A <Constants.ShipAlertStatus> string
----@enum ShipAlertStatus
-Constants.ShipAlertStatus = {
-	[1] = "NONE",
-	[2] = "SHIP_NEARBY",
-	[3] = "SHIP_FIRING",
-	[4] = "MISSILE_DETECTED",
+---@enum (key) ShipAlertStatus
+local ShipAlertStatus = {
+	NONE = 1,
+	SHIP_NEARBY = 2,
+	SHIP_FIRING = 3,
+	MISSILE_DETECTED = 4,
 }
+
+---@type ShipAlertStatus[]
+Constants.ShipAlertStatus = {}
 
 -- A <Constants.ShipAICmdName> string
----@enum ShipAICmdName
-Constants.ShipAICmdName = {
-	[1] = "CMD_NONE",
-	[2] = "CMD_DOCK",
-	[3] = "CMD_FLYTO",
-	[4] = "CMD_FLYAROUND",
-	[5] = "CMD_KILL",
-	[6] = "CMD_KAMIKAZE",
-	[7] = "CMD_HOLDPOSITION",
-	[8] = "CMD_FORMATION",
+---@enum (key) ShipAICmdName
+local ShipAICmdName = {
+	CMD_NONE = 1,
+	CMD_DOCK = 2,
+	CMD_FLYTO = 3,
+	CMD_FLYAROUND = 4,
+	CMD_KILL = 5,
+	CMD_KAMIKAZE = 6,
+	CMD_HOLDPOSITION = 7,
+	CMD_FORMATION = 8,
 }
+
+---@type ShipAICmdName[]
+Constants.ShipAICmdName = {}
 
 -- A <Constants.DualLaserOrientation> string
----@enum DualLaserOrientation
-Constants.DualLaserOrientation = {
-	[1] = "HORIZONTAL",
-	[2] = "VERTICAL",
+---@enum (key) DualLaserOrientation
+local DualLaserOrientation = {
+	HORIZONTAL = 1,
+	VERTICAL = 2,
 }
+
+---@type DualLaserOrientation[]
+Constants.DualLaserOrientation = {}
 
 -- A <Constants.ShipTypeTag> string
----@enum ShipTypeTag
-Constants.ShipTypeTag = {
-	[1] = "NONE",
-	[2] = "SHIP",
-	[3] = "STATIC_SHIP",
-	[4] = "MISSILE",
+---@enum (key) ShipTypeTag
+local ShipTypeTag = {
+	NONE = 1,
+	SHIP = 2,
+	STATIC_SHIP = 3,
+	MISSILE = 4,
 }
+
+---@type ShipTypeTag[]
+Constants.ShipTypeTag = {}
 
 -- A <Constants.DockingRefusedReason> string
----@enum DockingRefusedReason
-Constants.DockingRefusedReason = {
-	[1] = "ClearanceAlreadyGranted",
-	[2] = "TooFarFromStation",
-	[3] = "NoBaysAvailable",
+---@enum (key) DockingRefusedReason
+local DockingRefusedReason = {
+	ClearanceAlreadyGranted = 1,
+	TooFarFromStation = 2,
+	NoBaysAvailable = 3,
 }
+
+---@type DockingRefusedReason[]
+Constants.DockingRefusedReason = {}
 
 -- A <Constants.DockStage> string
----@enum DockStage
-Constants.DockStage = {
-	[1] = "NONE",
-	[2] = "MANUAL",
-	[3] = "DOCK_STAGES_BEGIN",
-	[4] = "CLEARANCE_GRANTED",
-	[5] = "DOCK_ANIMATION_NONE",
-	[6] = "DOCK_ANIMATION_1",
-	[7] = "DOCK_ANIMATION_2",
-	[8] = "DOCK_ANIMATION_3",
-	[9] = "DOCK_ANIMATION_MAX",
-	[10] = "TOUCHDOWN",
-	[11] = "LEVELING",
-	[12] = "REPOSITION",
-	[13] = "JUST_DOCK",
-	[14] = "DOCK_STAGES_END",
-	[15] = "DOCKED",
-	[16] = "UNDOCK_STAGES_BEGIN",
-	[17] = "UNDOCK_BEGIN",
-	[18] = "UNDOCK_ANIMATION_NONE",
-	[19] = "UNDOCK_ANIMATION_1",
-	[20] = "UNDOCK_ANIMATION_2",
-	[21] = "UNDOCK_ANIMATION_3",
-	[22] = "UNDOCK_ANIMATION_MAX",
-	[23] = "UNDOCK_END",
-	[24] = "LEAVE",
-	[25] = "UNDOCK_STAGES_END",
-	[26] = "APPROACH1",
-	[27] = "APPROACH2",
+---@enum (key) DockStage
+local DockStage = {
+	NONE = 1,
+	MANUAL = 2,
+	DOCK_STAGES_BEGIN = 3,
+	CLEARANCE_GRANTED = 4,
+	DOCK_ANIMATION_NONE = 5,
+	DOCK_ANIMATION_1 = 6,
+	DOCK_ANIMATION_2 = 7,
+	DOCK_ANIMATION_3 = 8,
+	DOCK_ANIMATION_MAX = 9,
+	TOUCHDOWN = 10,
+	LEVELING = 11,
+	REPOSITION = 12,
+	JUST_DOCK = 13,
+	DOCK_STAGES_END = 14,
+	DOCKED = 15,
+	UNDOCK_STAGES_BEGIN = 16,
+	UNDOCK_BEGIN = 17,
+	UNDOCK_ANIMATION_NONE = 18,
+	UNDOCK_ANIMATION_1 = 19,
+	UNDOCK_ANIMATION_2 = 20,
+	UNDOCK_ANIMATION_3 = 21,
+	UNDOCK_ANIMATION_MAX = 22,
+	UNDOCK_END = 23,
+	LEAVE = 24,
+	UNDOCK_STAGES_END = 25,
+	APPROACH1 = 26,
+	APPROACH2 = 27,
 }
+
+---@type DockStage[]
+Constants.DockStage = {}
 
 -- A <Constants.ProjectableTypes> string
----@enum ProjectableTypes
-Constants.ProjectableTypes = {
-	[1] = "NONE",
-	[2] = "OBJECT",
-	[3] = "L4",
-	[4] = "L5",
-	[5] = "APOAPSIS",
-	[6] = "PERIAPSIS",
+---@enum (key) ProjectableTypes
+local ProjectableTypes = {
+	NONE = 1,
+	OBJECT = 2,
+	L4 = 3,
+	L5 = 4,
+	APOAPSIS = 5,
+	PERIAPSIS = 6,
 }
+
+---@type ProjectableTypes[]
+Constants.ProjectableTypes = {}
 
 -- A <Constants.ProjectableBases> string
----@enum ProjectableBases
-Constants.ProjectableBases = {
-	[1] = "SYSTEMBODY",
-	[2] = "BODY",
-	[3] = "SHIP",
-	[4] = "PLAYER",
-	[5] = "PLANNER",
+---@enum (key) ProjectableBases
+local ProjectableBases = {
+	SYSTEMBODY = 1,
+	BODY = 2,
+	SHIP = 3,
+	PLAYER = 4,
+	PLANNER = 5,
 }
+
+---@type ProjectableBases[]
+Constants.ProjectableBases = {}
 
 -- A <Constants.SystemViewMode> string
----@enum SystemViewMode
-Constants.SystemViewMode = {
-	[1] = "Orrery",
-	[2] = "Atlas",
+---@enum (key) SystemViewMode
+local SystemViewMode = {
+	Orrery = 1,
+	Atlas = 2,
 }
+
+---@type SystemViewMode[]
+Constants.SystemViewMode = {}
 
 -- A <Constants.SystemViewColorIndex> string
----@enum SystemViewColorIndex
-Constants.SystemViewColorIndex = {
-	[1] = "GRID",
-	[2] = "GRID_LEG",
-	[3] = "SYSTEMBODY",
-	[4] = "SYSTEMBODY_ORBIT",
-	[5] = "PLAYER_ORBIT",
-	[6] = "PLANNER_ORBIT",
-	[7] = "SELECTED_SHIP_ORBIT",
-	[8] = "SHIP_ORBIT",
+---@enum (key) SystemViewColorIndex
+local SystemViewColorIndex = {
+	GRID = 1,
+	GRID_LEG = 2,
+	SYSTEMBODY = 3,
+	SYSTEMBODY_ORBIT = 4,
+	PLAYER_ORBIT = 5,
+	PLANNER_ORBIT = 6,
+	SELECTED_SHIP_ORBIT = 7,
+	SHIP_ORBIT = 8,
 }
+
+---@type SystemViewColorIndex[]
+Constants.SystemViewColorIndex = {}
 
 -- A <Constants.PolitEcon> string
----@enum PolitEcon
-Constants.PolitEcon = {
-	[1] = "NONE",
-	[2] = "VERY_CAPITALIST",
-	[3] = "CAPITALIST",
-	[4] = "MIXED",
-	[5] = "PLANNED",
+---@enum (key) PolitEcon
+local PolitEcon = {
+	NONE = 1,
+	VERY_CAPITALIST = 2,
+	CAPITALIST = 3,
+	MIXED = 4,
+	PLANNED = 5,
 }
+
+---@type PolitEcon[]
+Constants.PolitEcon = {}
 
 -- A <Constants.PolitGovType> string
----@enum PolitGovType
-Constants.PolitGovType = {
-	[1] = "NONE",
-	[2] = "EARTHCOLONIAL",
-	[3] = "EARTHDEMOC",
-	[4] = "EMPIRERULE",
-	[5] = "CISLIBDEM",
-	[6] = "CISSOCDEM",
-	[7] = "LIBDEM",
-	[8] = "CORPORATE",
-	[9] = "SOCDEM",
-	[10] = "EARTHMILDICT",
-	[11] = "MILDICT1",
-	[12] = "MILDICT2",
-	[13] = "EMPIREMILDICT",
-	[14] = "COMMUNIST",
-	[15] = "PLUTOCRATIC",
-	[16] = "DISORDER",
+---@enum (key) PolitGovType
+local PolitGovType = {
+	NONE = 1,
+	EARTHCOLONIAL = 2,
+	EARTHDEMOC = 3,
+	EMPIRERULE = 4,
+	CISLIBDEM = 5,
+	CISSOCDEM = 6,
+	LIBDEM = 7,
+	CORPORATE = 8,
+	SOCDEM = 9,
+	EARTHMILDICT = 10,
+	MILDICT1 = 11,
+	MILDICT2 = 12,
+	EMPIREMILDICT = 13,
+	COMMUNIST = 14,
+	PLUTOCRATIC = 15,
+	DISORDER = 16,
 }
+
+---@type PolitGovType[]
+Constants.PolitGovType = {}
 
 -- A <Constants.BodyType> string
----@enum BodyType
-Constants.BodyType = {
-	[1] = "GRAVPOINT",
-	[2] = "BROWN_DWARF",
-	[3] = "WHITE_DWARF",
-	[4] = "STAR_M",
-	[5] = "STAR_K",
-	[6] = "STAR_G",
-	[7] = "STAR_F",
-	[8] = "STAR_A",
-	[9] = "STAR_B",
-	[10] = "STAR_O",
-	[11] = "STAR_M_GIANT",
-	[12] = "STAR_K_GIANT",
-	[13] = "STAR_G_GIANT",
-	[14] = "STAR_F_GIANT",
-	[15] = "STAR_A_GIANT",
-	[16] = "STAR_B_GIANT",
-	[17] = "STAR_O_GIANT",
-	[18] = "STAR_M_SUPER_GIANT",
-	[19] = "STAR_K_SUPER_GIANT",
-	[20] = "STAR_G_SUPER_GIANT",
-	[21] = "STAR_F_SUPER_GIANT",
-	[22] = "STAR_A_SUPER_GIANT",
-	[23] = "STAR_B_SUPER_GIANT",
-	[24] = "STAR_O_SUPER_GIANT",
-	[25] = "STAR_M_HYPER_GIANT",
-	[26] = "STAR_K_HYPER_GIANT",
-	[27] = "STAR_G_HYPER_GIANT",
-	[28] = "STAR_F_HYPER_GIANT",
-	[29] = "STAR_A_HYPER_GIANT",
-	[30] = "STAR_B_HYPER_GIANT",
-	[31] = "STAR_O_HYPER_GIANT",
-	[32] = "STAR_M_WF",
-	[33] = "STAR_B_WF",
-	[34] = "STAR_O_WF",
-	[35] = "STAR_S_BH",
-	[36] = "STAR_IM_BH",
-	[37] = "STAR_SM_BH",
-	[38] = "PLANET_GAS_GIANT",
-	[39] = "PLANET_ASTEROID",
-	[40] = "PLANET_TERRESTRIAL",
-	[41] = "STARPORT_ORBITAL",
-	[42] = "STARPORT_SURFACE",
+---@enum (key) BodyType
+local BodyType = {
+	GRAVPOINT = 1,
+	BROWN_DWARF = 2,
+	WHITE_DWARF = 3,
+	STAR_M = 4,
+	STAR_K = 5,
+	STAR_G = 6,
+	STAR_F = 7,
+	STAR_A = 8,
+	STAR_B = 9,
+	STAR_O = 10,
+	STAR_M_GIANT = 11,
+	STAR_K_GIANT = 12,
+	STAR_G_GIANT = 13,
+	STAR_F_GIANT = 14,
+	STAR_A_GIANT = 15,
+	STAR_B_GIANT = 16,
+	STAR_O_GIANT = 17,
+	STAR_M_SUPER_GIANT = 18,
+	STAR_K_SUPER_GIANT = 19,
+	STAR_G_SUPER_GIANT = 20,
+	STAR_F_SUPER_GIANT = 21,
+	STAR_A_SUPER_GIANT = 22,
+	STAR_B_SUPER_GIANT = 23,
+	STAR_O_SUPER_GIANT = 24,
+	STAR_M_HYPER_GIANT = 25,
+	STAR_K_HYPER_GIANT = 26,
+	STAR_G_HYPER_GIANT = 27,
+	STAR_F_HYPER_GIANT = 28,
+	STAR_A_HYPER_GIANT = 29,
+	STAR_B_HYPER_GIANT = 30,
+	STAR_O_HYPER_GIANT = 31,
+	STAR_M_WF = 32,
+	STAR_B_WF = 33,
+	STAR_O_WF = 34,
+	STAR_S_BH = 35,
+	STAR_IM_BH = 36,
+	STAR_SM_BH = 37,
+	PLANET_GAS_GIANT = 38,
+	PLANET_ASTEROID = 39,
+	PLANET_TERRESTRIAL = 40,
+	STARPORT_ORBITAL = 41,
+	STARPORT_SURFACE = 42,
 }
+
+---@type BodyType[]
+Constants.BodyType = {}
 
 -- A <Constants.BodySuperType> string
----@enum BodySuperType
-Constants.BodySuperType = {
-	[1] = "NONE",
-	[2] = "STAR",
-	[3] = "ROCKY_PLANET",
-	[4] = "GAS_GIANT",
-	[5] = "STARPORT",
+---@enum (key) BodySuperType
+local BodySuperType = {
+	NONE = 1,
+	STAR = 2,
+	ROCKY_PLANET = 3,
+	GAS_GIANT = 4,
+	STARPORT = 5,
 }
+
+---@type BodySuperType[]
+Constants.BodySuperType = {}
 
 -- A <Constants.DetailLevel> string
----@enum DetailLevel
-Constants.DetailLevel = {
-	[1] = "VERY_LOW",
-	[2] = "LOW",
-	[3] = "MEDIUM",
-	[4] = "HIGH",
-	[5] = "VERY_HIGH",
+---@enum (key) DetailLevel
+local DetailLevel = {
+	VERY_LOW = 1,
+	LOW = 2,
+	MEDIUM = 3,
+	HIGH = 4,
+	VERY_HIGH = 5,
 }
+
+---@type DetailLevel[]
+Constants.DetailLevel = {}
 
 -- A <Constants.PiGuiFaceFlags> string
----@enum PiGuiFaceFlags
-Constants.PiGuiFaceFlags = {
-	[1] = "RAND",
-	[2] = "MALE",
-	[3] = "FEMALE",
-	[4] = "ARMOUR",
+---@enum (key) PiGuiFaceFlags
+local PiGuiFaceFlags = {
+	RAND = 1,
+	MALE = 2,
+	FEMALE = 3,
+	ARMOUR = 4,
 }
+
+---@type PiGuiFaceFlags[]
+Constants.PiGuiFaceFlags = {}
 
 -- A <Constants.ModelDebugFlags> string
----@enum ModelDebugFlags
-Constants.ModelDebugFlags = {
-	[1] = "NONE",
-	[2] = "BBOX",
-	[3] = "COLLMESH",
-	[4] = "WIREFRAME",
-	[5] = "TAGS",
-	[6] = "DOCKING",
-	[7] = "GEOMBBOX",
+---@enum (key) ModelDebugFlags
+local ModelDebugFlags = {
+	NONE = 1,
+	BBOX = 2,
+	COLLMESH = 3,
+	WIREFRAME = 4,
+	TAGS = 5,
+	DOCKING = 6,
+	GEOMBBOX = 7,
 }
+
+---@type ModelDebugFlags[]
+Constants.ModelDebugFlags = {}
 
 -- A <Constants.CruiseDirection> string
----@enum CruiseDirection
-Constants.CruiseDirection = {
-	[1] = "CRUISE_FWD",
-	[2] = "CRUISE_UP",
+---@enum (key) CruiseDirection
+local CruiseDirection = {
+	CRUISE_FWD = 1,
+	CRUISE_UP = 2,
 }
+
+---@type CruiseDirection[]
+Constants.CruiseDirection = {}
 
 -- A <Constants.FollowMode> string
----@enum FollowMode
-Constants.FollowMode = {
-	[1] = "FOLLOW_POS",
-	[2] = "FOLLOW_ORI",
+---@enum (key) FollowMode
+local FollowMode = {
+	FOLLOW_POS = 1,
+	FOLLOW_ORI = 2,
 }
+
+---@type FollowMode[]
+Constants.FollowMode = {}
 
 -- A <Constants.ShipTypeThruster> string
----@enum ShipTypeThruster
-Constants.ShipTypeThruster = {
-	[1] = "REVERSE",
-	[2] = "FORWARD",
-	[3] = "UP",
-	[4] = "DOWN",
-	[5] = "LEFT",
-	[6] = "RIGHT",
+---@enum (key) ShipTypeThruster
+local ShipTypeThruster = {
+	REVERSE = 1,
+	FORWARD = 2,
+	UP = 3,
+	DOWN = 4,
+	LEFT = 5,
+	RIGHT = 6,
 }
+
+---@type ShipTypeThruster[]
+Constants.ShipTypeThruster = {}
 
 -- A <Constants.PropulsionFuelStatus> string
----@enum PropulsionFuelStatus
-Constants.PropulsionFuelStatus = {
-	[1] = "OK",
-	[2] = "WARNING",
-	[3] = "EMPTY",
+---@enum (key) PropulsionFuelStatus
+local PropulsionFuelStatus = {
+	OK = 1,
+	WARNING = 2,
+	EMPTY = 3,
 }
 
+---@type PropulsionFuelStatus[]
+Constants.PropulsionFuelStatus = {}
+
 -- A <Constants.ShipControllerFlightControlState> string
----@enum ShipControllerFlightControlState
-Constants.ShipControllerFlightControlState = {
-	[1] = "CONTROL_MANUAL",
-	[2] = "CONTROL_FIXSPEED",
-	[3] = "CONTROL_FIXHEADING_FORWARD",
-	[4] = "CONTROL_FIXHEADING_BACKWARD",
-	[5] = "CONTROL_FIXHEADING_NORMAL",
-	[6] = "CONTROL_FIXHEADING_ANTINORMAL",
-	[7] = "CONTROL_FIXHEADING_RADIALLY_INWARD",
-	[8] = "CONTROL_FIXHEADING_RADIALLY_OUTWARD",
-	[9] = "CONTROL_FIXHEADING_KILLROT",
-	[10] = "CONTROL_AUTOPILOT",
+---@enum (key) ShipControllerFlightControlState
+local ShipControllerFlightControlState = {
+	CONTROL_MANUAL = 1,
+	CONTROL_FIXSPEED = 2,
+	CONTROL_FIXHEADING_FORWARD = 3,
+	CONTROL_FIXHEADING_BACKWARD = 4,
+	CONTROL_FIXHEADING_NORMAL = 5,
+	CONTROL_FIXHEADING_ANTINORMAL = 6,
+	CONTROL_FIXHEADING_RADIALLY_INWARD = 7,
+	CONTROL_FIXHEADING_RADIALLY_OUTWARD = 8,
+	CONTROL_FIXHEADING_KILLROT = 9,
+	CONTROL_AUTOPILOT = 10,
 }
+
+---@type ShipControllerFlightControlState[]
+Constants.ShipControllerFlightControlState = {}
 

--- a/data/meta/CoreObject/Body.meta.lua
+++ b/data/meta/CoreObject/Body.meta.lua
@@ -82,7 +82,7 @@ function Body:DistanceTo(otherBody) end
 --- Get the body's position relative to its parent frame.
 ---
 --- If the parent is a TerrainBody, altitude will be the height above terrain or sea level in meters.
----@param boolean? terrainRelative
+---@param terrainRelative boolean?
 ---@return number latitude the latitude of the body in radians
 ---@return number longitude the longitude of the body in radians
 ---@return number? altitude altitude above the ground or sea level in meters
@@ -108,7 +108,7 @@ function Body:GetPositionRelTo(other) end
 --- Returns height above terrain or sea level if the other body is a TerrainBody or
 --- distance between bodies otherwise.
 ---@param other Body
----@param boolean? terrainRelative
+---@param terrainRelative boolean?
 ---@return number altitude
 function Body:GetAltitudeRelTo(other, terrainRelative) end
 

--- a/data/meta/FileSystem.lua
+++ b/data/meta/FileSystem.lua
@@ -20,8 +20,8 @@ function FileSystem.ReadDirectory(path) end
 --- Join the passed arguments into a path, correctly handling separators and .
 --- and .. special dirs.
 ---
----@param arg string[]  A list of path elements to be joined
----@return string       The joined path elements
+---@param ... string  A list of path elements to be joined
+---@return string path The joined path elements
 function FileSystem.JoinPath( ... ) end
 
 ---@param dir_name string The name of the folder to create
@@ -40,10 +40,10 @@ function FileSystem.MakeDirectory( dir_name ) end
 --- > f = FileSystem.Open( "user://my_file.txt", "w" )
 --- > f:write( "file contents" )
 --- > f:close()
---- 
+---
 ---@param filename string   The name of the file to open, must start either user:// or data://
----@param mode string|nil   The mode to open the file in, defaults to read only. Only user location files can be written
----@return file             A lua io file
-function FileSystem.Open( filename ) end
+---@param mode string?      The mode to open the file in, defaults to read only. Only user location files can be written
+---@return file* file        A lua io file
+function FileSystem.Open( filename, mode ) end
 
 return FileSystem

--- a/scripts/scan_enums.py
+++ b/scripts/scan_enums.py
@@ -281,15 +281,17 @@ class EnumData:
     def write_meta_decl(s, fl):
         id = s.ident()
         fl.write('-- A <Constants.' + id + '> string\n')
-        fl.write('---@enum ' + id + '\n')
-        fl.write('Constants.' + id + ' = {\n')
+        fl.write('---@enum (key) ' + id + '\n')
+        fl.write('local ' + id + ' = {\n')
         index = 1
         for item in s.items:
             if item.skip: continue
-            id = item.name if item.name is not None else item.identifier
-            fl.write("\t[" + str(index) + "] = \"" + id + "\",\n" )
+            item_id = item.name if item.name is not None else item.identifier
+            fl.write("\t" + item_id + " = " + str(index) + ",\n" )
             index += 1
         fl.write("}\n\n")
+        fl.write('---@type ' + id + '[]\n')
+        fl.write('Constants.' + id + ' = {}\n\n')
 
 RX_ENUM_TAG = re.compile(r'<\s*enum((?:\s+[a-zA-Z_]+(?:=(\w+|\'[^\']*\'|"[^"]*"))?)*)\s*>')
 RX_ENUM_ATTR = re.compile(r'([a-zA-Z_]+)(?:=(\w+|\'[^\']*\'|"[^"]*"))?')


### PR DESCRIPTION
Lua-LS released a new `@enum (key)` annotation in version 3.7.0 which much better supports "string constants" as enum values. Functions which take an EnumStrings constant as a parameter will have full autocompletion for the list of constant values which make up that string enumeration, and the language server will render a diagnostic if an inappropriate enumeration value is used in that function call.

Note that at current, the effect of this change is limited to a very small subset of callsites where a) the function being called takes an EnumStrings constant, and b) full type information is available for the object the function is being called on.