### PR TITLE
ECM crime - Don't use your ECM near a station

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2583,6 +2583,10 @@
     "description": "",
     "message": "Unlawful weapons discharge"
   },
+  "UNLAWFUL_ECM_DISCHARGE": {
+    "description": "",
+    "message": "Unlawful ECM discharge"
+  },
   "UNOCCUPIED_PASSENGER_CABINS": {
     "description": "",
     "message": "Unoccupied Passenger Cabins"

--- a/data/libs/Legal.lua
+++ b/data/libs/Legal.lua
@@ -21,6 +21,7 @@ local l = Lang.GetResource("ui-core")
 -- PIRACY - fired on ship
 -- TRADING_ILLEGAL_GOODS - attempted to sell illegal goods
 -- WEAPONS_DISCHARGE - weapons discharged too close to station
+-- ECM_DISCHARGE - ECM discharged too close to station
 --
 -- Availability:
 --
@@ -41,6 +42,7 @@ Legal.CrimeType["MURDER"] = {basefine = 1.5e6, name = l.MURDER}
 Legal.CrimeType["PIRACY"] = {basefine = 1e5, name = l.PIRACY}
 Legal.CrimeType["TRADING_ILLEGAL_GOODS"] = {basefine = 5e3, name = l.TRADING_ILLEGAL_GOODS}
 Legal.CrimeType["WEAPONS_DISCHARGE"] = {basefine = 5e2, name = l.UNLAWFUL_WEAPONS_DISCHARGE}
+Legal.CrimeType["ECM_DISCHARGE"] = {basefine = 7.5e2, name = l.UNLAWFUL_ECM_DISCHARGE}
 Legal.CrimeType["CONTRACT_FRAUD"] = {basefine = 5e2, name = l.CONTRACT_FRAUD}
 
 

--- a/data/modules/CrimeTracking/CrimeTracking.lua
+++ b/data/modules/CrimeTracking/CrimeTracking.lua
@@ -102,6 +102,13 @@ local onShipFiring = function(ship)
 end
 
 
+local unlawfulDischargeECM = function(ship)
+	if ship:IsPlayer() then
+		Legal:notifyOfCrime(ship,"ECM_DISCHARGE")
+	end
+end
+
+
 local onLeaveSystem = function(ship)
 	if not ship:IsPlayer() then return end
 	-- if we leave the system, the space station object will be invalid
@@ -121,6 +128,7 @@ end
 Event.Register("onShipHit", onShipHit)
 Event.Register("onShipDestroyed", onShipDestroyed)
 Event.Register("onShipFiring", onShipFiring)
+Event.Register("unlawfulDischargeECM", unlawfulDischargeECM)
 Event.Register("onJettison", onJettison)
 Event.Register("onGameStart", onGameStart)
 Event.Register("onGameEnd", onGameEnd)

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -727,15 +727,20 @@ Ship::ECMResult Ship::UseECM()
 		Space::BodyNearList nearby = Pi::game->GetSpace()->GetBodiesMaybeNear(this, ECM_RADIUS);
 		for (Body *body : nearby) {
 			if (body->GetFrame() != GetFrame()) continue;
-			if (!body->IsType(ObjectType::MISSILE)) continue;
 
 			double dist = (body->GetPosition() - GetPosition()).Length();
-			if (dist < ECM_RADIUS) {
-				// increasing chance of destroying it with proximity
-				if (Pi::rng.Double() > (dist / ECM_RADIUS)) {
-					static_cast<Missile *>(body)->ECMAttack(ecm_power_cap);
+			if (body->IsType(ObjectType::MISSILE)) {
+				if (dist < ECM_RADIUS) {
+					// increasing chance of destroying it with proximity
+					if (Pi::rng.Double() > (dist / ECM_RADIUS)) {
+						static_cast<Missile *>(body)->ECMAttack(ecm_power_cap);
+					}
 				}
 			}
+			else if (body->IsType(ObjectType::SPACESTATION) && dist < ECM_RADIUS) {
+				LuaEvent::Queue("unlawfulDischargeECM", this);
+			}
+			else { continue; }
 		}
 		return ECM_ACTIVATED;
 	} else


### PR DESCRIPTION
~~_I hesitated a bit to submit this because of the overly harsh reaction if you happen to press the ecm button while taking off, but this is the same for all crime, dumping waste or firing a weapon. You will be terminated._~~

Updated: The effective range of the ban is now the same as the effective range of the ECM, 4 km.

I think there could be some more around this like a couple of the lights going out on the platform or the BBS being out of order the next time you land there. ECM should be used responsibly.

![ecmdischarge](https://github.com/user-attachments/assets/06fcb2c8-3f54-4e43-8a79-1dcfbfb4c3e4)

