### PR TITLE
Codedoc cleanup 2

### DIFF
--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -68,14 +68,6 @@ static LuaFlags<ObjectType> s_bodyFlags ({
  *
  * The label for the body. This is what is displayed in the HUD and usually
  * matches the name of the planet, space station, etc if appropriate.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 
 /*
@@ -85,14 +77,6 @@ static LuaFlags<ObjectType> s_bodyFlags ({
  * same for this body across runs of the same build of the game, and should be
  * used to seed a <Rand> object when you want to ensure the same random
  * numbers come out each time.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_body_attr_seed(lua_State *l)
 {
@@ -112,14 +96,6 @@ static int l_body_attr_seed(lua_State *l)
  *
  * If the body is a dynamic body it has no persistent path data, and its
  * <path> value will be nil.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_body_attr_path(lua_State *l)
 {
@@ -143,14 +119,6 @@ static int l_body_attr_path(lua_State *l)
  * Returns a handle to the specified LuaComponent or C++ Component attached
  * to the given body, if present. Will return nil if the specified component
  * does not exist on this body.
- *
- * Availability:
- *
- *   June 2022
- *
- * Status:
- *
- *   stable
  */
 static int l_body_get_component(lua_State *l)
 {
@@ -186,14 +154,6 @@ static int l_body_get_component(lua_State *l)
  *
  *   comp - a table object to be used as the component value or nil to remove
  *          the component from the Body.
- *
- * Availability:
- *
- *   June 2022
- *
- * Status:
- *
- *   stable
  */
 static int l_body_set_component(lua_State *l)
 {
@@ -231,14 +191,6 @@ static int l_body_set_component(lua_State *l)
  * Parameters:
  *
  *   other - the other body
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_body_get_velocity_rel_to(lua_State *l)
 {
@@ -364,14 +316,6 @@ static int l_body_is_more_important_than(lua_State *l)
  * Parameters:
  *
  *   other - the other body
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_body_get_position_rel_to(lua_State *l)
 {
@@ -400,14 +344,6 @@ static int l_body_get_position_rel_to(lua_State *l)
  *
  * > -- Get relative above terrain altitude to other body
  * > body:GetAltitudeRelTo(otherBody, true)
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_body_get_altitude_rel_to(lua_State *l)
 {
@@ -429,14 +365,6 @@ static int l_body_get_altitude_rel_to(lua_State *l)
  * The type of the body, as a <Constants.BodyType> constant.
  *
  * Only valid for non-dynamic <Bodies>. For dynamic bodies <type> will be nil.
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_body_attr_type(lua_State *l)
 {
@@ -457,14 +385,6 @@ static int l_body_attr_type(lua_State *l)
  * The supertype of the body, as a <Constants.BodySuperType> constant
  *
  * Only valid for non-dynamic <Bodies>. For dynamic bodies <superType> will be nil.
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_body_attr_super_type(lua_State *l)
 {
@@ -490,14 +410,6 @@ static int l_body_attr_super_type(lua_State *l)
  * <frameBody> can also be nil if this dynamic body is in a frame with no
  * non-dynamic body. This most commonly occurs when the player is in
  * hyperspace.
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_body_attr_frame_body(lua_State *l)
 {
@@ -525,14 +437,6 @@ static int l_body_attr_frame_body(lua_State *l)
  *
  * Only valid for dynamic <Bodies>. For non-dynamic bodies <frameRotating>
  * will be nil.
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_body_attr_frame_rotating(lua_State *l)
 {
@@ -573,14 +477,6 @@ static int l_body_attr_frame_rotating(lua_State *l)
  * The above list of static/dynamic bodies may change in the future. Scripts
  * should use this method to determine the difference rather than checking
  * types directly.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_body_is_dynamic(lua_State *l)
 {
@@ -603,14 +499,6 @@ static int l_body_is_dynamic(lua_State *l)
  * Returns:
  *
  *   dist - distance between the two bodies in meters
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_body_distance_to(lua_State *l)
 {
@@ -653,14 +541,6 @@ static int l_body_distance_to(lua_State *l)
  * > local lat, long, alt = Game.player:GetGroundPosition(false)
  * > lat = math.rad2deg(lat)
  * > long = math.rad2deg(long)
- *
- * Availability:
- *
- *   July 2013
- *
- * Status:
- *
- *   experimental
  */
 static int l_body_get_ground_position(lua_State *l)
 {
@@ -719,14 +599,6 @@ static int l_body_get_ground_position(lua_State *l)
  * > closestStar = Game.player:FindNearestTo("STAR")
  * > closestStation = Game.player:FindNearestTo("SPACESTATION")
  * > closestPlanet = Game.player:FindNearestTo("PLANET")
- *
- * Availability:
- *
- *   2014 April
- *
- * Status:
- *
- *   experimental
  */
 static int l_body_find_nearest_to(lua_State *l)
 {
@@ -745,14 +617,6 @@ static int l_body_find_nearest_to(lua_State *l)
  * Get the body's physical radius
  *
  * > body:GetPhysRadius()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_body_get_phys_radius(lua_State *l)
 {

--- a/src/lua/LuaConsole.cpp
+++ b/src/lua/LuaConsole.cpp
@@ -516,14 +516,6 @@ bool LuaConsole::ExecOrContinue(const std::string &stmt, bool repeatStatement)
  * Parameters:
  *
  *   text - the line of text to add (without a terminating newline character)
- *
- * Availability:
- *
- *   alpha 15
- *
- * Status:
- *
- *   stable
  */
 static int l_console_addline(lua_State *L)
 {

--- a/src/lua/LuaConstants.cpp
+++ b/src/lua/LuaConstants.cpp
@@ -173,14 +173,6 @@ void LuaConstants::Register(lua_State *l)
 	 * PLANET_TERRESTRIAL - terrestrial planet
 	 * STARPORT_ORBITAL - orbital starport (space station)
 	 * STARPORT_SURFACE - surface starport
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   stable
 	 */
 
 	/*
@@ -193,14 +185,6 @@ void LuaConstants::Register(lua_State *l)
 	 * ROCKY_PLANET - a solid planet (terrestrial or asteroid)
 	 * GAS_GIANT - gas giant
 	 * STARPORT - surface or orbital starport
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   stable
 	 */
 
 	/*
@@ -217,14 +201,6 @@ void LuaConstants::Register(lua_State *l)
 	 *	  STAR - .
 	 *	  CARGOBODY - .
 	 *	  MISSILE - .
-	 *
-	 * Availability:
-	 *
-	 *   2014 April
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -237,14 +213,6 @@ void LuaConstants::Register(lua_State *l)
 	 * CAPITALIST - .
 	 * MIXED - .
 	 * PLANNED - .
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -268,14 +236,6 @@ void LuaConstants::Register(lua_State *l)
 	 * COMMUNIST - .
 	 * PLUTOCRATIC - .
 	 * DISORDER - .
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -314,14 +274,6 @@ void LuaConstants::Register(lua_State *l)
 	 * MILITARY_FUEL - military fuel
 	 * RUBBISH - rubbish
 	 * RADIOACTIVES - radioactives
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -331,14 +283,6 @@ void LuaConstants::Register(lua_State *l)
 	 *
 	 * HORIZONTAL - Lasers are mounted left and right
 	 * VERTICAL   - Lasers are mounted top and bottom
-	 *
-	 * Availability:
-	 *
-	 *   alpha 27
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -354,14 +298,6 @@ void LuaConstants::Register(lua_State *l)
 	 *               are used for mission specific functions (large supply
 	 *               ships, warships, etc)
 	 * MISSILE - missiles.
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   stable
 	 */
 
 	/*
@@ -376,14 +312,6 @@ void LuaConstants::Register(lua_State *l)
 	 * DOWN - top/back (dorsal) thruster
 	 * LEFT - right-side (starboard) thruster
 	 * RIGHT - left-side (port) thruster
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   stable
 	 */
 
 	/*
@@ -401,14 +329,6 @@ void LuaConstants::Register(lua_State *l)
 	 *                     enough fuel
 	 * SAFETY_LOCKOUT - drive locked out for safety reasons
 	 *                  (currently this happens if landed, docked or docking)
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   stable
 	 */
 
 	/*
@@ -420,14 +340,6 @@ void LuaConstants::Register(lua_State *l)
 	 * SHIP_NEARBY - ship within 100km (yellow)
 	 * SHIP_FIRING - ship within 100km is firing lasers (though not
 	 * necessarily at us) (red)
-	 *
-	 * Availability:
-	 *
-	 *   alpha 10
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -438,14 +350,6 @@ void LuaConstants::Register(lua_State *l)
 	 * OK - more than 5% fuel remaining
 	 * WARNING - less than 5% fuel remaining
 	 * EMPTY - no fuel remaining
-	 *
-	 * Availability:
-	 *
-	 *   alpha 20
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -460,14 +364,6 @@ void LuaConstants::Register(lua_State *l)
 	 * LANDED     - rough landed (not docked)
 	 * JUMPING    - just initiating hyperjump (as of February 2014)
 	 * HYPERSPACE - in hyperspace
-	 *
-	 * Availability:
-	 *
-	 *   alpha 16
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -480,14 +376,6 @@ void LuaConstants::Register(lua_State *l)
 	 * REFUSED_PERM     - AI was refused docking permission
 	 * ORBIT_IMPOSSIBLE - AI was asked to enter an impossible orbit (orbit is
 	 *                    outside target's frame)
-	 *
-	 * Availability:
-	 *
-	 *   alpha 17
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	/*
@@ -498,14 +386,6 @@ void LuaConstants::Register(lua_State *l)
 	 * USER - directory containing Pioneer's config, savefiles, mods and other
 	 * user-specific data
 	 * DATA - directory containing Pioneer's data files
-	 *
-	 * Availability:
-	 *
-	 *   alpha 25
-	 *
-	 * Status:
-	 *
-	 *   experimental
 	 */
 
 	// XXX document UI tables

--- a/src/lua/LuaDev.cpp
+++ b/src/lua/LuaDev.cpp
@@ -33,14 +33,6 @@
  *       CountSystemNames
  *       CountPopulation
  *       PlanetsGravity
- *
- * Availability:
- *
- *   2020
- *
- * Status:
- *
- *   experimental
  */
 
 static int l_dev_galaxy_stats(lua_State *l)

--- a/src/lua/LuaEngine.cpp
+++ b/src/lua/LuaEngine.cpp
@@ -46,14 +46,6 @@
  * The global <Rand> object. Its stream of values will be different across
  * multiple Pioneer runs. Use this when you just need a random number and
  * don't care about the seed.
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_engine_attr_rand(lua_State *l)
 {
@@ -67,14 +59,6 @@ static int l_engine_attr_rand(lua_State *l)
  * Number of milliseconds since Pioneer was started. This should be used for
  * debugging purposes only (eg timing) and should never be used for game logic
  * of any kind.
- *
- * Availability:
- *
- *   alpha 26
- *
- * Status:
- *
- *   debug
  */
 static int l_engine_attr_ticks(lua_State *l)
 {
@@ -88,14 +72,6 @@ static int l_engine_attr_ticks(lua_State *l)
  * Number of real-time seconds since Pioneer was started. This should be used
  * for debugging or UI purposes only (eg animations), and should never be used
  * in game logic of any kind.
- *
- * Availability:
- *
- *   July 2022
- *
- * Status:
- *
- *   stable
  */
 static int l_engine_attr_time(lua_State *l)
 {
@@ -110,14 +86,6 @@ static int l_engine_attr_time(lua_State *l)
  * to the precise time this value is accessed. This should be used only for
  * profiling and debugging purposes to calculate a duration in sub-millisecond
  * units.
- *
- * Availability:
- *
- *   October 2024
- *
- * Status:
- *
- *   experimental
  */
 static int l_engine_attr_now_time(lua_State *l)
 {
@@ -131,14 +99,6 @@ static int l_engine_attr_now_time(lua_State *l)
  * Length of the last frame in seconds. This should be used for debugging or UI
  * purposes only (e.g. animations) and should never be used in game logic of
  * any kind.
- *
- * Availability:
- *
- *   July 2022
- *
- * Status:
- *
- *   stable
  */
 static int l_engine_attr_frame_time(lua_State *l)
 {
@@ -150,14 +110,6 @@ static int l_engine_attr_frame_time(lua_State *l)
  * Attribute: pigui
  *
  * The global PiGui object. It provides an interface to ImGui functions
- *
- * Availability:
- *
- *   2016-10-06
- *
- * Status:
- *
- *   experimental
  */
 static int l_engine_attr_pigui(lua_State *l)
 {
@@ -169,14 +121,6 @@ static int l_engine_attr_pigui(lua_State *l)
  * Attribute: version
  *
  * String describing the version of Pioneer
- *
- * Availability:
- *
- *   alpha 25
- *
- * Status:
- *
- *   experimental
  */
 static int l_engine_attr_version(lua_State *l)
 {
@@ -192,14 +136,6 @@ static int l_engine_attr_version(lua_State *l)
  * Exit the program. If there is a game running it ends the game first.
  *
  * > Engine.Quit()
- *
- * Availability:
- *
- *   alpha 28
- *
- * Status:
- *
- *   experimental
  */
 static int l_engine_quit(lua_State *l)
 {
@@ -213,14 +149,6 @@ static int l_engine_quit(lua_State *l)
  * Get the available video modes
  *
  * > Engine.GetVideoModeList()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_get_video_mode_list(lua_State *l)
@@ -245,20 +173,12 @@ static int l_engine_get_video_mode_list(lua_State *l)
 }
 
 /*
-* Method: GetMaximumAASamples
-*
-* Get the maximum number of samples the current OpenGL context supports
-*
-* > Engine.GetMaximumAASamples()
-*
-* Availability:
-*
-*   2017-12
-*
-* Status:
-*
-*   stable
-*/
+ * Method: GetMaximumAASamples
+ *
+ * Get the maximum number of samples the current OpenGL context supports
+ *
+ * > Engine.GetMaximumAASamples()
+ */
 
 static int l_engine_get_maximum_aa_samples(lua_State *l)
 {
@@ -281,14 +201,6 @@ static int l_engine_get_maximum_aa_samples(lua_State *l)
  * Get the current video resolution width and height
  *
  * > width,height = Engine.GetVideoResolution()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_get_video_resolution(lua_State *l)
@@ -309,14 +221,6 @@ static int l_engine_get_video_resolution(lua_State *l)
  *
  *   width - the new width in pixels
  *   height - the new height in pixels
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_set_video_resolution(lua_State *l)
@@ -334,14 +238,6 @@ static int l_engine_set_video_resolution(lua_State *l)
  * Return true if fullscreen is enabled
  *
  * > fullscreen = Engine.GetFullscreen()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_get_fullscreen(lua_State *l)
@@ -360,14 +256,6 @@ static int l_engine_get_fullscreen(lua_State *l)
  * Parameters:
  *
  *   fullscreen - true to turn on
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_set_fullscreen(lua_State *l)
@@ -391,10 +279,6 @@ static int l_engine_set_fullscreen(lua_State *l)
  * Parameters:
  *
  *   enabled - true to show, false to hide. If not present, toggles the state instead
- *
- * Availability: 2020-05
- *
- * Status: experimental
  */
 static int l_engine_set_show_debug_info(lua_State *l)
 {
@@ -900,14 +784,6 @@ static int l_engine_get_intro_current_model_name(lua_State *l)
  * Parameters:
  *
  *   camera_space - a Vector in camera space
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_world_space_to_ship_space(lua_State *l)
@@ -929,14 +805,6 @@ static int l_engine_world_space_to_ship_space(lua_State *l)
  * Parameters:
  *
  *   ship_space - a Vector in ship space
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_ship_space_to_screen_space(lua_State *l)
@@ -957,14 +825,6 @@ static int l_engine_ship_space_to_screen_space(lua_State *l)
  * Parameters:
  *
  *   camera_space - a Vector in camera space
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_camera_space_to_screen_space(lua_State *l)
@@ -986,13 +846,6 @@ static int l_engine_camera_space_to_screen_space(lua_State *l)
  *
  *   rel_space - a position Vector in player-relative space
  *               (e.g. `body:GetPositionRelTo(player)`)*
- * Availability:
- *
- *   2020-12
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_project_rel_position(lua_State *l)
@@ -1014,14 +867,6 @@ static int l_engine_project_rel_position(lua_State *l)
  *
  *   rel_space - a direction Vector in player-relative space
  *               (e.g. `body:GetVelocityRelTo(player)`)
- *
- * Availability:
- *
- *   2020-12
- *
- * Status:
- *
- *   stable
  */
 
 static int l_engine_project_rel_direction(lua_State *l)
@@ -1047,14 +892,6 @@ static int l_engine_project_rel_direction(lua_State *l)
  *   position - the screen-space position of the body if onscreen.
  *   direction - the screen-space direction from the center of the screen
  *               to the body if offscreen.
- *
- * Availability:
- *
- *   2020-12
- *
- * Status:
- *
- *   experimental
  */
 
 static int l_engine_get_projected_screen_position(lua_State *l)
@@ -1079,14 +916,6 @@ static int l_engine_get_projected_screen_position(lua_State *l)
  *   position - the screen-space position of the body if onscreen.
  *   direction - the screen-space direction from the center of the screen
  *               to the body if offscreen.
- *
- * Availability:
- *
- *   2020-12
- *
- * Status:
- *
- *   experimental
  */
 
 static int l_engine_get_target_indicator_screen_position(lua_State *l)

--- a/src/lua/LuaFaction.cpp
+++ b/src/lua/LuaFaction.cpp
@@ -18,14 +18,6 @@
  * Attribute: name
  *
  * The name of the faction
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_name(lua_State *l)
 {
@@ -38,14 +30,6 @@ static int l_faction_attr_name(lua_State *l)
  * Attribute: id
  *
  * A unique identification number of the faction
- *
- * Availability:
- *
- *  2014-06
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_id(lua_State *l)
 {
@@ -59,14 +43,6 @@ static int l_faction_attr_id(lua_State *l)
  * Attribute: descriptionShort
  *
  * The short description of the faction
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_description_short(lua_State *l)
 {
@@ -79,14 +55,6 @@ static int l_faction_attr_description_short(lua_State *l)
  * Attribute: description
  *
  * The full length description of the faction
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_description(lua_State *l)
 {
@@ -99,14 +67,6 @@ static int l_faction_attr_description(lua_State *l)
  * Attribute: hasHomeworld
  *
  * Does the faction have a homeworld?
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_has_homeworld(lua_State *l)
 {
@@ -119,14 +79,6 @@ static int l_faction_attr_has_homeworld(lua_State *l)
  * Attribute: homeworld
  *
  * Get the factions homeworld if it has one or a default SystemPath(0,0,0,0,0) if it doesn't
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_homeworld(lua_State *l)
 {
@@ -140,14 +92,6 @@ static int l_faction_attr_homeworld(lua_State *l)
  *
  * The date that the faction came into being.
  * Used in conjunction with expansionRate it can be used to calculate the volume of occupied space.
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_founding_date(lua_State *l)
 {
@@ -162,14 +106,6 @@ static int l_faction_attr_founding_date(lua_State *l)
  * The rate at which the faction has been expanding since it's foundation.
  * Measured in light-years per-year of expansion.
  * So for a value of 1.0 the volumes _RADIUS_ will expand by 1 light-year.
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_expansion_rate(lua_State *l)
 {
@@ -183,14 +119,6 @@ static int l_faction_attr_expansion_rate(lua_State *l)
  *
  * The radius in light years of the the spherical volume the faction
  * encompasses as at the year 3200
- *
- * Availability:
- *
- *  alpha 29
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_radius(lua_State *l)
 {
@@ -203,14 +131,6 @@ static int l_faction_attr_radius(lua_State *l)
  * Attribute: militaryName
  *
  * The military name used by the faction
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_military_name(lua_State *l)
 {
@@ -223,14 +143,6 @@ static int l_faction_attr_military_name(lua_State *l)
  * Attribute: policeName
  *
  * The name of the law enforcing agency in the faction
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_police_name(lua_State *l)
 {
@@ -243,14 +155,6 @@ static int l_faction_attr_police_name(lua_State *l)
  * Attribute: policeShip
  *
  * The ships used by the police
- *
- * Availability:
- *
- *  2015 September
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_police_ship(lua_State *l)
 {
@@ -267,14 +171,6 @@ static int l_faction_attr_police_ship(lua_State *l)
  * Attribute: colour
  *
  * The colour used to represent the faction in the SectorView screen
- *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  experimental
  */
 static int l_faction_attr_colour(lua_State *l)
 {

--- a/src/lua/LuaFileSystem.cpp
+++ b/src/lua/LuaFileSystem.cpp
@@ -109,14 +109,6 @@ int LuaFileSystem::l_patched_io_open(lua_State* L)
  *
  *   files - a list of files as full paths from the root
  *   dirs - a list of dirs as full paths from the root
- *
- * Availability:
- *
- *   alpha 26
- *
- * Status:
- *
- *   experimental
  */
 static int l_filesystem_read_dir(lua_State *l)
 {
@@ -171,14 +163,6 @@ static int l_filesystem_read_dir(lua_State *l)
  *
  * Join the passed arguments into a path, correctly handling separators and .
  * and .. special dirs.
- *
- * Availability:
- *
- *   alpha 26
- *
- * Status:
- *
- *   experimental
  */
 static int l_filesystem_join_path(lua_State *l)
 {
@@ -202,14 +186,6 @@ static int l_filesystem_join_path(lua_State *l)
  *
  * Creating the given directory if it's missing, returning a boolean
  * indicating success
- *
- * Availability:
- *
- *   Oct 2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_filesystem_make_directory(lua_State *l)
 {

--- a/src/lua/LuaFormat.cpp
+++ b/src/lua/LuaFormat.cpp
@@ -34,14 +34,6 @@
  * Return:
  *
  *   string - the string representation
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_format_date(lua_State *l)
 {
@@ -64,10 +56,6 @@ static int l_format_date(lua_State *l)
  * Return:
  *
  *   string - the string representation of the date
- *
- * Status:
- *
- *   stable
  */
 static int l_format_date_only(lua_State *l)
 {
@@ -90,14 +78,6 @@ static int l_format_date_only(lua_State *l)
  * Return:
  *
  *   string - the string representation
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_format_distance(lua_State *l)
 {
@@ -125,14 +105,6 @@ static int l_format_distance(lua_State *l)
  * Return:
  *
  *   string - the string representation
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_format_money(lua_State *l)
 {

--- a/src/lua/LuaGame.cpp
+++ b/src/lua/LuaGame.cpp
@@ -52,14 +52,6 @@
  *
  *   ship_type - string, ship id, i.e. 'sinonatrix'
  *
- *
- * Availability:
- *
- *   2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_start_game(lua_State *l)
 {
@@ -142,19 +134,11 @@ static void onSaveGameStatsJobFinished(std::string_view filename, const Json &ro
  *   filename - The filename of the save game to retrieve stats for.
  *              Stats will be loaded from the 'savefiles' directory in the user's game directory.
  *
- * Availability:
- *
- *   2018-02-10
- *
  * Modified:
  *
  *   2024-10-11 - the function no longer returns the Stats directly, but starts
  *                a Job. The Lua caller is responsible for registering an
  *                "onSaveGameStats" event handler to process the data.
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_savegame_stats(lua_State *l)
 {
@@ -193,14 +177,6 @@ static int l_game_current_save_version(lua_State *l)
  *
  *   filename - Filename to load. It will be loaded from the 'savefiles'
  *              directory in the user's game directory.
- *
- * Availability:
- *
- *   alpha 28
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_load_game(lua_State *l)
 {
@@ -238,15 +214,6 @@ static int l_game_load_game(lua_State *l)
  * Return:
  *
  *   bool - can the filename be found to load
- *
- * Availability:
- *
- *   YYYY - MM - DD
- *   2016 - 06 - 25
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_can_load_game(lua_State *l)
 {
@@ -273,14 +240,6 @@ static int l_game_can_load_game(lua_State *l)
  * Return:
  *
  *   path - the full path to the saved file (so it can be displayed)
- *
- * Availability:
- *
- *   June 2013
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_save_game(lua_State *l)
 {
@@ -325,14 +284,6 @@ static int l_game_save_game(lua_State *l)
  * Return:
  *
  *   bool - is save deleted successfully
- *
- * Availability:
- *
- *   November 2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_delete_save(lua_State *l)
 {
@@ -353,14 +304,6 @@ static int l_game_delete_save(lua_State *l)
  * Return:
  *
  *   saves - a list of save-games as names and modification-date
- *
- * Availability:
- *
- *   September 2024
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_list_saves(lua_State *l)
 {
@@ -388,14 +331,6 @@ static int l_game_list_saves(lua_State *l)
  * End the current game and return to the main menu.
  *
  * > Game.EndGame(filename)
- *
- * Availability:
- *
- *   June 2013
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_end_game(lua_State *l)
 {
@@ -411,14 +346,6 @@ static int l_game_end_game(lua_State *l)
  * Attribute: player
  *
  * The <Player> object for the current player.
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_game_attr_player(lua_State *l)
 {
@@ -433,14 +360,6 @@ static int l_game_attr_player(lua_State *l)
  * Attribute: system
  *
  * The <StarSystem> object for the system the player is currently in.
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_game_attr_system(lua_State *l)
 {
@@ -455,14 +374,6 @@ static int l_game_attr_system(lua_State *l)
  * Attribute: systemView
  *
  * The <SystemView> object for the system map view class
- *
- * Availability:
- *
- *  February 2020
- *
- * Status:
- *
- *  experiment
  */
 static int l_game_attr_systemview(lua_State *l)
 {
@@ -477,14 +388,6 @@ static int l_game_attr_systemview(lua_State *l)
  * Attribute: sectorView
  *
  * The <SectorView> object for the sector map view class
- *
- * Availability:
- *
- *  April 2020
- *
- * Status:
- *
- *  experiment
  */
 static int l_game_attr_sectorview(lua_State *l)
 {
@@ -499,14 +402,6 @@ static int l_game_attr_sectorview(lua_State *l)
  * Attribute: time
  *
  * The current game time, in seconds since 12:00 01-01-3200
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_game_attr_time(lua_State *l)
 {
@@ -521,14 +416,6 @@ static int l_game_attr_time(lua_State *l)
  * Attribute: paused
  *
  * True if the game is paused.
- *
- * Availability:
- *
- *  September 2014
- *
- * Status:
- *
- *  experimental
  */
 static int l_game_attr_paused(lua_State *l)
 {
@@ -549,14 +436,6 @@ static int l_game_attr_paused(lua_State *l)
  * Return:
  *
  *   hyperspace - true if the game is currently in hyperspace
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_game_in_hyperspace(lua_State *l)
@@ -575,14 +454,6 @@ static int l_game_in_hyperspace(lua_State *l)
  * Return:
  *
  *   view - a string describing the game view: "WorldView", "StationView", "InfoView", "SectorView", "SystemView", "DeathView"
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static int l_game_current_view(lua_State *l)

--- a/src/lua/LuaInput.cpp
+++ b/src/lua/LuaInput.cpp
@@ -694,14 +694,6 @@ static void setup_binding_table(lua_State *l, const char *id, const char *type)
  * >	},
  * >	-- ... more pages
  * > }
- *
- * Availability:
- *
- *   September 2018
- *
- * Status:
- *
- *   permanent
  */
 static int l_input_get_binding_pages(lua_State *l)
 {

--- a/src/lua/LuaMissile.cpp
+++ b/src/lua/LuaMissile.cpp
@@ -22,14 +22,6 @@
  * Arms the missile
  *
  * > missile:Arm()
- *
- * Availability:
- *
- *  alpha 31
- *
- * Status:
- *
- *  experimental
  */
 static int l_missile_arm(lua_State *l)
 {
@@ -44,14 +36,6 @@ static int l_missile_arm(lua_State *l)
  * Disarms the missile
  *
  * > missile:Disarm()
- *
- * Availability:
- *
- *  alpha 31
- *
- * Status:
- *
- *  experimental
  */
 static int l_missile_disarm(lua_State *l)
 {
@@ -73,14 +57,6 @@ static int l_missile_disarm(lua_State *l)
  *
  * Returns:
  *   true if the command could be enacted, false otherwise
- *
- * Availability:
- *
- *  Gen 2017
- *
- * Status:
- *
- *  experimental
  */
 static int l_missile_ai_kamikaze(lua_State *l)
 {
@@ -109,14 +85,6 @@ static int l_missile_ai_kamikaze(lua_State *l)
  * > if approaching_missile:isArmed then
  * >     print("DANGER! DANGER!")
  * > end
- *
- * Availability:
- *
- *  alpha 31
- *
- * Status:
- *
- *  experimental
  */
 static int l_missile_attr_is_armed(lua_State *l)
 {

--- a/src/lua/LuaMusic.cpp
+++ b/src/lua/LuaMusic.cpp
@@ -19,14 +19,6 @@
  *
  * This event does not not trigger when a song finishes
  * prematurely (sound system stopped, another song starts playing).
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 
 /*
@@ -39,14 +31,6 @@
  * > name = Music.GetSongName()
  *
  * The name does not include the data/music/ prefix or .ogg suffix.
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_music_get_song(lua_State *l)
 {
@@ -67,14 +51,6 @@ static int l_music_get_song(lua_State *l)
  *
  *   name - song file name, without data/music/ or file extension
  *   repeat - true or false, default false
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_music_play(lua_State *l)
 {
@@ -92,14 +68,6 @@ static int l_music_play(lua_State *l)
  * Example:
  *
  * > Music.Stop()
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_music_stop(lua_State *l)
 {
@@ -121,14 +89,6 @@ static int l_music_stop(lua_State *l)
  *   name - song file name, without data/music/ or file extension
  *   fade factor - 0.1 = slow fade, 1.0 = instant. The fade factor of our sound system does not represent any natural unit. Sorry.
  *   repeat - true or false, default false
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_music_fade_in(lua_State *l)
 {
@@ -151,14 +111,6 @@ static int l_music_fade_in(lua_State *l)
  * Parameters:
  *
  *   fade factor - 0.1 = slow fade, 1.0 = instant.
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_music_fade_out(lua_State *l)
 {
@@ -181,14 +133,6 @@ static int l_music_fade_out(lua_State *l)
  * > -- prints:
  * > -- 1   tingle
  * > -- 2   action/knighty
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_music_get_song_list(lua_State *l)
 {
@@ -214,14 +158,6 @@ static int l_music_get_song_list(lua_State *l)
  * Returns:
  *
  *   true or false
- *
- * Availability:
- *
- *   alpha 12
- *
- * Status:
- *
- *   experimental
  */
 static int l_music_is_playing(lua_State *l)
 {

--- a/src/lua/LuaObject.cpp
+++ b/src/lua/LuaObject.cpp
@@ -49,14 +49,6 @@
  *
  * > if not ship:exists() then return
  *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
- *
  *
  * Method: isa
  *
@@ -82,14 +74,6 @@
  * > if body:isa("Ship") then
  * >     body:AIKill(Game.player)
  * > end
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 
 static std::map<std::string, std::map<std::string, PromotionTest>> promotions;

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -602,14 +602,6 @@ static int l_pigui_lineOnClock(lua_State *l)
 /* ****************************** Lua imgui functions ****************************** */
 /*
  * Function: begin
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_pigui_begin(lua_State *l)
 {
@@ -630,14 +622,6 @@ static int l_pigui_begin(lua_State *l)
  * blocked by a modal window rendering underneath it. To render a window on top
  * of a modal, it must be submitted within that modal's begin()/end() block.
  * (See data/pigui/libs/modal-win.lua).
- *
- * Availability:
- *
- *   2024-07
- *
- * Status:
- *
- *   experimental
  */
 static int l_pigui_bring_window_to_display_front(lua_State *l)
 {
@@ -652,10 +636,6 @@ static int l_pigui_bring_window_to_display_front(lua_State *l)
  * Gets imgui internal time
  *
  * > local currentTime = ui.getTime()
- *
- * Status:
- *
- *   stable
  */
 static int l_pigui_get_time(lua_State *l)
 {
@@ -2470,14 +2450,6 @@ bool PiGui::first_body_is_more_important_than(Body *body, Body *other)
  *   hasFollowTarget - true if group contains the follow target
  *   multiple - true if group consists of more than one body
  *   bodies - array of all <Body> objects in the group, sorted by importance
- *
- * Availability:
- *
- *   2019-12
- *
- * Status:
- *
- *   stable
  */
 static int l_pigui_get_projected_bodies_grouped(lua_State *l)
 {

--- a/src/lua/LuaPlayer.cpp
+++ b/src/lua/LuaPlayer.cpp
@@ -38,14 +38,6 @@ static int l_player_is_player(lua_State *l)
  * Return:
  *
  *   target - nil, or a <Body>
- *
- * Availability:
- *
- *   alpha 15
- *
- * Status:
- *
- *   stable
  */
 static int l_get_nav_target(lua_State *l)
 {
@@ -64,14 +56,6 @@ static int l_get_nav_target(lua_State *l)
  * Parameters:
  *
  *   target - a <Body> to which to set the navigation target, or nil
- *
- * Availability:
- *
- *   alpha 14
- *
- * Status:
- *
- *   stable
  */
 static int l_set_nav_target(lua_State *l)
 {
@@ -136,14 +120,6 @@ static int l_change_cruise_speed(lua_State *l)
  * Return:
  *
  *   target - nil, or a <Body>
- *
- * Availability:
- *
- *   alpha 15
- *
- * Status:
- *
- *   stable
  */
 static int l_get_combat_target(lua_State *l)
 {
@@ -162,14 +138,6 @@ static int l_get_combat_target(lua_State *l)
  * Parameters:
  *
  *   target - a <Body> to which to set the combat target, or nil
- *
- * Availability:
- *
- *   alpha 14
- *
- * Status:
- *
- *   stable
  */
 static int l_set_combat_target(lua_State *l)
 {
@@ -189,14 +157,6 @@ static int l_set_combat_target(lua_State *l)
  * Return:
  *
  *   target - nil, or a <SystemPath>
- *
- * Availability:
- *
- *   alpha 32
- *
- * Status:
- *
- *   stable
  */
 static int l_get_hyperspace_target(lua_State *l)
 {
@@ -220,14 +180,6 @@ static int l_get_hyperspace_target(lua_State *l)
  * Parameters:
  *
  *   target - a <SystemPath> to which to set the hyperspace target. Must be a system path or the path of a star.
- *
- * Availability:
- *
- *   alpha 32
- *
- * Status:
- *
- *   stable
  */
 static int l_set_hyperspace_target(lua_State *l)
 {
@@ -265,14 +217,6 @@ static int l_get_mouse_direction(lua_State *l)
  * Return true if the player is using the mouse to rotate the ship (typically RMB held)
  *
  * > player:IsMouseActive()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_get_is_mouse_active(lua_State *l)
 {
@@ -287,14 +231,6 @@ static int l_get_is_mouse_active(lua_State *l)
  * Get the player's ship's maximum Δv (excluding hydrogen in cargo space)
  *
  * > player:GetMaxDeltaV()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_get_max_delta_v(lua_State *l)
 {
@@ -310,14 +246,6 @@ static int l_get_max_delta_v(lua_State *l)
  * Get the player's ship's current Δv capacity (excluding hydrogen in cargo space)
  *
  * > player:GetCurrentDeltaV()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_get_current_delta_v(lua_State *l)
 {
@@ -332,14 +260,6 @@ static int l_get_current_delta_v(lua_State *l)
  * Get the player's ship's remaining Δv capacity (excluding hydrogen in cargo space)
  *
  * > player:GetRemainingDeltaV()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_get_remaining_delta_v(lua_State *l)
 {
@@ -361,14 +281,6 @@ static int l_get_remaining_delta_v(lua_State *l)
  * Parameters:
  *
  *   thruster - a string specifying which thruster's acceleration to return. One of "forward", "reverse" or "up"
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 
 static std::map<std::string, Thruster> thrusters_map = {
@@ -397,14 +309,6 @@ static int l_get_acceleration(lua_State *l)
  *
  *   speed - speed in m/s
  *   thruster - a string specifying which thruster to user for deceleration. One of "forward", "reverse"
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_get_distance_to_zero_v(lua_State *l)
 {
@@ -423,14 +327,6 @@ static int l_get_distance_to_zero_v(lua_State *l)
  * Get the time remaining until start of maneuver in seconds
  *
  * > player:GetManeuverTime()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_get_maneuver_time(lua_State *l)
 {
@@ -445,14 +341,6 @@ static int l_get_maneuver_time(lua_State *l)
  * Get the current maneuver velocity in m/s
  *
  * > player:GetManeuverVelocity()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_get_maneuver_velocity(lua_State *l)
 {
@@ -472,14 +360,6 @@ static int l_get_maneuver_velocity(lua_State *l)
  * Parameters:
  *
  *   type - "system-wide" or "planet"
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_get_heading_pitch_roll(lua_State *l)
 {

--- a/src/lua/LuaRand.cpp
+++ b/src/lua/LuaRand.cpp
@@ -30,14 +30,6 @@ extern "C" {
  * Return:
  *
  *   rand - the newly-created generator
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_rand_new(lua_State *l)
 {
@@ -88,14 +80,6 @@ static int l_rand_new(lua_State *l)
  * Return:
  *
  *   number - the random number
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_rand_number(lua_State *l)
 {
@@ -134,14 +118,6 @@ static int l_rand_number(lua_State *l)
  * Return:
  *
  *   number - the random integer number
- *
- * Availability:
- *
- *   November 2014
- *
- * Status:
- *
- *   Experimental
  */
 static int l_rand_poisson(lua_State *l)
 {
@@ -176,14 +152,6 @@ static int l_rand_poisson(lua_State *l)
  * Return:
  *
  *   number - the random number
- *
- * Availability:
- *
- *   January 2014
- *
- * Status:
- *
- *   Experimental
  */
 static int l_rand_normal(lua_State *l)
 {
@@ -228,14 +196,6 @@ static int l_rand_normal(lua_State *l)
  * Return:
  *
  *   number - the random number
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_rand_integer(lua_State *l)
 {

--- a/src/lua/LuaServerAgent.cpp
+++ b/src/lua/LuaServerAgent.cpp
@@ -174,14 +174,6 @@ static void _fail_callback(const std::string &error, void *userdata)
  *   onFailure - optional. a function to call if the remote call fails for any
  *               reason. The text of the error will be passed as the first
  *               argument to the function.
- *
- * Availability:
- *
- *   alpha 29
- *
- * Status:
- *
- *   experimental
  */
 static int l_serveragent_call(lua_State *l)
 {

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -48,14 +48,6 @@
  * > if Game.player:IsPlayer() then
  * >     print("this is the player")
  * > end
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_ship_is_player(lua_State *l)
 {
@@ -76,14 +68,6 @@ static int l_ship_is_player(lua_State *l)
  * Example:
  *
  * > ship:SetShipType('sirius_interdictor')
- *
- * Availability:
- *
- *   alpha 15
- *
- * Status:
- *
- *   experimental
  */
 static int l_ship_set_type(lua_State *l)
 {
@@ -108,14 +92,6 @@ static int l_ship_set_type(lua_State *l)
  * Returns a string describing the ship type
  *
  * > local shiptype = ship:GetShipType()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_ship_get_ship_type(lua_State *l)
 {
@@ -129,14 +105,6 @@ static int l_ship_get_ship_type(lua_State *l)
  * Returns a string describing the ship class
  *
  * > local shipclass = ship:GetShipClass()
- *
- * Availability:
- *
- *   2017-04
- *
- * Status:
- *
- *   stable
  */
 static int l_ship_get_ship_class(lua_State *l)
 {
@@ -163,14 +131,6 @@ static int l_ship_get_ship_class(lua_State *l)
  * Example:
  *
  * > ship:SetHullPercent(3.14)
- *
- * Availability:
- *
- *  alpha 15
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_set_hull_percent(lua_State *l)
 {
@@ -210,14 +170,6 @@ static int l_ship_set_hull_percent(lua_State *l)
  * Example:
  *
  * > ship:SetFuelPercent(50)
- *
- * Availability:
- *
- *  alpha 20
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_set_fuel_percent(lua_State *l)
 {
@@ -253,14 +205,6 @@ static int l_ship_set_fuel_percent(lua_State *l)
  * Destroys the ship in an explosion
  *
  * > ship:Explode()
- *
- * Availability:
- *
- * 	alpha 20
- *
- * Status:
- *
- * 	experimental
  */
 static int l_ship_explode(lua_State *l)
 {
@@ -377,14 +321,6 @@ static int l_ship_set_pattern(lua_State *l)
  * Example:
  *
  * > ship:SetLabel("AB-1234")
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_ship_set_label(lua_State *l)
 {
@@ -409,14 +345,6 @@ static int l_ship_set_label(lua_State *l)
  * Example:
  *
  * > ship:SetShipName("Boris")
- *
- * Availability:
- *
- *  September 2014
- *
- * Status:
- *
- *  stable
  */
 static int l_ship_set_ship_name(lua_State *l)
 {
@@ -448,14 +376,6 @@ static int l_ship_set_ship_name(lua_State *l)
  *
  * > Game.player:SpawnCargo(Commodities.hydrogen, 0)
  * > Game.player:SpawnCargo(Commodities.hydrogen)
- *
- * Availability:
- *
- *   alpha 26
- *
- * Status:
- *
- *   experimental
  */
 static int l_ship_spawn_cargo(lua_State *l)
 {
@@ -494,14 +414,6 @@ static int l_ship_spawn_cargo(lua_State *l)
  *
  *   station - a <SpaceStation> object for the station, or nil if the ship is
  *             not docked
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_ship_get_docked_with(lua_State *l)
 {
@@ -525,14 +437,6 @@ static int l_ship_get_docked_with(lua_State *l)
  * Return:
  *
  *   success - a boolean indicating whether the current ship was able to be docked at the station
- *
- * Availability:
- *
- *   2022-11
- *
- * Status:
- *
- *   experimental
  */
 static int l_ship_set_docked_with(lua_State *l)
 {
@@ -564,14 +468,6 @@ static int l_ship_set_docked_with(lua_State *l)
  *
  *   success - true if ship is undocking, false if the ship is unable to undock,
  *             probably because another ship is currently undocking
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_ship_undock(lua_State *l)
 {
@@ -613,14 +509,6 @@ static int l_ship_blast_off(lua_State *l)
  * Return:
  *
  *   missile - The missile spawned, or nil if it was unsuccessful.
- *
- * Availability:
- *
- *   alpha 26
- *
- * Status:
- *
- *   experimental
  */
 static int l_ship_spawn_missile(lua_State *l)
 {
@@ -670,14 +558,6 @@ static int l_ship_spawn_missile(lua_State *l)
  *             recharged, or there is no ECM to activate.
  *
  *   recharge_wait - time left to recharge.
- *
- * Availability:
- *
- *   2014 July
- *
- * Status:
- *
- *   experimental
  */
 static int l_ship_use_ecm(lua_State *l)
 {
@@ -782,14 +662,6 @@ static int l_ship_get_duration_for_distance(lua_State *l)
  *
  *   status - a <Constants.ShipJumpStatus> string that tells if the ship can
  *            hyperspace and if not, describes the reason
- *
- * Availability:
- *
- *   February 2014
- *
- * Status:
- *
- *   experimental
  */
 static int l_ship_initiate_hyperjump_to(lua_State *l)
 {
@@ -824,14 +696,6 @@ static int l_ship_initiate_hyperjump_to(lua_State *l)
  *   Abort the upcoming hyperjump
  *
  * > ship:AbortHyperjump()
- *
- * Availability:
- *
- *   February 2014
- *
- * Status:
- *
- *   experimental
  */
 static int l_ship_abort_hyperjump(lua_State *l)
 {
@@ -873,14 +737,6 @@ static int l_ship_create(lua_State *l)
  * Return:
  *
  *   is_invulnerable - boolean; true if the ship is invulnerable to damage
- *
- * Availability:
- *
- *  November 2013
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_get_invulnerable(lua_State *l)
 {
@@ -896,14 +752,6 @@ static int l_ship_get_invulnerable(lua_State *l)
  * Note: Invulnerability is not currently stored in the save game.
  *
  * > ship:SetInvulnerable(true)
- *
- * Availability:
- *
- *  November 2013
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_set_invulnerable(lua_State *l)
 {
@@ -1081,14 +929,6 @@ static int l_ship_toggle_wheel_state(lua_State *l)
  * Get the ships velocity
  *
  * > ship:GetVelocity()
- *
- * Availability:
- *
- *  April 2016
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_get_velocity(lua_State *l)
 {
@@ -1104,14 +944,6 @@ static int l_ship_get_velocity(lua_State *l)
  * Get the ship's position
  *
  * > ship:GetPosition()
- *
- * Availability:
- *
- *  April 2016
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_get_position(lua_State *l)
 {
@@ -1353,14 +1185,6 @@ static int l_ship_get_thruster_acceleration(lua_State *l)
  *
  * Returns:
  *   true if the command could be enacted, false otherwise
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_ai_kill(lua_State *l)
 {
@@ -1390,14 +1214,6 @@ static int l_ship_ai_kill(lua_State *l)
  *
  * Returns:
  *   true if the command could be enacted, false otherwise
- *
- * Availability:
- *
- *  alpha 26
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_ai_kamikaze(lua_State *l)
 {
@@ -1424,14 +1240,6 @@ static int l_ship_ai_kamikaze(lua_State *l)
  * Parameters:
  *
  *   target - the <Body> to fly to
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_ai_fly_to(lua_State *l)
 {
@@ -1453,14 +1261,6 @@ static int l_ship_ai_fly_to(lua_State *l)
  * Parameters:
  *
  *   target - the <SpaceStation> to dock with
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_ai_dock_with(lua_State *l)
 {
@@ -1482,14 +1282,6 @@ static int l_ship_ai_dock_with(lua_State *l)
  * Parameters:
  *
  *   target - the <Star> or <Planet> to orbit
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_ai_enter_low_orbit(lua_State *l)
 {
@@ -1513,14 +1305,6 @@ static int l_ship_ai_enter_low_orbit(lua_State *l)
  * Parameters:
  *
  *   target - the <Star> or <Planet> to orbit
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_ai_enter_medium_orbit(lua_State *l)
 {
@@ -1544,14 +1328,6 @@ static int l_ship_ai_enter_medium_orbit(lua_State *l)
  * Parameters:
  *
  *   target - the <Star> or <Planet> to orbit
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_ai_enter_high_orbit(lua_State *l)
 {
@@ -1594,14 +1370,6 @@ static int l_ship_get_current_ai_command(lua_State *l)
  * You do not need to call this if you intend to immediately invoke another AI
  * method. Calling an AI method will replace the previous command if one
  * exists.
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_cancel_ai(lua_State *l)
 {
@@ -1616,14 +1384,6 @@ static int l_ship_cancel_ai(lua_State *l)
  * Update the ship's statistics with regards to equipment changes
  *
  * > ship:UpdateEquipStats()
- *
- * Availability:
- *
- *  June 2014
- *
- * Status:
- *
- *  experimental
  */
 static int l_ship_update_equip_stats(lua_State *l)
 {
@@ -1736,26 +1496,10 @@ void LuaObject<Ship>::RegisterClass()
  *
  * The current alert status of the ship. A <Constants.ShipAlertStatus> string.
  *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  experimental
- *
  *
  * Attribute: flightState
  *
  * The current flight state of the ship. A <Constants.ShipFlightState> string.
- *
- * Availability:
- *
- *  alpha 25
- *
- * Status:
- *
- *  experimental
  *
  *
  * Attribute: shipId
@@ -1763,53 +1507,21 @@ void LuaObject<Ship>::RegisterClass()
  * The internal id of the ship type. This value can be passed to
  * <ShipType.GetShipType> to retrieve information about this ship type.
  *
- * Availability:
- *
- *  alpha 28
- *
- * Status:
- *
- *  stable
- *
  *
  * Attribute: fuel
  *
  * The current amount of fuel, as a percentage of full
- *
- * Availability:
- *
- *   alpha 20
- *
- * Status:
- *
- *   experimental
  *
  *
  * Attribute: fuelMassLeft
  *
  * Remaining thruster fuel mass in tonnes.
  *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
- *
  *
  * Attribute: hullMassLeft
  *
  * Remaining hull integrity in tonnes. Ship damage reduces hull integrity.
  * When this reaches 0, the ship is destroyed.
- *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
  *
  *
  * Attribute: shieldMassLeft
@@ -1818,26 +1530,10 @@ void LuaObject<Ship>::RegisterClass()
  * shield strength decreases. When this reaches 0, the shields are
  * fully depleted and the hull is exposed to damage.
  *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
- *
  *
  * Attribute: shieldMass
  *
  * Maximum shield strength for installed shields. Measured in tonnes.
- *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
  *
  *
  * Attribute: hyperspaceRange
@@ -1845,27 +1541,11 @@ void LuaObject<Ship>::RegisterClass()
  * Furthest possible hyperjump given current hyperspace fuel available.
  * Measured in light-years.
  *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
- *
  *
  * Attribute: maxHyperspaceRange
  *
  * Furthest possible hyperjump assuming no limits to available hyperspace fuel.
  * Measured in light-years.
- *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
  *
  *
  * Attribute: loadedMass
@@ -1873,36 +1553,19 @@ void LuaObject<Ship>::RegisterClass()
  * Mass of all contents of the ship, including equipment and cargo, but
  * excluding hull and thruster fuel mass.
  *
- * Status:
- *
- *   stable
- *
  *
  * Attribute: staticMass
  *
  * Mass of the ship including hull, equipment and cargo, but excluding
  * thruster fuel mass. Measured in tonnes.
  *
- * Status:
- *
- *   stable
- *
  *
  * Attribute: usedCargo
  *
  * Hull capacity used by cargo only (not equipment). Measured in cargo units.
  *
- * Status:
- *
- *   stable
- *
  *
  * Attribute: totalCargo
  *
  * Hull capacity available for cargo (not equipment). Measured in cargo units.
- *
- * Status:
- *
- *   stable
- *
  */

--- a/src/lua/LuaShipDef.cpp
+++ b/src/lua/LuaShipDef.cpp
@@ -19,14 +19,6 @@
  * Attribute: name
  *
  * The name of the ship type
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 
 /*
@@ -34,28 +26,12 @@
  *
  * The amount of angular thrust this ship can achieve. This is the value
  * responsible for the rate that the ship can turn at.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 
 /*
  * Attribute: capacity
  *
  * The maximum space available for cargo and equipment, in tonnes
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 
 /*
@@ -64,14 +40,6 @@
  * The total mass of the ship's hull, independent of any equipment or cargo
  * inside it, in tonnes. This is the value used when calculating hyperjump
  * ranges and hull damage.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 
 /*
@@ -79,42 +47,18 @@
  *
  * The base price of the ship. This typically receives some adjustment before
  * being used as a buy or sell price (eg based on supply or demand)
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 
 /*
  * Attribute: minCrew
  *
  * Minimum number of crew required to launch.
- *
- * Availability:
- *
- *   alpha 30
- *
- * Status:
- *
- *   experimental
  */
 
 /*
  * Attribute: maxCrew
  *
  * Maximum number of crew the ship can carry.
- *
- * Availability:
- *
- *   alpha 30
- *
- * Status:
- *
- *   experimental
  */
 
 /*
@@ -123,14 +67,6 @@
  * An integer representing the power of the hyperdrive usually installed on
  * those ships. If zero, it means the ship usually isn't equipped with one,
  * although this does not necessarily mean one cannot be installed.
- *
- * Availability:
- *
- *   April 2014
- *
- * Status:
- *
- *   experimental
  */
 
 /*
@@ -138,14 +74,6 @@
  *
  * Table keyed on <Constants.ShipTypeThruster>, containing linear thrust of
  * that thruster in newtons
- *
- * Availability:
- *
- *   alpha 32
- *
- * Status:
- *
- *   experimental
  */
 
 /*
@@ -153,7 +81,6 @@
  *
  * Table keyed on <Constants.ShipTypeThruster>, containing acceleration cap of
  * that thruster direction in m/s/s
- *
  */
 
 /*
@@ -161,68 +88,36 @@
  *
  * Ship thruster efficiency as the effective exhaust velocity in m/s.
  * See http://en.wikipedia.org/wiki/Specific_impulse for an explanation of this value.
- *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
  */
 
 /*
  * Attribute: thrusterFuelUse
  *
  * Ship thruster efficiency as a percentage-of-tank-used per second of thrust.
- *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
  */
 
 /*
  * Attribute: shipClass
  *
  * Class of the ship (e.g. "medium_courier").
- *
- * Status:
- *
- *   experimental
  */
 
 /*
  * Attribute: manufacturer
  *
  * Manufacturer of the ship (e.g. "kaluri").
- *
- * Status:
- *
- *   experimental
  */
 
 /*
  * Attribute: modelName
  *
  * Name for the model of this ship. Important for looking up the actual ship model (Engine.GetModel(ShipDef.modelName)).
- *
- * Status:
- *
- *   experimental
  */
 
 /*
  * Attribute: shieldModelName
  *
  * Name for the shield model of this ship. Can be useful for debug purposes to determine the shield model used by the ship.
- *
- * Status:
- *
- *   experimental
  */
 
 void LuaShipDef::Register()

--- a/src/lua/LuaSpace.cpp
+++ b/src/lua/LuaSpace.cpp
@@ -160,14 +160,6 @@ static vector3d _orbital_velocity_random_direction(const SystemBody *sb, const v
  * >     "flowerfairy", 9, 11,
  * >     { SystemPath:New(0,0,0), Game.time + 600 }
  * > )
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 static int l_space_spawn_ship(lua_State *l)
 {
@@ -243,14 +235,6 @@ extern double MaxEffectRad(const Body *body, Propulsion *prop);
  *
  * > -- move a ship to the middle of the route (by time)
  * > Space.PutShipOnRoute(ship, some_staport, 0.5)
- *
- * Availability:
- *
- *   2020
- *
- * Status:
- *
- *   experimental
  */
 static int l_space_put_ship_on_route(lua_State *l)
 {
@@ -335,14 +319,6 @@ static int l_space_put_ship_on_route(lua_State *l)
  *   ship - a <Ship> object to be moved
  *
  *   target - the <Star> or <Planet> to orbit
- *
- * Availability:
- *
- *  October 2023
- *
- * Status:
- *
- *  experimental
  */
 static int l_put_ship_into_orbit(lua_State *l)
 {
@@ -417,14 +393,6 @@ static int l_put_ship_into_orbit(lua_State *l)
  *
  * > -- spawn a ship 10km from the player with the players velocity
  * > local ship = Space.SpawnShipNear("viper_police_craft", Game.player, 10, 10, nil, Game.player:velocity)
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 static int l_space_spawn_ship_near(lua_State *l)
 {
@@ -497,14 +465,6 @@ static int l_space_spawn_ship_near(lua_State *l)
  *
  *   ship - a <Ship> object for the new ship, or nil if there was no space
  *          inside the station
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_space_spawn_ship_docked(lua_State *l)
 {
@@ -561,13 +521,6 @@ static int l_space_spawn_ship_docked(lua_State *l)
  *
  *   ship - a <Ship> object for the new ship, or nil if there was no space
  *          inside the station
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 static int l_space_spawn_ship_parked(lua_State *l)
 {
@@ -641,14 +594,6 @@ static int l_space_spawn_ship_parked(lua_State *l)
  * > -- spawn 16km from L.A. when in Sol system
  * > local earth = Space.GetBody(3)
  * > local ship = Space.SpawnShipLanded("viper_police", earth, math.deg2rad(34.06473923), math.deg2rad(-118.1591568))
- *
- * Availability:
- *
- *   July 2013
- *
- * Status:
- *
- *   experimental
  */
 static int l_space_spawn_ship_landed(lua_State *l)
 {
@@ -706,14 +651,6 @@ static int l_space_spawn_ship_landed(lua_State *l)
  *
  * > -- spawn a ship 10km from the player
  * > local ship = Space.SpawnShipLandedNear("viper_police", Game.player, 10, 10)
- *
- * Availability:
- *
- *   July 2013
- *
- * Status:
- *
- *   experimental
  */
 static int l_space_spawn_ship_landed_near(lua_State *l)
 {
@@ -937,14 +874,6 @@ static int l_space_spawn_ship_orbit(lua_State *l)
  *
  *   body - the <Body> object for the requested body, or nil if no such body
  *          exists
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_space_get_body(lua_State *l)
 {
@@ -975,14 +904,6 @@ static int l_space_get_body(lua_State *l)
  * Return:
  *
  *   num - the number of bodies currently existing in Space
- *
- * Availability:
- *
- *   Oct. 2023
- *
- * Status:
- *
- *   stable
  */
 static int l_space_get_num_bodies(lua_State *l)
 {
@@ -1017,14 +938,6 @@ static int l_space_get_num_bodies(lua_State *l)
  * > local stations = utils.filter_array(Space.GetBodies("SpaceStation"), function(body)
  * >     return body.type == "STARPORT_SURFACE"
  * > end)
- *
- * Availability:
- *
- *   Oct. 2023
- *
- * Status:
- *
- *   stable
  */
 static int l_space_get_bodies(lua_State *l)
 {
@@ -1084,14 +997,6 @@ static int l_space_get_bodies(lua_State *l)
  *
  * > -- get all stations within 50,000m
  * > local stations = Space.GetBodiesNear(Game.player, 50000, "SPACE_STATION")
- *
- * Availability:
- *
- *   Oct. 2023
- *
- * Status:
- *
- *   stable
  */
 static int l_space_get_bodies_near(lua_State *l)
 {

--- a/src/lua/LuaSpaceStation.cpp
+++ b/src/lua/LuaSpaceStation.cpp
@@ -32,14 +32,6 @@
  * > local lat, long = la:GetGroundPosition()
  * > lat = math.rad2deg(lat)
  * > long = math.rad2deg(long)
- *
- * Availability:
- *
- *   July 2013
- *
- * Status:
- *
- *   experimental
  */
 static int l_spacestation_get_ground_position(lua_State *l)
 {
@@ -70,14 +62,6 @@ static int l_spacestation_get_ground_position(lua_State *l)
  * Returns:
  *   clearanceGranted - a boolean indicating whether the ship has been
  *                      approved by ATC to land at this station.
- *
- * Availability:
- *
- *   Nov 2020
- *
- * Status:
- *
- *   stable
  */
 static int l_spacestation_request_docking_clearance(lua_State *l)
 {
@@ -104,14 +88,6 @@ static int l_spacestation_request_docking_clearance(lua_State *l)
  * > -- Get our current bay number and print it
  * > local num = station:GetAssignedBayNumber(Game.player)
  * > Game.AddCommsLogLine(string.interp("Please proceed to dock at bay {}, thank you!", num + 1), station)
- *
- * Availability:
- *
- *   Nov 2020
- *
- * Status:
- *
- *   stable
  */
 static int l_spacestation_get_assigned_bay_number(lua_State *l)
 {
@@ -131,14 +107,6 @@ static int l_spacestation_get_assigned_bay_number(lua_State *l)
  *
  * Returns:
  *   nearby - the number of ships within the specified radius of the station.
- *
- * Availability:
- *
- *   Nov 2020
- *
- * Status:
- *
- *   stable
  */
 static int l_spacestation_get_nearby_traffic(lua_State *l)
 {
@@ -153,14 +121,6 @@ static int l_spacestation_get_nearby_traffic(lua_State *l)
  * Attribute: numDocks
  *
  * The number of docking ports a spacestation has.
- *
- * Availability:
- *
- *   alpha 21
- *
- * Status:
- *
- *   stable
  */
 static int l_spacestation_attr_num_docks(lua_State *l)
 {
@@ -173,14 +133,6 @@ static int l_spacestation_attr_num_docks(lua_State *l)
  * Attribute: numShipsDocked
  *
  * The number of ships docked at spacestation
- *
- * Availability:
- *
- *   201404
- *
- * Status:
- *
- *   stable
  */
 static int l_spacestation_attr_num_ships_docked(lua_State *l)
 {
@@ -193,14 +145,6 @@ static int l_spacestation_attr_num_ships_docked(lua_State *l)
  * Attribute: isGroundStation
  *
  * true if station is on the ground, false if its an orbital
- *
- * Availability:
- *
- *   alpha 30
- *
- * Status:
- *
- *   stable
  */
 static int l_spacestation_attr_is_ground_station(lua_State *l)
 {

--- a/src/lua/LuaStarSystem.cpp
+++ b/src/lua/LuaStarSystem.cpp
@@ -47,14 +47,6 @@
  * Return:
  *
  *   paths - an array of <SystemPath> objects, one for each space station
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_get_station_paths(lua_State *l)
 {
@@ -86,14 +78,6 @@ static int l_starsystem_get_station_paths(lua_State *l)
  * Return:
  *
  *   paths - an array of <SystemPath> objects, one for each <SystemBody>
- *
- * Availability:
- *
- *   alpha 13
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_get_body_paths(lua_State *l)
 {
@@ -142,14 +126,6 @@ static int l_starsystem_get_body_by_path(lua_State *l)
  *                positive values make the commodity more expensive,
  *                indicating it is in demand, while negative values make the
  *                commodity cheaper, indicating a surplus.
- *
- * Availability:
- *
- *   June 2014
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_get_commodity_base_price_alterations(lua_State *l)
 {
@@ -185,14 +161,6 @@ static int l_starsystem_get_commodity_base_price_alterations(lua_State *l)
  * Return:
  *
  *   is_legal  - true if the commodity is legal, otherwise false
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_is_commodity_legal(lua_State *l)
 {
@@ -230,14 +198,6 @@ static int l_starsystem_is_commodity_legal(lua_State *l)
  * Return:
  *
  *  systems - an array of systems in range that matched the filter
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_get_nearby_systems(lua_State *l)
 {
@@ -344,14 +304,6 @@ static int l_starsystem_get_jumpable(lua_State *l)
  * Return:
  *
  *   dist - the distance, in light years
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_starsystem_distance_to(lua_State *l)
 {
@@ -387,14 +339,6 @@ static int l_starsystem_distance_to(lua_State *l)
  * Method: ExportToLua
  *
  * Export of generated system for personal interest, customisation, etc
- *
- * Availability:
- *
- *   alpha 33
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_export_to_lua(lua_State *l)
 {
@@ -433,14 +377,6 @@ static int l_starsystem_export_to_lua(lua_State *l)
  *
  *   time - optional, the game time at which the system was explored.
  *          Defaults to current game time.
- *
- * Availability:
- *
- *   October 2014
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_explore(lua_State *l)
 {
@@ -464,14 +400,6 @@ static int l_starsystem_explore(lua_State *l)
  *
  * The name of the system. This is usually the same as the name of the primary
  * star.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_starsystem_attr_name(lua_State *l)
 {
@@ -499,14 +427,6 @@ static int l_starsystem_attr_other_names(lua_State *l)
  * Attribute: path
  *
  * The <SystemPath> to the system
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_starsystem_attr_path(lua_State *l)
 {
@@ -522,14 +442,6 @@ static int l_starsystem_attr_path(lua_State *l)
  *
  * The lawlessness value for the system, 0 for peaceful, 1 for raging
  * hordes of pirates
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_attr_lawlessness(lua_State *l)
 {
@@ -543,14 +455,6 @@ static int l_starsystem_attr_lawlessness(lua_State *l)
  * Attribute: population
  *
  * The population of this system, in billions of people
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_attr_population(lua_State *l)
 {
@@ -564,14 +468,6 @@ static int l_starsystem_attr_population(lua_State *l)
  * Attribute: faction
  *
  * The <Faction> that controls this system
- *
- * Availability:
- *
- *   alpha 28
- *
- * Status:
- *
- *   experimental
  */
 static int l_starsystem_attr_faction(lua_State *l)
 {
@@ -632,14 +528,6 @@ static int l_starsystem_attr_long_description(lua_State *l)
 * Attribute: govDescription
 *
 * The translated description of the system's government type.
-*
-* Availability:
-*
-*   November 2020
-*
-* Status:
-*
-*   experimental
 */
 static int l_starsystem_attr_gov_description(lua_State *l)
 {
@@ -652,14 +540,6 @@ static int l_starsystem_attr_gov_description(lua_State *l)
 * Attribute: econDescription
 *
 * The translated description of the system's economy type.
-*
-* Availability:
-*
-*   November 2020
-*
-* Status:
-*
-*   experimental
 */
 static int l_starsystem_attr_econ_description(lua_State *l)
 {
@@ -673,14 +553,6 @@ static int l_starsystem_attr_econ_description(lua_State *l)
 *
 * The government type used in the system
 * (PolitGovType string constant, EARTHCOLONIAL, EARTHDEMOC, EMPIRERULE, etc.
-*
-* Availability:
-*
-*   december 2017
-*
-* Status:
-*
-*   experimental
 */
 static int l_starsystem_attr_govtype(lua_State *l)
 {
@@ -694,14 +566,6 @@ static int l_starsystem_attr_govtype(lua_State *l)
  * Attribute: explored
  *
  *   If this system has been explored then returns true
- *
- * Availability:
- *
- *   alpha 30
- *
- * Status:
- *
- *   experimental
  */
 
 static int l_starsystem_attr_explored(lua_State *l)

--- a/src/lua/LuaSystemBody.cpp
+++ b/src/lua/LuaSystemBody.cpp
@@ -29,14 +29,6 @@
  * Attribute: index
  *
  * The body index of the body in its system
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_sbody_attr_index(lua_State *l)
 {
@@ -49,14 +41,6 @@ static int l_sbody_attr_index(lua_State *l)
  * Attribute: name
  *
  * The name of the body
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_sbody_attr_name(lua_State *l)
 {
@@ -69,14 +53,6 @@ static int l_sbody_attr_name(lua_State *l)
  * Attribute: type
  *
  * The type of the body, as a <Constants.BodyType> constant
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_sbody_attr_type(lua_State *l)
 {
@@ -89,14 +65,6 @@ static int l_sbody_attr_type(lua_State *l)
  * Attribute: superType
  *
  * The supertype of the body, as a <Constants.BodySuperType> constant
- *
- * Availability:
- *
- *  alpha 10
- *
- * Status:
- *
- *  stable
  */
 static int l_sbody_attr_super_type(lua_State *l)
 {
@@ -115,14 +83,6 @@ static int l_sbody_attr_super_type(lua_State *l)
  *
  * This value is the same is the one available via <Body.seed> once you enter
  * this system.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_sbody_attr_seed(lua_State *l)
 {
@@ -135,14 +95,6 @@ static int l_sbody_attr_seed(lua_State *l)
  * Attribute: parent
  *
  * The parent of the body, as a <SystemBody>. A body orbits its parent.
- *
- * Availability:
- *
- *   alpha 14
- *
- * Status:
- *
- *   stable
  */
 static int l_sbody_attr_parent(lua_State *l)
 {
@@ -164,14 +116,6 @@ static int l_sbody_attr_parent(lua_State *l)
  * Attribute: system
  *
  * The StarSystem which contains this SystemBody
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_system(lua_State *l)
 {
@@ -184,14 +128,6 @@ static int l_sbody_attr_system(lua_State *l)
  * Attribute: population
  *
  * The population of the body, in billions of people.
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_population(lua_State *l)
 {
@@ -204,14 +140,6 @@ static int l_sbody_attr_population(lua_State *l)
  * Attribute: radius
  *
  * The radius of the body, in metres (m).
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_radius(lua_State *l)
 {
@@ -224,14 +152,6 @@ static int l_sbody_attr_radius(lua_State *l)
  * Attribute: mass
  *
  * The mass of the body, in kilograms (kg).
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_mass(lua_State *l)
 {
@@ -244,14 +164,6 @@ static int l_sbody_attr_mass(lua_State *l)
  * Attribute: gravity
  *
  * The gravity on the surface of the body (m/s).
- *
- * Availability:
- *
- *   alpha 21
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_gravity(lua_State *l)
 {
@@ -265,14 +177,6 @@ static int l_sbody_attr_gravity(lua_State *l)
  *
  * The speed an object need to break free from the gravitational influence
  * of a body and leave it behind with no further acceleration.
- *
- * Availability:
- *
- *   July 2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_escape_velocity(lua_State *l)
 {
@@ -285,14 +189,6 @@ static int l_sbody_attr_escape_velocity(lua_State *l)
  * Attribute: meanDensity
  *
  * The mean density of a body (kg/m3).
- *
- * Availability:
- *
- *   July 2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_mean_density(lua_State *l)
 {
@@ -305,14 +201,6 @@ static int l_sbody_attr_mean_density(lua_State *l)
  * Attribute: periapsis
  *
  * The periapsis of the body's orbit, in metres (m).
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_periapsis(lua_State *l)
 {
@@ -325,14 +213,6 @@ static int l_sbody_attr_periapsis(lua_State *l)
  * Attribute: apoapsis
  *
  * The apoapsis of the body's orbit, in metres (m).
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_apoapsis(lua_State *l)
 {
@@ -345,14 +225,6 @@ static int l_sbody_attr_apoapsis(lua_State *l)
  * Attribute: orbitPeriod
  *
  * The orbit of the body, around its parent, in days, as a float
- *
- * Availability:
- *
- *   201708
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_orbital_period(lua_State *l)
 {
@@ -365,14 +237,6 @@ static int l_sbody_attr_orbital_period(lua_State *l)
  * Attribute: rotationPeriod
  *
  * The rotation period of the body, in days
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_rotation_period(lua_State *l)
 {
@@ -385,14 +249,6 @@ static int l_sbody_attr_rotation_period(lua_State *l)
  * Attribute: semiMajorAxis
  *
  * The semi-major axis of the orbit, in metres (m).
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_semi_major_axis(lua_State *l)
 {
@@ -405,14 +261,6 @@ static int l_sbody_attr_semi_major_axis(lua_State *l)
  * Attribute: eccentricity
  *
  * The orbital eccentricity of the body
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_eccentricty(lua_State *l)
 {
@@ -425,14 +273,6 @@ static int l_sbody_attr_eccentricty(lua_State *l)
  * Attribute: axialTilt
  *
  * The axial tilt of the body, in radians
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_axial_tilt(lua_State *l)
 {
@@ -445,14 +285,6 @@ static int l_sbody_attr_axial_tilt(lua_State *l)
  * Attribute: averageTemp
  *
  * The average surface temperature of the body, in degrees kelvin
- *
- * Availability:
- *
- *   alpha 16
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_average_temp(lua_State *l)
 {
@@ -466,14 +298,6 @@ static int l_sbody_attr_average_temp(lua_State *l)
  *
  * Returns the measure of metallicity of the body
  * (crust) 0.0 = light (Al, SiO2, etc), 1.0 = heavy (Fe, heavy metals)
- *
- * Availability:
- *
- *   January 2018
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_metallicity(lua_State *l)
 {
@@ -487,14 +311,6 @@ static int l_sbody_attr_metallicity(lua_State *l)
  *
  * Returns the atmospheric density at "surface level" of the body
  * 0.0 = no atmosphere, 1.225 = earth atmosphere density, 64+ ~= venus
- *
- * Availability:
- *
- *   January 2018
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_atmosDensity(lua_State *l)
 {
@@ -508,14 +324,6 @@ static int l_sbody_attr_atmosDensity(lua_State *l)
  *
  * Returns the compositional value of any atmospheric gasses in the bodys atmosphere (if any)
  * 0.0 = reducing (H2, NH3, etc), 1.0 = oxidising (CO2, O2, etc)
- *
- * Availability:
- *
- *   January 2018
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_atmosOxidizing(lua_State *l)
 {
@@ -528,14 +336,6 @@ static int l_sbody_attr_atmosOxidizing(lua_State *l)
  * Attribute: surfacePressure
  *
  * The pressure of the atmosphere at the surface of the body (atm).
- *
- * Availability:
- *
- *   2024
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_surfacePressure(lua_State *l)
 {
@@ -549,14 +349,6 @@ static int l_sbody_attr_surfacePressure(lua_State *l)
  *
  * Returns the measure of volatile liquids present on the body
  * 0.0 = none, 1.0 = waterworld (earth = 70%)
- *
- * Availability:
- *
- *   January 2018
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_volatileLiquid(lua_State *l)
 {
@@ -570,14 +362,6 @@ static int l_sbody_attr_volatileLiquid(lua_State *l)
  *
  * Returns the measure of volatile ices present on the body
  * 0.0 = none, 1.0 = total ice cover (earth = 3%)
- *
- * Availability:
- *
- *   January 2018
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_volatileIces(lua_State *l)
 {
@@ -591,14 +375,6 @@ static int l_sbody_attr_volatileIces(lua_State *l)
  *
  * Returns the measure of volcanicity of the body
  * 0.0 = none, 1.0 = lava planet
- *
- * Availability:
- *
- *   January 2018
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_volcanicity(lua_State *l)
 {
@@ -612,14 +388,6 @@ static int l_sbody_attr_volcanicity(lua_State *l)
  *
  * Returns the measure of life present on the body
  * 0.0 = dead, 1.0 = teeming (~= pandora)
- *
- * Availability:
- *
- *   January 2018
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_life(lua_State *l)
 {
@@ -633,14 +401,6 @@ static int l_sbody_attr_life(lua_State *l)
  *
  * Returns the measure of agricultural activity present on the body
  * 0.0 = dead, 1.0 = teeming (~= breadbasket)
- *
- * Availability:
- *
- *   January 2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_sbody_attr_agricultural(lua_State *l)
 {
@@ -653,14 +413,6 @@ static int l_sbody_attr_agricultural(lua_State *l)
  * Attribute: hasRings
  *
  * Returns true if the body has a ring or rings of debris or ice in orbit around it
- *
- * Availability:
- *
- *   January 2018
- *
- * Status:
- *
- *  experimental
  */
 
 static int l_sbody_attr_has_rings(lua_State *l)
@@ -674,14 +426,6 @@ static int l_sbody_attr_has_rings(lua_State *l)
  * Attribute: hasAtmosphere
  *
  * Returns true if an atmosphere is present, false if not
- *
- * Availability:
- *
- *   alpha 21
- *
- * Status:
- *
- *  experimental
  */
 
 static int l_sbody_attr_has_atmosphere(lua_State *l)
@@ -695,14 +439,6 @@ static int l_sbody_attr_has_atmosphere(lua_State *l)
  * Attribute: isScoopable
  *
  * Returns true if the system body can be scoopable, false if not
- *
- * Availablility:
- *
- *   alpha 21
- *
- * Status:
- *
- *  experimental
  */
 
 static int l_sbody_attr_is_scoopable(lua_State *l)

--- a/src/lua/LuaSystemPath.cpp
+++ b/src/lua/LuaSystemPath.cpp
@@ -95,14 +95,6 @@ void LuaObject<SystemPath>::PushToLua(const SystemPath &o)
  *   bodyIndex - optional. the numeric index of a specific body within the
  *               system. Defaults to 0, which typically corresponds to the
  *               primary star.
- *
- * Availability:
- *
- *   alpha 10, alpha 13 (updated)
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_new(lua_State *l)
 {
@@ -152,14 +144,6 @@ static int l_sbodypath_new(lua_State *l)
  * Return:
  *
  *   is_same - true if the path's point to the same system, false otherwise
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_is_same_system(lua_State *l)
 {
@@ -189,14 +173,6 @@ static int l_sbodypath_is_same_system(lua_State *l)
  * Return:
  *
  *   is_same - true if the path's point to the same sector, false otherwise
- *
- * Availability:
- *
- *   alpha 17
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_is_same_sector(lua_State *l)
 {
@@ -217,14 +193,6 @@ static int l_sbodypath_is_same_sector(lua_State *l)
  * Return:
  *
  *   system_path - the SystemPath that represents just the system
- *
- * Availability:
- *
- *   alpha 17
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_system_only(lua_State *l)
 {
@@ -249,14 +217,6 @@ static int l_sbodypath_system_only(lua_State *l)
  * Return:
  *
  *   sector_path - the SystemPath that represents just the sector
- *
- * Availability:
- *
- *   alpha 17
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_sector_only(lua_State *l)
 {
@@ -282,14 +242,6 @@ static int l_sbodypath_sector_only(lua_State *l)
  * Return:
  *
  *   dist - the distance, in light years
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_distance_to(lua_State *l)
 {
@@ -330,14 +282,6 @@ static int l_sbodypath_distance_to(lua_State *l)
  * Return:
  *
  *   system - the <StarSystem>
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_get_star_system(lua_State *l)
 {
@@ -363,14 +307,6 @@ static int l_sbodypath_get_star_system(lua_State *l)
  * Return:
  *
  *   body - the <SystemBody>
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_get_system_body(lua_State *l)
 {
@@ -427,14 +363,6 @@ static int l_sbodypath_is_system_path(lua_State *l)
 * Return:
 *
 *   sector_path - the SystemPath that represents just the sector
-*
-* Availability:
-*
-*   2018-06-16
-*
-* Status:
-*
-*   experimental
 */
 static int l_sbodypath_parse_string(lua_State *l)
 {
@@ -453,14 +381,6 @@ static int l_sbodypath_parse_string(lua_State *l)
  * Attribute: sectorX
  *
  * The X component of the path
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_attr_sector_x(lua_State *l)
 {
@@ -473,14 +393,6 @@ static int l_sbodypath_attr_sector_x(lua_State *l)
  * Attribute: sectorY
  *
  * The Y component of the path
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 
 static int l_sbodypath_attr_sector_y(lua_State *l)
@@ -494,14 +406,6 @@ static int l_sbodypath_attr_sector_y(lua_State *l)
  * Attribute: sectorZ
  *
  * The Z component of the path
- *
- * Availability:
- *
- *   alpha 13
- *
- * Status:
- *
- *   stable
  */
 
 static int l_sbodypath_attr_sector_z(lua_State *l)
@@ -516,14 +420,6 @@ static int l_sbodypath_attr_sector_z(lua_State *l)
  *
  * The system index component of the path, or nil if the SystemPath does
  * not point to a system.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_attr_system_index(lua_State *l)
 {
@@ -540,14 +436,6 @@ static int l_sbodypath_attr_system_index(lua_State *l)
  *
  * The body index component of the path, or nil if the SystemPath does
  * not point to a body.
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_sbodypath_attr_body_index(lua_State *l)
 {

--- a/src/lua/LuaSystemView.cpp
+++ b/src/lua/LuaSystemView.cpp
@@ -96,14 +96,6 @@ static int l_systemview_set_selected_object(lua_State *l)
  *
  * }
  *
- *
- * Availability:
- *
- *   2020-03
- *
- * Status:
- *
- *   experimental
  */
 
 static int l_systemview_get_projected_grouped(lua_State *l)

--- a/src/lua/LuaTimer.cpp
+++ b/src/lua/LuaTimer.cpp
@@ -176,14 +176,6 @@ static int _finish_timer_create(lua_State *l, int callbackIdx)
  * > Timer:CallAt(Game.time+30, function ()
  * >     Comms.Message("Special offer expired, sorry.")
  * > end)
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_timer_call_at(lua_State *l)
 {
@@ -242,14 +234,6 @@ static int l_timer_call_at(lua_State *l)
  * >     local did_dump = Game.player:Jettison(Equipment.cargo.hydrogen)
  * >     return not did_dump
  * > end)
- *
- * Availability:
- *
- *   alpha 10
- *
- * Status:
- *
- *   stable
  */
 static int l_timer_call_every(lua_State *l)
 {

--- a/src/lua/LuaUtils.cpp
+++ b/src/lua/LuaUtils.cpp
@@ -33,14 +33,6 @@ extern "C" {
  *   m, n - optional. If called as hash_random(seed), the result is in the range 0 <= x < 1.
  *          If called as hash_random(seed, m, n), the result is an integer in the range m <= x <= n.
  *          m must be less than n. (n - m) must be less than 2^32.
- *
- * Availability:
- *
- *   alpha 24
- *
- * Status:
- *
- *   experimental
  */
 static int l_hash_random(lua_State *L)
 {
@@ -134,14 +126,6 @@ static int l_hash_random(lua_State *L)
  * Parameters:
  *
  *   str - A string.
- *
- * Availability:
- *
- *   November 2013
- *
- * Status:
- *
- *   experimental
  */
 static int l_trim(lua_State *l)
 {
@@ -181,14 +165,6 @@ static int l_trim(lua_State *l)
  * Return:
  *
  *   gameTime - number, 0 means 3200-01-01 00:00:00
- *
- * Availability:
- *
- *   2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_time_parts_to_game_time(lua_State *L)
 {
@@ -212,14 +188,6 @@ static int l_time_parts_to_game_time(lua_State *L)
  * Return:
  *
  *   year, month, day, hour, minute, second - numbers
- *
- * Availability:
- *
- *   2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_game_time_to_time_parts(lua_State *L)
 {
@@ -242,14 +210,6 @@ static int l_game_time_to_time_parts(lua_State *L)
  * Return:
  *
  *   gameTime - number, 0 means 3200-01-01 00:00:00
- *
- * Availability:
- *
- *   2023
- *
- * Status:
- *
- *   experimental
  */
 static int l_standard_game_start_time(lua_State *L)
 {


### PR DESCRIPTION
Continuation of #6228. Remove **Availability** and **Status** from the codedocs on the C++ side.

