### PR TITLE
Fuel Computer + Some Reusable Fuel Code

### DIFF
--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -825,6 +825,15 @@
     "description": "",
     "message": "Shows profitable commodities to trade between selected and current system"
   },
+
+  "FUEL_COMPUTER": {
+    "description": "Ship equipment computing fuel transfer to hyperdrive if available.",
+    "message": "Fuel Computer"
+  },
+  "FUEL_COMPUTER_DESCRIPTION": {
+    "description": "",
+    "message": "Tired Of transferring fuel from cargo to your drive? Now have it automatically balanced on arrival to a system. "
+  },
   "UNOCCUPIED_CABIN": {
     "description": "",
     "message": "Extra Passenger Cabin"

--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -447,7 +447,7 @@ end
 --
 -- Return the maximum fuel capacity of the drive, in tons.
 function HyperdriveType:GetMaxFuel()
-	return self.fuel_resv_size
+	return self.fuel_resv_size -- is this a cpp value???
 end
 
 -- Function: CheckJump

--- a/data/modules/Equipment/Internal.lua
+++ b/data/modules/Equipment/Internal.lua
@@ -29,6 +29,14 @@ Equipment.Register("misc.trade_computer", EquipType.New {
 	icon_name="equip_trade_computer"
 })
 
+Equipment.Register("misc.fuel_computer", EquipType.New {
+	l10n_key="FUEL_COMPUTER",
+	price=450, purchasable=true, tech_level=6,
+	slot={ type="computer", size=1 },
+	mass=0.3, volume=0.5, capabilities={ fuel_computer=1 },
+	icon_name="equip_fuel_computer"
+})
+
 --===============================================
 -- Sensors
 --===============================================

--- a/data/modules/FuelComputer/FuelComputer.lua
+++ b/data/modules/FuelComputer/FuelComputer.lua
@@ -1,0 +1,64 @@
+
+
+
+-- Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+-- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+local Event = require 'Event'
+local Game = require 'Game'
+local Engine = require 'Engine'
+local Timer = require 'Timer'
+local Serializer = require 'Serializer'
+local Comms = require 'Comms'
+
+local fuel = require 'pigui.libs.fuel-transfer'
+
+-- store which station sent them out
+local policeDispatched = false
+
+local loaded_data
+
+
+local onGameStart = function ()
+	if (loaded_data) then
+	    fuel.setComputerReserve(loaded_data.mainReserve, loaded_data.cargoReserve)
+	end
+	loaded_data = nil
+end
+
+
+local serialize = function ()
+	local data = fuel.getComputerReserve()
+	return data
+end
+
+
+local unserialize = function (data)
+	loaded_data = data
+end
+
+
+
+local onEnterSystem = function (player)
+    if not player:IsPlayer() then return end
+
+	if (loaded_data) then
+		    fuel.setComputerReserve(loaded_data.mainReserve, loaded_data.cargoReserve)
+	end
+
+	loaded_data = nil
+
+	if(fuel.hasFuelComputerCapability()) then
+	    fuel.computerTransfer()
+	end
+end
+
+
+
+
+Event.Register("onGameStart", onGameStart)
+Event.Register("onEnterSystem", onEnterSystem)
+Event.Register("", onEnterSystem)
+
+
+Serializer:Register("FuelComputer", serialize, unserialize)

--- a/data/pigui/libs/fuel-transfer.lua
+++ b/data/pigui/libs/fuel-transfer.lua
@@ -1,0 +1,217 @@
+
+
+local ui = require 'pigui'
+local InfoView = require 'pigui.views.info-view'
+local Lang = require 'Lang'
+local Game = require 'Game'
+local ShipDef = require 'ShipDef'
+local StationView = require 'pigui.views.station-view'
+local Passengers = require 'Passengers'
+local Commodities = require 'Commodities'
+local CommodityType = require 'CommodityType'
+
+local l = Lang.GetResource("ui-core")
+
+local colors = ui.theme.colors
+local icons = ui.theme.icons
+local pionillium = ui.fonts.pionillium
+local orbiteer = ui.fonts.orbiteer
+local Vector2 = _G.Vector2
+
+local iconSize = ui.rescaleUI(Vector2(28, 28))
+local fuel = {}
+
+
+local function drawCentered(id, fun)
+	if not ui.beginTable(id .. "##centered", 3) then return end
+
+	ui.tableSetupColumn("leftPadding")
+	ui.tableSetupColumn("content", { "WidthFixed" })
+	ui.tableSetupColumn("rightPadding")
+
+	ui.tableNextRow()
+	ui.tableSetColumnIndex(1)
+
+	fun()
+
+	ui.endTable()
+end
+
+-- wrapper around gaugees, for consistent size, and vertical spacing
+local function gauge_bar(x, text, min, max, icon)
+	local height = ui.getTextLineHeightWithSpacing()
+	local cursorPos = ui.getCursorScreenPos()
+	local fudge_factor = 1.0
+	local gaugeWidth = ui.getContentRegion().x * fudge_factor
+	local gaugePos = Vector2(cursorPos.x, cursorPos.y + height * 0.5)
+
+	ui.gauge(gaugePos, x, '', text, min, max, icon,
+		colors.gaugeEquipmentMarket, '', gaugeWidth, height)
+
+	-- ui.addRect(cursorPos, cursorPos + Vector2(gaugeWidth, height), colors.gaugeCargo, 0, 0, 1)
+	ui.dummy(Vector2(gaugeWidth, height))
+end
+
+
+
+-- Gauge bar for internal, interplanetary, fuel tank
+local function gauge_fuel()
+	local player = Game.player
+	local tankSize = ShipDef[player.shipId].fuelTankMass
+	local text = string.format(l.FUEL .. ": %dt \t" .. l.DELTA_V .. ": %d km/s",
+		tankSize/100 * player.fuel, player:GetRemainingDeltaV()/1000)
+
+	gauge_bar(player.fuel, text, 0, 100, icons.fuel)
+end
+
+
+
+
+fuel.pumpDown = function (fuelAmt)
+	local player = Game.player
+	---@type CargoManager
+	local cargoMgr = player:GetComponent('CargoManager')
+
+	if player.fuel == 0 or cargoMgr:GetFreeSpace() == 0 then
+		print("No fuel left to pump!")
+		return
+	end
+
+	-- internal tanks capacity
+	local fuelTankMass = ShipDef[player.shipId].fuelTankMass
+
+	-- current fuel in internal tanks, in tonnes
+	local availableFuel = math.floor(player.fuel / 100 * fuelTankMass)
+
+	-- Convert fuel to positive number, don't take more fuel than is in the tank
+	local drainedFuel = math.min(math.abs(fuelAmt), availableFuel)
+	-- Don't pump down more fuel than we can fit in the cargo space available
+	drainedFuel = math.min(drainedFuel, cargoMgr:GetFreeSpace())
+
+	-- Military fuel is only used for the hyperdrive
+	local ok = cargoMgr:AddCommodity(Commodities.hydrogen, drainedFuel)
+	if not ok then
+		print("Couldn't pump fuel into cargo hold!")
+		return
+	end
+
+	-- Set internal thruster fuel tank state
+	-- (player.fuel is percentage, between 0-100)
+	player:SetFuelPercent(math.clamp(player.fuel - drainedFuel * 100 / fuelTankMass, 0, 100))
+end
+
+---@param hyperdrive Equipment.HyperdriveType
+function fuel.transfer_hyperfuel_mil(hyperdrive, amt)
+	local cargoMgr = Game.player:GetComponent('CargoManager')
+	local availableFuel = cargoMgr:CountCommodity(hyperdrive.fuel)
+	local availableCargo = cargoMgr:GetFreeSpace()
+
+	-- Ensure we're not transferring more than the hyperdrive holds
+	local delta = math.clamp(amt, -hyperdrive.storedFuel, hyperdrive:GetMaxFuel() - hyperdrive.storedFuel)
+	-- Ensure we're not transferring more than the cargo bay holds
+	delta = math.clamp(delta, -availableCargo, availableFuel)
+
+	-- TODO(CargoManager): liquid tanks / partially-filled cargo containers
+	-- Until then, we round down to a whole integer in both directions since we're dealing with integer cargo masses
+	delta = math.modf(delta)
+
+	if delta > 0 then
+		cargoMgr:RemoveCommodity(hyperdrive.fuel, delta)
+		hyperdrive:SetFuel(Game.player, hyperdrive.storedFuel + delta)
+	elseif delta < 0 then
+		cargoMgr:AddCommodity(hyperdrive.fuel, math.abs(delta))
+		hyperdrive:SetFuel(Game.player, hyperdrive.storedFuel + delta)
+	end
+end
+
+function fuel.fuelTransferButton(drive, amt)
+	local icon = amt < 0 and icons.chevron_down or icons.chevron_up
+
+	if ui.button(ui.get_icon_glyph(icon) .. tostring(math.abs(amt))) then
+
+		if drive.fuel == Commodities.hydrogen then
+			fuel.transfer_hyperfuel_hydrogen(drive, amt)
+		elseif drive.fuel == Commodities.military_fuel then
+			fuel.transfer_hyperfuel_mil(drive, amt)
+		end
+
+	end
+end
+
+function fuel.drawCentered(id, fun)
+	if not ui.beginTable(id .. "##centered", 3) then return end
+
+	ui.tableSetupColumn("leftPadding")
+	ui.tableSetupColumn("content", { "WidthFixed" })
+	ui.tableSetupColumn("rightPadding")
+
+	ui.tableNextRow()
+	ui.tableSetColumnIndex(1)
+
+	fun()
+
+	ui.endTable()
+end
+
+-- a function to dransfer fuel from the ship tank to the hyperdrive
+function fuel.drawFuelTransfer(drive)
+	-- Don't allow transferring fuel while the hyperdrive is doing its thing
+	if Game.player:IsHyperspaceActive() then return end
+
+	drawCentered("Hyperdrive", function()
+		ui.horizontalGroup(function()
+			fuel.fuelTransferButton(drive, 10)
+			fuel.fuelTransferButton(drive, 1)
+
+			ui.text(l.TRANSFER_FUEL)
+
+			fuel.fuelTransferButton(drive, -1)
+			fuel.fuelTransferButton(drive, -10)
+		end)
+	end)
+end
+
+--ui for above
+function fuel.drawPumpDialog()
+	local width1 = ui.calcTextSize(l.PUMP_DOWN)
+	local width2 = ui.calcTextSize(l.REFUEL)
+
+	local width
+	if width2.x > width1.x then width = width2.x else width = width1.x end
+	width = width * 1.2
+
+	-- to-do: maybe show disabled version of button if fuel==100 or hydrogen==0
+	-- (if so, what about military fuel?)
+	-- at the moment: no visual cue for this.
+	ui.alignTextToLineHeight(ui.getButtonHeight())
+	ui.text(l.REFUEL)
+	ui.sameLine(width)
+	local options = {1, 10, 100}
+	for _, k in ipairs(options) do
+		if ui.button(tostring(k)  .. "##fuel", Vector2(100, 0)) then
+			-- Refuel k tonnes from cargo hold
+			Game.player:Refuel(Commodities.hydrogen, k)
+		end
+		ui.sameLine()
+	end
+	ui.text("")
+
+	-- To-do: Maybe also show disabled version of button if currentfuel == 0 or player:GetEquipFree("cargo") == 0
+	-- at the moment: no visual cue for this.
+	ui.alignTextToLineHeight(ui.getButtonHeight())
+	ui.text(l.PUMP_DOWN)
+	ui.sameLine(width)
+	for _, v in ipairs(options) do
+		local fuelVal = -1*v
+		if ui.button(fuelVal .. "##pump", Vector2(100, 0)) then
+			fuel.pumpDown(fuel)
+		end
+		ui.sameLine()
+	end
+	ui.text("")
+end
+
+
+
+
+return fuel

--- a/data/pigui/libs/fuel-transfer.lua
+++ b/data/pigui/libs/fuel-transfer.lua
@@ -1,12 +1,10 @@
 
 
 local ui = require 'pigui'
-local InfoView = require 'pigui.views.info-view'
 local Lang = require 'Lang'
 local Game = require 'Game'
 local ShipDef = require 'ShipDef'
-local StationView = require 'pigui.views.station-view'
-local Passengers = require 'Passengers'
+
 local Commodities = require 'Commodities'
 local CommodityType = require 'CommodityType'
 

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -3,6 +3,8 @@
 
 local ui = require 'pigui'
 local InfoView = require 'pigui.views.info-view'
+local fuel = require 'pigui.libs.fuel-transfer'
+
 local Lang = require 'Lang'
 local Game = require 'Game'
 local ShipDef = require 'ShipDef'
@@ -91,39 +93,6 @@ local function cargolist ()
 end
 
 
-local pumpDown = function (fuel)
-	local player = Game.player
-	---@type CargoManager
-	local cargoMgr = player:GetComponent('CargoManager')
-
-	if player.fuel == 0 or cargoMgr:GetFreeSpace() == 0 then
-		print("No fuel left to pump!")
-		return
-	end
-
-	-- internal tanks capacity
-	local fuelTankMass = ShipDef[player.shipId].fuelTankMass
-
-	-- current fuel in internal tanks, in tonnes
-	local availableFuel = math.floor(player.fuel / 100 * fuelTankMass)
-
-	-- Convert fuel to positive number, don't take more fuel than is in the tank
-	local drainedFuel = math.min(math.abs(fuel), availableFuel)
-	-- Don't pump down more fuel than we can fit in the cargo space available
-	drainedFuel = math.min(drainedFuel, cargoMgr:GetFreeSpace())
-
-	-- Military fuel is only used for the hyperdrive
-	local ok = cargoMgr:AddCommodity(Commodities.hydrogen, drainedFuel)
-	if not ok then
-		print("Couldn't pump fuel into cargo hold!")
-		return
-	end
-
-	-- Set internal thruster fuel tank state
-	-- (player.fuel is percentage, between 0-100)
-	player:SetFuelPercent(math.clamp(player.fuel - drainedFuel * 100 / fuelTankMass, 0, 100))
-end
-
 -- wrapper around gaugees, for consistent size, and vertical spacing
 local function gauge_bar(x, text, min, max, icon)
 	local height = ui.getTextLineHeightWithSpacing()
@@ -176,59 +145,6 @@ local function gauge_cabins()
 		0, berths_total, icons.personal)
 end
 
----@param hyperdrive Equipment.HyperdriveType
-local function transfer_hyperfuel_hydrogen(hyperdrive, amt)
-	local fuelTankSize = ShipDef[Game.player.shipId].fuelTankMass
-	local fuelMassLeft = Game.player.fuelMassLeft
-
-	-- Ensure we're not transferring more than the hyperdrive holds
-	local delta = math.clamp(amt, -hyperdrive.storedFuel, hyperdrive:GetMaxFuel() - hyperdrive.storedFuel)
-	-- Ensure we're not transferring more than the fuel tank holds
-	delta = math.clamp(delta, fuelMassLeft - fuelTankSize, fuelMassLeft)
-
-	if math.abs(delta) > 0.0001 then
-		Game.player:SetFuelPercent((fuelMassLeft - delta) * 100 / fuelTankSize)
-		hyperdrive:SetFuel(Game.player, hyperdrive.storedFuel + delta)
-	end
-end
-
----@param hyperdrive Equipment.HyperdriveType
-local function transfer_hyperfuel_mil(hyperdrive, amt)
-	local cargoMgr = Game.player:GetComponent('CargoManager')
-	local availableFuel = cargoMgr:CountCommodity(hyperdrive.fuel)
-	local availableCargo = cargoMgr:GetFreeSpace()
-
-	-- Ensure we're not transferring more than the hyperdrive holds
-	local delta = math.clamp(amt, -hyperdrive.storedFuel, hyperdrive:GetMaxFuel() - hyperdrive.storedFuel)
-	-- Ensure we're not transferring more than the cargo bay holds
-	delta = math.clamp(delta, -availableCargo, availableFuel)
-
-	-- TODO(CargoManager): liquid tanks / partially-filled cargo containers
-	-- Until then, we round down to a whole integer in both directions since we're dealing with integer cargo masses
-	delta = math.modf(delta)
-
-	if delta > 0 then
-		cargoMgr:RemoveCommodity(hyperdrive.fuel, delta)
-		hyperdrive:SetFuel(Game.player, hyperdrive.storedFuel + delta)
-	elseif delta < 0 then
-		cargoMgr:AddCommodity(hyperdrive.fuel, math.abs(delta))
-		hyperdrive:SetFuel(Game.player, hyperdrive.storedFuel + delta)
-	end
-end
-
-local function fuelTransferButton(drive, amt)
-	local icon = amt < 0 and icons.chevron_down or icons.chevron_up
-
-	if ui.button(ui.get_icon_glyph(icon) .. tostring(math.abs(amt))) then
-
-		if drive.fuel == Commodities.hydrogen then
-			transfer_hyperfuel_hydrogen(drive, amt)
-		elseif drive.fuel == Commodities.military_fuel then
-			transfer_hyperfuel_mil(drive, amt)
-		end
-
-	end
-end
 
 local function drawCentered(id, fun)
 	if not ui.beginTable(id .. "##centered", 3) then return end
@@ -245,62 +161,6 @@ local function drawCentered(id, fun)
 	ui.endTable()
 end
 
-local function drawFuelTransfer(drive)
-	-- Don't allow transferring fuel while the hyperdrive is doing its thing
-	if Game.player:IsHyperspaceActive() then return end
-
-	drawCentered("Hyperdrive", function()
-		ui.horizontalGroup(function()
-			fuelTransferButton(drive, 10)
-			fuelTransferButton(drive, 1)
-
-			ui.text(l.TRANSFER_FUEL)
-
-			fuelTransferButton(drive, -1)
-			fuelTransferButton(drive, -10)
-		end)
-	end)
-end
-
-local function drawPumpDialog()
-	local width1 = ui.calcTextSize(l.PUMP_DOWN)
-	local width2 = ui.calcTextSize(l.REFUEL)
-
-	local width
-	if width2.x > width1.x then width = width2.x else width = width1.x end
-	width = width * 1.2
-
-	-- to-do: maybe show disabled version of button if fuel==100 or hydrogen==0
-	-- (if so, what about military fuel?)
-	-- at the moment: no visual cue for this.
-	ui.alignTextToLineHeight(ui.getButtonHeight())
-	ui.text(l.REFUEL)
-	ui.sameLine(width)
-	local options = {1, 10, 100}
-	for _, k in ipairs(options) do
-		if ui.button(tostring(k)  .. "##fuel", Vector2(100, 0)) then
-			-- Refuel k tonnes from cargo hold
-			Game.player:Refuel(Commodities.hydrogen, k)
-		end
-		ui.sameLine()
-	end
-	ui.text("")
-
-	-- To-do: Maybe also show disabled version of button if currentfuel == 0 or player:GetEquipFree("cargo") == 0
-	-- at the moment: no visual cue for this.
-	ui.alignTextToLineHeight(ui.getButtonHeight())
-	ui.text(l.PUMP_DOWN)
-	ui.sameLine(width)
-	for _, v in ipairs(options) do
-		local fuel = -1*v
-		if ui.button(fuel .. "##pump", Vector2(100, 0)) then
-			pumpDown(fuel)
-		end
-		ui.sameLine()
-	end
-	ui.text("")
-end
-
 local function drawEconTrade()
 	local player = Game.player
 	local drive = player:GetInstalledHyperdrive()
@@ -310,14 +170,14 @@ local function drawEconTrade()
 	gauge_fuel()
 
 	drawCentered("Pump Dialog", function()
-		drawPumpDialog()
+		fuel.drawPumpDialog()
 	end)
 
 	if drive then
 		ui.withFont(orbiteer.heading, function() ui.text(l.HYPERDRIVE) end)
 
 		gauge_hyperdrive(drive)
-		drawFuelTransfer(drive)
+		fuel.drawFuelTransfer(drive)
 	end
 
 	ui.newLine()

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -651,6 +651,8 @@ theme.icons = {
 	equip_thrusters_medium = 300,
 	equip_thrusters_best = 300,
 	equip_trade_computer = 301,
+	equip_fuel_computer = 63, -- copy fuel tank icon
+
 	equip_autopilot = 302,
 	equip_hyperdrive = 303,
 


### PR DESCRIPTION
Hi its 6am now but i think this is almost working. Fallow up on #6026

What do you guys think of adding a Fuel computer like a Trade computer. 

Especially with small class one hyperdirves it gets tedious to click back and forth to the menu each time to manually transfer fuel. 


Enter the fancy fuel computer that automatically does it when you enter a system for only 450$. 

But it takes the slot of your trade computer ;) 

Now you just set your reserved fuel and warp to your hearts content. 


![image](https://github.com/user-attachments/assets/005605bd-d8d6-4807-be99-20358cc9d7dd)


![image](https://github.com/user-attachments/assets/03513590-177d-44e2-b873-cd74977f674f)


I guess there are types and stuff and i need to test mil drives again but should be working. 

anyway though I would get your thoughts on the idea before I sink too much time into it.

 
