### PR TITLE
Fix docking clearance timeout and docking position issue with stale clearance

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -592,6 +592,7 @@ void SpaceStation::DockingUpdate(const double timeStep)
 				m_doorAnimationStep = -0.3; // close door
 				SwitchToStage(i, DockStage::NONE);
 			}
+			dt.stagePos += timeStep / DOCKING_CLEARANCE_TIMEOUT;
 			continue;
 
 		default:
@@ -750,7 +751,7 @@ void SpaceStation::TimeStepUpdate(const float timeStep)
 			m_navLights->SetColor(i + 1, NavLights::NAVLIGHT_BLUE);
 			m_navLights->SetMask(i + 1, 0xf6); // 11110110
 		}
-		if (dt.ship->GetFlightState() == Ship::DOCKED) { //docked
+		if ((dt.ship->GetFlightState() == Ship::DOCKED) && (dt.stage == DockStage::DOCKED)) { //docked
 			PositionDockedShip(dt.ship, i);
 		} else if (dt.ship->GetFlightState() == Ship::DOCKING || dt.ship->GetFlightState() == Ship::UNDOCKING) {
 			PositionDockingShip(dt.ship, i);

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -9,6 +9,7 @@
 #include "SpaceStationType.h"
 
 #define MAX_DOCKING_PORTS 240 //256-(0x10), 0x10 is used because the collision surfaces use it as an identifying flag
+#define DOCKING_CLEARANCE_TIMEOUT (10.0 * 60.0)  // (10 min)
 
 class Body;
 class Camera;


### PR DESCRIPTION
Fixes #6324. 

If you request docking clearance from a station, and then don't dock, but fly to a different station and dock there, the code would try to use the docking pad position from the first station. This is particularly noticeable when the first station is orbital and the second station is on a planet, because it would put you in the centre of the planet (offset by one docking pad thickness).

We can fix this by ensuring that ships docking positions only get updated after DockStage::DOCKED is available to set the correct pad location. 

An ancillary problem is that docking clearances never expire. There is already code to expire docking clearance and show a comms message, but due to missing the timestep increment it never triggers. So I added a small increment to make docking clearance expire after 10 minutes. Now the rest of the code works as expected.

