### PR TITLE
Minor optimisations and tweaks

### DIFF
--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -26,7 +26,7 @@ public:
 	virtual void Update() = 0;
 	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) = 0;
 
-	virtual double GetHeight(const vector3d &p) const = 0;
+	virtual double GetTerrainHeight(const vector3d &p) const = 0;
 
 	static void Init(Graphics::Renderer *renderer);
 	static void Uninit();

--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -26,7 +26,7 @@ public:
 	virtual void Update() = 0;
 	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) = 0;
 
-	virtual double GetHeight(const vector3d &p) const { return 0.0; }
+	virtual double GetHeight(const vector3d &p) const = 0;
 
 	static void Init(Graphics::Renderer *renderer);
 	static void Uninit();

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -379,7 +379,7 @@ void Camera::CalcLighting(const Body *b, double &ambient, double &direct) const
 	vector3d upDir = b->GetInterpPositionRelTo(rotFrame);
 	const double planetRadius = planet->GetSystemBody()->GetRadius();
 	const double dist = std::max(planetRadius, upDir.Length());
-	upDir = upDir.Normalized();
+	upDir.Normalize();
 
 	double pressure, density;
 	planet->GetAtmosphericState(dist, &pressure, &density);

--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -38,7 +38,7 @@ public:
 	void Update() override;
 	void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
 
-	double GetHeight(const vector3d &p) const final { return 0.0; }
+	double GetTerrainHeight(const vector3d &p) const final { return 0.0; }
 
 	// in sbody radii
 	double GetMaxFeatureHeight() const override { return 0.0; }

--- a/src/GeoPatchJobs.cpp
+++ b/src/GeoPatchJobs.cpp
@@ -30,23 +30,31 @@ void SSingleSplitRequest::GenerateMesh() const
 {
 	PROFILE_SCOPED()
 	const int borderedEdgeLen = edgeLen + (BORDER_SIZE * 2);
-#ifndef NDEBUG
 	const int numBorderedVerts = borderedEdgeLen * borderedEdgeLen;
-#endif
 
 	// generate heights plus a 1 unit border
-	double *bhts = borderHeights.get();
-	vector3d *vrts = borderVertexs.get();
+	std::vector<vector3d> positions;
+	positions.reserve(numBorderedVerts);
+	std::vector<double> heightsOut;
+	heightsOut.resize(numBorderedVerts);
 	for (int y = -BORDER_SIZE; y < borderedEdgeLen - BORDER_SIZE; y++) {
 		const double yfrac = double(y) * fracStep;
 		for (int x = -BORDER_SIZE; x < borderedEdgeLen - BORDER_SIZE; x++) {
 			const double xfrac = double(x) * fracStep;
 			const vector3d p = GetSpherePoint(v0, v1, v2, v3, xfrac, yfrac);
-			const double height = pTerrain->GetHeight(p);
-			assert(height >= 0.0f && height <= 1.0f);
-			*(bhts++) = height;
-			*(vrts++) = p * (height + 1.0);
+			positions.emplace_back(p);
 		}
+	}
+	pTerrain->GetHeights(positions, heightsOut);
+
+	double *bhts = borderHeights.get();
+	vector3d *vrts = borderVertexs.get();
+	for (int iHeights = 0; iHeights < numBorderedVerts; iHeights++)
+	{
+		const vector3d &p = positions[iHeights];
+		const double height = heightsOut[iHeights];
+		*(bhts++) = height;
+		*(vrts++) = p * (height + 1.0);
 	}
 	assert(bhts == &borderHeights.get()[numBorderedVerts]);
 
@@ -190,23 +198,30 @@ void SQuadSplitRequest::GenerateBorderedData() const
 {
 	PROFILE_SCOPED()
 	const int borderedEdgeLen = (edgeLen * 2) + (BORDER_SIZE * 2) - 1;
-#ifndef NDEBUG
 	const int numBorderedVerts = borderedEdgeLen * borderedEdgeLen;
-#endif
 
 	// generate heights plus a N=BORDER_SIZE unit border
-	double *bhts = borderHeights.get();
-	vector3d *vrts = borderVertexs.get();
+	std::vector<vector3d> positions;
+	positions.reserve(numBorderedVerts);
+	std::vector<double> heightsOut;
+	heightsOut.resize(numBorderedVerts);
 	for (int y = -BORDER_SIZE; y < (borderedEdgeLen - BORDER_SIZE); y++) {
 		const double yfrac = double(y) * (fracStep * 0.5);
 		for (int x = -BORDER_SIZE; x < (borderedEdgeLen - BORDER_SIZE); x++) {
 			const double xfrac = double(x) * (fracStep * 0.5);
 			const vector3d p = GetSpherePoint(v0, v1, v2, v3, xfrac, yfrac);
-			const double height = pTerrain->GetHeight(p);
-			assert(height >= 0.0f && height <= 1.0f);
-			*(bhts++) = height;
-			*(vrts++) = p * (height + 1.0);
+			positions.emplace_back(p);
 		}
+	}
+	pTerrain->GetHeights(positions, heightsOut);
+
+	double *bhts = borderHeights.get();
+	vector3d *vrts = borderVertexs.get();
+	for (int iHeights = 0; iHeights < numBorderedVerts; iHeights++) {
+		const vector3d &p = positions[iHeights];
+		const double height = heightsOut[iHeights];
+		*(bhts++) = height;
+		*(vrts++) = p * (height + 1.0);
 	}
 	assert(bhts == &borderHeights[numBorderedVerts]);
 }

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -35,15 +35,18 @@ public:
 	void Update() override;
 	void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
 
-	double GetHeight(const vector3d &p) const final
+	double GetTerrainHeight(const vector3d &p) const final
 	{
-		const double h = m_terrain->GetHeight(p);
+		std::vector<vector3d> pv{p};
+		std::vector<double> hv(size_t(1));
+		m_terrain->GetHeights(pv, hv);
+		const double h = hv[0];
 #ifndef NDEBUG
 		// XXX don't remove this. Fix your fractals instead
 		// Fractals absolutely MUST return heights >= 0.0 (one planet radius)
 		// otherwise atmosphere and other things break.
 		if (h < 0.0) {
-			Output("GetHeight({ %f, %f, %f }) returned %f\n", p.x, p.y, p.z, h);
+			Output("GetTerrainHeight({ %f, %f, %f }) returned %f\n", p.x, p.y, p.z, h);
 			m_terrain->DebugDump();
 			assert(h >= 0.0);
 		}

--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -189,6 +189,17 @@ void ObjectViewerView::DrawControlsWindow()
 		bool didChange = false;
 		uint32_t prevSeed = m_state.seed;
 
+		// if we can get the TerrainBody display the height and color fractal names, very useful for dev and debugging
+		if (const TerrainBody *terrainBody = static_cast<const TerrainBody *>(m_targetBody)) {
+			const char *heightFractalName = terrainBody->GetHeightFractalName();
+			const char *colorFractalName = terrainBody->GetColorFractalName();
+			if (heightFractalName) ImGui::Text("Height fractal: %s", heightFractalName);
+			if (colorFractalName) ImGui::Text("Color fractal: %s", colorFractalName);
+			ImGui::Spacing();
+			ImGui::Separator();
+			ImGui::Spacing();
+		}
+
 		ImGui::TextUnformatted("Seed");
 		int *seed = reinterpret_cast<int32_t *>(&m_state.seed);
 		didChange |= ImGui::DragInt("##seed", seed);

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -106,7 +106,7 @@ bool AICmdKill::TimeStepUpdate()
 	// ok, so now pick new direction
 	vector3d targdir = m_target->GetPositionRelTo(m_ship).Normalized();
 	vector3d tdir1 = targdir.Cross(vector3d(targdir.z+0.1, targdir.x, targdir.y));
-	tdir1 = tdir1.Normalized();
+	tdir1.Normalize();
 	vector3d tdir2 = targdir.Cross(tdir1);
 
 	double d1 = Pi::rng.Double() - 0.5;

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -143,7 +143,7 @@ double TerrainBody::GetTerrainHeight(const vector3d &pos_) const
 {
 	double radius = m_sbody->GetRadius();
 	if (m_baseSphere) {
-		return radius * (1.0 + m_baseSphere->GetHeight(pos_));
+		return radius * (1.0 + m_baseSphere->GetTerrainHeight(pos_));
 	} else {
 		assert(0);
 		return radius;

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -155,3 +155,20 @@ void TerrainBody::OnChangeDetailLevel(Graphics::Renderer *r)
 {
 	BaseSphere::OnChangeDetailLevel(r);
 }
+
+const char *TerrainBody::GetHeightFractalName() const
+{
+	if (Terrain* terrain = m_baseSphere->GetTerrain())
+	{
+		return terrain->GetHeightFractalName();
+	}
+	return nullptr;
+}
+
+const char* TerrainBody::GetColorFractalName() const
+{
+	if (Terrain *terrain = m_baseSphere->GetTerrain()) {
+		return terrain->GetColorFractalName();
+	}
+	return nullptr;
+}

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -36,6 +36,9 @@ public:
 	// implements calls to all relevant terrain management sub-systems
 	static void OnChangeDetailLevel(Graphics::Renderer *r);
 
+	const char *GetHeightFractalName() const;
+	const char *GetColorFractalName() const;
+
 protected:
 	TerrainBody() = delete;
 	TerrainBody(SystemBody *);

--- a/src/matrix4x4.h
+++ b/src/matrix4x4.h
@@ -479,7 +479,7 @@ public:
 		vector3<T> x(cell[0], cell[4], cell[8]);
 		vector3<T> y(cell[1], cell[5], cell[9]);
 		vector3<T> z(cell[2], cell[6], cell[10]);
-		x = x.Normalized();
+		x.Normalize();
 		z = x.Cross(y).Normalized();
 		y = z.Cross(x).Normalized();
 		cell[0] = x.x;

--- a/src/ship/Propulsion.cpp
+++ b/src/ship/Propulsion.cpp
@@ -394,7 +394,7 @@ double Propulsion::AIFaceUpdir(const vector3d &updir, double av)
 	vector3d uphead = updir * m_dBody->GetOrient(); // create desired object-space updir
 	if (uphead.z > 0.99999) return 0;				// bail out if facing updir
 	uphead.z = 0;
-	uphead = uphead.Normalized(); // only care about roll axis
+	uphead.Normalize(); // only care about roll axis
 
 	double ang = 0.0, dav = 0.0;
 	if (uphead.y < 0.99999999) {

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -491,9 +491,10 @@ Terrain::Terrain(const SystemBody *body) :
 	m_invPlanetRadius = 1.0 / rad;
 	m_planetEarthRadii = rad / EARTH_RADIUS;
 
+	// NB: I don't know what this does but only the 1st entry was ever used, and only for Neptune and Jupiter colours
+	m_entropy = m_rand.Double();
+
 	// Pick some colors, mainly reds and greens
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_rockColor)); i++) {
 		double r, g, b;
 		r = m_rand.Double(0.3, 1.0);
@@ -505,8 +506,6 @@ Terrain::Terrain(const SystemBody *body) :
 	}
 
 	// Pick some darker colours mainly reds and greens
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_darkrockColor)); i++) {
 		double r, g, b;
 		r = m_rand.Double(0.05, 0.3);
@@ -518,8 +517,6 @@ Terrain::Terrain(const SystemBody *body) :
 	}
 
 	// grey colours, in case you simply must have a grey colour on a world with high metallicity
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_greyrockColor)); i++) {
 		double g;
 		g = m_rand.Double(0.3, 0.9);
@@ -528,8 +525,6 @@ Terrain::Terrain(const SystemBody *body) :
 
 	// Pick some plant colours, mainly greens
 	// TODO take star class into account
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_plantColor)); i++) {
 		double r, g, b;
 		g = m_rand.Double(0.3, 1.0);
@@ -542,8 +537,6 @@ Terrain::Terrain(const SystemBody *body) :
 
 	// Pick some darker plant colours mainly greens
 	// TODO take star class into account
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_darkplantColor)); i++) {
 		double r, g, b;
 		g = m_rand.Double(0.05, 0.3);
@@ -556,8 +549,6 @@ Terrain::Terrain(const SystemBody *body) :
 
 	// Pick some sand colours, mainly yellow
 	// TODO let some planetary value scale this colour
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_sandColor)); i++) {
 		double r, g, b;
 		r = m_rand.Double(0.6, 1.0);
@@ -569,8 +560,6 @@ Terrain::Terrain(const SystemBody *body) :
 
 	// Pick some darker sand colours mainly yellow
 	// TODO let some planetary value scale this colour
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_darksandColor)); i++) {
 		double r, g, b;
 		r = m_rand.Double(0.05, 0.6);
@@ -582,8 +571,6 @@ Terrain::Terrain(const SystemBody *body) :
 
 	// Pick some dirt colours, mainly red/brown
 	// TODO let some planetary value scale this colour
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_dirtColor)); i++) {
 		double r, g, b;
 		r = m_rand.Double(0.3, 0.7);
@@ -594,8 +581,6 @@ Terrain::Terrain(const SystemBody *body) :
 
 	// Pick some darker dirt colours mainly red/brown
 	// TODO let some planetary value scale this colour
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_darkdirtColor)); i++) {
 		double r, g, b;
 		r = m_rand.Double(0.05, 0.3);
@@ -605,8 +590,6 @@ Terrain::Terrain(const SystemBody *body) :
 	}
 
 	// These are used for gas giant colours, they are more m_random and *should* really use volatileGasses - TODO
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_gglightColor)); i++) {
 		double r, g, b;
 		r = m_rand.Double(0.0, 0.5);
@@ -615,8 +598,6 @@ Terrain::Terrain(const SystemBody *body) :
 		m_gglightColor[i] = vector3d(r, g, b);
 	}
 	//darker gas giant colours, more reds and greens
-	for (int i = 0; i < int(COUNTOF(m_entropy)); i++)
-		m_entropy[i] = m_rand.Double();
 	for (int i = 0; i < int(COUNTOF(m_ggdarkColor)); i++) {
 		double r, g, b;
 		r = m_rand.Double(0.0, 0.3);

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -91,7 +91,7 @@ protected:
 	double m_invPlanetRadius;
 	double m_planetEarthRadii;
 
-	double m_entropy[12];
+	double m_entropy;
 
 	vector3d m_rockColor[8];
 	vector3d m_darkrockColor[8];

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -43,8 +43,7 @@ public:
 		return m_fracdef[index];
 	}
 
-	virtual double GetHeight(const vector3d &p) const = 0;
-	virtual void GetHeights(const std::vector<vector3d> &p, std::vector<double> &heightsOut) const = 0;
+	virtual void GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const = 0;
 	virtual vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const = 0;
 
 	virtual const char *GetHeightFractalName() const = 0;
@@ -125,16 +124,7 @@ template <typename HeightFractal>
 class TerrainHeightFractal : virtual public Terrain {
 public:
 	TerrainHeightFractal() = delete;
-	double GetHeight(const vector3d &p) const final;
-	void GetHeights(const std::vector<vector3d> &positions, std::vector<double> &heightsOut) const
-	{
-		assert(heightsOut.size() == positions.size());
-		// this is NOT the way
-		for (size_t i = 0; i < positions.size(); i++) {
-			double h = GetHeight(positions[i]);
-			heightsOut.at(i) = h;
-		}
-	}
+	void GetHeights(const std::vector<vector3d> &positions, std::vector<double> &heightsOut) const final;
 	const char *GetHeightFractalName() const final;
 
 protected:

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -44,6 +44,7 @@ public:
 	}
 
 	virtual double GetHeight(const vector3d &p) const = 0;
+	virtual void GetHeights(const std::vector<vector3d> &p, std::vector<double> &heightsOut) const = 0;
 	virtual vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const = 0;
 
 	virtual const char *GetHeightFractalName() const = 0;
@@ -124,26 +125,31 @@ template <typename HeightFractal>
 class TerrainHeightFractal : virtual public Terrain {
 public:
 	TerrainHeightFractal() = delete;
-	virtual double GetHeight(const vector3d &p) const;
-	virtual const char *GetHeightFractalName() const;
+	double GetHeight(const vector3d &p) const final;
+	void GetHeights(const std::vector<vector3d> &positions, std::vector<double> &heightsOut) const
+	{
+		assert(heightsOut.size() == positions.size());
+		// this is NOT the way
+		for (size_t i = 0; i < positions.size(); i++) {
+			double h = GetHeight(positions[i]);
+			heightsOut.at(i) = h;
+		}
+	}
+	const char *GetHeightFractalName() const final;
 
 protected:
 	TerrainHeightFractal(const SystemBody *body);
-
-private:
 };
 
 template <typename ColorFractal>
 class TerrainColorFractal : virtual public Terrain {
 public:
 	TerrainColorFractal() = delete;
-	virtual vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const;
-	virtual const char *GetColorFractalName() const;
+	vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const final;
+	const char *GetColorFractalName() const final;
 
 protected:
 	TerrainColorFractal(const SystemBody *body);
-
-private:
 };
 
 template <typename HeightFractal, typename ColorFractal>

--- a/src/terrain/TerrainColorGGJupiter.cpp
+++ b/src/terrain/TerrainColorGGJupiter.cpp
@@ -25,7 +25,7 @@ template <>
 vector3d TerrainColorFractal<TerrainColorGGJupiter>::GetColor(const vector3d &p, double height, const vector3d &norm) const
 {
 	double n;
-	const double h = river_octavenoise(GetFracDef(0), 0.5 * m_entropy[0] + 0.25f,
+	const double h = river_octavenoise(GetFracDef(0), 0.5 * m_entropy + 0.25f,
 						 vector3d(noise(vector3d(p.x * 8, p.y * 32, p.z * 8)))) *
 		.125;
 	const double equatorial_region_1 = billow_octavenoise(GetFracDef(0), 0.7, p) * p.y * p.x;
@@ -38,10 +38,10 @@ vector3d TerrainColorFractal<TerrainColorGGJupiter>::GetColor(const vector3d &p,
 		for (float i = -1; i < 1; i += 0.6f) {
 			double temp = p.y - i;
 			if (temp < .15 + h && temp > -.15 + h) {
-				n = billow_octavenoise(GetFracDef(2), 0.7 * m_entropy[0],
+				n = billow_octavenoise(GetFracDef(2), 0.7 * m_entropy,
 					noise(vector3d(p.x, p.y * m_planetEarthRadii * 0.3, p.z)) * p);
-				n += 0.5 * octavenoise(GetFracDef(1), 0.6 * m_entropy[0], noise(vector3d(p.x, p.y * m_planetEarthRadii, p.z)) * p);
-				n += ridged_octavenoise(GetFracDef(1), 0.6 * m_entropy[0],
+				n += 0.5 * octavenoise(GetFracDef(1), 0.6 * m_entropy, noise(vector3d(p.x, p.y * m_planetEarthRadii, p.z)) * p);
+				n += ridged_octavenoise(GetFracDef(1), 0.6 * m_entropy,
 					noise(vector3d(p.x, p.y * m_planetEarthRadii * 0.3, p.z)) * p);
 				//n += 0.5;
 				n *= n;
@@ -78,10 +78,10 @@ vector3d TerrainColorFractal<TerrainColorGGJupiter>::GetColor(const vector3d &p,
 		for (float i = -1; i < 1; i += 0.6f) {
 			double temp = p.y - i;
 			if (temp < .15 + h && temp > -.15 + h) {
-				n = billow_octavenoise(GetFracDef(2), 0.6 * m_entropy[0],
+				n = billow_octavenoise(GetFracDef(2), 0.6 * m_entropy,
 					noise(vector3d(p.x, p.y * m_planetEarthRadii * 0.3, p.z)) * p);
-				n += 0.5 * octavenoise(GetFracDef(1), 0.7 * m_entropy[0], noise(vector3d(p.x, p.y * m_planetEarthRadii, p.z)) * p);
-				n += ridged_octavenoise(GetFracDef(1), 0.6 * m_entropy[0],
+				n += 0.5 * octavenoise(GetFracDef(1), 0.7 * m_entropy, noise(vector3d(p.x, p.y * m_planetEarthRadii, p.z)) * p);
+				n += ridged_octavenoise(GetFracDef(1), 0.6 * m_entropy,
 					noise(vector3d(p.x, p.y * m_planetEarthRadii * 0.3, p.z)) * p);
 				//n += 0.5;
 				//n *= n;
@@ -118,10 +118,10 @@ vector3d TerrainColorFractal<TerrainColorGGJupiter>::GetColor(const vector3d &p,
 		for (float i = -1; i < 1; i += 0.3f) {
 			double temp = p.y - i;
 			if (temp < .1 + h && temp > -.0 + h) {
-				n = billow_octavenoise(GetFracDef(2), 0.6 * m_entropy[0],
+				n = billow_octavenoise(GetFracDef(2), 0.6 * m_entropy,
 					noise(vector3d(p.x, p.y * m_planetEarthRadii * 0.3, p.z)) * p);
-				n += 0.5 * octavenoise(GetFracDef(1), 0.6 * m_entropy[0], noise(vector3d(p.x, p.y * m_planetEarthRadii, p.z)) * p);
-				n += ridged_octavenoise(GetFracDef(1), 0.7 * m_entropy[0],
+				n += 0.5 * octavenoise(GetFracDef(1), 0.6 * m_entropy, noise(vector3d(p.x, p.y * m_planetEarthRadii, p.z)) * p);
+				n += ridged_octavenoise(GetFracDef(1), 0.7 * m_entropy,
 					noise(vector3d(p.x, p.y * m_planetEarthRadii * 0.3, p.z)) * p);
 				//n += 0.5;
 				//n *= n;
@@ -156,7 +156,7 @@ vector3d TerrainColorFractal<TerrainColorGGJupiter>::GetColor(const vector3d &p,
 		}
 	}
 	//if is not a stripe.
-	n = octavenoise(GetFracDef(1), 0.6 * m_entropy[0] + 0.25f, noise(vector3d(p.x, p.y * m_planetEarthRadii * 3, p.z)) * p);
+	n = octavenoise(GetFracDef(1), 0.6 * m_entropy + 0.25f, noise(vector3d(p.x, p.y * m_planetEarthRadii * 3, p.z)) * p);
 	n *= n * n;
 	n = (n < 0.0 ? -n : n);
 	n = (n > 1.0 ? 2.0 - n : n);

--- a/src/terrain/TerrainColorGGNeptune2.cpp
+++ b/src/terrain/TerrainColorGGNeptune2.cpp
@@ -25,7 +25,7 @@ template <>
 vector3d TerrainColorFractal<TerrainColorGGNeptune2>::GetColor(const vector3d &p, double height, const vector3d &norm) const
 {
 	double n;
-	const double h = billow_octavenoise(GetFracDef(0), 0.5 * m_entropy[0] + 0.25f,
+	const double h = billow_octavenoise(GetFracDef(0), 0.5 * m_entropy + 0.25f,
 						 vector3d(noise(vector3d(p.x * 8, p.y * 32, p.z * 8)))) *
 		.125;
 	const double equatorial_region_1 = billow_octavenoise(GetFracDef(0), 0.54, p) * p.y * p.x;
@@ -38,8 +38,8 @@ vector3d TerrainColorFractal<TerrainColorGGNeptune2>::GetColor(const vector3d &p
 		for (float i = -1; i < 1; i += 0.6f) {
 			double temp = p.y - i;
 			if (temp < .07 + h && temp > -.07 + h) {
-				n = 2.0 * billow_octavenoise(GetFracDef(2), 0.5 * m_entropy[0], noise(vector3d(p.x, p.y * m_planetEarthRadii * 0.3, p.z)) * p);
-				n += 0.8 * octavenoise(GetFracDef(1), 0.5 * m_entropy[0], noise(vector3d(p.x, p.y * m_planetEarthRadii, p.z)) * p);
+				n = 2.0 * billow_octavenoise(GetFracDef(2), 0.5 * m_entropy, noise(vector3d(p.x, p.y * m_planetEarthRadii * 0.3, p.z)) * p);
+				n += 0.8 * octavenoise(GetFracDef(1), 0.5 * m_entropy, noise(vector3d(p.x, p.y * m_planetEarthRadii, p.z)) * p);
 				n += 0.5 * billow_octavenoise(GetFracDef(3), 0.6, p);
 				n *= n;
 				n = (n < 0.0 ? -n : n);
@@ -73,9 +73,9 @@ vector3d TerrainColorFractal<TerrainColorGGNeptune2>::GetColor(const vector3d &p
 		}
 	}
 	//if is not a stripe.
-	n = octavenoise(GetFracDef(1), 0.5 * m_entropy[0] + 0.25f, noise(vector3d(p.x * 0.2, p.y * m_planetEarthRadii * 10, p.z)) * p);
+	n = octavenoise(GetFracDef(1), 0.5 * m_entropy + 0.25f, noise(vector3d(p.x * 0.2, p.y * m_planetEarthRadii * 10, p.z)) * p);
 	//n += 0.5;
-	//n += octavenoise(GetFracDef(0), 0.6*m_entropy[0], 3.142*p.z*p.z);
+	//n += octavenoise(GetFracDef(0), 0.6*m_entropy, 3.142*p.z*p.z);
 	n *= n * n * n;
 	n = (n < 0.0 ? -n : n);
 	n = (n > 1.0 ? 2.0 - n : n);

--- a/src/terrain/TerrainHeightAsteroid.cpp
+++ b/src/terrain/TerrainHeightAsteroid.cpp
@@ -23,20 +23,11 @@ TerrainHeightFractal<TerrainHeightAsteroid>::TerrainHeightFractal(const SystemBo
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightAsteroid>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightAsteroid>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	const double n = octavenoise(GetFracDef(0), 0.4, p) * dunes_octavenoise(GetFracDef(1), 0.5, p);
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
-}
-
-template <>
-void TerrainHeightFractal<TerrainHeightAsteroid>::GetHeights(const std::vector<vector3d>& p, std::vector<double>& heightsOut) const
-{
-	// this is NOT the way
-	for (size_t i = 0; i < p.size(); i++)
-	{
-		double h = GetHeight(p[i]);
-		heightsOut.at(i) = h;
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		const double n = octavenoise(GetFracDef(0), 0.4, p) * dunes_octavenoise(GetFracDef(1), 0.5, p) * m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
 	}
 }

--- a/src/terrain/TerrainHeightAsteroid.cpp
+++ b/src/terrain/TerrainHeightAsteroid.cpp
@@ -29,3 +29,14 @@ double TerrainHeightFractal<TerrainHeightAsteroid>::GetHeight(const vector3d &p)
 
 	return (n > 0.0 ? m_maxHeight * n : 0.0);
 }
+
+template <>
+void TerrainHeightFractal<TerrainHeightAsteroid>::GetHeights(const std::vector<vector3d>& p, std::vector<double>& heightsOut) const
+{
+	// this is NOT the way
+	for (size_t i = 0; i < p.size(); i++)
+	{
+		double h = GetHeight(p[i]);
+		heightsOut.at(i) = h;
+	}
+}

--- a/src/terrain/TerrainHeightAsteroid2.cpp
+++ b/src/terrain/TerrainHeightAsteroid2.cpp
@@ -26,10 +26,13 @@ TerrainHeightFractal<TerrainHeightAsteroid2>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightAsteroid2>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightAsteroid2>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	const double n = voronoiscam_octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 15.0 * octavenoise(GetFracDef(1), 0.5, p), p) *
-		0.75 * ridged_octavenoise(16.0 * octavenoise(GetFracDef(2), 0.275, p), 0.4 * ridged_octavenoise(GetFracDef(3), 0.4, p), 4.0 * octavenoise(GetFracDef(4), 0.35, p), p);
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double n = voronoiscam_octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 15.0 * octavenoise(GetFracDef(1), 0.5, p), p) *
+			0.75 * ridged_octavenoise(16.0 * octavenoise(GetFracDef(2), 0.275, p), 0.4 * ridged_octavenoise(GetFracDef(3), 0.4, p), 4.0 * octavenoise(GetFracDef(4), 0.35, p), p);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightAsteroid3.cpp
+++ b/src/terrain/TerrainHeightAsteroid3.cpp
@@ -23,9 +23,12 @@ TerrainHeightFractal<TerrainHeightAsteroid3>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightAsteroid3>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightAsteroid3>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	const double n = octavenoise(GetFracDef(0), 0.5, p) * ridged_octavenoise(GetFracDef(1), 0.5, p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		const double n = octavenoise(GetFracDef(0), 0.5, p) * ridged_octavenoise(GetFracDef(1), 0.5, p) * m_maxHeight;
 
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightAsteroid4.cpp
+++ b/src/terrain/TerrainHeightAsteroid4.cpp
@@ -26,10 +26,14 @@ TerrainHeightFractal<TerrainHeightAsteroid4>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightAsteroid4>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightAsteroid4>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	const double n = octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 2.8 * ridged_octavenoise(GetFracDef(1), 0.5, p), p) *
-		0.75 * ridged_octavenoise(16 * octavenoise(GetFracDef(2), 0.275, p), 0.3 * octavenoise(GetFracDef(3), 0.4, p), 2.8 * ridged_octavenoise(GetFracDef(4), 0.35, p), p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double n = octavenoise(6, 0.2 * octavenoise(GetFracDef(0), 0.3, p), 2.8 * ridged_octavenoise(GetFracDef(1), 0.5, p), p) *
+			0.75 * ridged_octavenoise(16 * octavenoise(GetFracDef(2), 0.275, p), 0.3 * octavenoise(GetFracDef(3), 0.4, p), 2.8 * ridged_octavenoise(GetFracDef(4), 0.35, p), p);
 
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightBarrenRock.cpp
+++ b/src/terrain/TerrainHeightBarrenRock.cpp
@@ -23,12 +23,13 @@ TerrainHeightFractal<TerrainHeightBarrenRock>::TerrainHeightFractal(const System
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	/*return std::max(0.0, m_maxHeight * (octavenoise(GetFracDef(0), 0.5, p) +
-			GetFracDef(1).amplitude * crater_function(GetFracDef(1), p)));*/
-	//fuck the fracdefs, direct control is better:
-	double n = ridged_octavenoise(16, 0.5 * octavenoise(8, 0.4, 2.5, p), Clamp(5.0 * octavenoise(8, 0.257, 4.0, p), 1.0, 5.0), p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double n = ridged_octavenoise(16, 0.5 * octavenoise(8, 0.4, 2.5, p), Clamp(5.0 * octavenoise(8, 0.257, 4.0, p), 1.0, 5.0), p);
 
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightBarrenRock2.cpp
+++ b/src/terrain/TerrainHeightBarrenRock2.cpp
@@ -21,10 +21,13 @@ TerrainHeightFractal<TerrainHeightBarrenRock2>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightBarrenRock2>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightBarrenRock2>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double n = billow_octavenoise(16, 0.3 * octavenoise(8, 0.4, 2.5, p), Clamp(5.0 * ridged_octavenoise(8, 0.377, 4.0, p), 1.0, 5.0), p);
 
-	double n = billow_octavenoise(16, 0.3 * octavenoise(8, 0.4, 2.5, p), Clamp(5.0 * ridged_octavenoise(8, 0.377, 4.0, p), 1.0, 5.0), p);
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightBarrenRock3.cpp
+++ b/src/terrain/TerrainHeightBarrenRock3.cpp
@@ -20,10 +20,13 @@ TerrainHeightFractal<TerrainHeightBarrenRock3>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightBarrenRock3>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightBarrenRock3>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double n = 0.07 * voronoiscam_octavenoise(12, Clamp(fabs(0.165 - (0.38 * river_octavenoise(12, 0.4, 2.5, p))), 0.15, 0.5), Clamp(8.0 * billow_octavenoise(12, 0.37, 4.0, p), 0.5, 9.0), p);
 
-	float n = 0.07 * voronoiscam_octavenoise(12, Clamp(fabs(0.165 - (0.38 * river_octavenoise(12, 0.4, 2.5, p))), 0.15, 0.5), Clamp(8.0 * billow_octavenoise(12, 0.37, 4.0, p), 0.5, 9.0), p);
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightEllipsoid.cpp
+++ b/src/terrain/TerrainHeightEllipsoid.cpp
@@ -53,15 +53,18 @@ TerrainHeightFractal<TerrainHeightEllipsoid>::TerrainHeightFractal(const SystemB
 //                                R(t) = ar/sqrt(x_^2+ar^2*y_^2) (eqn. 9) (substituting using eqn. 7 and eqn. 8)
 
 template <>
-double TerrainHeightFractal<TerrainHeightEllipsoid>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightEllipsoid>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	const double ar = m_minBody.m_aspectRatio;
-	// x_^2 = (p.z^2+p.x^2) (eqn. 5)
-	const double x_squared = (p.x * p.x + p.z * p.z);
-	// y_ = p.y
-	const double y_squared = p.y * p.y;
-	const double distFromCenter_R = ar / sqrt(x_squared + ar * ar * y_squared); // (eqn. 9)
-	// GetHeight must return the difference in the distance from center between a point in a sphere of
-	// Polar radius (in coords scaled to a unit sphere) and the point on the ellipsoid surface.
-	return std::max(distFromCenter_R - 1.0, 0.0);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		const double ar = m_minBody.m_aspectRatio;
+		// x_^2 = (p.z^2+p.x^2) (eqn. 5)
+		const double x_squared = (p.x * p.x + p.z * p.z);
+		// y_ = p.y
+		const double y_squared = p.y * p.y;
+		const double distFromCenter_R = ar / sqrt(x_squared + ar * ar * y_squared); // (eqn. 9)
+		// GetHeight must return the difference in the distance from center between a point in a sphere of
+		// Polar radius (in coords scaled to a unit sphere) and the point on the ellipsoid surface.
+		heightsOut.at(i) = std::max(distFromCenter_R - 1.0, 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightFlat.cpp
+++ b/src/terrain/TerrainHeightFlat.cpp
@@ -13,7 +13,9 @@ TerrainHeightFractal<TerrainHeightFlat>::TerrainHeightFractal(const SystemBody *
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightFlat>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightFlat>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	return 0.0;
+	for (size_t i = 0; i < vP.size(); i++) {
+		heightsOut.at(i) = 0.0;
+	}
 }

--- a/src/terrain/TerrainHeightHillsCraters.cpp
+++ b/src/terrain/TerrainHeightHillsCraters.cpp
@@ -24,21 +24,27 @@ TerrainHeightFractal<TerrainHeightHillsCraters>::TerrainHeightFractal(const Syst
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsCraters>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightHillsCraters>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
-	if (continents < 0) return 0;
-	// == TERRAIN_HILLS_NORMAL except river_octavenoise
-	double n = 0.3 * continents;
-	double distrib = river_octavenoise(GetFracDef(2), 0.5, p);
-	double m = GetFracDef(1).amplitude * river_octavenoise(GetFracDef(1), 0.5 * distrib, p);
-	// cliffs at shore
-	if (continents < 0.001)
-		n += m * continents * 1000.0f;
-	else
-		n += m;
-	n += crater_function(GetFracDef(3), p);
-	n += crater_function(GetFracDef(4), p);
-	n *= m_maxHeight;
-	return (n > 0.0 ? n : 0.0);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		const double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+
+		// == TERRAIN_HILLS_NORMAL except river_octavenoise
+		double n = 0.3 * continents;
+		double distrib = river_octavenoise(GetFracDef(2), 0.5, p);
+		double m = GetFracDef(1).amplitude * river_octavenoise(GetFracDef(1), 0.5 * distrib, p);
+
+		// cliffs at shore
+		if (continents < 0.001)
+			n += m * continents * 1000.0f;
+		else
+			n += m;
+		n += crater_function(GetFracDef(3), p);
+		n += crater_function(GetFracDef(4), p);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightHillsCraters2.cpp
+++ b/src/terrain/TerrainHeightHillsCraters2.cpp
@@ -28,25 +28,32 @@ TerrainHeightFractal<TerrainHeightHillsCraters2>::TerrainHeightFractal(const Sys
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsCraters2>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightHillsCraters2>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
-	if (continents < 0) return 0;
-	// == TERRAIN_HILLS_NORMAL except river_octavenoise
-	double n = 0.3 * continents;
-	double distrib = river_octavenoise(GetFracDef(2), 0.5, p);
-	double m = GetFracDef(1).amplitude * river_octavenoise(GetFracDef(1), 0.5 * distrib, p);
-	// cliffs at shore
-	if (continents < 0.001)
-		n += m * continents * 1000.0f;
-	else
-		n += m;
-	n += crater_function(GetFracDef(3), p);
-	n += crater_function(GetFracDef(4), p);
-	n += crater_function(GetFracDef(5), p);
-	n += crater_function(GetFracDef(6), p);
-	n += crater_function(GetFracDef(7), p);
-	n += crater_function(GetFracDef(8), p);
-	n *= m_maxHeight;
-	return (n > 0.0 ? n : 0.0);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		const double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+
+		// == TERRAIN_HILLS_NORMAL except river_octavenoise
+		double n = 0.3 * continents;
+		double distrib = river_octavenoise(GetFracDef(2), 0.5, p);
+		double m = GetFracDef(1).amplitude * river_octavenoise(GetFracDef(1), 0.5 * distrib, p);
+
+		// cliffs at shore
+		if (continents < 0.001)
+			n += m * continents * 1000.0f;
+		else
+			n += m;
+
+		n += crater_function(GetFracDef(3), p);
+		n += crater_function(GetFracDef(4), p);
+		n += crater_function(GetFracDef(5), p);
+		n += crater_function(GetFracDef(6), p);
+		n += crater_function(GetFracDef(7), p);
+		n += crater_function(GetFracDef(8), p);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightHillsDunes.cpp
+++ b/src/terrain/TerrainHeightHillsDunes.cpp
@@ -29,27 +29,32 @@ TerrainHeightFractal<TerrainHeightHillsDunes>::TerrainHeightFractal(const System
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsDunes>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightHillsDunes>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = ridged_octavenoise(GetFracDef(3), 0.65, p) * (1.0 - m_sealevel) - (m_sealevel * 0.1);
-	if (continents < 0) return 0;
-	double n = continents;
-	double distrib = dunes_octavenoise(GetFracDef(4), 0.4, p);
-	distrib *= distrib * distrib;
-	double m = octavenoise(GetFracDef(7), 0.5, p) * dunes_octavenoise(GetFracDef(7), 0.5, p) * Clamp(0.2 - distrib, 0.0, 0.05);
-	m += octavenoise(GetFracDef(2), 0.5, p) * dunes_octavenoise(GetFracDef(2), 0.5 * octavenoise(GetFracDef(6), 0.5 * distrib, p), p) * Clamp(1.0 - distrib, 0.0, 0.0005);
-	double mountains = ridged_octavenoise(GetFracDef(5), 0.5 * distrib, p) * octavenoise(GetFracDef(4), 0.5 * distrib, p) * octavenoise(GetFracDef(6), 0.5, p) * distrib;
-	mountains *= mountains;
-	m += mountains;
-	//detail for mountains, stops them looking smooth.
-	//m += mountains*mountains*0.02*octavenoise(GetFracDef(2), 0.6*mountains*mountains*distrib, p);
-	//m *= m*m*m*10.0;
-	// smooth cliffs at shore
-	if (continents < 0.01)
-		n += m * continents * 100.0f;
-	else
-		n += m;
-	//n += continents*Clamp(0.5-m, 0.0, 0.5)*0.2*dunes_octavenoise(GetFracDef(6), 0.6*distrib, p);
-	//n += continents*Clamp(0.05-n, 0.0, 0.01)*0.2*dunes_octavenoise(GetFracDef(2), Clamp(0.5-n, 0.0, 0.5), p);
-	return (n > 0.0 ? n * m_maxHeight : 0.0);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		const double continents = ridged_octavenoise(GetFracDef(3), 0.65, p) * (1.0 - m_sealevel) - (m_sealevel * 0.1);
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+		double n = continents;
+
+		double distrib = dunes_octavenoise(GetFracDef(4), 0.4, p);
+		distrib *= distrib * distrib;
+		double m = octavenoise(GetFracDef(7), 0.5, p) * dunes_octavenoise(GetFracDef(7), 0.5, p) * Clamp(0.2 - distrib, 0.0, 0.05);
+		m += octavenoise(GetFracDef(2), 0.5, p) * dunes_octavenoise(GetFracDef(2), 0.5 * octavenoise(GetFracDef(6), 0.5 * distrib, p), p) * Clamp(1.0 - distrib, 0.0, 0.0005);
+		double mountains = ridged_octavenoise(GetFracDef(5), 0.5 * distrib, p) * octavenoise(GetFracDef(4), 0.5 * distrib, p) * octavenoise(GetFracDef(6), 0.5, p) * distrib;
+		mountains *= mountains;
+		m += mountains;
+		//detail for mountains, stops them looking smooth.
+		//m += mountains*mountains*0.02*octavenoise(GetFracDef(2), 0.6*mountains*mountains*distrib, p);
+		//m *= m*m*m*10.0;
+		// smooth cliffs at shore
+		if (continents < 0.01)
+			n += m * continents * 100.0f;
+		else
+			n += m;
+		//n += continents*Clamp(0.5-m, 0.0, 0.5)*0.2*dunes_octavenoise(GetFracDef(6), 0.6*distrib, p);
+		//n += continents*Clamp(0.05-n, 0.0, 0.01)*0.2*dunes_octavenoise(GetFracDef(2), Clamp(0.5-n, 0.0, 0.5), p);
+		heightsOut.at(i) = (n > 0.0 ? n * m_maxHeight : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightHillsNormal.cpp
+++ b/src/terrain/TerrainHeightHillsNormal.cpp
@@ -28,25 +28,29 @@ TerrainHeightFractal<TerrainHeightHillsNormal>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsNormal>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightHillsNormal>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(3), 0.65, p) * (1.0 - m_sealevel) - (m_sealevel * 0.1);
-	if (continents < 0) return 0;
-	double n = continents;
-	double distrib = octavenoise(GetFracDef(4), 0.5, p);
-	distrib *= distrib;
-	double m = 0.5 * GetFracDef(3).amplitude * octavenoise(GetFracDef(4), 0.55 * distrib, p) * GetFracDef(5).amplitude;
-	m += 0.25 * billow_octavenoise(GetFracDef(5), 0.55 * distrib, p);
-	//hill footings
-	m -= octavenoise(GetFracDef(2), 0.6 * (1.0 - distrib), p) * Clamp(0.05 - m, 0.0, 0.05) * Clamp(0.05 - m, 0.0, 0.05);
-	//hill footings
-	m += voronoiscam_octavenoise(GetFracDef(6), 0.765 * distrib, p) * Clamp(0.025 - m, 0.0, 0.025) * Clamp(0.025 - m, 0.0, 0.025);
-	// cliffs at shore
-	if (continents < 0.01)
-		n += m * continents * 100.0f;
-	else
-		n += m;
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(3), 0.65, p) * (1.0 - m_sealevel) - (m_sealevel * 0.1);
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+		double n = continents;
 
-	if (n > 0.0) return n * m_maxHeight;
-	return 0.0;
+		double distrib = octavenoise(GetFracDef(4), 0.5, p);
+		distrib *= distrib;
+		double m = 0.5 * GetFracDef(3).amplitude * octavenoise(GetFracDef(4), 0.55 * distrib, p) * GetFracDef(5).amplitude;
+		m += 0.25 * billow_octavenoise(GetFracDef(5), 0.55 * distrib, p);
+		//hill footings
+		m -= octavenoise(GetFracDef(2), 0.6 * (1.0 - distrib), p) * Clamp(0.05 - m, 0.0, 0.05) * Clamp(0.05 - m, 0.0, 0.05);
+		//hill footings
+		m += voronoiscam_octavenoise(GetFracDef(6), 0.765 * distrib, p) * Clamp(0.025 - m, 0.0, 0.025) * Clamp(0.025 - m, 0.0, 0.025);
+		// cliffs at shore
+		if (continents < 0.01)
+			n += m * continents * 100.0f;
+		else
+			n += m;
+
+		heightsOut.at(i) = (n > 0.0 ? n * m_maxHeight : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightHillsRidged.cpp
+++ b/src/terrain/TerrainHeightHillsRidged.cpp
@@ -28,22 +28,27 @@ TerrainHeightFractal<TerrainHeightHillsRidged>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsRidged>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightHillsRidged>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = ridged_octavenoise(GetFracDef(3), 0.65, p) * (1.0 - m_sealevel) - (m_sealevel * 0.1);
-	if (continents < 0) return 0;
-	double n = continents;
-	double distrib = river_octavenoise(GetFracDef(4), 0.5, p);
-	double m = 0.5 * ridged_octavenoise(GetFracDef(4), 0.55 * distrib, p);
-	m += continents * 0.25 * ridged_octavenoise(GetFracDef(5), 0.58 * distrib, p);
-	// **
-	m += 0.001 * ridged_octavenoise(GetFracDef(6), 0.55 * distrib * m, p);
-	// cliffs at shore
-	if (continents < 0.01)
-		n += m * continents * 100.0f;
-	else
-		n += m;
-	// was n -= 0.001*ridged_octavenoise(GetFracDef(6), 0.55*distrib*m, p);
-	//n += 0.001*ridged_octavenoise(GetFracDef(6), 0.55*distrib*m, p);
-	return (n > 0.0 ? n * m_maxHeight : 0.0);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = ridged_octavenoise(GetFracDef(3), 0.65, p) * (1.0 - m_sealevel) - (m_sealevel * 0.1);
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+		double n = continents;
+
+		double distrib = river_octavenoise(GetFracDef(4), 0.5, p);
+		double m = 0.5 * ridged_octavenoise(GetFracDef(4), 0.55 * distrib, p);
+		m += continents * 0.25 * ridged_octavenoise(GetFracDef(5), 0.58 * distrib, p);
+		// **
+		m += 0.001 * ridged_octavenoise(GetFracDef(6), 0.55 * distrib * m, p);
+		// cliffs at shore
+		if (continents < 0.01)
+			n += m * continents * 100.0f;
+		else
+			n += m;
+		// was n -= 0.001*ridged_octavenoise(GetFracDef(6), 0.55*distrib*m, p);
+		//n += 0.001*ridged_octavenoise(GetFracDef(6), 0.55*distrib*m, p);
+		heightsOut.at(i) = (n > 0.0 ? n * m_maxHeight : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightHillsRivers.cpp
+++ b/src/terrain/TerrainHeightHillsRivers.cpp
@@ -28,26 +28,31 @@ TerrainHeightFractal<TerrainHeightHillsRivers>::TerrainHeightFractal(const Syste
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightHillsRivers>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightHillsRivers>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = river_octavenoise(GetFracDef(3), 0.65, p) * (1.0 - m_sealevel) - (m_sealevel * 0.1);
-	if (continents < 0) return 0;
-	double n = continents;
-	double distrib = voronoiscam_octavenoise(GetFracDef(4), 0.5 * GetFracDef(5).amplitude, p);
-	double m = 0.1 * GetFracDef(4).amplitude * river_octavenoise(GetFracDef(5), 0.5 * distrib, p);
-	double mountains = ridged_octavenoise(GetFracDef(5), 0.5 * distrib, p) * billow_octavenoise(GetFracDef(5), 0.5, p) *
-		voronoiscam_octavenoise(GetFracDef(4), 0.5 * distrib, p) * distrib;
-	m += mountains;
-	//detail for mountains, stops them looking smooth.
-	m += mountains * mountains * 0.02 * ridged_octavenoise(GetFracDef(2), 0.6 * mountains * mountains * distrib, p);
-	m *= m * m * m * 10.0;
-	// smooth cliffs at shore
-	if (continents < 0.01)
-		n += m * continents * 100.0f;
-	else
-		n += m;
-	n += continents * Clamp(0.5 - m, 0.0, 0.5) * 0.2 * river_octavenoise(GetFracDef(6), 0.6 * distrib, p);
-	n += continents * Clamp(0.05 - n, 0.0, 0.01) * 0.2 * dunes_octavenoise(GetFracDef(2), Clamp(0.5 - n, 0.0, 0.5), p);
-	n *= m_maxHeight;
-	return (n > 0.0 ? n : 0.0);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = river_octavenoise(GetFracDef(3), 0.65, p) * (1.0 - m_sealevel) - (m_sealevel * 0.1);
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+		double n = continents;
+
+		double distrib = voronoiscam_octavenoise(GetFracDef(4), 0.5 * GetFracDef(5).amplitude, p);
+		double m = 0.1 * GetFracDef(4).amplitude * river_octavenoise(GetFracDef(5), 0.5 * distrib, p);
+		double mountains = ridged_octavenoise(GetFracDef(5), 0.5 * distrib, p) * billow_octavenoise(GetFracDef(5), 0.5, p) *
+			voronoiscam_octavenoise(GetFracDef(4), 0.5 * distrib, p) * distrib;
+		m += mountains;
+		//detail for mountains, stops them looking smooth.
+		m += mountains * mountains * 0.02 * ridged_octavenoise(GetFracDef(2), 0.6 * mountains * mountains * distrib, p);
+		m *= m * m * m * 10.0;
+		// smooth cliffs at shore
+		if (continents < 0.01)
+			n += m * continents * 100.0f;
+		else
+			n += m;
+		n += continents * Clamp(0.5 - m, 0.0, 0.5) * 0.2 * river_octavenoise(GetFracDef(6), 0.6 * distrib, p);
+		n += continents * Clamp(0.05 - n, 0.0, 0.01) * 0.2 * dunes_octavenoise(GetFracDef(2), Clamp(0.5 - n, 0.0, 0.5), p);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightMapped.cpp
+++ b/src/terrain/TerrainHeightMapped.cpp
@@ -27,60 +27,63 @@ TerrainHeightFractal<TerrainHeightMapped>::TerrainHeightFractal(const SystemBody
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMapped>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightMapped>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	// This is all used for Earth and Earth alone
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		// This is all used for Earth and Earth alone
 
-	double v = BiCubicInterpolation(p);
+		double v = BiCubicInterpolation(p);
 
-	v = (v < 0 ? 0 : v);
-	double h = v;
+		v = (v < 0 ? 0 : v);
+		double h = v;
 
-	//Here's where we add some noise over the heightmap so it doesnt look so boring, we scale by height so values are greater high up
-	//large mountainous shapes
-	double mountains = h * h * 0.001 * octavenoise(GetFracDef(3), 0.5 * octavenoise(GetFracDef(5), 0.45, p), p) * ridged_octavenoise(GetFracDef(4), 0.475 * octavenoise(GetFracDef(6), 0.4, p), p);
-	v += mountains;
-	//smaller ridged mountains
-	if (v < 50.0) {
-		v += v * v * 0.04 * ridged_octavenoise(GetFracDef(5), 0.5, p);
-	} else if (v < 100.0) {
-		v += 100.0 * ridged_octavenoise(GetFracDef(5), 0.5, p);
-	} else {
-		v += (100.0 / v) * (100.0 / v) * (100.0 / v) * (100.0 / v) * (100.0 / v) *
-			100.0 * ridged_octavenoise(GetFracDef(5), 0.5, p);
+		//Here's where we add some noise over the heightmap so it doesnt look so boring, we scale by height so values are greater high up
+		//large mountainous shapes
+		double mountains = h * h * 0.001 * octavenoise(GetFracDef(3), 0.5 * octavenoise(GetFracDef(5), 0.45, p), p) * ridged_octavenoise(GetFracDef(4), 0.475 * octavenoise(GetFracDef(6), 0.4, p), p);
+		v += mountains;
+		//smaller ridged mountains
+		if (v < 50.0) {
+			v += v * v * 0.04 * ridged_octavenoise(GetFracDef(5), 0.5, p);
+		} else if (v < 100.0) {
+			v += 100.0 * ridged_octavenoise(GetFracDef(5), 0.5, p);
+		} else {
+			v += (100.0 / v) * (100.0 / v) * (100.0 / v) * (100.0 / v) * (100.0 / v) *
+				100.0 * ridged_octavenoise(GetFracDef(5), 0.5, p);
+		}
+		//high altitude detail/mountains
+		//v += Clamp(h, 0.0, 0.5)*octavenoise(GetFracDef(2-m_fracnum), 0.5, p);
+
+		//low altitude detail/dunes
+		//v += h*0.000003*ridged_octavenoise(GetFracDef(2-m_fracnum), Clamp(1.0-h*0.002, 0.0, 0.5), p);
+		if (v < 10.0) {
+			v += 2.0 * v * dunes_octavenoise(GetFracDef(6), 0.5, p) * octavenoise(GetFracDef(6), 0.5, p);
+		} else if (v < 50.0) {
+			v += 20.0 * dunes_octavenoise(GetFracDef(6), 0.5, p) * octavenoise(GetFracDef(6), 0.5, p);
+		} else {
+			v += (50.0 / v) * (50.0 / v) * (50.0 / v) * (50.0 / v) * (50.0 / v) * 20.0 * dunes_octavenoise(GetFracDef(6), 0.5, p) * octavenoise(GetFracDef(6), 0.5, p);
+		}
+		if (v < 40.0) {
+			//v = v;
+		} else if (v < 60.0) {
+			v += (v - 40.0) * billow_octavenoise(GetFracDef(5), 0.5, p);
+			//Output("V/height: %f\n", Clamp(v-20.0, 0.0, 1.0));
+		} else {
+			v += (30.0 / v) * (30.0 / v) * (30.0 / v) * 20.0 * billow_octavenoise(GetFracDef(5), 0.5, p);
+		}
+
+		//ridges and bumps
+		//v += h*0.1*ridged_octavenoise(GetFracDef(6-m_fracnum), Clamp(h*0.0002, 0.3, 0.5), p)
+		//	* Clamp(h*0.0002, 0.1, 0.5);
+		v += h * 0.2 * voronoiscam_octavenoise(GetFracDef(5), Clamp(1.0 - (h * 0.0002), 0.0, 0.6), p) * Clamp(1.0 - (h * 0.0006), 0.0, 1.0);
+		//polar ice caps with cracks
+		if ((m_icyness * 0.5) + (fabs(p.y * p.y * p.y * 0.38)) > 0.6) {
+			h = Clamp(1.0 - (v * 10.0), 0.0, 1.0) * voronoiscam_octavenoise(GetFracDef(5), 0.5, p);
+			h *= h * h * 2.0;
+			h -= 3.0;
+			v += h;
+		}
+
+		heightsOut.at(i) = (v < 0 ? 0 : (v * m_invPlanetRadius));
 	}
-	//high altitude detail/mountains
-	//v += Clamp(h, 0.0, 0.5)*octavenoise(GetFracDef(2-m_fracnum), 0.5, p);
-
-	//low altitude detail/dunes
-	//v += h*0.000003*ridged_octavenoise(GetFracDef(2-m_fracnum), Clamp(1.0-h*0.002, 0.0, 0.5), p);
-	if (v < 10.0) {
-		v += 2.0 * v * dunes_octavenoise(GetFracDef(6), 0.5, p) * octavenoise(GetFracDef(6), 0.5, p);
-	} else if (v < 50.0) {
-		v += 20.0 * dunes_octavenoise(GetFracDef(6), 0.5, p) * octavenoise(GetFracDef(6), 0.5, p);
-	} else {
-		v += (50.0 / v) * (50.0 / v) * (50.0 / v) * (50.0 / v) * (50.0 / v) * 20.0 * dunes_octavenoise(GetFracDef(6), 0.5, p) * octavenoise(GetFracDef(6), 0.5, p);
-	}
-	if (v < 40.0) {
-		//v = v;
-	} else if (v < 60.0) {
-		v += (v - 40.0) * billow_octavenoise(GetFracDef(5), 0.5, p);
-		//Output("V/height: %f\n", Clamp(v-20.0, 0.0, 1.0));
-	} else {
-		v += (30.0 / v) * (30.0 / v) * (30.0 / v) * 20.0 * billow_octavenoise(GetFracDef(5), 0.5, p);
-	}
-
-	//ridges and bumps
-	//v += h*0.1*ridged_octavenoise(GetFracDef(6-m_fracnum), Clamp(h*0.0002, 0.3, 0.5), p)
-	//	* Clamp(h*0.0002, 0.1, 0.5);
-	v += h * 0.2 * voronoiscam_octavenoise(GetFracDef(5), Clamp(1.0 - (h * 0.0002), 0.0, 0.6), p) * Clamp(1.0 - (h * 0.0006), 0.0, 1.0);
-	//polar ice caps with cracks
-	if ((m_icyness * 0.5) + (fabs(p.y * p.y * p.y * 0.38)) > 0.6) {
-		h = Clamp(1.0 - (v * 10.0), 0.0, 1.0) * voronoiscam_octavenoise(GetFracDef(5), 0.5, p);
-		h *= h * h * 2.0;
-		h -= 3.0;
-		v += h;
-	}
-
-	return v < 0 ? 0 : (v * m_invPlanetRadius);
 }

--- a/src/terrain/TerrainHeightMapped2.cpp
+++ b/src/terrain/TerrainHeightMapped2.cpp
@@ -17,18 +17,21 @@ TerrainHeightFractal<TerrainHeightMapped2>::TerrainHeightFractal(const SystemBod
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMapped2>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightMapped2>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double v = BiCubicInterpolation(p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double v = BiCubicInterpolation(p);
 
-	v = v * m_heightScaling + m_minh; // v = v*height scaling+min height
-	v *= m_invPlanetRadius;
+		v = v * m_heightScaling + m_minh; // v = v*height scaling+min height
+		v *= m_invPlanetRadius;
 
-	v += 0.1;
-	double h = 1.5 * v * v * v * ridged_octavenoise(16, 4.0 * v, 4.0, p);
-	h += 30000.0 * v * v * v * v * v * v * v * ridged_octavenoise(16, 5.0 * v, 20.0 * v, p);
-	h += v;
-	h -= 0.09;
+		v += 0.1;
+		double h = 1.5 * v * v * v * ridged_octavenoise(16, 4.0 * v, 4.0, p);
+		h += 30000.0 * v * v * v * v * v * v * v * ridged_octavenoise(16, 5.0 * v, 20.0 * v, p);
+		h += v;
+		h -= 0.09;
 
-	return (h > 0.0 ? h : 0.0);
+		heightsOut.at(i) = (h > 0.0 ? h : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightMountainsCraters.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters.cpp
@@ -29,21 +29,28 @@ TerrainHeightFractal<TerrainHeightMountainsCraters>::TerrainHeightFractal(const 
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsCraters>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightMountainsCraters>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
-	if (continents < 0) return 0;
-	double n = 0.3 * continents;
-	double m = GetFracDef(1).amplitude * ridged_octavenoise(GetFracDef(1), 0.5, p);
-	double distrib = ridged_octavenoise(GetFracDef(4), 0.5, p);
-	if (distrib > 0.5) m += 2.0 * (distrib - 0.5) * GetFracDef(3).amplitude * ridged_octavenoise(GetFracDef(3), 0.5 * distrib, p);
-	// cliffs at shore
-	if (continents < 0.001)
-		n += m * continents * 1000.0f;
-	else
-		n += m;
-	n += crater_function(GetFracDef(5), p);
-	n += crater_function(GetFracDef(6), p);
-	n *= m_maxHeight;
-	return (n > 0.0 ? n : 0.0);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+		double n = 0.3 * continents;
+
+		double m = GetFracDef(1).amplitude * ridged_octavenoise(GetFracDef(1), 0.5, p);
+		double distrib = ridged_octavenoise(GetFracDef(4), 0.5, p);
+		if (distrib > 0.5) m += 2.0 * (distrib - 0.5) * GetFracDef(3).amplitude * ridged_octavenoise(GetFracDef(3), 0.5 * distrib, p);
+
+		// cliffs at shore
+		if (continents < 0.001)
+			n += m * continents * 1000.0f;
+		else
+			n += m;
+
+		n += crater_function(GetFracDef(5), p);
+		n += crater_function(GetFracDef(6), p);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightMountainsCraters2.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters2.cpp
@@ -31,27 +31,33 @@ TerrainHeightFractal<TerrainHeightMountainsCraters2>::TerrainHeightFractal(const
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsCraters2>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightMountainsCraters2>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
-	if (continents < 0) return 0;
-	double n = 0.3 * continents;
-	double m = 0; //GetFracDef(1).amplitude * octavenoise(GetFracDef(1), 0.5, p);
-	double distrib = 0.5 * ridged_octavenoise(GetFracDef(1), 0.5 * octavenoise(GetFracDef(2), 0.5, p), p);
-	distrib += 0.7 * billow_octavenoise(GetFracDef(2), 0.5 * ridged_octavenoise(GetFracDef(1), 0.5, p), p) +
-		0.1 * octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+		double n = 0.3 * continents;
 
-	if (distrib > 0.5) m += 2.0 * (distrib - 0.5) * GetFracDef(3).amplitude * octavenoise(GetFracDef(4), 0.5 * distrib, p);
-	// cliffs at shore
-	if (continents < 0.001)
-		n += m * continents * 1000.0f;
-	else
-		n += m;
-	n += crater_function(GetFracDef(5), p);
-	n += crater_function(GetFracDef(6), p);
-	n += crater_function(GetFracDef(7), p);
-	n += crater_function(GetFracDef(8), p);
-	n += crater_function(GetFracDef(9), p);
-	n *= m_maxHeight;
-	return (n > 0.0 ? n : 0.0);
+		double m = 0; //GetFracDef(1).amplitude * octavenoise(GetFracDef(1), 0.5, p);
+		double distrib = 0.5 * ridged_octavenoise(GetFracDef(1), 0.5 * octavenoise(GetFracDef(2), 0.5, p), p);
+		distrib += 0.7 * billow_octavenoise(GetFracDef(2), 0.5 * ridged_octavenoise(GetFracDef(1), 0.5, p), p) +
+			0.1 * octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p);
+
+		if (distrib > 0.5) m += 2.0 * (distrib - 0.5) * GetFracDef(3).amplitude * octavenoise(GetFracDef(4), 0.5 * distrib, p);
+		// cliffs at shore
+		if (continents < 0.001)
+			n += m * continents * 1000.0f;
+		else
+			n += m;
+
+		n += crater_function(GetFracDef(5), p);
+		n += crater_function(GetFracDef(6), p);
+		n += crater_function(GetFracDef(7), p);
+		n += crater_function(GetFracDef(8), p);
+		n += crater_function(GetFracDef(9), p);
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightMountainsNormal.cpp
+++ b/src/terrain/TerrainHeightMountainsNormal.cpp
@@ -25,108 +25,115 @@ TerrainHeightFractal<TerrainHeightMountainsNormal>::TerrainHeightFractal(const S
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsNormal>::GetHeight(const vector3d &p) const
-//This is among the most complex of terrains, so I'll use this as an example:
+void TerrainHeightFractal<TerrainHeightMountainsNormal>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	//We need a continental pattern to place our noise onto, the 0.7*ridged_octavnoise..... is important here
-	// for making 'broken up' coast lines, as opposed to circular land masses, it will reduce the frequency of our
-	// continents depending on the ridged noise value, we subtract sealevel so that sea level will have an effect on the continents size
-	double continents = octavenoise(GetFracDef(0), 0.7 * ridged_octavenoise(GetFracDef(8), 0.58, p), p) - m_sealevel * 0.65;
-	// if there are no continents on an area, we want it to be sea level
-	if (continents < 0) return 0;
-	double n = continents - (GetFracDef(0).amplitude * m_sealevel * 0.5);
-	// we save the height n now as a constant h
-	const double h = n;
-	//We don't want to apply noise to sea level n=0
-	if (n > 0.0) {
-		//large mountainous shapes
-		n += h * 0.2 * ridged_octavenoise(GetFracDef(7), 0.5 * octavenoise(GetFracDef(6), 0.5, p), p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		//This is among the most complex of terrains, so I'll use this as an example:
+		//
+		//We need a continental pattern to place our noise onto, the 0.7*ridged_octavnoise..... is important here
+		// for making 'broken up' coast lines, as opposed to circular land masses, it will reduce the frequency of our
+		// continents depending on the ridged noise value, we subtract sealevel so that sea level will have an effect on the continents size
+		double continents = octavenoise(GetFracDef(0), 0.7 * ridged_octavenoise(GetFracDef(8), 0.58, p), p) - m_sealevel * 0.65;
+		// if there are no continents on an area, we want it to be sea level
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+		double n = continents - (GetFracDef(0).amplitude * m_sealevel * 0.5);
 
-		// This smoothes edges near the coast, we cant have vertical terrain its not handled correctly.
-		if (n < 0.4) {
-			n += n * 1.25 * ridged_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.3, 0.7) * ridged_octavenoise(GetFracDef(5), 0.5, p), p);
-		} else {
-			n += 0.5 * ridged_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.3, 0.7) * ridged_octavenoise(GetFracDef(5), 0.5, p), p);
+		// we save the height n now as a constant h
+		const double h = n;
+
+		//We don't want to apply noise to sea level n=0
+		if (n > 0.0) {
+			//large mountainous shapes
+			n += h * 0.2 * ridged_octavenoise(GetFracDef(7), 0.5 * octavenoise(GetFracDef(6), 0.5, p), p);
+
+			// This smoothes edges near the coast, we cant have vertical terrain its not handled correctly.
+			if (n < 0.4) {
+				n += n * 1.25 * ridged_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.3, 0.7) * ridged_octavenoise(GetFracDef(5), 0.5, p), p);
+			} else {
+				n += 0.5 * ridged_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.3, 0.7) * ridged_octavenoise(GetFracDef(5), 0.5, p), p);
+			}
+
+			if (n < 0.2) {
+				n += n * 15.0 * river_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.5, 0.7), p);
+			} else {
+				n += 3.0 * river_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.5, 0.7), p);
+			}
+			n *= 0.33333333333;
+
+			if (n < 0.133) {
+				n += n * billow_octavenoise(GetFracDef(6), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
+			} else {
+				n += (0.16 / n) * billow_octavenoise(GetFracDef(6), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
+			}
+
+			if (n < 0.066667) {
+				n += n * billow_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
+			} else {
+				n += (0.04 / n) * billow_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
+			}
+			//smaller ridged mountains
+			n += n * 0.7 * ridged_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(6), 0.5, p), p);
+
+			n = (n * 0.5) + (n * n);
+
+			//jagged surface for mountains
+			//This is probably using far too much noise, some of it is just not needed
+			// More specifically this: Clamp(h*0.0002*octavenoise(GetFracDef(5), 0.5, p),
+			//		 0.5*octavenoise(GetFracDef(3), 0.5, p),
+			//		 0.5*octavenoise(GetFracDef(3), 0.5, p))
+			//should probably be: Clamp(h*0.0002*octavenoise(GetFracDef(5), 0.5, p),
+			//		 0.1,
+			//		 0.5)  But I have no time for testing
+			if (n > 0.25) {
+				n += (n - 0.25) * 0.1 * octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p)), p); //[4]?
+			}
+
+			if (n > 0.2 && n <= 0.25) {
+				n += (0.25 - n) * 0.2 * ridged_octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(4), 0.5, p)), p);
+			} else if (n > 0.05) {
+				n += ((n - 0.05) / 15) * ridged_octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(4), 0.5, p)), p);
+			}
+			n = n * 0.2;
+
+			if (n < 0.01) {
+				n += n * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
+			} else if (n < 0.02) {
+				n += 0.01 * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
+			} else {
+				n += (0.02 / n) * 0.01 * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
+			}
+
+			if (n < 0.001) {
+				n += n * 3 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
+			} else if (n < 0.01) {
+				n += 0.003 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
+			} else {
+				n += (0.01 / n) * 0.003 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
+			}
+
+			if (n < 0.001) {
+				n += n * 0.2 * ridged_octavenoise(GetFracDef(1), 0.5 * octavenoise(GetFracDef(2), 0.5, p), p);
+			} else if (n < 0.01) {
+				n += 0.0002 * ridged_octavenoise(GetFracDef(1), 0.5 * octavenoise(GetFracDef(2), 0.5, p), p);
+			} else {
+				n += (0.01 / n) * 0.0002 * ridged_octavenoise(GetFracDef(1), 0.5 * octavenoise(GetFracDef(2), 0.5, p), p);
+			}
+
+			if (n < 0.1) {
+				n += n * 0.05 * dunes_octavenoise(GetFracDef(2), n * river_octavenoise(GetFracDef(2), 0.5, p), p);
+			} else if (n < 0.2) {
+				n += 0.005 * dunes_octavenoise(GetFracDef(2), ((n * n * 10.0) + (3 * (n - 0.1))) * river_octavenoise(GetFracDef(2), 0.5, p), p);
+			} else {
+				n += (0.2 / n) * 0.005 * dunes_octavenoise(GetFracDef(2), Clamp(0.7 - (1 - (5 * n)), 0.0, 0.7) * river_octavenoise(GetFracDef(2), 0.5, p), p);
+			}
+
+			//terrain is too mountainous, so we reduce the height
+			//n *= 0.3;
 		}
 
-		if (n < 0.2) {
-			n += n * 15.0 * river_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.5, 0.7), p);
-		} else {
-			n += 3.0 * river_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.5, 0.7), p);
-		}
-		n *= 0.33333333333;
-
-		if (n < 0.133) {
-			n += n * billow_octavenoise(GetFracDef(6), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
-		} else {
-			n += (0.16 / n) * billow_octavenoise(GetFracDef(6), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
-		}
-
-		if (n < 0.066667) {
-			n += n * billow_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
-		} else {
-			n += (0.04 / n) * billow_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
-		}
-		//smaller ridged mountains
-		n += n * 0.7 * ridged_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(6), 0.5, p), p);
-
-		n = (n * 0.5) + (n * n);
-
-		//jagged surface for mountains
-		//This is probably using far too much noise, some of it is just not needed
-		// More specifically this: Clamp(h*0.0002*octavenoise(GetFracDef(5), 0.5, p),
-		//		 0.5*octavenoise(GetFracDef(3), 0.5, p),
-		//		 0.5*octavenoise(GetFracDef(3), 0.5, p))
-		//should probably be: Clamp(h*0.0002*octavenoise(GetFracDef(5), 0.5, p),
-		//		 0.1,
-		//		 0.5)  But I have no time for testing
-		if (n > 0.25) {
-			n += (n - 0.25) * 0.1 * octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p)), p); //[4]?
-		}
-
-		if (n > 0.2 && n <= 0.25) {
-			n += (0.25 - n) * 0.2 * ridged_octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(4), 0.5, p)), p);
-		} else if (n > 0.05) {
-			n += ((n - 0.05) / 15) * ridged_octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(4), 0.5, p)), p);
-		}
-		n = n * 0.2;
-
-		if (n < 0.01) {
-			n += n * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
-		} else if (n < 0.02) {
-			n += 0.01 * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
-		} else {
-			n += (0.02 / n) * 0.01 * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
-		}
-
-		if (n < 0.001) {
-			n += n * 3 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
-		} else if (n < 0.01) {
-			n += 0.003 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
-		} else {
-			n += (0.01 / n) * 0.003 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
-		}
-
-		if (n < 0.001) {
-			n += n * 0.2 * ridged_octavenoise(GetFracDef(1), 0.5 * octavenoise(GetFracDef(2), 0.5, p), p);
-		} else if (n < 0.01) {
-			n += 0.0002 * ridged_octavenoise(GetFracDef(1), 0.5 * octavenoise(GetFracDef(2), 0.5, p), p);
-		} else {
-			n += (0.01 / n) * 0.0002 * ridged_octavenoise(GetFracDef(1), 0.5 * octavenoise(GetFracDef(2), 0.5, p), p);
-		}
-
-		if (n < 0.1) {
-			n += n * 0.05 * dunes_octavenoise(GetFracDef(2), n * river_octavenoise(GetFracDef(2), 0.5, p), p);
-		} else if (n < 0.2) {
-			n += 0.005 * dunes_octavenoise(GetFracDef(2), ((n * n * 10.0) + (3 * (n - 0.1))) * river_octavenoise(GetFracDef(2), 0.5, p), p);
-		} else {
-			n += (0.2 / n) * 0.005 * dunes_octavenoise(GetFracDef(2), Clamp(0.7 - (1 - (5 * n)), 0.0, 0.7) * river_octavenoise(GetFracDef(2), 0.5, p), p);
-		}
-
-		//terrain is too mountainous, so we reduce the height
-		//n *= 0.3;
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
 	}
-
-	n = m_maxHeight * n;
-	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsRidged.cpp
+++ b/src/terrain/TerrainHeightMountainsRidged.cpp
@@ -30,55 +30,60 @@ TerrainHeightFractal<TerrainHeightMountainsRidged>::TerrainHeightFractal(const S
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsRidged>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightMountainsRidged>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
-	if (continents < 0) return 0;
-	// unused variable \\ double mountain_distrib = octavenoise(GetFracDef(1), 0.5, p);
-	double mountains = octavenoise(GetFracDef(2), 0.5, p);
-	double mountains2 = ridged_octavenoise(GetFracDef(3), 0.5, p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
 
-	double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
-	double hills = hill_distrib * GetFracDef(5).amplitude * ridged_octavenoise(GetFracDef(5), 0.5, p);
-	double hills2 = hill_distrib * GetFracDef(6).amplitude * octavenoise(GetFracDef(6), 0.5, p);
+		// unused variable \\ double mountain_distrib = octavenoise(GetFracDef(1), 0.5, p);
+		double mountains = octavenoise(GetFracDef(2), 0.5, p);
+		double mountains2 = ridged_octavenoise(GetFracDef(3), 0.5, p);
 
-	double hill2_distrib = octavenoise(GetFracDef(7), 0.5, p);
-	double hills3 = hill2_distrib * GetFracDef(8).amplitude * ridged_octavenoise(GetFracDef(8), 0.5, p);
-	double hills4 = hill2_distrib * GetFracDef(9).amplitude * ridged_octavenoise(GetFracDef(9), 0.5, p);
+		double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
+		double hills = hill_distrib * GetFracDef(5).amplitude * ridged_octavenoise(GetFracDef(5), 0.5, p);
+		double hills2 = hill_distrib * GetFracDef(6).amplitude * octavenoise(GetFracDef(6), 0.5, p);
 
-	double n = continents - (GetFracDef(0).amplitude * m_sealevel);
+		double hill2_distrib = octavenoise(GetFracDef(7), 0.5, p);
+		double hills3 = hill2_distrib * GetFracDef(8).amplitude * ridged_octavenoise(GetFracDef(8), 0.5, p);
+		double hills4 = hill2_distrib * GetFracDef(9).amplitude * ridged_octavenoise(GetFracDef(9), 0.5, p);
 
-	if (n > 0.0) {
-		// smooth in hills at shore edges
-		if (n < 0.1)
-			n += hills * n * 10.0f;
-		else
-			n += hills;
-		if (n < 0.05)
-			n += hills2 * n * 20.0f;
-		else
-			n += hills2;
+		double n = continents - (GetFracDef(0).amplitude * m_sealevel);
 
-		if (n < 0.1)
-			n += hills3 * n * 10.0f;
-		else
-			n += hills3;
-		if (n < 0.05)
-			n += hills4 * n * 20.0f;
-		else
-			n += hills4;
+		if (n > 0.0) {
+			// smooth in hills at shore edges
+			if (n < 0.1)
+				n += hills * n * 10.0f;
+			else
+				n += hills;
+			if (n < 0.05)
+				n += hills2 * n * 20.0f;
+			else
+				n += hills2;
 
-		mountains = octavenoise(GetFracDef(1), 0.5, p) *
-			GetFracDef(2).amplitude * mountains * mountains * mountains;
-		mountains2 = octavenoise(GetFracDef(4), 0.5, p) *
-			GetFracDef(3).amplitude * mountains2 * mountains2 * mountains2 * mountains2;
-		if (n > 0.2) n += mountains2 * (n - 0.2);
-		if (n < 0.2)
-			n += mountains * n * 5.0f;
-		else
-			n += mountains;
+			if (n < 0.1)
+				n += hills3 * n * 10.0f;
+			else
+				n += hills3;
+			if (n < 0.05)
+				n += hills4 * n * 20.0f;
+			else
+				n += hills4;
+
+			mountains = octavenoise(GetFracDef(1), 0.5, p) *
+				GetFracDef(2).amplitude * mountains * mountains * mountains;
+			mountains2 = octavenoise(GetFracDef(4), 0.5, p) *
+				GetFracDef(3).amplitude * mountains2 * mountains2 * mountains2 * mountains2;
+			if (n > 0.2) n += mountains2 * (n - 0.2);
+			if (n < 0.2)
+				n += mountains * n * 5.0f;
+			else
+				n += mountains;
+		}
+
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
 	}
-
-	n = m_maxHeight * n;
-	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsRivers.cpp
+++ b/src/terrain/TerrainHeightMountainsRivers.cpp
@@ -28,117 +28,122 @@ TerrainHeightFractal<TerrainHeightMountainsRivers>::TerrainHeightFractal(const S
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsRivers>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightMountainsRivers>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), 0.7 * ridged_octavenoise(GetFracDef(8), 0.58, p), p) - m_sealevel * 0.65;
-	if (continents < 0) return 0;
-	double n = (river_function(GetFracDef(9), p) *
-				   river_function(GetFracDef(7), p) *
-				   river_function(GetFracDef(6), p) *
-				   canyon3_normal_function(GetFracDef(1), p) * continents) -
-		(GetFracDef(0).amplitude * m_sealevel * 0.1);
-	n *= 0.5;
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(0), 0.7 * ridged_octavenoise(GetFracDef(8), 0.58, p), p) - m_sealevel * 0.65;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
 
-	double h = n;
+		double n = (river_function(GetFracDef(9), p) *
+					river_function(GetFracDef(7), p) *
+					river_function(GetFracDef(6), p) *
+					canyon3_normal_function(GetFracDef(1), p) * continents) -
+					(GetFracDef(0).amplitude * m_sealevel * 0.1);
+		n *= 0.5;
 
-	if (n > 0.0) {
-		// smooth in hills at shore edges
-		//large mountainous shapes
-		n += h * river_octavenoise(GetFracDef(7), 0.5 * octavenoise(GetFracDef(6), 0.5, p), p);
+		double h = n;
 
-		//if (n < 0.2) n += canyon3_billow_function(GetFracDef(9), p) * n * 5;
-		//else if (n < 0.4) n += canyon3_billow_function(GetFracDef(9), p);
-		//else n += canyon3_billow_function(GetFracDef(9), p) * (0.4/n);
-		//n += -0.5;
+		if (n > 0.0) {
+			// smooth in hills at shore edges
+			//large mountainous shapes
+			n += h * river_octavenoise(GetFracDef(7), 0.5 * octavenoise(GetFracDef(6), 0.5, p), p);
+
+			//if (n < 0.2) n += canyon3_billow_function(GetFracDef(9), p) * n * 5;
+			//else if (n < 0.4) n += canyon3_billow_function(GetFracDef(9), p);
+			//else n += canyon3_billow_function(GetFracDef(9), p) * (0.4/n);
+			//n += -0.5;
+		}
+
+		if (n > 0.0) {
+			if (n < 0.4) {
+				n += n * 2.5 * river_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.3, 0.7) * ridged_octavenoise(GetFracDef(5), 0.5, p), p);
+			} else {
+				n += 1.0 * river_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.3, 0.7) * ridged_octavenoise(GetFracDef(5), 0.5, p), p);
+			}
+		}
+
+		if (n > 0.0) {
+			if (n < 0.2) {
+				n += n * 5.0 * billow_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.5, 0.7), p);
+			} else {
+				n += billow_octavenoise(GetFracDef(6),
+					Clamp(h * 0.00002, 0.5, 0.7), p);
+			}
+		}
+
+		if (n > 0.0) {
+			if (n < 0.4) {
+				n += n * 2.0 * river_octavenoise(GetFracDef(6), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
+			} else {
+				n += (0.32 / n) * river_octavenoise(GetFracDef(6), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
+			}
+
+			if (n < 0.2) {
+				n += n * ridged_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
+			} else {
+				n += (0.04 / n) * ridged_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
+			}
+			//smaller ridged mountains
+			n += n * 0.7 * ridged_octavenoise(GetFracDef(5), 0.7 * octavenoise(GetFracDef(6), 0.6, p), p);
+
+			//n += n*0.7*voronoiscam_octavenoise(GetFracDef(5),
+			//	0.7*octavenoise(GetFracDef(6), 0.6, p), p);
+
+			//n = n*0.6667;
+
+			//jagged surface for mountains
+			if (n > 0.25) {
+				n += (n - 0.25) * 0.1 * octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.6, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.6 * octavenoise(GetFracDef(4), 0.6, p)), p);
+			}
+
+			if (n > 0.2 && n <= 0.25) {
+				n += (0.25 - n) * 0.2 * ridged_octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(4), 0.5, p)), p);
+			} else if (n > 0.05) {
+				n += ((n - 0.05) / 15) * ridged_octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(4), 0.5, p)), p);
+			}
+			//n = n*0.2;
+
+			if (n < 0.01) {
+				n += n * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
+			} else if (n < 0.02) {
+				n += 0.01 * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
+			} else {
+				n += (0.02 / n) * 0.01 * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
+			}
+
+			if (n < 0.001) {
+				n += n * 3 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
+			} else if (n < 0.01) {
+				n += 0.003 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
+			} else {
+				n += (0.01 / n) * 0.003 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
+			}
+
+			//if (n < 0.001){
+			//	n += n*0.2*ridged_octavenoise(GetFracDef(2),
+			//		0.5*octavenoise(GetFracDef(2), 0.5, p), p);
+			//} else if (n <0.01){
+			//	n += 0.0002*ridged_octavenoise(GetFracDef(2),
+			//		0.5*octavenoise(GetFracDef(2), 0.5, p), p);
+			//} else {
+			//	n += (0.01/n)*0.0002*ridged_octavenoise(GetFracDef(2),
+			//		0.5*octavenoise(GetFracDef(2), 0.5, p), p);
+			//}
+
+			if (n < 0.1) {
+				n += n * 0.05 * dunes_octavenoise(GetFracDef(2), n * river_octavenoise(GetFracDef(2), 0.5, p), p);
+			} else if (n < 0.2) {
+				n += 0.005 * dunes_octavenoise(GetFracDef(2), ((n * n * 10.0) + (3 * (n - 0.1))) * river_octavenoise(GetFracDef(2), 0.5, p), p);
+			} else {
+				n += (0.2 / n) * 0.005 * dunes_octavenoise(GetFracDef(2), Clamp(0.7 - (1 - (5 * n)), 0.0, 0.7) * river_octavenoise(GetFracDef(2), 0.5, p), p);
+			}
+
+			n *= 0.3;
+		}
+
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
 	}
-
-	if (n > 0.0) {
-		if (n < 0.4) {
-			n += n * 2.5 * river_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.3, 0.7) * ridged_octavenoise(GetFracDef(5), 0.5, p), p);
-		} else {
-			n += 1.0 * river_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.3, 0.7) * ridged_octavenoise(GetFracDef(5), 0.5, p), p);
-		}
-	}
-
-	if (n > 0.0) {
-		if (n < 0.2) {
-			n += n * 5.0 * billow_octavenoise(GetFracDef(6), Clamp(h * 0.00002, 0.5, 0.7), p);
-		} else {
-			n += billow_octavenoise(GetFracDef(6),
-				Clamp(h * 0.00002, 0.5, 0.7), p);
-		}
-	}
-
-	if (n > 0.0) {
-		if (n < 0.4) {
-			n += n * 2.0 * river_octavenoise(GetFracDef(6), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
-		} else {
-			n += (0.32 / n) * river_octavenoise(GetFracDef(6), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
-		}
-
-		if (n < 0.2) {
-			n += n * ridged_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
-		} else {
-			n += (0.04 / n) * ridged_octavenoise(GetFracDef(5), 0.5 * octavenoise(GetFracDef(5), 0.5, p), p);
-		}
-		//smaller ridged mountains
-		n += n * 0.7 * ridged_octavenoise(GetFracDef(5), 0.7 * octavenoise(GetFracDef(6), 0.6, p), p);
-
-		//n += n*0.7*voronoiscam_octavenoise(GetFracDef(5),
-		//	0.7*octavenoise(GetFracDef(6), 0.6, p), p);
-
-		//n = n*0.6667;
-
-		//jagged surface for mountains
-		if (n > 0.25) {
-			n += (n - 0.25) * 0.1 * octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.6, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.6 * octavenoise(GetFracDef(4), 0.6, p)), p);
-		}
-
-		if (n > 0.2 && n <= 0.25) {
-			n += (0.25 - n) * 0.2 * ridged_octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(4), 0.5, p)), p);
-		} else if (n > 0.05) {
-			n += ((n - 0.05) / 15) * ridged_octavenoise(GetFracDef(3), Clamp(h * 0.0002 * octavenoise(GetFracDef(5), 0.5, p), 0.5 * octavenoise(GetFracDef(3), 0.5, p), 0.5 * octavenoise(GetFracDef(4), 0.5, p)), p);
-		}
-		//n = n*0.2;
-
-		if (n < 0.01) {
-			n += n * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
-		} else if (n < 0.02) {
-			n += 0.01 * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
-		} else {
-			n += (0.02 / n) * 0.01 * voronoiscam_octavenoise(GetFracDef(3), Clamp(h * 0.00002, 0.5, 0.5), p);
-		}
-
-		if (n < 0.001) {
-			n += n * 3 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
-		} else if (n < 0.01) {
-			n += 0.003 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
-		} else {
-			n += (0.01 / n) * 0.003 * dunes_octavenoise(GetFracDef(2), 1.0 * octavenoise(GetFracDef(2), 0.5, p), p);
-		}
-
-		//if (n < 0.001){
-		//	n += n*0.2*ridged_octavenoise(GetFracDef(2),
-		//		0.5*octavenoise(GetFracDef(2), 0.5, p), p);
-		//} else if (n <0.01){
-		//	n += 0.0002*ridged_octavenoise(GetFracDef(2),
-		//		0.5*octavenoise(GetFracDef(2), 0.5, p), p);
-		//} else {
-		//	n += (0.01/n)*0.0002*ridged_octavenoise(GetFracDef(2),
-		//		0.5*octavenoise(GetFracDef(2), 0.5, p), p);
-		//}
-
-		if (n < 0.1) {
-			n += n * 0.05 * dunes_octavenoise(GetFracDef(2), n * river_octavenoise(GetFracDef(2), 0.5, p), p);
-		} else if (n < 0.2) {
-			n += 0.005 * dunes_octavenoise(GetFracDef(2), ((n * n * 10.0) + (3 * (n - 0.1))) * river_octavenoise(GetFracDef(2), 0.5, p), p);
-		} else {
-			n += (0.2 / n) * 0.005 * dunes_octavenoise(GetFracDef(2), Clamp(0.7 - (1 - (5 * n)), 0.0, 0.7) * river_octavenoise(GetFracDef(2), 0.5, p), p);
-		}
-
-		n *= 0.3;
-	}
-
-	n = m_maxHeight * n;
-	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
@@ -35,190 +35,195 @@ TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::TerrainHeightFractal(
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
-	if (continents < 0) return 0;
-	// unused variable \\ double mountain_distrib = octavenoise(GetFracDef(1), 0.5, p);
-	double mountains = octavenoise(GetFracDef(2), 0.5, p);
-	double mountains2 = octavenoise(GetFracDef(3), 0.5, p);
-	double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
-	double hills = hill_distrib * GetFracDef(5).amplitude * octavenoise(GetFracDef(5), 0.5, p);
-	double hills2 = hill_distrib * GetFracDef(6).amplitude * octavenoise(GetFracDef(6), 0.5, p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
 
-	double n = continents - (GetFracDef(0).amplitude * m_sealevel);
+		// unused variable \\ double mountain_distrib = octavenoise(GetFracDef(1), 0.5, p);
+		double mountains = octavenoise(GetFracDef(2), 0.5, p);
+		double mountains2 = octavenoise(GetFracDef(3), 0.5, p);
+		double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
+		double hills = hill_distrib * GetFracDef(5).amplitude * octavenoise(GetFracDef(5), 0.5, p);
+		double hills2 = hill_distrib * GetFracDef(6).amplitude * octavenoise(GetFracDef(6), 0.5, p);
 
-	if (n < 0.01)
-		n += megavolcano_function(GetFracDef(7), p) * n * 800.0f;
-	else
-		n += megavolcano_function(GetFracDef(7), p) * 8.0f;
+		double n = continents - (GetFracDef(0).amplitude * m_sealevel);
 
-	//n = (n > 0.0 ? n : 0.0);
-	//n = n*.1f;
-
-	// BEWARE THE WALL OF TEXT
-	if ((m_seed >> 2) % 3 > 2) {
-
-		if (n < .2f)
-			n += canyon3_ridged_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_ridged_function(GetFracDef(8), p) * .4;
+		if (n < 0.01)
+			n += megavolcano_function(GetFracDef(7), p) * n * 800.0f;
 		else
-			n += canyon3_ridged_function(GetFracDef(8), p) * (.4 / n) * .4;
+			n += megavolcano_function(GetFracDef(7), p) * 8.0f;
 
-		if (n < .2f)
-			n += canyon2_ridged_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon2_ridged_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon2_ridged_function(GetFracDef(8), p) * (.4 / n) * .4;
+		//n = (n > 0.0 ? n : 0.0);
+		//n = n*.1f;
 
-		if (n < .2f)
-			n += canyon_ridged_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon_ridged_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon_ridged_function(GetFracDef(8), p) * (.4 / n) * .4;
+		// BEWARE THE WALL OF TEXT
+		if ((m_seed >> 2) % 3 > 2) {
 
-		if (n < .2f)
-			n += canyon3_ridged_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_ridged_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon3_ridged_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon3_ridged_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_ridged_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon3_ridged_function(GetFracDef(8), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon2_ridged_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon2_ridged_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon2_ridged_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon2_ridged_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon2_ridged_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon2_ridged_function(GetFracDef(8), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon_ridged_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon_ridged_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon_ridged_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon_ridged_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon_ridged_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon_ridged_function(GetFracDef(8), p) * (.4 / n) * .4;
 
-	} else if ((m_seed >> 2) % 3 > 1) {
+			if (n < .2f)
+				n += canyon3_ridged_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_ridged_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon3_ridged_function(GetFracDef(9), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon3_billow_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_billow_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon3_billow_function(GetFracDef(8), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon2_ridged_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon2_ridged_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon2_ridged_function(GetFracDef(9), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon2_billow_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon2_billow_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon2_billow_function(GetFracDef(8), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon_ridged_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon_ridged_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon_ridged_function(GetFracDef(9), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon_billow_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon_billow_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon_billow_function(GetFracDef(8), p) * (.4 / n) * .4;
+		} else if ((m_seed >> 2) % 3 > 1) {
 
-		if (n < .2f)
-			n += canyon3_billow_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_billow_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon3_billow_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon3_billow_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_billow_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon3_billow_function(GetFracDef(8), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon2_billow_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon2_billow_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon2_billow_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon2_billow_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon2_billow_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon2_billow_function(GetFracDef(8), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon_billow_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon_billow_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon_billow_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon_billow_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon_billow_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon_billow_function(GetFracDef(8), p) * (.4 / n) * .4;
 
-	} else {
+			if (n < .2f)
+				n += canyon3_billow_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_billow_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon3_billow_function(GetFracDef(9), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon3_voronoi_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_voronoi_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon3_voronoi_function(GetFracDef(8), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon2_billow_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon2_billow_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon2_billow_function(GetFracDef(9), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon2_voronoi_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon2_voronoi_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon2_voronoi_function(GetFracDef(8), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon_billow_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon_billow_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon_billow_function(GetFracDef(9), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon_voronoi_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon_voronoi_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon_voronoi_function(GetFracDef(8), p) * (.4 / n) * .4;
+		} else {
 
-		if (n < .2f)
-			n += canyon3_voronoi_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_voronoi_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon3_voronoi_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon3_voronoi_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_voronoi_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon3_voronoi_function(GetFracDef(8), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon2_voronoi_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon2_voronoi_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon2_voronoi_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon2_voronoi_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon2_voronoi_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon2_voronoi_function(GetFracDef(8), p) * (.4 / n) * .4;
 
-		if (n < .2f)
-			n += canyon_voronoi_function(GetFracDef(9), p) * n * 2;
-		else if (n < .4f)
-			n += canyon_voronoi_function(GetFracDef(9), p) * .4;
-		else
-			n += canyon_voronoi_function(GetFracDef(9), p) * (.4 / n) * .4;
+			if (n < .2f)
+				n += canyon_voronoi_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon_voronoi_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon_voronoi_function(GetFracDef(8), p) * (.4 / n) * .4;
+
+			if (n < .2f)
+				n += canyon3_voronoi_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_voronoi_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon3_voronoi_function(GetFracDef(9), p) * (.4 / n) * .4;
+
+			if (n < .2f)
+				n += canyon2_voronoi_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon2_voronoi_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon2_voronoi_function(GetFracDef(9), p) * (.4 / n) * .4;
+
+			if (n < .2f)
+				n += canyon_voronoi_function(GetFracDef(9), p) * n * 2;
+			else if (n < .4f)
+				n += canyon_voronoi_function(GetFracDef(9), p) * .4;
+			else
+				n += canyon_voronoi_function(GetFracDef(9), p) * (.4 / n) * .4;
+		}
+
+		n += -1.0f;
+		n = (n > 0.0 ? n : 0.0);
+
+		n = n * .03f;
+
+		//n += continents - (GetFracDef(0).amplitude*m_sealevel);
+
+		if (n > 0.0) {
+			// smooth in hills at shore edges
+			if (n < 0.1)
+				n += hills * n * 10.0f;
+			else
+				n += hills;
+			if (n < 0.05)
+				n += hills2 * n * 20.0f;
+			else
+				n += hills2;
+
+			mountains = octavenoise(GetFracDef(1), 0.5, p) *
+				GetFracDef(2).amplitude * mountains * mountains * mountains;
+			mountains2 = octavenoise(GetFracDef(4), 0.5, p) *
+				GetFracDef(3).amplitude * mountains2 * mountains2 * mountains2;
+			if (n > 0.5) n += mountains2 * (n - 0.5);
+			if (n < 0.2)
+				n += mountains * n * 5.0f;
+			else
+				n += mountains;
+		}
+
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
 	}
-
-	n += -1.0f;
-	n = (n > 0.0 ? n : 0.0);
-
-	n = n * .03f;
-
-	//n += continents - (GetFracDef(0).amplitude*m_sealevel);
-
-	if (n > 0.0) {
-		// smooth in hills at shore edges
-		if (n < 0.1)
-			n += hills * n * 10.0f;
-		else
-			n += hills;
-		if (n < 0.05)
-			n += hills2 * n * 20.0f;
-		else
-			n += hills2;
-
-		mountains = octavenoise(GetFracDef(1), 0.5, p) *
-			GetFracDef(2).amplitude * mountains * mountains * mountains;
-		mountains2 = octavenoise(GetFracDef(4), 0.5, p) *
-			GetFracDef(3).amplitude * mountains2 * mountains2 * mountains2;
-		if (n > 0.5) n += mountains2 * (n - 0.5);
-		if (n < 0.2)
-			n += mountains * n * 5.0f;
-		else
-			n += mountains;
-	}
-
-	n = m_maxHeight * n;
-	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightMountainsVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsVolcano.cpp
@@ -35,76 +35,81 @@ TerrainHeightFractal<TerrainHeightMountainsVolcano>::TerrainHeightFractal(const 
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightMountainsVolcano>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightMountainsVolcano>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
-	if (continents < 0) return 0;
-	// unused variable \\ double mountain_distrib = octavenoise(GetFracDef(1), 0.5, p);
-	double mountains = octavenoise(GetFracDef(2), 0.5, p);
-	double mountains2 = octavenoise(GetFracDef(3), 0.5, p);
-	double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
-	double hills = hill_distrib * GetFracDef(5).amplitude * octavenoise(GetFracDef(5), 0.5, p);
-	double hills2 = hill_distrib * GetFracDef(6).amplitude * octavenoise(GetFracDef(6), 0.5, p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
 
-	double n = continents - (GetFracDef(0).amplitude * m_sealevel);
+		// unused variable \\ double mountain_distrib = octavenoise(GetFracDef(1), 0.5, p);
+		double mountains = octavenoise(GetFracDef(2), 0.5, p);
+		double mountains2 = octavenoise(GetFracDef(3), 0.5, p);
+		double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
+		double hills = hill_distrib * GetFracDef(5).amplitude * octavenoise(GetFracDef(5), 0.5, p);
+		double hills2 = hill_distrib * GetFracDef(6).amplitude * octavenoise(GetFracDef(6), 0.5, p);
 
-	if (n < 0.01)
-		n += megavolcano_function(GetFracDef(7), p) * n * 3000.0f;
-	else
-		n += megavolcano_function(GetFracDef(7), p) * 30.0f;
+		double n = continents - (GetFracDef(0).amplitude * m_sealevel);
 
-	n = (n > 0.0 ? n : 0.0);
-
-	if ((m_seed >> 2) % 3 > 2) {
-		if (n < .2f)
-			n += canyon3_ridged_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_ridged_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon3_ridged_function(GetFracDef(8), p) * (.4 / n) * .4;
-	} else if ((m_seed >> 2) % 3 > 1) {
-		if (n < .2f)
-			n += canyon3_billow_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_billow_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon3_billow_function(GetFracDef(8), p) * (.4 / n) * .4;
-	} else {
-		if (n < .2f)
-			n += canyon3_voronoi_function(GetFracDef(8), p) * n * 2;
-		else if (n < .4f)
-			n += canyon3_voronoi_function(GetFracDef(8), p) * .4;
-		else
-			n += canyon3_voronoi_function(GetFracDef(8), p) * (.4 / n) * .4;
-	}
-
-	n += -0.05f;
-	n = (n > 0.0 ? n : 0.0);
-
-	n = n * .01f;
-
-	if (n > 0.0) {
-		// smooth in hills at shore edges
 		if (n < 0.01)
-			n += hills * n * 100.0f;
+			n += megavolcano_function(GetFracDef(7), p) * n * 3000.0f;
 		else
-			n += hills;
-		if (n < 0.02)
-			n += hills2 * n * 50.0f;
-		else
-			n += hills2 * (0.02f / n);
+			n += megavolcano_function(GetFracDef(7), p) * 30.0f;
 
-		mountains = octavenoise(GetFracDef(1), 0.5, p) *
-			GetFracDef(2).amplitude * mountains * mountains * mountains;
-		mountains2 = octavenoise(GetFracDef(4), 0.5, p) *
-			GetFracDef(3).amplitude * mountains2 * mountains2 * mountains2;
-		if (n > 2.5) n += mountains2 * (n - 2.5) * 0.6f;
-		if (n < 0.01)
-			n += mountains * n * 60.0f;
-		else
-			n += mountains * 0.6f;
+		n = (n > 0.0 ? n : 0.0);
+
+		if ((m_seed >> 2) % 3 > 2) {
+			if (n < .2f)
+				n += canyon3_ridged_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_ridged_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon3_ridged_function(GetFracDef(8), p) * (.4 / n) * .4;
+		} else if ((m_seed >> 2) % 3 > 1) {
+			if (n < .2f)
+				n += canyon3_billow_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_billow_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon3_billow_function(GetFracDef(8), p) * (.4 / n) * .4;
+		} else {
+			if (n < .2f)
+				n += canyon3_voronoi_function(GetFracDef(8), p) * n * 2;
+			else if (n < .4f)
+				n += canyon3_voronoi_function(GetFracDef(8), p) * .4;
+			else
+				n += canyon3_voronoi_function(GetFracDef(8), p) * (.4 / n) * .4;
+		}
+
+		n += -0.05f;
+		n = (n > 0.0 ? n : 0.0);
+
+		n = n * .01f;
+
+		if (n > 0.0) {
+			// smooth in hills at shore edges
+			if (n < 0.01)
+				n += hills * n * 100.0f;
+			else
+				n += hills;
+			if (n < 0.02)
+				n += hills2 * n * 50.0f;
+			else
+				n += hills2 * (0.02f / n);
+
+			mountains = octavenoise(GetFracDef(1), 0.5, p) *
+				GetFracDef(2).amplitude * mountains * mountains * mountains;
+			mountains2 = octavenoise(GetFracDef(4), 0.5, p) *
+				GetFracDef(3).amplitude * mountains2 * mountains2 * mountains2;
+			if (n > 2.5) n += mountains2 * (n - 2.5) * 0.6f;
+			if (n < 0.01)
+				n += mountains * n * 60.0f;
+			else
+				n += mountains * 0.6f;
+		}
+
+		n *= m_maxHeight;
+		heightsOut.at(i) = (n > 0.0 ? n : 0.0);
 	}
-
-	n = m_maxHeight * n;
-	return (n > 0.0 ? n : 0.0);
 }

--- a/src/terrain/TerrainHeightRuggedDesert.cpp
+++ b/src/terrain/TerrainHeightRuggedDesert.cpp
@@ -12,42 +12,6 @@ template <>
 const char *TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeightFractalName() const { return "RuggedDesert"; }
 
 template <>
-double TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeight(const vector3d &p) const
-{
-	double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel; // + (cliff_function(GetFracDef(7), p)*0.5);
-	if (continents < 0) return 0;
-	double mountain_distrib = octavenoise(GetFracDef(2), 0.5, p);
-	double mountains = ridged_octavenoise(GetFracDef(1), 0.5, p);
-	//double rocks = octavenoise(GetFracDef(9), 0.5, p);
-	double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
-	double hills = hill_distrib * GetFracDef(3).amplitude * billow_octavenoise(GetFracDef(3), 0.5, p);
-	double dunes = hill_distrib * GetFracDef(5).amplitude * dunes_octavenoise(GetFracDef(5), 0.5, p);
-	double n = continents * GetFracDef(0).amplitude * 2; //+ (cliff_function(GetFracDef(6), p)*0.5);
-	n += (n < 0.0 ? 0.0 : n);
-
-	// makes larger dunes at lower altitudes, flat ones at high altitude.
-	mountains = mountain_distrib * GetFracDef(3).amplitude * mountains * mountains * mountains;
-	// smoothes edges of mountains and places them only above a set altitude
-	if (n < 0.1)
-		n += n * 10.0f * hills;
-	else
-		n += hills;
-	if (n > 0.2)
-		n += dunes * (0.2 / n);
-	else
-		n += dunes;
-	if (n < 0.1)
-		n += n * 10.0f * mountains;
-	else
-		n += mountains;
-
-	//rocks = mountain_distrib * GetFracDef(9).amplitude * rocks*rocks*rocks;
-	//n += rocks ;
-
-	return (n > 0.0 ? m_maxHeight * n : 0.0);
-}
-
-template <>
 TerrainHeightFractal<TerrainHeightRuggedDesert>::TerrainHeightFractal(const SystemBody *body) :
 	Terrain(body)
 {
@@ -70,4 +34,45 @@ TerrainHeightFractal<TerrainHeightRuggedDesert>::TerrainHeightFractal(const Syst
 	//SetFracDef(9, m_maxHeightInMeters*0.1, 100, 10.0);
 	// adds bumps to the landscape
 	SetFracDef(9, height * 0.0025, m_rand.Double(1, 100), 100.0);
+}
+
+template <>
+void TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
+{
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(0), 0.5, p) - m_sealevel; // + (cliff_function(GetFracDef(7), p)*0.5);
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
+
+		double mountain_distrib = octavenoise(GetFracDef(2), 0.5, p);
+		double mountains = ridged_octavenoise(GetFracDef(1), 0.5, p);
+		//double rocks = octavenoise(GetFracDef(9), 0.5, p);
+		double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
+		double hills = hill_distrib * GetFracDef(3).amplitude * billow_octavenoise(GetFracDef(3), 0.5, p);
+		double dunes = hill_distrib * GetFracDef(5).amplitude * dunes_octavenoise(GetFracDef(5), 0.5, p);
+		double n = continents * GetFracDef(0).amplitude * 2; //+ (cliff_function(GetFracDef(6), p)*0.5);
+		n += (n < 0.0 ? 0.0 : n);
+
+		// makes larger dunes at lower altitudes, flat ones at high altitude.
+		mountains = mountain_distrib * GetFracDef(3).amplitude * mountains * mountains * mountains;
+		// smoothes edges of mountains and places them only above a set altitude
+		if (n < 0.1)
+			n += n * 10.0f * hills;
+		else
+			n += hills;
+		if (n > 0.2)
+			n += dunes * (0.2 / n);
+		else
+			n += dunes;
+		if (n < 0.1)
+			n += n * 10.0f * mountains;
+		else
+			n += mountains;
+
+		//rocks = mountain_distrib * GetFracDef(9).amplitude * rocks*rocks*rocks;
+		//n += rocks ;
+
+		heightsOut.at(i) = (n > 0.0 ? m_maxHeight * n : 0.0);
+	}
 }

--- a/src/terrain/TerrainHeightRuggedLava.cpp
+++ b/src/terrain/TerrainHeightRuggedLava.cpp
@@ -36,64 +36,69 @@ TerrainHeightFractal<TerrainHeightRuggedLava>::TerrainHeightFractal(const System
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightRuggedLava>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightRuggedLava>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = octavenoise(GetFracDef(0), Clamp(0.725 - (m_sealevel / 2), 0.1, 0.725), p) - m_sealevel;
-	if (continents < 0) return 0;
-	double mountain_distrib = octavenoise(GetFracDef(1), 0.55, p);
-	double mountains = octavenoise(GetFracDef(2), 0.5, p) * ridged_octavenoise(GetFracDef(2), 0.575, p);
-	double mountains2 = octavenoise(GetFracDef(3), 0.5, p);
-	double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
-	double hills = hill_distrib * GetFracDef(5).amplitude * octavenoise(GetFracDef(5), 0.5, p);
-	double rocks = octavenoise(GetFracDef(9), 0.5, p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = octavenoise(GetFracDef(0), Clamp(0.725 - (m_sealevel / 2), 0.1, 0.725), p) - m_sealevel;
+		if (continents < 0.0)
+			heightsOut.at(i) = 0.0;
 
-	double n = continents - (GetFracDef(0).amplitude * m_sealevel);
-	//double n = (megavolcano_function(p) + volcano_function(p) + smlvolcano_function(p));
-	n += mountains * mountains2 * 5.0 * megavolcano_function(GetFracDef(6), p);
-	n += 2.5 * megavolcano_function(GetFracDef(6), p);
-	n += mountains * mountains2 * 5.0 * volcano_function(GetFracDef(6), p) * volcano_function(GetFracDef(6), p);
-	n += 2.5 * volcano_function(GetFracDef(6), p);
+		double mountain_distrib = octavenoise(GetFracDef(1), 0.55, p);
+		double mountains = octavenoise(GetFracDef(2), 0.5, p) * ridged_octavenoise(GetFracDef(2), 0.575, p);
+		double mountains2 = octavenoise(GetFracDef(3), 0.5, p);
+		double hill_distrib = octavenoise(GetFracDef(4), 0.5, p);
+		double hills = hill_distrib * GetFracDef(5).amplitude * octavenoise(GetFracDef(5), 0.5, p);
+		double rocks = octavenoise(GetFracDef(9), 0.5, p);
 
-	n += mountains * mountains2 * 7.5 * megavolcano_function(GetFracDef(7), p);
-	n += 2.5 * megavolcano_function(GetFracDef(7), p);
-	n += mountains * mountains2 * 7.5 * volcano_function(GetFracDef(7), p) * volcano_function(GetFracDef(7), p);
-	n += 2.5 * volcano_function(GetFracDef(7), p);
+		double n = continents - (GetFracDef(0).amplitude * m_sealevel);
+		//double n = (megavolcano_function(p) + volcano_function(p) + smlvolcano_function(p));
+		n += mountains * mountains2 * 5.0 * megavolcano_function(GetFracDef(6), p);
+		n += 2.5 * megavolcano_function(GetFracDef(6), p);
+		n += mountains * mountains2 * 5.0 * volcano_function(GetFracDef(6), p) * volcano_function(GetFracDef(6), p);
+		n += 2.5 * volcano_function(GetFracDef(6), p);
 
-	//n += 1.4*(continents - targ.continents.amplitude*targ.sealevel + (volcano_function(p)*1)) ;
-	//smooth canyon transitions and limit height of canyon placement
-	if (n < .01)
-		n += n * 100.0f * canyon3_ridged_function(GetFracDef(8), p);
-	else
-		n += canyon3_ridged_function(GetFracDef(8), p);
+		n += mountains * mountains2 * 7.5 * megavolcano_function(GetFracDef(7), p);
+		n += 2.5 * megavolcano_function(GetFracDef(7), p);
+		n += mountains * mountains2 * 7.5 * volcano_function(GetFracDef(7), p) * volcano_function(GetFracDef(7), p);
+		n += 2.5 * volcano_function(GetFracDef(7), p);
 
-	if (n < .01)
-		n += n * 100.0f * canyon2_ridged_function(GetFracDef(8), p);
-	else
-		n += canyon2_ridged_function(GetFracDef(8), p);
-	n *= 0.5;
+		//n += 1.4*(continents - targ.continents.amplitude*targ.sealevel + (volcano_function(p)*1)) ;
+		//smooth canyon transitions and limit height of canyon placement
+		if (n < .01)
+			n += n * 100.0f * canyon3_ridged_function(GetFracDef(8), p);
+		else
+			n += canyon3_ridged_function(GetFracDef(8), p);
 
-	n += continents * hills * hill_distrib * mountain_distrib;
+		if (n < .01)
+			n += n * 100.0f * canyon2_ridged_function(GetFracDef(8), p);
+		else
+			n += canyon2_ridged_function(GetFracDef(8), p);
+		n *= 0.5;
 
-	mountains = octavenoise(GetFracDef(1), 0.5, p) *
-		GetFracDef(2).amplitude * mountains * mountains * mountains;
-	mountains2 = octavenoise(GetFracDef(4), 0.5, p) *
-		GetFracDef(3).amplitude * mountains2 * mountains2 * mountains2;
-	/*mountains = fractal(2, targ.mountainDistrib, (m_seed>>2)&3, p) *
-		targ.mountains.amplitude * mountains*mountains*mountains;
-	mountains2 = fractal(24, targ.mountainDistrib, (m_seed>>2)&3, p) *
-		targ.mountains.amplitude * mountains*mountains*mountains;*/
+		n += continents * hills * hill_distrib * mountain_distrib;
 
-	n += continents * mountains * hill_distrib;
-	if (n < 0.01)
-		n += continents * mountains2 * n * 40.0f;
-	else
-		n += continents * mountains2 * .4f;
-	n *= 0.2;
-	n += mountains * mountains2 * mountains2 * hills * hills * hill_distrib * mountain_distrib * 20.0;
+		mountains = octavenoise(GetFracDef(1), 0.5, p) *
+			GetFracDef(2).amplitude * mountains * mountains * mountains;
+		mountains2 = octavenoise(GetFracDef(4), 0.5, p) *
+			GetFracDef(3).amplitude * mountains2 * mountains2 * mountains2;
+		/*mountains = fractal(2, targ.mountainDistrib, (m_seed>>2)&3, p) *
+			targ.mountains.amplitude * mountains*mountains*mountains;
+		mountains2 = fractal(24, targ.mountainDistrib, (m_seed>>2)&3, p) *
+			targ.mountains.amplitude * mountains*mountains*mountains;*/
 
-	rocks = continents * mountain_distrib * GetFracDef(9).amplitude * rocks * rocks * rocks * 2.0;
-	n += rocks;
+		n += continents * mountains * hill_distrib;
+		if (n < 0.01)
+			n += continents * mountains2 * n * 40.0f;
+		else
+			n += continents * mountains2 * .4f;
+		n *= 0.2;
+		n += mountains * mountains2 * mountains2 * hills * hills * hill_distrib * mountain_distrib * 20.0;
 
-	n = (n < 0.0 ? 0.0 : m_maxHeight * n);
-	return n;
+		rocks = continents * mountain_distrib * GetFracDef(9).amplitude * rocks * rocks * rocks * 2.0;
+		n += rocks;
+
+		n = (n < 0.0 ? 0.0 : m_maxHeight * n);
+		heightsOut.at(i) = n;
+	}
 }

--- a/src/terrain/TerrainHeightWaterSolid.cpp
+++ b/src/terrain/TerrainHeightWaterSolid.cpp
@@ -28,37 +28,40 @@ TerrainHeightFractal<TerrainHeightWaterSolid>::TerrainHeightFractal(const System
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightWaterSolid>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightWaterSolid>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = 0.7 * river_octavenoise(GetFracDef(2), 0.5, p) - m_sealevel;
-	continents = GetFracDef(0).amplitude * ridged_octavenoise(GetFracDef(0), Clamp(continents, 0.0, 0.6), p);
-	double mountains = ridged_octavenoise(GetFracDef(2), 0.5, p);
-	double hills = octavenoise(GetFracDef(2), 0.5, p) *
-		GetFracDef(1).amplitude * river_octavenoise(GetFracDef(1), 0.5, p);
-	double n = continents - (GetFracDef(0).amplitude * m_sealevel);
-	// craters
-	n += crater_function(GetFracDef(5), p);
-	if (n > 0.0) {
-		// smooth in hills at shore edges
-		if (n < 0.05) {
-			n += hills * n * 4.0;
-			n += n * 20.0 * (billow_octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p) + river_octavenoise(GetFracDef(4), 0.5 * ridged_octavenoise(GetFracDef(3), 0.5, p), p) + billow_octavenoise(GetFracDef(3), 0.6 * ridged_octavenoise(GetFracDef(4), 0.55, p), p));
-		} else {
-			n += hills * .2f;
-			n += billow_octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p) +
-				river_octavenoise(GetFracDef(4), 0.5 * ridged_octavenoise(GetFracDef(3), 0.5, p), p) +
-				billow_octavenoise(GetFracDef(3), 0.6 * ridged_octavenoise(GetFracDef(4), 0.55, p), p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = 0.7 * river_octavenoise(GetFracDef(2), 0.5, p) - m_sealevel;
+		continents = GetFracDef(0).amplitude * ridged_octavenoise(GetFracDef(0), Clamp(continents, 0.0, 0.6), p);
+		double mountains = ridged_octavenoise(GetFracDef(2), 0.5, p);
+		double hills = octavenoise(GetFracDef(2), 0.5, p) *
+			GetFracDef(1).amplitude * river_octavenoise(GetFracDef(1), 0.5, p);
+		double n = continents - (GetFracDef(0).amplitude * m_sealevel);
+		// craters
+		n += crater_function(GetFracDef(5), p);
+		if (n > 0.0) {
+			// smooth in hills at shore edges
+			if (n < 0.05) {
+				n += hills * n * 4.0;
+				n += n * 20.0 * (billow_octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p) + river_octavenoise(GetFracDef(4), 0.5 * ridged_octavenoise(GetFracDef(3), 0.5, p), p) + billow_octavenoise(GetFracDef(3), 0.6 * ridged_octavenoise(GetFracDef(4), 0.55, p), p));
+			} else {
+				n += hills * .2f;
+				n += billow_octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p) +
+					river_octavenoise(GetFracDef(4), 0.5 * ridged_octavenoise(GetFracDef(3), 0.5, p), p) +
+					billow_octavenoise(GetFracDef(3), 0.6 * ridged_octavenoise(GetFracDef(4), 0.55, p), p);
+			}
+			// adds mountains hills craters
+			mountains = octavenoise(GetFracDef(3), 0.5, p) *
+				GetFracDef(2).amplitude * mountains * mountains * mountains;
+			if (n < 0.4)
+				n += 2.0 * n * mountains;
+			else
+				n += mountains * .8f;
 		}
-		// adds mountains hills craters
-		mountains = octavenoise(GetFracDef(3), 0.5, p) *
-			GetFracDef(2).amplitude * mountains * mountains * mountains;
-		if (n < 0.4)
-			n += 2.0 * n * mountains;
-		else
-			n += mountains * .8f;
+		n *= m_maxHeight;
+		n = (n < 0.0 ? -n : n);
+		n = (n > 1.0 ? 2.0 - n : n);
+		heightsOut.at(i) = n;
 	}
-	n = m_maxHeight * n;
-	n = (n < 0.0 ? -n : n);
-	n = (n > 1.0 ? 2.0 - n : n);
-	return n;
 }

--- a/src/terrain/TerrainHeightWaterSolidCanyons.cpp
+++ b/src/terrain/TerrainHeightWaterSolidCanyons.cpp
@@ -31,37 +31,40 @@ TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::TerrainHeightFractal(const
 }
 
 template <>
-double TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::GetHeight(const vector3d &p) const
+void TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::GetHeights(const std::vector<vector3d> &vP, std::vector<double> &heightsOut) const
 {
-	double continents = 0.7 * river_octavenoise(GetFracDef(2), 0.5, p) - m_sealevel;
-	continents = GetFracDef(0).amplitude * ridged_octavenoise(GetFracDef(0), Clamp(continents, 0.0, 0.6), p);
-	double mountains = ridged_octavenoise(GetFracDef(2), 0.5, p);
-	double hills = octavenoise(GetFracDef(2), 0.5, p) *
-		GetFracDef(1).amplitude * river_octavenoise(GetFracDef(1), 0.5, p);
-	double n = continents - (GetFracDef(0).amplitude * m_sealevel);
-	if (n > 0.0) {
-		// smooth in hills at shore edges
-		if (n < 0.05) {
-			n += hills * n * 4.0;
-			n += n * 20.0 * (billow_octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p) + river_octavenoise(GetFracDef(4), 0.5 * ridged_octavenoise(GetFracDef(3), 0.5, p), p) + billow_octavenoise(GetFracDef(3), 0.6 * ridged_octavenoise(GetFracDef(4), 0.55, p), p));
-		} else {
-			n += hills * .2f;
-			n += billow_octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p) +
-				river_octavenoise(GetFracDef(4), 0.5 * ridged_octavenoise(GetFracDef(3), 0.5, p), p) +
-				billow_octavenoise(GetFracDef(3), 0.6 * ridged_octavenoise(GetFracDef(4), 0.55, p), p);
+	for (size_t i = 0; i < vP.size(); i++) {
+		const vector3d &p = vP[i];
+		double continents = 0.7 * river_octavenoise(GetFracDef(2), 0.5, p) - m_sealevel;
+		continents = GetFracDef(0).amplitude * ridged_octavenoise(GetFracDef(0), Clamp(continents, 0.0, 0.6), p);
+		double mountains = ridged_octavenoise(GetFracDef(2), 0.5, p);
+		double hills = octavenoise(GetFracDef(2), 0.5, p) *
+			GetFracDef(1).amplitude * river_octavenoise(GetFracDef(1), 0.5, p);
+		double n = continents - (GetFracDef(0).amplitude * m_sealevel);
+		if (n > 0.0) {
+			// smooth in hills at shore edges
+			if (n < 0.05) {
+				n += hills * n * 4.0;
+				n += n * 20.0 * (billow_octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p) + river_octavenoise(GetFracDef(4), 0.5 * ridged_octavenoise(GetFracDef(3), 0.5, p), p) + billow_octavenoise(GetFracDef(3), 0.6 * ridged_octavenoise(GetFracDef(4), 0.55, p), p));
+			} else {
+				n += hills * .2f;
+				n += billow_octavenoise(GetFracDef(3), 0.5 * ridged_octavenoise(GetFracDef(2), 0.5, p), p) +
+					river_octavenoise(GetFracDef(4), 0.5 * ridged_octavenoise(GetFracDef(3), 0.5, p), p) +
+					billow_octavenoise(GetFracDef(3), 0.6 * ridged_octavenoise(GetFracDef(4), 0.55, p), p);
+			}
+			// adds mountains hills craters
+			mountains = octavenoise(GetFracDef(3), 0.5, p) *
+				GetFracDef(2).amplitude * mountains * mountains * mountains;
+			if (n < 0.4)
+				n += 2.0 * n * mountains;
+			else
+				n += mountains * .8f;
 		}
-		// adds mountains hills craters
-		mountains = octavenoise(GetFracDef(3), 0.5, p) *
-			GetFracDef(2).amplitude * mountains * mountains * mountains;
-		if (n < 0.4)
-			n += 2.0 * n * mountains;
-		else
-			n += mountains * .8f;
+		// craters
+		n += 3.0 * impact_crater_function(GetFracDef(5), p);
+		n *= m_maxHeight;
+		n = (n < 0.0 ? 0 : n);
+		n = (n > 1.0 ? 2.0 - n : n);
+		heightsOut.at(i) = n;
 	}
-	// craters
-	n += 3.0 * impact_crater_function(GetFracDef(5), p);
-	n = m_maxHeight * n;
-	n = (n < 0.0 ? 0 : n);
-	n = (n > 1.0 ? 2.0 - n : n);
-	return n;
 }

--- a/src/vector3.h
+++ b/src/vector3.h
@@ -32,39 +32,39 @@ public:
 	explicit vector3(const vector3<typename other_floating_type<T>::type> &v);
 	explicit vector3(const typename other_floating_type<T>::type vals[3]);
 
-	const T &operator[](const size_t i) const { return (const_cast<const T *>(&x))[i]; }
-	T &operator[](const size_t i) { return (&x)[i]; }
+	inline const T &operator[](const size_t i) const { return (const_cast<const T *>(&x))[i]; }
+	inline T &operator[](const size_t i) { return (&x)[i]; }
 
-	vector3 operator+(const vector3 &a) const { return vector3(a.x + x, a.y + y, a.z + z); }
-	vector3 &operator+=(const vector3 &a)
+	inline vector3 operator+(const vector3 &a) const { return vector3(a.x + x, a.y + y, a.z + z); }
+	inline vector3 &operator+=(const vector3 &a)
 	{
 		x += a.x;
 		y += a.y;
 		z += a.z;
 		return *this;
 	}
-	vector3 &operator-=(const vector3 &a)
+	inline vector3 &operator-=(const vector3 &a)
 	{
 		x -= a.x;
 		y -= a.y;
 		z -= a.z;
 		return *this;
 	}
-	vector3 &operator*=(const float a)
+	inline vector3 &operator*=(const float a)
 	{
 		x *= a;
 		y *= a;
 		z *= a;
 		return *this;
 	}
-	vector3 &operator*=(const double a)
+	inline vector3 &operator*=(const double a)
 	{
 		x *= a;
 		y *= a;
 		z *= a;
 		return *this;
 	}
-	vector3 &operator/=(const float a)
+	inline vector3 &operator/=(const float a)
 	{
 		const T inva = T(1.0 / a);
 		x *= inva;
@@ -72,7 +72,7 @@ public:
 		z *= inva;
 		return *this;
 	}
-	vector3 &operator/=(const double a)
+	inline vector3 &operator/=(const double a)
 	{
 		const T inva = T(1.0 / a);
 		x *= inva;
@@ -80,68 +80,75 @@ public:
 		z *= inva;
 		return *this;
 	}
-	vector3 operator-(const vector3 &a) const { return vector3(x - a.x, y - a.y, z - a.z); }
-	vector3 operator-() const { return vector3(-x, -y, -z); }
+	inline vector3 operator-(const vector3 &a) const { return vector3(x - a.x, y - a.y, z - a.z); }
+	inline vector3 operator-() const { return vector3(-x, -y, -z); }
 
-	bool operator==(const vector3 &a) const
+	inline bool operator==(const vector3 &a) const
 	{
 		return is_equal_exact(a.x, x) && is_equal_exact(a.y, y) && is_equal_exact(a.z, z);
 	}
-	bool ExactlyEqual(const vector3 &a) const
+	inline bool ExactlyEqual(const vector3 &a) const
 	{
 		return is_equal_exact(a.x, x) && is_equal_exact(a.y, y) && is_equal_exact(a.z, z);
 	}
 
-	friend vector3 operator+(const vector3 &a, const T &scalar) { return vector3(a.x + scalar, a.y + scalar, a.z + scalar); }
-	friend vector3 operator+(const T scalar, const vector3 &a) { return a + scalar; }
-	friend vector3 operator-(const vector3 &a, const T &scalar) { return vector3(a.x - scalar, a.y - scalar, a.z - scalar); }
-	friend vector3 operator-(const T scalar, const vector3 &a) { return a - scalar; }
+	inline friend vector3 operator+(const vector3 &a, const T &scalar) { return vector3(a.x + scalar, a.y + scalar, a.z + scalar); }
+	inline friend vector3 operator+(const T scalar, const vector3 &a) { return a + scalar; }
+	inline friend vector3 operator-(const vector3 &a, const T &scalar) { return vector3(a.x - scalar, a.y - scalar, a.z - scalar); }
+	inline friend vector3 operator-(const T scalar, const vector3 &a) { return a - scalar; }
 
-	friend vector3 operator*(const vector3 &a, const vector3 &b) { return vector3(T(a.x * b.x), T(a.y * b.y), T(a.z * b.z)); }
-	friend vector3 operator*(const vector3 &a, const T scalar) { return vector3(T(a.x * scalar), T(a.y * scalar), T(a.z * scalar)); }
+	inline friend vector3 operator*(const vector3 &a, const vector3 &b) { return vector3(T(a.x * b.x), T(a.y * b.y), T(a.z * b.z)); }
+	inline friend vector3 operator*(const vector3 &a, const T scalar) { return vector3(T(a.x * scalar), T(a.y * scalar), T(a.z * scalar)); }
 	//friend vector3 operator*(const vector3 &a, const double scalar) { return vector3(T(a.x*scalar), T(a.y*scalar), T(a.z*scalar)); }
-	friend vector3 operator*(const T scalar, const vector3 &a) { return a * scalar; }
+	inline friend vector3 operator*(const T scalar, const vector3 &a) { return a * scalar; }
 	//friend vector3 operator*(const double scalar, const vector3 &a) { return a*scalar; }
-	friend vector3 operator/(const vector3 &a, const float scalar)
+	inline friend vector3 operator/(const vector3 &a, const float scalar)
 	{
 		const T inv = 1.0 / scalar;
 		return vector3(a.x * inv, a.y * inv, a.z * inv);
 	}
-	friend vector3 operator/(const vector3 &a, const double scalar)
+	inline friend vector3 operator/(const vector3 &a, const double scalar)
 	{
 		const T inv = 1.0 / scalar;
 		return vector3(a.x * inv, a.y * inv, a.z * inv);
 	}
-	friend vector3 operator/(const T scalar, const vector3 &a)
+	inline friend vector3 operator/(const T scalar, const vector3 &a)
 	{
 		return vector3(scalar / a.x, scalar / a.y, scalar / a.z);
 	}
 
 	// component-wise ALL-less-than
-	auto operator<(const vector3 &b) const { return x < b.x && y < b.y && z < b.z; }
+	inline auto operator<(const vector3 &b) const { return x < b.x && y < b.y && z < b.z; }
 	// component-wise ALL-less-equal
-	auto operator<=(const vector3 &b) const { return x <= b.x && y <= b.y && z <= b.z; }
+	inline auto operator<=(const vector3 &b) const { return x <= b.x && y <= b.y && z <= b.z; }
 	// component-wise ALL-greater-than
-	auto operator>(const vector3 &b) const { return x > b.x && y > b.y && z > b.z; }
+	inline auto operator>(const vector3 &b) const { return x > b.x && y > b.y && z > b.z; }
 	// component-wise ALL-greater-equal
-	auto operator>=(const vector3 &b) const { return x >= b.x && y >= b.y && z >= b.z; }
+	inline auto operator>=(const vector3 &b) const { return x >= b.x && y >= b.y && z >= b.z; }
 
-	vector3 Cross(const vector3 &b) const { return vector3(y * b.z - z * b.y, z * b.x - x * b.z, x * b.y - y * b.x); }
-	T Dot(const vector3 &b) const { return x * b.x + y * b.y + z * b.z; }
-	T Length() const { return sqrt(x * x + y * y + z * z); }
-	T LengthSqr() const { return x * x + y * y + z * z; }
-	vector3 Lerp(const vector3 &b, const double percent) const
+	inline vector3 Cross(const vector3 &b) const { return vector3(y * b.z - z * b.y, z * b.x - x * b.z, x * b.y - y * b.x); }
+	inline T Dot(const vector3 &b) const { return x * b.x + y * b.y + z * b.z; }
+	inline T Length() const { return sqrt(x * x + y * y + z * z); }
+	inline T LengthSqr() const { return x * x + y * y + z * z; }
+	inline vector3 Lerp(const vector3 &b, const double percent) const
 	{
 		return *this + percent * (b - *this);
 	}
-	vector3 Normalized() const
+	inline void Normalize()
 	{
-		const T l = 1.0f / sqrt(x * x + y * y + z * z);
+		const T l = 1.0f / Length();
+		x *= l;
+		y *= l;
+		z *= l;
+	}
+	inline vector3 Normalized() const
+	{
+		const T l = 1.0f / Length();
 		return vector3(x * l, y * l, z * l);
 	}
-	vector3 NormalizedSafe() const
+	inline vector3 NormalizedSafe() const
 	{
-		const T lenSqr = x * x + y * y + z * z;
+		const T lenSqr = LengthSqr();
 		if (lenSqr < 1e-18) // sqrt(lenSqr) < 1e-9
 			return vector3(1, 0, 0);
 		else {
@@ -150,7 +157,7 @@ public:
 		}
 	}
 
-	void Print() const { printf("v(%f,%f,%f)\n", x, y, z); }
+	inline void Print() const { printf("v(%f,%f,%f)\n", x, y, z); }
 
 	/* Rotate this vector about point o, in axis defined by v. */
 	void ArbRotateAroundPoint(const vector3 &o, const vector3 &__v, T ang)
@@ -199,27 +206,27 @@ public:
 		*this = t;
 	}
 
-	void xy(const vector2<T> &v2)
+	inline void xy(const vector2<T> &v2)
 	{
 		x = v2.x;
 		y = v2.y;
 	}
-	void xz(const vector2<T> &v2)
+	inline void xz(const vector2<T> &v2)
 	{
 		x = v2.x;
 		z = v2.y;
 	}
-	void yz(const vector2<T> &v2)
+	inline void yz(const vector2<T> &v2)
 	{
 		y = v2.x;
 		z = v2.y;
 	}
 
-	vector2<T> xy() { return vector2<T>(x, y); }
-	vector2<T> xz() { return vector2<T>(x, z); }
-	vector2<T> yz() { return vector2<T>(y, z); }
-	vector2<T> yx() { return vector2<T>(y, x); }
-	vector2<T> zx() { return vector2<T>(z, x); }
+	inline vector2<T> xy() { return vector2<T>(x, y); }
+	inline vector2<T> xz() { return vector2<T>(x, z); }
+	inline vector2<T> yz() { return vector2<T>(y, z); }
+	inline vector2<T> yx() { return vector2<T>(y, x); }
+	inline vector2<T> zx() { return vector2<T>(z, x); }
 };
 
 // These are here in this manner to enforce that only float and double versions are possible.


### PR DESCRIPTION
Optimisations parts:
- Inlined methods and added a Normalise-in-place to vector3d
- Batched generating heights, avoid calling GetHeight 1225 times and instead request all heights at once
- Forced override of GetHeight in BaseSphere since it always is anyway
- `m_entropy[12]` is only used in 2 places and only ever used the first value but refreshed it hundreds of times every Terrain Ctor

Tweak:
- Display the Height and Color fractal names used for a terrain in ObjectViewerView (Ctrl+F10)

These changes probably do affect the terrain generation though I haven't noticed massive changes in testing. Unsure if we'll need a savegame bump