### PR TITLE
Conform to C.128, aka: Virtual functions should specify exactly one of virtual, override, or final

### DIFF
--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -382,7 +382,7 @@ namespace Background {
 
 		// Do the brightness sort on worker threads using the worker's subset
 		// of stars rather than on the main thread with all stars.
-		virtual void OnExecute(TaskRange) override
+		void OnExecute(TaskRange) override
 		{
 			PROFILE_SCOPED()
 			const size_t numStars = stars.pos.size();

--- a/src/Beam.h
+++ b/src/Beam.h
@@ -32,17 +32,17 @@ public:
 	Beam(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dir);
 	Beam(const Json &jsonObj, Space *space);
 	virtual ~Beam();
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override final;
-	void TimeStepUpdate(const float timeStep) override final;
-	void StaticUpdate(const float timeStep) override final;
-	virtual void NotifyRemoved(const Body *const removedBody) override final;
-	virtual void PostLoadFixup(Space *space) override final;
-	virtual void UpdateInterpTransform(double alpha) override final;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) final;
+	void TimeStepUpdate(const float timeStep) final;
+	void StaticUpdate(const float timeStep) final;
+	void NotifyRemoved(const Body *const removedBody) final;
+	void PostLoadFixup(Space *space) final;
+	void UpdateInterpTransform(double alpha) final;
 
 	static void FreeModel();
 
 protected:
-	virtual void SaveToJson(Json &jsonObj, Space *space) override final;
+	virtual void SaveToJson(Json &jsonObj, Space *space) final;
 
 private:
 	float GetDamage() const;

--- a/src/Body.h
+++ b/src/Body.h
@@ -53,8 +53,8 @@ enum class AltitudeType { // <enum name=AltitudeType scope='AltitudeType' public
 #define OBJDEF(__thisClass, __parentClass, __TYPE)                                  \
 	static constexpr ObjectType StaticType() { return ObjectType::__TYPE; }         \
 	static constexpr ObjectType SuperType() { return __parentClass::StaticType(); } \
-	virtual ObjectType GetType() const override { return ObjectType::__TYPE; }      \
-	virtual bool IsType(ObjectType c) const override                                \
+	ObjectType GetType() const override { return ObjectType::__TYPE; }              \
+	bool IsType(ObjectType c) const override                                        \
 	{                                                                               \
 		if (__thisClass::GetType() == (c))                                          \
 			return true;                                                            \

--- a/src/BodyComponent.h
+++ b/src/BodyComponent.h
@@ -101,7 +101,7 @@ public:
 		using PoolBase::PoolBase;
 
 		// Delete the component and delegate removing it from lua if necessary
-		virtual void deleteComponent(Body *body) override
+		void deleteComponent(Body *body) override
 		{
 			if (luaInterface)
 				luaInterface->DeregisterComponent(body);
@@ -136,12 +136,12 @@ public:
 		{}
 		Pool<T> *pool;
 
-		virtual void toJson(const Body *body, Json &obj, Space *space) override
+		void toJson(const Body *body, Json &obj, Space *space) override
 		{
 			pool->get(body)->SaveToJson(obj, space);
 		}
 
-		virtual void fromJson(Body *body, const Json &obj, Space *space) override
+		void fromJson(Body *body, const Json &obj, Space *space) override
 		{
 			auto *component = pool->newComponent(body);
 			component->LoadFromJson(obj, space);

--- a/src/CargoBody.h
+++ b/src/CargoBody.h
@@ -19,11 +19,11 @@ public:
 	CargoBody(const char *modelName, const LuaRef &cargo, float selfdestructTimer = 86400.0f); // default to 24 h lifetime
 	CargoBody(const Json &jsonObj, Space *space);
 	LuaRef GetCargoType() const { return m_cargo; }
-	virtual void SetLabel(const std::string &label) override;
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
-	virtual void TimeStepUpdate(const float timeStep) override;
-	virtual bool OnCollision(Body *o, Uint32 flags, double relVel) override;
-	virtual bool OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData) override;
+	void SetLabel(const std::string &label) override;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	void TimeStepUpdate(const float timeStep) override;
+	bool OnCollision(Body *o, Uint32 flags, double relVel) override;
+	bool OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData) override;
 
 	~CargoBody(){};
 

--- a/src/DynamicBody.h
+++ b/src/DynamicBody.h
@@ -21,19 +21,19 @@ public:
 	DynamicBody(const Json &jsonObj, Space *space);
 	virtual ~DynamicBody();
 
-	virtual vector3d GetVelocity() const override;
-	virtual void SetVelocity(const vector3d &v) override;
-	virtual void SetFrame(FrameId fId) override;
+	vector3d GetVelocity() const override;
+	void SetVelocity(const vector3d &v) override;
+	void SetFrame(FrameId fId) override;
 	vector3d GetAngVelocity() const override;
 	void SetAngVelocity(const vector3d &v) override;
-	virtual bool OnCollision(Body *o, Uint32 flags, double relVel) override;
+	bool OnCollision(Body *o, Uint32 flags, double relVel) override;
 	vector3d GetAngularMomentum() const;
 	double GetAngularInertia() const { return m_angInertia; }
 	void SetMassDistributionFromModel();
 	void SetMoving(bool isMoving);
 	bool IsMoving() const { return m_isMoving; }
-	virtual double GetMass() const override { return m_mass; } // XXX don't override this
-	virtual void TimeStepUpdate(const float timeStep) override;
+	double GetMass() const final { return m_mass; } // XXX don't override this
+	void TimeStepUpdate(const float timeStep) override;
 	double CalcAtmosphericDrag(double velSqr, double area, double coeff) const;
 	void CalcExternalForce();
 
@@ -50,9 +50,9 @@ public:
 	vector3d GetExternalForce() const { return m_externalForce; }
 	vector3d GetAtmosForce() const { return m_atmosForce; }
 	vector3d GetGravityForce() const { return m_gravityForce; }
-	virtual void UpdateInterpTransform(double alpha) override;
+	void UpdateInterpTransform(double alpha) override;
 
-	virtual void PostLoadFixup(Space *space) override;
+	void PostLoadFixup(Space *space) override;
 
 	Orbit ComputeOrbit() const;
 
@@ -78,7 +78,7 @@ public:
 	void SetDecelerating(bool decel) { m_decelerating = decel; }
 
 protected:
-	virtual void SaveToJson(Json &jsonObj, Space *space) override;
+	void SaveToJson(Json &jsonObj, Space *space) override;
 
 	void GetCurrentAtmosphericState(double &pressure, double &density) const;
 

--- a/src/FaceParts.cpp
+++ b/src/FaceParts.cpp
@@ -55,8 +55,8 @@ namespace {
 			prefix(prefix)
 		{}
 
-		virtual void OnRun() override;
-		virtual void OnFinish() override
+		void OnRun() override;
+		void OnFinish() override
 		{
 			for (auto &part : cache)
 				output.push_back(std::move(part));
@@ -73,7 +73,7 @@ namespace {
 
 	struct ScanGenderedPartJob : public ScanPartJob {
 		using ScanPartJob::ScanPartJob;
-		virtual void OnRun() override;
+		void OnRun() override;
 	};
 
 	class PartDb {

--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -35,15 +35,15 @@ public:
 	GasGiant(const SystemBody *body);
 	virtual ~GasGiant();
 
-	virtual void Update() override;
-	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
+	void Update() override;
+	void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
 
-	virtual double GetHeight(const vector3d &p) const override final { return 0.0; }
+	double GetHeight(const vector3d &p) const final { return 0.0; }
 
 	// in sbody radii
-	virtual double GetMaxFeatureHeight() const override { return 0.0; }
+	double GetMaxFeatureHeight() const override { return 0.0; }
 
-	virtual void Reset() override;
+	void Reset() override;
 
 	static bool OnAddTextureFaceResult(const SystemPath &path, GasGiantJobs::STextureFaceResult *res);
 	static bool OnAddGPUGenResult(const SystemPath &path, GasGiantJobs::SGPUGenResult *res);
@@ -71,7 +71,7 @@ private:
 	bool m_hasTempCampos;
 	vector3d m_tempCampos;
 
-	virtual void SetUpMaterials() override;
+	void SetUpMaterials() override;
 	RefCountedPtr<Graphics::Texture> m_surfaceTextureSmall;
 	RefCountedPtr<Graphics::Texture> m_surfaceTexture;
 	RefCountedPtr<Graphics::Texture> m_builtTexture;

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -32,10 +32,10 @@ public:
 	GeoSphere(const SystemBody *body);
 	virtual ~GeoSphere();
 
-	virtual void Update() override;
-	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
+	void Update() override;
+	void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
 
-	virtual double GetHeight(const vector3d &p) const override final
+	double GetHeight(const vector3d &p) const final
 	{
 		const double h = m_terrain->GetHeight(p);
 #ifndef NDEBUG
@@ -68,13 +68,13 @@ public:
 	static Uint32 GetDebugFlags();
 
 	// in sbody radii
-	virtual double GetMaxFeatureHeight() const override final { return m_terrain->GetMaxHeight(); }
+	double GetMaxFeatureHeight() const final { return m_terrain->GetMaxHeight(); }
 
 	bool AddQuadSplitResult(SQuadSplitResult *res);
 	bool AddSingleSplitResult(SSingleSplitResult *res);
 	void ProcessSplitResults();
 
-	virtual void Reset() override;
+	void Reset() override;
 
 	inline Sint32 GetMaxDepth() const { return m_maxDepth; }
 
@@ -113,7 +113,7 @@ private:
 
 	static RefCountedPtr<GeoPatchContext> s_patchContext;
 
-	virtual void SetUpMaterials() override;
+	void SetUpMaterials() override;
 	void CreateAtmosphereMaterial();
 
 	RefCountedPtr<Graphics::Texture> m_texHi;

--- a/src/HyperspaceCloud.h
+++ b/src/HyperspaceCloud.h
@@ -22,20 +22,20 @@ public:
 	HyperspaceCloud(Ship *, double dateDue, bool isArrival);
 	HyperspaceCloud(const Json &jsonObj, Space *space);
 	virtual ~HyperspaceCloud();
-	virtual void SetVelocity(const vector3d &v) override { m_vel = v; }
-	virtual vector3d GetVelocity() const override { return m_vel; }
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
-	virtual void PostLoadFixup(Space *space) override;
-	virtual void TimeStepUpdate(const float timeStep) override;
+	void SetVelocity(const vector3d &v) override { m_vel = v; }
+	vector3d GetVelocity() const override { return m_vel; }
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	void PostLoadFixup(Space *space) override;
+	void TimeStepUpdate(const float timeStep) override;
 	Ship *GetShip() { return m_ship; }
 	Ship *EvictShip();
 	double GetDueDate() const { return m_due; }
 	void SetIsArrival(bool isArrival);
 	bool IsArrival() const { return m_isArrival; }
-	virtual void UpdateInterpTransform(double alpha) override;
+	void UpdateInterpTransform(double alpha) override;
 
 protected:
-	virtual void SaveToJson(Json &jsonObj, Space *space) override;
+	void SaveToJson(Json &jsonObj, Space *space) override;
 
 private:
 	static void InitGraphics(Graphics::Renderer *renderer);

--- a/src/JobQueue.h
+++ b/src/JobQueue.h
@@ -133,9 +133,9 @@ public:
 	SyncJobQueue() = default;
 	virtual ~SyncJobQueue();
 
-	virtual Job::Handle Queue(Job *job, JobClient *client = nullptr) override;
-	virtual void Cancel(Job *job) override;
-	virtual Uint32 FinishJobs() override;
+	Job::Handle Queue(Job *job, JobClient *client = nullptr) override;
+	void Cancel(Job *job) override;
+	Uint32 FinishJobs() override;
 
 	Uint32 RunJobs(Uint32 count = 1);
 

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -38,11 +38,11 @@ public:
 	void Init();
 	void StaticUpdate(const float timeStep) override;
 	void TimeStepUpdate(const float timeStep) override;
-	virtual bool OnCollision(Body *o, Uint32 flags, double relVel) override;
-	virtual bool OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData) override;
-	virtual void NotifyRemoved(const Body *const removedBody) override;
-	virtual void PostLoadFixup(Space *space) override;
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	bool OnCollision(Body *o, Uint32 flags, double relVel) override;
+	bool OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData) override;
+	void NotifyRemoved(const Body *const removedBody) override;
+	void PostLoadFixup(Space *space) override;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 	void ECMAttack(int power_val);
 
 	Body *GetOwner() const { return m_owner; }
@@ -54,7 +54,7 @@ public:
 	void AIKamikaze(Body *target);
 
 protected:
-	virtual void SaveToJson(Json &jsonObj, Space *space) override;
+	void SaveToJson(Json &jsonObj, Space *space) override;
 
 private:
 	void Explode();

--- a/src/ModelBody.h
+++ b/src/ModelBody.h
@@ -31,7 +31,7 @@ public:
 	virtual ~ModelBody();
 	void SetPosition(const vector3d &p) override;
 	void SetOrient(const matrix3x3d &r) override;
-	virtual void SetFrame(FrameId fId) override;
+	void SetFrame(FrameId fId) override;
 	// Colliding: geoms are checked against collision space
 	void SetColliding(bool colliding);
 	bool IsColliding() const { return m_colliding; }
@@ -47,10 +47,10 @@ public:
 
 	void RenderModel(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform);
 
-	virtual void TimeStepUpdate(const float timeStep) override;
+	void TimeStepUpdate(const float timeStep) override;
 
 protected:
-	virtual void SaveToJson(Json &jsonObj, Space *space) override;
+	void SaveToJson(Json &jsonObj, Space *space) override;
 
 private:
 	void RebuildCollisionMesh();

--- a/src/ObjectViewerView.h
+++ b/src/ObjectViewerView.h
@@ -13,13 +13,13 @@ class SystemBody;
 class ObjectViewerView : public View {
 public:
 	ObjectViewerView();
-	virtual void Update() override;
-	virtual void Draw3D() override;
+	void Update() override;
+	void Draw3D() override;
 
 protected:
-	virtual void OnSwitchTo() override;
+	void OnSwitchTo() override;
 
-	virtual void DrawPiGui() override;
+	void DrawPiGui() override;
 
 private:
 	void ReloadState();

--- a/src/Planet.h
+++ b/src/Planet.h
@@ -22,7 +22,7 @@ public:
 	Planet(SystemBody *);
 	Planet(const Json &jsonObj, Space *space);
 
-	virtual void SubRender(Graphics::Renderer *r, const matrix4x4d &viewTran, const vector3d &camPos) override;
+	void SubRender(Graphics::Renderer *r, const matrix4x4d &viewTran, const vector3d &camPos) override;
 
 	void GetAtmosphericState(double dist, double *outPressure, double *outDensity) const;
 	double GetAtmosphereRadius() const { return m_atmosphereRadius; }

--- a/src/Projectile.h
+++ b/src/Projectile.h
@@ -46,17 +46,17 @@ public:
 	Projectile(Body *parent, const ProjectileData &prData, const vector3d &pos, const vector3d &baseVel, const vector3d &dirVel);
 	Projectile(const Json &jsonObj, Space *space);
 	virtual ~Projectile();
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override final;
-	void TimeStepUpdate(const float timeStep) override final;
-	void StaticUpdate(const float timeStep) override final;
-	virtual void NotifyRemoved(const Body *const removedBody) override final;
-	virtual void UpdateInterpTransform(double alpha) override final;
-	virtual void PostLoadFixup(Space *space) override final;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) final;
+	void TimeStepUpdate(const float timeStep) final;
+	void StaticUpdate(const float timeStep) final;
+	void NotifyRemoved(const Body *const removedBody) final;
+	void UpdateInterpTransform(double alpha) final;
+	void PostLoadFixup(Space *space) final;
 
 	static void FreeModel();
 
 protected:
-	virtual void SaveToJson(Json &jsonObj, Space *space) override final;
+	virtual void SaveToJson(Json &jsonObj, Space *space) final;
 
 private:
 	float GetDamage() const;

--- a/src/RefCounted.h
+++ b/src/RefCounted.h
@@ -12,7 +12,7 @@ class RefCounted : public LuaWrappable {
 public:
 	RefCounted() :
 		m_refCount(0) {}
-	virtual ~RefCounted() override {}
+	~RefCounted() override {}
 
 	inline void IncRefCount() const { ++m_refCount; }
 	inline void DecRefCount() const

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -73,7 +73,7 @@ public:
 	Ship(const ShipType::Id &shipId);
 	virtual ~Ship();
 
-	virtual void SetFrame(FrameId fId) override;
+	void SetFrame(FrameId fId) override;
 
 	void SetController(ShipController *c); //deletes existing
 	ShipController *GetController() const { return m_controller; }
@@ -87,7 +87,7 @@ public:
 
 	virtual void SetLandedOn(Planet *p, float latitude, float longitude);
 
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 
 	inline void ClearThrusterState()
 	{
@@ -107,16 +107,16 @@ public:
 	virtual bool ManualDocking() const { return false; }
 	void Blastoff();
 	bool Undock();
-	virtual void TimeStepUpdate(const float timeStep) override;
-	virtual void StaticUpdate(const float timeStep) override;
+	void TimeStepUpdate(const float timeStep) override;
+	void StaticUpdate(const float timeStep) override;
 
 	void TimeAccelAdjust(const float timeStep);
 
 	bool IsDecelerating() const { return m_decelerating; }
 
-	virtual void NotifyRemoved(const Body *const removedBody) override;
-	virtual bool OnCollision(Body *o, Uint32 flags, double relVel) override;
-	virtual bool OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData) override;
+	void NotifyRemoved(const Body *const removedBody) override;
+	bool OnCollision(Body *o, Uint32 flags, double relVel) override;
+	bool OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData) override;
 
 	enum FlightState { // <enum scope='Ship' name=ShipFlightState public>
 		FLYING,		   // open flight (includes autopilot)
@@ -137,7 +137,7 @@ public:
 	int GetWheelTransition() const { return m_wheelTransition; }
 	bool SpawnCargo(CargoBody *c_body) const;
 
-	virtual bool IsInSpace() const override { return (m_flightState != HYPERSPACE); }
+	bool IsInSpace() const override { return (m_flightState != HYPERSPACE); }
 
 	void SetHyperspaceDest(const SystemPath &dest) { m_hyperspace.dest = dest; }
 	const SystemPath &GetHyperspaceDest() const { return m_hyperspace.dest; }
@@ -199,7 +199,7 @@ public:
 	const AICommand *GetAICommand() const { return m_curAICmd; }
 	bool IsAIAttacking(const Ship *target) const;
 
-	virtual void PostLoadFixup(Space *space) override;
+	void PostLoadFixup(Space *space) override;
 
 	const ShipType *GetShipType() const { return m_type; }
 	virtual void SetShipType(const ShipType::Id &shipId);
@@ -246,7 +246,7 @@ public:
 protected:
 	vector3d CalcAtmosphericForce() const override;
 
-	virtual void SaveToJson(Json &jsonObj, Space *space) override;
+	void SaveToJson(Json &jsonObj, Space *space) override;
 
 	bool AITimeStep(float timeStep); // Called by controller. Returns true if complete
 

--- a/src/ShipCockpit.h
+++ b/src/ShipCockpit.h
@@ -21,7 +21,7 @@ public:
 	explicit ShipCockpit(const std::string &modelName, Body *ship);
 	virtual ~ShipCockpit();
 
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 
 	void Update(const Player *player, float timeStep);
 	void RenderCockpit(Graphics::Renderer *renderer, const Camera *camera, FrameId frameId);

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -44,18 +44,18 @@ public:
 	SpaceStation(const Json &jsonObj, Space *space);
 
 	virtual ~SpaceStation();
-	virtual vector3d GetAngVelocity() const override { return vector3d(0, m_type->AngVel(), 0); }
-	virtual bool OnCollision(Body *b, Uint32 flags, double relVel) override;
+	vector3d GetAngVelocity() const override { return vector3d(0, m_type->AngVel(), 0); }
+	bool OnCollision(Body *b, Uint32 flags, double relVel) override;
 	bool DoShipDamage(Ship *s, Uint32 flags, double relVel);
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
-	virtual void StaticUpdate(const float timeStep) override;
-	virtual void TimeStepUpdate(const float timeStep) override;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	void StaticUpdate(const float timeStep) override;
+	void TimeStepUpdate(const float timeStep) override;
 
-	virtual const SystemBody *GetSystemBody() const override { return m_sbody; }
-	virtual void PostLoadFixup(Space *space) override;
-	virtual void NotifyRemoved(const Body *const removedBody) override;
+	const SystemBody *GetSystemBody() const override { return m_sbody; }
+	void PostLoadFixup(Space *space) override;
+	void NotifyRemoved(const Body *const removedBody) override;
 
-	virtual void SetLabel(const std::string &label) override;
+	void SetLabel(const std::string &label) override;
 
 	// should call Ship::Undock and Ship::SetDockedWith instead
 	// Returns true on success, false if permission denied
@@ -80,7 +80,7 @@ public:
 	vector3d GetTargetIndicatorPosition() const override;
 
 	// need this now because stations rotate in their frame
-	virtual void UpdateInterpTransform(double alpha) override;
+	void UpdateInterpTransform(double alpha) override;
 
 	// Return true if any lightning changes were applied, only do so if body is inside
 	// or near enough to the station
@@ -88,7 +88,7 @@ public:
 
 
 protected:
-	virtual void SaveToJson(Json &jsonObj, Space *space) override;
+	void SaveToJson(Json &jsonObj, Space *space) override;
 
 private:
 	void DockingUpdate(const double timeStep);

--- a/src/Star.h
+++ b/src/Star.h
@@ -24,7 +24,7 @@ public:
 	Star(const Json &jsonObj, Space *space);
 	virtual ~Star();
 
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 
 protected:
 	void InitStar();

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -22,13 +22,13 @@ class TerrainBody : public Body {
 public:
 	OBJDEF(TerrainBody, Body, TERRAINBODY);
 
-	virtual void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
+	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 	virtual void SubRender(Graphics::Renderer *r, const matrix4x4d &modelView, const vector3d &camPos) {}
-	virtual void SetFrame(FrameId fId) override;
+	void SetFrame(FrameId fId) override;
 	virtual bool OnCollision(Body *b, Uint32 flags, double relVel) override { return true; }
-	virtual double GetMass() const override { return m_mass; }
+	double GetMass() const override { return m_mass; }
 	double GetTerrainHeight(const vector3d &pos) const;
-	virtual const SystemBody *GetSystemBody() const override { return m_sbody; }
+	const SystemBody *GetSystemBody() const override { return m_sbody; }
 
 	// returns value in metres
 	double GetMaxFeatureRadius() const { return m_maxFeatureHeight; }
@@ -44,7 +44,7 @@ protected:
 
 	void InitTerrainBody();
 
-	virtual void SaveToJson(Json &jsonObj, Space *space) override;
+	void SaveToJson(Json &jsonObj, Space *space) override;
 
 private:
 	const SystemBody *m_sbody;

--- a/src/collider/BVHTree.h
+++ b/src/collider/BVHTree.h
@@ -74,7 +74,7 @@ public:
 	~SingleBVHTree() {};
 
 protected:
-	virtual void BuildNode(Node *node, SortKey *keys, uint32_t numKeys, const AABBd *objAabbs, uint32_t height) override final;
+	void BuildNode(Node *node, SortKey *keys, uint32_t numKeys, const AABBd *objAabbs, uint32_t height) final;
 	uint32_t Partition(SortKey *keys, uint32_t numKeys, const AABBd &aabb, const AABBd *objAabbs);
 };
 
@@ -105,7 +105,7 @@ protected:
 	// experimentally shown to provide a better SAH for human-authored models.
 	static constexpr size_t NUM_BINS = 12;
 
-	virtual void BuildNode(Node *node, SortKey *keys, uint32_t numKeys, const AABBd *objAabbs, uint32_t height) override final;
+	void BuildNode(Node *node, SortKey *keys, uint32_t numKeys, const AABBd *objAabbs, uint32_t height) final;
 	uint32_t Partition(SortKey *keys, uint32_t numKeys, const AABBd &aabb, const AABBd *objAabbs);
 	float FindPivot(SortKey *keys, uint32_t numKeys, const AABBd &aabb, const AABBd *objAabbs, uint32_t axis, float &outCost) const;
 };

--- a/src/core/TaskGraph.cpp
+++ b/src/core/TaskGraph.cpp
@@ -28,9 +28,9 @@ public:
 	TaskGraphJobQueueImpl(TaskGraph *graph) :
 		m_graph(graph) {}
 
-	virtual Job::Handle Queue(Job *job, JobClient *client) override;
-	virtual void Cancel(Job *job) override;
-	virtual Uint32 FinishJobs() override;
+	Job::Handle Queue(Job *job, JobClient *client) override;
+	void Cancel(Job *job) override;
+	Uint32 FinishJobs() override;
 
 	TaskGraph *m_graph;
 };

--- a/src/editor/ViewportWindow.h
+++ b/src/editor/ViewportWindow.h
@@ -23,10 +23,10 @@ namespace Editor
 		ViewportWindow(EditorApp *app);
 		~ViewportWindow();
 
-		virtual void OnAppearing() override;
-		virtual void OnDisappearing() override;
+		void OnAppearing() override;
+		void OnDisappearing() override;
 
-		virtual void Update(float deltaTime) override;
+		void Update(float deltaTime) override;
 
 	protected:
 

--- a/src/graphics/Material.h
+++ b/src/graphics/Material.h
@@ -172,7 +172,7 @@ namespace Graphics {
 		bool SetBufferDynamic(size_t hash, T *buffer) { return SetBufferDynamic(hash, static_cast<void *>(buffer), sizeof(T)); }
 
 		// Set the given buffer object with an externally-managed uniform buffer.
-		virtual bool SetBuffer(size_t hash, BufferBinding<UniformBuffer> uboBinding) = 0;
+		virtual bool SetBuffer(size_t hash, BufferBinding<Graphics::UniformBuffer> uboBinding) = 0;
 
 		virtual bool SetPushConstant(size_t hash, int i) = 0;
 		virtual bool SetPushConstant(size_t hash, float f) = 0;

--- a/src/graphics/dummy/MaterialDummy.h
+++ b/src/graphics/dummy/MaterialDummy.h
@@ -22,20 +22,20 @@ namespace Graphics {
 				rsd(rsd) {}
 			// Create an appropriate program for this material.
 			virtual Program *CreateProgram(const MaterialDescriptor &) { return nullptr; }
-			virtual bool IsProgramLoaded() const override final { return false; }
+			bool IsProgramLoaded() const final { return false; }
 			virtual void SetProgram(Program *p) {}
 
-			virtual bool SetTexture(size_t name, Texture *tex) override { return false; }
-			virtual bool SetBuffer(size_t name, BufferBinding<UniformBuffer>) override { return false; }
-			virtual bool SetBufferDynamic(size_t name, void *data, size_t size) override { return false; }
+			bool SetTexture(size_t name, Texture *tex) override { return false; }
+			bool SetBuffer(size_t name, BufferBinding<Graphics::UniformBuffer>) override { return false; }
+			bool SetBufferDynamic(size_t name, void *data, size_t size) override { return false; }
 
-			virtual bool SetPushConstant(size_t name, int i) override { return false; }
-			virtual bool SetPushConstant(size_t name, float f) override { return false; }
-			virtual bool SetPushConstant(size_t name, vector3f v3) override { return false; }
-			virtual bool SetPushConstant(size_t name, vector3f v4, float f4) override { return false; }
-			virtual bool SetPushConstant(size_t name, Color c) override { return false; }
-			virtual bool SetPushConstant(size_t name, matrix3x3f mat3) override { return false; }
-			virtual bool SetPushConstant(size_t name, matrix4x4f mat4) override { return false; }
+			bool SetPushConstant(size_t name, int i) override { return false; }
+			bool SetPushConstant(size_t name, float f) override { return false; }
+			bool SetPushConstant(size_t name, vector3f v3) override { return false; }
+			bool SetPushConstant(size_t name, vector3f v4, float f4) override { return false; }
+			bool SetPushConstant(size_t name, Color c) override { return false; }
+			bool SetPushConstant(size_t name, matrix3x3f mat3) override { return false; }
+			bool SetPushConstant(size_t name, matrix4x4f mat4) override { return false; }
 
 			RenderStateDesc rsd; // here to ensure validation works correctly
 		};

--- a/src/graphics/dummy/RenderTargetDummy.h
+++ b/src/graphics/dummy/RenderTargetDummy.h
@@ -16,7 +16,7 @@ namespace Graphics {
 		public:
 			virtual Texture *GetColorTexture() const { return m_colorTexture.Get(); }
 			virtual Texture *GetDepthTexture() const { return m_depthTexture.Get(); }
-			virtual void SetCubeFaceTexture(const Uint32 face, Texture *t) final { m_colorTexture.Reset(t); }
+			void SetCubeFaceTexture(const Uint32 face, Texture *t) final { m_colorTexture.Reset(t); }
 			virtual void SetColorTexture(Texture *t) { m_colorTexture.Reset(t); }
 			virtual void SetDepthTexture(Texture *t) { m_depthTexture.Reset(t); }
 

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -28,75 +28,75 @@ namespace Graphics {
 			m_identity(matrix4x4f::Identity())
 		{}
 
-		virtual const char *GetName() const override final { return "Dummy"; }
-		virtual RendererType GetRendererType() const override final { return RENDERER_DUMMY; }
-		virtual bool SupportsInstancing() override final { return false; }
-		virtual int GetMaximumNumberAASamples() const override final { return 0; }
-		virtual bool GetNearFarRange(float &near_, float &far_) const override final { return true; }
+		const char *GetName() const final { return "Dummy"; }
+		RendererType GetRendererType() const final { return RENDERER_DUMMY; }
+		bool SupportsInstancing() final { return false; }
+		int GetMaximumNumberAASamples() const final { return 0; }
+		bool GetNearFarRange(float &near_, float &far_) const final { return true; }
 
-		virtual void SetVSyncEnabled(bool) override {}
+		void SetVSyncEnabled(bool) override {}
 
-		virtual bool BeginFrame() override final { return true; }
-		virtual bool EndFrame() override final { return true; }
-		virtual bool SwapBuffers() override final { return true; }
+		bool BeginFrame() final { return true; }
+		bool EndFrame() final { return true; }
+		bool SwapBuffers() final { return true; }
 
-		virtual RenderTarget *GetRenderTarget() override final { return m_rt; }
-		virtual bool SetRenderTarget(RenderTarget *rt) override final { m_rt = rt; return true; }
-		virtual bool SetScissor(ViewportExtents ext) override final { return true; }
+		RenderTarget *GetRenderTarget() final { return m_rt; }
+		bool SetRenderTarget(RenderTarget *rt) final { m_rt = rt; return true; }
+		bool SetScissor(ViewportExtents ext) final { return true; }
 
-		virtual void CopyRenderTarget(RenderTarget *, RenderTarget *, ViewportExtents, ViewportExtents, bool) override final {}
-		virtual void ResolveRenderTarget(RenderTarget *, RenderTarget *, ViewportExtents) override final {}
+		void CopyRenderTarget(RenderTarget *, RenderTarget *, ViewportExtents, ViewportExtents, bool) final {}
+		void ResolveRenderTarget(RenderTarget *, RenderTarget *, ViewportExtents) final {}
 
-		virtual bool ClearScreen(const Color &, bool) override final { return true; }
-		virtual bool ClearDepthBuffer() override final { return true; }
+		bool ClearScreen(const Color &, bool) final { return true; }
+		bool ClearDepthBuffer() final { return true; }
 
-		virtual bool SetViewport(ViewportExtents v) override final { return true; }
-		virtual ViewportExtents GetViewport() const override final { return {}; }
+		bool SetViewport(ViewportExtents v) final { return true; }
+		ViewportExtents GetViewport() const final { return {}; }
 
-		virtual bool SetTransform(const matrix4x4f &m) override final { return true; }
-		virtual matrix4x4f GetTransform() const override final { return matrix4x4f::Identity(); }
-		virtual bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) override final { return true; }
-		virtual bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) override final { return true; }
-		virtual bool SetProjection(const matrix4x4f &m) override final { return true; }
-		virtual matrix4x4f GetProjection() const override final { return matrix4x4f::Identity(); }
+		bool SetTransform(const matrix4x4f &m) final { return true; }
+		matrix4x4f GetTransform() const final { return matrix4x4f::Identity(); }
+		bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) final { return true; }
+		bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) final { return true; }
+		bool SetProjection(const matrix4x4f &m) final { return true; }
+		matrix4x4f GetProjection() const final { return matrix4x4f::Identity(); }
 
-		virtual bool SetWireFrameMode(bool enabled) override final { return true; }
+		bool SetWireFrameMode(bool enabled) final { return true; }
 
-		virtual bool SetLightIntensity(Uint32, const float *) override final { return true; }
-		virtual bool SetLights(Uint32 numlights, const Light *l) override final { return true; }
-		virtual Uint32 GetNumLights() const override final { return 1; }
-		virtual bool SetAmbientColor(const Color &c) override final { return true; }
+		bool SetLightIntensity(Uint32, const float *) final { return true; }
+		bool SetLights(Uint32 numlights, const Light *l) final { return true; }
+		Uint32 GetNumLights() const final { return 1; }
+		bool SetAmbientColor(const Color &c) final { return true; }
 
-		virtual bool FlushCommandBuffers() override final { return true; }
+		bool FlushCommandBuffers() final { return true; }
 
-		virtual bool DrawBuffer(const VertexArray *, Material *) override final { return true; }
-		virtual bool DrawBufferDynamic(VertexBuffer *, uint32_t, IndexBuffer *, uint32_t, uint32_t, Material *) override final { return true; }
-		virtual bool DrawMesh(MeshObject *, Material *) override final { return true; }
-		virtual bool DrawMeshInstanced(MeshObject *, Material *, InstanceBuffer *) override final { return true; }
+		bool DrawBuffer(const VertexArray *, Material *) final { return true; }
+		bool DrawBufferDynamic(VertexBuffer *, uint32_t, IndexBuffer *, uint32_t, uint32_t, Material *) final { return true; }
+		bool DrawMesh(MeshObject *, Material *) final { return true; }
+		bool DrawMeshInstanced(MeshObject *, Material *, InstanceBuffer *) final { return true; }
 
-		virtual Material *CreateMaterial(const std::string &s, const MaterialDescriptor &d, const RenderStateDesc &rsd) override final { return new Graphics::Dummy::Material(rsd); }
-		virtual Material *CloneMaterial(const Material *m, const MaterialDescriptor &d, const RenderStateDesc &rsd) override final { return new Graphics::Dummy::Material(rsd); }
-		virtual Texture *CreateTexture(const TextureDescriptor &d) override final { return new Graphics::TextureDummy(d); }
-		virtual RenderTarget *CreateRenderTarget(const RenderTargetDesc &d) override final { return new Graphics::Dummy::RenderTarget(d); }
-		virtual VertexBuffer *CreateVertexBuffer(const VertexBufferDesc &d) override final { return new Graphics::Dummy::VertexBuffer(d); }
-		virtual IndexBuffer *CreateIndexBuffer(Uint32 size, BufferUsage bu, IndexBufferSize el) override final { return new Graphics::Dummy::IndexBuffer(size, bu, el); }
-		virtual InstanceBuffer *CreateInstanceBuffer(Uint32 size, BufferUsage bu) override final { return new Graphics::Dummy::InstanceBuffer(size, bu); }
-		virtual UniformBuffer *CreateUniformBuffer(Uint32 size, BufferUsage bu) override final { return new Graphics::Dummy::UniformBuffer(size, bu); }
-		virtual MeshObject *CreateMeshObject(VertexBuffer *v, IndexBuffer *i) override final { return new Graphics::Dummy::MeshObject(static_cast<Dummy::VertexBuffer *>(v), static_cast<Dummy::IndexBuffer *>(i)); }
-		virtual MeshObject *CreateMeshObjectFromArray(const VertexArray *v, IndexBuffer *i = nullptr, BufferUsage = BUFFER_USAGE_STATIC) override final
+		Material *CreateMaterial(const std::string &s, const MaterialDescriptor &d, const RenderStateDesc &rsd) final { return new Graphics::Dummy::Material(rsd); }
+		Material *CloneMaterial(const Material *m, const MaterialDescriptor &d, const RenderStateDesc &rsd) final { return new Graphics::Dummy::Material(rsd); }
+		Texture *CreateTexture(const TextureDescriptor &d) final { return new Graphics::TextureDummy(d); }
+		RenderTarget *CreateRenderTarget(const RenderTargetDesc &d) final { return new Graphics::Dummy::RenderTarget(d); }
+		VertexBuffer *CreateVertexBuffer(const VertexBufferDesc &d) final { return new Graphics::Dummy::VertexBuffer(d); }
+		IndexBuffer *CreateIndexBuffer(Uint32 size, BufferUsage bu, IndexBufferSize el) final { return new Graphics::Dummy::IndexBuffer(size, bu, el); }
+		InstanceBuffer *CreateInstanceBuffer(Uint32 size, BufferUsage bu) final { return new Graphics::Dummy::InstanceBuffer(size, bu); }
+		UniformBuffer *CreateUniformBuffer(Uint32 size, BufferUsage bu) final { return new Graphics::Dummy::UniformBuffer(size, bu); }
+		MeshObject *CreateMeshObject(VertexBuffer *v, IndexBuffer *i) final { return new Graphics::Dummy::MeshObject(static_cast<Dummy::VertexBuffer *>(v), static_cast<Dummy::IndexBuffer *>(i)); }
+		MeshObject *CreateMeshObjectFromArray(const VertexArray *v, IndexBuffer *i = nullptr, BufferUsage = BUFFER_USAGE_STATIC) final
 		{
 			auto desc = Graphics::VertexBufferDesc::FromAttribSet(v->GetAttributeSet());
 			desc.numVertices = v->GetNumVerts();
 			return new Graphics::Dummy::MeshObject(static_cast<Dummy::VertexBuffer *>(CreateVertexBuffer(desc)), static_cast<Dummy::IndexBuffer *>(i));
 		}
 
-		virtual const RenderStateDesc &GetMaterialRenderState(const Graphics::Material *m) override final { return static_cast<const Dummy::Material *>(m)->rsd; }
+		const RenderStateDesc &GetMaterialRenderState(const Graphics::Material *m) final { return static_cast<const Dummy::Material *>(m)->rsd; }
 
-		virtual bool ReloadShaders() override final { return true; }
+		bool ReloadShaders() final { return true; }
 
 	protected:
-		virtual void PushState() override final {}
-		virtual void PopState() override final {}
+		void PushState() final {}
+		void PopState() final {}
 
 	private:
 		const matrix4x4f m_identity;

--- a/src/graphics/dummy/TextureDummy.h
+++ b/src/graphics/dummy/TextureDummy.h
@@ -10,16 +10,16 @@ namespace Graphics {
 
 	class TextureDummy : public Texture {
 	public:
-		virtual void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final {}
-		virtual void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final {}
-		virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips) override final {}
+		void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) final {}
+		void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) final {}
+		void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips) final {}
 
 		void Bind() override {}
 		void Unbind() override {}
 
-		virtual void SetSampleMode(TextureSampleMode) override {}
-		virtual void BuildMipmaps(const uint32_t) override {}
-		virtual uint32_t GetTextureID() const override final { return 0U; }
+		void SetSampleMode(TextureSampleMode) override {}
+		void BuildMipmaps(const uint32_t) override {}
+		uint32_t GetTextureID() const final { return 0U; }
 		uint32_t GetTextureMemSize() const final { return 0U; }
 
 	private:

--- a/src/graphics/dummy/UniformBufferDummy.h
+++ b/src/graphics/dummy/UniformBufferDummy.h
@@ -17,13 +17,13 @@ namespace Graphics {
 				Graphics::UniformBuffer(size, usage),
 				m_data(new uint8_t[size])
 			{}
-			virtual ~UniformBuffer() override {}
+			~UniformBuffer() override {}
 
-			virtual void Unmap() override {}
-			virtual void BufferData(const size_t, void *) override {}
+			void Unmap() override {}
+			void BufferData(const size_t, void *) override {}
 
 		private:
-			virtual void *MapInternal(BufferMapMode) override { return m_data.get(); }
+			void *MapInternal(BufferMapMode) override { return m_data.get(); }
 			std::unique_ptr<uint8_t[]> m_data;
 		};
 

--- a/src/graphics/dummy/VertexBufferDummy.h
+++ b/src/graphics/dummy/VertexBufferDummy.h
@@ -21,18 +21,18 @@ namespace Graphics {
 			{}
 
 			// copies the contents of the VertexArray into the buffer
-			virtual bool Populate(const VertexArray &) override final { return true; }
+			bool Populate(const VertexArray &) final { return true; }
 
 			// change the buffer data without mapping
-			virtual void BufferData(const size_t, void *) override final {}
+			void BufferData(const size_t, void *) final {}
 
-			virtual void Bind() override final {}
-			virtual void Release() override final {}
+			void Bind() final {}
+			void Release() final {}
 
-			virtual void Unmap() override final {}
+			void Unmap() final {}
 
 		protected:
-			virtual Uint8 *MapInternal(BufferMapMode) override final { return m_buffer.get(); }
+			Uint8 *MapInternal(BufferMapMode) final { return m_buffer.get(); }
 
 		private:
 			std::unique_ptr<Uint8[]> m_buffer;
@@ -49,14 +49,14 @@ namespace Graphics {
 					m_buffer16.reset(new Uint16[size]);
 			}
 
-			virtual Uint32 *Map(BufferMapMode) override final { return m_buffer.get(); }
-			virtual Uint16 *Map16(BufferMapMode) override final { return m_buffer16.get(); }
-			virtual void Unmap() override final {}
+			Uint32 *Map(BufferMapMode) final { return m_buffer.get(); }
+			Uint16 *Map16(BufferMapMode) final { return m_buffer16.get(); }
+			void Unmap() final {}
 
-			virtual void BufferData(const size_t, void *) override final {}
+			void BufferData(const size_t, void *) final {}
 
-			virtual void Bind() override final {}
-			virtual void Release() override final {}
+			void Bind() final {}
+			void Release() final {}
 
 		private:
 			std::unique_ptr<Uint32[]> m_buffer;
@@ -70,15 +70,15 @@ namespace Graphics {
 				Graphics::InstanceBuffer(size, hint),
 				m_data(new matrix4x4f[size])
 			{}
-			virtual ~InstanceBuffer(){};
-			virtual matrix4x4f *Map(BufferMapMode) override final { return m_data.get(); }
-			virtual void Unmap() override final {}
+			~InstanceBuffer() final {};
+			matrix4x4f *Map(BufferMapMode) final { return m_data.get(); }
+			void Unmap() final {}
 
 			Uint32 GetSize() const { return m_size; }
 			BufferUsage GetUsage() const { return m_usage; }
 
-			virtual void Bind() override final {}
-			virtual void Release() override final {}
+			void Bind() final {}
+			void Release() final {}
 
 		protected:
 			std::unique_ptr<matrix4x4f> m_data;
@@ -90,13 +90,13 @@ namespace Graphics {
 				m_vtxBuffer(v),
 				m_idxBuffer(i)
 			{}
-			virtual ~MeshObject() override final {}
+			~MeshObject() final {}
 
-			virtual Graphics::VertexBuffer *GetVertexBuffer() const override final { return m_vtxBuffer.Get(); }
-			virtual Graphics::IndexBuffer *GetIndexBuffer() const override final { return m_idxBuffer.Get(); }
+			Graphics::VertexBuffer *GetVertexBuffer() const final { return m_vtxBuffer.Get(); }
+			Graphics::IndexBuffer *GetIndexBuffer() const final { return m_idxBuffer.Get(); }
 
-			virtual void Bind() override final {}
-			virtual void Release() override final {}
+			void Bind() final {}
+			void Release() final {}
 
 		protected:
 			RefCountedPtr<VertexBuffer> m_vtxBuffer;

--- a/src/graphics/opengl/MaterialGL.h
+++ b/src/graphics/opengl/MaterialGL.h
@@ -36,22 +36,22 @@ namespace Graphics {
 		public:
 			Material() {}
 
-			virtual bool IsProgramLoaded() const override final;
+			bool IsProgramLoaded() const final;
 			virtual void SetShader(Shader *p);
 			virtual const Shader *GetShader() const { return m_shader; }
 
-			virtual bool SetTexture(size_t name, Texture *tex) override;
+			bool SetTexture(size_t name, Texture *tex) override;
 
-			virtual bool SetBufferDynamic(size_t name, void *buffer, size_t size) override;
-			virtual bool SetBuffer(size_t name, BufferBinding<Graphics::UniformBuffer> ub) override;
+			bool SetBufferDynamic(size_t name, void *buffer, size_t size) override;
+			bool SetBuffer(size_t name, BufferBinding<Graphics::UniformBuffer> ub) override;
 
-			virtual bool SetPushConstant(size_t name, int i) override;
-			virtual bool SetPushConstant(size_t name, float f) override;
-			virtual bool SetPushConstant(size_t name, vector3f v3) override;
-			virtual bool SetPushConstant(size_t name, vector3f v4, float f4) override;
-			virtual bool SetPushConstant(size_t name, Color c) override;
-			virtual bool SetPushConstant(size_t name, matrix3x3f mat3) override;
-			virtual bool SetPushConstant(size_t name, matrix4x4f mat4) override;
+			bool SetPushConstant(size_t name, int i) override;
+			bool SetPushConstant(size_t name, float f) override;
+			bool SetPushConstant(size_t name, vector3f v3) override;
+			bool SetPushConstant(size_t name, vector3f v4, float f4) override;
+			bool SetPushConstant(size_t name, Color c) override;
+			bool SetPushConstant(size_t name, matrix3x3f mat3) override;
+			bool SetPushConstant(size_t name, matrix4x4f mat4) override;
 
 		protected:
 			friend class Graphics::RendererOGL;

--- a/src/graphics/opengl/RenderTargetGL.h
+++ b/src/graphics/opengl/RenderTargetGL.h
@@ -28,11 +28,11 @@ namespace Graphics {
 			};
 
 			~RenderTarget();
-			virtual Texture *GetColorTexture() const override final;
-			virtual Texture *GetDepthTexture() const override final;
-			virtual void SetCubeFaceTexture(const Uint32 face, Texture *t) override final;
-			virtual void SetColorTexture(Texture *) override final;
-			virtual void SetDepthTexture(Texture *) override final;
+			Texture *GetColorTexture() const final;
+			Texture *GetDepthTexture() const final;
+			void SetCubeFaceTexture(const Uint32 face, Texture *t) final;
+			void SetColorTexture(Texture *) final;
+			void SetDepthTexture(Texture *) final;
 
 		protected:
 			friend class Graphics::RendererOGL;

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -41,92 +41,92 @@ namespace Graphics {
 		static void RegisterRenderer();
 
 		RendererOGL(SDL_Window *window, const Graphics::Settings &vs, SDL_GLContext &glContext);
-		virtual ~RendererOGL() override final;
+		~RendererOGL() final;
 
-		virtual const char *GetName() const override final { return "OpenGL 3.1, with extensions, renderer"; }
-		virtual RendererType GetRendererType() const override final { return RENDERER_OPENGL_3x; }
+		const char *GetName() const final { return "OpenGL 3.1, with extensions, renderer"; }
+		RendererType GetRendererType() const final { return RENDERER_OPENGL_3x; }
 
-		virtual void WriteRendererInfo(std::ostream &out) const override final;
+		void WriteRendererInfo(std::ostream &out) const final;
 
-		virtual void CheckRenderErrors(const char *func = nullptr, const int line = -1) const override final { CheckErrors(func, line); }
+		void CheckRenderErrors(const char *func = nullptr, const int line = -1) const final { CheckErrors(func, line); }
 		static void CheckErrors(const char *func = nullptr, const int line = -1);
 
-		virtual bool SupportsInstancing() override final { return true; }
+		bool SupportsInstancing() final { return true; }
 
-		virtual int GetMaximumNumberAASamples() const override final;
-		virtual bool GetNearFarRange(float &near_, float &far_) const override final;
+		int GetMaximumNumberAASamples() const final;
+		bool GetNearFarRange(float &near_, float &far_) const final;
 
-		virtual void SetVSyncEnabled(bool) override;
+		void SetVSyncEnabled(bool) override;
 
-		virtual void OnWindowResized() override;
+		void OnWindowResized() override;
 
-		virtual bool BeginFrame() override final;
-		virtual bool EndFrame() override final;
-		virtual bool SwapBuffers() override final;
+		bool BeginFrame() final;
+		bool EndFrame() final;
+		bool SwapBuffers() final;
 
-		virtual RenderTarget *GetRenderTarget() override final;
-		virtual bool SetRenderTarget(RenderTarget *) override final;
-		virtual bool SetScissor(ViewportExtents) override final;
+		RenderTarget *GetRenderTarget() final;
+		bool SetRenderTarget(RenderTarget *) final;
+		bool SetScissor(ViewportExtents) final;
 
-		virtual void CopyRenderTarget(RenderTarget *, RenderTarget *, ViewportExtents, ViewportExtents, bool) override final;
-		virtual void ResolveRenderTarget(RenderTarget *, RenderTarget *, ViewportExtents) override final;
+		void CopyRenderTarget(RenderTarget *, RenderTarget *, ViewportExtents, ViewportExtents, bool) final;
+		void ResolveRenderTarget(RenderTarget *, RenderTarget *, ViewportExtents) final;
 
-		virtual bool ClearScreen(const Color &c, bool) override final;
-		virtual bool ClearDepthBuffer() override final;
+		bool ClearScreen(const Color &c, bool) final;
+		bool ClearDepthBuffer() final;
 
-		virtual bool SetViewport(ViewportExtents v) override final;
-		virtual ViewportExtents GetViewport() const override final { return m_viewport; }
+		bool SetViewport(ViewportExtents v) final;
+		ViewportExtents GetViewport() const final { return m_viewport; }
 
-		virtual bool SetTransform(const matrix4x4f &m) override final;
-		virtual matrix4x4f GetTransform() const override final { return m_modelViewMat; }
+		bool SetTransform(const matrix4x4f &m) final;
+		matrix4x4f GetTransform() const final { return m_modelViewMat; }
 
-		virtual bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) override final;
-		virtual bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) override final;
-		virtual bool SetProjection(const matrix4x4f &m) override final;
-		virtual matrix4x4f GetProjection() const override final { return m_projectionMat; }
+		bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) final;
+		bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) final;
+		bool SetProjection(const matrix4x4f &m) final;
+		matrix4x4f GetProjection() const final { return m_projectionMat; }
 
-		virtual bool SetWireFrameMode(bool enabled) override final;
+		bool SetWireFrameMode(bool enabled) final;
 
-		virtual bool SetLightIntensity(Uint32 numlights, const float *intensity) override final;
-		virtual bool SetLights(Uint32 numlights, const Light *l) override final;
-		virtual Uint32 GetNumLights() const override final { return m_numLights; }
-		virtual bool SetAmbientColor(const Color &c) override final;
+		bool SetLightIntensity(Uint32 numlights, const float *intensity) final;
+		bool SetLights(Uint32 numlights, const Light *l) final;
+		Uint32 GetNumLights() const final { return m_numLights; }
+		bool SetAmbientColor(const Color &c) final;
 
-		virtual bool FlushCommandBuffers() override final;
+		bool FlushCommandBuffers() final;
 
-		virtual bool DrawBuffer(const VertexArray *v, Material *m) override final;
-		virtual bool DrawBufferDynamic(VertexBuffer *v, uint32_t vtxOffset, IndexBuffer *i, uint32_t idxOffset, uint32_t numElems, Material *m) override final;
-		virtual bool DrawMesh(MeshObject *, Material *) override final;
-		virtual bool DrawMeshInstanced(MeshObject *, Material *, InstanceBuffer *) override final;
+		bool DrawBuffer(const VertexArray *v, Material *m) final;
+		bool DrawBufferDynamic(VertexBuffer *v, uint32_t vtxOffset, IndexBuffer *i, uint32_t idxOffset, uint32_t numElems, Material *m) final;
+		bool DrawMesh(MeshObject *, Material *) final;
+		bool DrawMeshInstanced(MeshObject *, Material *, InstanceBuffer *) final;
 
-		virtual Material *CreateMaterial(const std::string &, const MaterialDescriptor &, const RenderStateDesc &) override final;
-		virtual Material *CloneMaterial(const Material *, const MaterialDescriptor &, const RenderStateDesc &) override final;
-		virtual Texture *CreateTexture(const TextureDescriptor &descriptor) override final;
-		virtual RenderTarget *CreateRenderTarget(const RenderTargetDesc &) override final;
-		virtual VertexBuffer *CreateVertexBuffer(const VertexBufferDesc &) override final;
-		virtual IndexBuffer *CreateIndexBuffer(Uint32 size, BufferUsage, IndexBufferSize) override final;
-		virtual InstanceBuffer *CreateInstanceBuffer(Uint32 size, BufferUsage) override final;
-		virtual UniformBuffer *CreateUniformBuffer(Uint32 size, BufferUsage) override final;
-		virtual MeshObject *CreateMeshObject(VertexBuffer *v, IndexBuffer *i) override final;
-		virtual MeshObject *CreateMeshObjectFromArray(const VertexArray *v, IndexBuffer *i = nullptr, BufferUsage u = BUFFER_USAGE_STATIC) override final;
+		Material *CreateMaterial(const std::string &, const MaterialDescriptor &, const RenderStateDesc &) final;
+		Material *CloneMaterial(const Material *, const MaterialDescriptor &, const RenderStateDesc &) final;
+		Texture *CreateTexture(const TextureDescriptor &descriptor) final;
+		RenderTarget *CreateRenderTarget(const RenderTargetDesc &) final;
+		VertexBuffer *CreateVertexBuffer(const VertexBufferDesc &) final;
+		IndexBuffer *CreateIndexBuffer(Uint32 size, BufferUsage, IndexBufferSize) final;
+		InstanceBuffer *CreateInstanceBuffer(Uint32 size, BufferUsage) final;
+		UniformBuffer *CreateUniformBuffer(Uint32 size, BufferUsage) final;
+		MeshObject *CreateMeshObject(VertexBuffer *v, IndexBuffer *i) final;
+		MeshObject *CreateMeshObjectFromArray(const VertexArray *v, IndexBuffer *i = nullptr, BufferUsage u = BUFFER_USAGE_STATIC) final;
 
-		virtual const RenderStateDesc &GetMaterialRenderState(const Graphics::Material *m) override final;
+		const RenderStateDesc &GetMaterialRenderState(const Graphics::Material *m) final;
 
 		const BufferBinding<UniformBuffer> &GetLightUniformBuffer();
 		OGL::UniformLinearBuffer *GetDrawUniformBuffer(Uint32 size);
 		OGL::RenderStateCache *GetStateCache() { return m_renderStateCache.get(); }
 
-		virtual bool ReloadShaders() override final;
+		bool ReloadShaders() final;
 
-		virtual bool Screendump(ScreendumpState &sd) override final;
+		bool Screendump(ScreendumpState &sd) final;
 
 		bool DrawMeshInternal(OGL::MeshObject *, PrimitiveType type);
 		bool DrawMeshInstancedInternal(OGL::MeshObject *, OGL::InstanceBuffer *, PrimitiveType type);
 		bool DrawMeshDynamicInternal(BufferBinding<OGL::VertexBuffer> vtxBind, BufferBinding<OGL::IndexBuffer> idxBind, PrimitiveType type);
 
 	protected:
-		virtual void PushState() override final{};
-		virtual void PopState() override final{};
+		void PushState() final{};
+		void PopState() final{};
 
 		size_t m_frameNum;
 

--- a/src/graphics/opengl/TextureGL.h
+++ b/src/graphics/opengl/TextureGL.h
@@ -11,19 +11,19 @@ namespace Graphics {
 	namespace OGL {
 		class TextureGL : public Texture {
 		public:
-			virtual void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final;
-			virtual void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) override final;
-			virtual void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips) override final;
+			void Update(const void *data, const vector2f &pos, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) final;
+			void Update(const TextureCubeData &data, const vector3f &dataSize, TextureFormat format, const unsigned int numMips) final;
+			void Update(const vecDataPtr &data, const vector3f &dataSize, const TextureFormat format, const unsigned int numMips) final;
 
 			TextureGL(const TextureDescriptor &descriptor, const bool useCompressed, const bool useAnisoFiltering, const Uint16 numSamples = 0);
 			virtual ~TextureGL();
 
-			virtual void Bind() override final;
-			virtual void Unbind() override final;
+			void Bind() final;
+			void Unbind() final;
 
-			virtual void SetSampleMode(TextureSampleMode) override final;
-			virtual void BuildMipmaps(const uint32_t validMips = 1) override final;
-			virtual uint32_t GetTextureID() const override final
+			void SetSampleMode(TextureSampleMode) final;
+			void BuildMipmaps(const uint32_t validMips = 1) final;
+			uint32_t GetTextureID() const final
 			{
 				static_assert(sizeof(uint32_t) == sizeof(GLuint));
 				return m_texture;

--- a/src/graphics/opengl/VertexBufferGL.h
+++ b/src/graphics/opengl/VertexBufferGL.h
@@ -19,21 +19,21 @@ namespace Graphics {
 			VertexBuffer(const VertexBufferDesc &, size_t stateHash);
 			~VertexBuffer();
 
-			virtual void Unmap() override;
+			void Unmap() override;
 
 			// copies the contents of the VertexArray into the buffer
-			virtual bool Populate(const VertexArray &) override;
+			bool Populate(const VertexArray &) override;
 
 			// change the buffer data without mapping
-			virtual void BufferData(const size_t, void *) override final;
+			void BufferData(const size_t, void *) final;
 
-			virtual void Bind() override final;
-			virtual void Release() override final;
+			void Bind() final;
+			void Release() final;
 
 			size_t GetVertexFormatHash() const { return m_vertexStateHash; }
 
 		protected:
-			virtual Uint8 *MapInternal(BufferMapMode) override;
+			Uint8 *MapInternal(BufferMapMode) override;
 			Uint8 *m_data;
 			size_t m_vertexStateHash;
 		};
@@ -42,7 +42,7 @@ namespace Graphics {
 		public:
 			CachedVertexBuffer(const VertexBufferDesc &, size_t stateHash);
 
-			virtual bool Populate(const VertexArray &) override final;
+			bool Populate(const VertexArray &) final;
 			uint32_t GetOffset() { return m_size * m_desc.stride; }
 
 			bool Flush();
@@ -62,15 +62,15 @@ namespace Graphics {
 			IndexBuffer(Uint32 size, BufferUsage, IndexBufferSize);
 			~IndexBuffer();
 
-			virtual Uint32 *Map(BufferMapMode) override final;
-			virtual Uint16 *Map16(BufferMapMode) override final;
-			virtual void Unmap() override final;
+			Uint32 *Map(BufferMapMode) final;
+			Uint16 *Map16(BufferMapMode) final;
+			void Unmap() final;
 
 			// change the buffer data without mapping
-			virtual void BufferData(const size_t, void *) override final;
+			void BufferData(const size_t, void *) final;
 
-			virtual void Bind() override final;
-			virtual void Release() override final;
+			void Bind() final;
+			void Release() final;
 
 		private:
 			Uint32 *m_data;
@@ -81,12 +81,12 @@ namespace Graphics {
 		class InstanceBuffer final : public Graphics::InstanceBuffer, public GLBufferBase {
 		public:
 			InstanceBuffer(Uint32 size, BufferUsage);
-			virtual ~InstanceBuffer() override final;
-			virtual matrix4x4f *Map(BufferMapMode) override final;
-			virtual void Unmap() override final;
+			~InstanceBuffer() final;
+			matrix4x4f *Map(BufferMapMode) final;
+			void Unmap() final;
 
-			virtual void Bind() override final;
-			virtual void Release() override final;
+			void Bind() final;
+			void Release() final;
 
 			enum InstOffs {
 				INSTOFFS_MAT0 = 6, // these value must match those of a_transform within data/shaders/opengl/attributes.glsl

--- a/src/lua/LuaBodyComponent.h
+++ b/src/lua/LuaBodyComponent.h
@@ -23,12 +23,12 @@ struct BodyComponentDB::LuaInterface final : LuaInterfaceBase {
 	{}
 	Pool<T> *pool;
 
-	virtual void PushToLua(const Body *body) override
+	void PushToLua(const Body *body) override
 	{
 		LuaObject<T>::PushComponentToLua(pool->get(body));
 	}
 
-	virtual void DeregisterComponent(const Body *body) override
+	void DeregisterComponent(const Body *body) override
 	{
 		LuaObjectBase::DeregisterObject(pool->get(body));
 	}

--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -54,9 +54,9 @@ public:
 		m_path(path),
 		m_inPlace(inPlace) {}
 
-	virtual void OnRun() override final { RunCompiler(m_name, m_path, m_inPlace); } // RUNS IN ANOTHER THREAD!! MUST BE THREAD SAFE!
-	virtual void OnFinish() override final {}
-	virtual void OnCancel() override final {}
+	void OnRun() final { RunCompiler(m_name, m_path, m_inPlace); } // RUNS IN ANOTHER THREAD!! MUST BE THREAD SAFE!
+	void OnFinish() final {}
+	void OnCancel() final {}
 
 protected:
 	std::string m_name;

--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -50,7 +50,7 @@ public:
 	{
 	}
 
-	virtual void OnExecute(TaskRange range) override
+	void OnExecute(TaskRange range) override
 	{
 		PROFILE_SCOPED()
 
@@ -96,7 +96,7 @@ public:
 		return true;
 	}
 
-	virtual void OnExecute(TaskRange range) override
+	void OnExecute(TaskRange range) override
 	{
 		PROFILE_SCOPED()
 
@@ -132,7 +132,7 @@ public:
 		}
 	}
 
-	virtual void OnComplete() override
+	void OnComplete() override
 	{
 		if (imageData)
 			delete[] imageData;

--- a/src/scenegraph/BinaryConverter.cpp
+++ b/src/scenegraph/BinaryConverter.cpp
@@ -37,12 +37,12 @@ public:
 		db.model = m;
 	}
 
-	virtual void ApplyNode(Node &n) override
+	void ApplyNode(Node &n) override
 	{
 		n.Save(db);
 	}
 
-	virtual void ApplyGroup(Group &g) override
+	void ApplyGroup(Group &g) override
 	{
 		ApplyNode(static_cast<Node &>(g));
 		db.wr->Int32(g.GetNumChildren());

--- a/src/scenegraph/CollisionGeometry.h
+++ b/src/scenegraph/CollisionGeometry.h
@@ -23,10 +23,10 @@ namespace SceneGraph {
 	public:
 		CollisionGeometry(Graphics::Renderer *r, const std::vector<vector3f> &, const std::vector<Uint32> &, unsigned int flag);
 		CollisionGeometry(const CollisionGeometry &, NodeCopyCache *cache = 0);
-		virtual Node *Clone(NodeCopyCache *cache = 0) override;
-		virtual const char *GetTypeName() const override { return "CollisionGeometry"; }
-		virtual void Accept(NodeVisitor &nv) override;
-		virtual void Save(NodeDatabase &) override;
+		Node *Clone(NodeCopyCache *cache = 0) override;
+		const char *GetTypeName() const override { return "CollisionGeometry"; }
+		void Accept(NodeVisitor &nv) override;
+		void Save(NodeDatabase &) override;
 		static CollisionGeometry *Load(NodeDatabase &);
 
 		const std::vector<vector3f> &GetVertices() const { return m_vertices; }

--- a/src/scenegraph/Group.h
+++ b/src/scenegraph/Group.h
@@ -14,9 +14,9 @@ namespace SceneGraph {
 	public:
 		Group(Graphics::Renderer *r);
 		Group(const Group &, NodeCopyCache *cache = 0);
-		virtual Node *Clone(NodeCopyCache *cache = 0) override;
-		virtual const char *GetTypeName() const override { return "Group"; }
-		virtual void Save(NodeDatabase &) override;
+		Node *Clone(NodeCopyCache *cache = 0) override;
+		const char *GetTypeName() const override { return "Group"; }
+		void Save(NodeDatabase &) override;
 		static Group *Load(NodeDatabase &);
 
 		virtual void AddChild(Node *child);
@@ -24,11 +24,11 @@ namespace SceneGraph {
 		virtual bool RemoveChildAt(unsigned int position); //true on success
 		unsigned int GetNumChildren() const { return static_cast<Uint32>(m_children.size()); }
 		Node *GetChildAt(unsigned int);
-		virtual void Accept(NodeVisitor &v) override;
-		virtual void Traverse(NodeVisitor &v) override;
-		virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
-		virtual void RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
-		virtual Node *FindNode(const std::string &) override;
+		void Accept(NodeVisitor &v) override;
+		void Traverse(NodeVisitor &v) override;
+		void Render(const matrix4x4f &trans, const RenderData *rd) override;
+		void RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
+		Node *FindNode(const std::string &) override;
 
 		// Walk the node hierarchy to the root of the model and compute the global transform of this node.
 		// The result of this *should* be cached if the model has not changed

--- a/src/scenegraph/LOD.h
+++ b/src/scenegraph/LOD.h
@@ -14,13 +14,13 @@ namespace SceneGraph {
 	public:
 		LOD(Graphics::Renderer *r);
 		LOD(const LOD &, NodeCopyCache *cache = 0);
-		virtual Node *Clone(NodeCopyCache *cache = 0) override;
-		virtual const char *GetTypeName() const override { return "LOD"; }
-		virtual void Accept(NodeVisitor &v) override;
-		virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
-		virtual void RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
+		Node *Clone(NodeCopyCache *cache = 0) override;
+		const char *GetTypeName() const override { return "LOD"; }
+		void Accept(NodeVisitor &v) override;
+		void Render(const matrix4x4f &trans, const RenderData *rd) override;
+		void RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
 		void AddLevel(float pixelRadius, Node *child);
-		virtual void Save(NodeDatabase &) override;
+		void Save(NodeDatabase &) override;
 		static LOD *Load(NodeDatabase &);
 
 	protected:

--- a/src/scenegraph/MatrixTransform.h
+++ b/src/scenegraph/MatrixTransform.h
@@ -26,20 +26,20 @@ namespace SceneGraph {
 		MatrixTransform(Graphics::Renderer *r, const matrix4x4f &m);
 		MatrixTransform(const MatrixTransform &, NodeCopyCache *cache = 0);
 
-		virtual Node *Clone(NodeCopyCache *cache = 0) override;
-		virtual const char *GetTypeName() const override { return "MatrixTransform"; }
-		virtual void Accept(NodeVisitor &v) override;
+		Node *Clone(NodeCopyCache *cache = 0) override;
+		const char *GetTypeName() const override { return "MatrixTransform"; }
+		void Accept(NodeVisitor &v) override;
 
-		virtual void Save(NodeDatabase &) override;
+		void Save(NodeDatabase &) override;
 		static MatrixTransform *Load(NodeDatabase &);
 
-		virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
-		virtual void RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
+		void Render(const matrix4x4f &trans, const RenderData *rd) override;
+		void RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
 
 		const matrix4x4f &GetTransform() const { return m_transform; }
 		void SetTransform(const matrix4x4f &m) { m_transform = m; }
 
-		virtual matrix4x4f CalcGlobalTransform() const override;
+		matrix4x4f CalcGlobalTransform() const override;
 
 	protected:
 		virtual ~MatrixTransform() {}

--- a/src/scenegraph/StaticGeometry.h
+++ b/src/scenegraph/StaticGeometry.h
@@ -26,13 +26,13 @@ namespace SceneGraph {
 		};
 		StaticGeometry(Graphics::Renderer *r);
 		StaticGeometry(const StaticGeometry &, NodeCopyCache *cache = 0);
-		virtual Node *Clone(NodeCopyCache *cache = 0) override;
-		virtual const char *GetTypeName() const override { return "StaticGeometry"; }
-		virtual void Accept(NodeVisitor &nv) override;
-		virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
-		virtual void RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
+		Node *Clone(NodeCopyCache *cache = 0) override;
+		const char *GetTypeName() const override { return "StaticGeometry"; }
+		void Accept(NodeVisitor &nv) override;
+		void Render(const matrix4x4f &trans, const RenderData *rd) override;
+		void RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd) override;
 
-		virtual void Save(NodeDatabase &) override;
+		void Save(NodeDatabase &) override;
 		static StaticGeometry *Load(NodeDatabase &);
 
 		void AddMesh(RefCountedPtr<Graphics::VertexBuffer>,

--- a/src/scenegraph/Tag.h
+++ b/src/scenegraph/Tag.h
@@ -20,11 +20,11 @@ namespace SceneGraph {
 		Tag(Graphics::Renderer *r, const matrix4x4f &m);
 		Tag(const Tag &, NodeCopyCache *cache = 0);
 
-		virtual Node *Clone(NodeCopyCache *cache = 0) override;
-		virtual const char *GetTypeName() const override { return "Tag"; }
-		virtual void Accept(NodeVisitor &v) override;
+		Node *Clone(NodeCopyCache *cache = 0) override;
+		const char *GetTypeName() const override { return "Tag"; }
+		void Accept(NodeVisitor &v) override;
 
-		virtual void Save(NodeDatabase &) override;
+		void Save(NodeDatabase &) override;
 		static Tag *Load(NodeDatabase &);
 
 		const matrix4x4f &GetGlobalTransform() const { return m_globalTransform; }

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -23,10 +23,10 @@ namespace SceneGraph {
 		Thruster(Graphics::Renderer *, bool linear, const vector3f &pos, const vector3f &dir);
 		Thruster(const Thruster &, NodeCopyCache *cache = 0);
 		Node *Clone(NodeCopyCache *cache = 0) override;
-		virtual void Accept(NodeVisitor &v) override;
-		virtual const char *GetTypeName() const override { return "Thruster"; }
-		virtual void Render(const matrix4x4f &trans, const RenderData *rd) override;
-		virtual void Save(NodeDatabase &) override;
+		void Accept(NodeVisitor &v) override;
+		const char *GetTypeName() const override { return "Thruster"; }
+		void Render(const matrix4x4f &trans, const RenderData *rd) override;
+		void Save(NodeDatabase &) override;
 		static Thruster *Load(NodeDatabase &);
 		void SetColor(const Color c) { currentColor = c; }
 		const vector3f &GetDirection() { return dir; }

--- a/src/ship/CameraController.h
+++ b/src/ship/CameraController.h
@@ -150,10 +150,10 @@ public:
 	const char *GetName() const override { return Lang::EXTERNAL_VIEW; }
 	bool IsExternal() const override { return true; }
 
-	virtual void PitchCamera(float amount) override { m_rotX += amount; }
-	virtual void YawCamera(float amount) override { m_rotY += amount; }
+	void PitchCamera(float amount) override { m_rotX += amount; }
+	void YawCamera(float amount) override { m_rotY += amount; }
 
-	virtual void SetRotationAngles(vector3f rotation) override
+	void SetRotationAngles(vector3f rotation) override
 	{
 		m_rotX = rotation.x;
 		m_rotY = rotation.y;

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -563,7 +563,7 @@ namespace Sound {
 			m_isMusic(isMusic)
 		{}
 
-		virtual void OnRun() override
+		void OnRun() override
 		{
 			PROFILE_SCOPED()
 			// TODO: this is *probably* thread-safe, but FileSystem could use some further evaluation
@@ -575,7 +575,7 @@ namespace Sound {
 			}
 		}
 
-		virtual void OnFinish() override
+		void OnFinish() override
 		{
 			for (const auto &pair : m_loadedSounds) {
 				sfx_samples.emplace(std::move(pair));


### PR DESCRIPTION
[C.128: Virtual functions should specify exactly one of virtual, override, or final](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines.html#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final)
I found out that there's an isocpp standard for this and decided that I'd see how much work it'd be to make us compliant with this and maybe shake out some bugs.

No issues found is the good news and after a LOT of edited files I don't think there's any cases of virtual, override, and/or final appearing in the same function declaration 👍 

Sadly this does touch on a LOT of files.