### PR TITLE
Make scanning missions survive hyperspace jumps

### DIFF
--- a/data/modules/Scout/ScanManager.lua
+++ b/data/modules/Scout/ScanManager.lua
@@ -669,4 +669,13 @@ Event.Register("onShipTypeChanged", function(ship)
 	end
 end)
 
+---@param ship Ship
+Event.Register("onLeaveSystem", function(ship)
+	local scanMgr = ship:GetComponent("ScanManager")
+
+	if scanMgr and scanMgr:GetActiveScan() then
+		scanMgr:ClearActiveScan()
+	end
+end)
+
 return ScanManager


### PR DESCRIPTION
Fixes #6304. 

The scan manager code was not expecting the player to ever jump out mid-scan, so doing so triggered an assert() which then caused the module manager to disable that module. Adding a hook for the _onLeaveSystem_ event, and then clearing any active scan in progress, prevents the assert from firing and thereby saves the ScanManager module from certain death.