### PR TITLE
Add custom "Load cargo" button to cargo pickup missions

### DIFF
--- a/data/lang/module-cargorun/en.json
+++ b/data/lang/module-cargorun/en.json
@@ -403,6 +403,10 @@
     "description": "",
     "message": "I'm taking damage. I need help."
   },
+  "LOAD_CARGO": {
+    "description": "UI button label",
+    "message": "Load cargo"
+  },
   "MACHINE_TOOLS": {
     "description": "custom cargo",
     "message": "machine tools"
@@ -661,7 +665,7 @@
   },
   "WE_HAVE_LOADED_UP_THE_CARGO_ON_YOUR_SHIP": {
     "description": "",
-    "message": "We have loaded up the cargo on your ship."
+    "message": "We have loaded the cargo onto your ship."
   },
   "WHAT_IS_THIS": {
     "description": "",
@@ -749,6 +753,6 @@
   },
   "YOU_DO_NOT_HAVE_ENOUGH_EMPTY_CARGO_SPACE": {
     "description": "",
-    "message": "Please come back when you have sufficient cargo space."
+    "message": "Please contact me when you have sufficient cargo space."
   }
 }

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2353,7 +2353,7 @@
   },
   "SET_AS_TARGET": {
     "description": "",
-    "message": "Set destination as navigation target."
+    "message": "Set destination as navigation target"
   },
   "SET_JUMP_TARGET": {
     "description": "Button tooltip which sets the jump route to the selected body",

--- a/data/modules/CargoRun/CargoRun.lua
+++ b/data/modules/CargoRun/CargoRun.lua
@@ -668,6 +668,21 @@ local onLeaveSystem = function (ship)
 	escort_ships = {}
 end
 
+local tryLoadPickupCargo = function(mission, player)
+	local cargoMgr = player:GetComponent('CargoManager')
+
+	if cargoMgr:GetFreeSpace() < mission.amount then
+		Comms.ImportantMessage(l.YOU_DO_NOT_HAVE_ENOUGH_EMPTY_CARGO_SPACE, mission.client.name)
+	else
+		cargoMgr:AddCommodity(mission.cargotype, mission.amount);
+		mission.cargo_picked_up = true
+		Comms.ImportantMessage(l.WE_HAVE_LOADED_UP_THE_CARGO_ON_YOUR_SHIP, mission.client.name)
+		mission.status = "ACTIVE"
+		mission.destination = mission.domicile
+		return true
+	end
+end
+
 local onPlayerDocked = function (player, station)
 
 	-- First drop off cargo (if any such missions)
@@ -726,18 +741,7 @@ local onPlayerDocked = function (player, station)
 		if readyToPickup then
 			if Game.time < mission.due then
 
-				---@type CargoManager
-				local cargoMgr = player:GetComponent('CargoManager')
-
-				if cargoMgr:GetFreeSpace() < mission.amount then
-					Comms.ImportantMessage(l.YOU_DO_NOT_HAVE_ENOUGH_EMPTY_CARGO_SPACE, mission.client.name)
-				else
-					cargoMgr:AddCommodity(mission.cargotype, mission.amount);
-					mission.cargo_picked_up = true
-					Comms.ImportantMessage(l.WE_HAVE_LOADED_UP_THE_CARGO_ON_YOUR_SHIP, mission.client.name)
-					mission.status = "ACTIVE"
-					mission.destination = mission.domicile
-				end
+				tryLoadPickupCargo(mission, player)
 
 			else
 
@@ -861,6 +865,22 @@ local buildMissionDescription = function(mission)
 		}
 
 		desc.returnLocation = mission.domicile
+
+		desc.customActions = {{
+			id = "cargorun_load_cargo",
+			label = l.LOAD_CARGO,
+			enabled = function()
+				local station = Game.player:GetDockedWith()
+				return station
+					and mission.pickup
+					and not mission.cargo_picked_up
+					and Game.time < mission.due
+					and station.path == mission.location
+			end,
+			onClick = function()
+				return tryLoadPickupCargo(mission, Game.player)
+			end,
+		}}
 	end
 
 	return desc

--- a/data/pigui/modules/info-view/04-missions.lua
+++ b/data/pigui/modules/info-view/04-missions.lua
@@ -21,6 +21,8 @@ local detailsSpacing = ui.rescaleUI(Vector2(6, 10), Vector2(1600, 900))
 local framePadding = ui.rescaleUI(Vector2(8, 4), Vector2(1600, 900))
 local face = nil
 
+local activeMission = nil
+
 local function setLocationAsTarget(location)
 	if location:isa("Body") and location:IsDynamic() then
 		Game.player:SetNavTarget(location)
@@ -37,7 +39,16 @@ local function setLocationAsTarget(location)
 	end
 end
 
-local activeMission = nil
+local function shouldShowCustomAction(action)
+	if action.enabled == nil then
+		return true
+	end
+	if type(action.enabled) == "function" then
+		return action.enabled()
+	end
+	return action.enabled
+end
+
 local function drawMissionDescription(missionDesc)
 	local contentRegion = ui.getContentRegion()
 	local leftColWidth = contentRegion.x / 1.618 - columnPadding.x / 2
@@ -72,6 +83,26 @@ local function drawMissionDescription(missionDesc)
 		if missionDesc.returnLocation then
 			ui.sameLine()
 			if ui.button(l.SET_RETURN_ROUTE, Vector2(0, 0)) then setLocationAsTarget(missionDesc.returnLocation) end
+		end
+
+		-- Optional per-mission buttons
+		if missionDesc.customActions then
+			for i, action in ipairs(missionDesc.customActions) do
+				ui.sameLine()
+				local show = shouldShowCustomAction(action)
+				if ui.button(action.label, Vector2(0, 0), not show and ui.theme.buttonColors.disabled) then
+					if show and type(action.onClick) == "function" then
+						local needRefresh = action.onClick()
+						local mission = activeMission._mission
+						if needRefresh and mission then
+							local makeForm = mission:GetClick()
+							activeMission = makeForm(mission)
+							activeMission._mission = mission
+							rowCache = nil
+						end
+					end
+				end
+			end
 		end
 	end)
 
@@ -139,6 +170,7 @@ local function makeMissionRows()
 				ui.sameLine(ui.getColumnWidth() - (framePadding.x * 2) - ui.calcTextSize(l.MORE_INFO).x)
 				if ui.button(l.MORE_INFO.."##"..tostring(mission), Vector2(0, 0)) then
 					activeMission = makeForm(mission)
+					activeMission._mission = mission
 				end
 			end
 		end


### PR DESCRIPTION
Fixes #6168.

I added some code so that missions can now add custom action buttons, which appear in the mission screen. 

Then I added a "Load cargo" button to cargo-run pickup missions, so that if you land with a full cargo hold and sell your cargo you don't have to take off and land again in order to trigger the loading of the mission cargo - you can just click the "Load cargo" button in the mission screen. See example below:

<img width="658" height="394" alt="image" src="https://github.com/user-attachments/assets/97a799df-5c7e-4407-93da-a7e98f264743" />

