### PR TITLE
Feat/modelspinnermousebutton

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1335,6 +1335,14 @@
     "description": "",
     "message": "Invert Mouse Y"
   },
+  "NO_MIDDLE_MOUSE_BUTTON": {
+    "description": "",
+    "message": "No middle mouse button available"
+  },
+  "NO_MIDDLE_MOUSE_BUTTON_DESC": {
+    "description": "",
+    "message": "Use left mouse button to grab/spin objects when there is no middle mouse button available"
+  },
   "IN_CARGO_HOLD": {
     "description": "",
     "message": "In cargo hold"

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -574,7 +574,7 @@ local function showControlsOptions()
 	ui.text(lui.CONTROL_OPTIONS)
 
 	local mouseYInvert = Input.GetMouseYInverted()
-	local middleMouseButton = Input.IsMiddleMouseButton()
+	local middleMouseButton = Input.EmulateMiddleMouseButton()
 	local joystickEnabled = Input.GetJoystickEnabled()
 	binding_pages = Input.GetBindingPages()
 	local c

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -574,12 +574,16 @@ local function showControlsOptions()
 	ui.text(lui.CONTROL_OPTIONS)
 
 	local mouseYInvert = Input.GetMouseYInverted()
+	local middleMouseButton = Input.IsMiddleMouseButton()
 	local joystickEnabled = Input.GetJoystickEnabled()
 	binding_pages = Input.GetBindingPages()
 	local c
 
 	c,mouseYInvert = checkbox(lui.INVERT_MOUSE_Y, mouseYInvert)
 	if c then Input.SetMouseYInverted(mouseYInvert) end
+
+	c,middleMouseButton = checkbox(lui.NO_MIDDLE_MOUSE_BUTTON, middleMouseButton, lui.NO_MIDDLE_MOUSE_BUTTON_DESC)
+	if c then Input.SetMiddleMouseButton(middleMouseButton) end
 
 	c,joystickEnabled = checkbox(lui.ENABLE_JOYSTICK, joystickEnabled)
 	if c then Input.SetJoystickEnabled(joystickEnabled) end

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -707,7 +707,9 @@ local function displayOnScreenObjects()
 
 	-- click once: select or deselect a body
 	-- double click: zoom to body or reset viewpoint
-	local clicked = not ui.isAnyWindowHovered() and (ui.isMouseClicked(0) or ui.isMouseDoubleClicked(0))
+	local clicked = not ui.isAnyWindowHovered()
+	                and not ui.ctrlHeld()
+	                and (ui.isMouseClicked(0) or ui.isMouseDoubleClicked(0))
 	if clicked then
 		if hoveredObject then
 			selectedObject = hoveredObject.ref

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -21,6 +21,7 @@ GameConfig::GameConfig(const map_string &override_)
 	map["SfxVolume"] = "0.8";
 	map["EnableJoystick"] = "1";
 	map["InvertMouseY"] = "0";
+	map["noMiddleMouseButton"] = "0";
 	map["FOVVertical"] = "65";
 	map["DisplayNavTunnel"] = "0";
 	map["CompactRadar"] = "1";

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -251,11 +251,13 @@ Manager::Manager(IniConfig *config, SDL_Window *window) :
 	m_capturingMouse(false),
 	joystickEnabled(true),
 	mouseYInvert(false),
+	noMiddleMouseButton(false), // Which means a middle mouse button is expected by default
 	m_enableBindings(true),
 	m_frameListChanged(false)
 {
 	joystickEnabled = (m_config->Int("EnableJoystick")) ? true : false;
 	mouseYInvert = (m_config->Int("InvertMouseY")) ? true : false;
+	noMiddleMouseButton = (m_config->Int("noMiddleMouseButton")) ? true : false;
 
 	Input::InitJoysticks(m_config);
 }
@@ -513,6 +515,15 @@ void Manager::SetMouseYInvert(bool state)
 	mouseYInvert = state;
 	if (m_enableConfigSaving) {
 		m_config->SetInt("InvertMouseY", mouseYInvert);
+		m_config->Save();
+	}
+}
+
+void Manager::SetMiddleMouseButton(bool state)
+{
+	noMiddleMouseButton = state;
+	if (m_enableConfigSaving) {
+		m_config->SetInt("noMiddleMouseButton", noMiddleMouseButton);
 		m_config->Save();
 	}
 }

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -857,10 +857,16 @@ void Manager::DispatchEvents()
 
 */
 
+// Mouse rotation is enabled if:
+// MMB is pressed, or Ctrl+LMB is pressed, AND no other mouse buttons are pressed
 bool Manager::IsMouseRotatePressed()
 {
-	return MouseButtonState(SDL_BUTTON_MIDDLE) ||
-	       ((keyModState & KMOD_LCTRL) && MouseButtonState(SDL_BUTTON_LEFT));
+	int state = keyModState & KMOD_LCTRL ? 0x01 : 0x00;
+	state |= MouseButtonState(SDL_BUTTON_LEFT) ? 0x02 : 0x00;
+	state |= MouseButtonState(SDL_BUTTON_MIDDLE) ? 0x04 : 0x00;
+	state |= MouseButtonState(SDL_BUTTON_RIGHT) ? 0x08 : 0x00;
+
+	return state == 0x03 || state == 0x04;
 }
 
 void Manager::SetCapturingMouse(bool grabbed)
@@ -884,6 +890,13 @@ float Manager::GetMoveSpeedShiftModifier()
 {
 	// Suggestion: make x1000 speed on pressing both keys?
 	if (KeyState(SDLK_LSHIFT)) return 100.f;
-	if (KeyState(SDLK_RSHIFT)) return 10.f;
+	if (KeyState(SDLK_LALT)) return 10.f;
+	return 1;
+}
+
+float Manager::GetRotateSpeedShiftModifier()
+{
+	if (KeyState(SDLK_LSHIFT)) return 10.f;
+	if (KeyState(SDLK_LALT)) return 0.1f;
 	return 1;
 }

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -857,6 +857,12 @@ void Manager::DispatchEvents()
 
 */
 
+bool Manager::IsMouseRotatePressed()
+{
+	return MouseButtonState(SDL_BUTTON_MIDDLE) ||
+	       ((keyModState & KMOD_LCTRL) && MouseButtonState(SDL_BUTTON_LEFT));
+}
+
 void Manager::SetCapturingMouse(bool grabbed)
 {
 	// early-out to avoid changing (possibly) expensive WM state

--- a/src/Input.h
+++ b/src/Input.h
@@ -209,6 +209,11 @@ public:
 
 	int GetMouseWheel() { return mouseWheel; }
 
+	// Here for unified UI experience.
+	// Returns true if the mouse button(s)/modifier(s) required to enable
+	// rotation are currently pressed.
+	bool IsMouseRotatePressed();
+
 	// Capturing the mouse hides the cursor, puts the mouse into relative mode,
 	// and passes all mouse inputs to the input system, regardless of whether
 	// ImGui is using them or not.

--- a/src/Input.h
+++ b/src/Input.h
@@ -191,6 +191,9 @@ public:
 	bool IsMouseYInvert() { return mouseYInvert; }
 	void SetMouseYInvert(bool state);
 
+	bool IsMiddleMouseButton() { return noMiddleMouseButton; }
+	void SetMiddleMouseButton(bool state);
+
 	bool IsMouseButtonPressed(int button) { return mouseButton[button] == 1; }
 	bool IsMouseButtonReleased(int button) { return mouseButton[button] == 4; }
 
@@ -246,6 +249,7 @@ private:
 
 	bool joystickEnabled;
 	bool mouseYInvert;
+	bool noMiddleMouseButton;
 
 	std::map<std::string, BindingPage> bindingPages;
 	std::map<std::string, InputBindings::Action> actionBindings;

--- a/src/Input.h
+++ b/src/Input.h
@@ -229,6 +229,10 @@ public:
 	// This is a default value only, centralized here to promote uniform user expericience.
 	float GetMoveSpeedShiftModifier();
 
+	// Get the default speed modifier to apply to rotation depending on the "shift" keys.
+	// This is a default value only, centralized here to promote uniform user expericience.
+	float GetRotateSpeedShiftModifier();
+
 	sigc::signal<void, SDL_Keysym *> onKeyPress;
 	sigc::signal<void, SDL_Keysym *> onKeyRelease;
 	sigc::signal<void, int, int, int> onMouseButtonUp;

--- a/src/Input.h
+++ b/src/Input.h
@@ -191,7 +191,7 @@ public:
 	bool IsMouseYInvert() { return mouseYInvert; }
 	void SetMouseYInvert(bool state);
 
-	bool IsMiddleMouseButton() { return noMiddleMouseButton; }
+	bool EmulateMiddleMouseButton() { return noMiddleMouseButton; }
 	void SetMiddleMouseButton(bool state);
 
 	bool IsMouseButtonPressed(int button) { return mouseButton[button] == 1; }

--- a/src/SectorMap.cpp
+++ b/src/SectorMap.cpp
@@ -1151,7 +1151,7 @@ void SectorMap::Update(float frameTime)
 	if (InputBindings.mapViewPitch->IsActive()) m_rotXMovingTo += 0.5f * moveSpeed * InputBindings.mapViewPitch->GetValue();
 
 	// to capture mouse when button was pressed and release when released
-	const int mouseButton = (input->IsMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
+	const int mouseButton = (input->EmulateMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
 	if (input->MouseButtonState(mouseButton) != m_rotateWithMouseButton) {
 		m_rotateWithMouseButton = !m_rotateWithMouseButton;
 		input->SetCapturingMouse(m_rotateWithMouseButton);

--- a/src/SectorMap.cpp
+++ b/src/SectorMap.cpp
@@ -1151,7 +1151,8 @@ void SectorMap::Update(float frameTime)
 	if (InputBindings.mapViewPitch->IsActive()) m_rotXMovingTo += 0.5f * moveSpeed * InputBindings.mapViewPitch->GetValue();
 
 	// to capture mouse when button was pressed and release when released
-	if (input->MouseButtonState(SDL_BUTTON_MIDDLE) != m_rotateWithMouseButton) {
+	const int mouseButton = (input->IsMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
+	if (input->MouseButtonState(mouseButton) != m_rotateWithMouseButton) {
 		m_rotateWithMouseButton = !m_rotateWithMouseButton;
 		input->SetCapturingMouse(m_rotateWithMouseButton);
 	}

--- a/src/SectorMap.cpp
+++ b/src/SectorMap.cpp
@@ -1151,8 +1151,7 @@ void SectorMap::Update(float frameTime)
 	if (InputBindings.mapViewPitch->IsActive()) m_rotXMovingTo += 0.5f * moveSpeed * InputBindings.mapViewPitch->GetValue();
 
 	// to capture mouse when button was pressed and release when released
-	const int mouseButton = (input->EmulateMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
-	if (input->MouseButtonState(mouseButton) != m_rotateWithMouseButton) {
+	if (input->IsMouseRotatePressed() != m_rotateWithMouseButton) {
 		m_rotateWithMouseButton = !m_rotateWithMouseButton;
 		input->SetCapturingMouse(m_rotateWithMouseButton);
 	}

--- a/src/SectorMap.cpp
+++ b/src/SectorMap.cpp
@@ -1159,8 +1159,9 @@ void SectorMap::Update(float frameTime)
 	if (m_rotateWithMouseButton || m_rotateView) {
 		int motion[2];
 		input->GetMouseMotion(motion);
-		m_rotXMovingTo += 0.2f * float(motion[1]);
-		m_rotZMovingTo += 0.2f * float(motion[0]);
+		float speed = 0.2f * input->GetRotateSpeedShiftModifier();
+		m_rotXMovingTo += speed * float(motion[1]);
+		m_rotZMovingTo += speed * float(motion[0]);
 	} else if (m_zoomView) {
 		input->SetCapturingMouse(true);
 		int motion[2];

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -843,13 +843,12 @@ void SystemMapViewport::HandleInput(float ft)
 	Input::Manager *inputMgr = m_app->GetInput();
 
 	// to capture mouse when button was pressed and release when released
-	const int mouseButton = (inputMgr->EmulateMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
-	if (inputMgr->MouseButtonState(mouseButton) != m_rotateWithMouseButton) {
+	if (inputMgr->IsMouseRotatePressed() != m_rotateWithMouseButton) {
 		m_rotateWithMouseButton = !m_rotateWithMouseButton;
 		inputMgr->SetCapturingMouse(m_rotateWithMouseButton);
 	}
 
-	float speedMod = inputMgr->KeyState(SDLK_LSHIFT) ? 10.f : (inputMgr->KeyState(SDLK_LCTRL) ? 0.1f : 1.f);
+	float speedMod = inputMgr->KeyState(SDLK_LSHIFT) ? 10.f : (inputMgr->KeyState(SDLK_LALT) ? 0.1f : 1.f);
 
 	if (m_rotateWithMouseButton || m_rotateView) {
 		int motion[2];

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -843,7 +843,8 @@ void SystemMapViewport::HandleInput(float ft)
 	Input::Manager *inputMgr = m_app->GetInput();
 
 	// to capture mouse when button was pressed and release when released
-	if (inputMgr->MouseButtonState(SDL_BUTTON_MIDDLE) != m_rotateWithMouseButton) {
+	const int mouseButton = (inputMgr->IsMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
+	if (inputMgr->MouseButtonState(mouseButton) != m_rotateWithMouseButton) {
 		m_rotateWithMouseButton = !m_rotateWithMouseButton;
 		inputMgr->SetCapturingMouse(m_rotateWithMouseButton);
 	}

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -843,7 +843,7 @@ void SystemMapViewport::HandleInput(float ft)
 	Input::Manager *inputMgr = m_app->GetInput();
 
 	// to capture mouse when button was pressed and release when released
-	const int mouseButton = (inputMgr->IsMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
+	const int mouseButton = (inputMgr->EmulateMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
 	if (inputMgr->MouseButtonState(mouseButton) != m_rotateWithMouseButton) {
 		m_rotateWithMouseButton = !m_rotateWithMouseButton;
 		inputMgr->SetCapturingMouse(m_rotateWithMouseButton);

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -848,7 +848,7 @@ void SystemMapViewport::HandleInput(float ft)
 		inputMgr->SetCapturingMouse(m_rotateWithMouseButton);
 	}
 
-	float speedMod = inputMgr->KeyState(SDLK_LSHIFT) ? 10.f : (inputMgr->KeyState(SDLK_LALT) ? 0.1f : 1.f);
+	float speedMod = inputMgr->GetRotateSpeedShiftModifier();
 
 	if (m_rotateWithMouseButton || m_rotateView) {
 		int motion[2];

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -891,7 +891,7 @@ static int l_input_set_mouse_y_inverted(lua_State *l)
 }
 
 
-static int l_input_is_middle_mouse_button(lua_State *l)
+static int l_input_emulate_middle_mouse_button(lua_State *l)
 {
 	lua_pushboolean(l, Pi::input->IsMiddleMouseButton());
 	return 1;
@@ -1140,7 +1140,7 @@ void LuaInput::Register()
 		{ "SaveBinding", l_input_save_binding },
 		{ "GetMouseYInverted", l_input_get_mouse_y_inverted },
 		{ "SetMouseYInverted", l_input_set_mouse_y_inverted },
-		{ "IsMiddleMouseButton", l_input_is_middle_mouse_button },
+		{ "EmulateMiddleMouseButton", l_input_emulate_middle_mouse_button },
 		{ "SetMiddleMouseButton", l_input_set_middle_mouse_button },
 		{ "GetJoystickEnabled", l_input_get_joystick_enabled },
 		{ "SetJoystickEnabled", l_input_set_joystick_enabled },

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -890,6 +890,24 @@ static int l_input_set_mouse_y_inverted(lua_State *l)
 	return 0;
 }
 
+
+static int l_input_is_middle_mouse_button(lua_State *l)
+{
+	lua_pushboolean(l, Pi::input->IsMiddleMouseButton());
+	return 1;
+}
+
+static int l_input_set_middle_mouse_button(lua_State *l)
+{
+	if (lua_isnone(l, 1))
+		return luaL_error(l, "SetMiddleMouseButton takes one boolean argument");
+	const bool mousebutton = lua_toboolean(l, 1);
+	Pi::config->SetInt("noMiddleMouseButton", (mousebutton ? 1 : 0));
+	Pi::config->Save();
+	Pi::input->SetMiddleMouseButton(mousebutton);
+	return 0;
+}
+
 static int l_input_get_mouse_captured(lua_State *l)
 {
 	LuaPush<bool>(l, Pi::input->IsCapturingMouse());
@@ -1122,6 +1140,8 @@ void LuaInput::Register()
 		{ "SaveBinding", l_input_save_binding },
 		{ "GetMouseYInverted", l_input_get_mouse_y_inverted },
 		{ "SetMouseYInverted", l_input_set_mouse_y_inverted },
+		{ "IsMiddleMouseButton", l_input_is_middle_mouse_button },
+		{ "SetMiddleMouseButton", l_input_set_middle_mouse_button },
 		{ "GetJoystickEnabled", l_input_get_joystick_enabled },
 		{ "SetJoystickEnabled", l_input_set_joystick_enabled },
 

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -893,7 +893,7 @@ static int l_input_set_mouse_y_inverted(lua_State *l)
 
 static int l_input_emulate_middle_mouse_button(lua_State *l)
 {
-	lua_pushboolean(l, Pi::input->IsMiddleMouseButton());
+	lua_pushboolean(l, Pi::input->EmulateMiddleMouseButton());
 	return 1;
 }
 

--- a/src/pigui/ModelSpinner.cpp
+++ b/src/pigui/ModelSpinner.cpp
@@ -9,6 +9,7 @@
 #include "graphics/RenderTarget.h"
 #include "graphics/Renderer.h"
 #include "graphics/Texture.h"
+#include "Input.h"
 #include "scenegraph/Tag.h"
 
 #include <algorithm>
@@ -17,6 +18,7 @@ using namespace PiGui;
 
 ModelSpinner::ModelSpinner() :
 	m_spinning(true),
+	m_middleMouseButton(false),
 	m_pauseTime(.0f),
 	m_rot(vector2f(DEG2RAD(-15.0), DEG2RAD(120.0))),
 	m_zoom(1.0f),
@@ -136,7 +138,8 @@ void ModelSpinner::DrawPiGui()
 
 	const ImGuiIO &io = ImGui::GetIO();
 	bool hovered = ImGui::IsItemHovered();
-	if (hovered && ImGui::IsMouseDown(0)) {
+	const int mouseButton = (Pi::input->IsMiddleMouseButton() ? 0 : 2); // 0 : 2 = ImGui mouse button Left and Middle.
+	if (hovered && ImGui::IsMouseDown(mouseButton)) {
 		m_rot.x -= 0.005 * io.MouseDelta.y;
 		m_rot.y -= 0.005 * io.MouseDelta.x;
 		m_pauseTime = 1.0f;

--- a/src/pigui/ModelSpinner.cpp
+++ b/src/pigui/ModelSpinner.cpp
@@ -19,6 +19,7 @@ using namespace PiGui;
 ModelSpinner::ModelSpinner() :
 	m_spinning(true),
 	m_middleMouseButton(false),
+	m_rotateWithMouseButton(false),
 	m_pauseTime(.0f),
 	m_rot(vector2f(DEG2RAD(-15.0), DEG2RAD(120.0))),
 	m_zoom(1.0f),
@@ -138,8 +139,13 @@ void ModelSpinner::DrawPiGui()
 
 	const ImGuiIO &io = ImGui::GetIO();
 	bool hovered = ImGui::IsItemHovered();
-	const int mouseButton = (Pi::input->EmulateMiddleMouseButton() ? 0 : 2); // 0 : 2 = ImGui mouse button Left and Middle.
-	if (hovered && ImGui::IsMouseDown(mouseButton)) {
+	// TODO: This should be unified with Input::Manager::IsMouseRotatePressed()
+	bool isMouseRotatePressed = ImGui::IsMouseDown(2) || ImGui::IsKeyDown(ImGuiKey_LeftCtrl) && ImGui::IsMouseDown(0);
+	if (hovered && isMouseRotatePressed != m_rotateWithMouseButton) {
+		m_rotateWithMouseButton = !m_rotateWithMouseButton;
+		Pi::input->SetCapturingMouse(m_rotateWithMouseButton);
+	}
+	if (m_rotateWithMouseButton) {
 		m_rot.x -= 0.005 * io.MouseDelta.y;
 		m_rot.y -= 0.005 * io.MouseDelta.x;
 		m_pauseTime = 1.0f;

--- a/src/pigui/ModelSpinner.cpp
+++ b/src/pigui/ModelSpinner.cpp
@@ -138,7 +138,7 @@ void ModelSpinner::DrawPiGui()
 
 	const ImGuiIO &io = ImGui::GetIO();
 	bool hovered = ImGui::IsItemHovered();
-	const int mouseButton = (Pi::input->IsMiddleMouseButton() ? 0 : 2); // 0 : 2 = ImGui mouse button Left and Middle.
+	const int mouseButton = (Pi::input->EmulateMiddleMouseButton() ? 0 : 2); // 0 : 2 = ImGui mouse button Left and Middle.
 	if (hovered && ImGui::IsMouseDown(mouseButton)) {
 		m_rot.x -= 0.005 * io.MouseDelta.y;
 		m_rot.y -= 0.005 * io.MouseDelta.x;

--- a/src/pigui/ModelSpinner.h
+++ b/src/pigui/ModelSpinner.h
@@ -74,6 +74,9 @@ namespace PiGui {
 		// Is there a middle mouse button?
 		bool m_middleMouseButton;
 
+		// Is the user rotating the model?
+		bool m_rotateWithMouseButton;
+
 		// After the user manually rotates the model, hold that orientation for
 		// a second to let them look at it. Assumes Update() is called every
 		// frame while visible.

--- a/src/pigui/ModelSpinner.h
+++ b/src/pigui/ModelSpinner.h
@@ -71,6 +71,9 @@ namespace PiGui {
 		// Shoulde we spinne?
 		bool m_spinning;
 
+		// Is there a middle mouse button?
+		bool m_middleMouseButton;
+
 		// After the user manually rotates the model, hold that orientation for
 		// a second to let them look at it. Assumes Update() is called every
 		// frame while visible.

--- a/src/ship/ShipViewController.cpp
+++ b/src/ship/ShipViewController.cpp
@@ -273,8 +273,7 @@ void ShipViewController::Update()
 	Pi::input->GetMouseMotion(mouseMotion);
 
 	// external camera mouselook
-	const int mouseButton = (Pi::input->EmulateMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
-	bool mouse_down = Pi::input->MouseButtonState(mouseButton);
+	bool mouse_down = Pi::input->IsMouseRotatePressed();
 	if (mouse_down && !headtracker_input_priority) {
 		if (!m_mouseActive) {
 			m_mouseActive = true;
@@ -283,8 +282,9 @@ void ShipViewController::Update()
 
 		// invert the mouse input to convert between screen coordinates and
 		// right-hand coordinate system rotation.
-		cam->YawCamera(float(-mouseMotion[0]) * MOUSELOOK_SPEED / M_PI);
-		cam->PitchCamera(float(-mouseMotion[1]) * MOUSELOOK_SPEED / M_PI);
+		float speed = MOUSELOOK_SPEED * Pi::input->GetRotateSpeedShiftModifier();
+		cam->YawCamera(float(-mouseMotion[0]) * speed / M_PI);
+		cam->PitchCamera(float(-mouseMotion[1]) * speed / M_PI);
 	}
 
 	if (!mouse_down && m_mouseActive) {

--- a/src/ship/ShipViewController.cpp
+++ b/src/ship/ShipViewController.cpp
@@ -273,7 +273,7 @@ void ShipViewController::Update()
 	Pi::input->GetMouseMotion(mouseMotion);
 
 	// external camera mouselook
-	const int mouseButton = (Pi::input->IsMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
+	const int mouseButton = (Pi::input->EmulateMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
 	bool mouse_down = Pi::input->MouseButtonState(mouseButton);
 	if (mouse_down && !headtracker_input_priority) {
 		if (!m_mouseActive) {

--- a/src/ship/ShipViewController.cpp
+++ b/src/ship/ShipViewController.cpp
@@ -273,7 +273,8 @@ void ShipViewController::Update()
 	Pi::input->GetMouseMotion(mouseMotion);
 
 	// external camera mouselook
-	bool mouse_down = Pi::input->MouseButtonState(SDL_BUTTON_MIDDLE);
+	const int mouseButton = (Pi::input->IsMiddleMouseButton() ? SDL_BUTTON_LEFT : SDL_BUTTON_MIDDLE);
+	bool mouse_down = Pi::input->MouseButtonState(mouseButton);
 	if (mouse_down && !headtracker_input_priority) {
 		if (!m_mouseActive) {
 			m_mouseActive = true;


### PR DESCRIPTION
Took over #5594 as @zonkmachine indicated they no longer have the time to complete their PR.

Changes from the last commit:

- Unify almost all spinning by creating Input::Manager::IsMouseRotatePressed()
  - almost a single place to implement the logic instead of in multiple places throughout the code.
  - the current button combos for rotation are the MMB and Ctrl+LMB
  - The ModelSpinner has its own implementation as it uses `ImGui`, not `Input::Manager`
  - TODO: remove the now-obsolete "No middle mouse button" option
  - TODO: add user configuration options for the buttons/modifiers used
- Add Input::Manager::GetRotateSpeedShiftModifier() to also unify rotation speed modifiers
  - change using the Right-Shift key to the Left-Alt key for the secondary speed and rotation modifiers
- Fix SystemView deselecting objects when rotation is started
- Fix ShipView rotating when rotating the ship (via RMB) itself.

**Discussion:**
Given that the RMB moves the ship itself, would this be the more natural default to spin everything instead of the MMB? That could free up the MMB for panning/moving in the SectorView and SystemView.


<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

