### PR TITLE
Animate thruster flame

### DIFF
--- a/data/shaders/opengl/thruster.frag
+++ b/data/shaders/opengl/thruster.frag
@@ -1,0 +1,27 @@
+// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "attributes.glsl"
+#include "lib.glsl"
+
+uniform sampler2D texture0; //diffuse
+
+in vec2 texCoord0;
+in vec4 flame_color;
+in float ramp;
+
+out vec4 frag_color;
+
+void main(void)
+{
+	vec4 color = texture(texture0, texCoord0);
+	vec3 old_color = color.rgb;
+	color *= flame_color;
+	// generate a light blue flickering glow around the flame
+	float ramp2 = ramp * ramp;
+	color.g += ramp2 * ramp2 * old_color.g;
+	color.r += ramp2 * ramp * old_color.r;
+	color.b += ramp2 * old_color.b;
+
+	frag_color = color;
+}

--- a/data/shaders/opengl/thruster.shaderdef
+++ b/data/shaders/opengl/thruster.shaderdef
@@ -1,0 +1,12 @@
+## Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+## Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+# Basic shader for drawing unlit, possibly textured models that are animated
+
+Shader thruster
+
+Texture sampler2D texture0 name=diffuse
+Buffer DrawData binding=1
+
+Vertex "thruster.vert"
+Fragment "thruster.frag"

--- a/data/shaders/opengl/thruster.vert
+++ b/data/shaders/opengl/thruster.vert
@@ -1,0 +1,46 @@
+// Copyright © 2008-2025 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+// #extension GL_ARB_gpu_shader5 : enable
+
+#include "attributes.glsl"
+#include "lib.glsl"
+
+out vec2 texCoord0;
+out vec4 flame_color;
+out float ramp;
+
+float map_percentage( float val, float base_percent)
+{
+   return base_percent + val * (1.0 - base_percent);
+}
+
+void main(void)
+{
+	// emission.r is the thruster power setting
+	float thruster_power = material.emission.r;
+	// emission.a is the random flicker value
+	float random = material.emission.a;
+	
+	// power setting effects the brightness and opacity of the flame
+	float brightness = map_percentage(thruster_power, 0.25);
+	// flicker should only change the brightness a small amount each frame
+	float flicker = map_percentage(random, 0.95);
+	
+	flame_color = material.diffuse * flicker * brightness;
+	// a very light blue flickering glow around flame
+	flame_color.rg *= vec2(flicker);
+
+	// the power setting also controls the length of the flame
+	// flame length can range from 50% to 100%
+	float flame_length = map_percentage(thruster_power, 0.5);
+	// modulate the flame shape using flicker
+	// flame_length only effects the z axis which is the thrust direction
+	vec4 scale = vec4(flicker, flicker, flicker * flame_length, 1.0);
+	
+	gl_Position = uViewProjectionMatrix * (a_vertex * scale);
+
+	texCoord0 = a_uv0.xy;
+	// set the blend ramp
+	ramp = a_uv0.y * 0.5;
+}

--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -160,5 +160,8 @@ void Intro::Draw(float deltaTime)
 		matrix4x4f::Translation(0, 0, m_dist) *
 		matrix4x4f::RotateXMatrix(DEG2RAD(-15.0f)) *
 		matrix4x4f::RotateYMatrix(duration);
+
+	// animate thrusters
+	m_model->SetTimeStep(duration);
 	m_model->Render(trans);
 }

--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -195,6 +195,8 @@ void ShipCockpit::Update(const Player *player, float timeStep)
 		vector3f linthrust{ prop->GetLinThrusterState() };
 		vector3f angthrust{ prop->GetAngThrusterState() };
 		GetModel()->SetThrust(linthrust, -angthrust);
+		// animate the thrusters
+		GetModel()->SetTimeStep(timeStep);
 	}
 }
 

--- a/src/editor/ModelViewerWidget.cpp
+++ b/src/editor/ModelViewerWidget.cpp
@@ -578,6 +578,7 @@ void ModelViewerWidget::DrawModel(matrix4x4f trans)
 		(m_options.showGeomBBox ? SceneGraph::Model::DEBUG_GEOMBBOX : 0x0) |
 		(m_options.wireframe ? SceneGraph::Model::DEBUG_WIREFRAME : 0x0));
 
+	m_model->SetTimeStep(0.01f);
 	m_model->Render(m_modelViewMat);
 	m_navLights->Render(m_renderer);
 }

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -150,6 +150,9 @@ namespace SceneGraph {
 		//Override renderdata if this model is called from ModelNode
 		RenderData params = (rd != 0) ? (*rd) : m_renderData;
 
+		// reset time step for next frame
+		m_renderData.timeStep = 0.f;
+
 		m_renderer->SetTransform(trans);
 
 		//using the entire model bounding radius for all nodes at the moment.
@@ -211,6 +214,9 @@ namespace SceneGraph {
 
 		//Override renderdata if this model is called from ModelNode
 		RenderData params = (rd != 0) ? (*rd) : m_renderData;
+
+		// reset time step
+		m_renderData.timeStep = 0.f;
 
 		//using the entire model bounding radius for all nodes at the moment.
 		//BR could also be a property of Node.
@@ -423,6 +429,11 @@ namespace SceneGraph {
 		m_renderData.angthrust[0] = ang.x;
 		m_renderData.angthrust[1] = ang.y;
 		m_renderData.angthrust[2] = ang.z;
+	}
+
+	void Model::SetTimeStep(const float timeStep)
+	{
+		m_renderData.timeStep = timeStep;
 	}
 
 	void Model::SetThrusterColor(const vector3f &dir, const Color &color)

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -171,6 +171,7 @@ namespace SceneGraph {
 		Graphics::Renderer *GetRenderer() const { return m_renderer; }
 
 		//special for ship model use
+		void SetTimeStep(const float timeStep);
 		void SetThrust(const vector3f &linear, const vector3f &angular);
 
 		void SetThrusterColor(const vector3f &dir, const Color &color);

--- a/src/scenegraph/Node.h
+++ b/src/scenegraph/Node.h
@@ -48,6 +48,7 @@ namespace SceneGraph {
 		float linthrust[3]; // 1.0 to -1.0
 		float angthrust[3]; // 1.0 to -1.0
 		Color customColor;
+		float timeStep; // used as a heart beat for shaders
 
 		float boundingRadius; //updated by model and passed to submodels
 		unsigned int nodemask;
@@ -55,6 +56,7 @@ namespace SceneGraph {
 		RenderData() :
 			linthrust(),
 			angthrust(),
+			timeStep(0.f),
 			boundingRadius(0.f),
 			nodemask(NODE_SOLID) //draw solids
 		{

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -29,7 +29,8 @@ namespace SceneGraph {
 		linearOnly(_linear),
 		dir(_dir),
 		pos(_pos),
-		currentColor(baseColor)
+		currentColor(baseColor),
+		m_time(0.f)
 	{
 		//set up materials
 		Graphics::MaterialDescriptor desc;
@@ -43,12 +44,12 @@ namespace SceneGraph {
 
 		auto vtxFormat = Graphics::VertexFormatDesc::FromAttribSet(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0);
 
-		m_tMat.Reset(r->CreateMaterial("unlit", desc, rsd, vtxFormat));
+		m_tMat.Reset(r->CreateMaterial("thruster", desc, rsd, vtxFormat));
 		m_tMat->SetTexture("texture0"_hash,
 			Graphics::TextureBuilder::Billboard(thrusterTextureFilename).GetOrCreateTexture(r, "billboard"));
 		m_tMat->diffuse = baseColor;
 
-		m_glowMat.Reset(r->CreateMaterial("unlit", desc, rsd, vtxFormat));
+		m_glowMat.Reset(r->CreateMaterial("thruster", desc, rsd, vtxFormat));
 		m_glowMat->SetTexture("texture0"_hash,
 			Graphics::TextureBuilder::Billboard(thrusterGlowTextureFilename).GetOrCreateTexture(r, "billboard"));
 		m_glowMat->diffuse = baseColor;
@@ -61,7 +62,8 @@ namespace SceneGraph {
 		linearOnly(thruster.linearOnly),
 		dir(thruster.dir),
 		pos(thruster.pos),
-		currentColor(thruster.currentColor)
+		currentColor(thruster.currentColor),
+		m_time(thruster.m_time)
 	{
 	}
 
@@ -102,8 +104,24 @@ namespace SceneGraph {
 			}
 		}
 		if (power < 0.001f) return;
+		
+		// animate the thrust flame using the thruster shader
+		// update animation time on each render
+		// a unique time stamp is needed for each thruster flame to have a unique flicker
+		// use thruster position to make each thruster time different
+		m_time += abs(trans[12] + trans[13] + trans[14]) * rd->timeStep * 1000.0f;
+		// generate a psuedo random flicker
+		// this could be done in the vertex shader but the value only needs to be 
+		// generated once per frame, not for every vertex
+		const float flicker = sin(m_time) * 43758.5453f;
 
-		m_tMat->diffuse = m_glowMat->diffuse = currentColor * power;
+		// pass the power setting and flicker value using the material emissive
+		// emissive.a is the flicker value for the flame
+		m_tMat->emissive.a = m_glowMat->emissive.a = flicker;
+		// emissive.r is the thruster power setting which effects flame length and brightness
+		m_tMat->emissive.r = m_glowMat->emissive.r = 255.0f * power;
+		
+		m_tMat->diffuse = m_glowMat->diffuse = currentColor;
 
 		//directional fade
 		vector3f cdir = vector3f(trans * -dir).Normalized();

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -44,6 +44,7 @@ namespace SceneGraph {
 		vector3f dir;
 		vector3f pos;
 		Color currentColor;
+		float m_time; // used for animating the thruster
 	};
 
 } // namespace SceneGraph

--- a/src/ship/Propulsion.cpp
+++ b/src/ship/Propulsion.cpp
@@ -241,7 +241,10 @@ void Propulsion::Render(Graphics::Renderer *r, const Camera *camera, const vecto
 	 * thruster and so on)... this code is :-/
 	*/
 	//angthrust negated, for some reason
-	if (m_smodel != nullptr) m_smodel->SetThrust(vector3f(GetLinThrusterState()), -vector3f(GetAngThrusterState()));
+	if (m_smodel != nullptr) {
+		m_smodel->SetThrust(vector3f(GetLinThrusterState()), -vector3f(GetAngThrusterState()));
+		m_smodel->SetTimeStep(Pi::game->GetTimeStep());
+	}
 }
 
 void Propulsion::AIModelCoordsMatchSpeedRelTo(const vector3d &v, const DynamicBody *other)


### PR DESCRIPTION
This is a resurrection of #6056 by possibly "jeffmd", it seemed a shame to lose the work with a nice visual effect

>The thrust flame is now animated by randomly expanding/contracting the flame and by making small changes in the flames diffuse color and alpha each frame. Its simplistic but for now adds some life to the ship when viewed externally.

Gifs by @bszlrd from that original PR
<img width="991" height="556" alt="image" src="https://github.com/user-attachments/assets/59d2ec53-2237-410e-b723-1d6913aad8e1" />
<img width="991" height="556" alt="image" src="https://github.com/user-attachments/assets/6e4ca795-2794-464c-bb1c-b30f9c607951" />


