### PR TITLE
Don't update the lights UBO if it hasn't changed

### DIFF
--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -767,6 +767,16 @@ namespace Graphics {
 			return false;
 		}
 
+		// on the principle that this won't change very often...
+		uint64_t lightHash(m_lightHash); 
+		if (numlights == m_numLights) {
+			lightHash = hash_64_fnv1a(reinterpret_cast<const char *>(lights), sizeof(Light) * numlights);
+			if (lightHash == m_lightHash) {
+				return true;
+			}
+		}
+
+		m_lightHash = lightHash;
 		m_numLights = numlights;
 		m_numDirLights = 0;
 		// ScopedMap will be released at the end of the function

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -129,7 +129,7 @@ namespace Graphics {
 		virtual void PopState() override final{};
 
 		size_t m_frameNum;
-
+		uint64_t m_lightHash;
 		Uint32 m_numLights;
 		Uint32 m_numDirLights;
 		float m_minZNear;


### PR DESCRIPTION
After doing some profiling on the RPi:
- SetLights cost 65% (_34.6 MCycles out of 53.1_) of a frame (_new game -> Mars_)
- calculate and store the hash_64_fnv1a to see if lights have changed per-call
- reduces cost to 0.0003 MCycles. Crude measure but fps went from 18 -> 25

This doesn't really remove the cost but it avoids updating the UBO needlessly if the data hasn't changed between calls to SetLights. 

### Real Results
In the best case this performs as above with a massive reduction in the cost of SetLights, for example on the pad at Mars start.
Really though this simply performs no worse most of the time and occassionally makes a large difference.

Tagging @Web-eWorks as this is an area you've been working on and I just tried this on a whim to see what would happen 🤷‍♂️ no worries if it's not suitable but I thought it worth trying.

Would you mind double checking the results when you have time?

### Testing
Started on Mars, flew to Torvalds (_Earth_) station and docked, left and hyperspaced to Barnards Star, flew to SysAdminResting and docked. Everything seemed lit correctly at all times. Menus all worked.
Test on Windows and RPi5