### PR TITLE
More bugfixes and improvements

### DIFF
--- a/data/factions/079_Tolisian_Scientific_Community.lua
+++ b/data/factions/079_Tolisian_Scientific_Community.lua
@@ -1,7 +1,7 @@
 -- Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-local f = Faction:new('Tolisian Scientific Community"')
+local f = Faction:new('Tolisian Scientific Community')
 	:description_short('Worlds who have submitted to the rule of a group of elite scientists called the Tolisians')
 	:description('')
 	:homeworld(4,-1,9, 0, 0)

--- a/data/modules/Debug/CheckShipData.lua
+++ b/data/modules/Debug/CheckShipData.lua
@@ -46,7 +46,7 @@ local function checkSlot(slot)
 	end
 
 	if EquipSet.SlotTypeMatches(slot.type, "hyperdrive") and not slot.default then
-		warn("Slot {id} has no default hyperdrive equipment." % slot)
+		info("Slot {id} has no default hyperdrive equipment and will not have a hyperdrive when purchased." % slot)
 	end
 
 	if slot.i18n_key then
@@ -75,7 +75,7 @@ local function checkSlot(slot)
 		end
 
 		if not slot.tag then
-			info("External slot {id} with type {type} is missing an associated tag." % slot)
+			warn("External slot {id} with type {type} is missing an associated tag." % slot)
 		end
 
 	end
@@ -120,7 +120,7 @@ local function checkShipDef(shipDef)
 	end
 
 	if not shipDef.shipClass or shipDef.shipClass == "" then
-		warn("Ship {id} has invalid/empty ship_class field." % shipDef)
+		warn("Ship {id} has missing/empty ship_class field." % shipDef)
 	end
 
 	if not shipDef.manufacturer then

--- a/data/pigui/views/debug.lua
+++ b/data/pigui/views/debug.lua
@@ -11,15 +11,14 @@ local childWindowFlags = ui.WindowFlags { "NoSavedSettings", "NoBackground" }
 
 local function drawTab(tab, i, delta)
 	local icon = tab.icon or ui.theme.icons.alert_generic
-	local label = tab.label or ""
 	local icon_str = "{}##{}" % { ui.get_icon_glyph(icon), i }
 
 	local active = false
 
-	ui.tabItem(icon_str, label, function()
+	ui.tabItem(icon_str, tab.label, function()
 		active = true
 
-		ui.child(label, Vector2(0, 0), childWindowFlags, function()
+		ui.child(tab.label, Vector2(0, 0), childWindowFlags, function()
 			tab.draw(tab, delta)
 		end)
 	end)
@@ -38,16 +37,10 @@ end
 ---@param name string
 ---@param tab Debug.DebugTab
 function debugView.registerTab(name, tab)
-	if type(tab) == "function" then
-		tab = {
-			icon = ui.theme.icons.alert_generic,
-			draw = tab
-		}
-	end
+	assert(type(tab) == "table", "Must pass a DebugTab table to debugView.registerTab()")
 
-	if not tab.module then
-		tab.module = package.modulename(2)
-	end
+	tab.label = tab.label or ""
+	tab.module = tab.module or package.modulename(2)
 
 	local index = debugView.tabs[name] or #debugView.tabs + 1
 	debugView.tabs[index] = tab

--- a/data/pigui/views/mainmenu.lua
+++ b/data/pigui/views/mainmenu.lua
@@ -147,7 +147,10 @@ local function showMainMenu()
 			ui.window("shipinfoWindow", overlayWindowFlags, function()
 				local mn = Engine.GetIntroCurrentModelName()
 				if mn then
-					local sd = ShipDef[mn]
+					-- TODO: this is kind of hacky, Intro should use shipdefs instead of models...
+					local sd = require 'utils'.to_array(ShipDef, function(def)
+						return def.modelName == mn
+					end)[1]
 					if sd then
 						ui.addFancyText(Vector2(ui.screenWidth / 3, ui.screenHeight / 5.0 * 4), ui.anchor.center, ui.anchor.bottom, {{text=sd.name, color=colors.white, font=orbiteer.medlarge}}, colors.transparent)
 						ui.addFancyText(Vector2(ui.screenWidth / 3, ui.screenHeight / 5.0 * 4.02), ui.anchor.center, ui.anchor.top, {{text=lui[sd.shipClass:upper()], color=colors.white, font=orbiteer.medium}}, colors.transparent)

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -446,6 +446,8 @@ namespace Background {
 		m_pointSprites.reset(new Graphics::Drawables::PointSprites);
 
 		const Uint32 NUM_BG_STARS = MathUtil::mix(BG_STAR_MIN, BG_STAR_MAX, Pi::GetAmountBackgroundStars());
+		m_animMesh.reset();
+
 		// user doesn't want to see stars
 		if (NUM_BG_STARS == BG_STAR_MIN) return;
 
@@ -610,6 +612,9 @@ namespace Background {
 		if (!Pi::game || Pi::player->GetFlightState() != Ship::HYPERSPACE) {
 			m_pointSprites->Draw(m_renderer, m_material.Get());
 		} else {
+			if (!m_animMesh) // user doesn't want to see stars
+				return;
+
 			Graphics::VertexBuffer *buffer = m_animMesh->GetVertexBuffer();
 			assert(sizeof(StarVert) == 16);
 			assert(buffer->GetDesc().stride == sizeof(StarVert));

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -195,6 +195,7 @@ bool StarSystemFromSectorGenerator::Apply(Random &rng, RefCountedPtr<Galaxy> gal
 	assert(system->GetPath().systemIndex < sec->m_systems.size());
 	const Sector::System &secSys = sec->m_systems[system->GetPath().systemIndex];
 
+	system->SetPosition(secSys.GetPosition());
 	system->SetFaction(galaxy->GetFactions()->GetNearestClaimant(&secSys));
 	system->SetSeed(secSys.GetSeed());
 	system->SetName(secSys.GetName());


### PR DESCRIPTION
- Fixed a (potential) issue where the main menu doesn't know how to find the ship its displaying if the name of the model doesn't exactly match the name of the shipdef.
- Amended some validation warnings/errors to shuffle around their severity.
- Fixed a rogue trailing quote in the Tolisay faction name.
- Fixed #6022.
- Fixed #5880.
- Fixed #6012.

As is traditional for my microfix PRs in the weeks leading up to release, this is getting merged quite quickly.