### PR TITLE
Last batch of fixes before release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 # Version identifier for current compiled build
 # Do not cache this variable
-set(PIONEER_VERSION "20260203-dev")
+set(PIONEER_VERSION "20260907")
 
 set(PROJECT_VERSION_INFO ""
 	CACHE STRING "Additional version information (optional)")

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,16 +1,31 @@
+September
+  * New Features
+    * Add thrust-to-weight ratio display to flight UI and station screen (#6382)
+	* Shield heating effect when flying at high speed in atmosphere (#6408)
+	* Terrain lighting now uses the Rayleigh-Mie atmospheric model (#6285)
+	* System view frames the entire system at default zoom level (#6422)
+
+  * Fixes
+    * Donation advertisements display amount of gained reputation and have a more even curve. (#6197)
+	* Revert "Improve calculations in AIMatchVel (AIChangeVelBy)" (#6296)
+	* Fix ImGui nag messages related to extending parent boundaries (#6422)
+	* Automatically open the System View body info window when switching to it (#6422)
+	* Fix debug-mode invulnerable ships playing damage sounds (#6422)
+	* Fix system view showing explored systems as unexplored (#6422)
+
 August
   * New Features
     * Improve flight reticle display, add orbit apoapsis/periapsis information (#6397)
     * Thruster exhaust plumes (#6346)
-    * Improve calculations in AIMatchVel (AIChangeVelBy) (#6296)
     * Add docking aid to flight reticle (#6373)
-    * Missile exhaust improvements (#6411)
-    * Decreasing radar minimum range to 50m (#6419)
+    * Improved missile exhaust plumes and trails (#6411)
 
   * Fixes
     * Adding missing DSMiner engines, adjusting plume sizes (#6403)
     * Crew Contracts: Do not show the $1 button twice (#6416)
     * Fix nil lastStockUpdate value, crash when exiting hyperspace (#6417)
+    * Improve calculations in AIMatchVel (AIChangeVelBy) (#6296)
+    * Decreasing radar minimum range to 50m (#6419)
 
   * Internal
     * Null audio backend for running headless unit tests (#6413)

--- a/data/lang/ui-core/en.json
+++ b/data/lang/ui-core/en.json
@@ -2946,5 +2946,9 @@
   "ZOOM": {
     "description": "Label for a zoom (magnification) control bar.",
     "message": "Zoom"
+  },
+  "JUMP_REACHABLE": {
+    "description": "Tooltip indicating the jump listed in the route planner is possible under the current ship configuration.",
+    "message": "Jump is reachable"
   }
 }

--- a/data/pigui/libs/gravity.lua
+++ b/data/pigui/libs/gravity.lua
@@ -8,11 +8,12 @@ local Game = require 'Game'
 local Gravity = {}
 
 --- Surface gravity for a body, walking up through starports if needed.
+---@param body Body|SystemBody
 function Gravity.GetSurfaceGravity(body)
 	if not body then return nil end
 
 	local root = body
-	local sbody = root:GetSystemBody()
+	local sbody = root:isa("SystemBody") and root or root:GetSystemBody()
 	if not sbody then
 		root = body.frameBody
 		if not root then return nil end

--- a/data/pigui/libs/sidebar.lua
+++ b/data/pigui/libs/sidebar.lua
@@ -78,6 +78,21 @@ function Sidebar:SafeCall(module, fn, ...)
 	module.disabled = not ui.pcall(fn, module, ...)
 end
 
+-- Manually force a module to become active without a transition.
+function Sidebar:MakeActive(module)
+	module.active = true
+	module.closing = false
+	module.alpha = nil
+
+	if self.active and self.active ~= module then
+		self.active.active = false
+		self.active.closing = false
+		self.active.alpha = nil
+	end
+
+	self.active = module.exclusive and module or nil
+end
+
 -- Update positions and sizes for the sidebar windows
 function Sidebar:UpdateCoords()
 	self.buttonPos.x = self.side == "right" and (ui.screenWidth - self.offset.x) or self.offset.x
@@ -288,7 +303,10 @@ function Sidebar:Refresh()
 		-- note that we cannot and should not use ui.pcall here as Refresh() is
 		-- not guaranteed to be called only during the ImGui frame.
 		if not v.disabled and v.refresh then
-			v.disabled = not pcall(v, v.refresh)
+			v.disabled = not xpcall(v.refresh, function(msg)
+				logWarning("Error in sidebar refresh() function:\n\t" .. msg)
+				logWarning(debug.dumpstack(2))
+			end, v)
 		end
 	end
 

--- a/data/pigui/modules/autopilot-window.lua
+++ b/data/pigui/modules/autopilot-window.lua
@@ -176,7 +176,7 @@ local speed_limiter = (function()
 		ui.addRectFilled(cp, cp + Vector2(full_width, full_height), colors.Button, 0, ui.RoundCornersNone)
 		if anim_active then
 			ui.addRectFilled(cp + Vector2(0, txt_shift), cp + Vector2(full_width - ui.getItemSpacing().x, full_height - txt_shift), colors.lightBlackBackground, 0, ui.RoundCornersNone)
-			ui.addCursorPos(Vector2(full_width, 0))
+			ui.dummy(Vector2(full_width, 0))
 		else
 			-- because of this, the window became larger by <txt_shift> pixels from
 			-- the bottom (but this is invisible and it sticks out of the bottom edge

--- a/data/pigui/modules/fx-window.lua
+++ b/data/pigui/modules/fx-window.lua
@@ -102,7 +102,8 @@ end
 local windowFlags = ui.WindowFlags {"NoTitleBar", "NoResize", "NoFocusOnAppearing", "NoBringToFrontOnFocus", "NoScrollbar", "NoBackground"}
 
 local function displayFxWindow()
-	if ui.optionsWindow.isOpen then return end
+	if not ui.shouldDrawUI() or ui.optionsWindow.isOpen then return end
+
 	player = Game.player
 	local current_view = Game.CurrentView()
 

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -1012,6 +1012,9 @@ local expanded_hover_body = nil -- body with expanded hover area (atlas view onl
 local function displayOnScreenObjects()
 	local isOrrery = systemView:GetDisplayMode() == 'Orrery'
 
+	Windows.unexplored.visible = not systemView:GetSystem().explored
+	if Windows.unexplored.visible then return end
+
 	local should_show_label = isOrrery and ui.shouldShowLabels()
 
 	local label_offset = 14 -- enough so that the target rectangle fits
@@ -1024,10 +1027,6 @@ local function displayOnScreenObjects()
 	-- to prevent overlap of selection regions
 	local objectCounter = 0
 	local objects_grouped = systemView:GetProjectedGrouped(collapse, 1e64)
-
-	-- if there's nothing to display, we're an unexplored system
-	Windows.unexplored.visible = #objects_grouped == 0
-	if Windows.unexplored.visible then return end
 
 	local hoveredObject = nil
 	local was_hovered = false

--- a/data/pigui/modules/system-view-ui.lua
+++ b/data/pigui/modules/system-view-ui.lua
@@ -675,6 +675,8 @@ local infoView = {
 
 			local data = getObjectData(obj)
 			tabular(data, 0)
+		else
+			ui.textColored(colors.fontDim, lc.SELECT_A_TARGET .. "...")
 		end
 	end
 }
@@ -1155,6 +1157,10 @@ local function displaySystemViewUI(delta_t, refresh)
 	if refresh then
 		leftSidebar:Refresh()
 		rightSidebar:Refresh()
+
+		if not leftSidebar.active and not infoView.active then
+			leftSidebar:MakeActive(infoView)
+		end
 	end
 
 	if not ui.shouldDrawUI() then return end
@@ -1183,6 +1189,7 @@ local function displaySystemViewUI(delta_t, refresh)
 	end
 
 	if ui.ctrlHeld() and ui.isKeyReleased(ui.keys.delete) then
+		package.reimport 'pigui.libs.sidebar'
 		package.reimport 'pigui.modules.system-overview-window'
 		systemEconView = package.reimport('pigui.modules.system-econ-view').New()
 		package.reimport()

--- a/data/pigui/modules/time-window.lua
+++ b/data/pigui/modules/time-window.lua
@@ -19,7 +19,7 @@ local windowFlags = ui.WindowFlags {"NoDecoration", "NoMove", "NoSavedSettings",
 
 local function displayTimeWindow()
 	-- HACK: Don't display the time window if we're in a bespoke view
-	if Game.CurrentView() == nil then return end
+	if Game.CurrentView() == nil or Game.CurrentView() == "WorldView" and not ui.shouldDrawUI() then return end
 
 	local year, month_num, day, hour, minute, second = Game.GetDateTime()
 	local month = lc[months[month_num]]

--- a/data/pigui/views/map-sector-view.lua
+++ b/data/pigui/views/map-sector-view.lua
@@ -600,7 +600,6 @@ local routeView = {
 	end,
 
 	drawBody = function(self)
-
 		local route = hyperJumpPlanner.getJumpRouteList()
 		---@type SystemPath?
 		local current = sectorView:GetCurrentSystemPath()
@@ -828,15 +827,6 @@ local function drawEdgeButtons()
 
 end
 
-local function hasActiveExclusiveLeftModule()
-	for _, module in ipairs(leftSidebar.modules) do
-		if module.exclusive and module.active and not module.closing then
-			return true
-		end
-	end
-	return false
-end
-
 local function refreshData()
 	leftSidebar:Refresh()
 	rightSidebar:Refresh()
@@ -848,10 +838,8 @@ ui.registerHandler("SectorView", function(delta_t, refresh)
 
 	if refresh then
 		-- Always show system info when entering SectorView, if we can. This helps the player find the hyperspace routing.
-		if not hasActiveExclusiveLeftModule() and not infoView.active then
-			infoView.active = true
-			infoView.closing = false
-			infoView.alpha = nil
+		if not leftSidebar.active and not infoView.active then
+			leftSidebar:MakeActive(infoView)
 		end
 
 		refreshData()

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -94,7 +94,7 @@ bool Player::DoDamage(float kgDamage)
 
 	// Don't fire audio on EVERY iteration (aka every 16ms, or 60fps), only when exceeds a value randomly
 	const float dam = kgDamage * 0.01f;
-	if (Pi::rng.Double() < dam) {
+	if (Pi::rng.Double() < dam && m_lastDamageSound > k_damageSoundInterval) {
 		if (!IsDead() && (GetPercentHull() < 25.0f)) {
 			Sound::BodyMakeNoise(this, "warning", .5f);
 		}
@@ -102,6 +102,8 @@ bool Player::DoDamage(float kgDamage)
 			Sound::BodyMakeNoise(this, "Hull_hit_Small", 1.0f);
 		else
 			Sound::BodyMakeNoise(this, "Hull_Hit_Medium", 1.0f);
+
+		m_lastDamageSound = 0.f;
 	}
 	return r;
 }

--- a/src/Sfx.h
+++ b/src/Sfx.h
@@ -53,8 +53,8 @@ namespace SfxParams {
 	inline constexpr float EXHAUST_ANGULAR_FACTOR = 0.2f;	// Rotational thruster exhaust is reduced by this factor, otherwise it looks far too strong
 	inline constexpr float EXHAUST_DRAG_FACTOR = 0.5f;	// Increase to have more atmospheric drag, so the jets shoot out less far before becoming cloud-like
 
-	inline constexpr float REENTRY_GLOW_MIN_SPEED = 100.0f;  // Minimum speed at 1.0 atm where the re-entry shield glow effect will start to show
-	inline constexpr float REENTRY_GLOW_MAX_SPEED = 200.0f;  // Speed at 1.0 atm at which the re-entry shield glow effect will max out
+	inline constexpr float REENTRY_GLOW_MIN_SPEED = 350.0f;  // Minimum speed at 1.0 atm where the re-entry shield glow effect will start to show
+	inline constexpr float REENTRY_GLOW_MAX_SPEED = 600.0f;  // Speed at 1.0 atm at which the re-entry shield glow effect will max out
 }
 
 struct Sfx {

--- a/src/Ship.cpp
+++ b/src/Ship.cpp
@@ -163,6 +163,7 @@ Ship::Ship(const ShipType::Id &shipId) :
 	m_shipNear = false;
 	m_shipFiring = false;
 	m_missileDetected = false;
+	m_lastDamageSound = 0.f;
 
 	m_testLanded = false;
 	m_launchLockTimeout = 0;
@@ -242,6 +243,7 @@ Ship::Ship(const Json &jsonObj, Space *space) :
 		m_shipNear = false;		   // alertstate check cache value
 		m_shipFiring = false;	   // alertstate check cache value
 		m_missileDetected = false; // alertstate check cache value
+		m_lastDamageSound = 0.f;
 
 		m_alertState = shipObj["alert_state"];
 		m_lastFiringAlert = shipObj["last_firing_alert"];
@@ -552,7 +554,6 @@ vector3d Ship::CalcAtmoTorque() const
 bool Ship::OnDamage(Body *attacker, float kgDamage, const CollisionContact &contactData)
 {
 	if (m_invulnerable) {
-		Sound::BodyMakeNoise(this, "Hull_hit_Small", 0.5f);
 		return true;
 	}
 
@@ -590,11 +591,13 @@ bool Ship::OnDamage(Body *attacker, float kgDamage, const CollisionContact &cont
 			if (Pi::rng.Double() < kgDamage)
 				SfxManager::Add(this, TYPE_DAMAGE);
 
-			if (dam > float(GetShipType()->hullMass / 1000.)) {
+			if (dam > float(GetShipType()->hullMass / 1000.) && m_lastDamageSound > k_damageSoundInterval) {
 				if (dam < 0.01 * float(GetShipType()->hullMass))
 					Sound::BodyMakeNoise(this, "Hull_hit_Small", 1.0f);
 				else
 					Sound::BodyMakeNoise(this, "Hull_Hit_Medium", 1.0f);
+
+				m_lastDamageSound = 0.f;
 			}
 		}
 	}
@@ -1036,6 +1039,9 @@ void Ship::SetFrame(FrameId fId)
 void Ship::TimeStepUpdate(const float timeStep)
 {
 	PROFILE_SCOPED()
+
+	m_lastDamageSound += timeStep;
+
 	// If docked, station is responsible for updating position/orient of ship
 	// but we call this crap anyway and hope it doesn't do anything bad
 
@@ -1640,7 +1646,7 @@ void Ship::Render(Graphics::Renderer *renderer, const Camera *camera, const vect
 			vector3f flight = matrix3x3f(viewTransform.GetOrient()).Inverse().Transpose() * vector3f(vel);
 			flight = flight.Normalized();
 			// Use Game::GetTime() as the streak seed to achieve a highly variable random streak distribution effect.
-			// If the game is paused we don't draw streaks at all - pass in -1 to signify this. 
+			// If the game is paused we don't draw streaks at all - pass in -1 to signify this.
 			const double simT = Pi::game->GetTime();
 			const float reentryPhaseT = Pi::game->IsPaused() ? -1.f	: float(std::fmod(simT, 2048.0));
 			for (ReentryGlowMatPair &mats : m_reentryGlowMaterials) {

--- a/src/Ship.h
+++ b/src/Ship.h
@@ -294,6 +294,10 @@ protected:
 	GunManager *m_gunManager;
 	Shields *m_shields;
 
+	float m_lastDamageSound;
+
+	static constexpr float k_damageSoundInterval = 0.75f;
+
 private:
 	friend struct ReentryGlowSetupVisitor;
 	float GetECMRechargeTime();

--- a/src/SystemView.cpp
+++ b/src/SystemView.cpp
@@ -402,6 +402,12 @@ void SystemMapViewport::ResetViewpoint()
 	m_rot_y_to = 0;
 	m_rot_x_to = 50;
 	m_zoomTo = 1.0f / float(AU);
+
+	SystemBody *rootBody = m_system ? m_system->GetRootBody().Get() : nullptr;
+	if (rootBody && rootBody->HasChildren()) {
+		m_zoomTo = 1.0f / (rootBody->GetChildren()[rootBody->GetNumChildren() - 1]->GetOrbMax() * float(AU) * 0.5f);
+	}
+
 	m_timeStep = 1.0f;
 	m_time = m_refTime;
 	m_transTo *= 0.0;


### PR DESCRIPTION
This PR is a work in progress:

- [x] Fix time / switcher buttons not hiding with the rest of the UI. (Fixes #6418)
- [x] Update min/max constants for ship shield heating.
- [x] Fix #6395
- [x] Automatically open the body info panel when switching to system atlas / orrery view.
- [x] Fix #6409
- [x] Fix #6322
- [x] Update changelog with prior merges.