### PR TITLE
Fix return-value warning in PiGuiRenderer.cpp

### DIFF
--- a/src/pigui/PiGui.cpp
+++ b/src/pigui/PiGui.cpp
@@ -670,7 +670,7 @@ void Instance::RequestSVGFaceData(FontPair pair, SVGFontBaked *font_data)
 	font_data->raster_idx = m_svgRasterData[filename].size();
 	m_svgRasterData[filename].emplace_back(std::move(raster));
 
-	Log::Info("Queuing rasterization of font {}@{}", filename, font_data->px_w);
+	// Log::Info("Queuing rasterization of font {}@{}", filename, font_data->px_w);
 	RasterizeSVGTask *rasterTask = new RasterizeSVGTask(filename, font_data->px_w, font_data->px_h);
 	// This font may accumulate pending glyph uploads while the SVG data is being rasterized.
 	m_pendingUploads[pair] = font_data;

--- a/src/pigui/PiGuiRenderer.cpp
+++ b/src/pigui/PiGuiRenderer.cpp
@@ -3,7 +3,6 @@
 
 #include "PiGuiRenderer.h"
 
-#include "core/Log.h"
 #include "graphics/Graphics.h"
 #include "graphics/Material.h"
 #include "graphics/RenderState.h"
@@ -26,7 +25,10 @@ Graphics::TextureFormat GetTextureFormat(ImTextureFormat fmt)
 	switch(fmt) {
 		case ImTextureFormat_RGBA32: return Graphics::TEXTURE_RGBA_8888;
 		case ImTextureFormat_Alpha8: return Graphics::TEXTURE_R8;
-		default: assert(0);
+		default: {
+			assert(0);
+			return Graphics::TEXTURE_NONE;
+		}
 	}
 }
 
@@ -197,7 +199,6 @@ void InstanceRenderer::UpdateFontTexture(ImTextureData *tex)
 
 	if (tex->Status == ImTextureStatus_WantUpdates) {
 		// Upload data to an existing texture
-		Log::Info("Updating font texture {},{},{},{}", tex->UpdateRect.x, tex->UpdateRect.y, tex->UpdateRect.w, tex->UpdateRect.h);
 
 		auto *ptr = reinterpret_cast<Graphics::Texture *>(tex->TexID);
 


### PR DESCRIPTION
This PR is just a small cleanup removing some left-over debug logging and adding a proper return statement to a function branch that isn't exercised.

CC @Mc-Pain - this should fix your compilation error.