### PR TITLE
Resurrect region based terrain flattening

### DIFF
--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -217,6 +217,8 @@ GeoSphere::GeoSphere(const SystemBody *body) :
 	}
 
 	//SetUpMaterials is not called until first Render since light count is zero :)
+
+	m_terrain->InitCityRegions(body);
 }
 
 GeoSphere::~GeoSphere()

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -633,7 +633,7 @@ Terrain::~Terrain()
 {
 }
 
-static constexpr double TARGET_CITY_RADIUS = 5000.0;
+static constexpr double TARGET_CITY_RADIUS = 600.0;
 
 // Set up region data for each of the system body's child surface starports
 void Terrain::InitCityRegions(const SystemBody *sb)

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -633,6 +633,95 @@ Terrain::~Terrain()
 {
 }
 
+static constexpr double TARGET_CITY_RADIUS = 5000.0;
+#pragma optimize(off, "")
+// Set up region data for each of the system body's child surface starports
+void Terrain::InitCityRegions(const SystemBody *body)
+{
+	m_regionTypes.clear();
+	m_positions.clear();
+
+	const SystemBody *&sb = body;
+	if (!sb->HasChildren()) {
+		return;
+	}
+
+	//Terrain *terrain = static_cast<Terrain *>(this);
+
+	m_regionTypes.reserve(16);
+	m_positions.reserve(16);
+
+	// step through the planet's sbody's children and set up regions for surface starports
+	for (std::vector<SystemBody *>::const_iterator i = sb->GetChildren().begin(); i != sb->GetChildren().end(); i++) {
+		if ((*i)->GetType() == SystemBody::TYPE_STARPORT_SURFACE) {
+			const double delta = (0.75 * TARGET_CITY_RADIUS / m_planetRadius);
+			const double citySize_m = TARGET_CITY_RADIUS * 1.1;
+
+			// calculate position of starport
+			const vector3d pos = ((*i)->GetOrbit().GetPlane() * vector3d(0, 1, 0));
+
+			// set up regions which contain the details for region implementation
+			RegionType rt;
+
+			rt.height = GetHeight(pos); // height in planet radii
+
+			// Calculate average variation of four points about star port
+			// points do not need to be on the planet surface
+			double avgVariation = fabs(GetHeight(vector3d(pos.x + delta, pos.y, pos.z)) - rt.height);
+			avgVariation += fabs(GetHeight(vector3d(pos.x - delta, pos.y, pos.z)) - rt.height);
+			avgVariation += fabs(GetHeight(vector3d(pos.x, pos.y, pos.z + delta)) - rt.height);
+			avgVariation += fabs(GetHeight(vector3d(pos.x, pos.y, pos.z - delta)) - rt.height);
+			avgVariation *= (1 / 4.0);
+			rt.heightVariation = 1.0 / m_planetRadius + 0.625 * avgVariation;
+
+			const double size = fabs(cos(std::min(citySize_m, 0.2 * sb->GetRadius()) / (sb->GetRadius()))); // angle between city center/boundary = 2pi*city size/(perimeter great circle = 2pi r)
+			rt.outer = size;																				// city center pos and current point will be dotted, and compared against size
+			rt.inner = (1.0 - size) * 0.5 + size;
+
+			m_positions.emplace_back(pos);
+			m_regionTypes.emplace_back(rt);
+		}
+	}
+}
+
+void Terrain::ApplySimpleHeightRegions(double &h, const vector3d &p) const
+{
+	const double dynamicRangeHeight = 60.0 / m_planetRadius; //in radii
+	for (unsigned int i = 0; i < m_positions.size(); i++) {
+		const vector3d &pos = m_positions[i];
+		const RegionType &rt = m_regionTypes[i];
+		if (pos.Dot(p) > rt.outer) {
+			// target height
+			const double th = rt.height;
+
+			// maximum variation in height with respect to target height
+			const double delta_h = fabs(h - th);
+			const double neg = (h - th > 0.0) ? 1.0 : -1.0;
+
+			// Make up an expression to compress delta_h:
+			// Compress delta_h between 0 and 1
+			//    1.1 use compression of the form c = (delta_h+a)/(a+(delta_h+a)) (eqn. 1)
+			//    1.2 this gives c in the interval [0.5, 1] for delta_h [0, +inf] with c=0.5 at delta_h=0.
+			//  2.0 Use compressed_h = dynamic range*(sign(h-th)*(c-0.5)) (eqn. 2) to get h between th-0.5*dynamic range, th+0.5*dynamic range
+
+			// Choosing a value for a
+			//    3.1 c [0.5, 0.8] occurs when delta_h [a to 3a] (3x difference) which is roughly the expressible range (above or below that the function changes slowly)
+			//    3.2 Find an expression for the expected variation and divide by around 3
+
+			// It may become necessary calculate expected variation based on intermediate quantities generated (e.g. distribution fractals)
+			// or to store a per planet estimation of variation when fracdefs are calculated.
+			const double variationEstimate = rt.heightVariation;
+			const double a = variationEstimate * (1.0 / 3.0); // point 3.2
+
+			const double c = (delta_h + a) / (2.0 * a + delta_h);					 // point 1.1
+			const double compressed_h = dynamicRangeHeight * (neg * (c - 0.5)) + th; // point 2.0
+
+			h= MathUtil::Lerp(h, compressed_h, Clamp((pos.Dot(p) - rt.outer) / (rt.inner - rt.outer), 0.0, 1.0));
+			break; // blends from compressed height-terrain height as pos goes inner to outer
+		}
+	}
+}
+#pragma optimize(on, "")
 /**
  * Feature width means roughly one perlin noise blob or grain.
  * This will end up being one hill, mountain or continent, roughly.

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -22,6 +22,14 @@ class SystemBody;
 template <typename, typename>
 class TerrainGenerator;
 
+// data about regions from feature to heightmap code go here
+struct RegionType {
+	double height;
+	double heightVariation;
+	double inner;
+	double outer;
+};
+
 class Terrain : public RefCounted {
 public:
 	// location and intensity of effects are controlled by the colour fractals;
@@ -35,6 +43,8 @@ public:
 	static Terrain *InstanceTerrain(const SystemBody *body);
 
 	virtual ~Terrain();
+
+	void InitCityRegions(const SystemBody *body);
 
 	void SetFracDef(const unsigned int index, const double featureHeightMeters, const double featureWidthMeters, const double smallestOctaveMeters = 20.0);
 	inline const fracdef_t &GetFracDef(const unsigned int index) const
@@ -65,6 +75,7 @@ private:
 
 protected:
 	Terrain(const SystemBody *body);
+	void ApplySimpleHeightRegions(double &h, const vector3d &p) const;
 
 	Uint32 m_seed;
 	Random m_rand;
@@ -118,6 +129,10 @@ protected:
 		std::string m_name;
 	};
 	MinBodyData m_minBody;
+
+	// used for region based terrain e.g. cities
+	std::vector<vector3d> m_positions;
+	std::vector<RegionType> m_regionTypes;
 };
 
 template <typename HeightFractal>

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -44,7 +44,7 @@ public:
 
 	virtual ~Terrain();
 
-	void InitCityRegions(const SystemBody *body);
+	void InitCityRegions(const SystemBody *sb);
 
 	void SetFracDef(const unsigned int index, const double featureHeightMeters, const double featureWidthMeters, const double smallestOctaveMeters = 20.0);
 	inline const fracdef_t &GetFracDef(const unsigned int index) const

--- a/src/terrain/TerrainColorEarthLikeHeightmapped.cpp
+++ b/src/terrain/TerrainColorEarthLikeHeightmapped.cpp
@@ -23,6 +23,17 @@ TerrainColorFractal<TerrainColorEarthLikeHeightmapped>::TerrainColorFractal(cons
 template <>
 vector3d TerrainColorFractal<TerrainColorEarthLikeHeightmapped>::GetColor(const vector3d &p, double height, const vector3d &norm) const
 {
+#if 0
+	// debug colour code
+	// if within city region set colour to debug pink
+	for (size_t ii = 0; ii < m_positions.size(); ii++) { //used for 2 vecs
+		const vector3d &pos = m_positions[ii];
+		if (pos.Dot(p) >= m_regionTypes[ii].outer) {
+			return vector3d(1, 0, 1);
+		}
+	}
+	return vector3d(.3, .3, .3);
+#endif
 	double n = m_invMaxHeight * height;
 	double flatness = pow(p.Dot(norm), 8.0);
 

--- a/src/terrain/TerrainHeightAsteroid.cpp
+++ b/src/terrain/TerrainHeightAsteroid.cpp
@@ -25,7 +25,7 @@ TerrainHeightFractal<TerrainHeightAsteroid>::TerrainHeightFractal(const SystemBo
 template <>
 double TerrainHeightFractal<TerrainHeightAsteroid>::GetHeight(const vector3d &p) const
 {
-	const double n = octavenoise(GetFracDef(0), 0.4, p) * dunes_octavenoise(GetFracDef(1), 0.5, p);
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+	double n = octavenoise(GetFracDef(0), 0.4, p) * dunes_octavenoise(GetFracDef(1), 0.5, p) * m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightAsteroid2.cpp
+++ b/src/terrain/TerrainHeightAsteroid2.cpp
@@ -28,8 +28,10 @@ TerrainHeightFractal<TerrainHeightAsteroid2>::TerrainHeightFractal(const SystemB
 template <>
 double TerrainHeightFractal<TerrainHeightAsteroid2>::GetHeight(const vector3d &p) const
 {
-	const double n = voronoiscam_octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 15.0 * octavenoise(GetFracDef(1), 0.5, p), p) *
-		0.75 * ridged_octavenoise(16.0 * octavenoise(GetFracDef(2), 0.275, p), 0.4 * ridged_octavenoise(GetFracDef(3), 0.4, p), 4.0 * octavenoise(GetFracDef(4), 0.35, p), p);
+	double n = voronoiscam_octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 15.0 * octavenoise(GetFracDef(1), 0.5, p), p) *
+		0.75 * ridged_octavenoise(16.0 * octavenoise(GetFracDef(2), 0.275, p), 0.4 * ridged_octavenoise(GetFracDef(3), 0.4, p), 4.0 * octavenoise(GetFracDef(4), 0.35, p), p) *
+		m_maxHeight;
 
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightAsteroid3.cpp
+++ b/src/terrain/TerrainHeightAsteroid3.cpp
@@ -25,7 +25,7 @@ TerrainHeightFractal<TerrainHeightAsteroid3>::TerrainHeightFractal(const SystemB
 template <>
 double TerrainHeightFractal<TerrainHeightAsteroid3>::GetHeight(const vector3d &p) const
 {
-	const double n = octavenoise(GetFracDef(0), 0.5, p) * ridged_octavenoise(GetFracDef(1), 0.5, p);
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+	double n = octavenoise(GetFracDef(0), 0.5, p) * ridged_octavenoise(GetFracDef(1), 0.5, p) * m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightAsteroid4.cpp
+++ b/src/terrain/TerrainHeightAsteroid4.cpp
@@ -28,8 +28,9 @@ TerrainHeightFractal<TerrainHeightAsteroid4>::TerrainHeightFractal(const SystemB
 template <>
 double TerrainHeightFractal<TerrainHeightAsteroid4>::GetHeight(const vector3d &p) const
 {
-	const double n = octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 2.8 * ridged_octavenoise(GetFracDef(1), 0.5, p), p) *
-		0.75 * ridged_octavenoise(16 * octavenoise(GetFracDef(2), 0.275, p), 0.3 * octavenoise(GetFracDef(3), 0.4, p), 2.8 * ridged_octavenoise(GetFracDef(4), 0.35, p), p);
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+	double n = octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 2.8 * ridged_octavenoise(GetFracDef(1), 0.5, p), p) *
+		0.75 * ridged_octavenoise(16 * octavenoise(GetFracDef(2), 0.275, p), 0.3 * octavenoise(GetFracDef(3), 0.4, p), 2.8 * ridged_octavenoise(GetFracDef(4), 0.35, p), p) *
+		m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightBarrenRock.cpp
+++ b/src/terrain/TerrainHeightBarrenRock.cpp
@@ -28,7 +28,7 @@ double TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeight(const vector3d &
 	/*return std::max(0.0, m_maxHeight * (octavenoise(GetFracDef(0), 0.5, p) +
 			GetFracDef(1).amplitude * crater_function(GetFracDef(1), p)));*/
 	//fuck the fracdefs, direct control is better:
-	double n = ridged_octavenoise(16, 0.5 * octavenoise(8, 0.4, 2.5, p), Clamp(5.0 * octavenoise(8, 0.257, 4.0, p), 1.0, 5.0), p);
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+	double n = ridged_octavenoise(16, 0.5 * octavenoise(8, 0.4, 2.5, p), Clamp(5.0 * octavenoise(8, 0.257, 4.0, p), 1.0, 5.0), p) * m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightBarrenRock2.cpp
+++ b/src/terrain/TerrainHeightBarrenRock2.cpp
@@ -25,6 +25,6 @@ double TerrainHeightFractal<TerrainHeightBarrenRock2>::GetHeight(const vector3d 
 {
 
 	double n = billow_octavenoise(16, 0.3 * octavenoise(8, 0.4, 2.5, p), Clamp(5.0 * ridged_octavenoise(8, 0.377, 4.0, p), 1.0, 5.0), p);
-
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? m_maxHeight * n : 0.0);
 }

--- a/src/terrain/TerrainHeightBarrenRock3.cpp
+++ b/src/terrain/TerrainHeightBarrenRock3.cpp
@@ -22,8 +22,7 @@ TerrainHeightFractal<TerrainHeightBarrenRock3>::TerrainHeightFractal(const Syste
 template <>
 double TerrainHeightFractal<TerrainHeightBarrenRock3>::GetHeight(const vector3d &p) const
 {
-
-	float n = 0.07 * voronoiscam_octavenoise(12, Clamp(fabs(0.165 - (0.38 * river_octavenoise(12, 0.4, 2.5, p))), 0.15, 0.5), Clamp(8.0 * billow_octavenoise(12, 0.37, 4.0, p), 0.5, 9.0), p);
-
+	double n = 0.07 * voronoiscam_octavenoise(12, Clamp(fabs(0.165 - (0.38 * river_octavenoise(12, 0.4, 2.5, p))), 0.15, 0.5), Clamp(8.0 * billow_octavenoise(12, 0.37, 4.0, p), 0.5, 9.0), p);
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? m_maxHeight * n : 0.0);
 }

--- a/src/terrain/TerrainHeightHillsCraters.cpp
+++ b/src/terrain/TerrainHeightHillsCraters.cpp
@@ -40,5 +40,6 @@ double TerrainHeightFractal<TerrainHeightHillsCraters>::GetHeight(const vector3d
 	n += crater_function(GetFracDef(3), p);
 	n += crater_function(GetFracDef(4), p);
 	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightHillsCraters2.cpp
+++ b/src/terrain/TerrainHeightHillsCraters2.cpp
@@ -48,5 +48,6 @@ double TerrainHeightFractal<TerrainHeightHillsCraters2>::GetHeight(const vector3
 	n += crater_function(GetFracDef(7), p);
 	n += crater_function(GetFracDef(8), p);
 	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightHillsDunes.cpp
+++ b/src/terrain/TerrainHeightHillsDunes.cpp
@@ -51,5 +51,7 @@ double TerrainHeightFractal<TerrainHeightHillsDunes>::GetHeight(const vector3d &
 		n += m;
 	//n += continents*Clamp(0.5-m, 0.0, 0.5)*0.2*dunes_octavenoise(GetFracDef(6), 0.6*distrib, p);
 	//n += continents*Clamp(0.05-n, 0.0, 0.01)*0.2*dunes_octavenoise(GetFracDef(2), Clamp(0.5-n, 0.0, 0.5), p);
-	return (n > 0.0 ? n * m_maxHeight : 0.0);
+	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightHillsNormal.cpp
+++ b/src/terrain/TerrainHeightHillsNormal.cpp
@@ -47,6 +47,7 @@ double TerrainHeightFractal<TerrainHeightHillsNormal>::GetHeight(const vector3d 
 	else
 		n += m;
 
-	if (n > 0.0) return n * m_maxHeight;
-	return 0.0;
+	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightHillsRidged.cpp
+++ b/src/terrain/TerrainHeightHillsRidged.cpp
@@ -45,5 +45,7 @@ double TerrainHeightFractal<TerrainHeightHillsRidged>::GetHeight(const vector3d 
 		n += m;
 	// was n -= 0.001*ridged_octavenoise(GetFracDef(6), 0.55*distrib*m, p);
 	//n += 0.001*ridged_octavenoise(GetFracDef(6), 0.55*distrib*m, p);
-	return (n > 0.0 ? n * m_maxHeight : 0.0);
+	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightHillsRivers.cpp
+++ b/src/terrain/TerrainHeightHillsRivers.cpp
@@ -49,5 +49,6 @@ double TerrainHeightFractal<TerrainHeightHillsRivers>::GetHeight(const vector3d 
 	n += continents * Clamp(0.5 - m, 0.0, 0.5) * 0.2 * river_octavenoise(GetFracDef(6), 0.6 * distrib, p);
 	n += continents * Clamp(0.05 - n, 0.0, 0.01) * 0.2 * dunes_octavenoise(GetFracDef(2), Clamp(0.5 - n, 0.0, 0.5), p);
 	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMapped.cpp
+++ b/src/terrain/TerrainHeightMapped.cpp
@@ -82,5 +82,7 @@ double TerrainHeightFractal<TerrainHeightMapped>::GetHeight(const vector3d &p) c
 		v += h;
 	}
 
-	return v < 0 ? 0 : (v * m_invPlanetRadius);
+	v *= m_invPlanetRadius;
+	ApplySimpleHeightRegions(v, p);
+	return v < 0 ? 0 : v;
 }

--- a/src/terrain/TerrainHeightMapped2.cpp
+++ b/src/terrain/TerrainHeightMapped2.cpp
@@ -29,6 +29,6 @@ double TerrainHeightFractal<TerrainHeightMapped2>::GetHeight(const vector3d &p) 
 	h += 30000.0 * v * v * v * v * v * v * v * ridged_octavenoise(16, 5.0 * v, 20.0 * v, p);
 	h += v;
 	h -= 0.09;
-
+	ApplySimpleHeightRegions(h, p);
 	return (h > 0.0 ? h : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsCraters.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters.cpp
@@ -45,5 +45,6 @@ double TerrainHeightFractal<TerrainHeightMountainsCraters>::GetHeight(const vect
 	n += crater_function(GetFracDef(5), p);
 	n += crater_function(GetFracDef(6), p);
 	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsCraters2.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters2.cpp
@@ -53,5 +53,6 @@ double TerrainHeightFractal<TerrainHeightMountainsCraters2>::GetHeight(const vec
 	n += crater_function(GetFracDef(8), p);
 	n += crater_function(GetFracDef(9), p);
 	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsNormal.cpp
+++ b/src/terrain/TerrainHeightMountainsNormal.cpp
@@ -128,5 +128,6 @@ double TerrainHeightFractal<TerrainHeightMountainsNormal>::GetHeight(const vecto
 	}
 
 	n = m_maxHeight * n;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsRidged.cpp
+++ b/src/terrain/TerrainHeightMountainsRidged.cpp
@@ -80,5 +80,6 @@ double TerrainHeightFractal<TerrainHeightMountainsRidged>::GetHeight(const vecto
 	}
 
 	n = m_maxHeight * n;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsRivers.cpp
+++ b/src/terrain/TerrainHeightMountainsRivers.cpp
@@ -140,5 +140,6 @@ double TerrainHeightFractal<TerrainHeightMountainsRivers>::GetHeight(const vecto
 	}
 
 	n = m_maxHeight * n;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
@@ -220,5 +220,6 @@ double TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::GetHeight(cons
 	}
 
 	n = m_maxHeight * n;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsVolcano.cpp
@@ -106,5 +106,6 @@ double TerrainHeightFractal<TerrainHeightMountainsVolcano>::GetHeight(const vect
 	}
 
 	n = m_maxHeight * n;
+	ApplySimpleHeightRegions(n, p);
 	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightRuggedDesert.cpp
+++ b/src/terrain/TerrainHeightRuggedDesert.cpp
@@ -44,7 +44,9 @@ double TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeight(const vector3d
 	//rocks = mountain_distrib * GetFracDef(9).amplitude * rocks*rocks*rocks;
 	//n += rocks ;
 
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return (n > 0.0 ? n : 0.0);
 }
 
 template <>

--- a/src/terrain/TerrainHeightRuggedLava.cpp
+++ b/src/terrain/TerrainHeightRuggedLava.cpp
@@ -94,6 +94,7 @@ double TerrainHeightFractal<TerrainHeightRuggedLava>::GetHeight(const vector3d &
 	rocks = continents * mountain_distrib * GetFracDef(9).amplitude * rocks * rocks * rocks * 2.0;
 	n += rocks;
 
-	n = (n < 0.0 ? 0.0 : m_maxHeight * n);
-	return n;
+	n *= m_maxHeight;
+	ApplySimpleHeightRegions(n, p);
+	return n > 0.0 ? n : 0.0;
 }

--- a/src/terrain/TerrainHeightWaterSolid.cpp
+++ b/src/terrain/TerrainHeightWaterSolid.cpp
@@ -60,5 +60,6 @@ double TerrainHeightFractal<TerrainHeightWaterSolid>::GetHeight(const vector3d &
 	n = m_maxHeight * n;
 	n = (n < 0.0 ? -n : n);
 	n = (n > 1.0 ? 2.0 - n : n);
+	ApplySimpleHeightRegions(n, p);
 	return n;
 }

--- a/src/terrain/TerrainHeightWaterSolidCanyons.cpp
+++ b/src/terrain/TerrainHeightWaterSolidCanyons.cpp
@@ -63,5 +63,6 @@ double TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::GetHeight(const vec
 	n = m_maxHeight * n;
 	n = (n < 0.0 ? 0 : n);
 	n = (n > 1.0 ? 2.0 - n : n);
+	ApplySimpleHeightRegions(n, p);
 	return n;
 }


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->
This was originally done by @Ae-2222 many (13/14) years ago in [this branch](https://github.com/Ae-2222/pioneer/tree/RegionBasedTerrainControl) and I've resurrected it here because issue #5154 is still a problem.

Fixes #5154

This works by querying for starports on a planet, adding them to a list, then checking that list whenever a height sample is requested... this has some performance implications but on my high end machine it runs very well. I've not yet tried it on a Raspberry Pi...

Putting this up as a draft to started discussion.

I have:
- reworked how it gets setup and initialised
- changed what was stored a little

Things I think it needs:
- optimising
- the blend method is strange to me but it works with a small enough region/city size set

**Issues:**
**- inconsistent results across machines!**
**- I don't think that it currently covers all starports on a planet!**
**- somtimes flattens terrain away from a starport whilst not flattening the starport**

Image taken at (0, -2, -2) `Gliese 1`
![PioneerGliese1](https://github.com/user-attachments/assets/82669d49-75a3-4954-9b33-3bd7326637d1)
