### PR TITLE
feat: degrade scooped cargo requiring cargo life support

### DIFF
--- a/data/modules/LifeSupport.lua
+++ b/data/modules/LifeSupport.lua
@@ -23,6 +23,23 @@ local function LifeSupportCallback(self)
 	if commodityName then
 		cargoMgr:RemoveCommodity(Commodities[commodityName], 1)
 
+		-- randomly convert the commodity into a suitable alternative
+		-- TODO: have a more generic check instead of hard-coding the only two commodities which current require life-support.
+		local dice = 0
+		if commodityName == "live_animals" then
+			Engine.rand:Integer(0,3)
+		elseif commodityName == "slaves" then
+			Engine.rand:Integer(0,2)
+		end
+		if dice == 3 then
+			commodityName = "animal_meat"
+		elseif dice == 2 then
+			commodityName = "fertilizer"
+		else
+			commodityName = "rubbish"
+		end
+		cargoMgr:AddCommodity(Commodities[commodityName], 1)
+
 		if self == Game.player then
 			Game.AddCommsLogLine(lc.CARGO_BAY_LIFE_SUPPORT_LOST)
 		end

--- a/data/modules/LifeSupport.lua
+++ b/data/modules/LifeSupport.lua
@@ -27,9 +27,9 @@ local function LifeSupportCallback(self)
 		-- TODO: have a more generic check instead of hard-coding the only two commodities which current require life-support.
 		local dice = 0
 		if commodityName == "live_animals" then
-			Engine.rand:Integer(0,3)
+			dice = Engine.rand:Integer(0,3)
 		elseif commodityName == "slaves" then
-			Engine.rand:Integer(0,2)
+			dice = Engine.rand:Integer(0,2)
 		end
 		if dice == 3 then
 			commodityName = "animal_meat"


### PR DESCRIPTION
If there is no cargo bay life-support module installed, scooping certain cargo cannisters should degrade their contents.

This PR randomly turns live animals into animal meat, fertilizer, or even rubbish. Slaves are turned into fertilizer or rubbish.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

