### PR TITLE
Change starting ships for a more even progression in difficulty levels

### DIFF
--- a/data/pigui/modules/new-game-window/class.lua
+++ b/data/pigui/modules/new-game-window/class.lua
@@ -29,37 +29,12 @@ StartVariants.register({
 	desc       = lui.START_AT_MARS_DESC,
 	location   = SystemPath.New(0,0,0,0,18),
 	logmsg     = lui.START_LOG_ENTRY_1,
-	shipType   = 'coronatrix',
+	shipType   = 'pumpkinseed',
 	money      = 600,
 	equipment = {
 		computer_1     = "misc.autopilot",
-		laser_front_s2 = "laser.pulsecannon_1mw",
-		shield_s1_1    = "shield.basic_s1",
-		shield_s1_2    = "shield.basic_s1",
-		sensor         = "sensor.radar",
-		hull_mod       = "hull.atmospheric_shielding_s1",
-		hyperdrive     = "hyperspace.hyperdrive_2",
-		thruster       = "thruster.default_s1",
-		missile_bay_1  = "missile_bay.opli_internal_s2",
-		missile_bay_2  = "missile_bay.opli_internal_s2",
-	},
-	cargo      = {
-	},
-	pattern    = 1,
-	colors     = { Color('000000'), Color('000000'), Color('000000') }
-})
-
-StartVariants.register({
-	name       = lui.START_AT_NEW_HOPE,
-	desc       = lui.START_AT_NEW_HOPE_DESC,
-	location   = SystemPath.New(1,-1,-1,0,4),
-	logmsg     = lui.START_LOG_ENTRY_2,
-	shipType   = 'pumpkinseed',
-	money      = 400,
-	hyperdrive = true,
-	equipment = {
-		computer_1     = "misc.autopilot",
 		laser_front_s1 = "laser.pulsecannon_1mw",
+		shield_s1_1    = "shield.basic_s1",
 		sensor         = "sensor.radar",
 		hull_mod       = "hull.atmospheric_shielding_s1",
 		hyperdrive     = "hyperspace.hyperdrive_1",
@@ -72,11 +47,32 @@ StartVariants.register({
 })
 
 StartVariants.register({
+	name       = lui.START_AT_NEW_HOPE,
+	desc       = lui.START_AT_NEW_HOPE_DESC,
+	location   = SystemPath.New(1,-1,-1,0,4),
+	logmsg     = lui.START_LOG_ENTRY_2,
+	shipType   = 'xylophis',
+	money      = 400,
+	hyperdrive = true,
+	equipment = {
+		computer_1     = "misc.autopilot",
+		sensor         = "sensor.radar",
+		hull_mod       = "hull.atmospheric_shielding_s0",
+		hyperdrive     = "hyperspace.hyperdrive_1",
+		thruster       = "thruster.default_s1",
+	},
+	cargo      = {
+	},
+	pattern    = 6,
+	colors     = { Color('E17F00'), Color('FFFFFF'), Color('FF7F00') }
+})
+
+StartVariants.register({
 	name       = lui.START_AT_BARNARDS_STAR,
 	desc           = lui.START_AT_BARNARDS_STAR_DESC,
 	location       = SystemPath.New(-1,0,0,0,16),
 	logmsg         = lui.START_LOG_ENTRY_3,
-	shipType       = 'xylophis',
+	shipType       = 'varada',
 	money          = 100,
 	hyperdrive     = false,
 	equipment = {
@@ -87,8 +83,8 @@ StartVariants.register({
 	},
 	cargo          = {
 	},
-	pattern    = 6,
-	colors     = { Color('E17F00'), Color('FFFFFF'), Color('FF7F00') }
+	pattern    = 1,
+	colors     = { Color('007FE1'), Color('FFFFFF'), Color('007FFF') }
 })
 
 -- synchronize parameter views with updated values


### PR DESCRIPTION
I've brought this issue up before, so apologies if everyone is tired of hearing about it, but now with the Auxiliary Cargo Rack equipment item available it's been amplified further, so I really think it should be addressed. 

**Expected behaviour**

Easy start ship has the most cargo space and cabin slots.
Medium start ship has less than that.
Hard start ship has even less still.

**Current behaviour**

Easy start ship has 16 cu cargo space and no cabin slots, for a maximum of 16 cu cargo space.
Medium start ship has 4 cu cargo space and 2 cabin slots, for a maximum of 20 cu cargo space.
Hard start ship has 8 cu cargo space and 1 cabin slot, for a maximum of 16 cu cargo space.

This means that:
For trading, Medium is best, Hard is the same as Easy.
For passenger transport missions, Medium is best, Hard is the next best. Easy is unable to do them at all.

This does not fit the ideal trend of the Easy start being the easiest, the Hard start being the hardest, and the Medium start being somewhere in the middle. So we should fix this.

Rather than get into a debate about how the ship stats could be adjusted to make them fit the difficulty progression while keeping them in line with the designs and layouts and so on, I realised that we can just change the starting ships. So this PR does that. They are now like this:

**Easy start - Pumpkinseed**
Even though nominally it only has 4 cu of cargo space, the Pumpkinseed is a pretty good all rounder. It can do passenger missions up to two berths, or convert the space for a maximum of 20 cu. Its price is almost the same as the Coronatrix, so it shouldn't take long for a player to be able to upgrade if they decide they prefer a faster but non-transport-mission-capable ship.

**Medium start - Xylophis**
Despite looking small, the Xylophis has nominal cargo space of 8, a maximum of 16, and one potential passenger berth, so fits the medium start well. 

**Hard start - Varada**
With only 4 cu of cargo space, no cabin slots, and no hyperspace jump drive slot, the Varada really is a hard start. 

I believe this fits the expected difficulty progression better.
