### PR TITLE
Persist NPC names and faces

### DIFF
--- a/data/culture/culture.lua
+++ b/data/culture/culture.lua
@@ -92,7 +92,7 @@ end
 --
 function Culture:FirstName (isFemale, rand, culture)
 	local c = self.lookup[culture] or utils.chooseNormalized(self.weights, rand).lang
-	return c:FirstName(isFemale)
+	return c:FirstName(isFemale, rand)
 end
 
 --
@@ -147,7 +147,7 @@ function Culture:FullName (isFemale, rand, culture)
 
 	-- local debug_code = "(".. c.code .. ") "
 	-- return debug_code .. c:FullName(isFemale, rand)
-	return c:FullName(isFemale)
+	return c:FullName(isFemale, rand)
 end
 
 --
@@ -182,7 +182,7 @@ end
 function Culture:Names (isFemale, rand, culture)
 	-- if 'culture' given as a string, e.g. "Russian" use that
 	local c = self.lookup[culture] or utils.chooseNormalized(self.weights, rand).lang
-	return c:FirstName(isFemale), c:Surname(isFemale), c.name
+	return c:FirstName(isFemale, rand), c:Surname(isFemale, rand), c.name
 end
 
 return Culture

--- a/data/pigui/libs/face.lua
+++ b/data/pigui/libs/face.lua
@@ -2,6 +2,7 @@
 -- Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
 
 local Engine = require 'Engine'
+local Rand = require 'Rand'
 local FaceTextureGenerator = require 'PiGui.Modules.Face'
 local Character = require 'Character'
 
@@ -26,19 +27,20 @@ local ensureCharacter = function (character)
 	return character
 end
 
-local function rerollFaceDesc(oldDesc)
+local function rerollFaceDesc(oldDesc, rand)
+	rand = rand or Engine.rand
 	return {
 		--Fit Integer by 2 into an signed int
-		FEATURE_SPECIES = Engine.rand:Integer() % 2^31,
-		FEATURE_RACE = Engine.rand:Integer() % 2^31,
+		FEATURE_SPECIES = rand:Integer() % 2^31,
+		FEATURE_RACE = rand:Integer() % 2^31,
 		FEATURE_GENDER = oldDesc.FEATURE_GENDER or 0,
-		FEATURE_HEAD = Engine.rand:Integer() % 2^31,
-		FEATURE_EYES = Engine.rand:Integer() % 2^31,
-		FEATURE_NOSE = Engine.rand:Integer() % 2^31,
-		FEATURE_MOUTH = Engine.rand:Integer() % 2^31,
-		FEATURE_HAIRSTYLE = Engine.rand:Integer() % 2^31,
-		FEATURE_ACCESSORIES = Engine.rand:Integer() % 4 == 0 and Engine.rand:Integer() % 2^31 or 0, -- accessory on one out of four faces
-		FEATURE_CLOTHES = Engine.rand:Integer() % 2^31,
+		FEATURE_HEAD = rand:Integer() % 2^31,
+		FEATURE_EYES = rand:Integer() % 2^31,
+		FEATURE_NOSE = rand:Integer() % 2^31,
+		FEATURE_MOUTH = rand:Integer() % 2^31,
+		FEATURE_HAIRSTYLE = rand:Integer() % 2^31,
+		FEATURE_ACCESSORIES = rand:Integer() % 4 == 0 and rand:Integer() % 2^31 or 0, -- accessory on one out of four faces
+		FEATURE_CLOTHES = rand:Integer() % 2^31,
 		FEATURE_ARMOUR = oldDesc.FEATURE_ARMOUR or 0,
 	}
 end
@@ -48,10 +50,11 @@ local PiGuiFace = {}
 function PiGuiFace.New (character, style, drawButtons)
 	character = ensureCharacter(character)
 	style = style or {}
-	character.faceDescription = character.faceDescription or rerollFaceDesc {
+	-- Derive face features from character.seed so the same NPC always looks the same.
+	character.faceDescription = character.faceDescription or rerollFaceDesc({
 		FEATURE_GENDER = character.female and 1 or 0,
 		FEATURE_ARMOUR = character.armour and 1 or 0,
-	}
+	}, Rand.New(tostring(character.seed) .. "-face"))
 
 	local faceTexGen = FaceTextureGenerator.New(character.faceDescription, character.seed)
 	local piguiFace = {


### PR DESCRIPTION
Fixes #6400. 

The existing code set everything up to use a per-station and per-character fixed seed to ensure that NPCs stayed the same each time, but missed the last step where you have to pass that fixed seed into the name and face generation functions. So it ended up generating new names and faces from the global game engine randomizer each time instead.

This PR makes things behave the way I think they were intended, so now the station manager at Mars High doesn't change every time you land there, and Duva Holdings always has the same cool guy fronting it.