### PR TITLE
Clear the next lifecycle variable after using it, so that it doesn't then repeat when it shouldn't

### DIFF
--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -138,6 +138,7 @@ void Application::EndLifecycle()
 	// wait until we've finished the control flow for the lifecycle;
 	// the lifecycle may decide to set the next lifecycle in End()
 	m_priorityLifecycle = m_activeLifecycle->m_nextLifecycle;
+	m_activeLifecycle->m_nextLifecycle.Reset();
 	m_activeLifecycle.Reset();
 }
 


### PR DESCRIPTION
Fixes #6174. Clear the next lifecycle variable after using it, so that it doesn't then repeat the next time the active lifecycle finishes. This fixes an issue whereby the spinning tombstone animation would be seen if the player previously died, and then starts a new game and ends it without dying.

I've been running the game on and off with this fix for a few days, and it doesn't seem to have broken anything.
