### PR TITLE
Fix for Barnard's Star display issues

### DIFF
--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -328,6 +328,7 @@ local infoView = {
 		}
 
 		local securityIdx = math.ceil(system.lawlessness * 5)
+		securityIdx = math.max(1, securityIdx)
 
 		ui.textWrapped(system.shortDescription)
 

--- a/data/systems/custom/00_barnard_s_star.lua
+++ b/data/systems/custom/00_barnard_s_star.lua
@@ -4,7 +4,7 @@
 local s = CustomSystem:new('Barnard\'s star',{ 'STAR_M' })
 	:faction('Solar Federation')
 	:govtype('EARTHCOLONIAL')
-	:lawlessness(f(0,100)) -- 1/100th from a peaceful eden
+	:lawlessness(f(1,100)) -- 1/100th from a peaceful eden
 	:short_desc('Earth Federation prison colony')
 	:long_desc([[Barnard's Star is a very low-mass red dwarf star.  Somewhere between 7 and 12 billion years old, it is probably one of the most ancient stars in the galaxy.  Despite that, it is still fairly active.  Pilots entering the system are warned that there might be considerable stellar activity, including flares and massive coronal ejections.
 

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -481,6 +481,7 @@ bool StarSystemCustomGenerator::ApplyToSystem(Random &rng, RefCountedPtr<StarSys
 	*rootBody = csbody->bodyData;
 	rootBody->m_parent = 0;
 	rootBody->m_isCustomBody = true;
+	rootBody->SetAtmFromParameters();
 
 	system->SetRootBody(rootBody);
 
@@ -1213,6 +1214,7 @@ void StarSystemRandomGenerator::MakeStarOfType(SystemBody *sbody, SystemBody::Bo
 	sbody->m_mass = fixed(rand.Int32(starTypeInfo[type].mass[0], starTypeInfo[type].mass[1]), 100);
 	sbody->m_averageTemp = rand.Int32(starTypeInfo[type].tempMin, starTypeInfo[type].tempMax);
 	sbody->GenerateStarColor();
+	sbody->SetAtmFromParameters();
 }
 
 void StarSystemRandomGenerator::MakeRandomStar(SystemBody *sbody, Random &rand)

--- a/src/galaxy/SystemBody.cpp
+++ b/src/galaxy/SystemBody.cpp
@@ -292,6 +292,8 @@ double GetMolarMass(SystemBody::BodySuperType superType)
 {
 	if (superType == SystemBody::SUPERTYPE_GAS_GIANT)
 		return 0.0023139903; // molar mass, for a combination of hydrogen and helium
+	else if (superType == SystemBody::SUPERTYPE_STAR)
+		return 0.00125;	// approximation of the sun's molar mass (in kg/mol) - mostly hydrogen
 	else
 		// XXX using earth's molar mass of air...
 		return 0.02897;
@@ -327,6 +329,25 @@ double SystemBody::GetAtmAverageTemp(double altitude) const
 void SystemBody::SetAtmFromParameters()
 {
 	double gasMolarMass = GetMolarMass(GetSuperType());
+	double surfaceGravity_g = CalcSurfaceGravity();
+
+	if ((GetSuperType() == SUPERTYPE_STAR) && (m_volatileGas == 0))
+	{
+		// This is a star, and there is no value for the gas density specified.
+		// Calculate one now based on the star's data so we can display something sensible.
+
+		double temperature = m_averageTemp;
+		if (temperature < 250) temperature = 250;
+
+		// We don't have a good way of determining a star's surface pressure, but the surface
+		// pressure for our Sun is about 0.01 atm, so divide that by its surface gravity value
+		// (274) to get a number that we can use to scale target pressure by star's gravity.
+		// This gives us the result that more dense or bigger stars have higher surface pressure.
+		double target_pressure = (0.01 / 274.0) * surfaceGravity_g;
+
+		double density = target_pressure * gasMolarMass / (GAS_CONSTANT_R * PA_2_ATMOS * temperature);
+		m_volatileGas = fixed::FromDouble(density);
+	}
 
 	double surfaceDensity = GetAtmSurfaceDensity() / gasMolarMass; // kg / m^3, convert to moles/m^3
 	double surfaceTemperature_T0 = GetAverageTemp(); //K
@@ -335,7 +356,6 @@ void SystemBody::SetAtmFromParameters()
 	//P = density*R*T=(n/V)*R*T
 	m_atmosPressure = PA_2_ATMOS * ((surfaceDensity) * GAS_CONSTANT_R * surfaceTemperature_T0); // in atmospheres
 
-	double surfaceGravity_g = CalcSurfaceGravity();
 	const double lapseRate_L = surfaceGravity_g / GetSpecificHeat(GetSuperType()); // deg/m
 
 	if (m_atmosPressure < 0.002)
@@ -344,7 +364,7 @@ void SystemBody::SetAtmFromParameters()
 		//*outPressure = p0*(1-l*h/T0)^(g*M/(R*L);
 		// want height for pressure 0.001 atm:
 		// h = (1 - exp(RL/gM * log(P/p0))) * T0 / l
-		double RLdivgM = (GAS_CONSTANT_R * lapseRate_L) / (surfaceGravity_g * GetMolarMass(GetSuperType()));
+		double RLdivgM = (GAS_CONSTANT_R * lapseRate_L) / (surfaceGravity_g * gasMolarMass);
 		m_atmosRadius = (1.0 - exp(RLdivgM * log(0.001 / m_atmosPressure))) * surfaceTemperature_T0 / lapseRate_L;
 	}
 }


### PR DESCRIPTION
Fixes #6293. The security rating display issue was that lawlessness was specified as 0/100 in the system definition, but the code expects the lowest possible value to be 1/100. Changed the system definition to 1/100 and also added a "min 1" check to the code to prevent recurrence.

For the surface pressure stat, actually all stars in the game were showing wrong values. I've added a default pressure calculation for stars that don't specify any atmosphere parameters, based on their surface gravity, to fix this.
