### PR TITLE
GeoPatch/GeoSphere refactoring

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -177,7 +177,7 @@ void Camera::Update()
 
 		// cull off-screen objects
 		double rad = b->GetClipRadius();
-		if (!m_context->GetFrustum().TestPointInfinite(attrs.viewCoords, rad))
+		if (!m_context->GetFrustum().TestSphereInfinite(attrs.viewCoords, rad))
 			continue;
 
 		attrs.camDist = attrs.viewCoords.Length();

--- a/src/CityOnPlanet.cpp
+++ b/src/CityOnPlanet.cpp
@@ -677,7 +677,7 @@ void CityOnPlanet::Render(Graphics::Renderer *r, const CameraContext *camera, co
 	// Early frustum test of whole city.
 	const vector3d stationPos = viewTransform * (station->GetPosition() + m_realCentre);
 
-	if (!camera->GetFrustum().TestPoint(stationPos, m_clipRadius))
+	if (!camera->GetFrustum().TestSphere(stationPos, m_clipRadius))
 		return;
 
 	// Use the station-centered frame-oriented coordinate system we generated building positions in
@@ -736,7 +736,7 @@ void CityOnPlanet::Render(Graphics::Renderer *r, const CameraContext *camera, co
 		for (size_t i = 0; i < m_enabledBuildings.size(); i++) {
 			const auto &building = m_enabledBuildings[i];
 
-			if (!frustum.TestPoint(building.pos, building.clipRadius))
+			if (!frustum.TestSphere(building.pos, building.clipRadius))
 				continue;
 
 			transform[building.instIndex].emplace_back(m_instanceTransforms[i]);

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -258,7 +258,7 @@ public:
 
 	void Render(Graphics::Renderer *renderer, const vector3d &campos, const matrix4x4d &modelView, const Graphics::Frustum &frustum)
 	{
-		if (!frustum.TestPoint(clipCentroid, clipRadius))
+		if (!frustum.TestSphere(clipCentroid, clipRadius))
 			return;
 
 		const vector3d relpos = clipCentroid - campos;

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -20,16 +20,18 @@
 #include "profiler/Profiler.h"
 #include "vcacheopt/vcacheopt.h"
 #include "Core/Log.h"
+
 #include <algorithm>
 #include <deque>
+#include <sstream>
 
 #define DEBUG_CENTROIDS 0
 
+#if DEBUG_PATCHES
 #ifdef DEBUG_BOUNDING_SPHERES
 #include "graphics/RenderState.h"
 #endif
 
-#if DEBUG_CENTROIDS
 #include "graphics/Drawables.h"
 #endif
 
@@ -280,6 +282,7 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 		m_patchVBOData->m_normals.reset();
 		m_patchVBOData->m_colors.reset();
 
+#if DEBUG_PATCHES
 #ifdef DEBUG_BOUNDING_SPHERES
 		RefCountedPtr<Graphics::Material> mat(Pi::renderer->CreateMaterial("unlit", Graphics::MaterialDescriptor(), Graphics::RenderStateDesc()));
 		switch (m_depth) {
@@ -291,6 +294,12 @@ void GeoPatch::UpdateVBOs(Graphics::Renderer *renderer)
 		}
 		m_boundsphere.reset(new Graphics::Drawables::Sphere3D(Pi::renderer, mat, 1, m_clipRadius));
 #endif
+		if (m_label3D == nullptr) {
+			std::stringstream stuff;
+			stuff << m_PatchID.GetPatchFaceIdx();
+			m_label3D.reset(new Graphics::Drawables::Label3D(Pi::renderer, stuff.str()));
+		}
+#endif // DEBUG_PATCHES
 	}
 }
 
@@ -305,6 +314,10 @@ void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, cons
 	if (!IsPatchVisible(frustum, campos))
 		return;
 
+#if DEBUG_PATCHES
+	RenderLabelDebug(campos, modelView);
+#endif // DEBUG_PATCHES
+
 	if (m_kids[0]) {
 		for (int i = 0; i < NUM_KIDS; i++)
 			m_kids[i]->Render(renderer, campos, modelView, frustum);
@@ -316,6 +329,11 @@ void GeoPatch::Render(Graphics::Renderer *renderer, const vector3d &campos, cons
 void GeoPatch::RenderImmediate(Graphics::Renderer *renderer, const vector3d &campos, const matrix4x4d &modelView) const
 {
 	PROFILE_SCOPED()
+
+#if DEBUG_PATCHES
+	RenderLabelDebug(campos, modelView);
+#endif // DEBUG_PATCHES
+
 	if (m_patchVBOData->m_heights) {
 		const vector3d relpos = m_clipCentroid - campos;
 		renderer->SetTransform(matrix4x4f(modelView * matrix4x4d::Translation(relpos)));
@@ -536,3 +554,13 @@ bool GeoPatch::IsOverHorizon(const vector3d &camPos) const
 	// not over the horizon
 	return false;
 }
+
+#if DEBUG_PATCHES
+void GeoPatch::RenderLabelDebug(const vector3d &campos, const matrix4x4d &modelView) const
+{
+	if (m_label3D != nullptr) {
+		const vector3d relpos = m_clipCentroid - campos;
+		m_label3D->Draw(Pi::renderer, matrix4x4f(modelView * matrix4x4d::Translation(relpos)));
+	}
+}
+#endif // DEBUG_PATCHES

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -19,7 +19,6 @@
 #include "perlin.h"
 #include "profiler/Profiler.h"
 #include "vcacheopt/vcacheopt.h"
-#include "Core/Log.h"
 
 #include <algorithm>
 #include <deque>

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -362,7 +362,7 @@ void GeoPatch::RenderImmediate(Graphics::Renderer *renderer, const vector3d &cam
 	}
 }
 
-void GeoPatch::GatherRenderablePatches(std::vector<GeoPatch *> &visiblePatches, Graphics::Renderer *renderer, const vector3d &campos, const Graphics::Frustum &frustum)
+void GeoPatch::GatherRenderablePatches(std::vector<std::pair<double, GeoPatch *>> &visiblePatches, Graphics::Renderer *renderer, const vector3d &campos, const Graphics::Frustum &frustum)
 {
 	PROFILE_SCOPED()
 	// must update the VBOs to calculate the clipRadius...
@@ -375,7 +375,7 @@ void GeoPatch::GatherRenderablePatches(std::vector<GeoPatch *> &visiblePatches, 
 		for (int i = 0; i < NUM_KIDS; i++)
 			m_kids[i]->GatherRenderablePatches(visiblePatches, renderer, campos, frustum);
 	} else if (m_patchVBOData->m_heights) {
-		visiblePatches.emplace_back(this);
+		visiblePatches.emplace_back((m_clipCentroid - campos).LengthSqr(), this);
 	}
 }
 

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -497,7 +497,7 @@ bool GeoPatch::IsPatchVisible(const Graphics::Frustum &frustum, const vector3d &
 {
 	PROFILE_SCOPED()
 	// Test if this patch is visible
-	if (!frustum.TestPoint(m_clipCentroid, m_clipRadius))
+	if (!frustum.TestSphere(m_clipCentroid, m_clipRadius))
 		return false; // nothing below this patch is visible
 
 	// We only want to horizon cull patches that can actually be over the horizon!

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -17,14 +17,18 @@
 #include <deque>
 #include <memory>
 
+#define DEBUG_PATCHES 0
 //#define DEBUG_BOUNDING_SPHERES
 
-#ifdef DEBUG_BOUNDING_SPHERES
+#if DEBUG_PATCHES
 #include "graphics/Drawables.h"
 namespace Graphics {
+#ifdef DEBUG_BOUNDING_SPHERES
 	class RenderState;
-}
 #endif
+	class Label3DWrapper;
+} //namespace Graphics
+#endif // DEBUG_PATCHES
 
 namespace Graphics {
 	class Renderer;
@@ -185,9 +189,14 @@ private:
 	uint8_t m_patchUpdateState;
 	bool m_needUpdateVBOs;
 	bool m_hasJobRequest;
+#if DEBUG_PATCHES
 #ifdef DEBUG_BOUNDING_SPHERES
 	std::unique_ptr<Graphics::Drawables::Sphere3D> m_boundsphere;
 #endif
+	std::unique_ptr<Graphics::Drawables::Label3D> m_label3D;
+
+	void RenderLabelDebug(const vector3d &campos, const matrix4x4d &modelView) const;
+#endif // #if DEBUG_PATCHES
 };
 
 #endif /* _GEOPATCH_H */

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -74,7 +74,7 @@ public:
 
 	void Render(Graphics::Renderer *renderer, const vector3d &campos, const matrix4x4d &modelView, const Graphics::Frustum &frustum);
 	void RenderImmediate(Graphics::Renderer *renderer, const vector3d &campos, const matrix4x4d &modelView) const;
-	void GatherRenderablePatches(std::vector<GeoPatch *> &visiblePatches, Graphics::Renderer *renderer, const vector3d &campos, const Graphics::Frustum &frustum);
+	void GatherRenderablePatches(std::vector<std::pair<double, GeoPatch *>> &visiblePatches, Graphics::Renderer *renderer, const vector3d &campos, const Graphics::Frustum &frustum);
 
 	inline bool canBeMerged() const
 	{
@@ -97,8 +97,6 @@ public:
 	void ReceiveJobHandle(Job::Handle job);
 
 	inline bool HasHeightData() const { return (m_patchVBOData != nullptr) && (m_patchVBOData->m_heights.get() != nullptr); }
-
-	inline const vector3d &Centroid() const { return m_clipCentroid; }
 
 	// used by GeoSphere so must be public
 	inline void SetNeedToUpdateVBOs()

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -84,7 +84,7 @@ public:
 				merge &= m_kids[i]->canBeMerged();
 			}
 		}
-		merge &= !(HasJobRequest());
+		merge &= !(m_hasJobRequest);
 		return merge;
 	}
 
@@ -102,33 +102,6 @@ public:
 	inline void SetNeedToUpdateVBOs()
 	{
 		m_needUpdateVBOs = HasHeightData();
-	}
-
-private:
-
-	inline bool NeedToUpdateVBOs() const
-	{
-		return m_needUpdateVBOs;
-	}
-
-	inline void ClearNeedToUpdateVBOs()
-	{
-		m_needUpdateVBOs = false;
-	}
-
-	inline void SetHasJobRequest()
-	{
-		m_hasJobRequest = true;
-	}
-
-	inline bool HasJobRequest() const
-	{
-		return m_hasJobRequest;
-	}
-
-	inline void ClearHasJobRequest()
-	{
-		m_hasJobRequest = false;
 	}
 
 

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -56,7 +56,9 @@ public:
 		return -1;
 	}
 
-	void Render(Graphics::Renderer *r, const vector3d &campos, const matrix4x4d &modelView, const Graphics::Frustum &frustum);
+	void Render(Graphics::Renderer *renderer, const vector3d &campos, const matrix4x4d &modelView, const Graphics::Frustum &frustum);
+	void RenderImmediate(Graphics::Renderer *renderer, const vector3d &campos, const matrix4x4d &modelView) const;
+	void GatherRenderablePatches(std::vector<GeoPatch *> &visiblePatches, Graphics::Renderer *renderer, const vector3d &campos, const Graphics::Frustum &frustum);
 
 	inline bool canBeMerged() const
 	{
@@ -79,6 +81,8 @@ public:
 	void ReceiveJobHandle(Job::Handle job);
 
 	inline bool HasHeightData() const { return (m_patchVBOData != nullptr) && (m_patchVBOData->m_heights.get() != nullptr); }
+
+	inline const vector3d &Centroid() const { return m_clipCentroid; }
 
 	// used by GeoSphere so must be public
 	inline void SetNeedToUpdateVBOs()

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -13,6 +13,7 @@
 #include "matrix4x4.h"
 #include "vector3.h"
 #include "graphics/Frustum.h"
+#include "math/Sphere.h"
 #include <deque>
 #include <memory>
 
@@ -36,6 +37,17 @@ class BasePatchJob;
 class SQuadSplitResult;
 class SSingleSplitResult;
 struct SSplitResultData;
+
+// Experiment:
+// Use smaller spheres than the (m_clipCentroid, m_clipRadius) to test against the horizon.
+// This can eliminate more patches due to not poking a giant clipping sphere over the horizon
+// but on terrains with extreme feature heights there is over-culling of GeoPatches
+// eg: Vesta in the Sol system has massive craters which are obviously culled as they go over the horizon.
+#define USE_SUB_CENTROID_CLIPPING 1
+#if USE_SUB_CENTROID_CLIPPING
+#define NUM_HORIZON_POINTS 5 // 9 // 9 points is more expensive
+static constexpr double CLIP_RADIUS_MULTIPLIER = 0.1;
+#endif // USE_SUB_CENTROID_CLIPPING
 
 class GeoPatch {
 public:
@@ -161,6 +173,9 @@ private:
 	std::unique_ptr<GeoPatch> m_kids[NUM_KIDS];
 
 	vector3d m_clipCentroid;
+#if USE_SUB_CENTROID_CLIPPING
+	SSphere m_clipHorizon[NUM_HORIZON_POINTS];
+#endif // #if USE_SUB_CENTROID_CLIPPING
 	GeoSphere *m_geosphere;
 	double m_splitLength; // rough length, is how near to the camera the m_clipCentroid should be before it must split
 	double m_clipRadius;

--- a/src/GeoPatch.h
+++ b/src/GeoPatch.h
@@ -121,7 +121,8 @@ private:
 private:
 	static const int NUM_KIDS = 4;
 
-	bool IsOverHorizon(const vector3d &camPos);
+	bool IsPatchVisible(const Graphics::Frustum &frustum, const vector3d &camPos) const;
+	bool IsOverHorizon(const vector3d &camPos) const;
 
 	RefCountedPtr<GeoPatchContext> m_ctx;
 	struct Corners {

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -429,9 +429,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 		ambient.a = 255;
 		emission = StarSystem::starRealColors[GetSystemBody()->GetType()];
 		emission.a = 255;
-	}
-
-	else {
+	} else {
 		// give planet some ambient lighting if the viewer is close to it
 		double camdist = 0.1 / campos.LengthSqr();
 		// why the fuck is this returning 0.1 when we are sat on the planet??

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -342,7 +342,7 @@ void GeoSphere::Update()
 	} break;
 	case eReceivedFirstPatches: {
 		for (int i = 0; i < NUM_PATCHES; i++) {
-			m_patches[i]->NeedToUpdateVBOs();
+			m_patches[i]->SetNeedToUpdateVBOs();
 		}
 		m_initStage = eDefaultUpdateState;
 	} break;

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -472,16 +472,16 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 		}
 
 		// distance sort the patches
-		std::sort(m_visiblePatches.begin(), m_visiblePatches.end(), [&, campos](const GeoPatch *a, const GeoPatch *b) {
-			return (a->Centroid() - campos).LengthSqr() < (b->Centroid() - campos).LengthSqr();
+		std::sort(m_visiblePatches.begin(), m_visiblePatches.end(), [&, campos](const std::pair<double, GeoPatch *> &a, const std::pair<double, GeoPatch *> &b) {
+			return (a.first) < (b.first);
 		});
 
 		// cull occluded patches somehow?
 		// create frustum from corner points, something vertical, and the campos??? Cull anything within that frustum?
 
 		// render the sorted patches
-		for (GeoPatch *pPatch : m_visiblePatches) {
-			pPatch->RenderImmediate(renderer, campos, modelView);
+		for (std::pair<double, GeoPatch *> &pPatch : m_visiblePatches) {
+			pPatch.second->RenderImmediate(renderer, campos, modelView);
 		}
 
 		// must clear this after each render otherwise it just accumulates every patch ever drawn!

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -90,7 +90,7 @@ private:
 	void ProcessQuadSplitRequests();
 
 	std::unique_ptr<GeoPatch> m_patches[6];
-	std::vector<GeoPatch *> m_visiblePatches;
+	std::vector<std::pair<double, GeoPatch *>> m_visiblePatches;
 
 	struct TDistanceRequest {
 		TDistanceRequest(double dist, SQuadSplitRequest *pRequest, GeoPatch *pRequester) :

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -80,6 +80,8 @@ private:
 	void ProcessQuadSplitRequests();
 
 	std::unique_ptr<GeoPatch> m_patches[6];
+	std::vector<GeoPatch *> m_visiblePatches;
+
 	struct TDistanceRequest {
 		TDistanceRequest(double dist, SQuadSplitRequest *pRequest, GeoPatch *pRequester) :
 			mDistance(dist),

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -57,6 +57,16 @@ public:
 	static void OnChangeGeoSphereDetailLevel();
 	static bool OnAddQuadSplitResult(const SystemPath &path, SQuadSplitResult *res);
 	static bool OnAddSingleSplitResult(const SystemPath &path, SSingleSplitResult *res);
+
+	enum DebugFlags : uint32_t { // <enum scope='GeoSphere' name=GeoSphereDebugFlags prefix=DEBUG_ public>
+		DEBUG_NONE = 0x0,
+		DEBUG_SORTGEOPATCHES = 0x1,
+		DEBUG_WIREFRAME = 0x2,
+		DEBUG_FACELABELS = 0x4
+	};
+	static void SetDebugFlags(Uint32 flags);
+	static Uint32 GetDebugFlags();
+
 	// in sbody radii
 	virtual double GetMaxFeatureHeight() const override final { return m_terrain->GetMaxHeight(); }
 

--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -123,8 +123,9 @@ void ObjectViewerView::ReloadState()
 
 void ObjectViewerView::Update()
 {
-	if (Pi::input->KeyState(SDLK_EQUALS)) viewingDist *= 0.99f;
-	if (Pi::input->KeyState(SDLK_MINUS)) viewingDist *= 1.01f;
+	const float zoomScaler = (Pi::input->KeyState(SDLK_LSHIFT) || Pi::input->KeyState(SDLK_RSHIFT)) ? 0.001f : 0.01f;
+	if (Pi::input->KeyState(SDLK_EQUALS)) viewingDist *= (1.0f - zoomScaler);
+	if (Pi::input->KeyState(SDLK_MINUS)) viewingDist *= (1.0f + zoomScaler);
 	viewingDist = Clamp(viewingDist, 10.0f, 1e12f);
 
 	Body *body = Pi::player->GetNavTarget();

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -7,8 +7,10 @@
 #include "graphics/Material.h"
 #include "graphics/VertexArray.h"
 #include "graphics/VertexBuffer.h"
+#include "text/DistanceFieldFont.h"
 
 #include <memory>
+#include <string>
 
 struct Aabb;
 
@@ -122,8 +124,6 @@ namespace Graphics {
 			void Draw(Renderer *, Material *);
 
 		private:
-			void CreateVertexBuffer(Graphics::Renderer *r, const Uint32 size);
-
 			bool m_refreshVertexBuffer;
 			RefCountedPtr<MeshObject> m_pointMesh;
 			std::unique_ptr<VertexArray> m_va;
@@ -288,6 +288,23 @@ namespace Graphics {
 		class AABB {
 		public:
 			static void DrawVertices(Graphics::VertexArray &va, const matrix4x4f &transform, const Aabb &aabb, Color color);
+		};
+
+		//------------------------------------------------------------
+
+		// Label3D
+		class Label3D {
+		public:
+			Label3D(Graphics::Renderer *r, const std::string &str);
+			void Draw(Graphics::Renderer *r, const matrix4x4f &trans);
+
+		private:
+			void SetText(Graphics::Renderer *r, const std::string &text);
+
+			RefCountedPtr<Graphics::Material> m_material;
+			std::unique_ptr<Graphics::VertexArray> m_geometry;
+			std::unique_ptr<Graphics::MeshObject> m_textMesh;
+			RefCountedPtr<Text::DistanceFieldFont> m_font;
 		};
 
 	} // namespace Drawables

--- a/src/graphics/Frustum.h
+++ b/src/graphics/Frustum.h
@@ -31,8 +31,8 @@ namespace Graphics {
 			InitFromMatrix(m);
 		}
 
-		// test if point (sphere) is in the frustum
-		bool TestPoint(const vector3<T> &p, T radius) const
+		// test if sphere is in the frustum
+		bool TestSphere(const vector3<T> &p, T radius) const
 		{
 			for (int i = 0; i < 6; i++)
 				if (m_planes[i].DistanceToPoint(p) + radius < 0)
@@ -40,8 +40,8 @@ namespace Graphics {
 			return true;
 		}
 
-		// test if point (sphere) is in the frustum, ignoring the far plane
-		bool TestPointInfinite(const vector3<T> &p, T radius) const
+		// test if sphere is in the frustum, ignoring the far plane
+		bool TestSphereInfinite(const vector3<T> &p, T radius) const
 		{
 			// check all planes except far plane
 			for (int i = 0; i < 5; i++)

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -350,11 +350,6 @@ void PerfInfo::DrawPerfWindow()
 				EndDebugTab();
 			}
 
-			if (BeginDebugTab(s_planetIcon, "Terrain")) {
-				DrawTerrainDebug();
-				EndDebugTab();
-			}
-
 			if (false && ImGui::BeginTabItem("Input")) {
 				DrawInputDebug();
 				ImGui::EndTabItem();
@@ -581,6 +576,7 @@ void PerfInfo::DrawWorldViewStats()
 		}
 	}
 
+	DrawTerrainDebug();
 }
 
 void PerfInfo::DrawInputDebug()
@@ -638,6 +634,7 @@ void PerfInfo::DrawInputDebug()
 
 void PiGui::PerfInfo::DrawTerrainDebug()
 {
+	ImGui::Spacing();
 	ImGui::SeparatorText("Terrain Debug");
 
 	using Flags = GeoSphere::DebugFlags;

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -5,6 +5,7 @@
 #include "Frame.h"
 #include "Game.h"
 #include "GameConfig.h"
+#include "GeoSphere.h"
 #include "Input.h"
 #include "LuaPiGui.h"
 #include "Pi.h"
@@ -631,10 +632,29 @@ void PerfInfo::DrawInputDebug()
 
 void PiGui::PerfInfo::DrawTerrainDebug()
 {
-	bool sortGeoPatches = Pi::config->Int("SortGeoPatches") == 1;
-	if (ImGui::Checkbox("Distance Sort GeoPatches", &sortGeoPatches)) {
-		Pi::config->SetInt("SortGeoPatches", sortGeoPatches ? 1 : 0);
+	ImGui::SeparatorText("Terrain Debug");
+
+	using Flags = GeoSphere::DebugFlags;
+	uint32_t debugFlags = GeoSphere::GetDebugFlags();
+	bool showSort = debugFlags & Flags::DEBUG_SORTGEOPATCHES;
+	bool showWire = debugFlags & Flags::DEBUG_WIREFRAME;
+	//bool showFace = debugFlags & Flags::DEBUG_FACELABELS;
+
+	bool changed = ImGui::Checkbox("Distance Sort GeoPatches", &showSort);
+	changed |= ImGui::Checkbox("Show Wireframe", &showWire);
+	//changed |= ImGui::Checkbox("Show Face IDs", &showFace);
+
+	/* clang-format off */
+	if (changed) {
+		debugFlags = (showSort ? Flags::DEBUG_SORTGEOPATCHES : 0)
+			| (showWire ? Flags::DEBUG_WIREFRAME : 0);
+			//| (showFace ? Flags::DEBUG_FACELABELS : 0);
+		GeoSphere::SetDebugFlags(debugFlags);
+		Pi::config->SetInt("SortGeoPatches", showSort ? 1 : 0);
+
+		Pi::config->Save();
 	}
+	/* clang-format on */
 }
 
 void PerfInfo::DrawImGuiStats()

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -4,6 +4,7 @@
 #include "PerfInfo.h"
 #include "Frame.h"
 #include "Game.h"
+#include "GameConfig.h"
 #include "Input.h"
 #include "LuaPiGui.h"
 #include "Pi.h"
@@ -349,10 +350,14 @@ void PerfInfo::DrawPerfWindow()
 
 			if (Pi::game && Pi::player->GetFlightState() != Ship::HYPERSPACE) {
 				if (BeginDebugTab(s_worldIcon, "WorldView Stats")) {
-
 					DrawWorldViewStats();
 					EndDebugTab();
 				}
+			}
+
+			if (ImGui::BeginTabItem("Terrain")) {
+				DrawTerrainDebug();
+				ImGui::EndTabItem();
 			}
 
 			PiGui::RunHandler(Pi::GetFrameTime(), "debug-tabs");
@@ -621,6 +626,14 @@ void PerfInfo::DrawInputDebug()
 
 		ImGui::Spacing();
 		index++;
+	}
+}
+
+void PiGui::PerfInfo::DrawTerrainDebug()
+{
+	bool sortGeoPatches = Pi::config->Int("SortGeoPatches") == 1;
+	if (ImGui::Checkbox("Distance Sort GeoPatches", &sortGeoPatches)) {
+		Pi::config->SetInt("SortGeoPatches", sortGeoPatches ? 1 : 0);
 	}
 }
 

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -256,9 +256,15 @@ void PerfInfo::Draw()
 		ImGui::ShowStackToolWindow(&m_state->stackToolOpen);
 }
 
-static const char *s_rendererIcon = "\uF082";
-static const char *s_worldIcon = "\uF092";
-static const char *s_perfIcon = "\uF0F0";
+// Icons are found in the file /data/icons/icons.svg
+// The value below can be calculated like this: \uF0A4
+// \uF0 ignore this part
+// A == 10 zero index based so the 11th row of icons.svg
+// 4 == 4 zero index based so the 5th column of icons.svg
+static const char *s_rendererIcon = u8"\uF082";
+static const char *s_worldIcon = u8"\uF092";
+static const char *s_perfIcon = u8"\uF0F0";
+static const char *s_planetIcon = u8"\uF0A0";
 
 bool BeginDebugTab(const char *icon, const char *label)
 {
@@ -344,6 +350,11 @@ void PerfInfo::DrawPerfWindow()
 				EndDebugTab();
 			}
 
+			if (BeginDebugTab(s_planetIcon, "Terrain")) {
+				DrawTerrainDebug();
+				EndDebugTab();
+			}
+
 			if (false && ImGui::BeginTabItem("Input")) {
 				DrawInputDebug();
 				ImGui::EndTabItem();
@@ -354,11 +365,6 @@ void PerfInfo::DrawPerfWindow()
 					DrawWorldViewStats();
 					EndDebugTab();
 				}
-			}
-
-			if (ImGui::BeginTabItem("Terrain")) {
-				DrawTerrainDebug();
-				ImGui::EndTabItem();
 			}
 
 			PiGui::RunHandler(Pi::GetFrameTime(), "debug-tabs");

--- a/src/pigui/PerfInfo.h
+++ b/src/pigui/PerfInfo.h
@@ -67,6 +67,7 @@ namespace PiGui {
 		void DrawWorldViewStats();
 		void DrawImGuiStats();
 		void DrawInputDebug();
+		void DrawTerrainDebug();
 		void DrawStatList(const Perf::Stats::FrameInfo &fi);
 
 		void DrawCounter(CounterInfo &counter, const char *label, float min, float max, float height, bool drawStats = false);


### PR DESCRIPTION
### How it started:
I wanted to reduce the wasted space and padding in the classes GeoSphere and GeoPatch...

### How's it's going:
... I reduced the wasted space and padding in the classes GeoSphere and GeoPatch, and then I went a bit crazy with refactoring things and just trying stuff out!!! 🤣

### What else is here?:
I'd better just list things.
- fixes #5806 by always render/updating the root GeoPatch
- experimental switch to using multiple smaller clipping spheres in the horizon test
- code deduplication in GeoPatch
- distance sorting of GeoPatches during rendering using gather/sort/dispatch
  - for future optimisation work like occlusion culling or depth-first rendering
- Terrain debug tab in PerfInfo, feedback ~~and icon needed~~
- renamed Frustum::TestPoint to Frustum::TestSphere because that's what it does
- added slow zoom using L/R shift keys in Object Viewer
- added Drawables::Label3D for showing GeoPatch Face ID 
  - not yet toggleable but under define

### Performance Improvement?
~~Absolutely no performance improvement that I can tell but then this was all done in areas that medium to high-end PCs just don't struggle with. I haven't tested it on the RPi5 very much and not at all since the profiling has been working again.~~

Tested on lower end machines and there is a definite performance improvement on the Raspberry Pi 5 and low-end x86/64 machines! Particularly with integrated graphics.
