### PR TITLE
Make giant stars circular in system overview

### DIFF
--- a/src/galaxy/SystemBody.cpp
+++ b/src/galaxy/SystemBody.cpp
@@ -761,13 +761,38 @@ const char *SystemBody::GetIcon() const
 	switch (m_type) {
 	case TYPE_BROWN_DWARF: return "icons/object_brown_dwarf.png";
 	case TYPE_WHITE_DWARF: return "icons/object_white_dwarf.png";
+	case TYPE_STAR_M_GIANT:
+	case TYPE_STAR_M_SUPER_GIANT:
+	case TYPE_STAR_M_HYPER_GIANT:
 	case TYPE_STAR_M: return "icons/object_star_m.png";
+	case TYPE_STAR_K_GIANT:
+	case TYPE_STAR_K_SUPER_GIANT:
+	case TYPE_STAR_K_HYPER_GIANT:
 	case TYPE_STAR_K: return "icons/object_star_k.png";
+	case TYPE_STAR_G_GIANT:
+	case TYPE_STAR_G_SUPER_GIANT:
+	case TYPE_STAR_G_HYPER_GIANT:
 	case TYPE_STAR_G: return "icons/object_star_g.png";
+	case TYPE_STAR_F_GIANT:
+	case TYPE_STAR_F_SUPER_GIANT:
+	case TYPE_STAR_F_HYPER_GIANT:
 	case TYPE_STAR_F: return "icons/object_star_f.png";
+	case TYPE_STAR_A_GIANT:
+	case TYPE_STAR_A_SUPER_GIANT:
+	case TYPE_STAR_A_HYPER_GIANT:
 	case TYPE_STAR_A: return "icons/object_star_a.png";
+	case TYPE_STAR_B_GIANT:
+	case TYPE_STAR_B_SUPER_GIANT:
+	case TYPE_STAR_B_HYPER_GIANT:
 	case TYPE_STAR_B: return "icons/object_star_b.png";
+	case TYPE_STAR_O_GIANT:
+	case TYPE_STAR_O_SUPER_GIANT:
+	case TYPE_STAR_O_HYPER_GIANT:
 	case TYPE_STAR_O: return "icons/object_star_b.png"; //shares B graphic for now
+
+/*
+	TODO: If we ever get circular icons for giant type stars, replace the above giant cases with the ones below
+
 	case TYPE_STAR_M_GIANT: return "icons/object_star_m_giant.png";
 	case TYPE_STAR_K_GIANT: return "icons/object_star_k_giant.png";
 	case TYPE_STAR_G_GIANT: return "icons/object_star_g_giant.png";
@@ -789,6 +814,8 @@ const char *SystemBody::GetIcon() const
 	case TYPE_STAR_A_HYPER_GIANT: return "icons/object_star_a_hyper_giant.png";
 	case TYPE_STAR_B_HYPER_GIANT: return "icons/object_star_b_hyper_giant.png";
 	case TYPE_STAR_O_HYPER_GIANT: return "icons/object_star_b_hyper_giant.png"; // uses B type graphic for now
+*/
+
 	case TYPE_STAR_M_WF: return "icons/object_star_m_wf.png";
 	case TYPE_STAR_B_WF: return "icons/object_star_b_wf.png";
 	case TYPE_STAR_O_WF: return "icons/object_star_o_wf.png";


### PR DESCRIPTION
When I first saw this, I thought it was a bug:

<img width="579" height="326" alt="image" src="https://github.com/user-attachments/assets/5a1ddc82-bd74-47ca-a751-e80ea51d3c8b" />
<br />
The star image appears to be offset from the circular mask that contains it, creating a strange "half moon" effect on the star. 

When I investigated, it turns out that the icons for giant stars are not the whole star - they are just a corner of it:

<img width="475" height="274" alt="image" src="https://github.com/user-attachments/assets/f9dac181-d361-4f45-9113-acae1303dbd8" />
<br />
This could be a cool effect if the star image was always at the edge of the screen, to give the impression that the star is so huge it won't even fit in the view. And maybe this was the case back when these icons were last updated 8 years ago. But currently the system overview lets you zoom in and out, and you can have binary star systems too:
<br /><br />
<img width="579" height="325" alt="image" src="https://github.com/user-attachments/assets/9a0e6189-60c5-400f-a26e-7d5077b57971" />
<br />
The result is, I'm afraid, that this concept doesn't work and looks confusing. 

If I were more graphically inclined, I would submit a new set of giant star icons that were the whole star, but I am not, so instead I've modified the code to use the "regular" star icons in place of giant ones. The above system views now look like this:
<br />
<img width="579" height="325" alt="image" src="https://github.com/user-attachments/assets/c837a8f1-815a-4114-bb51-32e38821782e" />

<img width="579" height="325" alt="image" src="https://github.com/user-attachments/assets/8fc4102d-e3ef-48ac-8ad4-d71525a56323" />
<br />
The code to switch on all the different star types is still there, commented out, so if in future someone else creates a set of suitable giant star icons then it would be super easy to incorporate them, but in the meantime I think this is an improvement.