### PR TITLE
Fix builds which use "-DDEBUG"

### DIFF
--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -38,7 +38,7 @@ public:
 	virtual double GetHeight(const vector3d &p) const override final
 	{
 		const double h = m_terrain->GetHeight(p);
-#ifdef DEBUG
+#ifndef NDEBUG
 		// XXX don't remove this. Fix your fractals instead
 		// Fractals absolutely MUST return heights >= 0.0 (one planet radius)
 		// otherwise atmosphere and other things break.
@@ -47,7 +47,7 @@ public:
 			m_terrain->DebugDump();
 			assert(h >= 0.0);
 		}
-#endif /* DEBUG */
+#endif /* NDEBUG */
 		return h;
 	}
 

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -8,6 +8,7 @@
 
 #include "BaseSphere.h"
 #include "Camera.h"
+#include "core/Log.h"
 #include "vector3.h"
 
 #include <deque>

--- a/src/lua/LuaMetaType.cpp
+++ b/src/lua/LuaMetaType.cpp
@@ -422,7 +422,7 @@ void *LuaMetaTypeBase::CheckUserdata(lua_State *l, int index, const char *type)
 	return p;
 }
 
-void LuaMetaTypeBase::CreateMetaType(lua_State *l)
+void LuaMetaTypeBase::CreateMetaType(lua_State *l, bool pushToStack)
 {
 	luaL_getsubtable(l, LUA_REGISTRYINDEX, "LuaMetaTypes");
 	m_lua = l;
@@ -476,4 +476,9 @@ void LuaMetaTypeBase::CreateMetaType(lua_State *l)
 
 	// replace the LuaMetaTypes registry table, leaving the created metatype on the stack
 	lua_replace(l, -2);
+
+	// clean up the stack if required
+	if (!pushToStack) {
+		lua_pop(l, 1);
+	}
 }

--- a/src/lua/LuaMetaType.h
+++ b/src/lua/LuaMetaType.h
@@ -48,7 +48,8 @@ public:
 	{}
 
 	// Creates and registers the lua-side object for this type.
-	void CreateMetaType(lua_State *l);
+	// If pushToStack is true, leaves the created metatype object on the top of the stack
+	void CreateMetaType(lua_State *l, bool pushToStack = false);
 
 	const char *GetTypeName() const { return m_typeName.c_str(); }
 

--- a/src/lua/LuaObject.cpp
+++ b/src/lua/LuaObject.cpp
@@ -450,6 +450,7 @@ bool LuaObjectBase::PushRegistered(LuaWrappable *o)
 
 	if (!o) {
 		lua_pushnil(l);
+		LUA_DEBUG_END(l, 1);
 		return true;
 	}
 

--- a/src/lua/LuaObject.cpp
+++ b/src/lua/LuaObject.cpp
@@ -286,7 +286,7 @@ void LuaObjectBase::CreateObject(const luaL_Reg *methods, const luaL_Reg *attrs,
 
 	// create a throwaway, non-inheriting metatype
 	LuaMetaTypeBase metaType("");
-	metaType.CreateMetaType(l);
+	metaType.CreateMetaType(l, true);
 
 	// add methods
 	if (methods) {
@@ -350,7 +350,7 @@ void LuaObjectBase::CreateClass(const char *type, const char *parent, const luaL
 	LuaMetaTypeBase metaType(type);
 	if (parent)
 		metaType.SetParent(parent);
-	metaType.CreateMetaType(l);
+	metaType.CreateMetaType(l, true);
 
 	// add attributes
 	if (attrs) {

--- a/src/lua/LuaSpace.cpp
+++ b/src/lua/LuaSpace.cpp
@@ -828,6 +828,8 @@ static int l_space_spawn_cargo_near(lua_State *l)
 	} else {
 		c_body = new CargoBody(model, LuaRef(l, 1));
 	}
+	lua_pop(l, 1); // pop model_name
+
 	Body *nearbody = LuaObject<Body>::CheckFromLua(2);
 	float min_dist = luaL_checknumber(l, 3);
 	float max_dist = luaL_checknumber(l, 4);

--- a/src/lua/LuaSpace.cpp
+++ b/src/lua/LuaSpace.cpp
@@ -318,7 +318,8 @@ static int l_space_put_ship_on_route(lua_State *l)
 		// update velocity direction
 		ship->SetVelocity((targpos - ship->GetPosition()).Normalized() * pp.getVel() + targetbody->GetVelocityRelTo(ship->GetFrame()));
 	}
-	LUA_DEBUG_END(l, 1);
+
+	LUA_DEBUG_END(l, 0);
 	return 0;
 }
 

--- a/src/lua/LuaUtils.h
+++ b/src/lua/LuaUtils.h
@@ -95,7 +95,7 @@ std::string pi_lua_dumpstack(lua_State *l, int top);
 void pi_lua_printvalue(lua_State *l, int idx);
 void pi_lua_stacktrace(lua_State *l);
 
-#ifdef DEBUG
+#ifndef NDEBUG
 #define LUA_DEBUG_START(luaptr) const int __luaStartStackDepth = lua_gettop(luaptr)
 #define LUA_DEBUG_END(luaptr, expectedStackDiff)                                                   \
 	do {                                                                                           \

--- a/src/lua/LuaUtils.h
+++ b/src/lua/LuaUtils.h
@@ -5,6 +5,7 @@
 #define _LUAUTILS_H
 
 // to mask __attribute on MSVC
+#include "core/Log.h"
 #include "core/macros.h"
 #include "DateTime.h"
 

--- a/src/lua/core/Sandbox.cpp
+++ b/src/lua/core/Sandbox.cpp
@@ -146,6 +146,8 @@ static const luaL_Reg STANDARD_LIBS[] = {
 
 void pi_lua_open_standard_base(lua_State *L)
 {
+	LUA_DEBUG_START(L);
+
 	for (const luaL_Reg *lib = STANDARD_LIBS; lib->func; ++lib) {
 		luaL_requiref(L, lib->name, lib->func, 1);
 		lua_pop(L, 1);
@@ -174,9 +176,7 @@ void pi_lua_open_standard_base(lua_State *L)
 	lua_getfield(L, -1, "open");
 	assert(lua_iscfunction(L, -1));
 	LuaFileSystem::register_raw_io_open_function(lua_tocfunction(L, -1));
-
-	lua_pop(L, 1); // pop the io table
-	lua_getglobal(L, LUA_IOLIBNAME);
+	lua_pop(L, 1); // pop the io.open function
 
 	// patch io.open so we can check the path
 	lua_pushcfunction(L, LuaFileSystem::l_patched_io_open);
@@ -245,6 +245,8 @@ void pi_lua_open_standard_base(lua_State *L)
 	lua_setfield(L, -2, "dumpstack");
 
 	lua_pop(L, 1); // pop the debug table
+
+	LUA_DEBUG_END(L, 0);
 }
 
 static int l_handle_error(lua_State *L)

--- a/src/pigui/LuaModelSpinner.cpp
+++ b/src/pigui/LuaModelSpinner.cpp
@@ -42,7 +42,11 @@ void LuaObject<PiGui::ModelSpinner>::RegisterClass()
 	using T = PiGui::ModelSpinner;
 
 	static LuaMetaType<T> s_metaType(s_type);
-	s_metaType.CreateMetaType(Lua::manager->GetLuaState());
+	auto l = Lua::manager->GetLuaState();
+
+	LUA_DEBUG_START(l);
+
+	s_metaType.CreateMetaType(l);
 
 	s_metaType.StartRecording()
 		.AddCallCtor(&l_model_new)

--- a/src/pigui/LuaPiGui.cpp
+++ b/src/pigui/LuaPiGui.cpp
@@ -63,6 +63,8 @@ namespace PiGui {
 				keys.Set(p.first, p.second);
 			}
 
+			lua_pop(l, 1);
+
 			pi_lua_import(l, "Event");
 
 			// Create a new event table and store it for UI use

--- a/src/pigui/LuaPiGui.cpp
+++ b/src/pigui/LuaPiGui.cpp
@@ -43,11 +43,11 @@ namespace PiGui {
 
 		void Init()
 		{
+			LuaObject<PiGui::Instance>::RegisterClass();
+			lua_State *l = ::Lua::manager->GetLuaState();
+
 			LUA_DEBUG_START(l);
 
-			LuaObject<PiGui::Instance>::RegisterClass();
-
-			lua_State *l = ::Lua::manager->GetLuaState();
 			lua_newtable(l);
 			m_handlers = LuaRef(l, -1);
 			lua_pop(l, 1);

--- a/src/pigui/PiGuiSandbox.cpp
+++ b/src/pigui/PiGuiSandbox.cpp
@@ -151,7 +151,7 @@ void PiGui::Lua::RegisterSandbox()
 	pi_lua_split_table_path(L, "PiGui");
 	lua_gettable(L, -2);
 	luaL_setfuncs(L, l_stack_functions, 0);
-	lua_pop(L, 1);
+	lua_pop(L, 2);
 
 	LUA_DEBUG_END(L, 0);
 }

--- a/src/scenegraph/Serializer.h
+++ b/src/scenegraph/Serializer.h
@@ -148,7 +148,7 @@ namespace Serializer {
 		template <typename T>
 		void readObject(T &out)
 		{
-#ifdef DEBUG
+#ifndef NDEBUG
 			if (!Check(sizeof(T)))
 				throw std::out_of_range("Serializer::Reader encountered truncated stream.");
 #endif


### PR DESCRIPTION
Thanks to @WickedSmoke (IRC) for pointing out that the debug builds were broken when "-DDEBUG" is specified as part of the build.


Specifically, "DEBUG" enables the "LUA_DEBUG" symbols, and these no longer compile in the current codebase. This patch fixes the compilation errors, but, notably, now cause runtime problems such as:

```
Pioneer/src/lua/LuaVector.cpp:240: lua stack difference is 1, expected 0
```

This patch also replaces all instances of checking "DEBUG" with checks against "NDEBUG" instead, as the latter is part of the C/C++ language standards and thus independant of any particular build system.