### PR TITLE
fix: select star for hyperspace target

### DIFF
--- a/src/SectorView.cpp
+++ b/src/SectorView.cpp
@@ -283,11 +283,10 @@ void SectorView::DrawPiGui()
 
 void SectorView::SetHyperspaceTarget(const SystemPath &path)
 {
-	if (m_hyperspaceTarget.IsSameSystem(path)) {
-		return;
+	if (m_hyperspaceTarget != path) {
+		m_hyperspaceTarget = path;
+		onHyperspaceTargetChanged.emit();
 	}
-	m_hyperspaceTarget = path;
-	onHyperspaceTargetChanged.emit();
 }
 
 void SectorView::ResetHyperspaceTarget()


### PR DESCRIPTION
Fixes #6142

When setting the hyperspace target, a check is in place which skips updating the target if it is in the same system as the current target.

This prevents changing the destination star in a multi-star system for the next jump. No such check exists when editing a jump further along a route.

The fix is to modify the check and only skip the update if the new hyperspace target is identical to the current target and not just whether they are in the same system.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

**TEST:**

1. Download the save-game attached to the bug.
2. Load the save-game
3. Enter sector map
4. Click on "Dequ B" in the "Route Jumps" list
5. In the system information panel, click on "Dequ A"
6. In the system information panel, click on "Dequ B"
7. Initiate Hyperjump
8. Arrive in the vicinity of Dequ B

If the same sequence is performed on the unpatched game, at Step 8 we arrive at Dequ A instead.

Unfortunately when loading the savegame, the destination is not automatically fixed. But for all future routes it should work as expected now.