### PR TITLE
Flatten terrain under surface starports

### DIFF
--- a/src/GeoSphere.cpp
+++ b/src/GeoSphere.cpp
@@ -26,6 +26,8 @@
 #include "vcacheopt/vcacheopt.h"
 #include <algorithm>
 #include <deque>
+#include <utility>
+#include <vector>
 
 RefCountedPtr<GeoPatchContext> GeoSphere::s_patchContext;
 
@@ -83,8 +85,10 @@ void GeoSphere::OnChangeGeoSphereDetailLevel()
 		// clearout anything we don't need
 		(*i)->Reset();
 
-		// reinit the terrain with the new settings
+		// reinit the terrain with the new settings, keeping starport flatten discs
+		std::vector<Terrain::FlattenRegion> flatten = (*i)->m_terrain->GetFlattenRegions();
 		(*i)->m_terrain.Reset(Terrain::InstanceTerrain((*i)->GetSystemBody()));
+		(*i)->m_terrain->SetFlattenRegions(std::move(flatten));
 		print_info((*i)->GetSystemBody(), (*i)->m_terrain.Get());
 
 		// Reload the surface and atmosphere material (scattering option)

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -167,13 +167,24 @@ static void FlattenTerrainUnderPlanetStarports(Space *space, Planet *planet, Sys
 		if (sb->GetType() != SystemBody::TYPE_STARPORT_SURFACE || sb->GetParent() != planetSbody)
 			continue;
 
-		// Calculate a flat disc radius that would lie under the station's XZ footprint (model origin = starport centre).
-		const Aabb &aabb = static_cast<const SpaceStation *>(b)->GetAabb();
+		const SpaceStation *station = static_cast<const SpaceStation *>(b);
+		const SpaceStationType *type = station->GetStationType();
+		double lowestPadHeight = type->GetStageTransform(0, DockStage::DOCKED).GetTranslate().y;
+		for (unsigned int bay = 1; bay < type->NumDockingPorts(); ++bay) {
+			const double padY = type->GetStageTransform(int(bay), DockStage::DOCKED).GetTranslate().y;
+			if (padY < lowestPadHeight)
+				lowestPadHeight = padY;
+		}
+		if (lowestPadHeight < 0.0)
+			lowestPadHeight = 0.0;
+
+		// Calculate a disc radius that would lie under the station's XZ footprint (model origin = starport centre).
+		const Aabb &aabb = station->GetAabb();
 		const double radiusMeters = std::max({ sqrt(aabb.min.x * aabb.min.x + aabb.min.z * aabb.min.z),
 			sqrt(aabb.min.x * aabb.min.x + aabb.max.z * aabb.max.z),
 			sqrt(aabb.max.x * aabb.max.x + aabb.min.z * aabb.min.z),
 			sqrt(aabb.max.x * aabb.max.x + aabb.max.z * aabb.max.z) });
-		planet->AddTerrainFlattenRegion(b->GetPosition().Normalized(), radiusMeters);
+		planet->AddTerrainFlattenRegion(station->GetPosition().Normalized(), radiusMeters, lowestPadHeight);
 	}
 }
 

--- a/src/Space.cpp
+++ b/src/Space.cpp
@@ -28,6 +28,7 @@
 #include "profiler/Profiler.h"
 
 #include <algorithm>
+#include <cmath>
 
 //#define DEBUG_CACHE
 
@@ -154,6 +155,25 @@ static void RelocateStarportIfNecessary(SystemBody *sbody, Planet *planet, vecto
 			Output("Error: Lua custom Systems definition: Surface starport is underwater (height not greater than 0.0) and has been automatically relocated. Please move the starport to another location by changing latitude and longitude fields.\n      Surface starport name: %s, Body name: %s, In sector: x = %i, y = %i, z = %i.\n",
 				sbody->GetName().c_str(), sbody->GetParent()->GetName().c_str(), p.sectorX, p.sectorY, p.sectorZ);
 		}
+	}
+}
+
+static void FlattenTerrainUnderPlanetStarports(Space *space, Planet *planet, SystemBody *planetSbody)
+{
+	for (Body *b : space->GetBodies()) {
+		if (!b->IsType(ObjectType::SPACESTATION))
+			continue;
+		const SystemBody *sb = b->GetSystemBody();
+		if (sb->GetType() != SystemBody::TYPE_STARPORT_SURFACE || sb->GetParent() != planetSbody)
+			continue;
+
+		// Calculate a flat disc radius that would lie under the station's XZ footprint (model origin = starport centre).
+		const Aabb &aabb = static_cast<const SpaceStation *>(b)->GetAabb();
+		const double radiusMeters = std::max({ sqrt(aabb.min.x * aabb.min.x + aabb.min.z * aabb.min.z),
+			sqrt(aabb.min.x * aabb.min.x + aabb.max.z * aabb.max.z),
+			sqrt(aabb.max.x * aabb.max.x + aabb.min.z * aabb.min.z),
+			sqrt(aabb.max.x * aabb.max.x + aabb.max.z * aabb.max.z) });
+		planet->AddTerrainFlattenRegion(b->GetPosition().Normalized(), radiusMeters);
 	}
 }
 
@@ -300,6 +320,8 @@ Space::Space(Game *game, RefCountedPtr<Galaxy> galaxy, const Json &jsonObj, doub
 					posAccum.push_back(pos);
 				}
 			}
+			// After all surface starports are placed, flatten the terrain under them.
+			FlattenTerrainUnderPlanetStarports(this, planet, sbody.Get());
 		}
 	}
 
@@ -897,6 +919,11 @@ void Space::GenBody(const double at_time, SystemBody *sbody, FrameId fId, std::v
 	PROFILE_STOP()
 	for (SystemBody *kid : sbody->GetChildren()) {
 		GenBody(at_time, kid, fId, posAccum);
+	}
+
+	// Flatten the terrain under any surface starports
+	if (sbody->GetSuperType() == SystemBody::SUPERTYPE_ROCKY_PLANET) {
+		FlattenTerrainUnderPlanetStarports(this, static_cast<Planet *>(b), sbody);
 	}
 }
 

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -150,6 +150,11 @@ double TerrainBody::GetTerrainHeight(const vector3d &pos_) const
 	}
 }
 
+void TerrainBody::AddTerrainFlattenRegion(const vector3d &centre, double radiusMeters)
+{
+	m_baseSphere->GetTerrain()->AddFlattenRegion(centre, radiusMeters);
+}
+
 //static
 void TerrainBody::OnChangeDetailLevel(Graphics::Renderer *r)
 {

--- a/src/TerrainBody.cpp
+++ b/src/TerrainBody.cpp
@@ -150,9 +150,9 @@ double TerrainBody::GetTerrainHeight(const vector3d &pos_) const
 	}
 }
 
-void TerrainBody::AddTerrainFlattenRegion(const vector3d &centre, double radiusMeters)
+void TerrainBody::AddTerrainFlattenRegion(const vector3d &centre, double radiusMeters, double maxVariationMeters)
 {
-	m_baseSphere->GetTerrain()->AddFlattenRegion(centre, radiusMeters);
+	m_baseSphere->GetTerrain()->AddFlattenRegion(centre, radiusMeters, maxVariationMeters);
 }
 
 //static

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -30,6 +30,11 @@ public:
 	double GetTerrainHeight(const vector3d &pos) const;
 	const SystemBody *GetSystemBody() const override { return m_sbody; }
 
+	// Flatten terrain under a surface starport.
+	// centre is a unit-sphere position on the planet surface.
+	// radiusMeters is the surface radius of the fully-flat disc (falloff may extend beyond).
+	void AddTerrainFlattenRegion(const vector3d &centre, double radiusMeters);
+
 	// returns value in metres
 	double GetMaxFeatureRadius() const { return m_maxFeatureHeight; }
 

--- a/src/TerrainBody.h
+++ b/src/TerrainBody.h
@@ -30,10 +30,11 @@ public:
 	double GetTerrainHeight(const vector3d &pos) const;
 	const SystemBody *GetSystemBody() const override { return m_sbody; }
 
-	// Flatten terrain under a surface starport.
+	// Reduce terrain amplitude under a surface starport.
 	// centre is a unit-sphere position on the planet surface.
-	// radiusMeters is the surface radius of the fully-flat disc (falloff may extend beyond).
-	void AddTerrainFlattenRegion(const vector3d &centre, double radiusMeters);
+	// radiusMeters is the surface radius of the fully-scaled disc (falloff may extend beyond).
+	// maxVariationMeters is the allowed max height from the model origin (typically the lowest landing pad).
+	void AddTerrainFlattenRegion(const vector3d &centre, double radiusMeters, double maxVariationMeters);
 
 	// returns value in metres
 	double GetMaxFeatureRadius() const { return m_maxFeatureHeight; }

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -615,6 +615,69 @@ Terrain::~Terrain()
 {
 }
 
+void Terrain::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+{
+	// First get the raw heights from the terrain generation
+	GetHeightsRaw(vP, heightsOut, count);
+
+	if (m_flattenRegions.empty())
+		return;
+
+	// Now apply additional transforms
+
+	// Flatten any areas underneath a surface starport, so that no part
+	// of the starport is clipping into the ground or hovering above it.
+	for (size_t i = 0; i < count; i++) {
+		for (const FlattenRegion &region : m_flattenRegions) {
+			const double d = vP[i].Dot(region.centre);
+			if (d < region.minDotOuter)
+				continue;
+			if (d >= region.minDotInner) {
+				heightsOut[i] = region.height;
+				break;
+			}
+			// The area directly under the starport is flattened. Then we apply a
+			// falloff beyond that to blend the edge with the underlying terrain.
+			const double theta = acos(Clamp(d, -1.0, 1.0));
+			double t = (theta - region.innerAngle) * region.invFalloffAngle;
+			t = Clamp(t, 0.0, 1.0);
+			const double s = t * t * (3.0 - 2.0 * t);
+			heightsOut[i] += (region.height - heightsOut[i]) * (1.0 - s);
+			break;
+		}
+	}
+}
+
+void Terrain::AddFlattenRegion(const vector3d &centre, double radiusMeters)
+{
+	// We will flatten a circular area directly under the starport.
+	// Then apply a fall-off so that there isn't a hard edge.
+	// Unless it's a tiny asteroid in which case a hard edge is more
+	// plausible as the edge of a man-made flattened area.
+	// 
+	// i.e. no blend on small worlds; 1000 m falloff once radius reaches 600 km.
+
+	constexpr double falloffMinPlanetRadius = 100000.0;
+	constexpr double falloffMaxPlanetRadius = 600000.0;
+	constexpr double falloffMaxMeters = 1000.0;
+	double falloffMeters = 0.0;
+	if (m_planetRadius >= falloffMaxPlanetRadius)
+		falloffMeters = falloffMaxMeters;
+	else if (m_planetRadius > falloffMinPlanetRadius)
+		falloffMeters = falloffMaxMeters * (m_planetRadius - falloffMinPlanetRadius) / (falloffMaxPlanetRadius - falloffMinPlanetRadius);
+
+	FlattenRegion region;
+	region.centre = centre.Normalized();
+	GetHeightsRaw(&region.centre, &region.height, 1);
+
+	region.innerAngle = Clamp(radiusMeters * m_invPlanetRadius, 0.0, M_PI);
+	const double outerAngle = Clamp((radiusMeters + falloffMeters) * m_invPlanetRadius, 0.0, M_PI);
+	region.minDotInner = cos(region.innerAngle);
+	region.minDotOuter = cos(outerAngle);
+	region.invFalloffAngle = (outerAngle > region.innerAngle) ? 1.0 / (outerAngle - region.innerAngle) : 0.0;
+	m_flattenRegions.push_back(region);
+}
+
 /**
  * Feature width means roughly one perlin noise blob or grain.
  * This will end up being one hill, mountain or continent, roughly.

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -625,37 +625,37 @@ void Terrain::GetHeights(const vector3d *vP, double *heightsOut, const size_t co
 
 	// Now apply additional transforms
 
-	// Flatten any areas underneath a surface starport, so that no part
-	// of the starport is clipping into the ground or hovering above it.
+	// Compress height variation under surface starports so pads are not buried
+	// or left hovering, while keeping existing bumpiness when it is already mild.
 	for (size_t i = 0; i < count; i++) {
 		for (const FlattenRegion &region : m_flattenRegions) {
 			const double d = vP[i].Dot(region.centre);
 			if (d < region.minDotOuter)
 				continue;
+			const double compressed = region.height + (heightsOut[i] - region.height) * region.amplitudeScale;
 			if (d >= region.minDotInner) {
-				heightsOut[i] = region.height;
+				heightsOut[i] = compressed;
 				break;
 			}
-			// The area directly under the starport is flattened. Then we apply a
-			// falloff beyond that to blend the edge with the underlying terrain.
 			const double theta = acos(Clamp(d, -1.0, 1.0));
 			double t = (theta - region.innerAngle) * region.invFalloffAngle;
 			t = Clamp(t, 0.0, 1.0);
 			const double s = t * t * (3.0 - 2.0 * t);
-			heightsOut[i] += (region.height - heightsOut[i]) * (1.0 - s);
+			heightsOut[i] = compressed + (heightsOut[i] - compressed) * s;
 			break;
 		}
 	}
 }
 
-void Terrain::AddFlattenRegion(const vector3d &centre, double radiusMeters)
+void Terrain::AddFlattenRegion(const vector3d &centre, double radiusMeters, double maxVariationMeters)
 {
-	// We will flatten a circular area directly under the starport.
-	// Then apply a fall-off so that there isn't a hard edge.
-	// Unless it's a tiny asteroid in which case a hard edge is more
-	// plausible as the edge of a man-made flattened area.
-	// 
-	// i.e. no blend on small worlds; 1000 m falloff once radius reaches 600 km.
+	// Compress fractal amplitude in a disc under a building so max height
+	// variation stays within a limit suitable for that building.
+	// So mildly bumpy sites under buildings on stilts can keep their shape,
+	// while steep ones are scaled down around the model origin.
+	// Falloff blends that scaled field back to raw terrain.
+	// Small worlds keep a hard edge, to make them look more terraformed.
+	// Larger worlds have a max 1000 m falloff.
 
 	constexpr double falloffMinPlanetRadius = 100000.0;
 	constexpr double falloffMaxPlanetRadius = 600000.0;
@@ -670,6 +670,33 @@ void Terrain::AddFlattenRegion(const vector3d &centre, double radiusMeters)
 	region.centre = centre.Normalized();
 	GetHeightsRaw(&region.centre, &region.height, 1);
 
+	// Calculate the raw terrain bumpiness in this to-be-flattened region
+	const vector3d tangent = MathUtil::OrthogonalDirection(region.centre);
+	const vector3d bitangent = region.centre.Cross(tangent);
+	double maxH = region.height;
+	const int halfSteps = Clamp(int(ceil(radiusMeters / 20.0)), 4, 20);
+	const double step = radiusMeters / double(halfSteps);
+	for (int iz = -halfSteps; iz <= halfSteps; ++iz) {
+		for (int ix = -halfSteps; ix <= halfSteps; ++ix) {
+			const double x = ix * step;
+			const double z = iz * step;
+			if (x * x + z * z > radiusMeters * radiusMeters)
+				continue;
+			vector3d p = (region.centre + (tangent * x + bitangent * z) * m_invPlanetRadius).Normalized();
+			double h;
+			GetHeightsRaw(&p, &h, 1);
+			if (h > maxH)
+				maxH = h;
+		}
+	}
+
+	const double range = maxH - region.height;
+	const double targetRange = maxVariationMeters * m_invPlanetRadius;
+	region.amplitudeScale = (maxH > targetRange) ? targetRange / range : 1.0;
+	if (region.amplitudeScale >= 1.0)
+		return; // Raw terrain bumpiness is within the building tolerance, so no flattening needed.
+
+	// Pre calculate dot-product values for inner and outer radii
 	region.innerAngle = Clamp(radiusMeters * m_invPlanetRadius, 0.0, M_PI);
 	const double outerAngle = Clamp((radiusMeters + falloffMeters) * m_invPlanetRadius, 0.0, M_PI);
 	region.minDotInner = cos(region.innerAngle);

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -49,16 +49,18 @@ public:
 	void GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const;
 	virtual vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const = 0;
 
-	// Flatten a circular region after fractal height generation has run for surface starports to sit comfortably.
+	// Reduce fractal amplitude in a circular region so a surface building sits on
+	// terrain whose max height variation is within building tolerance.
 	struct FlattenRegion {
 		vector3d centre;		// unit vector
-		double minDotInner;		// cos(inner angular radius) - fully flat if dot(centre, p) >= this
+		double minDotInner;		// cos(inner angular radius) - fully scaled if dot(centre, p) >= this
 		double minDotOuter;		// cos(outer angular radius) - ignored if dot(centre, p) < this
 		double innerAngle;		// radians
 		double invFalloffAngle; // 1 / (outer - inner), or 0 if hard-edged
-		double height;			// GetHeights units
+		double height;			// raw fractal height at centre (GetHeights units)
+		double amplitudeScale;	// 1 = unchanged, less than 1 reduces amplitude of terrain bumps
 	};
-	void AddFlattenRegion(const vector3d &centre, double radiusMeters);
+	void AddFlattenRegion(const vector3d &centre, double radiusMeters, double maxVariationMeters);
 	void SetFlattenRegions(std::vector<FlattenRegion> regions) { m_flattenRegions = std::move(regions); }
 	const std::vector<FlattenRegion> &GetFlattenRegions() const { return m_flattenRegions; }
 

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -13,6 +13,8 @@
 
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4250) // workaround for MSVC 2008 multiple inheritance bug
@@ -44,8 +46,21 @@ public:
 		return m_fracdef[index];
 	}
 
-	virtual void GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const = 0;
+	void GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const;
 	virtual vector3d GetColor(const vector3d &p, double height, const vector3d &norm) const = 0;
+
+	// Flatten a circular region after fractal height generation has run for surface starports to sit comfortably.
+	struct FlattenRegion {
+		vector3d centre;		// unit vector
+		double minDotInner;		// cos(inner angular radius) - fully flat if dot(centre, p) >= this
+		double minDotOuter;		// cos(outer angular radius) - ignored if dot(centre, p) < this
+		double innerAngle;		// radians
+		double invFalloffAngle; // 1 / (outer - inner), or 0 if hard-edged
+		double height;			// GetHeights units
+	};
+	void AddFlattenRegion(const vector3d &centre, double radiusMeters);
+	void SetFlattenRegions(std::vector<FlattenRegion> regions) { m_flattenRegions = std::move(regions); }
+	const std::vector<FlattenRegion> &GetFlattenRegions() const { return m_flattenRegions; }
 
 	virtual const char *GetHeightFractalName() const = 0;
 	virtual const char *GetColorFractalName() const = 0;
@@ -121,17 +136,21 @@ protected:
 		std::string m_name;
 	};
 	MinBodyData m_minBody;
+
+	virtual void GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const = 0;
+
+	std::vector<FlattenRegion> m_flattenRegions;
 };
 
 template <typename HeightFractal>
 class TerrainHeightFractal : virtual public Terrain {
 public:
 	TerrainHeightFractal() = delete;
-	void GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const final;
 	const char *GetHeightFractalName() const final;
 
 protected:
 	TerrainHeightFractal(const SystemBody *body);
+	void GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const final;
 };
 
 template <typename ColorFractal>

--- a/src/terrain/TerrainHeightAsteroid.cpp
+++ b/src/terrain/TerrainHeightAsteroid.cpp
@@ -23,7 +23,7 @@ TerrainHeightFractal<TerrainHeightAsteroid>::TerrainHeightFractal(const SystemBo
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightAsteroid>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightAsteroid>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightAsteroid2.cpp
+++ b/src/terrain/TerrainHeightAsteroid2.cpp
@@ -26,7 +26,7 @@ TerrainHeightFractal<TerrainHeightAsteroid2>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightAsteroid2>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightAsteroid2>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightAsteroid3.cpp
+++ b/src/terrain/TerrainHeightAsteroid3.cpp
@@ -23,7 +23,7 @@ TerrainHeightFractal<TerrainHeightAsteroid3>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightAsteroid3>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightAsteroid3>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightAsteroid4.cpp
+++ b/src/terrain/TerrainHeightAsteroid4.cpp
@@ -26,7 +26,7 @@ TerrainHeightFractal<TerrainHeightAsteroid4>::TerrainHeightFractal(const SystemB
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightAsteroid4>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightAsteroid4>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightBarrenRock.cpp
+++ b/src/terrain/TerrainHeightBarrenRock.cpp
@@ -23,7 +23,7 @@ TerrainHeightFractal<TerrainHeightBarrenRock>::TerrainHeightFractal(const System
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightBarrenRock>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightBarrenRock2.cpp
+++ b/src/terrain/TerrainHeightBarrenRock2.cpp
@@ -21,7 +21,7 @@ TerrainHeightFractal<TerrainHeightBarrenRock2>::TerrainHeightFractal(const Syste
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightBarrenRock2>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightBarrenRock2>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightBarrenRock3.cpp
+++ b/src/terrain/TerrainHeightBarrenRock3.cpp
@@ -20,7 +20,7 @@ TerrainHeightFractal<TerrainHeightBarrenRock3>::TerrainHeightFractal(const Syste
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightBarrenRock3>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightBarrenRock3>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightEllipsoid.cpp
+++ b/src/terrain/TerrainHeightEllipsoid.cpp
@@ -53,7 +53,7 @@ TerrainHeightFractal<TerrainHeightEllipsoid>::TerrainHeightFractal(const SystemB
 //                                R(t) = ar/sqrt(x_^2+ar^2*y_^2) (eqn. 9) (substituting using eqn. 7 and eqn. 8)
 
 template <>
-void TerrainHeightFractal<TerrainHeightEllipsoid>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightEllipsoid>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightFlat.cpp
+++ b/src/terrain/TerrainHeightFlat.cpp
@@ -13,7 +13,7 @@ TerrainHeightFractal<TerrainHeightFlat>::TerrainHeightFractal(const SystemBody *
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightFlat>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightFlat>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		heightsOut[i] = 0.0;

--- a/src/terrain/TerrainHeightHillsCraters.cpp
+++ b/src/terrain/TerrainHeightHillsCraters.cpp
@@ -24,7 +24,7 @@ TerrainHeightFractal<TerrainHeightHillsCraters>::TerrainHeightFractal(const Syst
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightHillsCraters>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightHillsCraters>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightHillsCraters2.cpp
+++ b/src/terrain/TerrainHeightHillsCraters2.cpp
@@ -63,7 +63,7 @@ TerrainHeightFractal<TerrainHeightHillsCraters2>::TerrainHeightFractal(const Sys
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightHillsCraters2>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightHillsCraters2>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightHillsDunes.cpp
+++ b/src/terrain/TerrainHeightHillsDunes.cpp
@@ -29,7 +29,7 @@ TerrainHeightFractal<TerrainHeightHillsDunes>::TerrainHeightFractal(const System
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightHillsDunes>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightHillsDunes>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightHillsNormal.cpp
+++ b/src/terrain/TerrainHeightHillsNormal.cpp
@@ -28,7 +28,7 @@ TerrainHeightFractal<TerrainHeightHillsNormal>::TerrainHeightFractal(const Syste
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightHillsNormal>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightHillsNormal>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightHillsRidged.cpp
+++ b/src/terrain/TerrainHeightHillsRidged.cpp
@@ -28,7 +28,7 @@ TerrainHeightFractal<TerrainHeightHillsRidged>::TerrainHeightFractal(const Syste
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightHillsRidged>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightHillsRidged>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightHillsRivers.cpp
+++ b/src/terrain/TerrainHeightHillsRivers.cpp
@@ -28,7 +28,7 @@ TerrainHeightFractal<TerrainHeightHillsRivers>::TerrainHeightFractal(const Syste
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightHillsRivers>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightHillsRivers>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightMapped.cpp
+++ b/src/terrain/TerrainHeightMapped.cpp
@@ -27,7 +27,7 @@ TerrainHeightFractal<TerrainHeightMapped>::TerrainHeightFractal(const SystemBody
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMapped>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMapped>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	// This is used for Earth and Mars
 	for (size_t i = 0; i < count; i++) {

--- a/src/terrain/TerrainHeightMapped2.cpp
+++ b/src/terrain/TerrainHeightMapped2.cpp
@@ -17,7 +17,7 @@ TerrainHeightFractal<TerrainHeightMapped2>::TerrainHeightFractal(const SystemBod
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMapped2>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMapped2>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightMountainsCraters.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters.cpp
@@ -29,7 +29,7 @@ TerrainHeightFractal<TerrainHeightMountainsCraters>::TerrainHeightFractal(const 
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMountainsCraters>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMountainsCraters>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightMountainsCraters2.cpp
+++ b/src/terrain/TerrainHeightMountainsCraters2.cpp
@@ -56,7 +56,7 @@ TerrainHeightFractal<TerrainHeightMountainsCraters2>::TerrainHeightFractal(const
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMountainsCraters2>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMountainsCraters2>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightMountainsNormal.cpp
+++ b/src/terrain/TerrainHeightMountainsNormal.cpp
@@ -25,7 +25,7 @@ TerrainHeightFractal<TerrainHeightMountainsNormal>::TerrainHeightFractal(const S
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMountainsNormal>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMountainsNormal>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightMountainsRidged.cpp
+++ b/src/terrain/TerrainHeightMountainsRidged.cpp
@@ -30,7 +30,7 @@ TerrainHeightFractal<TerrainHeightMountainsRidged>::TerrainHeightFractal(const S
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMountainsRidged>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMountainsRidged>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightMountainsRivers.cpp
+++ b/src/terrain/TerrainHeightMountainsRivers.cpp
@@ -28,7 +28,7 @@ TerrainHeightFractal<TerrainHeightMountainsRivers>::TerrainHeightFractal(const S
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMountainsRivers>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMountainsRivers>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsRiversVolcano.cpp
@@ -35,7 +35,7 @@ TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::TerrainHeightFractal(
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMountainsRiversVolcano>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightMountainsVolcano.cpp
+++ b/src/terrain/TerrainHeightMountainsVolcano.cpp
@@ -35,7 +35,7 @@ TerrainHeightFractal<TerrainHeightMountainsVolcano>::TerrainHeightFractal(const 
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightMountainsVolcano>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightMountainsVolcano>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightRuggedDesert.cpp
+++ b/src/terrain/TerrainHeightRuggedDesert.cpp
@@ -37,7 +37,7 @@ TerrainHeightFractal<TerrainHeightRuggedDesert>::TerrainHeightFractal(const Syst
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightRuggedDesert>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightRuggedLava.cpp
+++ b/src/terrain/TerrainHeightRuggedLava.cpp
@@ -36,7 +36,7 @@ TerrainHeightFractal<TerrainHeightRuggedLava>::TerrainHeightFractal(const System
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightRuggedLava>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightRuggedLava>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightWaterSolid.cpp
+++ b/src/terrain/TerrainHeightWaterSolid.cpp
@@ -28,7 +28,7 @@ TerrainHeightFractal<TerrainHeightWaterSolid>::TerrainHeightFractal(const System
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightWaterSolid>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightWaterSolid>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];

--- a/src/terrain/TerrainHeightWaterSolidCanyons.cpp
+++ b/src/terrain/TerrainHeightWaterSolidCanyons.cpp
@@ -31,7 +31,7 @@ TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::TerrainHeightFractal(const
 }
 
 template <>
-void TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::GetHeights(const vector3d *vP, double *heightsOut, const size_t count) const
+void TerrainHeightFractal<TerrainHeightWaterSolidCanyons>::GetHeightsRaw(const vector3d *vP, double *heightsOut, const size_t count) const
 {
 	for (size_t i = 0; i < count; i++) {
 		const vector3d &p = vP[i];


### PR DESCRIPTION
Fixes #5154.

If you look closely, you'll see that the terrain under a surface starport usually isn't completely flat. This is mostly not noticeable because the placing code fishes around for a relatively flat area to put them on. But the bottom of the building could still float in the air or clip into the ground. In extreme cases, like the linked issue above, particularly on small asteroid type worlds, the terrain would be too bumpy for the relocation code to find a suitable area, so it would give up after a while, and end up with steep terrain blocking some of the landing pads.

This PR modifies the terrain heights after the starports are placed to ensure that a circular area underneath each one is perfectly flat. On large worlds it then blends the flattened area with the surroundings, so that you don't really notice that it's been flattened. On bumpy asteroid worlds it keeps a sharp edge to make it look like a man-made flattened area for the starport to sit on.

Before:

<img width="1328" height="831" alt="image" src="https://github.com/user-attachments/assets/70c659dd-10e9-442d-8f48-a54e0b9cbfda" />

.

After:

<img width="1380" height="876" alt="image" src="https://github.com/user-attachments/assets/f438fe8c-7d77-479a-8ba9-d6fd14872c23" />
