### PR TITLE
Limit the number of messages on the saved Comms log

### DIFF
--- a/data/libs/Game.lua
+++ b/data/libs/Game.lua
@@ -37,8 +37,18 @@ Event.Register('onGameEnd', function()
 end)
 
 local function _serialize()
+	local length_comms_log = 200	-- Max number of Comms log messages saved
+	local comms_log_lines = {}
+	if #Game.comms_log_lines > length_comms_log then
+		for i = 1, length_comms_log do
+			comms_log_lines[i] = Game.comms_log_lines[#Game.comms_log_lines - length_comms_log + i]
+		end
+	else
+		comms_log_lines = Game.comms_log_lines
+	end
+
 	return { startTime = gameStartTime,
-			comms_log_lines = Game.comms_log_lines }
+			comms_log_lines = comms_log_lines }
 end
 
 local function _deserialize(data)


### PR DESCRIPTION
Follow up of https://github.com/pioneerspacesim/pioneer/pull/6361 which includes the Comms log in the game save.

I tested the impact on game save size and in one case, one hour of playing bumped the file size some 60kB. If you don't cull the Comms log this will blow the size of the file up eventually.

Fixed by only saving the last 200 messages.

