### PR TITLE
Changing seed for Impression to avoid the station being partially underground

### DIFF
--- a/data/systems/custom/00_barnard_s_star.lua
+++ b/data/systems/custom/00_barnard_s_star.lua
@@ -113,7 +113,7 @@ local impression = CustomSystemBody:new('Impression', 'PLANET_GAS_GIANT')
 
 local impression_moons = {
 		CustomSystemBody:new('Name and Form', 'PLANET_ASTEROID')
-		:seed(-9812342)
+		:seed(-542012498)
 		:radius(f(137,10000))
 		:mass(f(81,1000000))
 		:temp(121)


### PR DESCRIPTION
Changing the seed for Impression to avoid too bumpy terrain burrying port OPLI Contemplation, reported in #6086. The other ports were already fine.
Before:
<img width="2496" height="1416" alt="screenshot-20260201-101544" src="https://github.com/user-attachments/assets/b5c66a6f-2b20-45a2-acd8-cfd790624052" />
After:
<img width="2496" height="1416" alt="screenshot-20260201-101355" src="https://github.com/user-attachments/assets/35747ac5-b2bd-4a9e-ad26-5e17ea56060f" />


Does not fix the terrain issue in general, but only in this one specific instance in a starting system.
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

