### PR TITLE
Implement Circular Thrust Indicator

### DIFF
--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1320,8 +1320,8 @@
     "message": "The speed relative to the target"
   },
   "HUD_THRUST_INDICATOR": {
-    "description": "Tooltip: describe what the thrust/velocity indicator shows",
-    "message": "Show current velocity for each direction (thin lines) and thrust (thick background)"
+    "description": "Tooltip: describe what the thrust indicator shows",
+    "message": "Show current thrust levels for maneuvering (outer ring) and primary or retro engines (center circle)"
   },
   "HUD_WARNING_DESCENT_RATE": {
     "description": "Shown on HUD as a warning flasher",

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -1319,6 +1319,10 @@
     "description": "Tooltip: The speed relative to the target.",
     "message": "The speed relative to the target"
   },
+  "HUD_GRAVITY_INDICATOR": {
+    "description": "Tooltip: describe what the gravity indicator shows",
+    "message": "Local gravity acceleration (scale: ship maximum acceleration)"
+  },
   "HUD_THRUST_INDICATOR": {
     "description": "Tooltip: describe what the thrust indicator shows",
     "message": "Show current thrust levels for maneuvering (outer ring) and primary or retro engines (center circle)"

--- a/data/meta/CoreObject/Body.meta.lua
+++ b/data/meta/CoreObject/Body.meta.lua
@@ -25,6 +25,11 @@
 --- Only available for dynamic bodies.
 ---@field frameBody? Body
 ---
+--- The display label of the current frame of reference. Only available for
+--- dynamic bodies. This is valid even when there is no Body as the current
+--- frame root.
+---@field frameLabel? string
+---
 --- Whether the frame this body is in is a rotating frame.
 --- Only available for dynamic bodies.
 ---@field frameRotating? boolean

--- a/data/pigui/libs/forwarded.lua
+++ b/data/pigui/libs/forwarded.lua
@@ -82,6 +82,7 @@ ui.getCursorScreenPos = pigui.GetCursorScreenPos ---@type fun(): Vector2
 ui.addCursorScreenPos = pigui.AddCursorScreenPos ---@type fun(add: Vector2)
 ui.lowThrustButton = pigui.LowThrustButton
 ui.thrustIndicator = pigui.ThrustIndicator
+ui.circleIndicator = pigui.CircleIndicator ---@type fun(id: string, diameter: number, value: number, value_inv: number, phase: number, label: string, unit: string?)
 ui.isMouseClicked = pigui.IsMouseClicked
 ui.isMouseDoubleClicked = pigui.IsMouseDoubleClicked
 ui.isMouseDown = pigui.IsMouseDown

--- a/data/pigui/modules/ship-internals-window.lua
+++ b/data/pigui/modules/ship-internals-window.lua
@@ -17,6 +17,19 @@ local icons = ui.theme.icons
 
 local mainButtonSize = ui.theme.styles.MainButtonSize
 local mainButtonFramePadding = ui.theme.styles.MainButtonPadding
+local thrustWidgetDiameter = mainButtonSize.y * 1.5
+
+local thrustStyle = ui.Style:clone({
+	colors = {
+		FrameBg        = ui.theme.styleColors.primary_1000:opacity(0.6),
+		FrameBgHovered = ui.theme.styleColors.primary_1000:opacity(0.6),
+		FrameBgActive  = ui.theme.styleColors.primary_700,
+		SliderGrab     = ui.theme.styleColors.primary_300
+	},
+	vars = {
+		FrameBorderSize = ui.rescaleUI(4)
+	}
+})
 
 local show_thrust_slider = false
 
@@ -59,7 +72,9 @@ local function button_thrustIndicator(thrust_widget_size)
 	vel = vel / math.max(vel:length(), 10) -- minimum of 10m/s
 	local thrust = player:GetThrusterState()
 	thrust_widget_size = thrust_widget_size - Vector2(mainButtonFramePadding * 2)
-	ui.thrustIndicator("foo", thrust_widget_size, thrust, vel, colors.transparent, mainButtonFramePadding, colors.gaugeVelocityLight, colors.gaugeVelocityDark, colors.gaugeThrustLight, colors.gaugeThrustDark)
+	thrustStyle:withStyle(function()
+		ui.thrustIndicator("thrustIndicator", thrustWidgetDiameter, thrust)
+	end)
 	if ui.isItemHovered() then
 		ui.setTooltip(lui.HUD_THRUST_INDICATOR)
 	end
@@ -102,7 +117,7 @@ local function displayShipFunctionWindow()
 	player = Game.player
 	local current_view = Game.CurrentView()
 	local buttons = 3
-	local thrust_widget_size = Vector2(mainButtonSize.x * 3, mainButtonSize.y * 2)
+	local thrust_widget_size = Vector2(thrustWidgetDiameter * 1.2, thrustWidgetDiameter)
 	assert(thrust_widget_size.y >= mainButtonSize.y)
 	local window_width = ui.getWindowPadding().x * 2 + (mainButtonSize.x + ui.getItemSpacing().x) * buttons + thrust_widget_size.x
 	local window_height = thrust_widget_size.y + ui.getWindowPadding().y * 2
@@ -111,7 +126,7 @@ local function displayShipFunctionWindow()
 	ui.setNextWindowPos(Vector2(window_posx, window_posy), "Always")
 	ui.window("ShipFunctions", windowFlags, function()
 		if current_view == "WorldView" then
-			local shift = Vector2(0.0, thrust_widget_size.y - mainButtonSize.y)
+			local shift = Vector2(thrustWidgetDiameter - thrust_widget_size.x, thrust_widget_size.y - mainButtonSize.y)
 			ui.addCursorPos(shift)
 			button_wheelstate()
 			ui.sameLine()

--- a/data/pigui/modules/ship-internals-window.lua
+++ b/data/pigui/modules/ship-internals-window.lua
@@ -21,10 +21,11 @@ local thrustWidgetDiameter = mainButtonSize.y * 1.5
 
 local thrustStyle = ui.Style:clone({
 	colors = {
-		FrameBg        = ui.theme.styleColors.primary_1000:opacity(0.6),
-		FrameBgHovered = ui.theme.styleColors.primary_1000:opacity(0.6),
-		FrameBgActive  = ui.theme.styleColors.primary_700,
-		SliderGrab     = ui.theme.styleColors.primary_300
+		FrameBg          = ui.theme.styleColors.primary_1000:opacity(0.6),
+		FrameBgHovered   = ui.theme.styleColors.primary_1000:opacity(0.6),
+		FrameBgActive    = ui.theme.styleColors.primary_700,
+		SliderGrab       = ui.theme.styleColors.primary_300,
+		SliderGrabActive = ui.theme.styleColors.primary_900,
 	},
 	vars = {
 		FrameBorderSize = ui.rescaleUI(4)
@@ -80,6 +81,46 @@ local function button_thrustIndicator(thrust_widget_size)
 	end
 end
 
+local function gravity_indicator(diameter)
+
+	local parentBody = Game.player.frameBody
+	local gravity = 0.0
+	local maxG = Game.player:GetAcceleration("up")
+
+	if parentBody then
+		local sbody = assert(parentBody:GetSystemBody())
+
+		while sbody.superType == "STARPORT" and sbody.parent do
+			sbody = sbody.parent
+			parentBody = assert(sbody).body
+		end
+	end
+
+	if parentBody then
+		gravity = 6.67428e-11 * (parentBody:GetSystemBody().mass / Game.player:GetPositionRelTo(parentBody):lengthSqr())
+	end
+
+	thrustStyle:withStyle(function()
+		local gEarth = gravity / 9.8066
+		local label = ui.Format.Number(gEarth, gEarth < 1 and 2 or 1)
+		local unit = lc.UNIT_EARTH_GRAVITY:upper()
+
+		if gravity > maxG then
+			-- Cannot take off!
+			ui.withStyleColors({ SliderGrabActive = ui.theme.styleColors.danger_700 }, function()
+				local g1 = maxG / gravity
+				local g2 = (gravity - maxG) / gravity
+				ui.circleIndicator("gravity", diameter, g1, g2, math.pi * 0.667, label, unit)
+			end)
+		else
+			-- TWR > 1
+			local g1 = gravity / maxG
+			ui.circleIndicator("gravity", diameter, g1, 0, math.pi * 0.667, label, unit)
+
+		end
+	end)
+end
+
 local function button_wheelstate()
 	local wheelstate = player:GetWheelState() -- 0.0 is up, 1.0 is down
 	local locked = player:GetFlightControlState() == "CONTROL_AUTOPILOT"
@@ -116,7 +157,7 @@ local function displayShipFunctionWindow()
 	if ui.optionsWindow.isOpen then return end
 	player = Game.player
 	local current_view = Game.CurrentView()
-	local buttons = 3
+	local buttons = 3 + 1.5 -- HACK: gravity circle
 	local thrust_widget_size = Vector2(thrustWidgetDiameter * 1.2, thrustWidgetDiameter)
 	assert(thrust_widget_size.y >= mainButtonSize.y)
 	local window_width = ui.getWindowPadding().x * 2 + (mainButtonSize.x + ui.getItemSpacing().x) * buttons + thrust_widget_size.x
@@ -136,6 +177,9 @@ local function displayShipFunctionWindow()
 			ui.sameLine()
 			ui.addCursorPos(-shift)
 			button_thrustIndicator(thrust_widget_size)
+			ui.sameLine()
+			ui.addCursorPos(Vector2(0, -mainButtonSize.y * 0.5))
+			gravity_indicator(mainButtonSize.y * 1.5)
 			if ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f8) then
 				show_thrust_slider = not show_thrust_slider
 			end

--- a/data/pigui/modules/ship-internals-window.lua
+++ b/data/pigui/modules/ship-internals-window.lua
@@ -17,7 +17,7 @@ local icons = ui.theme.icons
 
 local mainButtonSize = ui.theme.styles.MainButtonSize
 local mainButtonFramePadding = ui.theme.styles.MainButtonPadding
-local thrustWidgetDiameter = mainButtonSize.y * 1.5
+local thrustWidgetDiameter = mainButtonSize.y * 1.2
 
 local thrustStyle = ui.Style:clone({
 	colors = {
@@ -68,11 +68,8 @@ local function button_lowThrustPower()
 	end
 end
 
-local function button_thrustIndicator(thrust_widget_size)
-	local vel = Engine.WorldSpaceToShipSpace(player:GetVelocity())
-	vel = vel / math.max(vel:length(), 10) -- minimum of 10m/s
+local function button_thrustIndicator()
 	local thrust = player:GetThrusterState()
-	thrust_widget_size = thrust_widget_size - Vector2(mainButtonFramePadding * 2)
 	thrustStyle:withStyle(function()
 		ui.thrustIndicator("thrustIndicator", thrustWidgetDiameter, thrust)
 	end)
@@ -119,6 +116,10 @@ local function gravity_indicator(diameter)
 
 		end
 	end)
+
+	if ui.isItemHovered() then
+		ui.setTooltip(lui.HUD_GRAVITY_INDICATOR)
+	end
 end
 
 local function button_wheelstate()
@@ -157,8 +158,8 @@ local function displayShipFunctionWindow()
 	if ui.optionsWindow.isOpen then return end
 	player = Game.player
 	local current_view = Game.CurrentView()
-	local buttons = 3 + 1.5 -- HACK: gravity circle
-	local thrust_widget_size = Vector2(thrustWidgetDiameter * 1.2, thrustWidgetDiameter)
+	local buttons = 3
+	local thrust_widget_size = Vector2(thrustWidgetDiameter * 1.2 + thrustWidgetDiameter, thrustWidgetDiameter)
 	assert(thrust_widget_size.y >= mainButtonSize.y)
 	local window_width = ui.getWindowPadding().x * 2 + (mainButtonSize.x + ui.getItemSpacing().x) * buttons + thrust_widget_size.x
 	local window_height = thrust_widget_size.y + ui.getWindowPadding().y * 2
@@ -167,7 +168,7 @@ local function displayShipFunctionWindow()
 	ui.setNextWindowPos(Vector2(window_posx, window_posy), "Always")
 	ui.window("ShipFunctions", windowFlags, function()
 		if current_view == "WorldView" then
-			local shift = Vector2(thrustWidgetDiameter - thrust_widget_size.x, thrust_widget_size.y - mainButtonSize.y)
+			local shift = Vector2(thrustWidgetDiameter * 2 - thrust_widget_size.x, thrust_widget_size.y - mainButtonSize.y)
 			ui.addCursorPos(shift)
 			button_wheelstate()
 			ui.sameLine()
@@ -176,10 +177,10 @@ local function displayShipFunctionWindow()
 			button_lowThrustPower()
 			ui.sameLine()
 			ui.addCursorPos(-shift)
-			button_thrustIndicator(thrust_widget_size)
+			button_thrustIndicator()
 			ui.sameLine()
-			ui.addCursorPos(Vector2(0, -mainButtonSize.y * 0.5))
-			gravity_indicator(mainButtonSize.y * 1.5)
+			ui.addCursorPos(Vector2(0, mainButtonSize.y - thrustWidgetDiameter))
+			gravity_indicator(thrustWidgetDiameter)
 			if ui.noModifierHeld() and ui.isKeyReleased(ui.keys.f8) then
 				show_thrust_slider = not show_thrust_slider
 			end

--- a/data/pigui/themes/default.lua
+++ b/data/pigui/themes/default.lua
@@ -67,6 +67,7 @@ local styleColors = {
 	primary_700		= Color "40477D",
 	primary_800		= Color "383C71",
 	primary_900		= Color "2C2D58",
+	primary_1000	= Color "1C1C35",
 
 	-- "Alternate" primary colors with significantly more saturation for use
 	-- as small foreground elements like checkmarks and grabs.

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -1377,21 +1377,11 @@ static int l_pigui_invisible_button(lua_State *l)
 
 static int l_pigui_thrust_indicator(lua_State *l)
 {
-	PROFILE_SCOPED()
-	std::string text = LuaPull<std::string>(l, 1);
-	ImVec2 size = LuaPull<ImVec2>(l, 2);
+	std::string id_str = LuaPull<std::string>(l, 1);
+	float diameter = LuaPull<float>(l, 2);
 	vector3d thr = LuaPull<vector3d>(l, 3);
-	vector3d vel = LuaPull<vector3d>(l, 4);
-	ImColor color = LuaPull<ImColor>(l, 5);
-	int frame_padding = LuaPull<int>(l, 6);
-	ImColor vel_fg = LuaPull<ImColor>(l, 7);
-	ImColor vel_bg = LuaPull<ImColor>(l, 8);
-	ImColor thrust_fg = LuaPull<ImColor>(l, 9);
-	ImColor thrust_bg = LuaPull<ImColor>(l, 10);
-	ImVec4 thrust(thr.x, thr.y, thr.z, 0);
-	ImVec4 velocity(vel.x, vel.y, vel.z, 0);
-	PiGui::Draw::ThrustIndicator(text.c_str(), size, thrust, velocity, color,
-		frame_padding, vel_fg, vel_bg, thrust_fg, thrust_bg);
+
+	PiGui::Draw::ThrustIndicator(ImGui::GetID(id_str.c_str()), diameter, thr);
 	return 0;
 }
 

--- a/src/lua/LuaPiGui.cpp
+++ b/src/lua/LuaPiGui.cpp
@@ -1385,6 +1385,20 @@ static int l_pigui_thrust_indicator(lua_State *l)
 	return 0;
 }
 
+static int l_pigui_circle_indicator(lua_State *l)
+{
+	std::string id_str = LuaPull<std::string>(l, 1);
+	float diameter = LuaPull<float>(l, 2);
+	float value = LuaPull<float>(l, 3);
+	float value_inv = LuaPull<float>(l, 4);
+	float phase = LuaPull<float>(l, 5);
+	std::string label = LuaPull<std::string>(l, 6);
+	std::string unit = LuaPull<std::string>(l, 7, "");
+
+	PiGui::Draw::CircleIndicator(ImGui::GetID(id_str.c_str()), diameter, label.c_str(), unit.empty() ? nullptr : unit.c_str(), value, value_inv, phase);
+	return 0;
+}
+
 static int l_pigui_low_thrust_button(lua_State *l)
 {
 	PROFILE_SCOPED()
@@ -3895,6 +3909,7 @@ void LuaObject<PiGui::Instance>::RegisterClass()
 		{ "ShouldShowLabels", l_pigui_should_show_labels },
 		{ "LowThrustButton", l_pigui_low_thrust_button },
 		{ "ThrustIndicator", l_pigui_thrust_indicator },
+		{ "CircleIndicator", l_pigui_circle_indicator },
 		{ "PlaySfx", l_pigui_play_sfx },
 		{ "DisableMouseFacing", l_pigui_disable_mouse_facing },
 		{ "SetMouseButtonState", l_pigui_set_mouse_button_state },

--- a/src/pigui/Widgets.cpp
+++ b/src/pigui/Widgets.cpp
@@ -142,91 +142,69 @@ bool Draw::CircularSlider(const ImVec2 &center, float *v, float v_min, float v_m
 		id, ImGuiDataType_Float, v, &v_min, &v_max, "%.4f", ImGuiSliderFlags_None, &grab_bb);
 }
 
-static void drawThrust(ImDrawList *draw_list, const ImVec2 &center, const ImVec2 &up, float value, const ImColor &fg, const ImColor &bg)
+void Draw::ThrustIndicator(ImGuiID id, float diameter, const vector3d &thrust)
 {
-	PROFILE_SCOPED()
-	float factor = 0.1; // how much to offset from center
-	const ImVec2 step(up.x * 0.5, up.y * 0.5);
-	const ImVec2 left(-step.y * (1.0 - factor), step.x * (1.0 - factor));
-	const ImVec2 u(up.x * (1.0 - factor), up.y * (1.0 - factor));
-	const ImVec2 c(center + ImVec2(u.x * factor, u.y * factor));
-	const ImVec2 right(-left.x, -left.y);
-	const ImVec2 leftmiddle = c + step + left;
-	const ImVec2 rightmiddle = c + step + right;
-	const ImVec2 bb_lowerright = c + right;
-	const ImVec2 bb_upperleft = c + left + ImVec2(u.x * value, u.y * value);
-	const ImVec2 lefttop = c + u + left;
-	const ImVec2 righttop = c + u + right;
-	const ImVec2 minimum(fmin(bb_upperleft.x, bb_lowerright.x), fmin(bb_upperleft.y, bb_lowerright.y));
-	const ImVec2 maximum(fmax(bb_upperleft.x, bb_lowerright.x), fmax(bb_upperleft.y, bb_lowerright.y));
-	ImVec2 points[] = { c, leftmiddle, lefttop, righttop, rightmiddle };
-	draw_list->AddConvexPolyFilled(points, 5, bg);
-	draw_list->PushClipRect(minimum - ImVec2(1, 1), maximum + ImVec2(1, 1));
-	draw_list->AddConvexPolyFilled(points, 5, fg);
-	draw_list->PopClipRect();
-}
-
-void Draw::ThrustIndicator(const std::string &id_string, const ImVec2 &size_arg, const ImVec4 &thrust, const ImVec4 &velocity, const ImVec4 &bg_col, int frame_padding, ImColor vel_fg, ImColor vel_bg, ImColor thrust_fg, ImColor thrust_bg)
-{
-	PROFILE_SCOPED()
 	ImGuiWindow *window = ImGui::GetCurrentWindow();
 	if (window->SkipItems)
 		return;
 
-	ImGuiContext &g = *GImGui;
-	const ImGuiStyle &style = g.Style;
-	const ImGuiID id = window->GetID(id_string.c_str());
+	const ImGuiStyle &style = ImGui::GetStyle();
 
-	ImVec2 pos = window->DC.CursorPos;
-	// if ((flags & ImGuiButtonFlags_AlignTextBaseLine) && style.FramePadding.y < window->DC.CurrentLineTextBaseOffset) // Try to vertically align buttons that are smaller/have no padding so that text baseline matches (bit hacky, since it shouldn't be a flag)
-	//     pos.y += window->DC.CurrentLineTextBaseOffset - style.FramePadding.y;
-	ImVec2 size = ImGui::CalcItemSize(size_arg, style.FramePadding.x * 2.0f, style.FramePadding.y * 2.0f);
+	const float radius = diameter * 0.5f;
+	const float thickness = style.FrameBorderSize;
+	const float offset = 0.5f * thickness;
+	// radius of elements in the inner circle, leaving a small gap between their edge and the outer ring.
+	const float inner_radius = radius - thickness * 2.f;
 
-	const ImVec2 padding = (frame_padding >= 0) ? ImVec2(static_cast<float>(frame_padding), static_cast<float>(frame_padding)) : style.FramePadding;
-	const ImRect bb(pos, pos + size + padding * 2);
-	const ImRect inner_bb(pos + padding, pos + padding + size);
+	const ImVec2 pos = ImGui::GetCursorScreenPos();
+	const ImVec2 center = pos + ImVec2(diameter * 0.5f, diameter * 0.5f);
+	const ImRect bb (pos, pos + ImVec2(diameter, diameter));
 
-	ImGui::ItemSize(bb, style.FramePadding.y);
+	ImGui::ItemSize(bb, 0.f);
 	if (!ImGui::ItemAdd(bb, id))
 		return;
 
-	// Render
-	const ImU32 col = ImGui::GetColorU32(static_cast<ImGuiCol>(ImGuiCol_Button));
-	ImGui::RenderFrame(bb.Min, bb.Max, col, true, style.FrameRounding);
-	ImDrawList *draw_list = ImGui::GetWindowDrawList();
-	if (bg_col.w > 0.0f)
-		draw_list->AddRectFilled(inner_bb.Min, inner_bb.Max, ImGui::GetColorU32(bg_col));
-	const ImVec2 leftupper = inner_bb.Min;
-	const ImVec2 rightlower = inner_bb.Max;
-	const ImVec2 rightcenter((rightlower.x - leftupper.x) * 0.8 + leftupper.x, (rightlower.y + leftupper.y) / 2);
-	const ImVec2 leftcenter((rightlower.x - leftupper.x) * 0.35 + leftupper.x, (rightlower.y + leftupper.y) / 2);
-	const ImVec2 up(0, -std::abs(leftupper.y - rightlower.y) * 0.4);
-	const ImVec2 left(-up.y, up.x);
-	float thrust_fwd = fmax(thrust.z, 0);
-	float thrust_bwd = fmax(-thrust.z, 0);
-	float thrust_left = fmax(-thrust.x, 0);
-	float thrust_right = fmax(thrust.x, 0);
-	float thrust_up = fmax(-thrust.y, 0);
-	float thrust_down = fmax(thrust.y, 0);
-	// actual thrust
-	drawThrust(draw_list, rightcenter, up, thrust_fwd, thrust_fg, thrust_bg);
-	drawThrust(draw_list, rightcenter, ImVec2(-up.x, -up.y), thrust_bwd, thrust_fg, thrust_bg);
-	drawThrust(draw_list, leftcenter, up, thrust_up, thrust_fg, thrust_bg);
-	drawThrust(draw_list, leftcenter, ImVec2(-up.x, -up.y), thrust_down, thrust_fg, thrust_bg);
-	drawThrust(draw_list, leftcenter, left, thrust_left, thrust_fg, thrust_bg);
-	drawThrust(draw_list, leftcenter, ImVec2(-left.x, -left.y), thrust_right, thrust_fg, thrust_bg);
-	// forward/back velocity
-	draw_list->AddLine(rightcenter + up, rightcenter - up, vel_bg, 3);
-	draw_list->AddLine(rightcenter, rightcenter - up * velocity.z, vel_fg, 3);
-	// left/right velocity
-	draw_list->AddLine(leftcenter + left, leftcenter - left, vel_bg, 3);
-	draw_list->AddLine(leftcenter, leftcenter + left * velocity.x, vel_fg, 3);
-	// up/down velocity
-	draw_list->AddLine(leftcenter + up, leftcenter - up, vel_bg, 3);
-	draw_list->AddLine(leftcenter, leftcenter + up * velocity.y, vel_fg, 3);
-	// Automatically close popups
-	//if (pressed && !(flags & ImGuiButtonFlags_DontClosePopups) && (window->Flags & ImGuiWindowFlags_Popup))
-	//    CloseCurrentPopup();
+	bool hovered = ImGui::IsItemHovered() && ImLengthSqr(ImGui::GetIO().MousePos - center) <= radius * radius;
+	if (!hovered) {
+		ImGui::GetCurrentContext()->LastItemData.StatusFlags &= ~ImGuiItemStatusFlags_HoveredRect;
+	}
+
+	const ImU32 col_bg = ImGui::GetColorU32(hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+	const ImU32 col_ring = ImGui::GetColorU32(ImGuiCol_FrameBgActive);
+	const ImU32 col_thr = ImGui::GetColorU32(ImGuiCol_SliderGrab);
+
+	ImDrawList *dl = ImGui::GetWindowDrawList();
+
+	const auto drawThrustRing = [&](const ImVec2 &offset, float base_angle, float thrust) {
+		if (thrust > 0.01) {
+			// offset already carries the 0.5*thickness term, so just subtract thickess from radius
+			dl->PathArcTo(center + offset, radius - thickness, base_angle - M_PI_4 * thrust, base_angle + M_PI_4 * thrust);
+			dl->PathStroke(col_thr, thickness);
+		}
+	};
+
+	dl->AddCircleFilled(center, radius - offset, col_bg);
+	dl->AddCircle(center, radius - offset, col_ring, 0.f, thickness);
+
+	// vertical thrust options
+	drawThrustRing(ImVec2(0,  offset),  M_PI_2, fmax(0.f,  thrust.y));
+	drawThrustRing(ImVec2(0, -offset), -M_PI_2, fmax(0.f, -thrust.y));
+
+	// horizontal thrust options
+	drawThrustRing(ImVec2( offset, 0), 0,    fmax(0.f,  thrust.x));
+	drawThrustRing(ImVec2(-offset, 0), M_PI, fmax(0.f, -thrust.x));
+
+	if (thrust.z > 0.01) {
+		float circle_thickness = thrust.z * inner_radius * 0.75f;
+		float circle_radius = inner_radius - circle_thickness * 0.5f;
+		// add 0.5f to match the smooth antialiasing of AddCircleFilled
+		dl->AddCircle(center, circle_radius + 0.5f, col_thr, 32, circle_thickness);
+	}
+
+	if (thrust.z < -0.01) {
+		dl->AddCircleFilled(center, inner_radius * -thrust.z, col_thr, 32);
+	}
+
 }
 
 bool Draw::LowThrustButton(const char *id_string, const ImVec2 &size_arg, int thrust_level, const ImVec4 &bg_col, int frame_padding, ImColor gauge_fg, ImColor gauge_bg)

--- a/src/pigui/Widgets.cpp
+++ b/src/pigui/Widgets.cpp
@@ -207,6 +207,88 @@ void Draw::ThrustIndicator(ImGuiID id, float diameter, const vector3d &thrust)
 
 }
 
+void Draw::CircleIndicator(ImGuiID id, float diameter, const char *label, const char *unit, float value, float value_inv, float phase)
+{
+	constexpr float M_TAU = 2.0 * M_PI;
+
+	ImGuiWindow *window = ImGui::GetCurrentWindow();
+	if (window->SkipItems)
+		return;
+
+	const ImGuiStyle &style = ImGui::GetStyle();
+
+	const float radius = diameter * 0.5f;
+	const float thickness = style.FrameBorderSize;
+	const float offset = 0.5f * thickness;
+	const float outer_radius = radius - offset;
+	const float inner_radius = radius - thickness * 1.5;
+
+	const ImVec2 pos = ImGui::GetCursorScreenPos();
+	const ImVec2 center = pos + ImVec2(radius, radius);
+	const ImRect bb (pos, pos + ImVec2(diameter, diameter));
+
+	ImGui::ItemSize(bb, 0.f);
+	if (!ImGui::ItemAdd(bb, id))
+		return;
+
+	bool hovered = ImGui::IsItemHovered() && ImLengthSqr(ImGui::GetIO().MousePos - center) <= radius * radius;
+	if (!hovered) {
+		ImGui::GetCurrentContext()->LastItemData.StatusFlags &= ~ImGuiItemStatusFlags_HoveredRect;
+	}
+
+	ImFont *font = ImGui::GetFont();
+
+	const ImU32 col_text = ImGui::GetColorU32(ImGuiCol_Text);
+	const ImU32 col_bg = ImGui::GetColorU32(hovered ? ImGuiCol_FrameBgHovered : ImGuiCol_FrameBg);
+	const ImU32 col_ring = ImGui::GetColorU32(ImGuiCol_FrameBgActive);
+	const ImU32 col_val1 = ImGui::GetColorU32(ImGuiCol_SliderGrab);
+	const ImU32 col_val2 = ImGui::GetColorU32(ImGuiCol_SliderGrabActive);
+
+	ImDrawList *dl = ImGui::GetWindowDrawList();
+
+	// Draw the center circle and outer ring
+	dl->AddCircleFilled(center, outer_radius, col_bg);
+	dl->AddCircle(center, outer_radius, col_ring, 0.f, thickness);
+
+	if (value_inv >= 0.01) {
+		// Draw the "limiter" dial under the "active" dial
+		dl->PathArcTo(center, outer_radius, phase, phase + value_inv * M_TAU, 32);
+		dl->PathStroke(col_val2, thickness);
+	}
+
+	if (value >= 0.01) {
+		// Draw the "active" dial
+		dl->PathArcTo(center, outer_radius, phase - value * M_TAU, phase, 32);
+		dl->PathStroke(col_val1, thickness);
+	}
+
+	const auto computeTextScaleFactor = [&](ImVec2 size, float rad) -> float {
+		return sqrt(size.x * size.x + size.y * size.y) / rad;
+	};
+
+	ImVec2 label_size = ImGui::CalcTextSize(label);
+	float descent = ImGui::GetFontBaked()->Descent; // descent is negative
+
+	if (unit) {
+		// Draw the value and unit text, sizing both to fit within the upper and lower halves of the circle
+		float scale_factor_inv = computeTextScaleFactor(ImVec2(label_size.x * 0.5f, label_size.y + descent), inner_radius);
+		label_size /= scale_factor_inv;
+		descent /= scale_factor_inv;
+		dl->AddText(font, label_size.y, center - ImVec2(label_size.x * 0.5f, label_size.y + descent), col_text, label);
+
+		float unit_voffset = descent - 2.f;
+
+		ImVec2 unit_size = ImGui::CalcTextSize(unit);
+		unit_size /= computeTextScaleFactor(ImVec2(unit_size.x * 0.5f, unit_size.y), fmin(inner_radius * 0.8, inner_radius + unit_voffset));
+		dl->AddText(font, unit_size.y, center - ImVec2(unit_size.x * 0.5f, unit_voffset), col_text, unit);
+	} else {
+		// Draw only the value text centered in the indicator
+		label_size /= computeTextScaleFactor(label_size * 0.5f, inner_radius);
+		dl->AddText(font, label_size.y, center - label_size * 0.5f, col_text, label);
+	}
+
+}
+
 bool Draw::LowThrustButton(const char *id_string, const ImVec2 &size_arg, int thrust_level, const ImVec4 &bg_col, int frame_padding, ImColor gauge_fg, ImColor gauge_bg)
 {
 	PROFILE_SCOPED()

--- a/src/pigui/Widgets.h
+++ b/src/pigui/Widgets.h
@@ -18,6 +18,10 @@ namespace PiGui::Draw {
 
 	void ThrustIndicator(ImGuiID id, float diameter, const vector3d &thrust);
 
+	// Draw a generic counter-clockwise circular indicator with a value dial going from 0..1 and a limit dial going from 1..0.
+	// The phase parameter controls where on the circle value and value_inv start at.
+	void CircleIndicator(ImGuiID id, float diameter, const char *label, const char *unit, float value, float value_inv, float phase);
+
 	bool GlyphButton(const char *id_str, const char *glyph, const ImVec2 &size, ImGuiButtonFlags flags);
 
 	// we need to know if the change was made by direct input or the change was

--- a/src/pigui/Widgets.h
+++ b/src/pigui/Widgets.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <imgui/imgui.h>
+#include "vector3.h"
 
-#include <string>
 #include <vector>
 
 namespace PiGui::Draw {
@@ -16,7 +16,7 @@ namespace PiGui::Draw {
 	bool LowThrustButton(const char *label, const ImVec2 &size_arg, int thrust_level, const ImVec4 &bg_col, int frame_padding, ImColor gauge_fg, ImColor gauge_bg);
 	bool ButtonImageSized(ImTextureID user_texture_id, const ImVec2 &size, const ImVec2 &imgSize, const ImVec2 &uv0, const ImVec2 &uv1, int frame_padding, const ImVec4 &bg_col, const ImVec4 &tint_col);
 
-	void ThrustIndicator(const std::string &id_string, const ImVec2 &size, const ImVec4 &thrust, const ImVec4 &velocity, const ImVec4 &bg_col, int frame_padding, ImColor vel_fg, ImColor vel_bg, ImColor thrust_fg, ImColor thrust_bg);
+	void ThrustIndicator(ImGuiID id, float diameter, const vector3d &thrust);
 
 	bool GlyphButton(const char *id_str, const char *glyph, const ImVec2 &size, ImGuiButtonFlags flags);
 


### PR DESCRIPTION
Per discussion on https://github.com/pioneerspacesim/pioneer/pull/6354#issuecomment-4928647819, this PR implements @bszlrd's mockup for a replacement ship thrust indicator. While this indicator does not show the direction of ship velocity, that information is far better conveyed using the prograde/flight-path marker on the main hud.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/52d32a10-3718-406d-a454-7de4b9c9bb66" />

Sizing and positioning is currently placeholder; ideally it will be integrated into the central flight reticle at a slightly smaller size. The indicator scales smoothly across a range of screen sizes; it has been tested at 1280x720 and 2560x1440 in addition to 1920x1080.