### PR TITLE
Show percent translation complete for language options

### DIFF
--- a/data/meta/Lang.lua
+++ b/data/meta/Lang.lua
@@ -26,4 +26,10 @@ function Lang.GetResource(name, langCode) return Resource end
 ---@return string[]
 function Lang.GetAvailableLanguages(resource) end
 
+--- Return the percentage of translated strings for a language code (0-100).
+--- English always returns 100.
+---@param langCode string
+---@return integer
+function Lang.GetLanguageCompletionPercent(langCode) end
+
 return Lang

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -365,6 +365,32 @@ end
 local function showLanguageOptions()
 	local langs = Lang.GetAvailableLanguages("core")
 
+	local filtered = {}
+	for _, lang in ipairs(langs) do
+		if lang == "en" or lang == Lang.currentLanguage or Lang.GetLanguageCompletionPercent(lang) > 0 then
+			table.insert(filtered, lang)
+		end
+	end
+	langs = filtered
+
+	table.sort(langs, function(a, b)
+		if a == "en" then return true end
+		if b == "en" then return false end
+		return a < b
+	end)
+
+	local function languageLabel(lang)
+		local name = Lang.GetResource("core", lang).LANG_NAME
+		if lang == "en" then
+			return name
+		end
+		local pct = Lang.GetLanguageCompletionPercent(lang)
+		if pct >= 90 then
+			return name
+		end
+		return string.format("%s (%d%%)", name, pct)
+	end
+
 	ui.withFont(pionillium.heading, function()
 		ui.text(lui.LANGUAGE_RESTART_GAME_TO_APPLY .. ":")
 	end)
@@ -372,7 +398,7 @@ local function showLanguageOptions()
 	ui.withFont(pionillium.body, function()
 		ui.child("##LanguageList", Vector2(0, 0), function()
 			for _, lang in ipairs(langs) do
-				if ui.selectable(Lang.GetResource("core",lang).LANG_NAME .. "##" .. lang, Lang.currentLanguage==lang, {}) then
+				if ui.selectable(languageLabel(lang) .. "##" .. lang, Lang.currentLanguage==lang, {}) then
 					Lang.SetCurrentLanguage(lang)
 				end
 			end

--- a/src/Lang.cpp
+++ b/src/Lang.cpp
@@ -33,19 +33,13 @@ namespace Lang {
 		return true;
 	}
 
-	bool Resource::Load()
+	static bool load_messages_from_file(const std::string &filename, Resource::StringMap &strings)
 	{
-		if (m_loaded)
-			return true;
-
-		std::string filename = "lang/" + m_name + "/" + m_langCode + ".json";
 		Json data = JsonUtils::LoadJsonDataFile(filename);
-		if (data.is_null()) {
-			Log::Warning("couldn't read language file '{}'\n", filename.c_str());
+		if (data.is_null())
 			return false;
-		}
 
-		for (Json::iterator i = data.begin(); i != data.end(); ++i) {
+		for (Json::const_iterator i = data.begin(); i != data.end(); ++i) {
 			const std::string token = i.key();
 			if (token.empty()) {
 				Log::Info("{}: found empty token, skipping it\n", filename.c_str());
@@ -97,7 +91,20 @@ namespace Lang {
 				text = adjustedText;
 			}
 
-			m_strings[token] = text;
+			strings[token] = text;
+		}
+		return true;
+	}
+
+	bool Resource::Load()
+	{
+		if (m_loaded)
+			return true;
+
+		std::string filename = "lang/" + m_name + "/" + m_langCode + ".json";
+		if (!load_messages_from_file(filename, m_strings)) {
+			Log::Warning("couldn't read language file '{}'\n", filename.c_str());
+			return false;
 		}
 
 		m_loaded = true;
@@ -230,6 +237,75 @@ namespace Lang {
 		m_cachedResources.insert(std::make_pair(key, std::move(res)));
 
 		return m_cachedResources.at(key);
+	}
+
+	static std::map<std::string, int> s_languageCompletion;
+	static bool s_languageCompletionScanned = false;
+
+	void ScanLanguageCompletion()
+	{
+		if (s_languageCompletionScanned)
+			return;
+		s_languageCompletionScanned = true;
+
+		struct Stats {
+			int translated = 0;
+			int total = 0;
+		};
+		std::map<std::string, Stats> stats;
+
+		const int dirFlags = FileSystem::FileEnumerator::IncludeDirs | FileSystem::FileEnumerator::ExcludeFiles;
+		for (FileSystem::FileEnumerator resources(FileSystem::gameDataFiles, "lang", dirFlags); !resources.Finished(); resources.Next()) {
+			const std::string resourcePath = resources.Current().GetPath();
+
+			Resource::StringMap english;
+			if (!load_messages_from_file(FileSystem::JoinPath(resourcePath, "en.json"), english) || english.empty())
+				continue;
+
+			for (FileSystem::FileEnumerator files(FileSystem::gameDataFiles, resourcePath); !files.Finished(); files.Next()) {
+				if (!files.Current().IsFile())
+					continue;
+
+				const std::string &name = files.Current().GetName();
+				if (!ends_with_ci(name, ".json"))
+					continue;
+
+				const std::string langCode = name.substr(0, name.size() - 5);
+				if (langCode == "en")
+					continue;
+
+				Resource::StringMap translated;
+				load_messages_from_file(files.Current().GetPath(), translated);
+
+				for (const auto &entry : english) {
+					const std::string &token = entry.first;
+					const std::string &enText = entry.second;
+					stats[langCode].total++;
+					const auto it = translated.find(token);
+					if (it != translated.end() && it->second != enText)
+						stats[langCode].translated++;
+				}
+			}
+		}
+
+		for (const auto &entry : stats) {
+			const Stats &s = entry.second;
+			s_languageCompletion[entry.first] = s.total > 0 ? (s.translated * 100) / s.total : 0;
+		}
+	}
+
+	int GetLanguageCompletionPercent(std::string_view langCode)
+	{
+		if (langCode == "en")
+			return 100;
+
+		if (!s_languageCompletionScanned)
+			ScanLanguageCompletion();
+
+		const auto it = s_languageCompletion.find(std::string(langCode));
+		if (it == s_languageCompletion.end())
+			return 0;
+		return it->second;
 	}
 
 } // namespace Lang

--- a/src/Lang.h
+++ b/src/Lang.h
@@ -55,6 +55,14 @@ namespace Lang {
 
 	Resource &GetResource(std::string_view name, std::string_view langCode);
 
+	// Scan all language files under lang/ and compute the percentage of strings
+	// that differ from the English version for each language code.
+	void ScanLanguageCompletion();
+
+	// Return the completion percentage (0-100) for a language code.
+	// Returns 100 for English. Computes completion on first call if needed.
+	int GetLanguageCompletionPercent(std::string_view langCode);
+
 } // namespace Lang
 
 #endif

--- a/src/lua/LuaLang.cpp
+++ b/src/lua/LuaLang.cpp
@@ -124,6 +124,15 @@ static int l_lang_get_available_languages(lua_State *l)
 	return 1;
 }
 
+static int l_lang_get_language_completion_percent(lua_State *l)
+{
+	LUA_DEBUG_START(l);
+	const std::string langCode(luaL_checkstring(l, 1));
+	lua_pushinteger(l, Lang::GetLanguageCompletionPercent(langCode));
+	LUA_DEBUG_END(l, 1);
+	return 1;
+}
+
 static int l_lang_set_current_language(lua_State *l)
 {
 	const std::vector<std::string> langs = Lang::Resource::GetAvailableLanguages("core");
@@ -158,6 +167,7 @@ void LuaLang::Register()
 	static const luaL_Reg l_methods[] = {
 		{ "GetResource", l_lang_get_resource },
 		{ "GetAvailableLanguages", l_lang_get_available_languages },
+		{ "GetLanguageCompletionPercent", l_lang_get_language_completion_percent },
 		{ "SetCurrentLanguage", l_lang_set_current_language },
 		{ 0, 0 }
 	};


### PR DESCRIPTION
Addresses #6366, mostly.

When showing the language options, we now scan all the language files to see what percentage of the strings are the same as the English version, i.e. those strings are not translated yet. The percentage of translated strings is then shown in the menu next to each language - e.g. "Francais (94%)" except for English itself which has "(default)" instead.

The default English is always put at the top of the list.

Any language with 0% translated strings is not shown in the list.

Yes, this is a bit of a blunt tool, because any string that is deliberately the same as the English version, like "OK", will count as not translated, while any string that was originally translated but is now out of date will count as translated. But it is probably accurate enough overall to be useful.

I couldn't do anything programmatically about the fact that some translators have literally translated the name "English" into the word for English in their language, instead of the name of their language in their language. I think that may have to be done on Transifex.

