### PR TITLE
Fix: SecondHand equipment market : add clearer error messages (#6130)

### DIFF
--- a/data/lang/module-secondhand/en.json
+++ b/data/lang/module-secondhand/en.json
@@ -3,6 +3,22 @@
     "description": "Buy a piece of ship equipment",
     "message": "Buy"
   },
+  "EQUIPMENT_NO_COMPATIBLE_SLOT": {
+    "description": "Message given when the second-hand equipment is not compatible with the ship slots.",
+    "message": "This equipment item is not compatible with your ship."
+  },
+  "EQUIPMENT_NO_FREE_SLOT": {
+    "description": "Message shown by second-hand market if the ship does not have a free slot for the equipment.",
+    "message": "Your ship does not have a free slot for this equipment item."
+  },
+  "EQUIPMENT_NO_SPACE": {
+    "description": "Message shown by second-hand market if the equipment requires a free slot or free capacity to fit",
+    "message": "Your ship does not have enough free space for this equipment item."
+  },
+  "EQUIPMENT_SLOT_NO_SPACE":{
+    "description": "Message given when the ship has a compatible slot, but not enough space left to fit the equipment item.",
+    "message": "Your ship has a compatible slot, but not enough space to install this equipment item."
+  },
   "FITTING_IS_INCLUDED_IN_THE_PRICE": {
     "description": "Regarding installing a component on the ship",
     "message": "Fitting is included in the price."
@@ -98,6 +114,22 @@
   "NO_LONGER_AVAILABLE_2": {
     "description": "If the sentence is hard to translate, just make up an excuse why the item is no longer available.",
     "message": "I've changed my mind, it's not for sale anymore."
+  },
+  "NOT_ENOUGH_MONEY_0": {
+    "description": "When the player doesn't have enough money to afford the item.",
+    "message": "You don't have enough money to afford this."
+  },
+  "NOT_ENOUGH_MONEY_1": {
+    "description": "When the player doesn't have enough money to afford the item.",
+    "message": "Come back when you have enough money."
+  },
+  "NOT_ENOUGH_MONEY_2": {
+    "description": "When the player doesn't have enough money to afford the item.",
+    "message": "I'm not a charity, come back when you can afford this."
+  },
+  "NOT_ENOUGH_MONEY_3": {
+    "description": "When the player doesn't have enough money to afford the item.",
+    "message": "It may be used, but the price is not negotiable."
   },
   "REPEAT_OFFER": {
     "description": "",

--- a/data/libs/EquipSet.lua
+++ b/data/libs/EquipSet.lua
@@ -270,6 +270,40 @@ function EquipSet:GetAllSlotsOfType(type, hardpoint)
 	return t
 end
 
+-- Method: HasCompatibleSlotForEquipment
+--
+-- Return true if the ship has at least one slot which is compatible with the
+-- equipment item regardless of whether the ship currently has the space to
+-- fit the equipemnt.
+--
+-- Parameters:
+--
+--  equip - EquipType, the equipment item instance to attempt to slot.
+--
+-- Returns:
+--
+--  True if the ship has at least one slot compatible with the equipment,
+--          otherwise false.
+--
+---@param equip EquipType
+---@return boolean
+function EquipSet:HasCompatibleSlotForEquipment(equip)
+	if not equip.slot then return false end
+
+	local isCompatible = function(equip, slot)
+		return slot.hardpoint == equip.slot.hardpoint
+			and self.CompatibleWithSlot(equip, slot)
+	end
+
+	for _, slot in pairs(self.slotCache) do
+		if isCompatible(equip, slot) then
+			return true
+		end
+	end
+
+	return false
+end
+
 -- Method: GetInstalledWithFilter
 --
 -- Return a list of all installed equipment of the given EquipType class matching the filter function


### PR DESCRIPTION
Fixes #6130 

Introduce additional error messages which detail why the equipment can not be installed in the ship. The second-hand equipment market now distinguishes between the ship not having a compatible equipment slot, not having a free slot, and not having enough free space.
    
It now also disables ads which the player cannot purchase as well as giving the reason when the player clicks on a disabled ad. Previously the player had to interact with the seller and click on buy before the error was shown.

### **Reviewer Notes**

The first commit fixes the spacing in the `SecondHand.lua` file, the actual changes are in the second commit.

### **Testing**

Use the attached save file (not a zip, just renamed to enable uploading).

[6130 - BBS Secondhand Equipment Market test - Big Ship.zip](https://github.com/user-attachments/files/20737750/6130.-.BBS.Secondhand.Equipment.Market.test.-.Big.Ship.zip)

The BBS has the following equipment for sale:
- Atmospheric Shielding (S4) - incompatible slot equipment
  - can be used to test the "no compatible slot" scenario
- Extra Passenger Cabin (S3) - compatible slot equipment
  - can be used to test various scenarios
- Reinforced Structure (S5) - compatible slot equipment
  - can be used to test various scenarios

The ship is a Malabar and has almost been filled with equipment. 
- There is a 20.4m³ free
- A S3 Passenger cabin slot is free
- A S5 Reinforced Structure slot is free

The player has enough money to purchase the S3 Cabin.

#### Test scenarios:

- [x] Not enough money
- [ ] Not enough space (non-slot equipment)
- [x] Not enough space (slot equipment)
- [x] No compatible slot (slot equipment)
- [x] No free slot (slot equipment)
- [x] Can buy (slot equipment)
- [ ] Can buy (non-slot equipment)

### **Out-of-scope notes**

Some equipment does not reduce the available volume. For example, Missiles. This makes sense as the missile rack presumably takes the space.

For other equipment it doesn't seem to make sense, for example, passenger cabins. If the ship already pre-reserves the space for passenger cabins, then what is actually being installed, just the interior fit-out? In which case an "empty" passenger cabin slot _could_ potentially be used for cargo instead.

Yet other equipment requires additional space even though logically there shouldn't be space in the hull for it - such as Weapons and Thrusters. Unless the idea is that the additional space is used up by supporting equipment which is not necessarily colocated within the actual hull slots for these equipment items.
