### PR TITLE
Decreasing radar minimum range to 50m

### DIFF
--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -18,7 +18,7 @@ local icons = ui.theme.icons
 local SCREEN_BORDER = 6
 
 local MAX_RADAR_SIZE = 1000000000
-local MIN_RADAR_SIZE = 500
+local MIN_RADAR_SIZE = 50
 local DEFAULT_RADAR_SIZE = 10000
 
 local shouldDisplay2DRadar = false


### PR DESCRIPTION
I find the 500m minimum range too vague while using the landing aid. So I reduced it from 500 to 50m to provide more fine reading. At 500m a ~10m deviation is 1-2 pixels, which isn't much useful.
Leaving it on auto picked about 130-200m for this orbital bellow, which is about fine, but that depends on the station size, which pad you've been assigned to.
Some comparisons, from the same positions:
<img width="2560" height="1440" alt="screenshot-20260829-091827" src="https://github.com/user-attachments/assets/4a4ee465-b01f-4f48-b0ce-e8babd1ad28e" />
<img width="2560" height="1440" alt="screenshot-20260829-091830" src="https://github.com/user-attachments/assets/063952d3-2afb-4b40-9a25-d0a7e55284d7" />
<img width="2560" height="1440" alt="screenshot-20260829-091858" src="https://github.com/user-attachments/assets/d375e491-ef0f-4aef-97e4-0e50eec2b662" />
<img width="2560" height="1440" alt="screenshot-20260829-091905" src="https://github.com/user-attachments/assets/5480c0ad-8041-463c-9bcc-b19977c00a20" />




<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

