### PR TITLE
Allocate light data UBO from per-frame allocator, misc. fixes and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if (USE_TIME_TRACE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftime-trace")
 endif()
 
-option(USE_ASAN "Use -fsanitize=asan when compiling (requires Clang)" OFF)
+option(USE_ASAN "Use -fsanitize=address when compiling (requires Clang)" OFF)
 if (USE_ASAN)
 	add_compile_options(
 		-g

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -268,7 +268,7 @@ function FormatAndCompareShips:draw_accel_cell(desc, thrustKey, massKey )
 end
 
 function FormatAndCompareShips:draw_deltav_cell(desc, massNumeratorKey, massDenominatorKey)
-	local deltavA = self.def.effectiveExhaustVelocity * math.log( self:get_value(massNumeratorKey) / self.b:get_value(massDenominatorKey) )
+	local deltavA = self.def.effectiveExhaustVelocity * math.log( self:get_value(massNumeratorKey) / self:get_value(massDenominatorKey) )
 	local deltavB = self.b.def.effectiveExhaustVelocity * math.log( self.b:get_value(massNumeratorKey) / self.b:get_value(massDenominatorKey) )
 
 	local function fmt( v )

--- a/src/graphics/opengl/MaterialGL.cpp
+++ b/src/graphics/opengl/MaterialGL.cpp
@@ -98,8 +98,8 @@ namespace Graphics {
 			PROFILE_SCOPED()
 
 			if (m_descriptor.lighting) {
-				UniformBuffer *lightBuffer = m_renderer->GetLightUniformBuffer();
-				SetBuffer(s_lightDataName, { lightBuffer, 0, lightBuffer->GetSize() });
+				assert(m_renderer->GetLightUniformBuffer().buffer != nullptr);
+				SetBuffer(s_lightDataName, m_renderer->GetLightUniformBuffer());
 
 				float intensity[4] = { 0.f, 0.f, 0.f, 0.f };
 				for (uint32_t i = 0; i < m_renderer->GetNumLights(); i++)
@@ -111,7 +111,7 @@ namespace Graphics {
 			// this should always be present, but just in case...
 			if (m_perDrawBinding != Shader::InvalidBinding) {
 				auto buffer = m_renderer->GetDrawUniformBuffer(sizeof(DrawDataBlock));
-				BufferBinding<UniformBuffer> binding;
+				BufferBinding<Graphics::UniformBuffer> binding;
 
 				auto dataBlock = buffer->Allocate<DrawDataBlock>(binding);
 				dataBlock->diffuse = this->diffuse.ToColor4f();
@@ -127,7 +127,7 @@ namespace Graphics {
 				dataBlock->uViewMatrixInverse = mv.Inverse();
 				dataBlock->uViewProjectionMatrix = proj * mv;
 
-				SetBuffer(s_drawDataName, { binding.buffer, binding.offset, binding.size });
+				SetBuffer(s_drawDataName, binding);
 			}
 		}
 

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -112,7 +112,7 @@ namespace Graphics {
 
 		virtual const RenderStateDesc &GetMaterialRenderState(const Graphics::Material *m) override final;
 
-		OGL::UniformBuffer *GetLightUniformBuffer();
+		const BufferBinding<UniformBuffer> &GetLightUniformBuffer();
 		OGL::UniformLinearBuffer *GetDrawUniformBuffer(Uint32 size);
 		OGL::RenderStateCache *GetStateCache() { return m_renderStateCache.get(); }
 
@@ -141,7 +141,7 @@ namespace Graphics {
 		std::vector<std::pair<std::string, OGL::Shader *>> m_shaders;
 		std::vector<std::unique_ptr<OGL::UniformLinearBuffer>> m_drawUniformBuffers;
 		std::unique_ptr<OGL::RenderStateCache> m_renderStateCache;
-		RefCountedPtr<OGL::UniformBuffer> m_lightUniformBuffer;
+		BufferBinding<UniformBuffer> m_lightUniformBuffer;
 		bool m_useNVDepthRanged;
 		OGL::RenderTarget *m_activeRenderTarget = nullptr;
 		std::unique_ptr<OGL::CommandList> m_drawCommandList;

--- a/src/graphics/opengl/UniformBuffer.cpp
+++ b/src/graphics/opengl/UniformBuffer.cpp
@@ -142,7 +142,7 @@ BufferBinding<UniformBuffer> UniformLinearBuffer::Allocate(void *data, size_t si
 	return { this, offset, uint32_t(size) };
 }
 
-void *UniformLinearBuffer::AllocInternal(size_t size, BufferBinding<UniformBuffer> &outBinding)
+void *UniformLinearBuffer::AllocInternal(size_t size, BufferBinding<Graphics::UniformBuffer> &outBinding)
 {
 	assert(m_mapMode == BUFFER_MAP_NONE);
 	m_mapMode = BUFFER_MAP_WRITE;

--- a/src/graphics/opengl/UniformBuffer.cpp
+++ b/src/graphics/opengl/UniformBuffer.cpp
@@ -37,6 +37,7 @@ void UniformBuffer::Unmap()
 
 void UniformBuffer::BufferData(const size_t size, void *data)
 {
+	PROFILE_SCOPED()
 	assert(m_mapMode == BUFFER_MAP_NONE);
 	glBindBuffer(GL_UNIFORM_BUFFER, m_buffer);
 	glBufferSubData(GL_UNIFORM_BUFFER, 0, size, data);
@@ -55,6 +56,7 @@ void UniformBuffer::Release()
 
 void *UniformBuffer::MapInternal(BufferMapMode mode)
 {
+	PROFILE_SCOPED()
 	assert(m_mapMode == BUFFER_MAP_NONE);
 	glBindBuffer(GL_UNIFORM_BUFFER, m_buffer);
 	void *data = glMapBuffer(GL_UNIFORM_BUFFER, (mode == BUFFER_MAP_READ) ? GL_READ_ONLY : GL_WRITE_ONLY);
@@ -142,7 +144,6 @@ BufferBinding<UniformBuffer> UniformLinearBuffer::Allocate(void *data, size_t si
 
 void *UniformLinearBuffer::AllocInternal(size_t size, BufferBinding<UniformBuffer> &outBinding)
 {
-	PROFILE_SCOPED()
 	assert(m_mapMode == BUFFER_MAP_NONE);
 	m_mapMode = BUFFER_MAP_WRITE;
 

--- a/src/graphics/opengl/UniformBuffer.h
+++ b/src/graphics/opengl/UniformBuffer.h
@@ -61,7 +61,7 @@ namespace Graphics {
 			uint32_t NumAllocs() const { return m_numAllocs; }
 
 			template <typename T>
-			ScopedMapping<T> Allocate(BufferBinding<UniformBuffer> &outBinding)
+			ScopedMapping<T> Allocate(BufferBinding<Graphics::UniformBuffer> &outBinding)
 			{
 				assert(m_mapMode == BUFFER_MAP_NONE);
 				return ScopedMapping<T>(AllocInternal(sizeof(T), outBinding), this);
@@ -74,7 +74,7 @@ namespace Graphics {
 			using UniformBuffer::BufferData;
 			using UniformBuffer::Map;
 
-			void *AllocInternal(size_t size, BufferBinding<UniformBuffer> &outBinding);
+			void *AllocInternal(size_t size, BufferBinding<Graphics::UniformBuffer> &outBinding);
 
 			// cache individual allocations into a single buffer and upload to
 			// the GPU in one large chunk.

--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -540,6 +540,7 @@ namespace Graphics {
 
 		matrix4x4f *InstanceBuffer::Map(BufferMapMode mode)
 		{
+			PROFILE_SCOPED()
 			assert(mode != BUFFER_MAP_NONE);	  //makes no sense
 			assert(m_mapMode == BUFFER_MAP_NONE); //must not be currently mapped
 			m_mapMode = mode;
@@ -556,6 +557,7 @@ namespace Graphics {
 
 		void InstanceBuffer::Unmap()
 		{
+			PROFILE_SCOPED()
 			assert(m_mapMode != BUFFER_MAP_NONE); //not currently mapped
 
 			if (GetUsage() == BUFFER_USAGE_STATIC) {

--- a/src/scenegraph/StaticGeometry.cpp
+++ b/src/scenegraph/StaticGeometry.cpp
@@ -69,6 +69,8 @@ namespace SceneGraph {
 		Graphics::InstanceBuffer *ib = m_instBuffer.Get();
 		matrix4x4f *pBuffer = ib->Map(Graphics::BUFFER_MAP_WRITE);
 		if (pBuffer) {
+			PROFILE_SCOPED_DESC("Copy Instance Data")
+
 			// Copy the transforms into the buffer
 			for (const matrix4x4f &mt : trans) {
 				(*pBuffer) = mt;


### PR DESCRIPTION
Another general collection of "fix" commits.

This PR adds additional profiling information to the renderer, and resolves an "early serialization" point which required the previous frame's rendering to be ~mostly complete before starting to record commands for the current frame.

I don't expect any significant performance increase from this PR, except in the case of extremely GPU-bound devices where you might see an improvement of up to a few milliseconds in frame-time, as more CPU work is able to be overlapped with the previous frame's GPU execution time.

This change does fully enforce the existing invariant that you must call `Renderer::SetLights()` *before* attempting to record a draw command using a lit material. An assertion will be thrown in debug mode if this invariant is broken.

It also fixes #5940 - turned out to be quite a simple one-liner once I realized what the problem was.