### PR TITLE
Fix billboard atlas animation playing order and frame count

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -783,6 +783,12 @@ void Pi::HandleKeyDown(SDL_Keysym *key)
 	case SDLK_F11: // Reload shaders
 		renderer->ReloadShaders();
 		break;
+
+	case SDLK_F8: // EXPLOSION!
+	{
+		SfxManager::AddExplosion(Pi::game->GetPlayer());
+		break;
+	}
 #endif /* DEVKEYS */
 
 #if WITH_OBJECTVIEWER

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -194,6 +194,8 @@ void SfxManager::Add(const Body *b, SFX_TYPE t)
 
 void SfxManager::AddExplosion(Body *b)
 {
+	if (!b) return;
+
 	SfxManager *sfxman = AllocSfxInFrame(b->GetFrame());
 	if (!sfxman) return;
 
@@ -311,7 +313,8 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 vector2f SfxManager::CalculateOffset(const enum SFX_TYPE type, const Sfx &inst)
 {
 	if (m_materialData[type].effect == Graphics::EFFECT_BILLBOARD_ATLAS) {
-		const int spriteframe = inst.AgeBlend() * (m_materialData[type].num_textures - 1);
+		const Uint32 max_texture = (m_materialData[type].num_textures);
+		const int spriteframe = max_texture - (inst.AgeBlend() * max_texture); // count DOWN from the maximum texture to zero
 		const Sint32 numImgsWide = m_materialData[type].num_imgs_wide;
 		const int u = (spriteframe % numImgsWide); // % is the "modulo operator", the remainder of i / width;
 		const int v = (spriteframe / numImgsWide); // where "/" is an integer division


### PR DESCRIPTION
Fixes #5881 

It looks like we had the texture atlas selection inverted so it was playing from the "end" of the atlases animation.

I say "inverted" and "end" but these are slightly arbitrary because we define what they should be. However starting at the top-left is a reasonable convention and not an arbitrary point within the texture atlas, progressing to the top-left which is how it was behaving.

This is a handy test atlas with numbers in each slot so you can change `Sfx.ini` to point to it, and then instead of the explosion you can see the numbers counting up.
[test_atlas.zip](https://github.com/user-attachments/files/18241664/test_atlas.zip)

Taking the above test-atlas you could see it counting down from 30 to 0, which I think most people would find odd.
![image](https://github.com/user-attachments/assets/258ab1bd-06e6-44cf-9e41-5f441287975f)

There was also an issue with it playing only 31 out of 32 frames of animation from the animation.

Finally I added the ability to press Ctrl+F8 if you're running a dev build with devkeys enables and it will spawn an explosion billboard right atop your ship. It's purely visual but very useful for testing, for example if someone wanted to replace the existing explosion etc, and could be extended to show other effects easily.

I've tested all of this quite a bit, sadly the texture supplied in the original bug by @Miner34dev isn't suitable for use as is because it fades to the black instead of alpha, and then terminates suddenly.