### PR TITLE
Generalize to any OpenGL binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ endif (MSVC)
 
 find_package(Threads REQUIRED)
 find_package(Freetype REQUIRED)
-find_package(OpenGL REQUIRED)
+find_package(OpenGL REQUIRED COMPONENTS OpenGL)
 
 set(FMT_INSTALL OFF CACHE BOOL "Enable install of libfmt" FORCE)
 
@@ -385,7 +385,7 @@ list(APPEND pioneerLibs
 	pioneer-lua
 	${ASSIMP_LIBRARIES}
 	${FREETYPE_LIBRARIES}
-	${OPENGL_LIBRARIES}
+	OpenGL::OpenGL
 	${SDL2_LIBRARIES}
 	${SDL2_IMAGE_LIBRARIES}
 	${SIGCPP_LIBRARIES}


### PR DESCRIPTION
Due to an unfortunate design of the FindOpenGL.cmake module, not specifying `COMPONENTS OpenGL` would fail for systems without GLX, and OPENGL_LIBRARIES would not be set, either.

This should hopefully work for both now (until cmake modifies the module).