### PR TITLE
Prevent spiky asteroids in random systems

### DIFF
--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -33,7 +33,7 @@ static const fixed TWOHUNDREDEUMASSES = fixed::FromDouble(200.0);
 
 // Estimate "prototype" body radius from sphere-density formula:
 // Convert 1 Earth Mass to a volume in cubic megameters (10^18 * m^3) then premultiply by 3/4pi
-static const fixedf<48> EARTH_MASS_TO_VOL_MM3 = fixedf<48>(2599, 10); // 259.901 = (3 / EARTH_DENSITY / 4*PI) * 5.9742
+static const fixedf<48> EARTH_MASS_TO_VOL_MM3 = fixedf<48>(25946, 100); // 259.46 = (3 / EARTH_DENSITY / 4*PI) * 5.9742
 // Convert a distance in megameters to earth radii
 static const fixedf<48> MM_TO_EARTH_RAD = fixedf<48>(15678, 100000);
 


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
The goal of this is to _try_ and fix #5999 and other issues like it, I suspect that it is at best a partial fix.

~I don't think that the conversion between fixedf<32> (_the default fixed format_) and fixedf<48> works, it may just copy the value raw which was producing planetary radius's millions of times greater than their mass.~

In Sol there are still bodies being created which have quite insane ratios, for example:
	Eros:
	height fractal: MountainsCraters2
	colour fractal: Rock
	seed: 842785371
	mass: 0.0000000009313225746154785
	radius: 0.0014999997802078724
	mass:radius ratio 1610612.5

That is a radius 1,610,612 times greater than it's mass, at which point some of our maths around terrain height scaling calculations goes absolutely insane.

However that's coming through our custom data, and this is about randomly generated bodies. This seems to fix the problem in my testing, but it will cause a savegame bump because it changes the galaxy.

Also this will need some testing by people to confirm, easiest way is to use the navigation menu and Ctrl+F10 to look at all of the bodies in a system.
<!-- Please make sure you've read documentation on contributing -->

