### PR TITLE
refactor: run SaveGameStats in a job

### DIFF
--- a/data/libs/utils.lua
+++ b/data/libs/utils.lua
@@ -960,4 +960,20 @@ utils.getFromIntervals = function(array, value)
 	return array[utils.getIndexFromIntervals(array, value)][1]
 end
 
+--
+-- Function: utils.profile
+--
+-- Simple manual scoped profiler to print the execution time of some invocation.
+-- The returned function should be called to terminate the profile scope.
+--
+utils.profile = function(name)
+	local start = Engine.nowTime
+
+	return function()
+		local duration = Engine.nowTime - start
+
+		print(string.format("PROFILE | %s took %.4fms", name, duration * 1000.0))
+	end
+end
+
 return utils

--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -300,6 +300,13 @@ function SaveLoadWindow:makeFileList()
 		return a.mtime.timestamp > b.mtime.timestamp
 	end)
 
+	-- Cache details about each savefile
+	for _, file in ipairs(self.files) do
+		if not self.entryCache[file.name] or self.entryCache[file.name].timestamp ~= file.mtime.timestamp then
+			self.entryCache[file.name] = makeEntryForSave(file)
+		end
+	end
+
 	self:makeFilteredList()
 	-- profileEndScope()
 end
@@ -349,21 +356,6 @@ function SaveLoadWindow:deleteSelectedSave()
 		-- List of files changed on disk, need to update our copy of it
 		self:makeFileList()
 	end)
-end
-
-function SaveLoadWindow:update()
-	ModalWindow.update(self)
-
-	-- Incrementally update cache until all files are up to date
-	-- We don't need to manually clear the cache, as changes to the list of
-	-- files will trigger the cache to be updated
-	local uncached = utils.find_if(self.files, function(_, file)
-		return not self.entryCache[file.name] or self.entryCache[file.name].timestamp ~= file.mtime.timestamp
-	end)
-
-	if uncached then
-		self.entryCache[uncached.name] = makeEntryForSave(uncached)
-	end
 end
 
 --=============================================================================

--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -2,6 +2,7 @@
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local Game       = require 'Game'
+local Event      = require 'Event'
 local FileSystem = require 'FileSystem'
 local Lang       = require 'Lang'
 local ShipDef    = require 'ShipDef'
@@ -197,42 +198,56 @@ end
 
 --=============================================================================
 
-local function makeEntryForSave(file)
-	local compatible, saveInfo = pcall(Game.SaveGameStats, file.name)
-	if not compatible then
-		saveInfo = {}
-	end
-
+-- Event callback once the savegame information has been loaded
+-- Updates the entryCache with the full details of the savegame.
+function SaveLoadWindow:onSaveGameStats(saveInfo)
+	-- local profileEndScope = utils.profile("SaveLoadWindow:onSaveGameStats()")
 	local location = saveInfo.system or lc.UNKNOWN
-
 	if saveInfo.docked_at then
 		location = location .. ", " .. saveInfo.docked_at
 	end
 
-	local saveEntry = SaveGameEntry:clone({
-		name = file.name,
-		compatible = compatible,
-		isAutosave = file.name:sub(1, 1) == "_",
-		character = saveInfo.character,
-		timestamp = file.mtime.timestamp,
-		gameTime = saveInfo.time,
-		duration = saveInfo.duration,
-		locationName = location,
-		credits = saveInfo.credits,
-		shipName = saveInfo.shipName,
-		shipHull = saveInfo.shipHull,
-	})
-
 	-- Old saves store only the name of the ship's *model* file for some dumb reason
 	-- Treat the model name as the ship id and otherwise ignore it if we have proper data
+	local shipHull
 	if not saveInfo.shipHull then
 		local shipDef = ShipDef[saveInfo.ship]
-
 		if shipDef then
-			saveEntry.shipHull = shipDef.name
+			shipHull = shipDef.name
 		end
+	else
+		shipHull = saveInfo.shipHull
 	end
 
+	local entry = self.entryCache[saveInfo.filename]
+	entry.character = saveInfo.character
+	entry.compatible = saveInfo.compatible
+	entry.credits = saveInfo.credits
+	entry.duration = saveInfo.duration
+	entry.gameTime = saveInfo.time
+	entry.locationName = location
+	entry.shipName = saveInfo.shipName
+	entry.shipHull = shipHull
+
+	-- profileEndScope()
+end
+
+local function onSaveGameStats(saveInfo)
+	ui.saveLoadWindow:onSaveGameStats(saveInfo)
+end
+
+-- Trigger load of savegame information and return bare-bones entry
+local function makeEntryForSave(file)
+	-- local profileEndScope = utils.profile("makeEntryForSave()")
+	Game.SaveGameStats(file.name)
+
+	local saveEntry = SaveGameEntry:clone({
+		name = file.name,
+		isAutosave = file.name:sub(1, 1) == "_",
+		timestamp = file.mtime.timestamp,
+	})
+
+	-- profileEndScope()
 	return saveEntry
 end
 
@@ -243,6 +258,7 @@ end
 --=============================================================================
 
 function SaveLoadWindow:makeFilteredList()
+	-- local profileEndScope = utils.profile("SaveLoadWindow::makeFilteredList()")
 	local shouldShow = function(f)
 		if not self.showAutosaves and f.name:sub(1, 1) == "_" then
 			return false
@@ -266,9 +282,11 @@ function SaveLoadWindow:makeFilteredList()
 	if not utils.contains_if(self.filteredFiles, isSelectedFile) then
 		self.selectedFile = nil
 	end
+	-- profileEndScope()
 end
 
 function SaveLoadWindow:makeFileList()
+	-- local profileEndScope = utils.profile("SaveLoadWindow::makeFileList()")
 	local ok, files = pcall(Game.ListSaves)
 
 	if not ok then
@@ -283,6 +301,7 @@ function SaveLoadWindow:makeFileList()
 	end)
 
 	self:makeFilteredList()
+	-- profileEndScope()
 end
 
 function SaveLoadWindow:loadSelectedSave()
@@ -551,6 +570,8 @@ function SaveLoadWindow:render()
 end
 
 --=============================================================================
+
+Event.Register("onSaveGameStats", onSaveGameStats)
 
 ui.saveLoadWindow = SaveLoadWindow
 

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -508,7 +508,7 @@ void StartupScreen::Start()
 	// XXX UI requires Lua  but Pi::ui must exist before we start loading
 	// templates. so now we have crap everywhere :/
 	Output("Lua::Init()\n");
-	Lua::Init();
+	Lua::Init(Pi::GetAsyncJobQueue());
 
 	// TODO: Get the lua state responsible for drawing the init progress up as fast as possible
 	// Investigate using a pigui-only Lua state that we can initialize without depending on

--- a/src/SaveGameManager.h
+++ b/src/SaveGameManager.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 class Game;
+class Job;
 
 class SaveGameManager {
 public:
@@ -47,6 +48,19 @@ public:
 	 * implementation.
 	 */
 	static Json LoadGameToJson(const std::string &name);
+
+	/** Create a job which can be scheduled on a job queue to load the game as
+	 * a Json object.
+	 * This is provided as LoadGameToJson can be expensive.
+	 *
+	 * The \p callback is called in the main thread with the Json data once the
+	 * job has completed.
+	 *
+	 * \param[in] name The name of the savegame to load.
+	 * \param[in] callback A callback to be called once the data has been loaded.
+	 * \return On success, a newly-created Job which can be passed to a job queue.
+	 */
+	static Job *LoadGameToJsonAsync(std::string_view name, void(*callback)(std::string_view, const Json &));
 
 	/** Save the game.
 	 * NOTE: This function will throw an exception if an error occurs while

--- a/src/editor/EditorApp.cpp
+++ b/src/editor/EditorApp.cpp
@@ -108,7 +108,7 @@ void EditorApp::OnStartup()
 	m_editorCfg->Save(); // write defaults if the file doesn't exist
 
 	EnumStrings::Init();
-	Lua::Init();
+	Lua::Init(GetAsyncJobQueue());
 	ModManager::Init();
 
 	ModManager::LoadMods(m_editorCfg.get());

--- a/src/lua/Lua.cpp
+++ b/src/lua/Lua.cpp
@@ -44,9 +44,9 @@ namespace Lua {
 
 	void InitMath();
 
-	void Init()
+	void Init(JobQueue *asyncJobQueue)
 	{
-		manager = new LuaManager();
+		manager = new LuaManager(asyncJobQueue);
 		InitMath();
 	}
 

--- a/src/lua/Lua.h
+++ b/src/lua/Lua.h
@@ -6,6 +6,8 @@
 
 #include "LuaManager.h"
 
+class JobQueue;
+
 // home for the global Lua context. here so its shareable between pioneer and
 // modelviewer. probably sucks in the long term
 namespace Lua {
@@ -13,7 +15,8 @@ namespace Lua {
 	extern LuaManager *manager;
 
 	// Initialize the lua instance
-	void Init();
+	void Init(JobQueue *asyncJobQueue);
+
 	// Uninitialize the lua instance
 	void Uninit();
 

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -104,6 +104,28 @@ static int l_engine_attr_time(lua_State *l)
 }
 
 /*
+ * Attribute: nowTime
+ *
+ * Returns an arbitrary value in seconds relative to some epoch corresponding
+ * to the precise time this value is accessed. This should be used only for
+ * profiling and debugging purposes to calculate a duration in sub-millisecond
+ * units.
+ *
+ * Availability:
+ *
+ *   October 2024
+ *
+ * Status:
+ *
+ *   experimental
+ */
+static int l_engine_attr_now_time(lua_State *l)
+{
+	lua_pushnumber(l, Profiler::Clock::ms(Profiler::Clock::getticks()) / 1000.0);
+	return 1;
+}
+
+/*
  * Attribute: frameTime
  *
  * Length of the last frame in seconds. This should be used for debugging or UI
@@ -1171,6 +1193,7 @@ void LuaEngine::Register()
 		{ "rand", l_engine_attr_rand },
 		{ "ticks", l_engine_attr_ticks },
 		{ "time", l_engine_attr_time },
+		{ "nowTime", l_engine_attr_now_time },
 		{ "frameTime", l_engine_attr_frame_time },
 		{ "pigui", l_engine_attr_pigui },
 		{ "version", l_engine_attr_version },

--- a/src/lua/LuaManager.cpp
+++ b/src/lua/LuaManager.cpp
@@ -9,8 +9,8 @@
 
 bool instantiated = false;
 
-LuaManager::LuaManager() :
-	m_lua(0)
+LuaManager::LuaManager(JobQueue *asyncJobQueue) :
+	m_lua(0), m_jobs(asyncJobQueue)
 {
 	if (instantiated) {
 		Output("Can't instantiate more than one LuaManager");
@@ -50,4 +50,11 @@ size_t LuaManager::GetMemoryUsage() const
 void LuaManager::CollectGarbage()
 {
 	lua_gc(m_lua, LUA_GCCOLLECT, 0);
+}
+
+void LuaManager::ScheduleJob(Job *job)
+{
+	if (job) {
+		m_jobs.Order(job);
+	}
 }

--- a/src/lua/LuaManager.h
+++ b/src/lua/LuaManager.h
@@ -4,22 +4,31 @@
 #ifndef _LUAMANAGER_H
 #define _LUAMANAGER_H
 
+#include "JobQueue.h"
 #include "LuaUtils.h"
 
 class LuaManager {
 public:
-	LuaManager();
+	// Create a new LuaManager
+	// @param[in] asyncJobQueue A job queue to run Lua jobs on. This should be
+	//            an asynchronous job queue to allow jobs to run in the
+	//            background via the \p ScheduleJob method.
+	LuaManager(JobQueue *asyncJobQueue);
 	~LuaManager();
 
 	lua_State *GetLuaState() { return m_lua; }
 	size_t GetMemoryUsage() const;
 	void CollectGarbage();
 
+	// Schedule a job to be run on the LuaManager job queue
+	void ScheduleJob(Job *job);
+
 private:
 	LuaManager(const LuaManager &);
 	LuaManager &operator=(const LuaManager &) = delete;
 
 	lua_State *m_lua;
+	JobSet m_jobs;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,7 +186,7 @@ start:
 			// Galaxy generation is (mostly) self-contained, no need to e.g.
 			// turn on the renderer or load UI for this.
 
-			Lua::Init();
+			Lua::Init(Pi::GetAsyncJobQueue());
 			Pi::luaNameGen = new LuaNameGen(Lua::manager);
 			LuaObject<SystemBody>::RegisterClass();
 			FILE *file = filename == "-" ? stdout : fopen(filename.c_str(), "w");


### PR DESCRIPTION
##' Bugs / Feature requests

Attempts to fix #5929 

## Background

The idea is to run this expensive task in an asynchronous job and notify the Lua side once it is completed. This is to prevent the stutter from occurring every time the SaveGameStats API is called from Lua.

## Details

The code was modified to call the expensive part of the SaveGameStats API (loading and parsing the game file) into a Job. Once finished, the data is marshalled into a LuaTable and a LuaEvent is triggered to pass the data to the Lua side.

The Lua side registers an Event listener, which parses the data and updates the SaveGame cache entry for the data.

Practically, this is achieved by the following changes :

* add a job manager to the LuaManager class which can run any job on
  the Lua job queue.
* add a LoadGameToJsonJob implementation in SaveGameManager, and a new function, LoadGameToJsonAsync(), which schedules an instance of this job on the Lua job queue.
* call this new function from Lua, as well as registering a callback for when the job completes, in saveloadgame.lua.

Many thanks to @Web-eWorks for feedback throughout the development of this change (details of which have been squashed, but the implementation went through several iterations) as well as providing the Lua profiler and removing the no longer required `SaveLoadWindow::update()` callback.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->