### PR TITLE
Store AtmosphereParameters in BaseSphere, calculate with material setup

### DIFF
--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -48,21 +48,22 @@ public:
 	RefCountedPtr<Graphics::Material> GetSurfaceMaterial() const { return m_surfaceMaterial; }
 
 protected:
+	virtual void SetUpMaterials() = 0;
+
+	// set up shader data for this geosphere's atmosphere
+	void SetMaterialParameters(const matrix4x4d &t, const float r, const std::vector<Camera::Shadow> &s, const AtmosphereParameters &ap);
+
 	const SystemBody *m_sbody;
 
 	// all variables for GetHeight(), GetColor()
 	RefCountedPtr<Terrain> m_terrain;
 
-	virtual void SetUpMaterials() = 0;
-
 	RefCountedPtr<Graphics::Material> m_surfaceMaterial;
 	RefCountedPtr<Graphics::Material> m_atmosphereMaterial;
 
-	// set up shader data for this geosphere's atmosphere
-	void SetMaterialParameters(const matrix4x4d &t, const float r, const std::vector<Camera::Shadow> &s, const AtmosphereParameters &ap);
-
 	// atmosphere geometry
 	std::unique_ptr<Graphics::Drawables::Sphere3D> m_atmos;
+	AtmosphereParameters m_atmosphereParameters;
 };
 
 #endif /* _GEOSPHERE_H */

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -635,15 +635,13 @@ void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView,
 		SetUpMaterials();
 
 	//Update material parameters
-	//XXX no need to calculate AP every frame
-	auto ap = GetSystemBody()->CalcAtmosphereParams();
-	SetMaterialParameters(trans, radius, shadows, ap);
-	if (ap.atmosDensity > 0.0) {
+	SetMaterialParameters(trans, radius, shadows, m_atmosphereParameters);
+	if (m_atmosphereParameters.atmosDensity > 0.0) {
 		// make atmosphere sphere slightly bigger than required so
 		// that the edges of the pixel shader atmosphere jizz doesn't
 		// show ugly polygonal angles
 		DrawAtmosphereSurface(renderer, trans, campos,
-			ap.atmosRadius * 1.01,
+			m_atmosphereParameters.atmosRadius * 1.01,
 			m_atmosphereMaterial);
 	}
 
@@ -678,7 +676,6 @@ void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView,
 
 void GasGiant::SetUpMaterials()
 {
-
 	// Request material for this planet, with atmosphere.
 	// Separate materials for surface and sky.
 	Graphics::MaterialDescriptor surfDesc;
@@ -687,8 +684,8 @@ void GasGiant::SetUpMaterials()
 	surfDesc.textures = 1;
 
 	//planetoid with atmosphere
-	const AtmosphereParameters ap(GetSystemBody()->CalcAtmosphereParams());
-	assert(ap.atmosDensity > 0.0);
+	m_atmosphereParameters = GetSystemBody()->CalcAtmosphereParams();
+	assert(m_atmosphereParameters.atmosDensity > 0.0);
 	assert(m_surfaceTextureSmall.Valid() || m_surfaceTexture.Valid());
 
 	// surface material is solid

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -423,16 +423,14 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 		SetUpMaterials();
 
 	//Update material parameters
-	//XXX no need to calculate AP every frame
-	auto ap = GetSystemBody()->CalcAtmosphereParams();
-	SetMaterialParameters(trans, radius, shadows, ap);
+	SetMaterialParameters(trans, radius, shadows, m_atmosphereParameters);
 
-	if (m_atmosphereMaterial.Valid() && ap.atmosDensity > 0.0) {
+	if (m_atmosphereMaterial.Valid() && m_atmosphereParameters.atmosDensity > 0.0) {
 		// make atmosphere sphere slightly bigger than required so
 		// that the edges of the pixel shader atmosphere jizz doesn't
 		// show ugly polygonal angles
 		DrawAtmosphereSurface(renderer, trans, campos,
-			ap.atmosRadius * 1.02,
+			m_atmosphereParameters.atmosRadius * 1.02,
 			m_atmosphereMaterial);
 	}
 
@@ -502,6 +500,7 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 
 void GeoSphere::SetUpMaterials()
 {
+	m_atmosphereParameters = GetSystemBody()->CalcAtmosphereParams();
 	// normal star has a different setup path than geosphere terrain does
 	if (GetSystemBody()->GetSuperType() == SystemBody::SUPERTYPE_STAR) {
 		Graphics::MaterialDescriptor surfDesc;
@@ -528,9 +527,8 @@ void GeoSphere::SetUpMaterials()
 			surfDesc.quality &= ~Graphics::HAS_ATMOSPHERE;
 		} else {
 			//planetoid with or without atmosphere
-			const AtmosphereParameters ap(GetSystemBody()->CalcAtmosphereParams());
 			surfDesc.lighting = true;
-			if (ap.atmosDensity > 0.0) {
+			if (m_atmosphereParameters.atmosDensity > 0.0) {
 				surfDesc.quality |= Graphics::HAS_ATMOSPHERE;
 			}
 		}


### PR DESCRIPTION
This is a bit of tidying up, dealing with the old comment `//XXX no need to calculate AP every frame` by calculating the atmosphere parameters only once.

It does mean bumping the BaseSphere size from 48 bytes to 128 bytes but that can't really be avoided.

No visual or gameplay differences

