### PR TITLE
CMakeList and scan_enums update to python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,14 +367,14 @@ if (NATURALDOCS)
 	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
 
-find_package(Python2 COMPONENTS Interpreter)
-if (Python2_Interpreter_FOUND)
+find_package(Python3 COMPONENTS Interpreter)
+if (Python3_Interpreter_FOUND)
 	add_custom_target(enums
-		COMMAND "${Python2_EXECUTABLE}" scripts/scan_enums.py -o src/enum_table.cpp --pattern='*.h' -r src
+		COMMAND "${Python3_EXECUTABLE}" scripts/scan_enums.py -o src/enum_table.cpp --pattern='*.h' -r src
 		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 	)
 else()
-	message(WARNING, "Python 2 not found; enums will not be scanned.")
+	message(WARNING, "Python 3 not found; enums will not be scanned.")
 endif()
 
 target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt)

--- a/scripts/scan_enums.py
+++ b/scripts/scan_enums.py
@@ -513,7 +513,7 @@ def main():
             if path == '-':
                 es = list(extract_enums(sys.stdin))
             else:
-                with open(path, 'rU') as fl:
+                with open(path, 'rt') as fl:
                     # skip an optional UTF-8 Byte Order Mark
                     if sys.version_info[0] >= 3:
                         hasbom = (fl.read(1) == '\uFEFF')


### PR DESCRIPTION
When trying to build Pioneer on the latest Raspberry Pi OS "Trixie" it ran into issues with the `scan_enums.py` requiring Python2 which now appears to be so deprecated it cannot be recovered at all.

So I've tried updating it to Python3 in both `CMakeLists.txt` and the `scan_enums.py` script. This seems to work with only minimal changes and resolves the issues around Python2 deprecation. It successfully generates:

>	modified:   data/meta/Constants.lua
	modified:   src/enum_table.cpp
	modified:   src/enum_table.h

I have not included those modified files here.