### PR TITLE
Updating Vatakara to use the shild mesh of the Malabar

### DIFF
--- a/data/ships/vatakara.json
+++ b/data/ships/vatakara.json
@@ -2,7 +2,7 @@
 	"model": "vatakara",
 	"name": "Vatakara",
 	"cockpit": "",
-	"shield_model": "vatakara_shield",
+	"shield_model": "malabar_shield",
 	"manufacturer": "mandarava-csepel",
 	"ship_class": "heavy_freighter",
 	"min_crew": 4,


### PR DESCRIPTION
Since they are essentially the same model apart some windows, Vatakara can use the malabar_shield. I believe the wrong data was from the Notion export autopulating the shield field
Fixes #5989 
