### PR TITLE
Prevent invoking SDL_PauseAudioDevice when it's already paused

### DIFF
--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -690,6 +690,10 @@ namespace Sound {
 
 	void Pause(int on)
 	{
+		if (bool(on) == (SDL_AUDIO_PAUSED == SDL_GetAudioDeviceStatus(m_audioDevice)))
+		{
+			return;
+		}
 		SDL_PauseAudioDevice(m_audioDevice, on);
 	}
 


### PR DESCRIPTION
This fixes #6155

The way the Sound menu is implemented is that it will continuously hammer the `Sound::Pause` function, which apparently causes audio artifacts on my system. Why the Flatpak is not affected is not clear to me, one possibility is that the underlying SDL version is different.

This patch makes sure that the `SDL_PauseAudioDevice` is only called when it would actually modify the pause state.