### PR TITLE
Sound Cleanup

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -302,8 +302,7 @@ void Player::StaticUpdate(const float timeStep)
 			m_creakSound.VolumeAnimate(creakVol, creakVol, 0.3f, 0.3f);
 		}
 	} else if (m_creakSound.IsPlaying()) {
-		m_creakSound.VolumeAnimate(0.0f, 0.0f, 1.5f, 1.5f);
-		m_creakSound.SetOp(Sound::OP_STOP_AT_TARGET_VOLUME);
+		m_creakSound.FadeOut(1.5f);
 	}
 	m_atmosAccel = current_atmosAccel;
 

--- a/src/sound/AmbientSounds.cpp
+++ b/src/sound/AmbientSounds.cpp
@@ -80,24 +80,15 @@ void AmbientSounds::Update()
 
 	if (Pi::player->GetFlightState() == Ship::DOCKED) {
 		if (s_starNoise.IsPlaying()) {
-			const float target[2] = { 0.0f, 0.0f };
-			const float dv_dt[2] = { 1.0f, 1.0f };
-			s_starNoise.VolumeAnimate(target, dv_dt);
-			s_starNoise.SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+			s_starNoise.FadeOut(1.0f, Sound::OP_REPEAT);
 		}
 		for (int i = 0; i < eMaxNumAtmosphereSounds; i++) {
 			if (s_atmosphereNoises[i].IsPlaying()) {
-				const float target[2] = { 0.0f, 0.0f };
-				const float dv_dt[2] = { 1.0f, 1.0f };
-				s_atmosphereNoises[i].VolumeAnimate(target, dv_dt);
-				s_atmosphereNoises[i].SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+				s_atmosphereNoises[i].FadeOut(1.0f, Sound::OP_REPEAT);
 			}
 		}
 		if (s_planetSurfaceNoise.IsPlaying()) {
-			const float target[2] = { 0.0f, 0.0f };
-			const float dv_dt[2] = { 1.0f, 1.0f };
-			s_planetSurfaceNoise.VolumeAnimate(target, dv_dt);
-			s_planetSurfaceNoise.SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+			s_planetSurfaceNoise.FadeOut(1.0f, Sound::OP_REPEAT);
 		}
 
 		if (!s_stationNoise.IsPlaying()) {
@@ -109,24 +100,15 @@ void AmbientSounds::Update()
 	} else if (Pi::player->GetFlightState() == Ship::LANDED) {
 		/* Planet surface noise on rough-landing */
 		if (s_starNoise.IsPlaying()) {
-			const float target[2] = { 0.0f, 0.0f };
-			const float dv_dt[2] = { 1.0f, 1.0f };
-			s_starNoise.VolumeAnimate(target, dv_dt);
-			s_starNoise.SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+			s_starNoise.FadeOut(1.0f, Sound::OP_REPEAT);
 		}
 		for (int i = 0; i < eMaxNumAtmosphereSounds; i++) {
 			if (s_atmosphereNoises[i].IsPlaying()) {
-				const float target[2] = { 0.0f, 0.0f };
-				const float dv_dt[2] = { 1.0f, 1.0f };
-				s_atmosphereNoises[i].VolumeAnimate(target, dv_dt);
-				s_atmosphereNoises[i].SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+				s_atmosphereNoises[i].FadeOut(1.0f, Sound::OP_REPEAT);
 			}
 		}
 		if (s_stationNoise.IsPlaying()) {
-			const float target[2] = { 0.0f, 0.0f };
-			const float dv_dt[2] = { 1.0f, 1.0f };
-			s_stationNoise.VolumeAnimate(target, dv_dt);
-			s_stationNoise.SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+			s_stationNoise.FadeOut(1.0f, Sound::OP_REPEAT);
 		}
 
 		// lets try something random for the time being
@@ -166,20 +148,14 @@ void AmbientSounds::Update()
 		}
 	} else {
 		if (s_stationNoise.IsPlaying()) {
-			const float target[2] = { 0.0f, 0.0f };
-			const float dv_dt[2] = { 1.0f, 1.0f };
-			s_stationNoise.VolumeAnimate(target, dv_dt);
-			s_stationNoise.SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+			s_stationNoise.FadeOut(1.0f, Sound::OP_REPEAT);
 		}
 		if (Pi::game->IsNormalSpace()) {
 			StarSystem *s = Pi::game->GetSpace()->GetStarSystem().Get();
 			if (astroNoiseSeed != s->GetSeed()) {
 				// change sound!
 				astroNoiseSeed = s->GetSeed();
-				const float target[2] = { 0.0f, 0.0f };
-				const float dv_dt[2] = { 0.1f, 0.1f };
-				s_starNoise.VolumeAnimate(target, dv_dt);
-				s_starNoise.SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+				s_starNoise.FadeOut(0.1f, Sound::OP_REPEAT);
 				// XXX the way Sound::Event works isn't totally obvious.
 				// to destroy the object doesn't stop the sound. it is
 				// really just a sound event reference
@@ -255,11 +231,8 @@ void AmbientSounds::Update()
 				}
 			}
 		} else {
-			const float target[2] = { 0.0f, 0.0f };
-			const float dv_dt[2] = { 1.0f, 1.0f };
 			for (int i = 0; i < eMaxNumAtmosphereSounds; i++) {
-				s_atmosphereNoises[i].VolumeAnimate(target, dv_dt);
-				s_atmosphereNoises[i].SetOp(Sound::OP_REPEAT | Sound::OP_STOP_AT_TARGET_VOLUME);
+				s_atmosphereNoises[i].FadeOut(1.0f, Sound::OP_REPEAT);
 			}
 		}
 	}

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -794,6 +794,14 @@ namespace Sound {
 		return status;
 	}
 
+	bool Event::FadeOut(float dv_dt, Op op)
+	{
+		bool found = VolumeAnimate(0.0f, 0.0f, dv_dt, dv_dt);
+		if (found)
+			SetOp(op | Sound::OP_STOP_AT_TARGET_VOLUME);
+		return found;
+	}
+
 	const std::vector<std::string> GetMusicFiles()
 	{
 		std::vector<std::string> songs;

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -183,10 +183,10 @@ namespace Sound {
 		const Sample *sample;
 		OggVorbis_File *oggv; // if sample->buf = 0 then stream this
 		OggFileDataStream ogg_data_stream;
-		Uint32 buf_pos;
+		uint32_t buf_pos;
 		float volume[2]; // left and right channels
 		eventid identifier;
-		Uint32 op;
+		uint32_t op;
 
 		float targetVolume[2];
 		float rateOfChange[2]; // per sample
@@ -244,12 +244,12 @@ namespace Sound {
 	/*
  * Volume should be 0-65535
  */
-	static Uint32 identifier = 1;
+	static uint32_t identifier = 1;
 	eventid PlaySfx(const char *fx, const float volume_left, const float volume_right, const Op op)
 	{
 		SDL_LockAudioDevice(m_audioDevice);
 		unsigned int idx;
-		Uint32 age;
+		uint32_t age;
 		/* find free wavstream (first two reserved for music) */
 		for (idx = 2; idx < MAX_WAVSTREAMS; idx++) {
 			if (!wavstream[idx].sample) break;

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -179,6 +179,16 @@ namespace Sound {
 		return Sound::PlaySfx(sfx, vl, vr, 0);
 	}
 
+	struct Sample {
+		uint16_t *buf;
+		uint32_t buf_len;
+		uint32_t channels;
+		int upsample; // 1 = 44100, 2=22050
+		/* if buf is null, this will be path to an ogg we must stream */
+		std::string path;
+		bool isMusic;
+	};
+
 	struct SoundEvent {
 		const Sample *sample;
 		OggVorbis_File *oggv; // if sample->buf = 0 then stream this
@@ -762,9 +772,16 @@ namespace Sound {
 		return status;
 	}
 
-	const std::map<std::string, Sample> &GetSamples()
+	const std::vector<std::string> GetMusicFiles()
 	{
-		return sfx_samples;
+		std::vector<std::string> songs;
+		songs.reserve(sfx_samples.size());
+		for (std::map<std::string, Sample>::const_iterator it = sfx_samples.begin();
+			 it != sfx_samples.end(); ++it) {
+			if (it->second.isMusic)
+				songs.emplace_back(it->first.c_str());
+		}
+		return songs;
 	}
 
 } /* namespace Sound */

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -702,12 +702,23 @@ namespace Sound {
 		}
 	}
 
-	void Event::PlayMusic(const char *fx, const float volume_left, const float volume_right, Op op)
+	void Event::PlayMusic(const char *fx, float volume, float fadeDelta, bool repeat, Event* fadeOut)
 	{
+		// The FadeOut, Stop, PlayMusicSample & VolumeAnimate calls perform
+		// five mutex lock operations. These could be reduced to a single
+		// lock/unlock if this were re-written.
+
+		if (fadeOut) {
+			fadeOut->FadeOut(fadeDelta);
+		}
 		Stop();
 		Sample* sample = GetSample(fx);
 		if (sample) {
-			eid = PlayMusicSample(sample, volume_left, volume_right, op);
+			float start = fadeDelta ? 0.0f : volume;
+			eid = PlayMusicSample(sample, start, start, repeat ? Sound::OP_REPEAT : 0);
+			if (fadeDelta) {
+				VolumeAnimate(volume, volume, fadeDelta, fadeDelta);
+			}
 		}
 	}
 

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -227,20 +227,6 @@ namespace Sound {
 		return nullptr;
 	}
 
-	bool SetOp(eventid id, Op op)
-	{
-		if (id == 0) return false;
-		bool ret = false;
-		SDL_LockAudioDevice(m_audioDevice);
-		SoundEvent *se = GetEvent(id);
-		if (se) {
-			se->op = op;
-			ret = true;
-		}
-		SDL_UnlockAudioDevice(m_audioDevice);
-		return ret;
-	}
-
 	static void DestroyEvent(SoundEvent *ev)
 	{
 		if (ev->oggv) {

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -23,13 +23,11 @@ namespace Sound {
 	public:
 		Event() :
 			eid(0) {}
-		Event(uint32_t id) :
-			eid(id) {}
-		virtual void Play(const char *fx, const float volume_left, const float volume_right, Op op);
+		void Play(const char *fx, const float volume_left, const float volume_right, Op op);
 		void Play(const char *fx) { Play(fx, 1.0f, 1.0f, 0); }
+		void PlayMusic(const char *fx, const float volume_left, const float volume_right, Op op);
 		bool Stop();
 		bool IsPlaying() const;
-		uint32_t EventId() { return eid; }
 		bool SetOp(Op op);
 		bool VolumeAnimate(const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2);
 		bool VolumeAnimate(const float targetVols[2], const float dv_dt[2])
@@ -43,10 +41,9 @@ namespace Sound {
 			return SetVolume(vol, vol);
 		}
 
-	protected:
+	private:
 		uint32_t eid;
 	};
-	typedef uint32_t eventid;
 
 	bool Init(bool automaticallyOpenDevice = true);
 	bool InitDevice(std::string &name);
@@ -59,11 +56,10 @@ namespace Sound {
 	void DestroyAllEvents();
 	void DestroyAllEventsExceptMusic();
 	void Pause(int on);
-	eventid PlaySfx(const char *fx, const float volume_left, const float volume_right, const Op op);
-	eventid PlayMusic(const char *fx, const float volume_left, const float volume_right, const Op op);
-	inline static eventid PlaySfx(const char *fx) { return PlaySfx(fx, 1.0f, 1.0f, 0); }
+	void PlaySfx(const char *fx, const float volume_left, const float volume_right, const Op op);
+	inline static void PlaySfx(const char *fx) { PlaySfx(fx, 1.0f, 1.0f, 0); }
 	void CalculateStereo(const Body *b, float vol, float *volLeftOut, float *volRightOut);
-	eventid BodyMakeNoise(const Body *b, const char *fx, float vol);
+	void BodyMakeNoise(const Body *b, const char *fx, float vol);
 	void SetMasterVolume(const float vol);
 	float GetMasterVolume();
 	void SetSfxVolume(const float vol);

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -19,16 +19,6 @@ namespace Sound {
 	};
 	typedef uint32_t Op;
 
-	struct Sample {
-		uint16_t *buf;
-		uint32_t buf_len;
-		uint32_t channels;
-		int upsample; // 1 = 44100, 2=22050
-		/* if buf is null, this will be path to an ogg we must stream */
-		std::string path;
-		bool isMusic;
-	};
-
 	class Event {
 	public:
 		Event() :
@@ -78,7 +68,7 @@ namespace Sound {
 	float GetMasterVolume();
 	void SetSfxVolume(const float vol);
 	float GetSfxVolume();
-	const std::map<std::string, Sample> &GetSamples();
+	const std::vector<std::string> GetMusicFiles();
 
 } /* namespace Sound */
 

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -1,10 +1,10 @@
 // Copyright © 2008-2024 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-#ifndef __OGGMIX_H
-#define __OGGMIX_H
+#ifndef __SOUND_H
+#define __SOUND_H
 
-#include <SDL_stdinc.h>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
@@ -17,12 +17,12 @@ namespace Sound {
 		OP_REPEAT = (1 << 0),
 		OP_STOP_AT_TARGET_VOLUME = (1 << 1)
 	};
-	typedef Uint32 Op;
+	typedef uint32_t Op;
 
 	struct Sample {
-		Uint16 *buf;
-		Uint32 buf_len;
-		Uint32 channels;
+		uint16_t *buf;
+		uint32_t buf_len;
+		uint32_t channels;
 		int upsample; // 1 = 44100, 2=22050
 		/* if buf is null, this will be path to an ogg we must stream */
 		std::string path;
@@ -33,13 +33,13 @@ namespace Sound {
 	public:
 		Event() :
 			eid(0) {}
-		Event(Uint32 id) :
+		Event(uint32_t id) :
 			eid(id) {}
 		virtual void Play(const char *fx, const float volume_left, const float volume_right, Op op);
 		void Play(const char *fx) { Play(fx, 1.0f, 1.0f, 0); }
 		bool Stop();
 		bool IsPlaying() const;
-		Uint32 EventId() { return eid; }
+		uint32_t EventId() { return eid; }
 		bool SetOp(Op op);
 		bool VolumeAnimate(const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2);
 		bool VolumeAnimate(const float targetVols[2], const float dv_dt[2])
@@ -54,9 +54,9 @@ namespace Sound {
 		}
 
 	protected:
-		Uint32 eid;
+		uint32_t eid;
 	};
-	typedef Uint32 eventid;
+	typedef uint32_t eventid;
 
 	bool Init(bool automaticallyOpenDevice = true);
 	bool InitDevice(std::string &name);
@@ -82,4 +82,4 @@ namespace Sound {
 
 } /* namespace Sound */
 
-#endif /* __OGGMIX_H */
+#endif /* __SOUND_H */

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -25,7 +25,7 @@ namespace Sound {
 			eid(0) {}
 		void Play(const char *fx, const float volume_left, const float volume_right, Op op);
 		void Play(const char *fx) { Play(fx, 1.0f, 1.0f, 0); }
-		void PlayMusic(const char *fx, const float volume_left, const float volume_right, Op op);
+		void PlayMusic(const char *fx, float volume, float fadeDelta, bool repeat, Event* fadeOut = nullptr);
 		bool Stop();
 		bool IsPlaying() const;
 		bool SetOp(Op op);

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -40,6 +40,7 @@ namespace Sound {
 		{
 			return SetVolume(vol, vol);
 		}
+		bool FadeOut(float dv_dt, Op op = 0);
 
 	private:
 		uint32_t eid;

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -43,14 +43,12 @@ namespace Sound {
 		if (repeat)
 			op |= Sound::OP_REPEAT;
 		if (m_eventOnePlaying) {
-			m_eventOne.VolumeAnimate(0.f, 0.f, fadeDelta, fadeDelta);
-			m_eventOne.SetOp(Sound::OP_STOP_AT_TARGET_VOLUME);
+			m_eventOne.FadeOut(fadeDelta);
 			m_eventTwo.PlayMusic(name.c_str(), 0.f, 0.f, op);
 			m_eventTwo.VolumeAnimate(m_volume, m_volume, fadeDelta, fadeDelta);
 			m_eventOnePlaying = false;
 		} else {
-			m_eventTwo.VolumeAnimate(0.f, 0.f, fadeDelta, fadeDelta);
-			m_eventTwo.SetOp(Sound::OP_STOP_AT_TARGET_VOLUME);
+			m_eventTwo.FadeOut(fadeDelta);
 			m_eventOne.PlayMusic(name.c_str(), 0.f, 0.f, op);
 			m_eventOne.VolumeAnimate(m_volume, m_volume, fadeDelta, fadeDelta);
 			m_eventOnePlaying = true;
@@ -69,11 +67,9 @@ namespace Sound {
 	void MusicPlayer::FadeOut(const float fadeDelta)
 	{
 		if (m_eventOnePlaying) { //2 might be already fading out
-			m_eventOne.SetOp(Sound::OP_STOP_AT_TARGET_VOLUME);
-			m_eventOne.VolumeAnimate(0.f, 0.f, fadeDelta, fadeDelta);
+			m_eventOne.FadeOut(fadeDelta);
 		} else { // 1 might be already fading out
-			m_eventTwo.SetOp(Sound::OP_STOP_AT_TARGET_VOLUME);
-			m_eventTwo.VolumeAnimate(0.f, 0.f, fadeDelta, fadeDelta);
+			m_eventTwo.FadeOut(fadeDelta);
 		}
 	}
 

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -8,20 +8,6 @@
 
 namespace Sound {
 
-	MusicEvent::MusicEvent() :
-		Event() {}
-
-	MusicEvent::MusicEvent(uint32_t id) :
-		Event(id) {}
-
-	MusicEvent::~MusicEvent() {}
-
-	void MusicEvent::Play(const char *fx, const float volume_left, const float volume_right, Op op)
-	{
-		Stop();
-		eid = PlayMusic(fx, volume_left, volume_right, op);
-	}
-
 	MusicPlayer::MusicPlayer() :
 		m_volume(0.8f),
 		m_playing(false),
@@ -59,13 +45,13 @@ namespace Sound {
 		if (m_eventOnePlaying) {
 			m_eventOne.VolumeAnimate(0.f, 0.f, fadeDelta, fadeDelta);
 			m_eventOne.SetOp(Sound::OP_STOP_AT_TARGET_VOLUME);
-			m_eventTwo.Play(name.c_str(), 0.f, 0.f, op);
+			m_eventTwo.PlayMusic(name.c_str(), 0.f, 0.f, op);
 			m_eventTwo.VolumeAnimate(m_volume, m_volume, fadeDelta, fadeDelta);
 			m_eventOnePlaying = false;
 		} else {
 			m_eventTwo.VolumeAnimate(0.f, 0.f, fadeDelta, fadeDelta);
 			m_eventTwo.SetOp(Sound::OP_STOP_AT_TARGET_VOLUME);
-			m_eventOne.Play(name.c_str(), 0.f, 0.f, op);
+			m_eventOne.PlayMusic(name.c_str(), 0.f, 0.f, op);
 			m_eventOne.VolumeAnimate(m_volume, m_volume, fadeDelta, fadeDelta);
 			m_eventOnePlaying = true;
 		}

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -11,7 +11,7 @@ namespace Sound {
 	MusicEvent::MusicEvent() :
 		Event() {}
 
-	MusicEvent::MusicEvent(Uint32 id) :
+	MusicEvent::MusicEvent(uint32_t id) :
 		Event(id) {}
 
 	MusicEvent::~MusicEvent() {}

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -39,20 +39,18 @@ namespace Sound {
 	void MusicPlayer::Play(const std::string &name, const bool repeat /* = false */, const float fadeDelta /* = 1.f */)
 	{
 		if (!m_enabled) return;
-		Sound::Op op = 0;
-		if (repeat)
-			op |= Sound::OP_REPEAT;
+
+		Event *current, *next;
 		if (m_eventOnePlaying) {
-			m_eventOne.FadeOut(fadeDelta);
-			m_eventTwo.PlayMusic(name.c_str(), 0.f, 0.f, op);
-			m_eventTwo.VolumeAnimate(m_volume, m_volume, fadeDelta, fadeDelta);
 			m_eventOnePlaying = false;
+			current = &m_eventOne;
+			next = &m_eventTwo;
 		} else {
-			m_eventTwo.FadeOut(fadeDelta);
-			m_eventOne.PlayMusic(name.c_str(), 0.f, 0.f, op);
-			m_eventOne.VolumeAnimate(m_volume, m_volume, fadeDelta, fadeDelta);
 			m_eventOnePlaying = true;
+			current = &m_eventTwo;
+			next = &m_eventOne;
 		}
+		next->PlayMusic(name.c_str(), m_volume, repeat, fadeDelta, current);
 		m_playing = true;
 		m_currentSongName = name;
 	}

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -109,18 +109,7 @@ namespace Sound {
 
 	const std::vector<std::string> MusicPlayer::GetSongList() const
 	{
-		using std::pair;
-		using std::string;
-		const std::map<string, Sample> samples = Sound::GetSamples();
-		std::vector<std::string> songs;
-		songs.reserve(samples.size());
-		for (std::map<string, Sample>::const_iterator it = samples.begin();
-			 it != samples.end(); ++it) {
-			if (it->second.isMusic)
-				songs.emplace_back(it->first.c_str());
-		}
-
-		return songs;
+		return GetMusicFiles();
 	}
 
 	bool MusicPlayer::IsPlaying() const

--- a/src/sound/SoundMusic.h
+++ b/src/sound/SoundMusic.h
@@ -11,14 +11,6 @@
 #include <vector>
 
 namespace Sound {
-	class MusicEvent : public Event {
-	public:
-		MusicEvent();
-		MusicEvent(uint32_t id);
-		~MusicEvent();
-		virtual void Play(const char *fx, const float volume_left, const float volume_right, Op op);
-	};
-
 	class MusicPlayer {
 	public:
 		MusicPlayer();
@@ -39,8 +31,8 @@ namespace Sound {
 	private:
 		float m_volume;
 		//two streams for crossfade
-		MusicEvent m_eventOne;
-		MusicEvent m_eventTwo;
+		Event m_eventOne;
+		Event m_eventTwo;
 		bool m_playing;
 		bool m_eventOnePlaying;
 		std::string m_currentSongName;

--- a/src/sound/SoundMusic.h
+++ b/src/sound/SoundMusic.h
@@ -14,7 +14,7 @@ namespace Sound {
 	class MusicEvent : public Event {
 	public:
 		MusicEvent();
-		MusicEvent(Uint32 id);
+		MusicEvent(uint32_t id);
 		~MusicEvent();
 		virtual void Play(const char *fx, const float volume_left, const float volume_right, Op op);
 	};


### PR DESCRIPTION
These commits cleanup the Sound and SoundMusic interfaces to allow plugging in an alternative backend (e.g. OpenAL) simply by switching out sound/Sound.cpp.

This pull request does not address the make file changes required to actually do this.  However, a working proof of concept can be found on [my repository](https://codeberg.org/wickedsmoke/pioneer/commits/branch/faun).

Future work could include:
- Adding a music crossfade method (to allow reducing the five mutex locks used in the SDL implementation down to one).
- Moving common backend code to it's own file.
