### PR TITLE
Cargo - upper case

### DIFF
--- a/data/pigui/modules/info-view/03-econ-trade.lua
+++ b/data/pigui/modules/info-view/03-econ-trade.lua
@@ -79,7 +79,7 @@ local function cargolist ()
 		-- name
 		ui.tableNextColumn()
 		ui.alignTextToButtonPadding()
-		ui.text(entry.commodity:GetName())
+		ui.text(entry.commodity:GetProperName())
 
 		-- jettison button
 		ui.tableNextColumn()

--- a/data/pigui/modules/sidebar/cargo.lua
+++ b/data/pigui/modules/sidebar/cargo.lua
@@ -196,7 +196,7 @@ function module:drawCargoRow(v, rowWidth, totalSpace)
 
 	-- Draw name
 	ui.tableNextColumn()
-	ui.text(commodity:GetName())
+	ui.text(commodity:GetProperName())
 
 	-- Draw contained amount or transferred amount
 	ui.tableNextColumn()


### PR DESCRIPTION
Some cases of cargo being lower case fixed.

- World view cargo window
- Economy and Trade, cargo list

In the latter view, cargo is preceded by a weight amount, but I take it as being a different column and the cargo name looks better in upper case.

<img width="687" height="205" alt="cargoucase" src="https://github.com/user-attachments/assets/7e41f916-a39d-4aa0-8229-0f81428334b8" />
