### PR TITLE
Linux de-profile and msvc compilation fix

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,8 +77,7 @@
 			"cacheVariables": {
 				"CMAKE_EXPORT_COMPILE_COMMANDS": true,
 				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
-				"CMAKE_BUILD_TYPE": "Debug",
-				"PROFILER_ENABLED": "1"
+				"CMAKE_BUILD_TYPE": "Debug"
 			},
 			"vendor": {
 				"microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -138,8 +137,7 @@
 				"CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
 				"CMAKE_BUILD_TYPE": "Debug",
 				"CMAKE_C_COMPILER": "/usr/bin/clang",
-				"CMAKE_CXX_COMPILER": "/usr/bin/clang++",
-				"PROFILER_ENABLED": "1"
+				"CMAKE_CXX_COMPILER": "/usr/bin/clang++"
 			},
 			"vendor": {
 				"microsoft.com/VisualStudioSettings/CMake/1.0": {

--- a/contrib/profiler/Profiler.cpp
+++ b/contrib/profiler/Profiler.cpp
@@ -25,7 +25,6 @@
 #include "Profiler.h"
 
 #if defined(USE_CHRONO)
-#undef __PROFILER_SMP__
 #include <atomic>
 #endif
 
@@ -115,7 +114,7 @@ namespace Profiler {
 			#if !defined(USE_CHRONO)
 			volatile u32 mLock;
 			#else
-			std::atomic_uint32_t mLock;
+			std::atomic_uint32_t mLock = { 0 };
 			#endif
 		};
 	#else
@@ -915,7 +914,7 @@ namespace Profiler {
 
 
 #if defined(__PROFILER_ENABLED__)
-	threadlocal Caller::ThreadState Caller::thisThread = { {0}, 0, 0, 0, 0 };
+	threadlocal Caller::ThreadState Caller::thisThread = { {}, 0, 0, 0, 0 };
 	f64 Caller::mTimerOverhead = 0, Caller::mRdtscOverhead = 0;
 	u64 Caller::mGlobalDuration = 0;
 	Caller::Max Caller::maxStats;
@@ -999,7 +998,7 @@ namespace Profiler {
 
 	u64 globalStart = Timer::getticks();
 	u64 globalClockStart = Clock::getticks();
-	GlobalThreadList threads = { NULL, {0} };
+	GlobalThreadList threads = { NULL, {} };
 	threadlocal Caller *root = NULL;
 
 

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -305,7 +305,8 @@ void Frame::CollideFrames(void (*callback)(CollisionContact *))
 		if (!frame.m_collisionSpace)
 			continue;
 
-		PROFILE_SCOPED_DESC(frame.m_label.c_str())
+		// Used to be frame.m_label.c_str() however the preprocessor is evaluated at compile time this fails on MSVC
+		PROFILE_SCOPED_DESC("Loop frame")
 		frame.m_collisionSpace->Collide(callback);
 	}
 }


### PR DESCRIPTION
Two minor changes:

- Disable the profiler in Debug builds on Linux because you shouldn't be profiling in Debug. The rationale for this is that Debug will behave very differently than Release builds and so the Profiling build is Release + Profiling tools.
- The 2nd is a compilation fix for MSVC under Profiling or Debug builds where a runtime string was being passed into a Profiling macro which failed to build. I tried a number of things to utilise it but it's the only example in the codebase so switched it out.
