### PR TITLE
Improve PerfInfo debug window

### DIFF
--- a/data/modules/Debug/DebugCommodityPrices.lua
+++ b/data/modules/Debug/DebugCommodityPrices.lua
@@ -378,10 +378,9 @@ local function main()
 end
 
 
-debugView.registerTab("Commodities", function()
-  if Game.player == nil then return end
-  if ui.beginTabItem("Commodities") then
-	main()
-	ui.endTabItem()
-  end
-end)
+debugView.registerTab("debug-commodity-price", {
+	icon = ui.theme.icons.money,
+	label = "Commodities",
+	show = function() return Game.player ~= nil end,
+	draw = main
+})

--- a/data/modules/Debug/DebugRPG.lua
+++ b/data/modules/Debug/DebugRPG.lua
@@ -38,9 +38,11 @@ local get_commodities = function()
 	end
 end
 
-debugView.registerTab("RPG-debug-view", function()
-	if Game.player == nil then return end
-	if not ui.beginTabItem("RPG") then return end
+debugView.registerTab("RPG-debug-view", {
+	icon = ui.theme.icons.personal_info,
+	label = "RPG",
+	show = function() return Game.player ~= nil end,
+	draw = function()
 		ui.text("State: " .. Game.player:GetFlightState())
 
 		-- Reputation
@@ -52,7 +54,6 @@ debugView.registerTab("RPG-debug-view", function()
 		Character.persistent.player.killcount = ui.sliderInt("Kills", Character.persistent.player.killcount, 0, 6000)
 		ui.sameLine()
 		ui.text(Character.persistent.player:GetCombatRating())
-		ui.endTabItem()
 
 		-- Ship hull condition
 		local hull = ui.sliderInt("Hull", Game.player.hullPercent, 0, 100)
@@ -128,4 +129,5 @@ debugView.registerTab("RPG-debug-view", function()
 
 		end
 
-end)
+	end
+})

--- a/data/modules/Debug/DebugShipSpawn.lua
+++ b/data/modules/Debug/DebugShipSpawn.lua
@@ -168,11 +168,11 @@ ship_spawn_debug_window = function()
     ship = ShipDef[ship_name]
   end
   if not (ship) then
-    return 
+    return
   end
   ui.sameLine()
   return ui.group(function()
-    local spawner_group_height = ui.getFrameHeightWithSpacing() * 3 + ui.getTextLineHeightWithSpacing()
+    local spawner_group_height = ui.getFrameHeightWithSpacing() * 4
     ui.child('ship_info', Vector2(0, -spawner_group_height), function()
       draw_ship_info(ship)
       if ui.button("Set Player Ship Type", Vector2(0, 0)) then
@@ -221,18 +221,14 @@ ship_spawn_debug_window = function()
     spawn_distance = ui.sliderFloat("##spawn_distance", spawn_distance, 0.5, 20, "%.1fkm")
   end)
 end
-debug_ui.registerTab("Ship Spawner", function()
-  if not (Game.player and Game.CurrentView() == "world") then
-    return nil
-  end
-  if ui.beginTabItem("Ship Spawner") then
-    ship_spawn_debug_window()
-    ui.endTabItem()
-    if ui.isKeyReleased(string.byte('r')) and ui.ctrlHeld() then
-      return package.reimport('.DebugShipSpawn')
-    end
-  end
-end)
+debug_ui.registerTab("Ship Spawner", {
+  icon = ui.theme.icons.medium_courier,
+  label = "Ship Spawner",
+  show = function()
+    return Game.player and Game.CurrentView() == "world"
+  end,
+  draw = ship_spawn_debug_window
+})
 return ui.registerModule("game", function()
   if not (Game.CurrentView() == "world") then
     return nil

--- a/data/modules/Debug/DebugShipSpawn.moon
+++ b/data/modules/Debug/DebugShipSpawn.moon
@@ -128,7 +128,7 @@ ship_spawn_debug_window = ->
 
     ui.sameLine!
 	ui.group ->
-		spawner_group_height = ui.getFrameHeightWithSpacing! * 3 + ui.getTextLineHeightWithSpacing!
+		spawner_group_height = ui.getFrameHeightWithSpacing! * 4
         ui.child 'ship_info', Vector2(0, -spawner_group_height), ->
 			draw_ship_info ship
 			if ui.button "Set Player Ship Type", Vector2(0, 0)
@@ -172,17 +172,12 @@ ship_spawn_debug_window = ->
 		ui.nextItemWidth -1.0
 		spawn_distance = ui.sliderFloat("##spawn_distance", spawn_distance, 0.5, 20, "%.1fkm")
 
-debug_ui.registerTab "Ship Spawner", ->
-	unless Game.player and Game.CurrentView() == "world" -- when not in a game, Game.player will return nil
-		return nil
-
-	if ui.beginTabItem "Ship Spawner"
-		ship_spawn_debug_window!
-
-		ui.endTabItem!
-
-		if ui.isKeyReleased(string.byte 'r') and ui.ctrlHeld!
-			package.reimport '.DebugShipSpawn'
+debug_ui.registerTab "Ship Spawner", {
+	icon: ui.theme.icons.medium_courier
+	label: "Ship Spawner"
+	show: -> Game.player and Game.CurrentView() == "world"
+	draw: ship_spawn_debug_window
+}
 
 ui.registerModule "game", ->
 	unless Game.CurrentView() == "world"

--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -457,19 +457,19 @@ Event.Register("onGameEnd", onGameEnd)
 Serializer:Register("NewsEventCommodity", serialize, unserialize)
 
 
-debugView.registerTab(
-	"News", function ()
-		if Game.player == nil then return end
-		if not ui.beginTabItem("News") then return end
-
-		ui.textWrapped("Note: Display of News on the BBS will not update until docking at new station")
+debugView.registerTab("news", {
+	label = "News",
+	icon = ui.theme.icons.info,
+	show = function() return Game.player end,
+	draw = function ()
+		ui.textWrapped("Note: Display of News on the BBS will not update until docking at new station.")
 		if ui.button("Make News", Vector2(100, 0)) then
 			createNewsEvent(0)
 		end
 		ui.sameLine()
-		ui.text("Radius: " .. maxDist .. " ly. (Usually no News before: " .. Format.DateOnly(minTime) ..")")
-		ui.sameLine()
-		ui.text("and max simultaneous news events: " .. maxNumberNews)
+		ui.text("Radius: " .. maxDist .. " ly.")
+
+		ui.textWrapped("There are usually no News before: " .. Format.DateOnly(minTime) .." and max simultaneous news events: " .. maxNumberNews)
 
 		for i ,n in pairs(news) do
 			local system_name = n.syspath:GetStarSystem().name
@@ -489,7 +489,8 @@ debugView.registerTab(
 						cargo = commodity_name,
 						date  = Format.DateOnly(n.date),
 				})
-				ui.text(headline)
+				ui.textWrapped(headline)
+				ui.spacing()
 
 				local newsbody = string.interp(
 					flavours[n.flavour].newsbody,
@@ -517,4 +518,5 @@ debugView.registerTab(
 				ui.separator()
 			end
 		end
-end)
+	end
+})

--- a/data/modules/TradeShips/Debug.lua
+++ b/data/modules/TradeShips/Debug.lua
@@ -54,305 +54,307 @@ local statuses = {
 	'unknown'
 }
 
-debugView.registerTab('debug-trade-ships', function()
-	if not Core.ships and not Core.params or not Game.system then return end
-	if not ui.beginTabItem("Tradeships") then return end
+debugView.registerTab('debug-trade-ships', {
+	icon = ui.theme.icons.heavy_freighter,
+	label = "Tradeships",
+	show = function() return Game.system and Core.ships and Core.params end,
+	draw = function()
 
-	local function property(key, value)
-		ui.withStyleColors({["Text"] = ui.theme.colors.fontDark}, function()
-			ui.text(key)
-		end)
-		ui.sameLine()
-		ui.text(value)
-	end
-
-	ui.child("tradeships_as_child", Vector2(-1, -infosize), {"NoSavedSettings", "HorizontalScrollbar"}, function()
-		if Core.params then
-		if ui.collapsingHeader("System summary", {"DefaultOpen"}) then
-			local precalculated = {}
-			if Core.params.spawn_in then
-				for _, param in ipairs(Core.params.spawn_in) do
-					precalculated[param[1]] = param[2]
-				end
-			end
-			local number_of = {}
-			for _, status in ipairs(statuses) do
-				number_of[status] = 0
-			end
-			local total_ships = 0
-			for _, trader in pairs(Core.ships) do
-				if number_of[trader.status] then
-					number_of[trader.status] = number_of[trader.status] + 1
-				else
-					number_of['unknown'] = number_of['unknown'] + 1
-				end
-				total_ships = total_ships + 1
-			end
-
-			arrayTable.draw("tradeships_statuses", statuses, arrayTable.addKeys(ipairs, {
-				ships_fact = function(_,v) return number_of[v] end,
-				ships_proj = function(_,v) return precalculated[v] end,
-				ratio      = function(_,v) return precalculated[v] and number_of[v] / precalculated[v] * 100 end
-			}),{
-				{ name = "Status",     key = 1,            string = true          },
-				{ name = "Current",    key = "ships_fact",                        },
-				{ name = "Calculated", key = "ships_proj", fnc = format("%.2f")   },
-				{ name = "%",          key = "ratio",      fnc = format("%.2f%%") }
-			},{
-				totals = {{status = "Total", ships_fact = total_ships}}
-			})
-			ui.separator()
-			property("Total flow", string.format("%.2f ship/hour", Core.params.total_flow))
+		local function property(key, value)
+			ui.withStyleColors({["Text"] = ui.theme.colors.fontDark}, function()
+				ui.text(key)
+			end)
 			ui.sameLine()
-			property("Last spawn interval", ui.Format.Duration(Core.last_spawn_interval))
-			ui.sameLine()
-			property("Lawlessness", string.format("%.4f", Game.system.lawlessness))
-			ui.sameLine()
-			property("Total bodies in space", Space.GetNumBodies())
+			ui.text(value)
 		end
 
-		if ui.collapsingHeader("Stations") then
-			local totals = {docks = 0, busy_s = 0, landed = 0, flow = 0}
-			-- count the inbound ships
-			local inbound = {}
-			for _, trader in pairs(Core.ships) do
-				local s = trader.status == 'inbound' and trader.starport
-				if s then
-					if inbound[s] then inbound[s] = inbound[s] + 1
-					else inbound[s] = 1
+		ui.child("tradeships_as_child", Vector2(-1, -infosize), {"NoSavedSettings", "HorizontalScrollbar"}, function()
+			if Core.params then
+			if ui.collapsingHeader("System summary", {"DefaultOpen"}) then
+				local precalculated = {}
+				if Core.params.spawn_in then
+					for _, param in ipairs(Core.params.spawn_in) do
+						precalculated[param[1]] = param[2]
 					end
 				end
-			end
-			totals.label = "Total for " .. utils.count(Core.params.port_params) .. " ports"
-			local obj = Game.systemView:GetSelectedObject()
-			local sb_selected = obj.type == Engine.GetEnumValue("ProjectableTypes", "OBJECT") and obj.base == Engine.GetEnumValue("ProjectableBases", "SYSTEMBODY")
-			arrayTable.draw("tradeships_stationinfo2", Core.params.port_params, arrayTable.addKeys(pairs, {
-				port =    function(k,_) return k end,
-				label =   function(k,_) return k:GetLabel() end,
-				parent =  function(k,_) return k:GetSystemBody().parent.name end,
-				dist =    function(k,_) return k:DistanceTo(k:GetSystemBody().nearestJumpable.body) end,
-				docks =   function(k,_) totals.docks = totals.docks + k.numDocks return k.numDocks end,
-				busy_s =  function(k,_) totals.busy_s = totals.busy_s + k.numShipsDocked return k.numShipsDocked end,
-				inbound = function(k,_) return inbound[k] end,
-				landed =  function(_,v) totals.landed = totals.landed + v.landed return v.landed end,
-				flow =    function(_,v) totals.flow = totals.flow + v.flow return v.flow end
-			}),{
-				{ name = "Port",       key = "label",  string = true               },
-				{ name = "Parent",     key = "parent", string = true               },
-				{ name = "Distance",   key = "dist",   fnc = distanceInAU          },
-				{ name = "Docks",      key = "docks"                               },
-				{ name = "Busy",       key = "busy",   fnc = format("%.2f")        },
-				{ name = "Landed",     key = "busy_s"                              },
-				{ name = "Calculated", key = "landed", fnc = format("%.2f")        },
-				{ name = "Dock time",  key = "time",   fnc = format("%.2fh")       },
-				{ name = "Inbound",    key = "inbound"                             },
-				{ name = "Ship flow",  key = "flow",   fnc = format("%.2f ship/h") },
-			},{
-				totals = { totals },
-				callbacks = {
-					onClick = function(row)
-						Game.systemView:SetSelectedObject(Engine.GetEnumValue("ProjectableTypes", "OBJECT"),
-							Engine.GetEnumValue("ProjectableBases", "SYSTEMBODY"), row.port:GetSystemBody())
-					end,
-					isSelected = function(row)
-						return sb_selected and Game.systemView:GetSelectedObject().ref == row.port:GetSystemBody()
+				local number_of = {}
+				for _, status in ipairs(statuses) do
+					number_of[status] = 0
+				end
+				local total_ships = 0
+				for _, trader in pairs(Core.ships) do
+					if number_of[trader.status] then
+						number_of[trader.status] = number_of[trader.status] + 1
+					else
+						number_of['unknown'] = number_of['unknown'] + 1
 					end
-				}})
-		end
+					total_ships = total_ships + 1
+				end
 
-		if ui.collapsingHeader("Local routes") then
-			for shipname, params in pairs(Core.params.local_routes) do
-				ui.text("  ")
+				arrayTable.draw("tradeships_statuses", statuses, arrayTable.addKeys(ipairs, {
+					ships_fact = function(_,v) return number_of[v] end,
+					ships_proj = function(_,v) return precalculated[v] end,
+					ratio      = function(_,v) return precalculated[v] and number_of[v] / precalculated[v] * 100 end
+				}),{
+					{ name = "Status",     key = 1,            string = true          },
+					{ name = "Current",    key = "ships_fact",                        },
+					{ name = "Calculated", key = "ships_proj", fnc = format("%.2f")   },
+					{ name = "%",          key = "ratio",      fnc = format("%.2f%%") }
+				},{
+					totals = {{status = "Total", ships_fact = total_ships}}
+				})
+				ui.separator()
+				property("Total flow", string.format("%.2f ship/hour", Core.params.total_flow))
 				ui.sameLine()
-				if ui.treeNode(shipname .. " (" .. #params .. ")") then
-					arrayTable.draw("tradeships_" .. shipname .. "_info", params, ipairs, {
-						{ name = "From",     key = "from",     fnc = method("GetLabel"), string = true },
-						{ name = "To",       key = "to",       fnc = method("GetLabel"), string = true },
-						{ name = "Duration", key = "duration", fnc = ui.Format.Duration                },
-						{ name = "Distance", key = "distance", fnc = distanceInAU                      }
-					})
-					ui.treePop()
-				end
+				property("Last spawn interval", ui.Format.Duration(Core.last_spawn_interval))
+				ui.sameLine()
+				property("Lawlessness", string.format("%.4f", Game.system.lawlessness))
+				ui.sameLine()
+				property("Total bodies in space", Space.GetNumBodies())
 			end
-		end
 
-		if ui.collapsingHeader("Hyperspace routes") then
-			local function sysName(path)
-				return path:GetStarSystem().name
-			end
-			local selected_in_sectorview = Game.sectorView:GetSelectedSystemPath()
-			for shipname, params in pairs(Core.params.hyper_routes) do
-				if ui.treeNode(shipname .. " (" .. #params .. ")") then
-					arrayTable.draw("tradeships_" .. shipname .. "_hyperinfo", params, ipairs, {
-						{ name = "From",           key = "from",           fnc = sysName,             string = true },
-						{ name = "Distance",       key = "distance",       fnc = format("%.2f l.y.")                },
-						{ name = "Fuel",           key = "fuel",           fnc = format("%.2f t")                   },
-						{ name = "Duration",       key = "duration",       fnc = ui.Format.Duration                 },
-						{ name = "Cloud Duration", key = "cloud_duration", fnc = ui.Format.Duration                 }
-					},{
-						callbacks = {
-							onClick = function(row)
-								Game.sectorView:SwitchToPath(row.from)
-							end,
-							isSelected = function(row)
-								return row.from:IsSameSystem(selected_in_sectorview)
-							end
-						}})
-					ui.treePop()
-				end
-			end
-		end
-		end
-
-		if ui.collapsingHeader("All ships") then
-			local ships = {}
-			for ship, trader in pairs(Core.ships) do
-				if ship:exists() then
-					table.insert(ships, {
-						ship = ship,
-						label = ship:GetLabel(),
-						status = trader.status,
-						ts_error = trader.ts_error,
-						cargo = ship.usedCargo,
-						ai = ship:GetCurrentAICommand(),
-						model = ship.shipId,
-						port = trader.starport and trader.starport:GetLabel()
-					})
-				end
-			end
-			local obj = Game.systemView:GetSelectedObject()
-			local ship_selected = obj.type == Engine.GetEnumValue("ProjectableTypes", "OBJECT") and obj.base == Engine.GetEnumValue("ProjectableBases", "SHIP")
-			arrayTable.draw("tradeships_all", ships, ipairs, {
-				{ name = "#",      key = "#"                       },
-				{ name = "Label",  key = "label",    string = true },
-				{ name = "Model",  key = "model",    string = true },
-				{ name = "Status", key = "status",   string = true },
-				{ name = "Error",  key = "ts_error", string = true },
-				{ name = "Cargo",  key = "cargo"                   },
-				{ name = "AI",     key = "ai",       string = true },
-				{ name = "Port",   key = "port",     string = true }
-			},
-			{ callbacks = {
-				onClick = function(row)
-					if row.status ~= "hyperspace" and row.status ~= "hyperspace_out" then
-						Game.systemView:SetSelectedObject(Engine.GetEnumValue("ProjectableTypes", "OBJECT"),
-							Engine.GetEnumValue("ProjectableBases", "SHIP"), row.ship)
+			if ui.collapsingHeader("Stations") then
+				local totals = {docks = 0, busy_s = 0, landed = 0, flow = 0}
+				-- count the inbound ships
+				local inbound = {}
+				for _, trader in pairs(Core.ships) do
+					local s = trader.status == 'inbound' and trader.starport
+					if s then
+						if inbound[s] then inbound[s] = inbound[s] + 1
+						else inbound[s] = 1
+						end
 					end
-				end,
-				isSelected = function(row)
-					return ship_selected and Game.systemView:GetSelectedObject().ref == row.ship
 				end
-			}
-			})
-		end
-		if ui.collapsingHeader("Log") then
-			local obj = Game.systemView:GetSelectedObject()
-			local ship_selected = obj.type == Engine.GetEnumValue("ProjectableTypes", "OBJECT") and obj.base == Engine.GetEnumValue("ProjectableBases", "SHIP")
-			search_text, _ = ui.inputText("Search log", search_text, {})
-			arrayTable.draw("tradeships_log", Core.log, Core.log.iter(search_text ~= "" and function (row)
-				return
-					row.label and string.match(row.label, search_text) or
-					row.msg and string.match(row.msg, search_text) or
-					row.model and string.match(row.model, search_text)
-			end),{
-				{ name = "Time",    key = "time" , fnc = ui.Format.Datetime },
-				{ name = "Label",   key = "label", string = true            },
-				{ name = "Model",   key = "model", string = true            },
-				{ name = "Message", key = "msg",   string = true            }
-			},{
-				callbacks = {
+				totals.label = "Total for " .. utils.count(Core.params.port_params) .. " ports"
+				local obj = Game.systemView:GetSelectedObject()
+				local sb_selected = obj.type == Engine.GetEnumValue("ProjectableTypes", "OBJECT") and obj.base == Engine.GetEnumValue("ProjectableBases", "SYSTEMBODY")
+				arrayTable.draw("tradeships_stationinfo2", Core.params.port_params, arrayTable.addKeys(pairs, {
+					port =    function(k,_) return k end,
+					label =   function(k,_) return k:GetLabel() end,
+					parent =  function(k,_) return k:GetSystemBody().parent.name end,
+					dist =    function(k,_) return k:DistanceTo(k:GetSystemBody().nearestJumpable.body) end,
+					docks =   function(k,_) totals.docks = totals.docks + k.numDocks return k.numDocks end,
+					busy_s =  function(k,_) totals.busy_s = totals.busy_s + k.numShipsDocked return k.numShipsDocked end,
+					inbound = function(k,_) return inbound[k] end,
+					landed =  function(_,v) totals.landed = totals.landed + v.landed return v.landed end,
+					flow =    function(_,v) totals.flow = totals.flow + v.flow return v.flow end
+				}),{
+					{ name = "Port",       key = "label",  string = true               },
+					{ name = "Parent",     key = "parent", string = true               },
+					{ name = "Distance",   key = "dist",   fnc = distanceInAU          },
+					{ name = "Docks",      key = "docks"                               },
+					{ name = "Busy",       key = "busy",   fnc = format("%.2f")        },
+					{ name = "Landed",     key = "busy_s"                              },
+					{ name = "Calculated", key = "landed", fnc = format("%.2f")        },
+					{ name = "Dock time",  key = "time",   fnc = format("%.2fh")       },
+					{ name = "Inbound",    key = "inbound"                             },
+					{ name = "Ship flow",  key = "flow",   fnc = format("%.2f ship/h") },
+				},{
+					totals = { totals },
+					callbacks = {
+						onClick = function(row)
+							Game.systemView:SetSelectedObject(Engine.GetEnumValue("ProjectableTypes", "OBJECT"),
+								Engine.GetEnumValue("ProjectableBases", "SYSTEMBODY"), row.port:GetSystemBody())
+						end,
+						isSelected = function(row)
+							return sb_selected and Game.systemView:GetSelectedObject().ref == row.port:GetSystemBody()
+						end
+					}})
+			end
+
+			if ui.collapsingHeader("Local routes") then
+				for shipname, params in pairs(Core.params.local_routes) do
+					ui.text("  ")
+					ui.sameLine()
+					if ui.treeNode(shipname .. " (" .. #params .. ")") then
+						arrayTable.draw("tradeships_" .. shipname .. "_info", params, ipairs, {
+							{ name = "From",     key = "from",     fnc = method("GetLabel"), string = true },
+							{ name = "To",       key = "to",       fnc = method("GetLabel"), string = true },
+							{ name = "Duration", key = "duration", fnc = ui.Format.Duration                },
+							{ name = "Distance", key = "distance", fnc = distanceInAU                      }
+						})
+						ui.treePop()
+					end
+				end
+			end
+
+			if ui.collapsingHeader("Hyperspace routes") then
+				local function sysName(path)
+					return path:GetStarSystem().name
+				end
+				local selected_in_sectorview = Game.sectorView:GetSelectedSystemPath()
+				for shipname, params in pairs(Core.params.hyper_routes) do
+					if ui.treeNode(shipname .. " (" .. #params .. ")") then
+						arrayTable.draw("tradeships_" .. shipname .. "_hyperinfo", params, ipairs, {
+							{ name = "From",           key = "from",           fnc = sysName,             string = true },
+							{ name = "Distance",       key = "distance",       fnc = format("%.2f l.y.")                },
+							{ name = "Fuel",           key = "fuel",           fnc = format("%.2f t")                   },
+							{ name = "Duration",       key = "duration",       fnc = ui.Format.Duration                 },
+							{ name = "Cloud Duration", key = "cloud_duration", fnc = ui.Format.Duration                 }
+						},{
+							callbacks = {
+								onClick = function(row)
+									Game.sectorView:SwitchToPath(row.from)
+								end,
+								isSelected = function(row)
+									return row.from:IsSameSystem(selected_in_sectorview)
+								end
+							}})
+						ui.treePop()
+					end
+				end
+			end
+			end
+
+			if ui.collapsingHeader("All ships") then
+				local ships = {}
+				for ship, trader in pairs(Core.ships) do
+					if ship:exists() then
+						table.insert(ships, {
+							ship = ship,
+							label = ship:GetLabel(),
+							status = trader.status,
+							ts_error = trader.ts_error,
+							cargo = ship.usedCargo,
+							ai = ship:GetCurrentAICommand(),
+							model = ship.shipId,
+							port = trader.starport and trader.starport:GetLabel()
+						})
+					end
+				end
+				local obj = Game.systemView:GetSelectedObject()
+				local ship_selected = obj.type == Engine.GetEnumValue("ProjectableTypes", "OBJECT") and obj.base == Engine.GetEnumValue("ProjectableBases", "SHIP")
+				arrayTable.draw("tradeships_all", ships, ipairs, {
+					{ name = "#",      key = "#"                       },
+					{ name = "Label",  key = "label",    string = true },
+					{ name = "Model",  key = "model",    string = true },
+					{ name = "Status", key = "status",   string = true },
+					{ name = "Error",  key = "ts_error", string = true },
+					{ name = "Cargo",  key = "cargo"                   },
+					{ name = "AI",     key = "ai",       string = true },
+					{ name = "Port",   key = "port",     string = true }
+				},
+				{ callbacks = {
 					onClick = function(row)
-						local status = Core.ships[row.ship] and Core.ships[row.ship].status
-						if status and status ~= "hyperspace" and status ~= "hyperspace_out" then
+						if row.status ~= "hyperspace" and row.status ~= "hyperspace_out" then
 							Game.systemView:SetSelectedObject(Engine.GetEnumValue("ProjectableTypes", "OBJECT"),
 								Engine.GetEnumValue("ProjectableBases", "SHIP"), row.ship)
 						end
 					end,
 					isSelected = function(row)
-						return ship_selected and obj.ref == row.ship
+						return ship_selected and Game.systemView:GetSelectedObject().ref == row.ship
 					end
-				}})
-		end
-	end)
-
-
-	infosize = ui.getCursorScreenPos().y
-	local obj = Game.systemView:GetSelectedObject()
-	if obj.type ~= Engine.GetEnumValue("ProjectableTypes", "NONE") and Core.ships[obj.ref] then
-		local ship = obj.ref
-		local trader = Core.ships[ship]
-
-		if ui.collapsingHeader("Info:", {"DefaultOpen"}) then
-			property("Trader: ", ship:GetShipType() .. " " .. ship:GetLabel())
-
-			local status = trader.status
-			if status == "docked" then
-				status = status .. " (" .. trader.starport:GetLabel() .. ")"
-			elseif status == "inbound" then
-				local d = ui.Format.Distance(ship:DistanceTo(trader.starport))
-				status = status .. " (" .. trader.starport:GetLabel() .. " - " .. d .. ")"
-			end
-			property("Status: ", status)
-
-			if trader.fnc then
-				property("Task: ", trader.fnc .. " in " .. ui.Format.Duration(trader.delay - Game.time))
-			end
-			property("Fuel: ", string.format("%.4f", ship.fuelMassLeft) .. "/" .. ShipDef[ship.shipId].fuelTankMass .. " t")
-		end
-
-		if ui.collapsingHeader("Internals:", {"DefaultOpen"}) then
-			local equipItems = {}
-			local total_mass = 0
-
-			local equips = { "misc", "hyperspace", "laser" }
-			for _,t in ipairs(equips) do
-				for _,et in pairs(e[t]) do
-					local count = ship:CountEquip(et)
-					if count > 0 then
-						local all_mass = count * et.capabilities.mass
-						table.insert(equipItems, {
-							name = et:GetName(),
-							eq_type = t,
-							count = count,
-							mass = et.capabilities.mass,
-							all_mass = all_mass
-						})
-						total_mass = total_mass + all_mass
-					end
-				end
-			end
-
-			---@type CargoManager
-			local cargoMgr = ship:GetComponent('CargoManager')
-
-			for name, info in pairs(cargoMgr.commodities) do
-				local ct = CommodityType.GetCommodity(name)
-				total_mass = total_mass + ct.mass * info.count
-				table.insert(equipItems, {
-					name = ct:GetName(),
-					eq_type = "cargo",
-					count = info.count,
-					mass = ct.mass,
-					all_mass = ct.mass * info.count
+				}
 				})
 			end
+			if ui.collapsingHeader("Log") then
+				local obj = Game.systemView:GetSelectedObject()
+				local ship_selected = obj.type == Engine.GetEnumValue("ProjectableTypes", "OBJECT") and obj.base == Engine.GetEnumValue("ProjectableBases", "SHIP")
+				search_text, _ = ui.inputText("Search log", search_text, {})
+				arrayTable.draw("tradeships_log", Core.log, Core.log.iter(search_text ~= "" and function (row)
+					return
+						row.label and string.match(row.label, search_text) or
+						row.msg and string.match(row.msg, search_text) or
+						row.model and string.match(row.model, search_text)
+				end),{
+					{ name = "Time",    key = "time" , fnc = ui.Format.Datetime },
+					{ name = "Label",   key = "label", string = true            },
+					{ name = "Model",   key = "model", string = true            },
+					{ name = "Message", key = "msg",   string = true            }
+				},{
+					callbacks = {
+						onClick = function(row)
+							local status = Core.ships[row.ship] and Core.ships[row.ship].status
+							if status and status ~= "hyperspace" and status ~= "hyperspace_out" then
+								Game.systemView:SetSelectedObject(Engine.GetEnumValue("ProjectableTypes", "OBJECT"),
+									Engine.GetEnumValue("ProjectableBases", "SHIP"), row.ship)
+							end
+						end,
+						isSelected = function(row)
+							return ship_selected and obj.ref == row.ship
+						end
+					}})
+			end
+		end)
 
-			local capacity = ShipDef[ship.shipId].capacity
 
-			arrayTable.draw("tradeships_traderequipment", equipItems, ipairs, {
-				{ name = "Name",        key = "name",     string = true       },
-				{ name = "Type",        key = "eq_type",  string = true       },
-				{ name = "Units",       key = "count"                         },
-				{ name = "Unit's mass", key = "mass",     fnc = format("%dt") },
-				{ name = "Total",       key = "all_mass", fnc = format("%dt") }
-			},
-			{ totals = {
-				{ name = "Total:",    all_mass = total_mass            },
-				{ name = "Capacity:", all_mass = capacity              },
-				{ name = "Free:",     all_mass = capacity - total_mass },
-			}})
+		infosize = ui.getCursorScreenPos().y
+		local obj = Game.systemView:GetSelectedObject()
+		if obj.type ~= Engine.GetEnumValue("ProjectableTypes", "NONE") and Core.ships[obj.ref] then
+			local ship = obj.ref
+			local trader = Core.ships[ship]
+
+			if ui.collapsingHeader("Info:", {"DefaultOpen"}) then
+				property("Trader: ", ship:GetShipType() .. " " .. ship:GetLabel())
+
+				local status = trader.status
+				if status == "docked" then
+					status = status .. " (" .. trader.starport:GetLabel() .. ")"
+				elseif status == "inbound" then
+					local d = ui.Format.Distance(ship:DistanceTo(trader.starport))
+					status = status .. " (" .. trader.starport:GetLabel() .. " - " .. d .. ")"
+				end
+				property("Status: ", status)
+
+				if trader.fnc then
+					property("Task: ", trader.fnc .. " in " .. ui.Format.Duration(trader.delay - Game.time))
+				end
+				property("Fuel: ", string.format("%.4f", ship.fuelMassLeft) .. "/" .. ShipDef[ship.shipId].fuelTankMass .. " t")
+			end
+
+			if ui.collapsingHeader("Internals:", {"DefaultOpen"}) then
+				local equipItems = {}
+				local total_mass = 0
+
+				local equips = { "misc", "hyperspace", "laser" }
+				for _,t in ipairs(equips) do
+					for _,et in pairs(e[t]) do
+						local count = ship:CountEquip(et)
+						if count > 0 then
+							local all_mass = count * et.capabilities.mass
+							table.insert(equipItems, {
+								name = et:GetName(),
+								eq_type = t,
+								count = count,
+								mass = et.capabilities.mass,
+								all_mass = all_mass
+							})
+							total_mass = total_mass + all_mass
+						end
+					end
+				end
+
+				---@type CargoManager
+				local cargoMgr = ship:GetComponent('CargoManager')
+
+				for name, info in pairs(cargoMgr.commodities) do
+					local ct = CommodityType.GetCommodity(name)
+					total_mass = total_mass + ct.mass * info.count
+					table.insert(equipItems, {
+						name = ct:GetName(),
+						eq_type = "cargo",
+						count = info.count,
+						mass = ct.mass,
+						all_mass = ct.mass * info.count
+					})
+				end
+
+				local capacity = ShipDef[ship.shipId].capacity
+
+				arrayTable.draw("tradeships_traderequipment", equipItems, ipairs, {
+					{ name = "Name",        key = "name",     string = true       },
+					{ name = "Type",        key = "eq_type",  string = true       },
+					{ name = "Units",       key = "count"                         },
+					{ name = "Unit's mass", key = "mass",     fnc = format("%dt") },
+					{ name = "Total",       key = "all_mass", fnc = format("%dt") }
+				},
+				{ totals = {
+					{ name = "Total:",    all_mass = total_mass            },
+					{ name = "Capacity:", all_mass = capacity              },
+					{ name = "Free:",     all_mass = capacity - total_mass },
+				}})
+			end
 		end
+		infosize = ui.getCursorScreenPos().y - infosize
 	end
-	infosize = ui.getCursorScreenPos().y - infosize
-	ui.endTabItem()
-end)
+})

--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -603,6 +603,36 @@ function ui.tabBarFont(id, items, font, ...)
 end
 
 --
+-- Function: ui.tabItem
+--
+-- ui.tabItem(label, [tooltip], function)
+--
+--
+-- Example:
+--
+-- > ui.tabItem("Test", "This Does Something", function() ... end)
+--
+-- Parameters:
+--   label   - string, Display label and unique ID for the tab.
+--   tooltip - string?, Tooltip to display when hovering the tab.
+--   fun     - function, Body code of the tab item
+--
+function ui.tabItem(label, tooltip, fun)
+	if not fun then
+		fun = tooltip
+		tooltip = nil
+	end
+
+	local open = pigui.BeginTabItem(label)
+	if tooltip then ui.setItemTooltip(tooltip) end
+	if not open then return end
+
+	fun()
+
+	pigui.EndTabItem()
+end
+
+--
 -- Function: ui.withFont
 --
 -- ui.withFont(name, size, fun)

--- a/data/pigui/modules/theme-debug.lua
+++ b/data/pigui/modules/theme-debug.lua
@@ -13,22 +13,24 @@ for name in pairs(styleColors) do table.insert(sortedStyleColors, name) end
 table.sort(sortedColors)
 table.sort(sortedStyleColors)
 
-debugView.registerTab('debug-theme-colors', function()
-	if not ui.beginTabItem("Theme Colors") then return end
-	ui.text("Palette Colors")
-	ui.separator()
-	for _, name in ipairs(sortedStyleColors) do
-		local changed, ncolor = ui.colorEdit(name, styleColors[name], { "NoAlpha" })
-		-- if we're changing semantic colors, we want to update all uses of the color object
-		if changed then styleColors[name](ncolor.r, ncolor.g, ncolor.b) end
-	end
+debugView.registerTab('debug-theme-colors', {
+	icon = ui.theme.icons.view_internal,
+	label = "Theme Colors",
+	draw = function()
+		ui.text("Palette Colors")
+		ui.separator()
+		for _, name in ipairs(sortedStyleColors) do
+			local changed, ncolor = ui.colorEdit(name, styleColors[name], { "NoAlpha" })
+			-- if we're changing semantic colors, we want to update all uses of the color object
+			if changed then styleColors[name](ncolor.r, ncolor.g, ncolor.b) end
+		end
 
-	ui.newLine()
-	ui.text("Semantic Colors")
-	ui.separator()
-	for _, name in ipairs(sortedColors) do
-		local changed, color = ui.colorEdit(name, colors[name])
-		if changed then colors[name] = color end
+		ui.newLine()
+		ui.text("Semantic Colors")
+		ui.separator()
+		for _, name in ipairs(sortedColors) do
+			local changed, color = ui.colorEdit(name, colors[name])
+			if changed then colors[name] = color end
+		end
 	end
-	ui.endTabItem()
-end)
+})

--- a/data/pigui/views/debug.lua
+++ b/data/pigui/views/debug.lua
@@ -4,23 +4,51 @@
 local ui = require 'pigui'
 
 local debugView = {
-	tabs = {},
-	modules = {}
+	tabs = {}
 }
 
-function debugView.registerModule(name, module)
-	if type(module) == "table" then
-		module = function(...) return module:draw(...) end
-	end
-
-	local index = debugView.modules[name] or #debugView.modules + 1
-	debugView.modules[index] = module
-	debugView.modules[name] = index
+local function encode_icon(idx)
+	idx = idx + 0xF000
+	return string.char(
+		0xe0 + bit32.rshift(idx, 12),
+		0x80 + bit32.band(bit32.rshift(idx, 6), 0x3f),
+		0x80 + bit32.band(idx, 0x3f))
 end
 
+local childWindowFlags = ui.WindowFlags { "NoSavedSettings", "NoBackground" }
+
+local function drawTab(tab, i, delta)
+	local icon = tab.icon or ui.theme.icons.alert_generic
+	local label = tab.label or ""
+	local icon_str = "{}##{}" % { encode_icon(icon), i }
+
+	ui.tabItem(icon_str, label, function()
+		ui.child(label, Vector2(0, 0), childWindowFlags, function()
+			tab.draw(delta)
+		end)
+	end)
+end
+
+---@class Debug.DebugTab
+---@field icon integer Icon of the debug tab in the tab bar
+---@field label string? Tooltip for the tab item
+---@field show function? Return true if the tab should be visible
+---@field draw function Render the contents of the debug tab
+---@field module string? Module name to hot reload, automatically filled
+
+-- Register a new tab to the debug view
+---@param name string
+---@param tab Debug.DebugTab
 function debugView.registerTab(name, tab)
-	if type(tab) == "table" then
-		tab = function(...) return tab:draw(...) end
+	if type(tab) == "function" then
+		tab = {
+			icon = ui.theme.icons.alert_generic,
+			draw = tab
+		}
+	end
+
+	if not tab.module then
+		tab.module = package.modulename(2)
 	end
 
 	local index = debugView.tabs[name] or #debugView.tabs + 1
@@ -28,19 +56,19 @@ function debugView.registerTab(name, tab)
 	debugView.tabs[name] = index
 end
 
-function debugView.render(delta)
-	for i, f in ipairs(debugView.modules) do
-		f(delta)
-	end
-end
-
 function debugView.drawTabs(delta)
-	for i, f in ipairs(debugView.tabs) do
-		f(delta)
+	for i, tab in ipairs(debugView.tabs) do
+		if not tab.show or tab.show() then
+			drawTab(tab, i, delta)
+
+			if ui.ctrlHeld() and ui.isKeyReleased(string.byte 'r') then
+				print("Hot reloading module " .. tab.module)
+				package.reimport(tab.module)
+			end
+		end
 	end
 end
 
-ui.registerHandler('debug', debugView.render)
 ui.registerHandler('debug-tabs', debugView.drawTabs)
 
 return debugView

--- a/data/pigui/views/debug.lua
+++ b/data/pigui/views/debug.lua
@@ -7,20 +7,12 @@ local debugView = {
 	tabs = {}
 }
 
-local function encode_icon(idx)
-	idx = idx + 0xF000
-	return string.char(
-		0xe0 + bit32.rshift(idx, 12),
-		0x80 + bit32.band(bit32.rshift(idx, 6), 0x3f),
-		0x80 + bit32.band(idx, 0x3f))
-end
-
 local childWindowFlags = ui.WindowFlags { "NoSavedSettings", "NoBackground" }
 
 local function drawTab(tab, i, delta)
 	local icon = tab.icon or ui.theme.icons.alert_generic
 	local label = tab.label or ""
-	local icon_str = "{}##{}" % { encode_icon(icon), i }
+	local icon_str = "{}##{}" % { ui.get_icon_glyph(icon), i }
 
 	ui.tabItem(icon_str, label, function()
 		ui.child(label, Vector2(0, 0), childWindowFlags, function()

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -980,7 +980,7 @@ void GameLoop::Update(float deltaTime)
 	// Record physics timestep but keep information about current frame timing.
 	perfTimer.SoftStop();
 	// store the physics time until the end of the frame
-	phys_time = perfTimer.milliseconds() / 1.e3;
+	phys_time = perfTimer.milliseconds();
 
 	// did the player die?
 	if (Pi::game->GetPlayer()->IsDead()) {
@@ -1056,7 +1056,7 @@ void GameLoop::Update(float deltaTime)
 	Pi::pigui->Render();
 
 	perfTimer.SoftStop();
-	pigui_time = perfTimer.milliseconds() / 1.e3;
+	pigui_time = perfTimer.milliseconds();
 
 	if (Pi::game->UpdateTimeAccel())
 		accumulator = 0; // fix for huge pauses 10000x -> 1x

--- a/src/pigui/PerfInfo.h
+++ b/src/pigui/PerfInfo.h
@@ -4,9 +4,7 @@
 #pragma once
 
 #include "PerfStats.h"
-#include "RefCounted.h"
 #include <array>
-#include <memory>
 
 namespace PiGui {
 
@@ -29,12 +27,20 @@ namespace PiGui {
 			size_t peakMemSize;
 		};
 
-		static const int NUM_FRAMES = 60;
+		static constexpr int NUM_FRAMES = 300;
 		struct CounterInfo {
 			std::array<float, NUM_FRAMES> history;
-			float average = 0.;
-			float min = 0.;
-			float max = 0.;
+			float average = 0.f;
+			float recent = 0.f;
+			float min = 0.f;
+			float max = 0.f;
+
+			const char *name;
+			const char *unit;
+
+			uint32_t numRecentSamples;
+
+			CounterInfo(const char *n, const char *u, uint32_t recent = 15);
 		};
 
 		struct ImGuiState;
@@ -63,7 +69,7 @@ namespace PiGui {
 		void DrawInputDebug();
 		void DrawStatList(const Perf::Stats::FrameInfo &fi);
 
-		void DrawCounter(CounterType ct, const char *label, float min, float max, float height);
+		void DrawCounter(CounterInfo &counter, const char *label, float min, float max, float height, bool drawStats = false);
 		CounterInfo &GetCounter(CounterType ct);
 
 		// Per-frame counters

--- a/src/pigui/PerfInfo.h
+++ b/src/pigui/PerfInfo.h
@@ -18,7 +18,9 @@ namespace PiGui {
 		enum CounterType {
 			COUNTER_FPS,
 			COUNTER_PHYS,
-			COUNTER_PIGUI
+			COUNTER_PIGUI,
+			COUNTER_PROCMEM,
+			COUNTER_LUAMEM,
 		};
 
 		// Information about the current process memory usage in KB.
@@ -26,6 +28,15 @@ namespace PiGui {
 			size_t currentMemSize;
 			size_t peakMemSize;
 		};
+
+		static const int NUM_FRAMES = 60;
+		struct CounterInfo {
+			std::array<float, NUM_FRAMES> history;
+			float average = 0.;
+			float min = 0.;
+			float max = 0.;
+		};
+
 		struct ImGuiState;
 
 		void Draw();
@@ -45,25 +56,24 @@ namespace PiGui {
 		void DrawTextureCache();
 		void DrawTextureInspector();
 
+		void DrawPerformanceStats();
 		void DrawRendererStats();
 		void DrawWorldViewStats();
 		void DrawImGuiStats();
 		void DrawInputDebug();
 		void DrawStatList(const Perf::Stats::FrameInfo &fi);
 
-		static const int NUM_FRAMES = 60;
-		struct CounterInfo {
-			std::array<float, NUM_FRAMES> history;
-			float average = 0.;
-			float min = 0.;
-			float max = 0.;
-		};
-
+		void DrawCounter(CounterType ct, const char *label, float min, float max, float height);
 		CounterInfo &GetCounter(CounterType ct);
 
+		// Per-frame counters
 		CounterInfo m_fpsCounter;
 		CounterInfo m_physCounter;
 		CounterInfo m_piguiCounter;
+
+		// Per-second counters
+		CounterInfo m_procMemCounter;
+		CounterInfo m_luaMemCounter;
 
 		MemoryInfo process_mem;
 		size_t lua_mem = 0;


### PR DESCRIPTION
I've converted the PerfInfo debug tabs to use icons rather than names, made the debug tabs themselves hot-reloadable, and improved the amount of data shown in the performance plots displayed in the performance section. Frame graphs now display the last 5 seconds of frame timings (up from 1s), and have both a recent "instantaneous average" and whole-graph average. Memory graphs (which have a sample rate of 1Hz instead of ~60Hz) now show the last five minutes of memory usage for a more complete picture.

The PerfInfo window is easier to read and use at smaller window sizes, and can be collapsed completely to only display the current FPS while flying around the world as a built-in FPS counter.

I've also made the counters slightly cheaper to update in most cases, which should entirely offset any performance loss from increasing the number of samples per counter by 5x.

![image](https://github.com/user-attachments/assets/38f8fc12-ac83-4bd5-bdff-6c9ef796b431)
