### PR TITLE
Interim payload implementation

### DIFF
--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -925,7 +925,7 @@
   },
   "UNOCCUPIED_CABIN": {
     "description": "",
-    "message": "Extra Passenger Cabin"
+    "message": "Passenger Cabin"
   },
   "UNOCCUPIED_CABIN_DESCRIPTION": {
     "description": "",

--- a/data/lang/module-searchrescue/en.json
+++ b/data/lang/module-searchrescue/en.json
@@ -737,7 +737,7 @@
   },
   "UNOCCUPIED_PASSENGER_CABINS": {
     "description": "",
-    "message": "unoccupied passenger cabins"
+    "message": "unoccupied passenger berths"
   },
   "WHERE_IS_THE_TARGET": {
     "description": "",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -33,7 +33,7 @@
   },
   "ALL_UP_WEIGHT": {
     "description": "",
-    "message": "All-up weight"
+    "message": "Current total weight"
   },
   "AMOUNT": {
     "description": "",
@@ -125,7 +125,7 @@
   },
   "CABINS": {
     "description": "For passengers",
-    "message": "Cabins"
+    "message": "Berths"
   },
   "CABIN_FREE": {
     "description": "Free capacity for passengers",
@@ -629,11 +629,15 @@
   },
   "EQUIPMENT_CAPACITY": {
     "description": "The equipment capacity of a ship",
-    "message": "Equipment Capacity"
+    "message": "Equipment capacity"
   },
   "EQUIPMENT_MARKET": {
     "description": "",
     "message": "Equipment Market"
+  },
+  "EQUIPMENT_USED": {
+    "description": "",
+    "message": "Equipment space used"
   },
   "EQUIPPED": {
     "description": "",
@@ -1819,6 +1823,10 @@
     "description": "",
     "message": "Notes:"
   },
+  "NOT_ENOUGH_SPACE_FOR_EQUIPMENT": {
+    "description": "",
+    "message": "Not enough space to install this equipment"
+  },
   "NOTORIETY": {
     "description": "Character parameter",
     "message": "Notoriety"
@@ -1863,21 +1871,13 @@
     "description": "",
     "message": "{range} light years ({maxRange} max)"
   },
-  "N_OCCUPIED_PASSENGER_CABINS": {
-    "description": "",
-    "message": "{quantity} Occupied Passenger Cabins"
-  },
   "N_SHIELD_GENERATORS": {
     "description": "",
     "message": "{quantity} Shield Generators"
   },
-  "N_UNOCCUPIED_PASSENGER_CABINS": {
-    "description": "",
-    "message": "{quantity} Unoccupied Passenger Cabins"
-  },
   "OCCUPIED_PASSENGER_CABINS": {
     "description": "",
-    "message": "Occupied Passenger Cabins"
+    "message": "Occupied passenger berths"
   },
   "OFF": {
     "description": "",
@@ -1969,7 +1969,7 @@
   },
   "PASSENGER_CABIN_CAPACITY": {
     "description": "Entry for ship info",
-    "message": "Passenger cabin capacity"
+    "message": "Max passenger capacity"
   },
   "PASTE": {
     "description": "As for clipboard",
@@ -1990,6 +1990,14 @@
   "PAY_FINE_OF_N": {
     "description": "",
     "message": "Pay fine of {amount}"
+  },
+  "PAYLOAD": {
+    "description": "Carry mass (short label)",
+    "message": "Payload"
+  },
+  "PAYLOAD_WEIGHT": {
+    "description": "Carry mass (long label)",
+    "message": "Payload weight"
   },
   "PENDING_RETURN": {
     "description": "Status if the mission has not yet been fully completed",
@@ -2745,7 +2753,7 @@
   },
   "UNOCCUPIED_PASSENGER_CABINS": {
     "description": "",
-    "message": "Unoccupied Passenger Cabins"
+    "message": "Unoccupied passenger berths"
   },
   "UNPROFITABLE_TRADE": {
     "description": "Indicates an unprofitable trade route.",
@@ -2764,8 +2772,8 @@
     "message": "Up acceleration"
   },
   "USED": {
-    "description": "",
-    "message": "Used"
+    "description": "Usually shown with FREE as a pair, e.g. 4t used / 7t free",
+    "message": "used"
   },
   "VERY_HIGH": {
     "description": "Game settings option: graphic resolution",

--- a/data/libs/CargoManager.lua
+++ b/data/libs/CargoManager.lua
@@ -63,7 +63,7 @@ end
 --
 -- Returns the available amount of cargo space currently present on the vessel.
 function CargoManager:GetFreeSpace()
-	return self:GetTotalSpace() - self.usedCargoSpace
+	return self.ship:GetPayloadFree()
 end
 
 -- Method: GetUsedSpace
@@ -99,7 +99,7 @@ function CargoManager:AddCommodity(type, count)
 	-- TODO: use a cargo volume metric with variable mass instead of fixed 1t == 1m^3
 	local required_space = (type.mass or 1) * (count or 1)
 
-	if self:GetFreeSpace() < required_space then
+	if self.ship:GetPayloadFree() < required_space then
 		return false
 	end
 

--- a/data/libs/EquipSet.lua
+++ b/data/libs/EquipSet.lua
@@ -421,10 +421,15 @@ end
 function EquipSet:CanInstallInSlot(slotHandle, equipment)
 	local equipped = self:GetItemInSlot(slotHandle)
 	local freeVolume = self:GetFreeVolume() + (equipped and equipped.volume or 0)
+	local freeMass = self.ship:GetPayloadFree()
+	local newMass = self:GetEquipPayloadMass(equipment)
+	local oldMass = equipped and self:GetEquipPayloadMass(equipped) or 0.0
+	local massDelta = newMass - oldMass
 
 	return (equipment.slot or false)
 		and EquipSet.CompatibleWithSlot(equipment, slotHandle)
 		and (freeVolume >= equipment.volume)
+		and (freeMass >= massDelta)
 end
 
 -- Method: CanInstallLoose
@@ -435,6 +440,7 @@ end
 function EquipSet:CanInstallLoose(equipment)
 	return not equipment.slot
 		and self:GetFreeVolume() >= equipment.volume
+		and self.ship:GetPayloadFree() >= self:GetEquipPayloadMass(equipment)
 end
 
 -- Method: AddListener
@@ -632,6 +638,19 @@ function EquipSet:_RemoveInternal(equipment)
 	end
 
 	self.ship:UpdateEquipStats()
+end
+
+-- Payload mass for an equipment item.
+-- Hyperdrives are counted at full reservoir equivalent.
+---@param equip EquipType
+---@return number
+function EquipSet:GetEquipPayloadMass(equip)
+	local mass = equip.mass or 0.0
+	-- Hyperdrive instances expose both GetMaxFuel() and storedFuel
+	if equip.GetMaxFuel and equip.storedFuel then
+		mass = mass + (equip:GetMaxFuel() - equip.storedFuel)
+	end
+	return mass
 end
 
 -- Populate the slot cache

--- a/data/libs/HullConfig.lua
+++ b/data/libs/HullConfig.lua
@@ -3,6 +3,8 @@
 
 local ShipDef = require 'ShipDef'
 local Serializer = require 'Serializer'
+local Equipment = require 'Equipment'
+require 'modules.Equipment.Internal'
 
 local utils = require 'utils'
 
@@ -44,6 +46,7 @@ local HullConfig = utils.proto("HullConfig")
 HullConfig.id = ""
 HullConfig.path = ""
 HullConfig.equipCapacity = 0
+HullConfig.maxPayload = 0
 
 -- Default slot config for a new shipdef
 -- Individual shipdefs can redefine slots or remove them by setting the slot to 'false'
@@ -63,6 +66,68 @@ Serializer:RegisterClass("HullConfig.Slot", Slot)
 
 --==============================================================================
 
+-- Function: AddAutoCabinSlots
+--
+-- Instead of meticulously filling out all ship definitions with cabin slots
+-- add them automatically according to the payload capacity of the ship.
+local function AddAutoCabinSlots(newShip, def)
+
+	-- Remove any existing cabin slots that don't have unique keys.
+	for name, slot in pairs(newShip.slots) do
+		if slot.type == "cabin" then
+			if slot.i18n_key == nul then
+				newShip.slots[name] = nil
+			end
+		end
+	end
+
+	local space = def.cargo or 0
+	local biggest = 0
+
+	-- Start with the largest possible cabin size and work down
+	for size = 4, 1, -1 do
+
+		local eq = Equipment.new["misc.cabin_s" .. tostring(size)]
+		local slot_mass = eq and eq.mass or math.huge
+
+		local slot_target = math.floor(space / slot_mass)
+
+		if size == biggest - 1 then
+			-- Whatever the biggest size cabin we can add is, we also want to add
+			-- at least one of the next size down, to ensure that the user always
+			-- has some extra cabin options to play with
+			if slot_target == 0 then
+				slot_target = 1
+			end
+		end
+
+		local slot_count = 0
+		for _, slot in pairs(newShip.slots) do
+			if slot.type == "cabin" and slot.size == size then
+				slot_count = slot_count + 1
+			end
+		end
+
+		local slot_need = math.max(0, slot_target - slot_count)
+		for i = 1, slot_need do
+			local name = string.format("auto_cabin_s%d_%02d", size, i)
+			newShip.slots[name] = Slot:clone {
+				id = name,
+				type = "cabin",
+				size = size,
+				size_min = 1,
+				i18n_key = "SLOT_CABIN",
+			}
+		end
+
+		if slot_target > 0 and biggest == 0 then
+			biggest = size
+		end
+
+		space = space - (slot_mass * slot_target)
+	end
+end
+
 local function CreateShipConfig(def)
 	local newShip = HullConfig:clone()
 	Serializer:RegisterPersistent("ShipDef." .. def.id, newShip)
@@ -70,6 +135,7 @@ local function CreateShipConfig(def)
 	newShip.id = def.id
 	newShip.path = def.path
 	newShip.equipCapacity = def.equipCapacity
+	newShip.maxPayload = def.cargo
 
 	table.merge(newShip.slots, def.raw.equipment_slots or {}, function(name, slotDef)
 		if slotDef == false then return name, nil end
@@ -82,6 +148,8 @@ local function CreateShipConfig(def)
 	for name, slot in pairs(newShip.slots) do
 		slot.id = name
 	end
+
+	AddAutoCabinSlots(newShip, def)
 
 	return newShip
 end

--- a/data/libs/Passengers.lua
+++ b/data/libs/Passengers.lua
@@ -162,25 +162,33 @@ end
 ---@return integer
 function Passengers.GetMaxPassengersForHull(hull, maxMass)
 	local numPassengers = 0
-	local availMass = maxMass or math.huge
+	local availMass = maxMass or hull.maxPayload or math.huge
 
 	---@type Equipment.CabinType
 	local cabins = utils.to_array(Equipment.new, function(equip)
 		return equip:IsA('Equipment.CabinType')
 	end)
 
+	-- Get a list of the cabin slots available to this hull type
+	local cabinSlots = utils.to_array(hull.slots, function(slot)
+		return EquipSet.SlotTypeMatches(slot.type, "cabin") and slot or nil
+	end)
+
+	-- Sort the cabin slots in order of largest size to smallest
+	table.sort(cabinSlots, function(a, b)
+		return (a.size or 0) > (b.size or 0)
+	end)
+
 	-- Compute the theoretical maximum number of passengers
-	for _, slot in pairs(hull.slots) do
-		if EquipSet.SlotTypeMatches(slot.type, "cabin") then
-			local cabin, passengers = utils.best_score(cabins, function(_, equip)
-				return EquipSet.CompatibleWithSlot(equip, slot)
-					and (availMass - equip.mass > 0)
-					and equip.capabilities.cabin or nil
-			end)
-			if cabin then
-				numPassengers = numPassengers + passengers
-				availMass = availMass - cabin.mass
-			end
+	for _, slot in ipairs(cabinSlots) do
+		local cabin, passengers = utils.best_score(cabins, function(_, equip)
+			return EquipSet.CompatibleWithSlot(equip, slot)
+				and (availMass - equip.mass >= 0)
+				and equip.capabilities.cabin or nil
+		end)
+		if cabin then
+			numPassengers = numPassengers + passengers
+			availMass = availMass - cabin.mass
 		end
 	end
 

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -94,6 +94,57 @@ function Ship:GetInstalledHyperdrive()
 	return drives[1]
 end
 
+-- Method: GetPayloadMax
+--
+-- Returns the ship's maximum payload capacity in tons.
+-- Currently this maps directly to ShipDef.cargo, since that's the only mass limit for ships.
+-- It is presented to the player as "this is the max equipment and cargo mass you can add to a ship.
+--
+---@return number
+function Ship:GetPayloadMax()
+	local def = ShipDef[self.shipId]
+	return (def and def.cargo) or 0
+end
+
+-- Method: GetEquipmentMass
+--
+-- Returns installed equipment mass in tons, assuming hyperdrives are always full 
+--
+---@return number
+function Ship:GetEquipmentMass()
+	local equipSet = self:GetComponent("EquipSet")
+	local total = 0.0
+	for _, equip in pairs(equipSet:GetInstalledEquipment()) do
+		local mass = equip.mass or 0.0
+		-- Hyperdrive mass is dynamic (includes storedFuel).
+		-- For payload calculation we use "full reservoir" mass.
+		if equip.GetMaxFuel and equip.storedFuel then
+			mass = mass + (equip:GetMaxFuel() - equip.storedFuel)
+		end
+		total = total + mass
+	end
+	return total
+end
+
+-- Method: GetPayloadUsed
+--
+-- Returns total payload currently used (cargo + equipment), in tons.
+--
+---@return number
+function Ship:GetPayloadUsed()
+	local cargoMgr = self:GetComponent("CargoManager")
+	local cargoMass = cargoMgr:GetUsedSpace() -- currently 1 unit == 1 ton gameplay-wise
+	return cargoMass + self:GetEquipmentMass()
+end
+
+-- Method: GetPayloadFree
+--
+-- Returns remaining payload capacity in tons.
+--
+---@return number
+function Ship:GetPayloadFree()
+	return math.max(0, self:GetPayloadMax() - self:GetPayloadUsed())
+end
 
 --
 -- Method: IsHyperjumpAllowed

--- a/data/modules/Equipment/Internal.lua
+++ b/data/modules/Equipment/Internal.lua
@@ -467,7 +467,7 @@ Equipment.Register("misc.cabin_s1", CabinType.New {
 	l10n_key="UNOCCUPIED_CABIN",
 	price=1350, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=1 },
-	mass=1, volume=0, capabilities={ cabin=1 },
+	mass=4, volume=0, capabilities={ cabin=1 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -475,7 +475,7 @@ Equipment.Register("misc.cabin_s2", CabinType.New {
 	l10n_key="UNOCCUPIED_CABIN",
 	price=3550, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=2 },
-	mass=4, volume=0, capabilities={ cabin=3 },
+	mass=11, volume=0, capabilities={ cabin=3 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -483,7 +483,7 @@ Equipment.Register("misc.cabin_s3", CabinType.New {
 	l10n_key="UNOCCUPIED_CABIN",
 	price=6550, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=3 },
-	mass=8, volume=0, capabilities={ cabin=8 },
+	mass=24, volume=0, capabilities={ cabin=8 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -491,15 +491,7 @@ Equipment.Register("misc.cabin_s4", CabinType.New {
 	l10n_key="UNOCCUPIED_CABIN",
 	price=13550, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=4 },
-	mass=16, volume=0, capabilities={ cabin=22 },
-	icon_name="equip_cabin_empty"
-})
-
-Equipment.Register("misc.cabin_s5", CabinType.New {
-	l10n_key="UNOCCUPIED_CABIN",
-	price=35150, purchasable=true, tech_level=1,
-	slot = { type="cabin.passenger.basic", size=5 },
-	mass=36, volume=0, capabilities={ cabin=60 },
+	mass=56, volume=0, capabilities={ cabin=22 },
 	icon_name="equip_cabin_empty"
 })
 

--- a/data/modules/Equipment/Stats.lua
+++ b/data/modules/Equipment/Stats.lua
@@ -29,10 +29,15 @@ function EquipType:GetDetailedStats()
 	local equipHealth = 1
 	local powerDraw = 0
 
+	-- If this is a hyperdrive the mass should not include the fuel tank, because fuel reservoir
+	-- size is listed separately later, but the mass property includes stored fuel already, so
+	-- we have to subtract it out before displaying the mass
+	local bare_mass = self.mass - (self.storedFuel or 0)
+
 	local stats = {
 		{ le.EQUIPMENT_INTEGRITY, icons.repairs, equipHealth, format_integrity },
 		{ le.STAT_VOLUME, icons.square, self.volume, ui.Format.Volume, true },
-		{ le.STAT_WEIGHT, icons.hull, self.mass, format_mass, true },
+		{ le.STAT_WEIGHT, icons.hull, bare_mass, format_mass, true },
 		{ le.STAT_POWER_DRAW, icons.ecm, powerDraw, format_power, true }
 	}
 

--- a/data/modules/MissionUtils/ShipBuilder.lua
+++ b/data/modules/MissionUtils/ShipBuilder.lua
@@ -139,6 +139,7 @@ ShipPlan.config = nil
 ShipPlan.shipId = ""
 ShipPlan.label = ""
 ShipPlan.freeVolume = 0
+ShipPlan.freeMass = 0
 ShipPlan.equipMass = 0
 ShipPlan.threat = 0
 ShipPlan.freeThreat = 0
@@ -166,6 +167,7 @@ function ShipPlan:SetConfig(shipConfig)
 	self.config = shipConfig
 	self.shipId = shipConfig.id
 	self.freeVolume = shipConfig.equipCapacity
+	self.freeMass = shipConfig.maxPayload
 
 	for _, slot in pairs(shipConfig.slots) do
 		table.insert(self.slots, slot)
@@ -182,6 +184,12 @@ function ShipPlan:AddSlots(baseId, slots)
 	end
 
 	self:SortSlots()
+end
+
+-- Can we fit this piece of equipment into the free volume and mass of the ship?
+function ShipPlan:CanFitEquip(equip)
+	return self.freeVolume >= (equip.volume or 0)
+		and self.freeMass >= (equip.mass or 0)
 end
 
 -- Add the given equipment object to the plan, making an instance as needed
@@ -201,6 +209,7 @@ function ShipPlan:AddEquipToPlan(equip, slot, threat)
 	end
 
 	self.freeVolume = self.freeVolume - equip.volume
+	self.freeMass = self.freeMass - equip.mass
 	self.equipMass = self.equipMass + equip.mass
 	self.threat = self.threat + (threat or 0)
 	self.freeThreat = self.freeThreat - (threat or 0)
@@ -365,8 +374,8 @@ function ShipBuilder.ApplyEquipmentRule(shipPlan, rule, rand, hullThreat)
 					rule.apply(inst)
 				end
 
-				if shipPlan.freeVolume >= inst.volume then
-					shipPlan:AddEquipToPlan(equip, slot, threat)
+				if shipPlan:CanFitEquip(inst) then
+					shipPlan:AddEquipToPlan(inst, slot, threat)
 				end
 
 				numInstalled = numInstalled + 1
@@ -447,7 +456,7 @@ function ShipBuilder.ApplyEquipmentRule(shipPlan, rule, rand, hullThreat)
 				rule.apply(inst)
 			end
 
-			return shipPlan.freeVolume >= inst.volume and inst or nil
+			return shipPlan:CanFitEquip(inst) and inst or nil
 		end)
 
 		-- print("Slot " .. slot.id .. " - compatible: " .. #compatible)
@@ -672,7 +681,7 @@ function ShipBuilder.MakePlan(template, shipConfig, threat)
 
 				local equipThreat = ShipBuilder.ComputeEquipThreatFactor(inst, hullThreat)
 
-				if shipPlan.freeVolume >= inst.volume and shipPlan.freeThreat >= equipThreat then
+				if shipPlan:CanFitEquip(inst) and shipPlan.freeThreat >= equipThreat then
 					shipPlan:AddEquipToPlan(inst)
 				end
 			end

--- a/data/pigui/libs/commodity-market.lua
+++ b/data/pigui/libs/commodity-market.lua
@@ -268,7 +268,7 @@ function CommodityMarketWidget:ChangeTradeAmount(delta)
 	self.tradeText = ''
 	if self.tradeModeBuy then
 		-- TODO: use a volume-based metric rather than a mass-based metric
-		local playerfreecargo = self.cargoMgr:GetFreeSpace()
+		local playerfreecargo = math.floor(self.cargoMgr:GetFreeSpace())
 
 		if tradecost > playerCash then
 			wantamount =  math.min(wantamount, math.floor(playerCash / price))
@@ -305,7 +305,7 @@ end
 function CommodityMarketWidget:DoBuy()
 	local price = self.funcs.getBuyPrice(self, self.selectedItem)
 	local stock = self.funcs.getStock(self, self.selectedItem)
-	local playerfreecargo = self.cargoMgr:GetFreeSpace()
+	local playerfreecargo = math.floor(self.cargoMgr:GetFreeSpace())
 	local orderAmount = price * self.tradeAmount
 
 	--check cash (should never happen since trade amount buttons wont let it happen)

--- a/data/pigui/libs/equipment-outfitter.lua
+++ b/data/pigui/libs/equipment-outfitter.lua
@@ -135,8 +135,10 @@ function EquipCardUnavailable:tooltipContents(data, isSelected)
 	ui.withStyleColors({ Text = self.textColor }, function()
 		ui.withFont(pionillium.details, function()
 
-			if not data.canInstall then
+			if not data.isCompatible then
 				ui.textWrapped(l.NOT_SUPPORTED_ON_THIS_SHIP % { equipment = data.name } .. ".")
+			elseif not data.canInstall then
+				ui.textWrapped(l.NOT_ENOUGH_SPACE_FOR_EQUIPMENT)
 			elseif not data.canReplace then
 				ui.textWrapped(l.CANNOT_SELL_NONEMPTY_EQUIP)
 			elseif data.outOfStock then
@@ -320,8 +322,11 @@ function Outfitter:buildEquipmentList()
 		self:modifyEquipmentStats(data)
 
 		if self.filterSlot then
-			data.canInstall = equipSet:CanInstallInSlot(self.filterSlot, equip)
+			data.isCompatible = EquipSet.CompatibleWithSlot(equip, self.filterSlot)
+			data.canInstall = data.isCompatible and equipSet:CanInstallInSlot(self.filterSlot, equip)
 		else
+			-- For loose install, "compatibility" means "is slotless equipment"
+			data.isCompatible = not equip.slot
 			data.canInstall = equipSet:CanInstallLoose(equip)
 		end
 

--- a/data/pigui/libs/gauge.lua
+++ b/data/pigui/libs/gauge.lua
@@ -5,7 +5,6 @@
 local ui = require 'pigui.baseui'
 local Vector2 = _G.Vector2
 
-local gauge_show_percent = true
 ui.gauge_height = ui.rescaleUI(25, Vector2(1600, 900))
 ui.gauge_width = ui.rescaleUI(275, Vector2(1600, 900))
 
@@ -40,35 +39,38 @@ ui.gauge_width = ui.rescaleUI(275, Vector2(1600, 900))
 --   width       - number, width of the gauge
 --   height      - number, height of the gauge
 --   formatFont  -
---   percentFont -
 --
 -- Returns:
 --
 --   nil
 --
-ui.gauge = function(position, value, unit, format, minimum, maximum, icon, color, tooltip, width, height, formatFont, percentFont)
+ui.gauge = function(position, value, unit, format, minimum, maximum, icon, showPercent, color, tooltip, width, height, formatFont)
 	local percent = math.clamp((value - minimum) / (maximum - minimum), 0, 1)
 	local uiPos = Vector2(position.x, position.y)
 	local gauge_width = width or ui.gauge_width
 	local gauge_height = height or ui.gauge_height
 	ui.withFont(ui.fonts.pionillium.medium.name, ui.fonts.pionillium.medium.size, function()
 		ui.addLine(uiPos, Vector2(uiPos.x + gauge_width, uiPos.y), ui.theme.colors.gaugeBackground, gauge_height, false)
-		if gauge_show_percent then
+		if showPercent then
 			local one_hundred = ui.calcTextSize("100%")
 			uiPos.x = uiPos.x + one_hundred.x * 1.2 -- 1.2 for a bit of slack
-			ui.addStyledText(Vector2(uiPos.x, uiPos.y + gauge_height / 12), ui.anchor.right, ui.anchor.center, string.format("%i%%", percent * 100), ui.theme.colors.reticuleCircle, percentFont or ui.fonts.pionillium.medium, tooltip)
+			ui.addStyledText(Vector2(uiPos.x, uiPos.y + gauge_height / 14), ui.anchor.right, ui.anchor.center, string.format("%i%%", percent * 100), ui.theme.colors.reticuleCircle, ui.fonts.pionillium.medium, tooltip)
 		end
-		uiPos.x = uiPos.x + gauge_height * 1.2
-		ui.addIcon(Vector2(uiPos.x - gauge_height / 2, uiPos.y), icon, ui.theme.colors.reticuleCircle, Vector2(gauge_height * 0.9, gauge_height * 0.9), ui.anchor.center, ui.anchor.center, tooltip)
+		if icon then
+			uiPos.x = uiPos.x + gauge_height * 1.2
+			ui.addIcon(Vector2(uiPos.x - gauge_height / 2, uiPos.y), icon, ui.theme.colors.reticuleCircle, Vector2(gauge_height * 0.9, gauge_height * 0.9), ui.anchor.center, ui.anchor.center, tooltip)
+		end
 		local w = (position.x + gauge_width) - uiPos.x
-		ui.addLine(uiPos, Vector2(uiPos.x + w * percent, uiPos.y), color, gauge_height, false)
+		local bar_length = w * percent
+		ui.addLine(uiPos, Vector2(uiPos.x + bar_length, uiPos.y), color, gauge_height, false)
+		ui.addLine(Vector2(uiPos.x + bar_length, uiPos.y), Vector2(uiPos.x + w, uiPos.y), ui.theme.colors.gaugeBarBackground, gauge_height, false)
 
-		formatFont = formatFont or ui.fonts.pionillium.small
+		formatFont = formatFont or ui.fonts.pionillium.medium
 		if value and format then
-			ui.addFancyText(Vector2(uiPos.x + gauge_height/2, uiPos.y), ui.anchor.left, ui.anchor.center, {
+			ui.addFancyText(Vector2(uiPos.x + gauge_height/2, uiPos.y + gauge_height / 14), ui.anchor.left, ui.anchor.center, {
 				{ text=string.format(format, value), color=ui.theme.colors.reticuleCircle,     font=formatFont, tooltip=tooltip },
 				{ text=unit,                         color=ui.theme.colors.reticuleCircleDark, font=formatFont, tooltip=tooltip }},
-				ui.theme.colors.gaugeBackground)
+				ui.theme.colors.transparent)
 		end
 	end)
 end

--- a/data/pigui/modules/flight-ui/gauges.lua
+++ b/data/pigui/modules/flight-ui/gauges.lua
@@ -52,7 +52,7 @@ function gauges.displayGauges(min, max)
 		local uiPos = ui.getCursorScreenPos() + Vector2(0, ui.gauge_height * 0.5)
 		for i, t in ipairs(drawGauges) do
 			local value, g = t[1], t[2]
-			ui.gauge(uiPos, value, g.unit, g.format, g.min, g.max, g.icon, g.color, g.tooltip)
+			ui.gauge(uiPos, value, g.unit, g.format, g.min, g.max, g.icon, true, g.color, g.tooltip)
 			uiPos = uiPos + Vector2(0, spacing)
 		end
 	end)

--- a/data/pigui/modules/flight-ui/target-scanner.lua
+++ b/data/pigui/modules/flight-ui/target-scanner.lua
@@ -72,11 +72,11 @@ local function displayTargetScannerFor(target, maxWidth)
 	local uiPos = ui.getCursorScreenPos()
 
 	if shield then
-		ui.gauge(uiPos + yOff, shield, nil, nil, 0, 100, icons.shield,
+		ui.gauge(uiPos + yOff, shield, nil, nil, 0, 100, icons.shield, true,
 			colors.gaugeShield, lui.HUD_SHIELD_STRENGTH, maxWidth)
 		yOff.y = yOff.y + spacing
 	end
-	ui.gauge(uiPos + yOff, hull, nil, nil, 0, 100, icons.hull,
+	ui.gauge(uiPos + yOff, hull, nil, nil, 0, 100, icons.hull, true,
 		colors.gaugeHull, lui.HUD_HULL_STRENGTH, maxWidth)
 	yOff.y = yOff.y + spacing
 end

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -5,6 +5,7 @@ local Event = require 'Event'
 local Game = require 'Game'
 local Lang = require 'Lang'
 local ShipDef = require 'ShipDef'
+local HullConfig = require 'HullConfig'
 local InfoView = require 'pigui.views.info-view'
 local Passengers = require 'Passengers'
 local Vector2 = Vector2
@@ -22,13 +23,14 @@ local function shipStats()
 
 	-- Taken directly from ShipInfo.lua.
 	local shipDef       =  ShipDef[player.shipId]
+	local hullConfig    =  HullConfig.GetHullConfig(player.shipId)
 	local shipLabel     =  player:GetLabel()
 	local hyperdrive    =  equipSet:GetInstalledOfType("hyperdrive")[1]
 	local frontWeapon   =  equipSet:GetInstalledOfType("weapon")[1]
 	local rearWeapon    =  equipSet:GetInstalledOfType("weapon")[2]
 	local cabinEmpty    =  Passengers.CountFreeBerths(player)
 	local cabinOccupied =  Passengers.CountOccupiedBerths(player)
-	local cabinMaximum  =  cabinEmpty + cabinOccupied
+	local cabinMaximum  =  Passengers.GetMaxPassengersForHull(hullConfig)
 
 	hyperdrive =  hyperdrive  or nil
 	frontWeapon = frontWeapon or nil
@@ -55,10 +57,10 @@ local function shipStats()
 		},
 		false,
 		{ l.WEIGHT_EMPTY..":",     string.format("%d t", player.staticMass - player.loadedMass) },
-		{ l.CAPACITY_USED..":",    string.format("%s (%s "..l.MAX..")", ui.Format.Volume(player.equipVolume), ui.Format.Volume(player.totalVolume) ) },
-		{ l.CARGO_SPACE_USED..":", string.format("%d cu (%d cu "..l.MAX..")", player.usedCargo, player.totalCargo) },
 		{ l.FUEL_WEIGHT..":",      string.format("%.1f t (%.1f t "..l.MAX..")", player.fuelMassLeft, shipDef.fuelTankMass ) },
+		{ l.PAYLOAD_WEIGHT..":",   string.format("%d t (%d t "..l.MAX..")", player:GetPayloadUsed(), player:GetPayloadMax()) },
 		{ l.ALL_UP_WEIGHT..":",    string.format("%d t", mass_with_fuel ) },
+		{ l.EQUIPMENT_USED..":",   string.format("%s (%s "..l.MAX..")", ui.Format.Volume(player.equipVolume), ui.Format.Volume(player.totalVolume) ) },
 		false,
 		{ l.FRONT_WEAPON..":", frontWeapon and frontWeapon:GetName() or l.NONE },
 		{ l.REAR_WEAPON..":",  rearWeapon and rearWeapon:GetName() or l.NONE },

--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -109,7 +109,9 @@ local pumpDown = function (fuel)
 	-- Convert fuel to positive number, don't take more fuel than is in the tank
 	local drainedFuel = math.min(math.abs(fuel), availableFuel)
 	-- Don't pump down more fuel than we can fit in the cargo space available
-	drainedFuel = math.min(drainedFuel, cargoMgr:GetFreeSpace())
+	-- Cargo transfer UI should stay in whole-ton units
+	local freeCargoInt = math.floor(cargoMgr:GetFreeSpace())
+	drainedFuel = math.min(drainedFuel, freeCargoInt)
 
 	-- Military fuel is only used for the hyperdrive
 	local ok = cargoMgr:AddCommodity(Commodities.hydrogen, drainedFuel)
@@ -131,7 +133,7 @@ local function gauge_bar(x, text, min, max, icon)
 	local gaugeWidth = ui.getContentRegion().x * fudge_factor
 	local gaugePos = Vector2(cursorPos.x, cursorPos.y + height * 0.5)
 
-	ui.gauge(gaugePos, x, '', text, min, max, icon,
+	ui.gauge(gaugePos, x, '', text, min, max, icon, true,
 		colors.gaugeEquipmentMarket, '', gaugeWidth, height)
 
 	-- ui.addRect(cursorPos, cursorPos + Vector2(gaugeWidth, height), colors.gaugeCargo, 0, ui.RoundCornersNone, 1)
@@ -142,7 +144,7 @@ end
 local function gauge_fuel()
 	local player = Game.player
 	local tankSize = ShipDef[player.shipId].fuelTankMass
-	local text = string.format(l.FUEL .. ": %d t \t" .. l.DELTA_V .. ": %d km/s",
+	local text = string.format(l.FUEL .. ": %0.1f t \t" .. l.DELTA_V .. ": %d km/s",
 		tankSize/100 * player.fuel, player:GetRemainingDeltaV()/1000)
 
 	gauge_bar(player.fuel, text, 0, 100, icons.fuel)
@@ -159,9 +161,10 @@ end
 local function gauge_cargo()
 	---@type CargoManager
 	local cargoMgr = Game.player:GetComponent('CargoManager')
+	local freeCargoDisplay = math.floor(cargoMgr:GetFreeSpace())
 
-	local fmtString = string.format('%%i t %s / %i t %s', l.USED, cargoMgr:GetFreeSpace(), l.FREE)
-	gauge_bar(cargoMgr:GetUsedSpace(), fmtString, 0, cargoMgr:GetFreeSpace() + cargoMgr:GetUsedSpace(), icons.market)
+	local fmtString = string.format('%%i t %s / %i t %s', l.USED, freeCargoDisplay, l.FREE)
+	gauge_bar(cargoMgr:GetUsedSpace(), fmtString, 0, freeCargoDisplay + cargoMgr:GetUsedSpace(), icons.market)
 end
 
 -- Gauge bar for used/free cabins
@@ -171,8 +174,12 @@ local function gauge_cabins()
 	local berths_used = Passengers.CountOccupiedBerths(player)
 	local berths_total = berths_used + berths_free
 
-	gauge_bar(berths_used, string.format('%%i %s / %i %s', l.USED, berths_free, l.FREE),
-		0, berths_total, icons.personal)
+	if berths_total == 0 then
+		ui.text(l.NONE)
+	else
+		gauge_bar(berths_used, string.format('%%i %s / %i %s', l.USED, berths_free, l.FREE),
+			0, berths_total, icons.personal)
+	end
 end
 
 ---@param hyperdrive Equipment.HyperdriveType

--- a/data/pigui/modules/new-game-window/ship.lua
+++ b/data/pigui/modules/new-game-window/ship.lua
@@ -1828,8 +1828,8 @@ function ShipSummary:prepareAndValidateParamList()
 	local eq_n_cargo = { valid = true }
 	freeCargo = math.max(freeCargo, 0)
 	local paramList = {
-		rowWithAlert(self.equip, lui.CAPACITY, ShipEquip.volume, def.equipCapacity, greater, lc.UNIT_CUBIC_METERS, "%.1f"),
-		rowWithAlert(self.cargo, lui.CARGO_SPACE, ShipCargo.mass, freeCargo, greater, 't'),
+		rowWithAlert(self.equip, lui.EQUIPMENT, ShipEquip.volume, def.equipCapacity, greater, lc.UNIT_CUBIC_METERS, "%.1f"),
+		rowWithAlert(self.cargo, lui.PAYLOAD, ShipCargo.mass + ShipEquip.mass, freeCargo, greater, 't'),
 		rowWithAlert(self.equip, lui.CREW_CABINS, #Crew.value + 1, def.maxCrew, greater),
 	}
 	self.cargo.valid = self.cargo.valid and eq_n_cargo.valid

--- a/data/pigui/modules/sidebar/cargo.lua
+++ b/data/pigui/modules/sidebar/cargo.lua
@@ -255,8 +255,6 @@ function module:drawBody()
 	local totalSpace = cargoMgr:GetTotalSpace()
 
 	ui.alignTextToButtonPadding()
-	ui.text(lui.CARGO_CAPACITY .. ": " .. totalSpace .. "t")
-	ui.sameLine()
 
 	self:drawModeButtons()
 
@@ -291,7 +289,7 @@ function module:drawBody()
 	ui.text("{} {}t {} / {}t {}" % {
 		lui.TOTAL,
 		cargoMgr:GetUsedSpace(), lui.USED,
-		cargoMgr:GetFreeSpace(), lui.FREE
+		math.floor(cargoMgr:GetFreeSpace()), lui.FREE
 	})
 
 	if self.transferMode then

--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -24,6 +24,7 @@ local pionillium = ui.fonts.pionillium
 local orbiteer = ui.fonts.orbiteer
 local colors = ui.theme.colors
 local icons = ui.theme.icons
+local gaugeSpacing = ui.getTextLineHeight() * 0.8
 
 local Lang = require 'Lang'
 local l = Lang.GetResource("ui-core")
@@ -189,11 +190,12 @@ local function lobbyMenu()
 	-- internal tank fuel gauge
 	local gaugePos = ui.getCursorScreenPos()
 	local gaugeHeight = widgetSizes.buttonSizeBase.y
+	gaugePos.x = gaugePos.x + gaugeSpacing;
 	gaugePos.y = gaugePos.y + widgetSizes.buttonSizeBase.y/2
 	local gaugeWidth = ui.getContentRegion().x
-	ui.gauge(gaugePos, Game.player.fuel, '', string.format(l.FUEL .. ": %d t \t" .. l.DELTA_V .. ": %d km/s",
+	ui.gauge(gaugePos, Game.player.fuel, '', string.format(l.FUEL .. ": %0.1f t \t" .. l.DELTA_V .. ": %d km/s",
 		shipDef.fuelTankMass/100 * Game.player.fuel, Game.player:GetRemainingDeltaV()/1000),
-		0, 100, icons.fuel,
+		0, 100, icons.fuel, true,
 		colors.gaugeEquipmentMarket, '', gaugeWidth, gaugeHeight, pionillium.body)
 
 	-- hyperspace fuel
@@ -225,11 +227,12 @@ local function lobbyMenu()
 
 	-- hyperspace fuel gauge
 	gaugePos = ui.getCursorScreenPos()
+	gaugePos.x = gaugePos.x + gaugeSpacing;
 	gaugePos.y = gaugePos.y + widgetSizes.buttonSizeBase.y/2
 	ui.gauge(gaugePos, stored_hyperfuel, '', string.format(l.FUEL .. ": %0.1f t \t" .. l.HYPERSPACE_RANGE .. ": %d " .. l.LY,
 		stored_hyperfuel, Game.player:GetHyperspaceRange()),
 		0, hyperdrive:GetMaxFuel(),
-		icons.hyperspace, colors.gaugeEquipmentMarket, '',
+		icons.hyperspace, true, colors.gaugeEquipmentMarket, '',
 		gaugeWidth, gaugeHeight, pionillium.body)
 
 	ui.columns(1, '', false)

--- a/data/pigui/modules/station-view/04-shipMarket.lua
+++ b/data/pigui/modules/station-view/04-shipMarket.lua
@@ -13,6 +13,7 @@ local ModelSpinner = require 'PiGui.Modules.ModelSpinner'
 local EquipSet = require 'EquipSet'
 local HullConfig = require 'HullConfig'
 local PlayerState= require 'PlayerState'
+local Passengers = require 'Passengers'
 
 local ui = require 'pigui'
 
@@ -183,7 +184,7 @@ local function buyShip (mkt, sos)
 	end
 
 	-- Not enough room to put all of the player's current cargo
-	if def.cargo < player.usedCargo then
+	if player:GetPayloadUsed() > def.cargo then
 		mkt.popup.msg = l.TOO_SMALL_TO_TRANSSHIP
 		mkt.popup:open()
 		return
@@ -328,6 +329,10 @@ function FormatAndCompareShips:draw_tonnage_cell(desc, key)
 	self:compare_and_draw_column( desc, self:get_value(key), self.b:get_value(key), Format.MassTonnes )
 end
 
+function FormatAndCompareShips:draw_volume_cell(desc, key)
+	self:compare_and_draw_column( desc, self:get_value(key), self.b:get_value(key), ui.Format.Volume )
+end
+
 function FormatAndCompareShips:draw_accel_cell(desc, thrustKey, massKey )
 	local accelA = self.def.linearThrust[thrustKey] / (9.8106*1000*(self:get_value(massKey)))
 	local accelB = self.b.def.linearThrust[thrustKey] / (9.8106*1000*(self.b:get_value(massKey)))
@@ -375,6 +380,12 @@ function FormatAndCompareShips:draw_equip_slot_cell(desc, key)
 	self:compare_and_draw_column( desc, getNumSlotsCompatibleWithType(self.def, key), getNumSlotsCompatibleWithType(self.b.def, key) )
 end
 
+function FormatAndCompareShips:draw_berths_slot_cell(desc)
+	local a_hull = HullConfig.GetHullConfig(self.def.id)
+	local b_hull = (self.b and self.b.def) and HullConfig.GetHullConfig(self.b.def.id) or nil
+	self:compare_and_draw_column( desc, Passengers.GetMaxPassengersForHull(a_hull), Passengers.GetMaxPassengersForHull(b_hull) )
+end
+
 function FormatAndCompareShips:draw_yes_no_equip_slot_cell(desc, key)
 
 	local function fmt( v ) return v==1 and l.YES or l.NO end
@@ -418,9 +429,9 @@ end
 function FormatAndCompareShips:Constructor(def, b)
 	self.column = 0
 	self.emptyMass = def.hullMass + def.fuelTankMass
-	self.fullMass = def.hullMass + def.equipCapacity + def.fuelTankMass
-	self.massAtCapacity = def.hullMass + def.equipCapacity
-	self.cargoCapacity = def.cargo
+	self.fullMass = def.hullMass + def.fuelTankMass + def.cargo
+	self.massAtCapacity = def.hullMass + def.cargo
+	self.maxPayload = def.cargo
 	self.def = def
 	self.b = b
 end
@@ -479,15 +490,15 @@ local tradeMenu = function()
 						if not shipFormatAndCompare:beginTable() then return end
 
 						shipFormatAndCompare:draw_hyperdrive_cell( l.HYPERDRIVE_FITTED )
-						shipFormatAndCompare:draw_tonnage_cell( l.CARGO_SPACE, "cargoCapacity" )
-						shipFormatAndCompare:draw_accel_cell( l.FORWARD_ACCEL_FULL, "FORWARD", "fullMass" )
-						shipFormatAndCompare:draw_tonnage_cell( l.WEIGHT_FULLY_LOADED, "fullMass" )
-						shipFormatAndCompare:draw_accel_cell( l.FORWARD_ACCEL_EMPTY, "FORWARD", "emptyMass" )
 						shipFormatAndCompare:draw_tonnage_cell( l.WEIGHT_EMPTY, "hullMass" )
-						shipFormatAndCompare:draw_accel_cell( l.REVERSE_ACCEL_EMPTY, "REVERSE", "emptyMass" )
-						shipFormatAndCompare:draw_tonnage_cell( l.EQUIPMENT_CAPACITY, "equipCapacity" )
-						shipFormatAndCompare:draw_accel_cell( l.REVERSE_ACCEL_FULL, "REVERSE", "fullMass" )
+						shipFormatAndCompare:draw_accel_cell( l.FORWARD_ACCEL_FULL, "FORWARD", "fullMass" )
 						shipFormatAndCompare:draw_tonnage_cell( l.FUEL_WEIGHT, "fuelTankMass" )
+						shipFormatAndCompare:draw_accel_cell( l.FORWARD_ACCEL_EMPTY, "FORWARD", "emptyMass" )
+						shipFormatAndCompare:draw_tonnage_cell( l.PAYLOAD_WEIGHT, "maxPayload" )
+						shipFormatAndCompare:draw_accel_cell( l.REVERSE_ACCEL_EMPTY, "REVERSE", "emptyMass" )
+						shipFormatAndCompare:draw_tonnage_cell( l.WEIGHT_FULLY_LOADED, "fullMass" )
+						shipFormatAndCompare:draw_accel_cell( l.REVERSE_ACCEL_FULL, "REVERSE", "fullMass" )
+						shipFormatAndCompare:draw_volume_cell( l.EQUIPMENT_CAPACITY, "equipCapacity" )
 						shipFormatAndCompare:draw_deltav_cell( l.DELTA_V_EMPTY, "emptyMass", "hullMass")
 						shipFormatAndCompare:draw_unformated_cell( l.MINIMUM_CREW, "minCrew" )
 						shipFormatAndCompare:draw_deltav_cell( l.DELTA_V_FULL, "fullMass", "massAtCapacity")
@@ -497,7 +508,7 @@ local tradeMenu = function()
 						shipFormatAndCompare:draw_yes_no_equip_slot_cell( l.ATMOSPHERIC_SHIELDING, "hull.atmo_shield" )
 						shipFormatAndCompare:draw_atmos_pressure_limit_cell( l.ATMO_PRESS_LIMIT )
 						shipFormatAndCompare:draw_equip_slot_cell( l.SCOOP_MOUNTS, "scoop" )
-						shipFormatAndCompare:draw_equip_slot_cell( l.PASSENGER_CABIN_CAPACITY, "cabin" )
+						shipFormatAndCompare:draw_berths_slot_cell( l.PASSENGER_CABIN_CAPACITY )
 
 						ui.endTable()
 
@@ -527,7 +538,7 @@ shipMarket = Table.New("shipMarketWidget", false, {
 			ui.nextColumn()
 			ui.text(l.PRICE)
 			ui.nextColumn()
-			ui.text(l.CAPACITY)
+			ui.text(l.PAYLOAD)
 			ui.nextColumn()
 		end)
 	end,
@@ -556,7 +567,7 @@ shipMarket = Table.New("shipMarketWidget", false, {
 			ui.text(Format.Money(advertDataCache[item].price, false))
 			ui.nextColumn()
 			ui.dummy(widgetSizes.rowVerticalSpacing)
-			ui.text(item.def.equipCapacity.." t")
+			ui.text(item.def.cargo.." t")
 			ui.nextColumn()
 		end)
 	end,

--- a/data/pigui/modules/station-view/06-shipRepairs.lua
+++ b/data/pigui/modules/station-view/06-shipRepairs.lua
@@ -227,7 +227,7 @@ local function drawShipRepair()
 			gaugePos.y = gaugePos.y + ui.getTextLineHeightWithSpacing() * 0.5
 			ui.dummy(Vector2(widgetSizes.gaugeWidth, ui.getTextLineHeightWithSpacing()))
 
-			ui.gauge(gaugePos, hullPercent, '', l.HULL_INTEGRITY, 0, 100, icons.hull, colors.gaugeEquipmentMarket, l.HUD_HULL_STRENGTH, widgetSizes.gaugeWidth, ui.getTextLineHeightWithSpacing())
+			ui.gauge(gaugePos, hullPercent, '', l.HULL_INTEGRITY, 0, 100, icons.hull, true, colors.gaugeEquipmentMarket, l.HUD_HULL_STRENGTH, widgetSizes.gaugeWidth, ui.getTextLineHeightWithSpacing())
 
 			ui.newLine()
 

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -271,6 +271,7 @@ theme.colors = {
 	gaugeJettison           = styleColors.danger_500,
 
 	gaugeBackground			= styleColors.panel_900:opacity(0.85),
+	gaugeBarBackground		= styleColors.primary_900,
 	gaugePressure			= styleColors.primary_600,
 	gaugeScanner			= styleColors.primary_500,
 	gaugeTemperature		= styleColors.danger_500,

--- a/data/pigui/views/station-view.lua
+++ b/data/pigui/views/station-view.lua
@@ -47,37 +47,56 @@ if not stationView then
 					local legalText = l.LEGAL_STATUS .. ': ' .. l[PlayerState.GetLegalStatus()]
 					local moneySize = ui.calcTextSize(moneyText) + self.style.inventoryPadding + self.style.itemSpacing
 					local legalSize = ui.calcTextSize(legalText) + self.style.inventoryPadding + self.style.itemSpacing
-					local gaugeSize = (ui.getContentRegion().x - moneySize.x - legalSize.x) / 2
-					ui.columns(4, 'shipInventory', false)
+					local gaugeSize = (ui.getContentRegion().x - moneySize.x - legalSize.x) / 4
+					ui.columns(5, 'shipInventory', false)
 					ui.setColumnWidth(0, moneySize.x)
-					ui.setColumnWidth(1, gaugeSize)
-					ui.setColumnWidth(2, gaugeSize)
-					ui.setColumnWidth(3, legalSize.x)
+					ui.setColumnWidth(1, gaugeSize * 1.5)
+					ui.setColumnWidth(2, gaugeSize * 1.5)
+					ui.setColumnWidth(3, gaugeSize * 1.0)
+					ui.setColumnWidth(4, legalSize.x)
 					ui.text(moneyText)
+
 					ui.nextColumn()
-					ui.text(l.CAPACITY .. ': ')
+					ui.text('    ' .. l.PAYLOAD .. ': ')
 					ui.sameLine()
-					local gaugePos = ui.getWindowPos() + ui.getCursorPos() + Vector2(0, ui.getTextLineHeight() / 2)
+					local gaugePos = ui.getWindowPos() + ui.getCursorPos() + Vector2(0, ui.getTextLineHeight() / 2.2)
+					local gaugeWidth = ui.getContentRegion().x - self.style.inventoryPadding.x - self.style.itemSpacing.x
+
+					local fmt = "{} {} / {} {}" % {
+						ui.Format.Mass(player:GetPayloadUsed() * 1000, 1), l.USED,
+						ui.Format.Mass(player:GetPayloadFree() * 1000, 1), l.FREE
+					}
+					ui.gauge(gaugePos, player:GetPayloadUsed(), '', fmt, 0, player:GetPayloadMax(), nil, false, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
+
+					ui.nextColumn()
+					ui.text('   ' .. l.EQUIPMENT .. ': ')
+					ui.sameLine()
+					local gaugePos = ui.getWindowPos() + ui.getCursorPos() + Vector2(0, ui.getTextLineHeight() / 2.2)
 					local gaugeWidth = ui.getContentRegion().x - self.style.inventoryPadding.x - self.style.itemSpacing.x
 
 					local fmt = "{} {} / {} {}" % {
 						ui.Format.Volume(player.equipVolume), l.USED,
 						ui.Format.Volume(player.totalVolume - player.equipVolume), l.FREE
 					}
-					ui.gauge(gaugePos, player.equipVolume, '', fmt, 0, player.totalVolume, icons.market, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
-					ui.nextColumn()
-					ui.text(l.CABINS .. ': ')
-					ui.sameLine()
+					ui.gauge(gaugePos, player.equipVolume, '', fmt, 0, player.totalVolume, nil, false, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
 
+					ui.nextColumn()
+					ui.text('   ' .. l.CABINS .. ': ')
+					ui.sameLine()
 					local berths_free = Passengers.CountFreeBerths(player)
 					local berths_used = Passengers.CountOccupiedBerths(player)
 					local berths_total = berths_used + berths_free
 
-					gaugePos = ui.getWindowPos() + ui.getCursorPos() + Vector2(0, ui.getTextLineHeight() / 2)
-					gaugeWidth = ui.getContentRegion().x - self.style.inventoryPadding.x - self.style.itemSpacing.x
-					ui.gauge(gaugePos, berths_used, '', string.format('%%i %s / %i %s', l.USED, berths_free, l.FREE), 0, berths_total, icons.personal, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
+					if berths_total == 0 then
+						ui.text(l.NONE)
+					else
+						gaugePos = ui.getWindowPos() + ui.getCursorPos() + Vector2(0, ui.getTextLineHeight() / 2.2)
+						gaugeWidth = ui.getContentRegion().x - self.style.inventoryPadding.x - self.style.itemSpacing.x
+						ui.gauge(gaugePos, berths_used, '', string.format('%%i %s / %i %s', l.USED, berths_free, l.FREE), 0, berths_total, nil, false, colors.gaugeEquipmentMarket, '', gaugeWidth, ui.getTextLineHeight())
+					end
+
 					ui.nextColumn()
-					ui.text(legalText)
+					ui.text('   ' .. legalText)
 					ui.columns(1, '', false)
 				end)
 			end)

--- a/data/ships/bowfin.json
+++ b/data/ships/bowfin.json
@@ -15,7 +15,7 @@
 	"volume": 135,
 	"atmospheric_pressure_limit": 6.5,
 	"capacity": 15,
-	"cargo": 4,
+	"cargo": 10,
 
 	"equipment_slots": {
 		"missile_bay_1": {

--- a/data/ships/coronatrix.json
+++ b/data/ships/coronatrix.json
@@ -8,14 +8,14 @@
 	"ship_class": "light_courier",
 	"min_crew": 1,
 	"max_crew": 1,
-	"price": 50349,
+	"price": 62349,
 	"hull_mass": 21,
 	"structure_mass": 7.1,
 	"armor_mass": 11.9,
 	"volume": 190,
 	"atmospheric_pressure_limit": 3.2,
 	"capacity": 35,
-	"cargo": 16,
+	"cargo": 24,
 
 	"equipment_slots": {
 		"utility_s1_2": {

--- a/data/ships/deneb.json
+++ b/data/ships/deneb.json
@@ -15,7 +15,7 @@
 	"volume": 1342,
 	"atmospheric_pressure_limit": 7.2,
 	"capacity": 125,
-	"cargo": 198,
+	"cargo": 248,
 
 	"equipment_slots": {
 		"shield_s3": {

--- a/data/ships/lunarshuttle.json
+++ b/data/ships/lunarshuttle.json
@@ -15,7 +15,7 @@
 	"volume": 310,
 	"atmospheric_pressure_limit": 2.5,
 	"capacity": 16,
-	"cargo": 6,
+	"cargo": 18,
 
 	"equipment_slots": {
 		"cabin_s2_fore": {

--- a/data/ships/malabar.json
+++ b/data/ships/malabar.json
@@ -14,7 +14,7 @@
 	"armor_mass": 256.7,
 	"volume": 14162,
 	"atmospheric_pressure_limit": 3,
-	"capacity": 1093,
+	"capacity": 493,
 	"cargo": 800,
 
 	"equipment_slots": {

--- a/data/ships/pumpkinseed.json
+++ b/data/ships/pumpkinseed.json
@@ -15,7 +15,7 @@
 	"volume": 87,
 	"atmospheric_pressure_limit": 4,
 	"capacity": 14.5,
-	"cargo": 4,
+	"cargo": 16,
 
 	"equipment_slots": {
 		"missile_s1_1": {
@@ -69,10 +69,6 @@
 			"size": 1,
 			"tag": "tag_utility_s1_1",
 			"hardpoint": true
-		},
-		"cabin_s1_2": {
-			"type": "cabin",
-			"size": 1
 		},
 		"computer_1": {
 			"type": "computer",

--- a/data/ships/pumpkinseed_police.json
+++ b/data/ships/pumpkinseed_police.json
@@ -15,7 +15,7 @@
 	"volume": 87,
 	"atmospheric_pressure_limit": 4,
 	"capacity": 21,
-	"cargo": 0,
+	"cargo": 12,
 
 	"equipment_slots": {
 		"laser_front_s1": {

--- a/data/ships/sinonatrix.json
+++ b/data/ships/sinonatrix.json
@@ -15,7 +15,7 @@
 	"volume": 576,
 	"atmospheric_pressure_limit": 3.2,
 	"capacity": 59,
-	"cargo": 24,
+	"cargo": 36,
 
 	"equipment_slots": {
 		"weapon_s2_1": {

--- a/data/ships/skipjack.json
+++ b/data/ships/skipjack.json
@@ -15,7 +15,7 @@
 	"volume": 831,
 	"atmospheric_pressure_limit": 4.8,
 	"capacity": 75,
-	"cargo": 78,
+	"cargo": 84,
 
 	"equipment_slots": {
 		"cabin_s1_1": {

--- a/data/ships/wave.json
+++ b/data/ships/wave.json
@@ -15,7 +15,7 @@
 	"volume": 434,
 	"atmospheric_pressure_limit": 14,
 	"capacity": 22,
-	"cargo": 6,
+	"cargo": 20,
 
 	"equipment_slots": {
 		"weapon_left_s1": {

--- a/data/ships/xylophis.json
+++ b/data/ships/xylophis.json
@@ -15,7 +15,7 @@
 	"volume": 48,
 	"atmospheric_pressure_limit": 3,
 	"capacity": 5.5,
-	"cargo": 8,
+	"cargo": 7,
 
 	"equipment_slots": {
 		"utility_s1": {


### PR DESCRIPTION
From what I can gather, a couple of years ago there was an effort to convert the ship capacity metric from mass to volume. I must say I don't really understand the reasoning behind this, because mass is far more relevant for gravity wells, delta-V, manoeuvrability, and hyperspace jump range than ship volume. Even here on Earth, with air resistance and friction, vehicle carrying capacity is mainly determined by mass, not volume. But maybe if I could see the final implementation in Pioneer I would get it. Anyway, the work was mostly completed on the equipment side, and then it seems everyone just gave up. This has left the game with a number of issues which I think seriously affect its credibility:

* The word "Capacity" is shown in various places in the UI, but generally only refers to equipment volume, which is a sub-set of the ship's overall capacity. However, during normal "flying around and trading" gameplay the player is more interested in cargo space than equipment space. That's why the cargo-run missions still have questions like "How much mass?". Even when fitting equipment it is mostly governed by available equipment slots rather than total equipment capacity. So the "Capacity" figure is featured far more prominently than is warranted by its value to the player.
* Cargo capacity is currently a separate fixed number, measured in ton(ne)s, which does not vary when you fill the ship up with other things. This makes no logical sense. Intuitively, as you load up a ship with equipment, the cargo capacity should reduce, and vice-versa. Even carmakers in the 1950s had figured out that you can convert passenger space into cargo space by folding the seats down. I'm sure that spaceship engineers 1,200 years from now will have made the equivalent discoveries.
* Speaking of passenger space - the passenger cabins take up no space at all. Their volume is set to 0, so they don't consume equipment capacity, and their weight doesn't affect cargo space, because nothing affects cargo space as previously mentioned. When I first saw this I thought that maybe someone forgot to update the cabin equipment volume fields after testing, but then I saw in the [Hardpoint-based Equipment System](https://dev.pioneerspacesim.net/design-document/hardpoint_design) design doc (last updated 2024-09) that this is by design. Huh? I think that installing passenger cabins into the ship ought to affect _something_.
* Passenger cabins also have a problem whereby "cabin" is used interchangeably to mean "berth" or "compartment that may contain multiple berths". For example in the ship market it will show that ships have "2 passenger cabins" but this tells you almost nothing useful about how many passengers you will be able to transport.
* Passenger cabins have a further problem whereby some ships don't have any slots for them at all. In particular the player is unable to add cabins to the "easy start" ship (Coronatrix). This is confusing and inconsistent, since many smaller ships _do_ have slots.

The goal of this pull request is to patch up the above holes in the current code, while leaving open the possibility for someone to come along and finish off the volume conversion, if they want to, at a future date. Therefore it does not introduce any new ship properties or parameters, merely making their current usage more explicit.

I have made the following changes:

* The "cargo" stat in ship definition files is now used to mean "max payload". The payload is the total amount of mass the ship can carry, excluding fuel. So when a ship is fully laden, the total mass for physics purposes will be hull + fuel + payload. Equipment mass therefore eats into the payload allowance and reduces the amount of cargo you can carry. Since cargo measurements were already still using mass, this doesn't lead to significant changes - just additional checks when fitting equipment.
* Due to the above, I bumped up the "cargo" stat (now meaning total payload mass) in some of the ships, especially the smaller ones. Except for Xylophis which I reduced.
* The "Capacity" column in the ship market now shows "Payload" instead, since it's a better indication of the ship's overall transporting abilities, covering both equipment and cargo, rather than just equipment.
* The UI gauges along the bottom of the station view (comms) screens now have "Payload" as well as "Equipment". I have tried to ban the word "capacity" from everywhere in the UI, to remove any ambiguity about what any given number refers to.
* In most places in the UI that refer to "cabins" I have replaced this with "berths" since that number is generally what the player wants to know.
* If you have no passenger cabins fitted, the UI now shows "None" instead of "100% of 0 cabins used".
* An existing bug was that if the player doesn't have room to add a new piece of equipment, the message shown was "This equipment is not compatible with your ship", even if it is compatible. I added an additional message which says "Not enough space" in those circumstances instead.
* In the equipment screen the mass of a fitted hyperdrive was shown including the fuel, which made the comparison to alternative (or even the same) hyperdrive types come out wrong. Hyperdrive mass is now shown as the bare mass. Fuel reservoir size was already shown separately, so the inclusive number was arguably wrong anyway.
* Cabin slots are now automatically added to ship hulls, according to the max payload, so they don't need to be defined in the ship definition files any more. Since smaller cabins can fit into larger slots, this doesn't mean we end up with hundreds of cabin slots in large transports - it adds as many as it can of the largest ones first, and then a couple of smaller ones to fill out the remaining payload.
* I also made some minor cosmetic tweaks to the way that gauges are drawn, and made the capitalization of some UI strings consistent with other UI strings.

I'd like people to try this code out and let me know what they think.

Note that since I didn't change any underlying ship stats, none of this requires a save bump. However, if the player has a full cargo hold when they save with the current code, and then they load the game with this new code, the ship keeps its cargo and it is possible to end up over the payload limit for the ship. As far as I can tell this doesn't cause any problems - the ship behaves as normal, and after you sell or deliver the excess cargo, you can't go back above the payload limit any more.

Also note that since equipment slots are saved in the save file, if you apply these changes and load a saved game, you won't get the new cabin slots. You have to start a new game, or buy a new ship (that wasn't also saved in the save file), to see what cabin slots it gets assigned.

Finally, yes, this change was my secret agenda all along. I only fixed all those bugs so that you would take me seriously when I submitted this pull request! Hah! Surprise attack!