### PR TITLE
Language options menu - add url to translation contrib wiki page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,11 +13,11 @@ contact_links:
     url: https://wiki.pioneerspacesim.net/wiki/Basic_flight
     about: Manual for flying
   - name: "🆘 Get in touch with other players"
-    url: https://spacesimcentral.com/community/pioneer/
+    url: https://spacesimcentral.com/viewforum.php?f=49
     about: Community forum is for players sharing
   - name: "👨‍💻 Get in touch with developers"
     url: https://kiwiirc.com/client/irc.libera.chat/pioneer
     about: Developers coordinate through IRC (mostly inactive during CET night).
   - name: "🗣️ Contribute language translation"
-    url: https://www.transifex.com/pioneer/pioneer/dashboard/
+    url: https://wiki.pioneerspacesim.net/wiki/Translations
     about: All translations and language improvements are entirely community driven

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Pioneer wiki
   https://wiki.pioneerspacesim.net
 
 Join the player's forum:
-  http://spacesimcentral.com/community/pioneer/
+  https://spacesimcentral.com/viewforum.php?f=49
 
 Join the development forum:
   http://forum.pioneerspacesim.net

--- a/data/pigui/modules/about-window.lua
+++ b/data/pigui/modules/about-window.lua
@@ -71,7 +71,7 @@ local function showInfo()
 
 		ui.bulletText(l.LINK_COMMUNITY_FORUM)
 		ui.sameLine()
-		ui.textLinkOpenURL("http://spacesimcentral.com/community/pioneer/")
+		ui.textLinkOpenURL("https://spacesimcentral.com/viewforum.php?f=49")
 
 		ui.bulletText(l.LINK_DEVELOPER_FORUM)
 		ui.sameLine()

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -411,19 +411,16 @@ local function showLanguageOptions()
 		return string.format("%s (%d%%)", name, pct)
 	end
 
-	ui.withFont(pionillium.heading, function()
-		ui.text(lui.LANGUAGE_RESTART_GAME_TO_APPLY .. ":")
+	ui.text(lui.LANGUAGE_RESTART_GAME_TO_APPLY .. ":")
+
+	ui.child("##LanguageList", Vector2(0, 0), function()
+		for _, lang in ipairs(langs) do
+			if ui.selectable(languageLabel(lang) .. "##" .. lang, Lang.currentLanguage==lang, {}) then
+				Lang.SetCurrentLanguage(lang)
+			end
+		end
 	end)
 
-	ui.withFont(pionillium.body, function()
-		ui.child("##LanguageList", Vector2(0, 0), function()
-			for _, lang in ipairs(langs) do
-				if ui.selectable(languageLabel(lang) .. "##" .. lang, Lang.currentLanguage==lang, {}) then
-					Lang.SetCurrentLanguage(lang)
-				end
-			end
-		end)
-	end)
 end
 
 local function actionBinding(info)

--- a/data/pigui/modules/settings-window.lua
+++ b/data/pigui/modules/settings-window.lua
@@ -413,14 +413,16 @@ local function showLanguageOptions()
 
 	ui.text(lui.LANGUAGE_RESTART_GAME_TO_APPLY .. ":")
 
-	ui.child("##LanguageList", Vector2(0, 0), function()
+	ui.child("##LanguageList", Vector2(0, -ui.getTextLineHeightWithSpacing()), function()
 		for _, lang in ipairs(langs) do
 			if ui.selectable(languageLabel(lang) .. "##" .. lang, Lang.currentLanguage==lang, {}) then
 				Lang.SetCurrentLanguage(lang)
 			end
 		end
 	end)
-
+	ui.text("Please consider contributing to our")
+	ui.sameLine()
+	ui.textLinkOpenURL("translations", "https://wiki.pioneerspacesim.net/wiki/Translations")
 end
 
 local function actionBinding(info)
@@ -766,7 +768,7 @@ end, function (_, drawPopupFn)
 end)
 
 function ui.optionsWindow:changeState()
-    if not self.isOpen then
+	if not self.isOpen then
 		self:open()
 	else
 		self:close()


### PR DESCRIPTION
As the commits suggests:
1. update broken SSC links
2. font size for language selection tab in options was larger than the other tabs, this unifies it to be equally small (I note 'About' menu has larger font... mostly)
3. @bszlrd suggested adding a "breadcrumb" link to translation wiki from the language selection page. Alas, I had imagined having it beneath the language selection table, rather than a part of it but my pigui skills are running low at the moment. As I was about to localize the string I realized it might actually be better to have it hard coded in English, so not translatable for now.

share opinions!
<img width="687" height="642" alt="2026-07-19-101426_687x642_scrot" src="https://github.com/user-attachments/assets/3fd6c674-40a7-44d0-90f3-2668b23eabf3" />

