### PR TITLE
Added Perf-Info button to Dump a system to systemeditor compatible JSON

### DIFF
--- a/src/editor/system/SystemEditor.cpp
+++ b/src/editor/system/SystemEditor.cpp
@@ -222,7 +222,7 @@ bool SystemEditor::LoadSystemFromFile(const FileSystem::FileInfo &file)
 			ok = LoadCustomSystem(csys);
 
 		if (ok)
-			m_systemInfo.comment = data["comment"];
+			m_systemInfo.comment = data.value("comment", "");
 	} else if (ends_with_ci(file.GetPath(), ".lua")) {
 		const CustomSystem *csys = m_systemLoader->LoadSystem(file.GetPath());
 		if (csys)

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -413,9 +413,7 @@ void PerfInfo::DrawWorldViewStats()
 			RefCountedPtr<StarSystem> system = Pi::game->GetGalaxy()->GetStarSystem(path);
 
 			if (system) {
-				char fileName[1024];
-				sprintf(fileName, "%s.json", system->GetName().c_str());
-				const std::string fname = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(), fileName);
+				const std::string fname = FileSystem::JoinPathBelow(FileSystem::userFiles.GetRoot(), fmt::format("{}.json", system->GetName()));
 				FILE *f = fopen(fname.c_str(), "w");
 
 				if (f) {

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -421,9 +421,6 @@ void PerfInfo::DrawWorldViewStats()
 
 					system->DumpToJson(systemdef);
 
-					// required otherwise the system editor crashes when trying to load it
-					systemdef["comment"] = system->GetName();
-
 					std::string jsonData = systemdef.dump(1, '\t');
 
 					fwrite(jsonData.data(), 1, jsonData.size(), f);


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Whilst debugging #5885 and #5830 today I wanted a quick way of getting a dumped system into the system editor so I've added a 2nd button to the Perf-Info screen which already allowed dumping the JSON to the output log.

Instead it now generates a JSON file which can be directly loaded into the system editor for viewing / modification and outputs it into the users pioneer directory where screenshots, savefiles, etc folders are located.

This should also make it easier for people to create custom systems based on generated ones they've found interesting to make that process a little easier.
<!-- Please make sure you've read documentation on contributing -->

