### PR TITLE
Balance number of combat and scout missions

### DIFF
--- a/data/modules/Assassination/Assassination.lua
+++ b/data/modules/Assassination/Assassination.lua
@@ -229,8 +229,8 @@ local makeAdvert = function (station)
 end
 
 local onCreateBB = function (station)
-	local num = Engine.rand:Integer(0, math.ceil(Game.system.population) / 2 + 1)
-	for i = 1,num do
+	local num = Engine.rand:Integer(math.ceil(Game.system.population * Game.system.lawlessness))
+	for _ = 1,num do
 		makeAdvert(station)
 	end
 end

--- a/data/modules/Combat/Combat.lua
+++ b/data/modules/Combat/Combat.lua
@@ -284,8 +284,8 @@ local makeAdvert = function (station)
 end
 
 local onCreateBB = function (station)
-	local num = Engine.rand:Integer(0, math.ceil(Game.system.population * 2 * Game.system.lawlessness) + 1)
-	for i = 1, num do
+	local num = Engine.rand:Integer(math.ceil(Game.system.population * Game.system.lawlessness))
+	for _ = 1, num do
 		makeAdvert(station)
 	end
 end

--- a/data/modules/Scout/Scout.lua
+++ b/data/modules/Scout/Scout.lua
@@ -560,9 +560,9 @@ local makeAdvert = function (station)
 end
 
 local onCreateBB = function (station)
-	local num = Engine.rand:Integer(math.ceil(Game.system.population)) / 3
+	local num = Engine.rand:Integer(math.ceil(Game.system.population / 3))
 
-	for i = 1,num do
+	for _ = 1,num do
 		makeAdvert(station)
 	end
 end


### PR DESCRIPTION
In my opinion, there are too many combat missions in low populated peaceful systems.

To put it a little exaggeratedly, the expensive scanner equipment is completely useless outside of Sol. There should at least be a chance that one mission will be generated.