### PR TITLE
Fix  lighting on models that use normal maps

### DIFF
--- a/src/graphics/opengl/VertexBufferGL.cpp
+++ b/src/graphics/opengl/VertexBufferGL.cpp
@@ -20,7 +20,7 @@ namespace Graphics {
 			case ATTRIB_NORMAL: return 1;
 			case ATTRIB_DIFFUSE: return 2;
 			case ATTRIB_UV0: return 3;
-			case ATTRIB_TANGENT: return 4;
+			case ATTRIB_TANGENT: return 5;
 			default:
 				assert(false);
 				return 0;


### PR DESCRIPTION
The lighting on the models that use a normal map were not looking correct and the normal map had no effect on lighting.
I setup a test shader that did a dump of a_tangent and it was always (0, 0, 0) which explained why the normal calc in the fragment shader was incorrect.  I then did a dump of a_uv1 and it had the tangent data.  I swapped the locations of a_tangent and a_uv1 in attributes.glsl and the lighting on normal mapped models now looks correct , to me :).

After some digging I found that attributes.glsl and Program.cpp have tangent at location 5 but the vertex buffer layout in VertexBufferGL.cpp (line 23) has tangent at index 4.

So by putting a_tangent in location 4 the lighting is now correct for models using a normal map

