### PR TITLE
Fix the ability to start from all start positions

### DIFF
--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -185,16 +185,16 @@ local function startGame(gameParams)
 		-- print("Installing equipment {} (proto: {}) into slot {}" % { item, proto, slot })
 		if type(slot) == "string" then
 			local slotHandle = equipSet:GetSlotHandle(slot)
-			assert(slotHandle)
+			if slotHandle then
+				local inst = proto:Instance()
 
-			local inst = proto:Instance()
+				if slotHandle.count then
+					inst:SetCount(slotHandle.count)
+				end
 
-			if slotHandle.count then
-				inst:SetCount(slotHandle.count)
-			end
-
-			if not equipSet:Install(inst, slotHandle) then
-				print("Couldn't install equipment item {} into slot {}" % { inst:GetName(), slot })
+				if not equipSet:Install(inst, slotHandle) then
+					print("Couldn't install equipment item {} into slot {}" % { inst:GetName(), slot })
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Although setting up and even loading the correct equipment from the start variant does not yet work, there is no crash when choosing a different starting position.

Thanks to @fluffyfreak
Fixes #5969

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

