### PR TITLE
Fixing missing material transparencies

### DIFF
--- a/data/models/cockpits/default_cockpit/default_cockpit.model
+++ b/data/models/cockpits/default_cockpit/default_cockpit.model
@@ -21,6 +21,11 @@ material "default_cockpit_transp" {
 	texture diffuse "default_cockpit_diff.dds"
 	texture specular "default_cockpit_spec.dds"
 	texture glow "default_cockpit_glow.dds"
+	
+			render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "default_cockpit_screen" {

--- a/data/models/cockpits/default_cockpit/default_cockpit.model
+++ b/data/models/cockpits/default_cockpit/default_cockpit.model
@@ -5,7 +5,7 @@ material "default_cockpit" {
 	diffuse 0.9 0.9 0.9
 	specular 0.3 0.3 0.3
 	shininess 43
-	
+
 	texture diffuse "default_cockpit_diff.dds"
 	texture specular "default_cockpit_spec.dds"
 	texture glow "default_cockpit_glow.dds"
@@ -21,8 +21,8 @@ material "default_cockpit_transp" {
 	texture diffuse "default_cockpit_diff.dds"
 	texture specular "default_cockpit_spec.dds"
 	texture glow "default_cockpit_glow.dds"
-	
-			render_state {
+
+	render_state {
 		blend alpha
 		depth_write off
 	}

--- a/data/models/cockpits/opli_courier_cockpit/coronatrix_cockpit.model
+++ b/data/models/cockpits/opli_courier_cockpit/coronatrix_cockpit.model
@@ -5,7 +5,7 @@ material "Sinonatrix.Cockpit" {
 	diffuse 0.9 0.9 0.9
 	specular 0.3 0.3 0.3
 	shininess 23
-	
+
 	texture diffuse "sinonatrix_cockpit_diff.dds"
 	texture specular "sinonatrix_cockpit_spec.dds"
 	texture normal "sinonatrix_cockpit_norm.png"
@@ -18,13 +18,13 @@ material "Sinonatrix.Transp" {
 	specular 0.3 0.3 0.3
 	shininess 23
 	opacity 30
-	
+
 	texture diffuse "sinonatrix_cockpit_diff.dds"
 	texture specular "sinonatrix_cockpit_spec.dds"
 	texture normal "sinonatrix_cockpit_norm.png"
 	texture glow "sinonatrix_cockpit_glow.dds"
-	
-			render_state {
+
+	render_state {
 		blend alpha
 		depth_write off
 	}
@@ -56,4 +56,3 @@ material "Coronatrix-fuselage" {
 lod 100 {
 	mesh "coronatrix_cockpit.dae"
 }
-

--- a/data/models/cockpits/opli_courier_cockpit/coronatrix_cockpit.model
+++ b/data/models/cockpits/opli_courier_cockpit/coronatrix_cockpit.model
@@ -23,6 +23,11 @@ material "Sinonatrix.Transp" {
 	texture specular "sinonatrix_cockpit_spec.dds"
 	texture normal "sinonatrix_cockpit_norm.png"
 	texture glow "sinonatrix_cockpit_glow.dds"
+	
+			render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Sinonatrix.Screens" {

--- a/data/models/cockpits/opli_courier_cockpit/sinonatrix_cockpit.model
+++ b/data/models/cockpits/opli_courier_cockpit/sinonatrix_cockpit.model
@@ -21,6 +21,11 @@ material "Sinonatrix.Transp" {
 	texture specular "sinonatrix_cockpit_spec.dds"
 	texture normal "sinonatrix_cockpit_norm.png"
 	texture glow "sinonatrix_cockpit_glow.dds"
+	
+			render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Sinonatrix.Screens" {

--- a/data/models/cockpits/opli_courier_cockpit/sinonatrix_cockpit.model
+++ b/data/models/cockpits/opli_courier_cockpit/sinonatrix_cockpit.model
@@ -21,8 +21,8 @@ material "Sinonatrix.Transp" {
 	texture specular "sinonatrix_cockpit_spec.dds"
 	texture normal "sinonatrix_cockpit_norm.png"
 	texture glow "sinonatrix_cockpit_glow.dds"
-	
-			render_state {
+
+	render_state {
 		blend alpha
 		depth_write off
 	}
@@ -52,4 +52,3 @@ material "Hull" {
 lod 100 {
 	mesh "sinonatrix_cockpit.dae"
 }
-

--- a/data/models/cockpits/xylophis_cockpit/natrix_cockpit.model
+++ b/data/models/cockpits/xylophis_cockpit/natrix_cockpit.model
@@ -23,6 +23,11 @@ material "Xylophis_cockpit_transparent" {
 	texture specular "xylophis_cockpit_spec.dds"
 	texture normal "xylophis_cockpit_norm.png"
 	texture glow "xylophis_cockpit_glow.dds"
+	
+			render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Xylophis_cockpit_screen" {

--- a/data/models/cockpits/xylophis_cockpit/natrix_cockpit.model
+++ b/data/models/cockpits/xylophis_cockpit/natrix_cockpit.model
@@ -5,7 +5,7 @@ material "Xylophis_cockpit" {
 	diffuse 1.0 1.0 1.0
 	specular 0.7 0.7 0.7
 	shininess 69
-	
+
 	texture diffuse "xylophis_cockpit_diff.dds"
 	texture specular "xylophis_cockpit_spec.dds"
 	texture normal "xylophis_cockpit_norm.png"
@@ -23,8 +23,8 @@ material "Xylophis_cockpit_transparent" {
 	texture specular "xylophis_cockpit_spec.dds"
 	texture normal "xylophis_cockpit_norm.png"
 	texture glow "xylophis_cockpit_glow.dds"
-	
-			render_state {
+
+	render_state {
 		blend alpha
 		depth_write off
 	}

--- a/data/models/cockpits/xylophis_cockpit/xylophis_cockpit.model
+++ b/data/models/cockpits/xylophis_cockpit/xylophis_cockpit.model
@@ -5,7 +5,7 @@ material "Xylophis_cockpit" {
 	diffuse 1.0 1.0 1.0
 	specular 0.7 0.7 0.7
 	shininess 69
-	
+
 	texture diffuse "xylophis_cockpit_diff.dds"
 	texture specular "xylophis_cockpit_spec.dds"
 	texture normal "xylophis_cockpit_norm.png"
@@ -18,13 +18,13 @@ material "Xylophis_cockpit_transparent" {
 	specular 0.7 0.7 0.7
 	shininess 69
 	opacity 30
-	
+
 	texture diffuse "xylophis_cockpit_diff.dds"
 	texture specular "xylophis_cockpit_spec.dds"
 	texture normal "xylophis_cockpit_norm.png"
 	texture glow "xylophis_cockpit_glow.dds"
-	
-			render_state {
+
+	render_state {
 		blend alpha
 		depth_write off
 	}
@@ -35,7 +35,7 @@ material "Xylophis_cockpit_screen" {
 	diffuse 1.0 1.0 1.0
 	specular 0.7 0.7 0.7
 	shininess 69
-	
+
 	texture diffuse "xylophis_cockpit_screen_diff.dds"
 	texture specular "xylophis_cockpit_screen_spec.dds"
 	texture glow "xylophis_cockpit_screen_glow.dds"

--- a/data/models/cockpits/xylophis_cockpit/xylophis_cockpit.model
+++ b/data/models/cockpits/xylophis_cockpit/xylophis_cockpit.model
@@ -23,6 +23,11 @@ material "Xylophis_cockpit_transparent" {
 	texture specular "xylophis_cockpit_spec.dds"
 	texture normal "xylophis_cockpit_norm.png"
 	texture glow "xylophis_cockpit_glow.dds"
+	
+			render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Xylophis_cockpit_screen" {

--- a/data/models/ships/bowfin/bowfin.model
+++ b/data/models/ships/bowfin/bowfin.model
@@ -15,12 +15,17 @@ material "Canopy" {
 	diffuse 1.0 1.0 1.0
 	specular 0.9 0.9 0.9
 	shininess 69
-	opacity 46
+	opacity 90
 	#use_patterns
 	texture diffuse  "bowfin_diff.dds"
 	texture glow     "bowfin_glow.dds"
 	texture specular "bowfin_spec.dds"
 	#texture normal   "bowfin_norm.dds"
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 lod 300 {

--- a/data/models/ships/coronatrix/coronatrix_police.model
+++ b/data/models/ships/coronatrix/coronatrix_police.model
@@ -23,6 +23,11 @@ material "Coronatrix-canopy" {
 	texture specular "coronatrix_spec.dds"
 	texture normal "coronatrix_norm.png"
 	texture glow "coronatrix_glow.dds"
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Coronatrix-parts" {

--- a/data/models/ships/natrix/natrix.model
+++ b/data/models/ships/natrix/natrix.model
@@ -17,11 +17,16 @@ material "Natrix-headlight" {
 	diffuse 1.0 1.0 1.0
 	specular 0.7 0.7 0.7
 	shininess 60
-	opacity 60
+	opacity 90
 	texture diffuse  "natrix_diff.dds"
 	texture specular "natrix_spec.dds"
 	texture normal   "natrix_norm.png"
 	texture glow     "natrix_glow.dds"
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Natrix-canopy" {
@@ -29,11 +34,16 @@ material "Natrix-canopy" {
 	diffuse 1.0 1.0 1.0
 	specular 0.7 0.7 0.7
 	shininess 60
-	opacity 60
+	opacity 90
 	texture diffuse  "natrix_diff.dds"
 	texture specular "natrix_spec.dds"
 	texture normal   "natrix_norm.png"
 	texture glow     "natrix_glow.dds"
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 lod 300 {

--- a/data/models/ships/sinonatrix/sinonatrix.model
+++ b/data/models/ships/sinonatrix/sinonatrix.model
@@ -17,11 +17,16 @@ material "Canopy" {
 	diffuse 1.0 1.0 1.0
 	specular 0.8 0.8 0.8
 	shininess 120
-	opacity 30
+	opacity 90
 	texture diffuse  "fuselage_diff.dds"
 	texture specular "fuselage_spec.dds"
 	texture normal   "fuselage_norm.png"
 	texture glow     "fuselage_glow.dds"
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Engine" {

--- a/data/models/ships/sinonatrix/sinonatrix_cockpit.model
+++ b/data/models/ships/sinonatrix/sinonatrix_cockpit.model
@@ -21,6 +21,11 @@ material "Sinonatrix.Transp" {
 	texture specular "sinonatrix_cockpit_spec.dds"
 	texture normal "sinonatrix_cockpit_norm.png"
 	texture glow "sinonatrix_cockpit_glow.dds"
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Sinonatrix.Screens" {

--- a/data/models/ships/sinonatrix/sinonatrix_police.model
+++ b/data/models/ships/sinonatrix/sinonatrix_police.model
@@ -16,11 +16,16 @@ material "Canopy" {
 	diffuse 1.0 1.0 1.0
 	specular 0.8 0.8 0.8
 	shininess 120
-	opacity 30
+	opacity 90
 	texture diffuse  "fuselage_diff.dds"
 	texture specular "fuselage_spec.dds"
 	texture normal   "fuselage_norm.png"
 	texture glow     "fuselage_glow.dds"
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "Engine" {

--- a/data/models/ships/xylophis/xylophis.model
+++ b/data/models/ships/xylophis/xylophis.model
@@ -22,6 +22,11 @@ material "Transparent" {
 	texture specular "xylophis_spec.dds"
 	texture normal   "xylophis_norm.png"
 	texture glow     "xylophis_glow.dds"
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "int" {

--- a/data/models/stations/new_ground/new_ground.model
+++ b/data/models/stations/new_ground/new_ground.model
@@ -38,6 +38,11 @@ material "Glass" {
 	texture specular "building_spec.dds"
 	texture glow     "building_glow.dds"
 	texture normal   "building_norm.dds"
+	
+			render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 lod 500 {

--- a/data/models/stations/new_ground/new_ground.model
+++ b/data/models/stations/new_ground/new_ground.model
@@ -38,8 +38,8 @@ material "Glass" {
 	texture specular "building_spec.dds"
 	texture glow     "building_glow.dds"
 	texture normal   "building_norm.dds"
-	
-			render_state {
+
+	render_state {
 		blend alpha
 		depth_write off
 	}

--- a/data/models/stations/orbital_station/orbital_station_2-10k.model
+++ b/data/models/stations/orbital_station/orbital_station_2-10k.model
@@ -29,7 +29,12 @@ material "facade_window" {
 	texture diffuse  "facades_diff.dds"
 	texture glow     "facades_diff.dds"
 	specular 0.6 0.6 0.6
-	opacity 13
+	opacity 40
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "ring" {
@@ -43,7 +48,12 @@ material "ring_glass" {
 	shader "multi"
 	texture diffuse  "ring_diff.dds"
 	specular 0.7 0.7 0.7
-	opacity 20
+	opacity 40
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "strut" {

--- a/data/models/stations/orbital_station/orbital_station_2-2k.model
+++ b/data/models/stations/orbital_station/orbital_station_2-2k.model
@@ -29,7 +29,12 @@ material "facade_window" {
 	texture diffuse  "facades_diff.dds"
 	texture glow     "facades_diff.dds"
 	specular 0.6 0.6 0.6
-	opacity 13
+	opacity 40
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "ring" {
@@ -43,7 +48,12 @@ material "ring_glass" {
 	shader "multi"
 	texture diffuse  "ring_diff.dds"
 	specular 0.7 0.7 0.7
-	opacity 20
+	opacity 40
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "strut" {

--- a/data/models/stations/orbital_station/orbital_station_2-5k.model
+++ b/data/models/stations/orbital_station/orbital_station_2-5k.model
@@ -29,7 +29,12 @@ material "facade_window" {
 	texture diffuse  "facades_diff.dds"
 	texture glow     "facades_diff.dds"
 	specular 0.6 0.6 0.6
-	opacity 13
+	opacity 40
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "ring" {
@@ -43,7 +48,12 @@ material "ring_glass" {
 	shader "multi"
 	texture diffuse  "ring_diff.dds"
 	specular 0.7 0.7 0.7
-	opacity 20
+	opacity 40
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "strut" {

--- a/data/models/stations/orbital_station/orbital_station_2-5k10k.model
+++ b/data/models/stations/orbital_station/orbital_station_2-5k10k.model
@@ -29,7 +29,12 @@ material "facade_window" {
 	texture diffuse  "facades_diff.dds"
 	texture glow     "facades_diff.dds"
 	specular 0.6 0.6 0.6
-	opacity 13
+	opacity 40
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "ring" {
@@ -43,7 +48,12 @@ material "ring_glass" {
 	shader "multi"
 	texture diffuse  "ring_diff.dds"
 	specular 0.7 0.7 0.7
-	opacity 20
+	opacity 40
+	
+		render_state {
+		blend alpha
+		depth_write off
+	}
 }
 
 material "strut" {


### PR DESCRIPTION
It took a while for me to notice, but when the new .model format was introduced, only the Coronatrix cockpit's transparency was set up. Every other transparent window and canopy or whatever is opaque. 
The materials were missing this part:
`render_state {
		blend alpha
		depth_write off
	}`

This PR fixes that both for the ships, cockpits, windows on orbitals, and on new ground station.
I've also adjusted the opacity levels here and there for better looks. Some canopies were too transparent.

Problem:
<img width="2496" height="1416" alt="image" src="https://github.com/user-attachments/assets/9fc5d895-f3ca-423e-9022-9cdda1ea5a1c" />
<img width="2496" height="1416" alt="screenshot-20260512-184243" src="https://github.com/user-attachments/assets/63802ae2-afcd-4d61-badf-22fac2fcf068" />

Fixed:
<img width="2494" height="1440" alt="image" src="https://github.com/user-attachments/assets/e327d710-d43e-4fef-ace2-b746963705de" />
<img width="2494" height="1440" alt="image" src="https://github.com/user-attachments/assets/587b8fe6-4b79-4ecb-9012-158a291808a1" />


