### PR TITLE
fmt::arg("unit", counter.unit) causes crash, hard code counter.unit

### DIFF
--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -291,8 +291,8 @@ void PerfInfo::DrawCounter(CounterInfo &counter, const char *label, float min, f
 {
 	if (drawStats) {
 		std::string line1 = fmt::format("{}: {:.1f} {}", counter.name, counter.recent, counter.unit);
-		std::string line2 = fmt::format("Min: {:.1f} {unit} | Avg: {:.1f} {unit} | Max: {:.1f} {unit}",
-			counter.min, counter.average, counter.max, fmt::arg("unit", counter.unit));
+		std::string line2 = fmt::format("Min: {:.1f} {} | Avg: {:.1f} {} | Max: {:.1f} {}",
+			counter.min, counter.unit, counter.average, counter.unit, counter.max, counter.unit);
 
 		ImGui::TextUnformatted(line1.c_str());
 		ImGui::TextUnformatted(line2.c_str());


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
Unfortunately the upgrade to libfmt v12.1.0 seems to break the PerfInfo screen.
Specifically the use of fmt::arg("unit", counter.unit) causes it to crash now.
To see this happen just open the Debug Tools with `ctrl+i` and then click the second tab for performance info.

This is something of a rubbish fix, but haven't been able to work out a better one.

Suggestions for how to _really_ fix the problem are welcome.

