### PR TITLE
Removing normal map from default cockpit materials

### DIFF
--- a/data/models/cockpits/default_cockpit/default_cockpit.model
+++ b/data/models/cockpits/default_cockpit/default_cockpit.model
@@ -5,7 +5,6 @@ shininess 43
 tex_diff default_cockpit_diff.dds
 tex_spec default_cockpit_spec.dds
 tex_glow default_cockpit_glow.dds
-tex_norm default_cockpit_norm.png
 
 material default_cockpit_transp
 diffuse 0.9 0.9 0.9
@@ -15,7 +14,6 @@ opacity 30
 tex_diff default_cockpit_diff.dds
 tex_spec default_cockpit_spec.dds
 tex_glow default_cockpit_glow.dds
-tex_norm default_cockpit_norm.png
 
 material default_cockpit_screen
 diffuse 0.333 0.324 0.329


### PR DESCRIPTION
Fixes #5960 
I do have the normal map, I forgot to include it, it seems. But its effect is negligible, and the file is 6mb, so I'd rather remove it. (Or I could add it if you peeps think it should be there, could also reduce its 4k size).
