### PR TITLE
Thruster exhaust plumes

### DIFF
--- a/data/shaders/opengl/exhaust.frag
+++ b/data/shaders/opengl/exhaust.frag
@@ -5,8 +5,8 @@
 #include "lib.glsl"
 
 in vec2 v_uv;
-in float v_ageNorm;
-in float v_opacityScale;
+in vec4 v_color;
+in float v_isDust;
 
 out vec4 frag_color;
 
@@ -18,10 +18,15 @@ void main(void)
 
 	float edge = smoothstep(1.0, 0.12, r);
 	float inner = smoothstep(0.75, 0.0, r);
-	// Nonlinear fade: keep strong near birth, then decay faster through mid/late life.
-	float ageFade = pow(1.0 - clamp(v_ageNorm, 0.0, 1.0), 2.8);
 
-	float alpha = material.diffuse.a * edge * ageFade * clamp(v_opacityScale, 0.0, 1.0);
-	vec3 color = material.diffuse.rgb + vec3(0.12, 0.14, 0.18) * inner;
+	// C++ supplies age fade in v_color: exhaust uses rgb as a uniform scale (ageFade);
+	// dust uses rgb as final tint * ageFade. v_color.a holds opacityScale * ageFade.
+	vec3 color;
+	if (v_isDust > 0.5)
+		color = v_color.rgb;
+	else
+		color = material.diffuse.rgb * v_color.rgb + vec3(0.12, 0.14, 0.18) * inner;
+
+	float alpha = material.diffuse.a * v_color.a * edge;
 	frag_color = vec4(color, alpha);
 }

--- a/data/shaders/opengl/exhaust.frag
+++ b/data/shaders/opengl/exhaust.frag
@@ -9,14 +9,38 @@ in vec4 v_color;
 
 out vec4 frag_color;
 
+vec2 rando(vec2 st){
+    st = vec2( dot(st,vec2(127.1,311.7)),
+              dot(st,vec2(269.5,183.3)) );
+    return -1.0 + 2.0*fract(sin(st)*43758.5453123);
+}
+
+float noise(vec2 st) {
+    vec2 i = floor(st);
+    vec2 f = fract(st);
+
+    vec2 u = f*f*(3.0-2.0*f);
+
+    return mix( mix( dot( rando(i + vec2(0.0,0.0) ), f - vec2(0.0,0.0) ),
+                     dot( rando(i + vec2(1.0,0.0) ), f - vec2(1.0,0.0) ), u.x),
+                mix( dot( rando(i + vec2(0.0,1.0) ), f - vec2(0.0,1.0) ),
+                     dot( rando(i + vec2(1.0,1.0) ), f - vec2(1.0,1.0) ), u.x), u.y);
+}
+
 void main(void)
 {
+	// Use a circular shape, with a soft edge
 	vec2 uv = v_uv * 2.0 - 1.0;
 	float r = length(uv);
 	if (r > 1.0) discard;
-
 	float edge = smoothstep(1.0, 0.12, r);
 
-	float alpha = v_color.a * edge;
+	// Make some noise! Woop Woop!
+	// Increase noise_cells for smaller blobs, decrease for larger ones.
+	const float noise_cells = 3.0;
+	vec2 pos = v_uv * noise_cells;
+	float noise_val = noise(pos) * 2.0 + 0.5;
+
+	float alpha = v_color.a * edge * noise_val;
 	frag_color = vec4(v_color.rgb, alpha);
 }

--- a/data/shaders/opengl/exhaust.frag
+++ b/data/shaders/opengl/exhaust.frag
@@ -6,7 +6,6 @@
 
 in vec2 v_uv;
 in vec4 v_color;
-in float v_isDust;
 
 out vec4 frag_color;
 
@@ -17,16 +16,7 @@ void main(void)
 	if (r > 1.0) discard;
 
 	float edge = smoothstep(1.0, 0.12, r);
-	float inner = smoothstep(0.75, 0.0, r);
 
-	// C++ supplies age fade in v_color: exhaust uses rgb as a uniform scale (ageFade);
-	// dust uses rgb as final tint * ageFade. v_color.a holds opacityScale * ageFade.
-	vec3 color;
-	if (v_isDust > 0.5)
-		color = v_color.rgb;
-	else
-		color = material.diffuse.rgb * v_color.rgb + vec3(0.12, 0.14, 0.18) * inner;
-
-	float alpha = material.diffuse.a * v_color.a * edge;
-	frag_color = vec4(color, alpha);
+	float alpha = v_color.a * edge;
+	frag_color = vec4(v_color.rgb, alpha);
 }

--- a/data/shaders/opengl/exhaust.frag
+++ b/data/shaders/opengl/exhaust.frag
@@ -1,0 +1,27 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "attributes.glsl"
+#include "lib.glsl"
+
+in vec2 v_uv;
+in float v_ageNorm;
+in float v_opacityScale;
+
+out vec4 frag_color;
+
+void main(void)
+{
+	vec2 uv = v_uv * 2.0 - 1.0;
+	float r = length(uv);
+	if (r > 1.0) discard;
+
+	float edge = smoothstep(1.0, 0.12, r);
+	float inner = smoothstep(0.75, 0.0, r);
+	// Nonlinear fade: keep strong near birth, then decay faster through mid/late life.
+	float ageFade = pow(1.0 - clamp(v_ageNorm, 0.0, 1.0), 2.8);
+
+	float alpha = material.diffuse.a * edge * ageFade * clamp(v_opacityScale, 0.0, 1.0);
+	vec3 color = material.diffuse.rgb + vec3(0.12, 0.14, 0.18) * inner;
+	frag_color = vec4(color, alpha);
+}

--- a/data/shaders/opengl/exhaust.shaderdef
+++ b/data/shaders/opengl/exhaust.shaderdef
@@ -1,0 +1,9 @@
+## Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+## Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+Shader exhaust
+
+Buffer DrawData binding=1
+
+Vertex "exhaust.vert"
+Fragment "exhaust.frag"

--- a/data/shaders/opengl/exhaust.vert
+++ b/data/shaders/opengl/exhaust.vert
@@ -6,13 +6,10 @@
 
 out vec2 v_uv;
 out vec4 v_color;
-// 1.0 when particle is dust kick (no material / inner lift); 0.0 for exhaust plume.
-out float v_isDust;
 
 void main(void)
 {
 	gl_Position = matrixTransform();
 	v_uv = a_uv0.xy;
 	v_color = vec4(a_color);
-	v_isDust = a_normal.x;
 }

--- a/data/shaders/opengl/exhaust.vert
+++ b/data/shaders/opengl/exhaust.vert
@@ -1,0 +1,17 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "attributes.glsl"
+#include "lib.glsl"
+
+out vec2 v_uv;
+out float v_ageNorm;
+out float v_opacityScale;
+
+void main(void)
+{
+	gl_Position = matrixTransform();
+	v_uv = a_uv0.xy;
+	v_ageNorm = a_normal.x;
+	v_opacityScale = a_normal.y;
+}

--- a/data/shaders/opengl/exhaust.vert
+++ b/data/shaders/opengl/exhaust.vert
@@ -5,13 +5,14 @@
 #include "lib.glsl"
 
 out vec2 v_uv;
-out float v_ageNorm;
-out float v_opacityScale;
+out vec4 v_color;
+// 1.0 when particle is dust kick (no material / inner lift); 0.0 for exhaust plume.
+out float v_isDust;
 
 void main(void)
 {
 	gl_Position = matrixTransform();
 	v_uv = a_uv0.xy;
-	v_ageNorm = a_normal.x;
-	v_opacityScale = a_normal.y;
+	v_color = vec4(a_color);
+	v_isDust = a_normal.x;
 }

--- a/data/shaders/opengl/exhaust.vert
+++ b/data/shaders/opengl/exhaust.vert
@@ -4,12 +4,57 @@
 #include "attributes.glsl"
 #include "lib.glsl"
 
+// Per-particle instance data
+layout (location = 6) in vec4 a_instCenterSize;
+layout (location = 7) in vec4 a_instJetVector;
+layout (location = 8) in float a_instStretchScale;
+layout (location = 9) in vec4 a_instColor;
+
 out vec2 v_uv;
 out vec4 v_color;
 
+vec3 normalizedSafe(vec3 v)
+{
+	float lenSq = dot(v, v);
+	if (lenSq < 1e-18)
+		return vec3(1.0, 0.0, 0.0);
+	return v * inversesqrt(lenSq);
+}
+
 void main(void)
 {
-	gl_Position = matrixTransform();
-	v_uv = a_uv0.xy;
-	v_color = vec4(a_color);
+	// Procedural unit quad: CCW triangle strip, lower-left origin (no per-vertex buffer).
+	vec2 uv = vec2(float(gl_VertexID & 1), float(gl_VertexID >> 1));
+	float ux = mix(-1.0, 1.0, uv.x);
+	float vy = mix(-1.0, 1.0, uv.y);
+
+	vec3 center = a_instCenterSize.xyz;
+	float size = a_instCenterSize.w;
+	vec3 jetVectorCam = a_instJetVector.xyz;
+	float backboneCamZ = a_instJetVector.w;
+	float stretchScale = a_instStretchScale;
+
+	vec3 viewDir = normalizedSafe(-center);
+
+	vec3 vProj = jetVectorCam - viewDir * dot(jetVectorCam, viewDir);
+	vec3 axisV = normalizedSafe(vProj);
+	vec3 axisU = normalizedSafe(cross(viewDir, axisV));
+
+	float speedMag = dot(jetVectorCam, axisV);
+	float attenuation = 1.0;
+	float prevZ = abs(backboneCamZ - jetVectorCam.z);
+	float curZ = abs(backboneCamZ);
+	if ((prevZ > 0.1) && (curZ > 0.1))
+		attenuation = min(1.0, curZ / prevZ);
+	float stretch = stretchScale * speedMag * attenuation;
+
+	vec3 worldPos = center + axisU * (ux * size) + axisV * (vy * size);
+
+	// Bottom row of the quad is stretched back along the jet axis for streak particles.
+	if (uv.y < 0.5)
+		worldPos -= axisV * stretch;
+
+	gl_Position = uViewProjectionMatrix * vec4(worldPos, 1.0);
+	v_uv = uv;
+	v_color = a_instColor;
 }

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -353,7 +353,7 @@ void Camera::Draw(const Body *excludeBody)
 		m_renderer->DrawBuffer(&billboards, m_billboardMaterial.get());
 	}
 
-	SfxManager::RenderAll(m_renderer, rootFrameId, camFrameId);
+	SfxManager::RenderAll(m_renderer, rootFrameId, camFrameId, this);
 }
 
 // Calculates the ambiently and directly lit portions of the lighting model taking into account the atmosphere and sun positions at a given location

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -353,7 +353,14 @@ void Camera::Draw(const Body *excludeBody)
 		m_renderer->DrawBuffer(&billboards, m_billboardMaterial.get());
 	}
 
-	SfxManager::RenderAll(m_renderer, rootFrameId, camFrameId, this);
+	float illuminationFactor = 1.f;
+	if (Pi::game && Pi::player && !Pi::player->IsDead()) {
+		double amb = 0.0, direct = 1.0;
+		CalcLighting(Pi::player, amb, direct);
+		illuminationFactor = Clamp(float(amb + direct), 0.08f, 1.0f);
+		illuminationFactor = std::pow(illuminationFactor, 1.5);
+	}
+	SfxManager::RenderAll(m_renderer, rootFrameId, camFrameId, illuminationFactor);
 }
 
 // Calculates the ambiently and directly lit portions of the lighting model taking into account the atmosphere and sun positions at a given location

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -156,7 +156,7 @@ void Frame::ToJson(Json &frameObj, FrameId fId, Space *space)
 		frameObj["child_frames"] = childFrameArray; // Add child frame array to frame object.
 
 	// Add sfx array to supplied object.
-	SfxManager::ToJson(frameObj, f->m_thisId);
+	SfxManager::ToJson(frameObj, f->m_thisId, space);
 }
 
 Frame::~Frame()

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -12,6 +12,7 @@
 #include "JsonUtils.h"
 #include "ModelBody.h"
 #include "Pi.h"
+#include "Space.h"
 #include "matrix4x4.h"
 
 #include "core/IniConfig.h"
@@ -26,9 +27,30 @@
 
 #include "profiler/Profiler.h"
 
+#include <algorithm>
+#include <vector>
+
 using namespace Graphics;
 
 namespace {
+	constexpr uint64_t EXHAUST_EMITTER_PTR_SORT_TAG = UINT64_C(0x8000000000000000);
+
+	inline uint64_t ExhaustStreamEmitterSortKey(const Sfx &s)
+	{
+		if (s.m_exhaustEmitter)
+			return EXHAUST_EMITTER_PTR_SORT_TAG | static_cast<uint64_t>(reinterpret_cast<uintptr_t>(s.m_exhaustEmitter));
+		return static_cast<uint64_t>(s.m_exhaustSavedEmitterBodyIdx);
+	}
+
+	inline bool SameExhaustJetStream(const Sfx &a, const Sfx &b)
+	{
+		if (a.m_exhaustJetIndex != b.m_exhaustJetIndex)
+			return false;
+		if (a.m_exhaustEmitter || b.m_exhaustEmitter)
+			return a.m_exhaustEmitter == b.m_exhaustEmitter;
+		return a.m_exhaustSavedEmitterBodyIdx == b.m_exhaustSavedEmitterBodyIdx;
+	}
+
 	float SizeToPixels(int screenHeight, const vector3f &trans, const float size)
 	{
 		//some hand-tweaked scaling, to make the lights seem larger from distance (final size is in pixels)
@@ -49,7 +71,7 @@ namespace {
 		case TYPE_SMOKE:
 			return Clamp(SizeToPixels(screenHeight, pos, (inst.m_speed * inst.m_age)), 0.1f, 50.0f);
 		case TYPE_EXHAUST:
-			// Calculated by the particle code
+			return 0.f; // billboards use explicit vertex quads in RenderAll
 		default:
 			return 0.f;
 		}
@@ -78,7 +100,12 @@ Sfx::Sfx(const vector3d &pos, const vector3d &vel, const float speed, const SFX_
 	m_dragScale(1.0f),
 	m_opacityScale(1.0f),
 	m_windVel(vector3d::Zero),
-	m_type(type)
+	m_type(type),
+	m_exhaustEmitter(nullptr),
+	m_exhaustSavedEmitterBodyIdx(Sfx::INVALID_EXHAUST_SAVED_BODY_IDX),
+	m_exhaustJetIndex(0),
+	m_exhaustBirthSeq(0),
+	m_exhaustSuppressStreakElongation(false)
 {
 	if (type == TYPE_EXHAUST)
 		m_lifetime = SfxParams::EXHAUST_LIFETIME * float(Pi::rng.Double(0.6, 1.0));
@@ -103,12 +130,17 @@ Sfx::Sfx(const Json &jsonObj)
 		m_opacityScale = sfxObj.value("opacityScale", 1.0f);
 		m_windVel = sfxObj.value("windVel", vector3d::Zero);
 		m_type = sfxObj["type"];
+		m_exhaustEmitter = nullptr;
+		m_exhaustSavedEmitterBodyIdx = sfxObj.value("exhaustEmitterBodyIdx", Sfx::INVALID_EXHAUST_SAVED_BODY_IDX);
+		m_exhaustJetIndex = Uint16(sfxObj.value("exhaustJetIndex", 0));
+		m_exhaustBirthSeq = sfxObj.value("exhaustBirthSeq", Uint32(0));
+		m_exhaustSuppressStreakElongation = sfxObj.value("exhaustSuppressStreakElongation", false);
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
 }
 
-void Sfx::SaveToJson(Json &jsonObj)
+void Sfx::SaveToJson(Json &jsonObj, const Space *space)
 {
 	Json sfxObj({}); // Create JSON object to contain sfx data.
 
@@ -124,6 +156,13 @@ void Sfx::SaveToJson(Json &jsonObj)
 		sfxObj["dragScale"] = m_dragScale;
 		sfxObj["opacityScale"] = m_opacityScale;
 		sfxObj["windVel"] = m_windVel;
+		Uint32 bodyIdxForSave = m_exhaustSavedEmitterBodyIdx;
+		if (m_exhaustEmitter && space && space->IsBodyIndexValid())
+			bodyIdxForSave = space->GetIndexForBody(m_exhaustEmitter);
+		sfxObj["exhaustEmitterBodyIdx"] = bodyIdxForSave;
+		sfxObj["exhaustJetIndex"] = m_exhaustJetIndex;
+		sfxObj["exhaustBirthSeq"] = m_exhaustBirthSeq;
+		sfxObj["exhaustSuppressStreakElongation"] = m_exhaustSuppressStreakElongation;
 	}
 	sfxObj["age"] = m_age;
 	sfxObj["seed"] = m_seed;
@@ -186,14 +225,15 @@ float Sfx::AgeBlend() const
 	return 0.0f;
 }
 
-SfxManager::SfxManager()
+SfxManager::SfxManager() :
+	m_nextExhaustBirthSeq(1)
 {
 	for (size_t t = 0; t < TYPE_NONE; t++) {
 		m_instances[t].clear();
 	}
 }
 
-void SfxManager::ToJson(Json &jsonObj, const FrameId fId)
+void SfxManager::ToJson(Json &jsonObj, const FrameId fId, const Space *space)
 {
 	Frame *f = Frame::GetFrame(fId);
 	Json sfxArray = Json::array(); // Create JSON array to contain sfx data.
@@ -204,7 +244,7 @@ void SfxManager::ToJson(Json &jsonObj, const FrameId fId)
 				Sfx &inst(f->m_sfx->GetInstanceByIndex(SFX_TYPE(t), i));
 				if (inst.m_type != TYPE_NONE) {
 					Json sfxArrayEl({}); // Create JSON object to contain sfx element.
-					inst.SaveToJson(sfxArrayEl);
+					inst.SaveToJson(sfxArrayEl, space);
 					sfxArray.push_back(sfxArrayEl); // Append sfx object to array.
 				}
 			}
@@ -273,7 +313,7 @@ void SfxManager::AddThrustSmoke(const Body *b, const float speed, const vector3d
 	sfxman->AddInstance(sfx);
 }
 
-void SfxManager::AddExhaust(const Body *b, const vector3d &startPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3d &windVel)
+void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const bool exhaustSuppressStreakElongation, const vector3d &startPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3d &windVel)
 {
 	SfxManager *sfxman = AllocSfxInFrame(b->GetFrame());
 	if (!sfxman) return;
@@ -289,6 +329,11 @@ void SfxManager::AddExhaust(const Body *b, const vector3d &startPos, const vecto
 	sfx.m_opacityScale = opacityScale;
 	sfx.m_windVel = windVel;
 	sfx.m_backboneAtStepStart = sfx.m_backbonePos;
+	sfx.m_exhaustJetIndex = exhaustJetIndex;
+	sfx.m_exhaustEmitter = b;
+	sfx.m_exhaustSavedEmitterBodyIdx = Sfx::INVALID_EXHAUST_SAVED_BODY_IDX;
+	sfx.m_exhaustSuppressStreakElongation = exhaustSuppressStreakElongation;
+	sfx.m_exhaustBirthSeq = sfxman->m_nextExhaustBirthSeq++;
 	sfxman->AddInstance(sfx);
 }
 
@@ -365,48 +410,59 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 				break;
 			}
 
-			// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
-			Graphics::VertexArray pointArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL, numInstances);
-			Graphics::VertexArray exhaustArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0 | Graphics::ATTRIB_NORMAL, numInstances * 6);
+			const double timeStep = Pi::game ? double(Pi::game->GetTimeStep()) : 0.0;
+			const double alpha = Pi::game ? Pi::GetGameTickAlpha() : 1.0;
 
-			vector3d prevInterpBackboneCam = vector3d::Zero;
-			bool hasPrevInterpBackboneCam = false;
+			if (t == TYPE_EXHAUST) {
+				Graphics::VertexArray exhaustArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0 | Graphics::ATTRIB_NORMAL, numInstances * 6);
+				std::vector<size_t> exhaustOrder(numInstances);
+				for (size_t i = 0; i < numInstances; ++i)
+					exhaustOrder[i] = i;
+				std::sort(exhaustOrder.begin(), exhaustOrder.end(), [&](size_t ia, size_t ib) {
+					const Sfx &a = f->m_sfx->GetInstanceByIndex(TYPE_EXHAUST, ia);
+					const Sfx &b = f->m_sfx->GetInstanceByIndex(TYPE_EXHAUST, ib);
+					const uint64_t keyA = ExhaustStreamEmitterSortKey(a);
+					const uint64_t keyB = ExhaustStreamEmitterSortKey(b);
+					if (keyA != keyB)
+						return keyA < keyB;
+					if (a.m_exhaustJetIndex != b.m_exhaustJetIndex)
+						return a.m_exhaustJetIndex < b.m_exhaustJetIndex;
+					if (a.m_exhaustBirthSeq != b.m_exhaustBirthSeq)
+						return a.m_exhaustBirthSeq < b.m_exhaustBirthSeq;
+					return ia < ib;
+				});
 
-			for (size_t i = 0; i < numInstances; i++) {
-				Sfx &inst(f->m_sfx->GetInstanceByIndex(SFX_TYPE(t), i));
+				const Sfx *prevStreakParticle = nullptr;
+				vector3d prevInterpBackboneCam = vector3d::Zero;
 
-				assert(inst.m_type == t);
+				for (const size_t i : exhaustOrder) {
+					Sfx &inst(f->m_sfx->GetInstanceByIndex(TYPE_EXHAUST, i));
 
-				// Interpolate particle position within the current physics tick so SFX
-				// motion matches interpolated ship/body rendering (see DynamicBody::UpdateInterpTransform).
-				const double interpDt = Pi::game ? (Pi::GetGameTickAlpha() * double(Pi::game->GetTimeStep())) : 0.0;
-				vector3d interpPos = inst.m_pos + inst.m_vel * interpDt;
-				vector3d interpBackbone{};
-				vector3d interpOffset{};
-				if (t == TYPE_EXHAUST) {
+					assert(inst.m_type == t);
+
 					// Backbone stores explicit start/end for this physics step.
-					const double alpha = Pi::game ? Pi::GetGameTickAlpha() : 1.0;
-					const double physicsStep = Pi::game ? double(Pi::game->GetTimeStep()) : 0.0;
-					interpBackbone = inst.m_backboneAtStepStart * (1.0 - alpha) + inst.m_backbonePos * alpha;
+					vector3d interpBackbone = inst.m_backboneAtStepStart * (1.0 - alpha) + inst.m_backbonePos * alpha;
+
 					// Plume offset is a small local perturbation; derive its start-of-step estimate
 					// from end-of-step offset and current plume offset velocity.
-					interpOffset = inst.m_plumeOffset - inst.m_plumeOffsetVel * ((1.0 - alpha) * physicsStep);
-					interpPos = interpBackbone + interpOffset;
-				}
-				// make the particle position relative to the camera frame
-				const vector3f pos(ftran * interpPos);
+					const vector3d interpOffset = inst.m_plumeOffset - inst.m_plumeOffsetVel * ((1.0 - alpha) * timeStep);
+					const vector3d interpPos = interpBackbone + interpOffset;
+					const vector3f pos(ftran * interpPos);
 
-				if (t == TYPE_EXHAUST) {
 					const float ageNorm = Clamp(inst.m_age / std::max(inst.m_lifetime, 0.001f), 0.0f, 1.0f);
 					const vector3d interpBackboneCam = ftran * interpBackbone;
-					vector3d backboneDirCamD;
-					if (hasPrevInterpBackboneCam) {
-						backboneDirCamD = interpBackboneCam - prevInterpBackboneCam;
-					} else {
-						backboneDirCamD = ftran.ApplyRotationOnly(inst.m_backboneVel);
-					}
+
+					const bool sameJetStream = prevStreakParticle && SameExhaustJetStream(*prevStreakParticle, inst);
+					const bool elongateTowardPrev = sameJetStream && !inst.m_exhaustSuppressStreakElongation;
+
+					vector3d backboneDirCamD = interpBackboneCam - prevInterpBackboneCam;
+					if ((backboneDirCamD.LengthSqr() < 1e-5) || !elongateTowardPrev)
+						backboneDirCamD = ftran.ApplyRotationOnly(-inst.m_backboneVel / SfxParams::EXHAUST_PARTICLES_PER_SEC);
+
 					prevInterpBackboneCam = interpBackboneCam;
-					hasPrevInterpBackboneCam = true;
+					prevStreakParticle = &inst;
+					if (!elongateTowardPrev) continue;
+
 					vector3f jetAxis = vector3f(backboneDirCamD).NormalizedSafe();
 					if (jetAxis.LengthSqr() < 1e-6f) jetAxis = vector3f(0.f, 0.f, 1.f);
 
@@ -429,7 +485,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 					const float baseStretch = Clamp(speedMag * 20.0f, 0.0f, 100.0f);
 					const float apparentStretch = baseStretch * sideOn;
 
-					float size = std::max(0.01f, float(inst.m_plumeOffset.Length()) * 2.0f);
+					float size = std::max(0.01f, float(inst.m_plumeOffset.Length()));
 
 					// Two UV triangles, the V-axis is aligned to the jet backbone axis.
 					const vector3f u = axisU * size;
@@ -448,19 +504,34 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 					exhaustArray.Add(p2, packed, vector2f(1.f, 1.f));
 					exhaustArray.Add(p3, packed, vector2f(0.f, 1.f));
 					exhaustArray.Add(p0, packed, vector2f(0.f, 0.f));
-				} else {
+				}
+
+				renderer->SetTransform(matrix4x4f::Identity);
+				renderer->DrawBuffer(&exhaustArray, material);
+
+			} else {
+				const double interpDt = alpha * timeStep;
+				// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
+				Graphics::VertexArray pointArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL, numInstances);
+
+				for (size_t i = 0; i < numInstances; i++) {
+					Sfx &inst(f->m_sfx->GetInstanceByIndex(SFX_TYPE(t), i));
+
+					assert(inst.m_type == t);
+
+					vector3d interpPos = inst.m_pos + inst.m_vel * interpDt;
+
+					const vector3f pos(ftran * interpPos);
+
 					// pack UV offset and particle size in normal attribute
 					const vector2f offset = CalculateOffset(SFX_TYPE(t), inst);
 					const float size = GetParticleSize(screenHeight, SFX_TYPE(t), pos, inst);
 					pointArray.Add(pos, vector3f(offset, Clamp(size, 0.1f, FLT_MAX)));
 				}
-			}
 
-			renderer->SetTransform(matrix4x4f::Identity);
-			if (t == TYPE_EXHAUST)
-				renderer->DrawBuffer(&exhaustArray, material);
-			else
+				renderer->SetTransform(matrix4x4f::Identity);
 				renderer->DrawBuffer(&pointArray, material);
+			}
 		}
 	}
 

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -4,14 +4,17 @@
 #include "Sfx.h"
 
 #include "Body.h"
+#include "Camera.h"
 #include "FileSystem.h"
 #include "Frame.h"
 #include "Game.h"
 #include "GameSaveError.h"
 #include "Json.h"
 #include "JsonUtils.h"
+#include "MathUtil.h"
 #include "ModelBody.h"
 #include "Pi.h"
+#include "Player.h"
 #include "Space.h"
 #include "matrix4x4.h"
 
@@ -28,6 +31,7 @@
 #include "profiler/Profiler.h"
 
 #include <algorithm>
+#include <cmath>
 #include <vector>
 
 using namespace Graphics;
@@ -76,6 +80,49 @@ namespace {
 			return 0.f;
 		}
 	}
+
+	void ApplyExhaustGroundThreshold(Sfx &s)
+	{
+		if (!(s.m_exhaustGroundRadius > 1.0))
+			return;
+
+		if (s.m_exhaustDustKick)
+			return;	// Already hit the ground
+
+		const vector3d particlePos = s.m_backbonePos + s.m_plumeOffset;
+		const double radialDistSqr = particlePos.LengthSqr();
+		const double groundRadius = s.m_exhaustGroundRadius;
+		if (radialDistSqr > groundRadius * groundRadius)
+			return;
+
+		// Randomly cull some particles right at exhaust->dust transition, because the
+		// dust clouds are large and diffuse and don't need nearly as many particles
+		if (Pi::rng.Double() < double(SfxParams::EXHAUST_DUST_TRANSITION_CULL_PROB)) {
+			s.m_type = TYPE_NONE;
+			return;
+		}
+
+		const double rl = std::sqrt(std::max(radialDistSqr, 1e-24));
+		const vector3d rad = particlePos / rl;
+		const vector3d surface = rad * groundRadius;
+
+		const vector3d ref(std::abs(rad.y) < 0.92 ? vector3d(0., 1., 0.) : vector3d(1., 0., 0.));
+		vector3d east = rad.Cross(ref).NormalizedSafe();
+		vector3d north = east.Cross(rad).NormalizedSafe();
+		const double ang = Pi::rng.Double(0., 2.0 * M_PI);
+		const vector3d tang = (east * std::cos(ang) + north * std::sin(ang)).NormalizedSafe();
+		const double tanJ = Pi::rng.Double(0.35, 1.0);
+		const double radJ = Pi::rng.Double(0.55, 1.0);
+
+		s.m_backbonePos = surface;
+		s.m_plumeOffset = vector3d(0.);
+		s.m_backboneVel = vector3d(0.);
+		s.m_plumeOffsetVel =
+			rad * double(SfxParams::EXHAUST_DUST_RADIAL_KICK_SPEED * float(radJ)) +
+			tang * double(SfxParams::EXHAUST_DUST_TANGENT_KICK_SPEED * float(tanJ));
+
+		s.m_exhaustDustKick = true;
+	}
 } // namespace
 
 std::unique_ptr<Graphics::Material> SfxManager::damageParticle;
@@ -105,10 +152,13 @@ Sfx::Sfx(const vector3d &pos, const vector3d &vel, const float speed, const SFX_
 	m_exhaustSavedEmitterBodyIdx(Sfx::INVALID_EXHAUST_SAVED_BODY_IDX),
 	m_exhaustJetIndex(0),
 	m_exhaustBirthSeq(0),
-	m_exhaustSuppressStreakElongation(false)
+	m_exhaustSuppressStreakElongation(false),
+	m_exhaustGroundRadius(0.0),
+	m_exhaustDustKick(false),
+	m_exhaustDustTint(0, 0, 0, 0)
 {
 	if (type == TYPE_EXHAUST)
-		m_lifetime = SfxParams::EXHAUST_LIFETIME * float(Pi::rng.Double(0.6, 1.0));
+		m_lifetime = SfxParams::EXHAUST_LIFETIME * float(std::pow(Pi::rng.Double(0.5, 1.0), 2.0));
 }
 
 Sfx::Sfx(const Json &jsonObj)
@@ -135,6 +185,9 @@ Sfx::Sfx(const Json &jsonObj)
 		m_exhaustJetIndex = Uint16(sfxObj.value("exhaustJetIndex", 0));
 		m_exhaustBirthSeq = sfxObj.value("exhaustBirthSeq", Uint32(0));
 		m_exhaustSuppressStreakElongation = sfxObj.value("exhaustSuppressStreakElongation", false);
+		m_exhaustGroundRadius = sfxObj.value("exhaustGroundRadius", 0.0);
+		m_exhaustDustKick = sfxObj.value("exhaustDustKick", false);
+		m_exhaustDustTint = sfxObj.value("exhaustDustTint", Color(0, 0, 0, 0));
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
@@ -163,6 +216,9 @@ void Sfx::SaveToJson(Json &jsonObj, const Space *space)
 		sfxObj["exhaustJetIndex"] = m_exhaustJetIndex;
 		sfxObj["exhaustBirthSeq"] = m_exhaustBirthSeq;
 		sfxObj["exhaustSuppressStreakElongation"] = m_exhaustSuppressStreakElongation;
+		sfxObj["exhaustGroundRadius"] = m_exhaustGroundRadius;
+		sfxObj["exhaustDustKick"] = m_exhaustDustKick;
+		sfxObj["exhaustDustTint"] = m_exhaustDustTint;
 	}
 	sfxObj["age"] = m_age;
 	sfxObj["seed"] = m_seed;
@@ -202,6 +258,7 @@ void Sfx::TimeStepUpdate(const float timeStep)
 
 			m_backbonePos += m_backboneVel * double(timeStep);
 			m_plumeOffset += m_plumeOffsetVel * double(timeStep);
+			ApplyExhaustGroundThreshold(*this);
 
 			// Keep legacy fields coherent for non-exhaust code paths.
 			m_pos = m_backbonePos + m_plumeOffset;
@@ -313,7 +370,7 @@ void SfxManager::AddThrustSmoke(const Body *b, const float speed, const vector3d
 	sfxman->AddInstance(sfx);
 }
 
-void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const bool exhaustSuppressStreakElongation, const vector3d &startPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3d &windVel)
+void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const bool exhaustSuppressStreakElongation, const vector3d &startPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3d &windVel, const double groundRadius, const Color &dustTint)
 {
 	SfxManager *sfxman = AllocSfxInFrame(b->GetFrame());
 	if (!sfxman) return;
@@ -334,6 +391,9 @@ void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const b
 	sfx.m_exhaustSavedEmitterBodyIdx = Sfx::INVALID_EXHAUST_SAVED_BODY_IDX;
 	sfx.m_exhaustSuppressStreakElongation = exhaustSuppressStreakElongation;
 	sfx.m_exhaustBirthSeq = sfxman->m_nextExhaustBirthSeq++;
+	sfx.m_exhaustGroundRadius = groundRadius;
+	sfx.m_exhaustDustKick = false;
+	sfx.m_exhaustDustTint = dustTint;
 	sfxman->AddInstance(sfx);
 }
 
@@ -374,12 +434,18 @@ void SfxManager::Cleanup()
 	}
 }
 
-void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
+void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, const Camera *camera, float exhaustIllumMul)
 {
+	PROFILE_SCOPED()
+
 	Frame *f = Frame::GetFrame(fId);
 	int screenHeight = renderer->GetWindowHeight();
 
-	PROFILE_SCOPED()
+	if (camera && Pi::game && Pi::player && !Pi::player->IsDead() && fId == Pi::game->GetSpace()->GetRootFrame()) {
+		double amb = 0.0, direct = 1.0;
+		camera->CalcLighting(Pi::player, amb, direct);
+		exhaustIllumMul = Clamp(float(amb + direct), 0.08f, 1.0f);
+	}
 	if (f->m_sfx) {
 		matrix4x4d ftran;
 		// Use interpolated frame transform so SFX aligns with interpolated body rendering.
@@ -414,7 +480,9 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 			const double alpha = Pi::game ? Pi::GetGameTickAlpha() : 1.0;
 
 			if (t == TYPE_EXHAUST) {
-				Graphics::VertexArray exhaustArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0 | Graphics::ATTRIB_NORMAL, numInstances * 6);
+				Graphics::VertexArray exhaustArray(
+					Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0,
+					numInstances * 6);
 				std::vector<size_t> exhaustOrder(numInstances);
 				for (size_t i = 0; i < numInstances; ++i)
 					exhaustOrder[i] = i;
@@ -452,19 +520,17 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 					const float ageNorm = Clamp(inst.m_age / std::max(inst.m_lifetime, 0.001f), 0.0f, 1.0f);
 					const vector3d interpBackboneCam = ftran * interpBackbone;
 
+					const bool prevWasDust = prevStreakParticle && prevStreakParticle->m_exhaustDustKick;
 					const bool sameJetStream = prevStreakParticle && SameExhaustJetStream(*prevStreakParticle, inst);
 					const bool elongateTowardPrev = sameJetStream && !inst.m_exhaustSuppressStreakElongation;
 
 					vector3d backboneDirCamD = interpBackboneCam - prevInterpBackboneCam;
-					if ((backboneDirCamD.LengthSqr() < 1e-5) || !elongateTowardPrev)
-						backboneDirCamD = ftran.ApplyRotationOnly(-inst.m_backboneVel / SfxParams::EXHAUST_PARTICLES_PER_SEC);
 
 					prevInterpBackboneCam = interpBackboneCam;
 					prevStreakParticle = &inst;
 					if (!elongateTowardPrev) continue;
 
 					vector3f jetAxis = vector3f(backboneDirCamD).NormalizedSafe();
-					if (jetAxis.LengthSqr() < 1e-6f) jetAxis = vector3f(0.f, 0.f, 1.f);
 
 					// Camera-space view direction from particle to camera origin.
 					vector3f viewDir = (-pos).NormalizedSafe();
@@ -473,8 +539,8 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 					// This approximates an ellipsoid projection:
 					// - looking down axis => round
 					// - side-on => elongated.
-					float axisViewDot = Clamp(fabs(jetAxis.Dot(viewDir)), 0.f, 1.f);
-					float sideOn = sqrtf(std::max(0.f, 1.f - axisViewDot * axisViewDot));
+					const float axisViewDot = Clamp(fabs(jetAxis.Dot(viewDir)), 0.f, 1.f);
+					const float sideOn = 1.0f - axisViewDot * axisViewDot;
 					vector3f vProj = jetAxis - viewDir * jetAxis.Dot(viewDir);
 					vector3f axisV = (vProj.LengthSqr() > 1e-8f) ? vProj.Normalized() : vector3f(0.f, 1.f, 0.f);
 					vector3f axisU = viewDir.Cross(axisV).NormalizedSafe();
@@ -482,10 +548,12 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 					// Elongation proportional to current velocity magnitude.
 					// As drag slows particles down, they naturally become rounder.
 					const float speedMag = float(backboneDirCamD.Length());
-					const float baseStretch = Clamp(speedMag * 20.0f, 0.0f, 100.0f);
-					const float apparentStretch = baseStretch * sideOn;
+					const float baseStretch = Clamp(speedMag * 10.0f, 0.0f, 100.0f);
+					const float apparentStretch = (prevWasDust || inst.m_exhaustDustKick ? 0.0 : baseStretch * sideOn);
 
 					float size = std::max(0.01f, float(inst.m_plumeOffset.Length()));
+					if (inst.m_exhaustDustKick)
+						size = SfxParams::EXHAUST_MAX_SPREAD * ageNorm;
 
 					// Two UV triangles, the V-axis is aligned to the jet backbone axis.
 					const vector3f u = axisU * size;
@@ -496,14 +564,35 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 					const vector3f p1 = pos + u - v - v_add;
 					const vector3f p2 = pos + u + v;
 					const vector3f p3 = pos - u + v;
-					const vector3f packed(ageNorm, inst.m_opacityScale, 0.f);
 
-					exhaustArray.Add(p0, packed, vector2f(0.f, 0.f));
-					exhaustArray.Add(p1, packed, vector2f(1.f, 0.f));
-					exhaustArray.Add(p2, packed, vector2f(1.f, 1.f));
-					exhaustArray.Add(p2, packed, vector2f(1.f, 1.f));
-					exhaustArray.Add(p3, packed, vector2f(0.f, 1.f));
-					exhaustArray.Add(p0, packed, vector2f(0.f, 0.f));
+					const float ageFade = powf(1.0f - ageNorm, 2.8f);
+
+					Color particleColor;
+					vector3f normalFlag;
+					if (inst.m_exhaustDustKick) {
+						// This is a dust cloud particle
+						particleColor = inst.m_exhaustDustTint;
+						const Uint8 opacityA = Uint8((float)particleColor.a * ageFade);
+						particleColor.a = opacityA;
+						normalFlag = vector3f(1.f, 0.f, 0.f);
+					} else {
+						// This is an exhaust plume particle
+						const float opacityTimesAge = Clamp(inst.m_opacityScale * ageFade, 0.f, 1.f);
+						const Uint8 opacityA = Uint8(opacityTimesAge * 255.f);
+						particleColor = Color(255, 255, 255, opacityA);
+						normalFlag = vector3f(0.f, 0.f, 0.f);
+					}
+
+					particleColor.r = Uint8(Clamp(int(float(particleColor.r) * exhaustIllumMul), 0, 255));
+					particleColor.g = Uint8(Clamp(int(float(particleColor.g) * exhaustIllumMul), 0, 255));
+					particleColor.b = Uint8(Clamp(int(float(particleColor.b) * exhaustIllumMul), 0, 255));
+
+					exhaustArray.Add(p0, normalFlag, particleColor, vector2f(0.f, 0.f));
+					exhaustArray.Add(p1, normalFlag, particleColor, vector2f(1.f, 0.f));
+					exhaustArray.Add(p2, normalFlag, particleColor, vector2f(1.f, 1.f));
+					exhaustArray.Add(p2, normalFlag, particleColor, vector2f(1.f, 1.f));
+					exhaustArray.Add(p3, normalFlag, particleColor, vector2f(0.f, 1.f));
+					exhaustArray.Add(p0, normalFlag, particleColor, vector2f(0.f, 0.f));
 				}
 
 				renderer->SetTransform(matrix4x4f::Identity);
@@ -536,7 +625,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 	}
 
 	for (FrameId kid : f->GetChildren()) {
-		RenderAll(renderer, kid, camFrameId);
+		RenderAll(renderer, kid, camFrameId, camera, exhaustIllumMul);
 	}
 }
 
@@ -668,9 +757,10 @@ void SfxManager::Init(Graphics::Renderer *r)
 	Graphics::MaterialDescriptor exhaustDesc;
 	exhaustDesc.textures = 0;
 	exhaustDesc.effect = Graphics::EFFECT_BILLBOARD;
-	const auto exhaustVfmt = Graphics::VertexFormatDesc::FromAttribSet(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0 | Graphics::ATTRIB_NORMAL);
+	const auto exhaustVfmt = Graphics::VertexFormatDesc::FromAttribSet(
+		Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 	exhaustParticle.reset(r->CreateMaterial("exhaust", exhaustDesc, exhaustAlphaState, exhaustVfmt));
-	exhaustParticle->diffuse = Color(220, 220, 220, 48);
+	exhaustParticle->diffuse = Color(255, 255, 255, 255);
 
 	desc.effect = m_materialData[TYPE_EXPLOSION].effect;
 	explosionParticle.reset(r->CreateMaterial("billboards", desc, alphaState, vfmt));

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -96,8 +96,9 @@ namespace {
 			return;
 
 		// Randomly cull some particles right at exhaust->dust transition, because the
-		// dust clouds are large and diffuse and don't need nearly as many particles
-		if (Pi::rng.Double() < double(SfxParams::EXHAUST_DUST_TRANSITION_CULL_PROB)) {
+		// dust clouds are large and diffuse and don't need nearly as many particles.
+		// The number of particles to cull depends on the thruster power (stored in m_speed).
+		if (Pi::rng.Double() > std::max(s.m_speed, SfxParams::EXHAUST_DUST_LOWEST_NON_CULL_PROB)) {
 			s.m_type = TYPE_NONE;
 			return;
 		}
@@ -118,12 +119,12 @@ namespace {
 		s.m_plumeOffset = vector3d(0.);
 		s.m_backboneVel = vector3d(0.);
 		s.m_plumeOffsetVel =
-			rad * double(SfxParams::EXHAUST_DUST_RADIAL_KICK_SPEED * float(radJ)) +
-			tang * double(SfxParams::EXHAUST_DUST_TANGENT_KICK_SPEED * float(tanJ));
+			rad * double(SfxParams::EXHAUST_DUST_RADIAL_KICK_SPEED * s.m_speed * float(radJ)) +
+			tang * double(SfxParams::EXHAUST_DUST_TANGENT_KICK_SPEED * s.m_speed * float(tanJ));
 
 		s.m_exhaustDustKick = true;
 	}
-} // namespace
+}
 
 std::unique_ptr<Graphics::Material> SfxManager::damageParticle;
 std::unique_ptr<Graphics::Material> SfxManager::ecmParticle;
@@ -257,7 +258,8 @@ void Sfx::TimeStepUpdate(const float timeStep)
 			m_backboneVel += (m_windVel - m_backboneVel) * drag;
 
 			m_backbonePos += m_backboneVel * double(timeStep);
-			m_plumeOffset += m_plumeOffsetVel * double(timeStep);
+			if (m_age > SfxParams::EXHAUST_TIME_BEFORE_SPREAD)
+				m_plumeOffset += m_plumeOffsetVel * double(timeStep);
 			ApplyExhaustGroundThreshold(*this);
 
 			// Keep legacy fields coherent for non-exhaust code paths.
@@ -481,7 +483,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 
 			if (t == TYPE_EXHAUST) {
 				Graphics::VertexArray exhaustArray(
-					Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0,
+					Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0,
 					numInstances * 6);
 				std::vector<size_t> exhaustOrder(numInstances);
 				for (size_t i = 0; i < numInstances; ++i)
@@ -524,36 +526,42 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 					const bool sameJetStream = prevStreakParticle && SameExhaustJetStream(*prevStreakParticle, inst);
 					const bool elongateTowardPrev = sameJetStream && !inst.m_exhaustSuppressStreakElongation;
 
-					vector3d backboneDirCamD = interpBackboneCam - prevInterpBackboneCam;
+					// The elongation effectively draws particles stretched from their current location back towards
+					// the previous particle in the stream. But since the particles are soft ellipses we need to 
+					// lengthen the jet vector first, to get a nice unbroken streaky stream.
+					const vector3f jetVectorCam = vector3f((interpBackboneCam - prevInterpBackboneCam) * 4.0);
 
 					prevInterpBackboneCam = interpBackboneCam;
 					prevStreakParticle = &inst;
-					if (!elongateTowardPrev) continue;
 
-					vector3f jetAxis = vector3f(backboneDirCamD).NormalizedSafe();
+					if (!elongateTowardPrev && !inst.m_exhaustDustKick) continue;
+					if (!sameJetStream && !inst.m_exhaustDustKick) continue;
+					if (prevWasDust && !inst.m_exhaustDustKick) continue;
 
 					// Camera-space view direction from particle to camera origin.
-					vector3f viewDir = (-pos).NormalizedSafe();
+					const vector3f viewDir = (-pos).NormalizedSafe();
+
+					// Attenuate elongation when difference in Z values is relatively large
+					float attenuation = 1.0;
+					const float prevZ = std::abs(interpBackboneCam.z - jetVectorCam.z);
+					const float curZ = std::abs(interpBackboneCam.z);
+					if ((prevZ > 0.1f) && (curZ > 0.1f))
+						attenuation = std::min(1.0f, curZ / prevZ);
 
 					// Billboard plane basis: V aligns with jet axis projection onto the view plane.
 					// This approximates an ellipsoid projection:
 					// - looking down axis => round
 					// - side-on => elongated.
-					const float axisViewDot = Clamp(fabs(jetAxis.Dot(viewDir)), 0.f, 1.f);
-					const float sideOn = 1.0f - axisViewDot * axisViewDot;
-					vector3f vProj = jetAxis - viewDir * jetAxis.Dot(viewDir);
-					vector3f axisV = (vProj.LengthSqr() > 1e-8f) ? vProj.Normalized() : vector3f(0.f, 1.f, 0.f);
-					vector3f axisU = viewDir.Cross(axisV).NormalizedSafe();
+					const vector3f vProj = jetVectorCam - viewDir * jetVectorCam.Dot(viewDir);
+					const vector3f axisV = vProj.NormalizedSafe();
+					const vector3f axisU = viewDir.Cross(axisV).NormalizedSafe();
 
-					// Elongation proportional to current velocity magnitude.
-					// As drag slows particles down, they naturally become rounder.
-					const float speedMag = float(backboneDirCamD.Length());
-					const float baseStretch = Clamp(speedMag * 10.0f, 0.0f, 100.0f);
-					const float apparentStretch = (prevWasDust || inst.m_exhaustDustKick ? 0.0 : baseStretch * sideOn);
+					const float speedMag = jetVectorCam.Dot(axisV);
+					const float apparentStretch = (prevWasDust || inst.m_exhaustDustKick ? 0.0 : speedMag * attenuation);
 
 					float size = std::max(0.01f, float(inst.m_plumeOffset.Length()));
 					if (inst.m_exhaustDustKick)
-						size = SfxParams::EXHAUST_MAX_SPREAD * ageNorm;
+						size = SfxParams::EXHAUST_DUST_SIZE * ageNorm * std::max(inst.m_speed, 0.2f);
 
 					// Two UV triangles, the V-axis is aligned to the jet backbone axis.
 					const vector3f u = axisU * size;
@@ -568,31 +576,28 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 					const float ageFade = powf(1.0f - ageNorm, 2.8f);
 
 					Color particleColor;
-					vector3f normalFlag;
 					if (inst.m_exhaustDustKick) {
 						// This is a dust cloud particle
 						particleColor = inst.m_exhaustDustTint;
 						const Uint8 opacityA = Uint8((float)particleColor.a * ageFade);
 						particleColor.a = opacityA;
-						normalFlag = vector3f(1.f, 0.f, 0.f);
 					} else {
 						// This is an exhaust plume particle
 						const float opacityTimesAge = Clamp(inst.m_opacityScale * ageFade, 0.f, 1.f);
 						const Uint8 opacityA = Uint8(opacityTimesAge * 255.f);
 						particleColor = Color(255, 255, 255, opacityA);
-						normalFlag = vector3f(0.f, 0.f, 0.f);
 					}
 
 					particleColor.r = Uint8(Clamp(int(float(particleColor.r) * exhaustIllumMul), 0, 255));
 					particleColor.g = Uint8(Clamp(int(float(particleColor.g) * exhaustIllumMul), 0, 255));
 					particleColor.b = Uint8(Clamp(int(float(particleColor.b) * exhaustIllumMul), 0, 255));
 
-					exhaustArray.Add(p0, normalFlag, particleColor, vector2f(0.f, 0.f));
-					exhaustArray.Add(p1, normalFlag, particleColor, vector2f(1.f, 0.f));
-					exhaustArray.Add(p2, normalFlag, particleColor, vector2f(1.f, 1.f));
-					exhaustArray.Add(p2, normalFlag, particleColor, vector2f(1.f, 1.f));
-					exhaustArray.Add(p3, normalFlag, particleColor, vector2f(0.f, 1.f));
-					exhaustArray.Add(p0, normalFlag, particleColor, vector2f(0.f, 0.f));
+					exhaustArray.Add(p0, particleColor, vector2f(0.f, 0.f));
+					exhaustArray.Add(p1, particleColor, vector2f(1.f, 0.f));
+					exhaustArray.Add(p2, particleColor, vector2f(1.f, 1.f));
+					exhaustArray.Add(p2, particleColor, vector2f(1.f, 1.f));
+					exhaustArray.Add(p3, particleColor, vector2f(0.f, 1.f));
+					exhaustArray.Add(p0, particleColor, vector2f(0.f, 0.f));
 				}
 
 				renderer->SetTransform(matrix4x4f::Identity);
@@ -758,7 +763,7 @@ void SfxManager::Init(Graphics::Renderer *r)
 	exhaustDesc.textures = 0;
 	exhaustDesc.effect = Graphics::EFFECT_BILLBOARD;
 	const auto exhaustVfmt = Graphics::VertexFormatDesc::FromAttribSet(
-		Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
+		Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
 	exhaustParticle.reset(r->CreateMaterial("exhaust", exhaustDesc, exhaustAlphaState, exhaustVfmt));
 	exhaustParticle->diffuse = Color(255, 255, 255, 255);
 

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -6,6 +6,7 @@
 #include "Body.h"
 #include "FileSystem.h"
 #include "Frame.h"
+#include "Game.h"
 #include "GameSaveError.h"
 #include "Json.h"
 #include "JsonUtils.h"
@@ -37,7 +38,7 @@ namespace {
 		return (size * Graphics::GetFovFactor()) * pixrad;
 	}
 
-	float GetParticleSpeed(int screenHeight, SFX_TYPE t, const vector3f &pos, const Sfx &inst)
+	float GetParticleSize(int screenHeight, SFX_TYPE t, const vector3f &pos, const Sfx &inst)
 	{
 		switch (t) {
 		case TYPE_NONE: assert(false);
@@ -47,6 +48,8 @@ namespace {
 			return SizeToPixels(screenHeight, pos, 20.f);
 		case TYPE_SMOKE:
 			return Clamp(SizeToPixels(screenHeight, pos, (inst.m_speed * inst.m_age)), 0.1f, 50.0f);
+		case TYPE_EXHAUST:
+			// Calculated by the particle code
 		default:
 			return 0.f;
 		}
@@ -56,16 +59,29 @@ namespace {
 std::unique_ptr<Graphics::Material> SfxManager::damageParticle;
 std::unique_ptr<Graphics::Material> SfxManager::ecmParticle;
 std::unique_ptr<Graphics::Material> SfxManager::smokeParticle;
+std::unique_ptr<Graphics::Material> SfxManager::exhaustParticle;
 std::unique_ptr<Graphics::Material> SfxManager::explosionParticle;
 SfxManager::MaterialData SfxManager::m_materialData[TYPE_NONE];
 
 Sfx::Sfx(const vector3d &pos, const vector3d &vel, const float speed, const SFX_TYPE type) :
 	m_pos(pos),
 	m_vel(vel),
+	m_backbonePos(pos),
+	m_backboneVel(vel),
+	m_backboneAtStepStart(pos),
+	m_plumeOffset(vector3d::Zero),
+	m_plumeOffsetVel(vector3d::Zero),
 	m_age(0.0f),
 	m_speed(speed),
+	m_seed(float(Pi::rng.Double())),
+	m_lifetime(SfxParams::EXHAUST_LIFETIME),
+	m_dragScale(1.0f),
+	m_opacityScale(1.0f),
+	m_windVel(vector3d::Zero),
 	m_type(type)
 {
+	if (type == TYPE_EXHAUST)
+		m_lifetime = SfxParams::EXHAUST_LIFETIME * float(Pi::rng.Double(0.6, 1.0));
 }
 
 Sfx::Sfx(const Json &jsonObj)
@@ -75,7 +91,17 @@ Sfx::Sfx(const Json &jsonObj)
 
 		m_pos = sfxObj["pos"];
 		m_vel = sfxObj["vel"];
+		m_backbonePos = sfxObj.value("backbonePos", m_pos);
+		m_backboneVel = sfxObj.value("backboneVel", m_vel);
+		m_backboneAtStepStart = sfxObj.value("backboneAtStepStart", m_backbonePos);
+		m_plumeOffset = sfxObj.value("plumeOffset", vector3d::Zero);
+		m_plumeOffsetVel = sfxObj.value("plumeOffsetVel", vector3d::Zero);
 		m_age = sfxObj["age"];
+		m_seed = sfxObj.value("seed", float(Pi::rng.Double()));
+		m_lifetime = sfxObj.value("lifetime", SfxParams::EXHAUST_LIFETIME);
+		m_dragScale = sfxObj.value("dragScale", 1.0f);
+		m_opacityScale = sfxObj.value("opacityScale", 1.0f);
+		m_windVel = sfxObj.value("windVel", vector3d::Zero);
 		m_type = sfxObj["type"];
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
@@ -88,7 +114,19 @@ void Sfx::SaveToJson(Json &jsonObj)
 
 	sfxObj["pos"] = m_pos;
 	sfxObj["vel"] = m_vel;
+	if (m_type == TYPE_EXHAUST) {
+		sfxObj["backbonePos"] = m_backbonePos;
+		sfxObj["backboneVel"] = m_backboneVel;
+		sfxObj["backboneAtStepStart"] = m_backboneAtStepStart;
+		sfxObj["plumeOffset"] = m_plumeOffset;
+		sfxObj["plumeOffsetVel"] = m_plumeOffsetVel;
+		sfxObj["lifetime"] = m_lifetime;
+		sfxObj["dragScale"] = m_dragScale;
+		sfxObj["opacityScale"] = m_opacityScale;
+		sfxObj["windVel"] = m_windVel;
+	}
 	sfxObj["age"] = m_age;
+	sfxObj["seed"] = m_seed;
 	sfxObj["type"] = m_type;
 
 	jsonObj["sfx"] = sfxObj; // Add sfx object to supplied object.
@@ -115,6 +153,23 @@ void Sfx::TimeStepUpdate(const float timeStep)
 	case TYPE_SMOKE:
 		if (m_age > 8.0) m_type = TYPE_NONE;
 		break;
+	case TYPE_EXHAUST:
+		{
+			m_backboneAtStepStart = m_backbonePos;
+
+			const double drag = Clamp(0.9 * double(m_dragScale) * double(timeStep), 0.0, 0.85);
+			// Backbone follows the coherent central jet flow.
+			m_backboneVel += (m_windVel - m_backboneVel) * drag;
+
+			m_backbonePos += m_backboneVel * double(timeStep);
+			m_plumeOffset += m_plumeOffsetVel * double(timeStep);
+
+			// Keep legacy fields coherent for non-exhaust code paths.
+			m_pos = m_backbonePos + m_plumeOffset;
+			m_vel = m_backboneVel + m_plumeOffsetVel;
+		}
+		if (m_age > m_lifetime) m_type = TYPE_NONE;
+		break;
 	case TYPE_NONE: break;
 	}
 }
@@ -125,6 +180,7 @@ float Sfx::AgeBlend() const
 	case TYPE_EXPLOSION: return (3.2 - m_age) / 3.2;
 	case TYPE_DAMAGE: return (2.0 - m_age) / 2.0;
 	case TYPE_SMOKE: return (8.0 - m_age) / 8.0;
+	case TYPE_EXHAUST: return (m_lifetime - m_age) / std::max(m_lifetime, 0.001f);
 	case TYPE_NONE: return 0.0f;
 	}
 	return 0.0f;
@@ -217,6 +273,25 @@ void SfxManager::AddThrustSmoke(const Body *b, const float speed, const vector3d
 	sfxman->AddInstance(sfx);
 }
 
+void SfxManager::AddExhaust(const Body *b, const vector3d &startPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3d &windVel)
+{
+	SfxManager *sfxman = AllocSfxInFrame(b->GetFrame());
+	if (!sfxman) return;
+
+	const vector3d pos = startPos + plumeOffset;
+	Sfx sfx(pos, backboneVel, intensity, TYPE_EXHAUST);
+	sfx.m_backbonePos = startPos;
+	sfx.m_backboneVel = backboneVel;
+	sfx.m_plumeOffset = plumeOffset;
+	sfx.m_plumeOffsetVel = plumeOffsetVel;
+	sfx.m_vel = sfx.m_backboneVel + sfx.m_plumeOffsetVel;
+	sfx.m_dragScale = dragScale;
+	sfx.m_opacityScale = opacityScale;
+	sfx.m_windVel = windVel;
+	sfx.m_backboneAtStepStart = sfx.m_backbonePos;
+	sfxman->AddInstance(sfx);
+}
+
 void SfxManager::TimeStepAll(const float timeStep, FrameId fId)
 {
 	PROFILE_SCOPED()
@@ -262,7 +337,11 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 	PROFILE_SCOPED()
 	if (f->m_sfx) {
 		matrix4x4d ftran;
-		Frame::GetFrameTransform(fId, camFrameId, ftran);
+		// Use interpolated frame transform so SFX aligns with interpolated body rendering.
+		const matrix3x3d forient = f->GetInterpOrientRelTo(camFrameId);
+		const vector3d fpos = f->GetInterpPositionRelTo(camFrameId);
+		ftran = forient;
+		ftran.SetTranslate(fpos);
 
 		for (size_t t = TYPE_EXPLOSION; t < TYPE_NONE; t++) {
 			const size_t numInstances = f->m_sfx->GetNumberInstances(SFX_TYPE(t));
@@ -281,27 +360,107 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId)
 			case TYPE_SMOKE:
 				material = smokeParticle.get();
 				break;
+			case TYPE_EXHAUST:
+				material = exhaustParticle.get();
+				break;
 			}
 
 			// NB - we're (ab)using the normal type to hold (uv coordinate offset value + point size)
 			Graphics::VertexArray pointArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL, numInstances);
+			Graphics::VertexArray exhaustArray(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0 | Graphics::ATTRIB_NORMAL, numInstances * 6);
+
+			vector3d prevInterpBackboneCam = vector3d::Zero;
+			bool hasPrevInterpBackboneCam = false;
 
 			for (size_t i = 0; i < numInstances; i++) {
 				Sfx &inst(f->m_sfx->GetInstanceByIndex(SFX_TYPE(t), i));
 
 				assert(inst.m_type == t);
 
+				// Interpolate particle position within the current physics tick so SFX
+				// motion matches interpolated ship/body rendering (see DynamicBody::UpdateInterpTransform).
+				const double interpDt = Pi::game ? (Pi::GetGameTickAlpha() * double(Pi::game->GetTimeStep())) : 0.0;
+				vector3d interpPos = inst.m_pos + inst.m_vel * interpDt;
+				vector3d interpBackbone{};
+				vector3d interpOffset{};
+				if (t == TYPE_EXHAUST) {
+					// Backbone stores explicit start/end for this physics step.
+					const double alpha = Pi::game ? Pi::GetGameTickAlpha() : 1.0;
+					const double physicsStep = Pi::game ? double(Pi::game->GetTimeStep()) : 0.0;
+					interpBackbone = inst.m_backboneAtStepStart * (1.0 - alpha) + inst.m_backbonePos * alpha;
+					// Plume offset is a small local perturbation; derive its start-of-step estimate
+					// from end-of-step offset and current plume offset velocity.
+					interpOffset = inst.m_plumeOffset - inst.m_plumeOffsetVel * ((1.0 - alpha) * physicsStep);
+					interpPos = interpBackbone + interpOffset;
+				}
 				// make the particle position relative to the camera frame
-				const vector3f pos(ftran * inst.m_pos);
-				// pack UV offset and particle size in normal attribute
-				const vector2f offset = CalculateOffset(SFX_TYPE(t), inst);
-				const float speed = GetParticleSpeed(screenHeight, SFX_TYPE(t), pos, inst);
+				const vector3f pos(ftran * interpPos);
 
-				pointArray.Add(pos, vector3f(offset, Clamp(speed, 0.1f, FLT_MAX)));
+				if (t == TYPE_EXHAUST) {
+					const float ageNorm = Clamp(inst.m_age / std::max(inst.m_lifetime, 0.001f), 0.0f, 1.0f);
+					const vector3d interpBackboneCam = ftran * interpBackbone;
+					vector3d backboneDirCamD;
+					if (hasPrevInterpBackboneCam) {
+						backboneDirCamD = interpBackboneCam - prevInterpBackboneCam;
+					} else {
+						backboneDirCamD = ftran.ApplyRotationOnly(inst.m_backboneVel);
+					}
+					prevInterpBackboneCam = interpBackboneCam;
+					hasPrevInterpBackboneCam = true;
+					vector3f jetAxis = vector3f(backboneDirCamD).NormalizedSafe();
+					if (jetAxis.LengthSqr() < 1e-6f) jetAxis = vector3f(0.f, 0.f, 1.f);
+
+					// Camera-space view direction from particle to camera origin.
+					vector3f viewDir = (-pos).NormalizedSafe();
+
+					// Billboard plane basis: V aligns with jet axis projection onto the view plane.
+					// This approximates an ellipsoid projection:
+					// - looking down axis => round
+					// - side-on => elongated.
+					float axisViewDot = Clamp(fabs(jetAxis.Dot(viewDir)), 0.f, 1.f);
+					float sideOn = sqrtf(std::max(0.f, 1.f - axisViewDot * axisViewDot));
+					vector3f vProj = jetAxis - viewDir * jetAxis.Dot(viewDir);
+					vector3f axisV = (vProj.LengthSqr() > 1e-8f) ? vProj.Normalized() : vector3f(0.f, 1.f, 0.f);
+					vector3f axisU = viewDir.Cross(axisV).NormalizedSafe();
+
+					// Elongation proportional to current velocity magnitude.
+					// As drag slows particles down, they naturally become rounder.
+					const float speedMag = float(backboneDirCamD.Length());
+					const float baseStretch = Clamp(speedMag * 20.0f, 0.0f, 100.0f);
+					const float apparentStretch = baseStretch * sideOn;
+
+					float size = std::max(0.01f, float(inst.m_plumeOffset.Length()) * 2.0f);
+
+					// Two UV triangles, the V-axis is aligned to the jet backbone axis.
+					const vector3f u = axisU * size;
+					const vector3f v = axisV * size;
+					const vector3f v_add = axisV * apparentStretch;
+
+					const vector3f p0 = pos - u - v - v_add;
+					const vector3f p1 = pos + u - v - v_add;
+					const vector3f p2 = pos + u + v;
+					const vector3f p3 = pos - u + v;
+					const vector3f packed(ageNorm, inst.m_opacityScale, 0.f);
+
+					exhaustArray.Add(p0, packed, vector2f(0.f, 0.f));
+					exhaustArray.Add(p1, packed, vector2f(1.f, 0.f));
+					exhaustArray.Add(p2, packed, vector2f(1.f, 1.f));
+					exhaustArray.Add(p2, packed, vector2f(1.f, 1.f));
+					exhaustArray.Add(p3, packed, vector2f(0.f, 1.f));
+					exhaustArray.Add(p0, packed, vector2f(0.f, 0.f));
+				} else {
+					// pack UV offset and particle size in normal attribute
+					const vector2f offset = CalculateOffset(SFX_TYPE(t), inst);
+					const float size = GetParticleSize(screenHeight, SFX_TYPE(t), pos, inst);
+					pointArray.Add(pos, vector3f(offset, Clamp(size, 0.1f, FLT_MAX)));
+				}
 			}
 
 			renderer->SetTransform(matrix4x4f::Identity);
-			renderer->DrawBuffer(&pointArray, material);
+			if (t == TYPE_EXHAUST)
+				renderer->DrawBuffer(&exhaustArray, material);
+			else
+				renderer->DrawBuffer(&pointArray, material);
 		}
 	}
 
@@ -397,6 +556,10 @@ void SfxManager::Init(Graphics::Renderer *r)
 	additiveAlphaState.depthWrite = false;
 	additiveAlphaState.primitiveType = Graphics::POINTS;
 
+	Graphics::RenderStateDesc exhaustAlphaState = alphaState;
+	exhaustAlphaState.primitiveType = Graphics::TRIANGLES;
+	exhaustAlphaState.cullMode = Graphics::CULL_NONE;
+
 	Graphics::VertexFormatDesc vfmt = Graphics::VertexFormatDesc::FromAttribSet(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL);
 
 	// materials
@@ -413,6 +576,7 @@ void SfxManager::Init(Graphics::Renderer *r)
 	SplitMaterialData(cfg.String("explosionPacking"), m_materialData[TYPE_EXPLOSION]);
 	SplitMaterialData(cfg.String("damagePacking"), m_materialData[TYPE_DAMAGE]);
 	SplitMaterialData(cfg.String("smokePacking"), m_materialData[TYPE_SMOKE]);
+	m_materialData[TYPE_EXHAUST].effect = Graphics::EFFECT_BILLBOARD;
 
 	desc.effect = m_materialData[TYPE_DAMAGE].effect;
 	damageParticle.reset(r->CreateMaterial("billboards", desc, additiveAlphaState, vfmt));
@@ -430,6 +594,13 @@ void SfxManager::Init(Graphics::Renderer *r)
 		smokeParticle->SetPushConstant("coordDownScale"_hash,
 			m_materialData[TYPE_SMOKE].coord_downscale);
 
+	Graphics::MaterialDescriptor exhaustDesc;
+	exhaustDesc.textures = 0;
+	exhaustDesc.effect = Graphics::EFFECT_BILLBOARD;
+	const auto exhaustVfmt = Graphics::VertexFormatDesc::FromAttribSet(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_UV0 | Graphics::ATTRIB_NORMAL);
+	exhaustParticle.reset(r->CreateMaterial("exhaust", exhaustDesc, exhaustAlphaState, exhaustVfmt));
+	exhaustParticle->diffuse = Color(220, 220, 220, 48);
+
 	desc.effect = m_materialData[TYPE_EXPLOSION].effect;
 	explosionParticle.reset(r->CreateMaterial("billboards", desc, alphaState, vfmt));
 	explosionParticle->SetTexture("texture0"_hash,
@@ -444,5 +615,6 @@ void SfxManager::Uninit()
 	damageParticle.reset();
 	ecmParticle.reset();
 	smokeParticle.reset();
+	exhaustParticle.reset();
 	explosionParticle.reset();
 }

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -4,7 +4,6 @@
 #include "Sfx.h"
 
 #include "Body.h"
-#include "Camera.h"
 #include "FileSystem.h"
 #include "Frame.h"
 #include "Game.h"
@@ -14,8 +13,8 @@
 #include "MathUtil.h"
 #include "ModelBody.h"
 #include "Pi.h"
-#include "Player.h"
 #include "Space.h"
+#include "matrix3x3.h"
 #include "matrix4x4.h"
 
 #include "core/IniConfig.h"
@@ -27,11 +26,14 @@
 #include "graphics/TextureBuilder.h"
 #include "graphics/Types.h"
 #include "graphics/VertexArray.h"
+#include "graphics/VertexBuffer.h"
 
 #include "profiler/Profiler.h"
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
+#include <map>
 #include <vector>
 
 using namespace Graphics;
@@ -46,13 +48,43 @@ namespace {
 		return static_cast<uint64_t>(s.m_exhaustSavedEmitterBodyIdx);
 	}
 
-	inline bool SameExhaustJetStream(const Sfx &a, const Sfx &b)
+	struct ExhaustJetStreamKey {
+		uint64_t emitterKey;
+		Uint16 jetIndex;
+
+		bool operator<(const ExhaustJetStreamKey &other) const
+		{
+			if (emitterKey != other.emitterKey)
+				return emitterKey < other.emitterKey;
+			return jetIndex < other.jetIndex;
+		}
+	};
+
+	// Reused each exhaust draw, cleared at the start of every pass.
+	std::map<ExhaustJetStreamKey, std::vector<Sfx *>> s_exhaustByJet;
+
+	// GPU instance record for instanced exhaust quads (40-byte stride, binding 1).
+	struct ExhaustInstanceData {
+		vector3f center;
+		float size;
+		vector3f jetVectorCam;
+		float backboneCamZ;
+		float stretchScale;
+		Color color;
+	};
+	static_assert(sizeof(ExhaustInstanceData) == 40);
+
+	Graphics::VertexFormatDesc BuildExhaustInstancedVertexFormat()
 	{
-		if (a.m_exhaustJetIndex != b.m_exhaustJetIndex)
-			return false;
-		if (a.m_exhaustEmitter || b.m_exhaustEmitter)
-			return a.m_exhaustEmitter == b.m_exhaustEmitter;
-		return a.m_exhaustSavedEmitterBodyIdx == b.m_exhaustSavedEmitterBodyIdx;
+		// Instance-only format, quad corners come from gl_VertexID in the shader.
+		Graphics::VertexFormatDesc vtxFormat = {};
+		vtxFormat.attribs[0] = { Graphics::ATTRIB_FORMAT_FLOAT4, 6, 0, 0 };
+		vtxFormat.attribs[1] = { Graphics::ATTRIB_FORMAT_FLOAT4, 7, 0, 16 };
+		vtxFormat.attribs[2] = { Graphics::ATTRIB_FORMAT_FLOAT, 8, 0, 32 };
+		vtxFormat.attribs[3] = { Graphics::ATTRIB_FORMAT_UBYTE4, 9, 0, 36 };
+		vtxFormat.bindings[0] = { sizeof(ExhaustInstanceData), true, Graphics::ATTRIB_RATE_INSTANCE };
+		assert(vtxFormat.ValidateDesc() == Graphics::InvalidVertexFormatReason::OK);
+		return vtxFormat;
 	}
 
 	float SizeToPixels(int screenHeight, const vector3f &trans, const float size)
@@ -89,7 +121,7 @@ namespace {
 		if (s.m_exhaustDustKick)
 			return;	// Already hit the ground
 
-		const vector3d particlePos = s.m_backbonePos + s.m_plumeOffset;
+		const vector3d particlePos = s.m_pos + vector3d(s.m_plumeOffset);
 		const double radialDistSqr = particlePos.LengthSqr();
 		const double groundRadius = s.m_exhaustGroundRadius;
 		if (radialDistSqr > groundRadius * groundRadius)
@@ -115,12 +147,12 @@ namespace {
 		const double tanJ = Pi::rng.Double(0.35, 1.0);
 		const double radJ = Pi::rng.Double(0.55, 1.0);
 
-		s.m_backbonePos = surface;
-		s.m_plumeOffset = vector3d(0.);
-		s.m_backboneVel = vector3d(0.);
+		s.m_pos = surface;
+		s.m_plumeOffset = vector3f(0.f);
+		s.m_vel = vector3d(0.);
 		s.m_plumeOffsetVel =
-			rad * double(SfxParams::EXHAUST_DUST_RADIAL_KICK_SPEED * s.m_speed * float(radJ)) +
-			tang * double(SfxParams::EXHAUST_DUST_TANGENT_KICK_SPEED * s.m_speed * float(tanJ));
+			vector3f(rad) * (SfxParams::EXHAUST_DUST_RADIAL_KICK_SPEED * s.m_speed * float(radJ)) +
+			vector3f(tang) * (SfxParams::EXHAUST_DUST_TANGENT_KICK_SPEED * s.m_speed * float(tanJ));
 
 		s.m_exhaustDustKick = true;
 	}
@@ -136,30 +168,25 @@ SfxManager::MaterialData SfxManager::m_materialData[TYPE_NONE];
 Sfx::Sfx(const vector3d &pos, const vector3d &vel, const float speed, const SFX_TYPE type) :
 	m_pos(pos),
 	m_vel(vel),
-	m_backbonePos(pos),
-	m_backboneVel(vel),
-	m_backboneAtStepStart(pos),
-	m_plumeOffset(vector3d::Zero),
-	m_plumeOffsetVel(vector3d::Zero),
+	m_posAtStepStart(pos),
 	m_age(0.0f),
 	m_speed(speed),
+	m_type(type),
 	m_seed(float(Pi::rng.Double())),
 	m_lifetime(SfxParams::EXHAUST_LIFETIME),
-	m_dragScale(1.0f),
-	m_opacityScale(1.0f),
-	m_windVel(vector3d::Zero),
-	m_type(type),
+	m_exhaustSuppressStreakElongation(false),
+	m_exhaustDustKick(false),
+	m_exhaustJetIndex(0),
+	m_plumeOffset(0.f),
+	m_plumeOffsetVel(0.f),
 	m_exhaustEmitter(nullptr),
 	m_exhaustSavedEmitterBodyIdx(Sfx::INVALID_EXHAUST_SAVED_BODY_IDX),
-	m_exhaustJetIndex(0),
-	m_exhaustBirthSeq(0),
-	m_exhaustSuppressStreakElongation(false),
+	m_opacityScale(1.0f),
+	m_exhaustDustTint(0, 0, 0, 0),
 	m_exhaustGroundRadius(0.0),
-	m_exhaustDustKick(false),
-	m_exhaustDustTint(0, 0, 0, 0)
+	m_dragScale(1.0f),
+	m_windVel(vector3f::Zero)
 {
-	if (type == TYPE_EXHAUST)
-		m_lifetime = SfxParams::EXHAUST_LIFETIME * float(std::pow(Pi::rng.Double(0.5, 1.0), 2.0));
 }
 
 Sfx::Sfx(const Json &jsonObj)
@@ -169,22 +196,19 @@ Sfx::Sfx(const Json &jsonObj)
 
 		m_pos = sfxObj["pos"];
 		m_vel = sfxObj["vel"];
-		m_backbonePos = sfxObj.value("backbonePos", m_pos);
-		m_backboneVel = sfxObj.value("backboneVel", m_vel);
-		m_backboneAtStepStart = sfxObj.value("backboneAtStepStart", m_backbonePos);
-		m_plumeOffset = sfxObj.value("plumeOffset", vector3d::Zero);
-		m_plumeOffsetVel = sfxObj.value("plumeOffsetVel", vector3d::Zero);
+		m_posAtStepStart = sfxObj.value("posAtStepStart", m_pos);
+		m_plumeOffset = vector3f(sfxObj.value("plumeOffset", vector3d::Zero));
+		m_plumeOffsetVel = vector3f(sfxObj.value("plumeOffsetVel", vector3d::Zero));
 		m_age = sfxObj["age"];
 		m_seed = sfxObj.value("seed", float(Pi::rng.Double()));
 		m_lifetime = sfxObj.value("lifetime", SfxParams::EXHAUST_LIFETIME);
 		m_dragScale = sfxObj.value("dragScale", 1.0f);
 		m_opacityScale = sfxObj.value("opacityScale", 1.0f);
-		m_windVel = sfxObj.value("windVel", vector3d::Zero);
+		m_windVel = vector3f(sfxObj.value("windVel", vector3d::Zero));
 		m_type = sfxObj["type"];
 		m_exhaustEmitter = nullptr;
 		m_exhaustSavedEmitterBodyIdx = sfxObj.value("exhaustEmitterBodyIdx", Sfx::INVALID_EXHAUST_SAVED_BODY_IDX);
 		m_exhaustJetIndex = Uint16(sfxObj.value("exhaustJetIndex", 0));
-		m_exhaustBirthSeq = sfxObj.value("exhaustBirthSeq", Uint32(0));
 		m_exhaustSuppressStreakElongation = sfxObj.value("exhaustSuppressStreakElongation", false);
 		m_exhaustGroundRadius = sfxObj.value("exhaustGroundRadius", 0.0);
 		m_exhaustDustKick = sfxObj.value("exhaustDustKick", false);
@@ -201,21 +225,18 @@ void Sfx::SaveToJson(Json &jsonObj, const Space *space)
 	sfxObj["pos"] = m_pos;
 	sfxObj["vel"] = m_vel;
 	if (m_type == TYPE_EXHAUST) {
-		sfxObj["backbonePos"] = m_backbonePos;
-		sfxObj["backboneVel"] = m_backboneVel;
-		sfxObj["backboneAtStepStart"] = m_backboneAtStepStart;
-		sfxObj["plumeOffset"] = m_plumeOffset;
-		sfxObj["plumeOffsetVel"] = m_plumeOffsetVel;
+		sfxObj["posAtStepStart"] = m_posAtStepStart;
+		sfxObj["plumeOffset"] = vector3d(m_plumeOffset);
+		sfxObj["plumeOffsetVel"] = vector3d(m_plumeOffsetVel);
 		sfxObj["lifetime"] = m_lifetime;
 		sfxObj["dragScale"] = m_dragScale;
 		sfxObj["opacityScale"] = m_opacityScale;
-		sfxObj["windVel"] = m_windVel;
+		sfxObj["windVel"] = vector3d(m_windVel);
 		Uint32 bodyIdxForSave = m_exhaustSavedEmitterBodyIdx;
 		if (m_exhaustEmitter && space && space->IsBodyIndexValid())
 			bodyIdxForSave = space->GetIndexForBody(m_exhaustEmitter);
 		sfxObj["exhaustEmitterBodyIdx"] = bodyIdxForSave;
 		sfxObj["exhaustJetIndex"] = m_exhaustJetIndex;
-		sfxObj["exhaustBirthSeq"] = m_exhaustBirthSeq;
 		sfxObj["exhaustSuppressStreakElongation"] = m_exhaustSuppressStreakElongation;
 		sfxObj["exhaustGroundRadius"] = m_exhaustGroundRadius;
 		sfxObj["exhaustDustKick"] = m_exhaustDustKick;
@@ -237,7 +258,8 @@ void Sfx::TimeStepUpdate(const float timeStep)
 {
 	PROFILE_SCOPED()
 	m_age += timeStep;
-	m_pos += m_vel * double(timeStep);
+	if (m_type != TYPE_EXHAUST)
+		m_pos += m_vel * double(timeStep);
 
 	switch (m_type) {
 	case TYPE_EXPLOSION:
@@ -251,20 +273,17 @@ void Sfx::TimeStepUpdate(const float timeStep)
 		break;
 	case TYPE_EXHAUST:
 		{
-			m_backboneAtStepStart = m_backbonePos;
+			m_posAtStepStart = m_pos;
 
 			const double drag = Clamp(0.9 * double(m_dragScale) * double(timeStep), 0.0, 0.85);
-			// Backbone follows the coherent central jet flow.
-			m_backboneVel += (m_windVel - m_backboneVel) * drag;
+			// Backbone is influenced by wind, the plume offset isn't, so we're not applying the wind twice.
+			m_vel += (vector3d(m_windVel) - m_vel) * drag;
+			m_plumeOffsetVel -= m_plumeOffsetVel * drag * 0.5;
 
-			m_backbonePos += m_backboneVel * double(timeStep);
+			m_pos += m_vel * double(timeStep);
 			if (m_age > SfxParams::EXHAUST_TIME_BEFORE_SPREAD)
-				m_plumeOffset += m_plumeOffsetVel * double(timeStep);
+				m_plumeOffset += m_plumeOffsetVel * timeStep;
 			ApplyExhaustGroundThreshold(*this);
-
-			// Keep legacy fields coherent for non-exhaust code paths.
-			m_pos = m_backbonePos + m_plumeOffset;
-			m_vel = m_backboneVel + m_plumeOffsetVel;
 		}
 		if (m_age > m_lifetime) m_type = TYPE_NONE;
 		break;
@@ -284,8 +303,7 @@ float Sfx::AgeBlend() const
 	return 0.0f;
 }
 
-SfxManager::SfxManager() :
-	m_nextExhaustBirthSeq(1)
+SfxManager::SfxManager()
 {
 	for (size_t t = 0; t < TYPE_NONE; t++) {
 		m_instances[t].clear();
@@ -372,27 +390,32 @@ void SfxManager::AddThrustSmoke(const Body *b, const float speed, const vector3d
 	sfxman->AddInstance(sfx);
 }
 
-void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const bool exhaustSuppressStreakElongation, const vector3d &startPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3d &windVel, const double groundRadius, const Color &dustTint)
+void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const bool exhaustSuppressStreakElongation, const vector3d &startPos, const vector3d &backboneVel, const vector3f &plumeOffset, const vector3f &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3f &windVel, const double groundRadius, const Color &dustTint)
 {
+	PROFILE_SCOPED()
+
 	SfxManager *sfxman = AllocSfxInFrame(b->GetFrame());
 	if (!sfxman) return;
 
-	const vector3d pos = startPos + plumeOffset;
-	Sfx sfx(pos, backboneVel, intensity, TYPE_EXHAUST);
-	sfx.m_backbonePos = startPos;
-	sfx.m_backboneVel = backboneVel;
+	Sfx sfx(startPos, backboneVel, intensity, TYPE_EXHAUST);
 	sfx.m_plumeOffset = plumeOffset;
 	sfx.m_plumeOffsetVel = plumeOffsetVel;
-	sfx.m_vel = sfx.m_backboneVel + sfx.m_plumeOffsetVel;
 	sfx.m_dragScale = dragScale;
 	sfx.m_opacityScale = opacityScale;
 	sfx.m_windVel = windVel;
-	sfx.m_backboneAtStepStart = sfx.m_backbonePos;
+	sfx.m_posAtStepStart = startPos;
 	sfx.m_exhaustJetIndex = exhaustJetIndex;
 	sfx.m_exhaustEmitter = b;
 	sfx.m_exhaustSavedEmitterBodyIdx = Sfx::INVALID_EXHAUST_SAVED_BODY_IDX;
 	sfx.m_exhaustSuppressStreakElongation = exhaustSuppressStreakElongation;
-	sfx.m_exhaustBirthSeq = sfxman->m_nextExhaustBirthSeq++;
+
+	// Give each exhaust particle a random lifetime, except for the "marker" particles which only exist to pinpoint
+	// the start of an exhaust pulse. Those stay alive as long as possible because if they disappear early then the
+	// next particle may try to streak back to an earlier one instead of stopping where it should.
+	sfx.m_lifetime = SfxParams::EXHAUST_LIFETIME + 0.5f;
+	if (!exhaustSuppressStreakElongation)
+		sfx.m_lifetime = SfxParams::EXHAUST_LIFETIME * float(std::pow(Pi::rng.Double(0.5, 1.0), 2.0));
+
 	sfx.m_exhaustGroundRadius = groundRadius;
 	sfx.m_exhaustDustKick = false;
 	sfx.m_exhaustDustTint = dustTint;
@@ -436,18 +459,13 @@ void SfxManager::Cleanup()
 	}
 }
 
-void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, const Camera *camera, float exhaustIllumMul)
+void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, float illuminationFactor)
 {
 	PROFILE_SCOPED()
 
 	Frame *f = Frame::GetFrame(fId);
 	int screenHeight = renderer->GetWindowHeight();
 
-	if (camera && Pi::game && Pi::player && !Pi::player->IsDead() && fId == Pi::game->GetSpace()->GetRootFrame()) {
-		double amb = 0.0, direct = 1.0;
-		camera->CalcLighting(Pi::player, amb, direct);
-		exhaustIllumMul = Clamp(float(amb + direct), 0.08f, 1.0f);
-	}
 	if (f->m_sfx) {
 		matrix4x4d ftran;
 		// Use interpolated frame transform so SFX aligns with interpolated body rendering.
@@ -482,126 +500,128 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 			const double alpha = Pi::game ? Pi::GetGameTickAlpha() : 1.0;
 
 			if (t == TYPE_EXHAUST) {
-				Graphics::VertexArray exhaustArray(
-					Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0,
-					numInstances * 6);
-				std::vector<size_t> exhaustOrder(numInstances);
-				for (size_t i = 0; i < numInstances; ++i)
-					exhaustOrder[i] = i;
-				std::sort(exhaustOrder.begin(), exhaustOrder.end(), [&](size_t ia, size_t ib) {
-					const Sfx &a = f->m_sfx->GetInstanceByIndex(TYPE_EXHAUST, ia);
-					const Sfx &b = f->m_sfx->GetInstanceByIndex(TYPE_EXHAUST, ib);
-					const uint64_t keyA = ExhaustStreamEmitterSortKey(a);
-					const uint64_t keyB = ExhaustStreamEmitterSortKey(b);
-					if (keyA != keyB)
-						return keyA < keyB;
-					if (a.m_exhaustJetIndex != b.m_exhaustJetIndex)
-						return a.m_exhaustJetIndex < b.m_exhaustJetIndex;
-					if (a.m_exhaustBirthSeq != b.m_exhaustBirthSeq)
-						return a.m_exhaustBirthSeq < b.m_exhaustBirthSeq;
-					return ia < ib;
-				});
+				const matrix3x3f frameRot(forient);
 
-				const Sfx *prevStreakParticle = nullptr;
-				vector3d prevInterpBackboneCam = vector3d::Zero;
+				// We need to draw the particles in order, so that we can have streaks in the exhaust jet - each particle
+				// elongates back to the previous particle's position. So the particles need to be in "jet stream order".
+				// However, they are already in order, because new particles are always added at the end, and existing
+				// particles may disappear but never swap places. Except - if there is more than one jet (quite likely
+				// given many ships have multiple thrusters grouped together) then the particles are all mixed up per jet.
+				// So we now separate them into jet stream buckets by walking through the list.
 
-				for (const size_t i : exhaustOrder) {
+				for (auto &bucket : s_exhaustByJet)
+					bucket.second.clear();
+
+				for (size_t i = 0; i < numInstances; ++i) {
 					Sfx &inst(f->m_sfx->GetInstanceByIndex(TYPE_EXHAUST, i));
-
 					assert(inst.m_type == t);
-
-					// Backbone stores explicit start/end for this physics step.
-					vector3d interpBackbone = inst.m_backboneAtStepStart * (1.0 - alpha) + inst.m_backbonePos * alpha;
-
-					// Plume offset is a small local perturbation; derive its start-of-step estimate
-					// from end-of-step offset and current plume offset velocity.
-					const vector3d interpOffset = inst.m_plumeOffset - inst.m_plumeOffsetVel * ((1.0 - alpha) * timeStep);
-					const vector3d interpPos = interpBackbone + interpOffset;
-					const vector3f pos(ftran * interpPos);
-
-					const float ageNorm = Clamp(inst.m_age / std::max(inst.m_lifetime, 0.001f), 0.0f, 1.0f);
-					const vector3d interpBackboneCam = ftran * interpBackbone;
-
-					const bool prevWasDust = prevStreakParticle && prevStreakParticle->m_exhaustDustKick;
-					const bool sameJetStream = prevStreakParticle && SameExhaustJetStream(*prevStreakParticle, inst);
-					const bool elongateTowardPrev = sameJetStream && !inst.m_exhaustSuppressStreakElongation;
-
-					// The elongation effectively draws particles stretched from their current location back towards
-					// the previous particle in the stream. But since the particles are soft ellipses we need to 
-					// lengthen the jet vector first, to get a nice unbroken streaky stream.
-					const vector3f jetVectorCam = vector3f((interpBackboneCam - prevInterpBackboneCam) * 4.0);
-
-					prevInterpBackboneCam = interpBackboneCam;
-					prevStreakParticle = &inst;
-
-					if (!elongateTowardPrev && !inst.m_exhaustDustKick) continue;
-					if (!sameJetStream && !inst.m_exhaustDustKick) continue;
-					if (prevWasDust && !inst.m_exhaustDustKick) continue;
-
-					// Camera-space view direction from particle to camera origin.
-					const vector3f viewDir = (-pos).NormalizedSafe();
-
-					// Attenuate elongation when difference in Z values is relatively large
-					float attenuation = 1.0;
-					const float prevZ = std::abs(interpBackboneCam.z - jetVectorCam.z);
-					const float curZ = std::abs(interpBackboneCam.z);
-					if ((prevZ > 0.1f) && (curZ > 0.1f))
-						attenuation = std::min(1.0f, curZ / prevZ);
-
-					// Billboard plane basis: V aligns with jet axis projection onto the view plane.
-					// This approximates an ellipsoid projection:
-					// - looking down axis => round
-					// - side-on => elongated.
-					const vector3f vProj = jetVectorCam - viewDir * jetVectorCam.Dot(viewDir);
-					const vector3f axisV = vProj.NormalizedSafe();
-					const vector3f axisU = viewDir.Cross(axisV).NormalizedSafe();
-
-					const float speedMag = jetVectorCam.Dot(axisV);
-					const float apparentStretch = (prevWasDust || inst.m_exhaustDustKick ? 0.0 : speedMag * attenuation);
-
-					float size = std::max(0.01f, float(inst.m_plumeOffset.Length()));
-					if (inst.m_exhaustDustKick)
-						size = SfxParams::EXHAUST_DUST_SIZE * ageNorm * std::max(inst.m_speed, 0.2f);
-
-					// Two UV triangles, the V-axis is aligned to the jet backbone axis.
-					const vector3f u = axisU * size;
-					const vector3f v = axisV * size;
-					const vector3f v_add = axisV * apparentStretch;
-
-					const vector3f p0 = pos - u - v - v_add;
-					const vector3f p1 = pos + u - v - v_add;
-					const vector3f p2 = pos + u + v;
-					const vector3f p3 = pos - u + v;
-
-					const float ageFade = powf(1.0f - ageNorm, 2.8f);
-
-					Color particleColor;
-					if (inst.m_exhaustDustKick) {
-						// This is a dust cloud particle
-						particleColor = inst.m_exhaustDustTint;
-						const Uint8 opacityA = Uint8((float)particleColor.a * ageFade);
-						particleColor.a = opacityA;
-					} else {
-						// This is an exhaust plume particle
-						const float opacityTimesAge = Clamp(inst.m_opacityScale * ageFade, 0.f, 1.f);
-						const Uint8 opacityA = Uint8(opacityTimesAge * 255.f);
-						particleColor = Color(255, 255, 255, opacityA);
-					}
-
-					particleColor.r = Uint8(Clamp(int(float(particleColor.r) * exhaustIllumMul), 0, 255));
-					particleColor.g = Uint8(Clamp(int(float(particleColor.g) * exhaustIllumMul), 0, 255));
-					particleColor.b = Uint8(Clamp(int(float(particleColor.b) * exhaustIllumMul), 0, 255));
-
-					exhaustArray.Add(p0, particleColor, vector2f(0.f, 0.f));
-					exhaustArray.Add(p1, particleColor, vector2f(1.f, 0.f));
-					exhaustArray.Add(p2, particleColor, vector2f(1.f, 1.f));
-					exhaustArray.Add(p2, particleColor, vector2f(1.f, 1.f));
-					exhaustArray.Add(p3, particleColor, vector2f(0.f, 1.f));
-					exhaustArray.Add(p0, particleColor, vector2f(0.f, 0.f));
+					const ExhaustJetStreamKey key{
+						ExhaustStreamEmitterSortKey(inst),
+						inst.m_exhaustJetIndex,
+					};
+					s_exhaustByJet[key].push_back(&inst);
 				}
 
-				renderer->SetTransform(matrix4x4f::Identity);
-				renderer->DrawBuffer(&exhaustArray, material);
+				for (auto it = s_exhaustByJet.begin(); it != s_exhaustByJet.end(); ) {
+					if (it->second.empty())
+						it = s_exhaustByJet.erase(it);
+					else
+						++it;
+				}
+
+				std::vector<ExhaustInstanceData> exhaustInstances;
+				exhaustInstances.reserve(numInstances);
+
+				for (const auto &jetBucket : s_exhaustByJet) {
+					const Sfx *prevStreakParticle = nullptr;
+					vector3f prevInterpBackboneCam = vector3f(0.f);
+
+					for (Sfx *instPtr : jetBucket.second) {
+						Sfx &inst(*instPtr);
+
+						// Backbone stores explicit start/end for this physics step.
+						vector3d interpBackbone = inst.m_posAtStepStart * (1.0 - alpha) + inst.m_pos * alpha;
+
+						// Plume offset is a small local perturbation, composite in camera space after backbone transform.
+						const vector3f interpOffset = inst.m_plumeOffset - inst.m_plumeOffsetVel * float((1.0 - alpha) * timeStep);
+						const vector3f backboneCam(ftran * interpBackbone);
+						const vector3f pos = backboneCam + frameRot * interpOffset;
+
+						const float ageNorm = Clamp(inst.m_age / std::max(inst.m_lifetime, 0.001f), 0.0f, 1.0f);
+						const vector3f interpBackboneCam = backboneCam;
+
+						// The first particle in a jet does not get drawn - it is there to allow the next particle to stretch back
+						// towards it. This also applies to the first particle in a thruster pulse - if the user repeatedly presses
+						// and lets go of a thruster key, then we don't want each burst's initial particle to streak towards the end
+						// of the previous burst, so we deliberately suppress those.
+						// However - none of this applies to dust particles, which have no streaking.
+						const bool prevWasDust = prevStreakParticle && prevStreakParticle->m_exhaustDustKick;
+						const bool elongateTowardPrev = prevStreakParticle && !inst.m_exhaustSuppressStreakElongation;
+
+						// The elongation effectively draws particles stretched from their current location back towards
+						// the previous particle in the stream. But since the particles are soft ellipses we need to
+						// lengthen the jet vector to make them overlap and get a nice unbroken streaky stream.
+						const vector3f jetVectorCam = (interpBackboneCam - prevInterpBackboneCam) * 4.0;
+
+						prevInterpBackboneCam = interpBackboneCam;
+						prevStreakParticle = &inst;
+
+						if (!elongateTowardPrev && !inst.m_exhaustDustKick) continue;
+						if (prevWasDust && !inst.m_exhaustDustKick) continue;
+
+						// Don't start drawing particles until they have started spreading. This ensures we don't have
+						// any thin lines coming from the thruster nozzle, preferring a later "emerging contrail" effect.
+						if (inst.m_age < SfxParams::EXHAUST_TIME_BEFORE_SPREAD) continue;
+
+						float size = std::max(0.01f, float(inst.m_plumeOffset.Length()));
+						if (inst.m_exhaustDustKick)
+							size = SfxParams::EXHAUST_DUST_SIZE * ageNorm * std::max(inst.m_speed, 0.2f);
+
+						const float ageFade = powf(1.0f - ageNorm, 2.8f);
+
+						Color particleColor;
+						if (inst.m_exhaustDustKick) {
+							particleColor = inst.m_exhaustDustTint;
+							const Uint8 opacityA = Uint8((float)particleColor.a * ageFade);
+							particleColor.a = opacityA;
+						} else {
+							const float opacityTimesAge = Clamp(inst.m_opacityScale * ageFade, 0.f, 1.f);
+							const Uint8 opacityA = Uint8(opacityTimesAge * 255.f);
+							particleColor = Color(255, 255, 255, opacityA);
+						}
+
+						particleColor.r = Uint8(Clamp(int(float(particleColor.r) * illuminationFactor), 0, 255));
+						particleColor.g = Uint8(Clamp(int(float(particleColor.g) * illuminationFactor), 0, 255));
+						particleColor.b = Uint8(Clamp(int(float(particleColor.b) * illuminationFactor), 0, 255));
+
+						const float stretchScale = (prevWasDust || inst.m_exhaustDustKick) ? 0.f : 1.f;
+
+						exhaustInstances.push_back({
+							pos,
+							size,
+							jetVectorCam,
+							interpBackboneCam.z,
+							stretchScale,
+							particleColor,
+						});
+					}
+				}
+
+				if (!exhaustInstances.empty()) {
+					const uint32_t numDrawn = uint32_t(exhaustInstances.size());
+					Graphics::BufferBinding<Graphics::VertexBuffer> instanceBinding =
+						renderer->CreateTempVertexBuffer(numDrawn, sizeof(ExhaustInstanceData));
+
+					ExhaustInstanceData *instanceData =
+						instanceBinding.buffer->MapRange<ExhaustInstanceData>(instanceBinding, Graphics::BUFFER_MAP_WRITE);
+					if (instanceData) {
+						std::memcpy(instanceData, exhaustInstances.data(), numDrawn * sizeof(ExhaustInstanceData));
+						instanceBinding.buffer->UnmapRange(false);
+					}
+
+					renderer->SetTransform(matrix4x4f::Identity);
+					renderer->Draw({ instanceBinding }, {}, material, 4, numDrawn);
+				}
 
 			} else {
 				const double interpDt = alpha * timeStep;
@@ -630,7 +650,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 	}
 
 	for (FrameId kid : f->GetChildren()) {
-		RenderAll(renderer, kid, camFrameId, camera, exhaustIllumMul);
+		RenderAll(renderer, kid, camFrameId, illuminationFactor);
 	}
 }
 
@@ -722,7 +742,7 @@ void SfxManager::Init(Graphics::Renderer *r)
 	additiveAlphaState.primitiveType = Graphics::POINTS;
 
 	Graphics::RenderStateDesc exhaustAlphaState = alphaState;
-	exhaustAlphaState.primitiveType = Graphics::TRIANGLES;
+	exhaustAlphaState.primitiveType = Graphics::TRIANGLE_STRIP;
 	exhaustAlphaState.cullMode = Graphics::CULL_NONE;
 
 	Graphics::VertexFormatDesc vfmt = Graphics::VertexFormatDesc::FromAttribSet(Graphics::ATTRIB_POSITION | Graphics::ATTRIB_NORMAL);
@@ -762,8 +782,7 @@ void SfxManager::Init(Graphics::Renderer *r)
 	Graphics::MaterialDescriptor exhaustDesc;
 	exhaustDesc.textures = 0;
 	exhaustDesc.effect = Graphics::EFFECT_BILLBOARD;
-	const auto exhaustVfmt = Graphics::VertexFormatDesc::FromAttribSet(
-		Graphics::ATTRIB_POSITION | Graphics::ATTRIB_DIFFUSE | Graphics::ATTRIB_UV0);
+	const Graphics::VertexFormatDesc exhaustVfmt = BuildExhaustInstancedVertexFormat();
 	exhaustParticle.reset(r->CreateMaterial("exhaust", exhaustDesc, exhaustAlphaState, exhaustVfmt));
 	exhaustParticle->diffuse = Color(255, 255, 255, 255);
 

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -21,8 +21,18 @@ enum SFX_TYPE {
 	TYPE_EXPLOSION = 1,
 	TYPE_DAMAGE,
 	TYPE_SMOKE,
+	TYPE_EXHAUST,
 	TYPE_NONE
 };
+
+namespace SfxParams {
+	inline constexpr float EXHAUST_MAX_PLAYER_DISTANCE = 5000.0f;
+	inline constexpr float EXHAUST_INITIAL_SPREAD = 0.1f;
+	inline constexpr float EXHAUST_MAX_SPREAD = 100.0f;
+	inline constexpr float EXHAUST_LIFETIME = 20.0f;
+	inline constexpr float EXHAUST_WIND_SPEED = 32.0f;
+	inline constexpr float EXHAUST_PARTICLES_PER_SEC = 300.0f;
+}
 
 struct Sfx {
 	Sfx() = delete;
@@ -39,8 +49,19 @@ struct Sfx {
 
 	vector3d m_pos;
 	vector3d m_vel;
+	vector3d m_backbonePos;
+	vector3d m_backboneVel;
+	// Start-of-current-physics-tick backbone (TYPE_EXHAUST); used for render interp like DynamicBody::m_oldPos.
+	vector3d m_backboneAtStepStart;
+	vector3d m_plumeOffset;
+	vector3d m_plumeOffsetVel;
 	float m_age;
 	float m_speed;
+	float m_seed;
+	float m_lifetime;
+	float m_dragScale;
+	float m_opacityScale;
+	vector3d m_windVel;
 	enum SFX_TYPE m_type;
 };
 
@@ -51,6 +72,7 @@ public:
 	static void Add(const Body *, SFX_TYPE);
 	static void AddExplosion(Body *);
 	static void AddThrustSmoke(const Body *b, float speed, const vector3d &adjustpos);
+	static void AddExhaust(const Body *b, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3d &windVel);
 	static void TimeStepAll(const float timeStep, FrameId f);
 	static void RenderAll(Graphics::Renderer *r, FrameId f, const FrameId camFrame);
 	static void ToJson(Json &jsonObj, const FrameId f);
@@ -62,6 +84,7 @@ public:
 	static std::unique_ptr<Graphics::Material> damageParticle;
 	static std::unique_ptr<Graphics::Material> ecmParticle;
 	static std::unique_ptr<Graphics::Material> smokeParticle;
+	static std::unique_ptr<Graphics::Material> exhaustParticle;
 	static std::unique_ptr<Graphics::Material> explosionParticle;
 
 	SfxManager();

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -4,6 +4,7 @@
 #ifndef _SFX_H
 #define _SFX_H
 
+#include "Color.h"
 #include "FrameId.h"
 #include "JsonFwd.h"
 #include "graphics/Material.h"
@@ -13,6 +14,7 @@
 #include <deque>
 
 class Body;
+class Camera;
 class Frame;
 class Space;
 
@@ -35,9 +37,12 @@ namespace SfxParams {
 	inline constexpr float EXHAUST_MAX_SPREAD = 100.0f;
 	inline constexpr float EXHAUST_LIFETIME = 10.0f;
 	inline constexpr float EXHAUST_WIND_SPEED = 32.0f;
-	inline constexpr float EXHAUST_PARTICLES_PER_SEC = 120.0f;
-	// Normalized reaction power ([0,1] from joystick / autopilot) needed before spawning plume
+	inline constexpr float EXHAUST_PARTICLES_PER_SHIP_PER_SEC = 1800.0f;
 	inline constexpr float EXHAUST_MIN_REACTION_POWER = 0.06f;
+	inline constexpr float EXHAUST_STREAM_TIMESTEP_CAP = 0.03f;
+	inline constexpr float EXHAUST_DUST_RADIAL_KICK_SPEED = 24.0f;
+	inline constexpr float EXHAUST_DUST_TANGENT_KICK_SPEED = 38.0f;
+	inline constexpr float EXHAUST_DUST_TRANSITION_CULL_PROB = 0.80f;
 }
 
 struct Sfx {
@@ -79,6 +84,11 @@ struct Sfx {
 	Uint32 m_exhaustBirthSeq; // monotonic per-frame SfxManager for sort order within a stream
 	// If true, billboard streak does not use backbone delta vs previous particle (new thrust pulse opener).
 	bool m_exhaustSuppressStreakElongation;
+	// Exhaust hit cached terrain radius threshold sampled at spawn-time.
+	double m_exhaustGroundRadius;
+	bool m_exhaustDustKick;
+	// Dust tint (rgb) and mix amount in a (0..255), sampled at spawn-time.
+	Color m_exhaustDustTint;
 	static constexpr Uint32 INVALID_EXHAUST_SAVED_BODY_IDX = Uint32(0xffffffffu);
 };
 
@@ -89,9 +99,9 @@ public:
 	static void Add(const Body *, SFX_TYPE);
 	static void AddExplosion(Body *);
 	static void AddThrustSmoke(const Body *b, float speed, const vector3d &adjustpos);
-	static void AddExhaust(const Body *b, Uint16 exhaustJetIndex, bool exhaustSuppressStreakElongation, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3d &windVel);
+	static void AddExhaust(const Body *b, Uint16 exhaustJetIndex, bool exhaustSuppressStreakElongation, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3d &windVel, double groundRadius, const Color &dustTint);
 	static void TimeStepAll(const float timeStep, FrameId f);
-	static void RenderAll(Graphics::Renderer *r, FrameId f, const FrameId camFrame);
+	static void RenderAll(Graphics::Renderer *r, FrameId f, FrameId camFrame, const Camera *camera = nullptr, float exhaustIllumMul = 1.f);
 	static void ToJson(Json &jsonObj, const FrameId f, const Space *space);
 	static void FromJson(const Json &jsonObj, FrameId f);
 

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -8,10 +8,13 @@
 #include "JsonFwd.h"
 #include "graphics/Material.h"
 
+#include <SDL_stdinc.h>
+
 #include <deque>
 
 class Body;
 class Frame;
+class Space;
 
 namespace Graphics {
 	class Renderer;
@@ -27,11 +30,14 @@ enum SFX_TYPE {
 
 namespace SfxParams {
 	inline constexpr float EXHAUST_MAX_PLAYER_DISTANCE = 5000.0f;
+	inline constexpr float EXHAUST_INITIAL_VELOCITY = 320.0f;
 	inline constexpr float EXHAUST_INITIAL_SPREAD = 0.1f;
 	inline constexpr float EXHAUST_MAX_SPREAD = 100.0f;
-	inline constexpr float EXHAUST_LIFETIME = 20.0f;
+	inline constexpr float EXHAUST_LIFETIME = 10.0f;
 	inline constexpr float EXHAUST_WIND_SPEED = 32.0f;
-	inline constexpr float EXHAUST_PARTICLES_PER_SEC = 300.0f;
+	inline constexpr float EXHAUST_PARTICLES_PER_SEC = 120.0f;
+	// Normalized reaction power ([0,1] from joystick / autopilot) needed before spawning plume
+	inline constexpr float EXHAUST_MIN_REACTION_POWER = 0.06f;
 }
 
 struct Sfx {
@@ -45,7 +51,7 @@ struct Sfx {
 	void SetPosition(const vector3d &p);
 
 	void TimeStepUpdate(const float timeStep);
-	void SaveToJson(Json &jsonObj);
+	void SaveToJson(Json &jsonObj, const Space *space);
 
 	vector3d m_pos;
 	vector3d m_vel;
@@ -63,6 +69,17 @@ struct Sfx {
 	float m_opacityScale;
 	vector3d m_windVel;
 	enum SFX_TYPE m_type;
+
+	// Atmospheric exhaust: streak direction chains consecutive spawns per thruster only.
+	// Runtime grouping uses emitting Body pointer (stable for object lifetime); savegames store
+	// Space body index separately because pointers are not serialized.
+	const Body *m_exhaustEmitter;
+	Uint32 m_exhaustSavedEmitterBodyIdx;
+	Uint16 m_exhaustJetIndex;
+	Uint32 m_exhaustBirthSeq; // monotonic per-frame SfxManager for sort order within a stream
+	// If true, billboard streak does not use backbone delta vs previous particle (new thrust pulse opener).
+	bool m_exhaustSuppressStreakElongation;
+	static constexpr Uint32 INVALID_EXHAUST_SAVED_BODY_IDX = Uint32(0xffffffffu);
 };
 
 class SfxManager {
@@ -72,10 +89,10 @@ public:
 	static void Add(const Body *, SFX_TYPE);
 	static void AddExplosion(Body *);
 	static void AddThrustSmoke(const Body *b, float speed, const vector3d &adjustpos);
-	static void AddExhaust(const Body *b, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3d &windVel);
+	static void AddExhaust(const Body *b, Uint16 exhaustJetIndex, bool exhaustSuppressStreakElongation, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3d &windVel);
 	static void TimeStepAll(const float timeStep, FrameId f);
 	static void RenderAll(Graphics::Renderer *r, FrameId f, const FrameId camFrame);
-	static void ToJson(Json &jsonObj, const FrameId f);
+	static void ToJson(Json &jsonObj, const FrameId f, const Space *space);
 	static void FromJson(const Json &jsonObj, FrameId f);
 
 	//create shared models
@@ -107,7 +124,7 @@ private:
 	};
 
 	Sfx &GetInstanceByIndex(const SFX_TYPE t, const size_t i) { return m_instances[t][i]; }
-	void AddInstance(Sfx &inst) { return m_instances[inst.m_type].push_back(inst); }
+	void AddInstance(Sfx &inst) { m_instances[inst.m_type].push_back(inst); }
 
 	// methods
 	static SfxManager *AllocSfxInFrame(FrameId f);
@@ -120,6 +137,7 @@ private:
 	// members
 	// per-frame
 	std::deque<Sfx> m_instances[TYPE_NONE];
+	Uint32 m_nextExhaustBirthSeq = 1;
 };
 
 #endif /* _SFX_H */

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -34,15 +34,19 @@ namespace SfxParams {
 	inline constexpr float EXHAUST_MAX_PLAYER_DISTANCE = 5000.0f;
 	inline constexpr float EXHAUST_INITIAL_VELOCITY = 320.0f;
 	inline constexpr float EXHAUST_INITIAL_SPREAD = 0.1f;
+	inline constexpr float EXHAUST_TIME_BEFORE_SPREAD = 0.1f;
 	inline constexpr float EXHAUST_MAX_SPREAD = 100.0f;
+	inline constexpr float EXHAUST_DUST_SIZE = 200.0f;
 	inline constexpr float EXHAUST_LIFETIME = 10.0f;
 	inline constexpr float EXHAUST_WIND_SPEED = 32.0f;
 	inline constexpr float EXHAUST_PARTICLES_PER_SHIP_PER_SEC = 1800.0f;
-	inline constexpr float EXHAUST_MIN_REACTION_POWER = 0.06f;
+	inline constexpr float EXHAUST_MIN_REACTION_POWER = 0.02f;
 	inline constexpr float EXHAUST_STREAM_TIMESTEP_CAP = 0.03f;
 	inline constexpr float EXHAUST_DUST_RADIAL_KICK_SPEED = 24.0f;
 	inline constexpr float EXHAUST_DUST_TANGENT_KICK_SPEED = 38.0f;
-	inline constexpr float EXHAUST_DUST_TRANSITION_CULL_PROB = 0.80f;
+	inline constexpr float EXHAUST_DUST_LOWEST_NON_CULL_PROB = 0.05f;	// Keep at least one in 20 particles
+	inline constexpr float EXHAUST_LOG_SCALE = 40.0f;
+	inline constexpr float EXHAUST_ANGULAR_FACTOR = 0.2f;
 }
 
 struct Sfx {
@@ -60,10 +64,13 @@ struct Sfx {
 
 	vector3d m_pos;
 	vector3d m_vel;
+	// Thruster exhaust jets have a "backbone" which is the centre of the stream. This is used
+	// to track how stretched out each particle should be, and in which direction.
 	vector3d m_backbonePos;
 	vector3d m_backboneVel;
-	// Start-of-current-physics-tick backbone (TYPE_EXHAUST); used for render interp like DynamicBody::m_oldPos.
 	vector3d m_backboneAtStepStart;
+	// Each particle then has a perpendicular offset from the backbone, which grows over time
+	// and gives the exhaust plume its conical shape
 	vector3d m_plumeOffset;
 	vector3d m_plumeOffsetVel;
 	float m_age;
@@ -81,14 +88,12 @@ struct Sfx {
 	const Body *m_exhaustEmitter;
 	Uint32 m_exhaustSavedEmitterBodyIdx;
 	Uint16 m_exhaustJetIndex;
-	Uint32 m_exhaustBirthSeq; // monotonic per-frame SfxManager for sort order within a stream
-	// If true, billboard streak does not use backbone delta vs previous particle (new thrust pulse opener).
+	Uint32 m_exhaustBirthSeq; // For sort order within a stream
+	// If true this particle should not streak towards the previous one, usually this is because it's the first particle in a new thruster pulse
 	bool m_exhaustSuppressStreakElongation;
-	// Exhaust hit cached terrain radius threshold sampled at spawn-time.
-	double m_exhaustGroundRadius;
-	bool m_exhaustDustKick;
-	// Dust tint (rgb) and mix amount in a (0..255), sampled at spawn-time.
-	Color m_exhaustDustTint;
+	double m_exhaustGroundRadius; // The height of the ground below this exhaust, calculated from the ground below the ship at spawn time
+	bool m_exhaustDustKick; // After the exhaust hits the ground, it can turn into a dust cloud particle
+	Color m_exhaustDustTint; // Dust tint and mix amount, calculated from the ground below the ship at spawn time.
 	static constexpr Uint32 INVALID_EXHAUST_SAVED_BODY_IDX = Uint32(0xffffffffu);
 };
 

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -14,7 +14,6 @@
 #include <deque>
 
 class Body;
-class Camera;
 class Frame;
 class Space;
 
@@ -34,19 +33,20 @@ namespace SfxParams {
 	inline constexpr float EXHAUST_MAX_PLAYER_DISTANCE = 5000.0f;
 	inline constexpr float EXHAUST_INITIAL_VELOCITY = 320.0f;
 	inline constexpr float EXHAUST_INITIAL_SPREAD = 0.1f;
-	inline constexpr float EXHAUST_TIME_BEFORE_SPREAD = 0.1f;
-	inline constexpr float EXHAUST_MAX_SPREAD = 100.0f;
+	inline constexpr float EXHAUST_TIME_BEFORE_SPREAD = 0.05f;
+	inline constexpr float EXHAUST_MAX_SPREAD = 50.0f;
 	inline constexpr float EXHAUST_DUST_SIZE = 200.0f;
 	inline constexpr float EXHAUST_LIFETIME = 10.0f;
 	inline constexpr float EXHAUST_WIND_SPEED = 32.0f;
 	inline constexpr float EXHAUST_PARTICLES_PER_SHIP_PER_SEC = 1800.0f;
 	inline constexpr float EXHAUST_MIN_REACTION_POWER = 0.02f;
-	inline constexpr float EXHAUST_STREAM_TIMESTEP_CAP = 0.03f;
+	inline constexpr float EXHAUST_STREAM_TIMESTEP_CAP = 0.1f;
 	inline constexpr float EXHAUST_DUST_RADIAL_KICK_SPEED = 24.0f;
 	inline constexpr float EXHAUST_DUST_TANGENT_KICK_SPEED = 38.0f;
 	inline constexpr float EXHAUST_DUST_LOWEST_NON_CULL_PROB = 0.05f;	// Keep at least one in 20 particles
-	inline constexpr float EXHAUST_LOG_SCALE = 40.0f;
-	inline constexpr float EXHAUST_ANGULAR_FACTOR = 0.2f;
+	inline constexpr float EXHAUST_LOG_SCALE = 2.0f;	// The log scale factor determining how opaque manouvering thruster exhaust is compared to main thruster exhaust
+	inline constexpr float EXHAUST_ANGULAR_FACTOR = 0.2f;	// Rotational thruster exhaust is reduced by this factor, otherwise it looks far too strong
+	inline constexpr float EXHAUST_DRAG_FACTOR = 0.5f;	// Increase to have more atmospheric drag, so the jets shoot out less far before becoming cloud-like
 }
 
 struct Sfx {
@@ -62,38 +62,48 @@ struct Sfx {
 	void TimeStepUpdate(const float timeStep);
 	void SaveToJson(Json &jsonObj, const Space *space);
 
+	// --- Shared by all SFX types ---
+	// For TYPE_EXHAUST these hold backbone (jet centreline) position and velocity.
 	vector3d m_pos;
 	vector3d m_vel;
-	// Thruster exhaust jets have a "backbone" which is the centre of the stream. This is used
-	// to track how stretched out each particle should be, and in which direction.
-	vector3d m_backbonePos;
-	vector3d m_backboneVel;
-	vector3d m_backboneAtStepStart;
-	// Each particle then has a perpendicular offset from the backbone, which grows over time
-	// and gives the exhaust plume its conical shape
-	vector3d m_plumeOffset;
-	vector3d m_plumeOffsetVel;
+	// Start-of-step position for render interpolation between physics ticks.
+	vector3d m_posAtStepStart;
 	float m_age;
-	float m_speed;
-	float m_seed;
-	float m_lifetime;
-	float m_dragScale;
-	float m_opacityScale;
-	vector3d m_windVel;
+	float m_speed; // For TYPE_EXHAUST this is used for thruster intensity at spawn, which is per jet - could be moved to an auxilliary table
 	enum SFX_TYPE m_type;
 
-	// Atmospheric exhaust: streak direction chains consecutive spawns per thruster only.
-	// Runtime grouping uses emitting Body pointer (stable for object lifetime); savegames store
-	// Space body index separately because pointers are not serialized.
-	const Body *m_exhaustEmitter;
-	Uint32 m_exhaustSavedEmitterBodyIdx;
-	Uint16 m_exhaustJetIndex;
-	Uint32 m_exhaustBirthSeq; // For sort order within a stream
+	float m_seed;
+	float m_lifetime;
+
 	// If true this particle should not streak towards the previous one, usually this is because it's the first particle in a new thruster pulse
 	bool m_exhaustSuppressStreakElongation;
-	double m_exhaustGroundRadius; // The height of the ground below this exhaust, calculated from the ground below the ship at spawn time
+
 	bool m_exhaustDustKick; // After the exhaust hits the ground, it can turn into a dust cloud particle
+
+	Uint16 m_exhaustJetIndex; // The jet index to the emitter that created this particle
+
+	// --- TYPE_EXHAUST stream kinematics (per particle) ---
+	// Each particle has a perpendicular offset from the backbone (m_pos), which grows over time
+	// and gives the exhaust plume its conical shape
+	vector3f m_plumeOffset;
+	vector3f m_plumeOffsetVel;
+
+	// --- TYPE_EXHAUST spawn context, can be the same for several particles in a tick ---
+	// Future work: move per-emitter (ship) and per-jet (thruster) fields to a side table keyed by
+	// (m_exhaustEmitter, m_exhaustJetIndex) to shrink the Sfx footprint.
+
+	// Emitter identity (for stream grouping)
+	const Body *m_exhaustEmitter;
+	Uint32 m_exhaustSavedEmitterBodyIdx;
+
+	float m_opacityScale; // How visible the exhaust should be - thinner atmosphere and weaker thrust levels reduce this
 	Color m_exhaustDustTint; // Dust tint and mix amount, calculated from the ground below the ship at spawn time.
+	double m_exhaustGroundRadius; // The height of the ground below this exhaust, calculated from the ground below the ship at spawn time
+
+	// Atmospheric behaviour - if planet wind is implemented then this would be the hook for making thruster plumes blow about
+	float m_dragScale;   // per emitter (ship), constant for all jets on a spawn tick
+	vector3f m_windVel;  // per emitter, constant for all jets on a spawn tick
+
 	static constexpr Uint32 INVALID_EXHAUST_SAVED_BODY_IDX = Uint32(0xffffffffu);
 };
 
@@ -104,9 +114,9 @@ public:
 	static void Add(const Body *, SFX_TYPE);
 	static void AddExplosion(Body *);
 	static void AddThrustSmoke(const Body *b, float speed, const vector3d &adjustpos);
-	static void AddExhaust(const Body *b, Uint16 exhaustJetIndex, bool exhaustSuppressStreakElongation, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3d &plumeOffset, const vector3d &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3d &windVel, double groundRadius, const Color &dustTint);
+	static void AddExhaust(const Body *b, Uint16 exhaustJetIndex, bool exhaustSuppressStreakElongation, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3f &plumeOffset, const vector3f &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3f &windVel, double groundRadius, const Color &dustTint);
 	static void TimeStepAll(const float timeStep, FrameId f);
-	static void RenderAll(Graphics::Renderer *r, FrameId f, FrameId camFrame, const Camera *camera = nullptr, float exhaustIllumMul = 1.f);
+	static void RenderAll(Graphics::Renderer *r, FrameId f, FrameId camFrame, float illuminationFactor = 1.f);
 	static void ToJson(Json &jsonObj, const FrameId f, const Space *space);
 	static void FromJson(const Json &jsonObj, FrameId f);
 
@@ -152,7 +162,6 @@ private:
 	// members
 	// per-frame
 	std::deque<Sfx> m_instances[TYPE_NONE];
-	Uint32 m_nextExhaustBirthSeq = 1;
 };
 
 #endif /* _SFX_H */

--- a/src/Ship-AI.cpp
+++ b/src/Ship-AI.cpp
@@ -5,6 +5,7 @@
 #include "Frame.h"
 #include "Ship.h"
 #include "ShipAICmd.h"
+#include "ship/Propulsion.h"
 #include "Space.h"
 #include "SpaceStation.h"
 #include "lua/LuaEvent.h"
@@ -29,7 +30,10 @@ bool Ship::AITimeStep(float timeStep)
 		return true;
 	}
 
-	if (m_curAICmd->TimeStepUpdate()) {
+	m_propulsion->BeginAISequentialThrusters();
+	const bool aiComplete = m_curAICmd->TimeStepUpdate();
+	m_propulsion->EndAISequentialThrusters();
+	if (aiComplete) {
 		AIClearInstructions();
 		//		ClearThrusterState();		// otherwise it does one timestep at 10k and gravity is fatal
 		LuaEvent::Queue("onAICompleted", this, EnumStrings::GetString("ShipAIError", AIMessage()));

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -56,7 +56,7 @@ namespace {
 		Space *space = Pi::game->GetSpace();
 		if (!space) return false;
 
-		// Keep this local query cheap; we only need stations close enough to plausibly be beneath the ship.
+		// Keep this local query cheap - we only need stations close enough to plausibly be beneath the ship.
 		constexpr double PAD_QUERY_RADIUS = 2000.0;
 		constexpr double PAD_MAX_VERTICAL_ABOVE_M = 350.0;
 		constexpr double PAD_MIN_VERTICAL_BELOW_M = -20.0;
@@ -285,11 +285,28 @@ void Ship::RefreshThrusterExhaustMounts()
 
 	std::vector<std::pair<SceneGraph::MatrixTransform *, SceneGraph::Thruster *>> tmp;
 	GetModel()->GatherThrusterMounts(tmp);
+
+	std::vector<float> thrusterScaleAvg;
+	thrusterScaleAvg.reserve(tmp.size());
+	float maxThrusterScale = 0.0f;
+	for (const auto &pr : tmp) {
+		const matrix4x4f M = pr.first->CalcGlobalTransform();
+		const float sx = vector3f(M[0], M[1], M[2]).Length();
+		const float sy = vector3f(M[4], M[5], M[6]).Length();
+		const float sz = vector3f(M[8], M[9], M[10]).Length();
+		const float scaleAvg = (sx + sy + sz) / 3.0f;
+		thrusterScaleAvg.push_back(scaleAvg);
+		maxThrusterScale = std::max(maxThrusterScale, scaleAvg);
+	}
 	m_thrusterExhaustMounts.reserve(tmp.size());
 	m_thrusterExhaustThrusters.reserve(tmp.size());
-	for (const auto &pr : tmp) {
+	for (size_t i = 0; i < tmp.size(); ++i) {
+		const auto &pr = tmp[i];
 		m_thrusterExhaustMounts.push_back(pr.first);
 		m_thrusterExhaustThrusters.push_back(pr.second);
+		const float scaleAvg = thrusterScaleAvg[i];
+		const float scaleProportional = (maxThrusterScale > 1e-6f) ? (scaleAvg / maxThrusterScale) : 1.0f;
+		pr.second->SetVisualSizeInfo(scaleAvg, scaleProportional);
 	}
 	m_exhaustThrusterChannels.assign(tmp.size(), ExhaustThrusterChannel{});
 }
@@ -1506,6 +1523,13 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 	const vector3f linT = vector3f(m_propulsion->GetLinThrusterState());
 	const vector3f angT = -vector3f(m_propulsion->GetAngThrusterState());
 
+	// How hard linear thrusters are firing vs a ship-wide reference (larger of up / forward max thrust).
+	const double maxRefThrust = std::max(m_propulsion->GetThrust(THRUSTER_UP), m_propulsion->GetThrust(THRUSTER_FORWARD));
+	const vector3d actualLinThrust = m_propulsion->GetActualLinThrust();
+	const vector3d actualAngThrust = m_propulsion->GetActualAngThrust();
+	const float linThrustEffortScalar = actualLinThrust.Length() / maxRefThrust;
+	const float angThrustEffortScalar = actualAngThrust.Length() * SfxParams::EXHAUST_ANGULAR_FACTOR / m_propulsion->GetAngThrustCap();
+
 	// Simple ambient wind model: fixed-speed direction tangent to local surface.
 	const vector3d localUp = GetPosition().NormalizedSafe();
 	vector3d windDir = vector3d(0.0, 1.0, 0.0).Cross(localUp);
@@ -1518,14 +1542,6 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 	if (m_exhaustThrusterChannels.size() != m_thrusterExhaustMounts.size())
 		m_exhaustThrusterChannels.assign(m_thrusterExhaustMounts.size(), ExhaustThrusterChannel{});
 
-	// Get the amount that each thruster is firing this tick
-	std::vector<float> reactionPowers;
-	reactionPowers.reserve(m_thrusterExhaustThrusters.size());
-	for (SceneGraph::Thruster *th : m_thrusterExhaustThrusters) {
-		reactionPowers.push_back(Clamp(th->ComputeReactionPower(linT, angT), 0.f, 1.f));
-	}
-
-	const float intensity = float(1.4 + 2.8 * Clamp(density, 0.0, 2.0));
 	const float dragScale = float(Clamp(density / 1.225, 0.0, 2.0));
 
 	const matrix3x3d &bodyOrient = GetOrient();
@@ -1551,8 +1567,20 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 			ch.hasLastNozzle = true;
 		}
 
-		const float thrusterPower = reactionPowers[ti];
-		const bool firing = thrusterPower >= SfxParams::EXHAUST_MIN_REACTION_POWER;
+		// Get the amount that each thruster is firing this tick.
+		// Scale by thruster visual size and overall thrust demand
+		SceneGraph::Thruster *th = m_thrusterExhaustThrusters[ti];
+		const float visualScaled = th->GetVisualSizeProportional();
+		// Same combined reaction as model thruster flames 
+		const float reactionPower = th->ComputeReactionPower(linT, angT);
+		const float linOnly = th->ComputeReactionPower(linT, vector3f(0.f));
+		const float angOnly = th->ComputeReactionPower(vector3f(0.f), angT);
+		const float effortScalar = (angOnly >= linOnly) ? angThrustEffortScalar : linThrustEffortScalar;
+		const float unscaledPower = reactionPower * visualScaled * effortScalar;
+		// Use a log scale on the final thruster power so that tiny maneouvering thrusters are still visible compared to huge delta-V ones
+		const float finalThrusterPower = std::log(1.0f + SfxParams::EXHAUST_LOG_SCALE * unscaledPower) / std::log(1.0f + SfxParams::EXHAUST_LOG_SCALE);
+
+		const bool firing = finalThrusterPower >= SfxParams::EXHAUST_MIN_REACTION_POWER;
 		const bool newPulseLeadingEdge = firing && !ch.wasThrusterFiring;
 
 		vector3d exhaustDirWorld = bodyOrient * exhaustDirModel;
@@ -1565,14 +1593,15 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 		ch.lastBackboneVel = backboneWorldVel;
 
 		if (firing) {
-			const float opacityScale = float(Clamp((density / 1.225) * double(thrusterPower), 0.0, 1.0));
+			// Reduce the alpha for weaker thrusters, so that the exhaust is less pronounced
+			const float opacityScale = Clamp((density / 1.225) * double(finalThrusterPower), 0.0, 1.0);
 
-			// Keep particle count independent of thrust / density so the stream remains full.
+			// Keep particle count mostly independent of thrust / density so the stream remains full.
 			// If time is accelerated then timeStep could be huge - limit the number of particles in that case
 			// If timeStep is tiny then ensure we have at least one particle.
 			const float timeStepCapped = std::min(timeStep, SfxParams::EXHAUST_STREAM_TIMESTEP_CAP);
-			const float thrusterEmit = particlesPerSecPerThruster * timeStepCapped;
-			int count = 1 + int(thrusterEmit);
+			const float thrusterEmit = particlesPerSecPerThruster * timeStepCapped * finalThrusterPower;
+			int count = std::max(1, int(thrusterEmit));
 
 			// If this is the first tick where the thruster is firing, then only add one particle
 			// at the current nozzle position as the leading edge. It won't be drawn but will be
@@ -1584,8 +1613,7 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 				const double segT = double(i + 1) / double(count);
 				const vector3d nozzleBaseWorld = lastBackbonePosWorld.Lerp(currentNozzleWorld, segT);
 
-				const double nozzleJitterRadius = SfxParams::EXHAUST_INITIAL_SPREAD * double(std::max(thrusterPower, SfxParams::EXHAUST_MIN_REACTION_POWER));
-				const double jitterR = Pi::rng.Double(nozzleJitterRadius);
+				const double jitterRadius = Pi::rng.Double(1.0);
 				const double jitterTheta = Pi::rng.Double(2.0 * M_PI);
 
 				const vector3d shipY = bodyOrient.VectorY();
@@ -1596,14 +1624,14 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 				const vector3d vAxis = exhaustDirWorld.Cross(uAxis).Normalized();
 
 				const vector3d jitterDirW = (uAxis * std::cos(jitterTheta) + vAxis * std::sin(jitterTheta)).Normalized();
-				const vector3d plumeOffset = jitterDirW * jitterR;
+				const vector3d plumeOffset = jitterDirW * (jitterRadius * th->GetVisualSize() * SfxParams::EXHAUST_INITIAL_SPREAD);
 
-				const double maxVel = SfxParams::EXHAUST_MAX_SPREAD / (nozzleJitterRadius * double(SfxParams::EXHAUST_LIFETIME));
-				const double spreadAmp = Clamp(maxVel / std::max(density, 1e-5), 0.05, maxVel * 10.0);
-				const vector3d plumeOffsetVel = jitterDirW * (jitterR * spreadAmp);
+				const double jitterVel = (SfxParams::EXHAUST_MAX_SPREAD * jitterRadius) / SfxParams::EXHAUST_LIFETIME;
+				const double spreadAmp = Clamp(1.0 / std::max(density, 1e-5), 0.05, 8.0);
+				const vector3d plumeOffsetVel = jitterDirW * (jitterVel * spreadAmp);
 
 				const bool suppressStreak = newPulseLeadingEdge && (i == 0);
-				SfxManager::AddExhaust(this, Uint16(ti), suppressStreak, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, intensity, dragScale, opacityScale, windVel, groundRadiusAtShip, dustTint);
+				SfxManager::AddExhaust(this, Uint16(ti), suppressStreak, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, finalThrusterPower, dragScale, opacityScale, windVel, groundRadiusAtShip, dustTint);
 			}
 		}
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -28,12 +28,17 @@
 #include "lua/LuaEvent.h"
 #include "lua/LuaObject.h"
 #include "scenegraph/Animation.h"
+#include "scenegraph/MatrixTransform.h"
+#include "scenegraph/Model.h"
 #include "scenegraph/Tag.h"
+#include "scenegraph/Thruster.h"
 #include "scenegraph/CollisionGeometry.h"
 #include "ship/GunManager.h"
 #include "ship/PlayerShipController.h"
 
+#include <algorithm>
 #include <cmath>
+#include <vector>
 
 static const float TONS_HULL_PER_SHIELD = 10.f;
 const float Ship::DEFAULT_SHIELD_COOLDOWN_TIME = 1.0f;
@@ -210,6 +215,23 @@ Ship::~Ship()
 	delete m_controller;
 }
 
+void Ship::RefreshThrusterExhaustMounts()
+{
+	m_thrusterExhaustMounts.clear();
+	m_thrusterExhaustThrusters.clear();
+	if (!GetModel()) return;
+
+	std::vector<std::pair<SceneGraph::MatrixTransform *, SceneGraph::Thruster *>> tmp;
+	GetModel()->GatherThrusterMounts(tmp);
+	m_thrusterExhaustMounts.reserve(tmp.size());
+	m_thrusterExhaustThrusters.reserve(tmp.size());
+	for (const auto &pr : tmp) {
+		m_thrusterExhaustMounts.push_back(pr.first);
+		m_thrusterExhaustThrusters.push_back(pr.second);
+	}
+	m_exhaustThrusterChannels.assign(tmp.size(), ExhaustThrusterChannel{});
+}
+
 void Ship::Init()
 {
 	m_invulnerable = false;
@@ -254,6 +276,8 @@ void Ship::Init()
 	}
 
 	InitMaterials();
+
+	RefreshThrusterExhaustMounts();
 }
 
 void Ship::PostLoadFixup(Space *space)
@@ -930,8 +954,12 @@ void Ship::SetLandedOn(Planet *p, float latitude, float longitude)
 
 void Ship::SetFrame(FrameId fId)
 {
-	if (fId != GetFrame())
-		m_hasLastExhaustNozzleWorld = false;
+	if (fId != GetFrame()) {
+		for (auto &ch : m_exhaustThrusterChannels) {
+			ch.hasAnchor = false;
+			ch.wasThrusterFiring = false;
+		}
+	}
 	DynamicBody::SetFrame(fId);
 }
 
@@ -1202,72 +1230,14 @@ void Ship::StaticUpdate(const float timeStep)
 			const bool spawnExhaustForShip = !Pi::player || this == Pi::player ||
 				(GetPositionRelTo(Pi::player).LengthSqr() <= EXHAUST_MAX_PLAYER_DISTANCE_SQR);
 			if (!spawnExhaustForShip) {
-				m_hasLastExhaustNozzleWorld = false;
-			}
-
-			// Atmospheric exhaust plume - high spawn count procedural particles with low alpha
-			const vector3d linThrust = m_propulsion->GetLinThrusterState();
-			const double thrustMag = Clamp(linThrust.Length(), 0.0, 1.0);
-
-			// Exhaust goes opposite commanded thrust.
-			vector3d localExhaustDir = (linThrust.LengthSqr() > 1e-8) ? (-linThrust).Normalized() : vector3d(0.0, 0.0, 1.0);
-			const vector3d relAir = -GetVelocity();
-			// Simple ambient wind model: fixed-speed direction tangent to local surface.
-			const vector3d localUp = GetPosition().NormalizedSafe();
-			vector3d windDir = vector3d(0.0, 1.0, 0.0).Cross(localUp);
-			if (windDir.LengthSqr() < 1e-8) windDir = vector3d(1.0, 0.0, 0.0).Cross(localUp);
-			windDir = windDir.NormalizedSafe();
-			const vector3d windVel = windDir * double(SfxParams::EXHAUST_WIND_SPEED) * Clamp(density, 0.0, 1.0);
-			const vector3d currentNozzleWorld = GetPosition();
-
-			if (!m_hasLastExhaustNozzleWorld)
-				m_lastExhaustNozzleWorld = currentNozzleWorld;
-
-			// Sfx::TimeStep runs after spawning in the same tick, advancing each backbone by vel*step.
-			// Next tick, Lerp from the raw stored anchor leaves a gap of ~ vel*step to the continuum;
-			// advect m_last forward by last tick's backbone vel before distributing new spawns.
-			const double stepD = double(timeStep);
-			const vector3d lastBackbonePosWorld = m_lastExhaustNozzleWorld + m_lastExhaustBackboneVel * stepD;
-
-			if (spawnExhaustForShip && thrustMag > 0.02) {
-				const double jetSpeed = 200.0 + 150.0 * thrustMag;
-				const vector3d backboneWorldVel = GetVelocity() + (GetOrient() * localExhaustDir).NormalizedSafe() * jetSpeed;
-				const float intensity = float(1.4 + 2.8 * Clamp(density, 0.0, 2.0));
-				const float dragScale = float(Clamp(density / 1.225, 0.0, 2.0));
-				const float opacityScale = float(Clamp((density / 1.225) * thrustMag, 0.0, 1.0));
-
-				// Keep particle count independent of thrust / density so the stream remains full.
-				// If time is accelerated then timeStep could be huge - limit the number of particles in that case
-				// If timeStep is tiny then ensure we have at least one particle.
-				const float emitCount = SfxParams::EXHAUST_PARTICLES_PER_SEC * Clamp(timeStep, 0.0f, 0.2f);
-				int count = int(emitCount + 1.0f);
-
-				for (int i = 0; i < count; i++) {
-					// Evenly distribute new particles along the nozzle motion segment for this render frame
-					const double segT = (double(i) + 0.5) / double(std::max(count, 1));
-					const vector3d nozzleBaseWorld = lastBackbonePosWorld.Lerp(currentNozzleWorld, segT);
-
-					const double nozzleJitterRadius = SfxParams::EXHAUST_INITIAL_SPREAD * thrustMag;
-					const double jitterR = Pi::rng.Double(nozzleJitterRadius);
-					const double jitterTheta = Pi::rng.Double(2.0 * M_PI);
-					const vector3d nozzleJitterLocal(jitterR * std::cos(jitterTheta), jitterR * std::sin(jitterTheta), 0.0);
-					const vector3d plumeOffset = GetOrient() * nozzleJitterLocal;
-
-					// Widen gently as air thins
-					const double maxVel = SfxParams::EXHAUST_MAX_SPREAD / (nozzleJitterRadius * SfxParams::EXHAUST_LIFETIME);
-					const double spreadAmp = Clamp(maxVel / std::max(density, 1e-5), 0.05, maxVel * 10.0f);
-					const vector3d plumeOffsetVel = nozzleJitterLocal * spreadAmp;
-
-					SfxManager::AddExhaust(this, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, intensity, dragScale, opacityScale, windVel);
+				for (auto &ch : m_exhaustThrusterChannels) {
+					ch.hasAnchor = false;
+					ch.wasThrusterFiring = false;
 				}
-				m_lastExhaustBackboneVel = backboneWorldVel;
-			} else if (spawnExhaustForShip) {
-				// Idle: don't advect using last jet — only ship motion carries the nozzle anchor next tick.
-				m_lastExhaustBackboneVel = GetVelocity();
+			} else {
+				// The ship is in range for exhaust plumes - if any thrusters are firing then show those plumes
+				SpawnThrusterPlumeParticles(timeStep, density);
 			}
-
-			m_lastExhaustNozzleWorld = currentNozzleWorld;
-			m_hasLastExhaustNozzleWorld = true;
 
 			int atmo_shield_cap = std::max(m_stats.atmo_shield_cap, 1); // needs to have some shielding by default
 			if (pressure > (m_type->atmosphericPressureLimit * atmo_shield_cap)) {
@@ -1434,6 +1404,117 @@ void Ship::StaticUpdate(const float timeStep)
 				Sound::BodyMakeNoise(this, "Missile_Inbound", 1.0f);
 			}
 		}
+	}
+}
+
+void Ship::SpawnThrusterPlumeParticles(float timeStep, double density)
+{
+	const vector3d linThrustState = m_propulsion->GetLinThrusterState();
+	const double thrustMag = Clamp(linThrustState.Length(), 0.0, 1.0);
+	const vector3f linT = vector3f(linThrustState);
+	const vector3f angT = -vector3f(m_propulsion->GetAngThrusterState());
+
+	// Simple ambient wind model: fixed-speed direction tangent to local surface.
+	const vector3d localUp = GetPosition().NormalizedSafe();
+	vector3d windDir = vector3d(0.0, 1.0, 0.0).Cross(localUp);
+	if (windDir.LengthSqr() < 1e-8) windDir = vector3d(1.0, 0.0, 0.0).Cross(localUp);
+	windDir = windDir.NormalizedSafe();
+	const vector3d windVel = windDir * double(SfxParams::EXHAUST_WIND_SPEED) * Clamp(density, 0.0, 1.0);
+
+	if (m_thrusterExhaustMounts.size() != m_thrusterExhaustThrusters.size())
+		RefreshThrusterExhaustMounts();
+	if (m_exhaustThrusterChannels.size() != m_thrusterExhaustMounts.size())
+		m_exhaustThrusterChannels.assign(m_thrusterExhaustMounts.size(), ExhaustThrusterChannel{});
+
+	float totalPower = 0.f;
+	std::vector<float> reactionPowers;
+	reactionPowers.reserve(m_thrusterExhaustThrusters.size());
+	for (SceneGraph::Thruster *th : m_thrusterExhaustThrusters) {
+		const float p = th->ComputeReactionPower(linT, angT);
+		const float pClamped = Clamp(p, 0.f, 1.f);
+		reactionPowers.push_back(pClamped);
+		if (pClamped >= SfxParams::EXHAUST_MIN_REACTION_POWER)
+			totalPower += pClamped;
+	}
+
+	const float intensity = float(1.4 + 2.8 * Clamp(density, 0.0, 2.0));
+	const float dragScale = float(Clamp(density / 1.225, 0.0, 2.0));
+	const float opacityDrive = float(std::max(thrustMag, std::min(double(totalPower), 1.0)));
+	const float opacityScale = float(Clamp((density / 1.225) * opacityDrive, 0.0, 1.0));
+
+	const matrix3x3d &bodyOrient = GetOrient();
+
+	for (size_t ti = 0; ti < m_thrusterExhaustMounts.size(); ++ti) {
+		SceneGraph::MatrixTransform *mt = m_thrusterExhaustMounts[ti];
+		SceneGraph::Thruster *thr = m_thrusterExhaustThrusters[ti];
+		ExhaustThrusterChannel &ch = m_exhaustThrusterChannels[ti];
+
+		const matrix4x4f M = mt->CalcGlobalTransform();
+		const vector3d nozzleLocal = vector3d(M.GetTranslate());
+		const vector3d exhaustDirModel = vector3d(thr->GetDirection()).NormalizedSafe();
+		const vector3d currentNozzleWorld = GetPosition() + bodyOrient * nozzleLocal;
+
+		if (!ch.hasAnchor) {
+			ch.lastNozzleWorld = currentNozzleWorld;
+			ch.hasAnchor = true;
+		}
+
+		const float pClamped = reactionPowers[ti];
+		const bool firing = pClamped >= SfxParams::EXHAUST_MIN_REACTION_POWER;
+		const bool newPulseLeadingEdge = firing && !ch.wasThrusterFiring;
+
+		vector3d exhaustDirWorld = bodyOrient * exhaustDirModel;
+		if (exhaustDirWorld.LengthSqr() < 1e-12)
+			exhaustDirWorld = bodyOrient.VectorZ();
+		exhaustDirWorld = exhaustDirWorld.Normalized();
+		const vector3d backboneWorldVel = GetVelocity() + exhaustDirWorld * double(SfxParams::EXHAUST_INITIAL_VELOCITY);
+
+		const vector3d lastBackbonePosWorld = ch.lastNozzleWorld + ch.lastBackboneVel * (double)timeStep;
+		ch.lastBackboneVel = backboneWorldVel;
+
+		if (firing) {
+
+			// Keep particle count independent of thrust / density so the stream remains full.
+			// If time is accelerated then timeStep could be huge - limit the number of particles in that case
+			// If timeStep is tiny then ensure we have at least one particle.
+			const float thrusterEmit = SfxParams::EXHAUST_PARTICLES_PER_SEC * Clamp(timeStep, 0.0f, 0.2f);
+			int count = 1 + int(thrusterEmit);
+
+			// If this is the first tick where the thruster is firing, then only add one particle
+			// at the current nozzle position as the leading edge. It won't be drawn but will be
+			// used as the starting elongation target on the next tick
+			if (newPulseLeadingEdge)
+				count = 1;
+
+			for (int i = 0; i < count; i++) {
+				const double segT = double(i + 1) / double(count);
+				const vector3d nozzleBaseWorld = lastBackbonePosWorld.Lerp(currentNozzleWorld, segT);
+
+				const double nozzleJitterRadius = SfxParams::EXHAUST_INITIAL_SPREAD * double(std::max(pClamped, SfxParams::EXHAUST_MIN_REACTION_POWER));
+				const double jitterR = Pi::rng.Double(nozzleJitterRadius);
+				const double jitterTheta = Pi::rng.Double(2.0 * M_PI);
+
+				const vector3d shipY = bodyOrient.VectorY();
+				const vector3d refAxis = (std::abs(exhaustDirWorld.Dot(shipY)) < 0.85) ? shipY : bodyOrient.VectorZ();
+				vector3d uAxis = refAxis.Cross(exhaustDirWorld).Normalized();
+				if (uAxis.LengthSqr() < 1e-12)
+					uAxis = bodyOrient.VectorX();
+				const vector3d vAxis = exhaustDirWorld.Cross(uAxis).Normalized();
+
+				const vector3d jitterDirW = (uAxis * std::cos(jitterTheta) + vAxis * std::sin(jitterTheta)).Normalized();
+				const vector3d plumeOffset = jitterDirW * jitterR;
+
+				const double maxVel = SfxParams::EXHAUST_MAX_SPREAD / (nozzleJitterRadius * double(SfxParams::EXHAUST_LIFETIME));
+				const double spreadAmp = Clamp(maxVel / std::max(density, 1e-5), 0.05, maxVel * 10.0);
+				const vector3d plumeOffsetVel = jitterDirW * (jitterR * spreadAmp);
+
+				const bool suppressStreak = newPulseLeadingEdge && (i == 0);
+				SfxManager::AddExhaust(this, Uint16(ti), suppressStreak, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, intensity, dragScale, opacityScale, windVel);
+			}
+		}
+
+		ch.wasThrusterFiring = firing;
+		ch.lastNozzleWorld = currentNozzleWorld;
 	}
 }
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -52,6 +52,8 @@ namespace {
 
 	bool TryGetLandingPadDustOverride(const Ship *ship, double *outGroundRadius, Color *outDustTint)
 	{
+		PROFILE_SCOPED()
+
 		if (!ship || !outGroundRadius || !outDustTint || !Pi::game) return false;
 		Space *space = Pi::game->GetSpace();
 		if (!space) return false;
@@ -1531,18 +1533,18 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 	const float angThrustEffortScalar = actualAngThrust.Length() * SfxParams::EXHAUST_ANGULAR_FACTOR / m_propulsion->GetAngThrustCap();
 
 	// Simple ambient wind model: fixed-speed direction tangent to local surface.
-	const vector3d localUp = GetPosition().NormalizedSafe();
-	vector3d windDir = vector3d(0.0, 1.0, 0.0).Cross(localUp);
-	if (windDir.LengthSqr() < 1e-8) windDir = vector3d(1.0, 0.0, 0.0).Cross(localUp);
+	const vector3f localUp = vector3f(GetPosition().NormalizedSafe());
+	vector3f windDir = vector3f(0.f, 1.f, 0.f).Cross(localUp);
+	if (windDir.LengthSqr() < 1e-8f) windDir = vector3f(1.f, 0.f, 0.f).Cross(localUp);
 	windDir = windDir.NormalizedSafe();
-	const vector3d windVel = windDir * double(SfxParams::EXHAUST_WIND_SPEED) * Clamp(density, 0.0, 1.0);
+	const vector3f windVel = windDir * (SfxParams::EXHAUST_WIND_SPEED * float(Clamp(density, 0.0, 1.0)));
 
 	if (m_thrusterExhaustMounts.size() != m_thrusterExhaustThrusters.size())
 		RefreshThrusterExhaustMounts();
 	if (m_exhaustThrusterChannels.size() != m_thrusterExhaustMounts.size())
 		m_exhaustThrusterChannels.assign(m_thrusterExhaustMounts.size(), ExhaustThrusterChannel{});
 
-	const float dragScale = float(Clamp(density / 1.225, 0.0, 2.0));
+	const float atmosDragScale = float(Clamp(density / 1.225, 0.0, 2.0));
 
 	const matrix3x3d &bodyOrient = GetOrient();
 
@@ -1596,6 +1598,9 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 			// Reduce the alpha for weaker thrusters, so that the exhaust is less pronounced
 			const float opacityScale = Clamp((density / 1.225) * double(finalThrusterPower), 0.0, 1.0);
 
+			// Increase drag for weaker thrusters, so that they slow down more quickly (less volume of exhaust)
+			const float dragScale = atmosDragScale * SfxParams::EXHAUST_DRAG_FACTOR / std::max(visualScaled, 0.2f);
+
 			// Keep particle count mostly independent of thrust / density so the stream remains full.
 			// If time is accelerated then timeStep could be huge - limit the number of particles in that case
 			// If timeStep is tiny then ensure we have at least one particle.
@@ -1609,26 +1614,27 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 			if (newPulseLeadingEdge)
 				count = 1;
 
+			const vector3f exhaustDirF = vector3f(exhaustDirWorld);
+			const vector3f shipY = vector3f(bodyOrient.VectorY());
+			const vector3f refAxis = (std::abs(exhaustDirF.Dot(shipY)) < 0.85f) ? shipY : vector3f(bodyOrient.VectorZ());
+			vector3f uAxis = refAxis.Cross(exhaustDirF).Normalized();
+			if (uAxis.LengthSqr() < 1e-12f)
+				uAxis = vector3f(bodyOrient.VectorX());
+			const vector3f vAxis = exhaustDirF.Cross(uAxis).Normalized();
+
 			for (int i = 0; i < count; i++) {
 				const double segT = double(i + 1) / double(count);
 				const vector3d nozzleBaseWorld = lastBackbonePosWorld.Lerp(currentNozzleWorld, segT);
 
-				const double jitterRadius = Pi::rng.Double(1.0);
-				const double jitterTheta = Pi::rng.Double(2.0 * M_PI);
+				const float jitterRadius = float(Pi::rng.Double(1.0));
+				const float jitterTheta = float(Pi::rng.Double(2.0 * M_PI));
 
-				const vector3d shipY = bodyOrient.VectorY();
-				const vector3d refAxis = (std::abs(exhaustDirWorld.Dot(shipY)) < 0.85) ? shipY : bodyOrient.VectorZ();
-				vector3d uAxis = refAxis.Cross(exhaustDirWorld).Normalized();
-				if (uAxis.LengthSqr() < 1e-12)
-					uAxis = bodyOrient.VectorX();
-				const vector3d vAxis = exhaustDirWorld.Cross(uAxis).Normalized();
+				const vector3f jitterDirW = (uAxis * std::cos(jitterTheta) + vAxis * std::sin(jitterTheta)).Normalized();
+				const vector3f plumeOffset = jitterDirW * (jitterRadius * SfxParams::EXHAUST_INITIAL_SPREAD);
 
-				const vector3d jitterDirW = (uAxis * std::cos(jitterTheta) + vAxis * std::sin(jitterTheta)).Normalized();
-				const vector3d plumeOffset = jitterDirW * (jitterRadius * th->GetVisualSize() * SfxParams::EXHAUST_INITIAL_SPREAD);
-
-				const double jitterVel = (SfxParams::EXHAUST_MAX_SPREAD * jitterRadius) / SfxParams::EXHAUST_LIFETIME;
-				const double spreadAmp = Clamp(1.0 / std::max(density, 1e-5), 0.05, 8.0);
-				const vector3d plumeOffsetVel = jitterDirW * (jitterVel * spreadAmp);
+				const float jitterVel = (SfxParams::EXHAUST_MAX_SPREAD * jitterRadius) / SfxParams::EXHAUST_LIFETIME;
+				const float spreadAmp = float(Clamp(1.0 / std::max(density, 1e-5), 0.05, 8.0));
+				const vector3f plumeOffsetVel = jitterDirW * (jitterVel * spreadAmp);
 
 				const bool suppressStreak = newPulseLeadingEdge && (i == 0);
 				SfxManager::AddExhaust(this, Uint16(ti), suppressStreak, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, finalThrusterPower, dragScale, opacityScale, windVel, groundRadiusAtShip, dustTint);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -14,6 +14,7 @@
 #include "NavLights.h"
 #include "Pi.h"
 #include "Planet.h"
+#include "galaxy/SystemBody.h"
 #include "Player.h" // <-- Here only for 1 occurrence of "Pi::player" in Ship::Explode
 #include "Sensors.h"
 #include "Sfx.h"
@@ -38,6 +39,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 static const float TONS_HULL_PER_SHIELD = 10.f;
@@ -47,6 +49,66 @@ const double Ship::DEFAULT_LIFT_TO_DRAG_RATIO = 0.001;
 namespace {
 	static constexpr size_t s_heatingNormalParam = "heatingNormal"_hash;
 	static constexpr size_t s_heatGradientTexParam = "heatGradient"_hash;
+
+	bool TryGetLandingPadDustOverride(const Ship *ship, double *outGroundRadius, Color *outDustTint)
+	{
+		if (!ship || !outGroundRadius || !outDustTint || !Pi::game) return false;
+		Space *space = Pi::game->GetSpace();
+		if (!space) return false;
+
+		// Keep this local query cheap; we only need stations close enough to plausibly be beneath the ship.
+		constexpr double PAD_QUERY_RADIUS = 2000.0;
+		constexpr double PAD_MAX_VERTICAL_ABOVE_M = 350.0;
+		constexpr double PAD_MIN_VERTICAL_BELOW_M = -20.0;
+		constexpr double PAD_BASE_LATERAL_RADIUS_M = 120.0;
+
+		const Space::BodyNearList nearby = space->GetBodiesMaybeNear(ship, PAD_QUERY_RADIUS);
+		bool foundPad = false;
+		double bestPadDistSq = std::numeric_limits<double>::max();
+		double bestPadRadius = 0.0;
+		for (Body *body : nearby) {
+			if (!body || !body->IsType(ObjectType::SPACESTATION)) continue;
+			SpaceStation *station = static_cast<SpaceStation *>(body);
+			if (!station->IsGroundStation()) continue;
+			if (station->GetFrame() != ship->GetFrame()) continue;
+
+			const SpaceStationType *stationType = station->GetStationType();
+			if (!stationType) continue;
+
+			for (Uint32 bay = 0; bay < stationType->NumDockingPorts(); ++bay) {
+				const matrix4x4f bayDocked = stationType->GetStageTransform(int(bay), DockStage::DOCKED);
+				const vector3d bayLocal = vector3d(bayDocked.GetTranslate());
+				const vector3d bayWorld = station->GetPosition() + station->GetOrient() * bayLocal;
+				const vector3d padUp = bayWorld.NormalizedSafe();
+
+				const vector3d shipRel = ship->GetPosition() - bayWorld;
+				const double vertical = shipRel.Dot(padUp);
+				if (vertical < PAD_MIN_VERTICAL_BELOW_M || vertical > PAD_MAX_VERTICAL_ABOVE_M)
+					continue;
+
+				const vector3d lateralVec = shipRel - padUp * vertical;
+				double padLateralRadius = PAD_BASE_LATERAL_RADIUS_M;
+				if (const SpaceStationType::SPort *port = stationType->FindPortByBay(int(bay)))
+					padLateralRadius = std::max(padLateralRadius, 0.5 * double(port->maxShipSize));
+
+				const double lateralDistSq = lateralVec.LengthSqr();
+				if (lateralDistSq > padLateralRadius * padLateralRadius)
+					continue;
+
+				if (lateralDistSq < bestPadDistSq) {
+					bestPadDistSq = lateralDistSq;
+					bestPadRadius = bayWorld.Length();
+					foundPad = true;
+				}
+			}
+		}
+		if (!foundPad) return false;
+
+		*outGroundRadius = bestPadRadius;
+		// Concrete or landing pad dust colour. We make this lower alpha because it's less intense than a dusty planet surface.
+		*outDustTint = Color(128, 128, 128, 63);
+		return true;
+	}
 } // namespace
 
 Ship::Ship(const ShipType::Id &shipId) :
@@ -956,7 +1018,7 @@ void Ship::SetFrame(FrameId fId)
 {
 	if (fId != GetFrame()) {
 		for (auto &ch : m_exhaustThrusterChannels) {
-			ch.hasAnchor = false;
+			ch.hasLastNozzle = false;
 			ch.wasThrusterFiring = false;
 		}
 	}
@@ -1225,25 +1287,13 @@ void Ship::StaticUpdate(const float timeStep)
 			double pressure, density;
 			p->GetAtmosphericState(dist, &pressure, &density);
 
-			// Atmospheric exhaust plume - spawn only for ships close enough to the player.
-			constexpr double EXHAUST_MAX_PLAYER_DISTANCE_SQR = SfxParams::EXHAUST_MAX_PLAYER_DISTANCE * SfxParams::EXHAUST_MAX_PLAYER_DISTANCE;
-			const bool spawnExhaustForShip = !Pi::player || this == Pi::player ||
-				(GetPositionRelTo(Pi::player).LengthSqr() <= EXHAUST_MAX_PLAYER_DISTANCE_SQR);
-			if (!spawnExhaustForShip) {
-				for (auto &ch : m_exhaustThrusterChannels) {
-					ch.hasAnchor = false;
-					ch.wasThrusterFiring = false;
-				}
-			} else {
-				// The ship is in range for exhaust plumes - if any thrusters are firing then show those plumes
-				SpawnThrusterPlumeParticles(timeStep, density);
-			}
-
 			int atmo_shield_cap = std::max(m_stats.atmo_shield_cap, 1); // needs to have some shielding by default
 			if (pressure > (m_type->atmosphericPressureLimit * atmo_shield_cap)) {
 				float damage = float(pressure - m_type->atmosphericPressureLimit);
 				DoDamage(damage);
 			}
+
+			SpawnThrusterExhaustParticles(timeStep);
 		}
 	}
 
@@ -1407,11 +1457,53 @@ void Ship::StaticUpdate(const float timeStep)
 	}
 }
 
-void Ship::SpawnThrusterPlumeParticles(float timeStep, double density)
+void Ship::SpawnThrusterExhaustParticles(float timeStep)
 {
-	const vector3d linThrustState = m_propulsion->GetLinThrusterState();
-	const double thrustMag = Clamp(linThrustState.Length(), 0.0, 1.0);
-	const vector3f linT = vector3f(linThrustState);
+	if (IsDead()) return;
+	if (m_flightState != FLYING) return;
+
+	Frame *frame = Frame::GetFrame(GetFrame());
+	Body *astro = frame->GetBody();
+	if (!astro || !astro->IsType(ObjectType::PLANET)) return;
+
+	Planet *p = static_cast<Planet *>(astro);
+	const double dist = GetPosition().Length();
+	double pressureAtDist, density;
+	p->GetAtmosphericState(dist, &pressureAtDist, &density);
+	(void)pressureAtDist;
+
+	const SystemBody *sbody = p->GetSystemBody();
+	// Terrestrial worlds / asteroids / moons with terrain (exclude gas giants and non-planet types).
+	const bool landableNaturalWorld = sbody && (sbody->GetSuperType() == SystemBodyType::SUPERTYPE_ROCKY_PLANET);
+	const double altitudeM = sbody ? (dist - sbody->GetRadius()) : 0.0;
+	const double plumeAltitudeCapM = sbody ? std::max(sbody->GetAtmRadius(), 1000.0) : 0.0;
+	double groundRadiusAtShip = landableNaturalWorld ? p->GetTerrainHeight(GetPosition().NormalizedSafe()) : 0.0;
+	Color dustTint = landableNaturalWorld ? sbody->CalcSurfaceDustColor() : Color(128, 128, 128, 255);
+	(void)TryGetLandingPadDustOverride(this, &groundRadiusAtShip, &dustTint);
+
+	// Slight per-spawn dust colour variation so dust clouds are less uniform.
+	const float shade = float(Pi::rng.Double(0.95, 1.05));
+	dustTint.r = Uint8(Clamp(int(dustTint.r * shade), 0, 255));
+	dustTint.g = Uint8(Clamp(int(dustTint.g * shade), 0, 255));
+	dustTint.b = Uint8(Clamp(int(dustTint.b * shade), 0, 255));
+
+	// Exhaust plumes shown if the ship is within the atmosphere height, or within 1 km of the surface for ground-hugging / surface dust.
+	const bool lowAltitudePlumes = landableNaturalWorld && ((altitudeM <= plumeAltitudeCapM) || (dist <= groundRadiusAtShip + 1000.0));
+
+	// Atmospheric exhaust plume - spawn only for ships close enough to the player.
+	constexpr double EXHAUST_MAX_PLAYER_DISTANCE_SQR = SfxParams::EXHAUST_MAX_PLAYER_DISTANCE * SfxParams::EXHAUST_MAX_PLAYER_DISTANCE;
+	const bool spawnExhaustForShip = !Pi::player || this == Pi::player || (GetPositionRelTo(Pi::player).LengthSqr() <= EXHAUST_MAX_PLAYER_DISTANCE_SQR);
+
+	if (!spawnExhaustForShip || !lowAltitudePlumes) {
+		// We're not adding any exhaust this tick. Clear the thruster exhaust channels so there is no stale state.
+		for (auto &ch : m_exhaustThrusterChannels) {
+			ch.hasLastNozzle = false;
+			ch.wasThrusterFiring = false;
+		}
+		return;
+	}
+
+	const vector3f linT = vector3f(m_propulsion->GetLinThrusterState());
 	const vector3f angT = -vector3f(m_propulsion->GetAngThrusterState());
 
 	// Simple ambient wind model: fixed-speed direction tangent to local surface.
@@ -1426,23 +1518,23 @@ void Ship::SpawnThrusterPlumeParticles(float timeStep, double density)
 	if (m_exhaustThrusterChannels.size() != m_thrusterExhaustMounts.size())
 		m_exhaustThrusterChannels.assign(m_thrusterExhaustMounts.size(), ExhaustThrusterChannel{});
 
-	float totalPower = 0.f;
+	// Get the amount that each thruster is firing this tick
 	std::vector<float> reactionPowers;
 	reactionPowers.reserve(m_thrusterExhaustThrusters.size());
 	for (SceneGraph::Thruster *th : m_thrusterExhaustThrusters) {
-		const float p = th->ComputeReactionPower(linT, angT);
-		const float pClamped = Clamp(p, 0.f, 1.f);
-		reactionPowers.push_back(pClamped);
-		if (pClamped >= SfxParams::EXHAUST_MIN_REACTION_POWER)
-			totalPower += pClamped;
+		reactionPowers.push_back(Clamp(th->ComputeReactionPower(linT, angT), 0.f, 1.f));
 	}
 
 	const float intensity = float(1.4 + 2.8 * Clamp(density, 0.0, 2.0));
 	const float dragScale = float(Clamp(density / 1.225, 0.0, 2.0));
-	const float opacityDrive = float(std::max(thrustMag, std::min(double(totalPower), 1.0)));
-	const float opacityScale = float(Clamp((density / 1.225) * opacityDrive, 0.0, 1.0));
 
 	const matrix3x3d &bodyOrient = GetOrient();
+
+	// Some ships have lots of small thrusters next to each other. Others have one big one.
+	// We use the same number of particles per ship, since small adjacent streams will merge
+	// visually anyway, and we this way we don't end up with too many particles on some ships
+	// and not enough on others.
+	const float particlesPerSecPerThruster = SfxParams::EXHAUST_PARTICLES_PER_SHIP_PER_SEC / m_thrusterExhaustMounts.size();
 
 	for (size_t ti = 0; ti < m_thrusterExhaustMounts.size(); ++ti) {
 		SceneGraph::MatrixTransform *mt = m_thrusterExhaustMounts[ti];
@@ -1454,13 +1546,13 @@ void Ship::SpawnThrusterPlumeParticles(float timeStep, double density)
 		const vector3d exhaustDirModel = vector3d(thr->GetDirection()).NormalizedSafe();
 		const vector3d currentNozzleWorld = GetPosition() + bodyOrient * nozzleLocal;
 
-		if (!ch.hasAnchor) {
+		if (!ch.hasLastNozzle) {
 			ch.lastNozzleWorld = currentNozzleWorld;
-			ch.hasAnchor = true;
+			ch.hasLastNozzle = true;
 		}
 
-		const float pClamped = reactionPowers[ti];
-		const bool firing = pClamped >= SfxParams::EXHAUST_MIN_REACTION_POWER;
+		const float thrusterPower = reactionPowers[ti];
+		const bool firing = thrusterPower >= SfxParams::EXHAUST_MIN_REACTION_POWER;
 		const bool newPulseLeadingEdge = firing && !ch.wasThrusterFiring;
 
 		vector3d exhaustDirWorld = bodyOrient * exhaustDirModel;
@@ -1469,15 +1561,17 @@ void Ship::SpawnThrusterPlumeParticles(float timeStep, double density)
 		exhaustDirWorld = exhaustDirWorld.Normalized();
 		const vector3d backboneWorldVel = GetVelocity() + exhaustDirWorld * double(SfxParams::EXHAUST_INITIAL_VELOCITY);
 
-		const vector3d lastBackbonePosWorld = ch.lastNozzleWorld + ch.lastBackboneVel * (double)timeStep;
+		const vector3d lastBackbonePosWorld = ch.lastNozzleWorld + ch.lastBackboneVel * double(timeStep);
 		ch.lastBackboneVel = backboneWorldVel;
 
 		if (firing) {
+			const float opacityScale = float(Clamp((density / 1.225) * double(thrusterPower), 0.0, 1.0));
 
 			// Keep particle count independent of thrust / density so the stream remains full.
 			// If time is accelerated then timeStep could be huge - limit the number of particles in that case
 			// If timeStep is tiny then ensure we have at least one particle.
-			const float thrusterEmit = SfxParams::EXHAUST_PARTICLES_PER_SEC * Clamp(timeStep, 0.0f, 0.2f);
+			const float timeStepCapped = std::min(timeStep, SfxParams::EXHAUST_STREAM_TIMESTEP_CAP);
+			const float thrusterEmit = particlesPerSecPerThruster * timeStepCapped;
 			int count = 1 + int(thrusterEmit);
 
 			// If this is the first tick where the thruster is firing, then only add one particle
@@ -1490,7 +1584,7 @@ void Ship::SpawnThrusterPlumeParticles(float timeStep, double density)
 				const double segT = double(i + 1) / double(count);
 				const vector3d nozzleBaseWorld = lastBackbonePosWorld.Lerp(currentNozzleWorld, segT);
 
-				const double nozzleJitterRadius = SfxParams::EXHAUST_INITIAL_SPREAD * double(std::max(pClamped, SfxParams::EXHAUST_MIN_REACTION_POWER));
+				const double nozzleJitterRadius = SfxParams::EXHAUST_INITIAL_SPREAD * double(std::max(thrusterPower, SfxParams::EXHAUST_MIN_REACTION_POWER));
 				const double jitterR = Pi::rng.Double(nozzleJitterRadius);
 				const double jitterTheta = Pi::rng.Double(2.0 * M_PI);
 
@@ -1509,7 +1603,7 @@ void Ship::SpawnThrusterPlumeParticles(float timeStep, double density)
 				const vector3d plumeOffsetVel = jitterDirW * (jitterR * spreadAmp);
 
 				const bool suppressStreak = newPulseLeadingEdge && (i == 0);
-				SfxManager::AddExhaust(this, Uint16(ti), suppressStreak, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, intensity, dragScale, opacityScale, windVel);
+				SfxManager::AddExhaust(this, Uint16(ti), suppressStreak, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, intensity, dragScale, opacityScale, windVel, groundRadiusAtShip, dustTint);
 			}
 		}
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -33,6 +33,8 @@
 #include "ship/GunManager.h"
 #include "ship/PlayerShipController.h"
 
+#include <cmath>
+
 static const float TONS_HULL_PER_SHIELD = 10.f;
 const float Ship::DEFAULT_SHIELD_COOLDOWN_TIME = 1.0f;
 const double Ship::DEFAULT_LIFT_TO_DRAG_RATIO = 0.001;
@@ -928,6 +930,8 @@ void Ship::SetLandedOn(Planet *p, float latitude, float longitude)
 
 void Ship::SetFrame(FrameId fId)
 {
+	if (fId != GetFrame())
+		m_hasLastExhaustNozzleWorld = false;
 	DynamicBody::SetFrame(fId);
 }
 
@@ -1192,6 +1196,78 @@ void Ship::StaticUpdate(const float timeStep)
 			double dist = GetPosition().Length();
 			double pressure, density;
 			p->GetAtmosphericState(dist, &pressure, &density);
+
+			// Atmospheric exhaust plume - spawn only for ships close enough to the player.
+			constexpr double EXHAUST_MAX_PLAYER_DISTANCE_SQR = SfxParams::EXHAUST_MAX_PLAYER_DISTANCE * SfxParams::EXHAUST_MAX_PLAYER_DISTANCE;
+			const bool spawnExhaustForShip = !Pi::player || this == Pi::player ||
+				(GetPositionRelTo(Pi::player).LengthSqr() <= EXHAUST_MAX_PLAYER_DISTANCE_SQR);
+			if (!spawnExhaustForShip) {
+				m_hasLastExhaustNozzleWorld = false;
+			}
+
+			// Atmospheric exhaust plume - high spawn count procedural particles with low alpha
+			const vector3d linThrust = m_propulsion->GetLinThrusterState();
+			const double thrustMag = Clamp(linThrust.Length(), 0.0, 1.0);
+
+			// Exhaust goes opposite commanded thrust.
+			vector3d localExhaustDir = (linThrust.LengthSqr() > 1e-8) ? (-linThrust).Normalized() : vector3d(0.0, 0.0, 1.0);
+			const vector3d relAir = -GetVelocity();
+			// Simple ambient wind model: fixed-speed direction tangent to local surface.
+			const vector3d localUp = GetPosition().NormalizedSafe();
+			vector3d windDir = vector3d(0.0, 1.0, 0.0).Cross(localUp);
+			if (windDir.LengthSqr() < 1e-8) windDir = vector3d(1.0, 0.0, 0.0).Cross(localUp);
+			windDir = windDir.NormalizedSafe();
+			const vector3d windVel = windDir * double(SfxParams::EXHAUST_WIND_SPEED) * Clamp(density, 0.0, 1.0);
+			const vector3d currentNozzleWorld = GetPosition();
+
+			if (!m_hasLastExhaustNozzleWorld)
+				m_lastExhaustNozzleWorld = currentNozzleWorld;
+
+			// Sfx::TimeStep runs after spawning in the same tick, advancing each backbone by vel*step.
+			// Next tick, Lerp from the raw stored anchor leaves a gap of ~ vel*step to the continuum;
+			// advect m_last forward by last tick's backbone vel before distributing new spawns.
+			const double stepD = double(timeStep);
+			const vector3d lastBackbonePosWorld = m_lastExhaustNozzleWorld + m_lastExhaustBackboneVel * stepD;
+
+			if (spawnExhaustForShip && thrustMag > 0.02) {
+				const double jetSpeed = 200.0 + 150.0 * thrustMag;
+				const vector3d backboneWorldVel = GetVelocity() + (GetOrient() * localExhaustDir).NormalizedSafe() * jetSpeed;
+				const float intensity = float(1.4 + 2.8 * Clamp(density, 0.0, 2.0));
+				const float dragScale = float(Clamp(density / 1.225, 0.0, 2.0));
+				const float opacityScale = float(Clamp((density / 1.225) * thrustMag, 0.0, 1.0));
+
+				// Keep particle count independent of thrust / density so the stream remains full.
+				// If time is accelerated then timeStep could be huge - limit the number of particles in that case
+				// If timeStep is tiny then ensure we have at least one particle.
+				const float emitCount = SfxParams::EXHAUST_PARTICLES_PER_SEC * Clamp(timeStep, 0.0f, 0.2f);
+				int count = int(emitCount + 1.0f);
+
+				for (int i = 0; i < count; i++) {
+					// Evenly distribute new particles along the nozzle motion segment for this render frame
+					const double segT = (double(i) + 0.5) / double(std::max(count, 1));
+					const vector3d nozzleBaseWorld = lastBackbonePosWorld.Lerp(currentNozzleWorld, segT);
+
+					const double nozzleJitterRadius = SfxParams::EXHAUST_INITIAL_SPREAD * thrustMag;
+					const double jitterR = Pi::rng.Double(nozzleJitterRadius);
+					const double jitterTheta = Pi::rng.Double(2.0 * M_PI);
+					const vector3d nozzleJitterLocal(jitterR * std::cos(jitterTheta), jitterR * std::sin(jitterTheta), 0.0);
+					const vector3d plumeOffset = GetOrient() * nozzleJitterLocal;
+
+					// Widen gently as air thins
+					const double maxVel = SfxParams::EXHAUST_MAX_SPREAD / (nozzleJitterRadius * SfxParams::EXHAUST_LIFETIME);
+					const double spreadAmp = Clamp(maxVel / std::max(density, 1e-5), 0.05, maxVel * 10.0f);
+					const vector3d plumeOffsetVel = nozzleJitterLocal * spreadAmp;
+
+					SfxManager::AddExhaust(this, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, intensity, dragScale, opacityScale, windVel);
+				}
+				m_lastExhaustBackboneVel = backboneWorldVel;
+			} else if (spawnExhaustForShip) {
+				// Idle: don't advect using last jet — only ship motion carries the nozzle anchor next tick.
+				m_lastExhaustBackboneVel = GetVelocity();
+			}
+
+			m_lastExhaustNozzleWorld = currentNozzleWorld;
+			m_hasLastExhaustNozzleWorld = true;
 
 			int atmo_shield_cap = std::max(m_stats.atmo_shield_cap, 1); // needs to have some shielding by default
 			if (pressure > (m_type->atmosphericPressureLimit * atmo_shield_cap)) {

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -16,6 +16,11 @@
 
 #include "ship/Propulsion.h"
 
+namespace SceneGraph {
+	class MatrixTransform;
+	class Thruster;
+}
+
 class AICommand;
 class Camera;
 class CargoBody;
@@ -115,6 +120,7 @@ public:
 	bool Undock();
 	void TimeStepUpdate(const float timeStep) override;
 	void StaticUpdate(const float timeStep) override;
+	void SpawnThrusterPlumeParticles(float timeStep, double density);
 
 	void TimeAccelAdjust(const float timeStep);
 
@@ -343,9 +349,19 @@ private:
 	double m_hydrogenScoopedAccumulator = 0;
 
 	double m_latestSpawnTime = 0.0;
-	bool m_hasLastExhaustNozzleWorld = false;
-	vector3d m_lastExhaustNozzleWorld = vector3d::Zero;
-	vector3d m_lastExhaustBackboneVel = vector3d::Zero;
+
+	// Per-thruster atmospheric exhaust (nozzle anchor + jet backbone)
+	struct ExhaustThrusterChannel {
+		bool hasAnchor = false;
+		vector3d lastNozzleWorld = vector3d::Zero;
+		vector3d lastBackboneVel = vector3d::Zero;
+		bool wasThrusterFiring = false;
+	};
+	std::vector<SceneGraph::MatrixTransform *> m_thrusterExhaustMounts;
+	std::vector<SceneGraph::Thruster *> m_thrusterExhaustThrusters;
+	std::vector<ExhaustThrusterChannel> m_exhaustThrusterChannels;
+	void RefreshThrusterExhaustMounts();
+
 	std::deque<CargoBody *> m_cargoSpawnQueue;
 
 public:

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -120,7 +120,6 @@ public:
 	bool Undock();
 	void TimeStepUpdate(const float timeStep) override;
 	void StaticUpdate(const float timeStep) override;
-	void SpawnThrusterPlumeParticles(float timeStep, double density);
 
 	void TimeAccelAdjust(const float timeStep);
 
@@ -352,7 +351,7 @@ private:
 
 	// Per-thruster atmospheric exhaust (nozzle anchor + jet backbone)
 	struct ExhaustThrusterChannel {
-		bool hasAnchor = false;
+		bool hasLastNozzle = false;
 		vector3d lastNozzleWorld = vector3d::Zero;
 		vector3d lastBackboneVel = vector3d::Zero;
 		bool wasThrusterFiring = false;
@@ -361,6 +360,7 @@ private:
 	std::vector<SceneGraph::Thruster *> m_thrusterExhaustThrusters;
 	std::vector<ExhaustThrusterChannel> m_exhaustThrusterChannels;
 	void RefreshThrusterExhaustMounts();
+	void SpawnThrusterExhaustParticles(float timeStep);
 
 	std::deque<CargoBody *> m_cargoSpawnQueue;
 

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -343,6 +343,9 @@ private:
 	double m_hydrogenScoopedAccumulator = 0;
 
 	double m_latestSpawnTime = 0.0;
+	bool m_hasLastExhaustNozzleWorld = false;
+	vector3d m_lastExhaustNozzleWorld = vector3d::Zero;
+	vector3d m_lastExhaustBackboneVel = vector3d::Zero;
 	std::deque<CargoBody *> m_cargoSpawnQueue;
 
 public:

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -1203,12 +1203,6 @@ bool AICmdFlyTo::TimeStepUpdate()
 	// linear thrust application, decel check
 	vector3d vdiff = linaccel * reldir + perpspeed * perpdir;
 	bool decel = sdiff <= 0;
-	// TODO: what is "SetDecelerating"??? => needs to be moved
-	m_dBody->SetDecelerating(decel);
-	if (decel)
-		m_prop->AIChangeVelBy(vdiff * m_dBody->GetOrient());
-	else
-		m_prop->AIChangeVelDir(vdiff * m_dBody->GetOrient());
 
 	// work out which way to head
 	vector3d head = reldir;
@@ -1242,6 +1236,13 @@ bool AICmdFlyTo::TimeStepUpdate()
 		m_prop->AIFaceDirection(head);
 	if (body && body->IsType(ObjectType::PLANET) && m_dBody->GetPosition().LengthSqr() < 2 * erad * erad)
 		m_prop->AIFaceUpdir(m_dBody->GetPosition()); // turn bottom thruster towards planet
+
+	// TODO: what is "SetDecelerating"??? => needs to be moved
+	m_dBody->SetDecelerating(decel);
+	if (decel)
+		m_prop->AIChangeVelBy(vdiff * m_dBody->GetOrient());
+	else
+		m_prop->AIChangeVelDir(vdiff * m_dBody->GetOrient());
 
 	// termination conditions: check
 	if (m_state >= 3) return true; // finished last adjustment, hopefully
@@ -1438,10 +1439,6 @@ bool AICmdDock::TimeStepUpdate()
 	const double maxdecel = m_prop->GetAccelUp() - GetGravityAtPos(m_target->GetFrame(), m_dockpos);
 	const double ispeed = calc_ivel(relpos.Length(), 0.0, maxdecel);
 	const vector3d vdiff = ispeed * reldir - relvel;
-	m_prop->AIChangeVelDir(vdiff * m_dBody->GetOrient());
-	if (vdiff.Dot(reldir) < 0) {
-		m_dBody->SetDecelerating(true);
-	}
 
 	// get rotation of station for next frame
 	matrix3x3d trot = m_target->GetOrientRelTo(m_dBody->GetFrame());
@@ -1459,6 +1456,11 @@ bool AICmdDock::TimeStepUpdate()
 	}
 	if (af < 0.01) {
 		af = m_prop->AIFaceUpdir(trot * m_dockupdir, av) - ang;
+	}
+
+	m_prop->AIChangeVelDir(vdiff * m_dBody->GetOrient());
+	if (vdiff.Dot(reldir) < 0) {
+		m_dBody->SetDecelerating(true);
 	}
 	if (m_state < eInvalidDockingStage && af < 0.01 && ship->GetWheelState() >= 1.0f) {
 		IncrementState();
@@ -1666,9 +1668,9 @@ bool AICmdFlyAround::TimeStepUpdate()
 	double ivel = calc_ivel(alt - m_alt, 0.0, m_prop->GetAccelMin());
 
 	vector3d finalvel = tanvel + ivel * obsdir;
-	m_prop->AIMatchVel(finalvel);
 	m_prop->AIFaceDirection(fwddir);
 	m_prop->AIFaceUpdir(-obsdir);
+	m_prop->AIMatchVel(finalvel);
 
 	//	vector3d newhead = GenerateTangent(m_ship, m_obstructor->GetFrame(), fwddir);
 	//	newhead = GetPosInFrame(m_ship->GetFrame(), m_obstructor->GetFrame(), newhead);

--- a/src/Space.h
+++ b/src/Space.h
@@ -36,6 +36,7 @@ public:
 	// if called while invalid
 	Body *GetBodyByIndex(Uint32 idx) const;
 	SystemBody *GetSystemBodyByIndex(Uint32 idx) const;
+	bool IsBodyIndexValid() const { return m_bodyIndexValid; }
 	Uint32 GetIndexForBody(const Body *body) const;
 	Uint32 GetIndexForSystemBody(const SystemBody *sbody) const;
 

--- a/src/galaxy/SystemBody.cpp
+++ b/src/galaxy/SystemBody.cpp
@@ -8,6 +8,7 @@
 #include "Game.h"
 #include "JsonUtils.h"
 #include "Lang.h"
+#include "MathUtil.h"
 #include "utils.h"
 
 SystemBodyData::SystemBodyData() :
@@ -384,6 +385,26 @@ bool SystemBody::IsScoopable() const
 		m_atmosOxidizing <= fixed(55, 100))
 		return true;
 	return false;
+}
+
+Color SystemBody::CalcSurfaceDustColor() const
+{
+	// Terrain texture sampling is not available from SystemBody; approximate from generated composition.
+	Color atmos(200, 200, 200, 255);
+	double density = 0.0;
+	GetAtmosphereFlavor(&atmos, &density);
+
+	const float metal = float(GetMetallicity());
+	const float ice = float(GetVolatileIces());
+
+	float rf = (atmos.r / 255.f) * 0.45f + 0.20f + metal * 0.12f;
+	float gf = (atmos.g / 255.f) * 0.40f + 0.16f + metal * 0.05f;
+	float bf = (atmos.b / 255.f) * 0.30f + 0.10f + ice * 0.10f;
+
+	rf = Clamp(rf, 0.f, 1.f);
+	gf = Clamp(gf, 0.f, 1.f);
+	bf = Clamp(bf, 0.f, 1.f);
+	return Color(Uint8(rf * 255.f), Uint8(gf * 255.f), Uint8(bf * 255.f), 255);
 }
 
 // this is a reduced version of original Rayleigh scattering function used to compute density once per planet

--- a/src/galaxy/SystemBody.h
+++ b/src/galaxy/SystemBody.h
@@ -318,6 +318,7 @@ public:
 	AtmosphereParameters CalcAtmosphereParams() const;
 
 	bool IsScoopable() const;
+	Color CalcSurfaceDustColor() const;
 
 	void Dump(FILE *file, const char *indent = "") const;
 

--- a/src/graphics/VertexArray.cpp
+++ b/src/graphics/VertexArray.cpp
@@ -300,14 +300,6 @@ namespace Graphics {
 		uv0.emplace_back(uv);
 	}
 
-	void VertexArray::Add(const vector3f &v, const vector3f &n, const Color &c, const vector2f &uv)
-	{
-		position.emplace_back(v);
-		normal.emplace_back(n);
-		diffuse.emplace_back(c);
-		uv0.emplace_back(uv);
-	}
-
 	void VertexArray::Add(const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang)
 	{
 		position.emplace_back(v);

--- a/src/graphics/VertexArray.cpp
+++ b/src/graphics/VertexArray.cpp
@@ -300,6 +300,14 @@ namespace Graphics {
 		uv0.emplace_back(uv);
 	}
 
+	void VertexArray::Add(const vector3f &v, const vector3f &n, const Color &c, const vector2f &uv)
+	{
+		position.emplace_back(v);
+		normal.emplace_back(n);
+		diffuse.emplace_back(c);
+		uv0.emplace_back(uv);
+	}
+
 	void VertexArray::Add(const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang)
 	{
 		position.emplace_back(v);

--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -61,6 +61,7 @@ namespace Graphics {
 		void Add(const vector3f &v, const vector2f &uv);
 		void Add(const vector3f &v, const vector3f &n);
 		void Add(const vector3f &v, const vector3f &n, const vector2f &uv);
+		void Add(const vector3f &v, const vector3f &n, const Color &c, const vector2f &uv);
 		void Add(const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang);
 		//virtual void Reserve(unsigned int howmuch)
 

--- a/src/graphics/VertexArray.h
+++ b/src/graphics/VertexArray.h
@@ -61,7 +61,6 @@ namespace Graphics {
 		void Add(const vector3f &v, const vector2f &uv);
 		void Add(const vector3f &v, const vector3f &n);
 		void Add(const vector3f &v, const vector3f &n, const vector2f &uv);
-		void Add(const vector3f &v, const vector3f &n, const Color &c, const vector2f &uv);
 		void Add(const vector3f &v, const vector3f &n, const vector2f &uv, const vector3f &tang);
 		//virtual void Reserve(unsigned int howmuch)
 

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -429,17 +429,12 @@ namespace SceneGraph {
 	{
 		assert(m_root != nullptr);
 
-		FindNodeVisitor thrusterFinder(FindNodeVisitor::MATCH_NAME_FULL, "thrusters");
-		m_root->Accept(thrusterFinder);
-		const std::vector<Node *> &results = thrusterFinder.GetResults();
-		Group *thrusters = static_cast<Group *>(results.at(0));
-
-		for (unsigned int i = 0; i < thrusters->GetNumChildren(); i++) {
-			MatrixTransform *mt = static_cast<MatrixTransform *>(thrusters->GetChildAt(i));
-			Thruster *my_thruster = static_cast<Thruster *>(mt->GetChildAt(0));
-			if (my_thruster == nullptr) continue;
-			float dot = my_thruster->GetDirection().Dot(dir);
-			if (dot > 0.99) my_thruster->SetColor(color);
+		std::vector<std::pair<MatrixTransform *, Thruster *>> mounts;
+		GatherThrusterMounts(mounts);
+		for (const auto &pr : mounts) {
+			Thruster *const my_thruster = pr.second;
+			const float dot = my_thruster->GetDirection().Dot(dir);
+			if (dot > 0.99f) my_thruster->SetColor(color);
 		}
 	}
 
@@ -460,16 +455,31 @@ namespace SceneGraph {
 	{
 		assert(m_root != nullptr);
 
+		std::vector<std::pair<MatrixTransform *, Thruster *>> mounts;
+		GatherThrusterMounts(mounts);
+		for (const auto &pr : mounts)
+			pr.second->SetColor(color);
+	}
+
+	void Model::GatherThrusterMounts(std::vector<std::pair<MatrixTransform *, Thruster *>> &outMounts) const
+	{
+		outMounts.clear();
+		if (!m_root) return;
+
 		FindNodeVisitor thrusterFinder(FindNodeVisitor::MATCH_NAME_FULL, "thrusters");
 		m_root->Accept(thrusterFinder);
 		const std::vector<Node *> &results = thrusterFinder.GetResults();
-		Group *thrusters = static_cast<Group *>(results.at(0));
+		if (results.empty()) return;
 
-		for (unsigned int i = 0; i < thrusters->GetNumChildren(); i++) {
-			MatrixTransform *mt = static_cast<MatrixTransform *>(thrusters->GetChildAt(i));
-			Thruster *my_thruster = static_cast<Thruster *>(mt->GetChildAt(0));
-			assert(my_thruster != nullptr);
-			my_thruster->SetColor(color);
+		Group *thrusters = dynamic_cast<Group *>(results.at(0));
+		if (!thrusters) return;
+
+		for (unsigned int i = 0; i < thrusters->GetNumChildren(); ++i) {
+			MatrixTransform *mt = dynamic_cast<MatrixTransform *>(thrusters->GetChildAt(i));
+			if (!mt || mt->GetNumChildren() < 1u) continue;
+			Thruster *th = dynamic_cast<Thruster *>(mt->GetChildAt(0));
+			if (!th) continue;
+			outMounts.emplace_back(mt, th);
 		}
 	}
 

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -67,7 +67,9 @@
 #include "graphics/Drawables.h"
 #include "graphics/Material.h"
 #include "LoaderDefinitions.h"
+#include <utility>
 #include <stdexcept>
+#include <vector>
 
 namespace SceneGraph {
 	class Animation;
@@ -75,6 +77,7 @@ namespace SceneGraph {
 	class BinaryConverter;
 	class MatrixTransform;
 	class ModelBinarizer;
+	class Thruster;
 	class Tag;
 
 	struct LoadingError : public std::runtime_error {
@@ -177,6 +180,8 @@ namespace SceneGraph {
 		void SetThrusterColor(const vector3f &dir, const Color &color);
 		void SetThrusterColor(const std::string &name, const Color &color);
 		void SetThrusterColor(const Color &color);
+
+		void GatherThrusterMounts(std::vector<std::pair<MatrixTransform *, Thruster *>> &outMounts) const;
 
 		void SaveToJson(Json &jsonObj) const;
 		void LoadFromJson(const Json &jsonObj);

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -88,17 +88,16 @@ namespace SceneGraph {
 		nv.ApplyThruster(*this);
 	}
 
-	void Thruster::Render(const matrix4x4f &trans, const RenderData *rd)
+	float Thruster::ComputeReactionPower(const vector3f &linThrust, const vector3f &angThrust) const
 	{
-		PROFILE_SCOPED()
-		float power = -dir.Dot(vector3f(rd->linthrust));
+		float power = -dir.Dot(linThrust);
 
 		if (!linearOnly) {
 			// pitch X
 			// yaw   Y
 			// roll  Z
 			//model center is at 0,0,0, no need for invSubModelMat stuff
-			const vector3f at = vector3f(rd->angthrust);
+			const vector3f at = angThrust;
 			const vector3f angdir = pos.Cross(dir);
 
 			const float xp = angdir.x * at.x;
@@ -114,6 +113,14 @@ namespace SceneGraph {
 					power = fabs(at.z);
 			}
 		}
+
+		return power;
+	}
+
+	void Thruster::Render(const matrix4x4f &trans, const RenderData *rd)
+	{
+		PROFILE_SCOPED()
+		const float power = ComputeReactionPower(vector3f(rd->linthrust), vector3f(rd->angthrust));
 
 		// fade in/out the amount of thruster power shown
 		displayedPower = MathUtil::Lerp(displayedPower, power, 0.2f);

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -41,6 +41,8 @@ namespace SceneGraph {
 		dir(_dir),
 		pos(_pos),
 		currentColor(baseColor),
+		visualSize(1.f),
+		visualSizeScaled(1.f),
 		displayedPower(0.f)
 	{
 		//set up materials
@@ -74,6 +76,8 @@ namespace SceneGraph {
 		dir(thruster.dir),
 		pos(thruster.pos),
 		currentColor(thruster.currentColor),
+		visualSize(thruster.visualSize),
+		visualSizeScaled(thruster.visualSizeScaled),
 		displayedPower(thruster.displayedPower)
 	{
 	}
@@ -96,25 +100,11 @@ namespace SceneGraph {
 		float power = -dir.Dot(linThrust);
 
 		if (!linearOnly) {
-			// pitch X
-			// yaw   Y
-			// roll  Z
-			//model center is at 0,0,0, no need for invSubModelMat stuff
-			const vector3f at = angThrust;
+			// pitch X, yaw Y, roll Z - angdir is torque direction per unit thrust (|pos x dir| = lever arm).
 			const vector3f angdir = pos.Cross(dir);
-
-			const float xp = angdir.x * at.x;
-			const float yp = angdir.y * at.y;
-			const float zp = angdir.z * at.z;
-
-			if (xp + yp + zp > 0) {
-				if (xp > yp && xp > zp && fabs(at.x) > power)
-					power = fabs(at.x);
-				else if (yp > xp && yp > zp && fabs(at.y) > power)
-					power = fabs(at.y);
-				else if (zp > xp && zp > yp && fabs(at.z) > power)
-					power = fabs(at.z);
-			}
+			const float align = angdir.Dot(angThrust);
+			if (align > 0.f)
+				power = std::max(power, align);
 		}
 
 		return power;

--- a/src/scenegraph/Thruster.cpp
+++ b/src/scenegraph/Thruster.cpp
@@ -90,6 +90,9 @@ namespace SceneGraph {
 
 	float Thruster::ComputeReactionPower(const vector3f &linThrust, const vector3f &angThrust) const
 	{
+		// Given the total linear and angular thrust of the ship, work out how much this thruster can
+		// contribute to it.
+
 		float power = -dir.Dot(linThrust);
 
 		if (!linearOnly) {

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -32,6 +32,13 @@ namespace SceneGraph {
 		const vector3f &GetDirection() const { return dir; }
 		bool IsLinearOnly() const { return linearOnly; }
 		float ComputeReactionPower(const vector3f &linThrust, const vector3f &angThrust) const;
+		void SetVisualSizeInfo(float size, float sizeProportional)
+		{
+			visualSize = size;
+			visualSizeScaled = sizeProportional;
+		}
+		float GetVisualSize() const { return visualSize; }
+		float GetVisualSizeProportional() const { return visualSizeScaled; }
 
 	private:
 		// thruster geometry is shared between all instances of Thruster
@@ -46,6 +53,8 @@ namespace SceneGraph {
 		vector3f dir;
 		vector3f pos;
 		Color currentColor;
+		float visualSize; // The size that the thruster appears on the 3D model at full power
+		float visualSizeScaled; // visualSize scaled by the largest thruster on the 3D model (i.e. the largest thruster has visualSizeScaled = 1.0)
 		float displayedPower; // used to fade in/out to power (size) of thruster shown
 	};
 

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -29,7 +29,9 @@ namespace SceneGraph {
 		void Save(NodeDatabase &) override;
 		static Thruster *Load(NodeDatabase &);
 		void SetColor(const Color c) { currentColor = c; }
-		const vector3f &GetDirection() { return dir; }
+		const vector3f &GetDirection() const { return dir; }
+		bool IsLinearOnly() const { return linearOnly; }
+		float ComputeReactionPower(const vector3f &linThrust, const vector3f &angThrust) const;
 
 	private:
 		// thruster geometry is shared between all instances of Thruster

--- a/src/ship/PlayerShipController.cpp
+++ b/src/ship/PlayerShipController.cpp
@@ -488,6 +488,8 @@ void PlayerShipController::ApplyTotalAction(const TotalDesiredAction &params)
 	} else if (params.desiredLinear.LengthSqr() > 0) {
 		// unlock launchlock in case of activation of linear thrust
 		m_ship->m_launchLockTimeout = 0;
+	} else if (!params.desireLinVel) {
+		m_ship->ClearLinThrusterState();
 	}
 
 	m_ship->AIMatchAngVelObjSpace(params.desiredAngular, params.angPower, !params.desireAngVelFull);

--- a/src/ship/Propulsion.cpp
+++ b/src/ship/Propulsion.cpp
@@ -64,6 +64,28 @@ Propulsion::Propulsion()
 	m_angThrusters = vector3d::Zero;
 	m_smodel = nullptr;
 	m_dBody = nullptr;
+	m_aiSequentialThrusters = false;
+	m_aiPitchActive = false;
+	m_aiYawActive = false;
+	m_aiRollActive = false;
+}
+
+void Propulsion::BeginAISequentialThrusters()
+{
+	m_aiSequentialThrusters = Pi::game->GetTimeAccel() == Game::TIMEACCEL_1X;
+	m_aiPitchActive = false;
+	m_aiYawActive = false;
+	m_aiRollActive = false;
+	if (m_aiSequentialThrusters)
+		ClearLinThrusterState();
+}
+
+void Propulsion::EndAISequentialThrusters()
+{
+	m_aiSequentialThrusters = false;
+	m_aiPitchActive = false;
+	m_aiYawActive = false;
+	m_aiRollActive = false;
 }
 
 void Propulsion::Init(DynamicBody *b, SceneGraph::Model *m, const int tank_mass, const double effExVel, const float lin_Thrust[], const float ang_Thrust)
@@ -149,12 +171,16 @@ vector3d Propulsion::ClampLinThrusterState(const vector3d &levels) const
 
 void Propulsion::SetLinThrusterState(int axis, double level)
 {
+	if (AICurrentlyTurning())
+		return;
 	if (m_thrusterFuel <= 0.f) level = 0.0;
 	m_linThrusters[axis] = ClampLinThrusterState(axis, level);
 }
 
 void Propulsion::SetLinThrusterState(const vector3d &levels)
 {
+	if (AICurrentlyTurning())
+		return;
 	if (m_thrusterFuel <= 0.f) {
 		m_linThrusters = vector3d(0.0);
 	} else {
@@ -330,6 +356,9 @@ bool Propulsion::AIMatchVel(const vector3d &vel, const vector3d &powerLimit)
 // returns true if this can be done in a single timestep
 bool Propulsion::AIChangeVelBy(const vector3d &diffvel, const vector3d &powerLimit)
 {
+	if (AICurrentlyTurning())
+		return false;
+
 	// counter external forces
 	vector3d extf = m_dBody->GetExternalForce() * (Pi::game->GetTimeStep() / m_dBody->GetMass());
 	vector3d diffvel2 = diffvel - extf * m_dBody->GetOrient();
@@ -409,6 +438,15 @@ double Propulsion::AIFaceUpdir(const vector3d &updir, double av)
 	double cav = (m_dBody->GetAngVelocity() * m_dBody->GetOrient()).z; // current obj-rel angvel
 	double diff = (dav - cav) / frameAccel;							   // find diff between current & desired angvel
 
+	if (m_aiSequentialThrusters) {
+		if (m_aiPitchActive || m_aiYawActive) {
+			m_aiRollActive = false;
+			m_angThrusters.z = 0.0;
+			return ang;
+		}
+		m_aiRollActive = ang > AI_MAJOR_TURN_ANGLE;
+	}
+
 	SetAngThrusterState(2, diff);
 	return ang;
 }
@@ -450,6 +488,31 @@ double Propulsion::AIFaceDirection(const vector3d &dir, double av)
 		auto *playerController = static_cast<const Player *>(m_dBody)->GetPlayerController();
 		if (playerController->InputBindings.roll->IsActive())
 			diff.z = GetAngThrusterState().z;
+	}
+
+	if (m_aiSequentialThrusters) {
+		// We're doing pitch and yaw, so zero out the rollLevel unless the player is explicitly setting it
+		const double rollLevel = (m_dBody->IsType(ObjectType::PLAYER) ? diff.z : 0.0);
+		double pitchAng = 0.0;
+		double yawAng = 0.0;
+		if (head.z > -0.99999999) {
+			pitchAng = std::abs(atan2(head.y, -head.z));
+			yawAng = std::abs(atan2(head.x, -head.z));
+		}
+		const bool majorPitchTurn = pitchAng > AI_MAJOR_TURN_ANGLE;
+		const bool majorYawTurn = yawAng > AI_MAJOR_TURN_ANGLE;
+		m_aiPitchActive = majorPitchTurn;
+		m_aiYawActive = majorYawTurn;
+		m_aiRollActive = false;
+
+		if (majorPitchTurn)
+			SetAngThrusterState(vector3d(diff.x, 0.0, rollLevel));
+		else if (majorYawTurn)
+			SetAngThrusterState(vector3d(0.0, diff.y, rollLevel));
+		else
+			SetAngThrusterState(diff);
+
+		return ang;
 	}
 
 	SetAngThrusterState(diff);

--- a/src/ship/Propulsion.h
+++ b/src/ship/Propulsion.h
@@ -123,7 +123,18 @@ public:
 	double AIFaceDirection(const vector3d &dir, double av = 0);
 	vector3d AIGetLeadDir(const Body *target, const vector3d &targaccel, double projspeed);
 
+	void BeginAISequentialThrusters();
+	void EndAISequentialThrusters();
+
 private:
+	// Ship turn angle above which linear thrust is blocked. For angles above this the ship will finish rotating first before firing main thrusters.
+	static constexpr double AI_MAJOR_TURN_ANGLE = 8.0 * DEG2RAD(1.0);
+	bool m_aiSequentialThrusters;
+	bool m_aiPitchActive;
+	bool m_aiYawActive;
+	bool m_aiRollActive;
+	bool AICurrentlyTurning() const { return m_aiSequentialThrusters && (m_aiPitchActive || m_aiYawActive || m_aiRollActive); }
+
 	// Thrust and thrusters
 	float m_linThrust[THRUSTER_MAX];
 	float m_angThrust;

--- a/src/ship/Propulsion.h
+++ b/src/ship/Propulsion.h
@@ -47,6 +47,7 @@ public:
 	inline double GetThrustRev() const { return GetThrust(THRUSTER_REVERSE); }
 	inline double GetThrustUp() const { return GetThrust(THRUSTER_UP); }
 	double GetThrustMin() const;
+	inline float GetAngThrustCap() const { return m_angThrust; }
 
 	vector3d GetThrustUncapped(const vector3d &dir) const;
 


### PR DESCRIPTION
My previous post here may have ruffled some feathers, so here is a peace offering: Thruster exhaust plumes.

Hopefully this doesn't contradict any established lore to do with the way ship thrusters work.

The plumes are only visible within planet atmospheres, and the spread depends on the atmospheric density. But they kick up dust on the planet's surface whether there is an atmosphere or not. Matching the dust colour to the planet's actual render colour currently isn't really possible, so it kind of guesses. Also, if you're very near a landing pad which is up in the air, you can sometimes see the plumes pass through it a short distance, which isn't ideal, but that wouldn't be very easy to fix.

Let me know what you think.
