### PR TITLE
Bugfix/fix hyperspace route update bug 5924

### DIFF
--- a/data/pigui/modules/hyperjump-planner.lua
+++ b/data/pigui/modules/hyperjump-planner.lua
@@ -22,7 +22,6 @@ local hyperJumpPlanner = {} -- for export
 
 -- hyperjump route stuff
 local hyperjump_route = {}
-local route_jumps = 0
 local current_system
 local current_path
 local map_selected_path
@@ -66,8 +65,8 @@ local function showInfo()
 
 		textIcon(icons.route_destination, lui.FINAL_TARGET)
 
-		if route_jumps > 0 then
-			local final_path = hyperjump_route[route_jumps].path
+		if #hyperjump_route > 0 then
+			local final_path = hyperjump_route[#hyperjump_route].path
 			ui.sameLine()
 			if ui.selectable(ui.Format.SystemPath(final_path), false, {}) then
 				sectorView:SwitchToPath(final_path)
@@ -314,7 +313,6 @@ function hyperJumpPlanner.display()
 	current_path = Game.system and current_system.path -- will be nil during the hyperjump
 	current_fuel = Game.player:GetComponent('CargoManager'):CountCommodity(fuel_type)
 	map_selected_path = sectorView:GetSelectedSystemPath()
-	route_jumps = sectorView:GetRouteSize()
 	showHyperJumpPlannerWindow()
 end -- hyperJumpPlanner.display
 
@@ -342,7 +340,7 @@ function hyperJumpPlanner.onEnterSystem(ship)
 	-- this should be the case if you are following a route and want the route to be
 	-- updated as you make multiple jumps
 	if ship:IsPlayer() and remove_first_if_current then
-		if route_jumps > 0 and hyperjump_route[1] and hyperjump_route[1].path:IsSameSystem(Game.system.path) then
+		if #hyperjump_route > 0 and hyperjump_route[1] and hyperjump_route[1].path:IsSameSystem(Game.system.path) then
 			sectorView:RemoveRouteItem(1)
 		end
 	end


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->
Fixes #5924 


This bug manifested itself in the edge-case of loading a game with an active hyperspace route, and jumping to the next system in the route without entering the Sector View first. On arrival in the new system, the Hyperspace Target is not updated to the next system in the route.
    
The bug is caused by the implementation of the `hyperJumpPlanner` Lua  module tracking the size of the route in a local variable "route_jumps".  This variable is not initialized until the Sector View is opened, but is crucial for correctly updating the HyperSpace target system after a jump.
    
2 ways were identified to fix this bug:
    
1. update the variable in the "buildJumpRouteList" function
2. remove the variable and read the size of the "hyperjump_route" table directly wherever it is needed.
    
The second option was chosen for this fix as it removes an unnecessary local variable at the expense of slightly more verbose code. This is deemed to be more robust as future refactoring or feature additions will not introduce similar issues where the variable and the table size get out of sync.

(EDIT: fix wording to use present tense to describe the bug)