### PR TITLE
Improve the follow modes for too far ranges

### DIFF
--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -699,6 +699,30 @@ static int l_player_set_follow_mode(lua_State *l)
 }
 
 /*
+ * Function: GetMaxFollowDistance(mode)
+ *
+ * Parameters:
+ *
+ *   mode - a string 'FOLLOW_POS' or 'FOLLOW_ORI'
+ *
+ * Returns:
+ *
+ *   number, distance in meters for specified mode
+ *
+ */
+static int l_player_get_max_follow_distance(lua_State *l)
+{
+	Player *player = LuaObject<Player>::CheckFromLua(1);
+	auto mode_name = LuaPull<const char *>(l, 2);
+	int value = EnumStrings::GetValue("FollowMode", mode_name);
+	if (value == -1)
+		return luaL_error(l, "Player:GetMaxFollowDistance(): invalid follow mode '%s' specified\n", mode_name);
+	auto mode = static_cast<PlayerShipController::FollowMode>(value);
+	LuaPush(l, PlayerShipController::maxFollowDistance[mode]);
+	return 1;
+}
+
+/*
  * Function: GetSpeedLimit(speed_limit)
  *
  * Returns:
@@ -820,6 +844,7 @@ void LuaObject<Player>::RegisterClass()
 		{ "SetCruiseDirection", l_player_set_cruise_direction },
 		{ "GetFollowMode", l_player_get_follow_mode },
 		{ "SetFollowMode", l_player_set_follow_mode },
+		{ "GetMaxFollowDistance", l_player_get_max_follow_distance },
 		{ "GetSpeedLimit", l_player_get_speed_limit },
 		{ "SetSpeedLimit", l_player_set_speed_limit },
 		{ "SetSpeedLimiterActive", l_player_set_speed_limiter_active },

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -638,8 +638,8 @@ void PlayerShipController::PollControls(const float timeStep, int *mouseMotion, 
 	// only linear thrust ^ is allowed in the system map
 	if (Pi::GetView() == Pi::game->GetSystemView()) return;
 
-	m_ship->SetGunState(0, 0);
-	m_ship->SetGunState(1, 0);
+	auto gunManager = m_ship->GetComponent<GunManager>();
+	if (gunManager) gunManager->SetAllGroupsFiring(false);
 
 	if (Pi::input->MouseButtonState(SDL_BUTTON_RIGHT)) {
 		// use ship rotation relative to system, unchanged by frame transitions
@@ -687,9 +687,9 @@ void PlayerShipController::PollControls(const float timeStep, int *mouseMotion, 
 		m_mouseActive = false;
 	}
 
-	if (InputBindings.primaryFire->IsActive() || (Pi::input->MouseButtonState(SDL_BUTTON_LEFT) && Pi::input->MouseButtonState(SDL_BUTTON_RIGHT))) {
-		//XXX worldview? madness, ask from ship instead
-		m_ship->SetGunState(Pi::game->GetWorldView()->GetActiveWeapon(), 1);
+	if (gunManager &&
+		(InputBindings.primaryFire->IsActive() || (Pi::input->MouseButtonState(SDL_BUTTON_LEFT) && Pi::input->MouseButtonState(SDL_BUTTON_RIGHT)))) {
+		gunManager->SetGroupFiring(Pi::game->GetWorldView()->GetActiveWeapon(), true);
 	}
 
 	vector3d wantAngVel = vector3d(

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -514,6 +514,15 @@ void PlayerShipController::StaticUpdate(const float timeStep)
 	UpdateLandingGear();
 
 	if (m_ship->GetFlightState() == Ship::FLYING) {
+
+		if (m_followTarget) {
+			double distSqr = m_followTarget->GetPositionRelTo(m_ship).LengthSqr();
+			if ((m_followMode == FOLLOW_ORI && distSqr > maxFollowDistanceSqr[FOLLOW_ORI]) ||
+				(m_followMode == FOLLOW_POS && distSqr > maxFollowDistanceSqr[FOLLOW_POS])) {
+				SetFollowTarget(nullptr);
+			}
+		}
+
 		switch (m_flightControlState) {
 		case CONTROL_FIXSPEED:
 			PollControls(timeStep, mouseMotion, act);

--- a/src/ship/PlayerShipController.h
+++ b/src/ship/PlayerShipController.h
@@ -43,8 +43,6 @@ public:
 	void SelectTarget();
 	void CycleHostiles();
 
-
-
 	//targeting
 	//XXX AI should utilize one or more of these
 	Body *GetCombatTarget() const;
@@ -66,6 +64,16 @@ public:
 	enum FollowMode { // <enum scope='PlayerShipController' name=FollowMode public>
 		FOLLOW_POS,
 		FOLLOW_ORI
+	};
+
+	static constexpr double maxFollowDistance[] = {
+		1000000.0, // FOLLOW_POS
+		10000.0    // FOLLOW_ORI
+	};
+
+	static constexpr double maxFollowDistanceSqr[] = {
+		maxFollowDistance[0] * maxFollowDistance[0],
+		maxFollowDistance[1] * maxFollowDistance[1]
 	};
 
 	void SetCruiseDirection(CruiseDirection mode);


### PR DESCRIPTION
Probably a slightly more thorough solution to the problem of #6081. 
If earlier this problem was solved through the opportunity to manually turn off the follow mode, even when it is too far for it, now it is turned off automatically. Also, a different maximum range is assigned for different modes. For follow position mode, this is 1000 km, since it can be convenient for intercepting the ship. For the follow orientation mode, it is 10 km, since it makes little sense over long distances, and the ship most likely cannot correctly follow the rotating target.

Also along the way fixed some warnings in `PlayerShipController`.