### PR TITLE
Make thruster visual more consistent

### DIFF
--- a/src/ModelBody.cpp
+++ b/src/ModelBody.cpp
@@ -5,6 +5,7 @@
 
 #include "Camera.h"
 #include "Frame.h"
+#include "Game.h"
 #include "GameSaveError.h"
 #include "JsonUtils.h"
 #include "Pi.h"
@@ -296,7 +297,10 @@ void ModelBody::MoveGeoms(const matrix4x4d &m, const vector3d &p)
 void ModelBody::RenderModel(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform)
 {
 	// HACK: this uses the global application time as a "render clock". This should be accessible through the Camera instead.
-	m_model->SetRenderTime(Pi::GetApp()->GetTime());
+	double renderTime = Pi::GetApp()->GetTime();
+	if (Pi::game)
+		renderTime = Pi::game->GetTime() + (Pi::GetGameTickAlpha() * Pi::game->GetTimeStep());
+	m_model->SetRenderTime(renderTime);
 	m_model->Render(matrix4x4f(viewTransform * GetInterpMatrix()));
 }
 

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -143,10 +143,13 @@ namespace SceneGraph {
 		m_tMat->diffuse = m_glowMat->diffuse = currentColor;
 
 		//directional fade
-		vector3f cdir = vector3f(trans * -dir).Normalized();
-		vector3f vdir = vector3f(trans[2], trans[6], -trans[10]).Normalized();
+		// In view space, camera is at origin, so view direction is from thruster position to origin.
+		vector3f flameDir = trans.ApplyRotationOnly(vector3f(0.f, 0.f, 1.f)).Normalized();
+		vector3f thrusterPos = trans.GetTranslate();
+		vector3f vdir = (thrusterPos.LengthSqr() > 1e-8f) ? (-thrusterPos).Normalized() : flameDir;
+		float facing = Clamp(std::abs(vdir.Dot(flameDir)), 0.f, 1.f);
 		// XXX check this for transition to new colors.
-		m_glowMat->diffuse.a = Easing::Circ::EaseIn(Clamp(vdir.Dot(cdir), 0.f, 1.f), 0.f, 1.f, 1.f) * 255;
+		m_glowMat->diffuse.a = Easing::Circ::EaseIn(facing, 0.f, 1.f, 1.f) * 255;
 		m_tMat->diffuse.a = 255 - m_glowMat->diffuse.a;
 
 		Graphics::Renderer *r = GetRenderer();

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -130,7 +130,7 @@ namespace SceneGraph {
 		// generated once per frame, not for every vertex
 		float hash = pos.x + pos.y + pos.z;
 		hash = (uint16_t(hash32(*reinterpret_cast<uint32_t *>(&hash)) & 0xFFFF)) / 65535.f;
-		const float x = static_cast<float>(rd->renderTime) * 35.f * (0.75f + hash * 0.5f);
+		const double x = rd->renderTime * 35.0 * (0.75 + hash * 0.5);
 		const float flicker = abs(sin(x) * sin(pow(x, 1.1)));
 
 		// pass the power setting and flicker value using the material emissive


### PR DESCRIPTION
Fixes #6245.

The math to calculate thruster flame intensity extracted a vector from the transformation matrix to represent its direction. This worked most of the time, except that certain thruster orientations could come out with different results. This was most noticeable on pairs of thrusters created by mirroring or rotating an existing thruster to a duplicate on the opposite side of the ship.

I've changed the code to use the actual thruster-to-camera vector instead of matrix-axis extraction. This eliminates any rotation-dependent brightness mismatch on mirrored thrusters, and the Coronatrix forward thrusters now look the same for me.

I also spent 5 minutes staring at the opening scene of the game that shows all the ships one by one rotating with all thrusters firing, and they all now look correct too.