### PR TITLE
Fix for station names disappearing

### DIFF
--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -49,8 +49,6 @@ SpaceStation::SpaceStation(const Json &jsonObj, Space *space) :
 	ModelBody(jsonObj, space),
 	m_type(nullptr)
 {
-	GetModel()->SetLabel(GetLabel());
-
 	try {
 		Json spaceStationObj = jsonObj["space_station"];
 
@@ -93,6 +91,8 @@ SpaceStation::SpaceStation(const Json &jsonObj, Space *space) :
 		m_doorAnimationState = spaceStationObj["door_animation_state"];
 
 		InitStation();
+
+		GetModel()->SetLabel(GetLabel());
 
 		m_navLights->LoadFromJson(spaceStationObj);
 	} catch (Json::type_error &) {


### PR DESCRIPTION
Fixes #6289.

The code that sets up space stations has two slightly different variations depending on whether they're being created from a system template (e.g. if you start a new game, or jump into a system), or if you're loading a saved game. In the "from template" version, SetLabel() is called after InitStation(), while in the saved game loader, it's the other way around. The problem arises because one of the side effects of InitStation() is to clear the label. So I moved the SetLabel() call to be after InitStation() in the JSON save game loader, so the behaviour is now the same as in the "from system template" path.
