### PR TITLE
Add ObjectViewer button to perfinfo debug view

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -802,13 +802,7 @@ void Pi::HandleKeyDown(SDL_Keysym *key)
 
 #if WITH_OBJECTVIEWER
 	case SDLK_F10: {
-		if (!Pi::game)
-			break;
-
-		if (Pi::GetView() == Pi::game->GetObjectViewerView())
-			Pi::SetView(Pi::game->GetWorldView());
-		else if (Pi::player->GetNavTarget())
-			Pi::SetView(Pi::game->GetObjectViewerView());
+		ToggleObjectViewer();
 		break;
 	}
 #endif
@@ -1281,6 +1275,17 @@ static void OnPlayerDockOrUndock()
 {
 	Pi::game->RequestTimeAccel(Game::TIMEACCEL_1X);
 	Pi::game->SetTimeAccel(Game::TIMEACCEL_1X);
+}
+
+void Pi::ToggleObjectViewer()
+{
+	if (!Pi::game)
+		return;
+
+	if (Pi::GetView() == Pi::game->GetObjectViewerView())
+		Pi::SetView(Pi::game->GetWorldView());
+	else if (Pi::player->GetNavTarget())
+		Pi::SetView(Pi::game->GetObjectViewerView());
 }
 
 // This absolutely ought not to be part of the Pi class

--- a/src/Pi.h
+++ b/src/Pi.h
@@ -190,6 +190,8 @@ public:
 		return bRet;
 	}
 
+	static void ToggleObjectViewer();
+
 	/* Only use #if WITH_DEVKEYS */
 	static bool showDebugInfo;
 

--- a/src/pigui/PerfInfo.cpp
+++ b/src/pigui/PerfInfo.cpp
@@ -577,6 +577,14 @@ void PerfInfo::DrawWorldViewStats()
 	}
 
 	DrawTerrainDebug();
+
+	if (ImGui::Button("ObjectViewer"))
+	{
+		if (Pi::game)
+		{
+			Pi::ToggleObjectViewer();
+		}
+	}
 }
 
 void PerfInfo::DrawInputDebug()


### PR DESCRIPTION
We've always had tje ObjectViewer on Ctrl+F10 but I ran into a problem on a new Linux install on my laptop and the row of function/media keys that made it unusable.

So I've added the button to the other existing Debug options with in the Ctrl+i debug menu. Currently it's under the terrain options because that's what I always use it for but it could be moved in the future if people want.

