### PR TITLE
Fix for HUD trails not displaying in rotating frames

### DIFF
--- a/src/WorldView.cpp
+++ b/src/WorldView.cpp
@@ -235,7 +235,9 @@ void WorldView::Update()
 
 	if (Pi::AreHudTrailsDisplayed()) {
 		matrix4x4d trans;
-		Frame::GetFrameTransform(playerFrameId, camFrameId, trans);
+		// HudTrail stores its points in the non-rotating frame, so the display transform must be built from that same frame.
+		FrameId nonRotFrameId = Frame::GetFrame(playerFrameId)->GetNonRotFrame();
+		Frame::GetFrameTransform(nonRotFrameId, camFrameId, trans);
 
 		for (auto it = Pi::player->GetSensors()->GetContacts().begin(); it != Pi::player->GetSensors()->GetContacts().end(); ++it)
 			it->trail->SetTransform(trans);


### PR DESCRIPTION
My previous fix for HUD trails (#6315) was working in 99% of cases. The remaining 1% of cases was when an NPC ship crossed between a non-rotating and a rotating frame of reference. In an effort to fix that, just before merge, I accidentally broke HUD trails for when the _player_ was in a rotating frame of reference. So now when the player is landed on a planet or docked at a starport, the HUD trails don't display any more. Oops.

I only just noticed this myself, and I guess that not many other people pay attention to HUD trails.

This PR should fix the issue so now HUD trails are displayed correctly in 100% of cases. I have tested 3 cases so far, and as a programmer that's 2 more cases than I would normally test, so I'm pretty confident about it. Fingers crossed...
