### PR TITLE
equipment-outfitter.lua: Interpret MILITARY as tech level 11.

### DIFF
--- a/data/pigui/libs/equipment-outfitter.lua
+++ b/data/pigui/libs/equipment-outfitter.lua
@@ -491,13 +491,6 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 	ui.tableNextColumn()
 	ui.text(label)
 
-	if stat_a then
-		stat_a[3] = stat_a[3] == "MILITARY" and 11 or stat_a[3]
-	end
-	if stat_b then
-		stat_b[3] = stat_b[3] == "MILITARY" and 11 or stat_b[3]
-	end
-
 	local icon_size = Vector2(ui.getTextLineHeight())
 	local color = stat_a and stat_b
 		and compare(stat_a[3], stat_b[3], stat_a[5])

--- a/data/pigui/libs/equipment-outfitter.lua
+++ b/data/pigui/libs/equipment-outfitter.lua
@@ -266,9 +266,11 @@ local function fmt_number(val) return ui.Format.Number(val, 0) end
 ---@param data UI.EquipCard.Data
 function Outfitter:modifyEquipmentStats(data)
 	local stock = self:getStock(data.equip)
+	local tech_level = data.equip.tech_level
+	tech_level = tech_level == "MILITARY" and 11 or tech_level
 
 	table.insert(data.stats, 1, { l.AVAILABLE_STOCK, icons.cargo_crate, stock, fmt_number })
-	table.insert(data.stats, 2, { l.TECH_LEVEL, icons.station_orbital_large, data.equip.tech_level, fmt_number })
+	table.insert(data.stats, 2, { l.TECH_LEVEL, icons.station_orbital_large, tech_level, fmt_number })
 end
 
 function Outfitter:buildEquipmentList()

--- a/data/pigui/libs/equipment-outfitter.lua
+++ b/data/pigui/libs/equipment-outfitter.lua
@@ -489,6 +489,13 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 	ui.tableNextColumn()
 	ui.text(label)
 
+	if stat_a then
+		stat_a[3] = stat_a[3] == "MILITARY" and 11 or stat_a[3]
+	end
+	if stat_b then
+		stat_b[3] = stat_b[3] == "MILITARY" and 11 or stat_b[3]
+	end
+
 	local icon_size = Vector2(ui.getTextLineHeight())
 	local color = stat_a and stat_b
 		and compare(stat_a[3], stat_b[3], stat_a[5])


### PR DESCRIPTION
The function `Outfitter:renderCompareRow()` in `equipment-outfitter.lua` assumes a numeric value. This causes a GUI crash in the equipment outfitter when selecting an item with the tech level `MILITARY` due to attempting either number formatting (if the slot is empty) or a numeric comparison (if the slot is full).

Give this the same handling as `MILITARY` level stations get by changing the level to `11` for comparison and display.

fix #6039 
