### PR TITLE
Font padding

### DIFF
--- a/data/pigui/modules/station-view/01-lobby.lua
+++ b/data/pigui/modules/station-view/01-lobby.lua
@@ -279,6 +279,7 @@ local function drawPlayerInfo()
 				-- face display has 1:1 aspect ratio, and we need size for a launch button underneath
 				local infoColumnWidth = -math.min(ui.getContentRegion().y - buttonSizeSpacing, widgetSizes.faceSize.x) - widgetSizes.itemSpacing.x
 				ui.child("PlayerShipFuel", Vector2(infoColumnWidth, 0), function()
+					ui.spacing()  -- Extra padding for umlaut and other signs on top of the station label.
 					textTable.withHeading(station.label, orbiteer.title, {
 						{ tech_certified, "" },
 						{ station_docks, "" },

--- a/data/pigui/modules/station-view/02-bulletinBoard.lua
+++ b/data/pigui/modules/station-view/02-bulletinBoard.lua
@@ -77,6 +77,9 @@ bulletinBoard = Table.New("BulletinBoardTable", false, {
 		ui.setColumnWidth(0, self.style.size.x)
 	end,
 	renderItem = function(self, item, key)
+		if key == 1 then	-- Insert padding or Orbiteer gets cut off on the first bbs item.
+			ui.dummy(Vector2(0, 0))
+		end
 		local icon = item.icon or "default"
 		local region = ui.getContentRegion()
 


### PR DESCRIPTION
Fixes #5476

Adds padding to the Lobby and the BBS, to allow for letters not to be cut off on the top. This is the case with some letters with umlaut, ÅÄÖÜ. The solution for the Lobby works well. The padding in the BBS also works, but it consumes a bit to much vertical space. On my screen this means 8 bulletin posts instead of 9.

Edit: Examples below in Swedish.

Now. Letters cut off on the first post 'AFFÄRSRESA'
<img width="1368" height="768" alt="bbsnow" src="https://github.com/user-attachments/assets/81d25961-96d3-4896-95fc-e10291dedf43" />

Fixed. Less space on the BBS
<img width="1368" height="768" alt="bbsfixed" src="https://github.com/user-attachments/assets/936fd301-57d3-4419-97f5-a89bd5447c01" />

