### PR TITLE
Invert illegal commodities icons in the Economy & Trade view. Fix #5876

### DIFF
--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -224,9 +224,9 @@ function SystemEconView:drawCommodityList(commList, illegalList, thisSystem, oth
 
 				-- only display illegal icon if the commodity is actually legal in the other system
 				if otherSystem and (info[2] or info[3]) then
-					drawIcon(SystemEconView.ClassifyPrice(info[2]), iconSize)
-					ui.sameLine(0, 0)
 					drawIcon(SystemEconView.ClassifyPrice(info[3]), iconSize)
+					ui.sameLine(0, 0)
+					drawIcon(SystemEconView.ClassifyPrice(info[2]), iconSize)
 				end
 			end)
 


### PR DESCRIPTION
To be coherent with the legal commodity list, the first icon must be for local system and the second for distant system.
That what this commit does.
Fixes #5876 