### PR TITLE
Fix frames in binary star systems

### DIFF
--- a/data/pigui/modules/flight-ui/reticule.lua
+++ b/data/pigui/modules/flight-ui/reticule.lua
@@ -279,7 +279,7 @@ local function updateReticuleTarget(frame, navTarget, combatTarget)
 	end
 
 	if reticuleTarget == "frame" then
-		if not frame then
+		if not frame and not player.frameLabel then
 			reticuleTarget = nil
 		end
 	end
@@ -389,8 +389,24 @@ local function displayDetailData(target, radius, colorLight, colorDark, tooltip,
 
 end
 
+-- display only frame name in the right-side "detail" HUD section
+local function displayDetailFrameLabel(label, radius, colorLight, colorDark, tooltip)
+	local uiPos = ui.pointOnClock(center, radius, 2.46)
+	-- frame label
+	ui.addStyledText(uiPos, ui.anchor.left, ui.anchor.baseline, label, colorDark, pionillium.medium, tooltip, colors.lightBlackBackground)
+end
+
 -- display data relative to frame left of the reticule circle
-local function displayFrameData(frame, radius)
+local function displayFrameData(frame, frameLabel, radius)
+	local uiPos = ui.pointOnClock(center, radius, -2.46)
+	-- label of frame
+	local label = frameLabel
+	if frame then label = frame.label end
+	if not label then return end
+	-- if we're not in a framebody then just display the label
+	ui.addStyledText(uiPos, ui.anchor.right, ui.anchor.baseline, label, colors.frame, pionillium.medium, lui.HUD_CURRENT_FRAME, colors.lightBlackBackground)
+	if not frame then return end
+
 	local velocity = player:GetVelocityRelTo(frame)
 	local position = player:GetPositionRelTo(frame)
 	local altitude = player:GetAltitudeRelTo(frame)
@@ -398,9 +414,6 @@ local function displayFrameData(frame, radius)
 	local altitude_txt, altitude_unit = ui.Format.DistanceUnit(altitude)
 	local approach_speed = position:dot(velocity) / position:length()
 	local speed, speed_unit = ui.Format.SpeedUnit(approach_speed)
-	local uiPos = ui.pointOnClock(center, radius, -2.46)
-	-- label of frame
-	ui.addStyledText(uiPos, ui.anchor.right, ui.anchor.baseline, frame.label, colors.frame, pionillium.medium, lui.HUD_CURRENT_FRAME, colors.lightBlackBackground)
 	-- speed of approach of frame
 	uiPos = ui.pointOnClock(center, radius, -2.75)
 	ui.addFancyText(uiPos, ui.anchor.right, ui.anchor.baseline, {
@@ -806,6 +819,7 @@ local function displayReticule()
 	ui.addCircle(center, reticuleCircleRadius, colors.reticuleCircle, ui.circleSegments(reticuleCircleRadius), reticuleCircleThickness)
 
 	local frame = player.frameBody
+	local frameLabel = player.frameLabel
 	local navTarget = player:GetNavTarget()
 	local combatTarget = player:GetCombatTarget()
 	local radius = reticuleCircleRadius * 1.2
@@ -813,7 +827,11 @@ local function displayReticule()
 	updateReticuleTarget(frame, navTarget, combatTarget)
 
 	if reticuleTarget == "frame" then
-		displayDetailData(frame, radius, colors.frame, colors.frameDark, lui.HUD_CURRENT_FRAME, true)
+		if frame then
+			displayDetailData(frame, radius, colors.frame, colors.frameDark, lui.HUD_CURRENT_FRAME, true)
+		elseif frameLabel then
+			displayDetailFrameLabel(frameLabel, radius, colors.frame, colors.frameDark, lui.HUD_CURRENT_FRAME)
+		end
 	elseif reticuleTarget == "navTarget" then
 		displayDetailData(navTarget, radius, colors.navTarget, colors.navTargetDark, lui.HUD_CURRENT_NAV_TARGET)
 	elseif reticuleTarget == "combatTarget" then
@@ -827,8 +845,8 @@ local function displayReticule()
 	displayReticuleDeltaV()
 	displayAlertMarker()
 
-	if frame and reticuleTarget ~= "frame" then
-		displayFrameData(frame, radius)
+	if (frame or frameLabel) and (reticuleTarget ~= "frame") then
+		displayFrameData(frame, frameLabel, radius)
 	end
 end
 

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -824,11 +824,12 @@ static FrameId MakeFramesFor(const double at_time, SystemBody *sbody, Body *b, F
 		Frame *orbFrame = Frame::GetFrame(orbFrameId);
 		orbFrame->SetBodies(sbody, b);
 		const double bodyRadius = sbody->GetEquatorialRadius();
-		double frameRadius = std::max(10.0 * bodyRadius, sbody->GetMaxChildOrbitalDistance() * 1.1);
+		double frameRadius = 10.0 * bodyRadius;
 		// Respect the frame of other stars in the multi-star system. We still make sure that the frame ends outside
 		// the body. For a minimum separation of 1.236 radii, nothing will overlap (see StarSystem::StarSystem()).
 		if (sbody->GetParent() && frameRadius > AU * 0.11 * sbody->GetOrbMin())
 			frameRadius = std::max(1.1 * bodyRadius, AU * 0.11 * sbody->GetOrbMin());
+		frameRadius = std::max(frameRadius, sbody->GetMaxChildOrbitalDistance() * 1.1);
 		orbFrame->SetRadius(frameRadius);
 		b->SetFrame(orbFrameId);
 		return orbFrameId;

--- a/src/lua/LuaBody.cpp
+++ b/src/lua/LuaBody.cpp
@@ -431,6 +431,39 @@ static int l_body_attr_frame_body(lua_State *l)
 }
 
 /*
+ * Attribute: frameLabel
+ *
+ * The label of the frame that this dynamic body is in.
+ *
+ * Most frames will have a <frameBody> that can be read instead, so this is
+ * for frames that don't have one of those, e.g. gravpoints and hyperspace
+ */
+static int l_body_attr_frame_label(lua_State *l)
+{
+	Body *b = LuaObject<Body>::CheckFromLua(1);
+	if (!b->IsType(ObjectType::DYNAMICBODY)) {
+		lua_pushnil(l);
+		return 1;
+	}
+
+	Frame *f = Frame::GetFrame(b->GetFrame());
+
+	if (!f) {
+		lua_pushnil(l);
+		return 1;
+	}
+
+	// If we're in the root "System" frame of a binary star system, then use
+	// the root SystemBody name for the frame label, e.g. "55 Cancri A,B".
+	const SystemBody *sb = f->GetSystemBody();
+	if (sb && !sb->GetParent() && sb->GetType() == SystemBody::TYPE_GRAVPOINT)
+		LuaPush(l, sb->GetName());
+	else
+		LuaPush(l, f->GetLabel());
+	return 1;
+}
+
+/*
  * Attribute: frameRotating
  *
  * Whether the frame this dynamic body is in is a rotating frame.
@@ -780,6 +813,7 @@ void LuaObject<Body>::RegisterClass()
 		{ "type", l_body_attr_type },
 		{ "superType", l_body_attr_super_type },
 		{ "frameBody", l_body_attr_frame_body },
+		{ "frameLabel", l_body_attr_frame_label },
 		{ "frameRotating", l_body_attr_frame_rotating },
 		{ 0, 0 }
 	};


### PR DESCRIPTION
Fixes #6312.

There were two problems with binary star systems.  

Firstly, the check to ensure that star frames in binary star systems don't overlap with each other was too conservative, resulting in some child bodies being outside their parent's frame. This confused the code that expects a nice consistent frame hierarchy. The first commit rearranges the radius checks to ensure that frames always encompass their children. The problem seems to only occur in custom binary systems, where the designer might have put planets further out than the procedurally generated code would place them. But now you have a better chance of entering frames correctly in custom binary systems.

The second issue isn't really an issue, but when the player is in a grav point frame, the HUD just doesn't show any frame of reference at all, which can be confusing, even when the frames _are_ working correctly. So the second commit displays the frame label in these cases, to reassure the player that everything is still okay. Actually having a full velocity and position readout would require deeper changes to the code, which assumes that there is no _Body_ object for gravpoints, while all the existing HUD display properties refer to _Body_ attributes. So this is kind of a patch, but a relatively safe one.

Note that for #6312 specifically, since the system body tree is stored in the save file, if you load that game after this fix is applied you will still see the problem. You have to jump out of the system and then back in before you can crash into Eternal.



