### PR TITLE
Show the return location in the mission list, if avaiable

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2551,6 +2551,10 @@
     "description": "Arm of the Milky Way galaxy",
     "message": "3kpc arm"
   },
+  "TO_PICK_UP": {
+    "description": "Mission status",
+    "message": "To pick up"
+  },
   "TOGGLE_CARGO_WINDOW": {
     "description": "Label for a button toggling the cargo display window.",
     "message": "Toggle Cargo Window"

--- a/data/libs/Mission.lua
+++ b/data/libs/Mission.lua
@@ -90,9 +90,9 @@ Mission = {
 	reward = 0,
 
 --
--- Attribute:Location
+-- Attribute: destination
 --
--- A [SystemPath] for the destination space station
+-- A [SystemPath] or string for the (next) destination
 --
 -- Availability:
 --
@@ -102,7 +102,7 @@ Mission = {
 --
 --   experimental
 --
-	location = nil,
+	destination = nil,
 
 --
 -- Attribute: status
@@ -187,12 +187,12 @@ Mission = {
 -- Create a new mission and add it to the player's mission list
 --
 -- >	missionRef = Mission.New({
--- >		'type'     = type,
--- >		'client'   = client,
--- >		'due'      = due,
--- >		'reward'   = reward,
--- >		'location' = location,
--- >		'status'   = status,
+-- >		'type'        = type,
+-- >		'client'      = client,
+-- >		'due'         = due,
+-- >		'reward'      = reward,
+-- >		'destination' = destination,
+-- >		'status'      = status,
 -- >	})
 --
 -- Parameters:
@@ -207,12 +207,12 @@ Mission = {
 -- Example:
 --
 -- >  local ref = Mission.New({
--- >      'type'     = 'Delivery', -- Must be a translatable token!
--- >      'client'   = Character.New()
--- >      'due'      = Game.time + 3*24*60*60,    -- three days
--- >      'reward'   = 123.45,
--- >      'location' = SystemPath:New(0,0,0,0,16),  -- Mars High, Sol
--- >      'status'   = 'ACTIVE',
+-- >      'type'        = 'Delivery', -- Must be a translatable token!
+-- >      'client'      = Character.New()
+-- >      'due'         = Game.time + 3*24*60*60,    -- three days
+-- >      'reward'      = 123.45,
+-- >      'destination' = SystemPath:New(0,0,0,0,16),  -- Mars High, Sol
+-- >      'status'      = 'ACTIVE',
 -- >  })
 --
 -- Availability:
@@ -253,7 +253,7 @@ Mission = {
 		end
 		if not (type(newMission.due) == "number") then newMission.due = nil end
 		if not (type(newMission.reward) == "number") then newMission.reward = nil end
-		if not (type(newMission.location) == "userdata") then newMission.location = Game.system.path end
+		if not (type(newMission.destination) == "string" or type(newMission.destination) == "userdata") then newMission.destination = Game.system.path end
 		table.insert(Character.persistent.player.missions,newMission)
 		return newMission;
 	end,

--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -136,6 +136,7 @@ local onChat = function (form, ref, option)
 			due			= ad.due,
 			flavour		= ad.flavour,
 			location	= ad.location,
+			destination	= ad.location,
 			reward		= ad.reward,
 			threat		= ad.threat,
 			shipid		= ad.shipid,
@@ -257,7 +258,7 @@ local onShipDestroyed = function (ship, body)
 				mission.notplayer = 'TRUE'
 			else -- well done, comrade
 				mission.status = 'COMPLETED'
-				mission.location = mission.backstation
+				mission.destination = mission.backstation
 				mission.notplayer = 'FALSE'
 			end
 			mission.ship = nil

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -17,10 +17,7 @@ local PlayerState = require 'PlayerState'
 local MissionUtils = require 'modules.MissionUtils'
 local ShipBuilder = require 'modules.MissionUtils.ShipBuilder'
 
-local OutfitRules = ShipBuilder.OutfitRules
-
 local l = Lang.GetResource("module-cargorun")
-local l_ui_core = Lang.GetResource("ui-core")
 local lc = Lang.GetResource 'core'
 
 local PirateTemplate = MissionUtils.ShipTemplates.WeakPirate
@@ -232,6 +229,7 @@ onChat = function (form, ref, option)
 			domicile        = ad.domicile,
 			client          = ad.client,
 			location        = ad.location,
+			destination     = ad.location,
 			localdelivery   = ad.localdelivery,
 			wholesaler      = ad.wholesaler,
 			pickup          = ad.pickup,
@@ -243,6 +241,7 @@ onChat = function (form, ref, option)
 			amount          = ad.negotiated_amount,
 			branch          = ad.branch,
 			cargotype       = ad.cargotype,
+			status          = cargo_picked_up and "ACTIVE" or "TO_PICK_UP",
 		}
 		table.insert(missions,Mission.New(mission))
 
@@ -730,7 +729,8 @@ local onPlayerDocked = function (player, station)
 					cargoMgr:AddCommodity(mission.cargotype, mission.amount);
 					mission.cargo_picked_up = true
 					Comms.ImportantMessage(l.WE_HAVE_LOADED_UP_THE_CARGO_ON_YOUR_SHIP, mission.client.name)
-					mission.status = "PENDING_RETURN"
+					mission.status = "ACTIVE"
+					mission.destination = mission.domicile
 				end
 
 			else

--- a/data/modules/Combat/Combat.lua
+++ b/data/modules/Combat/Combat.lua
@@ -454,7 +454,7 @@ local onEnterSystem = function (player)
 				local ship = ShipBuilder.MakeShipNear(Game.player, template)
 				assert(ship)
 
-				local path = mission.location:GetStarSystem().path
+				local path = mission.location:SystemOnly()
 				finishMission(ref, mission)
 				ship:HyperjumpTo(path)
 			end

--- a/data/modules/Combat/Combat.lua
+++ b/data/modules/Combat/Combat.lua
@@ -145,8 +145,10 @@ local onChat = function (form, ref, option)
 			type        = "Combat",
 			client      = ad.client,
 			faction     = Game.system.faction.id,
+			factionName = Game.system.faction.name,
 			org         = ad.org,
 			location    = ad.location,
+			destination = ad.location,
 			rendezvous  = ad.rendezvous,
 			mercenaries = {},
 			introtext   = ad.introtext,
@@ -162,6 +164,7 @@ local onChat = function (form, ref, option)
 		table.insert(missions,Mission.New(mission))
 		form:SetMessage(l["ACCEPTED_" .. Engine.rand:Integer(1, getNumberOfFlavours("ACCEPTED"))])
 		return
+
 	elseif option == 6 then
 		form:SetMessage(l.YOU_NEED_A_RADAR)
 	end
@@ -296,6 +299,19 @@ local onUpdateBB = function (station)
 	end
 end
 
+local setReturnLocation = function (mission)
+		if mission.rendezvous then
+			mission.destination = mission.rendezvous
+		else
+			if mission.flavour.is_multi then
+				mission.destination = mission.org .. "\n-"
+			else
+				mission.destination = mission.org .. "\n" .. mission.factionName
+			end
+		end
+		mission.status = "PENDING_RETURN"
+end
+
 local onShipDestroyed = function (ship, attacker)
 	if ship:IsPlayer() then return end
 
@@ -305,7 +321,7 @@ local onShipDestroyed = function (ship, attacker)
 				table.remove(mission.mercenaries, i)
 				if not mission.complete and (#mission.mercenaries == 0 or mission.dedication <= ARMEDRECON) then
 					mission.complete = true
-					mission.status = "PENDING_RETURN"
+					setReturnLocation(mission)
 					Comms.ImportantMessage(l.MISSION_COMPLETE)
 				end
 				if attacker and attacker:isa("Ship") and attacker:IsPlayer() then
@@ -322,7 +338,7 @@ local missionTimer = function (mission)
 		if mission.complete or Game.time > mission.due then return true end -- already complete or too late
 		if Game.player.frameBody and Game.player.frameBody.path == mission.location then
 			mission.complete = true
-			mission.status = "PENDING_RETURN"
+			setReturnLocation(mission)
 			Comms.ImportantMessage(l.MISSION_COMPLETE)
 			return true
 		else
@@ -523,11 +539,8 @@ local buildMissionDescription = function(mission)
 
 	desc.client = mission.client
 
-	if mission.status == "PENDING_RETURN" and mission.rendezvous then
-		desc.location = mission.rendezvous
-	else
-		desc.location = mission.location
-	end
+	desc.location = mission.location
+	desc.returnLocation = mission.rendezvous or nil
 
 	local paymentLoc = mission.rendezvous and ui.Format.SystemPath(mission.rendezvous)
 		or string.interp(l[mission.flavour.id .. "_LAND_THERE"], { org = mission.org })

--- a/data/modules/DeliverPackage/DeliverPackage.lua
+++ b/data/modules/DeliverPackage/DeliverPackage.lua
@@ -186,6 +186,7 @@ local onChat = function (form, ref, option)
 			type	 = "Delivery",
 			client	 = ad.client,
 			location = ad.location,
+			destination = ad.location,
 			risk	 = ad.risk,
 			reward	 = ad.reward,
 			due	 = ad.due,

--- a/data/modules/FindPerson/FindPerson.lua
+++ b/data/modules/FindPerson/FindPerson.lua
@@ -128,7 +128,7 @@ local onChat = function (form, ref, option)
 			wanted      = ad.wanted,
 			company     = ad.company,
 			location    = ad.location,
-			destination = ad.location:GetStarSystem().path,
+			destination = ad.location:SystemOnly(),
 			visited     = {},
 			shipid      = ad.shipid,
 			ship        = nil,
@@ -478,7 +478,7 @@ end
 local buildMissionDescription = function (mission)
 	local ui = require 'pigui'
 	local desc = {}
-	local dist = Game.system and string.format("%.2f", Game.system:DistanceTo(mission.location:GetStarSystem().path)) or "???"
+	local dist = Game.system and string.format("%.2f", Game.system:DistanceTo(mission.location:SystemOnly())) or "???"
 	local domicileDist = Game.system and string.format("%.2f", Game.system:DistanceTo(mission.domicile)) or "???"
 	local danger = getRiskMsg(mission)
 
@@ -496,7 +496,7 @@ local buildMissionDescription = function (mission)
 		dist = dist
 	})
 
-	desc.location = mission.location:GetStarSystem().path
+	desc.location = mission.location:SystemOnly()
 	desc.client = mission.client
 	desc.returnLocation = mission.domicile
 

--- a/data/modules/FindPerson/FindPerson.lua
+++ b/data/modules/FindPerson/FindPerson.lua
@@ -127,8 +127,8 @@ local onChat = function (form, ref, option)
 			client      = ad.client,
 			wanted      = ad.wanted,
 			company     = ad.company,
-			location    = ad.location:GetStarSystem().path,
-			destination = ad.location,
+			location    = ad.location,
+			destination = ad.location:GetStarSystem().path,
 			visited     = {},
 			shipid      = ad.shipid,
 			ship        = nil,
@@ -285,18 +285,18 @@ local onFrameChanged = function (player)
 	if not player:isa("Ship") or not player:IsPlayer() then return end
 
 	for ref, mission in pairs(missions) do
-		if mission.destination:IsSameSystem(Game.system.path) and player.frameBody
-			and player.frameBody.path == Space.GetBody(mission.destination:GetSystemBody().parent.index).path
+		if mission.location:IsSameSystem(Game.system.path) and player.frameBody
+			and player.frameBody.path == Space.GetBody(mission.location:GetSystemBody().parent.index).path
 			and not mission.flavour.ship and not mission.interceptor then
 
 			local riskmargin = Engine.rand:Number(-0.3, 0.0) -- Add some random luck
 			if (mission.risk + riskmargin) > Engine.rand:Number(1) then
 				-- The wanted person or one of his/her enemies has hired a mercenary to intercept
 				local threat = 10.0 + mission.risk * 25.0
-				local ship = ShipBuilder.MakeShipDocked(Space.GetBody(mission.destination.bodyIndex), MercenaryTemplate, threat)
+				local ship = ShipBuilder.MakeShipDocked(Space.GetBody(mission.location.bodyIndex), MercenaryTemplate, threat)
 				mission.interceptor = ship
-				if mission.destination.type == "STARPORT_SURFACE" then
-					ship:AIEnterLowOrbit(Space.GetBody(mission.destination:GetSystemBody().parent.index))
+				if mission.location.type == "STARPORT_SURFACE" then
+					ship:AIEnterLowOrbit(Space.GetBody(mission.location:GetSystemBody().parent.index))
 				end
 				Timer:CallAt(Game.time + 5, function () ship:AIKill(player) end)
 			end
@@ -310,7 +310,7 @@ end
 
 local onEnterSystem = function (player)
 	for ref, mission in pairs(missions) do
-		if mission.destination:IsSameSystem(Game.system.path) and mission.status == "ACTIVE" and mission.flavour.ship then
+		if mission.location:IsSameSystem(Game.system.path) and mission.status == "ACTIVE" and mission.flavour.ship then
 
 			local ship, pirate_msg
 			local threat = 10.0 + mission.risk * 25.0
@@ -333,12 +333,13 @@ local onEnterSystem = function (player)
 					else
 						pirate_msg = string.interp(l["PIRATE_ANSWER_" .. Engine.rand:Integer(1, getNumberOfFlavours("PIRATE_ANSWER"))], { client = mission.client.name })
 						Comms.ImportantMessage(pirate_msg, ship.label)
-						ship:AIDockWith(Space.GetBody(mission.destination.bodyIndex))
+						ship:AIDockWith(Space.GetBody(mission.location.bodyIndex))
 					end
+					mission.destination = mission.domicile
 					mission.status = "PENDING_RETURN"
 				end)
 			else
-				ship = ShipBuilder.MakeShipDocked(Space.GetBody(mission.destination.bodyIndex), PirateTemplate, threat)
+				ship = ShipBuilder.MakeShipDocked(Space.GetBody(mission.location.bodyIndex), PirateTemplate, threat)
 				ship:SetLabel(mission.shipid)
 			end
 			mission.ship = ship
@@ -394,23 +395,25 @@ local onPlayerDocked = function (player, station)
 				missions[ref] = nil
 			end
 		else
-			if mission.destination == station.path then
+			if mission.location == station.path then
 				msg = string.interp(l["GREETING_" .. mission.flavour.id], { client = mission.client.name })
 				Comms.ImportantMessage(msg, mission.wanted.name)
 				if mission.flavour.taxi then
 					if Passengers.CountFreeBerths(player) > 0 then
 						Passengers.EmbarkPassenger(player, mission.wanted)
+						mission.destination = mission.domicile
 						mission.status = "PENDING_RETURN"
 					else
 						-- cabin occupied or player has removed cabin?
 						Comms.ImportantMessage(l.YOU_DO_NOT_HAVE_A_CABIN, mission.wanted.name)
 					end
 				else
+					mission.destination = mission.domicile
 					mission.status = "PENDING_RETURN"
 				end
 			else
 				-- do nothing if not in the right system or a tipster was already there
-				if mission.destination:IsSameSystem(Game.system.path) and not mission.tipster then
+				if mission.location:IsSameSystem(Game.system.path) and not mission.tipster then
 					-- don't increase probability if last station is current station
 					if station.path ~= mission.visited[#mission.visited] then
 						table.insert(mission.visited, station.path)
@@ -418,7 +421,7 @@ local onPlayerDocked = function (player, station)
 					if #mission.visited > Engine.rand:Number(4) then
 						local tipster = Character.New()
 						local tip = "TIP_" .. (mission.wanted.female and "FEMALE" or "MALE")
-						msg = string.interp(l[tip .. "_" .. Engine.rand:Integer(1, getNumberOfFlavours(tip))], { wanted = mission.wanted.name, station = mission.destination:GetSystemBody().name })
+						msg = string.interp(l[tip .. "_" .. Engine.rand:Integer(1, getNumberOfFlavours(tip))], { wanted = mission.wanted.name, station = mission.location:GetSystemBody().name })
 						Comms.ImportantMessage(msg, tipster.name)
 						mission.tipster = true
 					end
@@ -475,7 +478,7 @@ end
 local buildMissionDescription = function (mission)
 	local ui = require 'pigui'
 	local desc = {}
-	local dist = Game.system and string.format("%.2f", Game.system:DistanceTo(mission.location)) or "???"
+	local dist = Game.system and string.format("%.2f", Game.system:DistanceTo(mission.location:GetStarSystem().path)) or "???"
 	local domicileDist = Game.system and string.format("%.2f", Game.system:DistanceTo(mission.domicile)) or "???"
 	local danger = getRiskMsg(mission)
 
@@ -483,17 +486,17 @@ local buildMissionDescription = function (mission)
 		client = mission.client.name,
 		wanted = mission.wanted.name,
 		company = mission.company,
-		system = mission.destination:GetStarSystem().name,
-		sectorx = mission.destination.sectorX,
-		sectory = mission.destination.sectorY,
-		sectorz = mission.destination.sectorZ,
+		system = mission.location:GetStarSystem().name,
+		sectorx = mission.location.sectorX,
+		sectory = mission.location.sectorY,
+		sectorz = mission.location.sectorZ,
 		shipid = mission.shipid,
 		domicile = mission.domicile:GetSystemBody().name,
 		cash = ui.Format.Money(mission.reward, false),
 		dist = dist
 	})
 
-	desc.location = mission.location
+	desc.location = mission.location:GetStarSystem().path
 	desc.client = mission.client
 	desc.returnLocation = mission.domicile
 

--- a/data/modules/Scout/Scout.lua
+++ b/data/modules/Scout/Scout.lua
@@ -263,6 +263,7 @@ local onChat = function (form, ref, option)
 			station     = station,
 			client      = ad.client,
 			location    = ad.location,
+			destination = ad.location,
 			difficulty  = ad.difficulty,
 			reward      = ad.reward,
 			due         = ad.due,
@@ -661,6 +662,7 @@ local onScanComplete = function (player, scanId)
 		end
 		mission.station = newlocation
 	end
+	mission.destination = newlocation
 
 	-- Set navigation target to the station
 	if Game.system and mission.station:IsSameSystem(Game.system.path) then
@@ -769,7 +771,7 @@ local buildMissionDescription = function (mission)
 			{
 				date = Format.Date(mission.due),
 				location = mission.station:GetSystemBody().name
-				           .. "," .. mission.station:GetStarSystem().name
+				           .. ", " .. mission.station:GetStarSystem().name
 			})
 	end
 

--- a/data/modules/SearchRescue/SearchRescue.lua
+++ b/data/modules/SearchRescue/SearchRescue.lua
@@ -804,12 +804,13 @@ local onChat = function (form, ref, option)
 			-- these variables are hardcoded and need to be filled
 			type	            = "searchrescue",
 			client             = ad.client,
-			location           = ad.location,
+			destination        = ad.location,
 			due                = ad.due,
 			reward             = ad.reward,
 			status             = "ACTIVE",
 
 			-- these variables are script specific
+			location           = ad.location,
 			station_local      = ad.station_local,
 			planet_local       = ad.planet_local,
 			system_local       = ad.system_local,
@@ -1499,7 +1500,7 @@ local pickupCrew = function (mission)
 			local resulttxt = string.interp(l.RESULT_PICKUP_CREW, {todo = todo, done = done})
 			Comms.ImportantMessage(resulttxt)
 			mission.pickup_crew_check = "COMPLETE"
-			mission.location = mission.system_local
+			mission.destination = mission.station_local
 		end
 	end
 end

--- a/data/modules/Taxi/Taxi.lua
+++ b/data/modules/Taxi/Taxi.lua
@@ -206,6 +206,7 @@ local onChat = function (form, ref, option)
 			client	 = ad.client,
 			start    = ad.station.path,
 			location = ad.location,
+			destination = ad.location,
 			risk	 = ad.risk,
 			reward	 = ad.reward,
 			due      = ad.due,

--- a/data/pigui/libs/chat-form.lua
+++ b/data/pigui/libs/chat-form.lua
@@ -175,7 +175,7 @@ function ChatForm:AddNavButton (target)
 				end
 			elseif not Game.InHyperspace() then
 				-- if a specific systembody is given, set the sector map to the correct star (if the system is multiple)
-				Game.sectorView:SwitchToPath(target:IsBodyPath() and target:GetSystemBody().nearestJumpable.path or target:GetStarSystem().path)
+				Game.sectorView:SwitchToPath(target:IsBodyPath() and target:GetSystemBody().nearestJumpable.path or target:SystemOnly())
 				ui.playBoinkNoise()
 			end
 		end

--- a/data/pigui/libs/radial-menu.lua
+++ b/data/pigui/libs/radial-menu.lua
@@ -83,7 +83,7 @@ local radial_menu_actions_hyperspace_cloud = {
 				-- implicitly drops second return value of GetHyperspaceDestination() when using this "and" construct
 				local destPath = ship and ship:GetHyperspaceDestination()
 				if destPath then
-					local target = destPath:IsBodyPath() and destPath:GetSystemBody().nearestJumpable.path or destPath:GetStarSystem().path
+					local target = destPath:IsBodyPath() and destPath:GetSystemBody().nearestJumpable.path or destPath:SystemOnly()
 					Game.player:SetHyperspaceTarget(target)
 					Game.sectorView:ClearRoute()
 					Game.sectorView:AddToRoute(target)

--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -32,7 +32,7 @@ local function setLocationAsTarget(location)
 		end
 	elseif not Game.InHyperspace() then
 		-- if a specific systembody is given, set the sector map to the correct star (if the system is multiple)
-		Game.sectorView:SwitchToPath(location:IsBodyPath() and location:GetSystemBody().nearestJumpable.path or location:GetStarSystem().path)
+		Game.sectorView:SwitchToPath(location:IsBodyPath() and location:GetSystemBody().nearestJumpable.path or location:SystemOnly())
 		ui.playBoinkNoise()
 	end
 end

--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -95,26 +95,33 @@ local function makeMissionRows()
 	}
 
 	for _, mission in pairs(Character.persistent.player.missions) do
-		local locationName = mission.location:GetStarSystem().name -- ui.Format.SystemPath(mission.location)
-		if mission.location.bodyIndex then
-			locationName = mission.location:GetSystemBody().name .. ", " .. locationName
-		end
+		local locationName, dist_display
 
-		local playerSystem = Game.system or Game.player:GetHyperspaceTarget():GetStarSystem()
-
-		-- Use AU for interplanetary, LY for interstellar distances
-		local dist, dist_display
-		if mission.location:IsSameSystem(playerSystem.path) and not Game.InHyperspace() then
-			if mission.location:IsBodyPath() then
-				local body = mission.location:GetSystemBody().body
-				dist = Game.player:GetPositionRelTo(body):length()
-				dist_display = "\n" .. ui.Format.Distance(dist)
-			else
-				dist_display = "\n-"
-			end
+		if type(mission.destination) == "string" then
+			locationName = mission.destination
+			dist_display = ""
 		else
-			dist = playerSystem:DistanceTo(mission.location)
-			dist_display = string.format("\n%.2f %s", dist, l.LY)
+			locationName = mission.destination:GetStarSystem().name -- ui.Format.SystemPath(mission.destination)
+			if mission.destination.bodyIndex then
+				locationName = mission.destination:GetSystemBody().name .. ", " .. locationName
+			end
+
+			local playerSystem = Game.system or Game.player:GetHyperspaceTarget():GetStarSystem()
+
+			-- Use AU for interplanetary, LY for interstellar distances
+			local dist
+			if mission.destination:IsSameSystem(playerSystem.path) and not Game.InHyperspace() then
+				if mission.destination:IsBodyPath() then
+					local body = mission.destination:GetSystemBody().body
+					dist = Game.player:GetPositionRelTo(body):length()
+					dist_display = "\n" .. ui.Format.Distance(dist)
+				else
+					dist_display = "\n-"
+				end
+			else
+				dist = playerSystem:DistanceTo(mission.destination)
+				dist_display = string.format("\n%.2f %s", dist, l.LY)
+			end
 		end
 
 		local row = {


### PR DESCRIPTION
I adopted the solution from the assassination module by simply overwriting mission.location.
In order not to change the mission description, I had to rename some variables.
If no defined return location is specified, the organization and, if necessary, the faction will be displayed.

Closes #6185 
