### PR TITLE
Fix pressure limit value if no atmo shield is installed

### DIFF
--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -41,7 +41,7 @@ local function shipStats()
 	local up_acc = player:GetAcceleration("up")
 
 	local atmo_shield = equipSet:GetInstalledOfType("hull.atmo_shield")[1]
-	local atmo_shield_cap = player["atmo_shield_cap"] or 1
+	local atmo_shield_cap = math.max(player["atmo_shield_cap"], 1)
 
 	textTable.draw({
 		{ l.REGISTRATION_NUMBER..":",	shipLabel},


### PR DESCRIPTION
The ship info screen shows always 0 atm if no atmospheric shield is installed.