### PR TITLE
Null audio backend for running headless unit tests

### DIFF
--- a/src/Pi.cpp
+++ b/src/Pi.cpp
@@ -406,6 +406,10 @@ void Pi::App::OnStartup()
 
 	QueueLifecycle(m_loader);
 
+	// Headless mode skips the normal startup screen, so initialize sound here.
+	if (m_noGui)
+		Sound::Init(Pi::config->String("AudioBackend"));
+
 	// Don't start the main menu if we don't have a GUI
 	if (!m_noGui)
 		QueueLifecycle(m_mainMenu);
@@ -537,12 +541,11 @@ void StartupScreen::Start()
 	Pi::pigui->EndFrame();
 
 	AddStep("Sound::Init", []() {
-		if (Pi::GetApp()->HeadlessMode() || Pi::config->Int("DisableSound"))
-			return;
-
 		Sound::Init(Pi::config->String("AudioBackend"));
-		Pi::GetMusicPlayer().SetVolume(Pi::config->Float("MusicVolume"));
-		if (Pi::config->Int("MusicMuted")) Pi::GetMusicPlayer().SetEnabled(false);
+		if (!Pi::GetApp()->HeadlessMode() && !Pi::config->Int("DisableSound")) {
+			Pi::GetMusicPlayer().SetVolume(Pi::config->Float("MusicVolume"));
+			if (Pi::config->Int("MusicMuted")) Pi::GetMusicPlayer().SetEnabled(false);
+		}
 	});
 
 #ifdef ENABLE_SERVER_AGENT

--- a/src/sound/NullAudioBackend.h
+++ b/src/sound/NullAudioBackend.h
@@ -1,0 +1,47 @@
+// Copyright © 2008-2026 Pioneer Developers. See AUTHORS.txt for details
+// Licensed under the terms of the GPL v3. See licenses/GPL-3.txt
+
+#ifndef __NULL_AUDIO_BACKEND_H
+#define __NULL_AUDIO_BACKEND_H
+
+#include "AudioBackend.h"
+
+namespace Sound {
+
+	class NullAudioBackend : public AudioBackend {
+	public:
+		void DestroyAllEvents() override {}
+		void DestroyAllEventsExceptMusic() override {}
+
+		bool EventStop(eventid) override { return false; }
+		bool IsEventPlaying(eventid) override { return false; }
+		bool EventSetOp(eventid, Op) override { return false; }
+		bool EventVolumeAnimate(eventid, const float, const float, const float, const float) override
+		{
+			return false;
+		}
+		bool EventSetVolume(eventid, const float, const float) override { return false; }
+
+		void Pause(int) override {}
+
+		eventid Play(std::string_view, const float, const float, const Op) override
+		{
+			return 0;
+		}
+		void BodyMakeNoise(const Body *, std::string_view, float) override {}
+
+		void SetMasterVolume(float vol) override { m_masterVolume = vol; }
+		float GetMasterVolume() override { return m_masterVolume; }
+		void SetSfxVolume(float vol) override { m_sfxVolume = vol; }
+		float GetSfxVolume() override { return m_sfxVolume; }
+
+		void AddSample(std::string_view, Sample &&) override {}
+
+	private:
+		float m_masterVolume = 1.0f;
+		float m_sfxVolume = 1.0f;
+	};
+
+} // namespace Sound
+
+#endif // __NULL_AUDIO_BACKEND_H

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -18,6 +18,7 @@
 #include "JobQueue.h"
 #include "Pi.h"
 #include "Player.h"
+#include "NullAudioBackend.h"
 #include "SdlAudioBackend.h"
 #include "utils.h"
 
@@ -34,6 +35,7 @@ namespace Sound {
 	static const double STREAM_IF_LONGER_THAN = 10.0;
 	constexpr std::string_view SDLBackendName = "SDL";
 	constexpr std::string_view OpenALBackendName = "OpenAL";
+	constexpr std::string_view NullBackendName = "Null";
 
 	static AudioBackend *m_backend = nullptr;
 	static std::vector<std::pair<std::string, Sample>> m_samples;
@@ -211,7 +213,9 @@ namespace Sound {
 
 	std::string_view GetBackend()
 	{
-		if (dynamic_cast<SdlAudioBackend *>(m_backend) != nullptr) {
+		if (dynamic_cast<NullAudioBackend *>(m_backend) != nullptr) {
+			return NullBackendName;
+		} else if (dynamic_cast<SdlAudioBackend *>(m_backend) != nullptr) {
 			return SDLBackendName;
 #if BUILD_WITH_OPENAL
 		} else if (dynamic_cast<AlAudioBackend *>(m_backend) != nullptr) {
@@ -231,6 +235,11 @@ namespace Sound {
 			} else {
 				Uninit();
 			}
+		}
+
+		if (Pi::GetApp()->HeadlessMode() || Pi::config->Int("DisableSound")) {
+			m_backend = new NullAudioBackend();
+			return true;
 		}
 
 		if (backend.empty()) {


### PR DESCRIPTION
This PR adds a null audio backend that can be loaded for unit tests and other headless modes. So now code can continue to make sound-related API calls in those contexts without issue.

This should fix the recent spate of integration test failures.

