### PR TITLE
Fix for radar not working with non-station target

### DIFF
--- a/data/pigui/modules/radar.lua
+++ b/data/pigui/modules/radar.lua
@@ -323,7 +323,7 @@ radar3d.draw = function(self, center)
 	end)
 
 	-- Display landing navaid
-	if navTarget and navTarget:GetAssignedBayNumber(Game.player) >= 0 then
+	if navTarget and navTarget:IsStation() and navTarget:GetAssignedBayNumber(Game.player) >= 0 then
 
 		local pos_err = navTarget:GetAssignedBayNavError(Game.player)
 


### PR DESCRIPTION
Fixes #6431.

The new landing navigation aid for the radar crashes if you click on anything that isn't a station. So then the module manager disables the radar and you can't get it back.

Adding a one-line object type check fixes this.

