### PR TITLE
Fix $HOME/.pioneer randomly created on Linux

### DIFF
--- a/src/posix/FileSystemPosix.cpp
+++ b/src/posix/FileSystemPosix.cpp
@@ -61,8 +61,8 @@ namespace FileSystem {
 		path += "Library/Application Support/Pioneer";
 #else
 		struct stat info;
-		stat((path + ".pioneer").c_str(), &info);
-		if (S_ISDIR(info.st_mode)) {
+		int err = stat((path + ".pioneer").c_str(), &info);
+		if (err == 0 && S_ISDIR(info.st_mode)) {
 			// Check for legacy pioneer directory.
 			path += ".pioneer";
 		} else {


### PR DESCRIPTION
Closes #5942

I've not reproduced the bug described in the issue above, but implemented the changes proposed and tested restart, and it creates a new pioneer config folder (for me under `~/.local/share/`)