### PR TITLE
Improve calculations in AIMatchVel (AIChangeVelBy)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,7 @@ endif (WIN32)
 add_subdirectory(src/editor)
 
 target_link_libraries(${PROJECT_NAME} LINK_PRIVATE ${pioneerLibs} ${winLibs})
-target_link_libraries(unittest LINK_PRIVATE ${pioneerLibs} ${winLibs})
+target_link_libraries(unittest LINK_PRIVATE pioneer-lib ${pioneerLibs} ${winLibs})
 target_link_libraries(modelcompiler LINK_PRIVATE ${pioneerLibs} ${winLibs})
 target_link_libraries(savegamedump LINK_PRIVATE pioneer-core ${SDL2_IMAGE_LIBRARIES} ${winLibs})
 

--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -56,6 +56,7 @@
 #include "graphics/RenderState.h"
 #include "graphics/Renderer.h"
 #include "graphics/opengl/RendererGL.h"
+#include "graphics/dummy/RendererDummy.h"
 
 #include "core/GuiApplication.h"
 #include "core/Log.h"
@@ -358,8 +359,13 @@ void Pi::App::OnStartup()
 	Pi::detail.planets = config->Int("DetailPlanets");
 	Pi::detail.cities = config->Int("DetailCities");
 
-	Graphics::RendererOGL::RegisterRenderer();
-	Pi::renderer = StartupRenderer(Pi::config, false, config->Int("DebugWindowResize"));
+	if (m_noGui) {
+		Graphics::RendererDummy::RegisterRenderer();
+		Pi::renderer = StartupRenderer(Pi::config, Graphics::RendererType::RENDERER_DUMMY, false, config->Int("DebugWindowResize"));
+	} else {
+		Graphics::RendererOGL::RegisterRenderer();
+		Pi::renderer = StartupRenderer(Pi::config, Graphics::RendererType::RENDERER_OPENGL_3x, false, config->Int("DebugWindowResize"));
+	}
 
 	Pi::rng.IncRefCount(); // so nothing tries to free it
 	Pi::rng.seed(time(0));

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -204,6 +204,12 @@ public:
 	void AIBodyDeleted(const Body *const body){}; // Note: defined in Ship-AI.cpp // todo: signals
 
 	const AICommand *GetAICommand() const { return m_curAICmd; }
+	void SetAICommand(AICommand *cmd)
+	{
+		if (AIIsActive()) AIClearInstructions();
+		m_curAICmd = cmd;
+	}
+
 	bool IsAIAttacking(const Ship *target) const;
 
 	void PostLoadFixup(Space *space) override;

--- a/src/core/GuiApplication.cpp
+++ b/src/core/GuiApplication.cpp
@@ -183,7 +183,7 @@ void GuiApplication::SetupProfiler(IniConfig *config)
 	SetProfileTrace(profileTraces);
 }
 
-Graphics::Renderer *GuiApplication::StartupRenderer(IniConfig *config, bool hidden, bool resizable)
+Graphics::Renderer *GuiApplication::StartupRenderer(IniConfig *config, Graphics::RendererType rendererType, bool hidden, bool resizable)
 {
 	PROFILE_SCOPED()
 
@@ -198,12 +198,10 @@ Graphics::Renderer *GuiApplication::StartupRenderer(IniConfig *config, bool hidd
 	OutputVersioningInfo();
 
 	// determine what renderer we should use, default to Opengl 3.x
-	const std::string rendererName = config->String("RendererName", Graphics::RendererNameFromType(Graphics::RENDERER_OPENGL_3x));
-	// if we add new renderer types, make sure to update this logic
-	Graphics::RendererType rType = Graphics::RENDERER_OPENGL_3x;
+	const std::string rendererName = config->String("RendererName", Graphics::RendererNameFromType(rendererType));
 
 	Graphics::Settings videoSettings = {};
-	videoSettings.rendererType = rType;
+	videoSettings.rendererType = rendererType;
 	videoSettings.width = config->Int("ScrWidth");
 	videoSettings.height = config->Int("ScrHeight");
 	videoSettings.fullscreen = (config->Int("StartFullscreen") != 0);

--- a/src/core/GuiApplication.h
+++ b/src/core/GuiApplication.h
@@ -22,6 +22,7 @@ namespace PiGui {
 namespace Graphics {
 	class Renderer;
 	class RenderTarget;
+	enum RendererType;
 }
 
 class GuiApplication : public Application {
@@ -44,7 +45,7 @@ protected:
 
 	// TODO: unify config handling, possibly make the config an Application member
 	// Call this from your OnStartup() method
-	Graphics::Renderer *StartupRenderer(IniConfig *config, bool hidden = false, bool resizable = false);
+	Graphics::Renderer *StartupRenderer(IniConfig *config, Graphics::RendererType rendererType, bool hidden = false, bool resizable = false);
 
 	// Call this from your OnStartup() method
 	Input::Manager *StartupInput(IniConfig *config);

--- a/src/editor/EditorApp.cpp
+++ b/src/editor/EditorApp.cpp
@@ -162,7 +162,7 @@ void EditorApp::OnStartup()
 	if (!m_headless) {
 		Graphics::RendererOGL::RegisterRenderer();
 
-		m_renderer = StartupRenderer(m_editorCfg.get(), false, true);
+		m_renderer = StartupRenderer(m_editorCfg.get(), Graphics::RendererType::RENDERER_OPENGL_3x, false, true);
 		StartupInput(m_editorCfg.get());
 
 		StartupPiGui();

--- a/src/graphics/dummy/RendererDummy.h
+++ b/src/graphics/dummy/RendererDummy.h
@@ -26,13 +26,20 @@ namespace Graphics {
 		RendererDummy() :
 			Renderer(0, 0, 0),
 			m_identity(matrix4x4f::Identity)
-		{}
+		{
+			m_width = 1024;
+			m_height = 768;
+		}
 
 		const char *GetName() const final { return "Dummy"; }
 		RendererType GetRendererType() const final { return RENDERER_DUMMY; }
 		bool SupportsInstancing() final { return false; }
 		int GetMaximumNumberAASamples() const final { return 0; }
-		bool GetNearFarRange(float &near_, float &far_) const final { return true; }
+		bool GetNearFarRange(float &near_, float &far_) const final {
+			near_ = 0.001;
+			far_ = 100'000'000;
+			return true;
+		}
 
 		void SetVSyncEnabled(bool) override {}
 

--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -396,15 +396,8 @@ void Instance::Init(Graphics::Renderer *renderer)
 	// unused, but that is slated to change very soon.
 	// We will need to fill this with a valid pointer to the OpenGL context.
 	ImGui_ImplSDL2_InitForOpenGL(m_renderer->GetSDLWindow(), NULL);
-	switch (m_renderer->GetRendererType()) {
-	default:
-	case Graphics::RENDERER_DUMMY:
-		Error("RENDERER_DUMMY is not a valid renderer, aborting.");
-		return;
-	case Graphics::RENDERER_OPENGL_3x:
-		m_instanceRenderer->Initialize();
-		break;
-	}
+
+	m_instanceRenderer->Initialize();
 
 	ImGuiIO &io = ImGui::GetIO();
 	// Apply the base style

--- a/src/posix/FileSystemPosix.cpp
+++ b/src/posix/FileSystemPosix.cpp
@@ -263,7 +263,7 @@ namespace FileSystem {
 				case ENOENT: {
 					size_t pos = path.rfind('/');
 					if (pos != std::string::npos) {
-						const std::string dirname = path.substr(0, pos - 1);
+						const std::string dirname = path.substr(0, pos);
 						if (dirname.empty() || !make_directory_raw(dirname)) {
 							return false;
 						}

--- a/src/test/SimulationTests.cpp
+++ b/src/test/SimulationTests.cpp
@@ -1,0 +1,211 @@
+#include "BaseSphere.h"
+#include "Body.h"
+#include "FileSystem.h"
+#include "Frame.h"
+#include "Game.h"
+#include "ModelCache.h"
+#include "NavLights.h"
+#include "Pi.h"
+#include "SDL_hints.h"
+#include "Shields.h"
+#include "Ship.h"
+#include "ShipAICmd.h"
+#include "Space.h"
+#include "SpaceStationType.h"
+#include "lua/Lua.h"
+#include "lua/LuaEvent.h"
+#include "pigui/LuaPiGui.h"
+
+#include "doctest.h"
+
+template <typename T>
+struct fmt::formatter<vector3<T>> : formatter<T> {
+
+	std::string_view fwdFormat;
+
+	constexpr auto parse(fmt::format_parse_context& ctx)
+	{
+		// presumably expanding to enclosing curly braces
+		auto end = fmt::formatter<T>::parse(ctx) + 1;
+		auto begin = ctx.begin() - 2;
+		fwdFormat = std::string_view(begin, end - begin);
+		return end - 1;
+	}
+
+	format_context::iterator format(const vector3<T> &v, format_context& ctx) const
+	{
+		fmt::format_to(ctx.out(), fwdFormat, v.x);
+		fmt::format_to(ctx.out(), " ");
+		fmt::format_to(ctx.out(), fwdFormat, v.y);
+		fmt::format_to(ctx.out(), " ");
+		return fmt::format_to(ctx.out(), fwdFormat, v.z);
+	}
+};
+
+template <typename T>
+struct fmt::formatter<matrix3x3<T>>: formatter<T> {
+
+	std::string_view fwdFormat;
+
+	constexpr auto parse(fmt::format_parse_context& ctx)
+	{
+		// presumably expanding to enclosing curly braces
+		auto end = fmt::formatter<T>::parse(ctx) + 1;
+		auto begin = ctx.begin() - 2;
+		fwdFormat = std::string_view(begin, end - begin);
+		return end - 1;
+	}
+
+	format_context::iterator format(const matrix3x3<T> &m, format_context& ctx) const
+	{
+		fmt::format_to(ctx.out(), fwdFormat, m.VectorX());
+		fmt::format_to(ctx.out(), " | ");
+		fmt::format_to(ctx.out(), fwdFormat, m.VectorY());
+		fmt::format_to(ctx.out(), " | ");
+		return fmt::format_to(ctx.out(), fwdFormat, m.VectorZ());
+	}
+};
+
+class TestApp {
+
+public:
+	TestApp()
+	{
+	   	SDL_setenv("SDL_VIDEODRIVER", "dummy", 1);
+		std::map<std::string, std::string> options;
+		Pi::Init(options, true);
+
+		auto enableLogsEnv = std::getenv("PIONEER_ENABLE_SIMULATION_LOGS");
+		if (enableLogsEnv && strncmp(enableLogsEnv, "0", 1)) {
+			enableLogging = true;
+		}
+
+		ShipType::Init();
+		Lua::Init(Pi::GetAsyncJobQueue());
+		PiGui::Lua::Init();
+		Lua::InitModules();
+		LuaEvent::Init();
+		FileSystem::Init();
+		BaseSphere::Init(Pi::renderer);
+		Pi::modelCache = new ModelCache(Pi::renderer);
+		Shields::Init(Pi::renderer);
+		NavLights::Init(Pi::renderer);
+		SpaceStationType::Init();
+
+		// Gliese 852, binary system, frame 0 is gravpoint
+		SystemPath path{ -2, -4, -1, 0, 1 };
+		game = new Game(path, 0);
+	}
+
+	~TestApp()
+	{
+		delete(game);
+		Pi::game = nullptr;
+		Pi::GetApp()->Shutdown();
+		StringTable::Get()->Reclaim();
+	}
+
+	template <typename... T>
+	void log(T&& ...args)
+	{
+		if (!enableLogging) return;
+		Log::Info(std::forward<T>(args)...);
+	}
+
+	void logShip(Ship *s)
+	{
+		auto p = s->GetPropulsion();
+		log("vel: {:.2f}  pos: {:.2f}  thr: {:.2f}  ori: {:.2f}", s->GetVelocity(), s->GetPosition(), p->GetLinThrusterState(), s->GetOrient());
+	}
+
+	Game *game;
+	bool enableLogging = false;
+};
+
+class AIMatchVelCommand : public AICommand {
+public:
+	AIMatchVelCommand(DynamicBody *db, const vector3d &vel) : AICommand(db, AICommand::CMD_NONE), m_vel(vel) {}
+
+private:
+	bool TimeStepUpdate() override {
+
+		auto s = static_cast<Ship*>(m_dBody);
+
+		if (s->GetVelocity() == m_vel) return true;
+
+		s->AIMatchVel(m_vel);
+		return false;
+	}
+	vector3d m_vel;
+};
+
+TEST_CASE("simulation_tests")
+{
+	TestApp app;
+
+	app.game->SetTimeAccel(Game::TIMEACCEL_10X);
+
+	LuaEvent::Queue("onGameStart");
+	LuaEvent::Emit();
+
+	Ship *s = new Ship("sinonatrix");
+	REQUIRE(s);
+
+	app.game->GetSpace()->AddBody(s);
+
+	s->SetFrame(0);
+	auto fb = Frame::GetFrame(s->GetFrame());
+	// don't want to position the test ship inside something
+	REQUIRE(fb->GetSystemBody()->GetType() == SystemBody::TYPE_GRAVPOINT);
+
+	auto eps = 0.001;
+
+	app.log("AIMatchVel - stable direction");
+
+	s->SetPosition({ 0, 0, 0 });
+	s->SetVelocity({ 0, 0, 0 });
+
+	// lower the bow of the ship by 45 degrees, so that it will have to gain
+	// speed  simultaneously with a powerful rear thruster and the weakest upper
+	s->SetOrient(matrix3x3d::RotateX(DEG2RAD(45.0)));
+
+	// update ship stats
+	app.game->TimeStep(app.game->GetTimeStep());
+
+	s->SetAICommand(new AIMatchVelCommand(s, { 0, -100, 0 }));
+
+	auto p = s->GetPropulsion();
+
+	for (int i = 0; i < 80; ++i) {
+
+		app.logShip(s);
+
+		app.game->TimeStep(app.game->GetTimeStep());
+
+		// check weak thrusters somewhere in the process
+		// if they are not fully loaded, AIMatchVel is not fully effective
+		if (i == 10) {
+			CHECK(abs(p->GetLinThrusterState().y + 1.0) < eps);
+		}
+	}
+
+	// we want to accelerate strictly in the specified direction
+	CHECK(s->GetVelocity().xz().Length() < eps);
+	CHECK(s->GetPosition().xz().Length() < eps);
+	CHECK(abs(s->GetVelocity().y + 100) < eps);
+
+	app.log("AIMatchVel - gain speed in one frame");
+
+	s->SetPosition({ 0, 0, 0 });
+	s->SetVelocity({ 0, 0, 0 });
+	app.game->SetTimeAccel(Game::TIMEACCEL_10000X);
+	s->SetAICommand(new AIMatchVelCommand(s, { 0, -100, 0 }));
+
+	app.logShip(s);
+	app.game->TimeStep(app.game->GetTimeStep());
+	app.logShip(s);
+
+	CHECK(s->GetVelocity().xz().Length() < eps);
+	CHECK(s->GetPosition().xz().Length() < eps);
+	CHECK(abs(s->GetVelocity().y + 100) < eps);
+}


### PR DESCRIPTION
The problem with the current version is that if the powerful thruster is turned away from the direction of the required speed, it pushes the ship to the side when gaining speed. This happens because the velocity vector is decomposed along the directions of the thrusters, and each thruster independently tries to maximize its component.

In the new version it is done so that the direction of the thrust vector necessarily coincides with the direction of the required speed.

Also wrote tests that allow to see the problem with the previous implementation and test the new one.