### PR TITLE
Detect Windows 11, update GL Renderer name

### DIFF
--- a/src/graphics/opengl/RendererGL.cpp
+++ b/src/graphics/opengl/RendererGL.cpp
@@ -309,6 +309,12 @@ namespace Graphics {
 		SDL_GL_DeleteContext(m_glContext);
 	}
 
+	const char *RendererOGL::GetName() const
+	{
+		// since 15/10/2020 we've been requiring OpenGL 3.2
+		return "OpenGL 3.2, with extensions, renderer";
+	}
+
 	static const char *gl_error_to_string(GLenum err)
 	{
 		switch (err) {
@@ -384,6 +390,12 @@ namespace Graphics {
 		out << "OpenGL version " << glGetString(GL_VERSION);
 		out << ", running on " << glGetString(GL_VENDOR);
 		out << " " << glGetString(GL_RENDERER) << "\n";
+
+		// Log this information to output as well to aid error reporting
+		Output("OpenGL version %s, running on %s %s",
+			(const char *)glGetString(GL_VERSION),
+			(const char *)glGetString(GL_VENDOR),
+			(const char *)glGetString(GL_RENDERER));
 
 		out << "Available extensions:"
 			<< "\n";

--- a/src/graphics/opengl/RendererGL.h
+++ b/src/graphics/opengl/RendererGL.h
@@ -43,7 +43,7 @@ namespace Graphics {
 		RendererOGL(SDL_Window *window, const Graphics::Settings &vs, SDL_GLContext &glContext);
 		~RendererOGL() final;
 
-		const char *GetName() const final { return "OpenGL 3.1, with extensions, renderer"; }
+		const char *GetName() const final;
 		RendererType GetRendererType() const final { return RENDERER_OPENGL_3x; }
 
 		void WriteRendererInfo(std::ostream &out) const final;

--- a/src/win32/OSWin32.cpp
+++ b/src/win32/OSWin32.cpp
@@ -51,17 +51,19 @@ namespace OS {
 		struct OSVersion {
 			DWORD major;
 			DWORD minor;
+			DWORD build;
 			const char *name;
 		};
 		static const struct OSVersion osVersions[] = {
-			{ 10, 0, "Windows 10" },
-			{ 6, 3, "Windows 8.1" },
-			{ 6, 2, "Windows 8" },
-			{ 6, 1, "Windows 7" },
-			{ 6, 0, "Windows Vista" },
-			{ 5, 1, "Windows XP" },
-			{ 5, 0, "Windows 2000" },
-			{ 0, 0, nullptr }
+			{ 10,	0,		22000,	"Windows 11" }, // fuck microsoft, major minor are the same as Windows 10, but builds from 22000 are Win11
+			{ 10,	0,		0,		"Windows 10" },
+			{ 6,	3,		0,		"Windows 8.1" },
+			{ 6,	2,		0,		"Windows 8" },
+			{ 6,	1,		0,		"Windows 7" },
+			{ 6,	0,		0,		"Windows Vista" },
+			{ 5,	1,		0,		"Windows XP" },
+			{ 5,	0,		0,		"Windows 2000" },
+			{ 0,	0,		0,		nullptr }
 		};
 	} // namespace
 
@@ -198,7 +200,9 @@ namespace OS {
 		OSVERSIONINFOEX os;
 		if (GetVersionHackNTDLL(&os) == TRUE) {
 			for (const OSVersion *scan = osVersions; scan->name; scan++) {
-				if (os.dwMajorVersion >= scan->major && os.dwMinorVersion >= scan->minor) {
+				if (os.dwMajorVersion >= scan->major &&
+ 					os.dwMinorVersion >= scan->minor &&
+ 					os.dwBuildNumber >= scan->build) {
 					name = scan->name;
 					break;
 				}
@@ -213,7 +217,9 @@ namespace OS {
 			GetVersionExA(&osa);
 
 			for (const OSVersion *scan = osVersions; scan->name; scan++) {
-				if (osa.dwMajorVersion >= scan->major && osa.dwMinorVersion >= scan->minor) {
+				if (osa.dwMajorVersion >= scan->major &&
+					osa.dwMinorVersion >= scan->minor &&
+					osa.dwBuildNumber >= scan->build) {
 					name = scan->name;
 					break;
 				}


### PR DESCRIPTION
Some minor tweaks I had laying around:

- Microsoft are annoying and Windows 11 is detect based on build number 🤦 
- We've actually been requesting an OpenGL 3.2 context since late 2020, so change the renderer description
- Output the OpenGL version and adapter info to the `output.log` file for easier error reporting