### PR TITLE
Explore system on game start

### DIFF
--- a/data/modules/System/Explore.lua
+++ b/data/modules/System/Explore.lua
@@ -46,4 +46,11 @@ local onEnterSystem = function (player)
 	end
 end
 
+local onGameStart = function ()
+    if not Game.system.explored then
+        exploreSystem(Game.system)
+    end
+end
+
 Event.Register("onEnterSystem", onEnterSystem)
+Event.Register("onGameStart", onGameStart)


### PR DESCRIPTION
If you enter an unexplored system, your handy ship computer will go into exploration mode and try and map out what bodies are in the system. This doesn't work if you start a new game in an unexplored system (https://github.com/pioneerspacesim/pioneer/issues/5672).

There are options to give a path to a system when launching Pioneer from the command line but this always crash for me.
You can test the fix by patching the start menu with the path to an unexplored system where mars used to be.
 
```
diff --git a/data/pigui/modules/new-game-window/class.lua b/data/pigui/modules/new-game-window/class.lua
index 8314e82f0..5ea2e5f14 100644
--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -26,7 +26,7 @@ local profileCombo = { items = {}, selected = 0 }
 StartVariants.register({
     name       = lui.START_AT_MARS,
     desc       = lui.START_AT_MARS_DESC,
-    location   = SystemPath.New(0,0,0,0,18),
+    location   = SystemPath.New(100,100,0,0,0),
     logmsg     = lui.START_LOG_ENTRY_1,
     shipType   = 'coronatrix',
     money      = 600,
```

Fixes https://github.com/pioneerspacesim/pioneer/issues/5672