### PR TITLE
Make probability of lava depend on volcanicity

### DIFF
--- a/src/terrain/TerrainColorVolcanic.cpp
+++ b/src/terrain/TerrainColorVolcanic.cpp
@@ -13,9 +13,12 @@ template <>
 TerrainColorFractal<TerrainColorVolcanic>::TerrainColorFractal(const SystemBody *body) :
 	Terrain(body)
 {
-	// 50 percent chance of there being exposed lava
-	if (m_rand.Int32(100) > 50)
+	// percent chance of there being exposed lava based on planets volcanicity
+	if (m_rand.Double(1.0) > (1.0 - m_volcanic)) {
 		m_surfaceEffects |= Terrain::EFFECT_LAVA;
+	}
+
+	SetFracDef(0, m_maxHeightInMeters, m_rand.Double(1e6, 1e7));
 }
 
 template <>
@@ -24,8 +27,7 @@ vector3d TerrainColorFractal<TerrainColorVolcanic>::GetColor(const vector3d &p, 
 	double n = m_invMaxHeight * height;
 	const double flatness = pow(p.Dot(norm), 6.0);
 	const vector3d color_cliffs = m_rockColor[2];
-	double equatorial_desert = (-1.0 + 2.0 * octavenoise(12, 0.5, 2.0, (n * 2.0) * p)) *
-		1.0 * (1.0 - p.y * p.y);
+	double equatorial_desert = (-1.0 + 2.0 * octavenoise(m_fracdef[0], 0.5, (n * 2.0) * p)) * 1.0 * (1.0 - p.y * p.y);
 
 	vector3d col;
 


### PR DESCRIPTION
This attempts to improve the planets with surface lava a little bit.
It makes the probabilty of there being surface lava higher on worlds with higher levels of volcanic activity.
Add randomness to the `octavenoise` used in locating the lava so that it varies for each world and stops it clumping up in one big area as seemed common before.

Fixes #6371 I think by making the chance of surface lava dependant on the volcanicity of the planet. It might increase the chance of surface lava lakes a bit too much but this was very hard to test.
<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

