### PR TITLE
OpenAL audio backend

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -39,6 +39,7 @@ env:
     libassimp-dev
     libsdl2-dev
     libsdl2-image-dev
+    libopenal-dev
     ninja-build
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,8 +200,6 @@ else (WIN32)
 	)
 endif (WIN32)
 
-configure_file(buildopts.h.cmakein buildopts.h @ONLY)
-
 LIST(APPEND PIONEER_CXX_FILES ${FILESYSTEM_CXX_FILES})
 
 option(USE_PIONEER_THIRDPARTY "Use pioneer's thirdparty library repository." OFF)
@@ -273,6 +271,8 @@ elseif(NOT DEFINED CACHE{BUILD_WITH_OPENAL} AND OpenAL_FOUND)
 endif()
 
 set(FMT_INSTALL OFF CACHE BOOL "Enable install of libfmt" FORCE)
+
+configure_file(buildopts.h.cmakein buildopts.h @ONLY)
 
 add_subdirectory(contrib/lz4)
 add_subdirectory(contrib/fmt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,7 +381,6 @@ else()
 endif()
 
 target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt $<$<BOOL:${BUILD_WITH_OPENAL}>:OpenAL::OpenAL>)
-target_compile_definitions(pioneer-lib PUBLIC $<$<BOOL:${BUILD_WITH_OPENAL}>:PI_BUILD_WITH_OPENAL>)
 
 # Fallback available on most legacy systems
 set(PIONEER_GL_LINK_TARGET OpenGL::GL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,15 @@ endif (MSVC)
 find_package(Threads REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(OpenGL REQUIRED COMPONENTS OpenGL)
-find_package(OpenAL CONFIG REQUIRED)
+if(NOT TARGET OpenAL::OpenAL)
+	find_package(OpenAL)
+endif()
+if (CACHE{BUILD_WITH_OPENAL} AND NOT OpenAL_FOUND)
+	message(FATAL_ERROR "Requested BUILD_WITH_OPENAL=ON, but the library is not found")
+elseif(NOT DEFINED CACHE{BUILD_WITH_OPENAL} AND OpenAL_FOUND)
+	message(STATUS "Found OpenAL, building with support")
+	set(BUILD_WITH_OPENAL ON CACHE BOOL "Enable or disable support for OpenAL")
+endif()
 
 set(FMT_INSTALL OFF CACHE BOOL "Enable install of libfmt" FORCE)
 
@@ -372,7 +380,8 @@ else()
 	message(WARNING, "Python 3 not found; enums will not be scanned.")
 endif()
 
-target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt OpenAL::OpenAL)
+target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt $<$<BOOL:${BUILD_WITH_OPENAL}>:OpenAL::OpenAL>)
+target_compile_definitions(pioneer-lib PUBLIC $<$<BOOL:${BUILD_WITH_OPENAL}>:PI_BUILD_WITH_OPENAL>)
 
 # Fallback available on most legacy systems
 set(PIONEER_GL_LINK_TARGET OpenGL::GL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ endif (MSVC)
 find_package(Threads REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(OpenGL REQUIRED COMPONENTS OpenGL)
+find_package(OpenAL CONFIG REQUIRED)
 
 set(FMT_INSTALL OFF CACHE BOOL "Enable install of libfmt" FORCE)
 
@@ -371,7 +372,7 @@ else()
 	message(WARNING, "Python 3 not found; enums will not be scanned.")
 endif()
 
-target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt)
+target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt OpenAL::OpenAL)
 
 # Fallback available on most legacy systems
 set(PIONEER_GL_LINK_TARGET OpenGL::GL)

--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -63,7 +63,7 @@ questions are welcome anytime.
     libassimp-dev >= 5.0.1
     libsdl2-dev
     libsdl2-image-dev
-    libopenal-dev
+    libopenal-dev (optional, used for the OpenAL sound backend)
 
    If your platform doesn't have assimp 5, you'll need to build it from
    source. It's available in pioneer-thirdparty, see below.

--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -63,6 +63,7 @@ questions are welcome anytime.
     libassimp-dev >= 5.0.1
     libsdl2-dev
     libsdl2-image-dev
+    libopenal-dev
 
    If your platform doesn't have assimp 5, you'll need to build it from
    source. It's available in pioneer-thirdparty, see below.

--- a/buildopts.h.cmakein
+++ b/buildopts.h.cmakein
@@ -9,6 +9,7 @@
 #cmakedefine01 WITH_OBJECTVIEWER
 #cmakedefine01 WITH_DEVKEYS
 #cmakedefine01 HAS_FPE_OPS
+#cmakedefine01 BUILD_WITH_OPENAL
 #cmakedefine REMOTE_LUA_REPL
 
 #endif /* BUILDOPTS_H */

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -67,6 +67,10 @@
     "description": "",
     "message": "Attempt to repair hull"
   },
+  "AUDIO_BACKEND": {
+    "description": "Audio backend label in settings menu",
+    "message": "Audio Backend"
+  },
   "AUTOMATED_MESSAGE": {
     "description": "For comm messages from bots",
     "message": "AUTOMATED MESSAGE"
@@ -90,6 +94,14 @@
   "BACKWARD_ACCEL": {
     "description": "",
     "message": "Backward acceleration"
+  },
+  "BINAURAL_RENDERING": {
+    "description": "Label of the binaural rendering checkbox in the audio settings menu",
+    "message": "Binaural Rendering"
+  },
+  "BINAURAL_RENDERING_DESC": {
+    "description": "Tooltip of the binaural rendering checkbox in the audio settings menu",
+    "message": "When enabled, HRTF filters are applied to the audio output. Works best with headphones."
   },
   "BODY_IN_ROUTE": {
     "description": "Label indicating a star is part of a planned hyperjump route",

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -334,6 +334,8 @@ end, function (_, drawPopupFn)
 end)
 
 local function showSoundOptions()
+	local available_backends = Engine.GetAvailableSoundBackends()
+	local current_backend_id = Engine.GetSoundBackendId()
 	local masterMuted = Engine.GetMasterMuted()
 	local masterLevel = Engine.GetMasterVolume()*100
 	local musicMuted = Engine.GetMusicMuted()
@@ -342,6 +344,9 @@ local function showSoundOptions()
 	local effectsLevel = Engine.GetEffectsVolume()*100
 
 	local c
+
+	c,new_backend_id = combo("Audio Backend", current_backend_id - 1, available_backends)
+	if c then Engine.SetSoundBackend(new_backend_id + 1) end
 
 	c,masterMuted = checkbox(lui.MUTE.."##master", masterMuted)
 	if c then Engine.SetMasterMuted(masterMuted) end

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -335,7 +335,7 @@ end)
 
 local function showSoundOptions()
 	local available_backends = Engine.GetAvailableSoundBackends()
-	local current_backend_id = Engine.GetSoundBackendId()
+	local current_backend = Engine.GetSoundBackend()
 	local masterMuted = Engine.GetMasterMuted()
 	local masterLevel = Engine.GetMasterVolume()*100
 	local musicMuted = Engine.GetMusicMuted()
@@ -346,9 +346,17 @@ local function showSoundOptions()
 	local binaural_enabled = Engine.GetBinauralRendering()
 
 	local c
+	local new_backend_idx
+	local current_backend_idx
 
-	c,new_backend_id = combo(lui.AUDIO_BACKEND, current_backend_id - 1, available_backends)
-	if c then Engine.SetSoundBackend(new_backend_id + 1) end
+	for i, v in ipairs(available_backends) do
+		if v == current_backend then
+			current_backend_idx = i
+		end
+	end
+
+	c, new_backend_idx = combo(lui.AUDIO_BACKEND, current_backend_idx - 1, available_backends)
+	if c then Engine.SetSoundBackend(available_backends[new_backend_idx + 1]) end
 
 	c,masterMuted = checkbox(lui.MUTE.."##master", masterMuted)
 	if c then Engine.SetMasterMuted(masterMuted) end

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -342,10 +342,12 @@ local function showSoundOptions()
 	local musicLevel = Engine.GetMusicVolume()*100
 	local effectsMuted = Engine.GetEffectsMuted()
 	local effectsLevel = Engine.GetEffectsVolume()*100
+	local binaural_supported = Engine.IsBinauralRenderingSupported()
+	local binaural_enabled = Engine.GetBinauralRendering()
 
 	local c
 
-	c,new_backend_id = combo("Audio Backend", current_backend_id - 1, available_backends)
+	c,new_backend_id = combo(lui.AUDIO_BACKEND, current_backend_id - 1, available_backends)
 	if c then Engine.SetSoundBackend(new_backend_id + 1) end
 
 	c,masterMuted = checkbox(lui.MUTE.."##master", masterMuted)
@@ -365,6 +367,11 @@ local function showSoundOptions()
 	ui.sameLine()
 	c,effectsLevel = slider(lui.EFFECTS, effectsLevel, 0, 100)
 	if c then Engine.SetEffectsVolume(effectsLevel/100) end
+
+	if binaural_supported then
+		c,binaural_enabled = checkbox(lui.BINAURAL_RENDERING, binaural_enabled, lui.BINAURAL_RENDERING_DESC)
+		if c then Engine.SetBinauralRendering(binaural_enabled) end
+	end
 end
 
 local function showLanguageOptions()

--- a/msvc-defaults.cmake
+++ b/msvc-defaults.cmake
@@ -21,3 +21,11 @@ set(VORBISFILE_LIBRARIES ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/${M
 
 set(SIGCPP_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include/sigc++-2.0)
 set(SIGCPP_LIBRARIES optimized ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/${MSVC_ARCH}/vs2019/sigc-vc140-2_0.lib debug ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/${MSVC_ARCH}/vs2019/sigc-vc140-d-2_0.lib)
+
+add_library(OpenAL SHARED IMPORTED)
+add_library(OpenAL::OpenAL ALIAS OpenAL)
+set_target_properties(OpenAL PROPERTIES
+    IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/bin/${MSVC_ARCH}/vs2019/OpenAL32.dll
+    IMPORTED_IMPLIB ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/${MSVC_ARCH}/vs2019/libOpenAL32.dll.a
+)
+set(OpenAL_FOUND ON)

--- a/msvc-defaults.cmake
+++ b/msvc-defaults.cmake
@@ -28,4 +28,5 @@ set_target_properties(OpenAL PROPERTIES
     IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/bin/${MSVC_ARCH}/vs2019/OpenAL32.dll
     IMPORTED_IMPLIB ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/lib/${MSVC_ARCH}/vs2019/libOpenAL32.dll.a
 )
+target_include_directories(OpenAL INTERFACE ${CMAKE_SOURCE_DIR}/../pioneer-thirdparty/win32/include)
 set(OpenAL_FOUND ON)

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -4,7 +4,6 @@
 #include "GameConfig.h"
 #include "FileSystem.h"
 #include "core/OS.h"
-#include "sound/Sound.h"
 
 GameConfig::GameConfig(const map_string &override_)
 {
@@ -26,7 +25,7 @@ GameConfig::GameConfig(const map_string &override_)
 	map["DisplayNavTunnel"] = "0";
 	map["CompactRadar"] = "1";
 	map["ConfirmQuit"] = "1";
-	map["AudioBackendId"] = Sound::AudioBackend_Default;
+	map["AudioBackend"] = "";
 	map["MasterVolume"] = "0.8";
 	map["MusicVolume"] = "0.8";
 	map["MasterMuted"] = "0";

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -26,7 +26,7 @@ GameConfig::GameConfig(const map_string &override_)
 	map["DisplayNavTunnel"] = "0";
 	map["CompactRadar"] = "1";
 	map["ConfirmQuit"] = "1";
-	map["AudioBackendId"] = Sound::AudioBackend_SDL;
+	map["AudioBackendId"] = Sound::AudioBackend_Default;
 	map["MasterVolume"] = "0.8";
 	map["MusicVolume"] = "0.8";
 	map["MasterMuted"] = "0";

--- a/src/GameConfig.cpp
+++ b/src/GameConfig.cpp
@@ -4,6 +4,7 @@
 #include "GameConfig.h"
 #include "FileSystem.h"
 #include "core/OS.h"
+#include "sound/Sound.h"
 
 GameConfig::GameConfig(const map_string &override_)
 {
@@ -25,11 +26,13 @@ GameConfig::GameConfig(const map_string &override_)
 	map["DisplayNavTunnel"] = "0";
 	map["CompactRadar"] = "1";
 	map["ConfirmQuit"] = "1";
+	map["AudioBackendId"] = Sound::AudioBackend_SDL;
 	map["MasterVolume"] = "0.8";
 	map["MusicVolume"] = "0.8";
 	map["MasterMuted"] = "0";
 	map["SfxMuted"] = "0";
 	map["MusicMuted"] = "0";
+	map["BinauralRendering"] = "0";
 	map["SectorViewXRotation"] = "-10.0";
 	map["SectorViewZRotation"] = "0";
 	map["SectorViewZoom"] = "2.0";

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -538,6 +538,7 @@ void StartupScreen::Start()
 		Sound::SetMasterVolume(Pi::config->Float("MasterVolume"));
 		Sound::SetSfxVolume(Pi::config->Float("SfxVolume"));
 		Pi::GetMusicPlayer().SetVolume(Pi::config->Float("MusicVolume"));
+		Sound::EnableBinaural(Pi::config->Int("BinauralRendering"));
 
 		Sound::Pause(0);
 		if (Pi::config->Int("MasterMuted")) Sound::Pause(1);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -534,7 +534,7 @@ void StartupScreen::Start()
 		if (Pi::GetApp()->HeadlessMode() || Pi::config->Int("DisableSound"))
 			return;
 
-		Sound::Init(Pi::config->Int("AudioBackendId", Sound::AudioBackend_Default));
+		Sound::Init(Pi::config->String("AudioBackend"));
 		Pi::GetMusicPlayer().SetVolume(Pi::config->Float("MusicVolume"));
 		if (Pi::config->Int("MusicMuted")) Pi::GetMusicPlayer().SetEnabled(false);
 	});

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -534,7 +534,7 @@ void StartupScreen::Start()
 		if (Pi::GetApp()->HeadlessMode() || Pi::config->Int("DisableSound"))
 			return;
 
-		Sound::Init(Pi::config->Int("AudioBackendId", Sound::AudioBackend_OpenAL));
+		Sound::Init(Pi::config->Int("AudioBackendId", Sound::AudioBackend_Default));
 		Sound::SetMasterVolume(Pi::config->Float("MasterVolume"));
 		Sound::SetSfxVolume(Pi::config->Float("SfxVolume"));
 		Pi::GetMusicPlayer().SetVolume(Pi::config->Float("MusicVolume"));

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -534,7 +534,7 @@ void StartupScreen::Start()
 		if (Pi::GetApp()->HeadlessMode() || Pi::config->Int("DisableSound"))
 			return;
 
-		Sound::Init();
+		Sound::Init(Pi::config->Int("AudioBackendId", Sound::AudioBackend_OpenAL));
 		Sound::SetMasterVolume(Pi::config->Float("MasterVolume"));
 		Sound::SetSfxVolume(Pi::config->Float("SfxVolume"));
 		Pi::GetMusicPlayer().SetVolume(Pi::config->Float("MusicVolume"));

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -535,14 +535,7 @@ void StartupScreen::Start()
 			return;
 
 		Sound::Init(Pi::config->Int("AudioBackendId", Sound::AudioBackend_Default));
-		Sound::SetMasterVolume(Pi::config->Float("MasterVolume"));
-		Sound::SetSfxVolume(Pi::config->Float("SfxVolume"));
 		Pi::GetMusicPlayer().SetVolume(Pi::config->Float("MusicVolume"));
-		Sound::EnableBinaural(Pi::config->Int("BinauralRendering"));
-
-		Sound::Pause(0);
-		if (Pi::config->Int("MasterMuted")) Sound::Pause(1);
-		if (Pi::config->Int("SfxMuted")) Sound::SetSfxVolume(0.f);
 		if (Pi::config->Int("MusicMuted")) Pi::GetMusicPlayer().SetEnabled(false);
 	});
 

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -715,6 +715,7 @@ void MainMenu::Update(float deltaTime)
 
 	Pi::renderer->ClearDepthBuffer();
 	Pi::pigui->Render();
+	Sound::Update(deltaTime);
 
 	if (Pi::game) {
 		RequestEndLifecycle();
@@ -1091,6 +1092,7 @@ void GameLoop::Update(float deltaTime)
 	}
 
 	Pi::GetMusicPlayer().Update();
+	Sound::Update(deltaTime);
 
 	perfInfoDisplay->Update(deltaTime);
 	perfInfoDisplay->UpdateCounter(PiGui::PerfInfo::COUNTER_PHYS, phys_time);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -306,7 +306,7 @@ void Player::StaticUpdate(const float timeStep)
 
 	if (playCreak) {
 		if (!m_creakSound.IsPlaying()) {
-			float creakVol = fmin(float((m_atmosJerk.Length() - 50) * 0.05f), 0.3f);
+			float creakVol = fmax(0.f, fmin(float((m_atmosJerk.Length() - 50) * 0.05f), 0.3f));
 			m_creakSound.Play("metal_creaking", creakVol, creakVol, Sound::OP_REPEAT);
 			m_creakSound.VolumeAnimate(creakVol, creakVol, 0.3f, 0.3f);
 		}

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -974,7 +974,7 @@ void Ship::DoThrusterSounds() const
 
 	// XXX sound logic could be part of a bigger class (ship internal sounds)
 	/* Ship engine noise. less loud inside */
-	float v_env = (Pi::game->GetWorldView()->shipView->IsExteriorView() ? 1.0f : 0.5f) * Sound::GetSfxVolume();
+	float v_env = (Pi::game->GetWorldView()->shipView->IsExteriorView() ? 1.0f : 0.5f);
 	static Sound::Event sndev;
 	float volBoth = 0.0f;
 	volBoth += 0.5f * fabs(m_propulsion->GetLinThrusterState().y);

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -611,13 +611,11 @@ static int l_engine_get_available_sound_backends(lua_State *l)
 {
 	const Sound::BackendFlags backends = Sound::GetAvailableBackends();
 	lua_newtable(l);
-	if (backends & Sound::AudioBackend_SDL)
-	{
+	if (backends & Sound::AudioBackend_SDL) {
 		lua_pushstring(l, "SDL");
 		lua_rawseti(l, -2, 1);
 	}
-	if (backends & Sound::AudioBackend_OpenAL)
-	{
+	if (backends & Sound::AudioBackend_OpenAL) {
 		lua_pushstring(l, "OpenAL");
 		lua_rawseti(l, -2, 2);
 	}
@@ -742,6 +740,28 @@ static int l_engine_set_music_volume(lua_State *l)
 {
 	const float volume = Clamp(luaL_checknumber(l, 1), 0.0, 1.0);
 	set_music_volume(Pi::config->Int("MusicMuted") != 0, volume);
+	return 0;
+}
+
+static int l_engine_is_binaural_supported(lua_State *l)
+{
+	lua_pushboolean(l, Sound::IsBinauralSupported());
+	return 1;
+}
+
+static int l_engine_get_binaural_rendering(lua_State *l)
+{
+	lua_pushboolean(l, Pi::config->Int("BinauralRendering"));
+	return 1;
+}
+
+static int l_engine_set_binaural_rendering(lua_State *l)
+{
+	if (lua_isnone(l, 1))
+		return luaL_error(l, "SetBinauralRendering takes one boolean argument");
+	const bool enabled = lua_toboolean(l, 1);
+	Sound::EnableBinaural(enabled);
+	Pi::config->SetInt("BinauralRendering", enabled ? 1 : 0);
 	return 0;
 }
 
@@ -1094,6 +1114,9 @@ void LuaEngine::Register()
 		{ "SetMusicMuted", l_engine_set_music_muted },
 		{ "GetMusicVolume", l_engine_get_music_volume },
 		{ "SetMusicVolume", l_engine_set_music_volume },
+		{ "IsBinauralRenderingSupported", l_engine_is_binaural_supported },
+		{ "GetBinauralRendering", l_engine_get_binaural_rendering },
+		{ "SetBinauralRendering", l_engine_set_binaural_rendering },
 
 		{ "CanBrowseUserFolder", l_get_can_browse_user_folders },
 		{ "OpenBrowseUserFolder", l_browse_user_folders },

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -628,10 +628,14 @@ static int l_engine_get_sound_backend_id(lua_State *l)
 	return 1;
 }
 
+static void set_music_volume(const bool muted, const float volume);
+
 static int l_engine_set_sound_backend(lua_State *l)
 {
 	const Sound::BackendId id = luaL_checkinteger(l, 1);
 	Sound::Init(id);
+	Pi::GetMusicPlayer().PlayAgain();
+	set_music_volume(Pi::config->Int("MusicMuted") != 0, Pi::config->Float("MusicVolume"));
 	Pi::config->SetInt("AudioBackendId", Sound::GetBackendId());
 	return 0;
 }

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -609,22 +609,21 @@ static int l_engine_get_star_field_star_size_factor(lua_State *l)
 
 static int l_engine_get_available_sound_backends(lua_State *l)
 {
-	const Sound::BackendFlags backends = Sound::GetAvailableBackends();
+	const std::vector<std::string_view> backends = Sound::GetAvailableBackends();
 	lua_newtable(l);
-	if (backends & Sound::AudioBackend_SDL) {
-		lua_pushstring(l, "SDL");
-		lua_rawseti(l, -2, 1);
-	}
-	if (backends & Sound::AudioBackend_OpenAL) {
-		lua_pushstring(l, "OpenAL");
-		lua_rawseti(l, -2, 2);
+	int idx = 1;
+	for (std::string_view backend : backends)
+	{
+		lua_pushlstring(l, backend.data(), backend.size());
+		lua_rawseti(l, -2, idx++);
 	}
 	return 1;
 }
 
-static int l_engine_get_sound_backend_id(lua_State *l)
+static int l_engine_get_sound_backend(lua_State *l)
 {
-	lua_pushnumber(l, Sound::GetBackendId());
+	std::string_view backend = Sound::GetBackend();
+	lua_pushlstring(l, backend.data(), backend.size());
 	return 1;
 }
 
@@ -632,11 +631,10 @@ static void set_music_volume(const bool muted, const float volume);
 
 static int l_engine_set_sound_backend(lua_State *l)
 {
-	const Sound::BackendId id = luaL_checkinteger(l, 1);
-	Sound::Init(id);
+	const std::string backend = luaL_checkstring(l, 1);
+	Sound::Init(backend);
 	Pi::GetMusicPlayer().PlayAgain();
-	set_music_volume(Pi::config->Int("MusicMuted") != 0, Pi::config->Float("MusicVolume"));
-	Pi::config->SetInt("AudioBackendId", Sound::GetBackendId());
+	Pi::config->SetString("AudioBackend", backend);
 	return 0;
 }
 
@@ -1103,9 +1101,8 @@ void LuaEngine::Register()
 		{ "GetStarFieldStarSizeFactor", l_engine_get_star_field_star_size_factor },
 
 		{ "GetAvailableSoundBackends", l_engine_get_available_sound_backends },
-		{ "GetSoundBackendId", l_engine_get_sound_backend_id },
+		{ "GetSoundBackend", l_engine_get_sound_backend },
 		{ "SetSoundBackend", l_engine_set_sound_backend },
-		{ "GetAvailableSoundBackends", l_engine_get_available_sound_backends },
 		{ "GetMasterMuted", l_engine_get_master_muted },
 		{ "SetMasterMuted", l_engine_set_master_muted },
 		{ "GetMasterVolume", l_engine_get_master_volume },

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -607,6 +607,37 @@ static int l_engine_get_star_field_star_size_factor(lua_State *l)
 	return 1;
 }
 
+static int l_engine_get_available_sound_backends(lua_State *l)
+{
+	const Sound::BackendFlags backends = Sound::GetAvailableBackends();
+	lua_newtable(l);
+	if (backends & Sound::AudioBackend_SDL)
+	{
+		lua_pushstring(l, "SDL");
+		lua_rawseti(l, -2, 1);
+	}
+	if (backends & Sound::AudioBackend_OpenAL)
+	{
+		lua_pushstring(l, "OpenAL");
+		lua_rawseti(l, -2, 2);
+	}
+	return 1;
+}
+
+static int l_engine_get_sound_backend_id(lua_State *l)
+{
+	lua_pushnumber(l, Sound::GetBackendId());
+	return 1;
+}
+
+static int l_engine_set_sound_backend(lua_State *l)
+{
+	const Sound::BackendId id = luaL_checkinteger(l, 1);
+	Sound::Init(id);
+	Pi::config->SetInt("AudioBackendId", Sound::GetBackendId());
+	return 0;
+}
+
 static void set_master_volume(const bool muted, const float volume)
 {
 	Sound::Pause(muted || is_zero_exact(volume));
@@ -1047,6 +1078,10 @@ void LuaEngine::Register()
 		{ "SetStarFieldStarSizeFactor", l_engine_set_star_field_star_size_factor },
 		{ "GetStarFieldStarSizeFactor", l_engine_get_star_field_star_size_factor },
 
+		{ "GetAvailableSoundBackends", l_engine_get_available_sound_backends },
+		{ "GetSoundBackendId", l_engine_get_sound_backend_id },
+		{ "SetSoundBackend", l_engine_set_sound_backend },
+		{ "GetAvailableSoundBackends", l_engine_get_available_sound_backends },
 		{ "GetMasterMuted", l_engine_get_master_muted },
 		{ "SetMasterMuted", l_engine_set_master_muted },
 		{ "GetMasterVolume", l_engine_get_master_volume },

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -627,8 +627,6 @@ static int l_engine_get_sound_backend(lua_State *l)
 	return 1;
 }
 
-static void set_music_volume(const bool muted, const float volume);
-
 static int l_engine_set_sound_backend(lua_State *l)
 {
 	const std::string backend = luaL_checkstring(l, 1);

--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -1,6 +1,8 @@
 // Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+#ifdef PI_BUILD_WITH_OPENAL
+
 #include "AlAudioBackend.h"
 #include "Pi.h"
 #include "Player.h"
@@ -460,3 +462,5 @@ void Sound::AlAudioBackend::SoundEvent::SetTargetGain(float gainL, float gainR, 
 	CHECK_OPENAL_ERROR(alGetSource3f, source, AL_POSITION, &current_pan, &y, &z);
 	pan_rate = rate * (target_pan - current_pan);
 }
+
+#endif

--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #include "buildopts.h"

--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -292,6 +292,10 @@ Sound::AlAudioBackend::SoundEvent::SoundEvent(const Sample &sample) :
 		FillBuffer(1);
 		CHECK_OPENAL_ERROR(alSourceQueueBuffers, source, 2, &buffers[0]);
 	}
+	if (is_music)
+	{
+		CHECK_OPENAL_ERROR(alSourcei, source, AL_DIRECT_CHANNELS_SOFT, AL_TRUE);
+	}
 }
 
 Sound::AlAudioBackend::SoundEvent::~SoundEvent()

--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -1,0 +1,437 @@
+// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "AlAudioBackend.h"
+#include "Pi.h"
+#include "Player.h"
+#include "core/Log.h"
+
+#include <algorithm>
+#include <utility>
+
+#define CHECK_OPENAL_ERROR_IMPL(file, line, fn, ...)                                                                                    \
+	do {                                                                                                                                \
+		fn(__VA_ARGS__);                                                                                                                \
+		if (auto error = alGetError(); error) {                                                                                         \
+			throw std::runtime_error("OpenAL error invoking " #fn "(" file ":" + std::to_string(line) + "): " + std::to_string(error)); \
+		}                                                                                                                               \
+	} while (0)
+
+#define CHECK_OPENAL_ERROR(fn, ...) CHECK_OPENAL_ERROR_IMPL(__FILE__, __LINE__, fn, __VA_ARGS__)
+
+namespace {
+	float calculate_pan(float left, float right)
+	{
+		if (left == 0.f && right == 0.f)
+		{
+			return 0.f;
+		}
+		return (right - left) / (right + left);
+	}
+} //namespace
+
+Sound::AlAudioBackend::AlAudioBackend()
+{
+	m_device = alcOpenDevice(nullptr);
+	if (!m_device) {
+		Error("Could not open OpenAL device");
+		throw std::exception();
+	}
+
+	m_context = alcCreateContext(m_device, nullptr);
+	if (!m_context) {
+		Error("Could not create OpenAL context");
+		throw std::exception();
+	}
+
+	const auto success = alcMakeContextCurrent(m_context);
+	if (!success) {
+		Error("Could not make OpenAL context current");
+		throw std::exception();
+	}
+
+	CHECK_OPENAL_ERROR(alDistanceModel, AL_INVERSE_DISTANCE_CLAMPED);
+	CHECK_OPENAL_ERROR(alSpeedOfSound, 1000.f);
+
+	Output("Initialized OpenAL audio backend");
+}
+
+Sound::AlAudioBackend::~AlAudioBackend()
+{
+	m_events.clear();
+	alcDestroyContext(m_context);
+	m_context = nullptr;
+	alcCloseDevice(m_device);
+	m_device = nullptr;
+	Output("Destroyed OpenAL audio backend");
+}
+
+void Sound::AlAudioBackend::DestroyAllEvents()
+{
+	m_events.clear();
+}
+
+void Sound::AlAudioBackend::DestroyAllEventsExceptMusic()
+{
+	std::vector<eventid> events_to_remove;
+	for (auto& [id, ev] : m_events)
+	{
+		if (!ev.IsMusic())
+		{
+			events_to_remove.push_back(id);
+		}
+	}
+	for (auto id : events_to_remove)
+	{
+		m_events.erase(id);
+	}
+}
+
+bool Sound::AlAudioBackend::EventStop(eventid eid)
+{
+	return m_events.erase(eid) > 0;
+}
+
+bool Sound::AlAudioBackend::IsEventPlaying(eventid eid)
+{
+	auto it = m_events.find(eid);
+	if (it == m_events.end()) {
+		return false;
+	}
+	return !it->second.IsDone();
+}
+
+bool Sound::AlAudioBackend::EventSetOp(eventid eid, Op op)
+{
+	auto it = m_events.find(eid);
+	if (it == m_events.end()) {
+		return false;
+	}
+	it->second.SetOp(op);
+	return true;
+}
+
+bool Sound::AlAudioBackend::EventVolumeAnimate(eventid eid, const float targetVol1, const float targetVol2, const float dv_dt1, const float /*dv_dt2*/)
+{
+	auto it = m_events.find(eid);
+	if (it == m_events.end()) {
+		return false;
+	}
+	it->second.SetTargetGain(targetVol1, targetVol2, dv_dt1);
+	return true;
+}
+
+bool Sound::AlAudioBackend::EventSetVolume(eventid eid, const float vol_left, const float vol_right)
+{
+	auto it = m_events.find(eid);
+	if (it == m_events.end()) {
+		return false;
+	}
+	it->second.SetGain(vol_left, vol_right);
+	return true;
+}
+
+void Sound::AlAudioBackend::Pause(int on)
+{
+	for (auto& [id, ev] : m_events)
+	{
+		ALint state;
+		CHECK_OPENAL_ERROR(alGetSourcei, ev.GetSource(), AL_SOURCE_STATE, &state);
+
+		if (on && state == AL_PLAYING)
+		{
+			CHECK_OPENAL_ERROR(alSourcePause, ev.GetSource());
+		}
+		else if (!on && state == AL_PAUSED)
+		{
+			CHECK_OPENAL_ERROR(alSourcePlay, ev.GetSource());
+		}
+	}
+}
+
+Sound::AudioBackend::eventid Sound::AlAudioBackend::Play(std::string_view key, const float volume_left, const float volume_right, const Op op)
+{
+	const std::string key_str(key);
+	auto sample_it = m_samples.find(key_str);
+	if (sample_it == m_samples.end()) {
+		Output("Could not find %s in samples", key_str.c_str());
+		return 0;
+	}
+	auto it = m_events.emplace(++next_event_id, sample_it->second).first;
+	it->second.SetOp(op);
+	it->second.SetGain(volume_left * m_sfxVolume, volume_right * m_sfxVolume);
+	CHECK_OPENAL_ERROR(alSourcePlay, it->second.GetSource());
+	return it->first;
+}
+
+void Sound::AlAudioBackend::BodyMakeNoise(const Body *b, std::string_view key, float vol)
+{
+	constexpr double distance_threshold = 3000;
+	auto pos = b->GetPositionRelTo(Pi::player);
+	pos = pos * Pi::player->GetOrient();
+
+	if (pos.Length() > distance_threshold) {
+		return;
+	}
+
+	const std::string key_str(key);
+	auto sample_it = m_samples.find(key_str);
+	if (sample_it == m_samples.end()) {
+		Output("Could not find %s in samples", key_str.c_str());
+		return;
+	}
+
+	auto it = m_events.emplace(++next_event_id, sample_it->second).first;
+	it->second.SetGain(m_sfxVolume);
+
+	CHECK_OPENAL_ERROR(alSource3f, it->second.GetSource(), AL_POSITION, pos.x, pos.y, pos.z);
+
+	auto vel = b->GetVelocityRelTo(Pi::player);
+	vel = vel * Pi::player->GetOrient();
+	CHECK_OPENAL_ERROR(alSource3f, it->second.GetSource(), AL_VELOCITY, vel.x, vel.y, vel.z);
+
+	CHECK_OPENAL_ERROR(alSourcei, it->second.GetSource(), AL_REFERENCE_DISTANCE, 10);
+	CHECK_OPENAL_ERROR(alSourcef, it->second.GetSource(), AL_ROLLOFF_FACTOR, 0.1f);
+	CHECK_OPENAL_ERROR(alSourcePlay, it->second.GetSource());
+}
+
+void Sound::AlAudioBackend::SetMasterVolume(float vol)
+{
+	CHECK_OPENAL_ERROR(alListenerf, AL_GAIN, vol);
+}
+
+float Sound::AlAudioBackend::GetMasterVolume()
+{
+	float vol;
+	CHECK_OPENAL_ERROR(alGetListenerf, AL_GAIN, &vol);
+	return vol;
+}
+
+void Sound::AlAudioBackend::SetSfxVolume(float vol)
+{
+	m_sfxVolume = vol;
+}
+
+float Sound::AlAudioBackend::GetSfxVolume()
+{
+	return m_sfxVolume;
+}
+
+void Sound::AlAudioBackend::AddSample(std::string_view key, Sample &&sample)
+{
+	m_samples[std::string(key)] = std::move(sample);
+}
+
+void Sound::AlAudioBackend::Update(float delta_t)
+{
+	std::vector<eventid> events_to_remove;
+	for (auto &[id, ev] : m_events) {
+		ev.Update(delta_t);
+		if (ev.IsDone()) {
+			events_to_remove.push_back(id);
+		}
+	}
+	for (auto id : events_to_remove) {
+		m_events.erase(id);
+	}
+}
+
+Sound::AlAudioBackend::SoundEvent::SoundEvent(const Sample &sample) :
+	channels(sample.channels), samplerate(sample.samplerate), target_gain(1.F), target_pan(0.F), fade_rate(0.F), pan_rate(0.F), streaming_finished(false), is_music(sample.isMusic), op(0)
+{
+	CHECK_OPENAL_ERROR(alGenSources, 1, &source);
+	CHECK_OPENAL_ERROR(alSourcei, source, AL_REFERENCE_DISTANCE, 1);
+	if (!sample.buf.empty()) {
+		CHECK_OPENAL_ERROR(alGenBuffers, 1, &buffers[0]);
+		CHECK_OPENAL_ERROR(alBufferData,
+			buffers[0],
+			sample.channels == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16,
+			sample.buf.data(),
+			sample.buf.size() * sizeof(sample.buf[0]),
+			sample.samplerate);
+		CHECK_OPENAL_ERROR(alSourcei, source, AL_BUFFER, buffers[0]);
+	} else {
+		CHECK_OPENAL_ERROR(alGenBuffers, 2, &buffers[0]);
+		oggv = std::make_unique<OggVorbis_File>();
+		ogg_data_stream.Reset(FileSystem::gameDataFiles.ReadFile(sample.path));
+		if (ov_open_callbacks(&ogg_data_stream, oggv.get(), nullptr, 0, OggFileDataStream::CALLBACKS) < 0) {
+			Output("Vorbis could not understand '%s'", sample.path.c_str());
+			throw std::exception();
+		}
+		FillBuffer(0);
+		FillBuffer(1);
+		CHECK_OPENAL_ERROR(alSourceQueueBuffers, source, 2, &buffers[0]);
+	}
+}
+
+Sound::AlAudioBackend::SoundEvent::~SoundEvent()
+{
+	if (source != 0) {
+		alDeleteSources(1, &source);
+	}
+	source = 0;
+	if (buffers[0] != 0) {
+		alDeleteBuffers(1, &buffers[0]);
+		buffers[0] = 0;
+	}
+	if (buffers[1] != 0) {
+		alDeleteBuffers(1, &buffers[1]);
+		buffers[1] = 0;
+	}
+	if (oggv) {
+		ov_clear(oggv.get());
+		oggv = nullptr;
+	}
+}
+
+Sound::AlAudioBackend::SoundEvent::SoundEvent(SoundEvent &&other)
+{
+	channels = other.channels;
+	samplerate = other.samplerate;
+	target_gain = other.target_gain;
+	fade_rate = other.fade_rate;
+	streaming_finished = other.streaming_finished;
+	is_music = other.is_music;
+	op = other.op;
+	buffers[0] = std::exchange(other.buffers[0], 0);
+	buffers[1] = std::exchange(other.buffers[1], 0);
+	source = std::exchange(other.source, 0);
+	playing_buffer_idx = other.playing_buffer_idx;
+	oggv = std::exchange(other.oggv, nullptr);
+	ogg_data_stream = std::move(other.ogg_data_stream);
+}
+
+Sound::AlAudioBackend::SoundEvent &Sound::AlAudioBackend::SoundEvent::operator=(SoundEvent &&other)
+{
+	channels = other.channels;
+	samplerate = other.samplerate;
+	target_gain = other.target_gain;
+	fade_rate = other.fade_rate;
+	streaming_finished = other.streaming_finished;
+	is_music = other.is_music;
+	op = other.op;
+	buffers[0] = std::exchange(other.buffers[0], 0);
+	buffers[1] = std::exchange(other.buffers[1], 0);
+	source = std::exchange(other.source, 0);
+	playing_buffer_idx = other.playing_buffer_idx;
+	oggv = std::exchange(other.oggv, nullptr);
+	ogg_data_stream = std::move(other.ogg_data_stream);
+	return *this;
+}
+
+bool Sound::AlAudioBackend::SoundEvent::IsDone() const
+{
+	ALint state;
+	CHECK_OPENAL_ERROR(alGetSourcei, source, AL_SOURCE_STATE, &state);
+	return state == AL_STOPPED;
+}
+
+void Sound::AlAudioBackend::SoundEvent::FillBuffer(int idx)
+{
+	constexpr int buffer_bytes = 44100 * 2;
+	char data[buffer_bytes]{};
+	int bitstream{};
+	int remaining_bytes = buffer_bytes;
+	while (remaining_bytes > 0) {
+		const int bytes_read = ov_read(oggv.get(), &data[0] + buffer_bytes - remaining_bytes,
+			remaining_bytes, 0, 2, 1, &bitstream);
+		if (bytes_read == 0) { // EOF
+			if (op & OP_REPEAT) {
+				const auto result = ov_pcm_seek(oggv.get(), 0);
+				if (result != 0) {
+					throw std::exception();
+				}
+			} else {
+				streaming_finished = true;
+				break;
+			}
+		}
+		remaining_bytes -= bytes_read;
+	}
+	CHECK_OPENAL_ERROR(alBufferData,
+		buffers[idx],
+		channels == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16,
+		data,
+		buffer_bytes - remaining_bytes,
+		samplerate);
+}
+
+void Sound::AlAudioBackend::SoundEvent::Update(float delta_t)
+{
+	if (!streaming_finished && oggv) // streaming
+	{
+		ALint num_processed_buffers;
+		CHECK_OPENAL_ERROR(alGetSourcei, source, AL_BUFFERS_PROCESSED, &num_processed_buffers);
+		if (num_processed_buffers > 0) {
+			CHECK_OPENAL_ERROR(alSourceUnqueueBuffers, source, 1, &buffers[playing_buffer_idx]);
+			FillBuffer(playing_buffer_idx);
+			CHECK_OPENAL_ERROR(alSourceQueueBuffers, source, 1, &buffers[playing_buffer_idx]);
+			playing_buffer_idx = 1 - playing_buffer_idx;
+		}
+	}
+	if (fade_rate != 0.f) {
+		float current_gain, current_pan, y, z;
+		CHECK_OPENAL_ERROR(alGetSourcef, source, AL_GAIN, &current_gain);
+		CHECK_OPENAL_ERROR(alGetSource3f, source, AL_POSITION, &current_pan, &y, &z);
+		float new_gain = current_gain + fade_rate * delta_t;
+		float new_pan = current_pan + pan_rate * delta_t;
+		if ((fade_rate > 0.F && new_gain >= target_gain) || (fade_rate < 0.F && new_gain < target_gain)) {
+			if (op & OP_STOP_AT_TARGET_VOLUME) {
+				CHECK_OPENAL_ERROR(alSourceStop, source);
+				return;
+			}
+			new_gain = target_gain;
+			new_pan = target_pan;
+			fade_rate = 0.f;
+			pan_rate = 0.f;
+		}
+		CHECK_OPENAL_ERROR(alSourcef, source, AL_GAIN, new_gain);
+		CHECK_OPENAL_ERROR(alSource3f, source, AL_POSITION, new_pan, y, z);
+	}
+}
+
+void Sound::AlAudioBackend::SoundEvent::SetGain(float gain)
+{
+	SetGain(gain, gain);
+}
+
+void Sound::AlAudioBackend::SoundEvent::SetGain(float gainL, float gainR)
+{
+	target_gain = (gainL + gainR) * 0.5f;
+	target_pan = calculate_pan(gainL, gainR);
+	fade_rate = 0.f;
+	pan_rate = 0.f;
+	CHECK_OPENAL_ERROR(alSourcef, source, AL_GAIN, target_gain);
+	if (target_pan != 0.f) {
+		CHECK_OPENAL_ERROR(alSource3f, source, AL_POSITION, target_pan, 0.f, 0.f);
+	}
+}
+
+void Sound::AlAudioBackend::SoundEvent::SetOp(Op new_op)
+{
+	op = new_op;
+	if (oggv) // streamed shouldn't use AL_LOOPING
+	{
+		return;
+	}
+	if (op & OP_REPEAT) {
+		CHECK_OPENAL_ERROR(alSourcei, source, AL_LOOPING, AL_TRUE);
+	} else {
+		CHECK_OPENAL_ERROR(alSourcei, source, AL_LOOPING, AL_FALSE);
+	}
+}
+
+void Sound::AlAudioBackend::SoundEvent::SetTargetGain(float gain, float rate)
+{
+	SetTargetGain(gain, gain, rate);
+}
+
+void Sound::AlAudioBackend::SoundEvent::SetTargetGain(float gainL, float gainR, float rate)
+{
+	target_gain = (gainL + gainR) * 0.5f;
+	fade_rate = rate;
+	target_pan = calculate_pan(gainL, gainR);
+	float current_pan, y, z;
+	CHECK_OPENAL_ERROR(alGetSource3f, source, AL_POSITION, &current_pan, &y, &z);
+	pan_rate = rate * (target_pan - current_pan);
+}

--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -422,7 +422,8 @@ void Sound::AlAudioBackend::SoundEvent::Update(float delta_t)
 			pan_rate = 0.f;
 		}
 		CHECK_OPENAL_ERROR(alSourcef, source, AL_GAIN, current_gain * volume);
-		CHECK_OPENAL_ERROR(alSource3f, source, AL_POSITION, current_pan, 0.F, 0.F);
+		// Panning is simulated by moving the sound source on a unit circle on the horizontal plane
+		CHECK_OPENAL_ERROR(alSource3f, source, AL_POSITION, current_pan, std::sqrt(1 - current_pan * current_pan), 0.F);
 	}
 }
 

--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -1,7 +1,8 @@
 // Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
-#ifdef PI_BUILD_WITH_OPENAL
+#include "buildopts.h"
+#if BUILD_WITH_OPENAL
 
 #include "AlAudioBackend.h"
 #include "Pi.h"

--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -167,7 +167,11 @@ Sound::AudioBackend::eventid Sound::AlAudioBackend::Play(std::string_view key, c
 
 void Sound::AlAudioBackend::BodyMakeNoise(const Body *b, std::string_view key, float vol)
 {
+	// Not ideal, but currently we prune every sound source beyond 3 km.
+	// This is needed not to run out of OpenAL sources, but a more involved pruning logic
+	// would be beneficial.
 	constexpr double distance_threshold = 3000;
+
 	auto pos = b->GetPositionRelTo(Pi::player);
 	pos = pos * Pi::player->GetOrient();
 

--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -297,8 +297,7 @@ Sound::AlAudioBackend::SoundEvent::SoundEvent(const Sample &sample) :
 		FillBuffer(1);
 		CHECK_OPENAL_ERROR(alSourceQueueBuffers, source, 2, &buffers[0]);
 	}
-	if (is_music)
-	{
+	if (is_music) {
 		CHECK_OPENAL_ERROR(alSourcei, source, AL_DIRECT_CHANNELS_SOFT, AL_TRUE);
 	}
 }
@@ -368,8 +367,8 @@ bool Sound::AlAudioBackend::SoundEvent::IsDone() const
 void Sound::AlAudioBackend::SoundEvent::FillBuffer(int idx)
 {
 	constexpr int buffer_bytes = 44100 * 2;
-	char data[buffer_bytes]{};
-	int bitstream{};
+	char data[buffer_bytes] {};
+	int bitstream {};
 	int remaining_bytes = buffer_bytes;
 	while (remaining_bytes > 0) {
 		const int bytes_read = ov_read(oggv.get(), &data[0] + buffer_bytes - remaining_bytes,

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -20,6 +20,7 @@ namespace Sound {
 		AlAudioBackend();
 		~AlAudioBackend();
 
+		BackendId GetId() override { return AudioBackend_OpenAL; }
 		void DestroyAllEvents() override;
 		void DestroyAllEventsExceptMusic() override;
 
@@ -84,7 +85,7 @@ namespace Sound {
 
 		ALCdevice *m_device;
 		ALCcontext *m_context;
-		eventid next_event_id = 0;
+		eventid m_next_event_id;
 		std::map<std::string, Sample> m_samples;
 		std::map<eventid, SoundEvent> m_events;
 		float m_sfxVolume = 1.F;

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -62,6 +62,7 @@ namespace Sound {
 			void Update(float delta_t);
 			void SetGain(float gain);
 			void SetGain(float gainL, float gainR);
+			void SetVolume(float vol);
 			void SetOp(Op op);
 			void SetTargetGain(float gain, float rate);
 			void SetTargetGain(float gainL, float gainR, float rate);
@@ -77,8 +78,11 @@ namespace Sound {
 			int samplerate;
 			float target_gain;
 			float target_pan;
+			float current_gain;
+			float current_pan;
 			float fade_rate;
 			float pan_rate;
+			float volume;
 			bool streaming_finished;
 			bool is_music;
 			Op op;
@@ -93,6 +97,7 @@ namespace Sound {
 		std::map<eventid, SoundEvent> m_events;
 		float m_masterVolume = 1.F;
 		float m_sfxVolume = 1.F;
+		bool m_paused = false;
 	};
 
 } // namespace Sound

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -21,7 +21,6 @@ namespace Sound {
 		AlAudioBackend();
 		~AlAudioBackend();
 
-		BackendId GetId() override { return AudioBackend_OpenAL; }
 		void DestroyAllEvents() override;
 		void DestroyAllEventsExceptMusic() override;
 

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -3,6 +3,7 @@
 
 #ifndef __AL_AUDIO_BACKEND_H
 #define __AL_AUDIO_BACKEND_H
+#ifdef PI_BUILD_WITH_OPENAL
 
 #include "AudioBackend.h"
 #include "OggFileDataStream.h"
@@ -96,4 +97,5 @@ namespace Sound {
 
 } // namespace Sound
 
+#endif
 #endif // __AL_AUDIO_BACKEND_H

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -1,0 +1,95 @@
+// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef __AL_AUDIO_BACKEND_H
+#define __AL_AUDIO_BACKEND_H
+
+#include "AudioBackend.h"
+#include "OggFileDataStream.h"
+
+#include "AL/al.h"
+#include "AL/alc.h"
+#include "vorbis/vorbisfile.h"
+
+#include <memory>
+
+namespace Sound {
+
+	class AlAudioBackend : public AudioBackend {
+	public:
+		AlAudioBackend();
+		~AlAudioBackend();
+
+		void DestroyAllEvents() override;
+		void DestroyAllEventsExceptMusic() override;
+
+		bool EventStop(eventid eid) override;
+		bool IsEventPlaying(eventid eid) override;
+		bool EventSetOp(eventid eid, Op op) override;
+		bool EventVolumeAnimate(eventid eid, const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2) override;
+		bool EventSetVolume(eventid eid, const float vol_left, const float vol_right) override;
+
+		void Pause(int on) override;
+
+		eventid Play(std::string_view key, const float volume_left, const float volume_right, const Op op) override;
+		void BodyMakeNoise(const Body *b, std::string_view key, float vol) override;
+
+		void SetMasterVolume(float vol) override;
+		float GetMasterVolume() override;
+		void SetSfxVolume(float vol) override;
+		float GetSfxVolume() override;
+
+		void AddSample(std::string_view key, Sample &&sample) override;
+		void Update(float delta_t) override;
+
+	private:
+		class SoundEvent {
+		public:
+			SoundEvent(const Sample &sample);
+			~SoundEvent();
+			SoundEvent(const SoundEvent &) = delete;
+			SoundEvent(SoundEvent &&);
+
+			SoundEvent &operator=(const SoundEvent &) = delete;
+			SoundEvent &operator=(SoundEvent &&);
+
+			ALuint GetSource() const { return source; }
+			bool IsDone() const;
+			void Update(float delta_t);
+			void SetGain(float gain);
+			void SetGain(float gainL, float gainR);
+			void SetOp(Op op);
+			void SetTargetGain(float gain, float rate);
+			void SetTargetGain(float gainL, float gainR, float rate);
+			bool IsMusic() const { return is_music; }
+
+		private:
+			void FillBuffer(int idx);
+
+			ALuint buffers[2]{};
+			ALuint source{};
+			int playing_buffer_idx{};
+			int channels;
+			int samplerate;
+			float target_gain;
+			float target_pan;
+			float fade_rate;
+			float pan_rate;
+			bool streaming_finished;
+			bool is_music;
+			Op op;
+			std::unique_ptr<OggVorbis_File> oggv;
+			OggFileDataStream ogg_data_stream;
+		};
+
+		ALCdevice *m_device;
+		ALCcontext *m_context;
+		eventid next_event_id = 0;
+		std::map<std::string, Sample> m_samples;
+		std::map<eventid, SoundEvent> m_events;
+		float m_sfxVolume = 1.F;
+	};
+
+} // namespace Sound
+
+#endif // __AL_AUDIO_BACKEND_H

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -3,7 +3,10 @@
 
 #ifndef __AL_AUDIO_BACKEND_H
 #define __AL_AUDIO_BACKEND_H
-#ifdef PI_BUILD_WITH_OPENAL
+
+#include "buildopts.h"
+
+#if BUILD_WITH_OPENAL
 
 #include "AudioBackend.h"
 #include "OggFileDataStream.h"

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -91,6 +91,7 @@ namespace Sound {
 		eventid m_next_event_id;
 		std::map<std::string, Sample> m_samples;
 		std::map<eventid, SoundEvent> m_events;
+		float m_masterVolume = 1.F;
 		float m_sfxVolume = 1.F;
 	};
 

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -43,6 +43,9 @@ namespace Sound {
 		void AddSample(std::string_view key, Sample &&sample) override;
 		void Update(float delta_t) override;
 
+		bool IsBinauralSupported() override;
+		void EnableBinaural(bool enabled) override;
+
 	private:
 		class SoundEvent {
 		public:

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -1,4 +1,4 @@
-// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #ifndef __AL_AUDIO_BACKEND_H

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -74,9 +74,9 @@ namespace Sound {
 		private:
 			void FillBuffer(int idx);
 
-			ALuint buffers[2]{};
-			ALuint source{};
-			int playing_buffer_idx{};
+			ALuint buffers[2] {};
+			ALuint source {};
+			int playing_buffer_idx {};
 			int channels;
 			int samplerate;
 			float target_gain;

--- a/src/sound/AudioBackend.h
+++ b/src/sound/AudioBackend.h
@@ -1,0 +1,61 @@
+// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef __AUDIO_BACKEND_H
+#define __AUDIO_BACKEND_H
+
+#include "Sound.h"
+
+#include <map>
+#include <string_view>
+
+namespace Sound {
+
+	struct Sample {
+		std::vector<uint16_t> buf;
+		uint32_t buf_len;
+		uint32_t channels;
+		int samplerate;
+		/* if buf is null, this will be path to an ogg we must stream */
+		std::string path;
+		bool isMusic;
+	};
+
+	class AudioBackend {
+	public:
+		using eventid = uint32_t;
+
+		virtual ~AudioBackend() = default;
+
+		virtual bool IsAvailable() { return true; }
+		virtual void DestroyAllEvents() = 0;
+		virtual void DestroyAllEventsExceptMusic() = 0;
+
+		virtual bool EventStop(eventid eid) = 0;
+		virtual bool IsEventPlaying(eventid eid) = 0;
+		virtual bool EventSetOp(eventid eid, Op op) = 0;
+		virtual bool EventVolumeAnimate(eventid eid, const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2) = 0;
+		virtual bool EventSetVolume(eventid eid, const float vol_left, const float vol_right) = 0;
+		virtual bool EventFadeOut(eventid eid, float dv_dt, Op op) = 0;
+
+		virtual void Pause(int on) = 0;
+
+		virtual eventid Play(std::string_view key, const float volume_left, const float volume_right, const Op op) = 0;
+		virtual void BodyMakeNoise(const Body *b, std::string_view key, float vol) = 0;
+
+		virtual void SetMasterVolume(const float vol) { m_masterVolume = vol; }
+		float GetMasterVolume() { return m_masterVolume; }
+		virtual void SetSfxVolume(const float vol) { m_sfxVolume = vol; }
+		float GetSfxVolume() { return m_sfxVolume; }
+
+		virtual void AddSample(std::string_view key, Sample &&sample) { m_samples.emplace(key, std::move(sample)); }
+
+	protected:
+		std::map<std::string, Sample> m_samples;
+		float m_masterVolume{};
+		float m_sfxVolume{};
+	};
+
+} // namespace Sound
+
+#endif // __AUDIO_BACKEND_H

--- a/src/sound/AudioBackend.h
+++ b/src/sound/AudioBackend.h
@@ -27,7 +27,6 @@ namespace Sound {
 
 		virtual ~AudioBackend() = default;
 
-		virtual BackendId GetId() = 0;
 		virtual void DestroyAllEvents() = 0;
 		virtual void DestroyAllEventsExceptMusic() = 0;
 

--- a/src/sound/AudioBackend.h
+++ b/src/sound/AudioBackend.h
@@ -1,4 +1,4 @@
-// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #ifndef __AUDIO_BACKEND_H

--- a/src/sound/AudioBackend.h
+++ b/src/sound/AudioBackend.h
@@ -49,6 +49,9 @@ namespace Sound {
 
 		virtual void AddSample(std::string_view key, Sample &&sample) = 0;
 		virtual void Update(float delta_t) {}
+
+		virtual bool IsBinauralSupported() { return false; }
+		virtual void EnableBinaural(bool enabled) {}
 	};
 
 } // namespace Sound

--- a/src/sound/AudioBackend.h
+++ b/src/sound/AudioBackend.h
@@ -27,7 +27,7 @@ namespace Sound {
 
 		virtual ~AudioBackend() = default;
 
-		virtual bool IsAvailable() { return true; }
+		virtual BackendId GetId() = 0;
 		virtual void DestroyAllEvents() = 0;
 		virtual void DestroyAllEventsExceptMusic() = 0;
 

--- a/src/sound/AudioBackend.h
+++ b/src/sound/AudioBackend.h
@@ -36,24 +36,19 @@ namespace Sound {
 		virtual bool EventSetOp(eventid eid, Op op) = 0;
 		virtual bool EventVolumeAnimate(eventid eid, const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2) = 0;
 		virtual bool EventSetVolume(eventid eid, const float vol_left, const float vol_right) = 0;
-		virtual bool EventFadeOut(eventid eid, float dv_dt, Op op) = 0;
 
 		virtual void Pause(int on) = 0;
 
 		virtual eventid Play(std::string_view key, const float volume_left, const float volume_right, const Op op) = 0;
 		virtual void BodyMakeNoise(const Body *b, std::string_view key, float vol) = 0;
 
-		virtual void SetMasterVolume(const float vol) { m_masterVolume = vol; }
-		float GetMasterVolume() { return m_masterVolume; }
-		virtual void SetSfxVolume(const float vol) { m_sfxVolume = vol; }
-		float GetSfxVolume() { return m_sfxVolume; }
+		virtual void SetMasterVolume(float vol) = 0;
+		virtual float GetMasterVolume() = 0;
+		virtual void SetSfxVolume(float vol) = 0;
+		virtual float GetSfxVolume() = 0;
 
-		virtual void AddSample(std::string_view key, Sample &&sample) { m_samples.emplace(key, std::move(sample)); }
-
-	protected:
-		std::map<std::string, Sample> m_samples;
-		float m_masterVolume{};
-		float m_sfxVolume{};
+		virtual void AddSample(std::string_view key, Sample &&sample) = 0;
+		virtual void Update(float delta_t) {}
 	};
 
 } // namespace Sound

--- a/src/sound/OggFileDataStream.cpp
+++ b/src/sound/OggFileDataStream.cpp
@@ -1,3 +1,6 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
 #include "OggFileDataStream.h"
 
 Sound::OggFileDataStream::OggFileDataStream() :

--- a/src/sound/OggFileDataStream.cpp
+++ b/src/sound/OggFileDataStream.cpp
@@ -1,0 +1,82 @@
+#include "OggFileDataStream.h"
+
+Sound::OggFileDataStream::OggFileDataStream() :
+	m_cursor(nullptr) {}
+
+Sound::OggFileDataStream::OggFileDataStream(const RefCountedPtr<FileSystem::FileData> &data) :
+	m_data(data),
+	m_cursor(data->GetData()) { assert(data); }
+
+void Sound::OggFileDataStream::Reset()
+{
+	m_data.Reset();
+	m_cursor = nullptr;
+}
+
+void Sound::OggFileDataStream::Reset(const RefCountedPtr<FileSystem::FileData> &data)
+{
+	assert(data);
+	m_data = data;
+	m_cursor = m_data->GetData();
+}
+
+size_t Sound::OggFileDataStream::read(char *buf, size_t sz, int n)
+{
+	assert(n >= 0);
+	ptrdiff_t offset = tell();
+	// clamp to available data
+	n = std::min(n, int((m_data->GetSize() - offset) / sz));
+	size_t fullsize = sz * n;
+	assert(offset + fullsize <= m_data->GetSize());
+	memcpy(buf, m_cursor, fullsize);
+	m_cursor += fullsize;
+	return n;
+}
+
+int Sound::OggFileDataStream::seek(ogg_int64_t offset, int whence)
+{
+	switch (whence) {
+	case SEEK_SET: m_cursor = m_data->GetData() + offset; break;
+	case SEEK_END: m_cursor = m_data->GetData() + (m_data->GetSize() + offset); break;
+	case SEEK_CUR: m_cursor += offset; break;
+	default: return -1;
+	}
+	return 0;
+}
+
+long Sound::OggFileDataStream::tell()
+{
+	assert(m_data && m_cursor);
+	return long(m_cursor - m_data->GetData());
+}
+
+int Sound::OggFileDataStream::close()
+{
+	if (m_data) {
+		m_data.Reset();
+		m_cursor = nullptr;
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+size_t Sound::OggFileDataStream::ov_callback_read(void *buf, size_t sz, size_t n, void *stream)
+{
+	return reinterpret_cast<OggFileDataStream *>(stream)->read(reinterpret_cast<char *>(buf), sz, n);
+}
+
+int Sound::OggFileDataStream::ov_callback_seek(void *stream, ogg_int64_t offset, int whence)
+{
+	return reinterpret_cast<OggFileDataStream *>(stream)->seek(offset, whence);
+}
+
+long Sound::OggFileDataStream::ov_callback_tell(void *stream)
+{
+	return reinterpret_cast<OggFileDataStream *>(stream)->tell();
+}
+
+int Sound::OggFileDataStream::ov_callback_close(void *stream)
+{
+	return reinterpret_cast<OggFileDataStream *>(stream)->close();
+}

--- a/src/sound/OggFileDataStream.cpp
+++ b/src/sound/OggFileDataStream.cpp
@@ -1,7 +1,9 @@
 #include "OggFileDataStream.h"
 
 Sound::OggFileDataStream::OggFileDataStream() :
-	m_cursor(nullptr) {}
+	m_cursor(nullptr)
+{
+}
 
 Sound::OggFileDataStream::OggFileDataStream(const RefCountedPtr<FileSystem::FileData> &data) :
 	m_data(data),

--- a/src/sound/OggFileDataStream.h
+++ b/src/sound/OggFileDataStream.h
@@ -1,0 +1,46 @@
+// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef __OGG_FILE_DATA_STREAM_H
+#define __OGG_FILE_DATA_STREAM_H
+
+#include "FileSystem.h"
+
+#include "vorbis/vorbisfile.h"
+
+namespace Sound {
+
+	class OggFileDataStream {
+	public:
+		OggFileDataStream();
+		explicit OggFileDataStream(const RefCountedPtr<FileSystem::FileData> &data);
+
+		void Reset();
+		void Reset(const RefCountedPtr<FileSystem::FileData> &data);
+
+		size_t read(char *buf, size_t sz, int n);
+		int seek(ogg_int64_t offset, int whence);
+		long tell();
+		int close();
+
+	private:
+		static size_t ov_callback_read(void *buf, size_t sz, size_t n, void *stream);
+		static int ov_callback_seek(void *stream, ogg_int64_t offset, int whence);
+		static long ov_callback_tell(void *stream);
+		static int ov_callback_close(void *stream);
+
+		RefCountedPtr<FileSystem::FileData> m_data;
+		const char *m_cursor;
+
+	public:
+		static inline ov_callbacks CALLBACKS{
+			&OggFileDataStream::ov_callback_read,
+			&OggFileDataStream::ov_callback_seek,
+			&OggFileDataStream::ov_callback_close,
+			&OggFileDataStream::ov_callback_tell
+		};
+	};
+
+} // namespace Sound
+
+#endif // __OGG_FILE_DATA_STREAM_H

--- a/src/sound/OggFileDataStream.h
+++ b/src/sound/OggFileDataStream.h
@@ -1,4 +1,4 @@
-// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #ifndef __OGG_FILE_DATA_STREAM_H

--- a/src/sound/OggFileDataStream.h
+++ b/src/sound/OggFileDataStream.h
@@ -33,7 +33,7 @@ namespace Sound {
 		const char *m_cursor;
 
 	public:
-		static inline ov_callbacks CALLBACKS{
+		static inline ov_callbacks CALLBACKS {
 			&OggFileDataStream::ov_callback_read,
 			&OggFileDataStream::ov_callback_seek,
 			&OggFileDataStream::ov_callback_close,

--- a/src/sound/SdlAudioBackend.cpp
+++ b/src/sound/SdlAudioBackend.cpp
@@ -2,7 +2,7 @@
 #include "MathUtil.h"
 #include "core/Log.h"
 
-#include "SDL2/SDL.h"
+#include "SDL.h"
 
 #include <random>
 #include <utility>
@@ -274,7 +274,7 @@ template <int T_channels, int T_upsample>
 void Sound::SdlAudioBackend::fill_audio_1stream(float *buffer, int len, int stream_num)
 {
 	// inbuf will be smaller for mono and for 22050hz samples
-	Sint16 *inbuf = static_cast<Sint16 *>(alloca(len * T_channels / T_upsample));
+	const Sint16 *inbuf = static_cast<Sint16 *>(alloca(len * T_channels / T_upsample));
 	// hm pity to put this here ^^ since not used by ev.sample->buf case
 	SoundEvent &ev = wavstream[stream_num];
 	int inbuf_pos = 0;

--- a/src/sound/SdlAudioBackend.cpp
+++ b/src/sound/SdlAudioBackend.cpp
@@ -1,3 +1,6 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
 #include "SdlAudioBackend.h"
 #include "MathUtil.h"
 #include "Pi.h"

--- a/src/sound/SdlAudioBackend.cpp
+++ b/src/sound/SdlAudioBackend.cpp
@@ -163,14 +163,6 @@ bool Sound::SdlAudioBackend::EventSetVolume(eventid eid, const float vol_left, c
 	return status;
 }
 
-bool Sound::SdlAudioBackend::EventFadeOut(eventid eid, float dv_dt, Op op)
-{
-	bool found = EventVolumeAnimate(eid, 0.0f, 0.0f, dv_dt, dv_dt);
-	if (found)
-		EventSetOp(eid, op | Sound::OP_STOP_AT_TARGET_VOLUME);
-	return found;
-}
-
 void Sound::SdlAudioBackend::Pause(int on)
 {
 	if (bool(on) == (SDL_AUDIO_PAUSED == SDL_GetAudioDeviceStatus(m_audioDevice))) {
@@ -211,6 +203,11 @@ void Sound::SdlAudioBackend::BodyMakeNoise(const Body *b, std::string_view key, 
 	float vl, vr;
 	CalculateStereo(b, vol, &vl, &vr);
 	this->Play(key, vl, vr, 0);
+}
+
+void Sound::SdlAudioBackend::AddSample(std::string_view key, Sample &&sample)
+{
+	m_samples.emplace(std::string(key), std::move(sample));
 }
 
 Sound::SdlAudioBackend::SoundEvent *Sound::SdlAudioBackend::GetEvent(eventid id)

--- a/src/sound/SdlAudioBackend.cpp
+++ b/src/sound/SdlAudioBackend.cpp
@@ -4,6 +4,7 @@
 
 #include "SDL2/SDL.h"
 
+#include <random>
 #include <utility>
 
 namespace {
@@ -68,6 +69,10 @@ Sound::SdlAudioBackend::SdlAudioBackend()
 		Output("Could not open audio device: %s\n", SDL_GetError());
 		throw std::exception();
 	}
+
+	std::default_random_engine prng(std::random_device{}());
+	std::uniform_int_distribution<decltype(identifier)> dist;
+	identifier = dist(prng);
 
 	Output("Initialized SDL audio backend");
 }

--- a/src/sound/SdlAudioBackend.cpp
+++ b/src/sound/SdlAudioBackend.cpp
@@ -1,10 +1,10 @@
 #include "SdlAudioBackend.h"
 #include "MathUtil.h"
+#include "Pi.h"
 #include "core/Log.h"
 
 #include "SDL.h"
 
-#include <random>
 #include <utility>
 
 namespace {
@@ -70,9 +70,7 @@ Sound::SdlAudioBackend::SdlAudioBackend()
 		throw std::exception();
 	}
 
-	std::default_random_engine prng(std::random_device{}());
-	std::uniform_int_distribution<decltype(identifier)> dist;
-	identifier = dist(prng);
+	identifier = Pi::rng.Int32();
 
 	Output("Initialized SDL audio backend");
 }

--- a/src/sound/SdlAudioBackend.cpp
+++ b/src/sound/SdlAudioBackend.cpp
@@ -1,0 +1,429 @@
+#include "SdlAudioBackend.h"
+#include "MathUtil.h"
+#include "core/Log.h"
+
+#include "SDL2/SDL.h"
+
+#include <utility>
+
+namespace {
+
+	class AudioDeviceGuard {
+	public:
+		explicit AudioDeviceGuard(SDL_AudioDeviceID dev) :
+			m_dev(dev), m_locked(true)
+		{
+			SDL_LockAudioDevice(m_dev);
+		}
+
+		AudioDeviceGuard(const AudioDeviceGuard &) = delete;
+
+		AudioDeviceGuard(AudioDeviceGuard &&other) :
+			m_dev(std::exchange(other.m_dev, 0)), m_locked(std::exchange(other.m_locked, false))
+		{
+		}
+
+		~AudioDeviceGuard()
+		{
+			if (m_locked) {
+				SDL_UnlockAudioDevice(m_dev);
+				m_locked = false;
+			}
+		}
+
+		AudioDeviceGuard &operator=(const AudioDeviceGuard &) = delete;
+
+		AudioDeviceGuard &operator=(AudioDeviceGuard &&other)
+		{
+			m_dev = std::exchange(other.m_dev, 0);
+			m_locked = std::exchange(other.m_locked, false);
+			return *this;
+		}
+
+	private:
+		SDL_AudioDeviceID m_dev;
+		bool m_locked;
+	};
+
+} //namespace
+
+Sound::SdlAudioBackend::SdlAudioBackend()
+{
+	if (SDL_Init(SDL_INIT_AUDIO) == -1) {
+		Output("Could not initialize SDL Audio: %s.\n", SDL_GetError());
+		throw std::exception();
+	}
+
+	SDL_AudioSpec wanted;
+	wanted.freq = FREQ;
+	wanted.channels = 2;
+	wanted.format = AUDIO_S16;
+	wanted.samples = BUF_SIZE;
+	wanted.callback = fill_audio_callback;
+	wanted.userdata = this;
+
+	// Automatically pick the best device.
+	m_audioDevice = SDL_OpenAudioDevice(nullptr, 0, &wanted, nullptr, 0);
+	if (!m_audioDevice) {
+		Output("Could not open audio device: %s\n", SDL_GetError());
+		throw std::exception();
+	}
+
+	Output("Initialized SDL audio backend");
+}
+
+Sound::SdlAudioBackend::~SdlAudioBackend()
+{
+	SDL_CloseAudioDevice(m_audioDevice);
+
+	Output("Destroyed SDL audio backend");
+}
+
+void Sound::SdlAudioBackend::DestroyAllEvents()
+{
+	/* silence any sound events */
+	AudioDeviceGuard guard(m_audioDevice);
+	for (unsigned int idx = 0; idx < MAX_WAVSTREAMS; idx++) {
+		this->DestroyEvent(&wavstream[idx]);
+	}
+}
+
+void Sound::SdlAudioBackend::DestroyAllEventsExceptMusic()
+{
+	/* silence any sound events EXCEPT music
+	which are on wavstream[0] and [1] */
+	AudioDeviceGuard guard(m_audioDevice);
+	for (unsigned int idx = 2; idx < MAX_WAVSTREAMS; idx++) {
+		this->DestroyEvent(&wavstream[idx]);
+	}
+}
+
+bool Sound::SdlAudioBackend::EventStop(eventid eid)
+{
+	if (eid) {
+		AudioDeviceGuard guard(m_audioDevice);
+		SoundEvent *s = GetEvent(eid);
+		if (s) {
+			DestroyEvent(s);
+		}
+		return s != nullptr;
+	} else {
+		return false;
+	}
+}
+
+bool Sound::SdlAudioBackend::IsEventPlaying(eventid eid)
+{
+	if (eid == 0)
+		return false;
+	else
+		return GetEvent(eid) != nullptr;
+}
+
+bool Sound::SdlAudioBackend::EventSetOp(eventid eid, Op op)
+{
+	if (eid == 0) return false;
+	bool ret = false;
+	AudioDeviceGuard guard(m_audioDevice);
+	SoundEvent *se = GetEvent(eid);
+	if (se) {
+		se->op = op;
+		ret = true;
+	}
+	return ret;
+}
+
+bool Sound::SdlAudioBackend::EventVolumeAnimate(eventid eid, const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2)
+{
+	AudioDeviceGuard guard(m_audioDevice);
+	SoundEvent *ev = GetEvent(eid);
+	if (ev) {
+		ev->targetVolume[0] = targetVol1;
+		ev->targetVolume[1] = targetVol2;
+		ev->rateOfChange[0] = dv_dt1 / float(FREQ);
+		ev->rateOfChange[1] = dv_dt2 / float(FREQ);
+	}
+	return (ev != nullptr);
+}
+
+bool Sound::SdlAudioBackend::EventSetVolume(eventid eid, const float vol_left, const float vol_right)
+{
+	AudioDeviceGuard guard(m_audioDevice);
+	bool status = false;
+	for (unsigned int i = 0; i < MAX_WAVSTREAMS; i++) {
+		if (wavstream[i].sample && (wavstream[i].identifier == eid)) {
+			wavstream[i].volume[0] = vol_left;
+			wavstream[i].volume[1] = vol_right;
+			wavstream[i].targetVolume[0] = vol_left;
+			wavstream[i].targetVolume[1] = vol_right;
+			status = true;
+			break;
+		}
+	}
+	return status;
+}
+
+bool Sound::SdlAudioBackend::EventFadeOut(eventid eid, float dv_dt, Op op)
+{
+	bool found = EventVolumeAnimate(eid, 0.0f, 0.0f, dv_dt, dv_dt);
+	if (found)
+		EventSetOp(eid, op | Sound::OP_STOP_AT_TARGET_VOLUME);
+	return found;
+}
+
+void Sound::SdlAudioBackend::Pause(int on)
+{
+	if (bool(on) == (SDL_AUDIO_PAUSED == SDL_GetAudioDeviceStatus(m_audioDevice))) {
+		return;
+	}
+	SDL_PauseAudioDevice(m_audioDevice, on);
+}
+
+/*
+ * Volume should be 0-65535
+ */
+Sound::AudioBackend::eventid Sound::SdlAudioBackend::Play(std::string_view key, const float volume_left, const float volume_right, const Op op)
+{
+	std::string key_str(key);
+	auto sample_it = m_samples.find(key_str);
+	if (sample_it == m_samples.end()) {
+		Warning("Could not find sample with key %s", key_str.c_str());
+		return 0;
+	}
+	const float mix_volume = sample_it->second.isMusic ? 1.0F : GetSfxVolume();
+	AudioDeviceGuard guard(m_audioDevice);
+	SoundEvent &empty_event = FindFreeEventForSample(sample_it->second);
+	empty_event.sample = &sample_it->second;
+	empty_event.oggv = 0;
+	empty_event.buf_pos = 0;
+	empty_event.volume[0] = volume_left * mix_volume;
+	empty_event.volume[1] = volume_right * mix_volume;
+	empty_event.op = op;
+	empty_event.identifier = identifier;
+	empty_event.targetVolume[0] = mix_volume;
+	empty_event.targetVolume[1] = mix_volume;
+	empty_event.rateOfChange[0] = empty_event.rateOfChange[1] = 0.0f;
+	return identifier++;
+}
+
+void Sound::SdlAudioBackend::BodyMakeNoise(const Body *b, std::string_view key, float vol)
+{
+	float vl, vr;
+	CalculateStereo(b, vol, &vl, &vr);
+	this->Play(key, vl, vr, 0);
+}
+
+Sound::SdlAudioBackend::SoundEvent *Sound::SdlAudioBackend::GetEvent(eventid id)
+{
+	for (unsigned int i = 0; i < MAX_WAVSTREAMS; i++) {
+		if (wavstream[i].sample && (wavstream[i].identifier == id))
+			return &wavstream[i];
+	}
+	return nullptr;
+}
+
+void Sound::SdlAudioBackend::DestroyEvent(SoundEvent *ev)
+{
+	if (ev->oggv) {
+		// streaming ogg
+		ov_clear(ev->oggv);
+		delete ev->oggv;
+		ev->oggv = 0;
+		ev->ogg_data_stream.Reset();
+	}
+	ev->sample = nullptr;
+}
+
+Sound::SdlAudioBackend::SoundEvent &Sound::SdlAudioBackend::FindFreeEventForSample(const Sample &sample)
+{
+	int idx = -1;
+	if (sample.isMusic) {
+		idx = nextMusicStream;
+		nextMusicStream ^= 1;
+		if (wavstream[idx].sample)
+			DestroyEvent(&wavstream[idx]);
+	} else {
+		uint32_t age;
+		/* find free wavstream (first two reserved for music) */
+		for (idx = 2; idx < MAX_WAVSTREAMS; idx++) {
+			if (!wavstream[idx].sample) {
+				return wavstream[idx];
+			}
+		}
+		/* otherwise overwrite oldest one */
+		age = 0;
+		idx = 0;
+		for (unsigned int i = 2; i < MAX_WAVSTREAMS; i++) {
+			if ((i == 0) || (wavstream[i].buf_pos > age)) {
+				idx = i;
+				age = wavstream[i].buf_pos;
+			}
+		}
+		DestroyEvent(&wavstream[idx]);
+	}
+
+	return wavstream[idx];
+}
+
+/*
+ * len is the number of floats to put in buffer, NOT full samples (a sample would be 2 floats since stereo)
+ */
+template <int T_channels, int T_upsample>
+void Sound::SdlAudioBackend::fill_audio_1stream(float *buffer, int len, int stream_num)
+{
+	// inbuf will be smaller for mono and for 22050hz samples
+	Sint16 *inbuf = static_cast<Sint16 *>(alloca(len * T_channels / T_upsample));
+	// hm pity to put this here ^^ since not used by ev.sample->buf case
+	SoundEvent &ev = wavstream[stream_num];
+	int inbuf_pos = 0;
+	int pos = 0;
+	while ((pos < len) && ev.sample) {
+		if (!ev.sample->buf.empty()) {
+			// already decoded
+			inbuf = reinterpret_cast<const Sint16 *>(ev.sample->buf.data());
+			inbuf_pos = ev.buf_pos;
+		} else {
+			// stream ogg vorbis
+			// ogg vorbis streaming
+			if (!ev.oggv) {
+				// open file to start streaming
+				ev.oggv = new OggVorbis_File;
+				RefCountedPtr<FileSystem::FileData> oggdata = FileSystem::gameDataFiles.ReadFile(ev.sample->path);
+				if (!oggdata) {
+					Output("Could not open '%s'", ev.sample->path.c_str());
+					ev.sample = nullptr;
+					return;
+				}
+				ev.ogg_data_stream.Reset(oggdata);
+				oggdata.Reset();
+				if (ov_open_callbacks(&ev.ogg_data_stream, ev.oggv, 0, 0, OggFileDataStream::CALLBACKS) < 0) {
+					Output("Vorbis could not understand '%s'", ev.sample->path.c_str());
+					ev.sample = nullptr;
+					return;
+				}
+			}
+			int i = 0;
+			// (len-pos) = num floats the destination buffer wants.
+			// if we are stereo then to fill this we need (len-pos)*2 bytes
+			// if we are mono we want (len-pos) bytes
+			int wanted_bytes = (len - pos) * T_channels / T_upsample;
+			for (;;) {
+				int music_section;
+				if (wanted_bytes == 0) break;
+				int amt = ov_read(ev.oggv, const_cast<char *>(reinterpret_cast<const char *>(inbuf)) + i,
+					wanted_bytes, 0, 2, 1, &music_section);
+				i += amt;
+				wanted_bytes -= amt;
+				if (amt == 0) break;
+			}
+		}
+
+		while (pos < len) {
+			/* Volume animations */
+			for (int chan = 0; chan < 2; chan++) {
+				if (ev.ascend[chan]) {
+					ev.volume[chan] = std::min(ev.volume[chan] + ev.rateOfChange[chan], ev.targetVolume[chan]);
+				} else {
+					ev.volume[chan] = std::max(ev.volume[chan] - ev.rateOfChange[chan], ev.targetVolume[chan]);
+				}
+			}
+
+			float s0, s1;
+
+			if (T_channels == 1) {
+				s0 = float(inbuf[inbuf_pos++]);
+				s1 = ev.volume[1] * s0;
+				s0 = ev.volume[0] * s0;
+				ev.buf_pos += 1;
+			} else /* stereo */ {
+				s0 = ev.volume[0] * float(inbuf[inbuf_pos++]);
+				s1 = ev.volume[1] * float(inbuf[inbuf_pos++]);
+				ev.buf_pos += 2;
+			}
+
+			if (T_upsample == 1) {
+				buffer[pos] += s0;
+				buffer[pos + 1] += s1;
+				pos += 2;
+			} else {
+				buffer[pos] += s0;
+				buffer[pos + 1] += s1;
+				buffer[pos + 2] += s0;
+				buffer[pos + 3] += s1;
+				pos += 4;
+			}
+
+			/* Repeat or end? */
+			if (ev.buf_pos >= ev.sample->buf_len) {
+				ev.buf_pos = 0;
+				inbuf_pos = 0;
+				if (!(ev.op & OP_REPEAT)) {
+					DestroyEvent(&ev);
+					break;
+				}
+				if (ev.oggv) {
+					// streaming ogg
+					ov_pcm_seek(ev.oggv, 0);
+					// repeat outer loop to decode some
+					// more vorbis from the start of the stream
+					break;
+				}
+			}
+		}
+	}
+}
+
+void Sound::SdlAudioBackend::fill_audio(Uint8 *dsp_buf, int len)
+{
+	const int len_in_floats = len >> 1;
+	float *tmpbuf = static_cast<float *>(alloca(sizeof(float) * len_in_floats)); // len is in chars not samples
+	memset(static_cast<void *>(tmpbuf), 0, sizeof(float) * len_in_floats);
+
+	for (unsigned int i = 0; i < MAX_WAVSTREAMS; i++) {
+		if (!wavstream[i].sample) continue;
+
+		wavstream[i].ascend[0] = (wavstream[i].targetVolume[0] > wavstream[i].volume[0]);
+		wavstream[i].ascend[1] = (wavstream[i].targetVolume[1] > wavstream[i].volume[1]);
+
+		if (wavstream[i].op & OP_STOP_AT_TARGET_VOLUME) {
+			if (wavstream[i].ascend[0] && wavstream[i].ascend[1]) {
+				if ((wavstream[i].targetVolume[0] <= wavstream[i].volume[0]) &&
+					(wavstream[i].targetVolume[1] <= wavstream[i].volume[1])) {
+					DestroyEvent(&wavstream[i]);
+					continue;
+				}
+			} else {
+				if ((wavstream[i].targetVolume[0] >= wavstream[i].volume[0]) &&
+					(wavstream[i].targetVolume[1] >= wavstream[i].volume[1])) {
+					DestroyEvent(&wavstream[i]);
+					continue;
+				}
+			}
+		}
+
+		if (wavstream[i].sample->channels == 1) {
+			if (wavstream[i].sample->samplerate == FREQ) {
+				fill_audio_1stream<1, 1>(tmpbuf, len_in_floats, i);
+			} else {
+				fill_audio_1stream<1, 2>(tmpbuf, len_in_floats, i);
+			}
+		} else {
+			if (wavstream[i].sample->samplerate == FREQ) {
+				fill_audio_1stream<2, 1>(tmpbuf, len_in_floats, i);
+			} else {
+				fill_audio_1stream<2, 2>(tmpbuf, len_in_floats, i);
+			}
+		}
+	}
+
+	/* Convert float sample buffer to Sint16 samples the hardware likes */
+	for (int pos = 0; pos < len_in_floats; pos++) {
+		const float val = m_masterVolume * tmpbuf[pos];
+		(reinterpret_cast<Sint16 *>(dsp_buf))[pos] = Sint16(Clamp(val, -32768.0f, 32767.0f));
+	}
+}
+
+void Sound::SdlAudioBackend::fill_audio_callback(void *udata, Uint8 *dsp_buf, int len)
+{
+	reinterpret_cast<SdlAudioBackend *>(udata)->fill_audio(dsp_buf, len);
+}

--- a/src/sound/SdlAudioBackend.h
+++ b/src/sound/SdlAudioBackend.h
@@ -1,4 +1,4 @@
-// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
 // Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 #ifndef __SDL_AUDIO_BACKEND_H

--- a/src/sound/SdlAudioBackend.h
+++ b/src/sound/SdlAudioBackend.h
@@ -7,7 +7,7 @@
 #include "AudioBackend.h"
 #include "OggFileDataStream.h"
 
-#include "SDL2/SDL_audio.h"
+#include "SDL_audio.h"
 
 namespace Sound {
 

--- a/src/sound/SdlAudioBackend.h
+++ b/src/sound/SdlAudioBackend.h
@@ -16,6 +16,7 @@ namespace Sound {
 		SdlAudioBackend();
 		~SdlAudioBackend();
 
+		BackendId GetId() override { return AudioBackend_SDL; }
 		void DestroyAllEvents() override;
 		void DestroyAllEventsExceptMusic() override;
 
@@ -68,7 +69,7 @@ namespace Sound {
 		float m_masterVolume = 1.F;
 		float m_sfxVolume = 1.F;
 		SDL_AudioDeviceID m_audioDevice;
-		uint32_t identifier = 1;
+		uint32_t identifier;
 		int nextMusicStream = 0;
 		SoundEvent wavstream[MAX_WAVSTREAMS]{};
 		std::map<std::string, Sample> m_samples;

--- a/src/sound/SdlAudioBackend.h
+++ b/src/sound/SdlAudioBackend.h
@@ -24,12 +24,18 @@ namespace Sound {
 		bool EventSetOp(eventid eid, Op op) override;
 		bool EventVolumeAnimate(eventid eid, const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2) override;
 		bool EventSetVolume(eventid eid, const float vol_left, const float vol_right) override;
-		bool EventFadeOut(eventid eid, float dv_dt, Op op) override;
 
 		void Pause(int on) override;
 
 		eventid Play(std::string_view key, const float volume_left, const float volume_right, const Op op) override;
 		void BodyMakeNoise(const Body *b, std::string_view key, float vol) override;
+
+		void SetMasterVolume(float vol) override { m_masterVolume = vol; }
+		float GetMasterVolume() override { return m_masterVolume; }
+		void SetSfxVolume(float vol) override { m_sfxVolume = vol; }
+		float GetSfxVolume() override { return m_sfxVolume; }
+
+		void AddSample(std::string_view key, Sample &&sample) override;
 
 	private:
 		struct SoundEvent {
@@ -59,10 +65,13 @@ namespace Sound {
 		void fill_audio(Uint8 *dsp_buf, int len);
 		static void fill_audio_callback(void *udata, Uint8 *dsp_buf, int len);
 
+		float m_masterVolume = 1.F;
+		float m_sfxVolume = 1.F;
 		SDL_AudioDeviceID m_audioDevice;
 		uint32_t identifier = 1;
 		int nextMusicStream = 0;
 		SoundEvent wavstream[MAX_WAVSTREAMS]{};
+		std::map<std::string, Sample> m_samples;
 	};
 
 } // namespace Sound

--- a/src/sound/SdlAudioBackend.h
+++ b/src/sound/SdlAudioBackend.h
@@ -1,0 +1,70 @@
+// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef __SDL_AUDIO_BACKEND_H
+#define __SDL_AUDIO_BACKEND_H
+
+#include "AudioBackend.h"
+#include "OggFileDataStream.h"
+
+#include "SDL2/SDL_audio.h"
+
+namespace Sound {
+
+	class SdlAudioBackend : public AudioBackend {
+	public:
+		SdlAudioBackend();
+		~SdlAudioBackend();
+
+		void DestroyAllEvents() override;
+		void DestroyAllEventsExceptMusic() override;
+
+		bool EventStop(eventid eid) override;
+		bool IsEventPlaying(eventid eid) override;
+		bool EventSetOp(eventid eid, Op op) override;
+		bool EventVolumeAnimate(eventid eid, const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2) override;
+		bool EventSetVolume(eventid eid, const float vol_left, const float vol_right) override;
+		bool EventFadeOut(eventid eid, float dv_dt, Op op) override;
+
+		void Pause(int on) override;
+
+		eventid Play(std::string_view key, const float volume_left, const float volume_right, const Op op) override;
+		void BodyMakeNoise(const Body *b, std::string_view key, float vol) override;
+
+	private:
+		struct SoundEvent {
+			const Sample *sample;
+			OggVorbis_File *oggv; // if sample->buf = 0 then stream this
+			OggFileDataStream ogg_data_stream;
+			uint32_t buf_pos;
+			float volume[2]; // left and right channels
+			eventid identifier;
+			uint32_t op;
+
+			float targetVolume[2];
+			float rateOfChange[2]; // per sample
+			bool ascend[2];
+		};
+
+		constexpr inline static unsigned int FREQ = 44100;
+		constexpr inline static unsigned int BUF_SIZE = 4096;
+		constexpr inline static unsigned int MAX_WAVSTREAMS = 10; //first two are for music
+
+		SoundEvent *GetEvent(eventid id);
+		void DestroyEvent(SoundEvent *ev);
+		SoundEvent &FindFreeEventForSample(const Sample &sample);
+
+		template <int T_channels, int T_upsample>
+		void fill_audio_1stream(float *buffer, int len, int stream_num);
+		void fill_audio(Uint8 *dsp_buf, int len);
+		static void fill_audio_callback(void *udata, Uint8 *dsp_buf, int len);
+
+		SDL_AudioDeviceID m_audioDevice;
+		uint32_t identifier = 1;
+		int nextMusicStream = 0;
+		SoundEvent wavstream[MAX_WAVSTREAMS]{};
+	};
+
+} // namespace Sound
+
+#endif // __SDL_AUDIO_BACKEND_H

--- a/src/sound/SdlAudioBackend.h
+++ b/src/sound/SdlAudioBackend.h
@@ -16,7 +16,6 @@ namespace Sound {
 		SdlAudioBackend();
 		~SdlAudioBackend();
 
-		BackendId GetId() override { return AudioBackend_SDL; }
 		void DestroyAllEvents() override;
 		void DestroyAllEventsExceptMusic() override;
 

--- a/src/sound/SdlAudioBackend.h
+++ b/src/sound/SdlAudioBackend.h
@@ -70,7 +70,7 @@ namespace Sound {
 		SDL_AudioDeviceID m_audioDevice;
 		uint32_t identifier;
 		int nextMusicStream = 0;
-		SoundEvent wavstream[MAX_WAVSTREAMS]{};
+		SoundEvent wavstream[MAX_WAVSTREAMS] {};
 		std::map<std::string, Sample> m_samples;
 	};
 

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -6,145 +6,47 @@
  */
 
 #include "Sound.h"
+#include "AudioBackend.h"
 #include "Body.h"
 #include "FileSystem.h"
 #include "JobQueue.h"
 #include "Pi.h"
 #include "Player.h"
+#include "SdlAudioBackend.h"
 #include "utils.h"
 
 #include <SDL.h>
 #include <vorbis/vorbisfile.h>
 
 #include <cassert>
-#include <cerrno>
-#include <cstdio>
 #include <string>
 #include <vector>
 
 namespace Sound {
 
 	static const unsigned int FREQ = 44100;
-	static const unsigned int BUF_SIZE = 4096;
-	static const unsigned int MAX_WAVSTREAMS = 10; //first two are for music
 	static const double STREAM_IF_LONGER_THAN = 10.0;
 
-	static SDL_AudioDeviceID m_audioDevice = 0;
-
-	class OggFileDataStream {
-	public:
-		static const ov_callbacks CALLBACKS;
-
-		OggFileDataStream() :
-			m_cursor(nullptr) {}
-		explicit OggFileDataStream(const RefCountedPtr<FileSystem::FileData> &data) :
-			m_data(data),
-			m_cursor(data->GetData()) { assert(data); }
-
-		void Reset()
-		{
-			m_data.Reset();
-			m_cursor = nullptr;
-		}
-
-		void Reset(const RefCountedPtr<FileSystem::FileData> &data)
-		{
-			assert(data);
-			m_data = data;
-			m_cursor = m_data->GetData();
-		}
-
-		size_t read(char *buf, size_t sz, int n)
-		{
-			assert(n >= 0);
-			ptrdiff_t offset = tell();
-			// clamp to available data
-			n = std::min(n, int((m_data->GetSize() - offset) / sz));
-			size_t fullsize = sz * n;
-			assert(offset + fullsize <= m_data->GetSize());
-			memcpy(buf, m_cursor, fullsize);
-			m_cursor += fullsize;
-			return n;
-		}
-
-		int seek(ogg_int64_t offset, int whence)
-		{
-			switch (whence) {
-			case SEEK_SET: m_cursor = m_data->GetData() + offset; break;
-			case SEEK_END: m_cursor = m_data->GetData() + (m_data->GetSize() + offset); break;
-			case SEEK_CUR: m_cursor += offset; break;
-			default: return -1;
-			}
-			return 0;
-		}
-
-		long tell()
-		{
-			assert(m_data && m_cursor);
-			return long(m_cursor - m_data->GetData());
-		}
-
-		int close()
-		{
-			if (m_data) {
-				m_data.Reset();
-				m_cursor = nullptr;
-				return 0;
-			} else {
-				return -1;
-			}
-		}
-
-	private:
-		static size_t ov_callback_read(void *buf, size_t sz, size_t n, void *stream)
-		{
-			return reinterpret_cast<OggFileDataStream *>(stream)->read(reinterpret_cast<char *>(buf), sz, n);
-		}
-		static int ov_callback_seek(void *stream, ogg_int64_t offset, int whence)
-		{
-			return reinterpret_cast<OggFileDataStream *>(stream)->seek(offset, whence);
-		}
-		static long ov_callback_tell(void *stream)
-		{
-			return reinterpret_cast<OggFileDataStream *>(stream)->tell();
-		}
-		static int ov_callback_close(void *stream)
-		{
-			return reinterpret_cast<OggFileDataStream *>(stream)->close();
-		}
-
-		RefCountedPtr<FileSystem::FileData> m_data;
-		const char *m_cursor;
-	};
-
-	const ov_callbacks OggFileDataStream::CALLBACKS = {
-		&OggFileDataStream::ov_callback_read,
-		&OggFileDataStream::ov_callback_seek,
-		&OggFileDataStream::ov_callback_close,
-		&OggFileDataStream::ov_callback_tell
-	};
-
-	static float m_masterVol = 1.0f;
-	static float m_sfxVol = 1.0f;
+	static AudioBackend *m_backend = nullptr;
 
 	void SetMasterVolume(const float vol)
 	{
-		m_masterVol = vol;
+		m_backend->SetMasterVolume(vol);
 	}
 
 	float GetMasterVolume()
 	{
-		return m_masterVol;
+		return m_backend->GetMasterVolume();
 	}
 
 	void SetSfxVolume(const float vol)
 	{
-		m_sfxVol = vol;
+		m_backend->SetSfxVolume(vol);
 	}
 
 	float GetSfxVolume()
 	{
-		return m_sfxVol;
+		return m_backend->GetSfxVolume();
 	}
 
 	void CalculateStereo(const Body *b, float vol, float *volLeftOut, float *volRightOut)
@@ -170,321 +72,26 @@ namespace Sound {
 		(*volRightOut) = Clamp((*volRightOut), 0.0f, 1.0f);
 	}
 
+	static std::vector<std::string> music_sample_keys;
+
 	void BodyMakeNoise(const Body *b, const char *sfx, float vol)
 	{
-		float vl, vr;
-		CalculateStereo(b, vol, &vl, &vr);
-		Sound::PlaySfx(sfx, vl, vr, 0);
-	}
-
-	struct Sample {
-		uint16_t *buf;
-		uint32_t buf_len;
-		uint32_t channels;
-		int upsample; // 1 = 44100, 2=22050
-		/* if buf is null, this will be path to an ogg we must stream */
-		std::string path;
-		bool isMusic;
-	};
-
-	typedef uint32_t eventid;
-
-	struct SoundEvent {
-		const Sample *sample;
-		OggVorbis_File *oggv; // if sample->buf = 0 then stream this
-		OggFileDataStream ogg_data_stream;
-		uint32_t buf_pos;
-		float volume[2]; // left and right channels
-		eventid identifier;
-		uint32_t op;
-
-		float targetVolume[2];
-		float rateOfChange[2]; // per sample
-		bool ascend[2];
-	};
-
-	static std::map<std::string, Sample> sfx_samples;
-	struct SoundEvent wavstream[MAX_WAVSTREAMS];
-
-	static Sample *GetSample(const char *filename)
-	{
-		if (sfx_samples.find(filename) != sfx_samples.end()) {
-			return &sfx_samples[filename];
-		} else {
-			//SilentWarning("Unknown sound sample: %s", filename);
-			return 0;
-		}
-	}
-
-	static SoundEvent *GetEvent(eventid id)
-	{
-		for (unsigned int i = 0; i < MAX_WAVSTREAMS; i++) {
-			if (wavstream[i].sample && (wavstream[i].identifier == id))
-				return &wavstream[i];
-		}
-		return nullptr;
-	}
-
-	static void DestroyEvent(SoundEvent *ev)
-	{
-		if (ev->oggv) {
-			// streaming ogg
-			ov_clear(ev->oggv);
-			delete ev->oggv;
-			ev->oggv = 0;
-			ev->ogg_data_stream.Reset();
-		}
-		ev->sample = nullptr;
-	}
-
-	/*
- * Volume should be 0-65535
- */
-	static uint32_t identifier = 1;
-	static eventid PlaySfxSample(Sample *sample, const float volume_left, const float volume_right, const Op op)
-	{
-		SDL_LockAudioDevice(m_audioDevice);
-		unsigned int idx;
-		uint32_t age;
-		/* find free wavstream (first two reserved for music) */
-		for (idx = 2; idx < MAX_WAVSTREAMS; idx++) {
-			if (!wavstream[idx].sample) break;
-		}
-		if (idx == MAX_WAVSTREAMS) {
-			/* otherwise overwrite oldest one */
-			age = 0;
-			idx = 0;
-			for (unsigned int i = 2; i < MAX_WAVSTREAMS; i++) {
-				if ((i == 0) || (wavstream[i].buf_pos > age)) {
-					idx = i;
-					age = wavstream[i].buf_pos;
-				}
-			}
-			DestroyEvent(&wavstream[idx]);
-		}
-		wavstream[idx].sample = sample;
-		wavstream[idx].oggv = 0;
-		wavstream[idx].buf_pos = 0;
-		wavstream[idx].volume[0] = volume_left * GetSfxVolume();
-		wavstream[idx].volume[1] = volume_right * GetSfxVolume();
-		wavstream[idx].op = op;
-		wavstream[idx].identifier = identifier;
-		wavstream[idx].targetVolume[0] = volume_left * GetSfxVolume();
-		wavstream[idx].targetVolume[1] = volume_right * GetSfxVolume();
-		wavstream[idx].rateOfChange[0] = wavstream[idx].rateOfChange[1] = 0.0f;
-		SDL_UnlockAudioDevice(m_audioDevice);
-		return identifier++;
+		m_backend->BodyMakeNoise(b, sfx, vol);
 	}
 
 	void PlaySfx(const char *fx, const float volume_left, const float volume_right, const Op op)
 	{
-		Sample* sample = GetSample(fx);
-		if (sample) {
-			PlaySfxSample(sample, volume_left, volume_right, op);
-		}
-	}
-
-	//unlike PlaySfxSample, we want uninterrupted play and do not care about age
-	//alternate between two streams for crossfade
-	static int nextMusicStream = 0;
-	static eventid PlayMusicSample(Sample *sample, const float volume_left, const float volume_right, const Op op)
-	{
-		const int idx = nextMusicStream;
-		nextMusicStream ^= 1;
-		SDL_LockAudioDevice(m_audioDevice);
-		if (wavstream[idx].sample)
-			DestroyEvent(&wavstream[idx]);
-		wavstream[idx].sample = sample;
-		wavstream[idx].oggv = nullptr;
-		wavstream[idx].buf_pos = 0;
-		wavstream[idx].volume[0] = volume_left;
-		wavstream[idx].volume[1] = volume_right;
-		wavstream[idx].op = op;
-		wavstream[idx].identifier = identifier;
-		wavstream[idx].targetVolume[0] = volume_left; //already scaled in MusicPlayer
-		wavstream[idx].targetVolume[1] = volume_right;
-		wavstream[idx].rateOfChange[0] = wavstream[idx].rateOfChange[1] = 0.0f;
-		SDL_UnlockAudioDevice(m_audioDevice);
-		return identifier++;
-	}
-
-	/*
- * len is the number of floats to put in buffer, NOT full samples (a sample would be 2 floats since stereo)
- */
-	template <int T_channels, int T_upsample>
-	static void fill_audio_1stream(float *buffer, int len, int stream_num)
-	{
-		// inbuf will be smaller for mono and for 22050hz samples
-		Sint16 *inbuf = static_cast<Sint16 *>(alloca(len * T_channels / T_upsample));
-		// hm pity to put this here ^^ since not used by ev.sample->buf case
-		SoundEvent &ev = wavstream[stream_num];
-		int inbuf_pos = 0;
-		int pos = 0;
-		while ((pos < len) && ev.sample) {
-			if (ev.sample->buf) {
-				// already decoded
-				inbuf = reinterpret_cast<Sint16 *>(ev.sample->buf);
-				inbuf_pos = ev.buf_pos;
-			} else {
-				// stream ogg vorbis
-				// ogg vorbis streaming
-				if (!ev.oggv) {
-					// open file to start streaming
-					ev.oggv = new OggVorbis_File;
-					RefCountedPtr<FileSystem::FileData> oggdata = FileSystem::gameDataFiles.ReadFile(ev.sample->path);
-					if (!oggdata) {
-						Output("Could not open '%s'", ev.sample->path.c_str());
-						ev.sample = nullptr;
-						return;
-					}
-					ev.ogg_data_stream.Reset(oggdata);
-					oggdata.Reset();
-					if (ov_open_callbacks(&ev.ogg_data_stream, ev.oggv, 0, 0, OggFileDataStream::CALLBACKS) < 0) {
-						Output("Vorbis could not understand '%s'", ev.sample->path.c_str());
-						ev.sample = nullptr;
-						return;
-					}
-				}
-				int i = 0;
-				// (len-pos) = num floats the destination buffer wants.
-				// if we are stereo then to fill this we need (len-pos)*2 bytes
-				// if we are mono we want (len-pos) bytes
-				int wanted_bytes = (len - pos) * T_channels / T_upsample;
-				for (;;) {
-					int music_section;
-					if (wanted_bytes == 0) break;
-					int amt = ov_read(ev.oggv, reinterpret_cast<char *>(inbuf) + i,
-						wanted_bytes, 0, 2, 1, &music_section);
-					i += amt;
-					wanted_bytes -= amt;
-					if (amt == 0) break;
-				}
-			}
-
-			while (pos < len) {
-				/* Volume animations */
-				for (int chan = 0; chan < 2; chan++) {
-					if (ev.ascend[chan]) {
-						ev.volume[chan] = std::min(ev.volume[chan] + ev.rateOfChange[chan], ev.targetVolume[chan]);
-					} else {
-						ev.volume[chan] = std::max(ev.volume[chan] - ev.rateOfChange[chan], ev.targetVolume[chan]);
-					}
-				}
-
-				float s0, s1;
-
-				if (T_channels == 1) {
-					s0 = float(inbuf[inbuf_pos++]);
-					s1 = ev.volume[1] * s0;
-					s0 = ev.volume[0] * s0;
-					ev.buf_pos += 1;
-				} else /* stereo */ {
-					s0 = ev.volume[0] * float(inbuf[inbuf_pos++]);
-					s1 = ev.volume[1] * float(inbuf[inbuf_pos++]);
-					ev.buf_pos += 2;
-				}
-
-				if (T_upsample == 1) {
-					buffer[pos] += s0;
-					buffer[pos + 1] += s1;
-					pos += 2;
-				} else {
-					buffer[pos] += s0;
-					buffer[pos + 1] += s1;
-					buffer[pos + 2] += s0;
-					buffer[pos + 3] += s1;
-					pos += 4;
-				}
-
-				/* Repeat or end? */
-				if (ev.buf_pos >= ev.sample->buf_len) {
-					ev.buf_pos = 0;
-					inbuf_pos = 0;
-					if (!(ev.op & OP_REPEAT)) {
-						DestroyEvent(&ev);
-						break;
-					}
-					if (ev.oggv) {
-						// streaming ogg
-						ov_pcm_seek(ev.oggv, 0);
-						// repeat outer loop to decode some
-						// more vorbis from the start of the stream
-						break;
-					}
-				}
-			}
-		}
-	}
-
-	static void fill_audio(void *udata, Uint8 *dsp_buf, int len)
-	{
-		const int len_in_floats = len >> 1;
-		float *tmpbuf = static_cast<float *>(alloca(sizeof(float) * len_in_floats)); // len is in chars not samples
-		memset(static_cast<void *>(tmpbuf), 0, sizeof(float) * len_in_floats);
-
-		for (unsigned int i = 0; i < MAX_WAVSTREAMS; i++) {
-			if (!wavstream[i].sample) continue;
-
-			wavstream[i].ascend[0] = (wavstream[i].targetVolume[0] > wavstream[i].volume[0]);
-			wavstream[i].ascend[1] = (wavstream[i].targetVolume[1] > wavstream[i].volume[1]);
-
-			if (wavstream[i].op & OP_STOP_AT_TARGET_VOLUME) {
-				if (wavstream[i].ascend[0] && wavstream[i].ascend[1]) {
-					if ((wavstream[i].targetVolume[0] <= wavstream[i].volume[0]) &&
-						(wavstream[i].targetVolume[1] <= wavstream[i].volume[1])) {
-						DestroyEvent(&wavstream[i]);
-						continue;
-					}
-				} else {
-					if ((wavstream[i].targetVolume[0] >= wavstream[i].volume[0]) &&
-						(wavstream[i].targetVolume[1] >= wavstream[i].volume[1])) {
-						DestroyEvent(&wavstream[i]);
-						continue;
-					}
-				}
-			}
-
-			if (wavstream[i].sample->channels == 1) {
-				if (wavstream[i].sample->upsample == 1) {
-					fill_audio_1stream<1, 1>(tmpbuf, len_in_floats, i);
-				} else {
-					fill_audio_1stream<1, 2>(tmpbuf, len_in_floats, i);
-				}
-			} else {
-				if (wavstream[i].sample->upsample == 1) {
-					fill_audio_1stream<2, 1>(tmpbuf, len_in_floats, i);
-				} else {
-					fill_audio_1stream<2, 2>(tmpbuf, len_in_floats, i);
-				}
-			}
-		}
-
-		/* Convert float sample buffer to Sint16 samples the hardware likes */
-		for (int pos = 0; pos < len_in_floats; pos++) {
-			const float val = m_masterVol * tmpbuf[pos];
-			(reinterpret_cast<Sint16 *>(dsp_buf))[pos] = Sint16(Clamp(val, -32768.0f, 32767.0f));
-		}
+		m_backend->Play(fx, volume_left, volume_right, op);
 	}
 
 	void DestroyAllEvents()
 	{
-		/* silence any sound events */
-		SDL_LockAudioDevice(m_audioDevice);
-		for (unsigned int idx = 0; idx < MAX_WAVSTREAMS; idx++) {
-			DestroyEvent(&wavstream[idx]);
-		}
-		SDL_UnlockAudioDevice(m_audioDevice);
+		m_backend->DestroyAllEvents();
 	}
 
 	void DestroyAllEventsExceptMusic()
 	{
-		/* silence any sound events EXCEPT music
-		   which are on wavstream[0] and [1] */
-		SDL_LockAudioDevice(m_audioDevice);
-		for (unsigned int idx = 2; idx < MAX_WAVSTREAMS; idx++) {
-			DestroyEvent(&wavstream[idx]);
-		}
-		SDL_UnlockAudioDevice(m_audioDevice);
+		m_backend->DestroyAllEventsExceptMusic();
 	}
 
 	static std::pair<std::string, Sample> load_sound(const std::string &basename, const std::string &path, bool is_music)
@@ -514,14 +121,12 @@ namespace Sound {
 			Error("Vorbis file %s is not mono or stereo. Bad!", path.c_str());
 		}
 
-		int resample_multiplier = ((info->rate == (FREQ >> 1)) ? 2 : 1);
 		const Sint64 num_samples = ov_pcm_total(&oggv, -1);
 		// since samples are 16 bits we have:
 
-		sample.buf = 0;
 		sample.buf_len = num_samples * info->channels;
 		sample.channels = info->channels;
-		sample.upsample = resample_multiplier;
+		sample.samplerate = info->rate;
 		sample.path = path;
 
 		const float seconds = num_samples / float(info->rate);
@@ -529,12 +134,12 @@ namespace Sound {
 
 		// immediately decode and store as raw sample if short enough
 		if (seconds < STREAM_IF_LONGER_THAN) {
-			sample.buf = new Uint16[sample.buf_len];
+			sample.buf.resize(sample.buf_len);
 
 			int i = 0;
 			for (;;) {
 				int music_section;
-				int amt = ov_read(&oggv, reinterpret_cast<char *>(sample.buf) + i,
+				int amt = ov_read(&oggv, reinterpret_cast<char *>(sample.buf.data()) + i,
 					2 * sample.buf_len - i, 0, 2, 1, &music_section);
 				i += amt;
 				if (amt == 0) break;
@@ -559,7 +164,8 @@ namespace Sound {
 		LoadSoundJob(const std::string &directory, bool isMusic) :
 			m_directory(directory),
 			m_isMusic(isMusic)
-		{}
+		{
+		}
 
 		void OnRun() override
 		{
@@ -575,8 +181,11 @@ namespace Sound {
 
 		void OnFinish() override
 		{
-			for (const auto &pair : m_loadedSounds) {
-				sfx_samples.emplace(std::move(pair));
+			for (auto &pair : m_loadedSounds) {
+				if (pair.second.isMusic) {
+					music_sample_keys.emplace_back(pair.first);
+				}
+				m_backend->AddSample(pair.first, std::move(pair.second));
 			}
 		}
 
@@ -589,13 +198,14 @@ namespace Sound {
 	bool Init()
 	{
 		PROFILE_SCOPED()
-		if (m_audioDevice) {
+		if (m_backend != nullptr) {
 			DestroyAllEvents();
 			return true;
 		}
 
-		if (SDL_Init(SDL_INIT_AUDIO) == -1) {
-			Output("Could not initialize SDL Audio: %s.\n", SDL_GetError());
+		try {
+			m_backend = new SdlAudioBackend();
+		} catch (...) {
 			return false;
 		}
 
@@ -605,22 +215,6 @@ namespace Sound {
 		//I'd rather do this in MusicPlayer and store in a different map too, this will do for now
 		Pi::GetApp()->GetAsyncStartupQueue()->Order(new LoadSoundJob("music", true));
 
-		SDL_AudioSpec wanted;
-		wanted.freq = FREQ;
-		wanted.channels = 2;
-		wanted.format = AUDIO_S16;
-		wanted.samples = BUF_SIZE;
-		wanted.callback = fill_audio;
-		wanted.userdata = 0;
-
-		// Automatically pick the best device.
-		// TODO: allow the user to select which device they'd like to use.
-		m_audioDevice = SDL_OpenAudioDevice(nullptr, 0, &wanted, nullptr, 0);
-		if (!m_audioDevice) {
-			Output("Could not open audio device: %s\n", SDL_GetError());
-			return false;
-		}
-
 		/* silence any sound events */
 		DestroyAllEvents();
 
@@ -629,36 +223,29 @@ namespace Sound {
 
 	void Uninit()
 	{
-		if (!m_audioDevice)
+		if (m_backend == nullptr) {
 			return;
+		}
 
 		DestroyAllEvents();
-		std::map<std::string, Sample>::iterator i;
-		for (i = sfx_samples.begin(); i != sfx_samples.end(); ++i)
-			delete[](*i).second.buf;
-		SDL_CloseAudioDevice(m_audioDevice);
-		m_audioDevice = 0;
+		delete m_backend;
+		m_backend = nullptr;
+
+		music_sample_keys.clear();
 	}
 
 	void Pause(int on)
 	{
-		if (bool(on) == (SDL_AUDIO_PAUSED == SDL_GetAudioDeviceStatus(m_audioDevice)))
-		{
-			return;
-		}
-		SDL_PauseAudioDevice(m_audioDevice, on);
+		m_backend->Pause(on);
 	}
 
 	void Event::Play(const char *fx, float volume_left, float volume_right, Op op)
 	{
 		Stop();
-		Sample* sample = GetSample(fx);
-		if (sample) {
-			eid = PlaySfxSample(sample, volume_left, volume_right, op);
-		}
+		eid = m_backend->Play(fx, volume_left, volume_right, op);
 	}
 
-	void Event::PlayMusic(const char *fx, float volume, float fadeDelta, bool repeat, Event* fadeOut)
+	void Event::PlayMusic(const char *fx, float volume, float fadeDelta, bool repeat, Event *fadeOut)
 	{
 		// The FadeOut, Stop, PlayMusicSample & VolumeAnimate calls perform
 		// five mutex lock operations. These could be reduced to a single
@@ -668,103 +255,46 @@ namespace Sound {
 			fadeOut->FadeOut(fadeDelta);
 		}
 		Stop();
-		Sample* sample = GetSample(fx);
-		if (sample) {
-			float start = fadeDelta ? 0.0f : volume;
-			eid = PlayMusicSample(sample, start, start, repeat ? Sound::OP_REPEAT : 0);
-			if (fadeDelta) {
-				VolumeAnimate(volume, volume, fadeDelta, fadeDelta);
-			}
+		float start = fadeDelta ? 0.0f : volume;
+		eid = m_backend->Play(fx, start, start, repeat ? Sound::OP_REPEAT : 0);
+		if (fadeDelta) {
+			VolumeAnimate(volume, volume, fadeDelta, fadeDelta);
 		}
 	}
 
 	bool Event::Stop()
 	{
-		if (eid) {
-			SDL_LockAudioDevice(m_audioDevice);
-			SoundEvent *s = GetEvent(eid);
-			if (s) {
-				DestroyEvent(s);
-			}
-			SDL_UnlockAudioDevice(m_audioDevice);
-			return s != nullptr;
-		} else {
-			return false;
-		}
+		return m_backend->EventStop(eid);
 	}
 
 	bool Event::IsPlaying() const
 	{
-		if (eid == 0)
-			return false;
-		else
-			return GetEvent(eid) != nullptr;
+		return m_backend->IsEventPlaying(eid);
 	}
 
 	bool Event::SetOp(Op op)
 	{
-		if (eid == 0) return false;
-		bool ret = false;
-		SDL_LockAudioDevice(m_audioDevice);
-		SoundEvent *se = GetEvent(eid);
-		if (se) {
-			se->op = op;
-			ret = true;
-		}
-		SDL_UnlockAudioDevice(m_audioDevice);
-		return ret;
+		return m_backend->EventSetOp(eid, op);
 	}
 
 	bool Event::VolumeAnimate(const float targetVol1, const float targetVol2, const float dv_dt1, const float dv_dt2)
 	{
-		SDL_LockAudioDevice(m_audioDevice);
-		SoundEvent *ev = GetEvent(eid);
-		if (ev) {
-			ev->targetVolume[0] = targetVol1;
-			ev->targetVolume[1] = targetVol2;
-			ev->rateOfChange[0] = dv_dt1 / float(FREQ);
-			ev->rateOfChange[1] = dv_dt2 / float(FREQ);
-		}
-		SDL_UnlockAudioDevice(m_audioDevice);
-		return (ev != nullptr);
+		return m_backend->EventVolumeAnimate(eid, targetVol1, targetVol2, dv_dt1, dv_dt2);
 	}
 
 	bool Event::SetVolume(const float vol_left, const float vol_right)
 	{
-		SDL_LockAudioDevice(m_audioDevice);
-		bool status = false;
-		for (unsigned int i = 0; i < MAX_WAVSTREAMS; i++) {
-			if (wavstream[i].sample && (wavstream[i].identifier == eid)) {
-				wavstream[i].volume[0] = vol_left;
-				wavstream[i].volume[1] = vol_right;
-				wavstream[i].targetVolume[0] = vol_left;
-				wavstream[i].targetVolume[1] = vol_right;
-				status = true;
-				break;
-			}
-		}
-		SDL_UnlockAudioDevice(m_audioDevice);
-		return status;
+		return m_backend->EventSetVolume(eid, vol_left, vol_right);
 	}
 
 	bool Event::FadeOut(float dv_dt, Op op)
 	{
-		bool found = VolumeAnimate(0.0f, 0.0f, dv_dt, dv_dt);
-		if (found)
-			SetOp(op | Sound::OP_STOP_AT_TARGET_VOLUME);
-		return found;
+		return m_backend->EventFadeOut(eid, dv_dt, op);
 	}
 
 	const std::vector<std::string> GetMusicFiles()
 	{
-		std::vector<std::string> songs;
-		songs.reserve(sfx_samples.size());
-		for (std::map<std::string, Sample>::const_iterator it = sfx_samples.begin();
-			 it != sfx_samples.end(); ++it) {
-			if (it->second.isMusic)
-				songs.emplace_back(it->first.c_str());
-		}
-		return songs;
+		return music_sample_keys;
 	}
 
 } /* namespace Sound */

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -8,7 +8,7 @@
 #include "Sound.h"
 #include "GameConfig.h"
 #ifdef PI_BUILD_WITH_OPENAL
-	#include "AlAudioBackend.h"
+#include "AlAudioBackend.h"
 #endif
 #include "AudioBackend.h"
 #include "Body.h"
@@ -209,12 +209,9 @@ namespace Sound {
 
 	std::string_view GetBackend()
 	{
-		if (dynamic_cast<SdlAudioBackend*>(m_backend) != nullptr)
-		{
+		if (dynamic_cast<SdlAudioBackend *>(m_backend) != nullptr) {
 			return SDLBackendName;
-		}
-		else if (dynamic_cast<AlAudioBackend*>(m_backend) != nullptr)
-		{
+		} else if (dynamic_cast<AlAudioBackend *>(m_backend) != nullptr) {
 			return OpenALBackendName;
 		}
 		return "Unknown Sound Backend";
@@ -241,18 +238,15 @@ namespace Sound {
 		}
 
 		try {
-			if (backend == SDLBackendName)
-			{
+			if (backend == SDLBackendName) {
 				m_backend = new SdlAudioBackend();
 			}
 #ifdef PI_BUILD_WITH_OPENAL
-			else if (backend == OpenALBackendName)
-			{
+			else if (backend == OpenALBackendName) {
 				m_backend = new AlAudioBackend();
 			}
 #endif
-			else
-			{
+			else {
 				throw std::runtime_error("Sound Backend does not exist");
 			}
 		} catch (...) {
@@ -357,8 +351,7 @@ namespace Sound {
 	const std::vector<std::string> GetMusicFiles()
 	{
 		std::vector<std::string> keys;
-		for (const auto& sample : m_samples)
-		{
+		for (const auto &sample : m_samples) {
 			keys.push_back(sample.first);
 		}
 		return keys;

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -29,6 +29,7 @@ namespace Sound {
 	static const double STREAM_IF_LONGER_THAN = 10.0;
 
 	static AudioBackend *m_backend = nullptr;
+	static std::vector<std::pair<std::string, Sample>> m_samples;
 
 	void SetMasterVolume(const float vol)
 	{
@@ -186,6 +187,7 @@ namespace Sound {
 				if (pair.second.isMusic) {
 					music_sample_keys.emplace_back(pair.first);
 				}
+				m_samples.emplace_back(pair.first, pair.second);
 				m_backend->AddSample(pair.first, std::move(pair.second));
 			}
 		}
@@ -196,25 +198,58 @@ namespace Sound {
 		std::map<std::string, Sample> m_loadedSounds;
 	};
 
-	bool Init()
+	BackendFlags GetAvailableBackends()
+	{
+		return AudioBackend_SDL | AudioBackend_OpenAL;
+	}
+
+	BackendId GetBackendId()
+	{
+		return m_backend->GetId();
+	}
+
+	bool Init(BackendId backend)
 	{
 		PROFILE_SCOPED()
 		if (m_backend != nullptr) {
-			DestroyAllEvents();
-			return true;
+			if (backend == m_backend->GetId()) {
+				DestroyAllEvents();
+				return true;
+			} else {
+				Uninit();
+			}
 		}
 
 		try {
-			m_backend = new AlAudioBackend();
+			switch (backend) {
+			case AudioBackend_OpenAL:
+				try {
+					m_backend = new AlAudioBackend();
+					break;
+				} catch (...) {
+					Output("Could not initialize OpenAL audio backend, falling back to default");
+				}
+			default:
+				m_backend = new SdlAudioBackend();
+				break;
+			}
 		} catch (...) {
+			Error("Could not initialize backend %u", backend);
 			return false;
 		}
 
-		// load all the wretched effects
-		Pi::GetApp()->GetAsyncStartupQueue()->Order(new LoadSoundJob("sounds", false));
+		if (m_samples.empty()) {
+			// load all the wretched effects
+			Pi::GetApp()->GetAsyncStartupQueue()->Order(new LoadSoundJob("sounds", false));
 
-		//I'd rather do this in MusicPlayer and store in a different map too, this will do for now
-		Pi::GetApp()->GetAsyncStartupQueue()->Order(new LoadSoundJob("music", true));
+			//I'd rather do this in MusicPlayer and store in a different map too, this will do for now
+			Pi::GetApp()->GetAsyncStartupQueue()->Order(new LoadSoundJob("music", true));
+		} else {
+			for (auto sample_copy : m_samples) {
+				m_backend->AddSample(sample_copy.first, std::move(sample_copy.second));
+			}
+			Pause(0);
+		}
 
 		/* silence any sound events */
 		DestroyAllEvents();

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Sound.h"
+#include "AlAudioBackend.h"
 #include "AudioBackend.h"
 #include "Body.h"
 #include "FileSystem.h"
@@ -204,7 +205,7 @@ namespace Sound {
 		}
 
 		try {
-			m_backend = new SdlAudioBackend();
+			m_backend = new AlAudioBackend();
 		} catch (...) {
 			return false;
 		}
@@ -289,12 +290,20 @@ namespace Sound {
 
 	bool Event::FadeOut(float dv_dt, Op op)
 	{
-		return m_backend->EventFadeOut(eid, dv_dt, op);
+		bool found = m_backend->EventVolumeAnimate(eid, 0.0f, 0.0f, dv_dt, dv_dt);
+		if (found)
+			m_backend->EventSetOp(eid, op | Sound::OP_STOP_AT_TARGET_VOLUME);
+		return found;
 	}
 
 	const std::vector<std::string> GetMusicFiles()
 	{
 		return music_sample_keys;
+	}
+
+	void Update(float delta_t)
+	{
+		m_backend->Update(delta_t);
 	}
 
 } /* namespace Sound */

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "Sound.h"
-#include "AlAudioBackend.h"
+#ifdef PI_BUILD_WITH_OPENAL
+	#include "AlAudioBackend.h"
+#endif
 #include "AudioBackend.h"
 #include "Body.h"
 #include "FileSystem.h"
@@ -200,7 +202,11 @@ namespace Sound {
 
 	BackendFlags GetAvailableBackends()
 	{
-		return AudioBackend_SDL | AudioBackend_OpenAL;
+		BackendFlags backends = AudioBackend_SDL;
+#ifdef PI_BUILD_WITH_OPENAL
+		backends |= AudioBackend_OpenAL;
+#endif
+		return backends;
 	}
 
 	BackendId GetBackendId()
@@ -222,6 +228,7 @@ namespace Sound {
 
 		try {
 			switch (backend) {
+#ifdef PI_BUILD_WITH_OPENAL
 			case AudioBackend_OpenAL:
 				try {
 					m_backend = new AlAudioBackend();
@@ -229,6 +236,7 @@ namespace Sound {
 				} catch (...) {
 					Output("Could not initialize OpenAL audio backend, falling back to default");
 				}
+#endif
 			default:
 				m_backend = new SdlAudioBackend();
 				break;

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -341,4 +341,14 @@ namespace Sound {
 		m_backend->Update(delta_t);
 	}
 
+	bool IsBinauralSupported()
+	{
+		return m_backend->IsBinauralSupported();
+	}
+
+	void EnableBinaural(bool enabled)
+	{
+		m_backend->EnableBinaural(enabled);
+	}
+
 } /* namespace Sound */

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -30,6 +30,8 @@ namespace Sound {
 
 	static const unsigned int FREQ = 44100;
 	static const double STREAM_IF_LONGER_THAN = 10.0;
+	constexpr std::string_view SDLBackendName = "SDL";
+	constexpr std::string_view OpenALBackendName = "OpenAL";
 
 	static AudioBackend *m_backend = nullptr;
 	static std::vector<std::pair<std::string, Sample>> m_samples;
@@ -196,25 +198,33 @@ namespace Sound {
 		std::map<std::string, Sample> m_loadedSounds;
 	};
 
-	BackendFlags GetAvailableBackends()
+	std::vector<std::string_view> GetAvailableBackends()
 	{
-		BackendFlags backends = AudioBackend_SDL;
+		std::vector<std::string_view> backends{ SDLBackendName };
 #ifdef PI_BUILD_WITH_OPENAL
-		backends |= AudioBackend_OpenAL;
+		backends.push_back(OpenALBackendName);
 #endif
 		return backends;
 	}
 
-	BackendId GetBackendId()
+	std::string_view GetBackend()
 	{
-		return m_backend->GetId();
+		if (dynamic_cast<SdlAudioBackend*>(m_backend) != nullptr)
+		{
+			return SDLBackendName;
+		}
+		else if (dynamic_cast<AlAudioBackend*>(m_backend) != nullptr)
+		{
+			return OpenALBackendName;
+		}
+		return "Unknown Sound Backend";
 	}
 
-	bool Init(BackendId backend)
+	bool Init(std::string_view backend)
 	{
 		PROFILE_SCOPED()
 		if (m_backend != nullptr) {
-			if (backend == m_backend->GetId()) {
+			if (backend == GetBackend()) {
 				DestroyAllEvents();
 				return true;
 			} else {
@@ -222,20 +232,28 @@ namespace Sound {
 			}
 		}
 
-		try {
-			switch (backend) {
+		if (backend.empty()) {
 #ifdef PI_BUILD_WITH_OPENAL
-			case AudioBackend_OpenAL:
-				try {
-					m_backend = new AlAudioBackend();
-					break;
-				} catch (...) {
-					Output("Could not initialize OpenAL audio backend, falling back to default");
-				}
+			backend = OpenALBackendName;
+#else
+			backend = SDLBackendName;
 #endif
-			default:
+		}
+
+		try {
+			if (backend == SDLBackendName)
+			{
 				m_backend = new SdlAudioBackend();
-				break;
+			}
+#ifdef PI_BUILD_WITH_OPENAL
+			else if (backend == OpenALBackendName)
+			{
+				m_backend = new AlAudioBackend();
+			}
+#endif
+			else
+			{
+				throw std::runtime_error("Sound Backend does not exist");
 			}
 		} catch (...) {
 			Error("Could not initialize backend %u", backend);

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -5,9 +5,11 @@
  * Sound, dude
  */
 
+#include "buildopts.h"
+
 #include "Sound.h"
 #include "GameConfig.h"
-#ifdef PI_BUILD_WITH_OPENAL
+#if BUILD_WITH_OPENAL
 #include "AlAudioBackend.h"
 #endif
 #include "AudioBackend.h"
@@ -201,7 +203,7 @@ namespace Sound {
 	std::vector<std::string_view> GetAvailableBackends()
 	{
 		std::vector<std::string_view> backends{ SDLBackendName };
-#ifdef PI_BUILD_WITH_OPENAL
+#if BUILD_WITH_OPENAL
 		backends.push_back(OpenALBackendName);
 #endif
 		return backends;
@@ -211,8 +213,10 @@ namespace Sound {
 	{
 		if (dynamic_cast<SdlAudioBackend *>(m_backend) != nullptr) {
 			return SDLBackendName;
+#if BUILD_WITH_OPENAL
 		} else if (dynamic_cast<AlAudioBackend *>(m_backend) != nullptr) {
 			return OpenALBackendName;
+#endif
 		}
 		return "Unknown Sound Backend";
 	}
@@ -230,7 +234,7 @@ namespace Sound {
 		}
 
 		if (backend.empty()) {
-#ifdef PI_BUILD_WITH_OPENAL
+#if BUILD_WITH_OPENAL
 			backend = OpenALBackendName;
 #else
 			backend = SDLBackendName;
@@ -241,7 +245,7 @@ namespace Sound {
 			if (backend == SDLBackendName) {
 				m_backend = new SdlAudioBackend();
 			}
-#ifdef PI_BUILD_WITH_OPENAL
+#if BUILD_WITH_OPENAL
 			else if (backend == OpenALBackendName) {
 				m_backend = new AlAudioBackend();
 			}

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Sound.h"
+#include "GameConfig.h"
 #ifdef PI_BUILD_WITH_OPENAL
 	#include "AlAudioBackend.h"
 #endif
@@ -75,8 +76,6 @@ namespace Sound {
 		(*volLeftOut) = Clamp((*volLeftOut), 0.0f, 1.0f);
 		(*volRightOut) = Clamp((*volRightOut), 0.0f, 1.0f);
 	}
-
-	static std::vector<std::string> music_sample_keys;
 
 	void BodyMakeNoise(const Body *b, const char *sfx, float vol)
 	{
@@ -186,9 +185,6 @@ namespace Sound {
 		void OnFinish() override
 		{
 			for (auto &pair : m_loadedSounds) {
-				if (pair.second.isMusic) {
-					music_sample_keys.emplace_back(pair.first);
-				}
 				m_samples.emplace_back(pair.first, pair.second);
 				m_backend->AddSample(pair.first, std::move(pair.second));
 			}
@@ -256,11 +252,14 @@ namespace Sound {
 			for (auto sample_copy : m_samples) {
 				m_backend->AddSample(sample_copy.first, std::move(sample_copy.second));
 			}
-			Pause(0);
 		}
 
-		/* silence any sound events */
-		DestroyAllEvents();
+		SetMasterVolume(Pi::config->Float("MasterVolume"));
+		SetSfxVolume(Pi::config->Float("SfxVolume"));
+		EnableBinaural(Pi::config->Int("BinauralRendering"));
+		if (Pi::config->Int("SfxMuted")) Sound::SetSfxVolume(0.f);
+
+		Pause(Pi::config->Int("MasterMuted"));
 
 		return true;
 	}
@@ -274,8 +273,6 @@ namespace Sound {
 		DestroyAllEvents();
 		delete m_backend;
 		m_backend = nullptr;
-
-		music_sample_keys.clear();
 	}
 
 	void Pause(int on)
@@ -341,7 +338,12 @@ namespace Sound {
 
 	const std::vector<std::string> GetMusicFiles()
 	{
-		return music_sample_keys;
+		std::vector<std::string> keys;
+		for (const auto& sample : m_samples)
+		{
+			keys.push_back(sample.first);
+		}
+		return keys;
 	}
 
 	void Update(float delta_t)

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -586,9 +586,7 @@ namespace Sound {
 		std::map<std::string, Sample> m_loadedSounds;
 	};
 
-	std::vector<std::string> s_audioDeviceNames = {};
-
-	bool Init(bool automaticallyOpenDevice)
+	bool Init()
 	{
 		PROFILE_SCOPED()
 		if (m_audioDevice) {
@@ -606,13 +604,6 @@ namespace Sound {
 
 		//I'd rather do this in MusicPlayer and store in a different map too, this will do for now
 		Pi::GetApp()->GetAsyncStartupQueue()->Order(new LoadSoundJob("music", true));
-
-		UpdateAudioDevices();
-
-		// If we're going to manually pick a device later, don't open a default one now.
-		if (!automaticallyOpenDevice) {
-			return true;
-		}
 
 		SDL_AudioSpec wanted;
 		wanted.freq = FREQ;
@@ -636,33 +627,6 @@ namespace Sound {
 		return true;
 	}
 
-	bool InitDevice(std::string &name)
-	{
-		if (m_audioDevice) {
-			DestroyAllEvents();
-			SDL_PauseAudioDevice(m_audioDevice, 1);
-			SDL_CloseAudioDevice(m_audioDevice);
-			m_audioDevice = 0;
-		}
-
-		SDL_AudioSpec wanted = {};
-		wanted.freq = FREQ;
-		wanted.channels = 2;
-		wanted.format = AUDIO_S16;
-		wanted.samples = BUF_SIZE;
-		wanted.callback = fill_audio;
-		wanted.userdata = 0;
-
-		m_audioDevice = SDL_OpenAudioDevice(name.c_str(), 0, &wanted, nullptr, 0);
-		if (!m_audioDevice) {
-			Output("Could not open audio device: %s\n", SDL_GetError());
-			return false;
-		}
-
-		DestroyAllEvents();
-		return true;
-	}
-
 	void Uninit()
 	{
 		if (!m_audioDevice)
@@ -674,16 +638,6 @@ namespace Sound {
 			delete[](*i).second.buf;
 		SDL_CloseAudioDevice(m_audioDevice);
 		m_audioDevice = 0;
-	}
-
-	void UpdateAudioDevices()
-	{
-		PROFILE_SCOPED()
-		s_audioDeviceNames.clear();
-		for (int idx = 0; idx < SDL_GetNumAudioDevices(0); idx++) {
-			const char *name = SDL_GetAudioDeviceName(idx, 0);
-			s_audioDeviceNames.emplace_back(name);
-		}
 	}
 
 	void Pause(int on)

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -7,8 +7,8 @@
 
 #include "buildopts.h"
 
-#include "Sound.h"
 #include "GameConfig.h"
+#include "Sound.h"
 #if BUILD_WITH_OPENAL
 #include "AlAudioBackend.h"
 #endif
@@ -202,7 +202,7 @@ namespace Sound {
 
 	std::vector<std::string_view> GetAvailableBackends()
 	{
-		std::vector<std::string_view> backends{ SDLBackendName };
+		std::vector<std::string_view> backends { SDLBackendName };
 #if BUILD_WITH_OPENAL
 		backends.push_back(OpenALBackendName);
 #endif

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -25,7 +25,7 @@ namespace Sound {
 			eid(0) {}
 		void Play(const char *fx, const float volume_left, const float volume_right, Op op);
 		void Play(const char *fx) { Play(fx, 1.0f, 1.0f, 0); }
-		void PlayMusic(const char *fx, float volume, float fadeDelta, bool repeat, Event* fadeOut = nullptr);
+		void PlayMusic(const char *fx, float volume, float fadeDelta, bool repeat, Event *fadeOut = nullptr);
 		bool Stop();
 		bool IsPlaying() const;
 		bool SetOp(Op op);

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -46,11 +46,8 @@ namespace Sound {
 		uint32_t eid;
 	};
 
-	bool Init(bool automaticallyOpenDevice = true);
-	bool InitDevice(std::string &name);
+	bool Init();
 	void Uninit();
-	std::vector<std::string> &GetAudioDevices();
-	void UpdateAudioDevices();
 	/**
 	 * Silence all active sound events.
 	 */

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -17,8 +17,7 @@ namespace Sound {
 		OP_STOP_AT_TARGET_VOLUME = (1 << 1)
 	};
 	typedef uint32_t Op;
-	enum
-	{
+	enum {
 		// Bitflags!
 		AudioBackend_SDL = 1 << 0,
 		AudioBackend_OpenAL = 1 << 1,
@@ -75,6 +74,8 @@ namespace Sound {
 	const std::vector<std::string> GetMusicFiles();
 	void Update(float delta_t);
 
+	bool IsBinauralSupported();
+	void EnableBinaural(bool enabled);
 } /* namespace Sound */
 
 #endif /* __SOUND_H */

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -5,7 +5,6 @@
 #define __SOUND_H
 
 #include <cstdint>
-#include <map>
 #include <string>
 #include <vector>
 
@@ -18,6 +17,14 @@ namespace Sound {
 		OP_STOP_AT_TARGET_VOLUME = (1 << 1)
 	};
 	typedef uint32_t Op;
+	enum
+	{
+		// Bitflags!
+		AudioBackend_SDL = 1 << 0,
+		AudioBackend_OpenAL = 1 << 1,
+	};
+	typedef uint32_t BackendId;
+	typedef uint32_t BackendFlags;
 
 	class Event {
 	public:
@@ -46,7 +53,10 @@ namespace Sound {
 		uint32_t eid;
 	};
 
-	bool Init();
+	BackendFlags GetAvailableBackends();
+	BackendId GetBackendId();
+
+	bool Init(BackendId backend);
 	void Uninit();
 	/**
 	 * Silence all active sound events.

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -17,18 +17,6 @@ namespace Sound {
 		OP_STOP_AT_TARGET_VOLUME = (1 << 1)
 	};
 	typedef uint32_t Op;
-	enum {
-		// Bitflags!
-		AudioBackend_SDL = 1 << 0,
-		AudioBackend_OpenAL = 1 << 1,
-#ifdef PI_BUILD_WITH_OPENAL
-		AudioBackend_Default = AudioBackend_OpenAL,
-#else
-		AudioBackend_Default = AudioBackend_SDL,
-#endif
-	};
-	typedef uint32_t BackendId;
-	typedef uint32_t BackendFlags;
 
 	class Event {
 	public:
@@ -57,10 +45,10 @@ namespace Sound {
 		uint32_t eid;
 	};
 
-	BackendFlags GetAvailableBackends();
-	BackendId GetBackendId();
+	std::vector<std::string_view> GetAvailableBackends();
+	std::string_view GetBackend();
 
-	bool Init(BackendId backend);
+	bool Init(std::string_view backend);
 	void Uninit();
 	/**
 	 * Silence all active sound events.

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -21,6 +21,11 @@ namespace Sound {
 		// Bitflags!
 		AudioBackend_SDL = 1 << 0,
 		AudioBackend_OpenAL = 1 << 1,
+#ifdef PI_BUILD_WITH_OPENAL
+		AudioBackend_Default = AudioBackend_OpenAL,
+#else
+		AudioBackend_Default = AudioBackend_SDL,
+#endif
 	};
 	typedef uint32_t BackendId;
 	typedef uint32_t BackendFlags;

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -63,6 +63,7 @@ namespace Sound {
 	void SetSfxVolume(const float vol);
 	float GetSfxVolume();
 	const std::vector<std::string> GetMusicFiles();
+	void Update(float delta_t);
 
 } /* namespace Sound */
 

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -52,7 +52,24 @@ namespace Sound {
 		}
 		next->PlayMusic(name.c_str(), m_volume, fadeDelta, repeat, current);
 		m_playing = true;
+		m_repeating = repeat;
 		m_currentSongName = name;
+	}
+
+	void MusicPlayer::PlayAgain()
+	{
+		if (m_eventOne.IsPlaying())
+		{
+			m_eventOne.Stop();
+		}
+		if (m_eventTwo.IsPlaying())
+		{
+			m_eventTwo.Stop();
+		}
+		if (m_playing)
+		{
+			Play(m_currentSongName, m_repeating);
+		}
 	}
 
 	void MusicPlayer::Stop()

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -58,16 +58,13 @@ namespace Sound {
 
 	void MusicPlayer::PlayAgain()
 	{
-		if (m_eventOne.IsPlaying())
-		{
+		if (m_eventOne.IsPlaying()) {
 			m_eventOne.Stop();
 		}
-		if (m_eventTwo.IsPlaying())
-		{
+		if (m_eventTwo.IsPlaying()) {
 			m_eventTwo.Stop();
 		}
-		if (m_playing)
-		{
+		if (m_playing) {
 			Play(m_currentSongName, m_repeating);
 		}
 	}
@@ -99,7 +96,7 @@ namespace Sound {
 		}
 	}
 
-	const std::string& MusicPlayer::GetCurrentSongName() const
+	const std::string &MusicPlayer::GetCurrentSongName() const
 	{
 		return m_currentSongName;
 	}

--- a/src/sound/SoundMusic.h
+++ b/src/sound/SoundMusic.h
@@ -18,6 +18,7 @@ namespace Sound {
 		float GetVolume() const;
 		void SetVolume(const float);
 		void Play(const std::string &, const bool repeat = false, const float fadeDelta = 1.f);
+		void PlayAgain();
 		void Stop();
 		void FadeOut(const float fadeDelta);
 		void Update();
@@ -37,6 +38,7 @@ namespace Sound {
 		bool m_eventOnePlaying;
 		std::string m_currentSongName;
 		bool m_enabled;
+		bool m_repeating;
 	};
 } // namespace Sound
 

--- a/src/sound/SoundMusic.h
+++ b/src/sound/SoundMusic.h
@@ -22,7 +22,7 @@ namespace Sound {
 		void Stop();
 		void FadeOut(const float fadeDelta);
 		void Update();
-		const std::string& GetCurrentSongName() const;
+		const std::string &GetCurrentSongName() const;
 		const std::vector<std::string> GetSongList() const;
 		bool IsPlaying() const;
 		void SetEnabled(bool);


### PR DESCRIPTION
- Defined `AudioBackend` pure virtual class that abstracts base audio functionality
- Extracted current audio system to `SDLAudioBackend`
- Implemented `AlAudioBackend` that uses OpenAL Soft
- Updated audio menu and INI config to be able to switch between audio backends
- Updated CMakeLists so that it is possible to build either with or without the OpenAL audio backend
  - On Windows, dependencies are provided by pioneer-thirdparty. Added the required binaries in https://github.com/pioneerspacesim/pioneer-thirdparty/pull/34

Note: this is what I think the most minimal changeset that brings OpenAL audio to Pioneer. It is out of scope for this PR to change how the rest of the program interacts with the audio system.
