### PR TITLE
Advice fixup

### DIFF
--- a/data/lang/module-advice/en.json
+++ b/data/lang/module-advice/en.json
@@ -21,7 +21,7 @@
   },
   "ADVICE_12_HEADLINE": {
     "description": "",
-    "message": "Bounce in"
+    "message": "Bounce out and back in"
   },
   "ADVICE_13_BODYTEXT": {
     "description": "",

--- a/data/lang/module-advice/en.json
+++ b/data/lang/module-advice/en.json
@@ -21,7 +21,7 @@
   },
   "ADVICE_12_HEADLINE": {
     "description": "",
-    "message": "The Billie Bounce detour"
+    "message": "Bounce in"
   },
   "ADVICE_13_BODYTEXT": {
     "description": "",

--- a/data/modules/Advice/Advice.lua
+++ b/data/modules/Advice/Advice.lua
@@ -33,7 +33,7 @@ local travellers_advice_indices = {481, -- tame black market
 								   52,  -- service ship
 								   248, -- change faction
 								   171, -- the harder the g
-								   203, -- the billie bounce
+								   203, -- bounce in
 								   194, -- running on fumes
 								   49,	-- a clear way out
 }


### PR DESCRIPTION
Rename 'Billie bounce' to 'bounce in'. With no lore to back it up it becomes a bit too enigmatic and hard to translate.

Following a brief [discussion here](https://github.com/pioneerspacesim/pioneer/pull/6234#issuecomment-4537220919), I suggest changing the title of one of the advices added in #6234. 