### PR TITLE
feat(audio): mute on pause

### DIFF
--- a/data/pigui/views/game.lua
+++ b/data/pigui/views/game.lua
@@ -24,6 +24,8 @@ local reticuleCircleRadius = math.min(ui.screenWidth, ui.screenHeight) / 8
 local reticuleCircleThickness = 2.0
 
 local lastTimeAcceleration
+-- Keep track of whether sound was muted before opening the pause menu
+local lastMasterVolumeMuted
 
 -- for modules
 ui.reticuleCircleRadius = reticuleCircleRadius
@@ -275,6 +277,19 @@ end)
 Event.Register("onPauseMenuClosed", function()
 	Game.SetTimeAcceleration((lastTimeAcceleration == "paused") and "1x" or lastTimeAcceleration)
 	Input.EnableBindings()
+end)
+
+Event.Register("onGamePaused", function()
+	lastMasterVolumeMuted = Engine.GetMasterMuted()
+	if not lastMasterVolumeMuted then
+		Engine.SetMasterMuted(true)
+	end
+end)
+
+Event.Register("onGameResumed", function()
+	if not lastMasterVolumeMuted then
+		Engine.SetMasterMuted(false)
+	end
 end)
 
 ui.registerHandler('game', function(delta_t)


### PR DESCRIPTION
Mute all audio when the game is paused, either by opening the settings window, or by clicking on the Pause icon, and resume when the game is resumed.

NOTE: This PR conflicts directly with #5644 ; so as it appears this is very much personal preference, it may be necessary to add a settings toggle which would make this a slightly less trivial PR.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

