### PR TITLE
Display how many instanced objects are drawn

### DIFF
--- a/src/graphics/Stats.cpp
+++ b/src/graphics/Stats.cpp
@@ -16,6 +16,8 @@ namespace Graphics {
 
 		m_counterRefs = {
 			GetOrCreateCounter("DrawMesh Calls"),
+			GetOrCreateCounter("DrawMesh Instance Calls"),
+			GetOrCreateCounter("DrawMesh Instanced Calls"),
 			GetOrCreateCounter("Num Points Drawn"),
 			GetOrCreateCounter("Num Lines Drawn"),
 			GetOrCreateCounter("Num Tris Drawn"),

--- a/src/graphics/Stats.h
+++ b/src/graphics/Stats.h
@@ -22,6 +22,8 @@ namespace Graphics {
 		enum StatType {
 			// renderer entries
 			STAT_DRAWCALL = 0,
+			STAT_DRAWCALLINSTANCES,
+			STAT_DRAWCALLSINSTANCED,
 			STAT_NUM_POINTS,
 			STAT_NUM_LINES,
 			STAT_NUM_TRIS,

--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -976,7 +976,8 @@ namespace Graphics {
 
 		inst->Release();
 		CheckRenderErrors(__FUNCTION__, __LINE__);
-		m_stats.AddToStatCount(Stats::STAT_DRAWCALL, 1);
+		m_stats.AddToStatCount(Stats::STAT_DRAWCALLINSTANCES, 1);
+		m_stats.AddToStatCount(Stats::STAT_DRAWCALLSINSTANCED, inst->GetInstanceCount());
 		stat_primitives(m_stats, type, numElems);
 		return true;
 	}

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -399,6 +399,8 @@ void PerfInfo::DrawRendererStats()
 {
 	const Graphics::Stats::TFrameData &stats = Pi::renderer->GetStats().FrameStatsPrevious();
 	const Uint32 numDrawCalls = stats.m_stats[Graphics::Stats::STAT_DRAWCALL];
+	const Uint32 numDrawCallInstances = stats.m_stats[Graphics::Stats::STAT_DRAWCALLINSTANCES];
+	const Uint32 numDrawCallsInstanced = stats.m_stats[Graphics::Stats::STAT_DRAWCALLSINSTANCED];
 	const Uint32 numTris = stats.m_stats[Graphics::Stats::STAT_NUM_TRIS];
 	const Uint32 numLines = stats.m_stats[Graphics::Stats::STAT_NUM_LINES];
 	const Uint32 numPoints = stats.m_stats[Graphics::Stats::STAT_NUM_POINTS];
@@ -433,8 +435,8 @@ void PerfInfo::DrawRendererStats()
 	const Uint32 cachedTextureMemUsage = tex2dMemUsage + texCubeMemUsage + texArray2dMemUsage;
 
 	ImGui::SeparatorText("Renderer");
-	ImGui::Text("%u Draw calls, %u CommandList flushes",
-		numDrawCalls, numCmdListFlushes);
+	ImGui::Text("%u Draw calls, %u | %u Instanced calls, %u CommandList flushes",
+		numDrawCalls, numDrawCallInstances, numDrawCallsInstanced, numCmdListFlushes);
 
 	ImGui::Indent();
 	ImGui::Text("%u points", numPoints);

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -435,8 +435,8 @@ void PerfInfo::DrawRendererStats()
 	const Uint32 cachedTextureMemUsage = tex2dMemUsage + texCubeMemUsage + texArray2dMemUsage;
 
 	ImGui::SeparatorText("Renderer");
-	ImGui::Text("%u Draw calls, %u | %u Instanced calls, %u CommandList flushes",
-		numDrawCalls, numDrawCallInstances, numDrawCallsInstanced, numCmdListFlushes);
+	ImGui::Text("%u Draw calls, %u Instances (%u Draw calls), %u CommandList flushes",
+		numDrawCalls, numDrawCallsInstanced, numDrawCallInstances, numCmdListFlushes);
 
 	ImGui::Indent();
 	ImGui::Text("%u points", numPoints);


### PR DESCRIPTION
Extend the information shown about Instanced Draw Calls to include the total number of instances actually drawn by them.
![image](https://github.com/user-attachments/assets/ada130ab-4942-4917-be56-4f0bb4a22c12)

I'm not sure about the formatting of the display `80 | 813 Instanced Calls` so would welcome feedback.
Maybe it should be `80 (813 total) Instanced` or something? There's not a lot of space available.