### PR TITLE
Fix ImGui error message of extending parent boundaries with `SetCursorPos`

### DIFF
--- a/data/pigui/libs/ship-equipment.lua
+++ b/data/pigui/libs/ship-equipment.lua
@@ -440,6 +440,10 @@ function EquipmentWidget:drawSectionHeader(section, fun)
 
 	ui.setCursorPos(contentsPos)
 
+	-- setCursorPos must be followed by a dummy if used for resizing
+	-- See ImGui::ErrorCheckUsingSetCursorPosToExtendParentBoundaries
+	ui.dummy(Vector2(0, 0))
+
 	if sectionOpen then
 		fun()
 		ui.treePop()


### PR DESCRIPTION
Since #6356, an ImGui warning message appeared on the Equipment screen, related to a changed API behavior of `SetCursorPos`. See https://github.com/ocornut/imgui/blob/776bf2ab0d61e719e58f2c6d27d109ab5dcf2af1/imgui.cpp#L11003-L11028 for reference.

This patch fixes this by adding a `Dummy`, as the documentation suggests.

Screenshot of the warning:

<img width="3840" height="2160" alt="Screenshot From 2026-07-05 19-03-17" src="https://github.com/user-attachments/assets/5d96e5b0-9080-4878-ba9c-7d327696b798" />
