### PR TITLE
Somewhat lukewarm fixes

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -680,7 +680,7 @@ function SpaceStation:LaunchPolice(targetShip)
 
 		-- The more lawless/dangerous the space is, the better equipped the few police ships are
 		-- In a high-law area, a spacestation has a bunch of traffic cops due to low crime rates
-		local shipThreat = 10.0 + Engine.rand:Number(10, 50) * lawlessness
+		local shipThreat = 15.0 + Engine.rand:Number(10, 50) * lawlessness
 
 		local shipTemplate = ShipTemplates.StationPolice:clone {
 			shipId = Game.system.faction.policeShip,

--- a/data/meta/Components/GunManager.meta.lua
+++ b/data/meta/Components/GunManager.meta.lua
@@ -27,4 +27,16 @@ function GunManager:UnmountWeapon(mount) end
 ---@param mount string
 function GunManager:IsWeaponMounted(mount) end
 
+---@param id string
+---@return integer weaponIndex
+function GunManager:GetWeaponIndexForHardpoint(id) end
+
+---@param weaponIndex integer
+---@param group integer
+function GunManager:AssignWeaponToGroup(weaponIndex, group) end
+
+---@param group integer
+---@param enabled boolean
+function GunManager:SetGroupFireWithoutTargeting(group, enabled) end
+
 -- TODO...

--- a/data/modules/Equipment/Internal.lua
+++ b/data/modules/Equipment/Internal.lua
@@ -202,7 +202,7 @@ Equipment.Register("hull.heavy_atmospheric_shielding_s3", EquipType.New {
 Equipment.Register("hull.heavy_atmospheric_shielding_s4", EquipType.New {
 	l10n_key="ATMOSPHERIC_SHIELDING_HEAVY",
 	price=21330, purchasable=true, tech_level=7,
-	slot = { type="hull.atmo_shield", size=3 },
+	slot = { type="hull.atmo_shield", size=4 },
 	mass=22, volume=28, capabilities = { atmo_shield=9 },
 	icon_name="equip_atmo_shield_generator"
 })

--- a/data/modules/Equipment/Types.lua
+++ b/data/modules/Equipment/Types.lua
@@ -53,6 +53,8 @@ function LaserType:OnInstall(ship, slot)
 	EquipType.OnInstall(self, ship, slot)
 
 	ship:GetComponent('GunManager'):MountWeapon(slot.id, self.weapon_data)
+	--- TEMP: enable always-on firing until a UI is provided to the player
+	ship:GetComponent('GunManager'):SetGroupFireWithoutTargeting(0, true)
 end
 
 ---@param ship Ship

--- a/data/modules/Equipment/Weapons.lua
+++ b/data/modules/Equipment/Weapons.lua
@@ -53,7 +53,7 @@ Equipment.Register("laser.pulsecannon_rapid_2mw", LaserType.New {
 	l10n_key="PULSECANNON_RAPID_2MW",
 	price=1800, purchasable=true, tech_level=5,
 	mass=7, volume=7, capabilities={},
-	slot = { type="weapon.energy.pulsecannon", size=2, hardpoint=true },
+	slot = { type="weapon.energy.pulsecannon", size=3, hardpoint=true },
 	laser_stats = {
 		lifespan=8, speed=1000, damage=2000, rechargeTime=0.13, length=30,
 		width=5, beam=0, dual=0, mining=0, rgba_r = 255, rgba_g = 127, rgba_b = 51, rgba_a = 255
@@ -85,11 +85,12 @@ Equipment.Register("laser.pulsecannon_10mw", LaserType.New {
 	icon_name="equip_pulsecannon"
 })
 
+-- TEMP: marked weapon as S4, should be restatted to S5
 Equipment.Register("laser.pulsecannon_20mw", LaserType.New {
 	l10n_key="PULSECANNON_20MW",
 	price=12000, purchasable=true, tech_level="MILITARY",
-	mass=65, volume=65, capabilities={},
-	slot = { type="weapon.energy.pulsecannon", size=5, hardpoint=true },
+	mass=55, volume=55, capabilities={},
+	slot = { type="weapon.energy.pulsecannon", size=4, hardpoint=true },
 	laser_stats = {
 		lifespan=8, speed=1000, damage=20000, rechargeTime=0.25, length=30,
 		width=5, beam=0, dual=0, mining=0, rgba_r = 0.1, rgba_g = 51, rgba_b = 255, rgba_a = 255
@@ -144,11 +145,12 @@ Equipment.Register("laser.beamlaser_2mw", LaserType.New {
 -- Plasma Accelerators
 --===============================================
 
+-- TEMP: marked weapon as S3, should be S4+
 Equipment.Register("laser.small_plasma_accelerator", LaserType.New {
 	l10n_key="SMALL_PLASMA_ACCEL",
 	price=120000, purchasable=true, tech_level=10,
 	mass=22, volume=22, capabilities={},
-	slot = { type="weapon.energy.plasma_acc", size=5, hardpoint=true },
+	slot = { type="weapon.energy.plasma_acc", size=3, hardpoint=true },
 	laser_stats = {
 		lifespan=8, speed=1000, damage=50000, rechargeTime=0.3, length=42,
 		width=7, beam=0, dual=0, mining=0, rgba_r = 51, rgba_g = 255, rgba_b = 255, rgba_a = 255
@@ -156,11 +158,12 @@ Equipment.Register("laser.small_plasma_accelerator", LaserType.New {
 	icon_name="equip_plasma_accelerator"
 })
 
+-- TEMP: marked weapon as S4, should be S5+
 Equipment.Register("laser.large_plasma_accelerator", LaserType.New {
 	l10n_key="LARGE_PLASMA_ACCEL",
 	price=390000, purchasable=true, tech_level=12,
 	mass=50, volume=50, capabilities={},
-	slot = { type="weapon.energy.plasma_acc", size=6, hardpoint=true },
+	slot = { type="weapon.energy.plasma_acc", size=4, hardpoint=true },
 	laser_stats = {
 		lifespan=8, speed=1000, damage=100000, rechargeTime=0.3, length=42,
 		width=7, beam=0, dual=0, mining=0, rgba_r = 127, rgba_g = 255, rgba_b = 255, rgba_a = 255

--- a/data/modules/SecondHand/SecondHand.lua
+++ b/data/modules/SecondHand/SecondHand.lua
@@ -92,8 +92,12 @@ local onChat = function (form, ref, option)
 
 			local ok, slot, message_str = canFit(ad.equipment)
 			if ok then
+
+				-- TEMP: clarify the size of items offered for secondhand purchase
+				local equipmentName = (ad.equipment.slot and "S" .. ad.equipment.slot.size .. " " or "") .. ad.equipment:GetName()
+
 				local buy_message = string.interp(l.HAS_BEEN_FITTED_TO_YOUR_SHIP, {
-					equipment = ad.equipment:GetName()
+					equipment = equipmentName
 				})
 
 				form:SetMessage(buy_message)
@@ -153,8 +157,11 @@ local makeAdvert = function (station)
 		station = station,
     }
 
+	-- TEMP: clarify the size of items offered for secondhand purchase
+	local equipmentName = (equipment.slot and "S" .. equipment.slot.size .. " " or "") .. equipment:GetName()
+
     ad.desc = string.interp(flavours[ad.flavour].adtext, {
-		equipment = equipment:GetName(),
+		equipment = equipmentName,
     })
     local ref = station:AddAdvert({
 		title       = flavours[ad.flavour].adtitle,

--- a/data/pigui/libs/chat-form.lua
+++ b/data/pigui/libs/chat-form.lua
@@ -142,24 +142,22 @@ function ChatForm:Clear ()
 	self.market = nil
 end
 
-local tradeFuncKeys = { "canTrade", "getStock", "getBuyPrice", "getSellPrice", "onClickBuy", "onClickSell", "canDisplayItem", "bought", "sold"}
+local tradeFuncKeys = { "canTrade", "getDemand", "getStock", "getBuyPrice", "getSellPrice", "onClickBuy", "onClickSell", "canDisplayItem", "bought", "sold"}
 function ChatForm:AddGoodsTrader (funcs)
 	self.equipWidgetConfig = {
 		stationColumns = { "icon", "name", "price", "stock" },
 		shipColumns = { "icon", "name", "amount" },
 	}
 
-	self.market = CommodityWidget.New("chatTrader", false)
-	for i = 1,#tradeFuncKeys do
-		local key = tradeFuncKeys[i]
-		local fn = funcs[key]
-		if fn then
-			self.market.funcs[key] = function (s, e)
-				return fn(self.ref, e, s)
-			end
+	local config = {}
+
+	for _, key in ipairs(tradeFuncKeys) do
+		if funcs[key] then
+			config[key] = funcs[key]
 		end
 	end
 
+	self.market = CommodityWidget.New("chatTrader", false, config)
 	self.resizeFunc()
 	self.market:Refresh()
 end

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -144,7 +144,7 @@ function CommodityMarketWidget.New(id, title, config)
         return self.station:GetCommodityStock(commodity)
     end
 
-	config.getDemand = function (self, commodity)
+	config.getDemand = config.getDemand or function (self, commodity)
 		return self.station:GetCommodityDemand(commodity)
 	end
 
@@ -257,7 +257,7 @@ function CommodityMarketWidget:ChangeTradeAmount(delta)
 	else
 		price = self.funcs.getSellPrice(self, self.selectedItem)
 		stock = self.cargoMgr:CountCommodity(self.selectedItem)
-		demand = self.station:GetCommodityDemand(self.selectedItem)
+		demand = self.funcs.getDemand(self, self.selectedItem)
 	end
 
 	--we cant trade more units than we have in stock

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -160,12 +160,15 @@ function CommodityMarketWidget.New(id, title, config)
 		return price * (1.0 - math.sign(price) * Economy.TradeFeeSplit * 0.01)
     end
 
-	config.bought = function (self, commodity, tradeamount)
+	config.onClickBuy = config.onClickBuy or function(self, commodity) return true end
+	config.onClickSell = config.onClickSell or function(self, commodity) return true end
+
+	config.bought = config.bought or function (self, commodity, tradeamount)
 		local count = tradeamount or 1
         self.station:AddCommodityStock(commodity, -count)
     end
 
-    config.sold = function (self, commodity, tradeamount)
+    config.sold = config.sold or function (self, commodity, tradeamount)
 		local count = tradeamount or 1
         self.station:AddCommodityStock(commodity, count)
     end
@@ -209,6 +212,8 @@ function CommodityMarketWidget.New(id, title, config)
 	self.funcs.getDemand = config.getDemand
 	self.funcs.getBuyPrice = config.getBuyPrice
 	self.funcs.getSellPrice = config.getSellPrice
+	self.funcs.onClickBuy = config.onClickBuy
+	self.funcs.onClickSell = config.onClickSell
 	self.funcs.bought = config.bought
 	self.funcs.sold = config.sold
 
@@ -334,6 +339,11 @@ function CommodityMarketWidget:DoBuy()
 		return
 	end
 
+	-- user validation code
+	if not self.funcs.onClickBuy(self, self.selectedItem) then
+		return
+	end
+
 	--all checks passed
 	assert(self.cargoMgr:AddCommodity(self.selectedItem, self.tradeAmount))
 	Game.player:AddMoney(-orderAmount) --grab the money
@@ -352,6 +362,11 @@ function CommodityMarketWidget:DoSell()
 	local price = self.funcs.getSellPrice(self, self.selectedItem)
 	--if commodity price is negative (radioactives, garbage), player needs to have enough cash
 	local orderamount = price * self.tradeAmount
+
+	-- user validation code
+	if not self.funcs.onClickSell(self, self.selectedItem) then
+		return
+	end
 
 	assert(self.cargoMgr:RemoveCommodity(self.selectedItem, self.tradeAmount) == self.tradeAmount)
 	Game.player:AddMoney(orderamount) --grab the money

--- a/data/pigui/modules/saveloadgame.lua
+++ b/data/pigui/modules/saveloadgame.lua
@@ -510,7 +510,12 @@ function SaveLoadWindow:drawSaveList()
 				self:message("onFileSelected", f.name)
 
 				if ui.isMouseDoubleClicked(0) then
-					self:message("loadSelectedSave")
+
+					if self.mode == SaveLoadWindow.Modes.Load then
+						self:message("loadSelectedSave")
+					else
+						self:message("saveToFilePath")
+					end
 				end
 			end
 		end

--- a/data/pigui/modules/station-view/02-bulletinBoard.lua
+++ b/data/pigui/modules/station-view/02-bulletinBoard.lua
@@ -86,7 +86,7 @@ bulletinBoard = Table.New("BulletinBoardTable", false, {
 
 		local active = adActive(item.__ref, item)
 
-		local adTextColor = active and colors.font or colors.fontDim
+		local adTextColor = active and colors.font or colors.fontDisabled
 
 		ui.withFont(pionillium.title, function()
 			images[icon]:Draw(Vector2(ui.getTextLineHeight()))

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -119,12 +119,19 @@ local function refreshShipMarket()
 	widgetSizes.rowVerticalSpacing = Vector2(0, (widgetSizes.iconSize.y + widgetSizes.itemSpacing.y - pionillium.large.size)/2)
 
 	local station = Game.player:GetDockedWith()
-	shipMarket.items = station:GetShipsOnSale()
+	if station then
+		shipMarket.items = station:GetShipsOnSale()
+
+		advertDataCache = utils.map_table(shipMarket.items, function(_, sos)
+			return sos, makeAdvertDataCacheEntry(sos)
+		end)
+	else
+		shipMarket.items = {}
+		advertDataCache = {}
+	end
+
 	selectedItem = nil
 	shipMarket.selectedItem = nil
-	advertDataCache = utils.map_table(shipMarket.items, function(_, sos)
-		return sos, makeAdvertDataCacheEntry(sos)
-	end)
 end
 
 local function manufacturerIcon (manufacturer)
@@ -526,11 +533,17 @@ shipMarket = Table.New("shipMarketWidget", false, {
 		if(icons[item.def.shipClass] == nil) then
 			icons[item.def.shipClass] = PiImage.New("icons/shipclass/".. item.def.shipClass ..".png")
 		end
+
 		if not selectedItem then
 			selectedItem = item
 			shipMarket.selectedItem = item
 			refreshModelSpinner()
 		end
+
+		if not advertDataCache[item] then
+			advertDataCache[item] = makeAdvertDataCacheEntry(item)
+		end
+
 		icons[item.def.shipClass]:Draw(widgetSizes.iconSize)
 		ui.nextColumn()
 		ui.withStyleVars({ItemSpacing = vZero}, function()

--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -309,7 +309,15 @@ function SystemEconView:drawStationComparison(selected, current)
 		ui.withFont(pionillium.heading, function()
 			if current then
 				ui.text(current.name)
-				ui.sameLine(ui.getContentRegion().x - ui.calcTextSize(selected.name).x)
+				ui.sameLine()
+
+				local spacing = ui.getContentRegion().x - ui.calcTextSize(selected.name).x
+
+				if spacing < 0.0 then
+					ui.newLine()
+				else
+					ui.addCursorPos(Vector2(spacing, 0))
+				end
 			end
 
 			ui.text(selected.name)

--- a/data/pigui/modules/system-overview-window.lua
+++ b/data/pigui/modules/system-overview-window.lua
@@ -114,8 +114,10 @@ end
 
 -- Render a row for an entry in the system overview
 function SystemOverviewWidget:renderEntry(entry, indent)
-	local sbody = entry.systemBody
+	local sbody = entry.systemBody ---@type SystemBody
 	local label = entry.label or "UNKNOWN"
+	-- Handle the case where there is more than one body with the same name (e.g. New Hope in Epsilon Eridani)
+	local id = "##" .. label .. "#" .. sbody.path.bodyIndex
 
 	ui.dummy(Vector2(style.iconSize.x * indent / 2.0, style.iconSize.y))
 	ui.sameLine()
@@ -123,7 +125,7 @@ function SystemOverviewWidget:renderEntry(entry, indent)
 	ui.sameLine()
 
 	local pos = ui.getCursorPos()
-	if ui.selectable("##" .. label, entry.selected, {"SpanAllColumns"}, Vector2(0, style.iconSize.y)) then
+	if ui.selectable(id, entry.selected, {"SpanAllColumns"}, Vector2(0, style.iconSize.y)) then
 		self:onBodySelected(sbody, entry.body)
 	end
 	if ui.isItemHovered() and ui.isMouseDoubleClicked(0) then

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -190,6 +190,7 @@ theme.colors = {
 
 	font					= styleColors.gray_100,
 	fontDim					= styleColors.gray_400,
+	fontDisabled			= styleColors.gray_500,
 	fontDark				= styleColors.gray_600,
 
 	-- FIXME: this color is primarily used to tint buttons by rendering over top of the frame color.

--- a/src/ship/GunManager.cpp
+++ b/src/ship/GunManager.cpp
@@ -445,7 +445,7 @@ void GunManager::StaticUpdate(float deltaTime)
 		// Temperature, gimbal checks, etc.
 		bool canFire = gun.temperature < gun.data.overheatThreshold && (gs.fireWithoutTargeting || gs.target && gun.withinGimbalLimit);
 
-		if (gs.firing && currentTime >= gun.nextFireTime) {
+		if (gs.firing && canFire && currentTime >= gun.nextFireTime) {
 
 			// Determine how much time we missed since the gun was supposed to fire
 			double missedTime = currentTime - gun.nextFireTime;


### PR DESCRIPTION
Missing the mark of a "hotfix" by about a month, this branch accumulates a number of fixes for items reported on the issue tracker.

- Fixes #6049 (display explicit size of item in addition to name).
- Fixes #6038.
- Fixes #6077.
- Fixes #6101.
- Fixes an unreported issue where double-clicking a save slot while saving the game attempted to quickload rather than quicksave.
- Fixes an unreported issue where you couldn't click on the second body of the same name in a system outliner (e.g. New Hope, New Hope).
- Fixes #6091.
- Mitigates #6099 by allowing ship follow modes to be disengaged even when out-of-range of the target.
- Fixes #5966.
- Fixes #6057. This includes a hack to force the default/0-th weapon group to disable the only-fire-with-target behavior, so as to match existing behavior from before this update.
- Fixes #6065 by increasing police budgets slightly.
- Fixes #6075.

This patch includes a minor overhaul of FuelClub and GoodsTrader to fix a significant amount of bitrot. I've also made a gameplay change to GoodsTrader: demand numbers are inherited from the station's commodity stock/demand for legit GoodsTraders, but observant eyes will notice that police sting operations have stock/demand numbers that sum to 50.

This is partially to preserve compatibility with existing save files, but also provides canny players a clue as to which trader is actually legit. This also means that GoodsTraders can run out of demand the same way they can run out of stock.

FuelClub also only accepts the sale of Radioactives up to the amount of military fuel the player has purchased.