### PR TITLE
fix(ui): correct temperature display units

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -1924,12 +1924,12 @@
     "message": "°C"
   },
   "UNIT_TEMPERATURE_FAHRENHEIT": {
-    "description": "Temperature unit: Fahrenheit (F)",
-    "message": "F"
+    "description": "Temperature unit: Fahrenheit (°F)",
+    "message": "°F"
   },
   "UNIT_TEMPERATURE_KELVIN": {
-    "description": "Temperature unit: degrees Kelvin (°K)",
-    "message": "°K"
+    "description": "Temperature unit: degrees Kelvin (K)",
+    "message": "K"
   },
   "UNIT_TERATONNES": {
     "description": "Mass unit: one teratonne",


### PR DESCRIPTION
As correctly pointed out by zonkmachine, Kelvin is not written as degrees-Kelvin (°K), but Fahrenheit is (°F).

Bug introduced in commit 74f390aaeacdb1a5be8e34ca3d343e415f39b82d

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

