### PR TITLE
Avast! Be ye knowin' of the Smuggler's Hold?

### DIFF
--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -63,6 +63,10 @@
     "description": "Category header for pressurized cabin slots",
     "message": "Cabins"
   },
+  "HABITAT": {
+    "description": "Category header for pressurized habitat slots",
+    "message": "Habitat"
+  },
   "CARGO_LIFE_SUPPORT": {
     "description": "",
     "message": "Cargo Bay Life Support"

--- a/data/lang/equipment-core/en.json
+++ b/data/lang/equipment-core/en.json
@@ -938,5 +938,37 @@
   "WEAPONS": {
     "description": "Category name of weapon-related equipment",
     "message": "Weapons"
+  },
+  "AUXILIARY_CARGO_RACK": {
+    "description": "Equipment name for a cargo-carrying rack installed as a cabin module",
+    "message": "Auxiliary Cargo Rack"
+  },
+  "AUXILIARY_CARGO_RACK_DESCRIPTION": {
+    "description": "Equipment description for a cargo-carrying rack installed as a cabin module",
+    "message": "Additional cargo space mounted inside the ship's pressurized habitat."
+  },
+  "AUXILIARY_CARGO_RACK_FLAVOURTEXT": {
+    "description": "Equipment description for a cargo-carrying rack installed as a cabin module",
+    "message": "Put your unneeded habitat space to work for you! This conversion kit fits a wide variety of ship hulls. Manufactured by Seversk a.k."
+  },
+  "CONCEALED_CARGO_RACK": {
+    "description": "Equipment name for a cargo-carrying smuggler's hold installed as a cabin module",
+    "message": "Concealed Cargo Rack"
+  },
+  "CONCEALED_CARGO_RACK_DESCRIPTION": {
+    "description": "Equipment description for a cargo-carrying smuggler's hold installed as a cabin module",
+    "message": "Shielded cargo space disguised as an innocuous habitat wall. Hides the contents from police scans."
+  },
+  "CONCEALED_CARGO_RACK_FLAVOURTEXT": {
+    "description": "Equipment description for a cargo-carrying smuggler's hold installed as a cabin module",
+    "message": "This cargo rack from Seversk a.k. has been crudely concealed by welding interior hull panels to it. A handwritten sticker bears the text \"Guaranteed to pass cursory inspection, or your money back.\""
+  },
+  "CARGO_CAPACITY": {
+    "description": "Statistic name for an equipment that provides cargo capacity",
+    "message": "Additional Cargo Capacity"
+  },
+  "SHIELDED_CARGO_CAPACITY": {
+    "description": "Statistic name for an equipment that provides cargo scan resistance",
+    "message": "Shielded Cargo Capacity"
   }
 }

--- a/data/libs/CargoManager.lua
+++ b/data/libs/CargoManager.lua
@@ -192,6 +192,18 @@ function CargoManager:CountCommodity(type)
 	return self.commodities[type.name].count
 end
 
+-- Method: Commodities
+--
+-- Return an iterator over { name, count } pairs of commodity cargo in this ship.
+function CargoManager:Commodities()
+	---@type fun(s: table, k: string): string, integer
+	return function(s, k)
+		k = next(s, k)
+		if not k then return end
+		return k, s[k].count
+	end, self.commodities, nil
+end
+
 -- Method: DoLifeSupportChecks
 --
 -- Check for commodities on this vessel which would perish under the given

--- a/data/libs/CargoManager.lua
+++ b/data/libs/CargoManager.lua
@@ -28,11 +28,11 @@ function CargoManager:Constructor(ship)
 
 	-- Initialize property variables on owning ship for backwards compatibility
 	-- don't initialize them if they're already created after first save
-	if not self.ship:hasprop("totalCargo") then
-		ship:setprop("totalCargo", self:GetTotalSpace())
+	if not ship:hasprop("cargo_cap") then
+		ship:setprop("cargo_cap", ShipDef[ship.shipId].cargo)
 	end
 
-	if not self.ship:hasprop("usedCargo") then
+	if not ship:hasprop("usedCargo") then
 		ship:setprop("usedCargo", 0)
 	end
 
@@ -53,7 +53,7 @@ end
 -- Reinitialize ship properties after changing the type of the ship
 -- Note: cargo mass is not removed from ship.mass_cap when changing ship types
 function CargoManager:OnShipTypeChanged()
-	self.ship:setprop("totalCargo", self:GetTotalSpace())
+	self.ship:setprop("cargo_cap", ShipDef[self.ship.shipId].cargo)
 	self.ship:setprop("usedCargo", self.usedCargoSpace)
 
 	self.ship:UpdateEquipStats()
@@ -77,7 +77,7 @@ end
 --
 -- Returns the maximum amount of cargo that could be stored on the vessel.
 function CargoManager:GetTotalSpace()
-	return ShipDef[self.ship.shipId].cargo
+	return self.ship["cargo_cap"]
 end
 
 -- Method: AddCommodity

--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -41,6 +41,8 @@ local misc = {}
 ---@field price number
 ---@field icon_name string?
 ---@field tech_level integer | "MILITARY"
+---@field lawlessness number? -- minimum lawlessness required for a station to stock this item
+---@field min_security number? -- minimum security (1-lawlessness) required for a station to stock this item
 ---@field transient table
 ---@field slots table -- deprecated
 ---@field count integer?

--- a/data/libs/EquipType.lua
+++ b/data/libs/EquipType.lua
@@ -164,7 +164,11 @@ end
 -- and sale from the craft. This should almost always be true, unless the item
 -- has been installed by some scripted event or otherwise cannot be sold (e.g.
 -- a passenger cabin with a passenger in it.)
-function EquipType:CanBeSold()
+--
+-- Parameters:
+--
+--  ship - Ship, the ship this equipment item is attached to.
+function EquipType:CanBeSold(ship)
 	return not self.inhibit_removal
 end
 

--- a/data/libs/Ship.lua
+++ b/data/libs/Ship.lua
@@ -42,6 +42,8 @@ end
 function Ship:OnShipTypeChanged()
 	-- immediately update any needed components or properties
 	self:GetComponent('EquipSet'):OnShipTypeChanged()
+	-- Reinitialize cargo-related ship properties when changing ship type
+	self:GetComponent('CargoManager'):OnShipTypeChanged()
 
 	self:UpdateWeaponSlots()
 end
@@ -666,17 +668,10 @@ local onShipDestroyed = function (ship, attacker)
 	end
 end
 
--- Reinitialize cargo-related ship properties when changing ship type
----@param ship Ship
-local onShipTypeChanged = function (ship)
-	ship:GetComponent('CargoManager'):OnShipTypeChanged()
-end
-
 Event.Register("onShipEnterSystem", onShipEnterSystem)
 Event.Register("onShipDestroyed", onShipDestroyed)
 Event.Register("onGameStart", onGameStart)
 Event.Register("onGameEnd", onGameEnd)
-Event.Register("onShipTypeChanged", onShipTypeChanged)
 Serializer:Register("ShipClass", serialize, unserialize)
 
 return Ship

--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -80,7 +80,20 @@ local function createEquipmentStock (station)
 		-- Stations stock everything at least three tech levels below them,
 		-- with an increasing chance of being out-of-stock as the item's tech
 		-- approaches that of the station
-		stock[id] = math.max(0, Engine.rand:Integer(-30, 100) + techLevelDiff(e.tech_level, station.techLevel) * 10)
+		local tlDelta = techLevelDiff(e.tech_level, station.techLevel)
+
+		if tlDelta >= 0 then
+			stock[id] = math.max(0, Engine.rand:Integer(-30, 100) + tlDelta * 10)
+
+			if e.lawlessness and Game.system.lawlessness < e.lawlessness then
+				stock[id] = nil -- not even advertised here
+			end
+
+			if e.min_security and Game.system.lawlessness >= (1 - e.min_security) then
+				stock[id] = nil -- not even advertised here
+			end
+		end
+
 	end
 
 	equipmentStock[station] = stock
@@ -155,11 +168,11 @@ end
 --
 -- Returns:
 --
---   stock - the amount available for trade
+--   stock? - the amount available for trade, or nil if the item is not possible to be stocked
 --
 function SpaceStation:GetEquipmentStock (e)
 	assert(self:exists())
-	return equipmentStock[self] and equipmentStock[self][e.id] or 0
+	return equipmentStock[self] and equipmentStock[self][e.id]
 end
 
 --

--- a/data/meta/CoreObject/Ship.meta.lua
+++ b/data/meta/CoreObject/Ship.meta.lua
@@ -34,7 +34,7 @@
 ---@field totalVolume number
 ---
 ---@field usedCargo number
----@field totalCargo number
+---@field cargo_cap number
 ---
 ---@field loadedMass number Mass of the equipment and cargo onboard the ship
 ---@field staticMass number Hull mass + loaded mass

--- a/data/modules/Equipment/Internal.lua
+++ b/data/modules/Equipment/Internal.lua
@@ -10,6 +10,7 @@ local CabinType = EquipTypes.CabinType
 local ShieldType = EquipTypes.ShieldType
 local ThrusterType = EquipTypes.ThrusterType
 local CargoScoopType = EquipTypes.CargoScoopType
+local CargoHoldType = EquipTypes.CargoHoldType
 
 --===============================================
 -- Computer Modules
@@ -500,6 +501,70 @@ Equipment.Register("misc.cabin_s5", CabinType.New {
 	price=35150, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=5 },
 	mass=36, volume=0, capabilities={ cabin=60 },
+	icon_name="equip_cabin_empty"
+})
+
+--===============================================
+-- Cargo Holds
+--===============================================
+
+Equipment.Register("misc.cabin_hold_s1", CargoHoldType.New {
+	l10n_key="AUXILIARY_CARGO_RACK",
+	price=750, purchasable=true, tech_level=1,
+	slot = { type="cabin.passenger.basic", size=1 },
+	mass=1, volume=0, capabilities={ cargo=8 },
+	icon_name="equip_cabin_empty"
+})
+
+Equipment.Register("misc.cabin_hold_s2", CargoHoldType.New {
+	l10n_key="AUXILIARY_CARGO_RACK",
+	price=1970, purchasable=true, tech_level=1,
+	slot = { type="cabin.passenger.basic", size=2 },
+	mass=4, volume=0, capabilities={ cargo=20 },
+	icon_name="equip_cabin_empty"
+})
+
+Equipment.Register("misc.cabin_hold_s3", CargoHoldType.New {
+	l10n_key="AUXILIARY_CARGO_RACK",
+	price=3640, purchasable=true, tech_level=1,
+	slot = { type="cabin.passenger.basic", size=3 },
+	mass=8, volume=0, capabilities={ cargo=48 },
+	icon_name="equip_cabin_empty"
+})
+
+Equipment.Register("misc.cabin_hold_s4", CargoHoldType.New {
+	l10n_key="AUXILIARY_CARGO_RACK",
+	price=7530, purchasable=true, tech_level=1,
+	slot = { type="cabin.passenger.basic", size=4 },
+	mass=16, volume=0, capabilities={ cargo=120 },
+	icon_name="equip_cabin_empty"
+})
+
+Equipment.Register("misc.cabin_hold_s5", CargoHoldType.New {
+	l10n_key="AUXILIARY_CARGO_RACK",
+	price=19530, purchasable=true, tech_level=1,
+	slot = { type="cabin.passenger.basic", size=5 },
+	mass=36, volume=0, capabilities={ cargo=272 },
+	icon_name="equip_cabin_empty"
+})
+
+--===============================================
+-- Smuggler's Holds
+--===============================================
+
+Equipment.Register("misc.cabin_smuggler_hold_s1", CargoHoldType.New {
+	l10n_key="CONCEALED_CARGO_RACK",
+	price=1620, purchasable=true, tech_level=4,
+	slot = { type="cabin.passenger.basic", size=1 },
+	mass=1, volume=0, capabilities={ cargo=6, cargo_shield=6 },
+	icon_name="equip_cabin_empty"
+})
+
+Equipment.Register("misc.cabin_smuggler_hold_s2", CargoHoldType.New {
+	l10n_key="CONCEALED_CARGO_RACK",
+	price=4260, purchasable=true, tech_level=4,
+	slot = { type="cabin.passenger.basic", size=2 },
+	mass=4, volume=0, capabilities={ cargo=16, cargo_shield=16 },
 	icon_name="equip_cabin_empty"
 })
 

--- a/data/modules/Equipment/Internal.lua
+++ b/data/modules/Equipment/Internal.lua
@@ -554,7 +554,7 @@ Equipment.Register("misc.cabin_hold_s5", CargoHoldType.New {
 
 Equipment.Register("misc.cabin_smuggler_hold_s1", CargoHoldType.New {
 	l10n_key="CONCEALED_CARGO_RACK",
-	price=1620, purchasable=true, tech_level=4,
+	price=1620, purchasable=true, tech_level=4, lawlessness=0.5,
 	slot = { type="cabin.passenger.basic", size=1 },
 	mass=1, volume=0, capabilities={ cargo=6, cargo_shield=6 },
 	icon_name="equip_cabin_empty"
@@ -562,7 +562,7 @@ Equipment.Register("misc.cabin_smuggler_hold_s1", CargoHoldType.New {
 
 Equipment.Register("misc.cabin_smuggler_hold_s2", CargoHoldType.New {
 	l10n_key="CONCEALED_CARGO_RACK",
-	price=4260, purchasable=true, tech_level=4,
+	price=4260, purchasable=true, tech_level=4, lawlessness=0.5,
 	slot = { type="cabin.passenger.basic", size=2 },
 	mass=4, volume=0, capabilities={ cargo=16, cargo_shield=16 },
 	icon_name="equip_cabin_empty"

--- a/data/modules/Equipment/Internal.lua
+++ b/data/modules/Equipment/Internal.lua
@@ -512,7 +512,7 @@ Equipment.Register("misc.cabin_hold_s1", CargoHoldType.New {
 	l10n_key="AUXILIARY_CARGO_RACK",
 	price=750, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=1 },
-	mass=1, volume=0, capabilities={ cargo=8 },
+	mass=0.5, volume=0, capabilities={ cargo=8 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -520,7 +520,7 @@ Equipment.Register("misc.cabin_hold_s2", CargoHoldType.New {
 	l10n_key="AUXILIARY_CARGO_RACK",
 	price=1970, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=2 },
-	mass=4, volume=0, capabilities={ cargo=20 },
+	mass=1.5, volume=0, capabilities={ cargo=24 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -528,7 +528,7 @@ Equipment.Register("misc.cabin_hold_s3", CargoHoldType.New {
 	l10n_key="AUXILIARY_CARGO_RACK",
 	price=3640, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=3 },
-	mass=8, volume=0, capabilities={ cargo=48 },
+	mass=4, volume=0, capabilities={ cargo=72 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -536,7 +536,7 @@ Equipment.Register("misc.cabin_hold_s4", CargoHoldType.New {
 	l10n_key="AUXILIARY_CARGO_RACK",
 	price=7530, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=4 },
-	mass=16, volume=0, capabilities={ cargo=120 },
+	mass=10, volume=0, capabilities={ cargo=210 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -544,7 +544,7 @@ Equipment.Register("misc.cabin_hold_s5", CargoHoldType.New {
 	l10n_key="AUXILIARY_CARGO_RACK",
 	price=19530, purchasable=true, tech_level=1,
 	slot = { type="cabin.passenger.basic", size=5 },
-	mass=36, volume=0, capabilities={ cargo=272 },
+	mass=25, volume=0, capabilities={ cargo=640 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -556,7 +556,7 @@ Equipment.Register("misc.cabin_smuggler_hold_s1", CargoHoldType.New {
 	l10n_key="CONCEALED_CARGO_RACK",
 	price=1620, purchasable=true, tech_level=4, lawlessness=0.5,
 	slot = { type="cabin.passenger.basic", size=1 },
-	mass=1, volume=0, capabilities={ cargo=6, cargo_shield=6 },
+	mass=0.8, volume=0, capabilities={ cargo=6, cargo_shield=6 },
 	icon_name="equip_cabin_empty"
 })
 
@@ -564,7 +564,15 @@ Equipment.Register("misc.cabin_smuggler_hold_s2", CargoHoldType.New {
 	l10n_key="CONCEALED_CARGO_RACK",
 	price=4260, purchasable=true, tech_level=4, lawlessness=0.5,
 	slot = { type="cabin.passenger.basic", size=2 },
-	mass=4, volume=0, capabilities={ cargo=16, cargo_shield=16 },
+	mass=2, volume=0, capabilities={ cargo=20, cargo_shield=20 },
+	icon_name="equip_cabin_empty"
+})
+
+Equipment.Register("misc.cabin_smuggler_hold_s3", CargoHoldType.New {
+	l10n_key="CONCEALED_CARGO_RACK",
+	price=7880, purchasable=true, tech_level=4, lawlessness=0.5,
+	slot = { type="cabin.passenger.basic", size=3 },
+	mass=6, volume=0, capabilities={ cargo=60, cargo_shield=60 },
 	icon_name="equip_cabin_empty"
 })
 

--- a/data/modules/Equipment/Stats.lua
+++ b/data/modules/Equipment/Stats.lua
@@ -194,6 +194,44 @@ function CabinType:GetItemCardStats()
 	}
 end
 
+
+--==============================================================================
+
+---@class Equipment.CargoHoldType
+local CargoHoldType = EquipTypes.CargoHoldType
+
+function CargoHoldType:GetDetailedStats()
+	local out = self:Super().GetDetailedStats(self)
+
+	if self.capabilities.cargo_shield then
+		table.insert(out, {
+			le.SHIELDED_CARGO_CAPACITY,
+			icons.cargo_crate,
+			self.capabilities.cargo_shield,
+			tostring
+		})
+	elseif self.capabilities.cargo then
+		table.insert(out, {
+			le.CARGO_CAPACITY,
+			icons.cargo_crate,
+			self.capabilities.cargo,
+			tostring
+		})
+	end
+
+	return out
+end
+
+---@return table[]
+function CargoHoldType:GetItemCardStats()
+	return {
+		{ icons.cargo_crate, "{}" % { self.capabilities.cargo } },
+		{ icons.hull, format_mass(self.mass) },
+		{ icons.ecm, format_power(0) },
+		{ icons.repairs, format_integrity(1) }
+	}
+end
+
 --==============================================================================
 
 ---@class Equipment.ThrusterType

--- a/data/modules/Equipment/Stats.lua
+++ b/data/modules/Equipment/Stats.lua
@@ -203,18 +203,18 @@ local CargoHoldType = EquipTypes.CargoHoldType
 function CargoHoldType:GetDetailedStats()
 	local out = self:Super().GetDetailedStats(self)
 
+	table.insert(out, {
+		le.CARGO_CAPACITY,
+		icons.cargo_crate,
+		self.capabilities.cargo,
+		tostring
+	})
+
 	if self.capabilities.cargo_shield then
 		table.insert(out, {
 			le.SHIELDED_CARGO_CAPACITY,
 			icons.cargo_crate,
 			self.capabilities.cargo_shield,
-			tostring
-		})
-	elseif self.capabilities.cargo then
-		table.insert(out, {
-			le.CARGO_CAPACITY,
-			icons.cargo_crate,
-			self.capabilities.cargo,
 			tostring
 		})
 	end

--- a/data/modules/Equipment/Types.lua
+++ b/data/modules/Equipment/Types.lua
@@ -344,8 +344,18 @@ function CabinType:OnRemove(ship, slot)
 	end
 end
 
-function CabinType:CanBeSold()
+function CabinType:CanBeSold(ship)
 	return (not self.passengers or #self.passengers == 0) and EquipType.CanBeSold(self)
+end
+
+--==============================================================================
+
+---@class Equipment.CargoHoldType : EquipType
+local CargoHoldType = EquipType:NewType("Equipment.CargoHoldType")
+
+---@param ship Ship
+function CargoHoldType:CanBeSold(ship)
+	return (ship.cargo_cap - ship.usedCargo) >= self.capabilities.cargo
 end
 
 --==============================================================================
@@ -404,6 +414,7 @@ end
 return {
 	EquipType		= EquipType,
 	CargoScoopType	= CargoScoopType,
+	CargoHoldType	= CargoHoldType,
 	LaserType		= LaserType,
 	HyperdriveType	= HyperdriveType,
 	SensorType		= SensorType,

--- a/data/modules/PolicePatrol/PolicePatrol.lua
+++ b/data/modules/PolicePatrol/PolicePatrol.lua
@@ -47,7 +47,6 @@ local hasIllegalGoods = function (cargo)
 	return illegal
 end
 
-
 local patrol = {}
 local showMercy = true
 local piracy = false
@@ -125,11 +124,36 @@ local onJettison = function (ship, cargo)
 	end
 end
 
+---@param player Player
 local onEnterSystem = function (player)
 	if not hasIllegalGoods(Commodities) then return end
 
 	local system = assert(Game.system)
-	if (1 - system.lawlessness) < Engine.rand:Number(4) then return end
+
+	local cargoMgr = player:GetComponent('CargoManager')
+
+	local illegalCount = 0
+	local illegalValue = 0
+
+	local totalCargo = player.usedCargo
+
+	for name, count in cargoMgr:Commodities() do
+		if not Game.system:IsCommodityLegal(name) then
+			illegalCount = illegalCount + count
+			illegalValue = illegalValue + Commodities[name].price * count
+		end
+	end
+
+	local scanChance = Engine.rand:Number(4)
+
+	if illegalCount > 0 then
+		-- 25% chance of a scan in 1.0-sec worlds... let's bump that number up a bit
+		-- Narratively, it's more interesting to be scanned when carrying illegal goods
+		-- than when not...
+		scanChance = scanChance * 0.75
+	end
+
+	if (1 - system.lawlessness) < scanChance then return end
 
 	local crimes, fine = PlayerState.GetCrimeOutstanding()
 	local ship
@@ -163,33 +187,59 @@ local onEnterSystem = function (player)
 					Comms.ImportantMessage(string.interp(l["OUTLAW_DETECTED_" .. Engine.rand:Integer(1, getNumberOfFlavours("OUTLAW_DETECTED"))], { ship_label = player.label }), ship.label)
 					showMercy = false
 					attackShip(player)
-				else
-					Comms.ImportantMessage(l["INITIATE_CARGO_SCAN_" .. Engine.rand:Integer(1, getNumberOfFlavours("INITIATE_CARGO_SCAN"))], ship.label)
-					Timer:CallAt(Game.time + Engine.rand:Integer(3, 9), function ()
-						if not Game.system or Game.system.path ~= system.path then return end -- Shut up when the player is already in hyperspace
 
-						local manifest = player:GetComponent('CargoManager').commodities
-						if hasIllegalGoods(manifest) then
-							Comms.ImportantMessage(l.ILLEGAL_GOODS_DETECTED, ship.label)
+					return
+				end
+
+				Comms.ImportantMessage(l["INITIATE_CARGO_SCAN_" .. Engine.rand:Integer(1, getNumberOfFlavours("INITIATE_CARGO_SCAN"))], ship.label)
+
+				Timer:CallAt(Game.time + Engine.rand:Integer(3, 9), function ()
+
+					if not Game.system or Game.system.path ~= system.path then return end -- Shut up when the player is already in hyperspace
+
+					if player:hasprop("cargo_shield_cap") then
+						local hiddenGoods = math.min(illegalCount, player["cargo_shield_cap"])
+						illegalCount = illegalCount - hiddenGoods
+						totalCargo = totalCargo - hiddenGoods
+					end
+
+					local proportion = illegalCount / math.max(totalCargo, 1)
+					local detection_chance = math.min(0.45 + proportion, 1.0)
+
+					if illegalCount > 0 and Engine.rand:Number() < detection_chance then
+						Comms.ImportantMessage(l.ILLEGAL_GOODS_DETECTED, ship.label)
+
+						-- $5000 in fines for every $5000 in goods in a high-sec system
+						-- This includes goods in shielded holds for simplicity (they look closer after finding evidence of wrongdoing...)
+						local newfine = Legal:fine("TRADING_ILLEGAL_GOODS", Game.system.lawlessness)
+						newfine = (newfine * illegalValue / 5000) * Engine.rand:Normal(1.0, 0.2)
+
+						PlayerState.AddCrime("TRADING_ILLEGAL_GOODS", newfine)
+
+						if fine + newfine > maxFineTolerated then
 							attackShip(player)
 							Comms.ImportantMessage(l["POLICE_TAUNT_" .. Engine.rand:Integer(1, getNumberOfFlavours("POLICE_TAUNT"))], ship.label)
-						else
-							Comms.ImportantMessage(l.NOTHING_DETECTED, ship.label)
-							if fine > 100 then
-								local message = l["FINES_INTRO_" .. Engine.rand:Integer(1, getNumberOfFlavours("FINES_INTRO"))]
-								message = message .. " " .. l["FINES_MESSAGE_" .. Engine.rand:Integer(1, getNumberOfFlavours("FINES_MESSAGE"))]
-								if fine > 1000 then
-									message = message .. " " .. l["FINES_ADMONISHING_HARSH_" .. Engine.rand:Integer(1, getNumberOfFlavours("FINES_ADMONISHING_HARSH"))]
-								else
-									message = message .. " " .. l["FINES_ADMONISHING_" .. Engine.rand:Integer(1, getNumberOfFlavours("FINES_ADMONISHING"))]
-								end
-								local policeforce = Game.system.faction.policeName
-								local ship_label = player.label
-								Comms.ImportantMessage(string.interp(message, {policeforce = policeforce, ship_label = ship_label, fine = ui.Format.Money(fine)}), ship.label)
-							end
+
+							return
 						end
-					end)
-				end
+					else
+						-- Got away clean... this time.
+						Comms.ImportantMessage(l.NOTHING_DETECTED, ship.label)
+					end
+
+					if fine > 100 then
+						local message = l["FINES_INTRO_" .. Engine.rand:Integer(1, getNumberOfFlavours("FINES_INTRO"))]
+						message = message .. " " .. l["FINES_MESSAGE_" .. Engine.rand:Integer(1, getNumberOfFlavours("FINES_MESSAGE"))]
+						if fine > 1000 then
+							message = message .. " " .. l["FINES_ADMONISHING_HARSH_" .. Engine.rand:Integer(1, getNumberOfFlavours("FINES_ADMONISHING_HARSH"))]
+						else
+							message = message .. " " .. l["FINES_ADMONISHING_" .. Engine.rand:Integer(1, getNumberOfFlavours("FINES_ADMONISHING"))]
+						end
+						local policeforce = Game.system.faction.policeName
+						local ship_label = player.label
+						Comms.ImportantMessage(string.interp(message, {policeforce = policeforce, ship_label = ship_label, fine = ui.Format.Money(fine)}), ship.label)
+					end
+				end)
 			end
 		end)
 	end)

--- a/data/pigui/libs/equipment-outfitter.lua
+++ b/data/pigui/libs/equipment-outfitter.lua
@@ -227,7 +227,7 @@ function Outfitter:getAvailableEquipment()
 
 	return utils.map_table(Equipment.new, function(id, equip)
 
-		if not equip.purchasable or not self:stationHasTech(equip.tech_level) then
+		if not equip.purchasable or not self.station:GetEquipmentStock(equip) then
 			return id, nil
 		end
 
@@ -284,7 +284,7 @@ local function fmt_number(val) return ui.Format.Number(val, 0) end
 -- Prepend information about the current station's stocking information to an equipment item's detailed stats
 ---@param data UI.EquipCard.Data
 function Outfitter:modifyEquipmentStats(data)
-	local stock = self:getStock(data.equip)
+	local stock = self:getStock(data.equip) or 0
 
 	table.insert(data.stats, 1, { l.AVAILABLE_STOCK, icons.cargo_crate, stock, fmt_number })
 	table.insert(data.stats, 2, { l.TECH_LEVEL, icons.station_orbital_large, data.equip.tech_level, fmt_number })
@@ -514,41 +514,42 @@ function Outfitter:renderCompareRow(label, stat_a, stat_b)
 	ui.text(label)
 
 	local icon_size = Vector2(ui.getTextLineHeight())
-	local cmp_a, cmp_b = "", ""
+	local default = type((stat_a or stat_b)[3]) == "number" and 0 or ""
+	local cmp_a, cmp_b = default, default
+
 	if stat_a then
 		cmp_a = stat_a[3] == "MILITARY" and 11 or stat_a[3]
 	end
 	if stat_b then
 		cmp_b = stat_b[3] == "MILITARY" and 11 or stat_b[3]
 	end
-	local color = stat_a and stat_b
-		and compare(cmp_a, cmp_b, stat_a[5])
+	local color = compare(cmp_a, cmp_b, (stat_a or stat_b)[5])
 		or colors.font
 
-	ui.tableNextColumn()
-	if stat_a then
-		ui.icon(stat_a[2], icon_size, colors.font)
-		ui.sameLine()
+	local icon = (stat_a or stat_b)[2]
+	local format = (stat_a or stat_b)[4]
 
-		local val, format = stat_a[3], stat_a[4]
-		if val ~= "MILITARY" then
-			ui.textColored(color, format(val))
-		else
-			ui.icon(icons.shield_other, icon_size, color)
-		end
+	local val_a = stat_a and format(stat_a[3]) or format(default)
+	local val_b = stat_b and format(stat_b[3]) or format(default)
+
+	ui.tableNextColumn()
+	ui.icon(icon, icon_size, colors.font)
+	ui.sameLine()
+
+	if stat_a and stat_a[3] == "MILITARY" then
+		ui.icon(icons.shield_other, icon_size, color)
+	else
+		ui.textColored(color, val_a)
 	end
 
 	ui.tableNextColumn()
-	if stat_b then
-		ui.icon(stat_b[2], icon_size, colors.font)
-		ui.sameLine()
+	ui.icon(icon, icon_size, colors.font)
+	ui.sameLine()
 
-		local val, format = stat_b[3], stat_b[4]
-		if val ~= "MILITARY" then
-			ui.textColored(color, format(val))
-		else
-			ui.icon(icons.shield_other, icon_size, color)
-		end
+	if stat_b and stat_b[3] == "MILITARY" then
+		ui.icon(icons.shield_other, icon_size, color)
+	else
+		ui.textColored(color, val_b)
 	end
 end
 

--- a/data/pigui/libs/ship-equipment.lua
+++ b/data/pigui/libs/ship-equipment.lua
@@ -43,7 +43,7 @@ EquipmentWidget.Sections = {
 	{ name = le.SHIELDS, type = "shield" },
 	{ name = le.SENSORS, type = "sensor", },
 	{ name = le.COMPUTER_MODULES, type = "computer", },
-	{ name = le.CABINS, types = { "cabin" } },
+	{ name = le.HABITAT, types = { "cabin" } },
 	{ name = le.HULL_MOUNTS, types = { "hull", "utility", "fuel_scoop", "structure" } },
 }
 

--- a/data/pigui/libs/ship-equipment.lua
+++ b/data/pigui/libs/ship-equipment.lua
@@ -195,7 +195,7 @@ function EquipmentWidget:onSelectSlot(slotData, children)
 		self.market.filterSlot = self.selectedSlot
 		self.market.replaceEquip = self.selectedEquip
 
-		local canBeSold = not self.selectedEquip or self.selectedEquip:CanBeSold()
+		local canBeSold = not self.selectedEquip or self.selectedEquip:CanBeSold(self.ship)
 
 		self.market.canReplaceEquip = not hasChildren and canBeSold
 		self.market.canSellEquip = not (self.selectedSlot and self.selectedSlot.required or hasChildren) and canBeSold

--- a/data/pigui/modules/info-view/01-ship-info.lua
+++ b/data/pigui/modules/info-view/01-ship-info.lua
@@ -56,7 +56,7 @@ local function shipStats()
 		false,
 		{ l.WEIGHT_EMPTY..":",     string.format("%d t", player.staticMass - player.loadedMass) },
 		{ l.CAPACITY_USED..":",    string.format("%s (%s "..l.MAX..")", ui.Format.Volume(player.equipVolume), ui.Format.Volume(player.totalVolume) ) },
-		{ l.CARGO_SPACE_USED..":", string.format("%d cu (%d cu "..l.MAX..")", player.usedCargo, player.totalCargo) },
+		{ l.CARGO_SPACE_USED..":", string.format("%d cu (%d cu "..l.MAX..")", player.usedCargo, player.cargo_cap) },
 		{ l.FUEL_WEIGHT..":",      string.format("%.1f t (%.1f t "..l.MAX..")", player.fuelMassLeft, shipDef.fuelTankMass ) },
 		{ l.ALL_UP_WEIGHT..":",    string.format("%d t", mass_with_fuel ) },
 		false,

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -617,7 +617,7 @@ void Ship::UpdateEquipStats()
 	m_stats.static_mass = m_stats.loaded_mass + m_type->hullMass;
 
 	m_stats.used_cargo = p.Get("usedCargo").get_integer();
-	m_stats.free_cargo = p.Get("totalCargo").get_integer() - m_stats.used_cargo;
+	m_stats.free_cargo = p.Get("cargo_cap").get_integer() - m_stats.used_cargo;
 
 	p.Set("loadedMass", m_stats.loaded_mass);
 	p.Set("staticMass", m_stats.static_mass);

--- a/src/lua/LuaShip.cpp
+++ b/src/lua/LuaShip.cpp
@@ -1565,7 +1565,7 @@ void LuaObject<Ship>::RegisterClass()
  * Hull capacity used by cargo only (not equipment). Measured in cargo units.
  *
  *
- * Attribute: totalCargo
+ * Attribute: cargo_cap
  *
  * Hull capacity available for cargo (not equipment). Measured in cargo units.
  */


### PR DESCRIPTION
This PR adds the long-awaited Smuggler's Hold equipment, known in-game as a "Concealed Cargo Rack". Available only in systems with a lawlessness > 0.5 (halfway through "Dangerous" or worse security rating), this equipment provides total immunity from police scans for the cargo stored inside.

It is designed as a habitat-slot equipment to both limit the amount of illegal cargo that can be smuggled without risk from a Doylist perspective, as well as to respect the fact that most ships' equipment bays are smaller than the dimensions of a 1u cargo container on at least one axis from a Watsonian perspective.

To complement this, police cargo scans have been partially rewritten. They now have a percentage chance to find your illegal goods, allowing you to smuggle small quantities of illegal items in a hold mostly filled with legitimate cargo. The detection chance starts at 45% for one item in a sea of cargo, and tops out at 100% when 55% of your cargo is illegal. Typically you will want to smuggle in the 5-10% range, though if you get caught...

...the police will no longer execute you on the spot! They'll instead assess you with a fine roughly equal to the intrinsic value of your illegal goods, and only proceed to immediate deresolution if that fine exceeds the usual threshold for immediate hostilities.

Note that smuggler's holds will *not* conceal their cargo from the police if you do get caught, whether that's by a random scan of the cargo in your hold or by buying or selling from a police honeypot at a station.

This PR also makes some minor QoL changes to the equipment stat comparison view, as well as changing the "Cabins" slot category to the more generic "Habitat". The intent is to expand this a bit to allow ships to have more modular habitat space, i.e. with crew amenities as equipment modules. Perhaps you'd like to change extra crew bunks out for a lavish zero-G kitchen for those longer travels out in the black?

I've not yet made more major changes to equipment slot names or types, seeking to save that for a later effort where we intentionally break save compatibility. Ideally that would go hand-in-hand with the crew happiness PR, as well as a "habitat space" metric that plays into crew dissatisfaction over longer trips.

### As usual, playtesting is extremely helpful!

Please make sure to test an existing save from before this PR to double-check that it is fully save-compatible.