### PR TITLE
Use ATTRIB_UV0 instead of ATTRIB_DIFFUSE, fix projectile crash

### DIFF
--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Graphics::Material> Projectile::s_glowMat;
 
 void Projectile::BuildModel()
 {
-	Graphics::AttributeSet vtxAttribs = Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE;
+	Graphics::AttributeSet vtxAttribs = Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0;
 	auto vtxFormat = Graphics::VertexFormatDesc::FromAttribSet(vtxAttribs);
 
 	//set up materials


### PR DESCRIPTION
Fixes #6194 crashing when weapons fired. 

This was due to a mismatch between the vertex attributes specified and the data entered in the VertexArray being built.