### PR TITLE
Make Sphere3D/Icosphere reserve space better

### DIFF
--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -80,8 +80,12 @@ void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
 
 	renderer->SetTransform(matrix4x4f(modelView * matrix4x4d::ScaleMatrix(rad) * invrot));
 
-	if (!m_atmos)
-		m_atmos.reset(new Drawables::Sphere3D(renderer, 4, 1.0f, ATTRIB_POSITION));
+	if (!m_atmos) {
+		// 5 subdivision = 20472 verts, 61440 indices NB: this should be configurable!
+		static constexpr int subdivisions = 5;
+		m_atmos.reset(new Drawables::Sphere3D(renderer, subdivisions, 1.0f, ATTRIB_POSITION));
+	}
+	
 	m_atmos->Draw(renderer, mat.Get());
 
 	renderer->GetStats().AddToStatCount(Graphics::Stats::STAT_ATMOSPHERES, 1);

--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -6,6 +6,8 @@
 #include "GasGiant.h"
 #include "GeoSphere.h"
 
+#include "Pi.h"
+
 #include "galaxy/AtmosphereParameters.h"
 #include "galaxy/SystemBody.h"
 #include "graphics/Drawables.h"
@@ -42,11 +44,12 @@ BaseSphere::BaseSphere(const SystemBody *body) :
 BaseSphere::~BaseSphere() {}
 
 //static
-void BaseSphere::Init()
+void BaseSphere::Init(Graphics::Renderer *renderer)
 {
 	PROFILE_SCOPED()
 	GeoSphere::InitGeoSphere();
 	GasGiant::InitGasGiant();
+	ResetAtmosphereGeometry(renderer);
 }
 
 //static
@@ -64,9 +67,11 @@ void BaseSphere::UpdateAllBaseSphereDerivatives()
 }
 
 //static
-void BaseSphere::OnChangeDetailLevel()
+void BaseSphere::OnChangeDetailLevel(Graphics::Renderer *renderer)
 {
 	GeoSphere::OnChangeGeoSphereDetailLevel();
+	GasGiant::OnChangeGasGiantsDetailLevel();
+	ResetAtmosphereGeometry(renderer);
 }
 
 void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
@@ -74,7 +79,7 @@ void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
 	RefCountedPtr<Graphics::Material> mat)
 {
 	PROFILE_SCOPED()
-	using namespace Graphics;
+	assert(m_atmos != nullptr);
 	const vector3d yaxis = campos.Normalized();
 	const vector3d zaxis = vector3d(1.0, 0.0, 0.0).Cross(yaxis).Normalized();
 	const vector3d xaxis = yaxis.Cross(zaxis);
@@ -82,12 +87,6 @@ void BaseSphere::DrawAtmosphereSurface(Graphics::Renderer *renderer,
 
 	renderer->SetTransform(matrix4x4f(modelView * matrix4x4d::ScaleMatrix(rad) * invrot));
 
-	if (!m_atmos) {
-		// 5 subdivision = 20472 verts, 61440 indices NB: this should be configurable!
-		static constexpr int subdivisions = 5;
-		m_atmos.reset(new Drawables::Sphere3D(renderer, subdivisions, 1.0f, ATTRIB_POSITION));
-	}
-	
 	m_atmos->Draw(renderer, mat.Get());
 
 	renderer->GetStats().AddToStatCount(Graphics::Stats::STAT_ATMOSPHERES, 1);
@@ -131,5 +130,20 @@ void BaseSphere::SetMaterialParameters(const matrix4x4d &trans, const float radi
 	if (m_atmosphereMaterial.Valid() && ap.atmosDensity > 0.0) {
 		m_atmosphereMaterial->SetBufferDynamic(s_baseSphereData, &matData);
 		m_atmosphereMaterial->SetPushConstant(s_numShadows, int(shadows.size()));
+	}
+}
+
+void BaseSphere::ResetAtmosphereGeometry(Graphics::Renderer *renderer)
+{
+	if (renderer) {
+		if (m_atmos) {
+			m_atmos.reset();
+		}
+
+		// 4 subdivision = 5112 verts, 15360 indices
+		// 5 subdivision = 20472 verts, 61440 indices
+		// Pi::detail.planets == 3 if High detail, 4 is Very high
+		int subdivisions = Pi::detail.planets >= 3 ? 5 : 4;
+		m_atmos.reset(new Graphics::Drawables::Sphere3D(renderer, subdivisions, 1.0f, Graphics::ATTRIB_POSITION));
 	}
 }

--- a/src/BaseSphere.cpp
+++ b/src/BaseSphere.cpp
@@ -33,6 +33,8 @@ struct BaseSphereDataBlock {
 };
 static_assert(sizeof(BaseSphereDataBlock) == 192, "");
 
+std::unique_ptr<Graphics::Drawables::Sphere3D> BaseSphere::m_atmos;
+
 BaseSphere::BaseSphere(const SystemBody *body) :
 	m_sbody(body),
 	m_terrain(Terrain::InstanceTerrain(body)) {}

--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -62,7 +62,7 @@ protected:
 	RefCountedPtr<Graphics::Material> m_atmosphereMaterial;
 
 	// atmosphere geometry
-	std::unique_ptr<Graphics::Drawables::Sphere3D> m_atmos;
+	static std::unique_ptr<Graphics::Drawables::Sphere3D> m_atmos; // always created with the same parameters so can be shared by all atmospheres
 	AtmosphereParameters m_atmosphereParameters;
 };
 

--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -28,10 +28,10 @@ public:
 
 	virtual double GetHeight(const vector3d &p) const { return 0.0; }
 
-	static void Init();
+	static void Init(Graphics::Renderer *renderer);
 	static void Uninit();
 	static void UpdateAllBaseSphereDerivatives();
-	static void OnChangeDetailLevel();
+	static void OnChangeDetailLevel(Graphics::Renderer *renderer);
 
 	void DrawAtmosphereSurface(Graphics::Renderer *renderer,
 		const matrix4x4d &modelView, const vector3d &campos, float rad,
@@ -64,6 +64,9 @@ protected:
 	// atmosphere geometry
 	static std::unique_ptr<Graphics::Drawables::Sphere3D> m_atmos; // always created with the same parameters so can be shared by all atmospheres
 	AtmosphereParameters m_atmosphereParameters;
+
+private:
+	static void ResetAtmosphereGeometry(Graphics::Renderer *renderer);
 };
 
 #endif /* _GEOSPHERE_H */

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -282,7 +282,7 @@ void GasGiant::UpdateAllGasGiants()
 }
 
 // static
-void GasGiant::OnChangeDetailLevel()
+void GasGiant::OnChangeGasGiantsDetailLevel()
 {
 	s_patchContext.Reset(new GasPatchContext(127));
 

--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -50,7 +50,7 @@ public:
 	static void InitGasGiant();
 	static void UninitGasGiant();
 	static void UpdateAllGasGiants();
-	static void OnChangeDetailLevel();
+	static void OnChangeGasGiantsDetailLevel();
 
 	static void CreateRenderTarget(const Uint16 width, const Uint16 height);
 	static void SetRenderTargetCubemap(const Uint32, Graphics::Texture *, const bool unBind = true);

--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -289,7 +289,7 @@ void ObjectViewerView::OnChangeTerrain()
 	Pi::renderer->FlushCommandBuffers();
 
 	// force reload
-	TerrainBody::OnChangeDetailLevel();
+	TerrainBody::OnChangeDetailLevel(Pi::renderer);
 	ReloadState();
 }
 

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -578,7 +578,9 @@ void StartupScreen::Start()
 		Shields::Init(Pi::renderer);
 	});
 
-	AddStep("BaseSphere::Init", &BaseSphere::Init);
+	AddStep("BaseSphere::Init", []() {
+		BaseSphere::Init(Pi::renderer);
+	});
 
 	AddStep("CityOnPlanet::Init", &CityOnPlanet::Init);
 
@@ -853,7 +855,7 @@ void Pi::App::HandleRequests()
 			if (!Pi::game)
 				break;
 
-			BaseSphere::OnChangeDetailLevel();
+			BaseSphere::OnChangeDetailLevel(Pi::renderer);
 		} break;
 		default:
 			Output("Pi::HandleRequests, unhandled request type %d processed.\n", int(request));

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -151,8 +151,7 @@ double TerrainBody::GetTerrainHeight(const vector3d &pos_) const
 }
 
 //static
-void TerrainBody::OnChangeDetailLevel()
+void TerrainBody::OnChangeDetailLevel(Graphics::Renderer *r)
 {
-	GeoSphere::OnChangeDetailLevel();
-	GasGiant::OnChangeDetailLevel();
+	BaseSphere::OnChangeDetailLevel(r);
 }

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -34,7 +34,7 @@ public:
 	double GetMaxFeatureRadius() const { return m_maxFeatureHeight; }
 
 	// implements calls to all relevant terrain management sub-systems
-	static void OnChangeDetailLevel();
+	static void OnChangeDetailLevel(Graphics::Renderer *r);
 
 protected:
 	TerrainBody() = delete;

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -491,9 +491,9 @@ namespace Graphics {
 			{ 12, 60 }, // subdivs 0
 			{ 72, 240 },
 			{ 312, 960 },
-			{ 1272, 3840 }, // subdivs 4 (planets atmopsheres as of 2025/02/11)
-			{ 5112, 15360 },
-			{ 20472, 61440 },
+			{ 1272, 3840 },
+			{ 5112, 15360 }, // subdivs 4 (old default planet atmospheres)
+			{ 20472, 61440 }, // subdivs 5 (current default planet atmospheres)
 			{ 81912, 245760 },
 			{ 327672, 983040 },
 			{ 1310712, 3932160 },

--- a/src/graphics/Drawables.h
+++ b/src/graphics/Drawables.h
@@ -150,7 +150,7 @@ namespace Graphics {
 		// and spherical texture coordinates.
 		class Sphere3D {
 		public:
-			//subdivisions must be 0-4
+			//subdivisions must be 0-10
 			Sphere3D(Renderer *, int subdivisions = 0, float scale = 1.f, AttributeSet attribs = (ATTRIB_POSITION | ATTRIB_NORMAL | ATTRIB_UV0));
 			void Draw(Renderer *r, Material *m);
 

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -489,7 +489,7 @@ static int l_engine_get_planet_detail_level(lua_State *l)
 
 static int l_engine_set_planet_detail_level(lua_State *l)
 {
-	const int level = LuaConstants::GetConstantFromArg(l, "DetailLevel", 1);
+	const int level = Clamp(LuaConstants::GetConstantFromArg(l, "DetailLevel", 1), 0, 4); // limit the values to the valid range
 	if (level != Pi::detail.planets) {
 		Pi::detail.planets = level;
 		Pi::config->SetInt("DetailPlanets", level);
@@ -507,7 +507,7 @@ static int l_engine_get_city_detail_level(lua_State *l)
 
 static int l_engine_set_city_detail_level(lua_State *l)
 {
-	const int level = LuaConstants::GetConstantFromArg(l, "DetailLevel", 1);
+	const int level = Clamp(LuaConstants::GetConstantFromArg(l, "DetailLevel", 1), 0, 4); // limit the values to the valid range
 	if (level != Pi::detail.cities) {
 		Pi::detail.cities = level;
 		Pi::config->SetInt("DetailCities", level);


### PR DESCRIPTION
Whilst doing something else I found that the Icosphere::Generate method wasn't reserving space for the indices it generates, and it was also miscalculating the number of vertices it would generate.

I spent some time trying to figure out a nifty formula to calculate those values and then realised I could just build a table of 11 entries for each of the valid subdivision we allow instead.

I have also increased the BaseSphere use of subdivision to 5 (from 4) for smoother atmospheres.

EDIT:
Made the `BaseSphere::m_atmos` into a static so it's only created once and used throughout the games lifetime instead of creating a new one for every single planet with an atmosphere. Making the icosphere generation faster is good, but avoiding doing it altogether is better still!
