### PR TITLE
Don't build against lzcnt by default and enable USE_SSE42 only on Intel architecture

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -133,41 +133,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         upload_release: true
 
-  build-gcc-avx:
-    runs-on: ubuntu-20.04
-
-    steps:
-    # Checkout the repository as $GITHUB_WORKSPACE
-    - uses: actions/checkout@v4
-
-    - name: Install Dependencies
-      run: |
-        sudo apt-fast update
-        sudo apt-fast install -y ${{ env.packages }}
-
-    - name: Setup CMake
-      run: |
-        echo "Project Version: $(echo "${{ github.ref }}" | awk -F '/' '/pull/ { print "PR#"$3 } /heads/ { print $3 }')"
-        cp scripts/CMakeBuildPresetsCI.json CMakeUserPresets.json
-        cmake -G Ninja --preset linux-x64-release-avx -DPROJECT_VERSION_INFO=$(echo "${{ github.ref }}" | awk -F '/' '/pull/ { print "PR#"$3 } /heads/ { print $3 }')
-
-    - name: Build GCC
-      run: cmake --build ./build --target all
-
-    - name: Build Pioneer Data
-      run: cmake --build ./build --target build-data
-
-    - name: Run Tests
-      run: ./build/unittest
-
-    - name: Generate Artifacts
-      uses: ./.github/actions/upload-linux
-      with:
-        artifact_name: Linux 64-bit (AVX2 enabled)
-        build_slug: linux-x64-release-avx
-        token: ${{ secrets.GITHUB_TOKEN }}
-        upload_release: true
-
   build-clang:
     runs-on: ubuntu-20.04
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(POLICY CMP0072)
 	cmake_policy(SET CMP0072 NEW)
 endif()
 
+include(cmake/TargetArchitecture.cmake)
 include(cmake/InstallPioneer.cmake)
 
 if (MINGW)
@@ -58,11 +59,11 @@ if (APPLE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu")
 endif(APPLE)
 
-option(USE_SSE42 "Compile for SSE4.2 compatible microarchitectures (enables optimizations)" ON)
+option(USE_SSE42 "Compile for SSE4.2 compatible microarchitectures (enables optimizations)" ${PIONEER_TARGET_INTEL})
 
 if (USE_SSE42)
 	if (NOT MSVC)
-		add_compile_options("-msse4.2" "-mlzcnt" "-mpopcnt")
+		add_compile_options("-msse4.2" "-mpopcnt")
 	endif()
 endif (USE_SSE42)
 
@@ -72,7 +73,7 @@ if (USE_AVX2)
 	if (MSVC)
 		add_compile_options("/arch:AVX2")
 	else()
-		add_compile_options("-mavx2")
+		add_compile_options("-mavx2" "-mlzcnt")
 	endif()
 endif(USE_AVX2)
 

--- a/cmake/TargetArchitecture.cmake
+++ b/cmake/TargetArchitecture.cmake
@@ -1,0 +1,26 @@
+# This script detects supported target architectures and configures test flags
+# accordingly
+
+if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+    set(TARGET_ARCH x86)
+else()
+    set(TARGET_ARCH x64)
+endif()
+
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+	set(TARGET_ARCH ARM64)
+endif()
+
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+	set(TARGET_ARCH ARM64)
+endif()
+
+if (TARGET_ARCH STREQUAL "x86" OR TARGET_ARCH STREQUAL "x64")
+	set(PIONEER_TARGET_ARM 0)
+	set(PIONEER_TARGET_INTEL 1)
+endif()
+
+if (TARGET_ARCH STREQUAL "ARM64")
+	set(PIONEER_TARGET_ARM 1)
+	set(PIONEER_TARGET_INTEL 0)
+endif()

--- a/cmake/TargetArchitecture.cmake
+++ b/cmake/TargetArchitecture.cmake
@@ -1,26 +1,10 @@
 # This script detects supported target architectures and configures test flags
 # accordingly
 
-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
-    set(TARGET_ARCH x86)
-else()
-    set(TARGET_ARCH x64)
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES x86|x64)
+	set(PIONEER_TARGET_INTEL ON)
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
-	set(TARGET_ARCH ARM64)
-endif()
-
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-	set(TARGET_ARCH ARM64)
-endif()
-
-if (TARGET_ARCH STREQUAL "x86" OR TARGET_ARCH STREQUAL "x64")
-	set(PIONEER_TARGET_ARM 0)
-	set(PIONEER_TARGET_INTEL 1)
-endif()
-
-if (TARGET_ARCH STREQUAL "ARM64")
-	set(PIONEER_TARGET_ARM 1)
-	set(PIONEER_TARGET_INTEL 0)
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES aarch64|ARM64)
+	set(PIONEER_TARGET_ARM64 ON)
 endif()


### PR DESCRIPTION
This PR addresses some slightly over-zealous feature enablement from the previous release cycle that we are not yet materially using. The build system now only defaults the USE_SSE42 flag to 'on' if we're compiling for a non-ARM64 target, and we no longer enable utilization of the `lzcnt` instruction for SSE4.2 builds - it was introduced in the Haswell microarchitecture alongside AVX2 and as such has been moved to that build option.

I've also added feature-test flags for the build script to use in the future to detect whether we're compiling for an ARM64 target or an Intel target (and whether we're compiling for 32 or 64-bit x86 architecture).