### PR TITLE
refactor: remove duplicate call to LoadGameToJson

### DIFF
--- a/src/SaveGameManager.cpp
+++ b/src/SaveGameManager.cpp
@@ -96,7 +96,7 @@ Game *SaveGameManager::LoadGame(const std::string &name)
 		if (!rootNode.is_object()) {
 			throw SavedGameCorruptException();
 		}
-		return new Game(LoadGameToJson(name));
+		return new Game(rootNode);
 	} catch (const Json::type_error &) {
 		throw SavedGameCorruptException();
 	} catch (const Json::out_of_range &) {


### PR DESCRIPTION
A duplicate call to LoadGameToJson() snuck past the developer and reviewers in SaveGameManager::LoadGame().

Replace the duplicate call by the local variable which already contains the loaded game.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

