### PR TITLE
Cargo Run custom risk message

### DIFF
--- a/data/lang/module-cargorun/en.json
+++ b/data/lang/module-cargorun/en.json
@@ -107,6 +107,18 @@
     "description": "custom cargo",
     "message": "Art objects"
   },
+  "ART_OBJECTS_RISK_MESSAGE_1": {
+    "description": "Answer to question: Will I be in any danger?",
+    "message": "Unless you consider art critics a risk, no."
+  },
+  "ART_OBJECTS_RISK_MESSAGE_2": {
+    "description": "Answer to question: Will I be in any danger?",
+    "message": "Between you and me. Don't look at it and you'll be fine."
+  },
+  "ART_OBJECTS_RISK_MESSAGE_3": {
+    "description": "Answer to question: Will I be in any danger?",
+    "message": "Risk? What do you know about 25th century impressionism?"
+  },
   "CARGO": {
     "description": "",
     "message": "Cargo:"
@@ -223,6 +235,10 @@
     "description": "custom cargo",
     "message": "Explosives"
   },
+  "EXPLOSIVES_RISK_MESSAGE_1": {
+    "description": "Answer to question: Will I be in any danger?",
+    "message": "Well, it's explosives."
+  },
   "FAILUREMSG_1": {
     "description": "",
     "message": "I'm very disappointed by the late delivery. You will not be paid."
@@ -262,6 +278,10 @@
   "HAZARDOUS_SUBSTANCES": {
     "description": "custom cargo",
     "message": "Hazardous substances"
+  },
+  "HAZARDOUS_SUBSTANCES_RISK_MESSAGE_1": {
+    "description": "Answer to question: Will I be in any danger?",
+    "message": "I guess you shouldn't open the containers."
   },
   "HOWMUCH_1": {
     "description": "regarding mass, always more than 1t",
@@ -475,6 +495,14 @@
     "description": "custom cargo, also used in the NewsEventCommodity module, a nod to Star Trek's Tribble (check wikipedia)",
     "message": "Quibbles"
   },
+  "QUIBBLES_RISK_MESSAGE_1": {
+    "description": "Answer to question: Will I be in any danger?",
+    "message": "Don't look them in the eyes."
+  },
+  "QUIBBLES_RISK_MESSAGE_2": {
+    "description": "Answer to question: Will I be in any danger?",
+    "message": "They're soo fluffy."
+  },
   "RISK_1": {
     "description": "",
     "message": "I expect no hassle."
@@ -626,6 +654,10 @@
   "WEDDING_DRESSES": {
     "description": "custom cargo",
     "message": "Wedding dresses"
+  },
+  "WEDDING_DRESSES_RISK_MESSAGE_1": {
+    "description": "Answer to question: Will I be in any danger?",
+    "message": "Over wedding dresses?"
   },
   "WE_HAVE_LOADED_UP_THE_CARGO_ON_YOUR_SHIP": {
     "description": "",

--- a/data/libs/CommodityType.lua
+++ b/data/libs/CommodityType.lua
@@ -1,6 +1,7 @@
 -- Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
+local Engine = require 'Engine'
 local Lang = require 'Lang'
 local Serializer = require 'Serializer'
 local utils = require 'utils'
@@ -67,10 +68,26 @@ function CommodityType:Constructor(name, data)
 	for k, v in pairs(data) do self[k] = v end
 
 	local l = Lang.GetResource(self.l10n_resource)
+
+	-- This function returns the number of flavours of the given string str
+	-- It is assumed that the first flavour has suffix '_1'
+	local getNumberOfFlavours = function (str)
+		local num = 1
+
+		while l:get(str .. num) do
+			num = num + 1
+		end
+		return num - 1
+	end
+
+	local numriskmessages = getNumberOfFlavours(self.l10n_key .. "_RISK_MESSAGE_")
+
 	---@type { name: string, description: string }
+	--local numriskmessage = getNumberOfFlavours( "_RISK_MESSAGE")
 	self.lang = {
 		name = l[self.l10n_key],
-		description = l:get(self.l10n_key .. "_DESCRIPTION") or ""
+		description = l:get(self.l10n_key .. "_DESCRIPTION") or "",
+		numriskmessages = numriskmessages
 	}
 end
 
@@ -86,6 +103,21 @@ end
 -- Returns the translated description of this commodity
 function CommodityType:GetDescription()
 	return self.lang.description
+end
+
+-- Method: GetRiskMessage()
+--
+-- Returns alternative string for possible danger of the mission. Not all
+-- cargo has the same danger involved.
+function CommodityType:GetRiskMessage()
+	local l = Lang.GetResource(self.l10n_resource)
+
+	print("numrisk: " .. self.lang.numriskmessages)
+	local riskmessage = Engine.rand:Integer(self.lang.numriskmessages)
+	print("riskmessage: " .. riskmessage)
+	local string = l:get(self.l10n_key .. "_RISK_MESSAGE_" .. riskmessage) or ""
+	print("string: " .. string)
+	return string
 end
 
 ---@type table<string, CommodityType>

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -80,13 +80,27 @@ local getNumberOfFlavours = function (str)
 end
 
 local getRiskMsg = function (mission)
+	local branch
+	if mission.wholesaler then branch = "WHOLESALER" else branch = mission.branch end
+	local risk = math.floor(mission.risk * (getNumberOfFlavours("RISK_" .. branch) - 1)) + 1
+				or math.floor(mission.risk * (getNumberOfFlavours("RISK") - 1)) + 1
+
+	-- If the risk is low, then maybe there is an alternative message available?
+	local cargoRiskMessage = mission.cargotype:GetRiskMessage() or ""
+	print("cargoRiskMessage: " .. cargoRiskMessage)
+	if risk < 2 and Engine.rand:Integer(0, 9) < 1 then
+		if not (cargoRiskMessage == "") then
+			return cargoRiskMessage -- Alternative string (_RISK_MESSAGE)
+		end
+	end
+
 	if mission.localdelivery then
 		return l.RISK_1 -- very low risk -> no specific text to give no confusing answer
 	else
-		local branch
 		if mission.wholesaler then branch = "WHOLESALER" else branch = mission.branch end
-		return l:get("RISK_" .. branch .. "_" .. math.floor(mission.risk * (getNumberOfFlavours("RISK_" .. branch) - 1)) + 1)
-			or l["RISK_" .. math.floor(mission.risk * (getNumberOfFlavours("RISK") - 1)) + 1]
+		print("risk: " .. risk)
+		return l:get("RISK_" .. branch .. "_" .. risk + 1)
+			or l["RISK_" .. risk + 1]
 	end
 end
 


### PR DESCRIPTION
Alternative strings for the 'Will I be in any danger' message.

Spice up the risk messages with occasional per cargo messages. You can have more than one alternative string and it's only considered when there is no risk involved.

**Mission**
<img width="425" height="320" alt="message1" src="https://github.com/user-attachments/assets/d099b96a-a2df-4113-b1a7-3cd0ff745cd5" />

**Default risk message**
<img width="425" height="304" alt="message3" src="https://github.com/user-attachments/assets/35339843-35f0-40a3-84b5-be25d2fd2084" />

**Alternative per cargo risk message**
<img width="425" height="305" alt="message2" src="https://github.com/user-attachments/assets/33364ef2-5807-42d1-9a0e-ab9cd080cc22" />
