### PR TITLE
Fix interrupted SAR missions, draggable popups in worldview

### DIFF
--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1499,6 +1499,8 @@ local pickupCrew = function (mission)
 
 		-- if all necessary crew transferred print result message
 		mission.pickup_crew = mission.pickup_crew - 1
+		mission.pickup_crew_check = nil -- clear PARTIAL flag if present
+
 		local done = mission.pickup_crew_orig - mission.pickup_crew
 		if todo == done then
 			local resulttxt = string.interp(l.RESULT_PICKUP_CREW, {todo = todo, done = done})
@@ -1538,6 +1540,8 @@ local pickupPassenger = function (mission)
 
 		-- if all necessary passengers have been picked up show result message
 		mission.pickup_pass = mission.pickup_pass - 1
+		mission.pickup_pass_check = nil -- clear PARTIAL flag if present
+
 		local done = mission.pickup_pass_orig - mission.pickup_pass
 		if todo == done then
 			local resulttxt = string.interp(l.RESULT_PICKUP_PASS, {todo = todo, done = done})
@@ -1576,6 +1580,8 @@ local pickupCommodity = function (mission, commodity)
 
 		-- show result message if done picking up this commodity
 		mission.pickup_comm[commodity] = mission.pickup_comm[commodity] - 1
+		mission.pickup_comm_check[commodity] = nil -- clear PARTIAL flag if present
+
 		local done = mission.pickup_comm_orig[commodity] - mission.pickup_comm[commodity]
 		if todo == done then
 			local resulttxt = string.interp(l.RESULT_PICKUP_COMM, {cargotype = commodity_name, todo = todo, done = done})
@@ -1612,6 +1618,8 @@ local deliverCrew = function (mission)
 
 		-- if all necessary crew transferred print result message
 		mission.deliver_crew = mission.deliver_crew - 1
+		mission.deliver_crew_check = nil -- clear PARTIAL flag if present
+
 		local done = mission.deliver_crew_orig - mission.deliver_crew
 		if todo == done then
 			local resulttxt = string.interp(l.RESULT_DELIVERY_CREW, {todo = todo, done = done})
@@ -1646,6 +1654,8 @@ local deliverPassenger = function (mission)
 
 		-- if all necessary passengers have been transferred show result message
 		mission.deliver_pass = mission.deliver_pass - 1
+		mission.deliver_pass_check = nil -- clear PARTIAL flag if present
+
 		local done = mission.deliver_pass_orig - mission.deliver_pass
 		if todo == done then
 			local resulttxt = string.interp(l.RESULT_DELIVERY_PASS, {todo = todo, done = done})
@@ -1687,6 +1697,8 @@ local deliverCommodity = function (mission, commodity)
 
 		-- show result message if done delivering this commodity
 		mission.deliver_comm[commodity] = mission.deliver_comm[commodity] - 1
+		mission.deliver_comm_check[commodity] = nil -- clear PARTIAL flag if present
+
 		local done = mission.deliver_comm_orig[commodity] - mission.deliver_comm[commodity]
 		if todo == done then
 			local resulttxt = string.interp(l.RESULT_DELIVERY_COMM, {done = done, todo = todo, cargotype = commodity_name})
@@ -1904,6 +1916,8 @@ local onFrameChanged = function (body)
 	end
 end
 
+---@param ship Ship
+---@param station SpaceStation?
 local onShipUndocked = function (ship, station)
 	-- Start search immediately if the target is on the same planet as the station.
 	if not ship:IsPlayer() then return end
@@ -2212,6 +2226,7 @@ Event.Register("onGameStart", onGameStart)
 Event.Register("onGameEnd", onGameEnd)
 Event.Register("onReputationChanged", onReputationChanged)
 Event.Register("onShipUndocked", onShipUndocked)
+Event.Register("onShipTakeoff", onShipUndocked)
 Event.Register("onFrameChanged", onFrameChanged)
 Event.Register("onShipDestroyed", onShipDestroyed)
 

--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -204,8 +204,14 @@ end
 --
 --   nil
 --
-function ui.popup(name, fun)
-	if pigui.BeginPopup(name) then
+---@overload fun(name: string, flags: any, fun: fun())
+---@overload fun(name: string, fun: fun())
+function ui.popup(name, flags, fun)
+	if not fun then
+		fun, flags = flags, nil
+	end
+
+	if pigui.BeginPopup(name, flags) then
 		fun()
 		pigui.EndPopup()
 	end

--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -162,7 +162,7 @@ local function displayOnScreenObjects()
 			end
 		end
 		-- popup content
-		ui.popup("navtarget" .. mainBody:GetLabel(), function()
+		ui.popup("navtarget" .. mainBody:GetLabel(), {"NoMove"}, function()
 			for _,b in pairs(group.bodies) do
 				ui.icon(getBodyIcon(b, true), small_iconsize, colors.frame)
 				ui.sameLine()

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -1935,7 +1935,8 @@ static int l_pigui_begin_popup(lua_State *l)
 {
 	PROFILE_SCOPED()
 	std::string id = LuaPull<std::string>(l, 1);
-	LuaPush<bool>(l, ImGui::BeginPopup(id.c_str()));
+	ImGuiWindowFlags flags = LuaPull<ImGuiWindowFlags_>(l, 2, ImGuiWindowFlags_None);
+	LuaPush<bool>(l, ImGui::BeginPopup(id.c_str(), flags));
 	return 1;
 }
 


### PR DESCRIPTION
Fixes #6041 by making all interactions properly clear the `PARTIAL` state flag after a successful transfer and triggering the start of a new interaction when the player takes off from the surface of a planet as well as undocking from a starport.

Fixes #6119 - it can be argued whether draggable popups (the ImGUI default) are actually a "bug" but at least the behavior is consistent with "user expectations" now.