### PR TITLE
Fix MILITARY tech level display and availability.

### DIFF
--- a/data/modules/Equipment/Hyperdrive.lua
+++ b/data/modules/Equipment/Hyperdrive.lua
@@ -96,7 +96,7 @@ Equipment.Register("hyperspace.hyperdrive_mil3", HyperdriveType.New {
 	slot = { type="hyperdrive.military", size=3 },
 	mass=12.5, volume=15, capabilities={ hyperclass=3 },
 	fuel_resv_size = 10, factor_eff = 60,
-	price=85000, purchasable=true, tech_level=11,
+	price=85000, purchasable=true, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
 Equipment.Register("hyperspace.hyperdrive_mil4", HyperdriveType.New {
@@ -104,7 +104,7 @@ Equipment.Register("hyperspace.hyperdrive_mil4", HyperdriveType.New {
 	slot = { type="hyperdrive.military", size=4 },
 	mass=32, volume=40, capabilities={ hyperclass=4 },
 	fuel_resv_size = 30, factor_eff = 48,
-	price=214000, purchasable=true, tech_level=12,
+	price=214000, purchasable=true, tech_level="MILITARY",
 	icon_name="equip_hyperdrive_mil"
 })
 Equipment.Register("hyperspace.hyperdrive_mil5", HyperdriveType.New {

--- a/data/pigui/libs/equipment-outfitter.lua
+++ b/data/pigui/libs/equipment-outfitter.lua
@@ -494,9 +494,15 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 	ui.text(label)
 
 	local icon_size = Vector2(ui.getTextLineHeight())
+	local cmp_a, cmp_b = "", ""
+	if stat_a then
+		cmp_a = stat_a[3] == "MILITARY" and 11 or stat_a[3]
+	end
+	if stat_b then
+		cmp_b = stat_b[3] == "MILITARY" and 11 or stat_b[3]
+	end
 	local color = stat_a and stat_b
-		and stat_a[3] ~= "MILITARY" and stat_b[3] ~= "MILITARY"
-		and compare(stat_a[3], stat_b[3], stat_a[5])
+		and compare(cmp_a, cmp_b, stat_a[5])
 		or colors.font
 
 	ui.tableNextColumn()
@@ -508,7 +514,7 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 		if val ~= "MILITARY" then
 			ui.textColored(color, format(val))
 		else
-			ui.icon(icons.shield_other, icon_size, colors.font)
+			ui.icon(icons.shield_other, icon_size, color)
 		end
 	end
 
@@ -521,7 +527,7 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 		if val ~= "MILITARY" then
 			ui.textColored(color, format(val))
 		else
-			ui.icon(icons.shield_other, icon_size, colors.font)
+			ui.icon(icons.shield_other, icon_size, color)
 		end
 	end
 end

--- a/data/pigui/libs/equipment-outfitter.lua
+++ b/data/pigui/libs/equipment-outfitter.lua
@@ -196,8 +196,12 @@ end
 --==================
 
 function Outfitter:stationHasTech(level)
-	level = level == "MILITARY" and 11 or level
-	return self.station.techLevel >= level
+	if level ~= "MILITARY" then
+		return self.station.techLevel >= level
+	else
+		level = 11
+		return self.station.techLevel == level
+	end
 end
 
 -- Override to support e.g. custom equipment shops
@@ -491,6 +495,7 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 
 	local icon_size = Vector2(ui.getTextLineHeight())
 	local color = stat_a and stat_b
+		and stat_a[3] ~= "MILITARY" and stat_b[3] ~= "MILITARY"
 		and compare(stat_a[3], stat_b[3], stat_a[5])
 		or colors.font
 
@@ -500,7 +505,11 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 		ui.sameLine()
 
 		local val, format = stat_a[3], stat_a[4]
-		ui.textColored(color, format(val))
+		if val ~= "MILITARY" then
+			ui.textColored(color, format(val))
+		else
+			ui.icon(icons.shield_other, icon_size, colors.font)
+		end
 	end
 
 	ui.tableNextColumn()
@@ -509,7 +518,11 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 		ui.sameLine()
 
 		local val, format = stat_b[3], stat_b[4]
-		ui.text(format(val))
+		if val ~= "MILITARY" then
+			ui.textColored(color, format(val))
+		else
+			ui.icon(icons.shield_other, icon_size, colors.font)
+		end
 	end
 end
 


### PR DESCRIPTION
fix #6039
RE #6046 

This PR addresses two related issues:

* The `MILITARY` tech level causes a GUI crash in `renderCompareRow()` in `equipment-outfitter.lua` because it assumes a numeric value.
  - Fix: If the tech level is `MILITARY`, in `renderCompareRow()`, skip the level comparison (if applicable) and render the level as the police shield icon (see screenshot).
* In `equipment-outfitter.lua`, `stationHasTech()` currently interprets `MILITARY` as tech level 11, making `MILITARY` equipment available in tech level 12 stations (e.g., Torvalds Platform).
  - Fix: If the tech level is `MILITARY`, interpret the level as 11 as before, but only pass the check if the station's level is also 11. In addition, change the tech level for the S3 and S4 military drives to `MILITARY`.

![tech_level](https://github.com/user-attachments/assets/4771349d-1a05-4091-a010-dea9ddeded72)
