### PR TITLE
Fix use-after-free with multiple custom system redefinition

### DIFF
--- a/src/galaxy/CustomSystem.h
+++ b/src/galaxy/CustomSystem.h
@@ -74,6 +74,7 @@ public:
 	bool want_rand_explored;
 	bool override_random_system;
 	bool explored;
+	std::string factionName;
 	const Faction *faction;
 	Polit::GovType govType;
 	bool want_rand_lawlessness;
@@ -107,7 +108,7 @@ public:
 	typedef std::vector<const CustomSystem *> SystemList;
 	// XXX this is not as const-safe as it should be
 	const SystemList &GetCustomSystemsForSector(int sectorX, int sectorY, int sectorZ) const;
-	void AddCustomSystem(const SystemPath &path, CustomSystem *csys);
+	bool AddCustomSystem(const SystemPath &path, CustomSystem *csys);
 	Galaxy *GetGalaxy() const { return m_galaxy; }
 
 	void RunLuaSystemSanityChecks(CustomSystem *csys);

--- a/src/galaxy/Factions.cpp
+++ b/src/galaxy/Factions.cpp
@@ -530,6 +530,18 @@ void FactionsDatabase::RegisterCustomSystem(CustomSystem *cs, const std::string 
 	m_missingFactionsMap[factionName].push_back(cs);
 }
 
+void FactionsDatabase::UnregisterCustomSystem(const CustomSystem *cs, const std::string &factionName)
+{
+	auto &list = m_missingFactionsMap[factionName];
+
+	for (auto iter = list.begin(); iter != list.end(); iter++) {
+		if (*iter == cs) {
+			list.erase(iter);
+			break;
+		}
+	}
+}
+
 void FactionsDatabase::AddFaction(Faction *faction)
 {
 	// add the faction to the various faction data structures

--- a/src/galaxy/Factions.h
+++ b/src/galaxy/Factions.h
@@ -102,6 +102,7 @@ public:
 	bool IsInitialized() const;
 	Galaxy *GetGalaxy() const { return m_galaxy; }
 	void RegisterCustomSystem(CustomSystem *cs, const std::string &factionName);
+	void UnregisterCustomSystem(const CustomSystem *cs, const std::string &factionName);
 	void AddFaction(Faction *faction);
 
 	const Faction *GetFaction(const Uint32 index) const;


### PR DESCRIPTION
If the same system is defined multiple times in JSON, the custom system deduplication code inadvertently left a dangling pointer in Factions.cpp (due to custom systems being registered piecemeal). This was responsible for Sol receiving an incorrect assignment to 102_Outer_Republic.

That this bug was found is minorly amazing, as it required the last faction in the faction list to share the same homeworld system as another faction, leading to two copies of the system being defined under two different JSON files. Sol is then loaded immediately after the end of the faction custom system files; if it were not these precise conditions we probably would have never caught this bug.