### PR TITLE
Scoop mission fix

### DIFF
--- a/data/modules/Scoop/Scoop.lua
+++ b/data/modules/Scoop/Scoop.lua
@@ -496,7 +496,7 @@ local placeAdvert = function (station, ad)
 				isEnabled   = isEnabled
 			})
 		else
-			local p = Game.player.frameBody
+			local p = station.path:GetSystemBody().parent.path
 			ref = station:AddAdvert({
 				title       = l["ADTITLE_" .. ad.id],
 				description = ad.desc,


### PR DESCRIPTION
Game.player.frameBody is nil if the player is orbiting the system barycenter. This is a correction for #6279.