### PR TITLE
Reverting reticule text background opacity back to 0.4

### DIFF
--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -195,7 +195,7 @@ theme.colors = {
 	-- FIXME: this color is primarily used to tint buttons by rendering over top of the frame color.
 	-- This is atrocious for obvious reasons. Refactor button / frame rendering to draw an independent frame border.
 	lightBlueBackground		= styleColors.primary_700:opacity(0.10),
-	lightBlackBackground	= styleColors.panel_900:opacity(0.80), --black:opacity(0.40),
+	lightBlackBackground	= styleColors.panel_900:opacity(0.40), --black:opacity(0.40),
 	windowBackground		= styleColors.panel_900,
 	windowFrame				= styleColors.panel_700,
 	notificationBackground	= styleColors.panel_800,


### PR DESCRIPTION
Reported on discord by Admetus, the text background around the reticule is quite dark:
![image](https://github.com/user-attachments/assets/6fddfcad-104f-462f-9981-86e89d1a9751)
Makes sense on light backgrounds, but is distracting over dark:
![image](https://github.com/user-attachments/assets/238fcf0c-8d71-479c-8dd3-114148848694)

This PR reverts back the 0.8 opacity to 0.4 in the theme:
![screenshot-20250204-115458](https://github.com/user-attachments/assets/91f6ec08-1877-4d42-9b93-e314a50cd936)
![screenshot-20250204-115453](https://github.com/user-attachments/assets/c99b1ef6-2f19-4750-ad4a-3f2865c903c8)
![screenshot-20250204-115652](https://github.com/user-attachments/assets/59ec9ac5-06f9-4dd1-8428-7236253c8d54)

In the long run I think it would be a better solution, if the blending mode of them would be Multiply. Then it would only darken, but not brighten. Not sure if that's easily and cheaply doable though.
