### PR TITLE
Add Buy and Sell prices to the Commodity Market

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -85,7 +85,7 @@
   },
   "BUY_PRICE": {
     "description": "Title for buy-price column in commodity market",
-    "message": "Buy Price"
+    "message": "Buy"
   },
   "BUY_SHIP": {
     "description": "",
@@ -234,6 +234,10 @@
   "COMMANDER": {
     "description": "",
     "message": "Commander"
+  },
+  "COMMODITY": {
+    "description": "Title for commodity name column in commodity market",
+    "message": "Commodity"
   },
   "COMMODITY_MARKET": {
     "description": "",
@@ -1299,9 +1303,13 @@
     "description": "",
     "message": "In cargo hold"
   },
+ "IN_HOLD": {
+    "description": "Column title of the Commodity Market screen",
+    "message": "In hold"
+  },
   "IN_STOCK": {
-    "description": "",
-    "message": "In stock"
+    "description": "Column title of Commodity and Ship Equipment markets showing current station stock level.",
+    "message": "Stock"
   },
   "IN_SYSTEM": {
     "description": "Used in flight log, show which star system we are/were in",
@@ -2157,7 +2165,7 @@
   },
   "SELL_PRICE": {
     "description": "Title for sell-price column in commodity market",
-    "message": "Sell Price"
+    "message": "Sell"
   },
   "SENSORS": {
     "description": "Crew skill",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -83,6 +83,10 @@
     "description": "Commodities and equipment prices",
     "message": "Buy"
   },
+  "BUY_PRICE": {
+    "description": "Title for buy-price column in commodity market",
+    "message": "Buy Price"
+  },
   "BUY_SHIP": {
     "description": "",
     "message": "Buy Ship"
@@ -2150,6 +2154,10 @@
   "SELL_EQUIPPED": {
     "description": "Button text to sell selected ship equipment",
     "message": "Sell Equipped"
+  },
+  "SELL_PRICE": {
+    "description": "Title for sell-price column in commodity market",
+    "message": "Sell Price"
   },
   "SENSORS": {
     "description": "Crew skill",

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -27,10 +27,10 @@ local baseWidgetSizes = {
 	fontSizeLarge = 22.5, -- pionillium.large.size,
 	fontSizeXLarge = 27, -- pionillium.xlarge.size,
 	iconSize = Vector2(0, 22.5 * 1.5),
-	smallButton = Vector2(92, 48),
-	bigButton = Vector2(128, 48),
+	smallButton = Vector2(80, 44),
+	bigButton = Vector2(100, 44),
 	confirmButtonSize = Vector2(384, 48),
-	windowGutter = 18
+	windowGutter = 16
 }
 
 local commodityIconSize = Vector2(38.0, 32.0) -- png icons, native resolution
@@ -60,7 +60,7 @@ function CommodityMarketWidget.New(id, title, config)
 
 	config.initTable = config.initTable or function(self)
 		ui.setColumnWidth(0, commodityIconSize.x + ui.getItemSpacing().x)
-		ui.setColumnWidth(1, self.style.size.x / 2.2 - 50 * self.style.widgetSizes.rescaleVector.x)
+		ui.setColumnWidth(1, self.style.size.x / 2.3  - 50 * self.style.widgetSizes.rescaleVector.x)
 	end
 
 	config.renderHeaderRow = config.renderHeaderRow or function(_)
@@ -458,7 +458,7 @@ function CommodityMarketWidget:SetSize(size)
 	size = Vector2(math.max(size.x, 100), math.max(size.y, 100))
 	if self.style.widgetSize ~= size then
 		self.style.widgetSize = size
-		self.style.size = Vector2(size.x / 2, size.y)
+		self.style.size = Vector2(size.x * 0.6, size.y)
 
 		self.style.widgetSizes = ui.rescaleUI(
 			baseWidgetSizes,

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -56,7 +56,7 @@ function CommodityMarketWidget.New(id, title, config)
 	config.style = config.style or {}
 	config.style.size = config.style.size or Vector2(0,0)
 	config.itemTypes = config.itemTypes or { Commodities }
-	config.columnCount = config.columnCount or 6
+	config.columnCount = config.columnCount or 7
 
 	config.initTable = config.initTable or function(self)
 		ui.setColumnWidth(0, commodityIconSize.x + ui.getItemSpacing().x)
@@ -68,7 +68,9 @@ function CommodityMarketWidget.New(id, title, config)
 		ui.nextColumn()
 		ui.text(l.NAME_OBJECT)
 		ui.nextColumn()
-		ui.text(l.PRICE)
+		ui.text(l.BUY_PRICE)
+		ui.nextColumn()
+		ui.text(l.SELL_PRICE)
 		ui.nextColumn()
 		ui.text(l.IN_STOCK)
 		ui.nextColumn()
@@ -103,7 +105,10 @@ function CommodityMarketWidget.New(id, title, config)
 
 			ui.nextColumn()
 			ui.dummy(vZero)
-			ui.text(Format.Money(price))
+			ui.text(Format.Money(config.getBuyPrice(self, item)))
+			ui.nextColumn()
+			ui.dummy(vZero)
+			ui.text(Format.Money(config.getSellPrice(self, item)))
 			ui.nextColumn()
 			ui.dummy(vZero)
 			ui.text(config.getStock(self, item))

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -60,7 +60,7 @@ function CommodityMarketWidget.New(id, title, config)
 
 	config.initTable = config.initTable or function(self)
 		ui.setColumnWidth(0, commodityIconSize.x + ui.getItemSpacing().x)
-		ui.setColumnWidth(1, self.style.size.x / 2.3  - 50 * self.style.widgetSizes.rescaleVector.x)
+		ui.setColumnWidth(1, self.style.size.x / 2.4  - 50 * self.style.widgetSizes.rescaleVector.x)
 	end
 
 	-- Adds a text column to the UI table with the given alignment
@@ -88,12 +88,12 @@ function CommodityMarketWidget.New(id, title, config)
 
 	config.renderHeaderRow = config.renderHeaderRow or function(_)
 		config.columnText('')
-		config.columnText(l.NAME_OBJECT, "MIDDLE")
+		config.columnText(l.COMMODITY, "MIDDLE")
 		config.columnText(l.BUY_PRICE, "MIDDLE")
 		config.columnText(l.SELL_PRICE, "MIDDLE")
 		config.columnText(l.IN_STOCK, "MIDDLE")
 		config.columnText(l.DEMAND, "MIDDLE")
-		config.columnText(l.CARGO, "MIDDLE")
+		config.columnText(l.IN_HOLD, "MIDDLE")
 	end
 
 	config.renderItem = config.renderItem or function(self, item)

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -103,22 +103,44 @@ function CommodityMarketWidget.New(id, title, config)
 				ui.icon(cls[1], Vector2(ui.getTextLineHeight()), cls[2])
 			end
 
-			ui.nextColumn()
+			local txt = ''
+			local posX = 0
+
+			ui.nextColumn() -- Buy Price
 			ui.dummy(vZero)
-			ui.text(Format.Money(config.getBuyPrice(self, item)))
-			ui.nextColumn()
+			txt = Format.Money(config.getBuyPrice(self, item))
+			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
+			ui.addCursorPos(Vector2(posX, 0))
+			ui.text(txt)
+			ui.nextColumn() -- Sell Price
 			ui.dummy(vZero)
-			ui.text(Format.Money(config.getSellPrice(self, item)))
-			ui.nextColumn()
+			txt = Format.Money(config.getSellPrice(self, item))
+			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
+			ui.addCursorPos(Vector2(posX, 0))
+			ui.text(txt)
+			ui.nextColumn() -- In Stock
 			ui.dummy(vZero)
-			ui.text(config.getStock(self, item))
-			ui.nextColumn()
+			txt = config.getStock(self, item)
+			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
+			ui.addCursorPos(Vector2(posX, 0))
+			ui.text(txt)
+			ui.nextColumn() -- Demand
 			ui.dummy(vZero)
-			ui.text(config.getDemand(self, item))
-			ui.nextColumn()
+			txt = config.getDemand(self, item)
+			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
+			ui.addCursorPos(Vector2(posX, 0))
+			ui.text(txt)
+			ui.nextColumn() -- Cargo
 			ui.dummy(vZero)
 			local n = self.cargoMgr:CountCommodity(item)
-			ui.text(n > 0 and n or '')
+			if n > 0 then
+				txt = n
+				posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
+				ui.addCursorPos(Vector2(posX, 0))
+				ui.text(txt)
+			else
+				ui.text('')
+			end
 		end)
 		ui.nextColumn()
 	end

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -63,21 +63,37 @@ function CommodityMarketWidget.New(id, title, config)
 		ui.setColumnWidth(1, self.style.size.x / 2.3  - 50 * self.style.widgetSizes.rescaleVector.x)
 	end
 
+	-- Adds a text column to the UI table with the given alignment
+	--  - txt - the text to display
+	--  - align - the horizontal alignment the text should have:
+	--          - "LEFT" (default if not specified)
+	--          - "MIDDLE", useful for table heading row
+	--          - "RIGHT", best for numbers
+	config.columnText = config.columnText or function(txt, align)
+		local posX = 0
+		txt = txt or ''
+		align = align or "LEFT"
+
+		if align == "RIGHT" then
+			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
+		elseif align == "MIDDLE" then
+			posX = (ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x) / 2
+		else -- default alignment is "LEFT"
+			-- no need to adjust the position
+		end
+		ui.addCursorPos(Vector2(posX, 0))
+		ui.text(txt)
+		ui.nextColumn()
+	end
+
 	config.renderHeaderRow = config.renderHeaderRow or function(_)
-		ui.text('')
-		ui.nextColumn()
-		ui.text(l.NAME_OBJECT)
-		ui.nextColumn()
-		ui.text(l.BUY_PRICE)
-		ui.nextColumn()
-		ui.text(l.SELL_PRICE)
-		ui.nextColumn()
-		ui.text(l.IN_STOCK)
-		ui.nextColumn()
-		ui.text(l.DEMAND)
-		ui.nextColumn()
-		ui.text(l.CARGO)
-		ui.nextColumn()
+		config.columnText('')
+		config.columnText(l.NAME_OBJECT, "MIDDLE")
+		config.columnText(l.BUY_PRICE, "MIDDLE")
+		config.columnText(l.SELL_PRICE, "MIDDLE")
+		config.columnText(l.IN_STOCK, "MIDDLE")
+		config.columnText(l.DEMAND, "MIDDLE")
+		config.columnText(l.CARGO, "MIDDLE")
 	end
 
 	config.renderItem = config.renderItem or function(self, item)
@@ -103,46 +119,20 @@ function CommodityMarketWidget.New(id, title, config)
 				ui.icon(cls[1], Vector2(ui.getTextLineHeight()), cls[2])
 			end
 
-			local txt = ''
-			local posX = 0
+			ui.nextColumn()
 
-			ui.nextColumn() -- Buy Price
 			ui.dummy(vZero)
-			txt = Format.Money(config.getBuyPrice(self, item))
-			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
-			ui.addCursorPos(Vector2(posX, 0))
-			ui.text(txt)
-			ui.nextColumn() -- Sell Price
+			config.columnText(Format.Money(config.getBuyPrice(self, item)), "RIGHT")
 			ui.dummy(vZero)
-			txt = Format.Money(config.getSellPrice(self, item))
-			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
-			ui.addCursorPos(Vector2(posX, 0))
-			ui.text(txt)
-			ui.nextColumn() -- In Stock
+			config.columnText(Format.Money(config.getSellPrice(self, item)), "RIGHT")
 			ui.dummy(vZero)
-			txt = config.getStock(self, item)
-			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
-			ui.addCursorPos(Vector2(posX, 0))
-			ui.text(txt)
-			ui.nextColumn() -- Demand
+			config.columnText(config.getStock(self, item), "RIGHT")
 			ui.dummy(vZero)
-			txt = config.getDemand(self, item)
-			posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
-			ui.addCursorPos(Vector2(posX, 0))
-			ui.text(txt)
-			ui.nextColumn() -- Cargo
+			config.columnText(config.getDemand(self, item), "RIGHT")
 			ui.dummy(vZero)
 			local n = self.cargoMgr:CountCommodity(item)
-			if n > 0 then
-				txt = n
-				posX = ui.getColumnWidth() - ui.calcTextSize(txt).x - ui.getItemSpacing().x
-				ui.addCursorPos(Vector2(posX, 0))
-				ui.text(txt)
-			else
-				ui.text('')
-			end
+			config.columnText(n > 0 and n or '', "RIGHT")
 		end)
-		ui.nextColumn()
 	end
 
 	config.canDisplayItem = config.canDisplayItem or function (self, commodity)


### PR DESCRIPTION
Fixes #5903 

Replace the "Price" column with a "Buy Price" and "Sell Price" column. This reflects what the user of the commodity market actually needs to know, instead of delegating this information until after the user has started buying or selling a particular commodity.

Also right-aligns all numbers in the table, and middle-aligns the column headings for a much more readable table.


**Before:**

![image](https://github.com/user-attachments/assets/5cce8f71-ceb4-46bd-9249-5e5bf4e74054)


**After:**

![image](https://github.com/user-attachments/assets/a718506e-4d11-4ef0-ac3c-cf5091f4735b)
