### PR TITLE
feat(equipment): add equipment for all size slots

### DIFF
--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -345,7 +345,7 @@
   },
   "MISSILE_RACK_322": {
     "description": "Name for a multiple-missile external missile rack. 'Hydri' is a brand name.",
-    "message": "LH-230 Hydri Missile Rack"
+    "message": "LH-220 Hydri Missile Rack"
   },
   "MISSILE_RACK_341": {
     "description": "Name for a multiple-missile external missile rack. 'Hydri' is a brand name.",

--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -335,33 +335,66 @@
     "description": "",
     "message": "Guided Missile"
   },
+
   "MISSILE_NAVAL": {
     "description": "",
     "message": "Naval Missile"
   },
+
   "MISSILE_RACK_221": {
-    "description": "Name for a multiple-missile external missile rack. 'Hydri' is a brand name.",
-    "message": "LH-120 Hydri Missile Rack"
+    "description": "Name for a multiple-missile external missile rack. 'Hydra' is a model name.",
+    "message": "Hydra LH-120 Missile Rack"
   },
+
   "MISSILE_RACK_322": {
-    "description": "Name for a multiple-missile external missile rack. 'Hydri' is a brand name.",
-    "message": "LH-220 Hydri Missile Rack"
+    "description": "Name for a multiple-missile external missile rack. 'Hydra' is a model name.",
+    "message": "Hydra LH-220 Missile Rack"
   },
+
   "MISSILE_RACK_341": {
-    "description": "Name for a multiple-missile external missile rack. 'Hydri' is a brand name.",
-    "message": "LH-140 Hydri Missile Rack"
+    "description": "Name for a multiple-missile external missile rack. 'Medusa' is a model name.",
+    "message": "Medusa LH-140 Missile Rack"
   },
+
+  "MISSILE_RACK_442": {
+    "description": "Name for a multiple-missile external missile rack. 'Medusa' is a model name.",
+    "message": "Medusa LH-240 Missile Rack"
+  },
+
+  "MISSILE_RACK_423": {
+    "description": "Name for a multiple-missile external missile rack. 'Hydra' is the model name.",
+    "message": "Hydra LH-320 Missile Rack"
+  },
+  },
+
+  "MISSILE_RACK_524": {
+    "description": "Name for a multiple-missile external missile rack. 'Hydra' is the model name.",
+    "message": "Hydra LH-420 Missile Rack"
+  },
+
+  "MISSILE_RACK_543": {
+    "description": "Name for a multiple-missile external missile rack. 'Medusa' is a model name.",
+    "message": "Medusa LH-340 Missile Rack"
+  },
+
   "MISSILE_RAIL_S1": {
-    "description": "Name for a single-missile external launcher. 'Cnida' is a brand name.",
+    "description": "Name for a single-missile external launcher. 'Cnida' is a model name.",
     "message": "Cnida-101 Missile Rail"
   },
+
   "MISSILE_RAIL_S2": {
-    "description": "Name for a single-missile external launcher. 'Cnida' is a brand name.",
+    "description": "Name for a single-missile external launcher. 'Cnida' is a model name.",
     "message": "Cnida-102 Missile Rail"
   },
+
   "MISSILE_RAIL_S3": {
-    "description": "Name for a single-missile external launcher. 'Cnida' is a brand name.",
+    "description": "Name for a single-missile external launcher. 'Cnida' is a model name.",
     "message": "Cnida-103 Missile Rail"
+  },
+
+  "MISSILE_RAIL_S4": {
+    "description": "Name for a single-missile external launcher. 'Cnida' is a model name.",
+    "message": "Cnida-104 Missile Rail"
   },
   "MISSILE_SMART": {
     "description": "",
@@ -380,6 +413,14 @@
     "message": "Bowfin Missile Launcher"
   },
   "OPLI_INTERNAL_MISSILE_RACK_S2": {
+    "description": "Equipment name for an OPLI internal missile rack",
+    "message": "OPLI Internal Missile Rack"
+  },
+  "OPLI_INTERNAL_MISSILE_RACK_S3": {
+    "description": "Equipment name for an OPLI internal missile rack",
+    "message": "OPLI Internal Missile Rack"
+  },
+  "OPLI_INTERNAL_MISSILE_RACK_S4": {
     "description": "Equipment name for an OPLI internal missile rack",
     "message": "OPLI Internal Missile Rack"
   },

--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -331,79 +331,202 @@
     "description": "Category name of missile-related equipment",
     "message": "Missiles"
   },
+
   "MISSILE_GUIDED": {
     "description": "",
     "message": "Guided Missile"
+  },
+  "MISSILE_GUIDED_DESCRIPTION": {
+    "description": "Equipment description",
+    "message": "Standard fire-and-forget guided missiles."
+  },
+  "MISSILE_GUIDED_FLAVOURTEXT": {
+    "description": "Equipment description",
+    "message": "Mass produced guided missile which will attempt to home in on a selected target. Depending on the exact model, this missile may use a variety of homing technologies including one or more of Radar, Laser, or LIDAR. Nevertheless, the technology in these missiles is not guaranteed to ensure a hit and most are quite vulnerable to ECM or other countermeasures."
   },
 
   "MISSILE_NAVAL": {
     "description": "",
     "message": "Naval Missile"
   },
+  "MISSILE_NAVAL_DESCRIPTION": {
+    "description": "Equipment description",
+    "message": "Fire-and-forget homing missile highly resistant to all known types of countermeasures."
+  },
+  "MISSILE_NAVAL_FLAVOURTEXT": {
+    "description": "Equipment description",
+    "message": "These missiles are produced in highly specialised and secretive naval factories in tightly controlled facilities and generally not available to non-military personel. Able to resist most known types of countermeasures, these missiles are fast for their size and usually pack exotic warheads for extreme destructive potential. Often specialised equipment is required in the ships carrying these in order to correctly arm and program the missiles prior to launch."
+  },
 
   "MISSILE_RACK_221": {
     "description": "Name for a multiple-missile external missile rack. 'Hydra' is a model name.",
     "message": "Hydra LH-120 Missile Rack"
+  },
+  "MISSILE_RACK_221_DESCRIPTION": {
+    "description": "Equipment tooltip",
+    "message": "External missile rack with a capacity of 2 small missiles."
+  },
+  "MISSILE_RACK_221_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "This quality missile rack from Hydri Defense allows you to carry more bangs per hardpoint, essential for taking on those pesky pirates."
   },
 
   "MISSILE_RACK_322": {
     "description": "Name for a multiple-missile external missile rack. 'Hydra' is a model name.",
     "message": "Hydra LH-220 Missile Rack"
   },
+  "MISSILE_RACK_322_DESCRIPTION": {
+    "description": "Equipment tooltip",
+    "message": "External missile rack with a capacity of 2 medium missiles."
+  },
+  "MISSILE_RACK_322_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "A missile rack for the more discerning Hydri Defense customer. Bigger bangs for your bucks!"
+  },
 
   "MISSILE_RACK_341": {
     "description": "Name for a multiple-missile external missile rack. 'Medusa' is a model name.",
     "message": "Medusa LH-140 Missile Rack"
+  },
+  "MISSILE_RACK_341_DESCRIPTION": {
+    "description": "Equipment tooltip",
+    "message": "External missile rack with a capacity of 4 small missiles."
+  },
+  "MISSILE_RACK_341_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "This one is a real beauty, coming straight to you from the R&D labs at Hydri Defense. We've squeezed even more missiles into this rack to allow you to really make some fireworks!"
   },
 
   "MISSILE_RACK_442": {
     "description": "Name for a multiple-missile external missile rack. 'Medusa' is a model name.",
     "message": "Medusa LH-240 Missile Rack"
   },
+  "MISSILE_RACK_442_DESCRIPTION": {
+    "description": "Equipment tooltip",
+    "message": "External missile rack with a capacity of 4 medium missiles."
+  },
+  "MISSILE_RACK_442_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "Ready to take on the big league? With this big rack from Hydri Defense, you'll always be fully loaded to unleash fiery destruction."
+  },
 
   "MISSILE_RACK_423": {
     "description": "Name for a multiple-missile external missile rack. 'Hydra' is the model name.",
     "message": "Hydra LH-320 Missile Rack"
   },
+  "MISSILE_RACK_423_DESCRIPTION": {
+    "description": "Equipment tooltip",
+    "message": "External missile rack with a capacity of 2 large missiles."
+  },
+  "MISSILE_RACK_423_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "Make sure to keep your distance after firing! Hydri Defense has packed 2 large missiles into this rack for some truly spectacular booms."
   },
 
   "MISSILE_RACK_524": {
     "description": "Name for a multiple-missile external missile rack. 'Hydra' is the model name.",
     "message": "Hydra LH-420 Missile Rack"
   },
+  "MISSILE_RACK_524_DESCRIPTION": {
+    "description": "Equipment tooltip",
+    "message": "External missile rack with a capacity of 2 huge missiles."
+  },
+  "MISSILE_RACK_524_FLAVOURTEXT": {
+    "description": "Equipment description",
+    "message": "Space for 2 huge missiles. Even we've run out of superlatives for what you can do with these.. we just hope you packed your sunnies!"
+  },
 
   "MISSILE_RACK_543": {
     "description": "Name for a multiple-missile external missile rack. 'Medusa' is a model name.",
     "message": "Medusa LH-340 Missile Rack"
+  },
+  "MISSILE_RACK_543_DESCRIPTION": {
+    "description": "Equipment tooltip",
+    "message": "External missile rack with a capacity of 4 large missiles."
+  },
+  "MISSILE_RACK_543_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "First Hydri Defense brought you the awesome LH-320, now we've doubled its capacity! Go ahead, and make your mark on any system that dares to defy your might."
   },
 
   "MISSILE_RAIL_S1": {
     "description": "Name for a single-missile external launcher. 'Cnida' is a model name.",
     "message": "Cnida-101 Missile Rail"
   },
+  "MISSILE_RAIL_S1_DESCRIPTION": {
+    "description": "Equipment description",
+    "message": "External launcher for a single small missile."
+  },
+  "MISSILE_RAIL_S1_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "Hydri Defense's entry point rail, this is a quality piece of equipment for all S1 missiles adhering to ISAAEEE standards."
+  },
 
   "MISSILE_RAIL_S2": {
     "description": "Name for a single-missile external launcher. 'Cnida' is a model name.",
     "message": "Cnida-102 Missile Rail"
+  },
+  "MISSILE_RAIL_S2_DESCRIPTION": {
+    "description": "Equipment description",
+    "message": "External launcher for a single medium missile."
+  },
+  "MISSILE_RAIL_S2_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "A quality missile rail from Hydri Defense, this provides a secure mounting point for S2 class missiles."
   },
 
   "MISSILE_RAIL_S3": {
     "description": "Name for a single-missile external launcher. 'Cnida' is a model name.",
     "message": "Cnida-103 Missile Rail"
   },
+  "MISSILE_RAIL_S3_DESCRIPTION": {
+    "description": "Equipment description",
+    "message": "External launcher for a single large missile."
+  },
+  "MISSILE_RAIL_S3_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "A quality missile rail from Hydri Defense, this provides a secure mounting point for S3 class missiles."
+  },
 
   "MISSILE_RAIL_S4": {
     "description": "Name for a single-missile external launcher. 'Cnida' is a model name.",
     "message": "Cnida-104 Missile Rail"
   },
+  "MISSILE_RAIL_S4_DESCRIPTION": {
+    "description": "Equipment description",
+    "message": "External launcher for a single huge missile."
+  },
+  "MISSILE_RAIL_S4_FLAVOURTEXT": {
+    "description": "Equipment description; 'Hydri Defense' is a manufacturer name.",
+    "message": "A quality missile rail from Hydri Defense, this provides a secure mounting point for S4 class missiles."
+  },
+
   "MISSILE_SMART": {
     "description": "",
     "message": "Smart Missile"
   },
+  "MISSILE_SMART_DESCRIPTION": {
+    "description": "Equipment description",
+    "message": "A guided missile somewhat resistant to ECM."
+  },
+  "MISSILE_SMART_FLAVOURTEXT": {
+    "description": "Equipment description",
+    "message": "A smart rocket capable of tracking down your target using an advanced sensor suite with an integrated AI module. Make sure not to call it HAL and we're sure it will home in on your intended target, and not you.."
+  },
+
   "MISSILE_UNGUIDED": {
     "description": "",
     "message": "R40 Unguided Rocket"
   },
+  "MISSILE_UNGUIDED_DESCRIPTION": {
+    "description": "Equipment description",
+    "message": "Dumb aim-and-fire missile."
+  },
+  "MISSILE_UNGUIDED_FLAVOURTEXT": {
+    "description": "Equipment description",
+    "message": "Mass-produced by local manufacturers on most worlds. These range from being lovingly hand-crafted by artisans on developing worlds to being mindlessly churned out by the millions in automated mega-factories on hyper-industrialised ones.\nBut regardless from where they are sourced, the specifications are tightly controlled by the ISAEEE and should work in most compatible ship systems."
+  },
+
   "OCCUPIED_BERTHS": {
     "description": "Label for the number of passenger berths currently occupied in a cabin equipment item",
     "message": "Occupied Berths"
@@ -412,18 +535,32 @@
     "description": "Equipment name for an OKB-Kaluri Bowfin internal missile launcher",
     "message": "Bowfin Missile Launcher"
   },
+
   "OPLI_INTERNAL_MISSILE_RACK_S2": {
     "description": "Equipment name for an OPLI internal missile rack",
     "message": "OPLI Internal Missile Rack"
+  },
+  "OPLI_INTERNAL_MISSILE_RACK_S2_DESCRIPTION": {
+    "description": "Short description and tooltip.",
+    "message": "Internal missile bay for 5x medium missiles."
   },
   "OPLI_INTERNAL_MISSILE_RACK_S3": {
     "description": "Equipment name for an OPLI internal missile rack",
     "message": "OPLI Internal Missile Rack"
   },
+  "OPLI_INTERNAL_MISSILE_RACK_S3_DESCRIPTION": {
+    "description": "Short description and tooltip.",
+    "message": "Internal missile bay for 8x medium missiles."
+  },
   "OPLI_INTERNAL_MISSILE_RACK_S4": {
     "description": "Equipment name for an OPLI internal missile rack",
     "message": "OPLI Internal Missile Rack"
   },
+  "OPLI_INTERNAL_MISSILE_RACK_S4_DESCRIPTION": {
+    "description": "Short description and tooltip.",
+    "message": "Internal missile bay for 12x medium missiles."
+  },
+
   "ORBIT_SCANNER": {
     "description": "A ship equipment that records data of terrain, for cartography mapping/geological survey. Note: Scout Mission module reference and distinguishes between 'orbital' and 'surface' scanner types, the former scans planet from orbit, the latter from low altitude.",
     "message": "Orbital scanner XKM-650"

--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -831,7 +831,7 @@
   },
   "UNOCCUPIED_CABIN_DESCRIPTION": {
     "description": "",
-    "message": "Required for transport of a single passenger"
+    "message": "Required for transporting passengers"
   },
   "UTILITY": {
     "description": "Category name of utility equipment",

--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -603,31 +603,31 @@
     "description": "",
     "message": "Used to remotely inspect the equipment, cargo and state of other ships."
   },
-  "THRUSTERS_BASIC": {
-    "description": "",
-    "message": "Modified Thrusters"
-  },
-  "THRUSTERS_BASIC_DESCRIPTION": {
-    "description": "",
-    "message": "A modified type of thrusters approved for your ship."
-  },
-  "THRUSTERS_BEST": {
-    "description": "",
-    "message": "Bespoke Thrusters"
-  },
-  "THRUSTERS_BEST_DESCRIPTION": {
-    "description": "",
-    "message": "Custom made thrusters that provide the best possible output."
-  },
   "THRUSTERS_DEFAULT": {
     "description": "Equipment name for default RCS thrusters",
     "message": "Default Thrusters"
   },
-  "THRUSTERS_MEDIUM": {
+  "THRUSTERS_IMPROVED": {
+    "description": "",
+    "message": "Improved Thrusters"
+  },
+  "THRUSTERS_IMPROVED_DESCRIPTION": {
+    "description": "",
+    "message": "An improved type of thrusters approved for your ship."
+  },
+  "THRUSTERS_NAVAL": {
+    "description": "",
+    "message": "Naval Thrusters"
+  },
+  "THRUSTERS_NAVAL_DESCRIPTION": {
+    "description": "",
+    "message": "Naval thrusters specifically tailored for your ship to provide the best possible output."
+  },
+  "THRUSTERS_OPTIMISED": {
     "description": "",
     "message": "Optimised Thrusters"
   },
-  "THRUSTERS_MEDIUM_DESCRIPTION": {
+  "THRUSTERS_OPTIMISED_DESCRIPTION": {
     "description": "",
     "message": "Thrusters that have been optimised to reduce inefficiencies and improve power output."
   },

--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -187,6 +187,10 @@
     "description": "Name for the 'Fuel Scoop' equipment hardpoint",
     "message": "Fuel Scoop"
   },
+  "HARDPOINT_MINING_LASER": {
+    "description": "Name for a mining laser mount.",
+    "message": "Mining Hardpoint"
+  },
   "HARDPOINT_MISSILE": {
     "description": "Name for a generic missile mount",
     "message": "Missile"
@@ -199,9 +203,33 @@
     "description": "Name for the 'Missile Bay' equipment hardpoint",
     "message": "Missile Bay"
   },
+  "HARDPOINT_MISSILE_BAY_LEFT": {
+    "description": "Name for the 'Missile Bay' equipment hardpoint",
+    "message": "Left Missile Bay"
+  },
+  "HARDPOINT_MISSILE_BAY_RIGHT": {
+    "description": "Name for the 'Missile Bay' equipment hardpoint",
+    "message": "Right Missile Bay"
+  },
   "HARDPOINT_PYLON": {
     "description": "Name for a generic missile pylon",
     "message": "Pylon"
+  },
+  "HARDPOINT_PYLON_LEFT": {
+    "description": "Name for a generic missile pylon",
+    "message": "Left Pylon"
+  },
+  "HARDPOINT_PYLON_LEFT_WING": {
+    "description": "Name for a generic missile pylon",
+    "message": "Left Wing Pylon"
+  },
+  "HARDPOINT_PYLON_RIGHT": {
+    "description": "Name for a generic missile pylon",
+    "message": "Right Pylon"
+  },
+  "HARDPOINT_PYLON_RIGHT_WING": {
+    "description": "Name for a generic missile pylon",
+    "message": "Right Wing Pylon"
   },
   "HARDPOINT_UTILITY": {
     "description": "Name for a generic utility hardpoint",
@@ -211,6 +239,14 @@
     "description": "Name for a generic weapon hardpoint",
     "message": "Weapon"
   },
+  "HARDPOINT_WEAPON_LEFT": {
+    "description": "Name for a generic weapon hardpoint",
+    "message": "Left Weapon"
+  },
+  "HARDPOINT_WEAPON_RIGHT": {
+    "description": "Name for a generic weapon hardpoint",
+    "message": "Right Weapon"
+  },
   "HARDPOINT_WEAPON_CHIN": {
     "description": "Name for the 'Chin Mount' equipment hardpoint",
     "message": "Chin Mount"
@@ -218,6 +254,14 @@
   "HARDPOINT_WEAPON_FRONT": {
     "description": "Name for a generic front-facing weapon hardpoint",
     "message": "Front Weapon"
+  },
+  "HARDPOINT_WEAPON_FRONT_LEFT": {
+    "description": "Name for a generic front-facing weapon hardpoint",
+    "message": "Front Left Weapon"
+  },
+  "HARDPOINT_WEAPON_FRONT_RIGHT": {
+    "description": "Name for a generic front-facing weapon hardpoint",
+    "message": "Front Right Weapon"
   },
   "HARDPOINT_WEAPON_LEFT_NOSE": {
     "description": "Name for the 'Left Nose' weapon hardpoint",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -67,6 +67,10 @@
     "description": "Market header when buying items",
     "message": "Available For Purchase"
   },
+  "AVAILABLE_STOCK": {
+    "description": "Market stat showing number of items in stock",
+    "message": "Available Stock"
+  },
   "AVERAGE": {
     "description": "",
     "message": "Average"
@@ -2409,7 +2413,7 @@
   },
   "TECH_LEVEL": {
     "description": "System view label for technology level",
-    "message": "Tech level"
+    "message": "Tech Level"
   },
   "TEXTURE_COMPRESSION": {
     "description": "",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1831,6 +1831,10 @@
     "description": "Ship jump status",
     "message": "Out of range"
   },
+  "OUT_OF_STOCK": {
+    "description": "Equipment availability",
+    "message": "Out of stock"
+  },
   "OVERVIEW_NAME_FILTER": {
     "description": "Filter overview window entries by name",
     "message": "Filter overview window entries by name"

--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -102,6 +102,7 @@ function EquipType._createTransient(obj)
 	local l = Lang.GetResource(obj.l10n_resource)
 	obj.transient = {
 		description = l:get(obj.l10n_key .. "_DESCRIPTION") or "",
+		flavourtext = l:get(obj.l10n_key .. "_FLAVOURTEXT") or "",
 		name = l[obj.l10n_key] or ""
 	}
 end
@@ -265,6 +266,15 @@ end
 ---@return string
 function EquipType:GetDescription()
 	return self.transient.description
+end
+
+-- Method: GetFlavourText
+--
+-- Returns the translated tooltip for this equipment item suitable for
+-- display to the user
+---@return string
+function EquipType:GetFlavourText()
+	return self.transient.flavourtext
 end
 
 --==============================================================================

--- a/data/modules/Equipment/Internal.lua
+++ b/data/modules/Equipment/Internal.lua
@@ -318,6 +318,22 @@ Equipment.Register("misc.fuel_scoop_s3", EquipType.New {
 	icon_name="equip_fuel_scoop"
 })
 
+Equipment.Register("misc.fuel_scoop_s4", EquipType.New {
+	l10n_key="FUEL_SCOOP",
+	price=14500, purchasable=true, tech_level=9,
+	slot = { type="fuel_scoop", size=4, hardpoint=true },
+	mass=22, volume=16, capabilities={ fuel_scoop=7 },
+	icon_name="equip_fuel_scoop"
+})
+
+Equipment.Register("misc.fuel_scoop_s5", EquipType.New {
+	l10n_key="FUEL_SCOOP",
+	price=21500, purchasable=true, tech_level=12,
+	slot = { type="fuel_scoop", size=5, hardpoint=true },
+	mass=30, volume=22, capabilities={ fuel_scoop=9 },
+	icon_name="equip_fuel_scoop"
+})
+
 Equipment.Register("misc.cargo_scoop", EquipType.New {
 	l10n_key="CARGO_SCOOP",
 	price=3900, purchasable=true, tech_level=5,

--- a/data/modules/Equipment/Internal.lua
+++ b/data/modules/Equipment/Internal.lua
@@ -125,7 +125,8 @@ Equipment.Register("misc.hull_autorepair", EquipType.New {
 -- Thruster Mods
 --===============================================
 
-Equipment.Register("misc.thrusters_default", ThrusterType.New {
+-- S1 thrusters
+Equipment.Register("misc.thrusters_default_s1", ThrusterType.New {
 	l10n_key="THRUSTERS_DEFAULT", slots="thruster",
 	price=120, purchasable=true, tech_level=2,
 	slot = { type="thruster", size=1 },
@@ -133,27 +134,159 @@ Equipment.Register("misc.thrusters_default", ThrusterType.New {
 	icon_name="equip_thrusters_basic"
 })
 
-Equipment.Register("misc.thrusters_basic", ThrusterType.New {
-	l10n_key="THRUSTERS_BASIC", slots="thruster",
+Equipment.Register("misc.thrusters_improved_s1", ThrusterType.New {
+	l10n_key="THRUSTERS_IMPROVED", slots="thruster",
 	price=250, purchasable=true, tech_level=5,
 	slot = { type="thruster", size=1 },
 	mass=0.1, volume=0.05, capabilities={ thruster_power=1 },
 	icon_name="equip_thrusters_basic"
 })
 
-Equipment.Register("misc.thrusters_medium", ThrusterType.New {
-	l10n_key="THRUSTERS_MEDIUM", slots="thruster",
+Equipment.Register("misc.thrusters_optimised_s1", ThrusterType.New {
+	l10n_key="THRUSTERS_OPTIMISED", slots="thruster",
 	price=560, purchasable=true, tech_level=8,
 	slot = { type="thruster", size=1 },
-	mass=0.05, volume=0.05, capabilities={ thruster_power=2 },
+	mass=0.05, volume=0.03, capabilities={ thruster_power=2 },
 	icon_name="equip_thrusters_medium"
 })
 
-Equipment.Register("misc.thrusters_best", ThrusterType.New {
-	l10n_key="THRUSTERS_BEST", slots="thruster",
-	price=14000, purchasable=true, tech_level="MILITARY",
+Equipment.Register("misc.thrusters_naval_s1", ThrusterType.New {
+	l10n_key="THRUSTERS_NAVAL", slots="thruster",
+	price=1400, purchasable=true, tech_level="MILITARY",
 	slot = { type="thruster", size=1 },
-	mass=0, volume=0, capabilities={ thruster_power=3 },
+	mass=0.1, volume=0.1, capabilities={ thruster_power=3 },
+	icon_name="equip_thrusters_best"
+})
+
+-- S2 thrusters
+Equipment.Register("misc.thrusters_default_s2", ThrusterType.New {
+	l10n_key="THRUSTERS_DEFAULT", slots="thruster",
+	price=220, purchasable=true, tech_level=2,
+	slot = { type="thruster", size=2 },
+	mass=0, volume=0, capabilities={ thruster_power=0 },
+	icon_name="equip_thrusters_basic"
+})
+
+Equipment.Register("misc.thrusters_improved_s2", ThrusterType.New {
+	l10n_key="THRUSTERS_IMPROVED", slots="thruster",
+	price=460, purchasable=true, tech_level=5,
+	slot = { type="thruster", size=2 },
+	mass=0.24, volume=0.12, capabilities={ thruster_power=1 },
+	icon_name="equip_thrusters_basic"
+})
+
+Equipment.Register("misc.thrusters_optimised_s2", ThrusterType.New {
+	l10n_key="THRUSTERS_OPTIMISED", slots="thruster",
+	price=1025, purchasable=true, tech_level=8,
+	slot = { type="thruster", size=2 },
+	mass=0.12, volume=0.1, capabilities={ thruster_power=2 },
+	icon_name="equip_thrusters_medium"
+})
+
+Equipment.Register("misc.thrusters_naval_s2", ThrusterType.New {
+	l10n_key="THRUSTERS_NAVAL", slots="thruster",
+	price=2565, purchasable=true, tech_level="MILITARY",
+	slot = { type="thruster", size=2 },
+	mass=0.24, volume=0.24, capabilities={ thruster_power=3 },
+	icon_name="equip_thrusters_best"
+})
+
+-- S3 thrusters
+Equipment.Register("misc.thrusters_default_s3", ThrusterType.New {
+	l10n_key="THRUSTERS_DEFAULT", slots="thruster",
+	price=420, purchasable=true, tech_level=2,
+	slot = { type="thruster", size=3 },
+	mass=0, volume=0, capabilities={ thruster_power=0 },
+	icon_name="equip_thrusters_basic"
+})
+
+Equipment.Register("misc.thrusters_improved_s3", ThrusterType.New {
+	l10n_key="THRUSTERS_IMPROVED", slots="thruster",
+	price=880, purchasable=true, tech_level=5,
+	slot = { type="thruster", size=3 },
+	mass=0.46, volume=0.23, capabilities={ thruster_power=1 },
+	icon_name="equip_thrusters_basic"
+})
+
+Equipment.Register("misc.thrusters_optimised_s3", ThrusterType.New {
+	l10n_key="THRUSTERS_OPTIMISED", slots="thruster",
+	price=1950, purchasable=true, tech_level=8,
+	slot = { type="thruster", size=3 },
+	mass=0.23, volume=0.2, capabilities={ thruster_power=2 },
+	icon_name="equip_thrusters_medium"
+})
+
+Equipment.Register("misc.thrusters_naval_s3", ThrusterType.New {
+	l10n_key="THRUSTERS_NAVAL", slots="thruster",
+	price=4970, purchasable=true, tech_level="MILITARY",
+	slot = { type="thruster", size=3 },
+	mass=0.46, volume=0.46, capabilities={ thruster_power=3 },
+	icon_name="equip_thrusters_best"
+})
+
+-- S4 Thrusters
+Equipment.Register("misc.thrusters_default_s4", ThrusterType.New {
+	l10n_key="THRUSTERS_DEFAULT", slots="thruster",
+	price=880, purchasable=true, tech_level=2,
+	slot = { type="thruster", size=4 },
+	mass=0, volume=0, capabilities={ thruster_power=0 },
+	icon_name="equip_thrusters_basic"
+})
+
+Equipment.Register("misc.thrusters_improved_s4", ThrusterType.New {
+	l10n_key="THRUSTERS_IMPROVED", slots="thruster",
+	price=1850, purchasable=true, tech_level=5,
+	slot = { type="thruster", size=4 },
+	mass=0.96, volume=0.48, capabilities={ thruster_power=1 },
+	icon_name="equip_thrusters_basic"
+})
+
+Equipment.Register("misc.thrusters_optimised_s4", ThrusterType.New {
+	l10n_key="THRUSTERS_OPTIMISED", slots="thruster",
+	price=4096, purchasable=true, tech_level=8,
+	slot = { type="thruster", size=4 },
+	mass=0.48, volume=0.42, capabilities={ thruster_power=2 },
+	icon_name="equip_thrusters_medium"
+})
+
+Equipment.Register("misc.thrusters_naval_s4", ThrusterType.New {
+	l10n_key="THRUSTERS_NAVAL", slots="thruster",
+	price=10240, purchasable=true, tech_level="MILITARY",
+	slot = { type="thruster", size=4 },
+	mass=0.96, volume=0.96, capabilities={ thruster_power=3 },
+	icon_name="equip_thrusters_best"
+})
+
+-- S5 thrusters
+Equipment.Register("misc.thrusters_default_s5", ThrusterType.New {
+	l10n_key="THRUSTERS_DEFAULT", slots="thruster",
+	price=1950, purchasable=true, tech_level=2,
+	slot = { type="thruster", size=5 },
+	mass=0, volume=0, capabilities={ thruster_power=0 },
+	icon_name="equip_thrusters_basic"
+})
+
+Equipment.Register("misc.thrusters_improved_s5", ThrusterType.New {
+	l10n_key="THRUSTERS_IMPROVED", slots="thruster",
+	price=4090, purchasable=true, tech_level=5,
+	slot = { type="thruster", size=5 },
+	mass=2.1, volume=1.05, capabilities={ thruster_power=1 },
+	icon_name="equip_thrusters_basic"
+})
+
+Equipment.Register("misc.thrusters_optimised_s5", ThrusterType.New {
+	l10n_key="THRUSTERS_OPTIMISED", slots="thruster",
+	price=9050, purchasable=true, tech_level=8,
+	slot = { type="thruster", size=5 },
+	mass=1.05, volume=0.9, capabilities={ thruster_power=2 },
+	icon_name="equip_thrusters_medium"
+})
+
+Equipment.Register("misc.thrusters_naval_s5", ThrusterType.New {
+	l10n_key="THRUSTERS_NAVAL", slots="thruster",
+	price=22620, purchasable=true, tech_level="MILITARY",
+	slot = { type="thruster", size=5 },
+	mass=2.1, volume=2.1, capabilities={ thruster_power=3 },
 	icon_name="equip_thrusters_best"
 })
 

--- a/data/modules/Equipment/Weapons.lua
+++ b/data/modules/Equipment/Weapons.lua
@@ -248,6 +248,74 @@ Equipment.Register("missile.naval_s4", EquipType.New {
 -- Missile Pylons
 --===============================================
 
+-- "LH-420 Hydri Missile Rack"
+Equipment.Register("missile_rack.524", EquipType.New {
+	l10n_key="MISSILE_RACK_524",
+	price=2250, purchasable=true, tech_level="MILITARY",
+	volume=0.0, mass=0.8,
+	slot = { type = "pylon.rack", size=5, hardpoint=true },
+	provides_slots = {
+		Slot:clone { id = "1", type = "missile", size = 4, hardpoint = true },
+		Slot:clone { id = "2", type = "missile", size = 4, hardpoint = true },
+	},
+	icon_name="equip_missile_unguided"
+})
+
+-- "LH-340 Hydri Missile Rack"
+Equipment.Register("missile_rack.543", EquipType.New {
+	l10n_key="MISSILE_RACK_543",
+	price=1800, purchasable=true, tech_level=9,
+	volume=0.0, mass=1.2,
+	slot = { type = "pylon.rack", size=5, hardpoint=true },
+	provides_slots = {
+		Slot:clone { id = "1", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "2", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "3", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "4", type = "missile", size = 3, hardpoint = true },
+	},
+	icon_name="equip_missile_unguided"
+})
+
+-- "Cnida-104 Missile Rail"
+Equipment.Register("missile_rack.414", EquipType.New {
+	l10n_key="MISSILE_RAIL_S4",
+	price=1125, purchasable=true, tech_level="MILITARY",
+	volume=0.0, mass=0.5,
+	slot = { type = "pylon.rack", size=4, hardpoint=true },
+	provides_slots = {
+		Slot:clone { id = "1", type = "missile", size = 4, hardpoint = true },
+	},
+	icon_name="equip_missile_unguided"
+})
+
+-- "LH-320 Hydri Missile Rack"
+Equipment.Register("missile_rack.423", EquipType.New {
+	l10n_key="MISSILE_RACK_423",
+	price=900, purchasable=true, tech_level=9,
+	volume=0.0, mass=0.6,
+	slot = { type = "pylon.rack", size=4, hardpoint=true },
+	provides_slots = {
+		Slot:clone { id = "1", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "2", type = "missile", size = 3, hardpoint = true },
+	},
+	icon_name="equip_missile_unguided"
+})
+
+-- "LH-240 Hydri Missile Rack"
+Equipment.Register("missile_rack.442", EquipType.New {
+	l10n_key="MISSILE_RACK_442",
+	price=1500, purchasable=true, tech_level=5,
+	volume=0.0, mass=0.8,
+	slot = { type = "pylon.rack", size=4, hardpoint=true },
+	provides_slots = {
+		Slot:clone { id = "1", type = "missile", size = 2, hardpoint = true },
+		Slot:clone { id = "2", type = "missile", size = 2, hardpoint = true },
+		Slot:clone { id = "3", type = "missile", size = 2, hardpoint = true },
+		Slot:clone { id = "4", type = "missile", size = 2, hardpoint = true },
+	},
+	icon_name="equip_missile_unguided"
+})
+
 -- "Cnida-103 Missile Rail"
 Equipment.Register("missile_rack.313", EquipType.New {
 	l10n_key="MISSILE_RAIL_S3",
@@ -329,6 +397,7 @@ Equipment.Register("missile_rack.111", EquipType.New {
 -- Internal Missile Bays
 --===============================================
 
+-- For the Coronatrix, Malabar, Sinonatrix (and Police), and Vatakara
 Equipment.Register("missile_bay.opli_internal_s2", EquipType.New {
 	l10n_key="OPLI_INTERNAL_MISSILE_RACK_S2",
 	price=150, purchasable=true, tech_level=1,
@@ -340,6 +409,40 @@ Equipment.Register("missile_bay.opli_internal_s2", EquipType.New {
 		Slot:clone { id = "3", type = "missile", size = 2, hardpoint = true },
 		Slot:clone { id = "4", type = "missile", size = 2, hardpoint = true },
 		Slot:clone { id = "5", type = "missile", size = 2, hardpoint = true },
+	},
+	icon_name="equip_missile_unguided"
+})
+
+-- For the Natrix, and Nerodia
+Equipment.Register("missile_bay.opli_internal_s3", EquipType.New {
+	l10n_key="OPLI_INTERNAL_MISSILE_RACK_S3",
+	price=450, purchasable=true, tech_level=5,
+	volume=8.5, mass=0.9,
+	slot = { type = "missile_bay.opli_internal", size=3, hardpoint=true },
+	provides_slots = {
+		Slot:clone { id = "1", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "2", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "3", type = "missile", size = 3, hardpoint = true },
+	},
+	icon_name="equip_missile_unguided"
+})
+
+-- For the Molar Ramsayi
+-- NOTE: This is a mixed-size bay containing both S3 and S2 missiles.
+Equipment.Register("missile_bay.opli_internal_s4", EquipType.New {
+	l10n_key="OPLI_INTERNAL_MISSILE_RACK_S4",
+	price=950, purchasable=true, tech_level=7,
+	volume=11.0, mass=1.1,
+	slot = { type = "missile_bay.opli_internal", size=4, hardpoint=true },
+	provides_slots = {
+		Slot:clone { id = "1", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "2", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "3", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "4", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "5", type = "missile", size = 3, hardpoint = true },
+		Slot:clone { id = "6", type = "missile", size = 2, hardpoint = true },
+		Slot:clone { id = "7", type = "missile", size = 2, hardpoint = true },
+		Slot:clone { id = "8", type = "missile", size = 2, hardpoint = true },
 	},
 	icon_name="equip_missile_unguided"
 })

--- a/data/modules/Equipment/Weapons.lua
+++ b/data/modules/Equipment/Weapons.lua
@@ -248,9 +248,10 @@ Equipment.Register("missile.naval_s4", EquipType.New {
 -- Missile Pylons
 --===============================================
 
+-- "Cnida-103 Missile Rail"
 Equipment.Register("missile_rack.313", EquipType.New {
 	l10n_key="MISSILE_RAIL_S3",
-	price=150, purchasable=true, tech_level=1,
+	price=450, purchasable=true, tech_level=9,
 	volume=0.0, mass=0.2,
 	slot = { type = "pylon.rack", size=3, hardpoint=true },
 	provides_slots = {
@@ -259,9 +260,10 @@ Equipment.Register("missile_rack.313", EquipType.New {
 	icon_name="equip_missile_unguided"
 })
 
+-- "LH-220 Hydri Missile Rack"
 Equipment.Register("missile_rack.322", EquipType.New {
 	l10n_key="MISSILE_RACK_322",
-	price=150, purchasable=true, tech_level=1,
+	price=750, purchasable=true, tech_level=5,
 	volume=0.0, mass=0.4,
 	slot = { type = "pylon.rack", size=3, hardpoint=true },
 	provides_slots = {
@@ -271,9 +273,10 @@ Equipment.Register("missile_rack.322", EquipType.New {
 	icon_name="equip_missile_unguided"
 })
 
+-- "LH-140 Hydri Missile Rack"
 Equipment.Register("missile_rack.341", EquipType.New {
 	l10n_key="MISSILE_RACK_341",
-	price=150, purchasable=true, tech_level=1,
+	price=600, purchasable=true, tech_level=1,
 	volume=0.0, mass=0.5,
 	slot = { type = "pylon.rack", size=3, hardpoint=true },
 	provides_slots = {
@@ -285,9 +288,10 @@ Equipment.Register("missile_rack.341", EquipType.New {
 	icon_name="equip_missile_unguided"
 })
 
+-- "Cnida-102 Missile Rail"
 Equipment.Register("missile_rack.212", EquipType.New {
 	l10n_key="MISSILE_RAIL_S2",
-	price=150, purchasable=true, tech_level=1,
+	price=375, purchasable=true, tech_level=5,
 	volume=0.0, mass=0.1,
 	slot = { type = "pylon.rack", size=2, hardpoint=true },
 	provides_slots = {
@@ -296,9 +300,10 @@ Equipment.Register("missile_rack.212", EquipType.New {
 	icon_name="equip_missile_unguided"
 })
 
+-- "LH-120 Hydri Missile Rack"
 Equipment.Register("missile_rack.221", EquipType.New {
 	l10n_key="MISSILE_RACK_221",
-	price=150, purchasable=true, tech_level=1,
+	price=300, purchasable=true, tech_level=1,
 	volume=0.0, mass=0.2,
 	slot = { type = "pylon.rack", size=2, hardpoint=true },
 	provides_slots = {
@@ -308,6 +313,7 @@ Equipment.Register("missile_rack.221", EquipType.New {
 	icon_name="equip_missile_unguided"
 })
 
+-- "Cnida-101 Missile Rail"
 Equipment.Register("missile_rack.111", EquipType.New {
 	l10n_key="MISSILE_RAIL_S1",
 	price=150, purchasable=true, tech_level=1,

--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -32,7 +32,7 @@ local equipment2 = {
 	sensor         = "sensor.radar",
 	hull_mod       = "hull.atmospheric_shielding",
 	hyperdrive     = "hyperspace.hyperdrive_2",
-	thruster       = "misc.thrusters_default",
+	thruster       = "misc.thrusters_default_s1",
 	missile_bay_1  = "missile_bay.opli_internal_s2",
 	missile_bay_2  = "missile_bay.opli_internal_s2",
 }

--- a/data/ships/molaramsayi.json
+++ b/data/ships/molaramsayi.json
@@ -36,7 +36,8 @@
 		"fuel_scoop": {
 			"type": "fuel_scoop",
 			"size": 3,
-			"size_min": 1
+			"size_min": 1,
+			"hardpoint": true
 		},
 		"computer_1": {
 			"type": "computer",

--- a/data/ships/sinonatrix.json
+++ b/data/ships/sinonatrix.json
@@ -103,7 +103,8 @@
 		},
 		"fuel_scoop_s1": {
 			"type": "fuel_scoop",
-			"size": 1
+			"size": 1,
+			"hardpoint": true
 		},
 		"cabin_s1_1": {
 			"type": "cabin",

--- a/data/ships/sinonatrix_police.json
+++ b/data/ships/sinonatrix_police.json
@@ -104,7 +104,7 @@
 		"fuel_scoop_s1": {
 			"type": "fuel_scoop",
 			"size": 1,
-			"size_min": 1
+			"hardpoint": true
 		},
 		"utility_s2_3": {
 			"type": "utility",


### PR DESCRIPTION
WIP PR to add (placeholder) equipment and descriptions for all slot sizes.

Fixes #5950 , #5951

(Feel free to reserve a set of equipment, work on it, and push to this PR)

----

## Feature creep

- translations: add a bunch of missing weapon hardpoint translation entries
- ships: fix fuel-scoop slot for the Sinonatrix (and Police variant) and the Mola Ramsayii; they were missing the "hardpoint":true flag on the slot, preventing it from accessing the correct translation string.

- equipment outfitter:
  - added an optional "flavourtext" which can be supplied for equipment. This should be a longer description of the equipment. Possibly useful, but mostly for adding some background and lore into the game itself.
  - fixed showing equipment stock levels
  - added showing equipment stock levels in the equipment tab
  - added showing out-of-stock equipment items to avoid player confusion
  - added showing tech-level of equipment to aid players track down out-of-stock equipment
----

## Thrusters

Design : https://www.notion.so/bszlrd/RCS-thrusters-1018c82e283f80a98bf5da0576472191

Adds a set of placeholder thrusters for slot sizes 1 through 5: default, improved, optimised, naval. (renamed from default, basic, medium, best) with proposed weight, volume, and price.

Each thruster improvement increases the linear and rotational thrust multipliers. Apart from weight and volume, no other statistics are currently taken into account.

TODO:
* Current game code assumes a ship always has at least "default" thrusters installed, even if the player has sold them. Either ensure the player can't leave ship-outfitting without buying at least default thrusters, or prevent the ship from taking off/flying without thrusters.
* Create more diversified thruster types - separate settings for delta-V, thrust, fuel/power-efficiency, etc.

----

## Fuel scoops

DONE: added S4 and S5 fuel scoops.

----

## Missile Racks

~~**TODO** : (Micha) Move from PR #5992 ; or merge that PR~~

Design: https://www.notion.so/bszlrd/Databases-1018c82e283f80d29d30e09a1f72f095

DONE: Merged the commits from #5992 here; that commit should be discarded now, unless people think it's better to keep these separate.

----

## OPLI internal missile racks

Added S3 and S4 sizes to support the Natrix, Nerodia, and Molar Ramsayi.

----

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

