### PR TITLE
CppCheck 2.15 performance cleanup

### DIFF
--- a/scripts/Pioneer.cppcheck
+++ b/scripts/Pioneer.cppcheck
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="1">
+    <platform>win64</platform>
+    <analyze-all-vs-configs>false</analyze-all-vs-configs>
+    <check-headers>true</check-headers>
+    <check-unused-templates>true</check-unused-templates>
+    <inline-suppression>true</inline-suppression>
+    <max-ctu-depth>2</max-ctu-depth>
+    <max-template-recursion>100</max-template-recursion>
     <paths>
         <dir name="../src"/>
     </paths>

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -262,7 +262,7 @@ namespace Background {
 
 	class SampleStarsTask : public Task {
 	public:
-		SampleStarsTask(RefCountedPtr<Galaxy> galaxy, StarQueryInfo info, int32_t starsLimit, StarInfo &stars, double &medianBrightness, TaskRange range) :
+		SampleStarsTask(RefCountedPtr<Galaxy> galaxy, const StarQueryInfo &info, int32_t starsLimit, StarInfo &stars, double &medianBrightness, TaskRange range) :
 			Task(range),
 			galaxy(galaxy),
 			info(info),
@@ -374,7 +374,7 @@ namespace Background {
 
 	class SortStarsTask : public Task {
 	public:
-		SortStarsTask(StarQueryInfo info, StarInfo &stars, double medianBrightness) :
+		SortStarsTask(const StarQueryInfo &info, StarInfo &stars, double medianBrightness) :
 			info(info),
 			stars(stars),
 			medianBrightness(medianBrightness)

--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -43,15 +43,15 @@ BaseSphere::~BaseSphere() {}
 void BaseSphere::Init()
 {
 	PROFILE_SCOPED()
-	GeoSphere::Init();
-	GasGiant::Init();
+	GeoSphere::InitGeoSphere();
+	GasGiant::InitGasGiant();
 }
 
 //static
 void BaseSphere::Uninit()
 {
-	GeoSphere::Uninit();
-	GasGiant::Uninit();
+	GeoSphere::UninitGeoSphere();
+	GasGiant::UninitGasGiant();
 }
 
 //static
@@ -64,7 +64,7 @@ void BaseSphere::UpdateAllBaseSphereDerivatives()
 //static
 void BaseSphere::OnChangeDetailLevel()
 {
-	GeoSphere::OnChangeDetailLevel();
+	GeoSphere::OnChangeGeoSphereDetailLevel();
 }
 
 void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,

--- a/src/FileSystem.cpp
+++ b/src/FileSystem.cpp
@@ -146,7 +146,7 @@ namespace FileSystem {
 		return path;
 	}
 
-	bool CopyDir(FileSource &sourceFS, std::string sourceDir, FileSourceFS &targetFS, std::string targetDir, FileSystem::CopyMode copymode)
+	bool CopyDir(FileSource &sourceFS, const std::string &sourceDir, FileSourceFS &targetFS, const std::string &targetDir, FileSystem::CopyMode copymode)
 	{
 		// NOTE: copymode var is not used, because only mode ONLY_MISSING_IN_TARGET is implemented
 		if (!sourceFS.Lookup(sourceDir).IsDir() || !targetFS.Lookup(targetDir).IsDir())

--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -73,7 +73,7 @@ namespace FileSystem {
 
 	/// Copy the contents of a directory from sourceFS into a directory in targetFS, according to copymode.
 	/// Returns false if sourceDir or targetDir are invalid
-	bool CopyDir(FileSource &sourceFS, std::string sourceDir, FileSourceFS &targetFS, std::string targetDir, CopyMode copymode = CopyMode::OVERWRITE);
+	bool CopyDir(FileSource &sourceFS, const std::string &sourceDir, FileSourceFS &targetFS, const std::string &targetDir, CopyMode copymode = CopyMode::OVERWRITE);
 
 	class FileInfo {
 		friend class FileSource;

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -135,7 +135,7 @@ public:
 
 		// add all of the middle indices
 		for (int i = 0; i < IDX_VBO_COUNT_ALL_IDX(); ++i) {
-			pl.push_back(indices[i]);
+			pl.emplace_back(indices[i]);
 		}
 
 		return tri_count;
@@ -303,7 +303,7 @@ GasGiant::GasGiant(const SystemBody *body) :
 	m_hasGpuJobRequest(false),
 	m_timeDelay(s_initialCPUDelayTime)
 {
-	s_allGasGiants.push_back(this);
+	s_allGasGiants.emplace_back(this);
 
 	for (int i = 0; i < NUM_PATCHES; i++) {
 		m_hasJobRequest[i] = false;
@@ -741,7 +741,7 @@ void GasGiant::BuildFirstPatches()
 	GenerateTexture();
 }
 
-void GasGiant::Init()
+void GasGiant::InitGasGiant()
 {
 	IniConfig cfg;
 	cfg.Read(FileSystem::gameDataFiles, "configs/GasGiants.ini");
@@ -764,7 +764,7 @@ void GasGiant::Init()
 	CreateRenderTarget(s_texture_size_gpu[Pi::detail.planets], s_texture_size_gpu[Pi::detail.planets]);
 }
 
-void GasGiant::Uninit()
+void GasGiant::UninitGasGiant()
 {
 	s_patchContext.Reset();
 }

--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -47,16 +47,14 @@ public:
 
 	static bool OnAddTextureFaceResult(const SystemPath &path, GasGiantJobs::STextureFaceResult *res);
 	static bool OnAddGPUGenResult(const SystemPath &path, GasGiantJobs::SGPUGenResult *res);
-	static void Init();
-	static void Uninit();
+	static void InitGasGiant();
+	static void UninitGasGiant();
 	static void UpdateAllGasGiants();
 	static void OnChangeDetailLevel();
 
 	static void CreateRenderTarget(const Uint16 width, const Uint16 height);
 	static void SetRenderTargetCubemap(const Uint32, Graphics::Texture *, const bool unBind = true);
 	static Graphics::RenderTarget *GetRenderTarget();
-	static void BeginRenderTarget();
-	static void EndRenderTarget();
 
 private:
 	void BuildFirstPatches();

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -40,12 +40,12 @@ static const int detail_edgeLen[5] = {
 static const double gs_targetPatchTriLength(100.0);
 static std::vector<GeoSphere *> s_allGeospheres;
 
-void GeoSphere::Init()
+void GeoSphere::InitGeoSphere()
 {
 	s_patchContext.Reset(new GeoPatchContext(detail_edgeLen[Pi::detail.planets > 4 ? 4 : Pi::detail.planets]));
 }
 
-void GeoSphere::Uninit()
+void GeoSphere::UninitGeoSphere()
 {
 	assert(s_patchContext.Unique());
 	s_patchContext.Reset();
@@ -71,7 +71,7 @@ void GeoSphere::UpdateAllGeoSpheres()
 }
 
 // static
-void GeoSphere::OnChangeDetailLevel()
+void GeoSphere::OnChangeGeoSphereDetailLevel()
 {
 	s_patchContext.Reset(new GeoPatchContext(detail_edgeLen[Pi::detail.planets > 4 ? 4 : Pi::detail.planets]));
 
@@ -187,7 +187,7 @@ GeoSphere::GeoSphere(const SystemBody *body) :
 {
 	print_info(body, m_terrain.Get());
 
-	s_allGeospheres.push_back(this);
+	s_allGeospheres.emplace_back(this);
 
 	CalculateMaxPatchDepth();
 
@@ -207,7 +207,7 @@ bool GeoSphere::AddQuadSplitResult(SQuadSplitResult *res)
 	assert(res);
 	assert(mQuadSplitResults.size() < MAX_SPLIT_OPERATIONS);
 	if (mQuadSplitResults.size() < MAX_SPLIT_OPERATIONS) {
-		mQuadSplitResults.push_back(res);
+		mQuadSplitResults.emplace_back(res);
 		result = true;
 	}
 	return result;
@@ -219,7 +219,7 @@ bool GeoSphere::AddSingleSplitResult(SSingleSplitResult *res)
 	assert(res);
 	assert(mSingleSplitResults.size() < MAX_SPLIT_OPERATIONS);
 	if (mSingleSplitResults.size() < MAX_SPLIT_OPERATIONS) {
-		mSingleSplitResults.push_back(res);
+		mSingleSplitResults.emplace_back(res);
 		result = true;
 	}
 	return result;
@@ -360,7 +360,7 @@ void GeoSphere::Update()
 
 void GeoSphere::AddQuadSplitRequest(double dist, SQuadSplitRequest *pReq, GeoPatch *pPatch)
 {
-	mQuadSplitRequests.push_back(TDistanceRequest(dist, pReq, pPatch));
+	mQuadSplitRequests.emplace_back(dist, pReq, pPatch);
 }
 
 void GeoSphere::ProcessQuadSplitRequests()

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -50,10 +50,10 @@ public:
 		return h;
 	}
 
-	static void Init();
-	static void Uninit();
+	static void InitGeoSphere();
+	static void UninitGeoSphere();
 	static void UpdateAllGeoSpheres();
-	static void OnChangeDetailLevel();
+	static void OnChangeGeoSphereDetailLevel();
 	static bool OnAddQuadSplitResult(const SystemPath &path, SQuadSplitResult *res);
 	static bool OnAddSingleSplitResult(const SystemPath &path, SSingleSplitResult *res);
 	// in sbody radii

--- a/src/HudTrail.cpp
+++ b/src/HudTrail.cpp
@@ -16,11 +16,10 @@ const Uint16 MAX_POINTS = 100;
 
 HudTrail::HudTrail(Body *b, const Color &c) :
 	m_body(b),
+	m_currentFrame(b->GetFrame()),
 	m_updateTime(0.f),
 	m_color(c)
 {
-	m_currentFrame = b->GetFrame();
-
 	Graphics::MaterialDescriptor desc;
 
 	Graphics::RenderStateDesc rsd;
@@ -45,7 +44,7 @@ void HudTrail::Update(float time)
 		}
 
 		if (bodyFrameId == m_currentFrame)
-			m_trailPoints.push_back(m_body->GetInterpPosition());
+			m_trailPoints.emplace_back(m_body->GetInterpPosition());
 	}
 
 	while (m_trailPoints.size() > MAX_POINTS)
@@ -71,15 +70,15 @@ void HudTrail::Render(Graphics::Renderer *r)
 		tvts.reserve(MAX_POINTS);
 		colors.reserve(MAX_POINTS);
 
-		tvts.push_back(vector3f(0.f));
-		colors.push_back(Color::BLANK);
+		tvts.emplace_back(vector3f(0.f));
+		colors.emplace_back(Color::BLANK);
 		float alpha = 1.f;
 		const float decrement = 1.f / m_trailPoints.size();
 		const Color tcolor = m_color;
 		for (size_t i = m_trailPoints.size() - 1; i > 0; i--) {
-			tvts.push_back(-vector3f(curpos - m_trailPoints[i]));
+			tvts.emplace_back(-vector3f(curpos - m_trailPoints[i]));
 			alpha -= decrement;
-			colors.push_back(tcolor);
+			colors.emplace_back(tcolor);
 			colors.back().a = Uint8(alpha * 255);
 		}
 

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -285,7 +285,7 @@ void Manager::InitGame()
 
 */
 
-InputBindings::Action *InputFrame::AddAction(std::string id)
+InputBindings::Action *InputFrame::AddAction(const std::string &id)
 {
 	auto *action = manager->GetActionBinding(id);
 	if (!action)
@@ -295,7 +295,7 @@ InputBindings::Action *InputFrame::AddAction(std::string id)
 	return action;
 }
 
-InputBindings::Axis *InputFrame::AddAxis(std::string id)
+InputBindings::Axis *InputFrame::AddAxis(const std::string &id)
 {
 	auto *axis = manager->GetAxisBinding(id);
 	if (!axis)
@@ -368,7 +368,7 @@ void Manager::RemoveInputFrame(InputFrame *frame)
 	}
 }
 
-InputBindings::Action *Manager::AddActionBinding(std::string id, BindingGroup *group, InputBindings::Action &&binding)
+InputBindings::Action *Manager::AddActionBinding(const std::string &id, BindingGroup *group, InputBindings::Action &&binding)
 {
 	// throw an error if we attempt to bind an action onto an already-bound axis in the same group.
 	if (group->bindings.count(id) && group->bindings[id] != BindingGroup::ENTRY_ACTION)
@@ -386,7 +386,7 @@ InputBindings::Action *Manager::AddActionBinding(std::string id, BindingGroup *g
 	return &(actionBindings[id] = binding);
 }
 
-InputBindings::Axis *Manager::AddAxisBinding(std::string id, BindingGroup *group, InputBindings::Axis &&binding)
+InputBindings::Axis *Manager::AddAxisBinding(const std::string &id, BindingGroup *group, InputBindings::Axis &&binding)
 {
 	// throw an error if we attempt to bind an axis onto an already-bound action in the same group.
 	if (group->bindings.count(id) && group->bindings[id] != BindingGroup::ENTRY_AXIS)
@@ -404,12 +404,12 @@ InputBindings::Axis *Manager::AddAxisBinding(std::string id, BindingGroup *group
 	return &(axisBindings[id] = binding);
 }
 
-InputBindings::Action *Manager::GetActionBinding(std::string id)
+InputBindings::Action *Manager::GetActionBinding(const std::string &id)
 {
 	return actionBindings.count(id) ? &actionBindings[id] : &Input::nullAction;
 }
 
-InputBindings::Axis *Manager::GetAxisBinding(std::string id)
+InputBindings::Axis *Manager::GetAxisBinding(const std::string &id)
 {
 	return axisBindings.count(id) ? &axisBindings[id] : &Input::nullAxis;
 }

--- a/src/Input.h
+++ b/src/Input.h
@@ -40,7 +40,7 @@ namespace Input {
 	};
 
 	struct BindingPage {
-		BindingGroup *GetBindingGroup(std::string id) { return &groups[id]; }
+		BindingGroup *GetBindingGroup(const std::string &id) { return &groups[id]; }
 
 		std::map<std::string, BindingGroup> groups;
 	};
@@ -71,8 +71,8 @@ namespace Input {
 		// Called when the frame is removed from the stack.
 		sigc::signal<void, InputFrame *> onFrameRemoved;
 
-		Action *AddAction(std::string id);
-		Axis *AddAxis(std::string id);
+		Action *AddAction(const std::string &id);
+		Axis *AddAxis(const std::string &id);
 	};
 
 	struct JoystickInfo {
@@ -138,8 +138,8 @@ public:
 	// When enable is false, this prevents the input system from writing to the config file.
 	void EnableConfigSaving(bool enable) { m_enableConfigSaving = enable; }
 
-	BindingPage *GetBindingPage(std::string id) { return &bindingPages[id]; }
-	std::map<std::string, BindingPage> GetBindingPages() { return bindingPages; }
+	BindingPage *GetBindingPage(const std::string &id) { return &bindingPages[id]; }
+	const std::map<std::string, BindingPage>& GetBindingPages() const { return bindingPages; }
 
 	// Pushes an InputFrame onto the input stack.
 	bool AddInputFrame(InputFrame *frame);
@@ -158,13 +158,13 @@ public:
 
 	// Creates a new action binding, copying the provided binding.
 	// The returned binding pointer points to the actual binding.
-	InputBindings::Action *AddActionBinding(std::string id, BindingGroup *group, InputBindings::Action &&binding);
-	InputBindings::Action *GetActionBinding(std::string id);
+	InputBindings::Action *AddActionBinding(const std::string &id, BindingGroup *group, InputBindings::Action &&binding);
+	InputBindings::Action *GetActionBinding(const std::string &id);
 
 	// Creates a new axis binding, copying the provided binding.
 	// The returned binding pointer points to the actual binding.
-	InputBindings::Axis *AddAxisBinding(std::string id, BindingGroup *group, InputBindings::Axis &&binding);
-	InputBindings::Axis *GetAxisBinding(std::string id);
+	InputBindings::Axis *AddAxisBinding(const std::string &id, BindingGroup *group, InputBindings::Axis &&binding);
+	InputBindings::Axis *GetAxisBinding(const std::string &id);
 
 	// Call EnableBindings() to temporarily disable handling input bindings while
 	// you're recording a new input binding or are in a modal window.

--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -58,10 +58,6 @@ Intro::Intro(Graphics::Renderer *r, int width, int height) :
 			}
 			model->SetThrusterColor(dir, ShipType::types[i].directionThrusterColor[j]);
 		}
-		const Uint32 numMats = model->GetNumMaterials();
-		for (Uint32 m = 0; m < numMats; m++) {
-			RefCountedPtr<Graphics::Material> mat = model->GetMaterialByIndex(m);
-		}
 		m_models.push_back(model);
 	}
 

--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -41,7 +41,7 @@ Intro::Intro(Graphics::Renderer *r, int width, int height) :
 	m_skin.SetDecal("pioneer");
 	m_skin.SetLabel(Lang::PIONEER);
 
-	for (auto i : ShipType::player_ships) {
+	for (const auto &i : ShipType::player_ships) {
 		SceneGraph::Model *model = Pi::FindModel(ShipType::types[i].modelName)->MakeInstance();
 		model->SetThrust(vector3f(0.f, 0.f, -0.6f), vector3f(0.f));
 		if (ShipType::types[i].isGlobalColorDefined) model->SetThrusterColor(ShipType::types[i].globalThrusterColor);

--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -30,11 +30,10 @@ ObjectViewerView::ObjectViewerView() :
 	PiGuiView("ObjectViewerView"),
 	m_targetBody(nullptr),
 	m_systemBody(nullptr),
-	m_state{}
+	m_state{},
+	viewingDist(1000.0f),
+	m_camRot(matrix4x4d::Identity())
 {
-	viewingDist = 1000.0f;
-	m_camRot = matrix4x4d::Identity();
-
 	float znear;
 	float zfar;
 	Pi::renderer->GetNearFarRange(znear, zfar);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -158,7 +158,7 @@ protected:
 	bool m_hasQueuedJobs = 0;
 
 	template <typename T>
-	void AddStep(std::string name, T fn)
+	void AddStep(const std::string &name, T fn)
 	{
 		m_loaders.push_back(LoadStep{ fn, name });
 	}

--- a/src/RefCounted.h
+++ b/src/RefCounted.h
@@ -12,7 +12,7 @@ class RefCounted : public LuaWrappable {
 public:
 	RefCounted() :
 		m_refCount(0) {}
-	virtual ~RefCounted() {}
+	virtual ~RefCounted() override {}
 
 	inline void IncRefCount() const { ++m_refCount; }
 	inline void DecRefCount() const

--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -372,7 +372,7 @@ void SectorView::ClearRoute()
 	m_setupLines = true;
 }
 
-std::vector<SystemPath> SectorView::GetRoute()
+const std::vector<SystemPath> &SectorView::GetRoute() const
 {
 	return m_route;
 }

--- a/src/SectorView.h
+++ b/src/SectorView.h
@@ -56,7 +56,7 @@ public:
 	void AddToRoute(const SystemPath &path);
 	bool RemoveRouteItem(const std::vector<SystemPath>::size_type element);
 	void ClearRoute();
-	std::vector<SystemPath> GetRoute();
+	const std::vector<SystemPath>& GetRoute() const;
 	const std::string AutoRoute(const SystemPath &start, const SystemPath &target, std::vector<SystemPath> &outRoute) const;
 	void SetDrawRouteLines(bool value);
 

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -80,13 +80,14 @@ static void RelocateStarportIfNecessary(SystemBody *sbody, Planet *planet, vecto
 		// check height at 6 points around the starport center stays within variation tolerances
 		// GetHeight gives a varying height field in 3 dimensions.
 		// Given it's smoothly varying it's fine to sample it in arbitrary directions to get an idea of how sharply it varies
-		double v[6];
-		v[0] = fabs(planet->GetTerrainHeight(vector3d(pos_.x + delta, pos_.y, pos_.z)) - radius - height);
-		v[1] = fabs(planet->GetTerrainHeight(vector3d(pos_.x - delta, pos_.y, pos_.z)) - radius - height);
-		v[2] = fabs(planet->GetTerrainHeight(vector3d(pos_.x, pos_.y, pos_.z + delta)) - radius - height);
-		v[3] = fabs(planet->GetTerrainHeight(vector3d(pos_.x, pos_.y, pos_.z - delta)) - radius - height);
-		v[4] = fabs(planet->GetTerrainHeight(vector3d(pos_.x, pos_.y + delta, pos_.z)) - radius - height);
-		v[5] = fabs(planet->GetTerrainHeight(vector3d(pos_.x, pos_.y - delta, pos_.z)) - radius - height);
+		double v[6]{
+			fabs(planet->GetTerrainHeight(vector3d(pos_.x + delta, pos_.y, pos_.z)) - radius - height),
+			fabs(planet->GetTerrainHeight(vector3d(pos_.x - delta, pos_.y, pos_.z)) - radius - height),
+			fabs(planet->GetTerrainHeight(vector3d(pos_.x, pos_.y, pos_.z + delta)) - radius - height),
+			fabs(planet->GetTerrainHeight(vector3d(pos_.x, pos_.y, pos_.z - delta)) - radius - height),
+			fabs(planet->GetTerrainHeight(vector3d(pos_.x, pos_.y + delta, pos_.z)) - radius - height),
+			fabs(planet->GetTerrainHeight(vector3d(pos_.x, pos_.y - delta, pos_.z)) - radius - height),
+		};
 
 		// break if variation for all points is within limits
 		double variationMax = 0.0;
@@ -1085,8 +1086,9 @@ void Space::TimeStep(float step)
 	}
 	Frame::UpdateOrbitRails(m_game->GetTime(), m_game->GetTimeStep());
 
-	for (Body *b : m_bodies)
+	for (Body *b : m_bodies) {
 		b->TimeStepUpdate(step);
+	}
 
 	LuaEvent::Emit();
 	Pi::luaTimer->Tick();

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -80,7 +80,7 @@ SystemView::~SystemView()
 {
 }
 
-void SystemView::CalculateShipPositionAtTime(const Ship *s, Orbit o, double t, vector3d &pos)
+void SystemView::CalculateShipPositionAtTime(const Ship *s, const Orbit &o, double t, vector3d &pos)
 {
 	pos = vector3d(0., 0., 0.);
 	FrameId shipFrameId = s->GetFrame();
@@ -289,15 +289,16 @@ SystemMapViewport::SystemMapViewport(GuiApplication *app) :
 	m_showL4L5(LAG_OFF),
 	m_shipDrawing(OFF),
 	m_gridDrawing(GridDrawing::OFF),
+	m_atlasPos(vector2f()),
+	m_atlasZoom(1.0f),
+	m_atlasZoomTo(1.0f),
+	m_rot_y(0),
+	m_rot_x(50),
+	m_zoom(1.0f / float(AU)),
 	m_trans(0.0),
-	m_transTo(0.0)
+	m_transTo(0.0),
+	m_realtime(true)
 {
-	m_rot_y = 0;
-	m_rot_x = 50;
-	m_atlasPos = vector2f();
-	m_zoom = 1.0f / float(AU);
-	m_atlasZoom = m_atlasZoomTo = 1.0f;
-
 	m_input.RegisterBindings();
 
 	Graphics::MaterialDescriptor lineMatDesc;
@@ -309,8 +310,6 @@ SystemMapViewport::SystemMapViewport(GuiApplication *app) :
 
 	rsd.primitiveType = Graphics::LINE_SINGLE;
 	m_gridMat.reset(m_renderer->CreateMaterial("vtxColor", lineMatDesc, rsd));
-
-	m_realtime = true;
 
 	ResetViewpoint();
 
@@ -388,7 +387,7 @@ void SystemMapViewport::SetCurrentSystem(RefCountedPtr<StarSystem> system)
 	ResetViewpoint();
 }
 
-void SystemMapViewport::RenderOrbit(Projectable p, const ProjectedOrbit *orbitData, const vector3d &offset)
+void SystemMapViewport::RenderOrbit(const Projectable &p, const ProjectedOrbit *orbitData, const vector3d &offset)
 {
 	PROFILE_SCOPED()
 
@@ -1037,7 +1036,7 @@ std::vector<Projectable::GroupInfo> SystemMapViewport::GroupProjectables(vector2
 	return outGroups;
 }
 
-void SystemMapViewport::AddObjectTrack(Projectable p)
+void SystemMapViewport::AddObjectTrack(const Projectable &p)
 {
 	m_objectTracks.push_back(p);
 
@@ -1073,7 +1072,7 @@ void SystemMapViewport::AddProjected(Projectable p, Projectable::types type, con
 	m_projected.push_back(p);
 }
 
-void SystemMapViewport::SetVisibility(std::string param)
+void SystemMapViewport::SetVisibility(const std::string &param)
 {
 	if (param == "RESET_VIEW")
 		ResetViewpoint();
@@ -1127,7 +1126,7 @@ void SystemMapViewport::ClearSelectedObject()
 	m_selectedObject.type = Projectable::NONE;
 }
 
-void SystemMapViewport::SetViewedObject(Projectable p)
+void SystemMapViewport::SetViewedObject(const Projectable &p)
 {
 	// we will immediately determine the coordinates of the viewed body so that
 	// there is a correct starting point of the transition animation, otherwise

--- a/src/SystemView.h
+++ b/src/SystemView.h
@@ -186,7 +186,7 @@ private:
 	void RefreshShips(void);
 	void AddShipTracks(double atTime);
 
-	void CalculateShipPositionAtTime(const Ship *s, Orbit o, double t, vector3d &pos);
+	void CalculateShipPositionAtTime(const Ship *s, const Orbit &o, double t, vector3d &pos);
 	void CalculateFramePositionAtTime(FrameId frameId, double t, vector3d &pos);
 
 	double CalculateStarportHeight(const SystemBody *body);
@@ -237,11 +237,11 @@ public:
 	void Draw3D();
 
 	Projectable *GetSelectedObject() { return &m_selectedObject; }
-	void SetSelectedObject(Projectable p) { m_selectedObject = p; }
+	void SetSelectedObject(const Projectable &p) { m_selectedObject = p; }
 	void ClearSelectedObject();
 
 	void ViewSelectedObject() { SetViewedObject(m_selectedObject); }
-	void SetViewedObject(Projectable p);
+	void SetViewedObject(const Projectable &p);
 	void ResetViewpoint();
 
 	Projectable *GetViewedObject() { return &m_viewedObject; }
@@ -257,7 +257,7 @@ public:
 
 	// Push a tracked object / sensor contact for display on the map.
 	// Object tracks are cleared every frame.
-	void AddObjectTrack(Projectable p);
+	void AddObjectTrack(const Projectable &p);
 
 	// Push an orbital conic for display on the map
 	// Expects the orbit's center to be provide as p.worldpos
@@ -272,7 +272,7 @@ public:
 	void SetReferenceTime(double time) { m_refTime = time; }
 	double GetTime() { return m_time; }
 	const std::vector<Projectable> &GetProjected() const { return m_projected; }
-	void SetVisibility(std::string param);
+	void SetVisibility(const std::string &param);
 	void SetZoomMode(bool enable);
 	void SetRotateMode(bool enable);
 	void SetDisplayMode(SystemView::Mode displayMode) { m_displayMode = displayMode; }
@@ -324,7 +324,7 @@ private:
 	// Project a track to screenspace with the current renderer state and add it to the list of projected objects
 	void AddProjected(Projectable p, Projectable::types type, const vector3d &transformedPos, float screensize = 0.f);
 	void RenderBody(const SystemBody *b, const vector3d &pos, const matrix4x4f &trans);
-	void RenderOrbit(Projectable p, const ProjectedOrbit *orbitData, const vector3d &transformedPos);
+	void RenderOrbit(const Projectable &p, const ProjectedOrbit *orbitData, const vector3d &transformedPos);
 
 	// draw a grid with `radius` * 2 gridlines on an evenly spaced 1-AU grid
 	void DrawGrid(uint32_t radius);

--- a/src/collider/GeomTree.cpp
+++ b/src/collider/GeomTree.cpp
@@ -8,6 +8,7 @@
 #include "scenegraph/Serializer.h"
 #include "../utils.h"
 
+#include <array>
 #include <map>
 
 #pragma GCC optimize("O3")
@@ -16,7 +17,7 @@ GeomTree::~GeomTree()
 {
 }
 
-GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vector3f> &vertices, const std::vector<Uint32> indices, const std::vector<Uint32> triFlags) :
+GeomTree::GeomTree(const int numVerts, const int numTris, const std::vector<vector3f> &vertices, const std::vector<Uint32> &indices, const std::vector<Uint32> &triFlags) :
 	m_numVertices(numVerts),
 	m_numTris(numTris),
 	m_vertices(vertices),

--- a/src/collider/GeomTree.h
+++ b/src/collider/GeomTree.h
@@ -25,7 +25,7 @@ struct BVHNode;
 
 class GeomTree {
 public:
-	GeomTree(const int numVerts, const int numTris, const std::vector<vector3f> &vertices, const std::vector<Uint32> indices, const std::vector<Uint32> triFlags);
+	GeomTree(const int numVerts, const int numTris, const std::vector<vector3f> &vertices, const std::vector<Uint32> &indices, const std::vector<Uint32> &triFlags);
 	GeomTree(Serializer::Reader &rd);
 	void Save(Serializer::Writer &wr) const;
 

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -19,7 +19,7 @@
 #include "profiler/Profiler.h"
 #include "versioningInfo.h"
 
-GuiApplication::GuiApplication(std::string title) :
+GuiApplication::GuiApplication(const std::string &title) :
 	Application(), m_applicationTitle(title)
 {}
 

--- a/src/core/GuiApplication.h
+++ b/src/core/GuiApplication.h
@@ -26,7 +26,7 @@ namespace Graphics {
 
 class GuiApplication : public Application {
 public:
-	GuiApplication(std::string title);
+	GuiApplication(const std::string &title);
 	~GuiApplication();
 
 	Graphics::Renderer *GetRenderer() { return m_renderer.get(); }

--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -35,7 +35,7 @@ Log::Logger::~Logger()
 		fclose(file);
 }
 
-bool Log::Logger::SetLogFile(std::string filename)
+bool Log::Logger::SetLogFile(const std::string &filename)
 {
 	FILE *stream = FileSystem::userFiles.OpenWriteStream(filename, FileSystem::FileSourceFS::WRITE_TEXT);
 	if (!stream) {

--- a/src/core/Log.h
+++ b/src/core/Log.h
@@ -28,7 +28,7 @@ namespace Log {
 		void LogLevel(Severity sv, std::string_view message);
 		void LogLevel(Severity sv, const char *message);
 
-		bool SetLogFile(std::string filename);
+		bool SetLogFile(const std::string &filename);
 		FILE *GetLogFileHandle() { return file; }
 
 		// Return the severity cutoff at which log messages will be printed to stderr.

--- a/src/core/StringUtils.cpp
+++ b/src/core/StringUtils.cpp
@@ -89,7 +89,7 @@ std::string format_date_only(double t)
 	return buf;
 }
 
-std::string string_join(std::vector<std::string> &v, std::string sep)
+std::string string_join(std::vector<std::string> &v, const std::string &sep)
 {
 	std::vector<std::string>::iterator i = v.begin();
 	std::string out;

--- a/src/editor/ActionBinder.cpp
+++ b/src/editor/ActionBinder.cpp
@@ -145,7 +145,7 @@ void ActionBinder::DrawMenuInternal(Group &group, bool submitMenuItem)
 		ImGui::EndMenu();
 }
 
-void ActionBinder::BeginInternal(std::string id, bool menu)
+void ActionBinder::BeginInternal(const std::string &id, bool menu)
 {
 	for (std::string_view name : SplitString(id, ".")) {
 
@@ -178,7 +178,7 @@ void ActionBinder::EndInternal()
 	m_activeGroupStack.pop_back();
 }
 
-void ActionBinder::AddInternal(std::string id, ActionEntry &&entry)
+void ActionBinder::AddInternal(const std::string &id, ActionEntry &&entry)
 {
 	if (m_activeGroupStack.empty())
 		return;
@@ -191,7 +191,7 @@ void ActionBinder::AddInternal(std::string id, ActionEntry &&entry)
 	group->entries.push_back(&iter->second);
 }
 
-ActionEntry *ActionBinder::GetAction(std::string id)
+ActionEntry *ActionBinder::GetAction(const std::string &id)
 {
 	if (!m_actionStorage.count(id))
 		return nullptr;
@@ -199,7 +199,7 @@ ActionEntry *ActionBinder::GetAction(std::string id)
 	return &m_actionStorage.at(id);
 }
 
-void ActionBinder::TriggerAction(std::string id)
+void ActionBinder::TriggerAction(const std::string &id)
 {
 	ActionEntry *entry = GetAction(id);
 

--- a/src/editor/ActionBinder.h
+++ b/src/editor/ActionBinder.h
@@ -87,10 +87,10 @@ namespace Editor {
 
 		// draw the GroupEntry named by 'id' in the context of an existing
 		// dropdown menu (i.e. do not submit a top-level BeginMenu)
-		void DrawGroup(std::string id) { DrawMenuInternal(m_groupStorage.at(id), false); }
+		void DrawGroup(const std::string &id) { DrawMenuInternal(m_groupStorage.at(id), false); }
 
 		// draw the GroupEntry named by 'id' as a submenu (with a top-level BeginMenu)
-		void DrawMenu(std::string id) { DrawMenuInternal(m_groupStorage.at(id), true); }
+		void DrawMenu(const std::string &id) { DrawMenuInternal(m_groupStorage.at(id), true); }
 
 		// draw the GroupEntry named by 'id' in the context of a button toolbar
 		// void DrawToolbar(std::string id)
@@ -99,26 +99,26 @@ namespace Editor {
 
 		// Begin a group or menu with the given ID. ID is a qualified domain
 		// name relative to the current ID stack.
-		ActionBinder &BeginGroup(std::string id) { BeginInternal(id, false); return *this; }
-		ActionBinder &BeginMenu(std::string id) { BeginInternal(id, true); return *this; }
+		ActionBinder &BeginGroup(const std::string &id) { BeginInternal(id, false); return *this; }
+		ActionBinder &BeginMenu(const std::string &id) { BeginInternal(id, true); return *this; }
 		void EndGroup() { EndInternal(); }
 		void EndMenu() { EndInternal(); }
 
 		// Add the given action to the currently open group. Fails if no group
 		// is open. The action can be referenced by the fully-qualified id
 		// 'group-id[.group-id[...]].action-id'.
-		ActionBinder &AddAction(std::string id, ActionEntry &&entry) { AddInternal(id, std::move(entry)); return *this; }
+		ActionBinder &AddAction(const std::string &id, ActionEntry &&entry) { AddInternal(id, std::move(entry)); return *this; }
 
 		std::vector<std::string> &GetGroups() { return m_topLevelGroups; }
 
-		ActionEntry *GetAction(std::string id);
-		void TriggerAction(std::string id);
+		ActionEntry *GetAction(const std::string &id);
+		void TriggerAction(const std::string &id);
 
 	private:
-		void BeginInternal(std::string id, bool menu);
+		void BeginInternal(const std::string &id, bool menu);
 		void EndInternal();
 
-		void AddInternal(std::string id, ActionEntry &&entry);
+		void AddInternal(const std::string &id, ActionEntry &&entry);
 
 		void DrawMenuInternal(Group &group, bool menuHeading);
 

--- a/src/galaxy/GalaxyGenerator.h
+++ b/src/galaxy/GalaxyGenerator.h
@@ -29,7 +29,7 @@ public:
 	}
 	static RefCountedPtr<Galaxy> CreateFromJson(const Json &jsonObj);
 
-	static std::string GetDefaultGeneratorName() { return s_defaultGenerator; }
+	static const std::string& GetDefaultGeneratorName() { return s_defaultGenerator; }
 	static Version GetDefaultGeneratorVersion() { return s_defaultVersion; }
 	static Version GetLastVersion(const std::string &name);
 

--- a/src/galaxy/StarSystem.h
+++ b/src/galaxy/StarSystem.h
@@ -41,7 +41,7 @@ public:
 	void ExportToLua(const char *filename);
 
 	const std::string &GetName() const { return m_name; }
-	std::vector<std::string> GetOtherNames() const { return m_other_names; }
+	const std::vector<std::string>& GetOtherNames() const { return m_other_names; }
 	SystemPath GetPathOf(const SystemBody *sbody) const;
 	SystemBody *GetBodyByPath(const SystemPath &path) const;
 	static void ToJson(Json &jsonObj, StarSystem *);

--- a/src/galaxy/SystemPath.cpp
+++ b/src/galaxy/SystemPath.cpp
@@ -42,11 +42,13 @@ SystemPath SystemPath::Parse(const char *const str)
 
 	assert(s.length() > 0);
 
+	// delete Leading '('
 	if (s[0] == '(')
 		s = s.substr(1, s.length());
 
+	// delete trailing ')'
 	if (s[s.length() - 1] == ')')
-		s = s.substr(0, s.length() - 1);
+		s.pop_back();
 
 	std::vector<std::string> parts = split(s, ",");
 	int x = 0, y = 0, z = 0, si = 0, bi = 0;

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -320,8 +320,7 @@ namespace Graphics {
 
 			m_va->normal.reserve(count);
 			for (int i = 0; i < count; i++) {
-				vector3f vSize(sizes[i]);
-				m_va->normal.push_back(vSize);
+				m_va->normal.emplace_back(sizes[i]);
 			}
 		}
 
@@ -525,13 +524,13 @@ namespace Graphics {
 		int Icosphere::AddVertex(VertexArray &vts, const vector3f &v, const vector3f &n)
 		{
 			PROFILE_SCOPED()
-			vts.position.push_back(v);
+			vts.position.emplace_back(v);
 			if (vts.HasAttrib(ATTRIB_NORMAL)) {
-				vts.normal.push_back(n);
+				vts.normal.emplace_back(n);
 			}
 			if (vts.HasAttrib(ATTRIB_UV0)) {
 				//http://www.mvps.org/directx/articles/spheremap.htm
-				vts.uv0.push_back(vector2f(asinf(n.x) / M_PI + 0.5f, asinf(n.y) / M_PI + 0.5f));
+				vts.uv0.emplace_back(asinf(n.x) / M_PI + 0.5f, asinf(n.y) / M_PI + 0.5f);
 			}
 			return vts.GetNumVerts() - 1;
 		}
@@ -539,9 +538,9 @@ namespace Graphics {
 		void Icosphere::AddTriangle(std::vector<Uint32> &indices, int i1, int i2, int i3)
 		{
 			PROFILE_SCOPED()
-			indices.push_back(i1);
-			indices.push_back(i2);
-			indices.push_back(i3);
+			indices.emplace_back(i1);
+			indices.emplace_back(i2);
+			indices.emplace_back(i3);
 		}
 
 		void Icosphere::Subdivide(VertexArray &vts, std::vector<Uint32> &indices,

--- a/src/graphics/Frustum.cpp
+++ b/src/graphics/Frustum.cpp
@@ -14,7 +14,7 @@ namespace Graphics {
 	// step for translating to frustum space
 	static const double TRANSLATE_STEP = 0.25;
 
-	Frustum::Frustum(const float width, const float height, const float fovAng, const float znear, const float zfar) :
+	Frustum::Frustum(float width, float height, float fovAng, float znear, float zfar) :
 		m_projMatrix(matrix4x4d::PerspectiveMatrix(DEG2RAD(Clamp(fovAng, FOV_MIN, FOV_MAX)), width / height, znear, zfar)),
 		m_modelMatrix(matrix4x4d::Identity())
 	{

--- a/src/graphics/Frustum.cpp
+++ b/src/graphics/Frustum.cpp
@@ -14,12 +14,10 @@ namespace Graphics {
 	// step for translating to frustum space
 	static const double TRANSLATE_STEP = 0.25;
 
-	Frustum::Frustum() {}
-
-	Frustum::Frustum(float width, float height, float fovAng, float znear, float zfar)
+	Frustum::Frustum(const float width, const float height, const float fovAng, const float znear, const float zfar) :
+		m_projMatrix(matrix4x4d::PerspectiveMatrix(DEG2RAD(Clamp(fovAng, FOV_MIN, FOV_MAX)), width / height, znear, zfar)),
+		m_modelMatrix(matrix4x4d::Identity())
 	{
-		m_projMatrix = matrix4x4d::PerspectiveMatrix(DEG2RAD(Clamp(fovAng, FOV_MIN, FOV_MAX)), width / height, znear, zfar);
-		m_modelMatrix = matrix4x4d::Identity();
 		InitFromMatrix(m_projMatrix);
 
 		m_translateThresholdSqr = zfar * zfar * TRANSLATE_STEP;

--- a/src/graphics/Frustum.h
+++ b/src/graphics/Frustum.h
@@ -17,7 +17,7 @@ namespace Graphics {
 	class Frustum {
 	public:
 		// create for specified values
-		Frustum(float width, float height, float fovAng, float nearClip, float farClip);
+		Frustum(const float width, const float height, const float fovAng, const float nearClip, const float farClip);
 		Frustum(const matrix4x4d &modelview, const matrix4x4d &projection);
 
 		// test if point (sphere) is in the frustum
@@ -34,7 +34,7 @@ namespace Graphics {
 
 	private:
 		// create from current gl state
-		Frustum();
+		Frustum(){};
 
 		void InitFromMatrix(const matrix4x4d &m);
 

--- a/src/graphics/Frustum.h
+++ b/src/graphics/Frustum.h
@@ -17,7 +17,7 @@ namespace Graphics {
 	class Frustum {
 	public:
 		// create for specified values
-		Frustum(const float width, const float height, const float fovAng, const float nearClip, const float farClip);
+		Frustum(float width, float height, float fovAng, float nearClip, float farClip);
 		Frustum(const matrix4x4d &modelview, const matrix4x4d &projection);
 
 		// test if point (sphere) is in the frustum

--- a/src/graphics/ShaderParser.cpp
+++ b/src/graphics/ShaderParser.cpp
@@ -147,7 +147,7 @@ bool Tokenizer::discardLine()
 // Parser
 //
 
-ShaderInfo Parser::Parse(std::string fileName, std::string_view fileData)
+ShaderInfo Parser::Parse(const std::string &fileName, std::string_view fileData)
 {
 	m_currentTok = Token{};
 	m_fileName = fileName;
@@ -349,7 +349,7 @@ Parser::ParseResult Parser::parsePushConstant()
 //
 
 // Format the current position in the source data
-std::string Parser::makeLineInfo()
+std::string Parser::makeLineInfo() const
 {
 	return fmt::format("{}:{}:{}", m_fileName,
 		m_tokenizer->getCurrentLine(), m_tokenizer->getCurrentChar());

--- a/src/graphics/ShaderParser.h
+++ b/src/graphics/ShaderParser.h
@@ -103,7 +103,7 @@ namespace Graphics {
 
 		class Parser {
 		public:
-			ShaderInfo Parse(std::string filename, std::string_view fileData);
+			ShaderInfo Parse(const std::string &filename, std::string_view fileData);
 
 		protected:
 			enum ParseResult {
@@ -126,7 +126,7 @@ namespace Graphics {
 
 			bool expect(Token::Type type, const Token &tok);
 			bool isKeyword(std::string_view keyword, const Token &tok);
-			std::string makeLineInfo();
+			std::string makeLineInfo() const;
 
 		private:
 			std::string m_fileName;

--- a/src/graphics/VertexArray.cpp
+++ b/src/graphics/VertexArray.cpp
@@ -48,54 +48,54 @@ namespace Graphics {
 
 	void VertexArray::Add(const vector3f &v)
 	{
-		position.push_back(v);
+		position.emplace_back(v);
 	}
 
 	void VertexArray::Add(const vector3f &v, const Color &c)
 	{
-		position.push_back(v);
-		diffuse.push_back(c);
+		position.emplace_back(v);
+		diffuse.emplace_back(c);
 	}
 
 	void VertexArray::Add(const vector3f &v, const Color &c, const vector3f &n)
 	{
-		position.push_back(v);
-		diffuse.push_back(c);
-		normal.push_back(n);
+		position.emplace_back(v);
+		diffuse.emplace_back(c);
+		normal.emplace_back(n);
 	}
 
 	void VertexArray::Add(const vector3f &v, const Color &c, const vector2f &uv)
 	{
-		position.push_back(v);
-		diffuse.push_back(c);
-		uv0.push_back(uv);
+		position.emplace_back(v);
+		diffuse.emplace_back(c);
+		uv0.emplace_back(uv);
 	}
 
 	void VertexArray::Add(const vector3f &v, const vector2f &uv)
 	{
-		position.push_back(v);
-		uv0.push_back(uv);
+		position.emplace_back(v);
+		uv0.emplace_back(uv);
 	}
 
 	void VertexArray::Add(const vector3f &v, const vector3f &n)
 	{
-		position.push_back(v);
-		normal.push_back(n);
+		position.emplace_back(v);
+		normal.emplace_back(n);
 	}
 
 	void VertexArray::Add(const vector3f &v, const vector3f &n, const vector2f &uv)
 	{
-		position.push_back(v);
-		normal.push_back(n);
-		uv0.push_back(uv);
+		position.emplace_back(v);
+		normal.emplace_back(n);
+		uv0.emplace_back(uv);
 	}
 
 	void VertexArray::Add(const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang)
 	{
-		position.push_back(v);
-		normal.push_back(n);
-		uv0.push_back(uv);
-		tangent.push_back(tang);
+		position.emplace_back(v);
+		normal.emplace_back(n);
+		uv0.emplace_back(uv);
+		tangent.emplace_back(tang);
 	}
 
 	void VertexArray::Set(const Uint32 idx, const vector3f &v)

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -26,7 +26,7 @@ using namespace InputBindings;
 
 // TODO: push the actual action pointer to lua
 struct LuaInputAction : public LuaWrappable {
-	LuaInputAction(std::string _id) :
+	LuaInputAction(const std::string &_id) :
 		id(_id) {}
 	std::string id;
 
@@ -158,7 +158,7 @@ struct LuaInputAction : public LuaWrappable {
 
 // TODO: push the actual axis pointer to lua
 struct LuaInputAxis : public LuaWrappable {
-	LuaInputAxis(std::string _id) :
+	LuaInputAxis(const std::string &_id) :
 		id(_id) {}
 	std::string id;
 

--- a/src/lua/LuaMusic.cpp
+++ b/src/lua/LuaMusic.cpp
@@ -194,10 +194,11 @@ static int l_music_get_song_list(lua_State *l)
 {
 	using std::string;
 	using std::vector;
-	const vector<string> vec = Pi::GetMusicPlayer().GetSongList();
+	vector<string> songList;
+	Pi::GetMusicPlayer().GetSongList(songList);
 	lua_newtable(l);
 	int idx = 1;
-	for (vector<string>::const_iterator it = vec.begin(); it != vec.end(); ++it) {
+	for (vector<string>::const_iterator it = songList.begin(); it != songList.end(); ++it) {
 		lua_pushnumber(l, idx);
 		lua_pushstring(l, it->c_str());
 		lua_settable(l, -3);

--- a/src/lua/LuaMusic.cpp
+++ b/src/lua/LuaMusic.cpp
@@ -194,8 +194,7 @@ static int l_music_get_song_list(lua_State *l)
 {
 	using std::string;
 	using std::vector;
-	vector<string> songList;
-	Pi::GetMusicPlayer().GetSongList(songList);
+	const vector<string> songList = Pi::GetMusicPlayer().GetSongList();
 	lua_newtable(l);
 	int idx = 1;
 	for (vector<string>::const_iterator it = songList.begin(); it != songList.end(); ++it) {

--- a/src/lua/LuaStarSystem.cpp
+++ b/src/lua/LuaStarSystem.cpp
@@ -487,7 +487,7 @@ static int l_starsystem_attr_other_names(lua_State *l)
 	StarSystem *s = LuaObject<StarSystem>::CheckFromLua(1);
 	LuaTable names(l);
 	int i = 1;
-	for (std::string n : s->GetOtherNames()) {
+	for (const std::string &n : s->GetOtherNames()) {
 		LuaPush(l, i++);
 		LuaPush(l, n);
 		lua_settable(l, -3);

--- a/src/lua/core/Import.cpp
+++ b/src/lua/core/Import.cpp
@@ -121,7 +121,7 @@ static std::string get_caller(lua_State *L, int depth = 1)
  * This function discards the trailing component of the directory path. If you
  * wish to retain it, ensure the path string ends with '/'.
  */
-static std::string path_to_module(std::string path)
+static std::string path_to_module(const std::string &path)
 {
 	std::string module_name;
 
@@ -350,7 +350,7 @@ static bool lua_import_module(lua_State *L, const std::string &moduleName)
 	lua_pop(L, 1);
 
 	// Load the module from the Core c++ module cache
-	if (load_from_core(L, moduleName.c_str())) {
+	if (load_from_core(L, moduleName)) {
 		DEBUG_INDENTED_PRINTF("-> loaded module %s from C++ core modules\n", moduleName.c_str());
 		DEBUG_INDENT_DECREASE();
 		LUA_DEBUG_END(L, 1);
@@ -361,7 +361,7 @@ static bool lua_import_module(lua_State *L, const std::string &moduleName)
 	std::string errorMsg = "could not load module '" + moduleName + "'";
 	errorMsg += "\n\tno entry Imports[\"" + moduleName + "\"]";
 	errorMsg += "\n\tno field package.core." + moduleName;
-	for (auto path : triedPaths) {
+	for (const auto &path : triedPaths) {
 		errorMsg += "\n\tno file '" + path + "'";
 	}
 	lua_pushstring(L, errorMsg.c_str());

--- a/src/pigui/LuaPiGui.cpp
+++ b/src/pigui/LuaPiGui.cpp
@@ -101,7 +101,7 @@ namespace PiGui {
 		queue.Call("_Emit");
 	}
 
-	void RunHandler(double delta, std::string handler)
+	void RunHandler(double delta, const std::string &handler)
 	{
 		PROFILE_SCOPED()
 		ScopedTable t(GetHandlers());
@@ -111,7 +111,7 @@ namespace PiGui {
 		}
 	}
 
-	void LoadTheme(ImGuiStyle &style, std::string theme)
+	void LoadTheme(ImGuiStyle &style, const std::string &theme)
 	{
 		PROFILE_SCOPED();
 		ScopedTable t(GetThemes());
@@ -123,7 +123,7 @@ namespace PiGui {
 		}
 	}
 
-	void LoadThemeFromDisk(std::string theme)
+	void LoadThemeFromDisk(const std::string &theme)
 	{
 		PROFILE_SCOPED();
 		GetThemes().PushCopyToStack();

--- a/src/pigui/LuaPiGui.h
+++ b/src/pigui/LuaPiGui.h
@@ -33,15 +33,15 @@ namespace PiGui {
 	void EmitEvents();
 
 	// Run a lua PiGui handler.
-	void RunHandler(double delta, std::string handler = "GAME");
+	void RunHandler(double delta, const std::string &handler = "GAME");
 
 	// Load a pigui theme into the specified ImGui style.
-	void LoadTheme(ImGuiStyle &style, std::string theme);
+	void LoadTheme(ImGuiStyle &style, const std::string &theme);
 
 	// FIXME: TEMPORARY to resolve loading order fiasco
 	// we want themes up as soon as possible (because they're usually flat data objects)
 	// so this function exists to load a theme out-of-order from Lua::InitModules
-	void LoadThemeFromDisk(std::string theme);
+	void LoadThemeFromDisk(const std::string &theme);
 } // namespace PiGui
 
 #endif

--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -64,7 +64,7 @@ public:
 class PiGui::RasterizeSVGTask : public Task, public CompleteNotifier {
 public:
 	// Rasterize an SVG file to a texture and upload to GPU on main thread
-	RasterizeSVGTask(std::string filename, int width, int height, Graphics::Texture *outputTexture) :
+	RasterizeSVGTask(const std::string &filename, int width, int height, Graphics::Texture *outputTexture) :
 		filename(filename),
 		width(width),
 		height(height),
@@ -73,7 +73,7 @@ public:
 	}
 
 	// Rasterize an SVG file to CPU buffer for use with font data
-	RasterizeSVGTask(std::string filename, int width, int height, PiFace *fontFace) :
+	RasterizeSVGTask(const std::string &filename, int width, int height, PiFace *fontFace) :
 		filename(filename),
 		width(width),
 		height(height),

--- a/src/pigui/PiGuiView.h
+++ b/src/pigui/PiGuiView.h
@@ -10,7 +10,7 @@
 // TODO: support rendering to a debug window during the Update() and Draw3D() methods.
 class PiGuiView : public View {
 public:
-	PiGuiView(std::string name) :
+	PiGuiView(const std::string &name) :
 		m_handlerName(name) {}
 
 	virtual void Update() override {}

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -149,7 +149,7 @@ namespace SceneGraph {
 		// Get the index of an animation in this container. If there is no such animation, returns UINT32_MAX.
 		uint32_t FindAnimationIndex(Animation *) const;
 		// Return a reference to all animations defined on this model.
-		const std::vector<Animation *> GetAnimations() const { return m_animations; }
+		const AnimationContainer& GetAnimations() const { return m_animations; }
 		// Mark an animation as actively updating. A maximum of 64 active animations are supported.
 		void SetAnimationActive(uint32_t index, bool active);
 		bool GetAnimationActive(uint32_t index) const;
@@ -196,7 +196,7 @@ namespace SceneGraph {
 		Graphics::Renderer *m_renderer;
 		std::string m_name;
 
-		std::vector<Animation *> m_animations;
+		AnimationContainer m_animations;
 		uint64_t m_activeAnimations; // bitmask of actively ticking animations
 
 		std::vector<Tag *> m_tags;		 //named attachment points

--- a/src/scenegraph/Serializer.h
+++ b/src/scenegraph/Serializer.h
@@ -96,10 +96,10 @@ namespace Serializer {
 		void String(const char *s) { *this << s; }
 		void String(const std::string &s) { *this << s; }
 
-		void Vector2f(vector2f vec) { *this << vec; }
-		void Vector2d(vector2d vec) { *this << vec; }
-		void Vector3f(vector3f vec) { *this << vec; }
-		void Vector3d(vector3d vec) { *this << vec; }
+		void Vector2f(const vector2f &vec) { *this << vec; }
+		void Vector2d(const vector2d &vec) { *this << vec; }
+		void Vector3f(const vector3f &vec) { *this << vec; }
+		void Vector3d(const vector3d &vec) { *this << vec; }
 		void WrQuaternionf(const Quaternionf &q) { *this << q; }
 		void Color4UB(const Color &c) { *this << c; }
 		void WrSection(const std::string &section_label, const std::string &section_data) { *this << section_label << section_data; }

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -552,7 +552,7 @@ namespace Sound {
 
 	class LoadSoundJob : public Job {
 	public:
-		LoadSoundJob(const std::string &directory, const bool isMusic) :
+		LoadSoundJob(const std::string &directory, bool isMusic) :
 			m_directory(directory),
 			m_isMusic(isMusic)
 		{}

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -552,7 +552,7 @@ namespace Sound {
 
 	class LoadSoundJob : public Job {
 	public:
-		LoadSoundJob(std::string directory, bool isMusic) :
+		LoadSoundJob(const std::string &directory, const bool isMusic) :
 			m_directory(directory),
 			m_isMusic(isMusic)
 		{}

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -102,24 +102,22 @@ namespace Sound {
 		}
 	}
 
-	const std::string MusicPlayer::GetCurrentSongName() const
+	const std::string& MusicPlayer::GetCurrentSongName() const
 	{
 		return m_currentSongName;
 	}
 
-	const std::vector<std::string> MusicPlayer::GetSongList() const
+	void MusicPlayer::GetSongList(std::vector<std::string> &songListOut) const
 	{
 		using std::pair;
 		using std::string;
-		std::vector<string> songs;
 		const std::map<string, Sample> samples = Sound::GetSamples();
+		songListOut.reserve(samples.size());
 		for (std::map<string, Sample>::const_iterator it = samples.begin();
 			 it != samples.end(); ++it) {
 			if (it->second.isMusic)
-				songs.push_back(it->first.c_str());
+				songListOut.emplace_back(it->first.c_str());
 		}
-
-		return songs;
 	}
 
 	bool MusicPlayer::IsPlaying() const

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -107,17 +107,20 @@ namespace Sound {
 		return m_currentSongName;
 	}
 
-	void MusicPlayer::GetSongList(std::vector<std::string> &songListOut) const
+	const std::vector<std::string> MusicPlayer::GetSongList() const
 	{
 		using std::pair;
 		using std::string;
 		const std::map<string, Sample> samples = Sound::GetSamples();
-		songListOut.reserve(samples.size());
+		std::vector<std::string> songs;
+		songs.reserve(samples.size());
 		for (std::map<string, Sample>::const_iterator it = samples.begin();
 			 it != samples.end(); ++it) {
 			if (it->second.isMusic)
-				songListOut.emplace_back(it->first.c_str());
+				songs.emplace_back(it->first.c_str());
 		}
+
+		return songs;
 	}
 
 	bool MusicPlayer::IsPlaying() const

--- a/src/sound/SoundMusic.h
+++ b/src/sound/SoundMusic.h
@@ -30,7 +30,7 @@ namespace Sound {
 		void FadeOut(const float fadeDelta);
 		void Update();
 		const std::string& GetCurrentSongName() const;
-		void GetSongList(std::vector<std::string> &songListOut) const;
+		const std::vector<std::string> GetSongList() const;
 		bool IsPlaying() const;
 		void SetEnabled(bool);
 

--- a/src/sound/SoundMusic.h
+++ b/src/sound/SoundMusic.h
@@ -29,8 +29,8 @@ namespace Sound {
 		void Stop();
 		void FadeOut(const float fadeDelta);
 		void Update();
-		const std::string GetCurrentSongName() const;
-		const std::vector<std::string> GetSongList() const;
+		const std::string& GetCurrentSongName() const;
+		void GetSongList(std::vector<std::string> &songListOut) const;
 		bool IsPlaying() const;
 		void SetEnabled(bool);
 

--- a/src/win32/msvc_bug.cpp
+++ b/src/win32/msvc_bug.cpp
@@ -18,7 +18,7 @@ public:
 		y(v.y),
 		z(v.z) {}
 
-	V operator+(const V a) const { return V(a.x + x, a.y + y, a.z + z); }
+	V operator+(const V &a) const { return V(a.x + x, a.y + y, a.z + z); }
 	friend V operator*(const V a, const double s) { return V(a.x * s, a.y * s, a.z * s); }
 };
 


### PR DESCRIPTION
Upgraded CppCheck to 2.15 and ran it over the codebase.

Tackled the most obvious performance warnings plus a few others.
LOTS of std::string being passed by copy instead of const references, along with vectors, maps, and other types which involve lots of copying. 
Switched some code to 'emplace_back' instead of 'push_back'.

None of this will make a huge difference to performance but it's no longer just throwing it away.