### PR TITLE
.desktop: Prefer Wayland over X11

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,10 @@ extern "C" int main(int argc, char **argv)
 	Profiler::detect(argc, argv);
 #endif
 
+	/* SDL2 does not enable Wayland by default, but we want to prefer it
+	 * when available, over X11 */
+	SDL_setenv("SDL_VIDEODRIVER", "windows,wayland,x11", 0);
+
 	OS::SetDPIAware();
 
 	RunMode mode = MODE_GAME;


### PR DESCRIPTION
Not specifying SDL_VIDEODRIVER will cause SDL to only use X11 and not even try Wayland, which is a problem on systems that only have Wayland.

By specifying SDL_VIDEODRIVER=wayland,x11 the game will work on both Wayland and X11 sessions.