### PR TITLE
Assassination - article quick fix

### DIFF
--- a/data/lang/module-assassination/en.json
+++ b/data/lang/module-assassination/en.json
@@ -349,6 +349,6 @@
   },
   "X_WILL_BE_LEAVING": {
     "description": "",
-    "message": "{target} will be leaving {spaceport} in the {system} system ({sectorX}, {sectorY}, {sectorZ}), distance {dist} ly, at {date}. The ship is {shipname} and has registration id {shipregid}."
+    "message": "{target} will be leaving {spaceport} in the {system} system ({sectorX}, {sectorY}, {sectorZ}), distance {dist} ly, at {date}. The ship is a {shipname} and has registration id {shipregid}."
   }
 }


### PR DESCRIPTION
In the Assassination module the answer to chat question "Where do I find {target}" is always the same and the ending looks a bit off as the string doesn't cater for the ship model, a/an.

`... The ship is Wave and has registration ID QA-7856.`

The quick solution is to assume article 'a' as by chance it fits in with all ship models except AC-33. Now the string is off only one out of 27 times.

