### PR TITLE
NameGen - Spice up the station names

### DIFF
--- a/data/libs/NameGen.lua
+++ b/data/libs/NameGen.lua
@@ -11,6 +11,7 @@ local Engine = require 'Engine'
 local Culture = require 'culture/culture'
 
 local r = function (t, rand) return t[rand:Integer(1,#t)] end
+local romanNumerals = {"II","III","IV","V","VI","VII","VIII","IX","X","XI","XII","XIII","XIV","XV","XVI","XVII","XVIII","XIX"}
 
 local NameGen
 NameGen = {
@@ -19,6 +20,7 @@ NameGen = {
 
 	orbitalStarportFormats = {},
 	surfaceStarportFormats = {},
+	asteroidStarportFormats = {},
 
 --
 -- Function: FullName
@@ -120,28 +122,48 @@ NameGen = {
 --
 --   experimental
 --
+
 	BodyName = function (body, rand)
 		local ascii = true -- want only ascii compatible characers in name
 
+		-- Occasional Roman numeral stuck to a planet name looks good
+		-- Called in the planet names with: "{name} {suffix}"
+		local suffix = ""
+		if rand:Number() < 0.4 then
+			local srand = 1 + math.floor((rand:Number() ^ 3) * #romanNumerals)
+			suffix = romanNumerals[srand]
+		end
+
 		if not rand then rand = Engine.rand end
 
+		-- One in three chance of a random station number. Only some formats use it.
+		-- Station names ending in: {number}"
+		local number = ""
+			if rand:Integer(0,2) == 0 then
+				number = " " .. math.min(rand:Integer(1,27), rand:Integer(1,27))  -- FIXUP: max could depend on system
+			end                                                                   -- population or faction size.
+
+		local name = NameGen.Surname(rand, ascii)
 		if body.type == "STARPORT_ORBITAL" then
-			return string.interp(r(NameGen.orbitalStarportFormats, rand), { name = NameGen.Surname(rand, ascii) })
+			return string.interp(r(NameGen.orbitalStarportFormats, rand), { name = name, number = number })
 		end
 
 		if body.type == "STARPORT_SURFACE" then
-			return string.interp(r(NameGen.surfaceStarportFormats, rand), { name = NameGen.Surname(rand, ascii) })
+			if body.parent.type == "PLANET_ASTEROID" then
+				return string.interp(r(NameGen.asteroidStarportFormats, rand), { name = name, number = number })
+			else
+				return string.interp(r(NameGen.surfaceStarportFormats, rand), { name = name, number = number })
+			end
 		end
 
 		if body.superType == "ROCKY_PLANET" then
-
 			-- XXX -15-50C is "outdoor". once more planet composition
 			-- attributes are exposed we can do better here
 			if body.averageTemp >= 258 and body.averageTemp <= 323 then
-				return string.interp(r(NameGen.outdoorPlanetFormats, rand), { name = NameGen.Surname(rand, ascii) })
+				return string.interp(r(NameGen.outdoorPlanetFormats, rand), { name = name, suffix = suffix })
 			end
 
-			return string.interp(r(NameGen.rockPlanetFormats, rand), { name = NameGen.Surname(rand, ascii) })
+			return string.interp(r(NameGen.rockPlanetFormats, rand), { name = name, suffix = suffix })
 		end
 
 		error("No available namegen for body type '" .. body.type .. "'")
@@ -149,7 +171,9 @@ NameGen = {
 }
 
 NameGen.outdoorPlanetFormats = {
-	"{name}",
+	"{name} {suffix}",
+	"{name} {suffix}",
+	"{name} {suffix}",
 	"{name}'s World",
 	"{name}world",
 	"{name} Colony",
@@ -159,7 +183,9 @@ NameGen.outdoorPlanetFormats = {
 }
 
 NameGen.rockPlanetFormats = {
-	"{name}'s Mine",
+	"{name} {suffix}",
+	"{name} {suffix}",
+	"{name} {suffix}",
 	"{name}'s Claim",
 	"{name}'s Folly",
 	"{name}'s Grave",
@@ -170,7 +196,10 @@ NameGen.rockPlanetFormats = {
 }
 
 NameGen.orbitalStarportFormats = {
-	"{name}",
+	"{name}{number}",
+	"{name}{number}",
+	"{name}{number}",
+	"{name}{number}",
 	"{name} Spaceport",
 	"{name} High",
 	"{name} Orbiter",
@@ -195,11 +224,20 @@ NameGen.orbitalStarportFormats = {
 	"{name} Dock",
 	"{name} Depot",
 	"{name} Anchorage",
+	"{name} Junction",
+	"{name} Connection",
+	"{name} Academy",
+	"{name} University",
+	"{name} Waystation",
+	"{name} Laboratory",
+	"{name} Station{number}",
+	"{name} Citadel",
 }
 
 NameGen.surfaceStarportFormats = {
-	"{name}",
-	"{name}",
+	"{name}{number}",
+	"{name}{number}",
+	"{name}{number}",
 	"{name} Starport",
 	"{name} Spaceport",
 	"{name} Town",
@@ -209,6 +247,8 @@ NameGen.surfaceStarportFormats = {
 	"Fortress {name}",
 	"{name} Base",
 	"{name} Station",
+	"{name} Base{number}",
+	"{name} Station{number}",
 	"{name}ton",
 	"{name}ville",
 	"Port {name}",
@@ -216,6 +256,29 @@ NameGen.surfaceStarportFormats = {
 	"{name} Pad",
 	"{name} Terminal",
 	"{name} Oasis",
+	"{name} Landing",
+	"{name} Plains",
+	"{name} Flats",
+	"{name} Fields",
+	"Camp {name}",
+	"{name} Ward{number}",
+	"{name} Mine",
+	"{name} Mine",
+}
+
+NameGen.asteroidStarportFormats = {
+	"{name}{number}",
+	"{name}{number}",
+	"{name}{number}",
+	"{name} Station",
+	"{name} Refinery",
+	"{name} Drilling Station{number}",
+	"{name} Depot",
+	"{name} Anchorage",
+	"Fort {name}",
+	"{name} Base",
+	"{name} Mine",
+	"{name} Mine",
 }
 
 return NameGen


### PR DESCRIPTION
    * Add separate name formats for asteroids
    * Occasional Roman numerals to planet names
    * Add new station names/functions
    * Add occasional random station number

What planet name isn't improved with a Roman numeral?
![namegenroman1](https://github.com/user-attachments/assets/2064dc44-6c4d-4c0d-8a8b-a59e37a7701a)

Numbers to spice up station names
![namegennumbers2](https://github.com/user-attachments/assets/7e4e3997-39bd-48e4-85e0-952ac72f7c29)

The smaller bodies gets their own set of name formats
![namegencoredrilling](https://github.com/user-attachments/assets/496d1375-e6cf-4226-9a5d-c05bba8e18f1)

Can there be more than one instance of the same number. Yes. Same name and number? Not likely, but yes. This is what I could come up with in a short amount of time that made a reasonable improvement in the naming of bodies. I think this could be improved further if the pioneer universe was populated with companies/entities that placed their assets, ships and stations, in the systems and that had it's own decals, naming schemes etc.
Core Drilling Station? Yes, they are an efficient way to process asteroids... ;)

@impaktor I saw https://github.com/impaktor/pioneer/commit/a628fcf7a43254eacf7c8cd8f1161d8653e528fc and was actually trying something similar but I'm not happy with the results yet. 

Addresses https://github.com/pioneerspacesim/pioneer/issues/897
