### PR TITLE
BulkShips fix for running out of parking slots

### DIFF
--- a/data/modules/BulkShips.lua
+++ b/data/modules/BulkShips.lua
@@ -31,9 +31,26 @@ local spawnShips = function ()
 	local num_bulk_ships = math.min(#stations*2, math.floor((math.ceil(population)+2)/3))
 
 	for i=1, num_bulk_ships do
-		local station = stations[Engine.rand:Integer(1,#stations)]
-		local ship = Space.SpawnShipParked(shipdefs[Engine.rand:Integer(1,#shipdefs)].id, station)
-		ship:SetLabel(Ship.MakeRandomLabel())
+		local ship = nil
+		local shipId = shipdefs[Engine.rand:Integer(1,#shipdefs)].id
+		local attempts = #stations
+
+		-- Try a bounded number of random stations to avoid a nil ship when
+		-- static parking slots are already full on the chosen station.
+		for _ = 1, attempts do
+			local station = stations[Engine.rand:Integer(1,#stations)]
+			ship = Space.SpawnShipParked(shipId, station)
+			if ship then
+				break
+			end
+		end
+
+		if ship then
+			ship:SetLabel(Ship.MakeRandomLabel())
+		else
+			-- No station had free static slots, stop trying to spawn more.
+			break
+		end
 	end
 end
 


### PR DESCRIPTION
When the game tried to allocate parked "bulk" ships outside of stations, there was a tiny chance of seeing a crash when the code ran out of parking slots. 

Today, @impaktor was our winner! Congratulations! 

Unfortunately, with the adoption of this PR, we shouldn't be seeing any more winners in this area. Please try other game features regularly in order to get additional chances of winning.

