### PR TITLE
fix(savegame): fix savefiles directory not being created (#5917)

### DIFF
--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -274,9 +274,9 @@ function SaveLoadWindow:makeFileList()
 	if not ok then
 		Notification.add(Notification.Type.Error, lui.COULD_NOT_LOAD_SAVE_FILES, files --[[@as string]])
 		self.files = {}
+	else
+		self.files = files
 	end
-
-	self.files = files
 
 	table.sort(self.files, function(a, b)
 		return a.mtime.timestamp > b.mtime.timestamp


### PR DESCRIPTION
Fixes https://github.com/pioneerspacesim/pioneer/issues/5917

A refactor of the load/save UI in commit
7b6a79700682124d29351fb83562778eaf5a2da4 introduced a bug preventing the "savefiles" directory from getting created, and causing an error-popup whenever the directory was attempted to be accessed by the LUA UI.

The bug was resetting a variable to an unexpected value which then caused the "sort" algorithm to throw an error. This was resolved by ensuring that the variable always had a valid value for the sort algorithm.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

