### PR TITLE
only set stationSeed from one place

### DIFF
--- a/data/pigui/modules/station-view/06-shipRepairs.lua
+++ b/data/pigui/modules/station-view/06-shipRepairs.lua
@@ -105,7 +105,6 @@ local function determinePaintshopAvailability()
 	-- high population stations often have them
 	local pop = station:GetSystemBody().population
 	if pop > 0.00005 then -- Mars is about 0.0002
-		stationSeed = station.seed
 		local rand = Rand.New(station.seed .. '-paintshop')
 		if rand:Number(0,1) < 0.75 then
 			return true


### PR DESCRIPTION
In response to #6225
I'm not sure it's a fix yet but 'stationSeed' shouldn't be set on two different places. If it's set via **determinePaintshopAvailability()** then, when either of **refresh()**, **drawPaintshop()** or **drawShipRepair()** is executed and there are no face, the face will not be generated. It's not obvious to me yet when **refresh()** is called. In any case, this is only a proplem on bodies with smaller populations.
#6225 states that the missing faces are on bot the lobby and the mechanic and this would not be explained by this find/fix. However, I'm unsure if I have tested this correctly as my local test branch I used to test this bug with debug statements accidentally had a fix built in, so it essentially sent me to intermittent hell with the issue suddenly gone. We must assume the possibility that the rest of my trouble shooting lived up to the same quality.

A draft for now.