### PR TITLE
fix(ui): fix crash in info screen

### DIFF
--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -41,7 +41,7 @@ local function shipStats()
 	local up_acc = player:GetAcceleration("up")
 
 	local atmo_shield = equipSet:GetInstalledOfType("hull.atmo_shield")[1]
-	local atmo_shield_cap = math.max(player["atmo_shield_cap"], 1)
+	local atmo_shield_cap = math.max(player["atmo_shield_cap"] or 0, 1)
 
 	textTable.draw({
 		{ l.REGISTRATION_NUMBER..":",	shipLabel},


### PR DESCRIPTION
Fixes #6137

Some users have reported crashes on the info screen.

This commit fixes at least one of these causes, namely a crash when the player ship does not have any atmospheric shielding installed. The improved check matches how this field is accessed in other modules in the codebase so may have just been an oversight in commit f3a1801d22f2508c156ff877f8db760679fa63ad.

~~While unable to reproduce it's possible this may have been caused in conjunction with loading older savegames.~~

TEST (Using attached savefile): 

1. Start recovery of the v90 savegame
2. Remove/replace all equipment (incompatible shielding, engines, thrusters, etc)
3. Ensure "Atmospheric Shielding" is only removed, not replaced!
4. Start game
5. Open Info screen
6. Unpactched game: *BOOM* (with the LUA error screen shown in the bug report)
7. Patched game: Info screen shown as intended, "Atmospheric shielding: No"

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

[Torvalds Class 12 Equipment Shop.zip](https://github.com/user-attachments/files/20794306/Torvalds.Class.12.Equipment.Shop.zip)
