### PR TITLE
Fix error shown in the Language selection list

### DIFF
--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -371,12 +371,10 @@ local function showLanguageOptions()
 
 	ui.withFont(pionillium.body, function()
 		ui.child("##LanguageList", Vector2(0, 0), function()
-			local incme = 0
 			for _, lang in ipairs(langs) do
-				if ui.selectable(Lang.GetResource("core",lang).LANG_NAME .. "##" .. incme, Lang.currentLanguage==lang, {}) then
+				if ui.selectable(Lang.GetResource("core",lang).LANG_NAME .. "##" .. lang, Lang.currentLanguage==lang, {}) then
 					Lang.SetCurrentLanguage(lang)
 				end
-				incme = incme + 1
 			end
 		end)
 	end)


### PR DESCRIPTION
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->
The languages selection list contains multiple double entries which causes errors in ImGui.

This fixes it by appending a hidden bit of text using the `##` formatting to add a number onto the end of the displayed string thus making it unique

<img width="773" height="179" alt="Ekrano_kopija_20260206_190709" src="https://github.com/user-attachments/assets/faf16ac7-e3d8-43f1-bf4b-30f6f93ba06d" />
