### PR TITLE
Fix several minor bugs

### DIFF
--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -299,6 +299,11 @@ function Ship:FireMissileAt(missile, target)
 		missile = equipSet:GetInstalledOfType("missile")[1]
 	end
 
+	-- No missile available to fire, likely this function was called from a C++ action binding
+	if not missile then
+		return nil
+	end
+
 	-- FIXME: handle multiple-count missile mounts
 	equipSet:Remove(missile)
 

--- a/data/modules/Debug/DebugShip.lua
+++ b/data/modules/Debug/DebugShip.lua
@@ -168,7 +168,12 @@ function DebugShipTool:onSpawnSelectedHull()
 		end
 
 		---@cast body SpaceStation
-		ship = ShipBuilder.MakeShipDocked(body, template, self.spawnThreat)
+		local ship = ShipBuilder.MakeShipDocked(body, template, self.spawnThreat)
+
+		if not ship then
+			Notification.add(Notification.Type.Error, "Can't spawn ship docked at {} - no room?" % { body.label })
+			return
+		end
 
 	elseif location == "Orbit" then
 

--- a/data/modules/MissionUtils/ShipBuilder.lua
+++ b/data/modules/MissionUtils/ShipBuilder.lua
@@ -418,10 +418,11 @@ function ShipBuilder.ApplyEquipmentRule(shipPlan, rule, rand, hullThreat)
 		---@type EquipType[]
 		local compatible = utils.map_array(filteredEquip, function(equip)
 			local threat = threatCache[equip]
-
-			local compat = EquipSet.CompatibleWithSlot(equip, slot)
-				and threat <= (shipPlan.freeThreat - reserveThreat)
+			local withinThreat = threat == 0
+				or threat <= (shipPlan.freeThreat - reserveThreat)
 				and threat <= maxThreat
+
+			local compat = EquipSet.CompatibleWithSlot(equip, slot) and withinThreat
 
 			if not compat then
 				return nil
@@ -607,6 +608,11 @@ function ShipBuilder.MakePlan(template, shipConfig, threat)
 	}
 
 	shipPlan:SetConfig(shipConfig)
+
+	if shipPlan.freeThreat <= 0 then
+		logWarning("ShipBuilder: {} has a hull threat of {}, greater than the provided threat {}. Ship will not be properly outfitted." % {
+			shipConfig.id, hullThreat, threat})
+	end
 
 	for _, rule in ipairs(template.rules) do
 

--- a/data/modules/MissionUtils/ShipBuilder.lua
+++ b/data/modules/MissionUtils/ShipBuilder.lua
@@ -795,7 +795,7 @@ end
 ---@param body SpaceStation
 ---@param template MissionUtils.ShipTemplate
 ---@param threat number?
----@return Ship
+---@return Ship?
 function ShipBuilder.MakeShipDocked(body, template, threat)
 	if not threat then
 		threat = Engine.rand:Number(ShipBuilder.kDefaultRandomThreatMin, ShipBuilder.kDefaultRandomThreatMax)
@@ -808,7 +808,11 @@ function ShipBuilder.MakeShipDocked(body, template, threat)
 	assert(plan)
 
 	local ship = Space.SpawnShipDocked(plan.shipId, body)
-	assert(ship)
+
+	-- All docks may be full...
+	if not ship then
+		return nil
+	end
 
 	ShipBuilder.ApplyPlan(ship, plan)
 

--- a/data/modules/Scoop/Scoop.lua
+++ b/data/modules/Scoop/Scoop.lua
@@ -219,10 +219,13 @@ local spawnPolice = function (station)
 
 	for i = 1, 2 do
 		ship = ShipBuilder.MakeShipDocked(station, template, threat)
-		table.insert(police, ship)
 
-		if station.type == "STARPORT_SURFACE" then
-			ship:AIEnterLowOrbit(Space.GetBody(station:GetSystemBody().parent.index))
+		if ship then
+			table.insert(police, ship)
+
+			if station.type == "STARPORT_SURFACE" then
+				ship:AIEnterLowOrbit(Space.GetBody(station:GetSystemBody().parent.index))
+			end
 		end
 	end
 

--- a/data/pigui/libs/notification.lua
+++ b/data/pigui/libs/notification.lua
@@ -162,7 +162,7 @@ local function drawNotification(notif, wrapWidth)
 	-- Draw the close button to the left of the notification in empty space
 	if hovered and not notif.closing then
 		ui.setCursorScreenPos(startPos)
-		local clicked = ui.iconButton(icons.retrograde, style.closeButtonSize, "##DismissNotification", ui.theme.buttonColors.transparent)
+		local clicked = ui.iconButton("DismissNotification", icons.retrograde, nil, ui.theme.buttonColors.transparent, style.closeButtonSize)
 
 		if clicked then
 			notif.closing = 0.0

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1643,6 +1643,8 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody *sbody, StarSys
 	// with respect to well-spaced orbital shells (e.g. a "station belt" around a high-population planet)
 	// as well as generating station placement for e.g. research, industrial, or communications stations
 
+	fixed totalPop = system->GetTotalPop();
+
 	if (sbody->GetPopulationAsFixed() < fixed(1, 1000)) return;
 	fixed orbMaxS = fixed(1, 4) * fixed(CalcHillRadius(sbody));
 	fixed orbMinS = fixed().FromDouble((sbody->CalcAtmosphereParams().atmosRadius + +500000.0 / EARTH_RADIUS)) * AU_EARTH_RADIUS;
@@ -1747,6 +1749,7 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody *sbody, StarSys
 				sp->m_orbMax = sp->GetSemiMajorAxisAsFixed();
 
 				sp->m_name = gen_unique_station_name(sp, system, namerand);
+				PopulateStage1(sp, system, totalPop);
 			}
 		}
 	}
@@ -1771,6 +1774,7 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody *sbody, StarSys
 		PositionSettlementOnPlanet(sp, previousOrbits);
 		sbody->m_children.insert(sbody->m_children.begin(), sp);
 		system->AddSpaceStation(sp);
+		PopulateStage1(sp, system, totalPop);
 	}
 
 	// guarantee that there is always a star port on a populated world
@@ -1786,7 +1790,10 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody *sbody, StarSys
 		PositionSettlementOnPlanet(sp, previousOrbits);
 		sbody->m_children.insert(sbody->m_children.begin(), sp);
 		system->AddSpaceStation(sp);
+		PopulateStage1(sp, system, totalPop);
 	}
+
+	system->SetTotalPop(totalPop);
 }
 
 void PopulateStarSystemGenerator::SetSysPolit(RefCountedPtr<Galaxy> galaxy, RefCountedPtr<StarSystem::GeneratorAPI> system, const fixed &human_infestedness)


### PR DESCRIPTION
- Fix ships spawned without enough threat value for the base hull receiving no equipment (fixes #6006)
- Fix assertion when spawning more police than a station has pads (no linked issue)
- Fix assertion when pressing the missile fire keybind with no installed missiles (fixes #6007)
- Fix assertion when hovering a notification (fixes #6004)
- Fix randomly-generated starports not having a population (fixes #5955).

The last one is the most interesting. Starports defined in custom system files exist when `PopulateStarSystemGenerator::PopulateStage1()` is called, but randomly-generated starports are only added afterwards, in `PopulateAddStations()`. This lead to a lack of actual population onboard those stations, which at current only manifested in a lack of paintshops outside of fully-custom systems.