### PR TITLE
feat(ui): target radial support hyperspace clouds

### DIFF
--- a/data/pigui/libs/radial-menu.lua
+++ b/data/pigui/libs/radial-menu.lua
@@ -186,21 +186,13 @@ local radial_menu_actions_systembody = {
 function ui.openDefaultRadialMenu(id, body, pos, action_binding)
 	if body then
 		local actions = {}
-		for _,v in pairs(radial_menu_actions_all_bodies) do
-			table.insert(actions, v)
-		end
+		table.append(actions, radial_menu_actions_all_bodies)
 		if body:IsStation() then
-			for _,v in pairs(radial_menu_actions_station) do
-				table.insert(actions, v)
-			end
+			table.append(actions, radial_menu_actions_station)
 		elseif body:IsHyperspaceCloud() then
-			for _,v in pairs(radial_menu_actions_hyperspace_cloud) do
-				table.insert(actions, v)
-			end
+			table.append(actions, radial_menu_actions_hyperspace_cloud)
 		elseif body:GetSystemBody() then
-			for _,v in pairs(radial_menu_actions_systembody) do
-				table.insert(actions, v)
-			end
+			table.append(actions, radial_menu_actions_systembody)
 		end
 		ui.openRadialMenu(id, body, 1, defaultRadialMenuIconSize, actions, defaultRadialMenuPadding, pos, action_binding)
 	end


### PR DESCRIPTION
Implement a long-running TODO item in the target radial popup menu.

When the target is a departure hyperspace cloud and the player has a hyperspace cloud analyzer fitted, add a target option to set the players' hyperspace target to the destination system of the cloud.

TODO Items:
- [x] update the route planner to reflect setting the hyperspace destination.

----
Update route planner:

Trying to `require` the hyperjumpPlanner directly results in an error "too many C levels".

Possibly we can expose the hyperjump-planner via a "gettter" on the system map object or otherwise have a small utility class for managing hyperspace jumps. Basically it should be possible to do everything which the player can do manually using the interface via an API. This could be useful for various missions.

There should also be a helper function to convert a SystemPath object into one which can be passed as a hyperjump destination; currently there are several different ways of how to do this in the game code, such as:

```lua
local target = dest.GetSystemPathOnly()
```
or
```lua
local target = dest:IsBodyPath() and dest:GetSystemBody().nearestJumpable.path or dest:GetStarSystem().path
```

The latter seems to achieve what is actually desired, but this is IMHO too complex as boilerplate and also relies on internal knowledge of the various classes which is a code smell to me.