### PR TITLE
Save settings to disk when closing the settings window

### DIFF
--- a/data/meta/Engine.lua
+++ b/data/meta/Engine.lua
@@ -25,4 +25,47 @@ local Engine = {}
 ---@return SceneGraph.Model model
 function Engine.GetModel(name) end
 
+-- Get a boolean value from the settings file.
+---@param key string
+---@return boolean
+function Engine.SettingsGetBool(key) end
+
+-- Get an integer value from the settings file.
+---@param key string
+---@return integer
+function Engine.SettingsGetInt(key) end
+
+-- Get a floating-point number value from the settings file.
+---@param key string
+---@return number
+function Engine.SettingsGetNumber(key) end
+
+-- Get a string value from the settings file.
+---@param key string
+---@return string
+function Engine.SettingsGetString(key) end
+
+-- Set a boolean value to the settings file.
+---@param key string
+---@param value boolean
+function Engine.SettingsSetBool(key, value) end
+
+-- Set an integer value to the settings file.
+---@param key string
+---@param value integer
+function Engine.SettingsSetInt(key, value) end
+
+-- Set a number value to the settings file.
+---@param key string
+---@param value number
+function Engine.SettingsSetNumber(key, value) end
+
+-- Set a string value to the settings file.
+---@param key string
+---@param value string
+function Engine.SettingsSetString(key, value) end
+
+-- Write any pending settings changes to disk.
+function Engine.SaveSettings() end
+
 return Engine

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -741,6 +741,9 @@ end
 function ui.optionsWindow:close()
 	if not captureBindingWindow.isOpen then
 		ModalWindow.close(self)
+
+		-- Write any changed settings to disk
+		Engine.SaveSettings()
 		if Game.player then
 			Game.SetTimeAcceleration("1x")
 			Event.Queue("onPauseMenuClosed")

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -375,7 +375,7 @@ InputBindings::Action *Manager::AddActionBinding(const std::string &id, BindingG
 	group->bindings[id] = BindingGroup::ENTRY_ACTION;
 
 	// Load from the config
-	std::string config_str = m_config->String(id.c_str());
+	std::string config_str = m_config->String("Input", id.c_str());
 	if (!config_str.empty()) {
 		std::string_view str(config_str);
 		str >> binding;
@@ -393,7 +393,7 @@ InputBindings::Axis *Manager::AddAxisBinding(const std::string &id, BindingGroup
 	group->bindings[id] = BindingGroup::ENTRY_AXIS;
 
 	// Load from the config
-	std::string config_str = m_config->String(id.c_str());
+	std::string config_str = m_config->String("Input", id.c_str());
 	if (!config_str.empty()) {
 		std::string_view str(config_str);
 		str >> binding;
@@ -502,19 +502,13 @@ float Manager::JoystickAxisState(int joystick, int axis)
 void Manager::SetJoystickEnabled(bool state)
 {
 	joystickEnabled = state;
-	if (m_enableConfigSaving) {
-		m_config->SetInt("EnableJoystick", joystickEnabled);
-		m_config->Save();
-	}
+	m_config->SetInt("EnableJoystick", joystickEnabled);
 }
 
 void Manager::SetMouseYInvert(bool state)
 {
 	mouseYInvert = state;
-	if (m_enableConfigSaving) {
-		m_config->SetInt("InvertMouseY", mouseYInvert);
-		m_config->Save();
-	}
+	m_config->SetInt("InvertMouseY", mouseYInvert);
 }
 
 void Manager::GetMousePosition(int position[2])

--- a/src/Input.h
+++ b/src/Input.h
@@ -131,9 +131,6 @@ public:
 	// Call immediately after processing events, dispatches events to Action / Axis bindings.
 	void DispatchEvents();
 
-	// When enable is false, this prevents the input system from writing to the config file.
-	void EnableConfigSaving(bool enable) { m_enableConfigSaving = enable; }
-
 	BindingPage *GetBindingPage(const std::string &id) { return &bindingPages[id]; }
 	const std::map<std::string, BindingPage>& GetBindingPages() const { return bindingPages; }
 
@@ -235,7 +232,6 @@ private:
 
 	SDL_Window *m_window;
 	IniConfig *m_config;
-	bool m_enableConfigSaving;
 
 	std::map<SDL_Keycode, uint8_t> keyState;
 	int keyModState;

--- a/src/core/IniConfig.cpp
+++ b/src/core/IniConfig.cpp
@@ -24,8 +24,12 @@ void IniConfig::SetFloat(const std::string &section, const std::string &key, flo
 
 void IniConfig::SetString(const std::string &section, const std::string &key, const std::string &val)
 {
-	m_map[section][key] = val;
-	m_unsaved = true;
+	std::string &store = m_map[section][key];
+
+	if (store != val) {
+		store = val;
+		m_unsaved = true;
+	}
 }
 
 int IniConfig::Int(const std::string &section, const std::string &key, int defval) const
@@ -163,6 +167,10 @@ bool IniConfig::Save()
 		return false;
 	}
 
+	if (!Write(*m_fs, m_path)) {
+		return false;
+	}
+
 	m_unsaved = false;
-	return Write(*m_fs, m_path);
+	return true;
 }

--- a/src/core/IniConfig.cpp
+++ b/src/core/IniConfig.cpp
@@ -25,6 +25,7 @@ void IniConfig::SetFloat(const std::string &section, const std::string &key, flo
 void IniConfig::SetString(const std::string &section, const std::string &key, const std::string &val)
 {
 	m_map[section][key] = val;
+	m_unsaved = true;
 }
 
 int IniConfig::Int(const std::string &section, const std::string &key, int defval) const
@@ -162,5 +163,6 @@ bool IniConfig::Save()
 		return false;
 	}
 
+	m_unsaved = false;
 	return Write(*m_fs, m_path);
 }

--- a/src/core/IniConfig.h
+++ b/src/core/IniConfig.h
@@ -60,6 +60,8 @@ public:
 	bool HasEntry(const std::string &key) const { return HasEntry("", key); }
 	SectionMapType &GetSections() { return m_map; }
 
+	bool HasUnsavedChanges() const { return m_unsaved; }
+
 protected:
 	void Read(const FileSystem::FileData &data);
 
@@ -67,6 +69,7 @@ protected:
 
 	FileSystem::FileSourceFS *m_fs = nullptr;
 	std::string m_path;
+	bool m_unsaved = false;
 };
 
 #endif /* _INICONFIG_H */

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -325,7 +325,6 @@ static int l_engine_set_video_resolution(lua_State *l)
 	const int height = luaL_checkinteger(l, 2);
 	Pi::config->SetInt("ScrWidth", width);
 	Pi::config->SetInt("ScrHeight", height);
-	Pi::config->Save();
 	return 0;
 }
 
@@ -377,7 +376,6 @@ static int l_engine_set_fullscreen(lua_State *l)
 		return luaL_error(l, "SetFullscreen takes one boolean argument");
 	const bool fullscreen = lua_toboolean(l, 1);
 	Pi::config->SetInt("StartFullscreen", (fullscreen ? 1 : 0));
-	Pi::config->Save();
 	return 0;
 }
 
@@ -486,6 +484,13 @@ static int l_engine_settings_set_string(lua_State *l)
 	return 0;
 }
 
+static int l_engine_save_settings(lua_State *l)
+{
+	if (Pi::config->HasUnsavedChanges())
+		Pi::config->Save();
+	return 0;
+}
+
 static int l_engine_get_disable_screenshot_info(lua_State *l)
 {
 	LuaPush<bool>(l, Pi::config->Int("DisableScreenshotInfo") != 0);
@@ -498,7 +503,6 @@ static int l_engine_set_disable_screenshot_info(lua_State *l)
 		return luaL_error(l, "SetDisableScreenshotInfo takes one boolean argument");
 	const bool disable = LuaPull<bool>(l, 1);
 	Pi::config->SetInt("DisableScreenshotInfo", (disable ? 1 : 0));
-	Pi::config->Save();
 	return 0;
 }
 static int l_engine_get_vsync_enabled(lua_State *l)
@@ -514,7 +518,6 @@ static int l_engine_set_vsync_enabled(lua_State *l)
 
 	const bool vsync = lua_toboolean(l, 1);
 	Pi::config->SetInt("VSync", (vsync ? 1 : 0));
-	Pi::config->Save();
 
 	Pi::renderer->SetVSyncEnabled(vsync);
 	return 0;
@@ -532,7 +535,6 @@ static int l_engine_set_texture_compression_enabled(lua_State *l)
 		return luaL_error(l, "SetTextureCompressionEnabled takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("UseTextureCompression", (enabled ? 1 : 0));
-	Pi::config->Save();
 	return 0;
 }
 
@@ -546,7 +548,6 @@ static int l_engine_set_multisampling(lua_State *l)
 {
 	const int samples = luaL_checkinteger(l, 1);
 	Pi::config->SetInt("AntiAliasingMode", samples);
-	Pi::config->Save();
 	return 0;
 }
 
@@ -562,7 +563,6 @@ static int l_engine_set_planet_detail_level(lua_State *l)
 	if (level != Pi::detail.planets) {
 		Pi::detail.planets = level;
 		Pi::config->SetInt("DetailPlanets", level);
-		Pi::config->Save();
 		Pi::OnChangeDetailLevel();
 	}
 	return 0;
@@ -580,7 +580,6 @@ static int l_engine_set_city_detail_level(lua_State *l)
 	if (level != Pi::detail.cities) {
 		Pi::detail.cities = level;
 		Pi::config->SetInt("DetailCities", level);
-		Pi::config->Save();
 		Pi::OnChangeDetailLevel();
 	}
 	return 0;
@@ -598,7 +597,6 @@ static int l_engine_set_display_nav_tunnels(lua_State *l)
 		return luaL_error(l, "SetDisplayNavTunnels takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("DisplayNavTunnel", (enabled ? 1 : 0));
-	Pi::config->Save();
 	Pi::SetNavTunnelDisplayed(enabled);
 	return 0;
 }
@@ -615,7 +613,6 @@ static int l_engine_set_display_speed_lines(lua_State *l)
 		return luaL_error(l, "SetDisplaySpeedLines takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("SpeedLines", (enabled ? 1 : 0));
-	Pi::config->Save();
 	Pi::SetSpeedLinesDisplayed(enabled);
 	return 0;
 }
@@ -632,7 +629,6 @@ static int l_engine_set_cockpit_enabled(lua_State *l)
 		return luaL_error(l, "SetCockpitEnabled takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("EnableCockpit", (enabled ? 1 : 0));
-	Pi::config->Save();
 	if (Pi::player) {
 		Pi::player->InitCockpit();
 		if (enabled) Pi::player->OnCockpitActivated();
@@ -652,7 +648,6 @@ static int l_engine_set_aniso_enabled(lua_State *l)
 		return luaL_error(l, "SetAnisoEnabled takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("UseAnisotropicFiltering", (enabled ? 1 : 0));
-	Pi::config->Save();
 	return 0;
 }
 
@@ -668,7 +663,6 @@ static int l_engine_set_autosave_enabled(lua_State *l)
 		return luaL_error(l, "SetAutosaveEnabled takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("EnableAutosave", (enabled ? 1 : 0));
-	Pi::config->Save();
 	return 0;
 }
 static int l_engine_get_reset_view_on_hyperspace_exit(lua_State *l)
@@ -683,7 +677,6 @@ static int l_engine_set_reset_view_on_hyperspace_exit(lua_State *l)
 		return luaL_error(l, "SetResetViewOnHyperspaceExit takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("ResetViewOnHyperspaceExit", (enabled ? 1 : 0));
-	Pi::config->Save();
 	return 0;
 }
 
@@ -699,7 +692,6 @@ static int l_engine_set_display_hud_trails(lua_State *l)
 		return luaL_error(l, "SetDisplayHudTrails takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("HudTrails", (enabled ? 1 : 0));
-	Pi::config->Save();
 	Pi::SetHudTrailsDisplayed(enabled);
 	return 0;
 }
@@ -708,7 +700,6 @@ static int l_engine_set_amount_stars(lua_State *l)
 {
 	const float amount = Clamp(luaL_checknumber(l, 1), 0.0, 1.0);
 	Pi::config->SetFloat("AmountOfBackgroundStars", amount);
-	Pi::config->Save();
 	Pi::SetAmountBackgroundStars(amount);
 	return 0;
 }
@@ -723,7 +714,6 @@ static int l_engine_set_star_field_star_size_factor(lua_State *l)
 {
 	const float amount = Clamp(luaL_checknumber(l, 1), 0.0, 1.0);
 	Pi::config->SetFloat("StarFieldStarSizeFactor", amount);
-	Pi::config->Save();
 	Pi::SetStarFieldStarSizeFactor(amount);
 	return 0;
 }
@@ -740,7 +730,6 @@ static void set_master_volume(const bool muted, const float volume)
 	Sound::SetMasterVolume(volume);
 	Pi::config->SetFloat("MasterVolume", volume);
 	Pi::config->SetInt("MasterMuted", muted ? 1 : 0);
-	Pi::config->Save();
 }
 
 static void set_effects_volume(const bool muted, const float volume)
@@ -748,7 +737,6 @@ static void set_effects_volume(const bool muted, const float volume)
 	Sound::SetSfxVolume(muted ? 0.0f : volume);
 	Pi::config->SetFloat("SfxVolume", volume);
 	Pi::config->SetInt("SfxMuted", muted ? 1 : 0);
-	Pi::config->Save();
 }
 
 static void set_music_volume(const bool muted, const float volume)
@@ -757,7 +745,6 @@ static void set_music_volume(const bool muted, const float volume)
 	Pi::GetMusicPlayer().SetVolume(volume);
 	Pi::config->SetFloat("MusicVolume", volume);
 	Pi::config->SetInt("MusicMuted", muted ? 1 : 0);
-	Pi::config->Save();
 }
 
 static int l_engine_get_master_muted(lua_State *l)
@@ -856,7 +843,6 @@ static int l_engine_set_gpu_jobs_enabled(lua_State *l)
 		return luaL_error(l, "SetGpuJobsEnabled takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("EnableGPUJobs", (enabled ? 1 : 0));
-	Pi::config->Save();
 	return 0;
 }
 
@@ -871,7 +857,6 @@ static int l_engine_set_realistic_scattering(lua_State *l)
 	const int scattering = luaL_checkinteger(l, 1);
 	if (scattering != Pi::config->Int("RealisticScattering")) {
 		Pi::config->SetInt("RealisticScattering", scattering);
-		Pi::config->Save();
 		Pi::OnChangeDetailLevel();
 	}
 	return 0;
@@ -1123,7 +1108,6 @@ static int l_engine_set_confirm_quit(lua_State *l)
 		return luaL_error(l, "ConfirmQuit takes one boolean argument");
 	const bool confirm = lua_toboolean(l, 1);
 	Pi::config->SetInt("ConfirmQuit", (confirm ? 1 : 0));
-	Pi::config->Save();
 	return 0;
 }
 
@@ -1177,6 +1161,8 @@ void LuaEngine::Register()
 		{ "SettingsSetInt", l_engine_settings_set_int },
 		{ "SettingsSetFloat", l_engine_settings_set_number },
 		{ "SettingsSetString", l_engine_settings_set_string },
+
+		{ "SaveSettings", l_engine_save_settings },
 
 		{ "GetVideoModeList", l_engine_get_video_mode_list },
 		{ "GetMaximumAASamples", l_engine_get_maximum_aa_samples },

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -760,11 +760,9 @@ static int l_input_save_binding(lua_State *l)
 	if (action) {
 		buffer << *action->getAction();
 		Pi::config->SetString(action->id, buffer.str());
-		Pi::config->Save();
 	} else if (axis) {
 		buffer << *axis->getAxis();
 		Pi::config->SetString(axis->id, buffer.str());
-		Pi::config->Save();
 	}
 
 	return 0;
@@ -800,7 +798,6 @@ static int l_input_save_joystick_config(lua_State *l)
 	uint32_t joystick = LuaPull<uint32_t>(l, 1);
 	if (joystick < Input::GetJoysticks().size()) {
 		Input::SaveJoystickConfig(joystick, Pi::config);
-		Pi::config->Save();
 	}
 
 	return 0;
@@ -885,7 +882,6 @@ static int l_input_set_mouse_y_inverted(lua_State *l)
 		return luaL_error(l, "SetMouseYInverted takes one boolean argument");
 	const bool inverted = lua_toboolean(l, 1);
 	Pi::config->SetInt("InvertMouseY", (inverted ? 1 : 0));
-	Pi::config->Save();
 	Pi::input->SetMouseYInvert(inverted);
 	return 0;
 }
@@ -908,7 +904,6 @@ static int l_input_set_joystick_enabled(lua_State *l)
 		return luaL_error(l, "SetJoystickEnabled takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
 	Pi::config->SetInt("EnableJoystick", (enabled ? 1 : 0));
-	Pi::config->Save();
 	Pi::input->SetJoystickEnabled(enabled);
 	return 0;
 }

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -759,10 +759,10 @@ static int l_input_save_binding(lua_State *l)
 	std::ostringstream buffer;
 	if (action) {
 		buffer << *action->getAction();
-		Pi::config->SetString(action->id, buffer.str());
+		Pi::config->SetString("Input", action->id, buffer.str());
 	} else if (axis) {
 		buffer << *axis->getAxis();
-		Pi::config->SetString(axis->id, buffer.str());
+		Pi::config->SetString("Input", axis->id, buffer.str());
 	}
 
 	return 0;
@@ -881,7 +881,6 @@ static int l_input_set_mouse_y_inverted(lua_State *l)
 	if (lua_isnone(l, 1))
 		return luaL_error(l, "SetMouseYInverted takes one boolean argument");
 	const bool inverted = lua_toboolean(l, 1);
-	Pi::config->SetInt("InvertMouseY", (inverted ? 1 : 0));
 	Pi::input->SetMouseYInvert(inverted);
 	return 0;
 }
@@ -903,7 +902,6 @@ static int l_input_set_joystick_enabled(lua_State *l)
 	if (lua_isnone(l, 1))
 		return luaL_error(l, "SetJoystickEnabled takes one boolean argument");
 	const bool enabled = lua_toboolean(l, 1);
-	Pi::config->SetInt("EnableJoystick", (enabled ? 1 : 0));
 	Pi::input->SetJoystickEnabled(enabled);
 	return 0;
 }

--- a/src/lua/LuaLang.cpp
+++ b/src/lua/LuaLang.cpp
@@ -132,7 +132,6 @@ static int l_lang_set_current_language(lua_State *l)
 	if (std::find(langs.begin(), langs.end(), lang) == langs.end())
 		return luaL_error(l, "The language '%s' is not known.", lang.c_str());
 	Pi::config->SetString("Lang", lang);
-	Pi::config->Save();
 	// XXX change it!
 	return 0;
 }


### PR DESCRIPTION
This PR does two (mostly) related things:

- It prevents the config file from being written to disk on every toggle of a setting, only actually writing to disk when the settings menu is closed and there was a change in state.
- It moves the input bindings settings into their own `[Input]` section within the config file, preventing them from stomping (or being stomped by) actual user settings.

As we now have a generic settings interface for mods to read/write their own arbitrary settings, I consider it important to move the input bindings into their own section for the reason outlined above. It also has the nice side-effect of making config files neater and easier to read and debug.

Existing user-configured input bindings can be migrated with a simple cut-and-paste to the new `[Input]` section of the config file. It is unclear at this time whether the code has the information necessary to perform automatic migration of config files. The old bindings are not lost, but simply not read from anymore.