### PR TITLE
Added long description to the sector map

### DIFF
--- a/CppProperties.json
+++ b/CppProperties.json
@@ -1,0 +1,15 @@
+{
+  "configurations": [
+    {
+      "inheritEnvironments": [
+        "mingw_64"
+      ],
+      "name": "Mingw64",
+      "includePath": [
+        "${env.INCLUDE}",
+        "${workspaceRoot}\\**"
+      ],
+      "intelliSenseMode": "linux-gcc-x64"
+    }
+  ]
+}

--- a/data/pigui/modules/system-econ-view.lua
+++ b/data/pigui/modules/system-econ-view.lua
@@ -346,6 +346,12 @@ for k, v in pairs(Commodities) do
 end
 table.sort(commodityOptions)
 
+function SystemEconView:displayLongDescription(selected) --get long description for star system
+	ui.withFont(pionillium.heading, function()
+		ui.textWrapped(selected.longDescription)
+	end)
+end
+
 function SystemEconView:drawPriceList(key, prices)
 	local iconSize = Vector2(ui.getTextLineHeight() + 4)
 	local out = nil

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -15,7 +15,7 @@ local Vector2 = _G.Vector2
 local Color = _G.Color
 
 local ui = require 'pigui'
-local layout = require 'pigui.libs.window-layout'
+local layout = require 'pigui.libs.window-layout' --important for project??
 
 local Serializer = require 'Serializer'
 
@@ -122,7 +122,8 @@ local Windows = {
 	systemInfo = layout.NewWindow("SectorMapSystemInfo"), -- selected system information
 	searchBar = layout.NewWindow("SectorMapSearchBar"),
 	edgeButtons = layout.NewWindow("SectorMapEdgeButtons"),
-	factions = layout.NewWindow("SectorMapFactions")
+	factions = layout.NewWindow("SectorMapFactions"),
+	longDescription = layout.NewWindow("SectorLongDescription") -- creates new window for long description --Added by Zack Whalen
 }
 
 local statusIcons = {
@@ -409,6 +410,12 @@ function Windows.current.Show()
 	end
 end
 
+function Windows.longDescription.Show() --window for long description
+	ui.text("Description")
+	local selectedPath = sectorView:GetSelectedSystemPath()
+	systemEconView:displayLongDescription(selectedPath:GetStarSystem())
+end 
+
 function Windows.factions.Show()
 	textIcon(icons.shield)
 	ui.text("Factions")
@@ -453,6 +460,9 @@ function sectorViewLayout:onUpdateWindowConstraints(w)
 
 	w.factions.pos = Vector2(w.hjPlanner.pos.x, edgePadding.y)
 	w.factions.size = Vector2(rightColWidth, 0.0) -- adaptive height
+
+	w.longDescription.pos = Vector2(18, 200) ---long description position
+	w.longDescription.size = Vector2(rightColWidth, 0.0) --long description size
 end
 
 ui.registerModule("game", { id = 'map-sector-view', draw = function()


### PR DESCRIPTION
Created a new window for the long description to be seen on the middle left-side of the sector map. The window needs to have a maximum height implemented to prevent the text from covering the date information in the lower right side of the screen. 

![pioneer_sector_map](https://github.com/user-attachments/assets/dc39b2d3-67db-44ec-93c9-5c6f5372aaf9)



