### PR TITLE
Clarify system-level economy display

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -239,6 +239,18 @@
     "description": "",
     "message": "Commodity trade analysis of:"
   },
+  "COMMODITY_TRADE_ANALYSIS_SYSTEM": {
+    "description": "",
+    "message": "System-wide trade analysis of:"
+  },
+  "COMMODITY_TRADE_ANALYSIS_TOOLTIP_1": {
+    "description": "",
+    "message": "Average interstellar trade flow for all commodities bought and sold in the system."
+  },
+  "COMMODITY_TRADE_ANALYSIS_TOOLTIP_2": {
+    "description": "",
+    "message": "Data may not reflect individual market prices."
+  },
   "COMPETENT": {
     "description": "Combat rating",
     "message": "Competent"

--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -246,7 +246,24 @@ function SystemEconView:drawSystemComparison(selected, current)
 	local otherSys = showComparison and current or nil
 
 	ui.withFont(pionillium.body, function()
-		ui.text(lui.COMMODITY_TRADE_ANALYSIS)
+		ui.text(lui.COMMODITY_TRADE_ANALYSIS_SYSTEM)
+
+		local iconSize = Vector2(ui.getTextLineHeight())
+		ui.sameLine(ui.getContentRegion().x - iconSize.x + ui.getWindowPadding().x)
+		ui.icon(icons.info, iconSize, colors.fontDim)
+
+		if ui.isItemHovered() then
+			ui.withFont(pionillium.details, function()
+				ui.customTooltip(function()
+					ui.pushTextWrapPos(ui.getTextLineHeight() * 20)
+					ui.textWrapped(lui.COMMODITY_TRADE_ANALYSIS_TOOLTIP_1)
+					ui.spacing()
+					ui.textWrapped(lui.COMMODITY_TRADE_ANALYSIS_TOOLTIP_2)
+					ui.popTextWrapPos()
+				end)
+			end)
+		end
+
 		ui.spacing()
 
 		ui.withFont(pionillium.heading, function()

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -220,12 +220,12 @@ theme.colors = {
 	FrameBgActive			= styleColors.panel_700,
 
 	Tab						= styleColors.primary_800,
-	TabActive				= styleColors.primary_700,
-	TabHovered				= styleColors.primary_600,
+	TabActive				= styleColors.primary_600,
+	TabHovered				= styleColors.primary_500,
 
 	Header					= styleColors.primary_800,
-	HeaderActive			= styleColors.primary_700,
 	HeaderHovered			= styleColors.primary_600,
+	HeaderActive			= styleColors.primary_500,
 
 	SliderGrab				= styleColors.primary_500a,
 	SliderGrabActive		= styleColors.primary_300a,


### PR DESCRIPTION
Per comments from @bszlrd / @impaktor, this PR modifies the system-wide economy display widget to clarify that it's not displaying the actual market data for any specific station within the system.

![image](https://github.com/user-attachments/assets/349cafc8-c353-4065-99d8-20c459b68997)

Closes #5882, closes #5836.

This also addresses https://github.com/pioneerspacesim/pioneer/pull/5865#issuecomment-2306520959 - the color breakpoints chosen for the tabs didn't get updated when the theme colors were changed.