### PR TITLE
New hyperdrive algorithms and internal hyperfuel tanks

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2690,5 +2690,9 @@
   "ZOOM": {
     "description": "Label for a zoom (magnification) control bar.",
     "message": "Zoom"
+  },
+  "TRANSFER_FUEL": {
+    "description": "Label indicating the ability to transfer fuel between equipment tanks",
+    "message": "Transfer Fuel"
   }
 }

--- a/data/libs/EquipSet.lua
+++ b/data/libs/EquipSet.lua
@@ -16,7 +16,7 @@ local utils = require 'utils'
 ---@field New fun(ship: Ship): EquipSet
 local EquipSet = utils.class("EquipSet")
 
----@alias EquipSet.Listener fun(op: 'install'|'remove', equip: EquipType, slot: HullConfig.Slot?)
+---@alias EquipSet.Listener fun(op: 'install'|'remove'|'modify', equip: EquipType, slot: HullConfig.Slot?)
 
 -- Function: SlotTypeMatches
 --
@@ -417,6 +417,18 @@ end
 -- Remove a previously-registered event listener function.
 function EquipSet:RemoveListener(fun)
 	utils.remove_elem(self.listeners, fun)
+end
+
+-- Method: NotifyListeners
+--
+-- Send a notification event to listeners.
+---@param op string The type of event to send.
+---@param equipment EquipType The equipment item generating the event
+---@param slot HullConfig.Slot? The slot handle on this EquipSet that is relevant to the event
+function EquipSet:NotifyListeners(op, equipment, slot)
+	for _, listener in ipairs(self.listeners) do
+		listener(op, equipment, slot)
+	end
 end
 
 -- Method: Install

--- a/data/libs/HullConfig.lua
+++ b/data/libs/HullConfig.lua
@@ -49,12 +49,7 @@ HullConfig.equipCapacity = 0
 -- Individual shipdefs can redefine slots or remove them by setting the slot to 'false'
 ---@type table<string, HullConfig.Slot>
 HullConfig.slots = {
-	sensor     = Slot:clone { type = "sensor",     size = 1 },
-	computer_1 = Slot:clone { type = "computer",   size = 1 },
-	hull_mod   = Slot:clone { type = "hull",       size = 1 },
-	structure  = Slot:clone { type = "structure",  size = 1 },
-	hyperdrive = Slot:clone { type = "hyperdrive", size = 1 },
-	thruster   = Slot:clone { type = "thruster",   size = 1 },
+	sensor = Slot:clone { type = "sensor", size = 1 },
 }
 
 function HullConfig:__clone()

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -241,14 +241,11 @@ Ship.GetHyperspaceDetails = function (self, source, destination)
 	local distance, fuel, duration = engine:CheckJump(self, source, destination)
 	local status = "OK"
 
-	---@type CargoManager
-	local cargoMgr = self:GetComponent('CargoManager')
-
 	if not duration then
 		duration = 0
 		fuel = 0
 		status = "OUT_OF_RANGE"
-	elseif fuel > cargoMgr:CountCommodity(engine.fuel) then
+	elseif fuel > engine.storedFuel then
 		status = "INSUFFICIENT_FUEL"
 	end
 	return status, distance, fuel, duration

--- a/data/meta/CoreObject/Body.meta.lua
+++ b/data/meta/CoreObject/Body.meta.lua
@@ -50,6 +50,10 @@ function Body:isa(type) end
 ---@param value any NOTE: functions, tables, and coroutines cannot be set as body properties
 function Body:setprop(key, value) end
 
+-- Clears the given body property
+---@param key string
+function Body:unsetprop(key) end
+
 -- Check if the given property exists on the body
 ---@param key string
 ---@return boolean

--- a/data/modules/Debug/CheckShipData.lua
+++ b/data/modules/Debug/CheckShipData.lua
@@ -102,6 +102,22 @@ local function checkConfig(config)
 		warn("Ship {id} has no thruster slots. This may break in the future.")
 	end
 
+	if utils.count(findMatchingSlots(config, "hull")) == 0 then
+		info("Ship {id} has no hull modification slots." % config)
+	end
+
+	if utils.count(findMatchingSlots(config, "structure")) == 0 then
+		info("Ship {id} has no structural modification slots." % config)
+	end
+
+	if utils.count(findMatchingSlots(config, "computer")) == 0 then
+		info("Ship {id} has no computer equipment slots." % config)
+	end
+
+	if utils.count(findMatchingSlots(config, "sensor")) == 0 then
+		info("Ship {id} has no sensor slots." % config)
+	end
+
 	-- TODO: more validation passes on the whole ship config
 end
 

--- a/data/modules/Equipment/Hyperdrive.lua
+++ b/data/modules/Equipment/Hyperdrive.lua
@@ -15,6 +15,7 @@ Equipment.Register("hyperspace.hyperdrive_1", HyperdriveType.New {
 	l10n_key="DRIVE_CLASS1", fuel=Commodities.hydrogen,
 	slot = { type="hyperdrive.civilian", size=1 },
 	mass=1.4, volume=2.5, capabilities={ hyperclass=1 },
+	fuel_resv_size = 1, factor_eff = 65,
 	price=1700, purchasable=true, tech_level=3,
 	icon_name="equip_hyperdrive"
 })
@@ -22,6 +23,7 @@ Equipment.Register("hyperspace.hyperdrive_2", HyperdriveType.New {
 	l10n_key="DRIVE_CLASS2", fuel=Commodities.hydrogen,
 	slot = { type="hyperdrive.civilian", size=2 },
 	mass=4, volume=6, capabilities={ hyperclass=2 },
+	fuel_resv_size = 4, factor_eff = 60,
 	price=2300, purchasable=true, tech_level=4,
 	icon_name="equip_hyperdrive"
 })
@@ -29,6 +31,7 @@ Equipment.Register("hyperspace.hyperdrive_3", HyperdriveType.New {
 	l10n_key="DRIVE_CLASS3", fuel=Commodities.hydrogen,
 	slot = { type="hyperdrive.civilian", size=3 },
 	mass=9.5, volume=15, capabilities={ hyperclass=3 },
+	fuel_resv_size = 10, factor_eff = 55,
 	price=7500, purchasable=true, tech_level=4,
 	icon_name="equip_hyperdrive"
 })
@@ -36,6 +39,7 @@ Equipment.Register("hyperspace.hyperdrive_4", HyperdriveType.New {
 	l10n_key="DRIVE_CLASS4", fuel=Commodities.hydrogen,
 	slot = { type="hyperdrive.civilian", size=4 },
 	mass=25, volume=40, capabilities={ hyperclass=4 },
+	fuel_resv_size = 30, factor_eff = 42,
 	price=21000, purchasable=true, tech_level=6,
 	icon_name="equip_hyperdrive"
 })
@@ -43,6 +47,7 @@ Equipment.Register("hyperspace.hyperdrive_5", HyperdriveType.New {
 	l10n_key="DRIVE_CLASS5", fuel=Commodities.hydrogen,
 	slot = { type="hyperdrive.civilian", size=5 },
 	mass=76, volume=120, capabilities={ hyperclass=5 },
+	fuel_resv_size = 75, factor_eff = 35,
 	price=68000, purchasable=true, tech_level=7,
 	icon_name="equip_hyperdrive"
 })
@@ -52,6 +57,7 @@ Equipment.Register("hyperspace.hyperdrive_6", HyperdriveType.New {
 	l10n_key="DRIVE_CLASS6", fuel=Commodities.hydrogen,
 	slot = { type="hyperdrive.civilian", size=6 },
 	mass=152, volume=340, capabilities={ hyperclass=6 },
+	fuel_resv_size = 120, factor_eff = 30,
 	price=129000, purchasable=true, tech_level=7,
 	icon_name="equip_hyperdrive"
 })
@@ -60,6 +66,7 @@ Equipment.Register("hyperspace.hyperdrive_7", HyperdriveType.New {
 	l10n_key="DRIVE_CLASS7", fuel=Commodities.hydrogen,
 	slot = { type="hyperdrive.civilian", size=7 },
 	mass=540, volume=960, capabilities={ hyperclass=7 },
+	fuel_resv_size = 350, factor_eff = 25,
 	price=341000, purchasable=true, tech_level=9,
 	icon_name="equip_hyperdrive"
 })
@@ -71,63 +78,40 @@ Equipment.Register("hyperspace.hyperdrive_7", HyperdriveType.New {
 Equipment.Register("hyperspace.hyperdrive_mil1", HyperdriveType.New {
 	l10n_key="DRIVE_MIL1", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
 	slot = { type="hyperdrive.military", size=1 },
-	mass=1, volume=1, capabilities={ hyperclass=1 },
+	mass=2, volume=2.5, capabilities={ hyperclass=1 },
+	fuel_resv_size = 1, factor_eff = 75,
 	price=23000, purchasable=true, tech_level=10,
 	icon_name="equip_hyperdrive_mil"
 })
 Equipment.Register("hyperspace.hyperdrive_mil2", HyperdriveType.New {
 	l10n_key="DRIVE_MIL2", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
 	slot = { type="hyperdrive.military", size=2 },
-	mass=3, volume=3, capabilities={ hyperclass=2 },
+	mass=5.5, volume=6, capabilities={ hyperclass=2 },
+	fuel_resv_size = 4, factor_eff = 68,
 	price=47000, purchasable=true, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
 Equipment.Register("hyperspace.hyperdrive_mil3", HyperdriveType.New {
 	l10n_key="DRIVE_MIL3", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
 	slot = { type="hyperdrive.military", size=3 },
-	mass=5, volume=5, capabilities={ hyperclass=3 },
+	mass=12.5, volume=15, capabilities={ hyperclass=3 },
+	fuel_resv_size = 10, factor_eff = 60,
 	price=85000, purchasable=true, tech_level=11,
 	icon_name="equip_hyperdrive_mil"
 })
 Equipment.Register("hyperspace.hyperdrive_mil4", HyperdriveType.New {
 	l10n_key="DRIVE_MIL4", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
 	slot = { type="hyperdrive.military", size=4 },
-	mass=13, volume=13, capabilities={ hyperclass=4 },
+	mass=32, volume=40, capabilities={ hyperclass=4 },
+	fuel_resv_size = 30, factor_eff = 48,
 	price=214000, purchasable=true, tech_level=12,
 	icon_name="equip_hyperdrive_mil"
 })
 Equipment.Register("hyperspace.hyperdrive_mil5", HyperdriveType.New {
 	l10n_key="DRIVE_MIL5", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
 	slot = { type="hyperdrive.military", size=5 },
-	mass=29, volume=29, capabilities={ hyperclass=5 },
+	mass=105, volume=120, capabilities={ hyperclass=5 },
+	fuel_resv_size = 75, factor_eff = 42,
 	price=540000, purchasable=false, tech_level="MILITARY",
-	icon_name="equip_hyperdrive_mil"
-})
-Equipment.Register("hyperspace.hyperdrive_mil6", HyperdriveType.New {
-	l10n_key="DRIVE_MIL6", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
-	slot = { type="hyperdrive.military", size=6 },
-	mass=60, volume=60, capabilities={ hyperclass=6 },
-	price=1350000, purchasable=false, tech_level="MILITARY",
-	icon_name="equip_hyperdrive_mil"
-})
-Equipment.Register("hyperspace.hyperdrive_mil7", HyperdriveType.New {
-	l10n_key="DRIVE_MIL7", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
-	slot = { type="hyperdrive.military", size=7 },
-	mass=135, volume=135, capabilities={ hyperclass=7 },
-	price=3500000, purchasable=false, tech_level="MILITARY",
-	icon_name="equip_hyperdrive_mil"
-})
-Equipment.Register("hyperspace.hyperdrive_mil8", HyperdriveType.New {
-	l10n_key="DRIVE_MIL8", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
-	slot = { type="hyperdrive.military", size=8 },
-	mass=190, volume=190, capabilities={ hyperclass=8 },
-	price=8500000, purchasable=false, tech_level="MILITARY",
-	icon_name="equip_hyperdrive_mil"
-})
-Equipment.Register("hyperspace.hyperdrive_mil9", HyperdriveType.New {
-	l10n_key="DRIVE_MIL9", fuel=Commodities.military_fuel, byproduct=Commodities.radioactives,
-	slot = { type="hyperdrive.military", size=9 },
-	mass=260, volume=260, capabilities={ hyperclass=9 },
-	price=22000000, purchasable=false, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })

--- a/data/modules/MissionUtils/OutfitRules.lua
+++ b/data/modules/MissionUtils/OutfitRules.lua
@@ -93,7 +93,10 @@ OutfitRules.DefaultPassengerCabins = {
 }
 
 OutfitRules.DefaultHyperdrive = {
-	slot = "hyperdrive"
+	slot = "hyperdrive",
+	apply = function(equip) ---@param equip Equipment.HyperdriveType
+		equip:SetFuel(nil, equip:GetMaxFuel())
+	end
 }
 
 OutfitRules.DefaultAtmoShield = {

--- a/data/modules/MissionUtils/OutfitRules.lua
+++ b/data/modules/MissionUtils/OutfitRules.lua
@@ -92,8 +92,16 @@ OutfitRules.DefaultPassengerCabins = {
 	filter = "cabin.passenger"
 }
 
+OutfitRules.AnyHyperdrive = {
+	slot = "hyperdrive",
+	apply = function(equip) ---@param equip Equipment.HyperdriveType
+		equip:SetFuel(nil, equip:GetMaxFuel())
+	end
+}
+
 OutfitRules.DefaultHyperdrive = {
 	slot = "hyperdrive",
+	filter = "hyperdrive.civilian",
 	apply = function(equip) ---@param equip Equipment.HyperdriveType
 		equip:SetFuel(nil, equip:GetMaxFuel())
 	end

--- a/data/modules/MissionUtils/OutfitRules.lua
+++ b/data/modules/MissionUtils/OutfitRules.lua
@@ -16,6 +16,7 @@ local OutfitRules = {}
 ---@field maxThreatFactor number? Maximum proportion of remaining threat that can be consumed by this rule
 ---@field randomChance number? Random chance to apply this rule, in [0..1]
 ---@field balance boolean? Attempt to balance volume / threat across all slots this rule matches (works best with .pick = nil)
+---@field apply fun(equip: EquipType)? Make custom changes to the selected equipment before it is installed in the ship
 
 OutfitRules.DifficultWeapon = {
 	slot = "weapon",

--- a/data/modules/MissionUtils/ShipBuilder.lua
+++ b/data/modules/MissionUtils/ShipBuilder.lua
@@ -361,6 +361,10 @@ function ShipBuilder.ApplyEquipmentRule(shipPlan, rule, rand, hullThreat)
 					inst:SetCount(slot.count)
 				end
 
+				if rule.apply then
+					rule.apply(inst)
+				end
+
 				if shipPlan.freeVolume >= inst.volume then
 					shipPlan:AddEquipToPlan(equip, slot, threat)
 				end
@@ -437,6 +441,10 @@ function ShipBuilder.ApplyEquipmentRule(shipPlan, rule, rand, hullThreat)
 
 			if slot.count then
 				inst:SetCount(slot.count)
+			end
+
+			if rule.apply then
+				rule.apply(inst)
 			end
 
 			return shipPlan.freeVolume >= inst.volume and inst or nil
@@ -652,13 +660,20 @@ function ShipBuilder.MakePlan(template, shipConfig, threat)
 			if rule.slot then
 				ShipBuilder.ApplyEquipmentRule(shipPlan, rule, Engine.rand, hullThreat)
 			else
-				local equip = Equipment.Get(rule.equip)
-				assert(equip)
+				local inst = assert(Equipment.Get(rule.equip)):Instance()
 
-				local equipThreat = ShipBuilder.ComputeEquipThreatFactor(equip, hullThreat)
+				if inst.SpecializeForShip then
+					inst:SpecializeForShip(shipPlan.config)
+				end
 
-				if shipPlan.freeVolume >= equip.volume and shipPlan.freeThreat >= equipThreat then
-					shipPlan:AddEquipToPlan(equip)
+				if rule.apply then
+					rule.apply(inst)
+				end
+
+				local equipThreat = ShipBuilder.ComputeEquipThreatFactor(inst, hullThreat)
+
+				if shipPlan.freeVolume >= inst.volume and shipPlan.freeThreat >= equipThreat then
+					shipPlan:AddEquipToPlan(inst)
 				end
 			end
 

--- a/data/modules/MissionUtils/ShipTemplates.lua
+++ b/data/modules/MissionUtils/ShipTemplates.lua
@@ -135,7 +135,7 @@ ShipTemplates.GenericMercenary = ShipBuilder.Template:clone {
 		utils.mixin(OutfitRules.DefaultLaserCooling, { minThreat = 40.0 }),
 		utils.mixin(OutfitRules.DefaultShieldBooster, { minThreat = 30.0 }),
 		-- Default equipment in remaining space
-		OutfitRules.DefaultHyperdrive,
+		OutfitRules.AnyHyperdrive,
 		OutfitRules.DefaultAtmoShield,
 		OutfitRules.DefaultRadar,
 	}

--- a/data/modules/TradeShips/Events.lua
+++ b/data/modules/TradeShips/Events.lua
@@ -130,7 +130,7 @@ local onShipDocked = function (ship, starport)
 		ship:SetHullPercent()
 		Trader.addEquip(ship)
 	end
-	Trader.addFuel(ship)
+	Trader.addHyperdriveFuel(ship)
 	ship:SetFuelPercent()
 
 	if trader.status == 'docked' then

--- a/data/modules/TradeShips/Flow.lua
+++ b/data/modules/TradeShips/Flow.lua
@@ -464,12 +464,8 @@ Flow.spawnInitialShips = function()
 			Core.ships[ship] = { ts_error = "OK", status = 'inbound', starport = params.to, ship_name	= params.id}
 
 			Trader.addEquip(ship)
-			local fuel_added = Trader.addFuel(ship)
+			Trader.addHyperdriveFuel(ship, hj_route.fuel)
 			Trader.addCargo(ship, 'import')
-
-			if fuel_added and fuel_added > 0 then
-				Trader.removeFuel(ship, math.min(hj_route.fuel, fuel_added))
-			end
 
 			Space.PutShipOnRoute(ship, params.to, Engine.rand:Number(0.0, 0.999))-- don't generate at the destination
 			ship:AIDockWith(params.to)

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -41,7 +41,7 @@ local function shipStats()
 	local up_acc = player:GetAcceleration("up")
 
 	local atmo_shield = equipSet:GetInstalledOfType("hull.atmo_shield")[1]
-	local atmo_shield_cap = player["atmo_shield_cap"]
+	local atmo_shield_cap = player["atmo_shield_cap"] or 1
 
 	textTable.draw({
 		{ l.REGISTRATION_NUMBER..":",	shipLabel},

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -25,10 +25,6 @@ local buttonSpaceSize = iconSize
 -- Need a style-var query system for best effect
 local itemSpacing = ui.rescaleUI(Vector2(6, 12), Vector2(1600, 900))
 
-local shipDef
-local hyperdrive
-local hyperdrive_fuel
-
 local jettison = function (item)
 	local enabled = Game.player.flightState == "FLYING"
 	local variant = enabled and ui.theme.buttonColors.default or ui.theme.buttonColors.disabled
@@ -146,21 +142,18 @@ end
 -- Gauge bar for internal, interplanetary, fuel tank
 local function gauge_fuel()
 	local player = Game.player
+	local tankSize = ShipDef[player.shipId].fuelTankMass
 	local text = string.format(l.FUEL .. ": %dt \t" .. l.DELTA_V .. ": %d km/s",
-		shipDef.fuelTankMass/100 * player.fuel, player:GetRemainingDeltaV()/1000)
+		tankSize/100 * player.fuel, player:GetRemainingDeltaV()/1000)
 
 	gauge_bar(player.fuel, text, 0, 100, icons.fuel)
 end
 
 -- Gauge bar for hyperdrive fuel / range
-local function gauge_hyperdrive()
-	---@type CargoManager
-	local cargoMgr = Game.player:GetComponent('CargoManager')
-	local fuel = cargoMgr:CountCommodity(hyperdrive_fuel)
+local function gauge_hyperdrive(drive)
+	local text = string.format(l.FUEL .. ": %%0.1ft \t" .. l.HYPERSPACE_RANGE .. ": %0.1f " .. l.LY, Game.player:GetHyperspaceRange())
 
-	local text = string.format(l.FUEL .. ": %%dt \t" .. l.HYPERSPACE_RANGE .. ": %d " .. l.LY, Game.player:GetHyperspaceRange())
-
-	gauge_bar(fuel, text, 0, cargoMgr:GetFreeSpace() + fuel, icons.hyperspace)
+	gauge_bar(drive.storedFuel, text, 0, drive:GetMaxFuel(), icons.hyperspace)
 end
 
 -- Gauge bar for used/free cargo space
@@ -181,6 +174,92 @@ local function gauge_cabins()
 
 	gauge_bar(berths_used, string.format('%%i %s / %i %s', l.USED, berths_free, l.FREE),
 		0, berths_total, icons.personal)
+end
+
+---@param hyperdrive Equipment.HyperdriveType
+local function transfer_hyperfuel_hydrogen(hyperdrive, amt)
+	local fuelTankSize = ShipDef[Game.player.shipId].fuelTankMass
+	local fuelMassLeft = Game.player.fuelMassLeft
+
+	-- Ensure we're not transferring more than the hyperdrive holds
+	local delta = math.clamp(amt, -hyperdrive.storedFuel, hyperdrive:GetMaxFuel() - hyperdrive.storedFuel)
+	-- Ensure we're not transferring more than the fuel tank holds
+	delta = math.clamp(delta, fuelMassLeft - fuelTankSize, fuelMassLeft)
+
+	if math.abs(delta) > 0.0001 then
+		Game.player:SetFuelPercent((fuelMassLeft - delta) * 100 / fuelTankSize)
+		hyperdrive:SetFuel(Game.player, hyperdrive.storedFuel + delta)
+	end
+end
+
+---@param hyperdrive Equipment.HyperdriveType
+local function transfer_hyperfuel_mil(hyperdrive, amt)
+	local cargoMgr = Game.player:GetComponent('CargoManager')
+	local availableFuel = cargoMgr:CountCommodity(hyperdrive.fuel)
+	local availableCargo = cargoMgr:GetFreeSpace()
+
+	-- Ensure we're not transferring more than the hyperdrive holds
+	local delta = math.clamp(amt, -hyperdrive.storedFuel, hyperdrive:GetMaxFuel() - hyperdrive.storedFuel)
+	-- Ensure we're not transferring more than the cargo bay holds
+	delta = math.clamp(delta, -availableCargo, availableFuel)
+
+	-- TODO(CargoManager): liquid tanks / partially-filled cargo containers
+	-- Until then, we round down to a whole integer in both directions since we're dealing with integer cargo masses
+	delta = math.modf(delta)
+
+	if delta > 0 then
+		cargoMgr:RemoveCommodity(hyperdrive.fuel, delta)
+		hyperdrive:SetFuel(Game.player, hyperdrive.storedFuel + delta)
+	elseif delta < 0 then
+		cargoMgr:AddCommodity(hyperdrive.fuel, math.abs(delta))
+		hyperdrive:SetFuel(Game.player, hyperdrive.storedFuel + delta)
+	end
+end
+
+local function fuelTransferButton(drive, amt)
+	local icon = amt < 0 and icons.chevron_down or icons.chevron_up
+
+	if ui.button(ui.get_icon_glyph(icon) .. tostring(math.abs(amt))) then
+
+		if drive.fuel == Commodities.hydrogen then
+			transfer_hyperfuel_hydrogen(drive, amt)
+		elseif drive.fuel == Commodities.military_fuel then
+			transfer_hyperfuel_mil(drive, amt)
+		end
+
+	end
+end
+
+local function drawCentered(id, fun)
+	if not ui.beginTable(id .. "##centered", 3) then return end
+
+	ui.tableSetupColumn("leftPadding")
+	ui.tableSetupColumn("content", { "WidthFixed" })
+	ui.tableSetupColumn("rightPadding")
+
+	ui.tableNextRow()
+	ui.tableSetColumnIndex(1)
+
+	fun()
+
+	ui.endTable()
+end
+
+local function drawFuelTransfer(drive)
+	-- Don't allow transferring fuel while the hyperdrive is doing its thing
+	if Game.player:IsHyperspaceActive() then return end
+
+	drawCentered("Hyperdrive", function()
+		ui.horizontalGroup(function()
+			fuelTransferButton(drive, 10)
+			fuelTransferButton(drive, 1)
+
+			ui.text(l.TRANSFER_FUEL)
+
+			fuelTransferButton(drive, -1)
+			fuelTransferButton(drive, -10)
+		end)
+	end)
 end
 
 local function drawPumpDialog()
@@ -224,13 +303,22 @@ end
 
 local function drawEconTrade()
 	local player = Game.player
+	local drive = player:GetInstalledHyperdrive()
 
 	ui.withFont(orbiteer.heading, function() ui.text(l.FUEL) end)
 
 	gauge_fuel()
-	gauge_hyperdrive()
 
-	drawPumpDialog()
+	drawCentered("Pump Dialog", function()
+		drawPumpDialog()
+	end)
+
+	if drive then
+		ui.withFont(orbiteer.heading, function() ui.text(l.HYPERDRIVE) end)
+
+		gauge_hyperdrive(drive)
+		drawFuelTransfer(drive)
+	end
 
 	ui.newLine()
 	ui.withFont(orbiteer.heading, function() ui.text(l.CABINS) end)
@@ -287,10 +375,6 @@ InfoView:registerView({
 		Game.player:GetComponent('CargoManager'):AddListener('econ-trade', function (type, count)
 			if type:Class() == CommodityType then cachedCargoList = nil end
 		end)
-
-		shipDef = ShipDef[Game.player.shipId]
-		hyperdrive = Game.player:GetInstalledHyperdrive()
-		hyperdrive_fuel = hyperdrive and hyperdrive.fuel or Commodities.hydrogen
 	end,
 
 	debugReload = function()

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -206,7 +206,7 @@ local function buyShip (mkt, sos)
 		if equipSet:CanInstallInSlot(handle, pair[2]) then
 			equipSet:Install(pair[2], handle)
 		else
-			logWarning("Default equipment item {} for ship slot {}.{} is not compatible with slot." % { slot.default, player.shipId, slot.id })
+			logWarning("Default equipment item {} for ship slot {}.{} is not compatible with slot." % { handle.default, player.shipId, handle.id })
 		end
 	end
 

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -139,7 +139,7 @@ sectorViewLayout.mainFont = font
 
 local function draw_jump_status(item)
 	textIcon(statusIcons[item.jumpStatus].icon, lui[item.jumpStatus])
-	ui.text(string.format("%.2f%s %d%s %s",
+	ui.text(string.format("%.2f%s %.1f%s %s",
 		item.distance, lc.UNIT_LY, item.fuelRequired, lc.UNIT_TONNES, ui.Format.Duration(item.duration, 2)))
 end
 
@@ -471,6 +471,7 @@ ui.registerModule("game", { id = 'map-sector-view', draw = function()
 
 		if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) then
 			systemEconView = package.reimport('pigui.modules.system-econ-view').New()
+			package.reimport('pigui.modules.hyperjump-planner')
 			package.reimport()
 		end
 	end


### PR DESCRIPTION
Redesigns the hyperdrive fuel use and duration-per-distance-travelled equations to implement the [redesign](https://dev.pioneerspacesim.net/design-document/hyperdrive-redesign) we've discussed and accepted.

This PR also converts hyperdrives to use an internal fuel reservoir rather than pulling directly from the cargo bay, and allows transferring fuel between the main tank and the hyperdrive reservoir. This enables fractional fuel usage in jumps - no longer will jumps of differing lengths use the same amount of fuel!

![image](https://github.com/user-attachments/assets/22257ca8-bf9d-4ab0-9762-843c1269e58e)

As part of this effort, about 50% of the capabilities of the planned fuel management UI were implemented; the fuel management will be left at this level until we get further time (after the upcoming release) to implement the full management interface.

![image](https://github.com/user-attachments/assets/a0659c50-ba32-4360-b87a-49450766b34c)

This PR fully implements all five sizes of hyperdrives in both military and civilian variants. Values have been assigned that "should" give decent jump ranges across the ship masses of that size, but a rigorous balance pass has **not** been done in interest of time.

Military drives have not been tested yet, but should function fine - I'd welcome any and all testers willing to give this branch a spin!

TODO:

- [x] ShipBuilder should fill hyperdrive tanks on spawn.
- [x] SAR mission needs to be able to interact with new hyperdrive tanks.
- [x] Military fuel needs to be handled correctly.

Fixes #5914.
Fixes #6025.