### PR TITLE
Add string for missing hypercloud analyzer message

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -1405,7 +1405,7 @@
   },
   "SET_HYPERSPACE_TARGET_TO_FOLLOW_THIS_DEPARTURE": {
     "description": "",
-    "message": "Hyperspace cloud analyzer: Set hyperspace target to follow this departure"
+    "message": "Hypercloud analyzer: Set hyperspace target to follow this departure"
   },
   "SET_LOW_THRUST_POWER_LEVEL_TO_X_PERCENT": {
     "description": "",

--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -1035,6 +1035,10 @@
     "description": "",
     "message": "No established order"
   },
+  "NO_HYPERCLOUD_ANALYZER_INSTALLED": {
+    "description": "",
+    "message": "No hypercloud analyzer installed"
+  },
   "NO_HYPERDRIVE": {
     "description": "",
     "message": "No hyperdrive"

--- a/data/pigui/libs/radial-menu.lua
+++ b/data/pigui/libs/radial-menu.lua
@@ -93,7 +93,7 @@ local radial_menu_actions_hyperspace_cloud = {
 					ui.playSfx("OK")
 				end
 			else
-				Game.AddCommsLogLine(lc.NO_HYPERCLOUD_SCANNER_INSTALLED)
+				Game.AddCommsLogLine(lc.NO_HYPERCLOUD_ANALYZER_INSTALLED)
 			end
 		end
 


### PR DESCRIPTION
First commit is to add a missing string. When you click on a hyperspace cloud without an analyzer installed, you see [NO_JSON]NO_HYPERCLOUD_SCANNER_INSTALLED in the comms messages, because the code thinks there is a string with that name, but there isn't. I took the opportunity to rename the string from "scanner" to "analyzer" because everywhere else it's called an analyzer.

Second commit is to make the equipment name of the analyzer consistent. Most of the game refers to "hyperspace clouds" but the equipment name itself is "Hypercloud Analyzer". Therefore, the UI tooltip that refers to that piece of equipment should call it that too. I updated it in all language files that still have the English string. Curiously, some non-English languages are already consistent with themselves - German, Spanish, Romanian, and Russian, while Chinese and Italian are different only in a minor "choice of translation" way. All the other language files have faithfully preserved the difference between "hyperspace cloud" and "hypercloud". So basically, it's already a bit of a mix, but I think this change nudges things in the right direction.

Alternatively, we should rename the Hypercloud Analyzer to be called the Hyperspace Cloud Analyzer. Then it will be consistent with all the strings that say things like "Hyperspace departure cloud".

Let the debate begin!