### PR TITLE
Vector3 ZERO

### DIFF
--- a/src/Beam.cpp
+++ b/src/Beam.cpp
@@ -314,7 +314,7 @@ void Beam::Render(Graphics::Renderer *renderer, const Camera *camera, const vect
 	const vector3f dir = vector3f(_dir).Normalized();
 
 	vector3f v1, v2;
-	matrix4x4f m = matrix4x4f::Identity();
+	matrix4x4f m = matrix4x4f::Identity;
 	v1.x = dir.y;
 	v1.y = dir.z;
 	v1.z = dir.x;

--- a/src/Body.cpp
+++ b/src/Body.cpp
@@ -25,9 +25,9 @@
 Body::Body() :
 	PropertiedObject(),
 	m_interpPos(0.0),
-	m_interpOrient(matrix3x3d::Identity()),
+	m_interpOrient(matrix3x3d::Identity),
 	m_pos(0.0),
-	m_orient(matrix3x3d::Identity()),
+	m_orient(matrix3x3d::Identity),
 	m_frame(FrameId::Invalid),
 	m_dead(false),
 	m_clipRadius(0.0),
@@ -39,7 +39,7 @@ Body::Body() :
 Body::Body(const Json &jsonObj, Space *space) :
 	PropertiedObject(),
 	m_interpPos(0.0),
-	m_interpOrient(matrix3x3d::Identity()),
+	m_interpOrient(matrix3x3d::Identity),
 	m_frame(FrameId::Invalid)
 {
 	try {
@@ -345,7 +345,7 @@ void Body::UpdateFrame()
 
 vector3d Body::GetTargetIndicatorPosition() const
 {
-	return vector3d(0, 0, 0);
+	return vector3d::Zero;
 }
 
 void Body::SetLabel(const std::string &label)

--- a/src/Body.h
+++ b/src/Body.h
@@ -210,7 +210,7 @@ public:
 
 	// TODO: abstract this functionality into a component of some fashion
 	// Return the position in body-local coordinates where the target indicator should be displayed.
-	// Usually equal to the center of the body == vector3d(0, 0, 0)
+	// Usually equal to the center of the body == vector3d::Zero
 	virtual vector3d GetTargetIndicatorPosition() const;
 
 	enum {

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -39,7 +39,7 @@ CameraContext::CameraContext(float width, float height, float fovAng, float zNea
 	m_projMatrix(matrix4x4f::InfinitePerspectiveMatrix(DEG2RAD(m_fovAng), m_width / m_height, m_zNear)),
 	m_frame(FrameId::Invalid),
 	m_pos(0.0),
-	m_orient(matrix3x3d::Identity()),
+	m_orient(matrix3x3d::Identity),
 	m_camFrame(FrameId::Invalid)
 {
 }
@@ -89,7 +89,7 @@ void CameraContext::ApplyDrawTransforms(Graphics::Renderer *r)
 {
 	Graphics::SetFov(m_fovAng);
 	r->SetProjection(GetProjectionMatrix());
-	r->SetTransform(matrix4x4f::Identity());
+	r->SetTransform(matrix4x4f::Identity);
 }
 
 bool Camera::BodyAttrs::sort_BodyAttrs(const BodyAttrs &a, const BodyAttrs &b)
@@ -348,7 +348,7 @@ void Camera::Draw(const Body *excludeBody)
 	RestoreLighting();
 
 	if (!billboards.IsEmpty()) {
-		Graphics::Renderer::MatrixTicket mt(m_renderer, matrix4x4f::Identity());
+		Graphics::Renderer::MatrixTicket mt(m_renderer, matrix4x4f::Identity);
 		m_renderer->DrawBuffer(&billboards, m_billboardMaterial.get());
 	}
 

--- a/src/DeathView.cpp
+++ b/src/DeathView.cpp
@@ -33,7 +33,7 @@ void DeathView::Init()
 	m_cameraDist = Pi::player->GetClipRadius() * 5.0;
 	m_cameraContext->SetCameraFrame(Pi::player->GetFrame());
 	m_cameraContext->SetCameraPosition(Pi::player->GetInterpPosition() + vector3d(0, 0, m_cameraDist));
-	m_cameraContext->SetCameraOrient(matrix3x3d::Identity());
+	m_cameraContext->SetCameraOrient(matrix3x3d::Identity);
 }
 
 void DeathView::OnSwitchTo()

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -19,8 +19,8 @@ Frame::Frame(const Dummy &d, FrameId parent, const char *label, unsigned int fla
 	m_sbody(nullptr),
 	m_astroBody(nullptr),
 	m_pos(vector3d(0.0)),
-	m_initialOrient(matrix3x3d::Identity()),
-	m_orient(matrix3x3d::Identity()),
+	m_initialOrient(matrix3x3d::Identity),
+	m_orient(matrix3x3d::Identity),
 	m_vel(vector3d(0.0)),
 	m_angSpeed(0.0),
 	m_radius(radius),
@@ -51,8 +51,8 @@ Frame::Frame(const Dummy &d, FrameId parent) :
 	m_sbody(nullptr),
 	m_astroBody(nullptr),
 	m_pos(vector3d(0.0)),
-	m_initialOrient(matrix3x3d::Identity()),
-	m_orient(matrix3x3d::Identity()),
+	m_initialOrient(matrix3x3d::Identity),
+	m_orient(matrix3x3d::Identity),
 	m_vel(vector3d(0.0)),
 	m_angSpeed(0.0),
 	m_label("camera"),
@@ -328,7 +328,7 @@ void Frame::AddStaticGeom(Geom *g) { m_collisionSpace->AddStaticGeom(g); }
 void Frame::RemoveStaticGeom(Geom *g) { m_collisionSpace->RemoveStaticGeom(g); }
 void Frame::SetPlanetGeom(double radius, Body *obj)
 {
-	m_collisionSpace->SetSphere(vector3d(0, 0, 0), radius, static_cast<void *>(obj));
+	m_collisionSpace->SetSphere(vector3d::Zero, radius, static_cast<void *>(obj));
 }
 
 CollisionSpace *Frame::GetCollisionSpace() const
@@ -339,7 +339,7 @@ CollisionSpace *Frame::GetCollisionSpace() const
 // doesn't consider stasis velocity
 vector3d Frame::GetVelocityRelTo(FrameId relToId) const
 {
-	if (m_thisId == relToId) return vector3d(0, 0, 0); // early-out to avoid unnecessary computation
+	if (m_thisId == relToId) return vector3d::Zero; // early-out to avoid unnecessary computation
 
 	const Frame *relTo = Frame::GetFrame(relToId);
 	vector3d diff = m_rootVel - relTo->m_rootVel;
@@ -352,7 +352,7 @@ vector3d Frame::GetVelocityRelTo(FrameId relToId) const
 vector3d Frame::GetPositionRelTo(FrameId relToId) const
 {
 	// early-outs for simple cases, required for accuracy in large systems
-	if (m_thisId == relToId) return vector3d(0, 0, 0);
+	if (m_thisId == relToId) return vector3d::Zero;
 
 	const Frame *relTo = Frame::GetFrame(relToId);
 
@@ -383,7 +383,7 @@ vector3d Frame::GetInterpPositionRelTo(FrameId relToId) const
 	const Frame *relTo = Frame::GetFrame(relToId);
 
 	// early-outs for simple cases, required for accuracy in large systems
-	if (m_thisId == relToId) return vector3d(0, 0, 0);
+	if (m_thisId == relToId) return vector3d::Zero;
 	if (GetParent() == relTo->GetId()) return m_interpPos; // relative to parent
 	if (relTo->GetParent() == m_thisId) {				   // relative to child
 		if (!relTo->IsRotFrame())
@@ -407,20 +407,20 @@ vector3d Frame::GetInterpPositionRelTo(FrameId relToId) const
 
 matrix3x3d Frame::GetOrientRelTo(FrameId relToId) const
 {
-	if (m_thisId == relToId) return matrix3x3d::Identity();
+	if (m_thisId == relToId) return matrix3x3d::Identity;
 	return Frame::GetFrame(relToId)->m_rootOrient.Transpose() * m_rootOrient;
 }
 
 matrix3x3d Frame::GetInterpOrientRelTo(FrameId relToId) const
 {
-	if (m_thisId == relToId) return matrix3x3d::Identity();
+	if (m_thisId == relToId) return matrix3x3d::Identity;
 	return Frame::GetFrame(relToId)->m_rootInterpOrient.Transpose() * m_rootInterpOrient;
 	/*	if (IsRotFrame()) {
 		if (relTo->IsRotFrame()) return m_interpOrient * relTo->m_interpOrient.Transpose();
 		else return m_interpOrient;
 	}
 	if (relTo->IsRotFrame()) return relTo->m_interpOrient.Transpose();
-	else return matrix3x3d::Identity();
+	else return matrix3x3d::Identity;
 */
 }
 
@@ -540,8 +540,8 @@ void Frame::UpdateRootRelativeVars()
 	// update pos & vel relative to parent frame
 	Frame *parent = Frame::GetFrame(m_parent);
 	if (!parent) {
-		m_rootPos = m_rootVel = vector3d(0, 0, 0);
-		m_rootOrient = matrix3x3d::Identity();
+		m_rootPos = m_rootVel = vector3d::Zero;
+		m_rootOrient = matrix3x3d::Identity;
 	} else {
 		m_rootPos = parent->m_rootOrient * m_pos + parent->m_rootPos;
 		m_rootVel = parent->m_rootOrient * m_vel + parent->m_rootVel;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -541,9 +541,9 @@ void Game::SwitchToHyperspace()
 
 	// put player at the origin. kind of unnecessary since it won't be moving
 	// but at least it gives some consistency
-	m_player->SetPosition(vector3d(0, 0, 0));
-	m_player->SetVelocity(vector3d(0, 0, 0));
-	m_player->SetOrient(matrix3x3d::Identity());
+	m_player->SetPosition(vector3d::Zero);
+	m_player->SetVelocity(vector3d::Zero);
+	m_player->SetOrient(matrix3x3d::Identity);
 
 	// animation and end time counters
 	m_hyperspaceProgress = 0;
@@ -605,7 +605,7 @@ void Game::SwitchToNormalSpace()
 
 			ship->SetFrame(m_space->GetRootFrame());
 			ship->SetVelocity(vector3d(0, 0, -100.0));
-			ship->SetOrient(matrix3x3d::Identity());
+			ship->SetOrient(matrix3x3d::Identity);
 			ship->SetFlightState(Ship::FLYING);
 
 			const SystemPath &sdest = ship->GetHyperspaceDest();
@@ -716,8 +716,8 @@ void Game::SetTimeAccel(TimeAccel t)
 	// don't want player to spin like mad when hitting time accel
 	if ((t != m_timeAccel) && (t > TIMEACCEL_1X) &&
 		m_player->GetPlayerController()->GetRotationDamping()) {
-		m_player->SetAngVelocity(vector3d(0, 0, 0));
-		m_player->SetTorque(vector3d(0, 0, 0));
+		m_player->SetAngVelocity(vector3d::Zero);
+		m_player->SetTorque(vector3d::Zero);
 		m_player->SetAngThrusterState(vector3d(0.0));
 	}
 

--- a/src/GasGiantJobs.cpp
+++ b/src/GasGiantJobs.cpp
@@ -260,7 +260,7 @@ namespace GasGiantJobs {
 
 		// enter ortho
 		Pi::renderer->SetOrthographicProjection(0, mData->UVDims(), mData->UVDims(), 0, -1, 1);
-		Pi::renderer->SetTransform(matrix4x4f::Identity());
+		Pi::renderer->SetTransform(matrix4x4f::Identity);
 
 		// render to offscreen rt
 		Pi::renderer->SetRenderTarget(GasGiant::GetRenderTarget());

--- a/src/HyperspaceCloud.cpp
+++ b/src/HyperspaceCloud.cpp
@@ -116,7 +116,7 @@ void HyperspaceCloud::TimeStepUpdate(const float timeStep)
 		// be moved into EvictShip()
 		m_ship->SetPosition(GetPosition());
 		m_ship->SetVelocity(m_vel);
-		m_ship->SetOrient(matrix3x3d::Identity());
+		m_ship->SetOrient(matrix3x3d::Identity);
 		m_ship->SetFrame(GetFrame());
 		Pi::game->GetSpace()->AddBody(m_ship);
 
@@ -156,7 +156,7 @@ static void make_circle_thing(VertexArray &va, float radius, const Color &colCen
 
 void HyperspaceCloud::UpdateInterpTransform(double alpha)
 {
-	m_interpOrient = matrix3x3d::Identity();
+	m_interpOrient = matrix3x3d::Identity;
 	const vector3d oldPos = GetPosition() - m_vel * Pi::game->GetTimeStep();
 	m_interpPos = alpha * GetPosition() + (1.0 - alpha) * oldPos;
 }
@@ -169,7 +169,7 @@ void HyperspaceCloud::Render(Renderer *renderer, const Camera *camera, const vec
 	if (!s_cloudMat)
 		InitGraphics(renderer);
 
-	matrix4x4d trans = matrix4x4d::Identity();
+	matrix4x4d trans = matrix4x4d::Identity;
 	trans.Translate(float(viewCoords.x), float(viewCoords.y), float(viewCoords.z));
 
 	// precise to the rendered frame (better than PHYSICS_HZ granularity)

--- a/src/Intro.cpp
+++ b/src/Intro.cpp
@@ -139,7 +139,7 @@ void Intro::Draw(float deltaTime)
 	Graphics::Renderer::StateTicket ticket(m_renderer);
 
 	m_renderer->SetPerspectiveProjection(75, m_aspectRatio, 1.f, 10000.f);
-	m_renderer->SetTransform(matrix4x4f::Identity());
+	m_renderer->SetTransform(matrix4x4f::Identity);
 
 	m_renderer->SetAmbientColor(m_ambientColor);
 

--- a/src/JsonUtils.cpp
+++ b/src/JsonUtils.cpp
@@ -194,7 +194,7 @@ void MatrixToJson(Json &jsonObj, const matrix3x3f &mat)
 {
 	PROFILE_SCOPED()
 #ifdef USE_STRING_VERSIONS
-	if (!memcmp(&matrix3x3fIdentity, &mat, sizeof(matrix3x3f))) return;
+	if (!memcmp(&matrix3x3f::Identity, &mat, sizeof(matrix3x3f))) return;
 	char str[512];
 	Matrix3x3fToStr(mat, str, 512);
 	jsonObj = str;
@@ -209,7 +209,7 @@ void MatrixToJson(Json &jsonObj, const matrix3x3d &mat)
 {
 	PROFILE_SCOPED()
 #ifdef USE_STRING_VERSIONS
-	if (!memcmp(&matrix3x3dIdentity, &mat, sizeof(matrix3x3d))) return;
+	if (!memcmp(&matrix3x3d::Identity, &mat, sizeof(matrix3x3d))) return;
 	char str[512];
 	Matrix3x3dToStr(mat, str, 512);
 	jsonObj = str;
@@ -224,7 +224,7 @@ void MatrixToJson(Json &jsonObj, const matrix4x4f &mat)
 {
 	PROFILE_SCOPED()
 #ifdef USE_STRING_VERSIONS
-	if (!memcmp(&matrix4x4fIdentity, &mat, sizeof(matrix4x4f))) return;
+	if (!memcmp(&matrix4x4f::Identity, &mat, sizeof(matrix4x4f))) return;
 	char str[512];
 	Matrix4x4fToStr(mat, str, 512);
 	jsonObj = str;
@@ -254,7 +254,7 @@ void MatrixToJson(Json &jsonObj, const matrix4x4d &mat)
 {
 	PROFILE_SCOPED()
 #ifdef USE_STRING_VERSIONS
-	if (!memcmp(&matrix4x4dIdentity, &mat, sizeof(matrix4x4d))) return;
+	if (!memcmp(&matrix4x4d::Identity, &mat, sizeof(matrix4x4d))) return;
 	char str[512];
 	Matrix4x4dToStr(mat, str, 512);
 	jsonObj = str;
@@ -400,7 +400,7 @@ void JsonToMatrix(matrix3x3f *pMat, const Json &jsonObj)
 	PROFILE_SCOPED()
 #ifdef USE_STRING_VERSIONS
 	if (!jsonObj.is_string()) {
-		*pMat = matrix3x3fIdentity;
+		*pMat = matrix3x3f::Identity;
 		return;
 	}
 	std::string matStr = jsonObj;
@@ -423,7 +423,7 @@ void JsonToMatrix(matrix3x3d *pMat, const Json &jsonObj)
 	PROFILE_SCOPED()
 #ifdef USE_STRING_VERSIONS
 	if (!jsonObj.is_string()) {
-		*pMat = matrix3x3dIdentity;
+		*pMat = matrix3x3d::Identity;
 		return;
 	}
 	std::string matStr = jsonObj;
@@ -446,7 +446,7 @@ void JsonToMatrix(matrix4x4f *pMat, const Json &jsonObj)
 	PROFILE_SCOPED()
 #ifdef USE_STRING_VERSIONS
 	if (!jsonObj.is_string()) {
-		*pMat = matrix4x4fIdentity;
+		*pMat = matrix4x4f::Identity;
 		return;
 	}
 	std::string matStr = jsonObj;
@@ -476,7 +476,7 @@ void JsonToMatrix(matrix4x4d *pMat, const Json &jsonObj)
 	PROFILE_SCOPED()
 #ifdef USE_STRING_VERSIONS
 	if (!jsonObj.is_string()) {
-		*pMat = matrix4x4dIdentity;
+		*pMat = matrix4x4d::Identity;
 		return;
 	}
 	std::string matStr = jsonObj;

--- a/src/MathUtil.cpp
+++ b/src/MathUtil.cpp
@@ -170,7 +170,7 @@ namespace MathUtil {
 		float det = cell[0] * inv[0] + cell[1] * inv[4] + cell[2] * inv[8] + cell[3] * inv[12];
 
 		if (is_equal_exact(det, 0.0f))
-			return matrix4x4f::Identity();
+			return matrix4x4f::Identity;
 
 		det = 1.0f / det;
 

--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -47,7 +47,7 @@ public:
 
 	virtual void ApplyMatrixTransform(SceneGraph::MatrixTransform &m)
 	{
-		matrix4x4f matrix = matrix4x4f::Identity();
+		matrix4x4f matrix = matrix4x4f::Identity;
 		if (!m_matrixStack.empty()) matrix = m_matrixStack.back();
 
 		m_matrixStack.push_back(matrix * m.GetTransform());
@@ -168,7 +168,7 @@ void ModelBody::RebuildCollisionMesh()
 	//dynamic geoms
 	for (auto it = m_collMesh->GetDynGeomTrees().begin(); it != m_collMesh->GetDynGeomTrees().end(); ++it) {
 		Geom *dynG = new Geom(*it, GetOrient(), GetPosition(), this);
-		dynG->m_animTransform = matrix4x4d::Identity();
+		dynG->m_animTransform = matrix4x4d::Identity;
 		SceneGraph::CollisionGeometry *cg = dgf.GetCgForTree(*it);
 		if (cg)
 			cg->SetGeom(dynG);

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -210,7 +210,7 @@ void NavLights::Update(float time)
 void NavLights::Render(Graphics::Renderer *renderer)
 {
 	if (!m_billboardTris.IsEmpty()) {
-		renderer->SetTransform(matrix4x4f::Identity());
+		renderer->SetTransform(matrix4x4f::Identity);
 		renderer->DrawBuffer(&m_billboardTris, matHalos4x4.Get());
 		renderer->GetStats().AddToStatCount(Graphics::Stats::STAT_BILLBOARD, m_billboardTris.GetNumVerts());
 

--- a/src/ObjectViewerView.cpp
+++ b/src/ObjectViewerView.cpp
@@ -32,7 +32,7 @@ ObjectViewerView::ObjectViewerView() :
 	m_systemBody(nullptr),
 	m_state{},
 	viewingDist(1000.0f),
-	m_camRot(matrix4x4d::Identity())
+	m_camRot(matrix4x4d::Identity)
 {
 	float znear;
 	float zfar;
@@ -44,7 +44,7 @@ ObjectViewerView::ObjectViewerView() :
 
 	m_cameraContext->SetCameraFrame(Pi::player->GetFrame());
 	m_cameraContext->SetCameraPosition(Pi::player->GetInterpPosition() + vector3d(0, 0, viewingDist));
-	m_cameraContext->SetCameraOrient(matrix3x3d::Identity());
+	m_cameraContext->SetCameraOrient(matrix3x3d::Identity);
 }
 
 void ObjectViewerView::Draw3D()
@@ -54,7 +54,7 @@ void ObjectViewerView::Draw3D()
 	float znear, zfar;
 	m_renderer->GetNearFarRange(znear, zfar);
 	m_renderer->SetPerspectiveProjection(75.f, m_renderer->GetDisplayAspect(), znear, zfar);
-	m_renderer->SetTransform(matrix4x4f::Identity());
+	m_renderer->SetTransform(matrix4x4f::Identity);
 
 	Graphics::Light light;
 	light.SetType(Graphics::Light::LIGHT_DIRECTIONAL);

--- a/src/Orbit.cpp
+++ b/src/Orbit.cpp
@@ -273,7 +273,7 @@ vector3d Orbit::Apogeum() const
 	if (m_eccentricity < 1) {
 		return m_semiMajorAxis * (1 + m_eccentricity) * (m_orient * vector3d(1, 0, 0));
 	} else {
-		return vector3d(0, 0, 0);
+		return vector3d::Zero;
 	}
 }
 

--- a/src/Orbit.h
+++ b/src/Orbit.h
@@ -25,7 +25,7 @@ public:
 		m_semiMajorAxis(0.0),
 		m_orbitalPhaseAtStart(0.0),
 		m_velocityAreaPerSecond(0.0),
-		m_orient(matrix3x3d::Identity())
+		m_orient(matrix3x3d::Identity)
 	{}
 
 	void SetShapeAroundBarycentre(double semiMajorAxis, double totalMass, double bodyMass, double eccentricity);

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -1027,7 +1027,7 @@ void GameLoop::Update(float deltaTime)
 		}
 	}
 
-	Pi::renderer->SetTransform(matrix4x4f::Identity());
+	Pi::renderer->SetTransform(matrix4x4f::Identity);
 
 	/* Calculate position for this rendered frame (interpolated between two physics ticks */
 	// XXX should this be here? what is this anyway?

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -323,7 +323,7 @@ void Player::StaticUpdate(const float timeStep)
 
 int Player::GetManeuverTime() const
 {
-	if (Pi::planner->GetOffsetVel().ExactlyEqual(vector3d(0, 0, 0))) {
+	if (Pi::planner->GetOffsetVel().ExactlyEqual(vector3d::Zero)) {
 		return 0;
 	}
 	return Pi::planner->GetStartTime();
@@ -336,8 +336,8 @@ vector3d Player::GetManeuverVelocity() const
 		frame = Frame::GetFrame(frame->GetNonRotFrame());
 	const SystemBody *systemBody = frame->GetSystemBody();
 
-	if (Pi::planner->GetOffsetVel().ExactlyEqual(vector3d(0, 0, 0))) {
-		return vector3d(0, 0, 0);
+	if (Pi::planner->GetOffsetVel().ExactlyEqual(vector3d::Zero)) {
+		return vector3d::Zero;
 	} else if (systemBody) {
 		Orbit playerOrbit = ComputeOrbit();
 		if (!is_zero_exact(playerOrbit.GetSemiMajorAxis())) {
@@ -347,7 +347,7 @@ vector3d Player::GetManeuverVelocity() const
 			return velocity;
 		}
 	}
-	return vector3d(0, 0, 0);
+	return vector3d::Zero;
 }
 
 void Player::DoFixspeedTakeoff(SpaceStation *from)

--- a/src/Projectile.cpp
+++ b/src/Projectile.cpp
@@ -313,7 +313,7 @@ void Projectile::Render(Graphics::Renderer *renderer, const Camera *camera, cons
 	vector3f dir = vector3f(_dir).Normalized();
 
 	vector3f v1, v2;
-	matrix4x4f m = matrix4x4f::Identity();
+	matrix4x4f m = matrix4x4f::Identity;
 	v1.x = dir.y;
 	v1.y = dir.z;
 	v1.z = dir.x;

--- a/src/SectorMap.cpp
+++ b/src/SectorMap.cpp
@@ -577,7 +577,7 @@ void SectorMap::SaveToJson(Json &jsonObj)
 }
 
 matrix4x4f SectorMap::PointOfView() {
-	matrix4x4f result = matrix4x4f::Identity();
+	matrix4x4f result = matrix4x4f::Identity;
 	// units are lightyears, my friend
 	result.Translate(0.f, 0.f, -10.f - 10.f * m_zoom); // not zoomClamped, let us zoom out a bit beyond what we're drawing
 	result.Rotate(DEG2RAD(m_rotX), 1.f, 0.f, 0.f);
@@ -629,7 +629,7 @@ void SectorMap::Draw3D()
 		m_customlines.Draw(renderer, m_lineMat.Get());
 	}
 
-	renderer->SetTransform(matrix4x4f::Identity());
+	renderer->SetTransform(matrix4x4f::Identity);
 
 	//draw star billboards in one go
 	renderer->SetAmbientColor(Color(30, 30, 30));
@@ -1115,7 +1115,7 @@ void SectorMap::Update(float frameTime)
 
 	auto input = m_context.input;
 
-	matrix4x4f rot = matrix4x4f::Identity();
+	matrix4x4f rot = matrix4x4f::Identity;
 	rot.RotateX(DEG2RAD(-m_rotX));
 	rot.RotateZ(DEG2RAD(-m_rotZ));
 

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -213,7 +213,7 @@ void SfxManager::AddThrustSmoke(const Body *b, const float speed, const vector3d
 	SfxManager *sfxman = AllocSfxInFrame(b->GetFrame());
 	if (!sfxman) return;
 
-	Sfx sfx(b->GetPosition() + adjustpos, vector3d(0, 0, 0), speed, TYPE_SMOKE);
+	Sfx sfx(b->GetPosition() + adjustpos, vector3d::Zero, speed, TYPE_SMOKE);
 	sfxman->AddInstance(sfx);
 }
 
@@ -300,7 +300,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 				pointArray.Add(pos, vector3f(offset, Clamp(speed, 0.1f, FLT_MAX)));
 			}
 
-			renderer->SetTransform(matrix4x4f::Identity());
+			renderer->SetTransform(matrix4x4f::Identity);
 			renderer->DrawBuffer(&pointArray, material);
 		}
 	}

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -858,8 +858,8 @@ void Ship::Blastoff()
 		p->DoFixspeedTakeoff();
 	} else {
 		const double planetRadius = 2.0 + static_cast<Planet *>(f->GetBody())->GetTerrainHeight(up);
-		SetVelocity(vector3d(0, 0, 0));
-		SetAngVelocity(vector3d(0, 0, 0));
+		SetVelocity(vector3d::Zero);
+		SetAngVelocity(vector3d::Zero);
 		SetFlightState(FLYING);
 
 		SetPosition(up * planetRadius - GetAabb().min.y * up);
@@ -893,8 +893,8 @@ void Ship::TestLanded()
 				vector3d right = up.Cross(GetOrient().VectorZ()).Normalized();
 				SetOrient(matrix3x3d::FromVectors(right, up));
 
-				SetVelocity(vector3d(0, 0, 0));
-				SetAngVelocity(vector3d(0, 0, 0));
+				SetVelocity(vector3d::Zero);
+				SetAngVelocity(vector3d::Zero);
 				ClearThrusterState();
 				SetFlightState(LANDED);
 				Sound::BodyMakeNoise(this, "Rough_Landing", 1.0f);
@@ -918,8 +918,8 @@ void Ship::SetLandedOn(Planet *p, float latitude, float longitude)
 	SetPosition(up * (planetRadius - GetAabb().min.y));
 	vector3d right = up.Cross(vector3d(0, 0, 1)).Normalized();
 	SetOrient(matrix3x3d::FromVectors(right, up));
-	SetVelocity(vector3d(0, 0, 0));
-	SetAngVelocity(vector3d(0, 0, 0));
+	SetVelocity(vector3d::Zero);
+	SetAngVelocity(vector3d::Zero);
 	ClearThrusterState();
 	SetFlightState(LANDED);
 	OnLanded(p);

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -1490,7 +1490,7 @@ AICmdHoldPosition::AICmdHoldPosition(const Json &jsonObj) :
 bool AICmdHoldPosition::TimeStepUpdate()
 {
 	// XXX perhaps try harder to move back to the original position
-	m_prop->AIMatchVel(vector3d(0, 0, 0));
+	m_prop->AIMatchVel(vector3d::Zero);
 	return false;
 }
 

--- a/src/ShipCockpit.cpp
+++ b/src/ShipCockpit.cpp
@@ -23,7 +23,7 @@ ShipCockpit::ShipCockpit(const std::string &modelName, Body *ship) :
 	m_offset(0.f),
 	m_shipVel(0.f),
 	m_translate(0.0),
-	m_transform(matrix4x4d::Identity())
+	m_transform(matrix4x4d::Identity)
 {
 	assert(!modelName.empty());
 	SetModel(modelName.c_str());
@@ -63,7 +63,7 @@ void ShipCockpit::Update(const Player *player, float timeStep)
 		resetInternalCameraController();
 	}
 
-	m_transform = matrix4x4d::Identity();
+	m_transform = matrix4x4d::Identity;
 	double rotX;
 	double rotY;
 	m_icc->getRots(rotX, rotY);

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -885,7 +885,7 @@ void Space::GenBody(const double at_time, SystemBody *sbody, FrameId fId, std::v
 			posAccum.clear();
 		}
 		b->SetLabel(sbody->GetName().c_str());
-		b->SetPosition(vector3d(0, 0, 0));
+		b->SetPosition(vector3d::Zero);
 		AddBody(b);
 	}
 	fId = MakeFramesFor(at_time, sbody, b, fId, posAccum);

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -82,7 +82,7 @@ void Star::Render(Graphics::Renderer *renderer, const Camera *camera, const vect
 		len *= 0.25;
 	}
 
-	matrix4x4d trans = matrix4x4d::Identity();
+	matrix4x4d trans = matrix4x4d::Identity;
 	trans.Translate(float(fpos.x), float(fpos.y), float(fpos.z));
 
 	// face the camera dammit

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -283,7 +283,7 @@ void SystemView::Update()
 			m_map->AddOrbitTrack({ Projectable::ORBIT, Projectable::PLAYER, PlayerBody, offset }, &playerOrbit, m_map->svColor[Col::PLAYER_ORBIT], planetRadius);
 
 			const double plannerStartTime = m_planner->GetStartTime();
-			if (!m_planner->GetPosition().ExactlyEqual(vector3d(0, 0, 0))) {
+			if (!m_planner->GetPosition().ExactlyEqual(vector3d::Zero)) {
 				Orbit plannedOrbit = Orbit::FromBodyState(m_planner->GetPosition(),
 					m_planner->GetVel(),
 					playerAround->GetMass());
@@ -632,7 +632,7 @@ void SystemMapViewport::DrawOrreryView()
 	m_renderer->SetPerspectiveProjection(CAMERA_FOV, float(m_viewportSize.w) / m_viewportSize.h, 1.f, 1500.f);
 
 	// Background is rotated around (0,0,0) and drawn
-	matrix4x4d trans2bg = matrix4x4d::Identity();
+	matrix4x4d trans2bg = matrix4x4d::Identity;
 	trans2bg.RotateX(DEG2RAD(-m_rot_x));
 	trans2bg.RotateY(DEG2RAD(-m_rot_y));
 
@@ -667,7 +667,7 @@ void SystemMapViewport::DrawOrreryView()
 	// the coordinates of the objects are scaled, but the shift is not.
 	// The surface distance translation ensures the view does not go inside of a planet.
 	// This matrix operation is read in reverse order (bottom-to-top).
-	m_cameraSpace = matrix4x4f::Identity();
+	m_cameraSpace = matrix4x4f::Identity;
 	m_cameraSpace.Translate(0, 0, -DEFAULT_VIEW_DISTANCE);
 	m_cameraSpace.Translate(0, 0, -surfaceDistance * m_zoom); // apply scale from m_zoom
 	m_cameraSpace.Rotate(DEG2RAD(m_rot_x), 1, 0, 0);
@@ -811,7 +811,7 @@ void SystemMapViewport::RenderAtlasBody(const AtlasBodyLayout &layout, vector3f 
 	pos += vector3f(layout.offset.x, -layout.offset.y, 0.f);
 
 	if (layout.body->GetType() != SystemBody::TYPE_GRAVPOINT) {
-		matrix4x4f bodyTrans = matrix4x4f::Identity();
+		matrix4x4f bodyTrans = matrix4x4f::Identity;
 		bodyTrans.Translate(pos);
 		bodyTrans.Scale(layout.radius);
 		m_renderer->SetTransform(cameraTrans * bodyTrans);
@@ -825,7 +825,7 @@ void SystemMapViewport::RenderAtlasBody(const AtlasBodyLayout &layout, vector3f 
 		AddProjected({ Projectable::OBJECT, Projectable::SYSTEMBODY, layout.body }, Projectable::OBJECT, vector3d(), layout.radius * pixPerUnit);
 	}
 	/* else { // gravpoint debugging
-		matrix4x4f bodyTrans = matrix4x4f::Identity();
+		matrix4x4f bodyTrans = matrix4x4f::Identity;
 		bodyTrans.Translate(pos - vector3f(layout.offset.x, -layout.offset.y, 0.f));
 		m_renderer->SetTransform(cameraTrans * bodyTrans);
 
@@ -843,7 +843,7 @@ void SystemMapViewport::DrawAtlasView()
 	m_renderer->SetPerspectiveProjection(CAMERA_FOV, float(m_viewportSize.w) / m_viewportSize.h, 1.f, 1500.f);
 
 	// Background is rotated around (0,0,0), adjusted for parallax effect, and drawn
-	matrix4x4d trans2bg = matrix4x4d::Identity();
+	matrix4x4d trans2bg = matrix4x4d::Identity;
 
 	// parallax effect
 	trans2bg.Translate(m_atlasPos.x, -m_atlasPos.y, 0.0);
@@ -862,10 +862,10 @@ void SystemMapViewport::DrawAtlasView()
 	// Pick an orthographic projection scale that has the same apparent size as a perspective projection at 30m.
 	m_renderer->SetProjection(matrix4x4f::OrthoMatrix(m_atlasViewW * m_atlasZoom, m_atlasViewH * m_atlasZoom, 1.0, 1000.0));
 
-	matrix4x4f cameraTrans = matrix4x4f::Identity();
+	matrix4x4f cameraTrans = matrix4x4f::Identity;
 	cameraTrans.Translate(vector3f(m_atlasPos.x, -m_atlasPos.y, -10.0));
 
-	matrix4x4f gridTransform = matrix4x4f::Identity();
+	matrix4x4f gridTransform = matrix4x4f::Identity;
 	gridTransform.Translate(vector3f(0, 0, -1.0f));
 	gridTransform.RotateX(M_PI / 2.0);
 	gridTransform.Scale(4.0 / float(AU)); // one grid square = one earth diameter = two units
@@ -987,7 +987,7 @@ void SystemMapViewport::Update(float ft)
 	if (m_displayMode == SystemView::Mode::Orrery) {
 		if (m_system && !m_system->GetUnexplored() && m_system->GetRootBody()) {
 			// all systembodies draws here
-			AddBodyTrack(m_system->GetRootBody().Get(), vector3d(0, 0, 0));
+			AddBodyTrack(m_system->GetRootBody().Get(), vector3d::Zero);
 		}
 	}
 }

--- a/src/Tombstone.cpp
+++ b/src/Tombstone.cpp
@@ -24,7 +24,7 @@ void Tombstone::Draw(float _time)
 	m_renderer->ClearScreen(Color::BLACK);
 
 	m_renderer->SetPerspectiveProjection(75, m_aspectRatio, 1.f, 10000.f);
-	m_renderer->SetTransform(matrix4x4f::Identity());
+	m_renderer->SetTransform(matrix4x4f::Identity);
 
 	m_renderer->SetAmbientColor(m_ambientColor);
 	m_renderer->SetLights(m_lights.size(), &m_lights[0]);

--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -185,7 +185,7 @@ void WorldView::Draw3D()
 	// setup orthographic projection the indicator coordinate system expects
 	// (could also draw this using ImGui methods in DrawPiGui, but this is a quick patch for release)
 	m_renderer->SetProjection(matrix4x4f::OrthoFrustum(0, m_renderer->GetWindowWidth(), m_renderer->GetWindowHeight(), 0, 0, 1));
-	m_renderer->SetTransform(matrix4x4f::Identity());
+	m_renderer->SetTransform(matrix4x4f::Identity);
 
 	// combat target indicator
 	DrawCombatTargetIndicator(m_combatTargetIndicator, m_targetLeadIndicator, red);
@@ -575,7 +575,7 @@ static vector3d projectToScreenSpace(const vector3d &pos, RefCountedPtr<CameraCo
 vector3d WorldView::WorldSpaceToScreenSpace(const Body *body) const
 {
 	if (body->IsType(ObjectType::PLAYER) && !shipView->IsExteriorView())
-		return vector3d(0, 0, 0);
+		return vector3d::Zero;
 
 	vector3d pos = body->GetInterpPositionRelTo(m_cameraContext->GetCameraFrame());
 	return WorldSpaceToScreenSpace(pos);
@@ -604,7 +604,7 @@ vector3d WorldView::CameraSpaceToScreenSpace(const vector3d &pos) const
 vector3d WorldView::GetTargetIndicatorScreenPosition(const Body *body) const
 {
 	if (body->IsType(ObjectType::PLAYER) && !shipView->IsExteriorView())
-		return vector3d(0, 0, 0);
+		return vector3d::Zero;
 
 	// get the target indicator position in body-local coordinates
 	vector3d pos = body->GetInterpPositionRelTo(m_cameraContext->GetCameraFrame());

--- a/src/editor/ModelViewer.cpp
+++ b/src/editor/ModelViewer.cpp
@@ -538,7 +538,7 @@ void ModelViewer::DrawTagNames()
 		return;
 
 	auto size = ImGui::GetWindowSize();
-	m_renderer->SetTransform(matrix4x4f::Identity());
+	m_renderer->SetTransform(matrix4x4f::Identity);
 
 	vector3f point = m_modelWindow->GetModelViewMat() * m_selectedTag->GetGlobalTransform().GetTranslate();
 	point = Graphics::ProjectToScreen(m_renderer, point);
@@ -578,7 +578,7 @@ void ModelViewer::BuildGeomTreeVisualizer(Graphics::VertexArray &va, SingleBVHTr
 			stack[stackLevel++] = node->kids[0];
 		}
 
-		Graphics::Drawables::AABB::DrawVertices(va, matrix4x4fIdentity, Aabb(node->aabb.min, node->aabb.max, 0.1), get_color(colIndexBase));
+		Graphics::Drawables::AABB::DrawVertices(va, matrix4x4f::Identity, Aabb(node->aabb.min, node->aabb.max, 0.1), get_color(colIndexBase));
 	}
 }
 

--- a/src/editor/ModelViewerWidget.cpp
+++ b/src/editor/ModelViewerWidget.cpp
@@ -503,7 +503,7 @@ void ModelViewerWidget::OnRender(Graphics::Renderer *r)
 void ModelViewerWidget::DrawBackground()
 {
 	m_renderer->SetOrthographicProjection(0.f, 1.f, 0.f, 1.f, 0.f, 1.f);
-	m_renderer->SetTransform(matrix4x4f::Identity());
+	m_renderer->SetTransform(matrix4x4f::Identity);
 
 	if (!m_bgMesh) {
 		const Color top = Color::BLACK;
@@ -528,7 +528,7 @@ void ModelViewerWidget::UpdateCamera()
 {
 	Graphics::ViewportExtents extents = GetViewportExtents();
 
-	m_renderer->SetTransform(matrix4x4f::Identity());
+	m_renderer->SetTransform(matrix4x4f::Identity);
 
 	// setup rendering
 	if (!m_options.orthoView) {
@@ -551,7 +551,7 @@ void ModelViewerWidget::UpdateCamera()
 		m_modelViewMat = m_viewRot.Transpose() * matrix4x4f::Translation(-m_viewPos);
 	} else {
 		m_rot.x = Clamp(m_rot.x, -90.0f, 90.0f);
-		matrix4x4f rot = matrix4x4f::Identity();
+		matrix4x4f rot = matrix4x4f::Identity;
 		rot.RotateX(DEG2RAD(-m_rot.x));
 		rot.RotateY(DEG2RAD(-m_rot.y));
 		if (m_options.orthoView)

--- a/src/graphics/Drawables.cpp
+++ b/src/graphics/Drawables.cpp
@@ -525,7 +525,7 @@ namespace Graphics {
 		{
 			subdivs = Clamp(subdivs, 0, 10);
 			scale = fabs(scale);
-			matrix4x4f trans = matrix4x4f::Identity();
+			matrix4x4f trans = matrix4x4f::Identity;
 			trans.Scale(scale, scale, scale);
 
 			// Reserve space for vertices and indices

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -25,7 +25,7 @@ namespace Graphics {
 
 		RendererDummy() :
 			Renderer(0, 0, 0),
-			m_identity(matrix4x4f::Identity())
+			m_identity(matrix4x4f::Identity)
 		{}
 
 		const char *GetName() const final { return "Dummy"; }
@@ -54,11 +54,11 @@ namespace Graphics {
 		ViewportExtents GetViewport() const final { return {}; }
 
 		bool SetTransform(const matrix4x4f &m) final { return true; }
-		matrix4x4f GetTransform() const final { return matrix4x4f::Identity(); }
+		matrix4x4f GetTransform() const final { return matrix4x4f::Identity; }
 		bool SetPerspectiveProjection(float fov, float aspect, float near_, float far_) final { return true; }
 		bool SetOrthographicProjection(float xmin, float xmax, float ymin, float ymax, float zmin, float zmax) final { return true; }
 		bool SetProjection(const matrix4x4f &m) final { return true; }
-		matrix4x4f GetProjection() const final { return matrix4x4f::Identity(); }
+		matrix4x4f GetProjection() const final { return matrix4x4f::Identity; }
 
 		bool SetWireFrameMode(bool enabled) final { return true; }
 

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -167,7 +167,7 @@ int PiGui::pushOnScreenPositionDirection(lua_State *l, vector3d position)
 	const int width = Pi::renderer->GetWindowWidth();
 	const int height = Pi::renderer->GetWindowHeight();
 	vector3d direction = (position - vector3d(width / 2.0, height / 2.0, 0)).Normalized();
-	if (vector3d(0, 0, 0) == position || position.x < 0 || position.y < 0 || position.x > width || position.y > height || position.z > 0) {
+	if (vector3d::Zero == position || position.x < 0 || position.y < 0 || position.x > width || position.y > height || position.z > 0) {
 		LuaPush<bool>(l, false);
 		LuaPush<vector2d>(l, vector2d(position.x, position.y));
 		LuaPush<vector3d>(l, direction * (position.z > 0 ? -1 : 1)); // reverse direction if behind camera
@@ -2332,7 +2332,7 @@ PiGui::TScreenSpace lua_world_space_to_screen_space(const Body *body)
 	const int width = Pi::renderer->GetWindowWidth();
 	const int height = Pi::renderer->GetWindowHeight();
 	const vector3d direction = (p - vector3d(width / 2.0, height / 2.0, 0)).Normalized();
-	if (vector3d(0, 0, 0) == p || p.x < 0 || p.y < 0 || p.x > width || p.y > height || p.z > 0) {
+	if (vector3d::Zero == p || p.x < 0 || p.y < 0 || p.x > width || p.y > height || p.z > 0) {
 		return PiGui::TScreenSpace(false, vector2d(0, 0), direction * (p.z > 0 ? -1 : 1));
 	} else {
 		return PiGui::TScreenSpace(true, vector2d(p.x, p.y), direction);

--- a/src/lua/LuaSpace.cpp
+++ b/src/lua/LuaSpace.cpp
@@ -193,7 +193,7 @@ static int l_space_spawn_ship(lua_State *l)
 		// XXX broken. this is ignoring min_dist & max_dist. otoh, what's the
 		// correct behaviour given there's now a fixed hyperspace exit point?
 		thing->SetPosition(Pi::game->GetSpace()->GetHyperspaceExitPoint(*source, *dest));
-	thing->SetVelocity(vector3d(0, 0, 0));
+	thing->SetVelocity(vector3d::Zero);
 	Pi::game->GetSpace()->AddBody(thing);
 
 	LuaObject<Ship>::PushToLua(ship);

--- a/src/matrix3x3.h
+++ b/src/matrix3x3.h
@@ -43,13 +43,6 @@ public:
 	vector3<T> VectorY() const { return vector3<T>(cell[1], cell[4], cell[7]); }
 	vector3<T> VectorZ() const { return vector3<T>(cell[2], cell[5], cell[8]); }
 
-	static matrix3x3 Identity()
-	{
-		matrix3x3 m;
-		m.cell[1] = m.cell[2] = m.cell[3] = m.cell[5] = m.cell[6] = m.cell[7] = 0.0f;
-		m.cell[0] = m.cell[4] = m.cell[8] = 1.0f;
-		return m;
-	}
 	static matrix3x3 Scale(T x, T y, T z)
 	{
 		matrix3x3 m;
@@ -231,12 +224,20 @@ public:
 	{
 		*this = Normalized();
 	}
+
+	static matrix3x3 IdentityFunc()
+	{
+		constexpr T IDENTITY3x3[] = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+		return matrix3x3(IDENTITY3x3);
+	}
+
+	static const matrix3x3 Identity;
 };
+
+template <typename T>
+const matrix3x3<T> matrix3x3<T>::Identity(IdentityFunc());
 
 typedef matrix3x3<float> matrix3x3f;
 typedef matrix3x3<double> matrix3x3d;
-
-static const matrix3x3f matrix3x3fIdentity(matrix3x3f::Identity());
-static const matrix3x3d matrix3x3dIdentity(matrix3x3d::Identity());
 
 #endif /* _MATRIX3x3_H */

--- a/src/matrix4x4.h
+++ b/src/matrix4x4.h
@@ -137,12 +137,6 @@ public:
 		c[3] = a[12]; c[7] = a[13]; c[11] = a[14]; c[15] = a[15];
 		return m;
 	}
-	static matrix4x4 Identity()
-	{
-		matrix4x4 m = matrix4x4(0.0);
-		m.cell[0] = m.cell[5] = m.cell[10] = m.cell[15] = 1.0f;
-		return m;
-	}
 	//glscale equivalent
 	void Scale(T x, T y, T z)
 	{
@@ -640,7 +634,7 @@ public:
 	}
 	void Translate(T x, T y, T z)
 	{
-		matrix4x4 m = Identity();
+		matrix4x4 m = Identity;
 		m[12] = x;
 		m[13] = y;
 		m[14] = z;
@@ -652,7 +646,7 @@ public:
 	}
 	static matrix4x4 Translation(T x, T y, T z)
 	{
-		matrix4x4 m = Identity();
+		matrix4x4 m = Identity;
 		m[12] = x;
 		m[13] = y;
 		m[14] = z;
@@ -717,12 +711,20 @@ public:
 	{
 		return vector3<T>(cell[8], cell[9], cell[10]);
 	}
+
+	static matrix4x4 IdentityFunc()
+	{
+		constexpr T IDENTITY4x4[] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
+		return matrix4x4(IDENTITY4x4);
+	}
+
+	static const matrix4x4 Identity;
 };
+
+template <typename T>
+const matrix4x4<T> matrix4x4<T>::Identity(IdentityFunc());
 
 typedef matrix4x4<float> matrix4x4f;
 typedef matrix4x4<double> matrix4x4d;
-
-static const matrix4x4f matrix4x4fIdentity(matrix4x4f::Identity());
-static const matrix4x4d matrix4x4dIdentity(matrix4x4d::Identity());
 
 #endif /* _MATRIX4X4_H */

--- a/src/pigui/ModelSpinner.cpp
+++ b/src/pigui/ModelSpinner.cpp
@@ -92,7 +92,7 @@ void ModelSpinner::Render()
 	r->ClearScreen(Color(0, 0, 0, 0));
 
 	r->SetProjection(matrix4x4f::PerspectiveMatrix(DEG2RAD(SPINNER_FOV), m_size.x / m_size.y, 1.f, 10000.f, true));
-	r->SetTransform(matrix4x4f::Identity());
+	r->SetTransform(matrix4x4f::Identity);
 
 	r->SetLights(1, &m_light);
 	AnimationCurves::Approach(m_zoom, m_zoomTo, Pi::GetFrameTime(), 5.0f, 0.4f);
@@ -114,7 +114,7 @@ matrix4x4f ModelSpinner::MakeModelViewMat()
 {
 	const float dist = m_model->GetDrawClipRadius() / sinf(DEG2RAD(SPINNER_FOV * 0.5f));
 
-	matrix4x4f rot = matrix4x4f::Identity();
+	matrix4x4f rot = matrix4x4f::Identity;
 	rot.Translate(vector3f(0, 0, -dist * m_zoom));
 	rot.RotateX(m_rot.x);
 	rot.RotateY(m_rot.y);

--- a/src/pigui/PiGuiRenderer.cpp
+++ b/src/pigui/PiGuiRenderer.cpp
@@ -72,7 +72,7 @@ void InstanceRenderer::RenderDrawData(ImDrawData *draw_data)
 	float T = draw_data->DisplayPos.y;
 	float B = draw_data->DisplayPos.y + draw_data->DisplaySize.y;
 
-	m_renderer->SetTransform(matrix4x4f::Identity());
+	m_renderer->SetTransform(matrix4x4f::Identity);
 	m_renderer->SetProjection(matrix4x4f::OrthoFrustum(L, R, B, T, -1.0, 0.0));
 
 	RenderDrawData(draw_data, m_material.get());

--- a/src/scenegraph/CollisionVisitor.cpp
+++ b/src/scenegraph/CollisionVisitor.cpp
@@ -39,7 +39,7 @@ namespace SceneGraph {
 	void CollisionVisitor::ApplyMatrixTransform(MatrixTransform &m)
 	{
 		PROFILE_SCOPED()
-		matrix4x4f matrix = matrix4x4f::Identity();
+		matrix4x4f matrix = matrix4x4f::Identity;
 		if (!m_matrixStack.empty()) matrix = m_matrixStack.back();
 
 		m_matrixStack.push_back(matrix * m.GetTransform());
@@ -54,7 +54,7 @@ namespace SceneGraph {
 
 		if (cg.IsDynamic()) return ApplyDynamicCollisionGeometry(cg);
 
-		const matrix4x4f matrix = m_matrixStack.empty() ? matrix4x4f::Identity() : m_matrixStack.back();
+		const matrix4x4f matrix = m_matrixStack.empty() ? matrix4x4f::Identity : m_matrixStack.back();
 
 		//copy data (with index offset)
 		int idxOffset = m_vertices.size();

--- a/src/scenegraph/Group.cpp
+++ b/src/scenegraph/Group.cpp
@@ -104,7 +104,7 @@ namespace SceneGraph {
 
 	matrix4x4f Group::CalcGlobalTransform() const
 	{
-		return GetParent() ? GetParent()->CalcGlobalTransform() : matrix4x4fIdentity;
+		return GetParent() ? GetParent()->CalcGlobalTransform() : matrix4x4f::Identity;
 	}
 
 	void Group::Accept(NodeVisitor &nv)

--- a/src/scenegraph/Loader.cpp
+++ b/src/scenegraph/Loader.cpp
@@ -394,7 +394,7 @@ namespace SceneGraph {
 		// special features that are absolute-positioned (thrusters)
 		RefCountedPtr<Node> meshRoot(new Group(m_renderer));
 
-		ConvertNodes(scene, scene->mRootNode, static_cast<Group *>(meshRoot.Get()), matrix4x4f::Identity());
+		ConvertNodes(scene, scene->mRootNode, static_cast<Group *>(meshRoot.Get()), matrix4x4f::Identity);
 		ConvertAnimations(scene, animDefs, static_cast<Group *>(meshRoot.Get()));
 
 		return meshRoot;

--- a/src/scenegraph/MatrixTransform.cpp
+++ b/src/scenegraph/MatrixTransform.cpp
@@ -44,7 +44,7 @@ namespace SceneGraph {
 		RenderChildren(t, rd);
 	}
 
-	static const matrix4x4f s_ident(matrix4x4f::Identity());
+	static const matrix4x4f s_ident(matrix4x4f::Identity);
 	void MatrixTransform::RenderInstanced(const std::vector<matrix4x4f> &trans, const RenderData *rd)
 	{
 		if (0 == memcmp(&m_transform, &s_ident, sizeof(matrix4x4f))) {

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -582,7 +582,7 @@ namespace SceneGraph {
 		}
 	}
 
-	static void AddAABBVisualizer(const Aabb &aabb, Color color, Graphics::VertexArray &lines, const matrix4x4f &transform = matrix4x4fIdentity)
+	static void AddAABBVisualizer(const Aabb &aabb, Color color, Graphics::VertexArray &lines, const matrix4x4f &transform = matrix4x4f::Identity)
 	{
 		PROFILE_SCOPED()
 
@@ -616,7 +616,7 @@ namespace SceneGraph {
 		ModelAABBVisitor(Graphics::VertexArray &lines) :
 			lines(lines)
 		{
-			matrixStack.push_back(matrix4x4fIdentity);
+			matrixStack.push_back(matrix4x4f::Identity);
 		}
 
 		void ApplyMatrixTransform(MatrixTransform &mt) override

--- a/src/scenegraph/Tag.cpp
+++ b/src/scenegraph/Tag.cpp
@@ -15,7 +15,7 @@ namespace SceneGraph {
 
 	Tag::Tag(Graphics::Renderer *r, const matrix4x4f &m) :
 		MatrixTransform(r, m),
-		m_globalTransform(matrix4x4f::Identity())
+		m_globalTransform(matrix4x4f::Identity)
 	{
 	}
 

--- a/src/ship/CameraController.cpp
+++ b/src/ship/CameraController.cpp
@@ -21,14 +21,14 @@ CameraController::CameraController(RefCountedPtr<CameraContext> camera, const Sh
 	m_camera(camera),
 	m_ship(ship),
 	m_pos(0.0),
-	m_orient(matrix3x3d::Identity())
+	m_orient(matrix3x3d::Identity)
 {
 }
 
 void CameraController::Reset()
 {
 	m_pos = vector3d(0.0);
-	m_orient = matrix3x3d::Identity();
+	m_orient = matrix3x3d::Identity;
 }
 
 void CameraController::Update()
@@ -57,7 +57,7 @@ InternalCameraController::InternalCameraController(RefCountedPtr<CameraContext> 
 	m_origFov(camera->GetFovAng()),
 	m_zoomPct(1),
 	m_zoomPctTo(1),
-	m_viewOrient(matrix3x3d::Identity()),
+	m_viewOrient(matrix3x3d::Identity),
 	m_smoothing(false)
 {
 	Reset();
@@ -65,7 +65,7 @@ InternalCameraController::InternalCameraController(RefCountedPtr<CameraContext> 
 
 static bool FillCameraPosOrient(const SceneGraph::Model *m, const char *tag, vector3d &pos, matrix3x3d &orient, matrix4x4f &trans, const matrix3x3d &fallbackOrient)
 {
-	matrix3x3d fixOrient(matrix3x3d::Identity());
+	matrix3x3d fixOrient(matrix3x3d::Identity);
 
 	const SceneGraph::Tag *tagNode = m->FindTagByName(tag);
 	if (!tagNode) {
@@ -96,7 +96,7 @@ void InternalCameraController::Reset()
 	if (fallback)
 		fallbackTransform = fallback->GetGlobalTransform() * matrix4x4f::RotateYMatrix(M_PI);
 
-	FillCameraPosOrient(m, "tag_camera_front", m_initPos[MODE_FRONT], m_initOrient[MODE_FRONT], fallbackTransform, matrix3x3d::Identity());
+	FillCameraPosOrient(m, "tag_camera_front", m_initPos[MODE_FRONT], m_initOrient[MODE_FRONT], fallbackTransform, matrix3x3d::Identity);
 	FillCameraPosOrient(m, "tag_camera_rear", m_initPos[MODE_REAR], m_initOrient[MODE_REAR], fallbackTransform, matrix3x3d::RotateY(M_PI));
 	FillCameraPosOrient(m, "tag_camera_left", m_initPos[MODE_LEFT], m_initOrient[MODE_LEFT], fallbackTransform, matrix3x3d::RotateY((M_PI / 2) * 3));
 	FillCameraPosOrient(m, "tag_camera_right", m_initPos[MODE_RIGHT], m_initOrient[MODE_RIGHT], fallbackTransform, matrix3x3d::RotateY(M_PI / 2));
@@ -204,7 +204,7 @@ ExternalCameraController::ExternalCameraController(RefCountedPtr<CameraContext> 
 	m_distTo(m_dist),
 	m_rotX(0),
 	m_rotY(0),
-	m_extOrient(matrix3x3d::Identity()),
+	m_extOrient(matrix3x3d::Identity),
 	m_smoothed_ship_orient(Quaternionf())
 {
 }
@@ -316,7 +316,7 @@ SiderealCameraController::SiderealCameraController(RefCountedPtr<CameraContext> 
 	MoveableCameraController(camera, ship),
 	m_dist(200),
 	m_distTo(m_dist),
-	m_sidOrient(matrix3x3d::Identity())
+	m_sidOrient(matrix3x3d::Identity)
 {
 }
 
@@ -380,7 +380,7 @@ FlyByCameraController::FlyByCameraController(RefCountedPtr<CameraContext> camera
 	m_dist(500),
 	m_distTo(m_dist),
 	m_roll(0),
-	m_flybyOrient(matrix3x3d::Identity())
+	m_flybyOrient(matrix3x3d::Identity)
 {
 }
 
@@ -400,7 +400,7 @@ void FlyByCameraController::Reset()
 {
 	m_dist = 500;
 	m_distTo = m_dist;
-	SetPosition(vector3d(0, 0, 0));
+	SetPosition(vector3d::Zero);
 }
 
 void FlyByCameraController::Update()
@@ -412,7 +412,7 @@ void FlyByCameraController::Update()
 	vector3d camerap;
 
 	Frame *shipFrame = Frame::GetFrame(ship->GetFrame());
-	if (GetPosition() == vector3d(0, 0, 0) || m_old_frame != shipFrame) {
+	if (GetPosition() == vector3d::Zero || m_old_frame != shipFrame) {
 		m_old_pos = ship_pos;
 		m_old_frame = shipFrame;
 	}

--- a/src/ship/CameraController.h
+++ b/src/ship/CameraController.h
@@ -206,7 +206,7 @@ public:
 	// Apply in YXZ order because euler angles are non-ideal.
 	void SetRotationAngles(vector3f rotation) override
 	{
-		m_sidOrient = matrix3x3d::Identity();
+		m_sidOrient = matrix3x3d::Identity;
 		YawCamera(rotation.y);
 		PitchCamera(rotation.x);
 		RollCamera(rotation.z);

--- a/src/ship/GunManager.cpp
+++ b/src/ship/GunManager.cpp
@@ -367,11 +367,11 @@ void GunManager::SetGroupFireWithoutTargeting(uint32_t group, bool enabled)
 vector3d GunManager::GetGroupLeadPos(uint32_t group)
 {
 	if (group >= m_groups.size() || !m_groups[group].target || m_groups[group].weapons.none())
-		return vector3d(0, 0, 0);
+		return vector3d::Zero;
 
 	GroupState &gs = m_groups[group];
 	double inv_count = 1.0 / double(gs.weapons.count());
-	vector3d lead_pos = vector3d(0, 0, 0);
+	vector3d lead_pos = vector3d::Zero;
 
 	for (size_t idx = 0; idx < m_weapons.size(); idx++) {
 		if (gs.weapons[idx]) {
@@ -421,7 +421,7 @@ void GunManager::StaticUpdate(float deltaTime)
 			const matrix3x3d &orient = m_parent->GetOrient();
 			const vector3d relPosition = gs.target->GetPositionRelTo(m_parent);
 			const vector3d relVelocity = gs.target->GetVelocityRelTo(m_parent->GetFrame()) - m_parent->GetVelocity();
-			vector3d relAccel = vector3d(0, 0, 0);
+			vector3d relAccel = vector3d::Zero;
 
 			if (gs.target->IsType(ObjectType::DYNAMICBODY)) {
 				relAccel = static_cast<const DynamicBody *>(gs.target)->GetLastForce() / gs.target->GetMass();
@@ -431,7 +431,7 @@ void GunManager::StaticUpdate(float deltaTime)
 			CalcWeaponLead(gun, relPosition * orient, relVelocity * orient, relAccel * orient);
 		} else {
 			gun.currentLead = vector3f(0, 0, 1);
-			gun.currentLeadPos = vector3d(0, 0, 0);
+			gun.currentLeadPos = vector3d::Zero;
 		}
 
 		// Update gun cooling per tick

--- a/src/ship/Propulsion.cpp
+++ b/src/ship/Propulsion.cpp
@@ -60,8 +60,8 @@ Propulsion::Propulsion()
 	m_thrusterFuel = 0.0; //0.0-1.0, remaining fuel
 	m_reserveFuel = 0.0;
 	m_fuelStateChange = false;
-	m_linThrusters = vector3d(0, 0, 0);
-	m_angThrusters = vector3d(0, 0, 0);
+	m_linThrusters = vector3d::Zero;
+	m_angThrusters = vector3d::Zero;
 	m_smodel = nullptr;
 	m_dBody = nullptr;
 }

--- a/src/ship/Propulsion.h
+++ b/src/ship/Propulsion.h
@@ -71,8 +71,8 @@ public:
 	inline vector3d GetLinThrusterState() const { return m_linThrusters; };
 	inline vector3d GetAngThrusterState() const { return m_angThrusters; }
 
-	inline void ClearLinThrusterState() { m_linThrusters = vector3d(0, 0, 0); }
-	inline void ClearAngThrusterState() { m_angThrusters = vector3d(0, 0, 0); }
+	inline void ClearLinThrusterState() { m_linThrusters = vector3d::Zero; }
+	inline void ClearAngThrusterState() { m_angThrusters = vector3d::Zero; }
 
 	inline vector3d GetActualLinThrust() const { return m_linThrusters * GetThrustUncapped(m_linThrusters); }
 	inline vector3d GetActualAngThrust() const { return m_angThrusters * m_angThrust; }

--- a/src/test/TestProperty.cpp
+++ b/src/test/TestProperty.cpp
@@ -94,7 +94,7 @@ TEST_CASE("PropertyValidation")
 		CHECK(prop.get_number() == 0.0);
 		CHECK(prop.get_integer() == 0);
 		CHECK(prop.get_vector2() == vector2d(0, 0));
-		CHECK(prop.get_vector3() == vector3d(0, 0, 0));
+		CHECK(prop.get_vector3() == vector3d::Zero);
 		CHECK(prop.get_quat() == Quaternionf(1, 0, 0, 0));
 		CHECK(prop.get_color() == Color4ub(0, 0, 0, 255));
 		CHECK(prop.get_string() == "");

--- a/src/vector3.h
+++ b/src/vector3.h
@@ -224,7 +224,12 @@ public:
 	inline vector2<T> yz() { return vector2<T>(y, z); }
 	inline vector2<T> yx() { return vector2<T>(y, x); }
 	inline vector2<T> zx() { return vector2<T>(z, x); }
+
+	static const vector3 Zero;
 };
+
+template <typename T>
+const vector3<T> vector3<T>::Zero(T(0));
 
 // These are here in this manner to enforce that only float and double versions are possible.
 template <>


### PR DESCRIPTION
Added a static const member variable for ~~`ZERO`~~ `Zero` values to vector3 and replaced all instances of using `vector3d(0, 0, 0)` in the code I could find.

Did not do the same for cases of `vector3f(0.f, 0.f, 0.f)` as this often made sense in the situatiuns that it is used.

EDIT:
Changed the usage of `matrix3x3::Identity()` and `matrix4x4::Identity()` static functions to be a static const member named `Identity` and the `Identity()` renamed to `IdentityFunc()`. Also deleted the lightly used `matrix4x4fIdentity` and other values in favour of `matrix4x4f::Identity`
