### PR TITLE
Fix missing station manager in the lobby of Torvalds station

### DIFF
--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -42,7 +42,7 @@ widgetSizes.buttonLaunchSize = Vector2(widgetSizes.buttonSizeBase.x*5, widgetSiz
 widgetSizes.iconSize = Vector2(0, widgetSizes.buttonSizeBase.y)
 
 local face = nil
-local stationSeed = 0
+local stationSeed = false
 local shipDef
 
 local hyperdrive ---@type Equipment.HyperdriveType?


### PR DESCRIPTION
'0' is a possible seed so if we compare the init value to a real seed of '0', it will test 'true', and the station face will not be drawn. Torvalds station is the only custom station that is seeded with 0.


<img width="821" height="461" alt="Image" src="https://github.com/user-attachments/assets/6e3f9806-ef05-43a9-9b05-f5b8ecf3d58e" />


