### PR TITLE
Convert FOV to Radians before using with Frustum

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -53,8 +53,9 @@ CameraContext::~CameraContext()
 void CameraContext::SetFovAng(float newAng)
 {
 	m_fovAng = newAng;
-	m_frustum = Frustum(m_width, m_height, m_fovAng, m_zNear, m_zFar);
-	m_projMatrix = matrix4x4f::InfinitePerspectiveMatrix(DEG2RAD(m_fovAng), m_width / m_height, m_zNear);
+	const float fovAngRadians = DEG2RAD(m_fovAng);
+	m_frustum = Frustum(m_width, m_height, fovAngRadians, m_zNear, m_zFar);
+	m_projMatrix = matrix4x4f::InfinitePerspectiveMatrix(fovAngRadians, m_width / m_height, m_zNear);
 }
 
 void CameraContext::BeginFrame()


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

This seems to fix #6121 for ships, as there was a small mistake when setting up the new Frustum. In the old you could pass it a FOV in degrees and it would internally convert to build the perspective matrix. This now needs to be done by the calling function which hadn't done that but did for the following usage a line below

PS: I'll merge this tomorrow unless anyone has comment or negative testing experiences