### PR TITLE
feat(ui): add keybinding for target radial

### DIFF
--- a/data/pigui/libs/radial-menu.lua
+++ b/data/pigui/libs/radial-menu.lua
@@ -156,7 +156,7 @@ local radial_menu_actions_systembody = {
 	},
 }
 
-function ui.openDefaultRadialMenu(id, body)
+function ui.openDefaultRadialMenu(id, body, pos, action_binding)
 	if body then
 		local actions = {}
 		for _,v in pairs(radial_menu_actions_all_bodies) do
@@ -171,7 +171,7 @@ function ui.openDefaultRadialMenu(id, body)
 				table.insert(actions, v)
 			end
 		end
-		ui.openRadialMenu(id, body, 1, defaultRadialMenuIconSize, actions, defaultRadialMenuPadding)
+		ui.openRadialMenu(id, body, 1, defaultRadialMenuIconSize, actions, defaultRadialMenuPadding, pos, action_binding)
 	end
 end
 

--- a/data/pigui/modules/flight-ui/reticule.lua
+++ b/data/pigui/modules/flight-ui/reticule.lua
@@ -43,7 +43,8 @@ local showNavigationalNumbers = true
 -- to interact with actions and axes in the input system
 local bindings = {
 	assistRadial = bindManager.registerAction('BindFlightAssistRadial'),
-	fixheadingRadial = bindManager.registerAction('BindFixheadingRadial')
+	fixheadingRadial = bindManager.registerAction('BindFixheadingRadial'),
+	targetRadial = bindManager.registerAction('BindTargetRadial'),
 }
 
 -- display the pitch indicator on the right inside of the reticule circle
@@ -321,8 +322,11 @@ local function displayDetailData(target, radius, colorLight, colorDark, tooltip,
 	local uiPos = ui.pointOnClock(center, radius, 2.46)
 	-- label of target
 	local nameSize = ui.addStyledText(uiPos, ui.anchor.left, ui.anchor.baseline, target.label, colorDark, pionillium.medium, tooltip, colors.lightBlackBackground)
-	if ui.isMouseHoveringRect(uiPos - Vector2(0, pionillium.medium.size), uiPos + nameSize - Vector2(0, pionillium.medium.size)) and ui.isMouseClicked(1) and ui.noModifierHeld() then
-		ui.openDefaultRadialMenu("game", target)
+	local isHovered = ui.isMouseHoveringRect(uiPos - Vector2(0, pionillium.medium.size), uiPos + nameSize - Vector2(0, pionillium.medium.size))
+	                  and ui.isMouseClicked(1) and ui.noModifierHeld()
+	if isHovered or bindings.targetRadial.action:IsJustActive() then
+		local action_binding = bindings.targetRadial.action:IsActive() and bindings.targetRadial.action
+		ui.openDefaultRadialMenu("game", target, uiPos, action_binding)
 	end
 	-- current distance, relative speed
 	uiPos = ui.pointOnClock(center, radius, 2.75)

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -47,6 +47,7 @@ REGISTER_INPUT_BINDING(WorldView)
 	// radial menu activators
 	input->AddActionBinding("BindFlightAssistRadial", group, Action{});
 	input->AddActionBinding("BindFixheadingRadial", group, Action{});
+	input->AddActionBinding("BindTargetRadial", group, Action{});
 }
 
 void WorldView::InputBinding::RegisterBindings()
@@ -58,6 +59,7 @@ void WorldView::InputBinding::RegisterBindings()
 	AddAxis("BindRadialHorizontalSelection");
 	AddAction("BindFlightAssistRadial");
 	AddAction("BindFixheadingRadial");
+	AddAction("BindTargetRadial");
 }
 
 WorldView::WorldView(Game *game) :


### PR DESCRIPTION
Add a keybinding to open the target radial menu. The bind is empty by default as per the other target radials.

This allows keyboard controls to fly to, orbit, or dock with the current frame object or nav target, as appropriate.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

