### PR TITLE
Create BBS if empty

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -901,8 +901,10 @@ end
 local function updateAdverts (station)
 	if not SpaceStation.adverts[station] then
 		logWarning("SpaceStation.lua: updateAdverts called for station that hasn't been visited")
+		Event.Queue("onCreateBB", station)
+	else
+		Event.Queue("onUpdateBB", station)
 	end
-	Event.Queue("onUpdateBB", station)
 end
 
 --


### PR DESCRIPTION
This is a fixup from #5894 / a005ad4
Instead of updating the BBS it should be created if SpaceStation.adverts[station] is missing.

Addresses #5894
Addresses #5886

