### PR TITLE
sound: Sound mixer in settings window have dB scaling

### DIFF
--- a/src/sound/AlAudioBackend.cpp
+++ b/src/sound/AlAudioBackend.cpp
@@ -207,11 +207,6 @@ void Sound::AlAudioBackend::SetMasterVolume(float vol)
 	CHECK_OPENAL_ERROR(alListenerf, AL_GAIN, m_masterVolume);
 }
 
-float Sound::AlAudioBackend::GetMasterVolume()
-{
-	return m_masterVolume;
-}
-
 void Sound::AlAudioBackend::SetSfxVolume(float vol)
 {
 	m_sfxVolume = vol;
@@ -220,11 +215,6 @@ void Sound::AlAudioBackend::SetSfxVolume(float vol)
 			ev.SetVolume(m_sfxVolume);
 		}
 	}
-}
-
-float Sound::AlAudioBackend::GetSfxVolume()
-{
-	return m_sfxVolume;
 }
 
 void Sound::AlAudioBackend::AddSample(std::string_view key, Sample &&sample)

--- a/src/sound/AlAudioBackend.h
+++ b/src/sound/AlAudioBackend.h
@@ -39,9 +39,7 @@ namespace Sound {
 		void BodyMakeNoise(const Body *b, std::string_view key, float vol) override;
 
 		void SetMasterVolume(float vol) override;
-		float GetMasterVolume() override;
 		void SetSfxVolume(float vol) override;
-		float GetSfxVolume() override;
 
 		void AddSample(std::string_view key, Sample &&sample) override;
 		void Update(float delta_t) override;

--- a/src/sound/AudioBackend.h
+++ b/src/sound/AudioBackend.h
@@ -42,9 +42,7 @@ namespace Sound {
 		virtual void BodyMakeNoise(const Body *b, std::string_view key, float vol) = 0;
 
 		virtual void SetMasterVolume(float vol) = 0;
-		virtual float GetMasterVolume() = 0;
 		virtual void SetSfxVolume(float vol) = 0;
-		virtual float GetSfxVolume() = 0;
 
 		virtual void AddSample(std::string_view key, Sample &&sample) = 0;
 		virtual void Update(float delta_t) {}

--- a/src/sound/NullAudioBackend.h
+++ b/src/sound/NullAudioBackend.h
@@ -31,9 +31,7 @@ namespace Sound {
 		void BodyMakeNoise(const Body *, std::string_view, float) override {}
 
 		void SetMasterVolume(float vol) override { m_masterVolume = vol; }
-		float GetMasterVolume() override { return m_masterVolume; }
 		void SetSfxVolume(float vol) override { m_sfxVolume = vol; }
-		float GetSfxVolume() override { return m_sfxVolume; }
 
 		void AddSample(std::string_view, Sample &&) override {}
 

--- a/src/sound/SdlAudioBackend.cpp
+++ b/src/sound/SdlAudioBackend.cpp
@@ -188,7 +188,7 @@ Sound::AudioBackend::eventid Sound::SdlAudioBackend::Play(std::string_view key, 
 		Warning("Could not find sample with key %s", key_str.c_str());
 		return 0;
 	}
-	const float mix_volume = sample_it->second.isMusic ? 1.0F : GetSfxVolume();
+	const float mix_volume = sample_it->second.isMusic ? 1.0F : m_sfxVolume;
 	AudioDeviceGuard guard(m_audioDevice);
 	SoundEvent &empty_event = FindFreeEventForSample(sample_it->second);
 	empty_event.sample = &sample_it->second;

--- a/src/sound/SdlAudioBackend.h
+++ b/src/sound/SdlAudioBackend.h
@@ -31,9 +31,7 @@ namespace Sound {
 		void BodyMakeNoise(const Body *b, std::string_view key, float vol) override;
 
 		void SetMasterVolume(float vol) override { m_masterVolume = vol; }
-		float GetMasterVolume() override { return m_masterVolume; }
 		void SetSfxVolume(float vol) override { m_sfxVolume = vol; }
-		float GetSfxVolume() override { return m_sfxVolume; }
 
 		void AddSample(std::string_view key, Sample &&sample) override;
 

--- a/src/sound/Sound.cpp
+++ b/src/sound/Sound.cpp
@@ -16,9 +16,9 @@
 #include "Body.h"
 #include "FileSystem.h"
 #include "JobQueue.h"
+#include "NullAudioBackend.h"
 #include "Pi.h"
 #include "Player.h"
-#include "NullAudioBackend.h"
 #include "SdlAudioBackend.h"
 #include "utils.h"
 
@@ -39,25 +39,29 @@ namespace Sound {
 
 	static AudioBackend *m_backend = nullptr;
 	static std::vector<std::pair<std::string, Sample>> m_samples;
+	static float m_master_volume = 1.F;
+	static float m_sfx_volume = 1.F;
 
 	void SetMasterVolume(const float vol)
 	{
-		m_backend->SetMasterVolume(vol);
+		m_master_volume = vol;
+		m_backend->SetMasterVolume(ScaleVolumeToLogarithmic(m_master_volume));
 	}
 
 	float GetMasterVolume()
 	{
-		return m_backend->GetMasterVolume();
+		return m_master_volume;
 	}
 
 	void SetSfxVolume(const float vol)
 	{
-		m_backend->SetSfxVolume(vol);
+		m_sfx_volume = vol;
+		m_backend->SetSfxVolume(ScaleVolumeToLogarithmic(m_sfx_volume));
 	}
 
 	float GetSfxVolume()
 	{
-		return m_backend->GetSfxVolume();
+		return m_sfx_volume;
 	}
 
 	void CalculateStereo(const Body *b, float vol, float *volLeftOut, float *volRightOut)
@@ -383,6 +387,17 @@ namespace Sound {
 	void EnableBinaural(bool enabled)
 	{
 		m_backend->EnableBinaural(enabled);
+	}
+
+	float ScaleVolumeToLogarithmic(float level)
+	{
+		level = Clamp(level, 0.F, 1.F);
+		if (level == 0.F) {
+			return 0.F;
+		}
+		constexpr float dB_min = 40.F;
+		const float dB = (level * dB_min) - dB_min;
+		return std::pow(10.F, dB / 20.F);
 	}
 
 } /* namespace Sound */

--- a/src/sound/Sound.h
+++ b/src/sound/Sound.h
@@ -69,6 +69,8 @@ namespace Sound {
 
 	bool IsBinauralSupported();
 	void EnableBinaural(bool enabled);
+
+	float ScaleVolumeToLogarithmic(float level);
 } /* namespace Sound */
 
 #endif /* __SOUND_H */

--- a/src/sound/SoundMusic.cpp
+++ b/src/sound/SoundMusic.cpp
@@ -9,7 +9,8 @@
 namespace Sound {
 
 	MusicPlayer::MusicPlayer() :
-		m_volume(0.8f),
+		m_controlVolume(0.8f),
+		m_actualVolume(Sound::ScaleVolumeToLogarithmic(m_controlVolume)),
 		m_playing(false),
 		m_eventOnePlaying(false),
 		m_currentSongName(""),
@@ -23,17 +24,18 @@ namespace Sound {
 
 	float MusicPlayer::GetVolume() const
 	{
-		return m_volume;
+		return m_controlVolume;
 	}
 
 	void MusicPlayer::SetVolume(const float vol)
 	{
-		m_volume = Clamp(vol, 0.f, 1.f);
+		m_controlVolume = Clamp(vol, 0.f, 1.f);
+		m_actualVolume = Sound::ScaleVolumeToLogarithmic(m_controlVolume);
 		//the other song might be fading out so don't set its volume
 		if (m_eventOnePlaying && m_eventOne.IsPlaying())
-			m_eventOne.SetVolume(m_volume);
+			m_eventOne.SetVolume(m_actualVolume);
 		else if (m_eventTwo.IsPlaying())
-			m_eventTwo.SetVolume(m_volume);
+			m_eventTwo.SetVolume(m_actualVolume);
 	}
 
 	void MusicPlayer::Play(const std::string &name, const bool repeat /* = false */, const float fadeDelta /* = 1.f */)
@@ -50,7 +52,7 @@ namespace Sound {
 			current = &m_eventTwo;
 			next = &m_eventOne;
 		}
-		next->PlayMusic(name.c_str(), m_volume, fadeDelta, repeat, current);
+		next->PlayMusic(name.c_str(), m_actualVolume, fadeDelta, repeat, current);
 		m_playing = true;
 		m_repeating = repeat;
 		m_currentSongName = name;

--- a/src/sound/SoundMusic.h
+++ b/src/sound/SoundMusic.h
@@ -30,7 +30,8 @@ namespace Sound {
 		sigc::signal<void> onSongFinished;
 
 	private:
-		float m_volume;
+		float m_controlVolume;
+		float m_actualVolume;
 		//two streams for crossfade
 		Event m_eventOne;
 		Event m_eventTwo;


### PR DESCRIPTION
With this change, the human ear's logarithmic reception is respected, that makes the volume sliders more pleasant to use.

This change applies decibel scaling to the master, SFX and music volume setting in the settings menu. This is achieved by applying the transformation in the `Sound` and `SoundMusic` wrapper, and the audio backends receive the scaled value already. Therefore the configuration and UI logic did not have to change.

The current hard-coded setting is a scaling between -40 and 0 dB which I found pretty pleasant.

<!-- Please describe new feature, possible with screenshot if needed. -->
<!-- Please make sure you've read documentation on contributing -->

