### PR TITLE
Balancing the Scout mission ads

### DIFF
--- a/data/modules/Scout/Scout.lua
+++ b/data/modules/Scout/Scout.lua
@@ -568,14 +568,14 @@ end
 local onUpdateBB = function (station)
 	for ref,ad in pairs(ads) do
 		if not flavours[ad.flavour].localscout
-			and ad.due < Game.time + 432000 then -- 5 days
+			and ad.due < Game.time + 5*24*60*60 then
 			ad.station:RemoveAdvert(ref)
 		elseif flavours[ad.flavour].localscout
-			and ad.due < Game.time + 172800 then -- 2 days
+			and ad.due < Game.time + 2*24*60*60 then
 			ad.station:RemoveAdvert(ref)
 		end
 	end
-	if Engine.rand:Integer(43200) < 3600 then    -- 12 h < 1 h
+	if Engine.rand:Integer(3*24*60*60) < 60*60 then
 		makeAdvert(station)
 	end
 end


### PR DESCRIPTION
In response to https://github.com/pioneerspacesim/pioneer/issues/5760 where the BBS over time lose balance as some modules take over. Especially the Scout module keeps adding missions in excess of the demand. This is a quick fix to soften the issue and with this PR the missions balance out at around ~30 missions per station if none is take by the player.

The fix works by creating fewer adverts for Scout missions. One sixth of previous rate.

I haven't tested this other than sitting at Cydonia for 9 months and watching the mission list build up.
Here is what it looks like on master when the missions build up while not doing anything.
```
Number of ads per module after...
                     ~2 months            ~4 months
------------------------------------------------------
Assassination               10                  5
Cargo run                   21                 32
Scoop                       ~1                  1
Scout                      119 !!!            174 ???
Combat                       6                  4
Deliver Package             24                 24
Search and rescue            3                  5
Second hand                  2                  1
Taxi                        34                 38
```