### PR TITLE
Redefine meaning of onEnterSystem/onLeaveSystem events

### DIFF
--- a/data/libs/Event.lua
+++ b/data/libs/Event.lua
@@ -318,19 +318,20 @@ end
 --
 -- Event: onEnterSystem
 --
--- Triggered when a ship enters a system after hyperspace.
+-- Triggered when a new system is loaded after hyperspace.
+-- For the event that is called when any ship enters the current system, see <onShipEnterSystem>.
 --
--- > local onEnterSystem = function (ship) ... end
+-- > local onEnterSystem = function (player) ... end
 -- > Event.Register("onEnterSystem", onEnterSystem)
 --
 -- This is the place to spawn pirates and other attack ships to give the
--- illusion that the ship was followed through hyperspace.
+-- illusion that the player's ship was followed through hyperspace.
 --
 -- Note that this event is *not* triggered at game start.
 --
 -- Parameters:
 --
---   ship - the <Ship> that entered the system
+--   player - the player's <Ship> that entered the system
 --
 -- Availability:
 --
@@ -344,21 +345,64 @@ end
 --
 -- Event: onLeaveSystem
 --
--- Triggered immediately before ship leaves a system and enters hyperspace.
+-- Triggered immediately before the player leaves a system and enters hyperspace.
+-- For the event that is called when any ship leaves the current system, see <onShipLeaveSystem>.
 --
--- > local onLeaveSystem = function (ship) ... end
+-- > local onLeaveSystem = function (player) ... end
 -- > Event.Register("onLeaveSystem", onLeaveSystem)
 --
--- If the ship was the player then all physics <Body> objects are invalid after
--- this method returns.
+-- This is the place to clean up per-system caches and other data structures that
+-- track ship objects.
+--
+-- All physics <Body> objects are invalid after this method returns, as the
+-- underlying <Space> is unloaded.
+--
+-- Parameters:
+--
+--   player - the player's <Ship> that left the system
+--
+-- Status:
+--
+--   stable
+--
+
+--
+-- Event: onShipEnterSystem
+--
+-- Triggered when a <Ship> enters the current system from a hyperspace cloud.
+-- This event is also called for the player's <Ship> when a new system is entered.
+--
+-- > local onShipEnterSystem = function (ship) ... end
+-- > Event.Register("onShipEnterSystem", onShipEnterSystem)
+--
+-- This is the place to give AI commands and track ship objects in mission modules.
+--
+-- Note that this event is *not* triggered at game start.
+--
+-- Parameters:
+--
+--   ship - the <Ship> that entered the system
+--
+-- Status:
+--
+--   stable
+--
+
+--
+-- Event: onShipLeaveSystem
+--
+-- Triggered immediately before a <Ship> enters hyperspace and leaves the current system.
+-- This event is also called for the player's <Ship> when the current system is unloaded.
+--
+-- > local onShipLeaveSystem = function (ship) ... end
+-- > Event.Register("onShipLeaveSystem", onShipLeaveSystem)
+--
+-- All physics <Body> objects are invalid after this method returns, as the
+-- underlying <Space> is unloaded.
 --
 -- Parameters:
 --
 --   ship - the <Ship> that left the system
---
--- Availability:
---
---   alpha 10
 --
 -- Status:
 --

--- a/data/libs/Player.lua
+++ b/data/libs/Player.lua
@@ -15,7 +15,6 @@ local Event = require 'Event'
 local Game = require 'Game'
 
 local onEnterSystem = function (ship)
-	if not ship.IsPlayer() then return end
 	-- Return to game view when we exit hyperspace
 	if Engine.GetResetViewOnHyperspaceExit() and Game.CurrentView() ~= "WorldView" then
 		Game.SetView("WorldView")

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -730,7 +730,7 @@ end
 
 -- Function to check whether ships exist after hyperspace, and if they do not,
 -- to remove their crew from the roster.
-local onEnterSystem = function (ship)
+local onShipEnterSystem = function (ship)
 	if ship:IsPlayer() then
 		for crewedShip,crew in pairs(CrewRoster) do
 			if not crewedShip:exists() then
@@ -738,6 +738,7 @@ local onEnterSystem = function (ship)
 			end
 		end
 	end
+
 	local engine = ship:GetInstalledHyperdrive()
 	if engine then
 		engine:OnLeaveHyperspace(ship)
@@ -761,7 +762,7 @@ local onShipTypeChanged = function (ship)
 	ship:GetComponent('CargoManager'):OnShipTypeChanged()
 end
 
-Event.Register("onEnterSystem", onEnterSystem)
+Event.Register("onShipEnterSystem", onShipEnterSystem)
 Event.Register("onShipDestroyed", onShipDestroyed)
 Event.Register("onGameStart", onGameStart)
 Event.Register("onGameEnd", onGameEnd)

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -1072,7 +1072,6 @@ Event.Register("onPlayerDocked", function (ship, station)
 end)
 
 Event.Register("onLeaveSystem", function (ship)
-	if ship ~= Game.player then return end
 	destroySystem()
 end)
 

--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -278,8 +278,6 @@ end
 
 local planets
 local onEnterSystem = function (ship)
-	if not ship:IsPlayer() then return end
-
 	local syspath = Game.system.path
 
 	for ref,mission in pairs(missions) do
@@ -321,10 +319,8 @@ local onEnterSystem = function (ship)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		nearbysystems = nil
-		planets = nil
-	end
+	nearbysystems = nil
+	planets = nil
 end
 
 local onShipDocked = function (ship, station)

--- a/data/modules/BreakdownServicing/BreakdownServicing.lua
+++ b/data/modules/BreakdownServicing/BreakdownServicing.lua
@@ -260,11 +260,7 @@ end
 
 ---@param ship Ship
 local onEnterSystem = function (ship)
-	if ship:IsPlayer() then
-		print(('DEBUG: Jumps since warranty: %d\nWarranty expires: %s'):format(service_history.jumpcount,Format.Date(service_history.lastdate + service_history.service_period)))
-	else
-		return -- Don't care about NPC ships
-	end
+	print(('DEBUG: Jumps since warranty: %d\nWarranty expires: %s'):format(service_history.jumpcount,Format.Date(service_history.lastdate + service_history.service_period)))
 
 	local engine = ship:GetInstalledHyperdrive()
 	if not engine then

--- a/data/modules/BulkShips.lua
+++ b/data/modules/BulkShips.lua
@@ -38,8 +38,6 @@ local spawnShips = function ()
 end
 
 local onEnterSystem = function (player)
-	if not player:IsPlayer() then return end
-
 	spawnShips()
 end
 

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -491,8 +491,6 @@ local escort_chatter_time
 local escort_switch_target
 
 local onEnterSystem = function (player)
-	if (not player:IsPlayer()) then return end
-
 	local syspath = Game.system.path
 
 	for ref,mission in pairs(missions) do
@@ -657,11 +655,9 @@ local onShipHit = function (ship, attacker)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		nearbysystems = nil
-		pirate_ships = {}
-		escort_ships = {}
-	end
+	nearbysystems = nil
+	pirate_ships = {}
+	escort_ships = {}
 end
 
 local onPlayerDocked = function (player, station)

--- a/data/modules/Combat/Combat.lua
+++ b/data/modules/Combat/Combat.lua
@@ -424,8 +424,6 @@ local finishMission = function (ref, mission)
 end
 
 local onEnterSystem = function (player)
-	if not player:IsPlayer() then return end
-
 	for ref, mission in pairs(missions) do
 		if mission.rendezvous and mission.rendezvous:IsSameSystem(Game.system.path) then
 			if mission.complete or Game.time > mission.due then
@@ -449,13 +447,11 @@ local onEnterSystem = function (player)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		for _, f in pairs(flavours) do
-			f.planets = nil
-		end
-		for ref, mission in pairs(missions) do
-			mission.mercenaries = {}
-		end
+	for _, f in pairs(flavours) do
+		f.planets = nil
+	end
+	for ref, mission in pairs(missions) do
+		mission.mercenaries = {}
 	end
 end
 

--- a/data/modules/CrewContracts/CrewContracts.lua
+++ b/data/modules/CrewContracts/CrewContracts.lua
@@ -457,10 +457,8 @@ Event.Register("onUpdateBB", onUpdateBB)
 
 -- Wipe temporary crew out when hyperspacing
 Event.Register("onEnterSystem", function(ship)
-	if ship:IsPlayer() then
-		nonPersistentCharactersForCrew = {}
-		stationsWithAdverts = {}
-	end
+	nonPersistentCharactersForCrew = {}
+	stationsWithAdverts = {}
 end)
 
 -- Load temporary crew from saved data

--- a/data/modules/CrimeTracking/CrimeTracking.lua
+++ b/data/modules/CrimeTracking/CrimeTracking.lua
@@ -111,7 +111,6 @@ end
 
 
 local onLeaveSystem = function(ship)
-	if not ship:IsPlayer() then return end
 	-- if we leave the system, the space station object will be invalid
 	policeDispatched = nil
 

--- a/data/modules/DeliverPackage/DeliverPackage.lua
+++ b/data/modules/DeliverPackage/DeliverPackage.lua
@@ -348,8 +348,6 @@ local onUpdateBB = function (station)
 end
 
 local onEnterSystem = function (player)
-	if (not player:IsPlayer()) then return end
-
 	local syspath = Game.system.path
 
 	for ref,mission in pairs(missions) do
@@ -394,9 +392,7 @@ local onEnterSystem = function (player)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		nearbysystems = nil
-	end
+	nearbysystems = nil
 end
 
 local onPlayerDocked = function (player, station)

--- a/data/modules/FindPerson/FindPerson.lua
+++ b/data/modules/FindPerson/FindPerson.lua
@@ -309,8 +309,6 @@ local onFrameChanged = function (player)
 end
 
 local onEnterSystem = function (player)
-	if not player:IsPlayer() then return end
-
 	for ref, mission in pairs(missions) do
 		if mission.destination:IsSameSystem(Game.system.path) and mission.status == "ACTIVE" and mission.flavour.ship then
 
@@ -439,12 +437,10 @@ local onPlayerUndocked = function (player, station)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		nearbysystems = nil
-		for ref, mission in pairs(missions) do
-			mission.ship = nil
-			mission.interceptor = nil
-		end
+	nearbysystems = nil
+	for ref, mission in pairs(missions) do
+		mission.ship = nil
+		mission.interceptor = nil
 	end
 end
 

--- a/data/modules/FlightLog/FlightLog.lua
+++ b/data/modules/FlightLog/FlightLog.lua
@@ -346,15 +346,11 @@ end
 
 -- onLeaveSystem
 local AddSystemDepartureToLog = function (ship)
-	if not ship:IsPlayer() then return end
-
 	FlightLog.AddEntry( FlightLogEntry.System.New( Game.system.path, nil, Game.time, nil ) )
 end
 
 -- onEnterSystem
 local AddSystemArrivalToLog = function (ship)
-	if not ship:IsPlayer() then return end
-
 	FlightLog.AddEntry( FlightLogEntry.System.New( Game.system.path, Game.time, nil, nil ) )
 end
 

--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -304,8 +304,6 @@ end
 local timeInHyperspace
 
 local onEnterSystem = function (player)
-	if (not player:IsPlayer()) then return end
-
 	-- remove old news before making new
 	checkOldNews()
 
@@ -322,7 +320,6 @@ end
 
 
 local onLeaveSystem = function (ship)
-	if not ship:IsPlayer() then return end
 	nearbySystems = nil
 	timeInHyperspace = Game.time
 end

--- a/data/modules/Pirates.lua
+++ b/data/modules/Pirates.lua
@@ -11,8 +11,6 @@ local MissionUtils = require 'modules.MissionUtils'
 local ShipBuilder  = require 'modules.MissionUtils.ShipBuilder'
 
 local onEnterSystem = function (player)
-	if not player:IsPlayer() then return end
-
 	local shipdefs = utils.build_array(utils.filter(function (k,def) return def.tag == 'SHIP'
 		and def.hyperdriveClass > 0 and def.roles.pirate end, pairs(ShipDef)))
 	if #shipdefs == 0 then return end

--- a/data/modules/PolicePatrol/PolicePatrol.lua
+++ b/data/modules/PolicePatrol/PolicePatrol.lua
@@ -125,8 +125,6 @@ local onJettison = function (ship, cargo)
 end
 
 local onEnterSystem = function (player)
-	if not player:IsPlayer() then return end
-
 	if not hasIllegalGoods(Commodities) then return end
 
 	local system = assert(Game.system)
@@ -199,12 +197,10 @@ local onEnterSystem = function (player)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		patrol = {}
-		showMercy = true
-		piracy = false
-		target = nil
-	end
+	patrol = {}
+	showMercy = true
+	piracy = false
+	target = nil
 end
 
 

--- a/data/modules/Rondel/Rondel.lua
+++ b/data/modules/Rondel/Rondel.lua
@@ -155,8 +155,6 @@ local onJettison = function (ship, cargo)
 end
 
 local onEnterSystem = function (player)
-	if not player:IsPlayer() then return end
-
 	local system = assert(Game.system)
 	if not system.path:IsSameSystem(rondel_syspath) then return end
 
@@ -193,11 +191,9 @@ local onEnterSystem = function (player)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		shipFiring = false
-		jetissionedCargo = false
-		patrol = {}
-	end
+	shipFiring = false
+	jetissionedCargo = false
+	patrol = {}
 end
 
 local loaded_data

--- a/data/modules/Scoop/Scoop.lua
+++ b/data/modules/Scoop/Scoop.lua
@@ -733,7 +733,7 @@ local getPopulatedPlanets = function (system)
 end
 
 local onEnterSystem = function (ship)
-	if not ship:IsPlayer() or Game.system.population == 0 then return end
+	if Game.system.population == 0 then return end
 
 	local planets = getPopulatedPlanets(Game.system)
 	local num = Engine.rand:Integer(0, math.ceil(Game.system.population * Game.system.lawlessness))
@@ -753,22 +753,20 @@ local onEnterSystem = function (ship)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		for ref, mission in pairs(missions) do
-			mission.destination = nil
-			mission.police = nil
-			if mission.client_ship then
-				mission.client_ship = nil
-				mission.status = "FAILED"
-			end
-			for i, e in pairs(mission.debris) do
-				e.body = nil
-			end
+	for ref, mission in pairs(missions) do
+		mission.destination = nil
+		mission.police = nil
+		if mission.client_ship then
+			mission.client_ship = nil
+			mission.status = "FAILED"
 		end
-		planets = nil
-		flavours[LEGAL].cargo_type = nil
-		flavours[ILLEGAL].cargo_type = nil
+		for i, e in pairs(mission.debris) do
+			e.body = nil
+		end
 	end
+	planets = nil
+	flavours[LEGAL].cargo_type = nil
+	flavours[ILLEGAL].cargo_type = nil
 end
 
 local onReputationChanged = function (oldRep, oldKills, newRep, newKills)

--- a/data/modules/Scout/Scout.lua
+++ b/data/modules/Scout/Scout.lua
@@ -583,7 +583,6 @@ end
 
 
 local onEnterSystem = function (playership)
-	if not playership:IsPlayer() then return end
 	nearbysystems = nil
 
 	for ref,mission in pairs(missions) do

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -1984,7 +1984,6 @@ local onUpdateBB = function (station)
 end
 
 local onEnterSystem = function (player)
-	if (not player:IsPlayer()) then return end
 	leaving_system = false
 
 	local syspath = Game.system.path
@@ -2000,21 +1999,19 @@ local onEnterSystem = function (player)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		leaving_system = true    --checked by searchForTarget to abort search
+	leaving_system = true    --checked by searchForTarget to abort search
 
-		local syspath = Game.system.path
+	local syspath = Game.system.path
 
-		-- remove references to ships that are left behind (cause serialization crash otherwise)
-		for _,mission in pairs(missions) do
-			if mission.system_target:IsSameSystem(syspath) then
-				mission.target = nil
-			end
+	-- remove references to ships that are left behind (cause serialization crash otherwise)
+	for _,mission in pairs(missions) do
+		if mission.system_target:IsSameSystem(syspath) then
+			mission.target = nil
 		end
-
-		discarded_ships = {}
-		-- TODO: put in tracker to recreate mission targets (already transferred personnel, cargo, etc.)
 	end
+
+	discarded_ships = {}
+	-- TODO: put in tracker to recreate mission targets (already transferred personnel, cargo, etc.)
 end
 
 ---@param ship Ship

--- a/data/modules/System/Explore.lua
+++ b/data/modules/System/Explore.lua
@@ -39,8 +39,6 @@ local exploreSystem = function (system)
 end
 
 local onEnterSystem = function (player)
-	if not player:IsPlayer() then return end
-
 	if not Game.system.explored then
 		exploreSystem(Game.system)
 	end

--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -325,8 +325,6 @@ local onUpdateBB = function (station)
 end
 
 local onEnterSystem = function (player)
-	if (not player:IsPlayer()) then return end
-
 	local syspath = Game.system.path
 
 	for ref,mission in pairs(missions) do
@@ -386,9 +384,7 @@ local onEnterSystem = function (player)
 end
 
 local onLeaveSystem = function (ship)
-	if ship:IsPlayer() then
-		nearbysystems = nil
-	end
+	nearbysystems = nil
 end
 
 local onPlayerDocked = function (player, station)

--- a/data/modules/TradeShips/Events.lua
+++ b/data/modules/TradeShips/Events.lua
@@ -38,7 +38,7 @@ local onGameStart = function ()
 end
 Event.Register("onGameStart", onGameStart)
 
-local onEnterSystem = function (ship)
+local onShipEnterSystem = function (ship)
 	-- dont crash when entering unexplored systems
 	if Game.system.explored == false then
 		return
@@ -70,9 +70,9 @@ local onEnterSystem = function (ship)
 		end
 	end
 end
-Event.Register("onEnterSystem", onEnterSystem)
+Event.Register("onShipEnterSystem", onShipEnterSystem)
 
-local onLeaveSystem = function (ship)
+local onShipLeaveSystem = function (ship)
 	if ship:IsPlayer() then
 		-- the next onEnterSystem will be in a new system
 		local total, removed = 0, 0
@@ -97,7 +97,7 @@ local onLeaveSystem = function (ship)
 		Flow.cleanTradeShipsTable()
 	end
 end
-Event.Register("onLeaveSystem", onLeaveSystem)
+Event.Register("onShipLeaveSystem", onShipLeaveSystem)
 
 local onShipDocked = function (ship, starport)
 	if Core.ships[ship] == nil then return end

--- a/data/pigui/modules/hyperjump-planner.lua
+++ b/data/pigui/modules/hyperjump-planner.lua
@@ -182,7 +182,7 @@ function hyperJumpPlanner.onEnterSystem(ship)
 	-- remove the first jump if it's the current system (and enabled to do so)
 	-- this should be the case if you are following a route and want the route to be
 	-- updated as you make multiple jumps
-	if ship:IsPlayer() and remove_first_if_current then
+	if remove_first_if_current then
 		if #hyperjump_route > 0 and hyperjump_route[1] and hyperjump_route[1].path:IsSameSystem(Game.system.path) then
 			sectorView:RemoveRouteItem(1)
 		end

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -104,9 +104,7 @@ local onGameStart = function ()
 end
 
 local onEnterSystem = function (ship)
-	if ship == Game.player then
-		Game.systemView:SetVisibility("RESET_VIEW");
-	end
+	Game.systemView:SetVisibility("RESET_VIEW");
 end
 
 local function textIcon(icon, tooltip)

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -863,10 +863,8 @@ end})
 Event.Register("onGameStart", onGameStart)
 Event.Register("onEnterSystem", function(ship)
 	hyperJumpPlanner.onEnterSystem(ship)
-	if ship:IsPlayer() then
-		hyperspaceDetailsCache = {}
-		shouldRefresh = true
-	end
+	hyperspaceDetailsCache = {}
+	shouldRefresh = true
 end)
 
 -- reset cached data

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -677,10 +677,12 @@ void Game::SwitchToNormalSpace()
 
 			m_space->AddBody(ship);
 
-			LuaEvent::Queue("onEnterSystem", ship);
+			LuaEvent::Queue("onShipEnterSystem", ship);
 		}
 	}
 	m_hyperspaceClouds.clear();
+
+	LuaEvent::Queue("onEnterSystem", m_player.get());
 
 	m_space->GetBackground()->SetDrawFlags(Background::Container::DRAW_SKYBOX | Background::Container::DRAW_STARS);
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -199,6 +199,13 @@ void Player::NotifyRemoved(const Body *const removedBody)
 	Ship::NotifyRemoved(removedBody);
 }
 
+void Player::OnBeforeEnterHyperspace()
+{
+	Ship::OnBeforeEnterHyperspace();
+
+	LuaEvent::Queue("onLeaveSystem", this);
+}
+
 //XXX ui stuff
 void Player::OnEnterHyperspace()
 {

--- a/src/Player.h
+++ b/src/Player.h
@@ -61,6 +61,7 @@ protected:
 	virtual void SaveToJson(Json &jsonObj, Space *space) override;
 
 	virtual void OnEnterSystem() override;
+	virtual void OnBeforeEnterHyperspace() override;
 	virtual void OnEnterHyperspace() override;
 
 private:

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1346,7 +1346,7 @@ void Ship::StaticUpdate(const float timeStep)
 				// We have to fire it here, because the event isn't actually fired until
 				// after the whole physics update, which means the flight state on next
 				// step would be HYPERSPACE, thus breaking quite a few things.
-				LuaEvent::Queue("onLeaveSystem", this);
+				OnBeforeEnterHyperspace();
 			} else if (!(is_equal_exact(m_wheelState, 0.0f)) && this->IsType(ObjectType::PLAYER)) {
 				AbortHyperjump();
 				Sound::BodyMakeNoise(this, "Missile_Inbound", 1.0f);
@@ -1507,6 +1507,11 @@ void Ship::EnterHyperspace()
 	OnEnterHyperspace();
 }
 
+void Ship::OnBeforeEnterHyperspace()
+{
+	LuaEvent::Queue("onShipLeaveSystem", this);
+}
+
 void Ship::OnEnterHyperspace()
 {
 	Sound::BodyMakeNoise(this, m_hyperspace.sounds.jump_sound.c_str(), 1.f);
@@ -1530,7 +1535,7 @@ void Ship::EnterSystem()
 
 	SetFlightState(Ship::FLYING);
 
-	LuaEvent::Queue("onEnterSystem", this);
+	LuaEvent::Queue("onShipEnterSystem", this);
 }
 
 void Ship::OnEnterSystem()

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -257,6 +257,7 @@ protected:
 
 	virtual void SetAlertState(AlertState as);
 
+	virtual void OnBeforeEnterHyperspace();
 	virtual void OnEnterHyperspace();
 	virtual void OnEnterSystem();
 


### PR DESCRIPTION
Per discussion on #6163, this PR adds player-specific versions of the `onEnterSystem`/`onLeaveSystem` events... by making those events player-specific.

This neatly maps to the semantic meaning of those names, as these events (when trigged for the player) change the actively-loaded system that the game is played in. Generic versions have been introduced as `onShipEnterSystem`/`onShipLeaveSystem` and the few mission modules interested in receiving events for all NPC ships have been migrated to use those events.

CC @robothauler for a quick review.