### PR TITLE
Round off new commodity stock on news event

### DIFF
--- a/data/modules/NewsEventCommodity/NewsEventCommodity.lua
+++ b/data/modules/NewsEventCommodity/NewsEventCommodity.lua
@@ -377,7 +377,7 @@ local onPlayerDocked = function (ship, station)
 
 			-- Blend from absolutely no stock to normal stock levels for this demand as the event goes on
 			if newDemand > 0 then
-				newStock = newStock * (1.0 - progress)^2
+				newStock = math.ceil(newStock * (1.0 - progress)^2)
 			end
 
 			-- print("--- NewsEvent old:", cargo_item:GetName(), "price:", price, "stock:", stock, "demand:", demand)


### PR DESCRIPTION
<img width="614" height="194" alt="newseventprice" src="https://github.com/user-attachments/assets/88554f09-63d3-4f51-b0c6-4313a65878fc" />

The rest of the commodities comes neatly rounded to a whole number but not the News event ones.



