### PR TITLE
Missile exhaust improvements

### DIFF
--- a/data/shaders/opengl/exhaust.frag
+++ b/data/shaders/opengl/exhaust.frag
@@ -6,6 +6,7 @@
 
 in vec2 v_uv;
 in vec4 v_color;
+in float v_noiseStrength;
 
 out vec4 frag_color;
 
@@ -39,7 +40,7 @@ void main(void)
 	// Increase noise_cells for smaller blobs, decrease for larger ones.
 	const float noise_cells = 3.0;
 	vec2 pos = v_uv * noise_cells;
-	float noise_val = noise(pos) * 2.0 + 0.5;
+	float noise_val = noise(pos) * v_noiseStrength + 0.5;
 
 	float alpha = v_color.a * edge * noise_val;
 	frag_color = vec4(v_color.rgb, alpha);

--- a/data/shaders/opengl/exhaust.vert
+++ b/data/shaders/opengl/exhaust.vert
@@ -8,10 +8,12 @@
 layout (location = 6) in vec4 a_instCenterSize;
 layout (location = 7) in vec4 a_instJetVector;
 layout (location = 8) in float a_instStretchScale;
-layout (location = 9) in vec4 a_instColor;
+layout (location = 9) in float a_instNoiseStrength;
+layout (location = 10) in vec4 a_instColor;
 
 out vec2 v_uv;
 out vec4 v_color;
+out float v_noiseStrength;
 
 vec3 normalizedSafe(vec3 v)
 {
@@ -57,4 +59,5 @@ void main(void)
 	gl_Position = uViewProjectionMatrix * vec4(worldPos, 1.0);
 	v_uv = uv;
 	v_color = a_instColor;
+	v_noiseStrength = a_instNoiseStrength;
 }

--- a/src/Missile.cpp
+++ b/src/Missile.cpp
@@ -3,10 +3,13 @@
 
 #include "Missile.h"
 
+#include "Frame.h"
 #include "Game.h"
 #include "Lang.h"
 #include "Json.h"
 #include "Pi.h"
+#include "Planet.h"
+#include "Player.h"
 #include "Sfx.h"
 #include "Ship.h"
 #include "ShipAICmd.h"
@@ -48,6 +51,7 @@ void Missile::Init()
 	m_decelerating = false;
 
 	m_propulsion->Init(this, GetModel(), m_type->fuelTankMass, m_type->effectiveExhaustVelocity, m_type->linThrust, m_type->angThrust);
+	m_exhaustSpawner.RefreshMounts(GetModel());
 }
 
 Missile::Missile(const Json &jsonObj, Space *space) :
@@ -79,6 +83,7 @@ Missile::Missile(const Json &jsonObj, Space *space) :
 	}
 
 	m_propulsion->Init(this, GetModel(), m_type->fuelTankMass, m_type->effectiveExhaustVelocity, m_type->linThrust, m_type->angThrust);
+	m_exhaustSpawner.RefreshMounts(GetModel());
 }
 
 void Missile::SaveToJson(Json &jsonObj, Space *space)
@@ -112,6 +117,13 @@ void Missile::PostLoadFixup(Space *space)
 	if (m_curAICmd) m_curAICmd->PostLoadFixup(space);
 }
 
+void Missile::SetFrame(FrameId fId)
+{
+	if (fId != GetFrame())
+		m_exhaustSpawner.ClearChannelState();
+	DynamicBody::SetFrame(fId);
+}
+
 Missile::~Missile()
 {
 	if (m_curAICmd) delete m_curAICmd;
@@ -136,15 +148,49 @@ void Missile::StaticUpdate(const float timeStep)
 		delete m_curAICmd;
 		m_curAICmd = nullptr;
 	}
-	//Add smoke trails for missiles on thruster state
-	static double s_timeAccum = 0.0;
-	s_timeAccum += timeStep;
-	if (!is_equal_exact(m_propulsion->GetLinThrusterState().LengthSqr(), 0.0) && (s_timeAccum > 4 || 0.1 * Pi::rng.Double() < timeStep)) {
-		s_timeAccum = 0.0;
-		const vector3d pos = GetOrient() * vector3d(0, 0, 5);
-		const float speed = std::min(10.0 * GetVelocity().Length() * std::max(1.0, fabs(m_propulsion->GetLinThrusterState().z)), 100.0);
-		SfxManager::AddThrustSmoke(this, speed, pos);
+
+	SpawnThrusterExhaustParticles(timeStep);
+}
+
+void Missile::SpawnThrusterExhaustParticles(float timeStep)
+{
+	if (IsDead()) return;
+
+	if (is_equal_exact(m_propulsion->GetLinThrusterState().LengthSqr(), 0.0)) {
+		m_exhaustSpawner.ClearChannelState();
+		return;
 	}
+
+	constexpr double EXHAUST_MAX_PLAYER_DISTANCE_SQR = SfxParams::EXHAUST_MAX_PLAYER_DISTANCE * SfxParams::EXHAUST_MAX_PLAYER_DISTANCE;
+	const bool spawnExhaust = !Pi::player || (GetPositionRelTo(Pi::player).LengthSqr() <= EXHAUST_MAX_PLAYER_DISTANCE_SQR);
+	if (!spawnExhaust) {
+		m_exhaustSpawner.ClearChannelState();
+		return;
+	}
+
+	ExhaustEnvironment env;
+	env.opacityAtmosphereFactor = 1.0f;
+	env.baseLifetime = SfxParams::MISSILE_EXHAUST_LIFETIME;
+	env.maxSpread = SfxParams::MISSILE_EXHAUST_MAX_SPREAD;
+
+	Frame *frame = Frame::GetFrame(GetFrame());
+	Body *astro = frame ? frame->GetBody() : nullptr;
+	if (astro && astro->IsType(ObjectType::PLANET)) {
+		Planet *p = static_cast<Planet *>(astro);
+		const double dist = GetPosition().Length();
+		double pressureAtDist, density;
+		p->GetAtmosphericState(dist, &pressureAtDist, &density);
+		(void)pressureAtDist;
+		env.density = density;
+
+		const vector3f localUp = vector3f(GetPosition().NormalizedSafe());
+		vector3f windDir = vector3f(0.f, 1.f, 0.f).Cross(localUp);
+		if (windDir.LengthSqr() < 1e-8f) windDir = vector3f(1.f, 0.f, 0.f).Cross(localUp);
+		windDir = windDir.NormalizedSafe();
+		env.windVel = windDir * (SfxParams::EXHAUST_WIND_SPEED * float(Clamp(density, 0.0, 1.0)));
+	}
+
+	m_exhaustSpawner.Spawn(this, m_propulsion, timeStep, env, SfxParams::MISSILE_EXHAUST_PARTICLES_PER_SEC);
 }
 
 bool Missile::IsValidTarget(const Body *body)

--- a/src/Missile.h
+++ b/src/Missile.h
@@ -6,6 +6,7 @@
 
 #include "DynamicBody.h"
 #include "ShipType.h"
+#include "ThrusterExhaust.h"
 
 class AICommand;
 
@@ -42,6 +43,7 @@ public:
 	bool OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData) override;
 	void NotifyRemoved(const Body *const removedBody) override;
 	void PostLoadFixup(Space *space) override;
+	void SetFrame(FrameId fId) override;
 	void Render(Graphics::Renderer *r, const Camera *camera, const vector3d &viewCoords, const matrix4x4d &viewTransform) override;
 	void ECMAttack(int power_val);
 
@@ -58,7 +60,10 @@ protected:
 
 private:
 	void Explode();
+	void SpawnThrusterExhaustParticles(float timeStep);
 	bool IsValidTarget(const Body *body);
+
+	ThrusterExhaustSpawner m_exhaustSpawner;
 
 	AICommand *m_curAICmd;
 	Body *m_owner;

--- a/src/Sfx.cpp
+++ b/src/Sfx.cpp
@@ -63,16 +63,17 @@ namespace {
 	// Reused each exhaust draw, cleared at the start of every pass.
 	std::map<ExhaustJetStreamKey, std::vector<Sfx *>> s_exhaustByJet;
 
-	// GPU instance record for instanced exhaust quads (40-byte stride, binding 1).
+	// GPU instance record for instanced exhaust quads (44-byte stride, binding 1).
 	struct ExhaustInstanceData {
 		vector3f center;
 		float size;
 		vector3f jetVectorCam;
 		float backboneCamZ;
 		float stretchScale;
+		float noiseStrength;
 		Color color;
 	};
-	static_assert(sizeof(ExhaustInstanceData) == 40);
+	static_assert(sizeof(ExhaustInstanceData) == 44);
 
 	Graphics::VertexFormatDesc BuildExhaustInstancedVertexFormat()
 	{
@@ -81,7 +82,8 @@ namespace {
 		vtxFormat.attribs[0] = { Graphics::ATTRIB_FORMAT_FLOAT4, 6, 0, 0 };
 		vtxFormat.attribs[1] = { Graphics::ATTRIB_FORMAT_FLOAT4, 7, 0, 16 };
 		vtxFormat.attribs[2] = { Graphics::ATTRIB_FORMAT_FLOAT, 8, 0, 32 };
-		vtxFormat.attribs[3] = { Graphics::ATTRIB_FORMAT_UBYTE4, 9, 0, 36 };
+		vtxFormat.attribs[3] = { Graphics::ATTRIB_FORMAT_FLOAT, 9, 0, 36 };
+		vtxFormat.attribs[4] = { Graphics::ATTRIB_FORMAT_UBYTE4, 10, 0, 40 };
 		vtxFormat.bindings[0] = { sizeof(ExhaustInstanceData), true, Graphics::ATTRIB_RATE_INSTANCE };
 		assert(vtxFormat.ValidateDesc() == Graphics::InvalidVertexFormatReason::OK);
 		return vtxFormat;
@@ -185,7 +187,9 @@ Sfx::Sfx(const vector3d &pos, const vector3d &vel, const float speed, const SFX_
 	m_exhaustDustTint(0, 0, 0, 0),
 	m_exhaustGroundRadius(0.0),
 	m_dragScale(1.0f),
-	m_windVel(vector3f::Zero)
+	m_windVel(vector3f::Zero),
+	m_exhaustMaxSpread(SfxParams::EXHAUST_MAX_SPREAD),
+	m_exhaustNoiseStrength(0.f)
 {
 }
 
@@ -213,6 +217,8 @@ Sfx::Sfx(const Json &jsonObj)
 		m_exhaustGroundRadius = sfxObj.value("exhaustGroundRadius", 0.0);
 		m_exhaustDustKick = sfxObj.value("exhaustDustKick", false);
 		m_exhaustDustTint = sfxObj.value("exhaustDustTint", Color(0, 0, 0, 0));
+		m_exhaustMaxSpread = sfxObj.value("exhaustMaxSpread", SfxParams::EXHAUST_MAX_SPREAD);
+		m_exhaustNoiseStrength = sfxObj.value("exhaustNoiseStrength", 0.f);
 	} catch (Json::type_error &) {
 		throw SavedGameCorruptException();
 	}
@@ -241,6 +247,8 @@ void Sfx::SaveToJson(Json &jsonObj, const Space *space)
 		sfxObj["exhaustGroundRadius"] = m_exhaustGroundRadius;
 		sfxObj["exhaustDustKick"] = m_exhaustDustKick;
 		sfxObj["exhaustDustTint"] = m_exhaustDustTint;
+		sfxObj["exhaustMaxSpread"] = m_exhaustMaxSpread;
+		sfxObj["exhaustNoiseStrength"] = m_exhaustNoiseStrength;
 	}
 	sfxObj["age"] = m_age;
 	sfxObj["seed"] = m_seed;
@@ -390,7 +398,7 @@ void SfxManager::AddThrustSmoke(const Body *b, const float speed, const vector3d
 	sfxman->AddInstance(sfx);
 }
 
-void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const bool exhaustSuppressStreakElongation, const vector3d &startPos, const vector3d &backboneVel, const vector3f &plumeOffset, const vector3f &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3f &windVel, const double groundRadius, const Color &dustTint)
+void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const bool exhaustSuppressStreakElongation, const vector3d &startPos, const vector3d &backboneVel, const vector3f &plumeOffset, const vector3f &plumeOffsetVel, const float intensity, const float dragScale, const float opacityScale, const vector3f &windVel, const double groundRadius, const Color &dustTint, const float baseLifetime, const float maxSpread, const float noiseStrength)
 {
 	PROFILE_SCOPED()
 
@@ -412,13 +420,15 @@ void SfxManager::AddExhaust(const Body *b, const Uint16 exhaustJetIndex, const b
 	// Give each exhaust particle a random lifetime, except for the "marker" particles which only exist to pinpoint
 	// the start of an exhaust pulse. Those stay alive as long as possible because if they disappear early then the
 	// next particle may try to streak back to an earlier one instead of stopping where it should.
-	sfx.m_lifetime = SfxParams::EXHAUST_LIFETIME + 0.5f;
+	sfx.m_lifetime = baseLifetime + 0.5f;
 	if (!exhaustSuppressStreakElongation)
-		sfx.m_lifetime = SfxParams::EXHAUST_LIFETIME * float(std::pow(Pi::rng.Double(0.5, 1.0), 2.0));
+		sfx.m_lifetime = baseLifetime * float(std::pow(Pi::rng.Double(0.5, 1.0), 2.0));
 
 	sfx.m_exhaustGroundRadius = groundRadius;
 	sfx.m_exhaustDustKick = false;
 	sfx.m_exhaustDustTint = dustTint;
+	sfx.m_exhaustMaxSpread = maxSpread;
+	sfx.m_exhaustNoiseStrength = noiseStrength;
 	sfxman->AddInstance(sfx);
 }
 
@@ -573,7 +583,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 						// any thin lines coming from the thruster nozzle, preferring a later "emerging contrail" effect.
 						if (inst.m_age < SfxParams::EXHAUST_TIME_BEFORE_SPREAD) continue;
 
-						float size = std::max(0.01f, float(inst.m_plumeOffset.Length()));
+						float size = std::max(0.01f, inst.m_exhaustMaxSpread * ageNorm);
 						if (inst.m_exhaustDustKick)
 							size = SfxParams::EXHAUST_DUST_SIZE * ageNorm * std::max(inst.m_speed, 0.2f);
 
@@ -602,6 +612,7 @@ void SfxManager::RenderAll(Renderer *renderer, FrameId fId, FrameId camFrameId, 
 							jetVectorCam,
 							interpBackboneCam.z,
 							stretchScale,
+							inst.m_exhaustNoiseStrength,
 							particleColor,
 						});
 					}

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -30,12 +30,17 @@ enum SFX_TYPE {
 };
 
 namespace SfxParams {
+	inline constexpr float MISSILE_EXHAUST_PARTICLES_PER_SEC = 600.0f;
+	inline constexpr float MISSILE_EXHAUST_LIFETIME = 5.0f;
+	inline constexpr float MISSILE_EXHAUST_MAX_SPREAD = 20.0f;
+
 	inline constexpr float EXHAUST_MAX_PLAYER_DISTANCE = 5000.0f;
 	inline constexpr float EXHAUST_INITIAL_VELOCITY = 320.0f;
 	inline constexpr float EXHAUST_INITIAL_SPREAD = 0.1f;
 	inline constexpr float EXHAUST_TIME_BEFORE_SPREAD = 0.05f;
 	inline constexpr float EXHAUST_MAX_SPREAD = 50.0f;
 	inline constexpr float EXHAUST_DUST_SIZE = 200.0f;
+	inline constexpr float EXHAUST_NOISE_STRENGTH = 2.0f;	// Fragment noise amplitude at sea-level air density
 	inline constexpr float EXHAUST_LIFETIME = 10.0f;
 	inline constexpr float EXHAUST_WIND_SPEED = 32.0f;
 	inline constexpr float EXHAUST_PARTICLES_PER_SHIP_PER_SEC = 1800.0f;
@@ -103,6 +108,8 @@ struct Sfx {
 	// Atmospheric behaviour - if planet wind is implemented then this would be the hook for making thruster plumes blow about
 	float m_dragScale;   // per emitter (ship), constant for all jets on a spawn tick
 	vector3f m_windVel;  // per emitter, constant for all jets on a spawn tick
+	float m_exhaustMaxSpread; // per emitter, constant for all jets on a spawn tick
+	float m_exhaustNoiseStrength; // per emitter; scales procedural fragment noise with atmosphere density
 
 	static constexpr Uint32 INVALID_EXHAUST_SAVED_BODY_IDX = Uint32(0xffffffffu);
 };
@@ -114,7 +121,7 @@ public:
 	static void Add(const Body *, SFX_TYPE);
 	static void AddExplosion(Body *);
 	static void AddThrustSmoke(const Body *b, float speed, const vector3d &adjustpos);
-	static void AddExhaust(const Body *b, Uint16 exhaustJetIndex, bool exhaustSuppressStreakElongation, const vector3d &backboneAdjustPos, const vector3d &backboneVel, const vector3f &plumeOffset, const vector3f &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3f &windVel, double groundRadius, const Color &dustTint);
+	static void AddExhaust(const Body *b, Uint16 exhaustJetIndex, bool exhaustSuppressStreakElongation, const vector3d &startPos, const vector3d &backboneVel, const vector3f &plumeOffset, const vector3f &plumeOffsetVel, float intensity, float dragScale, float opacityScale, const vector3f &windVel, double groundRadius, const Color &dustTint, float baseLifetime = SfxParams::EXHAUST_LIFETIME, float maxSpread = SfxParams::EXHAUST_MAX_SPREAD, float noiseStrength = 0.f);
 	static void TimeStepAll(const float timeStep, FrameId f);
 	static void RenderAll(Graphics::Renderer *r, FrameId f, FrameId camFrame, float illuminationFactor = 1.f);
 	static void ToJson(Json &jsonObj, const FrameId f, const Space *space);

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -32,7 +32,7 @@
 #include "scenegraph/MatrixTransform.h"
 #include "scenegraph/Model.h"
 #include "scenegraph/Tag.h"
-#include "scenegraph/Thruster.h"
+#include "ThrusterExhaust.h"
 #include "scenegraph/CollisionGeometry.h"
 #include "ship/GunManager.h"
 #include "ship/PlayerShipController.h"
@@ -279,40 +279,6 @@ Ship::~Ship()
 	delete m_controller;
 }
 
-void Ship::RefreshThrusterExhaustMounts()
-{
-	m_thrusterExhaustMounts.clear();
-	m_thrusterExhaustThrusters.clear();
-	if (!GetModel()) return;
-
-	std::vector<std::pair<SceneGraph::MatrixTransform *, SceneGraph::Thruster *>> tmp;
-	GetModel()->GatherThrusterMounts(tmp);
-
-	std::vector<float> thrusterScaleAvg;
-	thrusterScaleAvg.reserve(tmp.size());
-	float maxThrusterScale = 0.0f;
-	for (const auto &pr : tmp) {
-		const matrix4x4f M = pr.first->CalcGlobalTransform();
-		const float sx = vector3f(M[0], M[1], M[2]).Length();
-		const float sy = vector3f(M[4], M[5], M[6]).Length();
-		const float sz = vector3f(M[8], M[9], M[10]).Length();
-		const float scaleAvg = (sx + sy + sz) / 3.0f;
-		thrusterScaleAvg.push_back(scaleAvg);
-		maxThrusterScale = std::max(maxThrusterScale, scaleAvg);
-	}
-	m_thrusterExhaustMounts.reserve(tmp.size());
-	m_thrusterExhaustThrusters.reserve(tmp.size());
-	for (size_t i = 0; i < tmp.size(); ++i) {
-		const auto &pr = tmp[i];
-		m_thrusterExhaustMounts.push_back(pr.first);
-		m_thrusterExhaustThrusters.push_back(pr.second);
-		const float scaleAvg = thrusterScaleAvg[i];
-		const float scaleProportional = (maxThrusterScale > 1e-6f) ? (scaleAvg / maxThrusterScale) : 1.0f;
-		pr.second->SetVisualSizeInfo(scaleAvg, scaleProportional);
-	}
-	m_exhaustThrusterChannels.assign(tmp.size(), ExhaustThrusterChannel{});
-}
-
 void Ship::Init()
 {
 	m_invulnerable = false;
@@ -358,7 +324,7 @@ void Ship::Init()
 
 	InitMaterials();
 
-	RefreshThrusterExhaustMounts();
+	m_exhaustSpawner.RefreshMounts(GetModel());
 }
 
 void Ship::PostLoadFixup(Space *space)
@@ -1036,10 +1002,7 @@ void Ship::SetLandedOn(Planet *p, float latitude, float longitude)
 void Ship::SetFrame(FrameId fId)
 {
 	if (fId != GetFrame()) {
-		for (auto &ch : m_exhaustThrusterChannels) {
-			ch.hasLastNozzle = false;
-			ch.wasThrusterFiring = false;
-		}
+		m_exhaustSpawner.ClearChannelState();
 	}
 	DynamicBody::SetFrame(fId);
 }
@@ -1515,22 +1478,9 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 
 	if (!spawnExhaustForShip || !lowAltitudePlumes) {
 		// We're not adding any exhaust this tick. Clear the thruster exhaust channels so there is no stale state.
-		for (auto &ch : m_exhaustThrusterChannels) {
-			ch.hasLastNozzle = false;
-			ch.wasThrusterFiring = false;
-		}
+		m_exhaustSpawner.ClearChannelState();
 		return;
 	}
-
-	const vector3f linT = vector3f(m_propulsion->GetLinThrusterState());
-	const vector3f angT = -vector3f(m_propulsion->GetAngThrusterState());
-
-	// How hard linear thrusters are firing vs a ship-wide reference (larger of up / forward max thrust).
-	const double maxRefThrust = std::max(m_propulsion->GetThrust(THRUSTER_UP), m_propulsion->GetThrust(THRUSTER_FORWARD));
-	const vector3d actualLinThrust = m_propulsion->GetActualLinThrust();
-	const vector3d actualAngThrust = m_propulsion->GetActualAngThrust();
-	const float linThrustEffortScalar = actualLinThrust.Length() / maxRefThrust;
-	const float angThrustEffortScalar = actualAngThrust.Length() * SfxParams::EXHAUST_ANGULAR_FACTOR / m_propulsion->GetAngThrustCap();
 
 	// Simple ambient wind model: fixed-speed direction tangent to local surface.
 	const vector3f localUp = vector3f(GetPosition().NormalizedSafe());
@@ -1539,111 +1489,14 @@ void Ship::SpawnThrusterExhaustParticles(float timeStep)
 	windDir = windDir.NormalizedSafe();
 	const vector3f windVel = windDir * (SfxParams::EXHAUST_WIND_SPEED * float(Clamp(density, 0.0, 1.0)));
 
-	if (m_thrusterExhaustMounts.size() != m_thrusterExhaustThrusters.size())
-		RefreshThrusterExhaustMounts();
-	if (m_exhaustThrusterChannels.size() != m_thrusterExhaustMounts.size())
-		m_exhaustThrusterChannels.assign(m_thrusterExhaustMounts.size(), ExhaustThrusterChannel{});
+	ExhaustEnvironment env;
+	env.density = density;
+	env.opacityAtmosphereFactor = float(density / 1.225);
+	env.windVel = windVel;
+	env.groundRadius = groundRadiusAtShip;
+	env.dustTint = dustTint;
 
-	const float atmosDragScale = float(Clamp(density / 1.225, 0.0, 2.0));
-
-	const matrix3x3d &bodyOrient = GetOrient();
-
-	// Some ships have lots of small thrusters next to each other. Others have one big one.
-	// We use the same number of particles per ship, since small adjacent streams will merge
-	// visually anyway, and we this way we don't end up with too many particles on some ships
-	// and not enough on others.
-	const float particlesPerSecPerThruster = SfxParams::EXHAUST_PARTICLES_PER_SHIP_PER_SEC / m_thrusterExhaustMounts.size();
-
-	for (size_t ti = 0; ti < m_thrusterExhaustMounts.size(); ++ti) {
-		SceneGraph::MatrixTransform *mt = m_thrusterExhaustMounts[ti];
-		SceneGraph::Thruster *thr = m_thrusterExhaustThrusters[ti];
-		ExhaustThrusterChannel &ch = m_exhaustThrusterChannels[ti];
-
-		const matrix4x4f M = mt->CalcGlobalTransform();
-		const vector3d nozzleLocal = vector3d(M.GetTranslate());
-		const vector3d exhaustDirModel = vector3d(thr->GetDirection()).NormalizedSafe();
-		const vector3d currentNozzleWorld = GetPosition() + bodyOrient * nozzleLocal;
-
-		if (!ch.hasLastNozzle) {
-			ch.lastNozzleWorld = currentNozzleWorld;
-			ch.hasLastNozzle = true;
-		}
-
-		// Get the amount that each thruster is firing this tick.
-		// Scale by thruster visual size and overall thrust demand
-		SceneGraph::Thruster *th = m_thrusterExhaustThrusters[ti];
-		const float visualScaled = th->GetVisualSizeProportional();
-		// Same combined reaction as model thruster flames 
-		const float reactionPower = th->ComputeReactionPower(linT, angT);
-		const float linOnly = th->ComputeReactionPower(linT, vector3f(0.f));
-		const float angOnly = th->ComputeReactionPower(vector3f(0.f), angT);
-		const float effortScalar = (angOnly >= linOnly) ? angThrustEffortScalar : linThrustEffortScalar;
-		const float unscaledPower = reactionPower * visualScaled * effortScalar;
-		// Use a log scale on the final thruster power so that tiny maneouvering thrusters are still visible compared to huge delta-V ones
-		const float finalThrusterPower = std::log(1.0f + SfxParams::EXHAUST_LOG_SCALE * unscaledPower) / std::log(1.0f + SfxParams::EXHAUST_LOG_SCALE);
-
-		const bool firing = finalThrusterPower >= SfxParams::EXHAUST_MIN_REACTION_POWER;
-		const bool newPulseLeadingEdge = firing && !ch.wasThrusterFiring;
-
-		vector3d exhaustDirWorld = bodyOrient * exhaustDirModel;
-		if (exhaustDirWorld.LengthSqr() < 1e-12)
-			exhaustDirWorld = bodyOrient.VectorZ();
-		exhaustDirWorld = exhaustDirWorld.Normalized();
-		const vector3d backboneWorldVel = GetVelocity() + exhaustDirWorld * double(SfxParams::EXHAUST_INITIAL_VELOCITY);
-
-		const vector3d lastBackbonePosWorld = ch.lastNozzleWorld + ch.lastBackboneVel * double(timeStep);
-		ch.lastBackboneVel = backboneWorldVel;
-
-		if (firing) {
-			// Reduce the alpha for weaker thrusters, so that the exhaust is less pronounced
-			const float opacityScale = Clamp((density / 1.225) * double(finalThrusterPower), 0.0, 1.0);
-
-			// Increase drag for weaker thrusters, so that they slow down more quickly (less volume of exhaust)
-			const float dragScale = atmosDragScale * SfxParams::EXHAUST_DRAG_FACTOR / std::max(visualScaled, 0.2f);
-
-			// Keep particle count mostly independent of thrust / density so the stream remains full.
-			// If time is accelerated then timeStep could be huge - limit the number of particles in that case
-			// If timeStep is tiny then ensure we have at least one particle.
-			const float timeStepCapped = std::min(timeStep, SfxParams::EXHAUST_STREAM_TIMESTEP_CAP);
-			const float thrusterEmit = particlesPerSecPerThruster * timeStepCapped * finalThrusterPower;
-			int count = std::max(1, int(thrusterEmit));
-
-			// If this is the first tick where the thruster is firing, then only add one particle
-			// at the current nozzle position as the leading edge. It won't be drawn but will be
-			// used as the starting elongation target on the next tick
-			if (newPulseLeadingEdge)
-				count = 1;
-
-			const vector3f exhaustDirF = vector3f(exhaustDirWorld);
-			const vector3f shipY = vector3f(bodyOrient.VectorY());
-			const vector3f refAxis = (std::abs(exhaustDirF.Dot(shipY)) < 0.85f) ? shipY : vector3f(bodyOrient.VectorZ());
-			vector3f uAxis = refAxis.Cross(exhaustDirF).Normalized();
-			if (uAxis.LengthSqr() < 1e-12f)
-				uAxis = vector3f(bodyOrient.VectorX());
-			const vector3f vAxis = exhaustDirF.Cross(uAxis).Normalized();
-
-			for (int i = 0; i < count; i++) {
-				const double segT = double(i + 1) / double(count);
-				const vector3d nozzleBaseWorld = lastBackbonePosWorld.Lerp(currentNozzleWorld, segT);
-
-				const float jitterRadius = float(Pi::rng.Double(1.0));
-				const float jitterTheta = float(Pi::rng.Double(2.0 * M_PI));
-
-				const vector3f jitterDirW = (uAxis * std::cos(jitterTheta) + vAxis * std::sin(jitterTheta)).Normalized();
-				const vector3f plumeOffset = jitterDirW * (jitterRadius * SfxParams::EXHAUST_INITIAL_SPREAD);
-
-				const float jitterVel = (SfxParams::EXHAUST_MAX_SPREAD * jitterRadius) / SfxParams::EXHAUST_LIFETIME;
-				const float spreadAmp = float(Clamp(1.0 / std::max(density, 1e-5), 0.05, 8.0));
-				const vector3f plumeOffsetVel = jitterDirW * (jitterVel * spreadAmp);
-
-				const bool suppressStreak = newPulseLeadingEdge && (i == 0);
-				SfxManager::AddExhaust(this, Uint16(ti), suppressStreak, nozzleBaseWorld, backboneWorldVel, plumeOffset, plumeOffsetVel, finalThrusterPower, dragScale, opacityScale, windVel, groundRadiusAtShip, dustTint);
-			}
-		}
-
-		ch.wasThrusterFiring = firing;
-		ch.lastNozzleWorld = currentNozzleWorld;
-	}
+	m_exhaustSpawner.Spawn(this, m_propulsion, timeStep, env, SfxParams::EXHAUST_PARTICLES_PER_SHIP_PER_SEC);
 }
 
 void Ship::NotifyRemoved(const Body *const removedBody)

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -15,11 +15,7 @@
 #include "sound/Sound.h"
 
 #include "ship/Propulsion.h"
-
-namespace SceneGraph {
-	class MatrixTransform;
-	class Thruster;
-}
+#include "ThrusterExhaust.h"
 
 class AICommand;
 class Camera;
@@ -356,17 +352,7 @@ private:
 
 	double m_latestSpawnTime = 0.0;
 
-	// Per-thruster atmospheric exhaust (nozzle anchor + jet backbone)
-	struct ExhaustThrusterChannel {
-		bool hasLastNozzle = false;
-		vector3d lastNozzleWorld = vector3d::Zero;
-		vector3d lastBackboneVel = vector3d::Zero;
-		bool wasThrusterFiring = false;
-	};
-	std::vector<SceneGraph::MatrixTransform *> m_thrusterExhaustMounts;
-	std::vector<SceneGraph::Thruster *> m_thrusterExhaustThrusters;
-	std::vector<ExhaustThrusterChannel> m_exhaustThrusterChannels;
-	void RefreshThrusterExhaustMounts();
+	ThrusterExhaustSpawner m_exhaustSpawner;
 	void SpawnThrusterExhaustParticles(float timeStep);
 
 	std::deque<CargoBody *> m_cargoSpawnQueue;

--- a/src/ShipAICmd.cpp
+++ b/src/ShipAICmd.cpp
@@ -304,11 +304,17 @@ bool AICmdKamikaze::TimeStepUpdate()
 		sqrt(aimCollisionSpeed * aimCollisionSpeed + 2 * dist * brake);
 
 	const vector3d aimVel = aimRelSpeed * targetDir + m_target->GetVelocityRelTo(m_dBody->GetFrame());
-	const vector3d accelDir = (aimVel - m_dBody->GetVelocity()).NormalizedSafe();
+	const vector3d velError = aimVel - m_dBody->GetVelocity();
+	// When nearly matched to the desired intercept velocity, velError is tiny and its
+	// direction is numerically unstable. Point at the target instead to avoid terminal wobble.
+	const double faceDirThreshold = aimCollisionSpeed * 0.1;
+	const vector3d faceDir = (velError.LengthSqr() <= faceDirThreshold * faceDirThreshold)
+		? targetDir
+		: velError.NormalizedSafe();
 
 	m_prop->ClearLinThrusterState();
 	m_prop->ClearAngThrusterState();
-	m_prop->AIFaceDirection(accelDir);
+	m_prop->AIFaceDirection(faceDir);
 
 	m_prop->AIAccelToModelRelativeVelocity(aimVel * m_dBody->GetOrient());
 

--- a/src/ThrusterExhaust.cpp
+++ b/src/ThrusterExhaust.cpp
@@ -1,0 +1,180 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#include "ThrusterExhaust.h"
+
+#include "Body.h"
+#include "Pi.h"
+#include "Sfx.h"
+#include "scenegraph/MatrixTransform.h"
+#include "scenegraph/Model.h"
+#include "scenegraph/Thruster.h"
+#include "ship/Propulsion.h"
+
+#include <algorithm>
+#include <cmath>
+
+void ThrusterExhaustSpawner::RefreshMounts(SceneGraph::Model *model)
+{
+	m_mounts.clear();
+	m_thrusters.clear();
+	if (!model) return;
+
+	std::vector<std::pair<SceneGraph::MatrixTransform *, SceneGraph::Thruster *>> tmp;
+	model->GatherThrusterMounts(tmp);
+
+	std::vector<float> thrusterScaleAvg;
+	thrusterScaleAvg.reserve(tmp.size());
+	float maxThrusterScale = 0.0f;
+	for (const auto &pr : tmp) {
+		const matrix4x4f M = pr.first->CalcGlobalTransform();
+		const float sx = vector3f(M[0], M[1], M[2]).Length();
+		const float sy = vector3f(M[4], M[5], M[6]).Length();
+		const float sz = vector3f(M[8], M[9], M[10]).Length();
+		const float scaleAvg = (sx + sy + sz) / 3.0f;
+		thrusterScaleAvg.push_back(scaleAvg);
+		maxThrusterScale = std::max(maxThrusterScale, scaleAvg);
+	}
+	m_mounts.reserve(tmp.size());
+	m_thrusters.reserve(tmp.size());
+	for (size_t i = 0; i < tmp.size(); ++i) {
+		const auto &pr = tmp[i];
+		m_mounts.push_back(pr.first);
+		m_thrusters.push_back(pr.second);
+		const float scaleAvg = thrusterScaleAvg[i];
+		const float scaleProportional = (maxThrusterScale > 1e-6f) ? (scaleAvg / maxThrusterScale) : 1.0f;
+		pr.second->SetVisualSizeInfo(scaleAvg, scaleProportional);
+	}
+	m_channels.assign(tmp.size(), ExhaustThrusterChannel{});
+}
+
+void ThrusterExhaustSpawner::ClearChannelState()
+{
+	for (auto &ch : m_channels) {
+		ch.hasLastNozzle = false;
+		ch.wasThrusterFiring = false;
+	}
+}
+
+void ThrusterExhaustSpawner::Spawn(const Body *body, const Propulsion *propulsion, const float timeStep, const ExhaustEnvironment &env, const float particlesPerSecTotal)
+{
+	if (!body || !propulsion || m_mounts.empty()) return;
+
+	if (m_mounts.size() != m_thrusters.size())
+		return;
+	if (m_channels.size() != m_mounts.size())
+		m_channels.assign(m_mounts.size(), ExhaustThrusterChannel{});
+
+	const vector3f linT = vector3f(propulsion->GetLinThrusterState());
+	const vector3f angT = -vector3f(propulsion->GetAngThrusterState());
+
+	// How hard linear thrusters are firing vs a ship-wide reference (larger of up / forward max thrust).
+	const double maxRefThrust = std::max(propulsion->GetThrust(THRUSTER_UP), propulsion->GetThrust(THRUSTER_FORWARD));
+	const vector3d actualLinThrust = propulsion->GetActualLinThrust();
+	const vector3d actualAngThrust = propulsion->GetActualAngThrust();
+	const float linThrustEffortScalar = actualLinThrust.Length() / maxRefThrust;
+	const float angThrustEffortScalar = actualAngThrust.Length() * SfxParams::EXHAUST_ANGULAR_FACTOR / propulsion->GetAngThrustCap();
+
+	const float atmosDragScale = float(Clamp(env.density / 1.225, 0.0, 2.0));
+	const float noiseStrength = env.density * SfxParams::EXHAUST_NOISE_STRENGTH / 1.225;
+	const matrix3x3d &bodyOrient = body->GetOrient();
+
+	// Some ships have lots of small thrusters next to each other. Others have one big one.
+	// We use the same number of particles per ship, since small adjacent streams will merge
+	// visually anyway, and we this way we don't end up with too many particles on some ships
+	// and not enough on others.
+	const float particlesPerSecPerThruster = particlesPerSecTotal / m_mounts.size();
+
+	for (size_t ti = 0; ti < m_mounts.size(); ++ti) {
+		SceneGraph::MatrixTransform *mt = m_mounts[ti];
+		SceneGraph::Thruster *thr = m_thrusters[ti];
+		ExhaustThrusterChannel &ch = m_channels[ti];
+
+		const matrix4x4f M = mt->CalcGlobalTransform();
+		const vector3d nozzleLocal = vector3d(M.GetTranslate());
+		const vector3d exhaustDirModel = vector3d(thr->GetDirection()).NormalizedSafe();
+		const vector3d currentNozzleWorld = body->GetPosition() + bodyOrient * nozzleLocal;
+
+		if (!ch.hasLastNozzle) {
+			ch.lastNozzleWorld = currentNozzleWorld;
+			ch.hasLastNozzle = true;
+		}
+
+		const float visualScaled = thr->GetVisualSizeProportional();
+		// Get the amount that each thruster is firing this tick.
+		// Scale by thruster visual size and overall thrust demand
+		// Same combined reaction as model thruster flames
+		const float reactionPower = thr->ComputeReactionPower(linT, angT);
+		const float linOnly = thr->ComputeReactionPower(linT, vector3f(0.f));
+		const float angOnly = thr->ComputeReactionPower(vector3f(0.f), angT);
+		const float effortScalar = (angOnly >= linOnly) ? angThrustEffortScalar : linThrustEffortScalar;
+		const float unscaledPower = reactionPower * visualScaled * effortScalar;
+		// Use a log scale on the final thruster power so that tiny maneouvering thrusters are still visible compared to huge delta-V ones
+		const float finalThrusterPower = std::log(1.0f + SfxParams::EXHAUST_LOG_SCALE * unscaledPower) / std::log(1.0f + SfxParams::EXHAUST_LOG_SCALE);
+
+		const bool firing = finalThrusterPower >= SfxParams::EXHAUST_MIN_REACTION_POWER;
+		const bool newPulseLeadingEdge = firing && !ch.wasThrusterFiring;
+
+		vector3d exhaustDirWorld = bodyOrient * exhaustDirModel;
+		if (exhaustDirWorld.LengthSqr() < 1e-12)
+			exhaustDirWorld = bodyOrient.VectorZ();
+		exhaustDirWorld = exhaustDirWorld.Normalized();
+		const vector3d backboneWorldVel = body->GetVelocity() + exhaustDirWorld * double(SfxParams::EXHAUST_INITIAL_VELOCITY);
+
+		// Where the jet backbone was at the start of this frame (previous nozzle + last frame's exhaust velocity).
+		const vector3d lastBackbonePosWorld = ch.lastNozzleWorld + ch.lastBackboneVel * double(timeStep);
+
+		if (firing) {
+			// Reduce the alpha for weaker thrusters, so that the exhaust is less pronounced
+			const float opacityScale = Clamp(env.opacityAtmosphereFactor * finalThrusterPower, 0.0f, 1.0f);
+
+			// Increase drag for weaker thrusters, so that they slow down more quickly (less volume of exhaust)
+			const float dragScale = atmosDragScale * SfxParams::EXHAUST_DRAG_FACTOR / std::max(visualScaled, 0.2f);
+
+			// Keep particle count mostly independent of thrust / density so the stream remains full.
+			// If time is accelerated then timeStep could be huge - limit the number of particles in that case
+			// If timeStep is tiny then ensure we have at least one particle.
+			const float timeStepCapped = std::min(timeStep, SfxParams::EXHAUST_STREAM_TIMESTEP_CAP);
+			const float thrusterEmit = particlesPerSecPerThruster * timeStepCapped * finalThrusterPower;
+			int count = std::max(1, int(thrusterEmit));
+
+			// If this is the first tick where the thruster is firing, then only add one particle
+			// at the current nozzle position as the leading edge. It won't be drawn but will be
+			// used as the starting elongation target on the next tick
+			if (newPulseLeadingEdge)
+				count = 1;
+
+			const vector3f exhaustDirF = vector3f(exhaustDirWorld);
+			const vector3f shipY = vector3f(bodyOrient.VectorY());
+			const vector3f refAxis = (std::abs(exhaustDirF.Dot(shipY)) < 0.85f) ? shipY : vector3f(bodyOrient.VectorZ());
+			vector3f uAxis = refAxis.Cross(exhaustDirF).Normalized();
+			if (uAxis.LengthSqr() < 1e-12f)
+				uAxis = vector3f(bodyOrient.VectorX());
+			const vector3f vAxis = exhaustDirF.Cross(uAxis).Normalized();
+
+			for (int i = 0; i < count; i++) {
+				const double segT = double(i + 1) / double(count);
+				// Distribute new particles along the line from the projected backbone to the current nozzle.
+				const vector3d backbonePosWorld = lastBackbonePosWorld.Lerp(currentNozzleWorld, segT);
+				const vector3d backboneVelWorld = ch.lastBackboneVel.Lerp(backboneWorldVel, segT);
+
+				const float jitterRadius = float(Pi::rng.Double(1.0));
+				const float jitterTheta = float(Pi::rng.Double(2.0 * M_PI));
+
+				const vector3f jitterDirW = (uAxis * std::cos(jitterTheta) + vAxis * std::sin(jitterTheta)).Normalized();
+				const vector3f plumeOffset = jitterDirW * (jitterRadius * SfxParams::EXHAUST_INITIAL_SPREAD);
+
+				const float jitterVel = (env.maxSpread * jitterRadius) / SfxParams::EXHAUST_LIFETIME;
+				const float spreadAmp = float(Clamp(1.0 / std::max(env.density, 1e-5), 0.05, 2.0));
+				const vector3f plumeOffsetVel = jitterDirW * (jitterVel * spreadAmp);
+
+				const bool suppressStreak = newPulseLeadingEdge && (i == 0);
+				SfxManager::AddExhaust(body, Uint16(ti), suppressStreak, backbonePosWorld, backboneVelWorld, plumeOffset, plumeOffsetVel, finalThrusterPower, dragScale, opacityScale, env.windVel, env.groundRadius, env.dustTint, env.baseLifetime, env.maxSpread, noiseStrength);
+			}
+		}
+
+		ch.wasThrusterFiring = firing;
+		ch.lastNozzleWorld = currentNozzleWorld;
+		ch.lastBackboneVel = backboneWorldVel;
+	}
+}

--- a/src/ThrusterExhaust.h
+++ b/src/ThrusterExhaust.h
@@ -1,0 +1,52 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef _THRUSTER_EXHAUST_H
+#define _THRUSTER_EXHAUST_H
+
+#include "Color.h"
+#include "Sfx.h"
+#include "vector3.h"
+
+#include <vector>
+
+class Body;
+class Propulsion;
+
+namespace SceneGraph {
+	class MatrixTransform;
+	class Model;
+	class Thruster;
+} // namespace SceneGraph
+
+// Per-thruster atmospheric exhaust (nozzle anchor + jet backbone)
+struct ExhaustThrusterChannel {
+	bool hasLastNozzle = false;
+	vector3d lastNozzleWorld = vector3d::Zero;
+	vector3d lastBackboneVel = vector3d::Zero;
+	bool wasThrusterFiring = false;
+};
+
+struct ExhaustEnvironment {
+	double density = 0.0;
+	float opacityAtmosphereFactor = 1.0f;
+	vector3f windVel = vector3f(0.f);
+	double groundRadius = 0.0;
+	Color dustTint = Color(128, 128, 128, 255);
+	float baseLifetime = SfxParams::EXHAUST_LIFETIME;
+	float maxSpread = SfxParams::EXHAUST_MAX_SPREAD;
+};
+
+class ThrusterExhaustSpawner {
+public:
+	void RefreshMounts(SceneGraph::Model *model);
+	void ClearChannelState();
+	void Spawn(const Body *body, const Propulsion *propulsion, float timeStep, const ExhaustEnvironment &env, float particlesPerSecTotal);
+
+private:
+	std::vector<SceneGraph::MatrixTransform *> m_mounts;
+	std::vector<SceneGraph::Thruster *> m_thrusters;
+	std::vector<ExhaustThrusterChannel> m_channels;
+};
+
+#endif /* _THRUSTER_EXHAUST_H */


### PR DESCRIPTION
The existing missile smoke sprites are underwhelming. But now we have a more whelming thruster exhaust system available, so this PR switches missiles to use that instead.

<img width="878" height="494" alt="image" src="https://github.com/user-attachments/assets/3fc3d911-dd8b-487f-ba56-543cae4c6c99" />

As a result, missiles have visible exhaust, even in space (let's assume they use chemical rockets) which makes them easier to see and also hopefully looks cooler, especially when the missile first detaches from the ship and the exhaust curves in a big arc while orientating towards the target.

<img width="878" height="492" alt="image" src="https://github.com/user-attachments/assets/193e1cf4-0143-471c-a63b-6026fca59967" />

The first commit is a slight refactor of the thruster exhaust code to put shared particle spawner code into its own file, and then modifications to the missile code to call that instead of the old billboards. The exhaust effect now has a configurable noise parameter, so that thruster plumes on take-off still look cloud-like, but space missile exhaust looks more like a constant stream. Because, as we all know, there is no noise in space. 

The second commit is because the new missile exhaust revealed that a missile's orientation goes haywire as it approaches a target, as the velocity difference gets smaller and normalizing tiny vectors results in huge directional over-corrections. Using a simpler "point at" technique has better visual results once the missile is more or less on target, and the missiles seem just as effective at hitting things. 
