### PR TITLE
StringF: fix to_string overloads

### DIFF
--- a/src/StringF.h
+++ b/src/StringF.h
@@ -136,6 +136,9 @@ inline std::string to_string(uint8_t value, const FormatSpec &fmt) { return to_s
 inline std::string to_string(uint16_t value, const FormatSpec &fmt) { return to_string(uint64_t(value), fmt); }
 inline std::string to_string(uint32_t value, const FormatSpec &fmt) { return to_string(uint64_t(value), fmt); }
 
+inline std::string to_string(long value, const FormatSpec &fmt) { return to_string(int64_t(value), fmt); }
+inline std::string to_string(unsigned long value, const FormatSpec &fmt) { return to_string(uint64_t(value), fmt); }
+
 inline std::string to_string(float value, const FormatSpec &fmt) { return to_string(double(value), fmt); }
 
 inline std::string to_string(fixed value, const FormatSpec &fmt)


### PR DESCRIPTION
seeing failure in https://github.com/Homebrew/homebrew-core/pull/265699

```
  In file included from /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/scenegraph/Loader.cpp:15:
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:173:10: error: call to 'to_string' is ambiguous
    173 |                 return to_string(value, spec);
        |                        ^~~~~~~~~
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:167:2: note: in instantiation of member function 'FormatArgT<unsigned long>::format' requested here
    167 |         FormatArgT(const char *name_, const T &value_, const char *defaultformat_) :
        |         ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:190:10: note: in instantiation of member function 'FormatArgT<unsigned long>::FormatArgT' requested here
    190 |                 return FormatArgT<T>(name, arg, defaultformat);
        |                        ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:272:74: note: in instantiation of member function 'FormatArgWrapper<unsigned long>::wrap' requested here
    272 |         const typename FormatArgWrapper<T2>::type &arg2 = FormatArgWrapper<T2>::wrap(p2);
        |                                                                                 ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/scenegraph/Loader.cpp:602:12: note: in instantiation of function template specialization 'stringf<std::string, unsigned int, unsigned long>' requested here
    602 |                                 AddLog(stringf("%0: no material defined at index %1, falling back to material %2", m_curMeshDef, matIdx, m_modelDef->matDefs.size() - 1));
        |                                        ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:121:13: note: candidate function
    121 | std::string to_string(int64_t value, const FormatSpec &fmt);
        |             ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:125:13: note: candidate function
    125 | std::string to_string(uint64_t value, const FormatSpec &fmt);
        |             ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:127:13: note: candidate function
    127 | std::string to_string(double value, const FormatSpec &fmt);
        |             ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:132:20: note: candidate function
    132 | inline std::string to_string(int8_t value, const FormatSpec &fmt) { return to_string(int64_t(value), fmt); }
        |                    ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:133:20: note: candidate function
    133 | inline std::string to_string(int16_t value, const FormatSpec &fmt) { return to_string(int64_t(value), fmt); }
        |                    ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:134:20: note: candidate function
    134 | inline std::string to_string(int32_t value, const FormatSpec &fmt) { return to_string(int64_t(value), fmt); }
        |                    ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:135:20: note: candidate function
    135 | inline std::string to_string(uint8_t value, const FormatSpec &fmt) { return to_string(uint64_t(value), fmt); }
        |                    ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:136:20: note: candidate function
    136 | inline std::string to_string(uint16_t value, const FormatSpec &fmt) { return to_string(uint64_t(value), fmt); }
        |                    ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:137:20: note: candidate function
    137 | inline std::string to_string(uint32_t value, const FormatSpec &fmt) { return to_string(uint64_t(value), fmt); }
        |                    ^
  /private/tmp/pioneer-20260203-8614-qkzzlf/pioneer-20260203/src/StringF.h:139:20: note: candidate function
    139 | inline std::string to_string(float value, const FormatSpec &fmt) { return to_string(double(value), fmt); }
        |                    ^
  1 error generated.
```