### PR TITLE
Feat/UI system view work

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -1603,6 +1603,10 @@
     "description": "",
     "message": "Surface gravity"
   },
+  "SURFACE_PRESSURE": {
+    "description": "",
+    "message": "Surface pressure"
+  },
   "SURFACE_TEMPERATURE": {
     "description": "",
     "message": "Surface temperature"
@@ -1850,6 +1854,18 @@
   "UNIT_SQUARE_METERS": {
     "description": "Area unit: square meter (m²)",
     "message": "m²"
+  },
+  "UNIT_TEMPERATURE_CELSIUS": {
+    "description": "Temperature unit: degrees Celsius (°C)",
+    "message": "°C"
+  },
+  "UNIT_TEMPERATURE_FAHRENHEIT": {
+    "description": "Temperature unit: Fahrenheit (F)",
+    "message": "F"
+  },
+  "UNIT_TEMPERATURE_KELVIN": {
+    "description": "Temperature unit: degrees Kelvin (°K)",
+    "message": "°K"
   },
   "UNIT_TERATONNES": {
     "description": "Mass unit: one teratonne",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2623,6 +2623,10 @@
     "description": "Label indicating the ability to transfer fuel between equipment tanks",
     "message": "Transfer Fuel"
   },
+  "TRANSLATE_VIEW": {
+    "description": "Indicates that the button must be kept pressed down, to translate the camera view with mouse",
+    "message": "Hold down to Translate view"
+  },
   "TRUSTWORTHY": {
     "description": "For player reputation",
     "message": "Trustworthy"

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -286,8 +286,12 @@ ui.Format = {
 			return string.format(fmt, mass / 1e18), lc.UNIT_PETATONNES
 		elseif m < EARTH_MASS * 1e3 then
 			return oldFmt(lc.N_EARTH_MASSES, { mass = mass / EARTH_MASS }), ""
+			-- fmt = "%0." .. (digits or 3) .. "f"
+			--return string.format(fmt, mass / EARTH_MASS), "EM" -- Should be: "M🜨"
 		end
 		return oldFmt(lc.N_SOLAR_MASSES, { mass = mass / SOL_MASS }), ""
+		-- fmt = "%0." .. (digits or 3) .. "f"
+		--return string.format(fmt, mass / SOL_MASS), "SM" -- Should be : "M☉"
 	end,
 	Mass = function(mass, digits)
 		local m, u = ui.Format.MassUnit(mass, digits)
@@ -303,7 +307,7 @@ ui.Format = {
 		return string.format("%0.2f", grav) .. " " .. lc.UNIT_EARTH_GRAVITY
 	end,
 	Pressure = function(pres)
-		return string.format("%0.2f", pres) .. lc.UNIT_PRESSURE_ATMOSPHERES
+		return string.format("%0.2f ", pres) .. lc.UNIT_PRESSURE_ATMOSPHERES
 	end,
 	TemperatureCelsius = function(tempInKelvin)
 		return string.format("%0.2f", tempInKelvin - 273.15) .. lc.UNIT_TEMPERATURE_CELSIUS

--- a/data/pigui/libs/text.lua
+++ b/data/pigui/libs/text.lua
@@ -305,6 +305,19 @@ ui.Format = {
 	Pressure = function(pres)
 		return string.format("%0.2f", pres) .. lc.UNIT_PRESSURE_ATMOSPHERES
 	end,
+	TemperatureCelsius = function(tempInKelvin)
+		return string.format("%0.2f", tempInKelvin - 273.15) .. lc.UNIT_TEMPERATURE_CELSIUS
+	end,
+	TemperatureFahrenheit = function(tempInKelvin)
+		return string.format("%0.2f", (tempInKelvin - 273.15) * 9/5 + 32) .. lc.UNIT_TEMPERATURE_FAHRENHEIT
+	end,
+	TemperatureKelvin = function(tempInKelvin)
+		return string.format("%0.2f ", tempInKelvin) .. lc.UNIT_TEMPERATURE_KELVIN
+	end,
+	Temperature = function(tempInKelvin)
+		-- TODO: use user preference
+		return ui.Format.TemperatureCelsius(tempInKelvin)
+	end,
 	-- produce number..denominator format
 	NumberAbbv = function(number, places)
 		local s = number < 0.0 and "-" or ""

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -16,6 +16,8 @@ local luc = Lang.GetResource("ui-core")
 local layout = require 'pigui.libs.window-layout'
 local Sidebar = require 'pigui.libs.sidebar'
 
+local systemEconView = require 'pigui.modules.system-econ-view'.New()
+
 local player = nil
 local colors = ui.theme.colors
 local icons = ui.theme.icons
@@ -109,6 +111,37 @@ local onEnterSystem = function (ship)
 	end
 end
 
+-- all windows in this view
+local Windows = {
+	systemName = layout.NewWindow("SystemMapSystemName"),
+	edgeButtons = layout.NewWindow("SystemMapEdgeButtons"),
+	timeButtons = layout.NewWindow("SystemMapTimeButtons"),
+	unexplored = layout.NewWindow("SystemMapUnexplored")
+}
+
+Windows.systemName.style_colors["WindowBg"] = colors.transparent
+
+local systemViewLayout = layout.New(Windows)
+systemViewLayout.mainFont = winfont
+
+local leftSidebar = Sidebar.New("##SystemMapLeft", "left")
+local rightSidebar = Sidebar.New("##SystemMapRight", "right")
+
+local systemOverviewWidget = require 'pigui.modules.system-overview-window'.New()
+systemOverviewWidget.visible = true
+
+function systemOverviewWidget:onBodySelected(sBody)
+	systemView:SetSelectedObject(Projectable.OBJECT, Projectable.SYSTEMBODY, sBody)
+end
+
+function systemOverviewWidget:onBodyDoubleClicked(sBody)
+	systemView:ViewSelectedObject()
+end
+
+--
+-- Helper functions
+--
+
 local function textIcon(icon, tooltip)
 	ui.icon(icon, Vector2(ui.getTextLineHeight()), svColor.FONT, tooltip)
 	ui.sameLine()
@@ -161,37 +194,164 @@ local function timeButton(icon, tooltip, factor)
 	return active
 end
 
--- all windows in this view
-local Windows = {
-	systemName = layout.NewWindow("SystemMapSystemName"),
-	objectInfo = layout.NewWindow("SystemMapObjectInfo"),
-	edgeButtons = layout.NewWindow("SystemMapEdgeButtons"),
-	orbitPlanner = layout.NewWindow("SystemMapOrbitPlanner"),
-	timeButtons = layout.NewWindow("SystemMapTimeButtons"),
-	unexplored = layout.NewWindow("SystemMapUnexplored")
+-- cache some data to reduce per-frame overheads
+local data_cache = {
+	body = {},
+	prev_body = nil
 }
+-- populate a data structure with information about the currently selected body
+local function getObjectData(obj)
+	local isSystemBody = obj.base == Projectable.SYSTEMBODY
+	local body = obj.ref
 
-Windows.systemName.style_colors["WindowBg"] = colors.transparent
+	local data = {}
 
-local systemViewLayout = layout.New(Windows)
-systemViewLayout.mainFont = winfont
+	--SystemBody data is static so we use cache
+	--Ship data migh be dynamic in the future
+	if isSystemBody and data_cache.prev_body == body then
+		data = data_cache.body
+	else
+		data_cache.prev_body = body
 
-local leftSidebar = Sidebar.New("##SidebarL", "left")
+		if isSystemBody then -- system body
+			local parent = body.parent
+			local starport = body.superType == "STARPORT"
+			local surface = body.type == "STARPORT_SURFACE"
+			local sma = body.semiMajorAxis
+			local semimajoraxis = nil
+			if sma and sma > 0 then
+				semimajoraxis = ui.Format.Distance(sma)
+			end
+			local rp = body.rotationPeriod * 24 * 60 * 60
+			local op = body.orbitPeriod * 24 * 60 * 60
+			local pop = math.round(body.population * 1e9)
+			local techLevel = starport and SpaceStation.GetTechLevel(body) or nil
+			if techLevel == 11 then
+				techLevel = luc.MILITARY
+			end
+			data = {
+				{ name = lc.MASS, icon = icons.body_radius,
+					value = (not starport) and ui.Format.Mass(body.mass) or nil },
+				{ name = lc.RADIUS, icon = icons.body_radius,
+					value = (not starport) and ui.Format.Distance(body.radius) or nil },
+				{ name = lc.SURFACE_TEMPERATURE, icon = icons.temperature,
+					value = (not starport) and ui.Format.Temperature(body.averageTemp) or nil },
+				{ name = lc.SURFACE_PRESSURE, icon = icons.pressure,
+					value = (not starport) and ui.Format.Pressure(body.surfacePressure) or nil },
+				{ name = lc.SURFACE_GRAVITY, icon = icons.body_radius,
+					value = (not starport) and ui.Format.Speed(body.gravity, true).."²"..
+												" ("..ui.Format.Gravity(body.gravity / 9.80665)..")" or nil },
+				{ name = lc.ESCAPE_VELOCITY, icon = icons.body_radius,
+					value = (not starport) and ui.Format.Speed(body.escapeVelocity , true) or nil },
+				{ name = lc.MEAN_DENSITY, icon = icons.body_radius,
+					value = (not starport) and ui.Format.Number(body.meanDensity, 0).." "..lc.UNIT_DENSITY or nil },
+				{ name = lc.ORBITAL_PERIOD, icon = icons.body_orbit_period,
+					value = op and op > 0 and ui.Format.Duration(op, 2) or nil },
+				{ name = lc.DAY_LENGTH, icon = icons.body_day_length,
+					value = rp > 0 and ui.Format.Duration(rp, 2) or nil },
+				{ name = luc.ORBIT_APOAPSIS, icon = icons.body_semi_major_axis,
+					value = (parent and not surface) and ui.Format.Distance(body.apoapsis) or nil },
+				{ name = luc.ORBIT_PERIAPSIS, icon = icons.body_semi_major_axis,
+					value = (parent and not surface) and ui.Format.Distance(body.periapsis) or nil },
+				{ name = lc.SEMI_MAJOR_AXIS, icon = icons.body_semi_major_axis,
+					value = semimajoraxis },
+				{ name = lc.ECCENTRICITY, icon = icons.body_semi_major_axis,
+					value = (parent and not surface) and string.format("%0.2f", body.eccentricity) or nil },
+				{ name = lc.AXIAL_TILT, icon = icons.body_semi_major_axis,
+					value = (not starport) and string.format("%0.2f", body.axialTilt) or nil },
+				{ name = lc.POPULATION, icon = icons.personal,
+					value = pop > 0 and ui.Format.NumberAbbv(pop) or nil },
+				{ name = luc.TECH_LEVEL, icon = icons.equipment,
+					value = starport and techLevel or nil }
+			}
 
-local systemOverviewWidget = require 'pigui.modules.system-overview-window'.New()
-systemOverviewWidget.visible = true
+			--change the internal cached data only when new is fully built
+			--prevents additional flickering
+			data_cache.body = data
 
-function systemOverviewWidget:onBodySelected(sBody)
-	systemView:SetSelectedObject(Projectable.OBJECT, Projectable.SYSTEMBODY, sBody)
+		elseif obj.ref:IsShip() then -- physical body
+			---@cast body Ship
+			-- TODO: the advanced target scanner should add additional data here,
+			-- but we really do not want to hardcode that here. there should be
+			-- some kind of hook that the target scanner can hook into to display
+			-- more info here.
+			-- This is what should be inserted:
+			table.insert(data, { name = luc.SHIP_TYPE, value = body:GetShipType() })
+			if (player["target_scanner_level_cap"] or 0) > 0 then
+				local hd = body:GetInstalledHyperdrive()
+				table.insert(data, { name = luc.HYPERDRIVE, value = hd and hd:GetName() or lc.NO_HYPERDRIVE })
+				table.insert(data, { name = luc.MASS, value = Format.MassTonnes(body.staticMass) })
+				table.insert(data, { name = luc.CARGO, value = Format.MassTonnes(body.usedCargo) })
+			end
+		else
+			data = {}
+		end
+	end
+	return data
 end
 
-function systemOverviewWidget:onBodyDoubleClicked(sBody)
-	systemView:ViewSelectedObject()
+-- render a two-column dataset
+local function tabular(data, maxSize)
+	if data and #data > 0 then
+		ui.columns(2, "Attributes", false)
+		local nameWidth = 0
+		local valueWidth = 0
+
+		for _,item in pairs(data) do
+			if item.value then
+				local nWidth = ui.calcTextSize(item.name).x + ui.getItemSpacing().x
+				local vWidth = ui.calcTextSize(item.value).x + ui.getItemSpacing().x
+				if ui.getColumnWidth() < nWidth then
+					textIcon(item.icon or icons.info, item.name)
+				else
+					ui.text(item.name)
+				end
+				ui.nextColumn()
+				ui.text(item.value)
+				ui.nextColumn()
+
+				nameWidth = math.max(nameWidth, nWidth)
+				valueWidth = math.max(valueWidth, vWidth)
+			end
+		end
+		if maxSize > 0 and nameWidth + valueWidth > maxSize then
+			-- first of all, we want to see the values, but the keys should not be too small either
+			nameWidth = math.max(maxSize - valueWidth, maxSize * 0.1)
+		end
+		ui.setColumnWidth(0, nameWidth)
+
+		-- reset columns
+		ui.columns(1)
+	end
 end
 
-table.insert(leftSidebar.modules, {
-	priority = 1,
-	side = "left",
+local _getBodyIcon = require 'pigui.modules.flight-ui.body-icons'
+local function getBodyIcon(obj, forWorld, isOrrery)
+	if obj.type == Projectable.APOAPSIS then return icons.apoapsis
+	elseif obj.type == Projectable.PERIAPSIS then return icons.periapsis
+	elseif obj.type == Projectable.L4 then return icons.lagrange_marker
+	elseif obj.type == Projectable.L5 then return icons.lagrange_marker
+	elseif obj.base == Projectable.PLAYER or obj.base == Projectable.PLANNER then
+		local shipClass = obj.ref:GetShipClass()
+		if icons[shipClass] then
+			return icons[shipClass]
+		else
+			return icons.ship
+		end
+	elseif forWorld and not isOrrery and obj.ref.superType ~= "STARPORT" and obj.ref.type ~= "PLANET_ASTEROID" then
+		return icons.empty
+	else
+		return _getBodyIcon(obj.ref, forWorld)
+	end
+end
+
+
+--
+-- The sidebar views
+--
+
+---@type UI.Sidebar.Module
+local overviewView = {
 	showInHyperspace = false,
 	icon = icons.system_overview,
 	tooltip = luc.TOGGLE_OVERVIEW_WINDOW,
@@ -220,13 +380,10 @@ table.insert(leftSidebar.modules, {
 
 		systemOverviewWidget:display(Game.system, root, selected)
 	end
-})
+}
 
-local systemEconView = require 'pigui.modules.system-econ-view'.New()
-
-table.insert(leftSidebar.modules, {
-	priority = 2,
-	side = "left",
+---@type UI.Sidebar.Module
+local economyView = {
 	showInHyperspace = false,
 	icon = icons.money,
 	tooltip = luc.ECONOMY_TRADE,
@@ -255,91 +412,171 @@ table.insert(leftSidebar.modules, {
 			systemEconView:drawStationComparison(selected, current)
 		end
 	end
-})
+}
 
-local function drawWindowControlButton(window, icon, tooltip)
-	local isWindowActive = true
-	if window.ShouldShow then isWindowActive = window:ShouldShow() end
-
-	-- tristate: invisible, inactive, visible
-	local state = (isWindowActive or not window.visible) and buttonState[window.visible].state or buttonState['DISABLED'].state
-	if ui.mainMenuButton(icon, tooltip, state) then
-		window.visible = not window.visible
-	end
-end
-
-function Windows.edgeButtons.Show()
-	local isOrrery = systemView:GetDisplayMode() == "Orrery"
-	local isCurrent = systemView:GetSystemSelectionMode() == "CURRENT_SYSTEM"
-
-	if ui.mainMenuButton(icons.reset_view, luc.RESET_ORIENTATION_AND_ZOOM) then
-		systemView:SetVisibility("RESET_VIEW")
-	end
-	ui.mainMenuButton(icons.rotate_view, luc.ROTATE_VIEW)
-	systemView:SetRotateMode(ui.isItemActive())
-	ui.mainMenuButton(icons.search_lens, luc.ZOOM)
-	systemView:SetZoomMode(ui.isItemActive())
-
-	ui.newLine()
-
-	drawWindowControlButton(Windows.objectInfo, icons.info, lc.OBJECT_INFO)
-
-	-- view control buttons
-	if not isCurrent and ui.mainMenuButton(icons.planet_grid, luc.HUD_BUTTON_SWITCH_TO_CURRENT_SYSTEM) then
-		systemView:SetSystemSelectionMode("CURRENT_SYSTEM")
-	end
-
-	if isCurrent and ui.mainMenuButton(icons.galaxy_map, luc.HUD_BUTTON_SWITCH_TO_SELECTED_SYSTEM) then
-		systemView:SetSystemSelectionMode("SELECTED_SYSTEM")
-	end
-
-	-- visibility control buttons
-	if isOrrery then
-		if ui.mainMenuButton(buttonState[ship_drawing].icon, lc.SHIPS_DISPLAY_MODE_TOGGLE, buttonState[ship_drawing].state) then
-			ship_drawing = nextShipDrawings[ship_drawing]
-			systemView:SetVisibility(ship_drawing)
+---@type UI.Sidebar.Module
+local settingsView = {
+	icon = icons.settings,
+	tooltip = luc.SETTINGS,
+	title = luc.SETTINGS,
+	drawBody = function(self)
+		--sidebarStyle:push()
+		if systemView:GetDisplayMode() == "Orrery" then
+			ui.spacing()
+			if ui.mainMenuButton(buttonState[ship_drawing].icon, lc.SHIPS_DISPLAY_MODE_TOGGLE, buttonState[ship_drawing].state) then
+				ship_drawing = nextShipDrawings[ship_drawing]
+				systemView:SetVisibility(ship_drawing)
+			end
+			ui.sameLine()
+			ui.alignTextToLineHeight()
+			ui.text("Ship Display Mode")
+			if ui.mainMenuButton(buttonState[show_lagrange].icon, lc.L4L5_DISPLAY_MODE_TOGGLE, buttonState[show_lagrange].state) then
+				show_lagrange = nextShowLagrange[show_lagrange]
+				systemView:SetVisibility(show_lagrange)
+			end
+			ui.sameLine()
+			ui.alignTextToLineHeight()
+			ui.text("Lagrange Point Display Mode")
+			if ui.mainMenuButton(buttonState[show_grid].icon, lc.GRID_DISPLAY_MODE_TOGGLE, buttonState[show_grid].state) then
+				show_grid = nextShowGrid[show_grid]
+				systemView:SetVisibility(show_grid)
+			end
+			ui.sameLine()
+			ui.alignTextToLineHeight()
+			ui.text("Grid Display Mode")
+		--sidebarStyle:pop()
 		end
-		if ui.mainMenuButton(buttonState[show_lagrange].icon, lc.L4L5_DISPLAY_MODE_TOGGLE, buttonState[show_lagrange].state) then
-			show_lagrange = nextShowLagrange[show_lagrange]
-			systemView:SetVisibility(show_lagrange)
-		end
-		if ui.mainMenuButton(buttonState[show_grid].icon, lc.GRID_DISPLAY_MODE_TOGGLE, buttonState[show_grid].state) then
-			show_grid = nextShowGrid[show_grid]
-			systemView:SetVisibility(show_grid)
-		end
-		drawWindowControlButton(Windows.orbitPlanner, icons.semi_major_axis, lc.ORBIT_PLANNER)
 	end
-end
+}
 
-function Windows.orbitPlanner.ShouldShow()
-	return systemView:GetDisplayMode() == 'Orrery'
+---@type UI.Sidebar.Module
+local infoView = {
+	icon = icons.info,
+	tooltip = lc.OBJECT_INFO,
+	showInHyperspace = false,
+	--exclusive = true,
+
+	drawTitle = function()
+		local obj = systemView:GetSelectedObject()
+		if obj ~= nil and obj.ref ~= nil then
+			local isSystemBody = obj.base == Projectable.SYSTEMBODY
+			local body = obj.ref
+			textIcon(getBodyIcon(obj))
+			ui.text(isSystemBody and body.name or body.label)
+		end
+	end,
+
+	drawBody = function()
+		local obj = systemView:GetSelectedObject()
+
+		if obj ~= nil and obj.ref ~= nil then
+			local isSystemBody = obj.base == Projectable.SYSTEMBODY
+			local body = obj.ref
+
+			if isSystemBody then
+				ui.textWrapped(body.astroDescription)
+
+				ui.separator()
+				ui.spacing()
+			end
+
+			local data = getObjectData(obj)
+			tabular(data, 0)
+		end
+	end
+}
+
+---@type UI.Sidebar.Module
+local plannerView = {
+	icon = icons.semi_major_axis,
+	tooltip = lc.ORBIT_PLANNER,
+	title = lc.ORBIT_PLANNER,
+	disabled = false,
+
+	drawBody = function(self)
+		showDvLine(icons.decrease, icons.delta, icons.increase, "factor", function(i) return i, "x" end, luc.DECREASE, lc.PLANNER_RESET_FACTOR, luc.INCREASE)
+		showDvLine(icons.decrease, icons.clock, icons.increase, "starttime",
+			function(_)
+				local now = Game.time
+				local start = systemView:GetOrbitPlannerStartTime()
+				if start then
+					return ui.Format.Duration(math.floor(start - now)), ""
+				else
+					return lc.NOW, ""
+				end
+			end,
+			luc.DECREASE, lc.PLANNER_RESET_START, luc.INCREASE)
+		showDvLine(icons.decrease, icons.orbit_prograde, icons.increase, "prograde", ui.Format.SpeedUnit, luc.DECREASE, lc.PLANNER_RESET_PROGRADE, luc.INCREASE)
+		showDvLine(icons.decrease, icons.orbit_normal, icons.increase, "normal", ui.Format.SpeedUnit, luc.DECREASE, lc.PLANNER_RESET_NORMAL, luc.INCREASE)
+		showDvLine(icons.decrease, icons.orbit_radial, icons.increase, "radial", ui.Format.SpeedUnit, luc.DECREASE, lc.PLANNER_RESET_RADIAL, luc.INCREASE)
+	end
+}
+
+table.insert(leftSidebar.modules, overviewView)
+table.insert(leftSidebar.modules, economyView)
+table.insert(leftSidebar.modules, settingsView)
+
+table.insert(rightSidebar.modules, infoView)
+table.insert(rightSidebar.modules, plannerView)
+
+--
+-- Window functions
+--
+
+function Windows.edgeButtons.ShouldShow()
+	return true
 end
 
 function Windows.timeButtons.ShouldShow()
 	return systemView:GetDisplayMode() == 'Orrery'
 end
 
-function Windows.orbitPlanner.Show()
-	textIcon(icons.semi_major_axis)
-	ui.text(lc.ORBIT_PLANNER)
-	ui.separator()
-	showDvLine(icons.decrease, icons.delta, icons.increase, "factor", function(i) return i, "x" end, luc.DECREASE, lc.PLANNER_RESET_FACTOR, luc.INCREASE)
-	showDvLine(icons.decrease, icons.clock, icons.increase, "starttime",
-		function(_)
-			local now = Game.time
-			local start = systemView:GetOrbitPlannerStartTime()
-			if start then
-				return ui.Format.Duration(math.floor(start - now)), ""
-			else
-				return lc.NOW, ""
+function Windows.edgeButtons.Show()
+	local isCurrent = systemView:GetSystemSelectionMode() == "CURRENT_SYSTEM"
+	local isOrrery = systemView:GetDisplayMode() == "Orrery"
+
+	ui.horizontalGroup(function()
+		-- system selection button (current/selected)
+		if not isCurrent and ui.mainMenuButton(icons.planet_grid, luc.HUD_BUTTON_SWITCH_TO_CURRENT_SYSTEM) then
+			systemView:SetSystemSelectionMode("CURRENT_SYSTEM")
+		end
+		if isCurrent and ui.mainMenuButton(icons.galaxy_map, luc.HUD_BUTTON_SWITCH_TO_SELECTED_SYSTEM) then
+			systemView:SetSystemSelectionMode("SELECTED_SYSTEM")
+		end
+
+		-- view control buttons (reset, rotate, zoom)
+		if ui.mainMenuButton(icons.reset_view, luc.RESET_ORIENTATION_AND_ZOOM) then
+			systemView:SetVisibility("RESET_VIEW")
+		end
+		if isOrrery then
+			ui.mainMenuButton(icons.rotate_view, luc.ROTATE_VIEW)
+		else
+			ui.mainMenuButton(icons.distance, luc.TRANSLATE_VIEW)
+		end
+		systemView:SetRotateMode(ui.isItemActive())
+		ui.mainMenuButton(icons.search_lens, luc.ZOOM)
+		systemView:SetZoomMode(ui.isItemActive())
+
+		-- view settings buttons
+		if isOrrery then
+			ui.spacing()
+			if ui.mainMenuButton(buttonState[ship_drawing].icon, lc.SHIPS_DISPLAY_MODE_TOGGLE, buttonState[ship_drawing].state) then
+				ship_drawing = nextShipDrawings[ship_drawing]
+				systemView:SetVisibility(ship_drawing)
 			end
-		end,
-		luc.DECREASE, lc.PLANNER_RESET_START, luc.INCREASE)
-	showDvLine(icons.decrease, icons.orbit_prograde, icons.increase, "prograde", ui.Format.SpeedUnit, luc.DECREASE, lc.PLANNER_RESET_PROGRADE, luc.INCREASE)
-	showDvLine(icons.decrease, icons.orbit_normal, icons.increase, "normal", ui.Format.SpeedUnit, luc.DECREASE, lc.PLANNER_RESET_NORMAL, luc.INCREASE)
-	showDvLine(icons.decrease, icons.orbit_radial, icons.increase, "radial", ui.Format.SpeedUnit, luc.DECREASE, lc.PLANNER_RESET_RADIAL, luc.INCREASE)
+			if ui.mainMenuButton(buttonState[show_lagrange].icon, lc.L4L5_DISPLAY_MODE_TOGGLE, buttonState[show_lagrange].state) then
+				show_lagrange = nextShowLagrange[show_lagrange]
+				systemView:SetVisibility(show_lagrange)
+			end
+			if ui.mainMenuButton(buttonState[show_grid].icon, lc.GRID_DISPLAY_MODE_TOGGLE, buttonState[show_grid].state) then
+				show_grid = nextShowGrid[show_grid]
+				systemView:SetVisibility(show_grid)
+			end
+		end
+	end)
 end
 
+-- time conntrol buttons
 function Windows.timeButtons.Show()
 	local t = systemView:GetOrbitPlannerTime()
 	ui.text(t and ui.Format.Datetime(t) or lc.NOW)
@@ -357,26 +594,6 @@ function Windows.timeButtons.Show()
 		else
 			systemView:AccelerateTime(0.0)
 		end
-	end
-end
-
-local _getBodyIcon = require 'pigui.modules.flight-ui.body-icons'
-local function getBodyIcon(obj, forWorld, isOrrery)
-	if obj.type == Projectable.APOAPSIS then return icons.apoapsis
-	elseif obj.type == Projectable.PERIAPSIS then return icons.periapsis
-	elseif obj.type == Projectable.L4 then return icons.lagrange_marker
-	elseif obj.type == Projectable.L5 then return icons.lagrange_marker
-	elseif obj.base == Projectable.PLAYER or obj.base == Projectable.PLANNER then
-		local shipClass = obj.ref:GetShipClass()
-		if icons[shipClass] then
-			return icons[shipClass]
-		else
-			return icons.ship
-		end
-	elseif forWorld and not isOrrery and obj.ref.superType ~= "STARPORT" and obj.ref.type ~= "PLANET_ASTEROID" then
-		return icons.empty
-	else
-		return _getBodyIcon(obj.ref, forWorld)
 	end
 end
 
@@ -721,169 +938,10 @@ local function displayOnScreenObjects()
 	end
 end
 
-local function tabular(data, maxSize)
-	if data and #data > 0 then
-		ui.columns(2, "Attributes", false)
-		local nameWidth = 0
-		local valueWidth = 0
-		for _,item in pairs(data) do
-			if item.value then
-				local nWidth = ui.calcTextSize(item.name).x + ui.getItemSpacing().x
-				local vWidth = ui.calcTextSize(item.value).x + ui.getItemSpacing().x
-				if ui.getColumnWidth() < nWidth then
-					textIcon(item.icon or icons.info, item.name)
-				else
-					ui.text(item.name)
-				end
-				ui.nextColumn()
-				ui.text(item.value)
-				ui.nextColumn()
-
-				nameWidth = math.max(nameWidth, nWidth)
-				valueWidth = math.max(valueWidth, vWidth)
-			end
-		end
-		if nameWidth + valueWidth > maxSize then
-			-- first of all, we want to see the values, but the keys should not be too small either
-			nameWidth = math.max(maxSize - valueWidth, maxSize * 0.1)
-		end
-		ui.setColumnWidth(0, nameWidth)
-	end
-end
-
-function Windows.objectInfo.ShouldShow()
-	local obj = systemView:GetSelectedObject()
-
-	if obj.type ~= Projectable.OBJECT or obj.base ~= Projectable.SHIP and obj.base ~= Projectable.SYSTEMBODY then
-		return false
-	end
-
-	return true
-end
-
-function Windows.objectInfo:Show()
-	local obj = systemView:GetSelectedObject()
-	local isSystemBody = obj.base == Projectable.SYSTEMBODY
-	local body = obj.ref
-
-	--FIXME there is some flickering when changing from one info to another
-	--which has different lenght. If the new one is shorter then the first header drawing
-	--seems to be too high (accodring to positioning relative to old info).
-	--Probably only durring the second drawing the position is ok. The window is anchored at bottom
-	textIcon(getBodyIcon(obj))
-	ui.text(isSystemBody and body.name or body.label)
-	ui.spacing()
-
-	if isSystemBody then
-		ui.withFont(detailfont, function()
-			ui.textWrapped(body.astroDescription)
-		end)
-	end
-
-	ui.separator()
-	ui.spacing()
-
-	local data = {}
-
-	--SystemBody data is static so we use cache
-	--Ship data migh be dynamic in the future
-	if isSystemBody and self.prev_body == body then
-		data = self.data
-	else
-		self.prev_body = body
-
-		if isSystemBody then -- system body
-			local parent = body.parent
-			local starport = body.superType == "STARPORT"
-			local surface = body.type == "STARPORT_SURFACE"
-			local sma = body.semiMajorAxis
-			local semimajoraxis = nil
-			if sma and sma > 0 then
-				semimajoraxis = ui.Format.Distance(sma)
-			end
-			local rp = body.rotationPeriod * 24 * 60 * 60
-			local op = body.orbitPeriod * 24 * 60 * 60
-			local pop = math.round(body.population * 1e9)
-			local techLevel = starport and SpaceStation.GetTechLevel(body) or nil
-			if techLevel == 11 then
-				techLevel = luc.MILITARY
-			end
-			data = {
-				{ name = lc.MASS, icon = icons.body_radius,
-					value = (not starport) and ui.Format.Mass(body.mass) or nil },
-				{ name = lc.RADIUS, icon = icons.body_radius,
-					value = (not starport) and ui.Format.Distance(body.radius) or nil },
-				{ name = lc.SURFACE_TEMPERATURE, icon = icons.temperature,
-					value = (not starport) and ui.Format.Temperature(body.averageTemp) or nil },
-				{ name = lc.SURFACE_PRESSURE, icon = icons.pressure,
-					value = (not starport) and ui.Format.Pressure(body.surfacePressure) or nil },
-				{ name = lc.SURFACE_GRAVITY, icon = icons.body_radius,
-					value = (not starport) and ui.Format.Speed(body.gravity, true).."²"..
-												" ("..ui.Format.Gravity(body.gravity / 9.80665)..")" or nil },
-				{ name = lc.ESCAPE_VELOCITY, icon = icons.body_radius,
-					value = (not starport) and ui.Format.Speed(body.escapeVelocity , true) or nil },
-				{ name = lc.MEAN_DENSITY, icon = icons.body_radius,
-					value = (not starport) and ui.Format.Number(body.meanDensity, 0).." "..lc.UNIT_DENSITY or nil },
-				{ name = lc.ORBITAL_PERIOD, icon = icons.body_orbit_period,
-					value = op and op > 0 and ui.Format.Duration(op, 2) or nil },
-				{ name = lc.DAY_LENGTH, icon = icons.body_day_length,
-					value = rp > 0 and ui.Format.Duration(rp, 2) or nil },
-				{ name = luc.ORBIT_APOAPSIS, icon = icons.body_semi_major_axis,
-					value = (parent and not surface) and ui.Format.Distance(body.apoapsis) or nil },
-				{ name = luc.ORBIT_PERIAPSIS, icon = icons.body_semi_major_axis,
-					value = (parent and not surface) and ui.Format.Distance(body.periapsis) or nil },
-				{ name = lc.SEMI_MAJOR_AXIS, icon = icons.body_semi_major_axis,
-					value = semimajoraxis },
-				{ name = lc.ECCENTRICITY, icon = icons.body_semi_major_axis,
-					value = (parent and not surface) and string.format("%0.2f", body.eccentricity) or nil },
-				{ name = lc.AXIAL_TILT, icon = icons.body_semi_major_axis,
-					value = (not starport) and string.format("%0.2f", body.axialTilt) or nil },
-				{ name = lc.POPULATION, icon = icons.personal,
-					value = pop > 0 and ui.Format.NumberAbbv(pop) or nil },
-				{ name = luc.TECH_LEVEL, icon = icons.equipment,
-					value = starport and techLevel or nil }
-			}
-
-			--change the internal cached data only when new is fully built
-			--prevents additional flickering
-			self.data = data
-
-		elseif obj.ref:IsShip() then -- physical body
-			---@cast body Ship
-			-- TODO: the advanced target scanner should add additional data here,
-			-- but we really do not want to hardcode that here. there should be
-			-- some kind of hook that the target scanner can hook into to display
-			-- more info here.
-			-- This is what should be inserted:
-			table.insert(data, { name = luc.SHIP_TYPE, value = body:GetShipType() })
-			if (player["target_scanner_level_cap"] or 0) > 0 then
-				local hd = body:GetInstalledHyperdrive()
-				table.insert(data, { name = luc.HYPERDRIVE, value = hd and hd:GetName() or lc.NO_HYPERDRIVE })
-				table.insert(data, { name = luc.MASS, value = Format.MassTonnes(body.staticMass) })
-				table.insert(data, { name = luc.CARGO, value = Format.MassTonnes(body.usedCargo) })
-			end
-		else
-			data = {}
-		end
-	end
-
-	ui.withFont(detailfont, function()
-		tabular(data, Windows.objectInfo.size.x)
-	end)
-end
-
-function Windows.objectInfo.Dummy()
-	ui.withFont(detailfont, function()
-		ui.text("Tiny rocky planet with no significant")
-	end)
-end
-
 function systemViewLayout:onUpdateWindowPivots(w)
 	w.systemName.anchors   = { ui.anchor.center, ui.anchor.top }
-	w.edgeButtons.anchors  = { ui.anchor.right,  ui.anchor.top }
+	w.edgeButtons.anchors  = { ui.anchor.center,  ui.anchor.bottom }
 	w.timeButtons.anchors  = { ui.anchor.right,  ui.anchor.bottom }
-	w.orbitPlanner.anchors = { ui.anchor.right,  ui.anchor.bottom }
-	w.objectInfo.anchors   = { ui.anchor.right,  ui.anchor.bottom }
 	w.unexplored.anchors   = { ui.anchor.center, ui.anchor.center }
 end
 
@@ -893,12 +951,7 @@ function systemViewLayout:onUpdateWindowConstraints(w)
 	w.systemName.pos.y = styles.MainButtonSize.y + styles.WindowPadding.y * 2 -- matches fx-window.lua
 	w.systemName.size.x = 0 -- adaptive width
 
-	w.edgeButtons.size.y = 0 -- adaptive height
-
-	w.orbitPlanner.pos = w.timeButtons.pos - Vector2(w.edgeButtons.size.x, w.timeButtons.size.y)
-	w.orbitPlanner.size.x = w.timeButtons.size.x - w.edgeButtons.size.x
-	w.objectInfo.pos = Vector2(w.edgeButtons.pos.x - w.edgeButtons.size.x, w.orbitPlanner.pos.y - w.orbitPlanner.size.y)
-	w.objectInfo.size = Vector2(math.max(w.objectInfo.size.x, w.orbitPlanner.size.x), 0) -- adaptive height
+	w.edgeButtons.size.x = 0 -- adaptive width
 end
 
 local function displaySystemViewUI()
@@ -912,10 +965,16 @@ local function displaySystemViewUI()
 			systemViewLayout.enabled = not systemViewLayout.enabled
 		end
 
+		plannerView.disabled = systemView:GetDisplayMode() ~= "Orrery"
+		plannerView.icon = plannerView.disabled and icons.square_dashed or icons.semi_major_axis
+
 		systemViewLayout:display()
-		ui.withStyleColors({ WindowBg = colors.transparent }, function()
-			leftSidebar:Draw()
-		end)
+		if systemViewLayout.enabled then
+			ui.withStyleColors({ WindowBg = colors.transparent }, function()
+				leftSidebar:Draw()
+				rightSidebar:Draw()
+			end)
+		end
 
 		displayOnScreenObjects()
 
@@ -925,7 +984,7 @@ local function displaySystemViewUI()
 
 		if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) then
 			package.reimport 'pigui.modules.system-overview-window'
-			package.reimport 'pigui.modules.system-econ-view'
+			systemEconView = package.reimport('pigui.modules.system-econ-view').New()
 			package.reimport()
 		end
 	end

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -164,7 +164,7 @@ end
 -- all windows in this view
 local Windows = {
 	systemName = layout.NewWindow("SystemMapSystemName"),
-	objectInfo = layout.NewWindow("SystemMapObjectIngo"),
+	objectInfo = layout.NewWindow("SystemMapObjectInfo"),
 	edgeButtons = layout.NewWindow("SystemMapEdgeButtons"),
 	orbitPlanner = layout.NewWindow("SystemMapOrbitPlanner"),
 	timeButtons = layout.NewWindow("SystemMapTimeButtons"),
@@ -813,6 +813,10 @@ function Windows.objectInfo:Show()
 					value = (not starport) and ui.Format.Mass(body.mass) or nil },
 				{ name = lc.RADIUS, icon = icons.body_radius,
 					value = (not starport) and ui.Format.Distance(body.radius) or nil },
+				{ name = lc.SURFACE_TEMPERATURE, icon = icons.temperature,
+					value = (not starport) and ui.Format.Temperature(body.averageTemp) or nil },
+				{ name = lc.SURFACE_PRESSURE, icon = icons.pressure,
+					value = (not starport) and ui.Format.Pressure(body.surfacePressure) or nil },
 				{ name = lc.SURFACE_GRAVITY, icon = icons.body_radius,
 					value = (not starport) and ui.Format.Speed(body.gravity, true).."²"..
 												" ("..ui.Format.Gravity(body.gravity / 9.80665)..")" or nil },


### PR DESCRIPTION
**DRAFT PR**

The code still needs some cleaning up, but preparing a PR for initial review/commenting on the implementation and direction.

Specifically:
- keep view-setting buttons on the bottom or move them into the left sidebar (the latter makes them more consistent with the Sector View)
- if moved into sidebar, should they be converted to checkboxes or drop-downs, again, for consistency?

----

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

Fixes #6170  (see issue for screenshots; before, during, and final)

After the trivial work of adding the missing values, some of the values were shown using icons instead of text labels due to the Object Info window being too narrow (constrained by the time control buttons).

So the Object Info window was converted to a Sidebar Module and added to the left sidebar, which displayed nicely, but prevented being able to click through system objects using the overview window while seeing the object information.

So the entire view was rewritten to be more in-line with the sector map:
- right-side button bar moved to bottom-center
- right-hand sidebar created
- sidebar Object View moved to right sidebar
- Orbit Planner converted to sidebar module and added to right sidebar
- a new settings sidebar module was created and the view settings buttons copied into it (Proof-of-Concept)
- some other minor tweaks, such as renaming the translate-button when in the System Overview mode

