### PR TITLE
fix(Passengers): fix crash bugs in Passengers introduced by equip-v2

### DIFF
--- a/data/libs/Passengers.lua
+++ b/data/libs/Passengers.lua
@@ -106,7 +106,7 @@ function Passengers.EmbarkPassenger(ship, passenger, cabin)
 		return false
 	end
 
-	if not cabin:GetFreeBerths() > 0 then
+	if cabin:GetFreeBerths() == 0 then
 		return false
 	end
 

--- a/data/libs/Passengers.lua
+++ b/data/libs/Passengers.lua
@@ -177,9 +177,10 @@ function Passengers.GetMaxPassengersForHull(hull, maxMass)
 					and (availMass - equip.mass > 0)
 					and equip.capabilities.cabin or nil
 			end)
-
-			numPassengers = numPassengers + passengers
-			availMass = availMass - cabin.mass
+			if cabin then
+				numPassengers = numPassengers + passengers
+				availMass = availMass - cabin.mass
+			end
 		end
 	end
 


### PR DESCRIPTION
This PR contains the following fixes:

- fix(Passengers): fix boolean expression in Passengers:EmbarkPassenger
  The precedence of a boolean expression is invalid, with the unary 'not' operator being evaluated before the arithmetic expression. This results in a comparison between a boolean and a number, which gives a runtime error.

  This is fixed by refactoring the overall expression to remove the 'not' operator.

- avoid a nil dereference if hull can't fit any cabins in Passengers:GetMaxPassengersForHull
  When generating certain types of missions, the logic attempts to fill a ship with passenger cabins. Under the new system it's possible that a hull can't fit any. Add a sanity check to ensure we never dereference a nil cabin.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

