### PR TITLE
Fix placeAdvert error in Scoop.lua

### DIFF
--- a/data/modules/Scoop/Scoop.lua
+++ b/data/modules/Scoop/Scoop.lua
@@ -496,13 +496,14 @@ local placeAdvert = function (station, ad)
 				isEnabled   = isEnabled
 			})
 		else
-			local p = station.path:GetSystemBody().parent.path
+			local p = station:GetSystemBody().parent.body
+
 			ref = station:AddAdvert({
 				title       = l["ADTITLE_" .. ad.id],
 				description = ad.desc,
 				icon        = ad.id == "RESCUE" and "searchrescue" or "haul",
 				due         = ad.due,
-				dist        = p.path == ad.planet and p:GetPhysicalRadius() * 3 or nil,
+				dist        = (p and p.path == ad.planet) and p:GetPhysicalRadius() * 3 or nil,
 				reward      = ad.reward,
 				location    = ad.location,
 				onChat      = onChat,


### PR DESCRIPTION
This should fix an error I just got which crashed the game:
```
Pioneer Warning
[T] modules/Scoop/Scoop.lua:505: attempt to index local 'p' (a nil value) stack traceback:
[T] modules/Scoop/Scoop.lua:505: in function 'placeAdvert'
[T] modules/Scoop/Scoop.lua:561: in function 'makeAdvert [T] modules/Scoop/Scoop.lua:579: in function 'func'
[T] libs/Event.lua:31: in function 'executor'
[T] libs/Event.lua:79: in function '_Emit'
[T] libs/Event.lua:209: in function <[T] libs/Event.lua:208>
OK
```
<img width="576" height="359" alt="Screenshot_2026-04-26_19-44-46" src="https://github.com/user-attachments/assets/96fb4f60-e66d-4a97-b0fa-42f8433d27eb" />
