### PR TITLE
This seems to reduce the occurrence of random crashes.

### DIFF
--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -1068,8 +1068,10 @@ void Space::TimeStep(float step)
 
 	Frame::CollideFrames(&hitCallback);
 
-	for (Body *b : m_bodies)
+	for (size_t i = 0; i < m_bodies.size(); ++i) {
+		auto b = m_bodies[i];
 		CollideWithTerrain(b, step);
+	}
 
 	// update frames of reference
 	for (Body *b : m_bodies)
@@ -1090,7 +1092,8 @@ void Space::TimeStep(float step)
 	}
 	Frame::UpdateOrbitRails(m_game->GetTime(), m_game->GetTimeStep());
 
-	for (Body *b : m_bodies) {
+	for (size_t i = 0; i < m_bodies.size(); ++i) {
+		auto b = m_bodies[i];
 		b->TimeStepUpdate(step);
 	}
 


### PR DESCRIPTION
Fixes #6126, maybe. And possibly #6207. And perhaps #5831.

When running in debug mode I often see crashes when Space::TimeStep() is iterating through m_bodies in order to run TimeStepUpdate() on them. Since this function can add entries to m_bodies, it makes sense that this would cause occasional problems, as per the comments elsewhere in Space::TimeStep(). So I applied the same logic to the place where I see the crash, and one other place too, just in case.

However, this is hard to test, since the crashes are random. On the other hand, I don't see how this fix could make things worse.


