### PR TITLE
Fix moon orbit generation

### DIFF
--- a/src/fixed.h
+++ b/src/fixed.h
@@ -13,6 +13,7 @@ class fixedf {
 public:
 	static const int FRAC = FRAC_BITS;
 	static const Uint64 MASK = (Uint64(1UL) << FRAC_BITS) - 1;
+	static const fixedf PI;
 
 	fixedf() :
 		v(0) {}
@@ -250,5 +251,11 @@ public:
 };
 
 typedef fixedf<32> fixed;
+
+template<>
+constexpr fixed fixed::PI = fixed(13493037705LL);
+
+template<>
+constexpr fixedf<48> fixedf<48>::PI = fixedf<48>(884279719003555LL);
 
 #endif /* _FIXED_H */

--- a/src/fixed.h
+++ b/src/fixed.h
@@ -224,14 +224,26 @@ public:
 		return (fixedf(root));
 	}
 
-	static fixedf CubeRootOf(const fixedf &a)
+	static fixedf CubeRootOf(const fixedf &a_orig)
 	{
+		fixedf a = a_orig;
+		if (a == fixedf(0, 1)) return fixedf(0, 1);
+
+		// In order to prevent over or underflow in the (x * x) calculation
+		// below, we first scale the parameter into a reasonable range
+		int k = 0;
+		while (a.v > (Sint64(1) << 60)) { a >>= 3; k++; }
+		while (a < fixedf(1,1024)) { a <<= 3; k--; }
+
 		/* NR method. XXX very bad initial estimate (we get there in
 		 * the end... XXX */
 		fixedf x = a;
 		for (int i = 0; i < 48; i++)
 			x = fixedf(1, 3) * ((a / (x * x)) + 2 * x);
-		return x;
+
+		// We've got the cube root of the normalized parameter, now
+		// un-scale it back to get the real answer
+		return k >= 0 ? x << k : x >> -k;
 	}
 
 	Sint64 v;

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -1106,7 +1106,30 @@ void CustomSystemsDatabase::RunLuaSystemSanityChecks(CustomSystem *csys)
 			body->bodyData.m_volatileGas = rand.NormFixed(fixed(1050, 1000), fixed(8000, 1000)).Abs();
 			body->bodyData.m_atmosOxidizing = rand.NormFixed(fixed(0, 1), fixed(300, 1000)).Abs();
 		}
+	}
 
+	// This loop runs after the one above, to ensure that system bodies are all set up first.
+	// Now we ensure that any binary star systems have orbits set correctly.
+	for (CustomSystemBody *body : csys->bodies) {
+
+		if ((body->bodyData.m_type == SystemBody::TYPE_GRAVPOINT) && (body->children.size() == 2)) {
+			SystemBodyData *star_A = &body->children[0]->bodyData;
+			SystemBodyData *star_B = &body->children[1]->bodyData;
+
+			if ((star_A->m_type >= SystemBodyType::TYPE_STAR_MIN) && (star_A->m_type <= SystemBodyType::TYPE_STAR_MAX) &&
+				(star_B->m_type >= SystemBodyType::TYPE_STAR_MIN) && (star_B->m_type <= SystemBodyType::TYPE_STAR_MAX)) {
+
+				// This is a binary star system. Ensure that the stars are opposite each other in their orbits
+
+				star_B->m_orbitalOffset = star_A->m_orbitalOffset;
+				star_B->m_inclination = star_A->m_inclination;
+				star_B->m_argOfPeriapsis = star_A->m_argOfPeriapsis;
+
+				star_B->m_orbitalPhaseAtStart = star_A->m_orbitalPhaseAtStart + FIXED_PI;
+				if (star_B->m_orbitalPhaseAtStart > fixed(2, 1) * FIXED_PI)
+					star_B->m_orbitalPhaseAtStart -= fixed(2, 1) * FIXED_PI;
+			}
+		}
 	}
 }
 

--- a/src/galaxy/CustomSystem.cpp
+++ b/src/galaxy/CustomSystem.cpp
@@ -1125,9 +1125,9 @@ void CustomSystemsDatabase::RunLuaSystemSanityChecks(CustomSystem *csys)
 				star_B->m_inclination = star_A->m_inclination;
 				star_B->m_argOfPeriapsis = star_A->m_argOfPeriapsis;
 
-				star_B->m_orbitalPhaseAtStart = star_A->m_orbitalPhaseAtStart + FIXED_PI;
-				if (star_B->m_orbitalPhaseAtStart > fixed(2, 1) * FIXED_PI)
-					star_B->m_orbitalPhaseAtStart -= fixed(2, 1) * FIXED_PI;
+				star_B->m_orbitalPhaseAtStart = star_A->m_orbitalPhaseAtStart + fixed::PI;
+				if (star_B->m_orbitalPhaseAtStart > fixed(2, 1) * fixed::PI)
+					star_B->m_orbitalPhaseAtStart -= fixed(2, 1) * fixed::PI;
 			}
 		}
 	}

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -26,7 +26,6 @@ static const fixed SAFE_DIST_FROM_BINARY = fixed(5, 1);
 // very crudely
 static const fixed AU_SOL_RADIUS = fixed(305, 65536);
 static const fixed AU_EARTH_RADIUS = fixed(3, 65536); // XXX Duplication from StarSystem.cpp
-static const fixed FIXED_PI = fixed(103993, 33102);	  // XXX Duplication from StarSystem.cpp
 static const double CELSIUS = 273.15;
 static const fixed ONEEUMASS = fixed::FromDouble(1);
 static const fixed TWOHUNDREDEUMASSES = fixed::FromDouble(200.0);
@@ -1148,19 +1147,19 @@ SystemBody *StarSystemRandomGenerator::MakeBodyInOrbitSlice(Random &rand, StarSy
 	planet->m_rotationPeriod = fixed(rand.Int32(1, 200), 24);
 
 	// longitude of ascending node
-	planet->m_orbitalOffset = rand.Fixed() * 2 * FIXED_PI;
+	planet->m_orbitalOffset = rand.Fixed() * 2 * fixed::PI;
 	// inclination in the hemisphere above the equator, low probability of high-inclination orbits
 	fixed incl_scale = rand.Fixed() * fixed(666, 1000);
-	planet->m_inclination = rand.NormFixed().Abs() * incl_scale * FIXED_PI * fixed(1, 2);
+	planet->m_inclination = rand.NormFixed().Abs() * incl_scale * fixed::PI * fixed(1, 2);
 	// argument of periapsis, interval -PI .. PI
-	planet->m_argOfPeriapsis = rand.NormFixed() * FIXED_PI;
+	planet->m_argOfPeriapsis = rand.NormFixed() * fixed::PI;
 
 	// rare chance of reversed orbit
 	if (rand.Fixed() < fixed(1, 20))
-		planet->m_inclination = FIXED_PI - planet->m_inclination;
+		planet->m_inclination = fixed::PI - planet->m_inclination;
 
 	// true anomaly as rotation beyond periapsis
-	planet->m_orbitalPhaseAtStart = rand.Fixed() * 2 * FIXED_PI;
+	planet->m_orbitalPhaseAtStart = rand.Fixed() * 2 * fixed::PI;
 
 	planet->SetOrbitFromParameters();
 	planet->SetAtmFromParameters();
@@ -1272,10 +1271,10 @@ void StarSystemRandomGenerator::MakeBinaryPair(SystemBody *a, SystemBody *b, fix
 	b->m_orbit.SetPlane(matrix3x3d::RotateY(rotY - M_PI) * matrix3x3d::RotateX(rotX));
 
 	// store orbit parameters for later use to be accessible in other way than by rotMatrix
-	b->m_orbitalPhaseAtStart = b->m_orbitalPhaseAtStart + FIXED_PI;
-	b->m_orbitalPhaseAtStart = b->m_orbitalPhaseAtStart > 2 * FIXED_PI ? b->m_orbitalPhaseAtStart - 2 * FIXED_PI : b->m_orbitalPhaseAtStart;
-	a->m_orbitalPhaseAtStart = a->m_orbitalPhaseAtStart > 2 * FIXED_PI ? a->m_orbitalPhaseAtStart - 2 * FIXED_PI : a->m_orbitalPhaseAtStart;
-	a->m_orbitalPhaseAtStart = a->m_orbitalPhaseAtStart < 0 ? a->m_orbitalPhaseAtStart + 2 * FIXED_PI : a->m_orbitalPhaseAtStart;
+	b->m_orbitalPhaseAtStart = b->m_orbitalPhaseAtStart + fixed::PI;
+	b->m_orbitalPhaseAtStart = b->m_orbitalPhaseAtStart > 2 * fixed::PI ? b->m_orbitalPhaseAtStart - 2 * fixed::PI : b->m_orbitalPhaseAtStart;
+	a->m_orbitalPhaseAtStart = a->m_orbitalPhaseAtStart > 2 * fixed::PI ? a->m_orbitalPhaseAtStart - 2 * fixed::PI : a->m_orbitalPhaseAtStart;
+	a->m_orbitalPhaseAtStart = a->m_orbitalPhaseAtStart < 0 ? a->m_orbitalPhaseAtStart + 2 * fixed::PI : a->m_orbitalPhaseAtStart;
 	b->m_orbitalOffset = fixed(int(round(rotY * 10000)), 10000);
 	a->m_orbitalOffset = fixed(int(round(rotY * 10000)), 10000);
 
@@ -1451,8 +1450,8 @@ void PopulateStarSystemGenerator::PositionSettlementOnPlanet(SystemBody *sbody, 
 
 	// store latitude and longitude to equivalent orbital parameters to
 	// be accessible easier
-	sbody->m_inclination = latitude * FIXED_PI * fixed(1, 2);
-	sbody->m_orbitalOffset = longitude * FIXED_PI * 2;
+	sbody->m_inclination = latitude * fixed::PI * fixed(1, 2);
+	sbody->m_orbitalOffset = longitude * fixed::PI * 2;
 
 	sbody->SetOrbitFromParameters();
 }
@@ -1715,12 +1714,12 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody *sbody, StarSys
 				shells[1] = innerOrbit + ((orbMaxS - innerOrbit) * fixed(1, 2)); // med
 				shells[2] = orbMaxS;											 // high
 
-				shellIncl[0] = rand.NormFixed() * FIXED_PI;
-				shellIncl[1] = rand.NormFixed() * FIXED_PI;
-				shellIncl[2] = rand.NormFixed() * FIXED_PI;
+				shellIncl[0] = rand.NormFixed() * fixed::PI;
+				shellIncl[1] = rand.NormFixed() * fixed::PI;
+				shellIncl[2] = rand.NormFixed() * fixed::PI;
 			} else {
 				shells[0] = shells[1] = shells[2] = innerOrbit;
-				shellIncl[0] = shellIncl[1] = shellIncl[2] = rand.NormFixed() * FIXED_PI;
+				shellIncl[0] = shellIncl[1] = shellIncl[2] = rand.NormFixed() * fixed::PI;
 			}
 
 			Uint32 orbitIdx = 0;
@@ -1752,9 +1751,9 @@ void PopulateStarSystemGenerator::PopulateAddStations(SystemBody *sbody, StarSys
 				// slightly random min/max orbital distance
 				sp->m_eccentricity = rand.NormFixed().Abs() * fixed(1, 8);
 				// perturb the orbital plane to avoid all stations falling in line with each other
-				sp->m_inclination = currOrbitIncl + rand.NormFixed() * fixed(1, 4) * FIXED_PI;
+				sp->m_inclination = currOrbitIncl + rand.NormFixed() * fixed(1, 4) * fixed::PI;
 				// station spacing around the primary body
-				sp->m_argOfPeriapsis = rand.Fixed() * FIXED_PI * 2;
+				sp->m_argOfPeriapsis = rand.Fixed() * fixed::PI * 2;
 				// TODO: no axial tilt for stations / axial tilt in general is strangely modeled
 				sp->m_axialTilt = fixed();
 

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -385,8 +385,9 @@ fixedf<48> StarSystemLegacyGeneratorBase::CalcHillRadius(SystemBody *sbody) cons
 		fixedp a = sbody->GetSemiMajorAxisAsFixed();
 		fixedp e = sbody->GetEccentricityAsFixed();
 		fixedp pe = a * (fixedp(1, 1) - e); // periapsis in higher precision
+		fixedp mass_ratio = sbody->GetMassAsFixed() / (fixed(3, 1) * mprimary);
 
-		return pe * fixedp::CubeRootOf(sbody->GetMassAsFixed() / (fixed(3, 1) * mprimary));
+		return pe * fixedp::CubeRootOf(mass_ratio);
 
 		//fixed hr = semiMajorAxis*(fixed(1,1) - eccentricity) *
 		//  fixedcuberoot(mass / (3*mprimary));
@@ -976,7 +977,6 @@ fixed StarSystemRandomGenerator::CalcBodySatelliteShellDensity(Random &rand, Sys
 		// gameplay purposes instead of fully representing reality
 		fixedf<48> hillSphereRad = CalcHillRadius(primary) * fixedf<48>(1, 4);
 		discMax = std::min(discMax, fixed(hillSphereRad));
-
 		return get_disc_density(primary, discMin, discMax, fixed(1, 500));
 	}
 }

--- a/src/galaxy/StarSystemGenerator.cpp
+++ b/src/galaxy/StarSystemGenerator.cpp
@@ -1129,6 +1129,9 @@ SystemBody *StarSystemRandomGenerator::MakeBodyInOrbitSlice(Random &rand, StarSy
 
 	mass *= discDensity;
 
+	if (mass == fixed(0, 1))
+		return nullptr;	// We used our best math, but this body just turned out too small, sorry.
+
 	if (mass.v < 0) { // hack around overflow
 		Output("WARNING: planetary mass has overflowed! (child %d of %s)\n", primary->GetNumChildren(), primary->GetName().c_str());
 		mass = fixed(Sint64(0x7fFFffFFffFFffFFull));


### PR DESCRIPTION
Fixes #5885. 

The procedural generation was going wrong when adding moons to planets whose masses were small compared to their star's mass, because calculating the Hill Radius involves a cube root of the mass ratio, and the fixed point algorithm couldn't handle it. The system generator therefore calculated a far too large orbital slice, and filled it with moons at huge orbits. Doing a bit of parameter scaling fixes this issue, but results in different numbers of moons being generated, and hence probably qualifies for a save bump.

The second commit is to fix binary star orbits in custom systems. The procedural generation appears to get binary star systems correct, but if they are added in the system designer, or by hand, parameters can be left to random chance, and then the stars don't line up in their orbits correctly. Binary stars should always be on opposite sides of the barycentre, i.e. at the furthest possible distance allowed by their orbits, such that a line drawn between the two stars passes through the barycentre. Without this fix, 55 Cancri (for example) has both stars on the same side of the barycentre, which is gravitationally impossible.

While the second commit isn't save-breaking in a technical sense, it could lead to players being stranded if the star they are heading towards gets re-oriented to a different point in the orbit, so it seems like a good idea to lump it in with other save-breaking changes.

