### PR TITLE
Add ability to reroll random systems to System Editor

### DIFF
--- a/src/editor/EditorWindow.cpp
+++ b/src/editor/EditorWindow.cpp
@@ -11,7 +11,8 @@
 using namespace Editor;
 
 EditorWindow::EditorWindow(EditorApp *app) :
-	m_app(app)
+	m_app(app),
+	m_canBeClosed(true)
 {}
 
 EditorWindow::~EditorWindow()
@@ -25,7 +26,7 @@ void EditorWindow::Update(float deltaTime)
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
 
 	bool shouldClose = false;
-	bool open = ImGui::Begin(GetWindowName(), &shouldClose, flags);
+	bool open = ImGui::Begin(GetWindowName(), m_canBeClosed ? &shouldClose : nullptr, flags);
 
 	ImGui::PopStyleVar(2);
 

--- a/src/editor/EditorWindow.h
+++ b/src/editor/EditorWindow.h
@@ -19,6 +19,9 @@ namespace Editor
 
 		virtual const char *GetWindowName() = 0;
 
+		bool GetCanBeClosed() const { return m_canBeClosed; }
+		void SetCanBeClosed(bool closeable) { m_canBeClosed = closeable; }
+
 	protected:
 
 		virtual void OnDraw() = 0;
@@ -29,5 +32,6 @@ namespace Editor
 
 	private:
 		EditorApp *m_app;
+		bool m_canBeClosed;
 	};
 }

--- a/src/editor/ViewportWindow.cpp
+++ b/src/editor/ViewportWindow.cpp
@@ -47,7 +47,7 @@ void ViewportWindow::Update(float deltaTime)
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
 
 	bool shouldClose = false;
-	bool open = ImGui::Begin(GetWindowName(), (flags & ImGuiWindowFlags_NoTitleBar) ? nullptr : &shouldClose, flags);
+	bool open = ImGui::Begin(GetWindowName(), (flags & ImGuiWindowFlags_NoTitleBar || !GetCanBeClosed()) ? nullptr : &shouldClose, flags);
 
 	ImGui::PopStyleVar(2);
 

--- a/src/editor/system/GalaxyEditAPI.cpp
+++ b/src/editor/system/GalaxyEditAPI.cpp
@@ -1,7 +1,7 @@
 // Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
-#include "GalaxyEditAPI.h"
 
+#include "GalaxyEditAPI.h"
 
 #include "EditorIcons.h"
 #include "SystemEditorHelpers.h"
@@ -11,10 +11,10 @@
 #include "editor/UndoStepType.h"
 #include "editor/EditorDraw.h"
 
-#include "EnumStrings.h"
-#include "galaxy/Sector.h"
+#include "galaxy/Factions.h"
 #include "galaxy/Galaxy.h"
 #include "galaxy/NameGenerator.h"
+#include "galaxy/Sector.h"
 #include "galaxy/StarSystemGenerator.h"
 
 #include "imgui/imgui.h"

--- a/src/editor/system/SystemEditor.cpp
+++ b/src/editor/system/SystemEditor.cpp
@@ -130,6 +130,7 @@ SystemEditor::SystemEditor(EditorApp *app) :
 	m_systemLoader.reset(new CustomSystemsDatabase(m_galaxy.Get(), "systems"));
 
 	m_viewport.reset(new SystemEditorViewport(m_app, this));
+	m_viewport->SetCanBeClosed(false);
 
 	m_random.seed({
 		// generate random values not dependent on app runtime
@@ -926,29 +927,6 @@ void SystemEditor::DrawInterface()
 		ImGui::PopItemWidth();
 	}
 	ImGui::End();
-
-#if 0
-	if (ImGui::Begin("ModList")) {
-		for (const auto &mod : ModManager::EnumerateMods()) {
-			if (!mod.enabled)
-				ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 64, 64, 255));
-
-			ImGui::PushFont(m_app->GetPiGui()->GetFont("orbiteer", 14));
-			ImGui::TextUnformatted(mod.name.c_str());
-			ImGui::PopFont();
-
-			ImGui::PushFont(m_app->GetPiGui()->GetFont("pionillium", 12));
-			ImGui::TextUnformatted(mod.path.c_str());
-			ImGui::PopFont();
-
-			if (!mod.enabled)
-				ImGui::PopStyleColor();
-
-			ImGui::Spacing();
-		}
-	}
-	ImGui::End();
-#endif
 
 	if (m_binderWindowOpen)
 		m_menuBinder->DrawOverview("Shortcut List", &m_binderWindowOpen);

--- a/src/editor/system/SystemEditor.cpp
+++ b/src/editor/system/SystemEditor.cpp
@@ -5,14 +5,11 @@
 
 #include "GalaxyEditAPI.h"
 #include "SystemBodyUndo.h"
-#include "SystemEditorHelpers.h"
 #include "SystemEditorViewport.h"
 #include "SystemEditorModals.h"
 
-#include "EnumStrings.h"
 #include "FileSystem.h"
 #include "JsonUtils.h"
-#include "ModManager.h"
 #include "Pi.h" // just here for Pi::luaNameGen
 #include "SystemView.h"
 #include "core/StringUtils.h"
@@ -22,7 +19,6 @@
 #include "editor/EditorDraw.h"
 #include "editor/EditorIcons.h"
 #include "editor/UndoSystem.h"
-#include "editor/UndoStepType.h"
 
 #include "galaxy/Galaxy.h"
 #include "galaxy/GalaxyGenerator.h"

--- a/src/editor/system/SystemEditor.h
+++ b/src/editor/system/SystemEditor.h
@@ -73,6 +73,7 @@ private:
 	bool LoadSystemFromFile(const FileSystem::FileInfo &file);
 	bool LoadCustomSystem(const CustomSystem *system);
 	void LoadSystemFromGalaxy(RefCountedPtr<StarSystem> system);
+	bool RegenerateSystem(uint32_t newSeed);
 	void ClearSystem();
 
 	void OnFilepathChanged();
@@ -108,6 +109,7 @@ private:
 
 private:
 	class UndoSetSelection;
+	class UndoSetEditedSystem;
 
 	// Pending file actions which triggered an unsaved changes modal
 	enum FileRequestType {

--- a/src/editor/system/SystemEditor.h
+++ b/src/editor/system/SystemEditor.h
@@ -5,7 +5,6 @@
 
 #include "SystemEditorModals.h"
 
-#include "Input.h"
 #include "Random.h"
 #include "RefCounted.h"
 #include "core/Application.h"

--- a/src/editor/system/SystemEditorHelpers.cpp
+++ b/src/editor/system/SystemEditorHelpers.cpp
@@ -268,18 +268,18 @@ bool Draw::InputFixedRadius(const char *str, fixed *val, bool is_solar, ImGuiInp
 	if (ImGui::IsDisabled()) val_step *= 0.0;
 
 	if (is_solar && unit_type != RADIUS_SOLS)
-		val_d *= unit_type == RADIUS_EARTH ? SOL_TO_EARTH_MASS : SOL_RADIUS_KM;
+		val_d *= unit_type == RADIUS_EARTH ? SOL_TO_EARTH_RADIUS : SOL_RADIUS_KM;
 	if (!is_solar && unit_type != RADIUS_EARTH)
-		val_d *= unit_type == RADIUS_SOLS ? (1.0 / SOL_TO_EARTH_MASS) : EARTH_RADIUS_KM;
+		val_d *= unit_type == RADIUS_SOLS ? (1.0 / SOL_TO_EARTH_RADIUS) : EARTH_RADIUS_KM;
 
 	ImGui::SameLine(0.f, 1.f);
 	Draw::SubtractItemWidth();
 	bool changed = ImGui::InputDouble(str, &val_d, val_step, val_step * 10.0, radius_formats[unit_type], flags);
 
 	if (is_solar && unit_type != RADIUS_SOLS)
-		val_d /= unit_type == RADIUS_EARTH ? SOL_TO_EARTH_MASS : SOL_RADIUS_KM;
+		val_d /= unit_type == RADIUS_EARTH ? SOL_TO_EARTH_RADIUS : SOL_RADIUS_KM;
 	if (!is_solar && unit_type != RADIUS_EARTH)
-		val_d /= unit_type == RADIUS_SOLS ? (1.0 / SOL_TO_EARTH_MASS) : EARTH_RADIUS_KM;
+		val_d /= unit_type == RADIUS_SOLS ? (1.0 / SOL_TO_EARTH_RADIUS) : EARTH_RADIUS_KM;
 
 	if (changed)
 		*val = fixed::FromDouble(val_d);

--- a/src/editor/system/SystemEditorHelpers.cpp
+++ b/src/editor/system/SystemEditorHelpers.cpp
@@ -2,6 +2,9 @@
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "SystemEditorHelpers.h"
+
+#include "MathUtil.h"
+
 #include "core/macros.h"
 #include "gameconsts.h"
 

--- a/src/editor/system/SystemEditorHelpers.h
+++ b/src/editor/system/SystemEditorHelpers.h
@@ -4,9 +4,7 @@
 #pragma once
 
 #include "EditorIcons.h"
-#include "MathUtil.h"
 #include "imgui/imgui.h"
-#include "imgui/imgui_stdlib.h"
 
 #include "fixed.h"
 

--- a/src/editor/system/SystemEditorModals.cpp
+++ b/src/editor/system/SystemEditorModals.cpp
@@ -125,7 +125,11 @@ void NewSystemModal::DrawInternal()
 	ImGui::EndChild();
 
 	if (ImGui::Button("New System")) {
-		m_editor->NewSystem(m_path->SectorOnly());
+		// Ensure we generate a valid system index
+		SystemPath newPath = m_path->SectorOnly();
+		newPath.systemIndex = sec->m_systems.size();
+
+		m_editor->NewSystem(newPath);
 		ImGui::CloseCurrentPopup();
 	}
 

--- a/src/editor/system/SystemEditorViewport.cpp
+++ b/src/editor/system/SystemEditorViewport.cpp
@@ -8,7 +8,6 @@
 
 #include "Background.h"
 #include "SystemView.h"
-#include "galaxy/Galaxy.h"
 #include "galaxy/StarSystem.h"
 
 #include "editor/EditorApp.h"

--- a/src/galaxy/StarSystem.h
+++ b/src/galaxy/StarSystem.h
@@ -87,6 +87,8 @@ public:
 	double GetExploredTime() const { return m_exploredTime; }
 	void ExploreSystem(double time);
 
+	bool HasCustomBodies() const { return m_hasCustomBodies; }
+
 	fixed GetMetallicity() const { return m_metallicity; }
 	fixed GetIndustrial() const { return m_industrial; }
 	fixed GetAgricultural() const { return m_agricultural; }
@@ -169,8 +171,6 @@ private:
 
 public:
 	GeneratorAPI(const SystemPath &path, RefCountedPtr<Galaxy> galaxy, StarSystemCache *cache, Random &rand);
-
-	bool HasCustomBodies() const { return m_hasCustomBodies; }
 
 	void SetCustom(bool isCustom, bool hasCustomBodies)
 	{

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1224,25 +1224,31 @@ void StarSystemRandomGenerator::MakeBinaryPair(SystemBody *a, SystemBody *b, fix
 	fixed m = a->GetMassAsFixed() + b->GetMassAsFixed();
 	fixed a0 = b->GetMassAsFixed() / m;
 	fixed a1 = a->GetMassAsFixed() / m;
-	a->m_eccentricity = rand.NFixed(3);
+	fixed ecc = rand.NFixed(3);
+	fixed axis = fixed(0);
 	int mul = 1;
 
 	do {
 		switch (rand.Int32(3)) {
-		case 2: a->m_semiMajorAxis = fixed(rand.Int32(100, 10000), 100); break;
-		case 1: a->m_semiMajorAxis = fixed(rand.Int32(10, 1000), 100); break;
+		case 2: axis = fixed(rand.Int32(100, 10000), 100); break;
+		case 1: axis = fixed(rand.Int32(10, 1000), 100); break;
 		default:
-		case 0: a->m_semiMajorAxis = fixed(rand.Int32(1, 100), 100); break;
+		case 0: axis = fixed(rand.Int32(1, 100), 100); break;
 		}
-		a->m_semiMajorAxis *= mul;
+		axis *= mul;
 		mul *= 2;
-	} while (a->m_semiMajorAxis - a->m_eccentricity * a->m_semiMajorAxis < minDist);
+	} while (axis - ecc * axis < minDist);
+
+	a->m_semiMajorAxis = axis * a0;
+	b->m_semiMajorAxis = axis * a1;
+	a->m_eccentricity = ecc;
+	b->m_eccentricity = ecc;
 
 	const double total_mass = a->GetMass() + b->GetMass();
-	const double e = a->m_eccentricity.ToDouble();
+	const double e = ecc.ToDouble();
 
-	a->m_orbit.SetShapeAroundBarycentre(AU * (a->m_semiMajorAxis * a0).ToDouble(), total_mass, a->GetMass(), e);
-	b->m_orbit.SetShapeAroundBarycentre(AU * (a->m_semiMajorAxis * a1).ToDouble(), total_mass, b->GetMass(), e);
+	a->m_orbit.SetShapeAroundBarycentre(AU * a->m_semiMajorAxis.ToDouble(), total_mass, a->GetMass(), e);
+	b->m_orbit.SetShapeAroundBarycentre(AU * b->m_semiMajorAxis.ToDouble(), total_mass, b->GetMass(), e);
 
 	const float rotX = -0.5f * float(M_PI); //(float)(rand.Double()*M_PI/2.0);
 	const float rotY = static_cast<float>(rand.Double(M_PI));
@@ -1257,8 +1263,9 @@ void StarSystemRandomGenerator::MakeBinaryPair(SystemBody *a, SystemBody *b, fix
 	b->m_orbitalOffset = fixed(int(round(rotY * 10000)), 10000);
 	a->m_orbitalOffset = fixed(int(round(rotY * 10000)), 10000);
 
-	fixed orbMin = a->m_semiMajorAxis - a->m_eccentricity * a->m_semiMajorAxis;
-	fixed orbMax = 2 * a->m_semiMajorAxis - orbMin;
+	fixed orbMin = axis - ecc * axis;
+	fixed orbMax = 2 * axis - orbMin;
+
 	a->m_orbMin = orbMin;
 	b->m_orbMin = orbMin;
 	a->m_orbMax = orbMax;

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -493,6 +493,10 @@ bool StarSystemCustomGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> galaxy,
 	RefCountedPtr<const Sector> sec = galaxy->GetSector(system->GetPath());
 	system->SetCustom(false, false);
 
+	// No system entry in the Sector, may be a "new" custom system from the Editor
+	if (system->GetPath().systemIndex >= sec->m_systems.size())
+		return true;
+
 	if (const CustomSystem *customSys = sec->m_systems[system->GetPath().systemIndex].GetCustomSystem())
 		config->isCustomOnly = ApplyToSystem(rng, system, customSys);
 


### PR DESCRIPTION
Continuing on from the discussion in #5892, this PR cleans up some generation bugs in binary systems which caused the orbits of stars to change once edited (due to orbital parameters not being written back to the body), and adds a new "regenerate system from seed" functionality to quickly generate new variants of the edited system. It also addresses a unit conversion issue in body radius display when using Earth Radius as a unit.

Due to data plumbing issues, regenerating a system can only be done for a full-procedurally generated system or a "partially random" system sourced from the `local_stars` database of systems with randomly generated contents.

https://github.com/user-attachments/assets/cb859248-1401-43f9-8bb7-56ec3c35cb0b
