### PR TITLE
Fix for a bug where TraceRay could end up using stale static geometry.

### DIFF
--- a/src/collider/CollisionSpace.cpp
+++ b/src/collider/CollisionSpace.cpp
@@ -121,11 +121,11 @@ void CollisionSpace::TraceRay(const vector3d &start, const vector3d &dir, double
 	std::vector<uint32_t> isect_result;
 	isect_result.reserve(8);
 
-	if (m_enabledStaticGeoms > 0) {
+	if (m_enabledStaticGeoms > 0 && !m_needStaticGeomRebuild) {
 		m_staticObjectTree->TraceRay(start, invDir, len, isect_result);
 
 		for (uint32_t &idx : isect_result) {
-			assert(idx <= m_staticGeoms.size());
+			assert(idx < m_staticGeoms.size());
 			Geom *g = m_staticGeoms[idx];
 
 			if (g != ignore)


### PR DESCRIPTION
Fixes #6320. The crash is observed just after a successful refuelling mission on a planet's surface, because the target ship is initially "static geometry", it is immobile. After the player transfers some hydrogen, the target ship is then able to take off, transitioning into dynamic geometry. There is therefore a one-tick window when the static geometry array is stale, but still being looped by CollisionSpace::TraceRay(). My fix is to add a check for staleness before starting that loop, similar to the check for dynamic geometry staleness immediately afterwards in the same function.

