### PR TITLE
Fix nil lastStockUpdate value, crash when exiting hyperspace

### DIFF
--- a/data/libs/SpaceStation.lua
+++ b/data/libs/SpaceStation.lua
@@ -219,6 +219,7 @@ function SpaceStation:GetCommodityMarket()
 	if not marketCache[self.path] then
 		marketCache[self.path] = Economy.CreateStationMarket(assert(self:GetSystemBody()), Game.time)
 		logWarning("Creating transient station market for station {}; any changes to the market will not persist!" % { self.label })
+		logWarning(debug.dumpstack())
 	end
 
 	return marketCache[self.path]
@@ -842,7 +843,7 @@ local function destroySystem ()
 	equipmentPrice = {}
 
 	commodityPrice = utils.automagic()
-	marketCache = utils.automagic()
+	marketCache = {}
 
 	visited = {}
 

--- a/data/meta/_Core.lua
+++ b/data/meta/_Core.lua
@@ -10,7 +10,7 @@
 require 'Constants.lua'
 
 --- Dump all relevant variables and parameters for the current lua stack trace.
----@param level number stack level to start the stack dump at
+---@param level? number stack level to start the stack dump at. Defaults to 1.
 debug.dumpstack = function(level) end
 
 --- Convert the angle `a` from degrees to radians

--- a/data/pigui/libs/sidebar.lua
+++ b/data/pigui/libs/sidebar.lua
@@ -285,7 +285,11 @@ function Sidebar:Refresh()
 	local activeModules = utils.filter_array(self.modules, function(v) return v.active and not v.disabled end)
 
 	for i, v in ipairs(activeModules) do
-		self:SafeCall(v, v.refresh)
+		-- note that we cannot and should not use ui.pcall here as Refresh() is
+		-- not guaranteed to be called only during the ImGui frame.
+		if not v.disabled and v.refresh then
+			v.disabled = not pcall(v, v.refresh)
+		end
 	end
 
 	-- Handle the case where an exclusive module is default-open at startup or e.g. after hot-reload

--- a/data/pigui/libs/wrappers.lua
+++ b/data/pigui/libs/wrappers.lua
@@ -36,6 +36,9 @@ ui.RoundCornersAll = 0x0F
 -- A detailed stack dump of the error will be written to the game's output log
 -- and a traceback returned with the error message.
 --
+-- ui.pcall MUST be called inside of the ImGui frame. Attempts to call it in
+-- other states will produce fatal errors.
+--
 -- Example:
 --
 -- > local ok, err = ui.pcall(fun, ...)

--- a/src/pigui/PiGuiSandbox.cpp
+++ b/src/pigui/PiGuiSandbox.cpp
@@ -14,7 +14,14 @@ const char *s_meta_name = "PiGui.SavedImguiStackInfo";
 static int l_new_stack_info(lua_State *L)
 {
 	auto *savedStackInfo = static_cast<ImGuiErrorRecoveryState *>(lua_newuserdata(L, sizeof(ImGuiErrorRecoveryState)));
-	ImGui::ErrorRecoveryStoreState(savedStackInfo);
+
+	// Check to ensure we're within frame scope
+	if (ImGui::GetCurrentContext()->WithinFrameScope) {
+		ImGui::ErrorRecoveryStoreState(savedStackInfo);
+	} else {
+		Log::Debug("ui.pcall stack trace:\n{}", pi_lua_dumpstack(L, 1));
+		return luaL_error(L, "Attempt to call pigui.GetImGuiStack() outside of an ImGui frame.");
+	}
 
 	luaL_setmetatable(L, s_meta_name);
 	return 1;
@@ -31,6 +38,12 @@ static int l_stack_cleanup(lua_State *L)
 	auto *state = static_cast<ImGuiErrorRecoveryState *>(luaL_checkudata(L, 1, s_meta_name));
 
 	ImGuiContext &g = *ImGui::GetCurrentContext();
+
+	if (!g.WithinFrameScope) {
+		Log::Debug("pigui.CleanupImGuiStack stack trace:\n{}", pi_lua_dumpstack(L, 1));
+		return luaL_error(L, "Attempt to call pigui.CleanupImGuiStack() outside of an ImGui frame.");
+	}
+
 	ImGuiErrorCallback prev_callback = g.ErrorCallback;
 	void *prev_udata = g.ErrorCallbackUserData;
 


### PR DESCRIPTION
Fixes #6350, #6378, #6415.

The first two issues (which are the same) were caused by a mismatch between regular table and automagic table in SpaceStation.lua, and would only trigger when a mission module attempted to use a station market that hadn't been generated yet, *after* having jumped at least once during the current game session.

The third issue was caused by a use of `ui.pcall` outside of the ImGui frame. I've fixed that errant use, and added explicit checks and a fatal error to `ui.pcall` to ensure any other attempts to do so don't trigger segmentation faults.