### PR TITLE
Feat/save game manager

### DIFF
--- a/data/modules/AutoSave/AutoSave.lua
+++ b/data/modules/AutoSave/AutoSave.lua
@@ -6,7 +6,7 @@ local FileSystem = require 'FileSystem'
 local max_autosaves = 9
 
 local function PickNextAutosave()
-	local ok, files, _ = pcall(FileSystem.ReadDirectory, 'user://savefiles')
+	local ok, files = pcall(Game.ListSaves)
 	if not ok then
 		print('Error picking auto-save')
 		return '_autosave1'

--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -269,7 +269,7 @@ function SaveLoadWindow:makeFilteredList()
 end
 
 function SaveLoadWindow:makeFileList()
-	local ok, files, _ = pcall(FileSystem.ReadDirectory, "user://savefiles")
+	local ok, files = pcall(Game.ListSaves)
 
 	if not ok then
 		Notification.add(Notification.Type.Error, lui.COULD_NOT_LOAD_SAVE_FILES, files --[[@as string]])

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -24,6 +24,7 @@
 #endif
 #include "Pi.h"
 #include "Player.h"
+#include "SaveGameManager.h"
 #include "SectorView.h"
 #include "Sfx.h"
 #include "Space.h"
@@ -33,9 +34,6 @@
 #include "galaxy/GalaxyGenerator.h"
 #include "pigui/PiGuiView.h"
 #include "ship/PlayerShipController.h"
-
-static const char s_saveDirName[] = "savefiles";
-static const int s_saveVersion = 90;
 
 Game::Game(const SystemPath &path, const double startDateTime, const char *shipType) :
 	m_galaxy(GalaxyGenerator::Create()),
@@ -154,8 +152,8 @@ Game::Game(const Json &jsonObj) :
 	try {
 		int version = jsonObj["version"];
 		Output("savefile version: %d\n", version);
-		if (version != s_saveVersion) {
-			Output("can't load savefile, expected version: %d\n", s_saveVersion);
+		if (version != SaveGameManager::CurrentSaveVersion()) {
+			Output("can't load savefile, expected version: %d\n", SaveGameManager::CurrentSaveVersion());
 			throw SavedGameWrongVersionException();
 		}
 	} catch (Json::type_error &) {
@@ -229,7 +227,7 @@ void Game::ToJson(Json &jsonObj)
 	Pi::luaSerializer->SavePersistent(jsonObj);
 
 	// version
-	jsonObj["version"] = s_saveVersion;
+	jsonObj["version"] = SaveGameManager::CurrentSaveVersion();
 
 	// galaxy generator
 	m_galaxy->ToJson(jsonObj);
@@ -926,119 +924,4 @@ void Game::EmitPauseState(bool paused)
 		LuaEvent::Queue(PiGui::GetEventQueue(), "onGameResumed");
 	}
 	LuaEvent::Emit();
-}
-
-Json Game::LoadGameToJson(const std::string &filename)
-{
-	Json rootNode = JsonUtils::LoadJsonSaveFile(FileSystem::JoinPathBelow(s_saveDirName, filename), FileSystem::userFiles);
-	if (!rootNode.is_object()) {
-		Output("Loading saved game '%s' failed.\n", filename.c_str());
-		throw SavedGameCorruptException();
-	}
-	if (!rootNode["version"].is_number_integer() || rootNode["version"].get<int>() != s_saveVersion) {
-		Output("Loading saved game '%s' failed: wrong save file version.\n", filename.c_str());
-		throw SavedGameCorruptException();
-	}
-	return rootNode;
-}
-
-Game *Game::LoadGame(const std::string &filename)
-{
-	Output("Game::LoadGame('%s')\n", filename.c_str());
-
-	Json rootNode = LoadGameToJson(filename);
-
-	try {
-		return new Game(rootNode);
-	} catch (const Json::type_error &) {
-		throw SavedGameCorruptException();
-	} catch (const Json::out_of_range &) {
-		throw SavedGameCorruptException();
-	}
-}
-
-bool Game::CanLoadGame(const std::string &filename)
-{
-	FILE *f;
-	try {
-		f = FileSystem::userFiles.OpenReadStream(FileSystem::JoinPathBelow(s_saveDirName, filename));
-	} catch (const std::invalid_argument &) {
-		return false;
-	}
-	if (!f)
-		return false;
-
-	fclose(f);
-	return true;
-}
-
-bool Game::DeleteSave(const std::string &filename)
-{
-	std::string filePath;
-	try {
-		filePath = FileSystem::JoinPathBelow(s_saveDirName, filename);
-	} catch (const std::invalid_argument &) {
-		return false;
-	}
-	return FileSystem::userFiles.RemoveFile(filePath);
-}
-
-void Game::SaveGame(const std::string &filename, Game *game)
-{
-	PROFILE_SCOPED()
-	assert(game);
-
-	if (game->IsHyperspace())
-		throw CannotSaveInHyperspace();
-
-	if (game->GetPlayer()->IsDead())
-		throw CannotSaveDeadPlayer();
-
-	if (!FileSystem::IsValidFilename(filename))
-		throw std::invalid_argument(filename);
-	FILE *f;
-	try {
-		f = FileSystem::userFiles.OpenWriteStream(FileSystem::JoinPathBelow(s_saveDirName, filename));
-	} catch (const std::invalid_argument &) {
-		throw CouldNotOpenFileException();
-	}
-	if (!f)
-		throw CouldNotOpenFileException();
-	Json rootNode;
-	game->ToJson(rootNode); // Encode the game data as JSON and give to the root value.
-	std::vector<uint8_t> jsonData;
-	{
-		PROFILE_SCOPED_DESC("json.to_cbor");
-		jsonData = Json::to_cbor(rootNode); // Convert the JSON data to CBOR.
-	}
-
-	try {
-		// Compress the CBOR data.
-		const std::string comressed_data = gzip::CompressGZip(
-			std::string(reinterpret_cast<const char *>(jsonData.data()), jsonData.size()),
-			filename + ".json");
-		size_t nwritten = fwrite(comressed_data.data(), comressed_data.size(), 1, f);
-		fclose(f);
-		if (nwritten != 1) throw CouldNotWriteToFileException();
-	} catch (gzip::CompressionFailedException) {
-		fclose(f);
-		throw CouldNotWriteToFileException();
-	}
-
-	Pi::GetApp()->RequestProfileFrame("SaveGame");
-}
-
-int Game::CurrentSaveVersion()
-{
-	return s_saveVersion;
-}
-
-bool Game::CreateSaveGameDirectory()
-{
-	return FileSystem::userFiles.MakeDirectory(s_saveDirName);
-}
-
-const std::string Game::GetSaveGameDirectory()
-{
-	return FileSystem::JoinPath(FileSystem::userFiles.GetRoot(), s_saveDirName);
 }

--- a/src/Game.h
+++ b/src/Game.h
@@ -46,6 +46,9 @@ public:
 	static void SaveGame(const std::string &filename, Game *game);
 	static bool DeleteSave(const std::string &filename);
 	static int CurrentSaveVersion();
+	static bool CreateSaveGameDirectory();
+	static const std::string GetSaveGameDirectory();
+
 
 	// start docked in station referenced by path or nearby to body if it is no station
 	Game(const SystemPath &path, const double startDateTime, const char *shipType = "kanara");

--- a/src/Game.h
+++ b/src/Game.h
@@ -37,19 +37,6 @@ class ObjectViewerView;
 
 class Game {
 public:
-	static Json LoadGameToJson(const std::string &filename);
-	// LoadGame and SaveGame throw exceptions on failure
-	static Game *LoadGame(const std::string &filename);
-	static bool CanLoadGame(const std::string &filename);
-	// XXX game arg should be const, and this should probably be a member function
-	// (or LoadGame/SaveGame should be somewhere else entirely)
-	static void SaveGame(const std::string &filename, Game *game);
-	static bool DeleteSave(const std::string &filename);
-	static int CurrentSaveVersion();
-	static bool CreateSaveGameDirectory();
-	static const std::string GetSaveGameDirectory();
-
-
 	// start docked in station referenced by path or nearby to body if it is no station
 	Game(const SystemPath &path, const double startDateTime, const char *shipType = "kanara");
 

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -30,6 +30,7 @@
 #include "Player.h"
 #include "PngWriter.h"
 #include "Projectile.h"
+#include "SaveGameManager.h"
 #include "SectorView.h"
 #include "Sfx.h"
 #include "Shields.h"
@@ -336,7 +337,7 @@ void Pi::App::OnStartup()
 
 	Output("%s\n", OS::GetOSInfoString().c_str());
 
-	Game::CreateSaveGameDirectory();
+	SaveGameManager::Init();
 
 	ModManager::Init();
 	ModManager::LoadMods(config);
@@ -806,9 +807,9 @@ void Pi::HandleKeyDown(SDL_Keysym *key)
 
 		else {
 			const std::string name = "_quicksave";
-			const std::string path = FileSystem::JoinPath(Game::GetSaveGameDirectory(), name);
+			const std::string path = FileSystem::JoinPath(SaveGameManager::GetSaveGameDirectory(), name);
 			try {
-				Game::SaveGame(name, Pi::game);
+				SaveGameManager::SaveGame(name, Pi::game);
 				Pi::game->log->Add(Lang::GAME_SAVED_TO + path);
 			} catch (CouldNotOpenFileException) {
 				Pi::game->log->Add(stringf(Lang::COULD_NOT_OPEN_FILENAME, formatarg("path", path)));

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -336,6 +336,8 @@ void Pi::App::OnStartup()
 
 	Output("%s\n", OS::GetOSInfoString().c_str());
 
+	Game::CreateSaveGameDirectory();
+
 	ModManager::Init();
 	ModManager::LoadMods(config);
 
@@ -804,7 +806,7 @@ void Pi::HandleKeyDown(SDL_Keysym *key)
 
 		else {
 			const std::string name = "_quicksave";
-			const std::string path = FileSystem::JoinPath(GetSaveDir(), name);
+			const std::string path = FileSystem::JoinPath(Game::GetSaveGameDirectory(), name);
 			try {
 				Game::SaveGame(name, Pi::game);
 				Pi::game->log->Add(Lang::GAME_SAVED_TO + path);
@@ -1194,13 +1196,6 @@ SceneGraph::Model *Pi::FindModel(const std::string &name, bool allowPlaceholder)
 	}
 
 	return m;
-}
-
-const char Pi::SAVE_DIR_NAME[] = "savefiles";
-
-std::string Pi::GetSaveDir()
-{
-	return FileSystem::JoinPath(FileSystem::GetUserDir(), Pi::SAVE_DIR_NAME);
 }
 
 // request that the game is ended as soon as safely possible

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -150,10 +150,7 @@ public:
 	static bool AreHudTrailsDisplayed() { return hudTrailsDisplayed; }
 	static void SetHudTrailsDisplayed(bool state) { hudTrailsDisplayed = state; }
 
-	static std::string GetSaveDir();
 	static SceneGraph::Model *FindModel(const std::string &, bool allowPlaceholder = true);
-
-	static const char SAVE_DIR_NAME[];
 
 	static LuaSerializer *luaSerializer;
 	static LuaTimer *luaTimer;

--- a/src/SaveGameManager.cpp
+++ b/src/SaveGameManager.cpp
@@ -139,3 +139,18 @@ bool SaveGameManager::DeleteSave(const std::string &name)
 	}
 	return FileSystem::userFiles.RemoveFile(filePath);
 }
+
+std::vector<FileSystem::FileInfo> SaveGameManager::ListSaves()
+{
+	std::vector<FileSystem::FileInfo> saves;
+	auto files = FileSystem::userFiles.Enumerate(s_saveDirName, 0);
+	for (const FileSystem::FileInfo &fileInfo : files) {
+		// MKW TODO : should probably check that this file is actually a valid
+		// savegame file. But that would require actually loading the file,
+		// parsing it into a JSON object, and at the very least extracting the
+		// version number.
+		saves.push_back(fileInfo);
+	}
+	return saves;
+}
+

--- a/src/SaveGameManager.cpp
+++ b/src/SaveGameManager.cpp
@@ -1,0 +1,141 @@
+// Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "SaveGameManager.h"
+#include "core/GZipFormat.h"
+#include "core/Log.h"
+#include "FileSystem.h"
+#include "Game.h"
+#include "GameSaveError.h"
+#include "JsonUtils.h"
+#include "Player.h"
+#include "Pi.h"
+#include "profiler/Profiler.h"
+
+
+static const char s_saveDirName[] = "savefiles";
+
+static const int s_saveVersion = 90;
+
+void SaveGameManager::Init()
+{
+	if (!FileSystem::userFiles.MakeDirectory(s_saveDirName)) {
+		throw CouldNotOpenFileException();
+	}
+}
+
+void SaveGameManager::Uninit()
+{
+}
+
+int SaveGameManager::CurrentSaveVersion()
+{
+	return s_saveVersion;
+}
+
+const std::string SaveGameManager::GetSaveGameDirectory()
+{
+	return FileSystem::JoinPath(FileSystem::userFiles.GetRoot(), s_saveDirName);
+}
+
+bool SaveGameManager::CanLoadGame(const std::string &name)
+{
+	FILE *f = NULL;
+	try {
+		f = FileSystem::userFiles.OpenReadStream(FileSystem::JoinPathBelow(s_saveDirName, name));
+	} catch (const std::invalid_argument &) {
+		return false;
+	}
+	if (!f) {
+		return false;
+	}
+
+	fclose(f);
+	return true;
+}
+
+Json SaveGameManager::LoadGameToJson(const std::string &filename)
+{
+	return JsonUtils::LoadJsonSaveFile(FileSystem::JoinPathBelow(s_saveDirName, filename), FileSystem::userFiles);
+}
+
+Game *SaveGameManager::LoadGame(const std::string &name)
+{
+	Output("SaveGameManager::LoadGame('%s')\n", name.c_str());
+
+	try {
+		Json rootNode = LoadGameToJson(name);
+		if (!rootNode.is_object()) {
+			throw SavedGameCorruptException();
+		}
+		return new Game(LoadGameToJson(name));
+	} catch (const Json::type_error &) {
+		throw SavedGameCorruptException();
+	} catch (const Json::out_of_range &) {
+		throw SavedGameCorruptException();
+	}
+}
+
+void SaveGameManager::SaveGame(const std::string &name, Game *game)
+{
+	PROFILE_SCOPED()
+	assert(game);
+
+	if (game->IsHyperspace()) {
+		throw CannotSaveInHyperspace();
+	}
+
+	if (game->GetPlayer()->IsDead()) {
+		throw CannotSaveDeadPlayer();
+	}
+
+	if (!FileSystem::IsValidFilename(name)) {
+		throw std::invalid_argument(name);
+	}
+
+	FILE *f = NULL;
+	try {
+		f = FileSystem::userFiles.OpenWriteStream(FileSystem::JoinPathBelow(s_saveDirName, name));
+	} catch (const std::invalid_argument &) {
+		throw CouldNotOpenFileException();
+	}
+	if (!f) {
+		throw CouldNotOpenFileException();
+	}
+	Json rootNode;
+	game->ToJson(rootNode); // Encode the game data as JSON and give to the root value.
+	std::vector<uint8_t> jsonData;
+	{
+		PROFILE_SCOPED_DESC("json.to_cbor");
+		jsonData = Json::to_cbor(rootNode); // Convert the JSON data to CBOR.
+	}
+
+	try {
+		// Compress the CBOR data.
+		const std::string comressed_data = gzip::CompressGZip(
+			std::string(reinterpret_cast<const char *>(jsonData.data()), jsonData.size()),
+			name + ".json");
+		size_t nwritten = fwrite(comressed_data.data(), comressed_data.size(), 1, f);
+		fclose(f);
+		if (nwritten != 1) {
+			throw CouldNotWriteToFileException();
+		}
+	} catch (gzip::CompressionFailedException) {
+		fclose(f);
+		throw CouldNotWriteToFileException();
+	}
+
+	Pi::GetApp()->RequestProfileFrame("SaveGame");
+}
+
+
+bool SaveGameManager::DeleteSave(const std::string &name)
+{
+	std::string filePath;
+	try {
+		filePath = FileSystem::JoinPathBelow(s_saveDirName, name);
+	} catch (const std::invalid_argument &) {
+		return false;
+	}
+	return FileSystem::userFiles.RemoveFile(filePath);
+}

--- a/src/SaveGameManager.h
+++ b/src/SaveGameManager.h
@@ -56,7 +56,9 @@ public:
 
 	/** Delete a savegame file. */
 	static bool DeleteSave(const std::string &name);
+
+	/** Return a  list of saved games. */
+	static std::vector<FileSystem::FileInfo> ListSaves();
 };
 
 #endif
-

--- a/src/SaveGameManager.h
+++ b/src/SaveGameManager.h
@@ -1,0 +1,62 @@
+// Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef _SAVEGAMEMANAGER_H
+#define _SAVEGAMEMANAGER_H
+
+#include "FileSystem.h"
+#include "JsonFwd.h"
+
+#include <string>
+#include <vector>
+
+class Game;
+
+class SaveGameManager {
+public:
+	static void Init();
+	static void Uninit();
+
+	/** Return currently supported version of the save game format. */
+	static int CurrentSaveVersion();
+
+	/** Return the savegame direcotry name.
+	 * NOTE: This should only be used for logging purposes. The game nor any
+	 * mods should ever directly access the savegame directory.
+	 */
+	static const std::string GetSaveGameDirectory();
+
+	/** Check whether the named save exists and can be opened.
+	 * NOTE: This does not check whether the named save actually contains a
+	 *       compatible savegame file.
+	 */
+	static bool CanLoadGame(const std::string &name);
+
+	/** Load a game and return a new Game object.
+	 * This function will throw an exception if there is an error during the
+	 * loading process.
+	*/
+	static Game *LoadGame(const std::string &name);
+
+	/** Loads a game and returns it as a Json object.
+	 * NOTE: this function will not perform any sanity checks that the loaded
+	 * file actually contains a Pioneer savegame. It will return a null Json
+	 * object if the contents of the file could not be decoded as a Json object.
+	 *
+	 * This is only required to support the LUA game upgrade/recovery
+	 * implementation.
+	 */
+	static Json LoadGameToJson(const std::string &name);
+
+	/** Save the game.
+	 * NOTE: This function will throw an exception if an error occurs while
+	 * saving the game.
+	*/
+	static void SaveGame(const std::string &name, Game *game);
+
+	/** Delete a savegame file. */
+	static bool DeleteSave(const std::string &name);
+};
+
+#endif
+

--- a/src/lua/LuaGame.cpp
+++ b/src/lua/LuaGame.cpp
@@ -322,6 +322,47 @@ static int l_game_delete_save(lua_State *l)
 }
 
 /*
+ * Function: ListSaves
+ *
+ * Retrieves a list of all game saves along with their last-modified time.
+ *
+ * > Game.ListSaves()
+ *
+ * Parameters:
+ *
+ * Return:
+ *
+ *   saves - a list of save-games as names and modification-date
+ *
+ * Availability:
+ *
+ *   September 2024
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_game_list_saves(lua_State *l)
+{
+	auto saves = SaveGameManager::ListSaves();
+
+	lua_newtable(l);
+	int savesTable = lua_gettop(l);
+	int saves_len = 0;
+
+	for (const auto &save : saves)
+	{
+		LuaTable saveTable(l);
+		saveTable.Set("name", save.GetName());
+		saveTable.Set("mtime", save.GetModificationTime());
+
+		lua_rawseti(l, savesTable, ++saves_len);
+	}
+
+	return 1;
+}
+
+/*
  * Function: EndGame
  *
  * End the current game and return to the main menu.
@@ -710,6 +751,7 @@ void LuaGame::Register()
 		{ "CanLoadGame", l_game_can_load_game },
 		{ "SaveGame", l_game_save_game },
 		{ "DeleteSave", l_game_delete_save },
+		{ "ListSaves", l_game_list_saves },
 		{ "EndGame", l_game_end_game },
 		{ "InHyperspace", l_game_in_hyperspace },
 		{ "SaveGameStats", l_game_savegame_stats },

--- a/src/lua/LuaGame.cpp
+++ b/src/lua/LuaGame.cpp
@@ -14,6 +14,7 @@
 #include "LuaUtils.h"
 #include "Pi.h"
 #include "Player.h"
+#include "SaveGameManager.h"
 #include "SectorView.h"
 #include "Space.h"
 #include "StringF.h"
@@ -97,7 +98,7 @@ static int l_game_savegame_stats(lua_State *l)
 	const std::string filename = LuaPull<std::string>(l, 1);
 
 	try {
-		Json rootNode = Game::LoadGameToJson(filename);
+		Json rootNode = SaveGameManager::LoadGameToJson(filename);
 
 		LuaTable t(l, 0, 3);
 
@@ -157,7 +158,7 @@ static int l_game_savegame_stats(lua_State *l)
  */
 static int l_game_current_save_version(lua_State *l)
 {
-	LuaPush(l, Game::CurrentSaveVersion());
+	LuaPush(l, SaveGameManager::CurrentSaveVersion());
 	return 1;
 }
 
@@ -190,7 +191,7 @@ static int l_game_load_game(lua_State *l)
 	const std::string filename(luaL_checkstring(l, 1));
 
 	try {
-		Pi::StartGame(Game::LoadGame(filename));
+		Pi::StartGame(SaveGameManager::LoadGame(filename));
 	} catch (const SavedGameCorruptException &) {
 		return luaL_error(l, Lang::GAME_LOAD_CORRUPT);
 	} catch (const SavedGameWrongVersionException &) {
@@ -231,7 +232,7 @@ static int l_game_can_load_game(lua_State *l)
 {
 	const std::string filename(luaL_checkstring(l, 1));
 
-	const bool success = Game::CanLoadGame(filename);
+	const bool success = SaveGameManager::CanLoadGame(filename);
 	lua_pushboolean(l, success);
 
 	return 1;
@@ -271,8 +272,8 @@ static int l_game_save_game(lua_State *l)
 	std::string path;
 
 	try {
-		path = FileSystem::JoinPathBelow(Game::GetSaveGameDirectory(), filename);
-		Game::SaveGame(filename, Pi::game);
+		path = FileSystem::JoinPathBelow(SaveGameManager::GetSaveGameDirectory(), filename);
+		SaveGameManager::SaveGame(filename, Pi::game);
 		lua_pushlstring(l, path.c_str(), path.size());
 		return 1;
 	} catch (const CannotSaveInHyperspace &) {
@@ -316,7 +317,7 @@ static int l_game_save_game(lua_State *l)
 static int l_game_delete_save(lua_State *l)
 {
 	const std::string filename(luaL_checkstring(l, 1));
-	lua_pushboolean(l, Game::DeleteSave(filename));
+	lua_pushboolean(l, SaveGameManager::DeleteSave(filename));
 	return 1;
 }
 

--- a/src/lua/LuaGame.cpp
+++ b/src/lua/LuaGame.cpp
@@ -271,7 +271,7 @@ static int l_game_save_game(lua_State *l)
 	std::string path;
 
 	try {
-		path = FileSystem::JoinPathBelow(Pi::GetSaveDir(), filename);
+		path = FileSystem::JoinPathBelow(Game::GetSaveGameDirectory(), filename);
 		Game::SaveGame(filename, Pi::game);
 		lua_pushlstring(l, path.c_str(), path.size());
 		return 1;

--- a/src/lua/LuaJson.cpp
+++ b/src/lua/LuaJson.cpp
@@ -3,8 +3,8 @@
 
 #include "LuaJson.h"
 #include "FileSystem.h"
-#include "Game.h"
 #include "JsonUtils.h"
+#include "SaveGameManager.h"
 #include "LuaObject.h"
 #include "LuaUtils.h"
 
@@ -101,9 +101,10 @@ static int l_load_save_file(lua_State *l)
 {
 	std::string filename = luaL_checkstring(l, 1);
 
-	Json data = JsonUtils::LoadJsonSaveFile(FileSystem::JoinPathBelow(Game::GetSaveGameDirectory(), filename), FileSystem::userFiles);
-	if (data.is_null())
+	Json data = SaveGameManager::LoadGameToJson(filename);
+	if (data.is_null()) {
 		return luaL_error(l, "Error loading JSON file %s.", filename.c_str());
+	}
 
 	_push_json_to_lua(l, data);
 

--- a/src/lua/LuaJson.cpp
+++ b/src/lua/LuaJson.cpp
@@ -3,10 +3,10 @@
 
 #include "LuaJson.h"
 #include "FileSystem.h"
+#include "Game.h"
 #include "JsonUtils.h"
 #include "LuaObject.h"
 #include "LuaUtils.h"
-#include "Pi.h"
 
 /*
  * Interface: Json
@@ -101,7 +101,7 @@ static int l_load_save_file(lua_State *l)
 {
 	std::string filename = luaL_checkstring(l, 1);
 
-	Json data = JsonUtils::LoadJsonSaveFile(FileSystem::JoinPathBelow(Pi::SAVE_DIR_NAME, filename), FileSystem::userFiles);
+	Json data = JsonUtils::LoadJsonSaveFile(FileSystem::JoinPathBelow(Game::GetSaveGameDirectory(), filename), FileSystem::userFiles);
 	if (data.is_null())
 		return luaL_error(l, "Error loading JSON file %s.", filename.c_str());
 

--- a/src/lua/LuaPushPull.h
+++ b/src/lua/LuaPushPull.h
@@ -33,6 +33,22 @@ inline void pi_lua_generic_push(lua_State *l, const std::string_view &value)
 	lua_pushlstring(l, value.data(), value.size());
 }
 inline void pi_lua_generic_push(lua_State *l, const std::nullptr_t &value) { lua_pushnil(l); }
+inline void pi_lua_generic_push(lua_State *l, const Time::DateTime &dt) {
+	int year, month, day, hour, minute, second;
+	dt.GetDateParts(&year, &month, &day);
+	dt.GetTimeParts(&hour, &minute, &second);
+
+	lua_createtable(l, 7, 0);
+	pi_lua_settable(l, "year", year);
+	pi_lua_settable(l, "month", month);
+	pi_lua_settable(l, "day", day);
+	pi_lua_settable(l, "hour", hour);
+	pi_lua_settable(l, "minute", minute);
+	pi_lua_settable(l, "second", second);
+	pi_lua_settable(l, "timestamp", dt.ToGameTime());
+}
+
+
 
 inline void pi_lua_generic_pull(lua_State *l, int index, bool &out) { out = lua_toboolean(l, index); }
 inline void pi_lua_generic_pull(lua_State *l, int index, int32_t &out) { out = luaL_checkinteger(l, index); }

--- a/src/lua/LuaUtils.cpp
+++ b/src/lua/LuaUtils.cpp
@@ -303,6 +303,22 @@ static int l_readonly_table_ipairs(lua_State *l)
 	return 3;
 }
 
+void pi_lua_push_date_time(lua_State *l, const Time::DateTime &dt)
+{
+	int year, month, day, hour, minute, second;
+	dt.GetDateParts(&year, &month, &day);
+	dt.GetTimeParts(&hour, &minute, &second);
+
+	lua_newtable(l);
+	pi_lua_settable(l, "year", year);
+	pi_lua_settable(l, "month", month);
+	pi_lua_settable(l, "day", day);
+	pi_lua_settable(l, "hour", hour);
+	pi_lua_settable(l, "minute", minute);
+	pi_lua_settable(l, "second", second);
+	pi_lua_settable(l, "timestamp", dt.ToGameTime());
+}
+
 void pi_lua_readonly_table_proxy(lua_State *l, int table_idx)
 {
 	table_idx = lua_absindex(l, table_idx);

--- a/src/lua/LuaUtils.h
+++ b/src/lua/LuaUtils.h
@@ -6,6 +6,7 @@
 
 // to mask __attribute on MSVC
 #include "core/macros.h"
+#include "DateTime.h"
 
 #include <lua.hpp>
 #include <string>
@@ -62,6 +63,9 @@ inline void pi_lua_settable(lua_State *l, const char *key, const char *value)
 	lua_pushstring(l, value);
 	lua_rawset(l, -3);
 }
+
+/** Push a DateTime as a new table into \p l. */
+void pi_lua_push_date_time(lua_State *l, const Time::DateTime &dt);
 
 void pi_lua_open_standard_base(lua_State *l);
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Fixes #5921

The [first commit](64d48a8cef8f5a636b0a78b5c087045793456866) fixes the issue. This prevents a spurious popup from being shown when the game is started for the first time and the user attempts to load a game, as the creation of the "savefiles" directory was deferred until the first savegame was created. It also moves the remaining savegame-related items from the "Pi" class into the "Game" class to clean up the codebase.

The [second commit](63d31a389766f40487b91d4f8eb66a0efa98eb42) refactors the implementation to break all the savegame handling out of the "Game" class and into a new "SaveGameManager" class. This refactor is purely to compartmentalise the existing implementation better and follows the pattern laid out by the "ModManager" class.

The [third commit])(b60d6ca958617273ff3266340ee2626172a686f7) adds a "ListSaves" API, which allows a refactor of the Lua to remove the direct reference to the "savefiles" string and instead delegate this to the "SaveGameManager".

----

Initial testing shows all functionality behaving as expected (Load/Save games, list games, Autosave games).

No tests were made as to loading older saves to ensure upgrades still work, but there is nothing in this work to suggest that this should break.

----

NOTE: Only the first commit is necessary to fix the actual issue; the others are optional and can be reverted.