### PR TITLE
Autopilot can now fly to the vicinity of a landed ship

### DIFF
--- a/src/Ship-AI.cpp
+++ b/src/Ship-AI.cpp
@@ -90,9 +90,14 @@ void Ship::AIFlyTo(Body *target)
 	AIClearInstructions();
 	SetFuelReserve((GetFuel() < 0.5) ? GetFuel() / 2 : 0.25);
 
-	if (target->IsType(ObjectType::SHIP)) { // test code
-		vector3d posoff(-1000.0, 0.0, 1000.0);
-		m_curAICmd = new AICmdFormation(this, static_cast<Ship *>(target), posoff);
+	if (target->IsType(ObjectType::SHIP)) {
+		Ship *targetShip = static_cast<Ship *>(target);
+		if (targetShip->IsOnSurface())
+			m_curAICmd = new AICmdFlyTo(this, target);
+		else {
+			vector3d posoff(-1000.0, 0.0, 1000.0);
+			m_curAICmd = new AICmdFormation(this, targetShip, posoff);
+		}
 	} else
 		m_curAICmd = new AICmdFlyTo(this, target);
 }

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -1386,6 +1386,17 @@ void Ship::OnTakeoff(Body *b)
 	LuaEvent::Queue("onShipTakeOff", this, b);
 }
 
+bool Ship::IsOnSurface() const
+{
+	if (IsLanded())
+		return true;
+	if (IsDocked()) {
+		const SpaceStation *station = GetDockedWith();
+		return station && station->IsGroundStation();
+	}
+	return false;
+}
+
 bool Ship::Undock()
 {
 	return (m_dockedWith && m_dockedWith->LaunchShip(this, m_dockedWithPort));

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -85,6 +85,7 @@ public:
 	int GetDockingPort() const { return m_dockedWithPort; }
 	bool IsDocked() const { return GetFlightState() == Ship::DOCKED; }
 	bool IsLanded() const { return GetFlightState() == Ship::LANDED; }
+	bool IsOnSurface() const;
 
 	virtual void OnDocked(SpaceStation *, int port);
 	virtual void OnUndocked(SpaceStation *, int port);

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -945,7 +945,11 @@ AICmdFlyTo::AICmdFlyTo(DynamicBody *dBody, Body *target) :
 	else
 		m_dist = VICINITY_MUL * MaxEffectRad(target, m_prop);
 
-	if (target->IsType(ObjectType::SPACESTATION) && static_cast<SpaceStation *>(target)->IsGroundStation()) {
+	const bool useSurfaceVicinity =
+		(target->IsType(ObjectType::SPACESTATION) && static_cast<SpaceStation *>(target)->IsGroundStation())
+		|| (target->IsType(ObjectType::SHIP) && static_cast<Ship *>(target)->IsOnSurface());
+
+	if (useSurfaceVicinity) {
 		m_posoff = target->GetPosition() + VICINITY_MIN * target->GetOrient().VectorY();
 		//		m_posoff += 500.0 * target->GetOrient().VectorX();
 		m_targframeId = target->GetFrame();


### PR DESCRIPTION
Addresses a comment left on #6377. The autopilot "Fly to vicinity of X" command works great if X is a ship in space or any kind of station. But if X is a ship on a planet's surface then the autopilot tries to orbit around it and usually ends up crashing into the planet instead. 

This change makes the autopilot treat landed ships the same as ground-based starports, so it will fly to a point 15km above the target and then hover there. Works the same for both landed-on-terrain and ground-starport-docked ships.

