### PR TITLE
Feat/radar improvements

### DIFF
--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -371,7 +371,7 @@ local function displayRadar()
 			local clicked = ui.mainMenuButton(icon, tt, theme, Vector2(button_size))
 			if clicked then
 				if instrument:isAutoZoom() then
-					instrument:zoomIn()
+					instrument:zoomOut()
 				else
 					instrument:resetZoom()
 				end

--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -317,6 +317,7 @@ end
 -- between frames. We are trying to ensure that a mouse right-click started and
 -- finished inside the radar area in order to trigger the popup.
 local click_on_radar = false
+local radar_popup_displayed = false
 
 -- display either the 3D or the 2D radar, show a popup on right click to select
 local function displayRadar()
@@ -360,21 +361,29 @@ local function displayRadar()
 			Vector2(center.x + ui.reticuleCircleRadius * 0.9,
 			        center.y + ui.reticuleCircleRadius * 0.7))
 	end
-	if isMouseOverRadar() then
+	if isMouseOverRadar() or radar_popup_displayed then
 		ui.popup("radarselector", function()
 			if ui.selectable(lui.HUD_2D_RADAR, shouldDisplay2DRadar, {}) then
-				toggle_radar = true
+				if not shouldDisplay2DRadar then
+					toggle_radar = true
+				end
 			end
 			if ui.selectable(lui.HUD_3D_RADAR, not shouldDisplay2DRadar, {}) then
-				toggle_radar = true
+				if shouldDisplay2DRadar then
+					toggle_radar = true
+				end
 			end
 		end)
 
 		if ui.isMouseClicked(1) then
 			click_on_radar = true
 		end
+		if click_on_radar and ui.isMouseReleased(0) then
+			radar_popup_displayed = false
+		end
 		if not toggle_radar and click_on_radar and ui.isMouseReleased(1) then
 			ui.openPopup("radarselector")
+			radar_popup_displayed = true
 		end
 		-- TODO: figure out how to "capture" the mouse wheel to prevent
 		-- the game engine from using it to also zoom the viewport

--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -349,9 +349,18 @@ local function displayRadar()
 	end
 
 	-- Handle mouse if it is in the radar area
-	local mp = ui.getMousePos()
-	-- TODO: adjust properly for 3D radar; bit more challenging as its an ellipse
-	if (mp - center):length() < radar2d.getRadius(radar2d) then
+	local isMouseOverRadar = function()
+		if shouldDisplay2DRadar then
+			local mp = ui.getMousePos()
+			return (mp - center):length() < radar2d.getRadius(radar2d)
+		end
+		return ui.isMouseHoveringRect(
+			Vector2(center.x - ui.reticuleCircleRadius * 0.9,
+			        center.y - ui.reticuleCircleRadius * 0.7),
+			Vector2(center.x + ui.reticuleCircleRadius * 0.9,
+			        center.y + ui.reticuleCircleRadius * 0.7))
+	end
+	if isMouseOverRadar() then
 		ui.popup("radarselector", function()
 			if ui.selectable(lui.HUD_2D_RADAR, shouldDisplay2DRadar, {}) then
 				toggle_radar = true

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -50,7 +50,7 @@ namespace Sound {
 			current = &m_eventTwo;
 			next = &m_eventOne;
 		}
-		next->PlayMusic(name.c_str(), m_volume, repeat, fadeDelta, current);
+		next->PlayMusic(name.c_str(), m_volume, fadeDelta, repeat, current);
 		m_playing = true;
 		m_currentSongName = name;
 	}


### PR DESCRIPTION
**NOTE:** The code could probably do with some tidying up...

----

1. ensure targeted object remains visible when switching from automatic to manual zoom (https://github.com/pioneerspacesim/pioneer/pull/5978#pullrequestreview-2456782749)
2. add intermediate zoom steps for manual zoom (https://github.com/pioneerspacesim/pioneer/pull/5978#pullrequestreview-2456782749)
3. fix popup disappearing when mouse moves outside of radar area but still over popup
4. improve checking when mouse is over radar area (especially for the 3D scanner mode display)
5. add left-click to set navigation target when clicking on a target "pip". This will show a popup if there are multiple targets on a "pip".
6. add double-click to clear the navigation target

Additionally fix an issue introduced in 678d46e4a1efec765322076090fa54349a8af6ea where a couple of parameters are swapped when calling "PlayMusic" (found due to compiler warning).

**TODO:**

- [ ] code review
- [ ] clean up commits
- [ ] merge

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

