### PR TITLE
Only add systems once in GetNearbyStarSystemsByName

### DIFF
--- a/src/SectorMap.cpp
+++ b/src/SectorMap.cpp
@@ -1276,15 +1276,18 @@ std::vector<SystemPath> SectorMap::GetNearbyStarSystemsByName(std::string patter
 				SystemPath match((*i).first);
 				match.systemIndex = systemIndex;
 				result.push_back(match);
-			}
-			// now also check other names of this system, if there are any
-			for (const std::string &other_name : ss->GetOtherNames()) {
-				if (strncasecmp(pattern.c_str(), other_name.c_str(), pattern.size()) == 0
-					// look for the pattern term somewhere within the current system
-					|| pi_strcasestr(other_name.c_str(), pattern.c_str())) {
-					SystemPath match((*i).first);
-					match.systemIndex = systemIndex;
-					result.push_back(match);
+				continue; // only need to add once
+			} else {
+				// If we didn't match the main name also check other names of this system, if there are any
+				for (const std::string &other_name : ss->GetOtherNames()) {
+					if (strncasecmp(pattern.c_str(), other_name.c_str(), pattern.size()) == 0
+						// look for the pattern term somewhere within the current system
+						|| pi_strcasestr(other_name.c_str(), pattern.c_str())) {
+						SystemPath match((*i).first);
+						match.systemIndex = systemIndex;
+						result.push_back(match);
+						continue; // only need to add once
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This partially fixes #6240 by eliminating the adding of duplicates.

It was adding, incorrectly I feel, the SystemPath per matching name or `otherName` entry.
This was then looked up in the UI and always displaying the main system name for each entry resulting in the bug.

This could be easily repeaed by starting a new game and just searching for a blank space ` `

