### PR TITLE
Feat/reset view on hyperspace exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,11 +357,14 @@ if (NATURALDOCS)
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
 
-find_program(PYTHON NAMES python)
-if (PYTHON)
+find_package(Python2 COMPONENTS Interpreter)
+if (Python2_Interpreter_FOUND)
 	add_custom_target(enums
-		COMMAND scripts/scan_enums.py -o src/enum_table.cpp --pattern='*.h' -r src
-		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+		COMMAND "${Python2_EXECUTABLE}" scripts/scan_enums.py -o src/enum_table.cpp --pattern='*.h' -r src
+		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+	)
+else()
+	message(WARNING, "Python 2 not found; enums will not be scanned.")
 endif()
 
 target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt)

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -743,6 +743,10 @@
     "description": "",
     "message": "Full screen"
   },
+  "GAME_OPTIONS": {
+    "description": "GameOptions - tooltip for the Game Options tab in the Settings Window",
+    "message": "Game Options"
+  },
   "GAME_TIME": {
     "description": "",
     "message": "Game time"

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -967,6 +967,10 @@
     "description": "Tooltip: Sidereal camera view",
     "message": "Sidereal view"
   },
+  "HUD_BUTTON_SWITCH_TO_CURRENT_SYSTEM": {
+    "description": "Tooltip: Switch to current system",
+    "message": "Switch to current system"
+  },
   "HUD_BUTTON_SWITCH_TO_GALAXY_MAP": {
     "description": "Tooltip: Switch to galaxy map",
     "message": "Switch to galaxy map"
@@ -974,6 +978,10 @@
   "HUD_BUTTON_SWITCH_TO_SECTOR_MAP": {
     "description": "Tooltip: Switch to sector map",
     "message": "Switch to sector map"
+  },
+  "HUD_BUTTON_SWITCH_TO_SELECTED_SYSTEM": {
+    "description": "Tooltip: Switch to selected system",
+    "message": "Switch to selected system"
   },
   "HUD_BUTTON_SWITCH_TO_SYSTEM_MAP": {
     "description": "Tooltip: Switch to system map",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2031,6 +2031,14 @@
     "description": "Paintshop button",
     "message": "Reset Preview"
   },
+  "RESET_VIEW_ON_HYPERSPACE_EXIT": {
+    "description": "Reset View on Hyperspace Exit option",
+    "message": "Reset View on Hyperspace Exit"
+  },
+  "RESET_VIEW_ON_HYPERSPACE_EXIT_DESC": {
+    "description": "The tooltip of Reset View on Hyperspace Exit in the settings menu",
+    "message": "Reset view to main game view when exiting from hyperspace"
+  },
   "RETURN_TO_GAME": {
     "description": "",
     "message": "Return to game"

--- a/data/libs/Player.lua
+++ b/data/libs/Player.lua
@@ -11,6 +11,7 @@
 local Player = package.core["Player"]
 
 local Serializer = require 'Serializer'
+local Engine = require 'Engine'
 local Event = require 'Event'
 local Game = require 'Game'
 local utils = require 'utils'
@@ -430,8 +431,16 @@ local onGameEnd = function ()
 	-- clean up for next game:
 end
 
+local onEnterSystem = function ()
+	-- Return to game view when we exit hyperspace
+	if Engine.GetResetViewOnHyperspaceExit() and Game.CurrentView() ~= "world" then
+		Game.SetView("world")
+	end
+end
+
 Event.Register("onGameEnd", onGameEnd)
 Event.Register("onGameStart", onGameStart)
+Event.Register("onEnterSystem", onEnterSystem)
 Serializer:RegisterClass("CrimeRecord", CrimeRecord)
 Serializer:Register("Player", serialize, unserialize)
 

--- a/data/meta/Constants.lua
+++ b/data/meta/Constants.lua
@@ -221,6 +221,16 @@ local SystemViewMode = {
 ---@type SystemViewMode[]
 Constants.SystemViewMode = {}
 
+-- A <Constants.SystemSelectionMode> string
+---@enum (key) SystemSelectionMode
+local SystemSelectionMode = {
+	CURRENT_SYSTEM = 1,
+	SELECTED_SYSTEM = 2,
+}
+
+---@type SystemSelectionMode[]
+Constants.SystemSelectionMode = {}
+
 -- A <Constants.SystemViewColorIndex> string
 ---@enum (key) SystemViewColorIndex
 local SystemViewColorIndex = {

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -170,7 +170,6 @@ local function showVideoOptions()
 	local displaySpeedLines = Engine.GetDisplaySpeedLines()
 	local displayHudTrails = Engine.GetDisplayHudTrails()
 	local enableCockpit = Engine.GetCockpitEnabled()
-	local enableAutoSave = Engine.GetAutosaveEnabled()
 
 	local c
 	ui.text(lui.VIDEO_CONFIGURATION_RESTART_GAME_TO_APPLY)
@@ -256,11 +255,6 @@ local function showVideoOptions()
 	c,enableCockpit = checkbox(lui.ENABLE_COCKPIT, enableCockpit, lui.ENABLE_COCKPIT_DESC)
 	if c then
 		Engine.SetCockpitEnabled(enableCockpit)
-	end
-
-	c,enableAutoSave = checkbox(lui.ENABLE_AUTOSAVE, enableAutoSave, lui.ENABLE_AUTOSAVE_DESC)
-	if c then
-		Engine.SetAutosaveEnabled(enableAutoSave)
 	end
 
 	c,starDensity = slider(lui.STAR_FIELD_DENSITY, starDensity, 0, 100)
@@ -637,11 +631,22 @@ local function showControlsOptions()
 	end
 end
 
+local function showGameOptions()
+	local enableAutoSave = Engine.GetAutosaveEnabled()
+	local c
+
+	c,enableAutoSave = checkbox(lui.ENABLE_AUTOSAVE, enableAutoSave, lui.ENABLE_AUTOSAVE_DESC)
+	if c then
+		Engine.SetAutosaveEnabled(enableAutoSave)
+	end
+end
+
 local optionsTabs = {
 	["video"]=showVideoOptions,
 	["sound"]=showSoundOptions,
 	["language"]=showLanguageOptions,
-	["controls"]=showControlsOptions
+	["controls"]=showControlsOptions,
+	["game"]=showGameOptions
 }
 
 ui.optionsWindow = ModalWindow.New("Options", function()
@@ -660,6 +665,9 @@ ui.optionsWindow = ModalWindow.New("Options", function()
 
 		mainButton(icons.controls, lui.CONTROLS, showTab=='controls', function()
 			showTab = 'controls'
+		end)
+		mainButton(icons.settings, lui.GAME_OPTIONS, showTab=='game', function()
+			showTab = 'game'
 		end)
 	end)
 

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -633,11 +633,17 @@ end
 
 local function showGameOptions()
 	local enableAutoSave = Engine.GetAutosaveEnabled()
+	local resetViewOnHyperspaceExit = Engine.GetResetViewOnHyperspaceExit()
 	local c
 
 	c,enableAutoSave = checkbox(lui.ENABLE_AUTOSAVE, enableAutoSave, lui.ENABLE_AUTOSAVE_DESC)
 	if c then
 		Engine.SetAutosaveEnabled(enableAutoSave)
+	end
+
+	c,resetViewOnHyperspaceExit = checkbox(lui.RESET_VIEW_ON_HYPERSPACE_EXIT, resetViewOnHyperspaceExit, lui.RESET_VIEW_ON_HYPERSPACE_EXIT_DESC)
+	if c then
+		Engine.SetResetViewOnHyperspaceExit(resetViewOnHyperspaceExit)
 	end
 end
 

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -270,6 +270,8 @@ end
 
 function Windows.edgeButtons.Show()
 	local isOrrery = systemView:GetDisplayMode() == "Orrery"
+	local isCurrent = systemView:GetSystemSelectionMode() == "CURRENT_SYSTEM"
+
 	if ui.mainMenuButton(icons.reset_view, luc.RESET_ORIENTATION_AND_ZOOM) then
 		systemView:SetVisibility("RESET_VIEW")
 	end
@@ -281,6 +283,16 @@ function Windows.edgeButtons.Show()
 	ui.newLine()
 
 	drawWindowControlButton(Windows.objectInfo, icons.info, lc.OBJECT_INFO)
+
+	-- view control buttons
+	if not isCurrent and ui.mainMenuButton(icons.planet_grid, luc.HUD_BUTTON_SWITCH_TO_CURRENT_SYSTEM) then
+		systemView:SetSystemSelectionMode("CURRENT_SYSTEM")
+	end
+
+	if isCurrent and ui.mainMenuButton(icons.galaxy_map, luc.HUD_BUTTON_SWITCH_TO_SELECTED_SYSTEM) then
+		systemView:SetSystemSelectionMode("SELECTED_SYSTEM")
+	end
+
 	-- visibility control buttons
 	if isOrrery then
 		if ui.mainMenuButton(buttonState[ship_drawing].icon, lc.SHIPS_DISPLAY_MODE_TOGGLE, buttonState[ship_drawing].state) then
@@ -403,7 +415,12 @@ local function getColor(obj)
 end
 
 function Windows.systemName.Show()
-	local path = Game.sectorView:GetSelectedSystemPath()
+	local path
+	if systemView:GetSystemSelectionMode() == "SELECTED_SYSTEM" then
+		path = Game.sectorView:GetSelectedSystemPath()
+	else
+		path = systemView:GetSystem().path
+	end
 	ui.text(ui.Format.SystemPath(path))
 end
 

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -270,7 +270,6 @@ end
 
 function Windows.edgeButtons.Show()
 	local isOrrery = systemView:GetDisplayMode() == "Orrery"
-	-- view control buttons
 	if ui.mainMenuButton(icons.reset_view, luc.RESET_ORIENTATION_AND_ZOOM) then
 		systemView:SetVisibility("RESET_VIEW")
 	end
@@ -279,13 +278,9 @@ function Windows.edgeButtons.Show()
 	ui.mainMenuButton(icons.search_lens, luc.ZOOM)
 	systemView:SetZoomMode(ui.isItemActive())
 
-	if isOrrery and ui.mainMenuButton(icons.system_overview, luc.HUD_BUTTON_SWITCH_TO_SYSTEM_OVERVIEW) then
-		systemView:SetDisplayMode('Atlas')
-	end
-	if not isOrrery and ui.mainMenuButton(icons.system_map, luc.HUD_BUTTON_SWITCH_TO_SYSTEM_MAP) then
-		systemView:SetDisplayMode('Orrery')
-	end
 	ui.newLine()
+
+	drawWindowControlButton(Windows.objectInfo, icons.info, lc.OBJECT_INFO)
 	-- visibility control buttons
 	if isOrrery then
 		if ui.mainMenuButton(buttonState[ship_drawing].icon, lc.SHIPS_DISPLAY_MODE_TOGGLE, buttonState[ship_drawing].state) then
@@ -300,11 +295,6 @@ function Windows.edgeButtons.Show()
 			show_grid = nextShowGrid[show_grid]
 			systemView:SetVisibility(show_grid)
 		end
-		ui.newLine()
-	end
-
-	drawWindowControlButton(Windows.objectInfo, icons.info, lc.OBJECT_INFO)
-	if isOrrery then
 		drawWindowControlButton(Windows.orbitPlanner, icons.semi_major_axis, lc.ORBIT_PLANNER)
 	end
 end
@@ -867,7 +857,7 @@ end
 
 function systemViewLayout:onUpdateWindowPivots(w)
 	w.systemName.anchors   = { ui.anchor.center, ui.anchor.top }
-	w.edgeButtons.anchors  = { ui.anchor.right,  ui.anchor.center }
+	w.edgeButtons.anchors  = { ui.anchor.right,  ui.anchor.top }
 	w.timeButtons.anchors  = { ui.anchor.right,  ui.anchor.bottom }
 	w.orbitPlanner.anchors = { ui.anchor.right,  ui.anchor.bottom }
 	w.objectInfo.anchors   = { ui.anchor.right,  ui.anchor.bottom }

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -299,6 +299,10 @@ function Windows.edgeButtons.Show()
 	ui.mainMenuButton(icons.search_lens, lui.ZOOM)
 	sectorView:GetMap():SetZoomMode(ui.isItemActive())
 	ui.text("")
+
+	if ui.mainMenuButton(icons.info, lc.OBJECT_INFO, buttonState[Windows.systemInfo.visible]) then
+		Windows.systemInfo.visible = not Windows.systemInfo.visible
+	end
 	-- settings buttons
 	if ui.mainMenuButton(icons.settings, lui.SETTINGS) then
 		ui.openPopup("sectorViewLabelSettings")
@@ -309,9 +313,6 @@ function Windows.edgeButtons.Show()
 
 	if ui.mainMenuButton(icons.shield_other, lui.FACTIONS, buttonState[Windows.factions.visible]) then
 		Windows.factions.visible = not Windows.factions.visible
-	end
-	if ui.mainMenuButton(icons.info, lc.OBJECT_INFO, buttonState[Windows.systemInfo.visible]) then
-		Windows.systemInfo.visible = not Windows.systemInfo.visible
 	end
 	if ui.mainMenuButton(icons.route, lui.HYPERJUMP_ROUTE, buttonState[Windows.hjPlanner.visible]) then
 		Windows.hjPlanner.visible = not Windows.hjPlanner.visible
@@ -424,7 +425,7 @@ Windows.hjPlanner.Dummy = hyperJumpPlanner.Dummy
 function sectorViewLayout:onUpdateWindowPivots(w)
 	w.hjPlanner.anchors = { ui.anchor.right, ui.anchor.bottom }
 	w.systemInfo.anchors = { ui.anchor.right, ui.anchor.bottom }
-	w.edgeButtons.anchors = { ui.anchor.right, ui.anchor.center }
+	w.edgeButtons.anchors = { ui.anchor.right, ui.anchor.top }
 	w.factions.anchors = { ui.anchor.right, ui.anchor.top }
 end
 
@@ -465,6 +466,7 @@ ui.registerModule("game", { id = 'map-sector-view', draw = function()
 
 		if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) then
 			systemEconView = package.reimport('pigui.modules.system-econ-view').New()
+			package.reimport()
 		end
 	end
 end})

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -209,8 +209,6 @@ void Player::OnEnterHyperspace()
 void Player::OnEnterSystem()
 {
 	m_controller->SetFlightControlState(CONTROL_MANUAL);
-	//XXX don't call sectorview from here, use signals instead
-	Pi::game->GetSectorView()->ResetHyperspaceTarget();
 }
 
 //temporary targeting stuff

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -282,6 +282,9 @@ void SectorView::DrawPiGui()
 
 void SectorView::SetHyperspaceTarget(const SystemPath &path)
 {
+	if (m_hyperspaceTarget.IsSameSystem(path)) {
+		return;
+	}
 	m_hyperspaceTarget = path;
 	onHyperspaceTargetChanged.emit();
 }

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -168,6 +168,11 @@ public:
 		Atlas = 1
 	};
 
+	enum class SystemSelectionMode { // <enum name=SystemSelectionMode scope='SystemView::SystemSelectionMode' public>
+		CURRENT_SYSTEM = 0,
+		SELECTED_SYSTEM = 1,
+	};
+
 	SystemView(Game *game);
 	~SystemView() override;
 	void Update() override;
@@ -176,6 +181,9 @@ public:
 
 	Mode GetDisplayMode() { return m_displayMode; }
 	void SetDisplayMode(Mode displayMode) { m_displayMode = displayMode; }
+
+	SystemSelectionMode GetSystemSelectionMode() { return m_systemSelectionMode; }
+	void SetSystemSelectionMode(SystemSelectionMode systemMode);
 
 	TransferPlanner *GetTransferPlanner() const { return m_planner; }
 	double GetOrbitPlannerStartTime() const { return m_planner->GetStartTime(); }
@@ -199,6 +207,7 @@ private:
 	std::list<std::pair<Ship *, Orbit>> m_contacts;
 
 	Mode m_displayMode;
+	SystemSelectionMode m_systemSelectionMode;
 	bool m_viewingCurrentSystem;
 	bool m_unexplored;
 };

--- a/src/enum_table.cpp
+++ b/src/enum_table.cpp
@@ -171,6 +171,12 @@ const struct EnumItem ENUM_SystemViewMode[] = {
 	{ 0, 0 },
 };
 
+const struct EnumItem ENUM_SystemSelectionMode[] = {
+	{ "CURRENT_SYSTEM", int(SystemView::SystemSelectionMode::CURRENT_SYSTEM) },
+	{ "SELECTED_SYSTEM", int(SystemView::SystemSelectionMode::SELECTED_SYSTEM) },
+	{ 0, 0 },
+};
+
 const struct EnumItem ENUM_SystemViewColorIndex[] = {
 	{ "GRID", int(SystemMapViewport::GRID) },
 	{ "GRID_LEG", int(SystemMapViewport::GRID_LEG) },
@@ -353,6 +359,7 @@ const struct EnumTable ENUM_TABLES[] = {
 	{ "ProjectableTypes", ENUM_ProjectableTypes },
 	{ "ProjectableBases", ENUM_ProjectableBases },
 	{ "SystemViewMode", ENUM_SystemViewMode },
+	{ "SystemSelectionMode", ENUM_SystemSelectionMode },
 	{ "SystemViewColorIndex", ENUM_SystemViewColorIndex },
 	{ "PolitEcon", ENUM_PolitEcon },
 	{ "PolitGovType", ENUM_PolitGovType },
@@ -384,6 +391,7 @@ const struct EnumTable ENUM_TABLES_PUBLIC[] = {
 	{ "ProjectableTypes", ENUM_ProjectableTypes },
 	{ "ProjectableBases", ENUM_ProjectableBases },
 	{ "SystemViewMode", ENUM_SystemViewMode },
+	{ "SystemSelectionMode", ENUM_SystemSelectionMode },
 	{ "SystemViewColorIndex", ENUM_SystemViewColorIndex },
 	{ "PolitEcon", ENUM_PolitEcon },
 	{ "PolitGovType", ENUM_PolitGovType },

--- a/src/enum_table.h
+++ b/src/enum_table.h
@@ -30,6 +30,7 @@ extern const struct EnumItem ENUM_DockStage[];
 extern const struct EnumItem ENUM_ProjectableTypes[];
 extern const struct EnumItem ENUM_ProjectableBases[];
 extern const struct EnumItem ENUM_SystemViewMode[];
+extern const struct EnumItem ENUM_SystemSelectionMode[];
 extern const struct EnumItem ENUM_SystemViewColorIndex[];
 extern const struct EnumItem ENUM_PolitEcon[];
 extern const struct EnumItem ENUM_PolitGovType[];

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -580,6 +580,21 @@ static int l_engine_set_autosave_enabled(lua_State *l)
 	Pi::config->Save();
 	return 0;
 }
+static int l_engine_get_reset_view_on_hyperspace_exit(lua_State *l)
+{
+	lua_pushboolean(l, Pi::config->Int("ResetViewOnHyperspaceExit") != 0);
+	return 1;
+}
+
+static int l_engine_set_reset_view_on_hyperspace_exit(lua_State *l)
+{
+	if (lua_isnone(l, 1))
+		return luaL_error(l, "SetResetViewOnHyperspaceExit takes one boolean argument");
+	const bool enabled = lua_toboolean(l, 1);
+	Pi::config->SetInt("ResetViewOnHyperspaceExit", (enabled ? 1 : 0));
+	Pi::config->Save();
+	return 0;
+}
 
 static int l_engine_get_display_hud_trails(lua_State *l)
 {
@@ -1103,6 +1118,9 @@ void LuaEngine::Register()
 
 		{ "GetAutosaveEnabled", l_engine_get_autosave_enabled },
 		{ "SetAutosaveEnabled", l_engine_set_autosave_enabled },
+
+		{ "GetResetViewOnHyperspaceExit", l_engine_get_reset_view_on_hyperspace_exit },
+		{ "SetResetViewOnHyperspaceExit", l_engine_set_reset_view_on_hyperspace_exit },
 
 		{ "GetDisplayHudTrails", l_engine_get_display_hud_trails },
 		{ "SetDisplayHudTrails", l_engine_set_display_hud_trails },

--- a/src/lua/LuaSystemView.cpp
+++ b/src/lua/LuaSystemView.cpp
@@ -296,6 +296,20 @@ static int l_systemview_set_display_mode(lua_State *l)
 	return 1;
 }
 
+static int l_systemview_get_system_selection_mode(lua_State *l)
+{
+	SystemView *sv = LuaObject<SystemView>::CheckFromLua(1);
+	LuaPush(l, EnumStrings::GetString("SystemSelectionMode", int(sv->GetSystemSelectionMode())));
+	return 1;
+}
+
+static int l_systemview_set_system_selection_mode(lua_State *l)
+{
+	SystemView *sv = LuaObject<SystemView>::CheckFromLua(1);
+	int mode = EnumStrings::GetValue("SystemSelectionMode", LuaPull<const char *>(l, 2));
+	sv->SetSystemSelectionMode(SystemView::SystemSelectionMode(mode));
+	return 1;
+}
 static int l_systemview_transfer_planner_get(lua_State *l)
 {
 	SystemView *sv = LuaObject<SystemView>::CheckFromLua(1);
@@ -392,6 +406,8 @@ void LuaObject<SystemView>::RegisterClass()
 		{ "SetZoomMode", l_systemview_set_zoom_mode },
 		{ "GetDisplayMode", l_systemview_get_display_mode },
 		{ "SetDisplayMode", l_systemview_set_display_mode },
+		{ "GetSystemSelectionMode", l_systemview_get_system_selection_mode },
+		{ "SetSystemSelectionMode", l_systemview_set_system_selection_mode },
 		{ "GetZoom", l_systemview_get_zoom },
 		{ "AtlasViewPlanetGap", l_systemview_atlas_view_planet_gap },
 		{ "AtlasViewPixelPerUnit", l_systemview_atlas_view_pixel_per_unit },


### PR DESCRIPTION
Fixes #5691 

<!-- Please describe new feature, possible with screenshot if needed. -->
## Background
The current game has a concept of a "selected system" in the `Sector Map`. Whenever opening the `System Overview` or the `System Map`, this is the system whose details will be displayed.

The only way to change the "selected system" is by the user changing it in the `Sector Map`.

This is somewhat unintuitive from a players' perspective. When the player is interacting with the various maps, then yes, this is the expected behaviour, however, when the player is jumping into a new system, upon arrival, it is more intuitive for the `System Map` and `System Overview` to show the current system.

## Proposed changes
This PR proposes to fix this with 2 partially-related changes:

1. Add an option to reset the view to the WorldView following a hyperspace jump. 
2. Add a selection button to the Map Views allowing the player to choose to display either the current system, or the selected system.

When the option to reset the view to the WorldView is unchecked (default), and the Map Display is set to the selected system (default), there is no change to the game behaviour from the current behaviour.

### Reset View after hyperspace exit

This was originally added to avoid certain issues with the selected system changing, but is kept as some players may prefer this . **This could be split into a separate PR.**

A benefit of enabling this option is that players can immediately react to hostile actions following a hyperspace exit.

An improvement to this option may be to also reset the view to "internal" and "front" - the current implementation maintains the last camera setting.

### Add Map View mode to selected or current

When the Map View is set to the current system, the System Map and the System Overview will show the current system instead of the selected system. This can be especially useful if the player is exploring and wishes to quickly examine the current system while following a hyperspace route of multiple jumps.

One side-effect of this change is that if the player is currently viewing one of the maps while performing a hyperspace jump, then the view is updated as soon as the new system is reached. 

On the one hand this could be seen as a benefit as the player is immediately notified of arrival in a new system, on the other it could be disruptive if the player is currently examining some aspect of the previous system.

It would require additional work, potentially complex and fragile, to keep the view on the currently opened system.

## Issues with these changes

Apart from those already mentioned, there are no known issues or new bugs introduced by these changes.

## Original Draft-PR Description
<details>
<!-- Please describe new feature, possible with screenshot if needed. -->
## Background
The current game has a concept of a "selected system" in the `Sector Map`. Whenever opening the `System Overview` or the `System Map`, this is the system whose details will be displayed.

The only way to change the "selected system" is by the user changing it in the `Sector Map`.

This is somewhat unintuitive from a players' perspective. When the player is interacting with the various maps, then yes, this is the expected behaviour, however, when the player is jumping into a new system, upon arrival, it is more intuitive for the `System Map` and `System Overview` to show the current system.

## Proposed changes
This PR proposes to fix this by resetting the "selected system" to the "current system" when entering a new system.

## Issues with the fix
The current implementation has the downside that if the player is viewing the `System Map` or `System Overview` _while_ performing a hyperspace jump, the map is changed as soon as the jump is complete, even if the player is interacting with the map at the time.

## Discussion
Hence this PR is still a "draft" while ways to prevent the map from changing are investigated. While some players might like the current approach (ie, it's obvious when the jump is complete), others might prefer to keep viewing the old map.

One solution could be that the player is forcibly returned to the flight screen when the hyperspace jump is completed. This has the benefit that the player is immediately able to react to, for example, hostile actions by other ships.
This should be fairly easy to implement.

Another suggestion has been that the "selected system" is _not_ changed, but rather that the `System Map` and `System Overview` show the "selected system" when opened from the `Sector Map` (and possibly some other screens such as the BBS), but the "current system" when opened from the spaceflight screen. This might lead to confusing behaviour depending on the exact sequence of opening maps and the starting screen compared to what the player expects. This is also likely to be somewhat more complex to implement.

<!-- Please make sure you've read documentation on contributing -->
</details>