### PR TITLE
Update CMake and CI build files

### DIFF
--- a/.github/actions/upload-appimage/action.yml
+++ b/.github/actions/upload-appimage/action.yml
@@ -36,15 +36,15 @@ runs:
         ARCH=x86_64 ./linuxdeploy-x86_64.AppImage --appdir "out/install/pioneer-$BUILD_SLUG" --output appimage
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ format('Pioneer*.AppImage', inputs.build_slug) }}
         retention-days: 14
-        compression-level: 0 # Contains a pre-compressed AppImage file...
+        archive: false
 
     - name: Upload Release Files
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && inputs.upload_release }}
       with:
         files: Pioneer*.AppImage

--- a/.github/actions/upload-linux/action.yml
+++ b/.github/actions/upload-linux/action.yml
@@ -34,12 +34,12 @@ runs:
         tar -czf "pioneer-$BUILD_SLUG-$(date +%Y%m%d).tar.gz" "pioneer-$BUILD_SLUG"
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ format('out/install/pioneer-{0}-*.tar.gz', inputs.build_slug) }}
         retention-days: 14
-        compression-level: 0 # contains a pre-compressed .tar.gz archive...
+        archive: false
 
     - name: Build Release
       shell: bash
@@ -48,7 +48,7 @@ runs:
       run: ./scripts/package-release.sh
 
     - name: Upload Release Files
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && inputs.upload_release }}
       with:
         files: release/pioneer-linux-x64-*.tar.gz

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -52,12 +52,12 @@ jobs:
       run: |
         choco install gawk -y
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         path: pioneer
 
     - name: Checkout pioneer-thirdparty
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: pioneerspacesim/pioneer-thirdparty
         path: pioneer-thirdparty
@@ -111,7 +111,7 @@ jobs:
 
     steps:
     # Checkout the repository as $GITHUB_WORKSPACE
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
       run: |
@@ -149,7 +149,7 @@ jobs:
     steps:
 
     # Checkout the repository as $GITHUB_WORKSPACE
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
       run: |
@@ -177,7 +177,7 @@ jobs:
     if: ${{github.event_name == 'release' || github.event_name == 'workflow_dispatch'}}
     steps:
     # Checkout the repository as $GITHUB_WORKSPACE
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -90,15 +90,15 @@ jobs:
         cmake --build . --target win-installer
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Windows-Artifacts
         path: pioneer/pioneer-*-win.exe
         retention-days: 14
-        compression-level: 0 # contains a pre-compressed self-extracting archive...
+        archive: false
 
     - name: Upload Release Files
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
       with:
         files: pioneer/pioneer-*-win.exe

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
     # Checkout the repository as $GITHUB_WORKSPACE
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # Make sure to include the base we want to merge into
     - run: |

--- a/.github/workflows/import-ships.yml
+++ b/.github/workflows/import-ships.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     # Setup the runtime environment
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup dependencies
       working-directory: scripts/notion-import
       run: |

--- a/.github/workflows/naturaldocs.yml
+++ b/.github/workflows/naturaldocs.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Checkout the repository as $GITHUB_WORKSPACE
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/naturaldocs.yml
+++ b/.github/workflows/naturaldocs.yml
@@ -60,20 +60,21 @@ jobs:
           mono Natural\ Docs/NaturalDocs.exe -p nd
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "Lua API documentation"
         path: docs
 
     - name: Setup Pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v6
 
     - name: Upload pages
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         # only upload docs/ folder
         path: 'docs'
+        include-hidden-files: true # restore legacy v3 behavior
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,6 @@ set(PIONEER_VERSION "20260203-dev")
 set(PROJECT_VERSION_INFO ""
 	CACHE STRING "Additional version information (optional)")
 
-# If both libGL.so and libOpenGL.so are found, default to the latter
-# (former is a legacy name).
-# Set OpenGL_GL_PREFERENCE=LEGACY to force it to use the former.
-if(POLICY CMP0072)
-	cmake_policy(SET CMP0072 NEW)
-endif()
-
 include(cmake/TargetArchitecture.cmake)
 include(cmake/InstallPioneer.cmake)
 
@@ -380,13 +373,22 @@ endif()
 
 target_link_libraries(pioneer-lib PUBLIC lz4 fmt::fmt)
 
+# Fallback available on most legacy systems
+set(PIONEER_GL_LINK_TARGET OpenGL::GL)
+
+# If GLVND is available, the OpenGL::OpenGL target will be registered and we should prefer that
+# (it may be the only OpenGL target available on certain systems)
+if (TARGET OpenGL::OpenGL)
+	set(PIONEER_GL_LINK_TARGET OpenGL::OpenGL)
+endif()
+
 list(APPEND pioneerLibs
 	pioneer-core
 	pioneer-lib
 	pioneer-lua
 	${ASSIMP_LIBRARIES}
 	${FREETYPE_LIBRARIES}
-	OpenGL::GL
+	${PIONEER_GL_LINK_TARGET}
 	${SDL2_LIBRARIES}
 	${SDL2_IMAGE_LIBRARIES}
 	${SIGCPP_LIBRARIES}

--- a/contrib/lz4/CMakeLists.txt
+++ b/contrib/lz4/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 project(lz4 LANGUAGES C)
 
 list(APPEND LZ4_SOURCES

--- a/contrib/nanosockets/CMakeLists.txt
+++ b/contrib/nanosockets/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 project(nanosockets C)
 
 if (MSYS OR MINGW)


### PR DESCRIPTION
This PR should fix #6307, while not breaking MSVC builds linking to `OpenGL::GL`. CC @fluffyfreak for testing.

I've also addressed a bunch of pending deprecation notices from Github regarding the Node 20 runner used in a lot of our CI actions. They have been updated and changed to take advantage of new features in the action where it makes sense.