### PR TITLE
Fix Kanara translation tokens

### DIFF
--- a/data/lang/ships/en.json
+++ b/data/lang/ships/en.json
@@ -84,28 +84,28 @@
     "message": "a DS Miner"
   },
   "KANARA": {
-    "description": "ship name - base form",
+    "description": "ship name - base form, Kanara civilian",
     "message": "Kanara"
   },
-  "KANARA_CIV": {
-    "description": "ship name - base form",
-    "message": "Kanara Civ"
-  },
-  "KANARA_CIV_DEF": {
-    "description": "ship - definite form",
-    "message": "the Kanara Civ"
-  },
-  "KANARA_CIV_INDEF": {
-    "description": "ship name - indefinite form",
-    "message": "a Kanara Civ"
-  },
   "KANARA_DEF": {
-    "description": "ship - definite form",
+    "description": "ship - definite form, Kanara civilian",
     "message": "the Kanara"
   },
   "KANARA_INDEF": {
-    "description": "ship name - indefinite form",
+    "description": "ship name - indefinite form, Kanara civilian",
     "message": "a Kanara"
+  },
+  "KANARA_POLICE": {
+    "description": "ship name - base form",
+    "message": "Kanara police ship"
+  },
+  "KANARA_POLICE_DEF": {
+    "description": "ship - definite form",
+    "message": "the Kanara police ship"
+  },
+  "KANARA_POLICE_INDEF": {
+    "description": "ship name - indefinite form",
+    "message": "a Kanara police ship"
   },
   "LODOS": {
     "description": "ship name - base form",

--- a/data/lang/ships/en.json
+++ b/data/lang/ships/en.json
@@ -57,7 +57,7 @@
   },
   "CORONATRIX_POLICE_INDEF": {
     "description": "ship name - indefinite form",
-    "message": "a Coronatrix police ship"
+    "message": "a police model Coronatrix"
   },
   "DENEB": {
     "description": "ship name - base form",
@@ -105,7 +105,7 @@
   },
   "KANARA_POLICE_INDEF": {
     "description": "ship name - indefinite form",
-    "message": "a Kanara police ship"
+    "message": "a police model Kanara"
   },
   "LODOS": {
     "description": "ship name - base form",
@@ -225,7 +225,7 @@
   },
   "PUMPKINSEED_POLICE_INDEF": {
     "description": "ship name - indefinite form",
-    "message": "a Pumpkinseed police ship"
+    "message": "a police model Pumpkinseed"
   },
   "SHIP": {
     "description": "ship name - base form",
@@ -261,7 +261,7 @@
   },
   "SINONATRIX_POLICE_INDEF": {
     "description": "ship name - indefinite form",
-    "message": "a Sinonatrix police ship"
+    "message": "a police model Sinonatrix"
   },
   "SKIPJACK": {
     "description": "ship name - base form",


### PR DESCRIPTION
`Warning: Missing translation token 'KANARA_POLICE' in resource 'ships/en.json'.`

All ships with a police model follow the paradigm name/name_police apart from the Kanara which use kanara_civ/kanara where just 'kanara' is the police model. This caused me some confusion in #6103 where ships where made translatable. The translation tokens in the json files do follow the same pattern as the rest of the civ/police ships. I think just correcting the tokens in /data/lang/ships/en.json is enough for now but perhaps someone should look into the kanara json files too.

data/ships/kanara.json
```json
	"model": "kanara",
	"i18n_key": "KANARA_POLICE",
	"name": "Kanara (Police)",

```

data/ships/kanara_civ.json
```json
	"model": "kanara_civ",
	"i18n_key": "KANARA",
	"name": "Kanara (Civilian)",

```