### PR TITLE
feat(radar): capture mouse wheel for zooming radar

### DIFF
--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -15,7 +15,7 @@ local pionillium = ui.fonts.pionillium
 local colors = ui.theme.colors
 local icons = ui.theme.icons
 
-local SCREEN_BORDER = 4
+local SCREEN_BORDER = 6
 
 local MAX_RADAR_SIZE = 1000000000
 local MIN_RADAR_SIZE = 1000
@@ -112,12 +112,13 @@ local radar3d = {
 -- display the 2D radar
 radar2d.draw = function(self, center)
 	local targets = ui.getTargetsNearby(self.zoom)
-	local halfsize = self.size * 0.5
-	local thirdsize = self.size * 0.3
-	local twothirdsize = self.size * 0.7
+	local lineThickness = 1.5
+	local size = self.size - lineThickness
+	local halfsize = size * 0.5
+	local thirdsize = size * 0.3
+	local twothirdsize = size * 0.7
 	local fgColor = colors.uiPrimary
 	local bgColor = colors.uiBackground:opacity(0.54)
-	local lineThickness = 1.5
 
 	local function line(x,y)
 		-- Uncomment to extend the radial line all the way to the outer circle
@@ -126,8 +127,8 @@ radar2d.draw = function(self, center)
 	end
 
 	-- radar background and border
-	ui.addCircleFilled(center, self.size, bgColor, ui.circleSegments(self.size), 1)
-	ui.addCircle(center, self.size, fgColor, ui.circleSegments(self.size), lineThickness * 2)
+	ui.addCircleFilled(center, size, bgColor, ui.circleSegments(size), 1)
+	ui.addCircle(center, size, fgColor, ui.circleSegments(size), lineThickness * 2)
 
 	-- inner circles
 	-- Uncomment to add an additional circle dividing the 2D radar display
@@ -152,7 +153,7 @@ radar2d.draw = function(self, center)
 			if v.distance > halfRadarSize then
 				alpha = 255 * (1 - (v.distance - halfRadarSize) / halfRadarSize)
 			end
-			local position = center + v.aep * self.size * 2
+			local position = center + v.aep * size * 2
 			if v.body == navTarget then
 				local color = Color(colors.navTarget.r, colors.navTarget.g, colors.navTarget.b, alpha)
 				ui.addIcon(position, icons.square, color, Vector2(12, 12), ui.anchor.center, ui.anchor.center)
@@ -340,7 +341,7 @@ local function displayRadar()
 	-- This is in a window so the buttons work and the mouse-wheel is captured
 	local window_width = ui.reticuleCircleRadius * 1.8
 	local window_height = radar2d.size * 2
-	local window_pos = Vector2(center.x - window_width / 2, center.y - radar2d.size - SCREEN_BORDER)
+	local window_pos = Vector2(center.x - window_width / 2, center.y - window_height / 2)
 	local windowFlags = ui.WindowFlags {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"}
 	ui.setNextWindowPos(window_pos, "Always")
 	ui.setNextWindowPadding(Vector2(0))

--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -204,7 +204,7 @@ radar3d.draw = function(self, center)
 	radar.size = self.size
 	radar.zoom = radar.zoom or DEFAULT_RADAR_SIZE
 	local scale = radar.radius / radar.zoom
-	ui.setCursorPos(center - self.size / 2.0)
+	ui.setCursorScreenPos(center - self.size / 2.0)
 
 	-- draw targets below the plane
 	for k, v in pairs(targets) do
@@ -336,33 +336,35 @@ local function displayRadar()
 		instrument:zoomOut()
 	end
 
-	-- Draw the actual radar - this can't be in a window or the 3D scanner background doesn't render
-	instrument:draw(center)
-
-	-- Draw the radar buttons and info - this needs to be in a window, otherwise the buttons don't work.
+	-- Draw the radar, radar buttons and info
+	-- This is in a window so the buttons work and the mouse-wheel is captured
 	local window_width = ui.reticuleCircleRadius * 1.8
-	local window_height = radar2d.size / 3.5
-	local window_pos = Vector2(center.x - window_width / 2, center.y + radar2d.size - window_height - SCREEN_BORDER)
+	local window_height = radar2d.size * 2
+	local window_pos = Vector2(center.x - window_width / 2, center.y - radar2d.size - SCREEN_BORDER)
 	local windowFlags = ui.WindowFlags {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoSavedSettings"}
 	ui.setNextWindowPos(window_pos, "Always")
 	ui.setNextWindowPadding(Vector2(0))
 	ui.setNextWindowSize(Vector2(window_width, window_height), "Always")
+	ui.window("radar", windowFlags, function()
 
-	ui.window("radar_buttons", windowFlags, function()
+		-- Draw the actual radar
+		instrument:draw(center)
 
 		-- Draw radar mode toggle button
+		local toggle_button_size = radar2d.size / 3.5
+		ui.setCursorPos(Vector2(0, window_height - toggle_button_size))
 		local icon = shouldDisplay2DRadar and radar3d.icon or radar2d.icon
-		local clicked = ui.mainMenuButton(icon, lui.HUD_RADAR_TOGGLE_MODE, false, Vector2(window_height))
+		local clicked = ui.mainMenuButton(icon, lui.HUD_RADAR_TOGGLE_MODE, false, Vector2(toggle_button_size))
 		if toggle_radar or clicked then
 			shouldDisplay2DRadar = not shouldDisplay2DRadar
 		end
 
 		-- Draw zoom mode indicator
 		if not shouldDisplay2DRadar then
-			local button_size = window_height / 1.5
+			local button_size = toggle_button_size / 1.5
 			local tt = radar3d.auto_zoom and lui.HUD_RADAR_ZOOM_MODE_AUTOMATIC or lui.HUD_RADAR_ZOOM_MODE_MANUAL
 			ui.sameLine()
-			ui.addCursorPos(Vector2(0, window_height - button_size))
+			ui.addCursorPos(Vector2(0, toggle_button_size - button_size))
 			icon = instrument:isAutoZoom() and icons.radar_automatic or icons.radar_manual
 			ui.mainMenuButton(icon, tt, ui.theme.buttonColors.disabled, Vector2(button_size))
 		end
@@ -372,7 +374,7 @@ local function displayRadar()
 		local textpos = ui.getWindowPos() + Vector2(window_width, window_height)
 		ui.addStyledText(textpos, ui.anchor.right, ui.anchor.bottom, distance, colors.frame, pionillium.small, lui.HUD_RADAR_DISTANCE, colors.lightBlackBackground)
 
-	end) -- window
+	end) -- radar window
 
 end -- function displayRadar()
 

--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -367,7 +367,15 @@ local function displayRadar()
 			ui.sameLine()
 			ui.addCursorPos(Vector2(0, toggle_button_size - button_size))
 			icon = instrument:isAutoZoom() and icons.radar_automatic or icons.radar_manual
-			ui.mainMenuButton(icon, tt, ui.theme.buttonColors.disabled, Vector2(button_size))
+			local theme = instrument:isAutoZoom() and ui.theme.buttonColors.disabled or ui.theme.buttonColors.default
+			local clicked = ui.mainMenuButton(icon, tt, theme, Vector2(button_size))
+			if clicked then
+				if instrument:isAutoZoom() then
+					instrument:zoomIn()
+				else
+					instrument:resetZoom()
+				end
+			end
 		end
 
 		-- Draw radar range


### PR DESCRIPTION
By placing all of the radar drawing routines into a window, the mouse wheel is captured and is not passed back to the world view.

The work to add manual zoom to the 3D radar (#5958) failed to get this to function properly as the wrong API was used for setting the center of the 3D radar. Using 'setCursorScreenPops()' instead of 'setCursorPos()' has the 3D radar background being drawn properly  when placed inside a window.

~~TODO?: When zooming the 3D radar with the mouse, the mode is switched from automatic zoom to manual zoom, but there is not way (using the mouse) to switch the radar back to automatic zoom. Should there be? One option could be that zooming past the maximum zoom automatically switches back to auto-zoom, but testing shows that this is too easy to do accidentally.~~

->  Implemented by making the "Automatic/Manual" mode indicator button switch between manual and automatic mode.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

