### PR TITLE
Hyperdrive UI and sound

### DIFF
--- a/data/lang/core/en.json
+++ b/data/lang/core/en.json
@@ -601,11 +601,11 @@
   },
   "HYPERSPACE_ARRIVAL_CLOUD": {
     "description": "",
-    "message": "Hyperspace arrival cloud"
+    "message": "Arrival"
   },
   "HYPERSPACE_ARRIVAL_CLOUD_REMNANT": {
     "description": "",
-    "message": "Hyperspace arrival cloud remnant"
+    "message": "Arrival (Remnant)"
   },
   "HYPERSPACE_CLOUDS_DISPLAY_MODE": {
     "description": "Label for hyperspace cloud display modes.",
@@ -629,7 +629,7 @@
   },
   "HYPERSPACE_DEPARTURE_CLOUD": {
     "description": "",
-    "message": "Hyperspace departure cloud"
+    "message": "Departure"
   },
   "HYPERSPACE_JUMP_ABORT": {
     "description": "Mouse over text for hyperdrive button on ship control panel",

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -829,12 +829,29 @@ local function drawEdgeButtons()
 
 end
 
+local function hasActiveExclusiveLeftModule()
+	for _, module in ipairs(leftSidebar.modules) do
+		if module.exclusive and module.active and not module.closing then
+			return true
+		end
+	end
+	return false
+end
+
 ui.registerModule("game", { id = 'map-sector-view', draw = function()
 	player = Game.player
 	if Game.CurrentView() == "SectorView" then
 
 		if shouldRefresh then
 			shouldRefresh = false
+
+			-- Always show system info when entering SectorView, if we can. This helps the player find the hyperspace routing.
+			if not hasActiveExclusiveLeftModule() then
+				infoView.active = true
+				infoView.closing = false
+				infoView.alpha = nil
+			end
+
 			leftSidebar:Refresh()
 			rightSidebar:Refresh()
 			hyperJumpPlanner.updateRouteList()

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -846,7 +846,7 @@ ui.registerModule("game", { id = 'map-sector-view', draw = function()
 			shouldRefresh = false
 
 			-- Always show system info when entering SectorView, if we can. This helps the player find the hyperspace routing.
-			if not hasActiveExclusiveLeftModule() then
+			if not hasActiveExclusiveLeftModule() and not infoView.active then
 				infoView.active = true
 				infoView.closing = false
 				infoView.alpha = nil

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -929,10 +929,12 @@ void Game::EmitPauseState(bool paused)
 		// Notify UI that time is paused.
 		LuaEvent::Queue("onGamePaused");
 		LuaEvent::Queue(PiGui::GetEventQueue(), "onGamePaused");
+		Sound::Pause(1);
 	} else {
 		// Notify the UI that time is running again.
 		LuaEvent::Queue("onGameResumed");
 		LuaEvent::Queue(PiGui::GetEventQueue(), "onGameResumed");
+		Sound::Pause(0);
 	}
 	LuaEvent::Emit();
 }


### PR DESCRIPTION
There are three commits (so far) in this pull request, all fairly minor tweaks:

First is to shorten the UI and HUD text for hyperspace cloud labels. Since all the clouds already have a "wormhole" icon, it's clear what they are, so instead of labelling them as "Hyperspace departure cloud" it can just say "Departure", and so on. With this change, the system map screen looks like this:

<img width="642" height="512" alt="image" src="https://github.com/user-attachments/assets/68902465-54b8-4ab6-acde-c3d05aae804a" />
.

Second change is to pause all sound when the game is paused. It annoyed me that if you had the game paused and clicked on the hyperspace button, the hyperspace charge-up sound would start playing immediately. Then by the time you unpaused the game to start the countdown going, the sound had already finished. So I started adding flags to track the queuing of the sound while paused. Then I realised that the landing gear up/down sounds have the same issue. Rather than adding a whole complicated system to track which sounds should play at what times, just pausing the sound when the game is paused works flawlessly. It has the bonus of pausing all the ambient starport and ship sounds too, as well as the music if you have that active. I prefer it this way because previously it also annoyed me that if I paused the game to take a phone call, all the sounds would keep playing in the background. 

Third change is a direct result of an issue I personally experienced when trying the game for the first time, whereby I couldn't locate the "add jump" button on the sector map screen. I must have closed the info box, or clicked on the economy info which closes it, because it wasn't there. I found the routing window on the right, which _looks_ like it has buttons to add a jump, but actually doesn't. Rather than move the UI around, I've just added some code to always open the info box, if possible, when the sector map screen is opened. This could have saved me during my initial confusion, since one of the things I tried doing was selecting a mission and clicking on "Set destination as navigation target" and then going to the sector map to look for a "jump to here" button. Long term we might want to consider moving the "HyperJump Routing" section of the info box over to the Route Info box on the right, since that seems like a more logical place for it to live. Happy to do that myself if there is consensus agreement. Then I would remove this info box auto opening code too, since it would no longer be necessary.