### PR TITLE
Change modelcompiler single model filepathing, change Editor location for MSVC

### DIFF
--- a/src/editor/CMakeLists.txt
+++ b/src/editor/CMakeLists.txt
@@ -28,4 +28,9 @@ list(APPEND EDITOR_LIBRARIES
 add_executable(editor WIN32 editormain.cpp ${RESOURCES})
 set_cxx_properties(editor)
 target_link_libraries(editor LINK_PRIVATE ${EDITOR_LIBRARIES} ${pioneerLibs} ${winLibs})
-set_target_properties(editor PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+if (MSVC)
+	# Put the output into the root dir so it can be run from Visual Studio
+	set_target_properties(editor PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
+else()
+	set_target_properties(editor PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+endif (MSVC)

--- a/src/modelcompiler.cpp
+++ b/src/modelcompiler.cpp
@@ -220,25 +220,26 @@ start:
 			if (argc > 3) {
 				std::string arg3 = argv[3];
 				isInPlace = (arg3 == "inplace" || arg3 == "true");
+			}
 
-				// find all of the models
-				FileSystem::FileSource &fileSource = FileSystem::gameDataFiles;
-				for (FileSystem::FileEnumerator files(fileSource, "models", FileSystem::FileEnumerator::Recurse); !files.Finished(); files.Next()) {
-					const FileSystem::FileInfo &info = files.Current();
-					const std::string &fpath = info.GetPath();
+			// find all of the models
+			FileSystem::FileSource &fileSource = FileSystem::gameDataFiles;
+			for (FileSystem::FileEnumerator files(fileSource, "models", FileSystem::FileEnumerator::Recurse); !files.Finished(); files.Next()) {
+				const FileSystem::FileInfo &info = files.Current();
+				const std::string &fpath = info.GetPath();
 
-					//check it's the expected type
-					if (info.IsFile()) {
-						if (ends_with_ci(fpath, ".model")) { // store the path for ".model" files
-							const std::string shortname(info.GetName().substr(0, info.GetName().size() - 6));
-							if (shortname == modelName) {
-								filePath = fpath;
-								break;
-							}
+				//check it's the expected type
+				if (info.IsFile()) {
+					if (ends_with_ci(fpath, ".model")) { // store the path for ".model" files
+						const std::string shortname(info.GetName().substr(0, info.GetName().size() - 6));
+						if (shortname == modelName) {
+							filePath = fpath;
+							break;
 						}
 					}
 				}
 			}
+
 			SetupRenderer();
 			RunCompiler(modelName, filePath, isInPlace);
 		}


### PR DESCRIPTION
I noticed a bug/issue when trying to convert a single model to SGM format. It would only output the SGM to the full filepath if I specified `inplace` or some other 3rd parameter.

I've changed this to always find the full filepath regardless of having extra parameters.

The `Editor.exe` was also being output to a folder which meant I couldn't debug it from MSVC so for MSVC builds it now output to the CMAKE_SOURCE_DIR like the game and other tools.