### PR TITLE
Feat/ship market show details

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -307,6 +307,10 @@
     "description": "graphics option in game settings menu ",
     "message": "Compress Textures"
   },
+  "COMPUTER_MOUNTS": {
+    "description": "How many slots or mounts exist on the ship for fitting COMPUTER equipment (e.g. autopilot, trade computer, etc)",
+    "message": "Computer mounts"
+  },
   "CONFIRM_PURCHASE": {
     "description": "",
     "message": "Confirm purchase"
@@ -1307,6 +1311,10 @@
     "description": "",
     "message": "Hull integrity"
   },
+  "HULL_MOUNTS": {
+    "description": "How many slots or mounts exist on the ship for fitting Hull mounted equipment (eg. Atmospheric Shielding)",
+    "message": "Hull mounts"
+  },
   "HULL_REPAIRED_BY_NAME_NOW_AT_N_PERCENT": {
     "description": "",
     "message": "Hull repaired by {name}, now at {repairPercent}%"
@@ -1675,9 +1683,17 @@
     "description": "For displaying commodity information",
     "message": "Minor Import"
   },
+  "MISSILE_BAYS": {
+    "description": "How many slots or mounts exist on the ship for Missile Bays.",
+    "message": "Missile bays"
+  },
   "MISSILE_MOUNTS": {
     "description": "",
     "message": "Missile mounts"
+  },
+  "MISSILE_PYLONS": {
+    "description": "How many slots or mounts exist on the ship for Missile Pylons.",
+    "message": "Missile pylons"
   },
   "MISSIONS": {
     "description": "",
@@ -2299,6 +2315,10 @@
     "description": "Title for sell-price column in commodity market",
     "message": "Sell"
   },
+  "SENSOR_MOUNTS": {
+    "description": "How many slots or mounts exist on the ship for fitting SENSOR equipment (e.g. radar, etc)",
+    "message": "Sensor mounts"
+  },
   "SENSORS": {
     "description": "Crew skill",
     "message": "Sensors"
@@ -2334,6 +2354,10 @@
   "SET_TO_ZERO": {
     "description": "For the speed limiter button",
     "message": "Set to zero"
+  },
+  "SHIELD_MOUNTS": {
+    "description": "How many slots or mounts exist on the ship for fitting Shields",
+    "message": "Shield mounts"
   },
   "SHIP": {
     "description": "",
@@ -2494,6 +2518,10 @@
   "STATUS": {
     "description": "",
     "message": "Status"
+  },
+  "STRUCTURE_MOUNTS": {
+    "description": "How many slots or mounts exist on the ship for fitting Structural equipment (e.g. Hull Reinforcement)",
+    "message": "Structure mounts"
   },
   "SUMMARY": {
     "description": "Tab item in the start game menu",
@@ -2687,6 +2715,10 @@
     "description": "",
     "message": "Used"
   },
+  "UTILITY_MOUNTS": {
+    "description": "How many slots or mounts exist on the ship for fitting UTILITY equipment (e.g. scanners) ",
+    "message": "Utility mounts"
+  },
   "VERY_HIGH": {
     "description": "Game settings option: graphic resolution",
     "message": "Very high"
@@ -2738,6 +2770,10 @@
   "WAGE": {
     "description": "Salary of crew shown in crew roster",
     "message": "Wage"
+  },
+  "WEAPON_MOUNTS": {
+    "description": "How many slots or mounts exist on the ship for fitting Weapons.",
+    "message": "Weapon mounts"
   },
   "WEIGHT_EMPTY": {
     "description": "",

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -353,7 +353,7 @@ local function getNumSlotsCompatibleWithType(def, type)
 	local count = 0
 
 	for _, slot in pairs(config.slots) do
-		if EquipSet.SlotTypeMatches(type, slot.type) then
+		if EquipSet.SlotTypeMatches(slot.type, type) then
 			count = count + (slot.count or 1)
 		end
 	end

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -492,14 +492,24 @@ local tradeMenu = function()
 						shipFormatAndCompare:draw_deltav_cell( l.DELTA_V_FULL, "fullMass", "massAtCapacity")
 						shipFormatAndCompare:draw_unformated_cell( l.MAXIMUM_CREW, "maxCrew" )
 						shipFormatAndCompare:draw_deltav_cell( l.DELTA_V_MAX, "fullMass", "hullMass")
-						shipFormatAndCompare:draw_equip_slot_cell( l.MISSILE_MOUNTS, "missile" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.PASSENGER_CABIN_CAPACITY, "cabin" )
 						shipFormatAndCompare:draw_yes_no_equip_slot_cell( l.ATMOSPHERIC_SHIELDING, "hull.atmo_shield" )
 						shipFormatAndCompare:draw_atmos_pressure_limit_cell( l.ATMO_PRESS_LIMIT )
+
+						shipFormatAndCompare:draw_equip_slot_cell( l.SHIELD_MOUNTS, "shield" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.HULL_MOUNTS, "hull" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.WEAPON_MOUNTS, "weapon" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.STRUCTURE_MOUNTS, "structure" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.MISSILE_MOUNTS, "missile" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.COMPUTER_MOUNTS, "computer" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.MISSILE_PYLONS, "pylon" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.SENSOR_MOUNTS, "sensor" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.MISSILE_BAYS, "missile_bay" )
+
 						shipFormatAndCompare:draw_equip_slot_cell( l.SCOOP_MOUNTS, "scoop" )
-						shipFormatAndCompare:draw_equip_slot_cell( l.PASSENGER_CABIN_CAPACITY, "cabin" )
+						shipFormatAndCompare:draw_equip_slot_cell( l.UTILITY_MOUNTS, "utility" )
 
 						ui.endTable()
-
 					end)
 				end)
 


### PR DESCRIPTION
**DRAFT PR - discuss details**

----

**TODO:** 

- display a list of equipment installed on the ship.
- introspect the ships and display data accordingly instead of hard-coding the various slots.
- display the slot sizes?

**DISCUSS:**

- refactor equipment and slots? For example, scanners are in "utility" slots instead of "sensor" slots. The different scoops are in different slots. There are 3 (!) slot types which take missiles or missile equipment. etc.

----

Fixes #6183

The ShipMarket does not display all the statistic about the ships, specifically, the different slots available on each ship.

This PR adds (most of?) the different slots to the ship comparison display.


![image](https://github.com/user-attachments/assets/017859d2-db9a-43b6-ae72-ffd8ed5a2be2)
