### PR TITLE
Initialize the Lua console when the app starts

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -404,6 +404,19 @@ void Pi::App::OnStartup()
 	if (!m_noGui)
 		QueueLifecycle(m_mainMenu);
 
+	Output("Lua::Init()\n");
+	Lua::Init(Pi::GetAsyncJobQueue());
+
+	Pi::luaConsole.reset(new LuaConsole());
+	Pi::luaConsole->SetupBindings();
+
+#ifdef REMOTE_LUA_REPL
+#ifndef REMOTE_LUA_REPL_PORT
+#define REMOTE_LUA_REPL_PORT 12345
+#endif
+	Pi::luaConsole->OpenTCPDebugConnection(REMOTE_LUA_REPL_PORT);
+#endif
+
 	startupTimer.Stop();
 	Output("\n\nEngine startup took %.2fms\n", startupTimer.milliseconds());
 }
@@ -419,6 +432,10 @@ void Pi::App::OnShutdown()
 {
 	PROFILE_SCOPED()
 	Output("Pi shutting down.\n");
+
+#ifdef REMOTE_LUA_REPL
+	Pi::luaConsole->CloseTCPDebugConnection();
+#endif
 
 	// This function should only be called at the very end of the shutdown procedure.
 	assert(Pi::game == nullptr);
@@ -508,13 +525,7 @@ void StartupScreen::Start()
 	m_loadTimer.Start();
 
 	Output("ShipType::Init()\n");
-	// XXX early, Lua init needs it
 	ShipType::Init();
-
-	// XXX UI requires Lua  but Pi::ui must exist before we start loading
-	// templates. so now we have crap everywhere :/
-	Output("Lua::Init()\n");
-	Lua::Init(Pi::GetAsyncJobQueue());
 
 	// TODO: Get the lua state responsible for drawing the init progress up as fast as possible
 	// Investigate using a pigui-only Lua state that we can initialize without depending on
@@ -594,13 +605,11 @@ void StartupScreen::Start()
 	});
 
 	AddStep("PostLoad", []() {
-		Pi::luaConsole.reset(new LuaConsole());
-		Pi::luaConsole->SetupBindings();
-
 		Pi::planner = new TransferPlanner();
 
 		perfInfoDisplay.reset(new PiGui::PerfInfo());
 	});
+
 }
 
 void StartupScreen::Update(float deltaTime)
@@ -877,6 +886,9 @@ void Pi::App::PreUpdate()
 {
 	PROFILE_SCOPED()
 	Pi::frameTime = DeltaTime();
+#ifdef REMOTE_LUA_REPL
+	Pi::luaConsole->HandleTCPDebugConnections();
+#endif
 }
 
 void Pi::App::PostUpdate()
@@ -911,13 +923,6 @@ void GameLoop::Start()
 	Pi::player->onLanded.connect(sigc::ptr_fun(&OnPlayerDockOrUndock));
 	Pi::DrawGUI = true;
 	Pi::SetView(Pi::game->GetWorldView());
-
-#ifdef REMOTE_LUA_REPL
-#ifndef REMOTE_LUA_REPL_PORT
-#define REMOTE_LUA_REPL_PORT 12345
-#endif
-	Pi::luaConsole->OpenTCPDebugConnection(REMOTE_LUA_REPL_PORT);
-#endif
 
 	// fire event before the first frame
 	LuaEvent::Queue("onGameStart");
@@ -1033,10 +1038,6 @@ void GameLoop::Update(float deltaTime)
 	// capable of handling that eventuality and it prevents application-scope crashes
 	Pi::renderer->FlushCommandBuffers();
 
-#ifdef REMOTE_LUA_REPL
-	Pi::luaConsole->HandleTCPDebugConnections();
-#endif
-
 	// Ask ImGui to hide OS cursor if we're capturing it for input:
 	// it will do this if GetMouseCursor == ImGuiMouseCursor_None.
 	if (Pi::input->IsCapturingMouse()) {
@@ -1134,10 +1135,6 @@ void GameLoop::End()
 
 	// Clean up any left-over mouse state
 	Pi::input->SetCapturingMouse(false);
-
-#ifdef REMOTE_LUA_REPL
-	Pi::luaConsole->CloseTCPDebugConnection();
-#endif
 
 	// we have to make sure to autosave the game before the end game process starts
 	LuaEvent::Queue("onAutoSaveBeforeGameEnds");

--- a/src/lua/LuaConsole.cpp
+++ b/src/lua/LuaConsole.cpp
@@ -43,6 +43,23 @@ static const char CONSOLE_CHUNK_NAME[] = "console";
 
 static constexpr int EDIT_BUFFER_LENGTH = 1024;
 
+// Create the table and leave a copy on the stack for further use
+static void init_global_table(lua_State *l)
+{
+	LUA_DEBUG_START(l);
+
+	lua_newtable(l);
+	lua_newtable(l);
+	lua_pushliteral(l, "__index");
+	lua_getglobal(l, "_G");
+	lua_rawset(l, -3);
+	lua_setmetatable(l, -2);
+	lua_pushvalue(l, -1);
+	lua_setfield(l, LUA_REGISTRYINDEX, "ConsoleGlobal");
+
+	LUA_DEBUG_END(l, 1);
+}
+
 LuaConsole::LuaConsole() :
 	m_active(false),
 	m_inputFrame(Pi::input),
@@ -58,6 +75,8 @@ LuaConsole::LuaConsole() :
 	m_logCallbackConn = Log::GetLog()->printCallback.connect(sigc::mem_fun(this, &LuaConsole::LogCallback));
 	m_editBuffer.reset(new char[EDIT_BUFFER_LENGTH]);
 	std::fill_n(m_editBuffer.get(), EDIT_BUFFER_LENGTH, '\0');
+
+	init_global_table(Lua::manager->GetLuaState()); // _ENV
 }
 
 REGISTER_INPUT_BINDING(LuaConsole)
@@ -91,23 +110,6 @@ static int capture_traceback(lua_State *L)
 	luaL_traceback(L, L, nullptr, 0);
 	lua_concat(L, 3);
 	return 1;
-}
-
-// Create the table and leave a copy on the stack for further use
-static void init_global_table(lua_State *l)
-{
-	LUA_DEBUG_START(l);
-
-	lua_newtable(l);
-	lua_newtable(l);
-	lua_pushliteral(l, "__index");
-	lua_getglobal(l, "_G");
-	lua_rawset(l, -3);
-	lua_setmetatable(l, -2);
-	lua_pushvalue(l, -1);
-	lua_setfield(l, LUA_REGISTRYINDEX, "ConsoleGlobal");
-
-	LUA_DEBUG_END(l, 1);
 }
 
 static int console_autoexec(lua_State *l)


### PR DESCRIPTION
This will also allow to launch a remote debugging console earlier, before launching the game itself, and debug the start menu, for example.

Put `Pi::luaConsole->HandleTCPDebugConnections` in `Pi::App::PreUpdate` so this will work no matter what `LifeCycle` is active.

Put `Pi::luaConsole.reset` in `Pi::App::OnStartup` to ensure that `Pi::luaConsole` is never null on `Pi::luaConsole->HandleTCPDebugConnections`.

Put `init_global_table` in `LuaConsole` constructor so that the console works normally in the main menu.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

