### PR TITLE
fix: only reset view to WorldView when Player enters system

### DIFF
--- a/data/libs/Player.lua
+++ b/data/libs/Player.lua
@@ -431,7 +431,8 @@ local onGameEnd = function ()
 	-- clean up for next game:
 end
 
-local onEnterSystem = function ()
+local onEnterSystem = function (ship)
+	if not ship.IsPlayer() then return end
 	-- Return to game view when we exit hyperspace
 	if Engine.GetResetViewOnHyperspaceExit() and Game.CurrentView() ~= "world" then
 		Game.SetView("world")


### PR DESCRIPTION
Fixes #5935

Bug introduced in 99b0acdb9843d65fbb6f19e720c3e59a5abec86e, the 'onEnterSystem' event needs to check whether the ship which entered the system is the Player.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

