### PR TITLE
Add amd64 architecture

### DIFF
--- a/cmake/TargetArchitecture.cmake
+++ b/cmake/TargetArchitecture.cmake
@@ -1,7 +1,7 @@
 # This script detects supported target architectures and configures test flags
 # accordingly
 
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES x86|x64)
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES x86|x64|amd64)
 	set(PIONEER_TARGET_INTEL ON)
 endif()
 


### PR DESCRIPTION
It's how BSD systems spell x86_64, so it's also PIONEER_TARGET_INTEL.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

