### PR TITLE
SetFuel after hyperjumps

### DIFF
--- a/data/modules/Equipment/Types.lua
+++ b/data/modules/Equipment/Types.lua
@@ -267,7 +267,7 @@ function HyperdriveType:OnLeaveHyperspace(ship)
 		local amount = ship['nextJumpFuelUse']
 		ship:unsetprop('nextJumpFuelUse')
 
-		self.storedFuel = math.max(0, self.storedFuel - amount)
+		self:SetFuel(ship, math.max(0, self.storedFuel - amount))
 
 		if self.byproduct then
 			local cargoMgr = ship:GetComponent('CargoManager')


### PR DESCRIPTION
In `Types.lua`, the function `OnLeaveHyperspace()` currently adjusts the level of stored fuel without  calling `SetFuel`. The result is that the mass of the hyperdrive's fuel reserve does not decrease when fuel is used. To verify this, start a new game and jump anywhere; the reported mass of the hyperdrive will remain at 8.0 for a Mars start. The hyperdrive can gain a considerable amount of mass over time as the player refuels.

The fix is to call `SetFuel` in `OnLeaveHyperspace()` rather than adjusting `storedFuel` directly.