### PR TITLE
Improve Naval and Smart missiles

### DIFF
--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -548,6 +548,12 @@ local ThrusterType = utils.inherits(EquipType, "Equipment.ThrusterType")
 
 --==============================================================================
 
+---@class Equipment.MissileType : EquipType
+---@field missile_stats table
+local MissileType = utils.inherits(EquipType, "Equipment.MissileType")
+
+--==============================================================================
+
 Serializer:RegisterClass("EquipType", EquipType)
 Serializer:RegisterClass("Equipment.LaserType", LaserType)
 Serializer:RegisterClass("Equipment.HyperdriveType", HyperdriveType)
@@ -555,6 +561,7 @@ Serializer:RegisterClass("Equipment.SensorType", SensorType)
 Serializer:RegisterClass("Equipment.BodyScannerType", BodyScannerType)
 Serializer:RegisterClass("Equipment.CabinType", CabinType)
 Serializer:RegisterClass("Equipment.ThrusterType", ThrusterType)
+Serializer:RegisterClass("Equipment.MissileType", MissileType)
 
 EquipType:SetupPrototype()
 LaserType:SetupPrototype()
@@ -563,6 +570,7 @@ SensorType:SetupPrototype()
 BodyScannerType:SetupPrototype()
 CabinType:SetupPrototype()
 ThrusterType:SetupPrototype()
+MissileType:SetupPrototype()
 
 return {
 	laser			= laser,
@@ -575,4 +583,5 @@ return {
 	BodyScannerType	= BodyScannerType,
 	CabinType       = CabinType,
 	ThrusterType    = ThrusterType,
+	MissileType     = MissileType,
 }

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -307,11 +307,10 @@ function Ship:FireMissileAt(missile, target)
 	-- FIXME: handle multiple-count missile mounts
 	equipSet:Remove(missile)
 
-	local missile_object = self:SpawnMissile(missile.missile_type)
+	local missile_object = self:SpawnMissile(missile.missile_stats, target)
 
 	if missile_object then
 		if target then
-			missile_object:AIKamikaze(target)
 			Event.Queue("onShipFiring", self)
 		end
 		-- Let's keep a safe distance before activating this device, shall we ?

--- a/data/meta/CoreObject/Ship.meta.lua
+++ b/data/meta/CoreObject/Ship.meta.lua
@@ -131,3 +131,9 @@ function Ship:IsLanded() end
 -- Get the starport this ship is docked with, if any
 ---@return SpaceStation?
 function Ship:GetDockedWith() end
+
+-- Spawn a new missile from this ship
+---@param stats table Information about the missile to spawn. Must include a shipType: string field
+---@param target Body? Optional body to target with the missile
+---@return Body? missile The spawned missile if valid
+function Ship:SpawnMissile(stats, target) end

--- a/data/modules/Debug/DebugShip.lua
+++ b/data/modules/Debug/DebugShip.lua
@@ -41,17 +41,19 @@ local templateOptions = {
 }
 
 local missileOptions = {
-	"Guided Missile",
-	"Unguided Missile",
-	"Smart Missile",
-	"Naval Missile"
+	"S1 Guided Missile",
+	"S1 Unguided Missile",
+	"S2 Guided Missile",
+	"S3 Smart Missile",
+	"S4 Naval Missile"
 }
 
 local missileTypes = {
-	"missile_guided",
-	"missile_unguided",
-	"missile_smart",
-	"missile_naval",
+	"missile.guided_s1",
+	"missile.unguided_s1",
+	"missile.guided_s2",
+	"missile.smart_s3",
+	"missile.naval_s4",
 }
 
 ---@type HullConfig[]
@@ -221,15 +223,21 @@ end
 
 function DebugShipTool:onSpawnMissile()
 
-	local missile_type = missileTypes[self.missileIdx]
+	local missile_type = require 'Equipment'.Get(missileTypes[self.missileIdx]) --[[@as Equipment.MissileType?]]
 
-	if missile_type ~= "missile_unguided" and not Game.player:GetCombatTarget() then
+	if not missile_type then
+		Notification.add(Notification.Type.Error, "No missile equipment {}" % { missileTypes[self.missileIdx] })
+		return
+	end
+
+	if missile_type.missile_stats.guided and not Game.player:GetCombatTarget() then
 		Notification.add(Notification.Type.Error, "Debug: no target for {}" % { missileOptions[self.missileIdx] })
 		return
 	end
 
-	local missile = Game.player:SpawnMissile(missile_type)
-	missile:AIKamikaze(Game.player:GetCombatTarget())
+	local missile = Game.player:SpawnMissile(missile_type.missile_stats, Game.player:GetCombatTarget())
+
+	if not missile then return end
 
 	Timer:CallAt(Game.time + 1, function()
 		if missile:exists() then

--- a/data/modules/Equipment/Weapons.lua
+++ b/data/modules/Equipment/Weapons.lua
@@ -7,6 +7,7 @@ local Slot      = require 'HullConfig'.Slot
 
 local EquipType = EquipTypes.EquipType
 local LaserType = EquipTypes.LaserType
+local MissileType = EquipTypes.MissileType
 
 --===============================================
 -- Pulse Cannons
@@ -199,46 +200,46 @@ Equipment.Register("laser.miningcannon_17mw", LaserType.New {
 -- Missiles
 --===============================================
 
-Equipment.Register("missile.unguided_s1", EquipType.New {
+Equipment.Register("missile.unguided_s1", MissileType.New {
 	l10n_key="MISSILE_UNGUIDED",
 	price=30, purchasable=true, tech_level=1,
-	missile_type="missile_unguided",
+	missile_stats = { shipType="missile_unguided", guided=false, warheadSize=200.0, fuzeRadius=100.0, effectiveRadius=1000.0, chargeEffectiveness=1.0, ecmResist=5.0 },
 	volume=0, mass=0.045,
 	slot = { type="missile", size=1, hardpoint=true },
 	icon_name="equip_missile_unguided"
 })
 -- Approximately equivalent in size to an R60M / AA-8 'Aphid'
-Equipment.Register("missile.guided_s1", EquipType.New {
+Equipment.Register("missile.guided_s1", MissileType.New {
 	l10n_key="MISSILE_GUIDED",
 	price=45, purchasable=true, tech_level=5,
-	missile_type="missile_guided",
+	missile_stats = { shipType="missile_guided", guided=true, warheadSize=125.0, fuzeRadius=30.0, effectiveRadius=800.0, chargeEffectiveness=3.0, ecmResist=1.0 },
 	volume=0, mass=0.065,
 	slot = { type="missile", size=1, hardpoint=true },
 	icon_name="equip_missile_guided"
 })
 -- Approximately equivalent in size to an R73 / AA-11 'Archer'
-Equipment.Register("missile.guided_s2", EquipType.New {
+Equipment.Register("missile.guided_s2", MissileType.New {
 	l10n_key="MISSILE_GUIDED",
 	price=60, purchasable=true, tech_level=5,
-	missile_type="missile_guided",
+	missile_stats = { shipType="missile_guided", guided=true, warheadSize=200.0, fuzeRadius=40.0, effectiveRadius=1500.0, chargeEffectiveness=3.5, ecmResist=1.0 },
 	volume=0, mass=0.145,
 	slot = { type="missile", size=2, hardpoint=true },
 	icon_name="equip_missile_guided"
 })
 -- Approximately equivalent in size to an R77 / AA-12 'Adder'
-Equipment.Register("missile.smart_s3", EquipType.New {
+Equipment.Register("missile.smart_s3", MissileType.New {
 	l10n_key="MISSILE_SMART",
 	price=95, purchasable=true, tech_level=9,
-	missile_type="missile_smart",
+	missile_stats = { shipType="missile_smart", guided=true, warheadSize=320.0, fuzeRadius=35.0, effectiveRadius=2000.0, chargeEffectiveness=4.0, ecmResist=2.0 },
 	volume=0, mass=0.5,
 	slot = { type="missile", size=3, hardpoint=true },
 	icon_name="equip_missile_smart"
 })
 -- TBD
-Equipment.Register("missile.naval_s4", EquipType.New {
+Equipment.Register("missile.naval_s4", MissileType.New {
 	l10n_key="MISSILE_NAVAL",
 	price=160, purchasable=true, tech_level="MILITARY",
-	missile_type="missile_naval",
+	missile_stats = { shipType="missile_naval", guided=true, warheadSize=580.0, fuzeRadius=40.0, effectiveRadius=2000.0, chargeEffectiveness=4.5, ecmResist=3.0 },
 	volume=0, mass=1,
 	slot = { type="missile", size=4, hardpoint=true },
 	icon_name="equip_missile_naval"

--- a/data/pigui/modules/equipment.lua
+++ b/data/pigui/modules/equipment.lua
@@ -2,6 +2,7 @@
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local Engine = require 'Engine'
+local Equipment = require 'Equipment'
 local Game = require 'Game'
 local utils = require 'utils'
 local Event = require 'Event'
@@ -72,16 +73,9 @@ local function displayECM(uiPos)
 	return uiPos
 end
 
-local function getMissileIcon(missile)
-	if icons[missile.missile_type] then
-		return icons[missile.missile_type]
-	else
-		print("no icon for missile " .. missile.missile_type)
-		return icons.bullseye
-	end
-end
-
-local function fireMissile(missile)
+---@param player Player
+---@param missile Equipment.MissileType
+local function fireMissile(player, missile)
 	if not player:GetCombatTarget() then
 		Game.AddCommsLogLine(lc.SELECT_A_TARGET, "", 1)
 	else
@@ -90,28 +84,40 @@ local function fireMissile(missile)
 end
 
 local function displayMissiles(uiPos)
-	player = Game.player
-	local current_view = Game.CurrentView()
+	if Game.CurrentView() == "WorldView" then
 
-	if current_view == "WorldView" then
+		local paused = Game.paused
+		local docked = Game.player:GetDockedWith()
 
-		local missiles = player:GetComponent("EquipSet"):GetInstalledOfType("missile")
-		local count = {}
-		local types = {}
+		local missiles = Game.player:GetComponent("EquipSet"):GetInstalledOfType("missile") --[[@as Equipment.MissileType[] ]]
 
-		for i,missile in ipairs(missiles) do
-			count[missile.missile_type] = (count[missile.missile_type] or 0) + 1
-			types[missile.missile_type] = missile
+		local groups = utils.automagic()
+
+		for i, missile in ipairs(missiles) do
+			local group = groups[missile.id]
+
+			group.count = (group.count or 0) + 1
+			group.size = missile.slot.size
+			group.proto = missile:GetPrototype()
+			group.index = i
 		end
 
-		for t,missile in pairs(types) do
-			local c = count[t]
-			local size,clicked = iconEqButton(uiPos, getMissileIcon(missile), true, mainWideIconSize, c, c == 0, mainBackgroundColor, mainForegroundColor, mainHoverColor, mainPressedColor, lec[missile.l10n_key])
+		local display = utils.build_array(pairs(groups))
+		table.sort(display, function(a, b) return
+			a.size < b.size or (a.size == b.size and (not a.guided and b.guided))
+		end)
+
+		for _, group in ipairs(display) do
+			local count = tostring(group.count)
+
+			-- TODO: slot size indicators should have a translated string at some point
+			local tooltip = "{} (S{})" % { group.proto:GetName(), group.size }
+			local size, clicked = iconEqButton(uiPos, icons[group.proto.icon_name], false, mainIconSize,
+				count, false, mainBackgroundColor, mainForegroundColor, mainHoverColor, mainPressedColor, tooltip)
 			uiPos.y = uiPos.y + size.y + 10
 
-			if clicked then
-				print("firing missile " .. t)
-				fireMissile(missile)
+			if clicked and not paused and not docked then
+				fireMissile(Game.player, missiles[group.index])
 			end
 		end
 

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -9,13 +9,33 @@
 
 class AICommand;
 
+struct MissileDef {
+	StringName shipType;
+
+	// Distance in meters within which the missile will attempt to explode on a valid target
+	float fuzeRadius = 50.0;
+	// How much energy does the warhead have (in kg of TNT)
+	float warheadSize = 100.0;
+	// What is the effective radius within which the warhead can meaningfully damage something
+	float effectiveRadius = 2000.0;
+	// How effective is the blast at hitting a target compared to a omnidirectional warhead?
+	// defaults to 4x effectiveness, this is sufficient for most anti-ship missile explosions
+	// 1.0 = omnidirectional blast
+	// >1.0 = shaped charge in the direction of the target
+	float chargeEffectiveness = 4.0;
+	// How effective is the missile at resisting an ECM system?
+	float ecmResist = 1.0;
+};
+
 class Missile : public DynamicBody {
 public:
 	OBJDEF(Missile, DynamicBody, MISSILE);
 	Missile() = delete;
-	Missile(const ShipType::Id &type, Body *owner, int power = -1);
+	Missile(Body *owner, const MissileDef &def);
 	Missile(const Json &jsonObj, Space *space);
 	virtual ~Missile();
+
+	void Init();
 	void StaticUpdate(const float timeStep) override;
 	void TimeStepUpdate(const float timeStep) override;
 	virtual bool OnCollision(Body *o, Uint32 flags, double relVel) override;
@@ -41,11 +61,12 @@ private:
 	bool IsValidTarget(const Body *body);
 
 	AICommand *m_curAICmd;
-	int m_power;
 	Body *m_owner;
 	bool m_armed;
 	const ShipType *m_type;
 	Propulsion *m_propulsion;
+
+	MissileDef m_missileStats;
 
 	int m_ownerIndex; // deserialisation
 };

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -125,9 +125,9 @@ bool Player::SetWheelState(bool down)
 }
 
 //XXX all ships should make this sound
-Missile *Player::SpawnMissile(ShipType::Id missile_type, int power)
+Missile *Player::SpawnMissile(const MissileDef &def, Body *target)
 {
-	Missile *m = Ship::SpawnMissile(missile_type, power);
+	Missile *m = Ship::SpawnMissile(def, target);
 	if (m)
 		Sound::PlaySfx("Missile_launch", 1.0f, 1.0f, 0);
 	return m;

--- a/src/Player.h
+++ b/src/Player.h
@@ -24,7 +24,7 @@ public:
 	virtual bool DoDamage(float kgDamage) override final; // overloaded to add "crush" audio
 	virtual bool OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData) override;
 	virtual bool SetWheelState(bool down) override; // returns success of state change, NOT state itself
-	virtual Missile *SpawnMissile(ShipType::Id missile_type, int power = -1) override;
+	virtual Missile *SpawnMissile(const MissileDef &, Body *) override;
 	virtual void SetAlertState(Ship::AlertState as) override;
 	virtual void NotifyRemoved(const Body *const removedBody) override;
 	virtual bool ManualDocking() const override { return !AIIsActive(); }

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -257,6 +257,7 @@ void Ship::PostLoadFixup(Space *space)
 	m_dockedWith = static_cast<SpaceStation *>(space->GetBodyByIndex(m_dockedWithIndex));
 	if (m_curAICmd) m_curAICmd->PostLoadFixup(space);
 	m_controller->PostLoadFixup(space);
+	m_gunManager->PostLoadFixup(space);
 }
 
 void Ship::SaveToJson(Json &jsonObj, Space *space)

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -741,12 +741,12 @@ Ship::ECMResult Ship::UseECM()
 		return ECM_NOT_INSTALLED;
 }
 
-Missile *Ship::SpawnMissile(ShipType::Id missile_type, int power)
+Missile *Ship::SpawnMissile(const MissileDef &missileStats, Body *target)
 {
 	if (GetFlightState() != FLYING)
 		return 0;
 
-	Missile *missile = new Missile(missile_type, this, power);
+	Missile *missile = new Missile(this, missileStats);
 	missile->SetOrient(GetOrient());
 	missile->SetFrame(GetFrame());
 	const vector3d pos = GetOrient() * vector3d(0, GetAabb().min.y - 10, GetAabb().min.z);
@@ -754,6 +754,11 @@ Missile *Ship::SpawnMissile(ShipType::Id missile_type, int power)
 	missile->SetPosition(GetPosition() + pos);
 	missile->SetVelocity(GetVelocity() + vel);
 	Pi::game->GetSpace()->AddBody(missile);
+
+	if (target) {
+		missile->AIKamikaze(target);
+	}
+
 	return missile;
 }
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -21,6 +21,7 @@ class CargoBody;
 class SpaceStation;
 class HyperspaceCloud;
 class Missile;
+struct MissileDef;
 class NavLights;
 class Planet;
 class Sensors;
@@ -171,7 +172,7 @@ public:
 
 	ECMResult UseECM();
 
-	virtual Missile *SpawnMissile(ShipType::Id missile_type, int power = -1);
+	virtual Missile *SpawnMissile(const MissileDef &missileStats, Body *target);
 
 	enum AlertState { // <enum scope='Ship' name=ShipAlertStatus prefix=ALERT_ public>
 		ALERT_NONE,

--- a/src/ShipType.cpp
+++ b/src/ShipType.cpp
@@ -17,10 +17,6 @@ std::vector<ShipType::Id> ShipType::static_ships;
 std::vector<ShipType::Id> ShipType::missile_ships;
 
 const std::string ShipType::POLICE = "kanara";
-const std::string ShipType::MISSILE_GUIDED = "missile_guided";
-const std::string ShipType::MISSILE_NAVAL = "missile_naval";
-const std::string ShipType::MISSILE_SMART = "missile_smart";
-const std::string ShipType::MISSILE_UNGUIDED = "missile_unguided";
 
 float ShipType::GetFuelUseRate() const
 {

--- a/src/ShipType.h
+++ b/src/ShipType.h
@@ -80,10 +80,6 @@ struct ShipType {
 	float GetFuelUseRate() const;
 
 	static const std::string POLICE;
-	static const std::string MISSILE_GUIDED;
-	static const std::string MISSILE_NAVAL;
-	static const std::string MISSILE_SMART;
-	static const std::string MISSILE_UNGUIDED;
 
 	static std::map<Id, const ShipType> types;
 	static std::vector<Id> player_ships;

--- a/src/ship/GunManager.h
+++ b/src/ship/GunManager.h
@@ -121,6 +121,7 @@ public:
 	struct GroupState {
 		WeaponIndexSet weapons;				// Whic weapons are assigned to this group?
 		const Body *target;					// The target for this group, if any
+		uint32_t target_idx;				// Group target body index for serialization, used in PostLoadFixup()
 		bool firing;						// Is the group currently firing
 		bool fireWithoutTargeting;			// Can the group fire without a target/target not in gimbal range?
 		ConnectionTicket onTargetDestroyed;	// Unlock the target once it's been destroyed
@@ -132,6 +133,8 @@ public:
 
 	void SaveToJson(Json &jsonObj, Space *space);
 	void LoadFromJson(const Json &jsonObj, Space *space);
+
+	void PostLoadFixup(Space *space);
 
 	void StaticUpdate(float deltaTime);
 


### PR DESCRIPTION
Alternative title: finally fixed a bit of the mess that is missile handling in this game.

This PR rewrites how missiles get their "data", i.e. all parameters used in-flight. Missiles still reference a special ShipType file (one of the `missile_*.json` shipdefs), but we're no longer constrained to only four missile types any more!

What's more, Naval and Smart missiles now actually do more damage than regular guided missiles (as one would expect), and missiles in general got a bit better about detonating close to the target rather than at a 100m+ standoff.

As a quick perusal of `Missile.cpp` and `data/modules/Equipment/Weapons.lua` will show, most meaningful parameters for missiles are now defined in "data" rather than code, allowing mods to introduce new missile equipment and making it much easier to tweak missile gameplay balance.

Fixes #5926.
Fixes #6014.
Fixes #4159.