### PR TITLE
Add tooltip for pump down buttons on info view

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2051,6 +2051,22 @@
     "description": "Drain the fuel tank",
     "message": "Pump down"
   },
+  "PUMP_DOWN_FROM_CARGO_TOOLTIP": {
+    "description": "Tooltip for Info screen",
+    "message": "Pump %i t from cargo"
+  },
+  "PUMP_DOWN_FROM_HYPERDRIVE_TOOLTIP": {
+    "description": "Tooltip for Info screen",
+    "message": "Pump %i t from hyperdrive to fuel tanks"
+  },
+  "PUMP_DOWN_TO_CARGO_TOOLTIP": {
+    "description": "Tooltip for Info screen",
+    "message": "Pump %i t to cargo"
+  },
+  "PUMP_DOWN_TO_HYPERDRIVE_TOOLTIP": {
+    "description": "Tooltip for Info screen",
+    "message": "Pump %i t to hyperdrive from fuel tanks"
+  },
   "PURCHASE_PAINTJOB": {
     "description": "Paintshop button",
     "message": "Purchase Paintjob"

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -20,8 +20,6 @@ local pionillium = ui.fonts.pionillium
 local orbiteer = ui.fonts.orbiteer
 local Vector2 = _G.Vector2
 
-local iconSize = ui.rescaleUI(Vector2(28, 28))
-local buttonSpaceSize = iconSize
 -- FIXME: need to manually set itemSpacing to be able to properly size columns
 -- Need a style-var query system for best effect
 local itemSpacing = ui.rescaleUI(Vector2(6, 12), Vector2(1600, 900))
@@ -229,8 +227,9 @@ local function fuelTransferButton(drive, amt)
 
 	local color = driveEnabled and ui.theme.buttonColors.disabled or ui.theme.buttonColors.default
 	local icon = amt < 0 and icons.chevron_down or icons.chevron_up
+	local tooltip = amt < 0 and l.PUMP_DOWN_FROM_HYPERDRIVE_TOOLTIP or l.PUMP_DOWN_TO_HYPERDRIVE_TOOLTIP
 
-	if ui.button(ui.get_icon_glyph(icon) .. tostring(math.abs(amt)), Vector2(100, 0), color) then
+	if ui.button(ui.get_icon_glyph(icon) .. tostring(math.abs(amt)), Vector2(100, 0), color, string.format(tooltip, math.abs(amt))) then
 		if not driveEnabled then
 			if drive.fuel == Commodities.hydrogen then
 				transfer_hyperfuel_hydrogen(drive, amt)
@@ -286,7 +285,7 @@ local function drawPumpDialog()
 	ui.sameLine(width)
 	local options = {1, 10, 100}
 	for _, k in ipairs(options) do
-		if ui.button(tostring(k)  .. "##fuel", Vector2(100, 0)) then
+		if ui.button(tostring(k)  .. "##fuel", Vector2(100, 0), nil, string.format(l.PUMP_DOWN_FROM_CARGO_TOOLTIP, k)) then
 			-- Refuel k tonnes from cargo hold
 			Game.player:Refuel(Commodities.hydrogen, k)
 		end
@@ -301,7 +300,7 @@ local function drawPumpDialog()
 	ui.sameLine(width)
 	for _, v in ipairs(options) do
 		local fuel = -1*v
-		if ui.button(fuel .. "##pump", Vector2(100, 0)) then
+		if ui.button(fuel .. "##pump", Vector2(100, 0), nil, string.format(l.PUMP_DOWN_TO_CARGO_TOOLTIP, v)) then
 			pumpDown(fuel)
 		end
 		ui.sameLine()


### PR DESCRIPTION
Do we want this?
I've added it because I can never remember how these buttons work, which might be an indication there's a deeper UI issue. 

Anyway, if we want it I can clean this up and add it to localization. Looks like so now:

https://github.com/user-attachments/assets/3e8a63ea-ddde-41e8-968b-cf22ea6e6064


ping @bszlrd & @sturnclaw 