### PR TITLE
Findperson - New scenarios and some tests to give variation to the strings

### DIFF
--- a/data/culture/culture.lua
+++ b/data/culture/culture.lua
@@ -158,7 +158,7 @@ end
 -- one is randomly selected according to pre-set weights. Valid input
 -- is the same as Culture:Surname.
 --
--- > name1, name2 = Culture:Names(isfemale, rand, culture)
+-- > first_name, surname, culture = Culture:Names(isfemale, rand, culture)
 --
 -- Parameters:
 --
@@ -167,21 +167,22 @@ end
 --
 --   rand - the <Rand> object to use to generate the name
 --
---   culture - optional string
+--   culture - optional string. Equivalent to the language files parameter 'name'
 --
 -- Return:
 --
---   name1 - a string containing the first name
+--   first_name - a string containing the first name
 --
---   name2 - a string containing the surname
+--   surname - a string containing the surname
+--
+--   culture - a string containing the language/culture name
 --
 --
--- Return full name from the same culture/language
-
+-- Return full name, and language/culture name, as separate strings
 function Culture:Names (isFemale, rand, culture)
 	-- if 'culture' given as a string, e.g. "Russian" use that
 	local c = self.lookup[culture] or utils.chooseNormalized(self.weights, rand).lang
-	return c:FirstName(isFemale), c:Surname(isFemale)
+	return c:FirstName(isFemale), c:Surname(isFemale), c.name
 end
 
 return Culture

--- a/data/lang/module-findperson/en.json
+++ b/data/lang/module-findperson/en.json
@@ -223,6 +223,14 @@
     "description": "",
     "message": "Nice to meet you. My name is {client}. We are looking for an old business partner who still owes us a favour. Her name is {wanted}. She's gone into hiding in the {system} ({sectorx}, {sectory}, {sectorz}) system. If you can find her, hand over an encrypted document and then return to the {company} Office here at {domicile}. We pay {cash} in case of success. {system} is {dist} ly away."
   },
+  "INTROTEXT_DELIVER_DOCUMENT_FEMALE_3": {
+    "description": "",
+    "message": "Good day! I'm {client}. I represent {company} and we need help to track down a person in {system}. We bought her company last year but she is still in possession of some vital documents and has since relocated. Please track her down and have her hand over the documents. Her name is {wanted}, and she is somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system."
+  },
+  "INTROTEXT_DELIVER_DOCUMENT_FEMALE_4": {
+    "description": "",
+    "message": "Good day! I'm {client} and I represent {company}. We need to have a document delivered to {wanted} in {system}. We also need to see it signed and returned to us at this location. We don't know her precise location but she is somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system."
+  },
   "INTROTEXT_DELIVER_DOCUMENT_MALE_1": {
     "description": "",
     "message": "Greetings! I'm {client} and I speak for the {company}. One of our ships had a collision with another vessel just a few seconds before entering hyperspace. There wasn't enough time to stop the hyperjump sequence. Now we need someone who can locate the ship with ID number {shipid} in the {system} ({sectorx}, {sectory}, {sectorz}) system and hand over a proposal for an out-of-court settlement to Commander {wanted}. Please return to {domicile} for your payment of {cash}. You'll have to travel {dist} ly for this."
@@ -231,37 +239,85 @@
     "description": "",
     "message": "Nice to meet you. My name is {client}. We are looking for an old business partner who still owes us a favour. His name is {wanted}. He's gone into hiding in the {system} ({sectorx}, {sectory}, {sectorz}) system. If you can find him, hand over an encrypted document and then return to the {company} Office here at {domicile}. We pay {cash} in case of success. {system} is {dist} ly away."
   },
+  "INTROTEXT_DELIVER_DOCUMENT_MALE_3": {
+    "description": "",
+    "message": "Good day! I'm {client}. I represent {company} and we need help to track down a person in {system}. We bought his company last year but he is still in possession of some vital documents and has since relocated. Please track him down and have him hand over the documents. His name is {wanted}, and he is somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system."
+  },
+  "INTROTEXT_DELIVER_DOCUMENT_MALE_4": {
+    "description": "",
+    "message": "Good day! I'm {client} and I represent {company}. We need to have a document delivered to {wanted} in {system}. We also need to see it signed and returned to us at this location. We don't know his precise location but he is somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system."
+  },
   "INTROTEXT_DELIVER_MESSAGE_FEMALE_1": {
     "description": "",
-    "message": "Hi, my name is {client}. I'm looking for my stepsister {wanted}. She left the family in anger a few years ago. A friend of mine has seen her recently in the {system} ({sectorx}, {sectory}, {sectorz}) system. I would like to see if she is ready for a reconciliation. I pay you {cash} if you can deliver a message to her and return to {domicile} with an answer. Please do it! Will you?"
+    "message": "Hi, my name is {client}. I'm looking for {relative}, {wanted}. She left the family in anger a few years ago. A friend of mine has seen her recently in the {system} ({sectorx}, {sectory}, {sectorz}) system. I would like to see if she is ready for a reconciliation. I pay you {cash} if you can deliver a message to her and return to {domicile} with an answer. Please do it! Will you?"
   },
   "INTROTEXT_DELIVER_MESSAGE_FEMALE_2": {
     "description": "",
-    "message": "Hello. I'm {client}. I'm looking for an old friend. Her name is {wanted}. I know she resides in the {system} ({sectorx}, {sectory}, {sectorz}) system, but I don't know her exact location. I will pay you {cash} if you can deliver a message to her."
+    "message": "Hello. I'm {client}. I'm looking for {friend}. Her name is {wanted}. I know she resides in the {system} ({sectorx}, {sectory}, {sectorz}) system, but I don't know her exact location. I will pay you {cash} if you can deliver a message to her."
+  },
+  "INTROTEXT_DELIVER_MESSAGE_FEMALE_3": {
+    "description": "",
+    "message": "Hello. My name is {client}. I need to get in contact with {friend}, {wanted}. The last time I heard from her she was living in the {system} ({sectorx}, {sectory}, {sectorz}) system, and I've heard she's still there but don't know precisely where. I will pay you {cash} if you can deliver a message to her."
+  },
+  "INTROTEXT_DELIVER_MESSAGE_FEMALE_4": {
+    "description": "",
+    "message": "Hello. My name is {client}. {relative}, {wanted}, accepted a position in the {system} ({sectorx}, {sectory}, {sectorz}) system some years ago. After a year we stopped hearing from her and now the mail is being returned so something must have happened. My family will pay {cash} if you can track her down and deliver a message."
+  },
+  "INTROTEXT_DELIVER_MESSAGE_FEMALE_5": {
+    "description": "",
+    "message": "Good day, I'm {client}! I need to get a message delivered to my professor, {wanted}, who is doing research in the {system} ({sectorx}, {sectory}, {sectorz}) system. I haven't heard from her in six months, and the contact information I have is no longer valid. I'm prepared to pay {cash} for the service."
   },
   "INTROTEXT_DELIVER_MESSAGE_MALE_1": {
     "description": "",
-    "message": "Hi, my name is {client}. I'm looking for my stepbrother {wanted}. He left the family in anger a few years ago. A friend of mine has seen him recently in the {system} ({sectorx}, {sectory}, {sectorz}) system. I would like to see if he is ready for a reconciliation. I pay you {cash} if you can deliver a message to him and return to {domicile} with an answer. Please do it! Will you?"
+    "message": "Hi, my name is {client}. I'm looking for {relative}, {wanted}. He left the family in anger a few years ago. A friend of mine has seen him recently in the {system} ({sectorx}, {sectory}, {sectorz}) system. I would like to see if he is ready for a reconciliation. I pay you {cash} if you can deliver a message to him and return to {domicile} with an answer. Please do it! Will you?"
   },
   "INTROTEXT_DELIVER_MESSAGE_MALE_2": {
     "description": "",
-    "message": "Hello. I'm {client}. I'm looking for an old friend. His name is {wanted}. I know he resides in the {system} ({sectorx}, {sectory}, {sectorz}) system, but I don't know his exact location. I will pay you {cash} if you can deliver a message to him."
+    "message": "Hello. I'm {client}. I'm looking for {friend}. His name is {wanted}. I know he resides in the {system} ({sectorx}, {sectory}, {sectorz}) system, but I don't know his exact location. I will pay you {cash} if you can deliver a message to him."
+  },
+  "INTROTEXT_DELIVER_MESSAGE_MALE_3": {
+    "description": "",
+    "message": "Hello. My name is {client}. I need to get in contact with {friend}, {wanted}. The last time I heard from him he was living in the {system} ({sectorx}, {sectory}, {sectorz}) system, and I've heard he's still there but don't know precisely where. I will pay you {cash} if you can deliver a message to him."
+  },
+  "INTROTEXT_DELIVER_MESSAGE_MALE_4": {
+    "description": "",
+    "message": "Hello. My name is {client}. {relative}, {wanted}, accepted a position in the {system} ({sectorx}, {sectory}, {sectorz}) system some years ago. After a year we stopped hearing from him and now the mail is being returned so something must have happened. My family will pay {cash} if you can track him down and deliver a message."
+  },
+  "INTROTEXT_DELIVER_MESSAGE_MALE_5": {
+    "description": "",
+    "message": "Good day, I'm {client}! I need to get a message delivered to my professor, {wanted}, who is doing research in the {system} ({sectorx}, {sectory}, {sectorz}) system. I haven't heard from her in six months, and the contact information I have is no longer valid. I'm prepared to pay {cash} for the service."
   },
   "INTROTEXT_EVACUATION_FEMALE_1": {
     "description": "",
-    "message": "Hi. The {company} is in big trouble. Negotiations with an aggressive market competitor in the {system} ({sectorx}, {sectory}, {sectorz}) system, a distance of {dist} ly, went very badly. Our envoy {wanted} must be evacuated. Communication with her is very limited, so we don't know her exact location. We pay {cash} for this run."
+    "message": "Hi. The {company} is in big trouble. Negotiations with an aggressive market competitor in the {system} ({sectorx}, {sectory}, {sectorz}) system, a distance of {dist} ly, went very badly. Our envoy, {wanted}, must be evacuated. Communication with her is very limited, so we don't know her exact location. We pay {cash} for this run."
   },
   "INTROTEXT_EVACUATION_FEMALE_2": {
     "description": "",
-    "message": "Hello. Call me {client}. I'm employed by the {company}. Our sales representative {wanted} in the {system} ({sectorx}, {sectory}, {sectorz}) system, distance {dist} ly, has come into conflict with some dangerous crooks. She doesn't trust the local authorities, so she's gone into hiding. We pay {cash} if you can find her and bring her back to {domicile} safely."
+    "message": "Hello. Call me {client}. I'm employed by the {company}. Our sales representative, {wanted}, in the {system} ({sectorx}, {sectory}, {sectorz}) system, distance {dist} ly, has come into conflict with some dangerous crooks. She doesn't trust the local authorities, so she's gone into hiding. We pay {cash} if you can find her and bring her back to {domicile} safely."
+  },
+  "INTROTEXT_EVACUATION_FEMALE_3": {
+    "description": "",
+    "message": "Hello, I'm {client}. I represent {company}. We need to get one of our employees out of the {system} system immediately. I can't go into greater details due to security concerns, but there is a credible threat to her safety. She has gone into hiding at one of the spaceports in the system, but she was unable to safely tell us which one. Her name is {wanted}, and she's somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system."
+  },
+  "INTROTEXT_EVACUATION_FEMALE_4": {
+    "description": "",
+    "message": "Hello! My name is {client}. I have been reached by the news that {relative}, {wanted}, have been targeted by criminals and had to leave her home in a hurry. She is hiding somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system, distance {dist} ly. The family wants to solve this discretely. We will pay {cash} if you can find her and bring her back to {domicile}."
   },
   "INTROTEXT_EVACUATION_MALE_1": {
     "description": "",
-    "message": "Hi. The {company} is in big trouble. Negotiations with an aggressive market competitor in the {system} ({sectorx}, {sectory}, {sectorz}) system, a distance of {dist} ly, went very badly. Our envoy {wanted} must be evacuated. Communication with him is very limited, so we don't know his exact location. We pay {cash} for this run."
+    "message": "Hi. The {company} is in big trouble. Negotiations with an aggressive market competitor in the {system} ({sectorx}, {sectory}, {sectorz}) system, a distance of {dist} ly, went very badly. Our envoy, {wanted}, must be evacuated. Communication with him is very limited, so we don't know his exact location. We pay {cash} for this run."
   },
   "INTROTEXT_EVACUATION_MALE_2": {
     "description": "",
-    "message": "Hello. Call me {client}. I'm employed by the {company}. Our sales representative {wanted} in the {system} ({sectorx}, {sectory}, {sectorz}) system, distance {dist} ly, has come into conflict with some dangerous crooks. He doesn't trust the local authorities, so he's gone into hiding. We pay {cash} if you can find him and bring him back to {domicile} safely."
+    "message": "Hello. Call me {client}. I'm employed by the {company}. Our sales representative, {wanted}, in the {system} ({sectorx}, {sectory}, {sectorz}) system, distance {dist} ly, has come into conflict with some dangerous crooks. He doesn't trust the local authorities, so he's gone into hiding. We pay {cash} if you can find him and bring him back to {domicile} safely."
+  },
+  "INTROTEXT_EVACUATION_MALE_3": {
+    "description": "",
+    "message": "Hello, I'm {client}. I represent {company}. We need to get one of our employees out of the {system} system immediately. I can't go into greater details due to security concerns, but there is a credible threat to his safety. He has gone into hiding at one of the spaceports in the system, but he was unable to safely tell us which one. His name is {wanted}, and he's somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system."
+  },
+  "INTROTEXT_EVACUATION_MALE_4": {
+    "description": "",
+    "message": "Hello! My name is {client}. I have been reached by the news that {relative}, {wanted}, have been targeted by criminals and had to leave his home in a hurry. He is hiding somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system, distance {dist} ly. The family wants to solve this discretely. We will pay {cash} if you can find him and bring him back to {domicile}."
   },
   "INTROTEXT_PRIVATEER_FEMALE_1": {
     "description": "",
@@ -271,6 +327,10 @@
     "description": "",
     "message": "How are you. I'm Private Investigator {client}. I have to find privateer {wanted} in the {system} ({sectorx}, {sectory}, {sectorz}) system and ask her a few questions. Her ship has registration number {shipid}. I can't leave {domicile} right now because of another criminal case. So I would like to outsource this task. I will pay {cash} for this mission."
   },
+  "INTROTEXT_PRIVATEER_FEMALE_3": {
+    "description": "",
+    "message": "Hi there! My name is {client} and I need help to get a message through to {wanted} in the {system} ({sectorx}, {sectory}, {sectorz}) system. She flies missions there and her ship is registered as {shipid}. I will pay you {cash} upon returning to {domicile} with an answer."
+  },
   "INTROTEXT_PRIVATEER_MALE_1": {
     "description": "",
     "message": "Hi there! My name is {client}. I'm looking for {wanted}. He owes me a lot of money. According to the latest information, he's doing missions in the {system} ({sectorx}, {sectory}, {sectorz}) system. Please tell him that my patience is running thin. Return to {domicile} for your payment of {cash}."
@@ -278,6 +338,10 @@
   "INTROTEXT_PRIVATEER_MALE_2": {
     "description": "",
     "message": "How are you. I'm Private Investigator {client}. I have to find privateer {wanted} in the {system} ({sectorx}, {sectory}, {sectorz}) system and ask him a few questions. His ship has registration number {shipid}. I can't leave {domicile} right now because of another criminal case. So I would like to outsource this task. I will pay {cash} for this mission."
+  },
+  "INTROTEXT_PRIVATEER_MALE_3": {
+    "description": "",
+    "message": "Hi there! My name is {client} and I need help to get a message through to {wanted} in the {system} ({sectorx}, {sectory}, {sectorz}) system. He flies missions there and his ship is registered as {shipid}. I will pay you {cash} upon returning to {domicile} with an answer."
   },
   "INTROTEXT_TAXI_FEMALE_1": {
     "description": "",
@@ -287,6 +351,10 @@
     "description": "",
     "message": "Good day. I'm Insurance Assessor {client}. A high speed delivery drone failed to set a proper course, broke through a window and damaged the antique wooden furniture inside an apartment seriously. Fortunately no one was injured. But we couldn't locate the owner of the apartment in the {system} ({sectorx}, {sectory}, {sectorz}) system so far. So I will pay you {cash} if you can find her. Her personal presence is necessary to clarify the claim."
   },
+  "INTROTEXT_TAXI_FEMALE_3": {
+    "description": "",
+    "message": "Hi. I'm {client}. I need help finding {relative}, {wanted}. I need you to bring her here as she's needed in the family company. We will pay you {cash} for the service. She's somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system. Thank you!"
+  },
   "INTROTEXT_TAXI_MALE_1": {
     "description": "",
     "message": "Hi. I'm {client}. I'm looking for a relative in the {system} ({sectorx}, {sectory}, {sectorz}) system. His name is {wanted}. Time is of the essence due to a medical emergency in the family. Please find him and bring him back to {domicile}. I pay you {cash}."
@@ -294,6 +362,10 @@
   "INTROTEXT_TAXI_MALE_2": {
     "description": "",
     "message": "Good day. I'm Insurance Assessor {client}. A high speed delivery drone failed to set a proper course, broke through a window and damaged the antique wooden furniture inside an apartment seriously. Fortunately no one was injured. But we couldn't locate the owner of the apartment in the {system} ({sectorx}, {sectory}, {sectorz}) system so far. So I will pay you {cash} if you can find him. His personal presence is necessary to clarify the claim."
+  },
+  "INTROTEXT_TAXI_MALE_3": {
+    "description": "",
+    "message": "Hi. I'm {client}. I need help finding {relative}, {wanted}. I need you to bring him here as he's needed in the family company. We will pay you {cash} for the service. He's somewhere in the {system} ({sectorx}, {sectory}, {sectorz}) system. Thank you!"
   },
   "INTROTEXT_TRAITOR_FEMALE_1": {
     "description": "",
@@ -303,6 +375,10 @@
     "description": "",
     "message": "Good day. The {company} is searching for an employee who stole some classified documents. Her name is {wanted}. Management calls her a traitor, but wants to give her the opportunity to reconsider and repent. We pay {cash} if you can find her in the {system} ({sectorx}, {sectory}, {sectorz}) system, {dist} ly distance, and deliver a message to her."
   },
+  "INTROTEXT_TRAITOR_FEMALE_3": {
+    "description": "",
+    "message": "Good day. I'm {client} of {company}. We're trying to find a former employee, {employee}, who worked on one of our latest projects. Her name is {wanted}. We pay {cash} if you can find her in the {system} ({sectorx}, {sectory}, {sectorz}) system, {dist} ly distance, and deliver a message. Please be aware that she will not like this message."
+  },
   "INTROTEXT_TRAITOR_MALE_1": {
     "description": "",
     "message": "Hello, my name is {client}. {wanted} didn't return from a holiday trip to his workplace at the {company}. He was last seen in the {system} ({sectorx}, {sectory}, {sectorz}) system. {wanted} has knowledge of some vital business secrets. So we need someone who can get a few answers from him about his ongoing absence. We pay {cash} for this mission. {system} is in a distance of {dist} ly."
@@ -310,6 +386,10 @@
   "INTROTEXT_TRAITOR_MALE_2": {
     "description": "",
     "message": "Good day. The {company} is searching for an employee who stole some classified documents. His name is {wanted}. Management calls him a traitor, but wants to give him the opportunity to reconsider and repent. We pay {cash} if you can find him in the {system} ({sectorx}, {sectory}, {sectorz}) system, {dist} ly distance, and deliver a message to him."
+  },
+  "INTROTEXT_TRAITOR_MALE_3": {
+    "description": "",
+    "message": "Good day. I'm {client} of {company}. We're trying to find a former employee, {employee}, who worked on one of our latest projects. His name is {wanted}. We pay {cash} if you can find him in the {system} ({sectorx}, {sectory}, {sectorz}) system, {dist} ly distance, and deliver a message. Please be aware that he will not like this message."
   },
   "IS_THERE_A_RISK": {
     "description": "",

--- a/data/lang/persons/en.json
+++ b/data/lang/persons/en.json
@@ -1,0 +1,282 @@
+{
+  "RELATION_EMPLOYEE_FEMALE_1": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "an engineer"
+  },
+  "RELATION_EMPLOYEE_FEMALE_10": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "an accountant"
+  },
+  "RELATION_EMPLOYEE_FEMALE_11": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a lawyer"
+  },
+  "RELATION_EMPLOYEE_FEMALE_12": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a researcher"
+  },
+  "RELATION_EMPLOYEE_FEMALE_13": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "an administrator"
+  },
+  "RELATION_EMPLOYEE_FEMALE_2": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a scientist"
+  },
+  "RELATION_EMPLOYEE_FEMALE_3": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a technician"
+  },
+  "RELATION_EMPLOYEE_FEMALE_4": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "an inventor"
+  },
+  "RELATION_EMPLOYEE_FEMALE_5": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a contractor"
+  },
+  "RELATION_EMPLOYEE_FEMALE_6": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a chief mechanic"
+  },
+  "RELATION_EMPLOYEE_FEMALE_7": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a manager"
+  },
+  "RELATION_EMPLOYEE_FEMALE_8": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a developer"
+  },
+  "RELATION_EMPLOYEE_FEMALE_9": {
+  "description": "Female professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a co-worker"
+  },
+  "RELATION_EMPLOYEE_MALE_1": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "an engineer"
+  },
+  "RELATION_EMPLOYEE_MALE_10": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "an accountant"
+  },
+  "RELATION_EMPLOYEE_MALE_11": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a lawyer"
+  },
+  "RELATION_EMPLOYEE_MALE_12": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a researcher"
+  },
+  "RELATION_EMPLOYEE_MALE_13": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "an administrator"
+  },
+  "RELATION_EMPLOYEE_MALE_2": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a scientist"
+  },
+  "RELATION_EMPLOYEE_MALE_3": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a technician"
+  },
+  "RELATION_EMPLOYEE_MALE_4": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "an inventor"
+  },
+  "RELATION_EMPLOYEE_MALE_5": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a contractor"
+  },
+  "RELATION_EMPLOYEE_MALE_6": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a chief mechanic"
+  },
+  "RELATION_EMPLOYEE_MALE_7": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a manager"
+  },
+  "RELATION_EMPLOYEE_MALE_8": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a developer"
+  },
+  "RELATION_EMPLOYEE_MALE_9": {
+  "description": "Male professional or work-related contact. Substitutes {employee}. Indefinite form (a/an + noun).",
+    "message": "a co-worker"
+  },
+  "RELATION_FRIEND_FEMALE_1": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a friend"
+  },
+  "RELATION_FRIEND_FEMALE_10": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a former shipmate"
+  },
+  "RELATION_FRIEND_FEMALE_2": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "an old friend"
+  },
+  "RELATION_FRIEND_FEMALE_3": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "an old neighbour"
+  },
+  "RELATION_FRIEND_FEMALE_4": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a band mate"
+  },
+  "RELATION_FRIEND_FEMALE_5": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a friend from school"
+  },
+  "RELATION_FRIEND_FEMALE_6": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a friend from university"
+  },
+  "RELATION_FRIEND_FEMALE_7": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "an army buddy"
+  },
+  "RELATION_FRIEND_FEMALE_8": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a colleague"
+  },
+  "RELATION_FRIEND_FEMALE_9": {
+  "description": "Female friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "an old crewmate"
+  },
+  "RELATION_FRIEND_MALE_1": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a friend"
+  },
+  "RELATION_FRIEND_MALE_10": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a former shipmate"
+  },
+  "RELATION_FRIEND_MALE_2": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "an old friend"
+  },
+  "RELATION_FRIEND_MALE_3": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "an old neighbour"
+  },
+  "RELATION_FRIEND_MALE_4": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a band mate"
+  },
+  "RELATION_FRIEND_MALE_5": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a school friend"
+  },
+  "RELATION_FRIEND_MALE_6": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a friend from university"
+  },
+  "RELATION_FRIEND_MALE_7": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "an army buddy"
+  },
+  "RELATION_FRIEND_MALE_8": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "a colleague"
+  },
+  "RELATION_FRIEND_MALE_9": {
+  "description": "Male friend or acquaintance. Substitutes {friend}. Indefinite form (a/an + noun).",
+    "message": "an old crewmate"
+  },
+  "RELATION_RELATIVE_FEMALE_1": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my mother"
+  },
+  "RELATION_RELATIVE_FEMALE_10": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my stepmother"
+  },
+  "RELATION_RELATIVE_FEMALE_11": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my relative"
+  },
+  "RELATION_RELATIVE_FEMALE_12": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my niece"
+  },
+  "RELATION_RELATIVE_FEMALE_2": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my sister"
+  },
+  "RELATION_RELATIVE_FEMALE_3": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my daughter"
+  },
+  "RELATION_RELATIVE_FEMALE_4": {
+  "description": "Mothers sister. In some languages different from 'fathers sister'. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my aunt"
+  },
+  "RELATION_RELATIVE_FEMALE_5": {
+  "description": "Fathers sister. In some languages different from 'mothers sister'. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my aunt"
+  },
+  "RELATION_RELATIVE_FEMALE_6": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my cousin"
+  },
+  "RELATION_RELATIVE_FEMALE_7": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my sister-in-law"
+  },
+  "RELATION_RELATIVE_FEMALE_8": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my mother-in-law"
+  },
+  "RELATION_RELATIVE_FEMALE_9": {
+  "description": "Female family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my aunt', 'my cousin').",
+    "message": "my stepsister"
+  },
+  "RELATION_RELATIVE_MALE_1": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my father"
+  },
+  "RELATION_RELATIVE_MALE_10": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my stepfather"
+  },
+  "RELATION_RELATIVE_MALE_11": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my relative"
+  },
+  "RELATION_RELATIVE_MALE_12": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my nephew"
+  },
+  "RELATION_RELATIVE_MALE_2": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my brother"
+  },
+  "RELATION_RELATIVE_MALE_3": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my son"
+  },
+  "RELATION_RELATIVE_MALE_4": {
+  "description": "Mothers brother. In some languages different from 'fathers brother'. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my uncle"
+  },
+  "RELATION_RELATIVE_MALE_5": {
+  "description": "Fathers brother. In some languages different from 'mothers brother'. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my uncle"
+  },
+  "RELATION_RELATIVE_MALE_6": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my cousin"
+  },
+  "RELATION_RELATIVE_MALE_7": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my brother-in-law"
+  },
+  "RELATION_RELATIVE_MALE_8": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my father-in-law"
+  },
+  "RELATION_RELATIVE_MALE_9": {
+  "description": "Male family member / relative. Substitutes {relative}. Always starts with 'my' (e.g. 'my uncle', 'my cousin').",
+    "message": "my stepbrother"
+  }
+}

--- a/data/libs/Character.lua
+++ b/data/libs/Character.lua
@@ -332,8 +332,8 @@ Character = {
 		setmetatable(newCharacter,Character.meta)
 		-- initialize face characteristics if they weren't fully specified
 		if newCharacter.female == nil then newCharacter.female = (rand:Integer(1) ==1) end
-		if newCharacter.firstname == nil or newCharacter.surname == nil then
-			newCharacter.firstname, newCharacter.surname = NameGen.Names(newCharacter.female,rand)
+		if newCharacter.firstname == nil or newCharacter.surname == nil or newCharacter.culture == nil then
+			newCharacter.firstname, newCharacter.surname, newCharacter.culture = NameGen.Names(newCharacter.female,rand)
 		end
 		newCharacter.name = newCharacter.firstname .. " " .. newCharacter.surname
 		newCharacter.seed = newCharacter.seed or rand:Integer()

--- a/data/modules/FindPerson/FindPerson.lua
+++ b/data/modules/FindPerson/FindPerson.lua
@@ -4,6 +4,7 @@
 local Engine = require 'Engine'
 local Lang = require 'Lang'
 local Game = require 'Game'
+local Rand = require 'Rand'
 local Space = require 'Space'
 local Comms = require 'Comms'
 local Event = require 'Event'
@@ -13,6 +14,7 @@ local Passengers = require 'Passengers'
 local Format = require 'Format'
 local Serializer = require 'Serializer'
 local Character = require 'Character'
+local Culture = require 'culture/culture'
 local NameGen = require 'NameGen'
 local Ship = require 'Ship'
 local utils = require 'utils'
@@ -23,6 +25,7 @@ local ShipBuilder = require 'modules.MissionUtils.ShipBuilder'
 
 local l = Lang.GetResource 'module-findperson'
 local lc = Lang.GetResource 'core'
+local lp = Lang.GetResource 'persons'
 
 local PirateTemplate = MissionUtils.ShipTemplates.GenericPirate
 local MercenaryTemplate = MissionUtils.ShipTemplates.GenericMercenary
@@ -38,6 +41,17 @@ local flavours = {
 	{ id = "DELIVER_DOCUMENT", ship = true, taxi = false, company = true, max_risk = 1 },
 	{ id = "TAXI", ship = false, taxi = true, company = false, max_risk = 0.1 },
 	{ id = "EVACUATION", ship = false, taxi = true, company = true, max_risk = 1 },
+}
+
+-- Strings where 'wanted' is a relative (true). Needed for the possibility
+-- to sync cultures/culture names of client/wanted.
+local isfamily = {
+	{true, false, false, true, false,},					-- Deliver message
+	{false, false, false,},								-- Traitor
+	{false, false, false,},								-- Privateer
+	{false, false, false, false,},						-- Deliver document
+	{true, false, true,},								-- Taxi
+	{false, false, false, true,},						-- Evacuation
 }
 
 local ads = {}
@@ -56,6 +70,16 @@ local getNumberOfFlavours = function (str)
 	local num = 1
 
 	while l:get(str .. "_" .. num) do
+		num = num + 1
+	end
+	return num - 1
+end
+
+-- Returns the number of person roles of the given area (family/colleagues etc.).
+local getNumberOfRoles = function (str)
+	local num = 1
+
+	while lp:get(str .. "_" .. num) do
 		num = num + 1
 	end
 	return num - 1
@@ -88,10 +112,15 @@ local onChat = function (form, ref, option)
 
 	form:AddNavButton(ad.location)
 
+	local gender = ad.wanted.female and "_FEMALE" or "_MALE"
+
 	if option == 0 then
 		local introtext = string.interp(ad.introtext, {
 			client   = ad.client.name,
 			wanted   = ad.wanted.name,
+			employee = lp["RELATION_EMPLOYEE" .. gender .. "_" .. ad.employee],
+			friend   = lp["RELATION_FRIEND" .. gender .. "_" .. ad.friend],
+			relative = lp["RELATION_RELATIVE" .. gender .. "_" .. ad.relative],
 			company  = ad.company,
 			cash     = Format.Money(ad.reward, false),
 			system   = ad.location:GetStarSystem().name,
@@ -102,14 +131,13 @@ local onChat = function (form, ref, option)
 			domicile = ad.domicile:GetSystemBody().name,
 			dist     = string.format("%.2f", ad.dist),
 		})
-		form:SetMessage(introtext)
+		form:SetMessage(introtext:scase())
 
 	elseif option == 1 then
-		local gender = ad.wanted.female and "_FEMALE" or "_MALE"
 		form:SetMessage(l["HOW_TO_" .. ad.flavour.id .. gender])
 
 	elseif option == 2 then
-		form:SetMessage(string.interp(getRiskMsg(ad), { wanted = ad.wanted.name }))
+		form:SetMessage(string.interp(getRiskMsg(ad), { wanted = ad.wanted.surname }))
 
 	elseif option == 3 then
 		form:SetMessage(string.interp(l["HOW_MUCH_TIME_" .. ad.flavour.id], { date = Format.Date(ad.due) }))
@@ -126,6 +154,9 @@ local onChat = function (form, ref, option)
 			type        = "FindPerson",
 			client      = ad.client,
 			wanted      = ad.wanted,
+			employee    = ad.employee,
+			friend      = ad.friend,
+			relative    = ad.relative,
 			company     = ad.company,
 			location    = ad.location,
 			destination = ad.location:SystemOnly(),
@@ -191,23 +222,34 @@ local makeAdvert = function (station)
 	local location = nearbysystems[Engine.rand:Integer(1, #nearbysystems)]
 	local dist = location:DistanceTo(Game.system)
 
-	local flavour = flavours[Engine.rand:Integer(1, #flavours)]
+	local female = Engine.rand:Integer(1) == 1
+	local gender = female and "_FEMALE" or "_MALE"
+
+	local flavour_number = Engine.rand:Integer(1, #flavours)
+	local flavour = flavours[flavour_number]
+	local employee = Engine.rand:Integer(1, getNumberOfRoles("RELATION_EMPLOYEE" .. gender))
+	local friend = Engine.rand:Integer(1, getNumberOfRoles("RELATION_FRIEND" .. gender))
+	local relative = Engine.rand:Integer(1, getNumberOfRoles("RELATION_RELATIVE" .. gender))
 	local risk = Engine.rand:Number(0.01, flavour.max_risk)
 	local urgency = Engine.rand:Number(1)
 	local ns = location:GetStarSystem().numberOfStations
 	local reward = math.ceil(dist * (typical_reward + ns) * (1 + risk) * (1.5 + urgency) * Engine.rand:Number(0.8, 1.2))
 	local due = Game.time + ns * 86400 + MissionUtils.TravelTime(dist) * 1.75 * (1.5 - urgency) * Engine.rand:Number(0.9, 1.1)
 
-	local female = Engine.rand:Integer(1) == 1
-	local introtext = "INTROTEXT_" .. flavour.id .. (female and "_FEMALE" or "_MALE")
+	local introtext = "INTROTEXT_" .. flavour.id .. gender
+	local intro_number = Engine.rand:Integer(1, getNumberOfFlavours(introtext))
+	local isfamily = isfamily[flavour_number][intro_number]
 
 	local ad = {
 		station   = station,
 		domicile  = station.path,
-		introtext = l[introtext .. "_" .. Engine.rand:Integer(1, getNumberOfFlavours(introtext))],
+		introtext = l[introtext .. "_" .. intro_number],
 		flavour   = flavour,
 		client    = Character.New(),
 		wanted    = Character.New({ female = female }),
+		employee  = employee,
+		friend    = friend,
+		relative  = relative,
 		company   = flavour.company and string.interp(l["COMPANY_" .. Engine.rand:Integer(1, getNumberOfFlavours("COMPANY"))], { name = NameGen.Surname() }) or nil,
 		location  = location,
 		shipid    = flavour.ship and Ship.MakeRandomLabel() or nil,
@@ -218,6 +260,19 @@ local makeAdvert = function (station)
 		reward    = utils.round(reward, 100),
 	}
 
+	-- 'wanted' is likely to have the same surname as 'client' if they are related.
+	if isfamily and Engine.rand:Number() < 0.7 then
+		-- 'wanted' - surname is same culture as 'client'
+		ad.wanted.culture = ad.client.culture
+		ad.wanted.surname = ad.client.surname
+		ad.wanted.name = ad.wanted.firstname .. " " .. ad.client.surname
+		if Engine.rand:Number() < 0.7 then
+			-- 'wanted' - both first name and surname is same culture as 'client'
+			local rand = Rand.New(station.seed)
+			ad.wanted.firstname = Culture:FirstName(ad.wanted.female,rand,ad.client.culture)
+			ad.wanted.name = ad.wanted.firstname .. " " .. ad.client.surname
+		end
+	end
 	placeAdvert(station, ad)
 end
 
@@ -423,7 +478,8 @@ local onPlayerDocked = function (player, station)
 					if #mission.visited > Engine.rand:Number(4) then
 						local tipster = Character.New()
 						local tip = "TIP_" .. (mission.wanted.female and "FEMALE" or "MALE")
-						msg = string.interp(l[tip .. "_" .. Engine.rand:Integer(1, getNumberOfFlavours(tip))], { wanted = mission.wanted.name, station = mission.location:GetSystemBody().name })
+						local name = Engine.rand:Integer(0, 1) < 1 and mission.wanted.name or mission.wanted.firstname
+						msg = string.interp(l[tip .. "_" .. Engine.rand:Integer(1, getNumberOfFlavours(tip))], { wanted = name, station = mission.location:GetSystemBody().name })
 						Comms.ImportantMessage(msg, tipster.name)
 						mission.tipster = true
 					end
@@ -483,10 +539,14 @@ local buildMissionDescription = function (mission)
 	local dist = Game.system and string.format("%.2f", Game.system:DistanceTo(mission.location:SystemOnly())) or "???"
 	local domicileDist = Game.system and string.format("%.2f", Game.system:DistanceTo(mission.domicile)) or "???"
 	local danger = getRiskMsg(mission)
+	local gender = (mission.wanted.female and "_FEMALE" or "_MALE")
 
 	desc.description = mission.introtext:interp({
 		client = mission.client.name,
 		wanted = mission.wanted.name,
+		employee = lp["RELATION_EMPLOYEE" .. gender .. "_" .. mission.employee],
+		friend   = lp["RELATION_FRIEND" .. gender .. "_" .. mission.friend],
+		relative = lp["RELATION_RELATIVE" .. gender .. "_" .. mission.relative],
 		company = mission.company,
 		system = mission.location:GetStarSystem().name,
 		sectorx = mission.location.sectorX,
@@ -496,7 +556,7 @@ local buildMissionDescription = function (mission)
 		domicile = mission.domicile:GetSystemBody().name,
 		cash = ui.Format.Money(mission.reward, false),
 		dist = dist
-	})
+	}):scase()
 
 	desc.location = mission.location:SystemOnly()
 	desc.client = mission.client


### PR DESCRIPTION
Addresses #6249 (Find person)

 * Use different name forms in the risk messages for some variation. First name/Surname/Full name.
 * Adds character roles. i.e. Instead of 'a family member', use cousin, step brother, uncle, etc.
 * Adds more missions - 10 new scenarios (introtexts) for a total of 22.

---

The character roles are maybe a lot of lines but they are really easy to come up with and should be equally easy to translate.
- [ ] ~~The name variations, if wanted, should probably be a member function in 'Character'.~~ Too complex for now.
- [x] They should be a separate file in data/lang/ much like the ships.
- [x] The lists are currently inconsistent in that the **employees** and **friends** are in their indefinite form, but the **realtives** are in their base form. Maybe treat them fully like the ships with base, definitive, and indefinite forms?