### PR TITLE
Approximate ring shadow penumbra

### DIFF
--- a/data/shaders/opengl/planetrings.frag
+++ b/data/shaders/opengl/planetrings.frag
@@ -14,11 +14,6 @@ out vec4 frag_color;
 
 #define NUM_OCTAVES 3
 
-float findSphereEyeRayEntryDistance(in vec3 sphereCenter, in vec3 eyeTo, in float radius)
-{
-	return raySphereIntersect(sphereCenter, normalize(eyeTo), radius).x;
-}
-
 float octaveNoise(vec2 noiseCoord, float amplitude, float persistence, float lacunarity)
 {
 	float val = 0.0;
@@ -57,8 +52,17 @@ void main(void)
 	float density = (0.2 * detail1 + 0.8 * detail2);
 
 	for (int i=0; i<NUM_LIGHTS; ++i) {
-		float l = findSphereEyeRayEntryDistance(-vec3(texCoord1), vec3(uViewMatrixInverse * normalize(uLight[i].position)), 1.0);
-		if (l <= 0.0) {
+		// Compute intersection between the light ray and the planet sphere (rings are scaled so 1.0 = planet radius)
+		vec2 eye_dist = raySphereIntersect(-vec3(texCoord1), normalize(vec3(uViewMatrixInverse * normalize(uLight[i].position))), 1.0);
+		// Find the length of intersection in planet radii (ergo, a value ranging from 0..2)
+		float l = (eye_dist.y - eye_dist.x);
+		// Approximate shadow penumbra, completely non-physical.
+		// pixel_width controls the minimum screen-space size of the penumbra regardless of zoom level in pixels.
+		float pixel_width = abs(fwidth(l)) * 6;
+		float penumbra = 1 - smoothstep(0, max(0.2, pixel_width), l);
+
+		// Compute ring lighting
+		{
 			// first term: diffuse light phase (like in full/new moon)
 			float mu = dot(normalize(vec3(uLight[i].position)), eyenorm);
 			float diffuse = sqrt((1 - mu) / 2);
@@ -72,7 +76,8 @@ void main(void)
 			// Reduce impact of retro-reflectance by including density as a second term
 			float phaseReflect = density * miePhaseFunction(g, muRev);
 
-			col = col + texCol * (diffuse + phaseThrough + phaseReflect) * uLight[i].diffuse;
+			// Scale contributed lighting by penumbra factor.
+			col = col + texCol * (diffuse + phaseThrough + phaseReflect) * uLight[i].diffuse * vec4(penumbra);
 		}
 	}
 	col.a = texCol.a;


### PR DESCRIPTION
The ring shader has always had a minor problem where shadow edges are extremely sharp and alias horribly at long view distances.

<img width="1920" height="1080" alt="Screenshot From 2026-03-28 21-49-31" src="https://github.com/user-attachments/assets/53893a4f-d188-4e29-bcc6-5c6336a9bb66" />

They say a picture's worth a thousand words, so here's a video instead so I don't have to type out all thousand words.

https://github.com/user-attachments/assets/99ebc69e-ff93-46fc-a97d-974f69f3165b

This PR uses a completely non-physically based value for the shadow penumbra size (specifically performs a `smoothstep` over a distance corresponding to the light ray passing through ~0.5% of the planet's radius) to approximate atmosphere and light-source-size penumbra. I do not have the desire (or the exposed variables) at this time to make the value more physically based, and at the scales involved in Pioneer there would not be a significant amount of gain if I did so.