### PR TITLE
Fix traffic control message when starting in space

### DIFF
--- a/data/modules/StationTrafficControl/StationTrafficControl.lua
+++ b/data/modules/StationTrafficControl/StationTrafficControl.lua
@@ -13,9 +13,12 @@ local Lang = require 'Lang'
 local l = Lang.GetResource("module-stationtrafficcontrol")
 local ui = require 'pigui'
 
--- game starts with player docked with a station
--- otherwise, serialized data already has the value
-local playerInControlledSpace = true
+-- The game usually start at a station but may start in space by providing a system
+-- path, either via the command line or in the game menu via a custom start option.
+-- In the most common case in a new game, where we start at a station, we are in a
+-- controlled space and this is set in the onGameStart() function.
+-- In the case of a saved game, serialized data already has the value.
+local playerInControlledSpace = false
 
 local getNumberOfFlavours = function (str)
 	-- Returns the number of flavours of the given string (assuming first flavour has suffix '_1').
@@ -106,8 +109,12 @@ end
 local loaded_data
 
 local onGameStart = function ()
+	local station = Game.player:FindNearestTo("SPACESTATION")
 	if (loaded_data) then
 		playerInControlledSpace = loaded_data.playerInControlledSpace
+	elseif Game.player.flightState == "DOCKED" or
+			station and station:DistanceTo(Game.player) < station.lawEnforcedRange then
+		playerInControlledSpace = true
 	end
 	loaded_data = nil
 	Timer:CallEvery(5, notifyControlledSpace)


### PR DESCRIPTION
Fixes https://github.com/pioneerspacesim/pioneer/issues/6219 by making sure playerInControlledSpace == false when starting in space.

I don't know if there are possible edge cases where this new algorithm wouldn't work. If for instance we start in an orbit around a star but we're still in a controlled space via a space station.

