### PR TITLE
Repopulate BBS if empty

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -901,9 +901,8 @@ end
 local function updateAdverts (station)
 	if not SpaceStation.adverts[station] then
 		logWarning("SpaceStation.lua: updateAdverts called for station that hasn't been visited")
-	else
-		Event.Queue("onUpdateBB", station)
 	end
+	Event.Queue("onUpdateBB", station)
 end
 
 --


### PR DESCRIPTION
There is an infrequent issue where the BBS will show up empty on a game reload as SpaceStation.adverts[station] is missing. This fix will cause the BBS to repopulate itself but only from those modules that impements onUpdateBB(). It will not solve the underlying cause.

Addresses #5886

