### PR TITLE
Ship landing improvements 2: The Lightbringer

### DIFF
--- a/data/shaders/opengl/geosphere_terrain.frag
+++ b/data/shaders/opengl/geosphere_terrain.frag
@@ -4,6 +4,7 @@
 #include "attributes.glsl"
 #include "lib.glsl"
 #include "basesphere_uniforms.glsl"
+#include "terrain_local_lights.glsl"
 
 #define WATER_SHINE 16.0
 
@@ -68,9 +69,13 @@ void main(void)
 #endif
 	}
 
-	// Use the detail value to multiply the final colour before lighting
+	// Local lighting from nearby ships and starports.
+	vec4 localMultiply;
+	vec4 localAdd;
+	CalcTerrainLocalDiffuse(localMultiply, localAdd, varyingEyepos, tnorm);
+
 	vec4 ambient = scene.ambient * vertexColor;
-	vec4 final = vertexColor * detailMul * diff;
+	vec4 final = vertexColor * detailMul * (diff + localMultiply) + localAdd * detailMul;
 
 #ifdef ATMOSPHERE
 	float ldprod=0.0;

--- a/data/shaders/opengl/geosphere_terrain.shaderdef
+++ b/data/shaders/opengl/geosphere_terrain.shaderdef
@@ -9,9 +9,11 @@ Texture sampler2D texture1
 Buffer LightData binding=0
 Buffer DrawData binding=1
 Buffer BaseSphereData binding=2
+Buffer TerrainLocalLightsData binding=3
 
 PushConstant int NumShadows binding=0
 PushConstant float PatchDetailFrequency binding=1
+PushConstant vec3 PatchClipCentroid binding=2
 
 Vertex "geosphere_terrain.vert"
 Fragment "geosphere_terrain.frag"

--- a/data/shaders/opengl/terrain_local_lights.glsl
+++ b/data/shaders/opengl/terrain_local_lights.glsl
@@ -1,0 +1,62 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef TERRAIN_LOCAL_LIGHTS_GLSL
+#define TERRAIN_LOCAL_LIGHTS_GLSL
+
+#define MAX_TERRAIN_LOCAL_LIGHTS 16
+
+struct TerrainLocalLight {
+	vec4 position; // xyz in unit-sphere coords (planet-frame meters / planet radius)
+	vec4 colour;   // rgb, a unused
+	vec4 falloff;  // x = range (meters), y = strength, z = additiveFactor, w unused
+};
+
+layout(std140) uniform TerrainLocalLightsData {
+	int numLights;
+	float _pad0;
+	vec2 _pad1;
+	TerrainLocalLight localLights[MAX_TERRAIN_LOCAL_LIGHTS];
+};
+
+#ifdef FRAGMENT_SHADER
+
+uniform vec3 PatchClipCentroid;
+
+void CalcTerrainLocalDiffuse(
+	out vec4 multiplyContrib,
+	out vec4 additiveContrib,
+	in vec3 surfacePosView,
+	in vec3 surfaceNormal)
+{
+	multiplyContrib = vec4(0.0);
+	additiveContrib = vec4(0.0);
+	if (numLights <= 0)
+		return;
+
+	for (int i = 0; i < numLights; ++i) {
+		vec3 posUnit = localLights[i].position.xyz;
+		vec3 lightViewPos = vec3(uViewMatrix * vec4(posUnit - PatchClipCentroid, 1.0));
+		vec3 toLight = lightViewPos - surfacePosView;
+		float dist = length(toLight);
+		float range = max(localLights[i].falloff.x, 1.0);
+		float strength = localLights[i].falloff.y;
+		float additiveFactor = clamp(localLights[i].falloff.z, 0.0, 1.0);
+
+		float t = clamp(dist / range, 0.0, 1.0);
+		float radial = 1.0 - t;
+
+		vec3 L = toLight / max(dist, 1e-4);
+		float ndotl = max(dot(surfaceNormal, L), 0.0);
+		const float normalFloor = 0.5;
+		float cosine = mix(normalFloor, 1.0, ndotl);
+
+		vec3 lit = localLights[i].colour.rgb * radial * strength * cosine;
+		multiplyContrib += vec4(lit * (1.0 - additiveFactor), 0.0);
+		additiveContrib += vec4(lit * additiveFactor, 0.0);
+	}
+}
+
+#endif // FRAGMENT_SHADER
+
+#endif // TERRAIN_LOCAL_LIGHTS_GLSL

--- a/src/BaseSphere.h
+++ b/src/BaseSphere.h
@@ -18,13 +18,15 @@ namespace Graphics {
 	}
 } // namespace Graphics
 
+class Planet;
+
 class BaseSphere {
 public:
 	BaseSphere(const SystemBody *body);
 	virtual ~BaseSphere();
 
 	virtual void Update() = 0;
-	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) = 0;
+	virtual void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows, const Camera *camera = nullptr, const Planet *planet = nullptr) = 0;
 
 	virtual double GetTerrainHeight(const vector3d &p) const = 0;
 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -23,6 +23,88 @@
 
 using namespace Graphics;
 
+namespace {
+	struct LocationSunLight {
+		double light = 0.0;
+		double light_clamped = 0.0;
+		double opticalThicknessFraction = 0.0;
+		bool valid = false;
+	};
+
+	static LocationSunLight CalcLocationSunLight(
+		const Planet *planet,
+		const vector3d &posRelToRotFrame,
+		const std::vector<Camera::LightSource> &lightSources)
+	{
+		LocationSunLight result;
+		if (!planet || lightSources.empty())
+			return result;
+
+		const FrameId rotFrame = planet->GetFrame();
+
+		vector3d upDir = posRelToRotFrame;
+		const double planetRadius = planet->GetSystemBody()->GetRadius();
+		const double dist = std::max(planetRadius, upDir.Length());
+		if (dist < 1.0)
+			return result;
+		upDir.Normalize();
+
+		double pressure, density;
+		planet->GetAtmosphericState(dist, &pressure, &density);
+
+		// approximate optical thickness fraction as fraction of density remaining relative to earths
+		result.opticalThicknessFraction = density / EARTH_ATMOSPHERE_SURFACE_DENSITY;
+
+		// tweak optical thickness curve - lower exponent ==> higher altitude before ambient level drops
+		// Commenting this out, since it leads to a sharp transition at
+		// atmosphereRadius, where density is suddenly 0
+		//result.opticalThicknessFraction = pow(std::max(0.00001, result.opticalThicknessFraction), 0.15); //max needed to avoid 0^power
+
+		// step through all the lights and calculate contributions taking into account sun position
+		for (const Camera::LightSource &source : lightSources) {
+			double sunAngle;
+			// calculate the extent the sun is towards zenith
+			const Body *lightBody = source.GetBody();
+			if (lightBody) {
+				// relative to the rotating frame of the planet
+				const vector3d lightDir = (lightBody->GetInterpPositionRelTo(rotFrame).Normalized());
+				sunAngle = lightDir.Dot(upDir);
+			} else {
+				// light is the default light for systems without lights
+				sunAngle = 1.0;
+			}
+
+			const double critAngle = -sqrt(dist * dist - planetRadius * planetRadius) / dist;
+
+			//0 to 1 as sunangle goes from critAngle to 1.0
+			double sunAngle2 = (Clamp(sunAngle, critAngle, 1.0) - critAngle) / (1.0 - critAngle);
+
+			// angle at which light begins to fade on Earth
+			const double surfaceStartAngle = 0.3;
+			// angle at which sun set completes, which should be after sun has dipped below the horizon on Earth
+			const double surfaceEndAngle = -0.18;
+
+			const double start = std::min((surfaceStartAngle * result.opticalThicknessFraction), 1.0);
+			const double end = std::max((surfaceEndAngle * result.opticalThicknessFraction), -0.2);
+
+			const double span = start - end;
+			if (span < 1e-6)
+				// No atmosphere: sharp day/night at the geometric horizon.
+				sunAngle = sunAngle2;
+			else
+				sunAngle = (Clamp(sunAngle - critAngle, end, start) - end) / span;
+
+			result.light += sunAngle;
+			result.light_clamped += sunAngle2;
+		}
+
+		result.light_clamped /= lightSources.size();
+		result.light /= lightSources.size();
+		result.valid = true;
+		return result;
+	}
+} // namespace
+
 // if a body would render smaller than this many pixels, just ignore it
 static const float OBJECT_HIDDEN_PIXEL_THRESHOLD = 2.0f;
 
@@ -375,79 +457,32 @@ void Camera::Draw(const Body *excludeBody)
 //    * As suns set the split is biased towards ambient
 void Camera::CalcLighting(const Body *b, double &ambient, double &direct) const
 {
+	Body *astro = Frame::GetFrame(b->GetFrame())->GetBody();
+	if (!astro) {
+		ambient = 0.05;
+		direct = 1.0;
+		return;
+	}
+
+	CalcLightingForLocation(static_cast<Planet *>(astro), b->GetInterpPositionRelTo(static_cast<Planet *>(astro)->GetFrame()), ambient, direct);
+}
+
+void Camera::CalcLightingForLocation(const Planet *planet, const vector3d &posRelToRotFrame, double &ambient, double &direct) const
+{
 	const double minAmbient = 0.05;
 	ambient = minAmbient;
 	direct = 1.0;
 
-	Body *astro = Frame::GetFrame(b->GetFrame())->GetBody();
-	if (!astro)
+	if (!planet)
 		return;
 
-	Planet *planet = static_cast<Planet *>(astro);
-	FrameId rotFrame = planet->GetFrame();
-
-	// position relative to the rotating frame of the planet
-	vector3d upDir = b->GetInterpPositionRelTo(rotFrame);
-	const double planetRadius = planet->GetSystemBody()->GetRadius();
-	const double dist = std::max(planetRadius, upDir.Length());
-	upDir.Normalize();
-
-	double pressure, density;
-	planet->GetAtmosphericState(dist, &pressure, &density);
-	double surfaceDensity;
-	Color cl;
-	planet->GetSystemBody()->GetAtmosphereFlavor(&cl, &surfaceDensity);
-
-	// approximate optical thickness fraction as fraction of density remaining relative to earths
-	double opticalThicknessFraction = density / EARTH_ATMOSPHERE_SURFACE_DENSITY;
-
-	// tweak optical thickness curve - lower exponent ==> higher altitude before ambient level drops
-	// Commenting this out, since it leads to a sharp transition at
-	// atmosphereRadius, where density is suddenly 0
-	//opticalThicknessFraction = pow(std::max(0.00001,opticalThicknessFraction),0.15); //max needed to avoid 0^power
-
-	if (opticalThicknessFraction < 0.0001)
+	const LocationSunLight sun = CalcLocationSunLight(planet, posRelToRotFrame, m_lightSources);
+	if (!sun.valid || sun.opticalThicknessFraction < 0.0001)
 		return;
 
-	//step through all the lights and calculate contributions taking into account sun position
-	double light = 0.0;
-	double light_clamped = 0.0;
-
-	const std::vector<Camera::LightSource> &lightSources = m_lightSources;
-	for (const LightSource &source : m_lightSources) {
-		double sunAngle;
-		// calculate the extent the sun is towards zenith
-		const Body *lightBody = source.GetBody();
-		if (lightBody) {
-			// relative to the rotating frame of the planet
-			const vector3d lightDir = (lightBody->GetInterpPositionRelTo(rotFrame).Normalized());
-			sunAngle = lightDir.Dot(upDir);
-		} else {
-			// light is the default light for systems without lights
-			sunAngle = 1.0;
-		}
-
-		const double critAngle = -sqrt(dist * dist - planetRadius * planetRadius) / dist;
-
-		//0 to 1 as sunangle goes from critAngle to 1.0
-		double sunAngle2 = (Clamp(sunAngle, critAngle, 1.0) - critAngle) / (1.0 - critAngle);
-
-		// angle at which light begins to fade on Earth
-		const double surfaceStartAngle = 0.3;
-		// angle at which sun set completes, which should be after sun has dipped below the horizon on Earth
-		const double surfaceEndAngle = -0.18;
-
-		const double start = std::min((surfaceStartAngle * opticalThicknessFraction), 1.0);
-		const double end = std::max((surfaceEndAngle * opticalThicknessFraction), -0.2);
-
-		sunAngle = (Clamp(sunAngle - critAngle, end, start) - end) / (start - end);
-
-		light += sunAngle;
-		light_clamped += sunAngle2;
-	}
-
-	light_clamped /= lightSources.size();
-	light /= lightSources.size();
+	const double light = sun.light;
+	const double light_clamped = sun.light_clamped;
+	const double opticalThicknessFraction = sun.opticalThicknessFraction;
 
 	// brightness depends on optical depth and intensity of light from all the stars
 	direct = 1.0 - Clamp((1.0 - light), 0.0, 1.0) * Clamp(opticalThicknessFraction, 0.0, 1.0);
@@ -463,6 +498,14 @@ void Camera::CalcLighting(const Body *b, double &ambient, double &direct) const
 	ambient = fraction * (Clamp((light), 0.0, 1.0)) * 0.25;
 
 	ambient = std::max(minAmbient, ambient);
+}
+
+double Camera::CalcSunVisibilityForLocation(const Planet *planet, const vector3d &posRelToRotFrame) const
+{
+	const LocationSunLight sun = CalcLocationSunLight(planet, posRelToRotFrame, m_lightSources);
+	if (!sun.valid)
+		return 1.0;
+	return sun.light;
 }
 
 void Camera::CalcShadows(const int lightNum, const Body *b, std::vector<Shadow> &shadowsOut) const

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -23,6 +23,88 @@
 
 using namespace Graphics;
 
+namespace {
+	struct LocationSunLight {
+		double light = 0.0;
+		double light_clamped = 0.0;
+		double opticalThicknessFraction = 0.0;
+		bool valid = false;
+	};
+
+	static LocationSunLight CalcLocationSunLight(
+		const Planet *planet,
+		const vector3d &posRelToRotFrame,
+		const std::vector<Camera::LightSource> &lightSources)
+	{
+		LocationSunLight result;
+		if (!planet || lightSources.empty())
+			return result;
+
+		const FrameId rotFrame = planet->GetFrame();
+
+		vector3d upDir = posRelToRotFrame;
+		const double planetRadius = planet->GetSystemBody()->GetRadius();
+		const double dist = std::max(planetRadius, upDir.Length());
+		if (dist < 1.0)
+			return result;
+		upDir.Normalize();
+
+		double pressure, density;
+		planet->GetAtmosphericState(dist, &pressure, &density);
+
+		// approximate optical thickness fraction as fraction of density remaining relative to earths
+		result.opticalThicknessFraction = density / EARTH_ATMOSPHERE_SURFACE_DENSITY;
+
+		// tweak optical thickness curve - lower exponent ==> higher altitude before ambient level drops
+		// Commenting this out, since it leads to a sharp transition at
+		// atmosphereRadius, where density is suddenly 0
+		//result.opticalThicknessFraction = pow(std::max(0.00001, result.opticalThicknessFraction), 0.15); //max needed to avoid 0^power
+
+		// step through all the lights and calculate contributions taking into account sun position
+		for (const Camera::LightSource &source : lightSources) {
+			double sunAngle;
+			// calculate the extent the sun is towards zenith
+			const Body *lightBody = source.GetBody();
+			if (lightBody) {
+				// relative to the rotating frame of the planet
+				const vector3d lightDir = (lightBody->GetInterpPositionRelTo(rotFrame).Normalized());
+				sunAngle = lightDir.Dot(upDir);
+			} else {
+				// light is the default light for systems without lights
+				sunAngle = 1.0;
+			}
+
+			const double critAngle = -sqrt(dist * dist - planetRadius * planetRadius) / dist;
+
+			//0 to 1 as sunangle goes from critAngle to 1.0
+			double sunAngle2 = (Clamp(sunAngle, critAngle, 1.0) - critAngle) / (1.0 - critAngle);
+
+			// angle at which light begins to fade on Earth
+			const double surfaceStartAngle = 0.3;
+			// angle at which sun set completes, which should be after sun has dipped below the horizon on Earth
+			const double surfaceEndAngle = -0.18;
+
+			const double start = std::min((surfaceStartAngle * result.opticalThicknessFraction), 1.0);
+			const double end = std::max((surfaceEndAngle * result.opticalThicknessFraction), -0.2);
+
+			const double span = start - end;
+			if (span < 1e-6)
+				// No atmosphere: sharp day/night at the geometric horizon.
+				sunAngle = sunAngle2;
+			else
+				sunAngle = (Clamp(sunAngle - critAngle, end, start) - end) / span;
+
+			result.light += sunAngle;
+			result.light_clamped += sunAngle2;
+		}
+
+		result.light_clamped /= lightSources.size();
+		result.light /= lightSources.size();
+		result.valid = true;
+		return result;
+	}
+} // namespace
+
 // if a body would render smaller than this many pixels, just ignore it
 static const float OBJECT_HIDDEN_PIXEL_THRESHOLD = 2.0f;
 
@@ -368,79 +450,32 @@ void Camera::Draw(const Body *excludeBody)
 //    * As suns set the split is biased towards ambient
 void Camera::CalcLighting(const Body *b, double &ambient, double &direct) const
 {
+	Body *astro = Frame::GetFrame(b->GetFrame())->GetBody();
+	if (!astro) {
+		ambient = 0.05;
+		direct = 1.0;
+		return;
+	}
+
+	CalcLightingForLocation(static_cast<Planet *>(astro), b->GetInterpPositionRelTo(static_cast<Planet *>(astro)->GetFrame()), ambient, direct);
+}
+
+void Camera::CalcLightingForLocation(const Planet *planet, const vector3d &posRelToRotFrame, double &ambient, double &direct) const
+{
 	const double minAmbient = 0.05;
 	ambient = minAmbient;
 	direct = 1.0;
 
-	Body *astro = Frame::GetFrame(b->GetFrame())->GetBody();
-	if (!astro)
+	if (!planet)
 		return;
 
-	Planet *planet = static_cast<Planet *>(astro);
-	FrameId rotFrame = planet->GetFrame();
-
-	// position relative to the rotating frame of the planet
-	vector3d upDir = b->GetInterpPositionRelTo(rotFrame);
-	const double planetRadius = planet->GetSystemBody()->GetRadius();
-	const double dist = std::max(planetRadius, upDir.Length());
-	upDir.Normalize();
-
-	double pressure, density;
-	planet->GetAtmosphericState(dist, &pressure, &density);
-	double surfaceDensity;
-	Color cl;
-	planet->GetSystemBody()->GetAtmosphereFlavor(&cl, &surfaceDensity);
-
-	// approximate optical thickness fraction as fraction of density remaining relative to earths
-	double opticalThicknessFraction = density / EARTH_ATMOSPHERE_SURFACE_DENSITY;
-
-	// tweak optical thickness curve - lower exponent ==> higher altitude before ambient level drops
-	// Commenting this out, since it leads to a sharp transition at
-	// atmosphereRadius, where density is suddenly 0
-	//opticalThicknessFraction = pow(std::max(0.00001,opticalThicknessFraction),0.15); //max needed to avoid 0^power
-
-	if (opticalThicknessFraction < 0.0001)
+	const LocationSunLight sun = CalcLocationSunLight(planet, posRelToRotFrame, m_lightSources);
+	if (!sun.valid || sun.opticalThicknessFraction < 0.0001)
 		return;
 
-	//step through all the lights and calculate contributions taking into account sun position
-	double light = 0.0;
-	double light_clamped = 0.0;
-
-	const std::vector<Camera::LightSource> &lightSources = m_lightSources;
-	for (const LightSource &source : m_lightSources) {
-		double sunAngle;
-		// calculate the extent the sun is towards zenith
-		const Body *lightBody = source.GetBody();
-		if (lightBody) {
-			// relative to the rotating frame of the planet
-			const vector3d lightDir = (lightBody->GetInterpPositionRelTo(rotFrame).Normalized());
-			sunAngle = lightDir.Dot(upDir);
-		} else {
-			// light is the default light for systems without lights
-			sunAngle = 1.0;
-		}
-
-		const double critAngle = -sqrt(dist * dist - planetRadius * planetRadius) / dist;
-
-		//0 to 1 as sunangle goes from critAngle to 1.0
-		double sunAngle2 = (Clamp(sunAngle, critAngle, 1.0) - critAngle) / (1.0 - critAngle);
-
-		// angle at which light begins to fade on Earth
-		const double surfaceStartAngle = 0.3;
-		// angle at which sun set completes, which should be after sun has dipped below the horizon on Earth
-		const double surfaceEndAngle = -0.18;
-
-		const double start = std::min((surfaceStartAngle * opticalThicknessFraction), 1.0);
-		const double end = std::max((surfaceEndAngle * opticalThicknessFraction), -0.2);
-
-		sunAngle = (Clamp(sunAngle - critAngle, end, start) - end) / (start - end);
-
-		light += sunAngle;
-		light_clamped += sunAngle2;
-	}
-
-	light_clamped /= lightSources.size();
-	light /= lightSources.size();
+	const double light = sun.light;
+	const double light_clamped = sun.light_clamped;
+	const double opticalThicknessFraction = sun.opticalThicknessFraction;
 
 	// brightness depends on optical depth and intensity of light from all the stars
 	direct = 1.0 - Clamp((1.0 - light), 0.0, 1.0) * Clamp(opticalThicknessFraction, 0.0, 1.0);
@@ -456,6 +491,14 @@ void Camera::CalcLighting(const Body *b, double &ambient, double &direct) const
 	ambient = fraction * (Clamp((light), 0.0, 1.0)) * 0.25;
 
 	ambient = std::max(minAmbient, ambient);
+}
+
+double Camera::CalcSunVisibilityForLocation(const Planet *planet, const vector3d &posRelToRotFrame) const
+{
+	const LocationSunLight sun = CalcLocationSunLight(planet, posRelToRotFrame, m_lightSources);
+	if (!sun.valid)
+		return 1.0;
+	return sun.light;
 }
 
 void Camera::CalcShadows(const int lightNum, const Body *b, std::vector<Shadow> &shadowsOut) const

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -442,7 +442,7 @@ void Camera::Draw(const Body *excludeBody)
 		illuminationFactor = Clamp(float(amb + direct), 0.08f, 1.0f);
 		illuminationFactor = std::pow(illuminationFactor, 1.5);
 	}
-	SfxManager::RenderAll(m_renderer, rootFrameId, camFrameId, illuminationFactor);
+	SfxManager::RenderAll(m_renderer, rootFrameId, camFrameId, illuminationFactor, this);
 }
 
 // Calculates the ambiently and directly lit portions of the lighting model taking into account the atmosphere and sun positions at a given location

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -18,6 +18,7 @@
 
 class Body;
 class Frame;
+class Planet;
 
 namespace Graphics {
 	class Material;
@@ -118,6 +119,8 @@ public:
 	};
 
 	void CalcLighting(const Body *b, double &ambient, double &direct) const;
+	// Sun visibility at a planet-surface location (0 = night, 1 = full day).
+	double CalcSunVisibilityForLocation(const Planet *planet, const vector3d &posRelToRotFrame) const;
 	void CalcInteriorLighting(const Body* b, Color4ub &sLight, double &sFac) const;
 	void CalcShadows(const int lightNum, const Body *b, std::vector<Shadow> &shadowsOut) const;
 	float ShadowedIntensity(const int lightNum, const Body *b) const;
@@ -136,6 +139,8 @@ public:
 	void RestoreLighting() const;
 
 private:
+	void CalcLightingForLocation(const Planet *planet, const vector3d &posRelToRotFrame, double &ambient, double &direct) const;
+
 	std::vector<float> oldLightIntensities;
 
 	RefCountedPtr<CameraContext> m_context;

--- a/src/CityOnPlanet.h
+++ b/src/CityOnPlanet.h
@@ -42,6 +42,7 @@ public:
 	void Render(Graphics::Renderer *r, const CameraContext *camera, const SpaceStation *station, const vector3d &viewCoords, const matrix4x4d &viewTransform);
 	inline Planet *GetPlanet() const { return m_planet; }
 	float GetClipRadius() const { return m_clipRadius; }
+	double GetCityRadius() const { return m_cityRadius; }
 
 	static void Init();
 	static void Uninit();

--- a/src/GasGiant.cpp
+++ b/src/GasGiant.cpp
@@ -606,8 +606,10 @@ void GasGiant::Update()
 	}
 }
 
-void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows)
+void GasGiant::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows, const Camera *camera, const Planet *planet)
 {
+	(void)camera;
+	(void)planet;
 	PROFILE_SCOPED()
 	if (!m_surfaceTexture.Valid()) {
 		// Use the fact that we have a patch as a latch to prevent repeat generation requests.

--- a/src/GasGiant.h
+++ b/src/GasGiant.h
@@ -36,7 +36,7 @@ public:
 	virtual ~GasGiant();
 
 	void Update() override;
-	void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
+	void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows, const Camera *camera = nullptr, const Planet *planet = nullptr) override;
 
 	double GetTerrainHeight(const vector3d &p) const final { return 0.0; }
 

--- a/src/GeoPatch.cpp
+++ b/src/GeoPatch.cpp
@@ -342,6 +342,7 @@ void GeoPatch::RenderImmediate(Graphics::Renderer *renderer, const vector3d &cam
 		const float fDetailFrequency = pow(2.0f, float(m_geosphere->GetMaxDepth()) - float(m_depth));
 
 		m_geosphere->GetSurfaceMaterial()->SetPushConstant("PatchDetailFrequency"_hash, fDetailFrequency);
+		m_geosphere->GetSurfaceMaterial()->SetPushConstant("PatchClipCentroid"_hash, vector3f(m_clipCentroid));
 		renderer->DrawMesh(m_patchVBOData->m_patchMesh.get(), m_geosphere->GetSurfaceMaterial().Get());
 
 #if DEBUG_CENTROIDS

--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -9,6 +9,7 @@
 #include "GeoPatchJobs.h"
 #include "Pi.h"
 #include "RefCounted.h"
+#include "TerrainLocalLights.h"
 #include "galaxy/AtmosphereParameters.h"
 #include "galaxy/StarSystem.h"
 #include "graphics/Drawables.h"
@@ -399,7 +400,7 @@ void GeoSphere::ProcessQuadSplitRequests()
 	mQuadSplitRequests.clear();
 }
 
-void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows)
+void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows, const Camera *camera, const Planet *planet)
 {
 	PROFILE_SCOPED()
 	// store this for later usage in the update method.
@@ -426,6 +427,9 @@ void GeoSphere::Render(Graphics::Renderer *renderer, const matrix4x4d &modelView
 
 	//Update material parameters
 	SetMaterialParameters(trans, radius, shadows, m_atmosphereParameters);
+
+	if (planet && camera && m_surfaceMaterial.Valid())
+		TerrainLocalLights::UploadToMaterial(m_surfaceMaterial.Get(), camera, planet, radius);
 
 	if (m_atmosphereMaterial.Valid() && m_atmosphereParameters.atmosDensity > 0.0) {
 		// make atmosphere sphere slightly bigger than required so

--- a/src/GeoSphere.h
+++ b/src/GeoSphere.h
@@ -33,7 +33,7 @@ public:
 	virtual ~GeoSphere();
 
 	void Update() override;
-	void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows) override;
+	void Render(Graphics::Renderer *renderer, const matrix4x4d &modelView, vector3d campos, const float radius, const std::vector<Camera::Shadow> &shadows, const Camera *camera = nullptr, const Planet *planet = nullptr) override;
 
 	double GetTerrainHeight(const vector3d &p) const final
 	{

--- a/src/NavLights.cpp
+++ b/src/NavLights.cpp
@@ -237,3 +237,51 @@ void NavLights::SetMask(unsigned int group, uint8_t mask)
 		light.mask = mask;
 	}
 }
+
+namespace {
+Color4f GetLightColorRGB(NavLights::LightColor c)
+{
+	switch (c) {
+	case NavLights::NAVLIGHT_RED:
+		return Color4f(1.f, 0.15f, 0.05f, 1.f);
+	case NavLights::NAVLIGHT_GREEN:
+		return Color4f(0.05f, 1.f, 0.15f, 1.f);
+	case NavLights::NAVLIGHT_BLUE:
+		return Color4f(0.2f, 0.4f, 1.f, 1.f);
+	case NavLights::NAVLIGHT_YELLOW:
+		return Color4f(1.f, 0.85f, 0.1f, 1.f);
+	default:
+		return Color4f(0.f, 0.f, 0.f, 0.f);
+	}
+}
+} // namespace
+
+Color4f NavLights::GetActiveLightColor() const
+{
+	if (!m_enabled)
+		return Color4f(0.f, 0.f, 0.f, 0.f);
+
+	const int phase((fmod(m_time, m_period) / m_period) * 8);
+	const Uint8 mask = 1 << phase;
+
+	Color4f sum(0.f, 0.f, 0.f, 0.f);
+	for (const auto &group : m_groupLights) {
+		for (const LightBulb &light : group.second) {
+			if (light.color == LightColor::NAVLIGHT_OFF)
+				continue;
+			if (!(light.mask & mask))
+				continue;
+			const Color4f c = GetLightColorRGB(LightColor(light.color));
+			sum.r += c.r;
+			sum.g += c.g;
+			sum.b += c.b;
+		}
+	}
+
+	if (sum.r + sum.g + sum.b <= 0.f)
+		return Color4f(0.f, 0.f, 0.f, 0.f);
+
+	const float brightest = std::max(sum.r, std::max(sum.g, sum.b));
+
+	return Color4f(sum.r / brightest, sum.g / brightest, sum.b / brightest);
+}

--- a/src/NavLights.h
+++ b/src/NavLights.h
@@ -6,6 +6,7 @@
 /*
  * Blinking navigation lights for ships and stations
  */
+#include "Color.h"
 #include "JsonFwd.h"
 #include "graphics/VertexArray.h"
 #include "graphics/VertexBuffer.h"
@@ -46,6 +47,8 @@ public:
 	void Render(Graphics::Renderer *renderer);
 	void SetColor(unsigned int group, LightColor);
 	void SetMask(unsigned int group, uint8_t mask);
+
+	Color4f GetActiveLightColor() const;
 
 	static void Init(Graphics::Renderer *);
 	static void Uninit();

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -13,7 +13,9 @@
 #include "MathUtil.h"
 #include "ModelBody.h"
 #include "Pi.h"
+#include "Ship.h"
 #include "Space.h"
+#include "TerrainLocalLights.h"
 #include "matrix3x3.h"
 #include "matrix4x4.h"
 
@@ -459,7 +461,7 @@ void SfxManager::Cleanup()
 	}
 }
 
-void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, float illuminationFactor)
+void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, float illuminationFactor, const Camera *camera)
 {
 	PROFILE_SCOPED()
 
@@ -532,9 +534,28 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 				std::vector<ExhaustInstanceData> exhaustInstances;
 				exhaustInstances.reserve(numInstances);
 
+				const Body *cachedEmitter = nullptr;
+				Color4f shipLocalLight(0.f, 0.f, 0.f, 0.f);
+				vector3f shipCamPos(0.f);
+				bool haveShipLocalLight = false;
+
 				for (const auto &jetBucket : s_exhaustByJet) {
 					const Sfx *prevStreakParticle = nullptr;
 					vector3f prevInterpBackboneCam = vector3f(0.f);
+
+					const Body *emitter = jetBucket.second.empty() ? nullptr : jetBucket.second.front()->m_exhaustEmitter;
+					if (emitter != cachedEmitter) {
+						cachedEmitter = emitter;
+						shipLocalLight = Color4f(0.f, 0.f, 0.f, 0.f);
+						haveShipLocalLight = false;
+						if (camera && emitter && emitter->IsType(ObjectType::SHIP)) {
+							const Ship *ship = static_cast<const Ship *>(emitter);
+							shipLocalLight = TerrainLocalLights::CalcShipSelfIllumination(camera, ship);
+							// Exhaust particles are stored in the emitter's frame - match that for illumination distance falloff
+							shipCamPos = vector3f(ftran * ship->GetInterpPositionRelTo(fId));
+							haveShipLocalLight = (shipLocalLight.r + shipLocalLight.g + shipLocalLight.b) > 0.f;
+						}
+					}
 
 					for (Sfx *instPtr : jetBucket.second) {
 						Sfx &inst(*instPtr);
@@ -590,9 +611,19 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 							particleColor = Color(255, 255, 255, opacityA);
 						}
 
-						particleColor.r = Uint8(Clamp(int(float(particleColor.r) * illuminationFactor), 0, 255));
-						particleColor.g = Uint8(Clamp(int(float(particleColor.g) * illuminationFactor), 0, 255));
-						particleColor.b = Uint8(Clamp(int(float(particleColor.b) * illuminationFactor), 0, 255));
+						// At night time we add ship nav-lights and thruster glow to the exhaust illumination, using a distance falloff.
+						float addR = 0.f, addG = 0.f, addB = 0.f;
+						if (haveShipLocalLight) {
+							const float dist = (pos - shipCamPos).Length();
+							const float radial = 1.f - Clamp(dist / SfxParams::EXHAUST_ILLUMINATION_DISTANCE, 0.f, 1.f);
+							addR = shipLocalLight.r * radial;
+							addG = shipLocalLight.g * radial;
+							addB = shipLocalLight.b * radial;
+						}
+
+						particleColor.r = Uint8(Clamp(int(float(particleColor.r) * illuminationFactor + addR * 255.f), 0, 255));
+						particleColor.g = Uint8(Clamp(int(float(particleColor.g) * illuminationFactor + addG * 255.f), 0, 255));
+						particleColor.b = Uint8(Clamp(int(float(particleColor.b) * illuminationFactor + addB * 255.f), 0, 255));
 
 						const float stretchScale = (prevWasDust || inst.m_exhaustDustKick) ? 0.f : 1.f;
 
@@ -650,7 +681,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 	}
 
 	for (FrameId kid : f->GetChildren()) {
-		RenderAll(renderer, kid, camFrameId, illuminationFactor);
+		RenderAll(renderer, kid, camFrameId, illuminationFactor, camera);
 	}
 }
 

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -14,6 +14,7 @@
 #include <deque>
 
 class Body;
+class Camera;
 class Frame;
 class Space;
 
@@ -41,6 +42,7 @@ namespace SfxParams {
 	inline constexpr float EXHAUST_PARTICLES_PER_SHIP_PER_SEC = 1800.0f;
 	inline constexpr float EXHAUST_MIN_REACTION_POWER = 0.02f;
 	inline constexpr float EXHAUST_STREAM_TIMESTEP_CAP = 0.1f;
+	inline constexpr float EXHAUST_ILLUMINATION_DISTANCE = 400.0f;
 	inline constexpr float EXHAUST_DUST_RADIAL_KICK_SPEED = 24.0f;
 	inline constexpr float EXHAUST_DUST_TANGENT_KICK_SPEED = 38.0f;
 	inline constexpr float EXHAUST_DUST_LOWEST_NON_CULL_PROB = 0.05f;	// Keep at least one in 20 particles
@@ -116,7 +118,7 @@ public:
 	static void AddThrustSmoke(const Body *b, float speed, const vector3d &adjustpos);
 	static void AddExhaust(const Body *b, Uint16 exhaustJetIndex, bool exhaustSuppressStreakElongation, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3f &plumeOffset, const vector3f &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3f &windVel, double groundRadius, const Color &dustTint);
 	static void TimeStepAll(const float timeStep, FrameId f);
-	static void RenderAll(Graphics::Renderer *r, FrameId f, FrameId camFrame, float illuminationFactor = 1.f);
+	static void RenderAll(Graphics::Renderer *r, FrameId f, FrameId camFrame, float illuminationFactor = 1.f, const Camera *camera = nullptr);
 	static void ToJson(Json &jsonObj, const FrameId f, const Space *space);
 	static void FromJson(const Json &jsonObj, FrameId f);
 

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1723,6 +1723,65 @@ bool Ship::SetWheelState(bool down)
 	return true;
 }
 
+Color4f Ship::GetNavLightTerrainColor() const
+{
+	if (!m_navLights)
+		return Color4f(0.f, 0.f, 0.f, 0.f);
+	return m_navLights->GetActiveLightColor();
+}
+
+bool Ship::GetThrusterTerrainLight(Color4f &color, float &intensity) const
+{
+	const SceneGraph::Model *model = GetModel();
+	const float displayPower = model ? model->GetMaxThrusterDisplayedPower() : 0.f;
+	if (displayPower < 0.01f)
+		return false;
+
+	const vector3d actualLin = m_propulsion->GetActualLinThrust();
+	const vector3d actualAng = m_propulsion->GetActualAngThrust();
+	const double linPower = actualLin.Length();
+	const double angPower = actualAng.Length() * 0.5;
+	const double currentPower = std::max(linPower, angPower);
+
+	double maxPower = 0.0;
+	for (int t = THRUSTER_REVERSE; t < THRUSTER_MAX; ++t)
+		maxPower = std::max(maxPower, m_propulsion->GetThrust(Thruster(t)));
+
+	if (maxPower <= 0.0)
+		return false;
+
+	static const Color defaultColor(178, 153, 255, 255);
+	Color c = defaultColor;
+
+	if (linPower >= angPower && linPower > 0.0) {
+		const vector3d lin = m_propulsion->GetLinThrusterState();
+		int axis = 0;
+		double maxComp = std::fabs(lin.x);
+		if (std::fabs(lin.y) > maxComp) {
+			axis = 1;
+			maxComp = std::fabs(lin.y);
+		}
+		if (std::fabs(lin.z) > maxComp)
+			axis = 2;
+
+		static const Thruster posThrusters[3] = { THRUSTER_RIGHT, THRUSTER_UP, THRUSTER_REVERSE };
+		static const Thruster negThrusters[3] = { THRUSTER_LEFT, THRUSTER_DOWN, THRUSTER_FORWARD };
+		const Thruster t = lin[axis] >= 0.0 ? posThrusters[axis] : negThrusters[axis];
+
+		if (m_type->isGlobalColorDefined)
+			c = m_type->globalThrusterColor;
+		else if (m_type->isDirectionColorDefined[t])
+			c = m_type->directionThrusterColor[t];
+	} else if (m_type->isGlobalColorDefined) {
+		c = m_type->globalThrusterColor;
+	}
+
+	color = Color4f(c.r / 255.f, c.g / 255.f, c.b / 255.f, 1.f);
+	const float thrustScale = float(std::min(currentPower / maxPower, 1.0));
+	intensity = displayPower * thrustScale;
+	return true;
+}
+
 void Ship::Render(Graphics::Renderer *renderer, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform)
 {
 	if (IsDead()) return;

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1427,6 +1427,65 @@ bool Ship::SetWheelState(bool down)
 	return true;
 }
 
+Color4f Ship::GetNavLightTerrainColor() const
+{
+	if (!m_navLights)
+		return Color4f(0.f, 0.f, 0.f, 0.f);
+	return m_navLights->GetActiveLightColor();
+}
+
+bool Ship::GetThrusterTerrainLight(Color4f &color, float &intensity) const
+{
+	const SceneGraph::Model *model = GetModel();
+	const float displayPower = model ? model->GetMaxThrusterDisplayedPower() : 0.f;
+	if (displayPower < 0.01f)
+		return false;
+
+	const vector3d actualLin = m_propulsion->GetActualLinThrust();
+	const vector3d actualAng = m_propulsion->GetActualAngThrust();
+	const double linPower = actualLin.Length();
+	const double angPower = actualAng.Length() * 0.5;
+	const double currentPower = std::max(linPower, angPower);
+
+	double maxPower = 0.0;
+	for (int t = THRUSTER_REVERSE; t < THRUSTER_MAX; ++t)
+		maxPower = std::max(maxPower, m_propulsion->GetThrust(Thruster(t)));
+
+	if (maxPower <= 0.0)
+		return false;
+
+	static const Color defaultColor(178, 153, 255, 255);
+	Color c = defaultColor;
+
+	if (linPower >= angPower && linPower > 0.0) {
+		const vector3d lin = m_propulsion->GetLinThrusterState();
+		int axis = 0;
+		double maxComp = std::fabs(lin.x);
+		if (std::fabs(lin.y) > maxComp) {
+			axis = 1;
+			maxComp = std::fabs(lin.y);
+		}
+		if (std::fabs(lin.z) > maxComp)
+			axis = 2;
+
+		static const Thruster posThrusters[3] = { THRUSTER_RIGHT, THRUSTER_UP, THRUSTER_REVERSE };
+		static const Thruster negThrusters[3] = { THRUSTER_LEFT, THRUSTER_DOWN, THRUSTER_FORWARD };
+		const Thruster t = lin[axis] >= 0.0 ? posThrusters[axis] : negThrusters[axis];
+
+		if (m_type->isGlobalColorDefined)
+			c = m_type->globalThrusterColor;
+		else if (m_type->isDirectionColorDefined[t])
+			c = m_type->directionThrusterColor[t];
+	} else if (m_type->isGlobalColorDefined) {
+		c = m_type->globalThrusterColor;
+	}
+
+	color = Color4f(c.r / 255.f, c.g / 255.f, c.b / 255.f, 1.f);
+	const float thrustScale = float(std::min(currentPower / maxPower, 1.0));
+	intensity = displayPower * thrustScale;
+	return true;
+}
+
 void Ship::Render(Graphics::Renderer *renderer, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform)
 {
 	if (IsDead()) return;

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <deque>
 
+#include "Color.h"
 #include "DynamicBody.h"
 #include "ShipType.h"
 #include "galaxy/SystemPath.h"
@@ -359,6 +360,10 @@ public:
 	bool AIMatchVel(const vector3d &vel, const vector3d &powerLimit = vector3d(1.0)) { return m_propulsion->AIMatchVel(vel, powerLimit); }
 	double AIFaceDirection(const vector3d &dir, double av = 0) { return m_propulsion->AIFaceDirection(dir, av); }
 	void SetThrusterState(int axis, double level) { return m_propulsion->SetLinThrusterState(axis, level); }
+
+	Color4f GetNavLightTerrainColor() const;
+	bool GetThrusterTerrainLight(Color4f &color, float &intensity) const;
+
 	void AIMatchAngVelObjSpace(const vector3d &desiredAngVel, const vector3d &powerLimit = vector3d(1.0), bool ignoreZeroValues = false)
 	{
 		m_propulsion->AIMatchAngVelObjSpace(desiredAngVel, powerLimit, ignoreZeroValues);

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <deque>
 
+#include "Color.h"
 #include "DynamicBody.h"
 #include "ShipType.h"
 #include "galaxy/SystemPath.h"
@@ -385,6 +386,10 @@ public:
 	bool AIMatchVel(const vector3d &vel, const vector3d &powerLimit = vector3d(1.0)) { return m_propulsion->AIMatchVel(vel, powerLimit); }
 	double AIFaceDirection(const vector3d &dir, double av = 0) { return m_propulsion->AIFaceDirection(dir, av); }
 	void SetThrusterState(int axis, double level) { return m_propulsion->SetLinThrusterState(axis, level); }
+
+	Color4f GetNavLightTerrainColor() const;
+	bool GetThrusterTerrainLight(Color4f &color, float &intensity) const;
+
 	void AIMatchAngVelObjSpace(const vector3d &desiredAngVel, const vector3d &powerLimit = vector3d(1.0), bool ignoreZeroValues = false)
 	{
 		m_propulsion->AIMatchAngVelObjSpace(desiredAngVel, powerLimit, ignoreZeroValues);

--- a/src/SpaceStation.cpp
+++ b/src/SpaceStation.cpp
@@ -777,6 +777,20 @@ bool SpaceStation::IsGroundStation() const
 	return m_type->IsSurfaceStation();
 }
 
+// Return the radius of a planetside station complex within which lights from the buildings should illuminate the terrain at night
+float SpaceStation::GetTerrainLocalLightRange() const
+{
+	static constexpr float MIN_RANGE = 500.f;
+
+	if (m_adjacentCity)
+		return std::max(MIN_RANGE, float(1.5 * m_adjacentCity->GetCityRadius()));
+
+	if (IsGroundStation())
+		return std::max(MIN_RANGE, float(1.5 * GetClipRadius()));
+
+	return MIN_RANGE;
+}
+
 // Renders space station and adjacent city if applicable
 static const double SQRMAXCITYDIST = 1e5 * 1e5;
 

--- a/src/SpaceStation.h
+++ b/src/SpaceStation.h
@@ -74,6 +74,7 @@ public:
 
 	const SpaceStationType *GetStationType() const { return m_type; }
 	bool IsGroundStation() const;
+	float GetTerrainLocalLightRange() const;
 
 	bool AllocateStaticSlot(int &slot);
 

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -8,6 +8,7 @@
 #include "GasGiant.h"
 #include "GeoSphere.h"
 #include "Json.h"
+#include "Planet.h"
 #include "Space.h"
 #include "galaxy/SystemBody.h"
 #include "graphics/Renderer.h"
@@ -114,7 +115,8 @@ void TerrainBody::Render(Graphics::Renderer *renderer, const Camera *camera, con
 	ftran.Scale(rad, rad, rad);
 
 	// translation not applied until patch render to fix jitter
-	m_baseSphere->Render(renderer, ftran, -campos, m_sbody->GetRadius(), shadows);
+	m_baseSphere->Render(renderer, ftran, -campos, m_sbody->GetRadius(), shadows, camera,
+		IsType(ObjectType::PLANET) ? static_cast<const Planet *>(this) : nullptr);
 
 	ftran.Translate(campos.x, campos.y, campos.z);
 	SubRender(renderer, ftran, campos);

--- a/src/TerrainLocalLights.cpp
+++ b/src/TerrainLocalLights.cpp
@@ -130,6 +130,7 @@ namespace {
 		// When a ship is docked, or close to a station, the blinking nav lights are kind of annoying and also don't
 		// look realistic because the station is covered in lights so should be illuminated pretty well already.
 		// So we dim the ship's lights as it gets closer to the centre of the station's illumination range.
+		static constexpr float CITY_LIGHT_MIN_FACTOR = 0.25f;
 
 		const Ship::FlightState flightState = ship->GetFlightState();
 		if (flightState == Ship::DOCKED || flightState == Ship::DOCKING || flightState == Ship::UNDOCKING)
@@ -154,7 +155,7 @@ namespace {
 			const float t = span > 0.f
 				? std::max(0.f, std::min(1.f, (dist - suppressMin) / span))
 				: 0.f;
-			factor = std::min(factor, t);
+			factor = std::min(factor, CITY_LIGHT_MIN_FACTOR + (1.f - CITY_LIGHT_MIN_FACTOR) * t);
 		}
 
 		return factor;
@@ -283,4 +284,44 @@ void TerrainLocalLights::UploadToMaterial(
 		FillLightGPU(block.lights[i], candidates[i], planetRadius);
 
 	UploadBlock(material, block);
+}
+
+Color4f TerrainLocalLights::CalcShipSelfIllumination(const Camera *camera, const Ship *ship)
+{
+	Color4f contrib(0.f, 0.f, 0.f, 0.f);
+
+	Body *astro = Frame::GetFrame(ship->GetFrame())->GetBody();
+	if (!astro || !astro->IsType(ObjectType::PLANET))
+		return contrib;
+
+	const Planet *planet = static_cast<const Planet *>(astro);
+	const FrameId planetFrame = planet->GetFrame();
+	const vector3d shipPosPlanet = ship->GetInterpPositionRelTo(planetFrame);
+	const float nightTime = CalcNightTime(camera, planet, shipPosPlanet);
+	if (nightTime <= 0.f)
+		return contrib;
+
+	const float stationAtten = CalcShipStationLightAttenuation(ship, planet, planetFrame);
+	if (stationAtten <= 0.f)
+		return contrib;
+
+	const Color4f navColor = ship->GetNavLightTerrainColor();
+	if (navColor.r + navColor.g + navColor.b > 0.f) {
+		const float strength = SHIP_NAV_LIGHT_STRENGTH * nightTime * stationAtten;
+		contrib.r += navColor.r * strength;
+		contrib.g += navColor.g * strength;
+		contrib.b += navColor.b * strength;
+	}
+
+	Color4f thrusterColor;
+	float thrustLevel = 0.f;
+	if (ship->GetThrusterTerrainLight(thrusterColor, thrustLevel)) {
+		const float strength =
+			SHIP_THRUSTER_LIGHT_STRENGTH * thrustLevel * CalcThrusterLightFlicker(ship) * nightTime * stationAtten;
+		contrib.r += thrusterColor.r * strength;
+		contrib.g += thrusterColor.g * strength;
+		contrib.b += thrusterColor.b * strength;
+	}
+
+	return contrib;
 }

--- a/src/TerrainLocalLights.cpp
+++ b/src/TerrainLocalLights.cpp
@@ -1,0 +1,286 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "TerrainLocalLights.h"
+
+#include "Camera.h"
+#include "Color.h"
+#include "Frame.h"
+#include "Game.h"
+#include "Pi.h"
+#include "Planet.h"
+#include "Player.h"
+#include "Ship.h"
+#include "Space.h"
+#include "SpaceStation.h"
+#include "Random.h"
+#include "core/Log.h"
+#include "core/StringHash.h"
+
+#include "graphics/Material.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace {
+	static const int MAX_TERRAIN_LOCAL_LIGHTS = 16;
+	static const double MAX_SCAN_DISTANCE = 20000.0;
+
+	// Ship lights and starports only illuminate the terrain at night, this is the threshold below which they start showing
+	static const float NIGHT_LIGHT_THRESHOLD = 0.4f;
+
+	static const float SHIP_NAV_LIGHT_RANGE = 600.f;
+	static const float SHIP_NAV_LIGHT_STRENGTH = 0.5f;
+
+	static const float SHIP_THRUSTER_LIGHT_RANGE = 1200.f;
+	static const float SHIP_THRUSTER_LIGHT_STRENGTH = 0.8f;
+	static const float SHIP_THRUSTER_ADDITIVE_FACTOR = 0.5f;
+	static const float SHIP_THRUSTER_FLICKER = 0.15f;
+
+	static const float STARPORT_LIGHT_STRENGTH = 0.6f;
+	static const Color4f STARPORT_LIGHT_COLOR(1.f, 0.9f, 0.7f, 1.f);
+
+	struct TerrainLocalLightGPU {
+		Color4f position;
+		Color4f colour;
+		Color4f falloff; // x = range (meters), y = strength, z = additiveFactor
+	};
+
+	struct TerrainLocalLightsBlock {
+		int32_t numLights;
+		float _pad[3];
+		TerrainLocalLightGPU lights[MAX_TERRAIN_LOCAL_LIGHTS];
+	};
+	static_assert(sizeof(TerrainLocalLightsBlock) == 16 + MAX_TERRAIN_LOCAL_LIGHTS * 48, "");
+
+	static size_t s_terrainLocalLightsData = "TerrainLocalLightsData"_hash;
+	static bool s_loggedUploadFailure = false;
+
+	struct LightCandidate {
+		double distSq;
+		vector3d posPlanet;
+		Color4f colour;
+		float range;
+		float strength;
+		float additiveFactor;
+	};
+
+	static bool BodyOrbitsPlanet(const Body *body, const Planet *planet)
+	{
+		Frame *bodyFrame = Frame::GetFrame(body->GetFrame());
+		Frame *planetFrame = Frame::GetFrame(planet->GetFrame());
+		if (!bodyFrame || !planetFrame)
+			return false;
+		return bodyFrame->GetNonRotFrame() == planetFrame->GetNonRotFrame();
+	}
+
+	static float CalcNightTime(const Camera *camera, const Planet *planet, const vector3d &posRelToPlanet)
+	{
+		const double sunVisibility = camera->CalcSunVisibilityForLocation(planet, posRelToPlanet);
+		if (!std::isfinite(sunVisibility) || sunVisibility >= NIGHT_LIGHT_THRESHOLD)
+			return 0.f;
+
+		return float(1.0 - (sunVisibility / NIGHT_LIGHT_THRESHOLD));
+	}
+
+	static void UploadBlock(Graphics::Material *material, TerrainLocalLightsBlock &block)
+	{
+		if (!material->SetBufferDynamic(s_terrainLocalLightsData, &block)) {
+			if (!s_loggedUploadFailure) {
+				Log::Warning("TerrainLocalLights: failed to upload TerrainLocalLightsData (restart after shader changes)\n");
+				s_loggedUploadFailure = true;
+			}
+		}
+	}
+
+	static void TryAddLight(
+		const vector3d &posPlanet,
+		const vector3d &playerPosPlanet,
+		const Color4f &colour,
+		float range,
+		float strength,
+		float additiveFactor,
+		std::vector<LightCandidate> &candidates)
+	{
+		if (colour.r + colour.g + colour.b <= 0.f)
+			return;
+
+		if (strength <= 0.f || !std::isfinite(strength))
+			return;
+
+		if ((posPlanet - playerPosPlanet).LengthSqr() > MAX_SCAN_DISTANCE * MAX_SCAN_DISTANCE)
+			return;
+
+		LightCandidate c{};
+		c.distSq = (posPlanet - playerPosPlanet).LengthSqr();
+		c.posPlanet = posPlanet;
+		c.colour = colour;
+		c.range = range;
+		c.strength = strength;
+		c.additiveFactor = additiveFactor;
+		candidates.push_back(c);
+	}
+
+	static float CalcShipStationLightAttenuation(
+		const Ship *ship,
+		const Planet *planet,
+		const FrameId planetFrame)
+	{
+		// When a ship is docked, or close to a station, the blinking nav lights are kind of annoying and also don't
+		// look realistic because the station is covered in lights so should be illuminated pretty well already.
+		// So we dim the ship's lights as it gets closer to the centre of the station's illumination range.
+
+		const Ship::FlightState flightState = ship->GetFlightState();
+		if (flightState == Ship::DOCKED || flightState == Ship::DOCKING || flightState == Ship::UNDOCKING)
+			return 0.f;
+
+		const vector3d shipPos = ship->GetInterpPositionRelTo(planetFrame);
+		float factor = 1.f;
+
+		for (Body *body : Pi::game->GetSpace()->GetBodies()) {
+			if (!body->IsType(ObjectType::SPACESTATION))
+				continue;
+
+			const SpaceStation *station = static_cast<const SpaceStation *>(body);
+			if (!station->IsGroundStation() || !BodyOrbitsPlanet(station, planet))
+				continue;
+
+			const vector3d stationPos = station->GetInterpPositionRelTo(planetFrame);
+			const float dist = float((shipPos - stationPos).Length());
+			const float suppressMax = station->GetTerrainLocalLightRange();
+			const float suppressMin = suppressMax * 0.5f;
+			const float span = suppressMax - suppressMin;
+			const float t = span > 0.f
+				? std::max(0.f, std::min(1.f, (dist - suppressMin) / span))
+				: 0.f;
+			factor = std::min(factor, t);
+		}
+
+		return factor;
+	}
+
+	static float CalcThrusterLightFlicker(const Ship *ship)
+	{
+		const uint32_t tick = uint32_t(Pi::game->GetTime() / std::max(Pi::game->GetTimeStep(), 1e-6f));
+		Random rng({ tick, uint32_t(uintptr_t(ship)) });
+		return 1.f - float(rng.Double()) * SHIP_THRUSTER_FLICKER;
+	}
+
+	static void TryAddStarportLight(
+		const SpaceStation *station,
+		const Planet *planet,
+		const FrameId planetFrame,
+		const vector3d &playerPosPlanet,
+		float nightTime,
+		std::vector<LightCandidate> &candidates)
+	{
+		if (!station->IsGroundStation() || !BodyOrbitsPlanet(station, planet))
+			return;
+
+		const vector3d posPlanet = station->GetInterpPositionRelTo(planetFrame);
+		const float range = station->GetTerrainLocalLightRange();
+		const float strength = STARPORT_LIGHT_STRENGTH * nightTime;
+		TryAddLight(posPlanet, playerPosPlanet, STARPORT_LIGHT_COLOR, range, strength, 0.f, candidates);
+	}
+
+	static void TryAddShipLights(
+		const Ship *ship,
+		const Planet *planet,
+		const FrameId planetFrame,
+		const vector3d &playerPosPlanet,
+		float nightTime,
+		std::vector<LightCandidate> &candidates)
+	{
+		if (!BodyOrbitsPlanet(ship, planet))
+			return;
+
+		const vector3d posPlanet = ship->GetInterpPositionRelTo(planetFrame);
+		const float stationAtten = CalcShipStationLightAttenuation(ship, planet, planetFrame);
+
+		const Color4f navColor = ship->GetNavLightTerrainColor();
+		if (navColor.r + navColor.g + navColor.b > 0.f) {
+			TryAddLight(
+				posPlanet, playerPosPlanet, navColor,
+				SHIP_NAV_LIGHT_RANGE, SHIP_NAV_LIGHT_STRENGTH * nightTime * stationAtten, 0.f, candidates);
+		}
+
+		Color4f thrusterColor;
+		float thrustLevel = 0.f;
+		if (!ship->GetThrusterTerrainLight(thrusterColor, thrustLevel))
+			return;
+
+		TryAddLight(
+			posPlanet, playerPosPlanet, thrusterColor,
+			SHIP_THRUSTER_LIGHT_RANGE,
+			SHIP_THRUSTER_LIGHT_STRENGTH * thrustLevel * CalcThrusterLightFlicker(ship) * nightTime * stationAtten,
+			SHIP_THRUSTER_ADDITIVE_FACTOR, candidates);
+	}
+
+	static void FillLightGPU(
+		TerrainLocalLightGPU &gpu,
+		const LightCandidate &c,
+		double planetRadius)
+	{
+		gpu.position = Color4f(
+			float(c.posPlanet.x / planetRadius),
+			float(c.posPlanet.y / planetRadius),
+			float(c.posPlanet.z / planetRadius),
+			0.f);
+		gpu.colour = Color4f(c.colour.r, c.colour.g, c.colour.b, 0.f);
+		gpu.falloff = Color4f(c.range, c.strength, c.additiveFactor, 0.f);
+	}
+
+} // namespace
+
+void TerrainLocalLights::UploadToMaterial(
+	Graphics::Material *material,
+	const Camera *camera,
+	const Planet *planet,
+	double planetRadius)
+{
+	TerrainLocalLightsBlock block{};
+	if (!material)
+		return;
+
+	if (planetRadius <= 0.0)
+		planetRadius = 1.0;
+
+	if (!camera || !planet || !Pi::game) {
+		UploadBlock(material, block);
+		return;
+	}
+
+	Player *player = Pi::game->GetPlayer();
+	if (!player || !BodyOrbitsPlanet(player, planet)) {
+		UploadBlock(material, block);
+		return;
+	}
+
+	const FrameId planetFrame = planet->GetFrame();
+	const vector3d playerPosPlanet = player->GetInterpPositionRelTo(planetFrame);
+
+	const float nightTime = CalcNightTime(camera, planet, playerPosPlanet);
+
+	std::vector<LightCandidate> candidates;
+	candidates.reserve(32);
+
+	for (Body *body : Pi::game->GetSpace()->GetBodies()) {
+		if (body->IsType(ObjectType::SPACESTATION)) {
+			TryAddStarportLight(static_cast<const SpaceStation *>(body), planet, planetFrame, playerPosPlanet, nightTime, candidates);
+		} else if (body->IsType(ObjectType::SHIP)) {
+			TryAddShipLights(static_cast<const Ship *>(body), planet, planetFrame, playerPosPlanet, nightTime, candidates);
+		}
+	}
+
+	std::sort(candidates.begin(), candidates.end(), [](const LightCandidate &a, const LightCandidate &b) {
+		return a.distSq < b.distSq;
+	});
+
+	block.numLights = std::min<int>(int(candidates.size()), MAX_TERRAIN_LOCAL_LIGHTS);
+
+	for (int i = 0; i < block.numLights; ++i)
+		FillLightGPU(block.lights[i], candidates[i], planetRadius);
+
+	UploadBlock(material, block);
+}

--- a/src/TerrainLocalLights.h
+++ b/src/TerrainLocalLights.h
@@ -1,0 +1,23 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef _TERRAINLOCALLIGHTS_H
+#define _TERRAINLOCALLIGHTS_H
+
+class Camera;
+class Planet;
+
+namespace Graphics {
+	class Material;
+}
+
+class TerrainLocalLights {
+public:
+	static void UploadToMaterial(
+		Graphics::Material *material,
+		const Camera *camera,
+		const Planet *planet,
+		double planetRadius);
+};
+
+#endif

--- a/src/TerrainLocalLights.h
+++ b/src/TerrainLocalLights.h
@@ -4,8 +4,11 @@
 #ifndef _TERRAINLOCALLIGHTS_H
 #define _TERRAINLOCALLIGHTS_H
 
+#include "Color.h"
+
 class Camera;
 class Planet;
+class Ship;
 
 namespace Graphics {
 	class Material;
@@ -18,6 +21,10 @@ public:
 		const Camera *camera,
 		const Planet *planet,
 		double planetRadius);
+
+	// Additive RGB from this ship's nav/thruster lights, night-gated like terrain local lights.
+	// Used to brighten the ship's own exhaust/dust particles.
+	static Color4f CalcShipSelfIllumination(const Camera *camera, const Ship *ship);
 };
 
 #endif

--- a/src/scenegraph/Model.cpp
+++ b/src/scenegraph/Model.cpp
@@ -425,6 +425,28 @@ namespace SceneGraph {
 		m_renderData.angthrust[2] = ang.z;
 	}
 
+	float Model::GetMaxThrusterDisplayedPower() const
+	{
+		if (m_root == nullptr)
+			return 0.f;
+
+		FindNodeVisitor thrusterFinder(FindNodeVisitor::MATCH_NAME_FULL, "thrusters");
+		m_root->Accept(thrusterFinder);
+		const std::vector<Node *> &results = thrusterFinder.GetResults();
+		if (results.empty())
+			return 0.f;
+
+		float maxPower = 0.f;
+		Group *thrusters = static_cast<Group *>(results.at(0));
+		for (unsigned int i = 0; i < thrusters->GetNumChildren(); i++) {
+			MatrixTransform *mt = static_cast<MatrixTransform *>(thrusters->GetChildAt(i));
+			const Thruster *thruster = static_cast<const Thruster *>(mt->GetChildAt(0));
+			if (thruster != nullptr)
+				maxPower = std::max(maxPower, thruster->GetDisplayedPower());
+		}
+		return maxPower;
+	}
+
 	void Model::SetThrusterColor(const vector3f &dir, const Color &color)
 	{
 		assert(m_root != nullptr);

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -176,6 +176,7 @@ namespace SceneGraph {
 		//special for ship model use
 		void SetRenderTime(const double newRenderTime) { m_renderData.renderTime = newRenderTime; }
 		void SetThrust(const vector3f &linear, const vector3f &angular);
+		float GetMaxThrusterDisplayedPower() const;
 
 		void SetThrusterColor(const vector3f &dir, const Color &color);
 		void SetThrusterColor(const std::string &name, const Color &color);

--- a/src/scenegraph/Model.h
+++ b/src/scenegraph/Model.h
@@ -173,6 +173,7 @@ namespace SceneGraph {
 		//special for ship model use
 		void SetRenderTime(const double newRenderTime) { m_renderData.renderTime = newRenderTime; }
 		void SetThrust(const vector3f &linear, const vector3f &angular);
+		float GetMaxThrusterDisplayedPower() const;
 
 		void SetThrusterColor(const vector3f &dir, const Color &color);
 		void SetThrusterColor(const std::string &name, const Color &color);

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -39,6 +39,7 @@ namespace SceneGraph {
 		}
 		float GetVisualSize() const { return visualSize; }
 		float GetVisualSizeProportional() const { return visualSizeScaled; }
+		float GetDisplayedPower() const { return displayedPower; }
 
 	private:
 		// thruster geometry is shared between all instances of Thruster

--- a/src/scenegraph/Thruster.h
+++ b/src/scenegraph/Thruster.h
@@ -30,6 +30,7 @@ namespace SceneGraph {
 		static Thruster *Load(NodeDatabase &);
 		void SetColor(const Color c) { currentColor = c; }
 		const vector3f &GetDirection() { return dir; }
+		float GetDisplayedPower() const { return displayedPower; }
 
 	private:
 		// thruster geometry is shared between all instances of Thruster


### PR DESCRIPTION
I was playing Pioneer and trying to land a ship at night, and after a little while I thought "This should be easier".

If you've ever thought the same thing, then I have good news.

With this change, ship nav lights and thrusters now illuminate the terrain at night. This addresses the other complaint mentioned in #5208.

As a little bonus, starport city lights also illuminate the terrain at night.

By the way, if you find the blinking red and green illumination annoying then don't blame me, it's the ship designer's fault! My code just shows the logical result of the lights that they put on the ships!

Seriously though, if you think any of this should be tweaked then let me know. Or play with the constants at the top of TerrainLocalLights.cpp yourself.
